### PR TITLE
gpu: Fix build warning

### DIFF
--- a/gpu/gpu_info_oneapi.c
+++ b/gpu/gpu_info_oneapi.c
@@ -160,7 +160,7 @@ void oneapi_check_vram(oneapi_handle_t h, int driver, int device,
     return;
   }
 
-  snprintf(&resp->gpu_name[0], GPU_NAME_LEN, props.modelName);
+  snprintf(&resp->gpu_name[0], GPU_NAME_LEN, "%s", props.modelName);
 
   // TODO this needs to map to ONEAPI_DEVICE_SELECTOR syntax
   // (this is probably wrong...)


### PR DESCRIPTION
Fix build warning
```
# github.com/ollama/ollama/gpu
gpu_info_oneapi.c: In function ‘oneapi_check_vram’:
gpu_info_oneapi.c:163:51: warning: format not a string literal and no format arguments [-Wformat-security]
  163 |   snprintf(&resp->gpu_name[0], GPU_NAME_LEN, props.modelName);
      |                                              ~~~~~^~~~~~~~~~

```