### PR TITLE
feat(install): use curl -C to continue download

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -12,6 +12,8 @@ error() { echo "${red}ERROR:${plain} $*"; exit 1; }
 warning() { echo "${red}WARNING:${plain} $*"; }
 
 TEMP_DIR=$(mktemp -d)
+DOWNLOAD_DIR=/tmp/ollama_download
+mkdir -p $DOWNLOAD_DIR
 cleanup() { rm -rf $TEMP_DIR; }
 trap cleanup EXIT
 
@@ -79,9 +81,14 @@ status "Installing ollama to $OLLAMA_INSTALL_DIR"
 $SUDO install -o0 -g0 -m755 -d $BINDIR
 $SUDO install -o0 -g0 -m755 -d "$OLLAMA_INSTALL_DIR"
 status "Downloading Linux ${ARCH} bundle"
-curl --fail --show-error --location --progress-bar \
-    "https://ollama.com/download/ollama-linux-${ARCH}.tgz${VER_PARAM}" | \
-    $SUDO tar -xzf - -C "$OLLAMA_INSTALL_DIR"
+
+OLLAMA_INSTALL_TGZ="ollama-linux-${ARCH}.tgz${VER_PARAM}"
+curl --fail --show-error --location --progress-bar -C - -o $DOWNLOAD_DIR/$OLLAMA_INSTALL_TGZ \
+    "https://ollama.com/download/$OLLAMA_INSTALL_TGZ"
+$SUDO tar -xzf $DOWNLOAD_DIR/$OLLAMA_INSTALL_TGZ -C "$OLLAMA_INSTALL_DIR"
+rm -rf $DOWNLOAD_DIR
+
+exit
 if [ "$OLLAMA_INSTALL_DIR/bin/ollama" != "$BINDIR/ollama" ] ; then
     status "Making ollama accessible in the PATH in $BINDIR"
     $SUDO ln -sf "$OLLAMA_INSTALL_DIR/ollama" "$BINDIR/ollama"


### PR DESCRIPTION
I've recently tried to install ollama on Raspberry Pi and due to a combination of slow memory card and unreliable WiFi the download of installation artifact failed multiple times. I had to start downloading from scratch each time. 

This PR modifies the `curl` command to use `-C` to continue download rather than restart. This also means that the file has to be actually stored (i.e. not piped to `tar`), so it also introduces a new temporary directory `/tmp/ollama_download` to store the dowloaded tgz, which is removed immediately after unpacking it.

WDYT?