### PR TITLE
server: MkdirAll only if path does not exist

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1069,8 +1069,11 @@ func initializeKeypair() error {
 			return err
 		}
 
-		if err := os.MkdirAll(filepath.Dir(privKeyPath), 0o755); err != nil {
-			return fmt.Errorf("could not create directory %w", err)
+		_, err = os.Stat(filepath.Dir(privKeyPath))
+		if errors.Is(err, os.ErrNotExist) {
+			if err := os.MkdirAll(filepath.Dir(privKeyPath), 0o755); err != nil {
+				return fmt.Errorf("could not create directory %w", err)
+			}
 		}
 
 		if err := os.WriteFile(privKeyPath, pem.EncodeToMemory(privateKeyBytes), 0o600); err != nil {

--- a/readline/history.go
+++ b/readline/history.go
@@ -44,10 +44,12 @@ func (h *History) Init() error {
 	}
 
 	path := filepath.Join(home, ".ollama", "history")
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return err
+	_, err = os.Stat(filepath.Dir(path))
+	if errors.Is(err, os.ErrNotExist) {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return err
+		}
 	}
-
 	h.Filename = path
 
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDONLY, 0o600)

--- a/server/create.go
+++ b/server/create.go
@@ -686,8 +686,11 @@ func createConfigLayer(layers []Layer, config ConfigV2) (*Layer, error) {
 
 func createLink(src, dst string) error {
 	// make any subdirs for dst
-	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-		return err
+	_, err = os.Stat(filepath.Dir(dst))
+	if errors.Is(err, os.ErrNotExist) {
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			return err
+		}
 	}
 
 	_ = os.Remove(dst)

--- a/server/fixblobs_test.go
+++ b/server/fixblobs_test.go
@@ -39,8 +39,11 @@ func TestFixBlobs(t *testing.T) {
 				fullDir, _ := filepath.Split(fullPath)
 
 				t.Logf("creating dir %s", fullDir)
-				if err := os.MkdirAll(fullDir, 0o755); err != nil {
-					t.Fatal(err)
+				_, err = os.Stat(fullDir)
+				if errors.Is(err, os.ErrNotExist) {
+					if err := os.MkdirAll(fullDir, 0o755); err != nil {
+						t.Fatal(err)
+					}
 				}
 
 				t.Logf("writing file %s", fullPath)

--- a/server/images.go
+++ b/server/images.go
@@ -345,8 +345,11 @@ func CopyModel(src, dst model.Name) error {
 	}
 
 	dstpath := filepath.Join(manifests, dst.Filepath())
-	if err := os.MkdirAll(filepath.Dir(dstpath), 0o755); err != nil {
-		return err
+	_, err = os.Stat(filepath.Dir(dstpath))
+	if errors.Is(err, os.ErrNotExist) {
+		if err := os.MkdirAll(filepath.Dir(dstpath), 0o755); err != nil {
+			return err
+		}
 	}
 
 	srcpath := filepath.Join(manifests, src.Filepath())
@@ -607,8 +610,11 @@ func PullModel(ctx context.Context, name string, regOpts *registryOptions, fn fu
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(filepath.Dir(fp), 0o755); err != nil {
-		return err
+	_, err = os.Stat(filepath.Dir(fp))
+	if errors.Is(err, os.ErrNotExist) {
+		if err := os.MkdirAll(filepath.Dir(fp), 0o755); err != nil {
+			return err
+		}
 	}
 
 	err = os.WriteFile(fp, manifestJSON, 0o644)

--- a/server/internal/cache/blob/cache_test.go
+++ b/server/internal/cache/blob/cache_test.go
@@ -194,7 +194,10 @@ func TestManifestExistsWithoutBlob(t *testing.T) {
 	checkEntry := entryChecker(t, c)
 
 	man := must(c.manifestPath("h/n/m:t"))
-	os.MkdirAll(filepath.Dir(man), 0o777)
+	_, err = os.Stat(filepath.Dir(man))
+	if errors.Is(err, os.ErrNotExist) {
+		os.MkdirAll(filepath.Dir(man), 0o777)
+	}
 	testutil.WriteFile(t, man, "1")
 
 	got, err := c.Resolve("h/n/m:t")

--- a/server/internal/cache/blob/casecheck_test.go
+++ b/server/internal/cache/blob/casecheck_test.go
@@ -66,7 +66,10 @@ func useCaseInsensitiveTempDir(t *testing.T) bool {
 		_, err := os.Stat(volume)
 		if err == nil {
 			tmpdir := filepath.Join(volume, "tmp")
-			os.MkdirAll(tmpdir, 0o700)
+			_, err = os.Stat(tmpdir)
+			if errors.Is(err, os.ErrNotExist) {
+				os.MkdirAll(tmpdir, 0o700)
+			}
 			t.Setenv("TMPDIR", tmpdir)
 			return true
 		}

--- a/server/internal/testutil/testutil.go
+++ b/server/internal/testutil/testutil.go
@@ -93,8 +93,11 @@ func WriteFile[S []byte | string](t testing.TB, name string, data S) {
 	}
 	name = filepath.Clean(name)
 	dir := filepath.Dir(name)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatal(err)
+	_, err = os.Stat(dir)
+	if errors.Is(err, os.ErrNotExist) {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
 	}
 	if err := os.WriteFile(name, []byte(data), 0o644); err != nil {
 		t.Fatal(err)

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -103,8 +103,11 @@ func WriteManifest(name model.Name, config Layer, layers []Layer) error {
 	}
 
 	p := filepath.Join(manifests, name.Filepath())
-	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
-		return err
+	_, err = os.Stat(filepath.Dir(p))
+	if errors.Is(err, os.ErrNotExist) {
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			return err
+		}
 	}
 
 	f, err := os.Create(p)

--- a/server/manifest_test.go
+++ b/server/manifest_test.go
@@ -14,8 +14,11 @@ func createManifest(t *testing.T, path, name string) {
 	t.Helper()
 
 	p := filepath.Join(path, "manifests", name)
-	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
-		t.Fatal(err)
+	_, err = os.Stat(filepath.Dir(p))
+	if errors.Is(err, os.ErrNotExist) {
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	f, err := os.Create(p)

--- a/server/modelpath.go
+++ b/server/modelpath.go
@@ -116,8 +116,11 @@ func (mp ModelPath) BaseURL() *url.URL {
 
 func GetManifestPath() (string, error) {
 	path := filepath.Join(envconfig.Models(), "manifests")
-	if err := os.MkdirAll(path, 0o755); err != nil {
-		return "", err
+	_, err = os.Stat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			return "", err
+		}
 	}
 
 	return path, nil
@@ -139,8 +142,11 @@ func GetBlobsPath(digest string) (string, error) {
 		dirPath = path
 	}
 
-	if err := os.MkdirAll(dirPath, 0o755); err != nil {
-		return "", err
+	_, err = os.Stat(dirPath)
+	if errors.Is(err, os.ErrNotExist) {
+		if err := os.MkdirAll(dirPath, 0o755); err != nil {
+			return "", err
+		}
 	}
 
 	return path, nil

--- a/server/routes_create_test.go
+++ b/server/routes_create_test.go
@@ -754,8 +754,11 @@ func TestDetectModelTypeFromFiles(t *testing.T) {
 
 		data := []byte("12345678")
 		digest := fmt.Sprintf("sha256:%x", sha256.Sum256(data))
-		if err := os.MkdirAll(filepath.Join(p, "blobs"), 0o755); err != nil {
-			t.Fatal(err)
+		_, err = os.Stat(filepath.Join(p, "blobs"))
+		if errors.Is(err, os.ErrNotExist) {
+			if err := os.MkdirAll(filepath.Join(p, "blobs"), 0o755); err != nil {
+				t.Fatal(err)
+			}
 		}
 
 		f, err := os.Create(filepath.Join(p, "blobs", fmt.Sprintf("sha256-%s", strings.TrimPrefix(digest, "sha256:"))))
@@ -784,8 +787,11 @@ func TestDetectModelTypeFromFiles(t *testing.T) {
 
 		data := []byte("123")
 		digest := fmt.Sprintf("sha256:%x", sha256.Sum256(data))
-		if err := os.MkdirAll(filepath.Join(p, "blobs"), 0o755); err != nil {
-			t.Fatal(err)
+		_, err = os.Stat(filepath.Join(p, "blobs"))
+		if errors.Is(err, os.ErrNotExist) {
+			if err := os.MkdirAll(filepath.Join(p, "blobs"), 0o755); err != nil {
+				t.Fatal(err)
+			}
 		}
 
 		f, err := os.Create(filepath.Join(p, "blobs", fmt.Sprintf("sha256-%s", strings.TrimPrefix(digest, "sha256:"))))


### PR DESCRIPTION
Related to #9597  
Added checks to see if path does not exist before trying to create it.  
Ollama was trying to create the whole folder structure for a custom OLLAMA_MODELS path, but it already exist and parent directories have no permission, but target directory does have permission, so, only try to create if it does not exist.  
