### PR TITLE
Default Keep Alive environment variable

### DIFF
--- a/api/types_test.go
+++ b/api/types_test.go
@@ -1,0 +1,85 @@
+package api
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeepAliveParsingFromStruct(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *ChatRequest
+		exp  *Duration
+	}{
+		{
+			name: "Positive Duration",
+			req: &ChatRequest{
+				KeepAlive: &Duration{Duration: 42 * time.Minute},
+			},
+			exp: &Duration{42 * time.Minute},
+		},
+		{
+			name: "Negative Duration",
+			req: &ChatRequest{
+				KeepAlive: &Duration{Duration: -1 * time.Minute},
+			},
+			exp: &Duration{math.MaxInt64},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ser, err := json.Marshal(test.req)
+			require.NoError(t, err)
+
+			var dec ChatRequest
+			err = json.Unmarshal([]byte(ser), &dec)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.exp, dec.KeepAlive)
+		})
+	}
+}
+func TestKeepAliveParsingFromJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		req  string
+		exp  *Duration
+	}{
+		{
+			name: "Positive Integer",
+			req:  `{ "keep_alive": 42 }`,
+			exp:  &Duration{42 * time.Second},
+		},
+		{
+			name: "Positive Integer String",
+			req:  `{ "keep_alive": "42m" }`,
+			exp:  &Duration{42 * time.Minute},
+		},
+		{
+			name: "Negative Integer",
+			req:  `{ "keep_alive": -1 }`,
+			exp:  &Duration{math.MaxInt64},
+		},
+		{
+			name: "Negative Integer String",
+			req:  `{ "keep_alive": "-1m" }`,
+			exp:  &Duration{math.MaxInt64},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var dec ChatRequest
+			err := json.Unmarshal([]byte(test.req), &dec)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.exp, dec.KeepAlive)
+		})
+	}
+}

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -10,41 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestKeepAliveParsingFromStruct(t *testing.T) {
-	tests := []struct {
-		name string
-		req  *ChatRequest
-		exp  *Duration
-	}{
-		{
-			name: "Positive Duration",
-			req: &ChatRequest{
-				KeepAlive: &Duration{Duration: 42 * time.Minute},
-			},
-			exp: &Duration{42 * time.Minute},
-		},
-		{
-			name: "Negative Duration",
-			req: &ChatRequest{
-				KeepAlive: &Duration{Duration: -1 * time.Minute},
-			},
-			exp: &Duration{math.MaxInt64},
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			ser, err := json.Marshal(test.req)
-			require.NoError(t, err)
-
-			var dec ChatRequest
-			err = json.Unmarshal([]byte(ser), &dec)
-			require.NoError(t, err)
-
-			assert.Equal(t, test.exp, dec.KeepAlive)
-		})
-	}
-}
 func TestKeepAliveParsingFromJSON(t *testing.T) {
 	tests := []struct {
 		name string

--- a/server/routes.go
+++ b/server/routes.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -387,15 +388,24 @@ func GenerateHandler(c *gin.Context) {
 
 func getDefaultSessionDuration() time.Duration {
 	if t, exists := os.LookupEnv("OLLAMA_KEEP_ALIVE"); exists {
-		d, err := time.ParseDuration(t)
+		v, err := strconv.Atoi(t)
 		if err != nil {
-			return defaultSessionDuration
+			d, err := time.ParseDuration(t)
+			if err != nil {
+				return defaultSessionDuration
+			}
+
+			if d < 0 {
+				return time.Duration(math.MaxInt64)
+			}
+
+			return d
 		}
 
+		d := time.Duration(v) * time.Second
 		if d < 0 {
 			return time.Duration(math.MaxInt64)
 		}
-
 		return d
 	}
 

--- a/server/routes.go
+++ b/server/routes.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/fs"
 	"log/slog"
+	"math"
 	"net"
 	"net/http"
 	"net/netip"
@@ -207,7 +208,7 @@ func GenerateHandler(c *gin.Context) {
 
 	var sessionDuration time.Duration
 	if req.KeepAlive == nil {
-		sessionDuration = defaultSessionDuration
+		sessionDuration = getDefaultSessionDuration()
 	} else {
 		sessionDuration = req.KeepAlive.Duration
 	}
@@ -384,6 +385,23 @@ func GenerateHandler(c *gin.Context) {
 	streamResponse(c, ch)
 }
 
+func getDefaultSessionDuration() time.Duration {
+	if t, exists := os.LookupEnv("OLLAMA_KEEP_ALIVE"); exists {
+		d, err := time.ParseDuration(t)
+		if err != nil {
+			return defaultSessionDuration
+		}
+
+		if d < 0 {
+			return time.Duration(math.MaxInt64)
+		}
+
+		return d
+	}
+
+	return defaultSessionDuration
+}
+
 func EmbeddingsHandler(c *gin.Context) {
 	loaded.mu.Lock()
 	defer loaded.mu.Unlock()
@@ -427,7 +445,7 @@ func EmbeddingsHandler(c *gin.Context) {
 
 	var sessionDuration time.Duration
 	if req.KeepAlive == nil {
-		sessionDuration = defaultSessionDuration
+		sessionDuration = getDefaultSessionDuration()
 	} else {
 		sessionDuration = req.KeepAlive.Duration
 	}
@@ -1228,7 +1246,7 @@ func ChatHandler(c *gin.Context) {
 
 	var sessionDuration time.Duration
 	if req.KeepAlive == nil {
-		sessionDuration = defaultSessionDuration
+		sessionDuration = getDefaultSessionDuration()
 	} else {
 		sessionDuration = req.KeepAlive.Duration
 	}


### PR DESCRIPTION
This change adds a new environment variable called `OLLAMA_KEEP_ALIVE` which sets how long a model will be loaded into memory. It uses the same semantics as the `keep_alive` parameter in the `generate`, `chat`, and `embeddings` API calls, namely:

* if set to a positive value, it will default to whatever time was set
* if set to zero it will unload immediately after generation
* if set to a negative value it will remain in memory

You can either use a value in seconds (e.g. `OLLAMA_KEEP_ALIVE=60` for 60 seconds), or as a duration string (e.g. `OLLAMA_KEEP_ALIVE=10m`).

This change works with both the API, and with the REPL.

Fixes #2508 
