### PR TITLE
ci: fix artifact path prefix for missing windows payloads

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -447,15 +447,19 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: generate-windows-cpu
+          path: dist/windows-amd64/
       - uses: actions/download-artifact@v4
         with:
           name: generate-windows-cuda-11.3
+          path: dist/windows-amd64/
       - uses: actions/download-artifact@v4
         with:
           name: generate-windows-cuda-12.4
+          path: dist/windows-amd64/
       - uses: actions/download-artifact@v4
         with:
           name: generate-windows-rocm
+          path: dist/windows-amd64/
       - uses: actions/download-artifact@v4
         with:
           name: windows-arm64


### PR DESCRIPTION
upload-artifacts strips off leading common paths so when the ./build/ artifacts were removed, the ./dist/windows-amd64 prefix became common and was stripped, making the
later download-artifacts place them in the wrong location

Example intermediate artifact from before the build changes:
```
% unzip generate-windows-cuda-11.3.zip
Archive:  generate-windows-cuda-11.3.zip
  inflating: build/darwin/amd64/placeholder
  inflating: build/darwin/arm64/placeholder
  inflating: build/embed_darwin_amd64.go
  inflating: build/embed_darwin_arm64.go
  inflating: build/embed_linux.go
  inflating: build/embed_unused.go
  inflating: build/linux/amd64/placeholder
  inflating: build/linux/arm64/placeholder
  inflating: dist/windows-amd64/lib/ollama/cublas64_11.dll
  inflating: dist/windows-amd64/lib/ollama/cudart32_110.dll
  inflating: dist/windows-amd64/lib/ollama/cublasLt64_11.dll
  inflating: dist/windows-amd64/lib/ollama/cudart64_110.dll
  inflating: dist/windows-amd64/lib/ollama/ggml_cuda_v11.dll
  inflating: dist/windows-amd64/lib/ollama/runners/cuda_v11/ollama_llama_server.exe
```

Example artifact now:
```
% unzip generate-windows-cuda-11.3.zip
Archive:  generate-windows-cuda-11.3.zip
  inflating: lib/ollama/cublas64_11.dll
  inflating: lib/ollama/cublasLt64_11.dll
  inflating: lib/ollama/cudart64_110.dll
  inflating: lib/ollama/cudart32_110.dll
  inflating: lib/ollama/runners/cuda_v11_avx/ggml_cuda_v11.dll
  inflating: lib/ollama/runners/cuda_v11_avx/ollama_llama_server.exe
```