### PR TITLE
Feat: Add `OLLAMA_LOAD_TIMEOUT` env variable

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -148,6 +148,10 @@ If a different directory needs to be used, set the environment variable `OLLAMA_
 
 Refer to the section [above](#how-do-i-configure-ollama-server) for how to set environment variables on your platform.
 
+### How do I increase the timeout when i get "timed out waiting for llama runner to start"? 
+
+To increase the timeout for loading models from disk, set the environment variable `OLLAMA_LOAD_TIMEOUT` (default 600s).
+
 ## Does Ollama send my prompts and answers back to ollama.com?
 
 No. Ollama runs locally, and conversation data does not leave your machine.

--- a/llm/server.go
+++ b/llm/server.go
@@ -427,13 +427,13 @@ func (s *llmServer) WaitUntilRunning(ctx context.Context) error {
 	// TODO we need to wire up a better way to detect hangs during model load and startup of the server
 	timeout := 600
 	if timeoutEnv := os.Getenv("OLLAMA_LOAD_TIMEOUT"); timeoutEnv != "" {
-		var err error
-		timeout, err = strconv.Atoi(timeoutEnv)
-		if err != nil || timeout <= 0 {
-			return fmt.Errorf("invalid OLLAMA_LOAD_TIMEOUT=%s must be an integer greater than zero - %w", timeoutEnv, err)
+		timeoutInt, err := strconv.Atoi(timeoutEnv)
+		if err != nil || timeoutInt <= 0 {
+			slog.Info(fmt.Sprintf("invalid OLLAMA_LOAD_TIMEOUT=%s must be an integer greater than zero. Defaulting to %ds", timeoutEnv, timeout))
+		} else {
+			timeout = timeoutInt
 		}
 	}
-	print(timeout)
 	expiresAt := time.Now().Add(time.Duration(timeout) * time.Second) // be generous with timeout, large models can take a while to load
 	ticker := time.NewTicker(50 * time.Millisecond)
 	defer ticker.Stop()

--- a/llm/server.go
+++ b/llm/server.go
@@ -425,7 +425,16 @@ func (s *llmServer) Ping(ctx context.Context) error {
 func (s *llmServer) WaitUntilRunning(ctx context.Context) error {
 	start := time.Now()
 	// TODO we need to wire up a better way to detect hangs during model load and startup of the server
-	expiresAt := time.Now().Add(10 * time.Minute) // be generous with timeout, large models can take a while to load
+	timeout := 600
+	if timeoutEnv := os.Getenv("OLLAMA_LOAD_TIMEOUT"); timeoutEnv != "" {
+		var err error
+		timeout, err = strconv.Atoi(timeoutEnv)
+		if err != nil || timeout <= 0 {
+			return fmt.Errorf("invalid OLLAMA_LOAD_TIMEOUT=%s must be an integer greater than zero - %w", timeoutEnv, err)
+		}
+	}
+	print(timeout)
+	expiresAt := time.Now().Add(time.Duration(timeout) * time.Second) // be generous with timeout, large models can take a while to load
 	ticker := time.NewTicker(50 * time.Millisecond)
 	defer ticker.Stop()
 


### PR DESCRIPTION
Closes #3940 

For certain hardware setups and models, the offloading to the GPU can take a lot of time and the user can hit a timeout. This PR makes the timeout configurable via the `OLLAMA_LOAD_TIMEOUT` env variable, to be provided in seconds.

@dhiltgen I added a subsection in the FAQ, since I was not sure where to document the env variable. Let me know if this is the right place.