### PR TITLE
handle race condition while setting raw mode in windows

### DIFF
--- a/readline/readline_unix.go
+++ b/readline/readline_unix.go
@@ -6,8 +6,9 @@ import (
 	"syscall"
 )
 
-func handleCharCtrlZ(fd int, termios *Termios) (string, error) {
-	if err := UnsetRawMode(fd, termios); err != nil {
+func handleCharCtrlZ(fd int, termios any) (string, error) {
+	t := termios.(*Termios)
+	if err := UnsetRawMode(fd, t); err != nil {
 		return "", err
 	}
 

--- a/readline/readline_windows.go
+++ b/readline/readline_windows.go
@@ -1,6 +1,6 @@
 package readline
 
-func handleCharCtrlZ(fd int, state *State) (string, error) {
+func handleCharCtrlZ(fd int, state any) (string, error) {
 	// not supported
 	return "", nil
 }

--- a/readline/term.go
+++ b/readline/term.go
@@ -25,8 +25,9 @@ func SetRawMode(fd int) (*Termios, error) {
 	return termios, setTermios(fd, &newTermios)
 }
 
-func UnsetRawMode(fd int, termios *Termios) error {
-	return setTermios(fd, termios)
+func UnsetRawMode(fd int, termios any) error {
+	t := termios.(*Termios)
+	return setTermios(fd, t)
 }
 
 // IsTerminal returns true if the given file descriptor is a terminal.

--- a/readline/term_windows.go
+++ b/readline/term_windows.go
@@ -56,7 +56,8 @@ func SetRawMode(fd int) (*State, error) {
 	return &State{st}, nil
 }
 
-func UnsetRawMode(fd int, state *State) error {
+func UnsetRawMode(fd int, state any) error {
+	s := state.(*State)
 	_, _, err := syscall.SyscallN(procSetConsoleMode.Addr(), uintptr(fd), uintptr(state.mode), 0)
 	return err
 }

--- a/readline/term_windows.go
+++ b/readline/term_windows.go
@@ -58,6 +58,6 @@ func SetRawMode(fd int) (*State, error) {
 
 func UnsetRawMode(fd int, state any) error {
 	s := state.(*State)
-	_, _, err := syscall.SyscallN(procSetConsoleMode.Addr(), uintptr(fd), uintptr(state.mode), 0)
+	_, _, err := syscall.SyscallN(procSetConsoleMode.Addr(), uintptr(fd), uintptr(s.mode), 0)
 	return err
 }


### PR DESCRIPTION
This change handles a race condition in the go routine which handles reading in runes. On Windows "raw mode" (i.e. turning off echo/line/processed input) gets turned off too late which would cause `ReadRune()` to wait until the buffer was full (when it got a new line). This change goes into raw mode faster, but it still needs to happen before any input since we turn it back off again once we start processing output.
