### PR TITLE
fix dll compress in windows building

### DIFF
--- a/llm/generate/gen_windows.ps1
+++ b/llm/generate/gen_windows.ps1
@@ -146,7 +146,7 @@ function compress {
     }
 
     write-host "Compressing dlls..."
-    $binaries = dir "${script:buildDir}/bin/*.dll"
+    $dlls = dir "${script:buildDir}/bin/*.dll"
     foreach ($file in $dlls) {
         & "$script:GZIP" --best -f $file
     }


### PR DESCRIPTION
The compiled DLL on the Windows platform has not been properly compressed.