### PR TITLE
docs: add Helm Chart link to Package managers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 ### Package managers
 
 - [Pacman](https://archlinux.org/packages/extra/x86_64/ollama/)
+- [Helm Chart](https://artifacthub.io/packages/helm/ollama-helm/ollama)
 
 ### Libraries
 


### PR DESCRIPTION
Add a link to ArtifactHub in the Package managers section for Helm Chart.