### PR TITLE
fix(integration): check truncated length

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -634,7 +634,7 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 		ctxLen := min(opts.NumCtx, int(kvData.ContextLength()))
 		if len(tokens) > ctxLen {
 			if !truncate {
-				c.JSON(http.StatusBadRequest, gin.H{"error": "input length exceeds maximum context length"})
+				c.JSON(http.StatusBadRequest, gin.H{"error": "input exceeds maximum context length"})
 				return
 			}
 
@@ -644,6 +644,13 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 
 			if eos := kvData.Uint("tokenizer.ggml.eos_token_id"); tokens[len(tokens)-1] != int(eos) && kvData.Bool("add_eos_token", true) {
 				ctxLen--
+			}
+
+			slog.Info("", "ctxLen", ctxLen, "tokenCount", len(tokens))
+			if ctxLen <= 0 {
+				// return error if the truncated input would be empty or just special tokens
+				c.JSON(http.StatusBadRequest, gin.H{"error": "input after truncation exceeds maximum context length"})
+				return
 			}
 
 			tokens = tokens[:ctxLen]


### PR DESCRIPTION
the integration test truncates the input to 1 token which is problematic because the model adds bos and eos tokens so 1 token will leave only the bos token.

increase context to 3 tokens while also add an error when the input after truncation leaves an empty input or only special tokens