### PR TITLE
Workaround buggy P2P ROCm copy on windows

### DIFF
--- a/llama/make/Makefile.rocm
+++ b/llama/make/Makefile.rocm
@@ -87,6 +87,12 @@ GPU_COMPILER_CUFLAGS = \
 	-Wno-unused-result \
 	-I.
 
+# Workaround buggy P2P copy on some windows multi-GPU setups
+# This workaround breaks linux systems with small system RAM, so only enable on windows
+ifeq ($(OS),windows)
+	GPU_COMPILER_CUFLAGS += -DGGML_CUDA_NO_PEER_COPY=1
+endif
+
 include make/gpu.make
 
 # Adjust the rules from gpu.make to handle the ROCm dependencies properly


### PR DESCRIPTION
This enables the workaround code only for windows which should help windows users with muliple AMD GPUs

While testing #7378 I've only been able to reproduce the gibberish behavior on one system and only on Windows.  Windows ROCm shouldn't allow smaller system memory compared to VRAM, so we believe enabling this flag is safe.  (On linux, if we enable this flag, it breaks users with less RAM than VRAM when they try to load a model)

Fixes #7461 