### PR TITLE
llm,readline: use errors.Is instead of simple == check

### DIFF
--- a/llm/gguf.go
+++ b/llm/gguf.go
@@ -3,6 +3,7 @@ package llm
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -540,7 +541,7 @@ func (llm *GGUFModel) Encode(f *os.File) error {
 			b, err := io.ReadFull(dataFile, data)
 			remaining -= uint64(b)
 
-			if err == io.EOF || remaining <= 0 {
+			if errors.Is(io.EOF) || remaining <= 0 {
 				finished = true
 			} else if err != nil {
 				return err

--- a/llm/payload_common.go
+++ b/llm/payload_common.go
@@ -113,7 +113,7 @@ func nativeInit() error {
 
 	libs, err := extractDynamicLibs(payloadsDir, "llama.cpp/build/*/*/*/lib/*")
 	if err != nil {
-		if err == payloadMissing {
+		if errors.Is(err, payloadMissing) {
 			slog.Info(fmt.Sprintf("%s", payloadMissing))
 			return nil
 		}

--- a/readline/history.go
+++ b/readline/history.go
@@ -62,7 +62,7 @@ func (h *History) Init() error {
 	for {
 		line, err := r.ReadString('\n')
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			return err


### PR DESCRIPTION
This fixes some brittle, simple equality checks to use errors.Is. Since go1.13, errors.Is is the idiomatic way to check for errors.