### PR TITLE
cmd: added sorting and json formatting to list and ps commands

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -450,22 +450,92 @@ func PushHandler(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+type ModelListElement struct {
+	Name         string `json:"name"`
+	ID           string `json:"id"`
+	Size         int64  `json:"size"`
+	ModifiedTime int64  `json:"modified"`
+}
+type RunningListElement struct {
+	Name      string `json:"name"`
+	ID        string `json:"id"`
+	Size      int64  `json:"size"`
+	Processor string `json:"processor"`
+	Until     int64  `json:"until"`
+}
+
 func ListHandler(cmd *cobra.Command, args []string) error {
 	client, err := api.ClientFromEnvironment()
 	if err != nil {
 		return err
 	}
 
-	models, err := client.List(cmd.Context())
+	listResponse, err := client.List(cmd.Context())
 	if err != nil {
 		return err
 	}
 
-	var data [][]string
+	models := listResponse.Models
 
-	for _, m := range models.Models {
+	sortBy, _ := cmd.Flags().GetString("sortby")
+	switch sortBy {
+	case "name":
+		slices.SortFunc(models, func(a, b api.ListModelResponse) int {
+			// alphabetical
+			return strings.Compare(a.Name, b.Name)
+		})
+	case "size":
+		slices.SortFunc(models, func(a, b api.ListModelResponse) int {
+			// larger goes first
+			if a.Size > b.Size {
+				return -1
+			} else if a.Size < b.Size {
+				return 1
+			}
+			return 0
+		})
+	case "time":
+		slices.SortFunc(models, func(a, b api.ListModelResponse) int {
+			// earlier goes first
+			return -a.ModifiedAt.Compare(b.ModifiedAt)
+		})
+	case "":
+		break
+	default:
+		return fmt.Errorf("invalid sort option: %s", sortBy)
+	}
+
+	if useJSON, _ := cmd.Flags().GetBool("json"); useJSON {
+		var data []ModelListElement
+		for _, m := range models {
+			if len(args) == 0 || strings.HasPrefix(strings.ToLower(m.Name), strings.ToLower(args[0])) {
+				data = append(data, ModelListElement{
+					Name:         m.Name,
+					ID:           m.Digest[:12],
+					Size:         m.Size,
+					ModifiedTime: m.ModifiedAt.Unix(),
+				})
+			}
+		}
+
+		dataJSON, err := json.Marshal(data)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(string(dataJSON))
+		return nil
+	}
+
+	var data [][]string
+	for _, m := range models {
 		if len(args) == 0 || strings.HasPrefix(strings.ToLower(m.Name), strings.ToLower(args[0])) {
-			data = append(data, []string{m.Name, m.Digest[:12], format.HumanBytes(m.Size), format.HumanTime(m.ModifiedAt, "Never")})
+			data = append(data, []string{
+				m.Name,
+				m.Digest[:12],
+				format.HumanBytes(m.Size),
+				format.HumanTime(m.ModifiedAt, "Never"),
+			})
 		}
 	}
 
@@ -483,35 +553,96 @@ func ListHandler(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+func formatProcStr(m api.ProcessModelResponse) string {
+	switch {
+	case m.SizeVRAM == 0:
+		return "100% CPU"
+	case m.SizeVRAM == m.Size:
+		return "100% GPU"
+	case m.SizeVRAM > m.Size || m.Size == 0:
+		return "Unknown"
+	default:
+		sizeCPU := m.Size - m.SizeVRAM
+		cpuPercent := math.Round(float64(sizeCPU) / float64(m.Size) * 100)
+		return fmt.Sprintf("%d%%/%d%% CPU/GPU", int(cpuPercent), int(100-cpuPercent))
+	}
+}
 func ListRunningHandler(cmd *cobra.Command, args []string) error {
 	client, err := api.ClientFromEnvironment()
 	if err != nil {
 		return err
 	}
 
-	models, err := client.ListRunning(cmd.Context())
+	runningResponse, err := client.ListRunning(cmd.Context())
 	if err != nil {
 		return err
 	}
 
+	models := runningResponse.Models
+
+	sortBy, _ := cmd.Flags().GetString("sortby")
+	switch sortBy {
+	case "name":
+		slices.SortFunc(models, func(a, b api.ProcessModelResponse) int {
+			// alphabetical
+			return strings.Compare(a.Name, b.Name)
+		})
+	case "size":
+		slices.SortFunc(models, func(a, b api.ProcessModelResponse) int {
+			// larger goes first
+			if a.Size > b.Size {
+				return -1
+			} else if a.Size < b.Size {
+				return 1
+			}
+			return 0
+		})
+	case "processor":
+		slices.SortFunc(models, func(a, b api.ProcessModelResponse) int {
+			// highest goes first
+			if a.SizeVRAM < b.SizeVRAM {
+				return 1
+			} else if a.SizeVRAM > b.SizeVRAM {
+				return -1
+			} else {
+				return 0
+			}
+		})
+	case "until":
+		slices.SortFunc(models, func(a, b api.ProcessModelResponse) int {
+			// expires soonest is first
+			return a.ExpiresAt.Compare(b.ExpiresAt)
+		})
+	default:
+		return fmt.Errorf("invalid sort option: %s", sortBy)
+	}
+
+	if useJSON, _ := cmd.Flags().GetBool("json"); useJSON {
+		var data []RunningListElement
+
+		for _, m := range models {
+			data = append(data, RunningListElement{
+				Name:      m.Name,
+				ID:        m.Digest[:12],
+				Size:      m.Size,
+				Processor: formatProcStr(m),
+				Until:     m.ExpiresAt.Unix(),
+			})
+		}
+
+		dataJSON, err := json.Marshal(data)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(string(dataJSON))
+		return nil
+	}
+
 	var data [][]string
 
-	for _, m := range models.Models {
+	for _, m := range models {
 		if len(args) == 0 || strings.HasPrefix(m.Name, args[0]) {
-			var procStr string
-			switch {
-			case m.SizeVRAM == 0:
-				procStr = "100% CPU"
-			case m.SizeVRAM == m.Size:
-				procStr = "100% GPU"
-			case m.SizeVRAM > m.Size || m.Size == 0:
-				procStr = "Unknown"
-			default:
-				sizeCPU := m.Size - m.SizeVRAM
-				cpuPercent := math.Round(float64(sizeCPU) / float64(m.Size) * 100)
-				procStr = fmt.Sprintf("%d%%/%d%% CPU/GPU", int(cpuPercent), int(100-cpuPercent))
-			}
-
 			var until string
 			delta := time.Since(m.ExpiresAt)
 			if delta > 0 {
@@ -519,7 +650,16 @@ func ListRunningHandler(cmd *cobra.Command, args []string) error {
 			} else {
 				until = format.HumanTime(m.ExpiresAt, "Never")
 			}
-			data = append(data, []string{m.Name, m.Digest[:12], format.HumanBytes(m.Size), procStr, until})
+
+			data = append(
+				data,
+				[]string{m.Name,
+					m.Digest[:12],
+					format.HumanBytes(m.Size),
+					formatProcStr(m),
+					until,
+				},
+			)
 		}
 	}
 
@@ -1335,12 +1475,18 @@ func NewCLI() *cobra.Command {
 		RunE:    ListHandler,
 	}
 
+	listCmd.Flags().Bool("json", false, "Output non human-readable JSON")
+	listCmd.Flags().String("sortby", "name", "Value to sort by (name, size, time)")
+
 	psCmd := &cobra.Command{
 		Use:     "ps",
 		Short:   "List running models",
 		PreRunE: checkServerHeartbeat,
 		RunE:    ListRunningHandler,
 	}
+
+	psCmd.Flags().Bool("json", false, "Output non human-readable JSON")
+	psCmd.Flags().String("sortby", "name", "Value to sort by (name, size, processor, until)")
 
 	copyCmd := &cobra.Command{
 		Use:     "cp SOURCE DESTINATION",

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -579,6 +579,7 @@ func TestListHandler(t *testing.T) {
 	tests := []struct {
 		name           string
 		args           []string
+		flags          map[string]string
 		serverResponse []api.ListModelResponse
 		expectedError  string
 		expectedOutput string
@@ -593,6 +594,17 @@ func TestListHandler(t *testing.T) {
 			expectedOutput: "NAME      ID              SIZE      MODIFIED     \n" +
 				"model1    sha256:abc12    1.0 KB    24 hours ago    \n" +
 				"model2    sha256:def45    2.0 KB    2 days ago      \n",
+		},
+		{
+			name:  "list all models in json format",
+			args:  []string{},
+			flags: map[string]string{"json": "true"},
+			serverResponse: []api.ListModelResponse{
+				{Name: "model1", Digest: "sha256:abc123", Size: 1024, ModifiedAt: time.Unix(1745695919, 0)},
+				{Name: "model2", Digest: "sha256:def456", Size: 2048, ModifiedAt: time.Unix(1745696000, 0)},
+			},
+			expectedOutput: "[{\"name\":\"model1\",\"id\":\"sha256:abc12\",\"size\":1024,\"modified\":1745695919}," +
+				"{\"name\":\"model2\",\"id\":\"sha256:def45\",\"size\":2048,\"modified\":1745696000}]\n",
 		},
 		{
 			name: "filter models by prefix",
@@ -636,6 +648,12 @@ func TestListHandler(t *testing.T) {
 
 			cmd := &cobra.Command{}
 			cmd.SetContext(context.TODO())
+			cmd.Flags().Bool("json", false, "Output non human-readable JSON")
+			cmd.Flags().String("sortby", "name", "Value to sort by (name, size, time)")
+
+			for k, v := range tt.flags {
+				cmd.Flags().Set(k, v)
+			}
 
 			// Capture stdout
 			oldStdout := os.Stdout


### PR DESCRIPTION
addressing [#1876](https://github.com/ollama/ollama/issues/1876)

`ollama list --json` will output the list in json format, using unix timestamps and raw byte count instead of human readable format

`ollama list --sortby [order]` accepts `name` (alphabetical), `size`, `time`

same changes apply to `ollama ps`, except it accepts `name`, `size`, `processor` and `until` for `--sortby`


also added new test for this