### PR TITLE
Improve scratch buffer estimates

### DIFF
--- a/gpu/gpu.go
+++ b/gpu/gpu.go
@@ -190,13 +190,7 @@ func getCPUMem() (memInfo, error) {
 func CheckVRAM() (int64, error) {
 	gpuInfo := GetGPUInfo()
 	if gpuInfo.FreeMemory > 0 && (gpuInfo.Library == "cuda" || gpuInfo.Library == "rocm") {
-		// leave 10% or 512MiB of VRAM free per GPU to handle unaccounted for overhead
-		overhead := gpuInfo.FreeMemory / 10
-		gpus := uint64(gpuInfo.DeviceCount)
-		if overhead < gpus*512*1024*1024 {
-			overhead = gpus * 512 * 1024 * 1024
-		}
-		return int64(gpuInfo.FreeMemory - overhead), nil
+		return int64(gpuInfo.FreeMemory), nil
 	}
 
 	return 0, fmt.Errorf("no GPU detected") // TODO - better handling of CPU based memory determiniation


### PR DESCRIPTION
This tweaks the scratch buffer estimates to account for batch size and allocates a larger amount of overhead. This is a temporary fix – long term we want to inspect the model weights for proper tensor-by-tensor estimates.