### PR TITLE
build: set CFLAGS for cpu

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v*'
 
+env:
+  CGO_CFLAGS: '-O3'
+  CGO_CXXFLAGS: '-O3'
+
 jobs:
   setup-environment:
     runs-on: ubuntu-latest
@@ -291,7 +295,7 @@ jobs:
       - uses: docker/setup-buildx-action@v3
       - run: |
           apt-get update && apt-get install pigz
-          for TARGET in ${{ matrix.targets }}; do docker buildx build --platform $PLATFORM --target $TARGET --build-arg GOFLAGS --output type=local,dest=dist/$PLATFORM .; done
+          for TARGET in ${{ matrix.targets }}; do docker buildx build --platform $PLATFORM --target $TARGET --build-arg GOFLAGS --build-arg CGO_CFLAGS --build-args CGO_CXXFLAGS --output type=local,dest=dist/$PLATFORM .; done
           tar c -C dist/$PLATFORM . | pigz -9cv >dist/ollama-${PLATFORM//\//-}.tgz
         env:
           PLATFORM: ${{ matrix.os }}/${{ matrix.arch }}
@@ -308,12 +312,16 @@ jobs:
           - flavor: 'latest=false'
             platforms: linux/amd64,linux/arm64
             build-args: |
+              CGO_CFLAGS=${{ env.CGO_CFLAGS }}
+              CGO_CXXFLAGS=${{ env.CGO_CXXFLAGS }}
               GOFLAGS=${{ needs.setup-environment.outputs.GOFLAGS }}
           - flavor: 'latest=false,suffix=rocm'
             platforms: linux/amd64
             build-args: |
-              GOFLAGS=${{ needs.setup-environment.outputs.GOFLAGS }}
+              CGO_CFLAGS=${{ env.CGO_CFLAGS }}
+              CGO_CXXFLAGS=${{ env.CGO_CXXFLAGS }}
               FLAVOR=rocm
+              GOFLAGS=${{ needs.setup-environment.outputs.GOFLAGS }}
     runs-on: linux
     environment: release
     needs: setup-environment

--- a/discover/gpu.go
+++ b/discover/gpu.go
@@ -3,7 +3,6 @@
 package discover
 
 /*
-#cgo CPPFLAGS: -O3
 #cgo linux LDFLAGS: -lrt -lpthread -ldl -lstdc++ -lm
 #cgo windows LDFLAGS: -lpthread
 

--- a/discover/gpu_darwin.go
+++ b/discover/gpu_darwin.go
@@ -4,7 +4,6 @@ package discover
 
 /*
 #cgo CFLAGS: -x objective-c
-#cgo CPPFLAGS: -O3
 #cgo LDFLAGS: -framework Foundation -framework CoreGraphics -framework Metal
 #include "gpu_info_darwin.h"
 */

--- a/llama/llama.cpp/examples/llava/llava.go
+++ b/llama/llama.cpp/examples/llava/llava.go
@@ -1,7 +1,6 @@
 package llava
 
 // #cgo CXXFLAGS: -std=c++11
-// #cgo CPPFLAGS: -O3
 // #cgo CPPFLAGS: -I${SRCDIR}/../../include -I${SRCDIR}/../../common
 // #cgo CPPFLAGS: -I${SRCDIR}/../../../../ml/backend/ggml/ggml/include
 import "C"

--- a/llama/llama.cpp/src/llama.go
+++ b/llama/llama.cpp/src/llama.go
@@ -1,7 +1,6 @@
 package llama
 
 // #cgo CXXFLAGS: -std=c++17
-// #cgo CPPFLAGS: -O3
 // #cgo CPPFLAGS: -I${SRCDIR}/../include
 // #cgo CPPFLAGS: -I${SRCDIR}/../../../ml/backend/ggml/ggml/include
 // #cgo windows CPPFLAGS: -D_WIN32_WINNT=0x0602

--- a/llama/llama.go
+++ b/llama/llama.go
@@ -3,7 +3,6 @@ package llama
 /*
 #cgo CFLAGS: -std=c11
 #cgo CXXFLAGS: -std=c++17
-#cgo CPPFLAGS: -O3
 #cgo CPPFLAGS: -I${SRCDIR}/llama.cpp/include
 #cgo CPPFLAGS: -I${SRCDIR}/llama.cpp/common
 #cgo CPPFLAGS: -I${SRCDIR}/llama.cpp/examples/llava

--- a/ml/backend/ggml/ggml/src/ggml-blas/blas.go
+++ b/ml/backend/ggml/ggml/src/ggml-blas/blas.go
@@ -3,7 +3,6 @@
 package blas
 
 // #cgo CXXFLAGS: -std=c++11
-// #cgo CPPFLAGS: -O3
 // #cgo CPPFLAGS: -DGGML_USE_BLAS
 // #cgo CPPFLAGS: -I${SRCDIR}/.. -I${SRCDIR}/../../include
 // #cgo darwin,arm64 CPPFLAGS: -DGGML_BLAS_USE_ACCELERATE -DACCELERATE_NEW_LAPACK -DACCELERATE_LAPACK_ILP64

--- a/ml/backend/ggml/ggml/src/ggml-cpu/cpu.go
+++ b/ml/backend/ggml/ggml/src/ggml-cpu/cpu.go
@@ -2,11 +2,9 @@ package cpu
 
 // #cgo CFLAGS: -Wno-implicit-function-declaration
 // #cgo CXXFLAGS: -std=c++17
-// #cgo CPPFLAGS: -O3
-// #cgo CPPFLAGS: -DGGML_USE_LLAMAFILE
 // #cgo CPPFLAGS: -I${SRCDIR}/amx -I${SRCDIR}/llamafile -I${SRCDIR}/.. -I${SRCDIR}/../../include
+// #cgo CPPFLAGS: -DGGML_USE_LLAMAFILE
 // #cgo linux CPPFLAGS: -D_GNU_SOURCE
-// #cgo arm64 CPPFLAGS: -DGGML_USE_AARCH64
 // #cgo darwin,arm64 CPPFLAGS: -DGGML_USE_ACCELERATE -DACCELERATE_NEW_LAPACK -DACCELERATE_LAPACK_ILP64
 // #cgo darwin,arm64 LDFLAGS: -framework Accelerate
 import "C"

--- a/ml/backend/ggml/ggml/src/ggml-cpu/cpu.go
+++ b/ml/backend/ggml/ggml/src/ggml-cpu/cpu.go
@@ -1,6 +1,6 @@
 package cpu
 
-// #cgo CFLAGS: -Wno-implicit-function-declaration
+// #cgo CFLAGS: -O3 -Wno-implicit-function-declaration
 // #cgo CXXFLAGS: -std=c++17
 // #cgo CPPFLAGS: -I${SRCDIR}/amx -I${SRCDIR}/llamafile -I${SRCDIR}/.. -I${SRCDIR}/../../include
 // #cgo CPPFLAGS: -DGGML_USE_LLAMAFILE

--- a/ml/backend/ggml/ggml/src/ggml-cpu/llamafile/llamafile.go
+++ b/ml/backend/ggml/ggml/src/ggml-cpu/llamafile/llamafile.go
@@ -1,6 +1,5 @@
 package llamafile
 
 // #cgo CXXFLAGS: -std=c++17
-// #cgo CPPFLAGS: -O3
 // #cgo CPPFLAGS: -I${SRCDIR}/.. -I${SRCDIR}/../.. -I${SRCDIR}/../../../include
 import "C"

--- a/ml/backend/ggml/ggml/src/ggml-metal/metal.go
+++ b/ml/backend/ggml/ggml/src/ggml-metal/metal.go
@@ -4,7 +4,6 @@ package metal
 
 //go:generate sh -c "{ echo // Code generated $(date). DO NOT EDIT.; sed -e '/__embed_ggml-common.h__/r ../ggml-common.h' -e '/__embed_ggml-common.h__/d' -e '/#include \"ggml-metal-impl.h\"/r ggml-metal-impl.h' -e '/#include \"ggml-metal-impl.h\"/d' ggml-metal.metal; } >ggml-metal-embed.metal"
 
-// #cgo CPPFLAGS: -O3
 // #cgo CPPFLAGS: -DGGML_METAL_EMBED_LIBRARY -I.. -I../../include
 // #cgo LDFLAGS: -framework Metal -framework MetalKit
 import "C"

--- a/ml/backend/ggml/ggml/src/ggml.go
+++ b/ml/backend/ggml/ggml/src/ggml.go
@@ -1,7 +1,6 @@
 package ggml
 
 // #cgo CXXFLAGS: -std=c++17
-// #cgo CPPFLAGS: -O3
 // #cgo CPPFLAGS: -DNDEBUG -DGGML_USE_CPU
 // #cgo CPPFLAGS: -I${SRCDIR}/../include -I${SRCDIR}/ggml-cpu
 // #cgo windows LDFLAGS: -lmsvcrt -static -static-libgcc -static-libstdc++

--- a/ml/backend/ggml/ggml/src/ggml_darwin_arm64.go
+++ b/ml/backend/ggml/ggml/src/ggml_darwin_arm64.go
@@ -1,6 +1,5 @@
 package ggml
 
-// #cgo CPPFLAGS: -O3
 // #cgo CPPFLAGS: -DGGML_USE_METAL -DGGML_USE_BLAS
 // #cgo LDFLAGS: -framework Foundation
 import "C"


### PR DESCRIPTION
`CPPFLAGS` doesn't get inserted into the right place and gets overwritten by the default `CFLAGS='-O2 -g'`. Set `CFLAGS` in the place it matters most in code and optionally configure it globally through `CGO_CFLAGS` and `CGO_CXXFLAGS` for release