### PR TITLE
Add Serene Pub to community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [ollama launcher](https://github.com/NGC13009/ollama-launcher) (A launcher for Ollama, aiming to provide users with convenient functions such as ollama server launching, management, or configuration.)
 - [ai-hub](https://github.com/Aj-Seven/ai-hub) (AI Hub supports multiple models via API keys and Chat support via Ollama API.)
 - [Mayan EDMS](https://gitlab.com/mayan-edms/mayan-edms) (Open source document management system to organize, tag, search, and automate your files with powerful Ollama driven workflows.)
+- [Serene Pub](https://github.com/doolijb/serene-pub) (Beginner friendly, open source AI Roleplaying App for Windows, Mac OS and Linux. Search, download and use models with Ollama all inside the app.)
 
 ### Cloud
 


### PR DESCRIPTION
Hey!

Just want to share Serene Pub's new UI integration for Ollama. It's an open source AI role-play client that aims to be low-clutter and as easy as possible for beginners to get up and running. (Literally download, extract, run.)

https://github.com/doolijb/serene-pub

[Screenshots](https://github.com/doolijb/serene-pub?tab=readme-ov-file#ollama-manager)

Ollama was chosen as the preferred integration because it simply just works. The philosophy around Serene Pub is to make AI powered RP as accessible as possible to everyone regardless of what OS they use or skill-set they have. Ollama requires no tuning, extra dependencies or guess-work to get operational on user hardware.

- Opens as a feature-contained sidebar
- When Ollama is not detected, it provides the download link for Ollama
- One click model connection/activation
- Search available models
 - Recommended (from github repo)
 - Hugging face
 - Ollama (via [Ollama Models API (very limited)](https://github.com/frefrik/ollama-models-api))
- Download and delete models
- Manually paste ollama pull commands