### PR TITLE
ml/backend/ggml: fix debug logging

### DIFF
--- a/runner/llamarunner/runner.go
+++ b/runner/llamarunner/runner.go
@@ -915,7 +915,6 @@ func Execute(args []string) error {
 	level := slog.LevelInfo
 	if *verbose {
 		level = slog.LevelDebug
-		llama.EnableDebug()
 	}
 	handler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
 		Level:     level,


### PR DESCRIPTION
Debug logging was being set on init of both `./ml/backend/ggml/src` and `./llama` packages in that order. Since the new engine never calls `llama.EnableDebug()`, it means debug logging was never enabled regardless of `OLLAMA_DEBUG`. Since llama.cpp has its own logging, I've had to duplicate the log sink instead of removing it completely.

This change also reverts to using `fmt.Fprintf` rather than structured logging since some log statements, particularly in debug scenarios, assumes an unstructured log.