### PR TITLE
use sha:256 prefix to indicate blob rather than @

### DIFF
--- a/server/images.go
+++ b/server/images.go
@@ -307,7 +307,7 @@ func CreateModel(ctx context.Context, name, modelFileDir string, commands []pars
 
 		switch c.Name {
 		case "model":
-			if strings.HasPrefix(c.Args, "@") {
+			if strings.HasPrefix(c.Args, "sha256:") || strings.HasPrefix(c.Args, "@") {
 				blobPath, err := GetBlobsPath(strings.TrimPrefix(c.Args, "@"))
 				if err != nil {
 					return err


### PR DESCRIPTION
When uploading a remote blob we add an `@` sign in front of the `sha-256:` tag, this PR removes the `@` to achieve the same effect without requiring the additional step of adding the `@` to the digest