### PR TITLE
Wire up system info log for new engine

### DIFF
--- a/kvcache/causal_test.go
+++ b/kvcache/causal_test.go
@@ -305,6 +305,10 @@ func (b *testBackend) NewContext() ml.Context {
 	return &testContext{}
 }
 
+func (b *testBackend) SystemInfo() string {
+	return "not implemented"
+}
+
 type testContext struct{}
 
 func (c *testContext) Zeros(dtype ml.DType, shape ...int) ml.Tensor {

--- a/ml/backend.go
+++ b/ml/backend.go
@@ -23,6 +23,7 @@ type Backend interface {
 	Config() Config
 	Get(name string) Tensor
 	NewContext() Context
+	SystemInfo() string
 }
 
 var backends = make(map[string]func(*os.File) (Backend, error))

--- a/runner/ollamarunner/runner.go
+++ b/runner/ollamarunner/runner.go
@@ -813,6 +813,8 @@ func (s *Server) loadModel(
 		panic(err)
 	}
 
+	slog.Info("system", "info", s.model.Backend().SystemInfo() /* "threads", *threads */)
+
 	// TODO(jessegross): LoRA loading
 	if lpath.String() != "" {
 		panic("loras are not yet implemented")
@@ -881,7 +883,6 @@ func Execute(args []string) error {
 	})
 	slog.SetDefault(slog.New(handler))
 	slog.Info("starting ollama engine")
-	// TODO(jessegross): Some system info would be useful
 
 	server := &Server{
 		batchSize: *batchSize,


### PR DESCRIPTION
Example from the logs
```
time=2025-02-14T15:30:23.385-08:00 level=INFO source=runner.go:816 msg=system info="Metal : EMBED_LIBRARY = 1 | CPU : NEON = 1 | ARM_FMA = 1 | FP16_VA = 1 | DOTPROD = 1 | LLAMAFILE = 1 | ACCELERATE = 1 | cgo(clang)"
```

Threads aren't exposed yet since that wiring isn't complete yet for the new engine.