### PR TITLE
Correct typo in error message

### DIFF
--- a/server/sched.go
+++ b/server/sched.go
@@ -220,7 +220,7 @@ func (s *Scheduler) processCompleted(ctx context.Context) {
 			runner := s.loaded[finished.model.ModelPath]
 			s.loadedMu.Unlock()
 			if runner == nil {
-				slog.Error("finished requeset signal received after model unloaded", "modelPath", finished.model.ModelPath)
+				slog.Error("finished request signal received after model unloaded", "modelPath", finished.model.ModelPath)
 				continue
 			}
 			runner.refMu.Lock()


### PR DESCRIPTION
The spelling of the term "request" has been corrected, which was previously mistakenly written as "requeset" in the error log message.