### PR TITLE
Remove unused runner CpuFeatures

### DIFF
--- a/llama/llama.go
+++ b/llama/llama.go
@@ -96,8 +96,6 @@ import (
 	"unsafe"
 )
 
-var CpuFeatures = ""
-
 func BackendInit() {
 	C.llama_backend_init()
 }

--- a/make/Makefile.cpu
+++ b/make/Makefile.cpu
@@ -2,7 +2,7 @@
 
 include make/common-defs.make
 
-CPU_GOFLAGS="-ldflags=-w -s \"-X=github.com/ollama/ollama/version.Version=$(VERSION)\" \"-X=github.com/ollama/ollama/llama.CpuFeatures=$(subst $(space),$(comma),$(TARGET_CPU_FLAGS))\" $(TARGET_LDFLAGS)"
+CPU_GOFLAGS="-ldflags=-w -s \"-X=github.com/ollama/ollama/version.Version=$(VERSION)\"  $(TARGET_LDFLAGS)"
 ifeq ($(ARCH),amd64)
 ifeq ($(origin CUSTOM_CPU_FLAGS),undefined)
 	RUNNERS = cpu_avx cpu_avx2

--- a/make/Makefile.ollama
+++ b/make/Makefile.ollama
@@ -6,7 +6,7 @@ exe: $(OLLAMA_EXE)
 dist_exe dist_ollama: $(DIST_OLLAMA_EXE)
 
 GO_DEPS=$(foreach dir,$(shell go list -deps -f '{{.Dir}}' . ),$(wildcard $(dir)/*.go))
-CPU_GOFLAGS="-ldflags=-w -s \"-X=github.com/ollama/ollama/version.Version=$(VERSION)\" \"-X=github.com/ollama/ollama/llama.CpuFeatures=$(subst $(space),$(comma),$(TARGET_CPU_FLAGS))\" $(EXTRA_GOLDFLAGS) $(TARGET_LDFLAGS)"
+CPU_GOFLAGS="-ldflags=-w -s \"-X=github.com/ollama/ollama/version.Version=$(VERSION)\" $(EXTRA_GOLDFLAGS) $(TARGET_LDFLAGS)"
 
 $(OLLAMA_EXE) $(DIST_OLLAMA_EXE): TARGET_CPU_FLAGS=$(CUSTOM_CPU_FLAGS)
 $(OLLAMA_EXE) $(DIST_OLLAMA_EXE): $(COMMON_SRCS) $(COMMON_HDRS) $(GO_DEPS)

--- a/make/gpu.make
+++ b/make/gpu.make
@@ -5,7 +5,7 @@ dummy:
 	$(error This makefile is not meant to build directly, but instead included in other Makefiles that set required variables)
 endif
 
-GPU_GOFLAGS="-ldflags=-w -s \"-X=github.com/ollama/ollama/version.Version=$(VERSION)\" \"-X=github.com/ollama/ollama/llama.CpuFeatures=$(subst $(space),$(comma),$(GPU_RUNNER_CPU_FLAGS))\" $(EXTRA_GOLDFLAGS) $(TARGET_LDFLAGS)"
+GPU_GOFLAGS="-ldflags=-w -s \"-X=github.com/ollama/ollama/version.Version=$(VERSION)\" $(EXTRA_GOLDFLAGS) $(TARGET_LDFLAGS)"
 
 # TODO Unify how we handle dependencies in the dist/packaging and install flow
 # today, cuda is bundled, but rocm is split out.  Should split them each out by runner


### PR DESCRIPTION
The final implementation of #7499 removed dynamic vector requirements in favor of a simpler [filename based model](https://github.com/ollama/ollama/blob/main/runners/common.go#L125-L132), and this was left over logic that is no longer needed.