### PR TITLE
remove any unneeded build artifacts

### DIFF
--- a/llm/generate/gen_common.sh
+++ b/llm/generate/gen_common.sh
@@ -87,6 +87,8 @@ apply_patches() {
 build() {
     cmake -S ${LLAMACPP_DIR} -B ${BUILD_DIR} ${CMAKE_DEFS}
     cmake --build ${BUILD_DIR} ${CMAKE_TARGETS} -j8
+    # remove unnecessary build artifacts
+    rm -f ${BUILD_DIR}/bin/ggml-common.h ${BUILD_DIR}/bin/ggml-metal.metal
 }
 
 compress() {


### PR DESCRIPTION
metal lib is embedded so the file isn't necessary. this shaves off roughly 50KB