### PR TITLE
Support Multiple LoRa Adapters, Closes #7627

### DIFF
--- a/llama/runner/runner.go
+++ b/llama/runner/runner.go
@@ -93,17 +93,6 @@ type NewSequenceParams struct {
 	embedding      bool
 }
 
-type multiLPath []string
-
-func (m *multiLPath) Set(value string) error {
-	*m = append(*m, value)
-	return nil
-}
-
-func (m *multiLPath) String() string {
-	return strings.Join(*m, ", ")
-}
-
 func (s *Server) NewSequence(prompt string, images []ImageData, params NewSequenceParams) (*Sequence, error) {
 	s.ready.Wait()
 
@@ -762,6 +751,17 @@ func (s *Server) health(w http.ResponseWriter, r *http.Request) {
 	}); err != nil {
 		http.Error(w, fmt.Sprintf("failed to encode response: %v", err), http.StatusInternalServerError)
 	}
+}
+
+type multiLPath []string
+
+func (m *multiLPath) Set(value string) error {
+	*m = append(*m, value)
+	return nil
+}
+
+func (m *multiLPath) String() string {
+	return strings.Join(*m, ", ")
 }
 
 func (s *Server) loadModel(

--- a/llm/server.go
+++ b/llm/server.go
@@ -144,10 +144,6 @@ func NewLlamaServer(gpus discover.GpuInfoList, model string, ggml *GGML, adapter
 	// Loop through potential servers
 	finalErr := errors.New("no suitable llama servers found")
 
-	if len(adapters) > 1 {
-		return nil, errors.New("ollama supports only one lora adapter, but multiple were provided")
-	}
-
 	rDir, err := runners.Refresh(build.EmbedFS)
 	if err != nil {
 		return nil, err
@@ -201,8 +197,9 @@ func NewLlamaServer(gpus discover.GpuInfoList, model string, ggml *GGML, adapter
 	}
 
 	if len(adapters) > 0 {
-		// TODO: applying multiple adapters is not supported by the llama.cpp server yet
-		params = append(params, "--lora", adapters[0])
+		for _, adapter := range adapters {
+			params = append(params, "--lora", adapter)
+		}
 	}
 
 	if len(projectors) > 0 {


### PR DESCRIPTION
Hi, so I've updated the Llama server by allowing it to handle multiple LoRa adapters. Previously, the server supported only one LoRa adapter, limiting users who needed to apply multiple adapters for advanced fine-tuning.

Changes Made:

- Command-Line Parsing:
  - Updated to accept multiple `--lora` flags.
  - Introduced `multiLPath` to handle multiple LoRa paths.

- Model Loading:
  - Modified the `loadModel` function to loop through and apply each specified LoRa adapter.
  - Removed the restriction that only one adapter can be used at a time in `llm/server.go`.