### PR TITLE
fix: support wide characters in lib path

### DIFF
--- a/llm/dyn_ext_server.c
+++ b/llm/dyn_ext_server.c
@@ -52,15 +52,6 @@ char* LoadErrorWindows(void) {
 #define UNLOAD_LIBRARY(handle) dlclose(handle)
 #endif
 
-HMODULE LoadLibraryWindows(const char* lib) {
-  int _len = MultiByteToWideChar(CP_UTF8, 0, (lib), -1, NULL, 0);
-    wchar_t* _wLibPath = (wchar_t*)malloc(_len * sizeof(wchar_t));
-    MultiByteToWideChar(CP_UTF8, 0, (lib), -1, _wLibPath, _len);
-    HMODULE _mod = LoadLibraryW(_wLibPath);
-    free(_wLibPath);
-    _mod;
-}
-
 void dyn_init(const char *libPath, struct dynamic_llama_server *s,
                        ext_server_resp_t *err) {
   int i = 0;


### PR DESCRIPTION
Previous behavior:
```
Error: Unable to load dynamic library: Unable to load dynamic server library: ������ ������ ã�� �� �����ϴ�.
```

When the user's home path contains unicode characters on Windows the packaged runtime libraries failed to open, add support for wide characters to fix this.

resolves #2615 
resolces #3367 