### PR TITLE
Added golang template string manipulation functions, contains, hasPrefix, hasSuffix, split.

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -121,6 +121,11 @@ var funcs = template.FuncMap{
 		b, _ := json.Marshal(v)
 		return string(b)
 	},
+	"contains":  strings.Contains,
+	"split":     strings.Split,
+	"indexOf":   strings.Index,
+	"hasPrefix": strings.HasPrefix,
+	"hasSuffix": strings.HasSuffix,
 }
 
 func Parse(s string) (*Template, error) {
@@ -285,7 +290,7 @@ func (t *Template) Execute(w io.Writer, v Values) error {
 	})
 
 	tree := parse.Tree{Root: nodes.(*parse.ListNode)}
-	if err := template.Must(template.New("").AddParseTree("", &tree)).Execute(&b, map[string]any{
+	if err := template.Must(template.New("").Funcs(funcs).AddParseTree("", &tree)).Execute(&b, map[string]any{
 		"System":   system,
 		"Prompt":   prompt,
 		"Response": response,

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -376,3 +376,70 @@ func TestExecuteWithSuffix(t *testing.T) {
 		})
 	}
 }
+
+func TestStringFunctions(t *testing.T) {
+	cases := []struct {
+		name     string
+		template string
+		want     string
+	}{
+		{
+			name:     "contains (true)",
+			template: `{{ if contains "Hello World" "World" }}true{{ else }}false{{ end }}`,
+			want:     "true",
+		},
+		{
+			name:     "contains (false)",
+			template: `{{ if contains "Hello World" "world" }}true{{ else }}false{{ end }}`,
+			want:     "false",
+		},
+		{
+			name:     "split",
+			template: `{{ split "a,b,c" "," }}`,
+			want:     "[a b c]",
+		},
+		{
+			name:     "indexOf",
+			template: `{{ indexOf "Banana" "ana" }}`,
+			want:     "1", // first occurrence in "Banana" is at index 1
+		},
+		{
+			name:     "hasPrefix (true)",
+			template: `{{ if hasPrefix "foobar" "foo" }}yes{{ else }}no{{ end }}`,
+			want:     "yes",
+		},
+		{
+			name:     "hasPrefix (false)",
+			template: `{{ if hasPrefix "foobar" "bar" }}yes{{ else }}no{{ end }}`,
+			want:     "no",
+		},
+		{
+			name:     "hasSuffix (true)",
+			template: `{{ if hasSuffix "foobar" "bar" }}yes{{ else }}no{{ end }}`,
+			want:     "yes",
+		},
+		{
+			name:     "hasSuffix (false)",
+			template: `{{ if hasSuffix "foobar" "oo" }}yes{{ else }}no{{ end }}`,
+			want:     "no",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpl, err := Parse(tt.template)
+			if err != nil {
+				t.Fatal("Parse Error", err)
+			}
+
+			var buf bytes.Buffer
+			if err := tmpl.Execute(&buf, Values{}); err != nil {
+				t.Fatal("Execute Error", err)
+			}
+
+			if diff := cmp.Diff(tt.want, buf.String()); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Uncovered and corrected a bug where the Template.Execute block drops custom registered functions. Extended test suite to cover these new template functions. 
These have been introduced to support DeepSeek R1 models, their training templates elide old `<think>` blocks as the conversation progresses.
Supporting this use case;
```
  {{- else if eq $msg.Role "assistant" }}
    {{- if $is_tool }}
<｜tool▁outputs▁end｜>{{ $msg.Content }}<｜end▁of▁sentence｜>
      {{- $is_tool = false -}}
    {{- else }}
      {{- $content := $msg.Content -}}
      {{- /* Only strip chain-of-thought if we detect `</think>` via `contains` */ -}}
      {{- if (contains $content "</think>") }}
        {{- $parts := split $content "</think>" -}}
        {{- if gt (len $parts) 1 }}
          {{- $content = index $parts 1 -}}
        {{- end }}
      {{- end }}
<｜Assistant｜>{{ $content }}<｜end▁of▁sentence｜>
    {{- end }}
```

Duplicating this template (spacing mine):
```
{% set content = message['content'] %}
  {% if '</think>' in content %}
    {% set content = content.split('</think>')[-1] %}
  {% endif %}
  {{'<｜Assistant｜>' + content + '<｜end▁of▁sentence｜>'}}
{%- endif %}
```

Addresses: #8502 