### PR TITLE
Allow https with insecure flag

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -251,6 +251,7 @@ type CopyRequest struct {
 type PullRequest struct {
 	Model    string `json:"model"`
 	Insecure bool   `json:"insecure,omitempty"`
+	HTTP     bool   `json:"http,omitempty"`
 	Username string `json:"username"`
 	Password string `json:"password"`
 	Stream   *bool  `json:"stream,omitempty"`
@@ -272,6 +273,7 @@ type ProgressResponse struct {
 type PushRequest struct {
 	Model    string `json:"model"`
 	Insecure bool   `json:"insecure,omitempty"`
+	HTTP     bool   `json:"http,omitempty"`
 	Username string `json:"username"`
 	Password string `json:"password"`
 	Stream   *bool  `json:"stream,omitempty"`

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -419,6 +419,10 @@ func PushHandler(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	useHttp, err := cmd.Flags().GetBool("http")
+	if err != nil {
+		return err
+	}
 
 	p := progress.NewProgress(os.Stderr)
 	defer p.Stop()
@@ -454,7 +458,7 @@ func PushHandler(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	request := api.PushRequest{Name: args[0], Insecure: insecure}
+	request := api.PushRequest{Name: args[0], Insecure: insecure, HTTP: useHttp}
 	if err := client.Push(cmd.Context(), &request, fn); err != nil {
 		if spinner != nil {
 			spinner.Stop()
@@ -669,6 +673,10 @@ func PullHandler(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	useHttp, err := cmd.Flags().GetBool("http")
+	if err != nil {
+		return err
+	}
 
 	client, err := api.ClientFromEnvironment()
 	if err != nil {
@@ -710,7 +718,7 @@ func PullHandler(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	request := api.PullRequest{Name: args[0], Insecure: insecure}
+	request := api.PullRequest{Name: args[0], Insecure: insecure, HTTP: useHttp}
 	if err := client.Pull(cmd.Context(), &request, fn); err != nil {
 		return err
 	}
@@ -1162,7 +1170,8 @@ func NewCLI() *cobra.Command {
 
 	runCmd.Flags().String("keepalive", "", "Duration to keep a model loaded (e.g. 5m)")
 	runCmd.Flags().Bool("verbose", false, "Show timings for response")
-	runCmd.Flags().Bool("insecure", false, "Use an insecure registry")
+	runCmd.Flags().Bool("insecure", false, "Do not verify registry TLS")
+	runCmd.Flags().Bool("http", false, "Use an http registry instead of https")
 	runCmd.Flags().Bool("nowordwrap", false, "Don't wrap words to the next line automatically")
 	runCmd.Flags().String("format", "", "Response format (e.g. json)")
 	serveCmd := &cobra.Command{
@@ -1190,7 +1199,8 @@ Environment Variables:
 		RunE:    PullHandler,
 	}
 
-	pullCmd.Flags().Bool("insecure", false, "Use an insecure registry")
+	pullCmd.Flags().Bool("insecure", false, "Do not verify registry TLS")
+	pullCmd.Flags().Bool("http", false, "Use an http registry instead of https")
 
 	pushCmd := &cobra.Command{
 		Use:     "push MODEL",
@@ -1200,7 +1210,8 @@ Environment Variables:
 		RunE:    PushHandler,
 	}
 
-	pushCmd.Flags().Bool("insecure", false, "Use an insecure registry")
+	pushCmd.Flags().Bool("insecure", false, "Do not verify registry TLS")
+	pushCmd.Flags().Bool("http", false, "Use an http registry instead of https")
 
 	listCmd := &cobra.Command{
 		Use:     "list",

--- a/server/images.go
+++ b/server/images.go
@@ -5,6 +5,7 @@ import (
 	"cmp"
 	"context"
 	"crypto/sha256"
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -1072,9 +1073,13 @@ func makeRequestWithRetry(ctx context.Context, method string, requestURL *url.UR
 }
 
 func makeRequest(ctx context.Context, method string, requestURL *url.URL, headers http.Header, body io.Reader, regOpts *registryOptions) (*http.Response, error) {
-	if requestURL.Scheme != "http" && regOpts != nil && regOpts.Insecure {
-		requestURL.Scheme = "http"
+	tr := http.DefaultTransport
+	if regOpts != nil && regOpts.Insecure {
+		tr = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
 	}
+	client := &http.Client{Transport: tr}
 
 	req, err := http.NewRequestWithContext(ctx, method, requestURL.String(), body)
 	if err != nil {
@@ -1104,7 +1109,7 @@ func makeRequest(ctx context.Context, method string, requestURL *url.URL, header
 		req.ContentLength = contentLength
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/server/images.go
+++ b/server/images.go
@@ -37,6 +37,7 @@ import (
 
 type registryOptions struct {
 	Insecure bool
+	HTTP     bool
 	Username string
 	Password string
 	Token    string
@@ -807,8 +808,8 @@ func PushModel(ctx context.Context, name string, regOpts *registryOptions, fn fu
 	mp := ParseModelPath(name)
 	fn(api.ProgressResponse{Status: "retrieving manifest"})
 
-	if mp.ProtocolScheme == "http" && !regOpts.Insecure {
-		return fmt.Errorf("insecure protocol http")
+	if regOpts.HTTP {
+		mp.ProtocolScheme = "http"
 	}
 
 	manifest, _, err := GetManifest(mp)
@@ -874,8 +875,8 @@ func PullModel(ctx context.Context, name string, regOpts *registryOptions, fn fu
 		}
 	}
 
-	if mp.ProtocolScheme == "http" && !regOpts.Insecure {
-		return fmt.Errorf("insecure protocol http")
+	if regOpts.HTTP {
+		mp.ProtocolScheme = "http"
 	}
 
 	fn(api.ProgressResponse{Status: "pulling manifest"})
@@ -1078,6 +1079,9 @@ func makeRequest(ctx context.Context, method string, requestURL *url.URL, header
 		tr = &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		}
+	}
+	if regOpts.HTTP {
+		requestURL.Scheme = "http"
 	}
 	client := &http.Client{Transport: tr}
 

--- a/server/routes.go
+++ b/server/routes.go
@@ -440,6 +440,7 @@ func (s *Server) PullModelHandler(c *gin.Context) {
 
 		regOpts := &registryOptions{
 			Insecure: req.Insecure,
+			HTTP:     req.HTTP,
 		}
 
 		ctx, cancel := context.WithCancel(c.Request.Context())
@@ -489,6 +490,7 @@ func (s *Server) PushModelHandler(c *gin.Context) {
 
 		regOpts := &registryOptions{
 			Insecure: req.Insecure,
+			HTTP:     req.HTTP,
 		}
 
 		ctx, cancel := context.WithCancel(c.Request.Context())


### PR DESCRIPTION
The insecure flag now disables TLS verification on https requests

Fixes #2622 