### PR TITLE
api: Increase max response size from 512 KB to 5 MB

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -159,7 +159,10 @@ func (c *Client) do(ctx context.Context, method, path string, reqData, respData 
 	return nil
 }
 
-const maxBufferSize = 512 * format.KiloByte
+const (
+	maxBufferSize     = 5 * format.MegaByte
+	defaultBufferSize = 512 * format.KiloByte
+)
 
 func (c *Client) stream(ctx context.Context, method, path string, data any, fn func([]byte) error) error {
 	var buf io.Reader
@@ -210,7 +213,7 @@ func (c *Client) stream(ctx context.Context, method, path string, data any, fn f
 
 	scanner := bufio.NewScanner(response.Body)
 	// increase the buffer size to avoid running out of space
-	scanBuf := make([]byte, 0, maxBufferSize)
+	scanBuf := make([]byte, 0, defaultBufferSize)
 	scanner.Buffer(scanBuf, maxBufferSize)
 	for scanner.Scan() {
 		var errorResponse struct {


### PR DESCRIPTION
The second argument to bufio.Scanner's Buffer() is the maximum size that will ever be allocated (set to 512 KB), silently dropping larger responses from Ollama.

When sending large requests to /api/generate (MB-range), MB-sized contexts are returned and the whole response is silently dropped, causing users to complain.

This change keeps the default buffer size at 512 KB, but raises the maximum buffer size to 5 MB.

This fixes https://github.com/ollama/ollama/issues/11811 - or at least bumps the size by a factor of ten.