### PR TITLE
report progress during load

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -254,12 +254,15 @@ type ChatResponse struct {
 
 	Done bool `json:"done"`
 
+	Error string `json:"error,omitempty"`
+
 	Metrics
 }
 
 type Metrics struct {
 	TotalDuration      time.Duration `json:"total_duration,omitempty"`
 	LoadDuration       time.Duration `json:"load_duration,omitempty"`
+	LoadProgress       int           `json:"load_progress,omitempty"`
 	PromptEvalCount    int           `json:"prompt_eval_count,omitempty"`
 	PromptEvalDuration time.Duration `json:"prompt_eval_duration,omitempty"`
 	EvalCount          int           `json:"eval_count,omitempty"`
@@ -504,6 +507,10 @@ type GenerateResponse struct {
 	// Context is an encoding of the conversation used in this response; this
 	// can be sent in the next request to keep a conversational memory.
 	Context []int `json:"context,omitempty"`
+
+	// Error will contain an error message if the request could not
+	// be completed due to an error
+	Error string `json:"error,omitempty"`
 
 	Metrics
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1084,6 +1084,10 @@ func chat(cmd *cobra.Command, opts runOptions) (*api.Message, error) {
 	var thinkTagClosed bool = false
 
 	fn := func(response api.ChatResponse) error {
+		if response.Error != "" {
+			return fmt.Errorf("error: %s", response.Error)
+		}
+
 		if response.Message.Content != "" || !opts.HideThinking {
 			p.StopAndClear()
 		}
@@ -1192,6 +1196,9 @@ func generate(cmd *cobra.Command, opts runOptions) error {
 	plainText := !term.IsTerminal(int(os.Stdout.Fd()))
 
 	fn := func(response api.GenerateResponse) error {
+		if response.Error != "" {
+			return fmt.Errorf("error: %s", response.Error)
+		}
 		latest = response
 		content := response.Response
 

--- a/server/routes.go
+++ b/server/routes.go
@@ -89,7 +89,7 @@ func modelOptions(model *Model, requestOpts map[string]any) (api.Options, error)
 
 // scheduleRunner schedules a runner after validating inputs such as capabilities and model options.
 // It returns the allocated runner, model instance, and consolidated options if successful and error otherwise.
-func (s *Server) scheduleRunner(ctx context.Context, name string, caps []model.Capability, requestOpts map[string]any, keepAlive *api.Duration) (llm.LlamaServer, *Model, *api.Options, error) {
+func (s *Server) scheduleRunner(ctx context.Context, name string, caps []model.Capability, requestOpts map[string]any, keepAlive *api.Duration, cb func(int)) (llm.LlamaServer, *Model, *api.Options, error) {
 	if name == "" {
 		return nil, nil, nil, fmt.Errorf("model %w", errRequired)
 	}
@@ -112,7 +112,7 @@ func (s *Server) scheduleRunner(ctx context.Context, name string, caps []model.C
 		return nil, nil, nil, err
 	}
 
-	runnerCh, errCh := s.sched.GetRunner(ctx, model, opts, keepAlive)
+	runnerCh, errCh := s.sched.GetRunner(ctx, model, opts, keepAlive, cb)
 	var runner *runnerRef
 	select {
 	case runner = <-runnerCh:
@@ -127,10 +127,10 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 	checkpointStart := time.Now()
 	var req api.GenerateRequest
 	if err := c.ShouldBindJSON(&req); errors.Is(err, io.EOF) {
-		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "missing request body"})
+		c.AbortWithStatusJSON(http.StatusBadRequest, api.GenerateResponse{Done: true, Error: "missing request body"})
 		return
 	} else if err != nil {
-		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		c.AbortWithStatusJSON(http.StatusBadRequest, api.GenerateResponse{Done: true, Error: err.Error()})
 		return
 	}
 
@@ -138,7 +138,7 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 	if !name.IsValid() {
 		// Ideally this is "invalid model name" but we're keeping with
 		// what the API currently returns until we can change it.
-		c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("model '%s' not found", req.Model)})
+		c.JSON(http.StatusNotFound, api.GenerateResponse{Done: true, Error: fmt.Sprintf("model '%s' not found", req.Model)})
 		return
 	}
 
@@ -146,7 +146,7 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 	// induce infinite recursion given the current code structure.
 	name, err := getExistingName(name)
 	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("model '%s' not found", req.Model)})
+		c.JSON(http.StatusNotFound, api.GenerateResponse{Done: true, Error: fmt.Sprintf("model '%s' not found", req.Model)})
 		return
 	}
 
@@ -154,11 +154,11 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 	if err != nil {
 		switch {
 		case errors.Is(err, fs.ErrNotExist):
-			c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("model '%s' not found", req.Model)})
+			c.JSON(http.StatusNotFound, api.GenerateResponse{Done: true, Error: fmt.Sprintf("model '%s' not found", req.Model)})
 		case err.Error() == errtypes.InvalidModelNameErrMsg:
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			c.JSON(http.StatusBadRequest, api.GenerateResponse{Done: true, Error: err.Error()})
 		default:
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			c.JSON(http.StatusInternalServerError, api.GenerateResponse{Done: true, Error: err.Error()})
 		}
 		return
 	}
