### PR TITLE
Bundle missing CRT libraries

### DIFF
--- a/scripts/build_windows.ps1
+++ b/scripts/build_windows.ps1
@@ -107,9 +107,12 @@ function gatherDependencies() {
 
     # TODO - this varies based on host build system and MSVC version - drive from dumpbin output
     # currently works for Win11 + MSVC 2019 + Cuda V11
-    cp "${env:VCToolsRedistDir}\x64\Microsoft.VC*.CRT\msvcp140.dll" "${script:DEPS_DIR}\ollama_runners\"
+    cp "${env:VCToolsRedistDir}\x64\Microsoft.VC*.CRT\msvcp140*.dll" "${script:DEPS_DIR}\ollama_runners\"
     cp "${env:VCToolsRedistDir}\x64\Microsoft.VC*.CRT\vcruntime140.dll" "${script:DEPS_DIR}\ollama_runners\"
     cp "${env:VCToolsRedistDir}\x64\Microsoft.VC*.CRT\vcruntime140_1.dll" "${script:DEPS_DIR}\ollama_runners\"
+    foreach ($part in $("runtime", "stdio", "filesystem", "math", "convert", "heap", "string", "time", "locale", "environment")) {
+        cp "$env:VCToolsRedistDir\..\..\..\Tools\Llvm\x64\bin\api-ms-win-crt-${part}*.dll" "${script:DEPS_DIR}\ollama_runners\"
+    }
 
 
     cp "${script:SRC_DIR}\app\ollama_welcome.ps1" "${script:SRC_DIR}\dist\"


### PR DESCRIPTION
Some users are experienging runner startup errors due to not having these msvc redist libraries on their host

Fixes #4657 

```
> dumpbin /dependents .\llm\build\windows\amd64\cpu\bin\ollama_llama_server.exe
Microsoft (R) COFF/PE Dumper Version 14.29.30154.0
Copyright (C) Microsoft Corporation.  All rights reserved.


Dump of file .\llm\build\windows\amd64\cpu\bin\ollama_llama_server.exe

File Type: EXECUTABLE IMAGE

  Image has the following dependencies:

    WS2_32.dll
    llama.dll
    ggml.dll
    KERNEL32.dll
    MSVCP140.dll
    VCRUNTIME140.dll
    VCRUNTIME140_1.dll
    api-ms-win-crt-runtime-l1-1-0.dll
    api-ms-win-crt-stdio-l1-1-0.dll
    api-ms-win-crt-filesystem-l1-1-0.dll
    api-ms-win-crt-math-l1-1-0.dll
    api-ms-win-crt-convert-l1-1-0.dll
    api-ms-win-crt-heap-l1-1-0.dll
    api-ms-win-crt-string-l1-1-0.dll
    api-ms-win-crt-time-l1-1-0.dll
    api-ms-win-crt-locale-l1-1-0.dll
```

```
> dir .\dist\windows-amd64\ollama_runners\


    Directory: C:\Users\danie\code\ollama\dist\windows-amd64\ollama_runners


Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
d-----          7/8/2024   4:14 PM                cpu
d-----          7/8/2024   4:16 PM                cpu_avx
d-----          7/8/2024   4:19 PM                cpu_avx2
d-----          7/8/2024   4:40 PM                cuda_v11.3
d-----          7/8/2024   5:46 PM                rocm_v5.7
-a----          2/6/2024   8:14 PM          33752 api-ms-win-crt-convert-l1-1-0.dll
-a----          2/6/2024   8:14 PM          30168 api-ms-win-crt-environment-l1-1-0.dll
-a----          2/6/2024   8:14 PM          31672 api-ms-win-crt-filesystem-l1-1-0.dll
-a----          2/6/2024   8:14 PM          30680 api-ms-win-crt-heap-l1-1-0.dll
-a----          2/6/2024   8:14 PM          30168 api-ms-win-crt-locale-l1-1-0.dll
-a----          2/6/2024   8:14 PM          38632 api-ms-win-crt-math-l1-1-0.dll
-a----          2/6/2024   8:14 PM          34264 api-ms-win-crt-runtime-l1-1-0.dll
-a----          2/6/2024   8:14 PM          35776 api-ms-win-crt-stdio-l1-1-0.dll
-a----          2/6/2024   8:14 PM          35800 api-ms-win-crt-string-l1-1-0.dll
-a----          2/6/2024   8:14 PM          32192 api-ms-win-crt-time-l1-1-0.dll
-a----          2/6/2024   8:14 PM         567328 msvcp140.dll
-a----          2/6/2024   8:14 PM          25016 msvcp140_1.dll
-a----          2/6/2024   8:14 PM         186928 msvcp140_2.dll
-a----          2/6/2024   8:14 PM          57392 msvcp140_atomic_wait.dll
-a----          2/6/2024   8:14 PM          21536 msvcp140_codecvt_ids.dll
-a----          2/6/2024   8:14 PM          98336 vcruntime140.dll
-a----          2/6/2024   8:14 PM          38448 vcruntime140_1.dll
```