### PR TITLE
openai: support for structured outputs

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/wk8/go-ordered-map/v2"
 )
 
 // StatusError is an error with and HTTP status code.
@@ -31,6 +33,28 @@ func (e StatusError) Error() string {
 		// this should not happen
 		return "something went wrong, please see the ollama server logs for details"
 	}
+}
+
+// JsonSchemaObject represents an Object within a JSON Schema.
+type JsonSchemaObject struct {
+	Type                 *string                                          `json:"type,omitempty"`
+	Format               *string                                          `json:"format,omitempty"`
+	Properties           *orderedmap.OrderedMap[string, JsonSchemaObject] `json:"properties,omitempty"`
+	Required             *[]string                                        `json:"required,omitempty"`
+	AdditionalProperties *bool                                            `json:"additionalProperties,omitempty"`
+	Items                *JsonSchemaObject                                `json:"items,omitempty"`
+	MinItems             *int                                             `json:"minItems,omitempty"`
+	MaxItems             *int                                             `json:"maxItems,omitempty"`
+	Minimum              *int                                             `json:"minimum,omitempty"`
+	Maximum              *int                                             `json:"maximum,omitempty"`
+	Enum                 *[]string                                        `json:"enum,omitempty"`
+}
+
+// JsonSchema represents a JSON Schema.
+type JsonSchema struct {
+	Name   string            `json:"name"`
+	Strict bool              `json:"strict"`
+	Schema *JsonSchemaObject `json:"schema,omitempty"`
 }
 
 // ImageData represents the raw binary data of an image file.
