### PR TITLE
Override numParallel in pickBestPartialFitByLibrary() only if unset.

### DIFF
--- a/server/sched.go
+++ b/server/sched.go
@@ -736,8 +736,8 @@ func pickBestFullFitByLibrary(req *LlmRequest, ggml *llm.GGML, gpus gpu.GpuInfoL
 func pickBestPartialFitByLibrary(req *LlmRequest, ggml *llm.GGML, gpus gpu.GpuInfoList, numParallel *int) gpu.GpuInfoList {
 	if *numParallel <= 0 {
 		*numParallel = 1
-                req.opts.NumCtx = req.origNumCtx
-        }
+		req.opts.NumCtx = req.origNumCtx
+	}
 	byLibrary := gpus.ByLibrary()
 	if len(byLibrary) <= 1 {
 		return gpus

--- a/server/sched.go
+++ b/server/sched.go
@@ -734,7 +734,9 @@ func pickBestFullFitByLibrary(req *LlmRequest, ggml *llm.GGML, gpus gpu.GpuInfoL
 
 // If multiple Libraries are detected, pick the Library which loads the most layers for the model
 func pickBestPartialFitByLibrary(req *LlmRequest, ggml *llm.GGML, gpus gpu.GpuInfoList, numParallel *int) gpu.GpuInfoList {
-	*numParallel = 1
+	if *numParallel <= 0 {
+		*numParallel = 1
+        }
 	byLibrary := gpus.ByLibrary()
 	if len(byLibrary) <= 1 {
 		return gpus

--- a/server/sched.go
+++ b/server/sched.go
@@ -736,6 +736,7 @@ func pickBestFullFitByLibrary(req *LlmRequest, ggml *llm.GGML, gpus gpu.GpuInfoL
 func pickBestPartialFitByLibrary(req *LlmRequest, ggml *llm.GGML, gpus gpu.GpuInfoList, numParallel *int) gpu.GpuInfoList {
 	if *numParallel <= 0 {
 		*numParallel = 1
+                req.opts.NumCtx = req.origNumCtx
         }
 	byLibrary := gpus.ByLibrary()
 	if len(byLibrary) <= 1 {


### PR DESCRIPTION
pickBestPartialFitByLibrary() sets numParallel = 1, but doesn't adjust req.opts.NumCtx.  If OLLAMA_NUM_PARALLEL has been set, NumCtx = OLLAMA_NUM_PARALLEL * defaultParallel.  Unconditionally setting numParallel to 1 causes problems in needsReload()  - because NumCtx hasn't been reset,  ` !reflect.DeepEqual(optsExisting, optsNew)` always fails, causing the model to be reloaded for every request.

It's not clear why numParallel is forced to 1, testing indicates that models operate normally with a partial load and parallelism, so this PR changes the code to set numParallel and req.opts.NumCtx only if unset.

Fixes https://github.com/ollama/ollama/issues/6148
Fixes https://github.com/ollama/ollama/issues/6271