### PR TITLE
Update routes.go

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -925,6 +925,7 @@ func (s *Server) GenerateRoutes() http.Handler {
 	config.AllowWildcard = true
 	config.AllowBrowserExtensions = true
 
+	config.AddAllowHeaders("X-Requested-With")
 	config.AllowOrigins = origins
 	for _, allowOrigin := range defaultAllowOrigins {
 		config.AllowOrigins = append(config.AllowOrigins,


### PR DESCRIPTION
CORS policy: Request header field x-requested-with is not allowed by Access-Control-Allow-Headers in preflight response.

add X-Requested-With in Access-Control-Allow-Headers