### PR TITLE
update chatml template format to latest

### DIFF
--- a/docs/template.md
+++ b/docs/template.md
@@ -112,15 +112,9 @@ Keep the following tips and best practices in mind when working with Go template
 ChatML is a popular template format. It can be used for models such as Databrick's DBRX, Intel's Neural Chat, and Microsoft's Orca 2.
 
 ```gotmpl
-{{- if .System }}<|im_start|>system
-{{ .System }}<|im_end|>
-{{ end }}
 {{- range .Messages }}<|im_start|>{{ .Role }}
 {{ .Content }}<|im_end|>
 {{ end }}<|im_start|>assistant
-{{ else }}
-{{ if .System }}<|im_start|>system
-{{ .System }}<|im_end|>
 ```
 
 ### Example Tools

--- a/template/chatml.gotmpl
+++ b/template/chatml.gotmpl
@@ -1,6 +1,3 @@
-{{ if .System }}<|im_start|>system
-{{ .System }}<|im_end|>
-{{ end }}{{ if .Prompt }}<|im_start|>user
-{{ .Prompt }}<|im_end|>
+{{- range .Messages }}<|im_start|>{{ .Role }}
+{{ .Content }}<|im_end|>
 {{ end }}<|im_start|>assistant
-{{ .Response }}<|im_end|>

--- a/template/chatml.gotmpl
+++ b/template/chatml.gotmpl
@@ -1,3 +1,6 @@
-{{- range .Messages }}<|im_start|>{{ .Role }}
-{{ .Content }}<|im_end|>
+{{ if .System }}<|im_start|>system
+{{ .System }}<|im_end|>
+{{ end }}{{ if .Prompt }}<|im_start|>user
+{{ .Prompt }}<|im_end|>
 {{ end }}<|im_start|>assistant
+{{ .Response }}<|im_end|>


### PR DESCRIPTION
The chatml template format appears to be out of date in this template doc and the default chatml template we apply on conversion. Update these templates to match the most up to date version of this template.