### PR TITLE
fix padding in decode

### DIFF
--- a/llm/gguf.go
+++ b/llm/gguf.go
@@ -243,7 +243,7 @@ func (llm *gguf) Decode(rs io.ReadSeeker) error {
 	}
 
 	padding := llm.padding(offset, int64(alignment))
-	if _, err := rs.Seek(padding, io.SeekCurrent); err != nil {
+	if _, err := rs.Seek(padding-offset, io.SeekCurrent); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
TODO: update padding() to _only_ returning the padding