### PR TITLE
feat(server): remove hardcode gin mode

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -36,23 +36,9 @@ import (
 	"github.com/ollama/ollama/version"
 )
 
-var mode string = gin.DebugMode
-
 type Server struct {
 	addr  net.Addr
 	sched *Scheduler
-}
-
-func init() {
-	switch mode {
-	case gin.DebugMode:
-	case gin.ReleaseMode:
-	case gin.TestMode:
-	default:
-		mode = gin.DebugMode
-	}
-
-	gin.SetMode(mode)
 }
 
 var (


### PR DESCRIPTION
Respect `GIN_MODE=release` env, I think we shouldn't hardcode debug mode, leave the config for users.