### PR TITLE
Don't perform memory check if client sets use_mmap true.

### DIFF
--- a/llm/server.go
+++ b/llm/server.go
@@ -121,7 +121,7 @@ func NewLlamaServer(gpus discover.GpuInfoList, model string, ggml *GGML, adapter
 
 	// On linux and windows, over-allocating CPU memory will almost always result in an error
 	// Darwin has fully dynamic swap so has no direct concept of free swap space
-	if runtime.GOOS != "darwin" {
+	if runtime.GOOS != "darwin" && (opts.UseMMap == nil || !*opts.UseMMap) {
 		systemMemoryRequired := estimate.TotalSize - estimate.VRAMSize
 		available := systemFreeMemory + systemSwapFreeMemory
 		if systemMemoryRequired > available {


### PR DESCRIPTION
If the client overrides `use_mmap`, don't prevent the model from loading to due apparent over-commit.

On Linux, a mmap'd file doesn't use swap backing store unless modified, so there's no need for the check.  Windows has dynamic swap and so falls in to the same bucket as darwin.  Inference on deepseek-r1:671b-1.5b runs at ~0.15 t/s where the model requires swap on SSD, ~0.3 t/s with mmap instead of swap on the the same SSD, and ~1.4 t/s when the model is mapped on an NVME drive. 