@@ -95,6 +119,9 @@ type ChatRequest struct {
 
 	// Format is the format to return the response in (e.g. "json").
 	Format string `json:"format"`
+
+	// JsonSchema is the strict JSON Schema when format is "json".
+	JsonSchema *JsonSchema `json:"json_schema"`
 
 	// KeepAlive controls how long the model will stay loaded into memory
 	// followin the request.

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,8 @@ require (
 
 require (
 	github.com/apache/arrow/go/arrow v0.0.0-20211112161151-bc219186db40 // indirect
+	github.com/bahlo/generic-list-go v0.2.0 // indirect
+	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/bytedance/sonic/loader v0.1.1 // indirect
 	github.com/chewxy/hm v1.0.0 // indirect
 	github.com/chewxy/math32 v1.10.1 // indirect
@@ -35,9 +37,11 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/flatbuffers v24.3.25+incompatible // indirect
 	github.com/kr/text v0.2.0 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/xtgo/set v1.0.0 // indirect
 	go4.org/unsafe/assume-no-moving-gc v0.0.0-20231121144256-b99613f794b6 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,7 +12,11 @@ github.com/apache/arrow/go/arrow v0.0.0-20211112161151-bc219186db40 h1:q4dksr6IC
 github.com/apache/arrow/go/arrow v0.0.0-20211112161151-bc219186db40/go.mod h1:Q7yQnSMnLvcXlZ8RV+jwz/6y1rQTqbX6C82SndT52Zs=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
+github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
+github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
+github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
+github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/bytedance/sonic v1.11.6 h1:oUp34TzMlL+OY1OUWxHqsdkgC/Zfc85zGqw9siXjrc0=
 github.com/bytedance/sonic v1.11.6/go.mod h1:LysEHSvpvDySVdC2f87zGWf6CIKJcAvqab1ZaiQtds4=
 github.com/bytedance/sonic/loader v0.1.1 h1:c+e5Pt1k/cy5wMveRDyk2X4B9hF4g7an8N3zCYjJFNM=
@@ -118,6 +122,7 @@ github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jung-kurt/gofpdf v1.0.0/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
@@ -136,6 +141,8 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
+github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
+github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
@@ -194,6 +201,8 @@ github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
+github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
+github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xtgo/set v1.0.0 h1:6BCNBRv3ORNDQ7fyoJXRv+tstJz3m1JVFQErfeZz2pY=

--- a/llm/ext_server/server.cpp
+++ b/llm/ext_server/server.cpp
@@ -28,6 +28,7 @@
 #include "../llava/clip.h"
 #include "../llava/llava.h"
 
+#include "json-schema-to-grammar.h"
 #include "stb_image.h"
 
 #ifndef NDEBUG
@@ -52,7 +53,7 @@
 #include <atomic>
 #include <signal.h>
 
-using json = nlohmann::json;
+using json = nlohmann::ordered_json;
 
 struct server_params {
     std::string hostname = "127.0.0.1";
@@ -549,9 +550,10 @@ struct llama_server_context
         return last_used;
     }
 
-    bool launch_slot_with_data(server_slot* &slot, json data) {
+    bool launch_slot_with_task(server_slot* &slot, task_server &task) {
         slot_params default_params;
         llama_sampling_params default_sparams;
+        auto &data = task.data;
 
         slot->params.stream             = json_value(data, "stream",            false);
         slot->params.cache_prompt       = json_value(data, "cache_prompt",      false);
@@ -574,9 +576,24 @@ struct llama_server_context
         slot->sparams.penalize_nl       = json_value(data, "penalize_nl",       default_sparams.penalize_nl);
         slot->params.n_keep             = json_value(data, "n_keep",            slot->params.n_keep);
         slot->sparams.seed              = json_value(data, "seed",              default_params.seed);
-        slot->sparams.grammar           = json_value(data, "grammar",           default_sparams.grammar);
         slot->sparams.n_probs           = json_value(data, "n_probs",           default_sparams.n_probs);
         slot->sparams.min_keep          = json_value(data, "min_keep",          default_sparams.min_keep);
+
+        // process "json_schema" and "grammar"
+        if (data.contains("json_schema") && !data.at("json_schema").is_null() && data.contains("grammar") && !data.at("grammar").is_null()) {
+            send_error(task, "Either \"json_schema\" or \"grammar\" can be specified, but not both");
+            return false;
+        } else if (data.contains("json_schema") && !data.contains("grammar")) {
+            try {
+                auto schema                = json_value(data, "json_schema", json::object());
+                slot->sparams.grammar      = json_schema_to_grammar(schema);
+            } catch (const std::exception & e) {
+                send_error(task, std::string("\"json_schema\": ") + e.what());
+                return false;
+            }
+        } else {
+            slot->sparams.grammar      = json_value(data, "grammar",           default_sparams.grammar);
+        }
 
         if (slot->n_predict > 0 && slot->params.n_predict > slot->n_predict) {
             // Might be better to reject the request with a 400 ?
@@ -1456,7 +1473,7 @@ struct llama_server_context
                 slot->task_id      = task.id;
                 slot->multitask_id = task.multitask_id;
 
-                if (!launch_slot_with_data(slot, task.data))
+                if (!launch_slot_with_task(slot, task))
                 {
                     // send error result
                     send_error(task, "internal_error");

--- a/llm/ext_server/utils.hpp
+++ b/llm/ext_server/utils.hpp
@@ -33,7 +33,7 @@
 
 #include "../llava/clip.h"
 
-using json = nlohmann::json;
+using json = nlohmann::ordered_json;
 
 extern bool server_verbose;
 extern bool server_log_json;

--- a/llm/server.go
+++ b/llm/server.go
@@ -693,10 +693,11 @@ type completion struct {
 }
 
 type CompletionRequest struct {
-	Prompt  string
-	Format  string
-	Images  []ImageData
-	Options *api.Options
+	Prompt     string
+	Format     string
+	JsonSchema *api.JsonSchema
+	Images     []ImageData
+	Options    *api.Options
 }
 
 type CompletionResponse struct {
@@ -756,9 +757,13 @@ func (s *llmServer) Completion(ctx context.Context, req CompletionRequest, fn fu
 	}
 
 	if req.Format == "json" {
-		request["grammar"] = jsonGrammar
-		if !strings.Contains(strings.ToLower(req.Prompt), "json") {
-			slog.Warn("Prompt does not specify that the LLM should response in JSON, but JSON format is expected. For best results specify that JSON is expected in the system prompt.")
+		if req.JsonSchema != nil {
+			request["json_schema"] = req.JsonSchema.Schema
+		} else {
+			request["grammar"] = jsonGrammar
+			if !strings.Contains(strings.ToLower(req.Prompt), "json") {
+				slog.Warn("Prompt does not specify that the LLM should response in JSON, but JSON format is expected. For best results specify that JSON is expected in the system prompt.")
+			}
 		}
 	}
 

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -62,7 +62,8 @@ type Usage struct {
 }
 
 type ResponseFormat struct {
-	Type string `json:"type"`
+	Type       string          `json:"type"`
+	JsonSchema *api.JsonSchema `json:"json_schema"`
 }
 
 type EmbedRequest struct {
@@ -476,17 +477,23 @@ func fromChatRequest(r ChatCompletionRequest) (*api.ChatRequest, error) {
 	}
 
 	var format string
-	if r.ResponseFormat != nil && r.ResponseFormat.Type == "json_object" {
+	var jsonSchema *api.JsonSchema
+	if r.ResponseFormat != nil && (r.ResponseFormat.Type == "json_object" || r.ResponseFormat.Type == "json_schema") {
 		format = "json"
+
+		if r.ResponseFormat.JsonSchema != nil && r.ResponseFormat.JsonSchema.Strict {
+			jsonSchema = r.ResponseFormat.JsonSchema
+		}
 	}
 
 	return &api.ChatRequest{
-		Model:    r.Model,
-		Messages: messages,
-		Format:   format,
-		Options:  options,
-		Stream:   &r.Stream,
-		Tools:    r.Tools,
+		Model:      r.Model,
+		Messages:   messages,
+		Format:     format,
+		JsonSchema: jsonSchema,
+		Options:    options,
+		Stream:     &r.Stream,
+		Tools:      r.Tools,
 	}, nil
 }
 

--- a/server/routes.go
+++ b/server/routes.go
@@ -1420,10 +1420,11 @@ func (s *Server) ChatHandler(c *gin.Context) {
 	go func() {
 		defer close(ch)
 		if err := r.Completion(c.Request.Context(), llm.CompletionRequest{
-			Prompt:  prompt,
-			Images:  images,
-			Format:  req.Format,
-			Options: opts,
+			Prompt:     prompt,
+			Images:     images,
+			Format:     req.Format,
+			JsonSchema: req.JsonSchema,
+			Options:    opts,
 		}, func(r llm.CompletionResponse) {
 			res := api.ChatResponse{
 				Model:      req.Model,


### PR DESCRIPTION
This PR is enabling the [Structured Outputs](https://platform.openai.com/docs/guides/structured-outputs/supported-schemas) feature available on OpenAI.

Using the math reasoning example they have on their website, here's the response of both OpenAI and Ollama using the exact same request:

OpenAI (gpt-4o-2024-08-06)
```
{
  "steps": [
    {
      "explanation": "We start with the equation 8x + 7 = -23. Our goal is to isolate x on one side of the equation.",
      "output": "8x + 7 = -23"
    },
    {
      "explanation": "Subtract 7 from both sides to begin isolating the term with x. This will help us get rid of the constant term on the left side.",
      "output": "8x + 7 - 7 = -23 - 7"
    },
    {
      "explanation": "Simplify both sides of the equation. On the left side, 7 - 7 cancels out, leaving us with 8x. On the right side, -23 - 7 equals -30.",
      "output": "8x = -30"
    },
    {
      "explanation": "Now, divide both sides by 8 to solve for x. This will isolate x completely.",
      "output": "8x / 8 = -30 / 8"
    },
    {
      "explanation": "Simplify the right side of the equation. -30 divided by 8 simplifies to -3.75.",
      "output": "x = -3.75"
    }
  ],
  "final_answer": "x = -3.75"
}
```


Ollama (llama3.1:8b)
```
{
  "steps": [
    {
      "explanation": "The first step is to isolate the term with the variable (in this case, x) on one side of the equation.",
      "output": "Subtract 7 from both sides: 8x + 7 - 7 = -23 - 7"
    },
    {
      "explanation": "This simplifies to:",
      "output": "8x = -30"
    },
    {
      "explanation": "The next step is to get rid of the coefficient (the number being multiplied by x).",
      "output": "Divide both sides by 8: 8x / 8 = -30 / 8"
    },
    {
      "explanation": "This simplifies to:",
      "output": "x = -3.75"
    }
  ],
  "final_answer": "-3.75"
}
```
