### PR TITLE
Add a command to clear the screen

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -38,6 +38,7 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 		fmt.Fprintln(os.Stderr, "  /load <model>   Load a session or model")
 		fmt.Fprintln(os.Stderr, "  /save <model>   Save your current session")
 		fmt.Fprintln(os.Stderr, "  /clear          Clear session context")
+		fmt.Fprintln(os.Stderr, "  /clearscreen    Clear the screen")
 		fmt.Fprintln(os.Stderr, "  /bye            Exit")
 		fmt.Fprintln(os.Stderr, "  /?, /help       Help for a command")
 		fmt.Fprintln(os.Stderr, "  /? shortcuts    Help for keyboard shortcuts")
@@ -76,7 +77,7 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 		fmt.Fprintln(os.Stderr, "  Ctrl + u            Delete the sentence before the cursor")
 		fmt.Fprintln(os.Stderr, "  Ctrl + w            Delete the word before the cursor")
 		fmt.Fprintln(os.Stderr, "")
-		fmt.Fprintln(os.Stderr, "  Ctrl + l            Clear the screen")
+		fmt.Fprintln(os.Stderr, "  Ctrl + l            Clear the screen (/clearscreen)")
 		fmt.Fprintln(os.Stderr, "  Ctrl + c            Stop the model from responding")
 		fmt.Fprintln(os.Stderr, "  Ctrl + d            Exit ollama (/bye)")
 		fmt.Fprintln(os.Stderr, "")
@@ -227,6 +228,11 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 				return err
 			}
 			fmt.Printf("Created new model '%s'\n", args[1])
+			continue
+		case strings.HasPrefix(line, "/clearscreen"):
+			// Clear the screen with ANSI escape codes
+			// https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797
+			fmt.Print("\033[H\033[2J")
 			continue
 		case strings.HasPrefix(line, "/clear"):
 			opts.Messages = []api.Message{}


### PR DESCRIPTION
`/clearscreen` clears the screen
Kind of like Ctrl+L
I use [ansi escape codes](https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797) because I don't want to deal with the buffer

I made this because I have Ctrl+L bound to something else and wanted a quick slash command similar to `/clear`