### PR TITLE
feat: initial steps allow image embeddings

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -182,6 +182,9 @@ type EmbeddingRequest struct {
 	// Prompt is the textual prompt to embed.
 	Prompt string `json:"prompt"`
 
+	// Image is an optional images, for multimodal embedding models.
+	Image ImageData `json:"image,omitempty"`
+
 	// KeepAlive controls how long the model will stay loaded in memory following
 	// this request.
 	KeepAlive *Duration `json:"keep_alive,omitempty"`

--- a/llm/ext_server/server.cpp
+++ b/llm/ext_server/server.cpp
@@ -1244,6 +1244,7 @@ struct llama_server_context
 
     void request_completion(int task_id, json data, bool embedding, int multitask_id)
     {
+        //TODO: This should handle when `image` is in the json data
         task_server task;
         task.id = task_id;
         task.target_id = 0;

--- a/llm/server.go
+++ b/llm/server.go
@@ -828,6 +828,12 @@ type EmbeddingRequest struct {
 	Image  ImageData
 }
 
+type EmbeddingJSONRequest struct {
+	// According to ext_server, they should both be optional, TODO: Do it!
+	Content string    `json:"content"`
+	Image   ImageData `json:"image_data"` //TODO: Check how other Marshall these
+}
+
 type EmbeddingResponse struct {
 	Embedding []float64 `json:"embedding"`
 }
@@ -847,7 +853,8 @@ func (s *llmServer) Embedding(ctx context.Context, req EmbeddingRequest) ([]floa
 		return nil, fmt.Errorf("unexpected server status: %s", status.ToString())
 	}
 
-	data, err := json.Marshal(TokenizeRequest{Content: req.Prompt})
+	//TODO: Check if Marshal can handle the image, see how completion uses Encode method from an encoder
+	data, err := json.Marshal(EmbeddingJSONRequest{Content: req.Prompt, Image: req.Image})
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling embed data: %w", err)
 	}

--- a/llm/server.go
+++ b/llm/server.go
@@ -33,7 +33,7 @@ type LlamaServer interface {
 	Ping(ctx context.Context) error
 	WaitUntilRunning(ctx context.Context) error
 	Completion(ctx context.Context, req CompletionRequest, fn func(CompletionResponse)) error
-	Embedding(ctx context.Context, prompt string) ([]float64, error)
+	Embedding(ctx context.Context, req EmbeddingRequest) ([]float64, error)
 	Tokenize(ctx context.Context, content string) ([]int, error)
 	Detokenize(ctx context.Context, tokens []int) (string, error)
 	Close() error
@@ -824,14 +824,15 @@ func (s *llmServer) Completion(ctx context.Context, req CompletionRequest, fn fu
 }
 
 type EmbeddingRequest struct {
-	Content string `json:"content"`
+	Prompt string
+	Image  ImageData
 }
 
 type EmbeddingResponse struct {
 	Embedding []float64 `json:"embedding"`
 }
 
-func (s *llmServer) Embedding(ctx context.Context, prompt string) ([]float64, error) {
+func (s *llmServer) Embedding(ctx context.Context, req EmbeddingRequest) ([]float64, error) {
 	if err := s.sem.Acquire(ctx, 1); err != nil {
 		slog.Error("Failed to acquire semaphore", "error", err)
 		return nil, err
@@ -846,18 +847,18 @@ func (s *llmServer) Embedding(ctx context.Context, prompt string) ([]float64, er
 		return nil, fmt.Errorf("unexpected server status: %s", status.ToString())
 	}
 
-	data, err := json.Marshal(TokenizeRequest{Content: prompt})
+	data, err := json.Marshal(TokenizeRequest{Content: req.Prompt})
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling embed data: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("http://127.0.0.1:%d/embedding", s.port), bytes.NewBuffer(data))
+	http_req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("http://127.0.0.1:%d/embedding", s.port), bytes.NewBuffer(data))
 	if err != nil {
 		return nil, fmt.Errorf("error creating embed request: %w", err)
 	}
-	req.Header.Set("Content-Type", "application/json")
+	http_req.Header.Set("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := http.DefaultClient.Do(http_req)
 	if err != nil {
 		return nil, fmt.Errorf("do embedding request: %w", err)
 	}

--- a/server/routes.go
+++ b/server/routes.go
@@ -395,7 +395,7 @@ func (s *Server) EmbeddingsHandler(c *gin.Context) {
 		return
 	}
 
-	embedding, err := runner.llama.Embedding(c.Request.Context(), req.Prompt)
+	embedding, err := runner.llama.Embedding(c.Request.Context(), llm.EmbeddingRequest{Prompt: req.Prompt, Image: req.Image})
 	if err != nil {
 		slog.Info(fmt.Sprintf("embedding generation failed: %v", err))
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to generate embedding"})


### PR DESCRIPTION
I would like to start the discussion about the possibility to add Image as an Input to the Embedding route.

I guess it would also need the llama.cpp runner to be able to handle it, for which I still need to look at.

Also, I would like to know if `batch` embeddings is something you would consider adding.

This PR would only be a first step in that direction doing a small refactoring and adding the Image to the Embedding Request. 