### PR TITLE
skip hidden files in list models handler

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -733,6 +733,11 @@ func (s *Server) ListModelsHandler(c *gin.Context) {
 				return err
 			}
 
+			if strings.HasPrefix(filepath.Base(path), ".") {
+				// hidden system files
+				return nil
+			}
+
 			n := model.ParseNameFromFilepath(rel)
 			m, err := ParseNamedManifest(n)
 			if err != nil {

--- a/server/routes.go
+++ b/server/routes.go
@@ -733,12 +733,9 @@ func (s *Server) ListModelsHandler(c *gin.Context) {
 				return err
 			}
 
-			if hidden, err := filepath.Match(".*", filepath.Base(rel); err != nil {
+			if hidden, err := filepath.Match(".*", filepath.Base(rel)); err != nil {
 				return err
 			} else if hidden {
-				return nil
-			}
-				// hidden system files
 				return nil
 			}
 

--- a/server/routes.go
+++ b/server/routes.go
@@ -733,7 +733,11 @@ func (s *Server) ListModelsHandler(c *gin.Context) {
 				return err
 			}
 
-			if strings.HasPrefix(filepath.Base(path), ".") {
+			if hidden, err := filepath.Match(".*", filepath.Base(rel); err != nil {
+				return err
+			} else if hidden {
+				return nil
+			}
 				// hidden system files
 				return nil
 			}


### PR DESCRIPTION
Hidden files on MacOS (ex: `.DS_Store`) cause the list command to file when not skipped:
```
❯ ollama ls
Error: unqualified name: 
```