### PR TITLE
Use GOARCH for build dirs

### DIFF
--- a/llm/generate/gen_darwin.sh
+++ b/llm/generate/gen_darwin.sh
@@ -40,7 +40,7 @@ case "${GOARCH}" in
         init_vars
         CMAKE_DEFS="${COMMON_CPU_DEFS} -DGGML_ACCELERATE=off -DGGML_BLAS=off -DGGML_AVX=off -DGGML_AVX2=off -DGGML_AVX512=off -DGGML_FMA=off -DGGML_F16C=off ${CMAKE_DEFS}"
         RUNNER=cpu
-        BUILD_DIR="../build/darwin/${ARCH}/${RUNNER}"
+        BUILD_DIR="../build/darwin/${GOARCH}/${RUNNER}"
         echo "Building LCD CPU"
         build
         sign ${BUILD_DIR}/bin/ollama_llama_server
@@ -53,7 +53,7 @@ case "${GOARCH}" in
         init_vars
         CMAKE_DEFS="${COMMON_CPU_DEFS} -DGGML_ACCELERATE=off -DGGML_BLAS=off -DGGML_AVX=on -DGGML_AVX2=off -DGGML_AVX512=off -DGGML_FMA=off -DGGML_F16C=off ${CMAKE_DEFS}"
         RUNNER=cpu_avx
-        BUILD_DIR="../build/darwin/${ARCH}/${RUNNER}"
+        BUILD_DIR="../build/darwin/${GOARCH}/${RUNNER}"
         echo "Building AVX CPU"
         build
         sign ${BUILD_DIR}/bin/ollama_llama_server
@@ -66,7 +66,7 @@ case "${GOARCH}" in
         init_vars
         CMAKE_DEFS="${COMMON_CPU_DEFS} -DGGML_ACCELERATE=on -DGGML_BLAS=off -DGGML_AVX=on -DGGML_AVX2=on -DGGML_AVX512=off -DGGML_FMA=on -DGGML_F16C=on ${CMAKE_DEFS}"
         RUNNER=cpu_avx2
-        BUILD_DIR="../build/darwin/${ARCH}/${RUNNER}"
+        BUILD_DIR="../build/darwin/${GOARCH}/${RUNNER}"
         echo "Building AVX2 CPU"
         EXTRA_LIBS="${EXTRA_LIBS} -framework Accelerate -framework Foundation"
         build
@@ -88,7 +88,7 @@ case "${GOARCH}" in
         init_vars
         CMAKE_DEFS="${COMMON_DARWIN_DEFS} -DCMAKE_SYSTEM_PROCESSOR=${ARCH} -DCMAKE_OSX_ARCHITECTURES=${ARCH} ${CMAKE_DEFS}"
         RUNNER="metal"
-        BUILD_DIR="../build/darwin/${ARCH}/${RUNNER}"
+        BUILD_DIR="../build/darwin/${GOARCH}/${RUNNER}"
         EXTRA_LIBS="${EXTRA_LIBS} -framework Accelerate -framework Foundation -framework Metal -framework MetalKit -framework MetalPerformanceShaders"
         build
         sign ${BUILD_DIR}/bin/ollama_llama_server

--- a/llm/generate/gen_linux.sh
+++ b/llm/generate/gen_linux.sh
@@ -80,7 +80,7 @@ if [ -z "${OLLAMA_SKIP_CPU_GENERATE}" ]; then
         echo "OLLAMA_CUSTOM_CPU_DEFS=\"${OLLAMA_CUSTOM_CPU_DEFS}\""
         CMAKE_DEFS="${OLLAMA_CUSTOM_CPU_DEFS} -DBUILD_SHARED_LIBS=on -DCMAKE_POSITION_INDEPENDENT_CODE=on ${CMAKE_DEFS}"
         RUNNER="cpu"
-        BUILD_DIR="../build/linux/${ARCH}/${RUNNER}"
+        BUILD_DIR="../build/linux/${GOARCH}/${RUNNER}"
         echo "Building custom CPU"
         build
         install
@@ -105,7 +105,7 @@ if [ -z "${OLLAMA_SKIP_CPU_GENERATE}" ]; then
             init_vars
             CMAKE_DEFS="${COMMON_CPU_DEFS} -DGGML_AVX=off -DGGML_AVX2=off -DGGML_AVX512=off -DGGML_FMA=off -DGGML_F16C=off ${CMAKE_DEFS}"
             RUNNER=cpu
-            BUILD_DIR="../build/linux/${ARCH}/${RUNNER}"
+            BUILD_DIR="../build/linux/${GOARCH}/${RUNNER}"
             echo "Building LCD CPU"
             build
             install
@@ -125,7 +125,7 @@ if [ -z "${OLLAMA_SKIP_CPU_GENERATE}" ]; then
                 init_vars
                 CMAKE_DEFS="${COMMON_CPU_DEFS} -DGGML_AVX=on -DGGML_AVX2=off -DGGML_AVX512=off -DGGML_FMA=off -DGGML_F16C=off ${CMAKE_DEFS}"
                 RUNNER=cpu_avx
