### PR TITLE
Fixed redirect check if direct URL is already Present

### DIFF
--- a/server/download.go
+++ b/server/download.go
@@ -256,7 +256,7 @@ func (b *blobDownload) run(ctx context.Context, requestURL *url.URL, opts *regis
 				continue
 			}
 			defer resp.Body.Close()
-			if resp.StatusCode != http.StatusTemporaryRedirect {
+			if resp.StatusCode != http.StatusTemporaryRedirect && resp.StatusCode != http.StatusOK {
 				return nil, fmt.Errorf("unexpected status code %d", resp.StatusCode)
 			}
 			return resp.Location()


### PR DESCRIPTION
This is a fix regarding #6308 where the redirect check would fail with

`unexpected status code 200`.

The problem is, that if you try to pull a Model from an internal Registry, there would be no redirect, but the current logic expects at least one redirect. So i've added a the StatusCode 200 - OK to the check and return the Location of the redirect.

The bug was introduced with [Pull#5962](https://github.com/ollama/ollama/pull/5962)