### PR TITLE
cmd: print proxy info when OLLAMA_DEBUG is true

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -106,6 +106,15 @@ func (c *Client) do(ctx context.Context, method, path string, reqData, respData 
 	request.Header.Set("Accept", "application/json")
 	request.Header.Set("User-Agent", fmt.Sprintf("ollama/%s (%s %s) Go/%s", version.Version, runtime.GOARCH, runtime.GOOS, runtime.Version()))
 
+	if envconfig.Debug() {
+		proxy, err := http.ProxyFromEnvironment(request)
+		if err != nil {
+			fmt.Println("proxy parse error: " + err.Error())
+		} else {
+			fmt.Println("proxy found: " + proxy.String())
+		}
+	}
+
 	respObj, err := c.http.Do(request)
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR prints proxy information when OLLAMA_DEBUG is true.

I've noticed that users often encounter issues with HTTP proxy in their environment(like https://github.com/ollama/ollama/issues/6195 https://github.com/ollama/ollama/issues/4834), but setting OLLAMA_DEBUG to true doesn't provide additional debugging infos for this problem. All we got was `something went wrong, please see the ollama server logs for details`. Since this response comes from the HTTP proxy instead of the OLLAMA server, we still can't see anything in the server's log.

For my case, the proxy server will return 502 without any content for all requests to localhost. When I run `ollama ps`, the `something went wrong, please see the ollama server logs for details` is the only thing I can see.
After this PR, when I run `env OLLAMA_DEBUG=1 ollama ps`, I can see
```
proxy found: http://url.to.my.proxy
Error: something went wrong, please see the ollama server logs for details
```
