### PR TITLE
Gosec

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -689,7 +689,11 @@ func RunServer(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	return server.Serve(ln)
+	headerTimeout, err := cmd.Flags().GetDuration("request-header-timeout")
+	if err != nil {
+		return err
+	}
+	return server.Serve(ln, headerTimeout)
 }
 
 func initializeKeypair() error {
@@ -880,6 +884,7 @@ func NewCLI() *cobra.Command {
 		Args:    cobra.ExactArgs(0),
 		RunE:    RunServer,
 	}
+	serveCmd.Flags().Duration("request-header-timeout", 10*time.Second, "amount of time for the client to send headers before a timeout error will occur")
 
 	pullCmd := &cobra.Command{
 		Use:     "pull MODEL",

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -731,7 +731,7 @@ func initializeKeypair() error {
 
 		pubKeyData := ssh.MarshalAuthorizedKey(sshPrivateKey.PublicKey())
 
-		err = os.WriteFile(pubKeyPath, pubKeyData, 0o644)
+		err = os.WriteFile(pubKeyPath, pubKeyData, 0o600)
 		if err != nil {
 			return err
 		}

--- a/llm/payload_common.go
+++ b/llm/payload_common.go
@@ -173,12 +173,12 @@ func extractDynamicLibs(workDir, glob string) ([]string, error) {
 			// Include the variant in the path to avoid conflicts between multiple server libs
 			targetDir := filepath.Join(workDir, pathComps[pathComponentCount-3])
 			if err := os.MkdirAll(targetDir, 0o755); err != nil {
-				return fmt.Errorf("create payload temp dir %q: %v", targetDir, err)
+				return fmt.Errorf("create payload temp dir %q: %w", targetDir, err)
 			}
 
 			srcFile, err := libEmbed.Open(file)
 			if err != nil {
-				return fmt.Errorf("read payload %s: %v", file, err)
+				return fmt.Errorf("read payload %q: %w", file, err)
 			}
 			defer srcFile.Close()
 			destFile := filepath.Join(targetDir, filepath.Base(file))
@@ -202,7 +202,7 @@ func extractPayloadFiles(workDir, glob string) error {
 	}
 
 	if err := os.MkdirAll(workDir, 0o755); err != nil {
-		return fmt.Errorf("create payload temp dir %s: %v", workDir, err)
+		return fmt.Errorf("create payload temp dir %q: %w", workDir, err)
 	}
 
 	for _, file := range files {
@@ -236,11 +236,11 @@ func extractFile(src io.Reader, destFile string) (err error) {
 			return fmt.Errorf("write payload: %w", err)
 		}
 		defer destFile.Close()
-		if _, err := io.Copy(destFile, src); err != nil { //nolint:gosec source can be trusted as it comes from a go:embed
+		if _, err := io.Copy(destFile, src); err != nil { //nolint:gosec // source can be trusted as it comes from a go:embed
 			return fmt.Errorf("copy payload: %w", err)
 		}
 	case err != nil:
-		return fmt.Errorf("stat payload: %v", err)
+		return fmt.Errorf("stat payload: %w", err)
 	}
 	return nil
 }

--- a/llm/payload_common_test.go
+++ b/llm/payload_common_test.go
@@ -1,0 +1,69 @@
+package llm
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractFile(t *testing.T) {
+	const myContent = "Testing"
+
+	asGzip := func(c string) []byte {
+		var gzipBuffer bytes.Buffer
+		gzipWriter := gzip.NewWriter(&gzipBuffer)
+		_, err := gzipWriter.Write([]byte(myContent))
+		require.NoError(t, err)
+		_ = gzipWriter.Close()
+		return gzipBuffer.Bytes()
+	}
+
+	specs := map[string]struct {
+		sourceContent []byte
+		destFileName  string
+		expFileName   string
+		expErr        bool
+	}{
+		"non gzip": {
+			sourceContent: []byte(myContent),
+			destFileName:  "testfile",
+			expFileName:   "testfile",
+		},
+		"gzip": {
+			sourceContent: asGzip(myContent),
+			destFileName:  "testfile.gz",
+			expFileName:   "testfile",
+		},
+		"invalid gzip": {
+			sourceContent: []byte("not a gzip"),
+			destFileName:  "testfile.gz",
+			expErr:        true,
+		},
+	}
+	for name, spec := range specs {
+		t.Run(name, func(t *testing.T) {
+			workDir := t.TempDir()
+			targetFile := filepath.Join(workDir, spec.destFileName)
+			gotErr := extractFile(bytes.NewReader(spec.sourceContent), targetFile)
+			if spec.expErr {
+				require.Error(t, gotErr)
+				return
+			}
+			require.NoError(t, gotErr)
+			expFileName := filepath.Join(workDir, spec.expFileName)
+			require.FileExists(t, expFileName)
+			file, err := os.Open(expFileName)
+			defer file.Close()
+			require.NoError(t, err)
+			gotContent, err := io.ReadAll(file)
+			require.NoError(t, err)
+			assert.Equal(t, myContent, string(gotContent))
+		})
+	}
+}

--- a/server/images.go
+++ b/server/images.go
@@ -756,7 +756,7 @@ func CopyModel(src, dest string) error {
 		return err
 	}
 
-	err = os.WriteFile(destPath, input, 0o644)
+	err = os.WriteFile(destPath, input, 0o600)
 	if err != nil {
 		fmt.Println("Error reading file:", err)
 		return err
@@ -1122,7 +1122,7 @@ func PullModel(ctx context.Context, name string, regOpts *RegistryOptions, fn fu
 		return err
 	}
 
-	err = os.WriteFile(fp, manifestJSON, 0o644)
+	err = os.WriteFile(fp, manifestJSON, 0o600)
 	if err != nil {
 		slog.Info(fmt.Sprintf("couldn't write to %s", fp))
 		return err

--- a/server/manifests.go
+++ b/server/manifests.go
@@ -30,5 +30,5 @@ func WriteManifest(name string, config *Layer, layers []*Layer) error {
 		return err
 	}
 
-	return os.WriteFile(manifestPath, b.Bytes(), 0o644)
+	return os.WriteFile(manifestPath, b.Bytes(), 0o600)
 }

--- a/server/routes.go
+++ b/server/routes.go
@@ -937,7 +937,7 @@ func (s *Server) GenerateRoutes() http.Handler {
 	return r
 }
 
-func Serve(ln net.Listener) error {
+func Serve(ln net.Listener, headerTimeout time.Duration) error {
 	level := slog.LevelInfo
 	if debug := os.Getenv("OLLAMA_DEBUG"); debug != "" {
 		level = slog.LevelDebug
@@ -982,7 +982,8 @@ func Serve(ln net.Listener) error {
 
 	slog.Info(fmt.Sprintf("Listening on %s (version %s)", ln.Addr(), version.Version))
 	srvr := &http.Server{
-		Handler: r,
+		Handler:           r,
+		ReadHeaderTimeout: headerTimeout,
 	}
 
 	// listen for a ctrl+c and stop any loaded llm


### PR DESCRIPTION
Start fixing some [gosec](https://github.com/securego/gosec) reports

* more restrictive file permission for ~/.ollama files
* add `--request-header-timeout` param to server to prevent [slowloris](https://www.netscout.com/what-is-ddos/slowloris-attacks) DDos
* annotate false positive in `llm/payload_common.go` and DRY

Please note that there are still open issues that need to be addressed or annotated with more context:
* `cmd/cmd.go:761:12`: G204: Subprocess launched with a potential tainted input or cmd arguments (gosec)
* `server/upload.go:5:2`: G501: Blocklisted import crypto/md5: weak cryptographic primitive (gosec)

It would be good to add `gosec` to the `.golangci.yaml` linter config and CI when all issues are addressed