### PR TITLE
feat: timeout between token generation

### DIFF
--- a/llm/dyn_ext_server.go
+++ b/llm/dyn_ext_server.go
@@ -35,7 +35,6 @@ import (
 
 	"github.com/jmorganca/ollama/api"
 	"github.com/jmorganca/ollama/gpu"
-	"golang.org/x/exp/slog"
 )
 
 type dynExtServer struct {

--- a/server/routes.go
+++ b/server/routes.go
@@ -1362,6 +1362,15 @@ func ChatHandler(c *gin.Context) {
 			Options: opts,
 		}
 		if err := loaded.runner.Predict(c.Request.Context(), predictReq, fn); err != nil {
+			if errors.Is(err, llm.ErrPredictTimeout) {
+				// the loaded runner may be unresponsive, stop it now
+				if loaded.runner != nil {
+					loaded.runner.Close()
+				}
+				loaded.runner = nil
+				loaded.Model = nil
+				loaded.Options = nil
+			}
 			ch <- gin.H{"error": err.Error()}
 		}
 	}()


### PR DESCRIPTION
- if 30 seconds pass since the last token generation abort the request
- stop the llama thread to flush any accumulated context

This is an attempt to mitigate server hangs as seen in #2805. It is not a complete solution since we still need to address the root cause of the hangs, but it will make them recoverable.

TODO:
- [ ] reproduce hang and validate this allows the server to recover