### PR TITLE
Hybrid and recurrent memory estimates

### DIFF
--- a/llm/memory.go
+++ b/llm/memory.go
@@ -209,8 +209,6 @@ func estimateGPULayers(gpus []discover.GpuInfo, f *ggml.GGML, projectors []strin
 
 	kv, graphPartialOffload, graphFullOffload := f.GraphSize(uint64(opts.NumCtx), uint64(min(opts.NumCtx, opts.NumBatch)), numParallel, kvct, useFlashAttention)
 
-	slog.Debug("ggml graph size", "kv", kv, "graphPartialOffload", graphPartialOffload, "graphFullOffload", graphFullOffload)
-
 	if len(kv) > 0 {
 		layerSize += kv[0]
 	}


### PR DESCRIPTION
## Description

This PR updates the memory size estimate logic to better handle recurrent and hybrid-recurrent models which are currently being badly overestimated because the default logic assumes full attention for all layers.

The logic for the sizing of the recurrent layers comes from [the `llama.cpp` implementation](https://github.com/ggml-org/llama.cpp/blob/master/src/llama-memory-recurrent.cpp#L87)

```c++
        ggml_tensor * r = ggml_new_tensor_1d(ctx, type_r, hparams.n_embd_r()*mem_size);
        ggml_tensor * s = ggml_new_tensor_1d(ctx, type_s, hparams.n_embd_s()*mem_size);
```

## Testing

**Before**

```sh
ollama run gabegoodhart/granite4-preview:tiny
# NAME                                  ID              SIZE      PROCESSOR    CONTEXT    UNTIL               
# gabegoodhart/granite4-preview:tiny    2ea87d60356a    8.8 GB    100% GPU     16384      4 minutes from now

>>> /set parameter num_ctx 131072
# NAME                                  ID              SIZE     PROCESSOR    CONTEXT    UNTIL              
# gabegoodhart/granite4-preview:tiny    2ea87d60356a    37 GB    100% GPU     131072     4 minutes from now
```

**After**

```sh
ollama run gabegoodhart/granite4-preview:tiny
# NAME                                  ID              SIZE      PROCESSOR    CONTEXT    UNTIL              
# gabegoodhart/granite4-preview:tiny    2ea87d60356a    4.9 GB    100% GPU     4096       4 minutes from now

>>> /set parameter num_ctx 131072
# NAME                                  ID              SIZE     PROCESSOR    CONTEXT    UNTIL     
# gabegoodhart/granite4-preview:tiny    2ea87d60356a    8.0 GB    100% GPU     131072     4 minutes from now

>>> /set parameter num_ctx 524288
# NAME                                  ID              SIZE     PROCESSOR    CONTEXT    UNTIL     
# gabegoodhart/granite4-preview:tiny    2ea87d60356a    17 GB    100% GPU     524288     4 minutes from now
```