### PR TITLE
Add vim-intelligence-bridge to Terminal section  in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [gollama](https://github.com/sammcj/gollama)
 - [Ollama eBook Summary](https://github.com/cognitivetech/ollama-ebook-summary/)
 - [Ollama Mixture of Experts (MOE) in 50 lines of code](https://github.com/rapidarchitect/ollama_moe)
+- [vim-intelligence-bridge](https://github.com/pepo-ec/vim-intelligence-bridge) Simple interaction of "Ollama" with the Vim editor
 
 ### Apple Vision Pro
 - [Enchanted](https://github.com/AugustDev/enchanted)


### PR DESCRIPTION
I'm proposing to add vim-intelligence-bridge to the Terminal section. This plugin is unique as it's the only one that integrates Ollama directly with traditional Vim (not Neovim). Key benefits:

- Expands Ollama's reach to Vim users
- Promotes local, private AI processing within Vim
- Enhances developer productivity by integrating Ollama in the Vim workflow

This addition showcases Ollama's versatility and encourages wider adoption in the developer community.
Proposed change:

[vim-intelligence-bridge](https://github.com/pepo-ec/vim-intelligence-bridge) Simple interaction of "Ollama" with the Vim editor