### PR TITLE
Detect and recover if runner removed

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -260,7 +260,7 @@ jobs:
         shell: bash
       - uses: golangci/golangci-lint-action@v4
         with:
-          args: --timeout 8m0s
+          args: --timeout 8m0s -v
   test:
     strategy:
       matrix:

--- a/llm/server.go
+++ b/llm/server.go
@@ -250,6 +250,17 @@ func NewLlamaServer(gpus gpu.GpuInfoList, model string, ggml *GGML, adapters, pr
 			server = server + ".exe"
 		}
 
+		// Detect tmp cleaners wiping out the file
+		_, err := os.Stat(server)
+		if errors.Is(err, os.ErrNotExist) {
+			slog.Warn("llama server disappeared, reinitializing payloads", "path", server, "error", err)
+			err = Init()
+			if err != nil {
+				slog.Warn("failed to reinitialize payloads", "error", err)
+				return nil, err
+			}
+		}
+
 		s := &llmServer{
 			port:          port,
 			cmd:           exec.Command(server, finalParams...),


### PR DESCRIPTION
Tmp cleaners can nuke the file out from underneath us.  This detects the missing runner, and re-initializes the payloads.

Manually tested by hand removing the server after loading it once, trigger an unload with `keep_alive: 0` sent another request, saw the log message, and it loaded correctly.