### PR TITLE
Omit build date from gzip headers

### DIFF
--- a/llm/generate/gen_common.sh
+++ b/llm/generate/gen_common.sh
@@ -101,7 +101,7 @@ compress_libs() {
     pids=""
     rm -rf ${BUILD_DIR}/lib/*.${LIB_EXT}*.gz
     for lib in ${BUILD_DIR}/lib/*.${LIB_EXT}* ; do
-        gzip --best -f ${lib} &
+        gzip -n --best -f ${lib} &
         pids+=" $!"
     done
     echo 


### PR DESCRIPTION
See https://reproducible-builds.org/ for why this is good.

This patch was done while working on reproducible builds for openSUSE.