### PR TITLE
fix arm linux build when HWCAP2_SVE2 undefined

### DIFF
--- a/ml/backend/ggml/ggml/src/ggml-cpu/arch/arm/arm.go
+++ b/ml/backend/ggml/ggml/src/ggml-cpu/arch/arm/arm.go
@@ -1,5 +1,5 @@
 package arm
 
 // #cgo CXXFLAGS: -std=c++17
-// #cgo CPPFLAGS: -I${SRCDIR}/../.. -I${SRCDIR}/../../.. -I${SRCDIR}/../../../../include
+// #cgo CPPFLAGS: -I${SRCDIR}/../.. -I${SRCDIR}/../../.. -I${SRCDIR}/../../../../include -DHWCAP2_SVE2="2"
 import "C"


### PR DESCRIPTION
It looks like our almalinux-8 base doesn't have this macro defined in the headers we're including.

This includes `sys/auxv.h`, which includes `bits/hwcap.h`.  On our base image, that header states:
```
/* The following must match the kernel's <asm/hwcap.h>.  */
#define HWCAP_FP                (1 << 0)
#define HWCAP_ASIMD             (1 << 1)
...
```
and does NOT include HWCAP2_SVE2, however, looking at `asm/hwcap.h` the macro is defined as
```
#define HWCAP2_SVE2             (1 << 1)
```


Confirmed with this patch our docker build works