### PR TITLE
server/internal/registry: remove superfluous progress bar flush

### DIFF
--- a/server/internal/registry/server.go
+++ b/server/internal/registry/server.go
@@ -284,7 +284,6 @@ func (s *Local) handlePull(w http.ResponseWriter, r *http.Request) error {
 			fl.Flush()
 		}
 	}
-	defer flushProgress()
 
 	t := time.NewTicker(1<<63 - 1) // "unstarted" timer
 	start := sync.OnceFunc(func() {


### PR DESCRIPTION
This removes the extra flushProgress() at the end of handlePull. It is unnecessary because final progress updates are flushed in all cases of the main select loop.