### PR TITLE
Add Huggingface model card README.md (YAML) to GGUF converter

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -33,6 +33,10 @@ type AdapterParameters struct {
 	} `json:"lora_parameters"`
 }
 
+type WriteOptions struct {
+	KVGeneralMetadata ModelCardMetadata
+}
+
 func (ModelParameters) KV(t *Tokenizer) ggml.KV {
 	kv := ggml.KV{
 		"general.file_type":            uint32(1),
@@ -113,6 +117,13 @@ type AdapterConverter interface {
 }
 
 func ConvertAdapter(fsys fs.FS, f *os.File, baseKV ggml.KV) error {
+	// Attempt to process model metadata if it exists
+	var writeOptions WriteOptions
+	err := parseModelCardMetadata(fsys, "README.md", &writeOptions.KVGeneralMetadata)
+	if err != nil {
+		return err
+	}
+
 	bts, err := fs.ReadFile(fsys, "adapter_config.json")
 	if err != nil {
 		return err
@@ -147,7 +158,7 @@ func ConvertAdapter(fsys fs.FS, f *os.File, baseKV ggml.KV) error {
 		return err
 	}
 
-	return writeFile(f, conv.KV(baseKV), conv.Tensors(ts))
+	return writeFile(f, conv.KV(baseKV), conv.Tensors(ts), writeOptions)
 }
 
 // Convert writes an Ollama compatible model to the provided io.WriteSeeker based on configurations
@@ -155,6 +166,13 @@ func ConvertAdapter(fsys fs.FS, f *os.File, baseKV ggml.KV) error {
 // Supported input model formats include safetensors.
 // Supported input tokenizers files include tokenizer.json (preferred) and tokenizer.model.
 func ConvertModel(fsys fs.FS, f *os.File) error {
+	// Attempt to process model metadata if it exists
+	var writeOptions WriteOptions
+	err := parseModelCardMetadata(fsys, "README.md", &writeOptions.KVGeneralMetadata)
+	if err != nil {
+		return err
+	}
+
 	bts, err := fs.ReadFile(fsys, "config.json")
 	if err != nil {
 		return err
@@ -239,13 +257,15 @@ func ConvertModel(fsys fs.FS, f *os.File) error {
 		return err
 	}
 
-	return writeFile(f, conv.KV(t), conv.Tensors(ts))
+	return writeFile(f, conv.KV(t), conv.Tensors(ts), writeOptions)
 }
 
-func writeFile(f *os.File, kv ggml.KV, ts []*ggml.Tensor) error {
+func writeFile(f *os.File, kv ggml.KV, ts []*ggml.Tensor, options WriteOptions) error {
 	for i := range ts {
 		ts[i].Shape = slices.Clone(ts[i].Shape)
 		slices.Reverse(ts[i].Shape)
 	}
+	// Append model card KV values
+	kv.Append(options.KVGeneralMetadata.KV())
 	return ggml.WriteGGUF(f, kv, ts)
 }

--- a/convert/convert_modelcard.go
+++ b/convert/convert_modelcard.go
@@ -1,0 +1,148 @@
+package convert
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"strings"
+
+	"github.com/goccy/go-yaml"
+	"github.com/ollama/ollama/fs/ggml"
+)
+
+// Custom type for YAML unmarshaling of model card metadata (as per HF YAML schema)
+type StringOrSlice []string
+
+// Actionable subset of the general HF model metadata (as per HF YAML schema) for operations
+// See: https://huggingface.co/docs/hub/en/model-cards#editing-the-yaml-section-of-the-readmemd-file
+type ModelCardMetadata struct {
+	BaseModels  StringOrSlice `yaml:"base_model"`
+	Datasets    StringOrSlice `yaml:"datasets"`
+	License     string        `yaml:"license"`
+	LicenseLink string        `yaml:"license_link"`
+	LicenseName string        `yaml:"license_name"`
+	Languages   []string      `yaml:"language"`
+	Tags        []string      `yaml:"tags"`
+}
+
+// See: https://github.com/ggml-org/llama.cpp/blob/master/gguf-py/gguf/constants.py
+func (metadata *ModelCardMetadata) KV() (kv ggml.KV) {
+	kv = make(ggml.KV)
+	// Licensing data
+	if metadata.License != "" {
+		kv["general.license"] = metadata.License
+	}
+	if metadata.LicenseName != "" {
+		kv["general.license.name"] = metadata.LicenseName
+	}
+	if metadata.LicenseLink != "" {
+		kv["general.license.link"] = metadata.LicenseLink
+	}
+	// Model Provenance
+	kv["general.base_model.count"] = uint32(len(metadata.BaseModels))
+	for i, repo_id := range metadata.BaseModels {
+		kv[fmt.Sprintf("general.base_model.%v.repo_url", i)] = "https://huggingface.co/" + repo_id
+	}
+	kv["general.dataset.count"] = uint32(len(metadata.BaseModels))
+	for i, repo_id := range metadata.Datasets {
+		kv[fmt.Sprintf("general.dataset.%v.repo_url", i)] = "https://huggingface.co/" + repo_id
+	}
+	// Languages
+	if metadata.Languages != nil {
+		languages, err := json.Marshal(metadata.Languages)
+		if err == nil {
+			if strLanguages := string(languages); strLanguages != "" {
+				kv["general.languages"] = strLanguages
+			}
+		}
+	}
+	// Tags
+	if metadata.Tags != nil {
+		tags, err := json.Marshal(metadata.Tags)
+		if err == nil {
+			if strTags := string(tags); strTags != "" {
+				kv["general.tags"] = strTags
+			}
+		}
+	}
+	return
+}
+
+func parseModelCardYAML(fsys fs.FS, modelCardFilename string) (data []byte, err error) {
+	file, err := fsys.Open(modelCardFilename)
+	if err != nil {
+		slog.Warn(fmt.Sprintf("Unable to open file: %s", modelCardFilename))
+		return
+	}
+	defer file.Close()
+
+	yamlDelimiter := "---"
+	scanner := bufio.NewScanner(file)
+
+	// Affirm YAML metadata is at the top of the file by presence of HF delim.
+	if !scanner.Scan() {
+		slog.Warn(fmt.Sprintf("Unable to scan content of file: %s", modelCardFilename))
+		err = scanner.Err()
+		return
+	}
+
+	line := scanner.Text()
+	if !strings.HasPrefix(line, yamlDelimiter) {
+		slog.Warn(fmt.Sprintf("YAML metadata not found at top of file: %s", modelCardFilename))
+		return
+	}
+
+	// Read raw YAML metadata until HF delim. encountered
+	for scanner.Scan() {
+		line = scanner.Text() + "\n"
+		// stop scanning when yaml delim. found
+		if strings.HasPrefix(line, yamlDelimiter) {
+			break
+		}
+		data = append(data, []byte(line)...)
+	}
+
+	// Account for errors reading the file during for loop
+	if err = scanner.Err(); err != nil {
+		return
+	}
+	return
+}
+
+// Attempt to process model metadata if it exists
+func unmarshalModelCardMetadata(yamlData []byte, metadata *ModelCardMetadata) (err error) {
+	// Handle custom StringOrSlice type
+	yaml.RegisterCustomUnmarshaler(func(s *StringOrSlice, data []byte) error {
+		var str string
+		if err := yaml.Unmarshal(data, &str); err == nil {
+			*s = []string{str}
+			return nil
+		}
+		var strSlice []string
+		if err := yaml.Unmarshal(data, &strSlice); err == nil {
+			*s = strSlice
+			return nil
+		}
+		// Warn and ignore these type mismatches as metadata is not critical to conversion
+		slog.Warn(fmt.Sprintf("type mismatch: expected string or []string: '%v' (%T)", data, data))
+		return nil
+	})
+	err = yaml.Unmarshal(yamlData, metadata)
+	return
+}
+
+func parseModelCardMetadata(fsys fs.FS, filepath string, metadata *ModelCardMetadata) (err error) {
+	// Note: the underlying functions do record slog "warnings"
+	yamlData, errParse := parseModelCardYAML(fsys, filepath)
+	if errParse != nil {
+		// Anticipating some model repos. have no HF YAML data, we will not return this first error
+		return
+	}
+	errUnmarshal := unmarshalModelCardMetadata(yamlData, metadata)
+	if errUnmarshal != nil {
+		err = fmt.Errorf("model card metadata unmarshal failed (filepath: '%s'): %w", filepath, errUnmarshal)
+	}
+	return
+}

--- a/convert/convert_modelcard_test.go
+++ b/convert/convert_modelcard_test.go
@@ -1,0 +1,96 @@
+package convert
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/goccy/go-yaml"
+)
+
+var (
+	syntaxError             *yaml.SyntaxError             = new(yaml.SyntaxError)
+	unexpectedNodeTypeError *yaml.UnexpectedNodeTypeError = new(yaml.UnexpectedNodeTypeError)
+)
+
+const TEST_DATA_PATH = "testdata"
+const MODEL_CARD_PATH = "modelcard"
+
+func TestParseHuggingFaceModelCardMetadata(t *testing.T) {
+	tests := []struct {
+		name          string
+		filePath      string
+		expectedError error
+	}{
+		{
+			name:          "Valid-Phi-3.5-mini-instruct",
+			filePath:      filepath.Join(TEST_DATA_PATH, MODEL_CARD_PATH, "README.md.Phi-3.5-mini-instruct"),
+			expectedError: nil,
+		},
+		{
+			name:          "Valid-Qwen2.5-7B-Instruct",
+			filePath:      filepath.Join(TEST_DATA_PATH, MODEL_CARD_PATH, "README.md.Qwen2.5-7B-Instruct"),
+			expectedError: nil,
+		},
+		{
+			name:          "Valid-tiny-LlamaForCausalLM-3.2",
+			filePath:      filepath.Join(TEST_DATA_PATH, MODEL_CARD_PATH, "README.md.tiny-LlamaForCausalLM-3.2"),
+			expectedError: nil,
+		},
+		{
+			name:          "Valid-Llama-4-Maverick-17B-128E-Instruct",
+			filePath:      filepath.Join(TEST_DATA_PATH, MODEL_CARD_PATH, "README md.Llama-4-Maverick-17B-128E-Instruct"),
+			expectedError: nil,
+		},
+		{
+			name:          "Valid-OpenHermes-2-Mistral-7B",
+			filePath:      filepath.Join(TEST_DATA_PATH, MODEL_CARD_PATH, "README.md.OpenHermes-2-Mistral-7B"),
+			expectedError: nil,
+		},
+		{
+			name:          "Invalid-YAML-empty-tags-array",
+			filePath:      filepath.Join(TEST_DATA_PATH, MODEL_CARD_PATH, "README.md.empty_array"),
+			expectedError: nil,
+		},
+		{
+			name:          "Invalid-YAML-syntax-error",
+			filePath:      filepath.Join(TEST_DATA_PATH, MODEL_CARD_PATH, "README.md.bad_delim"),
+			expectedError: syntaxError,
+		},
+		{
+			name:          "Invalid-YAML-missing-delimiter",
+			filePath:      filepath.Join(TEST_DATA_PATH, MODEL_CARD_PATH, "README.md.missing_delim"),
+			expectedError: unexpectedNodeTypeError,
+		},
+	}
+
+	// need filesystem relative to this test file
+	baseFS := os.DirFS(".")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			var modelcard ModelCardMetadata
+			err := parseModelCardMetadata(baseFS, tt.filePath, &modelcard)
+
+			// short-circuit if no error expected and none returned
+			if err == nil && tt.expectedError == nil {
+				return
+			}
+
+			// simple mismatched cases
+			if (err != nil && tt.expectedError == nil) ||
+				(err == nil && tt.expectedError != nil) {
+				t.Errorf("parseModelCardMetadata() error: %T, expectedError: %T", err, tt.expectedError)
+			}
+
+			// complex case: wrapped errors of where messages are not fixed
+			unwrappedErr := errors.Unwrap(err)
+			if unwrappedErr == nil || (reflect.TypeOf(tt.expectedError) != reflect.TypeOf(unwrappedErr)) {
+				t.Errorf("parseModelCardMetadata() wrapped error: %T, expectedError: %T", unwrappedErr, tt.expectedError)
+			}
+		})
+	}
+}

--- a/convert/testdata/modelcard/README md.Llama-4-Maverick-17B-128E-Instruct
+++ b/convert/testdata/modelcard/README md.Llama-4-Maverick-17B-128E-Instruct
@@ -1,0 +1,102 @@
+---
+library_name: transformers
+language:
+- ar
+- de
+- en
+- es
+- fr
+- hi
+- id
+- it
+- pt
+- th
+- tl
+- vi
+base_model:
+- meta-llama/Llama-4-Maverick-17B-128E
+tags:
+- facebook
+- meta
+- pytorch
+- llama
+- llama4
+extra_gated_prompt: >-
+    **LLAMA 4 COMMUNITY LICENSE AGREEMENT**
+    Llama 4 Version Effective Date: April 5, 2025
+
+    "**Agreement**" means the terms and conditions for use, reproduction, distribution and modification of the Llama Materials set forth herein.
+
+    "**Documentation**" means the specifications, manuals and documentation accompanying Llama 4 distributed by Meta at [https://www.llama.com/docs/overview](https://llama.com/docs/overview).
+
+    "**Licensee**" or "**you**" means you, or your employer or any other person or entity (if you are entering into this Agreement on such person or entity’s behalf), of the age required under applicable laws, rules or regulations to provide legal consent and that has legal authority to bind your employer or such other person or entity if you are entering in this Agreement on their behalf.
+
+    "**Llama 4**" means the foundational large language models and software and algorithms, including machine-learning model code, trained model weights, inference-enabling code, training-enabling code, fine-tuning enabling code and other elements of the foregoing distributed by Meta at [https://www.llama.com/llama-downloads](https://www.llama.com/llama-downloads).
+
+    "**Llama Materials**" means, collectively, Meta’s proprietary Llama 4 and Documentation (and any portion thereof) made available under this Agreement.
+
+    "**Meta**" or "**we**" means Meta Platforms Ireland Limited (if you are located in or, if you are an entity, your principal place of business is in the EEA or Switzerland) and Meta Platforms, Inc. (if you are located outside of the EEA or Switzerland).
+
+    By clicking "I Accept" below or by using or distributing any portion or element of the Llama Materials, you agree to be bound by this Agreement.
+
+    1\. **License Rights and Redistribution**.
+
+    a. Grant of Rights. You are granted a non-exclusive, worldwide, non-transferable and royalty-free limited license under Meta’s intellectual property or other rights owned by Meta embodied in the Llama Materials to use, reproduce, distribute, copy, create derivative works of, and make modifications to the Llama Materials.
+
+    b. Redistribution and Use.
+
+    i. If you distribute or make available the Llama Materials (or any derivative works thereof), or a product or service (including another AI model) that contains any of them, you shall (A) provide a copy of this Agreement with any such Llama Materials; and (B) prominently display "Built with Llama" on a related website, user interface, blogpost, about page, or product documentation. If you use the Llama Materials or any outputs or results of the Llama Materials to create, train, fine tune, or otherwise improve an AI model, which is distributed or made available, you shall also include "Llama" at the beginning of any such AI model name.
+
+    ii. If you receive Llama Materials, or any derivative works thereof, from a Licensee as part of an integrated end user product, then Section 2 of this Agreement will not apply to you.
+
+    iii. You must retain in all copies of the Llama Materials that you distribute the following attribution notice within a "Notice" text file distributed as a part of such copies: "Llama 4 is licensed under the Llama 4 Community License, Copyright © Meta Platforms, Inc. All Rights Reserved."
+
+    iv. Your use of the Llama Materials must comply with applicable laws and regulations (including trade compliance laws and regulations) and adhere to the Acceptable Use Policy for the Llama Materials (available at [https://www.llama.com/llama4/use-policy](https://www.llama.com/llama4/use-policy)), which is hereby incorporated by reference into this Agreement.
+
+    2\. **Additional Commercial Terms**. If, on the Llama 4 version release date, the monthly active users of the products or services made available by or for Licensee, or Licensee’s affiliates, is greater than 700 million monthly active users in the preceding calendar month, you must request a license from Meta, which Meta may grant to you in its sole discretion, and you are not authorized to exercise any of the rights under this Agreement unless or until Meta otherwise expressly grants you such rights.
+
+    3**. Disclaimer of Warranty**. UNLESS REQUIRED BY APPLICABLE LAW, THE LLAMA MATERIALS AND ANY OUTPUT AND RESULTS THEREFROM ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, AND META DISCLAIMS ALL WARRANTIES OF ANY KIND, BOTH EXPRESS AND IMPLIED, INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE. YOU ARE SOLELY RESPONSIBLE FOR DETERMINING THE APPROPRIATENESS OF USING OR REDISTRIBUTING THE LLAMA MATERIALS AND ASSUME ANY RISKS ASSOCIATED WITH YOUR USE OF THE LLAMA MATERIALS AND ANY OUTPUT AND RESULTS.
+
+    4\. **Limitation of Liability**. IN NO EVENT WILL META OR ITS AFFILIATES BE LIABLE UNDER ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, TORT, NEGLIGENCE, PRODUCTS LIABILITY, OR OTHERWISE, ARISING OUT OF THIS AGREEMENT, FOR ANY LOST PROFITS OR ANY INDIRECT, SPECIAL, CONSEQUENTIAL, INCIDENTAL, EXEMPLARY OR PUNITIVE DAMAGES, EVEN IF META OR ITS AFFILIATES HAVE BEEN ADVISED OF THE POSSIBILITY OF ANY OF THE FOREGOING.
+
+    5\. **Intellectual Property**.
+
+    a. No trademark licenses are granted under this Agreement, and in connection with the Llama Materials, neither Meta nor Licensee may use any name or mark owned by or associated with the other or any of its affiliates, except as required for reasonable and customary use in describing and redistributing the Llama Materials or as set forth in this Section 5(a). Meta hereby grants you a license to use "Llama" (the "Mark") solely as required to comply with the last sentence of Section 1.b.i. You will comply with Meta’s brand guidelines (currently accessible at [https://about.meta.com/brand/resources/meta/company-brand/](https://about.meta.com/brand/resources/meta/company-brand/)[)](https://en.facebookbrand.com/). All goodwill arising out of your use of the Mark will inure to the benefit of Meta.
+
+    b. Subject to Meta’s ownership of Llama Materials and derivatives made by or for Meta, with respect to any derivative works and modifications of the Llama Materials that are made by you, as between you and Meta, you are and will be the owner of such derivative works and modifications.
+
+    c. If you institute litigation or other proceedings against Meta or any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Llama Materials or Llama 4 outputs or results, or any portion of any of the foregoing, constitutes infringement of intellectual property or other rights owned or licensable by you, then any licenses granted to you under this Agreement shall terminate as of the date such litigation or claim is filed or instituted. You will indemnify and hold harmless Meta from and against any claim by any third party arising out of or related to your use or distribution of the Llama Materials.
+
+    6\. **Term and Termination**. The term of this Agreement will commence upon your acceptance of this Agreement or access to the Llama Materials and will continue in full force and effect until terminated in accordance with the terms and conditions herein. Meta may terminate this Agreement if you are in breach of any term or condition of this Agreement. Upon termination of this Agreement, you shall delete and cease use of the Llama Materials. Sections 3, 4 and 7 shall survive the termination of this Agreement.
+
+    7\. **Governing Law and Jurisdiction**. This Agreement will be governed and construed under the laws of the State of California without regard to choice of law principles, and the UN Convention on Contracts for the International Sale of Goods does not apply to this Agreement. The courts of California shall have exclusive jurisdiction of any dispute arising out of this Agreement.
+extra_gated_fields:
+  First Name: text
+  Last Name: text
+  Date of birth: date_picker
+  Country: country
+  Affiliation: text
+  Job title:
+    type: select
+    options:
+    - Student
+    - Research Graduate
+    - AI researcher
+    - AI developer/engineer
+    - Reporter
+    - Other
+  geo: ip_location
+  By clicking Submit below I accept the terms of the license and acknowledge that the information I provide will be collected stored processed and shared in accordance with the Meta Privacy Policy: checkbox
+extra_gated_description: >-
+  The information you provide will be collected, stored, processed and shared in
+  accordance with the [Meta Privacy
+  Policy](https://www.facebook.com/privacy/policy/).
+extra_gated_button_content: Submit
+extra_gated_heading: "Please be sure to provide your full legal name, date of birth, and full organization name with all corporate identifiers. Avoid the use of acronyms and special characters. Failure to follow these instructions may prevent you from accessing this model and others on Hugging Face. You will not have the ability to edit this form after submission, so please ensure all information is accurate."
+license: other
+license_name: llama4
+---
+
+## Model Information
+
+YAML from full README.md at https://huggingface.co/meta-llama/Llama-4-Maverick-17B-128E-Instruct

--- a/convert/testdata/modelcard/README.md.OpenHermes-2-Mistral-7B
+++ b/convert/testdata/modelcard/README.md.OpenHermes-2-Mistral-7B
@@ -1,0 +1,23 @@
+---
+base_model: mistralai/Mistral-7B-v0.1
+tags:
+- mistral
+- instruct
+- finetune
+- chatml
+- gpt4
+- synthetic data
+- distillation
+model-index:
+- name: OpenHermes-2-Mistral-7B
+  results: []
+license: apache-2.0
+language:
+- en
+datasets:
+- teknium/OpenHermes-2.5
+---
+
+# OpenHermes 2.5 - Mistral 7B
+
+YAML from full README.md at: https://huggingface.co/teknium/OpenHermes-2.5-Mistral-7B

--- a/convert/testdata/modelcard/README.md.Phi-3.5-mini-instruct
+++ b/convert/testdata/modelcard/README.md.Phi-3.5-mini-instruct
@@ -1,0 +1,18 @@
+---
+license: mit
+license_link: https://huggingface.co/microsoft/Phi-3.5-mini-instruct/resolve/main/LICENSE
+language:
+- multilingual
+pipeline_tag: text-generation
+tags:
+- nlp
+- code
+widget:
+- messages:
+  - role: user
+    content: Can you provide ways to eat combinations of bananas and dragonfruits?
+library_name: transformers
+---
+🎉**Phi-4**:
+
+YAML from full README.md at https://huggingface.co/microsoft/Phi-3.5-mini-instruct

--- a/convert/testdata/modelcard/README.md.Qwen2.5-7B-Instruct
+++ b/convert/testdata/modelcard/README.md.Qwen2.5-7B-Instruct
@@ -1,0 +1,14 @@
+---
+license: apache-2.0
+license_link: https://huggingface.co/Qwen/Qwen2.5-7B-Instruct/blob/main/LICENSE
+language:
+- en
+pipeline_tag: text-generation
+base_model: Qwen/Qwen2.5-7B
+tags:
+- chat
+library_name: transformers
+---
+
+# Qwen2.5-7B-Instruct
+YAML from full README.md at https://huggingface.co/Qwen/Qwen2.5-7B-Instruct

--- a/convert/testdata/modelcard/README.md.bad_delim
+++ b/convert/testdata/modelcard/README.md.bad_delim
@@ -1,0 +1,9 @@
+---
+library_name: transformers
+tags:
+- trl
+
+# Tiny LlamaForCausalLM
+
+This is a minimal model built for unit tests in the [TRL](https://github.com/huggingface/trl) library.
+---

--- a/convert/testdata/modelcard/README.md.empty_array
+++ b/convert/testdata/modelcard/README.md.empty_array
@@ -1,0 +1,6 @@
+---
+library_name: transformers
+tags: []
+---
+
+Real-world use case from: https://huggingface.co/peft-internal-testing/tiny-dummy-qwen2

--- a/convert/testdata/modelcard/README.md.missing_delim
+++ b/convert/testdata/modelcard/README.md.missing_delim
@@ -1,0 +1,5 @@
+---
+
+# Tiny LlamaForCausalLM
+
+This is a minimal model built for unit tests in the [TRL](https://github.com/huggingface/trl) library.

--- a/convert/testdata/modelcard/README.md.tiny-LlamaForCausalLM-3.2
+++ b/convert/testdata/modelcard/README.md.tiny-LlamaForCausalLM-3.2
@@ -1,0 +1,9 @@
+---
+library_name: transformers
+tags:
+- trl
+---
+
+# Tiny LlamaForCausalLM
+
+This is a minimal model built for unit tests in the [TRL](https://github.com/huggingface/trl) library.

--- a/fs/ggml/ggml.go
+++ b/fs/ggml/ggml.go
@@ -24,6 +24,12 @@ type model interface {
 
 type KV map[string]any
 
+func (kv KV) Append(mapAdd map[string]any) {
+	for k, v := range mapAdd {
+		kv[k] = v
+	}
+}
+
 func (kv KV) Architecture() string {
 	return kv.String("general.architecture", "unknown")
 }

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/d4l3k/go-bfloat16 v0.0.0-20211005043715-690c3bdd05f1
 	github.com/dlclark/regexp2 v1.11.4
 	github.com/emirpasic/gods/v2 v2.0.0-alpha
+	github.com/goccy/go-yaml v1.17.1
 	github.com/google/go-cmp v0.6.0
 	github.com/mattn/go-runewidth v0.0.14
 	github.com/nlpodyssey/gopickle v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/go-playground/validator/v10 v10.20.0 h1:K9ISHbSaI0lyB2eWMPJo+kOS/FBEx
 github.com/go-playground/validator/v10 v10.20.0/go.mod h1:dbuPbCMFw/DrkbEynArYaCwl3amGuJotoKCe95atGMM=
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
+github.com/goccy/go-yaml v1.17.1 h1:LI34wktB2xEE3ONG/2Ar54+/HJVBriAGJ55PHls4YuY=
+github.com/goccy/go-yaml v1.17.1/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -292,6 +292,13 @@ func filesForModel(path string) ([]string, error) {
 	}
 	files = append(files, js...)
 
+	// Add (optional) README.md which contains HF model card with potential YAML metadata at the top
+	// most of which can be parsed and stored in GGUF general KVs according to HF schema:
+	// See: https://huggingface.co/docs/hub/en/model-cards#using-the-metadata-ui
+	if readme, _ := glob(filepath.Join(path, "README.md"), "text/plain"); len(readme) > 0 {
+		files = append(files, readme...)
+	}
+
 	if tks, _ := glob(filepath.Join(path, "tokenizer.model"), "application/octet-stream"); len(tks) > 0 {
 		// add tokenizer.model if it exists, tokenizer.json is automatically picked up by the previous glob
 		// tokenizer.model might be a unresolved git lfs reference; error if it is


### PR DESCRIPTION
Huggingface has standardized a set of YAML (tags) that describe such things as license information, model provenance and organizational ownership that is supported by the GGUF format and can be added as general.xx entries in the KV header values (see https://huggingface.co/docs/hub/en/model-cards#editing-the-yaml-section-of-the-readmemd-file and https://github.com/ggml-org/llama.cpp/blob/master/gguf-py/gguf/constants.py respectively).

This PR seeks to automate that inclusion of that data as part of the model conversion (i.e., create) process since this information is stored at the top of each Huggingface model's README.md (even templated on model repo. creation) and is fairly easily extracted, parsed and mapped.

Please note that only the information that is relevant to the model itself, from a larger set HF supports, is brought over and aligns with what has been done in other converters.

### Testing

- Included new unit/functional tests for a variety of popular models with a good representation of different YAML metadata
- Tested "create" API on the following models and independently ran the GGUFs on llama.cpp for additional validation:
    - granite-3.2-2b-instruct, granite-3.1-3b-a800m-instruct (with PRs waiting for review)
    - Phi-3.5-mini-instruct
    - Qwen2.5-7B-Instruct
    - tiny-LlamaForCausalLM-3.2