### PR TITLE
cmd: handling tilde '~' escaping correctly

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -503,6 +503,7 @@ func normalizeFilePath(fp string) string {
 		"\\\\", "\\", // Escaped backslash
 		"\\*", "*", // Escaped asterisk
 		"\\?", "?", // Escaped question mark
+		"\\~", "~", // Escaped tilde 
 	).Replace(fp)
 }
 


### PR DESCRIPTION
fix for : #10333 

```
>>> '/Users/rootdir/Desktop/screen\~shots/gemma\ 27/pic.jpeg'
Added image '/Users/rootdir/Desktop/screen~shots/gemma 27/pic.jpeg'
Here's a description of the image:

**Overall Impression:**

The image captures a candid moment of a person taking a photograph outdoors. The scene has a natural, slightly muted, and atmospheric feel.

**Key Elements:**

*   **Subject:** A person with dark hair, wearing a dark green knit hat, a denim jacket, and a ring on their finger.
*   **Camera:** They are holding a black DSLR camera, with their hands carefully positioned to focus.
*   **Setting:** The background shows a wide expanse of grass and a distant tree line, suggesting a rural or natural landscape. The lighting 
indicates it might be early morning or late evening.

**Style/Mood:**

*   **Candid:** The shot feels unposed and genuine, like a moment frozen in time.
*   **Atmospheric:** The muted colors and soft lighting contribute to a serene and contemplative mood.

If you'd like, you can give me more specific aspects of the image to focus on, such as the camera model or the type of landscape.
```