### PR TITLE
server: add hint to the error message when model path access fails

### DIFF
--- a/server/modelpath.go
+++ b/server/modelpath.go
@@ -116,7 +116,7 @@ func (mp ModelPath) BaseURL() *url.URL {
 func GetManifestPath() (string, error) {
 	path := filepath.Join(envconfig.Models(), "manifests")
 	if err := os.MkdirAll(path, 0o755); err != nil {
-		return "", err
+		return "", fmt.Errorf("%w: ensure path elements are traversable", err)
 	}
 
 	return path, nil
@@ -139,7 +139,7 @@ func GetBlobsPath(digest string) (string, error) {
 	}
 
 	if err := os.MkdirAll(dirPath, 0o755); err != nil {
-		return "", err
+		return "", fmt.Errorf("%w: ensure path elements are traversable", err)
 	}
 
 	return path, nil


### PR DESCRIPTION
A not-uncommon issue when users move the model directory is not realizing that all elements of the path it's being moved to needs to be accessible to the ollama user.  Add a hint to the error messages.

Fixes: #10839

Before:
```
Error: mkdir /usr/share/ollama/.ollama: permission denied
```
After:
```
Error: mkdir /usr/share/ollama/.ollama: permission denied: ensure path elements are traversable
```
