### PR TITLE
Run inference in a subprocess

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -77,8 +77,18 @@ func load(c *gin.Context, model *Model, opts *api.Options, sessionDuration time.
 		loaded.model != model.ModelPath || // has the base model changed?
 		!reflect.DeepEqual(loaded.adapters, model.AdapterPaths) || // have the adapters changed?
 		!reflect.DeepEqual(loaded.projectors, model.ProjectorPaths) || // have the adapters changed?
-		!reflect.DeepEqual(loaded.Options.Runner, opts.Runner) || // have the runner options changed?
 		loaded.llama.Ping(ctx) != nil
+
+	// have the runner options changed?
+	if loaded.llama != nil {
+		optsExisting := loaded.Options.Runner
+		if opts.Runner.NumGPU == -1 {
+			optsExisting.NumGPU = -1
+		}
+		if !reflect.DeepEqual(optsExisting, opts.Runner) {
+			needLoad = true
+		}
+	}
 
 	if needLoad {
 		if loaded.llama != nil {


### PR DESCRIPTION
This changes the underlying llama server to run in a subprocess, bringing back code from https://github.com/ollama/ollama/blob/v0.1.17/llm/llama.go while keeping the multi-variant support. This is helpful to make sure resources are freed when a model is unloaded and will help allow concurrent models to be loaded.

Note this should probably go in after https://github.com/ollama/ollama/pull/2885 

Remaining
- [ ] Handle crash/exit scenario (api will hang)
- [ ] Surface stderr message as an api error
- [ ] CI