### PR TITLE
api: fix unreachable status err

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -222,16 +222,16 @@ func (c *Client) stream(ctx context.Context, method, path string, data any, fn f
 			return fmt.Errorf("unmarshal: %w", err)
 		}
 
-		if errorResponse.Error != "" {
-			return errors.New(errorResponse.Error)
-		}
-
 		if response.StatusCode >= http.StatusBadRequest {
 			return StatusError{
 				StatusCode:   response.StatusCode,
 				Status:       response.Status,
 				ErrorMessage: errorResponse.Error,
 			}
+		}
+
+		if errorResponse.Error != "" {
+			return errors.New(errorResponse.Error)
 		}
 
 		if err := fn(bts); err != nil {

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -90,6 +90,16 @@ func TestClientStream(t *testing.T) {
 			wantErr: "mid-stream error",
 		},
 		{
+			name: "http status error takes precedence over error message",
+			responses: []any{
+				testError{
+					message:    "custom error message",
+					statusCode: http.StatusInternalServerError,
+				},
+			},
+			wantErr: "500",
+		},
+		{
 			name: "successful stream completion",
 			responses: []any{
 				ChatResponse{Message: Message{Content: "chunk 1"}},

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -90,7 +90,7 @@ func TestClientStream(t *testing.T) {
 			wantErr: "mid-stream error",
 		},
 		{
-			name: "http status error takes precedence over error message",
+			name: "http status error takes precedence over general error",
 			responses: []any{
 				testError{
 					message:    "custom error message",


### PR DESCRIPTION
StatusError was unreachable, the client always checked for error messages in the response body first, and the server always includes error messages with HTTP error status codes.