### PR TITLE
tools: find the right tool to call

### DIFF
--- a/tools/tools.go
+++ b/tools/tools.go
@@ -120,10 +120,12 @@ func (p *Parser) parseToolCall() *api.ToolCall {
 	var i int
 
 	// find tool name
+	longest := 0
 	for _, t := range p.tools {
 		n := t.Function.Name
 		if i = bytes.Index(p.buffer, []byte(n)); i != -1 {
-			if i+len(n) < end {
+			if len(n) > longest {
+				longest = len(n)
 				tool = &t
 				end = i + len(n)
 			}

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -119,15 +119,25 @@ func (p *Parser) parseToolCall() *api.ToolCall {
 	var end int = len(p.buffer)
 	var i int
 
-	// find tool name
-	longest := 0
+	// find the earliest tool name
+	start := end
 	for _, t := range p.tools {
 		n := t.Function.Name
 		if i = bytes.Index(p.buffer, []byte(n)); i != -1 {
-			if len(n) > longest {
+			if start > i {
+				start = i
+			}
+		}
+	}
+	// find the longest tool name
+	longest := 0
+	for _, t := range p.tools {
+		n := t.Function.Name
+		if bytes.Index(p.buffer[start:], []byte(n)) == 0 {
+			if longest < len(n) {
 				longest = len(n)
 				tool = &t
-				end = i + len(n)
+				end = start + len(n)
 			}
 		}
 	}


### PR DESCRIPTION
If a tool list has tools in which one is a substring of the other, it's possible for the wrong tool to be selected.

For example, tools=[add, get_ip_address].  If the model generates a tool call for `get_ip_address`, it's possible for the tool parser to incorrectly select `add`.

This PR avoids that by locating the earliest and longest matching tool name in the buffer.

Example failure:
```python
#!/usr/bin/env python3

import ollama
import sys

def rm(file):
  """
    Remove a file.
    Args:
      file (str): name of file to remove.
  """
  return True

def format(file):
  """
    Format the contents of file according to the go style guide.
    Args:
      file (str): name of file to be formatted.
  """
  return True

response = ollama.chat(model="devstral", tools=[rm, format],
    messages=[{"role":"user","content":sys.argv[1]}],
    stream=False)

print(response.message.tool_calls)
```
```shell
$ ./11386.py 'format server/routes.go to match the style guide'
[ToolCall(function=Function(name='rm', arguments={'file': 'server/routes.go'}))]
```