### PR TITLE
llama: Fix directory for conditional flash attention patch

### DIFF
--- a/llama/patches/10-conditional-fattn.diff
+++ b/llama/patches/10-conditional-fattn.diff
@@ -1,8 +1,8 @@
-diff --git a/llama/ggml-cuda.cu b/llama/ggml-cuda.cu
-index 8b310ae4..9a9e2c3f 100644
---- a/llama/ggml-cuda.cu
-+++ b/llama/ggml-cuda.cu
-@@ -2330,9 +2330,11 @@ static bool ggml_cuda_compute_forward(ggml_backend_cuda_context & ctx, struct gg
+diff --git a/ggml/src/ggml-cuda.cu b/ggml/src/ggml-cuda.cu
+index 8a844b02..61d61542 100644
+--- a/ggml/src/ggml-cuda.cu
++++ b/ggml/src/ggml-cuda.cu
+@@ -2310,9 +2310,11 @@ static bool ggml_cuda_compute_forward(ggml_backend_cuda_context & ctx, struct gg
          case GGML_OP_ARGSORT:
              ggml_cuda_op_argsort(ctx, dst);
              break;
@@ -11,6 +11,6 @@ index 8b310ae4..9a9e2c3f 100644
              ggml_cuda_flash_attn_ext(ctx, dst);
              break;
 +#endif
-         default:
-             return false;
-     }
+         case GGML_OP_CROSS_ENTROPY_LOSS:
+             ggml_cuda_cross_entropy_loss(ctx, dst);
+             break;


### PR DESCRIPTION
Patches are against the llama.cpp directory structure, otherwise sync.sh can't apply them.