### PR TITLE
`install.sh` : add `OLLAMA_INSTALL_ROCM` to make ROCM installation optionnal 

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -221,7 +221,9 @@ if ! check_gpu lspci nvidia && ! check_gpu lshw nvidia && ! check_gpu lspci amdg
     exit 0
 fi
 
-if check_gpu lspci amdgpu || check_gpu lshw amdgpu; then
+OLLAMA_INSTALL_ROCM=${OLLAMA_INSTALL_ROCM:-true}
+
+if [ "$OLLAMA_INSTALL_ROCM" != false ] && ( check_gpu lspci amdgpu || check_gpu lshw amdgpu ); then
     status "Downloading Linux ROCm ${ARCH} bundle"
     curl --fail --show-error --location --progress-bar \
         "https://ollama.com/download/ollama-linux-${ARCH}-rocm.tgz${VER_PARAM}" | \


### PR DESCRIPTION
Some AMD integrated GPU are not supported by ROCm, but the install script installs it anyway.

This PR makes Ollama ROCm installation optional on Linux.

**New environment variable :**

`OLLAMA_INSTALL_ROCM` takes boolean `true` or `false`, defaults to `true`.

**Usage example :**

`curl -fsSL https://ollama.com/install.sh | OLLAMA_INSTALL_ROCM=false sh`


**Note :**
I'm not fluent at all with bash scripting. I asked GPT for help. Please, double check.
