### PR TITLE
prefer ollama engine for qwen3moe

### DIFF
--- a/fs/ggml/ggml.go
+++ b/fs/ggml/ggml.go
@@ -244,6 +244,7 @@ func (kv KV) OllamaEngineRequired() bool {
 		"gemma3n",
 		"mistral3",
 		"qwen3",
+		"qwen3moe",
 		"llama4",
 		"mllama",
 		"qwen25vl",


### PR DESCRIPTION
this change enables qwen3moe so it runs on the ollama engine