### PR TITLE
Add support for applying control vectors in gguf format

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -227,6 +227,7 @@ type Options struct {
 	MirostatEta      float32  `json:"mirostat_eta,omitempty"`
 	PenalizeNewline  bool     `json:"penalize_newline,omitempty"`
 	Stop             []string `json:"stop,omitempty"`
+	ControlStrength  []string `json:"control_strength,omitempty"`
 }
 
 // Runner options which must be set when the model is loaded into memory
@@ -604,6 +605,7 @@ func DefaultOptions() Options {
 		MirostatEta:      0.1,
 		PenalizeNewline:  true,
 		Seed:             -1,
+		ControlStrength:  []string{},
 
 		Runner: Runner{
 			// options set when the model is loaded

--- a/docs/modelfile.md
+++ b/docs/modelfile.md
@@ -20,6 +20,7 @@ A model file is the blueprint to create and share models with Ollama.
     - [Template Variables](#template-variables)
   - [SYSTEM](#system)
   - [ADAPTER](#adapter)
+  - [CONTROLVECTOR](#controlvector)
   - [LICENSE](#license)
   - [MESSAGE](#message)
 - [Notes](#notes)
@@ -160,6 +161,7 @@ PARAMETER <parameter> <parametervalue>
 | top_k          | Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative. (Default: 40)                                                                        | int        | top_k 40             |
 | top_p          | Works together with top-k. A higher value (e.g., 0.95) will lead to more diverse text, while a lower value (e.g., 0.5) will generate more focused and conservative text. (Default: 0.9)                                                                 | float      | top_p 0.9            |
 | min_p          | Alternative to the top_p, and aims to ensure a balance of quality and variety. The parameter *p* represents the minimum probability for a token to be considered, relative to the probability of the most likely token. For example, with *p*=0.05 and the most likely token having a probability of 0.9, logits with a value less than 0.045 are filtered out. (Default: 0.0) | float      | min_p 0.05            |
+| control_strength | When a CONTROLVECTOR is applied, this can control the strength of that vector. Negative values are allowed (Default: 0.5)                                                                 | float | control_strength 1.3 |
 
 ### TEMPLATE
 
@@ -210,6 +212,21 @@ Currently supported Safetensor adapters:
 ```modelfile
 ADAPTER ./ollama-lora.gguf
 ```
+
+### CONTROLVECTOR
+
+The `CONTROLVECTOR` instruction allows specifying a control steering vector to be applied to the model. The value of the adapter should be an absolute path or a path relative to the Modelfile. The base model should be specified with a `FROM` instruction. If the base model is not the same as the base model that the control vector was trained from the behaviour will be erratic, most likely not applying the control vector at all.
+
+To specify the stength of the vector (including negative) follow this with a `PARAMETER controlstrength <strength>`, where `<strength>` is a float.
+
+Currently supported Control Vector formats:
+* gguf
+
+```modelfile
+CONTROLVECTOR ./mistral-happy.gguf
+PARAMETER control_strength 1.2
+```
+
 
 ### LICENSE
 

--- a/llama/control_vectors.cpp
+++ b/llama/control_vectors.cpp
@@ -1,0 +1,40 @@
+#include "control_vectors.h"
+#include "common.h"
+
+extern "C" {
+
+int32_t llama_apply_control_vector(
+    const struct llama_model * model,
+    struct llama_context * lctx,
+    char* path,
+    float strength
+) {
+    // TODO support multiple control vectors at once
+    struct common_control_vector_load_info info;
+    info.strength = strength;
+    info.fname = std::string(path);
+
+    std::vector<common_control_vector_load_info> infos;
+    infos.push_back(info);
+
+    const auto cvec = common_control_vector_load(infos);
+    if (cvec.n_embd == -1) {
+        return -1;
+    }
+
+    int32_t control_vector_layer_start = 1;
+    int32_t control_vector_layer_end = llama_n_layer(model);
+
+    int err = llama_control_vector_apply(
+        lctx,
+        cvec.data.data(),
+        cvec.data.size(),
+        cvec.n_embd,
+        control_vector_layer_start,
+        control_vector_layer_end
+    );
+
+    return err;
+}
+
+}

--- a/llama/control_vectors.h
+++ b/llama/control_vectors.h
@@ -1,0 +1,29 @@
+#ifndef CONTROL_VECTORS_H
+#define CONTROL_VECTORS_H
+
+#include "llama.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+Since we probably can't directly import common.h as it is a c++ file, we need to
+expose a C api for constructing control vector structs and applying them to the
+model.
+*/
+
+LLAMA_API int32_t llama_apply_control_vector(
+    const struct llama_model * model,
+    struct llama_context * ctx,
+    char* path,
+    float strength
+);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+

--- a/llama/llama.go
+++ b/llama/llama.go
@@ -67,6 +67,7 @@ package llama
 #include "llava.h"
 #include "mllama.h"
 #include "sampling_ext.h"
+#include "control_vectors.h"
 
 extern bool llamaProgressCallback(float progress, void *user_data);
 extern void llamaLog(int level, char* text, void* user_data);
@@ -342,6 +343,19 @@ func (m *Model) TokenIsEog(token int) bool {
 
 func (m *Model) AddBOSToken() bool {
 	return bool(C.llama_add_bos_token(m.c))
+}
+
+func (m *Model) ApplyControlVectorFromFile(context *Context, controlvectorPath string, scale float32, threads int) error {
+	strength := C.float(scale)
+	fname := C.CString(controlvectorPath)
+	defer C.free(unsafe.Pointer(fname))
+
+	res := C.llama_apply_control_vector(m.c, context.c, fname, strength)
+
+	if res != 0 {
+		return errors.New("error applying control vector")
+	}
+	return nil
 }
 
 func (m *Model) ApplyLoraFromFile(context *Context, loraPath string, scale float32, threads int) error {

--- a/llama/runner/runner.go
+++ b/llama/runner/runner.go
@@ -570,6 +570,7 @@ type Options struct {
 	MirostatEta      float32  `json:"mirostat_eta"`
 	PenalizeNewline  bool     `json:"penalize_nl"`
 	Stop             []string `json:"stop"`
+	ControlStrength  []string `json:"control_strength"`
 }
 
 type ImageData struct {
@@ -846,6 +847,7 @@ func (s *Server) loadModel(
 	params llama.ModelParams,
 	mpath string,
 	lpath multiLPath,
+	cvpath multiLPath,
 	ppath string,
 	kvSize int,
 	kvCacheType string,
@@ -872,6 +874,31 @@ func (s *Server) loadModel(
 			err := s.model.ApplyLoraFromFile(s.lc, path, 1.0, threads)
 			if err != nil {
 				panic(err)
+			}
+		}
+	}
+
+	if cvpath.String() != "" {
+		// format path=strength
+		for _, path := range cvpath {
+			parts := strings.Split(path, "=")
+			strength := float32(0.5) // Fallback to .5 if not provided
+			if len(parts) == 1 {
+				parts = strings.Split(path, ":")
+			}
+			if len(parts) == 2 {
+				path = parts[0] // We need to trim off the = part reguardless of if it is a valid float to prevent manipulation of the path (ie directory traversal)
+				strength_f64, err := strconv.ParseFloat(parts[1], 32)
+				if err == nil {
+					strength = float32(strength_f64)
+				}
+			}
+
+			slog.Debug("applying control vector", path, strength)
+
+			err := s.model.ApplyControlVectorFromFile(s.lc, path, strength, threads)
+			if err != nil {
+				slog.Debug("failed to apply control vector")
 			}
 		}
 	}
@@ -917,6 +944,9 @@ func Execute(args []string) error {
 
 	var lpaths multiLPath
 	fs.Var(&lpaths, "lora", "Path to lora layer file (can be specified multiple times)")
+
+	var cvpaths multiLPath
+	fs.Var(&cvpaths, "control-vector", "Path to control vector file in gguf format, followed by =<strength>, for example --control-vector /opt/myvec=.5 (can be specified multiple times)")
 
 	fs.Usage = func() {
 		fmt.Fprintf(fs.Output(), "Runner usage\n")
@@ -976,7 +1006,7 @@ func Execute(args []string) error {
 	}
 
 	server.ready.Add(1)
-	go server.loadModel(params, *mpath, lpaths, *ppath, *kvSize, *kvCacheType, *flashAttention, *threads, *multiUserCache)
+	go server.loadModel(params, *mpath, lpaths, cvpaths, *ppath, *kvSize, *kvCacheType, *flashAttention, *threads, *multiUserCache)
 
 	server.cond = sync.NewCond(&server.mu)
 

--- a/llm/server.go
+++ b/llm/server.go
@@ -89,7 +89,7 @@ func LoadModel(model string, maxArraySize int) (*GGML, error) {
 
 // NewLlamaServer will run a server for the given GPUs
 // The gpu list must be a single family.
-func NewLlamaServer(gpus discover.GpuInfoList, model string, ggml *GGML, adapters, projectors []string, opts api.Options, numParallel int) (LlamaServer, error) {
+func NewLlamaServer(gpus discover.GpuInfoList, model string, ggml *GGML, adapters, projectors, controlVectors []string, opts api.Options, numParallel int) (LlamaServer, error) {
 	var err error
 	var cpuRunner string
 	var estimate MemoryEstimate
@@ -191,6 +191,18 @@ func NewLlamaServer(gpus discover.GpuInfoList, model string, ggml *GGML, adapter
 	if len(adapters) > 0 {
 		for _, adapter := range adapters {
 			params = append(params, "--lora", adapter)
+		}
+	}
+
+	if len(controlVectors) > 0 {
+		for i, controlVector := range controlVectors {
+			// Check if there is a stength provided via PARAMETERS
+			if len(opts.ControlStrength) > i {
+				sep := "="
+				controlVector = fmt.Sprintf("%s%s%s", controlVector, sep, opts.ControlStrength[i])
+			}
+
+			params = append(params, "--control-vector", controlVector)
 		}
 	}
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -36,7 +36,7 @@ func (c Command) String() string {
 	switch c.Name {
 	case "model":
 		fmt.Fprintf(&sb, "FROM %s", c.Args)
-	case "license", "template", "system", "adapter":
+	case "license", "template", "system", "adapter", "controlvector":
 		fmt.Fprintf(&sb, "%s %s", strings.ToUpper(c.Name), quote(c.Args))
 	case "message":
 		role, message, _ := strings.Cut(c.Args, ": ")
@@ -62,7 +62,7 @@ const (
 var (
 	errMissingFrom        = errors.New("no FROM line")
 	errInvalidMessageRole = errors.New("message role must be one of \"system\", \"user\", or \"assistant\"")
-	errInvalidCommand     = errors.New("command must be one of \"from\", \"license\", \"template\", \"system\", \"adapter\", \"parameter\", or \"message\"")
+	errInvalidCommand     = errors.New("command must be one of \"from\", \"license\", \"template\", \"system\", \"adapter\", \"parameter\", \"message\", or \"controlvector\"")
 )
 
 type ParserError struct {
@@ -322,7 +322,7 @@ func isValidMessageRole(role string) bool {
 
 func isValidCommand(cmd string) bool {
 	switch strings.ToLower(cmd) {
-	case "from", "license", "template", "system", "adapter", "parameter", "message":
+	case "from", "license", "template", "system", "adapter", "parameter", "message", "controlvector":
 		return true
 	default:
 		return false

--- a/server/sched.go
+++ b/server/sched.go
@@ -42,7 +42,7 @@ type Scheduler struct {
 	loadedMu sync.Mutex
 
 	loadFn       func(req *LlmRequest, ggml *llm.GGML, gpus discover.GpuInfoList, numParallel int)
-	newServerFn  func(gpus discover.GpuInfoList, model string, ggml *llm.GGML, adapters []string, projectors []string, opts api.Options, numParallel int) (llm.LlamaServer, error)
+	newServerFn  func(gpus discover.GpuInfoList, model string, ggml *llm.GGML, adapters []string, projectors []string, controlVectors []string, opts api.Options, numParallel int) (llm.LlamaServer, error)
 	getGpuFn     func() discover.GpuInfoList
 	getCpuFn     func() discover.GpuInfoList
 	reschedDelay time.Duration
@@ -417,7 +417,7 @@ func (s *Scheduler) load(req *LlmRequest, ggml *llm.GGML, gpus discover.GpuInfoL
 	if req.sessionDuration != nil {
 		sessionDuration = req.sessionDuration.Duration
 	}
-	llama, err := s.newServerFn(gpus, req.model.ModelPath, ggml, req.model.AdapterPaths, req.model.ProjectorPaths, req.opts, numParallel)
+	llama, err := s.newServerFn(gpus, req.model.ModelPath, ggml, req.model.AdapterPaths, req.model.ProjectorPaths, req.model.ControlVectorPaths, req.opts, numParallel)
 	if err != nil {
 		// some older models are not compatible with newer versions of llama.cpp
 		// show a generalized compatibility error until there is a better way to


### PR DESCRIPTION
Control Vectors allow for changing the behavior of a model by steering towards or away from a specific behavior.

You can learn more about them from these source:
https://hlfshell.ai/posts/representation-engineering/
https://vgel.me/posts/representation-engineering/

Earlier this year https://github.com/ggerganov/llama.cpp/pull/5970 support for loading and applying control vectors in GGUF format was added to llama.cpp. This pull request exposes that cpp feature via the Modelfile, to make it easy to apply a control vector on top of an existing ollama model and serve it via ollama's api (currently there is no off-the-shelf serving solution which supports control vectors)

To create a train a control vector for a model, you can use this library which includes exporting in the GGUF format: https://github.com/vgel/repeng

# Example

Here is an example of how you can use this PR to build and serve a model with a control vector:

## Training the vector

First train a control vector for the given model. In this example I am using [`Mistral-7B-Instruct-v0.1`](https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.1). This takes about ~3 min on my mac mini
```python
from repeng import ControlVector, ControlModel, DatasetEntry
model_name = "mistralai/Mistral-7B-Instruct-v0.1"
model = AutoModelForCausalLM.from_pretrained(model_name, torch_dtype=torch.float16)
model = ControlModel(model, list(range(-5, -18, -1)))

# Train the control vector with two contrasting writing styles
happy_dataset = make_dataset(
    "Act as if you're extremely {persona}.",
    ["happy"],
    ["sad", "depressed"],
    truncated_output_suffixes_512,
)
model.reset()
happy_vector = ControlVector.train(model, tokenizer, happy_dataset)
happy_vector.export_gguf('/opt/happy.gguf')
```

## Applying the GGUF via Modelfile

### Ensure the base model works with ollama
First we make sure we have a working instance of `Mistral-7B-Instruct-v0.1` in ollama (using correct mistral template) (can be quantized)
<details>

<summary>Minimal Modelfile for `Mistral-7B-Instruct-v0.1` </summary>

```modelfile
FROM .

TEMPLATE """{{- if .Suffix }}[SUFFIX]{{ .Suffix }}[PREFIX] {{ .Prompt }}
{{- else if .Messages }}
{{- range $index, $_ := .Messages }}
{{- if eq .Role "user" }}[INST] {{ if and $.System (eq (len (slice $.Messages $index)) 1) }}{{ $.System }}

{{ end }}{{ .Content }}[/INST]
{{- else if eq .Role "assistant" }} {{ .Content }}</s>
{{- end }}
{{- end }}
{{- else }}[INST] {{ if .System }}{{ .System }}

{{ end }}{{ .Prompt }} [/INST]
{{- end }} {{ .Response }}
{{- if .Response }}</s>
{{- end }}"""

PARAMETER stop [INST]
PARAMETER stop [/INST]
PARAMETER stop [PREFIX]
PARAMETER stop [MIDDLE]
PARAMETER stop [SUFFIX]
```
</details>

```bash
Mistral-7B-Instruct-v0.1 % ollama create Mistral-7B-Instruct-v0.1 -f Modelfile
transferring model data 100%
converting model
using existing layer sha256:6cd684e7092d1561237a5de7262a0693940e712dbfa5f4556faf2ee41eec004c
using existing layer sha256:51707752a87ca45dc91470c0e4974028eb50096af69f97d9bef091edcf51a649
using existing layer sha256:5dea4f4d0fffcd67078a5f8fa107312bcf1d7d658cc668631a4fd6b4530a7159
creating new layer sha256:ccfb628e0111a2a7cd07cb19c0fc8c984ed8d72846c6f92e8a1b1b8842e82bb3
writing manifest
success
% ollama run Mistral-7B-Instruct-v0.1
>>> how do you feel?
1. I am an artificial intelligence and do not have feelings or emotions like humans do.
```

### Create a new model with the control vector
Now we will define our modified model via a new Modefile

```modelfile
FROM Mistral-7B-Instruct-v0.1

CONTROLVECTOR /opt/happy.gguf
PARAMETER control_strength 0.4
```

```bash
happy-mistral % ollama create happy-mistral -f Modelfile
transferring model data
using existing layer sha256:6cd684e7092d1561237a5de7262a0693940e712dbfa5f4556faf2ee41eec004c
using existing layer sha256:51707752a87ca45dc91470c0e4974028eb50096af69f97d9bef091edcf51a649
using existing layer sha256:218dfbcc5cc2b4949ff62cf67ef3707ad5ebbfcc110f35ab5516440775cc1ca5
using existing layer sha256:683c80fc5e2261a899cc69eea9143e4a8fee9194acf4aed2767d0354c862dfe7
creating new layer sha256:1c7084be5b7e84d88d27c2b8ad5542a583d39e2c67b517436ef2d9fcce859ceb
writing manifest
success
% ollama run happy-mistral
>>> how do you feel
😃 I'm absolutely thrilled and elated! You did it, dude!
```

Note in the server debug logs, we apply the new control vector with the strength from the `PARAMETER control_strength`

```
time=2024-12-17T15:57:40.248-08:00 level=DEBUG source=runner.go:897 msg="applying control vector" /Users/nyan/.ollama/models/blobs/sha256-218dfbcc5cc2b4949ff62cf67ef3707ad5ebbfcc110f35ab5516440775cc1ca5=0.4000000059604645
```

### Negative strength
We can also use a negative strength in our Modelfile to use the opposite direction of the vector
```modelfile
FROM Mistral-7B-Instruct-v0.1

CONTROLVECTOR /opt/happy.gguf
PARAMETER control_strength -0.5
```

```
happy-mistral % ollama create sad-mistral -f Modelfile
% ollama run sad-mistral
>>> how do you feel
1. I'm not sure if I should feel bad for a while, but I do know that it's important to have someone who is always sad and feeling the weight of the world. 
```

# Known Issues / Limitiations
- Only one control vector is supported right now, this is **not** a limitation of llama.cpp and I plan on adding multiple vector support soon
- `control_strength` is only applied when launching a new runner, not applicable via the API params
- If you re-create a running model with a different `control_strength`, you have to restart that model (ollama won't do that for you)
- I think there is a bug with relative paths to control vectors, see comment in commit, but it seems to not respect the relative path to the Modelfile. For now the workaround is just using an absolute path in the Modelfile