### PR TITLE
server: OLLAMA in modelfile and manifests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/xtgo/set v1.0.0 // indirect
 	go4.org/unsafe/assume-no-moving-gc v0.0.0-20231121144256-b99613f794b6 // indirect
+	golang.org/x/mod v0.19.0 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gonum.org/v1/gonum v0.15.0 // indirect
 	gorgonia.org/vecf32 v0.9.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 )
 
 require (
+	github.com/Masterminds/semver/v3 v3.2.1 // indirect
 	github.com/apache/arrow/go/arrow v0.0.0-20211112161151-bc219186db40 // indirect
 	github.com/bytedance/sonic/loader v0.1.1 // indirect
 	github.com/chewxy/hm v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 gioui.org v0.0.0-20210308172011-57750fc8a0a6/go.mod h1:RSH6KIUZ0p2xy5zHDxgAM4zumjgTw83q2ge/PI+yyw8=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
+github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/agnivade/levenshtein v1.1.1 h1:QY8M92nrzkmr798gCo3kmMyqXFzdQVpxLlGPRBij0P8=
 github.com/agnivade/levenshtein v1.1.1/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVbJomOvKkmgYbo=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=

--- a/go.sum
+++ b/go.sum
@@ -242,6 +242,8 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.19.0 h1:fEdghXQSo20giMthA7cd28ZC+jts4amQ3YMXiP5oMQ8=
+golang.org/x/mod v0.19.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -275,7 +275,7 @@ func parseRuneForState(r rune, cs state) (state, rune, error) {
 		switch {
 		case isNewline(r), isSpace(r):
 			return stateNil, 0, nil
-		case isAlpha(r), isNumber(r), r == '.':
+		case isAlpha(r), isNumber(r), r == '.', r == '+', r == '-':
 			return stateVersion, r, nil
 		default:
 			return stateNil, r, nil

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -67,7 +67,7 @@ var (
 	errMissingFrom        = errors.New("no FROM line")
 	errInvalidMessageRole = errors.New("message role must be one of \"system\", \"user\", or \"assistant\"")
 	errInvalidCommand     = errors.New("command must be one of \"from\", \"license\", \"template\", \"system\", \"adapter\", \"parameter\", or \"message\"")
-	errInvalidVersion     = errors.New("invalid version")
+	errInvalidVersion     = errors.New("invalid OLLAMA version")
 )
 
 func ParseFile(r io.Reader) (*File, error) {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -139,7 +139,7 @@ func ParseFile(r io.Reader) (*File, error) {
 					}
 
 					continue
-				} else if isSpace(r){
+				} else if isSpace(r) {
 					return nil, errInvalidVersion
 				} else if _, err := semver.NewVersion(s); err != nil {
 					return nil, errInvalidVersion

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -43,7 +43,7 @@ func (c Command) String() string {
 		role, message, _ := strings.Cut(c.Args, ": ")
 		fmt.Fprintf(&sb, "MESSAGE %s %s", role, quote(message))
 	case "ollama":
-		fmt.Fprintf(&sb, "OLLAMA %s", quote(c.Args))
+		fmt.Fprintf(&sb, "OLLAMA %s", c.Args)
 	default:
 		fmt.Fprintf(&sb, "PARAMETER %s %s", c.Name, quote(c.Args))
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/Masterminds/semver/v3"
+	"golang.org/x/mod/semver"
 	"golang.org/x/text/encoding/unicode"
 	"golang.org/x/text/transform"
 )
@@ -141,11 +141,17 @@ func ParseFile(r io.Reader) (*File, error) {
 					continue
 				} else if isSpace(r) {
 					return nil, errInvalidVersion
-				} else if _, err := semver.NewVersion(s); err != nil {
+				}
+
+				if s[0] != 'v' {
+					s = "v" + s
+				}
+
+				if !semver.IsValid(s) {
 					return nil, errInvalidVersion
 				}
 
-				cmd.Args = s
+				cmd.Args = semver.Canonical(s)
 				f.Commands = append(f.Commands, cmd)
 
 			case stateValue:
@@ -186,11 +192,17 @@ func ParseFile(r io.Reader) (*File, error) {
 		s, ok := unquote(strings.TrimSpace(b.String()))
 		if !ok {
 			return nil, io.ErrUnexpectedEOF
-		} else if _, err := semver.NewVersion(s); err != nil {
+		}
+
+		if s[0] != 'v' {
+			s = "v" + s
+		}
+
+		if !semver.IsValid(s) {
 			return nil, errInvalidVersion
 		}
 
-		cmd.Args = s
+		cmd.Args = semver.Canonical(s)
 		f.Commands = append(f.Commands, cmd)
 	case stateValue:
 		s, ok := unquote(strings.TrimSpace(b.String()))

--- a/server/images.go
+++ b/server/images.go
@@ -385,7 +385,7 @@ func CreateModel(ctx context.Context, name model.Name, modelFileDir, quantizatio
 		case "model", "adapter":
 			var baseLayers []*layerGGML
 			if name := model.ParseName(c.Args); name.IsValid() {
-				baseLayers, err = parseFromModel(ctx, name, fn)
+				baseLayers, version, err = parseFromModel(ctx, name, fn)
 				if err != nil {
 					return err
 				}
@@ -531,7 +531,9 @@ func CreateModel(ctx context.Context, name model.Name, modelFileDir, quantizatio
 
 			messages = append(messages, &api.Message{Role: role, Content: content})
 		case "ollama":
-			version = c.Args
+			if version == "" {
+				version = c.Args
+			}
 		default:
 			ps, err := api.FormatParams(map[string][]string{c.Name: {c.Args}})
 			if err != nil {

--- a/server/images.go
+++ b/server/images.go
@@ -550,7 +550,7 @@ func CreateModel(ctx context.Context, name model.Name, modelFileDir, quantizatio
 				}
 			}
 		}
-	}		
+	}
 
 	var err2 error
 	layers = slices.DeleteFunc(layers, func(layer *Layer) bool {

--- a/server/images.go
+++ b/server/images.go
@@ -374,6 +374,7 @@ func CreateModel(ctx context.Context, name model.Name, modelFileDir, quantizatio
 	}
 
 	var messages []*api.Message
+	var version string
 	parameters := make(map[string]any)
 
 	var layers []*Layer
@@ -529,6 +530,8 @@ func CreateModel(ctx context.Context, name model.Name, modelFileDir, quantizatio
 			}
 
 			messages = append(messages, &api.Message{Role: role, Content: content})
+		case "ollama":
+			version = c.Args
 		default:
 			ps, err := api.FormatParams(map[string][]string{c.Name: {c.Args}})
 			if err != nil {
@@ -545,7 +548,7 @@ func CreateModel(ctx context.Context, name model.Name, modelFileDir, quantizatio
 				}
 			}
 		}
-	}
+	}		
 
 	var err2 error
 	layers = slices.DeleteFunc(layers, func(layer *Layer) bool {
@@ -642,7 +645,7 @@ func CreateModel(ctx context.Context, name model.Name, modelFileDir, quantizatio
 	old, _ := ParseNamedManifest(name)
 
 	fn(api.ProgressResponse{Status: "writing manifest"})
-	if err := WriteManifest(name, layer, layers); err != nil {
+	if err := WriteManifest(name, layer, layers, version); err != nil {
 		return err
 	}
 

--- a/server/images.go
+++ b/server/images.go
@@ -22,7 +22,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/Masterminds/semver/v3"
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/auth"
 	"github.com/ollama/ollama/envconfig"
@@ -375,7 +374,7 @@ func CreateModel(ctx context.Context, name model.Name, modelFileDir, quantizatio
 	}
 
 	var messages []*api.Message
-	var version *semver.Version
+	var version string
 	parameters := make(map[string]any)
 
 	var layers []*Layer
@@ -532,11 +531,8 @@ func CreateModel(ctx context.Context, name model.Name, modelFileDir, quantizatio
 
 			messages = append(messages, &api.Message{Role: role, Content: content})
 		case "ollama":
-			if version == nil {
-				version, err = semver.NewVersion(c.Args)
-				if err != nil {
-					return err
-				}
+			if version == "" {
+				version = c.Args
 			}
 		default:
 			ps, err := api.FormatParams(map[string][]string{c.Name: {c.Args}})

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/ollama/ollama/types/model"
 )
 
@@ -18,7 +19,7 @@ type Manifest struct {
 	MediaType     string   `json:"mediaType"`
 	Config        *Layer   `json:"config"`
 	Layers        []*Layer `json:"layers"`
-	Ollama        string   `json:"ollama"`
+	Ollama        *semver.Version   `json:"ollama,omitempty"`
 
 	filepath string
 	fi       os.FileInfo
@@ -94,7 +95,7 @@ func ParseNamedManifest(n model.Name) (*Manifest, error) {
 	return &m, nil
 }
 
-func WriteManifest(name model.Name, config *Layer, layers []*Layer, ollama string) error {
+func WriteManifest(name model.Name, ollama *semver.Version, config *Layer, layers []*Layer) error {
 	manifests, err := GetManifestPath()
 	if err != nil {
 		return err

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -18,7 +18,7 @@ type Manifest struct {
 	MediaType     string   `json:"mediaType"`
 	Config        *Layer   `json:"config"`
 	Layers        []*Layer `json:"layers"`
-	Ollama		  string   `json:"ollama"`
+	Ollama        string   `json:"ollama"`
 
 	filepath string
 	fi       os.FileInfo
@@ -116,7 +116,7 @@ func WriteManifest(name model.Name, config *Layer, layers []*Layer, ollama strin
 		MediaType:     "application/vnd.docker.distribution.manifest.v2+json",
 		Config:        config,
 		Layers:        layers,
-		Ollama:		   ollama,
+		Ollama:        ollama,
 	}
 
 	return json.NewEncoder(f).Encode(m)

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -18,6 +18,7 @@ type Manifest struct {
 	MediaType     string   `json:"mediaType"`
 	Config        *Layer   `json:"config"`
 	Layers        []*Layer `json:"layers"`
+	Ollama		  string   `json:"ollama"`
 
 	filepath string
 	fi       os.FileInfo
@@ -93,7 +94,7 @@ func ParseNamedManifest(n model.Name) (*Manifest, error) {
 	return &m, nil
 }
 
-func WriteManifest(name model.Name, config *Layer, layers []*Layer) error {
+func WriteManifest(name model.Name, config *Layer, layers []*Layer, ollama string) error {
 	manifests, err := GetManifestPath()
 	if err != nil {
 		return err
@@ -115,6 +116,7 @@ func WriteManifest(name model.Name, config *Layer, layers []*Layer) error {
 		MediaType:     "application/vnd.docker.distribution.manifest.v2+json",
 		Config:        config,
 		Layers:        layers,
+		Ollama:		   ollama,
 	}
 
 	return json.NewEncoder(f).Encode(m)

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/Masterminds/semver/v3"
 	"github.com/ollama/ollama/types/model"
 )
 
@@ -19,7 +18,7 @@ type Manifest struct {
 	MediaType     string   `json:"mediaType"`
 	Config        *Layer   `json:"config"`
 	Layers        []*Layer `json:"layers"`
-	Ollama        *semver.Version   `json:"ollama,omitempty"`
+	Ollama        string   `json:"string,omitempty"`
 
 	filepath string
 	fi       os.FileInfo
@@ -95,7 +94,7 @@ func ParseNamedManifest(n model.Name) (*Manifest, error) {
 	return &m, nil
 }
 
-func WriteManifest(name model.Name, ollama *semver.Version, config *Layer, layers []*Layer) error {
+func WriteManifest(name model.Name, ollama string, config *Layer, layers []*Layer) error {
 	manifests, err := GetManifestPath()
 	if err != nil {
 		return err

--- a/server/model.go
+++ b/server/model.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"text/template/parse"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/convert"
 	"github.com/ollama/ollama/llm"
@@ -30,7 +31,7 @@ type layerGGML struct {
 	*llm.GGML
 }
 
-func parseFromModel(ctx context.Context, name model.Name, fn func(api.ProgressResponse)) (layers []*layerGGML, version string, err error) {
+func parseFromModel(ctx context.Context, name model.Name, fn func(api.ProgressResponse)) (layers []*layerGGML, version *semver.Version, err error) {
 	m, err := ParseNamedManifest(name)
 	switch {
 	case errors.Is(err, os.ErrNotExist):

--- a/server/model.go
+++ b/server/model.go
@@ -16,7 +16,6 @@ import (
 	"strings"
 	"text/template/parse"
 
-	"github.com/Masterminds/semver/v3"
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/convert"
 	"github.com/ollama/ollama/llm"
@@ -31,7 +30,7 @@ type layerGGML struct {
 	*llm.GGML
 }
 
-func parseFromModel(ctx context.Context, name model.Name, fn func(api.ProgressResponse)) (layers []*layerGGML, version *semver.Version, err error) {
+func parseFromModel(ctx context.Context, name model.Name, fn func(api.ProgressResponse)) (layers []*layerGGML, version string, err error) {
 	m, err := ParseNamedManifest(name)
 	switch {
 	case errors.Is(err, os.ErrNotExist):

--- a/server/routes_create_test.go
+++ b/server/routes_create_test.go
@@ -690,8 +690,8 @@ func TestCreateVersion(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if m.Ollama.String() != "" {
-			t.Errorf("got %s != want \"\"", m.Ollama)
+		if m.Ollama != nil {
+			t.Errorf("got %s != want nil", m.Ollama)
 		}
 	})
 

--- a/server/routes_create_test.go
+++ b/server/routes_create_test.go
@@ -659,7 +659,7 @@ func TestCreateVersion(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if m.Ollama != "0.2.3" {
+	if m.Ollama.String() != "0.2.3" {
 		t.Errorf("got %s != want 0.2.3", m.Ollama)
 	}
 
@@ -690,7 +690,7 @@ func TestCreateVersion(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if m.Ollama != "" {
+		if m.Ollama.String() != "" {
 			t.Errorf("got %s != want \"\"", m.Ollama)
 		}
 	})
@@ -734,7 +734,7 @@ func TestCreateVersion(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if m.Ollama != "0.2.3" {
+		if m.Ollama.String() != "0.2.3" {
 			t.Errorf("got %s != want 0.2.3", m.Ollama)
 		}
 	})

--- a/server/routes_create_test.go
+++ b/server/routes_create_test.go
@@ -647,40 +647,13 @@ func TestCreateVersion(t *testing.T) {
 	})
 
 	f, err := os.Open(filepath.Join(p, "manifests", "registry.ollama.ai", "library", "test", "latest"))
+	defer f.Close()
 	if err != nil {
 		t.Fatal(err)
 	}
 	bts := json.NewDecoder(f)
 
 	var m Manifest
-	if err := bts.Decode(&m); err != nil {
-		t.Fatal(err)
-	}
-
-	if m.Ollama != "0.2.3" {
-		t.Errorf("got %s != want 0.2.3", m.Ollama)
-	}
-
-	w = createRequest(t, s.CreateModelHandler, api.CreateRequest{
-		Name:      "fromvalid",
-		Modelfile: "FROM test",
-		Stream:    &stream,
-	})
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected status code 200, actual %d", w.Code)
-	}
-
-	checkFileExists(t, filepath.Join(p, "manifests", "*", "*", "fromvalid", "*"), []string{
-		filepath.Join(p, "manifests", "registry.ollama.ai", "library", "fromvalid", "latest"),
-	})
-
-	f, err = os.Open(filepath.Join(p, "manifests", "registry.ollama.ai", "library", "fromvalid", "latest"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	bts = json.NewDecoder(f)
-
 	if err := bts.Decode(&m); err != nil {
 		t.Fatal(err)
 	}
@@ -729,6 +702,37 @@ func TestCreateVersion(t *testing.T) {
 
 		if w.Code != http.StatusBadRequest {
 			t.Fatalf("expected status code 400, actual %d", w.Code)
+		}
+	})
+
+	t.Run("from valid version", func(t *testing.T) {
+		w = createRequest(t, s.CreateModelHandler, api.CreateRequest{
+			Name:      "fromvalid",
+			Modelfile: "FROM test",
+			Stream:    &stream,
+		})
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status code 200, actual %d", w.Code)
+		}
+
+		checkFileExists(t, filepath.Join(p, "manifests", "*", "*", "fromvalid", "*"), []string{
+			filepath.Join(p, "manifests", "registry.ollama.ai", "library", "fromvalid", "latest"),
+		})
+
+		f, err := os.Open(filepath.Join(p, "manifests", "registry.ollama.ai", "library", "fromvalid", "latest"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		bts := json.NewDecoder(f)
+
+		var m Manifest
+		if err := bts.Decode(&m); err != nil {
+			t.Fatal(err)
+		}
+
+		if m.Ollama != "0.2.3" {
+			t.Errorf("got %s != want 0.2.3", m.Ollama)
 		}
 	})
 }

--- a/server/routes_create_test.go
+++ b/server/routes_create_test.go
@@ -623,3 +623,34 @@ func TestCreateDetectTemplate(t *testing.T) {
 		})
 	})
 }
+
+func TestCreateVersion(t *testing.T){
+	gin.SetMode(gin.TestMode)
+
+	p := t.TempDir()
+	t.Setenv("OLLAMA_MODELS", p)
+	envconfig.LoadConfig()
+	var s Server
+
+	 w := createRequest(t, s.CreateModelHandler, api.CreateRequest{
+		Name:      "test",
+		Modelfile: fmt.Sprintf("FROM %s\nOLLAMA 0.2.3\nLICENSE MIT\nLICENSE Apache-2.0", createBinFile(t, nil, nil)),
+		Stream:    &stream,
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status code 200, actual %d", w.Code)
+	} 
+
+	t.Run("invalid version", func(t *testing.T) {
+		w = createRequest(t, s.CreateModelHandler, api.CreateRequest{
+			Name:      "test",
+			Modelfile: fmt.Sprintf("FROM %s\nOLLAMA 0..400", createBinFile(t, nil, nil)),
+			Stream:    &stream,
+		})
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected status code 400, actual %d", w.Code)
+		}
+	})
+}

--- a/server/routes_create_test.go
+++ b/server/routes_create_test.go
@@ -659,8 +659,8 @@ func TestCreateVersion(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if m.Ollama.String() != "0.2.3" {
-		t.Errorf("got %s != want 0.2.3", m.Ollama)
+	if m.Ollama != "v0.2.3" {
+		t.Errorf("got %s != want v0.2.3", m.Ollama)
 	}
 
 	t.Run("no version", func(t *testing.T) {
@@ -690,8 +690,8 @@ func TestCreateVersion(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if m.Ollama != nil {
-			t.Errorf("got %s != want nil", m.Ollama)
+		if m.Ollama != "" {
+			t.Errorf("got %s != want empty", m.Ollama)
 		}
 	})
 
@@ -734,8 +734,8 @@ func TestCreateVersion(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if m.Ollama.String() != "0.2.3" {
-			t.Errorf("got %s != want 0.2.3", m.Ollama)
+		if m.Ollama != "v0.2.3" {
+			t.Errorf("got %s != want v0.2.3", m.Ollama)
 		}
 	})
 }

--- a/server/routes_create_test.go
+++ b/server/routes_create_test.go
@@ -661,6 +661,34 @@ func TestCreateVersion(t *testing.T) {
 		t.Errorf("got %s != want 0.2.3", m.Ollama)
 	}
 
+	w = createRequest(t, s.CreateModelHandler, api.CreateRequest{
+		Name:      "fromvalid",
+		Modelfile: "FROM test",
+		Stream:    &stream,
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status code 200, actual %d", w.Code)
+	}
+
+	checkFileExists(t, filepath.Join(p, "manifests", "*", "*", "fromvalid", "*"), []string{
+		filepath.Join(p, "manifests", "registry.ollama.ai", "library", "fromvalid", "latest"),
+	})
+
+	f, err = os.Open(filepath.Join(p, "manifests", "registry.ollama.ai", "library", "fromvalid", "latest"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	bts = json.NewDecoder(f)
+
+	if err := bts.Decode(&m); err != nil {
+		t.Fatal(err)
+	}
+
+	if m.Ollama != "0.2.3" {
+		t.Errorf("got %s != want 0.2.3", m.Ollama)
+	}
+
 	t.Run("no version", func(t *testing.T) {
 		w = createRequest(t, s.CreateModelHandler, api.CreateRequest{
 			Name:      "noversion",
@@ -701,37 +729,6 @@ func TestCreateVersion(t *testing.T) {
 
 		if w.Code != http.StatusBadRequest {
 			t.Fatalf("expected status code 400, actual %d", w.Code)
-		}
-	})
-
-	t.Run("from valid version", func(t *testing.T) {
-		w = createRequest(t, s.CreateModelHandler, api.CreateRequest{
-			Name:      "fromvalid",
-			Modelfile: "FROM test",
-			Stream:    &stream,
-		})
-
-		if w.Code != http.StatusOK {
-			t.Fatalf("expected status code 200, actual %d", w.Code)
-		}
-
-		checkFileExists(t, filepath.Join(p, "manifests", "*", "*", "fromvalid", "*"), []string{
-			filepath.Join(p, "manifests", "registry.ollama.ai", "library", "fromvalid", "latest"),
-		})
-
-		f, err := os.Open(filepath.Join(p, "manifests", "registry.ollama.ai", "library", "fromvalid", "latest"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		bts := json.NewDecoder(f)
-
-		var m Manifest
-		if err := bts.Decode(&m); err != nil {
-			t.Fatal(err)
-		}
-
-		if m.Ollama != "0.2.3" {
-			t.Errorf("got %s != want 0.2.3", m.Ollama)
 		}
 	})
 }

--- a/server/routes_create_test.go
+++ b/server/routes_create_test.go
@@ -498,7 +498,7 @@ func TestCreateTemplateSystem(t *testing.T) {
 			Modelfile: fmt.Sprintf("FROM %s\nTEMPLATE {{ .Prompt", createBinFile(t, nil, nil)),
 			Stream:    &stream,
 		})
-	
+
 		if w.Code != http.StatusBadRequest {
 			t.Fatalf("expected status code 400, actual %d", w.Code)
 		}
@@ -510,7 +510,7 @@ func TestCreateTemplateSystem(t *testing.T) {
 			Modelfile: fmt.Sprintf("FROM %s\nTEMPLATE {{ if .Prompt }}", createBinFile(t, nil, nil)),
 			Stream:    &stream,
 		})
-	
+
 		if w.Code != http.StatusBadRequest {
 			t.Fatalf("expected status code 400, actual %d", w.Code)
 		}
@@ -522,7 +522,7 @@ func TestCreateTemplateSystem(t *testing.T) {
 			Modelfile: fmt.Sprintf("FROM %s\nTEMPLATE {{  Prompt }}", createBinFile(t, nil, nil)),
 			Stream:    &stream,
 		})
-	
+
 		if w.Code != http.StatusBadRequest {
 			t.Fatalf("expected status code 400, actual %d", w.Code)
 		}
@@ -624,7 +624,7 @@ func TestCreateDetectTemplate(t *testing.T) {
 	})
 }
 
-func TestCreateVersion(t *testing.T){
+func TestCreateVersion(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	p := t.TempDir()
@@ -640,12 +640,12 @@ func TestCreateVersion(t *testing.T){
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected status code 200, actual %d", w.Code)
-	} 
+	}
 
 	checkFileExists(t, filepath.Join(p, "manifests", "*", "*", "*", "*"), []string{
 		filepath.Join(p, "manifests", "registry.ollama.ai", "library", "test", "latest"),
 	})
-	
+
 	f, err := os.Open(filepath.Join(p, "manifests", "registry.ollama.ai", "library", "test", "latest"))
 	if err != nil {
 		t.Fatal(err)
@@ -667,11 +667,11 @@ func TestCreateVersion(t *testing.T){
 			Modelfile: fmt.Sprintf("FROM %s\nLICENSE MIT\nLICENSE Apache-2.0", createBinFile(t, nil, nil)),
 			Stream:    &stream,
 		})
-		
+
 		if w.Code != http.StatusOK {
 			t.Fatalf("expected status code 200, actual %d", w.Code)
 		}
-		
+
 		checkFileExists(t, filepath.Join(p, "manifests", "*", "*", "noversion", "*"), []string{
 			filepath.Join(p, "manifests", "registry.ollama.ai", "library", "noversion", "latest"),
 		})
@@ -686,7 +686,7 @@ func TestCreateVersion(t *testing.T){
 		if err := bts.Decode(&m); err != nil {
 			t.Fatal(err)
 		}
-		
+
 		if m.Ollama != "" {
 			t.Errorf("got %s != want \"\"", m.Ollama)
 		}
@@ -713,23 +713,23 @@ func TestCreateVersion(t *testing.T){
 
 		if w.Code != http.StatusOK {
 			t.Fatalf("expected status code 200, actual %d", w.Code)
-		} 
-	
+		}
+
 		checkFileExists(t, filepath.Join(p, "manifests", "*", "*", "fromvalid", "*"), []string{
 			filepath.Join(p, "manifests", "registry.ollama.ai", "library", "fromvalid", "latest"),
 		})
-		
+
 		f, err := os.Open(filepath.Join(p, "manifests", "registry.ollama.ai", "library", "fromvalid", "latest"))
 		if err != nil {
 			t.Fatal(err)
 		}
 		bts := json.NewDecoder(f)
-	
+
 		var m Manifest
 		if err := bts.Decode(&m); err != nil {
 			t.Fatal(err)
 		}
-	
+
 		if m.Ollama != "0.2.3" {
 			t.Errorf("got %s != want 0.2.3", m.Ollama)
 		}

--- a/server/routes_create_test.go
+++ b/server/routes_create_test.go
@@ -682,6 +682,7 @@ func TestCreateVersion(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		defer f.Close()
 
 		bts := json.NewDecoder(f)
 		var m Manifest
@@ -725,6 +726,7 @@ func TestCreateVersion(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		defer f.Close()
 		bts := json.NewDecoder(f)
 
 		var m Manifest

--- a/server/routes_create_test.go
+++ b/server/routes_create_test.go
@@ -647,10 +647,11 @@ func TestCreateVersion(t *testing.T) {
 	})
 
 	f, err := os.Open(filepath.Join(p, "manifests", "registry.ollama.ai", "library", "test", "latest"))
-	defer f.Close()
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer f.Close()
+
 	bts := json.NewDecoder(f)
 
 	var m Manifest

--- a/server/routes_delete_test.go
+++ b/server/routes_delete_test.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/Masterminds/semver/v3"
 	"github.com/gin-gonic/gin"
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/envconfig"
@@ -100,7 +99,7 @@ func TestDeleteDuplicateLayers(t *testing.T) {
 	}
 
 	// create a manifest with duplicate layers
-	if err := WriteManifest(n, &semver.Version{}, config, []*Layer{config}); err != nil {
+	if err := WriteManifest(n, "", config, []*Layer{config}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/server/routes_delete_test.go
+++ b/server/routes_delete_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/gin-gonic/gin"
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/envconfig"
@@ -99,7 +100,7 @@ func TestDeleteDuplicateLayers(t *testing.T) {
 	}
 
 	// create a manifest with duplicate layers
-	if err := WriteManifest(n, config, []*Layer{config}, ""); err != nil {
+	if err := WriteManifest(n, &semver.Version{}, config, []*Layer{config}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/server/routes_delete_test.go
+++ b/server/routes_delete_test.go
@@ -99,7 +99,7 @@ func TestDeleteDuplicateLayers(t *testing.T) {
 	}
 
 	// create a manifest with duplicate layers
-	if err := WriteManifest(n, config, []*Layer{config}); err != nil {
+	if err := WriteManifest(n, config, []*Layer{config}, ""); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
new optional parameter `OLLAMA` in modelfile to specify minimum version of ollama to run this model:
`ollama create newmodel`
```
FROM mymodel.gguf
OLLAMA 0.2.3
```

using another model with the `FROM` command defaults to the version if they specify it right now. otherwise, you can set it yourself
```
FROM newmodel
```
this will inherit the `OLLAMA 0.2.3` requirement