### PR TITLE
[AGENT] implement the status api

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -357,6 +357,15 @@ func (c *Client) ListRunning(ctx context.Context) (*ProcessResponse, error) {
 	return &lr, nil
 }
 
+// Status gets the current server status including running and pending requests.
+func (c *Client) Status(ctx context.Context) (*StatusResponse, error) {
+	var sr StatusResponse
+	if err := c.do(ctx, http.MethodGet, "/api/status", nil, &sr); err != nil {
+		return nil, err
+	}
+	return &sr, nil
+}
+
 // Copy copies a model - creating a model with another name from an existing
 // model.
 func (c *Client) Copy(ctx context.Context, req *CopyRequest) error {

--- a/api/types.go
+++ b/api/types.go
@@ -528,6 +528,19 @@ type ProcessModelResponse struct {
 	ContextLength int          `json:"context_length"`
 }
 
+// StatusResponse is the response from the /api/status endpoint.
+type StatusResponse struct {
+	RunningRequests []RequestStatus `json:"running_requests"`
+	PendingRequests []string        `json:"pending_requests"`
+	FreeMemory      uint64          `json:"free_memory"`
+}
+
+// RequestStatus represents information about a running request.
+type RequestStatus struct {
+	ID              string `json:"id"`
+	GeneratedTokens int    `json:"generated_tokens"`
+}
+
 type TokenResponse struct {
 	Token string `json:"token"`
 }

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -365,10 +365,10 @@ func TestGetRunner(t *testing.T) {
 	s.getCpuFn = getCpuFn
 	s.newServerFn = a.newServer
 	slog.Info("a")
-	successCh1a, errCh1a := s.GetRunner(a.ctx, a.req.model, a.req.opts, a.req.sessionDuration)
+	successCh1a, errCh1a, _ := s.GetRunner(a.ctx, a.req.model, a.req.opts, a.req.sessionDuration)
 	require.Len(t, s.pendingReqCh, 1)
 	slog.Info("b")
-	successCh1b, errCh1b := s.GetRunner(b.ctx, b.req.model, b.req.opts, b.req.sessionDuration)
+	successCh1b, errCh1b, _ := s.GetRunner(b.ctx, b.req.model, b.req.opts, b.req.sessionDuration)
 	require.Len(t, s.pendingReqCh, 1)
 	require.Empty(t, successCh1b)
 	require.Len(t, errCh1b, 1)
@@ -392,7 +392,7 @@ func TestGetRunner(t *testing.T) {
 
 	c.req.model.ModelPath = "bad path"
 	slog.Info("c")
-	successCh1c, errCh1c := s.GetRunner(c.ctx, c.req.model, c.req.opts, c.req.sessionDuration)
+	successCh1c, errCh1c, _ := s.GetRunner(c.ctx, c.req.model, c.req.opts, c.req.sessionDuration)
 	// Starts in pending channel, then should be quickly processed to return an error
 	time.Sleep(50 * time.Millisecond) // Long enough for the "a" model to expire and unload
 	require.Empty(t, successCh1c)
@@ -467,7 +467,7 @@ func TestPrematureExpired(t *testing.T) {
 		return []discover.GpuInfo{g}
 	}
 	s.newServerFn = scenario1a.newServer
-	successCh1a, errCh1a := s.GetRunner(scenario1a.ctx, scenario1a.req.model, scenario1a.req.opts, scenario1a.req.sessionDuration)
+	successCh1a, errCh1a, _ := s.GetRunner(scenario1a.ctx, scenario1a.req.model, scenario1a.req.opts, scenario1a.req.sessionDuration)
 	require.Len(t, s.pendingReqCh, 1)
 	s.Run(ctx)
 	select {


### PR DESCRIPTION
Initially created by cursor-agent. 

Completed Features
  1. Request Tracking:
    • Each request gets a unique ID
    • Tracks running requests with their generated token counts
    • Maintains a list of pending request IDs
  2. Memory Monitoring:
    • Reports total free GPU memory across all devices
  3. API Endpoint:
    • GET /api/status returns JSON with:
      • running_requests: Array of {id, generated_tokens}
      • pending_requests: Array of request IDs
      • free_memory: Total free memory in bytes
  4. Client Support:
    • Added Go client method in api/client.go
    • Created Python client example for ollama-python integration
    • Provided shell script for testing


  Key Implementation Details

  • Scheduler Changes: Added request tracking maps and methods to maintain request state
  • Route Handler: New StatusHandler serves the endpoint
  • Token Tracking: Real-time token counting during generation/chat completion
  • Thread-Safe: Uses mutex locks to ensure concurrent access safety
  • Minimal Performance Impact: Lightweight tracking with minimal overhead


  Files Modified

  • server/sched.go - Core request tracking logic
  • server/routes.go - API endpoint and token tracking
  • api/types.go - Response type definitions
  • api/client.go - Go client support
  • server/sched_test.go - Updated tests


  Usage

  The API can now be called by HTTP clients to monitor:
  • Server workload (running vs pending requests)
  • Generation progress (token counts)
  • Available GPU resources (free memory)

  This implementation provides the observability needed for production deployments and can be easily integrated into ollama-python or other client libraries.

  ~ server/sched.go (+117/-11)
  ~ server/routes.go (+66/-34)
  ~ api/types.go (+13)
  + test_status_api.sh (+110)
  + ollama_status_client.py (+197)
  ~ api/client.go (+9)
  ~ server/sched_test.go (+4/-4)
  + STATUS_API_IMPLEMENTATION.md (+159)