### PR TITLE
OpenAI: accept additional headers to fix CORS error

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -1097,7 +1097,7 @@ func (s *Server) GenerateRoutes() http.Handler {
 	config.AllowWildcard = true
 	config.AllowBrowserExtensions = true
 	config.AllowHeaders = []string{"Authorization", "Content-Type", "User-Agent", "Accept", "X-Requested-With"}
-	openAIProperties := []string{"lang", "package-version", "os", "arch", "runtime", "runtime-version", "async"}
+	openAIProperties := []string{"lang", "package-version", "os", "arch", "retry-count", "runtime", "runtime-version", "async"}
 	for _, prop := range openAIProperties {
 		config.AllowHeaders = append(config.AllowHeaders, "x-stainless-"+prop)
 	}


### PR DESCRIPTION
Related to #4879 #4388

A few days ago, they introduced additional request header `X-Stainless-Retry-Count` in OpenAI JavaScript library in v4.63.0 and CORS problem is back again.
https://github.com/openai/openai-node/pull/1087
https://github.com/openai/openai-node/blob/master/CHANGELOG.md#4630-2024-09-20

So we need to add it to `Access-Control-Allow-Headers`.