### PR TITLE
Add homebrew CI configuration

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,0 +1,17 @@
+name: homebrew
+
+on:
+  push:
+    tags: 'v*'
+
+jobs:
+  homebrew:
+    name: Bump Homebrew formula
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mislav/bump-homebrew-formula-action@v3
+        with:
+          # A PR will be sent to github.com/Homebrew/homebrew-core to update this formula:
+          formula-name: ollama
+        env:
+          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}


### PR DESCRIPTION
* Add a `build.yml` file for building and testing Ollama with Go 1.20 and 1.21 on both Ubuntu and macOS.
* Add a `homebrew.yml` file for automatically updating the Homebrew package when new releases are tagged. It can be configured by adding a personal access token with "repo" and "workflow" enabled to the GitHub secrets for this project. More info here: https://github.com/mislav/bump-homebrew-formula-action