### PR TITLE
fix modelfile message quotes

### DIFF
--- a/server/images.go
+++ b/server/images.go
@@ -184,7 +184,7 @@ func (m *Model) String() string {
 	for _, msg := range m.Messages {
 		modelfile.Commands = append(modelfile.Commands, parser.Command{
 			Name: "message",
-			Args: fmt.Sprintf("%s %s", msg.Role, msg.Content),
+			Args: fmt.Sprintf("%s: %s", msg.Role, msg.Content),
 		})
 	}
 


### PR DESCRIPTION
message commands should quote the content but it's not correctly formatted so it outputs content verbatim. fix the formatting will fix quoting

https://github.com/ollama/ollama/blob/main/parser/parser.go#L41-L43

resolves #6103