### PR TITLE
server: parallelize embeddings in API web handler instead of in subprocess runner

### DIFF
--- a/llm/ext_server/server.cpp
+++ b/llm/ext_server/server.cpp
@@ -3195,7 +3195,7 @@ int main(int argc, char **argv) {
                 // create and queue the task
                 const int task_id = llama.queue_tasks.get_new_id();
                 llama.queue_results.add_waiting_task_id(task_id);
-                llama.request_completion(task_id, { {"prompt", prompt}, { "n_predict", 0} }, true, -1);
+                llama.request_completion(task_id, {{"prompt", prompt}}, true, -1);
 
                 // get the result
                 task_result result = llama.queue_results.recv(task_id);

--- a/llm/ext_server/server.cpp
+++ b/llm/ext_server/server.cpp
@@ -1223,9 +1223,7 @@ struct llama_server_context
 
                 res.result_json = json
                 {
-                    {"id", res.id},
                     {"embedding", std::vector<float>(embd, embd + n_embd)},
-                    {"timings",             slot.get_formated_timings()},
                 };
             }
         }

--- a/llm/ext_server/server.cpp
+++ b/llm/ext_server/server.cpp
@@ -3194,41 +3194,17 @@ int main(int argc, char **argv) {
                     prompt = "";
                 }
 
-                if (prompt.size() == 1) {
-                    prompt = prompt[0];
-                }
-
                 // create and queue the task
-                json responses;
-                {
-                    const int id_task = llama.queue_tasks.get_new_id();
-                    llama.queue_results.add_waiting_task_id(id_task);
-                    llama.request_completion(id_task, {{"prompt", prompt}}, true, -1);
+                const int task_id = llama.queue_tasks.get_new_id();
+                llama.queue_results.add_waiting_task_id(task_id);
+                llama.request_completion(task_id, { {"prompt", prompt}, { "n_predict", 0} }, true, -1);
 
-                    // get the result
-                    task_result result = llama.queue_results.recv(id_task);
-                    llama.queue_results.remove_waiting_task_id(id_task);
-                    if (result.error) {
-                        return res.set_content(result.result_json.dump(), "application/json; charset=utf-8");
-                    }
+                // get the result
+                task_result result = llama.queue_results.recv(task_id);
+                llama.queue_results.remove_waiting_task_id(task_id);
 
-                    responses = result.result_json.value("results", std::vector<json>{result.result_json});
-                    std::sort(responses.begin(), responses.end(), [](const json& a, const json& b) {
-                        return a["id"] < b["id"];
-                    });
-
-                    json embeddings = json::array();
-
-                    int prompt_n = 0;
-                    for (auto & elem : responses) {
-                        embeddings.push_back(elem.at("embedding"));
-                        prompt_n += elem.at("timings").at("prompt_n").get<int>();
-                    }
-
-                    // send the result
-                    json embedding_res = json{{"embedding", embeddings}, {"prompt_n", prompt_n}};
-                    return res.set_content(embedding_res.dump(), "application/json; charset=utf-8");
-                }
+                // send the result
+                return res.set_content(result.result_json.dump(), "application/json; charset=utf-8");
             });
 
     // GG: if I put the main loop inside a thread, it crashes on the first request when build in Debug!?

