### PR TITLE
Allow any kind of JSON including arrays or straight literals, not just objects

### DIFF
--- a/llm/server.go
+++ b/llm/server.go
@@ -473,8 +473,8 @@ func (s *LlamaServer) WaitUntilRunning() error {
 }
 
 const jsonGrammar = `
-root   ::= object
 value  ::= object | array | string | number | ("true" | "false" | "null") ws
+root   ::= value
 
 object ::=
   "{" ws (


### PR DESCRIPTION
This is a simple PR which allows the `format=json` constraint to generate any valid JSON, not just JSON with an object at the top level.  This allows models to generate arrays, strings, numbers, or literals without an object wrapper around them, reducing the number of tokens necessary for many use cases.

Remember that every token is more CO2 emitted into the atmosphere and more $$$ transferred from everyone's pockets into NVidia's treasure. Tokens matter!