### PR TITLE
Add support for the BSD platforms

### DIFF
--- a/gpu/gpu_bsd.go
+++ b/gpu/gpu_bsd.go
@@ -1,0 +1,93 @@
+//go:build dragonfly || freebsd || netbsd || openbsd
+
+package gpu
+
+import "github.com/ollama/ollama/format"
+
+/*
+#cgo CFLAGS: -I/usr/local/include
+#cgo LDFLAGS: -L/usr/local/lib -lvulkan
+
+#include <stdbool.h>
+#include <unistd.h>
+#include <vulkan/vulkan.h>
+
+bool hasVulkanSupport(uint64_t *memSize) {
+	VkInstance instance;
+	VkApplicationInfo appInfo = { VK_STRUCTURE_TYPE_APPLICATION_INFO };
+	appInfo.pApplicationName = "Ollama";
+	appInfo.apiVersion = VK_API_VERSION_1_0;
+
+	VkInstanceCreateInfo createInfo = { VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO };
+	createInfo.pApplicationInfo = &appInfo;
+
+	// Create a Vulkan instance.
+	if (vkCreateInstance(&createInfo, NULL, &instance) != VK_SUCCESS) {
+		return false;
+	}
+
+	// Fetch the first physical Vulkan device. Note that numDevices is overwritten
+	// with the number of devices found.
+	uint32_t numDevices = 1;
+	VkPhysicalDevice device;
+	vkEnumeratePhysicalDevices(instance, &numDevices, &device);
+	if (numDevices == 0) {
+		vkDestroyInstance(instance, NULL);
+		return false;
+	}
+
+	// Fetch the memory information for this device.
+	VkPhysicalDeviceMemoryProperties memProperties;
+	vkGetPhysicalDeviceMemoryProperties(device, &memProperties);
+
+	// Add up all the heaps.
+	VkDeviceSize totalMemory = 0;
+	for (uint32_t i = 0; i < memProperties.memoryHeapCount; ++i) {
+		if (memProperties.memoryHeaps[i].flags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT) {
+			*memSize += memProperties.memoryHeaps[i].size;
+		}
+	}
+
+	vkDestroyInstance(instance, NULL);
+	return true;
+}
+*/
+import "C"
+
+func GetGPUInfo() GpuInfoList {
+	var gpuMem C.uint64_t
+
+	// Check if there is hardware support for Vulkan.
+	if C.hasVulkanSupport(&gpuMem) {
+		return []GpuInfo{
+			{
+				Library:       "vulkan",
+				ID:            "0",
+				MinimumMemory: 512 * format.MebiByte,
+				memInfo: memInfo{
+					FreeMemory:  uint64(gpuMem),
+					TotalMemory: uint64(gpuMem),
+				},
+			},
+		}
+	}
+
+	// If there is no Vulkan support, default back to CPU.
+	cpuMem, _ := GetCPUMem()
+	return []GpuInfo{
+		{
+			Library: "cpu",
+			Variant: GetCPUVariant(),
+			memInfo: cpuMem,
+		},
+	}
+}
+
+func GetCPUMem() (memInfo, error) {
+	size := C.sysconf(C._SC_PHYS_PAGES) * C.sysconf(C._SC_PAGE_SIZE)
+	return memInfo{TotalMemory: uint64(size)}, nil
+}
+
+func (l GpuInfoList) GetVisibleDevicesEnv() (string, string) {
+	return "", ""
+}

