### PR TITLE
XDG Spec Support

### DIFF
--- a/app/store/store_linux.go
+++ b/app/store/store_linux.go
@@ -3,6 +3,8 @@ package store
 import (
 	"os"
 	"path/filepath"
+
+	"github.com/ollama/ollama/envconfig"
 )
 
 func getStorePath() string {
@@ -11,6 +13,5 @@ func getStorePath() string {
 		return "/etc/ollama/config.json"
 	}
 
-	home := os.Getenv("HOME")
-	return filepath.Join(home, ".ollama", "config.json")
+	return filepath.Join(envconfig.ConfigDir(), "config.json")
 }

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -14,26 +14,18 @@ import (
 	"strings"
 
 	"golang.org/x/crypto/ssh"
+
+	"github.com/ollama/ollama/envconfig"
 )
 
 const defaultPrivateKey = "id_ed25519"
 
-func keyPath() (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-
-	return filepath.Join(home, ".ollama", defaultPrivateKey), nil
+func keyPath() string {
+	return filepath.Join(envconfig.KeyPath(), defaultPrivateKey)
 }
 
 func GetPublicKey() (string, error) {
-	keyPath, err := keyPath()
-	if err != nil {
-		return "", err
-	}
-
-	privateKeyFile, err := os.ReadFile(keyPath)
+	privateKeyFile, err := os.ReadFile(keyPath())
 	if err != nil {
 		slog.Info(fmt.Sprintf("Failed to load private key: %v", err))
 		return "", err
@@ -59,12 +51,8 @@ func NewNonce(r io.Reader, length int) (string, error) {
 }
 
 func Sign(ctx context.Context, bts []byte) (string, error) {
-	keyPath, err := keyPath()
-	if err != nil {
-		return "", err
-	}
 
-	privateKeyFile, err := os.ReadFile(keyPath)
+	privateKeyFile, err := os.ReadFile(keyPath())
 	if err != nil {
 		slog.Info(fmt.Sprintf("Failed to load private key: %v", err))
 		return "", err

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1290,15 +1290,11 @@ func RunServer(_ *cobra.Command, _ []string) error {
 }
 
 func initializeKeypair() error {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return err
-	}
+	keyPathRoot := envconfig.KeyPath()
+	privKeyPath := filepath.Join(keyPathRoot, "id_ed25519")
+	pubKeyPath := filepath.Join(keyPathRoot, "id_ed25519.pub")
 
-	privKeyPath := filepath.Join(home, ".ollama", "id_ed25519")
-	pubKeyPath := filepath.Join(home, ".ollama", "id_ed25519.pub")
-
-	_, err = os.Stat(privKeyPath)
+	_fileInfo, err := os.Stat(privKeyPath)
 	if os.IsNotExist(err) {
 		fmt.Printf("Couldn't find '%s'. Generating new private key.\n", privKeyPath)
 		cryptoPublicKey, cryptoPrivateKey, err := ed25519.GenerateKey(rand.Reader)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -204,9 +204,13 @@ Refer to the section [above](#how-do-i-configure-ollama-server) for how to set e
 
 ## Where are models stored?
 
-- macOS: `~/.ollama/models`
-- Linux: `/usr/share/ollama/.ollama/models`
-- Windows: `C:\Users\%username%\.ollama\models`
+* macOS: `~/.ollama/models`
+* Linux: `/usr/share/ollama/.ollama/models`
+* Windows: `C:\Users\%username%\.ollama\models`
+
+### XDG Spec
+
+If `XDG_STATE_HOME` is set, `$XDG_STATE_HOME/ollama/models` will be used
 
 ### How do I set them to a different location?
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,6 +1,8 @@
 # How to troubleshoot issues
 
-Sometimes Ollama may not perform as expected. One of the best ways to figure out what happened is to take a look at the logs. Find the logs on **Mac** by running the command:
+Sometimes Ollama may not perform as expected. One of the best ways to figure out what happened is to take a look at the logs.
+
+Find the logs on **Mac** by running the command:
 
 ```shell
 cat ~/.ollama/logs/server.log
@@ -10,6 +12,12 @@ On **Linux** systems with systemd, the logs can be found with this command:
 
 ```shell
 journalctl -u ollama --no-pager --follow --pager-end 
+```
+
+On a system using the XDG Spec, the logs can be found with this command:
+
+```shell
+cat $XDG_STATE_HOME/logs/server.log
 ```
 
 When you run Ollama in a **container**, the logs go to stdout/stderr in the container:

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -95,6 +95,13 @@ func ConfigDir() string {
 	return DefaultConfigDir()
 }
 
+func StateDir() string {
+	if dir := Var("XDG_STATE_HOME"); dir != "" {
+		return filepath.Join(dir, "ollama")
+	}
+	return DefaultConfigDir()
+}
+
 // Models returns the path to the models directory. Models directory can be configured via the OLLAMA_MODELS environment variable.
 // Default is $HOME/.ollama/models
 func Models() string {
@@ -102,7 +109,7 @@ func Models() string {
 		return s
 	}
 
-	return filepath.Join(ConfigDir(), "models")
+	return filepath.Join(StateDir(), "models")
 }
 
 func KeyPath() string {
@@ -110,7 +117,7 @@ func KeyPath() string {
 }
 
 func History() string {
-	return filepath.Join(ConfigDir(), "history")
+	return filepath.Join(StateDir(), "history")
 }
 
 // KeepAlive returns the duration that models stay loaded in memory. KeepAlive can be configured via the OLLAMA_KEEP_ALIVE environment variable.

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -94,6 +94,15 @@ func Models() string {
 	return filepath.Join(home, ".ollama", "models")
 }
 
+func KeyPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		panic(err)
+	}
+
+	return filepath.Join(home, ".ollama")
+}
+
 // KeepAlive returns the duration that models stay loaded in memory. KeepAlive can be configured via the OLLAMA_KEEP_ALIVE environment variable.
 // Negative values are treated as infinite. Zero is treated as no keep alive.
 // Default is 5 minutes.

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -79,22 +79,7 @@ func AllowedOrigins() (origins []string) {
 	return origins
 }
 
-// Models returns the path to the models directory. Models directory can be configured via the OLLAMA_MODELS environment variable.
-// Default is $HOME/.ollama/models
-func Models() string {
-	if s := Var("OLLAMA_MODELS"); s != "" {
-		return s
-	}
-
-	home, err := os.UserHomeDir()
-	if err != nil {
-		panic(err)
-	}
-
-	return filepath.Join(home, ".ollama", "models")
-}
-
-func KeyPath() string {
+func ConfigDir() string {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		panic(err)
@@ -103,13 +88,22 @@ func KeyPath() string {
 	return filepath.Join(home, ".ollama")
 }
 
-func History() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		panic(err)
+// Models returns the path to the models directory. Models directory can be configured via the OLLAMA_MODELS environment variable.
+// Default is $HOME/.ollama/models
+func Models() string {
+	if s := Var("OLLAMA_MODELS"); s != "" {
+		return s
 	}
 
-	return filepath.Join(home, ".ollama", "history")
+	return filepath.Join(ConfigDir(), "models")
+}
+
+func KeyPath() string {
+	return ConfigDir()
+}
+
+func History() string {
+	return filepath.Join(ConfigDir(), "history")
 }
 
 // KeepAlive returns the duration that models stay loaded in memory. KeepAlive can be configured via the OLLAMA_KEEP_ALIVE environment variable.

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -79,13 +79,20 @@ func AllowedOrigins() (origins []string) {
 	return origins
 }
 
-func ConfigDir() string {
+func DefaultConfigDir() string {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		panic(err)
 	}
 
 	return filepath.Join(home, ".ollama")
+}
+
+func ConfigDir() string {
+	if dir := Var("XDG_CONFIG_HOME"); dir != "" {
+		return filepath.Join(dir, "ollama")
+	}
+	return DefaultConfigDir()
 }
 
 // Models returns the path to the models directory. Models directory can be configured via the OLLAMA_MODELS environment variable.

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -251,25 +251,25 @@ type EnvVar struct {
 
 func AsMap() map[string]EnvVar {
 	ret := map[string]EnvVar{
+		"OLLAMA_CONTEXT_LENGTH":    {"OLLAMA_CONTEXT_LENGTH", ContextLength(), "Context length to use unless otherwise specified (default: 4096)"},
 		"OLLAMA_DEBUG":             {"OLLAMA_DEBUG", LogLevel(), "Show additional debug information (e.g. OLLAMA_DEBUG=1)"},
 		"OLLAMA_FLASH_ATTENTION":   {"OLLAMA_FLASH_ATTENTION", FlashAttention(), "Enabled flash attention"},
-		"OLLAMA_KV_CACHE_TYPE":     {"OLLAMA_KV_CACHE_TYPE", KvCacheType(), "Quantization type for the K/V cache (default: f16)"},
 		"OLLAMA_GPU_OVERHEAD":      {"OLLAMA_GPU_OVERHEAD", GpuOverhead(), "Reserve a portion of VRAM per GPU (bytes)"},
 		"OLLAMA_HOST":              {"OLLAMA_HOST", Host(), "IP Address for the ollama server (default 127.0.0.1:11434)"},
 		"OLLAMA_KEEP_ALIVE":        {"OLLAMA_KEEP_ALIVE", KeepAlive(), "The duration that models stay loaded in memory (default \"5m\")"},
+		"OLLAMA_KV_CACHE_TYPE":     {"OLLAMA_KV_CACHE_TYPE", KvCacheType(), "Quantization type for the K/V cache (default: f16)"},
 		"OLLAMA_LLM_LIBRARY":       {"OLLAMA_LLM_LIBRARY", LLMLibrary(), "Set LLM library to bypass autodetection"},
 		"OLLAMA_LOAD_TIMEOUT":      {"OLLAMA_LOAD_TIMEOUT", LoadTimeout(), "How long to allow model loads to stall before giving up (default \"5m\")"},
 		"OLLAMA_MAX_LOADED_MODELS": {"OLLAMA_MAX_LOADED_MODELS", MaxRunners(), "Maximum number of loaded models per GPU"},
 		"OLLAMA_MAX_QUEUE":         {"OLLAMA_MAX_QUEUE", MaxQueue(), "Maximum number of queued requests"},
 		"OLLAMA_MODELS":            {"OLLAMA_MODELS", Models(), "The path to the models directory"},
+		"OLLAMA_MULTIUSER_CACHE":   {"OLLAMA_MULTIUSER_CACHE", MultiUserCache(), "Optimize prompt caching for multi-user scenarios"},
+		"OLLAMA_NEW_ENGINE":        {"OLLAMA_NEW_ENGINE", NewEngine(), "Enable the new Ollama engine"},
 		"OLLAMA_NOHISTORY":         {"OLLAMA_NOHISTORY", NoHistory(), "Do not preserve readline history"},
 		"OLLAMA_NOPRUNE":           {"OLLAMA_NOPRUNE", NoPrune(), "Do not prune model blobs on startup"},
 		"OLLAMA_NUM_PARALLEL":      {"OLLAMA_NUM_PARALLEL", NumParallel(), "Maximum number of parallel requests"},
 		"OLLAMA_ORIGINS":           {"OLLAMA_ORIGINS", AllowedOrigins(), "A comma separated list of allowed origins"},
 		"OLLAMA_SCHED_SPREAD":      {"OLLAMA_SCHED_SPREAD", SchedSpread(), "Always schedule model across all GPUs"},
-		"OLLAMA_MULTIUSER_CACHE":   {"OLLAMA_MULTIUSER_CACHE", MultiUserCache(), "Optimize prompt caching for multi-user scenarios"},
-		"OLLAMA_CONTEXT_LENGTH":    {"OLLAMA_CONTEXT_LENGTH", ContextLength(), "Context length to use unless otherwise specified (default: 4096)"},
-		"OLLAMA_NEW_ENGINE":        {"OLLAMA_NEW_ENGINE", NewEngine(), "Enable the new Ollama engine"},
 
 		// Informational
 		"HTTP_PROXY":  {"HTTP_PROXY", String("HTTP_PROXY")(), "HTTP proxy"},

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -102,8 +102,8 @@ func StateDir() string {
 	return DefaultConfigDir()
 }
 
-// Models returns the path to the models directory. Models directory can be configured via the OLLAMA_MODELS environment variable.
-// Default is $HOME/.ollama/models
+// Models returns the path to the models directory.
+// Models directory can be configured via the OLLAMA_MODELS environment variable.
 func Models() string {
 	if s := Var("OLLAMA_MODELS"); s != "" {
 		return s

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -103,6 +103,15 @@ func KeyPath() string {
 	return filepath.Join(home, ".ollama")
 }
 
+func History() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		panic(err)
+	}
+
+	return filepath.Join(home, ".ollama", "history")
+}
+
 // KeepAlive returns the duration that models stay loaded in memory. KeepAlive can be configured via the OLLAMA_KEEP_ALIVE environment variable.
 // Negative values are treated as infinite. Zero is treated as no keep alive.
 // Default is 5 minutes.

--- a/envconfig/config_test.go
+++ b/envconfig/config_test.go
@@ -328,6 +328,25 @@ func TestLogLevel(t *testing.T) {
 	}
 }
 
+func TestConfigDir(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		panic(err)
+	}
+
+	cases := map[string]string{
+		"default": filepath.Join(home, ".ollama"),
+	}
+
+	for k, v := range cases {
+		t.Run(k, func(t *testing.T) {
+			if dir := ConfigDir(); dir != v {
+				t.Errorf("%s: expected %s, got %s", k, v, dir)
+			}
+		})
+	}
+}
+
 func TestModels(t *testing.T) {
 	home, err := os.UserHomeDir()
 	if err != nil {

--- a/envconfig/config_test.go
+++ b/envconfig/config_test.go
@@ -336,11 +336,11 @@ func TestModels(t *testing.T) {
 
 	cases := map[string]string{
 		"default": filepath.Join(home, ".ollama", "models"),
-		"manual": "/path/for/models",
+		"manual":  "/path/for/models",
 	}
 
-	for k,v := range cases {
-		t.Run(k, func(t *testing.T){
+	for k, v := range cases {
+		t.Run(k, func(t *testing.T) {
 			if k == "manual" {
 				t.Setenv("OLLAMA_MODELS", v)
 			}
@@ -362,9 +362,28 @@ func TestKeyPath(t *testing.T) {
 		"KeyPath": filepath.Join(home, ".ollama"),
 	}
 
-	for k,v := range cases {
-		t.Run(k, func(t *testing.T){
+	for k, v := range cases {
+		t.Run(k, func(t *testing.T) {
 			if dir := KeyPath(); dir != v {
+				t.Errorf("%s: expected %s, got %s", k, v, dir)
+			}
+		})
+	}
+}
+
+func TestHistory(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		panic(err)
+	}
+
+	cases := map[string]string{
+		"History": filepath.Join(home, ".ollama", "history"),
+	}
+
+	for k, v := range cases {
+		t.Run(k, func(t *testing.T) {
+			if dir := History(); dir != v {
 				t.Errorf("%s: expected %s, got %s", k, v, dir)
 			}
 		})

--- a/envconfig/config_test.go
+++ b/envconfig/config_test.go
@@ -3,6 +3,8 @@ package envconfig
 import (
 	"log/slog"
 	"math"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -321,6 +323,30 @@ func TestLogLevel(t *testing.T) {
 			t.Setenv("OLLAMA_DEBUG", k)
 			if i := LogLevel(); i != v {
 				t.Errorf("%s: expected %d, got %d", k, v, i)
+			}
+		})
+	}
+}
+
+func TestModels(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		panic(err)
+	}
+
+	cases := map[string]string{
+		"default": filepath.Join(home, ".ollama", "models"),
+		"manual": "/path/for/models",
+	}
+
+	for k,v := range cases {
+		t.Run(k, func(t *testing.T){
+			if k == "manual" {
+				t.Setenv("OLLAMA_MODELS", v)
+			}
+
+			if dir := Models(); dir != v {
+				t.Errorf("%s: expected %s, got %s", k, v, dir)
 			}
 		})
 	}

--- a/envconfig/config_test.go
+++ b/envconfig/config_test.go
@@ -362,7 +362,7 @@ func TestModels(t *testing.T) {
 
 	cases := map[string]string{
 		"default":  filepath.Join(home, ".ollama", "models"),
-		"xdg_spec": filepath.Join(home, ".config", "ollama", "models"),
+		"xdg_spec": filepath.Join(home, ".local", "state", "ollama", "models"),
 		"manual":   "/path/for/models",
 	}
 
@@ -372,9 +372,9 @@ func TestModels(t *testing.T) {
 			case "manual":
 				t.Setenv("OLLAMA_MODELS", v)
 			case "xdg_spec":
-				t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+				t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
 			default:
-				t.Setenv("XDG_CONFIG_HOME", "")
+				t.Setenv("XDG_STATE_HOME", "")
 			}
 
 			if dir := Models(); dir != v {
@@ -418,15 +418,15 @@ func TestHistory(t *testing.T) {
 
 	cases := map[string]string{
 		"default":  filepath.Join(home, ".ollama", "history"),
-		"xdg_spec": filepath.Join(home, ".config", "ollama", "history"),
+		"xdg_spec": filepath.Join(home, ".local", "state", "ollama", "history"),
 	}
 
 	for k, v := range cases {
 		t.Run(k, func(t *testing.T) {
 			if k == "xdg_spec" {
-				t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+				t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
 			} else {
-				t.Setenv("XDG_CONFIG_HOME", "")
+				t.Setenv("XDG_STATE_HOME", "")
 			}
 
 			if dir := History(); dir != v {

--- a/envconfig/config_test.go
+++ b/envconfig/config_test.go
@@ -351,3 +351,22 @@ func TestModels(t *testing.T) {
 		})
 	}
 }
+
+func TestKeyPath(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		panic(err)
+	}
+
+	cases := map[string]string{
+		"KeyPath": filepath.Join(home, ".ollama"),
+	}
+
+	for k,v := range cases {
+		t.Run(k, func(t *testing.T){
+			if dir := KeyPath(); dir != v {
+				t.Errorf("%s: expected %s, got %s", k, v, dir)
+			}
+		})
+	}
+}

--- a/envconfig/config_test.go
+++ b/envconfig/config_test.go
@@ -335,11 +335,18 @@ func TestConfigDir(t *testing.T) {
 	}
 
 	cases := map[string]string{
-		"default": filepath.Join(home, ".ollama"),
+		"default":  filepath.Join(home, ".ollama"),
+		"xdg_spec": filepath.Join(home, ".config", "ollama"),
 	}
 
 	for k, v := range cases {
 		t.Run(k, func(t *testing.T) {
+			if k == "xdg_spec" {
+				t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+			} else {
+				t.Setenv("XDG_CONFIG_HOME", "")
+			}
+
 			if dir := ConfigDir(); dir != v {
 				t.Errorf("%s: expected %s, got %s", k, v, dir)
 			}
@@ -354,14 +361,20 @@ func TestModels(t *testing.T) {
 	}
 
 	cases := map[string]string{
-		"default": filepath.Join(home, ".ollama", "models"),
-		"manual":  "/path/for/models",
+		"default":  filepath.Join(home, ".ollama", "models"),
+		"xdg_spec": filepath.Join(home, ".config", "ollama", "models"),
+		"manual":   "/path/for/models",
 	}
 
 	for k, v := range cases {
 		t.Run(k, func(t *testing.T) {
-			if k == "manual" {
+			switch k {
+			case "manual":
 				t.Setenv("OLLAMA_MODELS", v)
+			case "xdg_spec":
+				t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+			default:
+				t.Setenv("XDG_CONFIG_HOME", "")
 			}
 
 			if dir := Models(); dir != v {
@@ -378,11 +391,18 @@ func TestKeyPath(t *testing.T) {
 	}
 
 	cases := map[string]string{
-		"KeyPath": filepath.Join(home, ".ollama"),
+		"default":  filepath.Join(home, ".ollama"),
+		"xdg_spec": filepath.Join(home, ".config", "ollama"),
 	}
 
 	for k, v := range cases {
 		t.Run(k, func(t *testing.T) {
+			if k == "xdg_spec" {
+				t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+			} else {
+				t.Setenv("XDG_CONFIG_HOME", "")
+			}
+
 			if dir := KeyPath(); dir != v {
 				t.Errorf("%s: expected %s, got %s", k, v, dir)
 			}
@@ -397,11 +417,18 @@ func TestHistory(t *testing.T) {
 	}
 
 	cases := map[string]string{
-		"History": filepath.Join(home, ".ollama", "history"),
+		"default":  filepath.Join(home, ".ollama", "history"),
+		"xdg_spec": filepath.Join(home, ".config", "ollama", "history"),
 	}
 
 	for k, v := range cases {
 		t.Run(k, func(t *testing.T) {
+			if k == "xdg_spec" {
+				t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+			} else {
+				t.Setenv("XDG_CONFIG_HOME", "")
+			}
+
 			if dir := History(); dir != v {
 				t.Errorf("%s: expected %s, got %s", k, v, dir)
 			}

--- a/macapp/src/index.ts
+++ b/macapp/src/index.ts
@@ -20,11 +20,21 @@ let welcomeWindow: BrowserWindow | null = null
 
 declare const MAIN_WINDOW_WEBPACK_ENTRY: string
 
+const logsPath = () => {
+  const stateDir = process.env.XDG_STATE_HOME
+
+  if (stateDir && stateDir != "") {
+    return path.join(stateDir, 'ollama', 'logs')  
+  }
+
+  return path.join(app.getPath('home'), '.ollama', 'logs')
+}
+
 const logger = winston.createLogger({
   transports: [
     new winston.transports.Console(),
     new winston.transports.File({
-      filename: path.join(app.getPath('home'), '.ollama', 'logs', 'server.log'),
+      filename: path.join(logsPath(), 'server.log'),
       maxsize: 1024 * 1024 * 20,
       maxFiles: 5,
     }),

--- a/macapp/src/index.ts
+++ b/macapp/src/index.ts
@@ -27,6 +27,7 @@ const logsPath = () => {
     return path.join(stateDir, 'ollama', 'logs')  
   }
 
+  // TODO: this should probably point to ~/Library/Application Support/ollama/logs
   return path.join(app.getPath('home'), '.ollama', 'logs')
 }
 

--- a/readline/history.go
+++ b/readline/history.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/emirpasic/gods/v2/lists/arraylist"
+	"github.com/ollama/ollama/envconfig"
 )
 
 type History struct {
@@ -38,12 +39,7 @@ func NewHistory() (*History, error) {
 }
 
 func (h *History) Init() error {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return err
-	}
-
-	path := filepath.Join(home, ".ollama", "history")
+	path := envconfig.History()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}

--- a/server/internal/client/ollama/registry.go
+++ b/server/internal/client/ollama/registry.go
@@ -261,11 +261,7 @@ func (r *Registry) parseName(name string) (names.Name, error) {
 //
 // It returns an error if any configuration in the environment is invalid.
 func DefaultRegistry() (*Registry, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return nil, err
-	}
-	keyPEM, err := os.ReadFile(filepath.Join(home, ".ollama/id_ed25519"))
+	keyPEM, err := os.ReadFile(filepath.Join(envconfig.KeyPath(), "id_ed25519"))
 	if err != nil && errors.Is(err, fs.ErrNotExist) {
 		return nil, err
 	}

--- a/server/internal/client/ollama/registry.go
+++ b/server/internal/client/ollama/registry.go
@@ -255,9 +255,9 @@ func (r *Registry) parseName(name string) (names.Name, error) {
 	return n, nil
 }
 
-// DefaultRegistry returns a new Registry configured from the environment. The
-// key is read from $HOME/.ollama/id_ed25519, MaxStreams is set to the
-// value of OLLAMA_REGISTRY_MAXSTREAMS, and ReadTimeout is set to 30 seconds.
+// DefaultRegistry returns a new Registry configured from the environment.
+// MaxStreams is set to the value of OLLAMA_REGISTRY_MAXSTREAMS
+// and ReadTimeout is set to 30 seconds.
 //
 // It returns an error if any configuration in the environment is invalid.
 func DefaultRegistry() (*Registry, error) {

--- a/server/internal/client/ollama/registry.go
+++ b/server/internal/client/ollama/registry.go
@@ -36,6 +36,7 @@ import (
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/ollama/ollama/envconfig"
 	"github.com/ollama/ollama/server/internal/cache/blob"
 	"github.com/ollama/ollama/server/internal/internal/names"
 
@@ -74,12 +75,7 @@ const (
 )
 
 var defaultCache = sync.OnceValues(func() (*blob.DiskCache, error) {
-	dir := os.Getenv("OLLAMA_MODELS")
-	if dir == "" {
-		home, _ := os.UserHomeDir()
-		home = cmp.Or(home, ".")
-		dir = filepath.Join(home, ".ollama", "models")
-	}
+	dir := envconfig.Models()
 	return blob.Open(dir)
 })
 


### PR DESCRIPTION
# Summary
- Moves paths for history, models, and keys into envconfig
- Adds support for [XDG Spec](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) for logs, history, models, and keys
  - Will respect the existing locations unless `XDG_CONFIG_HOME` and `XDG_STATE_HOME` are defined

related: #228, #584, #4382, #4656, #9477