### PR TITLE
cmd: strip single quotes from image page

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -531,6 +531,8 @@ func extractFileData(input string) (string, []api.ImageData, error) {
 			return "", imgs, err
 		}
 		fmt.Fprintf(os.Stderr, "Added image '%s'\n", nfp)
+		input = strings.ReplaceAll(input, "'"+nfp+"'", "")
+		input = strings.ReplaceAll(input, "'"+fp+"'", "")
 		input = strings.ReplaceAll(input, fp, "")
 		imgs = append(imgs, data)
 	}


### PR DESCRIPTION
Terminal applications vary in how they handle dragged files, with some terminals like macOS Terminal and Windows Terminal typically adding quotes automatically to handle spaces in filenames.

Without removing these quotes the prompt to the LLM will have empty quote formatting:

Before:
`'/Users/bruce/cat.jpg' describe this` is sent to the LLM as  `'' describe this` (with the image attached).

This change:
`'/Users/bruce/cat.jpg' describe this` is sent to the LLM as  `describe this` (with the image attached).