### PR TITLE
added source.go for syntax highlighting on code blocks

### DIFF
--- a/docs/template.md
+++ b/docs/template.md
@@ -32,7 +32,7 @@ Omitting a template in these models puts the responsibility of correctly templat
 
 To add templates in your model, you'll need to add a `TEMPLATE` command to the Modelfile. Here's an example using Meta's Llama 3.
 
-```source.dockerfile
+```dockerfile
 FROM llama3.2
 
 TEMPLATE """{{- if .System }}<|start_header_id|>system<|end_header_id|>

--- a/docs/template.md
+++ b/docs/template.md
@@ -32,7 +32,7 @@ Omitting a template in these models puts the responsibility of correctly templat
 
 To add templates in your model, you'll need to add a `TEMPLATE` command to the Modelfile. Here's an example using Meta's Llama 3.
 
-```dockerfile
+```source.dockerfile
 FROM llama3.2
 
 TEMPLATE """{{- if .System }}<|start_header_id|>system<|end_header_id|>
@@ -111,7 +111,7 @@ Keep the following tips and best practices in mind when working with Go template
 
 ChatML is a popular template format. It can be used for models such as Databrick's DBRX, Intel's Neural Chat, and Microsoft's Orca 2.
 
-```gotmpl
+```source.go
 {{- range .Messages }}<|im_start|>{{ .Role }}
 {{ .Content }}<|im_end|>
 {{ end }}<|im_start|>assistant
@@ -125,7 +125,7 @@ Tools support can be added to a model by adding a `{{ .Tools }}` node to the tem
 
 Mistral v0.3 and Mixtral 8x22B supports tool calling.
 
-```gotmpl
+```source.go
 {{- range $index, $_ := .Messages }}
 {{- if eq .Role "user" }}
 {{- if and (le (len (slice $.Messages $index)) 2) $.Tools }}[AVAILABLE_TOOLS] {{ json $.Tools }}[/AVAILABLE_TOOLS]
@@ -151,7 +151,7 @@ Fill-in-middle support can be added to a model by adding a `{{ .Suffix }}` node 
 
 CodeLlama [7B](https://ollama.com/library/codellama:7b-code) and [13B](https://ollama.com/library/codellama:13b-code) code completion models support fill-in-middle.
 
-```gotmpl
+```source.go
 <PRE> {{ .Prompt }} <SUF>{{ .Suffix }} <MID>
 ```
 

--- a/docs/template.md
+++ b/docs/template.md
@@ -151,7 +151,7 @@ Fill-in-middle support can be added to a model by adding a `{{ .Suffix }}` node 
 
 CodeLlama [7B](https://ollama.com/library/codellama:7b-code) and [13B](https://ollama.com/library/codellama:13b-code) code completion models support fill-in-middle.
 
-```source.go
+```go
 <PRE> {{ .Prompt }} <SUF>{{ .Suffix }} <MID>
 ```
 

--- a/docs/template.md
+++ b/docs/template.md
@@ -111,7 +111,7 @@ Keep the following tips and best practices in mind when working with Go template
 
 ChatML is a popular template format. It can be used for models such as Databrick's DBRX, Intel's Neural Chat, and Microsoft's Orca 2.
 
-```source.go
+```go
 {{- range .Messages }}<|im_start|>{{ .Role }}
 {{ .Content }}<|im_end|>
 {{ end }}<|im_start|>assistant

--- a/docs/template.md
+++ b/docs/template.md
@@ -125,7 +125,7 @@ Tools support can be added to a model by adding a `{{ .Tools }}` node to the tem
 
 Mistral v0.3 and Mixtral 8x22B supports tool calling.
 
-```source.go
+```go
 {{- range $index, $_ := .Messages }}
 {{- if eq .Role "user" }}
 {{- if and (le (len (slice $.Messages $index)) 2) $.Tools }}[AVAILABLE_TOOLS] {{ json $.Tools }}[/AVAILABLE_TOOLS]


### PR DESCRIPTION
the code blocks were just shown as raw preformatted text with the `golang` code block.

I changed the code block info string to the value of the `go` language `tm_scope` from linguist in https://github.com/github-linguist/linguist/blob/main/lib/linguist/languages.yml which works fine on my end.

I hope the highlight issue is a global thing, i've tested it on another browser.

I can update the other files if this is accepted, thank you.