### PR TITLE
build: add sync-clean target

### DIFF
--- a/llama/Makefile
+++ b/llama/Makefile
@@ -40,7 +40,7 @@ runners: $(RUNNER_TARGETS)
 $(RUNNER_TARGETS):
 	$(MAKE) -f make/Makefile.$@
 
-help-sync apply-patches create-patches sync:
+help-sync apply-patches create-patches sync sync-clean:
 	$(MAKE) -f make/Makefile.sync $@
 
 clean:

--- a/llama/make/Makefile.sync
+++ b/llama/make/Makefile.sync
@@ -15,6 +15,7 @@ help-sync:
 	@echo ""
 	@echo "\tmake apply-patches   # Establish the tracking repo if not already present, reset to the base commit, and apply our patch set"
 	@echo "\tmake sync            # Vendor llama.cpp and ggml from the tracking repo working tree"
+	@echo "\tmake sync-clean      # Remove all vendored files"
 	@echo "\tmake create-patches  # Generate the patch set based on the current commits in the tracking repo since the base commit"
 	@echo ""
 	@echo "For more details on the workflow, see the Vendoring section in ../docs/development.md"
@@ -175,6 +176,9 @@ VENDORED_FILES += $(DST_DIR)build-info.cpp
 
 
 sync: $(LLAMACPP_REPO) .WAIT $(VENDORED_FILES) .WAIT remove-stale-files
+
+sync-clean:
+	rm -f $(VENDORED_FILES) $(EXTRA_NATIVE_FILES)
 
 PATS=*.c *.h *.cpp *.m *.metal *.cu *.cuh
 NATIVE_DIRS=$(DST_DIR) $(DST_DIR)llamafile/ $(DST_DIR)ggml-cuda/ $(DST_DIR)ggml-cuda/template-instances/ $(DST_DIR)ggml-cuda/vendors/


### PR DESCRIPTION
Helpful target to ensure all vendored files are fresh

Since the sync target uses file timestamps, if you jump back and forth between different upstream commits it can get confused and fail to sync the "new" content since timestamps are older.  This gives a quick way to reset all the vendored files to avoid potentially missing anything.