### PR TITLE
Update parser.go (granite 3.2 control role support)

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -557,7 +557,7 @@ func isNewline(r rune) bool {
 }
 
 func isValidMessageRole(role string) bool {
-	return role == "system" || role == "user" || role == "assistant"
+	return role == "system" || role == "user" || role == "assistant" || role == "control"
 }
 
 func isValidCommand(cmd string) bool {


### PR DESCRIPTION
Added "control" role to the list of valid roles. (Granite3.2 support)