### PR TITLE
types/model: remove knowledge of digest

### DIFF
--- a/types/model/name.go
+++ b/types/model/name.go
@@ -91,7 +91,6 @@ type Name struct {
 	Namespace string
 	Model     string
 	Tag       string
-	RawDigest string
 }
 
 // ParseName parses and assembles a Name from a name string. The
@@ -142,11 +141,6 @@ func ParseName(s string) Name {
 func ParseNameBare(s string) Name {
 	var n Name
 	var promised bool
-
-	s, n.RawDigest, promised = cutLast(s, "@")
-	if promised && n.RawDigest == "" {
-		n.RawDigest = MissingPart
-	}
 
 	// "/" is an illegal tag character, so we can use it to split the host
 	if strings.LastIndex(s, ":") > strings.LastIndex(s, "/") {
@@ -222,10 +216,6 @@ func (n Name) String() string {
 		b.WriteByte(':')
 		b.WriteString(n.Tag)
 	}
-	if n.RawDigest != "" {
-		b.WriteByte('@')
-		b.WriteString(n.RawDigest)
-	}
 	return b.String()
 }
 
@@ -250,16 +240,18 @@ func (n Name) DisplayShortest() string {
 	return sb.String()
 }
 
-func IsValidNamespace(namespace string) bool {
-	return isValidPart(kindNamespace, namespace)
+// IsValidNamespace reports whether the provided string is a valid
+// namespace.
+func IsValidNamespace(s string) bool {
+	return isValidPart(kindNamespace, s)
 }
 
 // IsValid reports whether all parts of the name are present and valid. The
 // digest is a special case, and is checked for validity only if present.
+//
+// Note: The digest check has been removed as is planned to be added back in
+// at a later time.
 func (n Name) IsValid() bool {
-	if n.RawDigest != "" && !isValidPart(kindDigest, n.RawDigest) {
-		return false
-	}
 	return n.IsFullyQualified()
 }
 

--- a/types/model/name_test.go
+++ b/types/model/name_test.go
@@ -122,21 +122,6 @@ func TestParseNameParts(t *testing.T) {
 			},
 			wantFilepath: filepath.Join(part350, part80, part80, part80),
 		},
-		{
-			in: "@digest",
-			want: Name{
-				RawDigest: "digest",
-			},
-			wantValidDigest: false,
-		},
-		{
-			in: "model@sha256:123",
-			want: Name{
-				Model:     "model",
-				RawDigest: "sha256:123",
-			},
-			wantValidDigest: true,
-		},
 	}
 
 	for _, tt := range cases {
@@ -160,22 +145,18 @@ var testCases = map[string]bool{ // name -> valid
 	"_why/_the/_lucky:_stiff": true,
 
 	// minimal
-	"h/n/m:t@d": true,
+	"h/n/m:t": true,
 
 	"host/namespace/model:tag": true,
 	"host/namespace/model":     false,
 	"namespace/model":          false,
 	"model":                    false,
-	"@sha256-1000000000000000000000000000000000000000000000000000000000000000":      false,
-	"model@sha256-1000000000000000000000000000000000000000000000000000000000000000": false,
-	"model@sha256:1000000000000000000000000000000000000000000000000000000000000000": false,
 
 	// long (but valid)
 	part80 + "/" + part80 + "/" + part80 + ":" + part80:  true,
 	part350 + "/" + part80 + "/" + part80 + ":" + part80: true,
 
-	"h/nn/mm:t@sha256-1000000000000000000000000000000000000000000000000000000000000000": true, // bare minimum part sizes
-	"h/nn/mm:t@sha256:1000000000000000000000000000000000000000000000000000000000000000": true, // bare minimum part sizes
+	"h/nn/mm:t": true, // bare minimum part sizes
 
 	// unqualified
 	"m":     false,
@@ -196,11 +177,10 @@ var testCases = map[string]bool{ // name -> valid
 	"@":      false,
 
 	// not starting with alphanum
-	"-hh/nn/mm:tt@dd": false,
-	"hh/-nn/mm:tt@dd": false,
-	"hh/nn/-mm:tt@dd": false,
-	"hh/nn/mm:-tt@dd": false,
-	"hh/nn/mm:tt@-dd": false,
+	"-hh/nn/mm:tt": false,
+	"hh/-nn/mm:tt": false,
+	"hh/nn/-mm:tt": false,
+	"hh/nn/mm:-tt": false,
 
 	// hosts
 	"host:https/namespace/model:tag": true,
@@ -334,7 +314,7 @@ func FuzzName(f *testing.F) {
 	f.Fuzz(func(t *testing.T, s string) {
 		n := ParseNameBare(s)
 		if n.IsValid() {
-			parts := [...]string{n.Host, n.Namespace, n.Model, n.Tag, n.RawDigest}
+			parts := [...]string{n.Host, n.Namespace, n.Model, n.Tag}
 			for _, part := range parts {
 				if part == ".." {
 					t.Errorf("unexpected .. as valid part")


### PR DESCRIPTION
This was leading to ambiguity and confusion in ollama.com, and is not used anywhere in ollama at the moment. Once manifests are addressable by digest, we can add this back in, and in a way that is more tailored to the concept of addressing a manifest by digest.