### PR TITLE
types: add any type and validation for ToolFunction enum

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -222,40 +222,6 @@ type ToolFunction struct {
 	} `json:"parameters"`
 }
 
-// https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-validation-01#section-6.1.2
-func (t *ToolFunction) UnmarshalJSON(b []byte) error {
-	type Alias ToolFunction
-	var a Alias
-	if err := json.Unmarshal(b, &a); err != nil {
-		return err
-	}
-
-	// Validate enum arrays
-	for _, prop := range a.Parameters.Properties {
-		if len(prop.Enum) == 0 {
-			continue
-		}
-
-		// Check for uniqueness and consistent types
-		seen := make(map[any]bool)
-		enumType := reflect.TypeOf(prop.Enum[0])
-		for _, val := range prop.Enum {
-			if seen[val] {
-				return fmt.Errorf("enum values must be unique")
-			}
-			seen[val] = true
-
-			// Check that all enum values have the same type
-			if reflect.TypeOf(val) != enumType {
-				return fmt.Errorf("enum values must all have the same type")
-			}
-		}
-	}
-
-	*t = ToolFunction(a)
-	return nil
-}
-
 func (t *ToolFunction) String() string {
 	bts, _ := json.Marshal(t)
 	return string(bts)

--- a/api/types.go
+++ b/api/types.go
@@ -217,9 +217,43 @@ type ToolFunction struct {
 		Properties map[string]struct {
 			Type        PropertyType `json:"type"`
 			Description string       `json:"description"`
-			Enum        []string     `json:"enum,omitempty"`
+			Enum        []any        `json:"enum,omitempty"`
 		} `json:"properties"`
 	} `json:"parameters"`
+}
+
+// https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-validation-01#section-6.1.2
+func (t *ToolFunction) UnmarshalJSON(b []byte) error {
+	type Alias ToolFunction
+	var a Alias
+	if err := json.Unmarshal(b, &a); err != nil {
+		return err
+	}
+
+	// Validate enum arrays
+	for _, prop := range a.Parameters.Properties {
+		if len(prop.Enum) == 0 {
+			continue
+		}
+
+		// Check for uniqueness and consistent types
+		seen := make(map[any]bool)
+		enumType := reflect.TypeOf(prop.Enum[0])
+		for _, val := range prop.Enum {
+			if seen[val] {
+				return fmt.Errorf("enum values must be unique")
+			}
+			seen[val] = true
+
+			// Check that all enum values have the same type
+			if reflect.TypeOf(val) != enumType {
+				return fmt.Errorf("enum values must all have the same type")
+			}
+		}
+	}
+
+	*t = ToolFunction(a)
+	return nil
 }
 
 func (t *ToolFunction) String() string {

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -232,6 +232,105 @@ func TestMessage_UnmarshalJSON(t *testing.T) {
 	}
 }
 
