### PR TITLE
handle cgo flags in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,6 +86,8 @@ RUN go mod download
 COPY . .
 ARG GOFLAGS="'-ldflags=-w -s'"
 ENV CGO_ENABLED=1
+ARG CGO_CFLAGS
+ARG CGO_CXXFLAGS
 RUN --mount=type=cache,target=/root/.cache/go-build \
     go build -trimpath -buildmode=pie -o /bin/ollama .
 


### PR DESCRIPTION
Docker build requires build-args to be defined.  This ensures the release.yaml settings will be used.