### PR TITLE
cmd: add `names-only` option to list handler.

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -525,6 +525,23 @@ func ListHandler(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Get the --names-only flag value
+	namesOnly, err := cmd.Flags().GetBool("names-only")
+	if err != nil {
+		return err
+	}
+
+	// If --names-only flag is set, just print model names
+	if namesOnly {
+		for _, m := range models.Models {
+			if len(args) == 0 || strings.HasPrefix(strings.ToLower(m.Name), strings.ToLower(args[0])) {
+				fmt.Println(m.Name)
+			}
+		}
+		return nil
+	}
+
+	// Original table output logic
 	var data [][]string
 
 	for _, m := range models.Models {
@@ -1509,6 +1526,8 @@ func NewCLI() *cobra.Command {
 		PreRunE: checkServerHeartbeat,
 		RunE:    ListHandler,
 	}
+
+	listCmd.Flags().Bool("names-only", false, "Only show model names")
 
 	psCmd := &cobra.Command{
 		Use:     "ps",


### PR DESCRIPTION
This PR introduces `names-only` to `ollama list` command, e.g:
```
 ~/G/ollama (feature/list-names-only)> ./ollama list
NAME                  ID              SIZE      MODIFIED
codellama:7b-code     8df0a30bb1e6    3.8 GB    11 days ago
codegemma:2b          926331004170    1.6 GB    11 days ago
mistral:latest        6577803aa9a0    4.4 GB    11 days ago
qwen3:latest          500a1f067a9f    5.2 GB    11 days ago
qwen2.5vl:latest      5ced39dfa4ba    6.0 GB    11 days ago
gemma3:latest         a2af6cc3eb7f    3.3 GB    11 days ago
deepseek-r1:8b        6995872bfe4c    5.2 GB    11 days ago
deepseek-r1:latest    6995872bfe4c    5.2 GB    11 days ago
 ~/G/ollama (feature/list-names-only)> ./ollama list --help
List models

Usage:
  ollama list [flags]

Aliases:
  list, ls

Flags:
  -h, --help         help for list
      --names-only   Only show model names

Environment Variables:
      OLLAMA_HOST                IP Address for the ollama server (default 127.0.0.1:11434)
 ~/G/ollama (feature/list-names-only)> ./ollama list --names-only
codellama:7b-code
codegemma:2b
mistral:latest
qwen3:latest
qwen2.5vl:latest
gemma3:latest
deepseek-r1:8b
deepseek-r1:latest
 ~/G/ollama (feature/list-names-only)>
 ```

Other tools, like `docker` and `podman` have a `quiet` flag to return only the IDs, e.g:

```shell
 ~/G/ollama (feature/list-names-only)> podman images
REPOSITORY                 TAG         IMAGE ID      CREATED      SIZE
docker.io/library/mariadb  latest      b5898e2f8654  6 weeks ago  361 MB
 ~/G/ollama (feature/list-names-only)> podman images --quiet
b5898e2f8654
 ~/G/ollama (feature/list-names-only)>
```
 
 The use case behind this is to get a list of local models, so you can iterate over them without using external tools to get the names only.

Feature request #11541 