### PR TITLE
get api models

### DIFF
--- a/server/manifest.go
+++ b/server/manifest.go
@@ -19,6 +19,7 @@ type Manifest struct {
 	Config        *Layer   `json:"config"`
 	Layers        []*Layer `json:"layers"`
 
+	name     model.Name
 	filepath string
 	fi       os.FileInfo
 	digest   string
@@ -69,7 +70,6 @@ func ParseNamedManifest(n model.Name) (*Manifest, error) {
 
 	p := filepath.Join(manifests, n.Filepath())
 
-	var m Manifest
 	f, err := os.Open(p)
 	if err != nil {
 		return nil, err
@@ -81,11 +81,13 @@ func ParseNamedManifest(n model.Name) (*Manifest, error) {
 		return nil, err
 	}
 
+	var m Manifest
 	sha256sum := sha256.New()
 	if err := json.NewDecoder(io.TeeReader(f, sha256sum)).Decode(&m); err != nil {
 		return nil, err
 	}
 
+	m.name = n
 	m.filepath = p
 	m.fi = fi
 	m.digest = hex.EncodeToString(sha256sum.Sum(nil))


### PR DESCRIPTION
implement a more restful models api starting with `GET /api/models` and `GET /api/models/{name}` which aims to replace `GET /api/tags` and `POST /api/show` respectively