### PR TITLE
feat: Add Asset Inventory to community integrations list

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [macLlama (macOS native)](https://github.com/hellotunamayo/macLlama) (A native macOS GUI application for interacting with Ollama models, featuring a chat interface.) 
 - [GPTranslate](https://github.com/philberndt/GPTranslate) (A fast and lightweight, AI powered desktop translation application written with Rust and Tauri. Features real-time translation with OpenAI/Azure/Ollama.)
 - [ollama launcher](https://github.com/NGC13009/ollama-launcher) (A launcher for Ollama, aiming to provide users with convenient functions such as ollama server launching, management, or configuration.)
+- [Asset Inventory](https://assetstore.unity.com/packages/tools/utilities/asset-inventory-3-308224) (Sophisticated asset search right inside Unity, utilizing AI to create searchable captions for preview images, allows to easily find an ambulance even if the file is called car1.prefab)
 
 ### Cloud
 


### PR DESCRIPTION
I've developed a tool for Unity which heavily utilized ollama to create captions for preview images which the user can then search through. It allows managing, downloading and comparing models and their results in a nice model tester as well.