### PR TITLE
More robust shutdown logic

### DIFF
--- a/llm/dyn_ext_server.c
+++ b/llm/dyn_ext_server.c
@@ -43,6 +43,7 @@ void dyn_init(const char *libPath, struct dynamic_llama_server *s,
       {"llama_server_init", (void *)&s->llama_server_init},
       {"llama_server_start", (void *)&s->llama_server_start},
       {"llama_server_stop", (void *)&s->llama_server_stop},
+      {"llama_server_kill", (void *)&s->llama_server_kill},
       {"llama_server_completion", (void *)&s->llama_server_completion},
       {"llama_server_completion_next_result",
        (void *)&s->llama_server_completion_next_result},
@@ -95,6 +96,9 @@ inline void dyn_llama_server_start(struct dynamic_llama_server s) {
 
 inline void dyn_llama_server_stop(struct dynamic_llama_server s) {
   s.llama_server_stop();
+}
+inline void dyn_llama_server_kill(struct dynamic_llama_server s) {
+  s.llama_server_kill();
 }
 
 inline void dyn_llama_server_completion(struct dynamic_llama_server s,

--- a/llm/dyn_ext_server.go
+++ b/llm/dyn_ext_server.go
@@ -361,6 +361,10 @@ func (llm *dynExtServer) Close() {
 	mutex.Unlock()
 }
 
+func (llm *dynExtServer) Kill() {
+	C.dyn_llama_server_kill(llm.s)
+}
+
 func updatePath(dir string) {
 	if runtime.GOOS == "windows" {
 		tmpDir := filepath.Dir(dir)

--- a/llm/dyn_ext_server.h
+++ b/llm/dyn_ext_server.h
@@ -11,6 +11,7 @@ struct dynamic_llama_server {
                             ext_server_resp_t *err);
   void (*llama_server_start)();
   void (*llama_server_stop)();
+  void (*llama_server_kill)();
   void (*llama_server_completion)(const char *json_req,
                                   ext_server_resp_t *resp);
   void (*llama_server_completion_next_result)(const int task_id,
@@ -38,6 +39,7 @@ void dyn_llama_server_init(struct dynamic_llama_server s,
 void dyn_llama_server_start(struct dynamic_llama_server s);
 
 void dyn_llama_server_stop(struct dynamic_llama_server s);
+void dyn_llama_server_kill(struct dynamic_llama_server s);
 
 void dyn_llama_server_completion(struct dynamic_llama_server s,
                                           const char *json_req,

--- a/llm/ext_server/ext_server.cpp
+++ b/llm/ext_server/ext_server.cpp
@@ -161,6 +161,18 @@ void llama_server_stop() {
   LOG_TEE("llama server shutdown complete\n");
 }
 
+void llama_server_kill() {
+  assert(llama != NULL);
+  LOG_TEE("\ninitiating kill - canceling remaining tasks...\n");
+  int count = llama->queue_tasks.id;
+  for (int i = 0; i < count; i++) {
+    LOG_TEE("Canceling task %d\n", i);
+    llama->request_cancel(i);
+    llama->queue_results.remove_waiting_task_id(i);
+  }
+  LOG_TEE("llama server kill complete\n");
+}
+
 void llama_server_completion(const char *json_req, ext_server_resp_t *resp) {
   assert(llama != NULL && json_req != NULL && resp != NULL);
   resp->id = -1;

--- a/llm/ext_server/ext_server.h
+++ b/llm/ext_server/ext_server.h
@@ -65,6 +65,8 @@ void llama_server_start();
 // Stop the main loop and free up resources allocated in init and start.  Init
 // must be called again to reuse
 void llama_server_stop();
+// Kill pending requests, called with a pending stop to cleanly shutdown
+void llama_server_kill();
 
 // json_req null terminated string, memory managed by caller
 // resp->id >= 0 on success (task ID)

--- a/llm/llm.go
+++ b/llm/llm.go
@@ -16,7 +16,8 @@ type LLM interface {
 	Embedding(context.Context, string) ([]float64, error)
 	Encode(context.Context, string) ([]int, error)
 	Decode(context.Context, []int) (string, error)
-	Close()
+	Close() // Gracefull shutdown
+	Kill()  // Abort pending requests
 }
 
 func New(workDir, model string, adapters, projectors []string, opts api.Options) (LLM, error) {

--- a/server/routes.go
+++ b/server/routes.go
@@ -1003,6 +1003,11 @@ func Serve(ln net.Listener) error {
 	go func() {
 		<-signals
 		if loaded.runner != nil {
+			// Wire up a secondary signal handler to kill if we get stuck
+			go func() {
+				<-signals
+				loaded.runner.Kill()
+			}()
 			loaded.runner.Close()
 		}
 		os.RemoveAll(s.WorkDir)


### PR DESCRIPTION
If a very long running request is in flight, or some bug causes an infinite loop this will allow a second signal to kill pending requests to ensure we can actually shutdown and not get stuck and require a `kill -9` to exit