### PR TITLE
Add handling for non printable characters in tool arguments & tests.

### DIFF
--- a/tools/tools.go
+++ b/tools/tools.go
@@ -39,6 +39,7 @@ func NewParserWithTag(tools []api.Tool, tag string) *Parser {
 	}
 }
 
+
 // Add processes a string input to parse tool calls and content that
 // should be sent back to the user.
 func (p *Parser) Add(s string) (calls []api.ToolCall, content string) {
@@ -46,7 +47,20 @@ func (p *Parser) Add(s string) (calls []api.ToolCall, content string) {
 		return nil, s
 	}
 
-	p.buffer = append(p.buffer, s...)
+	// removing the non printable characters from being added to the buffer
+	cleaned := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		b := s[i]
+		// skip the non printable characters
+		if b == 0xE2 && i+2 < len(s) && s[i+1] == 0x80 && s[i+2] == 0x8B {
+			// (U+200B)
+			i += 2
+			continue
+		}
+		cleaned = append(cleaned, b)
+	}
+
+	p.buffer = append(p.buffer, cleaned...)
 
 	if p.state == toolsState_LookingForTag {
 		i, found := p.findTag()

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -1084,15 +1084,31 @@ func TestFindArguments(t *testing.T) {
 			},
 			tool: tool,
 		},
+		{
+			name:   "non printable characters",
+			buffer: []byte("\xE2\x80\x8B{\"name\":\"get_temperature\",\"arguments\":{\"location\":\"Tokyo\"}}\xE2\x80\x8B"),
+			want: map[string]any{
+				"location": "Tokyo",
+			},
+			tool: tool,
+		},
+		{
+			name:   "non printable characters around json",
+			buffer: []byte("\u200B{\"name\":\"get_temperature\",\"arguments\":{\"location\":\"Berlin\"}}\u200B"),
+			want: map[string]any{
+				"location": "Berlin",
+			},
+			tool: tool,
+		},
+	}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				got, _ := findArguments(tt.tool, tt.buffer)
+
+				if diff := cmp.Diff(got, tt.want); diff != "" {
+					t.Errorf("scanArguments() args mismatch (-got +want):\n%s", diff)
+				}
+			})
+		}
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, _ := findArguments(tt.tool, tt.buffer)
-
-			if diff := cmp.Diff(got, tt.want); diff != "" {
-				t.Errorf("scanArguments() args mismatch (-got +want):\n%s", diff)
-			}
-		})
-	}
-}


### PR DESCRIPTION
When the AI generates large amounts of text and/or code blocks, they also produce large amounts of non printable characters. A mixture of this python doesn't like in the python Ollama framework which leads to issues which can't be resolved by the user. This is because of the way the AI calls the tool through the tool function interface where no parsing or removal of these non printable characters can occur before the tool is called. Then when python sees it as an argument it panics and throws a error.

I have provided some code below which should remove these characters before it is parsed into the tool as an argument.

I apologize if this is not correct but i at least wanted to try to do something to help fix it instead of just reporting the error itself. It passed all of the checks so thats a win. Let me know if i need to change anything else or if i have edited the wrong part of the codebase.

Thanks - Cassidy

