### PR TITLE
server: feedback before failing push on uppercase

### DIFF
--- a/server/images.go
+++ b/server/images.go
@@ -802,6 +802,12 @@ func PushModel(ctx context.Context, name string, regOpts *registryOptions, fn fu
 	if mp.ProtocolScheme == "http" && !regOpts.Insecure {
 		return errors.New("insecure protocol http")
 	}
+	if mp.Namespace != strings.ToLower(mp.Namespace) {
+		return fmt.Errorf("namespace must be lowercase, but is %s", mp.Namespace)
+	}
+	if mp.Repository != strings.ToLower(mp.Repository) {
+		return fmt.Errorf("model name must be lowercase, but is %s", mp.Repository)
+	}
 
 	manifest, _, err := GetManifest(mp)
 	if err != nil {

--- a/server/images_test.go
+++ b/server/images_test.go
@@ -2,10 +2,10 @@ package server
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/ollama/ollama/api"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestPushModel(t *testing.T) {
@@ -37,8 +37,14 @@ func TestPushModel(t *testing.T) {
 		t.Run(tt.modelStr, func(t *testing.T) {
 			err := PushModel(context.Background(), tt.modelStr, tt.regOpts, noOpProgress)
 
-			assert.Error(t, err)
-			assert.EqualError(t, err, tt.wantErr)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Errorf("PushModel() error = %v, wantErr %v", err, tt.wantErr)
+				} else if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("PushModel() error = %v, wantErr %v", err, tt.wantErr)
+				}
+				return
+			}
 		})
 	}
 }

--- a/server/images_test.go
+++ b/server/images_test.go
@@ -1,0 +1,44 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ollama/ollama/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPushModel(t *testing.T) {
+	noOpProgress := func(resp api.ProgressResponse) {}
+
+	tests := []struct {
+		modelStr string
+		regOpts  *registryOptions
+		wantErr  string
+	}{
+		{
+			modelStr: "http://example.com/namespace/repo:tag",
+			regOpts:  &registryOptions{Insecure: false},
+			wantErr:  "insecure protocol http",
+		},
+		{
+			modelStr: "docker://Example/repo:tag",
+			regOpts:  &registryOptions{},
+			wantErr:  "namespace must be lowercase, but is Example",
+		},
+		{
+			modelStr: "docker://example/Repo:tag",
+			regOpts:  &registryOptions{},
+			wantErr:  "model name must be lowercase, but is Repo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.modelStr, func(t *testing.T) {
+			err := PushModel(context.Background(), tt.modelStr, tt.regOpts, noOpProgress)
+
+			assert.Error(t, err)
+			assert.EqualError(t, err, tt.wantErr)
+		})
+	}
+}


### PR DESCRIPTION
When a username or model name is uppercase the registry will reject the push. This is done for file-system compatibility. If we rely on the registry error on push the message returned is 'file not found', which does not convey why the push actually failed.

Before:
```bash
> ollama push TEST_CAPS/x
retrieving manifest 
Error: file does not exist

> ollama push test_caps/X
retrieving manifest 
Error: file does not exist
```

Now:
```bash
> ollama push TEST_CAPS/x
retrieving manifest 
Error: namespace must be lowercase, but is TEST_CAPS

> ollama push test_caps/X
retrieving manifest 
Error: model name must be lowercase, but is X
```

An alternative option is to check this when the model is created, but I think its ok for users to name the model whatever they want on their local system. The model will still run.

related to #3501