--- a/llm/server.go
+++ b/llm/server.go
@@ -888,7 +888,7 @@ type EmbeddingRequest struct {
 
 type EmbeddingResponse struct {
 	Embedding       []float32 `json:"embedding"`
-	PromptEvalCount int         `json:"prompt_n"`
+	PromptEvalCount int       `json:"prompt_n"`
 }
 
 func (s *llmServer) Embedding(ctx context.Context, req EmbeddingRequest) (*EmbeddingResponse, error) {

--- a/llm/server.go
+++ b/llm/server.go
@@ -33,7 +33,7 @@ type LlamaServer interface {
 	Ping(ctx context.Context) error
 	WaitUntilRunning(ctx context.Context) error
 	Completion(ctx context.Context, req CompletionRequest, fn func(CompletionResponse)) error
-	Embed(ctx context.Context, input []string) (*EmbedResponse, error)
+	Embedding(ctx context.Context, req EmbeddingRequest) (*EmbeddingResponse, error)
 	Tokenize(ctx context.Context, content string) ([]int, error)
 	Detokenize(ctx context.Context, tokens []int) (string, error)
 	Close() error
@@ -882,24 +882,21 @@ func (s *llmServer) Completion(ctx context.Context, req CompletionRequest, fn fu
 	return nil
 }
 
-type EmbedRequest struct {
-	Content []string `json:"content"`
+type EmbeddingRequest struct {
+	Content string `json:"content"`
 }
 
-type EmbedResponse struct {
-	Embedding       [][]float32 `json:"embedding"`
+type EmbeddingResponse struct {
+	Embedding       []float32 `json:"embedding"`
 	PromptEvalCount int         `json:"prompt_n"`
 }
 
-func (s *llmServer) Embed(ctx context.Context, input []string) (*EmbedResponse, error) {
-	// each input will use a slot, so we need to acquire the semaphore for
-	// the number of inputs up to numParallel
-	slots := int64(min(len(input), s.numParallel))
-	if err := s.sem.Acquire(ctx, slots); err != nil {
+func (s *llmServer) Embedding(ctx context.Context, req EmbeddingRequest) (*EmbeddingResponse, error) {
+	if err := s.sem.Acquire(ctx, 1); err != nil {
 		slog.Error("Failed to acquire semaphore", "error", err)
 		return nil, err
 	}
-	defer s.sem.Release(slots)
+	defer s.sem.Release(1)
 
 	// Make sure the server is ready
 	status, err := s.getServerStatusRetry(ctx)
@@ -909,18 +906,18 @@ func (s *llmServer) Embed(ctx context.Context, input []string) (*EmbedResponse, 
 		return nil, fmt.Errorf("unexpected server status: %s", status.ToString())
 	}
 
-	data, err := json.Marshal(EmbedRequest{Content: input})
+	data, err := json.Marshal(EmbeddingRequest{Content: req.Content})
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling embed data: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("http://127.0.0.1:%d/embedding", s.port), bytes.NewBuffer(data))
+	r, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("http://127.0.0.1:%d/embedding", s.port), bytes.NewBuffer(data))
 	if err != nil {
 		return nil, fmt.Errorf("error creating embed request: %w", err)
 	}
-	req.Header.Set("Content-Type", "application/json")
+	r.Header.Set("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := http.DefaultClient.Do(r)
 	if err != nil {
 		return nil, fmt.Errorf("do embedding request: %w", err)
 	}
@@ -936,7 +933,7 @@ func (s *llmServer) Embed(ctx context.Context, input []string) (*EmbedResponse, 
 		return nil, fmt.Errorf("%s", body)
 	}
 
-	var e EmbedResponse
+	var e EmbeddingResponse
 	if err := json.Unmarshal(body, &e); err != nil {
 		return nil, fmt.Errorf("unmarshal tokenize response: %w", err)
 	}

--- a/llm/server.go
+++ b/llm/server.go
@@ -887,7 +887,7 @@ type EmbeddingRequest struct {
 }
 
 type EmbeddingResponse struct {
-	Embedding       []float32 `json:"embedding"`
+	Embedding []float32 `json:"embedding"`
 }
 
 func (s *llmServer) Embedding(ctx context.Context, input string) ([]float32, error) {

--- a/server/routes.go
+++ b/server/routes.go
@@ -387,7 +387,7 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 				return err
 			}
 			mu.Lock()
-			embeddings[i] = embedding
+			embeddings[i] = normalize(embedding)
 			mu.Unlock()
 			return nil
 		})
@@ -397,10 +397,6 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 		slog.Error("embedding generation failed", "error", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Errorf("failed to generate embeddings: %v", err)})
 		return
-	}
-
-	for i, embedding := range embeddings {
-		embeddings[i] = normalize(embedding)
 	}
 
 	resp := api.EmbedResponse{

--- a/server/routes.go
+++ b/server/routes.go
@@ -377,18 +377,14 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 	}
 
 	var g errgroup.Group
-	var mu sync.Mutex
 	embeddings := make([][]float32, len(input))
 	for i, text := range input {
-		i, text := i, text
 		g.Go(func() error {
 			embedding, err := r.Embedding(c.Request.Context(), text)
 			if err != nil {
 				return err
 			}
-			mu.Lock()
 			embeddings[i] = normalize(embedding)
-			mu.Unlock()
 			return nil
 		})
 	}

--- a/server/routes.go
+++ b/server/routes.go
@@ -399,6 +399,10 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 		return
 	}
 
+	for i, embedding := range embeddings {
+		embeddings[i] = normalize(embedding)
+	}
+
 	resp := api.EmbedResponse{
 		Model:           req.Model,
 		Embeddings:      embeddings,

--- a/server/routes.go
+++ b/server/routes.go
@@ -377,7 +377,7 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 
 	var wg sync.WaitGroup
 	var mu sync.Mutex
-	responses := make([][]float32, len(input))
+	embeddings := make([][]float32, len(input))
 	errors := make(chan error, len(input))
 
 	for i, text := range input {
@@ -390,7 +390,7 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 				return
 			}
 			mu.Lock()
-			responses[i] = embedding
+			embeddings[i] = embedding
 			mu.Unlock()
 		}(i, text)
 	}
@@ -403,11 +403,6 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 		slog.Error("embedding generation failed", "error", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Errorf("failed to generate embeddings: %v", err)})
 		return
