### PR TITLE
Readme - add LlmTornado to libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [GoLamify](https://github.com/prasad89/golamify)
 - [Ollama for Haskell](https://github.com/tusharad/ollama-haskell)
 - [multi-llm-ts](https://github.com/nbonamy/multi-llm-ts) (A Typescript/JavaScript library allowing access to different LLM in unified API)
+- [LlmTornado](https://github.com/lofcz/llmtornado) (C# library providing a unified interface for major FOSS & Commercial inference APIs)
 
 ### Mobile
 


### PR DESCRIPTION
There is already [OllamaSharp](https://github.com/awaescher/OllamaSharp) for .NET, however, business applications often need to rely on a mixture of open-weights and commercial models, hence why I created [LlmTornado](https://github.com/lofcz/LlmTornado) about a year ago. We provide an Ollama demo in our readme and have Ollama inference tests in our test suite. OllamaSharp offers a rich Ollama-specific API, we merely use the OAI-compatibility, nevertheless, I believe this could be a useful addon to the list of libraries.