### PR TITLE
fix to use ARCH var on downloading cuda driver

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -187,7 +187,7 @@ install_cuda_driver_yum() {
 # ref: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#debian
 install_cuda_driver_apt() {
     status 'Installing NVIDIA repository...'
-    curl -fsSL -o $TEMP_DIR/cuda-keyring.deb https://developer.download.nvidia.com/compute/cuda/repos/$1$2/$(uname -m)/cuda-keyring_1.1-1_all.deb
+    curl -fsSL -o $TEMP_DIR/cuda-keyring.deb https://developer.download.nvidia.com/compute/cuda/repos/$1$2/$ARCH/cuda-keyring_1.1-1_all.deb
 
     case $1 in
         debian)


### PR DESCRIPTION
I attempted to install Ollama on an AWS g5g instance with Ubuntu2204. but failed on that point.
The link for Nvidia driver uses 'arm64' instead of 'aarch64'