### PR TITLE
fix gpu_info_cuda.c compile warning

### DIFF
--- a/gpu/gpu_info_cuda.c
+++ b/gpu/gpu_info_cuda.c
@@ -155,8 +155,8 @@ void cuda_check_vram(cuda_handle_t h, mem_info_t *resp) {
       }
     }
 
-    LOG(h.verbose, "[%d] CUDA totalMem %ld\n", i, memInfo.total);
-    LOG(h.verbose, "[%d] CUDA usedMem %ld\n", i, memInfo.used);
+    LOG(h.verbose, "[%d] CUDA totalMem %llu\n", i, memInfo.total);
+    LOG(h.verbose, "[%d] CUDA usedMem %llu\n", i, memInfo.used);
 
     resp->total += memInfo.total;
     resp->free += memInfo.free;


### PR DESCRIPTION
fix compile warning 
`gpu_info_cuda.c: In function ‘cuda_check_vram’:
gpu_info_cuda.c:158:20: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 4 has type ‘long long unsigned int’`