### PR TITLE
Add API key authentication for Ollama server

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1023,9 +1023,31 @@ func generate(cmd *cobra.Command, opts runOptions) error {
 	return nil
 }
 
-func RunServer(_ *cobra.Command, _ []string) error {
+func RunServer(cmd *cobra.Command, _ []string) error {
 	if err := initializeKeypair(); err != nil {
 		return err
+	}
+
+	// Get flags
+	host, _ := cmd.Flags().GetString("host")
+	port, _ := cmd.Flags().GetString("port")
+	apiKey, _ := cmd.Flags().GetString("api-key")
+
+	// Set environment variables based on flags if provided
+	if host != "" || port != "" {
+		hostAddr := "127.0.0.1"
+		if host != "" {
+			hostAddr = host
+		}
+		portNum := "11434"
+		if port != "" {
+			portNum = port
+		}
+		os.Setenv("OLLAMA_HOST", fmt.Sprintf("%s:%s", hostAddr, portNum))
+	}
+
+	if apiKey != "" {
+		os.Setenv("OLLAMA_API_KEY", apiKey)
 	}
 
 	ln, err := net.Listen("tcp", envconfig.Host().Host)
@@ -1220,6 +1242,10 @@ func NewCLI() *cobra.Command {
 		Args:    cobra.ExactArgs(0),
 		RunE:    RunServer,
 	}
+
+	serveCmd.Flags().String("host", "", "Host to listen on (default: 127.0.0.1)")
+	serveCmd.Flags().String("port", "", "Port to listen on (default: 11434)")
+	serveCmd.Flags().String("api-key", "", "Optional API key to secure the server")
 
 	pullCmd := &cobra.Command{
 		Use:     "pull MODEL",

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -167,6 +167,8 @@ var (
 	MultiUserCache = Bool("OLLAMA_MULTIUSER_CACHE")
 	// Enable the new Ollama engine
 	NewEngine = Bool("OLLAMA_NEW_ENGINE")
+	// APIKey is used for server authentication
+	APIKey = String("OLLAMA_API_KEY")
 )
 
 func String(s string) func() string {
@@ -253,6 +255,7 @@ func AsMap() map[string]EnvVar {
 		"OLLAMA_SCHED_SPREAD":      {"OLLAMA_SCHED_SPREAD", SchedSpread(), "Always schedule model across all GPUs"},
 		"OLLAMA_MULTIUSER_CACHE":   {"OLLAMA_MULTIUSER_CACHE", MultiUserCache(), "Optimize prompt caching for multi-user scenarios"},
 		"OLLAMA_NEW_ENGINE":        {"OLLAMA_NEW_ENGINE", NewEngine(), "Enable the new Ollama engine"},
+		"OLLAMA_API_KEY":           {"OLLAMA_API_KEY", APIKey(), "Optional API key for server authentication"},
 
 		// Informational
 		"HTTP_PROXY":  {"HTTP_PROXY", String("HTTP_PROXY")(), "HTTP proxy"},

--- a/server/routes.go
+++ b/server/routes.go
@@ -1141,6 +1141,7 @@ func (s *Server) GenerateRoutes() http.Handler {
 	r.Use(
 		cors.New(config),
 		allowedHostsMiddleware(s.addr),
+		apiKeyAuthMiddleware(),
 	)
 
 	r.POST("/api/pull", s.PullHandler)


### PR DESCRIPTION
- Introduce optional API key authentication for the Ollama server
- Add new flags to `serve` command for host, port, and API key configuration
- Implement API key middleware to validate Bearer token authentication
- Update environment configuration to support API key setting