### PR TITLE
feat: add streaming response control flags to command line run feature

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -275,6 +275,12 @@ func RunHandler(cmd *cobra.Command, args []string) error {
 	}
 	opts.Format = format
 
+	stream, err := cmd.Flags().GetBool("stream")
+	if err != nil {
+		return err
+	}
+	opts.Stream = stream
+
 	keepAlive, err := cmd.Flags().GetString("keepalive")
 	if err != nil {
 		return err
@@ -788,6 +794,7 @@ type runOptions struct {
 	Options     map[string]interface{}
 	MultiModal  bool
 	KeepAlive   *api.Duration
+	Stream      bool
 }
 
 type displayResponseState struct {
@@ -894,6 +901,7 @@ func chat(cmd *cobra.Command, opts runOptions) (*api.Message, error) {
 		Messages: opts.Messages,
 		Format:   json.RawMessage(opts.Format),
 		Options:  opts.Options,
+		Stream:   &opts.Stream,
 	}
 
 	if opts.KeepAlive != nil {
@@ -1201,6 +1209,7 @@ func NewCLI() *cobra.Command {
 	runCmd.Flags().Bool("insecure", false, "Use an insecure registry")
 	runCmd.Flags().Bool("nowordwrap", false, "Don't wrap words to the next line automatically")
 	runCmd.Flags().String("format", "", "Response format (e.g. json)")
+	runCmd.Flags().Bool("stream", true, "Stream response")
 
 	stopCmd := &cobra.Command{
 		Use:     "stop MODEL",

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -61,6 +61,8 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 		fmt.Fprintln(os.Stderr, "  /set noformat          Disable formatting")
 		fmt.Fprintln(os.Stderr, "  /set verbose           Show LLM stats")
 		fmt.Fprintln(os.Stderr, "  /set quiet             Disable LLM stats")
+		fmt.Fprintln(os.Stderr, "  /set stream			  Enable streaming")
+		fmt.Fprintln(os.Stderr, "  /set nostream		  Disable streaming")
 		fmt.Fprintln(os.Stderr, "")
 	}
 
@@ -245,6 +247,12 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 				case "nowordwrap":
 					opts.WordWrap = false
 					fmt.Println("Set 'nowordwrap' mode.")
+				case "stream":
+					opts.Stream = true
+					fmt.Println("Set 'stream' mode.")
+				case "nostream":
+					opts.Stream = false
+					fmt.Println("Set 'nostream' mode.")
 				case "verbose":
 					if err := cmd.Flags().Set("verbose", "true"); err != nil {
 						return err


### PR DESCRIPTION
Quick pr to add the ability to toggle response streaming in the interactive run prompt through either the `/set stream/nostream` command or the `--stream` flag