### PR TITLE
Fix exe name for zip packaging on windows

### DIFF
--- a/scripts/build_windows.ps1
+++ b/scripts/build_windows.ps1
@@ -82,7 +82,7 @@ function buildOllama() {
         if ($LASTEXITCODE -ne 0) { exit($LASTEXITCODE)}
     }
     New-Item -ItemType Directory -Path .\dist\windows-amd64\ -Force
-    cp .\ollama.exe .\dist\windows-amd64\ollama-windows-amd64.exe
+    cp .\ollama.exe .\dist\windows-amd64\
 }
 
 function buildApp() {


### PR DESCRIPTION
The zip file encodes the OS and architecture, so keep the short exe name