### PR TITLE
exclude warning for home Applications dir

### DIFF
--- a/macapp/src/index.ts
+++ b/macapp/src/index.ts
@@ -219,7 +219,7 @@ function init() {
 
   if (process.platform === 'darwin') {
     if (app.isPackaged) {
-      if (!app.isInApplicationsFolder()) {
+      if (!app.isInApplicationsFolder() && !app.getAppPath().includes(path.join(app.getPath('home'), 'Applications'))) {
         const chosen = dialog.showMessageBoxSync({
           type: 'question',
           buttons: ['Move to Applications', 'Do Not Move'],


### PR DESCRIPTION
When checking if the MacOS package is in the applications directory we
are not considering if they are in the user home directory. This is a
valid location for a MacOS application and critical when directories
like `/Applications` is governed by system policies.