### PR TITLE
sched: error on over-allocation of system memory when on Linux

### DIFF
--- a/llm/server.go
+++ b/llm/server.go
@@ -122,6 +122,15 @@ func NewLlamaServer(gpus gpu.GpuInfoList, model string, ggml *GGML, adapters, pr
 		}
 	}
 
+	// On linux, over-allocating CPU memory will almost always result in an error
+	if runtime.GOOS == "linux" {
+		systemMemoryRequired := estimate.TotalSize - estimate.VRAMSize
+		if systemMemoryRequired > systemTotalMemory {
+			slog.Warn("model request too large for system", "requested", format.HumanBytes2(systemMemoryRequired), "system", format.HumanBytes2(systemTotalMemory))
+			return nil, fmt.Errorf("model requires more system memory (%s) than is available (%s)", format.HumanBytes2(systemMemoryRequired), format.HumanBytes2(systemTotalMemory))
+		}
+	}
+
 	estimate.log()
 
 	// Loop through potential servers


### PR DESCRIPTION
Model switching no longer works on CPU-only machines and the scheduler instead errors with `requested model is too large for this system` error: 

```
$ ollama run gemma2
Error: requested model (8.4 GiB) is too large for this system (1.9 GiB)
```

This PR changes this behavior to only stop a new model from loading if a crash will take place from over-allocating system memory on Linux. It also moves the check until after scheduling has taken place to avoid an error before knowing if another model would be unloaded.

Example on a 48GB VRAM system with 64GB of system memory

```
$ ollama run llama3:70b-instruct-fp16
Error: requested model requires more system memory (86.8 GiB) than is available (62.5 GiB)
```