### PR TITLE
Be quiet when redirecting output

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -456,6 +456,10 @@ func RunHandler(cmd *cobra.Command, args []string) error {
 	if len(prompts) > 0 {
 		interactive = false
 	}
+	// Be quiet if we're redirecting to a pipe or file
+	if !term.IsTerminal(int(os.Stdout.Fd())) {
+		interactive = false
+	}
 
 	nowrap, err := cmd.Flags().GetBool("nowordwrap")
 	if err != nil {


### PR DESCRIPTION
This avoids emitting the progress indicators to stderr, and the interactive prompts to the output file or pipe.  Running "ollama run model > out.txt" now exits immediately, and "echo hello | ollama run model > out.txt" produces zero stderr output and a typical response in out.txt

Example output from the echo pipe scenario:
```
% cat out.txt
Hello! It's nice to meet you. Is there something I can help you with, or would you like to chat?

```

Prior to this change "ollama run model > out.txt" would generate the progress spinners, but the prompt went to the file, so you have to type blind and you can enter prompts, then have to do `/bye` to exit the session, and the resulting output file looks something like this:
```
% cat out.txt
>>> hello
Hello! It's nice to meet you. Is there something I can help you with, or would you like to chat?

>>> /bye
```

Fixes #6120 