### PR TITLE
cmd: preserve exact bytes when displaying template/system layers

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -800,9 +800,9 @@ func ShowHandler(cmd *cobra.Command, args []string) error {
 		case "parameters":
 			fmt.Println(resp.Parameters)
 		case "system":
-			fmt.Println(resp.System)
+			fmt.Print(resp.System)
 		case "template":
-			fmt.Println(resp.Template)
+			fmt.Print(resp.Template)
 		}
 
 		return nil


### PR DESCRIPTION
Stop corrupting the output of template and system layers with extraneous newlines, which can alter model behavior if the output is used as input to a new model.