### PR TITLE
Limit `num_predict` to `num_ctx`

### DIFF
--- a/llm/dyn_ext_server.go
+++ b/llm/dyn_ext_server.go
@@ -172,6 +172,19 @@ func (llm *dynExtServer) Predict(ctx context.Context, predict PredictOpts, fn fu
 		slog.Info(fmt.Sprintf("loaded %d images", len(predict.Images)))
 	}
 
+	// Limit the number of predictions to the maximum context length
+	// this will cause no more than two context shifts
+	// TODO: limit this further to num_ctx - len(prompt) to avoid
+	// any context shifts at all
+	if predict.Options.NumPredict > llm.options.NumCtx {
+		slog.Warn(fmt.Sprintf("requested num_predict is greater than the context length (%d > %d), using %d instead", predict.Options.NumPredict, llm.options.NumCtx, llm.options.NumCtx))
+		predict.Options.NumPredict = llm.options.NumCtx
+	}
+
+	if predict.Options.NumPredict == -1 {
+		predict.Options.NumPredict = llm.options.NumCtx
+	}
+
 	request := map[string]any{
 		"prompt":            predict.Prompt,
 		"stream":            true,


### PR DESCRIPTION
This limits the number of tokens generated to the context window size, allowing a maximum of two "context shifts" should the context window limit be passed. It will also provide a maximum token limit to stop any "runaway" prompts that occur from smaller models that continue to generate indefinitely (e.g. in JSON mode)

Ideally we have no context shifts: we only generate the number of tokens left in the context window after the prompt, but this felt like a simple change that would ease our way into this since chat prompts can get quite large and we'd have to change our prompt trimming strategy to leave enough space for longer responses.
