### PR TITLE
ml/backend/ggml: optionally evaluate os.Executable() symlinks

### DIFF
--- a/ml/backend/ggml/ggml/src/ggml.go
+++ b/ml/backend/ggml/ggml/src/ggml.go
@@ -47,6 +47,10 @@ var OnceLoad = sync.OnceFunc(func() {
 		exe = "."
 	}
 
+	if eval, err := filepath.EvalSymlinks(exe); err == nil {
+		exe = eval
+	}
+
 	// PATH, LD_LIBRARY_PATH, and DYLD_LIBRARY_PATH are often
 	// set by the parent process, however, use a default value
 	// if the environment variable is not set.


### PR DESCRIPTION
For Intel macOS hosts, optionally evaluate symlinks to os.Executable ahead of loading backends, fixing issues where 'ollama' is a symlink and is run manually in the command line. This may not be required as the `ggml` package would not be run via a symlink.