### PR TITLE
Add PREPEND Modelfile directive to prepend text to model responses

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -306,6 +306,7 @@ type CreateRequest struct {
 	Template   string            `json:"template,omitempty"`
 	License    any               `json:"license,omitempty"`
 	System     string            `json:"system,omitempty"`
+	Prepend    string            `json:"prepend,omitempty"`
 	Parameters map[string]any    `json:"parameters,omitempty"`
 	Messages   []Message         `json:"messages,omitempty"`
 
@@ -345,6 +346,7 @@ type ShowResponse struct {
 	Parameters    string         `json:"parameters,omitempty"`
 	Template      string         `json:"template,omitempty"`
 	System        string         `json:"system,omitempty"`
+	Prepend       string         `json:"prepend,omitempty"`
 	Details       ModelDetails   `json:"details,omitempty"`
 	Messages      []Message      `json:"messages,omitempty"`
 	ModelInfo     map[string]any `json:"model_info,omitempty"`

--- a/llm/server.go
+++ b/llm/server.go
@@ -691,6 +691,7 @@ type CompletionRequest struct {
 	Format  json.RawMessage
 	Images  []ImageData
 	Options *api.Options
+	Prepend string
 }
 
 type CompletionResponse struct {
@@ -853,8 +854,12 @@ func (s *llmServer) Completion(ctx context.Context, req CompletionRequest, fn fu
 			}
 
 			if c.Content != "" {
+				content := c.Content
+				if req.Prepend != "" {
+					content = req.Prepend + content
+				}
 				fn(CompletionResponse{
-					Content: c.Content,
+					Content: content,
 				})
 			}
 

--- a/llm/server_test.go
+++ b/llm/server_test.go
@@ -11,6 +11,80 @@ import (
 	"golang.org/x/sync/semaphore"
 )
 
+// TestPrepend tests that the Prepend field in CompletionRequest is properly applied to responses
+func TestPrepend(t *testing.T) {
+	// Create a test case that simulates the behavior of the Completion method
+	// when processing a request with a Prepend value
+	
+	// This test directly tests the logic in the Completion method that handles prepending
+	// without trying to mock the entire server
+	
+	// Create a sample request with a prepend value
+	req := CompletionRequest{
+		Prompt:  "test prompt",
+		Options: new(api.Options),
+		Prepend: "<think>",
+	}
+	
+	// Create a sample completion response
+	completionResp := completion{
+		Content: "test response",
+		Stop:    true,
+	}
+	
+	// Create a response handler that captures the responses
+	var responses []string
+	responseHandler := func(cr CompletionResponse) {
+		if cr.Content != "" {
+			responses = append(responses, cr.Content)
+		}
+	}
+	
+	// Simulate the prepend logic from the Completion method
+	if completionResp.Content != "" {
+		content := completionResp.Content
+		if req.Prepend != "" {
+			content = req.Prepend + content
+		}
+		responseHandler(CompletionResponse{
+			Content: content,
+		})
+	}
+	
+	// Verify the response has the prepend value
+	if len(responses) != 1 {
+		t.Fatalf("Expected 1 response, got %d", len(responses))
+	}
+	
+	if responses[0] != "<think>test response" {
+		t.Fatalf("Expected '<think>test response', got '%s'", responses[0])
+	}
+	
+	// Test without prepend value
+	req.Prepend = ""
+	responses = nil
+	
+	// Simulate the prepend logic again
+	if completionResp.Content != "" {
+		content := completionResp.Content
+		if req.Prepend != "" {
+			content = req.Prepend + content
+		}
+		responseHandler(CompletionResponse{
+			Content: content,
+		})
+	}
+	
+	// Verify the response does not have a prepend value
+	if len(responses) != 1 {
+		t.Fatalf("Expected 1 response, got %d", len(responses))
+	}
+	
+	if responses[0] != "test response" {
+		t.Fatalf("Expected 'test response', got '%s'", responses[0])
+	}
+}
+
 func TestLLMServerCompletionFormat(t *testing.T) {
 	// This test was written to fix an already deployed issue. It is a bit
 	// of a mess, and but it's good enough, until we can refactoring the

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -85,6 +85,8 @@ func (f Modelfile) CreateRequest(relativeDir string) (*api.CreateRequest, error)
 			req.Template = c.Args
 		case "system":
 			req.System = c.Args
+		case "prepend":
+			req.Prepend = c.Args
 		case "license":
 			licenses = append(licenses, c.Args)
 		case "message":
@@ -276,7 +278,7 @@ func (c Command) String() string {
 	switch c.Name {
 	case "model":
 		fmt.Fprintf(&sb, "FROM %s", c.Args)
-	case "license", "template", "system", "adapter":
+	case "license", "template", "system", "adapter", "prepend":
 		fmt.Fprintf(&sb, "%s %s", strings.ToUpper(c.Name), quote(c.Args))
 	case "message":
 		role, message, _ := strings.Cut(c.Args, ": ")
@@ -302,7 +304,7 @@ const (
 var (
 	errMissingFrom        = errors.New("no FROM line")
 	errInvalidMessageRole = errors.New("message role must be one of \"system\", \"user\", or \"assistant\"")
-	errInvalidCommand     = errors.New("command must be one of \"from\", \"license\", \"template\", \"system\", \"adapter\", \"parameter\", or \"message\"")
+	errInvalidCommand     = errors.New("command must be one of \"from\", \"license\", \"template\", \"system\", \"adapter\", \"parameter\", \"message\", or \"prepend\"")
 )
 
 type ParserError struct {
@@ -562,7 +564,7 @@ func isValidMessageRole(role string) bool {
 
 func isValidCommand(cmd string) bool {
 	switch strings.ToLower(cmd) {
-	case "from", "license", "template", "system", "adapter", "parameter", "message":
+	case "from", "license", "template", "system", "adapter", "parameter", "message", "prepend":
 		return true
 	default:
 		return false

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -29,6 +29,7 @@ ADAPTER adapter1
 LICENSE MIT
 PARAMETER param1 value1
 PARAMETER param2 value2
+PREPEND "<think>"
 TEMPLATE """{{ if .System }}<|start_header_id|>system<|end_header_id|>
 
 {{ .System }}<|eot_id|>{{ end }}{{ if .Prompt }}<|start_header_id|>user<|end_header_id|>
@@ -49,6 +50,7 @@ TEMPLATE """{{ if .System }}<|start_header_id|>system<|end_header_id|>
 		{Name: "license", Args: "MIT"},
 		{Name: "param1", Args: "value1"},
 		{Name: "param2", Args: "value2"},
+		{Name: "prepend", Args: "<think>"},
 		{Name: "template", Args: "{{ if .System }}<|start_header_id|>system<|end_header_id|>\n\n{{ .System }}<|eot_id|>{{ end }}{{ if .Prompt }}<|start_header_id|>user<|end_header_id|>\n\n{{ .Prompt }}<|eot_id|>{{ end }}<|start_header_id|>assistant<|end_header_id|>\n\n{{ .Response }}<|eot_id|>"},
 	}
 
@@ -691,10 +693,12 @@ func TestCreateRequest(t *testing.T) {
 		{
 			`FROM test
 TEMPLATE some template
+PREPEND "<think>"
 `,
 			&api.CreateRequest{
 				From:     "test",
 				Template: "some template",
+				Prepend:  "<think>",
 			},
 		},
 		{

--- a/server/create.go
+++ b/server/create.go
@@ -368,6 +368,13 @@ func createModel(r api.CreateRequest, name model.Name, baseLayers []*layerGGML, 
 		}
 	}
 
+	if r.Prepend != "" {
+		layers, err = setPrepend(layers, r.Prepend)
+		if err != nil {
+			return err
+		}
+	}
+
 	if r.License != nil {
 		switch l := r.License.(type) {
 		case string:
@@ -576,6 +583,19 @@ func setSystem(layers []Layer, s string) ([]Layer, error) {
 	if s != "" {
 		blob := strings.NewReader(s)
 		layer, err := NewLayer(blob, "application/vnd.ollama.image.system")
+		if err != nil {
+			return nil, err
+		}
+		layers = append(layers, layer)
+	}
+	return layers, nil
+}
+
+func setPrepend(layers []Layer, p string) ([]Layer, error) {
+	layers = removeLayer(layers, "application/vnd.ollama.image.prepend")
+	if p != "" {
+		blob := strings.NewReader(p)
+		layer, err := NewLayer(blob, "application/vnd.ollama.image.prepend")
 		if err != nil {
 			return nil, err
 		}

--- a/server/images.go
+++ b/server/images.go
@@ -63,6 +63,7 @@ type Model struct {
 	AdapterPaths   []string
 	ProjectorPaths []string
 	System         string
+	Prepend        string
 	License        []string
 	Digest         string
 	Options        map[string]interface{}
@@ -150,6 +151,13 @@ func (m *Model) String() string {
 		modelfile.Commands = append(modelfile.Commands, parser.Command{
 			Name: "system",
 			Args: m.System,
+		})
+	}
+
+	if m.Prepend != "" {
+		modelfile.Commands = append(modelfile.Commands, parser.Command{
+			Name: "prepend",
+			Args: m.Prepend,
 		})
 	}
 
@@ -294,6 +302,13 @@ func GetModel(name string) (*Model, error) {
 			}
 
 			model.System = string(bts)
+		case "application/vnd.ollama.image.prepend":
+			bts, err := os.ReadFile(filename)
+			if err != nil {
+				return nil, err
+			}
+
+			model.Prepend = string(bts)
 		case "application/vnd.ollama.image.params":
 			params, err := os.Open(filename)
 			if err != nil {

--- a/server/routes.go
+++ b/server/routes.go
@@ -306,6 +306,7 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 			Images:  images,
 			Format:  req.Format,
 			Options: opts,
+			Prepend: m.Prepend,
 		}, func(cr llm.CompletionResponse) {
 			res := api.GenerateResponse{
 				Model:      req.Model,
@@ -817,6 +818,7 @@ func GetModelInfo(req api.ShowRequest) (*api.ShowResponse, error) {
 	resp := &api.ShowResponse{
 		License:    strings.Join(m.License, "\n"),
 		System:     m.System,
+		Prepend:    m.Prepend,
 		Template:   m.Template.String(),
 		Details:    modelDetails,
 		Messages:   msgs,
@@ -1525,6 +1527,7 @@ func (s *Server) ChatHandler(c *gin.Context) {
 			Images:  images,
 			Format:  req.Format,
 			Options: opts,
+			Prepend: m.Prepend,
 		}, func(r llm.CompletionResponse) {
 			res := api.ChatResponse{
 				Model:      req.Model,


### PR DESCRIPTION
I would like to have a PREPEND directive in the modelfile, to support prepending arbitrary text to all responses from a model.

In particular - I would like to add a <think> token like this:

```
TEMPLATE """
{{- if or .System .Tools }}<|im_start|>system
{{- if .System }}
{{ .System }}
{{- end }}
{{- if .Tools }}

# Tools

You may call one or more functions to assist with the user query.

You are provided with function signatures within <tools></tools> XML tags:
<tools>
{{- range .Tools }}
{"type": "function", "function": {{ .Function }}}
{{- end }}
</tools>

For each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:
<tool_call>
{"name": <function-name>, "arguments": <args-json-object>}
</tool_call>
{{- end }}<|im_end|>
{{ end }}
{{- range $i, $_ := .Messages }}
{{- $last := eq (len (slice $.Messages $i)) 1 -}}
{{- if eq .Role "user" }}<|im_start|>user
{{ .Content }}<|im_end|>
{{ else if eq .Role "assistant" }}<|im_start|>assistant
{{ if .Content }}{{ .Content }}
{{- else if .ToolCalls }}<tool_call>
{{ range .ToolCalls }}{"name": "{{ .Function.Name }}", "arguments": {{ .Function.Arguments }}}
{{ end }}</tool_call>
{{- end }}{{ if not $last }}<|im_end|>
{{ end }}
{{- else if eq .Role "tool" }}<|im_start|>user
<tool_response>
{{ .Content }}
</tool_response><|im_end|>
{{ end }}
{{- if and (ne .Role "assistant") $last }}<|im_start|>assistant
<think>   // Added a <think> token in the template like they do in the official huggingface template - but that causes the model not to return a <think>
{{ end }}
{{- end }}
"""

PREPEND "<think>" // This fixes clients which expect to see a <think> token up front
```