### PR TITLE
Added support for specifying an arbitrary GBNF compatible grammar

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -101,6 +101,7 @@ type Options struct {
 	Mirostat         int      `json:"mirostat,omitempty"`
 	MirostatTau      float32  `json:"mirostat_tau,omitempty"`
 	MirostatEta      float32  `json:"mirostat_eta,omitempty"`
+	Grammar          string   `json:"grammar,omitempty"`
 	PenalizeNewline  bool     `json:"penalize_newline,omitempty"`
 	Stop             []string `json:"stop,omitempty"`
 }

--- a/docs/modelfile.md
+++ b/docs/modelfile.md
@@ -149,6 +149,7 @@ PARAMETER <parameter> <parametervalue>
 | num_predict    | Maximum number of tokens to predict when generating text. (Default: 128, -1 = infinite generation, -2 = fill context)                                                                                                                                   | int        | num_predict 42       |
 | top_k          | Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative. (Default: 40)                                                                        | int        | top_k 40             |
 | top_p          | Works together with top-k. A higher value (e.g., 0.95) will lead to more diverse text, while a lower value (e.g., 0.5) will generate more focused and conservative text. (Default: 0.9)                                                                 | float      | top_p 0.9            |
+| grammar        | The [GBNF](https://github.com/ggerganov/llama.cpp/tree/master/grammars) grammar used to constrain the model output. | string | grammar "root ::= [0-9]+" |
 
 ### TEMPLATE
 

--- a/examples/grammar/Modelfile
+++ b/examples/grammar/Modelfile
@@ -1,0 +1,39 @@
+FROM codellama:13b-instruct-q5_K_M
+
+# Note that this is just an example, any type of GBNF compatible
+# grammar can be specified. More information about the grammar
+# syntax and other examples at:
+#
+# https://github.com/ggerganov/llama.cpp/blob/master/grammars/README.md
+
+# JSON grammar provided by llama.cpp
+# MIT License
+# Copyright (c) 2023 Georgi Gerganov
+
+PARAMETER grammar """
+root   ::= object
+value  ::= object | array | string | number | ("true" | "false" | "null") ws
+
+object ::=
+  "{" ws (
+            string ":" ws value
+    ("," ws string ":" ws value)*
+  )? "}" ws
+
+array  ::=
+  "[" ws (
+            value
+    ("," ws value)*
+  )? "]" ws
+
+string ::=
+  "\"" (
+    [^"\\] |
+    "\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]) # escapes
+  )* "\"" ws
+
+number ::= ("-"? ([0-9] | [1-9] [0-9]*)) ("." [0-9]+)? ([eE] [-+]? [0-9]+)? ws
+
+# Optional space: by convention, applied in this grammar after literal chars when allowed
+ws ::= ([ \t\n] ws)?
+"""

--- a/llm/llama.go
+++ b/llm/llama.go
@@ -594,6 +594,7 @@ func (llm *llama) Predict(ctx context.Context, predict PredictOpts, fn func(Pred
 		"mirostat":          llm.Mirostat,
 		"mirostat_tau":      llm.MirostatTau,
 		"mirostat_eta":      llm.MirostatEta,
+		"grammar":           llm.Grammar,
 		"penalize_nl":       llm.PenalizeNewline,
 		"seed":              llm.Seed,
 		"stop":              llm.Stop,


### PR DESCRIPTION
in the Modelfile, for models running on the llama.cpp backend

Note that this is basically just the same PR as the one submitted by SyrupThinker in September (#565), and that has been mentioned in issue #1507 and #808 since then.

There are plenty of users that would appreciate this feature, so I really hope that it can get merged.

It's great that support for JSON grammar specifically has been added, by setting the GBNF grammar in question when JSON format is requested, but providing the user with the ability to specify an arbitrary grammar opens up for a lot more possibilities than that

Pull request #830 adds support for specifying JSON schemas, which is yet another great convenience feature for a specific and common usecase, but by adding support for arbitrary GBNF grammar it would be possible to have any model outputting data in any type of format, including custom DSLs and text-based file formats in general

This is a tremendously useful thing to have when building various types of automation related applications, so I really hope that this can get merged to avoid having to maintain separate forks. Ollama is a great project, let's keep making it even better