### PR TITLE
Fix incremental builds on linux

### DIFF
--- a/llm/generate/gen_common.sh
+++ b/llm/generate/gen_common.sh
@@ -137,7 +137,7 @@ wait_for_compress() {
 
 install() {
     echo "Installing libraries to bin dir ${BUILD_DIR}/bin/"
-    for lib in $(find ${BUILD_DIR} -name \*.${LIB_EXT}); do
+    for lib in $(find ${BUILD_DIR} -name \*.${LIB_EXT} | grep -v "${BUILD_DIR}/bin/" ); do
         rm -f "${BUILD_DIR}/bin/$(basename ${lib})"
         cp -af "${lib}" "${BUILD_DIR}/bin/"
     done


### PR DESCRIPTION
Building in containers worked fine.  Building iteratively on a persistent filesystem doesn't. Running the install function twice on a second generate caused an error cp: cannot stat '../build/linux/amd64/cpu/bin/libllama.so': No such file or directory