### PR TITLE
api: handle http reponse statuscode

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -208,6 +208,13 @@ func (c *Client) stream(ctx context.Context, method, path string, data any, fn f
 	}
 	defer response.Body.Close()
 
+	if response.StatusCode >= http.StatusBadRequest {
+		return StatusError{
+			StatusCode: response.StatusCode,
+			Status:     response.Status,
+		}
+	}
+
 	scanner := bufio.NewScanner(response.Body)
 	// increase the buffer size to avoid running out of space
 	scanBuf := make([]byte, 0, maxBufferSize)


### PR DESCRIPTION
Add a check for HTTP status codes >= 400 in the Client.stream method. When such a response is received, return a StatusError containing the status code and status text. This improves error handling for streaming API calls.