### PR TITLE
Fix typo in chat with image docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -587,7 +587,7 @@ Final response:
 
 ##### Request
 
-Send a chat message with a conversation history.
+Send a chat message with images. The images should be provided as an array, with the individual images encoded in Base64.
 
 ```shell
 curl http://localhost:11434/api/chat -d '{


### PR DESCRIPTION
It looks like the docs were just copy-pasted form the conversaiton history above. This PR fixes that part of the docs with a short explanation.

Cheers