### PR TITLE
Fix message truncation logic and ensure at least one system message i…

### DIFF
--- a/server/prompt.go
+++ b/server/prompt.go
@@ -44,9 +44,8 @@ func chatPrompt(ctx context.Context, m *Model, tokenize tokenizeFunc, opts *api.
 			return "", nil, errTooManyImages
 		}
 
-		// always include the last message
-		if i == n {
-			continue
+		if i == 0 && msgs[i].Role == "system" {
+			break
 		}
 
 		system = make([]api.Message, 0)
@@ -54,6 +53,11 @@ func chatPrompt(ctx context.Context, m *Model, tokenize tokenizeFunc, opts *api.
 			if msgs[j].Role == "system" {
 				system = append(system, msgs[j])
 			}
+		}
+
+		// always include the last message
+		if i == n {
+			continue
 		}
 
 		var b bytes.Buffer

--- a/server/prompt_test.go
+++ b/server/prompt_test.go
@@ -86,6 +86,18 @@ func TestChatPrompt(t *testing.T) {
 			},
 		},
 		{
+			name:  "truncate messages, keep system",
+			model: visionModel,
+			limit: 1,
+			msgs: []api.Message{
+				{Role: "system", Content: "You are the Test Who Lived."},
+				{Role: "user", Content: "A test. And a thumping good one at that, I'd wager."},
+			},
+			expect: expect{
+				prompt: "You are the Test Who Lived. A test. And a thumping good one at that, I'd wager. ",
+			},
+		},
+		{
 			name:  "truncate messages with image",
 			model: visionModel,
 			limit: 64,


### PR DESCRIPTION
### Changes:
- Fixed the message truncation logic to ensure that at least one `system` message is included.
- Adjusted the message handling to always include the last message, even if the context window is exceeded.

### Motivation:
- This change ensures that the context window truncation logic respects the system messages and guarantees that at least one `system` message is always included in the prompt.

### Related Issue(s):
- https://github.com/ollama/ollama/issues/6176