### PR TITLE
server: return empty slice on empty `/api/embed` request

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -206,7 +206,7 @@ type EmbedRequest struct {
 // EmbedResponse is the response from [Client.Embed].
 type EmbedResponse struct {
 	Model      string      `json:"model"`
-	Embeddings [][]float32 `json:"embeddings,omitempty"`
+	Embeddings [][]float32 `json:"embeddings"`
 }
 
 // EmbeddingRequest is the request passed to [Client.Embeddings].

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -306,8 +306,12 @@ func Test_Routes(t *testing.T) {
 					t.Fatalf("expected model t-bone, got %s", embedResp.Model)
 				}
 
-				if embedResp.Embeddings != nil {
-					t.Fatalf("expected embeddings to be nil, got %v", embedResp.Embeddings)
+				if embedResp.Embeddings == nil {
+					t.Fatalf("expected embeddings to not be nil, got %v", embedResp.Embeddings)
+				}
+
+				if len(embedResp.Embeddings) != 0 {
+					t.Fatalf("expected embeddings to be empty, got %v", embedResp.Embeddings)
 				}
 			},
 		},


### PR DESCRIPTION
Before:

```
curl http://localhost:11434/api/embed \                                 
  -H "Content-Type: application/json" \
  -d '{
    "input": "",
    "model": "all-minilm"
  }'
{"model":"all-minilm"}
```

After:

```
curl http://localhost:11434/api/embed \                                 
  -H "Content-Type: application/json" \
  -d '{
    "input": "",
    "model": "all-minilm"
  }'
{"model":"all-minilm","embeddings":[]}
```