### PR TITLE
Refine container image build script

### DIFF
--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -5,13 +5,15 @@ set -eu
 export VERSION=${VERSION:-$(git describe --tags --first-parent --abbrev=7 --long --dirty --always | sed -e "s/^v//g")}
 export GOFLAGS="'-ldflags=-w -s \"-X=github.com/jmorganca/ollama/version.Version=$VERSION\" \"-X=github.com/jmorganca/ollama/server.mode=release\"'"
 
+IMAGE_NAME=${IMAGE_NAME:-"ollama/ollama"}
+BUILD_PLATFORM=${BUILD_PLATFORM:-"linux/arm64,linux/amd64"}
 docker build \
     --load \
-    --platform=linux/arm64,linux/amd64 \
+    --platform=${BUILD_PLATFORM} \
     --build-arg=VERSION \
     --build-arg=GOFLAGS \
     -f Dockerfile \
-    -t ollama/ollama:$VERSION \
+    -t ${IMAGE_NAME}:$VERSION \
     .
 
 docker build \
@@ -21,5 +23,12 @@ docker build \
     --build-arg=GOFLAGS \
     --target runtime-rocm \
     -f Dockerfile \
-    -t ollama/ollama:$VERSION-rocm \
+    -t ${IMAGE_NAME}:$VERSION-rocm \
     .
+
+docker tag ${IMAGE_NAME}:$VERSION ${IMAGE_NAME}:latest
+docker tag ${IMAGE_NAME}:$VERSION-rocm ${IMAGE_NAME}:rocm
+
+echo "To release, run:"
+echo "  docker push ${IMAGE_NAME}:$VERSION && docker push ${IMAGE_NAME}:latest"
+echo "  docker push ${IMAGE_NAME}:$VERSION-rocm && docker push ${IMAGE_NAME}:rocm"


### PR DESCRIPTION
Allow overriding the platform, image name, and tag latest for standard and rocm images.

Fixes #2721 