### PR TITLE
add verbose mode to the show command

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -349,6 +349,7 @@ type ShowResponse struct {
 	Messages      []Message      `json:"messages,omitempty"`
 	ModelInfo     map[string]any `json:"model_info,omitempty"`
 	ProjectorInfo map[string]any `json:"projector_info,omitempty"`
+	Tensors       []Tensor       `json:"tensors,omitempty"`
 	ModifiedAt    time.Time      `json:"modified_at,omitempty"`
 }
 
@@ -465,6 +466,13 @@ type ModelDetails struct {
 	Families          []string `json:"families"`
 	ParameterSize     string   `json:"parameter_size"`
 	QuantizationLevel string   `json:"quantization_level"`
+}
+
+// Tensor describes the metadata for a given tensor.
+type Tensor struct {
+	Name  string   `json:"name"`
+	Type  string   `json:"type"`
+	Shape []uint64 `json:"shape"`
 }
 
 func (m *Metrics) Summary() {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -18,6 +18,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -568,8 +569,9 @@ func ShowHandler(cmd *cobra.Command, args []string) error {
 	parameters, errParams := cmd.Flags().GetBool("parameters")
 	system, errSystem := cmd.Flags().GetBool("system")
 	template, errTemplate := cmd.Flags().GetBool("template")
+	verbose, errVerbose := cmd.Flags().GetBool("verbose")
 
-	for _, boolErr := range []error{errLicense, errModelfile, errParams, errSystem, errTemplate} {
+	for _, boolErr := range []error{errLicense, errModelfile, errParams, errSystem, errTemplate, errVerbose} {
 		if boolErr != nil {
 			return errors.New("error retrieving flags")
 		}
@@ -607,7 +609,7 @@ func ShowHandler(cmd *cobra.Command, args []string) error {
 		return errors.New("only one of '--license', '--modelfile', '--parameters', '--system', or '--template' can be specified")
 	}
 
-	req := api.ShowRequest{Name: args[0]}
+	req := api.ShowRequest{Name: args[0], Verbose: verbose}
 	resp, err := client.Show(cmd.Context(), &req)
 	if err != nil {
 		return err
@@ -630,10 +632,10 @@ func ShowHandler(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	return showInfo(resp, os.Stdout)
+	return showInfo(resp, verbose, os.Stdout)
 }
 
-func showInfo(resp *api.ShowResponse, w io.Writer) error {
+func showInfo(resp *api.ShowResponse, verbose bool, w io.Writer) error {
 	tableRender := func(header string, rows func() [][]string) {
 		fmt.Fprintln(w, " ", header)
 		table := tablewriter.NewWriter(w)
@@ -685,6 +687,45 @@ func showInfo(resp *api.ShowResponse, w io.Writer) error {
 				if text := scanner.Text(); text != "" {
 					rows = append(rows, append([]string{""}, strings.Fields(text)...))
 				}
+			}
+			return
+		})
+	}
+
+	if resp.ModelInfo != nil && verbose {
+		tableRender("Metadata", func() (rows [][]string) {
+			keys := make([]string, 0, len(resp.ModelInfo))
+			for k := range resp.ModelInfo {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+
+			for _, k := range keys {
+				v := ""
+				switch vData := resp.ModelInfo[k].(type) {
+				case string:
+					v = vData
+				case float64:
+					v = fmt.Sprintf("%g", vData)
+				case []any:
+					n := 3
+					if len(vData) < n {
+						n = len(vData)
+					}
+					v = fmt.Sprintf("%v", vData[:n])
+				default:
+					v = fmt.Sprintf("%T", vData)
+				}
+				rows = append(rows, []string{"", k, v})
+			}
+			return
+		})
+	}
+
+	if len(resp.Tensors) > 0 && verbose {
+		tableRender("Tensors", func() (rows [][]string) {
+			for _, t := range resp.Tensors {
+				rows = append(rows, []string{"", t.Name, t.Type, fmt.Sprint(t.Shape)})
 			}
 			return
 		})
@@ -1196,6 +1237,7 @@ func NewCLI() *cobra.Command {
 	showCmd.Flags().Bool("parameters", false, "Show parameters of a model")
 	showCmd.Flags().Bool("template", false, "Show template of a model")
 	showCmd.Flags().Bool("system", false, "Show system message of a model")
+	showCmd.Flags().BoolP("verbose", "v", false, "Show detailed model information")
 
 	runCmd := &cobra.Command{
 		Use:     "run MODEL [PROMPT]",

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -701,7 +701,7 @@ func showInfo(resp *api.ShowResponse, verbose bool, w io.Writer) error {
 			sort.Strings(keys)
 
 			for _, k := range keys {
-				v := ""
+				var v string
 				switch vData := resp.ModelInfo[k].(type) {
 				case string:
 					v = vData

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -91,8 +91,8 @@ func TestShowInfo(t *testing.T) {
 				"test.embedding_length":   float64(11434),
 			},
 			Tensors: []api.Tensor{
-				{ "blk.0.attn_k.weight", "BF16", []uint64{42, 3117} },
-				{ "blk.0.attn_q.weight", "FP16", []uint64{3117, 42} },
+				{Name: "blk.0.attn_k.weight", Type: "BF16", Shape: []uint64{42, 3117}},
+				{Name: "blk.0.attn_q.weight", Type: "FP16", Shape: []uint64{3117, 42}},
 			},
 		}, true, &b); err != nil {
 			t.Fatal(err)
@@ -123,7 +123,6 @@ func TestShowInfo(t *testing.T) {
 			t.Errorf("unexpected output (-want +got):\n%s", diff)
 		}
 	})
-
 
 	t.Run("parameters", func(t *testing.T) {
 		var b bytes.Buffer

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -347,7 +347,7 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 
 				switch args[1] {
 				case "info":
-					_ = showInfo(resp, os.Stderr)
+					_ = showInfo(resp, false, os.Stderr)
 				case "license":
 					if resp.License == "" {
 						fmt.Println("No license was specified for this model.")

--- a/fs/ggml/ggml.go
+++ b/fs/ggml/ggml.go
@@ -327,6 +327,10 @@ func (t Tensor) Size() uint64 {
 	return t.parameters() * t.typeSize() / t.blockSize()
 }
 
+func (t Tensor) Type() string {
+	return fileType(t.Kind).String()
+}
+
 type container interface {
 	Name() string
 	Decode(io.ReadSeeker) (model, error)

--- a/server/routes.go
+++ b/server/routes.go
@@ -435,7 +435,7 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 		return
 	}
 
-	kvData, err := getKVData(m.ModelPath, false)
+	kvData, _, err := getModelData(m.ModelPath, false)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -866,7 +866,7 @@ func GetModelInfo(req api.ShowRequest) (*api.ShowResponse, error) {
 	resp.Tensors = tensorData
 
 	if len(m.ProjectorPaths) > 0 {
-		projectorData, err := getKVData(m.ProjectorPaths[0], req.Verbose)
+		projectorData, _, err := getModelData(m.ProjectorPaths[0], req.Verbose)
 		if err != nil {
 			return nil, err
 		}
@@ -897,11 +897,6 @@ func getModelData(digest string, verbose bool) (ggml.KV, ggml.Tensors, error) {
 	}
 
 	return kv, data.Tensors(), nil
-}
-
-func getKVData(digest string, verbose bool) (ggml.KV, error) {
-	kv, _, err := getModelData(digest, verbose)
-	return kv, err
 }
 
 func (s *Server) ListHandler(c *gin.Context) {

--- a/server/routes.go
+++ b/server/routes.go
@@ -861,7 +861,7 @@ func GetModelInfo(req api.ShowRequest) (*api.ShowResponse, error) {
 
 	tensorData := make([]api.Tensor, len(tensors.Items()))
 	for cnt, t := range tensors.Items() {
-		tensorData[cnt] = api.Tensor{t.Name, t.Type(), t.Shape}
+		tensorData[cnt] = api.Tensor{Name: t.Name, Type: t.Type(), Shape: t.Shape}
 	}
 	resp.Tensors = tensorData
 


### PR DESCRIPTION
This change adds metadata and tensor information to the show command to be able to see more information about a model. The output is roughly the same as on the model details page on ollama.com.