### PR TITLE
Update RAM requirements for model sizes in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Here are some example models that can be downloaded:
 | Solar              | 10.7B      | 6.1GB | `ollama run solar`             |
 
 > [!NOTE]
-> You should have at least 8 GB of RAM available to run the 7B models, 16 GB to run the 13B models, and 32 GB to run the 33B models.
+> You should have at least 8 GB of RAM available to run the 9B models, 12 GB to run the 14B models, and 32 GB to run the 33B models.
 
 ## Customize a model
 


### PR DESCRIPTION
I have used RTX3070 with 8GB of ram and I can Run gemma2 9b on all GPU and I can run qwen2.5 14B on RTX4070 with 12GB of ram on all GPU. So I revise requirements so that people with that GPU's would know they can run these models.