### PR TITLE
readme: update the llama.cpp github link

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,7 +598,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 
 ### Supported backends
 
-- [llama.cpp](https://github.com/ggerganov/llama.cpp) project founded by Georgi Gerganov.
+- [llama.cpp](https://github.com/ggml-org/llama.cpp) project founded by Georgi Gerganov.
 
 ### Observability
 - [Opik](https://www.comet.com/docs/opik/cookbook/ollama) is an open-source platform to debug, evaluate, and monitor your LLM applications, RAG systems, and agentic workflows with comprehensive tracing, automated evaluations, and production-ready dashboards. Opik supports native intergration to Ollama.


### PR DESCRIPTION
A nit update to reach the llama.cpp project without URL redirection.