### PR TITLE
Add OLLAMA_RUNNER_THREADS environment variable to allow for control of the number of runner cpu threads created

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1573,6 +1573,7 @@ func NewCLI() *cobra.Command {
 				envVars["OLLAMA_LLM_LIBRARY"],
 				envVars["OLLAMA_GPU_OVERHEAD"],
 				envVars["OLLAMA_LOAD_TIMEOUT"],
+				envVars["OLLAMA_RUNNER_THREADS"],
 			})
 		default:
 			appendEnvDocs(cmd, envs)

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -224,6 +224,8 @@ var (
 	MaxRunners = Uint("OLLAMA_MAX_LOADED_MODELS", 0)
 	// MaxQueue sets the maximum number of queued requests. MaxQueue can be configured via the OLLAMA_MAX_QUEUE environment variable.
 	MaxQueue = Uint("OLLAMA_MAX_QUEUE", 512)
+	// RunnerThreads sets the number of threads to use during generation. RunnerThreads can be configured via the OLLAMA_RUNNER_THREADS environment variable.
+	RunnerThreads = Uint("OLLAMA_RUNNER_THREADS", 0)
 )
 
 func Uint64(key string, defaultValue uint64) func() uint64 {
@@ -269,6 +271,7 @@ func AsMap() map[string]EnvVar {
 		"OLLAMA_SCHED_SPREAD":      {"OLLAMA_SCHED_SPREAD", SchedSpread(), "Always schedule model across all GPUs"},
 		"OLLAMA_MULTIUSER_CACHE":   {"OLLAMA_MULTIUSER_CACHE", MultiUserCache(), "Optimize prompt caching for multi-user scenarios"},
 		"OLLAMA_CONTEXT_LENGTH":    {"OLLAMA_CONTEXT_LENGTH", ContextLength(), "Context length to use unless otherwise specified (default: 4096)"},
+		"OLLAMA_RUNNER_THREADS":    {"OLLAMA_RUNNER_THREADS", RunnerThreads(), "Number of threads to use during generation (default: runtime.NumCPU())"},
 		"OLLAMA_NEW_ENGINE":        {"OLLAMA_NEW_ENGINE", NewEngine(), "Enable the new Ollama engine"},
 
 		// Informational

--- a/runner/ollamarunner/runner.go
+++ b/runner/ollamarunner/runner.go
@@ -938,6 +938,11 @@ func Execute(args []string) error {
 	// TODO(jessegross): Parameters that need to be implemented:
 	//	no-mmap
 
+	// Check for OLLAMA_RUNNER_THREADS environment variable to override thread count
+	if runnerThreads := envconfig.RunnerThreads(); runnerThreads > 0 {
+		*threads = int(runnerThreads)
+	}
+
 	var tensorSplitFloats []float32
 	if *tensorSplit != "" {
 		splits := strings.Split(*tensorSplit, ",")

--- a/runner/ollamarunner/threads_test.go
+++ b/runner/ollamarunner/threads_test.go
@@ -1,0 +1,124 @@
+package ollamarunner
+
+import (
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/ollama/ollama/envconfig"
+)
+
+func TestOllamaRunnerThreadsEnvVar(t *testing.T) {
+	tests := []struct {
+		name        string
+		envValue    string
+		expected    uint
+	}{
+		{
+			name:        "valid positive integer",
+			envValue:    "8",
+			expected:    8,
+		},
+		{
+			name:        "valid positive integer large",
+			envValue:    "32",
+			expected:    32,
+		},
+		{
+			name:        "zero threads",
+			envValue:    "0",
+			expected:    0, // envconfig.Uint returns 0 for invalid/zero values
+		},
+		{
+			name:        "negative threads",
+			envValue:    "-1",
+			expected:    0, // envconfig.Uint returns default (0) for invalid values
+		},
+		{
+			name:        "invalid string",
+			envValue:    "abc",
+			expected:    0, // envconfig.Uint returns default (0) for invalid values
+		},
+		{
+			name:        "empty string",
+			envValue:    "",
+			expected:    0, // envconfig.Uint returns default (0) when env var not set
+		},
+		{
+			name:        "float value",
+			envValue:    "4.5",
+			expected:    0, // envconfig.Uint returns default (0) for invalid values
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up environment variable
+			if tt.envValue != "" {
+				t.Setenv("OLLAMA_RUNNER_THREADS", tt.envValue)
+			} else {
+				os.Unsetenv("OLLAMA_RUNNER_THREADS")
+			}
+
+			// Test the environment variable parsing using envconfig
+			threads := envconfig.RunnerThreads()
+
+			if threads != tt.expected {
+				t.Errorf("Expected threads=%d, got threads=%d", tt.expected, threads)
+			}
+		})
+	}
+}
+
+func TestOllamaRunnerThreadsIntegration(t *testing.T) {
+	// Test the full logic as it would be used in Execute function
+	tests := []struct {
+		name        string
+		envValue    string
+		expected    int
+	}{
+		{
+			name:        "valid threads override",
+			envValue:    "4",
+			expected:    4,
+		},
+		{
+			name:        "zero threads uses default",
+			envValue:    "0",
+			expected:    runtime.NumCPU(),
+		},
+		{
+			name:        "invalid threads uses default",
+			envValue:    "abc",
+			expected:    runtime.NumCPU(),
+		},
+		{
+			name:        "no env var uses default",
+			envValue:    "",
+			expected:    runtime.NumCPU(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up environment variable
+			if tt.envValue != "" {
+				t.Setenv("OLLAMA_RUNNER_THREADS", tt.envValue)
+			} else {
+				os.Unsetenv("OLLAMA_RUNNER_THREADS")
+			}
+
+			// Simulate the logic from Execute function
+			threads := runtime.NumCPU() // default value from flag
+			
+			// Apply the same logic as in Execute function
+			if runnerThreads := envconfig.RunnerThreads(); runnerThreads > 0 {
+				threads = int(runnerThreads)
+			}
+
+			if threads != tt.expected {
+				t.Errorf("Expected final threads=%d, got threads=%d", tt.expected, threads)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Was running on my dual xeon server and was only getting half the worker thread as I expected because of the logic around that. Current behaviour makes sense as an automatic default, but this should be configurable by anyone deploying on their machine so they can tweak as they see fit. 

### Environment Variable Setup:
* [`envconfig/config.go`](diffhunk://#diff-f2766e983a91949170e97b80faaf822c3e362af58cc65b9c38a2a09d84a6bd1bR227-R228): Added `RunnerThreads` as a new environment variable to configure thread count. Updated the `AsMap` method to include documentation for the new variable. [[1]](diffhunk://#diff-f2766e983a91949170e97b80faaf822c3e362af58cc65b9c38a2a09d84a6bd1bR227-R228) [[2]](diffhunk://#diff-f2766e983a91949170e97b80faaf822c3e362af58cc65b9c38a2a09d84a6bd1bR274)

### Application Logic:
* [`cmd/cmd.go`](diffhunk://#diff-8e494a434a8037b6c0b888e25b2baae7618fe65e792d4a155dadd096e9350667R1576): Integrated `OLLAMA_RUNNER_THREADS` into the CLI environment variables list for documentation purposes.
* [`runner/ollamarunner/runner.go`](diffhunk://#diff-8138918098aff3e64b3e34dc9904bcb4f55c1798c01c948795ed69ea00c99fffR941-R945): Updated the `Execute` function to check for `OLLAMA_RUNNER_THREADS` and override the default thread count if the environment variable is set.

### Testing:
* [`runner/ollamarunner/threads_test.go`](diffhunk://#diff-8d5614356e0e54231b7ec5ed7bb2ebf782dfeb693aa0810866fafb56ee99b839R1-R124): Added unit and integration tests to validate the behavior of `OLLAMA_RUNNER_THREADS`, ensuring proper handling of valid, invalid, and unset values, as well as integration with runtime defaults.