### PR TITLE
server: prevent model thrashing from unset API fields

### DIFF
--- a/llm/server.go
+++ b/llm/server.go
@@ -44,6 +44,7 @@ type LlamaServer interface {
 	EstimatedVRAM() uint64 // Total VRAM across all GPUs
 	EstimatedTotal() uint64
 	EstimatedVRAMByGPU(gpuID string) uint64
+	RunnerOptions() map[string]any
 }
 
 // llmServer is an instance of the llama.cpp server
@@ -1009,4 +1010,16 @@ func (s *llmServer) EstimatedVRAMByGPU(gpuID string) uint64 {
 		}
 	}
 	return 0
+}
+
+func (s *llmServer) RunnerOptions() map[string]any {
+	options := map[string]any{
+		"num_ctx":    int64(s.options.NumCtx / s.numParallel),
+		"num_thread": int64(s.options.NumThread),
+		"use_mlock":  s.options.UseMLock,
+	}
+	if s.options.UseMMap != nil {
+		options["use_mmap"] = *s.options.UseMMap
+	}
+	return options
 }

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -765,6 +765,7 @@ type mockLlm struct {
 	estimatedVRAM      uint64
 	estimatedTotal     uint64
 	estimatedVRAMByGPU map[string]uint64
+	numCtx             int
 }
 
 func (s *mockLlm) Ping(ctx context.Context) error             { return s.pingResp }
@@ -792,3 +793,4 @@ func (s *mockLlm) Close() error {
 func (s *mockLlm) EstimatedVRAM() uint64                  { return s.estimatedVRAM }
 func (s *mockLlm) EstimatedTotal() uint64                 { return s.estimatedTotal }
 func (s *mockLlm) EstimatedVRAMByGPU(gpuid string) uint64 { return s.estimatedVRAMByGPU[gpuid] }
+func (s *mockLlm) RunnerOptions() map[string]any          { return map[string]any{"num_ctx": int64(s.numCtx)} }


### PR DESCRIPTION
TLDR: a model shouldn't be evicted due to different valued API fields if the client doesn't care about those fields.

This is a superseding PR to #8029, which only dealt with `num_ctx`.  It turns out there are other fields that have the same effect.

Client A loads a model with a context window different to the default or the value configured in the Modelfile:
```console
$ curl localhost:11434/api/generate -d '{"model":"llama3.2","options":{"num_ctx":65536}}'
$ ollama ps
NAME               ID              SIZE     PROCESSOR    UNTIL   
llama3.2:latest    a80c4f17acd5    13 GB    100% GPU     Forever 
```
Client B does a completion but doesn't specify a context window, causing the default value of 2048 to be used, resulting in eviction and immediate reload of the model.
```console
$ curl localhost:11434/api/generate -d '{"model":"llama3.2"}'
$ ollama ps
NAME               ID              SIZE      PROCESSOR    UNTIL   
llama3.2:latest    a80c4f17acd5    3.1 GB    100% GPU     Forever    
```
Client A sends another completion with the large context causing another eviction and reload.
```console
$ curl localhost:11434/api/generate -d '{"model":"llama3.2","options":{"num_ctx":65536}}'
$ ollama ps
NAME               ID              SIZE     PROCESSOR    UNTIL   
llama3.2:latest    a80c4f17acd5    13 GB    100% GPU     Forever    
```
If client B is not concerned about the context window, it shouldn't cause the eviction of an an already loaded model.  This is particularly noticeable when sharing a model between ollama and OpenAI endpoints - since the OpenAI endpoint can't set a context window, a model loaded via the ollama endpoint with a custom context window gets evicted by the next OpenAI request.

Thrashing can also occur when a client makes secondary completions after a primary completion, eg open-webui's auto-complete feature (see https://github.com/ollama/ollama/issues/7919#issuecomment-2560465774), or when a model is used for both completion and embedding (https://github.com/ollama/ollama/issues/6148#issuecomment-2568402497).

This also happens with other fields, eg `use_mlock`: #8903, #8922.

Fixes: #8903
Fixes: #8922