### PR TITLE
Update download.go

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -312,16 +312,18 @@ jobs:
           - flavor: 'latest=false'
             platforms: linux/amd64,linux/arm64
             build-args: |
-              CGO_CFLAGS=${{ env.CGO_CFLAGS }}
-              CGO_CXXFLAGS=${{ env.CGO_CXXFLAGS }}
-              GOFLAGS=${{ needs.setup-environment.outputs.GOFLAGS }}
+              CGO_CFLAGS
+              CGO_CXXFLAGS
+              GOFLAGS
           - flavor: 'latest=false,suffix=rocm'
             platforms: linux/amd64
             build-args: |
-              CGO_CFLAGS=${{ env.CGO_CFLAGS }}
-              CGO_CXXFLAGS=${{ env.CGO_CXXFLAGS }}
+              CGO_CFLAGS
+              CGO_CXXFLAGS
+              GOFLAGS
               FLAVOR=rocm
-              GOFLAGS=${{ needs.setup-environment.outputs.GOFLAGS }}
+    env:
+      GOFLAGS: ${{ needs.setup-environment.outputs.GOFLAGS }}
     runs-on: linux
     environment: release
     needs: setup-environment

--- a/server/download.go
+++ b/server/download.go
@@ -372,8 +372,8 @@ func (b *blobDownload) downloadChunk(ctx context.Context, requestURL *url.URL, w
 					part.lastUpdatedMu.Lock()
 					part.lastUpdated = time.Time{}
 					part.lastUpdatedMu.Unlock()
-				return errPartStalled
-			}
+					return errPartStalled
+				}
 
 			case <-ctx.Done():
 				return ctx.Err()

--- a/server/download.go
+++ b/server/download.go
@@ -366,9 +366,9 @@ func (b *blobDownload) downloadChunk(ctx context.Context, requestURL *url.URL, w
 				part.lastUpdatedMu.Unlock()
 
 				if !lastUpdated.IsZero() && time.Since(lastUpdated) > 30*time.Second {
- 			   		const msg = "%s part %d stalled; retrying. If this persists, press ctrl-c to exit, then 'ollama pull' to find a faster connection."
+					const msg = "%s part %d stalled; retrying. If this persists, press ctrl-c to exit, then 'ollama pull' to find a faster connection."
 					slog.Info(fmt.Sprintf(msg, b.Digest[7:19], part.N))
-    					// reset last updated
+					// reset last updated
 					part.lastUpdatedMu.Lock()
 					part.lastUpdated = time.Time{}
 					part.lastUpdatedMu.Unlock()

--- a/server/download.go
+++ b/server/download.go
@@ -365,15 +365,16 @@ func (b *blobDownload) downloadChunk(ctx context.Context, requestURL *url.URL, w
 				lastUpdated := part.lastUpdated
 				part.lastUpdatedMu.Unlock()
 
-				if !lastUpdated.IsZero() && time.Since(lastUpdated) > 5*time.Second {
-					const msg = "%s part %d stalled; retrying. If this persists, press ctrl-c to exit, then 'ollama pull' to find a faster connection."
-					slog.Info(fmt.Sprintf(msg, b.Digest[7:19], part.N))
-					// reset last updated
-					part.lastUpdatedMu.Lock()
-					part.lastUpdated = time.Time{}
-					part.lastUpdatedMu.Unlock()
-					return errPartStalled
+				if !lastUpdated.IsZero() && time.Since(lastUpdated) > 20*time.Second {
+ 			   		const msg = "%s part %d stalled; retrying. If this persists, press ctrl-c to exit, then 'ollama pull' to find a faster connection."
+    					slog.Info(fmt.Sprintf(msg, b.Digest[7:19], part.N))
+    					// reset last updated
+    					part.lastUpdatedMu.Lock()
+    					part.lastUpdated = time.Time{}
+    					part.lastUpdatedMu.Unlock()
+    					return errPartStalled
 				}
+
 			case <-ctx.Done():
 				return ctx.Err()
 			}


### PR DESCRIPTION
1. **Current Timeout Check**: ```go if !lastUpdated.IsZero() && time.Since(lastUpdated) > 5*time.Second { ```
   - **Purpose**: This line checks if a download part has stalled by comparing the current time with the `lastUpdated` time.
   - **Condition**: The `if` statement evaluates two conditions:
     1. `!lastUpdated.IsZero()`: Ensures that `lastUpdated` has been set.
     2. `time.Since(lastUpdated) > 5*time.Second`: Checks if more than 5 seconds have passed since the last update.

2. **Proposed Change**: ```go if !lastUpdated.IsZero() && time.Since(lastUpdated) > 20*time.Second { ```
   - **Purpose**: Increase the stall timeout from 5 seconds to 20 seconds.
   - **Reason**: To allow more time for packets to be received before considering the download stalled and retrying.

### Impact of the Change

- **Increased Timeout**: By increasing the timeout to 20 seconds, the system allows more time for packets to be received before it considers the download stalled. This can help prevent premature retries, especially in cases of temporary network slowdowns.
- **Potential Risks**: With a longer timeout, if a part of the download is genuinely stalled, the system will take longer to detect and retry, which could delay the overall download process.

### Context and Considerations

- **Network Conditions**: This change is particularly beneficial in environments with intermittent or slow network connections, as it reduces the likelihood of unnecessary retries.
- **Monitoring**: It is advisable to monitor the system's behavior after implementing this change to ensure it resolves the issue without introducing new problems.