### PR TITLE
Add Ollama for Swift to the community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [High-level function abstraction in Go](https://gitlab.com/tozd/go/fun)
 - [Ollama PHP](https://github.com/ArdaGnsrn/ollama-php)
 - [Agents-Flex for Java](https://github.com/agents-flex/agents-flex) with [example](https://github.com/agents-flex/agents-flex/tree/main/agents-flex-llm/agents-flex-llm-ollama/src/test/java/com/agentsflex/llm/ollama)
+- [Ollama for Swift](https://github.com/mattt/ollama-swift)
 
 ### Mobile
 


### PR DESCRIPTION
This PR updates the README by adding a link to a [Swift client library](https://github.com/mattt/ollama-swift) I recently published.

I'm using it for a few internal projects, and thought it might be useful to anyone else who's building macOS apps with Ollama.

```swift
import Ollama

let response = try await Client.default.chat(
    model: "llama3.2",
    messages: [
        .system("You are a helpful assistant."),
        .user("Tell me a joke about the Swift programming language.")
    ]
)
print(response.message.content)
// "The best part about Swift's interoperability with Objective-C is realizing you now have two languages you don't fully understand."
```

