### PR TITLE
Fix crash on startup when trying to clean up unused files (#5840)

### DIFF
--- a/server/images.go
+++ b/server/images.go
@@ -233,6 +233,10 @@ func GetManifest(mp ModelPath) (*Manifest, string, error) {
 		return nil, "", err
 	}
 
+	if err := ValidateManifest(manifest, fp); err != nil {
+		return nil, "", err
+	}
+
 	return manifest, shaStr, nil
 }
 
@@ -995,6 +999,10 @@ func pullModelManifest(ctx context.Context, mp ModelPath, regOpts *registryOptio
 
 	var m *Manifest
 	if err := json.NewDecoder(resp.Body).Decode(&m); err != nil {
+		return nil, err
+	}
+
+	if err := ValidateManifest(m, requestURL.String()); err != nil {
 		return nil, err
 	}
 

--- a/server/images.go
+++ b/server/images.go
@@ -714,8 +714,7 @@ func deleteUnusedLayers(skipModelPath *ModelPath, deleteMap map[string]struct{})
 		// save (i.e. delete from the deleteMap) any files used in other manifests
 		manifest, _, err := GetManifest(fmp)
 		if err != nil {
-			//nolint:nilerr
-			return nil
+			return err
 		}
 
 		for _, layer := range manifest.Layers {
@@ -782,7 +781,9 @@ func PruneLayers() error {
 
 	err = deleteUnusedLayers(nil, deleteMap)
 	if err != nil {
-		return err
+		slog.Info(fmt.Sprintf("couldn't prune layers: %v", err))
+		//nolint:nilerr
+		return nil
 	}
 
 	slog.Info(fmt.Sprintf("total unused blobs removed: %d", len(deleteMap)))
@@ -971,7 +972,8 @@ func PullModel(ctx context.Context, name string, regOpts *registryOptions, fn fu
 		fn(api.ProgressResponse{Status: "removing any unused layers"})
 		err = deleteUnusedLayers(nil, deleteMap)
 		if err != nil {
-			return err
+			slog.Info(fmt.Sprintf("couldn't prune layers: %v", err))
+			fn(api.ProgressResponse{Status: fmt.Sprintf("couldn't prune layers: %v", err)})
 		}
 	}
 


### PR DESCRIPTION
Improve validation and error handling of manifest files in the event of corruption. This prevents nil pointer errors and possible unintended deletion of data.