### PR TITLE
fix: use requested model template

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -1092,12 +1092,12 @@ func streamResponse(c *gin.Context, ch chan any) {
 }
 
 // ChatPrompt builds up a prompt from a series of messages for the currently `loaded` model
-func chatPrompt(ctx context.Context, model *Model, messages []api.Message) (string, error) {
+func chatPrompt(ctx context.Context, template, system string, messages []api.Message, numCtx int) (string, error) {
 	encode := func(s string) ([]int, error) {
 		return loaded.runner.Encode(ctx, s)
 	}
 
-	prompt, err := ChatPrompt(model.Template, model.System, messages, loaded.Options.NumCtx, encode)
+	prompt, err := ChatPrompt(template, system, messages, numCtx, encode)
 	if err != nil {
 		return "", err
 	}
@@ -1167,7 +1167,7 @@ func ChatHandler(c *gin.Context) {
 
 	checkpointLoaded := time.Now()
 
-	prompt, err := chatPrompt(c.Request.Context(), model, req.Messages)
+	prompt, err := chatPrompt(c.Request.Context(), model.Template, model.System, req.Messages, opts.NumCtx)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return

--- a/server/routes.go
+++ b/server/routes.go
@@ -1092,12 +1092,12 @@ func streamResponse(c *gin.Context, ch chan any) {
 }
 
 // ChatPrompt builds up a prompt from a series of messages for the currently `loaded` model
-func chatPrompt(ctx context.Context, messages []api.Message) (string, error) {
+func chatPrompt(ctx context.Context, model *Model, messages []api.Message) (string, error) {
 	encode := func(s string) ([]int, error) {
 		return loaded.runner.Encode(ctx, s)
 	}
 
-	prompt, err := ChatPrompt(loaded.Model.Template, loaded.Model.System, messages, loaded.Options.NumCtx, encode)
+	prompt, err := ChatPrompt(model.Template, model.System, messages, loaded.Options.NumCtx, encode)
 	if err != nil {
 		return "", err
 	}
@@ -1167,7 +1167,7 @@ func ChatHandler(c *gin.Context) {
 
 	checkpointLoaded := time.Now()
 
-	prompt, err := chatPrompt(c.Request.Context(), req.Messages)
+	prompt, err := chatPrompt(c.Request.Context(), model, req.Messages)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return


### PR DESCRIPTION
As reported in scenario 1 of #2492 

When a request was made to a model than inherits from the currently loaded model the system and template were not updated in the `/chat` endpoint. The fix is to use the requested model rather than the loaded one.

Steps to reproduce:
1. Create a model that overrides the system prompt of another model:
```
FROM phi
SYSTEM """I want you to speak French only."""
```
`ollama create phi-french -f ~/models/phi-french/Modelfile`
2. Run the base model
`ollama run phi`
3. Quit the repl and run the custom model
```
ollama run phi-french
```
The system message from the base model was not changed, as the loaded model did not change.