### PR TITLE
GraniteMoE new engine

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -200,6 +200,8 @@ func ConvertModel(fsys fs.FS, ws io.WriteSeeker) error {
 		conv = &bertModel{}
 	case "CohereForCausalLM":
 		conv = &commandrModel{}
+	case "GraniteForCausalLM":
+		conv = &graniteModel{}
 	default:
 		return fmt.Errorf("unsupported architecture %q", p.Architectures[0])
 	}

--- a/convert/convert_granite.go
+++ b/convert/convert_granite.go
@@ -1,0 +1,231 @@
+package convert
+
+import (
+	"cmp"
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/pdevine/tensor"
+	"github.com/pdevine/tensor/native"
+
+	"github.com/ollama/ollama/fs/ggml"
+)
+
+type graniteModel struct {
+	ModelParameters
+	NLayers               uint32  `json:"n_layers"`
+	NumHiddenLayers       uint32  `json:"num_hidden_layers"`
+	NLayer                uint32  `json:"n_layer"`
+	MaxPositionEmbeddings uint32  `json:"max_position_embeddings"`
+	NCtx                  uint32  `json:"n_ctx"`
+	HiddenSize            uint32  `json:"hidden_size"`
+	NEmbd                 uint32  `json:"n_embd"`
+	IntermediateSize      uint32  `json:"intermediate_size"`
+	NInner                uint32  `json:"n_inner"`
+	NumAttentionHeads     uint32  `json:"num_attention_heads"`
+	NHead                 uint32  `json:"n_head"`
+	NumKeyValueHeads      uint32  `json:"num_key_value_heads"`
+	RopeTheta             float32 `json:"rope_theta"`
+	RopeScaling           struct {
+		Type                            string  `json:"type"`
+		RopeType                        string  `json:"rope_type"`
+		Factor                          float32 `json:"factor"`
+		LowFrequencyFactor              float32 `json:"low_freq_factor"`
+		HighFrequencyFactor             float32 `json:"high_freq_factor"`
+		OriginalMaxPositionalEmbeddings uint32  `json:"original_max_positional_embeddings"`
+
+		factors ropeFactor
+	} `json:"rope_scaling"`
+	RMSNormEPS          float32 `json:"rms_norm_eps"`
+	LayerNormEPS        float32 `json:"layer_norm_eps"`
+	LayerNormEpsilon    float32 `json:"layer_norm_epsilon"`
+	NormEpsilon         float32 `json:"norm_epsilon"`
+	HeadDim             uint32  `json:"head_dim"`
+	AttentionMultiplier float32 `json:"attention_multiplier"`
+	EmbeddingMultiplier float32 `json:"embedding_multiplier"`
+	ResidualMultiplier  float32 `json:"residual_multiplier"`
+	LogitsScaling       float32 `json:"logits_scaling"`
+}
+
+var _ ModelConverter = (*graniteModel)(nil)
+
+func (p *graniteModel) KV(t *Tokenizer) ggml.KV {
+	kv := p.ModelParameters.KV(t)
+	kv["general.architecture"] = "granite"
+	kv["granite.vocab_size"] = p.VocabSize
+
+	kv["granite.block_count"] = cmp.Or(p.NLayers, p.NumHiddenLayers, p.NLayer)
+
+	if contextLength := cmp.Or(p.MaxPositionEmbeddings, p.NCtx); contextLength > 0 {
+		kv["granite.context_length"] = contextLength
+	}
+
+	if embeddingLength := cmp.Or(p.HiddenSize, p.NEmbd); embeddingLength > 0 {
+		kv["granite.embedding_length"] = cmp.Or(p.HiddenSize, p.NEmbd)
+	}
+
+	if feedForwardLength := cmp.Or(p.IntermediateSize, p.NInner); feedForwardLength > 0 {
+		kv["granite.feed_forward_length"] = cmp.Or(p.IntermediateSize, p.NInner)
+	}
+
+	if headCount := cmp.Or(p.NumAttentionHeads, p.NHead); headCount > 0 {
+		kv["granite.attention.head_count"] = cmp.Or(p.NumAttentionHeads, p.NHead)
+		kv["granite.rope.dimension_count"] = p.HiddenSize / headCount
+	}
+
+	if p.RopeTheta > 0 {
+		kv["granite.rope.freq_base"] = p.RopeTheta
+	}
+
+	if p.RopeScaling.Type == "linear" {
+		kv["granite.rope.scaling.type"] = p.RopeScaling.Type
+		kv["granite.rope.scaling.factor"] = p.RopeScaling.Factor
+	} else if p.RopeScaling.RopeType == "llama3" {
+		dim := p.HiddenSize / p.NumAttentionHeads
+		for i := uint32(0); i < dim; i += 2 {
+			factor := cmp.Or(p.RopeScaling.Factor, 8.0)
+			factorLow := cmp.Or(p.RopeScaling.LowFrequencyFactor, 1.0)
+			factorHigh := cmp.Or(p.RopeScaling.HighFrequencyFactor, 4.0)
+
+			original := cmp.Or(p.RopeScaling.OriginalMaxPositionalEmbeddings, 8192)
+			lambdaLow := float32(original) / factorLow
+			lambdaHigh := float32(original) / factorHigh
+
+			lambda := 2 * math.Pi * math.Pow(float64(p.RopeTheta), float64(i)/float64(dim))
+			if lambda < float64(lambdaHigh) {
+				p.RopeScaling.factors = append(p.RopeScaling.factors, 1.0)
+			} else if lambda > float64(lambdaLow) {
+				p.RopeScaling.factors = append(p.RopeScaling.factors, factor)
+			} else {
+				smooth := (float32(original)/float32(lambda) - factorLow) / (factorHigh - factorLow)
+				p.RopeScaling.factors = append(p.RopeScaling.factors, 1.0/((1-smooth)/factor+smooth))
+			}
+		}
+	}
+
+	if p.NumKeyValueHeads > 0 {
+		kv["granite.attention.head_count_kv"] = p.NumKeyValueHeads
+	}
+
+	if p.RMSNormEPS > 0 {
+		kv["granite.attention.layer_norm_rms_epsilon"] = p.RMSNormEPS
+	}
+
+	if layerNormEpsilon := cmp.Or(p.LayerNormEPS, p.LayerNormEpsilon, p.NormEpsilon); layerNormEpsilon > 0 {
+		kv["granite.attention.layer_norm_epsilon"] = layerNormEpsilon
+	}
+
+	if p.HeadDim > 0 {
+		kv["granite.attention.key_length"] = p.HeadDim
+		kv["granite.attention.value_length"] = p.HeadDim
+	}
+
+	// Granite multipliers
+	if p.AttentionMultiplier != 0 {
+		kv["granite.attention.scale"] = p.AttentionMultiplier
+	}
+	if p.EmbeddingMultiplier != 0 {
+		kv["granite.embedding_scale"] = p.EmbeddingMultiplier
+	}
+	if p.ResidualMultiplier != 0 {
+		kv["granite.residual_scale"] = p.ResidualMultiplier
+	}
+	if p.LogitsScaling != 0 {
+		kv["granite.logit_scale"] = p.LogitsScaling
+	}
+
+	return kv
+}
+
+func (p *graniteModel) Tensors(ts []Tensor) []ggml.Tensor {
+	var out []ggml.Tensor
+
+	if p.RopeScaling.factors != nil {
+		out = append(out, ggml.Tensor{
+			Name:     "rope_freqs.weight",
+			Kind:     0,
+			Shape:    []uint64{uint64(len(p.RopeScaling.factors))},
+			WriterTo: p.RopeScaling.factors,
+		})
+	}
+
+	for _, t := range ts {
+		if strings.HasSuffix(t.Name(), "attn_q.weight") ||
+			strings.HasSuffix(t.Name(), "attn_k.weight") {
+			t.SetRepacker(p.repack)
+		}
+
+		out = append(out, ggml.Tensor{
+			Name:     t.Name(),
+			Kind:     t.Kind(),
+			Shape:    t.Shape(),
+			WriterTo: t,
+		})
+	}
+
+	return out
+}
+
+func (p *graniteModel) Replacements() []string {
+	return []string{
+		"lm_head", "output",
+		"model.embed_tokens", "token_embd",
+		"model.norm", "output_norm",
+		"model.layers", "blk",
+		"input_layernorm", "attn_norm",
+		"self_attn.q_proj", "attn_q",
+		"self_attn.k_proj", "attn_k",
+		"self_attn.v_proj", "attn_v",
+		"self_attn.o_proj", "attn_output",
+		"mlp.gate_proj", "ffn_gate",
+		"mlp.down_proj", "ffn_down",
+		"mlp.up_proj", "ffn_up",
+		"post_attention_layernorm", "ffn_norm",
+	}
+}
+
+func (p *graniteModel) repack(name string, data []float32, shape []uint64) ([]float32, error) {
+	var dims []int
+	for _, dim := range shape {
+		dims = append(dims, int(dim))
+	}
+
+	var heads uint32
+	if strings.HasSuffix(name, "attn_q.weight") {
+		heads = p.NumAttentionHeads
+	} else if strings.HasSuffix(name, "attn_k.weight") {
+		heads = cmp.Or(p.NumKeyValueHeads, p.NumAttentionHeads)
+	} else {
+		return nil, fmt.Errorf("unknown tensor for repack: %s", name)
+	}
+
+	n := tensor.New(tensor.WithShape(dims...), tensor.WithBacking(data))
+	if err := n.Reshape(append([]int{int(heads), 2, dims[0] / int(heads) / 2}, dims[1:]...)...); err != nil {
+		return nil, err
+	}
+
+	if err := n.T(0, 2, 1, 3); err != nil {
+		return nil, err
+	}
+
+	if err := n.Reshape(dims...); err != nil {
+		return nil, err
+	}
+
+	if err := n.Transpose(); err != nil {
+		return nil, err
+	}
+
+	ts, err := native.SelectF32(n, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	var f32s []float32
+	for _, t := range ts {
+		f32s = append(f32s, t...)
+	}
+
+	return f32s, nil
+}

--- a/ml/backend.go
+++ b/ml/backend.go
@@ -130,13 +130,17 @@ type Tensor interface {
 
 	Add(ctx Context, t2 Tensor) Tensor
 	Mul(ctx Context, t2 Tensor) Tensor
+	Div(ctx Context, t2 Tensor) Tensor
 	Mulmat(ctx Context, t2 Tensor) Tensor
 	MulmatFullPrec(ctx Context, t2 Tensor) Tensor
+	MulmatId(ctx Context, t2, ids Tensor) Tensor
 
 	Softmax(ctx Context) Tensor
 	LayerNorm(ctx Context, weight, bias Tensor, eps float32) Tensor
 	RMSNorm(ctx Context, weight Tensor, eps float32) Tensor
 	Scale(ctx Context, s float64) Tensor
+	TopK(ctx Context, k int) Tensor
+	SumRows(ctx Context) Tensor
 
 	AvgPool2D(ctx Context, k, s int, p float32) Tensor
 	Conv2D(ctx Context, weight Tensor, s0, s1, p0, p1, d0, d1 int) Tensor

--- a/ml/backend/ggml/ggml.go
+++ b/ml/backend/ggml/ggml.go
@@ -746,6 +746,13 @@ func (t *Tensor) Mul(ctx ml.Context, t2 ml.Tensor) ml.Tensor {
 	}
 }
 
+func (t *Tensor) Div(ctx ml.Context, t2 ml.Tensor) ml.Tensor {
+	return &Tensor{
+		b: t.b,
+		t: C.ggml_div(ctx.(*Context).ctx, t.t, t2.(*Tensor).t),
+	}
+}
+
 func (t *Tensor) Mulmat(ctx ml.Context, t2 ml.Tensor) ml.Tensor {
 	return &Tensor{
 		b: t.b,
@@ -760,6 +767,13 @@ func (t *Tensor) MulmatFullPrec(ctx ml.Context, t2 ml.Tensor) ml.Tensor {
 	return &Tensor{
 		b: t.b,
 		t: mul,
+	}
+}
+
+func (t *Tensor) MulmatId(ctx ml.Context, t2, ids ml.Tensor) ml.Tensor {
+	return &Tensor{
+		b: t.b,
+		t: C.ggml_mul_mat_id(ctx.(*Context).ctx, t.t, t2.(*Tensor).t, ids.(*Tensor).t),
 	}
 }
 
@@ -843,6 +857,20 @@ func (t *Tensor) Scale(ctx ml.Context, s float64) ml.Tensor {
 	return &Tensor{
 		b: t.b,
 		t: C.ggml_scale(ctx.(*Context).ctx, t.t, (C.float)(s)),
+	}
+}
+
+func (t *Tensor) TopK(ctx ml.Context, k int) ml.Tensor {
+	return &Tensor{
+		b: t.b,
+		t: C.ggml_top_k(ctx.(*Context).ctx, t.t, (C.int)(k)),
+	}
+}
+
+func (t *Tensor) SumRows(ctx ml.Context) ml.Tensor {
+	return &Tensor{
+		b: t.b,
+		t: C.ggml_sum_rows(ctx.(*Context).ctx, t.t),
 	}
 }
 

--- a/model/models/granite/model.go
+++ b/model/models/granite/model.go
@@ -42,17 +42,10 @@ func New(c ml.Config) (model.Model, error) {
 	// TODO: Support a mapping of all possible tokenizer.ggml.pre values used by granite
 	var tokenizerPreExprs []string
 	if tokenizerPre := c.String("tokenizer.ggml.pretokenizer", ""); tokenizerPre == "" {
-		if tokenizerPreName := c.String("tokenizer.ggml.pre", ""); tokenizerPreName == "refact" {
-			tokenizerPreExprs = []string{
-				`[^\p{N}]+|\p{N}`,
-				`'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)`,
-			}
-		} else if tokenizerPreName == "qwen2" {
-			tokenizerPreExprs = []string{
-				`(?:'[sS]|'[tT]|'[rR][eE]|'[vV][eE]|'[mM]|'[lL][lL]|'[dD])|[^\r\n\p{L}\p{N}]?\p{L}+|\p{N}| ?[^\s\p{L}\p{N}]+[\r\n]*|\s*[\r\n]+|\s+(?!\S)|\s+`,
-			}
-		} else {
-			return nil, fmt.Errorf("invalid tokenizer pre-tokenizer: %s", tokenizerPreName)
+		tokenizerPreName := c.String("tokenizer.ggml.pre", "")
+		var tokenizerPreErr error
+		if tokenizerPreExprs, tokenizerPreErr = model.GetKnownPretokenizerExpressions(tokenizerPreName); tokenizerPreErr != nil {
+			return nil, tokenizerPreErr
 		}
 	} else {
 		tokenizerPreExprs = []string{tokenizerPre}

--- a/model/models/granite/model.go
+++ b/model/models/granite/model.go
@@ -169,8 +169,8 @@ func (m *Model) Forward(ctx ml.Context, batch input.Batch) (ml.Tensor, error) {
 		return nil, err
 	}
 
-	hiddenState := m.TokenEmbedding.Forward(ctx, inputs)
-	hiddenState.Scale(ctx, m.Options.embeddingMultiplier)
+	hiddenState := m.TokenEmbedding.Forward(ctx, batch.Inputs)
+	hiddenState = hiddenState.Scale(ctx, m.Options.embeddingMultiplier)
 
 	for i, layer := range m.Layers {
 		m.Cache.SetLayer(i)

--- a/model/models/granite/model.go
+++ b/model/models/granite/model.go
@@ -1,0 +1,197 @@
+package granite
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/ollama/ollama/kvcache"
+	"github.com/ollama/ollama/ml"
+	"github.com/ollama/ollama/ml/nn"
+	"github.com/ollama/ollama/model"
+)
+
+type Options struct {
+	RopeFactors                      ml.Tensor `gguf:"rope_freqs.weight"`
+	hiddenSize, numHeads, numKVHeads int
+	eps, ropeBase, ropeScale         float32
+	residualMultiplier,
+	embeddingMultiplier,
+	attentionMultiplier,
+	logitsScaling float64
+	ropeDim uint32
+}
+
+type Model struct {
+	model.Base
+	model.BytePairEncoding
+
+	TokenEmbedding *nn.Embedding `gguf:"token_embd"`
+	Layers         []Layer       `gguf:"blk"`
+	OutputNorm     *nn.RMSNorm   `gguf:"output_norm"`
+	Output         *nn.Linear    `gguf:"output,alt:token_embd"`
+
+	*Options
+}
+
+func New(c ml.Config) (model.Model, error) {
+	if !strings.EqualFold(c.String("tokenizer.ggml.model"), "gpt2") {
+		return nil, fmt.Errorf("tokenizer %s not yet supported", c.String("tokenizer.ggml.model"))
+	}
+
+	// TODO: Support a mapping of all possible tokenizer.ggml.pre values used by granite
+	tokenizerPre := c.String("tokenizer.ggml.pretokenizer", "")
+	if tokenizerPre == "" {
+		if tokenizerPreName := c.String("tokenizer.ggml.pre", ""); tokenizerPreName == "refact" {
+			return nil, fmt.Errorf("TODO: Support multiple split expressions for pretokenizer %s", tokenizerPreName)
+		} else if tokenizerPreName == "qwen2" {
+			tokenizerPre = `(?:'[sS]|'[tT]|'[rR][eE]|'[vV][eE]|'[mM]|'[lL][lL]|'[dD])|[^\r\n\p{L}\p{N}]?\p{L}+|\p{N}| ?[^\s\p{L}\p{N}]+[\r\n]*|\s*[\r\n]+|\s+(?!\S)|\s+`
+		}
+	}
+	m := Model{
+		BytePairEncoding: model.NewBytePairEncoding(
+			tokenizerPre,
+			&model.Vocabulary{
+				Values: c.Strings("tokenizer.ggml.tokens"),
+				Types:  c.Uints("tokenizer.ggml.token_type"),
+				Merges: c.Strings("tokenizer.ggml.merges"),
+				BOS:    int32(c.Uint("tokenizer.ggml.bos_token_id")),
+				AddBOS: c.Bool("tokenizer.ggml.add_bos_token", false),
+				EOS:    int32(c.Uint("tokenizer.ggml.eos_token_id")),
+				AddEOS: c.Bool("tokenizer.ggml.add_eos_token", false),
+			},
+		),
+		Layers: make([]Layer, c.Uint("block_count")),
+		Options: &Options{
+			hiddenSize:          int(c.Uint("embedding_length")),
+			numHeads:            int(c.Uint("attention.head_count")),
+			numKVHeads:          int(c.Uint("attention.head_count_kv")),
+			eps:                 c.Float("attention.layer_norm_rms_epsilon"),
+			ropeBase:            c.Float("rope.freq_base"),
+			ropeScale:           c.Float("rope.freq_scale", 1),
+			ropeDim:             c.Uint("rope.dimension_count"),
+			residualMultiplier:  float64(c.Float("residual_scale")),
+			attentionMultiplier: float64(c.Float("attention.scale")),
+			embeddingMultiplier: float64(c.Float("embedding_scale")),
+			logitsScaling:       float64(c.Float("logit_scale")),
+		},
+	}
+	slog.Debug("Parsed Options", "", m.Options)
+
+	m.Cache = kvcache.NewCausalCache(m.Shift)
+
+	return &m, nil
+}
+
+type SelfAttention struct {
+	Query  *nn.Linear `gguf:"attn_q"`
+	Key    *nn.Linear `gguf:"attn_k"`
+	Value  *nn.Linear `gguf:"attn_v"`
+	Output *nn.Linear `gguf:"attn_output"`
+}
+
+func (sa *SelfAttention) Forward(ctx ml.Context, hiddenState, positionIDs ml.Tensor, cache kvcache.Cache, opts *Options) ml.Tensor {
+	batchSize := hiddenState.Dim(1)
+	headDim := opts.hiddenSize / opts.numHeads
+
+	q := sa.Query.Forward(ctx, hiddenState)
+	q = q.Reshape(ctx, headDim, opts.numHeads, batchSize)
+	q = q.RoPE(ctx, positionIDs, opts.RopeFactors, opts.ropeDim, opts.ropeBase, opts.ropeScale)
+
+	k := sa.Key.Forward(ctx, hiddenState)
+	k = k.Reshape(ctx, headDim, opts.numKVHeads, batchSize)
+	k = k.RoPE(ctx, positionIDs, opts.RopeFactors, opts.ropeDim, opts.ropeBase, opts.ropeScale)
+
+	v := sa.Value.Forward(ctx, hiddenState)
+	v = v.Reshape(ctx, headDim, opts.numKVHeads, batchSize)
+
+	kqv := nn.Attention(ctx, q, k, v, opts.attentionMultiplier, cache)
+	kqv = kqv.Reshape(ctx, opts.hiddenSize, batchSize)
+
+	return sa.Output.Forward(ctx, kqv)
+}
+
+func (m *Model) Shift(ctx ml.Context, layer int, key, shift ml.Tensor) (ml.Tensor, error) {
+	return key.RoPE(ctx, shift, m.Options.RopeFactors, m.Options.ropeDim, m.Options.ropeBase, m.Options.ropeScale), nil
+}
+
+type MLP struct {
+	Up   *nn.Linear `gguf:"ffn_up"`
+	Down *nn.Linear `gguf:"ffn_down"`
+	Gate *nn.Linear `gguf:"ffn_gate"`
+}
+
+func (mlp *MLP) Forward(ctx ml.Context, hiddenState ml.Tensor, opts *Options) ml.Tensor {
+	hiddenState = mlp.Gate.Forward(ctx, hiddenState).SILU(ctx).Mul(ctx, mlp.Up.Forward(ctx, hiddenState))
+	return mlp.Down.Forward(ctx, hiddenState)
+}
+
+type Layer struct {
+	AttentionNorm *nn.RMSNorm `gguf:"attn_norm"`
+	SelfAttention *SelfAttention
+	MLPNorm       *nn.RMSNorm `gguf:"ffn_norm"`
+	MLP           *MLP
+}
+
+func (l *Layer) Forward(ctx ml.Context, hiddenState, positionIDs, outputs ml.Tensor, cache kvcache.Cache, opts *Options) ml.Tensor {
+	residual := hiddenState
+
+	hiddenState = l.AttentionNorm.Forward(ctx, hiddenState, opts.eps)
+	hiddenState = l.SelfAttention.Forward(ctx, hiddenState, positionIDs, cache, opts)
+
+	// In the final layer (outputs != nil), optimize by pruning to just the token positions
+	// we need logits for.
+	if outputs != nil {
+		hiddenState = hiddenState.Rows(ctx, outputs)
+		residual = residual.Rows(ctx, outputs)
+	}
+
+	hiddenState = hiddenState.Scale(ctx, opts.residualMultiplier)
+	hiddenState = hiddenState.Add(ctx, residual)
+	residual = hiddenState
+
+	hiddenState = l.MLPNorm.Forward(ctx, hiddenState, opts.eps)
+	hiddenState = l.MLP.Forward(ctx, hiddenState, opts)
+	hiddenState = hiddenState.Scale(ctx, opts.residualMultiplier)
+	return hiddenState.Add(ctx, residual)
+}
+
+func (m *Model) Forward(ctx ml.Context, opts model.Options) (ml.Tensor, error) {
+	inputs, err := ctx.FromIntSlice(opts.Inputs, len(opts.Inputs))
+	if err != nil {
+		return nil, err
+	}
+
+	positions, err := ctx.FromIntSlice(opts.Positions, len(opts.Positions))
+	if err != nil {
+		return nil, err
+	}
+
+	outputs, err := ctx.FromIntSlice(opts.Outputs, len(opts.Outputs))
+	if err != nil {
+		return nil, err
+	}
+
+	hiddenState := m.TokenEmbedding.Forward(ctx, inputs)
+	hiddenState.Scale(ctx, m.Options.embeddingMultiplier)
+
+	for i, layer := range m.Layers {
+		m.Cache.SetLayer(i)
+
+		var lastLayerOutputs ml.Tensor
+		if i == len(m.Layers)-1 {
+			lastLayerOutputs = outputs
+		}
+
+		hiddenState = layer.Forward(ctx, hiddenState, positions, lastLayerOutputs, m.Cache, m.Options)
+	}
+
+	hiddenState = m.OutputNorm.Forward(ctx, hiddenState, m.eps)
+	hiddenState = m.Output.Forward(ctx, hiddenState)
+	hiddenState = hiddenState.Scale(ctx, 1.0/m.Options.logitsScaling)
+	return hiddenState, nil
+}
+
+func init() {
+	model.Register("granite", New)
+}

--- a/model/models/granite/model.go
+++ b/model/models/granite/model.go
@@ -13,7 +13,6 @@ import (
 )
 
 type Options struct {
-	RopeFactors                      ml.Tensor `gguf:"rope_freqs.weight"`
 	hiddenSize, numHeads, numKVHeads int
 	eps, ropeBase, ropeScale         float32
 	residualMultiplier,
@@ -99,11 +98,11 @@ func (sa *SelfAttention) Forward(ctx ml.Context, hiddenState, positionIDs ml.Ten
 
 	q := sa.Query.Forward(ctx, hiddenState)
 	q = q.Reshape(ctx, headDim, opts.numHeads, batchSize)
-	q = q.RoPE(ctx, positionIDs, opts.RopeFactors, opts.ropeDim, ropeType, opts.ropeBase, opts.ropeScale)
+	q = q.RoPE(ctx, positionIDs, sa.RopeFactors, opts.ropeDim, ropeType, opts.ropeBase, opts.ropeScale)
 
 	k := sa.Key.Forward(ctx, hiddenState)
 	k = k.Reshape(ctx, headDim, opts.numKVHeads, batchSize)
-	k = k.RoPE(ctx, positionIDs, opts.RopeFactors, opts.ropeDim, ropeType, opts.ropeBase, opts.ropeScale)
+	k = k.RoPE(ctx, positionIDs, sa.RopeFactors, opts.ropeDim, ropeType, opts.ropeBase, opts.ropeScale)
 
 	v := sa.Value.Forward(ctx, hiddenState)
 	v = v.Reshape(ctx, headDim, opts.numKVHeads, batchSize)
@@ -115,7 +114,7 @@ func (sa *SelfAttention) Forward(ctx ml.Context, hiddenState, positionIDs ml.Ten
 }
 
 func (m *Model) Shift(ctx ml.Context, layer int, key, shift ml.Tensor) (ml.Tensor, error) {
-	return key.RoPE(ctx, shift, m.Options.RopeFactors, m.Options.ropeDim, uint32(0), m.Options.ropeBase, m.Options.ropeScale), nil
+	return key.RoPE(ctx, shift, m.Layers[layer].SelfAttention.RopeFactors, uint32(0), m.Options.ropeDim, m.Options.ropeBase, m.Options.ropeScale), nil
 }
 
 type MLP struct {

--- a/model/models/granite/model.go
+++ b/model/models/granite/model.go
@@ -166,7 +166,7 @@ func (m *Model) Forward(ctx ml.Context, batch input.Batch) (ml.Tensor, error) {
 		return nil, err
 	}
 
-	outputs, err := ctx.Output().FromIntSlice(batch.Outputs, len(batch.Outputs))
+	outputs, err := ctx.Input().FromIntSlice(batch.Outputs, len(batch.Outputs))
 	if err != nil {
 		return nil, err
 	}

--- a/model/models/granite/model.go
+++ b/model/models/granite/model.go
@@ -158,18 +158,13 @@ func (l *Layer) Forward(ctx ml.Context, hiddenState, positionIDs, outputs ml.Ten
 	return hiddenState.Add(ctx, residual)
 }
 
-func (m *Model) Forward(ctx ml.Context, opts input.Options) (ml.Tensor, error) {
-	inputs, err := ctx.Input().FromIntSlice(opts.Inputs, len(opts.Inputs))
+func (m *Model) Forward(ctx ml.Context, batch input.Batch) (ml.Tensor, error) {
+	positions, err := ctx.Input().FromIntSlice(batch.Positions, len(batch.Positions))
 	if err != nil {
 		return nil, err
 	}
 
-	positions, err := ctx.Input().FromIntSlice(opts.Positions, len(opts.Positions))
-	if err != nil {
-		return nil, err
-	}
-
-	outputs, err := ctx.Output().FromIntSlice(opts.Outputs, len(opts.Outputs))
+	outputs, err := ctx.Output().FromIntSlice(batch.Outputs, len(batch.Outputs))
 	if err != nil {
 		return nil, err
 	}

--- a/model/models/granitemoe/model.go
+++ b/model/models/granitemoe/model.go
@@ -1,0 +1,242 @@
+package granitemoe
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/ollama/ollama/kvcache"
+	"github.com/ollama/ollama/ml"
+	"github.com/ollama/ollama/ml/nn"
+	"github.com/ollama/ollama/model"
+	"github.com/ollama/ollama/model/input"
+)
+
+type Options struct {
+	hiddenSize, numHeads, numKVHeads, expertCount, expertUsedCount int
+	eps, ropeBase, ropeScale                                       float32
+	residualMultiplier,
+	embeddingMultiplier,
+	attentionMultiplier,
+	logitsScaling float64
+	ropeDim uint32
+}
+
+type Model struct {
+	model.Base
+	model.BytePairEncoding
+
+	TokenEmbedding *nn.Embedding `gguf:"token_embd"`
+	Layers         []Layer       `gguf:"blk"`
+	OutputNorm     *nn.RMSNorm   `gguf:"output_norm"`
+	Output         *nn.Linear    `gguf:"output,alt:token_embd"`
+
+	*Options
+}
+
+func New(c ml.Config) (model.Model, error) {
+	if !strings.EqualFold(c.String("tokenizer.ggml.model"), "gpt2") {
+		return nil, fmt.Errorf("tokenizer %s not yet supported", c.String("tokenizer.ggml.model"))
+	}
+	var tokenizerPreExprs []string
+	if tokenizerPre := c.String("tokenizer.ggml.pretokenizer", ""); tokenizerPre == "" {
+		tokenizerPreName := c.String("tokenizer.ggml.pre", "")
+		var tokenizerPreErr error
+		if tokenizerPreExprs, tokenizerPreErr = model.GetKnownPretokenizerExpressions(tokenizerPreName); tokenizerPreErr != nil {
+			return nil, tokenizerPreErr
+		}
+	} else {
+		tokenizerPreExprs = []string{tokenizerPre}
+	}
+	m := Model{
+		BytePairEncoding: model.NewMultiRegexBytePairEncoding(
+			tokenizerPreExprs,
+			&model.Vocabulary{
+				Values: c.Strings("tokenizer.ggml.tokens"),
+				Types:  c.Uints("tokenizer.ggml.token_type"),
+				Merges: c.Strings("tokenizer.ggml.merges"),
+				BOS:    int32(c.Uint("tokenizer.ggml.bos_token_id")),
+				AddBOS: c.Bool("tokenizer.ggml.add_bos_token", false),
+				EOS:    int32(c.Uint("tokenizer.ggml.eos_token_id")),
+				AddEOS: c.Bool("tokenizer.ggml.add_eos_token", false),
+			},
+		),
+		Layers: make([]Layer, c.Uint("block_count")),
+		Options: &Options{
+			hiddenSize:          int(c.Uint("embedding_length")),
+			numHeads:            int(c.Uint("attention.head_count")),
+			numKVHeads:          int(c.Uint("attention.head_count_kv")),
+			expertCount:         int(c.Uint("expert_count")),
+			expertUsedCount:     int(c.Uint("expert_used_count")),
+			eps:                 c.Float("attention.layer_norm_rms_epsilon"),
+			ropeBase:            c.Float("rope.freq_base"),
+			ropeScale:           c.Float("rope.freq_scale", 1),
+			ropeDim:             c.Uint("rope.dimension_count"),
+			residualMultiplier:  float64(c.Float("residual_scale")),
+			attentionMultiplier: float64(c.Float("attention.scale")),
+			embeddingMultiplier: float64(c.Float("embedding_scale")),
+			logitsScaling:       float64(c.Float("logit_scale")),
+		},
+	}
+	slog.Debug("Parsed Options", "", m.Options)
+
+	m.Cache = kvcache.NewCausalCache(m.Shift)
+
+	return &m, nil
+}
+
+type SelfAttention struct {
+	Query       *nn.Linear `gguf:"attn_q"`
+	Key         *nn.Linear `gguf:"attn_k"`
+	Value       *nn.Linear `gguf:"attn_v"`
+	Output      *nn.Linear `gguf:"attn_output"`
+	RopeFactors ml.Tensor  `gguf:"rope_freqs.weight"`
+}
+
+func (sa *SelfAttention) Forward(ctx ml.Context, hiddenState, positionIDs ml.Tensor, cache kvcache.Cache, opts *Options) ml.Tensor {
+	batchSize := hiddenState.Dim(1)
+	headDim := opts.hiddenSize / opts.numHeads
+	ropeType := uint32(0)
+
+	q := sa.Query.Forward(ctx, hiddenState)
+	q = q.Reshape(ctx, headDim, opts.numHeads, batchSize)
+	q = q.RoPE(ctx, positionIDs, sa.RopeFactors, opts.ropeDim, ropeType, opts.ropeBase, opts.ropeScale)
+
+	k := sa.Key.Forward(ctx, hiddenState)
+	k = k.Reshape(ctx, headDim, opts.numKVHeads, batchSize)
+	k = k.RoPE(ctx, positionIDs, sa.RopeFactors, opts.ropeDim, ropeType, opts.ropeBase, opts.ropeScale)
+
+	v := sa.Value.Forward(ctx, hiddenState)
+	v = v.Reshape(ctx, headDim, opts.numKVHeads, batchSize)
+
+	kqv := nn.Attention(ctx, q, k, v, opts.attentionMultiplier, cache)
+	kqv = kqv.Reshape(ctx, opts.hiddenSize, batchSize)
+
+	return sa.Output.Forward(ctx, kqv)
+}
+
+func (m *Model) Shift(ctx ml.Context, layer int, key, shift ml.Tensor) (ml.Tensor, error) {
+	return key.RoPE(ctx, shift, m.Layers[layer].SelfAttention.RopeFactors, uint32(0), m.Options.ropeDim, m.Options.ropeBase, m.Options.ropeScale), nil
+}
+
+type MoE struct {
+	UpExps   *nn.Linear `gguf:"ffn_up_exps"`
+	DownExps *nn.Linear `gguf:"ffn_down_exps"`
+	GateInp  *nn.Linear `gguf:"ffn_gate_inp"`
+	GateExps *nn.Linear `gguf:"ffn_gate_exps"`
+}
+
+func (moe *MoE) Forward(ctx ml.Context, hiddenState ml.Tensor, opts *Options) ml.Tensor {
+	shape := hiddenState.Shape()
+	nEmbed := shape[0]
+	nTokens := 1
+	if len(shape) > 1 {
+		nTokens = shape[1]
+	}
+
+	// GateInp * hiddenState => "logits"
+	logits := moe.GateInp.Forward(ctx, hiddenState)
+	// softmax(logits) => "probs"
+	probs := logits.Softmax(ctx)
+	// topk(probs, n_expert_used) => "selected_experts"
+	selectedExperts := probs.TopK(ctx, int(opts.expertUsedCount))
+	// Rows (probs, selected_experts) => "weights"
+	weights := probs.Reshape(ctx, 1, opts.expertCount, nTokens).Rows(ctx, selectedExperts)
+	// norm weights (weights / sum weights)
+	weights = weights.Reshape(ctx, opts.expertUsedCount, nTokens)
+	weightSum := weights.SumRows(ctx)
+	weights = weights.Div(ctx, weightSum)
+	weights = weights.Reshape(ctx, 1, opts.expertUsedCount, nTokens)
+	// (?) reshape hiddenState => hiddenState
+	hiddenState = hiddenState.Reshape(ctx, nEmbed, 1, nTokens)
+	// UpExps * hiddenState (ids = selected_experts) => "up"
+	up := moe.UpExps.Weight.MulmatId(ctx, hiddenState, selectedExperts)
+	// GateExps * hiddenState (ids = selected_experts) => "gate"
+	gate := moe.GateExps.Weight.MulmatId(ctx, hiddenState, selectedExperts)
+	// SILU (gate) => "gate"
+	gate = gate.SILU(ctx)
+	// up * gate => "par"
+	par := up.Mul(ctx, gate)
+	// DownExps * par (ids = selected_experts) => "experts"
+	experts := moe.DownExps.Weight.MulmatId(ctx, par, selectedExperts)
+	// experts * weights => experts
+	experts = experts.Mul(ctx, weights)
+	expertStride1 := experts.Stride(1)
+	expertStride2 := experts.Stride(2)
+	// sum experts
+	var moeOut ml.Tensor
+	for i := 0; i < opts.expertUsedCount; i++ {
+		curExpert := experts.View(ctx, i*expertStride1, nEmbed, expertStride2, nTokens)
+		if i == 0 {
+			moeOut = curExpert
+		} else {
+			moeOut = moeOut.Add(ctx, curExpert)
+		}
+	}
+	return moeOut
+}
+
+type Layer struct {
+	AttentionNorm *nn.RMSNorm `gguf:"attn_norm"`
+	SelfAttention *SelfAttention
+	MoENorm       *nn.RMSNorm `gguf:"ffn_norm"`
+	MoE           *MoE
+}
+
+func (l *Layer) Forward(ctx ml.Context, hiddenState, positionIDs, outputs ml.Tensor, cache kvcache.Cache, opts *Options) ml.Tensor {
+	residual := hiddenState
+
+	hiddenState = l.AttentionNorm.Forward(ctx, hiddenState, opts.eps)
+	hiddenState = l.SelfAttention.Forward(ctx, hiddenState, positionIDs, cache, opts)
+
+	// In the final layer (outputs != nil), optimize by pruning to just the token positions
+	// we need logits for.
+	if outputs != nil {
+		hiddenState = hiddenState.Rows(ctx, outputs)
+		residual = residual.Rows(ctx, outputs)
+	}
+
+	hiddenState = hiddenState.Scale(ctx, opts.residualMultiplier)
+	hiddenState = hiddenState.Add(ctx, residual)
+	residual = hiddenState
+
+	hiddenState = l.MoENorm.Forward(ctx, hiddenState, opts.eps)
+	hiddenState = l.MoE.Forward(ctx, hiddenState, opts)
+	hiddenState = hiddenState.Scale(ctx, opts.residualMultiplier)
+	return hiddenState.Add(ctx, residual)
+}
+
+func (m *Model) Forward(ctx ml.Context, batch input.Batch) (ml.Tensor, error) {
+	positions, err := ctx.Input().FromIntSlice(batch.Positions, len(batch.Positions))
+	if err != nil {
+		return nil, err
+	}
+
+	outputs, err := ctx.Input().FromIntSlice(batch.Outputs, len(batch.Outputs))
+	if err != nil {
+		return nil, err
+	}
+
+	hiddenState := m.TokenEmbedding.Forward(ctx, batch.Inputs)
+	hiddenState = hiddenState.Scale(ctx, m.Options.embeddingMultiplier)
+
+	for i, layer := range m.Layers {
+		m.Cache.SetLayer(i)
+
+		var lastLayerOutputs ml.Tensor
+		if i == len(m.Layers)-1 {
+			lastLayerOutputs = outputs
+		}
+
+		hiddenState = layer.Forward(ctx, hiddenState, positions, lastLayerOutputs, m.Cache, m.Options)
+	}
+
+	hiddenState = m.OutputNorm.Forward(ctx, hiddenState, m.eps)
+	hiddenState = m.Output.Forward(ctx, hiddenState)
+	hiddenState = hiddenState.Scale(ctx, 1.0/m.Options.logitsScaling)
+	return hiddenState, nil
+}
+
+func init() {
+	model.Register("granitemoe", New)
+}

--- a/model/models/models.go
+++ b/model/models/models.go
@@ -3,6 +3,7 @@ package models
 import (
 	_ "github.com/ollama/ollama/model/models/gemma2"
 	_ "github.com/ollama/ollama/model/models/gemma3"
+	_ "github.com/ollama/ollama/model/models/granite"
 	_ "github.com/ollama/ollama/model/models/llama"
 	_ "github.com/ollama/ollama/model/models/mllama"
 )

--- a/model/models/models.go
+++ b/model/models/models.go
@@ -4,6 +4,7 @@ import (
 	_ "github.com/ollama/ollama/model/models/gemma2"
 	_ "github.com/ollama/ollama/model/models/gemma3"
 	_ "github.com/ollama/ollama/model/models/granite"
+	_ "github.com/ollama/ollama/model/models/granitemoe"
 	_ "github.com/ollama/ollama/model/models/llama"
 	_ "github.com/ollama/ollama/model/models/mllama"
 )

--- a/model/process_text.go
+++ b/model/process_text.go
@@ -110,13 +110,24 @@ func (v *Vocabulary) Merge(left, right string) int {
 }
 
 type BytePairEncoding struct {
-	pre   *regexp2.Regexp
+	pre   []*regexp2.Regexp
 	vocab *Vocabulary
 }
 
 func NewBytePairEncoding(pre string, vocab *Vocabulary) BytePairEncoding {
 	return BytePairEncoding{
-		pre:   regexp2.MustCompile(pre, regexp2.Unicode|regexp2.RE2),
+		pre:   []*regexp2.Regexp{regexp2.MustCompile(pre, regexp2.Unicode|regexp2.RE2)},
+		vocab: vocab,
+	}
+}
+
+func NewMultiRegexBytePairEncoding(pres []string, vocab *Vocabulary) BytePairEncoding {
+	preExprs := []*regexp2.Regexp{}
+	for _, pre := range pres {
+		preExprs = append(preExprs, regexp2.MustCompile(pre, regexp2.Unicode|regexp2.RE2))
+	}
+	return BytePairEncoding{
+		pre:   preExprs,
 		vocab: vocab,
 	}
 }
@@ -127,8 +138,18 @@ func (bpe BytePairEncoding) Is(id int32, special Special) bool {
 
 func (bpe *BytePairEncoding) split(s string) iter.Seq[string] {
 	return func(yield func(string) bool) {
-		for m, _ := bpe.pre.FindStringMatch(s); m != nil; m, _ = bpe.pre.FindNextMatch(m) {
-			if !yield(m.String()) {
+		chunks := []string{s}
+		for _, pre := range bpe.pre {
+			prevChunks := chunks
+			chunks = []string{}
+			for _, chunk := range prevChunks {
+				for m, _ := pre.FindStringMatch(chunk); m != nil; m, _ = pre.FindNextMatch(m) {
+					chunks = append(chunks, m.String())
+				}
+			}
+		}
+		for _, chunk := range chunks {
+			if !yield(chunk) {
 				break
 			}
 		}

--- a/model/process_text.go
+++ b/model/process_text.go
@@ -4,7 +4,6 @@ import (
 	"cmp"
 	"iter"
 	"log/slog"
-	"slices"
 	"strings"
 	"sync"
 
@@ -86,9 +85,7 @@ func (v *Vocabulary) Decode(id int32) string {
 func (v *Vocabulary) SpecialVocabulary() []string {
 	v.specialOnce.Do(func() {
 		for i := range v.Values {
-			if slices.Contains([]int{105, 106}, i) {
-				v.special = append(v.special, v.Values[i])
-			} else if v.Types[i] == TOKEN_TYPE_CONTROL {
+			if v.Types[i] == TOKEN_TYPE_CONTROL {
 				v.special = append(v.special, v.Values[i])
 			}
 		}

--- a/model/process_text.go
+++ b/model/process_text.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"cmp"
+	"fmt"
 	"iter"
 	"log/slog"
 	"strings"
@@ -357,4 +358,20 @@ func (bpe BytePairEncoding) Decode(ids []int32) (string, error) {
 	}
 
 	return sb.String(), nil
+}
+
+func GetKnownPretokenizerExpressions(pretokName string) ([]string, error) {
+	switch pretokName {
+	case "refact":
+		return []string{
+			`[^\p{N}]+|\p{N}`,
+			`'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)`,
+		}, nil
+	case "qwen2":
+		return []string{
+			`(?:'[sS]|'[tT]|'[rR][eE]|'[vV][eE]|'[mM]|'[lL][lL]|'[dD])|[^\r\n\p{L}\p{N}]?\p{L}+|\p{N}| ?[^\s\p{L}\p{N}]+[\r\n]*|\s*[\r\n]+|\s+(?!\S)|\s+`,
+		}, nil
+	default:
+		return nil, fmt.Errorf("invalid pretokenizer name: %s", pretokName)
+	}
 }


### PR DESCRIPTION
## Description

This PR is a follow on to #9966 that extends support to the `GraniteMoE` architecture.

## Outstanding TODO

- [ ] Merge #9966
- [ ] Add support for `GraniteMoE` in the `convert` package

## Testing

(using the same `find-ollama-gguf.sh` from the previous PR)

```sh
# Run the model with the llama.cpp engine
./ollama runner -model $(find-ollama-gguf.sh granite3.1-moe:1b) -port 12345 -n-gpu-layers 100

# Run the model with the ollama engine
./ollama runner --ollama-engine -model $(find-ollama-gguf.sh granite3.1-moe:1b) -port 12346 -n-gpu-layers 100
```

```py
import requests
import json
llama_url = "http://localhost:12345/completion"
ollama_url = "http://localhost:12346/completion"
request = {"prompt": "Hi there", "options": {"temperature": 0, "num_predict": 100}}

llama_resp = requests.post(llama_url, json=request)
llama_text = "".join([json.loads(line)["content"] for line in llama_resp.text.splitlines()])

ollama_resp = requests.post(ollama_url, json=request)
ollama_text = "".join([json.loads(line)["content"] for line in ollama_resp.text.splitlines()])

print(f"############ llama.cpp output:\n{llama_text}")
print("-----------")
print(f"############ ollama output:\n{ollama_text}")
```