### PR TITLE
model: add frontend support for diffusion language models

### DIFF
--- a/llama/llama.go
+++ b/llama/llama.go
@@ -214,6 +214,16 @@ type ModelParams struct {
 	TensorSplit  []float32
 	Progress     func(float32)
 	VocabOnly    bool
+
+	// Diffusion parameters for diffusion models
+	DiffusionSteps         int32
+	DiffusionVisualMode    bool
+	DiffusionEps           float32
+	DiffusionBlockLength   int32
+	DiffusionAlgorithm     int32
+	DiffusionAlgTemp       float32
+	DiffusionCfgScale      float32
+	DiffusionAddGumbelNoise bool
 }
 
 //export llamaProgressCallback
@@ -397,6 +407,11 @@ func (b *Batch) Free() {
 
 type Model struct {
 	c *C.struct_llama_model
+}
+
+// IsDiffusion returns true if the model is a diffusion-based model
+func (m *Model) IsDiffusion() bool {
+	return bool(C.llama_model_is_diffusion(m.c))
 }
 
 func (m *Model) TokenToPiece(token int) string {

--- a/llm/server.go
+++ b/llm/server.go
@@ -192,6 +192,38 @@ func NewLlamaServer(gpus discover.GpuInfoList, modelPath string, f *ggml.GGML, a
 		loadRequest.ProjectorPath = projectors[0]
 	}
 
+	// Set diffusion parameters if they are provided
+	if opts.Diffusion != nil {
+		if opts.Diffusion.Steps != nil {
+			loadRequest.DiffusionSteps = *opts.Diffusion.Steps
+		} else {
+			loadRequest.DiffusionSteps = 128 // default value from llama.cpp
+		}
+		if opts.Diffusion.VisualMode != nil {
+			loadRequest.DiffusionVisualMode = *opts.Diffusion.VisualMode
+		}
+		if opts.Diffusion.Eps != nil {
+			loadRequest.DiffusionEps = *opts.Diffusion.Eps
+		}
+		if opts.Diffusion.BlockLength != nil {
+			loadRequest.DiffusionBlockLength = *opts.Diffusion.BlockLength
+		}
+		if opts.Diffusion.Algorithm != nil {
+			loadRequest.DiffusionAlgorithm = *opts.Diffusion.Algorithm
+		} else {
+			loadRequest.DiffusionAlgorithm = 4 // default value from llama.cpp
+		}
+		if opts.Diffusion.AlgTemp != nil {
+			loadRequest.DiffusionAlgTemp = *opts.Diffusion.AlgTemp
+		}
+		if opts.Diffusion.CfgScale != nil {
+			loadRequest.DiffusionCfgScale = *opts.Diffusion.CfgScale
+		}
+		if opts.Diffusion.AddGumbelNoise != nil {
+			loadRequest.DiffusionAddGumbelNoise = *opts.Diffusion.AddGumbelNoise
+		}
+	}
+
 	// This will disable flash attention unless all GPUs on the system support it, even if we end up selecting a subset
 	// that can handle it.
 	fa := envconfig.FlashAttention()
@@ -481,6 +513,16 @@ type LoadRequest struct {
 	NumThreads     int
 	GPULayers      ml.GPULayersList
 	MultiUserCache bool
+
+	// Diffusion parameters for diffusion models
+	DiffusionSteps         int32
+	DiffusionVisualMode    bool
+	DiffusionEps           float32
+	DiffusionBlockLength   int32
+	DiffusionAlgorithm     int32
+	DiffusionAlgTemp       float32
+	DiffusionCfgScale      float32
+	DiffusionAddGumbelNoise bool
 
 	// Legacy fields - not used with the Ollama engine
 	ProjectorPath string

--- a/runner/llamarunner/runner.go
+++ b/runner/llamarunner/runner.go
@@ -829,6 +829,16 @@ func (s *Server) load(w http.ResponseWriter, r *http.Request) {
 			},
 		}
 
+		// Add diffusion parameters to ModelParams
+		params.DiffusionSteps = req.DiffusionSteps
+		params.DiffusionVisualMode = req.DiffusionVisualMode
+		params.DiffusionEps = req.DiffusionEps
+		params.DiffusionBlockLength = req.DiffusionBlockLength
+		params.DiffusionAlgorithm = req.DiffusionAlgorithm
+		params.DiffusionAlgTemp = req.DiffusionAlgTemp
+		params.DiffusionCfgScale = req.DiffusionCfgScale
+		params.DiffusionAddGumbelNoise = req.DiffusionAddGumbelNoise
+
 		s.status = llm.ServerStatusLoadingModel
 		go s.loadModel(params, s.modelPath, req.LoraPath, req.ProjectorPath, req.KvSize, req.KvCacheType, req.FlashAttention, req.NumThreads, req.MultiUserCache)
 

--- a/types/model/capability.go
+++ b/types/model/capability.go
@@ -9,6 +9,7 @@ const (
 	CapabilityVision     = Capability("vision")
 	CapabilityEmbedding  = Capability("embedding")
 	CapabilityThinking   = Capability("thinking")
+	CapabilityDiffusion  = Capability("diffusion")
 )
 
 func (c Capability) String() string {


### PR DESCRIPTION
  This PR adds comprehensive frontend support for diffusion language models (such as Dream-Coder and LLaDA) to
  Ollama, enabling users to interact with these models through the existing API while providing
  diffusion-specific parameters and capabilities.

  Key Changes

  • New API Types: Added DiffusionOptions struct with support for diffusion-specific parameters including steps,
   visual mode, epsilon, block length, algorithm type, temperature, CFG scale, and Gumbel noise
  • Parameter Handling: Extended Options.FromMap() and FormatParams() to parse and validate diffusion parameters
   from API requests• Model Capability Detection: Added CapabilityDiffusion and automatic detection of diffusion
   models based on architecture (dream/llada)
  • Backend Integration: Propagated diffusion parameters through the entire inference pipeline from API → server
   → runner → llama.cpp
  • API Validation: Added proper error handling for diffusion models - they support /api/generate but not
  /api/chat
  • Native Bindings: Added IsDiffusion() method to detect diffusion models at the llama.cpp level

  Technical Details

  - Diffusion parameters are passed as a nested diffusion object in the API request options
  - Parameters include defaults (steps: 128, algorithm: 4) matching llama.cpp expectations
  - Chat endpoint explicitly rejects diffusion models with helpful error messages
  - All parameter parsing includes proper type validation and error handling
  - Integration follows existing patterns for model capabilities and parameter propagation

  Test Plan

  - Verify diffusion model detection works correctly for Dream/LLaDA architectures
  - Test parameter validation for all diffusion options (int32, float32, bool types)
  - Confirm chat endpoint properly rejects diffusion models
  - Validate generate endpoint accepts diffusion models with proper parameters
  - Test parameter defaults are applied when not specified