### PR TITLE
Wire up windows AMD driver reporting

### DIFF
--- a/gpu/amd_hip_windows.go
+++ b/gpu/amd_hip_windows.go
@@ -84,9 +84,8 @@ func (hl *HipLib) AMDDriverVersion() (driverMajor, driverMinor int, err error) {
 	}
 
 	slog.Debug("hipDriverGetVersion", "version", version)
-	// TODO - this isn't actually right, but the docs claim hipDriverGetVersion isn't accurate anyway...
-	driverMajor = version / 1000
-	driverMinor = (version - (driverMajor * 1000)) / 10
+	driverMajor = version / 10000000
+	driverMinor = (version - (driverMajor * 10000000)) / 100000
 
 	return driverMajor, driverMinor, nil
 }

--- a/gpu/amd_windows.go
+++ b/gpu/amd_windows.go
@@ -35,12 +35,11 @@ func AMDGetGPUInfo() []RocmGPUInfo {
 	}
 	defer hl.Release()
 
-	// TODO - this reports incorrect version information, so omitting for now
-	// driverMajor, driverMinor, err := hl.AMDDriverVersion()
-	// if err != nil {
-	// 	// For now this is benign, but we may eventually need to fail compatibility checks
-	// 	slog.Debug("error looking up amd driver version", "error", err)
-	// }
+	driverMajor, driverMinor, err := hl.AMDDriverVersion()
+	if err != nil {
+		// For now this is benign, but we may eventually need to fail compatibility checks
+		slog.Debug("error looking up amd driver version", "error", err)
+	}
 
 	// Note: the HIP library automatically handles subsetting to any HIP_VISIBLE_DEVICES the user specified
 	count := hl.HipGetDeviceCount()
@@ -131,10 +130,8 @@ func AMDGetGPUInfo() []RocmGPUInfo {
 				MinimumMemory:  rocmMinimumMemory,
 				Name:           name,
 				Compute:        gfx,
-
-				// TODO - this information isn't accurate on windows, so don't report it until we find the right way to retrieve
-				// DriverMajor:    driverMajor,
-				// DriverMinor:    driverMinor,
+				DriverMajor:    driverMajor,
+				DriverMinor:    driverMinor,
 			},
 			index: i,
 		}


### PR DESCRIPTION
This seems to be ROCm version, not actually driver version, but it may be useful for toggling logic for VRAM reporting in the future


Before:
```
time=2024-06-18T15:56:19.574-07:00 level=INFO source=types.go:98 msg="inference compute" id=1 library=rocm compute=gfx1100 driver=0.0 name="AMD Radeon RX 7900 XTX" total="24.0 GiB" available="23.9 GiB"
```

After:
```
time=2024-06-18T16:15:27.513-07:00 level=INFO source=types.go:98 msg="inference compute" id=1 library=rocm compute=gfx1100 driver=5.7 name="AMD Radeon RX 7900 XTX" total="24.0 GiB" available="23.9 GiB"
```

fwiw, this version string doesn't seem to be wired to the actual driver version.    On this same test system:
```
Get-WmiObject Win32_VideoController | format-table Name, Description,VideoProcessor,DriverVersion

Name                    Description             VideoProcessor                         DriverVersion
----                    -----------             --------------                         -------------
AMD Radeon(TM) Graphics AMD Radeon(TM) Graphics AMD Radeon Graphics Processor (0x164E) 31.0.24019.1006
AMD Radeon RX 7900 XTX  AMD Radeon RX 7900 XTX  AMD Radeon Graphics Processor (0x744C) 31.0.24019.1006
```