### PR TITLE
server: improve spacing for JSON grammar

### DIFF
--- a/llm/server.go
+++ b/llm/server.go
@@ -636,13 +636,13 @@ func (s *llmServer) WaitUntilRunning(ctx context.Context) error {
 }
 
 var grammarJSON = `
-root   ::= object
-value  ::= object | array | string | number | ("true" | "false" | "null") ws
+root   ::= s? object
+value  ::= (object | array | string | number | ("true" | "false" | "null")) ws
 object ::=
   "{" ws (
             string ":" ws value
     ("," ws string ":" ws value)*
-  )? "}" ws
+  )? "}" 
 array  ::=
   "[" ws (
             value
@@ -651,12 +651,11 @@ array  ::=
 string ::=
   "\"" (
     [^"\\\x7F\x00-\x1F] |
-    "\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]) # escapes
-  )* "\"" ws
-number ::= ("-"? ([0-9] | [1-9] [0-9]*)) ("." [0-9]+)? ([eE] [-+]? [0-9]+)? ws
-# Optional space: by convention, applied in this grammar after literal chars when allowed
-ws ::= ([ \t\n] ws)?
-`
+    "\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F])
+  )* "\""
+number ::= "-"? ("0" | [1-9] [0-9]*) ("." [0-9]+)? ([eE] [-+]? [0-9]+)?
+ws     ::= [ \t \n \r]*
+s     ::= [ \t \n \r]`
 
 const maxBufferSize = 512 * format.KiloByte
 

--- a/llm/server.go
+++ b/llm/server.go
@@ -636,26 +636,27 @@ func (s *llmServer) WaitUntilRunning(ctx context.Context) error {
 }
 
 var grammarJSON = `
-root   ::= s? object
-value  ::= (object | array | string | number | ("true" | "false" | "null")) ws
+root   ::= ws object
+value  ::= object | array | string | number | ("true" | "false" | "null") ws
 object ::=
   "{" ws (
-            string ":" ws value
+            ws string ":" ws value
     ("," ws string ":" ws value)*
-  )? "}" 
+  )? ws "}" 
 array  ::=
   "[" ws (
             value
     ("," ws value)*
-  )? "]" ws
+  )? ws "]" 
 string ::=
   "\"" (
     [^"\\\x7F\x00-\x1F] |
-    "\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F])
-  )* "\""
-number ::= "-"? ("0" | [1-9] [0-9]*) ("." [0-9]+)? ([eE] [-+]? [0-9]+)?
-ws     ::= [ \t \n \r]*
-s     ::= [ \t \n \r]`
+    "\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]) # escapes
+  )* "\"" 
+number ::= ("-"? ([0-9] | [1-9] [0-9]*)) ("." [0-9]+)? ([eE] [-+]? [0-9]+)? 
+# Optional space: by convention, applied in this grammar after literal chars when allowed
+ws ::= ([ \t\n] ws)?
+`
 
 const maxBufferSize = 512 * format.KiloByte
 

--- a/llm/server.go
+++ b/llm/server.go
@@ -636,11 +636,11 @@ func (s *llmServer) WaitUntilRunning(ctx context.Context) error {
 }
 
 var grammarJSON = `
-root   ::= ws object
+root   ::= object
 value  ::= object | array | string | number | ("true" | "false" | "null") ws
 object ::=
   "{" ws (
-            ws string ":" ws value
+         string ":" ws value
     ("," ws string ":" ws value)*
   )? ws "}" 
 array  ::=


### PR DESCRIPTION
Pulled out from https://github.com/ollama/ollama/pull/10096 for improving whitespace in grammars 

## Fixing `\n` with grammar
New gemma output
```
❯ go run . run gemma3
# github.com/ollama/ollama
ld: warning: ignoring duplicate libraries: '-lobjc'
>>> /set format json
Set format to 'json' mode.
>>> create a json
        {
                "name": "Example JSON",
                "version":      "1.0",
                "description":  "A simple example JSON document.",
                "author":       "Bard",
                "date": "2023-10-27",
                "data": {
                        "numbers":      [1,     2,      3,      4,      5],
                        "strings":      ["apple",       "banana",       "cherry"],
                        "boolean":      true,
                        "null_value":   null,
                        "object":       {
                                "key1": "value1",
                                "key2": 123,
                                "key3": {
                                        "nested_key":   "nested_value"
                                }
                        }
                }
        }
```


Previous gemma output
```
❯ go run . run gemma3
# github.com/ollama/ollama
ld: warning: ignoring duplicate libraries: '-lobjc'
>>> /set format json
Set format to 'json' mode.
>>> create a json
{}

   
   
   
   
   
   
   
   
   
   
   
   
   
   
```
