### PR TITLE
Detect and bubble up terminal errors in server main loop

### DIFF
--- a/llm/ext_server/ext_server.h
+++ b/llm/ext_server/ext_server.h
@@ -20,6 +20,10 @@ typedef struct ext_server_resp {
   char *msg;
 } ext_server_resp_t;
 
+#define SERVER_RESP_SUCCESS 0
+#define SERVER_RESP_MINOR_ERROR -1
+#define SERVER_RESP_TERMINAL_ERROR -2
+
 // Allocated and freed by caller
 typedef struct ext_server_lora_adapter {
   char *adapter;


### PR DESCRIPTION
If something goes wrong in the async processing in the server the loop will terminate with an exception.  This wires up recording the error message, and detection in the other entry points so we can report the failure to the user, and restart the server.

Verified happy-path on Mac.  Still need to find or synthesize one of these hang scenarios to actually validate the primary logic.