### PR TITLE
Create blogs and tutorials section

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,3 +302,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Rivet plugin](https://github.com/abrenneke/rivet-plugin-ollama)
 - [Llama Coder](https://github.com/ex3ndr/llama-coder) (Copilot alternative using Ollama)
 - [Obsidian BMO Chatbot plugin](https://github.com/longy2k/obsidian-bmo-chatbot)
+
+## Blog Posts and Tutorials about ollama
+
+- [fly.io](https://fly.io/blog/scaling-llm-ollama/): Scaling Large Language Models to zero with Ollama


### PR DESCRIPTION
This allows for users to get additional usage info outside of the scope of the ollama documentation and for the users to discover additional use cases and How- To's

This would resolve issue #1510

Feedback is appreciated