### PR TITLE
convert: return name of unsupported architecture

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -201,7 +201,7 @@ func ConvertModel(fsys fs.FS, ws io.WriteSeeker) error {
 	case "CohereForCausalLM":
 		conv = &commandrModel{}
 	default:
-		return errors.New("unsupported architecture")
+		return fmt.Errorf("unsupported architecture %q", p.Architectures[0])
 	}
 
 	if err := json.Unmarshal(bts, conv); err != nil {


### PR DESCRIPTION
When a model's architecture cannot be converted return the name of the unsupported arch in the error message.

Sample output:
```
copying file sha256:99c38a089b14a0fca228899132eb8db54ea551bdc96b639267d5177e4a172776 100%
converting model
Error: unsupported architecture "Mistral3ForConditionalGeneration"
```