### PR TITLE
added new community integration (headless-ollama)

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [AI ST Completion](https://github.com/yaroslavyaroslav/OpenAI-sublime-text) (Sublime Text 4 AI assistant plugin with Ollama support)
 - [Discord-Ollama Chat Bot](https://github.com/kevinthedang/discord-ollama) (Generalized TypeScript Discord Bot w/ Tuning Documentation)
 - [Discord AI chat/moderation bot](https://github.com/rapmd73/Companion) Chat/moderation bot written in python. Uses Ollama to create personalities.
+- [Headless Ollama](https://github.com/nischalj10/headless-ollama) (Scripts to automatically install ollama client & models on any OS for apps that depends on ollama server)
 
 ### Supported backends 
 - [llama.cpp](https://github.com/ggerganov/llama.cpp) project founded by Georgi Gerganov.


### PR DESCRIPTION
ollama makes it wonderfully easy to build desktop apps that rely on local LLMs with its js and python libraries.

> however, the user's system needs to have ollama already installed for the desktop app to use the libraries and make calls to the LLMs. Making users install ollama client separately isn't good UX tbh. thus, "headless-ollama"

this repo has pre-run scripts which automatically utilises node runtime to check for the host OS and installs the ollama client and the models needed by the desktop app before the server starts.

this is really helpful while building desktop apps where you want everything to be local and self contained within the system.