### PR TITLE
runner.go: Prompt caching

### DIFF
--- a/llama/llama.go
+++ b/llama/llama.go
@@ -139,6 +139,10 @@ func (c *Context) KvCacheSeqRm(seqId int, p0 int, p1 int) bool {
 	return bool(C.llama_kv_cache_seq_rm(c.c, C.int(seqId), C.int(p0), C.int(p1)))
 }
 
+func (c *Context) KvCacheSeqCp(srcSeqId int, dstSeqId int, p0 int, p1 int) {
+	C.llama_kv_cache_seq_cp(c.c, C.int(srcSeqId), C.int(dstSeqId), C.int(p0), C.int(p1))
+}
+
 // Get the embeddings for a sequence id
 func (c *Context) GetEmbeddingsSeq(seqId int) []float32 {
 	embeddings := unsafe.Pointer(C.llama_get_embeddings_seq(c.c, C.int(seqId)))

--- a/llama/runner/cache.go
+++ b/llama/runner/cache.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/ollama/ollama/llama"
+)
+
+type TokenCache struct {
+	// context window size (per slot)
+	numCtx int
+
+	// individual caches
+	slots []TokenCacheSlot
+
+	lc *llama.Context
+}
+
+func NewTokenCache(lc *llama.Context, kvSize int, numSlots int) *TokenCache {
+	slots := make([]TokenCacheSlot, numSlots)
+
+	for i := range slots {
+		slots[i] = TokenCacheSlot{
+			id:     i,
+			tokens: make([]int, 0),
+		}
+	}
+
+	return &TokenCache{
+		numCtx: kvSize / numSlots,
+		slots:  slots,
+		lc:     lc,
+	}
+}
+
+// Locking: Operations on TokenCacheSlot (including finding one
+// through LoadCacheSlot) require a lock to be be held that serializes
+// these operations with each other and llama.Decode
+
+type TokenCacheSlot struct {
+	// Index in the KV cache
+	id int
+
+	// tokens that are stored in the KV cache
+	tokens []int
+
+	// is this cache actively being processed as part of a sequence?
+	inUse bool
+
+	// last time this cache was used (as of start of processing)
+	lastUsed time.Time
+}
+
+func (t *TokenCache) LoadCacheSlot(prompt []int) (*TokenCacheSlot, []int, int) {
+	slot, numPast := t.findCacheSlot(prompt)
+
+	slot.inUse = true
+	slot.lastUsed = time.Now()
+
+	if numPast == len(prompt) {
+		// Leave one token to sample so we can get a response
+		numPast--
+	}
+
+	if !t.lc.KvCacheSeqRm(slot.id, numPast, -1) {
+		// Some models don't support partial erasure
+		t.lc.KvCacheSeqRm(slot.id, 0, -1)
+		numPast = 0
+	}
+
+	slog.Debug("loading cache slot", "id", slot.id, "cache", len(slot.tokens), "prompt", len(prompt),
+		"used", numPast, "remaining", len(prompt)-numPast)
+
+	prompt = prompt[numPast:]
+	slot.tokens = slot.tokens[:numPast]
+
+	return slot, prompt, numPast
+}
+
+func (t *TokenCache) findCacheSlot(prompt []int) (*TokenCacheSlot, int) {
+	oldest := time.Now()
+	var oldestSlot *TokenCacheSlot
+
+	longest := -1
+	var longestSlot *TokenCacheSlot
+
+	for i, s := range t.slots {
+		count := countCommonPrefix(s.tokens, prompt)
+		if count > longest {
+			longest = count
+			longestSlot = &t.slots[i]
+		}
+
+		if s.lastUsed.Compare(oldest) < 0 && !s.inUse {
+			oldest = s.lastUsed
+			oldestSlot = &t.slots[i]
+		}
+	}
+
+	if longest == len(longestSlot.tokens) && !longestSlot.inUse {
+		return longestSlot, longest
+	}
+
+	if oldestSlot.inUse {
+		panic("no available cache slots")
+	}
+
+	if len(oldestSlot.tokens) != 0 {
+		slog.Debug("evicting cache slot", "id", oldestSlot.id, "tokens", len(oldestSlot.tokens),
+			"used", oldestSlot.lastUsed)
+	}
+
+	if longest > 0 && longestSlot != oldestSlot {
+		slog.Debug("forking cache slot", "src", longestSlot.id, "dst", oldestSlot.id, "tokens", longest, "total",
+			len(longestSlot.tokens))
+		oldestSlot.tokens = make([]int, longest)
+		copy(oldestSlot.tokens, longestSlot.tokens[:longest])
+		// This is only nil for unit tests
+		if t.lc != nil {
+			t.lc.KvCacheSeqCp(longestSlot.id, oldestSlot.id, 0, longest)
+		}
+	}
+
+	return oldestSlot, longest
+}
+
+func countCommonPrefix(a []int, b []int) int {
+	var count int
+
+	for i := range a {
+		if i >= len(b) {
+			break
+		}
+
+		if a[i] != b[i] {
+			break
+		}
+
+		count++
+	}
+
+	return count
+}
+
+func (t *TokenCache) ShiftCacheSlot(slot *TokenCacheSlot, numKeep int, numDiscard int, numPast int) {
+	// TODO (jessegross): KV cache removal can fail for certain types of models
+	// server.cpp doesn't handle this, though we can be more graceful
+	t.lc.KvCacheSeqRm(slot.id, numKeep, numKeep+numDiscard)
+	t.lc.KvCacheSeqAdd(slot.id, numKeep+numDiscard, numPast, -numDiscard)
+
+	for i := numKeep + numDiscard; i < len(slot.tokens); i++ {
+		slot.tokens[i-numDiscard] = slot.tokens[i]
+	}
+	slot.tokens = slot.tokens[:len(slot.tokens)-numDiscard]
+}

