### PR TITLE
readme: add Ellama to list of integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [1Panel](https://github.com/1Panel-dev/1Panel/) (Web-based Linux Server Management Tool)
 - [AstrBot](https://github.com/Soulter/AstrBot/) (User-friendly LLM-based multi-platform chatbot with a WebUI, supporting RAG, LLM agents, and plugins integration)
 - [Reins](https://github.com/ibrahimcetin/reins) (Easily tweak parameters, customize system prompts per chat, and enhance your AI experiments with reasoning model support.)
+- [Ellama](https://github.com/zeozeozeo/ellama) (Friendly native app to chat with an Ollama instance)
 
 ### Cloud
 


### PR DESCRIPTION
Ellama is a friendly native chat app for Ollama: https://github.com/zeozeozeo/ellama

![ellama](https://github.com/zeozeozeo/ellama/blob/master/media/pokey.png?raw=true)