### PR TITLE
README: Update README.md with Deepseek R1 info

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Here are some example models that can be downloaded:
 
 | Model              | Parameters | Size  | Download                         |
 | ------------------ | ---------- | ----- | -------------------------------- |
+| Deepseek R1        | 7B         | 4.7GB | `ollama run deepseek-r1`         |
+| Deepseek R1        | 671B       | 404GB | `ollama run deepseek-r1:671b`    |
 | Llama 3.3          | 70B        | 43GB  | `ollama run llama3.3`            |
 | Llama 3.2          | 3B         | 2.0GB | `ollama run llama3.2`            |
 | Llama 3.2          | 1B         | 1.3GB | `ollama run llama3.2:1b`         |
@@ -74,6 +76,7 @@ Here are some example models that can be downloaded:
 | Llama 2 Uncensored | 7B         | 3.8GB | `ollama run llama2-uncensored`   |
 | LLaVA              | 7B         | 4.5GB | `ollama run llava`               |
 | Solar              | 10.7B      | 6.1GB | `ollama run solar`               |
+
 
 > [!NOTE]
 > You should have at least 8 GB of RAM available to run the 7B models, 16 GB to run the 13B models, and 32 GB to run the 33B models.


### PR DESCRIPTION
 update README with latest configuration details for  Deepseek R1. Include deepseek-r1 7b and deepseek-r1 671b in  [Model Library](https://github.com/ollama/ollama?tab=readme-ov-file#model-library) Section.