### PR TITLE
Dockerfile: Don't strip the Go symbol table

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,7 +92,7 @@ RUN curl -fsSL https://golang.org/dl/go$(awk '/^go/ { print $2 }' go.mod).linux-
 ENV PATH=/usr/local/go/bin:$PATH
 RUN go mod download
 COPY . .
-ARG GOFLAGS="'-ldflags=-w -s'"
+ARG GOFLAGS="'-ldflags=-w'"
 ENV CGO_ENABLED=1
 RUN --mount=type=cache,target=/root/.cache/go-build \
     go build -trimpath -buildmode=pie -o /bin/ollama .


### PR DESCRIPTION
Please consider building ollama with the symbol table. This is helpful for debugging and use cases like continuous profiling. 

![image](https://github.com/user-attachments/assets/62220196-fd5d-48fe-929a-c4d1104d3776)
