### PR TITLE
cmd/runner: capitalize "Ollama" in CLI help output

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1412,7 +1412,7 @@ func NewCLI() *cobra.Command {
 		},
 	}
 
-	//added custom help flag to capitalize Ollama
+	// Added custom help flag to capitalize "Ollama"
 	rootCmd.PersistentFlags().BoolP("help", "h", false, "Help for Ollama")
 
 	rootCmd.Flags().BoolP("version", "v", false, "Show version information")
@@ -1467,7 +1467,7 @@ func NewCLI() *cobra.Command {
 		RunE:    StopHandler,
 	}
 
-	// updated Short to capitalize "Ollama"
+	// updated Short description to capitalize "Ollama" 
 	serveCmd := &cobra.Command{
 		Use:     "serve",
 		Aliases: []string{"start"},

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1412,6 +1412,9 @@ func NewCLI() *cobra.Command {
 		},
 	}
 
+	//added custom help flag to capitalize Ollama
+	rootCmd.PersistentFlags().BoolP("help", "h", false, "Help for Ollama")
+
 	rootCmd.Flags().BoolP("version", "v", false, "Show version information")
 
 	createCmd := &cobra.Command{
@@ -1464,10 +1467,11 @@ func NewCLI() *cobra.Command {
 		RunE:    StopHandler,
 	}
 
+	// updated Short to capitalize "Ollama"
 	serveCmd := &cobra.Command{
 		Use:     "serve",
 		Aliases: []string{"start"},
-		Short:   "Start ollama",
+		Short:   "Start Ollama",
 		Args:    cobra.ExactArgs(0),
 		RunE:    RunServer,
 	}


### PR DESCRIPTION
This changes Ollama to display "Ollama" with a capital "O" in CLI help output, to ensure branding consistency throughout the tool.

Fixes #10165
