### PR TITLE
chore: add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "submodules"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "go"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
related to https://github.com/ollama/ollama/pull/3627 though I don't recall is dependabot will catch a submodule if it's a directory down?