### PR TITLE
feat: Override system prompt from non-interactive CLI

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -263,6 +263,12 @@ func RunHandler(cmd *cobra.Command, args []string) error {
 	}
 	opts.Format = format
 
+	system, err := cmd.Flags().GetString("system")
+	if err != nil {
+		return err
+	}
+	opts.System = system
+
 	prompts := args[1:]
 	// prepend stdin to the prompt if provided
 	if !term.IsTerminal(int(os.Stdin.Fd())) {
@@ -960,6 +966,7 @@ func NewCLI() *cobra.Command {
 	runCmd.Flags().Bool("insecure", false, "Use an insecure registry")
 	runCmd.Flags().Bool("nowordwrap", false, "Don't wrap words to the next line automatically")
 	runCmd.Flags().String("format", "", "Response format (e.g. json)")
+	runCmd.Flags().StringP("system", "s", "", "Set the system prompt")
 	serveCmd := &cobra.Command{
 		Use:     "serve",
 		Aliases: []string{"start"},


### PR DESCRIPTION
- Closes #1415

Previously, the only way to set the system prompt for non-interactive use was to import a new Modelfile.

This PR makes Ollama much easier to script non-interatively:

```
ollama run llama2 --system "Translate into French" "This is really useful!"
```