### PR TITLE
Add back ROCm container support

### DIFF
--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -13,3 +13,13 @@ docker build \
     -f Dockerfile \
     -t ollama/ollama:$VERSION \
     .
+
+docker build \
+    --load \
+    --platform=linux/amd64 \
+    --build-arg=VERSION \
+    --build-arg=GOFLAGS \
+    --target runtime-rocm \
+    -f Dockerfile \
+    -t ollama/ollama:$VERSION-rocm \
+    .


### PR DESCRIPTION
This adds ROCm support back as a discrete image.