### PR TITLE
Don't hard fail on sparse setup error

### DIFF
--- a/server/download.go
+++ b/server/download.go
@@ -216,9 +216,7 @@ func (b *blobDownload) run(ctx context.Context, requestURL *url.URL, opts *regis
 		return err
 	}
 	defer file.Close()
-	if err := setSparse(file); err != nil {
-		return err
-	}
+	setSparse(file)
 
 	_ = file.Truncate(b.Total)
 

--- a/server/sparse_common.go
+++ b/server/sparse_common.go
@@ -4,6 +4,5 @@ package server
 
 import "os"
 
-func setSparse(file *os.File) error {
-	return nil
+func setSparse(*os.File) {
 }

--- a/server/sparse_windows.go
+++ b/server/sparse_windows.go
@@ -6,8 +6,9 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-func setSparse(file *os.File) error {
-	return windows.DeviceIoControl(
+func setSparse(file *os.File) {
+	// exFat (and other FS types) don't support sparse files, so ignore errors
+	windows.DeviceIoControl( //nolint:errcheck
 		windows.Handle(file.Fd()), windows.FSCTL_SET_SPARSE,
 		nil, 0,
 		nil, 0,


### PR DESCRIPTION
It seems this can fail in some casees, but proceed with the download anyway.

I haven't reproduced the users failure, but based on the log message and the recent regression, this seems highly likely to be the cause.

Fixes #6263 