```
ollama % go test ./...            

?   	github.com/ollama/ollama	[no test files]
ok  	github.com/ollama/ollama/api	(cached)
?   	github.com/ollama/ollama/api/examples/chat	[no test files]
?   	github.com/ollama/ollama/api/examples/generate	[no test files]
?   	github.com/ollama/ollama/api/examples/generate-streaming	[no test files]
?   	github.com/ollama/ollama/api/examples/multimodal	[no test files]
?   	github.com/ollama/ollama/api/examples/pull-progress	[no test files]
?   	github.com/ollama/ollama/app	[no test files]
?   	github.com/ollama/ollama/app/assets	[no test files]
# github.com/ollama/ollama/cmd.test
ld: warning: ignoring duplicate libraries: '-lobjc'
ok  	github.com/ollama/ollama/app/lifecycle	(cached)
?   	github.com/ollama/ollama/app/store	[no test files]
?   	github.com/ollama/ollama/app/tray	[no test files]
?   	github.com/ollama/ollama/app/tray/commontray	[no test files]
?   	github.com/ollama/ollama/auth	[no test files]
ok  	github.com/ollama/ollama/cmd	(cached)
?   	github.com/ollama/ollama/cmd/runner	[no test files]
ok  	github.com/ollama/ollama/convert	(cached)
?   	github.com/ollama/ollama/convert/sentencepiece	[no test files]
ok  	github.com/ollama/ollama/discover	(cached)
ok  	github.com/ollama/ollama/envconfig	(cached)
ok  	github.com/ollama/ollama/format	(cached)
?   	github.com/ollama/ollama/fs	[no test files]
ok  	github.com/ollama/ollama/fs/ggml	(cached)
# github.com/ollama/ollama/llm.test
ld: warning: ignoring duplicate libraries: '-lobjc'
ok  	github.com/ollama/ollama/fs/gguf	(cached)
ok  	github.com/ollama/ollama/fs/util/bufioutil	(cached)
ok  	github.com/ollama/ollama/kvcache	(cached)
ok  	github.com/ollama/ollama/llama	(cached)
?   	github.com/ollama/ollama/llama/llama.cpp/common	[no test files]
?   	github.com/ollama/ollama/llama/llama.cpp/src	[no test files]
?   	github.com/ollama/ollama/llama/llama.cpp/tools/mtmd	[no test files]
ok  	github.com/ollama/ollama/llm	(cached)
?   	github.com/ollama/ollama/logutil	[no test files]
?   	github.com/ollama/ollama/ml	[no test files]
?   	github.com/ollama/ollama/ml/backend	[no test files]
?   	github.com/ollama/ollama/ml/backend/ggml	[no test files]
?   	github.com/ollama/ollama/ml/backend/ggml/ggml/src	[no test files]
?   	github.com/ollama/ollama/ml/backend/ggml/ggml/src/ggml-blas	[no test files]
?   	github.com/ollama/ollama/ml/backend/ggml/ggml/src/ggml-cpu	[no test files]
?   	github.com/ollama/ollama/ml/backend/ggml/ggml/src/ggml-cpu/llamafile	[no test files]
?   	github.com/ollama/ollama/ml/backend/ggml/ggml/src/ggml-metal	[no test files]
?   	github.com/ollama/ollama/ml/nn	[no test files]
?   	github.com/ollama/ollama/ml/nn/fast	[no test files]
?   	github.com/ollama/ollama/ml/nn/rope	[no test files]
ok  	github.com/ollama/ollama/model	(cached)
ok  	github.com/ollama/ollama/model/imageproc	(cached)
?   	github.com/ollama/ollama/model/input	[no test files]
?   	github.com/ollama/ollama/model/models	[no test files]
?   	github.com/ollama/ollama/model/models/gemma2	[no test files]
?   	github.com/ollama/ollama/model/models/gemma3	[no test files]
?   	github.com/ollama/ollama/model/models/gemma3n	[no test files]
?   	github.com/ollama/ollama/model/models/llama	[no test files]
ok  	github.com/ollama/ollama/model/models/llama4	(cached)
?   	github.com/ollama/ollama/model/models/mistral3	[no test files]
ok  	github.com/ollama/ollama/model/models/mllama	(cached)
?   	github.com/ollama/ollama/model/models/qwen2	[no test files]
?   	github.com/ollama/ollama/model/models/qwen25vl	[no test files]
?   	github.com/ollama/ollama/model/models/qwen3	[no test files]
# github.com/ollama/ollama/runner/llamarunner.test
ld: warning: ignoring duplicate libraries: '-lobjc'
# github.com/ollama/ollama/runner/ollamarunner.test
ld: warning: ignoring duplicate libraries: '-lobjc'
ok  	github.com/ollama/ollama/openai	(cached)
ok  	github.com/ollama/ollama/parser	(cached)
?   	github.com/ollama/ollama/progress	[no test files]
?   	github.com/ollama/ollama/readline	[no test files]
?   	github.com/ollama/ollama/runner	[no test files]
ok  	github.com/ollama/ollama/runner/common	(cached)
ok  	github.com/ollama/ollama/runner/llamarunner	(cached)
ok  	github.com/ollama/ollama/runner/ollamarunner	(cached)
ok  	github.com/ollama/ollama/sample	(cached)
# github.com/ollama/ollama/server.test
ld: warning: ignoring duplicate libraries: '-lobjc'
ok  	github.com/ollama/ollama/server	(cached)
ok  	github.com/ollama/ollama/server/internal/cache/blob	(cached)
ok  	github.com/ollama/ollama/server/internal/client/ollama	(cached)
?   	github.com/ollama/ollama/server/internal/internal/backoff	[no test files]
ok  	github.com/ollama/ollama/server/internal/internal/names	(cached)
ok  	github.com/ollama/ollama/server/internal/internal/stringsx	(cached)
?   	github.com/ollama/ollama/server/internal/internal/syncs	[no test files]
?   	github.com/ollama/ollama/server/internal/manifest	[no test files]
ok  	github.com/ollama/ollama/server/internal/registry	(cached)
?   	github.com/ollama/ollama/server/internal/testutil	[no test files]
ok  	github.com/ollama/ollama/template	(cached)
ok  	github.com/ollama/ollama/thinking	(cached)
ok  	github.com/ollama/ollama/tools	(cached)
?   	github.com/ollama/ollama/types/errtypes	[no test files]
ok  	github.com/ollama/ollama/types/model	(cached)
?   	github.com/ollama/ollama/types/syncmap	[no test files]
?   	github.com/ollama/ollama/version	[no test files]

```