### PR TITLE
server: update model blob and manifest permissions

### DIFF
--- a/server/create.go
+++ b/server/create.go
@@ -674,7 +674,7 @@ func createConfigLayer(layers []Layer, config ConfigV2) (*Layer, error) {
 
 func createLink(src, dst string) error {
 	// make any subdirs for dst
-	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o777); err != nil {
 		return err
 	}
 

--- a/server/download.go
+++ b/server/download.go
@@ -215,7 +215,7 @@ func (b *blobDownload) run(ctx context.Context, requestURL *url.URL, opts *regis
 	defer blobDownloadManager.Delete(b.Digest)
 	ctx, b.CancelFunc = context.WithCancel(ctx)
 
-	file, err := os.OpenFile(b.Name+"-partial", os.O_CREATE|os.O_RDWR, 0o644)
+	file, err := os.OpenFile(b.Name+"-partial", os.O_CREATE|os.O_RDWR, 0o666)
 	if err != nil {
 		return err
 	}
@@ -414,7 +414,7 @@ func (b *blobDownload) readPart(partName string) (*blobDownloadPart, error) {
 }
 
 func (b *blobDownload) writePart(partName string, part *blobDownloadPart) error {
-	partFile, err := os.OpenFile(partName, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o644)
+	partFile, err := os.OpenFile(partName, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o666)
 	if err != nil {
 		return err
 	}

--- a/server/images.go
+++ b/server/images.go
@@ -393,7 +393,7 @@ func CopyModel(src, dst model.Name) error {
 	}
 
 	dstpath := filepath.Join(manifests, dst.Filepath())
-	if err := os.MkdirAll(filepath.Dir(dstpath), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(dstpath), 0o777); err != nil {
 		return err
 	}
 
@@ -655,11 +655,11 @@ func PullModel(ctx context.Context, name string, regOpts *registryOptions, fn fu
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(filepath.Dir(fp), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(fp), 0o777); err != nil {
 		return err
 	}
 
-	err = os.WriteFile(fp, manifestJSON, 0o644)
+	err = os.WriteFile(fp, manifestJSON, 0o666)
 	if err != nil {
 		slog.Info(fmt.Sprintf("couldn't write to %s", fp))
 		return err

--- a/server/layer.go
+++ b/server/layer.go
@@ -5,7 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand"
 	"os"
+	"path/filepath"
+	"strconv"
 )
 
 type Layer struct {
@@ -22,8 +25,17 @@ func NewLayer(r io.Reader, mediatype string) (Layer, error) {
 		return Layer{}, err
 	}
 
-	temp, err := os.CreateTemp(blobs, "sha256-")
-	if err != nil {
+	var temp *os.File
+
+	for range 10000 {
+		tempPath := filepath.Join(blobs, "sha256-"+strconv.Itoa(int(rand.Int31())))
+		temp, err = os.OpenFile(tempPath, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o666)
+		if err == nil {
+			break
+		}
+		if os.IsExist(err) {
+			continue
+		}
 		return Layer{}, err
 	}
 	defer temp.Close()
@@ -49,9 +61,6 @@ func NewLayer(r io.Reader, mediatype string) (Layer, error) {
 	if _, err := os.Stat(blob); err != nil {
 		status = "creating new layer"
 		if err := os.Rename(temp.Name(), blob); err != nil {
-			return Layer{}, err
-		}
-		if err := os.Chmod(blob, 0o644); err != nil {
 			return Layer{}, err
 		}
 	}

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -103,7 +103,7 @@ func WriteManifest(name model.Name, config Layer, layers []Layer) error {
 	}
 
 	p := filepath.Join(manifests, name.Filepath())
-	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(p), 0o777); err != nil {
 		return err
 	}
 

--- a/server/modelpath.go
+++ b/server/modelpath.go
@@ -115,7 +115,7 @@ func (mp ModelPath) BaseURL() *url.URL {
 
 func GetManifestPath() (string, error) {
 	path := filepath.Join(envconfig.Models(), "manifests")
-	if err := os.MkdirAll(path, 0o755); err != nil {
+	if err := os.MkdirAll(path, 0o777); err != nil {
 		return "", fmt.Errorf("%w: ensure path elements are traversable", err)
 	}
 
@@ -138,7 +138,7 @@ func GetBlobsPath(digest string) (string, error) {
 		dirPath = path
 	}
 
-	if err := os.MkdirAll(dirPath, 0o755); err != nil {
+	if err := os.MkdirAll(dirPath, 0o777); err != nil {
 		return "", fmt.Errorf("%w: ensure path elements are traversable", err)
 	}
 


### PR DESCRIPTION
This PR updates the permissions for the model blob and manifest files to 666, and directories to 777, before applying umask.

We're using Ollama in a multi-user environment and want to set up a shared models directory to prevent duplicate downloads. Currently, model files (644) and directories (755) restrict sharing, regardless of umask. With this change, setting a permissive umask (e.g., 000) allows all users to read/write shared models, while the default umask (022) keeps the existing behavior.

Thank you for reviewing this PR.