### PR TITLE
server: add "Cache-Control: max-age=0" response header

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -1092,6 +1092,13 @@ func allowedHostsMiddleware(addr net.Addr) gin.HandlerFunc {
 	}
 }
 
+func CacheControlMiddleware() gin.HandlerFunc {
+    return func(c *gin.Context) {
+        c.Header("Cache-Control", "max-age=0")
+        c.Next()
+    }
+}
+
 func (s *Server) GenerateRoutes() http.Handler {
 	config := cors.DefaultConfig()
 	config.AllowWildcard = true
@@ -1105,6 +1112,7 @@ func (s *Server) GenerateRoutes() http.Handler {
 
 	r := gin.Default()
 	r.Use(
+		CacheControlMiddleware(),
 		cors.New(config),
 		allowedHostsMiddleware(s.addr),
 	)


### PR DESCRIPTION
Response header `Cache-Control` is missing for APIs such as /api/tags and /api/ps are missing.

Adding `Cache-Control: max-age=0` directive to HTTP headers tells clients the response is considered stale immediately after receiving it.