### PR TITLE
Add Perfect Memory AI to community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [ARGO](https://github.com/xark-argo/argo) (Locally download and run Ollama and Huggingface models with RAG on Mac/Windows/Linux)
 - [G1](https://github.com/bklieger-groq/g1) (Prototype of using prompting strategies to improve the LLM's reasoning through o1-like reasoning chains.)
 - [Ollama App](https://github.com/JHubi1/ollama-app) (Modern and easy-to-use multi-platform client for Ollama)
+- [Perfect Memory AI](https://www.perfectmemory.ai/) (Productivity AI assists personalized by what you have seen on your screen, heard and said in the meetings)
 
 ### Terminal
 


### PR DESCRIPTION
I added Perfect Memory AI to community integrations.

Perfect Memory uses Ollama as an AI provider for offline inference. https://www.perfectmemory.ai/support/ai-assistant/ollama-setup
