### PR TITLE
Server tls 3203

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"runtime"
@@ -63,9 +64,24 @@ func checkError(resp *http.Response, body []byte) error {
 // If the variable is not specified, a default ollama host and port will be
 // used.
 func ClientFromEnvironment() (*Client, error) {
+	ollamaHost := envconfig.Host()
+	var httpClient *http.Client
+	if clientTlsConfig := envconfig.ClientTlsConfig(); clientTlsConfig != nil {
+		slog.Info("Using TLS configuration for client")
+		httpClient = &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: clientTlsConfig,
+			},
+		}
+	} else {
+		httpClient = http.DefaultClient
+	}
 	return &Client{
-		base: envconfig.Host(),
-		http: http.DefaultClient,
+		base: &url.URL{
+			Scheme: ollamaHost.Scheme,
+			Host:   ollamaHost.Host,
+		},
+		http: httpClient,
 	}, nil
 }
 

--- a/api/client.go
+++ b/api/client.go
@@ -67,7 +67,7 @@ func ClientFromEnvironment() (*Client, error) {
 	ollamaHost := envconfig.Host()
 	var httpClient *http.Client
 	if clientTlsConfig := envconfig.ClientTlsConfig(); clientTlsConfig != nil {
-		slog.Info("Using TLS configuration for client")
+		slog.Debug("Using TLS configuration for client")
 		httpClient = &http.Client{
 			Transport: &http.Transport{
 				TLSClientConfig: clientTlsConfig,

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1414,7 +1414,13 @@ func NewCLI() *cobra.Command {
 	} {
 		switch cmd {
 		case runCmd:
-			appendEnvDocs(cmd, []envconfig.EnvVar{envVars["OLLAMA_HOST"], envVars["OLLAMA_NOHISTORY"]})
+			appendEnvDocs(cmd, []envconfig.EnvVar{
+				envVars["OLLAMA_HOST"],
+				envVars["OLLAMA_NOHISTORY"],
+				envVars["OLLAMA_TLS_CLIENT_KEY"],
+				envVars["OLLAMA_TLS_CLIENT_CERT"],
+				envVars["OLLAMA_TLS_SERVER_CA"],
+			})
 		case serveCmd:
 			appendEnvDocs(cmd, []envconfig.EnvVar{
 				envVars["OLLAMA_DEBUG"],

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1152,6 +1152,15 @@ func RunServer(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
+	// Make sure host scheme matches TLS config
+	host := envconfig.Host()
+	serverTlsConfig := envconfig.ServerTlsConfig()
+	if host.Scheme == "https" && serverTlsConfig == nil {
+		return fmt.Errorf("cannot use https as the server's host scheme without a TLS configuration")
+	} else if host.Scheme == "http" && serverTlsConfig != nil {
+		return fmt.Errorf("cannot use http as the server's host scheme with a TLS configuration")
+	}
+
 	ln, err := net.Listen("tcp", envconfig.Host().Host)
 	if err != nil {
 		return err

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1423,6 +1423,9 @@ func NewCLI() *cobra.Command {
 				envVars["OLLAMA_LLM_LIBRARY"],
 				envVars["OLLAMA_GPU_OVERHEAD"],
 				envVars["OLLAMA_LOAD_TIMEOUT"],
+				envVars["OLLAMA_TLS_SERVER_KEY"],
+				envVars["OLLAMA_TLS_SERVER_CERT"],
+				envVars["OLLAMA_TLS_CLIENT_CA"],
 			})
 		default:
 			appendEnvDocs(cmd, envs)

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -1,6 +1,8 @@
 package envconfig
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"log/slog"
 	"math"
@@ -226,6 +228,103 @@ func RunnersDir() (p string) {
 	return p
 }
 
+// Get the configuration for the server-side (m)TLS
+func ServerTlsConfig() *tls.Config {
+	// If the host scheme is set to http, no TLS should be enabled
+	if Host().Scheme != "https" {
+		return nil
+	}
+
+	// Read the config from the env
+	keyEnvVar := "OLLAMA_TLS_SERVER_KEY"
+	certEnvVar := "OLLAMA_TLS_SERVER_CERT"
+	caCertEnvVar := "OLLAMA_TLS_CLIENT_CA"
+	keyFile := Var(keyEnvVar)
+	certFile := Var(certEnvVar)
+	caCertFile := Var(caCertEnvVar)
+
+	// If configuring for the server, we need a key and cert pair
+	if keyFile == "" && certFile == "" {
+		slog.Debug("Configuring server without TLS")
+		return nil
+	}
+
+	// If one but not both of key/cert are specified, return an error
+	if (keyFile != "" && certFile == "") || (keyFile == "" && certFile != "") {
+		slog.Error(fmt.Sprintf("both %s and %s must be specified together", keyEnvVar, certEnvVar))
+	}
+
+	// Parse key/cert pair if given
+	tlsConfig := &tls.Config{}
+	if keyFile != "" && certFile != "" {
+		slog.Debug("Configuring server for TLS")
+		if keyCertPair, err := tls.LoadX509KeyPair(certFile, keyFile); err != nil {
+			slog.Error(fmt.Sprintf("failed to load server key/cert pair from %v/%v: %v", keyFile, certFile, err))
+		} else {
+			tlsConfig.Certificates = []tls.Certificate{keyCertPair}
+		}
+	}
+
+	// Parse the CA to enable mTLS
+	if caCertFile != "" {
+		certPool := x509.NewCertPool()
+		if caCert, err := os.ReadFile(caCertFile); err != nil {
+			slog.Error(fmt.Sprintf("failed to load CA from %v: %v", caCertFile, err))
+		} else if !certPool.AppendCertsFromPEM(caCert) {
+			slog.Error(fmt.Sprintf("failed to append CAs from %v", caCertFile))
+		}
+		slog.Debug("Configuring server for mTLS")
+		tlsConfig.ClientCAs = certPool
+		tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
+	}
+	return tlsConfig
+}
+
+// Get the configuration for the client-side (m)TLS
+func ClientTlsConfig() *tls.Config {
+	// If the host scheme is set to http, no TLS should be enabled
+	if Host().Scheme != "https" {
+		return nil
+	}
+
+	// Read the config from the env
+	keyEnvVar := "OLLAMA_TLS_CLIENT_KEY"
+	certEnvVar := "OLLAMA_TLS_CLIENT_CERT"
+	caCertEnvVar := "OLLAMA_TLS_SERVER_CA"
+	keyFile := Var(keyEnvVar)
+	certFile := Var(certEnvVar)
+	caCertFile := Var(caCertEnvVar)
+
+	// If one but not both of key/cert are specified, return an error
+	if (keyFile != "" && certFile == "") || (keyFile == "" && certFile != "") {
+		slog.Error(fmt.Sprintf("both %s and %s must be specified together", keyEnvVar, certEnvVar))
+	}
+
+	// Parse key/cert pair if given
+	tlsConfig := &tls.Config{}
+	if keyFile != "" && certFile != "" {
+		slog.Debug("Configuring client for mTLS")
+		if keyCertPair, err := tls.LoadX509KeyPair(certFile, keyFile); err != nil {
+			slog.Error(fmt.Sprintf("failed to load server key/cert pair from %v/%v: %v", keyFile, certFile, err))
+		} else {
+			tlsConfig.Certificates = []tls.Certificate{keyCertPair}
+		}
+	}
+
+	// Parse the CA to enable non-standard CA
+	if caCertFile != "" {
+		certPool := x509.NewCertPool()
+		if caCert, err := os.ReadFile(caCertFile); err != nil {
+			slog.Error(fmt.Sprintf("failed to load CA from %v: %v", caCertFile, err))
+		} else if !certPool.AppendCertsFromPEM(caCert) {
+			slog.Error(fmt.Sprintf("failed to append CAs from %v", caCertFile))
+		}
+		slog.Debug("Configuring client for non-standard CA")
+		tlsConfig.RootCAs = certPool
+	}
+	return tlsConfig
+}
+
 func Uint(key string, defaultValue uint) func() uint {
 	return func() uint {
 		if s := Var(key); s != "" {
@@ -293,6 +392,18 @@ func AsMap() map[string]EnvVar {
 		"OLLAMA_RUNNERS_DIR":       {"OLLAMA_RUNNERS_DIR", RunnersDir(), "Location for runners"},
 		"OLLAMA_SCHED_SPREAD":      {"OLLAMA_SCHED_SPREAD", SchedSpread(), "Always schedule model across all GPUs"},
 		"OLLAMA_TMPDIR":            {"OLLAMA_TMPDIR", TmpDir(), "Location for temporary files"},
+		// (m)TLS configuration for the server:
+		// - Key/Cert pair: Used to serve TLS requests
+		// - Client CA: Used to validate certs from clients for mTLS
+		"OLLAMA_TLS_SERVER_KEY":  {"OLLAMA_TLS_SERVER_KEY", ServerTlsConfig, "PEM-encoded file with the private key for serving TLS"},
+		"OLLAMA_TLS_SERVER_CERT": {"OLLAMA_TLS_SERVER_CERT", ServerTlsConfig, "PEM-encoded file with the public certificate for serving TLS"},
+		"OLLAMA_TLS_CLIENT_CA":   {"OLLAMA_TLS_CLIENT_CA", ServerTlsConfig, "PEM-encoded file with the public certificate authority for validating clients with mutual TLS"},
+		// (m)TLS configuration for clients
+		// - Key/Cert pair: Used to make mTLS requests to the server
+		// - Server CA: Used to validate the cert from the server for TLS. System CAs used if omitted.
+		"OLLAMA_TLS_CLIENT_KEY":  {"OLLAMA_TLS_CLIENT_KEY", ClientTlsConfig, "PEM-encoded file with the private key for mTLS client calls"},
+		"OLLAMA_TLS_CLIENT_CERT": {"OLLAMA_TLS_CLIENT_CERT", ClientTlsConfig, "PEM-encoded file with the public certificate for mTLS client calls"},
+		"OLLAMA_TLS_SERVER_CA":   {"OLLAMA_TLS_SERVER_CA", ClientTlsConfig, "PEM-encoded file with the public certificate authority for validating the server cert on the client side"},
 	}
 	if runtime.GOOS != "darwin" {
 		ret["CUDA_VISIBLE_DEVICES"] = EnvVar{"CUDA_VISIBLE_DEVICES", CudaVisibleDevices(), "Set which NVIDIA devices are visible"}

--- a/envconfig/config_test.go
+++ b/envconfig/config_test.go
@@ -1,22 +1,13 @@
 package envconfig
 
 import (
-	"crypto/rand"
-	"crypto/rsa"
 	"crypto/tls"
-	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/pem"
-	"fmt"
 	"math"
-	"math/big"
-	"net"
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/ollama/ollama/envconfig/configtest"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -281,93 +272,9 @@ func TestVar(t *testing.T) {
 	}
 }
 
-// Helper struct for testing TLS
-type TLSTestData struct {
-	ServerKey  string
-	ServerCert string
-	ServerCA   string
-	ClientKey  string
-	ClientCert string
-	ClientCA   string
-}
-
-func genKeyCertCA(dir string, label string) (string, string, string) {
-	// Generate the CA key/cert
-	caKey, _ := rsa.GenerateKey(rand.Reader, 2048)
-	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
-	caSerialNumber, _ := rand.Int(rand.Reader, serialNumberLimit)
-	ca := &x509.Certificate{
-		SerialNumber: caSerialNumber,
-		Subject: pkix.Name{
-			Organization: []string{fmt.Sprintf("Root Ollama %s", label)},
-		},
-		NotBefore: time.Now(),
-		NotAfter:  time.Now().Add(time.Hour * 24),
-
-		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
-		BasicConstraintsValid: true,
-		IsCA:                  true,
-	}
-	caCertBytes, _ := x509.CreateCertificate(rand.Reader, ca, ca, &caKey.PublicKey, caKey)
-
-	// Generate the derived key/cert
-	derivedKey, _ := rsa.GenerateKey(rand.Reader, 2048)
-	derivedSerialNumber, _ := rand.Int(rand.Reader, serialNumberLimit)
-	cert := &x509.Certificate{
-		SerialNumber: derivedSerialNumber,
-		Subject: pkix.Name{
-			CommonName:   fmt.Sprintf("foo.bar.%s", label),
-			Organization: []string{fmt.Sprintf("Derived Ollama %s", label)},
-		},
-		NotBefore: time.Now(),
-		NotAfter:  time.Now().Add(time.Hour * 24),
-
-		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
-		BasicConstraintsValid: true,
-		IsCA:                  false,
-		DNSNames:              []string{"localhost"},
-		IPAddresses:           []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
-	}
-	derivedCertBytes, _ := x509.CreateCertificate(rand.Reader, cert, ca, &derivedKey.PublicKey, caKey)
-
-	// Create the PEM serialized versions and return them
-	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caCertBytes})
-	derivedKeyPEM := pem.EncodeToMemory(&pem.Block{
-		Type:  "RSA PRIVATE KEY",
-		Bytes: x509.MarshalPKCS1PrivateKey(derivedKey),
-	})
-	derivedCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derivedCertBytes})
-
-	// Write them all to the output dir
-	keyFile := filepath.Join(dir, fmt.Sprintf("%s.key.pem", label))
-	certFile := filepath.Join(dir, fmt.Sprintf("%s.cert.pem", label))
-	caFile := filepath.Join(dir, fmt.Sprintf("%s.ca.pem", label))
-	os.WriteFile(keyFile, derivedKeyPEM, 0644)
-	os.WriteFile(certFile, derivedCertPEM, 0644)
-	os.WriteFile(caFile, caPEM, 0644)
-
-	// Return the file paths
-	return keyFile, certFile, caFile
-}
-
-func NewTLSTestData(dir string) TLSTestData {
-	serverKey, serverCert, serverCA := genKeyCertCA(dir, "server")
-	clientKey, clientCert, clientCA := genKeyCertCA(dir, "client")
-	return TLSTestData{
-		ServerCA:   serverCA,
-		ServerKey:  serverKey,
-		ServerCert: serverCert,
-		ClientCA:   clientCA,
-		ClientKey:  clientKey,
-		ClientCert: clientCert,
-	}
-}
-
 // Test that config is parsed correctly if all TLS config is given
 func TestTlsConfigFromEnvironment(t *testing.T) {
-	tlsTestData := NewTLSTestData(t.TempDir())
+	tlsTestData := configtest.NewTLSTestData(t.TempDir())
 	t.Setenv("OLLAMA_HOST", "https://localhost:12345")
 	t.Setenv("OLLAMA_TLS_SERVER_KEY", tlsTestData.ServerKey)
 	t.Setenv("OLLAMA_TLS_SERVER_CERT", tlsTestData.ServerCert)
@@ -381,7 +288,7 @@ func TestTlsConfigFromEnvironment(t *testing.T) {
 
 // Test that server TLS config is parsed correctly if only server config is given
 func TestTlsConfigServerOnly(t *testing.T) {
-	tlsTestData := NewTLSTestData(t.TempDir())
+	tlsTestData := configtest.NewTLSTestData(t.TempDir())
 	t.Setenv("OLLAMA_HOST", "https://localhost:12345")
 	t.Setenv("OLLAMA_TLS_SERVER_KEY", tlsTestData.ServerKey)
 	t.Setenv("OLLAMA_TLS_SERVER_CERT", tlsTestData.ServerCert)
@@ -393,7 +300,7 @@ func TestTlsConfigServerOnly(t *testing.T) {
 
 // Test that client TLS config is parsed correctly if only client config is given
 func TestTlsConfigClientOnly(t *testing.T) {
-	tlsTestData := NewTLSTestData(t.TempDir())
+	tlsTestData := configtest.NewTLSTestData(t.TempDir())
 	t.Setenv("OLLAMA_HOST", "https://localhost:12345")
 	t.Setenv("OLLAMA_TLS_CLIENT_KEY", tlsTestData.ClientKey)
 	t.Setenv("OLLAMA_TLS_CLIENT_CERT", tlsTestData.ClientCert)
@@ -404,7 +311,7 @@ func TestTlsConfigClientOnly(t *testing.T) {
 
 // Test that no TLS config is parsed, even if env vars set, when scheme is http
 func TestTlsConfigHTTPOnlyScheme(t *testing.T) {
-	tlsTestData := NewTLSTestData(t.TempDir())
+	tlsTestData := configtest.NewTLSTestData(t.TempDir())
 	t.Setenv("OLLAMA_HOST", "http://localhost:12345")
 	t.Setenv("OLLAMA_TLS_SERVER_KEY", tlsTestData.ServerKey)
 	t.Setenv("OLLAMA_TLS_SERVER_CERT", tlsTestData.ServerCert)
@@ -418,7 +325,7 @@ func TestTlsConfigHTTPOnlyScheme(t *testing.T) {
 
 // Test non-mutual TLS config
 func TestTlsConfigNonMutual(t *testing.T) {
-	tlsTestData := NewTLSTestData(t.TempDir())
+	tlsTestData := configtest.NewTLSTestData(t.TempDir())
 	t.Setenv("OLLAMA_HOST", "https://localhost:12345")
 	t.Setenv("OLLAMA_TLS_SERVER_KEY", tlsTestData.ServerKey)
 	t.Setenv("OLLAMA_TLS_SERVER_CERT", tlsTestData.ServerCert)

--- a/envconfig/configtest/tls_helpers.go
+++ b/envconfig/configtest/tls_helpers.go
@@ -1,0 +1,99 @@
+package configtest
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Helper struct for testing TLS
+type TLSTestData struct {
+	ServerKey  string
+	ServerCert string
+	ServerCA   string
+	ClientKey  string
+	ClientCert string
+	ClientCA   string
+}
+
+func genKeyCertCA(dir string, label string) (string, string, string) {
+	// Generate the CA key/cert
+	caKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	caSerialNumber, _ := rand.Int(rand.Reader, serialNumberLimit)
+	ca := &x509.Certificate{
+		SerialNumber: caSerialNumber,
+		Subject: pkix.Name{
+			Organization: []string{fmt.Sprintf("Root Ollama %s", label)},
+		},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().Add(time.Hour * 24),
+
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caCertBytes, _ := x509.CreateCertificate(rand.Reader, ca, ca, &caKey.PublicKey, caKey)
+
+	// Generate the derived key/cert
+	derivedKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	derivedSerialNumber, _ := rand.Int(rand.Reader, serialNumberLimit)
+	cert := &x509.Certificate{
+		SerialNumber: derivedSerialNumber,
+		Subject: pkix.Name{
+			CommonName:   fmt.Sprintf("foo.bar.%s", label),
+			Organization: []string{fmt.Sprintf("Derived Ollama %s", label)},
+		},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().Add(time.Hour * 24),
+
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  false,
+		DNSNames:              []string{"localhost"},
+		IPAddresses:           []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+	}
+	derivedCertBytes, _ := x509.CreateCertificate(rand.Reader, cert, ca, &derivedKey.PublicKey, caKey)
+
+	// Create the PEM serialized versions and return them
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caCertBytes})
+	derivedKeyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(derivedKey),
+	})
+	derivedCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derivedCertBytes})
+
+	// Write them all to the output dir
+	keyFile := filepath.Join(dir, fmt.Sprintf("%s.key.pem", label))
+	certFile := filepath.Join(dir, fmt.Sprintf("%s.cert.pem", label))
+	caFile := filepath.Join(dir, fmt.Sprintf("%s.ca.pem", label))
+	os.WriteFile(keyFile, derivedKeyPEM, 0644)
+	os.WriteFile(certFile, derivedCertPEM, 0644)
+	os.WriteFile(caFile, caPEM, 0644)
+
+	// Return the file paths
+	return keyFile, certFile, caFile
+}
+
+func NewTLSTestData(dir string) TLSTestData {
+	serverKey, serverCert, serverCA := genKeyCertCA(dir, "server")
+	clientKey, clientCert, clientCA := genKeyCertCA(dir, "client")
+	return TLSTestData{
+		ServerCA:   serverCA,
+		ServerKey:  serverKey,
+		ServerCert: serverCert,
+		ClientCA:   clientCA,
+		ClientKey:  clientKey,
+		ClientCert: clientCert,
+	}
+}

--- a/server/mtls_test.go
+++ b/server/mtls_test.go
@@ -1,0 +1,152 @@
+package server
+
+/**
+ * These tests validate the client/server interactions with various combinations
+ * TLS enabled. The tests validate both the client and server, but live here in
+ * the server package to avoid cyclic dependencies.
+ */
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/envconfig/configtest"
+	"github.com/stretchr/testify/assert"
+)
+
+/////////////
+// Helpers //
+/////////////
+
+func setupListener(t *testing.T) (*net.Listener, int) {
+	// Create a listener on a random port
+	ln, _ := net.Listen("tcp", "localhost:0")
+	port := ln.Addr().(*net.TCPAddr).Port
+	t.Cleanup(func() { ln.Close() })
+	return &ln, port
+}
+
+func startServer(t *testing.T, ln *net.Listener) {
+	server, serverErr := ServeNonBlocking(*ln)
+	t.Cleanup(func() {
+		http.DefaultServeMux = new(http.ServeMux)
+	})
+	assert.Nil(t, serverErr)
+	t.Cleanup(server.Terminate)
+}
+
+func setupClient(t *testing.T) *api.Client {
+	client, clientErr := api.ClientFromEnvironment()
+	assert.Nil(t, clientErr)
+	assert.NotNil(t, client)
+	return client
+}
+
+func runEndToEndTest(t *testing.T, ln *net.Listener) error {
+	startServer(t, ln)
+	client := setupClient(t)
+	return client.Heartbeat(context.Background())
+}
+
+// Test that the client and server can communicate with no TLS enabled
+func TestClientServerNoTLS(t *testing.T) {
+	// Create a listener on a random port
+	ln, port := setupListener(t)
+
+	// Set the testing env and re-parse config
+	t.Setenv("OLLAMA_HOST", fmt.Sprintf("http://localhost:%d", port))
+
+	// Run the end to end test
+	assert.Nil(t, runEndToEndTest(t, ln))
+}
+
+// Test that the client and server can communicate with non-mutual TLS enabled
+func TestClientServerTLS(t *testing.T) {
+	// Generate the TLS data
+	tlsTestData := configtest.NewTLSTestData(t.TempDir())
+
+	// Create a listener on a random port
+	ln, port := setupListener(t)
+
+	// Set the testing env and re-parse config
+	t.Setenv("OLLAMA_HOST", fmt.Sprintf("https://localhost:%d", port))
+	t.Setenv("OLLAMA_TLS_SERVER_KEY", tlsTestData.ServerKey)
+	t.Setenv("OLLAMA_TLS_SERVER_CERT", tlsTestData.ServerCert)
+	t.Setenv("OLLAMA_TLS_SERVER_CA", tlsTestData.ServerCA)
+
+	// Run the end to end test
+	assert.Nil(t, runEndToEndTest(t, ln))
+}
+
+// Test that the client and server can communicate with mutual TLS enabled where
+// the client and server share a CA
+func TestClientServerMTLSSharedCA(t *testing.T) {
+	// Generate the TLS data
+	tlsTestData := configtest.NewTLSTestData(t.TempDir())
+
+	// Create a listener on a random port
+	ln, port := setupListener(t)
+
+	// Set the testing env and re-parse config
+	// NOTE: Reusing server TLS data for client to share CA
+	t.Setenv("OLLAMA_HOST", fmt.Sprintf("https://localhost:%d", port))
+	t.Setenv("OLLAMA_TLS_SERVER_KEY", tlsTestData.ServerKey)
+	t.Setenv("OLLAMA_TLS_SERVER_CERT", tlsTestData.ServerCert)
+	t.Setenv("OLLAMA_TLS_SERVER_CA", tlsTestData.ServerCA)
+	t.Setenv("OLLAMA_TLS_CLIENT_KEY", tlsTestData.ServerKey)
+	t.Setenv("OLLAMA_TLS_CLIENT_CERT", tlsTestData.ServerCert)
+	t.Setenv("OLLAMA_TLS_CLIENT_CA", tlsTestData.ServerCA)
+
+	// Run the end to end test
+	assert.Nil(t, runEndToEndTest(t, ln))
+}
+
+// Test that the client and server can communicate with mutual TLS enabled where
+// the client and server use separate CAs
+func TestClientServerMTLSSeparateCA(t *testing.T) {
+	// Generate the TLS data
+	tlsTestData := configtest.NewTLSTestData(t.TempDir())
+
+	// Create a listener on a random port
+	ln, port := setupListener(t)
+
+	// Set the testing env and re-parse config
+	t.Setenv("OLLAMA_HOST", fmt.Sprintf("https://localhost:%d", port))
+	t.Setenv("OLLAMA_TLS_SERVER_KEY", tlsTestData.ServerKey)
+	t.Setenv("OLLAMA_TLS_SERVER_CERT", tlsTestData.ServerCert)
+	t.Setenv("OLLAMA_TLS_SERVER_CA", tlsTestData.ServerCA)
+	t.Setenv("OLLAMA_TLS_CLIENT_KEY", tlsTestData.ClientKey)
+	t.Setenv("OLLAMA_TLS_CLIENT_CERT", tlsTestData.ClientCert)
+	t.Setenv("OLLAMA_TLS_CLIENT_CA", tlsTestData.ClientCA)
+
+	// Run the end to end test
+	assert.Nil(t, runEndToEndTest(t, ln))
+}
+
+// Test that a client without a key/cert is rejected by a server with mTLS
+func TestClientServerMTLSServerOnly(t *testing.T) {
+	// Generate the TLS data
+	tlsTestData := configtest.NewTLSTestData(t.TempDir())
+	assert.NotNil(t, tlsTestData)
+
+	// Create a listener on a random port
+	ln, port := setupListener(t)
+
+	// Set the testing env for the server to require mTLS and re-parse config
+	t.Setenv("OLLAMA_HOST", fmt.Sprintf("https://localhost:%d", port))
+	t.Setenv("OLLAMA_TLS_SERVER_KEY", tlsTestData.ServerKey)
+	t.Setenv("OLLAMA_TLS_SERVER_CERT", tlsTestData.ServerCert)
+	t.Setenv("OLLAMA_TLS_CLIENT_CA", tlsTestData.ClientCA)
+	startServer(t, ln)
+
+	// Reset config for client to only require TLS
+	t.Setenv("OLLAMA_TLS_SERVER_CA", tlsTestData.ServerCA)
+	client := setupClient(t)
+
+	// Run the end to end test and make sure an error is returned
+	assert.NotNil(t, client.Heartbeat(context.Background()))
+}


### PR DESCRIPTION
**Disclaimer!**

This PR started as a small feature addition and resulted in some significant scope creep when I added the unit tests. I'm certainly open to trying to remove some of that refactoring for `ServerNonBlocking` if that's preferred, but figured it was worth presenting as-is to start the discussion.

## Issues

This issue supports https://github.com/ollama/ollama/issues/3203 by adding encryption between client and server. It does not fully address the issue since the core feature request is for auth.

## Description

This PR adds support for running the primary `ollama` server/client interactions using TLS and Mutual TLS (mTLS). It does not address encryption between the `ollama` server and the individual model servers.

## Changes

The changes in this PR are grouped as follows:

### New `envconfig` variables:

* To boot an (m)TLS server:
    * `OLLAMA_HOST`: If the `scheme` is `https://`, the server will attempt to boot with TLS or mTLS based on the presence of the below variables
    * `OLLAMA_TLS_SERVER_KEY`: File with the private key (required for TLS)
    * `OLLAMA_TLS_SERVER_CERT`: File with the public cert (required for TLS)
    * `OLLAMA_TLS_CLIENT_CA`: File with the CA cert for the key/cert pair the client will use (required for mTLS)
* To connect a client to an (m)TLS server:
    * `OLLAMA_HOST`: If the `scheme` is `https://`, the client will attempt to connect to a (m)TLS server depending on the presence of the below variables
    * `OLLAMA_TLS_SERVER_CA`: File with the CA cert for the server's key/cert pair (required for TLS if the server's key/cert pair is signed by a non-system CA. If not given, but the `scheme` is `https://`, the system CAs will be used.)
    * `OLLAMA_TLS_CLIENT_KEY`: File with the private key for the client when connecting to an mTLS server (required for mTLS)
    * `OLLAMA_TLS_CLIENT_CERT`: File with the public cert for the client when connecting to an mTLS server (required for mTLS)

### Config parsing:

* In `envconfig`, there is a new `getTlsConfig` function which parses all of the TLS-related variables for both client and server
* `getTlsConfig` is used to populate `envconfig.ServerTlsConfig` and `envconfig.ClientTlsconfig` with [tls.Config](https://pkg.go.dev/crypto/tls#Config) objects if configured to use (m)TLS
* If not configured for TLS, these objects will remain `nil` which is the indicator elsewhere in the code that TLS is not enabled

### Server Setup

The primary change in `routes.go` is to add a conditional around calling the `ServeTLS` function on the `http.Server` object based on the value of `envconfig.ServerTlsConfig`.

The rest of the changes there were all made in support of helping to make the server easier to boot in unit tests. For that, I split the `Serve` function into two parts: `ServeNonBlocking` which returns an instance of the `server.Server` struct, and `Serve` which uses `ServeNonBlocking` and then blocks on the server terminating.

### Client Setup

In `client.go`, the change is to look at `envconfig.ClientTlsConfig` and instantiate the `http.Client` accordingly

### Unit Testing

* Add a new testing package `envconfig/configtest` that holds helpers for dynamically generating TLS data
* Extend the `envconfig` tests to test the parsing of config data
* Add a new `server/mtls_test.go` test suite that tests the server/client communication with no TLS, standard TLS, and mTLS

## Testing

In addition to the unit tests, I've also verified that the communication works separately using scripts I have from other projects for generating self-signed mTLS data. Here are the steps I used:

<details>
<summary>gen_mtls_test_files.sh</summary>

```sh
#!/usr/bin/env bash

## Config ######################################################################

# Optional additional SANs can be set with SANS
SANS=${SANS:-""}

# CN can be overloaded
CN=${CN:-"foo.bar.com"}

set -eo pipefail

# Set up additional SANs block
IFS=' ' read -r -a sans_arr <<< "$SANS"
extra_sans=""
counter="1"
for san in "${sans_arr[@]}"
do
    counter=$(expr "$counter" "+" "1")
    echo "Adding SAN DNS.$counter [$san]"
    extra_sans="$extra_sans\nDNS.$counter = $san"
done

root_name="ca"
root_key="$root_name.key.pem"
root_crt="$root_name.cert.pem"

server_name="server"
server_key="$server_name.key.pem"
server_crt="$server_name.cert.pem"

client_name="client"
client_key="$client_name.key.pem"
client_crt="$client_name.cert.pem"

common_config='
[req]
default_bits       = 4096
default_keyfile    = server.key.pem
distinguished_name = req_distinguished_name
x509_extensions    = x509_ext
string_mask        = utf8only

[req_distinguished_name]
countryName                 = Country Name (2 letter code)
countryName_default         = US
stateOrProvinceName         = State or Province Name (full name)
stateOrProvinceName_default = Denver
localityName                = Locality Name (eg, city)
localityName_default        = Denver
organizationName            = Organization Name (eg, company)
organizationName_default    = Gabe Inc
commonName                  = Common Name (eg, YOUR name)
commonName_max              = 64
'

ca_config="
$common_config

[x509_ext]
subjectKeyIdentifier   = hash
authorityKeyIdentifier = keyid:always, issuer
basicConstraints       = critical, CA:TRUE, pathlen:1
keyUsage               = keyCertSign, cRLSign
"

derived_config="
$common_config

[x509_ext]
subjectKeyIdentifier   = hash
authorityKeyIdentifier = keyid,issuer
basicConstraints       = CA:FALSE
keyUsage               = digitalSignature, keyEncipherment
subjectAltName         = @alt_names

[alt_names]
DNS.1 = localhost
$extra_sans
IP.1  = '127.0.0.1'
"

# use wild card in subject, not all clients accept that, but Java grpc client does
# we also have subject alternative names 127.0.0.1 and localhost in our openssl.cnf file (used when creating the server crt)
SUBJ="/C=US/ST=Denver/L=Denver/O=Gabe Inc/CN=$CN"

# Set the expiration for 10 years
expiration_days=3650

## Root ########################################################################


# Create the root key
echo "[Creating root key]"
openssl genrsa -out $root_key 2048

# create root key and cert
echo "[Creating root cert]"
openssl req \
    -config <(echo -e "$ca_config") \
    -x509 \
    -new \
    -nodes \
    -key $root_key \
    -sha256 \
    -subj "$SUBJ" \
    -out $root_crt

## Server ######################################################################

# create a new server key and certificate signing request
echo "[Creating server key and signing request]"
openssl req -config <(echo -e "$derived_config") -new -nodes -sha256 -keyout $server_key -out $server_name.csr -newkey rsa:2048 -subj "$SUBJ"

# sign the request with our root cert key
echo "[Sign server cert]"
openssl x509 -req -sha256 -extfile <(echo -e "$derived_config") -extensions x509_ext -in $server_name.csr -CA $root_crt -CAkey $root_key -CAcreateserial -out $server_crt -days $expiration_days

# write out server key in pkcs8 format, required by grpc
echo "[Convert server key to pkcs8]"
cp $server_key $server_key.tmp
openssl pkcs8 -topk8 -nocrypt -in $server_key.tmp -out $server_key

## Client ######################################################################

# create a new server key and certificate signing request
echo "[Creating client key and signing request]"
openssl req -config <(echo -e "$derived_config") -new -nodes -sha256 -keyout $client_key -out $client_name.csr -newkey rsa:2048 -subj "$SUBJ"

# sign the request with our root cert key
echo "[Sign client cert]"
openssl x509 -req -sha256 -extfile <(echo -e "$derived_config") -extensions x509_ext -in $client_name.csr -CA $root_crt -CAkey $root_key -CAcreateserial -out $client_crt -days $expiration_days

# write out client key in pkcs8 format, required by grpc
echo "[Convert client key to pkcs8]"
cp $client_key $client_key.tmp
openssl pkcs8 -topk8 -nocrypt -in $client_key.tmp -out $client_key

# Clean up
rm *.tmp
rm *.csr
rm *.srl
```
</details>

```sh
# Using the above gen_mtls_test_files.sh
gen_mtls_test_files.sh

# Build it
go build .

# Boot the server with mTLS enabled
OLLAMA_HOST="https://localhost:54321" \
OLLAMA_TLS_SERVER_KEY=server.key.pem \
OLLAMA_TLS_SERVER_CERT=server.cert.pem \
OLLAMA_TLS_CLIENT_CA=ca.cert.pem \
./ollama serve

# Run a client command with mTLS enabled (separate terminal or background the server)
OLLAMA_HOST="https://127.0.0.1:54321" \
OLLAMA_TLS_SERVER_CA=ca.cert.pem \
OLLAMA_TLS_CLIENT_KEY=client.key.pem \
OLLAMA_TLS_CLIENT_CERT=client.cert.pem  \
./ollama ls
```