### PR TITLE
Add llm-ollama plugin for Datasette's LLM CLI to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [gptel Emacs client](https://github.com/karthink/gptel)
 - [Oatmeal](https://github.com/dustinblackman/oatmeal)
 - [cmdh](https://github.com/pgibler/cmdh)
+- [llm-ollama](https://github.com/taketwo/llm-ollama) for [Datasette's LLM CLI](https://llm.datasette.io/en/stable/).
 
 ### Database
 


### PR DESCRIPTION
The Datasette project's LLM cli provides a common interface to a variety of LLM APIs and local LLMs. This PR adds a link to an Ollama plugin for that tool.