@@ -178,7 +178,7 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 	}
 
 	if req.Raw && (req.Template != "" || req.System != "" || len(req.Context) > 0) {
-		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "raw mode does not support template, system, or context"})
+		c.AbortWithStatusJSON(http.StatusBadRequest, api.GenerateResponse{Done: true, Error: "raw mode does not support template, system, or context"})
 		return
 	}
 
@@ -194,12 +194,48 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 		// updated template supporting thinking
 	}
 
-	r, m, opts, err := s.scheduleRunner(c.Request.Context(), name.String(), caps, req.Options, req.KeepAlive)
+	streamStarted := false
+	cb := func(progress int) {
+		if req.Stream == nil || *req.Stream {
+			res := api.GenerateResponse{
+				Model:     req.Model,
+				CreatedAt: time.Now().UTC(),
+				Metrics: api.Metrics{
+					LoadProgress: progress,
+				},
+			}
+			if !streamStarted {
+				c.Header("Content-Type", "application/x-ndjson")
+				streamStarted = true
+			}
+			bts, err := json.Marshal(res)
+			if err != nil {
+				slog.Info(fmt.Sprintf("streamResponse: json.Marshal failed with %s", err))
+				return
+			}
+			bts = append(bts, '\n')
+			w := c.Writer
+			clientGone := w.CloseNotify()
+			select {
+			case <-clientGone:
+				return
+			default:
+				if _, err := w.Write(bts); err != nil {
+					slog.Info(fmt.Sprintf("streamResponse: w.Write failed with %s", err))
+					return
+				}
+				w.Flush()
+			}
+		}
+	}
+
+	r, m, opts, err := s.scheduleRunner(c.Request.Context(), name.String(), caps, req.Options, req.KeepAlive, cb)
 	if errors.Is(err, errCapabilityCompletion) {
-		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("%q does not support generate", req.Model)})
+		c.JSON(http.StatusBadRequest, api.GenerateResponse{Done: true, Error: fmt.Sprintf("%q does not support generate", req.Model)})
 		return
 	} else if err != nil {
-		handleScheduleError(c, req.Model, err)
+		code, msg := scheduleError(err)
+		c.JSON(code, api.GenerateResponse{Done: true, Error: msg})
 		return
 	}
 
@@ -217,7 +253,7 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 	}
 
 	if slices.Contains(m.Config.ModelFamilies, "mllama") && len(req.Images) > 1 {
-		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "this model only supports one image while more than one image requested"})
+		c.AbortWithStatusJSON(http.StatusBadRequest, api.GenerateResponse{Done: true, Error: "this model only supports one image while more than one image requested"})
 		return
 	}
 
@@ -232,7 +268,7 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 		if req.Template != "" {
 			tmpl, err = template.Parse(req.Template)
 			if err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+				c.JSON(http.StatusInternalServerError, api.GenerateResponse{Done: true, Error: err.Error()})
 				return
 			}
 		}
