### PR TITLE
update default registry domain

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -456,7 +456,7 @@ curl http://localhost:11434/api/chat -d '{
 
 ```json
 {
-  "model": "registry.ollama.ai/library/llama2:latest",
+  "model": "ollama.com/library/llama2:latest",
   "created_at": "2023-12-12T14:13:43.416799Z",
   "message": {
     "role": "assistant",

--- a/scripts/setup_integration_tests.sh
+++ b/scripts/setup_integration_tests.sh
@@ -11,7 +11,7 @@ set -o pipefail
 REPO=$(dirname $0)/../
 export OLLAMA_MODELS=${REPO}/test_data/models
 REGISTRY_SCHEME=https
-REGISTRY=registry.ollama.ai
+REGISTRY=ollama.com
 TEST_MODELS=("library/orca-mini:latest" "library/llava:7b")
 ACCEPT_HEADER="Accept: application/vnd.docker.distribution.manifest.v2+json"
 

--- a/server/modelpath.go
+++ b/server/modelpath.go
@@ -3,6 +3,8 @@ package server
 import (
 	"errors"
 	"fmt"
+	"io/fs"
+	"log/slog"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -19,7 +21,7 @@ type ModelPath struct {
 }
 
 const (
-	DefaultRegistry       = "registry.ollama.ai"
+	DefaultRegistry       = "ollama.com"
 	DefaultNamespace      = "library"
 	DefaultTag            = "latest"
 	DefaultProtocolScheme = "https"
@@ -164,4 +166,34 @@ func GetBlobsPath(digest string) (string, error) {
 	}
 
 	return path, nil
+}
+
+func migrateRegistryDomain() error {
+	manifests, err := GetManifestPath()
+	if err != nil {
+		return err
+	}
+
+	olddomainpath := filepath.Join(manifests, "registry.ollama.ai")
+	newdomainpath := filepath.Join(manifests, DefaultRegistry)
+
+	return filepath.Walk(olddomainpath, func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !info.IsDir() {
+			slog.Info("migrating registry domain", "path", path)
+			newpath := filepath.Join(newdomainpath, strings.TrimPrefix(path, olddomainpath))
+			if err := os.MkdirAll(filepath.Dir(newpath), 0o755); err != nil {
+				return err
+			}
+
+			if err := os.Rename(path, newpath); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
 }

--- a/server/modelpath.go
+++ b/server/modelpath.go
@@ -46,8 +46,7 @@ func ParseModelPath(name string) ModelPath {
 		name = after
 	}
 
-	name = strings.ReplaceAll(name, string(os.PathSeparator), "/")
-	parts := strings.Split(name, "/")
+	parts := strings.Split(filepath.ToSlash(name), "/")
 	switch len(parts) {
 	case 3:
 		mp.Registry = parts[0]

--- a/server/routes.go
+++ b/server/routes.go
@@ -802,7 +802,7 @@ func ListModelsHandler(c *gin.Context) {
 			path, tag := filepath.Split(path)
 			model := strings.Trim(strings.TrimPrefix(path, manifestsPath), string(os.PathSeparator))
 			modelPath := strings.Join([]string{model, tag}, ":")
-			canonicalModelPath := strings.ReplaceAll(modelPath, string(os.PathSeparator), "/")
+			canonicalModelPath := filepath.ToSlash(modelPath)
 
 			resp, err := modelResponse(canonicalModelPath)
 			if err != nil {

--- a/server/routes.go
+++ b/server/routes.go
@@ -1005,6 +1005,13 @@ func Serve(ln net.Listener) error {
 		}
 	}
 
+	// migrate registry.ollama.ai to ollama.com
+	if err := migrateRegistryDomain(); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	}
+
 	s, err := NewServer()
 	if err != nil {
 		return err


### PR DESCRIPTION
update default registry domain from registry.ollama.ai to ollama.com
migrate models by moving models to their new location. this is one directional