### PR TITLE
CI: dist directories no longer present

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -623,8 +623,6 @@ jobs:
           ls -lh dist/
           (cd dist; find . -type f | xargs sha256sum > ../sha256sum.txt)
           mv sha256sum.txt dist/
-          mv dist/linux-???64 .
-          mv dist/linux-amd64-rocm .
           cat dist/sha256sum.txt
       - name: Create or update Release
         run: |


### PR DESCRIPTION
The new buildx based build no longer leaves the dist/linux-* directories around, so we don't have to clean them up before uploading.