### PR TITLE
Readme: Add Hexabot the to community integrations 

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [ARGO](https://github.com/xark-argo/argo) (Locally download and run Ollama and Huggingface models with RAG on Mac/Windows/Linux)
 - [G1](https://github.com/bklieger-groq/g1) (Prototype of using prompting strategies to improve the LLM's reasoning through o1-like reasoning chains.)
 - [Ollama App](https://github.com/JHubi1/ollama-app) (Modern and easy-to-use multi-platform client for Ollama)
+- [Hexabot](https://github.com/hexastack/hexabot) (A conversational AI builder)
 
 ### Terminal
 


### PR DESCRIPTION
## Motivation

Added Hexabot to the community integrations.

- A Hexabot extension for Hexabot has been developed : https://github.com/Hexastack/Hexabot-plugin-ollama
- Ollama is the default LLM provider when creating a fresh project.
- Demo : https://youtu.be/hyJW6JGCga4
