### PR TITLE
Revert "Merge pull request #4938 from ollama/mxyng/fix-byte-order"

### DIFF
--- a/llm/gguf.go
+++ b/llm/gguf.go
@@ -36,22 +36,9 @@ func (c *containerGGUF) Name() string {
 }
 
 func (c *containerGGUF) Decode(rs io.ReadSeeker) (model, error) {
-	var version [4]byte
-	if err := binary.Read(rs, c.ByteOrder, &version); err != nil {
+	if err := binary.Read(rs, c.ByteOrder, &c.Version); err != nil {
 		return nil, err
 	}
-
-	// if the lower 16 bits are 0, the byte order is probably wrong
-	if c.ByteOrder.Uint32(version[:])&1<<4 == 0 {
-		switch c.ByteOrder {
-		case binary.LittleEndian:
-			c.ByteOrder = binary.BigEndian
-		case binary.BigEndian:
-			c.ByteOrder = binary.LittleEndian
-		}
-	}
-
-	c.Version = c.ByteOrder.Uint32(version[:])
 
 	var err error
 	switch c.Version {


### PR DESCRIPTION
This reverts commit f5f245cc154580fa7b4052c001d2a7e3d771cfb8, reversing changes made to 94d37fdcae30ddeb6c9f65c8707004f5ec9eaf33.

this change broke gguf v2 which is incorrectly detected as big endian