### PR TITLE
llm: always add bos token to prompt

### DIFF
--- a/llm/ext_server/server.cpp
+++ b/llm/ext_server/server.cpp
@@ -424,6 +424,7 @@ struct llama_server_context
         n_ctx = llama_n_ctx(ctx);
 
         add_bos_token = llama_should_add_bos_token(model);
+        GGML_ASSERT(llama_add_eos_token(model) != 1);
 
         return true;
     }
@@ -835,7 +836,7 @@ struct llama_server_context
         system_tokens.clear();
 
         if (!system_prompt.empty()) {
-            system_tokens = ::llama_tokenize(ctx, system_prompt, add_bos_token);
+            system_tokens = ::llama_tokenize(ctx, system_prompt, true);
 
             llama_batch_clear(batch);
 
@@ -1656,7 +1657,7 @@ struct llama_server_context
                     slot.t_start_process_prompt = ggml_time_us();
                     slot.t_start_genereration = 0;
 
-                    prompt_tokens = tokenize(slot.prompt, system_prompt.empty() && add_bos_token);  // add BOS if there isn't system prompt
+                    prompt_tokens = tokenize(slot.prompt, system_prompt.empty());  // add BOS if there isn't system prompt
 
                     slot.n_prompt_tokens = prompt_tokens.size();
 

--- a/llm/ext_server/server.cpp
+++ b/llm/ext_server/server.cpp
@@ -424,7 +424,6 @@ struct llama_server_context
         n_ctx = llama_n_ctx(ctx);
 
         add_bos_token = llama_should_add_bos_token(model);
-        GGML_ASSERT(llama_add_eos_token(model) != 1);
 
         return true;
     }


### PR DESCRIPTION
Carries https://github.com/ollama/ollama/pull/4399

Fixes issues with embeddings not working because `bos` tokens were omitted from the prompt

Thank you @deadbeef84 for finding and fixing this.

Fixes https://github.com/ollama/ollama/issues/4207
Fixes https://github.com/ollama/ollama/issues/3777