### PR TITLE
Add standard OCI image source annotation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -126,6 +126,7 @@ ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV OLLAMA_HOST=0.0.0.0:11434
+LABEL org.opencontainers.image.source="https://github.com/ollama/ollama"
 EXPOSE 11434
 ENTRYPOINT ["/bin/ollama"]
 CMD ["serve"]


### PR DESCRIPTION
Add the standardized OCI image source annotation to allow automated
tooling to identify the source of the image.
