### PR TITLE
Interleave text and images in interactive mode

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -563,9 +563,12 @@ func extractFileData(input string) (string, []api.ImageData, error) {
 			return "", imgs, err
 		}
 		fmt.Fprintf(os.Stderr, "Added image '%s'\n", nfp)
-		input = strings.ReplaceAll(input, "'"+nfp+"'", "")
-		input = strings.ReplaceAll(input, "'"+fp+"'", "")
-		input = strings.ReplaceAll(input, fp, "")
+		input = strings.ReplaceAll(input, "'"+nfp+"'", "[img]")
+		input = strings.ReplaceAll(input, "\""+nfp+"\"", "[img]")
+		input = strings.ReplaceAll(input, "'"+fp+"'", "[img]")
+		input = strings.ReplaceAll(input, "\""+fp+"\"", "[img]")
+		input = strings.ReplaceAll(input, nfp, "[img]")
+		input = strings.ReplaceAll(input, fp, "[img]")
 		imgs = append(imgs, data)
 	}
 	return strings.TrimSpace(input), imgs, nil


### PR DESCRIPTION
Enables interleaving of text and images (instead of prefixing images) when prompting in the interactive mode.

## Description
This PR updates the logic for replacing image file paths with `[img]` tokens in interactive mode. The change ensures that both normalized and original file paths, with or without quotes, are replaced consistently in the user input. This way, the ollama server is able to seamlessly assign image IDs to each of these tokens in order of the images inputted.
This works for: 'path', "path", and unquoted paths. Both normalized and original file paths

Previously, when a user entered a message in interactive mode containing an image file path (e.g., /path/to/image.jpg), the code would remove the file path from the prompt entirely, leaving the images to be prefixed into the prompt later when reconstructed at the server. This is not ideal behavior, and can reduce the quality of output.

## Changes in behaviour
```
Prompt: Hi, tell me about this image: "C:\Users\sagnikpal2004\image1.png", and how it is related to this image folder\image2.png
Old behavior: [img-0] [img-1] Hi, tell me about this image: , and how it is related to this image 
New behavior: Hi, tell me about this image: [img-0], and how it is related to this image [img-1]
```

Related to: #10274