### PR TITLE
Deprecate `name` from ps response, `model` from ls response

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -326,7 +326,7 @@ type ProcessResponse struct {
 
 // ListModelResponse is a single model description in [ListResponse].
 type ListModelResponse struct {
-	Model      string       `json:"model"`
+	Name       string       `json:"name"`
 	ModifiedAt time.Time    `json:"modified_at"`
 	Size       int64        `json:"size"`
 	Digest     string       `json:"digest"`

--- a/api/types.go
+++ b/api/types.go
@@ -326,7 +326,6 @@ type ProcessResponse struct {
 
 // ListModelResponse is a single model description in [ListResponse].
 type ListModelResponse struct {
-	Name       string       `json:"name"`
 	Model      string       `json:"model"`
 	ModifiedAt time.Time    `json:"modified_at"`
 	Size       int64        `json:"size"`
@@ -336,7 +335,6 @@ type ListModelResponse struct {
 
 // ProcessModelResponse is a single model description in [ProcessResponse].
 type ProcessModelResponse struct {
-	Name      string       `json:"name"`
 	Model     string       `json:"model"`
 	Size      int64        `json:"size"`
 	Digest    string       `json:"digest"`

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -526,7 +526,7 @@ func ListRunningHandler(cmd *cobra.Command, args []string) error {
 	var data [][]string
 
 	for _, m := range models.Models {
-		if len(args) == 0 || strings.HasPrefix(m.Name, args[0]) {
+		if len(args) == 0 || strings.HasPrefix(m.Model, args[0]) {
 			var procStr string
 			switch {
 			case m.SizeVRAM == 0:
@@ -540,7 +540,7 @@ func ListRunningHandler(cmd *cobra.Command, args []string) error {
 				cpuPercent := math.Round(float64(sizeCPU) / float64(m.Size) * 100)
 				procStr = fmt.Sprintf("%d%%/%d%% CPU/GPU", int(cpuPercent), int(100-cpuPercent))
 			}
-			data = append(data, []string{m.Name, m.Digest[:12], format.HumanBytes(m.Size), procStr, format.HumanTime(m.ExpiresAt, "Never")})
+			data = append(data, []string{m.Model, m.Digest[:12], format.HumanBytes(m.Size), procStr, format.HumanTime(m.ExpiresAt, "Never")})
 		}
 	}
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1086,7 +1086,6 @@ A single JSON object will be returned.
 {
   "models": [
     {
-      "name": "mistral:latest",
       "model": "mistral:latest",
       "size": 5137025024,
       "digest": "2ae6f6dd7a3dd734790bbbf58b8909a606e0e7e97e94b7604e0aa7ae4490e6d8",

--- a/server/routes.go
+++ b/server/routes.go
@@ -800,7 +800,6 @@ func (s *Server) ListModelsHandler(c *gin.Context) {
 
 		// tag should never be masked
 		models = append(models, api.ListModelResponse{
-			Model:      n.DisplayShortest(),
 			Name:       n.DisplayShortest(),
 			Size:       m.Size(),
 			Digest:     m.digest,
@@ -1219,7 +1218,6 @@ func (s *Server) ProcessHandler(c *gin.Context) {
 
 		mr := api.ProcessModelResponse{
 			Model:     model.ShortName,
-			Name:      model.ShortName,
 			Size:      int64(v.estimatedTotal),
 			SizeVRAM:  int64(v.estimatedVRAM),
 			Digest:    model.Digest,


### PR DESCRIPTION
Keeping name for ls as removing could be severely breaking, could keep both name and model