### PR TITLE
Document that `--format` now supports passing JSON Schemas

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1343,7 +1343,7 @@ func NewCLI() *cobra.Command {
 	runCmd.Flags().Bool("verbose", false, "Show timings for response")
 	runCmd.Flags().Bool("insecure", false, "Use an insecure registry")
 	runCmd.Flags().Bool("nowordwrap", false, "Don't wrap words to the next line automatically")
-	runCmd.Flags().String("format", "", "Response format (\"json\" or a JSON Schema)")
+	runCmd.Flags().String("format", "", `Response format ("json" or a JSON Schema)`)
 
 	stopCmd := &cobra.Command{
 		Use:     "stop MODEL",

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1343,7 +1343,7 @@ func NewCLI() *cobra.Command {
 	runCmd.Flags().Bool("verbose", false, "Show timings for response")
 	runCmd.Flags().Bool("insecure", false, "Use an insecure registry")
 	runCmd.Flags().Bool("nowordwrap", false, "Don't wrap words to the next line automatically")
-	runCmd.Flags().String("format", "", "Response format (e.g. json)")
+	runCmd.Flags().String("format", "", "Response format (\"json\" or a JSON Schema)")
 
 	stopCmd := &cobra.Command{
 		Use:     "stop MODEL",


### PR DESCRIPTION
JSON Schema support was added in #7900.

--------

I removed `e.g.` because I don't believe it supports anything else, right? Let me know if that's wrong.