### PR TITLE
use nvml for gpu info

### DIFF
--- a/gpu/gpu_info.h
+++ b/gpu/gpu_info.h
@@ -62,6 +62,7 @@ void cpu_check_ram(mem_info_t *resp);
 
 #include "gpu_info_cudart.h"
 #include "gpu_info_nvcuda.h"
+#include "gpu_info_nvml.h"
 
 #endif  // __GPU_INFO_H__
 #endif  // __APPLE__

--- a/gpu/gpu_info_nvcuda.h
+++ b/gpu/gpu_info_nvcuda.h
@@ -53,6 +53,10 @@ typedef struct nvcuda_handle {
   CUresult (*cuDeviceGetAttribute)(int* pi, CUdevice_attribute attrib, CUdevice dev);
   CUresult (*cuDeviceGetUuid)(CUuuid* uuid, CUdevice dev); // signature compatible with cuDeviceGetUuid_v2
   CUresult (*cuDeviceGetName)(char *name, int len, CUdevice dev);
+  CUresult (*cuDevicePrimaryCtxRetain)(CUcontext* pctx, CUdevice dev);
+  CUresult (*cuCtxSynchronize)();
+  CUresult (*cuCtxSetCurrent)(CUcontext pctx);
+  CUresult (*cuDevicePrimaryCtxRelease)(CUcontext ctx);
 
   // Context specific aspects
   CUresult (*cuCtxCreate_v3)(CUcontext* pctx, void *params, int len, unsigned int flags, CUdevice dev);

--- a/gpu/gpu_info_nvml.c
+++ b/gpu/gpu_info_nvml.c
@@ -1,0 +1,112 @@
+#ifndef __APPLE__  // TODO - maybe consider nvidia support on intel macs?
+
+#include "gpu_info_nvml.h"
+
+void nvml_init(char *nvml_lib_path, nvml_init_resp_t *resp) {
+    resp->err = NULL;
+    resp->num_devices = 0;
+    const int buflen = 256;
+    char buf[buflen + 1];
+    int i;
+
+    struct lookup {
+        char *s;
+        void **p;
+    } l[] = {
+        {"nvmlInit", (void *)&resp->nh.nvmlInit},
+        {"nvmlShutdown", (void *)&resp->nh.nvmlShutdown},
+        {"nvmlDeviceGetCount", (void *)&resp->nh.nvmlDeviceGetCount},
+        {"nvmlDeviceGetHandleByIndex", (void *)&resp->nh.nvmlDeviceGetHandleByIndex},
+        {"nvmlDeviceGetMemoryInfo", (void *)&resp->nh.nvmlDeviceGetMemoryInfo},
+        {"nvmlDeviceGetCudaComputeCapability", (void *)&resp->nh.nvmlDeviceGetCudaComputeCapability},
+        {"nvmlErrorString", (void *)&resp->nh.nvmlErrorString},
+        {NULL, NULL},
+    };
+
+    resp->nh.handle = LOAD_LIBRARY(nvml_lib_path, RTLD_LAZY);
+    if (!resp->nh.handle) {
+        char *msg = LOAD_ERR();
+        snprintf(buf, buflen, "Unable to load %s library to query for Nvidia GPUs: %s", nvml_lib_path, msg);
+        resp->err = strdup(buf);
+        return;
+    }
+
+    for (i = 0; l[i].s != NULL; i++) {
+        *l[i].p = LOAD_SYMBOL(resp->nh.handle, l[i].s);
+        if (!*l[i].p) {
+            char *msg = LOAD_ERR();
+            UNLOAD_LIBRARY(resp->nh.handle);
+            resp->nh.handle = NULL;
+            snprintf(buf, buflen, "symbol lookup for %s failed: %s", l[i].s, msg);
+            resp->err = strdup(buf);
+            return;
+        }
+    }
+
+    nvmlReturn_t ret = (*resp->nh.nvmlInit)();
+    if (ret != NVML_SUCCESS) {
+        snprintf(buf, buflen, "nvml init failure: %s", (*resp->nh.nvmlErrorString)(ret));
+        resp->err = strdup(buf);
+        return;
+    }
+
+    ret = (*resp->nh.nvmlDeviceGetCount)(&resp->num_devices);
+    if (ret != NVML_SUCCESS) {
+        snprintf(buf, buflen, "unable to get device count: %s", (*resp->nh.nvmlErrorString)(ret));
+        resp->err = strdup(buf);
+        return;
+    }
+}
+
+void nvml_check_vram(nvml_handle_t nh, int device_id, mem_info_t *resp) {
+    resp->err = NULL;
+    nvmlMemory_t memInfo;
+    nvmlReturn_t ret;
+    const int buflen = 256;
+    char buf[buflen + 1];
+
+    if (nh.handle == NULL) {
+        resp->err = strdup("nvml handle isn't initialized");
+        return;
+    }
+
+    nvmlDevice_t device;
+    ret = (*nh.nvmlDeviceGetHandleByIndex)(device_id, &device);
+    if (ret != NVML_SUCCESS) {
+        snprintf(buf, buflen, "nvml device handle by index failed: %s", (*nh.nvmlErrorString)(ret));
+        resp->err = strdup(buf);
+        return;
+    }
+
+    ret = (*nh.nvmlDeviceGetMemoryInfo)(device, &memInfo);
+    if (ret != NVML_SUCCESS) {
+        snprintf(buf, buflen, "nvml device memory info lookup failure: %s", (*nh.nvmlErrorString)(ret));
+        resp->err = strdup(buf);
+        return;
+    }
+
+    resp->total = memInfo.total;
+    resp->free = memInfo.free;
+
+    int major, minor;
+    ret = (*nh.nvmlDeviceGetCudaComputeCapability)(device, &resp->major, &resp->minor);
+    if (ret != NVML_SUCCESS) {
+        snprintf(buf, buflen, "nvml device compute capability lookup failure: %s", (*nh.nvmlErrorString)(ret));
+        resp->err = strdup(buf);
+        return;
+    }
+
+    printf("[Device %u] NVML totalMem %llu\n", device_id, resp->total);
+    printf("[Device %u] NVML freeMem %llu\n", device_id, resp->free);
+    printf("[Device %u] NVML major %d\n", device_id, resp->major);
+    printf("[Device %u] NVML minor %d\n", device_id, resp->minor);
+}
+
+void nvml_release(nvml_handle_t nh) {
+    if (nh.handle != NULL) {
+        (*nh.nvmlShutdown)();
+        UNLOAD_LIBRARY(nh.handle);
+        nh.handle = NULL;
+    }
+}
+#endif  // __APPLE__

--- a/gpu/gpu_info_nvml.h
+++ b/gpu/gpu_info_nvml.h
@@ -1,0 +1,71 @@
+#ifndef __APPLE__
+#ifndef __GPU_INFO_NVML_H__
+#define __GPU_INFO_NVML_H__
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "gpu_info.h"
+
+// NVML types and structures
+typedef int nvmlReturn_t;
+#define NVML_SUCCESS 0
+#define NVML_ERROR_UNINITIALIZED 1
+#define NVML_ERROR_INVALID_ARGUMENT 2
+#define NVML_ERROR_NOT_SUPPORTED 3
+#define NVML_ERROR_NO_PERMISSION 4
+#define NVML_ERROR_ALREADY_INITIALIZED 5
+#define NVML_ERROR_NOT_FOUND 6
+#define NVML_ERROR_INSUFFICIENT_SIZE 7
+#define NVML_ERROR_INSUFFICIENT_POWER 8
+#define NVML_ERROR_DRIVER_NOT_LOADED 9
+#define NVML_ERROR_TIMEOUT 10
+#define NVML_ERROR_IRQ_ISSUE 11
+#define NVML_ERROR_LIBRARY_NOT_FOUND 12
+#define NVML_ERROR_FUNCTION_NOT_FOUND 13
+#define NVML_ERROR_CORRUPTED_INFOROM 14
+#define NVML_ERROR_GPU_IS_LOST 15
+#define NVML_ERROR_RESET_REQUIRED 16
+#define NVML_ERROR_OPERATING_SYSTEM 17
+#define NVML_ERROR_LIB_RM_VERSION_MISMATCH 18
+#define NVML_ERROR_IN_USE 19
+#define NVML_ERROR_MEMORY 20
+#define NVML_ERROR_NO_DATA 21
+#define NVML_ERROR_VGPU_ECC_NOT_SUPPORTED 22
+#define NVML_ERROR_INSUFFICIENT_RESOURCES 23
+#define NVML_ERROR_UNKNOWN 999
+
+typedef void* nvmlDevice_t;
+
+typedef struct nvmlMemory_st {
+    unsigned long long total;
+    unsigned long long free;
+    unsigned long long used;
+    int major;
+    int minor;
+} nvmlMemory_t;
+
+// Just enough typedef's to dlopen/dlsym for memory information
+typedef struct nvml_handle {
+    void *handle;
+    uint16_t verbose;
+    nvmlReturn_t (*nvmlInit)(void);
+    nvmlReturn_t (*nvmlShutdown)(void);
+    nvmlReturn_t (*nvmlDeviceGetCount)(unsigned int *);
+    nvmlReturn_t (*nvmlDeviceGetHandleByIndex)(int, nvmlDevice_t *);
+    nvmlReturn_t (*nvmlDeviceGetMemoryInfo)(nvmlDevice_t, nvmlMemory_t *);
+    nvmlReturn_t (*nvmlDeviceGetCudaComputeCapability)(nvmlDevice_t, int *, int *);
+    nvmlReturn_t (*nvmlErrorString)(nvmlReturn_t);
+} nvml_handle_t;
+
+typedef struct nvml_init_resp {
+    char *err;  // If err is non-null handle is invalid
+    nvml_handle_t nh;
+    unsigned int num_devices;
+} nvml_init_resp_t;
+
+void nvml_init(char *nvml_lib_path, nvml_init_resp_t *resp);
+void nvml_check_vram(nvml_handle_t nh, int device_id, mem_info_t *resp);
+void nvml_release(nvml_handle_t nh);
+
+#endif  // __GPU_INFO_NVML_H__
+#endif  // __APPLE__

--- a/server/sched.go
+++ b/server/sched.go
@@ -499,7 +499,7 @@ func (runner *runnerRef) waitForVRAMRecovery() chan interface{} {
 	}
 	go func() {
 		expiresAt := start.Add(5 * time.Second) // typical convergence is 0.5-1.5s
-		ticker := time.NewTicker(250 * time.Millisecond)
+		ticker := time.NewTicker(100 * time.Millisecond)
 		defer ticker.Stop()
 		for {
 			<-ticker.C


### PR DESCRIPTION
Also decreases period between recovery lookups since memory is freed quickly on graphics cards like the 4090

TODO:
- [ ] Test on Windows 10
- [ ] Test on other Nvidia GPUs
- [ ] Test on Linux
- [ ] Test on WSL2
- [ ] Make sure `nvml.dll` (and equivalent .so) lookup paths are correct (it seems that it will always be in `C:\Windows\System32` on Windows)
- [ ] rocsmi for AMD?