### PR TITLE
Add helpful info for Mac users about environment variables

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -82,6 +82,8 @@ If Ollama is run as a macOS application, environment variables should be set usi
 
 2. Restart Ollama application.
 
+This change will not persist when the system is rebooted; you will need to add the `launchctl` command to your `.zshrc` for this to happen.
+
 ### Setting environment variables on Linux
 
 If Ollama is run as a systemd service, environment variables should be set using `systemctl`:


### PR DESCRIPTION
The launchctl command given in the FAQ does not survive a reboot, unlike the commands given for Windows and Linux. This commit adds a note to that effect, and suggests adding the command to the .zshrc.