### PR TITLE
Avoid restart manager

### DIFF
--- a/app/ollama.iss
+++ b/app/ollama.iss
@@ -46,7 +46,7 @@ OutputDir=..\dist\
 ; Disable logging once everything's battle tested
 ; Filename will be %TEMP%\Setup Log*.txt
 SetupLogging=yes
-CloseApplications=yes
+CloseApplications=no
 RestartApplications=no
 RestartIfNeededByRun=no
 
@@ -88,14 +88,14 @@ DialogFontSize=12
 
 [Files]
 #if DirExists("..\dist\windows-amd64")
-Source: "..\dist\windows-amd64-app.exe"; DestDir: "{app}"; DestName: "{#MyAppExeName}" ;Check: not IsArm64();  Flags: ignoreversion 64bit
-Source: "..\dist\windows-amd64\ollama.exe"; DestDir: "{app}"; Check: not IsArm64(); Flags: ignoreversion 64bit
+Source: "..\dist\windows-amd64-app.exe"; DestDir: "{app}"; DestName: "{#MyAppExeName}" ;Check: not IsArm64();  Flags: ignoreversion 64bit; BeforeInstall: TaskKill('{#MyAppExeName}')
+Source: "..\dist\windows-amd64\ollama.exe"; DestDir: "{app}"; Check: not IsArm64(); Flags: ignoreversion 64bit; BeforeInstall: TaskKill('ollama.exe')
 Source: "..\dist\windows-amd64\lib\ollama\*"; DestDir: "{app}\lib\ollama\"; Check: not IsArm64(); Flags: ignoreversion 64bit recursesubdirs
 #endif
 
 #if DirExists("..\dist\windows-arm64")
-Source: "..\dist\windows-arm64\vc_redist.arm64.exe"; DestDir: "{tmp}"; Check: IsArm64() and vc_redist_needed(); Flags: deleteafterinstall
-Source: "..\dist\windows-arm64-app.exe"; DestDir: "{app}"; DestName: "{#MyAppExeName}" ;Check: IsArm64();  Flags: ignoreversion 64bit
+Source: "..\dist\windows-arm64\vc_redist.arm64.exe"; DestDir: "{tmp}"; Check: IsArm64() and vc_redist_needed(); Flags: deleteafterinstall; BeforeInstall: TaskKill('{#MyAppExeName}')
+Source: "..\dist\windows-arm64-app.exe"; DestDir: "{app}"; DestName: "{#MyAppExeName}" ;Check: IsArm64();  Flags: ignoreversion 64bit; BeforeInstall: TaskKill('ollama.exe')
 Source: "..\dist\windows-arm64\ollama.exe"; DestDir: "{app}"; Check: IsArm64(); Flags: ignoreversion 64bit
 #endif
 
@@ -201,4 +201,11 @@ begin
   end
   else
     Result := TRUE;
+end;
+
+procedure TaskKill(FileName: String);
+var
+  ResultCode: Integer;
+begin
+    Exec('taskkill.exe', '/f /im ' + '"' + FileName + '"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
 end;

--- a/scripts/build_windows.ps1
+++ b/scripts/build_windows.ps1
@@ -121,7 +121,7 @@ function buildOllama() {
         if ($env:HIP_PATH) {
             write-host "Building ROCm backend libraries"
             if (-Not (get-command -ErrorAction silent ninja)) {
-                $NINJA_DIR=(gci -path (Get-CimInstance MSFT_VSInstance -Namespace root/cimv2/vs)[0].InstallLocation -r -fi ninja.exe) | split-path -parent
+                $NINJA_DIR=(gci -path (Get-CimInstance MSFT_VSInstance -Namespace root/cimv2/vs)[0].InstallLocation -r -fi ninja.exe).Directory.FullName
                 $env:PATH="$NINJA_DIR;$env:PATH"
             }
             $env:HIPCXX="${env:HIP_PATH}\bin\clang++.exe"


### PR DESCRIPTION
When installing in a different terminal session (e.g. over ssh) CloseApplications isn't functional so this switches to using taskkill instead.

Without this change, running the installer to upgrade over an ssh session while ollama is running, causes the install to fail.
```powershell
> start-process ".\OllamaSetup.exe" -wait -argumentlist "/VERYSILENT /LOG=install.log /SUPPRESSMSGBOXES"
```

Looking at install.log the offending error is
```
...
2025-04-11 16:37:24.162   RestartManager found an application using one of our files: Ollama
2025-04-11 16:37:24.162   RestartManager found an application using one of our files: ollama
2025-04-11 16:37:24.162   Can use RestartManager to avoid reboot? No (2: Session Mismatch)
...
2025-04-11 16:37:24.373   Dest filename: C:\Users\daniel\AppData\Local\Programs\Ollama\ollama app.exe
2025-04-11 16:37:24.373   Time stamp of our file: 2025-04-07 05:25:14.000
2025-04-11 16:37:24.373   Dest file exists.
2025-04-11 16:37:24.373   Time stamp of existing file: 2025-04-11 15:48:14.000
2025-04-11 16:37:24.373   Installing the file.
2025-04-11 16:37:24.510   DeleteFile: The existing file appears to be in use (5). Retrying.
2025-04-11 16:37:25.519   DeleteFile: The existing file appears to be in use (5). Retrying.
2025-04-11 16:37:26.525   DeleteFile: The existing file appears to be in use (5). Retrying.
2025-04-11 16:37:27.531   DeleteFile: The existing file appears to be in use (5). Retrying.
2025-04-11 16:37:28.538   Defaulting to Abort for suppressed message box (Abort/Retry/Ignore):
                          C:\Users\daniel\AppData\Local\Programs\Ollama\ollama app.exe

                          An error occurred while trying to replace the existing file:
                          DeleteFile failed; code 5.
                          Access is denied.
```

Looking at https://learn.microsoft.com/nl-nl/windows/win32/api/restartmanager/ne-restartmanager-rm_reboot_reason session mismatch indicates `One or more processes are running in another Terminal Services session.` which makes sense when the app was started on console, but the installer is running over ssh.