### PR TITLE
Docs: Add /api/version endpoint to API documentation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1528,7 +1528,7 @@ curl http://localhost:11434/api/embeddings -d '{
 }
 ```
 
-## App Version
+## Version
 
 ```shell
 GET /api/version

--- a/docs/api.md
+++ b/docs/api.md
@@ -13,6 +13,7 @@
 - [Push a Model](#push-a-model)
 - [Generate Embeddings](#generate-embeddings)
 - [List Running Models](#list-running-models)
+- [App Version](#app-version)
 
 ## Conventions
 
@@ -1526,3 +1527,29 @@ curl http://localhost:11434/api/embeddings -d '{
   ]
 }
 ```
+
+## App Version
+
+```shell
+GET /api/version
+```
+
+This endpoint returns the current version of the Ollama installed on system.
+
+### Examples
+
+#### Request
+
+```shell
+curl http://localhost:11434/api/version
+```
+
+#### Response
+
+```json
+{
+  "version": "0.5.1"
+}
+```
+
+

--- a/docs/api.md
+++ b/docs/api.md
@@ -13,7 +13,7 @@
 - [Push a Model](#push-a-model)
 - [Generate Embeddings](#generate-embeddings)
 - [List Running Models](#list-running-models)
-- [App Version](#app-version)
+- [Version](#version)
 
 ## Conventions
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1534,7 +1534,7 @@ curl http://localhost:11434/api/embeddings -d '{
 GET /api/version
 ```
 
-This endpoint returns the current version of the Ollama installed on system.
+Retrieve the Ollama version
 
 ### Examples
 


### PR DESCRIPTION
This PR adds documentation for the `/api/version` endpoint to the Ollama API documentation. This endpoint allows clients to retrieve the Ollama server version, which is useful for ensuring compatibility with features that are dependent on specific server versions.

The `/api/version` endpoint was added in a previous commit but was not documented. This PR addresses that omission.

Resolves #8040 
