### PR TITLE
Send all images in conversation history

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -442,13 +442,6 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 					return err
 				}
 
-				// clear all previous images for better responses
-				if len(images) > 0 {
-					for i := range opts.Messages {
-						opts.Messages[i].Images = nil
-					}
-				}
-
 				newMessage.Content = msg
 				newMessage.Images = images
 			}


### PR DESCRIPTION
@pdevine I'm not entirely sure what the history of this check was - it sounds like there were previously some models that didn't do well with images in the history. However, it worked well with the models that I tried it on.

Regardless, I don't think the check belongs in the CLI.