### PR TITLE
server/routes: stream both tool call and content

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -1568,19 +1568,9 @@ func (s *Server) ChatHandler(c *gin.Context) {
 					toolCalls[i].Function.Index = toolCallIndex
 					toolCallIndex++
 				}
-				res.Message.Content = ""
 				sb.Reset()
-				ch <- res
-				return
 			}
-
-			if r.Done {
-				// Send any remaining content if no tool calls were detected
-				if toolCallIndex == 0 {
-					res.Message.Content = sb.String()
-				}
-				ch <- res
-			}
+			ch <- res
 		}); err != nil {
 			ch <- gin.H{"error": err.Error()}
 		}


### PR DESCRIPTION
An attempt to fix #7886 and #9632, with potential API breaking change.

As noted by [ParthSareen](https://github.com/ParthSareen) in https://github.com/ollama/ollama/issues/8887#issuecomment-2640721896, the current implementation ensures that `content` and `tool_calls` cannot coexist. When no `tool_call` is present, Ollama returns the content as a single chunk.

This PR stream both `tool_calls` and `content`, ensuring `content` stream is available even if no tool call is parsed, which means you'll get `tool_calls` alongside with `content`.

The impact might be minimal, since we can ignore `content` all alone when handling tool call response, same as the current implementation assumes adding tools only when you expect the model to use it, 

Anyway, more input is definitely needed on this change to ensure it addresses the broader range of use cases with minimal side effect.

Demo from MCP client with qwen2.5:0.5b:

https://github.com/user-attachments/assets/302435ee-d3eb-4394-8b5a-a1ddb6848d1e

