### PR TITLE
changed line display to be calculated with runewidth

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -739,7 +739,7 @@ type displayResponseState struct {
 	wordBuffer string
 }
 
-// using runewidth instead of len (cus length is number of bytes, we wnat display length)
+// using runewidth instead of len (cus length is number of bytes, we want display length)
 func displayResponse(content string, wordWrap bool, state *displayResponseState) {
 	termWidth, _, _ := term.GetSize(int(os.Stdout.Fd()))
 	if wordWrap && termWidth >= 10 {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"github.com/containerd/console"
-
+	"github.com/mattn/go-runewidth"
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh"
@@ -739,12 +739,13 @@ type displayResponseState struct {
 	wordBuffer string
 }
 
+// using runewidth instead of len (cus length is number of bytes, we wnat display length)
 func displayResponse(content string, wordWrap bool, state *displayResponseState) {
 	termWidth, _, _ := term.GetSize(int(os.Stdout.Fd()))
 	if wordWrap && termWidth >= 10 {
 		for _, ch := range content {
-			if state.lineLength+1 > termWidth-5 {
-				if len(state.wordBuffer) > termWidth-10 {
+			if state.lineLength+1 > termWidth - 5 {
+				if runewidth.StringWidth(state.wordBuffer) > termWidth - 10 {
 					fmt.Printf("%s%c", state.wordBuffer, ch)
 					state.wordBuffer = ""
 					state.lineLength = 0
@@ -752,12 +753,18 @@ func displayResponse(content string, wordWrap bool, state *displayResponseState)
 				}
 
 				// backtrack the length of the last word and clear to the end of the line
-				fmt.Printf("\x1b[%dD\x1b[K\n", len(state.wordBuffer))
+				fmt.Printf("\x1b[%dD\x1b[K\n", runewidth.StringWidth(state.wordBuffer))
 				fmt.Printf("%s%c", state.wordBuffer, ch)
-				state.lineLength = len(state.wordBuffer) + 1
+				chWidth := runewidth.RuneWidth(ch)
+
+				state.lineLength = runewidth.StringWidth(state.wordBuffer) + chWidth
 			} else {
 				fmt.Print(string(ch))
-				state.lineLength += 1
+				state.lineLength += runewidth.RuneWidth(ch)
+				if runewidth.RuneWidth(ch) >= 2 {
+					state.wordBuffer = ""
+					continue
+				}	
 
 				switch ch {
 				case ' ':

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -739,7 +739,6 @@ type displayResponseState struct {
 	wordBuffer string
 }
 
-// using runewidth instead of len (cus length is number of bytes, we want display length)
 func displayResponse(content string, wordWrap bool, state *displayResponseState) {
 	termWidth, _, _ := term.GetSize(int(os.Stdout.Fd()))
 	if wordWrap && termWidth >= 10 {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -744,9 +744,9 @@ func displayResponse(content string, wordWrap bool, state *displayResponseState)
 	termWidth, _, _ := term.GetSize(int(os.Stdout.Fd()))
 	if wordWrap && termWidth >= 10 {
 		for _, ch := range content {
-			if state.lineLength+1 > termWidth - 5 {
+			if state.lineLength+1 > termWidth-5 {
 
-				if runewidth.StringWidth(state.wordBuffer) > termWidth - 10 {
+				if runewidth.StringWidth(state.wordBuffer) > termWidth-10 {
 					fmt.Printf("%s%c", state.wordBuffer, ch)
 					state.wordBuffer = ""
 					state.lineLength = 0
@@ -765,7 +765,7 @@ func displayResponse(content string, wordWrap bool, state *displayResponseState)
 				if runewidth.RuneWidth(ch) >= 2 {
 					state.wordBuffer = ""
 					continue
-				}	
+				}
 
 				switch ch {
 				case ' ':

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -745,6 +745,7 @@ func displayResponse(content string, wordWrap bool, state *displayResponseState)
 	if wordWrap && termWidth >= 10 {
 		for _, ch := range content {
 			if state.lineLength+1 > termWidth - 5 {
+
 				if runewidth.StringWidth(state.wordBuffer) > termWidth - 10 {
 					fmt.Printf("%s%c", state.wordBuffer, ch)
 					state.wordBuffer = ""


### PR DESCRIPTION
Calculates line length using `runewidth` instead of `len(string)` as `len(string)` produces the number of bytes in that string (often resulting in an incorrect calculation of display length for multi-width runes). Now cuts lines accordingly for multi-byte characters (Russian, latin, etc) as well as word-wraps for multi-width characters (Chinese, Japanese, Korean)

Old Russian: 
<img width="560" alt="Screenshot 2024-05-15 at 5 05 42 PM" src="https://github.com/ollama/ollama/assets/76125168/50bda24b-7fff-4cc9-8e85-6f1b4f006a65">

New: Russian
<img width="555" alt="Screenshot 2024-05-15 at 5 01 21 PM" src="https://github.com/ollama/ollama/assets/76125168/a664d1f0-c321-4993-bad7-2c2e066e6a10">

Old: Chinese
<img width="576" alt="Screenshot 2024-05-15 at 5 10 09 PM" src="https://github.com/ollama/ollama/assets/76125168/5d47f924-9467-4f3b-ba1d-515072f875f3">

New: Chinese
<img width="572" alt="Screenshot 2024-05-15 at 5 15 12 PM" src="https://github.com/ollama/ollama/assets/76125168/275e39dd-c89f-4545-9323-0aba1c8060e2">

