### PR TITLE
install: break up windows and linux bundles

### DIFF
--- a/docs/linux.md
+++ b/docs/linux.md
@@ -13,13 +13,40 @@ curl -fsSL https://ollama.com/install.sh | sh
 > [!NOTE]
 > If you are upgrading from a prior version, you **MUST** remove the old libraries with `sudo rm -rf /usr/lib/ollama` first.
 
-Download and extract the package:
+Download and extract the base CPU package:
 
 ```shell
-curl -LO https://ollama.com/download/ollama-linux-amd64.tgz
+curl -LO https://ollama.com/download/ollama-linux-amd64-cpu.tgz
 sudo rm -rf /usr/lib/ollama
-sudo tar -C /usr -xzf ollama-linux-amd64.tgz
+sudo tar -C /usr -xzf ollama-linux-amd64-cpu.tgz
 ```
+
+If you have a GPU, install the bundle(s) applicable to your system
+
+> [!IMPORTANT]
+> The GPU bundles contains only GPU specific libraries.  You must extract **both** `ollama-linux-amd64-cpu.tgz` and the `ollama-linux-amd64-GPULIB.tgz` bundles into the same location.
+
+
+### NVIDIA v13 (driver 580 or newer)
+Compute Capability 7.5 or newer (e.g. RTX 2080 or newer)
+```shell
+curl -LO https://ollama.com/download/ollama-linux-amd64-cuda-v13.tgz
+sudo tar -C /usr -xzf ollama-linux-amd64-cuda-v13.tgz
+```
+
+### NVIDIA v12 (driver 575 or older)
+Compute Capability 5.0 or newer (e.g. GTX 750 or newer)
+```shell
+curl -LO https://ollama.com/download/ollama-linux-amd64-cuda-v12.tgz
+sudo tar -C /usr -xzf ollama-linux-amd64-cuda-v12.tgz
+```
+
+### AMD GPUs
+```shell
+curl -LO https://ollama.com/download/ollama-linux-amd64-rocm.tgz
+sudo tar -C /usr -xzf ollama-linux-amd64-rocm.tgz
+```
+
 
 Start Ollama:
 
@@ -33,27 +60,46 @@ In another terminal, verify that Ollama is running:
 ollama -v
 ```
 
-### AMD GPU install
-
-If you have an AMD GPU, **also** download and extract the additional ROCm package:
-
-> [!IMPORTANT]
-> The ROCm tgz contains only AMD dependent libraries.  You must extract **both** `ollama-linux-amd64.tgz` and `ollama-linux-amd64-rocm.tgz` into the same location.
-
-
-```shell
-curl -L https://ollama.com/download/ollama-linux-amd64-rocm.tgz -o ollama-linux-amd64-rocm.tgz
-sudo tar -C /usr -xzf ollama-linux-amd64-rocm.tgz
-```
 
 ### ARM64 install
 
 Download and extract the ARM64-specific package:
 
 ```shell
-curl -L https://ollama.com/download/ollama-linux-arm64.tgz -o ollama-linux-arm64.tgz
-sudo tar -C /usr -xzf ollama-linux-arm64.tgz
+curl -LO https://ollama.com/download/ollama-linux-arm64-cpu.tgz
+sudo rm -rf /usr/lib/ollama
+sudo tar -C /usr -xzf ollama-linux-arm64-cpu.tgz
 ```
+
+If you have a GPU, install the bundle(s) applicable to your system
+
+> [!IMPORTANT]
+> The GPU bundles contains only GPU specific libraries.  You must extract **both** `ollama-linux-arm64-cpu.tgz` and the `ollama-linux-arm64-GPULIB.tgz` bundles into the same location.
+
+### NVIDIA v13 (driver 580 or newer)
+```shell
+curl -LO https://ollama.com/download/ollama-linux-arm64-cuda-v13.tgz
+sudo tar -C /usr -xzf ollama-linux-arm64-cuda-v13.tgz
+```
+
+### NVIDIA v12 (driver 575 or older)
+```shell
+curl -LO https://ollama.com/download/ollama-linux-arm64-cuda-v12.tgz
+sudo tar -C /usr -xzf ollama-linux-arm64-cuda-v12.tgz
+```
+
+### NVIDIA JetPack 6
+```shell
+curl -LO https://ollama.com/download/ollama-linux-arm64-jetpack6.tgz
+sudo tar -C /usr -xzf ollama-linux-arm64-jetpack6.tgz
+```
+
+### NVIDIA JetPack 5
+```shell
+curl -LO https://ollama.com/download/ollama-linux-arm64-jetpack5.tgz
+sudo tar -C /usr -xzf ollama-linux-arm64-jetpack5.tgz
+```
+
 
 ### Adding Ollama as a startup service (recommended)
 
@@ -143,12 +189,7 @@ Update Ollama by running the install script again:
 curl -fsSL https://ollama.com/install.sh | sh
 ```
 
