### PR TITLE
fix: initialize Options map in GetModel to prevent nil panic

### DIFF
--- a/server/images.go
+++ b/server/images.go
@@ -283,6 +283,7 @@ func GetModel(name string) (*Model, error) {
 		ShortName: mp.GetShortTagname(),
 		Digest:    digest,
 		Template:  template.DefaultTemplate,
+		Options:   make(map[string]any),
 	}
 
 	if manifest.Config.Digest != "" {


### PR DESCRIPTION
## Summary
- Initialize the Options map when creating a new Model struct to prevent "assignment to entry in nil map" panics
- Fixes panic that occurs when models don't have params layers in their manifest

Closes #6890

🤖 Generated with [Claude Code](https://claude.ai/code)