### PR TITLE
Add support for CC v5 and v6+ multi-gpu cuda setups

### DIFF
--- a/discover/gpu_test.go
+++ b/discover/gpu_test.go
@@ -2,6 +2,7 @@ package discover
 
 import (
 	"runtime"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -44,7 +45,7 @@ func TestByLibrary(t *testing.T) {
 		"cpu + GPU":                {input: []GpuInfo{{Library: "cpu"}, {Library: "cuda"}}, expect: 2},
 		"cpu + 2 GPU no variant":   {input: []GpuInfo{{Library: "cpu"}, {Library: "cuda"}, {Library: "cuda"}}, expect: 2},
 		"cpu + 2 GPU same variant": {input: []GpuInfo{{Library: "cpu"}, {Library: "cuda", Variant: "v11"}, {Library: "cuda", Variant: "v11"}}, expect: 2},
-		"cpu + 2 GPU diff variant": {input: []GpuInfo{{Library: "cpu"}, {Library: "cuda", Variant: "v11"}, {Library: "cuda", Variant: "v12"}}, expect: 3},
+		"cpu + 2 GPU diff variant": {input: []GpuInfo{{Library: "cpu"}, {Library: "cuda", Variant: "v11"}, {Library: "cuda", Variant: "v12"}}, expect: 2},
 	}
 
 	for k, v := range testCases {
@@ -52,6 +53,60 @@ func TestByLibrary(t *testing.T) {
 			resp := (GpuInfoList)(v.input).ByLibrary()
 			if len(resp) != v.expect {
 				t.Fatalf("expected length %d, got %d => %+v", v.expect, len(resp), resp)
+			}
+		})
+	}
+}
+
+func TestByVariant(t *testing.T) {
+	type testCase struct {
+		input  []GpuInfo
+		expect []GpuInfo
+	}
+
+	testCases := map[string]*testCase{
+		"empty":                {input: []GpuInfo{}, expect: []GpuInfo{}},
+		"one item, no variant": {input: []GpuInfo{{Library: "cpu"}}, expect: []GpuInfo{{Library: "cpu"}}},
+		"both v11":             {input: []GpuInfo{{Library: "cuda", Variant: "v11"}, {Library: "cuda", Variant: "v11"}}, expect: []GpuInfo{{Library: "cuda", Variant: "v11"}, {Library: "cuda", Variant: "v11"}}},
+		"v11, v12":             {input: []GpuInfo{{Library: "cuda", Variant: "v11"}, {Library: "cuda", Variant: "v12"}}, expect: []GpuInfo{{Library: "cuda", Variant: "v11"}, {Library: "cuda", Variant: "v12"}}},
+		"v12, v11":             {input: []GpuInfo{{Library: "cuda", Variant: "v12"}, {Library: "cuda", Variant: "v11"}}, expect: []GpuInfo{{Library: "cuda", Variant: "v11"}, {Library: "cuda", Variant: "v12"}}},
+	}
+
+	for k, v := range testCases {
+		t.Run(k, func(t *testing.T) {
+			resp := append(make([]GpuInfo, 0, len(v.input)), v.input...)
+			sort.Sort(ByVariant(resp))
+			if len(resp) != len(v.expect) {
+				t.Fatalf("expected length %d, got %d => %+v", len(v.expect), len(resp), resp)
+			}
+			for i := range resp {
+				if resp[i].Variant != v.expect[i].Variant || resp[i].Library != v.expect[i].Library {
+					t.Fatalf("expected index %d, got %v wanted %+v", i, resp[i], v.expect[i])
+				}
+			}
+		})
+	}
+}
+
+func TestBestRunnerName(t *testing.T) {
+	type testCase struct {
+		input  GpuInfoList
+		expect string
+	}
+
+	testCases := map[string]*testCase{
+		"empty":                {input: []GpuInfo{}, expect: ""},
+		"one item, no variant": {input: []GpuInfo{{Library: "cpu"}}, expect: "cpu"},
+		"both v11":             {input: []GpuInfo{{Library: "cuda", Variant: "v11"}, {Library: "cuda", Variant: "v11"}}, expect: "cuda_v11"},
+		"v11, v12":             {input: []GpuInfo{{Library: "cuda", Variant: "v11"}, {Library: "cuda", Variant: "v12"}}, expect: "cuda_v11"},
+		"v12, v11":             {input: []GpuInfo{{Library: "cuda", Variant: "v12"}, {Library: "cuda", Variant: "v11"}}, expect: "cuda_v11"},
+	}
+
+	for k, v := range testCases {
+		t.Run(k, func(t *testing.T) {
+			resp := v.input.BestRunnerName()
+			if resp != v.expect {
+				t.Fatalf("got %v wanted %+v", resp, v.expect)
 			}
 		})
 	}

--- a/llm/server.go
+++ b/llm/server.go
@@ -149,7 +149,7 @@ func NewLlamaServer(gpus discover.GpuInfoList, model string, ggml *GGML, adapter
 	if cpuRunner != "" {
 		servers = []string{cpuRunner}
 	} else {
-		servers = runners.ServersForGpu(gpus[0].RunnerName()) // All GPUs in the list are matching Library and Variant
+		servers = runners.ServersForGpu(gpus.BestRunnerName()) // All GPUs in the list are matching Library
 	}
 	demandLib := envconfig.LLMLibrary()
 	if demandLib != "" {


### PR DESCRIPTION
With the new addition of cuda v12 and selecting the newer version for GPUs that support it, users with a mix of v11 only and v12 supporting GPUs weren't able to load models spanning the GPU.  This refines the algorithm to use the oldest variant (v11 in this case) so that all the GPUs will be supported.  This will break down if a user has a CC 5.x card and a CC 9.x card, as we don't currently have plumbing in place to understand the maximum version support. 

Fixes #6930 
Fixes #8066 