### PR TITLE
Refactor app.tsx and index.ts to use APP_DISPLAY_NAME constant

### DIFF
--- a/macapp/src/app.tsx
+++ b/macapp/src/app.tsx
@@ -6,6 +6,7 @@ import { getCurrentWindow, app } from '@electron/remote'
 
 import { install } from './install'
 import OllamaIcon from './ollama.svg'
+import { APP_DISPLAY_NAME } from './utils'
 
 const store = new Store()
 
@@ -27,7 +28,7 @@ export default function () {
         {step === Step.WELCOME && (
           <>
             <div className='mx-auto text-center'>
-              <h1 className='mb-6 mt-4 text-2xl tracking-tight text-gray-900'>Welcome to Ollama</h1>
+              <h1 className='mb-6 mt-4 text-2xl tracking-tight text-gray-900'>Welcome to {APP_DISPLAY_NAME}</h1>
               <p className='mx-auto w-[65%] text-sm text-gray-400'>
                 Let's get you up and running with your own large language models.
               </p>

--- a/macapp/src/index.ts
+++ b/macapp/src/index.ts
@@ -7,6 +7,7 @@ import * as path from 'path'
 
 import { v4 as uuidv4 } from 'uuid'
 import { installed } from './install'
+import { APP_DISPLAY_NAME } from './utils'
 
 require('@electron/remote/main').initialize()
 
@@ -123,7 +124,7 @@ function updateTray() {
     tray = new Tray(trayIconPath())
   }
 
-  tray.setToolTip(updateAvailable ? 'An update is available' : 'Ollama')
+  tray.setToolTip(updateAvailable ? 'An update is available' : APP_DISPLAY_NAME)
   tray.setContextMenu(menu)
   tray.setImage(trayIconPath())
 
@@ -223,7 +224,7 @@ function init() {
         const chosen = dialog.showMessageBoxSync({
           type: 'question',
           buttons: ['Move to Applications', 'Do Not Move'],
-          message: 'Ollama works best when run from the Applications directory.',
+          message: `${APP_DISPLAY_NAME} works best when run from the Applications directory.`,
           defaultId: 0,
           cancelId: 1,
         })
@@ -236,8 +237,7 @@ function init() {
                   dialog.showMessageBoxSync({
                     type: 'info',
                     message: 'Cannot move to Applications directory',
-                    detail:
-                      'Another version of Ollama is currently running from your Applications directory. Close it first and try again.',
+                    detail: `Another version of ${APP_DISPLAY_NAME} is currently running from your Applications directory. Close it first and try again.`,
                   })
                 }
                 return true

--- a/macapp/src/utils.ts
+++ b/macapp/src/utils.ts
@@ -1,0 +1,3 @@
+const APP_DISPLAY_NAME = 'Ollama'
+
+export { APP_DISPLAY_NAME }


### PR DESCRIPTION
This pull request refactors the `app.tsx` and `index.ts` files in the `macapp/src` directory to use the `APP_DISPLAY_NAME` constant. The `APP_DISPLAY_NAME` constant is defined in the newly added `utils.ts` file and is used to display the name of the application. This change ensures that the application name is consistently displayed as `Ollama` throughout the codebase.