### PR TITLE
Switch windows to clang

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -296,10 +296,13 @@ The following tools are required as a minimal development environment to build C
   - https://go.dev/dl/
 - Git
   - https://git-scm.com/download/win
-- GCC and Make.  There are multiple options on how to go about installing these tools on Windows.  We have verified the following, but others may work as well:  
+- clang with gcc compat and Make.  There are multiple options on how to go about installing these tools on Windows.  We have verified the following, but others may work as well:  
   - [MSYS2](https://www.msys2.org/)
-    - After installing, from an MSYS2 terminal, run `pacman -S mingw-w64-ucrt-x86_64-gcc make` to install the required tools
-  - Assuming you used the default install prefix for msys2 above, add `c:\msys64\ucrt64\bin` and `c:\msys64\usr\bin` to your environment variable `PATH` where you will perform the build steps below (e.g. system-wide, account-level, powershell, cmd, etc.)
+    - After installing, from an MSYS2 terminal, run `pacman -S mingw-w64-clang-x86_64-gcc-compat mingw-w64-clang-x86_64-clang make` to install the required tools
+  - Assuming you used the default install prefix for msys2 above, add `C:\msys64\clang64\bin` and `c:\msys64\usr\bin` to your environment variable `PATH` where you will perform the build steps below (e.g. system-wide, account-level, powershell, cmd, etc.)
+
+> [!NOTE]  
+> Due to bugs in the GCC C++ library for unicode support, Ollama requires clang on windows.  If the gcc executable in your path is not the clang compatibility wrapper, the build will error.
 
 Then, build the `ollama` binary:
 

--- a/llama/make/common-defs.make
+++ b/llama/make/common-defs.make
@@ -57,6 +57,10 @@ ifeq ($(OS),windows)
 	EXE_EXT := .exe
 	SHARED_PREFIX := 
 	CPU_FLAG_PREFIX := /arch:
+	_GCC_TEST:=$(findstring clang,$(shell gcc --version))
+	ifneq ($(_GCC_TEST),clang)
+$(error WRONG COMPILER DETECTED $(shell type gcc) - gcc must be a clang compat compiler on windows - see docs/development.md for setup instructions)
+	endif
 ifneq ($(HIP_PATH),)
 	# If HIP_PATH has spaces, hipcc trips over them when subprocessing
 	HIP_PATH := $(shell cygpath -m -s "$(patsubst %\,%,$(HIP_PATH))")


### PR DESCRIPTION
The recent deepseek patch for windows only works if built with clang.

CI changes carried on #7157 - it doesn't appear the clang installed in the standard github runner windows image has the gcc compat wrapper, so we'll use msys2 to get that installed.  While make is already present, I went ahead and replicated the documented instructions for completeness.

```yaml
      - name: Install msys2
        run: |
          $msys2_url="https://github.com/msys2/msys2-installer/releases/download/2024-07-27/msys2-x86_64-20240727.exe"
          write-host "Downloading msys2"
          Invoke-WebRequest -Uri "${msys2_url}" -OutFile "${env:RUNNER_TEMP}\msys2.exe"
          write-host "Installing msys2"
          Start-Process "${env:RUNNER_TEMP}\msys2.exe" -ArgumentList @("in", "--confirm-command", "--accept-messages", "--root", "C:/msys64") -NoNewWindow -Wait
          echo "c:\msys64\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
      - name: Install msys2 tools
        run: |
          Start-Process "c:\msys64\usr\bin\pacman.exe" -ArgumentList @("-S", "--noconfirm", "mingw-w64-clang-x86_64-gcc-compat", "mingw-w64-clang-x86_64-clang", "make") -NoNewWindow -Wait
          echo "C:\msys64\clang64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
      - name: verify tools
        run: |
          get-command gcc
          gcc --version
          get-command make
          make --version
```