### PR TITLE
fix `ollama create`'s usage string

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1050,7 +1050,7 @@ func NewCLI() *cobra.Command {
 		RunE:    CreateHandler,
 	}
 
-	createCmd.Flags().StringP("file", "f", "Modelfile", "Name of the Modelfile (default \"Modelfile\")")
+	createCmd.Flags().StringP("file", "f", "Modelfile", "Name of the Modelfile")
 	createCmd.Flags().StringP("quantize", "q", "", "Quantize model to this level (e.g. q4_0)")
 
 	showCmd := &cobra.Command{


### PR DESCRIPTION
Since `StringP()` automatically adds the initial value, the initial value description for Modelfile was duplicated.
I have fixed this by removing the redundant default value description from the usage.

Before:
```
$ ./ollama create -h
Create a model from a Modelfile

Usage:
  ollama create MODEL [flags]

Flags:
  -f, --file string       Name of the Modelfile (default "Modelfile") (default "Modelfile")
  -h, --help              help for create
  -q, --quantize string   Quantize model to this level (e.g. q4_0)

Environment Variables:
      OLLAMA_HOST        The host:port or base URL of the Ollama server (e.g. http://localhost:11434)
```

After:
```
$ ./ollama create -h
Create a model from a Modelfile

Usage:
  ollama create MODEL [flags]

Flags:
  -f, --file string       Name of the Modelfile (default "Modelfile")
  -h, --help              help for create
  -q, --quantize string   Quantize model to this level (e.g. q4_0)

Environment Variables:
      OLLAMA_HOST        The host:port or base URL of the Ollama server (e.g. http://localhost:11434)
```