### PR TITLE
fix: consider any status code as redirect

### DIFF
--- a/server/download.go
+++ b/server/download.go
@@ -256,10 +256,14 @@ func (b *blobDownload) run(ctx context.Context, requestURL *url.URL, opts *regis
 				continue
 			}
 			defer resp.Body.Close()
-			if resp.StatusCode != http.StatusTemporaryRedirect && resp.StatusCode != http.StatusOK {
-				return nil, fmt.Errorf("unexpected status code %d", resp.StatusCode)
+			statusClass := resp.StatusCode / 100
+			if statusClass == 3 {
+				return resp.Location()
 			}
-			return resp.Location()
+			if statusClass == 2 {
+				return requestURL, nil
+			}
+			return nil, fmt.Errorf("unexpected status code %d", resp.StatusCode)
 		}
 	}()
 	if err != nil {

--- a/server/download.go
+++ b/server/download.go
@@ -256,11 +256,10 @@ func (b *blobDownload) run(ctx context.Context, requestURL *url.URL, opts *regis
 				continue
 			}
 			defer resp.Body.Close()
-			statusClass := resp.StatusCode / 100
-			if statusClass == 3 {
+			if resp.StatusCode == http.StatusTemporaryRedirect || resp.StatusCode == http.StatusFound {
 				return resp.Location()
 			}
-			if statusClass == 2 {
+			if resp.StatusCode == http.StatusOK {
 				return requestURL, nil
 			}
 			return nil, fmt.Errorf("unexpected status code %d", resp.StatusCode)


### PR DESCRIPTION
When retrieving the url for downloading a model, ollama always consider that the model is host on a CDN.

This PR resolve:
 - If 200 is return on the same host, just return the current url
 - Consider any 3xx as a redirect url