### PR TITLE
small fix in chatbot example to get stream of tokens

### DIFF
--- a/examples/python-simplechat/client.py
+++ b/examples/python-simplechat/client.py
@@ -9,6 +9,7 @@ def chat(messages):
     r = requests.post(
         "http://0.0.0.0:11434/api/chat",
         json={"model": model, "messages": messages, "stream": True},
+	stream=True
     )
     r.raise_for_status()
     output = ""


### PR DESCRIPTION
It seems like without this line it is not getting the answer as a stream and we have to wait for the whole output to be generated before printing it.