### PR TITLE
openai: set `context_length` size 

### DIFF
--- a/docs/openai.md
+++ b/docs/openai.md
@@ -206,29 +206,29 @@ curl http://localhost:11434/v1/embeddings \
 
 ## Extra arguments
 
-### Setting context window size
-- `context_window` parameter can be used to set the context window for the model
+### Setting context length
+- `context_length` parameter can be used to set the context length for the model
 
 #### OpenAI python library 
-- OpenAI python library does not support setting context window size, however this can be set for Ollama through the `extra_body` parameter
+- OpenAI python library does not support setting context length, however this can be set for Ollama through the `extra_body` parameter
 
 ```py
 completion = client.chat.completions.create(
     model="llama3.1:8b",
     messages=[{"role": "user", "content": "Say this is a test"}],
-    extra_body={"context_window": 4096},
+    extra_body={"context_length": 4096},
 )
 ```
 
 #### OpenAI JavaScript library
-- OpenAI JavaScript library does not support setting context window size, however this can be set for Ollama by passing `num_ctx` directly with a `@ts-expect-error` as an undocumented parameter in the OpenAI JavaScript library. [See documentation here](https://github.com/openai/openai-node?tab=readme-ov-file#making-customundocumented-requests)
+- OpenAI JavaScript library does not support setting context length, however this can be set for Ollama by passing `context_length` directly with a `@ts-expect-error` as an undocumented parameter in the OpenAI JavaScript library. [See documentation here](https://github.com/openai/openai-node?tab=readme-ov-file#making-customundocumented-requests)
 
 ```ts
 const chatCompletion = await openai.chat.completions.create({
     messages: [{ role: 'user', content: 'Say this is a test' }],
     model: 'llama3.2',
-    // @ts-expect-error context_window is an additional parameter 
-    context_window: 4096,
+    // @ts-expect-error context_length is an additional parameter 
+    context_length: 4096,
 })
 ```
 
@@ -239,7 +239,7 @@ curl http://localhost:11434/v1/chat/completions \
     -d '{
         "model": "llama3.2",
         "messages": [{"role": "user", "content": "Say this is a test"}],
-        "context_window": 4096
+        "context_length": 4096
     }'
 ```
 

--- a/docs/openai.md
+++ b/docs/openai.md
@@ -94,12 +94,11 @@ except Exception as e:
     print(f"Error: {e}")
 ```
 
-#### Experimental 
+#### Extra Arguments 
 
 - `num_ctx` parameter can be used to set the context window for the model
 - OpenAI Python SDK does not support setting context window size, however this can be set for Ollama through the `extra_body` parameter
 
-- The recommended way to control this is through the [Ollama Python SDK](https://github.com/ollama/ollama-python) with the `options` parameter
 ```py
 completion = client.beta.chat.completions.create(
     model="llama3.1:8b",
@@ -156,12 +155,11 @@ const embedding = await openai.embeddings.create({
 })
 ```
 
-#### Experimental
+#### Extra Arguments 
 
 - `num_ctx` parameter can be used to set the context window for the model
 - OpenAI JS SDK does not support setting context window size, however this can be set for Ollama by passing `num_ctx` directly with a `@ts-expect-error` as an undocumented parameter in the [OpenAI JS SDK](https://github.com/openai/openai-node?tab=readme-ov-file#making-customundocumented-requests)
 
-- The recommended way to control this is through the [Ollama JS SDK](https://github.com/ollama/ollama-js) with the `options` parameter
 ```js
 const chatCompletion = await openai.chat.completions.create({
     messages: [{ role: 'user', content: 'Say this is a test' }],

--- a/docs/openai.md
+++ b/docs/openai.md
@@ -204,31 +204,31 @@ curl http://localhost:11434/v1/embeddings \
     }'
 ```
 
-## Extra Arguments
+## Extra arguments
 
-### Setting Context Window Size
-- `num_ctx` parameter can be used to set the context window for the model
+### Setting context window size
+- `context_window` parameter can be used to set the context window for the model
 
-#### OpenAI Python SDK
-- OpenAI Python SDK does not support setting context window size, however this can be set for Ollama through the `extra_body` parameter
+#### OpenAI python library 
+- OpenAI python library does not support setting context window size, however this can be set for Ollama through the `extra_body` parameter
 
 ```py
-completion = client.beta.chat.completions.create(
+completion = client.chat.completions.create(
     model="llama3.1:8b",
     messages=[{"role": "user", "content": "Say this is a test"}],
-    extra_body={"num_ctx": 4096},
+    extra_body={"context_window": 4096},
 )
 ```
 
-#### OpenAI JS SDK
-- OpenAI JS SDK does not support setting context window size, however this can be set for Ollama by passing `num_ctx` directly with a `@ts-expect-error` as an undocumented parameter in the [OpenAI JS SDK](https://github.com/openai/openai-node?tab=readme-ov-file#making-customundocumented-requests)
+#### OpenAI JavaScript library
+- OpenAI JavaScript library does not support setting context window size, however this can be set for Ollama by passing `num_ctx` directly with a `@ts-expect-error` as an undocumented parameter in the OpenAI JavaScript library. [See documentation here](https://github.com/openai/openai-node?tab=readme-ov-file#making-customundocumented-requests)
 
 ```ts
 const chatCompletion = await openai.chat.completions.create({
     messages: [{ role: 'user', content: 'Say this is a test' }],
     model: 'llama3.2',
-    // @ts-expect-error num_ctx is not officially supported
-    num_ctx: 4096,
+    // @ts-expect-error context_window is an additional parameter 
+    context_window: 4096,
 })
 ```
 
@@ -239,7 +239,7 @@ curl http://localhost:11434/v1/chat/completions \
     -d '{
         "model": "llama3.2",
         "messages": [{"role": "user", "content": "Say this is a test"}],
-        "num_ctx": 4096
+        "context_window": 4096
     }'
 ```
 

--- a/docs/openai.md
+++ b/docs/openai.md
@@ -94,19 +94,6 @@ except Exception as e:
     print(f"Error: {e}")
 ```
 
-#### Extra Arguments 
-
-- `num_ctx` parameter can be used to set the context window for the model
-- OpenAI Python SDK does not support setting context window size, however this can be set for Ollama through the `extra_body` parameter
-
-```py
-completion = client.beta.chat.completions.create(
-    model="llama3.1:8b",
-    messages=[{"role": "user", "content": "Say this is a test"}],
-    extra_body={"num_ctx": 4096},
-)
-```
-
 ### OpenAI JavaScript library
 
 ```javascript
@@ -152,20 +139,6 @@ const model = await openai.models.retrieve("llama3.2")
 const embedding = await openai.embeddings.create({
   model: "all-minilm",
   input: ["why is the sky blue?", "why is the grass green?"],
-})
-```
-
-#### Extra Arguments 
-
-- `num_ctx` parameter can be used to set the context window for the model
-- OpenAI JS SDK does not support setting context window size, however this can be set for Ollama by passing `num_ctx` directly with a `@ts-expect-error` as an undocumented parameter in the [OpenAI JS SDK](https://github.com/openai/openai-node?tab=readme-ov-file#making-customundocumented-requests)
-
-```js
-const chatCompletion = await openai.chat.completions.create({
-    messages: [{ role: 'user', content: 'Say this is a test' }],
-    model: 'llama3.2',
-    // @ts-expect-error num_ctx is not officially supported
-    num_ctx: 4096,
 })
 ```
 
@@ -228,6 +201,45 @@ curl http://localhost:11434/v1/embeddings \
     -d '{
         "model": "all-minilm",
         "input": ["why is the sky blue?", "why is the grass green?"]
+    }'
+```
+
+## Extra Arguments
+
+### Setting Context Window Size
+- `num_ctx` parameter can be used to set the context window for the model
+
+#### OpenAI Python SDK
+- OpenAI Python SDK does not support setting context window size, however this can be set for Ollama through the `extra_body` parameter
+
+```py
+completion = client.beta.chat.completions.create(
+    model="llama3.1:8b",
+    messages=[{"role": "user", "content": "Say this is a test"}],
+    extra_body={"num_ctx": 4096},
+)
+```
+
+#### OpenAI JS SDK
+- OpenAI JS SDK does not support setting context window size, however this can be set for Ollama by passing `num_ctx` directly with a `@ts-expect-error` as an undocumented parameter in the [OpenAI JS SDK](https://github.com/openai/openai-node?tab=readme-ov-file#making-customundocumented-requests)
+
+```ts
+const chatCompletion = await openai.chat.completions.create({
+    messages: [{ role: 'user', content: 'Say this is a test' }],
+    model: 'llama3.2',
+    // @ts-expect-error num_ctx is not officially supported
+    num_ctx: 4096,
+})
+```
+
+#### `curl`
+```shell
+curl http://localhost:11434/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+        "model": "llama3.2",
+        "messages": [{"role": "user", "content": "Say this is a test"}],
+        "num_ctx": 4096
     }'
 ```
 
@@ -367,27 +379,3 @@ curl http://localhost:11434/v1/chat/completions \
     }'
 ```
 
-### Setting the context size
-
-The OpenAI API does not have a way of setting the context size for a model. If you need to change the context size, create a `Modelfile` which looks like:
-
-```modelfile
-FROM <some model>
-PARAMETER num_ctx <context size>
-```
-
-Use the `ollama create mymodel` command to create a new model with the updated context size. Call the API with the updated model name:
-
-```shell
-curl http://localhost:11434/v1/chat/completions \
-    -H "Content-Type: application/json" \
-    -d '{
-        "model": "mymodel",
-        "messages": [
-            {
-                "role": "user",
-                "content": "Hello!"
-            }
-        ]
-    }'
-```

--- a/docs/openai.md
+++ b/docs/openai.md
@@ -94,6 +94,20 @@ except Exception as e:
     print(f"Error: {e}")
 ```
 
+#### Experimental 
+
+- `num_ctx` parameter can be used to set the context window for the model
+- OpenAI Python SDK does not support setting context window size, however this can be set for Ollama through the `extra_body` parameter
+
+- The recommended way to control this is through the [Ollama Python SDK](https://github.com/ollama/ollama-python) with the `options` parameter
+```py
+completion = client.beta.chat.completions.create(
+    model="llama3.1:8b",
+    messages=[{"role": "user", "content": "Say this is a test"}],
+    extra_body={"num_ctx": 4096},
+)
+```
+
 ### OpenAI JavaScript library
 
 ```javascript
@@ -139,6 +153,21 @@ const model = await openai.models.retrieve("llama3.2")
 const embedding = await openai.embeddings.create({
   model: "all-minilm",
   input: ["why is the sky blue?", "why is the grass green?"],
+})
+```
+
+#### Experimental
+
+- `num_ctx` parameter can be used to set the context window for the model
+- OpenAI JS SDK does not support setting context window size, however this can be set for Ollama by passing `num_ctx` directly with a `@ts-expect-error` as an undocumented parameter in the [OpenAI JS SDK](https://github.com/openai/openai-node?tab=readme-ov-file#making-customundocumented-requests)
+
+- The recommended way to control this is through the [Ollama JS SDK](https://github.com/ollama/ollama-js) with the `options` parameter
+```js
+const chatCompletion = await openai.chat.completions.create({
+    messages: [{ role: 'user', content: 'Say this is a test' }],
+    model: 'llama3.2',
+    // @ts-expect-error num_ctx is not officially supported
+    num_ctx: 4096,
 })
 ```
 
@@ -213,6 +242,7 @@ curl http://localhost:11434/v1/embeddings \
 - [x] Chat completions
 - [x] Streaming
 - [x] JSON mode
+- [x] Structured outputs
 - [x] Reproducible outputs
 - [x] Vision
 - [x] Tools

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -95,7 +95,7 @@ type ChatCompletionRequest struct {
 	TopP             *float64        `json:"top_p"`
 	ResponseFormat   *ResponseFormat `json:"response_format"`
 	Tools            []api.Tool      `json:"tools"`
-	ContextWindow    *int            `json:"context_window"`
+	ContextLength    *int            `json:"context_length"`
 }
 
 type ChatCompletion struct {
@@ -478,9 +478,8 @@ func fromChatRequest(r ChatCompletionRequest) (*api.ChatRequest, error) {
 		options["stop"] = stops
 	}
 
-	if r.ContextWindow != nil {
-		slog.Info("context_window in if", "context_window", *r.ContextWindow)
-		options["num_ctx"] = *r.ContextWindow
+	if r.ContextLength != nil {
+		options["num_ctx"] = *r.ContextLength
 	}
 
 	// Deprecated: MaxTokens is deprecated, use MaxCompletionTokens instead

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -487,13 +487,13 @@ func fromChatRequest(r ChatCompletionRequest) (*api.ChatRequest, error) {
 	}
 
 	DEFAULT_NUM_CTX := 2048
+	// set num_ctx to max_completion_tokens if it's greater than num_ctx
 	if r.MaxCompletionTokens != nil {
 		options["num_predict"] = *r.MaxCompletionTokens
-
-		if numCtx, ok := options["num_ctx"].(int); ok && *r.MaxCompletionTokens > numCtx {
+		if r.NumCtx != nil && *r.MaxCompletionTokens > *r.NumCtx {
 			options["num_ctx"] = *r.MaxCompletionTokens
 		} else if *r.MaxCompletionTokens > DEFAULT_NUM_CTX {
-			options["num_ctx"] = DEFAULT_NUM_CTX
+			options["num_ctx"] = *r.MaxCompletionTokens
 		}
 	}
 

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -86,7 +86,7 @@ type ChatCompletionRequest struct {
 	StreamOptions       *StreamOptions `json:"stream_options"`
 	MaxCompletionTokens *int           `json:"max_completion_tokens"`
 	// Deprecated: Use [ChatCompletionRequest.MaxCompletionTokens]
-	MaxTokens        *int            `json:"max_tokens" deprecated:"use max_completion_tokens instead"`
+	MaxTokens        *int            `json:"max_tokens"`
 	Seed             *int            `json:"seed"`
 	Stop             any             `json:"stop"`
 	Temperature      *float64        `json:"temperature"`
@@ -95,7 +95,7 @@ type ChatCompletionRequest struct {
 	TopP             *float64        `json:"top_p"`
 	ResponseFormat   *ResponseFormat `json:"response_format"`
 	Tools            []api.Tool      `json:"tools"`
-	NumCtx           *int            `json:"num_ctx"`
+	ContextWindow    *int            `json:"context_window"`
 }
 
 type ChatCompletion struct {
@@ -478,8 +478,9 @@ func fromChatRequest(r ChatCompletionRequest) (*api.ChatRequest, error) {
 		options["stop"] = stops
 	}
 
-	if r.NumCtx != nil {
-		options["num_ctx"] = *r.NumCtx
+	if r.ContextWindow != nil {
+		slog.Info("context_window in if", "context_window", *r.ContextWindow)
+		options["num_ctx"] = *r.ContextWindow
 	}
 
 	// Deprecated: MaxTokens is deprecated, use MaxCompletionTokens instead
@@ -974,6 +975,7 @@ func ChatMiddleware() gin.HandlerFunc {
 			c.AbortWithStatusJSON(http.StatusBadRequest, NewError(http.StatusBadRequest, err.Error()))
 			return
 		}
+		slog.Info("num_ctx", "num_ctx", chatReq.Options["num_ctx"])
 
 		if err := json.NewEncoder(&b).Encode(chatReq); err != nil {
 			c.AbortWithStatusJSON(http.StatusInternalServerError, NewError(http.StatusInternalServerError, err.Error()))

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -80,22 +80,22 @@ type StreamOptions struct {
 }
 
 type ChatCompletionRequest struct {
-	Model               string          `json:"model"`
-	Messages            []Message       `json:"messages"`
-	Stream              bool            `json:"stream"`
-	StreamOptions       *StreamOptions  `json:"stream_options"`
-	MaxCompletionTokens *int            `json:"max_completion_tokens"`
+	Model               string         `json:"model"`
+	Messages            []Message      `json:"messages"`
+	Stream              bool           `json:"stream"`
+	StreamOptions       *StreamOptions `json:"stream_options"`
+	MaxCompletionTokens *int           `json:"max_completion_tokens"`
 	// Deprecated: Use [ChatCompletionRequest.MaxCompletionTokens]
-	MaxTokens           *int            `json:"max_tokens" deprecated:"use max_completion_tokens instead"`
-	Seed                *int            `json:"seed"`
-	Stop                any             `json:"stop"`
-	Temperature         *float64        `json:"temperature"`
-	FrequencyPenalty    *float64        `json:"frequency_penalty"`
-	PresencePenalty     *float64        `json:"presence_penalty"`
-	TopP                *float64        `json:"top_p"`
-	ResponseFormat      *ResponseFormat `json:"response_format"`
-	Tools               []api.Tool      `json:"tools"`
-	NumCtx              *int            `json:"num_ctx"`
+	MaxTokens        *int            `json:"max_tokens" deprecated:"use max_completion_tokens instead"`
+	Seed             *int            `json:"seed"`
+	Stop             any             `json:"stop"`
+	Temperature      *float64        `json:"temperature"`
+	FrequencyPenalty *float64        `json:"frequency_penalty"`
+	PresencePenalty  *float64        `json:"presence_penalty"`
+	TopP             *float64        `json:"top_p"`
+	ResponseFormat   *ResponseFormat `json:"response_format"`
+	Tools            []api.Tool      `json:"tools"`
+	NumCtx           *int            `json:"num_ctx"`
 }
 
 type ChatCompletion struct {

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -85,6 +85,7 @@ type ChatCompletionRequest struct {
 	Stream              bool            `json:"stream"`
 	StreamOptions       *StreamOptions  `json:"stream_options"`
 	MaxCompletionTokens *int            `json:"max_completion_tokens"`
+	// Deprecated: Use [ChatCompletionRequest.MaxCompletionTokens]
 	MaxTokens           *int            `json:"max_tokens" deprecated:"use max_completion_tokens instead"`
 	Seed                *int            `json:"seed"`
 	Stop                any             `json:"stop"`

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -477,24 +477,17 @@ func fromChatRequest(r ChatCompletionRequest) (*api.ChatRequest, error) {
 		options["stop"] = stops
 	}
 
+	if r.NumCtx != nil {
+		options["num_ctx"] = *r.NumCtx
+	}
+
 	// Deprecated: MaxTokens is deprecated, use MaxCompletionTokens instead
 	if r.MaxTokens != nil {
 		r.MaxCompletionTokens = r.MaxTokens
 	}
 
-	if r.NumCtx != nil {
-		options["num_ctx"] = *r.NumCtx
-	}
-
-	DEFAULT_NUM_CTX := 2048
-	// set num_ctx to max_completion_tokens if it's greater than num_ctx
 	if r.MaxCompletionTokens != nil {
 		options["num_predict"] = *r.MaxCompletionTokens
-		if r.NumCtx != nil && *r.MaxCompletionTokens > *r.NumCtx {
-			options["num_ctx"] = *r.MaxCompletionTokens
-		} else if *r.MaxCompletionTokens > DEFAULT_NUM_CTX {
-			options["num_ctx"] = *r.MaxCompletionTokens
-		}
 	}
 
 	if r.Temperature != nil {

--- a/openai/openai_test.go
+++ b/openai/openai_test.go
@@ -81,7 +81,7 @@ func TestChatMiddleware(t *testing.T) {
 					{"role": "user", "content": "Hello"}
 				],
 				"stream":            true,
-				"max_completion_tokens":        999,
+				"max_tokens":        999,
 				"seed":              123,
 				"stop":              ["\n", "stop"],
 				"temperature":       3.0,
@@ -333,7 +333,7 @@ func TestChatMiddleware(t *testing.T) {
 			},
 		},
 		{
-			name: "chat handler with max_completion_tokens < num_ctx",
+			name: "chat handler with max_completion_tokens",
 			body: `{
 				"model": "test-model",
 				"messages": [{"role": "user", "content": "Hello"}],
@@ -344,25 +344,6 @@ func TestChatMiddleware(t *testing.T) {
 				Messages: []api.Message{{Role: "user", Content: "Hello"}},
 				Options: map[string]any{
 					"num_predict": 2.0, // float because JSON doesn't distinguish between float and int
-					"temperature": 1.0,
-					"top_p":       1.0,
-				},
-				Stream: &False,
-			},
-		},
-		{
-			name: "chat handler with max_completion_tokens > num_ctx",
-			body: `{
-				"model": "test-model",
-				"messages": [{"role": "user", "content": "Hello"}],
-				"max_completion_tokens": 4096
-			}`,
-			req: api.ChatRequest{
-				Model:    "test-model",
-				Messages: []api.Message{{Role: "user", Content: "Hello"}},
-				Options: map[string]any{
-					"num_predict": 4096.0, // float because JSON doesn't distinguish between float and int
-					"num_ctx":     4096.0,
 					"temperature": 1.0,
 					"top_p":       1.0,
 				},

--- a/openai/openai_test.go
+++ b/openai/openai_test.go
@@ -315,11 +315,11 @@ func TestChatMiddleware(t *testing.T) {
 			},
 		},
 		{
-			name: "chat handler with num_ctx",
+			name: "chat handler with context_window",
 			body: `{
 				"model": "test-model",
 				"messages": [{"role": "user", "content": "Hello"}],
-				"num_ctx": 4096 
+				"context_window": 4096 
 			}`,
 			req: api.ChatRequest{
 				Model:    "test-model",

--- a/openai/openai_test.go
+++ b/openai/openai_test.go
@@ -315,11 +315,11 @@ func TestChatMiddleware(t *testing.T) {
 			},
 		},
 		{
-			name: "chat handler with context_window",
+			name: "chat handler with context_length",
 			body: `{
 				"model": "test-model",
 				"messages": [{"role": "user", "content": "Hello"}],
-				"context_window": 4096 
+				"context_length": 4096 
 			}`,
 			req: api.ChatRequest{
 				Model:    "test-model",


### PR DESCRIPTION
> [!IMPORTANT]
> Closed in favor of #8938 


To change context window size using the openai supported endpoint:

#### `curl`
```shell
curl http://localhost:11434/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d '{
        "model": "llama3.2",
        "messages": [{"role": "user", "content": "Say this is a test"}],
        "context_length": 4096
    }'
```

#### OpenAI python library 
- OpenAI python library does not support setting context length, however this can be set for Ollama through the `extra_body` parameter

```py
completion = client.chat.completions.create(
    model="llama3.1:8b",
    messages=[{"role": "user", "content": "Say this is a test"}],
    extra_body={"context_length": 4096},
)
```

#### OpenAI JavaScript library
- OpenAI JavaScript library does not support setting context length, however this can be set for Ollama by passing `context_length` directly with a `@ts-expect-error` as an undocumented parameter in the OpenAI JavaScript library. [See documentation here](https://github.com/openai/openai-node?tab=readme-ov-file#making-customundocumented-requests)

```ts
const chatCompletion = await openai.chat.completions.create({
    messages: [{ role: 'user', content: 'Say this is a test' }],
    model: 'llama3.2',
    // @ts-expect-error context_length is an additional parameter 
    context_length: 4096,
})
```


This PR also adds support for `max_completion_tokens` to be on parity with OpenAI

closes: #6504, #8794, #5356