### PR TITLE
fix: build warn

### DIFF
--- a/ml/backend/ggml/ggml/src/ggml-backend-reg.cpp
+++ b/ml/backend/ggml/ggml/src/ggml-backend-reg.cpp
@@ -432,9 +432,8 @@ static std::filesystem::path get_executable_path() {
     }
 
     return std::filesystem::path(path.data()).parent_path();
-#else
-    return {};
 #endif
+    return {};
 }
 
 static std::string backend_filename_prefix() {


### PR DESCRIPTION
```
ggml-backend-reg.cpp: In function ‘std::filesystem::__cxx11::path get_executable_path()’:
ggml-backend-reg.cpp:438:1: warning: control reaches end of non-void function [-Wreturn-type]
  438 | }
      | ^
```