### PR TITLE
Allow more parts of model path

### DIFF
--- a/server/modelpath.go
+++ b/server/modelpath.go
@@ -57,6 +57,10 @@ func ParseModelPath(name string) ModelPath {
 		mp.Repository = parts[1]
 	case 1:
 		mp.Repository = parts[0]
+	default:
+		mp.Registry = parts[0]
+		mp.Namespace = strings.Join(parts[1:len(parts)-1], "/")
+		mp.Repository = parts[len(parts)-1]
 	}
 
 	if repo, tag, found := strings.Cut(mp.Repository, ":"); found {


### PR DESCRIPTION
I expect that in different Registry storage models, the path doesn't have to be only 3 parts, such as ghcr.io, which has 4 parts.
