### PR TITLE
fix(generate): disable gpg signing when applying git patches

### DIFF
--- a/llm/generate/gen_common.sh
+++ b/llm/generate/gen_common.sh
@@ -71,7 +71,7 @@ git_module_setup() {
 apply_patches() {
     # apply temporary patches until fix is upstream
     for patch in ../patches/*.patch; do
-        git -c 'user.name=nobody' -c 'user.email=<>' -C ${LLAMACPP_DIR} am ${patch}
+        git -c 'user.name=nobody' -c 'user.email=<>' -c 'commit.gpgsign=false' -C ${LLAMACPP_DIR} am ${patch}
     done
 }
 

--- a/llm/generate/gen_windows.ps1
+++ b/llm/generate/gen_windows.ps1
@@ -98,7 +98,7 @@ function git_module_setup {
 function apply_patches {
     # Apply temporary patches until fix is upstream
     foreach ($patch in $(Get-ChildItem "../patches/*.patch")) {
-        git -c 'user.name=nobody' -c 'user.email=<>' -C "${script:llamacppDir}" am $patch.FullName
+        git -c 'user.name=nobody' -c 'user.email=<>' -c 'commit.gpgsign=false' -C "${script:llamacppDir}" am $patch.FullName
     }
 }
 


### PR DESCRIPTION
Signing the patch commits is unnecessary. When building `ollama-*-git` AUR packages, if the user has a GPG signing key configured in their global git config, they will be prompted to unlock their GPG during configure. This is unexpected and will cause the build to fail if they decline to unlock their key.