### PR TITLE
Fix Ollama silently failing on extra, unsupported openai parameters.

### DIFF
--- a/openai/openai_test.go
+++ b/openai/openai_test.go
@@ -211,6 +211,102 @@ func TestChatMiddleware(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "chat handler with unsupported parameter",
+			body: `{
+				"model": "test-model",
+				"messages": [
+					{"role": "user", "content": "Hello"}
+				],
+				"n": 2
+			}`,
+			err: ErrorResponse{
+				Error: Error{
+					Message: "Unsupported parameter: \"n\"",
+					Type:    "invalid_request_error",
+				},
+			},
+		},
+		{
+			name: "chat handler with multiple unsupported parameters",
+			body: `{
+				"model": "test-model",
+				"messages": [
+					{"role": "user", "content": "Hello"}
+				],
+				"n": 2,
+				"best_of": 3
+			}`,
+			err: ErrorResponse{
+				Error: Error{
+					Message: "Unsupported parameter: \"n\"",
+					Type:    "invalid_request_error",
+				},
+			},
+		},
+		{
+			name: "chat handler with unsupported nested parameter",
+			body: `{
+				"model": "test-model",
+				"messages": [
+					{"role": "user", "content": "Hello"}
+				],
+				"options": {
+					"unsupported_option": true
+				}
+			}`,
+			err: ErrorResponse{
+				Error: Error{
+					Message: "Unsupported parameter: \"options\"",
+					Type:    "invalid_request_error",
+				},
+			},
+		},
+		{
+			name: "chat handler with empty messages array",
+			body: `{
+				"model": "test-model",
+				"messages": []
+			}`,
+			err: ErrorResponse{
+				Error: Error{
+					Message: "[] is too short - 'messages'",
+					Type:    "invalid_request_error",
+				},
+			},
+		},
+		{
+			name: "chat handler with invalid JSON",
+			body: `{
+				"model": "test-model",
+				"messages": [
+					{"role": "user", "content": "Hello"}
+				],
+				"temperature": 0.7,
+			}`,
+			err: ErrorResponse{
+				Error: Error{
+					Message: "Invalid JSON syntax",
+					Type:    "invalid_request_error",
+				},
+			},
+		},
+		{
+			name: "chat handler with invalid type for known field",
+			body: `{
+				"model": "test-model",
+				"messages": [
+					{"role": "user", "content": "Hello"}
+				],
+				"temperature": "not a number"
+			}`,
+			err: ErrorResponse{
+				Error: Error{
+					Message: "Invalid type for field temperature. Expected float64, got string",
+					Type:    "invalid_request_error",
+				},
+			},
+		},
 	}
 
 	endpoint := func(c *gin.Context) {
@@ -235,15 +331,15 @@ func TestChatMiddleware(t *testing.T) {
 			var errResp ErrorResponse
 			if resp.Code != http.StatusOK {
 				if err := json.Unmarshal(resp.Body.Bytes(), &errResp); err != nil {
-					t.Fatal(err)
+					t.Fatalf("Failed to unmarshal error response: %v", err)
 				}
 			}
 			if capturedRequest != nil && !reflect.DeepEqual(tc.req, *capturedRequest) {
-				t.Fatal("requests did not match")
+				t.Fatalf("Requests did not match.\nExpected: %+v\nGot: %+v", tc.req, *capturedRequest)
 			}
 
 			if !reflect.DeepEqual(tc.err, errResp) {
-				t.Fatal("errors did not match")
+				t.Fatalf("Errors did not match.\nExpected: %+v\nGot: %+v\nResponse body: %s", tc.err, errResp, resp.Body.String())
 			}
 		})
 	}


### PR DESCRIPTION
Currently Ollama will just let you send unsupported api params to the openai compatible endpoint and just silently fail. This wreaks havoc on downstream uses causing unexpected behaviour. 

```python
# Retrieve the API key and ensure it's set
ollama_api_key = os.getenv("OLLAMA_API_KEY")
if not ollama_api_key:
    raise ValueError("API key not found. Please ensure that the OLLAMA_API_KEY is set in your .env.local file.")

# Initialize the OpenAI client
ollama_client = OpenAI(
    base_url="http://localhost:11434/v1",
    api_key=ollama_api_key,
)
model = "llama3.1:latest"


# Construct the completion request with n=2
response = openai.Completion.create(
    model=model,
    prompt="Once upon a time",
    max_tokens=50,
    n=2,  # Requesting two completions
    temperature=0.7
)

print(f"Number of completions requested: 2")
print(f"Number of completions received: {len(response.choices)}\n")
assert len(response.choices) == 2, "Shouldn't ever get here"

# Iterate and print each completion
for idx, choice in enumerate(response.choices, 1):
    print(f"Completion {idx}: {choice.text.strip()}")
 ```
This leads to
```
umber of completions requested: 2
Number of completions received: 1

Completion 1: Once upon a time, in a land where the sun always shone brightly, there lived a young adventurer eager to explore uncharted territories and uncover hidden treasures.
```

My change would cause the API to error because that parameter is just plainly not supported by ollama
 