### PR TITLE
openai: do not set temperature to 0 when setting seed

### DIFF
--- a/docs/openai.md
+++ b/docs/openai.md
@@ -104,7 +104,6 @@ curl http://localhost:11434/v1/chat/completions \
 
 #### Notes
 
-- Setting `seed` will always set `temperature` to `0`
 - `finish_reason` will always be `stop`
 - `usage.prompt_tokens` will be 0 for completions where prompt evaluation is cached
 

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -178,9 +178,6 @@ func fromRequest(r ChatCompletionRequest) api.ChatRequest {
 
 	if r.Seed != nil {
 		options["seed"] = *r.Seed
-
-		// temperature=0 is required for reproducible outputs
-		options["temperature"] = 0.0
 	}
 
 	if r.FrequencyPenalty != nil {


### PR DESCRIPTION
`tempearture` was previously set to 0 for reproducible outputs when setting seed, however this is not required

Note https://github.com/ollama/ollama/issues/4990 is still an open issue on Nvidia/AMD GPUs

Fixes https://github.com/ollama/ollama/issues/5044