### PR TITLE
Added Encoding endpoint

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -343,3 +343,16 @@ func (c *Client) Version(ctx context.Context) (string, error) {
 
 	return version.Version, nil
 }
+
+type EncodeResponseFunc func(EncodeResponse) error
+
+func (c *Client) Encode(ctx context.Context, req *GenerateRequest, fn EncodeResponseFunc) error {
+	return c.stream(ctx, http.MethodPost, "/api/encode", req, func(bts []byte) error {
+		var resp EncodeResponse
+		if err := json.Unmarshal(bts, &resp); err != nil {
+			return err
+		}
+
+		return fn(resp)
+	})
+}

--- a/api/types.go
+++ b/api/types.go
@@ -248,6 +248,16 @@ type ModelDetails struct {
 	QuantizationLevel string   `json:"quantization_level"`
 }
 
+type EncodeResponse struct {
+	Model         string        `json:"model"`
+	CreatedAt     time.Time     `json:"created_at"`
+	TotalDuration time.Duration `json:"total_duration,omitempty"`
+	LoadDuration  time.Duration `json:"load_duration,omitempty"`
+
+	Context         []int `json:"context,omitempty"`
+	PromptEvalCount int   `json:"prompt_eval_count,omitempty"`
+}
+
 func (m *Metrics) Summary() {
 	if m.TotalDuration > 0 {
 		fmt.Fprintf(os.Stderr, "total duration:       %v\n", m.TotalDuration)


### PR DESCRIPTION
It seems useful to expose the encoding function of a model that us called by the generate methods to enable token counting (without running the model end to end). 

Some thoughts:
- Im not sure whether replicating the logic that modifies the prompt (the same as the generate function is correct here or whether we should just simplify and just look at the raw prompt string. 
- I havent made a similar endpoint for getting the tokens from a chat call. 

My current thinking is that simplification of this would be better and i dont need replicate all the prompt logic necessarily. Im interested in feedback and if folks have any pushback to exposing the function. 

Following up from https://github.com/ollama/ollama/issues/1345

Btw the proposal makes a new endpoint `/api/encode` for requests of the following 

Looks a bit like this at a request level:
Input
```json
{
  "model": "mistral:latest",
  "prompt": "Why is the sky blue?"
}
```
Output
```json
{
    "model": "mistral:latest",
    "created_at": "2024-02-05T21:49:44.472893Z",
    "total_duration": 8965307875,
    "load_duration": 8961889917,
    "context": [
        733,
        16289,
        28793,
        28705,
        4315,
        349,
        272,
        7212,
        5045,
        28804,
        733,
        28748,
        16289,
        28793,
        13
    ],
    "prompt_eval_count": 15
}
```