### PR TITLE
Explicit mention `ollama serve` will start a server, friendly for new users

### DIFF
--- a/docs/linux.md
+++ b/docs/linux.md
@@ -20,7 +20,7 @@ curl -L https://ollama.com/download/ollama-linux-amd64.tgz -o ollama-linux-amd64
 sudo tar -C /usr -xzf ollama-linux-amd64.tgz
 ```
 
-Start Ollama:
+Start Ollama （this will start a long-running Ollama server):
 
 ```shell
 ollama serve


### PR DESCRIPTION
Different local LLM framework run differently. Some run as a stand-alone single while others run as server to serve API requests.
New users are coming to Ollama and we could make it clear in this quick start tutorial.