### PR TITLE
Invalid OLLAMA_LLM_LIBRARY Error

### DIFF
--- a/llm/server.go
+++ b/llm/server.go
@@ -168,6 +168,7 @@ func NewLlamaServer(gpus discover.GpuInfoList, model string, ggml *GGML, adapter
 		serverPath := availableServers[demandLib]
 		if serverPath == "" {
 			slog.Info(fmt.Sprintf("Invalid OLLAMA_LLM_LIBRARY %s - not found", demandLib))
+			return nil, errors.New("Invalid OLLAMA_LLM_LIBRARY")
 		} else {
 			slog.Info("user override", "OLLAMA_LLM_LIBRARY", demandLib, "path", serverPath)
 			servers = []string{demandLib}


### PR DESCRIPTION
If the OLLAMA_LLM_LIBRARY environment variable is an invalid target, currently the server logs a message of the problem and continues to work using another available runner. This change causes it instead to raise an error. If you are using the OLLAMA_LLM_LIBRARY variable, you should intend for it to use that runner, and if that runner isn’t available it should error, not fall back to something else.

The specific use case is from the testing of the ollama builder with jetson-containers. Previous versions of the ollama build process included the env variable: OLLAMA_SKIP_CPU_GENERATE which allowed us to only generate the CUDA runner. If the binary build process completed but the cuda runner failed to build, our test would fail due to there being no available runners. Now, trying to use OLLAMA_LLM_LIBRARY with the desired but failed-to-build cuda_vXX runner, it falls back to use the CPU runner and the test doesn’t fail.

Re-implementing the build variables OLLAMA_SKIP_CPU_GENERATE and OLLAMA_SKIP_CUDA_GENERATE, would work: https://github.com/ollama/ollama/pull/7499; but doesn’t change that targeting an invalid OLLAMA_LLM_LIBRARY should error.