### PR TITLE
Update install.sh

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -66,7 +66,7 @@ if [ -n "$NEEDS" ]; then
     exit 1
 fi
 
-for BINDIR in /usr/local/bin /usr/bin /bin; do
+for BINDIR in $HOME/.local/bin /usr/local/bin /usr/bin /bin; do
     echo $PATH | grep -q $BINDIR && break || continue
 done
 OLLAMA_INSTALL_DIR=$(dirname ${BINDIR})


### PR DESCRIPTION
BINDIR add $HOME/.local/bin, so users can install OLLAMA into $HOME/.local/bin as first choice.