### PR TITLE
Added Solar example at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Here are some example models that can be downloaded:
 | LLaVA              | 7B         | 4.5GB | `ollama run llava`             |
 | Gemma              | 2B         | 1.4GB | `ollama run gemma:2b`          |
 | Gemma              | 7B         | 4.8GB | `ollama run gemma:7b`          |
+| Solar              | 10.7B      | 6.1GB | `ollama run solar`             |
 
 > Note: You should have at least 8 GB of RAM available to run the 7B models, 16 GB to run the 13B models, and 32 GB to run the 33B models.
 


### PR DESCRIPTION
Added just one line

| Solar              | 10.7B      | 6.1GB | `ollama run solar`             |