### PR TITLE
Increase performance for Gemma3n models on NVGPUs by enabling CUDA Graph execution

### DIFF
--- a/llama/patches/0019-metal-add-mean-kernel-14267.patch
+++ b/llama/patches/0019-metal-add-mean-kernel-14267.patch
@@ -16,7 +16,7 @@ ggml-ci
  2 files changed, 67 insertions(+), 14 deletions(-)
 
 diff --git a/ggml/src/ggml-metal/ggml-metal.m b/ggml/src/ggml-metal/ggml-metal.m
-index ee4f2dcb..f20f5615 100644
+index a9eeebc6..110c9ece 100644
 --- a/ggml/src/ggml-metal/ggml-metal.m
 +++ b/ggml/src/ggml-metal/ggml-metal.m
 @@ -489,6 +489,7 @@ enum ggml_metal_kernel_type {

--- a/llama/patches/0020-CUDA-add-mean-operation-14313.patch
+++ b/llama/patches/0020-CUDA-add-mean-operation-14313.patch
@@ -52,7 +52,7 @@ index 64fb4ff4..5b9a0fe3 100644
  static __device__ __forceinline__ float warp_reduce_max(float x) {
  #pragma unroll
 diff --git a/ggml/src/ggml-cuda/ggml-cuda.cu b/ggml/src/ggml-cuda/ggml-cuda.cu
-index 4c829153..9e64e5ae 100644
+index d6960174..2b9fabf4 100644
 --- a/ggml/src/ggml-cuda/ggml-cuda.cu
 +++ b/ggml/src/ggml-cuda/ggml-cuda.cu
 @@ -35,6 +35,7 @@

--- a/llama/patches/0021-Enable-CUDA-Graphs-for-gemma3n.patch
+++ b/llama/patches/0021-Enable-CUDA-Graphs-for-gemma3n.patch
@@ -9,48 +9,42 @@ though ollama has a slightly different model graph
 than llama.cpp which requires different workaround
 checks.
 ---
- ggml/src/ggml-cuda/ggml-cuda.cu | 22 ++++++++++++++++++----
- 1 file changed, 18 insertions(+), 4 deletions(-)
+ ggml/src/ggml-cuda/ggml-cuda.cu | 16 ++++++++++++----
+ 1 file changed, 12 insertions(+), 4 deletions(-)
 
 diff --git a/ggml/src/ggml-cuda/ggml-cuda.cu b/ggml/src/ggml-cuda/ggml-cuda.cu
-index 2b9fabf4..e7e8798b 100644
+index 2b9fabf4..28ccf4be 100644
 --- a/ggml/src/ggml-cuda/ggml-cuda.cu
 +++ b/ggml/src/ggml-cuda/ggml-cuda.cu
-@@ -2474,6 +2474,10 @@ static bool check_node_graph_compatibility_and_refresh_copy_ops(ggml_backend_cud
+@@ -2474,6 +2474,9 @@ static bool check_node_graph_compatibility_and_refresh_copy_ops(ggml_backend_cud
      // Loop over nodes in GGML graph to obtain info needed for CUDA graph
      cuda_ctx->cuda_graph->cpy_dest_ptrs.clear();
  
-+    const std::string gemma3n_hidden_state_ops_src1_name = " (permuted) (cont)";
 +    const std::string gemma3n_per_layer_proj_src1_name   = " (reshaped)";
 +    const std::string gemma3n_node_name                  = "node_";
 +
      for (int i = 0; i < cgraph->n_nodes; i++) {
          ggml_tensor * node = cgraph->nodes[i];
  
-@@ -2496,12 +2500,22 @@ static bool check_node_graph_compatibility_and_refresh_copy_ops(ggml_backend_cud
+@@ -2495,12 +2498,17 @@ static bool check_node_graph_compatibility_and_refresh_copy_ops(ggml_backend_cud
+ #endif
          }
  
-         if (node->op == GGML_OP_ADD && node->src[1] && node->src[1]->ne[1] > 1) {
+-        if (node->op == GGML_OP_ADD && node->src[1] && node->src[1]->ne[1] > 1) {
 -            // disable CUDA graphs for batch size > 1 for now.
 -            // Changes in batch size or context size can cause changes to the grid size of some kernels.
--            use_cuda_graph = false;
-+            // workarounds to exclude Gemma3n's `project_per_layer_input` operation and its hidden state operations from the batch-size heuristic, specific to ollama
-+            // number of layers is different for per_layer_proj between gemma3n:2b and gemma3n:4b, which is why we don't check that value here
-+            if (!((node->ne[0] == 4 && node->ne[1] == 2048 && node->ne[2] == 1 && node->ne[3] == 1 && node->src[0] ?
-+                       std::string(node->src[0]->name).find(gemma3n_node_name) != std::string::npos :
-+                   false && node->src[1] ? node->src[1]->name == gemma3n_hidden_state_ops_src1_name :
-+                                           false) ||
-+                  (node->ne[0] == 256 && node->ne[2] == 1 && node->ne[3] == 1 && node->src[0] ?
-+                       std::string(node->src[0]->name).find(gemma3n_node_name) != std::string::npos :
-+                   false && node->src[1] ? node->src[1]->name == gemma3n_per_layer_proj_src1_name :
-+                                           false))) {
-+                // Generally, changes in batch size or context size can cause changes to the grid size of some kernels.
-+                use_cuda_graph = false;
++        // workarounds to exclude Gemma3n's `project_per_layer_input` operation from the batch-size heuristic, specific to ollama's implementation of gemma3n
++        // number of layers is different for per_layer_proj between gemma3n:2b and gemma3n:4b, which is why we don't check that value here
++        if (node->op == GGML_OP_ADD && node->src[1] && node->src[1]->ne[1] > 1 && !(node->ne[0] == 256
++                                                                                    && node->ne[2] == 1
++                                                                                    && node->ne[3] == 1
++                                                                                    && node->src[0] ? std::string(node->src[0]->name).find(gemma3n_node_name) != std::string::npos : false
++                                                                                    && node->src[1] ? node->src[1]->name == gemma3n_per_layer_proj_src1_name : false)) {
++            // Generally, changes in batch size or context size can cause changes to the grid size of some kernels.
+             use_cuda_graph = false;
  #ifndef NDEBUG
 -            GGML_LOG_DEBUG("%s: disabling CUDA graphs due to batch size > 1 [%s] [%ld %ld %ld %ld]\n", __func__, node->name, node->ne[0], node->ne[1], node->ne[2], node->ne[3]);
-+                GGML_LOG_DEBUG("%s: disabling CUDA graphs due to batch size > 1 [%s] [%ld %ld %ld %ld]\n", __func__, node->name, node->ne[0], node->ne[1], node->ne[2], node->ne[3]);
++            GGML_LOG_INFO("%s: disabling CUDA graphs due to batch size > 1 [%s] [%ld %ld %ld %ld]\n", __func__, node->name, node->ne[0], node->ne[1], node->ne[2], node->ne[3]);
  #endif
-+            }
          }
  
-         if (node->op == GGML_OP_CPY) {

--- a/llama/patches/0021-Enable-CUDA-Graphs-for-gemma3n.patch
+++ b/llama/patches/0021-Enable-CUDA-Graphs-for-gemma3n.patch
@@ -1,0 +1,56 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Oliver Simons <osimons@nvidia.com>
+Date: Tue, 22 Jul 2025 11:02:28 +0200
+Subject: [PATCH] Enable CUDA Graphs for gemma3n.
+
+Similar to
+https://github.com/ggml-org/llama.cpp/pull/14741,
+though ollama has a slightly different model graph
+than llama.cpp which requires different workaround
+checks.
+---
+ ggml/src/ggml-cuda/ggml-cuda.cu | 22 ++++++++++++++++++----
+ 1 file changed, 18 insertions(+), 4 deletions(-)
+
+diff --git a/ggml/src/ggml-cuda/ggml-cuda.cu b/ggml/src/ggml-cuda/ggml-cuda.cu
+index 2b9fabf4..e7e8798b 100644
+--- a/ggml/src/ggml-cuda/ggml-cuda.cu
++++ b/ggml/src/ggml-cuda/ggml-cuda.cu
+@@ -2474,6 +2474,10 @@ static bool check_node_graph_compatibility_and_refresh_copy_ops(ggml_backend_cud
+     // Loop over nodes in GGML graph to obtain info needed for CUDA graph
+     cuda_ctx->cuda_graph->cpy_dest_ptrs.clear();
+ 
++    const std::string gemma3n_hidden_state_ops_src1_name = " (permuted) (cont)";
++    const std::string gemma3n_per_layer_proj_src1_name   = " (reshaped)";
++    const std::string gemma3n_node_name                  = "node_";
++
+     for (int i = 0; i < cgraph->n_nodes; i++) {
+         ggml_tensor * node = cgraph->nodes[i];
+ 
+@@ -2496,12 +2500,22 @@ static bool check_node_graph_compatibility_and_refresh_copy_ops(ggml_backend_cud
+         }
+ 
+         if (node->op == GGML_OP_ADD && node->src[1] && node->src[1]->ne[1] > 1) {
+-            // disable CUDA graphs for batch size > 1 for now.
+-            // Changes in batch size or context size can cause changes to the grid size of some kernels.
+-            use_cuda_graph = false;
++            // workarounds to exclude Gemma3n's `project_per_layer_input` operation and its hidden state operations from the batch-size heuristic, specific to ollama
++            // number of layers is different for per_layer_proj between gemma3n:2b and gemma3n:4b, which is why we don't check that value here
++            if (!((node->ne[0] == 4 && node->ne[1] == 2048 && node->ne[2] == 1 && node->ne[3] == 1 && node->src[0] ?
++                       std::string(node->src[0]->name).find(gemma3n_node_name) != std::string::npos :
++                   false && node->src[1] ? node->src[1]->name == gemma3n_hidden_state_ops_src1_name :
++                                           false) ||
++                  (node->ne[0] == 256 && node->ne[2] == 1 && node->ne[3] == 1 && node->src[0] ?
++                       std::string(node->src[0]->name).find(gemma3n_node_name) != std::string::npos :
++                   false && node->src[1] ? node->src[1]->name == gemma3n_per_layer_proj_src1_name :
++                                           false))) {
++                // Generally, changes in batch size or context size can cause changes to the grid size of some kernels.
++                use_cuda_graph = false;
+ #ifndef NDEBUG
+-            GGML_LOG_DEBUG("%s: disabling CUDA graphs due to batch size > 1 [%s] [%ld %ld %ld %ld]\n", __func__, node->name, node->ne[0], node->ne[1], node->ne[2], node->ne[3]);
++                GGML_LOG_DEBUG("%s: disabling CUDA graphs due to batch size > 1 [%s] [%ld %ld %ld %ld]\n", __func__, node->name, node->ne[0], node->ne[1], node->ne[2], node->ne[3]);
+ #endif
++            }
+         }
+ 
+         if (node->op == GGML_OP_CPY) {

--- a/ml/backend/ggml/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ml/backend/ggml/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -2474,7 +2474,6 @@ static bool check_node_graph_compatibility_and_refresh_copy_ops(ggml_backend_cud
     // Loop over nodes in GGML graph to obtain info needed for CUDA graph
     cuda_ctx->cuda_graph->cpy_dest_ptrs.clear();
 
-    const std::string gemma3n_hidden_state_ops_src1_name = " (permuted) (cont)";
     const std::string gemma3n_per_layer_proj_src1_name   = " (reshaped)";
     const std::string gemma3n_node_name                  = "node_";
 
@@ -2499,23 +2498,18 @@ static bool check_node_graph_compatibility_and_refresh_copy_ops(ggml_backend_cud
 #endif
         }
 
-        if (node->op == GGML_OP_ADD && node->src[1] && node->src[1]->ne[1] > 1) {
-            // workarounds to exclude Gemma3n's `project_per_layer_input` operation and its hidden state operations from the batch-size heuristic, specific to ollama
-            // number of layers is different for per_layer_proj between gemma3n:2b and gemma3n:4b, which is why we don't check that value here
-            if (!((node->ne[0] == 4 && node->ne[1] == 2048 && node->ne[2] == 1 && node->ne[3] == 1 && node->src[0] ?
-                       std::string(node->src[0]->name).find(gemma3n_node_name) != std::string::npos :
-                   false && node->src[1] ? node->src[1]->name == gemma3n_hidden_state_ops_src1_name :
-                                           false) ||
-                  (node->ne[0] == 256 && node->ne[2] == 1 && node->ne[3] == 1 && node->src[0] ?
-                       std::string(node->src[0]->name).find(gemma3n_node_name) != std::string::npos :
-                   false && node->src[1] ? node->src[1]->name == gemma3n_per_layer_proj_src1_name :
-                                           false))) {
-                // Generally, changes in batch size or context size can cause changes to the grid size of some kernels.
-                use_cuda_graph = false;
+        // workarounds to exclude Gemma3n's `project_per_layer_input` operation from the batch-size heuristic, specific to ollama's implementation of gemma3n
+        // number of layers is different for per_layer_proj between gemma3n:2b and gemma3n:4b, which is why we don't check that value here
+        if (node->op == GGML_OP_ADD && node->src[1] && node->src[1]->ne[1] > 1 && !(node->ne[0] == 256
+                                                                                    && node->ne[2] == 1
+                                                                                    && node->ne[3] == 1
+                                                                                    && node->src[0] ? std::string(node->src[0]->name).find(gemma3n_node_name) != std::string::npos : false
+                                                                                    && node->src[1] ? node->src[1]->name == gemma3n_per_layer_proj_src1_name : false)) {
+            // Generally, changes in batch size or context size can cause changes to the grid size of some kernels.
+            use_cuda_graph = false;
 #ifndef NDEBUG
-                GGML_LOG_DEBUG("%s: disabling CUDA graphs due to batch size > 1 [%s] [%ld %ld %ld %ld]\n", __func__, node->name, node->ne[0], node->ne[1], node->ne[2], node->ne[3]);
+            GGML_LOG_INFO("%s: disabling CUDA graphs due to batch size > 1 [%s] [%ld %ld %ld %ld]\n", __func__, node->name, node->ne[0], node->ne[1], node->ne[2], node->ne[3]);
 #endif
-            }
         }
 
         if (node->op == GGML_OP_CPY) {

--- a/ml/backend/ggml/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ml/backend/ggml/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -2474,6 +2474,10 @@ static bool check_node_graph_compatibility_and_refresh_copy_ops(ggml_backend_cud
     // Loop over nodes in GGML graph to obtain info needed for CUDA graph
     cuda_ctx->cuda_graph->cpy_dest_ptrs.clear();
 
+    const std::string gemma3n_hidden_state_ops_src1_name = " (permuted) (cont)";
+    const std::string gemma3n_per_layer_proj_src1_name   = " (reshaped)";
+    const std::string gemma3n_node_name                  = "node_";
+
     for (int i = 0; i < cgraph->n_nodes; i++) {
         ggml_tensor * node = cgraph->nodes[i];
 
@@ -2496,12 +2500,22 @@ static bool check_node_graph_compatibility_and_refresh_copy_ops(ggml_backend_cud
         }
 
         if (node->op == GGML_OP_ADD && node->src[1] && node->src[1]->ne[1] > 1) {
-            // disable CUDA graphs for batch size > 1 for now.
-            // Changes in batch size or context size can cause changes to the grid size of some kernels.
-            use_cuda_graph = false;
+            // workarounds to exclude Gemma3n's `project_per_layer_input` operation and its hidden state operations from the batch-size heuristic, specific to ollama
+            // number of layers is different for per_layer_proj between gemma3n:2b and gemma3n:4b, which is why we don't check that value here
+            if (!((node->ne[0] == 4 && node->ne[1] == 2048 && node->ne[2] == 1 && node->ne[3] == 1 && node->src[0] ?
+                       std::string(node->src[0]->name).find(gemma3n_node_name) != std::string::npos :
+                   false && node->src[1] ? node->src[1]->name == gemma3n_hidden_state_ops_src1_name :
+                                           false) ||
+                  (node->ne[0] == 256 && node->ne[2] == 1 && node->ne[3] == 1 && node->src[0] ?
+                       std::string(node->src[0]->name).find(gemma3n_node_name) != std::string::npos :
+                   false && node->src[1] ? node->src[1]->name == gemma3n_per_layer_proj_src1_name :
+                                           false))) {
+                // Generally, changes in batch size or context size can cause changes to the grid size of some kernels.
+                use_cuda_graph = false;
 #ifndef NDEBUG
-            GGML_LOG_DEBUG("%s: disabling CUDA graphs due to batch size > 1 [%s] [%ld %ld %ld %ld]\n", __func__, node->name, node->ne[0], node->ne[1], node->ne[2], node->ne[3]);
+                GGML_LOG_DEBUG("%s: disabling CUDA graphs due to batch size > 1 [%s] [%ld %ld %ld %ld]\n", __func__, node->name, node->ne[0], node->ne[1], node->ne[2], node->ne[3]);
 #endif
+            }
         }
 
         if (node->op == GGML_OP_CPY) {

--- a/model/models/gemma3n/model_text.go
+++ b/model/models/gemma3n/model_text.go
@@ -203,10 +203,9 @@ func (a AltUp) Predict(ctx ml.Context, hiddenStates ml.Tensor, opts *TextOptions
 	coefficients := a.PredictionCoefficient.Forward(ctx, modalities)
 	coefficients = coefficients.Reshape(ctx, opts.altupInputs, opts.altupInputs, coefficients.Dim(1), coefficients.Dim(2))
 
-	hiddenStates = hiddenStates.Permute(ctx, 1, 2, 0, 3).Contiguous(ctx)
-	predictions := coefficients.Mulmat(ctx, hiddenStates)
-	predictions = predictions.Add(ctx, hiddenStates)
-	return predictions.Permute(ctx, 2, 0, 1, 3).Contiguous(ctx)
+	predictions := coefficients.Mulmat(ctx, hiddenStates.Permute(ctx, 1, 2, 0, 3).Contiguous(ctx))
+	predictions = predictions.Permute(ctx, 2, 0, 1, 3).Contiguous(ctx)
+	return predictions.Add(ctx, hiddenStates)
 }
 
 func (a AltUp) Correct(ctx ml.Context, predictions, activated, one ml.Tensor, opts *TextOptions) ml.Tensor {


### PR DESCRIPTION
This PR enables the execution of Gemma3n as CUDA Graphs on NVGPUs by porting https://github.com/ggml-org/llama.cpp/pull/14741 to ollama. Since the model graph is defined differently in ollama compared to llama.cpp, the heuristic used to identify and exclude the `per_layer_projection` from batch-size determination needed to be modified a bit. As a consequence, the patch will need to be maintained even after llama.cpp is updated to a commit that contains https://github.com/ggml-org/llama.cpp/pull/14741.

On a RTX PRO 6000 Max-Q under Windows, this PR improves perf by ~2.5x, see

Model | Configuration | Tokens/sec
-- | -- | --
gemma3n:e2b | CG ON | 103
gemma3n:e2b | CG OFF | 43
gemma3n:e4b | CG ON | 79
gemma3n:e4b | CG OFF | 35

Thanks @mxyng for providing changes to gemma3n model graph definition in c4de3eaa3e11eee48ed061ebbae5737f7a7cd2b2 that make the checking more robust.