### PR TITLE
Fixed the API endpoint /api/tags when the model list is empty.

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -725,7 +725,7 @@ func (s *Server) ListModelsHandler(c *gin.Context) {
 		return
 	}
 
-	models := make([]api.ModelResponse, 0)
+	models := []api.ModelResponse{}
 	if err := filepath.Walk(manifests, func(path string, info os.FileInfo, _ error) error {
 		if !info.IsDir() {
 			rel, err := filepath.Rel(manifests, path)

--- a/server/routes.go
+++ b/server/routes.go
@@ -725,7 +725,7 @@ func (s *Server) ListModelsHandler(c *gin.Context) {
 		return
 	}
 
-	var models []api.ModelResponse
+	models := make([]api.ModelResponse, 0)
 	if err := filepath.Walk(manifests, func(path string, info os.FileInfo, _ error) error {
 		if !info.IsDir() {
 			rel, err := filepath.Rel(manifests, path)

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -95,6 +95,7 @@ func Test_Routes(t *testing.T) {
 				err = json.Unmarshal(body, &modelList)
 				assert.Nil(t, err)
 
+				assert.NotNil(t, modelList.Models)
 				assert.Equal(t, 0, len(modelList.Models))
 			},
 		},


### PR DESCRIPTION
## Summary

Fixed an issue with the `/api/tags` endpoint where an empty model list was returning `{models: null}`. The endpoint now returns `{models: []}` when no models are available.