### PR TITLE
Record more GPU information

### DIFF
--- a/gpu/amd_hip_windows.go
+++ b/gpu/amd_hip_windows.go
@@ -3,7 +3,6 @@ package gpu
 import (
 	"fmt"
 	"log/slog"
-	"strconv"
 	"syscall"
 	"unsafe"
 
@@ -74,16 +73,22 @@ func (hl *HipLib) Release() {
 	hl.dll = 0
 }
 
-func (hl *HipLib) AMDDriverVersion() (string, error) {
+func (hl *HipLib) AMDDriverVersion() (driverMajor, driverMinor int, err error) {
 	if hl.dll == 0 {
-		return "", fmt.Errorf("dll has been unloaded")
+		return 0, 0, fmt.Errorf("dll has been unloaded")
 	}
 	var version int
 	status, _, err := syscall.SyscallN(hl.hipDriverGetVersion, uintptr(unsafe.Pointer(&version)))
 	if status != hipSuccess {
-		return "", fmt.Errorf("failed call to hipDriverGetVersion: %d %s", status, err)
+		return 0, 0, fmt.Errorf("failed call to hipDriverGetVersion: %d %s", status, err)
 	}
-	return strconv.Itoa(version), nil
+
+	slog.Debug("hipDriverGetVersion", "version", version)
+	// TODO - this isn't actually right, but the docs claim hipDriverGetVersion isn't accurate anyway...
+	driverMajor = version / 1000
+	driverMinor = (version - (driverMajor * 1000)) / 10
+
+	return driverMajor, driverMinor, nil
 }
 
 func (hl *HipLib) HipGetDeviceCount() int {

--- a/gpu/gpu_info.h
+++ b/gpu/gpu_info.h
@@ -39,16 +39,19 @@ extern "C" {
 #endif
 
 #define GPU_ID_LEN 64
+#define GPU_NAME_LEN 96
 
 typedef struct mem_info {
   char *err;  // If non-nill, caller responsible for freeing
   char gpu_id[GPU_ID_LEN];
+  char gpu_name[GPU_NAME_LEN];
   uint64_t total;
   uint64_t free;
 
   // Compute Capability
   int major; 
   int minor;
+  int patch;
 } mem_info_t;
 
 void cpu_check_ram(mem_info_t *resp);

--- a/gpu/gpu_info_cpu.c
+++ b/gpu/gpu_info_cpu.c
@@ -10,8 +10,6 @@ void cpu_check_ram(mem_info_t *resp) {
   if (GlobalMemoryStatusEx(&info) != 0) {
     resp->total = info.ullTotalPhys;
     resp->free = info.ullAvailPhys;
-    resp->major = 0;
-    resp->minor = 0;
     snprintf(&resp->gpu_id[0], GPU_ID_LEN, "0");
   } else {
     resp->err = LOAD_ERR();
@@ -31,8 +29,6 @@ void cpu_check_ram(mem_info_t *resp) {
   } else {
     resp->total = info.totalram * info.mem_unit;
     resp->free = info.freeram * info.mem_unit;
-    resp->major = 0;
-    resp->minor = 0;
     snprintf(&resp->gpu_id[0], GPU_ID_LEN, "0");
   }
   return;

--- a/gpu/gpu_info_nvcuda.h
+++ b/gpu/gpu_info_nvcuda.h
@@ -44,12 +44,15 @@ typedef void* CUcontext;
 typedef struct nvcuda_handle {
   void *handle;
   uint16_t verbose;
+  int driver_major;
+  int driver_minor;
   CUresult (*cuInit)(unsigned int Flags);
   CUresult (*cuDriverGetVersion)(int *driverVersion);
   CUresult (*cuDeviceGetCount)(int *);
   CUresult (*cuDeviceGet)(CUdevice* device, int ordinal);
   CUresult (*cuDeviceGetAttribute)(int* pi, CUdevice_attribute attrib, CUdevice dev);
   CUresult (*cuDeviceGetUuid)(CUuuid* uuid, CUdevice dev); // signature compatible with cuDeviceGetUuid_v2
+  CUresult (*cuDeviceGetName)(char *name, int len, CUdevice dev);
 
   // Context specific aspects
   CUresult (*cuCtxCreate_v3)(CUcontext* pctx, void *params, int len, unsigned int flags, CUdevice dev);

--- a/server/routes.go
+++ b/server/routes.go
@@ -1065,7 +1065,8 @@ func Serve(ln net.Listener) error {
 
 	// At startup we retrieve GPU information so we can get log messages before loading a model
 	// This will log warnings to the log in case we have problems with detected GPUs
-	_ = gpu.GetGPUInfo()
+	gpus := gpu.GetGPUInfo()
+	gpus.LogDetails()
 
 	return srvr.Serve(ln)
 }


### PR DESCRIPTION
This cleans up the logging for GPU discovery a bit, and can serve as a foundation to report GPU information in a future UX.

Some example output (without OLLAMA_DEBUG set)

Windows Cuda:
```
time=2024-05-07T14:55:04.202-07:00 level=INFO source=payload.go:44 msg="Dynamic LLM libraries [cpu cpu_avx cpu_avx2 cuda_v11.3 cuda_v12.3 rocm_v5.7]"
time=2024-05-07T14:55:04.310-07:00 level=INFO source=cpu_common.go:11 msg="CPU has AVX2"
time=2024-05-07T14:55:04.572-07:00 level=INFO source=amd_windows.go:90 msg="unsupported Radeon iGPU detected skipping" id=0 name="AMD Radeon(TM) Graphics" gfx=gfx1036
time=2024-05-07T14:55:04.635-07:00 level=INFO source=gpu.go:246 msg="inference compute" id=GPU-13b3d4ff-808b-ab50-e395-de65e58aa716 library=cuda compute=8.9 driver=12.3 name="NVIDIA GeForce RTX 4090" total="24563.5 MiB" available="23008.0 MiB"
```

Windows Radeon:
```
time=2024-05-07T15:00:22.839-07:00 level=INFO source=amd_windows.go:90 msg="unsupported Radeon iGPU detected skipping" id=0 name="AMD Radeon(TM) Graphics" gfx=gfx1036
time=2024-05-07T15:00:23.082-07:00 level=INFO source=gpu.go:246 msg="inference compute" id=1 library=rocm compute=gfx1100 driver=0.0 name="AMD Radeon RX 7900 XTX" total="24560.0 MiB" available="24432.0 MiB"
```

Linux Radeon mismatch gfx without override
```
time=2024-05-07T21:56:20.080Z level=WARN source=amd_linux.go:290 msg="amdgpu is not supported" gpu=0 gpu_type=gfx1034 library=/usr/share/ollama/lib/rocm supported_types="[gfx1030 gfx1100 gfx1101 gfx1102 gfx900 gfx906 gfx908 gfx90a gfx940 gfx941 gfx942]"
time=2024-05-07T21:56:20.080Z level=WARN source=amd_linux.go:292 msg="See https://github.com/ollama/ollama/blob/main/docs/gpu.md#overrides for HSA_OVERRIDE_GFX_VERSION usage"
time=2024-05-07T21:56:20.080Z level=INFO source=amd_linux.go:305 msg="no compatible amdgpu devices detected"
time=2024-05-07T21:56:20.080Z level=INFO source=gpu.go:246 msg="inference compute" id=0 library=cpu compute="" driver=0.0 name="" total="32051.6 MiB" available="271.3 MiB"
```

Same system with the override set
```
time=2024-05-07T21:57:08.855Z level=INFO source=amd_linux.go:298 msg="skipping rocm gfx compatibility check" HSA_OVERRIDE_GFX_VERSION=10.3.0
time=2024-05-07T21:57:08.855Z level=INFO source=gpu.go:246 msg="inference compute" id=0 library=rocm compute=gfx1034 driver=6.3 name=1002:743f total="4080.0 MiB" available="1102.9 MiB"
```

Dual CUDA setup:
```
time=2024-05-07T21:51:19.894Z level=INFO source=gpu.go:246 msg="inference compute" id=GPU-19fc4f1e-fbcc-de33-f14a-ae21199420b6 library=cuda compute=8.6 driver=12.4 name="NVIDIA GeForce RTX 3060" total="12030.6 MiB" available="11922.6 MiB"
time=2024-05-07T21:51:19.894Z level=INFO source=gpu.go:246 msg="inference compute" id=GPU-f3a94ab8-b31d-61ff-9fbb-ce91ac1cdd95 library=cuda compute=8.6 driver=12.4 name="NVIDIA GeForce RTX 3060" total="12037.4 MiB" available="8897.4 MiB"
```
