### PR TITLE
linux.md: Make it clear that ollama does not need to be installed as a service [docs only]

### DIFF
--- a/docs/linux.md
+++ b/docs/linux.md
@@ -30,6 +30,9 @@ sudo chmod +x /usr/bin/ollama
 ```
 
 ### Adding Ollama as a startup service (recommended)
+*Note:* After completing the above steps, you can run ollama with `ollama serve`,
+you do not need to set it up as a service. These steps are designed for increased
+convenience if you are using ollama regularly. 
 
 Create a user for Ollama:
 


### PR DESCRIPTION
I had gotten halfway through these steps before I realized that they were fully optional and overkill for my use case of playing with ollama.

This commit makes it clearer these steps are optional, and only recommended if you will be using ollama quite regularly.