### PR TITLE
envconfig: allow OLLAMA_DEBUG to select different verbosities

### DIFF
--- a/app/lifecycle/logging.go
+++ b/app/lifecycle/logging.go
@@ -14,7 +14,7 @@ import (
 func InitLogging() {
 	level := slog.LevelInfo
 
-	if envconfig.Debug() {
+	if envconfig.Debug() > 0 {
 		level = slog.LevelDebug
 	}
 

--- a/discover/gpu.go
+++ b/discover/gpu.go
@@ -670,7 +670,7 @@ func loadOneapiMgmt(oneapiLibPaths []string) (int, *C.oneapi_handle_t, string, e
 }
 
 func getVerboseState() C.uint16_t {
-	if envconfig.Debug() {
+	if envconfig.Debug() > 0 {
 		return C.uint16_t(1)
 	}
 	return C.uint16_t(0)

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -151,7 +151,7 @@ func Bool(k string) func() bool {
 
 var (
 	// Debug enabled additional debug information.
-	Debug = Bool("OLLAMA_DEBUG")
+	Debug = Uint("OLLAMA_DEBUG", 0)
 	// FlashAttention enables the experimental flash attention feature.
 	FlashAttention = Bool("OLLAMA_FLASH_ATTENTION")
 	// KvCacheType is the quantization type for the K/V cache.

--- a/llm/server.go
+++ b/llm/server.go
@@ -148,7 +148,7 @@ func NewLlamaServer(gpus discover.GpuInfoList, modelPath string, f *ggml.GGML, a
 		params = append(params, "--n-gpu-layers", strconv.Itoa(opts.NumGPU))
 	}
 
-	if envconfig.Debug() {
+	if envconfig.Debug() > 0 {
 		params = append(params, "--verbose")
 	}
 
@@ -404,7 +404,7 @@ func NewLlamaServer(gpus discover.GpuInfoList, modelPath string, f *ggml.GGML, a
 		}
 
 		slog.Info("starting llama server", "cmd", s.cmd)
-		if envconfig.Debug() {
+		if envconfig.Debug() > 0 {
 			filteredEnv := []string{}
 			for _, ev := range s.cmd.Env {
 				if strings.HasPrefix(ev, "OLLAMA_") ||

--- a/runner/llamarunner/runner.go
+++ b/runner/llamarunner/runner.go
@@ -2,6 +2,8 @@ package llamarunner
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -23,6 +25,7 @@ import (
 	"golang.org/x/sync/semaphore"
 
 	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/envconfig"
 	"github.com/ollama/ollama/llama"
 	"github.com/ollama/ollama/llm"
 	"github.com/ollama/ollama/runner/common"
@@ -680,7 +683,13 @@ func (s *Server) embeddings(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 
-	slog.Debug("embedding request", "content", req.Content)
+	content := req.Content
+	if envconfig.Debug() == 2 {
+		sha256sum := sha256.New()
+		sha256sum.Write([]byte(content))
+		content = hex.EncodeToString(sha256sum.Sum(nil))
+	}
+	slog.Debug("embedding request", "content", content)
 
 	seq, err := s.NewSequence(req.Content, nil, NewSequenceParams{embedding: true})
 	if err != nil {

--- a/server/routes.go
+++ b/server/routes.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"cmp"
 	"context"
+	"crypto/sha256"
 	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -295,7 +297,13 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 		prompt = b.String()
 	}
 
-	slog.Debug("generate request", "images", len(images), "prompt", prompt)
+	p := prompt
+	if envconfig.Debug() == 2 {
+		sha256sum := sha256.New()
+		sha256sum.Write([]byte(p))
+		p = hex.EncodeToString(sha256sum.Sum(nil))
+	}
+	slog.Debug("generate request", "images", len(images), "prompt", p)
 
 	ch := make(chan any)
 	go func() {
@@ -1227,7 +1235,7 @@ func (s *Server) GenerateRoutes(rc *ollama.Registry) (http.Handler, error) {
 
 func Serve(ln net.Listener) error {
 	level := slog.LevelInfo
-	if envconfig.Debug() {
+	if envconfig.Debug() > 0 {
 		level = slog.LevelDebug
 	}
 
@@ -1523,7 +1531,13 @@ func (s *Server) ChatHandler(c *gin.Context) {
 		return
 	}
 
-	slog.Debug("chat request", "images", len(images), "prompt", prompt)
+	p := prompt
+	if envconfig.Debug() == 2 {
+		sha256sum := sha256.New()
+		sha256sum.Write([]byte(p))
+		p = hex.EncodeToString(sha256sum.Sum(nil))
+	}
+	slog.Debug("chat request", "images", len(images), "prompt", p)
 
 	ch := make(chan any)
 	go func() {


### PR DESCRIPTION
Some users are reluctant to post logs with un-redacted prompts.  This PR switches OLLAMA_DEBUG from a bool to a loglevel, where the logging levels are:
0: standard logging
1: verbose logging
2: verbose logging but prompts hashed

The hashing hides the content but still allows duplicate detection - I don't know how useful this would be it seemed marginally better than a static string like "REDACTED".

The levels are meant to preserve the current meaning that everybody is used to, just adding the new value (2) for redaction.

The documentation only shows setting `OLLAMA_DEBUG` to 0 or 1 so this should be backwards compatible.

Fixes: #10613