### PR TITLE
fix: add rootless container support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -197,5 +197,11 @@ ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
 ENV NVIDIA_VISIBLE_DEVICES=all
 
+RUN mkdir -p /.ollama && \
+    chown -R 1001:0 /.ollama && \
+    chmod -R g=u /.ollama
+
+USER 1001
+
 ENTRYPOINT ["/bin/ollama"]
 CMD ["serve"]


### PR DESCRIPTION
**Enable Rootless Container Deployment Support**

**Description**

This PR adds support for running ollama in rootless containers by properly setting up permissions for the `.ollama` directory. This change enables ollama to run in environments that enforce non-root execution such as:

* OpenShift
* Kubernetes with strict security contexts
* Containers with user namespace remapping
* Podman/Docker rootless mode

**Changes**

* Added directory creation and permission setup in the final stage of Dockerfile
* Set container to run as non-root user (UID 1001)
* Configured group permissions to support random GID assignment

**Testing Done**

* Built image with podman
* Deployed on OpenShift
* Verified container starts successfully with non-root user
* Confirmed `.ollama` directory is properly accessible

**Previous Behavior**

The container would fail to start in rootless environments with the error:

```
Couldn't find '/.ollama/id_ed25519'. Generating new private key.
Error: could not create directory mkdir /.ollama: permission denied
```

**New Behavior**

* Container starts successfully as non-root user
* `.ollama` directory is created with proper permissions
* Works in both root and rootless deployment scenarios

**Additional Notes**

This change maintains backward compatibility while adding support for secure container deployments. No application changes were required, only container configuration updates.

I hope this Markdown version is more readable and helpful!
