### PR TITLE
trim chat prompt based on llm context size

### DIFF
--- a/server/images_test.go
+++ b/server/images_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
@@ -238,7 +239,7 @@ func TestChat(t *testing.T) {
 		name     string
 		template string
 		msgs     []api.Message
-		want     string
+		want     []string
 		wantErr  string
 	}{
 		{
@@ -254,7 +255,7 @@ func TestChat(t *testing.T) {
 					Content: "What are the potion ingredients?",
 				},
 			},
-			want: "[INST] You are a Wizard. What are the potion ingredients? [/INST]",
+			want: []string{"[INST] You are a Wizard. What are the potion ingredients? [/INST]"},
 		},
 		{
 			name:     "First Message",
@@ -277,7 +278,10 @@ func TestChat(t *testing.T) {
 					Content: "Anything else?",
 				},
 			},
-			want: "[INST] Hello! You are a Wizard. What are the potion ingredients? [/INST]eye of newt[INST]   Anything else? [/INST]",
+			want: []string{
+				"[INST] Hello! You are a Wizard. What are the potion ingredients? [/INST]eye of newt",
+				"[INST]   Anything else? [/INST]",
+			},
 		},
 		{
 			name:     "Message History",
@@ -300,7 +304,10 @@ func TestChat(t *testing.T) {
 					Content: "Anything else?",
 				},
 			},
-			want: "[INST] You are a Wizard. What are the potion ingredients? [/INST]sugar[INST]  Anything else? [/INST]",
+			want: []string{
+				"[INST] You are a Wizard. What are the potion ingredients? [/INST]sugar",
+				"[INST]  Anything else? [/INST]",
+			},
 		},
 		{
 			name:     "Assistant Only",
@@ -311,7 +318,7 @@ func TestChat(t *testing.T) {
 					Content: "everything nice",
 				},
 			},
