### PR TITLE
runner.go: Support for vision models

### DIFF
--- a/llama/example/main.go
+++ b/llama/example/main.go
@@ -38,21 +38,19 @@ func main() {
 		},
 	}
 	model := llama.LoadModelFromFile(*mpath, params)
-	ctxParams := llama.NewContextParams(2048, 512, 1, runtime.NumCPU(), false)
+	ctxParams := llama.NewContextParams(2048, 1024, 1, runtime.NumCPU(), false)
 
 	// language model context
 	lc := llama.NewContextWithModel(model, ctxParams)
 
 	// eval before
-	batch := llama.NewBatch(512, 0, 1)
+	batch := llama.NewBatch(1024, 0, 1)
 	var nPast int
-
-	// clip context
-	var clipCtx *llama.ClipContext
 
 	// multi-modal
 	if *ppath != "" {
-		clipCtx = llama.NewClipContext(*ppath)
+		// clip context
+		clipCtx := llama.NewClipContext(*ppath)
 
 		// open image file
 		file, err := os.Open(*image)
@@ -66,20 +64,22 @@ func main() {
 			log.Fatal(err)
 		}
 
-		embedding := llama.NewLlavaImageEmbed(clipCtx, data)
+		// generate embeddings for the image
+		embedding := llama.NewLlavaImageEmbed(lc, clipCtx, data)
 
 		parts := strings.Split(*prompt, "<image>")
 		if len(parts) != 2 {
 			panic("prompt must contain exactly one <image>")
 		}
 
+		// process text before the image
 		beforeTokens, err := lc.Model().Tokenize(parts[0], true, true)
 		if err != nil {
 			panic(err)
 		}
 
 		for _, t := range beforeTokens {
-			batch.Add(t, nPast, []int{0}, true)
+			batch.Add(t, nil, nPast, []int{0}, false)
 			nPast++
 		}
 
@@ -87,16 +87,28 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
+		batch.Clear()
 
-		llama.LlavaEvalImageEmbed(lc, embedding, 512, &nPast)
+		// set up a separate batch for image embeddings
+		imageBatch := llama.NewBatch(1024, lc.Model().NEmbd(), 1)
+		for _, e := range embedding {
+			imageBatch.Add(0, e, nPast, []int{0}, false)
+			nPast++
+		}
 
+		err = lc.Decode(imageBatch)
+		if err != nil {
+			panic(err)
+		}
+
+		// process text after the image
 		afterTokens, err := lc.Model().Tokenize(parts[1], true, true)
 		if err != nil {
 			panic(err)
 		}
 
 		for _, t := range afterTokens {
-			batch.Add(t, nPast, []int{0}, true)
+			batch.Add(t, nil, nPast, []int{0}, true)
 			nPast++
 		}
 	} else {
@@ -106,7 +118,7 @@ func main() {
 		}
 
 		for _, t := range tokens {
-			batch.Add(t, nPast, []int{0}, true)
+			batch.Add(t, nil, nPast, []int{0}, true)
 			nPast++
 		}
 	}
@@ -131,6 +143,6 @@ func main() {
 		str := lc.Model().TokenToPiece(token)
 		fmt.Print(str)
 		batch.Clear()
-		batch.Add(token, n, []int{0}, true)
+		batch.Add(token, nil, n, []int{0}, true)
 	}
 }

--- a/llama/llama.go
+++ b/llama/llama.go
@@ -357,8 +357,6 @@ func (m *Model) Tokenize(text string, addSpecial bool, parseSpecial bool) ([]int
 		if result < 0 {
 			return nil, fmt.Errorf("tokenization failed, required %d tokens", -result)
 		}
-	} else if result == 0 {
-		return nil, nil
 	}
 
 	tokens := make([]int, result)

--- a/llama/llama.go
+++ b/llama/llama.go
@@ -464,13 +464,10 @@ func NewSamplingContext(params SamplingParams) *SamplingContext {
 	defer C.free(unsafe.Pointer(grammar))
 
 	cparams.grammar = grammar
-	return &SamplingContext{c: C.llama_sampling_cinit(&cparams)}
-}
+	context := &SamplingContext{c: C.llama_sampling_cinit(&cparams)}
+	runtime.SetFinalizer(context, func(s *SamplingContext) { C.llama_sampling_cfree(s.c) })
 
