### PR TITLE
doc: Adding docs on how to compile ollama to run on Intel discrete GPU platform

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -92,6 +92,31 @@ go build .
 
 ROCm requires elevated privileges to access the GPU at runtime. On most distros you can add your user account to the `render` group, or run as root.
 
+#### Linux SYCL (Intel)
+
+_Your operating system distribution may already have packages for Intel® OneAPI Basekit and CLBlast. Distro packages are often preferable, but instructions are distro-specific. Please consult distro-specific docs for dependencies if available!_
+
+Install [CLBlast](https://github.com/CNugteren/CLBlast/blob/master/doc/installation.md) and [Intel® OneAPI Basekit](https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit.html) packages first, as well as `cmake` and `golang`.
+
+Export the Intel® OneAPI environment and `OLLAMA_INTEL_GPU` first by:
+
+```bash
+source /opt/intel/oneapi/setvars.sh --force
+export OLLAMA_INTEL_GPU=1
+```
+
+Then generate dependencies:
+
+```bash
+go generate ./...
+```
+
+Then build the binary:
+
+```bash
+go build .
+```
+
 #### Advanced CPU Settings
 
 By default, running `go generate ./...` will compile a few different variations

--- a/docs/gpu.md
+++ b/docs/gpu.md
@@ -109,5 +109,13 @@ In some Linux distributions, SELinux can prevent containers from
 accessing the AMD GPU devices.  On the host system you can run 
 `sudo setsebool container_use_devices=1` to allow containers to use devices.
 
+## Intel
+Ollama supports GPU acceleration on Intel® discrete GPU devices via the Intel® OneAPI SYCL API.
+
+### Linux Support
+| Family         | Cards and accelerators |
+| -------------- | ---------------------- |
+| Intel® Arc™ A-Series Graphics  | `A770` `A750` `A770M` |
+
 ### Metal (Apple GPUs)
 Ollama supports GPU acceleration on Apple devices via the Metal API.


### PR DESCRIPTION
- Adding the steps to compile Ollama to run on Intel(R) discrete GPU platform
- Adding the discrete GPU that have been verified in the GPU docs