-Or by re-downloading Ollama:
-
-```shell
-curl -L https://ollama.com/download/ollama-linux-amd64.tgz -o ollama-linux-amd64.tgz
-sudo tar -C /usr -xzf ollama-linux-amd64.tgz
-```
+Or by re-downloading the base CPU and any GPU bundles.  See (manual install)[#manual-install]
 
 ## Installing specific versions
 
@@ -157,7 +198,7 @@ Use `OLLAMA_VERSION` environment variable with the install script to install a s
 For example:
 
 ```shell
-curl -fsSL https://ollama.com/install.sh | OLLAMA_VERSION=0.5.7 sh
+curl -fsSL https://ollama.com/install.sh | OLLAMA_VERSION=0.11.12 sh
 ```
 
 ## Viewing logs

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -13,7 +13,7 @@ terminal application. As usual the Ollama [api](./api.md) will be served on
 ## System Requirements
 
 * Windows 10 22H2 or newer, Home or Pro
-* NVIDIA 452.39 or newer Drivers if you have an NVIDIA card
+* NVIDIA 531 or newer Drivers if you have an NVIDIA card
 * AMD Radeon Driver https://www.amd.com/en/support if you have a Radeon card
 
 Ollama uses unicode characters for progress indication, which may render as unknown squares in some older terminal fonts in Windows 10. If you see this, try changing your terminal font settings.
@@ -60,17 +60,47 @@ The Ollama Windows installer registers an Uninstaller application.  Under `Add o
 ## Standalone CLI
 
 The easiest way to install Ollama on Windows is to use the `OllamaSetup.exe`
-installer. It installs in your account without requiring Administrator rights.
-We update Ollama regularly to support the latest models, and this installer will
-help you keep up to date.
+installer which includes a Desktop GUI. It installs in your account without
+requiring Administrator rights. We update Ollama regularly to support the latest
+models, and this installer will help you keep up to date.
 
-If you'd like to install or integrate Ollama as a service, a standalone
-`ollama-windows-amd64.zip` zip file is available containing only the Ollama CLI
-and GPU library dependencies for Nvidia.  If you have an AMD GPU, also download
-and extract the additional ROCm package `ollama-windows-amd64-rocm.zip` into the
-same directory.  Both zip files are necessary for a complete AMD installation.
-This allows for embedding Ollama in existing applications, or running it as a
-system service via `ollama serve` with tools such as [NSSM](https://nssm.cc/). 
+If you would like to manually install the Ollama CLI, run Ollama as a system
+service via `ollama serve` with tools such as [NSSM](https://nssm.cc/), or embed
+Ollama in existing applications, we provide a set of standalone zip files. You
+must extract at least the base CPU zip file and optionally one or more GPU zip
+files into the same location.   
 
-> [!NOTE]  
-> If you are upgrading from a prior version, you should remove the old directories first.
+
+> [!NOTE]
+> If you are upgrading from a prior version, you **MUST** remove the old Ollama version first.
+
+Download and extract the base CPU package:
+
+```powershell
+$ProgressPreference="silent"
+$ollamaDir="c:\Program Files\Ollama"
+
+Invoke-WebRequest -Uri https://ollama.com/download/ollama-windows-amd64-cpu.zip -OutFile ollama-windows-amd64-cpu.zip
+Remove-Item -ErrorAction 0 -Recurse $ollamaDir
+Expand-Archive -Path ollama-windows-amd64-cpu.zip -DestinationPath $ollamaDir
+```
+
+### NVIDIA v13 (driver 580 or newer)
+Compute Capability 7.5 or newer (e.g. RTX 2080 or newer)
+```powershell
+Invoke-WebRequest -Uri https://ollama.com/download/ollama-windows-amd64-cuda-v13.zip -OutFile ollama-windows-amd64-cuda-v13.zip
+Expand-Archive -Path ollama-windows-amd64-cuda-v13.zip -DestinationPath $ollamaDir
+```
+
+### NVIDIA v12 (driver 575 or older)
+Compute Capability 5.0 or newer (e.g. GTX 750 or newer)
+```powershell
+Invoke-WebRequest -Uri https://ollama.com/download/ollama-windows-amd64-cuda-v12.zip -OutFile ollama-windows-amd64-cuda-v12.zip
+Expand-Archive -Path ollama-windows-amd64-cuda-v12.zip -DestinationPath $ollamaDir
+```
+
+### AMD GPUs
+```powershell
+Invoke-WebRequest -Uri https://ollama.com/download/ollama-windows-amd64-rocm.zip -OutFile ollama-windows-amd64-rocm.zip
+Expand-Archive -Path ollama-windows-amd64-rocm.zip -DestinationPath $ollamaDir
+```

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -40,16 +40,24 @@ fi
 # buildx behavior changes for single vs. multiplatform
 echo "Compressing linux tar bundles..."
 if echo $PLATFORM | grep "," > /dev/null ; then
-        tar c -C ./dist/linux_arm64 --exclude cuda_jetpack5 --exclude cuda_jetpack6 . | pigz -9vc >./dist/ollama-linux-arm64.tgz
+        tar c -C ./dist/linux_arm64 --exclude cuda_jetpack5 --exclude cuda_jetpack6 --exclude cuda_v12 --exclude cuda_v13 . | pigz -9vc >./dist/ollama-linux-arm64-cpu.tgz
         tar c -C ./dist/linux_arm64 ./lib/ollama/cuda_jetpack5  | pigz -9vc >./dist/ollama-linux-arm64-jetpack5.tgz
         tar c -C ./dist/linux_arm64 ./lib/ollama/cuda_jetpack6  | pigz -9vc >./dist/ollama-linux-arm64-jetpack6.tgz
-        tar c -C ./dist/linux_amd64 --exclude rocm . | pigz -9vc >./dist/ollama-linux-amd64.tgz
+        tar c -C ./dist/linux_arm64 ./lib/ollama/cuda_v12  | pigz -9vc >./dist/ollama-linux-arm64-cuda-v12.tgz
+        tar c -C ./dist/linux_arm64 ./lib/ollama/cuda_v13  | pigz -9vc >./dist/ollama-linux-arm64-cuda-v13.tgz
+        tar c -C ./dist/linux_amd64 --exclude rocm --exclude cuda_v12 --exclude cuda_v13 . | pigz -9vc >./dist/ollama-linux-amd64-cpu.tgz
         tar c -C ./dist/linux_amd64 ./lib/ollama/rocm  | pigz -9vc >./dist/ollama-linux-amd64-rocm.tgz
+        tar c -C ./dist/linux_amd64 ./lib/ollama/cuda_v12  | pigz -9vc >./dist/ollama-linux-amd64-cuda-v12.tgz
+        tar c -C ./dist/linux_amd64 ./lib/ollama/cuda_v13  | pigz -9vc >./dist/ollama-linux-amd64-cuda-v13.tgz
 elif echo $PLATFORM | grep "arm64" > /dev/null ; then
-        tar c -C ./dist/ --exclude cuda_jetpack5 --exclude cuda_jetpack6 bin lib | pigz -9vc >./dist/ollama-linux-arm64.tgz
+        tar c -C ./dist/ --exclude cuda_jetpack5 --exclude cuda_jetpack6 --exclude cuda_v12 --exclude cuda_v13 bin lib | pigz -9vc >./dist/ollama-linux-arm64-cpu.tgz
+        tar c -C ./dist/ ./lib/ollama/cuda_v12  | pigz -9vc >./dist/ollama-linux-arm64-cuda-v12.tgz
+        tar c -C ./dist/ ./lib/ollama/cuda_v13  | pigz -9vc >./dist/ollama-linux-arm64-cuda-v13.tgz
         tar c -C ./dist/ ./lib/ollama/cuda_jetpack5  | pigz -9vc >./dist/ollama-linux-arm64-jetpack5.tgz
         tar c -C ./dist/ ./lib/ollama/cuda_jetpack6  | pigz -9vc >./dist/ollama-linux-arm64-jetpack6.tgz
 elif echo $PLATFORM | grep "amd64" > /dev/null ; then
-        tar c -C ./dist/ --exclude rocm bin lib | pigz -9vc >./dist/ollama-linux-amd64.tgz
+        tar c -C ./dist/ --exclude rocm --exclude cuda_v12 --exclude cuda_v13 bin lib | pigz -9vc >./dist/ollama-linux-amd64-cpu.tgz
         tar c -C ./dist/ ./lib/ollama/rocm  | pigz -9vc >./dist/ollama-linux-amd64-rocm.tgz
+        tar c -C ./dist/ ./lib/ollama/cuda_v12  | pigz -9vc >./dist/ollama-linux-amd64-cuda-v12.tgz
+        tar c -C ./dist/ ./lib/ollama/cuda_v13  | pigz -9vc >./dist/ollama-linux-amd64-cuda-v13.tgz
 fi

--- a/scripts/build_windows.ps1
+++ b/scripts/build_windows.ps1
@@ -170,7 +170,7 @@ function buildROCm() {
                 -DCMAKE_CXX_COMPILER=clang++ `
                 -DCMAKE_C_FLAGS="-parallel-jobs=4 -Wno-ignored-attributes -Wno-deprecated-pragma" `
                 -DCMAKE_CXX_FLAGS="-parallel-jobs=4 -Wno-ignored-attributes -Wno-deprecated-pragma" `
-                --install-prefix $script:DIST_DIR
+                --install-prefix $script:DIST_DIR -DOLLAMA_RUNNER_DIR="rocm"
             if ($LASTEXITCODE -ne 0) { exit($LASTEXITCODE)}
             $env:HIPCXX=""
             $env:HIP_PLATFORM=""
@@ -266,27 +266,33 @@ function buildInstaller() {
 }
 
 function distZip() {
-    if (Test-Path -Path "${script:SRC_DIR}\dist\windows-amd64") {
-        if (Test-Path -Path "${script:SRC_DIR}\dist\windows-amd64\lib\ollama\rocm") {
-            write-host "Generating stand-alone distribution zip file ${script:SRC_DIR}\dist\ollama-windows-amd64-rocm.zip"
-            # Temporarily adjust paths so we can retain the same directory structure
-            Remove-Item -ea 0 -r "${script:SRC_DIR}\dist\windows-amd64-rocm"
-            mkdir -Force -path "${script:SRC_DIR}\dist\windows-amd64-rocm\lib\ollama"
-            Write-Output "Extract this ROCm zip file to the same location where you extracted ollama-windows-amd64.zip" > "${script:SRC_DIR}\dist\windows-amd64-rocm\README.txt"
-            Move-Item -path "${script:SRC_DIR}\dist\windows-amd64\lib\ollama\rocm" -destination "${script:SRC_DIR}\dist\windows-amd64-rocm\lib\ollama"
-            Compress-Archive -CompressionLevel Optimal -Path "${script:SRC_DIR}\dist\windows-amd64-rocm\*" -DestinationPath "${script:SRC_DIR}\dist\ollama-windows-amd64-rocm.zip" -Force
-        }
+    foreach ($arch in @('amd64', 'arm64')) {
+        if (Test-Path -Path "${script:SRC_DIR}\dist\windows-${arch}") {
+            # CPU bundle
+            $name = "cpu"
+            write-host "Creating ${arch} ${name} bundle"
+            $gpuDirs = @('rocm', 'cuda_v12', 'cuda_v13')
+            Remove-Item -ea 0 -r "${script:SRC_DIR}\dist\windows-${arch}-${name}"
+            Copy-Item -Recurse -path "${script:SRC_DIR}\dist\windows-${arch}" -destination "${script:SRC_DIR}\dist\windows-${arch}-${name}"
+            foreach ($dir in $gpuDirs) {
+                Remove-Item -ea 0 -r "${script:SRC_DIR}\dist\windows-${arch}-${name}\lib\ollama\${dir}"
+            }
+            Compress-Archive -CompressionLevel Optimal -Path "${script:SRC_DIR}\dist\windows-${arch}-${name}\*" -DestinationPath "${script:SRC_DIR}\dist\ollama-windows-${arch}-${name}.zip" -Force
+            Remove-Item -ea 0 -r "${script:SRC_DIR}\dist\windows-${arch}-${name}"
 
-        write-host "Generating stand-alone distribution zip file ${script:SRC_DIR}\dist\ollama-windows-amd64.zip"
-        Compress-Archive -CompressionLevel Optimal -Path "${script:SRC_DIR}\dist\windows-amd64\*" -DestinationPath "${script:SRC_DIR}\dist\ollama-windows-amd64.zip" -Force
-        if (Test-Path -Path "${script:SRC_DIR}\dist\windows-amd64-rocm") {
-            Move-Item -destination "${script:SRC_DIR}\dist\windows-amd64\lib\ollama\rocm" -path "${script:SRC_DIR}\dist\windows-amd64-rocm\lib\ollama\rocm"
+            # GPU bundles if present
+            foreach ($dir in $gpuDirs) {
+                $name = $dir -replace '_', '-'
+                if (Test-Path -Path "${script:SRC_DIR}\dist\windows-${arch}\lib\ollama\${dir}") {
+                    write-host "Creating ${arch} ${name} bundle"
+                    Remove-Item -ea 0 -r "${script:SRC_DIR}\dist\windows-${arch}-${name}"
+                    mkdir -Force -path "${script:SRC_DIR}\dist\windows-${arch}-${name}\lib\ollama"
+                    Copy-Item -Recurse -path "${script:SRC_DIR}\dist\windows-${arch}\lib\ollama\${dir}" -destination "${script:SRC_DIR}\dist\windows-${arch}-${name}\lib\ollama"
+                    Compress-Archive -CompressionLevel Optimal -Path "${script:SRC_DIR}\dist\windows-${arch}-${name}\*" -DestinationPath "${script:SRC_DIR}\dist\ollama-windows-${arch}-${name}.zip" -Force
+                    Remove-Item -ea 0 -r "${script:SRC_DIR}\dist\windows-${arch}-${name}"
+                }
+            }
         }
-    }
-
-    if (Test-Path -Path "${script:SRC_DIR}\dist\windows-arm64") {
-        write-host "Generating stand-alone distribution zip file ${script:SRC_DIR}\dist\ollama-windows-arm64.zip"
-        Compress-Archive -CompressionLevel Optimal -Path "${script:SRC_DIR}\dist\windows-arm64\*" -DestinationPath "${script:SRC_DIR}\dist\ollama-windows-arm64.zip" -Force
     }
 }
 


### PR DESCRIPTION
Fixes #12268

Marking draft until I run further tests.

With the addition of CUDA v13, our base Windows and Linux bundles have grown in size.  This change breaks down our binary artifacts into more pieces so the individual sizes are more manageable and provides the ability for users to download only what they need. Since the base bundle no longer contains any GPU libraries, I elected to rename it to make it more obvious the bundle lacked GPU content.  The result is users with CPU only systems have a much smaller bundle size.  Users with GPUs now can download only the parts they actually need.  

This does add complexity to the manual install flows, so I expanded the Windows and Linux docs to be more complete.

I have not modified the container images, but that might be something to consider.  If we do, perhaps the "latest" tag would map to a "full" image that has everything for simplicity, and then `-cpu`, `-cuda-v12`, `-cuda-v13`, and `-rocm` tags for stripped down images.

Before merging, the install script change should be split out into a separate PR to sequence with whatever release this lands in.

## Windows
- 14M ollama-windows-amd64-cpu.zip
- 1019M ollama-windows-amd64-cuda-v12.zip
- 618M ollama-windows-amd64-cuda-v13.zip
- 373M ollama-windows-amd64-rocm.zip

## Linux
- 13M ollama-linux-amd64-cpu.tgz
- 1.0G ollama-linux-amd64-cuda-v12.tgz
- 635M ollama-linux-amd64-cuda-v13.tgz
- 1.2G ollama-linux-amd64-rocm.tgz
- 11M ollama-linux-arm64-cpu.tgz
- 1.0G ollama-linux-arm64-cuda-v12.tgz
- 748M ollama-linux-arm64-cuda-v13.tgz
- 429M ollama-linux-arm64-jetpack5.tgz
- 343M ollama-linux-arm64-jetpack6.tgz