### PR TITLE
server: print environment variables in sorted, one-line

### DIFF
--- a/app/lifecycle/lifecycle.go
+++ b/app/lifecycle/lifecycle.go
@@ -16,7 +16,7 @@ import (
 
 func Run() {
 	InitLogging()
-	envconfig.SlogPrint("app config:")
+	envconfig.SlogPrint("app config")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	var done chan int

--- a/app/lifecycle/lifecycle.go
+++ b/app/lifecycle/lifecycle.go
@@ -16,7 +16,7 @@ import (
 
 func Run() {
 	InitLogging()
-	slog.Info("app config", "env", envconfig.Values())
+	envconfig.SlogPrint("app config:")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	var done chan int

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -284,10 +284,11 @@ func SlogPrint(header string) {
 	m := AsMap()
 	names := maps.Keys(m)
 	slices.Sort(names)
-	slog.Info(header)
+	data := make([]any, 0, len(names)*2)
 	for _, name := range names {
-		slog.Info(fmt.Sprintf("env: %v=%q", name, m[name]))
+		data = append(data, name, m[name])
 	}
+	slog.Info(header, slog.Group("env", data...))
 }
 
 // Var returns an environment variable stripped of leading and trailing quotes or spaces

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -2,6 +2,7 @@ package envconfig
 
 import (
 	"fmt"
+	"golang.org/x/exp/maps"
 	"log/slog"
 	"math"
 	"net"
@@ -9,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -278,12 +280,14 @@ func AsMap() map[string]EnvVar {
 	return ret
 }
 
-func Values() map[string]string {
-	vals := make(map[string]string)
-	for k, v := range AsMap() {
-		vals[k] = fmt.Sprintf("%v", v.Value)
+func SlogPrint(header string) {
+	m := AsMap()
+	names := maps.Keys(m)
+	slices.Sort(names)
+	slog.Info(header)
+	for _, name := range names {
+		slog.Info(fmt.Sprintf("env: %v=%q", name, m[name]))
 	}
-	return vals
 }
 
 // Var returns an environment variable stripped of leading and trailing quotes or spaces

--- a/server/routes.go
+++ b/server/routes.go
@@ -1192,7 +1192,8 @@ func Serve(ln net.Listener) error {
 		level = slog.LevelDebug
 	}
 
-	slog.Info("server config", "env", envconfig.Values())
+	envconfig.SlogPrint("server config:")
+
 	handler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
 		Level:     level,
 		AddSource: true,

--- a/server/routes.go
+++ b/server/routes.go
@@ -1192,7 +1192,7 @@ func Serve(ln net.Listener) error {
 		level = slog.LevelDebug
 	}
 
-	envconfig.SlogPrint("server config:")
+	envconfig.SlogPrint("server config")
 
 	handler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
 		Level:     level,


### PR DESCRIPTION
Printing the map directly is difficult to read, especially when some environment variable is excessively long.