### PR TITLE
Use llama3.1 in tools example

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -668,7 +668,7 @@ curl http://localhost:11434/api/chat -d '{
 
 ```
 curl http://localhost:11434/api/chat -d '{
-  "model": "mistral",
+  "model": "llama3.1:8b",
   "messages": [
     {
       "role": "user",
@@ -707,7 +707,7 @@ curl http://localhost:11434/api/chat -d '{
 
 ```json
 {
-  "model": "mistral:7b-instruct-v0.3-q4_K_M",
+  "model": "llama3.1:8b",
   "created_at": "2024-07-22T20:33:28.123648Z",
   "message": {
     "role": "assistant",

--- a/docs/api.md
+++ b/docs/api.md
@@ -668,7 +668,7 @@ curl http://localhost:11434/api/chat -d '{
 
 ```
 curl http://localhost:11434/api/chat -d '{
-  "model": "llama3.1:8b",
+  "model": "llama3.1",
   "messages": [
     {
       "role": "user",
@@ -707,7 +707,7 @@ curl http://localhost:11434/api/chat -d '{
 
 ```json
 {
-  "model": "llama3.1:8b",
+  "model": "llama3.1",
   "created_at": "2024-07-22T20:33:28.123648Z",
   "message": {
     "role": "assistant",


### PR DESCRIPTION
Running this example with `mistral` produces the error "mistral does not support tools". What wasn't obvious to me until I made this PR was that my copy of mistral needed upgrading for tools (`ollama pull mistral`). Making the example be `llama3.1` will lead to more success for other long time ollama users.