### PR TITLE
Update gpu.go with additional RocmLinuxGlob

### DIFF
--- a/gpu/gpu.go
+++ b/gpu/gpu.go
@@ -56,6 +56,7 @@ var CudaWindowsGlobs = []string{
 
 var RocmLinuxGlobs = []string{
 	"/opt/rocm*/lib*/librocm_smi64.so*",
+	"/usr*/lib*/librocm_smi64.so*",
 }
 
 var RocmWindowsGlobs = []string{


### PR DESCRIPTION
Add additional RocmLinuxGlob for e.g Fedora

This leads to a correctly discovered GPU library in the log.
However something else needs to be fixed as a cpu_avx2 server is loaded.