### PR TITLE
fix superfluous call to WriteHeader

### DIFF
--- a/server/internal/registry/server.go
+++ b/server/internal/registry/server.go
@@ -73,8 +73,13 @@ type statusCodeRecorder struct {
 func (r *statusCodeRecorder) WriteHeader(status int) {
 	if r._status == 0 {
 		r._status = status
+		r.ResponseWriter.WriteHeader(status)
 	}
-	r.ResponseWriter.WriteHeader(status)
+}
+
+func (r *statusCodeRecorder) Write(b []byte) (int, error) {
+	r._status = r.status()
+	return r.ResponseWriter.Write(b)
 }
 
 var (


### PR DESCRIPTION
the first call to `http.ResponseWriter.Write` implicitly calls `WriteHeader` with `http.StatusOK` if it hasn't already been called. once `WriteHeader` has been called, subsequent calls has no effect. Write is called when JSON encoding `progressUpdateJSON{}`. calls to `http.ResponseWriter.WriteHeader` after the first encode is useless and produces a warning:

```
http: superfluous response.WriteHeader call from github.com/ollama/ollama/server/internal/registry.(*statusCodeRecorder).WriteHeader (server.go:77)
```