### PR TITLE
Fix: return direct URL when OCI registry is not redirecting

### DIFF
--- a/server/download.go
+++ b/server/download.go
@@ -259,7 +259,11 @@ func (b *blobDownload) run(ctx context.Context, requestURL *url.URL, opts *regis
 			if resp.StatusCode != http.StatusTemporaryRedirect && resp.StatusCode != http.StatusOK {
 				return nil, fmt.Errorf("unexpected status code %d", resp.StatusCode)
 			}
-			return resp.Location()
+			loc, err := resp.Location()
+			if loc == nil {
+				return requestURL, nil
+			}
+			return loc, err
 		}
 	}()
 	if err != nil {


### PR DESCRIPTION
When debugging why I couldn't use a regular OCI registry (See screenshot below), I found out the ollama server was doing a redirect to AWS. This change returns the direct URL when such redirect does not happen, while assuring regular behavior when it does, so that regular pulls still work!

<img width="1710" alt="SCR-20241102-rgnu" src="https://github.com/user-attachments/assets/26c97b1e-f0d6-4b9f-82ac-a33e14f64fb3">

This PR fixes https://github.com/ollama/ollama/issues/7244