### PR TITLE
Enable JSON Schema support

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -80,6 +80,9 @@ type GenerateRequest struct {
 	// Options lists model-specific options. For example, temperature can be
 	// set through this field, if the model supports it.
 	Options map[string]interface{} `json:"options"`
+
+	// JsonSchema is an optional json schema to use for this request.
+	JsonSchema string `json:"json_schema,omitempty"`
 }
 
 // ChatRequest describes a request sent by [Client.Chat].
@@ -105,6 +108,9 @@ type ChatRequest struct {
 
 	// Options lists model-specific options.
 	Options map[string]interface{} `json:"options"`
+
+	// JsonSchema is an optional json schema to use for this request.
+	JsonSchema string `json:"json_schema,omitempty"`
 }
 
 type Tools []Tool

--- a/llama/common.h
+++ b/llama/common.h
@@ -160,6 +160,7 @@ struct gpt_sampler_params {
     };
 
     std::string grammar; // optional BNF-like grammar to constrain sampling
+    std::string json_schema; // optional JSON schema to constrain sampling
 
     std::vector<llama_logit_bias> logit_bias; // logit biases to apply
 

--- a/llama/llama.go
+++ b/llama/llama.go
@@ -621,6 +621,7 @@ type SamplingParams struct {
 	PenalizeNl     bool
 	Seed           uint32
 	Grammar        string
+	JsonSchema     string
 }
 
 func NewSamplingContext(model *Model, params SamplingParams) (*SamplingContext, error) {
@@ -643,8 +644,12 @@ func NewSamplingContext(model *Model, params SamplingParams) (*SamplingContext, 
 
 	grammar := C.CString(params.Grammar)
 	defer C.free(unsafe.Pointer(grammar))
-
 	cparams.grammar = grammar
+
+	jsonSchema := C.CString(params.JsonSchema)
+	defer C.free(unsafe.Pointer(jsonSchema))
+	cparams.json_schema = jsonSchema
+
 	context := &SamplingContext{c: C.gpt_sampler_cinit(model.c, &cparams)}
 	if context.c == nil {
 		return nil, errors.New("unable to create sampling context")

--- a/llama/runner/runner.go
+++ b/llama/runner/runner.go
@@ -552,6 +552,7 @@ type CompletionRequest struct {
 	Prompt      string      `json:"prompt"`
 	Images      []ImageData `json:"image_data"`
 	Grammar     string      `json:"grammar"`
+	JsonSchema  string      `json:"json_schema"`
 	CachePrompt bool        `json:"cache_prompt"`
 
 	Options
@@ -614,6 +615,7 @@ func (s *Server) completion(w http.ResponseWriter, r *http.Request) {
 	samplingParams.PenalizeNl = req.PenalizeNewline
 	samplingParams.Seed = uint32(req.Seed)
 	samplingParams.Grammar = req.Grammar
+	samplingParams.JsonSchema = req.JsonSchema
 
 	seq, err := s.NewSequence(req.Prompt, req.Images, NewSequenceParams{
 		numPredict:     req.NumPredict,

--- a/llama/sampling.cpp
+++ b/llama/sampling.cpp
@@ -250,7 +250,7 @@ struct gpt_sampler * gpt_sampler_init(const struct llama_model * model, const st
         llama_sampler_chain_add(result->chain, llama_sampler_init_greedy());
     }
     if (params.json_schema != "") {
-        nlohmann::json jsonSchema = nlohmann::json::parse(params.json_schema);
+        nlohmann::ordered_json jsonSchema = nlohmann::ordered_json::parse(params.json_schema);
         result->grmr = llama_sampler_init_grammar(model, json_schema_to_grammar(jsonSchema).c_str(), "root");
     } else {
         result->grmr = llama_sampler_init_grammar(model, params.grammar.c_str(), "root");

--- a/llama/sampling_ext.cpp
+++ b/llama/sampling_ext.cpp
@@ -23,6 +23,7 @@ struct gpt_sampler *gpt_sampler_cinit(
         sparams.penalize_nl = params->penalize_nl;
         sparams.seed = params->seed;
         sparams.grammar = params->grammar;
+        sparams.json_schema = params->json_schema;
         return gpt_sampler_init(model, sparams);
     } catch (const std::exception & err) {
         return nullptr;

--- a/llama/sampling_ext.h
+++ b/llama/sampling_ext.h
@@ -29,6 +29,7 @@ extern "C"
         bool penalize_nl;
         uint32_t seed;
         char *grammar;
+        char *json_schema;
     };
 
     struct gpt_sampler *gpt_sampler_cinit(

--- a/llm/server.go
+++ b/llm/server.go
@@ -673,6 +673,7 @@ type CompletionRequest struct {
 	Format  string
 	Images  []ImageData
 	Options *api.Options
+	JsonSchema string
 }
 
 type CompletionResponse struct {
@@ -733,9 +734,7 @@ func (s *llmServer) Completion(ctx context.Context, req CompletionRequest, fn fu
 
 	if req.Format == "json" {
 		request["grammar"] = jsonGrammar
-		if !strings.Contains(strings.ToLower(req.Prompt), "json") {
-			slog.Warn("Prompt does not specify that the LLM should response in JSON, but JSON format is expected. For best results specify that JSON is expected in the system prompt.")
-		}
+		request["json_schema"] = req.JsonSchema
 	}
 
 	// Handling JSON marshaling with special characters unescaped.

--- a/server/routes.go
+++ b/server/routes.go
@@ -275,10 +275,11 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 		var sb strings.Builder
 		defer close(ch)
 		if err := r.Completion(c.Request.Context(), llm.CompletionRequest{
-			Prompt:  prompt,
-			Images:  images,
-			Format:  req.Format,
-			Options: opts,
+			Prompt:     prompt,
+			Images:     images,
+			Format:     req.Format,
+			Options:    opts,
+			JsonSchema: req.JsonSchema,
 		}, func(cr llm.CompletionResponse) {
 			res := api.GenerateResponse{
 				Model:      req.Model,
@@ -1460,10 +1461,11 @@ func (s *Server) ChatHandler(c *gin.Context) {
 	go func() {
 		defer close(ch)
 		if err := r.Completion(c.Request.Context(), llm.CompletionRequest{
-			Prompt:  prompt,
-			Images:  images,
-			Format:  req.Format,
-			Options: opts,
+			Prompt:     prompt,
+			Images:     images,
+			Format:     req.Format,
+			Options:    opts,
+			JsonSchema: req.JsonSchema,
 		}, func(r llm.CompletionResponse) {
 			res := api.ChatResponse{
 				Model:      req.Model,


### PR DESCRIPTION
This merge request introduces a new feature that adds support for response_format based on the grammar guide of llama.cpp. This new functionality has been implemented to improve the flexibility of response formats, and it has been tested and works well with both the openai library and langchain.

Please review the code changes and test the feature to confirm compatibility with any additional components or configurations specific to your setup.

Let me know if you need further adjustments!

<img width="950" alt="Screenshot 2024-11-09 at 5 32 06 PM" src="https://github.com/user-attachments/assets/7fe1b87c-f8f2-4601-8148-df69452ba8d0">
<img width="752" alt="Screenshot 2024-11-09 at 5 32 48 PM" src="https://github.com/user-attachments/assets/bc871b4b-9e57-450d-84a4-099dd40b734d">
