### PR TITLE
cli: add `/export` command to export current session

### DIFF
--- a/cmd/interactive_test.go
+++ b/cmd/interactive_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/ollama/ollama/api"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -83,4 +84,15 @@ func TestExtractFileDataRemovesQuotedFilepath(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, imgs, 1)
 	assert.Equal(t, cleaned, "before  after")
+}
+
+func TestBuildTranscript(t *testing.T) {
+	msgs := []api.Message{
+		{Role: "system", Content: "You are helpful."},
+		{Role: "user", Content: "Hello"},
+		{Role: "assistant", Content: "Hi there!"},
+	}
+	got := buildTranscript("llama3", msgs)
+	want := "llama3\n\nSystem: You are helpful.\n\nUser: Hello\n\nAssistant: Hi there!\n"
+	assert.Equal(t, want, got)
 }


### PR DESCRIPTION
## Add interactive /export command

### Summary
Adds `/export [path]` to the interactive CLI to save the current conversation as a clean `.txt` transcript. 
### Usage
- Default path (timestamped):
```text
/export
```
- Relative path:
```text
/export chat.txt
```
- Absolute path:
```text
/export /Users/johndoe/Documents/chat.txt
```

### Use Cases
- Makes it easy to share transcripts with teammates, open-source communities, or in bug reports without screenshots.
- Users can archive the exact prompt/response flow to revisit later, useful for debugging model behavior or comparing across model versions.
- Exported transcripts can be included in project docs, tutorials, or blog posts to showcase example interactions.
- Users can save and read transcripts **offline**, without depending on the CLI session history.

### Behavior
- If the file exists, prompt before overwriting: `Overwrite? [y/N]`.
- Default export directory: `~/.ollama/exports/` with filename `chat-YYYYMMDD-HHMMSS.txt`.


### Example output
```text
llama2:7b

User: Hello

Assistant: Hi there!
```

Closes #11937.