### PR TITLE
chore: add --no-headers flag to ListHandler for optional header suppression

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -534,7 +534,13 @@ func ListHandler(cmd *cobra.Command, args []string) error {
 	}
 
 	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{"NAME", "ID", "SIZE", "MODIFIED"})
+	
+	// Check for --no-headers flag
+	noHeaders, _ := cmd.Flags().GetBool("no-headers")
+	if !noHeaders {
+		table.SetHeader([]string{"NAME", "ID", "SIZE", "MODIFIED"})
+	}
+	
 	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 	table.SetAlignment(tablewriter.ALIGN_LEFT)
 	table.SetHeaderLine(false)
@@ -1499,6 +1505,8 @@ func NewCLI() *cobra.Command {
 		PreRunE: checkServerHeartbeat,
 		RunE:    ListHandler,
 	}
+
+	listCmd.Flags().Bool("no-headers", false, "Don't print column headers")
 
 	psCmd := &cobra.Command{
 		Use:     "ps",

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -574,6 +574,7 @@ func TestListHandler(t *testing.T) {
 	tests := []struct {
 		name           string
 		args           []string
+		noHeaders      bool
 		serverResponse []api.ListModelResponse
 		expectedError  string
 		expectedOutput string
@@ -598,6 +599,17 @@ func TestListHandler(t *testing.T) {
 			},
 			expectedOutput: "NAME      ID              SIZE      MODIFIED     \n" +
 				"model1    sha256:abc12    1.0 KB    24 hours ago    \n",
+		},
+		{
+			name:      "list all models without headers",
+			args:      []string{},
+			noHeaders: true,
+			serverResponse: []api.ListModelResponse{
+				{Name: "model1", Digest: "sha256:abc123", Size: 1024, ModifiedAt: time.Now().Add(-24 * time.Hour)},
+				{Name: "model2", Digest: "sha256:def456", Size: 2048, ModifiedAt: time.Now().Add(-48 * time.Hour)},
+			},
+			expectedOutput: "model1    sha256:abc12    1.0 KB    24 hours ago    \n" +
+				"model2    sha256:def45    2.0 KB    2 days ago      \n",
 		},
 		{
 			name:          "server error",
@@ -630,6 +642,10 @@ func TestListHandler(t *testing.T) {
 			t.Setenv("OLLAMA_HOST", mockServer.URL)
 
 			cmd := &cobra.Command{}
+			cmd.Flags().Bool("no-headers", false, "Don't print column headers")
+			if tt.noHeaders {
+				cmd.Flags().Set("no-headers", "true")
+			}
 			cmd.SetContext(t.Context())
 
 			// Capture stdout


### PR DESCRIPTION
This pull request introduces a new `--no-headers` flag to the `list` command, allowing users to suppress column headers in the output. Corresponding changes were made to the command implementation and its tests to support and validate this feature.

### Feature Addition: `--no-headers` Flag

* **Command Implementation:**
  - Added a `--no-headers` flag to the `list` command in `func NewCLI()` to allow users to toggle the display of column headers.
  - Updated `ListHandler` to conditionally set table headers based on the `--no-headers` flag.

* **Testing:**
  - Enhanced the `TestListHandler` test suite to include a new test case for the `--no-headers` flag, verifying output without column headers.
  - Modified the test setup to handle the `--no-headers` flag in test cases, ensuring accurate simulation of the command's behavior.