### PR TITLE
Add action for publishing package to WinGet

### DIFF
--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -1,0 +1,29 @@
+name: Submit Ollama package to WinGet community repository
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  publish-winget:
+    name: Publish to winget repository
+    runs-on: windows-latest
+    steps:
+      - name: Sync fork
+        run: gh repo sync <repo-owner>/winget-pkgs -b master
+        env:
+          GH_TOKEN: ${{ secrets.WINGET_GITHUB_TOKEN }}
+      - name: Submit package using wingetcreate
+        run: |
+          $packageId = "Ollama.Ollama"
+
+          # Fetching latest stable release from GitHub
+          $github = Invoke-RestMethod -uri "https://api.github.com/repos/ollama/ollama/releases"
+          $targetRelease = $github | Where-Object {$_.prerelease -eq $false} | Select-Object -First 1
+          $installerUrl = $targetRelease | Select-Object -ExpandProperty assets -First 1 | Where-Object -Property name -eq 'OllamaSetup.exe' | Select-Object -ExpandProperty browser_download_url
+          $packageVersion = $targetRelease.tag_name.Trim("v")
+
+          # Update package using wingetcreate
+          Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          .\wingetcreate.exe update $packageId --version $packageVersion --urls "$installerUrl|x64" --submit --token "${{ secrets.WINGET_GITHUB_TOKEN }}"


### PR DESCRIPTION
## Description

This PR proposes to add a GitHub action for submitting the latest stable release to WinGet as it gets published. [microsoft/winget-create](https://github.com/microsoft/winget-create) is used as the tool for submitting the latest package.

## Steps needed from maintainers

If the maintainers approve of these changes, they will need to do the following before merging this PR:

1. Fork [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) under a personal or bot account.
2. Create a [public access token (classic)](https://github.com/microsoft/winget-create?tab=readme-ov-file#github-personal-access-token-classic-permissions) with `public_repo` scope from the user account where the fork exists.
3. Create a repo secret in this repo with the name `WINGET_GITHUB_TOKEN`


For reference, maintainers may see similar implemented actions in the following repos:
[PowerToys](https://github.com/microsoft/PowerToys/blob/main/.github/workflows/package-submissions.yml), [Terminal](https://github.com/microsoft/terminal/blob/main/.github/workflows/winget.yml), [DevHome](https://github.com/microsoft/devhome/blob/main/.github/workflows/winget-submission.yml), [Oh-my-posh](https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/.github/workflows/winget.yml)