### PR TITLE
sched: don't error if paging to disk on Windows and macOS

### DIFF
--- a/server/sched.go
+++ b/server/sched.go
@@ -197,25 +197,36 @@ func (s *Scheduler) processPending(ctx context.Context) {
 						break
 					}
 
-					// Block attempting to load a model larger than system memory + GPU memory
 					estimate := llm.EstimateGPULayers(gpus, ggml, pending.model.ProjectorPaths, pending.opts)
 					maxSize := systemMem.FreeMemory
-					for _, gpu := range gpus {
-						if gpu.Library == "cpu" {
-							continue
-						}
-						if loadedCount == 0 {
-							// If no other models are loaded, set the limit based on what's available
-							maxSize += gpu.FreeMemory
-						} else {
-							// Other models could be unloaded, favor total memory for limit
-							maxSize += gpu.TotalMemory
+
+					// Add available GPU memory to the total pool
+					// macOS hardware has unified memory so don't double count
+					if runtime.GOOS != "darwin" {
+						for _, gpu := range gpus {
+							if gpu.Library == "cpu" {
+								continue
+							}
+							if loadedCount == 0 {
+								// If no other models are loaded, set the limit based on what's available
+								maxSize += gpu.FreeMemory
+							} else {
+								// Other models could be unloaded, favor total memory for limit
+								maxSize += gpu.TotalMemory
+							}
 						}
 					}
+
+					// Block attempting to load a model larger than system memory + GPU memory
 					if estimate.TotalSize > maxSize {
 						slog.Warn("model request too large for system", "requested", format.HumanBytes2(estimate.TotalSize), "system", format.HumanBytes2(maxSize))
-						pending.errCh <- fmt.Errorf("requested model (%s) is too large for this system (%s)", format.HumanBytes2(estimate.TotalSize), format.HumanBytes2(maxSize))
-						break
+
+						// Linux will crash if over-allocating memory, so 
+						// return an error to the user
+						if runtime.GOOS == "linux" {
+							pending.errCh <- fmt.Errorf("requested model (%s) is too large for this system (%s)", format.HumanBytes2(estimate.TotalSize), format.HumanBytes2(maxSize))
+							break
+						}
 					}
 
 					// Evaluate if the model will fit in the available system memory, or if we should unload a model first

--- a/server/sched.go
+++ b/server/sched.go
@@ -221,8 +221,8 @@ func (s *Scheduler) processPending(ctx context.Context) {
 					if estimate.TotalSize > maxSize {
 						slog.Warn("model request too large for system", "requested", format.HumanBytes2(estimate.TotalSize), "system", format.HumanBytes2(maxSize))
 
-						// Linux will crash if over-allocating memory, so 
-						// return an error to the user
+						// Linux will crash if over-allocating memory - return an error to the user.
+						// TODO (jmorganca): add reasonable upper limits for darwin and windows as well
 						if runtime.GOOS == "linux" {
 							pending.errCh <- fmt.Errorf("requested model (%s) is too large for this system (%s)", format.HumanBytes2(estimate.TotalSize), format.HumanBytes2(maxSize))
 							break


### PR DESCRIPTION
macOS and Windows don't error when paging to disk, so loosen this check for now to not return an error to users that could still run the model (albeit a little slowly). It also stops us from double counting memory on Apple Silicon Macs.

In the future, we should still select an upper limit on memory for macOS and Windows to avoid timeouts, etc. This PR is meant to unblock 0.1.49 and doesn't include that yet.