### PR TITLE
Critical fix from llama.cpp JSON grammar to forbid un-escaped escape characters in JSON strings

### DIFF
--- a/llm/server.go
+++ b/llm/server.go
@@ -490,7 +490,7 @@ array  ::=
 
 string ::=
   "\"" (
-    [^"\\] |
+    [^"\\\x7F\x00-\x1F] |
     "\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]) # escapes
   )* "\"" ws
 


### PR DESCRIPTION
JSON generation is broken, as models can insert control characters inside strings, which violates JSON.  For example, with the current JSON grammar, models could generate:

```
{ "key": "value
broken" }
```

This is incorrect, and if a linebreak is wanted in the middle of the string there, it should be:

```
{ "key": "value\nbroken" }
```

The former breaks at least the nodejs JSON parser, and likely many many others, since it's not compliant JSON.

This PR injects the grammar directly from llama.cpp upstream, which prohibits `\x00` through `\x1f` inside JSON strings, fixing the problem.