### PR TITLE
Add MLflow Tracing as an observability integration in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,3 +545,4 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [OpenLIT](https://github.com/openlit/openlit) is an OpenTelemetry-native tool for monitoring Ollama Applications & GPUs using traces and metrics.
 - [HoneyHive](https://docs.honeyhive.ai/integrations/ollama) is an AI observability and evaluation platform for AI agents. Use HoneyHive to evaluate agent performance, interrogate failures, and monitor quality in production.
 - [Langfuse](https://langfuse.com/docs/integrations/ollama) is an open source LLM observability platform that enables teams to collaboratively monitor, evaluate and debug AI applications.
+- [MLflow Tracing](https://mlflow.org/docs/latest/llms/tracing/index.html#automatic-tracing) is an open source LLM observability tool with a convenient API to log and visualize traces, making it easy to debug and evaluate GenAI applications.


### PR DESCRIPTION
[MLflow Tracing](https://mlflow.org/docs/latest/llms/tracing/index.html) has an automatic integration with Ollama (see the [Ollama section in the docs](https://mlflow.org/docs/latest/llms/tracing/index.html#automatic-tracing)), which allows users to conveniently record the inputs, outputs, and other metadata of their interactions with the Ollama API.

We'd like to add a line in the README to mention this integration. Please let me know if there's anything else required, or if you'd like to change the content in any way!