### PR TITLE
Fix `no slots available` error with concurrent requests

### DIFF
--- a/llm/server.go
+++ b/llm/server.go
@@ -503,7 +503,6 @@ ws ::= ([ \t\n] ws)?
 `
 
 const maxBufferSize = 512 * format.KiloByte
-const maxRetries = 3
 
 type ImageData struct {
 	Data []byte `json:"data"`

--- a/llm/server.go
+++ b/llm/server.go
@@ -715,13 +715,13 @@ func (s *llmServer) Completion(ctx context.Context, req CompletionRequest, fn fu
 			if s.status != nil && s.status.LastErrMsg != "" {
 				msg = s.status.LastErrMsg
 			}
-
 			return fmt.Errorf("an unknown error was encountered while running the model %s", msg)
 		}
+
 		return fmt.Errorf("error reading llm response: %v", err)
 	}
 
-	return nil // success
+	return nil
 }
 
 type EmbeddingRequest struct {
@@ -738,6 +738,7 @@ func (s *llmServer) Embedding(ctx context.Context, prompt string) ([]float64, er
 		return nil, err
 	}
 	defer s.sem.Release(1)
+
 	// Make sure the server is ready
 	status, err := s.getServerStatusRetry(ctx)
 	if err != nil {

--- a/llm/server.go
+++ b/llm/server.go
@@ -627,7 +627,6 @@ func (s *llmServer) Completion(ctx context.Context, req CompletionRequest, fn fu
 		buf := make([]byte, 0, maxBufferSize)
 		scanner.Buffer(buf, maxBufferSize)
 
-		retryNeeded := false
 		// keep track of the last token generated, this is used to abort if the model starts looping
 		var lastToken string
 		var tokenRepeat int
@@ -641,14 +640,6 @@ func (s *llmServer) Completion(ctx context.Context, req CompletionRequest, fn fu
 				line := scanner.Bytes()
 				if len(line) == 0 {
 					continue
-				}
-
-				fmt.Println("LINE", string(line))
-
-				// try again on slot unavailable
-				if bytes.Contains(line, []byte("slot unavailable")) {
-					retryNeeded = true
-					break
 				}
 
 				evt, ok := bytes.CutPrefix(line, []byte("data: "))


### PR DESCRIPTION
This fixes a few issues with queuing requests:

- Always wait for the server.cpp ready state to avoid "server busy" errors this should fix `no slots available`

Fixes #4159