### PR TITLE
cmd: Add --base2 option to ps to show model sizes in KiB/MiB/GiB

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -626,6 +626,11 @@ func ListRunningHandler(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	base2, err := cmd.Flags().GetBool("base2")
+	if err != nil {
+		return err
+	}
+
 	models, err := client.ListRunning(cmd.Context())
 	if err != nil {
 		return err
@@ -656,7 +661,13 @@ func ListRunningHandler(cmd *cobra.Command, args []string) error {
 			} else {
 				until = format.HumanTime(m.ExpiresAt, "Never")
 			}
-			data = append(data, []string{m.Name, m.Digest[:12], format.HumanBytes(m.Size), procStr, until})
+			var size string
+			if base2 {
+				size = format.HumanBytes2(uint64(m.Size))
+			} else {
+				size = format.HumanBytes(m.Size)
+			}
+			data = append(data, []string{m.Name, m.Digest[:12], size, procStr, until})
 		}
 	}
 
@@ -1405,6 +1416,8 @@ func NewCLI() *cobra.Command {
 		PreRunE: checkServerHeartbeat,
 		RunE:    ListRunningHandler,
 	}
+
+	psCmd.Flags().Bool("base2", false, "Use base 2 units (KiB, MiB, GiB)")
 
 	copyCmd := &cobra.Command{
 		Use:     "cp SOURCE DESTINATION",


### PR DESCRIPTION
Add `--base2` option to ps to show model sizes in KiB/MiB/GiB.  It also shows a decimal place, but I consider this a feature.

```
industrial:~/projects/ollama-src$ ollama ps
NAME                                     ID              SIZE     PROCESSOR         UNTIL
DEFAULT/mistral-small-2409-22b:latest    671ad04c21ce    26 GB    7%/93% CPU/GPU    Forever

industrial:~/projects/ollama-src$ ollama ps --base2
NAME                                     ID              SIZE        PROCESSOR         UNTIL
DEFAULT/mistral-small-2409-22b:latest    671ad04c21ce    24.4 GiB    7%/93% CPU/GPU    Forever
```