### PR TITLE
docs: Add ingest to list of cli tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [tlm](https://github.com/yusufcanb/tlm)
 - [podman-ollama](https://github.com/ericcurtin/podman-ollama)
 - [gollama](https://github.com/sammcj/gollama)
+- [ingest](https://github.com/sammcj/ingest)
 
 ### Database
 


### PR DESCRIPTION
Add ingest (https://github.com/sammcj/ingest) to list of CLI tools for Ollama.

Ingest is a tool for parsing files/directories into a LLM friendly markdown formatted prompt and can directly pass the content and prompt to Ollama.