### PR TITLE
feat: configure auto startup in macos

### DIFF
--- a/macapp/src/app.tsx
+++ b/macapp/src/app.tsx
@@ -45,7 +45,7 @@ export default function () {
         )}
         {step === Step.CLI && (
           <>
-            <div className='mx-auto flex flex-col space-y-28 text-center'>
+            <div className='mx-auto flex flex-col gap-y-28 text-center'>
               <h1 className='mt-4 text-2xl tracking-tight text-gray-900'>Install the command line</h1>
               <pre className='mx-auto text-4xl text-gray-400'>&gt; ollama</pre>
               <div className='mx-auto'>
@@ -74,35 +74,48 @@ export default function () {
         )}
         {step === Step.FINISH && (
           <>
-            <div className='mx-auto flex flex-col space-y-20 text-center'>
+            <div className='mx-auto flex flex-col gap-y-16 text-center'>
               <h1 className='mt-4 text-2xl tracking-tight text-gray-900'>Run your first model</h1>
-              <div className='flex flex-col'>
-                <div className='group relative flex items-center'>
-                  <pre className='language-none text-2xs w-full rounded-md bg-gray-100 px-4 py-3 text-start leading-normal'>
-                    {command}
-                  </pre>
-                  <button
-                    className={`no-drag absolute right-[5px] px-2 py-2 ${
-                      commandCopied
-                        ? 'text-gray-900 opacity-100 hover:cursor-auto'
-                        : 'text-gray-200 opacity-50 hover:cursor-pointer'
-                    } hover:font-bold hover:text-gray-900 group-hover:opacity-100`}
-                    onClick={() => {
-                      copy(command)
-                      setCommandCopied(true)
-                      setTimeout(() => setCommandCopied(false), 3000)
-                    }}
-                  >
-                    {commandCopied ? (
-                      <CheckIcon className='h-4 w-4 font-bold text-gray-500' />
-                    ) : (
-                      <DocumentDuplicateIcon className='h-4 w-4 text-gray-500' />
-                    )}
-                  </button>
+              <div>
+                <div className='flex flex-col'>
+                  <div className='group relative flex items-center'>
+                    <pre className='language-none text-2xs w-full rounded-md bg-gray-100 px-4 py-3 text-start leading-normal'>
+                      {command}
+                    </pre>
+                    <button
+                      className={`no-drag absolute right-[5px] px-2 py-2 ${
+                        commandCopied
+                          ? 'text-gray-900 opacity-100 hover:cursor-auto'
+                          : 'text-gray-200 opacity-50 hover:cursor-pointer'
+                      } hover:font-bold hover:text-gray-900 group-hover:opacity-100`}
+                      onClick={() => {
+                        copy(command)
+                        setCommandCopied(true)
+                        setTimeout(() => setCommandCopied(false), 3000)
+                      }}
+                    >
+                      {commandCopied ? (
+                        <CheckIcon className='h-4 w-4 font-bold text-gray-500' />
+                      ) : (
+                        <DocumentDuplicateIcon className='h-4 w-4 text-gray-500' />
+                      )}
+                    </button>
+                  </div>
+                  <p className='mx-auto my-4 w-[70%] text-xs text-gray-400'>
+                    Run this command in your favorite terminal.
+                  </p>
                 </div>
-                <p className='mx-auto my-4 w-[70%] text-xs text-gray-400'>
-                  Run this command in your favorite terminal.
-                </p>
+                <div
+                  className='rounded-lg bg-blue-50 p-4 text-start text-sm text-blue-800 dark:bg-gray-800 dark:text-blue-400'
+                  role='alert'
+                >
+                  <span className='font-medium'>
+                    {app.getLoginItemSettings().openAtLogin
+                      ? 'Autostart is enabled by default.'
+                      : 'Autostart is disabled by default.'}
+                  </span>
+                  <p>You can modify this setting in the preferences menu.</p>
+                </div>
               </div>
               <button
                 onClick={() => {

--- a/macapp/src/app.tsx
+++ b/macapp/src/app.tsx
@@ -109,7 +109,7 @@ export default function () {
                   className='rounded-lg bg-blue-50 p-4 text-start text-sm text-blue-800 dark:bg-gray-800 dark:text-blue-400'
                   role='alert'
                 >
-                  <span className='font-medium'>
+                  <span className='font-semibold'>
                     {app.getLoginItemSettings().openAtLogin
                       ? 'Autostart is enabled by default.'
                       : 'Autostart is disabled by default.'}

--- a/macapp/src/index.ts
+++ b/macapp/src/index.ts
@@ -156,7 +156,7 @@ function updateTray() {
   if (!tray) {
     tray = new Tray(trayIconPath())
     // make sure the tray is updated when clicked to avoid stale info
-    // e.g. user disables auto startup in system preferences but tray menu still shows it as enabled
+    // e.g. user disables auto startup in OS preferences but tray menu still shows it as enabled
     tray.on('click', () => {
       updateTray()
     })

--- a/macapp/src/index.ts
+++ b/macapp/src/index.ts
@@ -121,7 +121,7 @@ function toggleAutoStartup() {
   app.setLoginItemSettings({ openAtLogin: newOpenAtLogin })
 
   const notification = new Notification({
-    title: 'Auto Startup',
+    title: 'Ollama Auto Startup',
     body: `Auto startup is now ${newOpenAtLogin ? 'enabled' : 'disabled'}`,
   })
   notification.show()

--- a/macapp/src/index.ts
+++ b/macapp/src/index.ts
@@ -150,7 +150,6 @@ function updateTray() {
   const menu = Menu.buildFromTemplate([
     ...(updateAvailable ? updateItems : []),
     toggleAutoStartupItem,
-    { role: 'about' },
     { role: 'quit', accelerator: 'Command+Q' },
   ])
 

--- a/macapp/src/index.ts
+++ b/macapp/src/index.ts
@@ -70,11 +70,11 @@ app.on('ready', () => {
 function firstRunWindow() {
   // Create the browser window.
   welcomeWindow = new BrowserWindow({
-    width: 400,
+    width: 440,
     height: 500,
     frame: false,
     fullscreenable: false,
-    resizable: false,
+    resizable: true,
     movable: true,
     show: false,
     webPreferences: {

--- a/macapp/src/index.ts
+++ b/macapp/src/index.ts
@@ -65,7 +65,6 @@ app.on('ready', () => {
   app.focus({ steal: true })
 
   init()
-  updateTray()
 })
 
 function firstRunWindow() {

--- a/macapp/tailwind.config.js
+++ b/macapp/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: ['./src/**/*.{js,ts,jsx,tsx,mdx}'],
   theme: {},
   plugins: [],


### PR DESCRIPTION
This pull request adds a new function called `toggleAutoStartup` and a corresponding menu item to the application. The function allows the user to enable or disable auto startup of the application. When the function is called, it updates the application's login item settings and displays a notification to indicate whether auto startup is enabled or disabled. The menu item is added to the tray menu and allows the user to easily toggle the auto startup setting. Additionally, the tray menu is now updated when clicked to avoid displaying stale information.

closes #162

![image](https://github.com/user-attachments/assets/2ada1db6-5906-49b9-bcdf-ff8f39c7b3d2)

![image](https://github.com/user-attachments/assets/312af349-6c8f-4d0a-b411-c6bf22baf714)

![image](https://github.com/user-attachments/assets/6a6be040-5964-4148-aaca-ff3c7292204a)


https://github.com/user-attachments/assets/83c43726-4348-4074-9fe8-d893236acf12


