### PR TITLE
CUDA: set gpu_name from props in cudart Implementation (align with nvcuda)

### DIFF
--- a/discover/gpu_info_cudart.c
+++ b/discover/gpu_info_cudart.c
@@ -153,6 +153,8 @@ void cudart_bootstrap(cudart_handle_t h, int i, mem_info_t *resp) {
           props.uuid.bytes[15]
         );
     }
+    strncpy(&resp->gpu_name[0], props.name, GPU_NAME_LEN - 1);
+    resp->gpu_name[GPU_NAME_LEN - 1] = '\0';
     resp->major = props.major;
     resp->minor = props.minor;
 

--- a/discover/gpu_info_cudart.h
+++ b/discover/gpu_info_cudart.h
@@ -118,7 +118,7 @@ typedef struct cudaDeviceProp {
     int          maxBlocksPerMultiProcessor; /**< Maximum number of resident blocks per multiprocessor */
     int          accessPolicyMaxWindowSize;  /**< The maximum value of ::cudaAccessPolicyWindow::num_bytes. */
     size_t       reservedSharedMemPerBlock;  /**< Shared memory reserved by CUDA driver per block in bytes */
-  } cudaDeviceProp_t;
+} cudaDeviceProp_t;
 
 typedef struct cudart_handle {
   void *handle;

--- a/discover/gpu_info_nvcuda.c
+++ b/discover/gpu_info_nvcuda.c
@@ -18,7 +18,6 @@ void nvcuda_init(char *nvcuda_lib_path, nvcuda_init_resp_t *resp) {
     char *s;
     void **p;
   } l[] = {
-   
       {"cuInit", (void *)&resp->ch.cuInit},
       {"cuDriverGetVersion", (void *)&resp->ch.cuDriverGetVersion},
       {"cuDeviceGetCount", (void *)&resp->ch.cuDeviceGetCount},
@@ -104,13 +103,13 @@ void nvcuda_init(char *nvcuda_lib_path, nvcuda_init_resp_t *resp) {
   LOG(resp->ch.verbose, "device count %d\n", resp->num_devices);
 }
 
-const int buflen = 256;
 void nvcuda_bootstrap(nvcuda_handle_t h, int i, mem_info_t *resp) {
   resp->err = NULL;
   nvcudaMemory_t memInfo = {0,0};
   CUresult ret;
   CUdevice device = -1;
   CUcontext ctx = NULL;
+  const int buflen = 256;
   char buf[buflen + 1];
   CUuuid uuid = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
 
@@ -136,8 +135,8 @@ void nvcuda_bootstrap(nvcuda_handle_t h, int i, mem_info_t *resp) {
     if (ret != CUDA_SUCCESS) {
       LOG(h.verbose, "[%d] device minor lookup failure: %d\n", i, ret);
     } else {
-      resp->minor = minor;  
-      resp->major = major;  
+      resp->minor = minor;
+      resp->major = major;
     }
   }
 
@@ -198,7 +197,7 @@ void nvcuda_bootstrap(nvcuda_handle_t h, int i, mem_info_t *resp) {
   LOG(h.verbose, "[%s] CUDA freeMem %" PRId64 "mb\n", resp->gpu_id, resp->free / 1024 / 1024);
   LOG(h.verbose, "[%s] Compute Capability %d.%d\n", resp->gpu_id, resp->major, resp->minor);
 
-  
+
 
   ret = (*h.cuCtxDestroy)(ctx);
   if (ret != CUDA_SUCCESS) {

--- a/runner/README.md
+++ b/runner/README.md
@@ -2,7 +2,7 @@
 
 > Note: this is a work in progress
 
-A minimial runner for loading a model and running inference via a http web server.
+A minimal runner for loading a model and running inference via a http web server.
 
 ```shell
 ./runner -model <model binary>


### PR DESCRIPTION
This PR updates the CUDA (`cudart`) implementation to set `gpu_name` using properties retrieved from the device, aligning the behavior with the `nvcuda` implementation.