### PR TITLE
Adding a search command

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -476,3 +476,11 @@ func (c *Client) Whoami(ctx context.Context) (*UserResponse, error) {
 	}
 	return &resp, nil
 }
+
+func (c *Client) Search(ctx context.Context, req *SearchRequest) (*SearchResponse, error) {
+	var resp SearchResponse
+	if err := c.do(ctx, http.MethodPost, "/api/search", req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/api/types.go
+++ b/api/types.go
@@ -797,6 +797,27 @@ type PushRequest struct {
 	Name string `json:"name"`
 }
 
+// SearchRequest is request passed to [Client.Search]
+type SearchRequest struct {
+	Query string `json:"query"`
+	Order string `json:"order"`
+	Category string `json:"category"`
+}
+
+// SearchResponse is response from [Client.Search]
+type SearchResponse struct {
+	Models []SearchModelResponse `json:"models"`
+}
+
+// SearchModelResponse is a single model description in [SearchResponse]
+type SearchModelResponse struct {
+	Name string `json:"name"`
+	Description string `json:"description"` 
+	Sizes string `json:"sizes"`
+	Pulls string `json:"pulls"`
+	Category string `json:"category"`
+}
+
 // ListResponse is the response from [Client.List].
 type ListResponse struct {
 	Models []ListModelResponse `json:"models"`

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1059,6 +1059,83 @@ func DeleteHandler(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+func SearchHandler(cmd *cobra.Command, args []string) error {
+	// by default an empty query lists all models
+	query := ""
+	if len(args) != 0 {
+		query = args[0]
+	}
+
+	category, err := cmd.Flags().GetString("category")
+	if err != nil {
+		return err
+	}
+
+	// this ensures a well-formed query downstream
+	// i.e [server.SearchRegistry] gets a well formed request
+	switch category {
+	case "":
+		// no-op
+	case "e":
+		category = "embedding"
+	case "v":
+		category = "vision"
+	case "t":
+		category = "tools"
+	default:
+		return errors.New("invalid category to search, valid options: e for embedding, v for vision, t for tools, omit flag for no filters")
+	}
+
+	// this ensures a well-formed query downstream
+	// i.e [server.SearchRegistry] gets a well formed request
+	newest, err := cmd.Flags().GetBool("newest")
+	if err != nil {
+		return err
+	}
+	order := "popularity"
+	if newest {
+		order = "newest"
+	}
+
+	client, err := api.ClientFromEnvironment()
+	if err != nil {
+		return err
+	}
+
+	request := api.SearchRequest{Query: query, Category: category, Order: order}
+	response, err := client.Search(cmd.Context(), &request)
+	if err != nil {
+		return err
+	}
+
+	var data [][]string
+
+	var _trim = func (s string) string {
+		if len(s) > 80 {
+			return s[:80] + "..."
+		}
+		return s
+	}
+
+	for _, model := range response.Models {
+		data = append(data, []string{model.Name, _trim(model.Description), model.Sizes, model.Pulls, model.Category})
+	}
+
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"NAME", "DESCRIPTION", "SIZES", "PULL COUNT", "CATEGORY"})
+	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetAutoWrapText(false)
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetNoWhiteSpace(true)
+	table.SetTablePadding("    ")
+	table.AppendBulk(data)
+	table.Render()
+
+	return nil
+}
+
 func ShowHandler(cmd *cobra.Command, args []string) error {
 	client, err := api.ClientFromEnvironment()
 	if err != nil {
@@ -2270,6 +2347,16 @@ func NewCLI() *cobra.Command {
 		RunE:    DeleteHandler,
 	}
 
+	searchCmd := &cobra.Command{
+		Use:     "search [MODEL]",
+		Short:   "Search for a model",
+		Args:    cobra.MaximumNArgs(1),
+		PreRunE: checkServerHeartbeat,
+		RunE:    SearchHandler,
+	}
+	searchCmd.Flags().String("category", "", "Filter on category: [A]ll/[e]mbedding/[v]ision/[t]ools")
+	searchCmd.Flags().Bool("newest", false, "Order by date instead of popularity")
+
 	runnerCmd := &cobra.Command{
 		Use:    "runner",
 		Hidden: true,
@@ -2298,6 +2385,7 @@ func NewCLI() *cobra.Command {
 		copyCmd,
 		deleteCmd,
 		serveCmd,
+		searchCmd,
 	} {
 		switch cmd {
 		case runCmd:
@@ -2346,6 +2434,7 @@ func NewCLI() *cobra.Command {
 		deleteCmd,
 		runnerCmd,
 		launch.LaunchCmd(checkServerHeartbeat, runInteractiveTUI),
+		searchCmd,
 	)
 
 	return rootCmd

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -2213,3 +2213,105 @@ func TestIsLocalhost(t *testing.T) {
 		})
 	}
 }
+
+func TestSearchRequest(t *testing.T) {
+	testcases := []struct {
+		testName string
+		query []string
+		flags map[string]any
+		models []api.SearchModelResponse
+		expectedOutput string
+	}{
+		{
+			testName: "basic test - no flags",
+			models: []api.SearchModelResponse{
+				{
+					Name: "model0",
+					Description: "This is the first mock model",
+					Pulls: "10M",
+					Sizes: "1b,7b,70b",
+					Category: "",
+				},
+				{
+					Name: "model1",
+					Description: "This is the second mock model. This model has vision capability",
+					Pulls: "12M",
+					Sizes: "7b,70b",
+					Category: "vision",
+				},
+				{
+					Name: "model2",
+					Description: "This is the third mock model. This model has embedding capability",
+					Pulls: "10M",
+					Sizes: "1b,7b,70b",
+					Category: "embedding",
+				},
+				{
+					Name: "model3",
+					Description: "This is the fourth mock model. This model has tools capability",
+					Pulls: "100M",
+					Sizes: "8b,32b",
+					Category: "tools",
+				},
+				{
+					Name: "model4",
+					Description: "This is the fifth mock model. This model has a very long description, that should be truncated to prevent the text from overflowing on a small terminal window. If you are reading this then there is a bug in the truncation (shameful)",
+					Pulls: "10M",
+					Sizes: "1b,7b,70b",
+					Category: "",
+				},
+			},
+			expectedOutput: "NAME      DESCRIPTION                                                                            SIZES        PULL COUNT    CATEGORY  \n" +
+			"model0    This is the first mock model                                                           1b,7b,70b    10M                        \n" +
+			"model1    This is the second mock model. This model has vision capability                        7b,70b       12M           vision       \n" +
+			"model2    This is the third mock model. This model has embedding capability                      1b,7b,70b    10M           embedding    \n" +
+			"model3    This is the fourth mock model. This model has tools capability                         8b,32b       100M          tools        \n" +
+			"model4    This is the fifth mock model. This model has a very long description, that shoul...    1b,7b,70b    10M                        \n" +
+			"",
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.testName, func(t *testing.T) {
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// ensures that our Handler only calls the correct service endpoints
+				if r.URL.Path != "/api/search" || r.Method != http.MethodPost {
+					t.Errorf("unexpected api call to %s using method %s", r.URL.Path, r.Method)
+					http.Error(w, "unknonw path", http.StatusNotFound)
+					return
+				}
+
+				response := api.SearchResponse{Models: testcase.models}
+				if err := json.NewEncoder(w).Encode(response); err != nil {
+					t.Fatal(err)
+				}
+			}))
+			defer mockServer.Close()
+
+			t.Setenv("OLLAMA_HOST", mockServer.URL)
+
+			// create a cobra command, run the handler, and match the output
+			cmd := &cobra.Command{}
+			cmd.Flags().Bool("newest", false, "")
+			cmd.Flags().String("category", "", "")
+			cmd.SetContext(context.TODO())
+
+			// this captures stdout
+			oldStdout := os.Stdout
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+
+			err := SearchHandler(cmd, testcase.query)
+
+			// Restore stdout and get output
+			w.Close()
+			os.Stdout = oldStdout
+			output, _ := io.ReadAll(r)
+			if got := string(output); got != testcase.expectedOutput {
+				t.Errorf("expected output:\n%s\ngot:\n%s", testcase.expectedOutput, got)
+			} else if err != nil {
+				t.Errorf("expected no error, got %v", err)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 )
 
 require (
+	github.com/PuerkitoBio/goquery v1.10.2
 	github.com/agnivade/levenshtein v1.1.1
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
@@ -42,6 +43,7 @@ require (
 )
 
 require (
+	github.com/andybalholm/cascadia v1.3.3 // indirect
 	github.com/apache/arrow/go/arrow v0.0.0-20211112161151-bc219186db40 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect

--- a/server/routes.go
+++ b/server/routes.go
@@ -1024,6 +1024,24 @@ func (s *Server) PushHandler(c *gin.Context) {
 	streamResponse(c, ch)
 }
 
+func (s *Server) SearchHandler(c *gin.Context) {
+	var req api.SearchRequest
+	if err := c.ShouldBindJSON(&req) ; errors.Is(err, io.EOF) {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "missing request body"})
+		return
+	} else if err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	} 
+
+	resp, err := SearchRegistry(c.Request.Context(), &req)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": strings.TrimSpace(err.Error())})
+		return 
+	}
+	c.JSON(http.StatusOK, resp)
+}
+
 // getExistingName searches the models directory for the longest prefix match of
 // the input name and returns the input name with all existing parts replaced
 // with each part found. If no parts are found, the input name is returned as
@@ -1684,6 +1702,7 @@ func (s *Server) GenerateRoutes(rc *ollama.Registry) (http.Handler, error) {
 	r.GET("/api/tags", s.ListHandler)
 	r.POST("/api/show", s.ShowHandler)
 	r.DELETE("/api/delete", s.DeleteHandler)
+	r.POST("/api/search", s.SearchHandler)
 
 	r.POST("/api/me", s.WhoamiHandler)
 

--- a/server/search.go
+++ b/server/search.go
@@ -1,0 +1,94 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/ollama/ollama/api"
+)
+
+const (
+	DefaultSearchUrl = "https://registry.ollama.ai/search"
+)
+
+func flaky(selection *goquery.Selection) string {
+	if selection != nil {
+		return strings.Trim(strings.Trim(selection.Text(), "\n"), " ")
+	}
+	return ""
+}
+
+func parseSearchResults(resp *http.Response) (*api.SearchResponse, error) {
+	doc, err := goquery.NewDocumentFromReader(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	results := &api.SearchResponse{}
+
+	// main parsing logic
+	// all search results are in this div
+	doc.Find("#searchresults > ul > li").Each(func(i int, s *goquery.Selection) {
+		desc := flaky(s.Find("p").First())
+		modelName := flaky(s.Find("span[x-test-search-response-title]"))
+		capability := flaky(s.Find("span[x-test-capability]"))
+
+		var modelSizes []string
+		s.Find("span[x-test-size]").Each(func(j int, span *goquery.Selection) {
+			modelSizes = append(modelSizes, flaky(span.First()))
+		})
+
+		pullCount := flaky(s.Find("span[x-test-pull-count]"))
+
+		results.Models = append(results.Models, api.SearchModelResponse{
+			Name:        modelName,
+			Description: desc,
+			Category:    capability,
+			Sizes:       strings.Join(modelSizes, ","),
+			Pulls:       pullCount,
+		})
+	})
+
+	return results, nil
+}
+
+func formatSearchRequestURL(params *api.SearchRequest) (*url.URL, error) {
+	// base URL
+	u, err := url.Parse(DefaultSearchUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	// query path parameters
+	query := u.Query()
+	query.Add("c", params.Category)
+	query.Add("o", params.Order)
+	query.Add("q", params.Query)
+	u.RawQuery = query.Encode()
+	return u, nil
+}
+
+func SearchRegistry(ctx context.Context, params *api.SearchRequest) (*api.SearchResponse, error) {
+	requestURL, err := formatSearchRequestURL(params)
+	if err != nil {
+		return nil, err
+	}
+	headers := make(http.Header)
+
+	resp, err := makeRequest(ctx, http.MethodGet, requestURL, headers, nil, &registryOptions{})
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		// we messed up somewhere :(
+		return nil, errors.New("error - can't search default registry at " + DefaultSearchUrl)
+	}
+
+	return parseSearchResults(resp)
+}


### PR DESCRIPTION
Adding a search command to the cli.
Issue: #286 

It makes it easier to find and list models.

This does not pull model tags and I have left that line of work open for future once the community settles on how the search command looks and feels.

Once we are satisfied we can add a flag (--model) or a command (info) to pull model specific information such as tags, model size (bytes), license, creator, long description, etc.

note: this is a rough draft, and in no way final. The idea is to get feedback from community before moving forward.

I have followed the client <-> server architecture and the logic for parsing the output from registry.ollama.ai is fairly isolated to make it easy to refactor should a JSON api be made available.

Please provide feedback :heart:
