### PR TITLE
serve: handle user parameters when there are no model parameters

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -385,16 +385,16 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 				case "modelfile":
 					fmt.Println(resp.Modelfile)
 				case "parameters":
+					if len(opts.Options) > 0 {
+						fmt.Println("User defined parameters:")
+						for k, v := range opts.Options {
+							fmt.Printf("%-*s %v\n", 30, k, v)
+						}
+						fmt.Println()
+					}
 					if resp.Parameters == "" {
 						fmt.Println("No parameters were specified for this model.")
 					} else {
-						if len(opts.Options) > 0 {
-							fmt.Println("User defined parameters:")
-							for k, v := range opts.Options {
-								fmt.Printf("%-*s %v\n", 30, k, v)
-							}
-							fmt.Println()
-						}
 						fmt.Println("Model defined parameters:")
 						fmt.Println(resp.Parameters)
 					}

--- a/server/routes.go
+++ b/server/routes.go
@@ -844,6 +844,9 @@ func GetModelInfo(req api.ShowRequest) (*api.ShowResponse, error) {
 
 	for k, v := range req.Options {
 		if _, ok := req.Options[k]; ok {
+			if m.Options == nil {
+				m.Options = make(map[string]any)
+			}
 			m.Options[k] = v
 		}
 	}


### PR DESCRIPTION
If a model has no PARAMETER lines in the Modelfile and the user sets parameters, `/show parameters` in the CLI returns an error due to a nil map.

Fixes: #11395