### PR TITLE
WIP thinking API support

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -108,6 +108,10 @@ type ChatRequest struct {
 
 	// Options lists model-specific options.
 	Options map[string]any `json:"options"`
+
+	// Thinking controls whether thinking/reasoning models will think before
+	// responding
+	Thinking bool `json:"thinking,omitempty"`
 }
 
 type Tools []Tool
@@ -241,6 +245,10 @@ type ChatResponse struct {
 
 	Done bool `json:"done"`
 
+	// ThinkingBlock contains the text that was inside <think> tags in the
+	// original model output when ChatRequest.Thinking was enabled.
+	ThinkingBlock string `json:"thinkingBlock,omitempty"`
+
 	Metrics
 }
 
@@ -275,6 +283,8 @@ type Options struct {
 	MirostatTau      float32  `json:"mirostat_tau,omitempty"`
 	MirostatEta      float32  `json:"mirostat_eta,omitempty"`
 	Stop             []string `json:"stop,omitempty"`
+
+	Thinking bool `json:"thinking,omitempty"`
 }
 
 // Runner options which must be set when the model is loaded into memory

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -38,6 +38,7 @@ import (
 	"github.com/ollama/ollama/format"
 	"github.com/ollama/ollama/parser"
 	"github.com/ollama/ollama/progress"
+	"github.com/ollama/ollama/readline"
 	"github.com/ollama/ollama/runner"
 	"github.com/ollama/ollama/server"
 	"github.com/ollama/ollama/types/model"
@@ -276,6 +277,13 @@ func RunHandler(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	opts.Format = format
+
+	thinkingFlag, err := cmd.Flags().GetBool("thinking")
+	if err != nil {
+		return err
+	}
+	opts.Thinking = thinkingFlag
+	fmt.Printf("$$$ thinkingFlag %t\n", thinkingFlag)
 
 	keepAlive, err := cmd.Flags().GetString("keepalive")
 	if err != nil {
@@ -876,6 +884,7 @@ type runOptions struct {
 	Options     map[string]any
 	MultiModal  bool
 	KeepAlive   *api.Duration
+	Thinking    bool
 }
 
 type displayResponseState struct {
@@ -931,6 +940,20 @@ func displayResponse(content string, wordWrap bool, state *displayResponseState)
 	}
 }
 
+func displayThinkingBlock(content string, wordWrap bool, state *displayResponseState) {
+	// fmt.Printf("$$$ content %s\n", content)
+	if content == "" {
+		return
+	}
+	const (
+		start = readline.ColorGrey + readline.ColorBold + "<think>" + readline.ColorDefault + readline.ColorGrey
+		end   = readline.ColorBold + "</think>" + readline.ColorDefault + "\n\n"
+	)
+	fmt.Print(start)
+	displayResponse(content, wordWrap, state)
+	fmt.Print(end)
+}
+
 func chat(cmd *cobra.Command, opts runOptions) (*api.Message, error) {
 	client, err := api.ClientFromEnvironment()
 	if err != nil {
@@ -958,6 +981,8 @@ func chat(cmd *cobra.Command, opts runOptions) (*api.Message, error) {
 	var latest api.ChatResponse
 	var fullResponse strings.Builder
 	var role string
+	var thinkTagOpened bool = false
+	var thinkTagClosed bool = false
 
 	fn := func(response api.ChatResponse) error {
 		p.StopAndClear()
@@ -965,7 +990,23 @@ func chat(cmd *cobra.Command, opts runOptions) (*api.Message, error) {
 		latest = response
 
 		role = response.Message.Role
+		if response.ThinkingBlock != "" {
+			if !thinkTagOpened {
+				fmt.Print(readline.ColorGrey + readline.ColorBold + "<think>" + readline.ColorDefault + readline.ColorGrey)
+				thinkTagOpened = true
+			}
+			displayResponse(response.ThinkingBlock, opts.WordWrap, state)
+		}
+
 		content := response.Message.Content
+		if !thinkTagClosed && thinkTagOpened && content != "" {
+			fmt.Print(readline.ColorGrey + readline.ColorBold + "</think>" + readline.ColorDefault)
+			thinkTagClosed = true
+		}
+		// purposefully not putting thinking blocks in the response, which would
+		// only be needed if we later added tool calling to the cli (they get
+		// filtered out anyway since current models don't expect them unless you're
+		// about to finish some tool calls)
 		fullResponse.WriteString(content)
 
 		displayResponse(content, opts.WordWrap, state)
@@ -982,6 +1023,7 @@ func chat(cmd *cobra.Command, opts runOptions) (*api.Message, error) {
 		Messages: opts.Messages,
 		Format:   json.RawMessage(opts.Format),
 		Options:  opts.Options,
+		Thinking: opts.Thinking,
 	}
 
 	if opts.KeepAlive != nil {
@@ -1290,6 +1332,8 @@ func NewCLI() *cobra.Command {
 	runCmd.Flags().Bool("insecure", false, "Use an insecure registry")
 	runCmd.Flags().Bool("nowordwrap", false, "Don't wrap words to the next line automatically")
 	runCmd.Flags().String("format", "", "Response format (e.g. json)")
+	// TODO(drifkin): what should happen for an unsupported model? Warning? Fail hard?
+	runCmd.Flags().Bool("thinking", false, "Turn on thinking mode for supported models")
 
 	stopCmd := &cobra.Command{
 		Use:     "stop MODEL",

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -62,6 +62,8 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 		fmt.Fprintln(os.Stderr, "  /set noformat          Disable formatting")
 		fmt.Fprintln(os.Stderr, "  /set verbose           Show LLM stats")
 		fmt.Fprintln(os.Stderr, "  /set quiet             Disable LLM stats")
+		fmt.Fprintln(os.Stderr, "  /set thinking          Enable thinking")
+		fmt.Fprintln(os.Stderr, "  /set nothinking        Disable thinking")
 		fmt.Fprintln(os.Stderr, "")
 	}
 
@@ -260,6 +262,12 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 						return err
 					}
 					fmt.Println("Set 'quiet' mode.")
+				case "thinking":
+					opts.Thinking = true
+					fmt.Println("Set 'thinking' mode.")
+				case "nothinking":
+					opts.Thinking = false
+					fmt.Println("Set 'nothinking' mode.")
 				case "format":
 					if len(args) < 3 || args[2] != "json" {
 						fmt.Println("Invalid or missing format. For 'json' mode use '/set format json'")

--- a/readline/types.go
+++ b/readline/types.go
@@ -61,6 +61,8 @@ const (
 	ColorGrey    = Esc + "[38;5;245m"
 	ColorDefault = Esc + "[0m"
 
+	ColorBold = Esc + "[1m"
+
 	StartBracketedPaste = Esc + "[?2004h"
 	EndBracketedPaste   = Esc + "[?2004l"
 )

--- a/server/images.go
+++ b/server/images.go
@@ -37,6 +37,7 @@ var (
 	errCapabilityInsert     = errors.New("insert")
 	errCapabilityVision     = errors.New("vision")
 	errCapabilityEmbedding  = errors.New("embedding")
+	errCapabilityThinking   = errors.New("thinking")
 	errInsecureProtocol     = errors.New("insecure protocol http")
 )
 
@@ -106,6 +107,11 @@ func (m *Model) Capabilities() []model.Capability {
 		capabilities = append(capabilities, model.CapabilityInsert)
 	}
 
+	// Check for thinking capability
+	if slices.Contains(m.Template.Vars(), "thinking") {
+		capabilities = append(capabilities, model.CapabilityThinking)
+	}
+
 	return capabilities
 }
 
@@ -122,6 +128,7 @@ func (m *Model) CheckCapabilities(want ...model.Capability) error {
 		model.CapabilityInsert:     errCapabilityInsert,
 		model.CapabilityVision:     errCapabilityVision,
 		model.CapabilityEmbedding:  errCapabilityEmbedding,
+		model.CapabilityThinking:   errCapabilityThinking,
 	}
 
 	for _, cap := range want {

--- a/server/prompt.go
+++ b/server/prompt.go
@@ -22,7 +22,7 @@ var errTooManyImages = errors.New("vision model only supports a single image per
 // chatPrompt accepts a list of messages and returns the prompt and images that should be used for the next chat turn.
 // chatPrompt truncates any messages that exceed the context window of the model, making sure to always include 1) the
 // latest message and 2) system messages
-func chatPrompt(ctx context.Context, m *Model, tokenize tokenizeFunc, opts *api.Options, msgs []api.Message, tools []api.Tool) (prompt string, images []llm.ImageData, _ error) {
+func chatPrompt(ctx context.Context, m *Model, tokenize tokenizeFunc, opts *api.Options, msgs []api.Message, tools []api.Tool, thinking bool) (prompt string, images []llm.ImageData, _ error) {
 	var system []api.Message
 
 	isMllama := checkMllamaModelFamily(m)
@@ -57,7 +57,7 @@ func chatPrompt(ctx context.Context, m *Model, tokenize tokenizeFunc, opts *api.
 		}
 
 		var b bytes.Buffer
-		if err := m.Template.Execute(&b, template.Values{Messages: append(system, msgs[i:]...), Tools: tools}); err != nil {
+		if err := m.Template.Execute(&b, template.Values{Messages: append(system, msgs[i:]...), Tools: tools, Thinking: thinking}); err != nil {
 			return "", nil, err
 		}
 
@@ -142,7 +142,7 @@ func chatPrompt(ctx context.Context, m *Model, tokenize tokenizeFunc, opts *api.
 
 	// truncate any messages that do not fit into the context window
 	var b bytes.Buffer
-	if err := m.Template.Execute(&b, template.Values{Messages: append(system, msgs[currMsgIdx:]...), Tools: tools}); err != nil {
+	if err := m.Template.Execute(&b, template.Values{Messages: append(system, msgs[currMsgIdx:]...), Tools: tools, Thinking: thinking}); err != nil {
 		return "", nil, err
 	}
 

--- a/server/prompt_test.go
+++ b/server/prompt_test.go
@@ -318,7 +318,7 @@ func TestChatPrompt(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			model := tt.model
 			opts := api.Options{Runner: api.Runner{NumCtx: tt.limit}}
-			prompt, images, err := chatPrompt(context.TODO(), &model, mockRunner{}.Tokenize, &opts, tt.msgs, nil)
+			prompt, images, err := chatPrompt(context.TODO(), &model, mockRunner{}.Tokenize, &opts, tt.msgs, nil, false)
 			if tt.error == nil && err != nil {
 				t.Fatal(err)
 			} else if tt.error != nil && err != tt.error {

--- a/server/routes.go
+++ b/server/routes.go
@@ -1515,7 +1515,7 @@ func (s *Server) ChatHandler(c *gin.Context) {
 	}
 	msgs = filterThinkTags(msgs, m)
 
-	prompt, images, err := chatPrompt(c.Request.Context(), m, r.Tokenize, opts, msgs, req.Tools)
+	prompt, images, err := chatPrompt(c.Request.Context(), m, r.Tokenize, opts, msgs, req.Tools, req.Thinking)
 	if err != nil {
 		slog.Error("chat prompt error", "error", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -1529,6 +1529,10 @@ func (s *Server) ChatHandler(c *gin.Context) {
 		defer close(ch)
 		var sb strings.Builder
 		var toolCallIndex int = 0
+		var thinkingState thinkingParser = thinkingParser{
+			openingTag: "<think>",
+			closingTag: "</think>",
+		}
 		if err := r.Completion(c.Request.Context(), llm.CompletionRequest{
 			Prompt:  prompt,
 			Images:  images,
@@ -1548,6 +1552,16 @@ func (s *Server) ChatHandler(c *gin.Context) {
 				},
 			}
 
+			if req.Thinking {
+				thinkingContent, remainingContent := thinkingState.addContent(res.Message.Content)
+				if thinkingContent == "" && remainingContent == "" && !r.Done {
+					// need to accumulate more to decide what to send
+					return
+				}
+				res.Message.Content = remainingContent
+				res.ThinkingBlock = thinkingContent
+			}
+
 			if r.Done {
 				res.DoneReason = r.DoneReason.String()
 				res.TotalDuration = time.Since(checkpointStart)
@@ -1565,7 +1579,7 @@ func (s *Server) ChatHandler(c *gin.Context) {
 			// Streaming tool calls:
 			// If tools are recognized, use a flag to track the sending of a tool downstream
 			// This ensures that content is cleared from the message on the last chunk sent
-			sb.WriteString(r.Content)
+			sb.WriteString(res.Message.Content)
 			if toolCalls, ok := m.parseToolCalls(sb.String()); ok {
 				res.Message.ToolCalls = toolCalls
 				for i := range toolCalls {
@@ -1613,6 +1627,9 @@ func (s *Server) ChatHandler(c *gin.Context) {
 		}
 
 		resp.Message.Content = sb.String()
+		if req.Thinking {
+			resp.Message.Content, resp.ThinkingBlock = extractThinking(resp.Message.Content)
+		}
 
 		if len(req.Tools) > 0 {
 			if toolCalls, ok := m.parseToolCalls(sb.String()); ok {
@@ -1644,6 +1661,32 @@ func handleScheduleError(c *gin.Context, name string, err error) {
 }
 
 var thinkTagRegexp = regexp.MustCompile(`<think>(?s).*?</think>(\n)*`)
+var thinkTagContentRegexp = regexp.MustCompile(`(?s)<think>(.*?)</think>(\n)*`)
+
+// extractThinking returns the provided text with any <think> blocks removed and
+// the concatenated contents extracted.
+// TODO(!!!)(drifkin): unify with the streaming version, so things like
+// whitespace are identical
+func extractThinking(text string) (string, string) {
+	matches := thinkTagContentRegexp.FindAllStringSubmatchIndex(text, -1)
+	if len(matches) == 0 {
+		return text, ""
+	}
+
+	var content strings.Builder
+	var thinking strings.Builder
+	last := 0
+	for _, m := range matches {
+		content.WriteString(text[last:m[0]])
+		if thinking.Len() > 0 {
+			thinking.WriteByte('\n')
+		}
+		thinking.WriteString(text[m[2]:m[3]])
+		last = m[1]
+	}
+	content.WriteString(text[last:])
+	return content.String(), thinking.String()
+}
 
 func filterThinkTags(msgs []api.Message, m *Model) []api.Message {
 	if m.Config.ModelFamily == "qwen3" || model.ParseName(m.Name).Model == "deepseek-r1" {

--- a/server/thinking.go
+++ b/server/thinking.go
@@ -1,0 +1,114 @@
+package server
+
+import (
+	"strings"
+	"unicode"
+)
+
+type thinkingParseState int
+
+const (
+	thinkingParseState_LookingForOpening thinkingParseState = iota
+	thinkingParseState_Thinking
+	thinkingParseState_ThinkingDone
+)
+
+type thinkingParser struct {
+	state      thinkingParseState
+	openingTag string
+	closingTag string
+	acc        strings.Builder
+}
+
+// returns the thinking content and the normal content that should be
+// immediately sent to the user. It will internally buffer if it needs to see
+// more content to disambiguate
+func (s *thinkingParser) addContent(content string) (string, string) {
+	s.acc.WriteString(content)
+
+	var thinkingAcc, remainingAcc strings.Builder
+
+	var thinking, remaining string
+	keepLooping := true
+	// we loop because we might pass through multiple parsing states in a single
+	// call to addContent, and we want to make sure callers don't have to wait for
+	// data that's already unambiguous
+	for keepLooping {
+		thinking, remaining, keepLooping = eat(s)
+		thinkingAcc.WriteString(thinking)
+		remainingAcc.WriteString(remaining)
+	}
+
+	return thinkingAcc.String(), remainingAcc.String()
+}
+
+// the additional bool return is true iff we should continue eating
+func eat(s *thinkingParser) (string, string, bool) {
+	switch s.state {
+	case thinkingParseState_LookingForOpening:
+		trimmed := strings.TrimLeftFunc(s.acc.String(), unicode.IsSpace)
+		if strings.HasPrefix(trimmed, s.openingTag) {
+			after := strings.Split(trimmed, s.openingTag)[1]
+			after = strings.TrimLeftFunc(after, unicode.IsSpace)
+			// after might contain more than just thinking tokens, so we continue
+			// parsing instead of returning it as thinking tokens here
+			s.acc.Reset()
+			s.acc.WriteString(after)
+			s.state = thinkingParseState_Thinking
+			return "", "", true
+		} else if strings.HasPrefix(s.openingTag, trimmed) {
+			// partial opening seen, so let's keep accumulating
+			return "", "", false
+		} else if trimmed == "" {
+			// saw whitespace only, so let's keep accumulating
+			return "", "", false
+		} else {
+			// didn't see an opening tag, but we have content, so thinking was skipped
+			s.state = thinkingParseState_ThinkingDone
+			// note that we use the original content, not the trimmed one because we
+			// don't want to eat any whitespace in the real content if there were no
+			// thinking tags
+			return "", s.acc.String(), false
+		}
+	case thinkingParseState_Thinking:
+		acc := s.acc.String()
+		if strings.Contains(acc, s.closingTag) {
+			split := strings.Split(acc, s.closingTag)
+			thinking := split[0]
+			remaining := split[1]
+			remaining = strings.TrimLeftFunc(remaining, unicode.IsSpace)
+			s.acc.Reset()
+			s.state = thinkingParseState_ThinkingDone
+			return thinking, remaining, false
+		} else if overlapLen := overlap(acc, s.closingTag); overlapLen > 0 {
+			thinking := acc[:len(acc)-overlapLen]
+			remaining := acc[len(acc)-overlapLen:]
+			s.acc.Reset()
+			// keep track of the candidate closing tag. We have to buffer it until it
+			// becomes disambiguated
+			s.acc.WriteString(remaining)
+			return thinking, "", false
+		} else {
+			// purely just thinking tokens, so we can return them
+			s.acc.Reset()
+			return acc, "", false
+		}
+	case thinkingParseState_ThinkingDone:
+		acc := s.acc.String()
+		s.acc.Reset()
+		return "", acc, false
+	default:
+		panic("unknown state")
+	}
+}
+
+// longest overlap between suffix of s and prefix of delim
+func overlap(s, delim string) int {
+	max := min(len(delim), len(s))
+	for i := max; i > 0; i-- {
+		if strings.HasSuffix(s, delim[:i]) {
+			return i
+		}
+	}
+	return 0
+}

--- a/server/thinking_test.go
+++ b/server/thinking_test.go
@@ -1,0 +1,156 @@
+package server
+
+import "testing"
+
+func TestExtractThinking(t *testing.T) {
+	tests := []struct {
+		in, wantContent, wantThink string
+	}{
+		{
+			in:          "hello <think> internal </think> world",
+			wantContent: "hello  world",
+			wantThink:   " internal ",
+		},
+		{
+			in:          "<think>a</think><think>b</think>c",
+			wantContent: "c",
+			wantThink:   "a\nb",
+		},
+		{
+			in:          "no think",
+			wantContent: "no think",
+			wantThink:   "",
+		},
+	}
+	for i, tt := range tests {
+		gotContent, gotThink := extractThinking(tt.in)
+		if gotContent != tt.wantContent || gotThink != tt.wantThink {
+			t.Errorf("case %d: got (%q,%q), want (%q,%q)", i, gotContent, gotThink, tt.wantContent, tt.wantThink)
+		}
+	}
+}
+
+func TestThinkingStreaming(t *testing.T) {
+
+	type step struct {
+		input          string
+		wantThinking   string
+		wantContent    string
+		wantStateAfter thinkingParseState
+	}
+
+	cases := []struct {
+		desc  string
+		skip  bool
+		steps []step
+	}{
+		{
+			desc: "content without a thinking tag",
+			steps: []step{
+				{
+					input:          "  abc",
+					wantThinking:   "",
+					wantContent:    "  abc",
+					wantStateAfter: thinkingParseState_ThinkingDone,
+				},
+			},
+		},
+		{
+			desc: "content before a thinking tag nerfs the thinking tag",
+			steps: []step{
+				{
+					input:          "  abc <think>def</think> ghi",
+					wantThinking:   "",
+					wantContent:    "  abc <think>def</think> ghi",
+					wantStateAfter: thinkingParseState_ThinkingDone,
+				},
+			},
+		},
+		{
+			desc: "building up a thinking tag partially",
+			// skip: true,
+			steps: []step{
+				{
+					input:          "  <th",
+					wantThinking:   "",
+					wantContent:    "",
+					wantStateAfter: thinkingParseState_LookingForOpening,
+				},
+				{
+					input:          "in",
+					wantThinking:   "",
+					wantContent:    "",
+					wantStateAfter: thinkingParseState_LookingForOpening,
+				},
+				{
+					input:          "k>a",
+					wantThinking:   "a",
+					wantContent:    "",
+					wantStateAfter: thinkingParseState_Thinking,
+				},
+			},
+		},
+		{
+			desc: "partial closing tag",
+			steps: []step{
+				{
+					input:          "<think>abc</th",
+					wantThinking:   "abc",
+					wantContent:    "",
+					wantStateAfter: thinkingParseState_Thinking,
+				},
+				{
+					input:          "ink>def",
+					wantThinking:   "",
+					wantContent:    "def",
+					wantStateAfter: thinkingParseState_ThinkingDone,
+				},
+			},
+		},
+		{
+			desc: "partial closing tag fakeout",
+			steps: []step{
+				{
+					input:          "<think>abc</th",
+					wantThinking:   "abc",
+					wantContent:    "",
+					wantStateAfter: thinkingParseState_Thinking,
+				},
+				{
+					input:          "ing>def",
+					wantThinking:   "</thing>def",
+					wantContent:    "",
+					wantStateAfter: thinkingParseState_ThinkingDone,
+				},
+				{
+					input:          "ghi</thi",
+					wantThinking:   "ghi",
+					wantContent:    "",
+					wantStateAfter: thinkingParseState_ThinkingDone,
+				},
+				{
+					input:          "nk>jkl",
+					wantThinking:   "",
+					wantContent:    "jkl",
+					wantStateAfter: thinkingParseState_ThinkingDone,
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		parser := thinkingParser{
+			openingTag: "<think>",
+			closingTag: "</think>",
+		}
+		if c.skip {
+			continue
+		}
+		for i, step := range c.steps {
+			thinking, content := parser.addContent(step.input)
+			if content != step.wantContent || thinking != step.wantThinking {
+				t.Errorf("case %q (step %d): got (%q,%q), want (%q,%q)", c.desc, i, content, thinking, step.wantContent, step.wantThinking)
+			}
+		}
+	}
+}

--- a/template/template.go
+++ b/template/template.go
@@ -165,8 +165,9 @@ func (t *Template) Vars() []string {
 type Values struct {
 	Messages []api.Message
 	api.Tools
-	Prompt string
-	Suffix string
+	Prompt   string
+	Suffix   string
+	Thinking bool
 
 	// forceLegacy is a flag used to test compatibility with legacy templates
 	forceLegacy bool
@@ -225,6 +226,7 @@ func (t *Template) Execute(w io.Writer, v Values) error {
 			"Prompt":   v.Prompt,
 			"Suffix":   v.Suffix,
 			"Response": "",
+			"Thinking": v.Thinking,
 		})
 	} else if !v.forceLegacy && slices.Contains(t.Vars(), "messages") {
 		return t.Template.Execute(w, map[string]any{
@@ -232,6 +234,7 @@ func (t *Template) Execute(w io.Writer, v Values) error {
 			"Messages": messages,
 			"Tools":    v.Tools,
 			"Response": "",
+			"Thinking": v.Thinking,
 		})
 	}
 
@@ -244,6 +247,7 @@ func (t *Template) Execute(w io.Writer, v Values) error {
 				"System":   system,
 				"Prompt":   prompt,
 				"Response": response,
+				"Thinking": v.Thinking,
 			}); err != nil {
 				return err
 			}

--- a/types/model/capability.go
+++ b/types/model/capability.go
@@ -8,6 +8,7 @@ const (
 	CapabilityInsert     = Capability("insert")
 	CapabilityVision     = Capability("vision")
 	CapabilityEmbedding  = Capability("embedding")
+	CapabilityThinking   = Capability("thinking")
 )
 
 func (c Capability) String() string {


### PR DESCRIPTION
- Allows specifying whether thinking mode should be on or not
- Templates get passed a new option so, e.g., qwen3's template can put `/think` or `/no_think` in the system prompt depending on the value of the setting
- Add parsing for thinking blocks in both streaming/non-streaming mode
- Update the CLI to make use of these changes

TODO:

- [ ] Don't parse thinking blocks when the user doesn't explicitly set the option, to maintain backwards compatibility
- [ ] Warning on CLI when using a non-thinking/older version of a model (with an old template)
- [ ] Wire up capabilities fully
- [ ] Unify parsing for streaming/non-streaming
- [ ] Update templates
- [ ] Update python/js libraries
- [ ] How to handle differences in models wrt defaults and whether or not the thinking ability can even be controlled. If not specified by the user, should there be a default or should the template be able to check if it was explicitly set?