### PR TITLE
grammar: surgically wrenching gbnf from system messages

### DIFF
--- a/llm/server.go
+++ b/llm/server.go
@@ -676,6 +676,7 @@ type completion struct {
 type CompletionRequest struct {
 	Prompt  string
 	Format  string
+	Grammar string
 	Images  []ImageData
 	Options *api.Options
 }
@@ -726,6 +727,7 @@ func (s *llmServer) Completion(ctx context.Context, req CompletionRequest, fn fu
 		"stop":              req.Options.Stop,
 		"image_data":        req.Images,
 		"cache_prompt":      true,
+		"grammar":           req.Grammar,
 	}
 
 	// Make sure the server is ready

--- a/server/grammar.go
+++ b/server/grammar.go
@@ -1,0 +1,53 @@
+package server
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+
+	"github.com/ollama/ollama/api"
+)
+
+// wrenchGrammarFrom extracts the grammar from the system message, and
+// returns it. If the grammar is not found, it returns an empty string.
+// If there's more than one grammar in the system message, it returns an
+// error.
+//
+// NOTE: will mutate the system message if, and only if grammar is set!
+func wrenchGrammarFrom(msgs []api.Message) (string, error) {
+	for i, m := range msgs {
+		if m.Role != "system" {
+			continue
+		}
+		s, g := surgeryOnGrape(m.Content, "gbnf")
+		switch len(g) {
+		case 0:
+		case 1:
+			msgs[i].Content = s
+			return g[0], nil
+		default:
+			return "", errors.New("too many grammars in the system prompt")
+		}
+	}
+	return "", nil
+}
+
+// wrench Markdown code blocks for language `lang` out of source text `md`
+func surgeryOnGrape(md, lang string) (string, []string) {
+	if !strings.Contains(md, "```"+lang) {
+		return md, nil
+	}
+	pattern := "(?ms)(?:\n)?```" + lang + "\n(.*?)\n```(?:\n)?"
+	re := regexp.MustCompile(pattern)
+	var blocks []string
+	for _, match := range re.FindAllStringSubmatch(md, -1) {
+		if len(match) > 1 {
+			// match[1] contains the code content without the markers
+			blocks = append(blocks, strings.ReplaceAll(match[1], "\\`", "`"))
+		}
+	}
+	if blocks == nil {
+		return md, nil
+	}
+	return strings.TrimSpace(re.ReplaceAllString(md, "")), blocks
+}

