### PR TITLE
Bubble up model load error messages

### DIFF
--- a/llm/status.go
+++ b/llm/status.go
@@ -26,6 +26,7 @@ var errorPrefixes = []string{
 	"cudaMalloc failed",
 	"\"ERR\"",
 	"architecture",
+	"error loading model",
 }
 
 func (w *StatusWriter) Write(b []byte) (int, error) {


### PR DESCRIPTION
Looking over a pool of issues reported by users over the past few weeks I see a pattern of generic windows exit codes which more often than not were the result of a model load failure.  This adds the prefix string to detect this so we can report it up instead of just the generic process exit code.