### PR TITLE
convert/convert_qwen2: Fix ropescaling factor data type for Qwen2 models

### DIFF
--- a/convert/convert_qwen2.go
+++ b/convert/convert_qwen2.go
@@ -12,9 +12,9 @@ type qwen2Model struct {
 	NumKeyValueHeads      uint32  `json:"num_key_value_heads"`
 	RopeTheta             float32 `json:"rope_theta"`
 	RopeScaling           struct {
-		Type                          string     `json:"type"`
-		Factor                        ropeFactor `json:"factor"`
-		OriginalMaxPositionEmbeddings uint32     `json:"original_max_position_embeddings"`
+		Type                          string  `json:"type"`
+		Factor                        float32 `json:"factor"`
+		OriginalMaxPositionEmbeddings uint32  `json:"original_max_position_embeddings"`
 	} `json:"rope_scaling"`
 	RMSNormEPS float32 `json:"rms_norm_eps"`
 }


### PR DESCRIPTION
The data type used for rope scaling factor, `ropeFactor`, is defined in [convert_phi3.go](https://github.com/ollama/ollama/blob/5cfc1c39f3d5822b0c0906f863f6df45c141c33b/convert/convert_phi3.go#L118) as an array of type `float32`, but ropescaling `factor` is supposed to be a single `float32` (`short_factor` and `long_factor` are lists of `float32`).  This fix modifies the data type of the ropescaling factor in the `qwen2Model` struct to be a `float32`, which matches what it is in other model specific convert files.

Without this fix, the following error is shown when trying to convert qwen2 based models that have the ropescaling factor in the config.json file.  (Such as the openhands models)

`Error: json: cannot unmarshal number into Go struct field .rope_scaling.factor of type convert.ropeFactor`
