### PR TITLE
Revert "CI: switch back to x86 macos builder"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
           echo GOFLAGS="'-ldflags=-w -s \"-X=github.com/ollama/ollama/version.Version=${GITHUB_REF_NAME#v}\" \"-X=github.com/ollama/ollama/server.mode=release\"'" >>$GITHUB_OUTPUT
 
   darwin-build:
-    runs-on: macos-13
+    runs-on: macos-13-xlarge
     environment: release
     needs: setup-environment
     strategy:


### PR DESCRIPTION
This reverts commit 9d071e6089319b37acf62bb739e3430dcb2ac0c3.


Turns out CI wasn't to blame - actual fix in #11585 