### PR TITLE
server: speed up single gguf creates

### DIFF
--- a/server/model.go
+++ b/server/model.go
@@ -179,7 +179,10 @@ func parseFromFile(ctx context.Context, file *os.File, digest string, fn func(ap
 		var layer *Layer
 		if digest != "" && n == stat.Size() {
 			layer, err = NewLayerFromLayer(digest, mediatype, file.Name())
-		} else {
+		}
+
+		// Fallback to creating layer from file copy (either NewLayerFromLayer failed, or digest empty/n != stat.Size())
+		if layer == nil {
 			layer, err = NewLayer(io.NewSectionReader(file, offset, n), mediatype)
 		}
 		if err != nil {

--- a/server/model.go
+++ b/server/model.go
@@ -176,7 +176,12 @@ func parseFromFile(ctx context.Context, file *os.File, digest string, fn func(ap
 			mediatype = "application/vnd.ollama.image.projector"
 		}
 
-		layer, err := NewLayer(io.NewSectionReader(file, offset, n), mediatype)
+		var layer *Layer
+		if digest != "" && n == stat.Size() {
+			layer, err = NewLayerFromLayer(digest, mediatype, file.Name())
+		} else {
+			layer, err = NewLayer(io.NewSectionReader(file, offset, n), mediatype)
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/server/model.go
+++ b/server/model.go
@@ -177,7 +177,7 @@ func parseFromFile(ctx context.Context, file *os.File, digest string, fn func(ap
 		}
 
 		var layer *Layer
-		if digest != "" && n == stat.Size() {
+		if digest != "" && n == stat.Size() && offset == 0 {
 			layer, err = NewLayerFromLayer(digest, mediatype, file.Name())
 		}
 

--- a/server/model.go
+++ b/server/model.go
@@ -179,6 +179,10 @@ func parseFromFile(ctx context.Context, file *os.File, digest string, fn func(ap
 		var layer *Layer
 		if digest != "" && n == stat.Size() && offset == 0 {
 			layer, err = NewLayerFromLayer(digest, mediatype, file.Name())
+		} 
+		if err != nil {
+			layer = nil
+			slog.Warn(fmt.Sprintf("NewLayerFromLayer failed: %v", err))
 		}
 
 		// Fallback to creating layer from file copy (either NewLayerFromLayer failed, or digest empty/n != stat.Size())

--- a/server/model.go
+++ b/server/model.go
@@ -180,8 +180,7 @@ func parseFromFile(ctx context.Context, file *os.File, digest string, fn func(ap
 		if digest != "" && n == stat.Size() && offset == 0 {
 			layer, err = NewLayerFromLayer(digest, mediatype, file.Name())
 			if err != nil {
-				layer = nil
-				slog.Warn(fmt.Sprintf("NewLayerFromLayer failed: %v", err))
+				slog.Debug("could not create new layer from layer", "error", err)			
 			}
 		} 
 		

--- a/server/model.go
+++ b/server/model.go
@@ -178,6 +178,7 @@ func parseFromFile(ctx context.Context, file *os.File, digest string, fn func(ap
 
 		var layer *Layer
 		if digest != "" && n == stat.Size() && offset == 0 {
+			fmt.Println("creating layer from layer")
 			layer, err = NewLayerFromLayer(digest, mediatype, file.Name())
 			if err != nil {
 				slog.Debug("could not create new layer from layer", "error", err)
@@ -186,6 +187,7 @@ func parseFromFile(ctx context.Context, file *os.File, digest string, fn func(ap
 
 		// Fallback to creating layer from file copy (either NewLayerFromLayer failed, or digest empty/n != stat.Size())
 		if layer == nil {
+			fmt.Println("creating layer from file copy")
 			layer, err = NewLayer(io.NewSectionReader(file, offset, n), mediatype)
 			if err != nil {
 				return nil, err

--- a/server/model.go
+++ b/server/model.go
@@ -180,10 +180,10 @@ func parseFromFile(ctx context.Context, file *os.File, digest string, fn func(ap
 		if digest != "" && n == stat.Size() && offset == 0 {
 			layer, err = NewLayerFromLayer(digest, mediatype, file.Name())
 			if err != nil {
-				slog.Debug("could not create new layer from layer", "error", err)			
+				slog.Debug("could not create new layer from layer", "error", err)
 			}
-		} 
-		
+		}
+
 		// Fallback to creating layer from file copy (either NewLayerFromLayer failed, or digest empty/n != stat.Size())
 		if layer == nil {
 			layer, err = NewLayer(io.NewSectionReader(file, offset, n), mediatype)
@@ -191,7 +191,6 @@ func parseFromFile(ctx context.Context, file *os.File, digest string, fn func(ap
 				return nil, err
 			}
 		}
-		
 
 		layers = append(layers, &layerGGML{layer, ggml})
 		offset = n

--- a/server/model.go
+++ b/server/model.go
@@ -178,7 +178,6 @@ func parseFromFile(ctx context.Context, file *os.File, digest string, fn func(ap
 
 		var layer *Layer
 		if digest != "" && n == stat.Size() && offset == 0 {
-			fmt.Println("creating layer from layer")
 			layer, err = NewLayerFromLayer(digest, mediatype, file.Name())
 			if err != nil {
 				slog.Debug("could not create new layer from layer", "error", err)
@@ -187,7 +186,6 @@ func parseFromFile(ctx context.Context, file *os.File, digest string, fn func(ap
 
 		// Fallback to creating layer from file copy (either NewLayerFromLayer failed, or digest empty/n != stat.Size())
 		if layer == nil {
-			fmt.Println("creating layer from file copy")
 			layer, err = NewLayer(io.NewSectionReader(file, offset, n), mediatype)
 			if err != nil {
 				return nil, err

--- a/server/model.go
+++ b/server/model.go
@@ -179,19 +179,20 @@ func parseFromFile(ctx context.Context, file *os.File, digest string, fn func(ap
 		var layer *Layer
 		if digest != "" && n == stat.Size() && offset == 0 {
 			layer, err = NewLayerFromLayer(digest, mediatype, file.Name())
+			if err != nil {
+				layer = nil
+				slog.Warn(fmt.Sprintf("NewLayerFromLayer failed: %v", err))
+			}
 		} 
-		if err != nil {
-			layer = nil
-			slog.Warn(fmt.Sprintf("NewLayerFromLayer failed: %v", err))
-		}
-
+		
 		// Fallback to creating layer from file copy (either NewLayerFromLayer failed, or digest empty/n != stat.Size())
 		if layer == nil {
 			layer, err = NewLayer(io.NewSectionReader(file, offset, n), mediatype)
+			if err != nil {
+				return nil, err
+			}
 		}
-		if err != nil {
-			return nil, err
-		}
+		
 
 		layers = append(layers, &layerGGML{layer, ggml})
 		offset = n

--- a/server/model_test.go
+++ b/server/model_test.go
@@ -157,6 +157,7 @@ func TestParseFromFileFromLayer(t *testing.T) {
 
 	sGGUF := llm.NewGGUFV3(binary.LittleEndian)
 	kv := make(llm.KV)
+	kv["general.architecture"] = "gemma"
 	tensors := []llm.Tensor{}
 
 	if err := sGGUF.Encode(file, kv, tensors); err != nil {
@@ -169,7 +170,9 @@ func TestParseFromFileFromLayer(t *testing.T) {
 	}
 
 	fmt.Println(layers)
-	// assert something here i don't know yet
+
+	// figure out assert
+	// make GGUF valid to decode
 
 	t.Run("2x gguf", func(t *testing.T) {
 		digest := "sha256-fb9d435dc2c4fe681ce63917c062c91022524e9ce57474c9b10ef5169495d903"
@@ -198,7 +201,8 @@ func TestParseFromFileFromLayer(t *testing.T) {
 			t.Fatalf("failed to parse from file: %v", err)
 		}
 
-		// assert on layers
 		fmt.Println(layers)
+
+		// assert on layers
 	})
 }

--- a/server/model_test.go
+++ b/server/model_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/ollama/ollama/api"
-	"github.com/ollama/ollama/envconfig"
 	"github.com/ollama/ollama/llm"
 	"github.com/ollama/ollama/template"
 )
@@ -141,7 +140,6 @@ The temperature in San Francisco, CA is 70°F and in Toronto, Canada is 20°C.`,
 func TestParseFromFileFromLayer(t *testing.T) {
 	tempModels := t.TempDir()
 	t.Setenv("OLLAMA_MODELS",tempModels)
-	envconfig.LoadConfig()
 	digest := "sha256-fb9d435dc2c4fe681ce63917c062c91022524e9ce57474c9b10ef5169495d902"
 
 	_, err := GetBlobsPath(digest)
@@ -151,6 +149,7 @@ func TestParseFromFileFromLayer(t *testing.T) {
 
 	file, err := os.CreateTemp(tempModels+"/blobs", digest)
 	if err != nil {
+		fmt.Printf("failed to open file: %v", err)
 		t.Fatalf("failed to open file: %v", err)
 	}
 	defer file.Close()

--- a/server/model_test.go
+++ b/server/model_test.go
@@ -185,31 +185,33 @@ func TestParseFromFileFromLayer(t *testing.T) {
 	if layers[0].MediaType != layers2[0].MediaType {
 		t.Fatalf("got %v != want %v", layers[0].MediaType, layers2[0].MediaType)
 	}
+}
 
-	t.Run("2x gguf", func(t *testing.T) {
-		file2, err := os.CreateTemp(tempModels, "")
-		if err != nil {
-			t.Fatalf("failed to open file: %v", err)
-		}
-		defer file2.Close()
+func TestParseLayerFromCopy(t *testing.T) {
+	tempModels := t.TempDir()
 
-		for range 5 {
-			if err := llm.WriteGGUF(file2, llm.KV{"general.architecture": "gemma"}, []llm.Tensor{}); err != nil {
-				t.Fatalf("failed to write gguf: %v", err)
-			}
-		}
+	file2, err := os.CreateTemp(tempModels, "")
+	if err != nil {
+		t.Fatalf("failed to open file: %v", err)
+	}
+	defer file2.Close()
 
-		if _, err := file2.Seek(0, io.SeekStart); err != nil {
-			t.Fatalf("failed to seek to start: %v", err)
+	for range 5 {
+		if err := llm.WriteGGUF(file2, llm.KV{"general.architecture": "gemma"}, []llm.Tensor{}); err != nil {
+			t.Fatalf("failed to write gguf: %v", err)
 		}
+	}
 
-		layers, err := parseFromFile(context.Background(), file2, "", func(api.ProgressResponse) {})
-		if err != nil {
-			t.Fatalf("failed to parse from file: %v", err)
-		}
+	if _, err := file2.Seek(0, io.SeekStart); err != nil {
+		t.Fatalf("failed to seek to start: %v", err)
+	}
 
-		if len(layers) != 5 {
-			t.Fatalf("got %d != want 5", len(layers))
-		}
-	})
+	layers, err := parseFromFile(context.Background(), file2, "", func(api.ProgressResponse) {})
+	if err != nil {
+		t.Fatalf("failed to parse from file: %v", err)
+	}
+
+	if len(layers) != 5 {
+		t.Fatalf("got %d != want 5", len(layers))
+	}
 }

--- a/server/model_test.go
+++ b/server/model_test.go
@@ -149,7 +149,6 @@ func TestParseFromFileFromLayer(t *testing.T) {
 
 	file, err := os.CreateTemp(tempModels+"/blobs", digest)
 	if err != nil {
-		fmt.Printf("failed to open file: %v", err)
 		t.Fatalf("failed to open file: %v", err)
 	}
 	defer file.Close()

--- a/server/model_test.go
+++ b/server/model_test.go
@@ -167,7 +167,7 @@ func TestParseFromFileFromLayer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to parse from file: %v", err)
 	}
-	
+
 	fmt.Println(layers)
 	// assert something here i don't know yet
 
@@ -185,16 +185,11 @@ func TestParseFromFileFromLayer(t *testing.T) {
 		}
 		defer file2.Close()
 
-		num1GGUF := llm.NewGGUFV3(binary.LittleEndian)
-		num2GGUF := llm.NewGGUFV3(binary.LittleEndian)
-		kv := make(llm.KV)
-		tensors := []llm.Tensor{}
-
-		if err := num1GGUF.Encode(file2, kv, tensors); err != nil {
+		if err := sGGUF.Encode(file2, kv, tensors); err != nil {
 			t.Fatalf("failed to encode gguf1: %v", err)
 		}
 
-		if err := num2GGUF.Encode(file2, kv, tensors); err != nil {
+		if err := sGGUF.Encode(file2, kv, tensors); err != nil {
 			t.Fatalf("failed to encode gguf2: %v", err)
 		}
 


### PR DESCRIPTION
the blob for a file with a single gguf is already copied to the server on `/api/blobs/:digest`.
on `createModel`, we can avoid the rewriting of this blob.

This does not improve create speeds for safetensors or files with multiple gguf files

New logs
```
[GIN] 2024/07/23 - 17:21:45 | 201 |  5.298126708s |       127.0.0.1 | POST     "/api/blobs/sha256:54696cbcadd1959275fc99f9cc67880d2f38419124da06cdf2140bad2dc3d94c"
[GIN] 2024/07/23 - 17:21:45 | 200 |    8.519125ms |       127.0.0.1 | POST     "/api/create"
```

Old logs
```
[GIN] 2024/07/23 - 17:24:27 | 201 |  5.283626083s |       127.0.0.1 | POST     "/api/blobs/sha256:54696cbcadd1959275fc99f9cc67880d2f38419124da06cdf2140bad2dc3d94c"
[GIN] 2024/07/23 - 17:24:32 | 200 |  4.302020959s |       127.0.0.1 | POST     "/api/create"
```


resolves: https://github.com/ollama/ollama/issues/5388