### PR TITLE
llm: do not evaluate symlinks for exe path lookup

### DIFF
--- a/discover/path.go
+++ b/discover/path.go
@@ -19,11 +19,6 @@ var LibOllamaPath string = func() string {
 		return ""
 	}
 
-	exe, err = filepath.EvalSymlinks(exe)
-	if err != nil {
-		return ""
-	}
-
 	var libPath string
 	switch runtime.GOOS {
 	case "windows":

--- a/llm/server.go
+++ b/llm/server.go
@@ -320,11 +320,6 @@ func NewLlamaServer(gpus discover.GpuInfoList, model string, ggml *GGML, adapter
 			return nil, fmt.Errorf("unable to lookup executable path: %w", err)
 		}
 
-		exe, err = filepath.EvalSymlinks(exe)
-		if err != nil {
-			return nil, fmt.Errorf("unable to evaluate symlinks for executable path: %w", err)
-		}
-
 		// TODO - once fully switched to the Go runner, load the model here for tokenize/detokenize cgo access
 		s := &llmServer{
 			port:        port,


### PR DESCRIPTION
In some cases, the directories in the executable path read by filepath.EvalSymlinks are not accessible, resulting in permission errors which results in an error when running models. It also doesn't work well on long paths on windows, also resulting in errors. This change removes filepath.EvalSymlinks when accessing os.Executable() altogether

Fixes https://github.com/ollama/ollama/issues/9085
Fixes https://github.com/ollama/ollama/issues/9085