### PR TITLE
Add max_prompt_tokens to OpenAI compatability API

### DIFF
--- a/openai/openai.go
+++ b/openai/openai.go
@@ -85,6 +85,7 @@ type ChatCompletionRequest struct {
 	Stream           bool            `json:"stream"`
 	StreamOptions    *StreamOptions  `json:"stream_options"`
 	MaxTokens        *int            `json:"max_tokens"`
+	MaxPromptTokens  *int            `json:"max_prompt_tokens"`
 	Seed             *int            `json:"seed"`
 	Stop             any             `json:"stop"`
 	Temperature      *float64        `json:"temperature"`
@@ -477,6 +478,10 @@ func fromChatRequest(r ChatCompletionRequest) (*api.ChatRequest, error) {
 
 	if r.MaxTokens != nil {
 		options["num_predict"] = *r.MaxTokens
+	}
+
+	if r.MaxPromptTokens != nil {
+		options["num_ctx"] = *r.MaxPromptTokens
 	}
 
 	if r.Temperature != nil {


### PR DESCRIPTION
Hey there,

I noticed that we have an issue in which we cannot turn off truncating requests to ollama made through the OpenAI compatability. Fortunately, it appears that OpenAI has a new parameter that allows us to configure it ourselves, [max_prompt_tokens](https://platform.openai.com/docs/api-reference/runs-v1/createRun#runs-v1-createrun-max_prompt_tokens). 

I have this running locally an it allows me to use avante.nvim with qwen2.5-coder:32b quite nicely (it was cutting out file inputs before). Hope this helps!

Fixes https://github.com/ollama/ollama/issues/6286 https://github.com/ollama/ollama/issues/5356