### PR TITLE
Add community dashboard for OllamaChat

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Andes](https://github.com/aqerd/andes) (A Visual Studio Code extension that provides a local UI interface for Ollama models)
 - [Clueless](https://github.com/KashyapTan/clueless) (Open Source & Local Cluely: A desktop application LLM assistant to help you talk to anything on your screen using locally served Ollama models. Also undetectable to screenshare)
 - [ollama-co2](https://github.com/carbonatedWaterOrg/ollama-co2) (FastAPI web interface for monitoring and managing local and remote Ollama servers with real-time model monitoring and concurrent downloads)
+- [OllamaChat](https://github.com/vaccarov/OllamaChat) A modern, multi-languages dashboard with import/export, voice transcription written in Next.js
 
 ### Cloud
 


### PR DESCRIPTION
The last few months I've created a fully featured dashboard to interact with local models.

Project readme & screenshots: [https://github.com/vaccarov/OllamaChat](https://github.com/vaccarov/OllamaChat)

Some of them:

- Interact with local LLM via Ollama
- Show models capabilities
- Import/Export Sessions
- Voice Transcription (STT)
- Text-to-Speech (TTS)
- Image Management
- Internationalization (i18n)
- Markdown Rendering
- Customizable System Prompt
- Remote access
- ...

It's written in React, and I'm currently implementing new features.

I'd be honored to merge this PR as my first contribution in the open source community.