### PR TITLE
Add ROCm support to linux install script

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -101,13 +101,14 @@ future release which should increase support for more GPUs.
 Reach out on [Discord](https://discord.gg/ollama) or file an
 [issue](https://github.com/ollama/ollama/issues) for additional help.
 
-## Installing older versions on Linux
+## Installing older or pre-release versions on Linux
 
-If you run into problems on Linux and want to install an older version you can tell the install script
-which version to install.
+If you run into problems on Linux and want to install an older version, or you'd
+like to try out a pre-release before it's officially released, you can tell the
+install script which version to install.
 
 ```sh
-curl -fsSL https://ollama.com/install.sh | OLLAMA_VERSION="0.1.27" sh
+curl -fsSL https://ollama.com/install.sh | OLLAMA_VERSION="0.1.29" sh
 ```
 
 ## Known issues


### PR DESCRIPTION
Merge after #2885 and the release is out to avoid users with rocm failing to install due to the dependency file not being available yet.

This depends on corresponding path changes in PR #3008 


Prior to merging this, folks who want to install the pre-release on Radeon systems can use the following:

```
curl -fsSL https://raw.githubusercontent.com/dhiltgen/ollama/rocm_install/scripts/install.sh  | OLLAMA_VERSION="0.1.29" sh
```