### PR TITLE
do not prompt to move the CLI on install flow if already installed

### DIFF
--- a/macapp/src/app.tsx
+++ b/macapp/src/app.tsx
@@ -16,7 +16,10 @@ enum Step {
 }
 
 export default function () {
-  const [step, setStep] = useState<Step>(Step.WELCOME)
+  const urlParams = new URLSearchParams(window.location.search);
+  const stepParam = urlParams.get('step');
+  const initialStep = stepParam ? Number(stepParam) : Step.WELCOME;
+  const [step, setStep] = useState<Step>(initialStep);
   const [commandCopied, setCommandCopied] = useState<boolean>(false)
 
   const command = 'ollama run llama2'
@@ -29,7 +32,7 @@ export default function () {
             <div className='mx-auto text-center'>
               <h1 className='mb-6 mt-4 text-2xl tracking-tight text-gray-900'>Welcome to Ollama</h1>
               <p className='mx-auto w-[65%] text-sm text-gray-400'>
-                Let's get you up and running with your own large language models.
+                {stepParam} Let's get you up and running with your own large language models.
               </p>
               <button
                 onClick={() => setStep(Step.CLI)}

--- a/macapp/src/index.ts
+++ b/macapp/src/index.ts
@@ -32,7 +32,7 @@ const logger = winston.createLogger({
   format: winston.format.printf(info => info.message),
 })
 
-app.on('ready', () => {
+app.on('ready', async () => {
   const gotTheLock = app.requestSingleInstanceLock()
   if (!gotTheLock) {
     app.exit(0)
@@ -54,7 +54,7 @@ app.on('ready', () => {
 
   app.focus({ steal: true })
 
-  init()
+  await init()
 })
 
 function firstRunWindow() {
@@ -207,7 +207,7 @@ async function checkUpdate() {
   }
 }
 
-function init() {
+async function init() {
   if (app.isPackaged) {
     checkUpdate()
     setInterval(() => {
@@ -217,44 +217,42 @@ function init() {
 
   updateTray()
 
-  if (process.platform === 'darwin') {
-    if (app.isPackaged) {
-      if (!app.isInApplicationsFolder()) {
-        const chosen = dialog.showMessageBoxSync({
-          type: 'question',
-          buttons: ['Move to Applications', 'Do Not Move'],
-          message: 'Ollama works best when run from the Applications directory.',
-          defaultId: 0,
-          cancelId: 1,
-        })
+  const isInstalled = await installed();
 
-        if (chosen === 0) {
-          try {
-            app.moveToApplicationsFolder({
-              conflictHandler: conflictType => {
-                if (conflictType === 'existsAndRunning') {
-                  dialog.showMessageBoxSync({
-                    type: 'info',
-                    message: 'Cannot move to Applications directory',
-                    detail:
-                      'Another version of Ollama is currently running from your Applications directory. Close it first and try again.',
-                  })
-                }
-                return true
-              },
-            })
-            return
-          } catch (e) {
-            logger.error(`[Move to Applications] Failed to move to applications folder - ${e.message}}`)
-          }
-        }
+  if (process.platform === 'darwin' && app.isPackaged && !app.isInApplicationsFolder() && !isInstalled) {
+    const chosen = dialog.showMessageBoxSync({
+      type: 'question',
+      buttons: ['Move to Applications', 'Do Not Move'],
+      message: 'Ollama works best when run from the Applications directory.',
+      defaultId: 0,
+      cancelId: 1,
+    })
+
+    if (chosen === 0) {
+      try {
+        app.moveToApplicationsFolder({
+          conflictHandler: conflictType => {
+            if (conflictType === 'existsAndRunning') {
+              dialog.showMessageBoxSync({
+                type: 'info',
+                message: 'Cannot move to Applications directory',
+                detail:
+                  'Another version of Ollama is currently running from your Applications directory. Close it first and try again.',
+              })
+            }
+            return true
+          },
+        })
+        return
+      } catch (e) {
+        logger.error(`[Move to Applications] Failed to move to applications folder - ${e.message}}`)
       }
     }
   }
 
   server()
 
-  if (store.get('first-time-run') && installed()) {
+  if (store.get('first-time-run1') && isInstalled) {
     if (process.platform === 'darwin') {
       app.dock.hide()
     }

--- a/macapp/src/index.ts
+++ b/macapp/src/index.ts
@@ -57,7 +57,7 @@ app.on('ready', async () => {
   await init()
 })
 
-function firstRunWindow() {
+function firstRunWindow(isInstalled: boolean) {
   // Create the browser window.
   welcomeWindow = new BrowserWindow({
     width: 400,
@@ -75,7 +75,11 @@ function firstRunWindow() {
 
   require('@electron/remote/main').enable(welcomeWindow.webContents)
 
-  welcomeWindow.loadURL(MAIN_WINDOW_WEBPACK_ENTRY)
+  let url = MAIN_WINDOW_WEBPACK_ENTRY
+  if (isInstalled) {
+    url += '?step=2' // set the window to the finish screen
+  }
+  welcomeWindow.loadURL(url);
   welcomeWindow.on('ready-to-show', () => welcomeWindow.show())
   welcomeWindow.on('closed', () => {
     if (process.platform === 'darwin') {
@@ -263,7 +267,7 @@ async function init() {
 
   // This is the first run or the CLI is no longer installed
   app.setLoginItemSettings({ openAtLogin: true })
-  firstRunWindow()
+  firstRunWindow(isInstalled)
 }
 
 // Quit when all windows are closed, except on macOS. There, it's common

--- a/macapp/src/index.ts
+++ b/macapp/src/index.ts
@@ -256,7 +256,7 @@ async function init() {
 
   server()
 
-  if (store.get('first-time-run1') && isInstalled) {
+  if (store.get('first-time-run') && isInstalled) {
     if (process.platform === 'darwin') {
       app.dock.hide()
     }


### PR DESCRIPTION
If Ollama is installed via brew or the user wishes to manage their path manually they will be prompted to install the CLI when opening the Ollama Mac app. This change attempts to check if Ollama is already set in the path, and if it is found the user is not prompted to link the executable to `/usr/local/bin/ollama`.

- rather than checking if the symlink is set try to spawn common shells and see if ollama is available within them
- make init async to allow for spawning shells
- check for `step` param in installation UI to bypass the `move to applications` prompt
- flatten `init()` conditional check to link ollama in `/usr/local/bin/ollama`

resolves #283 
resolves #3186 