### PR TITLE
types/model: fix parser for empty values

### DIFF
--- a/types/model/file.go
+++ b/types/model/file.go
@@ -249,10 +249,6 @@ func quote(s string) string {
 }
 
 func unquote(s string) (string, bool) {
-	if len(s) == 0 {
-		return "", false
-	}
-
 	// TODO: single quotes
 	if len(s) >= 3 && s[:3] == `"""` {
 		if len(s) >= 6 && s[len(s)-3:] == `"""` {

--- a/types/model/file_test.go
+++ b/types/model/file_test.go
@@ -490,6 +490,10 @@ You are a store greeter. Always responsed with "Hello!".
 MESSAGE user Hey there!
 MESSAGE assistant Hello, I want to parse all the things!
 `,
+		`
+FROM foo
+SYSTEM ""
+`,
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
empty values were incorrectly seen as `\n` after parsing, formatting, and reparsing