### PR TITLE
(Rebased) Add Braina AI as an Ollama Desktop GUI #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 ### Web & Desktop
 
 - [Open WebUI](https://github.com/open-webui/open-webui)
+- [Braina AI](https://www.brainasoft.com/braina/) - (Desktop Chat Client for Windows)
 - [Enchanted (macOS native)](https://github.com/AugustDev/enchanted)
 - [Hollama](https://github.com/fmaclen/hollama)
 - [Lollms-Webui](https://github.com/ParisNeo/lollms-webui)


### PR DESCRIPTION
Rebased PR. Added Braina in Ollama's community Integration list as desktop client for Windows. Please see the old pull request for more information: **https://github.com/ollama/ollama/pull/6112**