### PR TITLE
runner.go: Check for zero length images

### DIFF
--- a/llama/runner/image.go
+++ b/llama/runner/image.go
@@ -68,6 +68,10 @@ func (c *ImageContext) NewEmbed(llamaContext *llama.Context, data []byte, aspect
 		return nil, nil
 	}
 
+	if len(data) <= 0 {
+		return nil, errors.New("received zero length image")
+	}
+
 	hash := c.hashImage(data)
 
 	c.mu.Lock()


### PR DESCRIPTION
If we get a request with a zero length image, it will result in an out-of-bounds error when we pass the data to the image encoder.