### PR TITLE
cmd: better version info when client/server not equal

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1177,11 +1177,10 @@ func versionHandler(cmd *cobra.Command, _ []string) {
 		fmt.Println("Warning: could not connect to a running Ollama instance")
 	}
 
-	if serverVersion != "" {
+	if serverVersion == version.Version {
 		fmt.Printf("ollama version is %s\n", serverVersion)
-	}
-
-	if serverVersion != version.Version {
+	} else {
+		fmt.Printf("ollama server version is %s\n", serverVersion)
 		fmt.Printf("Warning: client version is %s\n", version.Version)
 	}
 }


### PR DESCRIPTION
This pr updates version info when client version != server version

## example

1. **client version == server version**. local build with command `GOFLAGS="'-ldflags=-w -s \"-X=github.com/ollama/ollama/version.Version=v0.2.1-rc3\"'" go build .`
	```shell
	$ ./ollama --version
	ollama version is v0.2.1-rc3
	```
2. **client version != server version**. client is local built with specific version `v0.2.1-rc3`. This sometimes happens when upgrade ollama but not restart server or a client connects to remote ollama server.
	```shell
	$ ./ollama --version
	ollama server version is 0.1.45
	Warning: client version is v0.2.1-rc3
	```
3. **client version != server version**. server built with default version.
	```shell
	$ ./ollama --version
	ollama server version is 0.0.0
	Warning: client version is v0.2.1-rc3
	```

@jmorganca @dhiltgen please help review or give feadback.