### PR TITLE
ppc64le: corrected ioctls

### DIFF
--- a/readline/term_linux.go
+++ b/readline/term_linux.go
@@ -5,11 +5,12 @@ package readline
 import (
 	"syscall"
 	"unsafe"
+	"golang.org/x/sys/unix"
 )
 
 const (
-	tcgets = 0x5401
-	tcsets = 0x5402
+	tcgets = unix.TCGETS
+	tcsets = unix.TCSETSF
 )
 
 func getTermios(fd uintptr) (*Termios, error) {


### PR DESCRIPTION
As described in #796 `ollama run` won't work on ppc64le out of the box, as the ioctl `TCSETS` is invalid.

This PR changes the ioctl to `TCSETSF` while also moving it away from "magic numbers".

According to man pages:
```
       TCSETSF
              Equivalent to tcsetattr(fd, TCSAFLUSH, argp).

              Allow the output buffer to drain, discard pending input,
              and set the current serial port settings.
```

I've tested this change on an x64 CPU as well, and saw no issues/regressions.