### PR TITLE
ollamarunner: Don't panic for unimplemented features at runtime.

### DIFF
--- a/runner/ollamarunner/runner.go
+++ b/runner/ollamarunner/runner.go
@@ -436,10 +436,9 @@ func (s *Server) processBatch() error {
 		// if done processing the prompt, generate an embedding and return
 		if seq.embeddingOnly {
 			// TODO(jessegross): Embedding support
-			// s.removeSequence(i, "")
-			// continue
-
-			panic("generation of embedding outputs not yet supported")
+			slog.Warn("generation of embedding outputs not yet supported")
+			s.removeSequence(i, "")
+			continue
 		}
 
 		// sample a token


### PR DESCRIPTION
It's ok to fail on startup but we shouldn't panic during runtime based on user input. Downgrade the panic to a warning.