### PR TITLE
Export ctx, gpu, parallel parameters via /api/ps

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -408,13 +408,18 @@ type ListModelResponse struct {
 
 // ProcessModelResponse is a single model description in [ProcessResponse].
 type ProcessModelResponse struct {
-	Name      string       `json:"name"`
-	Model     string       `json:"model"`
-	Size      int64        `json:"size"`
-	Digest    string       `json:"digest"`
-	Details   ModelDetails `json:"details,omitempty"`
-	ExpiresAt time.Time    `json:"expires_at"`
-	SizeVRAM  int64        `json:"size_vram"`
+	Name        string       `json:"name"`
+	Model       string       `json:"model"`
+	Size        int64        `json:"size"`
+	Digest      string       `json:"digest"`
+	Details     ModelDetails `json:"details,omitempty"`
+	ExpiresAt   time.Time    `json:"expires_at"`
+	SizeVRAM    int64        `json:"size_vram"`
+	NumCtx      int          `json:"num_ctx"`
+	MaxCtx      int          `json:"max_ctx"`
+	NumGPU      int          `json:"num_gpu"`
+	MaxGPU      int          `json:"max_gpu"`
+	NumParallel int          `json:"num_parallel"`
 }
 
 type RetrieveModelResponse struct {

--- a/llm/server.go
+++ b/llm/server.go
@@ -44,6 +44,10 @@ type LlamaServer interface {
 	EstimatedVRAM() uint64 // Total VRAM across all GPUs
 	EstimatedTotal() uint64
 	EstimatedVRAMByGPU(gpuID string) uint64
+	NumGPU() int
+	NumCtx() int
+	MaxGPU() int
+	NumParallel() int
 }
 
 // llmServer is an instance of the llama.cpp server
@@ -1108,6 +1112,22 @@ func (s *llmServer) EstimatedVRAMByGPU(gpuID string) uint64 {
 		}
 	}
 	return 0
+}
+
+func (s *llmServer) NumParallel() int {
+	return s.numParallel
+}
+
+func (s *llmServer) NumGPU() int {
+	return s.options.NumGPU
+}
+
+func (s *llmServer) NumCtx() int {
+	return s.options.NumCtx
+}
+
+func (s *llmServer) MaxGPU() int {
+	return s.estimate.layersModel
 }
 
 func parseDurationMs(ms float64) time.Duration {

--- a/server/routes.go
+++ b/server/routes.go
@@ -1350,6 +1350,10 @@ func (s *Server) PsHandler(c *gin.Context) {
 
 	for _, v := range s.sched.loaded {
 		model := v.model
+		contextLength := -1
+		if kvData, err := getKVData(model.ModelPath, false); err == nil {
+			contextLength = int(kvData.ContextLength())
+		}
 		modelDetails := api.ModelDetails{
 			Format:            model.Config.ModelFormat,
 			Family:            model.Config.ModelFamily,
@@ -1359,13 +1363,18 @@ func (s *Server) PsHandler(c *gin.Context) {
 		}
 
 		mr := api.ProcessModelResponse{
-			Model:     model.ShortName,
-			Name:      model.ShortName,
-			Size:      int64(v.estimatedTotal),
-			SizeVRAM:  int64(v.estimatedVRAM),
-			Digest:    model.Digest,
-			Details:   modelDetails,
-			ExpiresAt: v.expiresAt,
+			Model:       model.ShortName,
+			Name:        model.ShortName,
+			Size:        int64(v.estimatedTotal),
+			SizeVRAM:    int64(v.estimatedVRAM),
+			Digest:      model.Digest,
+			Details:     modelDetails,
+			ExpiresAt:   v.expiresAt,
+			NumCtx:      v.llama.NumCtx() / v.numParallel,
+			MaxCtx:      contextLength,
+			NumGPU:      v.llama.NumGPU(),
+			MaxGPU:      v.llama.MaxGPU(),
+			NumParallel: v.numParallel,
 		}
 		// The scheduler waits to set expiresAt, so if a model is loading it's
 		// possible that it will be set to the unix epoch. For those cases, just

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -764,6 +764,10 @@ type mockLlm struct {
 	estimatedVRAM      uint64
 	estimatedTotal     uint64
 	estimatedVRAMByGPU map[string]uint64
+	numGPU             int
+	maxGPU             int
+	numCtx             int
+	numParallel        int
 }
 
 func (s *mockLlm) Ping(ctx context.Context) error             { return s.pingResp }
@@ -791,3 +795,7 @@ func (s *mockLlm) Close() error {
 func (s *mockLlm) EstimatedVRAM() uint64                  { return s.estimatedVRAM }
 func (s *mockLlm) EstimatedTotal() uint64                 { return s.estimatedTotal }
 func (s *mockLlm) EstimatedVRAMByGPU(gpuid string) uint64 { return s.estimatedVRAMByGPU[gpuid] }
+func (s *mockLlm) NumGPU() int                            { return s.numGPU }
+func (s *mockLlm) MaxGPU() int                            { return s.maxGPU }
+func (s *mockLlm) NumCtx() int                            { return s.numCtx }
+func (s *mockLlm) NumParallel() int                       { return s.numParallel }


### PR DESCRIPTION
Allow clients to query some model run-time parameters.