### PR TITLE
build: avoid unbounded parallel builds

### DIFF
--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -16,6 +16,7 @@ OLLAMA_COMMON_BUILD_ARGS="--build-arg=VERSION \
     --build-arg=OLLAMA_FAST_BUILD \
     --build-arg=CUSTOM_CPU_FLAGS \
     --build-arg=GPU_RUNNER_CPU_FLAGS \
+    --build-arg=PARALLEL \
     --build-arg=AMDGPU_TARGETS"
 
 echo "Building Ollama"


### PR DESCRIPTION
With the addition of cuda v13, on a clean setup, the level of parallelism was causing docker desktop to become overwhelmed and compilers were crashing.  This limits to 8 parallel per build stage, with the ability to override if you have many more cores available.

Tested with:
- `PARALLEL=2 ./scripts/build_linux.sh`  -  low system load
- `PARALLEL=8 ./scripts/build_linux.sh`  -  same load as unspecified PARALLEL
- `PARALLEL=99 ./scripts/build_linux.sh`  -  Same behavior as before this PR - system thrashing, leading to crashed compiles