### PR TITLE
add insert support to generate endpoint

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -47,6 +47,9 @@ type GenerateRequest struct {
 	// Prompt is the textual prompt to send to the model.
 	Prompt string `json:"prompt"`
 
+	// Suffix is the text that comes after the inserted text.
+	Suffix string `json:"suffix"`
+
 	// System overrides the model's default system message/prompt.
 	System string `json:"system"`
 

--- a/template/template.go
+++ b/template/template.go
@@ -151,6 +151,8 @@ func (t *Template) Vars() []string {
 type Values struct {
 	Messages []api.Message
 	Tools    []api.Tool
+	Prompt   string
+	Suffix   string
 
 	// forceLegacy is a flag used to test compatibility with legacy templates
 	forceLegacy bool
@@ -204,7 +206,13 @@ func (t *Template) Subtree(fn func(parse.Node) bool) *template.Template {
 
 func (t *Template) Execute(w io.Writer, v Values) error {
 	system, messages := collate(v.Messages)
-	if !v.forceLegacy && slices.Contains(t.Vars(), "messages") {
+	if v.Prompt != "" && v.Suffix != "" {
+		return t.Template.Execute(w, map[string]any{
+			"Prompt":   v.Prompt,
+			"Suffix":   v.Suffix,
+			"Response": "",
+		})
+	} else if !v.forceLegacy && slices.Contains(t.Vars(), "messages") {
 		return t.Template.Execute(w, map[string]any{
 			"System":   system,
 			"Messages": messages,

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -359,3 +359,38 @@ Answer: `,
 		})
 	}
 }
+
+func TestExecuteWithSuffix(t *testing.T) {
+	tmpl, err := Parse(`{{- if .Suffix }}<PRE> {{ .Prompt }} <SUF>{{ .Suffix }} <MID>
+{{- else }}{{ .Prompt }}
+{{- end }}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name   string
+		values Values
+		expect string
+	}{
+		{
+			"message", Values{Messages: []api.Message{{Role: "user", Content: "hello"}}}, "hello",
+		},
+		{
+			"prompt suffix", Values{Prompt: "def add(", Suffix: "return x"}, "<PRE> def add( <SUF>return x <MID>",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			var b bytes.Buffer
+			if err := tmpl.Execute(&b, tt.values); err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(b.String(), tt.expect); diff != "" {
+				t.Errorf("mismatch (-got +want):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
this change is triggered by the presence of "suffix", particularly useful for code completion tasks

examples templates

codellama merged code completion and fill-in-middle template
```
{{- if .Suffix }}<PRE> {{ .Prompt }} <SUF>{{ .Suffix }} <MID>
{{- else }}{{ Prompt }}
{{- end }}
```

deepseek coder v2 merged messages #5126 and fill-in-middle template
```
{{- if .Suffix }}<｜fim▁begin｜>{{ .Prompt }}
<｜fim▁hole｜>
{{ .Suffix }}<｜fim▁end｜>
{{- else }}
{{- range .Messages }}
{{- if eq .Role "user" }}
{{- if and (eq (index $.Messages (sub (len $.Messages) 1)) .) $.System }}{{ $.System }}{{ "\n\n" }}
{{- end }}User: {{ .Content }}{{ "\n\n" }}
{{- else if eq .Role "assistant" }}Assistant: {{ .Content }}<｜end▁of▁sentence｜>
{{- end }}
{{- end }}Assistant:
{{- end }}
```

example request

```
curl 127.0.0.1:11434/api/generate -d '{
    "model": "deepseek-coder-v2",
    "prompt": "def add(",
    "suffix": "return c",
    "stream": false,
    "options": {
        "temperature": 0
    }
}'
```

models that do no support `suffix` will return error `model does not support [suffix]`

an example fill-in-middle model is [mike/deepseek-coder-v2](https://ollama.com/mike/deepseek-coder-v2)

resolves #496 
resolves #3869 
resolves #5403 