### PR TITLE
Align OpenAI Chat option processing with Completion option processing

### DIFF
--- a/openai/openai.go
+++ b/openai/openai.go
@@ -452,7 +452,7 @@ func fromChatRequest(r ChatCompletionRequest) (*api.ChatRequest, error) {
 	}
 
 	if r.Temperature != nil {
-		options["temperature"] = *r.Temperature * 2.0
+		options["temperature"] = *r.Temperature
 	} else {
 		options["temperature"] = 1.0
 	}
@@ -462,11 +462,11 @@ func fromChatRequest(r ChatCompletionRequest) (*api.ChatRequest, error) {
 	}
 
 	if r.FrequencyPenalty != nil {
-		options["frequency_penalty"] = *r.FrequencyPenalty * 2.0
+		options["frequency_penalty"] = *r.FrequencyPenalty
 	}
 
 	if r.PresencePenalty != nil {
-		options["presence_penalty"] = *r.PresencePenalty * 2.0
+		options["presence_penalty"] = *r.PresencePenalty
 	}
 
 	if r.TopP != nil {

--- a/openai/openai_test.go
+++ b/openai/openai_test.go
@@ -102,9 +102,9 @@ func TestChatMiddleware(t *testing.T) {
 					"num_predict":       999.0, // float because JSON doesn't distinguish between float and int
 					"seed":              123.0,
 					"stop":              []any{"\n", "stop"},
-					"temperature":       6.0,
-					"frequency_penalty": 8.0,
-					"presence_penalty":  10.0,
+					"temperature":       3.0,
+					"frequency_penalty": 4.0,
+					"presence_penalty":  5.0,
 					"top_p":             6.0,
 				},
 				Format: "json",


### PR DESCRIPTION
https://github.com/ollama/ollama/pull/6514 removed the option scaling for OpenAI Completion requests.  Do the same for Chat requests.