### PR TITLE
do not regenerate embeddings

### DIFF
--- a/server/images.go
+++ b/server/images.go
@@ -505,7 +505,7 @@ func embeddingLayers(e EmbeddingParams) ([]*LayerReader, error) {
 		// this will be used to check if we already have embeddings for a file
 		modelInfo, err := os.Stat(e.model)
 		if err != nil {
-			log.Fatalf("Error getting file info: %s", err)
+			return nil, fmt.Errorf("failed to get model file info: %v", err)
 		}
 
 		addedFiles := make(map[string]bool) // keep track of files that have already been added


### PR DESCRIPTION
- re-use previously evaluated embeddings when possible
- change embeddings digest identifier to be based on model name and embedded file path

This change opens previously generated embeddings for the same model/file and re-uses them when possible. This means that running create on the same file will not generate the embeddings again. This also means that only the difference between the current version of the file and the old version of the file will have the embeddings re-generated.

resolves #331 
resolves #332 