### PR TITLE
Skip PhysX cudart library

### DIFF
--- a/gpu/gpu.go
+++ b/gpu/gpu.go
@@ -220,6 +220,11 @@ func FindGPULibs(baseLibName string, patterns []string) []string {
 	}
 	slog.Debug("gpu library search", "globs", patterns)
 	for _, pattern := range patterns {
+
+		// Nvidia PhysX known to return bogus results
+		if strings.Contains(pattern, "PhysX") {
+			slog.Debug("skipping PhysX cuda library path", "path", pattern)
+		}
 		// Ignore glob discovery errors
 		matches, _ := filepath.Glob(pattern)
 		for _, match := range matches {


### PR DESCRIPTION
For some reason this library gives incorrect GPU information, so skip it


I'm not convinced yet this is the optimal fix, but queuing this up in case we get ready to cut a new release and haven't found a better solution yet.

Fixes #4008 