### PR TITLE
fix(cli): Capitalize 'Ollama' in serve command help description (#10165)

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1521,7 +1521,7 @@ func NewCLI() *cobra.Command {
 	serveCmd := &cobra.Command{
 		Use:     "serve",
 		Aliases: []string{"start"},
-		Short:   "Start ollama",
+		Short:   "Start Ollama",
 		Args:    cobra.ExactArgs(0),
 		RunE:    RunServer,
 	}


### PR DESCRIPTION
Title:
        fix(cli): Capitalize 'Ollama' in serve command help description
Description:
         This PR fixes issue #10165 by updating the CLI help text to capitalize Ollama consistently, except when referring to the ollama CLI command itself.


