### PR TITLE
Update Web UI link to new project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Chatbot UI](https://github.com/ivanfioravanti/chatbot-ollama)
 - [Typescript UI](https://github.com/ollama-interface/Ollama-Gui?tab=readme-ov-file)
 - [Minimalistic React UI for Ollama Models](https://github.com/richawo/minimal-llm-ui)
-- [Web UI](https://github.com/ollama-webui/ollama-webui)
+- [Open WebUI](https://github.com/open-webui/open-webui)
 - [Ollamac](https://github.com/kevinhermawan/Ollamac)
 - [big-AGI](https://github.com/enricoros/big-agi/blob/main/docs/config-ollama.md)
 - [Cheshire Cat assistant framework](https://github.com/cheshire-cat-ai/core)


### PR DESCRIPTION
Ollama WebUI is now known as Open WebUI:

https://openwebui.com

https://github.com/open-webui/open-webui