### PR TITLE
Set n_ubatch parameter to same batch size as n_batch

### DIFF
--- a/llama/llama.go
+++ b/llama/llama.go
@@ -165,6 +165,7 @@ func NewContextParams(numCtx int, batchSize int, numSeqMax int, threads int, fla
 	params := C.llama_context_default_params()
 	params.n_ctx = C.uint(numCtx)
 	params.n_batch = C.uint(batchSize)
+	params.n_ubatch = C.uint(batchSize)
 	params.n_seq_max = C.uint(numSeqMax)
 	params.n_threads = C.int(threads)
 	params.n_threads_batch = params.n_threads


### PR DESCRIPTION
This change prevents panic during batch embeddings calculation

Relates to https://github.com/ollama/ollama/issues/3554

See also https://github.com/ggerganov/llama.cpp/issues/6263