### PR TITLE
use merge base for diff-tree

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,9 @@ jobs:
       - id: changes
         run: |
           changed() {
-            git diff-tree -r --no-commit-id --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} \
+            git diff-tree -r --no-commit-id --name-only \
+              $(git merge-base ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }}) \
+              ${{ github.event.pull_request.head.sha }} \
               | xargs python3 -c "import sys; print(any([x.startswith('$1') for x in sys.argv[1:]]))"
           }
 


### PR DESCRIPTION
the diff-tree previously compared the head ref (the latest commit in the PR) against the base ref (the latest commit in the target branch). if the target branch is updated, this comparison will include the new files in the target as well which is wrong.

instead, find and compare the head ref against the merge base of the head and base refs. this should ensure only the changes added in the pr are evaluated