### PR TITLE
fix gemma, command-r layer weights

### DIFF
--- a/llm/memory.go
+++ b/llm/memory.go
@@ -102,10 +102,14 @@ func EstimateGPULayers(gpus []gpu.GpuInfo, ggml *GGML, projectors []string, opts
 	layers := ggml.Tensors().Layers()
 
 	var memoryLayerOutput uint64
-	for k, v := range layers {
-		if k == "output" || k == "output_norm" {
-			memoryLayerOutput += v.size()
-		}
+	if layer, ok := layers["output_norm"]; ok {
+		memoryLayerOutput += layer.size()
+	}
+
+	if layer, ok := layers["output"]; ok {
+		memoryLayerOutput += layer.size()
+	} else if layer, ok := layers["token_embd"]; ok {
+		memoryLayerOutput += layer.size()
 	}
 
 	if gpus[0].Library == "metal" && opts.UseMMap {


### PR DESCRIPTION
some models (gemma, command-r) do not have output tensors. instead the token_embd tensor are offloaded in its place