### PR TITLE
Add Community Integration: LibreChat

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 
 ### Web & Desktop
 
+- [LibreChat](https://github.com/danny-avila/LibreChat)
 - [Bionic GPT](https://github.com/bionic-gpt/bionic-gpt)
 - [Enchanted (macOS native)](https://github.com/AugustDev/enchanted)
 - [HTML UI](https://github.com/rtcfirefly/ollama-ui)


### PR DESCRIPTION
**LibreChat** is the leading ChatGPT-style Web UI that supports virtually every OpenAI-API-compatible endpoint, which now includes Ollama.

**Relevant docs:** https://docs.librechat.ai/install/configuration/ollama.html

**Screenshot**

![309832679-fcfe48cf-bbd6-4010-915f-66b4b238728d](https://github.com/ollama/ollama/assets/110412045/3756434e-1201-444e-b4b7-d4592b5c26cb)
