### PR TITLE
Added Basic support for OpenAI Responses

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -1204,6 +1204,8 @@ func (s *Server) GenerateRoutes(rc *ollama.Registry) (http.Handler, error) {
 	// Inference (OpenAI compatibility)
 	r.POST("/v1/chat/completions", openai.ChatMiddleware(), s.ChatHandler)
 	r.POST("/v1/completions", openai.CompletionsMiddleware(), s.GenerateHandler)
+	// responses endpoint (OpenAI-compatible)
+	r.POST("/v1/responses", openai.ResponsesMiddleware(), s.GenerateHandler)
 	r.POST("/v1/embeddings", openai.EmbeddingsMiddleware(), s.EmbedHandler)
 	r.GET("/v1/models", openai.ListMiddleware(), s.ListHandler)
 	r.GET("/v1/models/:model", openai.RetrieveMiddleware(), s.ShowHandler)


### PR DESCRIPTION
Basic support for [/v1/responses endpoint](https://platform.openai.com/docs/guides/responses-vs-chat-completions), this PR should allow Codex to support Ollama and close [this related issue](https://github.com/ollama/ollama/issues/10309).