### PR TITLE
interactive generate

### DIFF
--- a/ollama/engine.py
+++ b/ollama/engine.py
@@ -27,7 +27,7 @@ def generate(model, prompt, models_home=".", llms={}, *args, **kwargs):
         kwargs.update({"max_tokens": 16384})
 
     if "stop" not in kwargs:
-        kwargs.update({"stop": ["Q:", "\n"]})
+        kwargs.update({"stop": ["Q:"]})
 
     if "stream" not in kwargs:
         kwargs.update({"stream": True})


### PR DESCRIPTION
generate prompt is now optional. if a prompt is omitted, it will start an interactive session

previous behaviour with prompt

```
$ ollama generate ~/Downloads/vicuna-7b-v1.3.ggmlv3.q4_0.bin 'Hi!'
>>> Hi!

 Hello! How can I help you today?

```

new behaviour without a prompt. ctrl-c to exit interactive mode

```
$ ollama generate ~/Downloads/vicuna-7b-v1.3.ggmlv3.q4_0.bin
>>> Hi!

 Hello! How can I help you today?

>>> How are you?

 I am just a computer program, so I don't have feelings or emotions like humans do. I exist solely to provide information and assist with tasks to the best of my abilities. Is there anything specific you would like help with today?

>>>
```

new behaviour with a input file
```
$ ollama generate orca-mini-3b.ggmlv3.q4_0 <questions.txt
>>> Hi!

 Hello! How can I assist you today?

>>> How are you?

 I'm doing well, thank you for asking. How about you?

>>>
```