### PR TITLE
cuda: add support for thor

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -27,6 +27,14 @@
       }
     },
     {
+      "name": "CUDA 13",
+      "inherits": [ "CUDA" ],
+      "cacheVariables": {
+        "CMAKE_CUDA_ARCHITECTURES": "75;80;86;87;89;90;90a;100;110;120;121",
+        "CMAKE_CUDA_FLAGS": "-t 2"
+      }
+    },
+    {
       "name": "JetPack 5",
       "inherits": [ "CUDA" ],
       "cacheVariables": {
@@ -76,6 +84,11 @@
       "name": "CUDA 12",
       "inherits": [ "CUDA" ],
       "configurePreset": "CUDA 12"
+    },
+    {
+      "name": "CUDA 13",
+      "inherits": [ "CUDA" ],
+      "configurePreset": "CUDA 13"
     },
     {
       "name": "JetPack 5",

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,16 @@ RUN --mount=type=cache,target=/root/.ccache \
         && cmake --build --parallel --preset 'CUDA 12' \
         && cmake --install build --component CUDA --strip --parallel 8
 
+FROM base AS cuda-13
+ARG CUDA13VERSION=13.0
+RUN dnf install -y cuda-toolkit-${CUDA13VERSION//./-}
+ENV PATH=/usr/local/cuda-13/bin:$PATH
+RUN --mount=type=cache,target=/root/.ccache \
+    cmake --preset 'CUDA 13' \
+        && cmake --build --parallel --preset 'CUDA 13' \
+        && cmake --install build --component CUDA --strip --parallel 8
+
+
 FROM base AS rocm-6
 ENV PATH=/opt/rocm/hcc/bin:/opt/rocm/hip/bin:/opt/rocm/bin:/opt/rocm/hcc/bin:$PATH
 RUN --mount=type=cache,target=/root/.ccache \
@@ -95,7 +105,7 @@ FROM --platform=linux/amd64 scratch AS amd64
 COPY --from=cuda-12 dist/lib/ollama /lib/ollama
 
 FROM --platform=linux/arm64 scratch AS arm64
-COPY --from=cuda-12 dist/lib/ollama /lib/ollama/cuda_sbsa
+COPY --from=cuda-13 dist/lib/ollama /lib/ollama/cuda_sbsa
 COPY --from=jetpack-5 dist/lib/ollama /lib/ollama/cuda_jetpack5
 COPY --from=jetpack-6 dist/lib/ollama /lib/ollama/cuda_jetpack6
 


### PR DESCRIPTION
I'm exploring a few different options on how we can add Jetson AGX Thor support.  This seems like it is probably the lowest risk change.

AGX Thor is CC 11.0, which requires CUDA v13.
Apparently arm64 SBSA CUDA support started at CC 8.0, so the 7.x and older arm CC targets we had been shipping were never used.

Eventually we'll need to support v13 for other new GPUs as they come out, so I'm also exploring adding back the dual CUDA stack support and trying v11 + v13 with "virtual" targets and leveraging JIT to keep the footprint reasonable, but I don't have that working yet on Windows.