### PR TITLE
Revert "cuda: leverage JIT for smaller footprint (#11635)"

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -22,7 +22,7 @@
       "name": "CUDA 12",
       "inherits": [ "CUDA" ],
       "cacheVariables": {
-        "CMAKE_CUDA_ARCHITECTURES": "50-virtual;60-virtual;61-virtual;70-virtual;75-virtual;80-virtual;86-virtual;89-virtual;90-virtual;90a-virtual;100-virtual;120-virtual",
+        "CMAKE_CUDA_ARCHITECTURES": "50;60;61;70;75;80;86;87;89;90;90a;120",
         "CMAKE_CUDA_FLAGS": "-Wno-deprecated-gpu-targets -t 2"
       }
     },
@@ -30,14 +30,14 @@
       "name": "JetPack 5",
       "inherits": [ "CUDA" ],
       "cacheVariables": {
-        "CMAKE_CUDA_ARCHITECTURES": "72-virtual;87-virtual"
+        "CMAKE_CUDA_ARCHITECTURES": "72;87"
       }
     },
     {
       "name": "JetPack 6",
       "inherits": [ "CUDA" ],
       "cacheVariables": {
-        "CMAKE_CUDA_ARCHITECTURES": "87-virtual"
+        "CMAKE_CUDA_ARCHITECTURES": "87"
       }
     },
     {


### PR DESCRIPTION
This reverts commit dc5a645434f0ea6364c426c6ba112da1afa40cb2.

Looks like this is causing problems on some systems.  I'll investigate deeper later to see if there's some way to re-enable the savings, but for now, back this out to get a good build.

```
CUDA error: the provided PTX was compiled with an unsupported toolchain.
  current device: 0, in function ggml_cuda_mul_mat_q at //ml/backend/ggml/ggml/src/ggml-cuda/mmq.cu:129
  cudaGetLastError()
```