### PR TITLE
Increase LLAMA_MAX_EXPERTS to 512

### DIFF
--- a/llama/llama.cpp/src/llama-hparams.h
+++ b/llama/llama.cpp/src/llama-hparams.h
@@ -6,7 +6,7 @@
 
 // bump if necessary
 #define LLAMA_MAX_LAYERS  512
-#define LLAMA_MAX_EXPERTS 256  // DeepSeekV3
+#define LLAMA_MAX_EXPERTS 512  // Kimi K2
 
 enum llama_expert_gating_func_type {
     LLAMA_EXPERT_GATING_FUNC_TYPE_NONE    = 0,


### PR DESCRIPTION
Kimi K2 model needs 384 experts to run.
I'm proposing 512 as 384 feels arbitrary.

https://ollama.com/huihui_ai/kimi-k2