### PR TITLE
Update main.py print summary only

### DIFF
--- a/examples/langchain-python-rag-websummary/main.py
+++ b/examples/langchain-python-rag-websummary/main.py
@@ -1,5 +1,5 @@
-from langchain.llms import Ollama
-from langchain.document_loaders import WebBaseLoader
+from langchain_community.llms import Ollama
+from langchain_community.document_loaders import WebBaseLoader
 from langchain.chains.summarize import load_summarize_chain
 
 loader = WebBaseLoader("https://ollama.com/blog/run-llama2-uncensored-locally")
@@ -8,5 +8,5 @@ docs = loader.load()
 llm = Ollama(model="llama2")
 chain = load_summarize_chain(llm, chain_type="stuff")
 
-result = chain.run(docs)
-print(result)
+result = chain.invoke(docs)
+print(result['output_text'])


### PR DESCRIPTION
The original program printed both the input document and its summary. The input document is very long and its summary hides at the end. It really costed me some time to extract the summary by my eyes.

>>> type(result)
<class 'dict'>
>>> result.keys()
dict_keys(['input_documents', 'output_text'])

BTW, the deprecated functions are also adjusted.
