### PR TITLE
Add Metrics to `api\embed` response

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -259,8 +259,9 @@ type EmbedRequest struct {
 
 // EmbedResponse is the response from [Client.Embed].
 type EmbedResponse struct {
-	Model      string      `json:"model"`
-	Embeddings [][]float32 `json:"embeddings"`
+	Model           string      `json:"model"`
+	Embeddings      [][]float32 `json:"embeddings"`
+	PromptEvalCount int         `json:"prompt_eval_count,omitempty"`
 }
 
 // EmbeddingRequest is the request passed to [Client.Embeddings].

--- a/api/types.go
+++ b/api/types.go
@@ -261,7 +261,6 @@ type EmbedRequest struct {
 type EmbedResponse struct {
 	Model      string      `json:"model"`
 	Embeddings [][]float32 `json:"embeddings"`
-	// PromptEvalCount int         `json:"prompt_eval_count,omitempty"`
 
 	Metrics
 }

--- a/api/types.go
+++ b/api/types.go
@@ -259,9 +259,11 @@ type EmbedRequest struct {
 
 // EmbedResponse is the response from [Client.Embed].
 type EmbedResponse struct {
-	Model           string      `json:"model"`
-	Embeddings      [][]float32 `json:"embeddings"`
-	PromptEvalCount int         `json:"prompt_eval_count,omitempty"`
+	Model      string      `json:"model"`
+	Embeddings [][]float32 `json:"embeddings"`
+	// PromptEvalCount int         `json:"prompt_eval_count,omitempty"`
+
+	Metrics
 }
 
 // EmbeddingRequest is the request passed to [Client.Embeddings].

--- a/api/types.go
+++ b/api/types.go
@@ -262,7 +262,9 @@ type EmbedResponse struct {
 	Model      string      `json:"model"`
 	Embeddings [][]float32 `json:"embeddings"`
 
-	Metrics
+	TotalDuration   time.Duration `json:"total_duration,omitempty"`
+	LoadDuration    time.Duration `json:"load_duration,omitempty"`
+	PromptEvalCount int           `json:"prompt_eval_count,omitempty"`
 }
 
 // EmbeddingRequest is the request passed to [Client.Embeddings].

--- a/integration/embed_test.go
+++ b/integration/embed_test.go
@@ -74,7 +74,7 @@ func TestAllMiniLMBatchEmbed(t *testing.T) {
 	}
 }
 
-func TestAllMiniLmEmbedTruncate(t *testing.T) {
+func TestAllMiniLMEmbedTruncate(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 

--- a/integration/embed_test.go
+++ b/integration/embed_test.go
@@ -36,6 +36,10 @@ func TestAllMiniLMEmbed(t *testing.T) {
 	if res.Embeddings[0][0] != 0.010071031 {
 		t.Fatalf("expected 0.010071031, got %f", res.Embeddings[0][0])
 	}
+
+	if res.PromptEvalCount != 8 {
+		t.Fatalf("expected 8 prompt tokens, got %d", res.PromptEvalCount)
+	}
 }
 
 func TestAllMiniLMBatchEmbed(t *testing.T) {
@@ -63,6 +67,10 @@ func TestAllMiniLMBatchEmbed(t *testing.T) {
 
 	if res.Embeddings[0][0] != 0.010071031 || res.Embeddings[1][0] != -0.009802706 {
 		t.Fatalf("expected 0.010071031 and -0.009802706, got %f and %f", res.Embeddings[0][0], res.Embeddings[1][0])
+	}
+
+	if res.PromptEvalCount != 16 {
+		t.Fatalf("expected 16 prompt tokens, got %d", res.PromptEvalCount)
 	}
 }
 

--- a/llm/ext_server/server.cpp
+++ b/llm/ext_server/server.cpp
@@ -1212,6 +1212,7 @@ struct llama_server_context
                         res.result_json = json
                         {
                             {"embedding", std::vector<float>(n_embd, 0.0f)},
+                            {"prompt_n", slot.n_prompt_tokens_processed},
                         };
                         continue;
                     }
@@ -1220,6 +1221,7 @@ struct llama_server_context
                 res.result_json = json
                 {
                     {"embedding", std::vector<float>(embd, embd + n_embd)},
+                    {"prompt_n", slot.n_prompt_tokens_processed},
                 };
             }
         }
@@ -3211,8 +3213,12 @@ int main(int argc, char **argv) {
                     for (auto & elem : responses) {
                         embeddings.push_back(elem.at("embedding"));
                     }
+                    int total_n_prompt = 0;
+                    for (const auto & elem : responses) {
+                        total_n_prompt += elem.at("prompt_n").get<int>();
+                    }
                     // send the result
-                    json embedding_res = json{{"embedding", embeddings}};
+                    json embedding_res = json{{"embedding", embeddings}, {"prompt_n", total_n_prompt}};
                     return res.set_content(embedding_res.dump(), "application/json; charset=utf-8");
                 }
             });

