### PR TITLE
Add env override for opts.NumThread & opts.NumGPU

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -999,11 +999,13 @@ func NewCLI() *cobra.Command {
 	serveCmd.SetUsageTemplate(serveCmd.UsageTemplate() + `
 Environment Variables:
 
-    OLLAMA_HOST         The host:port to bind to (default "127.0.0.1:11434")
-    OLLAMA_ORIGINS      A comma separated list of allowed origins.
-    OLLAMA_MODELS       The path to the models directory (default is "~/.ollama/models")
-    OLLAMA_KEEP_ALIVE   The duration that models stay loaded in memory (default is "5m")
-    OLLAMA_DEBUG        Set to 1 to enable additional debug logging
+    OLLAMA_HOST              The host:port to bind to (default "127.0.0.1:11434")
+    OLLAMA_ORIGINS           A comma separated list of allowed origins.
+    OLLAMA_MODELS            The path to the models directory (default is "~/.ollama/models")
+    OLLAMA_MAX_LLM_THREADS   Maximum number of LLM CPU threads (default is unlimited: 0)
+    OLLAMA_MAX_GPU_LAYERS    Maximum number of GPU layers (default is unlimited: -1)
+    OLLAMA_KEEP_ALIVE        The duration that models stay loaded in memory (default is "5m")
+    OLLAMA_DEBUG             Set to 1 to enable additional debug logging
 `)
 
 	pullCmd := &cobra.Command{


### PR DESCRIPTION
This enables the capability to limit or disable both `NumThread` & `NumGPU` which can be useful for testing and running multiple concurrent instances. `NumThread` limitation is also valuable to reliably enforce core affinity (as with `taskset`) on hybrid architectures like modern Intel & ARM.

- `OLLAMA_MAX_LLM_THREADS` **Maximum number of LLM CPU threads (default is unlimited: 0)**
- `OLLAMA_MAX_GPU_LAYERS` **Maximum number of GPU layers (default is unlimited: -1)**