### PR TITLE
server: allow vscode-file origins

### DIFF
--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -73,6 +73,7 @@ func AllowedOrigins() (origins []string) {
 		"file://*",
 		"tauri://*",
 		"vscode-webview://*",
+		"vscode-file://*",
 	)
 
 	return origins

--- a/envconfig/config_test.go
+++ b/envconfig/config_test.go
@@ -69,6 +69,7 @@ func TestOrigins(t *testing.T) {
 			"file://*",
 			"tauri://*",
 			"vscode-webview://*",
+			"vscode-file://*",
 		}},
 		{"http://10.0.0.1", []string{
 			"http://10.0.0.1",
@@ -88,6 +89,7 @@ func TestOrigins(t *testing.T) {
 			"file://*",
 			"tauri://*",
 			"vscode-webview://*",
+			"vscode-file://*",
 		}},
 		{"http://172.16.0.1,https://192.168.0.1", []string{
 			"http://172.16.0.1",
@@ -108,6 +110,7 @@ func TestOrigins(t *testing.T) {
 			"file://*",
 			"tauri://*",
 			"vscode-webview://*",
+			"vscode-file://*",
 		}},
 		{"http://totally.safe,http://definitely.legit", []string{
 			"http://totally.safe",
@@ -128,6 +131,7 @@ func TestOrigins(t *testing.T) {
 			"file://*",
 			"tauri://*",
 			"vscode-webview://*",
+			"vscode-file://*",
 		}},
 	}
 	for _, tt := range cases {


### PR DESCRIPTION
## Overview
When using [Cursor](https://cursor.com) and trying to verify with Local Ollama service, requests to `POST /v1/chat/completions` fail with **403 Forbidden** due to the Origin header using `vscode-file://vscode-app` which isn't currently whitelisted.

![403 Forbidden Error](https://github.com/user-attachments/assets/2a5d4415-1dfd-44a8-b66c-05fff9a39392)

## Suggested Fix
Add `vscode-file://*` to the allowed origins list in the `OLLAMA_ORIGINS` environment variable configuration.
