### PR TITLE
Draft: Row Order model definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ test_data
 __debug_bin*
 llama/build
 llama/vendor
+build/
+

--- a/kvcache/causal.go
+++ b/kvcache/causal.go
@@ -183,8 +183,8 @@ func moveCell(ctx ml.Context, objs []ml.Tensor, src, dst, len int) {
 			continue
 		}
 
-		srcView := obj.View(ctx, obj.Stride(2)*src, obj.Dim(0)*obj.Dim(1)*len)
-		dstView := obj.View(ctx, obj.Stride(2)*dst, obj.Dim(0)*obj.Dim(1)*len)
+		srcView := obj.View(ctx, obj.Stride(0)*src, []int{obj.Dim(0) * obj.Dim(2) * len}, nil)
+		dstView := obj.View(ctx, obj.Stride(0)*dst, []int{obj.Dim(0) * obj.Dim(2) * len}, nil)
 
 		ctx.Forward(srcView.Copy(ctx, dstView))
 	}
@@ -305,33 +305,37 @@ func (c *Causal) Get(ctx ml.Context) (ml.Tensor, ml.Tensor, ml.Tensor) {
 	key := c.keys[c.curLayer]
 	value := c.values[c.curLayer]
 
-	key = key.View(ctx, key.Stride(2)*c.curCellRange.min,
-		key.Dim(0), key.Stride(1),
-		key.Dim(1), key.Stride(2),
-		c.curMask.Dim(0),
+	key = key.View(ctx, key.Stride(0)*c.curCellRange.min,
+		[]int{c.curMask.Dim(0), key.Dim(1), key.Dim(2)},
+		[]int{key.Stride(0), key.Stride(1)},
 	)
 
-	value = value.View(ctx, key.Stride(2)*c.curCellRange.min,
-		value.Dim(0), value.Stride(1),
-		value.Dim(1), value.Stride(2),
-		c.curMask.Dim(0),
+	value = value.View(ctx, value.Stride(0)*c.curCellRange.min,
+		[]int{c.curMask.Dim(0), value.Dim(1), value.Dim(2)},
+		[]int{value.Stride(0), value.Stride(1)},
 	)
 
+	// TODO The mask changes from X,X to 1,X, and with the Row-order change
+	// the 1 becomes trailing and messes up later operations
+	// This isn't the right solution, but works around it...
+	if c.curMask.Dim(1) == 1 {
+		return key, value, c.curMask.Permute(ctx, 1, 0, 2, 3)
+	}
 	return key, value, c.curMask
 }
 
 func (c *Causal) Put(ctx ml.Context, key, value ml.Tensor) {
-	if c.curBatchSize != key.Dim(2) {
-		panic(fmt.Errorf("inconsistent batch sizes (layer: %v, batch size: %v layer batch size: %v)", c.curLayer, c.curBatchSize, key.Dim(2)))
+	if c.curBatchSize != key.Dim(0) {
+		panic(fmt.Errorf("inconsistent batch sizes (layer: %v, batch size: %v layer batch size: %v)", c.curLayer, c.curBatchSize, key.Dim(0)))
 	}
 
 	if c.keys[c.curLayer] == nil || c.values[c.curLayer] == nil {
-		c.keys[c.curLayer] = c.cacheCtx.Zeros(c.DType, key.Dim(0), key.Dim(1), int(c.Capacity))
-		c.values[c.curLayer] = c.cacheCtx.Zeros(c.DType, value.Dim(0), value.Dim(1), int(c.Capacity))
+		c.keys[c.curLayer] = c.cacheCtx.Zeros(c.DType, int(c.Capacity), key.Dim(1), key.Dim(2))
+		c.values[c.curLayer] = c.cacheCtx.Zeros(c.DType, int(c.Capacity), value.Dim(1), value.Dim(2))
 	}
 
-	ctx.Forward(key.Copy(ctx, c.keys[c.curLayer].View(ctx, c.keys[c.curLayer].Stride(2)*c.curLoc, key.Dim(0)*key.Dim(1)*key.Dim(2))))
-	ctx.Forward(value.Copy(ctx, c.values[c.curLayer].View(ctx, c.values[c.curLayer].Stride(2)*c.curLoc, value.Dim(0)*value.Dim(1)*value.Dim(2))))
+	ctx.Forward(key.Copy(ctx, c.keys[c.curLayer].View(ctx, c.keys[c.curLayer].Stride(0)*c.curLoc, []int{key.Dim(0) * key.Dim(1) * key.Dim(2)}, nil)))
+	ctx.Forward(value.Copy(ctx, c.values[c.curLayer].View(ctx, c.values[c.curLayer].Stride(0)*c.curLoc, []int{value.Dim(0) * value.Dim(1) * value.Dim(2)}, nil)))
 }
 
 func (c *Causal) CopyPrefix(srcSeq, dstSeq int, len int32) {
@@ -387,10 +391,9 @@ func (c *Causal) shift(seq int, beginIndex, offset int32) error {
 			continue
 		}
 
-		key = key.View(ctx, key.Stride(2)*seqRange.min,
-			key.Dim(0), key.Stride(1),
-			key.Dim(1), key.Stride(2),
-			size,
+		key = key.View(ctx, key.Stride(0)*seqRange.min,
+			[]int{size, key.Dim(0), key.Dim(2)},
+			[]int{key.Stride(0), key.Stride(1)},
 		)
 
 		roped, err := c.shiftFn(ctx, i, key, kShift)

--- a/ml/backend.go
+++ b/ml/backend.go
@@ -45,6 +45,10 @@ func NewBackend(f *os.File) (Backend, error) {
 
 type Context interface {
 	Zeros(dtype DType, shape ...int) Tensor
+
+	// TODO - the (Tensor, error) return pattern makes this impossible to
+	// one-line in cases where we need to pass a scalar into a function that
+	// requires a Tensor leading to overly verbose impls.  Consider a Must* API.
 	FromFloatSlice(s []float32, shape ...int) (Tensor, error)
 	FromIntSlice(s []int32, shape ...int) (Tensor, error)
 
@@ -52,6 +56,21 @@ type Context interface {
 	Compute(...Tensor)
 	MaxTensors() int
 	Close()
+
+	// TODO remove this before merging - temporary debugging aid
+	Abort(Tensor) // Evaluate the graph up to this point, retrieve the data from the tensor and dump it to a json file for comparision
+}
+
+// Usage:
+//
+//	if sdpa, ok := ctx.(ml.FastScaledDotProductAttention); ok {
+//	  hiddenState = sdpa.FastScaledDotProductAttention(...)
+//	} else {
+//
+//	  // manual sdpa
+//	}
+type FastScaledDotProductAttention interface {
+	FastScaledDotProductAttention(queries, keys, values Tensor, scale float32, mask Tensor) Tensor
 }
 
 type Tensor interface {
@@ -69,20 +88,21 @@ type Tensor interface {
 	Mulmat(ctx Context, t2 Tensor) Tensor
 	MulmatFullPrec(ctx Context, t2 Tensor) Tensor
 
-	Softmax(ctx Context) Tensor
+	Softmax(ctx Context) Tensor // TODO axis parameter?
 	LayerNorm(ctx Context, weight, bias Tensor, eps float32) Tensor
 	RMSNorm(ctx Context, weight Tensor, eps float32) Tensor
 	Scale(ctx Context, s float64) Tensor
 
 	Conv2D(ctx Context, weight Tensor, s0, s1, p0, p1, d0, d1 int) Tensor
-	RoPE(ctx Context, positionIDs, ropeFactors Tensor, dim uint32, base, scale float32) Tensor
+
+	RoPE(ctx Context, positionIDs, ropeFactors, freqs Tensor, dim uint32, base, scale float32) Tensor
 
 	Tanh(ctx Context) Tensor
 	GELU(ctx Context) Tensor
 	SILU(ctx Context) Tensor
 
 	Reshape(ctx Context, shape ...int) Tensor
-	View(ctx Context, offset int, shape ...int) Tensor
+	View(ctx Context, offset int, shape, stride []int) Tensor
 	Permute(ctx Context, shape ...int) Tensor
 	Contiguous(ctx Context) Tensor
 
@@ -93,6 +113,7 @@ type Tensor interface {
 	Concat(ctx Context, t2 Tensor, dim int) Tensor
 	Rows(ctx Context, t2 Tensor) Tensor
 	Copy(ctx Context, t2 Tensor) Tensor
+	Repeat(ctx Context, repeats, axis int) Tensor
 }
 
 type number interface {
@@ -203,3 +224,14 @@ const (
 	DTypeF16
 	DTypeI32
 )
+
+func (dt DType) String() string {
+	switch dt {
+	case DTypeF32:
+		return "float32"
+	case DTypeI32:
+		return "int32"
+	default:
+		return "unknon"
+	}
+}

--- a/ml/backend/ggml/ggml.go
+++ b/ml/backend/ggml/ggml.go
@@ -9,10 +9,13 @@ package ggml
 import "C"
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"os"
+	"runtime/debug"
 	"sync"
 	"unsafe"
 
@@ -22,6 +25,10 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	ggml "github.com/ollama/ollama/ml/backend/ggml/ggml/src"
+)
+
+var (
+	rev = []C.int{3, 2, 1, 0}
 )
 
 type device struct {
@@ -75,7 +82,7 @@ func New(r *os.File) (ml.Backend, error) {
 	}
 
 	slog.Info(
-		"",
+		"initializing GGML backend",
 		"architecture", meta.KV().Architecture(),
 		"file_type", meta.KV().FileType(),
 		"name", meta.KV().String("general.name"),
@@ -187,7 +194,10 @@ func (b *Backend) Get(name string) ml.Tensor {
 
 	for _, c := range append(b.gpus, b.cpus...) {
 		if t := C.ggml_get_tensor(c.ctx, cname); t != nil {
-			return &Tensor{t: t}
+			return &Tensor{
+				t:     t,
+				nDims: int(C.ggml_n_dims(t)),
+			}
 		}
 	}
 
@@ -271,15 +281,22 @@ func shapeToGGML(shape []int) *C.int64_t {
 	return &sh[0]
 }
 
-func (c Context) Zeros(dtype ml.DType, shape ...int) ml.Tensor {
-	if len(shape) < 1 || len(shape) > 4 {
+func (c Context) Zeros(dtype ml.DType, rshape ...int) ml.Tensor {
+	if len(rshape) < 1 || len(rshape) > 4 {
 		panic("unsupported number of dimensions")
 	}
 
-	for _, dim := range shape {
+	for _, dim := range rshape {
 		if dim < 1 {
 			panic("invalid shape")
 		}
+	}
+	// Inverted
+	shape := make([]int, len(rshape))
+	i := len(rshape) - 1
+	for _, dim := range rshape {
+		shape[i] = dim
+		i--
 	}
 
 	var t *C.struct_ggml_tensor
@@ -293,14 +310,21 @@ func (c Context) Zeros(dtype ml.DType, shape ...int) ml.Tensor {
 	default:
 		panic("unsupported dtype")
 	}
-
 	b := C.ggml_backend_alloc_buffer(c.backend, C.ggml_nbytes(t))
 	C.ggml_backend_tensor_alloc(b, t, C.ggml_backend_buffer_get_base(b))
 	C.ggml_set_zero(t)
-	return &Tensor{t: t}
+	return &Tensor{t: t, nDims: len(shape)}
 }
 
-func fromSlice[S ~[]E, E float32 | int32](ctx Context, s S, shape []int, dtype uint32) (ml.Tensor, error) {
+func fromSlice[S ~[]E, E float32 | int32](ctx Context, s S, rshape []int, dtype uint32) (ml.Tensor, error) {
+	// Inverted
+	shape := make([]int, len(rshape))
+	i := len(rshape) - 1
+	for _, dim := range rshape {
+		shape[i] = dim
+		i--
+	}
+
 	n := len(s)
 
 	if n == 0 {
@@ -321,7 +345,7 @@ func fromSlice[S ~[]E, E float32 | int32](ctx Context, s S, shape []int, dtype u
 	b := C.ggml_backend_alloc_buffer(ctx.backend, C.ggml_nbytes(t))
 	C.ggml_backend_tensor_alloc(b, t, C.ggml_backend_buffer_get_base(b))
 	C.ggml_backend_tensor_set(t, unsafe.Pointer(&s[0]), 0, C.ggml_nbytes(t))
-	return &Tensor{t: t}, nil
+	return &Tensor{t: t, nDims: len(shape)}, nil
 }
 
 func (c Context) FromFloatSlice(s []float32, shape ...int) (ml.Tensor, error) {
@@ -340,7 +364,13 @@ func (c *Context) Close() {
 }
 
 type Tensor struct {
-	t    *C.struct_ggml_tensor
+	t *C.struct_ggml_tensor
+
+	// keep track of the number of dimensions
+	// Since we reverse the shape, GGML considers a trailing "1" dimension as not present
+	// and we can't actually trust the output of ggml_n_dims
+	nDims int
+
 	sync func()
 }
 
@@ -349,23 +379,35 @@ func (t *Tensor) LogValue() slog.Value {
 		slog.String("name", C.GoString(C.ggml_get_name(t.t))),
 		slog.String("type", C.GoString(C.ggml_type_name(t.t._type))),
 		slog.Any("shape", t.Shape()),
+		slog.Any("underlying shape", t.t.ne),
+		slog.Any("underlying stride", t.t.nb),
 	)
 }
 
 func (t *Tensor) Dim(n int) int {
-	return int(t.t.ne[n])
+	if t.nDims == 0 {
+		// If this hits we likely forgot to copy the dimension to the returned tensor in some operation
+		panic("zero dimension tensor")
+	}
+	r := rev[4-t.nDims:]
+	return int(t.t.ne[r[n]])
 }
 
 func (t *Tensor) Stride(n int) int {
-	return int(t.t.nb[n])
+	if t.nDims == 0 {
+		slog.Error("Stride", "tensor", t, "dim", n)
+		panic("zero dimension tensor")
+	}
+	r := rev[4-t.nDims:]
+	s := int(t.t.nb[r[n]])
+	return s
 }
 
 func (t *Tensor) Shape() []int {
-	shape := make([]int, C.ggml_n_dims(t.t))
+	shape := make([]int, t.nDims)
 	for i := range shape {
 		shape[i] = t.Dim(i)
 	}
-
 	return shape
 }
 
@@ -406,7 +448,8 @@ func (t *Tensor) DType() ml.DType {
 
 func (t *Tensor) Add(ctx ml.Context, t2 ml.Tensor) ml.Tensor {
 	return &Tensor{
-		t: C.ggml_add(ctx.(*Context).ctx, t.t, t2.(*Tensor).t),
+		t:     C.ggml_add(ctx.(*Context).ctx, t.t, t2.(*Tensor).t),
+		nDims: t.nDims,
 	}
 }
 
@@ -420,25 +463,34 @@ func (t *Tensor) Stack(ctx ml.Context, dim int, s ...ml.Tensor) ml.Tensor {
 
 func (t *Tensor) Concat(ctx ml.Context, t2 ml.Tensor, dim int) ml.Tensor {
 	return &Tensor{
-		t: C.ggml_concat(ctx.(*Context).ctx, t.t, t2.(*Tensor).t, C.int(dim)),
+		t:     C.ggml_concat(ctx.(*Context).ctx, t.t, t2.(*Tensor).t, C.int(dim)),
+		nDims: t.nDims,
 	}
 }
 
 func (t *Tensor) Contiguous(ctx ml.Context) ml.Tensor {
 	return &Tensor{
-		t: C.ggml_cont(ctx.(*Context).ctx, t.t),
+		t:     C.ggml_cont(ctx.(*Context).ctx, t.t),
+		nDims: t.nDims,
 	}
 }
 
 func (t *Tensor) Mul(ctx ml.Context, t2 ml.Tensor) ml.Tensor {
 	return &Tensor{
-		t: C.ggml_mul(ctx.(*Context).ctx, t.t, t2.(*Tensor).t),
+		t:     C.ggml_mul(ctx.(*Context).ctx, t.t, t2.(*Tensor).t),
+		nDims: t.nDims, // TODO should this be max(t.nDims, t2.nDims)?
 	}
 }
 
 func (t *Tensor) Mulmat(ctx ml.Context, t2 ml.Tensor) ml.Tensor {
+	if t.t.ne[0] != t2.(*Tensor).t.ne[0] {
+		slog.Error("incorrect tensor shapes for Mulmat", "t", t, "t2", t2)
+		panic("malformed tensors passed to Mulmat")
+	}
+	r := C.ggml_mul_mat(ctx.(*Context).ctx, t.t, t2.(*Tensor).t)
 	return &Tensor{
-		t: C.ggml_mul_mat(ctx.(*Context).ctx, t.t, t2.(*Tensor).t),
+		t:     r,
+		nDims: max(t.nDims, t2.(*Tensor).nDims),
 	}
 }
 
@@ -447,12 +499,13 @@ func (t *Tensor) MulmatFullPrec(ctx ml.Context, t2 ml.Tensor) ml.Tensor {
 	C.ggml_mul_mat_set_prec(mul, C.GGML_PREC_F32)
 
 	return &Tensor{
-		t: mul,
+		t:     mul,
+		nDims: max(t.nDims, t2.(*Tensor).nDims),
 	}
 }
 
 func (t *Tensor) LayerNorm(ctx ml.Context, w, b ml.Tensor, eps float32) ml.Tensor {
-	tt := (&Tensor{t: C.ggml_norm(ctx.(*Context).ctx, t.t, C.float(eps))}).Mul(ctx, w)
+	tt := (&Tensor{t: C.ggml_norm(ctx.(*Context).ctx, t.t, C.float(eps)), nDims: t.nDims}).Mul(ctx, w)
 	if b != nil {
 		tt = tt.Add(ctx, b)
 	}
@@ -461,7 +514,7 @@ func (t *Tensor) LayerNorm(ctx ml.Context, w, b ml.Tensor, eps float32) ml.Tenso
 }
 
 func (t *Tensor) RMSNorm(ctx ml.Context, w ml.Tensor, eps float32) ml.Tensor {
-	return (&Tensor{t: C.ggml_norm(ctx.(*Context).ctx, t.t, C.float(eps))}).Mul(ctx, w)
+	return (&Tensor{t: C.ggml_norm(ctx.(*Context).ctx, t.t, C.float(eps)), nDims: t.nDims}).Mul(ctx, w)
 }
 
 func (t *Tensor) Pad(ctx ml.Context, shape ...int) ml.Tensor {
@@ -470,7 +523,8 @@ func (t *Tensor) Pad(ctx ml.Context, shape ...int) ml.Tensor {
 	}
 
 	return &Tensor{
-		t: C.ggml_pad(ctx.(*Context).ctx, t.t, C.int(shape[0]), C.int(shape[1]), C.int(shape[2]), C.int(shape[3])),
+		t:     C.ggml_pad(ctx.(*Context).ctx, t.t, C.int(shape[3]), C.int(shape[2]), C.int(shape[1]), C.int(shape[0])),
+		nDims: t.nDims,
 	}
 }
 
@@ -478,41 +532,85 @@ func (t *Tensor) Permute(ctx ml.Context, shape ...int) ml.Tensor {
 	if len(shape) != 4 {
 		panic("expected 4 dimensions")
 	}
-
-	return &Tensor{
-		t: C.ggml_permute(ctx.(*Context).ctx, t.t, C.int(shape[0]), C.int(shape[1]), C.int(shape[2]), C.int(shape[3])),
+	rshape := []C.int{0, 1, 2, 3}
+	switch t.nDims {
+	case 2:
+		rshape[0] = rev[2:][shape[1]]
+		rshape[1] = rev[2:][shape[0]]
+	case 3:
+		rshape[0] = rev[1:][shape[2]]
+		rshape[1] = rev[1:][shape[1]]
+		rshape[2] = rev[1:][shape[0]]
+	case 4:
+		rshape[0] = rev[shape[3]]
+		rshape[1] = rev[shape[2]]
+		rshape[2] = rev[shape[1]]
+		rshape[3] = rev[shape[1]]
 	}
+	r := &Tensor{
+		t:     C.ggml_permute(ctx.(*Context).ctx, t.t, rshape[0], rshape[1], rshape[2], rshape[3]),
+		nDims: t.nDims,
+	}
+	return r
 }
 
 func (t *Tensor) Rows(ctx ml.Context, t2 ml.Tensor) ml.Tensor {
 	return &Tensor{
-		t: C.ggml_get_rows(ctx.(*Context).ctx, t.t, t2.(*Tensor).t),
+		t:     C.ggml_get_rows(ctx.(*Context).ctx, t.t, t2.(*Tensor).t),
+		nDims: t.nDims,
 	}
 }
 
 func (t *Tensor) Copy(ctx ml.Context, t2 ml.Tensor) ml.Tensor {
-	return &Tensor{
-		t: C.ggml_cpy(ctx.(*Context).ctx, t.t, t2.(*Tensor).t),
+	r := &Tensor{
+		t:     C.ggml_cpy(ctx.(*Context).ctx, t.t, t2.(*Tensor).t),
+		nDims: t.nDims,
 	}
+	return r
 }
 
 func (t *Tensor) Reshape(ctx ml.Context, shape ...int) ml.Tensor {
+	// GGML does not handle -1 natively
+	for i, sh := range shape {
+		if sh == -1 {
+			totalElems := 1
+			for d := range t.nDims {
+				totalElems *= int(t.t.ne[d])
+			}
+			otherElems := 1
+			for _, osh := range shape {
+				if osh != -1 {
+					otherElems *= int(osh)
+				}
+			}
+			if otherElems > totalElems {
+				slog.Error("Invalid request", "req", shape, "actual", t.Shape(), "totalElems", totalElems, "otherElems", otherElems)
+				panic("impossible -1 shape request")
+			}
+			shape[i] = int(float64(totalElems) / float64(otherElems))
+			break
+		}
+	}
 	switch len(shape) {
 	case 1:
 		return &Tensor{
-			t: C.ggml_reshape_1d(ctx.(*Context).ctx, t.t, C.int64_t(shape[0])),
+			t:     C.ggml_reshape_1d(ctx.(*Context).ctx, t.t, C.int64_t(shape[0])),
+			nDims: len(shape),
 		}
 	case 2:
 		return &Tensor{
-			t: C.ggml_reshape_2d(ctx.(*Context).ctx, t.t, C.int64_t(shape[0]), C.int64_t(shape[1])),
+			t:     C.ggml_reshape_2d(ctx.(*Context).ctx, t.t, C.int64_t(shape[1]), C.int64_t(shape[0])),
+			nDims: len(shape),
 		}
 	case 3:
 		return &Tensor{
-			t: C.ggml_reshape_3d(ctx.(*Context).ctx, t.t, C.int64_t(shape[0]), C.int64_t(shape[1]), C.int64_t(shape[2])),
+			t:     C.ggml_reshape_3d(ctx.(*Context).ctx, t.t, C.int64_t(shape[2]), C.int64_t(shape[1]), C.int64_t(shape[0])),
+			nDims: len(shape),
 		}
 	case 4:
 		return &Tensor{
-			t: C.ggml_reshape_4d(ctx.(*Context).ctx, t.t, C.int64_t(shape[0]), C.int64_t(shape[1]), C.int64_t(shape[2]), C.int64_t(shape[3])),
+			t:     C.ggml_reshape_4d(ctx.(*Context).ctx, t.t, C.int64_t(shape[3]), C.int64_t(shape[2]), C.int64_t(shape[1]), C.int64_t(shape[0])),
+			nDims: len(shape),
 		}
 	default:
 		panic("unsupported number of dimensions")
@@ -521,19 +619,22 @@ func (t *Tensor) Reshape(ctx ml.Context, shape ...int) ml.Tensor {
 
 func (t *Tensor) Scale(ctx ml.Context, s float64) ml.Tensor {
 	return &Tensor{
-		t: C.ggml_scale(ctx.(*Context).ctx, t.t, (C.float)(s)),
+		t:     C.ggml_scale(ctx.(*Context).ctx, t.t, (C.float)(s)),
+		nDims: t.nDims,
 	}
 }
 
 func (t *Tensor) Softmax(ctx ml.Context) ml.Tensor {
 	return &Tensor{
-		t: C.ggml_soft_max(ctx.(*Context).ctx, t.t),
+		t:     C.ggml_soft_max(ctx.(*Context).ctx, t.t),
+		nDims: t.nDims,
 	}
 }
 
 func (t *Tensor) Tanh(ctx ml.Context) ml.Tensor {
 	return &Tensor{
-		t: C.ggml_tanh_inplace(ctx.(*Context).ctx, t.t),
+		t:     C.ggml_tanh_inplace(ctx.(*Context).ctx, t.t),
+		nDims: t.nDims,
 	}
 }
 
@@ -543,36 +644,45 @@ func (t *Tensor) Unpad(ctx ml.Context, shape ...int) ml.Tensor {
 	}
 
 	return &Tensor{
-		t: C.ggml_unpad(ctx.(*Context).ctx, t.t, C.int(shape[0]), C.int(shape[1]), C.int(shape[2]), C.int(shape[3])),
+		t:     C.ggml_unpad(ctx.(*Context).ctx, t.t, C.int(shape[3]), C.int(shape[2]), C.int(shape[1]), C.int(shape[0])),
+		nDims: t.nDims, // TODO is this right?
 	}
 }
 
-func (t *Tensor) View(ctx ml.Context, offset int, shape ...int) ml.Tensor {
+func (t *Tensor) View(ctx ml.Context, offset int, shape, stride []int) ml.Tensor {
+	if len(stride)+1 != len(shape) {
+		panic(fmt.Sprintf("malformed view request: shape=%v stride=%v", shape, stride))
+	}
+
 	switch len(shape) {
 	case 1:
 		return &Tensor{
-			t: C.ggml_view_1d(ctx.(*Context).ctx, t.t, C.int64_t(shape[0]), C.size_t(offset)),
+			t:     C.ggml_view_1d(ctx.(*Context).ctx, t.t, C.int64_t(shape[0]), C.size_t(offset)),
+			nDims: 1,
+		}
+	case 2:
+		return &Tensor{
+			t: C.ggml_view_2d(ctx.(*Context).ctx, t.t,
+				C.int64_t(shape[1]), C.int64_t(shape[0]),
+				C.size_t(stride[0]),
+				C.size_t(offset)),
+			nDims: 2,
 		}
 	case 3:
 		return &Tensor{
-			t: C.ggml_view_2d(ctx.(*Context).ctx, t.t,
-				C.int64_t(shape[0]), C.int64_t(shape[2]),
-				C.size_t(shape[1]),
-				C.size_t(offset)),
-		}
-	case 5:
-		return &Tensor{
 			t: C.ggml_view_3d(ctx.(*Context).ctx, t.t,
-				C.int64_t(shape[0]), C.int64_t(shape[2]), C.int64_t(shape[4]),
-				C.size_t(shape[1]), C.size_t(shape[3]),
+				C.int64_t(shape[2]), C.int64_t(shape[1]), C.int64_t(shape[0]),
+				C.size_t(stride[1]), C.size_t(stride[0]),
 				C.size_t(offset)),
+			nDims: 3,
 		}
-	case 7:
+	case 4:
 		return &Tensor{
 			t: C.ggml_view_4d(ctx.(*Context).ctx, t.t,
-				C.int64_t(shape[0]), C.int64_t(shape[2]), C.int64_t(shape[4]), C.int64_t(shape[6]),
-				C.size_t(shape[1]), C.size_t(shape[3]), C.size_t(shape[5]),
+				C.int64_t(shape[3]), C.int64_t(shape[2]), C.int64_t(shape[1]), C.int64_t(shape[0]),
+				C.size_t(stride[2]), C.size_t(stride[1]), C.size_t(stride[0]),
 				C.size_t(offset)),
+			nDims: 4,
 		}
 	default:
 		panic("unsupported number of dimensions")
@@ -583,7 +693,15 @@ const (
 	ropeTypeNorm C.int = iota
 )
 
-func (t *Tensor) RoPE(ctx ml.Context, positionIDs, ropeFactors ml.Tensor, ropeDim uint32, ropeBase, ropeScale float32) ml.Tensor {
+func (t *Tensor) RoPE(
+	ctx ml.Context,
+	positionIDs ml.Tensor,
+	ropeFactors ml.Tensor,
+	freqs ml.Tensor, // Unused on GGML
+	ropeDim uint32,
+	ropeBase,
+	ropeScale float32,
+) ml.Tensor {
 	if ropeFactors == nil {
 		ropeFactors = &Tensor{}
 	}
@@ -592,7 +710,6 @@ func (t *Tensor) RoPE(ctx ml.Context, positionIDs, ropeFactors ml.Tensor, ropeDi
 	if C.ggml_is_quantized(t.t._type) {
 		dequant = C.ggml_cast(ctx.(*Context).ctx, t.t, C.GGML_TYPE_F32)
 	}
-
 	return &Tensor{
 		t: C.ggml_rope_ext(
 			ctx.(*Context).ctx, dequant, positionIDs.(*Tensor).t, ropeFactors.(*Tensor).t,
@@ -606,23 +723,78 @@ func (t *Tensor) RoPE(ctx ml.Context, positionIDs, ropeFactors ml.Tensor, ropeDi
 			32., // YaRN beta_fast
 			1.,  // YaRN beta_slow
 		),
+		nDims: t.nDims,
 	}
 }
 
 func (t *Tensor) GELU(ctx ml.Context) ml.Tensor {
 	return &Tensor{
-		t: C.ggml_gelu_inplace(ctx.(*Context).ctx, t.t),
+		t:     C.ggml_gelu_inplace(ctx.(*Context).ctx, t.t),
+		nDims: t.nDims,
 	}
 }
 
 func (t *Tensor) SILU(ctx ml.Context) ml.Tensor {
 	return &Tensor{
-		t: C.ggml_silu_inplace(ctx.(*Context).ctx, t.t),
+		t:     C.ggml_silu_inplace(ctx.(*Context).ctx, t.t),
+		nDims: t.nDims,
 	}
 }
 
 func (t *Tensor) Conv2D(ctx ml.Context, t2 ml.Tensor, s0, s1, p0, p1, d0, d1 int) ml.Tensor {
 	return &Tensor{
-		t: C.ggml_conv_2d(ctx.(*Context).ctx, t.t, t2.(*Tensor).t, C.int(s0), C.int(s1), C.int(p0), C.int(p1), C.int(d0), C.int(d1)),
+		t:     C.ggml_conv_2d(ctx.(*Context).ctx, t.t, t2.(*Tensor).t, C.int(s0), C.int(s1), C.int(p0), C.int(p1), C.int(d0), C.int(d1)),
+		nDims: t.nDims,
 	}
+}
+
+func (t *Tensor) Repeat(ctx ml.Context, repeats, axis int) ml.Tensor {
+	shape := make([]int64, t.nDims)
+	for i := range shape {
+		shape[i] = int64(t.t.ne[i])
+	}
+
+	shape[rev[axis]] *= int64(repeats)
+	tt := C.ggml_new_tensor(ctx.(*Context).ctx, t.t._type, C.int(len(shape)), (*C.int64_t)(unsafe.Pointer(&shape[0])))
+	r := &Tensor{
+		t:     C.ggml_repeat(ctx.(*Context).ctx, t.t, tt),
+		nDims: t.nDims,
+	}
+	return r
+}
+
+// TODO remove this before merging - temporary debugging aid
+func (c *Context) Abort(t ml.Tensor) {
+	// Hack to make sure we're f32, otherwise r.Floats will fail due to short read
+	if t.(*Tensor).t._type != C.GGML_TYPE_F32 {
+		t.(*Tensor).t = C.ggml_cast(c.ctx, t.(*Tensor).t, C.GGML_TYPE_F32)
+	}
+	c.Forward(t)
+	c.Compute(t)
+	f32 := t.Floats()
+	// Convert [-]Inf to serializable values
+	for i, v := range f32 {
+		if v > math.MaxFloat32 {
+			f32[i] = math.MaxFloat32
+		}
+		if v < -math.SmallestNonzeroFloat32 {
+			f32[i] = -math.MaxFloat32
+		}
+	}
+	debug.PrintStack()
+
+	filename := "ggml.json"
+	slog.Info("Writing tensors to", "filename", filename)
+	f, err := os.Create(filename)
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+	encoder := json.NewEncoder(f)
+	err = encoder.Encode(f32)
+	if err != nil {
+		panic(err)
+	}
+
+	os.Exit(1)
 }

--- a/model/README.md
+++ b/model/README.md
@@ -1,0 +1,62 @@
+# Ollama Models
+
+Large Language Models in Ollama are defined in the Go programming language within this directory.
+
+
+## Model Implementation Guide
+
+Ollama supports multiple backends, and provides an astracted interface for model implementers.  [Backend API ](../ml/backend.go)
+
+This API is designed to be similar to other popular python libraries such as
+PyTorch, with row-major tensors and a forward function that takes a sequence of
+inputs.  
+
+Use an existing model as an initial reference, such as [llama](./models/llama/)
+
+Cheatsheet:
+
+<table>
+<tr>
+  <td><b>PyTorch</b></td>
+  <td><b>Ollama</b></td>
+</tr>
+<tr>
+  <td>torch.zeros((2, 2))</td>
+  <td>ctx.Zeros(ml.DTypeF32, 2, 2)</td>
+</tr>
+<tr>
+  <td>tensor.view((2, 2))</td>
+  <td>t.Reshape(ctx, 2, 2)</td>
+</tr>
+<tr>
+   <td>torch.permute(t1, (1, 2, 3))</td>
+   <td>t1.Permute(ctx, 1, 2, 3)</td>
+</tr>
+<tr>
+    <td>torch.add(t1, t2)</td>
+    <td>t1.Add(ctx, t2)</td>
+</tr>
+<tr>
+<td>
+
+```python
+class Attention(nn.Module):
+    def __call__(self, ...):
+        ...
+```
+
+</td>
+<td>
+
+```go
+func (sa *SelfAttention) Forward(ctx ml.Context,
+                                 hiddenState, positionIDs ml.Tensor,
+                                 cache kvcache.Cache,
+                                 opts *Options) ml.Tensor {
+    ...
+}
+```
+
+</td>
+</tr>
+</table>

--- a/model/model.go
+++ b/model/model.go
@@ -247,3 +247,14 @@ func Forward(ctx ml.Context, m Model, opts Options) (ml.Tensor, error) {
 
 	return t, nil
 }
+
+func ArangeF32(start, end, step float32) []float32 {
+	if step == 0 || start >= end {
+		return nil
+	}
+	var res []float32
+	for i := float32(start); i < end; i += step {
+		res = append(res, i)
+	}
+	return res
+}

--- a/model/models/llama/model.go
+++ b/model/models/llama/model.go
@@ -65,41 +65,36 @@ type SelfAttention struct {
 }
 
 func (sa *SelfAttention) Forward(ctx ml.Context, hiddenState, positionIDs ml.Tensor, cache kvcache.Cache, opts *Options) ml.Tensor {
-	batchSize := hiddenState.Dim(1)
+	batchSize := hiddenState.Dim(0) // TODO Consider renaming "L" as this is the sequence length, not batch size
 	headDim := opts.hiddenSize / opts.numHeads
 
 	q := sa.Query.Forward(ctx, hiddenState)
-	q = q.Reshape(ctx, headDim, opts.numHeads, batchSize)
-	q = q.RoPE(ctx, positionIDs, opts.RopeFactors, opts.ropeDim, opts.ropeBase, opts.ropeScale)
+	q = q.Reshape(ctx, batchSize, opts.numHeads, -1)
+	q = LlamaRoPE(ctx, q, positionIDs, opts)
 
 	k := sa.Key.Forward(ctx, hiddenState)
-	k = k.Reshape(ctx, headDim, opts.numKVHeads, batchSize)
-	k = k.RoPE(ctx, positionIDs, opts.RopeFactors, opts.ropeDim, opts.ropeBase, opts.ropeScale)
+	k = k.Reshape(ctx, batchSize, opts.numKVHeads, -1)
+	k = LlamaRoPE(ctx, k, positionIDs, opts)
 
 	v := sa.Value.Forward(ctx, hiddenState)
-	v = v.Reshape(ctx, headDim, opts.numKVHeads, batchSize)
+	v = v.Reshape(ctx, batchSize, opts.numKVHeads, -1)
 
 	cache.Put(ctx, k, v)
 	k, v, mask := cache.Get(ctx)
 
-	q = q.Permute(ctx, 0, 2, 1, 3).Contiguous(ctx)
-	k = k.Permute(ctx, 0, 2, 1, 3).Contiguous(ctx)
-	v = v.Permute(ctx, 1, 2, 0, 3).Contiguous(ctx)
+	q = q.Permute(ctx, 1, 0, 2, 3).Contiguous(ctx)
+	k = k.Permute(ctx, 1, 0, 2, 3).Contiguous(ctx)
+	v = v.Permute(ctx, 1, 0, 2, 3).Contiguous(ctx)
 
-	kq := k.MulmatFullPrec(ctx, q)
-	kq = kq.Scale(ctx, 1.0/math.Sqrt(float64(headDim)))
-	kq = kq.Add(ctx, mask)
-	kq = kq.Softmax(ctx)
+	kqv := ScaledDotProductAttention(ctx, q, k, v, mask, float32(math.Pow(float64(headDim), -0.5)))
 
-	kqv := v.Mulmat(ctx, kq)
-	kqv = kqv.Permute(ctx, 0, 2, 1, 3).Contiguous(ctx)
-	kqv = kqv.Reshape(ctx, opts.hiddenSize, batchSize)
-
+	kqv = kqv.Permute(ctx, 1, 0, 2, 3).Contiguous(ctx)
+	kqv = kqv.Reshape(ctx, batchSize, -1)
 	return sa.Output.Forward(ctx, kqv)
 }
 
 func (m *Model) Shift(ctx ml.Context, layer int, key, shift ml.Tensor) (ml.Tensor, error) {
-	return key.RoPE(ctx, shift, m.Options.RopeFactors, m.Options.ropeDim, m.Options.ropeBase, m.Options.ropeScale), nil
+	return LlamaRoPE(ctx, key, shift, m.Options), nil
 }
 
 type MLP struct {

--- a/model/models/llama/utils.go
+++ b/model/models/llama/utils.go
@@ -1,0 +1,96 @@
+package llama
+
+import (
+	"math"
+	"sync"
+
+	"github.com/ollama/ollama/ml"
+	"github.com/ollama/ollama/model"
+)
+
+func LlamaRoPE(ctx ml.Context, x, positionIDs ml.Tensor, opts *Options) ml.Tensor {
+	var once sync.Once
+	var _freqs ml.Tensor
+	dims := opts.ropeDim
+	onceBody := func() {
+		// Reference: https://github.com/ml-explore/mlx-examples/blob/main/llms/mlx_lm/models/rope_utils.py#L9
+
+		base := opts.ropeBase // aka rope_scale
+		if base == 0 {
+			base = 10000.0
+		}
+		low_freq_factor := opts.ropeScale // ???
+		high_freq_factor := float32(4.0)  // TODO should attempt to get from metadata
+		factor := float32(8.0)            // metadata?
+		old_context_len := float32(8192)  // metadata?  (aka original_max_position_embeddings)
+
+		// Calcs...
+		low_freq_wavelen := float32(old_context_len) / low_freq_factor
+		high_freq_wavelen := float32(old_context_len) / high_freq_factor
+
+		// freqs = base ** (mx.model.ArangeF32(0, dims, 2) / dims)
+		freqs := model.ArangeF32(0, float32(dims), 2)
+		for i := range freqs {
+			freqs[i] = (float32)(math.Pow(float64(base), float64(freqs[i])/float64(dims)))
+		}
+		// wavelens = 2 * mx.pi * freqs
+		wavelens := make([]float32, len(freqs))
+		for i := range wavelens {
+			wavelens[i] = freqs[i] * 2 * float32(math.Pi)
+		}
+		// freqs = mx.where(wavelens > low_freq_wavelen, freqs * factor, freqs)
+		for i := range freqs {
+			if wavelens[i] > low_freq_wavelen {
+				freqs[i] = freqs[i] * factor
+			}
+		}
+		// is_medium_freq = (wavelens > high_freq_wavelen) & (wavelens < low_freq_wavelen)
+		is_medium_freq := make([]bool, len(freqs))
+		for i := range freqs {
+			is_medium_freq[i] = (wavelens[i] > high_freq_wavelen) && (wavelens[i] < low_freq_wavelen)
+		}
+		// smooth_factors = (old_context_len / wavelens - low_freq_factor) / (high_freq_factor - low_freq_factor)
+		smooth_factors := make([]float32, len(freqs))
+		for i := range freqs {
+			smooth_factors[i] = ((old_context_len)/wavelens[i] - (low_freq_factor)) / ((high_freq_factor) - (low_freq_factor))
+		}
+		// smooth_freqs = freqs / ((1 - smooth_factors) / factor + smooth_factors)
+		smooth_freqs := make([]float32, len(freqs))
+		for i := range freqs {
+			smooth_freqs[i] = freqs[i] / ((1-smooth_factors[i])/factor + (smooth_factors[i]))
+		}
+		// _freqs = mx.where(is_medium_freq, smooth_freqs, freqs)
+		for i := range freqs {
+			if is_medium_freq[i] {
+				freqs[i] = float32(smooth_freqs[i])
+			}
+		}
+		_freqs, _ = ctx.FromFloatSlice(freqs, len(freqs))
+	}
+	once.Do(onceBody)
+
+	return x.RoPE(
+		ctx,
+		positionIDs,
+		opts.RopeFactors,
+		_freqs,
+		dims,
+		500000, // base
+		1.0,    // scale
+	)
+}
+
+func ScaledDotProductAttention(ctx ml.Context, q, k, v, mask ml.Tensor, scale float32) ml.Tensor {
+	if sdpa, ok := ctx.(ml.FastScaledDotProductAttention); ok {
+		// MLX support
+		return sdpa.FastScaledDotProductAttention(q, k, v, scale, mask)
+	} else {
+		// GGML support
+		kq := k.MulmatFullPrec(ctx, q)
+		kq = kq.Scale(ctx, float64(scale))
+		kq = kq.Add(ctx, mask)
+		kq = kq.Softmax(ctx)
+		v = v.Permute(ctx, 0, 2, 1, 3).Contiguous(ctx)
+		return v.Mulmat(ctx, kq)
+	}
+}

--- a/model/models/mllama/model_text.go
+++ b/model/models/mllama/model_text.go
@@ -22,11 +22,11 @@ func (sa *TextSelfAttention) Forward(ctx ml.Context, hiddenState, positions, _ m
 
 	query := sa.Query.Forward(ctx, hiddenState)
 	query = query.Reshape(ctx, headDim, opts.numHeads, batchSize)
-	query = query.RoPE(ctx, positions, opts.RopeFactors, opts.ropeDim, opts.ropeBase, opts.ropeScale)
+	query = query.RoPE(ctx, positions, nil /* TODO freqs */, opts.RopeFactors, opts.ropeDim, opts.ropeBase, opts.ropeScale)
 
 	key := sa.Key.Forward(ctx, hiddenState)
 	key = key.Reshape(ctx, headDim, opts.numKVHeads, batchSize)
-	key = key.RoPE(ctx, positions, opts.RopeFactors, opts.ropeDim, opts.ropeBase, opts.ropeScale)
+	key = key.RoPE(ctx, positions, nil /* TODO freqs */, opts.RopeFactors, opts.ropeDim, opts.ropeBase, opts.ropeScale)
 
 	value := sa.Value.Forward(ctx, hiddenState)
 	value = value.Reshape(ctx, headDim, opts.numKVHeads, batchSize)
@@ -52,7 +52,8 @@ func (sa *TextSelfAttention) Forward(ctx ml.Context, hiddenState, positions, _ m
 
 func (m *TextModel) Shift(ctx ml.Context, layer int, key, shift ml.Tensor) (ml.Tensor, error) {
 	// This will only get called for layers in the cache, which are just the self attention layers
-	return key.RoPE(ctx, shift, m.RopeFactors, m.ropeDim, m.ropeBase, m.ropeScale), nil
+	// return llama.LlamaRoPE(ctx, key, shift, m.TextModelOptions), nil //options type mismatch
+	panic("NOT YET IMPLEMENTED")
 }
 
 type TextMLP struct {


### PR DESCRIPTION
Replaces #8731 on main.

This change switches the model API (and backend) to be row-order.

The GGML backend reverses the shape, and tracks the number of dimensions to handle trailing 1 dimensions.

This also starts to lay some initial foundation for a future change that will add MLX as a second backend.

Keeping this in DRAFT state since only llama3 is converted to row-order - other models will not be functional until they're adjusted following the same pattern.