### PR TITLE
openai: remove reasoning as an api.Options

### DIFF
--- a/openai/openai.go
+++ b/openai/openai.go
@@ -557,12 +557,10 @@ func fromChatRequest(r ChatCompletionRequest) (*api.ChatRequest, error) {
 
 	var think *api.ThinkValue
 	if r.Reasoning != nil {
-		options["reasoning"] = *r.Reasoning.Effort
 		think = &api.ThinkValue{
 			Value: *r.Reasoning.Effort,
 		}
 	} else if r.ReasoningEffort != nil {
-		options["reasoning"] = *r.ReasoningEffort
 		think = &api.ThinkValue{
 			Value: *r.ReasoningEffort,
 		}


### PR DESCRIPTION
it's not an api.Options so setting it produces a warn log. this does not remove reasoning_effort or reasoning

time=2025-08-20T11:43:36.781-07:00 level=WARN source=types.go:647 msg="invalid option provided" option=reasoning