### PR TITLE
docs: add Hollama to Web & Desktop integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 
 - [Open WebUI](https://github.com/open-webui/open-webui)
 - [Enchanted (macOS native)](https://github.com/AugustDev/enchanted)
+- [Hollama](https://github.com/fmaclen/hollama)
 - [Lollms-Webui](https://github.com/ParisNeo/lollms-webui)
 - [LibreChat](https://github.com/danny-avila/LibreChat)
 - [Bionic GPT](https://github.com/bionic-gpt/bionic-gpt)


### PR DESCRIPTION
**Hollama** is a minimal web-UI for talking to Ollama servers.
https://hollama.fernando.is

**Repository:**
https://github.com/fmaclen/hollama

**Current features:**
- Large prompt fields
- Streams completions
- Copy completions as raw text
- Markdown parsing w/syntax highlighting
- Saves sessions/context in your browser's localStorage
- With [more to come](https://github.com/fmaclen/hollama/issues)...

**Screenshots:**
> ![image](https://github.com/ollama/ollama/assets/1434675/ec9d95b6-19c1-44fa-b4e2-9d47e32edd18)
> ![image](https://github.com/ollama/ollama/assets/1434675/315d6b06-01a7-45c8-b7ef-b1a074e893bb)
> ![image](https://github.com/ollama/ollama/assets/1434675/333e9ab3-3474-42cf-a0c1-cbf26025ad45)
