### PR TITLE
Add --no-kv-offload parameter

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1323,6 +1323,7 @@ func NewCLI() *cobra.Command {
 				envVars["OLLAMA_ORIGINS"],
 				envVars["OLLAMA_SCHED_SPREAD"],
 				envVars["OLLAMA_TMPDIR"],
+				envVars["OLLAMA_NO_KV_OFFLOAD"],
 				envVars["OLLAMA_FLASH_ATTENTION"],
 				envVars["OLLAMA_KV_CACHE_TYPE"],
 				envVars["OLLAMA_LLM_LIBRARY"],

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -166,6 +166,8 @@ var (
 	IntelGPU = Bool("OLLAMA_INTEL_GPU")
 	// MultiUserCache optimizes prompt caching for multi-user scenarios
 	MultiUserCache = Bool("OLLAMA_MULTIUSER_CACHE")
+	// NoKVOffload prevents KV cache from being offloaded to GPU
+	NoKVOffload = Bool("OLLAMA_NO_KV_OFFLOAD")
 	// Enable the new Ollama engine
 	NewEngine = Bool("OLLAMA_NEW_ENGINE")
 	// ContextLength sets the default context length
@@ -257,6 +259,7 @@ func AsMap() map[string]EnvVar {
 		"OLLAMA_MULTIUSER_CACHE":   {"OLLAMA_MULTIUSER_CACHE", MultiUserCache(), "Optimize prompt caching for multi-user scenarios"},
 		"OLLAMA_CONTEXT_LENGTH":    {"OLLAMA_CONTEXT_LENGTH", ContextLength(), "Context length to use unless otherwise specified (default: 2048)"},
 		"OLLAMA_NEW_ENGINE":        {"OLLAMA_NEW_ENGINE", NewEngine(), "Enable the new Ollama engine"},
+		"OLLAMA_NO_KV_OFFLOAD": {"OLLAMA_NO_KV_OFFLOAD", NoKVOffload(), "Disable KV Cache Offloading to GPU"},
 
 		// Informational
 		"HTTP_PROXY":  {"HTTP_PROXY", String("HTTP_PROXY")(), "HTTP proxy"},

--- a/llama/llama.go
+++ b/llama/llama.go
@@ -86,7 +86,7 @@ type ContextParams struct {
 	c C.struct_llama_context_params
 }
 
-func NewContextParams(numCtx int, batchSize int, numSeqMax int, threads int, flashAttention bool, kvCacheType string) ContextParams {
+func NewContextParams(numCtx int, batchSize int, numSeqMax int, threads int, flashAttention bool, noKVOffload bool, kvCacheType string) ContextParams {
 	params := C.llama_context_default_params()
 	params.n_ctx = C.uint(numCtx)
 	params.n_batch = C.uint(batchSize)
@@ -95,6 +95,7 @@ func NewContextParams(numCtx int, batchSize int, numSeqMax int, threads int, fla
 	params.n_threads_batch = params.n_threads
 	params.embeddings = C.bool(true)
 	params.flash_attn = C.bool(flashAttention)
+	params.offload_kqv = !C.bool(noKVOffload)
 	params.type_k = kvCacheTypeFromStr(strings.ToLower(kvCacheType))
 	params.type_v = kvCacheTypeFromStr(strings.ToLower(kvCacheType))
 

--- a/llm/server.go
+++ b/llm/server.go
@@ -189,6 +189,10 @@ func NewLlamaServer(gpus discover.GpuInfoList, modelPath string, f *ggml.GGML, a
 		// Enable if the requested and kv cache type is supported by the model
 		if kvct != "" && f.SupportsKVCacheType(kvct) {
 			params = append(params, "--kv-cache-type", kvct)
+			if envconfig.NoKVOffload() {
+				slog.Info("Not offloading KV Cache to GPU")
+				params = append(params, "--no-kv-offload")
+			}
 		} else {
 			slog.Warn("kv cache type not supported by model", "type", kvct)
 		}

--- a/ml/backend.go
+++ b/ml/backend.go
@@ -73,6 +73,9 @@ type BackendParams struct {
 
 	// FlashAttention indicates that we should use a fused flash attention kernel
 	FlashAttention bool
+
+	// NoKVOffloads indicates that the KV Cache shouldn't be offloaded to GPUs.
+	NoKVOffload bool
 }
 
 var backends = make(map[string]func(*os.File, BackendParams) (Backend, error))

--- a/runner/llamarunner/runner.go
+++ b/runner/llamarunner/runner.go
@@ -842,6 +842,7 @@ func (s *Server) loadModel(
 	kvSize int,
 	kvCacheType string,
 	flashAttention bool,
+	noKVOffload bool,
 	threads int,
 	multiUserCache bool,
 ) {
@@ -851,7 +852,7 @@ func (s *Server) loadModel(
 		panic(err)
 	}
 
-	ctxParams := llama.NewContextParams(kvSize, s.batchSize*s.parallel, s.parallel, threads, flashAttention, kvCacheType)
+	ctxParams := llama.NewContextParams(kvSize, s.batchSize*s.parallel, s.parallel, threads, flashAttention, noKVOffload, kvCacheType)
 	s.lc, err = llama.NewContextWithModel(s.model, ctxParams)
 	if err != nil {
 		panic(err)
@@ -892,6 +893,7 @@ func Execute(args []string) error {
 	nGpuLayers := fs.Int("n-gpu-layers", 0, "Number of layers to offload to GPU")
 	mainGpu := fs.Int("main-gpu", 0, "Main GPU")
 	flashAttention := fs.Bool("flash-attn", false, "Enable flash attention")
+	noKVOffload := fs.Bool("no-kv-offload", false, "Prevent KV cache from being offloaded to GPU")
 	kvSize := fs.Int("ctx-size", 2048, "Context (or KV cache) size")
 	kvCacheType := fs.String("kv-cache-type", "", "quantization type for KV cache (default: f16)")
 	port := fs.Int("port", 8080, "Port to expose the server on")
@@ -962,7 +964,7 @@ func Execute(args []string) error {
 	}
 
 	server.ready.Add(1)
-	go server.loadModel(params, *mpath, lpaths, *ppath, *kvSize, *kvCacheType, *flashAttention, *threads, *multiUserCache)
+	go server.loadModel(params, *mpath, lpaths, *ppath, *kvSize, *kvCacheType, *flashAttention, *noKVOffload, *threads, *multiUserCache)
 
 	server.cond = sync.NewCond(&server.mu)
 

--- a/runner/ollamarunner/runner.go
+++ b/runner/ollamarunner/runner.go
@@ -845,6 +845,7 @@ func Execute(args []string) error {
 	flashAttention := fs.Bool("flash-attn", false, "Enable flash attention")
 	kvSize := fs.Int("ctx-size", 2048, "Context (or KV cache) size")
 	kvCacheType := fs.String("kv-cache-type", "", "quantization type for KV cache (default: f16)")
+	noKVOffload := fs.Bool("no-kv-offload", false, "don't offload the KV cache to GPU")
 	port := fs.Int("port", 8080, "Port to expose the server on")
 	threads := fs.Int("threads", runtime.NumCPU(), "Number of threads to use during generation")
 	verbose := fs.Bool("verbose", false, "verbose output (default: disabled)")
@@ -906,6 +907,7 @@ func Execute(args []string) error {
 		MainGPU:        *mainGPU,
 		TensorSplit:    tensorSplitFloats,
 		FlashAttention: *flashAttention,
+		NoKVOffload:    *noKVOffload,
 	}
 
 	server.ready.Add(1)


### PR DESCRIPTION
allows pushing context window into system memory, allows vram-constrained users to offload more model layers, especially for models with larger context windows. Currently starting ollama with `OLLAMA_NO_KV_OFFLOAD=1` and `OLLAMA_FLASH_ATTENTION=1` enables this. I believe flash attention is a prerequisite, but my understanding of the relationship between flash attention and the kv cache is minimal.

I am unfamiliar with this code-base; any pointers on what additional changes are missing would be very welcome.

TODO:
- When `OLLAMA_NEW_ENGINE=0`, this seems to work and performs really well; though it seems to fail when `OLLAMA_NEW_ENGINE=1`, and I believe I am missing some areas in runner/ollamarunner which need to be modified. 
- Anything extra which may be needed for this parameter to be modified as a model is loaded instead of when starting ollama.
