### PR TITLE
Update README.md - Terminal Integration - ShellOracle

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Oatmeal](https://github.com/dustinblackman/oatmeal)
 - [cmdh](https://github.com/pgibler/cmdh)
 - [llm-ollama](https://github.com/taketwo/llm-ollama) for [Datasette's LLM CLI](https://llm.datasette.io/en/stable/).
+- [ShellOracle](https://github.com/djcopley/ShellOracle)
 
 ### Database
 


### PR DESCRIPTION
ShellOracle is a new ZSH Line Editor widget that uses Ollama for intelligent shell command generation! Ollama rocks!

![ShellOracle](https://i.imgur.com/QM2LkAf.gif)