### PR TITLE
runner.go: Handle truncation of tokens for stop sequences

### DIFF
--- a/llama/runner/stop.go
+++ b/llama/runner/stop.go
@@ -28,13 +28,13 @@ func containsStopSuffix(sequence string, stops []string) bool {
 
 // truncateStop removes the provided stop string from pieces,
 // returning the partial pieces with stop removed, including truncating
-// the last piece if required
-func truncateStop(pieces []string, stop string) []string {
+// the last piece if required (and signalling if this was the case)
+func truncateStop(pieces []string, stop string) ([]string, bool) {
 	joined := strings.Join(pieces, "")
 
 	index := strings.Index(joined, stop)
 	if index == -1 {
-		return pieces
+		return pieces, false
 	}
 
 	joined = joined[:index]
@@ -46,6 +46,7 @@ func truncateStop(pieces []string, stop string) []string {
 	}
 
 	var result []string
+	tokenTruncated := false
 	start := 0
 	for _, length := range lengths {
 		if start >= len(joined) {
@@ -55,12 +56,13 @@ func truncateStop(pieces []string, stop string) []string {
 		end := start + length
 		if end > len(joined) {
 			end = len(joined)
+			tokenTruncated = true
 		}
 		result = append(result, joined[start:end])
 		start = end
 	}
 
-	return result
+	return result, tokenTruncated
 }
 
 func incompleteUnicode(token string) bool {

--- a/llama/runner/stop_test.go
+++ b/llama/runner/stop_test.go
@@ -7,42 +7,54 @@ import (
 
 func TestTruncateStop(t *testing.T) {
 	tests := []struct {
-		name     string
-		pieces   []string
-		stop     string
-		expected []string
+		name          string
+		pieces        []string
+		stop          string
+		expected      []string
+		expectedTrunc bool
 	}{
 		{
-			name:     "Single word",
-			pieces:   []string{"hello", "world"},
-			stop:     "world",
-			expected: []string{"hello"},
+			name:          "Single word",
+			pieces:        []string{"hello", "world"},
+			stop:          "world",
+			expected:      []string{"hello"},
+			expectedTrunc: false,
 		},
 		{
-			name:     "Partial",
-			pieces:   []string{"hello", "wor"},
-			stop:     "or",
-			expected: []string{"hello", "w"},
+			name:          "Partial",
+			pieces:        []string{"hello", "wor"},
+			stop:          "or",
+			expected:      []string{"hello", "w"},
+			expectedTrunc: true,
 		},
 		{
-			name:     "Suffix",
-			pieces:   []string{"Hello", " there", "!"},
-			stop:     "!",
-			expected: []string{"Hello", " there"},
+			name:          "Suffix",
+			pieces:        []string{"Hello", " there", "!"},
+			stop:          "!",
+			expected:      []string{"Hello", " there"},
+			expectedTrunc: false,
 		},
 		{
-			name:     "Middle",
-			pieces:   []string{"hello", " wor"},
-			stop:     "llo w",
-			expected: []string{"he"},
+			name:          "Suffix partial",
+			pieces:        []string{"Hello", " the", "re!"},
+			stop:          "there!",
+			expected:      []string{"Hello", " "},
+			expectedTrunc: true,
+		},
+		{
+			name:          "Middle",
+			pieces:        []string{"hello", " wor"},
+			stop:          "llo w",
+			expected:      []string{"he"},
+			expectedTrunc: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := truncateStop(tt.pieces, tt.stop)
-			if !reflect.DeepEqual(result, tt.expected) {
-				t.Errorf("truncateStop(%v, %s): have %v; want %v", tt.pieces, tt.stop, result, tt.expected)
+			result, resultTrunc := truncateStop(tt.pieces, tt.stop)
+			if !reflect.DeepEqual(result, tt.expected) || resultTrunc != tt.expectedTrunc {
+				t.Errorf("truncateStop(%v, %s): have %v (%v); want %v (%v)", tt.pieces, tt.stop, result, resultTrunc, tt.expected, tt.expectedTrunc)
 			}
 		})
 	}

--- a/llm/server.go
+++ b/llm/server.go
@@ -1086,10 +1086,13 @@ func (s *llmServer) Detokenize(ctx context.Context, tokens []int) (string, error
 }
 
 func (s *llmServer) Close() error {
+	s.modelLock.Lock()
 	if s.model != nil {
 		llama.FreeModel(s.model)
 		s.model = nil
 	}
+	s.modelLock.Unlock()
+
 	if s.cmd != nil {
 		slog.Debug("stopping llama server")
 		if err := s.cmd.Process.Kill(); err != nil {
@@ -1100,7 +1103,6 @@ func (s *llmServer) Close() error {
 			slog.Debug("waiting for llama server to exit")
 			<-s.done
 		}
-		s.cmd = nil
 
 		slog.Debug("llama server stopped")
 	}


### PR DESCRIPTION
When a single token contains both text to be return and a stop sequence, this causes an out of bounds error when we update the cache to match our text. This is because we currently assume that the removing the stop sequence will consume at least one token.

This also inverts the logic to deal with positive numbers, rather than a value to be subtracted, which is easier to reason about.