### PR TITLE
Fix crash on cuda ml init failure

### DIFF
--- a/gpu/gpu_info_cuda.c
+++ b/gpu/gpu_info_cuda.c
@@ -70,6 +70,7 @@ void cuda_init(char *cuda_lib_path, cuda_init_resp_t *resp) {
     resp->ch.handle = NULL;
     snprintf(buf, buflen, "nvml vram init failure: %d", ret);
     resp->err = strdup(buf);
+    return;
   }
 
   // Report driver version if we're in verbose mode, ignore errors


### PR DESCRIPTION
The new driver lookup code was triggering after init failure due to a missing return

Fixes #2198 