### PR TITLE
Implement OLLAMA_MAX_KEEP_ALIVE environment variable

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1460,6 +1460,7 @@ func NewCLI() *cobra.Command {
 				envVars["OLLAMA_DEBUG"],
 				envVars["OLLAMA_HOST"],
 				envVars["OLLAMA_KEEP_ALIVE"],
+				envVars["OLLAMA_MAX_KEEP_ALIVE"],
 				envVars["OLLAMA_MAX_LOADED_MODELS"],
 				envVars["OLLAMA_MAX_QUEUE"],
 				envVars["OLLAMA_MODELS"],

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -263,6 +263,9 @@ Alternatively, you can change the amount of time all models are loaded into memo
 
 The `keep_alive` API parameter with the `/api/generate` and `/api/chat` API endpoints will override the `OLLAMA_KEEP_ALIVE` setting.
 
+For cooperative server environments, the maximum possible keep alive value for durations specified in the environment via `OLLAMA_KEEP_ALIVE` and the `keep_alive` API parameter can be limited using the `OLLAMA_MAX_KEEP_ALIVE` environment variable.
+All model in memory lifetimes will be limited to this value. Refer to the section explaining [how to configure the Ollama server](#how-do-i-configure-ollama-server) to correctly set the environment variable.
+
 ## How do I manage the maximum number of requests the Ollama server can queue?
 
 If too many requests are sent to the server, it will respond with a 503 error indicating the server is overloaded.  You can adjust how many requests may be queue by setting `OLLAMA_MAX_QUEUE`.

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -113,6 +113,28 @@ func KeepAlive() (keepAlive time.Duration) {
 	return keepAlive
 }
 
+// MaxKeepAlive returns the maximum duration that models may stay loaded in memory.
+// MaxKeepAlive can be configured via the OLLAMA_MAX_KEEP_ALIVE environment variable.
+// Negative values are treated as infinite.
+// Default is infinite, or -1.
+func MaxKeepAlive() (maxKeepAlive time.Duration) {
+	maxKeepAlive = time.Duration(math.MaxInt64)
+	if s := Var("OLLAMA_MAX_KEEP_ALIVE"); s != "" {
+		if d, err := time.ParseDuration(s); err == nil {
+			maxKeepAlive = d
+		} else if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+			maxKeepAlive = time.Duration(n) * time.Second
+		}
+	}
+
+	if maxKeepAlive < 0 {
+		return time.Duration(math.MaxInt64)
+	}
+
+	return maxKeepAlive
+}
+
+
 // LoadTimeout returns the duration for stall detection during model loads. LoadTimeout can be configured via the OLLAMA_LOAD_TIMEOUT environment variable.
 // Zero or Negative values are treated as infinite.
 // Default is 5 minutes.
@@ -239,6 +261,7 @@ func AsMap() map[string]EnvVar {
 		"OLLAMA_GPU_OVERHEAD":      {"OLLAMA_GPU_OVERHEAD", GpuOverhead(), "Reserve a portion of VRAM per GPU (bytes)"},
 		"OLLAMA_HOST":              {"OLLAMA_HOST", Host(), "IP Address for the ollama server (default 127.0.0.1:11434)"},
 		"OLLAMA_KEEP_ALIVE":        {"OLLAMA_KEEP_ALIVE", KeepAlive(), "The duration that models stay loaded in memory (default \"5m\")"},
+		"OLLAMA_MAX_KEEP_ALIVE":    {"OLLAMA_MAX_KEEP_ALIVE", MaxKeepAlive(), "The maximum duration that models stay loaded in memory, overriding OLLAMA_KEEP_ALIVE if it is larger. (default \"infinity\")"},
 		"OLLAMA_LLM_LIBRARY":       {"OLLAMA_LLM_LIBRARY", LLMLibrary(), "Set LLM library to bypass autodetection"},
 		"OLLAMA_LOAD_TIMEOUT":      {"OLLAMA_LOAD_TIMEOUT", LoadTimeout(), "How long to allow model loads to stall before giving up (default \"5m\")"},
 		"OLLAMA_MAX_LOADED_MODELS": {"OLLAMA_MAX_LOADED_MODELS", MaxRunners(), "Maximum number of loaded models per GPU"},

--- a/envconfig/config_test.go
+++ b/envconfig/config_test.go
@@ -219,6 +219,39 @@ func TestKeepAlive(t *testing.T) {
 	}
 }
 
+func TestMaxKeepAlive(t *testing.T) {
+	cases := map[string]time.Duration{
+		"":       time.Duration(math.MaxInt64),
+		"1s":     time.Second,
+		"1m":     time.Minute,
+		"1h":     time.Hour,
+		"5m0s":   5 * time.Minute,
+		"1h2m3s": 1*time.Hour + 2*time.Minute + 3*time.Second,
+		"0":      time.Duration(0),
+		"60":     60 * time.Second,
+		"120":    2 * time.Minute,
+		"3600":   time.Hour,
+		"-0":     time.Duration(0),
+		"-1":     time.Duration(math.MaxInt64),
+		"-1m":    time.Duration(math.MaxInt64),
+		// invalid values
+		" ":   time.Duration(math.MaxInt64),
+		"???": time.Duration(math.MaxInt64),
+		"1d":  time.Duration(math.MaxInt64),
+		"1y":  time.Duration(math.MaxInt64),
+		"1w":  time.Duration(math.MaxInt64),
+	}
+
+	for tt, expect := range cases {
+		t.Run(tt, func(t *testing.T) {
+			t.Setenv("OLLAMA_MAX_KEEP_ALIVE", tt)
+			if actual := MaxKeepAlive(); actual != expect {
+				t.Errorf("%s: expected %s, got %s", tt, expect, actual)
+			}
+		})
+	}
+}
+
 func TestLoadTimeout(t *testing.T) {
 	defaultTimeout := 5 * time.Minute
 	cases := map[string]time.Duration{


### PR DESCRIPTION
In cooperative server environments, it is desirable to cap the keep_alive value of models to a maximum duration. This enables server administrators to guarantee that models are unloaded at _some_ point if they are not needed anymore. 

For this, I propose to introduce the  `OLLAMA_MAX_KEEP_ALIVE` environment variable, which allows the administrator to specify a maximum keep alive value at which all other requests will be capped. This additionally disallows indefinite loading of models.