### PR TITLE
Fix GetModelInfo

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -385,18 +385,21 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 				case "modelfile":
 					fmt.Println(resp.Modelfile)
 				case "parameters":
-					if len(opts.Options) > 0 {
+					fmt.Println("Model defined parameters:")
+					if resp.Parameters == "" {
+						fmt.Println("  No additional parameters were specified for this model.")
+					} else {
+						for _, l := range strings.Split(resp.Parameters, "\n") {
+							fmt.Printf("  %s\n", l)
+						}
+					}
+					fmt.Println()
+					if opts.Options != nil && len(opts.Options) > 0 {
 						fmt.Println("User defined parameters:")
 						for k, v := range opts.Options {
-							fmt.Printf("%-*s %v\n", 30, k, v)
+							fmt.Printf("  %-*s %v\n", 30, k, v)
 						}
 						fmt.Println()
-					}
-					if resp.Parameters == "" {
-						fmt.Println("No parameters were specified for this model.")
-					} else {
-						fmt.Println("Model defined parameters:")
-						fmt.Println(resp.Parameters)
 					}
 				case "system":
 					switch {

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -394,7 +394,7 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 						}
 					}
 					fmt.Println()
-					if opts.Options != nil && len(opts.Options) > 0 {
+					if len(opts.Options) > 0 {
 						fmt.Println("User defined parameters:")
 						for k, v := range opts.Options {
 							fmt.Printf("  %-*s %v\n", 30, k, v)

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -385,16 +385,16 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 				case "modelfile":
 					fmt.Println(resp.Modelfile)
 				case "parameters":
+					if len(opts.Options) > 0 {
+						fmt.Println("User defined parameters:")
+						for k, v := range opts.Options {
+							fmt.Printf("%-*s %v\n", 30, k, v)
+						}
+						fmt.Println()
+					}
 					if resp.Parameters == "" {
 						fmt.Println("No parameters were specified for this model.")
 					} else {
-						if len(opts.Options) > 0 {
-							fmt.Println("User defined parameters:")
-							for k, v := range opts.Options {
-								fmt.Printf("%-*s %v\n", 30, k, v)
-							}
-							fmt.Println()
-						}
 						fmt.Println("Model defined parameters:")
 						fmt.Println(resp.Parameters)
 					}

--- a/server/routes.go
+++ b/server/routes.go
@@ -844,6 +844,9 @@ func GetModelInfo(req api.ShowRequest) (*api.ShowResponse, error) {
 
 	for k, v := range req.Options {
 		if _, ok := req.Options[k]; ok {
+			if m.Options == nil {
+				m.Options = make(map[string]any)
+			}
 			m.Options[k] = v
 		}
 	}

--- a/server/routes.go
+++ b/server/routes.go
@@ -842,11 +842,11 @@ func GetModelInfo(req api.ShowRequest) (*api.ShowResponse, error) {
 	}
 	resp.Parameters = strings.Join(params, "\n")
 
-	for k, v := range req.Options {
-		if _, ok := req.Options[k]; ok {
-			if m.Options == nil {
-				m.Options = make(map[string]any)
-			}
+	if len(req.Options) > 0 {
+		if m.Options == nil {
+			m.Options = make(map[string]any)
+		}
+		for k, v := range req.Options {
 			m.Options[k] = v
 		}
 	}


### PR DESCRIPTION
This change carries #11396 and fixes #11395.

If GetModelInfo was called with optional params it was throwing an error if the model didn't have any parameters already defined for it.