### PR TITLE
Revert "fix golangci workflow not enable gofmt and goimports"

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -269,7 +269,7 @@ jobs:
           mkdir -p llm/build/darwin/$ARCH/stub/bin
           touch llm/build/darwin/$ARCH/stub/bin/ollama_llama_server
         if: ${{ startsWith(matrix.os, 'macos-') }}
-      - uses: golangci/golangci-lint-action@v5
+      - uses: golangci/golangci-lint-action@v4
         with:
           args: --timeout 8m0s -v
   test:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,8 +9,9 @@ linters:
     - contextcheck
     - exportloopref
     - gocheckcompilerdirectives
-    - gofmt
-    - goimports
+    # FIXME: for some reason this errors on windows
+    # - gofmt
+    # - goimports
     - misspell
     - nilerr
     - unused


### PR DESCRIPTION
Reverts ollama/ollama#4190

gofmt is still a problem on windows see https://github.com/ollama/ollama/actions/runs/8989369091/job/24692319408?pr=4153