### PR TITLE
convert: fix tensor iteration by calling Items() method

### DIFF
--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -75,7 +75,7 @@ func generateResultsJSON(t *testing.T, f *os.File, kv llm.KV, tensors *llm.Tenso
 		}
 	}
 
-	for _, tensor := range tensors.Items {
+	for _, tensor := range tensors.Items() {
 		sha256sum := sha256.New()
 		sr := io.NewSectionReader(f, int64(tensors.Offset+tensor.Offset), int64(tensor.Size()))
 		if _, err := io.Copy(sha256sum, sr); err != nil {


### PR DESCRIPTION
This fixes a range iteration error by properly calling the `Items()` method instead of trying to range over the method itself. 

Previously the code was attempting to iterate over the function definition of `Items`, which isn't the valid way to do a range over a function in Go. By adding parentheses to call the method, we now correctly iterate over the returned `[]*Tensor` slice.