### PR TITLE
Fix FAQ link to download Ollama

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,7 +2,7 @@
 
 ## How can I upgrade Ollama?
 
-Ollama on macOS and Windows will automatically download updates. Click on the taskbar or menubar item and then click "Restart to update" to apply the update. Updates can also be installed by downloading the latest version [manually](https://ollama.com/download/).
+Ollama on macOS and Windows will automatically download updates. Click on the taskbar or menubar item and then click "Restart to update" to apply the update. Updates can also be installed by downloading the latest version [manually](https://ollama.com/download).
 
 On Linux, re-run the install script:
 


### PR DESCRIPTION
The current link is a 404. <!--Also I'm annoyed because the FAQ says that Windows versions automatically update but I just discovered I am MANY versions behind. Huh. It never occurred to me to just hide text on GitHub like this. That's convenient.-->