### PR TITLE
Teach ollama to be patient

### DIFF
--- a/server/download.go
+++ b/server/download.go
@@ -365,7 +365,7 @@ func (b *blobDownload) downloadChunk(ctx context.Context, requestURL *url.URL, w
 				lastUpdated := part.lastUpdated
 				part.lastUpdatedMu.Unlock()
 
-				if !lastUpdated.IsZero() && time.Since(lastUpdated) > 5*time.Second {
+				if !lastUpdated.IsZero() && time.Since(lastUpdated) > 600*time.Second {
 					const msg = "%s part %d stalled; retrying. If this persists, press ctrl-c to exit, then 'ollama pull' to find a faster connection."
 					slog.Info(fmt.Sprintf(msg, b.Digest[7:19], part.N))
 					// reset last updated


### PR DESCRIPTION
Ollama has very stupid download behavior. It buffers in memory for way too long then dumps a huge buffer all at once to disk. This overloads my hard disk, brings the entire computer to a crawl. This takes more than 5 seconds to recover, and so ollama just gives up the download and starts over at 0. 

This fixes the bug.