### PR TITLE
Update Readme Quickstart Ollama with Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ To run and chat with [Llama 2](https://ollama.ai/library/llama2):
 ollama run llama2
 ```
 
+Also check [ollama-quickstart-docker](./docs/tutorials/ollama-quickstart-docker.md).
+
 ## Model library
 
 Ollama supports a list of open-source models available on [ollama.ai/library](https://ollama.ai/library 'ollama model library')

--- a/docs/tutorials/ollama-quickstart-docker.md
+++ b/docs/tutorials/ollama-quickstart-docker.md
@@ -3,33 +3,19 @@
 1. Run the Ollama Docker container:
 
 ```shell
-sudo docker run -d -v ollama:/root/.ollama -p 11434:11434 --name ollama ollama/ollama
+docker run -d -v ollama:/root/.ollama -p 11434:11434 --name ollama ollama/ollama
 ```
 
 For more detailed information, refer to the [Ollama Docker](https://hub.docker.com/r/ollama/ollama). Please note we are using CPU only, the AI will response slow, if you have GPU, you can follow the instruction to run the docker and using your GPU to improve performance.
 
-2. Pull the llama2 model:
+2. Open bash in `ollama` container:
 
 ```shell
-curl --location 'http://localhost:11434/api/pull' \
---header 'Content-Type: application/json' \
---data '{
-    "name": "llama2:7b"
-}'
+docker exec -it ollama bash
 ```
 
-3. Chat with llama2
+3. Chat with Llama 2 inside `ollama` container:
 
-```shell
-curl --location 'http://localhost:11434/api/chat' \
---header 'Content-Type: application/json' \
---data '{
-    "model": "llama2:7b",
-    "messages": [
-        {
-            "role": "user",
-            "content": "why sky blue"
-        }
-    ]
-}'
+```
+root@e4d14c182583:/# ollama run llama2
 ```

--- a/docs/tutorials/ollama-quickstart-docker.md
+++ b/docs/tutorials/ollama-quickstart-docker.md
@@ -1,0 +1,35 @@
+# Ollama Quickstart with Docker
+
+1. Run the Ollama Docker container:
+
+```shell
+sudo docker run -d -v ollama:/root/.ollama -p 11434:11434 --name ollama ollama/ollama
+```
+
+For more detailed information, refer to the [Ollama Docker](https://hub.docker.com/r/ollama/ollama). Please note we are using CPU only, the AI will response slow, if you have GPU, you can follow the instruction to run the docker and using your GPU to improve performance.
+
+2. Pull the llama2 model:
+
+```shell
+curl --location 'http://localhost:11434/api/pull' \
+--header 'Content-Type: application/json' \
+--data '{
+    "name": "llama2:7b"
+}'
+```
+
+3. Chat with llama2
+
+```shell
+curl --location 'http://localhost:11434/api/chat' \
+--header 'Content-Type: application/json' \
+--data '{
+    "model": "llama2:7b",
+    "messages": [
+        {
+            "role": "user",
+            "content": "why sky blue"
+        }
+    ]
+}'
+```


### PR DESCRIPTION
# Update Readme Quickstart Ollama with Docker

Upon initial exploration of the repository, leveraging Docker for getting started appears to be the most straightforward approach. Following the [Ollama documentation for initiating with Docker](https://github.com/jmorganca/ollama?tab=readme-ov-file#docker) led me to the [Ollama Docker Image](https://hub.docker.com/r/ollama/ollama).

Subsequently, I launched Ollama using the command:

```shell
docker run -d -v ollama:/root/.ollama -p 11434:11434 --name ollama ollama/ollama
```

However, beyond this point, there lacks guidance on the subsequent steps.

This pull request aims to address this gap by incorporating instructions to guide users from spinning up the Docker image to utilizing the chat API.