### PR TITLE
support no caching when kvCacheType is "nocache" for deterministic completion

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -20,9 +20,9 @@ Please refer to the [GPU docs](./gpu.md).
 
 ## How can I specify the context window size?
 
-By default, Ollama uses a context window size of 2048 tokens. 
+By default, Ollama uses a context window size of 2048 tokens.
 
-This can be overridden with the `OLLAMA_CONTEXT_LENGTH` environment variable. For example, to set the default context window to 8K, use: 
+This can be overridden with the `OLLAMA_CONTEXT_LENGTH` environment variable. For example, to set the default context window to 8K, use:
 
 ```shell
 OLLAMA_CONTEXT_LENGTH=8192 ollama serve
@@ -329,6 +329,7 @@ The currently available K/V cache quantization types are:
 - `f16` - high precision and memory usage (default).
 - `q8_0` - 8-bit quantization, uses approximately 1/2 the memory of `f16` with a very small loss in precision, this usually has no noticeable impact on the model's quality (recommended if not using f16).
 - `q4_0` - 4-bit quantization, uses approximately 1/4 the memory of `f16` with a small-medium loss in precision that may be more noticeable at higher context sizes.
+- `nocache` - no cache.
 
 How much the cache quantization impacts the model's response quality will depend on the model and the task.  Models that have a high GQA count (e.g. Qwen2) may see a larger impact on precision from quantization than models with a low GQA count.
 

--- a/fs/ggml/ggml.go
+++ b/fs/ggml/ggml.go
@@ -649,7 +649,7 @@ func (llm GGML) VisionGraphSize() (weights, graphSize uint64) {
 
 // SupportsKVCacheType checks if the requested cache type is supported
 func (f GGML) SupportsKVCacheType(cacheType string) bool {
-	return slices.Contains([]string{"f16", "q8_0", "q4_0"}, cacheType)
+	return slices.Contains([]string{"f16", "q8_0", "q4_0", "nocache"}, cacheType)
 }
 
 // SupportsFlashAttention checks if the model supports flash attention

--- a/runner/ollamarunner/cache.go
+++ b/runner/ollamarunner/cache.go
@@ -72,7 +72,9 @@ func kvCacheTypeFromStr(s string) ml.DType {
 }
 
 func (c *InputCache) Close() {
-	c.cache.Close()
+	if c.cache != nil {
+		c.cache.Close()
+	}
 }
 
 // Locking: Operations on InputCacheSlot (including finding one

--- a/runner/ollamarunner/cache.go
+++ b/runner/ollamarunner/cache.go
@@ -45,8 +45,10 @@ func NewInputCache(model model.Model, kvCacheType string, kvSize int32, numSlots
 	}
 
 	cache := model.Config().Cache
-	if cache != nil {
+	if cache != nil && kvCacheType != "nocache" {
 		cache.Init(model.Backend(), kvCacheTypeFromStr(kvCacheType), numSlots, int(numCtx), batchSize)
+	} else {
+		cache = nil
 	}
 
 	return &InputCache{

--- a/runner/ollamarunner/runner.go
+++ b/runner/ollamarunner/runner.go
@@ -750,7 +750,7 @@ func Execute(args []string) error {
 	mainGPU := fs.Int("main-gpu", 0, "Main GPU")
 	flashAttention := fs.Bool("flash-attn", false, "Enable flash attention")
 	kvSize := fs.Int("ctx-size", 2048, "Context (or KV cache) size")
-	kvCacheType := fs.String("kv-cache-type", "", "quantization type for KV cache (default: f16)")
+	kvCacheType := fs.String("kv-cache-type", "f16", "quantization type for KV cache (default: f16)")
 	port := fs.Int("port", 8080, "Port to expose the server on")
 	threads := fs.Int("threads", runtime.NumCPU(), "Number of threads to use during generation")
 	verbose := fs.Bool("verbose", false, "verbose output (default: disabled)")


### PR DESCRIPTION
based on the discussions https://github.com/ollama/ollama/issues/5321, an option to disable caching is needed to ensure reproducibility. setting `kvCacheType` to `"nocache"` is a simple way to achieve it.