### PR TITLE
Add K/V cache quantization config to Modelfile (Follow-Up to PR #6279)

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -243,6 +243,7 @@ type Runner struct {
 	UseMMap   *bool `json:"use_mmap,omitempty"`
 	UseMLock  bool  `json:"use_mlock,omitempty"`
 	NumThread int   `json:"num_thread,omitempty"`
+	KVCacheType string `json:"kv_cache_type,omitempty"`
 }
 
 // EmbedRequest is the request passed to [Client.Embed].

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -107,6 +107,7 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 		fmt.Fprintln(os.Stderr, "  /set parameter repeat_last_n <int>    Set how far back to look for repetitions")
 		fmt.Fprintln(os.Stderr, "  /set parameter num_gpu <int>          The number of layers to send to the GPU")
 		fmt.Fprintln(os.Stderr, "  /set parameter stop <string> <string> ...   Set the stop parameters")
+		fmt.Fprintln(os.Stderr, "  /set parameter kv_cache_type <string>  Set the K/V cache type")
 		fmt.Fprintln(os.Stderr, "")
 	}
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -405,6 +405,7 @@ curl http://localhost:11434/api/generate -d '{
     "num_gpu": 1,
     "main_gpu": 0,
     "low_vram": false,
+    "kv_cache_type": "q8_0",
     "vocab_only": false,
     "use_mmap": true,
     "use_mlock": false,

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -295,11 +295,11 @@ Flash Attention is a feature of most modern models that can significantly reduce
 
 The K/V context cache can be quantized to significantly reduce memory usage when Flash Attention is enabled.
 
-To use quantized K/V cache with Ollama you can set the following environment variable:
-
-- `OLLAMA_KV_CACHE_TYPE` - The quantization type for the K/V cache.  Default is `f16`.
-
-> Note: Currently this is a global option - meaning all models will run with the specified quantization type.
+You can set the quantization type in a number of ways:
+1. In the environment using `OLLAMA_KV_CACHE_TYPE` which will be the default vault for all models loaded.
+2. In a model's Modelfile using the `kv_cache_type` parameter which will be loaded with the model.
+3. In an API request to Ollama's native API using the `kv_cache_type` parameter which will be used for that request.
+4. In the CLI with `/set parameter kv_cache_type <value>` which will be used for that session.
 
 The currently available K/V cache quantization types are:
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -473,6 +473,7 @@ func TestParseFileParameters(t *testing.T) {
 		"num_gpu 1":                    {"num_gpu", "1"},
 		"main_gpu 1":                   {"main_gpu", "1"},
 		"low_vram true":                {"low_vram", "true"},
+		"kv_cache_type f16":            {"kv_cache_type", "f16"},
 		"logits_all true":              {"logits_all", "true"},
 		"vocab_only true":              {"vocab_only", "true"},
 		"use_mmap true":                {"use_mmap", "true"},


### PR DESCRIPTION
This PR attempts to add support for setting the K/V cache quantization type directly from a model’s Modelfile, building on the recently merged K/V cache quantization feature introduced in PR #6279. The original contributor, **@sammcj**, invested months navigating architectural challenges and extensive review cycles to get K/V cache quantization into Ollama. Given the complexity involved, he understandably decided not to pursue Modelfile support further.

Currently, the most straightforward way to propagate Modelfile parameters (including `kv_cache_type`) into the codepaths that need them (`llm/memory.go:EstimateGPULayers` and `llm/server.go:NewLlamaServer`) is via `api.Options`. However, these codepaths are already tied to environment variables for K/V cache configuration. Integrating `kv_cache_type` from the Modelfile without significant architectural changes essentially requires hacky workarounds, such as writing the Modelfile’s `kv_cache_type` into an environment variable in `server/routes.go:modelOptions` and then relying on `envconfig.KvCacheType()` downstream.

This is not ideal and falls short of a clean, maintainable solution. But for users who need this functionality now and cannot wait months for a more elegant architectural change, this PR serves as a temporary measure or a reference point. It acknowledges the trade-offs and the imperfect nature of the approach, hoping that future efforts—potentially with deeper involvement from the Ollama team—will yield a more robust long-term solution.