### PR TITLE
Support unicode characters in model path

### DIFF
--- a/llm/ext_server/server.cpp
+++ b/llm/ext_server/server.cpp
@@ -2808,13 +2808,6 @@ int main(int argc, char **argv) {
 
     server_params_parse(argc, argv, sparams, params, llama);
 
-#if defined(_WIN32)
-    for (int i = 0; i < argc; ++i) {
-        delete[] argv[i];
-    }
-    delete[] argv;
-#endif
-
     if (params.model_alias == "unknown")
     {
         params.model_alias = params.model;
@@ -3313,6 +3306,11 @@ int main(int argc, char **argv) {
         return (ctrl_type == CTRL_C_EVENT) ? (signal_handler(SIGINT), true) : false;
     };
     SetConsoleCtrlHandler(reinterpret_cast<PHANDLER_ROUTINE>(console_ctrl_handler), true);
+
+    for (int i = 0; i < argc; ++i) {
+        delete[] argv[i];
+    }
+    delete[] argv;
 #endif
     llama.queue_tasks.start_loop();
     svr.stop();

--- a/llm/ext_server/server.cpp
+++ b/llm/ext_server/server.cpp
@@ -39,6 +39,10 @@
 #include "httplib.h"
 #include "json.hpp"
 
+#if defined(_WIN32)
+#include <windows.h>
+#endif
+
 #include <cstddef>
 #include <thread>
 #include <chrono>
@@ -2770,11 +2774,37 @@ inline void signal_handler(int signal) {
     shutdown_handler(signal);
 }
 
-int main(int argc, char **argv)
-{
+#if defined(_WIN32)
+char* wchar_to_char(const wchar_t* wstr) {
+    if (wstr == nullptr) return nullptr;
+
+    // Determine the number of bytes needed for the UTF-8 string
+    int bytes = WideCharToMultiByte(CP_UTF8, 0, wstr, -1, nullptr, 0, nullptr, nullptr);
+    char* str = new char[bytes];
+
+    // Convert the wide-character string to a UTF-8 string
+    WideCharToMultiByte(CP_UTF8, 0, wstr, -1, str, bytes, nullptr, nullptr);
+    return str;
+}
+
+int wmain(int argc, wchar_t **wargv) {
+    // Create a new array to hold the converted char* arguments
+    char** argv = new char*[argc];
+
+    // Convert each wide-character argument to a UTF-8 char* argument
+    for (int i = 0; i < argc; ++i) {
+        argv[i] = wchar_to_char(wargv[i]);
+    }
+#else
+int main(int argc, char **argv) {
+#endif
+
 #if SERVER_VERBOSE != 1
     log_disable();
 #endif
+    std::setlocale(LC_ALL, "");
+    std::locale::global(std::locale(""));
+
     // own arguments required by this example
     gpt_params params;
     server_params sparams;
@@ -2783,6 +2813,13 @@ int main(int argc, char **argv)
     llama_server_context llama;
 
     server_params_parse(argc, argv, sparams, params, llama);
+
+#if defined(_WIN32)
+    for (int i = 0; i < argc; ++i) {
+        delete[] argv[i];
+    }
+    delete[] argv;
+#endif
 
     if (params.model_alias == "unknown")
     {

--- a/llm/ext_server/server.cpp
+++ b/llm/ext_server/server.cpp
@@ -2788,10 +2788,7 @@ char* wchar_to_char(const wchar_t* wstr) {
 }
 
 int wmain(int argc, wchar_t **wargv) {
-    // Create a new array to hold the converted char* arguments
     char** argv = new char*[argc];
-
-    // Convert each wide-character argument to a UTF-8 char* argument
     for (int i = 0; i < argc; ++i) {
         argv[i] = wchar_to_char(wargv[i]);
     }
@@ -2802,9 +2799,6 @@ int main(int argc, char **argv) {
 #if SERVER_VERBOSE != 1
     log_disable();
 #endif
-    std::setlocale(LC_ALL, "");
-    std::locale::global(std::locale(""));
-
     // own arguments required by this example
     gpt_params params;
     server_params sparams;


### PR DESCRIPTION
When running the c++ subprocess, unicode characters in file names were not being parsed correctly, resulting in an error. This changes `server.cpp` to use `wmain` to receive the wide characters and converts them first.

Closes #3273
Fixes #2888
Fixes #3120 