### PR TITLE
Expose GPU and basic system info 

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -428,3 +428,12 @@ func (c *Client) Version(ctx context.Context) (string, error) {
 
 	return version.Version, nil
 }
+
+// Info retrieves server information.
+func (c *Client) Info(ctx context.Context) (*InfoResponse, error) {
+	var resp InfoResponse
+	if err := c.do(ctx, http.MethodGet, "/api/info", nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/api/types.go
+++ b/api/types.go
@@ -975,3 +975,87 @@ func FormatParams(params map[string][]string) (map[string]any, error) {
 
 	return out, nil
 }
+
+type SystemModelInfo struct {
+	// Store is the location where the server stores models in the filesystem.
+	Store string `json:"store"`
+
+	// Count is the number of models currently stored in the filesystem.
+	Count int `json:"count"`
+
+	// FilesystemUsed is the number of bytes used on the filesystem to store models
+	FilesystemUsed uint64 `json:"filesystem_used"`
+
+	// Running is the number of models currently running in the server.
+	Running int `json:"running"`
+
+	// VRAMUsed is the amount of GPU VRAM consumed by the loaded models
+	VRAMUsed uint64 `json:"vram_used"`
+}
+
+type SystemComputeInfo struct {
+	// Cores is the number of detected CPU Cores in the system
+	CPUCores int `json:"cpu_cores"`
+
+	// TotalMemory is the amount of system memory discovered by the server
+	TotalMemory uint64 `json:"total_memory"`
+
+	// FreeMemory is the amount of system memory available for loading new models
+	FreeMemory uint64 `json:"free_memory"`
+
+	// FreeSwap is the amount of swap space available for loading new models
+	FreeSwap uint64 `json:"free_swap"`
+}
+
+type GPUInfo struct {
+	// ID is the unique identifier to use for selection of this specific GPU by device vendor
+	ID string `json:"gpu_id"`
+
+	// Name is the model or other identifying information about the GPU
+	Name string `json:"name"`
+
+	// TotalMemory is the amount of video memory on the GPU
+	TotalMemory uint64 `json:"total_memory"`
+
+	// FreeMemory is the amount of video memory on the GPU available for loading new models
+	FreeMemory uint64 `json:"free_memory"`
+
+	// Compute is the GPU capability version information, specific to each device vendor
+	Compute string `json:"compute"`
+
+	// Driver is the device driver detected for this GPU
+	Driver string `json:"driver"`
+
+	// Runner is the default runner for this GPU
+	Runner string `json:"runner"`
+}
+
+type UnsupportedGPUInfo struct {
+	GPUInfo
+
+	// Error explains the reason why this GPU can not be used for running models
+	Error string `json:"error"`
+}
+type ComputeInfo struct {
+	// AvailableRunners is the current available LLM runners in the server
+	AvailableRunners []string `json:"available_runners"`
+
+	SystemCompute SystemComputeInfo `json:"system_compute"`
+
+	SupportedGPUs []GPUInfo `json:"supported_gpus"`
+
+	UnsupportedGPUs []UnsupportedGPUInfo `json:"unsupported_gpus"`
+
+	// DiscoveryErrors contains any errors encountered while trying to discover GPUs
+	DiscoveryErrors []string `json:"discovery_errors"`
+}
+
+// InfoResponse is the response returned from [Client.Info].
+type InfoResponse struct {
+	// Version is the current version of the server.
+	Version string `json:"version"`
+
+	Models SystemModelInfo `json:"models"`
+
+	ComputeInfo ComputeInfo `json:"compute"`
+}

--- a/api/types.go
+++ b/api/types.go
@@ -1037,9 +1037,6 @@ type UnsupportedGPUInfo struct {
 	Error string `json:"error"`
 }
 type ComputeInfo struct {
-	// AvailableRunners is the current available LLM runners in the server
-	AvailableRunners []string `json:"available_runners"`
-
 	SystemCompute SystemComputeInfo `json:"system_compute"`
 
 	SupportedGPUs []GPUInfo `json:"supported_gpus"`

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1588,6 +1588,13 @@ func NewCLI() *cobra.Command {
 		_ = runner.Execute(args[1:])
 	})
 
+	infoCmd := &cobra.Command{
+		Use:     "info",
+		Short:   "Display system-wide information",
+		PreRunE: checkServerHeartbeat,
+		RunE:    InfoHandler,
+	}
+
 	envVars := envconfig.AsMap()
 
 	envs := []envconfig.EnvVar{envVars["OLLAMA_HOST"]}
@@ -1604,6 +1611,7 @@ func NewCLI() *cobra.Command {
 		copyCmd,
 		deleteCmd,
 		serveCmd,
+		infoCmd,
 	} {
 		switch cmd {
 		case runCmd:
@@ -1645,6 +1653,7 @@ func NewCLI() *cobra.Command {
 		copyCmd,
 		deleteCmd,
 		runnerCmd,
+		infoCmd,
 	)
 
 	return rootCmd

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -1,0 +1,186 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/envconfig"
+	"github.com/ollama/ollama/format"
+	"github.com/ollama/ollama/version"
+)
+
+func InfoHandler(cmd *cobra.Command, args []string) error {
+	client, err := api.ClientFromEnvironment()
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Info(cmd.Context())
+	if err != nil {
+		return err
+	}
+	out := os.Stdout
+	prettyPrintClientInfo(out)
+	fmt.Fprint(out, "\n")
+
+	prettyPrintInfoResponse(out, *resp)
+
+	return nil
+}
+
+func prettyPrintClientInfo(out io.Writer) {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetNoWhiteSpace(true)
+	table.SetTablePadding(" ")
+	indent := ""
+
+	cfgDir := ""
+	home, err := os.UserHomeDir()
+	if err == nil {
+		cfgDir = filepath.Join(home, ".ollama")
+	}
+
+	data := [][]string{
+		{
+			indent, "Version:", version.Version,
+		},
+		{
+			indent, "Configuration:", cfgDir,
+		},
+		{
+			indent, "Connection:", envconfig.Host().String(),
+		},
+	}
+	fmt.Fprint(out, "Client:\n")
+	table.AppendBulk(data)
+	table.Render()
+}
+
+func prettyPrintInfoResponse(out io.Writer, resp api.InfoResponse) {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetNoWhiteSpace(true)
+	table.SetTablePadding(" ")
+	indent := ""
+	data := [][]string{
+		{
+			indent, "Version:", resp.Version,
+		},
+	}
+	fmt.Fprint(out, "Server:\n")
+	table.AppendBulk(data)
+	table.Render()
+	prettyPrintModels(out, " ", resp)
+	prettyPrintCompute(out, " ", resp)
+}
+
+func prettyPrintModels(out io.Writer, indent string, resp api.InfoResponse) {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetNoWhiteSpace(true)
+	table.SetTablePadding(" ")
+	data := [][]string{
+		{
+			indent, "Store:", envconfig.Models(),
+		},
+		{
+			indent, "Downloaded:", strconv.Itoa(resp.Models.Count),
+		},
+		{
+			indent, "Filesystem Used:", format.HumanBytes(int64(resp.Models.FilesystemUsed)),
+		},
+		{
+			indent, "Running:", strconv.Itoa(resp.Models.Running),
+		},
+		{
+			indent, "VRAM Used:", format.HumanBytes(int64(resp.Models.VRAMUsed)),
+		},
+	}
+	fmt.Fprintf(out, "%sModels:\n", indent)
+	table.AppendBulk(data)
+	table.Render()
+}
+
+func prettyPrintCompute(out io.Writer, indent string, resp api.InfoResponse) {
+	fmt.Fprintf(out, "%sCompute:\n", indent)
+	indent += " "
+	prettyPrintSystem(out, indent, resp)
+	prettyPrintSupportedGPUs(out, indent, resp)
+}
+
+func prettyPrintSystem(out io.Writer, indent string, resp api.InfoResponse) {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetNoWhiteSpace(true)
+	table.SetTablePadding(" ")
+	data := [][]string{
+		{
+			indent, "CPU Cores:", strconv.Itoa(resp.ComputeInfo.SystemCompute.CPUCores),
+		},
+		{
+			indent, "Total Memory:", format.HumanBytes(int64(resp.ComputeInfo.SystemCompute.TotalMemory)),
+		},
+		{
+			indent, "Free Memory:", format.HumanBytes(int64(resp.ComputeInfo.SystemCompute.FreeMemory)),
+		},
+		{
+			indent, "Free Swap:", format.HumanBytes(int64(resp.ComputeInfo.SystemCompute.FreeSwap)),
+		},
+	}
+	fmt.Fprintf(out, "%sSystem:\n", indent)
+	table.AppendBulk(data)
+	table.Render()
+}
+
+func prettyPrintSupportedGPUs(out io.Writer, indent string, resp api.InfoResponse) {
+	fmt.Fprintf(out, "%sSupported GPUs:\n", indent)
+	indent += " "
+	for _, gpu := range resp.ComputeInfo.SupportedGPUs {
+		prettyPrintSupportedGPU(out, indent, gpu)
+	}
+}
+
+func prettyPrintSupportedGPU(out io.Writer, indent string, gpu api.GPUInfo) {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetNoWhiteSpace(true)
+	table.SetTablePadding(" ")
+	data := [][]string{
+		{
+			indent, "Name:", gpu.Name,
+		},
+		{
+			indent, "Total Memory:", format.HumanBytes(int64(gpu.TotalMemory)),
+		},
+		{
+			indent, "Free Memory:", format.HumanBytes(int64(gpu.FreeMemory)),
+		},
+		{
+			indent, "Compute:", gpu.Compute,
+		},
+		{
+			indent, "Driver:", gpu.Driver,
+		},
+	}
+	fmt.Fprintf(out, "%s%s %s:\n", indent, gpu.Runner, gpu.ID)
+	table.AppendBulk(data)
+	table.Render()
+}

--- a/server/routes.go
+++ b/server/routes.go
@@ -18,7 +18,6 @@ import (
 	"os"
 	"os/signal"
 	"slices"
-	"sort"
 	"strings"
 	"syscall"
 	"time"
@@ -37,7 +36,6 @@ import (
 	"github.com/ollama/ollama/llm"
 	"github.com/ollama/ollama/logutil"
 	"github.com/ollama/ollama/openai"
-	"github.com/ollama/ollama/runners"
 	"github.com/ollama/ollama/server/internal/client/ollama"
 	"github.com/ollama/ollama/server/internal/registry"
 	"github.com/ollama/ollama/template"
@@ -1537,12 +1535,6 @@ func (s *Server) PsHandler(c *gin.Context) {
 }
 
 func (s *Server) InfoHandler(c *gin.Context) {
-	availRunners := []string{}
-	for k := range runners.GetAvailableServers(s.runnerDir) {
-		availRunners = append(availRunners, k)
-	}
-	sort.Strings(availRunners)
-
 	sysInfo := discover.GetSystemInfo()
 	ms, _ := Manifests(true)
 	fsUsed := uint64(0)
@@ -1593,7 +1585,6 @@ func (s *Server) InfoHandler(c *gin.Context) {
 			VRAMUsed:       vramUsed,
 		},
 		ComputeInfo: api.ComputeInfo{
-			AvailableRunners: availRunners,
 			SystemCompute: api.SystemComputeInfo{
 				CPUCores:    cores,
 				TotalMemory: sysInfo.System.TotalMemory,

--- a/server/routes.go
+++ b/server/routes.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"os/signal"
 	"slices"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
@@ -36,6 +37,7 @@ import (
 	"github.com/ollama/ollama/llm"
 	"github.com/ollama/ollama/logutil"
 	"github.com/ollama/ollama/openai"
+	"github.com/ollama/ollama/runners"
 	"github.com/ollama/ollama/server/internal/client/ollama"
 	"github.com/ollama/ollama/server/internal/registry"
 	"github.com/ollama/ollama/template"
@@ -1303,6 +1305,7 @@ func (s *Server) GenerateRoutes(rc *ollama.Registry) (http.Handler, error) {
 	r.POST("/api/chat", s.ChatHandler)
 	r.POST("/api/embed", s.EmbedHandler)
 	r.POST("/api/embeddings", s.EmbeddingsHandler)
+	r.GET("/api/info", s.InfoHandler)
 
 	// Inference (OpenAI compatibility)
 	r.POST("/v1/chat/completions", openai.ChatMiddleware(), s.ChatHandler)
@@ -1490,6 +1493,7 @@ func streamResponse(c *gin.Context, ch chan any) {
 func (s *Server) PsHandler(c *gin.Context) {
 	models := []api.ProcessModelResponse{}
 
+	s.sched.loadedMu.Lock()
 	for _, v := range s.sched.loaded {
 		model := v.model
 		modelDetails := api.ModelDetails{
@@ -1522,6 +1526,7 @@ func (s *Server) PsHandler(c *gin.Context) {
 
 		models = append(models, mr)
 	}
+	s.sched.loadedMu.Unlock()
 
 	slices.SortStableFunc(models, func(i, j api.ProcessModelResponse) int {
 		// longest duration remaining listed first
@@ -1529,6 +1534,76 @@ func (s *Server) PsHandler(c *gin.Context) {
 	})
 
 	c.JSON(http.StatusOK, api.ProcessResponse{Models: models})
+}
+
+func (s *Server) InfoHandler(c *gin.Context) {
+	availRunners := []string{}
+	for k := range runners.GetAvailableServers(s.runnerDir) {
+		availRunners = append(availRunners, k)
+	}
+	sort.Strings(availRunners)
+
+	sysInfo := discover.GetSystemInfo()
+	ms, _ := Manifests(true)
+	fsUsed := uint64(0)
+	layers := map[string]interface{}{}
+	for _, m := range ms {
+		for _, l := range m.Layers {
+			if _, counted := layers[l.Digest]; !counted {
+				layers[l.Digest] = struct{}{}
+				fsUsed += uint64(l.Size)
+			}
+		}
+	}
+	vramUsed := uint64(0)
+	s.sched.loadedMu.Lock()
+	runningCount := len(s.sched.loaded)
+	for _, r := range s.sched.loaded {
+		vramUsed += r.vramSize
+	}
+	s.sched.loadedMu.Unlock()
+	supportedGPUs := make([]api.GPUInfo, len(sysInfo.GPUs))
+	for i, gpu := range sysInfo.GPUs {
+		supportedGPUs[i].ID = gpu.ID
+		supportedGPUs[i].Name = gpu.Name
+		supportedGPUs[i].TotalMemory = gpu.TotalMemory
+		supportedGPUs[i].FreeMemory = gpu.FreeMemory
+		supportedGPUs[i].Compute = gpu.Compute
+		if gpu.DriverMajor > 0 {
+			supportedGPUs[i].Driver = fmt.Sprintf("%d.%d", gpu.DriverMajor, gpu.DriverMinor)
+		} else {
+			supportedGPUs[i].Driver = "upstream driver"
+		}
+		supportedGPUs[i].Runner = gpu.Library
+		if gpu.Variant != "" {
+			supportedGPUs[i].Runner += "_" + gpu.Variant
+		}
+	}
+	cores := 0
+	for _, cpu := range sysInfo.System.CPUs {
+		cores += cpu.CoreCount
+	}
+	info := api.InfoResponse{
+		Version: version.Version,
+		Models: api.SystemModelInfo{
+			Store:          envconfig.Models(),
+			Count:          len(ms),
+			FilesystemUsed: fsUsed,
+			Running:        runningCount,
+			VRAMUsed:       vramUsed,
+		},
+		ComputeInfo: api.ComputeInfo{
+			AvailableRunners: availRunners,
+			SystemCompute: api.SystemComputeInfo{
+				CPUCores:    cores,
+				TotalMemory: sysInfo.System.TotalMemory,
+				FreeMemory:  sysInfo.System.FreeMemory,
+				FreeSwap:    sysInfo.System.FreeSwap,
+			},
+			SupportedGPUs: supportedGPUs,
+		},
+	}
+	c.JSON(http.StatusOK, info)
 }
 
 func (s *Server) ChatHandler(c *gin.Context) {


### PR DESCRIPTION
This adds a new API and CLI UX to expose some basic information about the system.

Example CLI output:
```
% ollama info
Client:
 Version:       0.0.0
 Configuration: /Users/daniel/.ollama
 Connection:    http://localhost:11434

Server:
 Version: 0.3.13-13-g436602d
 Models:
  Store:           /Users/daniel/.ollama/models
  Downloaded:      41
  Filesystem Used: 475.8 GiB
  Running:         0
  VRAM Used:       0 B
 Compute:
  Available Runners: cpu, cpu_avx, cpu_avx2,
                      cuda_v11, cuda_v12, rocm
  System:
   CPU Cores:    16
   Total Memory: 62.6 GiB
   Free Memory:  60.9 GiB
   Free Swap:    7.5 GiB
  Supported GPUs:
   cuda_v12 GPU-19fc4f1e-fbcc-de33-f14a-ae21199420b6:
    Name:         NVIDIA GeForce RTX 3060
    Total Memory: 11.8 GiB
    Free Memory:  11.6 GiB
    Compute:      8.6
    Driver:       12.4
```

Fixes #7180 
Fixes #3822 