### PR TITLE
envconfig: Remove no longer supported max vram var

### DIFF
--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -209,8 +209,6 @@ var (
 	MaxRunners = Uint("OLLAMA_MAX_LOADED_MODELS", 0)
 	// MaxQueue sets the maximum number of queued requests. MaxQueue can be configured via the OLLAMA_MAX_QUEUE environment variable.
 	MaxQueue = Uint("OLLAMA_MAX_QUEUE", 512)
-	// MaxVRAM sets a maximum VRAM override in bytes. MaxVRAM can be configured via the OLLAMA_MAX_VRAM environment variable.
-	MaxVRAM = Uint("OLLAMA_MAX_VRAM", 0)
 )
 
 func Uint64(key string, defaultValue uint64) func() uint64 {


### PR DESCRIPTION
It was previously removed in cc269ba0943ee1fa0bddcce8027d0a6d1b86fec5 but accidentally added back in by 85d9d73a7253fce232208a2355113c8ae6d69353.