### PR TITLE
fix: solve network disruption during downloads, add OLLAMA_DOWNLOAD_CONN setting

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1341,6 +1341,7 @@ func NewCLI() *cobra.Command {
 				envVars["OLLAMA_MAX_QUEUE"],
 				envVars["OLLAMA_MODELS"],
 				envVars["OLLAMA_NUM_PARALLEL"],
+				envVars["OLLAMA_DOWNLOAD_CONN"],
 				envVars["OLLAMA_NOPRUNE"],
 				envVars["OLLAMA_ORIGINS"],
 				envVars["OLLAMA_TMPDIR"],

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -273,3 +273,19 @@ The following server settings may be used to adjust how Ollama handles concurren
 - `OLLAMA_MAX_QUEUE` - The maximum number of requests Ollama will queue when busy before rejecting additional requests. The default is 512
 
 Note: Windows with Radeon GPUs currently default to 1 model maximum due to limitations in ROCm v5.7 for available VRAM reporting.  Once ROCm v6.2 is available, Windows Radeon will follow the defaults above.  You may enable concurrent model loads on Radeon on Windows, but ensure you don't load more models than will fit into your GPUs VRAM.
+
+## How do I select the amount of concurrent connections during model downloads?
+
+The Ollama server can download models using multiple concurrent connections. If the default setting doesn't achieve the desired bandwidth utilization, you can increase the environment variable `OLLAMA_DOWNLOAD_CONN` up to a maximum of 64. The default value is 1, ensuring each Ollama download is given the same priority as other network activities.
+
+- For home and office use, the default value of 1 is ideal to prevent network disruptions on the computer running the Ollama server or its local network. A value of 2 is also reasonable in order to increase network utilization if needed.
+- When running the Ollama server on a host that downloads models each time it is initialized, it may be beneficial to increase the `OLLAMA_DOWNLOAD_CONN` variable. The optimal value is one that maximizes utilization up to the link bandwidth during model downloads without significantly increasing overall network latency, which could negatively impact the API request latency for content generation.
+
+The setting can be set either as environement variable:
+```bash
+export OLLAMA_DOWNLOAD_CONN=2
+````
+or when needed by running the server manually
+```bash
+OLLAMA_DOWNLOAD_CONN=2 ollama server
+````

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -287,5 +287,5 @@ export OLLAMA_DOWNLOAD_CONN=2
 ````
 or when needed by running the server manually
 ```bash
-OLLAMA_DOWNLOAD_CONN=2 ollama server
+OLLAMA_DOWNLOAD_CONN=2 ollama serve
 ````


### PR DESCRIPTION
The process of managing bandwidth for model downloads has been an ongoing journey. 
- Users reported difficulties when downloading model since January in issue #2006
- The feature #2995 was reverted in March 2024

The situation left Ollama server with unsafe network concurrency defaults since, causing problems for many users and people sharing the same network, whether they realize Ollama is the origin of their troubles or not.
In the associated issue, users describe in length the problems caused and creative mitigations.
Fortunately, the root cause is simple: 64 concurrent connections, an extremely aggressive value guaranteed to challenge any network congestion algorithm, and the fix is straightforward: opting for 1 concurrent connection by default per model download.
This PR addresses the root cause while adding the ability to configure network concurrency for download if required, via the `OLLAMA_DOWNLOAD_CONN` setting. 
This PR avoids on purpose any complex, ineffective or hard to configure workarounds, like dynamic concurrency adjustments or manual bandwidth limiting.

From the commit associated:
The Ollama server now downloads models using a single connection. This change addresses the root cause of issue #2006 by following best practices instead of relying on workarounds. Users have been reporting problems associated with model downloads since January 2024, describing issues such as "hogging the entire device", "reliably and repeatedly kills my connection", "freezes completely leaving no choice but to hard reset", "when I download models, everyone in the office gets a really slow internet", and "when downloading large models, it feels like my home network is being DDoSed."

The environment variable `OLLAMA_DOWNLOAD_CONN` can be set to control the number of concurrent connections with a maximum value of 64 (the previous default, an aggressive value - unsafe in some conditions). The new default value is 1, ensuring each Ollama download is given the same priority as other network activities.

An entry in the FAQ describes how to use `OLLAMA_DOWNLOAD_CONN` for different use cases. This patch comes with a safe and unproblematic default value.

Changes include updates to the `envconfig/config.go`, `cmd/cmd.go`, `server/download.go`, and `docs/faq.md` files.