### PR TITLE
Add GBNF grammar support

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -103,6 +103,7 @@ type Options struct {
 	Mirostat         int      `json:"mirostat,omitempty"`
 	MirostatTau      float32  `json:"mirostat_tau,omitempty"`
 	MirostatEta      float32  `json:"mirostat_eta,omitempty"`
+	Grammar          string   `json:"grammar,omitempty"`
 	PenalizeNewline  bool     `json:"penalize_newline,omitempty"`
 	Stop             []string `json:"stop,omitempty"`
 }

--- a/docs/modelfile.md
+++ b/docs/modelfile.md
@@ -151,6 +151,7 @@ PARAMETER <parameter> <parametervalue>
 | num_predict    | Maximum number of tokens to predict when generating text. (Default: 128, -1 = infinite generation, -2 = fill context)                                                                                                                                   | int        | num_predict 42       |
 | top_k          | Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative. (Default: 40)                                                                        | int        | top_k 40             |
 | top_p          | Works together with top-k. A higher value (e.g., 0.95) will lead to more diverse text, while a lower value (e.g., 0.5) will generate more focused and conservative text. (Default: 0.9)                                                                 | float      | top_p 0.9            |
+| grammar        | The [GBNF](https://github.com/ggerganov/llama.cpp/tree/master/grammars) grammar used to constrain the model output. | string | grammar "root ::= [0-9]+" |
 
 ### TEMPLATE
 

--- a/examples/grammar/Modelfile
+++ b/examples/grammar/Modelfile
@@ -1,0 +1,39 @@
+FROM codellama:13b-instruct-q5_K_M
+
+# Note that this is just an example, any type of GBNF compatible
+# grammar can be specified. More information about the grammar
+# syntax and other examples at:
+#
+# https://github.com/ggerganov/llama.cpp/blob/master/grammars/README.md
+
+# JSON grammar provided by llama.cpp
+# MIT License
+# Copyright (c) 2023 Georgi Gerganov
+
+PARAMETER grammar """
+root   ::= object
+value  ::= object | array | string | number | ("true" | "false" | "null") ws
+
+object ::=
+  "{" ws (
+            string ":" ws value
+    ("," ws string ":" ws value)*
+  )? "}" ws
+
+array  ::=
+  "[" ws (
+            value
+    ("," ws value)*
+  )? "]" ws
+
+string ::=
+  "\"" (
+    [^"\\] |
+    "\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]) # escapes
+  )* "\"" ws
+
+number ::= ("-"? ([0-9] | [1-9] [0-9]*)) ("." [0-9]+)? ([eE] [-+]? [0-9]+)? ws
+
+# Optional space: by convention, applied in this grammar after literal chars when allowed
+ws ::= ([ \t\n] ws)?
+"""

--- a/llm/dyn_ext_server.go
+++ b/llm/dyn_ext_server.go
@@ -183,6 +183,7 @@ func (llm *dynExtServer) Predict(ctx context.Context, predict PredictOpts, fn fu
 		"mirostat":          predict.Options.Mirostat,
 		"mirostat_tau":      predict.Options.MirostatTau,
 		"mirostat_eta":      predict.Options.MirostatEta,
+		"grammar":           predict.Options.Grammar,
 		"penalize_nl":       predict.Options.PenalizeNewline,
 		"seed":              predict.Options.Seed,
 		"stop":              predict.Options.Stop,


### PR DESCRIPTION
This is an updated version of #1606 that accounts for changes to the code since it was originally submitted.

Adds support for llama.cpp's GBNF grammars, which enable very specific steering of model outputs. This feature is already used on the backend by when the `format` option is set to `json`, but this allows any arbitrary grammar to be passed in. In the case where both `grammar` and `format` are specified, the `format` is preferred.