-                BUILD_DIR="../build/linux/${ARCH}/${RUNNER}"
+                BUILD_DIR="../build/linux/${GOARCH}/${RUNNER}"
                 echo "Building AVX CPU"
                 build
                 install
@@ -141,7 +141,7 @@ if [ -z "${OLLAMA_SKIP_CPU_GENERATE}" ]; then
                 init_vars
                 CMAKE_DEFS="${COMMON_CPU_DEFS} -DGGML_AVX=on -DGGML_AVX2=on -DGGML_AVX512=off -DGGML_FMA=on -DGGML_F16C=on ${CMAKE_DEFS}"
                 RUNNER=cpu_avx2
-                BUILD_DIR="../build/linux/${ARCH}/${RUNNER}"
+                BUILD_DIR="../build/linux/${GOARCH}/${RUNNER}"
                 echo "Building AVX2 CPU"
                 build
                 install
@@ -196,7 +196,7 @@ if [ -z "${OLLAMA_SKIP_CUDA_GENERATE}" -a -d "${CUDA_LIB_DIR}" ]; then
     export CUDAFLAGS="-t8"
     CMAKE_DEFS="${COMMON_CMAKE_DEFS} ${CMAKE_DEFS} ${ARM64_DEFS} ${CMAKE_CUDA_DEFS} -DGGML_STATIC=off"
     RUNNER=cuda${CUDA_VARIANT}
-    BUILD_DIR="../build/linux/${ARCH}/${RUNNER}"
+    BUILD_DIR="../build/linux/${GOARCH}/${RUNNER}"
     export LLAMA_SERVER_LDFLAGS="-L${CUDA_LIB_DIR} -lcudart -lcublas -lcublasLt -lcuda"
     CUDA_DIST_DIR="${CUDA_DIST_DIR:-${DIST_BASE}/lib/ollama}"
     build
@@ -223,7 +223,7 @@ if [ -z "${OLLAMA_SKIP_ONEAPI_GENERATE}" -a -d "${ONEAPI_ROOT}" ]; then
     CC=icx
     CMAKE_DEFS="${COMMON_CMAKE_DEFS} ${CMAKE_DEFS} -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx -DGGML_SYCL=ON -DGGML_SYCL_F16=OFF"
     RUNNER=oneapi
-    BUILD_DIR="../build/linux/${ARCH}/${RUNNER}"
+    BUILD_DIR="../build/linux/${GOARCH}/${RUNNER}"
     ONEAPI_DIST_DIR="${DIST_BASE}/lib/ollama"
     export LLAMA_SERVER_LDFLAGS="-fsycl -lOpenCL -lmkl_core -lmkl_sycl_blas -lmkl_intel_ilp64 -lmkl_tbb_thread -ltbb"
     DEBUG_FLAGS="" # icx compiles with -O0 if we pass -g, so we must remove it
@@ -272,7 +272,7 @@ if [ -z "${OLLAMA_SKIP_ROCM_GENERATE}" -a -d "${ROCM_PATH}" ]; then
         echo "Building custom ROCM GPU"
     fi
     RUNNER=rocm${ROCM_VARIANT}
-    BUILD_DIR="../build/linux/${ARCH}/${RUNNER}"
+    BUILD_DIR="../build/linux/${GOARCH}/${RUNNER}"
     # ROCm dependencies are too large to fit into a unified bundle
     ROCM_DIST_DIR="${DIST_BASE}/../linux-${GOARCH}-rocm/lib/ollama"
     # TODO figure out how to disable runpath (rpath)
@@ -282,7 +282,7 @@ if [ -z "${OLLAMA_SKIP_ROCM_GENERATE}" -a -d "${ROCM_PATH}" ]; then
 
     # copy the ROCM dependencies
     mkdir -p "${ROCM_DIST_DIR}"
-    for dep in $(ldd "${BUILD_DIR}/bin/ollama_llama_server" | grep "=>" | cut -f2 -d= | cut -f2 -d' ' | grep -v "${ARCH}/rocm${ROCM_VARIANT}" | grep -e rocm -e amdgpu -e libtinfo -e libnuma -e libelf ); do
+    for dep in $(ldd "${BUILD_DIR}/bin/ollama_llama_server" | grep "=>" | cut -f2 -d= | cut -f2 -d' ' | grep -v "${GOARCH}/rocm${ROCM_VARIANT}" | grep -e rocm -e amdgpu -e libtinfo -e libnuma -e libelf ); do
         cp -a "${dep}"* "${ROCM_DIST_DIR}"
         if [ $(readlink -f "${dep}") != "${dep}" ] ; then
             cp $(readlink -f "${dep}") "${ROCM_DIST_DIR}"


### PR DESCRIPTION
Corrects x86_64 vs amd64 discrepancy

See https://github.com/ollama/ollama/blob/main/llm/generate/gen_common.sh#L6

This went unnoticed from #6547 due to the wildcards used in the payload, but once I tried to carry this over to the Go server branch we noticed when toggling between the C++ and Go servers they weren't correctly swapping back and forth on Linux.