### PR TITLE
Fix install_cuda_driver_yum() for dnf5

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -249,8 +249,14 @@ install_cuda_driver_yum() {
             fi
             ;;
         dnf)
+            DNF_VERSION=$(dnf --version | grep -E -o -m 1 "dnf[4-5]")
+            if [ "$DNF_VERSION" = "dnf5" ]; then
+                ADD_REPO_FMT="--addrepo"
+            else
+                ADD_REPO_FMT="--add-repo"
+            fi
             if curl -I --silent --fail --location "https://developer.download.nvidia.com/compute/cuda/repos/$1$2/$(uname -m | sed -e 's/aarch64/sbsa/')/cuda-$1$2.repo" >/dev/null ; then
-                $SUDO $PACKAGE_MANAGER config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/$1$2/$(uname -m | sed -e 's/aarch64/sbsa/')/cuda-$1$2.repo
+                $SUDO $PACKAGE_MANAGER config-manager $ADD_REPO_FMT https://developer.download.nvidia.com/compute/cuda/repos/$1$2/$(uname -m | sed -e 's/aarch64/sbsa/')/cuda-$1$2.repo
             else
                 error $CUDA_REPO_ERR_MSG
             fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -253,10 +253,10 @@ install_cuda_driver_yum() {
             if [ "$DNF_VERSION" = "dnf5" ]; then
                 DNF_COMPATIBILITY_FMT="addrepo --from-repofile="
             else
-                DNF_COMPATIBILITY_FMT="--add-repo"
+                DNF_COMPATIBILITY_FMT="--add-repo "
             fi
             if curl -I --silent --fail --location "https://developer.download.nvidia.com/compute/cuda/repos/$1$2/$(uname -m | sed -e 's/aarch64/sbsa/')/cuda-$1$2.repo" >/dev/null ; then
-                $SUDO $PACKAGE_MANAGER config-manager $DNF_COMPATIBILITY_FMT https://developer.download.nvidia.com/compute/cuda/repos/$1$2/$(uname -m | sed -e 's/aarch64/sbsa/')/cuda-$1$2.repo
+                $SUDO $PACKAGE_MANAGER config-manager ${DNF_COMPATIBILITY_FMT}https://developer.download.nvidia.com/compute/cuda/repos/$1$2/$(uname -m | sed -e 's/aarch64/sbsa/')/cuda-$1$2.repo
             else
                 error $CUDA_REPO_ERR_MSG
             fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -251,12 +251,12 @@ install_cuda_driver_yum() {
         dnf)
             DNF_VERSION=$(dnf --version | grep -E -o -m 1 "dnf[4-5]")
             if [ "$DNF_VERSION" = "dnf5" ]; then
-                ADD_REPO_FMT="--addrepo"
+                DNF_COMPATIBILITY_FMT="addrepo --from-repofile="
             else
-                ADD_REPO_FMT="--add-repo"
+                DNF_COMPATIBILITY_FMT="--add-repo"
             fi
             if curl -I --silent --fail --location "https://developer.download.nvidia.com/compute/cuda/repos/$1$2/$(uname -m | sed -e 's/aarch64/sbsa/')/cuda-$1$2.repo" >/dev/null ; then
-                $SUDO $PACKAGE_MANAGER config-manager $ADD_REPO_FMT https://developer.download.nvidia.com/compute/cuda/repos/$1$2/$(uname -m | sed -e 's/aarch64/sbsa/')/cuda-$1$2.repo
+                $SUDO $PACKAGE_MANAGER config-manager $DNF_COMPATIBILITY_FMT https://developer.download.nvidia.com/compute/cuda/repos/$1$2/$(uname -m | sed -e 's/aarch64/sbsa/')/cuda-$1$2.repo
             else
                 error $CUDA_REPO_ERR_MSG
             fi


### PR DESCRIPTION
This commit tests the version of dnf because in version 5 there was a change to the `--add-repo` flag to `--addrepo`, which would fail the script.