### PR TITLE
Adds an uninstall script to the installer

### DIFF
--- a/docs/linux.md
+++ b/docs/linux.md
@@ -120,6 +120,11 @@ journalctl -e -u ollama
 
 ## Uninstall
 
+### Uninstall script
+A script will be created in the same location as the `ollama` binary called `ollama_uninstall.sh`. Running it will remove the installation from the sustem.
+
+### Manual uninstall
+
 Remove the ollama service:
 
 ```bash

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -135,6 +135,7 @@ $SUDO install -o0 -g0 -m755 ${TEMP_DIR}/${UNINSTALL_SCRIPT} ${BINDIR}/${UNINSTAL
 install_success() {
     status 'The Ollama API is now available at 127.0.0.1:11434.'
     status 'Install complete. Run "ollama" from the command line.'
+    status "Run \"${UNINSTALL_SCRIPT}\" from the command line to uninstall."
 }
 trap install_success EXIT
 


### PR DESCRIPTION
A new script called ollama_uninstall.sh gets created as part of the installation process on Linux. Running this will remove the ollama installation.