### PR TITLE
docs: add OllamaFarm to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [LangChainRust](https://github.com/Abraxas-365/langchain-rust) with [example](https://github.com/Abraxas-365/langchain-rust/blob/main/examples/llm_ollama.rs)
 - [LlamaIndex](https://gpt-index.readthedocs.io/en/stable/examples/llm/ollama.html)
 - [LiteLLM](https://github.com/BerriAI/litellm)
+- [OllamaFarm for Go](https://github.com/presbrey/ollamafarm)
 - [OllamaSharp for .NET](https://github.com/awaescher/OllamaSharp)
 - [Ollama for Ruby](https://github.com/gbaptista/ollama-ai)
 - [Ollama-rs for Rust](https://github.com/pepperoni21/ollama-rs)


### PR DESCRIPTION
OllamaFarm is a Go library that builds on the native Ollama Go API with automated tracking of the heartbeat and model availability of multiple Ollama servers to provide increased reliability and failover access to your Ollama models. This is especially helpful for protection from transient issues with networks or server hardware.