### PR TITLE
One corrupt manifest should not wedge model operations

### DIFF
--- a/server/layer.go
+++ b/server/layer.go
@@ -106,7 +106,8 @@ func (l *Layer) Remove() error {
 		return nil
 	}
 
-	ms, err := Manifests()
+	// Ignore corrupt manifests to avoid blocking deletion of layers that are freshly orphaned
+	ms, err := Manifests(true)
 	if err != nil {
 		return err
 	}

--- a/server/manifest_test.go
+++ b/server/manifest_test.go
@@ -112,7 +112,7 @@ func TestManifests(t *testing.T) {
 				createManifest(t, d, p)
 			}
 
-			ms, err := Manifests()
+			ms, err := Manifests(true)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
One potential failure mode is an empty file which bubbles up as an EOF error, leading to all attempts to pull anything failing, and listing operations failing.  Instead, continue and warn about the corrupt manifest, and allow re-pulling the model to clean up the corruption.

Fixes #7393 
Fixes #6920 


