### PR TITLE
server/download.go: Fix downloading with too much EOF error

### DIFF
--- a/server/download.go
+++ b/server/download.go
@@ -26,6 +26,7 @@ import (
 )
 
 const maxRetries = 6
+const downloadTimeout = 5
 
 var errMaxRetriesExceeded = errors.New("max retries exceeded")
 var errPartStalled = errors.New("part stalled")
@@ -246,7 +247,7 @@ func (b *blobDownload) downloadChunk(ctx context.Context, requestURL *url.URL, w
 					return nil
 				}
 
-				if !part.lastUpdated.IsZero() && time.Since(part.lastUpdated) > 5*time.Second {
+				if !part.lastUpdated.IsZero() && time.Since(part.lastUpdated) > downloadTimeout*time.Second {
 					const msg = "%s part %d stalled; retrying. If this persists, press ctrl-c to exit, then 'ollama pull' to find a faster connection."
 					slog.Info(fmt.Sprintf(msg, b.Digest[7:19], part.N))
 					// reset last updated

--- a/server/download.go
+++ b/server/download.go
@@ -222,7 +222,7 @@ func (b *blobDownload) downloadChunk(ctx context.Context, requestURL *url.URL, w
 		defer resp.Body.Close()
 
 		n, err := io.CopyN(w, io.TeeReader(resp.Body, part), part.Size-part.Completed)
-		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, io.ErrUnexpectedEOF) {
+		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, io.ErrUnexpectedEOF) && !errors.Is(err, io.EOF) {
 			// rollback progress
 			b.Completed.Add(-n)
 			return err


### PR DESCRIPTION
 PR #4436 use `io.CopyN` instead of `io.Copy`, `CopyN` will return `io.EOF` if src stop early, please refer to:
  https://cs.opensource.google/go/go/+/refs/tags/go1.22.3:src/io/io.go;l=370
```
func CopyN(dst Writer, src Reader, n int64) (written int64, err error) {
	written, err = Copy(dst, LimitReader(src, n))
	if written == n {
		return n, nil
	}
	if written < n && err == nil {
		// src stopped early; must have been EOF.
		err = EOF
	}
	return
}
```
   Too much `io.EOF` make the download exceed the max tries easily. #4619 fix some of this issue, this is a follow up fix.
