### PR TITLE
tools: replace structured ToolFunction.Parameters with json.RawMessage

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -224,20 +224,9 @@ func (pt PropertyType) String() string {
 }
 
 type ToolFunction struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	Parameters  struct {
-		Type       string   `json:"type"`
-		Defs       any      `json:"$defs,omitempty"`
-		Items      any      `json:"items,omitempty"`
-		Required   []string `json:"required"`
-		Properties map[string]struct {
-			Type        PropertyType `json:"type"`
-			Items       any          `json:"items,omitempty"`
-			Description string       `json:"description"`
-			Enum        []any        `json:"enum,omitempty"`
-		} `json:"properties"`
-	} `json:"parameters"`
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	Parameters  json.RawMessage `json:"parameters"`
 }
 
 func (t *ToolFunction) String() string {

--- a/openai/openai_test.go
+++ b/openai/openai_test.go
@@ -279,36 +279,7 @@ func TestChatMiddleware(t *testing.T) {
 						Function: api.ToolFunction{
 							Name:        "get_weather",
 							Description: "Get the current weather",
-							Parameters: struct {
-								Type       string   `json:"type"`
-								Defs       any      `json:"$defs,omitempty"`
-								Items      any      `json:"items,omitempty"`
-								Required   []string `json:"required"`
-								Properties map[string]struct {
-									Type        api.PropertyType `json:"type"`
-									Items       any              `json:"items,omitempty"`
-									Description string           `json:"description"`
-									Enum        []any            `json:"enum,omitempty"`
-								} `json:"properties"`
-							}{
-								Type:     "object",
-								Required: []string{"location"},
-								Properties: map[string]struct {
-									Type        api.PropertyType `json:"type"`
-									Items       any              `json:"items,omitempty"`
-									Description string           `json:"description"`
-									Enum        []any            `json:"enum,omitempty"`
-								}{
-									"location": {
-										Type:        api.PropertyType{"string"},
-										Description: "The city and state",
-									},
-									"unit": {
-										Type: api.PropertyType{"string"},
-										Enum: []any{"celsius", "fahrenheit"},
-									},
-								},
-							},
+							Parameters:  json.RawMessage(`{"type":"object","required":["location"],"properties":{"location":{"type":"string","description":"The city and state"},"unit":{"type":"string","enum":["celsius","fahrenheit"]}}}`),
 						},
 					},
 				},

