### PR TITLE
llm: attempt to evaluate symlinks for os.Executable, but do not fail

### DIFF
--- a/discover/path.go
+++ b/discover/path.go
@@ -19,6 +19,10 @@ var LibOllamaPath string = func() string {
 		return ""
 	}
 
+	if eval, err := filepath.EvalSymlinks(exe); err == nil {
+		exe = eval
+	}
+
 	var libPath string
 	switch runtime.GOOS {
 	case "windows":

--- a/llm/server.go
+++ b/llm/server.go
@@ -320,6 +320,10 @@ func NewLlamaServer(gpus discover.GpuInfoList, model string, f *ggml.GGML, adapt
 			return nil, fmt.Errorf("unable to lookup executable path: %w", err)
 		}
 
+		if eval, err := filepath.EvalSymlinks(exe); err == nil {
+			exe = eval
+		}
+
 		// TODO - once fully switched to the Go runner, load the model here for tokenize/detokenize cgo access
 		s := &llmServer{
 			port:        port,


### PR DESCRIPTION
This PR provides a better approach to https://github.com/ollama/ollama/pull/9088 that will attempt to evaluate symlinks (important for macOS where `ollama` is often a symlink), but use the result of `os.Executable()` as a fallback in scenarios where `filepath.EvalSymlinks` fails due to permission errors.

Fixes https://github.com/ollama/ollama/issues/9082