### PR TITLE
fix golangci workflow not enable gofmt and goimports

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 llm/ext_server/* linguist-vendored
+*.go text eol=lf

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -269,7 +269,7 @@ jobs:
           mkdir -p llm/build/darwin/$ARCH/stub/bin
           touch llm/build/darwin/$ARCH/stub/bin/ollama_llama_server
         if: ${{ startsWith(matrix.os, 'macos-') }}
-      - uses: golangci/golangci-lint-action@v4
+      - uses: golangci/golangci-lint-action@v5
         with:
           args: --timeout 8m0s -v
   test:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,9 +9,8 @@ linters:
     - contextcheck
     - exportloopref
     - gocheckcompilerdirectives
-    # FIXME: for some reason this errors on windows
-    # - gofmt
-    # - goimports
+    - gofmt
+    - goimports
     - misspell
     - nilerr
     - unused


### PR DESCRIPTION
Hi, this pr tries to fix golangci not enable `gofmt` and `goimport` in github workflows.

All workflows have passed. But I notice `* text eol=lf`  was removed in commit [9164b0161](https://github.com/ollama/ollama/commit/9164b0161bcb24e543cba835a8863b80af2c0c21) which v0.1.33 was released. So I still need help from maintainers because `.github/workflows/release.yaml` is not tested. By now I can not trigger release workflow in my own repo https://github.com/alwqx/ollama because `.github/workflows/release.yaml` references some environments which I don't have or I don't known how to get my own value:
- MACOS_SIGNING_KEY
- MACOS_SIGNING_KEY_PASSWORD
- APPLE_IDENTITY
- APPLE_PASSWORD
- APPLE_ID
- KEY_CONTAINER
- GOOGLE_SIGNING_CREDENTIALS
- ...

I hope maintainer/collaborators help test release workflow for this change.