### PR TITLE
build: add source label to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -133,6 +133,7 @@ ENTRYPOINT ["/bin/ollama"]
 CMD ["serve"]
 
 FROM runtime-$TARGETARCH
+LABEL org.opencontainers.image.source="https://github.com/ollama/ollama"
 EXPOSE 11434
 ENV OLLAMA_HOST 0.0.0.0
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin


### PR DESCRIPTION
This allows tools such as dependabot and renovate
to find the source and changelog