### PR TITLE
Add some more debugging logs for intel discovery

### DIFF
--- a/gpu/gpu_info_oneapi.c
+++ b/gpu/gpu_info_oneapi.c
@@ -13,7 +13,7 @@ void oneapi_init(char *oneapi_lib_path, oneapi_init_resp_t *resp) {
   resp->oh.num_drivers = 0;
   const int buflen = 256;
   char buf[buflen + 1];
-  int i, d, count;
+  int i, d;
   struct lookup {
     char *s;
     void **p;
@@ -62,6 +62,8 @@ void oneapi_init(char *oneapi_lib_path, oneapi_init_resp_t *resp) {
     }
   }
 
+  LOG(resp->oh.verbose, "calling zesInit\n");
+
   ret = (*resp->oh.zesInit)(0);
   if (ret != ZE_RESULT_SUCCESS) {
     LOG(resp->oh.verbose, "zesInit err: %x\n", ret);
@@ -71,7 +73,7 @@ void oneapi_init(char *oneapi_lib_path, oneapi_init_resp_t *resp) {
     return;
   }
 
-  count = 0;
+  LOG(resp->oh.verbose, "calling zesDriverGet\n");
   ret = (*resp->oh.zesDriverGet)(&resp->oh.num_drivers, NULL);
   if (ret != ZE_RESULT_SUCCESS) {
     LOG(resp->oh.verbose, "zesDriverGet err: %x\n", ret);
@@ -96,6 +98,7 @@ void oneapi_init(char *oneapi_lib_path, oneapi_init_resp_t *resp) {
   }
 
   for (d = 0; d < resp->oh.num_drivers; d++) {
+    LOG(resp->oh.verbose, "calling zesDeviceGet %d\n", resp->oh.drivers[d]);
     ret = (*resp->oh.zesDeviceGet)(resp->oh.drivers[d],
                                    &resp->oh.num_devices[d], NULL);
     if (ret != ZE_RESULT_SUCCESS) {
@@ -116,7 +119,6 @@ void oneapi_init(char *oneapi_lib_path, oneapi_init_resp_t *resp) {
       oneapi_release(resp->oh);
       return;
     }
-    count += resp->oh.num_devices[d];
   }
 
   return;


### PR DESCRIPTION
Also removes an unused overall count variable

Until we can find a repro to fully root cause the crash, this may help narrow the search space.

Related to #5073 