### PR TITLE
Fix absolute path names + gguf detection

### DIFF
--- a/parser/expandpath_test.go
+++ b/parser/expandpath_test.go
@@ -57,10 +57,10 @@ func TestExpandPath(t *testing.T) {
 		}
 
 		tests := []struct {
-			path            string
-			relativeDir     string
-			expected        string
-			shouldErr       bool
+			path        string
+			relativeDir string
+			expected    string
+			shouldErr   bool
 		}{
 			{"~", "", "/home/testuser", false},
 			{"~/myfolder/myfile.txt", "", "/home/testuser/myfolder/myfile.txt", false},
@@ -92,10 +92,10 @@ func TestExpandPath(t *testing.T) {
 		}
 
 		tests := []struct {
-			path            string
-			relativeDir     string
-			expected        string
-			shouldErr       bool
+			path        string
+			relativeDir string
+			expected    string
+			shouldErr   bool
 		}{
 			{"~", "", "D:\\home\\testuser", false},
 			{"~/myfolder/myfile.txt", "", "D:\\home\\testuser\\myfolder\\myfile.txt", false},

--- a/parser/expandpath_test.go
+++ b/parser/expandpath_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -45,39 +46,78 @@ func TestExpandPath(t *testing.T) {
 		return nil, os.ErrNotExist
 	}
 
-	tests := []struct {
-		path            string
-		relativeDir     string
-		expected        string
-		windowsExpected string
-		shouldErr       bool
-	}{
-		{"~", "", "/home/testuser", "D:\\home\\testuser", false},
-		{"~/myfolder/myfile.txt", "", "/home/testuser/myfolder/myfile.txt", "D:\\home\\testuser\\myfolder\\myfile.txt", false},
-		{"~anotheruser/docs/file.txt", "", "/home/anotheruser/docs/file.txt", "D:\\home\\anotheruser\\docs\\file.txt", false},
-		{"~nonexistentuser/file.txt", "", "", "", true},
-		{"relative/path/to/file", "", filepath.Join(os.Getenv("PWD"), "relative/path/to/file"), "relative\\path\\to\\file", false},
-		{"/absolute/path/to/file", "", "/absolute/path/to/file", "D:\\absolute\\path\\to\\file", false},
-		{"/absolute/path/to/file", "someotherdir/", "/absolute/path/to/file", "D:\\absolute\\path\\to\\file", false},
-		{".", os.Getenv("PWD"), os.Getenv("PWD"), os.Getenv("PWD"), false},
-		{".", "", os.Getenv("PWD"), os.Getenv("PWD"), false},
-		{"somefile", "somedir", filepath.Join(os.Getenv("PWD"), "somedir", "somefile"), "somedir\\somefile", false},
+	pwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	for _, test := range tests {
-		result, err := expandPathImpl(test.path, test.relativeDir, mockCurrentUser, mockLookupUser)
-		if (err != nil) != test.shouldErr {
-			t.Errorf("expandPathImpl(%q) returned error: %v, expected error: %v", test.path, err != nil, test.shouldErr)
+	t.Run("unix tests", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			return
 		}
 
-		if os.PathSeparator == '\\' {
-			if result != test.windowsExpected && !test.shouldErr {
-				t.Errorf("(win) expandPathImpl(%q) = %q, want %q", test.path, result, test.windowsExpected)
+		tests := []struct {
+			path            string
+			relativeDir     string
+			expected        string
+			shouldErr       bool
+		}{
+			{"~", "", "/home/testuser", false},
+			{"~/myfolder/myfile.txt", "", "/home/testuser/myfolder/myfile.txt", false},
+			{"~anotheruser/docs/file.txt", "", "/home/anotheruser/docs/file.txt", false},
+			{"~nonexistentuser/file.txt", "", "", true},
+			{"relative/path/to/file", "", filepath.Join(pwd, "relative/path/to/file"), false},
+			{"/absolute/path/to/file", "", "/absolute/path/to/file", false},
+			{"/absolute/path/to/file", "someotherdir/", "/absolute/path/to/file", false},
+			{".", pwd, pwd, false},
+			{".", "", pwd, false},
+			{"somefile", "somedir", filepath.Join(pwd, "somedir", "somefile"), false},
+		}
+
+		for _, test := range tests {
+			result, err := expandPathImpl(test.path, test.relativeDir, mockCurrentUser, mockLookupUser)
+			if (err != nil) != test.shouldErr {
+				t.Errorf("expandPathImpl(%q) returned error: %v, expected error: %v", test.path, err != nil, test.shouldErr)
 			}
-		} else {
+
 			if result != test.expected && !test.shouldErr {
 				t.Errorf("expandPathImpl(%q) = %q, want %q", test.path, result, test.expected)
 			}
 		}
-	}
+	})
+
+	t.Run("windows tests", func(t *testing.T) {
+		if runtime.GOOS != "windows" {
+			return
+		}
+
+		tests := []struct {
+			path            string
+			relativeDir     string
+			expected        string
+			shouldErr       bool
+		}{
+			{"~", "", "D:\\home\\testuser", false},
+			{"~/myfolder/myfile.txt", "", "D:\\home\\testuser\\myfolder\\myfile.txt", false},
+			{"~anotheruser/docs/file.txt", "", "D:\\home\\anotheruser\\docs\\file.txt", false},
+			{"~nonexistentuser/file.txt", "", "", true},
+			{"relative\\path\\to\\file", "", filepath.Join(pwd, "relative\\path\\to\\file"), false},
+			{"D:\\absolute\\path\\to\\file", "", "D:\\absolute\\path\\to\\file", false},
+			{"D:\\absolute\\path\\to\\file", "someotherdir/", "D:\\absolute\\path\\to\\file", false},
+			{".", pwd, pwd, false},
+			{".", "", pwd, false},
+			{"somefile", "somedir", filepath.Join(pwd, "somedir", "somefile"), false},
+		}
+
+		for _, test := range tests {
+			result, err := expandPathImpl(test.path, test.relativeDir, mockCurrentUser, mockLookupUser)
+			if (err != nil) != test.shouldErr {
+				t.Errorf("expandPathImpl(%q) returned error: %v, expected error: %v", test.path, err != nil, test.shouldErr)
+			}
+
+			if result != test.expected && !test.shouldErr {
+				t.Errorf("expandPathImpl(%q) = %q, want %q", test.path, result, test.expected)
+			}
+		}
+	})
 }

--- a/parser/expandpath_test.go
+++ b/parser/expandpath_test.go
@@ -43,6 +43,7 @@ func TestExpandPath(t *testing.T) {
 		{"~nonexistentuser/file.txt", "", "", "", true},
 		{"relative/path/to/file", "", filepath.Join(os.Getenv("PWD"), "relative/path/to/file"), "relative\\path\\to\\file", false},
 		{"/absolute/path/to/file", "", "/absolute/path/to/file", "D:\\absolute\\path\\to\\file", false},
+		{"/absolute/path/to/file", "someotherdir/", "/absolute/path/to/file", "D:\\absolute\\path\\to\\file", false},
 		{".", os.Getenv("PWD"), "", os.Getenv("PWD"), false},
 		{"somefile", "somedir", filepath.Join(os.Getenv("PWD"), "somedir", "somefile"), "somedir\\somefile", false},
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -591,6 +591,8 @@ func expandPathImpl(path, relativeDir string, currentUserFunc func() (*user.User
 		}
 
 		path = filepath.Join(homeDir, path)
+	} else if strings.HasPrefix(path, "/") {
+		return path, nil
 	} else {
 		path = filepath.Join(relativeDir, path)
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -564,7 +564,9 @@ func isValidCommand(cmd string) bool {
 }
 
 func expandPathImpl(path, relativeDir string, currentUserFunc func() (*user.User, error), lookupUserFunc func(string) (*user.User, error)) (string, error) {
-	if strings.HasPrefix(path, "~") {
+	if filepath.IsAbs(path) {
+		return path, nil
+	} else if strings.HasPrefix(path, "~") {
 		var homeDir string
 
 		if path == "~" || strings.HasPrefix(path, "~/") {
@@ -591,8 +593,6 @@ func expandPathImpl(path, relativeDir string, currentUserFunc func() (*user.User
 		}
 
 		path = filepath.Join(homeDir, path)
-	} else if filepath.IsAbs(path) {
-		return path, nil
 	} else {
 		path = filepath.Join(relativeDir, path)
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -591,7 +591,7 @@ func expandPathImpl(path, relativeDir string, currentUserFunc func() (*user.User
 		}
 
 		path = filepath.Join(homeDir, path)
-	} else if strings.HasPrefix(path, "/") {
+	} else if filepath.IsAbs(path) {
 		return path, nil
 	} else {
 		path = filepath.Join(relativeDir, path)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -565,7 +565,7 @@ func isValidCommand(cmd string) bool {
 
 func expandPathImpl(path, relativeDir string, currentUserFunc func() (*user.User, error), lookupUserFunc func(string) (*user.User, error)) (string, error) {
 	if filepath.IsAbs(path) || strings.HasPrefix(path, "\\") || strings.HasPrefix(path, "/") {
-		return path, nil
+		return filepath.Abs(path)
 	} else if strings.HasPrefix(path, "~") {
 		var homeDir string
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -564,7 +564,7 @@ func isValidCommand(cmd string) bool {
 }
 
 func expandPathImpl(path, relativeDir string, currentUserFunc func() (*user.User, error), lookupUserFunc func(string) (*user.User, error)) (string, error) {
-	if filepath.IsAbs(path) {
+	if filepath.IsAbs(path) || strings.HasPrefix(path, "\\") || strings.HasPrefix(path, "/") {
 		return path, nil
 	} else if strings.HasPrefix(path, "~") {
 		var homeDir string

--- a/server/create.go
+++ b/server/create.go
@@ -187,7 +187,7 @@ func detectModelTypeFromFiles(files map[string]string) string {
 			// try to see if we can find a gguf file even without the file extension
 			blobPath, err := GetBlobsPath(files[fn])
 			if err != nil {
-				slog.Error("error gettings blobs path")
+				slog.Error("error getting blobs path", "file", fn)
 				return ""
 			}
 
@@ -196,6 +196,8 @@ func detectModelTypeFromFiles(files map[string]string) string {
 				slog.Error("error reading file", "error", err)
 				return ""
 			}
+			defer f.Close()
+
 			buf := make([]byte, 4)
 			_, err = f.Read(buf)
 			if err != nil {

--- a/server/routes_create_test.go
+++ b/server/routes_create_test.go
@@ -754,7 +754,7 @@ func TestDetectModelTypeFromFiles(t *testing.T) {
 
 		data := []byte("12345678")
 		digest := fmt.Sprintf("sha256:%x", sha256.Sum256(data))
-		if err := os.MkdirAll(filepath.Join(p, "blobs"), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Join(p, "blobs"), 0o755); err != nil {
 			t.Fatal(err)
 		}
 
@@ -784,7 +784,7 @@ func TestDetectModelTypeFromFiles(t *testing.T) {
 
 		data := []byte("123")
 		digest := fmt.Sprintf("sha256:%x", sha256.Sum256(data))
-		if err := os.MkdirAll(filepath.Join(p, "blobs"), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Join(p, "blobs"), 0o755); err != nil {
 			t.Fatal(err)
 		}
 

--- a/server/routes_create_test.go
+++ b/server/routes_create_test.go
@@ -710,3 +710,51 @@ func TestCreateDetectTemplate(t *testing.T) {
 		})
 	})
 }
+
+func TestDetectModelTypeFromFiles(t *testing.T) {
+	t.Run("gguf file", func(t *testing.T) {
+		_, digest := createBinFile(t, nil, nil)
+		files := map[string]string{
+			"model.gguf": digest,
+		}
+
+		modelType := detectModelTypeFromFiles(files)
+		if modelType != "gguf" {
+			t.Fatalf("expected model type 'gguf', got %q", modelType)
+		}
+	})
+
+	t.Run("gguf file w/o extension", func(t *testing.T) {
+		_, digest := createBinFile(t, nil, nil)
+		files := map[string]string{
+			fmt.Sprintf("%x", digest): digest,
+		}
+
+		modelType := detectModelTypeFromFiles(files)
+		if modelType != "gguf" {
+			t.Fatalf("expected model type 'gguf', got %q", modelType)
+		}
+	})
+
+	t.Run("safetensors file", func(t *testing.T) {
+		files := map[string]string{
+			"model.safetensors": "sha256:abc123",
+		}
+
+		modelType := detectModelTypeFromFiles(files)
+		if modelType != "safetensors" {
+			t.Fatalf("expected model type 'safetensors', got %q", modelType)
+		}
+	})
+
+	t.Run("unsupported file type", func(t *testing.T) {
+		files := map[string]string{
+			"model.bin": "sha256:invalid",
+		}
+
+		modelType := detectModelTypeFromFiles(files)
+		if modelType != "" {
+			t.Fatalf("expected empty model type for unsupported file, got %q", modelType)
+		}
+	})
+}


### PR DESCRIPTION
This change fixes two issues with the model creation:

1. Absolute pathnames for GGUF files were being treated as a relative pathname; and
2. The GGUF image detection wasn't able to correctly determine if a GGUF file w/o the correct extension was actually a GGUF file.

This change fixes both issues and adds additional unit tests.

Fixes #8427 and #8423