### PR TITLE
Allow XDG user directories

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"errors"
 
 	"golang.org/x/crypto/ssh"
 )
@@ -21,6 +22,13 @@ func keyPath() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
+	}
+
+	defaultOllamaPath := filepath.Join(home, ".ollama")
+	dataHome, dataHomeExists := os.LookupEnv("XDG_DATA_HOME")
+
+	if _, err := os.Stat(defaultOllamaPath); errors.Is(err, os.ErrNotExist) && dataHomeExists {
+		return filepath.Join(dataHome, "ollama", defaultPrivateKey), nil
 	}
 
 	return filepath.Join(home, ".ollama", defaultPrivateKey), nil

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -912,8 +912,19 @@ func initializeKeypair() error {
 		return err
 	}
 
-	privKeyPath := filepath.Join(home, ".ollama", "id_ed25519")
-	pubKeyPath := filepath.Join(home, ".ollama", "id_ed25519.pub")
+	defaultOllamaPath := filepath.Join(home, ".ollama")
+	dataHome, dataHomeExists := os.LookupEnv("XDG_DATA_HOME")
+    var privKeyPath string
+	var pubKeyPath  string
+
+	if _, err := os.Stat(defaultOllamaPath); errors.Is(err, os.ErrNotExist) && dataHomeExists {
+		privKeyPath = filepath.Join(dataHome, "id_ed25519")
+		pubKeyPath = filepath.Join(dataHome, "id_ed25519.pub")
+	} else {
+		privKeyPath = filepath.Join(home, ".ollama", "id_ed25519")
+		pubKeyPath = filepath.Join(home, ".ollama", "id_ed25519.pub")
+	}
+
 
 	_, err = os.Stat(privKeyPath)
 	if os.IsNotExist(err) {

--- a/readline/history.go
+++ b/readline/history.go
@@ -42,7 +42,17 @@ func (h *History) Init() error {
 		return err
 	}
 
-	path := filepath.Join(home, ".ollama", "history")
+	var path string
+
+	defaultOllamaPath := filepath.Join(home, ".ollama")
+	dataHome, dataHomeExists := os.LookupEnv("XDG_DATA_HOME")
+
+	if _, err := os.Stat(defaultOllamaPath); errors.Is(err, os.ErrNotExist) && dataHomeExists {
+		path = filepath.Join(dataHome, "ollama", "history")
+	} else {
+		path = filepath.Join(home, ".ollama", "history")
+	}
+
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}

--- a/server/modelpath.go
+++ b/server/modelpath.go
@@ -111,6 +111,13 @@ func modelsDir() (string, error) {
 	if err != nil {
 		return "", err
 	}
+
+	defaultOllamaPath := filepath.Join(home, ".ollama")
+	dataHome, dataHomeExists := os.LookupEnv("XDG_DATA_HOME")
+
+	if _, err := os.Stat(defaultOllamaPath); errors.Is(err, os.ErrNotExist) && dataHomeExists {
+		return filepath.Join(dataHome, "ollama", "models"), nil
+	}
 	return filepath.Join(home, ".ollama", "models"), nil
 }
 


### PR DESCRIPTION
Addresses #228. This is my first time writing go, please feel free to correct any bad code. *

This change defaults to using the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) for the history file and private key files which are currently generated in the `.ollama` directory.
It will still use `.ollama` if it exists (hence shouldn't break current setups), but allows use of `$XDG_DATA_HOME/ollama` instead.

I am unsure if/where these should be moved to, do they also belong in XDG_DATA_HOME?
- https://github.com/ollama/ollama/blob/4ec7445a6f678b6efc773bb9fa886d7c9b075577/app/store/store_linux.go#L15
- https://github.com/ollama/ollama/blob/4ec7445a6f678b6efc773bb9fa886d7c9b075577/macapp/src/index.ts#L27

I'm also unsure if I need to add/change anything here, I'm assuming my changes don't even affect windows, so no?
- https://github.com/ollama/ollama/blob/4ec7445a6f678b6efc773bb9fa886d7c9b075577/app/ollama.iss#L122

I simply searched the repo for ".ollama" to find stuff to change, please let me know if I missed anything.
I have only tested and designed this to work on Linux, let me know if this doesn't work for macOS.

*A styleguide and/or contributing document would be great #2231