### PR TITLE
types/model: support : in PartHost for host:port

### DIFF
--- a/types/model/name.go
+++ b/types/model/name.go
@@ -521,6 +521,8 @@ func parts(s string) iter_Seq2[PartKind, string] {
 						return
 					}
 					state, j, partLen = PartModel, i, 0
+				case PartHost:
+					// noop: support for host:port
 				default:
 					yield(PartExtraneous, s[i+1:j])
 					return
@@ -677,6 +679,9 @@ func isValidPart(kind PartKind, s string) bool {
 func isValidByteFor(kind PartKind, c byte) bool {
 	if kind == PartNamespace && c == '.' {
 		return false
+	}
+	if kind == PartHost && c == ':' {
+		return true
 	}
 	if c == '.' || c == '-' {
 		return true

--- a/types/model/name_test.go
+++ b/types/model/name_test.go
@@ -40,6 +40,7 @@ var testNames = map[string]fields{
 	"user/model":                     {namespace: "user", model: "model"},
 	"example.com/ns/mistral:7b+Q4_0": {host: "example.com", namespace: "ns", model: "mistral", tag: "7b", build: "Q4_0"},
 	"example.com/ns/mistral:7b+X":    {host: "example.com", namespace: "ns", model: "mistral", tag: "7b", build: "X"},
+	"localhost:5000/ns/mistral":      {host: "localhost:5000", namespace: "ns", model: "mistral"},
 
 	// invalid digest
 	"mistral:latest@invalid256-": {},


### PR DESCRIPTION
PartHost needs to allow `:` to support host:port