### PR TITLE
 runner.go: Don't panic when processing sequences

### DIFF
--- a/llama/runner/cache_test.go
+++ b/llama/runner/cache_test.go
@@ -182,8 +182,10 @@ func TestFindCacheSlot(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, resultLen := tt.cache.findCacheSlot(tt.prompt)
-			if result.id != tt.expected || resultLen != tt.expectedLen {
+			result, resultLen, err := tt.cache.findCacheSlot(tt.prompt)
+			if err != nil {
+				t.Errorf("findCacheSlot: err %v", err)
+			} else if result.id != tt.expected || resultLen != tt.expectedLen {
 				t.Errorf("findCacheSlot: slot have %v, want %v len have %v, want %v",
 					result.id, tt.expected, resultLen, tt.expectedLen)
 			}

--- a/llama/runner/runner.go
+++ b/llama/runner/runner.go
@@ -655,7 +655,7 @@ func (s *Server) loadModel(
 
 	s.model = llama.LoadModelFromFile(mpath, params)
 
-	ctxParams := llama.NewContextParams(kvSize, s.batchSize, s.parallel, threads, flashAttention)
+	ctxParams := llama.NewContextParams(kvSize, s.batchSize*s.parallel, s.parallel, threads, flashAttention)
 	s.lc = llama.NewContextWithModel(s.model, ctxParams)
 
 	if lpath != "" {

--- a/llama/runner/runner.go
+++ b/llama/runner/runner.go
@@ -374,7 +374,12 @@ func (s *Server) processBatch() {
 		if ok, stop := findStop(sequence, seq.stop); ok {
 			slog.Info("hit stop token", "stop", seq.stop)
 
+			trimCacheLen := len(seq.pendingResponses) - 1
 			seq.pendingResponses = truncateStop(seq.pendingResponses, stop)
+			trimCacheLen -= len(seq.pendingResponses)
+
+			// remove any tokens from the cache that we don't actually return
+			seq.cache.tokens = seq.cache.tokens[:len(seq.cache.tokens)-trimCacheLen]
 			s.removeSequence(i, "stop")
 			continue
 		}

--- a/llama/runner/runner.go
+++ b/llama/runner/runner.go
@@ -254,6 +254,13 @@ func (s *Server) run(ctx context.Context) {
 	}
 }
 
+// TODO (jmorganca): processBatch should be simplified, removing:
+// * sampling
+// * stop token checking
+// * metrics
+// these should instead be handled by the handlers
+// it should only be responsible for accepting tokens or embeddings and
+// processing batches as fast as possible
 func (s *Server) processBatch() {
 	batch := llama.NewBatch(s.batchSize*len(s.seqs), 0, len(s.seqs))
 	defer batch.Free()
@@ -385,6 +392,9 @@ func (s *Server) processBatch() {
 	}
 }
 
+// TODO (jmorganca): use structs from the api package to avoid duplication
+// this way the api acts as a proxy instead of using a different api for the
+// runner
 type Options struct {
 	api.Runner
 


### PR DESCRIPTION
If there is an error processing a sequence, we should simply return
an HTTP error and abort that sequence rather than panic the whole
runner. This will make us more resilient to transient failures.

Panics can still occur during startup as there is no way to serve
requests if that fails.

Based on some code that was originally part of the vision work.

Co-authored-by: jmorganca <jmorganca@gmail.com>