### PR TITLE
Update gpu.go to support older amdgpu

### DIFF
--- a/gpu/gpu.go
+++ b/gpu/gpu.go
@@ -59,7 +59,7 @@ var (
 // With our current CUDA compile flags, older than 5.0 will not work properly
 var CudaComputeMin = [2]C.int{5, 0}
 
-var RocmComputeMin = 9
+var RocmComputeMin = 8
 
 // TODO find a better way to detect iGPU instead of minimum memory
 const IGPUMemLimit = 1 * format.GibiByte // 512G is what they typically report, so anything less than 1G must be iGPU


### PR DESCRIPTION
Unblock users trying to run on older GPUs like AMD RX 580 when setting env vars `ROC_ENABLE_PRE_VEGA=1` and `HSA_OVERRIDE_GFX_VERSION=8.0.3` which should fix the error from https://github.com/ollama/ollama/blob/main/gpu/gpu.go#L62 and https://github.com/ollama/ollama/blob/main/gpu/amd_linux.go#L200 about gpu being too old.