### PR TITLE
script/install.sh: Resume large downloads when rerun after error

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -26,6 +26,9 @@ cleanup () {
   fi
 }
 trap 'status=$?; cleanup; exit $status' EXIT
+trap 'trap - HUP; cleanup SIGHUP; kill -HUP $$' HUP
+trap 'trap - INT; cleanup SIGINT; kill -INT $$' INT
+trap 'trap - TERM; cleanup SIGTERM; kill -TERM $$' TERM
 
 available() { command -v $1 >/dev/null; }
 require() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,9 +11,21 @@ status() { echo ">>> $*" >&2; }
 error() { echo "${red}ERROR:${plain} $*"; exit 1; }
 warning() { echo "${red}WARNING:${plain} $*"; }
 
-TEMP_DIR=$(mktemp -d)
-cleanup() { rm -rf $TEMP_DIR; }
-trap cleanup EXIT
+TEMP_ROOT_DIR=/tmp/ollama
+TEMP_DIR=${TEMP_ROOT_DIR}/install
+mkdir -p $TEMP_DIR
+cleanup () {
+  if [ -n "$1" ]; then
+    >&2 echo "Aborted by $1"
+  elif [ $status -ne 0 ]; then
+    >&2 echo "Failure (status $status). Current progress can be resumed and available in ${TEMP_DIR}"
+  else
+    rm -rf $TEMP_DIR
+    # If install is the only tmp content, remove all traces
+    rmdir --ignore-fail-on-non-empty $TEMP_ROOT_DIR || true
+  fi
+}
+trap 'status=$?; cleanup; exit $status' EXIT
 
 available() { command -v $1 >/dev/null; }
 require() {
@@ -80,8 +92,9 @@ $SUDO install -o0 -g0 -m755 -d $BINDIR
 $SUDO install -o0 -g0 -m755 -d "$OLLAMA_INSTALL_DIR/lib/ollama"
 status "Downloading Linux ${ARCH} bundle"
 curl --fail --show-error --location --progress-bar \
-    "https://ollama.com/download/ollama-linux-${ARCH}.tgz${VER_PARAM}" | \
-    $SUDO tar -xzf - -C "$OLLAMA_INSTALL_DIR"
+    --output-dir $TEMP_DIR --continue-at - --remote-name \
+    "https://ollama.com/download/ollama-linux-${ARCH}.tgz${VER_PARAM}"
+$SUDO tar -xzf "${TEMP_DIR}/ollama-linux-${ARCH}.tgz${VER_PARAM}" -C "$OLLAMA_INSTALL_DIR"
 
 if [ "$OLLAMA_INSTALL_DIR/bin/ollama" != "$BINDIR/ollama" ] ; then
     status "Making ollama accessible in the PATH in $BINDIR"
@@ -93,13 +106,15 @@ if [ -f /etc/nv_tegra_release ] ; then
     if grep R36 /etc/nv_tegra_release > /dev/null ; then
         status "Downloading JetPack 6 components"
         curl --fail --show-error --location --progress-bar \
-            "https://ollama.com/download/ollama-linux-${ARCH}-jetpack6.tgz${VER_PARAM}" | \
-            $SUDO tar -xzf - -C "$OLLAMA_INSTALL_DIR"
+            --output-dir $TEMP_DIR --continue-at - --remote-name \
+            "https://ollama.com/download/ollama-linux-${ARCH}-jetpack6.tgz${VER_PARAM}"
+        $SUDO tar -xzf "${TEMP_DIR}/ollama-linux-${ARCH}.tgz${VER_PARAM}"  -C "$OLLAMA_INSTALL_DIR"
     elif grep R35 /etc/nv_tegra_release > /dev/null ; then
         status "Downloading JetPack 5 components"
         curl --fail --show-error --location --progress-bar \
-            "https://ollama.com/download/ollama-linux-${ARCH}-jetpack5.tgz${VER_PARAM}" | \
-            $SUDO tar -xzf - -C "$OLLAMA_INSTALL_DIR"
+            --output-dir $TEMP_DIR --continue-at - --remote-name \
+            "https://ollama.com/download/ollama-linux-${ARCH}-jetpack5.tgz${VER_PARAM}"
+        $SUDO tar -xzf "${TEMP_DIR}/ollama-linux-${ARCH}-jetpack5.tgz${VER_PARAM}" -C "$OLLAMA_INSTALL_DIR"
     else
         warning "Unsupported JetPack version detected.  GPU may not be supported"
     fi
@@ -224,8 +239,9 @@ fi
 if check_gpu lspci amdgpu || check_gpu lshw amdgpu; then
     status "Downloading Linux ROCm ${ARCH} bundle"
     curl --fail --show-error --location --progress-bar \
-        "https://ollama.com/download/ollama-linux-${ARCH}-rocm.tgz${VER_PARAM}" | \
-        $SUDO tar -xzf - -C "$OLLAMA_INSTALL_DIR"
+        --output-dir $TEMP_DIR --continue-at - --remote-name \
+        "https://ollama.com/download/ollama-linux-${ARCH}-rocm.tgz${VER_PARAM}"
+    $SUDO tar -xzf "${TEMP_DIR}/ollama-linux-${ARCH}-rocm.tgz${VER_PARAM}" -C "$OLLAMA_INSTALL_DIR"
 
     install_success
     status "AMD GPU ready."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -25,7 +25,7 @@ cleanup () {
     rmdir --ignore-fail-on-non-empty $TEMP_ROOT_DIR || true
   fi
 }
-trap 'status=$?; cleanup; exit $status' EXIT
+trap 'status=$?; cleanup ""; exit $status' EXIT
 trap 'trap - HUP; cleanup SIGHUP; kill -HUP $$' HUP
 trap 'trap - INT; cleanup SIGINT; kill -INT $$' INT
 trap 'trap - TERM; cleanup SIGTERM; kill -TERM $$' TERM


### PR DESCRIPTION
### Problem

Install can take time and fail for a range of reasons, typically network loss when many Linux distributions default to go power saving. Reruns of the script so far restart from zero, getting large bundles again for Ollama, Nvidia or AMD.

### Importance

Adopting Ollama can be improved and broadened with an install script that helps across runs.

### Proposed change

The changes are all in `scripts/install.sh` to modify two aspects:

1. Large downloads via cURL adopt new option flags to resume downloads where they last stopped.
2. Extended cleanup at the end of the script, to decide keeping pending download on error, and cleanup all on success.

(1) requires to save files to disc (to get something to resume from), so the original pipe to `tar` is split into two commands with files saved in a dedicated temporary directory. (2) provides an extended logic depending on the script success or error, but also the use of a predictable temporary directory path (instead of `mktemp -d`).

### Tests

* Fresh install on an Ubuntu 22 machine with an Nvidia GTX1050Ti
* Fresh install on an Ubuntu 24 machine with an AMD AI Max+ 395 system featuring a Radeon 8060S

The tests included scenarios:

a. Success of the script
b. Cut networking while downloading. Resumes when network is back.
c. Files kept on SIGINT. Resumes on rerun.

Not tested, but supported in the code: Same processing for SIGHUP and SIGTERM.