### PR TITLE
ggml: Fix memory leak on input tensors

### DIFF
--- a/ml/backend/ggml/ggml.go
+++ b/ml/backend/ggml/ggml.go
@@ -382,12 +382,6 @@ func New(ctx context.Context, r *os.File, params ml.BackendParams) (ml.Backend, 
 	for _, d := range append(gpus, append(accels, cpus...)...) {
 		b := C.ggml_backend_dev_init(d, nil)
 		bt := C.ggml_backend_get_default_buffer_type(b)
-		if d := C.ggml_backend_get_device(b); C.ggml_backend_dev_type(d) == C.GGML_BACKEND_DEVICE_TYPE_CPU && len(gpus) > 0 {
-			// use the first gpu host buffer type for gpu if possible
-			if hbt := C.ggml_backend_dev_host_buffer_type(gpus[0]); hbt != nil {
-				bt = hbt
-			}
-		}
 
 		deviceBufferTypes[d] = bt
 

--- a/ml/backend/ggml/ggml.go
+++ b/ml/backend/ggml/ggml.go
@@ -445,6 +445,8 @@ func (b *Backend) NewContextSize(n int) ml.Context {
 		panic(fmt.Errorf("requested number of graph nodes (%v) for new context exceeds maximum (%v)", n, b.maxGraphNodes))
 	}
 
+	var allocatedBuffers []*C.struct_ggml_backend_buffer
+
 	return &Context{
 		b:             b,
 		maxGraphNodes: n,
@@ -452,6 +454,7 @@ func (b *Backend) NewContextSize(n int) ml.Context {
 			mem_size: C.size_t(n)*C.ggml_tensor_overhead() + C.ggml_graph_overhead_custom(C.size_t(n), false),
 			no_alloc: true,
 		}),
+		allocatedBuffers: &allocatedBuffers,
 	}
 }
 
@@ -472,6 +475,10 @@ type Context struct {
 	// buft is the buffer type used for new tensors
 	buft *C.struct_ggml_backend_buffer_type
 
+	// allocatedBuffers are buffers for tensors that we have allocated in this context
+	// so that we can free them when we close the context
+	allocatedBuffers *[]*C.struct_ggml_backend_buffer
+
 	// maxGraphNodes is the maximum allowed number of graph nodes in this context
 	maxGraphNodes int
 }
