### PR TITLE
CONTRIBUTING: fix typo in commit message example (clairity → clarity)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ continuation of the sentence:
 Examples:
 
       llm/backend/mlx: support the llama architecture
-      CONTRIBUTING: provide clairity on good commit messages, and bad
+      CONTRIBUTING: provide clarity on good commit messages, and bad
 
 Bad Examples:
 


### PR DESCRIPTION
Corrected the word "clairity" to "clarity" in the example commit message