-	}
-
-	var embeddings [][]float32
-	for _, r := range responses {
-		embeddings = append(embeddings, r)
 	}
 
 	resp := api.EmbedResponse{

--- a/server/routes.go
+++ b/server/routes.go
@@ -18,7 +18,6 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
-	"sync"
 	"syscall"
 	"time"
 

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -708,8 +708,8 @@ type mockLlm struct {
 	pingResp           error
 	waitResp           error
 	completionResp     error
-	embedResp          *llm.EmbedResponse
-	embedRespErr       error
+	embeddingResp      *llm.EmbeddingResponse
+	embeddingRespErr   error
 	tokenizeResp       []int
 	tokenizeRespErr    error
 	detokenizeResp     string
@@ -727,8 +727,8 @@ func (s *mockLlm) Completion(ctx context.Context, req llm.CompletionRequest, fn 
 	return s.completionResp
 }
 
-func (s *mockLlm) Embed(ctx context.Context, input []string) (*llm.EmbedResponse, error) {
-	return s.embedResp, s.embedRespErr
+func (s *mockLlm) Embedding(ctx context.Context, req llm.EmbeddingRequest) (*llm.EmbeddingResponse, error) {
+	return s.embeddingResp, s.embeddingRespErr
 }
 
 func (s *mockLlm) Tokenize(ctx context.Context, content string) ([]int, error) {

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -708,7 +708,7 @@ type mockLlm struct {
 	pingResp           error
 	waitResp           error
 	completionResp     error
-	embeddingResp      *llm.EmbeddingResponse
+	embeddingResp      []float32
 	embeddingRespErr   error
 	tokenizeResp       []int
 	tokenizeRespErr    error
@@ -727,7 +727,7 @@ func (s *mockLlm) Completion(ctx context.Context, req llm.CompletionRequest, fn 
 	return s.completionResp
 }
 
-func (s *mockLlm) Embedding(ctx context.Context, req llm.EmbeddingRequest) (*llm.EmbeddingResponse, error) {
+func (s *mockLlm) Embedding(ctx context.Context, input string) ([]float32, error) {
 	return s.embeddingResp, s.embeddingRespErr
 }
 


### PR DESCRIPTION
This moves the "batching" for the `/api/embed` endpoint to the Go server instead of in the runner, helping to keep the interface in `llm` simpler