### PR TITLE
Add Haystack to Community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Ollama for Dart](https://github.com/breitburg/dart-ollama)
 - [Ollama for Laravel](https://github.com/cloudstudio/ollama-laravel)
 - [LangChainDart](https://github.com/davidmigloz/langchain_dart)
+- [Haystack LLM framework](https://haystack.deepset.ai/integrations/ollama)
 
 ### Mobile
 

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Ollama for Dart](https://github.com/breitburg/dart-ollama)
 - [Ollama for Laravel](https://github.com/cloudstudio/ollama-laravel)
 - [LangChainDart](https://github.com/davidmigloz/langchain_dart)
-- [Haystack LLM framework](https://haystack.deepset.ai/integrations/ollama)
+- [Haystack](https://haystack.deepset.ai/integrations/ollama)
 
 ### Mobile
 


### PR DESCRIPTION
Hi, maintainers!

[Haystack](https://github.com/deepset-ai/haystack) is a quite popular open-source LLM orchestration framework.
We recently developed an [integration with Ollama](https://haystack.deepset.ai/integrations/ollama).

This PR is to add Haystack to the Community integrations.

If you agree, we would also like to add one or two simple examples [here](https://github.com/jmorganca/ollama/tree/main/examples) (to be done in other PRs).

Thanks for this great project!