@@ -269,14 +305,14 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 			slog.Warn("the context field is deprecated and will be removed in a future version of Ollama")
 			s, err := r.Detokenize(c.Request.Context(), req.Context)
 			if err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+				c.JSON(http.StatusInternalServerError, api.GenerateResponse{Done: true, Error: err.Error()})
 				return
 			}
 			b.WriteString(s)
 		}
 
 		if err := tmpl.Execute(&b, values); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			c.JSON(http.StatusInternalServerError, api.GenerateResponse{Done: true, Error: err.Error()})
 			return
 		}
 
@@ -323,7 +359,7 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 			}
 
 			if _, err := sb.WriteString(cr.Content); err != nil {
-				ch <- gin.H{"error": err.Error()}
+				ch <- api.GenerateResponse{Done: true, Error: err.Error()}
 			}
 
 			if cr.Done {
@@ -334,7 +370,7 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 				if !req.Raw {
 					tokens, err := r.Tokenize(c.Request.Context(), prompt+sb.String())
 					if err != nil {
-						ch <- gin.H{"error": err.Error()}
+						ch <- api.GenerateResponse{Done: true, Error: err.Error()}
 						return
 					}
 					res.Context = tokens
@@ -343,7 +379,7 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 
 			ch <- res
 		}); err != nil {
-			ch <- gin.H{"error": err.Error()}
+			ch <- api.GenerateResponse{Done: true, Error: err.Error()}
 		}
 	}()
 
@@ -363,10 +399,10 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 					msg = "unexpected error format in response"
 				}
 
-				c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
+				c.JSON(http.StatusInternalServerError, api.GenerateResponse{Done: true, Error: msg})
 				return
 			default:
-				c.JSON(http.StatusInternalServerError, gin.H{"error": "unexpected response"})
+				c.JSON(http.StatusInternalServerError, api.GenerateResponse{Done: true, Error: "unexpected response"})
 				return
 			}
 		}
@@ -428,7 +464,7 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 		return
 	}
 
-	r, m, opts, err := s.scheduleRunner(c.Request.Context(), name.String(), []model.Capability{}, req.Options, req.KeepAlive)
+	r, m, opts, err := s.scheduleRunner(c.Request.Context(), name.String(), []model.Capability{}, req.Options, req.KeepAlive, nil)
 	if err != nil {
 		handleScheduleError(c, req.Model, err)
 		return
@@ -536,7 +572,7 @@ func (s *Server) EmbeddingsHandler(c *gin.Context) {
 		return
 	}
 
-	r, _, _, err := s.scheduleRunner(c.Request.Context(), name.String(), []model.Capability{}, req.Options, req.KeepAlive)
+	r, _, _, err := s.scheduleRunner(c.Request.Context(), name.String(), []model.Capability{}, req.Options, req.KeepAlive, nil)
 	if err != nil {
 		handleScheduleError(c, req.Model, err)
 		return
@@ -1480,12 +1516,47 @@ func (s *Server) ChatHandler(c *gin.Context) {
 		return
 	}
 
-	r, m, opts, err := s.scheduleRunner(c.Request.Context(), name.String(), caps, req.Options, req.KeepAlive)
+	streamStarted := false
+	cb := func(progress int) {
+		if req.Stream == nil || *req.Stream {
+			res := api.ChatResponse{
+				Model:     req.Model,
+				CreatedAt: time.Now().UTC(),
+				Metrics: api.Metrics{
+					LoadProgress: progress,
+				},
+			}
+			if !streamStarted {
+				c.Header("Content-Type", "application/x-ndjson")
+				streamStarted = true
+			}
+			bts, err := json.Marshal(res)
+			if err != nil {
+				slog.Info(fmt.Sprintf("streamResponse: json.Marshal failed with %s", err))
+				return
+			}
+			bts = append(bts, '\n')
+			w := c.Writer
+			clientGone := w.CloseNotify()
+			select {
+			case <-clientGone:
+				return
+			default:
+				if _, err := w.Write(bts); err != nil {
+					slog.Info(fmt.Sprintf("streamResponse: w.Write failed with %s", err))
+					return
+				}
+				w.Flush()
+			}
+		}
+	}
+	r, m, opts, err := s.scheduleRunner(c.Request.Context(), name.String(), caps, req.Options, req.KeepAlive, cb)
 	if errors.Is(err, errCapabilityCompletion) {
-		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("%q does not support chat", req.Model)})
+		c.JSON(http.StatusBadRequest, api.ChatResponse{Done: true, Error: fmt.Sprintf("%q does not support chat", req.Model)})
 		return
 	} else if err != nil {
-		handleScheduleError(c, req.Model, err)
+		code, msg := scheduleError(err)
+		c.JSON(code, api.ChatResponse{Done: true, Error: msg})
 		return
 	}
 
