### PR TITLE
llama: Support both old and new runners with a toggle with release build rigging

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -97,6 +97,7 @@ jobs:
           $env:CMAKE_SYSTEM_VERSION="10.0.22621.0"
           $env:PATH="$gopath;$env:PATH"
           go generate -x ./...
+          make -C llama -j 8
         name: go generate
       - uses: actions/upload-artifact@v4
         with:
@@ -164,6 +165,7 @@ jobs:
           $env:OLLAMA_SKIP_CPU_GENERATE="1"
           $env:HIP_PATH=$(Resolve-Path 'C:\Program Files\AMD\ROCm\*\bin\clang.exe' | split-path | split-path)
           go generate -x ./...
+          make -C llama -j 8
         name: go generate
       - name: 'gather rocm dependencies'
         run: |
@@ -254,6 +256,7 @@ jobs:
           $env:PATH="$gopath;$cudabin;$env:PATH"
           $env:OLLAMA_SKIP_CPU_GENERATE="1"
           go generate -x ./...
+          make -C llama -j 8
       - name: 'gather cuda dependencies'
         run: |
           $NVIDIA_DIR=(resolve-path 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\*\bin\')[0]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,17 +67,15 @@ jobs:
           cache: true
       - run: go get ./...
       - run: |
-          $gopath=(get-command go).source | split-path -parent
-          $gccpath=(get-command gcc).source | split-path -parent
-          & "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\Launch-VsDevShell.ps1"
-          cd $env:GITHUB_WORKSPACE
           $env:CMAKE_SYSTEM_VERSION="10.0.22621.0"
-          $env:PATH="$gopath;$gccpath;$env:PATH"
           echo $env:PATH
           go generate -x ./...
+          make -C llama -j 8
         if: ${{ startsWith(matrix.os, 'windows-') }}
         name: 'Windows Go Generate'
-      - run: go generate -x ./...
+      - run: |
+          go generate -x ./...
+          make -C llama -j 8
         if: ${{ ! startsWith(matrix.os, 'windows-') }}
         name: 'Unix Go Generate'
       - run: go build .
@@ -112,6 +110,7 @@ jobs:
       - run: |
           git config --global --add safe.directory /__w/ollama/ollama
           go generate -x ./...
+          make -C llama -j 8
         env:
           OLLAMA_SKIP_CPU_GENERATE: '1'
       - uses: actions/upload-artifact@v4
@@ -145,6 +144,7 @@ jobs:
       - run: |
           git config --global --add safe.directory /__w/ollama/ollama
           go generate -x ./...
+          make -C llama -j 8
         env:
           OLLAMA_SKIP_CPU_GENERATE: '1'
       - uses: actions/upload-artifact@v4
@@ -179,13 +179,15 @@ jobs:
       - run: go get ./...
       - run: |
           $gopath=(get-command go).source | split-path -parent
+          $makepath=(get-command make).source | split-path -parent
+          $gccpath=(get-command gcc).source | split-path -parent
           & "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\Launch-VsDevShell.ps1"
           cd $env:GITHUB_WORKSPACE
           $env:CMAKE_SYSTEM_VERSION="10.0.22621.0"
-          $env:PATH="$gopath;$env:PATH"
-          $env:OLLAMA_SKIP_CPU_GENERATE="1"
-          $env:HIP_PATH=$(Resolve-Path 'C:\Program Files\AMD\ROCm\*\bin\clang.exe' | split-path | split-path)
+          $env:PATH="$gopath;$makepath;$gccpath;$env:PATH" 
+          echo $env:PATH
           go generate -x ./...
+          make -C llama -j 8
         name: go generate
         env:
           OLLAMA_SKIP_CPU_GENERATE: '1'
@@ -222,13 +224,16 @@ jobs:
       - name: go generate
         run: |
           $gopath=(get-command go).source | split-path -parent
-          $cudabin=(get-command nvcc).source | split-path
+          $makepath=(get-command make).source | split-path -parent
+          $gccpath=(get-command gcc).source | split-path -parent
+          $cudabin=(get-command nvcc).source | split-path -parent
           & "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\Launch-VsDevShell.ps1"
           cd $env:GITHUB_WORKSPACE
           $env:CMAKE_SYSTEM_VERSION="10.0.22621.0"
-          $env:PATH="$gopath;$cudabin;$env:PATH"
-          $env:OLLAMA_SKIP_CPU_GENERATE="1"
+          $env:PATH="$gopath;$makepath;$gccpath;$cudabin;$env:PATH" 
+          echo $env:PATH
           go generate -x ./...
+          make -C llama -j 8
         env:
           OLLAMA_SKIP_CPU_GENERATE: '1'
       # TODO - do we need any artifacts?

--- a/envconfig/config_test.go
+++ b/envconfig/config_test.go
@@ -17,6 +17,8 @@ func TestHost(t *testing.T) {
 		"only address":        {"1.2.3.4", "1.2.3.4:11434"},
 		"only port":           {":1234", ":1234"},
 		"address and port":    {"1.2.3.4:1234", "1.2.3.4:1234"},
+		"expose and port":     {"0.0.0.0:1234", "0.0.0.0:1234"},
+		"expose without port": {"0.0.0.0", "0.0.0.0:11434"},
 		"hostname":            {"example.com", "example.com:11434"},
 		"hostname and port":   {"example.com:1234", "example.com:1234"},
 		"zero port":           {":0", ":0"},

--- a/integration/context_test.go
+++ b/integration/context_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ollama/ollama/api"
+	"github.com/stretchr/testify/require"
 )
 
 func TestContextExhaustion(t *testing.T) {
@@ -31,4 +32,34 @@ func TestContextExhaustion(t *testing.T) {
 		t.Fatalf("PullIfMissing failed: %v", err)
 	}
 	DoGenerate(ctx, t, client, req, []string{"once", "upon", "lived"}, 120*time.Second, 10*time.Second)
+}
+
+func TestContextRoundTrip(t *testing.T) {
+	req := api.GenerateRequest{
+		Model:     "orca-mini",
+		Prompt:    "why is the sky blue?",
+		Stream:    &stream,
+		KeepAlive: &api.Duration{Duration: 10 * time.Second},
+		Options: map[string]interface{}{
+			"seed":        42,
+			"temperature": 0.0,
+		},
+	}
+	resp := []string{"sunlight"}
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+
+	client, _, cleanup := InitServerConnection(ctx, t)
+	defer cleanup()
+
+	require.NoError(t, PullIfMissing(ctx, client, req.Model))
+
+	context := DoGenerate(ctx, t, client, req, resp, 60*time.Second, 10*time.Second)
+	require.NotEmpty(t, context)
+
+	req.Prompt = "what about the ocean"
+	req.Context = context
+	resp = []string{"blue"}
+
+	DoGenerate(ctx, t, client, req, resp, 60*time.Second, 10*time.Second)
 }

--- a/integration/llm_image_test.go
+++ b/integration/llm_image_test.go
@@ -17,7 +17,7 @@ func TestIntegrationMultimodal(t *testing.T) {
 	require.NoError(t, err)
 	req := api.GenerateRequest{
 		Model:  "llava:7b",
-		Prompt: "what does the text in this image say?",
+		Prompt: "describe what is in this image ",
 		Stream: &stream,
 		Options: map[string]interface{}{
 			"seed":        42,
@@ -29,14 +29,14 @@ func TestIntegrationMultimodal(t *testing.T) {
 	}
 
 	// Note: sometimes it returns "the ollamas" sometimes "the ollams"
-	resp := "the ollam"
+	resp := []string{"the ollam", "cartoon"}
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancel()
 	client, _, cleanup := InitServerConnection(ctx, t)
 	defer cleanup()
 	require.NoError(t, PullIfMissing(ctx, client, req.Model))
 	// llava models on CPU can be quite slow to start,
-	DoGenerate(ctx, t, client, req, []string{resp}, 120*time.Second, 30*time.Second)
+	DoGenerate(ctx, t, client, req, resp, 120*time.Second, 30*time.Second)
 }
 
 const imageEncoding = `iVBORw0KGgoAAAANSUhEUgAAANIAAAB4CAYAAACHHqzKAAAAAXNSR0IArs4c6QAAAIRlWElmTU0AKgAAAAgABQESAAMAAAABAAEAAAEaAAUAAAABAAAASgEb

--- a/integration/utils_test.go
+++ b/integration/utils_test.go
@@ -336,7 +336,7 @@ func GenerateRequests() ([]api.GenerateRequest, [][]string) {
 		[][]string{
 			{"sunlight"},
 			{"soil", "organic", "earth", "black", "tan"},
-			{"england", "english", "massachusetts", "pilgrims", "british"},
+			{"england", "english", "massachusetts", "pilgrims", "british", "harvest", "festival"},
 			{"fourth", "july", "declaration", "independence"},
 			{"nitrogen", "oxygen", "carbon", "dioxide"},
 		}

--- a/llm/generate/gen_common.sh
+++ b/llm/generate/gen_common.sh
@@ -31,6 +31,7 @@ init_vars() {
         NO_WHOLE_ARCHIVE=""
         GCC_ARCH="-arch ${ARCH}"
         DIST_BASE=../../dist/darwin-${GOARCH}/
+        OS=darwin
         ;;
     "Linux")
         LIB_EXT="so"
@@ -40,6 +41,7 @@ init_vars() {
         # Cross compiling not supported on linux - Use docker
         GCC_ARCH=""
         DIST_BASE=../../dist/linux-${GOARCH}/
+        OS=linux
         ;;
     *)
         ;;
@@ -48,6 +50,8 @@ init_vars() {
         CMAKE_CUDA_ARCHITECTURES="50;52;61;70;75;80"
     fi
     GZIP=$(which pigz 2>/dev/null || echo "gzip")
+    DIST_BASE=../../dist/${OS}-${GOARCH}
+    RUNNER_BASE=${DIST_BASE}/ollama_runners
 }
 
 git_module_setup() {
@@ -87,6 +91,18 @@ apply_patches() {
 build() {
     cmake -S ${LLAMACPP_DIR} -B ${BUILD_DIR} ${CMAKE_DEFS}
     cmake --build ${BUILD_DIR} ${CMAKE_TARGETS} -j8
+}
+
+install() {
+    echo "Installing binaries to dist dir ${DIST_DIR}"
+    mkdir -p ${DIST_DIR}
+    for f in ${BUILD_DIR}/bin/* ; do
+        # Skip over any compressed files
+        if [[ $f == *.gz ]] ; then
+            continue
+        fi
+        cp ${f} ${DIST_DIR}/
+    done
 }
 
 compress() {

--- a/llm/generate/gen_darwin.sh
+++ b/llm/generate/gen_darwin.sh
@@ -40,9 +40,12 @@ case "${GOARCH}" in
         init_vars
         CMAKE_DEFS="${COMMON_CPU_DEFS} -DGGML_ACCELERATE=off -DGGML_BLAS=off -DGGML_AVX=off -DGGML_AVX2=off -DGGML_AVX512=off -DGGML_FMA=off -DGGML_F16C=off ${CMAKE_DEFS}"
         BUILD_DIR="../build/darwin/${ARCH}/cpu"
+        DIST_DIR=${RUNNER_BASE}/cpu
+        DEPS_DIR=${DIST_BASE}/cpu
         echo "Building LCD CPU"
         build
         sign ${BUILD_DIR}/bin/ollama_llama_server
+        install
         compress
 
         #
@@ -52,9 +55,12 @@ case "${GOARCH}" in
         init_vars
         CMAKE_DEFS="${COMMON_CPU_DEFS} -DGGML_ACCELERATE=off -DGGML_BLAS=off -DGGML_AVX=on -DGGML_AVX2=off -DGGML_AVX512=off -DGGML_FMA=off -DGGML_F16C=off ${CMAKE_DEFS}"
         BUILD_DIR="../build/darwin/${ARCH}/cpu_avx"
+        DIST_DIR=${RUNNER_BASE}/cpu_avx
+        DEPS_DIR=${DIST_BASE}/cpu_avx
         echo "Building AVX CPU"
         build
         sign ${BUILD_DIR}/bin/ollama_llama_server
+        install
         compress
 
         #
@@ -64,10 +70,13 @@ case "${GOARCH}" in
         init_vars
         CMAKE_DEFS="${COMMON_CPU_DEFS} -DGGML_ACCELERATE=on -DGGML_BLAS=off -DGGML_AVX=on -DGGML_AVX2=on -DGGML_AVX512=off -DGGML_FMA=on -DGGML_F16C=on ${CMAKE_DEFS}"
         BUILD_DIR="../build/darwin/${ARCH}/cpu_avx2"
+        DIST_DIR=${RUNNER_BASE}/cpu_avx2
+        DEPS_DIR=${DIST_BASE}/cpu_avx2
         echo "Building AVX2 CPU"
         EXTRA_LIBS="${EXTRA_LIBS} -framework Accelerate -framework Foundation"
         build
         sign ${BUILD_DIR}/bin/ollama_llama_server
+        install
         compress
     fi
     ;;
@@ -85,9 +94,12 @@ case "${GOARCH}" in
         init_vars
         CMAKE_DEFS="${COMMON_DARWIN_DEFS} -DCMAKE_SYSTEM_PROCESSOR=${ARCH} -DCMAKE_OSX_ARCHITECTURES=${ARCH} ${CMAKE_DEFS}"
         BUILD_DIR="../build/darwin/${ARCH}/metal"
+        DIST_DIR=${RUNNER_BASE}/metal
+        DEPS_DIR=${DIST_BASE}/metal
         EXTRA_LIBS="${EXTRA_LIBS} -framework Accelerate -framework Foundation -framework Metal -framework MetalKit -framework MetalPerformanceShaders"
         build
         sign ${BUILD_DIR}/bin/ollama_llama_server
+        install
         compress
     fi
     ;;

--- a/llm/generate/gen_linux.sh
+++ b/llm/generate/gen_linux.sh
@@ -80,6 +80,7 @@ if [ -z "${OLLAMA_SKIP_CPU_GENERATE}" ]; then
         echo "OLLAMA_CUSTOM_CPU_DEFS=\"${OLLAMA_CUSTOM_CPU_DEFS}\""
         CMAKE_DEFS="${OLLAMA_CUSTOM_CPU_DEFS} -DBUILD_SHARED_LIBS=on -DCMAKE_POSITION_INDEPENDENT_CODE=on ${CMAKE_DEFS}"
         BUILD_DIR="../build/linux/${ARCH}/cpu"
+        DIST_DIR=${RUNNER_BASE}/cpu
         echo "Building custom CPU"
         build
         install
@@ -103,6 +104,7 @@ if [ -z "${OLLAMA_SKIP_CPU_GENERATE}" ]; then
             init_vars
             CMAKE_DEFS="${COMMON_CPU_DEFS} -DGGML_AVX=off -DGGML_AVX2=off -DGGML_AVX512=off -DGGML_FMA=off -DGGML_F16C=off ${CMAKE_DEFS}"
             BUILD_DIR="../build/linux/${ARCH}/cpu"
+            DIST_DIR=${RUNNER_BASE}/cpu
             echo "Building LCD CPU"
             build
             install
@@ -121,6 +123,7 @@ if [ -z "${OLLAMA_SKIP_CPU_GENERATE}" ]; then
                 init_vars
                 CMAKE_DEFS="${COMMON_CPU_DEFS} -DGGML_AVX=on -DGGML_AVX2=off -DGGML_AVX512=off -DGGML_FMA=off -DGGML_F16C=off ${CMAKE_DEFS}"
                 BUILD_DIR="../build/linux/${ARCH}/cpu_avx"
+                DIST_DIR=${RUNNER_BASE}/cpu_avx
                 echo "Building AVX CPU"
                 build
                 install
@@ -135,6 +138,7 @@ if [ -z "${OLLAMA_SKIP_CPU_GENERATE}" ]; then
                 init_vars
                 CMAKE_DEFS="${COMMON_CPU_DEFS} -DGGML_AVX=on -DGGML_AVX2=on -DGGML_AVX512=off -DGGML_FMA=on -DGGML_F16C=on ${CMAKE_DEFS}"
                 BUILD_DIR="../build/linux/${ARCH}/cpu_avx2"
+                DIST_DIR=${RUNNER_BASE}/cpu_avx2
                 echo "Building AVX2 CPU"
                 build
                 install

--- a/llm/generate/gen_linux.sh
+++ b/llm/generate/gen_linux.sh
@@ -65,7 +65,7 @@ if [ -z "${OLLAMA_SKIP_STATIC_GENERATE}" -o "${OLLAMA_CPU_TARGET}" = "static" ];
     # Static build for linking into the Go binary
     init_vars
     CMAKE_TARGETS="--target llama --target ggml"
-    CMAKE_DEFS="-DBUILD_SHARED_LIBS=off -DLLAMA_NATIVE=off -DLLAMA_AVX=off -DLLAMA_AVX2=off -DLLAMA_AVX512=off -DLLAMA_FMA=off -DLLAMA_F16C=off -DGGML_OPENMP=off ${CMAKE_DEFS}"
+    CMAKE_DEFS="-DBUILD_SHARED_LIBS=off -DLLAMA_NATIVE=off -DGGML_AVX=off -DGGML_AVX2=off -DGGML_AVX512=off -DGGML_FMA=off -DGGML_F16C=off -DGGML_OPENMP=off ${CMAKE_DEFS}"
     BUILD_DIR="../build/linux/${ARCH}_static"
     echo "Building static library"
     build

--- a/llm/generate/gen_windows.ps1
+++ b/llm/generate/gen_windows.ps1
@@ -196,11 +196,11 @@ function build_static() {
             "-DCMAKE_CXX_COMPILER=g++.exe",
             "-DBUILD_SHARED_LIBS=off",
             "-DLLAMA_NATIVE=off",
-            "-DLLAMA_AVX=off",
-            "-DLLAMA_AVX2=off",
-            "-DLLAMA_AVX512=off",
-            "-DLLAMA_F16C=off",
-            "-DLLAMA_FMA=off",
+            "-DGGML_AVX=off",
+            "-DGGML_AVX2=off",
+            "-DGGML_AVX512=off",
+            "-DGGML_F16C=off",
+            "-DGGML_FMA=off",
             "-DGGML_OPENMP=off")
         $script:buildDir="../build/windows/${script:ARCH}_static"
         write-host "Building static library"

--- a/llm/llm.go
+++ b/llm/llm.go
@@ -13,7 +13,6 @@ import "C"
 
 import (
 	"fmt"
-	"log/slog"
 	"unsafe"
 )
 
@@ -46,14 +45,12 @@ type loadedModel struct {
 
 func loadModel(modelfile string, vocabOnly bool) (*loadedModel, error) {
 	// TODO figure out how to quiet down the logging so we don't have 2 copies of the model metadata showing up
-	slog.Info("XXX initializing default model params")
 	params := C.llama_model_default_params()
 	params.vocab_only = C.bool(vocabOnly)
 
 	cmodelfile := C.CString(modelfile)
 	defer C.free(unsafe.Pointer(cmodelfile))
 
-	slog.Info("XXX loading model", "model", modelfile)
 	model := C.llama_load_model_from_file(cmodelfile, params)
 	if model == nil {
 		return nil, fmt.Errorf("failed to load model %s", modelfile)
@@ -76,7 +73,6 @@ func tokenize(model *loadedModel, content string) ([]int, error) {
 		&tokens[0], C.int32_t(tokenCount), true, true))
 	if tokenCount < 0 {
 		tokenCount = -tokenCount
-		slog.Info("XXX got negative response", "count", tokenCount)
 		tokens = make([]C.int32_t, tokenCount)
 		tokenCount = int(C.llama_tokenize(model.model, ccontent, C.int32_t(len(content)), &tokens[0],
 			C.int32_t(tokenCount), true, true))
@@ -91,12 +87,10 @@ func tokenize(model *loadedModel, content string) ([]int, error) {
 	for i := range tokenCount {
 		ret[i] = int(tokens[i])
 	}
-	slog.Debug("XXX tokenized", "tokens", tokens, "content", content)
 	return ret, nil
 }
 
 func detokenize(model *loadedModel, tokens []int) string {
-	slog.Info("XXX in CGO detokenize")
 	var resp string
 	for _, token := range tokens {
 		buf := make([]C.char, 8)
@@ -108,6 +102,5 @@ func detokenize(model *loadedModel, tokens []int) string {
 		tokString := C.GoStringN(&buf[0], nTokens)
 		resp += tokString
 	}
-	slog.Debug("XXX detokenized", "tokens", tokens, "content", resp)
 	return resp
 }


### PR DESCRIPTION
Notable bugs in the new runners uncovered via integration tests:
- llava integration test seems to show hallucinations, so multimodal isn't quite right
- large context test case shows the batch processing needs additional work

This bundles the new runner into the publishing model for linux, mac and windows, so each platform can now toggle the new runners by simply setting `OLLAMA_NEW_RUNNERS=1` (note: linux+arm does not include new runners in the containerized build)

Integrated the new linux packaging changes from #5049 

```
% ls -lh
drwxr-xr-x 2 daniel daniel 4.0K Jul 15 00:12 cuda
-rw-r--r-- 1 daniel daniel 725M Jul 15 00:22 ollama
-rw-r--r-- 1 daniel daniel 2.4G Jul 15 00:30 ollama-linux-amd64.tgz
drwxr-xr-x 3 daniel daniel 4.0K Jul 15 00:30 rocm
% du -sh cuda rocm
895M	cuda
6.8G	rocm
% find /tmp/ollama921132520/runners -type f | xargs ls -lh
-rwxr-xr-x 1 daniel daniel 2.5M Jul 15 00:31 /tmp/ollama921132520/runners/cpu_avx2/libllama.so
-rwxr-xr-x 1 daniel daniel 1.8M Jul 15 00:31 /tmp/ollama921132520/runners/cpu_avx2/ollama_llama_server
-rwxr-xr-x 1 daniel daniel 7.2M Jul 15 00:31 /tmp/ollama921132520/runners/cpu_avx2/ollama_runner
-rwxr-xr-x 1 daniel daniel 2.5M Jul 15 00:31 /tmp/ollama921132520/runners/cpu_avx/libllama.so
-rwxr-xr-x 1 daniel daniel 1.7M Jul 15 00:31 /tmp/ollama921132520/runners/cpu_avx/ollama_llama_server
-rwxr-xr-x 1 daniel daniel 7.2M Jul 15 00:31 /tmp/ollama921132520/runners/cpu_avx/ollama_runner
-rwxr-xr-x 1 daniel daniel 2.4M Jul 15 00:31 /tmp/ollama921132520/runners/cpu/libllama.so
-rwxr-xr-x 1 daniel daniel 1.7M Jul 15 00:31 /tmp/ollama921132520/runners/cpu/ollama_llama_server
-rwxr-xr-x 1 daniel daniel 7.2M Jul 15 00:31 /tmp/ollama921132520/runners/cpu/ollama_runner
-rwxr-xr-x 1 daniel daniel 233M Jul 15 00:31 /tmp/ollama921132520/runners/cuda_v11/libggml_cuda.so
-rwxr-xr-x 1 daniel daniel 249M Jul 15 00:31 /tmp/ollama921132520/runners/cuda_v11/libllama.so
-rwxr-xr-x 1 daniel daniel 1.7M Jul 15 00:31 /tmp/ollama921132520/runners/cuda_v11/ollama_llama_server
-rwxr-xr-x 1 daniel daniel 7.3M Jul 15 00:31 /tmp/ollama921132520/runners/cuda_v11/ollama_runner
-rwxr-xr-x 1 daniel daniel 234M Jul 15 00:31 /tmp/ollama921132520/runners/cuda_v12/libggml_cuda.so
-rwxr-xr-x 1 daniel daniel 252M Jul 15 00:31 /tmp/ollama921132520/runners/cuda_v12/libllama.so
-rwxr-xr-x 1 daniel daniel 1.7M Jul 15 00:31 /tmp/ollama921132520/runners/cuda_v12/ollama_llama_server
-rwxr-xr-x 1 daniel daniel 7.3M Jul 15 00:31 /tmp/ollama921132520/runners/cuda_v12/ollama_runner
-rwxr-xr-x 1 daniel daniel 178M Jul 15 00:31 /tmp/ollama921132520/runners/rocm_v6.1/libggml_hipblas.so
-rwxr-xr-x 1 daniel daniel 181M Jul 15 00:31 /tmp/ollama921132520/runners/rocm_v6.1/libllama.so
-rwxr-xr-x 1 daniel daniel 1.7M Jul 15 00:31 /tmp/ollama921132520/runners/rocm_v6.1/ollama_llama_server
-rwxr-xr-x 1 daniel daniel 7.3M Jul 15 00:31 /tmp/ollama921132520/runners/rocm_v6.1/ollama_runner
```

