### PR TITLE
reference license, template, system as files

### DIFF
--- a/server/images.go
+++ b/server/images.go
@@ -459,7 +459,22 @@ func CreateModel(ctx context.Context, name model.Name, modelFileDir, quantizatio
 				})
 			}
 
-			blob := strings.NewReader(c.Args)
+			var blob io.Reader = strings.NewReader(c.Args)
+			if strings.HasPrefix(c.Args, "@") {
+				p, err := GetBlobsPath(strings.TrimPrefix(c.Args, "@"))
+				if err != nil {
+					return err
+				}
+
+				b, err := os.Open(p)
+				if err != nil {
+					return err
+				}
+				defer b.Close()
+
+				blob = b
+			}
+
 			layer, err := NewLayer(blob, mediatype)
 			if err != nil {
 				return err


### PR DESCRIPTION
this change allows certain layers to take files as values. the final value for the layer is the content of the file

```
FROM llama3
LICENSE ./meta-llama/Meta-Llama-3-8B-Instruct/LICENSE
LICENSE ./meta-llama/Meta-Llama-3-8B-Instruct/USE_POLICY.md
```

any value that does not reference a file will use the original value

```
FROM foo
TEMPLATE {{ .System }} {{ .Prompt }}
```

the file value does not support wildcards or globs