### PR TITLE
Separate ListResponse and ModelResponse for api/tags vs api/ps

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -355,8 +355,8 @@ func (c *Client) List(ctx context.Context) (*ListResponse, error) {
 }
 
 // List running models.
-func (c *Client) ListRunning(ctx context.Context) (*ListResponse, error) {
-	var lr ListResponse
+func (c *Client) ListRunning(ctx context.Context) (*ProcessResponse, error) {
+	var lr ProcessResponse
 	if err := c.do(ctx, http.MethodGet, "/api/ps", nil, &lr); err != nil {
 		return nil, err
 	}

--- a/api/types.go
+++ b/api/types.go
@@ -289,11 +289,11 @@ type ListResponse struct {
 type ModelResponse struct {
 	Name       string       `json:"name"`
 	Model      string       `json:"model"`
-	ModifiedAt time.Time    `json:"modified_at,omitempty"`
+	ModifiedAt *time.Time   `json:"modified_at,omitempty"`
 	Size       int64        `json:"size"`
 	Digest     string       `json:"digest"`
 	Details    ModelDetails `json:"details,omitempty"`
-	ExpiresAt  time.Time    `json:"expires_at,omitempty"`
+	ExpiresAt  *time.Time   `json:"expires_at,omitempty"`
 	SizeVRAM   int64        `json:"size_vram,omitempty"`
 }
 

--- a/api/types.go
+++ b/api/types.go
@@ -282,19 +282,33 @@ type PushRequest struct {
 
 // ListResponse is the response from [Client.List].
 type ListResponse struct {
-	Models []ModelResponse `json:"models"`
+	Models []ListModelResponse `json:"models"`
 }
 
-// ModelResponse is a single model description in [ListResponse].
-type ModelResponse struct {
+// ProcessResponse is the response from [Client.Process].
+type ProcessResponse struct {
+	Models []ProcessModelResponse `json:"models"`
+}
+
+// ListModelResponse is a single model description in [ListResponse].
+type ListModelResponse struct {
 	Name       string       `json:"name"`
 	Model      string       `json:"model"`
-	ModifiedAt *time.Time   `json:"modified_at,omitempty"`
+	ModifiedAt time.Time    `json:"modified_at"`
 	Size       int64        `json:"size"`
 	Digest     string       `json:"digest"`
 	Details    ModelDetails `json:"details,omitempty"`
-	ExpiresAt  *time.Time   `json:"expires_at,omitempty"`
-	SizeVRAM   int64        `json:"size_vram,omitempty"`
+}
+
+// ProcessModelResponse is a single model description in [ProcessResponse].
+type ProcessModelResponse struct {
+	Name      string       `json:"name"`
+	Model     string       `json:"model"`
+	Size      int64        `json:"size"`
+	Digest    string       `json:"digest"`
+	Details   ModelDetails `json:"details,omitempty"`
+	ExpiresAt time.Time    `json:"expires_at"`
+	SizeVRAM  int64        `json:"size_vram"`
 }
 
 type TokenResponse struct {
@@ -484,6 +498,26 @@ func DefaultOptions() Options {
 		},
 	}
 }
+
+// TODO: Remove Custom Marshalling if struct separation is fine
+// type Time struct {
+// 	time.Time
+// }
+
+// func (t Time) MarshalJSON() ([]byte, error) {
+// 	if t.IsZero() {
+// 		return json.Marshal(nil)
+// 	}
+// 	return json.Marshal(t.Time)
+// }
+
+// func (t *Time) UnmarshalJSON(b []byte) error {
+// 	if string(b) == "null" {
+// 		t.Time = time.Time{}
+// 		return nil
+// 	}
+// 	return json.Unmarshal(b, &t.Time)
+// }
 
 type Duration struct {
 	time.Duration

--- a/api/types.go
+++ b/api/types.go
@@ -499,26 +499,6 @@ func DefaultOptions() Options {
 	}
 }
 
-// TODO: Remove Custom Marshalling if struct separation is fine
-// type Time struct {
-// 	time.Time
-// }
-
-// func (t Time) MarshalJSON() ([]byte, error) {
-// 	if t.IsZero() {
-// 		return json.Marshal(nil)
-// 	}
-// 	return json.Marshal(t.Time)
-// }
-
-// func (t *Time) UnmarshalJSON(b []byte) error {
-// 	if string(b) == "null" {
-// 		t.Time = time.Time{}
-// 		return nil
-// 	}
-// 	return json.Unmarshal(b, &t.Time)
-// }
-
 type Duration struct {
 	time.Duration
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -493,7 +493,7 @@ func ListHandler(cmd *cobra.Command, args []string) error {
 
 	for _, m := range models.Models {
 		if len(args) == 0 || strings.HasPrefix(m.Name, args[0]) {
-			data = append(data, []string{m.Name, m.Digest[:12], format.HumanBytes(m.Size), format.HumanTime(m.ModifiedAt, "Never")})
+			data = append(data, []string{m.Name, m.Digest[:12], format.HumanBytes(m.Size), format.HumanTime(*m.ModifiedAt, "Never")})
 		}
 	}
 
@@ -539,7 +539,7 @@ func ListRunningHandler(cmd *cobra.Command, args []string) error {
 				cpuPercent := math.Round(float64(sizeCPU) / float64(m.Size) * 100)
 				procStr = fmt.Sprintf("%d%%/%d%% CPU/GPU", int(cpuPercent), int(100-cpuPercent))
 			}
-			data = append(data, []string{m.Name, m.Digest[:12], format.HumanBytes(m.Size), procStr, format.HumanTime(m.ExpiresAt, "Never")})
+			data = append(data, []string{m.Name, m.Digest[:12], format.HumanBytes(m.Size), procStr, format.HumanTime(*m.ExpiresAt, "Never")})
 		}
 	}
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -493,7 +493,7 @@ func ListHandler(cmd *cobra.Command, args []string) error {
 
 	for _, m := range models.Models {
 		if len(args) == 0 || strings.HasPrefix(m.Name, args[0]) {
-			data = append(data, []string{m.Name, m.Digest[:12], format.HumanBytes(m.Size), format.HumanTime(*m.ModifiedAt, "Never")})
+			data = append(data, []string{m.Name, m.Digest[:12], format.HumanBytes(m.Size), format.HumanTime(m.ModifiedAt, "Never")})
 		}
 	}
 
@@ -539,7 +539,7 @@ func ListRunningHandler(cmd *cobra.Command, args []string) error {
 				cpuPercent := math.Round(float64(sizeCPU) / float64(m.Size) * 100)
 				procStr = fmt.Sprintf("%d%%/%d%% CPU/GPU", int(cpuPercent), int(100-cpuPercent))
 			}
-			data = append(data, []string{m.Name, m.Digest[:12], format.HumanBytes(m.Size), procStr, format.HumanTime(*m.ExpiresAt, "Never")})
+			data = append(data, []string{m.Name, m.Digest[:12], format.HumanBytes(m.Size), procStr, format.HumanTime(m.ExpiresAt, "Never")})
 		}
 	}
 

--- a/server/routes.go
+++ b/server/routes.go
@@ -746,12 +746,13 @@ func (s *Server) ListModelsHandler(c *gin.Context) {
 		}
 
 		// tag should never be masked
+		modified := m.fi.ModTime()
 		models = append(models, api.ModelResponse{
 			Model:      n.DisplayShortest(),
 			Name:       n.DisplayShortest(),
 			Size:       m.Size(),
 			Digest:     m.digest,
-			ModifiedAt: m.fi.ModTime(),
+			ModifiedAt: &modified,
 			Details: api.ModelDetails{
 				Format:            cf.ModelFormat,
 				Family:            cf.ModelFamily,
@@ -1158,14 +1159,15 @@ func (s *Server) ProcessHandler(c *gin.Context) {
 			SizeVRAM:  int64(v.estimatedVRAM),
 			Digest:    model.Digest,
 			Details:   modelDetails,
-			ExpiresAt: v.expiresAt,
+			ExpiresAt: &v.expiresAt,
 		}
 		// The scheduler waits to set expiresAt, so if a model is loading it's
 		// possible that it will be set to the unix epoch. For those cases, just
 		// calculate the time w/ the sessionDuration instead.
 		var epoch time.Time
 		if v.expiresAt == epoch {
-			mr.ExpiresAt = time.Now().Add(v.sessionDuration)
+			expiresAt := time.Now().Add(v.sessionDuration)
+			mr.ExpiresAt = &expiresAt
 		}
 
 		models = append(models, mr)

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -112,6 +112,8 @@ func Test_Routes(t *testing.T) {
 				body, err := io.ReadAll(resp.Body)
 				assert.Nil(t, err)
 
+				assert.NotContains(t, string(body), "expires_at")
+
 				var modelList api.ListResponse
 				err = json.Unmarshal(body, &modelList)
 				assert.Nil(t, err)


### PR DESCRIPTION
/api/tags was returning "0001-01-01T00:00:00Z" for 'expires_at'
/api/ps was returning "0001-01-01T00:00:00Z" for 'modified_at'

- Removes these fields from the respective endpoints

/api/ps was omitting 'size_vram' when it was 0

- ensures that size_vram is always returned

Added assertion in test case, and tested locally both with curl and CLI