### PR TITLE
Disable paging for journalctl

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -9,7 +9,7 @@ cat ~/.ollama/logs/server.log
 On **Linux** systems with systemd, the logs can be found with this command:
 
 ```shell
-journalctl -u ollama
+journalctl -u ollama --no-pager
 ```
 
 When you run Ollama in a **container**, the logs go to stdout/stderr in the container:


### PR DESCRIPTION
Users using `journalctl` to get logs for issue logging sometimes don't realize that paging is causing information to be missed.