### PR TITLE
Create a new file descriptor for each goroutine during GGML model loading to improve loading from network filesystems.

### DIFF
--- a/ml/backend/ggml/ggml.go
+++ b/ml/backend/ggml/ggml.go
@@ -318,12 +318,14 @@ func New(ctx context.Context, r *os.File, params ml.BackendParams) (ml.Backend, 
 				tts[i] = tt
 			}
 
-			newFile, err := os.Open(r.Name())
+			// Create a new FD for each goroutine so that each FD is read sequentially, rather than
+			// seeking around within an FD shared between all goroutines.
+			file, err := os.Open(r.Name())
 			if err != nil {
 				return err
 			}
-			defer newFile.Close()
-			sr := io.NewSectionReader(newFile, int64(meta.Tensors().Offset+t.Offset), int64(t.Size()))
+			defer file.Close()
+			sr := io.NewSectionReader(file, int64(meta.Tensors().Offset+t.Offset), int64(t.Size()))
 			bts := make([]byte, 128*format.KibiByte)
 
 			var s uint64

--- a/ml/backend/ggml/ggml.go
+++ b/ml/backend/ggml/ggml.go
@@ -20,7 +20,6 @@ import (
 	"strconv"
 	"strings"
 	"sync/atomic"
-	"syscall"
 	"unicode"
 	"unsafe"
 
@@ -319,13 +318,11 @@ func New(ctx context.Context, r *os.File, params ml.BackendParams) (ml.Backend, 
 				tts[i] = tt
 			}
 
-			fd := int(r.Fd())
-			newFd, err := syscall.Dup(fd)
+			newFile, err := os.Open(r.Name())
 			if err != nil {
-				fmt.Println("Error duplicating file descriptor:", err)
 				return err
 			}
-			newFile := os.NewFile(uintptr(newFd), r.Name())
+			defer newFile.Close()
 			sr := io.NewSectionReader(newFile, int64(meta.Tensors().Offset+t.Offset), int64(t.Size()))
 			bts := make([]byte, 128*format.KibiByte)
 


### PR DESCRIPTION
This fixes #9691 

Ollama currently reuses the same file descriptor across all goroutines reading the model. GCS Fuse (and often other network-based filesystems) only keeps one open download stream per FD, as you cannot seek within a stream. This means every read at a non-sequential offset has to close the existing download and start a new one at the desired offset, which is slow. This happens frequently as each goroutine is reading from a different offset from the same FD. The error in #9691 is because the model cannot be loaded within the timeout.

This fixes the issue by creating a new FD per goroutine, which each goroutine reads sequentally from.

On Cloud Run with the Cloud Storage volume (powered by GCS Fuse), this fixes the issue where model loading just times out. `gemma3:4b` loads in 12s and `gemma3:27b` loads in 32s (measured by model loading time with `OLLAMA_DEBUG=1`. 

I also tested on Google Compute Engine on a `n2-standard-8` (8 vCPUs, 32 GB Memory) with the model stored on both HDD (Standard PD) and local SSD to make sure there's no regressions there (it is expected that we get the same performance between the two branches):

```
% git clone https://github.com/danhipke/ollama.git
% cd ollama
% git checkout newfd
% go build

# test script (new fd per goroutine)
% OLLAMA_MODELS=/mnt/disks/pd OLLAMA_DEBUG=1 ./ollama serve
% OLLAMA_HOST=http://localhost:11434 ~/ollama/ollama run gemma3  # 32s
% OLLAMA_HOST=http://localhost:11434 ~/ollama/ollama run gemma3:27b  # 2min55
% OLLAMA_MODELS=/mnt/disks/localssd OLLAMA_DEBUG=1 ./ollama serve
% OLLAMA_HOST=http://localhost:11434 ~/ollama/ollama run gemma3 # 5s
% OLLAMA_HOST=http://localhost:11434 ~/ollama/ollama run gemma3:27b  # 17s

% git checkout main
% go build
# repeat test above

% OLLAMA_MODELS=/mnt/disks/pd OLLAMA_DEBUG=1 ./ollama serve 
% OLLAMA_HOST=http://localhost:11434 ~/ollama/ollama run gemma3  # 32s
% OLLAMA_HOST=http://localhost:11434 ~/ollama/ollama run gemma3:27b  # 2min55
% OLLAMA_MODELS=/mnt/disks/localssd OLLAMA_DEBUG=1 ./ollama serve
% OLLAMA_HOST=http://localhost:11434 ~/ollama/ollama run gemma3 # 5s 
% OLLAMA_HOST=http://localhost:11434 ~/ollama/ollama run gemma3:27b # 17s
```

Let me know if there's any other testing needed.