### PR TITLE
Fix iGPU detection for linux

### DIFF
--- a/gpu/amd_common.go
+++ b/gpu/amd_common.go
@@ -40,19 +40,17 @@ func amdSetVisibleDevices(ids []int, skip map[int]interface{}) {
 	// TODO - does sort order matter?
 	devices := []string{}
 	for i := range ids {
-		slog.Debug(fmt.Sprintf("i=%d", i))
 		if _, skipped := skip[i]; skipped {
-			slog.Debug("skipped")
 			continue
 		}
 		devices = append(devices, strconv.Itoa(i))
 	}
-	slog.Debug(fmt.Sprintf("devices=%v", devices))
 
 	val := strings.Join(devices, ",")
 	err := os.Setenv("HIP_VISIBLE_DEVICES", val)
 	if err != nil {
 		slog.Warn(fmt.Sprintf("failed to set env: %s", err))
+	} else {
+		slog.Info("Setting HIP_VISIBLE_DEVICES=" + val)
 	}
-	slog.Debug("HIP_VISIBLE_DEVICES=" + val)
 }


### PR DESCRIPTION
This fixes a few bugs in the new sysfs discovery logic.  iGPUs are now correctly identified by their <1G VRAM reported.  the sysfs IDs are off by one compared to what HIP wants due to the CPU being reported in amdgpu, but HIP only cares about GPUs.


Tested on a Ryzen 9 7900X system with an RX 7900 XTX.  The amdgpu driver exposes 3 nodes, 0 is CPU, 1 is the discrete GPU, and 2 is the iGPU.  This logic now correctly detects this system and sets the visible devices properly.

Example scenario 1:
```
% OLLAMA_DEBUG=1 ./ollama-linux-amd64 serve
..
time=2024-03-13T00:03:55.440Z level=DEBUG source=amd_linux.go:110 msg="rocm supported GPU types [gfx1030 gfx1100 gfx1101 gfx1102 gfx900 gfx906 gfx908 gfx90a gfx940 gfx941 gfx942]"
time=2024-03-13T00:03:55.440Z level=INFO source=amd_linux.go:119 msg="amdgpu [0] gfx1100 is supported"
time=2024-03-13T00:03:55.440Z level=WARN source=amd_linux.go:114 msg="amdgpu [1] gfx1036 is not supported by /tmp/ollama2436258655/rocm [gfx1030 gfx1100 gfx1101 gfx1102 gfx900 gfx906 gfx908 gfx90a gfx940 gfx941 gfx942]"
time=2024-03-13T00:03:55.440Z level=WARN source=amd_linux.go:116 msg="See https://github.com/ollama/ollama/blob/main/docs/troubleshooting.md for HSA_OVERRIDE_GFX_VERSION usage"
time=2024-03-13T00:03:55.440Z level=DEBUG source=amd_linux.go:152 msg="discovering VRAM for amdgpu devices"
time=2024-03-13T00:03:55.440Z level=DEBUG source=amd_linux.go:171 msg="amdgpu devices [0 1]"
time=2024-03-13T00:03:55.441Z level=INFO source=amd_linux.go:246 msg="[0] amdgpu totalMemory 24560M"
time=2024-03-13T00:03:55.441Z level=INFO source=amd_linux.go:247 msg="[0] amdgpu freeMemory  24560M"
time=2024-03-13T00:03:55.441Z level=INFO source=amd_common.go:54 msg="Setting HIP_VISIBLE_DEVICES=0"
time=2024-03-13T00:03:55.441Z level=DEBUG source=gpu.go:180 msg="rocm detected 1 devices with 22104M available memory"
```

If I force the override to bypass the compatibility check, the new iGPU detection logic kicks in  (both of these scenarios work)
```
% OLLAMA_DEBUG=1 HSA_OVERRIDE_GFX_VERSION=11.0.0 ./ollama-linux-amd64 serve
...
time=2024-03-13T00:04:59.799Z level=DEBUG source=amd_linux.go:123 msg="skipping rocm gfx compatibility check with HSA_OVERRIDE_GFX_VERSION=11.0.0"
time=2024-03-13T00:04:59.799Z level=DEBUG source=amd_linux.go:152 msg="discovering VRAM for amdgpu devices"
time=2024-03-13T00:04:59.799Z level=DEBUG source=amd_linux.go:171 msg="amdgpu devices [0 1]"
time=2024-03-13T00:04:59.799Z level=INFO source=amd_linux.go:246 msg="[0] amdgpu totalMemory 24560M"
time=2024-03-13T00:04:59.799Z level=INFO source=amd_linux.go:247 msg="[0] amdgpu freeMemory  24560M"
time=2024-03-13T00:04:59.799Z level=INFO source=amd_linux.go:217 msg="amdgpu [1] appears to be an iGPU with 512M reported total memory, skipping"
time=2024-03-13T00:04:59.799Z level=INFO source=amd_common.go:54 msg="Setting HIP_VISIBLE_DEVICES=0"
time=2024-03-13T00:04:59.799Z level=DEBUG source=gpu.go:180 msg="rocm detected 1 devices with 22104M available memory"
```