### PR TITLE
Remove False Time Fields

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -289,11 +289,11 @@ type ListResponse struct {
 type ModelResponse struct {
 	Name       string       `json:"name"`
 	Model      string       `json:"model"`
-	ModifiedAt time.Time    `json:"modified_at,omitempty"`
+	ModifiedAt *time.Time   `json:"modified_at,omitempty"`
 	Size       int64        `json:"size"`
 	Digest     string       `json:"digest"`
 	Details    ModelDetails `json:"details,omitempty"`
-	ExpiresAt  time.Time    `json:"expires_at,omitempty"`
+	ExpiresAt  *time.Time   `json:"expires_at,omitempty"`
 	SizeVRAM   int64        `json:"size_vram,omitempty"`
 }
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -493,7 +493,7 @@ func ListHandler(cmd *cobra.Command, args []string) error {
 
 	for _, m := range models.Models {
 		if len(args) == 0 || strings.HasPrefix(m.Name, args[0]) {
-			data = append(data, []string{m.Name, m.Digest[:12], format.HumanBytes(m.Size), format.HumanTime(m.ModifiedAt, "Never")})
+			data = append(data, []string{m.Name, m.Digest[:12], format.HumanBytes(m.Size), format.HumanTime(*m.ModifiedAt, "Never")})
 		}
 	}
 
@@ -539,7 +539,7 @@ func ListRunningHandler(cmd *cobra.Command, args []string) error {
 				cpuPercent := math.Round(float64(sizeCPU) / float64(m.Size) * 100)
 				procStr = fmt.Sprintf("%d%%/%d%% CPU/GPU", int(cpuPercent), int(100-cpuPercent))
 			}
-			data = append(data, []string{m.Name, m.Digest[:12], format.HumanBytes(m.Size), procStr, format.HumanTime(m.ExpiresAt, "Never")})
+			data = append(data, []string{m.Name, m.Digest[:12], format.HumanBytes(m.Size), procStr, format.HumanTime(*m.ExpiresAt, "Never")})
 		}
 	}
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -12,6 +12,7 @@
 - [Pull a Model](#pull-a-model)
 - [Push a Model](#push-a-model)
 - [Generate Embeddings](#generate-embeddings)
+- [List Running Models](#list-running-models)
 
 ## Conventions
 
@@ -1032,6 +1033,51 @@ curl http://localhost:11434/api/embeddings -d '{
   "embedding": [
     0.5670403838157654, 0.009260174818336964, 0.23178744316101074, -0.2916173040866852, -0.8924556970596313,
     0.8785552978515625, -0.34576427936553955, 0.5742510557174683, -0.04222835972905159, -0.137906014919281
+  ]
+}
+```
+
+## List Running Models
+```shell
+GET /api/ps
+```
+
+List models that are currently loaded into memory.
+
+\* If a model is loaded completely into system memory, `size_vram` is omitted from the response.
+
+#### Examples
+
+### Request
+```shell
+curl http://localhost:11434/api/ps
+```
+
+#### Response
+
+A single JSON object will be returned.
+
+```json
+{
+  "models": [
+    {
+      "name": "mistral:latest",
+      "model": "mistral:latest",
+      "size": 5137025024,
+      "digest": "2ae6f6dd7a3dd734790bbbf58b8909a606e0e7e97e94b7604e0aa7ae4490e6d8",
+      "details": {
+        "parent_model": "",
+        "format": "gguf",
+        "family": "llama",
+        "families": [
+          "llama"
+        ],
+        "parameter_size": "7.2B",
+        "quantization_level": "Q4_0"
+      },
+      "expires_at": "2024-06-04T14:38:31.83753-07:00",
+      "size_vram": 5137025024
+    }
   ]
 }
 ```

--- a/new.txt
+++ b/new.txt
@@ -1,0 +1,8 @@
+[?2004h>>> [38;5;245mSend a message (/? for help)[28D[0m[Kfasdfsafasdfasf
+Use Ctrl + d or /bye to exit.
+>>> [38;5;245mSend a message (/? for help)[28D[0m[K
+Use Ctrl + d or /bye to exit.
+>>> [38;5;245mSend a message (/? for help)[28D[0m[K
+Use Ctrl + d or /bye to exit.
+>>> [38;5;245mSend a message (/? for help)[28D[0m[K
+[?2004l

--- a/response.txt
+++ b/response.txt
@@ -1,0 +1,18 @@
+Hello! It's nice to meet you. Is there something I can help you with, or would you like to chat?
+
+[?2004h>>> [38;5;245mSend a message (/? for help)[28D[0m[Khsaeljkljfa
+Use Ctrl + d or /bye to exit.
+>>> [38;5;245mSend a message (/? for help)[28D[0m[K
+Use Ctrl + d or /bye to exit.
+>>> [38;5;245mSend a message (/? for help)[28D[0m[K
+Use Ctrl + d or /bye to exit.
+>>> [38;5;245mSend a message (/? for help)[28D[0m[K
+Use Ctrl + d or /bye to exit.
+>>> [38;5;245mSend a message (/? for help)[28D[0m[K
+Use Ctrl + d or /bye to exit.
+>>> [38;5;245mSend a message (/? for help)[28D[0m[K
+Use Ctrl + d or /bye to exit.
+>>> [38;5;245mSend a message (/? for help)[28D[0m[K
+Use Ctrl + d or /bye to exit.
+>>> [38;5;245mSend a message (/? for help)[28D[0m[K
+[?2004l

--- a/server/routes.go
+++ b/server/routes.go
@@ -746,12 +746,13 @@ func (s *Server) ListModelsHandler(c *gin.Context) {
 		}
 
 		// tag should never be masked
+		modified := m.fi.ModTime()
 		models = append(models, api.ModelResponse{
 			Model:      n.DisplayShortest(),
 			Name:       n.DisplayShortest(),
 			Size:       m.Size(),
 			Digest:     m.digest,
-			ModifiedAt: m.fi.ModTime(),
+			ModifiedAt: &modified,
 			Details: api.ModelDetails{
 				Format:            cf.ModelFormat,
 				Family:            cf.ModelFamily,
@@ -1158,14 +1159,15 @@ func (s *Server) ProcessHandler(c *gin.Context) {
 			SizeVRAM:  int64(v.estimatedVRAM),
 			Digest:    model.Digest,
 			Details:   modelDetails,
-			ExpiresAt: v.expiresAt,
+			ExpiresAt: &v.expiresAt,
 		}
 		// The scheduler waits to set expiresAt, so if a model is loading it's
 		// possible that it will be set to the unix epoch. For those cases, just
 		// calculate the time w/ the sessionDuration instead.
 		var epoch time.Time
 		if v.expiresAt == epoch {
-			mr.ExpiresAt = time.Now().Add(v.sessionDuration)
+			expiresAt := time.Now().Add(v.sessionDuration)
+			mr.ExpiresAt = &expiresAt
 		}
 
 		models = append(models, mr)

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -112,6 +112,8 @@ func Test_Routes(t *testing.T) {
 				body, err := io.ReadAll(resp.Body)
 				assert.Nil(t, err)
 
+				assert.NotContains(t, string(body), "expires_at")
+
 				var modelList api.ListResponse
 				err = json.Unmarshal(body, &modelList)
 				assert.Nil(t, err)


### PR DESCRIPTION
/api/tags was returning "0001-01-01T00:00:00Z" for 'expires_at'
/api/ps was returning "0001-01-01T00:00:00Z" for 'modified_at'

Removes these fields from the respective endpoints

Added assertion in test case, and tested locally both with curl and CLI