### PR TITLE
Better tmpdir cleanup

### DIFF
--- a/llm/payload_common.go
+++ b/llm/payload_common.go
@@ -196,7 +196,13 @@ func extractDynamicLibs(payloadsDir, glob string) ([]string, error) {
 			return nil
 		})
 	}
-	return libs, g.Wait()
+	err = g.Wait()
+	if err != nil {
+		// If we fail to extract, the payload dir is unusable, so cleanup whatever we extracted
+		gpu.Cleanup()
+		return nil, err
+	}
+	return libs, nil
 }
 
 func verifyDriverAccess() error {


### PR DESCRIPTION
If expanding the runners fails, don't leave a corrupt/incomplete payloads dir. We now write a pid file out to the tmpdir, which allows us to scan for stale tmpdirs and remove this as long as there isn't still a process running.

Fixes #3051 
Fixes #2472 
Fixes #2658  (indirectly)

Verified on Mac, Linux and Windows.