### PR TITLE
 server: add signature metadata to manifest format

### DIFF
--- a/server/manifest.go
+++ b/server/manifest.go
@@ -15,13 +15,12 @@ import (
 	"github.com/ollama/ollama/types/model"
 )
 
-// SignatureInfo contains metadata about a model signature
 type SignatureInfo struct {
-	Format       string    `json:"format"`           // Signature format version (e.g., "oms-v1.0")
-	SignatureURI string    `json:"signatureUri"`     // URI to signature file
-	Verified     bool      `json:"verified"`         // Whether signature has been verified
-	Signer       string    `json:"signer,omitempty"` // Identity of the signer
-	SignedAt     time.Time `json:"signedAt,omitempty"` // When the model was signed
+	Format       string    `json:"format"` // e.g. "oms-v1.0"
+	SignatureURI string    `json:"signatureUri"`
+	Verified     bool      `json:"verified"`
+	Signer       string    `json:"signer,omitempty"` 
+	SignedAt     time.Time `json:"signedAt,omitempty"`
 }
 
 type Manifest struct {
@@ -30,9 +29,7 @@ type Manifest struct {
 	Config        Layer   `json:"config"`
 	Layers        []Layer `json:"layers"`
 
-	// Signature contains cryptographic signature information for this model
-	// This field is optional to maintain backward compatibility with unsigned models
-	Signature *SignatureInfo `json:"signature,omitempty"`
+	Signature *SignatureInfo `json:"signature,omitempty"` // optional
 
 	filepath string
 	fi       os.FileInfo


### PR DESCRIPTION
# Problem

  Currently, Ollama has no mechanism to store or track signature
  information for models. To enable future model integrity
  verification, we need a way to associate signature metadata with
  model manifests.

# Solution

  This PR adds an optional SignatureInfo struct to the Manifest format
  to prepare for model signature verification capabilities. The change
  is designed to be completely backwards compatible with existing
  unsigned models.

# Changes

## Core Changes:

  - Add SignatureInfo struct with fields for signature metadata:
    - Format: signature format version (e.g., "oms-v1.0")
    - SignatureURI: reference to signature file location
    - Verified: boolean indicating verification status
    - Signer: identity of the signer (optional)
    - SignedAt: timestamp when model was signed (optional)
  - Add optional Signature field to Manifest using omitempty JSON tag
  for backwards compatibility

## Testing:

 No business logic to test yet.

## Backwards Compatibility

  ✅ Fully backwards compatible - existing manifests continue to work
  unchanged:
  - Uses `json:"signature,omitempty"` to exclude field when nil
  - No behavioral changes to existing code paths
  - All existing tests continue to pass

## Usage Example

```
  // Future usage - model with signature
  manifest := &Manifest{
      SchemaVersion: 2,
      MediaType:
  "application/vnd.docker.distribution.manifest.v2+json",
      Config:        layer,
      Layers:        []Layer{modelLayer},
      Signature: &SignatureInfo{
          Format:       "oms-v1.0",
          SignatureURI: "sha256:abc123...",
          Verified:     true,
          Signer:       "signer@example.com",
          SignedAt:     time.Now(),
      },
  }

  // Existing usage - unchanged
  manifest := &Manifest{
      SchemaVersion: 2,
      Config:        layer,
      Layers:        []Layer{modelLayer},
      // No signature field - works exactly as before
  }
```

# Testing

  ## All existing tests pass
  `go test ./server -run TestManifests -v`

# Future Work

  This struct provides the foundation for upcoming PRs that will add:
  - Signature verification workflows
  - CLI commands for signing/verifying models
  - Integration with model pull/push operations

Draft PR with the full implementation #11573 

# Files Changed

  - `server/manifest.go` - Add SignatureInfo struct and optional
  Manifest.Signature field