### PR TITLE
example: update langchain-python-rag-websummary, resolve deprecated class problem

### DIFF
--- a/examples/langchain-python-rag-websummary/main.py
+++ b/examples/langchain-python-rag-websummary/main.py
@@ -1,11 +1,11 @@
-from langchain_community.llms import Ollama
+from langchain_ollama.llms import OllamaLLM
 from langchain_community.document_loaders import WebBaseLoader
 from langchain.chains.summarize import load_summarize_chain
 
 loader = WebBaseLoader("https://ollama.com/blog/run-llama2-uncensored-locally")
 docs = loader.load()
 
-llm = Ollama(model="llama3.2")
+llm = OllamaLLM(model="llama3.2")
 chain = load_summarize_chain(llm, chain_type="stuff")
 
 result = chain.invoke(docs)

--- a/examples/langchain-python-rag-websummary/requirements.txt
+++ b/examples/langchain-python-rag-websummary/requirements.txt
@@ -1,1 +1,3 @@
-langchain==0.0.259
+langchain-ollama==0.2.2
+langchain-community==0.3.14
+beautifulsoup4==4.12.3


### PR DESCRIPTION
**Issue**
When running the original code, the following deprecation warning is encountered:
```bash
LangChainDeprecationWarning: The class Ollama was deprecated in LangChain 0.3.1 and will be removed in 1.0.0.
```
**Changes Made**

- Replaced the deprecated Ollama class with the updated implementation, it work with most recent LangChain version.
- Added BeautifulSoup4 to the project dependencies to support WebBaseLoader.
