### PR TITLE
fix: chat system prompting overrides

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -180,6 +180,7 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 
 	var sb strings.Builder
 	var multiline MultilineState
+	var system string
 
 	for {
 		line, err := scanner.Readline()
@@ -354,8 +355,8 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 					}
 
 					if args[1] == "system" {
-						opts.System = sb.String()
-						opts.Messages = append(opts.Messages, api.Message{Role: "system", Content: opts.System})
+						opts.System = sb.String() // for display in modelfile
+						system = sb.String()
 						fmt.Println("Set system message.")
 						sb.Reset()
 					} else if args[1] == "template" {
@@ -489,6 +490,11 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 		}
 
 		if sb.Len() > 0 && multiline == MultilineNone {
+			if system != "" {
+				// the user has set a new system message
+				opts.Messages = append(opts.Messages, api.Message{Role: "system", Content: system})
+				system = ""
+			}
 			newMessage := api.Message{Role: "user", Content: sb.String()}
 
 			if opts.MultiModal {

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -361,7 +361,6 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 							// Replace the last message
 							opts.Messages[len(opts.Messages)-1] = newMessage
 						} else {
-							// Append the new message
 							opts.Messages = append(opts.Messages, newMessage)
 						}
 						fmt.Println("Set system message.")

--- a/server/prompt.go
+++ b/server/prompt.go
@@ -91,7 +91,7 @@ func countTokens(tmpl string, system string, prompt string, response string, enc
 }
 
 // ChatPrompt builds up a prompt from a series of messages, truncating based on context window size
-func ChatPrompt(tmpl string, system string, messages []api.Message, window int, encode func(string) ([]int, error)) (string, error) {
+func ChatPrompt(tmpl string, messages []api.Message, window int, encode func(string) ([]int, error)) (string, error) {
 	type prompt struct {
 		System   string
 		Prompt   string
@@ -102,11 +102,6 @@ func ChatPrompt(tmpl string, system string, messages []api.Message, window int, 
 	}
 
 	var p prompt
-
-	// Set the first system prompt to the model's system prompt
-	if system != "" {
-		p.System = system
-	}
 
 	// iterate through messages to build up {system,user,response} prompts
 	var imgId int

--- a/server/prompt_test.go
+++ b/server/prompt_test.go
@@ -77,7 +77,6 @@ func TestChatPrompt(t *testing.T) {
 	tests := []struct {
 		name     string
 		template string
-		system   string
 		messages []api.Message
 		window   int
 		want     string
@@ -90,16 +89,6 @@ func TestChatPrompt(t *testing.T) {
 			},
 			window: 1024,
 			want:   "[INST] Hello [/INST]",
-		},
-		{
-			name:     "with default system message",
-			system:   "You are a Wizard.",
-			template: "[INST] {{ if .System }}<<SYS>>{{ .System }}<</SYS>> {{ end }}{{ .Prompt }} [/INST]",
-			messages: []api.Message{
-				{Role: "user", Content: "Hello"},
-			},
-			window: 1024,
-			want:   "[INST] <<SYS>>You are a Wizard.<</SYS>> Hello [/INST]",
 		},
 		{
 			name:     "with system message",
@@ -186,24 +175,6 @@ func TestChatPrompt(t *testing.T) {
 			want:     "",
 		},
 		{
-			name:     "empty list default system",
-			system:   "You are a Wizard.",
-			template: "{{ .System }} {{ .Prompt }}",
-			messages: []api.Message{},
-			window:   1024,
-			want:     "You are a Wizard. ",
-		},
-		{
-			name:     "empty user message",
-			system:   "You are a Wizard.",
-			template: "{{ .System }} {{ .Prompt }}",
-			messages: []api.Message{
-				{Role: "user", Content: ""},
-			},
-			window: 1024,
-			want:   "You are a Wizard. ",
-		},
-		{
 			name:     "empty prompt",
 			template: "[INST] {{ if .System }}<<SYS>>{{ .System }}<</SYS>> {{ end }}{{ .Prompt }} [/INST] {{ .Response }} ",
 			messages: []api.Message{
@@ -221,7 +192,7 @@ func TestChatPrompt(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := ChatPrompt(tc.template, tc.system, tc.messages, tc.window, encode)
+			got, err := ChatPrompt(tc.template, tc.messages, tc.window, encode)
 			if err != nil {
 				t.Errorf("error = %v", err)
 			}

--- a/server/routes.go
+++ b/server/routes.go
@@ -1167,6 +1167,16 @@ func ChatHandler(c *gin.Context) {
 
 	checkpointLoaded := time.Now()
 
+	if len(req.Messages) > 0 && req.Messages[0].Role != "system" {
+		// if the first message is not a system message, then add the model's default system message
+		req.Messages = append([]api.Message{
+			{
+				Role:    "system",
+				Content: model.System,
+			},
+		}, req.Messages...)
+	}
+
 	prompt, err := chatPrompt(c.Request.Context(), req.Messages)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})

--- a/server/routes.go
+++ b/server/routes.go
@@ -1092,12 +1092,12 @@ func streamResponse(c *gin.Context, ch chan any) {
 }
 
 // ChatPrompt builds up a prompt from a series of messages for the currently `loaded` model
-func chatPrompt(ctx context.Context, messages []api.Message) (string, error) {
+func chatPrompt(ctx context.Context, template string, messages []api.Message, numCtx int) (string, error) {
 	encode := func(s string) ([]int, error) {
 		return loaded.runner.Encode(ctx, s)
 	}
 
-	prompt, err := ChatPrompt(loaded.Model.Template, loaded.Model.System, messages, loaded.Options.NumCtx, encode)
+	prompt, err := ChatPrompt(template, messages, numCtx, encode)
 	if err != nil {
 		return "", err
 	}
@@ -1177,7 +1177,7 @@ func ChatHandler(c *gin.Context) {
 		}, req.Messages...)
 	}
 
-	prompt, err := chatPrompt(c.Request.Context(), req.Messages)
+	prompt, err := chatPrompt(c.Request.Context(), model.Template, req.Messages, opts.NumCtx)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return

--- a/server/routes.go
+++ b/server/routes.go
@@ -1167,8 +1167,8 @@ func ChatHandler(c *gin.Context) {
 
 	checkpointLoaded := time.Now()
 
+	// if the first message is not a system message, then add the model's default system message
 	if len(req.Messages) > 0 && req.Messages[0].Role != "system" {
-		// if the first message is not a system message, then add the model's default system message
 		req.Messages = append([]api.Message{
 			{
 				Role:    "system",


### PR DESCRIPTION
This change fixes two more system message related issues with the CLI and message templates.
- When `/set system ...` is run multiple times in the CLI, use only the most recent system message rather than adding multiple system messages to the history.
- Do not add the model's default message as a first message when a new system message is specified.
- When a request was made to a model than inherits from the currently loaded model the system and template were not updated in the /chat endpoint. The fix is to use the requested model rather than the loaded one.

Previous behavior, when running a model and setting a new system message:
```
ollama run phi
>>> /set system you are mario
Set system message.
>>> hi
```
```
level=DEBUG source=routes.go:1205 msg="chat handler" prompt="System: A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful answers to the user's questions.\nUser: \nAssistant:System: you are mario\nUser: hi\nAssistant:"
```

New behavior:
```
level=DEBUG source=routes.go:1205 msg="chat handler" prompt="System: you are mario\nUser: hi\nAssistant:"
```

resolves #2492 

Follow up: This keep the "system message history" further testing on model behavior of this is needed, it could be better to just override the system message, and not keep the old system message in the history.