### PR TITLE
kvcache: Log contents of cache when unable to find a slot

### DIFF
--- a/kvcache/causal.go
+++ b/kvcache/causal.go
@@ -214,6 +214,7 @@ func (c *Causal) StartForward(ctx ml.Context, batch input.Batch, reserve bool) e
 			c.curLoc, err = c.findStartLoc()
 		}
 		if err != nil {
+			slog.Warn("unable to find a kv cache slot", "cache", c)
 			return err
 		}
 


### PR DESCRIPTION
There is a bug when using sliding window attention where we run out of KV cache slots. This is likely due to not correctly removing all of the entries as they slide out of range. This adds additional logging when this occurs to track down the source.

Bug #10127