### PR TITLE
add yi-1.5 example to model library

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Here are some example models that can be downloaded:
 | ------------------ | ---------- | ----- | ------------------------------ |
 | Llama 3            | 8B         | 4.7GB | `ollama run llama3`            |
 | Llama 3            | 70B        | 40GB  | `ollama run llama3:70b`        |
+| Yi-1.5             | 34B        | 19GB  | `ollama run yi:34b-v1.5`       |
 | Phi-3              | 3.8B       | 2.3GB | `ollama run phi3`              |
 | Mistral            | 7B         | 4.1GB | `ollama run mistral`           |
 | Neural Chat        | 7B         | 4.1GB | `ollama run neural-chat`       |


### PR DESCRIPTION
We hope the open-source community can be promptly informed that ollama supports the yi-1.5 series. We have updated the list of example models in the README.md. Thank you for your time. @jmorganca 