### PR TITLE
Fix build leakages

### DIFF
--- a/llama/Makefile
+++ b/llama/Makefile
@@ -42,7 +42,7 @@ $(RUNNER_TARGETS):
 	$(MAKE) -f make/Makefile.$@
 
 clean:
-	rm -rf $(BUILD_DIR) $(DIST_RUNNERS) $(PAYLOAD_RUNNERS) $(RUNNERS_PAYLOAD_DIR)
+	rm -rf $(BUILD_DIR) $(DIST_RUNNERS) $(PAYLOAD_RUNNERS)
 
 clean-payload:
 	rm -rf $(addprefix $(RUNNERS_PAYLOAD_DIR)/, $(RUNNER_TARGETS) metal cpu cpu_avx cpu_avx2)

--- a/llm/generate/gen_common.sh
+++ b/llm/generate/gen_common.sh
@@ -133,13 +133,5 @@ install() {
 
 # Keep the local tree clean after we're done with the build
 cleanup() {
-    (cd ${LLAMACPP_DIR}/ && git checkout CMakeLists.txt)
-
-    if [ -n "$(ls -A ../patches/*.diff)" ]; then
-        for patch in ../patches/*.diff; do
-            for file in $(grep "^+++ " ${patch} | cut -f2 -d' ' | cut -f2- -d/); do
-                (cd ${LLAMACPP_DIR}; git checkout ${file})
-            done
-        done
-    fi
+    git submodule update --force ${LLAMACPP_DIR}
 }


### PR DESCRIPTION
The recent change to applying patches leaves the submodule dirty based on "new commits" being present.  This ensures we clean up so the tree no longer reports dirty after a `go generate ./...` run.

The Makefile was being a bit too aggressive in cleaning things up and would result in deleting the placeholder files which someone might accidentally commit.