### PR TITLE
Introduce GBNF grammar parameter: run flags, REPL and API

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -63,6 +63,10 @@ type GenerateRequest struct {
 	// Format specifies the format to return a response in.
 	Format string `json:"format"`
 
+	// Grammar specifies the grammar to use for the response.
+	// Mutually exclusive with Format.
+	Grammar string `json:"grammar"`
+
 	// KeepAlive controls how long the model will stay loaded in memory following
 	// this request.
 	KeepAlive *Duration `json:"keep_alive,omitempty"`
@@ -81,6 +85,7 @@ type ChatRequest struct {
 	Messages  []Message `json:"messages"`
 	Stream    *bool     `json:"stream,omitempty"`
 	Format    string    `json:"format"`
+	Grammar   string    `json:"grammar"`
 	KeepAlive *Duration `json:"keep_alive,omitempty"`
 
 	Options map[string]interface{} `json:"options"`

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -109,17 +109,20 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 
 	usageSet := func() {
 		fmt.Fprintln(os.Stderr, "Available Commands:")
-		fmt.Fprintln(os.Stderr, "  /set parameter ...     Set a parameter")
-		fmt.Fprintln(os.Stderr, "  /set system <string>   Set system message")
-		fmt.Fprintln(os.Stderr, "  /set template <string> Set prompt template")
-		fmt.Fprintln(os.Stderr, "  /set history           Enable history")
-		fmt.Fprintln(os.Stderr, "  /set nohistory         Disable history")
-		fmt.Fprintln(os.Stderr, "  /set wordwrap          Enable wordwrap")
-		fmt.Fprintln(os.Stderr, "  /set nowordwrap        Disable wordwrap")
-		fmt.Fprintln(os.Stderr, "  /set format json       Enable JSON mode")
-		fmt.Fprintln(os.Stderr, "  /set noformat          Disable formatting")
-		fmt.Fprintln(os.Stderr, "  /set verbose           Show LLM stats")
-		fmt.Fprintln(os.Stderr, "  /set quiet             Disable LLM stats")
+		fmt.Fprintln(os.Stderr, "  /set parameter ...       Set a parameter")
+		fmt.Fprintln(os.Stderr, "  /set system <string>     Set system message")
+		fmt.Fprintln(os.Stderr, "  /set template <string>   Set prompt template")
+		fmt.Fprintln(os.Stderr, "  /set history             Enable history")
+		fmt.Fprintln(os.Stderr, "  /set nohistory           Disable history")
+		fmt.Fprintln(os.Stderr, "  /set wordwrap            Enable wordwrap")
+		fmt.Fprintln(os.Stderr, "  /set nowordwrap          Disable wordwrap")
+		fmt.Fprintln(os.Stderr, "  /set format json         Constraint output to JSON")
+		fmt.Fprintln(os.Stderr, "  /set grammar <gbnf>      Constraint output grammar as GBNF string")
+		fmt.Fprintln(os.Stderr, "  /set grammar-file <path> Constraint output grammar as GBNF file")
+		fmt.Fprintln(os.Stderr, "  /set noformat            Disable output format constraint")
+		fmt.Fprintln(os.Stderr, "  /set nogrammar           Disable output format constraint")
+		fmt.Fprintln(os.Stderr, "  /set verbose             Show LLM stats")
+		fmt.Fprintln(os.Stderr, "  /set quiet               Disable LLM stats")
 		fmt.Fprintln(os.Stderr, "")
 	}
 
@@ -309,11 +312,35 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 						fmt.Println("Invalid or missing format. For 'json' mode use '/set format json'")
 					} else {
 						opts.Format = args[2]
+						opts.Grammar = ""
 						fmt.Printf("Set format to '%s' mode.\n", args[2])
 					}
 				case "noformat":
+				case "nogrammar":
 					opts.Format = ""
+					opts.Grammar = ""
 					fmt.Println("Disabled format.")
+				case "grammar":
+					if len(args) < 3 {
+						usageParameters()
+						continue
+					}
+					opts.Format = ""
+					opts.Grammar = strings.Join(args[2:], " ")
+					fmt.Printf("Set grammar.\n")
+				case "grammar-file":
+					if len(args) != 3 {
+						usageParameters()
+						continue
+					}
+					data, err := os.ReadFile(args[2])
+					if err != nil {
+						fmt.Printf("Error reading grammar file: %s\n", err)
+						continue
+					}
+					opts.Format = ""
+					opts.Grammar = string(data)
+					fmt.Printf("Set grammar from %s.\n", args[2])
 				case "parameter":
 					if len(args) < 4 {
 						usageParameters()

--- a/llm/server.go
+++ b/llm/server.go
@@ -492,6 +492,7 @@ type completion struct {
 type CompletionRequest struct {
 	Prompt  string
 	Format  string
+	Grammar string
 	Images  []ImageData
 	Options api.Options
 }
@@ -527,6 +528,7 @@ func (s *LlamaServer) Completion(ctx context.Context, req CompletionRequest, fn 
 		"penalize_nl":       req.Options.PenalizeNewline,
 		"seed":              req.Options.Seed,
 		"stop":              req.Options.Stop,
+		"grammar":           req.Grammar,
 		"image_data":        req.Images,
 		"cache_prompt":      true,
 	}
@@ -539,8 +541,7 @@ func (s *LlamaServer) Completion(ctx context.Context, req CompletionRequest, fn 
 		return fmt.Errorf("unexpected server status: %d", status)
 	}
 
-	if req.Format == "json" {
-		request["grammar"] = jsonGrammar
+	if request["grammar"] == jsonGrammar {
 		if !strings.Contains(strings.ToLower(req.Prompt), "json") {
 			slog.Warn("Prompt does not specify that the LLM should response in JSON, but JSON format is expected. For best results specify that JSON is expected in the system prompt.")
 		}

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -48,22 +48,18 @@ type Usage struct {
 	TotalTokens      int `json:"total_tokens"`
 }
 
-type ResponseFormat struct {
-	Type string `json:"type"`
-}
-
 type ChatCompletionRequest struct {
-	Model            string          `json:"model"`
-	Messages         []Message       `json:"messages"`
-	Stream           bool            `json:"stream"`
-	MaxTokens        *int            `json:"max_tokens"`
-	Seed             *int            `json:"seed"`
-	Stop             any             `json:"stop"`
-	Temperature      *float64        `json:"temperature"`
-	FrequencyPenalty *float64        `json:"frequency_penalty"`
-	PresencePenalty  *float64        `json:"presence_penalty_penalty"`
-	TopP             *float64        `json:"top_p"`
-	ResponseFormat   *ResponseFormat `json:"response_format"`
+	Model            string    `json:"model"`
+	Messages         []Message `json:"messages"`
+	Stream           bool      `json:"stream"`
+	MaxTokens        *int      `json:"max_tokens"`
+	Seed             *int      `json:"seed"`
+	Stop             any       `json:"stop"`
+	Temperature      *float64  `json:"temperature"`
+	FrequencyPenalty *float64  `json:"frequency_penalty"`
+	PresencePenalty  *float64  `json:"presence_penalty_penalty"`
+	TopP             *float64  `json:"top_p"`
+	Grammar          string    `json:"grammar"`
 }
 
 type ChatCompletion struct {
@@ -201,15 +197,10 @@ func fromRequest(r ChatCompletionRequest) api.ChatRequest {
 		options["top_p"] = 1.0
 	}
 
-	var format string
-	if r.ResponseFormat != nil && r.ResponseFormat.Type == "json_object" {
-		format = "json"
-	}
-
 	return api.ChatRequest{
 		Model:    r.Model,
 		Messages: messages,
-		Format:   format,
+		Grammar:  r.Grammar,
 		Options:  options,
 		Stream:   &r.Stream,
 	}

--- a/server/routes.go
+++ b/server/routes.go
@@ -150,6 +150,14 @@ func isSupportedImageType(image []byte) bool {
 	return slices.Contains(allowedTypes, contentType)
 }
 
+func getGrammar(format, grammar string) string {
+	switch format {
+	case "json":
+		return jsonGrammar
+	}
+	return grammar
+}
+
 func GenerateHandler(c *gin.Context) {
 	loaded.mu.Lock()
 	defer loaded.mu.Unlock()
@@ -172,11 +180,14 @@ func GenerateHandler(c *gin.Context) {
 	case req.Model == "":
 		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "model is required"})
 		return
+	case req.Raw && (req.Template != "" || req.System != "" || len(req.Context) > 0):
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "raw mode does not support template, system, or context"})
+		return
 	case len(req.Format) > 0 && req.Format != "json":
 		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "format must be json"})
 		return
-	case req.Raw && (req.Template != "" || req.System != "" || len(req.Context) > 0):
-		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "raw mode does not support template, system, or context"})
+	case req.Format != "" && req.Grammar != "":
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "only one of 'format' or 'grammar' is allowed at a time"})
 		return
 	}
 
