### PR TITLE
add done_reason to the api

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -310,6 +310,9 @@ type GenerateResponse struct {
 	// Done specifies if the response is complete.
 	Done bool `json:"done"`
 
+	// DoneReason is the reason the model stopped generating text.
+	DoneReason string `json:"done_reason,omitempty"`
+
 	// Context is an encoding of the conversation used in this response; this
 	// can be sent in the next request to keep a conversational memory.
 	Context []int `json:"context,omitempty"`

--- a/api/types.go
+++ b/api/types.go
@@ -114,10 +114,10 @@ type Message struct {
 // ChatResponse is the response returned by [Client.Chat]. Its fields are
 // similar to [GenerateResponse].
 type ChatResponse struct {
-	Model        string    `json:"model"`
-	CreatedAt    time.Time `json:"created_at"`
-	Message      Message   `json:"message"`
-	FinishReason string    `json:"finish_reason,omitempty"`
+	Model      string    `json:"model"`
+	CreatedAt  time.Time `json:"created_at"`
+	Message    Message   `json:"message"`
+	DoneReason string    `json:"done_reason,omitempty"`
 
 	Done bool `json:"done"`
 

--- a/api/types.go
+++ b/api/types.go
@@ -114,9 +114,10 @@ type Message struct {
 // ChatResponse is the response returned by [Client.Chat]. Its fields are
 // similar to [GenerateResponse].
 type ChatResponse struct {
-	Model     string    `json:"model"`
-	CreatedAt time.Time `json:"created_at"`
-	Message   Message   `json:"message"`
+	Model        string    `json:"model"`
+	CreatedAt    time.Time `json:"created_at"`
+	Message      Message   `json:"message"`
+	FinishReason string    `json:"finish_reason,omitempty"`
 
 	Done bool `json:"done"`
 

--- a/api/types.go
+++ b/api/types.go
@@ -117,7 +117,7 @@ type ChatResponse struct {
 	Model      string    `json:"model"`
 	CreatedAt  time.Time `json:"created_at"`
 	Message    Message   `json:"message"`
-	DoneReason string    `json:"done_reason,omitempty"`
+	DoneReason string    `json:"done_reason"`
 
 	Done bool `json:"done"`
 
@@ -311,7 +311,7 @@ type GenerateResponse struct {
 	Done bool `json:"done"`
 
 	// DoneReason is the reason the model stopped generating text.
-	DoneReason string `json:"done_reason,omitempty"`
+	DoneReason string `json:"done_reason"`
 
 	// Context is an encoding of the conversation used in this response; this
 	// can be sent in the next request to keep a conversational memory.

--- a/llm/server.go
+++ b/llm/server.go
@@ -576,10 +576,11 @@ type ImageData struct {
 }
 
 type completion struct {
-	Content string `json:"content"`
-	Model   string `json:"model"`
-	Prompt  string `json:"prompt"`
-	Stop    bool   `json:"stop"`
+	Content      string `json:"content"`
+	Model        string `json:"model"`
+	Prompt       string `json:"prompt"`
+	Stop         bool   `json:"stop"`
+	StoppedLimit bool   `json:"stopped_limit"`
 
 	Timings struct {
 		PredictedN  int     `json:"predicted_n"`
@@ -598,6 +599,7 @@ type CompletionRequest struct {
 
 type CompletionResponse struct {
 	Content            string
+	FinishReason       string
 	Done               bool
 	PromptEvalCount    int
 	PromptEvalDuration time.Duration
@@ -739,8 +741,14 @@ func (s *llmServer) Completion(ctx context.Context, req CompletionRequest, fn fu
 			}
 
 			if c.Stop {
+				finishReason := "stop"
+				if c.StoppedLimit {
+					finishReason = "length"
+				}
+
 				fn(CompletionResponse{
 					Done:               true,
+					FinishReason:       finishReason,
 					PromptEvalCount:    c.Timings.PromptN,
 					PromptEvalDuration: parseDurationMs(c.Timings.PromptMS),
 					EvalCount:          c.Timings.PredictedN,

--- a/llm/server.go
+++ b/llm/server.go
@@ -599,7 +599,7 @@ type CompletionRequest struct {
 
 type CompletionResponse struct {
 	Content            string
-	FinishReason       string
+	DoneReason         string
 	Done               bool
 	PromptEvalCount    int
 	PromptEvalDuration time.Duration
@@ -741,14 +741,14 @@ func (s *llmServer) Completion(ctx context.Context, req CompletionRequest, fn fu
 			}
 
 			if c.Stop {
-				finishReason := "stop"
+				doneReason := "stop"
 				if c.StoppedLimit {
-					finishReason = "length"
+					doneReason = "length"
 				}
 
 				fn(CompletionResponse{
 					Done:               true,
-					FinishReason:       finishReason,
+					DoneReason:         doneReason,
 					PromptEvalCount:    c.Timings.PromptN,
 					PromptEvalDuration: parseDurationMs(c.Timings.PromptMS),
 					EvalCount:          c.Timings.PredictedN,

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -109,7 +109,7 @@ func toChatCompletion(id string, r api.ChatResponse) ChatCompletion {
 		Choices: []Choice{{
 			Index:        0,
 			Message:      Message{Role: r.Message.Role, Content: r.Message.Content},
-			FinishReason: &r.FinishReason,
+			FinishReason: &r.DoneReason,
 		}},
 		Usage: Usage{
 			// TODO: ollama returns 0 for prompt eval if the prompt was cached, but openai returns the actual count
@@ -131,7 +131,7 @@ func toChunk(id string, r api.ChatResponse) ChatCompletionChunk {
 			{
 				Index:        0,
 				Delta:        Message{Role: "assistant", Content: r.Message.Content},
-				FinishReason: &r.FinishReason,
+				FinishReason: &r.DoneReason,
 			},
 		},
 	}

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -107,15 +107,9 @@ func toChatCompletion(id string, r api.ChatResponse) ChatCompletion {
 		Model:             r.Model,
 		SystemFingerprint: "fp_ollama",
 		Choices: []Choice{{
-			Index:   0,
-			Message: Message{Role: r.Message.Role, Content: r.Message.Content},
-			FinishReason: func(done bool) *string {
-				if done {
-					reason := "stop"
-					return &reason
-				}
-				return nil
-			}(r.Done),
+			Index:        0,
+			Message:      Message{Role: r.Message.Role, Content: r.Message.Content},
+			FinishReason: &r.FinishReason,
 		}},
 		Usage: Usage{
 			// TODO: ollama returns 0 for prompt eval if the prompt was cached, but openai returns the actual count
@@ -135,15 +129,9 @@ func toChunk(id string, r api.ChatResponse) ChatCompletionChunk {
 		SystemFingerprint: "fp_ollama",
 		Choices: []ChunkChoice{
 			{
-				Index: 0,
-				Delta: Message{Role: "assistant", Content: r.Message.Content},
-				FinishReason: func(done bool) *string {
-					if done {
-						reason := "stop"
-						return &reason
-					}
-					return nil
-				}(r.Done),
+				Index:        0,
+				Delta:        Message{Role: "assistant", Content: r.Message.Content},
+				FinishReason: &r.FinishReason,
 			},
 		},
 	}

--- a/server/routes.go
+++ b/server/routes.go
@@ -152,9 +152,10 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 	// of `raw` mode so we need to check for it too
 	if req.Prompt == "" && req.Template == "" && req.System == "" {
 		c.JSON(http.StatusOK, api.GenerateResponse{
-			CreatedAt: time.Now().UTC(),
-			Model:     req.Model,
-			Done:      true,
+			CreatedAt:    time.Now().UTC(),
+			Model:        req.Model,
+			Done:         true,
+			FinishReason: "load",
 		})
 		return
 	}
@@ -222,10 +223,11 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 			}
 
 			resp := api.GenerateResponse{
-				Model:     req.Model,
-				CreatedAt: time.Now().UTC(),
-				Done:      r.Done,
-				Response:  r.Content,
+				Model:        req.Model,
+				CreatedAt:    time.Now().UTC(),
+				Done:         r.Done,
+				Response:     r.Content,
+				FinishReason: r.FinishReason,
 				Metrics: api.Metrics{
 					PromptEvalCount:    r.PromptEvalCount,
 					PromptEvalDuration: r.PromptEvalDuration,
@@ -1210,10 +1212,11 @@ func (s *Server) ChatHandler(c *gin.Context) {
 	// an empty request loads the model
 	if len(req.Messages) == 0 || prompt == "" {
 		resp := api.ChatResponse{
-			CreatedAt: time.Now().UTC(),
-			Model:     req.Model,
-			Done:      true,
-			Message:   api.Message{Role: "assistant"},
+			CreatedAt:    time.Now().UTC(),
+			Model:        req.Model,
+			Done:         true,
+			FinishReason: "load",
+			Message:      api.Message{Role: "assistant"},
 		}
 		c.JSON(http.StatusOK, resp)
 		return
@@ -1246,10 +1249,11 @@ func (s *Server) ChatHandler(c *gin.Context) {
 		fn := func(r llm.CompletionResponse) {
 
 			resp := api.ChatResponse{
-				Model:     req.Model,
-				CreatedAt: time.Now().UTC(),
-				Message:   api.Message{Role: "assistant", Content: r.Content},
-				Done:      r.Done,
+				Model:        req.Model,
+				CreatedAt:    time.Now().UTC(),
+				Message:      api.Message{Role: "assistant", Content: r.Content},
+				Done:         r.Done,
+				FinishReason: r.FinishReason,
 				Metrics: api.Metrics{
 					PromptEvalCount:    r.PromptEvalCount,
 					PromptEvalDuration: r.PromptEvalDuration,

--- a/server/routes.go
+++ b/server/routes.go
@@ -152,10 +152,10 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 	// of `raw` mode so we need to check for it too
 	if req.Prompt == "" && req.Template == "" && req.System == "" {
 		c.JSON(http.StatusOK, api.GenerateResponse{
-			CreatedAt:    time.Now().UTC(),
-			Model:        req.Model,
-			Done:         true,
-			FinishReason: "load",
+			CreatedAt:  time.Now().UTC(),
+			Model:      req.Model,
+			Done:       true,
+			DoneReason: "load",
 		})
 		return
 	}
@@ -223,11 +223,11 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 			}
 
 			resp := api.GenerateResponse{
-				Model:        req.Model,
-				CreatedAt:    time.Now().UTC(),
-				Done:         r.Done,
-				Response:     r.Content,
-				FinishReason: r.FinishReason,
+				Model:      req.Model,
+				CreatedAt:  time.Now().UTC(),
+				Done:       r.Done,
+				Response:   r.Content,
+				DoneReason: r.DoneReason,
 				Metrics: api.Metrics{
 					PromptEvalCount:    r.PromptEvalCount,
 					PromptEvalDuration: r.PromptEvalDuration,
@@ -1212,11 +1212,11 @@ func (s *Server) ChatHandler(c *gin.Context) {
 	// an empty request loads the model
 	if len(req.Messages) == 0 || prompt == "" {
 		resp := api.ChatResponse{
-			CreatedAt:    time.Now().UTC(),
-			Model:        req.Model,
-			Done:         true,
-			FinishReason: "load",
-			Message:      api.Message{Role: "assistant"},
+			CreatedAt:  time.Now().UTC(),
+			Model:      req.Model,
+			Done:       true,
+			DoneReason: "load",
+			Message:    api.Message{Role: "assistant"},
 		}
 		c.JSON(http.StatusOK, resp)
 		return
@@ -1249,11 +1249,11 @@ func (s *Server) ChatHandler(c *gin.Context) {
 		fn := func(r llm.CompletionResponse) {
 
 			resp := api.ChatResponse{
-				Model:        req.Model,
-				CreatedAt:    time.Now().UTC(),
-				Message:      api.Message{Role: "assistant", Content: r.Content},
-				Done:         r.Done,
-				FinishReason: r.FinishReason,
+				Model:      req.Model,
+				CreatedAt:  time.Now().UTC(),
+				Message:    api.Message{Role: "assistant", Content: r.Content},
+				Done:       r.Done,
+				DoneReason: r.DoneReason,
 				Metrics: api.Metrics{
 					PromptEvalCount:    r.PromptEvalCount,
 					PromptEvalDuration: r.PromptEvalDuration,


### PR DESCRIPTION
When generating content using the chat or generate endpoints it is useful to know the reason the LLM stopped generating.

This may be due to 3 reasons currently in our API:
- "stop" - The generation hit a stop token.
- "length" - The maximum `num_tokens` was reached.
- "load" - The request was sent with an empty body to load the model.

This change proposes a new `done_reason` parameter on the chat and generate responses.

Moving forward this change help us give more information to the user. For example we can add timeouts on requests to prevent the server from hanging.

Follow-up:
- update docs
- update javascript and python client libraries

Related: #4230