### PR TITLE
Add fast server stop

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,11 +2,18 @@ package main
 
 import (
 	"context"
+	"errors"
+	"net/http"
+	"os"
 
 	"github.com/jmorganca/ollama/cmd"
 	"github.com/spf13/cobra"
 )
 
 func main() {
-	cobra.CheckErr(cmd.NewCLI().ExecuteContext(context.Background()))
+	err := cmd.NewCLI().ExecuteContext(context.Background())
+	if errors.Is(err, http.ErrServerClosed) {
+		os.Exit(0)
+	}
+	cobra.CheckErr(err)
 }


### PR DESCRIPTION
Resolves #2052

First sigterm for a graceful shutdown, second to kill the server.


There are no automated tests for this. Steps to reproduce:
in 1st terminal:
```sh
# go build . 
 ./ollama serve
```
in 2nd terminal
```
./ollama run llama2
```
then start a request that takes some seconds: `long response 100 words min`
While running, do  `Control-c` on terminal 1 twice. Server should exit immediately with code 1.

Also test graceful shutdown with 1 `Control-c` and wait for end of server response with exit code 0

