### PR TITLE
Added OLLAMA_DEFAULT_KEEPALIVE, OLLAMA_KEEPALIVE environment variables

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -404,6 +404,22 @@ type Duration struct {
 	time.Duration
 }
 
+func (d *Duration) FromString(s string) error {
+	var err error
+	d.Duration, err = time.ParseDuration(s)
+	if err != nil {
+		return err
+	}
+	if d.Duration < 0 {
+		d.Duration = time.Duration(math.MaxInt64)
+	}
+	return nil
+}
+
+func (d *Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.String())
+}
+
 func (d *Duration) UnmarshalJSON(b []byte) (err error) {
 	var v any
 	if err := json.Unmarshal(b, &v); err != nil {
@@ -420,12 +436,8 @@ func (d *Duration) UnmarshalJSON(b []byte) (err error) {
 			d.Duration = time.Duration(t * float64(time.Second))
 		}
 	case string:
-		d.Duration, err = time.ParseDuration(t)
-		if err != nil {
+		if err = d.FromString(t); err != nil {
 			return err
-		}
-		if d.Duration < 0 {
-			d.Duration = time.Duration(math.MaxInt64)
 		}
 	}
 

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -1,0 +1,85 @@
+package api
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeepAliveParsingFromStruct(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *ChatRequest
+		exp  *Duration
+	}{
+		{
+			name: "Positive Duration",
+			req: &ChatRequest{
+				KeepAlive: &Duration{Duration: 42 * time.Minute},
+			},
+			exp: &Duration{42 * time.Minute},
+		},
+		{
+			name: "Negative Duration",
+			req: &ChatRequest{
+				KeepAlive: &Duration{Duration: -1 * time.Minute},
+			},
+			exp: &Duration{math.MaxInt64},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ser, err := json.Marshal(test.req)
+			require.NoError(t, err)
+
+			var dec ChatRequest
+			err = json.Unmarshal([]byte(ser), &dec)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.exp, dec.KeepAlive)
+		})
+	}
+}
+func TestKeepAliveParsingFromJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		req  string
+		exp  *Duration
+	}{
+		{
+			name: "Positive Integer",
+			req:  `{ "keep_alive": 42 }`,
+			exp:  &Duration{42 * time.Second},
+		},
+		{
+			name: "Positive Integer String",
+			req:  `{ "keep_alive": "42m" }`,
+			exp:  &Duration{42 * time.Minute},
+		},
+		{
+			name: "Negative Integer",
+			req:  `{ "keep_alive": -1 }`,
+			exp:  &Duration{math.MaxInt64},
+		},
+		{
+			name: "Negative Integer String",
+			req:  `{ "keep_alive": "-1m" }`,
+			exp:  &Duration{math.MaxInt64},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var dec ChatRequest
+			err := json.Unmarshal([]byte(test.req), &dec)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.exp, dec.KeepAlive)
+		})
+	}
+}

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -14,21 +15,21 @@ func TestKeepAliveParsingFromStruct(t *testing.T) {
 	tests := []struct {
 		name string
 		req  *ChatRequest
-		exp  *Duration
+		exp  *SessionDuration
 	}{
 		{
 			name: "Positive Duration",
 			req: &ChatRequest{
-				KeepAlive: &Duration{Duration: 42 * time.Minute},
+				KeepAlive: &SessionDuration{42 * time.Minute},
 			},
-			exp: &Duration{42 * time.Minute},
+			exp: &SessionDuration{42 * time.Minute},
 		},
 		{
 			name: "Negative Duration",
 			req: &ChatRequest{
-				KeepAlive: &Duration{Duration: -1 * time.Minute},
+				KeepAlive: &SessionDuration{-1 * time.Minute},
 			},
-			exp: &Duration{math.MaxInt64},
+			exp: &SessionDuration{math.MaxInt64},
 		},
 	}
 
@@ -49,27 +50,27 @@ func TestKeepAliveParsingFromJSON(t *testing.T) {
 	tests := []struct {
 		name string
 		req  string
-		exp  *Duration
+		exp  *SessionDuration
 	}{
 		{
 			name: "Positive Integer",
 			req:  `{ "keep_alive": 42 }`,
-			exp:  &Duration{42 * time.Second},
+			exp:  &SessionDuration{42 * time.Second},
 		},
 		{
 			name: "Positive Integer String",
 			req:  `{ "keep_alive": "42m" }`,
-			exp:  &Duration{42 * time.Minute},
+			exp:  &SessionDuration{42 * time.Minute},
 		},
 		{
 			name: "Negative Integer",
 			req:  `{ "keep_alive": -1 }`,
-			exp:  &Duration{math.MaxInt64},
+			exp:  &SessionDuration{math.MaxInt64},
 		},
 		{
 			name: "Negative Integer String",
 			req:  `{ "keep_alive": "-1m" }`,
-			exp:  &Duration{math.MaxInt64},
+			exp:  &SessionDuration{math.MaxInt64},
 		},
 	}
 
@@ -80,6 +81,44 @@ func TestKeepAliveParsingFromJSON(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Equal(t, test.exp, dec.KeepAlive)
+		})
+	}
+}
+
+func TestKeepAliveParsingFromContext(t *testing.T) {
+	tests := []struct {
+		name string
+		ctx  *gin.Context
+		exp  *SessionDuration
+	}{
+		{
+			name: "Positive Integer",
+			ctx: func() *gin.Context {
+				c := &gin.Context{}
+				d, _ := NewSessionDuration(WithDuration(42 * time.Minute))
+				c.Set("keepAlive", d)
+				return c
+			}(),
+			exp: &SessionDuration{42 * time.Minute},
+		},
+		{
+			name: "Negative Integer",
+			ctx: func() *gin.Context {
+				c := &gin.Context{}
+				d, _ := NewSessionDuration(WithDuration(-1 * time.Minute))
+				c.Set("keepAlive", d)
+				return c
+			}(),
+			exp: &SessionDuration{math.MaxInt64},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			keepAliveStr, _ := test.ctx.Get("keepAlive")
+			keepAlive := keepAliveStr.(*SessionDuration)
+
+			assert.Equal(t, test.exp, keepAlive)
 		})
 	}
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -167,10 +167,13 @@ func RunHandler(cmd *cobra.Command, args []string) error {
 
 	interactive := true
 
-	var defaultSessionDuration = 5 * time.Minute
-	keepAlive := &api.Duration{Duration: defaultSessionDuration}
-	if envKeepAlive := os.Getenv("OLLAMA_KEEPALIVE"); envKeepAlive != "" {
-		if err = keepAlive.FromString(envKeepAlive); err != nil {
+	// leaves it nil if unset. will use the default server behavior
+	var keepAlive *api.SessionDuration
+	if os.Getenv("OLLAMA_KEEPALIVE") != "" {
+		keepAlive, err = api.NewSessionDuration(
+			api.WithEnvVar("OLLAMA_KEEPALIVE"),
+		)
+		if err != nil {
 			return err
 		}
 	}
@@ -483,7 +486,7 @@ type runOptions struct {
 	Images      []api.ImageData
 	Options     map[string]interface{}
 	MultiModal  bool
-	KeepAlive   *api.Duration
+	KeepAlive   *api.SessionDuration
 }
 
 type displayResponseState struct {


### PR DESCRIPTION
This pull request introduces the ability to set `keep_alive` via the environment variable `OLLAMA_KEEPALIVE`. It currently supports both `generate` and `chat` endpoints.
I added tests to verify the parsing, as it was inconsistent without a dedicated marshalling function.

This is related to #2146.