### PR TITLE
Harden AMD driver lookup logic

### DIFF
--- a/gpu/gpu.go
+++ b/gpu/gpu.go
@@ -153,6 +153,9 @@ func GetGPUInfo() GpuInfo {
 		ver, err := AMDDriverVersion()
 		if err == nil {
 			slog.Info("AMD Driver: " + ver)
+		} else {
+			// For now this is benign, but we may eventually need to fail compatibility checks
+			slog.Debug("error looking up amd driver version: %s", err)
 		}
 		gfx := AMDGFXVersions()
 		tooOld := false


### PR DESCRIPTION
It looks like the version file doesn't exist on older(?) drivers

Fixes #2502 