### PR TITLE
chore: fix some inconsistent function name in comment

### DIFF
--- a/ml/backend/ggml/quantization.go
+++ b/ml/backend/ggml/quantization.go
@@ -15,7 +15,7 @@ import (
 	fsggml "github.com/ollama/ollama/fs/ggml"
 )
 
-// convertToF32 converts (dequantizes) the raw data to F32 so we can then quantize it
+// ConvertToF32 converts (dequantizes) the raw data to F32 so we can then quantize it
 func ConvertToF32(data []byte, dtype uint32, nelements uint64) []float32 {
 	f32s := make([]float32, nelements)
 	elems := C.int64_t(nelements)

--- a/ml/nn/rope/rope.go
+++ b/ml/nn/rope/rope.go
@@ -22,7 +22,7 @@ func WithOriginalContextLength(n int) func(*Options) {
 	}
 }
 
-// WithType sets RoPE type to NeoX
+// WithTypeNeoX sets RoPE type to NeoX
 func WithTypeNeoX() func(*Options) {
 	return func(opts *Options) {
 		opts.Type = 2

--- a/runner/common/stop.go
+++ b/runner/common/stop.go
@@ -26,7 +26,7 @@ func ContainsStopSuffix(sequence string, stops []string) bool {
 	return false
 }
 
-// truncateStop removes the provided stop string from pieces,
+// TruncateStop removes the provided stop string from pieces,
 // returning the partial pieces with stop removed, including truncating
 // the last piece if required (and signalling if this was the case)
 func TruncateStop(pieces []string, stop string) ([]string, bool) {

--- a/server/internal/client/ollama/registry_test.go
+++ b/server/internal/client/ollama/registry_test.go
@@ -468,7 +468,7 @@ func TestErrorUnmarshal(t *testing.T) {
 	}
 }
 
-// TestParseNameErrors tests that parseName returns errors messages with enough
+// TestParseNameExtendedErrors tests that parseName returns errors messages with enough
 // detail for users to debug naming issues they may encounter. Previous to this
 // test, the error messages were not very helpful and each problem was reported
 // as the same message.


### PR DESCRIPTION
 fix some inconsistent function name in comment