### PR TITLE
README: Added LLMStack to the list of UI integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Kerlig AI](https://www.kerlig.com/) (AI writing assistant for macOS)
 - [AI Studio](https://github.com/MindWorkAI/AI-Studio)
 - [Sidellama](https://github.com/gyopak/sidellama) (browser-based LLM client)
+- [LLMStack](https://github.com/trypromptly/LLMStack) (No-code multi-agent framework to build LLM agents and workflows)
 
 ### Terminal
 


### PR DESCRIPTION
Also wrote a quick guide to show to how to use `ollama` with `LLMStack` at https://docs.trypromptly.com/guides/using-llama3-with-ollama.