### PR TITLE
Support for `bert` and `nomic-bert` embedding models

### DIFF
--- a/server/images.go
+++ b/server/images.go
@@ -52,6 +52,10 @@ type Model struct {
 	Messages       []Message
 }
 
+func (m *Model) IsEmbedding() bool {
+	return slices.Contains(m.Config.ModelFamilies, "bert") || slices.Contains(m.Config.ModelFamilies, "nomic-bert")
+}
+
 type Message struct {
 	Role    string `json:"role"`
 	Content string `json:"content"`

--- a/server/routes.go
+++ b/server/routes.go
@@ -191,6 +191,11 @@ func GenerateHandler(c *gin.Context) {
 		return
 	}
 
+	if model.IsEmbedding() {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "model does not support generate"})
+		return
+	}
+
 	opts, err := modelOptions(model, req.Options)
 	if err != nil {
 		if errors.Is(err, api.ErrInvalidOpts) {
@@ -1140,6 +1145,11 @@ func ChatHandler(c *gin.Context) {
 			return
 		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	if model.IsEmbedding() {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "model does not support chat"})
 		return
 	}
 


### PR DESCRIPTION
Fixes #327 

This adds initial support for embedding models using the `/api/embeddings` endpoint.