### PR TITLE
Disallow Tool Streaming

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -1398,6 +1398,12 @@ func (s *Server) ChatHandler(c *gin.Context) {
 		return
 	}
 
+	// Error if streaming is enabled and tools are present
+	if req.Stream != nil && *req.Stream && len(req.Tools) > 0 {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "streaming is not supported with tools"})
+		return
+	}
+
 	// expire the runner
 	if len(req.Messages) == 0 && req.KeepAlive != nil && int(req.KeepAlive.Seconds()) == 0 {
 		model, err := GetModel(req.Model)


### PR DESCRIPTION
While Tool streaming is scoped to be supported, we currently allow it, which can lead to some weird edge cases.

The tool gets added to capabilities and is passed into runner without checking if the behavior should be occurring.

https://github.com/ollama/ollama/blob/807ace5b1f4fc9de7347297b3c8a695c566d9fd9/server/routes.go#L1427-L1432

The error raised now: 
```
  File "/Users/parth/Documents/repos/ollama-python/ollama/_client.py", line 668, in inner
    raise ResponseError(e.response.text, e.response.status_code) from None
ollama._types.ResponseError: streaming is not supported with tools
```
I'm a bit weary of getting this PR in since people might have some work arounds for now. We could also just table this for now and it'll get fixed in the streamed tool calls PR.

Will add tests depending on what we decide.