### PR TITLE
Reference ollama integration with Harbor

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Sidellama](https://github.com/gyopak/sidellama) (browser-based LLM client)
 - [LLMStack](https://github.com/trypromptly/LLMStack) (No-code multi-agent framework to build LLM agents and workflows)
 - [BoltAI for Mac](https://boltai.com) (AI Chat Client for Mac)
+- [Harbor](https://github.com/av/harbor) (Containerized LLM Toolkit with Ollama as default backend)
 
 ### Terminal
 


### PR DESCRIPTION
Harbor runs Ollama as a default LLM backend:
```bash
# Everything is dockerized, User doesn't have to install 
# ollama on their host
harbor up ollama

# Ollama CLI/API is available as is
harbor ollama list
curl $(harbor url ollama)/api/ps
```

On Harbor's end, Ollama is integrated with the supported frontends (currently Open WebUI, LibreChat, Hollama, BionicGPT)