### PR TITLE
Refactor: Move root command to a separate file

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -40,7 +40,6 @@ import (
 	"github.com/ollama/ollama/runner"
 	"github.com/ollama/ollama/server"
 	"github.com/ollama/ollama/types/model"
-	"github.com/ollama/ollama/version"
 )
 
 var errModelfileNotFound = errors.New("specified Modelfile wasn't found")
@@ -1103,26 +1102,6 @@ func checkServerHeartbeat(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func versionHandler(cmd *cobra.Command, _ []string) {
-	client, err := api.ClientFromEnvironment()
-	if err != nil {
-		return
-	}
-
-	serverVersion, err := client.Version(cmd.Context())
-	if err != nil {
-		fmt.Println("Warning: could not connect to a running Ollama instance")
-	}
-
-	if serverVersion != "" {
-		fmt.Printf("ollama version is %s\n", serverVersion)
-	}
-
-	if serverVersion != version.Version {
-		fmt.Printf("Warning: client version is %s\n", version.Version)
-	}
-}
-
 func appendEnvDocs(cmd *cobra.Command, envs []envconfig.EnvVar) {
 	if len(envs) == 0 {
 		return
@@ -1146,25 +1125,7 @@ func NewCLI() *cobra.Command {
 		console.ConsoleFromFile(os.Stdin) //nolint:errcheck
 	}
 
-	rootCmd := &cobra.Command{
-		Use:           "ollama",
-		Short:         "Large language model runner",
-		SilenceUsage:  true,
-		SilenceErrors: true,
-		CompletionOptions: cobra.CompletionOptions{
-			DisableDefaultCmd: true,
-		},
-		Run: func(cmd *cobra.Command, args []string) {
-			if version, _ := cmd.Flags().GetBool("version"); version {
-				versionHandler(cmd, args)
-				return
-			}
-
-			cmd.Print(cmd.UsageString())
-		},
-	}
-
-	rootCmd.Flags().BoolP("version", "v", false, "Show version information")
+	rootCmd := NewRootCmd()
 
 	createCmd := &cobra.Command{
 		Use:     "create MODEL",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/version"
+	"github.com/spf13/cobra"
+)
+
+func NewRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "ollama",
+		Short:         "Large language model runner",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		CompletionOptions: cobra.CompletionOptions{
+			DisableDefaultCmd: true,
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			if v, _ := cmd.Flags().GetBool("version"); v {
+				versionHandler(cmd, args)
+				return
+			}
+
+			cmd.Print(cmd.UsageString())
+		},
+	}
+
+	cmd.Flags().BoolP("version", "v", false, "Show version information")
+
+	return cmd
+}
+
+func versionHandler(cmd *cobra.Command, _ []string) {
+	client, err := api.ClientFromEnvironment()
+	if err != nil {
+		return
+	}
+
+	serverVersion, err := client.Version(cmd.Context())
+	if err != nil {
+		fmt.Println("Warning: could not connect to a running Ollama instance")
+	}
+
+	if serverVersion != "" {
+		fmt.Printf("ollama version is %s\n", serverVersion)
+	}
+
+	if serverVersion != version.Version {
+		fmt.Printf("Warning: client version is %s\n", version.Version)
+	}
+}


### PR DESCRIPTION
This PR is the first step in an incremental approach to refactor the CLI structure. As part of this change, the root command has been moved to a separate file, helping to improve the readability and maintainability of the project.

### **Background:**
The main goal of this change is to make it easier to extend and maintain the CLI by separating commands into individual files, starting with the root command. This is part of a larger plan, as outlined in the related issue: #9086.

### **Next Steps:**
- Gradually refactor other commands into separate files in subsequent PRs.

This approach minimizes the risk of large refactors and ensures that each change is small, manageable, and easy to review.
