### PR TITLE
Update documentation: Change .bin to .gguf in GGUF file and adapter examples

### DIFF
--- a/docs/modelfile.md
+++ b/docs/modelfile.md
@@ -128,10 +128,10 @@ Currently supported model architectures:
 #### Build from a GGUF file
 
 ```modelfile
-FROM ./ollama-model.bin
+FROM ./ollama-model.gguf
 ```
 
-The GGUF bin file location should be specified as an absolute path or relative to the `Modelfile` location.
+The GGUF file location should be specified as an absolute path or relative to the `Modelfile` location.
 
 
 ### PARAMETER
@@ -208,7 +208,7 @@ Currently supported Safetensor adapters:
 #### GGUF adapter
 
 ```modelfile
-ADAPTER ./ollama-lora.bin
+ADAPTER ./ollama-lora.gguf
 ```
 
 ### LICENSE


### PR DESCRIPTION
This pull request updates the documentation to reflect the change from GGML to GGUF format.

Changes made:
- In the "Build from a GGUF file" section, updated the example Modelfile to use the .gguf extension instead of .bin
- Modified the explanatory text to refer to "GGUF file" instead of "GGUF bin file"
- In the "GGUF adapter" section, updated the example Modelfile to use the .gguf extension for the adapter file

(This is my first contribution to OSS, so I'm excited about it. Thank you.)