### PR TITLE
fix: validate input size in parseSafetensors to prevent integer overflow

### DIFF
--- a/convert/reader_safetensors.go
+++ b/convert/reader_safetensors.go
@@ -36,6 +36,11 @@ func parseSafetensors(fsys fs.FS, replacer *strings.Replacer, ps ...string) ([]T
 			return nil, err
 		}
 
+		// Validate the value of n
+		if n <= 0 || n > 1<<30 { // Example: Limit n to 1GB for safety
+			return nil, fmt.Errorf("invalid or excessive size for safetensors file: %d", n)
+		}
+
 		b := bytes.NewBuffer(make([]byte, 0, n))
 		if _, err = io.CopyN(b, f, n); err != nil {
 			return nil, err


### PR DESCRIPTION
Added validation for the `n` variable in the `parseSafetensors` function to ensure it is within a safe and reasonable range. This prevents potential integer overflow or excessive memory allocation issues that could lead to a panic. Updated error handling to provide clearer messages for invalid or excessive sizes.