### PR TITLE
Report better warning on client closed abort of load

### DIFF
--- a/llm/server.go
+++ b/llm/server.go
@@ -528,7 +528,7 @@ func (s *llmServer) WaitUntilRunning(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			slog.Info("context expired before server started")
+			slog.Warn("client connection closed before server finished loading, aborting load")
 			return fmt.Errorf("timed out waiting for llama runner to start: %w", ctx.Err())
 		case err := <-s.done:
 			msg := ""


### PR DESCRIPTION
If the client closes the connection before we finish loading the model we abort, so lets make the log message clearer why to help users understand this failure mode