### PR TITLE
fix embedding by adding fixes from llama.cpp upstream

### DIFF
--- a/llm/ext_server/server.cpp
+++ b/llm/ext_server/server.cpp
@@ -425,6 +425,7 @@ struct llama_server_context
         n_ctx = llama_n_ctx(ctx);
 
         add_bos_token = llama_should_add_bos_token(model);
+        GGML_ASSERT(llama_add_eos_token(model) != 1);
 
         return true;
     }
@@ -846,7 +847,7 @@ struct llama_server_context
         system_tokens.clear();
 
         if (!system_prompt.empty()) {
-            system_tokens = ::llama_tokenize(ctx, system_prompt, add_bos_token);
+            system_tokens = ::llama_tokenize(ctx, system_prompt, true);
 
             llama_batch_clear(batch);
 
@@ -1721,7 +1722,7 @@ struct llama_server_context
                     }
                     else
                     {
-                        prompt_tokens = tokenize(slot.prompt, system_prompt.empty() && add_bos_token);  // add BOS if there isn't system prompt
+                        prompt_tokens = tokenize(slot.prompt, system_prompt.empty());  // add BOS if there isn't system prompt
                     }
 
                     slot.n_prompt_tokens = prompt_tokens.size();


### PR DESCRIPTION
Embedding appears broken since v0.1.32

See #3777 #4207 for details.

This PR applies fixes based on https://github.com/ggerganov/llama.cpp/commit/1b67731e184e27a465b8c5476061294a4af668ea#diff-87355a1a297a9f0fdc86af5e2a59cae153290f58d68822cd10c30fee4f7f7076.

I've tested it and embedding vectors looks correct after applying this patch.