@@ -1511,7 +1582,7 @@ func (s *Server) ChatHandler(c *gin.Context) {
 	prompt, images, err := chatPrompt(c.Request.Context(), m, r.Tokenize, opts, msgs, req.Tools, req.Think)
 	if err != nil {
 		slog.Error("chat prompt error", "error", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		c.JSON(http.StatusInternalServerError, api.ChatResponse{Done: true, Error: err.Error()})
 		return
 	}
 
@@ -1588,7 +1659,7 @@ func (s *Server) ChatHandler(c *gin.Context) {
 
 			ch <- res
 		}); err != nil {
-			ch <- gin.H{"error": err.Error()}
+			ch <- api.ChatResponse{Done: true, Error: err.Error()}
 		}
 	}()
 
@@ -1612,10 +1683,10 @@ func (s *Server) ChatHandler(c *gin.Context) {
 					msg = "unexpected error format in response"
 				}
 
-				c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
+				c.JSON(http.StatusInternalServerError, api.ChatResponse{Done: true, Error: msg})
 				return
 			default:
-				c.JSON(http.StatusInternalServerError, gin.H{"error": "unexpected response"})
+				c.JSON(http.StatusInternalServerError, api.ChatResponse{Done: true, Error: "unexpected response"})
 				return
 			}
 		}
@@ -1634,6 +1705,22 @@ func (s *Server) ChatHandler(c *gin.Context) {
 	streamResponse(c, ch)
 }
 
+func scheduleError(err error) (int, string) {
+	switch {
+	case errors.Is(err, errCapabilities), errors.Is(err, errRequired):
+		return http.StatusBadRequest, err.Error()
+	case errors.Is(err, context.Canceled):
+		return 499, "request canceled"
+	case errors.Is(err, ErrMaxQueue):
+		return http.StatusServiceUnavailable, err.Error()
+	case errors.Is(err, os.ErrNotExist):
+		return http.StatusNotFound, "model not found, try pulling it first"
+	default:
+		return http.StatusInternalServerError, err.Error()
+	}
+}
+
+// TODO remove once no longer used
 func handleScheduleError(c *gin.Context, name string, err error) {
 	switch {
 	case errors.Is(err, errCapabilities), errors.Is(err, errRequired):

--- a/server/routes_generate_test.go
+++ b/server/routes_generate_test.go
@@ -157,7 +157,7 @@ func TestGenerateChat(t *testing.T) {
 			t.Errorf("expected status 400, got %d", w.Code)
 		}
 
-		if diff := cmp.Diff(w.Body.String(), `{"error":"registry.ollama.ai/library/test:latest does not support thinking"}`); diff != "" {
+		if diff := cmp.Diff(w.Body.String(), `{"model":"","created_at":"0001-01-01T00:00:00Z","message":{"role":"","content":""},"done":true,"error":"registry.ollama.ai/library/test:latest does not support thinking"}`); diff != "" {
 			t.Errorf("mismatch (-got +want):\n%s", diff)
 		}
 	})
@@ -196,7 +196,7 @@ func TestGenerateChat(t *testing.T) {
 			t.Errorf("expected status 400, got %d", w.Code)
 		}
 
-		if diff := cmp.Diff(w.Body.String(), `{"error":"\"bert\" does not support chat"}`); diff != "" {
+		if diff := cmp.Diff(w.Body.String(), `{"model":"","created_at":"0001-01-01T00:00:00Z","message":{"role":"","content":""},"done":true,"error":"\"bert\" does not support chat"}`); diff != "" {
 			t.Errorf("mismatch (-got +want):\n%s", diff)
 		}
 	})
