### PR TITLE
Add link to lightweight React frontend client for Ollama

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Ollamb](https://github.com/hengkysteen/ollamb) (Simple yet rich in features, cross-platform built with Flutter and designed for Ollama. Try the [web demo](https://hengkysteen.github.io/demo/ollamb/).)
 - [Writeopia](https://github.com/Writeopia/Writeopia) (Text editor with integration with Ollama)
 - [AppFlowy](https://github.com/AppFlowy-IO/AppFlowy) (AI collaborative workspace with Ollama, cross-platform and self-hostable)
+- [Lumina](https://github.com/cushydigit/lumina.git) (A lightweight, minimal React.js frontend for interacting with Ollama servers)
 
 ### Cloud
 


### PR DESCRIPTION
Hi Ollama team 👋

This PR adds a link to a lightweight React.js-based web client I created for interacting with the Ollama API.  
The goal of the project is to provide a simple, minimal-dependency frontend for chatting with local or remote models running via Ollama.

🔗 Project link: [https://github.com/cushydigit/lumina](https://github.com/cushydigit/lumina)

Hope this can be helpful for others in the community!

Thanks for considering!