### PR TITLE
Refactor context shift flag for infinite text generation comment 

### DIFF
--- a/llama/common.h
+++ b/llama/common.h
@@ -272,7 +272,7 @@ struct gpt_params {
     bool cont_batching     = true;  // insert new sequences for decoding on-the-fly
     bool flash_attn        = false; // flash attention
     bool no_perf           = false; // disable performance metrics
-    bool ctx_shift         = true;  // context shift on inifinite text generation
+    bool ctx_shift         = true;  // context shift on infinite text generation
 
     bool input_prefix_bos  = false; // prefix BOS to user inputs, preceding input_prefix
     bool logits_all        = false; // return logits for all tokens in the batch


### PR DESCRIPTION
(should be
This pull request includes a minor correction to a comment in the `llama/common.h` file. The change fixes a typo in the comment for the `ctx_shift` parameter.

* [`llama/common.h`](diffhunk://#diff-670d1015c5d0908848f1f635691ebcc8372dc9a337ca0e93ad02abb72df998e3L275-R275): Corrected a typo in the comment for the `ctx_shift` parameter, changing "inifinite" to "infinite". "infinite") not inifinite