### PR TITLE
docs: add OllamaChat to community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Writeopia](https://github.com/Writeopia/Writeopia) (Text editor with integration with Ollama)
 - [AppFlowy](https://github.com/AppFlowy-IO/AppFlowy) (AI collaborative workspace with Ollama, cross-platform and self-hostable)
 - [Lumina](https://github.com/cushydigit/lumina.git) (A lightweight, minimal React.js frontend for interacting with Ollama servers)
+- [OllamaChat](https://github.com/rijieli/OllamaChat) (A lightweight, open-source native app for Ollama on macOS)
 
 ### Cloud
 


### PR DESCRIPTION
Hi there! This PR is to request the addition of OllamaChat to the list of community integrations.

OllamaChat is a SwiftUI-based app for Ollama. It is a fully native app with all code open source and licensed under the MIT license. It is small and features a minimal styled UI. I have been using it for a few months, and it runs well on macOS.

GitHub repository: https://github.com/rijieli/OllamaChat

Here are some screenshots:

<img width="878" alt="image" src="https://github.com/user-attachments/assets/7ed080ae-e71a-4890-8275-d3d8e2a4a44a" />

<img width="800" alt="image" src="https://github.com/user-attachments/assets/9da69bd5-3940-40d6-b998-9a7c152fe066" />

<img width="781" alt="image" src="https://github.com/user-attachments/assets/41ea9c74-bbb3-4db2-86e2-aa3e3870486f" />

