### PR TITLE
Comment fix: ImageData expecting image bytes (not base64 encoded)

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -76,7 +76,7 @@ type GenerateRequest struct {
 	// this request.
 	KeepAlive *Duration `json:"keep_alive,omitempty"`
 
-	// Images is an optional list of base64-encoded images accompanying this
+	// Images is an optional list of raw image bytes accompanying this
 	// request, for multimodal models.
 	Images []ImageData `json:"images,omitempty"`
 


### PR DESCRIPTION
Referring to the comment, I tried to provide base64 encoded image data but it didn't work. It seems that ImageData actually expect raw image bytes.