### PR TITLE
Add SSL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,27 @@ curl http://localhost:11434/api/generate -d '{
 
 See the [API documentation](./docs/api.md) for all endpoints.
 
+## SSL Support
+
+Ollama now supports SSL, allowing you to run your server securely using HTTPS.
+
+### Configuring SSL
+
+1. Obtain an SSL certificate and a private key. You can acquire these from a Certificate Authority (CA) or generate a self-signed certificate (not recommended for production use).
+   
+2. Place the certificate and key files in the `~/.ollama/ssl/` directory on your server.
+
+3. Ensure the files are named `cert.pem` and `key.pem`, respectively.
+
+4. Restart the Ollama server. It will automatically detect the presence of these files and enable HTTPS.
+
+### Running Without SSL
+
+If you prefer to run Ollama without SSL or are setting it up for a local, secure environment, simply do not place the SSL files in the `~/.ollama/ssl/` directory. The server will operate over standard HTTP in this case.
+
+> Note: While SSL provides enhanced security, especially for data in transit, ensure you follow best practices for securing your server and managing SSL certificates.
+
+
 ## Community Integrations
 
 ### Mobile

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -6,6 +6,7 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/sha256"
+	"crypto/tls"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -778,6 +779,7 @@ func generateInteractive(cmd *cobra.Command, model string, wordWrap bool, format
 
 func RunServer(cmd *cobra.Command, _ []string) error {
 	host, port, err := net.SplitHostPort(os.Getenv("OLLAMA_HOST"))
+
 	if err != nil {
 		host, port = "127.0.0.1", "11434"
 		if ip := net.ParseIP(strings.Trim(os.Getenv("OLLAMA_HOST"), "[]")); ip != nil {
@@ -789,9 +791,34 @@ func RunServer(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	ln, err := net.Listen("tcp", net.JoinHostPort(host, port))
-	if err != nil {
-		return err
+	certFile := filepath.Join(os.Getenv("HOME"), ".ollama/ssl/cert.pem")
+	keyFile := filepath.Join(os.Getenv("HOME"), ".ollama/ssl/key.pem")
+
+	var ln net.Listener
+
+	if _, certErr := os.Stat(certFile); certErr == nil {
+		if _, keyErr := os.Stat(keyFile); keyErr == nil {
+			cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+
+			if err != nil {
+				return err
+			}
+
+			ln, err = tls.Listen("tcp", net.JoinHostPort(host, port), &tls.Config{
+				Certificates: []tls.Certificate{cert},
+			})
+
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	if ln == nil {
+		ln, err = net.Listen("tcp", net.JoinHostPort(host, port))
+		if err != nil {
+			return err
+		}
 	}
 
 	var origins []string


### PR DESCRIPTION
Completes https://github.com/jmorganca/ollama/issues/701

Place `cert.pem` and `key.pem` into ` ~/.ollama/ssl/`  restart server. It will come up in SSL mode. Remove, rename or delete files to disable ssl mode.

example of me connecting to my own box via ssl.

```
Jasons-MacBook-Air:ollama rootedbox$ OLLAMA_HOST=https://pleaseignore.me:11434  ./ollama run orca-mini
>>> What is the significance of 42
 The number 42 has several significant meanings in different contexts. 

In mathematics, it is the answer to the riddle of Euclid's Fourth Problem, which involves finding the greatest common divisor of two numbers. In computer programming, it is an important value in some 
algorithms and data structures.

In literature, 42 is a character in the novel "The Hitchhiker's Guide to the Galaxy" by Douglas Adams, who is a robot with the ability to reason and make decisions.

In sports, 42 is the number of points a player needs to score to win the NBA MVP award, and it is also the age at which a player becomes eligible for the Hall of Fame in baseball.
```