@@ -697,7 +697,7 @@ func TestGenerate(t *testing.T) {
 			t.Errorf("expected status 404, got %d", w.Code)
 		}
 
-		if diff := cmp.Diff(w.Body.String(), `{"error":"model '' not found"}`); diff != "" {
+		if diff := cmp.Diff(w.Body.String(), `{"model":"","created_at":"0001-01-01T00:00:00Z","response":"","done":true,"error":"model '' not found"}`); diff != "" {
 			t.Errorf("mismatch (-got +want):\n%s", diff)
 		}
 	})
@@ -708,7 +708,7 @@ func TestGenerate(t *testing.T) {
 			t.Errorf("expected status 404, got %d", w.Code)
 		}
 
-		if diff := cmp.Diff(w.Body.String(), `{"error":"model '' not found"}`); diff != "" {
+		if diff := cmp.Diff(w.Body.String(), `{"model":"","created_at":"0001-01-01T00:00:00Z","response":"","done":true,"error":"model '' not found"}`); diff != "" {
 			t.Errorf("mismatch (-got +want):\n%s", diff)
 		}
 	})
@@ -737,7 +737,7 @@ func TestGenerate(t *testing.T) {
 			t.Errorf("expected status 400, got %d", w.Code)
 		}
 
-		if diff := cmp.Diff(w.Body.String(), `{"error":"\"bert\" does not support generate"}`); diff != "" {
+		if diff := cmp.Diff(w.Body.String(), `{"model":"","created_at":"0001-01-01T00:00:00Z","response":"","done":true,"error":"\"bert\" does not support generate"}`); diff != "" {
 			t.Errorf("mismatch (-got +want):\n%s", diff)
 		}
 	})
@@ -753,7 +753,7 @@ func TestGenerate(t *testing.T) {
 			t.Errorf("expected status 400, got %d", w.Code)
 		}
 
-		if diff := cmp.Diff(w.Body.String(), `{"error":"registry.ollama.ai/library/test:latest does not support insert"}`); diff != "" {
+		if diff := cmp.Diff(w.Body.String(), `{"model":"","created_at":"0001-01-01T00:00:00Z","response":"","done":true,"error":"registry.ollama.ai/library/test:latest does not support insert"}`); diff != "" {
 			t.Errorf("mismatch (-got +want):\n%s", diff)
 		}
 	})

