### PR TITLE
Adding Aide to the list of desktop apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Amica](https://github.com/semperai/amica)
 - [chatd](https://github.com/BruceMacD/chatd)
 - [Ollama-SwiftUI](https://github.com/kghandour/Ollama-SwiftUI)
+- [Aide](https://github.com/codestoryai)
 
 
 ### Terminal


### PR DESCRIPTION
Hi all! We added support for running local models in the editor using Ollama, would love to show that Aide is supported on the README