### PR TITLE
disable rocm builds

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,6 +59,8 @@ jobs:
           name: cuda-${{ matrix.cuda-version }}-libraries
           path: llm/llama.cpp/build/**/lib/*
   generate-rocm:
+    # TODO: re-enable once runners get more storage
+    if: ${{ false }}
     strategy:
       matrix:
         rocm-version:


### PR DESCRIPTION
rocm builds are failing because of disk space issues. disable them temporarily until larger runners

resolves #2373