--- a/server/sched.go
+++ b/server/sched.go
@@ -33,6 +33,7 @@ type LlmRequest struct {
 	successCh       chan *runnerRef
 	errCh           chan error
 	schedAttempts   uint
+	progressCb      func(progress int) // if non-nil, report progress while loading periodically
 }
 
 type Scheduler struct {
@@ -81,7 +82,7 @@ func InitScheduler(ctx context.Context) *Scheduler {
 }
 
 // context must be canceled to decrement ref count and release the runner
-func (s *Scheduler) GetRunner(c context.Context, model *Model, opts api.Options, sessionDuration *api.Duration) (chan *runnerRef, chan error) {
+func (s *Scheduler) GetRunner(c context.Context, model *Model, opts api.Options, sessionDuration *api.Duration, cb func(int)) (chan *runnerRef, chan error) {
 	if opts.NumCtx < 4 {
 		opts.NumCtx = 4
 	}
@@ -93,6 +94,7 @@ func (s *Scheduler) GetRunner(c context.Context, model *Model, opts api.Options,
 		sessionDuration: sessionDuration,
 		successCh:       make(chan *runnerRef),
 		errCh:           make(chan error, 1),
+		progressCb:      cb,
 	}
 
 	select {
@@ -485,7 +487,7 @@ func (s *Scheduler) load(req *LlmRequest, f *ggml.GGML, gpus discover.GpuInfoLis
 
 	go func() {
 		defer runner.refMu.Unlock()
-		if err = llama.WaitUntilRunning(req.ctx); err != nil {
+		if err = llama.WaitUntilRunning(req.ctx, req.progressCb); err != nil {
 			slog.Error("error loading llama server", "error", err)
 			req.errCh <- err
 			slog.Debug("triggering expiration for failed load", "runner", runner)

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -363,10 +363,10 @@ func TestGetRunner(t *testing.T) {
 	s.getCpuFn = getCpuFn
 	s.newServerFn = a.newServer
 	slog.Info("a")
-	successCh1a, errCh1a := s.GetRunner(a.ctx, a.req.model, a.req.opts, a.req.sessionDuration)
+	successCh1a, errCh1a := s.GetRunner(a.ctx, a.req.model, a.req.opts, a.req.sessionDuration, nil)
 	require.Len(t, s.pendingReqCh, 1)
 	slog.Info("b")
-	successCh1b, errCh1b := s.GetRunner(b.ctx, b.req.model, b.req.opts, b.req.sessionDuration)
+	successCh1b, errCh1b := s.GetRunner(b.ctx, b.req.model, b.req.opts, b.req.sessionDuration, nil)
 	require.Len(t, s.pendingReqCh, 1)
 	require.Empty(t, successCh1b)
 	require.Len(t, errCh1b, 1)
@@ -390,7 +390,7 @@ func TestGetRunner(t *testing.T) {
 
 	c.req.model.ModelPath = "bad path"
 	slog.Info("c")
-	successCh1c, errCh1c := s.GetRunner(c.ctx, c.req.model, c.req.opts, c.req.sessionDuration)
+	successCh1c, errCh1c := s.GetRunner(c.ctx, c.req.model, c.req.opts, c.req.sessionDuration, nil)
 	// Starts in pending channel, then should be quickly processed to return an error
 	time.Sleep(50 * time.Millisecond) // Long enough for the "a" model to expire and unload
 	require.Empty(t, successCh1c)
@@ -464,7 +464,7 @@ func TestPrematureExpired(t *testing.T) {
 		return []discover.GpuInfo{g}
 	}
 	s.newServerFn = scenario1a.newServer
-	successCh1a, errCh1a := s.GetRunner(scenario1a.ctx, scenario1a.req.model, scenario1a.req.opts, scenario1a.req.sessionDuration)
+	successCh1a, errCh1a := s.GetRunner(scenario1a.ctx, scenario1a.req.model, scenario1a.req.opts, scenario1a.req.sessionDuration, nil)
 	require.Len(t, s.pendingReqCh, 1)
 	s.Run(ctx)
 	select {
@@ -763,8 +763,8 @@ type mockLlm struct {
 	estimatedVRAMByGPU map[string]uint64
 }
 
-func (s *mockLlm) Ping(ctx context.Context) error             { return s.pingResp }
-func (s *mockLlm) WaitUntilRunning(ctx context.Context) error { return s.waitResp }
+func (s *mockLlm) Ping(ctx context.Context) error                           { return s.pingResp }
+func (s *mockLlm) WaitUntilRunning(ctx context.Context, cb func(int)) error { return s.waitResp }
 func (s *mockLlm) Completion(ctx context.Context, req llm.CompletionRequest, fn func(llm.CompletionResponse)) error {
 	return s.completionResp
 }


### PR DESCRIPTION
This extends the Chat and Generate APIs to stream progress updates during model load.  A side-effect of the change is loading errors can be reported in the stream if they occur after we start streaming progress updates.

Example curl output:
```
% curl http://localhost:11434/api/chat -d '{
  "model": "gemma3n",
  "messages":[{"role":"user","content":"hello"}]
}'
{"model":"gemma3n","created_at":"2025-07-06T20:31:51.83739Z","message":{"role":"","content":""},"done":false,"load_progress":11}
{"model":"gemma3n","created_at":"2025-07-06T20:31:52.088228Z","message":{"role":"","content":""},"done":false,"load_progress":48}
{"model":"gemma3n","created_at":"2025-07-06T20:31:52.33935Z","message":{"role":"","content":""},"done":false,"load_progress":70}
{"model":"gemma3n","created_at":"2025-07-06T20:31:52.589736Z","message":{"role":"","content":""},"done":false,"load_progress":92}
{"model":"gemma3n","created_at":"2025-07-06T20:31:52.841086Z","message":{"role":"","content":""},"done":false,"load_progress":100}
{"model":"gemma3n","created_at":"2025-07-06T20:31:52.945664Z","message":{"role":"assistant","content":"Hello"},"done":false}
{"model":"gemma3n","created_at":"2025-07-06T20:31:52.964794Z","message":{"role":"assistant","content":" there"},"done":false}
...
{"model":"gemma3n","created_at":"2025-07-06T20:31:53.705994Z","message":{"role":"assistant","content":""},"done_reason":"stop","done":true,"total_duration":2524677375,"load_duration":1659822750,"prompt_eval_count":10,"prompt_eval_duration":103464958,"eval_count":43,"eval_duration":760736709}
```

```
% curl http://localhost:11434/api/generate -d '{
  "model": "gemma3n",
  "prompt": "hello"
}'
{"model":"gemma3n","created_at":"2025-07-06T20:52:18.804913Z","response":"","done":false,"load_progress":8}
{"model":"gemma3n","created_at":"2025-07-06T20:52:19.056388Z","response":"","done":false,"load_progress":37}
{"model":"gemma3n","created_at":"2025-07-06T20:52:19.307753Z","response":"","done":false,"load_progress":47}
{"model":"gemma3n","created_at":"2025-07-06T20:52:19.558891Z","response":"","done":false,"load_progress":64}
{"model":"gemma3n","created_at":"2025-07-06T20:52:19.810266Z","response":"","done":false,"load_progress":82}
{"model":"gemma3n","created_at":"2025-07-06T20:52:20.061133Z","response":"","done":false,"load_progress":100}
{"model":"gemma3n","created_at":"2025-07-06T20:52:20.176715Z","response":"Hello","done":false}
{"model":"gemma3n","created_at":"2025-07-06T20:52:20.194763Z","response":" there","done":false}
...
{"model":"gemma3n","created_at":"2025-07-06T20:52:23.026797Z","response":"","done":true,"done_reason":"stop","context":[105,2364,107,23391,106,107,105,4368,107,9259,993,236888,103453,236743,107,107,3910,740,564,1601,611,3124,236881,138,107,107,236777,740,236787,107,107,236829,5213,7925,822,4137,53121,236743,29020,786,614,109542,522,611,236789,500,23210,1003,236888,107,236829,5213,43204,9578,3004,53121,236743,33403,236764,510,4755,1356,236764,3393,236764,32524,236764,13906,9097,236764,4553,236764,11739,236764,4044,236761,107,236829,5213,40414,21389,44070,3624,53121,236743,564,740,17866,1534,1551,1607,21389,44070,3624,236761,107,236829,5213,160773,969,1816,53121,236743,23097,786,496,1440,4676,532,564,236789,859,2583,611,496,63510,12323,236761,107,236829,5213,67400,4393,741,6549,53121,236743,19704,1601,4891,872,607,6549,573,496,2203,236881,564,740,1601,236888,107,236829,5213,11896,11184,236888,1018,236743,18692,625,236789,236751,6290,531,735,1647,50105,866,531,2910,531,236761,107,107,11896,1531,786,1281,1144,611,236789,236753,1133,786,531,776,236888,73687,107,107,107,107],"total_duration":4879476959,"load_duration":1913893875,"prompt_eval_count":10,"prompt_eval_duration":114435209,"eval_count":157,"eval_duration":2850490458}
```

The interactive CLI keeps the spinner running throughout the load phase.