### PR TITLE
allow ctl-j to add a new line + fix multiline bracketed paste

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -30,6 +30,11 @@ const (
 	MultilineSystem
 )
 
+const (
+	scannerPrompt    = ">>> "
+	scannerAltPrompt = "... "
+)
+
 func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 	usage := func() {
 		fmt.Fprintln(os.Stderr, "Available Commands:")
@@ -111,8 +116,8 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 	}
 
 	scanner, err := readline.New(readline.Prompt{
-		Prompt:         ">>> ",
-		AltPrompt:      "... ",
+		Prompt:         scannerPrompt,
+		AltPrompt:      scannerAltPrompt,
 		Placeholder:    "Send a message (/? for help)",
 		AltPlaceholder: `Use """ to end multi-line input`,
 	})
@@ -145,6 +150,11 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 			sb.Reset()
 
 			continue
+		case errors.Is(err, readline.ErrNewLineDetected):
+			sb.WriteString(line)
+			fmt.Fprintln(&sb)
+			scanner.Prompt.Prompt = scannerAltPrompt
+			continue
 		case err != nil:
 			return err
 		}
@@ -169,7 +179,7 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 
 			multiline = MultilineNone
 			scanner.Prompt.UseAlt = false
-		case strings.HasPrefix(line, `"""`):
+		case strings.HasPrefix(line, `"""`) && !scanner.Pasting:
 			line := strings.TrimPrefix(line, `"""`)
 			line, ok := strings.CutSuffix(line, `"""`)
 			sb.WriteString(line)
@@ -433,7 +443,7 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 			sb.WriteString(line)
 		}
 
-		if sb.Len() > 0 && multiline == MultilineNone {
+		if sb.Len() > 0 && strings.TrimSpace(sb.String()) != "" && multiline == MultilineNone {
 			newMessage := api.Message{Role: "user", Content: sb.String()}
 
 			if opts.MultiModal {
@@ -464,6 +474,7 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 			}
 
 			sb.Reset()
+			scanner.Prompt.Prompt = scannerPrompt
 		}
 	}
 }

--- a/readline/errors.go
+++ b/readline/errors.go
@@ -5,6 +5,7 @@ import (
 )
 
 var ErrInterrupt = errors.New("Interrupt")
+var ErrNewLineDetected = errors.New("new line detected")
 
 type InterruptError struct {
 	Line []rune

--- a/readline/readline.go
+++ b/readline/readline.go
@@ -225,6 +225,9 @@ func (i *Instance) Readline() (string, error) {
 			buf.MoveToEnd()
 			fmt.Println()
 
+			if r == CharCtrlJ {
+				return output, ErrNewLineDetected
+			}
 			return output, nil
 		default:
 			if metaDel {


### PR DESCRIPTION
This change allows users to use Ctrl-J to send a newline when typing in the terminal (the equivalent of Ctrl-Enter). It also fixes a glitch in bracketed paste mode if `"""` was part of the paste.