### PR TITLE
Added messages confirming arm64 support (NEON and SVE)

### DIFF
--- a/gpu/cpu_common.go
+++ b/gpu/cpu_common.go
@@ -7,6 +7,7 @@ import (
 )
 
 func GetCPUVariant() string {
+	// Check for x86 features
 	if cpu.X86.HasAVX2 {
 		slog.Debug("CPU has AVX2")
 		return "avx2"
@@ -15,7 +16,18 @@ func GetCPUVariant() string {
 		slog.Debug("CPU has AVX")
 		return "avx"
 	}
-	slog.Debug("CPU does not have vector extensions")
+
+	// Check for ARM64 features
+	if cpu.ARM64.HasASIMD {
+		slog.Debug("CPU has NEON (ASIMD)")
+		return "asimd"
+	}
+	if cpu.ARM64.HasSVE {
+		slog.Debug("CPU has SVE")
+		return "sve"
+	}
+
+	slog.Debug("CPU does not have recognized vector extensions")
 	// else LCD
 	return ""
 }


### PR DESCRIPTION
Added messages confirming arm64 support (NEON and SVE) to along with AVX messages in gpu/cpu_common.go. Currently, only AVX is checked but that doesn't apply to arm64 builds and the default message `CPU does not have vector extensions` is displayed even though that isn't correct for builds on arm64.   