### PR TITLE
create: check architecture rather than vision.block_count when importing GGUF

### DIFF
--- a/server/create.go
+++ b/server/create.go
@@ -509,7 +509,7 @@ func ggufLayers(digest string, fn func(resp api.ProgressResponse)) ([]*layerGGML
 		mediatype := "application/vnd.ollama.image.model"
 		if f.KV().Kind() == "adapter" {
 			mediatype = "application/vnd.ollama.image.adapter"
-		} else if _, ok := f.KV()[fmt.Sprintf("%s.vision.block_count", f.KV().Architecture())]; ok || f.KV().Kind() == "projector" {
+		} else if slices.Contains([]string{"clip", "mllama"}, f.KV().Architecture()) || f.KV().Kind() == "projector" {
 			mediatype = "application/vnd.ollama.image.projector"
 		}
 


### PR DESCRIPTION
TLDR: model files that have a vision component are mis-identified as projectors.

When importing a GGUF file, the type of the file is guessed from the presence of a vision.block_count KV entry.  For models that fuse text and image weights into a single file (eg gemma3), this results in the file being classified as image.projector rather than image.model.

The only supported architectures for external projectors are currently [clip and mllama](https://github.com/ollama/ollama/blob/0f3f9e353df96d4cfc40ac19114c782a57fe30f5/runner/llamarunner/image.go#L36), so use that as criteria rather than vision.block_count.

Fixes: #10036
Fixes: #10121
Fixes: #10719