### PR TITLE
Refactor cmd.go for Improved Readability

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -126,14 +126,14 @@ func CreateHandler(cmd *cobra.Command, args []string) error {
 			spinner.Stop()
 
 			bar, ok := bars[resp.Digest]
-			if ok {
-				bar.Set(resp.Completed)
+			if !ok {
+				bar = progress.NewBar(fmt.Sprintf("pulling %s...", resp.Digest[7:19]), resp.Total, resp.Completed)
+				bars[resp.Digest] = bar
+				p.Add(resp.Digest, bar)				
 				return nil
 			}
 
-			bar = progress.NewBar(fmt.Sprintf("pulling %s...", resp.Digest[7:19]), resp.Total, resp.Completed)
-			bars[resp.Digest] = bar
-			p.Add(resp.Digest, bar)
+			bar.Set(resp.Completed)
 			return nil
 		}
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -129,8 +129,7 @@ func CreateHandler(cmd *cobra.Command, args []string) error {
 			if !ok {
 				bar = progress.NewBar(fmt.Sprintf("pulling %s...", resp.Digest[7:19]), resp.Total, resp.Completed)
 				bars[resp.Digest] = bar
-				p.Add(resp.Digest, bar)				
-				return nil
+				p.Add(resp.Digest, bar)
 			}
 
 			bar.Set(resp.Completed)


### PR DESCRIPTION
This PR refactors cmd.go to improve readability by eliminating unnecessary nesting, removing redundant count variables, and replacing HasPrefix with TrimPrefix for path manipulation.