### PR TITLE
routes: fix show llava models

### DIFF
--- a/server/images.go
+++ b/server/images.go
@@ -68,6 +68,20 @@ func (m *Model) String() string {
 		Args: m.ModelPath,
 	})
 
+	for _, adapter := range m.AdapterPaths {
+		modelfile.Commands = append(modelfile.Commands, model.Command{
+			Name: "adapter",
+			Args: adapter,
+		})
+	}
+
+	for _, projector := range m.ProjectorPaths {
+		modelfile.Commands = append(modelfile.Commands, model.Command{
+			Name: "model",
+			Args: projector,
+		})
+	}
+
 	if m.Template != "" {
 		modelfile.Commands = append(modelfile.Commands, model.Command{
 			Name: "template",
@@ -79,20 +93,6 @@ func (m *Model) String() string {
 		modelfile.Commands = append(modelfile.Commands, model.Command{
 			Name: "system",
 			Args: m.System,
-		})
-	}
-
-	for _, adapter := range m.AdapterPaths {
-		modelfile.Commands = append(modelfile.Commands, model.Command{
-			Name: "adapter",
-			Args: adapter,
-		})
-	}
-
-	for _, projector := range m.ProjectorPaths {
-		modelfile.Commands = append(modelfile.Commands, model.Command{
-			Name: "projector",
-			Args: projector,
 		})
 	}
 


### PR DESCRIPTION
show model file isn't showing the projector because it's set to name `projector` instead of `model`

also change the order so adapters/projectors appear ahead of template/system to group with the language model