### PR TITLE
add information about compiling with intel mkl

### DIFF
--- a/docs/blas.md
+++ b/docs/blas.md
@@ -1,0 +1,22 @@
+# Linear Algebra Libraries
+
+llama.cpp provides support for non GPU enabled hosts.
+If you don't have a GPU, you can also get some of this acceleration.
+One common way is to utilize linear algebra software to accelerate math operations.
+
+## Intel MKL
+
+[llama.cpp](https://github.com/ggerganov/llama.cpp/blob/master/README.md#intel-onemkl) provides details on how to configure llama.cpp build with intel mkl.
+
+On intel cpus, intel MKL (math kernel library) is available to use.
+MKL speeds up linear algebra and optimizies the math required.
+
+One can follow the directions for installing mkl on your platform choice.
+
+For linux, you can then:
+
+```bash
+source /opt/intel/oneapi/setvars.sh
+OLLAMA_CUSTOM_CPU_DEFS="-DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx -DLLAMA_BLAS=ON -DLLAMA_BLAS_VENDOR=Intel10_64lp -DLLAMA_NATIVE=ON" go generate ./...
+go build .
+```

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -18,6 +18,10 @@ Review the [Troubleshooting](./troubleshooting.md) docs for more about using log
 
 Please refer to the [GPU docs](./gpu.md).
 
+## Can I improve the performance on just a CPU?
+
+Please refer to the [Linear Algebra](./blas.md)
+
 ## How can I specify the context window size?
 
 By default, Ollama uses a context window size of 2048 tokens.


### PR DESCRIPTION
llama.cpp has some information about how to compile with non gpu options.

I added a section on blas options for non gpu hosts. I use intel mkl and compile ollama (and llama.cpp) with this library.
