### PR TITLE
runner: allow to set a custom host

### DIFF
--- a/runner/llamarunner/runner.go
+++ b/runner/llamarunner/runner.go
@@ -894,6 +894,7 @@ func Execute(args []string) error {
 	flashAttention := fs.Bool("flash-attn", false, "Enable flash attention")
 	kvSize := fs.Int("ctx-size", 2048, "Context (or KV cache) size")
 	kvCacheType := fs.String("kv-cache-type", "", "quantization type for KV cache (default: f16)")
+	host := fs.String("host", "127.0.0.1", "Host to expose the server on")
 	port := fs.Int("port", 8080, "Port to expose the server on")
 	threads := fs.Int("threads", runtime.NumCPU(), "Number of threads to use during generation")
 	verbose := fs.Bool("verbose", false, "verbose output (default: disabled)")
@@ -971,7 +972,7 @@ func Execute(args []string) error {
 
 	go server.run(ctx)
 
-	addr := "127.0.0.1:" + strconv.Itoa(*port)
+	addr := *host + ":" + strconv.Itoa(*port)
 	listener, err := net.Listen("tcp", addr)
 	if err != nil {
 		fmt.Println("Listen error:", err)

--- a/runner/ollamarunner/runner.go
+++ b/runner/ollamarunner/runner.go
@@ -845,6 +845,7 @@ func Execute(args []string) error {
 	flashAttention := fs.Bool("flash-attn", false, "Enable flash attention")
 	kvSize := fs.Int("ctx-size", 2048, "Context (or KV cache) size")
 	kvCacheType := fs.String("kv-cache-type", "", "quantization type for KV cache (default: f16)")
+	host := fs.String("host", "127.0.0.1", "Host to expose the server on")
 	port := fs.Int("port", 8080, "Port to expose the server on")
 	threads := fs.Int("threads", runtime.NumCPU(), "Number of threads to use during generation")
 	verbose := fs.Bool("verbose", false, "verbose output (default: disabled)")
@@ -918,7 +919,7 @@ func Execute(args []string) error {
 
 	go server.run(ctx)
 
-	addr := "127.0.0.1:" + strconv.Itoa(*port)
+	addr := *host + ":" + strconv.Itoa(*port)
 	listener, err := net.Listen("tcp", addr)
 	if err != nil {
 		fmt.Println("Listen error:", err)


### PR DESCRIPTION
Allow exposing the Ollama runner on `0.0.0.0` or `::1` (IPv6).

This is helpful when the Ollama runner is executed in standalone mode (e.g. kubernetes pod):

```shell
ollama runner --model ${model} --host 0.0.0.0 --port 8080
```