### PR TITLE
Fix negative keep_alive

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -415,8 +415,7 @@ func (d *Duration) UnmarshalJSON(b []byte) (err error) {
 	switch t := v.(type) {
 	case float64:
 		if t < 0 {
-			t = math.MaxFloat64
-			d.Duration = time.Duration(t)
+			d.Duration = time.Duration(math.MaxInt64)
 		} else {
 			d.Duration = time.Duration(t * float64(time.Second))
 		}
@@ -426,8 +425,7 @@ func (d *Duration) UnmarshalJSON(b []byte) (err error) {
 			return err
 		}
 		if d.Duration < 0 {
-			mf := math.MaxFloat64
-			d.Duration = time.Duration(mf)
+			d.Duration = time.Duration(math.MaxInt64)
 		}
 	}
 


### PR DESCRIPTION
Using a negative `keep_alive` did not work as expected, models would unload instantly. Some logging of the duration which was unmarshalled showed that the `math.MaxFloat64` was resulting in a very large negative duration rather than the desired very large positive duration.

I just changed these codepaths to use `math.MaxInt64`, which is what I understand `time.Duration` to expect.