### PR TITLE
Compatibility Patches for LUMI Supercomputer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ ENV LIBRARY_PATH /opt/amdgpu/lib64
 COPY --from=llm-code / /go/src/github.com/ollama/ollama/
 WORKDIR /go/src/github.com/ollama/ollama/llm/generate
 ARG CGO_CFLAGS
+ARG GOFLAGS
 ARG AMDGPU_TARGETS
 RUN OLLAMA_SKIP_STATIC_GENERATE=1 OLLAMA_SKIP_CPU_GENERATE=1 sh gen_linux.sh
 RUN mkdir /tmp/scratch && \

--- a/gpu/amd_linux.go
+++ b/gpu/amd_linux.go
@@ -41,7 +41,7 @@ const (
 
 var (
 	// Used to validate if the given ROCm lib is usable
-	ROCmLibGlobs          = []string{"libhipblas.so*", "rocblas"} // TODO - probably include more coverage of files here...
+	ROCmLibGlobs          = []string{"libhipblas.so.2*", "rocblas"} // TODO - probably include more coverage of files here...
 	RocmStandardLocations = []string{"/opt/rocm/lib", "/usr/lib64"}
 )
 

--- a/gpu/amd_linux.go
+++ b/gpu/amd_linux.go
@@ -41,7 +41,7 @@ const (
 
 var (
 	// Used to validate if the given ROCm lib is usable
-	ROCmLibGlobs          = []string{"libhipblas.so.2*", "rocblas"} // TODO - probably include more coverage of files here...
+	ROCmLibGlobs          = []string{"libhipblas.so*", "rocblas"} // TODO - probably include more coverage of files here...
 	RocmStandardLocations = []string{"/opt/rocm/lib", "/usr/lib64"}
 )
 

--- a/gpu/amd_linux.go
+++ b/gpu/amd_linux.go
@@ -98,6 +98,7 @@ func AMDGetGPUInfo() []RocmGPUInfo {
 		return a < b
 	})
 	cpuCount := 0
+	gpuID := -1
 	for _, match := range matches {
 		slog.Debug("evaluating amdgpu node " + match)
 		fp, err := os.Open(match)
@@ -194,12 +195,12 @@ func AMDGetGPUInfo() []RocmGPUInfo {
 			continue
 		}
 
-		// CPUs are always first in the list
-		gpuID := nodeID - cpuCount
+		// Found an accessible GPU, increment GPU counter (assuming that non-accessible GPUs are cgroup-ed out of ROCr views)
+		gpuID++
 
 		// Shouldn't happen, but just in case...
-		if gpuID < 0 {
-			slog.Error("unexpected amdgpu sysfs data resulted in negative GPU ID, please set OLLAMA_DEBUG=1 and report an issue")
+		if gpuID > nodeID - cpuCount {
+			slog.Error("unexpected amdgpu sysfs data resulted in too large GPU ID, please set OLLAMA_DEBUG=1 and report an issue")
 			return nil
 		}
 

--- a/gpu/amd_linux.go
+++ b/gpu/amd_linux.go
@@ -179,6 +179,12 @@ func AMDGetGPUInfo() []RocmGPUInfo {
 			// Other metrics that may help us understand relative performance between multiple GPUs
 		}
 
+		err = scanner.Err()
+		if err != nil {
+			slog.Debug("failed to read sysfs node", "file", match, "error", err)
+			continue
+		}
+
 		// Note: while ./mem_banks/*/used_memory exists, it doesn't appear to take other VRAM consumers
 		// into consideration, so we instead map the device over to the DRM driver sysfs nodes which
 		// do reliably report VRAM usage.

--- a/gpu/amd_linux.go
+++ b/gpu/amd_linux.go
@@ -41,7 +41,8 @@ const (
 
 var (
 	// Used to validate if the given ROCm lib is usable
-	ROCmLibGlobs          = []string{"libhipblas.so.2*", "rocblas"} // TODO - probably include more coverage of files here...
+	ROCmLib = "libhipblas.so.2*"
+	ROCmLibGlobs          = []string{ROCmLib, "rocblas"} // TODO - probably include more coverage of files here...
 	RocmStandardLocations = []string{"/opt/rocm/lib", "/usr/lib64"}
 )
 


### PR DESCRIPTION
These are 3 patches required to allow Ollama to be run on the LUMI EuroHPC Supercomputer.

1. 32adb46833f0e47b2ef3d967dc2d49dd7226e98f - Skip unreadable AMD GPU nodes in AMDGetGPUInfo.
    This is a general bug fix: Errors while reading (as opposed to opening) a  `/sys/class/kfd/kfd/topology/nodes/*/properties` file were previously not caught, leading to uninitialized values for the corresponding GPU in `AMDGetGPUInfo`.
2. 07eb2f07a6ec24deb68980f1544fff7a206479fc - Check ROCM install for libhipblas.so* instead of libhipblas.so.2*
     Ollama compiles fine for older ROCm versions (such as 5.6.1) but then refuses to use them due to the current detection logic requiring ` libhipblas.so.2*` (without the code apparently really relying on hipblas v2). Relaxing to ` libhipblas.so.*` allows it to run without observed issues.
 3. 77cc65fa1bd9831eb92909b757301213718d7f82 - Index only available AMD GPUs.
     On systems using the SLUM job scheduler and cgroups to limit access to GPU devices, Ollama's mapping of device indices to devices is inaccurate, i.e., devices end up being indexed differently by the ROCm Runtime than by Ollama in this case. (by _indexed_ I here refer to the number assigned to a GPU device, as is used, e.g., to set `ROCR_VISIBLE_DEVICES`, etc). This is a fix for that.

Please refer to the individual commit texts for more detailed descriptions.

For the last commit I have to admit that I cannot be a hundred percent sure that it would work for all systems. It appears to work fine for LUMI but I was unable to confirm this for other systems. I am willing to exclude it from this PR in favour of getting the other changes in, if you feel strongly opposed to it. However, the underlying problem that it attempts to fix should have another solution then. (Probably ideal would be if Ollama would use some ROCm provided API to obtain all available devices rather than enumerating things in `/sys` manually).