### PR TITLE
Fix/issue 3736: When runners are closing or expiring. Scheduler is getting dirty VRAM size readings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ ggml-metal.metal
 test_data
 *.crt
 llm/build
+__debug_bin*

--- a/llm/server.go
+++ b/llm/server.go
@@ -903,9 +903,7 @@ func (s *llmServer) Close() error {
 			return err
 		}
 
-		if err := s.cmd.Wait(); err != nil {
-			return err
-		}
+		_ = s.cmd.Wait()
 
 		slog.Debug("llama server stopped")
 	}

--- a/llm/server.go
+++ b/llm/server.go
@@ -899,7 +899,10 @@ func (s *llmServer) Detokenize(ctx context.Context, tokens []int) (string, error
 func (s *llmServer) Close() error {
 	if s.cmd != nil {
 		slog.Debug("stopping llama server")
-		return s.cmd.Process.Kill()
+		if err := s.cmd.Process.Kill(); err != nil {
+			return err
+		}
+		return s.cmd.Wait()
 	}
 
 	return nil

--- a/llm/server.go
+++ b/llm/server.go
@@ -902,7 +902,12 @@ func (s *llmServer) Close() error {
 		if err := s.cmd.Process.Kill(); err != nil {
 			return err
 		}
-		return s.cmd.Wait()
+
+		if err := s.cmd.Wait(); err != nil {
+			return err
+		}
+
+		slog.Debug("llama server stopped")
 	}
 
 	return nil

--- a/llm/server.go
+++ b/llm/server.go
@@ -300,12 +300,6 @@ func NewLlamaServer(gpus gpu.GpuInfoList, model string, ggml *GGML, adapters, pr
 			continue
 		}
 
-		// reap subprocess when it exits
-		go func() {
-			// Exit status managed via getServerStatus
-			_ = s.cmd.Wait()
-		}()
-
 		// TODO - make sure this is all wired up correctly
 		// if err = s.WaitUntilRunning(); err != nil {
 		// 	slog.Error("error starting llama server", "server", servers[i], "error", err)

--- a/server/sched.go
+++ b/server/sched.go
@@ -296,6 +296,10 @@ func (pending *LlmRequest) useLoadedRunner(runner *runnerRef, finished chan *Llm
 	runner.refMu.Lock()
 	defer runner.refMu.Unlock()
 	runner.refCount++
+	if runner.expireTimer != nil {
+		runner.expireTimer.Stop()
+		runner.expireTimer = nil
+	}
 	runner.sessionDuration = pending.sessionDuration
 	pending.successCh <- runner
 	go func() {

--- a/server/sched.go
+++ b/server/sched.go
@@ -250,6 +250,7 @@ func (s *Scheduler) processCompleted(ctx context.Context) {
 						defer runner.refMu.Unlock()
 						if runner.expireTimer != nil {
 							runner.expireTimer.Stop()
+							runner.expireTimer = nil
 						}
 						s.expiredCh <- runner
 					})
@@ -430,6 +431,10 @@ type runnerRef struct {
 
 // The refMu must already be held when calling unload
 func (runner *runnerRef) unload() {
+	if runner.expireTimer != nil {
+		runner.expireTimer.Stop()
+		runner.expireTimer = nil
+	}
 	if runner.llama != nil {
 		runner.llama.Close()
 	}


### PR DESCRIPTION
Issue: When the Ollama `Scheduler` requests a runner to stop (kill), the `Scheduler` reads the available VRAM and gets a size that includes the terminating runner. This results in offloading to the CPU and slower execution. Each time a new model is swapped in, the new runner reads the previous runner's memory allocation. This affects the new runner's VRAM allocation estimate.
Fix: When stopping a runner, wait for the process to exit so that the memory is free before `Scheduler` checks the amount of VRAM available.

Issue: After a runner finishes a request, an expiration timer is assigned based on the session duration. Subsequent requests will renew the expiration timer after each request has finished. If a request happens to take too long and the timer fires, the runner will be scheduled to be unloaded.  If concurrently, a new pending may get an incorrect measure of VRAM, resulting in offloading to the CPU and slower execution.  Runners are expiring in the middle of heavy use, which results in the same model closing and reloading.  The reloading gets a dirty VRAM measurement because the previous runner is not fully closed before the new runner is created. The concurrency of the pending and completed Go routines.  The pending continues on the unloaded event, which can be "any" unloaded event.  
Fix: Clear the timer so it does not fire when reusing runners.  Only assign the timer when the runner has finished.  Clear any assigned timers when closing runners.  An active runner should not have an expire timer.  