### PR TITLE
Only set default keep_alive on initial model load

### DIFF
--- a/envconfig/config_test.go
+++ b/envconfig/config_test.go
@@ -2,8 +2,10 @@ package envconfig
 
 import (
 	"fmt"
+	"math"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -23,6 +25,21 @@ func TestConfig(t *testing.T) {
 	t.Setenv("OLLAMA_FLASH_ATTENTION", "1")
 	LoadConfig()
 	require.True(t, FlashAttention)
+	t.Setenv("OLLAMA_KEEP_ALIVE", "")
+	LoadConfig()
+	require.Equal(t, 5*time.Minute, KeepAlive)
+	t.Setenv("OLLAMA_KEEP_ALIVE", "3")
+	LoadConfig()
+	require.Equal(t, 3*time.Second, KeepAlive)
+	t.Setenv("OLLAMA_KEEP_ALIVE", "1h")
+	LoadConfig()
+	require.Equal(t, 1*time.Hour, KeepAlive)
+	t.Setenv("OLLAMA_KEEP_ALIVE", "-1s")
+	LoadConfig()
+	require.Equal(t, time.Duration(math.MaxInt64), KeepAlive)
+	t.Setenv("OLLAMA_KEEP_ALIVE", "-1")
+	LoadConfig()
+	require.Equal(t, time.Duration(math.MaxInt64), KeepAlive)
 }
 
 func TestClientFromEnvironment(t *testing.T) {


### PR DESCRIPTION
This change fixes the handling of keep_alive so that if client request omits the setting, we only set this on initial load.  Once the model is loaded, if new requests leave this unset, we'll keep whatever keep_alive was there.

Fixes #5272 

```
% ollama run llama3 --keepalive 1h hello
Hello! It's nice to meet you. Is there something I can help you with, or would you like to chat?

% ollama ps
NAME         	ID          	SIZE  	PROCESSOR	UNTIL
llama3:latest	365c0bd3c000	6.7 GB	100% GPU 	59 minutes from now
% curl http://localhost:11434/api/generate -d '{
  "model": "llama3",
  "prompt": "hi",
  "stream": false
}' > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   594  100   534  100    60    797     89 --:--:-- --:--:-- --:--:--   886
% ollama ps
NAME         	ID          	SIZE  	PROCESSOR	UNTIL
llama3:latest	365c0bd3c000	6.7 GB	100% GPU 	59 minutes from now
```

Compare against https://github.com/ollama/ollama/issues/5272#issuecomment-2204491896 showing the incorrect behavior before.