### PR TITLE
Add OpenAI /v1/models API support

### DIFF
--- a/openai/openai.go
+++ b/openai/openai.go
@@ -14,6 +14,18 @@ import (
 	"github.com/jmorganca/ollama/api"
 )
 
+type Model struct {
+	ID      string `json:"id"`
+	Object  string `json:"object"`
+	Created int    `json:"created"`
+	OwnedBy string `json:"owned_by"`
+}
+
+type ModelsListResponse struct {
+	Object string  `json:"object"`
+	Data   []Model `json:"data"`
+}
+
 type Error struct {
 	Message string      `json:"message"`
 	Type    string      `json:"type"`

--- a/server/routes.go
+++ b/server/routes.go
@@ -826,6 +826,64 @@ func ListModelsHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, api.ListResponse{Models: models})
 }
 
+func ListModelsOpenAIHandler(c *gin.Context) {
+	var models []openai.Model
+
+	manifestsPath, err := GetManifestPath()
+
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	modelResponse := func(modelName string) (openai.Model, error) {
+		model, err := GetModel(modelName)
+		if err != nil {
+			return openai.Model{}, err
+		}
+
+		return openai.Model{
+			ID:      model.ShortName,
+			Object:  "model",
+			Created: int(time.Now().Unix()),
+			OwnedBy: "ollama",
+		}, nil
+	}
+
+	walkFunc := func(path string, info os.FileInfo, _ error) error {
+		if !info.IsDir() {
+			path, tag := filepath.Split(path)
+			model := strings.Trim(strings.TrimPrefix(path, manifestsPath), string(os.PathSeparator))
+			modelPath := strings.Join([]string{model, tag}, ":")
+			canonicalModelPath := strings.ReplaceAll(modelPath, string(os.PathSeparator), "/")
+
+			resp, err := modelResponse(canonicalModelPath)
+			if err != nil {
+				slog.Info(fmt.Sprintf("skipping file: %s", canonicalModelPath))
+				// nolint: nilerr
+				return nil
+			}
+
+			resp.Created = int(info.ModTime().Unix())
+			models = append(models, resp)
+		}
+
+		return nil
+	}
+
+	if err := filepath.Walk(manifestsPath, walkFunc); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	response := openai.ModelsListResponse{
+		Object: "list",
+		Data:   models,
+	}
+
+	c.JSON(http.StatusOK, response)
+}
+
 func CopyModelHandler(c *gin.Context) {
 	var req api.CopyRequest
 	err := c.ShouldBindJSON(&req)
@@ -953,6 +1011,7 @@ func (s *Server) GenerateRoutes() http.Handler {
 
 	// Compatibility endpoints
 	r.POST("/v1/chat/completions", openai.Middleware(), ChatHandler)
+	r.GET("/v1/models", ListModelsOpenAIHandler)
 
 	for _, method := range []string{http.MethodGet, http.MethodHead} {
 		r.Handle(method, "/", func(c *gin.Context) {


### PR DESCRIPTION
Add openaAI API **v1/models** endpoint compatibility.

See spec at: https://platform.openai.com/docs/api-reference/models/list

Personally I am not so sure about putting the ListModelsHandlerOpenAI method into the router file, however the original ollama ListModelsHandler function is also there.

I generally don't write go, so sorry for any weird things. Let me know what you think about this change.

Requested in #2430

Example usage:

```shell
❯ curl http://localhost:11434/v1/models | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   226  100   226    0     0  33776      0 --:--:-- --:--:-- --:--:--  110k
{
  "object": "list",
  "data": [
    {
      "id": "codegpt/deepseek-coder-1.3b-typescript:latest",
      "object": "model",
      "created": 1707753573,
      "owned_by": "ollama"
    },
    {
      "id": "deepseek-coder:6.7b",
      "object": "model",
      "created": 1705498161,
      "owned_by": "ollama"
    }
  ]
}
```