### PR TITLE
Better handle small models in scheduler

### DIFF
--- a/llm/ggml.go
+++ b/llm/ggml.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"strings"
 
 	"github.com/ollama/ollama/util/bufioutil"
@@ -471,6 +472,8 @@ func (llm GGML) GraphSize(context, batch uint64) (partialOffload, fullOffload ui
 					4*qkvBias.Shape[0],
 			)
 		}
+	default:
+		slog.Debug("memory prediction may be incorrect", "architecture", llm.KV().Architecture())
 	}
 
 	return


### PR DESCRIPTION
Our memory prediction for small models tends to over-estimate the actual VRAM usage, which causes the scheduler to incorrectly wait too long for recovery.

Fixes #7130 