### PR TITLE
Use the xyproto/env package

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -34,6 +34,8 @@ import (
 	"github.com/jmorganca/ollama/readline"
 	"github.com/jmorganca/ollama/server"
 	"github.com/jmorganca/ollama/version"
+
+	"github.com/xyproto/env/v2"
 )
 
 func CreateHandler(cmd *cobra.Command, args []string) error {
@@ -416,7 +418,7 @@ func RunGenerate(cmd *cobra.Command, args []string) error {
 
 	opts := generateOptions{
 		Model:    args[0],
-		WordWrap: os.Getenv("TERM") == "xterm-256color",
+		WordWrap: env.Str("TERM") == "xterm-256color",
 		Options:  map[string]interface{}{},
 	}
 
@@ -912,10 +914,10 @@ func generateInteractive(cmd *cobra.Command, opts generateOptions) error {
 }
 
 func RunServer(cmd *cobra.Command, _ []string) error {
-	host, port, err := net.SplitHostPort(os.Getenv("OLLAMA_HOST"))
+	host, port, err := net.SplitHostPort(env.Str("OLLAMA_HOST"))
 	if err != nil {
 		host, port = "127.0.0.1", "11434"
-		if ip := net.ParseIP(strings.Trim(os.Getenv("OLLAMA_HOST"), "[]")); ip != nil {
+		if ip := net.ParseIP(strings.Trim(env.Str("OLLAMA_HOST"), "[]")); ip != nil {
 			host = ip.String()
 		}
 	}
@@ -930,7 +932,7 @@ func RunServer(cmd *cobra.Command, _ []string) error {
 	}
 
 	var origins []string
-	if o := os.Getenv("OLLAMA_ORIGINS"); o != "" {
+	if o := env.Str("OLLAMA_ORIGINS"); o != "" {
 		origins = strings.Split(o, ",")
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/gin-gonic/gin v1.9.1
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/spf13/cobra v1.7.0
+	github.com/xyproto/env/v2 v2.2.4
 	golang.org/x/sync v0.3.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,8 @@ github.com/ugorji/go v1.2.7/go.mod h1:nF9osbDWLy6bDVv/Rtoh6QgnvNDpmCalQV5urGCCS6
 github.com/ugorji/go/codec v1.2.7/go.mod h1:WGN1fab3R1fzQlVQTkfxVtIBhWDRqOviHU95kRgeqEY=
 github.com/ugorji/go/codec v1.2.11 h1:BMaWp1Bb6fHwEtbplGBGJ498wD+LKlNSl25MjdZY4dU=
 github.com/ugorji/go/codec v1.2.11/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
+github.com/xyproto/env/v2 v2.2.4 h1:Eysqz8rlZRBjKwH0a+oxyFj4WMDBaezKNHLx2S5f8go=
+github.com/xyproto/env/v2 v2.2.4/go.mod h1:F81ZEzu15s3TWUZJ1uzBl9iNeq9zcfHvxMkQJaLZUl0=
 golang.org/x/arch v0.0.0-20210923205945-b76863e36670/go.mod h1:5om86z9Hs0C8fWVUuoMHwpExlXzs5Tkyp9hOrfG7pp8=
 golang.org/x/arch v0.3.0 h1:02VY4/ZcO/gBOH6PUaoiptASxtXU10jazRCP865E97k=
 golang.org/x/arch v0.3.0/go.mod h1:5om86z9Hs0C8fWVUuoMHwpExlXzs5Tkyp9hOrfG7pp8=

--- a/server/images.go
+++ b/server/images.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jmorganca/ollama/llm"
 	"github.com/jmorganca/ollama/parser"
 	"github.com/jmorganca/ollama/version"
+	"github.com/xyproto/env/v2"
 )
 
 type RegistryOptions struct {
@@ -605,7 +606,7 @@ func CreateModel(ctx context.Context, name, modelFileDir string, commands []pars
 		return err
 	}
 
-	if noprune := os.Getenv("OLLAMA_NOPRUNE"); noprune == "" {
+	if !env.Bool("OLLAMA_NOPRUNE") {
 		if err := deleteUnusedLayers(nil, deleteMap, false); err != nil {
 			return err
 		}
@@ -926,7 +927,7 @@ func PullModel(ctx context.Context, name string, regOpts *RegistryOptions, fn fu
 	// build deleteMap to prune unused layers
 	deleteMap := make(map[string]struct{})
 
-	if noprune = os.Getenv("OLLAMA_NOPRUNE"); noprune == "" {
+	if !env.Bool("OLLAMA_NOPRUNE") {
 		manifest, _, err = GetManifest(mp)
 		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			return err

--- a/server/modelpath.go
+++ b/server/modelpath.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/xyproto/env/v2"
 )
 
 type ModelPath struct {
@@ -102,14 +104,11 @@ func (mp ModelPath) GetShortTagname() string {
 // modelsDir returns the value of the OLLAMA_MODELS environment variable or the user's home directory if OLLAMA_MODELS is not set.
 // The models directory is where Ollama stores its model files and manifests.
 func modelsDir() (string, error) {
-	if models, exists := os.LookupEnv("OLLAMA_MODELS"); exists {
-		return models, nil
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
+	path := env.Dir("OLLAMA_MODELS", "~/.ollama/models")
+	if _, err := os.Stat(path); os.IsNotExist(err) {
 		return "", err
 	}
-	return filepath.Join(home, ".ollama", "models"), nil
+	return path, nil
 }
 
 // GetManifestPath returns the path to the manifest file for the given model path, it is up to the caller to create the directory if it does not exist.
@@ -118,7 +117,6 @@ func (mp ModelPath) GetManifestPath() (string, error) {
 	if err != nil {
 		return "", err
 	}
-
 	return filepath.Join(dir, "manifests", mp.Registry, mp.Namespace, mp.Repository, mp.Tag), nil
 }
 

--- a/server/routes.go
+++ b/server/routes.go
@@ -28,6 +28,8 @@ import (
 	"github.com/jmorganca/ollama/llm"
 	"github.com/jmorganca/ollama/parser"
 	"github.com/jmorganca/ollama/version"
+
+	"github.com/xyproto/env/v2"
 )
 
 var mode string = gin.DebugMode
@@ -773,7 +775,7 @@ var defaultAllowOrigins = []string{
 }
 
 func Serve(ln net.Listener, allowOrigins []string) error {
-	if noprune := os.Getenv("OLLAMA_NOPRUNE"); noprune == "" {
+	if !env.Bool("OLLAMA_NOPRUNE") {
 		// clean up unused layers and manifests
 		if err := PruneLayers(); err != nil {
 			return err


### PR DESCRIPTION
xyproto/env is a package that is used in production in at least company, and that is used in several open source projects and has a few (minor) advantages:

* Cache the environment variables when the program is starting, for quick repeated lookups.
* Use `.Str()` for strings, `.Bool()` for boolean values and `.Dir()` for directories, for clarity.

Also, changing:

```go
if noprune := os.Getenv("OLLAMA_NOPRUNE"); noprune == "" {
```

into

```go
if !env.Bool("OLLAMA_NOPRUNE") {
```

Is a change that highlights that the environment variable is being used like a boolean value, where it's either set or not.