### PR TITLE
Switch runner for final release job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -419,7 +419,7 @@ jobs:
       - build-windows
       - build-linux-amd64
       - build-linux-arm64
-    runs-on: ubuntu-latest
+    runs-on: linux
     environment: release
     permissions:
       contents: write


### PR DESCRIPTION
The manifest and tagging step use a lot of disk space