### PR TITLE
Add Ollamb to the list of Ollama clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Reins](https://github.com/ibrahimcetin/reins) (Easily tweak parameters, customize system prompts per chat, and enhance your AI experiments with reasoning model support.)
 - [Ellama](https://github.com/zeozeozeo/ellama) (Friendly native app to chat with an Ollama instance)
 - [screenpipe](https://github.com/mediar-ai/screenpipe) Build agents powered by your screen history
+- [Ollamb](https://github.com/hengkysteen/ollamb) (Simple yet rich in features, cross-platform built with Flutter and designed for Ollama. Try the [web demo](https://hengkysteen.github.io/demo/ollamb/).)
 
 ### Cloud
 


### PR DESCRIPTION
This PR adds OLLAMB to the list of Ollama clients in the README.

OLLAMB is a simple yet rich-in-features, cross-platform client built with Flutter and designed for Ollama. It offers an easy installation process and a smooth user experience.

<img width="1552" alt="OLLAMB" src="https://github.com/user-attachments/assets/132a4120-cd38-435f-a3be-fdef5fd5dd89" />

**Repo:** [hengkysteen/ollamb](https://github.com/hengkysteen/ollamb)  
**Demo:** [Web Demo](https://hengkysteen.github.io/demo/ollamb/)

I appreciate your time in reviewing this PR.