### PR TITLE
Ensure sparse files on windows during download

### DIFF
--- a/server/download.go
+++ b/server/download.go
@@ -216,6 +216,9 @@ func (b *blobDownload) run(ctx context.Context, requestURL *url.URL, opts *regis
 		return err
 	}
 	defer file.Close()
+	if err := setSparse(file); err != nil {
+		return err
+	}
 
 	_ = file.Truncate(b.Total)
 

--- a/server/sparse_common.go
+++ b/server/sparse_common.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package server
+
+import "os"
+
+func setSparse(file *os.File) error {
+	return nil
+}

--- a/server/sparse_windows.go
+++ b/server/sparse_windows.go
@@ -1,0 +1,16 @@
+package server
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func setSparse(file *os.File) error {
+	return windows.DeviceIoControl(
+		windows.Handle(file.Fd()), windows.FSCTL_SET_SPARSE,
+		nil, 0,
+		nil, 0,
+		nil, nil,
+	)
+}


### PR DESCRIPTION
The file.Truncate call on windows will write the whole file unless you set the sparse flag, leading to heavy I/O at the beginning of download.  This should improve our I/O behavior on windows and put less stress on the users disk.

Fixes #5852