### PR TITLE
docs: add missing powershell package to windows development instructions

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -114,15 +114,18 @@ If you have Docker available, you can build linux binaries with `./scripts/build
 
 ### Windows
 
-Note: The windows build for Ollama is still under development.
+Note: The Windows build for Ollama is still under development.
 
-Install required tools:
+First, install required tools:
 
 - MSVC toolchain - C/C++ and cmake as minimal requirements
 - Go version 1.22 or higher
 - MinGW (pick one variant) with GCC.
   - [MinGW-w64](https://www.mingw-w64.org/)
   - [MSYS2](https://www.msys2.org/)
+- The `ThreadJob` Powershell module `Install-Module -Name ThreadJob -Scope CurrentUser`
+
+Then, build the `ollama` binary:
 
 ```powershell
 $env:CGO_ENABLED="1"

--- a/docs/development.md
+++ b/docs/development.md
@@ -123,7 +123,7 @@ First, install required tools:
 - MinGW (pick one variant) with GCC.
   - [MinGW-w64](https://www.mingw-w64.org/)
   - [MSYS2](https://www.msys2.org/)
-- The `ThreadJob` Powershell module `Install-Module -Name ThreadJob -Scope CurrentUser`
+- The `ThreadJob` Powershell module: `Install-Module -Name ThreadJob -Scope CurrentUser`
 
 Then, build the `ollama` binary:
 


### PR DESCRIPTION
The powershell script for building Ollama on Windows requires the `ThreadJob` module. Add this to the instructions and dependency list.