### PR TITLE
Update docs OLLAMA_VERSION to 0.5.7

### DIFF
--- a/docs/linux.md
+++ b/docs/linux.md
@@ -152,7 +152,7 @@ Use `OLLAMA_VERSION` environment variable with the install script to install a s
 For example:
 
 ```shell
-curl -fsSL https://ollama.com/install.sh | OLLAMA_VERSION=6.3.2 sh
+curl -fsSL https://ollama.com/install.sh | OLLAMA_VERSION=0.5.7 sh
 ```
 
 ## Viewing logs

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -152,7 +152,7 @@ Use `OLLAMA_VERSION` environment variable with the install script to install a s
 For example:
 
 ```shell
-curl -fsSL https://ollama.com/install.sh | OLLAMA_VERSION=0.3.9 sh
+curl -fsSL https://ollama.com/install.sh | OLLAMA_VERSION=6.3.2 sh
 ```
 
 ## Viewing logs


### PR DESCRIPTION
I know it's only docs: but let's update it anyway to the latest release 0.5.7.

So even if people are stupid enough to just copy paste this example, it at least is up to date (for now 2025).