### PR TITLE
Remove reference to the deleted examples folder

### DIFF
--- a/docs/modelfile.md
+++ b/docs/modelfile.md
@@ -67,8 +67,6 @@ To use this:
 3. `ollama run choose-a-model-name`
 4. Start using the model!
 
-More examples are available in the [examples directory](../examples).
-
 To view the Modelfile of a given model, use the `ollama show --modelfile` command.
 
   ```bash


### PR DESCRIPTION
The documentation links the reader to an examples folder which no longer exists.