### PR TITLE
Limit collation 9929

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -126,6 +126,10 @@ func (f Modelfile) CreateRequest(relativeDir string) (*api.CreateRequest, error)
 	return req, nil
 }
 
+func IsKnownMessageRole(role string) bool {
+	return role == "system" || role == "user" || role == "assistant"
+}
+
 func fileDigestMap(path string) (map[string]string, error) {
 	fl := make(map[string]string)
 
@@ -557,7 +561,7 @@ func isNewline(r rune) bool {
 }
 
 func isValidMessageRole(role string) bool {
-	return role == "system" || role == "user" || role == "assistant"
+	return IsKnownMessageRole(role)
 }
 
 func isValidCommand(cmd string) bool {

--- a/template/template.go
+++ b/template/template.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/exp/maps"
 
 	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/parser"
 )
 
 //go:embed index.json
@@ -309,7 +310,7 @@ func collate(msgs []api.Message) (string, []*api.Message) {
 			system = append(system, msg.Content)
 		}
 
-		if len(collated) > 0 && collated[len(collated)-1].Role == msg.Role {
+		if len(collated) > 0 && parser.IsKnownMessageRole(msg.Role) && collated[len(collated)-1].Role == msg.Role {
 			collated[len(collated)-1].Content += "\n\n" + msg.Content
 		} else {
 			collated = append(collated, &msg)


### PR DESCRIPTION
## Description

Closes #9929 

This PR limits the collation logic to only apply to `"user"`, `"system"`, and `"assistant"` roles.

## Discussion

* It looks like #9874 was reverted in #9917, but there's no discussion on the PR, so I'm not clear if the decision to support other roles was revisited, or if this is a temporary state.
* In the current implementation, I exposed `IsKnownMessageRole` as a public function in the `parser` package, but there may be a better central place to put the list of "known" roles