### PR TITLE
Add support for the 'ignore_eos'.

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -364,6 +364,7 @@ type Options struct {
 	PresencePenalty  float32  `json:"presence_penalty,omitempty"`
 	FrequencyPenalty float32  `json:"frequency_penalty,omitempty"`
 	Stop             []string `json:"stop,omitempty"`
+	IgnoreEOS        bool     `json:"ignore_eos,omitempty"`
 }
 
 // Runner options which must be set when the model is loaded into memory
@@ -745,6 +746,7 @@ func DefaultOptions() Options {
 		PresencePenalty:  0.0,
 		FrequencyPenalty: 0.0,
 		Seed:             -1,
+		IgnoreEOS:        false,
 
 		Runner: Runner{
 			// options set when the model is loaded

--- a/llama/llama.cpp/common/sampling.cpp
+++ b/llama/llama.cpp/common/sampling.cpp
@@ -297,6 +297,10 @@ void common_sampler_free(struct common_sampler * gsmpl) {
     }
 }
 
+bool common_sampler_ignore_eos(struct common_sampler * gsmpl){
+    return gsmpl->params.ignore_eos;
+}
+
 void common_sampler_accept(struct common_sampler * gsmpl, llama_token token, bool accept_grammar) {
     if (accept_grammar) {
         llama_sampler_accept(gsmpl->grmr, token);

--- a/llama/llama.cpp/common/sampling.h
+++ b/llama/llama.cpp/common/sampling.h
@@ -40,6 +40,8 @@ struct common_sampler * common_sampler_init(const struct llama_model * model, co
 
 void common_sampler_free(struct common_sampler * gsmpl);
 
+bool common_sampler_ignore_eos(struct common_sampler * gsmpl);
+
 // if accept_grammar is true, the token is accepted both by the sampling chain and the grammar
 void                    common_sampler_accept(struct common_sampler * gsmpl, llama_token token, bool accept_grammar);
 void                    common_sampler_reset (struct common_sampler * gsmpl);

--- a/llama/llama.go
+++ b/llama/llama.go
@@ -568,6 +568,7 @@ type SamplingParams struct {
 	PenalizeNl     bool
 	Seed           uint32
 	Grammar        string
+	IgnoreEOS      bool
 }
 
 func NewSamplingContext(model *Model, params SamplingParams) (*SamplingContext, error) {
@@ -582,6 +583,7 @@ func NewSamplingContext(model *Model, params SamplingParams) (*SamplingContext, 
 	cparams.penalty_freq = C.float(params.PenaltyFreq)
 	cparams.penalty_present = C.float(params.PenaltyPresent)
 	cparams.seed = C.uint32_t(params.Seed)
+	cparams.ignore_eos = C.bool(params.IgnoreEOS)
 
 	grammar := C.CString(params.Grammar)
 	defer C.free(unsafe.Pointer(grammar))
@@ -607,6 +609,10 @@ func (s *SamplingContext) Sample(llamaContext *Context, idx int) int {
 
 func (s *SamplingContext) Accept(id int, applyGrammar bool) {
 	C.common_sampler_caccept(s.c, C.llama_token(id), C.bool(applyGrammar))
+}
+
+func (s *SamplingContext) IgnoreEOS() bool {
+	return bool(C.common_sampler_cignore_eos(s.c))
 }
 
 // SchemaToGrammar converts the provided JSON schema to a grammar. It returns

--- a/llama/sampling_ext.cpp
+++ b/llama/sampling_ext.cpp
@@ -22,6 +22,7 @@ struct common_sampler *common_sampler_cinit(const struct llama_model *model, str
         sparams.penalty_present = params->penalty_present;
         sparams.seed = params->seed;
         sparams.grammar = params->grammar;
+        sparams.ignore_eos = params->ignore_eos;
         sparams.xtc_probability = 0.0;
         sparams.xtc_threshold = 0.5;
         return common_sampler_init(model, sparams);
@@ -40,6 +41,10 @@ void common_sampler_creset(struct common_sampler *sampler) {
 
 void common_sampler_caccept(struct common_sampler *sampler, llama_token id, bool apply_grammar) {
     common_sampler_accept(sampler, id, apply_grammar);
+}
+
+bool common_sampler_cignore_eos(struct common_sampler *sampler){
+    return common_sampler_ignore_eos(sampler);
 }
 
 llama_token common_sampler_csample(struct common_sampler *sampler, struct llama_context *ctx, int idx) {

--- a/llama/sampling_ext.h
+++ b/llama/sampling_ext.h
@@ -21,6 +21,7 @@ extern "C"
         float penalty_freq;
         float penalty_present;
         uint32_t seed;
+        bool ignore_eos;
         char *grammar;
     };
 
@@ -28,6 +29,7 @@ extern "C"
     void common_sampler_cfree(struct common_sampler *sampler);
     void common_sampler_creset(struct common_sampler *sampler);
     void common_sampler_caccept(struct common_sampler *sampler, llama_token id, bool apply_grammar);
+    bool common_sampler_cignore_eos(struct common_sampler *sampler);
     llama_token common_sampler_csample(struct common_sampler *sampler, struct llama_context *ctx, int idx);
 
     int schema_to_grammar(const char *json_schema, char *grammar, size_t max_len);

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -140,6 +140,7 @@ type CompletionRequest struct {
 	Temperature      *float32       `json:"temperature"`
 	TopP             float32        `json:"top_p"`
 	Suffix           string         `json:"suffix"`
+	IgnoreEOS        bool           `json:"ignore_eos"`
 }
 
 type Completion struct {
@@ -645,6 +646,8 @@ func fromCompleteRequest(r CompletionRequest) (api.GenerateRequest, error) {
 	} else {
 		options["top_p"] = 1.0
 	}
+
+	options["ignore_eos"] = r.IgnoreEOS
 
 	return api.GenerateRequest{
 		Model:   r.Model,

--- a/runner/llamarunner/runner.go
+++ b/runner/llamarunner/runner.go
@@ -484,7 +484,7 @@ func (s *Server) processBatch(tokenBatch *llama.Batch, embedBatch *llama.Batch) 
 		seq.numPredicted++
 
 		// if it's an end of sequence token, break
-		if s.model.TokenIsEog(token) {
+		if s.model.TokenIsEog(token) && !seq.samplingCtx.IgnoreEOS() {
 			// TODO (jmorganca): we should send this back
 			// as it's important for the /api/generate context
 			// seq.responses <- piece
@@ -575,6 +575,7 @@ func (s *Server) completion(w http.ResponseWriter, r *http.Request) {
 		PenaltyPresent: req.Options.PresencePenalty,
 		Seed:           uint32(req.Options.Seed),
 		Grammar:        req.Grammar,
+		IgnoreEOS:      req.Options.IgnoreEOS,
 	}
 
 	seq, err := s.NewSequence(req.Prompt, req.Images, NewSequenceParams{


### PR DESCRIPTION
### Add support for the 'ignore eos' parameter, which can be used in conjunction with 'num_predict' to specify the number of output tokens of the model.

When using tools to conduct performance tests on Ollama's openai-compatible API, it is necessary to specify the size of the output token. However, in Ollama, the num predict parameter can only limit the upper bound of the number of tokens generated by the model. Therefore, the 'ignore eos' parameter is needed to enable the model to generate tokens infinitely to achieve the purpose of generating a specified number of tokens.