### PR TITLE
server: skip parsing initial <think> if provided in the prompt for /api/generate

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -348,6 +348,9 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 				OpeningTag: openingTag,
 				ClosingTag: closingTag,
 			}
+			if strings.HasSuffix(strings.TrimSpace(prompt), openingTag) {
+				thinkingState.AddContent(openingTag)
+			}
 		}
 	}
 


### PR DESCRIPTION
Same as for https://github.com/ollama/ollama/pull/12024 but for /api/generate.