### PR TITLE
Ignore AMD integrated GPUs

### DIFF
--- a/gpu/gpu_info.h
+++ b/gpu/gpu_info.h
@@ -42,6 +42,7 @@ typedef struct mem_info {
   uint64_t total;
   uint64_t free;
   unsigned int count;
+  int igpu_index; // If >= 0, we detected an integrated GPU to ignore
   char *err;  // If non-nill, caller responsible for freeing
 } mem_info_t;
 


### PR DESCRIPTION
Fixes #2054 

Integrated GPUs (APUs) from AMD may be reported by ROCm, but we can't run on them with our current llama.cpp configuration.  These iGPUs report 512M of memory, so I've coded the check to ignore any ROCm reported GPU that has less than 1G of memory.  If we detect only an integrated GPU, this will fallback to CPU mode.  If we detect multiple ROCm GPUs, meaning one or more are discrete, and one is integrated, we'll now set `ROCR_VISIBLE_DEVICES` so we ignore the iGPU.  If the user has explicitly set `ROCR_VISIBLE_DEVICES` we'll respect their setting.