### PR TITLE
Soften windows clang requirement

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -115,6 +115,7 @@ jobs:
           $env:CMAKE_SYSTEM_VERSION="10.0.22621.0"
           $env:PATH="$gopath;$env:PATH"
           $cores = (Get-ComputerInfo -Property CsProcessors).CsProcessors.NumberOfCores
+          if (!(gcc --version | select-string -quiet clang)) { throw "wrong gcc compiler detected - must be clang" }
           make -j $cores
         name: make
       - uses: actions/upload-artifact@v4
@@ -201,6 +202,7 @@ jobs:
           $env:OLLAMA_SKIP_CPU_GENERATE="1"
           $env:HIP_PATH=$(Resolve-Path 'C:\Program Files\AMD\ROCm\*\bin\clang.exe' | split-path | split-path)
           $cores = (Get-ComputerInfo -Property CsProcessors).CsProcessors.NumberOfCores
+          if (!(gcc --version | select-string -quiet clang)) { throw "wrong gcc compiler detected - must be clang" }
           make -j $cores
         name: make
       - uses: actions/upload-artifact@v4
@@ -299,6 +301,7 @@ jobs:
           $env:PATH="$gopath;$cudabin;$env:PATH"
           $env:OLLAMA_SKIP_CPU_GENERATE="1"
           $cores = (Get-ComputerInfo -Property CsProcessors).CsProcessors.NumberOfCores
+          if (!(gcc --version | select-string -quiet clang)) { throw "wrong gcc compiler detected - must be clang" }
           make -j $cores
       - uses: actions/upload-artifact@v4
         with:
@@ -545,6 +548,7 @@ jobs:
           $env:PATH="$gopath;$env:PATH"
           $env:OLLAMA_SKIP_GENERATE="1"
           $env:ARCH="amd64"
+          if (!(gcc --version | select-string -quiet clang)) { throw "wrong gcc compiler detected - must be clang" }
           & .\scripts\build_windows.ps1
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -138,6 +138,7 @@ jobs:
           $env:HIP_PATH=$(Resolve-Path 'C:\Program Files\AMD\ROCm\*\bin\clang.exe' | split-path | split-path)
           $cores = (Get-ComputerInfo -Property CsProcessors).CsProcessors.NumberOfCores
           write-host $env:HIP_PATH
+          if (!(gcc --version | select-string -quiet clang)) { throw "wrong gcc compiler detected - must be clang" }
           make -C llama print-HIP_PATH print-HIP_LIB_DIR
           make -j $cores rocm
         name: make
@@ -198,6 +199,7 @@ jobs:
           $env:PATH="$gopath;$cudabin;$env:PATH"
           $env:OLLAMA_SKIP_CPU_GENERATE="1"
           $cores = (Get-ComputerInfo -Property CsProcessors).CsProcessors.NumberOfCores
+          if (!(gcc --version | select-string -quiet clang)) { throw "wrong gcc compiler detected - must be clang" }
           make -j $cores cuda_v11
         env:
           OLLAMA_SKIP_CPU_GENERATE: '1'
@@ -257,6 +259,7 @@ jobs:
           $env:CMAKE_SYSTEM_VERSION="10.0.22621.0"
           $env:PATH="$gopath;$gccpath;$env:PATH"
           echo $env:PATH
+          if (!(gcc --version | select-string -quiet clang)) { throw "wrong gcc compiler detected - must be clang" }
           make -j 4      
       - name: 'Build Unix Go Runners'
         if: ${{ ! startsWith(matrix.os, 'windows-') }}

--- a/docs/development.md
+++ b/docs/development.md
@@ -124,7 +124,7 @@ The following tools are required as a minimal development environment to build C
   - Assuming you used the default install prefix for msys2 above, add `C:\msys64\clang64\bin` and `c:\msys64\usr\bin` to your environment variable `PATH` where you will perform the build steps below (e.g. system-wide, account-level, powershell, cmd, etc.)
 
 > [!NOTE]  
-> Due to bugs in the GCC C++ library for unicode support, Ollama requires clang on windows.  If the gcc executable in your path is not the clang compatibility wrapper, the build will error.
+> Due to bugs in the GCC C++ library for unicode support, Ollama should be built with clang on windows.
 
 Then, build the `ollama` binary:
 

