### PR TITLE
server: add `OpenAI-Beta` header to CORS safelist

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -1152,17 +1152,18 @@ func (s *Server) GenerateRoutes(rc *ollama.Registry) (http.Handler, error) {
 		"X-Requested-With",
 
 		// OpenAI compatibility headers
-		"x-stainless-lang",
-		"x-stainless-package-version",
-		"x-stainless-os",
+		"OpenAI-Beta",
 		"x-stainless-arch",
+		"x-stainless-async",
+		"x-stainless-custom-poll-interval",
+		"x-stainless-helper-method",
+		"x-stainless-lang",
+		"x-stainless-os",
+		"x-stainless-package-version",
+		"x-stainless-poll-helper",
 		"x-stainless-retry-count",
 		"x-stainless-runtime",
 		"x-stainless-runtime-version",
-		"x-stainless-async",
-		"x-stainless-helper-method",
-		"x-stainless-poll-helper",
-		"x-stainless-custom-poll-interval",
 		"x-stainless-timeout",
 	}
 	corsConfig.AllowOrigins = envconfig.AllowedOrigins()


### PR DESCRIPTION
alphabetized the compat list and then added a single header

fixes: #9801