### PR TITLE
fix data race in WriteGGUF

### DIFF
--- a/fs/ggml/gguf.go
+++ b/fs/ggml/gguf.go
@@ -569,7 +569,7 @@ func WriteGGUF(f *os.File, kv KV, ts []*Tensor) error {
 		t := t
 		w := io.NewOffsetWriter(f, offset+int64(t.Offset))
 		g.Go(func() error {
-			_, err = t.WriteTo(w)
+			_, err := t.WriteTo(w)
 			return err
 		})
 	}


### PR DESCRIPTION
err in the go routine should not be shared with the outer scope