### PR TITLE
server: add OLLAMA_RUNNERS_DIR to help description

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1344,6 +1344,7 @@ func NewCLI() *cobra.Command {
 				envVars["OLLAMA_TMPDIR"],
 				envVars["OLLAMA_FLASH_ATTENTION"],
 				envVars["OLLAMA_LLM_LIBRARY"],
+				envVars["OLLAMA_RUNNERS_DIR"],
 			})
 		default:
 			appendEnvDocs(cmd, envs)


### PR DESCRIPTION
The env OLLAMA_RUNNERS_DIR is useful to avoid extract embedded files every time at `ollama serve` start.