### PR TITLE
Add AMD RX 9000-series to supported GPU documentation

### DIFF
--- a/docs/gpu.md
+++ b/docs/gpu.md
@@ -53,7 +53,7 @@ Ollama supports the following AMD GPUs:
 ### Linux Support
 | Family         | Cards and accelerators                                                                                                               |
 | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| AMD Radeon RX  | `7900 XTX` `7900 XT` `7900 GRE` `7800 XT` `7700 XT` `7600 XT` `7600` `6950 XT` `6900 XTX` `6900XT` `6800 XT` `6800` `Vega 64` `Vega 56`    |
+| AMD Radeon RX  | `9070 XT`, `9070 GRE`, `9070`, `9060 XT`, `7900 XTX` `7900 XT` `7900 GRE` `7800 XT` `7700 XT` `7600 XT` `7600` `6950 XT` `6900 XTX` `6900XT` `6800 XT` `6800` `Vega 64` `Vega 56`    |
 | AMD Radeon PRO | `W7900` `W7800` `W7700` `W7600` `W7500` `W6900X` `W6800X Duo` `W6800X` `W6800` `V620` `V420` `V340` `V320` `Vega II Duo` `Vega II` `VII` `SSG` |
 | AMD Instinct   | `MI300X` `MI300A` `MI300` `MI250X` `MI250` `MI210` `MI200` `MI100` `MI60` `MI50`                                                               |
 


### PR DESCRIPTION
Per https://github.com/ollama/ollama/issues/9812#issuecomment-3040194955 and https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html#supported-gpus these cards are currently supported on linux.

I'm a little less clear about windows support, I think it's coming soon but not there yet, so I didn't edit that section.

I also omitted the RX 9060 non-XT because it doesn't seem to exist yet.