### PR TITLE
Fix help string for stop parameter

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -155,7 +155,7 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 		fmt.Fprintln(os.Stderr, "  /set parameter repeat_penalty <float> How strongly to penalize repetitions")
 		fmt.Fprintln(os.Stderr, "  /set parameter repeat_last_n <int>    Set how far back to look for repetitions")
 		fmt.Fprintln(os.Stderr, "  /set parameter num_gpu <int>          The number of layers to send to the GPU")
-		fmt.Fprintln(os.Stderr, "  /set parameter stop \"<string>\", ...   Set the stop parameters")
+		fmt.Fprintln(os.Stderr, "  /set parameter stop <string> <string> ...   Set the stop parameters")
 		fmt.Fprintln(os.Stderr, "")
 	}
 


### PR DESCRIPTION
Changed the help prompt for setting the stop parameters, and quotes or commas are otherwise included in the stop-token:

/set parameter stop "?", "!" # Invalid
/set parameter stop ? ! # Valid