### PR TITLE
readme: fix nix package link

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Gentoo](https://github.com/gentoo/guru/tree/master/app-misc/ollama)
 - [Helm Chart](https://artifacthub.io/packages/helm/ollama-helm/ollama)
 - [Guix channel](https://codeberg.org/tusharhero/ollama-guix)
-- [Nix package](https://search.nixos.org/packages?channel=24.05&show=ollama&from=0&size=50&sort=relevance&type=packages&query=ollama)
+- [Nix package](https://search.nixos.org/packages?show=ollama&from=0&size=50&sort=relevance&type=packages&query=ollama)
 - [Flox](https://flox.dev/blog/ollama-part-one)
 
 ### Libraries


### PR DESCRIPTION
Existing link is to the now deprecated 24.05 release, removing the channel tag from the url so it will always go to the current stable channel.