### PR TITLE
Disable mmap by default for Windows ROCm

### DIFF
--- a/llm/server.go
+++ b/llm/server.go
@@ -242,10 +242,10 @@ func NewLlamaServer(gpus gpu.GpuInfoList, model string, ggml *GGML, adapters, pr
 		params = append(params, "--flash-attn")
 	}
 
-	// Windows CUDA should not use mmap for best performance
+	// Windows CUDA/ROCm should not use mmap for best performance
 	// Linux  with a model larger than free space, mmap leads to thrashing
 	// For CPU loads we want the memory to be allocated, not FS cache
-	if (runtime.GOOS == "windows" && gpus[0].Library == "cuda" && opts.UseMMap == nil) ||
+	if (runtime.GOOS == "windows" && (gpus[0].Library == "cuda" || gpus[0].Library == "rocm") && opts.UseMMap == nil) ||
 		(runtime.GOOS == "linux" && systemFreeMemory < estimate.TotalSize && opts.UseMMap == nil) ||
 		(gpus[0].Library == "cpu" && opts.UseMMap == nil) ||
 		(opts.UseMMap != nil && !*opts.UseMMap) {


### PR DESCRIPTION
The same as with CUDA, disabling mmap when using ROCm on windows seems to speed up model load times significantly. I get a >2x speedup in model load times on my 7900xtx when disabling mmap.