### PR TITLE
llama: parse JSON schema using nlohmann::ordered_json

### DIFF
--- a/llama/sampling_ext.cpp
+++ b/llama/sampling_ext.cpp
@@ -49,7 +49,7 @@ int schema_to_grammar(const char *json_schema, char *grammar, size_t max_len)
 {
     try
     {
-        nlohmann::json schema = nlohmann::json::parse(json_schema);
+        nlohmann::ordered_json schema = nlohmann::ordered_json::parse(json_schema);
         std::string grammar_str = json_schema_to_grammar(schema);
         size_t len = grammar_str.length();
         if (len >= max_len)


### PR DESCRIPTION
PR #8002 has handled the JSON within Go to ensure we could keep the schema as-is, without affecting the order of the properties. However, when parsed within the cpp wrapper, `nlohmann::json` was used instead of relying on `nlohmann::ordered_json`. This PR simply changes the parser for the ordered one in order to maintain the order.