### PR TITLE
Update linux.md:  the file to be downloaded for ARM CPU should be  ol…

### DIFF
--- a/docs/linux.md
+++ b/docs/linux.md
@@ -14,10 +14,18 @@ curl -fsSL https://ollama.com/install.sh | sh
 
 ### Download the `ollama` binary
 
-Ollama is distributed as a self-contained binary. Download it to a directory in your PATH:
+Ollama is distributed as a self-contained binary. Download it to a directory in your PATH according to your CPU architecture:
 
+For Intel x86 architecture:
 ```bash
 sudo curl -L https://ollama.com/download/ollama-linux-amd64 -o /usr/bin/ollama
+```
+For ARM architecure
+```bash
+sudo curl -L https://ollama.com/download/ollama-linux-arm64 -o /usr/bin/ollama
+```
+
+```bash
 sudo chmod +x /usr/bin/ollama
 ```
 


### PR DESCRIPTION
…lama-linux-arm64 instead of ollama-linux-amd64

For manual installation, there was only one download command for both Intel x86 and ARM CPU architecture.  The executable ollama-linux-amd64 wouldn't work on ARM CPU.

Testing environment
$ uname -m
aarch64

$ ollama -v
ollama version is 0.1.27