### PR TITLE
template: Add deepseek with tools support

### DIFF
--- a/template/deepseek.gotmpl
+++ b/template/deepseek.gotmpl
@@ -1,0 +1,20 @@
+{{- if .System }}{{ .System }}{{ end }}
+{{- range $i, $_ := .Messages }}
+{{- $last := eq (len (slice $.Messages $i)) 1}}
+{{- if eq .Role "user" }}<｜User｜>{{ .Content }}
+{{- else if eq .Role "assistant" }}<｜Assistant｜>
+  {{- if and $.IsThinkSet (and $last .Thinking) -}}
+<think>
+{{ .Thinking }}
+</think>
+{{- end }}{{ .Content }}{{- if not $last }}<｜end▁of▁sentence｜>{{- end }}
+{{- end }}
+{{- if and $last (ne .Role "assistant") }}<｜Assistant｜>
+{{- if and $.IsThinkSet (not $.Think) -}}
+<think>
+
+</think>
+
+{{ end }}
+{{- end -}}
+{{- end }}

--- a/template/deepseek.gotmpl
+++ b/template/deepseek.gotmpl
@@ -1,20 +1,20 @@
 {{- if .System }}{{ .System }}{{ end }}
 {{- range $i, $_ := .Messages }}
-{{- $last := eq (len (slice $.Messages $i)) 1}}
-{{- if eq .Role "user" }}<｜User｜>{{ .Content }}
-{{- else if eq .Role "assistant" }}<｜Assistant｜>
-  {{- if and $.IsThinkSet (and $last .Thinking) -}}
-<think>
-{{ .Thinking }}
-</think>
-{{- end }}{{ .Content }}{{- if not $last }}<｜end▁of▁sentence｜>{{- end }}
-{{- end }}
-{{- if and $last (ne .Role "assistant") }}<｜Assistant｜>
-{{- if and $.IsThinkSet (not $.Think) -}}
-<think>
-
-</think>
-
-{{ end }}
+  {{- $last := eq (len (slice $.Messages $i)) 1 }}
+  {{- if eq .Role "user" -}}
+    <｜User｜>{{ .Content }}
+  {{- else if eq .Role "assistant" -}}
+    <｜Assistant｜>
+    {{- if and $.IsThinkSet (and $last .Thinking) -}}
+      <think>
+        {{ .Thinking }}
+      </think>
+    {{- end }}{{ .Content }}{{- if not $last }}<｜end▁of▁sentence｜>{{- end }}
+  {{- end }}
+  {{- if and $last (ne .Role "assistant") -}}
+    <｜Assistant｜>
+    {{- if and $.IsThinkSet (not $.Think) -}}
+      <think> </think>
+    {{ end }}
+  {{- end -}}
 {{- end -}}
-{{- end }}

--- a/template/deepseek.gotmpl
+++ b/template/deepseek.gotmpl
@@ -1,15 +1,41 @@
 {{- if .System }}{{ .System }}{{ end }}
+{{- if .Tools }}
+# Tools
+
+You may call one or more functions to assist with the user query.
+
+You are provided with function signatures within <tools></tools> XML tags:
+<tools>
+{{- range $i, $_ := .Tools }}
+{{ .Function }}
+{{- end }}
+</tools>
+
+For each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags.
+{{- end }}
 {{- range $i, $_ := .Messages }}
   {{- $last := eq (len (slice $.Messages $i)) 1 }}
   {{- if eq .Role "user" -}}
     <｜User｜>{{ .Content }}
   {{- else if eq .Role "assistant" -}}
     <｜Assistant｜>
+    {{- if .ToolCalls -}}
+      {{ "\n" }}<｜tool▁calls▁begin｜>{{ "\n" }}
+      {{- range $i, $_ := .ToolCalls -}}
+        <｜tool▁call▁begin｜>function<｜tool▁sep｜>{{ .Function.Name }}
+```json
+{{ .Function.Arguments }}
+```<｜tool▁call▁end｜>{{ "\n" }}
+      {{- end -}}
+      <｜tool▁calls▁end｜><｜end▁of▁sentence｜>
+    {{- end }}
     {{- if and $.IsThinkSet (and $last .Thinking) -}}
       <think>
         {{ .Thinking }}
       </think>
     {{- end }}{{ .Content }}{{- if not $last }}<｜end▁of▁sentence｜>{{- end }}
+  {{- else if eq .Role "tool" -}}
+    {{ "\n" }}<｜tool▁output▁begin｜>{{ .Content }}<｜tool▁output▁end｜>{{ "\n" }}
   {{- end }}
   {{- if and $last (ne .Role "assistant") -}}
     <｜Assistant｜>

--- a/template/deepseek.json
+++ b/template/deepseek.json
@@ -1,0 +1,8 @@
+{
+  "stop": [
+    "<｜begin▁of▁sentence｜>",
+    "<｜end▁of▁sentence｜>",
+    "<｜User｜>",
+    "<｜Assistant｜>"
+  ]
+}

