### PR TITLE
Add GoLamify in Libraries section

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Ollama PHP](https://github.com/ArdaGnsrn/ollama-php)
 - [Agents-Flex for Java](https://github.com/agents-flex/agents-flex) with [example](https://github.com/agents-flex/agents-flex/tree/main/agents-flex-llm/agents-flex-llm-ollama/src/test/java/com/agentsflex/llm/ollama)
 - [Ollama for Swift](https://github.com/mattt/ollama-swift)
+- [GoLamify](https://github.com/prasad89/golamify)
 
 ### Mobile
 


### PR DESCRIPTION
### GoLamify Package

This PR adds the [GoLamify](https://github.com/prasad89/golamify), a Go package designed to simplify integration of Go projects with Ollama. 

The GoLamify package provides an easy and efficient way to connect Go applications with Ollama services, allowing for seamless interaction and enhanced functionality.