### PR TITLE
api: add Client.BaseURL method

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -378,3 +378,10 @@ func (c *Client) Version(ctx context.Context) (string, error) {
 
 	return version.Version, nil
 }
+
+// BaseURL returns the base URL of the client.
+func (c *Client) BaseURL() *url.URL {
+	// make a copy of the base URL to prevent mutation
+	base := *c.base
+	return &base
+}

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -40,6 +40,9 @@ func TestClientFromEnvironment(t *testing.T) {
 			if client.base.String() != v.expect {
 				t.Fatalf("expected %s, got %s", v.expect, client.base.String())
 			}
+			if client.BaseURL().String() != v.expect {
+				t.Fatalf("expected %s, got %s", v.expect, client.BaseURL().String())
+			}
 		})
 	}
 }


### PR DESCRIPTION
This method is useful in identifying and integrating an `api.Client` that has already been setup by another package or caller.

We return a copy of `base` to prevent any modification from interacting with the `api.Client`.