### PR TITLE
Add Community Integration: NextChat

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [NextJS Web Interface for Ollama](https://github.com/jakobhoeg/nextjs-ollama-llm-ui)
 - [Msty](https://msty.app)
 - [Chatbox](https://github.com/Bin-Huang/Chatbox)
+- [NextChat](https://github.com/ChatGPTNextWeb/ChatGPT-Next-Web) with [Get Started Doc](https://docs.nextchat.dev/models/ollama)
 
 ### Terminal
 


### PR DESCRIPTION
NextChat just drop support for Ollama, Adding NextChat reference in README.md

Doc: https://docs.nextchat.dev/models/ollama
Release: https://github.com/ChatGPTNextWeb/ChatGPT-Next-Web/releases/tag/v2.11.2