### PR TITLE
fix(runner): Set logits to 0 if false on Batch.Add

### DIFF
--- a/llama/llama.go
+++ b/llama/llama.go
@@ -384,6 +384,8 @@ func (b *Batch) Add(token int, embed []float32, pos int, logits bool, seqIds ...
 
 	if logits {
 		unsafe.Slice(b.c.logits, b.allocSize())[b.c.n_tokens] = 1
+	} else {
+		unsafe.Slice(b.c.logits, b.allocSize())[b.c.n_tokens] = 0
 	}
 
 	b.c.n_tokens += 1


### PR DESCRIPTION
Closes: https://github.com/ollama/ollama/issues/7656

This was a fun bunch of bug hunting to try to chase down nondeterministic behavior with the Granite 3 models that shows up with the switch to the go-based runner.