-			want: "[INST]   [/INST]everything nice",
+			want: []string{"[INST]   [/INST]everything nice"},
 		},
 		{
 			name: "Invalid Role",
@@ -330,7 +337,7 @@ func TestChat(t *testing.T) {
 			Template: tt.template,
 		}
 		t.Run(tt.name, func(t *testing.T) {
-			got, _, err := m.ChatPrompt(tt.msgs)
+			got, _, err := m.ChatPrompts(tt.msgs)
 			if tt.wantErr != "" {
 				if err == nil {
 					t.Errorf("ChatPrompt() expected error, got nil")
@@ -339,7 +346,7 @@ func TestChat(t *testing.T) {
 					t.Errorf("ChatPrompt() error = %v, wantErr %v", err, tt.wantErr)
 				}
 			}
-			if got != tt.want {
+			if !slices.Equal(got, tt.want) {
 				t.Errorf("ChatPrompt() got = %v, want %v", got, tt.want)
 			}
 		})

--- a/server/images_test.go
+++ b/server/images_test.go
@@ -238,6 +238,9 @@ func chatHistoryEqual(a, b ChatHistory) bool {
 	if len(a.Prompts) != len(b.Prompts) {
 		return false
 	}
+	if len(a.CurrentImages) != len(b.CurrentImages) {
+		return false
+	}
 	for i, v := range a.Prompts {
 		if v != b.Prompts[i] {
 			return false

--- a/server/images_test.go
+++ b/server/images_test.go
@@ -1,9 +1,10 @@
 package server
 
 import (
-	"slices"
 	"strings"
 	"testing"
+
+	"golang.org/x/exp/slices"
 
 	"github.com/jmorganca/ollama/api"
 )

--- a/server/routes.go
+++ b/server/routes.go
@@ -1012,33 +1012,17 @@ func streamResponse(c *gin.Context, ch chan any) {
 
 // contextLimitPrompt builds a prompt to send to a running model while trimming it to fit the template into the max context length
 func contextLimitPrompt(ctx context.Context, prompts []string, ctxLen int) (string, error) {
-	if len(prompts) == 0 {
-		return "", nil
-	}
-
-	prompt := ""
 	promptLen := 0
-
-	// always process the last prompt
-	lastPrompt := prompts[len(prompts)-1]
-	enc, err := loaded.runner.Encode(ctx, lastPrompt)
-	if err != nil {
-		return "", err
-	}
-	prompt = lastPrompt
-	promptLen = len(enc)
-
-	if len(prompts) == 1 {
-		return prompt, nil
-	}
+	prompt := ""
 
 	// iterate over the rest of the prompts in reverse order until we reach the max context length
-	for i := len(prompts) - 2; i >= 0; i-- {
+	for i := len(prompts) - 1; i >= 0; i-- {
 		enc, err := loaded.runner.Encode(ctx, prompts[i])
 		if err != nil {
 			return "", err
 		}
-		if promptLen+len(enc) > loaded.NumCtx {
+		// if not most recent prompt and adding the prompt to the chat history would exceed the max context length
+		if i != len(prompts)-1 && promptLen+len(enc) > loaded.NumCtx {
 			// the context window is full, stop adding to the chat history
 			break
 		}

--- a/server/routes.go
+++ b/server/routes.go
@@ -1010,6 +1010,44 @@ func streamResponse(c *gin.Context, ch chan any) {
 	})
 }
 
+// contextLimitPrompt builds a prompt to send to a running model while trimming it to fit the template into the max context length
+func contextLimitPrompt(ctx context.Context, prompts []string, ctxLen int) (string, error) {
+	if len(prompts) == 0 {
+		return "", nil
+	}
+
+	prompt := ""
+	promptLen := 0
+
+	// always process the last prompt
+	lastPrompt := prompts[len(prompts)-1]
+	enc, err := loaded.runner.Encode(ctx, lastPrompt)
+	if err != nil {
+		return "", err
+	}
+	prompt = lastPrompt
+	promptLen = len(enc)
+
+	if len(prompts) == 1 {
+		return prompt, nil
+	}
+
+	// iterate over the rest of the prompts in reverse order until we reach the max context length
+	for i := len(prompts) - 2; i >= 0; i-- {
+		enc, err := loaded.runner.Encode(ctx, prompts[i])
+		if err != nil {
+			return "", err
+		}
+		if promptLen+len(enc) > loaded.NumCtx {
+			// the context window is full, stop adding to the chat history
+			break
+		}
+		prompt = prompts[i] + prompt
+		promptLen += len(enc)
+	}
+	return prompt, nil
+}
+
 func ChatHandler(c *gin.Context) {
 	loaded.mu.Lock()
 	defer loaded.mu.Unlock()
@@ -1071,9 +1109,15 @@ func ChatHandler(c *gin.Context) {
 
 	checkpointLoaded := time.Now()
 
-	prompt, images, err := model.ChatPrompt(req.Messages)
+	prompts, images, err := model.ChatPrompts(req.Messages)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	prompt, err := contextLimitPrompt(c.Request.Context(), prompts, loaded.NumCtx)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/jmorganca/ollama/api"
+	"github.com/jmorganca/ollama/llm"
 	"github.com/jmorganca/ollama/parser"
 	"github.com/jmorganca/ollama/version"
 )
@@ -201,4 +202,244 @@ func Test_Routes(t *testing.T) {
 		}
 
 	}
+}
+
+func Test_ChatPrompt(t *testing.T) {
+	tests := []struct {
+		name     string
+		template string
+		chat     ChatHistory
+		numCtx   int
+		runner   MockLLM
+		want     string
+		wantErr  string
+	}{
+		{
+			name:     "Single Message",
+			template: "[INST] {{ .System }} {{ .Prompt }} [/INST]",
+			chat: ChatHistory{
+				Prompts: []PromptVars{
+					{
+						System: "You are a Wizard.",
+						Prompt: "What are the potion ingredients?",
+						First:  true,
+					},
+				},
+				LastSystem: "You are a Wizard.",
+			},
+			numCtx: 1,
+			runner: MockLLM{
+				encoding: []int{1}, // fit the ctxLen
+			},
+			want: "[INST] You are a Wizard. What are the potion ingredients? [/INST]",
+		},
+		{
+			name:     "First Message",
+			template: "[INST] {{if .First}}Hello!{{end}} {{ .System }} {{ .Prompt }} [/INST]",
+			chat: ChatHistory{
+				Prompts: []PromptVars{
+					{
+						System:   "You are a Wizard.",
+						Prompt:   "What are the potion ingredients?",
+						Response: "eye of newt",
+						First:    true,
+					},
+					{
+						Prompt: "Anything else?",
+					},
+				},
+				LastSystem: "You are a Wizard.",
+			},
+			numCtx: 2,
+			runner: MockLLM{
+				encoding: []int{1}, // fit the ctxLen
+			},
+			want: "[INST] Hello! You are a Wizard. What are the potion ingredients? [/INST]eye of newt[INST]   Anything else? [/INST]",
+		},
+		{
+			name:     "Message History",
+			template: "[INST] {{ .System }} {{ .Prompt }} [/INST]",
+			chat: ChatHistory{
+				Prompts: []PromptVars{
+					{
+						System:   "You are a Wizard.",
+						Prompt:   "What are the potion ingredients?",
+						Response: "sugar",
+						First:    true,
+					},
+					{
+						Prompt: "Anything else?",
+					},
+				},
+				LastSystem: "You are a Wizard.",
+			},
+			numCtx: 4,
+			runner: MockLLM{
+				encoding: []int{1}, // fit the ctxLen, 1 for each message
+			},
+			want: "[INST] You are a Wizard. What are the potion ingredients? [/INST]sugar[INST]  Anything else? [/INST]",
+		},
+		{
+			name:     "Assistant Only",
+			template: "[INST] {{ .System }} {{ .Prompt }} [/INST]",
+			chat: ChatHistory{
+				Prompts: []PromptVars{
+					{
+						Response: "everything nice",
+						First:    true,
+					},
+				},
+			},
+			numCtx: 1,
+			runner: MockLLM{
+				encoding: []int{1},
+			},
+			want: "[INST]   [/INST]everything nice",
+		},
+		{
+			name:     "Message History Truncated, No System",
+			template: "[INST] {{ .System }} {{ .Prompt }} [/INST]",
+			chat: ChatHistory{
+				Prompts: []PromptVars{
+					{
+						Prompt:   "What are the potion ingredients?",
+						Response: "sugar",
+						First:    true,
+					},
+					{
+						Prompt:   "Anything else?",
+						Response: "spice",
+					},
+					{
+						Prompt: "... and?",
+					},
+				},
+			},
+			numCtx: 2, // only 1 message from history and most recent message
+			runner: MockLLM{
+				encoding: []int{1},
+			},
+			want: "[INST]  Anything else? [/INST]spice[INST]  ... and? [/INST]",
+		},
+		{
+			name:     "System is Preserved when Truncated",
+			template: "[INST] {{ .System }} {{ .Prompt }} [/INST]",
+
+			chat: ChatHistory{
+				Prompts: []PromptVars{
+					{
+						System:   "You are a wizard.",
+						Prompt:   "What are the magic words?",
+						Response: "abracadabra",
+						First:    true,
+					},
+					{
+						Prompt: "What is the spell for invisibility?",
+					},
+				},
+				LastSystem: "You are a wizard.",
+			},
+			numCtx: 1, // only most recent message
+			runner: MockLLM{
+				encoding: []int{1},
+			},
+			want: "[INST] You are a wizard. What is the spell for invisibility? [/INST]",
+		},
+		{
+			name:     "First is Preserved when Truncated",
+			template: "[INST] {{ if .First }}{{ .System }} {{ end }}{{ .Prompt }} [/INST]",
+
+			chat: ChatHistory{
+				Prompts: []PromptVars{
+					{
+						System:   "You are a wizard.",
+						Prompt:   "What are the magic words?",
+						Response: "abracadabra",
+						First:    true,
+					},
+					{
+						Prompt:   "Do you have a magic hat?",
+						Response: "Of course.",
+					},
+					{
+						Prompt: "What is the spell for invisibility?",
+					},
+				},
+				LastSystem: "You are a wizard.",
+			},
+			numCtx: 2, // two most recent messages
+			runner: MockLLM{
+				encoding: []int{1},
+			},
+			want: "[INST] You are a wizard. Do you have a magic hat? [/INST]Of course.[INST] What is the spell for invisibility? [/INST]",
+		},
+		{
+			name:     "Most recent message is returned when longer than ctxLen",
+			template: "[INST] {{ .Prompt }} [/INST]",
+
+			chat: ChatHistory{
+				Prompts: []PromptVars{
+					{
+						Prompt: "What is the spell for invisibility?",
+						First:  true,
+					},
+				},
+			},
+			numCtx: 1, // two most recent messages
+			runner: MockLLM{
+				encoding: []int{1, 2},
+			},
+			want: "[INST] What is the spell for invisibility? [/INST]",
+		},
+	}
+
+	for _, tt := range tests {
+		m := &Model{
+			Template: tt.template,
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			loaded.runner = &tt.runner
+			loaded.Options = &api.Options{
+				Runner: api.Runner{
+					NumCtx: tt.numCtx,
+				},
+			}
+			got, err := trimmedPrompt(context.Background(), &tt.chat, m)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Errorf("ChatPrompt() expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("ChatPrompt() error = %v, wantErr %v", err, tt.wantErr)
+				}
+			}
+			if got != tt.want {
+				t.Errorf("ChatPrompt() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+type MockLLM struct {
+	encoding []int
+}
+
+func (llm *MockLLM) Predict(ctx context.Context, pred llm.PredictOpts, fn func(llm.PredictResult)) error {
+	return nil
+}
+
+func (llm *MockLLM) Encode(ctx context.Context, prompt string) ([]int, error) {
+	return llm.encoding, nil
+}
+
+func (llm *MockLLM) Decode(ctx context.Context, tokens []int) (string, error) {
+	return "", nil
+}
+
+func (llm *MockLLM) Embedding(ctx context.Context, input string) ([]float64, error) {
+	return []float64{}, nil
+}
+
+func (llm *MockLLM) Close() {
+	// do nothing
 }

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -392,7 +392,8 @@ func Test_ChatPrompt(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
+	for _, testCase := range tests {
+		tt := testCase
 		m := &Model{
 			Template: tt.template,
 		}

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -327,10 +327,8 @@ func Test_ChatPrompt(t *testing.T) {
 			chat: &ChatHistory{
 				Prompts: []PromptVars{
 					{
-						System:   "You are a wizard.",
 						Prompt:   "What are the magic words?",
 						Response: "abracadabra",
-						First:    true,
 					},
 					{
 						Prompt: "What is the spell for invisibility?",
@@ -338,7 +336,28 @@ func Test_ChatPrompt(t *testing.T) {
 				},
 				LastSystem: "You are a wizard.",
 			},
-			numCtx: 1, // only most recent message
+			numCtx: 2,
+			runner: MockLLM{
+				encoding: []int{1},
+			},
+			want: "[INST] You are a wizard. What is the spell for invisibility? [/INST]",
+		},
+		{
+			name:     "System is Preserved when Length Exceeded",
+			template: "[INST] {{ .System }} {{ .Prompt }} [/INST]",
+			chat: &ChatHistory{
+				Prompts: []PromptVars{
+					{
+						Prompt:   "What are the magic words?",
+						Response: "abracadabra",
+					},
+					{
+						Prompt: "What is the spell for invisibility?",
+					},
+				},
+				LastSystem: "You are a wizard.",
+			},
+			numCtx: 1,
 			runner: MockLLM{
 				encoding: []int{1},
 			},
@@ -350,12 +369,7 @@ func Test_ChatPrompt(t *testing.T) {
 
 			chat: &ChatHistory{
 				Prompts: []PromptVars{
-					{
-						System:   "You are a wizard.",
-						Prompt:   "What are the magic words?",
-						Response: "abracadabra",
-						First:    true,
-					},
+					// first message omitted for test
 					{
 						Prompt:   "Do you have a magic hat?",
 						Response: "Of course.",
@@ -366,7 +380,7 @@ func Test_ChatPrompt(t *testing.T) {
 				},
 				LastSystem: "You are a wizard.",
 			},
-			numCtx: 2, // two most recent messages
+			numCtx: 3, // two most recent messages and room for system message
 			runner: MockLLM{
 				encoding: []int{1},
 			},

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -208,7 +208,7 @@ func Test_ChatPrompt(t *testing.T) {
 	tests := []struct {
 		name     string
 		template string
-		chat     ChatHistory
+		chat     *ChatHistory
 		numCtx   int
 		runner   MockLLM
 		want     string
@@ -217,7 +217,7 @@ func Test_ChatPrompt(t *testing.T) {
 		{
 			name:     "Single Message",
 			template: "[INST] {{ .System }} {{ .Prompt }} [/INST]",
-			chat: ChatHistory{
+			chat: &ChatHistory{
 				Prompts: []PromptVars{
 					{
 						System: "You are a Wizard.",
@@ -236,7 +236,7 @@ func Test_ChatPrompt(t *testing.T) {
 		{
 			name:     "First Message",
 			template: "[INST] {{if .First}}Hello!{{end}} {{ .System }} {{ .Prompt }} [/INST]",
-			chat: ChatHistory{
+			chat: &ChatHistory{
 				Prompts: []PromptVars{
 					{
 						System:   "You are a Wizard.",
@@ -259,7 +259,7 @@ func Test_ChatPrompt(t *testing.T) {
 		{
 			name:     "Message History",
 			template: "[INST] {{ .System }} {{ .Prompt }} [/INST]",
-			chat: ChatHistory{
+			chat: &ChatHistory{
 				Prompts: []PromptVars{
 					{
 						System:   "You are a Wizard.",
@@ -282,7 +282,7 @@ func Test_ChatPrompt(t *testing.T) {
 		{
 			name:     "Assistant Only",
 			template: "[INST] {{ .System }} {{ .Prompt }} [/INST]",
-			chat: ChatHistory{
+			chat: &ChatHistory{
 				Prompts: []PromptVars{
 					{
 						Response: "everything nice",
@@ -299,7 +299,7 @@ func Test_ChatPrompt(t *testing.T) {
 		{
 			name:     "Message History Truncated, No System",
 			template: "[INST] {{ .System }} {{ .Prompt }} [/INST]",
-			chat: ChatHistory{
+			chat: &ChatHistory{
 				Prompts: []PromptVars{
 					{
 						Prompt:   "What are the potion ingredients?",
@@ -324,8 +324,7 @@ func Test_ChatPrompt(t *testing.T) {
 		{
 			name:     "System is Preserved when Truncated",
 			template: "[INST] {{ .System }} {{ .Prompt }} [/INST]",
-
-			chat: ChatHistory{
+			chat: &ChatHistory{
 				Prompts: []PromptVars{
 					{
 						System:   "You are a wizard.",
@@ -349,7 +348,7 @@ func Test_ChatPrompt(t *testing.T) {
 			name:     "First is Preserved when Truncated",
 			template: "[INST] {{ if .First }}{{ .System }} {{ end }}{{ .Prompt }} [/INST]",
 
-			chat: ChatHistory{
+			chat: &ChatHistory{
 				Prompts: []PromptVars{
 					{
 						System:   "You are a wizard.",
@@ -377,7 +376,7 @@ func Test_ChatPrompt(t *testing.T) {
 			name:     "Most recent message is returned when longer than ctxLen",
 			template: "[INST] {{ .Prompt }} [/INST]",
 
-			chat: ChatHistory{
+			chat: &ChatHistory{
 				Prompts: []PromptVars{
 					{
 						Prompt: "What is the spell for invisibility?",
@@ -404,7 +403,7 @@ func Test_ChatPrompt(t *testing.T) {
 					NumCtx: tt.numCtx,
 				},
 			}
-			got, err := trimmedPrompt(context.Background(), &tt.chat, m)
+			got, err := trimmedPrompt(context.Background(), tt.chat, m)
 			if tt.wantErr != "" {
 				if err == nil {
 					t.Errorf("ChatPrompt() expected error, got nil")


### PR DESCRIPTION
When trimming the input chat prompt we need to make sure we keep the prompt template in the expected format. Without this the prompt will be trimmed without accounting for the model template when the maximum context length is reached, which can result in unexpected behavior from the model.

- update the `ChatPrompt` function to return a list of prompt variable, to allow the calling function to append them into the final prompt
- create the final prompt based on the loaded LLM's context window size, while preserving the prompt template formatting and system message in the first message of the new context window