### PR TITLE
win: handle more than 2048 processes

### DIFF
--- a/cmd/start_windows.go
+++ b/cmd/start_windows.go
@@ -74,7 +74,16 @@ func isProcRunning(procName string) []uint32 {
 		slog.Debug("failed to check for running installers", "error", err)
 		return nil
 	}
-	pids = pids[:ret]
+	if ret > uint32(len(pids)) {
+		pids = make([]uint32, ret+10)
+		if err := windows.EnumProcesses(pids, &ret); err != nil || ret == 0 {
+			slog.Debug("failed to check for running installers", "error", err)
+			return nil
+		}
+	}
+	if ret < uint32(len(pids)) {
+		pids = pids[:ret]
+	}
 	var matches []uint32
 	for _, pid := range pids {
 		if pid == 0 {


### PR DESCRIPTION
Fix an array out of bounds crash when trying to start the desktop app

```
>  ollama ps
panic: runtime error: slice bounds out of range [:2692] with capacity 2048

goroutine 1 [running]:
github.com/ollama/ollama/cmd.isProcRunning({0x7ff7575bc25a, 0xf})
        C:/a/ollama/ollama/cmd/start_windows.go:77 +0x398
github.com/ollama/ollama/cmd.startApp({0x7ff75777d210, 0x7ff7580d4920}, 0x40002a1d18)
        C:/a/ollama/ollama/cmd/start_windows.go:25 +0x48
github.com/ollama/ollama/cmd.checkServerHeartbeat(0x40000c6908, {0x7ff7575a975a?, 0x4?, 0x7ff7575a975e?})
        C:/a/ollama/ollama/cmd/cmd.go:1347 +0xf0
github.com/spf13/cobra.(*Command).execute(0x40000c6908, {0x7ff7580d4920, 0x0, 0x0})
        C:/Users/runneradmin/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:925 +0x5f0
github.com/spf13/cobra.(*Command).ExecuteC(0x4000029208)
        C:/Users/runneradmin/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1068 +0x320
github.com/spf13/cobra.(*Command).Execute(...)
        C:/Users/runneradmin/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:992
github.com/spf13/cobra.(*Command).ExecuteContext(...)
        C:/Users/runneradmin/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:985
main.main()
        C:/a/ollama/ollama/main.go:12 +0x54
```