### PR TITLE
Fix CVE-2025-1975

### DIFF
--- a/server/download.go
+++ b/server/download.go
@@ -474,6 +474,9 @@ func downloadBlob(ctx context.Context, opts downloadOpts) (cacheHit bool, _ erro
 	case errors.Is(err, os.ErrNotExist):
 	case err != nil:
 		return false, err
+	case len(opts.digest) <= 0:
+		err := fmt.Errorf("digest is empty")
+		return false, err
 	default:
 		opts.fn(api.ProgressResponse{
 			Status:    fmt.Sprintf("pulling %s", opts.digest[7:19]),


### PR DESCRIPTION
check length of digest to fix [CVE-2025-1975](https://huntr.com/bounties/921ba5d4-f1d0-4c66-9764-4f72dffe7acd) which can lead to DoS