### PR TITLE
Update faq.md

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -185,6 +185,7 @@ Refer to the section [above](#how-do-i-configure-ollama-server) for how to set e
 
 - macOS: `~/.ollama/models`
 - Linux: `/usr/share/ollama/.ollama/models`
+- Arch Linux: `/var/lib/ollama/.ollama/models`
 - Windows: `C:\Users\%username%\.ollama\models`
 
 ### How do I set them to a different location?


### PR DESCRIPTION
I tried to find the model storage path in the FAQ, but it was missing: For two of my arch linux based machines, it is "/var/lib/ollama/.ollama/models", not "/usr/share/ollama/.ollama/models". I don't know about other distributions

Added this model storage path to FAQ