### PR TITLE
Require cached prompt to match certain percentage.

### DIFF
--- a/llm/ext_server/server.cpp
+++ b/llm/ext_server/server.cpp
@@ -1402,7 +1402,12 @@ struct llama_server_context
                 std::string s_prompt = s.prompt.get<std::string>();
                 std::string prefix = common_prefix(s_prompt, prompt_str);
 
-                if (prefix.size() > longest) {
+                if (prefix.size() > longest && prefix.size() > (s_prompt.size()*0.6)) {
+                    LOG_DEBUG("Slot with longest prefix found with atlest 60\% match", {{
+                        "slot_id", s.id,
+                        "Prefix length", prefix.size(),
+                        "Slot prompt lenght", s_prompt.size()
+                    }});
                     slot = &s;
                     longest = prefix.size();
                 }
@@ -1413,7 +1418,7 @@ struct llama_server_context
             return get_slot(-1);
         }
 
-        LOG_DEBUG("slot with common prefix found", {{
+        LOG_DEBUG("slot with common prefix selected", {{
             "slot_id", slot->id,
             "characters", longest
         }});


### PR DESCRIPTION
We have three options:
1. Any number of characters are matched
   - This is the current logic. The issue is even matching beginning of the prompt "<|user|>" leads to the selection of the slot. So, every request is using 1st slot.
2. All characters are matched
   - We can require matching entire prompt. I use OpenWeb UI. It has functionality to edit last prompt. Even editing the last prompt will re-evaluate entire prompt.
3. Partial match
   - This is what I have currently implemented in the PR. It will fix the bug that we are facing and also allow potentially changing the prompt without leading to full re-evaluation. We are matching 60% of the cached prompt but it could be any % value. Essentially, we are asking for re-evaluation if the prompt doesn't match at least 60% with the cached prompt. 


Let me know if you have any other ideas to fix this issue.