### PR TITLE
runner.go: Don't cache prompts for embeddings

### DIFF
--- a/llama/runner/cache.go
+++ b/llama/runner/cache.go
@@ -64,7 +64,7 @@ type InputCacheSlot struct {
 	lastUsed time.Time
 }
 
-func (c *InputCache) LoadCacheSlot(prompt []input) (*InputCacheSlot, []input, int, error) {
+func (c *InputCache) LoadCacheSlot(prompt []input, cachePrompt bool) (*InputCacheSlot, []input, int, error) {
 	var slot *InputCacheSlot
 	var numPast int
 	var err error
@@ -82,6 +82,10 @@ func (c *InputCache) LoadCacheSlot(prompt []input) (*InputCacheSlot, []input, in
 	}
 	if err != nil {
 		return nil, nil, 0, err
+	}
+
+	if !cachePrompt {
+		numPast = 0
 	}
 
 	slot.InUse = true

--- a/llama/runner/runner.go
+++ b/llama/runner/runner.go
@@ -513,9 +513,10 @@ type ImageData struct {
 }
 
 type CompletionRequest struct {
-	Prompt  string      `json:"prompt"`
-	Images  []ImageData `json:"image_data"`
-	Grammar string      `json:"grammar"`
+	Prompt      string      `json:"prompt"`
+	Images      []ImageData `json:"image_data"`
+	Grammar     string      `json:"grammar"`
+	CachePrompt bool        `json:"cache_prompt"`
 
 	Options
 }
@@ -595,7 +596,7 @@ func (s *Server) completion(w http.ResponseWriter, r *http.Request) {
 	s.mu.Lock()
 	for i, sq := range s.seqs {
 		if sq == nil {
-			seq.cache, seq.inputs, seq.numPast, err = s.cache.LoadCacheSlot(seq.inputs)
+			seq.cache, seq.inputs, seq.numPast, err = s.cache.LoadCacheSlot(seq.inputs, req.CachePrompt)
 			if err != nil {
 				s.mu.Unlock()
 				http.Error(w, fmt.Sprintf("Failed to load cache: %v", err), http.StatusInternalServerError)
@@ -646,7 +647,8 @@ func (s *Server) completion(w http.ResponseWriter, r *http.Request) {
 }
 
 type EmbeddingRequest struct {
-	Content string `json:"content"`
+	Content     string `json:"content"`
+	CachePrompt bool   `json:"cache_prompt"`
 }
 
 type EmbeddingResponse struct {
@@ -674,7 +676,7 @@ func (s *Server) embeddings(w http.ResponseWriter, r *http.Request) {
 	s.mu.Lock()
 	for i, sq := range s.seqs {
 		if sq == nil {
-			seq.cache, seq.inputs, seq.numPast, err = s.cache.LoadCacheSlot(seq.inputs)
+			seq.cache, seq.inputs, seq.numPast, err = s.cache.LoadCacheSlot(seq.inputs, req.CachePrompt)
 			if err != nil {
 				s.mu.Unlock()
 				http.Error(w, fmt.Sprintf("Failed to load cache: %v", err), http.StatusInternalServerError)


### PR DESCRIPTION
Our integration with server.cpp implicitly disables prompt caching because it is not part of the JSON object being parsed, this makes the Go runner behavior similarly.

Prompt caching has been seen to affect the results of text completions on certain hardware. The results are not wrong either way but they are non-deterministic. However, embeddings seem to be affected even on hardware that does not show this behavior for completions. For now, it is best to maintain consistency with the existing behavior.