### PR TITLE
Add TensorSplit option to runners and API

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -159,18 +159,19 @@ type Options struct {
 
 // Runner options which must be set when the model is loaded into memory
 type Runner struct {
-	UseNUMA   bool  `json:"numa,omitempty"`
-	NumCtx    int   `json:"num_ctx,omitempty"`
-	NumBatch  int   `json:"num_batch,omitempty"`
-	NumGPU    int   `json:"num_gpu,omitempty"`
-	MainGPU   int   `json:"main_gpu,omitempty"`
-	LowVRAM   bool  `json:"low_vram,omitempty"`
-	F16KV     bool  `json:"f16_kv,omitempty"`
-	LogitsAll bool  `json:"logits_all,omitempty"`
-	VocabOnly bool  `json:"vocab_only,omitempty"`
-	UseMMap   *bool `json:"use_mmap,omitempty"`
-	UseMLock  bool  `json:"use_mlock,omitempty"`
-	NumThread int   `json:"num_thread,omitempty"`
+	UseNUMA     bool     `json:"numa,omitempty"`
+	NumCtx      int      `json:"num_ctx,omitempty"`
+	NumBatch    int      `json:"num_batch,omitempty"`
+	NumGPU      int      `json:"num_gpu,omitempty"`
+	MainGPU     int      `json:"main_gpu,omitempty"`
+	LowVRAM     bool     `json:"low_vram,omitempty"`
+	F16KV       bool     `json:"f16_kv,omitempty"`
+	LogitsAll   bool     `json:"logits_all,omitempty"`
+	VocabOnly   bool     `json:"vocab_only,omitempty"`
+	UseMMap     *bool    `json:"use_mmap,omitempty"`
+	UseMLock    bool     `json:"use_mlock,omitempty"`
+	NumThread   int      `json:"num_thread,omitempty"`
+    TensorSplit string   `json:"tensor_split,omitempty"` 
 }
 
 // EmbeddingRequest is the request passed to [Client.Embeddings].
@@ -516,6 +517,7 @@ func DefaultOptions() Options {
 			UseMLock:  false,
 			UseMMap:   nil,
 			UseNUMA:   false,
+            TensorSplit: "",
 		},
 	}
 }

