### PR TITLE
llm/server: add option to ignore free memory size checks (#5700)

### DIFF
--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -185,6 +185,8 @@ var (
 	ContextLength = Uint("OLLAMA_CONTEXT_LENGTH", 4096)
 	// Auth enables authentication between the Ollama client and server
 	UseAuth = Bool("OLLAMA_AUTH")
+	// Ignore free memory size checks
+	IgnoreMemSize = Bool("OLLAMA_IGNORE_MEMSIZE")
 )
 
 func String(s string) func() string {
@@ -270,6 +272,7 @@ func AsMap() map[string]EnvVar {
 		"OLLAMA_MULTIUSER_CACHE":   {"OLLAMA_MULTIUSER_CACHE", MultiUserCache(), "Optimize prompt caching for multi-user scenarios"},
 		"OLLAMA_CONTEXT_LENGTH":    {"OLLAMA_CONTEXT_LENGTH", ContextLength(), "Context length to use unless otherwise specified (default: 4096)"},
 		"OLLAMA_NEW_ENGINE":        {"OLLAMA_NEW_ENGINE", NewEngine(), "Enable the new Ollama engine"},
+		"OLLAMA_IGNORE_MEMSIZE":    {"OLLAMA_IGNORE_MEMSIZE", NewMemoryEstimates(), "Ignore free memory size checks (default: false)"},
 
 		// Informational
 		"HTTP_PROXY":  {"HTTP_PROXY", String("HTTP_PROXY")(), "HTTP proxy"},

--- a/llm/server.go
+++ b/llm/server.go
@@ -537,7 +537,9 @@ func (s *llamaServer) Load(ctx context.Context, gpus discover.GpuInfoList, requi
 		available := systemInfo.System.FreeMemory + systemInfo.System.FreeSwap
 		if systemMemoryRequired > available {
 			slog.Warn("model request too large for system", "requested", format.HumanBytes2(systemMemoryRequired), "available", format.HumanBytes2(available), "total", format.HumanBytes2(systemInfo.System.TotalMemory), "free", format.HumanBytes2(systemInfo.System.FreeMemory), "swap", format.HumanBytes2(systemInfo.System.FreeSwap))
-			return fmt.Errorf("model requires more system memory (%s) than is available (%s)", format.HumanBytes2(systemMemoryRequired), format.HumanBytes2(available))
+			if !envconfig.IgnoreMemSize() {
+				return fmt.Errorf("model requires more system memory (%s) than is available (%s)", format.HumanBytes2(systemMemoryRequired), format.HumanBytes2(available))
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR adds an environment option to ignore free memory size checks: `OLLAMA_IGNORE_MEMSIZE` - it still prints the warning but allows the program to continue (and crash if the allocation fails down the line).

This is a workaround for #5700 and other cases, where high cache usage would make the naive check `model_size > (vram_size + sys_free_mem + sys_free_swap)` raise a false positive; fully detecting and taking into account e.g. ZFS cache usage would require much bigger changes that are potentially out of scope for this project.

If e.g. other variable name is preferred I'll be happy to adjust it.
Additionally, as I haven't worked with Golang before, all suggestions on improving the code are very welcome - though hopefully the changes are trivial enough to not require too many revisions.