### PR TITLE
Correct directory reference in macapp/README

### DIFF
--- a/macapp/README.md
+++ b/macapp/README.md
@@ -14,7 +14,7 @@ go build .
 Then run the desktop app with `npm start`:
 
 ```
-cd app
+cd macapp
 npm install
 npm start
 ```


### PR DESCRIPTION
Minor README change that was likely omitted from https://github.com/ollama/ollama/commit/9da9e8fb7254df1148f9619bec781e52dc954678