### PR TITLE
Updating DSET from 3.12. to 3.14

### DIFF
--- a/macapp/package-lock.json
+++ b/macapp/package-lock.json
@@ -4284,7 +4284,7 @@
       "integrity": "sha512-ujScWZH49NK1hYlp2/EMw45nOPEh+pmTydAnR6gSkRNucZD4fuinvpPL03rmFCw8ibaMuKLAdgPJfQ0gkLKZ5A==",
       "dependencies": {
         "@lukeed/uuid": "^2.0.0",
-        "dset": "^3.1.2",
+        "dset": "^3.1.4",
         "tslib": "^2.4.1"
       }
     },
@@ -7652,9 +7652,9 @@
       }
     },
     "node_modules/dset": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.2.tgz",
-      "integrity": "sha512-g/M9sqy3oHe477Ar4voQxWtaPIFw1jTdKZuomOjhCcBx9nHUNn0pu6NopuFFrTh/TRZIKEj+76vLWFu9BNKk+Q==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
+      "integrity": "sha512-D9017F83DFF34DA3C373706335C5531A805B5C18187CC4D371E2DA61C149FD6F64820154921C43FE13047AE2CA6EE83279FF52A80C7C7298309483FF8E29D44C",
       "engines": {
         "node": ">=4"
       }


### PR DESCRIPTION
updating dset from 3.1.2 to 3.1.4.

3.1.2 is flagging for CVE-2024-21529 as a high issue in scans for enterprise use blocking approval of the install. Probably double check my syntax and sha512 hash here but raising to your attention to address.

There doesn't seem to be any issues from 3.1.2 to 3.1.4 (and knowing like 4287 would install the most recent version). The defined older version is flagging on vulnerablity scans. 