### PR TITLE
Allow whitespace within objects and arrays, but remove trailing possibly infinite whitespace

### DIFF
--- a/llm/server.go
+++ b/llm/server.go
@@ -624,27 +624,27 @@ func (s *llmServer) WaitUntilRunning(ctx context.Context) error {
 
 const jsonGrammar = `
 root   ::= object
-value  ::= object | array | string | number | ("true" | "false" | "null") ws
+value  ::= object | array | string | number | ("true" | "false" | "null")
 
 object ::=
   "{" ws (
             string ":" ws value
     ("," ws string ":" ws value)*
-  )? "}" ws
+  )? ws "}"
 
 array  ::=
   "[" ws (
             value
     ("," ws value)*
-  )? "]" ws
+  )? ws "]"
 
 string ::=
   "\"" (
     [^"\\\x7F\x00-\x1F] |
     "\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]) # escapes
-  )* "\"" ws
+  )* "\""
 
-number ::= ("-"? ([0-9] | [1-9] [0-9]*)) ("." [0-9]+)? ([eE] [-+]? [0-9]+)? ws
+number ::= ("-"? ([0-9] | [1-9] [0-9]*)) ("." [0-9]+)? ([eE] [-+]? [0-9]+)?
 
 # Optional space: by convention, applied in this grammar after literal chars when allowed
 ws ::= ([ \t\n] ws)?


### PR DESCRIPTION
The PR tweaks the JSON grammar to improve use of whitespace (though doesn't remove it entirely); it prevents trailing whitespace on grammatical elements, but does allow whitespace inside of `{}` or `[]`. This reduces the likelihood that a model might spit out a complete JSON object/array/primitive/literal, and then append a whole bunch of useless whitespace, consuming time and money and churning more CO2 into the atmosphere.

There's still a chance with the definition of `ws` that it could do this *within* objects/arrays, but from anecdotal testing on my machine with various models, this seems way way less common than trailing whitespace at the end of the entire reponse.