### PR TITLE
[doc update] Update broken URLs

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -41,7 +41,7 @@ Install prerequisites:
 - [CMake](https://cmake.org/download/)
 - [Visual Studio 2022](https://visualstudio.microsoft.com/downloads/) including the Native Desktop Workload
 - (Optional) AMD GPU support
-    - [ROCm](https://rocm.github.io/install.html)
+    - [ROCm](https://github.com/ROCm/ROCm?tab=readme-ov-file)
     - [Ninja](https://github.com/ninja-build/ninja/releases)
 - (Optional) NVIDIA GPU support
     - [CUDA SDK](https://developer.nvidia.com/cuda-downloads?target_os=Windows&target_arch=x86_64&target_version=11&target_type=exe_network)


### PR DESCRIPTION
[rocm.github.io](https://rocm.github.io/install.html)  is no longer available: 404 page not found. 