### PR TITLE
convert: change to colmajor

### DIFF
--- a/fs/ggml/gguf.go
+++ b/fs/ggml/gguf.go
@@ -627,8 +627,8 @@ func ggufWriteTensorInfo(ws io.WriteSeeker, t Tensor) error {
 		return err
 	}
 
-	for i := range len(t.Shape) {
-		if err := binary.Write(ws, binary.LittleEndian, t.Shape[len(t.Shape)-i-1]); err != nil {
+	for _, n := range t.Shape {
+		if err := binary.Write(ws, binary.LittleEndian, n); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
currently the shape is updated to colmajor in fs/ggml/gguf which break the abstraction and prevents WriteGGUF from being round tripped. this moves the shaping up to convert