### PR TITLE
Add missing BF16 tensor type.

### DIFF
--- a/llm/ggml.go
+++ b/llm/ggml.go
@@ -244,6 +244,8 @@ func (t Tensor) typeSize() uint64 {
 		return 8
 	case 29: // IQ1_M
 		return blockSize/8 + blockSize/16 + blockSize/32
+	case 30: // BF16
+		return 2
 	default:
 		return 0
 	}


### PR DESCRIPTION
Models with BF16 tensors are not imported because the typeSize is 0.

Fixes: https://github.com/ollama/ollama/issues/7188