### PR TITLE
fix: add unsupported architecture message for linux/windows

### DIFF
--- a/llm/server.go
+++ b/llm/server.go
@@ -560,6 +560,9 @@ func (s *llmServer) WaitUntilRunning(ctx context.Context) error {
 			if s.status != nil && s.status.LastErrMsg != "" {
 				msg = s.status.LastErrMsg
 			}
+			if strings.Contains(msg, "unknown model") {
+				return fmt.Errorf("this model is not supported by your version of Ollama. You may need to upgrade")
+			}
 			return fmt.Errorf("llama runner process has terminated: %v %s", err, msg)
 		default:
 		}

--- a/llm/status.go
+++ b/llm/status.go
@@ -25,6 +25,7 @@ var errorPrefixes = []string{
 	"CUDA error",
 	"cudaMalloc failed",
 	"\"ERR\"",
+	"architecture",
 }
 
 func (w *StatusWriter) Write(b []byte) (int, error) {


### PR DESCRIPTION
Running unsupported models on linux/windows outputs
`Error: llama runner process has terminated: signal: aborted (core dumped)`

New error message:
`Error: this model is not supported by your version of Ollama. You may need to upgrade`

Resolves: https://github.com/ollama/ollama/issues/4889