### PR TITLE
Fixe bug tha image cannot be seen when slice image

### DIFF
--- a/llama/llama.go
+++ b/llama/llama.go
@@ -539,7 +539,6 @@ func (c *MtmdContext) NewEmbed(llamaContext *Context, data []byte) ([][]float32,
 		copy(rows, s)
 		for i := range numTokens {
 			chunkEmbed[i] = rows[i*numEmbed : (i+1)*numEmbed]
-			// slog.Debug("image embe
 		}
 		embed = append(embed, chunkEmbed...)
 	}

--- a/llama/llama.go
+++ b/llama/llama.go
@@ -519,7 +519,7 @@ func (c *MtmdContext) NewEmbed(llamaContext *Context, data []byte) ([][]float32,
 	for i := range int(nChunks) {
 		chunk := C.mtmd_input_chunks_get(ic, C.size_t(i))
 		numTokens := int(C.mtmd_input_chunk_get_n_tokens(chunk))
-		lastChunkSize = numTokens
+		lastChunkSize = max(lastChunkSize, numTokens)
 
 		// Encode the chunk
 		if C.int32_t(0) != C.mtmd_encode_chunk(c.c, chunk) {


### PR DESCRIPTION
Fixe bug tha image cannot be seen when slice image.

I discovered a bug in Ollama's recent engine update, llama.cpp, causing all models requiring a slice schema to not display images.
I investigated and discovered that the API used by Ollama in llama.cpp differs from how llama.cpp defines it. As a result, the value of numTokens isn't always the length of the sliced ​​image embed, but rather the end length of the schema. This causes the image embed to not be correctly included during all slice processing.