### PR TITLE
implement tunable registry defaults for registry and update mirrors

### DIFF
--- a/app/lifecycle/updater.go
+++ b/app/lifecycle/updater.go
@@ -19,11 +19,11 @@ import (
 	"time"
 
 	"github.com/ollama/ollama/auth"
+	"github.com/ollama/ollama/types/defaults"
 	"github.com/ollama/ollama/version"
 )
 
 var (
-	UpdateCheckURLBase  = "https://ollama.com/api/update"
 	UpdateDownloaded    = false
 	UpdateCheckInterval = 60 * 60 * time.Second
 )
@@ -37,7 +37,7 @@ type UpdateResponse struct {
 func IsNewReleaseAvailable(ctx context.Context) (bool, UpdateResponse) {
 	var updateResp UpdateResponse
 
-	requestURL, err := url.Parse(UpdateCheckURLBase)
+	requestURL, err := url.Parse(defaults.UPDATE_CHECK_ENDPOINT)
 	if err != nil {
 		return false, updateResp
 	}

--- a/server/modelpath.go
+++ b/server/modelpath.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/ollama/ollama/types/defaults"
 )
 
 type ModelPath struct {
@@ -18,13 +20,6 @@ type ModelPath struct {
 	Tag            string
 }
 
-const (
-	DefaultRegistry       = "registry.ollama.ai"
-	DefaultNamespace      = "library"
-	DefaultTag            = "latest"
-	DefaultProtocolScheme = "https"
-)
-
 var (
 	ErrInvalidImageFormat  = errors.New("invalid image format")
 	ErrInvalidProtocol     = errors.New("invalid protocol scheme")
@@ -34,11 +29,11 @@ var (
 
 func ParseModelPath(name string) ModelPath {
 	mp := ModelPath{
-		ProtocolScheme: DefaultProtocolScheme,
-		Registry:       DefaultRegistry,
-		Namespace:      DefaultNamespace,
+		ProtocolScheme: defaults.REGISTRY_PROTOCOL_SCHEME,
+		Registry:       defaults.REGISTRY_ENDPOINT,
+		Namespace:      defaults.REGISTRY_NAMESPACE,
 		Repository:     "",
-		Tag:            DefaultTag,
+		Tag:            defaults.REGISTRY_TAG,
 	}
 
 	before, after, found := strings.Cut(name, "://")
@@ -92,8 +87,8 @@ func (mp ModelPath) GetFullTagname() string {
 }
 
 func (mp ModelPath) GetShortTagname() string {
-	if mp.Registry == DefaultRegistry {
-		if mp.Namespace == DefaultNamespace {
+	if mp.Registry == defaults.REGISTRY_ENDPOINT {
+		if mp.Namespace == defaults.REGISTRY_NAMESPACE {
 			return fmt.Sprintf("%s:%s", mp.Repository, mp.Tag)
 		}
 		return fmt.Sprintf("%s/%s:%s", mp.Namespace, mp.Repository, mp.Tag)

--- a/server/modelpath_test.go
+++ b/server/modelpath_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/ollama/ollama/types/defaults"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -113,7 +114,7 @@ func TestParseModelPath(t *testing.T) {
 			"ns/repo:tag",
 			ModelPath{
 				ProtocolScheme: "https",
-				Registry:       DefaultRegistry,
+				Registry:       defaults.REGISTRY_ENDPOINT,
 				Namespace:      "ns",
 				Repository:     "repo",
 				Tag:            "tag",
@@ -124,8 +125,8 @@ func TestParseModelPath(t *testing.T) {
 			"repo:tag",
 			ModelPath{
 				ProtocolScheme: "https",
-				Registry:       DefaultRegistry,
-				Namespace:      DefaultNamespace,
+				Registry:       defaults.REGISTRY_ENDPOINT,
+				Namespace:      defaults.REGISTRY_NAMESPACE,
 				Repository:     "repo",
 				Tag:            "tag",
 			},
@@ -135,10 +136,10 @@ func TestParseModelPath(t *testing.T) {
 			"repo",
 			ModelPath{
 				ProtocolScheme: "https",
-				Registry:       DefaultRegistry,
-				Namespace:      DefaultNamespace,
+				Registry:       defaults.REGISTRY_ENDPOINT,
+				Namespace:      defaults.REGISTRY_NAMESPACE,
 				Repository:     "repo",
-				Tag:            DefaultTag,
+				Tag:            defaults.REGISTRY_TAG,
 			},
 		},
 	}

--- a/types/defaults/environment_variables.go
+++ b/types/defaults/environment_variables.go
@@ -20,14 +20,18 @@ const (
 // such as a password.
 func setFromEnvString(name string, dest *string, sensitive bool) bool {
 	if value := os.Getenv(name); value != "" {
-		// store the environment variable name to place in the logging details
-		debug_info := []string{"evironment_varialbe_name", name}
-		// store info about the value change if it is not sensitive information
-		if !sensitive {
-			debug_info = append(debug_info, "new_value", value, "old_value", *dest)
+		// handle debugging output for sensitive values
+		if sensitive {
+			// log only the environment variable name in the debug message
+			slog.Debug("setFromEnvString", "evironment_varialbe_name", name)
+
+			// set the value and return true to indicate the mutation happened
+			*dest = value
+			return true
 		}
-		// only log at the debug level
-		slog.Debug("setFromEnvString", debug_info)
+
+		// log all the details in the debug message
+		slog.Debug("setFromEnvString", "evironment_varialbe_name", name, "new_value", value, "old_value", *dest)
 
 		// set the value and return true to indicate the mutation happened
 		*dest = value

--- a/types/defaults/environment_variables.go
+++ b/types/defaults/environment_variables.go
@@ -1,0 +1,39 @@
+package defaults
+
+import (
+	"log/slog"
+	"os"
+)
+
+const (
+	ENV_OLLAMA_DEFAULT_REGISTRY_ENDPOINT = "OLLAMA_DEFAULT_REGISTRY_ENDPOINT"
+	ENV_OLLAMA_DEFAULT_NAMESPACE         = "OLLAMA_DEFAULT_NAMESPACE"
+	ENV_OLLAMA_DEFAULT_PROTOCOL_SCHEME   = "OLLAMA_DEFAULT_PROTOCOL_SCHEME"
+	ENV_OLLAMA_DEFAULT_TAG               = "OLLAMA_DEFAULT_TAG"
+	ENV_OLLAMA_UPDATE_CHECK_ENDPOINT     = "OLLAMA_UPDATE_CHECK_ENDPOINT"
+)
+
+// setFromEnvString searches for a environment variable by name. If the value is
+// not empty, setFromEnvString will update the destination variable to the value
+// found. When the logging level is that of "debug", it will log anytime changes
+// are made. Set the sensitive value to true if the value is secure material,
+// such as a password.
+func setFromEnvString(name string, dest *string, sensitive bool) bool {
+	if value := os.Getenv(name); value != "" {
+		// store the environment variable name to place in the logging details
+		debug_info := []string{"evironment_varialbe_name", name}
+		// store info about the value change if it is not sensitive information
+		if !sensitive {
+			debug_info = append(debug_info, "new_value", value, "old_value", *dest)
+		}
+		// only log at the debug level
+		slog.Debug("setFromEnvString", debug_info)
+
+		// set the value and return true to indicate the mutation happened
+		*dest = value
+		return true
+	}
+
+	// return false to indicate no mutation happened
+	return false
+}

--- a/types/defaults/registries.go
+++ b/types/defaults/registries.go
@@ -1,0 +1,15 @@
+package defaults
+
+var (
+	REGISTRY_ENDPOINT        = "registry.ollama.ai"
+	REGISTRY_NAMESPACE       = "library"
+	REGISTRY_TAG             = "latest"
+	REGISTRY_PROTOCOL_SCHEME = "https"
+)
+
+func init() {
+	setFromEnvString(ENV_OLLAMA_DEFAULT_REGISTRY_ENDPOINT, &REGISTRY_ENDPOINT, false)
+	setFromEnvString(ENV_OLLAMA_DEFAULT_NAMESPACE, &REGISTRY_NAMESPACE, false)
+	setFromEnvString(ENV_OLLAMA_DEFAULT_PROTOCOL_SCHEME, &REGISTRY_TAG, false)
+	setFromEnvString(ENV_OLLAMA_DEFAULT_TAG, &REGISTRY_PROTOCOL_SCHEME, false)
+}

--- a/types/defaults/updates.go
+++ b/types/defaults/updates.go
@@ -1,0 +1,9 @@
+package defaults
+
+var (
+	UPDATE_CHECK_ENDPOINT = "https://ollama.com/api/update"
+)
+
+func init() {
+	setFromEnvString(ENV_OLLAMA_UPDATE_CHECK_ENDPOINT, &UPDATE_CHECK_ENDPOINT, false)
+}

--- a/types/model/name.go
+++ b/types/model/name.go
@@ -10,6 +10,8 @@ import (
 	"log/slog"
 	"path/filepath"
 	"strings"
+
+	"github.com/ollama/ollama/types/defaults"
 )
 
 // Errors
@@ -35,12 +37,6 @@ func Unqualified(n Name) error {
 // spot in logs.
 const MissingPart = "!MISSING!"
 
-const (
-	defaultHost      = "registry.ollama.ai"
-	defaultNamespace = "library"
-	defaultTag       = "latest"
-)
-
 // DefaultName returns a name with the default values for the host, namespace,
 // and tag parts. The model and digest parts are empty.
 //
@@ -49,9 +45,9 @@ const (
 //   - The default tag is ("latest")
 func DefaultName() Name {
 	return Name{
-		Host:      defaultHost,
-		Namespace: defaultNamespace,
-		Tag:       defaultTag,
+		Host:      defaults.REGISTRY_ENDPOINT,
+		Namespace: defaults.REGISTRY_NAMESPACE,
+		Tag:       defaults.REGISTRY_TAG,
 	}
 }
 
@@ -234,12 +230,12 @@ func (n Name) String() string {
 func (n Name) DisplayShortest() string {
 	var sb strings.Builder
 
-	if n.Host != defaultHost {
+	if n.Host != defaults.REGISTRY_ENDPOINT {
 		sb.WriteString(n.Host)
 		sb.WriteByte('/')
 		sb.WriteString(n.Namespace)
 		sb.WriteByte('/')
-	} else if n.Namespace != defaultNamespace {
+	} else if n.Namespace != defaults.REGISTRY_NAMESPACE {
 		sb.WriteString(n.Namespace)
 		sb.WriteByte('/')
 	}


### PR DESCRIPTION
# What is the problem this change solves?
In large environments with many cloud instances are running `ollama serve`, accidentally pushing code to run `ollama pull llama3` can result in 100's of cloud instances are trying to download from `ollama.ai`. 

The correct change for production should have been `ollama pull https://registry.prod.someside.tld/library/llama3`. The registry mirror at `registry.prod.someside.tld` is necessary to reduce bandwidth costs for high volume data, like an AI model or container image.

Mistakes like this can go unnoticed by novices building scalable infrastructure for their developers, until they get the resulting bill.

Also registry owners often have to implement rate limiting to keep bandwidth costs down. Hitting a rate limit in a production environment often results in an outage. Further making convenient mirroring options desirable.

# What are the changes being made?
- Created a new package called `defaults` to hold tunable values.
- Moved variables related to endpoints to a single package called `github.com/ollama/ollama/types/defaults`
- Exposes control to admins via environment variables.

# Are there any tasks remaining?
I need some guidance on how testing should work for these changes.