### PR TITLE
Fix a build warning again

### DIFF
--- a/gpu/gpu_info_oneapi.c
+++ b/gpu/gpu_info_oneapi.c
@@ -98,7 +98,7 @@ void oneapi_init(char *oneapi_lib_path, oneapi_init_resp_t *resp) {
   }
 
   for (d = 0; d < resp->oh.num_drivers; d++) {
-    LOG(resp->oh.verbose, "calling zesDeviceGet %d\n", resp->oh.drivers[d]);
+    LOG(resp->oh.verbose, "calling zesDeviceGet count %d: %p\n", d, resp->oh.drivers[d]);
     ret = (*resp->oh.zesDeviceGet)(resp->oh.drivers[d],
                                    &resp->oh.num_devices[d], NULL);
     if (ret != ZE_RESULT_SUCCESS) {


### PR DESCRIPTION
With the latest main branch, there is a build warning
```
# github.com/ollama/ollama/gpu
In file included from gpu_info_oneapi.h:4,
                 from gpu_info_oneapi.c:3:
gpu_info_oneapi.c: In function ‘oneapi_init’:
gpu_info_oneapi.c:101:27: warning: format ‘%d’ expects argument of type ‘int’, but argument 3 has type ‘zes_driver_handle_t’ {aka ‘struct _zes_driver_handle_t *’} [-Wformat=]
  101 |     LOG(resp->oh.verbose, "calling zesDeviceGet %d\n", resp->oh.drivers[d]);
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~~~~~~~~~~
      |                                                                        |
      |                                                                        zes_driver_handle_t {aka struct _zes_driver_handle_t *}
gpu_info.h:33:23: note: in definition of macro ‘LOG’
   33 |       fprintf(stderr, __VA_ARGS__); \
      |                       ^~~~~~~~~~~
gpu_info_oneapi.c:101:50: note: format string is defined here
  101 |     LOG(resp->oh.verbose, "calling zesDeviceGet %d\n", resp->oh.drivers[d]);
      |                                                 ~^
      |                                                  |
      |                                                  int
```