-func (s *SamplingContext) Free() {
-	if s != nil {
-		C.llama_sampling_cfree(s.c)
-	}
+	return context
 }
 
 func (s *SamplingContext) Reset() {

--- a/llama/runner/cache.go
+++ b/llama/runner/cache.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"hash/maphash"
 	"log/slog"
 	"reflect"
 	"time"
@@ -13,8 +14,12 @@ type InputCache struct {
 	// context window size (per slot)
 	numCtx int
 
-	// individual caches
+	// individual KV caches
 	slots []InputCacheSlot
+
+	// cache of images to embeddings
+	images    []imageCache
+	imageHash maphash.Hash
 
 	lc *llama.Context
 }
@@ -32,6 +37,7 @@ func NewInputCache(lc *llama.Context, kvSize int, numSlots int) *InputCache {
 	return &InputCache{
 		numCtx: kvSize / numSlots,
 		slots:  slots,
+		images: make([]imageCache, numSlots),
 		lc:     lc,
 	}
 }
@@ -159,4 +165,56 @@ func (c *InputCache) ShiftCacheSlot(slot *InputCacheSlot, numKeep int, numDiscar
 		slot.Inputs[i-numDiscard] = slot.Inputs[i]
 	}
 	slot.Inputs = slot.Inputs[:len(slot.Inputs)-numDiscard]
+}
+
+// Locking: Lookup and store operations on imageCache require a lock
+// to be held that serializes these with each other. Hash does not
+// require a lock nor they need to be serialized with InputCacheSlot.
+
+type imageCache struct {
+	key      uint64
+	val      [][]float32
+	lastUsed time.Time
+}
+
+func (c *InputCache) HashImage(image []byte) uint64 {
+	c.imageHash.Reset()
+	_, _ = c.imageHash.Write(image)
+	return c.imageHash.Sum64()
+}
+
+var ErrImageNotFound = errors.New("image not found in cache")
+
+func (c *InputCache) FindImage(hash uint64) ([][]float32, error) {
+	for i := range c.images {
+		if c.images[i].key == hash {
+			slog.Debug("loading image embeddings from cache", "entry", i)
+			c.images[i].lastUsed = time.Now()
+			return c.images[i].val, nil
+		}
+	}
+
+	return nil, ErrImageNotFound
+}
+
+func (c *InputCache) AddImage(hash uint64, embed [][]float32) {
+	best := time.Now()
+	var bestImage int
+
+	for i := range c.images {
+		if c.images[i].key == hash {
+			bestImage = i
+			break
+		}
+
+		if c.images[i].lastUsed.Compare(best) < 0 {
+			best = c.images[i].lastUsed
+			bestImage = i
+		}
+	}
+
+	slog.Debug("storing image embeddings in cache", "entry", bestImage, "used", c.images[bestImage].lastUsed)
+	c.images[bestImage].key = hash
+	c.images[bestImage].val = embed
+	c.images[bestImage].lastUsed = time.Now()
 }

