### PR TITLE
discover: fix ROCm 7.0 library detection error

### DIFF
--- a/discover/amd_linux.go
+++ b/discover/amd_linux.go
@@ -42,7 +42,7 @@ const (
 
 var (
 	// Used to validate if the given ROCm lib is usable
-	ROCmLibGlobs          = []string{"libhipblas.so.2*", "rocblas"} // TODO - probably include more coverage of files here...
+	ROCmLibGlobs          = []string{"libhipblas.so.*", "rocblas"} // TODO - probably include more coverage of files here...
 	RocmStandardLocations = []string{"/opt/rocm/lib", "/usr/lib64"}
 )
 


### PR DESCRIPTION
ROCm 7.0 has upgraded 'libhipblas.so' from '2' to '3'. Use the library
name with any version number.