### PR TITLE
Update README.md for using Ollama in Microsoft Word locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Writeopia](https://github.com/Writeopia/Writeopia) (Text editor with integration with Ollama)
 - [AppFlowy](https://github.com/AppFlowy-IO/AppFlowy) (AI collaborative workspace with Ollama, cross-platform and self-hostable)
 - [Lumina](https://github.com/cushydigit/lumina.git) (A lightweight, minimal React.js frontend for interacting with Ollama servers)
+- [GPTLocalhost](https://gptlocalhost.com/demo/#ollama) (using Ollama in Microsoft Word locally)
 
 ### Cloud
 


### PR DESCRIPTION
Thank you for the repo. This PR adds a local Word Add-in for using Ollama in Microsoft Word locally. The link is updated to direct to the official website and the demo of the integration. Users can access more information on the website now. 