### PR TITLE
feat: add support for running ollama on rocm in wsl

### DIFF
--- a/gpu/amd_hip_linux.go
+++ b/gpu/amd_hip_linux.go
@@ -1,0 +1,172 @@
+package gpu
+
+/*
+#cgo LDFLAGS: -ldl
+#include <dlfcn.h>
+
+int _hipGetDeviceCount(void* fn, int* count) {
+	return ((int (*)(int*)) fn)(count);
+}
+
+int _hipGetDeviceProperties(void* fn, void* prop, int deviceId) {
+	return ((int (*)(void*, int)) fn)(prop, deviceId);
+}
+
+int _hipMemGetInfo(void* fn, size_t* free, size_t* total) {
+	return ((int (*)(size_t*, size_t*)) fn)(free, total);
+}
+
+int _hipSetDevice(void* fn, int deviceId) {
+	return ((int (*)(int)) fn)(deviceId);
+}
+
+int _hipDriverGetVersion(void* fn, int* deviceVersion) {
+	return ((int (*)(int*)) fn)(deviceVersion);
+}
+*/
+import "C"
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"unsafe"
+)
+
+const (
+	hipSuccess       = 0
+	hipErrorNoDevice = 100
+)
+
+type hipDevicePropMinimal struct {
+	Name        [256]byte
+	unused1     [140]byte
+	GcnArchName [256]byte // gfx####
+	iGPU        int       // Doesn't seem to actually report correctly
+	unused2     [128]byte
+}
+
+// Wrap the amdhip64.dll library for GPU discovery
+type HipLib struct {
+	dll                    unsafe.Pointer
+	hipGetDeviceCount      unsafe.Pointer
+	hipGetDeviceProperties unsafe.Pointer
+	hipMemGetInfo          unsafe.Pointer
+	hipSetDevice           unsafe.Pointer
+	hipDriverGetVersion    unsafe.Pointer
+}
+
+func NewHipLib() (*HipLib, error) {
+	libDir, err := AMDValidateLibDir()
+	if err != nil {
+		return nil, fmt.Errorf("unable to verify rocm library, will use cpu %w", err)
+	}
+
+	h := C.dlopen(C.CString(libDir+"/libamdhip64.so"), C.RTLD_LAZY)
+
+	if h == nil {
+		return nil, fmt.Errorf("unable to load libamdhip64.so")
+	}
+	hl := &HipLib{}
+	hl.dll = h
+	hl.hipGetDeviceCount = C.dlsym(hl.dll, C.CString("hipGetDeviceCount"))
+	if hl.hipGetDeviceCount == nil {
+		return nil, fmt.Errorf("unable to load hipGetDeviceCount")
+	}
+	hl.hipGetDeviceProperties = C.dlsym(hl.dll, C.CString("hipGetDeviceProperties"))
+	if hl.hipGetDeviceProperties == nil {
+		return nil, fmt.Errorf("unable to load hipGetDeviceProperties")
+	}
+	hl.hipMemGetInfo = C.dlsym(hl.dll, C.CString("hipMemGetInfo"))
+	if hl.hipMemGetInfo == nil {
+		return nil, fmt.Errorf("unable to load hipMemGetInfo")
+	}
+	hl.hipSetDevice = C.dlsym(hl.dll, C.CString("hipSetDevice"))
+	if hl.hipSetDevice == nil {
+		return nil, fmt.Errorf("unable to load hipSetDevice")
+	}
+	hl.hipDriverGetVersion = C.dlsym(hl.dll, C.CString("hipDriverGetVersion"))
+	if hl.hipDriverGetVersion == nil {
+		return nil, fmt.Errorf("unable to load hipDriverGetVersion")
+	}
+	return hl, nil
+}
+
+// The hip library only evaluates the HIP_VISIBLE_DEVICES variable at startup
+// so we have to unload/reset the library after we do our initial discovery
+// to make sure our updates to that variable are processed by llama.cpp
+func (hl *HipLib) Release() {
+	C.dlclose(hl.dll)
+	hl.dll = nil
+}
+
+func (hl *HipLib) AMDDriverVersion() (driverMajor, driverMinor int, err error) {
+	if hl.dll == nil {
+		return 0, 0, errors.New("dll has been unloaded")
+	}
+	var version C.int
+	status := uintptr(C._hipDriverGetVersion(hl.hipDriverGetVersion, &version))
+	if status != hipSuccess {
+		return 0, 0, fmt.Errorf("failed call to hipDriverGetVersion: %d", status)
+	}
+
+	slog.Debug("hipDriverGetVersion", "version", version)
+	driverMajor = int(version / 10000000)
+	driverMinor = int((version - C.int(driverMajor*10000000)) / 100000)
+
+	return driverMajor, driverMinor, nil
+}
+
+func (hl *HipLib) HipGetDeviceCount() int {
+	if hl.dll == nil {
+		slog.Error("dll has been unloaded")
+		return 0
+	}
+	var count C.int
+	status := C._hipGetDeviceCount(hl.hipGetDeviceCount, &count)
+	if status == hipErrorNoDevice {
+		slog.Info("AMD ROCm reports no devices found")
+		return 0
+	}
+	if status != hipSuccess {
+		slog.Warn("failed call to hipGetDeviceCount", "status", status)
+	}
+	return int(count)
+}
+
+func (hl *HipLib) HipSetDevice(device int) error {
+	if hl.dll == nil {
+		return errors.New("dll has been unloaded")
+	}
+	status := C._hipSetDevice(hl.hipSetDevice, C.int(device))
+	if status != hipSuccess {
+		return fmt.Errorf("failed call to hipSetDevice: %d", status)
+	}
+	return nil
+}
+
+func (hl *HipLib) HipGetDeviceProperties(device int) (*hipDevicePropMinimal, error) {
+	if hl.dll == nil {
+		return nil, errors.New("dll has been unloaded")
+	}
+	var props hipDevicePropMinimal
+	status := C._hipGetDeviceProperties(hl.hipGetDeviceProperties, unsafe.Pointer(&props), C.int(device))
+	if status != hipSuccess {
+		return nil, fmt.Errorf("failed call to hipGetDeviceProperties: %d", status)
+	}
+	return &props, nil
+}
+
+// free, total, err
+func (hl *HipLib) HipMemGetInfo() (uint64, uint64, error) {
+	if hl.dll == nil {
+		return 0, 0, errors.New("dll has been unloaded")
+	}
+	var totalMemory C.size_t
+	var freeMemory C.size_t
+	status := C._hipMemGetInfo(hl.hipMemGetInfo, &freeMemory, &totalMemory)
+	if status != hipSuccess {
+		return 0, 0, fmt.Errorf("failed call to hipMemGetInfo: %d", status)
+	}
+	return uint64(freeMemory), uint64(totalMemory), nil
+}

