### PR TITLE
Fix paste of text with line feed characters

### DIFF
--- a/readline/readline.go
+++ b/readline/readline.go
@@ -218,7 +218,7 @@ func (i *Instance) Readline() (string, error) {
 		case CharCtrlZ:
 			fd := int(syscall.Stdin)
 			return handleCharCtrlZ(fd, i.Terminal.termios)
-		case CharEnter:
+		case CharEnter, CharCtrlJ:
 			output := buf.String()
 			if output != "" {
 				i.History.Add([]rune(output))
@@ -232,7 +232,7 @@ func (i *Instance) Readline() (string, error) {
 				metaDel = false
 				continue
 			}
-			if r >= CharSpace || r == CharEnter {
+			if r >= CharSpace || r == CharEnter || r == CharCtrlJ {
 				buf.Add(r)
 			}
 		}


### PR DESCRIPTION
Hey there, thanks for this awesome tool 🙌 

This is a small patch to fix copy-paste with some terminals that send line feed characters when pasting text with newlines.

To test these changes, run ollama in interactive mode on [Kitty](https://github.com/kovidgoyal/kitty) and paste:
```txt
text
on multiple
lines
```

Curiously this issue doesn't occur on MacOS's default terminal, because it sends CR characters for the newlines. I'm not sure which terminal behavior is the correct one, anyway I figured it would make sense for ollama to support CR and LF characters in the same way.