### PR TITLE
Clear screen when `/clear` command is used in interactive mode

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -229,6 +229,8 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 			fmt.Printf("Created new model '%s'\n", args[1])
 			continue
 		case strings.HasPrefix(line, "/clear"):
+			// clear the screen
+			fmt.Print("\033[H\033[2J")
 			opts.Messages = []api.Message{}
 			if opts.System != "" {
 				newMessage := api.Message{Role: "system", Content: opts.System}


### PR DESCRIPTION
Use ANSI escape codes to clear the terminal and reset the cursor's position with the `/clear` command.