### PR TITLE
Integrating Ollama with Microsoft Word

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [VT](https://github.com/vinhnx/vt.ai) (A minimal multimodal AI chat app, with dynamic conversation routing. Supports local models via Ollama)
 - [Witsy](https://github.com/nbonamy/witsy) (An AI Desktop application avaiable for Mac/Windows/Linux) 
 - [Abbey](https://github.com/US-Artificial-Intelligence/abbey) (A configurable AI interface server with notebooks, document storage, and YouTube support)
+- [GPTLocalhost (Word Add-in)](https://gptlocalhost.com/demo#ollama) (Use Ollama in Microsoft Word locally. Alternative to Microsoft's [Colipot in Word](https://support.microsoft.com/en-us/copilot-word))
 
 ### Terminal
 


### PR DESCRIPTION
Thank you for this repo. I have integrated Ollama with Microsoft Word through a local Word Add-in ([GPTLocalhost](https://gptlocalhost.com/demo#ollama)). It would be great if this Word Add-in can be listed in the following so that users have another way to utilize Ollama. Thank you for your consideration. 

 * [Community Integrations > Web & Desktop](https://github.com/ollama/ollama?tab=readme-ov-file#web--desktop)