--- a/llama/runner/cache_test.go
+++ b/llama/runner/cache_test.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCountCommon(t *testing.T) {
+	tests := []struct {
+		name     string
+		t1       []int
+		t2       []int
+		expected int
+	}{
+		{
+			name:     "Equal",
+			t1:       []int{1, 2, 3},
+			t2:       []int{1, 2, 3},
+			expected: 3,
+		},
+		{
+			name:     "Prefix",
+			t1:       []int{1},
+			t2:       []int{1, 2, 3},
+			expected: 1,
+		},
+		{
+			name:     "Empty",
+			t1:       []int{},
+			t2:       []int{1, 2, 3},
+			expected: 0,
+		},
+		{
+			name:     "Both Empty",
+			t1:       []int{},
+			t2:       []int{},
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := countCommonPrefix(tt.t1, tt.t2)
+			if result != tt.expected {
+				t.Errorf("countCommonPrefix(%v, %v): have %v; want %v", tt.t1, tt.t2, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFindCacheSlot(t *testing.T) {
+	tests := []struct {
+		name        string
+		cache       TokenCache
+		prompt      []int
+		expected    int
+		expectedLen int
+	}{
+		{
+			name: "Empty",
+			cache: TokenCache{slots: []TokenCacheSlot{
+				{
+					id:       0,
+					tokens:   []int{},
+					inUse:    false,
+					lastUsed: time.Time{},
+				},
+				{
+					id:       1,
+					tokens:   []int{},
+					inUse:    false,
+					lastUsed: time.Time{},
+				},
+			}},
+			prompt:      []int{1},
+			expected:    0,
+			expectedLen: 0,
+		},
+		{
+			name: "Extend",
+			cache: TokenCache{slots: []TokenCacheSlot{
+				{
+					id:       0,
+					tokens:   []int{1},
+					inUse:    false,
+					lastUsed: time.Now().Add(-time.Second),
+				},
+				{
+					id:       1,
+					tokens:   []int{1, 2},
+					inUse:    false,
+					lastUsed: time.Now().Add(-2 * time.Second),
+				},
+			}},
+			prompt:      []int{1, 2},
+			expected:    1,
+			expectedLen: 2,
+		},
+		{
+			name: "New",
+			cache: TokenCache{slots: []TokenCacheSlot{
+				{
+					id:       0,
+					tokens:   []int{1, 2},
+					inUse:    false,
+					lastUsed: time.Now().Add(-time.Second),
+				},
+				{
+					id:       1,
+					tokens:   []int{},
+					inUse:    false,
+					lastUsed: time.Time{},
+				},
+			}},
+			prompt:      []int{2},
+			expected:    1,
+			expectedLen: 0,
+		},
+		{
+			name: "Fork",
+			cache: TokenCache{
+				slots: []TokenCacheSlot{
+					{
+						id:       0,
+						tokens:   []int{1, 2},
+						inUse:    false,
+						lastUsed: time.Now().Add(-time.Second),
+					},
+					{
+						id:       1,
+						tokens:   []int{},
+						inUse:    false,
+						lastUsed: time.Time{},
+					},
+				},
+			},
+			prompt:      []int{1},
+			expected:    1,
+			expectedLen: 1,
+		},
+		{
+			name: "Evict",
+			cache: TokenCache{slots: []TokenCacheSlot{
+				{
+					id:       0,
+					tokens:   []int{1},
+					inUse:    false,
+					lastUsed: time.Now().Add(-time.Second),
+				},
+				{
+					id:       1,
+					tokens:   []int{1, 2},
+					inUse:    false,
+					lastUsed: time.Now().Add(-2 * time.Second),
+				},
+			}},
+			prompt:      []int{2, 3},
+			expected:    1,
+			expectedLen: 0,
+		},
+		{
+			name: "In use",
+			cache: TokenCache{slots: []TokenCacheSlot{
+				{
+					id:       0,
+					tokens:   []int{1},
+					inUse:    false,
+					lastUsed: time.Now().Add(-time.Second),
+				},
+				{
+					id:       1,
+					tokens:   []int{1, 2},
+					inUse:    true,
+					lastUsed: time.Now().Add(-2 * time.Second),
+				},
+			}},
+			prompt:      []int{1, 2},
+			expected:    0,
+			expectedLen: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, resultLen := tt.cache.findCacheSlot(tt.prompt)
+			if result.id != tt.expected || resultLen != tt.expectedLen {
+				t.Errorf("findCacheSlot: slot have %v, want %v len have %v, want %v",
+					result.id, tt.expected, resultLen, tt.expectedLen)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Currently, KV cache entries from a sequence are discarded at the end of each processing run. In a typical chat conversation, this results in each message taking longer and longer to process as the entire history of the conversation needs to be replayed.

Prompt caching retains the KV entries as long as possible so that we only need to process the newest message in the converation, at least until there are too many simultaneous conversations and something needs to be evicted.