### PR TITLE
llama: fix incorrect initialization of C.struct_common_sampler_cparams.penalty_present

### DIFF
--- a/llama/llama.go
+++ b/llama/llama.go
@@ -544,7 +544,7 @@ func NewSamplingContext(model *Model, params SamplingParams) (*SamplingContext, 
 	cparams.penalty_last_n = C.int32_t(params.RepeatLastN)
 	cparams.penalty_repeat = C.float(params.PenaltyRepeat)
 	cparams.penalty_freq = C.float(params.PenaltyFreq)
-	cparams.penalty_present = C.float(params.PenaltyFreq)
+	cparams.penalty_present = C.float(params.PenaltyPresent)
 	cparams.seed = C.uint32_t(params.Seed)
 
 	grammar := C.CString(params.Grammar)


### PR DESCRIPTION
It should be initialized with SamplingParams.PenaltyPresent instead of SamplingParams.PenaltyFreq.
Bugfix for #10771, and, probably #10767