### PR TITLE
Ensure `nvidia` and `nvidia_uvm` kernel modules are loaded in `install.sh` script and at startup

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -283,11 +283,6 @@ if ! lsmod | grep -q nvidia; then
     if [ -n "$NVIDIA_CUDA_VERSION" ]; then
         $SUDO dkms install $NVIDIA_CUDA_VERSION
     fi
-
-    if lsmod | grep -q nouveau; then
-        status 'Reboot to complete NVIDIA CUDA driver install.'
-        exit 0
-    fi
 fi
 
 $SUDO modprobe nvidia
@@ -302,6 +297,11 @@ if command -v nvidia-persistenced > /dev/null 2>&1; then
             echo "$MODULE" | sudo tee -a /etc/modules-load.d/nvidia.conf > /dev/null
         fi
     done
+fi
+
+if lsmod | grep -q nouveau; then
+    status 'Reboot to complete NVIDIA CUDA driver install.'
+    exit 0
 fi
 
 status "NVIDIA GPU ready."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -298,9 +298,9 @@ if command -v nvidia-persistenced > /dev/null 2>&1; then
     sudo touch /etc/modules-load.d/nvidia.conf
     MODULES="nvidia nvidia-uvm"
     for MODULE in $MODULES; do
-    if ! grep -qxF "$MODULE" /etc/modules-load.d/nvidia.conf; then
-        echo "$MODULE" | sudo tee -a /etc/modules-load.d/nvidia.conf > /dev/null
-    fi
+        if ! grep -qxF "$MODULE" /etc/modules-load.d/nvidia.conf; then
+            echo "$MODULE" | sudo tee -a /etc/modules-load.d/nvidia.conf > /dev/null
+        fi
     done
 fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -176,7 +176,7 @@ if check_gpu lspci amdgpu || check_gpu lshw amdgpu; then
     curl --fail --show-error --location --progress-bar "https://ollama.com/download/ollama-linux-amd64-rocm.tgz${VER_PARAM}" \
         | $SUDO tar zx --owner ollama --group ollama -C /usr/share/ollama/lib/rocm .
     install_success
-    status "AMD GPU dependencies installed."
+    status "AMD GPU ready."
     exit 0
 fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -295,7 +295,7 @@ $SUDO modprobe nvidia_uvm
 
 # make sure the NVIDIA modules are loaded on boot with nvidia-persistenced
 if command -v nvidia-persistenced > /dev/null 2>&1; then
-    sudo touch /etc/modules-load.d/nvidia.conf
+    $SUDO touch /etc/modules-load.d/nvidia.conf
     MODULES="nvidia nvidia-uvm"
     for MODULE in $MODULES; do
         if ! grep -qxF "$MODULE" /etc/modules-load.d/nvidia.conf; then


### PR DESCRIPTION
Make sure the `nvidia` and `nvidia_uvm` kernel modules are loaded on install.

Nvidia has a daemon that takes care of that `nvidia-persistenced` for restarts, so add both to its config file as well

Lastly, make sure the kernel modules are loaded when re-running the install script, even if drivers are already installed.

Fixes https://github.com/ollama/ollama/issues/4563