### PR TITLE
readme: add TextCraft to community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [LSP-AI](https://github.com/SilasMarvin/lsp-ai) (Open-source language server for AI-powered functionality)
 - [QodeAssist](https://github.com/Palm1r/QodeAssist) (AI-powered coding assistant plugin for Qt Creator)
 - [Obsidian Quiz Generator plugin](https://github.com/ECuiDev/obsidian-quiz-generator)
+- [TextCraft](https://github.com/suncloudsmoon/TextCraft) (Copilot in Word alternative using Ollama)
 
 ### Supported backends
 


### PR DESCRIPTION
Hey everyone! I've recently been working on an extension for Word that aims to be a local, privacy-friendly alternative to Microsoft 365 Copilot by utilizing Ollama as the backend. I would like to introduce TextCraft, which is an add-in for Word that seamlessly integrates essential AI tools, including text generation, proofreading, and more, directly into the user interface. I think it would be great if more people are aware of this local alternative to Copilot. Thank you.