### PR TITLE
cmd: handle single quote in filenames on Linux

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -536,6 +536,7 @@ func normalizeFilePath(fp string) string {
 		"\\*", "*", // Escaped asterisk
 		"\\?", "?", // Escaped question mark
 		"\\~", "~", // Escaped tilde
+		"'\\''", "'", // Shell-escaped single quote
 	).Replace(fp)
 }
 


### PR DESCRIPTION
Fixes #10333 

This PR fixes the single quote escaping that was not working on Linux. This was brought up in the comment section from the Issue. 

Output from my local code and from ollama:

Image correctly embeded:
```
drull@smart-toaster:~/Documents/ollama$ go run . run qwen2.5vl:3b
>>> '/home/drull/Pictures/'\''a'\''a'\''a'\''a'\''a'\''aa'\'''\'''\'''\''aaa'\''.png' 
Added image '/home/drull/Pictures/'a'a'a'a'a'aa''''aaa'.png'
I'm sorry, but I'm not sure what you're asking. Can you please provide more context or information?

```
Previously (image not embeded):
```
drull@smart-toaster:~/Documents/ollama$ ollama run qwen2.5vl:3b
>>> '/home/drull/Pictures/'\''a'\''a'\''a'\''a'\''a'\''aa'\'''\'''\'''\''aaa'\''.png' 
The string you provided appears to be a path to a file in the home directory of a user named "drull". 
```