### PR TITLE
add link to chat-ollama UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 
 ### Web & Desktop
 
+- [chat-ollama](https://github.com/sugarforever/chat-ollama)
 - [LibreChat](https://github.com/danny-avila/LibreChat)
 - [Bionic GPT](https://github.com/bionic-gpt/bionic-gpt)
 - [Enchanted (macOS native)](https://github.com/AugustDev/enchanted)


### PR DESCRIPTION
`ChatOllama` is an open source chatbot based on LLMs. It supports a wide range of language models including:

- Ollama local models
- OpenAI
- Azure OpenAI
- Anthropic
- ChatOllama supports multiple types (including RAG)

feature list:

- Ollama models management
- Knowledge bases management
- Chat
- Commercial LLMs API keys management
