### PR TITLE
bump go version to 1.22.5 to fix security vulnerabilities in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GOLANG_VERSION=1.22.1
+ARG GOLANG_VERSION=1.22.5
 ARG CMAKE_VERSION=3.22.1
 # this CUDA_VERSION corresponds with the one specified in docs/gpu.md
 ARG CUDA_VERSION=11.3.1


### PR DESCRIPTION
The existing Version of 1.22.1 Is showing Security Vulnerabilities when scanned by Prisma

Scan results for: image ollama/ollama:latest sha256:56505af4d7ed5e66de96c124c21312aee6cdd518098efd0fa524738f24b1a701
Vulnerabilities
|       CVE        | SEVERITY | CVSS |         PACKAGE          |        VERSION        |          STATUS          | PUBLISHED  | DISCOVERED |                    DESCRIPTION                     |
| CVE-2024-24790   | critical | 9.80 | net/netip                | 1.22.1                | fixed in 1.21.11, 1.22.4 | 42 days    | < 1 hour   | The various Is methods (IsPrivate, IsLoopback,     |
|                  |          |      |                          |                       | 42 days ago              |            |            

This minor update to GO 1.22.5 fixes the CRITICAL CVE-2024-24790, as well as corrects the MEDIUM  CVE-2024-24791  .

I locally built and tested the Docker Build.

Scan results for: image ollama_orig_1_22_5:latest sha256:5b7f98e681c9a7b807d02beecc2eb303a5303a6cd248dcf448ae360e79b759ab
Vulnerabilities found for image ollama_orig_1_22_5:latest: total - 16, critical - 0, high - 0, medium - 4, low - 12

It would be great to get these fixes in ASAP.
