### PR TITLE
🛠️ Add service activation prompt

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -69,6 +69,17 @@ install_success() {
 }
 trap install_success EXIT
 
+ask_to_activate_service() {
+    while true; do
+        read -p "Do you want to activate the Ollama service? [Y/n]: " yn
+        case $yn in
+            [Yy]* ) return 0;;
+            [Nn]* ) return 1;;
+            * ) echo "Please answer y or n.";;
+        esac
+    done
+}
+
 # Everything from this point onwards is optional.
 
 configure_systemd() {
@@ -110,8 +121,12 @@ EOF
     esac
 }
 
-if available systemctl; then
-    configure_systemd
+if ask_to_activate_service; then
+    if available systemctl; then
+        configure_systemd
+    fi
+else
+    status "Service activation skipped by user."
 fi
 
 if ! available lspci && ! available lshw; then


### PR DESCRIPTION
Closes #1352 

### Key Changes:
- Added `ask_to_activate_service` function to prompt users for service activation post-installation.
- Integrated the prompt in the script's flow, allowing conditional execution of systemd service configuration.


### Impact:
- Improves user experience by providing a choice to activate the service.
- Ensures clearer installation process, aligning with user expectations.