### PR TITLE
Add Ollama-hpp to Community Libraries in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [OllamaSharp for .NET](https://github.com/awaescher/OllamaSharp)
 - [Ollama for Ruby](https://github.com/gbaptista/ollama-ai)
 - [Ollama-rs for Rust](https://github.com/pepperoni21/ollama-rs)
+- [Ollama-hpp for C++](https://github.com/jmont-dev/ollama-hpp)
 - [Ollama4j for Java](https://github.com/amithkoujalgi/ollama4j)
 - [ModelFusion Typescript Library](https://modelfusion.dev/integration/model-provider/ollama)
 - [OllamaKit for Swift](https://github.com/kevinhermawan/OllamaKit)


### PR DESCRIPTION
Ollama-hpp is a header-only C++ implementation of the Ollama API. Adding to the README for Community Libraries at Pat's suggestion.