### PR TITLE
CI: Fix win arm version defect

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -354,7 +354,7 @@ jobs:
       - name: Set Version
         run: |
           $ver=${env:GITHUB_REF_NAME}.trim("v")
-          write-host VERSION=$ver | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
+          echo VERSION=$ver | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
       - uses: 'google-github-actions/auth@v2'
         with:
           project_id: 'ollama'


### PR DESCRIPTION
Build 0.3.12-rc5 reports a pre-release string on win-arm due to the version not being set properly in CI.

write-host in powershell writes directly to the console and will not be picked
up by a pipe.  Echo, or write-output will.
