### PR TITLE
template extra args

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -32,11 +32,12 @@ func (e StatusError) Error() string {
 }
 
 type GenerateRequest struct {
-	Model    string `json:"model"`
-	Prompt   string `json:"prompt"`
-	System   string `json:"system"`
-	Template string `json:"template"`
-	Context  []int  `json:"context,omitempty"`
+	Model    string         `json:"model"`
+	Prompt   string         `json:"prompt"`
+	System   string         `json:"system"`
+	Template string         `json:"template"`
+	Context  []int          `json:"context,omitempty"`
+	Args     map[string]any `json:"args,omitempty"`
 
 	Options map[string]interface{} `json:"options"`
 }

--- a/server/images.go
+++ b/server/images.go
@@ -66,6 +66,7 @@ func (m *Model) Prompt(request api.GenerateRequest, embedding string) (string, e
 		System string
 		Prompt string
 		Embed  string
+		Args   map[string]any
 
 		// deprecated: versions <= 0.0.7 used this to omit the system prompt
 		Context []int
@@ -75,6 +76,7 @@ func (m *Model) Prompt(request api.GenerateRequest, embedding string) (string, e
 	vars.System = m.System
 	vars.Prompt = request.Prompt
 	vars.Context = request.Context
+	vars.Args = request.Args
 	vars.Embed = embedding
 
 	if request.System != "" {


### PR DESCRIPTION
User defined arguments to the template, making things like infilling easier:

```
FROM codellama:7b-code
TEMPLATE "<PRE> {{ .Args.Prefix }} <SUF> {{- .Args.Suffix }} <MID>"
```

Request:
```
$ curl -s localhost:11434/api/generate -d '{"model":"codellama-infill","args":{"Prefix":"def remove_non_ascii(s: str) -> str:\n\t\"\"\"","Suffix":"return result"}}' | jq -r -j 'select(.response != null) | .response'

    Remove non-ASCII characters from a string.

    Parameters
    ----------
    s : str
        The input string.

    Returns
    -------
    str
        The output string.
    """
        result = ""
        for char in s:
                if ord(char) < 128:
                        result += char

```


Or messages:

```
FROM llama2:7b

TEMPLATE """{{ range .Args.Messages }}[INST] {{ if .System -}}
<<SYS>>{{ .System }}<</SYS>>
{{- end }}

{{ range .Request }} [/INST] {{ .Response }} {{ end }}"""
```

```
$ curl -s localhost:11434/api/generate -d '{"model":"llama2","args": {"Messages": [{"System":"you are a good robot","Request":"tell me a joke","Response":"why is the sky blue?"},{"Request":"why did you say that?","Response":"i don't know"},{"Request":"do it again"}]'
```
