### PR TITLE
server: add dynamic configuration for download variables

### DIFF
--- a/server/images.go
+++ b/server/images.go
@@ -1277,6 +1277,4 @@ func verifyBlob(digest string) error {
 		slog.Warn(err.Error())
 	}
 	return err
-
-	return nil
 }

--- a/server/util.go
+++ b/server/util.go
@@ -3,6 +3,7 @@ package server
 import (
 	"os"
 	"strconv"
+	"unsafe"
 )
 
 type Int interface {
@@ -10,7 +11,7 @@ type Int interface {
 }
 
 func parseInt[T Int](v string, fallback T) T {
-	i, err := strconv.ParseInt(v, 10, 64)
+	i, err := strconv.ParseInt(v, 10, int(unsafe.Sizeof(fallback)))
 	if err != nil {
 		return fallback
 	}

--- a/server/util.go
+++ b/server/util.go
@@ -1,0 +1,26 @@
+package server
+
+import (
+	"os"
+	"strconv"
+)
+
+type Int interface {
+	int | int8 | int16 | int32 | int64
+}
+
+func parseInt[T Int](v string, fallback T) T {
+	i, err := strconv.ParseInt(v, 10, 64)
+	if err != nil {
+		return fallback
+	}
+	return T(i)
+}
+
+func getEnvInt[T Int](key string, fallback T) T {
+	v, ok := os.LookupEnv(key)
+	if !ok {
+		return fallback
+	}
+	return parseInt(v, fallback)
+}


### PR DESCRIPTION
 ## Issue

I've found that downloads can be unreliable for large models, either due to errors during the download or during processing the digest.

## Workaround

Add some environment variables to the server to allow runtime configuration of the number of parallel downloads and how big the chunks can be.

## Follow-up

Ideally the server would be configured to respect the `?partNumber` query parameters that the returned `x-amz-mp-parts-count` header implies should be supported. I'd also like it to support `x-amz-checksum-mode=ENABLED` (currently returns a `501 NOT IMPLEMENTED`), so that each part number returns an expected digest in the response headers for `GET` and `HEAD`. This would enable us to split the digest by parts, so that if a part download fails, we don't need to retrieve the full model each time.

It seems that the current implementation is done via [github.com/distribution/distribution](github.com/distribution/distribution), which delegates its `Range` handling to `http.ServeContent`, and as such does not support the `partNumber` functionality implied by the CloudFlare response headers. So any such support would have to fork github.com/distribution/distribution. CloudFlare also does not appear to support these headers.