### PR TITLE
Reject empty prompts on embeddings api

### DIFF
--- a/llm/dyn_ext_server.go
+++ b/llm/dyn_ext_server.go
@@ -24,6 +24,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -331,7 +332,12 @@ func (llm *dynExtServer) Decode(ctx context.Context, tokens []int) (string, erro
 	return decoded.Content, err
 }
 
+// Embedding calculates the embedding of the input string.
+// Empty input is rejected with an error
 func (llm *dynExtServer) Embedding(ctx context.Context, input string) ([]float64, error) {
+	if len(input) == 0 {
+		return nil, errors.New("empty input")
+	}
 	data, err := json.Marshal(TokenizeRequest{Content: input})
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling embed data: %w", err)

--- a/server/routes.go
+++ b/server/routes.go
@@ -398,6 +398,10 @@ func EmbeddingHandler(c *gin.Context) {
 		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "model is required"})
 		return
 	}
+	if req.Prompt == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "empty prompt"})
+		return
+	}
 
 	model, err := GetModel(req.Model)
 	if err != nil {


### PR DESCRIPTION
Resolves #2140 

This PR prevents empty prompts for the `api/embeddings` endpoint.  Please note that other endpoints may be affected as well. 🤷 

The changes to the unit test contain some minor updates as well to make better use of the testing framework of stdgo.

