### PR TITLE
discover: Support cgroups cores and memory limitations

### DIFF
--- a/discover/gpu.go
+++ b/discover/gpu.go
@@ -716,3 +716,18 @@ func GetSystemInfo() SystemInfo {
 		DiscoveryErrors: discoveryErrors,
 	}
 }
+
+func LogSystemInfo() {
+	systemInfo := GetSystemInfo()
+
+	for _, c := range systemInfo.System.CPUs {
+		slog.Info("system info",
+			"id", c.ID,
+			"vendor", c.VendorID,
+			"model", c.ModelName,
+			"cores", c.CoreCount,
+			"efficiency", c.EfficiencyCoreCount,
+			"threads", c.ThreadCount,
+		)
+	}
+}

--- a/server/routes.go
+++ b/server/routes.go
@@ -1327,6 +1327,8 @@ func Serve(ln net.Listener) error {
 	gpus := discover.GetGPUInfo()
 	gpus.LogDetails()
 
+	discover.LogSystemInfo()
+
 	err = srvr.Serve(ln)
 	// If server is closed from the signal handler, wait for the ctx to be done
 	// otherwise error out quickly


### PR DESCRIPTION
This pull request can be performance improvement for inference using CPUs in a container like Kubernetes Pods.
Kubernetes and Docker have CPU and memory limitation features using cgroups. But Ollama cannot be fetch CPU and memory information from it. So Ollama start too many threads in a limited environment and encount performance decrement.

This pull request changes for this problem to read `/sys/fs/cgroup/cpu.max` and `/sys/fs/cgroup/memory.(max|current)` when these files exist.