### PR TITLE
better client error for /api/create

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -162,6 +162,9 @@ func CreateHandler(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := client.Create(cmd.Context(), req, fn); err != nil {
+		if strings.Contains(err.Error(), "path or Modelfile are required") {
+			return fmt.Errorf("the ollama server must be updated to use `ollama create` with this client")
+		}
 		return err
 	}
 

--- a/server/create.go
+++ b/server/create.go
@@ -33,6 +33,7 @@ var (
 	errOnlyOneAdapterSupported = errors.New("only one adapter is currently supported")
 	errOnlyGGUFSupported       = errors.New("supplied file was not in GGUF format")
 	errUnknownType             = errors.New("unknown type")
+	errNeitherFromOrFiles      = errors.New("neither 'from' or 'files' was specified")
 )
 
 func (s *Server) CreateHandler(c *gin.Context) {
@@ -95,7 +96,7 @@ func (s *Server) CreateHandler(c *gin.Context) {
 				return
 			}
 		} else {
-			ch <- gin.H{"error": "neither 'from' or 'files' was specified", "status": http.StatusBadRequest}
+			ch <- gin.H{"error": errNeitherFromOrFiles.Error(), "status": http.StatusBadRequest}
 			return
 		}
 


### PR DESCRIPTION
This change shows a mode descriptive error in the client w/ the `POST /api/create` endpoint if the client has been refreshed but the server hasn't been updated.