### PR TITLE
Allocate a large enough kv cache for all parallel requests

### DIFF
--- a/server/sched.go
+++ b/server/sched.go
@@ -82,6 +82,9 @@ func InitScheduler(ctx context.Context) *Scheduler {
 
 // context must be canceled to decrement ref count and release the runner
 func (s *Scheduler) GetRunner(c context.Context, model *Model, opts api.Options, sessionDuration time.Duration) (chan *runnerRef, chan error) {
+	// allocate a large enough kv cache for all parallel requests
+	opts.NumCtx = opts.NumCtx * numParallel
+
 	req := &LlmRequest{
 		ctx:             c,
 		model:           model,
@@ -90,8 +93,7 @@ func (s *Scheduler) GetRunner(c context.Context, model *Model, opts api.Options,
 		successCh:       make(chan *runnerRef),
 		errCh:           make(chan error, 1),
 	}
-	// context split across parallel threads
-	opts.NumCtx = opts.NumCtx * numParallel
+
 	select {
 	case s.pendingReqCh <- req:
 	default:


### PR DESCRIPTION
This fixes `opts.NumCtx` being assigned correctly