### PR TITLE
Update LLAMA_MAX_EXPERTS to 384

### DIFF
--- a/llama/llama.cpp/src/llama-hparams.h
+++ b/llama/llama.cpp/src/llama-hparams.h
@@ -6,7 +6,7 @@
 
 // bump if necessary
 #define LLAMA_MAX_LAYERS  512
-#define LLAMA_MAX_EXPERTS 256  // DeepSeekV3
+#define LLAMA_MAX_EXPERTS 384  // Kimi K2
 
 enum llama_expert_gating_func_type {
     LLAMA_EXPERT_GATING_FUNC_TYPE_NONE    = 0,


### PR DESCRIPTION
This updates the max number of experts from 256 (minimum required for DeepSeekV3) to 384 (minimum required for Kimi K2), in support of #11382.