### PR TITLE
Expose llm library and layer info in verbose output

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -79,6 +79,13 @@ type Metrics struct {
 	PromptEvalDuration time.Duration `json:"prompt_eval_duration,omitempty"`
 	EvalCount          int           `json:"eval_count,omitempty"`
 	EvalDuration       time.Duration `json:"eval_duration,omitempty"`
+	Runtime            Runtime       `json:"runtime,omitempty"`
+}
+
+type Runtime struct {
+	Library   string `json:"library,omitempty"`
+	Layers    int64  `json:"layers,omitempty"`
+	MaxLayers int64  `json:"max_layers,omitempty"`
 }
 
 // Options specfied in GenerateRequest, if you add a new option here add it to the API docs also
@@ -268,6 +275,11 @@ func (m *Metrics) Summary() {
 	if m.EvalDuration > 0 {
 		fmt.Fprintf(os.Stderr, "eval duration:        %s\n", m.EvalDuration)
 		fmt.Fprintf(os.Stderr, "eval rate:            %.2f tokens/s\n", float64(m.EvalCount)/m.EvalDuration.Seconds())
+	}
+
+	if m.Runtime.Library != "" {
+		fmt.Fprintf(os.Stderr, "llm library:          %s\n", m.Runtime.Library)
+		fmt.Fprintf(os.Stderr, "GPU loaded layers:    %d/%d\n", m.Runtime.Layers, m.Runtime.MaxLayers)
 	}
 }
 

--- a/llm/llama.go
+++ b/llm/llama.go
@@ -73,6 +73,13 @@ type PredictResult struct {
 	PromptEvalDuration time.Duration
 	EvalCount          int
 	EvalDuration       time.Duration
+	Runtime            Runtime
+}
+
+type Runtime struct {
+	Library   string
+	Layers    int64
+	MaxLayers int64
 }
 
 type TokenizeRequest struct {

--- a/server/routes.go
+++ b/server/routes.go
@@ -268,6 +268,7 @@ func GenerateHandler(c *gin.Context) {
 					PromptEvalDuration: r.PromptEvalDuration,
 					EvalCount:          r.EvalCount,
 					EvalDuration:       r.EvalDuration,
+					Runtime:            api.Runtime(r.Runtime),
 				},
 			}
 
@@ -1107,6 +1108,7 @@ func ChatHandler(c *gin.Context) {
 					PromptEvalDuration: r.PromptEvalDuration,
 					EvalCount:          r.EvalCount,
 					EvalDuration:       r.EvalDuration,
+					Runtime:            api.Runtime(r.Runtime),
 				},
 			}
 


### PR DESCRIPTION
This wires up additional information in our verbose metrics so you can see which llm library was used, and how many layers were loaded into the GPU.

Example output in the CLI:
```
./ollama run orca-mini
>>> /set verbose
Set 'verbose' mode.
>>> hello
 Hello, how can I assist you today?

total duration:       835.322625ms
load duration:        452.875µs
prompt eval count:    42 token(s)
prompt eval duration: 593.785ms
prompt eval rate:     70.73 tokens/s
eval count:           10 token(s)
eval duration:        240.374ms
eval rate:            41.60 tokens/s
llm library:          metal
GPU loaded layers:    1/27
>>>
```

The JSON payload:
```json
{
  "model": "orca-mini",
  "created_at": "2024-01-23T20:23:02.168454Z",
  "response": " Hello, what can I assist you with today?",
  "done": true,
  "context": [
    31822,
    ...
  ],
  "total_duration": 849287875,
  "load_duration": 185542,
  "prompt_eval_count": 42,
  "prompt_eval_duration": 558791000,
  "eval_count": 11,
  "eval_duration": 290096000,
  "runtime": {
    "library": "metal",
    "layers": 1,
    "max_layers": 27
  }
}
```