### PR TITLE
types/model: accept former `:` as a separator in digest

### DIFF
--- a/types/model/digest.go
+++ b/types/model/digest.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"fmt"
 	"log/slog"
 	"strings"
 	"unicode"
@@ -47,8 +48,11 @@ var (
 // Digest.
 func ParseDigest(s string) Digest {
 	typ, digest, ok := strings.Cut(s, "-")
+	if !ok {
+		typ, digest, ok = strings.Cut(s, ":")
+	}
 	if ok && isValidDigestType(typ) && isValidHex(digest) {
-		return Digest{s: s}
+		return Digest{s: fmt.Sprintf("%s-%s", typ, digest)}
 	}
 	return Digest{}
 }


### PR DESCRIPTION
This also converges the old sep `:` to the new sep `-`.