### PR TITLE
fix: return scanner error when stream connection unexpectedly disconnects

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -189,7 +189,7 @@ func (c *Client) stream(ctx context.Context, method, path string, data any, fn f
 		}
 	}
 
-	return nil
+	return scanner.Err()
 }
 
 // GenerateResponseFunc is a function that [Client.Generate] invokes every time


### PR DESCRIPTION
return scanner error when stream connection unexpectedly disconnects