### PR TITLE
Fix download retry issue

### DIFF
--- a/server/download.go
+++ b/server/download.go
@@ -221,7 +221,7 @@ func (b *blobDownload) downloadChunk(ctx context.Context, requestURL *url.URL, w
 		}
 		defer resp.Body.Close()
 
-		n, err := io.CopyN(w, io.TeeReader(resp.Body, part), part.Size)
+		n, err := io.CopyN(w, io.TeeReader(resp.Body, part), part.Size-part.Completed)
 		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, io.ErrUnexpectedEOF) {
 			// rollback progress
 			b.Completed.Add(-n)


### PR DESCRIPTION
Partial downloaded chunks currently resume incorrectly as the code tries to always download the full size of the chunk rather than the remaining size.

Fixes #4520