### PR TITLE
Get paths right for first run, and deps

### DIFF
--- a/app/ollama.iss
+++ b/app/ollama.iss
@@ -86,7 +86,7 @@ Name: "{userstartup}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; IconFilen
 
 [Run]
 ; TODO consider starting a powershell window with a wall of text showing how to run ollama
-Filename: "{app}\{#MyAppExeName}"; Flags: postinstall nowait runhidden
+Filename: "{cmd}"; Parameters: "/C set PATH={app};%PATH% & ""{app}\{#MyAppExeName}"""; Flags: postinstall nowait runhidden
 
 [UninstallRun]
 ; Filename: "{cmd}"; Parameters: "/C ""taskkill /im ''{#MyAppExeName}'' /f /t"; Flags: runhidden

--- a/scripts/build_windows.ps1
+++ b/scripts/build_windows.ps1
@@ -40,12 +40,15 @@ function gatherDependencies() {
     rm -ea 0 -recurse -force -path "${script:DEPS_DIR}"
     md "${script:DEPS_DIR}" -ea 0 > $null
 
+    # TODO - this varies based on host build system and MSVC version - drive from dumpbin output
+    # currently works for Win11 + MSVC 2022 + Cuda V12
     cp "${env:VCToolsRedistDir}\x64\Microsoft.VC*.CRT\msvcp140.dll" "${script:DEPS_DIR}\"
     cp "${env:VCToolsRedistDir}\x64\Microsoft.VC*.CRT\vcruntime140.dll" "${script:DEPS_DIR}\"
-    cp "${env:VCToolsRedistDir}\x64\Microsoft.VC*.CRT\vcruntime140.dll" "${script:DEPS_DIR}\"
+    cp "${env:VCToolsRedistDir}\x64\Microsoft.VC*.CRT\vcruntime140_1.dll" "${script:DEPS_DIR}\"
 
     cp "${script:NVIDIA_DIR}\cudart64_*.dll" "${script:DEPS_DIR}\"
     cp "${script:NVIDIA_DIR}\cublas64_*.dll" "${script:DEPS_DIR}\"
+    # cp "${script:NVIDIA_DIR}\nvcuda.dll" "${script:DEPS_DIR}\"
 }
 
 function buildInstaller() {


### PR DESCRIPTION
Tested inside a Win 10 home hyperV VM with nothing extra added.  This gets all the deps right and loads the CPU runner.

![Screenshot 2024-02-04 at 8 50 15 PM](https://github.com/ollama/ollama/assets/4033016/5ad64dd7-0203-4510-a672-0b31189439c5)
