### PR TITLE
Configure `OLLAMA_ORIGINS` via settings.json

### DIFF
--- a/macapp/src/index.ts
+++ b/macapp/src/index.ts
@@ -14,6 +14,7 @@ import Store from 'electron-store'
 import winston from 'winston'
 import 'winston-daily-rotate-file'
 import * as path from 'path'
+import * as os from 'os'
 
 import { v4 as uuidv4 } from 'uuid'
 import { installed } from './install'
@@ -126,12 +127,25 @@ function updateTray() {
     ...(updateAvailable ? updateItems : []),
     {
       label: 'Settings',
+      // See: https://github.com/ollama/ollama/blob/main/docs/faq.md#where-are-models-stored
       click: () => {
-        // TODO: check if the settings file exists, if not, create it
-        // TODO: move this to a new browser window with a settings page
-        // ~/.ollama/settings.json
-        const settingsFilePath = path.join(app.getPath('home'), '.ollama', 'settings.json')
-        shell.openPath(settingsFilePath)
+        let settingsPath;
+        switch (os.platform()) {
+          case 'darwin': // macOS
+            settingsPath = path.join(os.homedir(), '.ollama', 'models', 'settings.json');
+            break;
+          case 'win32': // Windows
+            settingsPath = path.join(os.homedir(), '.ollama', 'models', 'settings.json');
+            break;
+          case 'linux': // Linux
+            settingsPath = path.join('/usr', 'share', 'ollama', '.ollama', 'models', 'settings.json');
+            break;
+          default:
+            // Default to home directory if OS is not recognized
+            settingsPath = path.join(os.homedir(), '.ollama', 'models', 'settings.json');
+            break;
+        }
+        shell.openPath(settingsPath);
       },
       accelerator: 'Command+,',
     },

--- a/macapp/src/index.ts
+++ b/macapp/src/index.ts
@@ -129,6 +129,7 @@ function updateTray() {
       click: () => {
         // TODO: check if the settings file exists, if not, create it
         // TODO: move this to a new browser window with a settings page
+        // ~/.ollama/settings.json
         const settingsFilePath = path.join(app.getPath('home'), '.ollama', 'settings.json')
         shell.openPath(settingsFilePath)
       },

--- a/macapp/src/index.ts
+++ b/macapp/src/index.ts
@@ -129,23 +129,23 @@ function updateTray() {
       label: 'Settings',
       // See: https://github.com/ollama/ollama/blob/main/docs/faq.md#where-are-models-stored
       click: () => {
-        let settingsPath;
+        let settingsPath
         switch (os.platform()) {
           case 'darwin': // macOS
-            settingsPath = path.join(os.homedir(), '.ollama', 'models', 'settings.json');
-            break;
+            settingsPath = path.join(os.homedir(), '.ollama', 'settings.json')
+            break
           case 'win32': // Windows
-            settingsPath = path.join(os.homedir(), '.ollama', 'models', 'settings.json');
-            break;
+            settingsPath = path.join(os.homedir(), '.ollama', 'settings.json')
+            break
           case 'linux': // Linux
-            settingsPath = path.join('/usr', 'share', 'ollama', '.ollama', 'models', 'settings.json');
-            break;
+            settingsPath = path.join('/usr', 'share', 'ollama', '.ollama', 'settings.json')
+            break
           default:
             // Default to home directory if OS is not recognized
-            settingsPath = path.join(os.homedir(), '.ollama', 'models', 'settings.json');
-            break;
+            settingsPath = path.join(os.homedir(), '.ollama', 'settings.json')
+            break
         }
-        shell.openPath(settingsPath);
+        shell.openPath(settingsPath)
       },
       accelerator: 'Command+,',
     },

--- a/server/routes.go
+++ b/server/routes.go
@@ -898,12 +898,6 @@ func CreateBlobHandler(c *gin.Context) {
 	c.Status(http.StatusCreated)
 }
 
-var defaultAllowOrigins = []string{
-	"localhost",
-	"127.0.0.1",
-	"0.0.0.0",
-}
-
 func NewServer() (*Server, error) {
 	workDir, err := os.MkdirTemp("", "ollama")
 	if err != nil {
@@ -1016,9 +1010,6 @@ func (s *Server) GenerateRoutes() http.Handler {
 	config := cors.DefaultConfig()
 	config.AllowWildcard = true
 	config.AllowBrowserExtensions = true
-
-	// Append default and specified origins
-	// config.AllowOrigins = append(origins, generateDefaultOrigins(defaultAllowOrigins)...)
 	config.AllowOrigins = origins
 
 	r := gin.Default()
@@ -1031,19 +1022,6 @@ func (s *Server) GenerateRoutes() http.Handler {
 	defineAPIEndpoints(r)
 
 	return r
-}
-
-func generateDefaultOrigins(origins []string) []string {
-	var formattedOrigins []string
-	for _, origin := range origins {
-		formattedOrigins = append(formattedOrigins,
-			fmt.Sprintf("http://%s", origin),
-			fmt.Sprintf("https://%s", origin),
-			fmt.Sprintf("http://%s:*", origin),
-			fmt.Sprintf("https://%s:*", origin),
-		)
-	}
-	return formattedOrigins
 }
 
 func defineAPIEndpoints(r *gin.Engine) {

--- a/server/routes.go
+++ b/server/routes.go
@@ -922,11 +922,11 @@ func getSettingsPath() string {
 	}
 	switch runtime.GOOS {
 	case "darwin", "windows":
-		settingsPath = filepath.Join(homeDir, ".ollama", "models", "settings.json")
+		settingsPath = filepath.Join(homeDir, ".ollama", "settings.json")
 	case "linux":
-		settingsPath = "/usr/share/ollama/.ollama/models/settings.json"
+		settingsPath = "/usr/share/ollama/.ollama/settings.json"
 	default:
-		settingsPath = filepath.Join(homeDir, ".ollama", "models", "settings.json")
+		settingsPath = filepath.Join(homeDir, ".ollama", "settings.json")
 	}
 	return settingsPath
 }
@@ -1019,7 +1019,6 @@ func (s *Server) GenerateRoutes() http.Handler {
 		c.Next()
 	})
 
-	// Define API endpoints
 	defineAPIEndpoints(r)
 
 	return r

--- a/server/routes.go
+++ b/server/routes.go
@@ -913,6 +913,7 @@ type Settings struct {
 	Origins []string `json:"OLLAMA_ORIGINS"`
 }
 
+// See: https://github.com/ollama/ollama/blob/main/docs/faq.md#where-are-models-stored
 func getSettingsPath() string {
 	var settingsPath string
 	homeDir, err := os.UserHomeDir()


### PR DESCRIPTION
Took a stab at these issues https://github.com/ollama/ollama/issues/2335, https://github.com/ollama/ollama/issues/2369

Added settings menu item in the Electron tray application. Also, hoisted the `OLLAMA_ORIGINS` environment variable to the settings.json file, ensuring routes.go retrieves origins from the file rather than the environment variable.

Open for suggestions.

![CleanShot 2024-02-21 at 18 09 37@2x](https://github.com/ollama/ollama/assets/1021101/61a2ba18-2b52-4d53-9eed-38c2c3d87f89)

![CleanShot 2024-02-21 at 18 10 05@2x](https://github.com/ollama/ollama/assets/1021101/df9bb6a2-7246-40af-9b98-f5e066d427c9)