--- a/gpu/amd_linux.go
+++ b/gpu/amd_linux.go
@@ -2,6 +2,7 @@ package gpu
 
 import (
 	"bufio"
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -45,8 +46,17 @@ var (
 	RocmStandardLocations = []string{"/opt/rocm/lib", "/usr/lib64"}
 )
 
-// Gather GPU information from the amdgpu driver if any supported GPUs are detected
 func AMDGetGPUInfo() []RocmGPUInfo {
+	resp := AMDGetGPUInfoFromSys()
+	if len(resp) != 0 {
+		return resp
+	}
+
+	return AMDGetGPUInfoFromHip()
+}
+
+// Gather GPU information from the amdgpu driver if any supported GPUs are detected
+func AMDGetGPUInfoFromSys() []RocmGPUInfo {
 	resp := []RocmGPUInfo{}
 	if !AMDDetected() {
 		return resp
@@ -454,4 +464,122 @@ func getFreeMemory(usedFile string) (uint64, error) {
 		return 0, fmt.Errorf("failed to parse sysfs node %s %w", usedFile, err)
 	}
 	return usedMemory, nil
+}
+
+func AMDGetGPUInfoFromHip() []RocmGPUInfo {
+	resp := []RocmGPUInfo{}
+	hl, err := NewHipLib()
+	if err != nil {
+		slog.Debug(err.Error())
+		return nil
+	}
+	defer hl.Release()
+
+	driverMajor, driverMinor, err := hl.AMDDriverVersion()
+	if err != nil {
+		// For now this is benign, but we may eventually need to fail compatibility checks
+		slog.Debug("error looking up amd driver version", "error", err)
+	}
+
+	// Note: the HIP library automatically handles subsetting to any HIP_VISIBLE_DEVICES the user specified
+	count := hl.HipGetDeviceCount()
+	if count == 0 {
+		return nil
+	}
+	libDir, err := AMDValidateLibDir()
+	if err != nil {
+		slog.Warn("unable to verify rocm library, will use cpu", "error", err)
+		return nil
+	}
+
+	var supported []string
+	gfxOverride := envconfig.HsaOverrideGfxVersion()
+	if gfxOverride == "" {
+		supported, err = GetSupportedGFX(libDir)
+		if err != nil {
+			slog.Warn("failed to lookup supported GFX types, falling back to CPU mode", "error", err)
+			return nil
+		}
+	} else {
+		slog.Info("skipping rocm gfx compatibility check", "HSA_OVERRIDE_GFX_VERSION", gfxOverride)
+	}
+
+	slog.Debug("detected hip devices", "count", count)
+	// TODO how to determine the underlying device ID when visible devices is causing this to subset?
+	for i := range count {
+		err = hl.HipSetDevice(i)
+		if err != nil {
+			slog.Warn("set device", "id", i, "error", err)
+			continue
+		}
+
+		props, err := hl.HipGetDeviceProperties(i)
+		if err != nil {
+			slog.Warn("get properties", "id", i, "error", err)
+			continue
+		}
+		n := bytes.IndexByte(props.Name[:], 0)
+		name := string(props.Name[:n])
+		// TODO is UUID actually populated on windows?
+		// Can luid be used on windows for setting visible devices (and is it actually set?)
+		n = bytes.IndexByte(props.GcnArchName[:], 0)
+		gfx := string(props.GcnArchName[:n])
+		slog.Debug("hip device", "id", i, "name", name, "gfx", gfx)
+		// slog.Info(fmt.Sprintf("[%d] Integrated: %d", i, props.iGPU)) // DOESN'T REPORT CORRECTLY!  Always 0
+		// ROCm in WSL does not support iGPU at the moment
+		// if strings.EqualFold(name, iGPUName) {
+		// 	slog.Info("unsupported Radeon iGPU detected skipping", "id", i, "name", name, "gfx", gfx)
+		// 	continue
+		// }
+		if gfxOverride == "" {
+			// Strip off Target Features when comparing
+			if !slices.Contains[[]string, string](supported, strings.Split(gfx, ":")[0]) {
+				slog.Warn("amdgpu is not supported", "gpu", i, "gpu_type", gfx, "library", libDir, "supported_types", supported)
+				// TODO - consider discrete markdown just for ROCM troubleshooting?
+				slog.Warn("See https://github.com/ollama/ollama/blob/main/docs/troubleshooting.md for HSA_OVERRIDE_GFX_VERSION usage")
+				continue
+			} else {
+				slog.Debug("amdgpu is supported", "gpu", i, "gpu_type", gfx)
+			}
+		}
+
+		freeMemory, totalMemory, err := hl.HipMemGetInfo()
+		if err != nil {
+			slog.Warn("get mem info", "id", i, "error", err)
+			continue
+		}
+
+		// iGPU detection, remove this check once we can support an iGPU variant of the rocm library
+		if totalMemory < IGPUMemLimit {
+			slog.Info("amdgpu appears to be an iGPU, skipping", "gpu", i, "total", format.HumanBytes2(totalMemory))
+			continue
+		}
+
+		slog.Debug("amdgpu memory", "gpu", i, "total", format.HumanBytes2(totalMemory))
+		slog.Debug("amdgpu memory", "gpu", i, "available", format.HumanBytes2(freeMemory))
+		gpuInfo := RocmGPUInfo{
+			GpuInfo: GpuInfo{
+				Library: "rocm",
+				memInfo: memInfo{
+					TotalMemory: totalMemory,
+					FreeMemory:  freeMemory,
+				},
+				// Free memory reporting on Windows is not reliable until we bump to ROCm v6.2
+				UnreliableFreeMemory: true,
+
+				ID:             strconv.Itoa(i), // TODO this is probably wrong if we specify visible devices
+				DependencyPath: libDir,
+				MinimumMemory:  rocmMinimumMemory,
+				Name:           name,
+				Compute:        gfx,
+				DriverMajor:    driverMajor,
+				DriverMinor:    driverMinor,
+			},
+			index: i,
+		}
+
+		resp = append(resp, gpuInfo)
+	}
+
+	return resp
 }


### PR DESCRIPTION
Allow running Ollama on ROCm in WSL by calling HIP functions instead of querying sysfs.

The `amd_hip_linux.go` was duplicated from `amd_hip_windows.go`, `windows.LoadLibrary` and `syscall.SyscallN` are replaced with CGO and `dlfcn.h`, to avoid depending on the HIP runtime directly.

Finally, I add an alternative routine for `RocmGPUInfo`: if existing method could not find any AMD GPUs, it will give the new method a try.

Please note, that the code changes haven't been tested outside of WSL.