### PR TITLE
cmake: build compute capability 12.0

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -28,7 +28,7 @@
       "name": "CUDA 12",
       "inherits": [ "CUDA" ],
       "cacheVariables": {
-        "CMAKE_CUDA_ARCHITECTURES": "50;60;61;70;75;80;86;87;89;90;90a;100"
+        "CMAKE_CUDA_ARCHITECTURES": "50;60;61;70;75;80;86;87;89;90;90a;120"
       }
     },
     {


### PR DESCRIPTION
Focusing initial Blackwell support on 12.0 which includes the 50x series of GeForce cards. In the future additional compute capabilities may be added.