### PR TITLE
Add ollama-bash-toolshed to Community Integrations : Terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [GGUF-to-Ollama](https://github.com/jonathanhecl/gguf-to-ollama) - Importing GGUF to Ollama made easy (multiplatform)
 - [AWS-Strands-With-Ollama](https://github.com/rapidarchitect/ollama_strands) - AWS Strands Agents with Ollama Examples
 - [ollama-multirun](https://github.com/attogram/ollama-multirun) - A bash shell script to run a single prompt against any or all of your locally installed ollama models, saving the output and performance statistics as easily navigable web pages. ([Demo](https://attogram.github.io/ai_test_zone/))
+- [ollama-bash-toolshed](https://github.com/attogram/ollama-bash-toolshed) - Bash scripts to chat with tool using models. Add new tools to your shed with ease. Runs on Ollama.
 
 ### Apple Vision Pro
 


### PR DESCRIPTION
Ollama Bash Toolshed: Bash scripts to chat with tool using models. Add new tools to your shed with ease. Runs on Ollama.

Repo: https://github.com/attogram/ollama-bash-toolshed