### PR TITLE
Catch one more error log

### DIFF
--- a/llm/status.go
+++ b/llm/status.go
@@ -26,6 +26,7 @@ var errorPrefixes = []string{
 	"cudaMalloc failed",
 	"\"ERR\"",
 	"error loading model",
+	"GGML_ASSERT",
 }
 
 func (w *StatusWriter) Write(b []byte) (int, error) {


### PR DESCRIPTION
Example from recent user reported error log on a fine tune that didn't load correctly
```
C:\a\ollama\ollama\llm\llama.cpp\src\llama.cpp:5511: GGML_ASSERT(vocab.id_to_token.size() == vocab.token_to_id.size()) failed
time=2024-08-05T10:44:06.625+02:00 level=INFO source=server.go:618 msg="waiting for server to become available" status="llm server not responding"
time=2024-08-05T10:44:08.717+02:00 level=INFO source=server.go:618 msg="waiting for server to become available" status="llm server error"
time=2024-08-05T10:44:09.223+02:00 level=ERROR source=sched.go:451 msg="error loading llama server" error="llama runner process has terminated: exit status 0xc0000409"
```

This will help bubble up the underlying error instead of the ~useless exit status.