### PR TITLE
cache: Clear old KV cache entries when evicting a slot

### DIFF
--- a/llama/runner/cache.go
+++ b/llama/runner/cache.go
@@ -118,6 +118,7 @@ func (t *TokenCache) findCacheSlot(prompt []int) (*TokenCacheSlot, int) {
 		copy(oldestSlot.tokens, longestSlot.tokens[:longest])
 		// This is only nil for unit tests
 		if t.lc != nil {
+			t.lc.KvCacheSeqRm(oldestSlot.id, 0, -1)
 			t.lc.KvCacheSeqCp(longestSlot.id, oldestSlot.id, 0, longest)
 		}
 	}


### PR DESCRIPTION
When forking a cache entry, if no empty slots are available we evict the least recently used one and copy over the KV entries from the closest match. However, this copy does not overwrite existing values but only adds new ones. Therefore, we need to clear the old slot first.

This change fixes two issues:
 - The KV cache fills up and runs out of space even though we think we are managing it correctly
 - Performance gets worse over time as we use new cache entries that are not hot in the processor caches