### PR TITLE
fix: quantization on non-macos systems

### DIFF
--- a/ml/backend/ggml/ggml/src/ggml.go
+++ b/ml/backend/ggml/ggml/src/ggml.go
@@ -5,6 +5,7 @@ package ggml
 // #cgo CPPFLAGS: -I${SRCDIR}/../include -I${SRCDIR}/ggml-cpu
 // #cgo windows CFLAGS: -Wno-dll-attribute-on-redeclaration
 // #cgo windows LDFLAGS: -lmsvcrt -static -static-libgcc -static-libstdc++
+// #cgo windows linux CPPFLAGS: -DGGML_FP16_TO_FP32=ggml_compute_fp16_to_fp32
 // #include <stdlib.h>
 // #include "ggml-backend.h"
 // extern void sink(int level, char *text, void *user_data);

--- a/ml/backend/ggml/quantization.go
+++ b/ml/backend/ggml/quantization.go
@@ -79,7 +79,3 @@ func Quantize(newType fsggml.TensorType, f32s []float32, shape []uint64) iter.Se
 		}
 	}
 }
-
-func QuantizationVersion() uint32 {
-	return uint32(C.GGML_QNT_VERSION)
-}


### PR DESCRIPTION
This fixes and adds a test for quantization on non-Darwin system. Previously quantizing on Linux and Window would produce corrupt files due to values being mapped incorrectly. 

Also update `Quantize` to return a `iter.Seq[[]byte]`. This allows portions of the tensor to be quantized at a time (which it was already doing before) which reduces overall memory usage