--- a/llama/llama.go
+++ b/llama/llama.go
@@ -68,6 +68,17 @@ package llama
 #include "sampling_ext.h"
 
 bool llamaProgressCallback(float progress, void *user_data);
+
+typedef enum {COMP_UNKNOWN,COMP_GCC,COMP_CLANG} COMPILER;
+COMPILER inline get_compiler() {
+#if defined(__clang__)
+	return COMP_CLANG;
+#elif defined(__GNUC__)
+	return COMP_GCC;
+#else
+	return UNKNOWN_COMPILER;
+#endif
+}
 */
 import "C"
 
@@ -88,7 +99,16 @@ func BackendInit() {
 }
 
 func PrintSystemInfo() string {
-	return C.GoString(C.llama_print_system_info())
+	var compiler string
+	switch C.get_compiler() {
+	case C.COMP_UNKNOWN:
+		compiler = "cgo(unknown_compiler)"
+	case C.COMP_GCC:
+		compiler = "cgo(gcc)"
+	case C.COMP_CLANG:
+		compiler = "cgo(clang)"
+	}
+	return C.GoString(C.llama_print_system_info()) + compiler
 }
 
 type ContextParams struct {

--- a/llama/make/common-defs.make
+++ b/llama/make/common-defs.make
@@ -57,10 +57,6 @@ ifeq ($(OS),windows)
 	EXE_EXT := .exe
 	SHARED_PREFIX := 
 	CPU_FLAG_PREFIX := /arch:
-	_GCC_TEST:=$(findstring clang,$(shell gcc --version))
-	ifneq ($(_GCC_TEST),clang)
-$(error WRONG COMPILER DETECTED $(shell type gcc) - gcc must be a clang compat compiler on windows - see docs/development.md for setup instructions)
-	endif
 ifneq ($(HIP_PATH),)
 	# If HIP_PATH has spaces, hipcc trips over them when subprocessing
 	HIP_PATH := $(shell cygpath -m -s "$(patsubst %\,%,$(HIP_PATH))")

--- a/llama/runner/runner.go
+++ b/llama/runner/runner.go
@@ -874,7 +874,7 @@ func main() {
 	})
 	slog.SetDefault(slog.New(handler))
 	slog.Info("starting go runner")
-	slog.Debug("system info", "cpu", llama.PrintSystemInfo(), "threads", *threads)
+	slog.Info("system", "info", llama.PrintSystemInfo(), "threads", *threads)
 
 	server := &Server{
 		batchSize: *batchSize,


### PR DESCRIPTION
This will no longer error if built with regular gcc on windows.  To help triage issues that may come in related to different compilers, the runner now reports the compiler used by cgo.

Example runner output when compiled with GCC
```
time=2024-10-30T11:29:49.863-07:00 level=INFO source=runner.go:877 msg=system info="AVX = 1 | AVX_VNNI = 0 | AVX2 = 0 | AVX512 = 0 | AVX512_VBMI = 0 | AVX512_VNNI = 0 | AVX512_BF16 = 0 | FMA = 0 | NEON = 0 | SVE = 0 | ARM_FMA = 0 | F16C = 0 | FP16_VA = 0 | RISCV_VECT = 0 | WASM_SIMD = 0 | BLAS = 1 | SSE3 = 1 | SSSE3 = 1 | VSX = 0 | MATMUL_INT8 = 0 | LLAMAFILE = 1 | cgo(gcc)" threads=16
```

and with clang:
```
time=2024-10-30T11:33:00.866-07:00 level=INFO source=runner.go:877 msg=system info="AVX = 1 | AVX_VNNI = 0 | AVX2 = 0 | AVX512 = 0 | AVX512_VBMI = 0 | AVX512_VNNI = 0 | AVX512_BF16 = 0 | FMA = 0 | NEON = 0 | SVE = 0 | ARM_FMA = 0 | F16C = 0 | FP16_VA = 0 | RISCV_VECT = 0 | WASM_SIMD = 0 | BLAS = 1 | SSE3 = 1 | SSSE3 = 1 | VSX = 0 | MATMUL_INT8 = 0 | LLAMAFILE = 1 | cgo(clang)" threads=16
```