### PR TITLE
benchmark: compare backend graph computation times

### DIFF
--- a/benchmark/ggml_backend_benchmark_test.go
+++ b/benchmark/ggml_backend_benchmark_test.go
@@ -1,0 +1,86 @@
+package backend
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/ollama/ollama/ml"
+	"github.com/ollama/ollama/model"
+	"github.com/ollama/ollama/server"
+
+	_ "github.com/ollama/ollama/model/models/llama"
+)
+
+var modelName = flag.String("m", "", "Name of the model to benchmark")
+
+func suppressOutput() (cleanup func()) {
+	oldStdout, oldStderr := os.Stdout, os.Stderr
+	os.Stdout, os.Stderr = nil, nil
+	log.SetOutput(io.Discard)
+
+	return func() {
+		os.Stdout, os.Stderr = oldStdout, oldStderr
+		log.SetOutput(os.Stderr)
+	}
+}
+
+func setupModel(b *testing.B) model.Model {
+	if *modelName == "" {
+		b.Fatal("Error: -m flag is required for benchmark tests")
+	}
+
+	sm, err := server.GetModel(*modelName)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	m, err := model.New(sm.ModelPath)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	m.Config().Cache.Init(m.Backend(), ml.DTypeF32, 2048)
+	return m
+}
+
+func BenchmarkGGMLOperations(b *testing.B) {
+	// loading the GGML back-end logs to standard out and makes the bench output messy
+	cleanup := suppressOutput()
+	defer cleanup()
+
+	b.Setenv("OLLAMA_BENCHMARK", "1")
+	b.Setenv("OLLAMA_BACKEND", "ggml")
+
+	m := setupModel(b)
+
+	// Sample input data
+	inputIDs := []int32{1, 2, 3, 4, 5}
+	options := model.Options{
+		Inputs:    inputIDs,
+		Positions: []int32{1, 2, 3, 4, 5},
+		Sequences: []int{1, 1, 1, 1, 1},
+		Outputs:   []int32{int32(len(inputIDs) - 1)},
+	}
+
+	b.ResetTimer()
+
+	for range b.N {
+		ctx := m.Backend().NewContext()
+		defer ctx.Close()
+
+		modelOutput, err := model.Forward(ctx, m, options)
+		if err != nil {
+			b.Fatal(fmt.Errorf("forward pass failed: %v", err))
+		}
+
+		ctx.Compute(modelOutput)
+
+		for _, op := range ctx.Timing() {
+			b.ReportMetric(op.Duration, fmt.Sprintf("%s_ms", op.Type))
+		}
+	}
+}

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -167,6 +167,8 @@ var (
 	MultiUserCache = Bool("OLLAMA_MULTIUSER_CACHE")
 	// Enable the new Ollama engine
 	NewEngine = Bool("OLLAMA_NEW_ENGINE")
+	// Ollama is running in a benchmark context, additional timing data will be collected.
+	Benchmark = Bool("OLLAMA_BENCHMARK")
 )
 
 func String(s string) func() string {

--- a/kvcache/causal_test.go
+++ b/kvcache/causal_test.go
@@ -352,6 +352,10 @@ func (c *testContext) MaxTensors() int {
 	return 10
 }
 
+func (c *testContext) Timing() []ml.OpTiming {
+	return []ml.OpTiming{}
+}
+
 func (c *testContext) Close() {}
 
 type testTensor struct {


### PR DESCRIPTION
Depends on #8301 

This PR adds bindings to track execution time of individual operations during LLM forward passes, helping identify performance bottlenecks and optimization opportunities in our computation graphs.

Run from the benchmark dir with:
```bash
 go test -bench=. -m $MODEL_NAME ./...
```

## What changed
- Added CGo bindings to interface with the native graph runtime's timing instrumentation
- Created Go structs to categorize and track different operation types (compute nodes, views, reshapes, etc.)
- Added methods to collect timing data for the full operation sequence
- Added `OLLAMA_BENCHMARK` environment variable that collects graph compute timing details.

## Why this matters
When optimizing LLM inference, understanding where time is spent is crucial. During development, this profiling is useful for finding bottlenecks and comparing performance across back-ends.

## Example findings
I built a logging utility (not included in this PR) that produces detailed timing breakdowns. The logging utility is currently separate as it adds some complexity. Happy to bring it into this PR if there's interest in having standardized profiling output. Let me know if you'd find that useful.

```bash
Operation Sequence Analysis
==========================
Step Type         Operation                                Duration
----------------------------------------------------------------------
0    Compute      Computation node_0                          0.435 ms
1    Compute      Computation node_1                          0.211 ms
2    Compute      Computation node_2                          0.206 ms
3    Compute      Computation node_3                          0.218 ms
4    Reshape      Reshape                                     0.046 ms
...
639  Compute      Computation node_639                        0.350 ms
640  Compute      Computation node_640                        0.400 ms
641  Compute      Computation node_641                        0.183 ms
642  Compute      Computation node_642                        0.211 ms
643  Compute      Computation node_643                        1.518 ms
644  Compute      Computation node_644                        3.664 ms

Operation Type Summary:
----------------------------------------------------------------------
Type         Count    Total (ms)   Avg (ms)     Max (ms)
----------------------------------------------------------------------
Compute      341      98.600       0.289        3.664
View         176      25.206       0.143        0.539
Permute      64       10.335       0.161        0.583
Reshape      64       2.782        0.043        0.063

Total execution time: 136.923 ms
```