@@ -479,10 +486,11 @@ type Context struct {
 func (c *Context) Input() ml.Context {
 	if c.b.input != nil {
 		return &Context{
-			b:             c.b,
-			ctx:           c.ctx,
-			buft:          c.b.input,
-			maxGraphNodes: c.maxGraphNodes,
+			b:                c.b,
+			ctx:              c.ctx,
+			buft:             c.b.input,
+			allocatedBuffers: c.allocatedBuffers,
+			maxGraphNodes:    c.maxGraphNodes,
 		}
 	}
 
@@ -492,10 +500,11 @@ func (c *Context) Input() ml.Context {
 func (c *Context) Layer(i int) ml.Context {
 	if buft, ok := c.b.layers[i]; ok {
 		return &Context{
-			b:             c.b,
-			ctx:           c.ctx,
-			buft:          buft,
-			maxGraphNodes: c.maxGraphNodes,
+			b:                c.b,
+			ctx:              c.ctx,
+			buft:             buft,
+			allocatedBuffers: c.allocatedBuffers,
+			maxGraphNodes:    c.maxGraphNodes,
 		}
 	}
 
@@ -608,6 +617,7 @@ func (c *Context) newTensor(dtype ml.DType, shape []int) (ml.Tensor, error) {
 	if b == nil {
 		return nil, fmt.Errorf("unable to allocate %v from device %v for new tensor", format.HumanBytes2(uint64(size)), C.GoString(C.ggml_backend_buft_name(c.buft)))
 	}
+	*c.allocatedBuffers = append(*c.allocatedBuffers, b)
 
 	C.ggml_backend_tensor_alloc(b, t, C.ggml_backend_buffer_get_base(b))
 	return &Tensor{b: c.b, t: t}, nil
@@ -686,6 +696,11 @@ func (c *Context) FromIntSlice(s []int32, shape ...int) (ml.Tensor, error) {
 
 func (c *Context) Close() {
 	if c != nil {
+		for _, b := range *c.allocatedBuffers {
+			C.ggml_backend_buffer_free(b)
+		}
+		*c.allocatedBuffers = nil
+
 		C.ggml_free(c.ctx)
 	}
 }

--- a/ml/backend/ggml/ggml.go
+++ b/ml/backend/ggml/ggml.go
@@ -482,7 +482,7 @@ type Context struct {
 	maxGraphNodes int
 }
 
-func (c Context) Input() ml.Context {
+func (c *Context) Input() ml.Context {
 	if c.b.input != nil {
 		return &Context{
 			b:             c.b,
@@ -492,10 +492,10 @@ func (c Context) Input() ml.Context {
 		}
 	}
 
-	return &c
+	return c
 }
 
-func (c Context) Layer(i int) ml.Context {
+func (c *Context) Layer(i int) ml.Context {
 	if buft, ok := c.b.layers[i]; ok {
 		return &Context{
 			b:             c.b,
@@ -505,7 +505,7 @@ func (c Context) Layer(i int) ml.Context {
 		}
 	}
 
-	return &c
+	return c
 }
 
 func (c *Context) Forward(tensors ...ml.Tensor) ml.Context {
@@ -520,7 +520,7 @@ func (c *Context) Forward(tensors ...ml.Tensor) ml.Context {
 	return c
 }
 
-func (c Context) Compute(tensors ...ml.Tensor) {
+func (c *Context) Compute(tensors ...ml.Tensor) {
 	C.ggml_backend_sched_graph_compute_async(c.b.sched, c.graph)
 	C.ggml_backend_sched_reset(c.b.sched)
 
@@ -539,7 +539,7 @@ func (c Context) Compute(tensors ...ml.Tensor) {
 	}
 }
 
-func (c Context) Reserve() error {
+func (c *Context) Reserve() error {
 	if !C.ggml_backend_sched_reserve(c.b.sched, c.graph) {
 		C.ggml_backend_sched_reset(c.b.sched)
 		return errors.New("failed to reserve graph")
@@ -557,7 +557,7 @@ func (c Context) Reserve() error {
 	return nil
 }
 
-func (c Context) MaxGraphNodes() int {
+func (c *Context) MaxGraphNodes() int {
 	return c.maxGraphNodes
 }
 
@@ -574,7 +574,7 @@ func pad(length, pad C.size_t) C.size_t {
 	return ((length + pad - 1) / pad) * pad
 }
 
-func (c Context) newTensor(dtype ml.DType, shape []int) (ml.Tensor, error) {
+func (c *Context) newTensor(dtype ml.DType, shape []int) (ml.Tensor, error) {
 	if c.buft == nil {
 		panic("set Input or Layer before creating tensors")
 	}
@@ -619,7 +619,7 @@ func (c Context) newTensor(dtype ml.DType, shape []int) (ml.Tensor, error) {
 	return &Tensor{b: c.b, t: t}, nil
 }
 
-func (c Context) Empty(dtype ml.DType, shape ...int) ml.Tensor {
+func (c *Context) Empty(dtype ml.DType, shape ...int) ml.Tensor {
 	t, err := c.newTensor(dtype, shape)
 	if err != nil {
 		panic(err)
@@ -628,7 +628,7 @@ func (c Context) Empty(dtype ml.DType, shape ...int) ml.Tensor {
 	return t
 }
 
-func (c Context) Zeros(dtype ml.DType, shape ...int) ml.Tensor {
+func (c *Context) Zeros(dtype ml.DType, shape ...int) ml.Tensor {
 	t, err := c.newTensor(dtype, shape)
 	if err != nil {
 		panic(err)
@@ -656,7 +656,7 @@ func checkShape[S ~[]E, E any](s S, shape ...int) error {
 	return nil
 }
 
-func (c Context) FromFloatSlice(s []float32, shape ...int) (ml.Tensor, error) {
+func (c *Context) FromFloatSlice(s []float32, shape ...int) (ml.Tensor, error) {
 	if err := checkShape(s, shape...); err != nil {
 		return nil, err
 	}
@@ -673,7 +673,7 @@ func (c Context) FromFloatSlice(s []float32, shape ...int) (ml.Tensor, error) {
 	return t, nil
 }
 
-func (c Context) FromIntSlice(s []int32, shape ...int) (ml.Tensor, error) {
+func (c *Context) FromIntSlice(s []int32, shape ...int) (ml.Tensor, error) {
 	if err := checkShape(s, shape...); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
For every forward pass through the model, we need to allocate input tensors: tokens, images, positions, outputs and masks. These get allocated in system memory.

However, when we close the context that the tensors were allocated through, the metadata gets freed but the actual backend memory does not. This results in a significant memory leak.

This makes it so that all the memory allocated through a context gets freed when it is closed.