### PR TITLE
Add OpenAI Function Calling

### DIFF
--- a/docs/openai.md
+++ b/docs/openai.md
@@ -78,7 +78,7 @@ curl http://localhost:11434/v1/chat/completions \
 - [x] JSON mode
 - [x] Reproducible outputs
 - [ ] Vision
-- [ ] Function calling
+- [x] Function calling
 - [ ] Logprobs
 
 #### Supported request fields


### PR DESCRIPTION
See https://platform.openai.com/docs/guides/function-calling

Using https://huggingface.co/NousResearch/Hermes-2-Pro-Mistral-7B-GGUF

This is a proof of concept! I am thinking that all the Hermes2Pro specifics should be modeled somehow in the Modelfile.

<details>

<summary>Script to compare `gpt-3.5-turbo-0125` with this branch using `adrienbrault/nous-hermes2pro:Q4_K_M`</summary>

```bash
export OPENAI_FUNCTION_CALLING_REQUEST='{
  "model": "${MODEL}",
  "messages": [
    {
      "role": "user",
      "content": "What is the weather like in Seattle today?"
    }
  ],
  "tools": [
    {
      "type": "function",
        "function": {
          "name": "get_current_weather",
          "description": "Get the current weather",
          "parameters": {
            "type": "object",
            "properties": {
              "location": {
              "type": "string",
              "description": "The city and state, e.g. San Francisco, CA"
            },
            "format": {
              "type": "string",
              "enum": ["celsius", "fahrenheit"],
              "description": "The temperature unit to use. Infer this from the users location."
            }
          },
          "required": ["location", "format"]
        }
      }
    }
  ]
}'

export MODEL_OLLAMA="adrienbrault/nous-hermes2pro:Q4_K_M"
export MODEL_OPENAI="gpt-3.5-turbo-0125"
export OLLAMA_HOST=127.0.0.1:11435

go build . && ./ollama serve

curl "${OLLAMA_HOST}/v1/chat/completions" \
  -H "Content-Type: application/json" \
  -d "$(echo "${OPENAI_FUNCTION_CALLING_REQUEST}" | MODEL="${MODEL_OLLAMA}" envsubst '${MODEL}')" -s \
  | jq . \
  | tee ollama.json

curl "https://api.openai.com/v1/chat/completions" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer ${OPENAI_API_KEY}" \
  -d "$(echo "${OPENAI_FUNCTION_CALLING_REQUEST}" | MODEL="${MODEL_OPENAI}" envsubst '${MODEL}')" -s \
  | jq . \
  | tee openai.json

git diff --no-index openai.json ollama.json
```
</details>

```diff
diff --git a/openai.json b/ollama.json
index 59d4977..faaa2d6 100644
--- a/openai.json
+++ b/ollama.json
@@ -1,33 +1,32 @@
 {
-  "id": "chatcmpl-95hyRBATFpkeeajKuAc1D4y8gw29w",
+  "id": "chatcmpl-395",
   "object": "chat.completion",
-  "created": 1711147703,
-  "model": "gpt-3.5-turbo-0125",
+  "created": 1711149126,
+  "model": "adrienbrault/nous-hermes2pro:Q4_K_M",
+  "system_fingerprint": "fp_ollama",
   "choices": [
     {
       "index": 0,
       "message": {
         "role": "assistant",
-        "content": null,
+        "content": "",
         "tool_calls": [
           {
-            "id": "call_DBgXGrqufbzrp7rDN0VspAdw",
+            "id": "call_YxkK26AReyBuOGUJiQbLNGHq",
             "type": "function",
             "function": {
               "name": "get_current_weather",
-              "arguments": "{\"location\":\"Seattle\",\"format\":\"celsius\"}"
+              "arguments": "{\"format\":\"celsius\",\"location\":\"Seattle, WA\"}"
             }
           }
         ]
       },
-      "logprobs": null,
       "finish_reason": "tool_calls"
     }
   ],
   "usage": {
-    "prompt_tokens": 93,
-    "completion_tokens": 20,
-    "total_tokens": 113
-  },
-  "system_fingerprint": "fp_3bc1b5746c"
+    "prompt_tokens": 349,
+    "completion_tokens": 45,
+    "total_tokens": 394
+  }
 }
```
