### PR TITLE
OpenAI Compatibility: Correct Finish Reason Documentation 

### DIFF
--- a/docs/openai.md
+++ b/docs/openai.md
@@ -104,7 +104,6 @@ curl http://localhost:11434/v1/chat/completions \
 
 #### Notes
 
-- `finish_reason` will always be `stop`
 - `usage.prompt_tokens` will be 0 for completions where prompt evaluation is cached
 
 ## Models


### PR DESCRIPTION
`finish_reason` is not bound to only being `stop`

```
curl http://localhost:11434/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d '{
        "model": "llama3",
        "messages": [
            {
                "role": "system",
                "content": "You are a helpful assistant."
            },
            {
                "role": "user",
                "content": "Hello!"
            }
        ],
       "max_tokens": 1
    }' | jq

{
  "id": "chatcmpl-20",
  "object": "chat.completion",
  "created": 1719437652,
  "model": "llama3",
  "system_fingerprint": "fp_ollama",
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "content": "Hello"
      },
      "finish_reason": "length"
    }
  ],
  "usage": {
    "prompt_tokens": 23,
    "completion_tokens": 1,
    "total_tokens": 24
  }
}
```