### PR TITLE
int: add coverage for older models

### DIFF
--- a/integration/model_arch_test.go
+++ b/integration/model_arch_test.go
@@ -45,6 +45,8 @@ var (
 		"qwen2.5-coder:latest",
 		"qwen:latest",
 		"solar-pro:latest",
+		"codellama:latest",
+		"nous-hermes:latest",
 	}
 )
 


### PR DESCRIPTION
Verified these fail on 0.9.1 and pass on HEAD.