### PR TITLE
server: collect nested tool call objects when parsing

### DIFF
--- a/server/model.go
+++ b/server/model.go
@@ -366,7 +366,7 @@ func (m *Model) parseToolCalls(s string) ([]api.ToolCall, bool) {
 		} else {
 			offset += int(decoder.InputOffset())
 
-			// collect all nested-objects
+			// collect all nested objects
 			var collect func(any) []map[string]any
 			collect = func(obj any) (all []map[string]any) {
 				switch o := obj.(type) {

--- a/server/model.go
+++ b/server/model.go
@@ -389,9 +389,9 @@ func (m *Model) parseToolCalls(s string) ([]api.ToolCall, bool) {
 
 	var toolCalls []api.ToolCall
 	for _, kv := range objs {
-		n, nameOk := kv[name].(string)
-		a, argumentsOk := kv[arguments].(map[string]any)
-		if nameOk && argumentsOk {
+		n, nok := kv[name].(string)
+		a, aok := kv[arguments].(map[string]any)
+		if nok && aok {
 			toolCalls = append(toolCalls, api.ToolCall{
 				Function: api.ToolCallFunction{
 					Name:      n,

--- a/server/model.go
+++ b/server/model.go
@@ -348,23 +348,6 @@ func (m *Model) parseToolCalls(s string) ([]api.ToolCall, bool) {
 		return nil, false
 	}
 
-	var collect func(any) []map[string]any
-	collect = func(obj any) (all []map[string]any) {
-		switch o := obj.(type) {
-		case map[string]any:
-			all = append(all, o)
-			for _, v := range o {
-				all = append(all, collect(v)...)
-			}
-		case []any:
-			for _, v := range o {
-				all = append(all, collect(v)...)
-			}
-		}
-
-		return all
-	}
-
 	var objs []map[string]any
 	for offset := 0; offset < len(s); {
 		var obj map[string]any
@@ -382,6 +365,24 @@ func (m *Model) parseToolCalls(s string) ([]api.ToolCall, bool) {
 			return nil, false
 		} else {
 			offset += int(decoder.InputOffset())
+
+			// collect all nested-objects
+			var collect func(any) []map[string]any
+			collect = func(obj any) (all []map[string]any) {
+				switch o := obj.(type) {
+				case map[string]any:
+					all = append(all, o)
+					for _, v := range o {
+						all = append(all, collect(v)...)
+					}
+				case []any:
+					for _, v := range o {
+						all = append(all, collect(v)...)
+					}
+				}
+
+				return all
+			}
 			objs = append(objs, collect(obj)...)
 		}
 	}

--- a/server/model_test.go
+++ b/server/model_test.go
@@ -166,6 +166,7 @@ The temperature in San Francisco, CA is 70°F and in Toronto, Canada is 20°C.`,
 {"name": "get_current_weather", "arguments": {"format":"fahrenheit","location":"San Francisco, CA"}}
 {"name": "get_current_weather", "arguments": {"format":"celsius","location":"Toronto, Canada"}}
 </tool_call>`, true},
+		{"xlam", `{"tool_calls": [{"name": "get_current_weather", "arguments": {"format":"fahrenheit","location":"San Francisco, CA"}},{"name": "get_current_weather", "arguments": {"format":"celsius","location":"Toronto, Canada"}}]}`, true},
 	}
 
 	var tools []api.Tool

--- a/server/routes.go
+++ b/server/routes.go
@@ -1393,11 +1393,9 @@ func (s *Server) ChatHandler(c *gin.Context) {
 		}
 
 		resp.Message.Content = sb.String()
-		slog.Debug("chat response", "content", resp.Message.Content)
 
 		if len(req.Tools) > 0 {
 			if toolCalls, ok := m.parseToolCalls(sb.String()); ok {
-				slog.Debug("parsed tool", "calls", toolCalls)
 				resp.Message.ToolCalls = toolCalls
 				resp.Message.Content = ""
 			}

--- a/server/routes.go
+++ b/server/routes.go
@@ -611,10 +611,10 @@ func (s *Server) CreateModelHandler(c *gin.Context) {
 		quantization := cmp.Or(r.Quantize, r.Quantization)
 		if err := CreateModel(ctx, name, filepath.Dir(r.Path), strings.ToUpper(quantization), f, fn); err != nil {
 			if errors.Is(err, errBadTemplate) {
-			  ch <- gin.H{"error": err.Error(), "status": http.StatusBadRequest}
+				ch <- gin.H{"error": err.Error(), "status": http.StatusBadRequest}
 			}
 			ch <- gin.H{"error": err.Error()}
-		  }
+		}
 	}()
 
 	if r.Stream != nil && !*r.Stream {
@@ -1393,9 +1393,11 @@ func (s *Server) ChatHandler(c *gin.Context) {
 		}
 
 		resp.Message.Content = sb.String()
+		slog.Debug("chat response", "content", resp.Message.Content)
 
 		if len(req.Tools) > 0 {
 			if toolCalls, ok := m.parseToolCalls(sb.String()); ok {
+				slog.Debug("parsed tool", "calls", toolCalls)
 				resp.Message.ToolCalls = toolCalls
 				resp.Message.Content = ""
 			}

--- a/server/testdata/tools/xlam.gotmpl
+++ b/server/testdata/tools/xlam.gotmpl
@@ -1,10 +1,9 @@
-{{ if .System }}{{ .System }}
+{{- if .System }}{{ .System }}
 {{ end }}
-{{- range $i, $m := .Messages }}
+{{- range $i, $_ := .Messages }}
 {{- if eq .Role "user" }}
-{{- $last := (or (eq (len (slice $.Messages $i)) 1) (eq (len (slice $.Messages $i)) 2)) -}}
 ### Instruction:
-{{- if and $.Tools $last }}
+{{ if and $.Tools (le (len (slice $.Messages $i)) 2) }}
 [BEGIN OF TASK INSTRUCTION]
 You are an expert in composing functions. You are given a question and a set of possible functions. 
 Based on the question, you will need to make one or more function/tool calls to achieve the purpose. 

--- a/server/testdata/tools/xlam.gotmpl
+++ b/server/testdata/tools/xlam.gotmpl
@@ -1,8 +1,7 @@
 {{- if .System }}{{ .System }}
 {{ end }}
 {{- range $i, $_ := .Messages }}
-{{- if eq .Role "user" -}}
-### Instruction:
+{{- if eq .Role "user" }}### Instruction:
 {{- if and $.Tools (le (len (slice $.Messages $i)) 2) }}
 [BEGIN OF TASK INSTRUCTION]
 You are an expert in composing functions. You are given a question and a set of possible functions. 

--- a/server/testdata/tools/xlam.gotmpl
+++ b/server/testdata/tools/xlam.gotmpl
@@ -43,7 +43,5 @@ The example format is as follows. Please make sure the parameter type is correct
 {{ else if eq .Role "assistant" }}### Response:
 {{ .Content }}
 <|EOT|>
-{{ else if eq .Role "tool" }}### Instruct:
-The tool response was: {{ .Content }}
 {{ end }}
 {{- end }}### Response:

--- a/server/testdata/tools/xlam.gotmpl
+++ b/server/testdata/tools/xlam.gotmpl
@@ -1,0 +1,49 @@
+{{ if .System }}{{ .System }}
+{{ end }}
+{{- range $i, $m := .Messages }}
+{{- if eq .Role "user" }}
+{{- $last := (or (eq (len (slice $.Messages $i)) 1) (eq (len (slice $.Messages $i)) 2)) -}}
+### Instruction:
+{{- if and $.Tools $last }}
+[BEGIN OF TASK INSTRUCTION]
+You are an expert in composing functions. You are given a question and a set of possible functions. 
+Based on the question, you will need to make one or more function/tool calls to achieve the purpose. 
+If none of the functions can be used, point it out and refuse to answer. 
+If the given question lacks the parameters required by the function, also point it out.
+[END OF TASK INSTRUCTION]
+
+[BEGIN OF AVAILABLE TOOLS]
+{{ $.Tools }}
+[END OF AVAILABLE TOOLS]
+
+[BEGIN OF FORMAT INSTRUCTION]
+The output MUST strictly adhere to the following JSON format, and NO other text MUST be included.
+The example format is as follows. Please make sure the parameter type is correct. If no function call is needed, please make tool_calls an empty list '[]'.
+```
+{
+    "tool_calls": [
+    {"name": "func_name1", "arguments": {"argument1": "value1", "argument2": "value2"}},
+    ... (more tool calls as required)
+    ]
+}
+```
+[END OF FORMAT INSTRUCTION]
+
+[BEGIN OF QUERY]
+{{ .Content }}
+[END OF QUERY]
+
+
+{{ else }}
+{{ .Content }}
+{{ end }}
+{{- else if .ToolCalls }}### Response:
+{"tool_calls": [{{ range .ToolCalls }}{"name": "{{ .Function.Name }}", "arguments": {{ .Function.Arguments }}}{{ end }}]}
+<|EOT|>
+{{ else if eq .Role "assistant" }}### Response:
+{{ .Content }}
+<|EOT|>
+{{ else if eq .Role "tool" }}### Instruct:
+The tool response was: {{ .Content }}
+{{ end }}
+{{- end }}### Response:

--- a/server/testdata/tools/xlam.gotmpl
+++ b/server/testdata/tools/xlam.gotmpl
@@ -1,9 +1,9 @@
 {{- if .System }}{{ .System }}
 {{ end }}
 {{- range $i, $_ := .Messages }}
-{{- if eq .Role "user" }}
+{{- if eq .Role "user" -}}
 ### Instruction:
-{{ if and $.Tools (le (len (slice $.Messages $i)) 2) }}
+{{- if and $.Tools (le (len (slice $.Messages $i)) 2) }}
 [BEGIN OF TASK INSTRUCTION]
 You are an expert in composing functions. You are given a question and a set of possible functions. 
 Based on the question, you will need to make one or more function/tool calls to achieve the purpose. 

--- a/server/testdata/tools/xlam.out
+++ b/server/testdata/tools/xlam.out
@@ -1,0 +1,42 @@
+You are a knowledgable assistant. You can answer questions and perform tasks.
+### Instruction:
+What's the weather like today in Paris?
+### Response:
+{"tool_calls": [{"name": "get_current_weather", "arguments": {"format":"celsius","location":"Paris, France"}}]}
+<|EOT|>
+### Instruct:
+The tool response was: 22
+### Response:
+The current temperature in Paris, France is 22 degrees Celsius.
+<|EOT|>
+### Instruction:
+[BEGIN OF TASK INSTRUCTION]
+You are an expert in composing functions. You are given a question and a set of possible functions. 
+Based on the question, you will need to make one or more function/tool calls to achieve the purpose. 
+If none of the functions can be used, point it out and refuse to answer. 
+If the given question lacks the parameters required by the function, also point it out.
+[END OF TASK INSTRUCTION]
+
+[BEGIN OF AVAILABLE TOOLS]
+[{"type":"function","function":{"name":"get_current_weather","description":"Get the current weather","parameters":{"type":"object","required":["location","format"],"properties":{"format":{"type":"string","description":"The temperature unit to use. Infer this from the users location.","enum":["celsius","fahrenheit"]},"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"}}}}}]
+[END OF AVAILABLE TOOLS]
+
+[BEGIN OF FORMAT INSTRUCTION]
+The output MUST strictly adhere to the following JSON format, and NO other text MUST be included.
+The example format is as follows. Please make sure the parameter type is correct. If no function call is needed, please make tool_calls an empty list '[]'.
+```
+{
+    "tool_calls": [
+    {"name": "func_name1", "arguments": {"argument1": "value1", "argument2": "value2"}},
+    ... (more tool calls as required)
+    ]
+}
+```
+[END OF FORMAT INSTRUCTION]
+
+[BEGIN OF QUERY]
+What's the weather like today in San Francisco and Toronto?
+[END OF QUERY]
+
+
+### Response:

--- a/server/testdata/tools/xlam.out
+++ b/server/testdata/tools/xlam.out
@@ -4,8 +4,6 @@ What's the weather like today in Paris?
 ### Response:
 {"tool_calls": [{"name": "get_current_weather", "arguments": {"format":"celsius","location":"Paris, France"}}]}
 <|EOT|>
-### Instruct:
-The tool response was: 22
 ### Response:
 The current temperature in Paris, France is 22 degrees Celsius.
 <|EOT|>


### PR DESCRIPTION
This changes tool calling to handle the output format:

```
{
    "tool_calls": [
        {"name": "func_name1", "arguments": {"argument1": "value1", "argument2": "value2"}},
        ... (more tool calls as required)
    ]
}
```

To support

https://huggingface.co/Salesforce/xLAM-1b-fc-r
https://huggingface.co/Salesforce/xLAM-7b-fc-r

and future models that may have tool call objects nested in others