### PR TITLE
docs: added view logs instruction for Ollama via brew

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,9 +1,17 @@
 # How to troubleshoot issues
 
-Sometimes Ollama may not perform as expected. One of the best ways to figure out what happened is to take a look at the logs. Find the logs on **Mac** by running the command:
+Sometimes Ollama may not perform as expected. One of the best ways to figure out what happened is to take a look at the logs. 
+
+On **Mac**, the logs can be found with this command:
 
 ```shell
 cat ~/.ollama/logs/server.log
+```
+
+or if you install and run Ollama via `brew services`:
+
+```shell
+cat $HOMEBREW_PREFIX/var/log/ollama.log
 ```
 
 On **Linux** systems with systemd, the logs can be found with this command:


### PR DESCRIPTION
For users that installed Ollama via brew and run via `brew services`, the log file locates in different place.
I propose to update the troubleshoot doc to align such behaviour.

This PR use the log file path specified in this [spec](https://formulae.brew.sh/api/formula/ollama.json) (you can search "log_path" in the JSON file)