### PR TITLE
Add comments to clarify generateHandler by referencing completion logic

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -123,6 +123,8 @@ func (s *Server) scheduleRunner(ctx context.Context, name string, caps []model.C
 	return runner.llama, model, &opts, nil
 }
 
+// GenerateHandler handles api/generate. It would return the llm response. For details please refer to api.md
+// Note that the completion logic appears in llm/server.go:completion
 func (s *Server) GenerateHandler(c *gin.Context) {
 	checkpointStart := time.Now()
 	var req api.GenerateRequest


### PR DESCRIPTION
It turns out that the generateHandler function can be quite confusing to read.

I’ve added these two lines of comments to help readers understand the code more easily by directing them to the main completion logic.

This PR would not affect other code. 