### PR TITLE
docs: add brew installation note

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ Get up and running with large language models locally.
 
 [Download](https://ollama.ai/download/Ollama-darwin.zip)
 
+### Homebrew
+
+If you are a [Homebrew](https://brew.sh/) user, you can install [ollama](https://formulae.brew.sh/formula/ollama) with:
+
+```
+$ brew install ollama
+```
+
 ### Windows
 
 Coming soon!


### PR DESCRIPTION
Add brew installation note

```
$ brew install ollama
==> Downloading https://ghcr.io/v2/homebrew/core/ollama/manifests/0.1.9
############################################################################################### 100.0%
==> Fetching ollama
==> Downloading https://ghcr.io/v2/homebrew/core/ollama/blobs/sha256:10126ce5346a2eb4b4b5b02f8fb9e9ce6
############################################################################################### 100.0%
==> Pouring ollama--0.1.9.arm64_ventura.bottle.tar.gz
==> Caveats
To start ollama now and restart at login:
  brew services start ollama
Or, if you don't want/need a background service you can just run:
  /opt/homebrew/opt/ollama/bin/ollama serve
==> Summary
🍺  /opt/homebrew/Cellar/ollama/0.1.9: 7 files, 15.5MB
```