### PR TITLE
Refactor ToolFunction.Parameters to use json.RawMessage

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -223,20 +223,9 @@ func (pt PropertyType) String() string {
 }
 
 type ToolFunction struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	Parameters  struct {
-		Type       string   `json:"type"`
-		Defs       any      `json:"$defs,omitempty"`
-		Items      any      `json:"items,omitempty"`
-		Required   []string `json:"required"`
-		Properties map[string]struct {
-			Type        PropertyType `json:"type"`
-			Items       any          `json:"items,omitempty"`
-			Description string       `json:"description"`
-			Enum        []any        `json:"enum,omitempty"`
-		} `json:"properties"`
-	} `json:"parameters"`
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	Parameters  json.RawMessage `json:"parameters"`
 }
 
 func (t *ToolFunction) String() string {


### PR DESCRIPTION
### Issues related

- **Fixes #11444** (Take a look for more context)
- **Relates to #8222***

### Summary
Simplified `ToolFunction.Parameters` from a structured schema to `json.RawMessage` for better flexibility and performance.

### Problem
The previous structured approach was stripping essential JSON schema fields from tool function parameters, causing compatibility issues with advanced tooling that relies on complete schema definitions.

### Changes
- Replace structured `Parameters` field with `json.RawMessage` in `ToolFunction`
- Add `getProperties()` helper to extract properties from JSON parameters  
- Update tests to use `json.RawMessage` format
- Tools Test renamed json to jsonTmpl variable since adding "encoding/json"

### Benefits
- Better performance (single JSON unmarshal vs multiple field accesses)
- Support for flexible parameter schemas beyond rigid JSON Schema structure
- Cleaner, more maintainable code
- Maintains backward compatibility

### Tool Schema Flexibility
This change particularly benefits advanced tool usage scenarios:
- **MCP (Model Context Protocol) servers**: Support for MCP-specific schema formats and validation requirements
- **Tools with union types**: Enable `anyOf`, `oneOf` schema patterns for complex parameter validation
- **Strict validation tools**: Support `additionalProperties: false` and other strict validation rules
- **Tools using constant values**: Enable `const` and other advanced JSON Schema features

### Additional Context
This issue was discovered while testing [Netlify MCP Server](https://github.com/netlify/netlify-mcp) with the [MCP client for Ollama](https://github.com/jonigl/mcp-client-for-ollama). This MCP Server tool specification relies heavily on JSON schema features that were being stripped by the previous structured approach.

### Testing
- All existing tests pass
- Tool parsing functionality preserved
- No breaking changes to external API