### PR TITLE
docs(integrations): add claude-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [PartCAD](https://github.com/openvmp/partcad/) (CAD model generation with OpenSCAD and CadQuery)
 - [Ollama4j Web UI](https://github.com/ollama4j/ollama4j-web-ui) - Java-based Web UI for Ollama built with Vaadin, Spring Boot and Ollama4j
 - [PyOllaMx](https://github.com/kspviswa/pyOllaMx) - macOS application capable of chatting with both Ollama and Apple MLX models.
+- [Claude Dev](https://github.com/saoudrizwan/claude-dev) - VSCode extension for multi-file/whole-repo coding
   
 ### Terminal
 


### PR DESCRIPTION
- Claude Dev [just added](https://github.com/saoudrizwan/claude-dev/releases/tag/v1.5.19) support for Ollama.

It's currently via the OpenAI compatible API, but specifically calls out Ollama as an option.

<img width="594" alt="image" src="https://github.com/user-attachments/assets/21167eb3-5020-4f21-b354-27d4e7e04275">
