### PR TITLE
docs: provide clarity for accepted modelfile types and reorder Customize a Model for readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,32 +83,6 @@ Here are some example models that can be downloaded:
 
 ## Customize a model
 
-### Import from GGUF
-
-Ollama supports importing GGUF models in the Modelfile:
-
-1. Create a file named `Modelfile`, with a `FROM` instruction with the local filepath to the model you want to import.
-
-   ```
-   FROM ./vicuna-33b.Q4_0.gguf
-   ```
-
-2. Create the model in Ollama
-
-   ```shell
-   ollama create example -f Modelfile
-   ```
-
-3. Run the model
-
-   ```shell
-   ollama run example
-   ```
-
-### Import from Safetensors
-
-See the [guide](docs/import.md) on importing models for more information.
-
 ### Customize a prompt
 
 Models from the Ollama library can be customized with a prompt. For example, to customize the `llama3.2` model:
@@ -141,6 +115,32 @@ Hello! It's your friend Mario.
 ```
 
 For more information on working with a Modelfile, see the [Modelfile](docs/modelfile.md) documentation.
+
+### Import from GGUF
+
+Ollama supports importing GGUF models in the Modelfile:
+
+1. Create a file named `Modelfile`, with a `FROM` instruction with the local filepath to the model you want to import.
+
+   ```
+   FROM ./vicuna-33b.Q4_0.gguf
+   ```
+
+2. Create the model in Ollama
+
+   ```shell
+   ollama create example -f Modelfile
+   ```
+
+3. Run the model
+
+   ```shell
+   ollama run example
+   ```
+
+### Import from Safetensors
+
+See the [guide](docs/import.md) on importing models for more information.
 
 ## CLI Reference
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ ollama pull llama3.2
 
 Create a `Modelfile`:
 
+File Format: Any simple text file format(.modelfile, .md, .txt, etc.)
+
 ```
 FROM llama3.2
 


### PR DESCRIPTION
Based off of issue #9582.

# Changes
- Added line specifying ModelFile accepted file types
- Reordered Customize a Model Section from GGUF->SafeTensor->Custom Prompt, to Custom Prompt->GGUF->SafeTensor

# Reasoning 
- Improve user experience for low to mid-level users who were confused about the ambiguous format ModelFile(specifically for the creation of a new file). Heuristic Usability Testing found for heuristic 2, Match Between the System and the Real World, that there was an assumption of the users understanding of word/concept in regards to the creation of Modefiles, either using FROM/SHOW command to get a current Modefile of appropriate format, or assuming user would understand it is any simple text readable file format.
- To improve readability and time to accomplish tasks for lower to mid-level users looking to create a custom model. The reasoning is that customizing models you already have from a file are most likely, followed by popular GGUF file format, and finally by Safetensors which Heuristic Usability testing found to be uncommon/unknown. This change would support heuristic number 8, Aesthetic and Minimalist Design by prioritizing content and features needed to support primary goals(specifically for low-mid level users).