### PR TITLE
ci: be more aggressive on parallelism in build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ ARG OLLAMA_FAST_BUILD
 ARG VERSION
 RUN --mount=type=cache,target=/root/.ccache \
     if grep "^flags" /proc/cpuinfo|grep avx>/dev/null; then \
-        make -j $(expr $(nproc) / 2 ) dist ; \
+        make -j $(nproc) dist ; \
     else \
         make -j 5 dist ; \
     fi


### PR DESCRIPTION
This might help speed up release builds.

The old algorithm was trying not to overwhelm systems with hyperthreading.