### PR TITLE
fix(test): do not clobber models directory

### DIFF
--- a/server/model_test.go
+++ b/server/model_test.go
@@ -139,6 +139,7 @@ The temperature in San Francisco, CA is 70°F and in Toronto, Canada is 20°C.`,
 
 func TestParseFromFileFromLayer(t *testing.T) {
 	tempModels := t.TempDir()
+	t.Setenv("OLLAMA_MODELS", tempModels)
 
 	file, err := os.CreateTemp(tempModels, "")
 	if err != nil {
@@ -189,6 +190,7 @@ func TestParseFromFileFromLayer(t *testing.T) {
 
 func TestParseLayerFromCopy(t *testing.T) {
 	tempModels := t.TempDir()
+	t.Setenv("OLLAMA_MODELS", tempModels)
 
 	file2, err := os.CreateTemp(tempModels, "")
 	if err != nil {


### PR DESCRIPTION
these tests create these blobs in the user's blobs directory

```
sha256-4e06a933feaf7e21f9ea4442bec46e1a5c99f5931d06caecb5603653628ad9f1
sha256-5738747671c0649396ed0b138cf8daed5bdb7140df5ee18d0a520295045feac3
sha256-d45102d885e542798514de3c17c3d431732d90ff3bd5c743e411dcd93c7f8d1a
```