### PR TITLE
runner: switch logging back to stderr

### DIFF
--- a/llama/llama.go
+++ b/llama/llama.go
@@ -89,6 +89,7 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
+	"os"
 	"runtime"
 	"runtime/cgo"
 	"slices"
@@ -131,7 +132,7 @@ func llamaLog(level int32, text *C.char, _ unsafe.Pointer) {
 		return
 	}
 
-	fmt.Print(C.GoString(text))
+	fmt.Fprint(os.Stderr, C.GoString(text))
 }
 
 func GetModelArch(modelPath string) (string, error) {


### PR DESCRIPTION
This puts the low-level runner logging back on stderr for consistency with prior releases