### PR TITLE
fix: free clip_image_u8 objects in clip_image_preprocess

### DIFF
--- a/llama/llama.cpp/examples/llava/clip.cpp
+++ b/llama/llama.cpp/examples/llava/clip.cpp
@@ -2114,6 +2114,7 @@ bool clip_image_preprocess(struct clip_ctx * ctx, const clip_image_u8 * img, cli
                 normalize_image_u8_to_f32(imgs[i][j], res, ctx->image_mean, ctx->image_std);
                 res_imgs->data[idx++] = *res;
                 clip_image_f32_free(res);
+                clip_image_u8_free(imgs[i][j]);
             }
         }
         return true;


### PR DESCRIPTION
Fix memory leak in clip_image_preprocess function where clip_image_u8  objects returned by uhd_slice_image were not being freed. Added explicit  calls to clip_image_u8_free() after converting each image to clip_image_f32.

The memory leak occurred because:
- uhd_slice_image allocates multiple clip_image_u8 objects
- These objects were stored in the returned vector
- The caller (clip_image_preprocess) didn't free them after use

This commit ensures proper cleanup of all allocated clip_image_u8 objects.