### PR TITLE
Add SemanticFinder to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,3 +354,4 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [twinny](https://github.com/rjmacarthy/twinny) (Copilot and Copilot chat alternative using Ollama)
 - [Wingman-AI](https://github.com/RussellCanfield/wingman-ai) (Copilot code and chat alternative using Ollama and HuggingFace)
 - [Page Assist](https://github.com/n4ze3m/page-assist) (Chrome Extension)
+- [SemanticFinder](https://github.com/do-me/SemanticFinder)


### PR DESCRIPTION
[SemanticFinder](https://github.com/do-me/SemanticFinder) is an in-browser tool for semantic search and now offers an Ollama integration to help understand the search results.

Announcement on Ollama [r/ollama/](https://www.reddit.com/r/ollama/comments/1b79c23/inbrowser_rag_feeding_ollama/)