### PR TITLE
Use default transport to preserve proxy settings

### DIFF
--- a/server/images.go
+++ b/server/images.go
@@ -1076,10 +1076,16 @@ func makeRequest(ctx context.Context, method string, requestURL *url.URL, header
 		req.ContentLength = contentLength
 	}
 
+	// Create transport based on default transport to preserve proxy settings
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	
+	// Only override DialContext if test function is provided
+	if testMakeRequestDialContext != nil {
+		transport.DialContext = testMakeRequestDialContext
+	}
+
 	resp, err := (&http.Client{
-		Transport: &http.Transport{
-			DialContext: testMakeRequestDialContext,
-		},
+		Transport:     transport,
 		CheckRedirect: regOpts.CheckRedirect,
 	}).Do(req)
 	if err != nil {


### PR DESCRIPTION
Attempt to fix regression in 0.4.3 as per #7788

To test this change, I created a small program to verify that the change indeed respects the proxy settings:

```go
package main

import (
	"fmt"
	"net/http"
	"os"
)

func BuggyClient() *http.Client {
	return &http.Client{
		Transport: &http.Transport{},
	}
}

func CorrectClient() *http.Client {
	transport := http.DefaultTransport.(*http.Transport).Clone()
	return &http.Client{
		Transport: transport,
	}
}

func main() {
	targetURL := "http://httpbin.org/get"

	fmt.Println("Testing with buggy client:")
	buggyResp, err := BuggyClient().Get(targetURL)
	if err != nil {
		fmt.Printf("Buggy client error: %v\n", err)
	} else {
		defer buggyResp.Body.Close()
		fmt.Printf("Buggy client status: %s\n", buggyResp.Status)
	}

	fmt.Println("\nTesting with correct client:")
	correctResp, err := CorrectClient().Get(targetURL)
	if err != nil {
		fmt.Printf("Correct client error: %v\n", err)
	} else {
		defer correctResp.Body.Close()
		fmt.Printf("Correct client status: %s\n", correctResp.Status)
	}

	fmt.Println("\nProxy settings:")
	fmt.Printf("HTTP_PROXY: %s\n", os.Getenv("HTTP_PROXY"))
}
```

```bash
# I run tinyproxy with DENY all requests for testing
% go run main.go
Testing with buggy client:
Buggy client status: 200 OK

Testing with correct client:
Correct client status: 403 Access denied

Proxy settings:
HTTP_PROXY: http://localhost:8888
```