--- a/api/types.go
+++ b/api/types.go
@@ -159,19 +159,19 @@ type Options struct {
 
 // Runner options which must be set when the model is loaded into memory
 type Runner struct {
-	UseNUMA     bool     `json:"numa,omitempty"`
-	NumCtx      int      `json:"num_ctx,omitempty"`
-	NumBatch    int      `json:"num_batch,omitempty"`
-	NumGPU      int      `json:"num_gpu,omitempty"`
-	MainGPU     int      `json:"main_gpu,omitempty"`
-	LowVRAM     bool     `json:"low_vram,omitempty"`
-	F16KV       bool     `json:"f16_kv,omitempty"`
-	LogitsAll   bool     `json:"logits_all,omitempty"`
-	VocabOnly   bool     `json:"vocab_only,omitempty"`
-	UseMMap     *bool    `json:"use_mmap,omitempty"`
-	UseMLock    bool     `json:"use_mlock,omitempty"`
-	NumThread   int      `json:"num_thread,omitempty"`
-    TensorSplit string   `json:"tensor_split,omitempty"` 
+	UseNUMA     bool   `json:"numa,omitempty"`
+	NumCtx      int    `json:"num_ctx,omitempty"`
+	NumBatch    int    `json:"num_batch,omitempty"`
+	NumGPU      int    `json:"num_gpu,omitempty"`
+	MainGPU     int    `json:"main_gpu,omitempty"`
+	LowVRAM     bool   `json:"low_vram,omitempty"`
+	F16KV       bool   `json:"f16_kv,omitempty"`
+	LogitsAll   bool   `json:"logits_all,omitempty"`
+	VocabOnly   bool   `json:"vocab_only,omitempty"`
+	UseMMap     *bool  `json:"use_mmap,omitempty"`
+	UseMLock    bool   `json:"use_mlock,omitempty"`
+	NumThread   int    `json:"num_thread,omitempty"`
+	TensorSplit string `json:"tensor_split,omitempty"`
 }
 
 // EmbeddingRequest is the request passed to [Client.Embeddings].
@@ -220,8 +220,8 @@ type DeleteRequest struct {
 
 // ShowRequest is the request passed to [Client.Show].
 type ShowRequest struct {
-	Model    string `json:"model"`
-	System   string `json:"system"`
+	Model  string `json:"model"`
+	System string `json:"system"`
 
 	// Template is deprecated
 	Template string `json:"template"`
@@ -508,16 +508,16 @@ func DefaultOptions() Options {
 
 		Runner: Runner{
 			// options set when the model is loaded
-			NumCtx:    2048,
-			NumBatch:  512,
-			NumGPU:    -1, // -1 here indicates that NumGPU should be set dynamically
-			NumThread: 0,  // let the runtime decide
-			LowVRAM:   false,
-			F16KV:     true,
-			UseMLock:  false,
-			UseMMap:   nil,
-			UseNUMA:   false,
-            TensorSplit: "",
+			NumCtx:      2048,
+			NumBatch:    512,
+			NumGPU:      -1, // -1 here indicates that NumGPU should be set dynamically
+			NumThread:   0,  // let the runtime decide
+			LowVRAM:     false,
+			F16KV:       true,
+			UseMLock:    false,
+			UseMMap:     nil,
+			UseNUMA:     false,
+			TensorSplit: "",
 		},
 	}
 }

--- a/llm/server.go
+++ b/llm/server.go
@@ -262,13 +262,13 @@ func NewLlamaServer(gpus gpu.GpuInfoList, model string, ggml *GGML, adapters, pr
 
 	params = append(params, "--parallel", fmt.Sprintf("%d", numParallel))
 
-    if opts.Runner.TensorSplit == "" {
-        if estimate.TensorSplit != "" {
-            params = append(params, "--tensor-split", estimate.TensorSplit)
-        }
-    } else {
-        params = append(params, "--tensor-split", opts.Runner.TensorSplit)
-    }
+	if opts.Runner.TensorSplit == "" {
+		if estimate.TensorSplit != "" {
+			params = append(params, "--tensor-split", estimate.TensorSplit)
+		}
+	} else {
+		params = append(params, "--tensor-split", opts.Runner.TensorSplit)
+	}
 
 	for i := range len(servers) {
 		dir := availableServers[servers[i]]

--- a/llm/server.go
+++ b/llm/server.go
@@ -262,9 +262,13 @@ func NewLlamaServer(gpus gpu.GpuInfoList, model string, ggml *GGML, adapters, pr
 
 	params = append(params, "--parallel", fmt.Sprintf("%d", numParallel))
 
-	if estimate.TensorSplit != "" {
-		params = append(params, "--tensor-split", estimate.TensorSplit)
-	}
+    if opts.TensorSplit == "" {
+        if estimate.TensorSplit != "" {
+            params = append(params, "--tensor-split", estimate.TensorSplit)
+        }
+    } else {
+        params = append(params, "--tensor-split", opts.TensorSplit)
+    }
 
 	for i := range len(servers) {
 		dir := availableServers[servers[i]]

--- a/llm/server.go
+++ b/llm/server.go
@@ -262,11 +262,9 @@ func NewLlamaServer(gpus gpu.GpuInfoList, model string, ggml *GGML, adapters, pr
 
 	params = append(params, "--parallel", fmt.Sprintf("%d", numParallel))
 
-	if opts.Runner.TensorSplit == "" {
-		if estimate.TensorSplit != "" {
-			params = append(params, "--tensor-split", estimate.TensorSplit)
-		}
-	} else {
+	if opts.Runner.TensorSplit == "" && estimate.TensorSplit != "" {
+        params = append(params, "--tensor-split", estimate.TensorSplit)
+	} else if opts.Runner.TensorSplit != "" {
 		params = append(params, "--tensor-split", opts.Runner.TensorSplit)
 	}
 

--- a/llm/server.go
+++ b/llm/server.go
@@ -262,12 +262,12 @@ func NewLlamaServer(gpus gpu.GpuInfoList, model string, ggml *GGML, adapters, pr
 
 	params = append(params, "--parallel", fmt.Sprintf("%d", numParallel))
 
-    if opts.TensorSplit == "" {
+    if opts.Runner.TensorSplit == "" {
         if estimate.TensorSplit != "" {
             params = append(params, "--tensor-split", estimate.TensorSplit)
         }
     } else {
-        params = append(params, "--tensor-split", opts.TensorSplit)
+        params = append(params, "--tensor-split", opts.Runner.TensorSplit)
     }
 
 	for i := range len(servers) {

--- a/llm/server.go
+++ b/llm/server.go
@@ -263,7 +263,7 @@ func NewLlamaServer(gpus gpu.GpuInfoList, model string, ggml *GGML, adapters, pr
 	params = append(params, "--parallel", fmt.Sprintf("%d", numParallel))
 
 	if opts.Runner.TensorSplit == "" && estimate.TensorSplit != "" {
-        params = append(params, "--tensor-split", estimate.TensorSplit)
+		params = append(params, "--tensor-split", estimate.TensorSplit)
 	} else if opts.Runner.TensorSplit != "" {
 		params = append(params, "--tensor-split", opts.Runner.TensorSplit)
 	}


### PR DESCRIPTION
This pull request adds non-breaking functionality to Ollama function `NewLlamaServer` and adds a `TensorSplit` field to the `Runner` struct in `api/types.go`.

- Add option to pass a `tensor_split` in "options" object for generate api to manually define how tensors should be split with llama.cpp.
- Add conditional to check for manual `tensor_split` value in the Runner options to set the `tensor_split` parameter, defaults to `estimate.TensorSplit` when no manual `tensor_split` is passed (works exactly the same for existing applications).
- Add `TensorSplit` to `Runner` struct in `api/types.go` for accessing the `tensor_split` value.

I have added this functionality because the team I work with is using Ollama on a server with 8 GPUs. We have run into issues with the automatic tensor splitting causing the server to crash due to unbalanced splitting between the GPUs (the splitting does not account for buffer VRAM usage after the model is loaded). Being able to specify manually the tensor splits has made it easier to implement Ollama on the server.