### PR TITLE
Handle padding bytes in GGUF files.

### DIFF
--- a/llm/ggml.go
+++ b/llm/ggml.go
@@ -57,6 +57,13 @@ func (kv KV) ParameterCount() uint64 {
 	return kv.u64("general.parameter_count")
 }
 
+func (kv KV) Alignment() int64 {
+	if alignment := int64(kv.u64("general.alignment")); alignment != 0 {
+		return alignment
+	}
+	return 32
+}
+
 func (kv KV) FileType() fileType {
 	if u64 := kv.u64("general.file_type"); u64 > 0 {
 		return fileType(uint32(u64))

--- a/llm/gguf.go
+++ b/llm/gguf.go
@@ -558,6 +558,14 @@ func WriteGGUF(ws io.WriteSeeker, kv KV, ts []Tensor) error {
 		}
 	}
 
+	offset, err := ws.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return err
+	}
+	if err := binary.Write(ws, binary.LittleEndian, bytes.Repeat([]byte{0}, int(ggufPadding(offset, alignment)))); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/server/model.go
+++ b/server/model.go
@@ -217,7 +217,11 @@ func parseFromFile(ctx context.Context, command string, baseLayers []*layerGGML,
 		}
 
 		layers = append(layers, &layerGGML{layer, ggml})
-		offset = n
+
+		alignment := ggml.KV().Alignment()
+		if offset, err = file.Seek(n+(alignment-(n%alignment))%alignment, os.SEEK_SET); err != nil {
+			return nil, err
+		}
 	}
 
 	return detectChatTemplate(layers)


### PR DESCRIPTION
GGUF files are [padded](https://github.com/ggerganov/ggml/blob/master/docs/gguf.md#file-structure:~:text=Where%20required%2C%20the%20file%20is%20padded%20with%200x00%20bytes%20to%20the%20next%20multiple%20of%20general.alignment) to an alignment value, by default 32 bytes.  `parseFromFile()` doesn't handle this, which causes an `invalid file magic` for some imports since it tries to read multiple GGML structures from a single file and stumbles over the padding bytes when the last tensor didn't end on the alignment mark.

The doc is not as clear on adapters and projectors, but the fine-tuning code in llama.cpp uses an alignment of 32 and all the projectors I checked were aligned to 32 bytes. 

Fixes: https://github.com/ollama/ollama/issues/5939
Fixes: https://github.com/ollama/ollama/issues/6272