### PR TITLE
llm: dont cap context window limit to training context window

### DIFF
--- a/llm/server.go
+++ b/llm/server.go
@@ -73,8 +73,7 @@ func LoadModel(model string) (*GGML, error) {
 func NewLlamaServer(gpus gpu.GpuInfoList, model string, ggml *GGML, adapters, projectors []string, opts api.Options) (LlamaServer, error) {
 	var err error
 	if opts.NumCtx > int(ggml.KV().ContextLength()) {
-		slog.Warn("requested context length is greater than model max context length", "requested", opts.NumCtx, "model", ggml.KV().ContextLength())
-		opts.NumCtx = int(ggml.KV().ContextLength())
+		slog.Warn("requested context length is greater than the model's training context window size", "requested", opts.NumCtx, "training size", ggml.KV().ContextLength())
 	}
 
 	if opts.NumCtx < 4 {


### PR DESCRIPTION
Some models such as the new Llama 3 8B context window fine tunes support larger context windows such as 128k, 256k. However, the "training" context window is still 8k. To avoid confusion, this change loosens the limit and logs a warning.