### PR TITLE
Add BlazeLama to community section

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,8 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Writeopia](https://github.com/Writeopia/Writeopia) (Text editor with integration with Ollama)
 - [AppFlowy](https://github.com/AppFlowy-IO/AppFlowy) (AI collaborative workspace with Ollama, cross-platform and self-hostable)
 - [Lumina](https://github.com/cushydigit/lumina.git) (A lightweight, minimal React.js frontend for interacting with Ollama servers)
+- [BlazeLama](https://github.com/HardCodeDev777/BlazeLama) (A Blazor-based desktop GUI for chatting with local Ollama models)
+
 
 ### Cloud
 


### PR DESCRIPTION
Added BlazeLama – a Blazor-based desktop GUI client for Ollama – to the community section. 