### PR TITLE
Fixing generate failure due to global gpgsign setting

### DIFF
--- a/llm/generate/gen_common.sh
+++ b/llm/generate/gen_common.sh
@@ -71,7 +71,7 @@ git_module_setup() {
 apply_patches() {
     # apply temporary patches until fix is upstream
     for patch in ../patches/*.patch; do
-        git -c 'user.name=nobody' -c 'user.email=<>' -C ${LLAMACPP_DIR} am ${patch}
+        git -c 'user.name=nobody' -c 'user.email=<>' -C ${LLAMACPP_DIR} am --no-gpg-sign ${patch}
     done
 }
 


### PR DESCRIPTION
Hi all, first time commit here so please let me know if I'm missing anything.

Found a small issue in the generate script for `llama.cpp` where the script patches with a placeholder user. Since I have `commit.gpgsign` enabled globally on my system, this was causing the following error during `go generate ./...`.

```
$ go generate ./...
<snip>
+ git submodule init
+ git submodule update --force ../llama.cpp
Submodule path '../llama.cpp': checked out '8962422b1c6f9b8b15f5aeaea42600bcc2d44177'
+ apply_patches
+ for patch in ../patches/*.patch
+ git -c user.name=nobody -c 'user.email=<>' -C ../llama.cpp am ../patches/0000-cmakelist.patch
Applying: patch cmakelist
error: gpg failed to sign the data:
gpg: skipped "nobody <>": No secret key
[GNUPG:] INV_SGNR 9 nobody <>
[GNUPG:] FAILURE sign 17
gpg: signing failed: No secret key

fatal: failed to write commit object
llm/generate/generate_linux.go:3: running "bash": exit status 128
```

Since this happens in a submodule, setting `commit.gpgsign` to `false` for the top-level git repository does not have any effect.

A workaround in the meantime is to disable global gpg signing temporarily, I.E.
```
git config --global commit.gpgsign false
go generate ./...
git config --global commit.gpgsign true
```

Cheers!