### PR TITLE
server: allow running embed models in parallel

### DIFF
--- a/server/sched.go
+++ b/server/sched.go
@@ -194,11 +194,6 @@ func (s *Scheduler) processPending(ctx context.Context) {
 						break
 					}
 
-					// Embedding models should always be loaded with parallel=1
-					if pending.model.CheckCapabilities(CapabilityCompletion) != nil {
-						numParallel = 1
-					}
-
 					// Evaluate if the model will fit in the available system memory, or if we should unload a model first
 					if len(gpus) == 1 && gpus[0].Library == "cpu" {
 						// simplifying assumption of defaultParallel when in CPU mode


### PR DESCRIPTION
The ability to run embedding models in parallel with other types of models was removed due to limitations in server slot loading in a past version of the server. This slot loading system is no longer used, and embedding models can run in parallel with chat models.

Without running embedding and chat models in parallel doing retrieval-augmented-generation can be much slower. As the chat model will need to be unloaded from memory before the embedding model can be run, and then reloaded when a chat request is sent.

Original PR for this bug, for reference: https://github.com/ollama/ollama/pull/6467