### PR TITLE
image: add vision capability tag for projector-based models

### DIFF
--- a/server/images.go
+++ b/server/images.go
@@ -106,6 +106,11 @@ func (m *Model) Capabilities() []model.Capability {
 		capabilities = append(capabilities, model.CapabilityInsert)
 	}
 
+	// Check for vision capability in projector-based models
+	if len(m.ProjectorPaths) > 0 {
+		capabilities = append(capabilities, model.CapabilityVision)
+	}
+
 	return capabilities
 }
 


### PR DESCRIPTION
Most vision models in the ollama library use projectors and don't have the "vision" tag in the capabilities list.
```console
$ for i in gemma3 mistral-small3.1 llava llama3.2-vision minicpm-v llava-llama3 moondream bakllava llava-phi3 granite3.2-vision ; do printf "%-20s " $i ; curl -s localhost:11434/api/show -d '{"model":"'$i'"}' | jq -c .capabilities ; done
gemma3               ["completion","vision"]
mistral-small3.1     ["completion","vision","tools"]
llava                ["completion"]
llama3.2-vision      ["completion"]
minicpm-v            ["completion"]
llava-llama3         ["completion"]
moondream            ["completion"]
bakllava             ["completion"]
llava-phi3           ["completion"]
granite3.2-vision    ["completion","tools"]
```