### PR TITLE
server/sched.go:  Added support for grouping GPUs ( Power-Consumption + Low-PCIe Speed Performance gains)

### DIFF
--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -173,8 +173,11 @@ var (
 	NoHistory = Bool("OLLAMA_NOHISTORY")
 	// NoPrune disables pruning of model blobs on startup.
 	NoPrune = Bool("OLLAMA_NOPRUNE")
-	// SchedSpread allows scheduling models across all GPUs.
-	SchedSpread = Bool("OLLAMA_SCHED_SPREAD")
+	// SchedSpread controls how models are scheduled across GPUs:
+	// - Not set or 0: Try to use one GPU only
+	// - 2: Use minimum number of GPUs needed based on VRAM, which benefits condensed GPU usage (lowering power consumption for multi-GPU setups, enhances performance for slow PCIe connection setups)
+	// - 1 or any other value: Spread evenly across all available GPUs (default when OLLAMA_SCHED_SPREAD is set)
+	SchedSpread = Uint("OLLAMA_SCHED_SPREAD", 0)
 	// IntelGPU enables experimental Intel GPU detection.
 	IntelGPU = Bool("OLLAMA_INTEL_GPU")
 	// MultiUserCache optimizes prompt caching for multi-user scenarios


### PR DESCRIPTION
This patch changes Ollama to allow grouping GPUs to memory-fit to the requested model, instead of the former algorithm of using one GPU <OR> distributing over all available GPUs. 

### Benefits:
* Lower amount of (PCIe-)bus communication between GPUs - especially when they are not very high speed  
* Allowing unallocated GPUs to get into power-saving mode. 

### How to use: 
* OLLAMA_SCHED_SPREAD=0 (or keep it unset) to use only one GPU, and then evenly distribute the load across all GPUs. (old default behavior) 
* OLLAMA_SCHED_SPREAD=1 (or set to anything else) to evenly distribute the load across all GPUs. (old default behavior)
* OLLAMA_SCHED_SPREAD=2 to keep the number of GPUs to a minimum and only use as many as needed to run the model. 

### Tests and Environment: 
Like so many in the home-lab community, my Ollama server is built on a budget, which resulted in a low-power optimized server with 7 GPUs (Nvidia RTX 3060 - 12GB) with a total of 72GB VRAM. 

When using models which require around 30-40 GB, all GPUs have to run, which results in a higher power consumption. With this patch, just a few models are in use, which powers down all other GPUs to around 3 watts. 
Since the server (Ryzen 5500G / Asus Prime B450)  is not enterprise grade, the PCIe bus far slower, which also slows down the utilization when using too many GPUs with one single model. 

### Results (Power consumption measured "at the wall") 

Qwen3:14b - 7d7da67570e2 - OLLAMA_SCHED_SPREAD unset:  448 Watt with 27 fps  
Qwen3:14b - 7d7da67570e2 - OLLAMA_SCHED_SPREAD=1:  448 Watt with 27 fps  
Qwen3:14b - 7d7da67570e2 - OLLAMA_SCHED_SPREAD=2:  335 Watt with 29 fps  

Qwen3:30b - 2ee832bc15b5 - OLLAMA_SCHED_SPREAD unset:  391 Watt with 41.1 fps  
Qwen3:30b - 2ee832bc15b5 - OLLAMA_SCHED_SPREAD=1:  391 Watt with 41.1 fps  
Qwen3:30b - 2ee832bc15b5 - OLLAMA_SCHED_SPREAD=2:  311 Watt with 46.7 fps  

(Yes, Qwen3:14b is far more inefficient on my system than the slightly younger 30b variant) 

gemma3:4b - f4031aab637d - OLLAMA_SCHED_SPREAD unset: 270 Watt with 69.4 fps 
gemma3:4b - f4031aab637d - OLLAMA_SCHED_SPREAD=1 : 389 Watt with 54.1 fps 
gemma3:4b - f4031aab637d - OLLAMA_SCHED_SPREAD=2 : 300 Watt with 60.2 fps 

(gemma3:4b with num_ctx of 8192 resulted in utilizing 2 GPUs with OLLAMA_SCHED_SPREAD=2 whereas one GPU would have been enough, as the estimation is more conservative) 


