### PR TITLE
Add Swollama links to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Ollama eBook Summary](https://github.com/cognitivetech/ollama-ebook-summary/)
 - [Ollama Mixture of Experts (MOE) in 50 lines of code](https://github.com/rapidarchitect/ollama_moe)
 - [vim-intelligence-bridge](https://github.com/pepo-ec/vim-intelligence-bridge) Simple interaction of "Ollama" with the Vim editor
+- [SwollamaCLI](https://github.com/marcusziade/Swollama) bundled with the Swollama Swift package. [Demo](https://github.com/marcusziade/Swollama?tab=readme-ov-file#cli-usage)
 
 ### Apple Vision Pro
 - [Enchanted](https://github.com/AugustDev/enchanted)
@@ -413,6 +414,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Ollama PHP](https://github.com/ArdaGnsrn/ollama-php)
 - [Agents-Flex for Java](https://github.com/agents-flex/agents-flex) with [example](https://github.com/agents-flex/agents-flex/tree/main/agents-flex-llm/agents-flex-llm-ollama/src/test/java/com/agentsflex/llm/ollama)
 - [Ollama for Swift](https://github.com/mattt/ollama-swift)
+- [Swollama for Swift](https://github.com/marcusziade/Swollama) with [DocC](https://marcusziade.github.io/Swollama/documentation/swollama/)
 
 ### Mobile
 


### PR DESCRIPTION
This PR updates the README by adding a link to a feature-complete Swift client library I built.

I have _extensive_ documentation in [DocC](https://marcusziade.github.io/Swollama/documentation/swollama/), and I already have a draft PR open for Linux and Docker support.

The CLI is also purely written in Swift without dependencies and has a cyberpunk theme:


![CleanShot 2024-10-27 at 15 12 39](https://github.com/user-attachments/assets/4e3ac529-a0aa-4ae2-82d8-e374cbabc166)

![CleanShot 2024-10-27 at 15 19 34](https://github.com/user-attachments/assets/3b3c4b40-caa0-40c2-8e4c-c7172519649c)



