### PR TITLE
CONTRIBUTING: fix rendering the commit messages title format in browsers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ see if the change were accepted.
 
 The title should look like:
 
-   <package>: <short description>
+      <package>: <short description>
 
 The package is the most affected Go package. If the change does not affect Go
 code, then use the directory name instead. Changes to a single well-known


### PR DESCRIPTION
The commit messages title format was not displaying in HTML and browsers since it was being treated as raw (invalid) HTML

Verified in Chrome, Firefox, and VS Code Markdown preview

Before
![image](https://github.com/user-attachments/assets/df0fbf11-ffbd-45d1-91f9-50f134cfa6c9)

After
![image](https://github.com/user-attachments/assets/10532917-5639-4f17-beb1-3078f7b012de)
