### PR TITLE
Change -j8 to --parallel in gen_common.sh

### DIFF
--- a/llm/generate/gen_common.sh
+++ b/llm/generate/gen_common.sh
@@ -77,7 +77,7 @@ apply_patches() {
 
 build() {
     cmake -S ${LLAMACPP_DIR} -B ${BUILD_DIR} ${CMAKE_DEFS}
-    cmake --build ${BUILD_DIR} ${CMAKE_TARGETS} -j8
+    cmake --build ${BUILD_DIR} ${CMAKE_TARGETS} --parallel
     # remove unnecessary build artifacts
     rm -f ${BUILD_DIR}/bin/ggml-common.h ${BUILD_DIR}/bin/ggml-metal.metal
 }


### PR DESCRIPTION
-j8 makes the build process use 8 jobs no matter how many cores you have. Instead, --parallel will use all available cores, depending on the setup.

This change will change nothing for people with 8 cores, while making the build process faster for people with more or less than 8 cores.