### PR TITLE
cuda: require driver 550 or newer for compression

### DIFF
--- a/discover/gpu.go
+++ b/discover/gpu.go
@@ -284,6 +284,11 @@ func GetGPUInfo() GpuInfoList {
 				gpuInfo.MinimumMemory = cudaMinimumMemory
 				gpuInfo.DriverMajor = driverMajor
 				gpuInfo.DriverMinor = driverMinor
+				// Compression requires driver 12.4 or newer
+				if gpuInfo.DriverMajor == 12 && gpuInfo.DriverMinor < 4 {
+					slog.Error("CUDA devices require driver 550 or newer (v12.4)", "driver", fmt.Sprintf("%d.%d", gpuInfo.DriverMajor, gpuInfo.DriverMinor))
+					continue
+				}
 				variant := cudaVariant(gpuInfo)
 
 				// Start with our bundled libraries

--- a/docs/gpu.md
+++ b/docs/gpu.md
@@ -1,6 +1,6 @@
 # GPU
 ## Nvidia
-Ollama supports Nvidia GPUs with compute capability 5.0+ and driver version 531 and newer.
+Ollama supports Nvidia GPUs with compute capability 5.0+ and driver version 550 and newer.
 
 Check your compute compatibility to see if your card is supported:
 [https://developer.nvidia.com/cuda-gpus](https://developer.nvidia.com/cuda-gpus)


### PR DESCRIPTION
Our minimum before was 531 (Feb 23) and this new min came out in Feb 24.

Without this changes, older drivers fail at runtime with errors like:
```
CUDA error: device kernel image is invalid
  current device: 0, in function ggml_cuda_mul_mat_q at //ml/backend/ggml/ggml/src/ggml-cuda/mmq.cu:129
  cudaGetLastError()
//ml/backend/ggml/ggml/src/ggml-cuda/ggml-cuda.cu:84: CUDA error
```