--- a/llama/runner/cache_test.go
+++ b/llama/runner/cache_test.go
@@ -182,8 +182,10 @@ func TestFindCacheSlot(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, resultLen := tt.cache.findCacheSlot(tt.prompt)
-			if result.id != tt.expected || resultLen != tt.expectedLen {
+			result, resultLen, err := tt.cache.findCacheSlot(tt.prompt)
+			if err != nil {
+				t.Errorf("findCacheSlot: err %v", err)
+			} else if result.id != tt.expected || resultLen != tt.expectedLen {
 				t.Errorf("findCacheSlot: slot have %v, want %v len have %v, want %v",
 					result.id, tt.expected, resultLen, tt.expectedLen)
 			}

--- a/llama/runner/cache_test.go
+++ b/llama/runner/cache_test.go
@@ -78,15 +78,15 @@ func TestFindCacheSlot(t *testing.T) {
 			name: "Empty",
 			cache: InputCache{slots: []InputCacheSlot{
 				{
-					id:       0,
-					inputs:   []input{},
-					inUse:    false,
+					Id:       0,
+					Inputs:   []input{},
+					InUse:    false,
 					lastUsed: time.Time{},
 				},
 				{
-					id:       1,
-					inputs:   []input{},
-					inUse:    false,
+					Id:       1,
+					Inputs:   []input{},
+					InUse:    false,
 					lastUsed: time.Time{},
 				},
 			}},
@@ -98,15 +98,15 @@ func TestFindCacheSlot(t *testing.T) {
 			name: "Extend",
 			cache: InputCache{slots: []InputCacheSlot{
 				{
-					id:       0,
-					inputs:   []input{{token: 1}},
-					inUse:    false,
+					Id:       0,
+					Inputs:   []input{{token: 1}},
+					InUse:    false,
 					lastUsed: time.Now().Add(-time.Second),
 				},
 				{
-					id:       1,
-					inputs:   []input{{token: 1}, {token: 2}},
-					inUse:    false,
+					Id:       1,
+					Inputs:   []input{{token: 1}, {token: 2}},
+					InUse:    false,
 					lastUsed: time.Now().Add(-2 * time.Second),
 				},
 			}},
@@ -118,15 +118,15 @@ func TestFindCacheSlot(t *testing.T) {
 			name: "New",
 			cache: InputCache{slots: []InputCacheSlot{
 				{
-					id:       0,
-					inputs:   []input{{token: 1}, {token: 2}},
-					inUse:    false,
+					Id:       0,
+					Inputs:   []input{{token: 1}, {token: 2}},
+					InUse:    false,
 					lastUsed: time.Now().Add(-time.Second),
 				},
 				{
-					id:       1,
-					inputs:   []input{},
-					inUse:    false,
+					Id:       1,
+					Inputs:   []input{},
+					InUse:    false,
 					lastUsed: time.Time{},
 				},
 			}},
@@ -139,15 +139,15 @@ func TestFindCacheSlot(t *testing.T) {
 			cache: InputCache{
 				slots: []InputCacheSlot{
 					{
-						id:       0,
-						inputs:   []input{{token: 1}, {token: 2}},
-						inUse:    false,
+						Id:       0,
+						Inputs:   []input{{token: 1}, {token: 2}},
+						InUse:    false,
 						lastUsed: time.Now().Add(-time.Second),
 					},
 					{
-						id:       1,
-						inputs:   []input{},
-						inUse:    false,
+						Id:       1,
+						Inputs:   []input{},
+						InUse:    false,
 						lastUsed: time.Time{},
 					},
 				},
@@ -160,15 +160,15 @@ func TestFindCacheSlot(t *testing.T) {
 			name: "Evict",
 			cache: InputCache{slots: []InputCacheSlot{
 				{
-					id:       0,
-					inputs:   []input{{token: 1}},
-					inUse:    false,
+					Id:       0,
+					Inputs:   []input{{token: 1}},
+					InUse:    false,
 					lastUsed: time.Now().Add(-time.Second),
 				},
 				{
-					id:       1,
-					inputs:   []input{{token: 1}, {token: 2}},
-					inUse:    false,
+					Id:       1,
+					Inputs:   []input{{token: 1}, {token: 2}},
+					InUse:    false,
 					lastUsed: time.Now().Add(-2 * time.Second),
 				},
 			}},
@@ -180,15 +180,15 @@ func TestFindCacheSlot(t *testing.T) {
 			name: "In use",
 			cache: InputCache{slots: []InputCacheSlot{
 				{
-					id:       0,
-					inputs:   []input{{token: 1}},
-					inUse:    false,
+					Id:       0,
+					Inputs:   []input{{token: 1}},
+					InUse:    false,
 					lastUsed: time.Now().Add(-time.Second),
 				},
 				{
-					id:       1,
-					inputs:   []input{{token: 1}, {token: 2}},
-					inUse:    true,
+					Id:       1,
+					Inputs:   []input{{token: 1}, {token: 2}},
+					InUse:    true,
 					lastUsed: time.Now().Add(-2 * time.Second),
 				},
 			}},
@@ -203,9 +203,9 @@ func TestFindCacheSlot(t *testing.T) {
 			result, resultLen, err := tt.cache.findCacheSlot(tt.prompt)
 			if err != nil {
 				t.Errorf("findCacheSlot: err %v", err)
-			} else if result.id != tt.expected || resultLen != tt.expectedLen {
+			} else if result.Id != tt.expected || resultLen != tt.expectedLen {
 				t.Errorf("findCacheSlot: slot have %v, want %v len have %v, want %v",
-					result.id, tt.expected, resultLen, tt.expectedLen)
+					result.Id, tt.expected, resultLen, tt.expectedLen)
 			}
 		})
 	}

--- a/llama/runner/cache_test.go
+++ b/llama/runner/cache_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"reflect"
 	"testing"
 	"time"
 )
@@ -208,5 +209,79 @@ func TestFindCacheSlot(t *testing.T) {
 					result.Id, tt.expected, resultLen, tt.expectedLen)
 			}
 		})
+	}
+}
+
+func TestImageCache(t *testing.T) {
+	cache := NewInputCache(nil, 2048, 4)
+
+	valA := [][]float32{{0.1, 0.2}, {0.3}}
+	valB := [][]float32{{0.4}, {0.5}, {0.6}}
+	valC := [][]float32{{0.7}}
+	valD := [][]float32{{0.8}}
+	valE := [][]float32{{0.9}}
+
+	// Empty cache
+	result, err := cache.FindImage(0x5adb61d31933a946)
+	if err != ErrImageNotFound {
+		t.Errorf("found result in empty cache: result %v, err %v", result, err)
+	}
+
+	// Insert A
+	cache.AddImage(0x5adb61d31933a946, valA)
+
+	result, err = cache.FindImage(0x5adb61d31933a946)
+	if !reflect.DeepEqual(result, valA) {
+		t.Errorf("failed to find expected value: result %v, err %v", result, err)
+	}
+
+	// Insert B
+	cache.AddImage(0x011551369a34a901, valB)
+
+	result, err = cache.FindImage(0x5adb61d31933a946)
+	if !reflect.DeepEqual(result, valA) {
+		t.Errorf("failed to find expected value: result %v, err %v", result, err)
+	}
+	result, err = cache.FindImage(0x011551369a34a901)
+	if !reflect.DeepEqual(result, valB) {
+		t.Errorf("failed to find expected value: result %v, err %v", result, err)
+	}
+
+	// Replace B with C
+	cache.AddImage(0x011551369a34a901, valC)
+
+	result, err = cache.FindImage(0x5adb61d31933a946)
+	if !reflect.DeepEqual(result, valA) {
+		t.Errorf("failed to find expected value: result %v, err %v", result, err)
+	}
+	result, err = cache.FindImage(0x011551369a34a901)
+	if !reflect.DeepEqual(result, valC) {
+		t.Errorf("failed to find expected value: result %v, err %v", result, err)
+	}
+
+	// Evict A
+	cache.AddImage(0x756b218a517e7353, valB)
+	cache.AddImage(0x75e5e8d35d7e3967, valD)
+	cache.AddImage(0xd96f7f268ca0646e, valE)
+
+	result, err = cache.FindImage(0x5adb61d31933a946)
+	if reflect.DeepEqual(result, valA) {
+		t.Errorf("failed to find expected value: result %v, err %v", result, err)
+	}
+	result, err = cache.FindImage(0x756b218a517e7353)
+	if !reflect.DeepEqual(result, valB) {
+		t.Errorf("failed to find expected value: result %v, err %v", result, err)
+	}
+	result, err = cache.FindImage(0x011551369a34a901)
+	if !reflect.DeepEqual(result, valC) {
+		t.Errorf("failed to find expected value: result %v, err %v", result, err)
+	}
+	result, err = cache.FindImage(0x75e5e8d35d7e3967)
+	if !reflect.DeepEqual(result, valD) {
+		t.Errorf("failed to find expected value: result %v, err %v", result, err)
+	}
+	result, err = cache.FindImage(0xd96f7f268ca0646e)
+	if !reflect.DeepEqual(result, valE) {
+		t.Errorf("failed to find expected value: result %v, err %v", result, err)
 	}
 }

