### PR TITLE
Add information on model tagging to `import.md`.

### DIFF
--- a/docs/import.md
+++ b/docs/import.md
@@ -146,7 +146,7 @@ After publishing, your model will be available at `https://ollama.com/<your user
 
 ### Tagging models
 
-If your model has different versions you can optionally tag them, without a tag it will be `latest`:
+If your model has different versions you can optionally tag them, without a tag, it will be `latest`:
 
 ```
 ollama push <your username>/example[:tag]
@@ -156,7 +156,7 @@ All your tags will be available at `https://ollama.com/<your username>/example/t
 
 ## Quantization reference
 
-The quantization options are as follow (from highest highest to lowest levels of quantization). Note: some architectures such as Falcon do not support K quants.
+The quantization options are as follows (from highest to lowest levels of quantization). Note: some architectures such as Falcon do not support K quants.
 
 - `q2_K`
 - `q3_K`

--- a/docs/import.md
+++ b/docs/import.md
@@ -144,6 +144,16 @@ ollama push <your username>/example
 
 After publishing, your model will be available at `https://ollama.com/<your username>/example`.
 
+### Tagging models
+
+If your model has different versions you can optionally tag them, without a tag it will be `latest`:
+
+```
+ollama push <your username>/example[:tag]
+```
+
+All your tags will be available at `https://ollama.com/<your username>/example/tags`.
+
 ## Quantization reference
 
 The quantization options are as follow (from highest highest to lowest levels of quantization). Note: some architectures such as Falcon do not support K quants.


### PR DESCRIPTION
I added a section to the import documentation on model tagging and cleaned up the quantization reference section a smidge.