@@ -351,7 +362,7 @@ func GenerateHandler(c *gin.Context) {
 		// Start prediction
 		req := llm.CompletionRequest{
 			Prompt:  prompt,
-			Format:  req.Format,
+			Grammar: getGrammar(req.Format, req.Grammar),
 			Images:  images,
 			Options: opts,
 		}
@@ -1255,6 +1266,9 @@ func ChatHandler(c *gin.Context) {
 	case len(req.Format) > 0 && req.Format != "json":
 		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "format must be json"})
 		return
+	case req.Format != "" && req.Grammar != "":
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "only one of 'format' or 'grammar' is allowed at a time"})
+		return
 	}
 
 	model, err := GetModel(req.Model)
@@ -1376,7 +1390,7 @@ func ChatHandler(c *gin.Context) {
 
 		if err := loaded.llama.Completion(c.Request.Context(), llm.CompletionRequest{
 			Prompt:  prompt,
-			Format:  req.Format,
+			Grammar: getGrammar(req.Format, req.Grammar),
 			Images:  images,
 			Options: opts,
 		}, fn); err != nil {
@@ -1414,3 +1428,31 @@ func ChatHandler(c *gin.Context) {
 
 	streamResponse(c, ch)
 }
+
+const jsonGrammar = `
+root   ::= object
+value  ::= object | array | string | number | ("true" | "false" | "null") ws
+
+object ::=
+  "{" ws (
+            string ":" ws value
+    ("," ws string ":" ws value)*
+  )? "}" ws
+
+array  ::=
+  "[" ws (
+            value
+    ("," ws value)*
+  )? "]" ws
+
+string ::=
+  "\"" (
+    [^"\\] |
+    "\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]) # escapes
+  )* "\"" ws
+
+number ::= ("-"? ([0-9] | [1-9] [0-9]*)) ("." [0-9]+)? ([eE] [-+]? [0-9]+)? ws
+
+# Optional space: by convention, applied in this grammar after literal chars when allowed
+ws ::= ([ \t\n] ws)?
+`


### PR DESCRIPTION
This patch adds full support for the llama.cpp "grammar" option, which defaults to "" i.e. no grammar constraint.

For backwards compatability, the existing `format` parameter remains available in flags, the REPL and the API. Only one of `grammar` or `format` at a time is legal, since `format: json` is just a shortcut for the hard-coded JSON grammar.

Tested locally:

```console
$ ./ollama run mistral-openorca --grammar-file json-two-string-array.bnf \
  'Write the result of "3+5" followed by the english spelling of the number, as two JSON strings'
["8", "Eight"]

$ ./ollama run mistral-openorca --grammar ' root ::= "[" [0-9]+ ", \"" [a-z]+ "\"]" ' \
  'Write the result of "3+5" followed by the english spelling of the number, as a json number and a json string'
[8, "eight"]
```

This more or less conflicts with #2404 which instead decided to go with an `Options`, which AFAICT is more geared towards creating derived models with an embedded grammar, whereas this patch is more about runtime override. It would be nice to eventually converge on something that does both, but today the concept of "format", which is very limiting (list of well-known formats and only JSON today), is not an `Options` but a top-level parameter and I wasn't sure how to make this play nice with #2404 without too many changes.