### PR TITLE
Update `LlamaScript` to point to new link from Legacy link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Testcontainers](https://testcontainers.com/modules/ollama/)
 - [Portkey](https://portkey.ai/docs/welcome/integration-guides/ollama)
 - [PromptingTools.jl](https://github.com/svilupp/PromptingTools.jl) with an [example](https://svilupp.github.io/PromptingTools.jl/dev/examples/working_with_ollama)
-- [LlamaScript](https://github.com/WolfTheDeveloper/llamascript)
+- [LlamaScript](https://github.com/Project-Llama/llamascript)
 ### Mobile
 
 - [Enchanted](https://github.com/AugustDev/enchanted)


### PR DESCRIPTION
Still used Legacy link.