### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ Get up and running with large language models.
 
 [Download](https://ollama.com/download/Ollama-darwin.zip)
 
+Or using Homebrew 
+  ```
+  brew install ollama
+  ```
+
 ### Windows
 
 [Download](https://ollama.com/download/OllamaSetup.exe)
@@ -136,6 +141,14 @@ For more examples, see the [examples](examples) directory. For more information 
 
 ## CLI Reference
 
+### Start Ollama
+
+When you want to start ollama without running the desktop application . Or see this "Error: could not connect to ollama app, is it running?"
+
+```
+ollama serve
+```
+
 ### Create a model
 
 `ollama create` is used to create a model from a Modelfile.
@@ -213,9 +226,6 @@ ollama ps
 ollama stop llama3.2
 ```
 
-### Start Ollama
-
-`ollama serve` is used when you want to start ollama without running the desktop application.
 
 ## Building
 


### PR DESCRIPTION
- Add option to install ollama via brew
- Move Start Ollama section to the top of CLI Refence section to avoid seeing "Error: could not connect to ollama app, is it running?" when first start ollama.
<img width="913" alt="Screenshot 2024-11-27 at 2 01 08 PM" src="https://github.com/user-attachments/assets/10684f11-6a56-46e8-841e-c8a44a1c7faa">

