### PR TITLE
fix: skip os.removeAll() if PID does not exist

### DIFF
--- a/gpu/assets.go
+++ b/gpu/assets.go
@@ -87,6 +87,8 @@ func cleanupTmpDirs() {
 			}
 		} else {
 			slog.Debug("failed to open ollama.pid", "path", d, "error", err)
+			// No pid, ignore this tmpdir
+			continue
 		}
 		err = os.RemoveAll(d)
 		if err != nil {


### PR DESCRIPTION
previously deleted all directories in $TMPDIR starting with ollama. Added a "continue" to skip the directory removal if a PID doesn't exist. We do this to prevent accidentally deleting directories in tmpdir that share the ollama name but aren't created by us for processes

resolves: https://github.com/ollama/ollama/issues/5129