### PR TITLE
use model template by default

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -176,11 +176,7 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 		prompt = req.Prompt
 	case req.Prompt != "":
 		if req.Template == "" {
-			model.Template, err = template.Parse(req.Template)
-			if err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-				return
-			}
+			tmpl = model.Template
 		}
 
 		if req.System == "" {


### PR DESCRIPTION
this fixes a bug introduced in https://github.com/ollama/ollama/pull/5051 which causes generate requests to not use the model template

instead of many more dramatic changes, this change mirrors with the previous behaviour using the existing control flow