### PR TITLE
Add MindMac to Community Integrations -> Web & Desktop section

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Amica](https://github.com/semperai/amica)
 - [chatd](https://github.com/BruceMacD/chatd)
 - [Ollama-SwiftUI](https://github.com/kghandour/Ollama-SwiftUI)
+- [MindMac](https://mindmac.app)
 
 
 ### Terminal


### PR DESCRIPTION
Hi there,

MindMac is a privacy-first & feature-rich GPT client for macOS, designed for maximum productivity. It already has Ollama support, enabling users to run any model on their devices and easily connect with MindMac to ask questions seamlessly. Quick documentation can be found [here](https://docs.mindmac.app/how-to.../add-ollama-endpoint). Please help to review this PR. Thank you in advance.

Best regards,

Hoang
