### PR TITLE
Add basic authentication support to client via env vars

### DIFF
--- a/api/client_test.go
+++ b/api/client_test.go
@@ -143,7 +143,7 @@ func TestClientStream(t *testing.T) {
 			}))
 			defer ts.Close()
 
-			client := NewClient(&url.URL{Scheme: "http", Host: ts.Listener.Addr().String()}, http.DefaultClient)
+			client := NewClient(&url.URL{Scheme: "http", Host: ts.Listener.Addr().String()}, http.DefaultClient, "")
 
 			var receivedChunks []ChatResponse
 			err := client.stream(t.Context(), http.MethodPost, "/v1/chat", nil, func(chunk []byte) error {
@@ -226,7 +226,7 @@ func TestClientDo(t *testing.T) {
 			}))
 			defer ts.Close()
 
-			client := NewClient(&url.URL{Scheme: "http", Host: ts.Listener.Addr().String()}, http.DefaultClient)
+			client := NewClient(&url.URL{Scheme: "http", Host: ts.Listener.Addr().String()}, http.DefaultClient, "")
 
 			var resp struct {
 				ID      string `json:"id"`

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -1,6 +1,7 @@
 package envconfig
 
 import (
+	"encoding/base64"
 	"fmt"
 	"log/slog"
 	"math"
@@ -185,6 +186,10 @@ var (
 	ContextLength = Uint("OLLAMA_CONTEXT_LENGTH", 4096)
 	// Auth enables authentication between the Ollama client and server
 	UseAuth = Bool("OLLAMA_AUTH")
+	// Username returns the username for authentication
+	Username = String("OLLAMA_USERNAME")
+	// Password returns the password for authentication
+	Password = String("OLLAMA_PASSWORD")
 )
 
 func String(s string) func() string {
@@ -270,6 +275,8 @@ func AsMap() map[string]EnvVar {
 		"OLLAMA_MULTIUSER_CACHE":   {"OLLAMA_MULTIUSER_CACHE", MultiUserCache(), "Optimize prompt caching for multi-user scenarios"},
 		"OLLAMA_CONTEXT_LENGTH":    {"OLLAMA_CONTEXT_LENGTH", ContextLength(), "Context length to use unless otherwise specified (default: 4096)"},
 		"OLLAMA_NEW_ENGINE":        {"OLLAMA_NEW_ENGINE", NewEngine(), "Enable the new Ollama engine"},
+		"OLLAMA_USERNAME":          {"OLLAMA_USERNAME", Username(), "Username for authentication"},
+		"OLLAMA_PASSWORD":          {"OLLAMA_PASSWORD", Password(), "Password for authentication"},	
 
 		// Informational
 		"HTTP_PROXY":  {"HTTP_PROXY", String("HTTP_PROXY")(), "HTTP proxy"},
@@ -307,4 +314,27 @@ func Values() map[string]string {
 // Var returns an environment variable stripped of leading and trailing quotes or spaces
 func Var(key string) string {
 	return strings.Trim(strings.TrimSpace(os.Getenv(key)), "\"'")
+}
+
+func username() string {
+	if s := Var("OLLAMA_USERNAME"); s != "" {
+		return s
+	}
+
+	return ""
+}
+
+func password() string {
+	if s := Var("OLLAMA_PASSWORD"); s != "" {
+		return s
+	}
+
+	return ""
+}
+
+func AuthHeader() string {
+	if username() != "" && password() != "" {
+		return "Basic " + base64.StdEncoding.EncodeToString([]byte(username()+":"+password()))
+	}
+	return ""
 }


### PR DESCRIPTION
The Ollama CLI lacked user authentication.  
This PR adds basic auth support using OLLAMA_USERNAME and OLLAMA_PASSWORD environment variables.  
If both are set, an Authorization header is added to client requests.
