### PR TITLE
Dockerfile: use variables for package version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,15 @@ FROM nvidia/cuda:11.8.0-devel-ubuntu22.04
 
 ARG TARGETARCH
 ARG GOFLAGS="'-ldflags=-w -s'"
+ARG GOURL="https://dl.google.com/go"
+ARG GOVER="go1.21.3"
+ARG GOPKG="$GOVER.linux-$TARGETARCH.tar.gz"
+ARG GOOUT="/tmp/$GOVER.tar.gz"
 
 WORKDIR /go/src/github.com/jmorganca/ollama
 RUN apt-get update && apt-get install -y git build-essential cmake
-ADD https://dl.google.com/go/go1.21.3.linux-$TARGETARCH.tar.gz /tmp/go1.21.3.tar.gz
-RUN mkdir -p /usr/local && tar xz -C /usr/local </tmp/go1.21.3.tar.gz
+ADD $GOURL/$GOPKG $GOOUT
+RUN mkdir -p /usr/local && tar xz -C /usr/local <$GOOUT
 
 COPY . .
 ENV GOARCH=$TARGETARCH


### PR DESCRIPTION
Update Dockerfile to use variables instead of hardcoded values