### PR TITLE
config: allow setting fixed context length

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -503,6 +503,15 @@ func (m *Metrics) Summary() {
 	}
 }
 
+func (opts *Options) ApplyFixedContextLength() error {
+	if envconfig.FixedContextLength() > 0 {
+		opts.NumCtx = int(envconfig.FixedContextLength())
+		slog.Info("context length is set to fixed length", "opts.NumCtx", opts.NumCtx)
+	}
+
+	return nil
+}
+
 func (opts *Options) FromMap(m map[string]interface{}) error {
 	valueOpts := reflect.ValueOf(opts).Elem() // names of the fields in the options struct
 	typeOpts := reflect.TypeOf(opts).Elem()   // types of the fields in the options struct

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -40,6 +40,10 @@ curl http://localhost:11434/api/generate -d '{
 }'
 ```
 
+## How can I specify a fixed context window size?
+
+Ollama supports a fixed context window size by setting the `OLLAMA_FIXED_CTX_LENGTH` environment variable. For example, to set the context length to 8k, use: `OLLAMA_FIXED_CTX_LENGTH=8192 ollama serve`. This will override the context length obtained from the model or request settings.
+
 ## How can I tell if my model was loaded onto the GPU?
 
 Use the `ollama ps` command to see what models are currently loaded into memory.

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -170,6 +170,8 @@ var (
 	NewEngine = Bool("OLLAMA_NEW_ENGINE")
 	// ContextLength sets the default context length
 	ContextLength = Uint("OLLAMA_CONTEXT_LENGTH", 2048)
+	// FixedContextLength eliminates the overhead of model reloading
+	FixedContextLength = Uint("OLLAMA_FIXED_CTX_LENGTH", 0)
 )
 
 func String(s string) func() string {
@@ -256,6 +258,7 @@ func AsMap() map[string]EnvVar {
 		"OLLAMA_SCHED_SPREAD":      {"OLLAMA_SCHED_SPREAD", SchedSpread(), "Always schedule model across all GPUs"},
 		"OLLAMA_MULTIUSER_CACHE":   {"OLLAMA_MULTIUSER_CACHE", MultiUserCache(), "Optimize prompt caching for multi-user scenarios"},
 		"OLLAMA_CONTEXT_LENGTH":    {"OLLAMA_CONTEXT_LENGTH", ContextLength(), "Context length to use unless otherwise specified (default: 2048)"},
+		"OLLAMA_FIXED_CTX_LENGTH":  {"OLLAMA_FIXED_CTX_LENGTH", FixedContextLength(), "Override context length obtained from model or request settings"},
 		"OLLAMA_NEW_ENGINE":        {"OLLAMA_NEW_ENGINE", NewEngine(), "Enable the new Ollama engine"},
 
 		// Informational

--- a/envconfig/config_test.go
+++ b/envconfig/config_test.go
@@ -292,3 +292,19 @@ func TestContextLength(t *testing.T) {
 		})
 	}
 }
+
+func TestFixedContextLength(t *testing.T) {
+	cases := map[string]uint{
+		"":     0,
+		"4096": 4096,
+	}
+
+	for k, v := range cases {
+		t.Run(k, func(t *testing.T) {
+			t.Setenv("OLLAMA_FIXED_CTX_LENGTH", k)
+			if i := FixedContextLength(); i != v {
+				t.Errorf("%s: expected %d, got %d", k, v, i)
+			}
+		})
+	}
+}

--- a/server/routes.go
+++ b/server/routes.go
@@ -82,6 +82,10 @@ func modelOptions(model *Model, requestOpts map[string]interface{}) (api.Options
 		return api.Options{}, err
 	}
 
+	if err := opts.ApplyFixedContextLength(); err != nil {
+		return api.Options{}, err
+	}
+
 	return opts, nil
 }
 


### PR DESCRIPTION
Add `OLLAMA_FIXED_CTX_LENGTH` to eliminate the overhead of reloading the same model with different context lengths. This will override the context length obtained from the model or request settings. #9749 