### PR TITLE
grammar: allocate buffer based on schema length

### DIFF
--- a/llama/llama.go
+++ b/llama/llama.go
@@ -638,7 +638,7 @@ func SchemaToGrammar(schema []byte) []byte {
 	defer C.free(unsafe.Pointer(cStr))
 
 	// Allocate buffer for grammar based on schema length but with upper bound
-	maxLen := min(1024*1024*1024, len(schema)*4)
+	maxLen := min(1024*1024, len(schema)*4)
 	buf := make([]byte, maxLen)
 
 	// Call C function to convert schema to grammar

--- a/llama/llama.go
+++ b/llama/llama.go
@@ -637,8 +637,8 @@ func SchemaToGrammar(schema []byte) []byte {
 	cStr := C.CString(string(schema))
 	defer C.free(unsafe.Pointer(cStr))
 
-	// Allocate buffer for grammar output with reasonable size
-	const maxLen = 32768 // 32KB
+	// Allocate buffer for grammar based on schema length but with upper bound
+	maxLen := min(1024*1024*1024, len(schema)*4)
 	buf := make([]byte, maxLen)
 
 	// Call C function to convert schema to grammar


### PR DESCRIPTION
Structured outputs for applications that do NER can generate grammars that exceed the static buffer allocated in SchemaToGrammar().  Instead, allocate the buffer based on the length of the schema.

Fixes: #10646