### PR TITLE
Add /api/infill for fill-in-the-middle

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -267,6 +267,20 @@ func (c *Client) Generate(ctx context.Context, req *GenerateRequest, fn Generate
 	})
 }
 
+// Infill generates a response for a given input_prefix and input_suffix. The req parameter should
+// be populated with input prefix and suffix. fn is called for each response (there may
+// be multiple responses, e.g. in case streaming is enabled).
+func (c *Client) Infill(ctx context.Context, req *InfillRequest, fn GenerateResponseFunc) error {
+	return c.stream(ctx, http.MethodPost, "/api/infill", req, func(bts []byte) error {
+		var resp GenerateResponse
+		if err := json.Unmarshal(bts, &resp); err != nil {
+			return err
+		}
+
+		return fn(resp)
+	})
+}
+
 // ChatResponseFunc is a function that [Client.Chat] invokes every time
 // a response is received from the service. If this function returns an error,
 // [Client.Chat] will stop generating and return this error.

--- a/api/types.go
+++ b/api/types.go
@@ -80,6 +80,36 @@ type GenerateRequest struct {
 	Options map[string]interface{} `json:"options"`
 }
 
+// InfillRequest describes a request sent by [Client.Infill]. While you
+// have to specify the Model, InputPrefix and InputSuffix fields, all the other fields have
+// reasonable defaults for basic uses.
+type InfillRequest struct {
+
+	// InputPrefix is the text before the infilling position to send to the model.
+	InputPrefix string `json:"input_prefix"`
+
+	// InputSuffix is the text after the infilling position to send to the model.
+	InputSuffix string `json:"input_suffix"`
+
+	// Model is the model name; it should be a name familiar to Ollama from
+	// the library at https://ollama.com/library and support Fill-In-the-Middle (FIM)
+	Model string `json:"model"`
+
+	// System overrides the model's default system message/prompt.
+	System string `json:"system"`
+
+	// Stream specifies whether the response is streaming; it is true by default.
+	Stream *bool `json:"stream,omitempty"`
+
+	// KeepAlive controls how long the model will stay loaded in memory following
+	// this request.
+	KeepAlive *Duration `json:"keep_alive,omitempty"`
+
+	// Options lists model-specific options. For example, temperature can be
+	// set through this field, if the model supports it.
+	Options map[string]interface{} `json:"options"`
+}
+
 // ChatRequest describes a request sent by [Client.Chat].
 type ChatRequest struct {
 	// Model is the model name, as in [GenerateRequest].

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -586,6 +586,9 @@ func (s *mockLlm) WaitUntilRunning(ctx context.Context) error { return s.waitRes
 func (s *mockLlm) Completion(ctx context.Context, req llm.CompletionRequest, fn func(llm.CompletionResponse)) error {
 	return s.completionResp
 }
+func (s *mockLlm) Infill(ctx context.Context, req llm.InfillRequest, fn func(llm.CompletionResponse)) error {
+	return s.completionResp
+}
 func (s *mockLlm) Embedding(ctx context.Context, prompt string) ([]float64, error) {
 	return s.embeddingResp, s.embeddingRespErr
 }


### PR DESCRIPTION
This PR closes #3869

Adds `/api/infill` to leverage llama.cpp's [POST /infill](https://github.com/ggerganov/llama.cpp/blob/master/examples/server/README.md#api-endpoints) API for infilling / fill-in-the-middle / code-completion.

An example request looks like this:
```http
POST /api/infill HTTP/1.1
Host: localhost:11434
Content-Type: application/json
Content-Length: 199
{
    "stream": false,
    "model": "codellama:7b-instruct-q3_K_M",
    "input_prefix": "public int gcd(int x, int y) {",
    "input_suffix": "\n}",
    "options": {
        "num_predict": 10
    }
}
```
Response:
```json
{
    "model": "codellama:7b-instruct-q3_K_M",
    "created_at": "2024-04-25T11:09:06.691622744Z",
    "response": "\n    return y == 0 ? x :",
    "done": true,
    "total_duration": 3385921466,
    "load_duration": 948913941,
    "prompt_eval_count": 18,
    "prompt_eval_duration": 1175793000,
    "eval_count": 10,
    "eval_duration": 1219642000
}
``` 
(Streaming is also available)

Note: could probably need more refactoring to cleanup duplicate code, I am very new to Golang programming, so feedback would be appreciated