### PR TITLE
build: support Compute Capability 5.0, 5.2 and 5.3 for CUDA 12.x

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -28,7 +28,7 @@
       "name": "CUDA 12",
       "inherits": [ "CUDA" ],
       "cacheVariables": {
-        "CMAKE_CUDA_ARCHITECTURES": "60;61;62;70;72;75;80;86;87;89;90;90a"
+        "CMAKE_CUDA_ARCHITECTURES": "50;52;53;60;61;62;70;72;75;80;86;87;89;90;90a"
       }
     },
     {

--- a/discover/cuda_common.go
+++ b/discover/cuda_common.go
@@ -57,7 +57,8 @@ func cudaVariant(gpuInfo CudaGPUInfo) string {
 		}
 	}
 
-	if gpuInfo.computeMajor < 6 || gpuInfo.DriverMajor < 12 || (gpuInfo.DriverMajor == 12 && gpuInfo.DriverMinor == 0) {
+	// driver 12.0 has problems with the cuda v12 library, so run v11 on those older drivers
+	if gpuInfo.DriverMajor < 12 || (gpuInfo.DriverMajor == 12 && gpuInfo.DriverMinor == 0) {
 		return "v11"
 	}
 	return "v12"


### PR DESCRIPTION
CUDA 12.x still supports Compute Capability 5.0, 5.2 and 5.3, so let's build for these architectures as well

I have a GPU with CC 5.2 and confirmed that before the change ollama crashes, afterwards it works just fine.

source: https://stackoverflow.com/questions/28932864/which-compute-capability-is-supported-by-which-cuda-versions