### PR TITLE
Add reranking in new engine (ollamarunner)

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -296,6 +296,7 @@ type Runner struct {
 	MainGPU   int   `json:"main_gpu,omitempty"`
 	UseMMap   *bool `json:"use_mmap,omitempty"`
 	NumThread int   `json:"num_thread,omitempty"`
+	Reranking bool  `json:"reranking,omitempty"`
 }
 
 // EmbedRequest is the request passed to [Client.Embed].
@@ -345,6 +346,32 @@ type EmbeddingRequest struct {
 // EmbeddingResponse is the response from [Client.Embeddings].
 type EmbeddingResponse struct {
 	Embedding []float64 `json:"embedding"`
+}
+
+type RerankRequest struct {
+	Model           string                 `json:"model"`
+	Query           string                 `json:"query"`
+	TopN            int                    `json:"top_n"`     // return top N documents
+	Documents       []string               `json:"documents"` // list of documents to rerank
+	ReturnDocuments bool                   `json:"return_documents"`
+	KeepAlive       *Duration              `json:"keep_alive,omitempty"`
+	Options         map[string]interface{} `json:"options,omitempty"`
+}
+
+type Usage struct {
+	TotalTokens int `json:"total_tokens"`
+}
+
+type RerankResponse struct {
+	Model   string `json:"model"`
+	Results []struct {
+		Index    int `json:"index"`
+		Document *struct {
+			Text string `json:"text"`
+		} `json:"document,omitempty"`
+		RelevanceScore float32 `json:"relevance_score"`
+	} `json:"results"`
+	Usage Usage `json:"usage,omitempty"`
 }
 
 // CreateRequest is the request passed to [Client.Create].

--- a/docs/api.md
+++ b/docs/api.md
@@ -1894,7 +1894,18 @@ Using the Modelfile:
 ```
 FROM fanyx/Qwen3-Reranker-0.6B-Q8_0
 
-TEMPLATE """!{{ .Query }}"\""[SEP]{{ .Document }}[EOS]"""
+TEMPLATE """<|im_start|>system
+Judge whether the Document meets the requirements based on the Query and the
+Instruct provided. Note that the answer can only be "yes" or
+"no".<|im_end|>
+<|im_start|>user
+<Instruct>: Judge whether the Document meets the requirements based on the Query and the
+Instruct provided. Note that the answer can only be "yes" or
+"no".
+<Query>: {{ .Query }}
+<Document>: {{ .Document }}<|im_end|>
+<|im_start|>assistant
+<think>\n\n</think>\n\n"""
 ```
 
 #### Request

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,6 +4,7 @@
 
 - [Generate a completion](#generate-a-completion)
 - [Generate a chat completion](#generate-a-chat-completion)
+- [Rerank documents](#rerank-documents)
 - [Create a Model](#create-a-model)
 - [List Local Models](#list-local-models)
 - [Show Model Information](#show-model-information)
@@ -1866,6 +1867,101 @@ curl http://localhost:11434/api/version
 ```json
 {
   "version": "0.5.1"
+}
+```
+
+## Rerank documents
+
+```
+POST /api/rerank
+```
+
+Rerank a list of documents based on a query.
+
+### Parameters
+
+- `model`: (required) the name of the model to use for reranking
+- `query`: (required) the query to use for reranking
+- `documents`: (required) a list of documents to rerank
+- `top_n`: (optional) the number of results to return. Defaults to returning all results.
+- `return_documents`: (optional) if `true`, the documents will be returned in the response. Defaults to `false`.
+
+### Examples
+
+Run ollama with environment variable OLLAMA_NEW_ENGINE=1
+
+Using the Modelfile:
+```
+FROM fanyx/Qwen3-Reranker-0.6B-Q8_0
+
+TEMPLATE """[BOS]{{ .Query }}[EOS][SEP]{{ .Document }}[EOS]"""
+```
+
+#### Request
+
+```shell
+curl http://127.0.0.1:11434/api/rerank \
+	-H "Content-Type: application/json" \
+	-d '{
+      "model": "reranker-fanyx",
+      "query": "What is Ollama, the framework for machine learning things?",
+      "top_n": 10,
+	    "return_documents": true,
+      "documents": [
+		"Angela Merkel was the Chancellor of Germany",
+		"Llamas are animals that have a very soft fur",
+		"Pizza is made of tomatoes and cheese.",
+		"Spaghetti is a type of italian food",
+		"Ollama is a machine learning framework"
+      ]
+    }' | jq
+```
+
+#### Response
+
+```json
+{
+  "model": "reranker-fanyx",
+  "results": [
+    {
+      "index": 4,
+      "document": {
+        "text": "Ollama is a machine learning framework"
+      },
+      "relevance_score": 8.932385
+    },
+    {
+      "index": 3,
+      "document": {
+        "text": "Spaghetti is a type of italian food"
+      },
+      "relevance_score": 8.688866
+    },
+    {
+      "index": 1,
+      "document": {
+        "text": "Llamas are animals that have a very soft fur"
+      },
+      "relevance_score": 8.252699
+    },
+    {
+      "index": 0,
+      "document": {
+        "text": "Angela Merkel was the Chancellor of Germany"
+      },
+      "relevance_score": 7.8848386
+    },
+    {
+      "index": 2,
+      "document": {
+        "text": "Pizza is made of tomatoes and cheese."
+      },
+      "relevance_score": 6.823088
+    }
+  ],
+  "usage": {
+    "total_tokens": 132
+  }
 }
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1894,7 +1894,7 @@ Using the Modelfile:
 ```
 FROM fanyx/Qwen3-Reranker-0.6B-Q8_0
 
-TEMPLATE """[BOS]{{ .Query }}[EOS][SEP]{{ .Document }}[EOS]"""
+TEMPLATE """!{{ .Query }}"\""[SEP]{{ .Document }}[EOS]"""
 ```
 
 #### Request
@@ -1921,46 +1921,46 @@ curl http://127.0.0.1:11434/api/rerank \
 
 ```json
 {
-  "model": "reranker-fanyx",
+  "model": "reranker-fanyx-correct",
   "results": [
     {
       "index": 4,
       "document": {
         "text": "Ollama is a machine learning framework"
       },
-      "relevance_score": 8.932385
-    },
-    {
-      "index": 3,
-      "document": {
-        "text": "Spaghetti is a type of italian food"
-      },
-      "relevance_score": 8.688866
-    },
-    {
-      "index": 1,
-      "document": {
-        "text": "Llamas are animals that have a very soft fur"
-      },
-      "relevance_score": 8.252699
+      "relevance_score": 9.151519
     },
     {
       "index": 0,
       "document": {
         "text": "Angela Merkel was the Chancellor of Germany"
       },
-      "relevance_score": 7.8848386
+      "relevance_score": 8.595248
+    },
+    {
+      "index": 3,
+      "document": {
+        "text": "Spaghetti is a type of italian food"
+      },
+      "relevance_score": 7.900294
     },
     {
       "index": 2,
       "document": {
         "text": "Pizza is made of tomatoes and cheese."
       },
-      "relevance_score": 6.823088
+      "relevance_score": 7.504794
+    },
+    {
+      "index": 1,
+      "document": {
+        "text": "Llamas are animals that have a very soft fur"
+      },
+      "relevance_score": 7.247923
     }
   ],
   "usage": {
-    "total_tokens": 132
+    "total_tokens": 147
   }
 }
 ```

--- a/docs/modelfile.md
+++ b/docs/modelfile.md
@@ -172,6 +172,8 @@ PARAMETER <parameter> <parametervalue>
 | `{{ .System }}`   | The system message used to specify custom behavior.                                           |
 | `{{ .Prompt }}`   | The user prompt message.                                                                      |
 | `{{ .Response }}` | The response from the model. When generating a response, text after this variable is omitted. |
+| `{{ .Query }}`     | The user query message(for rerank usage).                                                    | 
+| `{{ .Document }}` | The user provided documents(for rerank usage).                                               |
 
 ```
 TEMPLATE """{{ if .System }}<|im_start|>system
@@ -180,6 +182,10 @@ TEMPLATE """{{ if .System }}<|im_start|>system
 {{ .Prompt }}<|im_end|>
 {{ end }}<|im_start|>assistant
 """
+```
+
+```
+TEMPLATE """[BOS]{{ .Query }}[EOS][SEP]{{ .Document }}[EOS]"""
 ```
 
 ### SYSTEM

--- a/docs/template.md
+++ b/docs/template.md
@@ -57,6 +57,10 @@ TEMPLATE """{{- if .System }}<|start_header_id|>system<|end_header_id|>
 
 `Suffix` (string): text inserted after the assistant's response
 
+`Query` (string): rerank prompt
+
+`Document` (string): rerank document text
+
 `Messages` (list): list of messages
 
 `Messages[].Role` (string): role which can be one of `system`, `user`, `assistant`, or `tool`

--- a/llm/server.go
+++ b/llm/server.go
@@ -67,6 +67,7 @@ type LlamaServer interface {
 	WaitUntilRunning(ctx context.Context) error
 	Completion(ctx context.Context, req CompletionRequest, fn func(CompletionResponse)) error
 	Embedding(ctx context.Context, input string) ([]float32, error)
+	Rerank(ctx context.Context, req RerankRequest, fn func(RerankResponse)) error
 	Tokenize(ctx context.Context, content string) ([]int, error)
 	Detokenize(ctx context.Context, tokens []int) (string, error)
 	Close() error
@@ -180,6 +181,9 @@ func NewLlamaServer(gpus discover.GpuInfoList, modelPath string, f *ggml.GGML, a
 		"--batch-size", strconv.Itoa(opts.NumBatch),
 	}
 
+	if opts.Reranking {
+		params = append(params, "--reranking")
+	}
 	if opts.NumGPU >= 0 {
 		params = append(params, "--n-gpu-layers", strconv.Itoa(opts.NumGPU))
 	}
@@ -953,6 +957,70 @@ func (s *llmServer) Embedding(ctx context.Context, input string) ([]float32, err
 	}
 
 	return e.Embedding, nil
+}
+
+type RerankRequest struct {
+	Model   string   `json:"model"`
+	Prompts []string `json:"prompts"`
+}
+
+type RerankResponse struct {
+	Results []struct {
+		Index          int     `json:"index"`
+		RelevanceScore float32 `json:"relevance_score"`
+	} `json:"results"`
+	api.Usage
+}
+
+func (s *llmServer) Rerank(ctx context.Context, req RerankRequest, fn func(RerankResponse)) error {
+	if err := s.sem.Acquire(ctx, 1); err != nil {
+		slog.Error("Failed to acquire semaphore", "error", err)
+		return err
+	}
+	defer s.sem.Release(1)
+
+	status, err := s.getServerStatusRetry(ctx)
+	if err != nil {
+		return err
+	} else if status != ServerStatusReady {
+		return fmt.Errorf("unexpected server status: %s", status.String())
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("error marshaling rerank data: %w", err)
+	}
+
+	r, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("http://127.0.0.1:%d/rerank", s.port), bytes.NewBuffer(data))
+	if err != nil {
+		return fmt.Errorf("error creating rerank request: %w", err)
+	}
+
+	r.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(r)
+	if err != nil {
+		return fmt.Errorf("do rerank request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("error reading rerank response: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		log.Printf("llm rerank error: %s", body)
+		return fmt.Errorf("%s", body)
+	}
+
+	var rr RerankResponse
+	if err := json.Unmarshal(body, &rr); err != nil {
+		return fmt.Errorf("unmarshal tokenize response: %w", err)
+	}
+	fn(rr)
+
+	return nil
 }
 
 type TokenizeRequest struct {

--- a/runner/ollamarunner/runner.go
+++ b/runner/ollamarunner/runner.go
@@ -302,6 +302,9 @@ type Server struct {
 	// multimodalHash generates hashes for comparing equality
 	// of non-text data
 	multimodalHash maphash.Hash
+
+	// reranking indicates if the loaded model supports reranking.
+	reranking bool
 }
 
 func (s *Server) allNil() bool {
@@ -508,16 +511,28 @@ func (s *Server) processBatch() error {
 			seq.startGenerationTime = time.Now()
 		}
 
+		// sample a token
+		vocabSize := len(logits) / len(batch.Outputs)
+
 		// if done processing the prompt, generate an embedding and return
 		if seq.embeddingOnly {
+			if s.reranking {
+				// For reranking, the "embedding" is the relevance score
+				if len(logits) == 0 {
+					slog.Warn("reranking model returned no logits")
+					s.removeSequence(i, llm.DoneReasonStop)
+					continue
+				}
+				seq.embedding <- []float32{logits[seq.iBatch*vocabSize]}
+				s.removeSequence(i, llm.DoneReasonStop)
+				continue
+			}
+
 			// TODO(jessegross): Embedding support
 			slog.Warn("generation of embedding outputs not yet supported")
 			s.removeSequence(i, llm.DoneReasonStop)
 			continue
 		}
-
-		// sample a token
-		vocabSize := len(logits) / len(batch.Outputs)
 
 		token, err := seq.sampler.Sample(logits[seq.iBatch*vocabSize : (seq.iBatch+1)*vocabSize])
 		if err != nil {
@@ -720,6 +735,131 @@ func (s *Server) health(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+type RerankRequest struct {
+	Model   string   `json:"model"`
+	Prompts []string `json:"prompts"`
+}
+
+type RerankResult struct {
+	Index          int     `json:"index"`
+	RelevanceScore float32 `json:"relevance_score"`
+}
+
+type RerankResponse struct {
+	Results []RerankResult `json:"results"`
+	*api.Usage
+}
+
+func (s *Server) rerank(w http.ResponseWriter, r *http.Request) {
+	if !s.reranking {
+		http.Error(w, "this model does not support reranking", http.StatusNotImplemented)
+		return
+	}
+
+	var req RerankRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, fmt.Sprintf("bad rerank request: %s", err), http.StatusBadRequest)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+
+	textProcessor, ok := s.model.(model.TextProcessor)
+	if !ok {
+		http.Error(w, "model does not support text processing for reranking", http.StatusInternalServerError)
+		return
+	}
+
+	BOSPiece, err := s.model.(model.TextProcessor).Decode([]int32{int32(model.SpecialBOS)})
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to decode BOS token: %v", err), http.StatusInternalServerError)
+		return
+	}
+	EOSPiece, err := s.model.(model.TextProcessor).Decode([]int32{int32(model.SpecialEOS)})
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to decode EOS token: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	parseFn := func(p string) string {
+		// For reranking, we explicitly replace placeholder tags if they exist in the prompt.
+		p = strings.ReplaceAll(p, "[BOS]", BOSPiece)
+		p = strings.ReplaceAll(p, "[EOS]", EOSPiece)
+		return p
+	}
+
+	var totalTokens int
+	for _, p := range req.Prompts {
+		parsedPrompt := parseFn(p)
+		slog.Debug("Processing prompt", "parsed", parsedPrompt)
+		tokens, err := textProcessor.Encode(parsedPrompt, true)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("failed to tokenize prompt: %v", err), http.StatusInternalServerError)
+			return
+		}
+		totalTokens += len(tokens)
+	}
+
+	var rsp RerankResponse
+	rsp.Results = make([]RerankResult, 0, len(req.Prompts))
+	rsp.Usage = &api.Usage{
+		TotalTokens: totalTokens,
+	}
+
+	for i, prompt := range req.Prompts {
+		seq, err := s.NewSequence(parseFn(prompt), nil, NewSequenceParams{embedding: true})
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Failed to create new sequence: %v", err), http.StatusInternalServerError)
+			return
+		}
+
+		// Ensure there is a place to put the sequence, released when removed from s.seqs
+		if err := s.seqsSem.Acquire(r.Context(), 1); err != nil {
+			if errors.Is(err, context.Canceled) {
+				slog.Info("aborting reranking request due to client closing the connection")
+			} else {
+				slog.Error("Failed to acquire semaphore", "error", err)
+			}
+			return
+		}
+
+		s.mu.Lock()
+		found := false
+		for j, sq := range s.seqs {
+			if sq == nil {
+				seq.cache, seq.inputs, err = s.cache.LoadCacheSlot(seq.inputs)
+				if err != nil {
+					s.mu.Unlock()
+					s.seqsSem.Release(1)
+					http.Error(w, fmt.Sprintf("Failed to load cache: %v", err), http.StatusInternalServerError)
+					return
+				}
+				s.seqs[j] = seq
+				s.cond.Signal()
+				found = true
+				break
+			}
+		}
+		s.mu.Unlock()
+
+		if !found {
+			s.seqsSem.Release(1)
+			http.Error(w, "could not find an available sequence", http.StatusInternalServerError)
+			return
+		}
+
+		score := <-seq.embedding
+
+		rsp.Results = append(rsp.Results, RerankResult{
+			Index:          i,
+			RelevanceScore: score[0], // Assuming the first element of the embedding is the relevance score
+		})
+	}
+
+	if err := json.NewEncoder(w).Encode(&rsp); err != nil {
+		http.Error(w, fmt.Sprintf("failed to encode response: %v", err), http.StatusInternalServerError)
+	}
+}
+
 type multiLPath []string
 
 func (m *multiLPath) Set(value string) error {
@@ -836,6 +976,7 @@ func (s *Server) initModel(
 	kvCacheType string,
 	kvSize int,
 	multiUserCache bool,
+	reranking bool,
 ) error {
 	var err error
 	s.model, err = model.New(mpath, params)
@@ -861,6 +1002,7 @@ func (s *Server) initModel(
 	s.parallel = parallel
 	s.seqs = make([]*Sequence, s.parallel)
 	s.seqsSem = semaphore.NewWeighted(int64(s.parallel))
+	s.reranking = reranking
 
 	return s.reserveWorstCaseGraph()
 }
@@ -874,8 +1016,9 @@ func (s *Server) load(
 	kvCacheType string,
 	kvSize int,
 	multiUserCache bool,
+	reranking bool,
 ) {
-	err := s.initModel(mpath, params, lpath, parallel, kvCacheType, kvSize, multiUserCache)
+	err := s.initModel(mpath, params, lpath, parallel, kvCacheType, kvSize, multiUserCache, reranking)
 	if err != nil {
 		panic(err)
 	}
@@ -910,6 +1053,7 @@ func Execute(args []string) error {
 	_ = fs.Bool("no-mmap", false, "do not memory-map model (slower load but may reduce pageouts if not using mlock)")
 	tensorSplit := fs.String("tensor-split", "", "fraction of the model to offload to each GPU, comma-separated list of proportions")
 	multiUserCache := fs.Bool("multiuser-cache", false, "optimize input cache algorithm for multiple users")
+	reranking := fs.Bool("reranking", false, "enable reranking")
 
 	var lpaths multiLPath
 	fs.Var(&lpaths, "lora", "Path to lora layer file (can be specified multiple times)")
@@ -956,7 +1100,7 @@ func Execute(args []string) error {
 		FlashAttention: *flashAttention,
 	}
 
-	go server.load(ctx, *mpath, params, lpaths, *parallel, *kvCacheType, *kvSize, *multiUserCache)
+	go server.load(ctx, *mpath, params, lpaths, *parallel, *kvCacheType, *kvSize, *multiUserCache, *reranking) // Pass reranking flag
 	go server.run(ctx)
 
 	addr := "127.0.0.1:" + strconv.Itoa(*port)
@@ -972,6 +1116,8 @@ func Execute(args []string) error {
 	mux.HandleFunc("POST /embedding", func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "this model does not support embeddings", http.StatusNotImplemented)
 	})
+
+	mux.HandleFunc("POST /rerank", server.rerank) // Add rerank handler
 
 	mux.HandleFunc("POST /completion", server.completion)
 	mux.HandleFunc("GET /health", server.health)

--- a/server/routes.go
+++ b/server/routes.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"os/signal"
 	"slices"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
@@ -379,6 +380,111 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 	}
 
 	streamResponse(c, ch)
+}
+
+func (s *Server) RerankHandler(c *gin.Context) {
+	var req api.RerankRequest
+	if err := c.ShouldBindJSON(&req); errors.Is(err, io.EOF) {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "missing request body"})
+		return
+	} else if err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	switch {
+	case len(req.Documents) == 0:
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Document cannot be empty"})
+		return
+	case req.Query == "":
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Query cannot be empty"})
+		return
+	case req.TopN < 0:
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "TopN cannot be negative"})
+		return
+	}
+	name := model.ParseName(req.Model)
+	if !name.IsValid() {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "model is required"})
+		return
+	}
+	name, err := getExistingName(name)
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("model '%s' not found", req.Model)})
+		return
+	}
+	if req.Options == nil {
+		req.Options = make(map[string]any)
+	}
+	req.Options["reranking"] = true
+	r, m, _, err := s.scheduleRunner(c.Request.Context(), req.Model, []model.Capability{}, req.Options, req.KeepAlive)
+	if err != nil {
+		handleScheduleError(c, req.Model, err)
+		return
+	}
+	if m.Template == nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("model '%s' missing template", req.Model)})
+		return
+	}
+	var prompts []string
+	for _, doc := range req.Documents {
+		var b bytes.Buffer
+		var values template.Values
+		values.Query = req.Query
+		values.Document = doc
+		if err := m.Template.Execute(&b, values); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		prompts = append(prompts, b.String())
+	}
+	llmreq := llm.RerankRequest{
+		Model:   req.Model,
+		Prompts: prompts,
+	}
+	err = r.Rerank(c.Request.Context(), llmreq, func(rr llm.RerankResponse) {
+		sort.SliceStable(rr.Results, func(i, j int) bool {
+			return rr.Results[i].RelevanceScore > rr.Results[j].RelevanceScore
+		})
+
+		var topn int
+		if req.TopN == 0 {
+			topn = len(rr.Results) // if TopN is unset, return all results
+		} else {
+			topn = min(len(rr.Results), req.TopN)
+		}
+		topResults := rr.Results[:topn]
+
+		rsp := api.RerankResponse{
+			Model: req.Model,
+			Usage: rr.Usage,
+			Results: make([]struct {
+				Index    int `json:"index"`
+				Document *struct {
+					Text string `json:"text"`
+				} `json:"document,omitempty"`
+				RelevanceScore float32 `json:"relevance_score"`
+			}, topn),
+		}
+
+		for i, result := range topResults {
+			rsp.Results[i].Index = result.Index
+			if req.ReturnDocuments {
+				rsp.Results[i].Document = &struct {
+					Text string `json:"text"`
+				}{Text: req.Documents[result.Index]}
+			}
+			rsp.Results[i].RelevanceScore = result.RelevanceScore
+		}
+
+		c.JSON(http.StatusOK, rsp)
+	})
+
+	if err != nil {
+		slog.Info(fmt.Sprintf("rerank failed: %v", err))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to rerank"})
+		return
+	}
 }
 
 func (s *Server) EmbedHandler(c *gin.Context) {
@@ -1207,6 +1313,9 @@ func (s *Server) GenerateRoutes(rc *ollama.Registry) (http.Handler, error) {
 	r.POST("/api/chat", s.ChatHandler)
 	r.POST("/api/embed", s.EmbedHandler)
 	r.POST("/api/embeddings", s.EmbeddingsHandler)
+	r.POST("/api/rerank", s.RerankHandler)
+	// jina.ai compatibility
+	r.POST("/v1/rerank", s.RerankHandler)
 
 	// Inference (OpenAI compatibility)
 	r.POST("/v1/chat/completions", openai.ChatMiddleware(), s.ChatHandler)

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -752,6 +752,7 @@ type mockLlm struct {
 	completionResp     error
 	embeddingResp      []float32
 	embeddingRespErr   error
+	rerankResp         error
 	tokenizeResp       []int
 	tokenizeRespErr    error
 	detokenizeResp     string
@@ -771,6 +772,10 @@ func (s *mockLlm) Completion(ctx context.Context, req llm.CompletionRequest, fn 
 
 func (s *mockLlm) Embedding(ctx context.Context, input string) ([]float32, error) {
 	return s.embeddingResp, s.embeddingRespErr
+}
+
+func (s *mockLlm) Rerank(ctx context.Context, req llm.RerankRequest, fn func(llm.RerankResponse)) error {
+	return s.rerankResp
 }
 
 func (s *mockLlm) Tokenize(ctx context.Context, content string) ([]int, error) {

--- a/template/template.go
+++ b/template/template.go
@@ -165,9 +165,11 @@ func (t *Template) Vars() []string {
 type Values struct {
 	Messages []api.Message
 	api.Tools
-	Prompt string
-	Suffix string
-	Think  bool
+	Prompt   string
+	Suffix   string
+	Query    string
+	Document string
+	Think    bool
 	// whether or not the user explicitly set the thinking flag (vs. it being
 	// implicitly false). Templates can't see whether `Think` is nil
 	IsThinkSet bool
@@ -232,7 +234,8 @@ func (t *Template) Execute(w io.Writer, v Values) error {
 			"Think":      v.Think,
 			"IsThinkSet": v.IsThinkSet,
 		})
-	} else if !v.forceLegacy && slices.Contains(t.Vars(), "messages") {
+	} else if !v.forceLegacy && (slices.Contains(t.Vars(), "messages") ||
+		slices.Contains(t.Vars(), "document")) {
 		return t.Template.Execute(w, map[string]any{
 			"System":     system,
 			"Messages":   messages,
@@ -240,6 +243,8 @@ func (t *Template) Execute(w io.Writer, v Values) error {
 			"Response":   "",
 			"Think":      v.Think,
 			"IsThinkSet": v.IsThinkSet,
+			"Query":      v.Query,
+			"Document":   v.Document,
 		})
 	}
 


### PR DESCRIPTION
Implements reranking: https://github.com/ollama/ollama/issues/3368
Implemented reranking in the new engine (ollamarunner), based on https://github.com/ollama/ollama/pull/11156 

I tested it with this model: `fanyx/Qwen3-Reranker-0.6B-Q8_0`
With Modelfile:
```
FROM fanyx/Qwen3-Reranker-0.6B-Q8_0

TEMPLATE """[BOS]{{ .Query }}[EOS][SEP]{{ .Document }}[EOS]"""
```
And environment variable `OLLAMA_NEW_ENGINE=1`

However, it did not work with `dengcao/Qwen3-Reranker-0.6B:Q8_0 `  (I got all zero output logits), maybe there are differences between the models that I'm not aware of, as mentioned by [@halfcrazy.](https://github.com/ollama/ollama/pull/11156#issuecomment-3018589644).

I also did not find any other reranking models supported by the new engine (most seem based on bert which is not yet supported)

Looking forward to receive feedback.