### PR TITLE
server: longer timeout in `TestRequests`

### DIFF
--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -150,7 +150,7 @@ func newScenario(t *testing.T, ctx context.Context, modelName string, estimatedV
 }
 
 func TestRequests(t *testing.T) {
-	ctx, done := context.WithTimeout(context.Background(), time.Second)
+	ctx, done := context.WithTimeout(context.Background(), 10*time.Second)
 	defer done()
 
 	// Same model, same request


### PR DESCRIPTION
@dhiltgen this seems like a band-aid - is there something deeper we should fix in this test?