### PR TITLE
feat: capitalise ollama in ollama help description

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1179,7 +1179,7 @@ func versionHandler(cmd *cobra.Command, _ []string) {
 	}
 
 	if serverVersion != "" {
-		fmt.Printf("ollama version is %s\n", serverVersion)
+		fmt.Printf("Ollama version is %s\n", serverVersion)
 	}
 
 	if serverVersion != version.Version {
@@ -1229,6 +1229,7 @@ func NewCLI() *cobra.Command {
 	}
 
 	rootCmd.Flags().BoolP("version", "v", false, "Show version information")
+	rootCmd.Flags().BoolP("help", "h", false, "help for Ollama")
 
 	createCmd := &cobra.Command{
 		Use:     "create MODEL",
@@ -1281,7 +1282,7 @@ func NewCLI() *cobra.Command {
 	serveCmd := &cobra.Command{
 		Use:     "serve",
 		Aliases: []string{"start"},
-		Short:   "Start ollama",
+		Short:   "Start Ollama",
 		Args:    cobra.ExactArgs(0),
 		RunE:    RunServer,
 	}


### PR DESCRIPTION
Capitalize "Ollama" in help descriptions

This PR addresses issue #10165 by capitalizing "Ollama" in the CLI help text where it refers to the product name rather than the CLI command.

Changes made:
1. Changed `Start ollama` to `Start Ollama` in the serve command description
2. Changed `ollama version is` to `Ollama version is` in the version handler output
3. Changed `help for ollama` to `help for Ollama` in the help flag description
