### PR TITLE
win: static link msvc libs

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -6,7 +6,8 @@
       "binaryDir": "${sourceDir}/build",
       "installDir": "${sourceDir}/dist",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release"
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreaded"
       }
     },
     {


### PR DESCRIPTION
This should help reduce the runtime dependencies on windows.

Reference: https://cmake.org/cmake/help/latest/prop_tgt/MSVC_RUNTIME_LIBRARY.html

Prior to this change, the various `ggml-*.dll`  libraries all depend on MSVCP140.dll and VCRUNTIME140.dll

Fixes #11447 
Fixes #11556 