### PR TITLE
Update base image from Ubuntu 20.24 to 24.04 LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -114,7 +114,7 @@ FROM ${FLAVOR} AS archive
 COPY --from=cpu dist/lib/ollama /lib/ollama
 COPY --from=build /bin/ollama /bin/ollama
 
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 RUN apt-get update \
     && apt-get install -y ca-certificates \
     && apt-get clean \


### PR DESCRIPTION
Ollama actually use Ubuntu 20.04 LTS that is arriving to it's end of life.
Upgrading to Ubuntu 24.04 LTS.
Address issue #9679