### PR TITLE
parser: don't check the file type of safetensors to prevent false negatives.

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -255,6 +255,7 @@ func filesForModel(path string) ([]string, error) {
 	}
 
 	var files []string
+	// some safetensors files do not properly match "application/octet-stream", so skip checking their contentType
 	if st, _ := glob(filepath.Join(path, "*.safetensors"), ""); len(st) > 0 {
 		// safetensors files might be unresolved git lfs references; skip if they are
 		// covers model-x-of-y.safetensors, model.fp32-x-of-y.safetensors, model.safetensors

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -246,7 +246,7 @@ func filesForModel(path string) ([]string, error) {
 		for _, match := range matches {
 			if ct, err := detectContentType(match); err != nil {
 				return nil, err
-			} else if ct != contentType {
+			} else if len(contentType) > 0 && ct != contentType {
 				return nil, fmt.Errorf("invalid content type: expected %s for %s", ct, match)
 			}
 		}
@@ -255,7 +255,7 @@ func filesForModel(path string) ([]string, error) {
 	}
 
 	var files []string
-	if st, _ := glob(filepath.Join(path, "*.safetensors"), "application/octet-stream"); len(st) > 0 {
+	if st, _ := glob(filepath.Join(path, "*.safetensors"), ""); len(st) > 0 {
 		// safetensors files might be unresolved git lfs references; skip if they are
 		// covers model-x-of-y.safetensors, model.fp32-x-of-y.safetensors, model.safetensors
 		files = append(files, st...)


### PR DESCRIPTION
The server tries to verify that the safetensor files are `application/octet-stream` by using `http.DetectContentType()` to determine the type of the contents of the file.  The safetensor [format](https://huggingface.co/docs/safetensors/en/index#format) is pretty simple, with the first 8 bytes being the length of the following header.  Unfortunately  the length of the header in model-00001-of-00050.safetensors is 256 bytes, or `00 01 00 00 00 00 00 00`, and this [matches](https://cs.opensource.google/go/go/+/refs/tags/go1.25.1:src/net/http/sniff.go;l=174) the [pattern](https://mimesniff.spec.whatwg.org/#matching-a-font-type-pattern:~:text=Embedded%20OpenType%20signature.-,00%2001%2000%2000,-FF%20FF%20FF) for `font/ttf`.  So the server is skipping the safetensor files because at least one of them looks like a font file.

Modify the test to skip checking the filetype for safetensors; keep the glob matching and prefix loading to verify the files are readable.

Fixes: #11897