--- a/template/testdata/command-r.gotmpl/tools-single
+++ b/template/testdata/command-r.gotmpl/tools-single
@@ -1,0 +1,22 @@
+<|START_OF_TURN_TOKEN|><|SYSTEM_TOKEN|># Safety Preamble
+The instructions in this section override those in the task description and style guide sections. Don't answer questions that are harmful or immoral.
+
+# System Preamble
+## Basic Rules
+You are a powerful conversational AI trained by Cohere to help people. You are augmented by a number of tools, and your job is to use and consume the output of these tools to best help the user. You will see a conversation history between yourself and a user, ending with an utterance from the user. You will then see a specific instruction instructing you what kind of response to generate. When you answer the user's requests, you cite your sources in your answers, according to those instructions.
+
+
+
+## Available Tools
+Here is a list of tools that you have available to you:
+
+```python
+def get_weather(location: string, unit: string, ) -> List[Dict]:
+    '''Get current weather information for a location
+
+    Args:
+        location (string): The city and state, e.g. San Francisco, CA
+        unit (string): The unit of temperature to use
+    '''
+    pass
+```<|END_OF_TURN_TOKEN|><|END_OF_TURN_TOKEN|><|START_OF_TURN_TOKEN|><|CHATBOT_TOKEN|>

--- a/template/testdata/command-r.gotmpl/tools-single-call
+++ b/template/testdata/command-r.gotmpl/tools-single-call
@@ -1,0 +1,8 @@
+<|START_OF_TURN_TOKEN|><|CHATBOT_TOKEN|>
+Action: ```json
+[
+    {
+        "tool_name": "get_weather",
+        "parameters": {"location":"San Francisco, CA"}
+    }
+]```<|END_OF_TURN_TOKEN|><|END_OF_TURN_TOKEN|><|START_OF_TURN_TOKEN|><|CHATBOT_TOKEN|>

--- a/template/testdata/command-r.gotmpl/tools-single-result
+++ b/template/testdata/command-r.gotmpl/tools-single-result
@@ -1,0 +1,3 @@
+<|START_OF_TURN_TOKEN|><|SYSTEM_TOKEN|><results>
+console_output: {"temperature": 22, "condition": "Sunny", "humidity": 45, "wind_speed": 10}
+</results><|END_OF_TURN_TOKEN|><|END_OF_TURN_TOKEN|><|START_OF_TURN_TOKEN|><|CHATBOT_TOKEN|>

--- a/template/testdata/deepseek.gotmpl/system-user-assistant-user
+++ b/template/testdata/deepseek.gotmpl/system-user-assistant-user
@@ -1,0 +1,1 @@
+You are a helpful assistant.<｜User｜>Hello, how are you?<｜Assistant｜>I'm doing great. How can I help you today?<｜end▁of▁sentence｜><｜User｜>I'd like to show off how chat templating works!<｜Assistant｜>

--- a/template/testdata/deepseek.gotmpl/tools-single
+++ b/template/testdata/deepseek.gotmpl/tools-single
@@ -1,0 +1,11 @@
+
+# Tools
+
+You may call one or more functions to assist with the user query.
+
+You are provided with function signatures within <tools></tools> XML tags:
+<tools>
+{"name":"get_weather","description":"Get current weather information for a location","parameters":{"type":"object","required":["location"],"properties":{"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"},"unit":{"type":"string","description":"The unit of temperature to use","enum":["celsius","fahrenheit"]}}}}
+</tools>
+
+For each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags.

--- a/template/testdata/deepseek.gotmpl/tools-single-call
+++ b/template/testdata/deepseek.gotmpl/tools-single-call
@@ -1,0 +1,7 @@
+<｜Assistant｜>
+<｜tool▁calls▁begin｜>
+<｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+```json
+{"location":"San Francisco, CA"}
+```<｜tool▁call▁end｜>
+<｜tool▁calls▁end｜><｜end▁of▁sentence｜>

--- a/template/testdata/deepseek.gotmpl/tools-single-result
+++ b/template/testdata/deepseek.gotmpl/tools-single-result
@@ -1,0 +1,3 @@
+
+<｜tool▁output▁begin｜>{"temperature": 22, "condition": "Sunny", "humidity": 45, "wind_speed": 10}<｜tool▁output▁end｜>
+<｜Assistant｜>

--- a/template/testdata/deepseek.gotmpl/user
+++ b/template/testdata/deepseek.gotmpl/user
@@ -1,0 +1,1 @@
+<｜User｜>Hello, how are you?<｜Assistant｜>

--- a/template/testdata/deepseek.gotmpl/user-assistant-user
+++ b/template/testdata/deepseek.gotmpl/user-assistant-user
@@ -1,0 +1,1 @@
+<｜User｜>Hello, how are you?<｜Assistant｜>I'm doing great. How can I help you today?<｜end▁of▁sentence｜><｜User｜>I'd like to show off how chat templating works!<｜Assistant｜>


### PR DESCRIPTION
* add template tests involving tools
* add deepseek template from current model and add tools support

Addressing https://github.com/ollama/ollama/issues/10912

Using https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-32B?chat_template=default&format=true as reference for the special tokens.

Now, I don't really understand what is important in the templates and which tokens need to be included in parameters too. So:
1. are the test cases sufficiently complex or should there be more interleaving messages?
2. review the use of tokens, should some be included in params?
3. template doesn't try to join consecutive tool outputs and surround them in `<tools_output></tools_output>` like the jinja2 seems to try. should it?

It does seem to work but I'm not qualified to evaluate how well or if something else broke (see https://github.com/ollama/ollama/issues/10912#issuecomment-2927853932)

It could be useful to have tests verifying that the tool calls do indeed get parsed as tool calls.

Is "deepseek" ok for levenshtein or should it be "deepseek-r1"?