### PR TITLE
ggml: log when cuda is skipped

### DIFF
--- a/ml/backend/ggml/ggml/src/ggml-backend-reg.cpp
+++ b/ml/backend/ggml/ggml/src/ggml-backend-reg.cpp
@@ -580,6 +580,10 @@ void ggml_backend_load_all_from_path(const char * dir_path) {
     if (!hip_devices && !rocr_devices) {
         ggml_backend_load_best("cuda", silent, dir_path);
     } else {
+        if (!silent) {
+            GGML_LOG_DEBUG("%s: skipping CUDA backend due to HIP_VISIBLE_DEVICES='%s' or ROCR_VISIBLE_DEVICES='%s' being set\n",
+                           __func__, hip_devices ? hip_devices : "nullptr", rocr_devices ? rocr_devices : "nullptr");
+        }
         ggml_backend_load_best("hip", silent, dir_path);
     }
     


### PR DESCRIPTION
After discussion in #11220, it was identified that certain configurations (in this case with Slurm, a common HPC scheduler), may set both `CUDA_VISIBLE_DEVICES` and `ROCR_VISIBLE_DEVICES`, even for nvidia GPUs.

Adding a log message when the cuda backend is skipped would help others debugging this issue.