--- a/gpu/gpu_info_cpu.c
+++ b/gpu/gpu_info_cpu.c
@@ -44,6 +44,8 @@ void cpu_check_ram(mem_info_t *resp) {
 //   mem_info_t resp = {0, 0, NULL};
 //   return resp;
 // }
+#elif __DragonFly__ || __FreeBSD__ || __NetBSD__ || __OpenBSD__
+// This is already implemented as a Go function in GetCPUMem().
 #else
 #error "Unsupported platform"
 #endif

--- a/gpu/gpu_test.go
+++ b/gpu/gpu_test.go
@@ -23,7 +23,7 @@ func TestCPUMemInfo(t *testing.T) {
 	switch runtime.GOOS {
 	case "darwin":
 		t.Skip("CPU memory not populated on darwin")
-	case "openbsd", "netbsd", "freebsd", "dragonfly":
+	case "dragonfly", "freebsd", "netbsd", "openbsd":
 		t.Skip("CPU memory not populated on BSD")
 	case "linux", "windows":
 		assert.Greater(t, info.TotalMemory, uint64(0))

--- a/gpu/gpu_test.go
+++ b/gpu/gpu_test.go
@@ -10,7 +10,7 @@ import (
 func TestBasicGetGPUInfo(t *testing.T) {
 	info := GetGPUInfo()
 	assert.Greater(t, len(info), 0)
-	assert.Contains(t, "cuda rocm cpu metal", info[0].Library)
+	assert.Contains(t, "cuda rocm cpu metal vulkan", info[0].Library)
 	if info[0].Library != "cpu" {
 		assert.Greater(t, info[0].TotalMemory, uint64(0))
 		assert.Greater(t, info[0].FreeMemory, uint64(0))
@@ -23,6 +23,8 @@ func TestCPUMemInfo(t *testing.T) {
 	switch runtime.GOOS {
 	case "darwin":
 		t.Skip("CPU memory not populated on darwin")
+	case "openbsd", "netbsd", "freebsd", "dragonfly":
+		t.Skip("CPU memory not populated on BSD")
 	case "linux", "windows":
 		assert.Greater(t, info.TotalMemory, uint64(0))
 		assert.Greater(t, info.FreeMemory, uint64(0))

--- a/llm/generate/gen_bsd.sh
+++ b/llm/generate/gen_bsd.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+# This script is intended to run inside the go generate
+# working directory must be ./llm/generate/
+
+set -ex
+set -o pipefail
+echo "Starting BSD generate script"
+. $(dirname $0)/gen_common.sh
+init_vars
+git_module_setup
+apply_patches
+
+COMMON_BSD_DEFS="-DCMAKE_SYSTEM_NAME=$(uname -s)"
+CMAKE_TARGETS="--target llama --target ggml"
+
+case "${GOARCH}" in
+  "amd64")
+    COMMON_CPU_DEFS="${COMMON_BSD_DEFS} -DCMAKE_SYSTEM_PROCESSOR=${ARCH}"
+
+    # Static build for linking into the Go binary
+    init_vars
+    CMAKE_DEFS="${COMMON_CPU_DEFS} -DBUILD_SHARED_LIBS=off -DLLAMA_ACCELERATE=off -DLLAMA_AVX=off -DLLAMA_AVX2=off -DLLAMA_AVX512=off -DLLAMA_FMA=off -DLLAMA_F16C=off ${CMAKE_DEFS}"
+    BUILD_DIR="../build/bsd/${ARCH}_static"
+    echo "Building static library"
+    build
+
+    init_vars
+    CMAKE_DEFS="${COMMON_CPU_DEFS} -DLLAMA_AVX=off -DLLAMA_AVX2=off -DLLAMA_AVX512=off -DLLAMA_FMA=off -DLLAMA_F16C=off ${CMAKE_DEFS}"
+    BUILD_DIR="../build/bsd/${ARCH}/cpu"
+    echo "Building LCD CPU"
+    build
+    compress
+
+    init_vars
+    CMAKE_DEFS="${COMMON_CPU_DEFS} -DLLAMA_AVX=on -DLLAMA_AVX2=off -DLLAMA_AVX512=off -DLLAMA_FMA=off -DLLAMA_F16C=off ${CMAKE_DEFS}"
+    BUILD_DIR="../build/bsd/${ARCH}/cpu_avx"
+    echo "Building AVX CPU"
+    build
+    compress
+
+    init_vars
+    CMAKE_DEFS="${COMMON_CPU_DEFS} -DLLAMA_AVX=on -DLLAMA_AVX2=on -DLLAMA_AVX512=off -DLLAMA_FMA=on -DLLAMA_F16C=on ${CMAKE_DEFS}"
+    BUILD_DIR="../build/bsd/${ARCH}/cpu_avx2"
+    echo "Building AVX2 CPU"
+    build
+    compress
+
+    init_vars
+    CMAKE_DEFS="${COMMON_CPU_DEFS} -DLLAMA_VULKAN=on ${CMAKE_DEFS}"
+    BUILD_DIR="../build/bsd/${ARCH}/vulkan"
+    echo "Building Vulkan GPU"
+    build
+    compress
+    ;;
+
+  *)
+    echo "GOARCH must be set"
+    echo "this script is meant to be run from within go generate"
+    exit 1
+    ;;
+esac
+
+cleanup
+echo "go generate completed.  LLM runners: $(cd ${BUILD_DIR}/..; echo *)"

--- a/llm/generate/gen_common.sh
+++ b/llm/generate/gen_common.sh
@@ -89,7 +89,7 @@ compress() {
     rm -rf ${BUILD_DIR}/bin/*.gz
     for f in ${BUILD_DIR}/bin/* ; do
         gzip -n --best -f ${f} &
-        pids+=" $!"
+        pids="$pids $!"
     done
     # check for lib directory
     if [ -d ${BUILD_DIR}/lib ]; then

--- a/llm/generate/generate_bsd.go
+++ b/llm/generate/generate_bsd.go
@@ -1,0 +1,5 @@
+//go:build dragonfly || freebsd || netbsd || openbsd
+
+package generate
+
+//go:generate sh ./gen_bsd.sh

--- a/llm/llm.go
+++ b/llm/llm.go
@@ -7,10 +7,10 @@ package llm
 // #cgo windows,arm64 LDFLAGS: ${SRCDIR}/build/windows/arm64_static/libllama.a -static -lstdc++
 // #cgo linux,amd64 LDFLAGS: ${SRCDIR}/build/linux/x86_64_static/libllama.a -lstdc++
 // #cgo linux,arm64 LDFLAGS: ${SRCDIR}/build/linux/arm64_static/libllama.a -lstdc++
-// #cgo openbsd,amd64 LDFLAGS: ${SRCDIR}/build/bsd/x86_64_static/libllama.a -lstdc++ -lm
-// #cgo netbsd,amd64 LDFLAGS: ${SRCDIR}/build/bsd/x86_64_static/libllama.a -lstdc++ -lm
-// #cgo freebsd,amd64 LDFLAGS: ${SRCDIR}/build/bsd/x86_64_static/libllama.a -lstdc++ -lm
 // #cgo dragonfly,amd64 LDFLAGS: ${SRCDIR}/build/bsd/x86_64_static/libllama.a -lstdc++ -lm
+// #cgo freebsd,amd64 LDFLAGS: ${SRCDIR}/build/bsd/x86_64_static/libllama.a -lstdc++ -lm
+// #cgo netbsd,amd64 LDFLAGS: ${SRCDIR}/build/bsd/x86_64_static/libllama.a -lstdc++ -lm
+// #cgo openbsd,amd64 LDFLAGS: ${SRCDIR}/build/bsd/x86_64_static/libllama.a -lstdc++ -lm
 // #include <stdlib.h>
 // #include "llama.h"
 import "C"

--- a/llm/llm.go
+++ b/llm/llm.go
@@ -7,6 +7,10 @@ package llm
 // #cgo windows,arm64 LDFLAGS: ${SRCDIR}/build/windows/arm64_static/libllama.a -static -lstdc++
 // #cgo linux,amd64 LDFLAGS: ${SRCDIR}/build/linux/x86_64_static/libllama.a -lstdc++
 // #cgo linux,arm64 LDFLAGS: ${SRCDIR}/build/linux/arm64_static/libllama.a -lstdc++
+// #cgo openbsd,amd64 LDFLAGS: ${SRCDIR}/build/bsd/x86_64_static/libllama.a -lstdc++ -lm
+// #cgo netbsd,amd64 LDFLAGS: ${SRCDIR}/build/bsd/x86_64_static/libllama.a -lstdc++ -lm
+// #cgo freebsd,amd64 LDFLAGS: ${SRCDIR}/build/bsd/x86_64_static/libllama.a -lstdc++ -lm
+// #cgo dragonfly,amd64 LDFLAGS: ${SRCDIR}/build/bsd/x86_64_static/libllama.a -lstdc++ -lm
 // #include <stdlib.h>
 // #include "llama.h"
 import "C"

--- a/llm/llm_bsd.go
+++ b/llm/llm_bsd.go
@@ -1,0 +1,8 @@
+//go:build dragonfly || freebsd || netbsd || openbsd
+
+package llm
+
+import "embed"
+
+//go:embed build/bsd/*/*/bin/*
+var libEmbed embed.FS

--- a/scripts/build_bsd.sh
+++ b/scripts/build_bsd.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+set -e
+
+case "$(uname -s)" in
+  DragonFly)
+    ;;
+  FreeBSD)
+    ;;
+  NetBSD)
+    ;;
+  OpenBSD)
+    ;;
+  *)
+    echo "$(uname -s) is not supported"
+    exit 1
+    ;;
+esac
+
+export VERSION=${VERSION:-$(git describe --tags --first-parent --abbrev=7 --long --dirty --always | sed -e "s/^v//g")}
+export GOFLAGS="'-ldflags=-w -s \"-X=github.com/ollama/ollama/version.Version=$VERSION\" \"-X=github.com/ollama/ollama/server.mode=release\"'"
+
+mkdir -p dist
+rm -rf llm/llama.cpp/build
+
+go generate ./...
+CGO_ENABLED=1 go build -trimpath -o dist/ollama-bsd


### PR DESCRIPTION
This PR adds the ability to compile and run Ollama on various BSD platforms, specifically DragonFly, FreeBSD, NetBSD and OpenBSD. A couple notes:

1. It includes support for Vulkan to offload work to the GPU.
2. It's only been tested on OpenBSD, but hopefully interested parties in this community can test the other platforms.
3. `ollama run` is broken on OpenBSD. The [readline](readline) package uses `syscall` which OpenBSD [has removed from libc and the kernel](https://marc.info/?l=openbsd-tech&m=169841790407370&w=2). Instead, the readline package should be updated to use `golang.org/x/sys/unix`, similar to how [ergochat/readline](https://github.com/ergochat/readline) does it. I didn't want to include that work in this PR.
4. The tweak in `gen_common.sh` is to remove a bash'ism so that the file can be sourced from `ksh`.

On OpenBSD I needed to add these packages:

```pkg_add cmake go vulkan-headers```

The other platforms will probably have similarly named packages to install.