### PR TITLE
Install Ollama on OSTree systems

### DIFF
--- a/gpu/amd_linux.go
+++ b/gpu/amd_linux.go
@@ -271,6 +271,17 @@ func amdProcMemLookup(resp *GpuInfo, skip map[int]interface{}, ids []int) {
 	}
 }
 
+func dirExists(target string) bool {
+	_, err := os.Stat(target)
+	if errors.Is(err, os.ErrNotExist) {
+		return false
+        } else if err != nil {
+		return false
+        }
+
+	return true
+}
+
 // Quick check for AMD driver so we can skip amdgpu discovery if not present
 func AMDDetected() bool {
 	// Some driver versions (older?) don't have a version file, so just lookup the parent dir
@@ -332,6 +343,10 @@ func AMDValidateLibDir() (string, error) {
 
 	// Well known ollama installer path
 	installedRocmDir := "/usr/share/ollama/lib/rocm"
+	if dirExists("/usr/local/share/ollama/lib/rocm") {
+		installedRocmDir = "/usr/local/share/ollama/lib/rocm"
+	}
+
 	if rocmLibUsable(installedRocmDir) {
 		return rocmTargetDir, setupLink(installedRocmDir, rocmTargetDir)
 	}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -68,6 +68,15 @@ for BINDIR in /usr/local/bin /usr/bin /bin; do
     echo $PATH | grep -q $BINDIR && break || continue
 done
 
+# In an OSTree system, since it's immutable, /usr/local is writable but
+# /usr is read-only, the best way to complete this is to package this
+# in an rpm for OSTree systems, but this works too. But regardless if we use
+# /usr/local/bin, it kinda makes sense to use /usr/local/share .
+SHAREDIR="/usr/share"
+if [ "$BINDIR" = "/usr/local/bin" ] && [ -e "/usr/local/share" ]; then
+    SHAREDIR="/usr/local/share"
+fi
+
 status "Installing ollama to $BINDIR..."
 $SUDO install -o0 -g0 -m755 -d $BINDIR
 $SUDO install -o0 -g0 -m755 $TEMP_DIR/ollama $BINDIR/ollama
@@ -83,7 +92,7 @@ trap install_success EXIT
 configure_systemd() {
     if ! id ollama >/dev/null 2>&1; then
         status "Creating ollama user..."
-        $SUDO useradd -r -s /bin/false -U -m -d /usr/share/ollama ollama
+        $SUDO useradd -r -s /bin/false -U -m -d $SHAREDIR/ollama ollama
     fi
     if getent group render >/dev/null 2>&1; then
         status "Adding ollama user to render group..."
@@ -175,11 +184,11 @@ if check_gpu lspci amdgpu || check_gpu lshw amdgpu; then
     done
 
     status "Downloading AMD GPU dependencies..."
-    $SUDO rm -rf /usr/share/ollama/lib
-    $SUDO chmod o+x /usr/share/ollama
-    $SUDO install -o ollama -g ollama -m 755 -d /usr/share/ollama/lib/rocm
+    $SUDO rm -rf $SHAREDIR/ollama/lib
+    $SUDO chmod o+x $SHAREDIR/ollama
+    $SUDO install -o ollama -g ollama -m 755 -d $SHAREDIR/ollama/lib/rocm
     curl --fail --show-error --location --progress-bar "https://ollama.com/download/ollama-linux-amd64-rocm.tgz${VER_PARAM}" \
-        | $SUDO tar zx --owner ollama --group ollama -C /usr/share/ollama/lib/rocm .
+        | $SUDO tar zx --owner ollama --group ollama -C $SHAREDIR/ollama/lib/rocm .
     install_success
     status "AMD GPU dependencies installed."
     exit 0


### PR DESCRIPTION
There's a large plethora of OSTree OSes in the Fedora family:

Silverblue, Kinoite, CoreOS, IoT, Onyx, Sericea, Vauxite

In the CentOS Stream family:

Automotive Stream Distribution, CoreOS

In the Red Hat family:

Red Hat In-Vehicle Operating System, Red Hat Enterprise Linux CoreOS, RHEL for Edge

Then there's the Universal Blue family:

Things like podman-machine and podman-desktop on Windows and macOS use Fedora CoreOS as the host OS so there is that also.

The list goes on and on.

These OSes are ideal for containerized AI LLMs like Ollama.

I eventually got this working with podman, which is probably the best route to use on these OSes (or an rpm when someone packages it).

This change gets the install script working.

/usr/bin and /usr/share aren't writable on these systems, but /usr/local/bin and /usr/local/share are.

So this change ensures if /usr/local/bin is used during installation, that we also use /usr/local/share, if /usr/local/share exists. And then everything seems to work fine on these OSes for non-containerized installs.