--- a/llm/ext_server/server.cpp
+++ b/llm/ext_server/server.cpp
@@ -3210,23 +3210,14 @@ int main(int argc, char **argv) {
                     responses = result.result_json.value("results", std::vector<json>{result.result_json});
                     json embeddings = json::array();
 
-                    int total_n_prompt = 0;
-                    float predicted_ms = 0.0;
-                    float prompt_ms = 0.0;
+                    int prompt_n = 0;
                     for (auto & elem : responses) {
                         embeddings.push_back(elem.at("embedding"));
-                        total_n_prompt += elem.at("timings").at("prompt_n").get<int>();
-                        predicted_ms += elem.at("timings").at("predicted_ms").get<double>();
-                        prompt_ms += elem.at("timings").at("prompt_ms").get<double>();
+                        prompt_n += elem.at("timings").at("prompt_n").get<int>();
                     }
 
                     // send the result
-                    LOG_INFO("timing", {
-                        {"\nprompt_ms", prompt_ms},
-                        {"\ntotal_n_prompt", total_n_prompt},
-                        {"\npredicted_ms", predicted_ms},
-                    });
-                    json embedding_res = json{{"embedding", embeddings}, {"prompt_ms", prompt_ms}, {"predicted_ms", predicted_ms}, {"total_n_prompt", total_n_prompt}};
+                    json embedding_res = json{{"embedding", embeddings}, {"prompt_n", prompt_n}};
                     return res.set_content(embedding_res.dump(), "application/json; charset=utf-8");
                 }
             });

