### PR TITLE
openai: increase context window when max_tokens is provided

### DIFF
--- a/openai/openai.go
+++ b/openai/openai.go
@@ -449,6 +449,11 @@ func fromChatRequest(r ChatCompletionRequest) (*api.ChatRequest, error) {
 
 	if r.MaxTokens != nil {
 		options["num_predict"] = *r.MaxTokens
+
+		// Increase context size up to max_tokens
+		if *r.MaxTokens > 2048 {
+			options["num_ctx"] = *r.MaxTokens
+		}
 	}
 
 	if r.Temperature != nil {

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -584,7 +584,7 @@ func (w *BaseWriter) writeError(code int, data []byte) (int, error) {
 	}
 
 	w.ResponseWriter.Header().Set("Content-Type", "application/json")
-	err = json.NewEncoder(w.ResponseWriter).Encode(NewError(http.StatusInternalServerError, serr.Error()))
+	err = json.NewEncoder(w.ResponseWriter).Encode(NewError(code, serr.Error()))
 	if err != nil {
 		return 0, err
 	}

--- a/openai/openai_test.go
+++ b/openai/openai_test.go
@@ -20,7 +20,7 @@ import (
 func capture(req any) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		body, _ := io.ReadAll(c.Request.Body)
-		json.Unmarshal(body, req)
+		_ = json.Unmarshal(body, req)
 		c.Next()
 	}
 }
@@ -200,7 +200,7 @@ func TestChatMiddleware(t *testing.T) {
 		})
 
 		t.Run(tt.name, func(t *testing.T) {
-			r, _ := http.NewRequest("POST", "/api/chat", strings.NewReader(tt.body))
+			r, _ := http.NewRequest(http.MethodPost, "/api/chat", strings.NewReader(tt.body))
 			r.Header.Set("Content-Type", "application/json")
 			resp := httptest.NewRecorder()
 			router.ServeHTTP(resp, r)
@@ -408,7 +408,8 @@ func TestListMiddleware(t *testing.T) {
 							Name:       "test-model",
 							ModifiedAt: time.Unix(int64(1686935002), 0).UTC(),
 						},
-					}})
+					},
+				})
 			},
 			body: `{
 				"object": "list",

--- a/openai/openai_test.go
+++ b/openai/openai_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -497,7 +496,7 @@ func TestRetrieveMiddleware(t *testing.T) {
 				  "code": null,
 				  "message": "model not found",
 				  "param": null,
-				  "type": "api_error"
+				  "type": "invalid_request_error"
 				}
 			}`,
 		},
@@ -525,8 +524,8 @@ func TestRetrieveMiddleware(t *testing.T) {
 			t.Fatalf("failed to unmarshal actual response: %v", err)
 		}
 
-		if !reflect.DeepEqual(expected, actual) {
-			t.Errorf("responses did not match\nExpected: %+v\nActual: %+v", expected, actual)
+		if diff := cmp.Diff(expected, actual); diff != "" {
+			t.Errorf("responses did not match (-want +got):\n%s", diff)
 		}
 	}
 }


### PR DESCRIPTION
Previously, `/v1/chat/completions` requests were limited to 2048 tokens. This PR extends the context length by setting `num_ctx` to `max_tokens` if it's larger than the default context window of 2048 tokens. It also includes a minor clean up for the OpenAI compatibility unit tests.

Note: this doesn't solve the case of having a large context window while limiting the number of tokens to a small number. This will be solved in a future change where `num_ctx` will be set automatically based on available VRAM and compute.

Fixes https://github.com/ollama/ollama/issues/6286 https://github.com/ollama/ollama/issues/5356