### PR TITLE
build: update go stdlib to 1.24.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ollama/ollama
 
-go 1.24.0
+go 1.24.6
 
 require (
 	github.com/containerd/console v1.0.3


### PR DESCRIPTION
According to trivy scan, go stdlib 1.2.6 fixes 5 CVEs: CVE-2025-22874 CVE-2025-0913 CVE-2025-22871 CVE-2025-4673 CVE-2025-47907.

Testing: go test; end-to-end vanilla and rocm flavor Docker images ran on CPU and AMDGPU with basic prompt responded, GPU utilization as expected.