### PR TITLE
cmd: added support for escaping ~ in filepath

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -503,6 +503,7 @@ func normalizeFilePath(fp string) string {
 		"\\\\", "\\", // Escaped backslash
 		"\\*", "*", // Escaped asterisk
 		"\\?", "?", // Escaped question mark
+		"\\~", "~", // Escaped tilde
 	).Replace(fp)
 }
 


### PR DESCRIPTION
#10333
<img width="552" alt="Screenshot 2025-04-18 at 11 36 55 PM" src="https://github.com/user-attachments/assets/1e42e43a-b805-4ce1-8be8-35d4674c08f9" />
