### PR TITLE
Add error handling for get_summary function in the newssummary example.

### DIFF
--- a/examples/python-rag-newssummary/summ.py
+++ b/examples/python-rag-newssummary/summ.py
@@ -7,10 +7,10 @@ from mattsollamatools import chunker
 
 if __name__ == "__main__":
     chosen_topic = curses.wrapper(menu)
-    print("Here is your news summary:\n")
     urls = getUrls(chosen_topic, n=5)
     model = SentenceTransformer('all-MiniLM-L6-v2')
     allEmbeddings = []
+    failed = False
 
     for url in urls:
       article={}
@@ -18,6 +18,11 @@ if __name__ == "__main__":
       article['url'] = url
       text = getArticleText(url)
       summary = get_summary(text)
+      if summary is None:
+        failed = True
+        print(f"Failed to get summary for {url}")
+        break  # Exit the loop if we failed to get a summary
+
       chunks = chunker(text)  # Use the chunk_text function from web_utils
       embeddings = model.encode(chunks)
       for (chunk, embedding) in zip(chunks, embeddings):
@@ -31,7 +36,11 @@ if __name__ == "__main__":
 
       print(f"{summary}\n")
 
-    
+    if failed:
+       exit(1)
+
+    print("Here is your news summary:\n")
+
     while True:
       context = []
       # Input a question from the user

--- a/examples/python-rag-newssummary/utils.py
+++ b/examples/python-rag-newssummary/utils.py
@@ -86,10 +86,26 @@ def get_summary(text):
   }
   payload_json = json.dumps(payload)
   headers = {"Content-Type": "application/json"}
-  response = requests.post(url, data=payload_json, headers=headers)
 
-  return json.loads(response.text)["response"]
+  try:
+    response = requests.post(url, data=payload_json, headers=headers)
+    response_data = json.loads(response.text)
 
+    # Check if the response contains an error key
+    if 'error' in response_data:
+      print(f"Error occurred: {response_data['error']}")
+      return None
+    return response_data["response"]
+  except requests.RequestException as e:
+      print(f"Request error: {e}")
+      return None  # or some other appropriate action
+  except json.JSONDecodeError as e:
+      print(f"JSON decode error: {e}")
+      return None  # or some other appropriate action
+  except Exception as e:
+      print(f"An unexpected error occurred: {e}")
+      return None  # or some other appropriate action
+  
 # Perform K-nearest neighbors (KNN) search
 def knn_search(question_embedding, embeddings, k=5):
     X = np.array([item['embedding'] for article in embeddings for item in article['embeddings']])


### PR DESCRIPTION
Calling `get_summary` fails when the hard coded model `mistral-openorca` is not installed. It makes sense to save people trying to figure out why.