### PR TITLE
Adds an env var to allow overriding the default port using an env var

### DIFF
--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -16,8 +16,14 @@ import (
 
 // Host returns the scheme and host. Host can be configured via the OLLAMA_HOST environment variable.
 // Default is scheme "http" and host "127.0.0.1:11434"
-func Host() *url.URL {
-	defaultPort := "11434"
+// Default port can be configured via the OLLAMA_PORT environment variable.
+func Host() *url.URL {	
+	defaultPort :=  "11434"
+	
+	portFromEnv := Var("OLLAMA_PORT")
+	if portFromEnv != "" {
+		defaultPort =  portFromEnv
+	}
 
 	s := strings.TrimSpace(Var("OLLAMA_HOST"))
 	scheme, hostport, ok := strings.Cut(s, "://")

--- a/envconfig/config_test.go
+++ b/envconfig/config_test.go
@@ -49,6 +49,13 @@ func TestHost(t *testing.T) {
 	}
 }
 
+func TestPortFromVar(t *testing.T) {
+	t.Setenv("OLLAMA_PORT", "8080")
+	if host := Host(); host.String() != "http://127.0.0.1:8081" {
+		t.Errorf("Expected %s, got %s", "http://127.0.0.1:8080", host.String())
+	}
+}
+
 func TestOrigins(t *testing.T) {
 	cases := []struct {
 		value  string


### PR DESCRIPTION
This will allow users to deploy the container / server and have it listen to a port other than the hard-coded port