### PR TITLE
(docs): add ai-hub to community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [macLlama (macOS native)](https://github.com/hellotunamayo/macLlama) (A native macOS GUI application for interacting with Ollama models, featuring a chat interface.) 
 - [GPTranslate](https://github.com/philberndt/GPTranslate) (A fast and lightweight, AI powered desktop translation application written with Rust and Tauri. Features real-time translation with OpenAI/Azure/Ollama.)
 - [ollama launcher](https://github.com/NGC13009/ollama-launcher) (A launcher for Ollama, aiming to provide users with convenient functions such as ollama server launching, management, or configuration.)
+- [ai-hub](https://github.com/Aj-Seven/ai-hub) (AI Hub supports multiple models via API keys and Chat support via Ollama API.)
 
 ### Cloud
 


### PR DESCRIPTION
Hello!! This PR is to request the addition of ai-hub to the list of community integrations.

AI Hub is a Next.js-based framework that supports multiple AI models via API keys, as well as local model integration through Ollama's API — thanks to its great community.

Github repo: https://github.com/Aj-Seven/ai-hub

Here is demo screenshot:

![Screenshot from 2025-06-23 17-11-40](https://github.com/user-attachments/assets/9146fefc-2671-4cd7-89e2-3aaf0cb4c4cf)
![Screenshot from 2025-06-23 17-21-38](https://github.com/user-attachments/assets/e74903f9-cdf2-40fa-b993-e51a0faa0d41)
![Screenshot from 2025-06-23 17-18-16](https://github.com/user-attachments/assets/d7bb8da5-96c4-47c0-8eeb-f52ea86bda11)
![Screenshot from 2025-06-23 17-18-43](https://github.com/user-attachments/assets/9b5f7046-c1d6-456b-bab2-4f458f9da162)

