### PR TITLE
refactor: using testing.B.Loop

### DIFF
--- a/model/bytepairencoding_test.go
+++ b/model/bytepairencoding_test.go
@@ -251,7 +251,7 @@ func BenchmarkBytePairEncoding(b *testing.B) {
 		bts := bts[:n]
 		b.Run("encode"+strconv.Itoa(n), func(b *testing.B) {
 			b.ResetTimer()
-			for range b.N {
+			for b.Loop() {
 				_, err := tokenizer.Encode(string(bts), true)
 				if err != nil {
 					b.Fatal(err)
@@ -266,7 +266,7 @@ func BenchmarkBytePairEncoding(b *testing.B) {
 			}
 
 			b.ResetTimer()
-			for range b.N {
+			for b.Loop() {
 				_, err := tokenizer.Decode(ids)
 				if err != nil {
 					b.Fatal(err)
@@ -276,7 +276,7 @@ func BenchmarkBytePairEncoding(b *testing.B) {
 
 		b.Run("split"+strconv.Itoa(n), func(b *testing.B) {
 			b.ResetTimer()
-			for range b.N {
+			for b.Loop() {
 				slices.Collect(tokenizer.split(string(bts)))
 			}
 		})


### PR DESCRIPTION
use b.Loop() to simplify the code and improve performance


before:

```shell
go test -run=^$ -bench=. ./model -timeout=1h             
goos: darwin
goarch: arm64
pkg: github.com/ollama/ollama/model
cpu: Apple M4
BenchmarkBytePairEncoding/encode1-10         	 2034903	       604.4 ns/op
BenchmarkBytePairEncoding/decode1-10         	22407132	        56.35 ns/op
BenchmarkBytePairEncoding/split1-10          	 2190558	       487.3 ns/op
BenchmarkBytePairEncoding/encode10-10        	  808230	      1478 ns/op
BenchmarkBytePairEncoding/decode10-10        	14217931	        85.32 ns/op
BenchmarkBytePairEncoding/split10-10         	  904519	      1296 ns/op
BenchmarkBytePairEncoding/encode100-10       	   80082	     15268 ns/op
BenchmarkBytePairEncoding/decode100-10       	 3367110	       353.2 ns/op
BenchmarkBytePairEncoding/split100-10        	  126951	      9483 ns/op
BenchmarkBytePairEncoding/encode1000-10      	    8446	    135918 ns/op
BenchmarkBytePairEncoding/decode1000-10      	  362342	      3012 ns/op
BenchmarkBytePairEncoding/split1000-10       	   13258	     90312 ns/op
BenchmarkBytePairEncoding/encode10000-10     	     892	   1377467 ns/op
BenchmarkBytePairEncoding/decode10000-10     	   39751	     27501 ns/op
BenchmarkBytePairEncoding/split10000-10      	    1444	    834748 ns/op
BenchmarkBytePairEncoding/encode100000-10    	      86	  12968816 ns/op
BenchmarkBytePairEncoding/decode100000-10    	    3208	    350494 ns/op
BenchmarkBytePairEncoding/split100000-10     	     141	   8554128 ns/op
BenchmarkBytePairEncoding/encode1000000-10   	       8	 136400802 ns/op
BenchmarkBytePairEncoding/decode1000000-10   	     318	   3855845 ns/op
BenchmarkBytePairEncoding/split1000000-10    	      12	  84651771 ns/op
BenchmarkBytePairEncoding/encode3202320-10   	       3	 437016222 ns/op
BenchmarkBytePairEncoding/decode3202320-10   	      90	  12046368 ns/op
BenchmarkBytePairEncoding/split3202320-10    	       4	 269510136 ns/op
PASS
ok  	github.com/ollama/ollama/model	38.540s

```

after:

```shell
go test -run=^$ -bench=. ./model -timeout=1h
goos: darwin
goarch: arm64
pkg: github.com/ollama/ollama/model
cpu: Apple M4
BenchmarkBytePairEncoding/encode1-10         	 2024184	       590.8 ns/op
BenchmarkBytePairEncoding/decode1-10         	22583328	        58.97 ns/op
BenchmarkBytePairEncoding/split1-10          	 2303569	       518.9 ns/op
BenchmarkBytePairEncoding/encode10-10        	  841950	      1474 ns/op
BenchmarkBytePairEncoding/decode10-10        	13812796	        84.28 ns/op
BenchmarkBytePairEncoding/split10-10         	  918715	      1345 ns/op
BenchmarkBytePairEncoding/encode100-10       	   77550	     14722 ns/op
BenchmarkBytePairEncoding/decode100-10       	 3577322	       329.9 ns/op
BenchmarkBytePairEncoding/split100-10        	  125736	      9480 ns/op
BenchmarkBytePairEncoding/encode1000-10      	    9220	    133805 ns/op
BenchmarkBytePairEncoding/decode1000-10      	  469340	      2507 ns/op
BenchmarkBytePairEncoding/split1000-10       	   13192	     91128 ns/op
BenchmarkBytePairEncoding/encode10000-10     	     892	   1308327 ns/op
BenchmarkBytePairEncoding/decode10000-10     	   40533	     29673 ns/op
BenchmarkBytePairEncoding/split10000-10      	    1460	    820587 ns/op
BenchmarkBytePairEncoding/encode100000-10    	      84	  12846453 ns/op
BenchmarkBytePairEncoding/decode100000-10    	    3222	    356956 ns/op
BenchmarkBytePairEncoding/split100000-10     	     144	   8591398 ns/op
BenchmarkBytePairEncoding/encode1000000-10   	       8	 132183818 ns/op
BenchmarkBytePairEncoding/decode1000000-10   	     315	   3747281 ns/op
BenchmarkBytePairEncoding/split1000000-10    	      13	  83538782 ns/op
BenchmarkBytePairEncoding/encode3202320-10   	       3	 423927208 ns/op
BenchmarkBytePairEncoding/decode3202320-10   	     100	  11806510 ns/op
BenchmarkBytePairEncoding/split3202320-10    	       4	 267830042 ns/op
PASS
ok  	github.com/ollama/ollama/model	29.521s
```