### PR TITLE
Configurable windows CPU process priority for runnner

### DIFF
--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -251,7 +251,7 @@ func AsMap() map[string]EnvVar {
 		"OLLAMA_ORIGINS":           		{"OLLAMA_ORIGINS", Origins(), "A comma separated list of allowed origins"},
 		"OLLAMA_SCHED_SPREAD":      		{"OLLAMA_SCHED_SPREAD", SchedSpread(), "Always schedule model across all GPUs"},
 		"OLLAMA_MULTIUSER_CACHE":   		{"OLLAMA_MULTIUSER_CACHE", MultiUserCache(), "Optimize prompt caching for multi-user scenarios"},
-		"OLLAMA_WINDOWS_PROCESS_PRIORITY": 	{"OLLAMA_WINDOWS_PROCESS_PRIORITY", WindowsProcessPriority(), "Set process priority when running on Windows"}
+		"OLLAMA_WINDOWS_PROCESS_PRIORITY": 	{"OLLAMA_WINDOWS_PROCESS_PRIORITY", WindowsProcessPriority(), "Set process priority when running on Windows"},
 
 		// Informational
 		"HTTP_PROXY":  {"HTTP_PROXY", String("HTTP_PROXY")(), "HTTP proxy"},

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -176,11 +176,12 @@ func String(s string) func() string {
 var (
 	LLMLibrary = String("OLLAMA_LLM_LIBRARY")
 
-	CudaVisibleDevices    = String("CUDA_VISIBLE_DEVICES")
-	HipVisibleDevices     = String("HIP_VISIBLE_DEVICES")
-	RocrVisibleDevices    = String("ROCR_VISIBLE_DEVICES")
-	GpuDeviceOrdinal      = String("GPU_DEVICE_ORDINAL")
-	HsaOverrideGfxVersion = String("HSA_OVERRIDE_GFX_VERSION")
+	CudaVisibleDevices     = String("CUDA_VISIBLE_DEVICES")
+	HipVisibleDevices      = String("HIP_VISIBLE_DEVICES")
+	RocrVisibleDevices     = String("ROCR_VISIBLE_DEVICES")
+	GpuDeviceOrdinal       = String("GPU_DEVICE_ORDINAL")
+	HsaOverrideGfxVersion  = String("HSA_OVERRIDE_GFX_VERSION")
+	WindowsProcessPriority = String("OLLAMA_WINDOWS_PROCESS_PRIORITY")
 )
 
 func Uint(key string, defaultValue uint) func() uint {
@@ -233,23 +234,24 @@ type EnvVar struct {
 
 func AsMap() map[string]EnvVar {
 	ret := map[string]EnvVar{
-		"OLLAMA_DEBUG":             {"OLLAMA_DEBUG", Debug(), "Show additional debug information (e.g. OLLAMA_DEBUG=1)"},
-		"OLLAMA_FLASH_ATTENTION":   {"OLLAMA_FLASH_ATTENTION", FlashAttention(), "Enabled flash attention"},
-		"OLLAMA_KV_CACHE_TYPE":     {"OLLAMA_KV_CACHE_TYPE", KvCacheType(), "Quantization type for the K/V cache (default: f16)"},
-		"OLLAMA_GPU_OVERHEAD":      {"OLLAMA_GPU_OVERHEAD", GpuOverhead(), "Reserve a portion of VRAM per GPU (bytes)"},
-		"OLLAMA_HOST":              {"OLLAMA_HOST", Host(), "IP Address for the ollama server (default 127.0.0.1:11434)"},
-		"OLLAMA_KEEP_ALIVE":        {"OLLAMA_KEEP_ALIVE", KeepAlive(), "The duration that models stay loaded in memory (default \"5m\")"},
-		"OLLAMA_LLM_LIBRARY":       {"OLLAMA_LLM_LIBRARY", LLMLibrary(), "Set LLM library to bypass autodetection"},
-		"OLLAMA_LOAD_TIMEOUT":      {"OLLAMA_LOAD_TIMEOUT", LoadTimeout(), "How long to allow model loads to stall before giving up (default \"5m\")"},
-		"OLLAMA_MAX_LOADED_MODELS": {"OLLAMA_MAX_LOADED_MODELS", MaxRunners(), "Maximum number of loaded models per GPU"},
-		"OLLAMA_MAX_QUEUE":         {"OLLAMA_MAX_QUEUE", MaxQueue(), "Maximum number of queued requests"},
-		"OLLAMA_MODELS":            {"OLLAMA_MODELS", Models(), "The path to the models directory"},
-		"OLLAMA_NOHISTORY":         {"OLLAMA_NOHISTORY", NoHistory(), "Do not preserve readline history"},
-		"OLLAMA_NOPRUNE":           {"OLLAMA_NOPRUNE", NoPrune(), "Do not prune model blobs on startup"},
-		"OLLAMA_NUM_PARALLEL":      {"OLLAMA_NUM_PARALLEL", NumParallel(), "Maximum number of parallel requests"},
-		"OLLAMA_ORIGINS":           {"OLLAMA_ORIGINS", Origins(), "A comma separated list of allowed origins"},
-		"OLLAMA_SCHED_SPREAD":      {"OLLAMA_SCHED_SPREAD", SchedSpread(), "Always schedule model across all GPUs"},
-		"OLLAMA_MULTIUSER_CACHE":   {"OLLAMA_MULTIUSER_CACHE", MultiUserCache(), "Optimize prompt caching for multi-user scenarios"},
+		"OLLAMA_DEBUG":             		{"OLLAMA_DEBUG", Debug(), "Show additional debug information (e.g. OLLAMA_DEBUG=1)"},
+		"OLLAMA_FLASH_ATTENTION":   		{"OLLAMA_FLASH_ATTENTION", FlashAttention(), "Enabled flash attention"},
+		"OLLAMA_KV_CACHE_TYPE":     		{"OLLAMA_KV_CACHE_TYPE", KvCacheType(), "Quantization type for the K/V cache (default: f16)"},
+		"OLLAMA_GPU_OVERHEAD":      		{"OLLAMA_GPU_OVERHEAD", GpuOverhead(), "Reserve a portion of VRAM per GPU (bytes)"},
+		"OLLAMA_HOST":              		{"OLLAMA_HOST", Host(), "IP Address for the ollama server (default 127.0.0.1:11434)"},
+		"OLLAMA_KEEP_ALIVE":        		{"OLLAMA_KEEP_ALIVE", KeepAlive(), "The duration that models stay loaded in memory (default \"5m\")"},
+		"OLLAMA_LLM_LIBRARY":       		{"OLLAMA_LLM_LIBRARY", LLMLibrary(), "Set LLM library to bypass autodetection"},
+		"OLLAMA_LOAD_TIMEOUT":      		{"OLLAMA_LOAD_TIMEOUT", LoadTimeout(), "How long to allow model loads to stall before giving up (default \"5m\")"},
+		"OLLAMA_MAX_LOADED_MODELS": 		{"OLLAMA_MAX_LOADED_MODELS", MaxRunners(), "Maximum number of loaded models per GPU"},
+		"OLLAMA_MAX_QUEUE":         		{"OLLAMA_MAX_QUEUE", MaxQueue(), "Maximum number of queued requests"},
+		"OLLAMA_MODELS":            		{"OLLAMA_MODELS", Models(), "The path to the models directory"},
+		"OLLAMA_NOHISTORY":         		{"OLLAMA_NOHISTORY", NoHistory(), "Do not preserve readline history"},
+		"OLLAMA_NOPRUNE":           		{"OLLAMA_NOPRUNE", NoPrune(), "Do not prune model blobs on startup"},
+		"OLLAMA_NUM_PARALLEL":      		{"OLLAMA_NUM_PARALLEL", NumParallel(), "Maximum number of parallel requests"},
+		"OLLAMA_ORIGINS":           		{"OLLAMA_ORIGINS", Origins(), "A comma separated list of allowed origins"},
+		"OLLAMA_SCHED_SPREAD":      		{"OLLAMA_SCHED_SPREAD", SchedSpread(), "Always schedule model across all GPUs"},
+		"OLLAMA_MULTIUSER_CACHE":   		{"OLLAMA_MULTIUSER_CACHE", MultiUserCache(), "Optimize prompt caching for multi-user scenarios"},
+		"OLLAMA_WINDOWS_PROCESS_PRIORITY": 	{"OLLAMA_WINDOWS_PROCESS_PRIORITY", WindowsProcessPriority(), "Set process priority when running on Windows"}
 
 		// Informational
 		"HTTP_PROXY":  {"HTTP_PROXY", String("HTTP_PROXY")(), "HTTP proxy"},

--- a/llm/llm_windows.go
+++ b/llm/llm_windows.go
@@ -1,7 +1,7 @@
 package llm
 
 import (
-	"syscall",
+	"syscall"
 
 	"github.com/ollama/ollama/envconfig"
 )

--- a/llm/llm_windows.go
+++ b/llm/llm_windows.go
@@ -1,13 +1,33 @@
 package llm
 
 import (
-	"syscall"
+	"syscall",
+
+	"github.com/ollama/ollama/envconfig"
 )
 
 const (
 	CREATE_DEFAULT_ERROR_MODE   = 0x04000000
 	ABOVE_NORMAL_PRIORITY_CLASS = 0x00008000
+	NORMAL_PRIORITY_CLASS = 0x00000020
+	BELOW_NORMAL_PRIORITY_CLASS = 0x00004000
+	IDLE_PRIORITY_CLASS = 0x00000040
 )
+
+func getPriorityClass(prio string) uint32 {
+	switch prio {
+	case "ABOVE_NORMAL":
+		return ABOVE_NORMAL_PRIORITY_CLASS
+	case "NORMAL":
+		return NORMAL_PRIORITY_CLASS
+	case "BELOW_NORMAL":
+		return BELOW_NORMAL_PRIORITY_CLASS
+	case "IDLE":
+		return IDLE_PRIORITY_CLASS
+	default:
+		return ABOVE_NORMAL_PRIORITY_CLASS // Default to above normal priority
+	}
+}
 
 var LlamaServerSysProcAttr = &syscall.SysProcAttr{
 	// Wire up the default error handling logic If for some reason a DLL is
@@ -18,5 +38,5 @@ var LlamaServerSysProcAttr = &syscall.SysProcAttr{
 	//
 	// Setting Above Normal priority class ensures when running as a "background service"
 	// with "programs" given best priority, we aren't starved of cpu cycles
-	CreationFlags: CREATE_DEFAULT_ERROR_MODE | ABOVE_NORMAL_PRIORITY_CLASS,
+	CreationFlags: CREATE_DEFAULT_ERROR_MODE | getPriorityClass(envconfig.Prio()),
 }

--- a/llm/llm_windows.go
+++ b/llm/llm_windows.go
@@ -38,5 +38,5 @@ var LlamaServerSysProcAttr = &syscall.SysProcAttr{
 	//
 	// Setting Above Normal priority class ensures when running as a "background service"
 	// with "programs" given best priority, we aren't starved of cpu cycles
-	CreationFlags: CREATE_DEFAULT_ERROR_MODE | getPriorityClass(envconfig.Prio()),
+	CreationFlags: CREATE_DEFAULT_ERROR_MODE | getPriorityClass(envconfig.WindowsProcessPriority()),
 }


### PR DESCRIPTION
This is small change regarding to #6905 and #3511.

I have small box (CPU only, W10) where I run ollama which also runs some other important processes. 
With process priority set as above normal other processes are becoming slow or unresponsive for time when ollama generates response.
I've implemented small change where I can put expected sub-process priority as env variable (IDLE/ BELOW_NORMAL / NORMAL / ABOVE_NORMAL), leaving "ABOVE_NORMAL" as default value to match current implementation on main.

For my use case I don't care if ollama will respond in minutes instead of seconds, more important is that ollama won't interfere and slow down other running processes.

Please review deeply and share feedback.