### PR TITLE
cmd: add num_thread to /set parameter help text

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -107,6 +107,7 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 		fmt.Fprintln(os.Stderr, "  /set parameter repeat_penalty <float> How strongly to penalize repetitions")
 		fmt.Fprintln(os.Stderr, "  /set parameter repeat_last_n <int>    Set how far back to look for repetitions")
 		fmt.Fprintln(os.Stderr, "  /set parameter num_gpu <int>          The number of layers to send to the GPU")
+		fmt.Fprintln(os.Stderr, "  /set parameter num_thread <int>       The number of threads to use for computation")
 		fmt.Fprintln(os.Stderr, "  /set parameter stop <string> <string> ...   Set the stop parameters")
 		fmt.Fprintln(os.Stderr, "")
 	}


### PR DESCRIPTION
Fixes #10035

Adds the num_thread parameter to the help text for the /set parameter interactive command, as it was missing.