### PR TITLE
Allow Skipping Update Checker (OLLAMA_NO_UPDATE_CHECKS=true)

### DIFF
--- a/app/lifecycle/lifecycle.go
+++ b/app/lifecycle/lifecycle.go
@@ -82,7 +82,11 @@ func Run() {
 		}
 	}
 
-	StartBackgroundUpdaterChecker(ctx, t.UpdateAvailable)
+	if os.Getenv("OLLAMA_NO_UPDATE_CHECKS") == "true" {
+		slog.Info("Skipping update checks")
+	} else {
+		StartBackgroundUpdaterChecker(ctx, t.UpdateAvailable)
+	}
 
 	t.Run()
 	cancel()

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -152,6 +152,10 @@ Ollama binds 127.0.0.1 port 11434 by default. Change the bind address with the `
 
 Refer to the section [above](#how-do-i-configure-ollama-server) for how to set environment variables on your platform.
 
+## How can I disable the Update Checker on Ollama?
+
+Set the environment variable `OLLAMA_NO_UPDATE_CHECKS` to `true`.
+
 ## How can I use Ollama with a proxy server?
 
 Ollama runs an HTTP server and can be exposed using a proxy server such as Nginx. To do so, configure the proxy to forward requests and optionally set required headers (if not exposing Ollama on the network). For example, with Nginx:


### PR DESCRIPTION
Some users (like me) prefer to keep their current stable build without unexpected updates, helps maintain setups that rely on specific versions, and prevents unnecessary downloads, disk space and bandwidth.

This PR attempts to fix #6024, allowing the update checker to be disabled via the OLLAMA_NO_UPDATE_CHECKS environment variable. It also partially addresses #6782 by preventing updates on portable or non-standard installations.

Here's an example of a non-standard version I have.
This one is packaged with a Chat UI, so I'd like to keep fixed at a specific version.

![image](https://github.com/user-attachments/assets/3095aca4-75cb-45f0-8a6a-ba6f8d04c6ee)
