### PR TITLE
Require no extra disk space for windows installation

### DIFF
--- a/app/ollama.iss
+++ b/app/ollama.iss
@@ -49,9 +49,6 @@ SetupLogging=yes
 CloseApplications=yes
 RestartApplications=no
 
-; Make sure they can at least download llama2 as a minimum
-ExtraDiskSpaceRequired=3826806784
-
 ; https://jrsoftware.org/ishelp/index.php?topic=setup_wizardimagefile
 WizardSmallImageFile=.\assets\setup.bmp
 


### PR DESCRIPTION
Fixes https://github.com/ollama/ollama/issues/2734

Since quite a few folks won't install a model on `C:\`, and will instead use `OLLAMA_MODELS` to change where models are stored, lower the check for minimum disk space.