### PR TITLE
show ggml modelinfo through the show api

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -207,6 +207,7 @@ type ShowResponse struct {
 	System     string       `json:"system,omitempty"`
 	Details    ModelDetails `json:"details,omitempty"`
 	Messages   []Message    `json:"messages,omitempty"`
+	ModelInfo  string       `json:"modelinfo,omitempty"`
 }
 
 type CopyRequest struct {

--- a/llm/ggml.go
+++ b/llm/ggml.go
@@ -191,7 +191,7 @@ func (l Layer) size() (size uint64) {
 type Tensor struct {
 	Name   string `json:"name"`
 	Kind   uint32 `json:"kind"`
-	Offset uint64 `json:"-"`
+	Offset uint64 `json:"offset"`
 
 	// Shape is the number of elements in each dimension
 	Shape []uint64 `json:"shape"`

--- a/server/routes.go
+++ b/server/routes.go
@@ -752,16 +752,16 @@ func getGGMLData(model *Model) ([]byte, error) {
 	kvMap := make(map[string]any)
 
 	for _, k := range keys {
-		v := kv[k]
+		val := kv[k]
 
-		switch v.(type) {
+		switch v := val.(type) {
 		case []interface{}:
-			if len(v.([]interface{})) > 5 {
+			if len(v) > 5 {
 				kvMap[k] = []string{}
 				continue
 			}
 		}
-		kvMap[k] = v
+		kvMap[k] = val
 	}
 
 	ggmlMap := make(map[string]any)


### PR DESCRIPTION
This change exposes the GGML KVs and tensor data to make it easier to introspect a model.