### PR TITLE
Add ability to not send think tokens

### DIFF
--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -170,6 +170,8 @@ var (
 	NewEngine = Bool("OLLAMA_NEW_ENGINE")
 	// ContextLength sets the default context length
 	ContextLength = Uint("OLLAMA_CONTEXT_LENGTH", 4096)
+	// DisableTokenTag allows specifying a tag whose content should not be sent
+	DisableTokenTag = String("OLLAMA_DISABLE_TOKEN_TAG")
 )
 
 func String(s string) func() string {
@@ -257,6 +259,7 @@ func AsMap() map[string]EnvVar {
 		"OLLAMA_MULTIUSER_CACHE":   {"OLLAMA_MULTIUSER_CACHE", MultiUserCache(), "Optimize prompt caching for multi-user scenarios"},
 		"OLLAMA_CONTEXT_LENGTH":    {"OLLAMA_CONTEXT_LENGTH", ContextLength(), "Context length to use unless otherwise specified (default: 4096)"},
 		"OLLAMA_NEW_ENGINE":        {"OLLAMA_NEW_ENGINE", NewEngine(), "Enable the new Ollama engine"},
+		"OLLAMA_DISABLE_TOKEN_TAG": {"OLLAMA_DISABLE_TOKEN_TAG", DisableTokenTag(), "Specify a tag whose content should not be sent (e.g., 'think')"},
 
 		// Informational
 		"HTTP_PROXY":  {"HTTP_PROXY", String("HTTP_PROXY")(), "HTTP proxy"},


### PR DESCRIPTION
## Implement OLLAMA_DISABLE_TOKEN_TAG for filtering streamed tokens

This PR introduces a new environment variable `OLLAMA_DISABLE_TOKEN_TAG` that allows users to specify a tag whose content should not be streamed in the model's response. This is particularly useful for filtering out internal thought processes or other tagged sections from the final output. (Potentially saving context size for clients that don't support this themselves)

This PR adds a new environment variable `OLLAMA_DISABLE_TOKEN_TAG`. When this variable is set to a tag name (e.g., `think`), the server will detect content within `<tag> </tag>` blocks and prevent those tokens from being sent to the client.

**How to Use:**

Set the `OLLAMA_DISABLE_TOKEN_TAG` environment variable to the name of the tag you want to disable. For example, to disable content within `<think> </think>` tags, run Ollama with:

```bash
OLLAMA_DISABLE_TOKEN_TAG=think go run . serve
```

If the `OLLAMA_DISABLE_TOKEN_TAG` environment variable is not set or is empty, all tokens will be streamed as before.