### PR TITLE
Do not reinstall the CLI tools if they are already installed on macOS

### DIFF
--- a/macapp/src/install.ts
+++ b/macapp/src/install.ts
@@ -13,6 +13,8 @@ export function installed() {
 }
 
 export async function install() {
+  if (await installed()) {return}
+  
   const command = `do shell script "mkdir -p ${path.dirname(
     symlinkPath
   )} && ln -F -s \\"${ollama}\\" \\"${symlinkPath}\\"" with administrator privileges`


### PR DESCRIPTION
Check `installed()` inside of the `install` function before running the cli setup commands. Fix #5305.