### PR TITLE
ci: build dir changed

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -460,7 +460,6 @@ jobs:
         with:
           name: windows-arm64
           path: dist
-      - run: dir build
       - run: |
           import-module 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\Microsoft.VisualStudio.DevShell.dll'
           Enter-VsDevShell -vsinstallpath 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise' -skipautomaticlocation -DevCmdArguments '-arch=x64 -no_logo'


### PR DESCRIPTION
Remove no longer relevant build log dir

The build artifacts are no longer in ./build