### PR TITLE
Add back fallback CPU runner

### DIFF
--- a/make/Makefile.cpu
+++ b/make/Makefile.cpu
@@ -8,6 +8,7 @@ ifeq ($(origin CUSTOM_CPU_FLAGS),undefined)
 	RUNNERS = cpu_avx cpu_avx2
 endif
 endif
+RUNNERS += cpu
 
 DIST_RUNNERS = $(addprefix $(RUNNERS_DIST_DIR)/,$(addsuffix /ollama_llama_server$(EXE_EXT),$(RUNNERS)))
 BUILD_RUNNERS = $(addprefix $(RUNNERS_BUILD_DIR)/,$(addsuffix /ollama_llama_server$(EXE_EXT),$(RUNNERS)))
@@ -15,6 +16,11 @@ BUILD_RUNNERS = $(addprefix $(RUNNERS_BUILD_DIR)/,$(addsuffix /ollama_llama_serv
 cpu: $(BUILD_RUNNERS)
 
 dist: $(DIST_RUNNERS)
+
+$(RUNNERS_BUILD_DIR)/cpu/ollama_llama_server$(EXE_EXT): TARGET_CPU_FLAGS=""
+$(RUNNERS_BUILD_DIR)/cpu/ollama_llama_server$(EXE_EXT): ./llama/*.go ./llama/runner/*.go $(COMMON_SRCS) $(COMMON_HDRS)
+	@-mkdir -p $(dir $@)
+	GOARCH=$(ARCH) go build -buildmode=pie $(CPU_GOFLAGS) -trimpath -tags $(subst $(space),$(comma),$(TARGET_CPU_FLAGS)) -o $@ ./cmd/runner
 
 $(RUNNERS_BUILD_DIR)/cpu_avx/ollama_llama_server$(EXE_EXT): TARGET_CPU_FLAGS="avx"
 $(RUNNERS_BUILD_DIR)/cpu_avx/ollama_llama_server$(EXE_EXT): ./llama/*.go ./llama/runner/*.go $(COMMON_SRCS) $(COMMON_HDRS)


### PR DESCRIPTION
Previous versions of Ollama can build CPU runners without any optimization, but now (0.5.x) it can only build AVX and AVX2 variants. Add back `cpu` runner without any `TARGET_CPU_FLAGS` to enable this.