### PR TITLE
Add truncate option to generate/chat to error on overflow

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -84,6 +84,12 @@ type GenerateRequest struct {
 	// set through this field, if the model supports it.
 	Options map[string]any `json:"options"`
 
+	// Truncate controls behavior when the input exceeds the context window.
+	// If true or omitted (default), Ollama will truncate inputs to fit.
+	// If false, the server will return HTTP 400 when the input exceeds the
+	// effective context length instead of truncating.
+	Truncate *bool `json:"truncate,omitempty"`
+
 	// Think controls whether thinking/reasoning models will think before
 	// responding. Can be a boolean (true/false) or a string ("high", "medium", "low")
 	// for supported models. Needs to be a pointer so we can distinguish between false
@@ -119,6 +125,12 @@ type ChatRequest struct {
 
 	// Options lists model-specific options.
 	Options map[string]any `json:"options"`
+
+	// Truncate controls behavior when the composed chat prompt exceeds the
+	// context window. If true or omitted (default), Ollama will truncate
+	// messages to fit the context (keeping the latest message and any system
+	// messages). If false, the server will return HTTP 400 instead.
+	Truncate *bool `json:"truncate,omitempty"`
 
 	// Think controls whether thinking/reasoning models will think before
 	// responding. Can be a boolean (true/false) or a string ("high", "medium", "low")

--- a/docs/api.md
+++ b/docs/api.md
@@ -53,6 +53,7 @@ Advanced parameters (optional):
 - `template`: the prompt template to use (overrides what is defined in the `Modelfile`)
 - `stream`: if `false` the response will be returned as a single response object, rather than a stream of objects
 - `raw`: if `true` no formatting will be applied to the prompt. You may choose to use the `raw` parameter if you are specifying a full templated prompt in your request to the API
+- `truncate`: truncates the composed prompt to fit within the context length. If `false`, the server returns `400` when the prompt exceeds the effective context length. Defaults to `true`.
 - `keep_alive`: controls how long the model will stay loaded into memory following the request (default: `5m`)
 - `context` (deprecated): the context parameter returned from a previous request to `/generate`, this can be used to keep a short conversational memory
 
@@ -508,6 +509,7 @@ Advanced parameters (optional):
 - `options`: additional model parameters listed in the documentation for the [Modelfile](./modelfile.md#valid-parameters-and-values) such as `temperature`
 - `stream`: if `false` the response will be returned as a single response object, rather than a stream of objects
 - `keep_alive`: controls how long the model will stay loaded into memory following the request (default: `5m`)
+- `truncate`: truncates older messages to fit the prompt into the context window (keeping the latest message and any system messages). If `false`, the server returns `400` when the composed prompt exceeds the effective context length. Defaults to `true`.
 
 ### Tool calling
 

--- a/server/prompt_test.go
+++ b/server/prompt_test.go
@@ -209,7 +209,7 @@ func TestChatPrompt(t *testing.T) {
 			model := tt.model
 			opts := api.Options{Runner: api.Runner{NumCtx: tt.limit}}
 			think := false
-			prompt, images, err := chatPrompt(t.Context(), &model, mockRunner{}.Tokenize, &opts, tt.msgs, nil, &api.ThinkValue{Value: think})
+			prompt, images, err := chatPrompt(t.Context(), &model, mockRunner{}.Tokenize, &opts, tt.msgs, nil, &api.ThinkValue{Value: think}, true)
 			if tt.error == nil && err != nil {
 				t.Fatal(err)
 			} else if tt.error != nil && err != tt.error {


### PR DESCRIPTION
This PR adds a truncate switch to /api/generate and /api/chat to optionally error when inputs exceed num_ctx.

This mirrors the truncate key that is already available on the embeddings API.

Motivation
- Current behavior always truncates using a sliding window, which can hide issues and lead to surprising outputs
- Strict mode helps surface upstream problems sooner

Changes
- API: add truncate to GenerateRequest and ChatRequest (default true)
- Generate: when truncate=false, validate rendered prompt (+ image token estimate) and return 400 if overflow
- Chat: wire truncate into chatPrompt; validate and error when disabled
- Tests: add unit tests for generate/chat overflow with truncate=false
- Docs: update docs/api.md to document truncate for generate/chat

Backwards compatibility
- Defaults remain truncation; no behavior change unless truncate=false is passed

Examples
- Generate: { truncate: false, options: { num_ctx: 64 }, prompt: 'very long...' } => 400 on overflow
- Chat: { truncate: false, options: { num_ctx: 64 }, messages: [{ role: 'user', content: 'very long...' }] } => 400 on overflow
