### PR TITLE
server/routers.go: Fix checkNameExists

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -426,11 +426,6 @@ func (s *Server) PullModelHandler(c *gin.Context) {
 		return
 	}
 
-	if err := checkNameExists(name); err != nil {
-		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
-
 	ch := make(chan any)
 	go func() {
 		defer close(ch)
@@ -514,7 +509,7 @@ func checkNameExists(name model.Name) error {
 	}
 
 	for n := range names {
-		if strings.EqualFold(n.Filepath(), name.Filepath()) && n != name {
+		if strings.EqualFold(n.Filepath(), name.Filepath()) {
 			return fmt.Errorf("a model with that name already exists")
 		}
 	}
@@ -535,11 +530,6 @@ func (s *Server) CreateModelHandler(c *gin.Context) {
 	name := model.ParseName(cmp.Or(r.Model, r.Name))
 	if !name.IsValid() {
 		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": errtypes.InvalidModelNameErrMsg})
-		return
-	}
-
-	if err := checkNameExists(name); err != nil {
-		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -279,37 +279,6 @@ func TestCase(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			t.Run("create", func(t *testing.T) {
-				w = createRequest(t, s.CreateModelHandler, api.CreateRequest{
-					Name:      strings.ToUpper(tt),
-					Modelfile: fmt.Sprintf("FROM %s", createBinFile(t, nil, nil)),
-					Stream:    &stream,
-				})
-
-				if w.Code != http.StatusBadRequest {
-					t.Fatalf("expected status 500 got %d", w.Code)
-				}
-
-				if !bytes.Equal(w.Body.Bytes(), expect) {
-					t.Fatalf("expected error %s got %s", expect, w.Body.String())
-				}
-			})
-
-			t.Run("pull", func(t *testing.T) {
-				w := createRequest(t, s.PullModelHandler, api.PullRequest{
-					Name:   strings.ToUpper(tt),
-					Stream: &stream,
-				})
-
-				if w.Code != http.StatusBadRequest {
-					t.Fatalf("expected status 500 got %d", w.Code)
-				}
-
-				if !bytes.Equal(w.Body.Bytes(), expect) {
-					t.Fatalf("expected error %s got %s", expect, w.Body.String())
-				}
-			})
-
 			t.Run("copy", func(t *testing.T) {
 				w := createRequest(t, s.CopyModelHandler, api.CopyRequest{
 					Source:      tt,


### PR DESCRIPTION
When copy a model with a existed name, it suppose to error out, but it success.
The old `checkNameExists` only report exist model name in case the name is different, but they are same when both of
them convert to upper case, it means `TEST` and `test` is a same name, but `test` and `test` is not a same name.

```
# ollama cp tinyllama tinyllama
copied 'tinyllama' to 'tinyllama'
```

And we should not check name existence on create and pull, because
it suppose to replace some layers of the existing model