### PR TITLE
Add preflight OPTIONS handling and update CORS config

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -948,6 +948,7 @@ func (s *Server) GenerateRoutes() http.Handler {
 	config := cors.DefaultConfig()
 	config.AllowWildcard = true
 	config.AllowBrowserExtensions = true
+	config.AllowHeaders = []string{"Authorization", "Content-Type", "User-Agent"}
 	config.AllowOrigins = envconfig.AllowOrigins
 
 	r := gin.Default()

--- a/server/routes.go
+++ b/server/routes.go
@@ -948,7 +948,7 @@ func (s *Server) GenerateRoutes() http.Handler {
 	config := cors.DefaultConfig()
 	config.AllowWildcard = true
 	config.AllowBrowserExtensions = true
-	config.AllowHeaders = []string{"Authorization", "Content-Type", "User-Agent"}
+	config.AllowHeaders = []string{"Authorization", "Content-Type", "User-Agent", "Accept", "X-Requested-With"}
 	config.AllowOrigins = envconfig.AllowOrigins
 
 	r := gin.Default()

--- a/server/routes.go
+++ b/server/routes.go
@@ -931,6 +931,11 @@ func allowedHostsMiddleware(addr net.Addr) gin.HandlerFunc {
 		}
 
 		if allowedHost(host) {
+			if c.Request.Method == "OPTIONS" {
+				c.AbortWithStatus(http.StatusNoContent)
+				return
+			}
+
 			c.Next()
 			return
 		}


### PR DESCRIPTION
Couple of tweaks to our CORS configuration and how we handle `OPTIONS` requests. This update is geared towards making our service more compatible with clients originally designed to work with OpenAI, where sending an `Authorization` header is common.

#### Details of Changes
1. **Handling OPTIONS Requests**: I added a quick return for `OPTIONS` requests in our `allowedHostsMiddleware`. This means we're now ending these preflight requests with a 204 (No Content) status right off the bat.

2. **Updating CORS for Authorization Headers**: Since some of the Ollama clients automatically send an `Authorization` header (because they're set up for OpenAI), I've updated our CORS config to accept these headers. This is needed for making sure these clients can interact with our service without hitting CORS.

####  Security
Since we're not currently using the `Authorization` header for our own authentication, allowing this header doesn't open us up to new security risks as long as we don't have auth. 

Enabling the `OPTIONS` method is mainly about letting browsers do their preflight check when they see that `Authorization` header. It's pretty standard and doesn't pose a direct risk by itself as far as I am aware.

resolves #4001
resolves #3983 
resolves https://github.com/ollama/ollama-js/issues/80