### PR TITLE
llm: suppress large allocations for GGUF arrays

### DIFF
--- a/llm/ggml.go
+++ b/llm/ggml.go
@@ -321,7 +321,7 @@ func (llm GGML) GraphSize(context, batch uint64) (partialOffload, fullOffload ui
 	embedding := llm.KV().EmbeddingLength()
 	heads := llm.KV().HeadCount()
 	headsKV := llm.KV().HeadCountKV()
-	vocab := uint64(len(llm.KV()["tokenizer.ggml.tokens"].([]any)))
+	vocab := llm.KV()["tokenizer.ggml.tokens"].(*array).size
 
 	embeddingHeads := llm.KV().EmbeddingHeadCount()
 	embeddingHeadsK := llm.KV().EmbeddingHeadCountK()


### PR DESCRIPTION
This introduces a little array type for holding GGUF arrays that prevents the array from growing too large. It preserves the total size of the array, but limits the number of elements that are actually allocated.

GGUF arrays that are extremely large, such as tokens, etc, are generally uninteresting to users, and are not worth the memory overhead, and the time spent allocating and freeing them. They are necessary for inference, but not for inspection.

The size of these arrays is, however, important in Ollama, so it is preserved in a separate field on array.