### PR TITLE
Add chromem-go to community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 ### Database
 
 - [MindsDB](https://github.com/mindsdb/mindsdb/blob/staging/mindsdb/integrations/handlers/ollama_handler/README.md)
+- [chromem-go](https://github.com/philippgille/chromem-go/blob/v0.5.0/embed_ollama.go) with [example](https://github.com/philippgille/chromem-go/tree/v0.5.0/examples/rag-wikipedia-ollama)
 
 ### Package managers
 


### PR DESCRIPTION
Hello :wave: , I've been a happy Ollama user for a while (both on macOS and Linux), thank you so much for creating and maintaining this project! I recommend it when talking to other people about running LLMs locally.

I recently worked on a Go library for a simple embedded vector DB, to be able to write RAG applications without having to host a separate vector DB server (like you have to with most of them, like Qdrant and Milvus). Chroma is embeddable in Python, Weaviate in Python and JS/TS, but not in Go.

I had locally running embedding models and LLMs in mind from the beginning, and the repo includes a detailed example of using Ollama with the `nomic-embed-text` and `gemma:2b` models for a simple RAG app.

- Library: https://github.com/philippgille/chromem-go
- Ollama integration: https://github.com/philippgille/chromem-go/blob/v0.5.0/embed_ollama.go
- RAG example using Ollama: https://github.com/philippgille/chromem-go/tree/v0.5.0/examples/rag-wikipedia-ollama

I would be very happy if the project could be included in the list of community integrations!