### PR TITLE
Improved json grammar

### DIFF
--- a/llm/server.go
+++ b/llm/server.go
@@ -490,7 +490,7 @@ array  ::=
 
 string ::=
   "\"" (
-    [^"\\] |
+    [^"\\\x7F\x00-\x1F] |
     "\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]) # escapes
   )* "\"" ws
 

--- a/llm/server.go
+++ b/llm/server.go
@@ -473,8 +473,8 @@ func (s *LlamaServer) WaitUntilRunning() error {
 }
 
 const jsonGrammar = `
-root   ::= object
 value  ::= object | array | string | number | ("true" | "false" | "null") ws
+root   ::= value
 
 object ::=
   "{" ws (

--- a/llm/server.go
+++ b/llm/server.go
@@ -477,16 +477,16 @@ root   ::= value
 value  ::= object | array | string | number | ("true" | "false" | "null")
 
 object ::=
-  "{" ws (
-            string ":" ws value
-    ("," ws string ":" ws value)*
-  )? ws "}"
+  "{" (
+            string ":" value
+    ("," string ":" value)*
+  )? "}"
 
 array  ::=
-  "[" ws (
+  "[" (
             value
-    ("," ws value)*
-  )? ws "]"
+    ("," value)*
+  )? "]"
 
 string ::=
   "\"" (
@@ -495,9 +495,6 @@ string ::=
   )* "\""
 
 number ::= ("-"? ([0-9] | [1-9] [0-9]*)) ("." [0-9]+)? ([eE] [-+]? [0-9]+)?
-
-# Optional space: by convention, applied in this grammar after literal chars when allowed
-ws ::= ([ \t\n] ws)?
 `
 
 const maxBufferSize = 512 * format.KiloByte

--- a/llm/server.go
+++ b/llm/server.go
@@ -473,28 +473,28 @@ func (s *LlamaServer) WaitUntilRunning() error {
 }
 
 const jsonGrammar = `
-value  ::= object | array | string | number | ("true" | "false" | "null") ws
 root   ::= value
+value  ::= object | array | string | number | ("true" | "false" | "null")
 
 object ::=
   "{" ws (
             string ":" ws value
     ("," ws string ":" ws value)*
-  )? "}" ws
+  )? ws "}"
 
 array  ::=
   "[" ws (
             value
     ("," ws value)*
-  )? "]" ws
+  )? ws "]"
 
 string ::=
   "\"" (
     [^"\\\x7F\x00-\x1F] |
     "\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]) # escapes
-  )* "\"" ws
+  )* "\""
 
-number ::= ("-"? ([0-9] | [1-9] [0-9]*)) ("." [0-9]+)? ([eE] [-+]? [0-9]+)? ws
+number ::= ("-"? ([0-9] | [1-9] [0-9]*)) ("." [0-9]+)? ([eE] [-+]? [0-9]+)?
 
 # Optional space: by convention, applied in this grammar after literal chars when allowed
 ws ::= ([ \t\n] ws)?


### PR DESCRIPTION
This PR includes #3782 #3783 #3784 but also completely removes *all* whitespace generation when applying `format=json`.

Whitespace is completely unnecessary in JSON - it is optionally acceptable, but can be ignored if we're *generating* and not parsing.  Since every token costs time, money, and CO2, removing all whitespace is highly recommended.

It will also fix a buglet, where models could get "stuck" generating infinite whitespace, since there is no limit in the definition of `ws` for how long it can be.