### PR TITLE
Remove hard-coded GIN mode

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -39,23 +39,9 @@ import (
 	"github.com/ollama/ollama/version"
 )
 
-var mode string = gin.DebugMode
-
 type Server struct {
 	addr  net.Addr
 	sched *Scheduler
-}
-
-func init() {
-	switch mode {
-	case gin.DebugMode:
-	case gin.ReleaseMode:
-	case gin.TestMode:
-	default:
-		mode = gin.DebugMode
-	}
-
-	gin.SetMode(mode)
 }
 
 var (


### PR DESCRIPTION
## Context
https://github.com/ollama/ollama/issues/8682: Gin mode is hard-coded to `gin.DebugMode` and the server displays this log on start up.
```
[GIN-debug] [WARNING] Running in "debug" mode. Switch to "release" mode in production.
```
## Changes
This PR removes hard-coded `gin.DebugMode` from the source code, which allows users to set the desired `GIN_MODE` via environment variable without modifying the source code.
Gin v1.10.0 loads `GIN_MODE` from the [environment variable](https://github.com/gin-gonic/gin/blob/v1.10.0/mode.go#L16-L25) and falls back to debug mode if it is unset by default. 
