### PR TITLE
Expose ROCm P2P workaround as runtime config

### DIFF
--- a/docs/gpu.md
+++ b/docs/gpu.md
@@ -114,5 +114,13 @@ In some Linux distributions, SELinux can prevent containers from
 accessing the AMD GPU devices.  On the host system you can run 
 `sudo setsebool container_use_devices=1` to allow containers to use devices.
 
-### Metal (Apple GPUs)
+### Multiple GPU Workarounds
+
+In some configurations, multiple AMD GPUs can generate gibberish responses due
+to bugs in peer-to-peer copy.  If you experience this behavior, set
+`OLLAMA_NO_PEER_COPY=1` for the server to disable peer-to-peer copying between
+the GPUs.  This will cause slower memory copy performance, so only enable if you
+experience gibberish responses.
+
+## Metal (Apple GPUs)
 Ollama supports GPU acceleration on Apple devices via the Metal API.

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -180,6 +180,7 @@ var (
 	RocrVisibleDevices    = String("ROCR_VISIBLE_DEVICES")
 	GpuDeviceOrdinal      = String("GPU_DEVICE_ORDINAL")
 	HsaOverrideGfxVersion = String("HSA_OVERRIDE_GFX_VERSION")
+	ROCmP2PWorkaround     = String("OLLAMA_NO_PEER_COPY")
 )
 
 func Uint(key string, defaultValue uint) func() uint {
@@ -270,6 +271,7 @@ func AsMap() map[string]EnvVar {
 		ret["GPU_DEVICE_ORDINAL"] = EnvVar{"GPU_DEVICE_ORDINAL", GpuDeviceOrdinal(), "Set which AMD devices are visible by numeric ID"}
 		ret["HSA_OVERRIDE_GFX_VERSION"] = EnvVar{"HSA_OVERRIDE_GFX_VERSION", HsaOverrideGfxVersion(), "Override the gfx used for all detected AMD GPUs"}
 		ret["OLLAMA_INTEL_GPU"] = EnvVar{"OLLAMA_INTEL_GPU", IntelGPU(), "Enable experimental Intel GPU detection"}
+		ret["OLLAMA_NO_PEER_COPY"] = EnvVar{"OLLAMA_NO_PEER_COPY", ROCmP2PWorkaround(), "Workaround ROCm P2P copy bugs on multi-GPU"}
 	}
 
 	return ret

--- a/llama/patches/0013-no-peer-copy-workaround-at-runtime.patch
+++ b/llama/patches/0013-no-peer-copy-workaround-at-runtime.patch
@@ -1,0 +1,66 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Daniel Hiltgen <daniel@ollama.com>
+Date: Sat, 26 Oct 2024 15:10:42 -0700
+Subject: [PATCH] no peer copy workaround at runtime
+
+Switch the logic from compile time to runtime for working
+around buggy rocm p2p copy on multi-GPU setups.
+---
+ ggml/src/ggml-cuda.cu | 18 +++++++++---------
+ 1 file changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/ggml/src/ggml-cuda.cu b/ggml/src/ggml-cuda.cu
+index 6e84af56..d8c5b100 100644
+--- a/ggml/src/ggml-cuda.cu
++++ b/ggml/src/ggml-cuda.cu
+@@ -531,11 +531,11 @@ GGML_CALL static bool ggml_backend_cuda_buffer_cpy_tensor(ggml_backend_buffer_t
+         if (src_ctx->device == dst_ctx->device) {
+             CUDA_CHECK(cudaMemcpyAsync(dst->data, src->data, ggml_nbytes(src), cudaMemcpyDeviceToDevice, cudaStreamPerThread));
+         } else {
+-#ifdef GGML_CUDA_NO_PEER_COPY
++            if (getenv("OLLAMA_NO_PEER_COPY")) {
+             return false;
+-#else
++            } else {
+             CUDA_CHECK(cudaMemcpyPeerAsync(dst->data, dst_ctx->device, src->data, src_ctx->device, ggml_nbytes(src), cudaStreamPerThread));
+-#endif
++            }
+         }
+         CUDA_CHECK(cudaStreamSynchronize(cudaStreamPerThread));
+         return true;
+@@ -2452,11 +2452,11 @@ GGML_CALL static bool ggml_backend_cuda_cpy_tensor_async(ggml_backend_t backend_
+         if (cuda_ctx_src->device == cuda_ctx_dst->device) {
+             CUDA_CHECK(cudaMemcpyAsync(dst->data, src->data, ggml_nbytes(dst), cudaMemcpyDeviceToDevice, cuda_ctx_src->stream()));
+         } else {
+-#ifdef GGML_CUDA_NO_PEER_COPY
++            if (getenv("OLLAMA_NO_PEER_COPY")) {
+             return false;
+-#else
++            } else {
+             CUDA_CHECK(cudaMemcpyPeerAsync(dst->data, cuda_ctx_dst->device, src->data, cuda_ctx_src->device, ggml_nbytes(dst), cuda_ctx_src->stream()));
+-#endif
++            }
+         }
+ 
+         // record event on src stream after the copy
+@@ -3052,9 +3052,9 @@ GGML_CALL static bool ggml_backend_cuda_offload_op(ggml_backend_t backend, const
+ }
+ 
+ static ggml_backend_event_t ggml_backend_cuda_event_new(ggml_backend_t backend) {
+-#ifdef GGML_CUDA_NO_PEER_COPY
++    if (getenv("OLLAMA_NO_PEER_COPY")) {
+     return nullptr;
+-#else
++    } else {
+     ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *)backend->context;
+ 
+     ggml_cuda_set_device(cuda_ctx->device);
+@@ -3066,7 +3066,7 @@ static ggml_backend_event_t ggml_backend_cuda_event_new(ggml_backend_t backend)
+         /* .backend = */ backend,
+         /* .context = */ event,
+     };
+-#endif
++    }
+ }
+ 
+ static void ggml_backend_cuda_event_free(ggml_backend_event_t event) {


### PR DESCRIPTION
We have toggled GGML_CUDA_NO_PEER_COPY back and forth a few times over the past few months and ultimately it seems that **with the workaround**, systems with less physical RAM than VRAM crash, and **without the workaround**, some multi-GPU systems generate gibberish.  With the current llama.cpp code, we can't ship a single binary and keep both sets of users happy.

Instead of compiling in support for the P2P workaround, make it available as a runtime configuration so we can ship a single binary that will work in both cases (small system memory and multi-GPU with buggy P2P copy)

Marking draft until I can answer a few questions:
- I'm hoping we can find a simpler env var or setting in ROCm to avoid carrying this patch
- Failing the above, if we can find a way to "know" that P2P will be buggy on a system, I'd prefer to enable automatically instead of requiring the user to set this manually, but I'm not sure if that will be possible or reliable, and this setting will have a negative performance impact if P2P is working properly

Fixes #6595 
Fixes #5629 
Fixes #7433
Fixes #7461 