### PR TITLE
CI: win arm artifact dist dir

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -470,6 +470,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: windows-arm64
+          path: dist
       - run: dir build
       - run: |
           $gopath=(get-command go).source | split-path -parent


### PR DESCRIPTION
The upload artifact is missing the dist prefix since all payloads are in the same directory, so restore the prefix on download.