### PR TITLE
Configuration: added the environment variable OLLAMA_BATCH_SIZE

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -669,7 +669,7 @@ func DefaultOptions() Options {
 		Runner: Runner{
 			// options set when the model is loaded
 			NumCtx:    int(envconfig.ContextLength()),
-			NumBatch:  512,
+			NumBatch:  int(envconfig.BatchSize()),
 			NumGPU:    -1, // -1 here indicates that NumGPU should be set dynamically
 			NumThread: 0,  // let the runtime decide
 			UseMMap:   nil,

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -183,6 +183,8 @@ var (
 	NewEngine = Bool("OLLAMA_NEW_ENGINE")
 	// ContextLength sets the default context length
 	ContextLength = Uint("OLLAMA_CONTEXT_LENGTH", 4096)
+	// NumBatch sets the default for batch size
+	BatchSize = Uint("OLLAMA_BATCH_SIZE", 512)
 	// Auth enables authentication between the Ollama client and server
 	UseAuth = Bool("OLLAMA_AUTH")
 )
@@ -269,6 +271,7 @@ func AsMap() map[string]EnvVar {
 		"OLLAMA_SCHED_SPREAD":      {"OLLAMA_SCHED_SPREAD", SchedSpread(), "Always schedule model across all GPUs"},
 		"OLLAMA_MULTIUSER_CACHE":   {"OLLAMA_MULTIUSER_CACHE", MultiUserCache(), "Optimize prompt caching for multi-user scenarios"},
 		"OLLAMA_CONTEXT_LENGTH":    {"OLLAMA_CONTEXT_LENGTH", ContextLength(), "Context length to use unless otherwise specified (default: 4096)"},
+		"OLLAMA_BATCH_SIZE":        {"OLLAMA_BATCH_SIZE", BatchSize(), "Batch Size to use unless otherwise specified (default: 512)"},
 		"OLLAMA_NEW_ENGINE":        {"OLLAMA_NEW_ENGINE", NewEngine(), "Enable the new Ollama engine"},
 
 		// Informational

--- a/envconfig/config_test.go
+++ b/envconfig/config_test.go
@@ -295,6 +295,22 @@ func TestContextLength(t *testing.T) {
 	}
 }
 
+func TestBatchSize(t *testing.T) {
+	cases := map[string]uint{
+		"":    512,
+		"128": 128,
+	}
+
+	for k, v := range cases {
+		t.Run(k, func(t *testing.T) {
+			t.Setenv("OLLAMA_BATCH_SIZE", k)
+			if i := BatchSize(); i != v {
+				t.Errorf("%s: expected %d, got %d", k, v, i)
+			}
+		})
+	}
+}
+
 func TestLogLevel(t *testing.T) {
 	cases := map[string]slog.Level{
 		// Default to INFO


### PR DESCRIPTION
Can be used to configure the default Batch Size (Default Value 512)

Unless the variable is set by the user nothing should change in the behavior.