### PR TITLE
with curl installed in final docker build image,

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -106,7 +106,7 @@ COPY --from=build /bin/ollama /bin/ollama
 
 FROM ubuntu:20.04
 RUN apt-get update \
-    && apt-get install -y ca-certificates \
+    && apt-get install -y ca-certificates curl\
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=archive /bin /usr/bin


### PR DESCRIPTION
user can perform ollama healthy check using the following config in docker
```yaml
services:
    ollama:
        # ... image and container config ...
        healthcheck:
            test: curl localhost:11434
            interval: 10s
            timeout: 3s
            retries: 3
            start_period: 30s
```