### PR TITLE
First take at a community resources page of blogs, tutorials, videos

### DIFF
--- a/docs/community.md
+++ b/docs/community.md
@@ -1,0 +1,41 @@
+# Community Resources
+
+The Ollama maintainer team is incredibly excited to see how many in the community have created resources showing how Ollama works. At the bottom of the main Readme, you will find a list of Community Projects that use Ollama. This page shows the Blogs, Videos, and Tutorials that many of our users have gotten value out of.
+
+## Videos
+
+| Date         | Title/URL | Author |
+| ------------ | --------- | --------|
+| Dec 18, 2023 | [This new AI is powerful and uncensored... Let's run it](https://www.youtube.com/watch?v=GyllRd2E6fg&pp=ygUIZmlyZXNoaXA%3D) | Fireship |
+| Dec 17, 2023 | [Ollama Multimodal: EASILY setup Llava locally & Integrate API](https://www.youtube.com/watch?v=CNGwscEsl0E) | Mervin Praison |
+| Dec 10, 2023| [Run AutoGEN using Ollama/LiteLLM in SIMPLE Steps - Updated (Use Case)](https://www.youtube.com/watch?v=gx6X5XJ8uH4) | Prompt Engineer |
+| Nov 29, 2023  |  [AutoGen with Ollama/LiteLLM - Each Agent With Its OWN LOCAL MODEL (Tutorial)](https://www.youtube.com/watch?v=y7wMTwJN7rA) | Matthew Berman | 
+| Nov 10, 2023 | [Ollama Is INSANE: Building Open-Source ChatGPT From Scratch (FULLY Local Tutorial)](https://www.youtube.com/watch?v=rIRkxZSn-A8)          | Matthew Berman| 
+| Nov 2, 2023 | [this open source project has a bright future](https://www.youtube.com/watch?v=jib1wjgIaa4) | Code to the Moon |
+| Oct 17, 2023 | [Ollama - Loading Custom Models](https://www.youtube.com/watch?v=3BnnsQCmgLo) | Sam Witteveen |
+| Oct 13, 2023 | [Ollama meets Langchain](https://www.youtube.com/watch?v=k_1pOF1mj8k) | Sam Witteveen |
+| Oct 8, 2023 | [Ollama - Local Models on your machine](https://www.youtube.com/watch?v=Ox8hhpgrUi0) | Sam Witteveen |
+| Oct 6, 2023 | [Ollama: The Easiest Way to RUN LLMs Locally](https://www.youtube.com/watch?v=MGr1V4LyGFA) | Prompt Engineering |
+| Oct 5, 2023 | [Running Mistral AI on your machine with Ollama](https://www.youtube.com/watch?v=NFgEgqua-fg) | Learn Data with Mark |
+| Sept 27, 2023 | [Ollama on Linux: Easily Install Any LLM on Your Server](https://www.youtube.com/watch?v=swNeoKGFkQM) | Ian Wootten |
+
+## Tutorials
+
+| Date | Title / URL | Author | 
+| ----|-----|----|
+| Dec 9, 2023 | [Create Your Own Local Chatbot with Next.js, Ollama, and ModelFusion](https://javascript.plainenglish.io/create-your-own-local-chatbot-with-next-js-ollama-and-modelfusion-dcc0bd63810f)| Lars Grammel |
+| Dec 8, 2023 | [How to Run Mistral-7B on an M1 Mac With Ollama](https://wandb.ai/byyoung3/ml-news/reports/How-to-Run-Mistral-7B-on-an-M1-Mac-With-Ollama--Vmlldzo2MTg4MjA0) | Weights & Biases |
+| Nov 22, 2023 | [Using Ollama with LangChainGo](https://eli.thegreenplace.net/2023/using-ollama-with-langchaingo/) | Eli Bendersky |
+| Oct 12 2023 | [Running Open Source LLMs Locally Using Ollama: A Step-by-Step Guide](https://medium.com/@kbdhunga/running-open-source-llms-locally-using-ollama-a-step-by-step-guide-cf2ab62c817a) | Kamal Dhungana |
+| Jul 22, 2023 | [A comprehensive guide to running Llama 2 locally](https://replicate.com/blog/run-llama-locally) | Replicate |
+
+
+## Blogs
+
+| Date | Title / URL | Author | 
+| ----|-----|----|
+| Dec 15, 2023 | [Your private AI can have eyes. Ollama with the LLaVA model](https://benyoung.blog/your-private-ai-can-have-eyes-ollama-with-the-llava-model/) | Ben Young |
+| Nov 10, 2023 | [Ollama](https://www.lifeintech.com/2023/11/10/ollama/) | Matthew Bull | 
+| Oct 12, 2023 | [Ollama - Self-Hosted AI Chat with Llama 2, Code Llama and More in Docker](https://noted.lol/ollama/) | Noted.lol |
+| Oct 11, 2023 | [Ollama: Experiments with few-shot prompting on Llama2 7B](https://www.markhneedham.com/blog/2023/10/11/ollama-few-shot-prompting-experiments-llama2-7b/) | Mark Needham |
+

--- a/docs/community.md
+++ b/docs/community.md
@@ -1,6 +1,6 @@
 # Community Resources
 
-The Ollama maintainer team is incredibly excited to see how many in the community have created resources showing how Ollama works. At the bottom of the main Readme, you will find a list of Community Projects that use Ollama. This page shows the Blogs, Videos, and Tutorials that many of our users have gotten value out of.
+The Ollama maintainer team is incredibly excited to see how many in the community have created resources showing how Ollama works. At the bottom of the main `README`, you will find a list of Community Projects that use Ollama. This page shows the Blogs, Videos, and Tutorials that many of our users have gotten value out of.
 
 ## Videos
 


### PR DESCRIPTION
we need a community page in the docs for blogs, videos, and tutorials. Tools that use Ollama will still go on the front readme.