### PR TITLE
Get term size from stderr and /dev/tty to avoid redirection caused getting size error.

### DIFF
--- a/readline/buffer.go
+++ b/readline/buffer.go
@@ -37,9 +37,9 @@ func getTermSize() (width, height int, err error) {
 }
 
 func NewBuffer(prompt *Prompt) (*Buffer, error) {
-	width, height, err := getTermSize()
-	if err != nil {
-		return nil, err
+	width, height := 80, 24
+	if termWidth, termHeight, err := getTermSize(); err == nil {
+		width, height = termWidth, termHeight
 	}
 
 	lwidth := width - len(prompt.prompt())

--- a/readline/readline.go
+++ b/readline/readline.go
@@ -86,7 +86,10 @@ func (i *Instance) Readline() (string, error) {
 		i.Terminal.rawmode = false
 	}()
 
-	buf, _ := NewBuffer(i.Prompt)
+	buf, err := NewBuffer(i.Prompt)
+	if err != nil {
+		return "", err
+	}
 
 	var esc bool
 	var escex bool


### PR DESCRIPTION
As issue #2970 said, `ollama run phi | tee llms/out.txt` leads to error. When using a pipe operator following the `ollama` command the`os.Stdout` points to a pipe instead of the terminal, so `term.Getsize` failed. 

Now the code gets terminal size from stderr first, which enables `ollama run phi | tee llms/out.txt` to execute normally. 
If the user enter `ollama run phi 2>&1 | tee llms/out.txt`, the code then tries to get `/dev/tty` instead. 