### PR TITLE
fix crash bug with /save when quotes are used

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -485,6 +485,9 @@ func buildModelfile(opts runOptions) string {
 	}
 
 	for _, msg := range opts.Messages {
+		if strings.Contains(msg.Content, "\"") {
+			msg.Content = `"""` + msg.Content + `"""`
+		}
 		f.Commands = append(f.Commands, parser.Command{Name: "message", Args: fmt.Sprintf("%s: %s", msg.Role, msg.Content)})
 	}
 


### PR DESCRIPTION
This is a temporary fix for the `/save` command in the REPL to stop it from crashing when quotes are used.

This will be replaced when we introduce the new Create API.

Fixes #7551 