### PR TITLE
fix utf8 parser error

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -324,7 +324,8 @@ type scannerDecoder interface {
 type utf8ScannerDecoder struct{}
 
 func (utf8ScannerDecoder) ScanBytes(data []byte, atEOF bool) (advance int, token []byte, err error) {
-	return scanBytesN(data, 1, atEOF)
+	_, size := utf8.DecodeRune(data)
+	return scanBytesN(data, size, atEOF)
 }
 
 func (utf8ScannerDecoder) DecodeRune(data []byte) (rune, error) {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -268,6 +268,17 @@ SYSTEM """This is a multiline system."""
 		{
 			`
 FROM foo
+SYSTEM """utf8测试"""
+			`,
+			[]Command{
+				{Name: "model", Args: "foo"},
+				{Name: "system", Args: "utf8测试"},
+			},
+			nil,
+		},
+		{
+			`
+FROM foo
 SYSTEM """This is a multiline system.""
 			`,
 			nil,


### PR DESCRIPTION
in `v0.1.43` when utf8 char in  modelfile ,after parse got `�������������`

test code :
```
	var Modelfile string = "FROM llama3:70b\nSYSTEM \"\"\"\n提问和回答都使用中文\n\"\"\""
	var sr io.Reader = strings.NewReader(Modelfile)
	f, err := parser.ParseFile(sr)
	fmt.Printf("err: %v\n", err)
	fmt.Printf("f: %v\n", f)
```