### PR TITLE
parser: remove role validation from Modelfile parser

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -301,9 +301,8 @@ const (
 )
 
 var (
-	errMissingFrom        = errors.New("no FROM line")
-	errInvalidMessageRole = errors.New("message role must be one of \"system\", \"user\", or \"assistant\"")
-	errInvalidCommand     = errors.New("command must be one of \"from\", \"license\", \"template\", \"system\", \"adapter\", \"parameter\", or \"message\"")
+	errMissingFrom    = errors.New("no FROM line")
+	errInvalidCommand = errors.New("command must be one of \"from\", \"license\", \"template\", \"system\", \"adapter\", \"parameter\", or \"message\"")
 )
 
 type ParserError struct {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -381,7 +381,7 @@ func ParseFile(r io.Reader) (*Modelfile, error) {
 			case stateMessage:
 				role = b.String()
 				if !isKnownMessageRole(b.String()) {
-					fmt.Printf("warning: received non-standard role %s. Continuing...\n", role)
+					slog.Warn("received non-standard role", "role", role)
 				}
 			case stateComment, stateNil:
 				// pass

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -379,14 +379,10 @@ func ParseFile(r io.Reader) (*Modelfile, error) {
 			case stateParameter:
 				cmd.Name = b.String()
 			case stateMessage:
-				if !isValidMessageRole(b.String()) {
-					return nil, &ParserError{
-						LineNumber: currLine,
-						Msg:        errInvalidMessageRole.Error(),
-					}
-				}
-
 				role = b.String()
+				if !isKnownMessageRole(b.String()) {
+					fmt.Printf("warning: received non-standard role %s. Continuing...\n", role)
+				}
 			case stateComment, stateNil:
 				// pass
 			case stateValue:
@@ -556,7 +552,7 @@ func isNewline(r rune) bool {
 	return r == '\r' || r == '\n'
 }
 
-func isValidMessageRole(role string) bool {
+func isKnownMessageRole(role string) bool {
 	return role == "system" || role == "user" || role == "assistant"
 }
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/user"

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -256,13 +256,13 @@ You are a multiline file parser. Always parse things.
 		{
 			`
 FROM foo
-MESSAGE badguy I'm a bad guy!
+MESSAGE somerandomrole I'm ok with you adding any role message now!
 `,
-			nil,
-			&ParserError{
-				LineNumber: 3,
-				Msg:        errInvalidMessageRole.Error(),
+			[]Command{
+				{Name: "model", Args: "foo"},
+				{Name: "message", Args: "somerandomrole: I'm ok with you adding any role message now!"},
 			},
+			nil,
 		},
 		{
 			`


### PR DESCRIPTION
This allows passing arbitrary roles in a MESSAGE block in a Modelfile. Related to https://github.com/ollama/ollama-python/pull/462 and comments from @ParthSareen.

Example Modelfiles that this PR will now allow:
```
FROM granite3.2

MESSAGE control thinking
```

or

```
FROM granite3.2

MESSAGE somerandomrole whatever you want here
```