### PR TITLE
Add Page Assist to the community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [chatd](https://github.com/BruceMacD/chatd)
 - [Ollama-SwiftUI](https://github.com/kghandour/Ollama-SwiftUI)
 - [MindMac](https://mindmac.app)
+- [Page Assist](https://github.com/n4ze3m/page-assist)
 
 ### Terminal
 


### PR DESCRIPTION
Hey, I'd like to share my Chrome extension project I've been working on, `Page Assist`, for community integration. It offers a sidebar and web UI for Ollama :). Please review this PR. Thank you.