--- a/llama/runner/runner.go
+++ b/llama/runner/runner.go
@@ -187,6 +187,7 @@ func (s *Server) shiftContext(seq *Sequence) {
 	seq.numPast -= numDiscard
 }
 
+// TODO(jessegross): Move this to stop.go and add unit tests
 func incompleteUnicode(token string) bool {
 	incomplete := false
 
@@ -254,6 +255,13 @@ func (s *Server) run(ctx context.Context) {
 	}
 }
 
+// TODO (jmorganca): processBatch should be simplified, removing:
+// * sampling
+// * stop token checking
+// * metrics
+// these should instead be handled by the handlers
+// it should only be responsible for accepting tokens or embeddings and
+// processing batches as fast as possible
 func (s *Server) processBatch() {
 	batch := llama.NewBatch(s.batchSize*len(s.seqs), 0, len(s.seqs))
 	defer batch.Free()
@@ -388,6 +396,9 @@ func (s *Server) processBatch() {
 	}
 }
 
+// TODO (jmorganca): use structs from the api package to avoid duplication
+// this way the api acts as a proxy instead of using a different api for the
+// runner
 type Options struct {
 	api.Runner
 

--- a/llama/runner/runner.go
+++ b/llama/runner/runner.go
@@ -267,37 +267,6 @@ func (s *Server) shiftContext(seq *Sequence) {
 	seq.numPast -= numDiscard
 }
 
-// TODO(jessegross): Move this to stop.go and add unit tests
-func incompleteUnicode(token string) bool {
-	incomplete := false
-
-	// check if there is incomplete UTF-8 character at the end
-	for i := 1; i < 5 && i <= len(token); i++ {
-		c := token[len(token)-i]
-
-		if (c & 0xc0) == 0x80 {
-			// continuation byte: 10xxxxxx
-			continue
-		}
-
-		if (c & 0xe0) == 0xc0 {
-			// 2-byte character: 110xxxxx ...
-			incomplete = i < 2
-		} else if (c & 0xf0) == 0xe0 {
-			// 3-byte character: 1110xxxx ...
-			incomplete = i < 3
-		} else if (c & 0xf8) == 0xf0 {
-			// 4-byte character: 11110xxx ...
-			incomplete = i < 4
-		}
-
-		// else 1-byte character or invalid byte
-		break
-	}
-
-	return incomplete
-}
-
 func flushPending(seq *Sequence) bool {
 	for _, p := range seq.pendingResponses {
 		select {

--- a/llama/runner/runner.go
+++ b/llama/runner/runner.go
@@ -364,7 +364,12 @@ func (s *Server) processBatch() {
 		if ok, stop := findStop(sequence, seq.stop); ok {
 			slog.Info("hit stop token", "stop", seq.stop)
 
+			trimCacheLen := len(seq.pendingResponses) - 1
 			seq.pendingResponses = truncateStop(seq.pendingResponses, stop)
+			trimCacheLen -= len(seq.pendingResponses)
+
+			// remove any tokens from the cache that we don't actually return
+			seq.cache.tokens = seq.cache.tokens[:len(seq.cache.tokens)-trimCacheLen]
 			s.removeSequence(i, "stop")
 			continue
 		}

--- a/llama/runner/runner.go
+++ b/llama/runner/runner.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -82,12 +83,14 @@ type NewSequenceParams struct {
 	embedding      bool
 }
 
-func (s *Server) NewSequence(prompt string, params NewSequenceParams) *Sequence {
+func (s *Server) NewSequence(prompt string, params NewSequenceParams) (*Sequence, error) {
 	s.ready.Wait()
 
 	tokens, err := s.lc.Model().Tokenize(prompt, true, true)
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("failed to process input: %w", err)
+	} else if tokens == nil {
+		return nil, errors.New("no input provided")
 	}
 
 	if params.numKeep < 0 {
@@ -131,7 +134,7 @@ func (s *Server) NewSequence(prompt string, params NewSequenceParams) *Sequence 
 		embeddingOnly:    params.embedding,
 		stop:             params.stop,
 		numKeep:          params.numKeep,
-	}
+	}, nil
 }
 
 type Server struct {
@@ -240,7 +243,6 @@ func (s *Server) removeSequence(seqIndex int, reason string) {
 	close(seq.responses)
 	close(seq.embedding)
 	seq.cache.inUse = false
-	seq.samplingCtx.Free()
 	s.seqs[seqIndex] = nil
 }
 
@@ -315,7 +317,7 @@ func (s *Server) processBatch() {
 	err := s.lc.Decode(batch)
 	if err != nil {
 		slog.Error("failed to decode batch", "error", err)
-		panic("Failed to decode")
+		return
 	}
 
 	for i, seq := range s.seqs {
@@ -463,7 +465,12 @@ func (s *Server) completion(w http.ResponseWriter, r *http.Request) {
 	// Set the headers to indicate streaming
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Transfer-Encoding", "chunked")
-	w.WriteHeader(http.StatusOK)
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "Streaming not supported", http.StatusInternalServerError)
+		return
+	}
 
 	var samplingParams llama.SamplingParams
 	samplingParams.TopK = req.TopK
@@ -483,20 +490,29 @@ func (s *Server) completion(w http.ResponseWriter, r *http.Request) {
 	samplingParams.Seed = uint32(req.Seed)
 	samplingParams.Grammar = req.Grammar
 
-	seq := s.NewSequence(req.Prompt, NewSequenceParams{
+	seq, err := s.NewSequence(req.Prompt, NewSequenceParams{
 		numPredict:     req.NumPredict,
 		stop:           req.Stop,
 		numKeep:        req.NumKeep,
 		samplingParams: &samplingParams,
 		embedding:      false,
 	})
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to create new sequence: %v", err), http.StatusInternalServerError)
+		return
+	}
 
 	// TODO (jmorganca): add to sequence queue instead of
 	// failing if a slot isn't available
 	s.mu.Lock()
 	for i, sq := range s.seqs {
 		if sq == nil {
-			seq.cache, seq.tokens, seq.numPast = s.cache.LoadCacheSlot(seq.tokens)
+			seq.cache, seq.tokens, seq.numPast, err = s.cache.LoadCacheSlot(seq.tokens)
+			if err != nil {
+				s.mu.Unlock()
+				http.Error(w, fmt.Sprintf("Failed to load cache: %v", err), http.StatusInternalServerError)
+				return
+			}
 			s.seqs[i] = seq
 			s.cond.Signal()
 			break
@@ -504,48 +520,41 @@ func (s *Server) completion(w http.ResponseWriter, r *http.Request) {
 	}
 	s.mu.Unlock()
 
-	// stream the response
-	for content := range seq.responses {
-		if err := json.NewEncoder(w).Encode(&CompletionResponse{
-			Content: content,
-		}); err != nil {
-			log.Println("Failed to encode result:", err)
+	for {
+		select {
+		case <-r.Context().Done():
 			close(seq.quit)
 			return
+		case content, ok := <-seq.responses:
+			if ok {
+				if err := json.NewEncoder(w).Encode(&CompletionResponse{
+					Content: content,
+				}); err != nil {
+					http.Error(w, fmt.Sprintf("failed to encode response: %v", err), http.StatusInternalServerError)
+					close(seq.quit)
+					return
+				}
+
+				flusher.Flush()
+			} else {
+				// Send the final response
+				if err := json.NewEncoder(w).Encode(&CompletionResponse{
+					Stop:         true,
+					StoppedLimit: seq.doneReason == "limit",
+					Timings: Timings{
+						PromptN:     seq.numPromptTokens,
+						PromptMS:    float64(seq.startGenerationTime.Sub(seq.startProcessingTime).Milliseconds()),
+						PredictedN:  seq.numDecoded,
+						PredictedMS: float64(time.Since(seq.startGenerationTime).Milliseconds()),
+					},
+				}); err != nil {
+					http.Error(w, fmt.Sprintf("failed to encode final response: %v", err), http.StatusInternalServerError)
+				}
+
+				return
+			}
 		}
-
-		flusher, ok := w.(http.Flusher)
-		if !ok {
-			http.Error(w, "Streaming not supported", http.StatusInternalServerError)
-			close(seq.quit)
-			return
-		}
-
-		flusher.Flush()
 	}
-
-	// Send the stop
-	if err := json.NewEncoder(w).Encode(&CompletionResponse{
-		Stop:         true,
-		StoppedLimit: seq.doneReason == "limit",
-		Timings: Timings{
-			PromptN:     seq.numPromptTokens,
-			PromptMS:    float64(seq.startGenerationTime.Sub(seq.startProcessingTime).Milliseconds()),
-			PredictedN:  seq.numDecoded,
-			PredictedMS: float64(time.Since(seq.startGenerationTime).Milliseconds()),
-		},
-	}); err != nil {
-		log.Println("Failed to encode result:", err)
-		return
-	}
-
-	flusher, ok := w.(http.Flusher)
-	if !ok {
-		http.Error(w, "Streaming not supported", http.StatusInternalServerError)
-		return
-	}
-
-	flusher.Flush()
 }
 
 type EmbeddingRequest struct {
@@ -559,7 +568,7 @@ type EmbeddingResponse struct {
 func (s *Server) embeddings(w http.ResponseWriter, r *http.Request) {
 	var req EmbeddingRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "Bad request", http.StatusBadRequest)
+		http.Error(w, fmt.Sprintf("bad request: %s", err), http.StatusBadRequest)
 		return
 	}
 
@@ -567,13 +576,22 @@ func (s *Server) embeddings(w http.ResponseWriter, r *http.Request) {
 
 	slog.Debug("embedding request", "content", req.Content)
 
-	seq := s.NewSequence(req.Content, NewSequenceParams{embedding: true})
+	seq, err := s.NewSequence(req.Content, NewSequenceParams{embedding: true})
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to create new sequence: %v", err), http.StatusInternalServerError)
+		return
+	}
 
 	// TODO (jessegross): Wait for a free slot instead of failing and blocking forever
 	s.mu.Lock()
 	for i, sq := range s.seqs {
 		if sq == nil {
-			seq.cache, seq.tokens, seq.numPast = s.cache.LoadCacheSlot(seq.tokens)
+			seq.cache, seq.tokens, seq.numPast, err = s.cache.LoadCacheSlot(seq.tokens)
+			if err != nil {
+				s.mu.Unlock()
+				http.Error(w, fmt.Sprintf("Failed to load cache: %v", err), http.StatusInternalServerError)
+				return
+			}
 			s.seqs[i] = seq
 			s.cond.Signal()
 			break
@@ -586,8 +604,7 @@ func (s *Server) embeddings(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewEncoder(w).Encode(&EmbeddingResponse{
 		Embedding: embedding,
 	}); err != nil {
-		log.Println("Failed to encode result:", err)
-		return
+		http.Error(w, fmt.Sprintf("failed to encode response: %v", err), http.StatusInternalServerError)
 	}
 }
 
@@ -621,8 +638,7 @@ func (s *Server) health(w http.ResponseWriter, r *http.Request) {
 		Status:   s.status.ToString(),
 		Progress: s.progress,
 	}); err != nil {
-		log.Println("Failed to encode result:", err)
-		return
+		http.Error(w, fmt.Sprintf("failed to encode response: %v", err), http.StatusInternalServerError)
 	}
 }
 

--- a/llama/runner/runner.go
+++ b/llama/runner/runner.go
@@ -625,7 +625,7 @@ func (s *Server) loadModel(
 
 	s.model = llama.LoadModelFromFile(mpath, params)
 
-	ctxParams := llama.NewContextParams(kvSize, s.batchSize, s.parallel, threads, flashAttention)
+	ctxParams := llama.NewContextParams(kvSize, s.batchSize*s.parallel, s.parallel, threads, flashAttention)
 	s.lc = llama.NewContextWithModel(s.model, ctxParams)
 
 	if lpath != "" {

--- a/llama/runner/runner.go
+++ b/llama/runner/runner.go
@@ -288,7 +288,7 @@ func (s *Server) removeSequence(seqIndex int, reason string) {
 	seq.doneReason = reason
 	close(seq.responses)
 	close(seq.embedding)
-	seq.cache.inUse = false
+	seq.cache.InUse = false
 	s.seqs[seqIndex] = nil
 }
 
@@ -364,13 +364,13 @@ func (s *Server) processBatch() {
 				break
 			}
 
-			batch.Add(input.token, input.embed, seq.numPast, []int{seq.cache.id}, numInputsProcessed+1 == len(seq.inputs))
+			batch.Add(input.token, input.embed, seq.numPast, []int{seq.cache.Id}, numInputsProcessed+1 == len(seq.inputs))
 			seq.numPast++
 			numInputsProcessed++
 		}
 
 		if numInputsProcessed > 0 {
-			seq.cache.inputs = append(seq.cache.inputs, seq.inputs[:numInputsProcessed]...)
+			seq.cache.Inputs = append(seq.cache.Inputs, seq.inputs[:numInputsProcessed]...)
 			seq.inputs = seq.inputs[numInputsProcessed:]
 			seq.iBatch = batch.NumTokens() - 1
 		}
@@ -445,7 +445,7 @@ func (s *Server) processBatch() {
 			trimCacheLen -= len(seq.pendingResponses)
 
 			// remove any tokens from the cache that we don't actually return
-			seq.cache.inputs = seq.cache.inputs[:len(seq.cache.inputs)-trimCacheLen]
+			seq.cache.Inputs = seq.cache.Inputs[:len(seq.cache.Inputs)-trimCacheLen]
 			s.removeSequence(i, "stop")
 			continue
 		}

--- a/llama/runner/stop.go
+++ b/llama/runner/stop.go
@@ -62,3 +62,33 @@ func truncateStop(pieces []string, stop string) []string {
 
 	return result
 }
+
+func incompleteUnicode(token string) bool {
+	incomplete := false
+
+	// check if there is incomplete UTF-8 character at the end
+	for i := 1; i < 5 && i <= len(token); i++ {
+		c := token[len(token)-i]
+
+		if (c & 0xc0) == 0x80 {
+			// continuation byte: 10xxxxxx
+			continue
+		}
+
+		if (c & 0xe0) == 0xc0 {
+			// 2-byte character: 110xxxxx ...
+			incomplete = i < 2
+		} else if (c & 0xf0) == 0xe0 {
+			// 3-byte character: 1110xxxx ...
+			incomplete = i < 3
+		} else if (c & 0xf8) == 0xf0 {
+			// 4-byte character: 11110xxx ...
+			incomplete = i < 4
+		}
+
+		// else 1-byte character or invalid byte
+		break
+	}
+
+	return incomplete
+}

--- a/llama/runner/stop_test.go
+++ b/llama/runner/stop_test.go
@@ -47,3 +47,71 @@ func TestTruncateStop(t *testing.T) {
 		})
 	}
 }
+
+func TestIncompleteUnicode(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{
+			name:     "Basic",
+			input:    "hi",
+			expected: false,
+		},
+		{
+			name:     "Two byte",
+			input:    "hi" + string([]byte{0xc2, 0xa3}),
+			expected: false,
+		},
+		{
+			name:     "Two byte - missing last",
+			input:    "hi" + string([]byte{0xc2}),
+			expected: true,
+		},
+		{
+			name:     "Three byte",
+			input:    "hi" + string([]byte{0xe0, 0xA0, 0x80}),
+			expected: false,
+		},
+		{
+			name:     "Three byte - missing last",
+			input:    "hi" + string([]byte{0xe0, 0xA0}),
+			expected: true,
+		},
+		{
+			name:     "Three byte - missing last 2",
+			input:    "hi" + string([]byte{0xe0}),
+			expected: true,
+		},
+		{
+			name:     "Four byte",
+			input:    "hi" + string([]byte{0xf0, 0x92, 0x8a, 0xb7}),
+			expected: false,
+		},
+		{
+			name:     "Four byte - missing last",
+			input:    "hi" + string([]byte{0xf0, 0x92, 0x8a}),
+			expected: true,
+		},
+		{
+			name:     "Four byte - missing last 2",
+			input:    "hi" + string([]byte{0xf0, 0x92}),
+			expected: true,
+		},
+		{
+			name:     "Four byte - missing last 3",
+			input:    "hi" + string([]byte{0xf0}),
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := incompleteUnicode(tt.input)
+			if result != tt.expected {
+				t.Errorf("incompleteUnicode(%s): have %v; want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
In addition to bringing feature parity with the C++ runner, this also incorporates several improvements:
 - Cache prompting works with images, avoiding the need to re-decode embeddings for every message in a conversation
 - Parallelism is supported, avoiding the need to restrict to one sequence at a time. (Though for now Ollama will not schedule them while we might need to fall back to the old runner.)

Co-authored-by: jmorganca <jmorganca@gmail.com>