### PR TITLE
add cuda 13.x support

### DIFF
--- a/discover/cuda_common.go
+++ b/discover/cuda_common.go
@@ -64,6 +64,10 @@ func cudaVariant(gpuInfo CudaGPUInfo) string {
 		// The detected driver is older than Feb 2023
 		slog.Warn("old CUDA driver detected - please upgrade to a newer driver", "version", fmt.Sprintf("%d.%d", gpuInfo.DriverMajor, gpuInfo.DriverMinor))
 		return "v11"
+	} else if gpuInfo.DriverMajor == 12 && gpuInfo.DriverMinor > 1 {
+		return "v12"
+	} else if gpuInfo.DriverMajor == 13 && gpuInfo.DriverMinor >= 0 {
+		return "v13"
 	}
 	return "v12"
 }


### PR DESCRIPTION
fix ollama can't use nvidia gpu when use ollama with cuda 13.0, meet error log:

    Error: 500 Internal Server Error: llama runner process has terminated: cudaMalloc failed: out of memory
    ggml_gallocr_reserve_n: failed to allocate CUDA0 buffer of size 8891928576
