### PR TITLE
fix: fix memory leak in uhd_slice_image function

### DIFF
--- a/llama/llama.cpp/examples/llava/clip.cpp
+++ b/llama/llama.cpp/examples/llava/clip.cpp
@@ -2078,6 +2078,7 @@ static std::vector<std::vector<clip_image_u8 *>> uhd_slice_image(const clip_imag
                 images[images.size()-1].push_back(patch);
             }
         }
+        clip_image_u8_free(refine_image);
     }
     return images;
 }


### PR DESCRIPTION
Add clip_image_u8_free to release refine_image after use to prevent memory leak.