--- a/llm/ext_server/server.cpp
+++ b/llm/ext_server/server.cpp
@@ -3216,15 +3216,15 @@ int main(int argc, char **argv) {
                     for (auto & elem : responses) {
                         embeddings.push_back(elem.at("embedding"));
                         total_n_prompt += elem.at("timings").at("prompt_n").get<int>();
-                        predicted_ms += elem.at("timings").at("predicted_ms").get<float>();
-                        prompt_ms += elem.at("timings").at("prompt_ms").get<float>();
+                        predicted_ms += elem.at("timings").at("predicted_ms").get<double>();
+                        prompt_ms += elem.at("timings").at("prompt_ms").get<double>();
                     }
 
                     // send the result
                     LOG_INFO("timing", {
                         {"\nprompt_ms", prompt_ms},
                         {"\ntotal_n_prompt", total_n_prompt},
-                        {"\npredicted_ms", predicted_ms}
+                        {"\npredicted_ms", predicted_ms},
                     });
                     json embedding_res = json{{"embedding", embeddings}, {"prompt_ms", prompt_ms}, {"predicted_ms", predicted_ms}, {"total_n_prompt", total_n_prompt}};
                     return res.set_content(embedding_res.dump(), "application/json; charset=utf-8");

--- a/llm/server.go
+++ b/llm/server.go
@@ -33,7 +33,7 @@ type LlamaServer interface {
 	Ping(ctx context.Context) error
 	WaitUntilRunning(ctx context.Context) error
 	Completion(ctx context.Context, req CompletionRequest, fn func(CompletionResponse)) error
-	Embed(ctx context.Context, input []string) ([][]float32, error)
+	Embed(ctx context.Context, input []string) (*EmbedResponse, error)
 	Tokenize(ctx context.Context, content string) ([]int, error)
 	Detokenize(ctx context.Context, tokens []int) (string, error)
 	Close() error
@@ -878,9 +878,10 @@ type EmbedRequest struct {
 
 type EmbedResponse struct {
 	Embedding [][]float32 `json:"embedding"`
+	PromptN   int         `json:"prompt_n"`
 }
 
-func (s *llmServer) Embed(ctx context.Context, input []string) ([][]float32, error) {
+func (s *llmServer) Embed(ctx context.Context, input []string) (*EmbedResponse, error) {
 	if err := s.sem.Acquire(ctx, 1); err != nil {
 		slog.Error("Failed to acquire semaphore", "error", err)
 		return nil, err
@@ -927,7 +928,7 @@ func (s *llmServer) Embed(ctx context.Context, input []string) ([][]float32, err
 		return nil, fmt.Errorf("unmarshal tokenize response: %w", err)
 	}
 
-	return embedding.Embedding, nil
+	return &embedding, nil
 }
 
 type TokenizeRequest struct {

--- a/llm/server.go
+++ b/llm/server.go
@@ -872,21 +872,13 @@ func (s *llmServer) Completion(ctx context.Context, req CompletionRequest, fn fu
 	return nil
 }
 
-type embedding struct {
-	Embedding [][]float32 `json:"embedding"`
-	PromptN   int         `json:"prompt_n"`
-}
-
 type EmbedRequest struct {
 	Content []string `json:"content"`
 }
 
 type EmbedResponse struct {
-	Embedding [][]float32 `json:"embedding"`
-
-	PromptEvalCount    int
-	PromptEvalDuration time.Duration
-	EvalDuration       time.Duration
+	Embedding       [][]float32 `json:"embedding"`
+	PromptEvalCount int         `json:"prompt_n"`
 }
 
 func (s *llmServer) Embed(ctx context.Context, input []string) (*EmbedResponse, error) {
@@ -931,15 +923,12 @@ func (s *llmServer) Embed(ctx context.Context, input []string) (*EmbedResponse, 
 		return nil, fmt.Errorf("%s", body)
 	}
 
-	var e embedding
+	var e EmbedResponse
 	if err := json.Unmarshal(body, &e); err != nil {
 		return nil, fmt.Errorf("unmarshal tokenize response: %w", err)
 	}
 
-	return &EmbedResponse{
-		Embedding:       e.Embedding,
-		PromptEvalCount: e.PromptN,
-	}, nil
+	return &e, nil
 }
 
 type TokenizeRequest struct {

--- a/llm/server.go
+++ b/llm/server.go
@@ -874,17 +874,7 @@ func (s *llmServer) Completion(ctx context.Context, req CompletionRequest, fn fu
 
 type embedding struct {
 	Embedding [][]float32 `json:"embedding"`
-	// PredictedN int         `json:"predicted_n"`
-	PredictedMS float64 `json:"predicted_ms"`
-	PromptN     int     `json:"total_n_prompt"`
-	PromptMS    float64 `json:"prompt_ms"`
-
-	// Timings struct {
-	// 	PredictedN  int     `json:"predicted_n"`
-	// 	PredictedMS float64 `json:"predicted_ms"`
-	// 	PromptN     int     `json:"prompt_n"`
-	// 	PromptMS    float64 `json:"prompt_ms"`
-	// }
+	PromptN   int         `json:"prompt_n"`
 }
 
 type EmbedRequest struct {
@@ -947,10 +937,8 @@ func (s *llmServer) Embed(ctx context.Context, input []string) (*EmbedResponse, 
 	}
 
 	return &EmbedResponse{
-		Embedding:          e.Embedding,
-		PromptEvalCount:    e.PromptN,
-		PromptEvalDuration: parseDurationMs(e.PromptMS),
-		EvalDuration:       parseDurationMs(e.PredictedMS),
+		Embedding:       e.Embedding,
+		PromptEvalCount: e.PromptN,
 	}, nil
 }
 

--- a/llm/server.go
+++ b/llm/server.go
@@ -874,7 +874,7 @@ func (s *llmServer) Completion(ctx context.Context, req CompletionRequest, fn fu
 
 type embedding struct {
 	Embedding [][]float32 `json:"embedding"`
-	// PredictedN  int         `json:"predicted_n"`
+	// PredictedN int         `json:"predicted_n"`
 	PredictedMS float64 `json:"predicted_ms"`
 	PromptN     int     `json:"total_n_prompt"`
 	PromptMS    float64 `json:"prompt_ms"`

--- a/server/routes.go
+++ b/server/routes.go
@@ -381,17 +381,11 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 		Model:      req.Model,
 		Embeddings: embeddings.Embedding,
 		Metrics: api.Metrics{
-			PromptEvalCount:    embeddings.PromptEvalCount,
-			PromptEvalDuration: embeddings.PromptEvalDuration,
-			EvalDuration:       embeddings.EvalDuration,
-			TotalDuration:      time.Since(checkpointStart),
-			LoadDuration:       checkpointLoaded.Sub(checkpointStart),
+			PromptEvalCount: embeddings.PromptEvalCount,
+			TotalDuration:   time.Since(checkpointStart),
+			LoadDuration:    checkpointLoaded.Sub(checkpointStart),
 		},
 	}
-	slog.Info("total duration", "duration", resp.TotalDuration)
-	slog.Info("load duration", "duration", resp.LoadDuration)
-	slog.Info("prompt eval duration", "duration", resp.PromptEvalDuration)
-	slog.Info("eval duration", "duration", resp.EvalDuration)
 	c.JSON(http.StatusOK, resp)
 }
 

--- a/server/routes.go
+++ b/server/routes.go
@@ -370,13 +370,16 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 		return
 	}
 
-	for i, e := range embeddings {
-		embeddings[i] = normalize(e)
+	for i, e := range embeddings.Embedding {
+		embeddings.Embedding[i] = normalize(e)
 	}
 
+	slog.Info("prompt n", "n", embeddings.PromptN)
+
 	resp := api.EmbedResponse{
-		Model:      req.Model,
-		Embeddings: embeddings,
+		Model:           req.Model,
+		Embeddings:      embeddings.Embedding,
+		PromptEvalCount: embeddings.PromptN,
 	}
 	c.JSON(http.StatusOK, resp)
 }
@@ -428,9 +431,9 @@ func (s *Server) EmbeddingsHandler(c *gin.Context) {
 		return
 	}
 
-	embedding := make([]float64, len(embeddings[0]))
+	embedding := make([]float64, len(embeddings.Embedding[0]))
 
-	for i, v := range embeddings[0] {
+	for i, v := range embeddings.Embedding[0] {
 		embedding[i] = float64(v)
 	}
 

--- a/server/routes.go
+++ b/server/routes.go
@@ -374,8 +374,6 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 		embeddings.Embedding[i] = normalize(e)
 	}
 
-	slog.Info("prompt n", "n", embeddings.PromptN)
-
 	resp := api.EmbedResponse{
 		Model:           req.Model,
 		Embeddings:      embeddings.Embedding,

--- a/server/routes.go
+++ b/server/routes.go
@@ -378,13 +378,11 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 	}
 
 	resp := api.EmbedResponse{
-		Model:      req.Model,
-		Embeddings: embeddings.Embedding,
-		Metrics: api.Metrics{
-			PromptEvalCount: embeddings.PromptEvalCount,
-			TotalDuration:   time.Since(checkpointStart),
-			LoadDuration:    checkpointLoaded.Sub(checkpointStart),
-		},
+		Model:           req.Model,
+		Embeddings:      embeddings.Embedding,
+		TotalDuration:   time.Since(checkpointStart),
+		LoadDuration:    checkpointLoaded.Sub(checkpointStart),
+		PromptEvalCount: embeddings.PromptEvalCount,
 	}
 	c.JSON(http.StatusOK, resp)
 }

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -670,7 +670,7 @@ type mockLlm struct {
 	pingResp           error
 	waitResp           error
 	completionResp     error
-	embedResp          [][]float32
+	embedResp          *llm.EmbedResponse
 	embedRespErr       error
 	tokenizeResp       []int
 	tokenizeRespErr    error
@@ -688,7 +688,7 @@ func (s *mockLlm) WaitUntilRunning(ctx context.Context) error { return s.waitRes
 func (s *mockLlm) Completion(ctx context.Context, req llm.CompletionRequest, fn func(llm.CompletionResponse)) error {
 	return s.completionResp
 }
-func (s *mockLlm) Embed(ctx context.Context, input []string) ([][]float32, error) {
+func (s *mockLlm) Embed(ctx context.Context, input []string) (*llm.EmbedResponse, error) {
 	return s.embedResp, s.embedRespErr
 }
 func (s *mockLlm) Tokenize(ctx context.Context, content string) ([]int, error) {


### PR DESCRIPTION
"timings" is returned per request_completion in server.cpp, which must be aggregated to return metrics for a batch of completions.

supporting: prompt_eval_count (total number of tokens evaluated), load duration, total duration