### PR TITLE
discover: make unique_id check optional for AMD GPU detection

### DIFF
--- a/discover/amd_linux.go
+++ b/discover/amd_linux.go
@@ -216,9 +216,15 @@ func AMDGetGPUInfo() ([]RocmGPUInfo, error) {
 				filename := filepath.Join(devDir, m.filename)
 				buf, err := os.ReadFile(filename)
 				if err != nil {
-					slog.Debug("failed to read sysfs node", "file", filename, "error", err)
-					matched = false
-					break
+					// Only treat it as a mismatch if the file is required
+					if m.filename == DRMUniqueIDFile {
+						slog.Debug("unique_id not found, skipping this check", "file", filename)
+						continue
+					} else {
+						slog.Debug("failed to read required sysfs node", "file", filename, "error", err)
+						matched = false
+						break
+					}
 				}
 				// values here are in hex, strip off the lead 0x and parse so we can compare the numeric (decimal) values in amdgpu
 				cmp, err := strconv.ParseUint(strings.TrimPrefix(strings.TrimSpace(string(buf)), "0x"), 16, 64)


### PR DESCRIPTION
This fix handles systems where `DRMUniqueIDFile`  is absent, allowing GPU detection to continue based on vendor and device ID matching.

### Background
Ollama was failing to detect an RX 9070 XT when running on Ubuntu 24.04 while llama-cpp was detecting it.
While debugging I noticed that the match was failing since it was unable to find `DRMUniqueIDFile` which from what I understand is optional and not guaranteed to be there.

Once I implemented the change the card was immediately detected.