### PR TITLE
gptoss: fix memory calc

### DIFF
--- a/fs/ggml/ggml.go
+++ b/fs/ggml/ggml.go
@@ -676,7 +676,7 @@ func (f GGML) GraphSize(context, batch uint64, numParallel int, kvCacheType stri
 			}
 		}
 		fullOffload = 4 * f.KV().HeadCountMax() / cmp.Or(f.KV().HeadCountKVMin(), 1) * kvTotal / 6
-		partialOffload = 2 * fullOffload
+		partialOffload = fullOffload
 	}
 
 	return


### PR DESCRIPTION
multipler was added by mistake so when model is offloaded to cpu, more gpu memory is thought to be used so even more layers will be offloaded