### PR TITLE
Update requirements.txt

### DIFF
--- a/examples/langchain-python-rag-privategpt/requirements.txt
+++ b/examples/langchain-python-rag-privategpt/requirements.txt
@@ -1,6 +1,6 @@
 langchain==0.0.274
 gpt4all==1.0.8
-chromadb==0.4.7
+chromadb==0.5.0
 llama-cpp-python==0.1.81
 urllib3==2.0.4
 PyMuPDF==1.23.5


### PR DESCRIPTION
With chromadb==0.4.7, ingest.py still fails with 
`Cannot submit more than 5,461 embeddings at once. Please submit your embeddings in batches of size 5,461 or less.`

See 
- https://github.com/ollama/ollama/issues/4476
- https://github.com/ollama/ollama/issues/2572
- https://github.com/ollama/ollama/issues/533