### PR TITLE
feat: add environment variable that allow user to disable gin default logging middleware

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1581,6 +1581,7 @@ func NewCLI() *cobra.Command {
 				envVars["OLLAMA_LLM_LIBRARY"],
 				envVars["OLLAMA_GPU_OVERHEAD"],
 				envVars["OLLAMA_LOAD_TIMEOUT"],
+				envVars["GIN_DISABLE_LOG_REQUEST"],
 			})
 		default:
 			appendEnvDocs(cmd, envs)

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -165,6 +165,8 @@ func LogLevel() slog.Level {
 }
 
 var (
+	// GinLogRequest disable GIN logging middleware that logs every request
+	GinDisableLogRequest = Bool("GIN_DISABLE_LOG_REQUEST")
 	// FlashAttention enables the experimental flash attention feature.
 	FlashAttention = Bool("OLLAMA_FLASH_ATTENTION")
 	// KvCacheType is the quantization type for the K/V cache.
@@ -275,6 +277,9 @@ func AsMap() map[string]EnvVar {
 		"HTTP_PROXY":  {"HTTP_PROXY", String("HTTP_PROXY")(), "HTTP proxy"},
 		"HTTPS_PROXY": {"HTTPS_PROXY", String("HTTPS_PROXY")(), "HTTPS proxy"},
 		"NO_PROXY":    {"NO_PROXY", String("NO_PROXY")(), "No proxy"},
+
+		// GIN
+		"GIN_DISABLE_LOG_REQUEST": {"GIN_DISABLE_LOG_REQUEST", GinDisableLogRequest(), "Disable Gin logging middleware that logs every request"},
 	}
 
 	if runtime.GOOS != "windows" {

--- a/server/routes.go
+++ b/server/routes.go
@@ -1177,12 +1177,23 @@ func (s *Server) GenerateRoutes(rc *ollama.Registry) (http.Handler, error) {
 	}
 	corsConfig.AllowOrigins = envconfig.AllowedOrigins()
 
-	r := gin.Default()
+	r := gin.New()
 	r.HandleMethodNotAllowed = true
-	r.Use(
-		cors.New(corsConfig),
-		allowedHostsMiddleware(s.addr),
-	)
+
+	if envconfig.GinDisableLogRequest() {
+		r.Use(
+			gin.Recovery(),
+			cors.New(corsConfig),
+			allowedHostsMiddleware(s.addr),
+		)
+	} else {
+		r.Use(
+			gin.Logger(),
+			gin.Recovery(),
+			cors.New(corsConfig),
+			allowedHostsMiddleware(s.addr),
+		)
+	}
 
 	// General
 	r.HEAD("/", func(c *gin.Context) { c.String(http.StatusOK, "Ollama is running") })


### PR DESCRIPTION
Allows the user to disable through an environment variable the GIN logging middleware, which logs every request by default.

This is very useful if ollama is exposed through a reverse proxy that already logs all requests, or to avoid filling ollama logs with requests from health checks.

It might also fix this issue #3197.