### PR TITLE
case sensitive filepaths

### DIFF
--- a/types/model/name.go
+++ b/types/model/name.go
@@ -291,11 +291,9 @@ func (n Name) Filepath() string {
 		panic("illegal attempt to get filepath of invalid name")
 	}
 	return filepath.Join(
-		strings.ToLower(filepath.Join(
-			n.Host,
-			n.Namespace,
-			n.Model,
-		)),
+		n.Host,
+		n.Namespace,
+		n.Model,
 		n.Tag,
 	)
 }

--- a/types/model/name_test.go
+++ b/types/model/name_test.go
@@ -276,9 +276,9 @@ func TestFilepathAllocs(t *testing.T) {
 	allocs := testing.AllocsPerRun(1000, func() {
 		n.Filepath()
 	})
-	var allowedAllocs float64 = 3
+	var allowedAllocs float64 = 1
 	if runtime.GOOS == "windows" {
-		allowedAllocs = 5
+		allowedAllocs = 3
 	}
 	if allocs > allowedAllocs {
 		t.Errorf("allocs = %v; allowed %v", allocs, allowedAllocs)


### PR DESCRIPTION
TODO: filenames can be case sensitive but filepaths should not. however this needs to be backwards compatible. it currently is not so fix the regression first

resolves #4346 