### PR TITLE
Prevent loading too large models on windows

### DIFF
--- a/llm/server.go
+++ b/llm/server.go
@@ -124,8 +124,9 @@ func NewLlamaServer(gpus gpu.GpuInfoList, model string, ggml *GGML, adapters, pr
 		}
 	}
 
-	// On linux, over-allocating CPU memory will almost always result in an error
-	if runtime.GOOS == "linux" {
+	// On linux and windows, over-allocating CPU memory will almost always result in an error
+	// Darwin has fully dynamic swap so has no direct concept of free swap space
+	if runtime.GOOS != "darwin" {
 		systemMemoryRequired := estimate.TotalSize - estimate.VRAMSize
 		available := systemFreeMemory + systemSwapFreeMemory
 		if systemMemoryRequired > available {


### PR DESCRIPTION
We already blocked linux memory exhaustion, but should apply the same check for Windows as well

We can't apply the same logic to MacOS, as it uses fully dynamic swap space and has no concept of free swap space.

Fixes #5882 
Fixes #4955
Fixes #5958