### PR TITLE
fix(integration): move waitgroup Add(1) outside goroutine to avoid potential issue

### DIFF
--- a/integration/max_queue_test.go
+++ b/integration/max_queue_test.go
@@ -52,8 +52,8 @@ func TestMaxQueue(t *testing.T) {
 	embedCtx := ctx
 
 	var genwg sync.WaitGroup
+	genwg.Add(1)
 	go func() {
-		genwg.Add(1)
 		defer genwg.Done()
 		slog.Info("Starting generate request")
 		DoGenerate(ctx, t, client, req, resp, 45*time.Second, 5*time.Second)
@@ -71,8 +71,8 @@ func TestMaxQueue(t *testing.T) {
 	counterMu := sync.Mutex{}
 	var embedwg sync.WaitGroup
 	for i := 0; i < threadCount; i++ {
+		embedwg.Add(1)
 		go func(i int) {
-			embedwg.Add(1)
 			defer embedwg.Done()
 			slog.Info("embed started", "id", i)
 			embedReq := api.EmbeddingRequest{


### PR DESCRIPTION
Detailed description:
- Moved waitgroup.Add(1) out of the goroutine to ensure the WaitGroup counter is properly set before any goroutine starts.
- Prevents potential issues where waitgroup.Wait() might return prematurely due to scheduling delays.
- Aligns with best practices for using sync.WaitGroup.