### PR TITLE
Set *.png and *.ico to be treated as binary files.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,3 @@
 llm/ext_server/* linguist-vendored
-* text eol=lf
-*.png binary
-*.ico binary
-*.icns binary
+* text=auto
+*.go text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 llm/ext_server/* linguist-vendored
 * text eol=lf
+*.png binary
+*.ico binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@ llm/ext_server/* linguist-vendored
 * text eol=lf
 *.png binary
 *.ico binary
+*.icns binary


### PR DESCRIPTION
The change b732beba6 makes all files text files and sets lf as eol. This will automatically change all files to have lf if they are touched by git (e.g. via git status). This change cannot be stashed and makes it hard to work with the repo (rebase and checkout don't really work). See also #6183.

Here, we set the offending files (*.png and *.ico, but that might be more in the future) to be treated as binary files and not be changed by git.