### PR TITLE
Refactor fixBlobs to use WalkDir for efficiency instead of Walk

### DIFF
--- a/server/fixblobs.go
+++ b/server/fixblobs.go
@@ -14,7 +14,6 @@ func fixBlobs(dir string) error {
 			return err
 		}
 
-		//Skip the directory
 		if d.IsDir() {
 			return nil
 		}

--- a/server/fixblobs.go
+++ b/server/fixblobs.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"

--- a/server/fixblobs.go
+++ b/server/fixblobs.go
@@ -9,10 +9,16 @@ import (
 // fixBlobs walks the provided dir and replaces (":") to ("-") in the file
 // prefix. (e.g. sha256:1234 -> sha256-1234)
 func fixBlobs(dir string) error {
-	return filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+	return filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
+
+		//Skip the directory
+		if d.IsDir() {
+			return nil
+		}
+
 		baseName := filepath.Base(path)
 		typ, sha, ok := strings.Cut(baseName, ":")
 		if ok && typ == "sha256" {

--- a/server/fixblobs.go
+++ b/server/fixblobs.go
@@ -9,7 +9,7 @@ import (
 // fixBlobs walks the provided dir and replaces (":") to ("-") in the file
 // prefix. (e.g. sha256:1234 -> sha256-1234)
 func fixBlobs(dir string) error {
-	return filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+	return filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
filepath.Walk calls os.Lstat for every file or directory to retrieve os.FileInfo, which can be slower.

filepath.WalkDir avoids unnecessary system calls since it provides a fs.DirEntry, which includes file type information without requiring a stat call.