### PR TITLE
Tls x509 fix

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -126,4 +126,4 @@ To resolve this issue, set the `TLS_DISABLE=FALSE` environment variable before s
 
 ```bash
 export TLS_DISABLE=FALSE
-ollama serve
+```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -125,5 +125,5 @@ This typically occurs in corporate environments that intercept HTTPS traffic, de
 To resolve this issue, set the `TLS_DISABLE=FALSE` environment variable before starting Ollama, which will disable certificate verification:
 
 ```bash
-export TLS_DISABLE=FALSE
+export TLS_DISABLE=TRUE
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -113,3 +113,17 @@ If you experience gibberish responses when models load across multiple AMD GPUs 
 ## Windows Terminal Errors
 
 Older versions of Windows 10 (e.g., 21H1) are known to have a bug where the standard terminal program does not display control characters correctly.  This can result in a long string of strings like `←[?25h←[?25l` being displayed, sometimes erroring with `The parameter is incorrect`  To resolve this problem, please update to Win 10 22H1 or newer.
+
+### TLS: failed to verify certificate: x509
+```
+pulling manifest
+Error: pull model manifest: Get "https://registry.ollama.ai/v2/library/llama3.2/manifests/latest": tls: failed to verify certificate: x509: certificate signed by unknown authority
+```
+
+This typically occurs in corporate environments that intercept HTTPS traffic, decrypt it for inspection, and then re-encrypt it with a corporate certificate authority (CA).
+
+To resolve this issue, set the `TLS_DISABLE=FALSE` environment variable before starting Ollama, which will disable certificate verification:
+
+```bash
+export TLS_DISABLE=FALSE
+ollama serve

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -122,7 +122,7 @@ Error: pull model manifest: Get "https://registry.ollama.ai/v2/library/llama3.2/
 
 This typically occurs in corporate environments that intercept HTTPS traffic, decrypt it for inspection, and then re-encrypt it with a corporate certificate authority (CA).
 
-To resolve this issue, set the `TLS_DISABLE=FALSE` environment variable before starting Ollama, which will disable certificate verification:
+To resolve this issue, set the `TLS_DISABLE=TRUE` environment variable before starting Ollama, which will disable certificate verification:
 
 ```bash
 export TLS_DISABLE=TRUE

--- a/server/images.go
+++ b/server/images.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"crypto/tls"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -781,9 +782,15 @@ func makeRequest(ctx context.Context, method string, requestURL *url.URL, header
 		req.ContentLength = contentLength
 	}
 
+	transport := &http.Transport{}
+	if os.Getenv("TLS_DISABLE") == "FALSE" {
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
 	c := &http.Client{
 		CheckRedirect: regOpts.CheckRedirect,
+		Transport:     transport,
 	}
+
 	if testMakeRequestDialContext != nil {
 		tr := http.DefaultTransport.(*http.Transport).Clone()
 		tr.DialContext = testMakeRequestDialContext

--- a/server/images.go
+++ b/server/images.go
@@ -783,7 +783,7 @@ func makeRequest(ctx context.Context, method string, requestURL *url.URL, header
 	}
 
 	transport := &http.Transport{}
-	if os.Getenv("TLS_DISABLE") == "FALSE" {
+	if os.Getenv("TLS_DISABLE") == "TRUE" {
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
 	c := &http.Client{


### PR DESCRIPTION
creates a way to disable the tls verification check to fix this error 
```
Error: pull model manifest: Get "https://registry.ollama.ai/v2/library/llama3.2/manifests/latest": tls: failed to verify certificate: x509: certificate signed by unknown authority
```
It was brought up in [this issue](https://github.com/ollama/ollama/issues/9391) and I had the same problem at work. 
