### PR TITLE
CI: give windows lint more time

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -281,7 +281,7 @@ jobs:
         shell: bash
       - uses: golangci/golangci-lint-action@v6
         with:
-          args: --timeout 8m0s -v
+          args: --timeout 10m0s -v
   test:
     strategy:
       matrix:


### PR DESCRIPTION
It looks like 8 minutes isn't quite enough and we're seeing sporadic timeouts