### PR TITLE
Support Unix sockets for OLLAMA_HOST

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1178,7 +1178,12 @@ func RunServer(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	ln, err := net.Listen("tcp", envconfig.Host().Host)
+	host := envconfig.Host()
+	scheme := host.Scheme
+	if scheme != "unix" {
+		scheme = "tcp"
+	}
+	ln, err := net.Listen(scheme, host.Host)
 	if err != nil {
 		return err
 	}

--- a/envconfig/config_test.go
+++ b/envconfig/config_test.go
@@ -35,6 +35,7 @@ func TestHost(t *testing.T) {
 		"https":               {"https://1.2.3.4", "https://1.2.3.4:443"},
 		"https port":          {"https://1.2.3.4:4321", "https://1.2.3.4:4321"},
 		"proxy path":          {"https://example.com/ollama", "https://example.com:443/ollama"},
+		"unix socket":         {"unix:///tmp/ollama.sock", "unix://%2Ftmp%2Follama.sock"},
 	}
 
 	for name, tt := range cases {


### PR DESCRIPTION
Add support for Unix sockets for OLLAMA_HOST.

```
OLLAMA_HOST=unix:///tmp/ollama.sock ./ollama serve
curl --unix-socket /tmp/ollama.sock localhost/v1/models
```


Implements https://github.com/ollama/ollama/issues/739.