### PR TITLE
server: add option to preserve think tags in chat

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -109,6 +109,9 @@ type ChatRequest struct {
 	// following the request.
 	KeepAlive *Duration `json:"keep_alive,omitempty"`
 
+	// PreserveThinkBlock preserves the <think> block in .content (false by default).
+	PreserveThinkBlock *bool `json:"preserve_think_block,omitempty"`
+
 	// Tools is an optional list of tools the model has access to.
 	Tools `json:"tools,omitempty"`
 


### PR DESCRIPTION
This commit introduces a preserve_think_block option to the chat API. When set to true, the server will not strip <think> tags from the assistant's response content.

This is useful for agentic workflows and multi-turn reasoning where preserving the full model output, including thought processes, is required.

This also fixes a bug where the thinking parser was not active unless the think true parameter was explicitly set, causing think tags to be leaked to the user unexpectedly.

Fixes #11279