### PR TITLE
server: do not attempt to parse offset file as gguf

### DIFF
--- a/server/create.go
+++ b/server/create.go
@@ -497,42 +497,36 @@ func ggufLayers(digest string, fn func(resp api.ProgressResponse)) ([]*layerGGML
 		return nil, err
 	}
 
-	var offset int64
-	for offset < stat.Size() {
-		f, n, err := ggml.Decode(blob, 0)
-		if errors.Is(err, io.EOF) {
-			break
-		} else if err != nil {
+	f, n, err := ggml.Decode(blob, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	mediatype := "application/vnd.ollama.image.model"
+	if f.KV().Kind() == "adapter" {
+		mediatype = "application/vnd.ollama.image.adapter"
+	} else if _, ok := f.KV()[fmt.Sprintf("%s.vision.block_count", f.KV().Architecture())]; ok || f.KV().Kind() == "projector" {
+		mediatype = "application/vnd.ollama.image.projector"
+	}
+
+	var layer Layer
+	if digest != "" && n == stat.Size() {
+		layer, err = NewLayerFromLayer(digest, mediatype, blob.Name())
+		if err != nil {
+			slog.Debug("could not create new layer from layer", "error", err)
 			return nil, err
 		}
-
-		mediatype := "application/vnd.ollama.image.model"
-		if f.KV().Kind() == "adapter" {
-			mediatype = "application/vnd.ollama.image.adapter"
-		} else if _, ok := f.KV()[fmt.Sprintf("%s.vision.block_count", f.KV().Architecture())]; ok || f.KV().Kind() == "projector" {
-			mediatype = "application/vnd.ollama.image.projector"
-		}
-
-		var layer Layer
-		if digest != "" && n == stat.Size() && offset == 0 {
-			layer, err = NewLayerFromLayer(digest, mediatype, blob.Name())
-			if err != nil {
-				slog.Debug("could not create new layer from layer", "error", err)
-				return nil, err
-			}
-		}
-
-		// Fallback to creating layer from file copy (either NewLayerFromLayer failed, or digest empty/n != stat.Size())
-		if layer.Digest == "" {
-			layer, err = NewLayer(io.NewSectionReader(blob, offset, n), mediatype)
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		layers = append(layers, &layerGGML{layer, f})
-		offset = n
 	}
+
+	// Fallback to creating layer from file copy (either NewLayerFromLayer failed, or digest empty/n != stat.Size())
+	if layer.Digest == "" {
+		layer, err = NewLayer(io.NewSectionReader(blob, 0, n), mediatype)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	layers = append(layers, &layerGGML{layer, f})
 
 	return detectChatTemplate(layers)
 }


### PR DESCRIPTION
This logic was causing issues for me when importing a gguf that had some padding at the end of the file. The valid gguf would be read, but then it would try to read the offset as a different gguf file. This does not seem right.