--- a/server/grammar_test.go
+++ b/server/grammar_test.go
@@ -1,0 +1,63 @@
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestSurgeryOnGrape(t *testing.T) {
+	testdata := filepath.Join("testdata", "grammar")
+	ls, err := os.ReadDir(testdata)
+	if err != nil {
+		t.Fatal(err)
+	}
+	type testcase struct {
+		filename string
+		lang     string
+		before   string
+		after    string
+		blocks   []string
+	}
+	var cases []testcase
+	for _, f := range ls {
+		if f.IsDir() || !strings.HasSuffix(f.Name(), ".txt") {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(testdata, f.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := strings.Split(string(b), "\n^^^\n")
+		if len(s) < 3 {
+			t.Fatalf("incomplete test file %s", f.Name())
+		}
+		cases = append(cases, testcase{
+			filename: f.Name(),
+			lang:     s[0],
+			before:   strings.TrimSpace(s[1]),
+			after:    strings.TrimSpace(s[2]),
+			blocks:   s[3:],
+		})
+	}
+	for _, tc := range cases {
+		t.Run(tc.filename, func(t *testing.T) {
+			after, blocks := surgeryOnGrape(tc.before, tc.lang)
+			if diff := cmp.Diff(after, tc.after); diff != "" {
+				t.Errorf("mismatch (-got +want):\n%s", diff)
+			}
+			if len(blocks) != len(tc.blocks) {
+				t.Fatalf("expected %d blocks, got %d", len(tc.blocks), len(blocks))
+			}
+			for i := range blocks {
+				want := strings.TrimSpace(tc.blocks[i])
+				if diff := cmp.Diff(blocks[i], want); diff != "" {
+					t.Errorf("mismatch (-got +want) at block i=%d:\n%s", i, diff)
+				}
+			}
+		})
+	}
+}

--- a/server/testdata/grammar/gbnf.txt
+++ b/server/testdata/grammar/gbnf.txt
@@ -1,0 +1,21 @@
+gbnf
+^^^
+You are helpful assistant.
+
+```gbnf
+root  ::= (expr "=" ws term "\n")+
+expr  ::= term ([-+*/] term)*
+term  ::= ident | num | "(" ws expr ")" ws
+ident ::= [a-z] [a-z0-9_]* ws
+num   ::= [0-9]+ ws
+ws    ::= [ \t\n]*
+```
+^^^
+You are helpful assistant.
+^^^
+root  ::= (expr "=" ws term "\n")+
+expr  ::= term ([-+*/] term)*
+term  ::= ident | num | "(" ws expr ")" ws
+ident ::= [a-z] [a-z0-9_]* ws
+num   ::= [0-9]+ ws
+ws    ::= [ \t\n]*

--- a/server/testdata/grammar/gbnf_markdown.txt
+++ b/server/testdata/grammar/gbnf_markdown.txt
@@ -1,0 +1,11 @@
+gbnf
+^^^
+Have some quoted backticks, too.
+
+```gbnf
+tick3  ::= "\`\`\`"
+```
+^^^
+Have some quoted backticks, too.
+^^^
+tick3  ::= "```"

--- a/server/testdata/grammar/gbnf_multi.txt
+++ b/server/testdata/grammar/gbnf_multi.txt
@@ -1,0 +1,36 @@
+gbnf
+^^^
+You are helpful assistant.
+
+```gbnf
+root  ::= (expr "=" ws term "\n")+
+expr  ::= term ([-+*/] term)*
+term  ::= ident | num | "(" ws expr ")" ws
+ident ::= [a-z] [a-z0-9_]* ws
+num   ::= [0-9]+ ws
+ws    ::= [ \t\n]*
+```
+
+And have this, too.
+```gbnf
+root ::= item+
+
+# Excludes various line break characters
+item ::= "- " [^\r\n\x0b\x0c\x85\u2028\u2029]+ "\n"
+```
+^^^
+You are helpful assistant.
+
+And have this, too.
+^^^
+root  ::= (expr "=" ws term "\n")+
+expr  ::= term ([-+*/] term)*
+term  ::= ident | num | "(" ws expr ")" ws
+ident ::= [a-z] [a-z0-9_]* ws
+num   ::= [0-9]+ ws
+ws    ::= [ \t\n]*
+^^^
+root ::= item+
+
+# Excludes various line break characters
+item ::= "- " [^\r\n\x0b\x0c\x85\u2028\u2029]+ "\n"

--- a/server/testdata/grammar/gbnf_too.txt
+++ b/server/testdata/grammar/gbnf_too.txt
@@ -1,0 +1,31 @@
+gbnf
+^^^
+You are helpful assistant.
+
+```gbnf
+root  ::= (expr "=" ws term "\n")+
+expr  ::= term ([-+*/] term)*
+term  ::= ident | num | "(" ws expr ")" ws
+ident ::= [a-z] [a-z0-9_]* ws
+num   ::= [0-9]+ ws
+ws    ::= [ \t\n]*
+```
+
+And have this, too.
+```cpp
+#include "stdio.h"
+```
+^^^
+You are helpful assistant.
+
+And have this, too.
+```cpp
+#include "stdio.h"
+```
+^^^
+root  ::= (expr "=" ws term "\n")+
+expr  ::= term ([-+*/] term)*
+term  ::= ident | num | "(" ws expr ")" ws
+ident ::= [a-z] [a-z0-9_]* ws
+num   ::= [0-9]+ ws
+ws    ::= [ \t\n]*

--- a/server/testdata/grammar/jsonschema.txt
+++ b/server/testdata/grammar/jsonschema.txt
@@ -1,0 +1,51 @@
+jsonschema
+^^^
+You are helpful assistant.
+
+```jsonschema
+{
+  "$id": "https://example.com/person.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Person",
+  "type": "object",
+  "properties": {
+    "firstName": {
+      "type": "string",
+      "description": "The person's first name."
+    },
+    "lastName": {
+      "type": "string",
+      "description": "The person's last name."
+    },
+    "age": {
+      "description": "Age in years which must be equal to or greater than zero.",
+      "type": "integer",
+      "minimum": 0
+    }
+  }
+}
+```
+^^^
+You are helpful assistant.
+^^^
+{
+  "$id": "https://example.com/person.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Person",
+  "type": "object",
+  "properties": {
+    "firstName": {
+      "type": "string",
+      "description": "The person's first name."
+    },
+    "lastName": {
+      "type": "string",
+      "description": "The person's last name."
+    },
+    "age": {
+      "description": "Age in years which must be equal to or greater than zero.",
+      "type": "integer",
+      "minimum": 0
+    }
+  }
+}


### PR DESCRIPTION
Some people have reached out to me re: my comment from earlier https://github.com/ollama/ollama/issues/6237#issuecomment-2428338129 so I'd decided it might be worth a shot. To re-cap: this pull request implements wrenching GBNF's (only one at a time!) from the system prompt. I know a bunch of pull requests to similar effect already exist.

However, I also believe that the prior efforts are completely misguided. What they should be doing instead is parsing the system prompt for **\`\`\`gbnf** code blocks. This approach does not impact the API surface, and it would also allow for dynamically generating the grammar on the fly from _any_ existing Ollama client.

More details in the linked comment.

```bash
set GRAMMAR '
```gbnf
root  ::= (expr "=" ws term "\n")+
expr  ::= term ([-+*/] term)*
term  ::= ident | num | "(" ws expr ")" ws
ident ::= [a-z] [a-z0-9_]* ws
num   ::= [0-9]+ ws
ws    ::= [ \t\n]*
```'
curl http://ollama.lan/chat -d '{
  "model": "llama3.2",
  "messages": [
    {
      "role": "system",
      "content": "You are helpful assistant.\n$GRAMMAR"
    },
    {
      "role": "user",
      "content": "why is the sky blue?"
    }
  ]
}'
```

I've so far only committed the bare-bones portion (i.e. vanilla GBNF only) and some tests I had lying around—due to obvious reasons. I don't believe a `jsonschema` and/or `openapi` function-calling implementation is necessary, as it may as well be done trivially on the client-side, but hey, that may be fun for all I care.

Otherwise, happy to bestow my genius upon this world.