### PR TITLE
[fix] /bye and /exit are now treated as prefixes

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -463,7 +463,7 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 			} else {
 				usage()
 			}
-		case line == "/exit", line == "/bye":
+    case strings.HasPrefix(line, "/exit"), strings.HasPrefix(line, "/bye"):
 			return nil
 		case strings.HasPrefix(line, "/"):
 			args := strings.Fields(line)

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -463,7 +463,7 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 			} else {
 				usage()
 			}
-    case strings.HasPrefix(line, "/exit"), strings.HasPrefix(line, "/bye"):
+		case strings.HasPrefix(line, "/exit"), strings.HasPrefix(line, "/bye"):
 			return nil
 		case strings.HasPrefix(line, "/"):
 			args := strings.Fields(line)


### PR DESCRIPTION
instead of being treated as entire lines which doesn't align with the way the rest of the commands are treated
it was a little annoying typing "/bye " and not having it work as expected