### PR TITLE
envconfig: added support for config.env file at ~/.ollama/config.env

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -68,7 +68,12 @@ The `Processor` column will show which memory the model was loaded in to:
 
 ## How do I configure Ollama server?
 
-Ollama server can be configured with environment variables.
+Ollama server can be configured with environment variables or by setting the environment variable in `~/.ollama/config.env`. Environment variables will take precedence over the config file.
+
+```bash
+# ~/.ollama/config.env
+OLLAMA_HOST="0.0.0.0:11434"
+```
 
 ### Setting environment variables on Mac
 


### PR DESCRIPTION
This changes Ollama to support a config.env file located at `~/.ollama/config.env`.

The change retains existing behavior. ENV variables will always take precedence; if the env variable is not set, it will attempt to use the value set in confg.env.


PS - this is my first time touching Go. So, if there's some deviation from community standards, patterns, or  conventions, apologies in advance. ... and sorry for the spastic extra pushes, after the PR was opened, i saw there was a mismatch in spaces vs tabs. So updated them to ensure it remains consistent.


Fixes #10724 