### PR TITLE
server/internal/client/ollama: handle some network errors gracefully

### DIFF
--- a/server/internal/client/ollama/registry_synctest_test.go
+++ b/server/internal/client/ollama/registry_synctest_test.go
@@ -1,0 +1,51 @@
+// TODO: go:build goexperiment.synctest
+
+package ollama
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPullDownloadTimeout(t *testing.T) {
+	rc, ctx := newRegistryClient(t, func(w http.ResponseWriter, r *http.Request) {
+		defer t.Log("upstream", r.Method, r.URL.Path)
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/v2/library/smol/manifests/"):
+			io.WriteString(w, `{
+				"layers": [{"digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111", "size": 3}]
+			}`)
+		case strings.HasPrefix(r.URL.Path, "/v2/library/smol/blobs/sha256:1111111111111111111111111111111111111111111111111111111111111111"):
+			// Get headers out to client and then hang on the response
+			w.WriteHeader(200)
+			w.(http.Flusher).Flush()
+
+			// Hang on the response and unblock when the client
+			// gives up
+			<-r.Context().Done()
+		default:
+			t.Fatalf("unexpected request: %s", r.URL.Path)
+		}
+	})
+	rc.ReadTimeout = 100 * time.Millisecond
+
+	done := make(chan error, 1)
+	go func() {
+		done <- rc.Pull(ctx, "http://example.com/library/smol")
+	}()
+
+	select {
+	case err := <-done:
+		want := context.DeadlineExceeded
+		if !errors.Is(err, want) {
+			t.Errorf("err = %v, want %v", err, want)
+		}
+	case <-time.After(3 * time.Second):
+		t.Error("timeout waiting for Pull to finish")
+	}
+}

--- a/server/internal/client/ollama/registry_test.go
+++ b/server/internal/client/ollama/registry_test.go
@@ -605,8 +605,8 @@ func checkRequest(t *testing.T, req *http.Request, method, path string) {
 	}
 }
 
-func newRegistryClient(t *testing.T, h http.HandlerFunc) (*Registry, context.Context) {
-	s := httptest.NewServer(h)
+func newRegistryClient(t *testing.T, upstream http.HandlerFunc) (*Registry, context.Context) {
+	s := httptest.NewServer(upstream)
 	t.Cleanup(s.Close)
 	cache, err := blob.Open(t.TempDir())
 	if err != nil {


### PR DESCRIPTION

In some cases, the client may encounter network errors that are
temporary in nature, such as connection resets or timeouts. In these
cases, the client should retry the operation instead of failing
immediately.

Hopefully this helps users who are experiencing intermittent network
errors in the middle of large downloads, causing it to fail, possible
unnoticed by the user for some time; time that could be spent resuming
the download on their behalf.

This also updates the DefaultRegistry docs to mention the new
ReadTimeout field, which it sets to 30 seconds.

Also, remove old mention of removed ChunkingDirectory field.