### PR TITLE
go.mod: Use full version for go 1.24.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ollama/ollama
 
-go 1.24
+go 1.24.0
 
 require (
 	github.com/containerd/console v1.0.3


### PR DESCRIPTION
Otherwise on Linux I get:
go: download go1.24 for linux/amd64: toolchain not available