### PR TITLE
postmerge(qkvct): normalise kvct parameter handling

### DIFF
--- a/llm/memory.go
+++ b/llm/memory.go
@@ -129,7 +129,7 @@ func EstimateGPULayers(gpus []discover.GpuInfo, ggml *GGML, projectors []string,
 
 	var kvct string
 	if fa {
-		requested := envconfig.KvCacheType()
+		requested := strings.ToLower(envconfig.KvCacheType())
 		if requested != "" && ggml.SupportsKVCacheType(requested) {
 			kvct = requested
 		}

--- a/llm/server.go
+++ b/llm/server.go
@@ -225,7 +225,7 @@ func NewLlamaServer(gpus discover.GpuInfoList, model string, ggml *GGML, adapter
 		fa = false
 	}
 
-	kvct := envconfig.KvCacheType()
+	kvct := strings.ToLower(envconfig.KvCacheType())
 
 	if fa {
 		slog.Info("enabling flash attention")


### PR DESCRIPTION
Minor improvement to the k/v cache quantisation parameter handling to normalise the value to lower case, allowing users to specify Q8_0 as well as q8_0.

fyi @jmorganca 