### PR TITLE
fix vendoring attribute

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,11 @@
 llm/ext_server/* linguist-vendored
-llama/**/*.{cpp,hpp,h,c,cu,cuh,m} linguist-vendored
+llama/**/*.cpp linguist-vendored
+llama/**/*.hpp linguist-vendored
+llama/**/*.h linguist-vendored
+llama/**/*.c linguist-vendored
+llama/**/*.cu linguist-vendored
+llama/**/*.cuh linguist-vendored
+llama/**/*.m linguist-vendored
 
 * text=auto
 *.go text eol=lf


### PR DESCRIPTION
Expand out the file extensions for vendored code so git reports the status correctly

e.g.:
```
% git check-attr -a -- ./llama/ggml.c
./llama/ggml.c: text: auto
./llama/ggml.c: linguist-vendored: set
```