### PR TITLE
Update documentation to include error return introduced in v0.9.3

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -67,6 +67,16 @@ Enable JSON mode by setting the `format` parameter to `json`. This will structur
 > [!IMPORTANT]
 > It's important to instruct the model to use JSON in the `prompt`. Otherwise, the model may generate large amounts whitespace.
 
+#### Errors
+
+If computation of the model fails, a status code of 500 ("Internal server error") will be returned along with a JSON object:
+
+```json
+{
+"error":"model runner has unexpectedly stopped, this may be due to resource limitations or an internal error, check ollama server logs for details"
+}
+```
+
 ### Examples
 
 #### Generate request (Streaming)

--- a/docs/api.md
+++ b/docs/api.md
@@ -531,6 +531,15 @@ Models can also explain the result of the tool call in the response. See the [Ch
 
 Structured outputs are supported by providing a JSON schema in the `format` parameter. The model will generate a response that matches the schema. See the [Chat request (Structured outputs)](#chat-request-structured-outputs) example below.
 
+### Errors
+If computation of the model fails, a status code of 500 ("Internal server error") will be returned along with a JSON object:
+
+```json
+{
+"error":"model runner has unexpectedly stopped, this may be due to resource limitations or an internal error, check ollama server logs for details"
+}
+```
+
 ### Examples
 
 #### Chat request (Streaming)


### PR DESCRIPTION
Commit 87b7af6 introduced a panic if a model can't be computed. This documents the error returned by the API for the generate and chat endpoints. 