### PR TITLE
runner: defer context cancel

### DIFF
--- a/runner/llamarunner/runner.go
+++ b/runner/llamarunner/runner.go
@@ -968,13 +968,14 @@ func Execute(args []string) error {
 	server.cond = sync.NewCond(&server.mu)
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	go server.run(ctx)
 
 	addr := "127.0.0.1:" + strconv.Itoa(*port)
 	listener, err := net.Listen("tcp", addr)
 	if err != nil {
 		fmt.Println("Listen error:", err)
-		cancel()
 		return err
 	}
 	defer listener.Close()
@@ -994,6 +995,5 @@ func Execute(args []string) error {
 		return err
 	}
 
-	cancel()
 	return nil
 }

--- a/runner/ollamarunner/runner.go
+++ b/runner/ollamarunner/runner.go
@@ -890,13 +890,14 @@ func Execute(args []string) error {
 	server.cond = sync.NewCond(&server.mu)
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	go server.run(ctx)
 
 	addr := "127.0.0.1:" + strconv.Itoa(*port)
 	listener, err := net.Listen("tcp", addr)
 	if err != nil {
 		fmt.Println("Listen error:", err)
-		cancel()
 		return err
 	}
 	defer listener.Close()
@@ -916,6 +917,5 @@ func Execute(args []string) error {
 		return err
 	}
 
-	cancel()
 	return nil
 }


### PR DESCRIPTION
defer the cancel to guarantee it runs. e.g. if the http server errors, cancel doesn't currently get called