### PR TITLE
chore: update readme, add open-webui

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Msty](https://msty.app)
 - [Chatbox](https://github.com/Bin-Huang/Chatbox)
 - [NextChat](https://github.com/ChatGPTNextWeb/ChatGPT-Next-Web) with [Get Started Doc](https://docs.nextchat.dev/models/ollama)
+- [Open WebUI](https://github.com/open-webui/open-webui)
 
 ### Terminal
 


### PR DESCRIPTION
After testing most of these suggested frontends, "Open WebUI", formerly "ollama-webui", looks like the best open option for amateurs looking to self-host a frontend similar to OpenAI's ChatGPT interface.