### PR TITLE
CI: fix matrix wiring

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,10 +3,6 @@ name: release
 env:
   ROCM_WINDOWS_URL: https://download.amd.com/developer/eula/rocm-hub/AMD-Software-PRO-Edition-24.Q3-WinSvr2022-For-HIP.exe
   MSYS2_URL: https://github.com/msys2/msys2-installer/releases/download/2024-07-27/msys2-x86_64-20240727.exe
-  CUDA_12_WINDOWS_URL: https://developer.download.nvidia.com/compute/cuda/12.4.0/local_installers/cuda_12.4.0_551.61_windows.exe
-  CUDA_12_WINDOWS_VER: 12.4
-  CUDA_11_WINDOWS_URL: https://developer.download.nvidia.com/compute/cuda/11.3.1/local_installers/cuda_11.3.1_465.89_win10.exe
-  CUDA_11_WINDOWS_VER: 11.3
 
 on:
   push:
@@ -163,10 +159,10 @@ jobs:
     strategy:
       matrix:
         cuda:
-          - version: "${{ env.CUDA_11_WINDOWS_VER }}"
-            url: ${{ env.CUDA_11_WINDOWS_URL }}
-          - version: "${{ env.CUDA_12_WINDOWS_VER }}"
-            url: ${{ env.CUDA_12_WINDOWS_URL }}
+          - version: "11.3"
+            url: https://developer.download.nvidia.com/compute/cuda/11.3.1/local_installers/cuda_11.3.1_465.89_win10.exe
+          - version: "12.4"
+            url: https://developer.download.nvidia.com/compute/cuda/12.4.0/local_installers/cuda_12.4.0_551.61_windows.exe
     env:
       KEY_CONTAINER: ${{ vars.KEY_CONTAINER }}
     steps:
@@ -456,10 +452,10 @@ jobs:
           name: generate-windows-cpu
       - uses: actions/download-artifact@v4
         with:
-          name: generate-windows-cuda-${{ env.CUDA_11_WINDOWS_VER }}
+          name: generate-windows-cuda-11.3
       - uses: actions/download-artifact@v4
         with:
-          name: generate-windows-cuda-${{ env.CUDA_12_WINDOWS_VER }}
+          name: generate-windows-cuda-12.4
       - uses: actions/download-artifact@v4
         with:
           name: generate-windows-rocm


### PR DESCRIPTION
Matrix strategies can't use env vars so unwind the prior changes to dry the definitions out a little.


Fixes release CI error:
```
[Invalid workflow file: .github/workflows/release.yaml#L166](https://github.com/ollama/ollama/actions/runs/11670233094/workflow)
The workflow is not valid. .github/workflows/release.yaml (Line: 166, Col: 22): Unrecognized named-value: 'env'. Located at position 1 within expression: env.CUDA_11_WINDOWS_VER .github/workflows/release.yaml (Line: 167, Col: 18): Unrecognized named-value: 'env'. Located at position 1 within expression: env.CUDA_11_WINDOWS_URL
```