### PR TITLE
Use stdin for term discovery on windows

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -900,8 +900,7 @@ func NewCLI() *cobra.Command {
 	cobra.EnableCommandSorting = false
 
 	if runtime.GOOS == "windows" {
-		// Enable colorful ANSI escape code in Windows terminal (disabled by default)
-		console.ConsoleFromFile(os.Stdout) //nolint:errcheck
+		console.ConsoleFromFile(os.Stdin) //nolint:errcheck
 	}
 
 	rootCmd := &cobra.Command{


### PR DESCRIPTION
When you feed input to the cmd via a pipe it no longer reports a warning


Before:
```
> echo "what is the captial of australia" | .\ollama.exe run phi
failed to get console mode for stdin: The handle is invalid.
 The capital of Australia is Canberra. It's located in the Australian Capital Territory, about 120 kilometers
northwest of Sydney and 130 kilometers southwest of Melbourne.
```

After fix:
```
> echo "what is the captial of australia" | .\ollama.exe run phi
 The capital city of Australia is Canberra. It is located in the Australian Capital Territory (ACT) and is home to important government buildings, such as Parliament House and the National Museum of Australia
```


Fixes #2698 