### PR TITLE
Show supported types list in help message for `ollama create`

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -38,6 +39,7 @@ import (
 	"github.com/ollama/ollama/auth"
 	"github.com/ollama/ollama/envconfig"
 	"github.com/ollama/ollama/format"
+	"github.com/ollama/ollama/llm"
 	"github.com/ollama/ollama/parser"
 	"github.com/ollama/ollama/progress"
 	"github.com/ollama/ollama/server"
@@ -1314,6 +1316,27 @@ Environment Variables:
 	cmd.SetUsageTemplate(cmd.UsageTemplate() + envUsage)
 }
 
+func get_supported_filetypes_lines(max_count_per_line int) string {
+	filetypes := llm.GetSupportedFileTypes()
+	sort.Strings(filetypes)
+
+	var builder strings.Builder
+	for i, key := range filetypes {
+		if i%max_count_per_line == 0 {
+			if i > 0 {
+				builder.WriteString("\n")
+			}
+			builder.WriteString("   ")
+		}
+		if i%max_count_per_line != 0 {
+			builder.WriteString(", ")
+		}
+		builder.WriteString(key)
+	}
+
+	return builder.String()
+
+}
 func NewCLI() *cobra.Command {
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 	cobra.EnableCommandSorting = false
@@ -1351,7 +1374,7 @@ func NewCLI() *cobra.Command {
 	}
 
 	createCmd.Flags().StringP("file", "f", "", "Name of the Modelfile (default \"Modelfile\"")
-	createCmd.Flags().StringP("quantize", "q", "", "Quantize model to this level (e.g. q4_0)")
+	createCmd.Flags().StringP("quantize", "q", "", "Quantize model to this level (e.g. q4_0)\n Supported types:\n"+get_supported_filetypes_lines(6))
 
 	showCmd := &cobra.Command{
 		Use:     "show MODEL",

--- a/llm/filetype.go
+++ b/llm/filetype.go
@@ -74,6 +74,14 @@ var fileTypeMap = map[string]fileType{
 	"BF16":     fileTypeBF16,
 }
 
+func GetSupportedFileTypes() []string {
+	keys := make([]string, 0, len(fileTypeMap))
+	for key := range fileTypeMap {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
 func ParseFileType(s string) (fileType, error) {
 	if ft, exists := fileTypeMap[s]; exists {
 		return ft, nil

--- a/llm/filetype.go
+++ b/llm/filetype.go
@@ -41,138 +41,54 @@ const (
 	fileTypeUnknown
 )
 
+var fileTypeMap = map[string]fileType{
+	"F32":      fileTypeF32,
+	"F16":      fileTypeF16,
+	"Q4_0":     fileTypeQ4_0,
+	"Q4_1":     fileTypeQ4_1,
+	"Q4_1_F16": fileTypeQ4_1_F16,
+	"Q8_0":     fileTypeQ8_0,
+	"Q5_0":     fileTypeQ5_0,
+	"Q5_1":     fileTypeQ5_1,
+	"Q2_K":     fileTypeQ2_K,
+	"Q3_K_S":   fileTypeQ3_K_S,
+	"Q3_K_M":   fileTypeQ3_K_M,
+	"Q3_K_L":   fileTypeQ3_K_L,
+	"Q4_K_S":   fileTypeQ4_K_S,
+	"Q4_K_M":   fileTypeQ4_K_M,
+	"Q5_K_S":   fileTypeQ5_K_S,
+	"Q5_K_M":   fileTypeQ5_K_M,
+	"Q6_K":     fileTypeQ6_K,
+	"IQ2_XXS":  fileTypeIQ2_XXS,
+	"IQ2_XS":   fileTypeIQ2_XS,
+	"Q2_K_S":   fileTypeQ2_K_S,
+	"IQ3_XS":   fileTypeIQ3_XS,
+	"IQ3_XXS":  fileTypeIQ3_XXS,
+	"IQ1_S":    fileTypeIQ1_S,
+	"IQ4_NL":   fileTypeIQ4_NL,
+	"IQ3_S":    fileTypeIQ3_S,
+	"IQ2_S":    fileTypeIQ2_S,
+	"IQ4_XS":   fileTypeIQ4_XS,
+	"IQ2_M":    fileTypeIQ2_M,
+	"IQ1_M":    fileTypeIQ1_M,
+	"BF16":     fileTypeBF16,
+}
+
 func ParseFileType(s string) (fileType, error) {
-	switch s {
-	case "F32":
-		return fileTypeF32, nil
-	case "F16":
-		return fileTypeF16, nil
-	case "Q4_0":
-		return fileTypeQ4_0, nil
-	case "Q4_1":
-		return fileTypeQ4_1, nil
-	case "Q4_1_F16":
-		return fileTypeQ4_1_F16, nil
-	case "Q8_0":
-		return fileTypeQ8_0, nil
-	case "Q5_0":
-		return fileTypeQ5_0, nil
-	case "Q5_1":
-		return fileTypeQ5_1, nil
-	case "Q2_K":
-		return fileTypeQ2_K, nil
-	case "Q3_K_S":
-		return fileTypeQ3_K_S, nil
-	case "Q3_K_M":
-		return fileTypeQ3_K_M, nil
-	case "Q3_K_L":
-		return fileTypeQ3_K_L, nil
-	case "Q4_K_S":
-		return fileTypeQ4_K_S, nil
-	case "Q4_K_M":
-		return fileTypeQ4_K_M, nil
-	case "Q5_K_S":
-		return fileTypeQ5_K_S, nil
-	case "Q5_K_M":
-		return fileTypeQ5_K_M, nil
-	case "Q6_K":
-		return fileTypeQ6_K, nil
-	case "IQ2_XXS":
-		return fileTypeIQ2_XXS, nil
-	case "IQ2_XS":
-		return fileTypeIQ2_XS, nil
-	case "Q2_K_S":
-		return fileTypeQ2_K_S, nil
-	case "IQ3_XS":
-		return fileTypeIQ3_XS, nil
-	case "IQ3_XXS":
-		return fileTypeIQ3_XXS, nil
-	case "IQ1_S":
-		return fileTypeIQ1_S, nil
-	case "IQ4_NL":
-		return fileTypeIQ4_NL, nil
-	case "IQ3_S":
-		return fileTypeIQ3_S, nil
-	case "IQ2_S":
-		return fileTypeIQ2_S, nil
-	case "IQ4_XS":
-		return fileTypeIQ4_XS, nil
-	case "IQ2_M":
-		return fileTypeIQ2_M, nil
-	case "IQ1_M":
-		return fileTypeIQ1_M, nil
-	case "BF16":
-		return fileTypeBF16, nil
-	default:
-		return fileTypeUnknown, fmt.Errorf("unknown fileType: %s", s)
+	if ft, exists := fileTypeMap[s]; exists {
+		return ft, nil
 	}
+	return fileTypeUnknown, fmt.Errorf("unknown fileType: %s", s)
 }
 
 func (t fileType) String() string {
-	switch t {
-	case fileTypeF32:
-		return "F32"
-	case fileTypeF16:
-		return "F16"
-	case fileTypeQ4_0:
-		return "Q4_0"
-	case fileTypeQ4_1:
-		return "Q4_1"
-	case fileTypeQ4_1_F16:
-		return "Q4_1_F16"
-	case fileTypeQ8_0:
-		return "Q8_0"
-	case fileTypeQ5_0:
-		return "Q5_0"
-	case fileTypeQ5_1:
-		return "Q5_1"
-	case fileTypeQ2_K:
-		return "Q2_K"
-	case fileTypeQ3_K_S:
-		return "Q3_K_S"
-	case fileTypeQ3_K_M:
-		return "Q3_K_M"
-	case fileTypeQ3_K_L:
-		return "Q3_K_L"
-	case fileTypeQ4_K_S:
-		return "Q4_K_S"
-	case fileTypeQ4_K_M:
-		return "Q4_K_M"
-	case fileTypeQ5_K_S:
-		return "Q5_K_S"
-	case fileTypeQ5_K_M:
-		return "Q5_K_M"
-	case fileTypeQ6_K:
-		return "Q6_K"
-	case fileTypeIQ2_XXS:
-		return "IQ2_XXS"
-	case fileTypeIQ2_XS:
-		return "IQ2_XS"
-	case fileTypeQ2_K_S:
-		return "Q2_K_S"
-	case fileTypeIQ3_XS:
-		return "IQ3_XS"
-	case fileTypeIQ3_XXS:
-		return "IQ3_XXS"
-	case fileTypeIQ1_S:
-		return "IQ1_S"
-	case fileTypeIQ4_NL:
-		return "IQ4_NL"
-	case fileTypeIQ3_S:
-		return "IQ3_S"
-	case fileTypeIQ2_S:
-		return "IQ2_S"
-	case fileTypeIQ4_XS:
-		return "IQ4_XS"
-	case fileTypeIQ2_M:
-		return "IQ2_M"
-	case fileTypeIQ1_M:
-		return "IQ1_M"
-	case fileTypeBF16:
-		return "BF16"
-	default:
-		return "unknown"
+
+	for str, ft := range fileTypeMap {
+		if ft == t {
+			return str
+		}
 	}
+	return "unknown"
 }
 
 func (t fileType) Value() uint32 {


### PR DESCRIPTION
This PR adds supported types list to the help message for `ollama create`


```console
$  go run main.go create -h
Create a model from a Modelfile

Usage:
  ollama create MODEL [flags]

Flags:
  -f, --file string       Name of the Modelfile (default "Modelfile")
  -h, --help              help for create
  -q, --quantize string   Quantize model to this level (e.g. q4_0)
                           Supported types:
                             BF16, F16, F32, IQ1_M, IQ1_S, IQ2_M
                             IQ2_S, IQ2_XS, IQ2_XXS, IQ3_S, IQ3_XS, IQ3_XXS
                             IQ4_NL, IQ4_XS, Q2_K, Q2_K_S, Q3_K_L, Q3_K_M
                             Q3_K_S, Q4_0, Q4_1, Q4_1_F16, Q4_K_M, Q4_K_S
                             Q5_0, Q5_1, Q5_K_M, Q5_K_S, Q6_K, Q8_0

Environment Variables:
      OLLAMA_HOST                IP Address for the ollama server (default 127.0.0.1:11434)
```