### PR TITLE
ci: recombine linux amd64 binaries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -468,8 +468,18 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           pattern: dist-linux-*
-          path: dist
-          merge-multiple: true
+          path: stage
+          merge-multiple: false
+      - name: Merge linux amd64 payload
+        working-directory: stage/dist-linux-amd64-archive
+        run: |
+          tar zxf ollama-linux-amd64.tgz
+          tar zxf ../dist-linux-amd64-rocm/ollama-linux-amd64.tgz
+          rm -f ollama-linux-amd64.tgz ../dist-linux-amd64-rocm/ollama-linux-amd64.tgz
+          tar -c -f- --owner 0 --group 0 . | pigz -9vc > ../ollama-linux-amd64.tgz
+      - name: Cleanup linux payloads
+        run: |
+          find stage -name ollama-linux\*.tgz -exec mv {} dist/ \;
       - run: find . -type f -not -name 'sha256sum.txt' | xargs sha256sum | tee sha256sum.txt
         working-directory: dist
       - name: Create or update Release


### PR DESCRIPTION
Glue the rocm and archive builds back together.

Now that the ggml-* libraries are bundled into the main lib dir, the `linux-build` matrix build and tar logic was creating 2 conflicting ollama-linux-amd64.tgz files - one with just ggml-hip, and the other with cuda+cpu+ollama.  This resulted in the main payloads being overwritten by `merge-multiples: true`.  The fix glues the contents back together so we can retain the build speedup of the matrix flow.

Scratch build verifying flow: https://github.com/ollama/ollama/actions/runs/15864595364/job/44729718604