### PR TITLE
Fix curl command in documentation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -649,7 +649,7 @@ Create a new model from a `Modelfile`.
 ##### Request
 
 ```shell
-curl http://localhost:11434/api/create -d '{
+curl -X POST http://localhost:11434/api/create -d '{
   "name": "mario",
   "modelfile": "FROM llama2\nSYSTEM You are mario from Super Mario Bros."
 }'


### PR DESCRIPTION
 Explicitly set the HTTP method to POST using the -X flag to avoid errors when creating a new model from `modelfile`