### PR TITLE
Update openai.md to remove extra checkbox for vision

### DIFF
--- a/docs/openai.md
+++ b/docs/openai.md
@@ -182,7 +182,6 @@ curl http://localhost:11434/v1/embeddings \
 - [x] Reproducible outputs
 - [x] Vision
 - [x] Tools (streaming support coming soon)
-- [ ] Vision
 - [ ] Logprobs
 
 #### Supported request fields


### PR DESCRIPTION
The list has Vision twice- once checked, the other unchecked. I'm removing the second one, optimistically, but I haven't verified a vision model works yet. So maybe the first one should be removed instead?