### PR TITLE
Fix unicode output on windows with redirect to file

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1318,7 +1318,7 @@ func NewCLI() *cobra.Command {
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 	cobra.EnableCommandSorting = false
 
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == "windows" && term.IsTerminal(int(os.Stdout.Fd())) {
 		console.ConsoleFromFile(os.Stdin) //nolint:errcheck
 	}
 


### PR DESCRIPTION
If we're not writing out to a terminal, avoid setting the console mode on windows, which corrupts the output file.

Fixes #3826 