### PR TITLE
Ollama getting index oob exception

### DIFF
--- a/server/download.go
+++ b/server/download.go
@@ -170,8 +170,7 @@ func (b *blobDownload) Prepare(ctx context.Context, requestURL *url.URL, opts *r
 
 			offset += size
 		}
-	}
-	if len(b.Parts) != 0 {
+	} else {
 		slog.Info(fmt.Sprintf("downloading %s in %d %s part(s)", b.Digest[7:19], len(b.Parts), format.HumanBytes(b.Parts[0].Size)))
 	}
 	return nil

--- a/server/download.go
+++ b/server/download.go
@@ -171,8 +171,9 @@ func (b *blobDownload) Prepare(ctx context.Context, requestURL *url.URL, opts *r
 			offset += size
 		}
 	}
-
-	slog.Info(fmt.Sprintf("downloading %s in %d %s part(s)", b.Digest[7:19], len(b.Parts), format.HumanBytes(b.Parts[0].Size)))
+	if len(b.Parts) != 0 {
+		slog.Info(fmt.Sprintf("downloading %s in %d %s part(s)", b.Digest[7:19], len(b.Parts), format.HumanBytes(b.Parts[0].Size)))
+	}
 	return nil
 }
 


### PR DESCRIPTION
When looking at some of the tickets, I was noticing a lot of them revolving around: #8745

Ollama Server is getting Index OOB on line 175 of server/downloads.go.

It seemed to be something common, with the array being empty and trying to reference the first index.  This should resolve it.