### PR TITLE
feat: add option to specify runner name and path in env

### DIFF
--- a/llm/server.go
+++ b/llm/server.go
@@ -146,7 +146,15 @@ func NewLlamaServer(gpus discover.GpuInfoList, model string, ggml *GGML, adapter
 	availableServers := runners.GetAvailableServers()
 
 	var servers []string
-	if cpuRunner != "" {
+
+	ollamaRunnerNameEnv := os.Getenv("OLLAMA_RUNNER_NAME")
+	ollamaRunnerPathEnv := os.Getenv("OLLAMA_RUNNER_PATH")
+
+	if ollamaRunnerNameEnv != "" && ollamaRunnerPathEnv != "" {
+		// Use server specified in environment variable
+		availableServers[ollamaRunnerNameEnv] = ollamaRunnerPathEnv
+		servers = []string{ollamaRunnerNameEnv}
+	} else if cpuRunner != "" {
 		servers = []string{cpuRunner}
 	} else {
 		servers = runners.ServersForGpu(gpus[0].RunnerName()) // All GPUs in the list are matching Library and Variant


### PR DESCRIPTION
Add option to specify custom runner path.
This will be useful as a temporary solution for [using vulkan](https://github.com/ollama/ollama/pull/5059) until the related PR is merged.


macOS:

```console
git clone https://github.com/thewh1teagle/ollama -b feat/custom-runner-path
cd ollama
echo "Building darwin arm64"
GOOS=darwin ARCH=arm64 GOARCH=arm64 make -j 8 dist
OLLAMA_DEBUG=true OLLAMA_RUNNER_NAME="cpu" OLLAMA_RUNNER_PATH="/path/to/custom/runner" ./dist/darwin-arm64/bin/ollama serve
```

Windows:

```console
# https://www.msys2.org/ 

C:\msys64\msys2_shell.cmd -here -no-start -defterm -clang64
pacman -S --needed $MINGW_PACKAGE_PREFIX-{go,clang,vulkan-devel,github-cli} make git
git clone https://github.com/thewh1teagle/ollama -b feat/custom-runner-path
cd ollama
export GOROOT=/c/msys64/clang64/lib/go
export CGO_ENABLED="1"
export CC="clang"
export CXX="clang++"
make -j 8
go build .

OLLAMA_DEBUG=true OLLAMA_RUNNER_NAME="cpu" OLLAMA_RUNNER_PATH="/path/to/runner.exe" ./ollama.exe serve
```