### PR TITLE
Add an Open-Source Laravel PHP System

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Ollama RAG Chatbot](https://github.com/datvodinh/rag-chatbot.git) (Local Chat with multiple PDFs using Ollama and RAG)
 - [BrainSoup](https://www.nurgo-software.com/products/brainsoup) (Flexible native client with RAG & multi-agent automation)
 - [macai](https://github.com/Renset/macai) (macOS client for Ollama, ChatGPT, and other compatible API back-ends)
+- [LaraLamma - Laravel Ollama RAG System](https://laralamma-docs.readthedocs.io/en/latest/overview.html)
 
 ### Terminal
 


### PR DESCRIPTION
Would like to add - [LaraLamma - Laravel Ollama RAG System](https://laralamma-docs.readthedocs.io/en/latest/overview.html) Which attempts to make it easy to use Laravel and any LLM as a RAG system. Especially Ollama since it can be run locally.