### PR TITLE
Allow to refer local type definitions on a root level of ToolFunction schema

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -226,12 +226,14 @@ type ToolFunction struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
 	Parameters  struct {
-		Type       string   `json:"type"`
+		Type       string   `json:"type,omitempty"`
+		Ref        any      `json:"$ref,omitempty"`
 		Defs       any      `json:"$defs,omitempty"`
 		Items      any      `json:"items,omitempty"`
 		Required   []string `json:"required"`
 		Properties map[string]struct {
-			Type        PropertyType `json:"type"`
+			Type        PropertyType `json:"type,omitempty"`
+			Ref         any          `json:"$ref,omitempty"`
 			Items       any          `json:"items,omitempty"`
 			Description string       `json:"description"`
 			Enum        []any        `json:"enum,omitempty"`


### PR DESCRIPTION
As it is allowed to define json schema definitions for a `ToolFunction` structure still it is not possible to refer this declarations from the `Properties` declarations their selfs.

So this trying to fix this.

[x]  Verified the tests scoped for `api/types*.go` only. Not affected.