### PR TITLE
fix docker build-args

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -312,16 +312,18 @@ jobs:
           - flavor: 'latest=false'
             platforms: linux/amd64,linux/arm64
             build-args: |
-              CGO_CFLAGS=${{ env.CGO_CFLAGS }}
-              CGO_CXXFLAGS=${{ env.CGO_CXXFLAGS }}
-              GOFLAGS=${{ needs.setup-environment.outputs.GOFLAGS }}
+              CGO_CFLAGS
+              CGO_CXXFLAGS
+              GOFLAGS
           - flavor: 'latest=false,suffix=rocm'
             platforms: linux/amd64
             build-args: |
-              CGO_CFLAGS=${{ env.CGO_CFLAGS }}
-              CGO_CXXFLAGS=${{ env.CGO_CXXFLAGS }}
+              CGO_CFLAGS
+              CGO_CXXFLAGS
+              GOFLAGS
               FLAVOR=rocm
-              GOFLAGS=${{ needs.setup-environment.outputs.GOFLAGS }}
+    env:
+      GOFLAGS: ${{ needs.setup-environment.outputs.GOFLAGS }}
     runs-on: linux
     environment: release
     needs: setup-environment


### PR DESCRIPTION
`env` context is not accessible from `job.*.strategy`. since it's in the environment, just tell Docker to use the environment variable

> You can also use the --build-arg flag without a value, in which case the daemon propagates the value from the local environment into the Docker container it's building

https://docs.docker.com/reference/cli/docker/buildx/build/#build-arg