--- a/server/routes_generate_test.go
+++ b/server/routes_generate_test.go
@@ -387,36 +387,20 @@ func TestGenerateChat(t *testing.T) {
 				Function: api.ToolFunction{
 					Name:        "get_weather",
 					Description: "Get the current weather",
-					Parameters: struct {
-						Type       string   `json:"type"`
-						Defs       any      `json:"$defs,omitempty"`
-						Items      any      `json:"items,omitempty"`
-						Required   []string `json:"required"`
-						Properties map[string]struct {
-							Type        api.PropertyType `json:"type"`
-							Items       any              `json:"items,omitempty"`
-							Description string           `json:"description"`
-							Enum        []any            `json:"enum,omitempty"`
-						} `json:"properties"`
-					}{
-						Type:     "object",
-						Required: []string{"location"},
-						Properties: map[string]struct {
-							Type        api.PropertyType `json:"type"`
-							Items       any              `json:"items,omitempty"`
-							Description string           `json:"description"`
-							Enum        []any            `json:"enum,omitempty"`
-						}{
+					Parameters: json.RawMessage(`{
+						"type": "object",
+						"required": ["location"],
+						"properties": {
 							"location": {
-								Type:        api.PropertyType{"string"},
-								Description: "The city and state",
+								"type": "string",
+								"description": "The city and state"
 							},
 							"unit": {
-								Type: api.PropertyType{"string"},
-								Enum: []any{"celsius", "fahrenheit"},
-							},
-						},
-					},
+								"type": "string",
+								"enum": ["celsius", "fahrenheit"]
+							}
+						}
+					}`),
 				},
 			},
 		}
@@ -488,36 +472,20 @@ func TestGenerateChat(t *testing.T) {
 				Function: api.ToolFunction{
 					Name:        "get_weather",
 					Description: "Get the current weather",
-					Parameters: struct {
-						Type       string   `json:"type"`
-						Defs       any      `json:"$defs,omitempty"`
-						Items      any      `json:"items,omitempty"`
-						Required   []string `json:"required"`
-						Properties map[string]struct {
-							Type        api.PropertyType `json:"type"`
-							Items       any              `json:"items,omitempty"`
-							Description string           `json:"description"`
-							Enum        []any            `json:"enum,omitempty"`
-						} `json:"properties"`
-					}{
-						Type:     "object",
-						Required: []string{"location"},
-						Properties: map[string]struct {
-							Type        api.PropertyType `json:"type"`
-							Items       any              `json:"items,omitempty"`
-							Description string           `json:"description"`
-							Enum        []any            `json:"enum,omitempty"`
-						}{
+					Parameters: json.RawMessage(`{
+						"type": "object",
+						"required": ["location"],
+						"properties": {
 							"location": {
-								Type:        api.PropertyType{"string"},
-								Description: "The city and state",
+								"type": "string",
+								"description": "The city and state"
 							},
 							"unit": {
-								Type: api.PropertyType{"string"},
-								Enum: []any{"celsius", "fahrenheit"},
-							},
-						},
-					},
+								"type": "string",
+								"enum": ["celsius", "fahrenheit"]
+							}
+						}
+					}`),
 				},
 			},
 		}

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	stdjson "encoding/json"
 	"testing"
 	"text/template"
 
@@ -40,37 +41,21 @@ func TestParser(t *testing.T) {
 			Function: api.ToolFunction{
 				Name:        "get_temperature",
 				Description: "Retrieve the temperature for a given location",
-				Parameters: struct {
-					Type       string   `json:"type"`
-					Defs       any      `json:"$defs,omitempty"`
-					Items      any      `json:"items,omitempty"`
-					Required   []string `json:"required"`
-					Properties map[string]struct {
-						Type        api.PropertyType `json:"type"`
-						Items       any              `json:"items,omitempty"`
-						Description string           `json:"description"`
-						Enum        []any            `json:"enum,omitempty"`
-					} `json:"properties"`
-				}{
-					Type:     "object",
-					Required: []string{"city"},
-					Properties: map[string]struct {
-						Type        api.PropertyType `json:"type"`
-						Items       any              `json:"items,omitempty"`
-						Description string           `json:"description"`
-						Enum        []any            `json:"enum,omitempty"`
-					}{
+				Parameters: stdjson.RawMessage(`{
+					"type": "object",
+					"required": ["city"],
+					"properties": {
 						"format": {
-							Type:        api.PropertyType{"string"},
-							Description: "The format to return the temperature in",
-							Enum:        []any{"fahrenheit", "celsius"},
+							"type": "string",
+							"description": "The format to return the temperature in",
+							"enum": ["fahrenheit", "celsius"]
 						},
 						"city": {
-							Type:        api.PropertyType{"string"},
-							Description: "The city to get the temperature for",
-						},
-					},
-				},
+							"type": "string",
+							"description": "The city to get the temperature for"
+						}
+					}
+				}`),
 			},
 		},
 		{
@@ -78,31 +63,15 @@ func TestParser(t *testing.T) {
 			Function: api.ToolFunction{
 				Name:        "get_conditions",
 				Description: "Retrieve the current weather conditions for a given location",
-				Parameters: struct {
-					Type       string   `json:"type"`
-					Defs       any      `json:"$defs,omitempty"`
-					Items      any      `json:"items,omitempty"`
-					Required   []string `json:"required"`
-					Properties map[string]struct {
-						Type        api.PropertyType `json:"type"`
-						Items       any              `json:"items,omitempty"`
-						Description string           `json:"description"`
-						Enum        []any            `json:"enum,omitempty"`
-					} `json:"properties"`
-				}{
-					Type: "object",
-					Properties: map[string]struct {
-						Type        api.PropertyType `json:"type"`
-						Items       any              `json:"items,omitempty"`
-						Description string           `json:"description"`
-						Enum        []any            `json:"enum,omitempty"`
-					}{
+				Parameters: stdjson.RawMessage(`{
+					"type": "object",
+					"properties": {
 						"location": {
-							Type:        api.PropertyType{"string"},
-							Description: "The location to get the weather conditions for",
-						},
-					},
-				},
+							"type": "string",
+							"description": "The location to get the weather conditions for"
+						}
+					}
+				}`),
 			},
 		},
 		{
@@ -110,6 +79,7 @@ func TestParser(t *testing.T) {
 			Function: api.ToolFunction{
 				Name:        "say_hello",
 				Description: "Say hello",
+				Parameters:  stdjson.RawMessage(`{}`),
 			},
 		},
 	}
@@ -930,36 +900,20 @@ func TestFindArguments(t *testing.T) {
 		Function: api.ToolFunction{
 			Name:        "get_temperature",
 			Description: "Retrieve the temperature for a given location",
-			Parameters: struct {
-				Type       string   `json:"type"`
-				Defs       any      `json:"$defs,omitempty"`
-				Items      any      `json:"items,omitempty"`
-				Required   []string `json:"required"`
-				Properties map[string]struct {
-					Type        api.PropertyType `json:"type"`
-					Items       any              `json:"items,omitempty"`
-					Description string           `json:"description"`
-					Enum        []any            `json:"enum,omitempty"`
-				} `json:"properties"`
-			}{
-				Type: "object",
-				Properties: map[string]struct {
-					Type        api.PropertyType `json:"type"`
-					Items       any              `json:"items,omitempty"`
-					Description string           `json:"description"`
-					Enum        []any            `json:"enum,omitempty"`
-				}{
+			Parameters: stdjson.RawMessage(`{
+				"type": "object",
+				"properties": {
 					"format": {
-						Type:        api.PropertyType{"string"},
-						Description: "The format to return the temperature in",
-						Enum:        []any{"fahrenheit", "celsius"},
+						"type": "string",
+						"description": "The format to return the temperature in",
+						"enum": ["fahrenheit", "celsius"]
 					},
 					"location": {
-						Type:        api.PropertyType{"string"},
-						Description: "The location to get the temperature for",
-					},
-				},
-			},
+						"type": "string",
+						"description": "The location to get the temperature for"
+					}
+				}
+			}`),
 		},
 	}
 


### PR DESCRIPTION
### Issues and PRs related

- **Fixes #11444** (Take a look for more context)
- **Relates to #8222**
- **ollama-python related PR** to allow sending full json parameters schema https://github.com/ollama/ollama-python/pull/542

### Summary
Simplified `ToolFunction.Parameters` from a structured schema to `json.RawMessage` for better flexibility and performance.

### Problem
The previous structured approach was limiting JSON schema flexibility and preventing support for advanced tooling scenarios that require complete schema definitions.

### Changes
- Replace structured `Parameters` field with `json.RawMessage` in `ToolFunction`
- Add `getProperties()` and `getRequired()` helpers to extract data from JSON parameters  
- Update tests to use `json.RawMessage` format
- Remove rigid `ParametersSchema` struct for true flexibility

### Benefits
- Better performance (minimal JSON parsing vs full struct unmarshaling)
- Support for any valid JSON schema structure without predefined types
- Cleaner, more maintainable code with focused helper functions
- Maintains backward compatibility

### Tool Schema Flexibility
This change enables advanced tool usage scenarios:
- **MCP (Model Context Protocol) servers**: Full support for MCP-specific schema formats
- **Advanced JSON Schema features**: `anyOf`, `oneOf`, `const`, `additionalProperties: false`, etc.
- **Dynamic schema generation**: Runtime schema creation without structural limitations

### Additional Context
This issue was discovered while testing [Netlify MCP Server](https://github.com/netlify/netlify-mcp) with the [MCP client for Ollama](https://github.com/jonigl/mcp-client-for-ollama). The previous structured approach was incompatible with flexible schema requirements.

### Testing
- All existing tests pass
- Tool parsing functionality preserved  
- No breaking changes to external API