### PR TITLE
server: convert progress

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -124,6 +124,7 @@ func CreateHandler(cmd *cobra.Command, args []string) error {
 	}
 
 	bars := make(map[string]*progress.Bar)
+	var convertSpin *progress.Spinner
 	fn := func(resp api.ProgressResponse) error {
 		if resp.Digest != "" {
 			spinner.Stop()
@@ -136,6 +137,16 @@ func CreateHandler(cmd *cobra.Command, args []string) error {
 			}
 
 			bar.Set(resp.Completed)
+		} else if strings.Contains(resp.Status, "converting") {
+			spinner.Stop()
+
+			if convertSpin != nil {
+				convertSpin.SetMessage(resp.Status)
+			} else {
+				status = resp.Status
+				convertSpin = progress.NewSpinner(resp.Status)
+				p.Add("convert", convertSpin)
+			}
 		} else if status != resp.Status {
 			spinner.Stop()
 

--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -19,6 +19,7 @@ import (
 
 	"golang.org/x/exp/maps"
 
+	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/llm"
 )
 
@@ -31,7 +32,7 @@ func convertFull(t *testing.T, fsys fs.FS) (*os.File, llm.KV, llm.Tensors) {
 	}
 	defer f.Close()
 
-	if err := ConvertModel(fsys, f); err != nil {
+	if err := ConvertModel(fsys, f, func(api.ProgressResponse){}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -150,7 +151,7 @@ func TestConvertInvalidDatatype(t *testing.T) {
 	tempDir := t.TempDir()
 	generateSafetensorTestData(t, tempDir)
 
-	err = ConvertModel(os.DirFS(tempDir), f)
+	err = ConvertModel(os.DirFS(tempDir), f, func(api.ProgressResponse){})
 	if err == nil || err.Error() != "unsupported safetensors model" {
 		t.Errorf("expected error but didn't get one")
 	}
@@ -287,7 +288,7 @@ func TestConvertAdapter(t *testing.T) {
 			tempDir := t.TempDir()
 			generateLoraTestData(t, tempDir)
 
-			if err = ConvertAdapter(os.DirFS(tempDir), f, c.BaseKV); err != nil {
+			if err = ConvertAdapter(os.DirFS(tempDir), f, c.BaseKV, func(api.ProgressResponse){}); err != nil {
 				t.Fatal(err)
 			}
 

--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -32,7 +32,7 @@ func convertFull(t *testing.T, fsys fs.FS) (*os.File, llm.KV, llm.Tensors) {
 	}
 	defer f.Close()
 
-	if err := ConvertModel(fsys, f, func(api.ProgressResponse){}); err != nil {
+	if err := ConvertModel(fsys, f, func(api.ProgressResponse) {}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -151,7 +151,7 @@ func TestConvertInvalidDatatype(t *testing.T) {
 	tempDir := t.TempDir()
 	generateSafetensorTestData(t, tempDir)
 
-	err = ConvertModel(os.DirFS(tempDir), f, func(api.ProgressResponse){})
+	err = ConvertModel(os.DirFS(tempDir), f, func(api.ProgressResponse) {})
 	if err == nil || err.Error() != "unsupported safetensors model" {
 		t.Errorf("expected error but didn't get one")
 	}
@@ -288,7 +288,7 @@ func TestConvertAdapter(t *testing.T) {
 			tempDir := t.TempDir()
 			generateLoraTestData(t, tempDir)
 
-			if err = ConvertAdapter(os.DirFS(tempDir), f, c.BaseKV, func(api.ProgressResponse){}); err != nil {
+			if err = ConvertAdapter(os.DirFS(tempDir), f, c.BaseKV, func(api.ProgressResponse) {}); err != nil {
 				t.Fatal(err)
 			}
 

--- a/llm/gguf.go
+++ b/llm/gguf.go
@@ -11,8 +11,9 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/ollama/ollama/api"
 	"golang.org/x/exp/maps"
+
+	"github.com/ollama/ollama/api"
 )
 
 type containerGGUF struct {

--- a/llm/memory_test.go
+++ b/llm/memory_test.go
@@ -41,7 +41,7 @@ func TestEstimateGPULayers(t *testing.T) {
 		"tokenizer.ggml.tokens":         []string{" "},
 		"tokenizer.ggml.scores":         []float32{0},
 		"tokenizer.ggml.token_type":     []int32{0},
-	}, tensors, func(api.ProgressResponse){})
+	}, tensors, func(api.ProgressResponse) {})
 	require.NoError(t, err)
 
 	ggml, err := LoadModel(f.Name(), 0)

--- a/llm/memory_test.go
+++ b/llm/memory_test.go
@@ -41,7 +41,7 @@ func TestEstimateGPULayers(t *testing.T) {
 		"tokenizer.ggml.tokens":         []string{" "},
 		"tokenizer.ggml.scores":         []float32{0},
 		"tokenizer.ggml.token_type":     []int32{0},
-	}, tensors)
+	}, tensors, func(api.ProgressResponse){})
 	require.NoError(t, err)
 
 	ggml, err := LoadModel(f.Name(), 0)

--- a/server/model.go
+++ b/server/model.go
@@ -98,7 +98,6 @@ func parseFromZipFile(_ context.Context, command string, baseLayers []*layerGGML
 	}
 	defer os.RemoveAll(p)
 
-	fn(api.ProgressResponse{Status: "converting model"})
 	// TODO(mxyng): this should write directly into a layer
 	// e.g. NewLayer(arch.Reader(), "application/vnd.ollama.image.model")
 	t, err := os.CreateTemp(p, "fp16")
@@ -123,13 +122,18 @@ func parseFromZipFile(_ context.Context, command string, baseLayers []*layerGGML
 		if baseModel == nil {
 			return nil, fmt.Errorf("no base model specified for the adapter")
 		}
-
-		if err := convert.ConvertAdapter(convert.NewZipReader(r, p, 32<<20), t, baseModel.KV()); err != nil {
+		fn(api.ProgressResponse{
+			Status: "converting adapter",
+		})
+		if err := convert.ConvertAdapter(convert.NewZipReader(r, p, 32<<20), t, baseModel.KV(), fn); err != nil {
 			return nil, err
 		}
 		layerType = "application/vnd.ollama.image.adapter"
 	case "model":
-		if err := convert.ConvertModel(convert.NewZipReader(r, p, 32<<20), t); err != nil {
+		fn(api.ProgressResponse{
+			Status: "converting model",
+		})
+		if err := convert.ConvertModel(convert.NewZipReader(r, p, 32<<20), t, fn); err != nil {
 			return nil, err
 		}
 		layerType = "application/vnd.ollama.image.model"

--- a/server/model_test.go
+++ b/server/model_test.go
@@ -145,7 +145,7 @@ func TestParseFromFileFromLayer(t *testing.T) {
 		t.Fatalf("failed to open file: %v", err)
 	}
 	defer file.Close()
-	if err := llm.WriteGGUF(file, llm.KV{"general.architecture": "gemma"}, []llm.Tensor{}, func(api.ProgressResponse){}); err != nil {
+	if err := llm.WriteGGUF(file, llm.KV{"general.architecture": "gemma"}, []llm.Tensor{}, func(api.ProgressResponse) {}); err != nil {
 		t.Fatalf("failed to write gguf: %v", err)
 	}
 
@@ -197,7 +197,7 @@ func TestParseLayerFromCopy(t *testing.T) {
 	defer file2.Close()
 
 	for range 5 {
-		if err := llm.WriteGGUF(file2, llm.KV{"general.architecture": "gemma"}, []llm.Tensor{}, func(api.ProgressResponse){}); err != nil {
+		if err := llm.WriteGGUF(file2, llm.KV{"general.architecture": "gemma"}, []llm.Tensor{}, func(api.ProgressResponse) {}); err != nil {
 			t.Fatalf("failed to write gguf: %v", err)
 		}
 	}

--- a/server/model_test.go
+++ b/server/model_test.go
@@ -145,7 +145,7 @@ func TestParseFromFileFromLayer(t *testing.T) {
 		t.Fatalf("failed to open file: %v", err)
 	}
 	defer file.Close()
-	if err := llm.WriteGGUF(file, llm.KV{"general.architecture": "gemma"}, []llm.Tensor{}); err != nil {
+	if err := llm.WriteGGUF(file, llm.KV{"general.architecture": "gemma"}, []llm.Tensor{}, func(api.ProgressResponse){}); err != nil {
 		t.Fatalf("failed to write gguf: %v", err)
 	}
 
@@ -197,7 +197,7 @@ func TestParseLayerFromCopy(t *testing.T) {
 	defer file2.Close()
 
 	for range 5 {
-		if err := llm.WriteGGUF(file2, llm.KV{"general.architecture": "gemma"}, []llm.Tensor{}); err != nil {
+		if err := llm.WriteGGUF(file2, llm.KV{"general.architecture": "gemma"}, []llm.Tensor{}, func(api.ProgressResponse){}); err != nil {
 			t.Fatalf("failed to write gguf: %v", err)
 		}
 	}

--- a/server/routes_create_test.go
+++ b/server/routes_create_test.go
@@ -30,7 +30,7 @@ func createBinFile(t *testing.T, kv map[string]any, ti []llm.Tensor) string {
 	}
 	defer f.Close()
 
-	if err := llm.WriteGGUF(f, kv, ti, func(api.ProgressResponse){}); err != nil {
+	if err := llm.WriteGGUF(f, kv, ti, func(api.ProgressResponse) {}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/server/routes_create_test.go
+++ b/server/routes_create_test.go
@@ -30,7 +30,7 @@ func createBinFile(t *testing.T, kv map[string]any, ti []llm.Tensor) string {
 	}
 	defer f.Close()
 
-	if err := llm.WriteGGUF(f, kv, ti); err != nil {
+	if err := llm.WriteGGUF(f, kv, ti, func(api.ProgressResponse){}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -128,8 +128,8 @@ func newScenarioRequest(t *testing.T, ctx context.Context, modelName string, est
 	}, []llm.Tensor{
 		{Name: "blk.0.attn.weight", Kind: uint32(0), Offset: uint64(0), Shape: []uint64{1, 1, 1, 1}, WriterTo: bytes.NewReader(make([]byte, 32))},
 		{Name: "output.weight", Kind: uint32(0), Offset: uint64(0), Shape: []uint64{1, 1, 1, 1}, WriterTo: bytes.NewReader(make([]byte, 32))},
-	}, 
-	func(api.ProgressResponse){}))
+	},
+		func(api.ProgressResponse) {}))
 	require.NoError(t, err)
 
 	fname := f.Name()

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -128,7 +128,8 @@ func newScenarioRequest(t *testing.T, ctx context.Context, modelName string, est
 	}, []llm.Tensor{
 		{Name: "blk.0.attn.weight", Kind: uint32(0), Offset: uint64(0), Shape: []uint64{1, 1, 1, 1}, WriterTo: bytes.NewReader(make([]byte, 32))},
 		{Name: "output.weight", Kind: uint32(0), Offset: uint64(0), Shape: []uint64{1, 1, 1, 1}, WriterTo: bytes.NewReader(make([]byte, 32))},
-	}))
+	}, 
+	func(api.ProgressResponse){}))
 	require.NoError(t, err)
 
 	fname := f.Name()


### PR DESCRIPTION
use callback for convert progress on models and adapters
```
transferring model data 100% 
converting model 100% 
creating new layer sha256:7fd0cf1e9b7f7cbf3a3ef9dfffb9a9cf24c8e54ba47d0b7c323429c2dba40e23 
using existing layer sha256:35c6d0195dfd0c11a81f9dff428c7c63bece1fd3a44f989f75b4e1d562bbd7e0 
using existing layer sha256:7d004c54ed218968d29ef809bece2a53846417995b77b34e35ae7eb79a498bc4 
using existing layer sha256:214742a89d95d503b15a0ae7a459e0df214ad02493233016e329a812e22009c3 
using existing layer sha256:7ddbc7f11df908034a49940ba566869f0c293396e569af41f52b23231e1c8374 
creating new layer sha256:24f1c0377dc2e6542fb248a18d3e4ea37263abe7541fa8d3aff6bb165e56cb23 
writing manifest 
success 
```