### PR TITLE
Allow singular array for CompletionRequest prompt field

### DIFF
--- a/openai/openai_test.go
+++ b/openai/openai_test.go
@@ -269,6 +269,76 @@ func TestCompletionsMiddleware(t *testing.T) {
 				}
 			},
 		},
+		{
+			Name: "completions handler",
+			Setup: func(t *testing.T, req *http.Request) {
+				temp := float32(0.8)
+				body := CompletionRequest{
+					Model:       "test-model",
+					Prompt:      []string{"Hello"},
+					Temperature: &temp,
+					Stop:        []string{"\n", "stop"},
+					Suffix:      "suffix",
+				}
+				prepareRequest(req, body)
+			},
+			Expected: func(t *testing.T, req *api.GenerateRequest, resp *httptest.ResponseRecorder) {
+				if resp.Code != http.StatusOK {
+					t.Fatalf("expected 200, got %d", resp.Code)
+				}
+
+				if req.Prompt != "Hello" {
+					t.Fatalf("expected 'Hello', got %s", req.Prompt)
+				}
+			},
+		},
+
+		{
+			Name: "completions handler prompt error forwarding",
+			Setup: func(t *testing.T, req *http.Request) {
+				temp := float32(0.8)
+				body := CompletionRequest{
+					Model:       "test-model",
+					Prompt:      []string{},
+					Temperature: &temp,
+					Stop:        []string{"\n", "stop"},
+					Suffix:      "suffix",
+				}
+				prepareRequest(req, body)
+			},
+			Expected: func(t *testing.T, req *api.GenerateRequest, resp *httptest.ResponseRecorder) {
+				if resp.Code != http.StatusBadRequest {
+					t.Fatalf("expected 400, got %d", resp.Code)
+				}
+
+				if !strings.Contains(resp.Body.String(), "invalid size of 'prompt' field: must be 1") {
+					t.Fatalf("error was not forwarded")
+				}
+			},
+		},
+		{
+			Name: "completions handler prompt error forwarding",
+			Setup: func(t *testing.T, req *http.Request) {
+				temp := float32(0.8)
+				body := CompletionRequest{
+					Model:       "test-model",
+					Prompt:      []int{1},
+					Temperature: &temp,
+					Stop:        []string{"\n", "stop"},
+					Suffix:      "suffix",
+				}
+				prepareRequest(req, body)
+			},
+			Expected: func(t *testing.T, req *api.GenerateRequest, resp *httptest.ResponseRecorder) {
+				if resp.Code != http.StatusBadRequest {
+					t.Fatalf("expected 400, got %d", resp.Code)
+				}
+
+				if !strings.Contains(resp.Body.String(), "invalid type for 'prompt' field") {
+					t.Fatalf("error was not forwarded")
+				}
+			},
+		},
 	}
 
 	endpoint := func(c *gin.Context) {


### PR DESCRIPTION
## Overview

OpenAI `v1/completions` to handle `[]string`, `[]int` and `[][]int`, in addition to just a `string` according to https://platform.openai.com/docs/api-reference/completions/create#completions-create-prompt

Also some aggregators (like litellm) send a list of prompts as a prompt: https://github.com/ollama/ollama/issues/5259#issuecomment-2242611375

This PR allows sending singular arrays as the `prompt` field.