### PR TITLE
build: set goflags in linux release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -291,7 +291,7 @@ jobs:
       - uses: docker/setup-buildx-action@v3
       - run: |
           apt-get update && apt-get install pigz
-          for TARGET in ${{ matrix.targets }}; do docker buildx build --platform $PLATFORM --target $TARGET --output type=local,dest=dist/$PLATFORM .; done
+          for TARGET in ${{ matrix.targets }}; do docker buildx build --platform $PLATFORM --target $TARGET --build-arg GOFLAGS --output type=local,dest=dist/$PLATFORM .; done
           tar c -C dist/$PLATFORM . | pigz -9cv >dist/ollama-${PLATFORM//\//-}.tgz
         env:
           PLATFORM: ${{ matrix.os }}/${{ matrix.arch }}


### PR DESCRIPTION
GOFLAGS is set in the environment but need to tell docker to forward it to the build context