### PR TITLE
Add any-llm to Libraries in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,6 +537,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Nichey](https://github.com/goodreasonai/nichey) is a Python package for generating custom wikis for your research topic
 - [Ollama for D](https://github.com/kassane/ollama-d)
 - [OllamaPlusPlus](https://github.com/HardCodeDev777/OllamaPlusPlus) (Very simple C++ library for Ollama)
+- [any-llm](https://github.com/mozilla-ai/any-llm) (A single interface to use different llm providers by [mozilla.ai](https://www.mozilla.ai/))
 
 ### Mobile
 


### PR DESCRIPTION
This PR adds a reference to our any-llm library under the Libraries section of the README.

[any-llm](https://github.com/mozilla-ai/any-llm) is developed by [mozilla.ai](https://www.mozilla.ai/), and aims to provide a single, unified interface to use different llm providers. For more information, for example on how it differs from LiteLLM or AISuite, you can read our blog [here](https://blog.mozilla.ai/introducing-any-llm-a-unified-api-to-access-any-llm-provider/)