### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [LLMStack](https://github.com/trypromptly/LLMStack) (No-code multi-agent framework to build LLM agents and workflows)
 - [BoltAI for Mac](https://boltai.com) (AI Chat Client for Mac)
 - [Harbor](https://github.com/av/harbor) (Containerized LLM Toolkit with Ollama as default backend)
+- [CrewAI with Mesop](https://github.com/rapidarchitect/ollama-crew-mesop) (Mesop Web Interface to run CrewAI with Ollama)
 
 ### Terminal
 


### PR DESCRIPTION
added CrewAI and Mesop example that uses Ollama instead of OpenAI