### PR TITLE
Fix extra context concatenation in generate handler (#5980).

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -247,7 +247,7 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 						ch <- gin.H{"error": err.Error()}
 						return
 					}
-					res.Context = append(req.Context, tokens...)
+					res.Context = tokens
 				}
 			}
 


### PR DESCRIPTION
This PR fixes [Context in /api/generate response grows too big. #5980
](https://github.com/ollama/ollama/issues/5980)