### PR TITLE
server: limit upload parts to 16

### DIFF
--- a/server/upload.go
+++ b/server/upload.go
@@ -45,7 +45,7 @@ type blobUpload struct {
 }
 
 const (
-	numUploadParts          = 64
+	numUploadParts          = 16
 	minUploadPartSize int64 = 100 * format.MegaByte
 	maxUploadPartSize int64 = 1000 * format.MegaByte
 )


### PR DESCRIPTION
In similar vein as https://github.com/ollama/ollama/pull/6347, limit the number of upload connections to 16.