### PR TITLE
Add Orbiton to the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [vim-intelligence-bridge](https://github.com/pepo-ec/vim-intelligence-bridge) Simple interaction of "Ollama" with the Vim editor
 - [SwollamaCLI](https://github.com/marcusziade/Swollama) bundled with the Swollama Swift package. [Demo](https://github.com/marcusziade/Swollama?tab=readme-ov-file#cli-usage)
 - [aichat](https://github.com/sigoden/aichat) All-in-one LLM CLI tool featuring Shell Assistant, Chat-REPL, RAG, AI tools & agents, with access to OpenAI, Claude, Gemini, Ollama, Groq, and more.
+- [orbiton](https://github.com/xyproto/orbiton) Configuration-free text editor and IDE with support for tab completion with Ollama.
 
 ### Apple Vision Pro
 - [Enchanted](https://github.com/AugustDev/enchanted)


### PR DESCRIPTION
Orbiton is a configuration-free text editor and IDE that can use Ollama for tab-completion.