### PR TITLE
docs(modelfile): document creating vision models

### DIFF
--- a/docs/modelfile.md
+++ b/docs/modelfile.md
@@ -137,6 +137,7 @@ FROM ./ollama-model.gguf
 
 The GGUF file location should be specified as an absolute path or relative to the `Modelfile` location.
 
+Note: When creating a vision model that comprises of both a main model GGUF and a `mmproj` (projector) GGUF - place both files in the same directory and provide the directory path in the `FROM` instruction.
 
 ### PARAMETER
 


### PR DESCRIPTION
Add note on how to create Ollama models with vision capabilities by providing a mmproj file and using the directory rather than the single model GGUF.

Reason for adding this: I've seen multiple people incorrectly stating things like "Ollama can't create vision models unless you create a single GGUF with the mmproj embedded", I suspected this wasn't true and after reading through the current codebase I found simply providing both files in the same directory works.

---

Related:

- https://github.com/ollama/ollama/issues/9967
- https://github.com/unslothai/unsloth/issues/2248
- https://github.com/covercash2/modelfile/pull/19
- https://www.reddit.com/r/ollama/comments/1jdkevi/creating_gemma_3_from_gguf_with_mmproj_not_working/