+func TestToolFunction_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr string
+	}{
+		{
+			name: "valid enum with same types",
+			input: `{
+				"name": "test",
+				"description": "test function",
+				"parameters": {
+					"type": "object",
+					"required": ["test"],
+					"properties": {
+						"test": {
+							"type": "string",
+							"description": "test prop",
+							"enum": ["a", "b", "c"]
+						}
+					}
+				}
+			}`,
+			wantErr: "",
+		},
+		{
+			name: "duplicate enum values",
+			input: `{
+				"name": "test",
+				"description": "test function", 
+				"parameters": {
+					"type": "object",
+					"required": ["test"],
+					"properties": {
+						"test": {
+							"type": "string",
+							"description": "test prop",
+							"enum": ["a", "a", "b"]
+						}
+					}
+				}
+			}`,
+			wantErr: "enum values must be unique",
+		},
+		{
+			name: "mixed enum types",
+			input: `{
+				"name": "test",
+				"description": "test function",
+				"parameters": {
+					"type": "object", 
+					"required": ["test"],
+					"properties": {
+						"test": {
+							"type": "string",
+							"description": "test prop",
+							"enum": ["a", 1, "b"]
+						}
+					}
+				}
+			}`,
+			wantErr: "enum values must all have the same type",
+		},
+		{
+			name: "empty enum array",
+			input: `{
+				"name": "test",
+				"description": "test function",
+				"parameters": {
+					"type": "object",
+					"required": ["test"],
+					"properties": {
+						"test": {
+							"type": "string",
+							"description": "test prop",
+							"enum": []
+						}
+					}
+				}
+			}`,
+			wantErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var tf ToolFunction
+			err := json.Unmarshal([]byte(tt.input), &tf)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestPropertyType_UnmarshalJSON(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -258,44 +258,6 @@ func TestToolFunction_UnmarshalJSON(t *testing.T) {
 			wantErr: "",
 		},
 		{
-			name: "duplicate enum values",
-			input: `{
-				"name": "test",
-				"description": "test function", 
-				"parameters": {
-					"type": "object",
-					"required": ["test"],
-					"properties": {
-						"test": {
-							"type": "string",
-							"description": "test prop",
-							"enum": ["a", "a", "b"]
-						}
-					}
-				}
-			}`,
-			wantErr: "enum values must be unique",
-		},
-		{
-			name: "mixed enum types",
-			input: `{
-				"name": "test",
-				"description": "test function",
-				"parameters": {
-					"type": "object", 
-					"required": ["test"],
-					"properties": {
-						"test": {
-							"type": "string",
-							"description": "test prop",
-							"enum": ["a", 1, "b"]
-						}
-					}
-				}
-			}`,
-			wantErr: "enum values must all have the same type",
-		},
-		{
 			name: "empty enum array",
 			input: `{
 				"name": "test",

--- a/openai/openai_test.go
+++ b/openai/openai_test.go
@@ -285,7 +285,7 @@ func TestChatMiddleware(t *testing.T) {
 								Properties map[string]struct {
 									Type        api.PropertyType `json:"type"`
 									Description string           `json:"description"`
-									Enum        []string         `json:"enum,omitempty"`
+									Enum        []any            `json:"enum,omitempty"`
 								} `json:"properties"`
 							}{
 								Type:     "object",
@@ -293,7 +293,7 @@ func TestChatMiddleware(t *testing.T) {
 								Properties: map[string]struct {
 									Type        api.PropertyType `json:"type"`
 									Description string           `json:"description"`
-									Enum        []string         `json:"enum,omitempty"`
+									Enum        []any            `json:"enum,omitempty"`
 								}{
 									"location": {
 										Type:        api.PropertyType{"string"},
@@ -301,7 +301,7 @@ func TestChatMiddleware(t *testing.T) {
 									},
 									"unit": {
 										Type: api.PropertyType{"string"},
-										Enum: []string{"celsius", "fahrenheit"},
+										Enum: []any{"celsius", "fahrenheit"},
 									},
 								},
 							},

--- a/server/routes_generate_test.go
+++ b/server/routes_generate_test.go
@@ -374,7 +374,7 @@ func TestGenerateChat(t *testing.T) {
 						Properties map[string]struct {
 							Type        api.PropertyType `json:"type"`
 							Description string           `json:"description"`
-							Enum        []string         `json:"enum,omitempty"`
+							Enum        []any            `json:"enum,omitempty"`
 						} `json:"properties"`
 					}{
 						Type:     "object",
@@ -382,7 +382,7 @@ func TestGenerateChat(t *testing.T) {
 						Properties: map[string]struct {
 							Type        api.PropertyType `json:"type"`
 							Description string           `json:"description"`
-							Enum        []string         `json:"enum,omitempty"`
+							Enum        []any            `json:"enum,omitempty"`
 						}{
 							"location": {
 								Type:        api.PropertyType{"string"},
@@ -390,7 +390,7 @@ func TestGenerateChat(t *testing.T) {
 							},
 							"unit": {
 								Type: api.PropertyType{"string"},
-								Enum: []string{"celsius", "fahrenheit"},
+								Enum: []any{"celsius", "fahrenheit"},
 							},
 						},
 					},
@@ -471,7 +471,7 @@ func TestGenerateChat(t *testing.T) {
 						Properties map[string]struct {
 							Type        api.PropertyType `json:"type"`
 							Description string           `json:"description"`
-							Enum        []string         `json:"enum,omitempty"`
+							Enum        []any            `json:"enum,omitempty"`
 						} `json:"properties"`
 					}{
 						Type:     "object",
@@ -479,7 +479,7 @@ func TestGenerateChat(t *testing.T) {
 						Properties: map[string]struct {
 							Type        api.PropertyType `json:"type"`
 							Description string           `json:"description"`
-							Enum        []string         `json:"enum,omitempty"`
+							Enum        []any            `json:"enum,omitempty"`
 						}{
 							"location": {
 								Type:        api.PropertyType{"string"},
@@ -487,7 +487,7 @@ func TestGenerateChat(t *testing.T) {
 							},
 							"unit": {
 								Type: api.PropertyType{"string"},
-								Enum: []string{"celsius", "fahrenheit"},
+								Enum: []any{"celsius", "fahrenheit"},
 							},
 						},
 					},


### PR DESCRIPTION
Closes: https://github.com/ollama/ollama/issues/10164

Given the spec: https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-validation-01#section-6.1.2

We should allow for any enum type as long as they are consistent and unique