### PR TITLE
Handle models with divergent layer sizes

### DIFF
--- a/llm/memory.go
+++ b/llm/memory.go
@@ -1,6 +1,7 @@
 package llm
 
 import (
+	"fmt"
 	"log/slog"
 	"strconv"
 	"strings"
@@ -179,6 +180,11 @@ func EstimateGPULayers(gpus []gpu.GpuInfo, ggml *GGML, projectors []string, opts
 
 	// For all the layers, find where they can fit on the GPU(s)
 	for i := range int(ggml.KV().BlockCount()) {
+		// Some models have inconsistent layer sizes
+		if blk, ok := layers[fmt.Sprintf("blk.%d", i)]; ok {
+			layerSize = blk.size()
+			layerSize += kv / ggml.KV().BlockCount()
+		}
 		memoryWeights += layerSize
 
 		if opts.NumGPU >= 0 && layerCount >= opts.NumGPU {


### PR DESCRIPTION
The recent refactoring of the memory prediction assumed all layers are the same size, but for some models (like deepseek-coder-v2) this is not the case, so our predictions were significantly off.


Without the fix:
```
time=2024-06-18T11:03:42.708-07:00 level=INFO source=memory.go:303 msg="offload to metal" layers.requested=-1 layers.model=28 layers.offload=28 layers.split="" memory.available="[96.0 GiB]" memory.required.full="2.4 GiB" memory.required.partial="2.4 GiB" memory.required.kv="432.0 MiB" memory.required.allocations="[2.4 GiB]" memory.weights.total="1.6 GiB" memory.weights.repeating="1.4 GiB" memory.weights.nonrepeating="164.1 MiB" memory.graph.full="72.0 MiB" memory.graph.partial="72.0 MiB"
```

With the fix:
```
time=2024-06-18T11:02:47.707-07:00 level=INFO source=memory.go:309 msg="offload to metal" layers.requested=-1 layers.model=28 layers.offload=28 layers.split="" memory.available="[96.0 GiB]" memory.required.full="9.2 GiB" memory.required.partial="9.2 GiB" memory.required.kv="432.0 MiB" memory.required.allocations="[9.2 GiB]" memory.weights.total="8.4 GiB" memory.weights.repeating="8.3 GiB" memory.weights.nonrepeating="164.1 MiB" memory.graph.full="72.0 MiB" memory.graph.partial="72.0 MiB"
```

Partial fix for #5113 but we'll need additional graph updates...