### PR TITLE
Implicit openai model parameter multiplication disabled

### DIFF
--- a/openai/openai.go
+++ b/openai/openai.go
@@ -513,7 +513,7 @@ func fromCompleteRequest(r CompletionRequest) (api.GenerateRequest, error) {
 	}
 
 	if r.Temperature != nil {
-		options["temperature"] = *r.Temperature * 2.0
+		options["temperature"] = *r.Temperature
 	} else {
 		options["temperature"] = 1.0
 	}
@@ -522,9 +522,9 @@ func fromCompleteRequest(r CompletionRequest) (api.GenerateRequest, error) {
 		options["seed"] = *r.Seed
 	}
 
-	options["frequency_penalty"] = r.FrequencyPenalty * 2.0
+	options["frequency_penalty"] = r.FrequencyPenalty
 
-	options["presence_penalty"] = r.PresencePenalty * 2.0
+	options["presence_penalty"] = r.PresencePenalty
 
 	if r.TopP != 0.0 {
 		options["top_p"] = r.TopP

--- a/openai/openai_test.go
+++ b/openai/openai_test.go
@@ -233,7 +233,7 @@ func TestCompletionsMiddleware(t *testing.T) {
 				Options: map[string]any{
 					"frequency_penalty": 0.0,
 					"presence_penalty":  0.0,
-					"temperature":       1.6,
+					"temperature":       0.8,
 					"top_p":             1.0,
 					"stop":              []any{"\n", "stop"},
 				},


### PR DESCRIPTION
Current state of openai.go setup makes absolutely valid openai config to be broken. This happens because of implicit doubling the config numbers performed in it.

I see the idea of making OpenAI API endpoint compatible with native ollama endpoint, but I think it've made wrong, as again, it leads to completely valid OpenAI config makes model goes wild.

Thus user is unable to use the same config for openai and ollama without modifications outside of model's field.

```json
{
    "url": "http://localhost:11434",
    "token": "sk-your-token",
    "status_hint": [
        "name",
        "prompt_mode",
        "chat_model"
    ],
    "assistants": [
        {
            "name": "qwen2",
            "chat_model": "qwen2:1.5b",
            "assistant_role": "You are a senior python and sublime text 4 code assistant",
            "prompt_mode": "panel",
            "temperature": 1, // makes model go insane, coz the temperature is 2 on ollama's side.
            "max_tokens": 1048,
            "top_p": 1,
            "frequency_penalty": 0, // doubles as well
            "presence_penalty": 0, // doubles as well
        }
    ]
}
```

Closes: #6492 
Affects: https://github.com/yaroslavyaroslav/OpenAI-sublime-text/issues/57