### PR TITLE
Support repositories with more than three slash-delimited parts

### DIFF
--- a/server/modelpath.go
+++ b/server/modelpath.go
@@ -47,7 +47,7 @@ func ParseModelPath(name string) ModelPath {
 	}
 
 	name = strings.ReplaceAll(name, string(os.PathSeparator), "/")
-	parts := strings.Split(name, "/")
+	parts := strings.SplitN(name, "/", 3)
 	switch len(parts) {
 	case 3:
 		mp.Registry = parts[0]

--- a/server/modelpath_test.go
+++ b/server/modelpath_test.go
@@ -74,6 +74,17 @@ func TestParseModelPath(t *testing.T) {
 				Tag:            DefaultTag,
 			},
 		},
+		{
+			"path with more than three parts",
+			"https://example.com/ns/another-part/repo:tag",
+			ModelPath{
+				ProtocolScheme: "https",
+				Registry:       "example.com",
+				Namespace:      "ns",
+				Repository:     "another-part/repo",
+				Tag:            "tag",
+			},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Some registries use URL schemes that have more than three slash-delimited parts. For example Google Artifact Registry has a format like `us-central1-docker.pkg.dev/PROJECT/NAMESPACE/REPOSITORY`. From Docker's and Ollama's point of view, `NAMESPACE/REPOSITORY` should all be treated as repository.