### PR TITLE
Add per-model parallel request configuration using OLLAMA_NUM_PARALLEL_RULES environment variable

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1741,6 +1741,7 @@ func NewCLI() *cobra.Command {
 				envVars["OLLAMA_MAX_QUEUE"],
 				envVars["OLLAMA_MODELS"],
 				envVars["OLLAMA_NUM_PARALLEL"],
+				envVars["OLLAMA_NUM_PARALLEL_RULES"],
 				envVars["OLLAMA_NOPRUNE"],
 				envVars["OLLAMA_ORIGINS"],
 				envVars["OLLAMA_SCHED_SPREAD"],

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -306,6 +306,11 @@ The following server settings may be used to adjust how Ollama handles concurren
 
 - `OLLAMA_MAX_LOADED_MODELS` - The maximum number of models that can be loaded concurrently provided they fit in available memory.  The default is 3 * the number of GPUs or 3 for CPU inference.
 - `OLLAMA_NUM_PARALLEL` - The maximum number of parallel requests each model will process at the same time.  The default is 1, and will handle 1 request per model at a time.
+- `OLLAMA_NUM_PARALLEL_RULES` - Per‑model parallel request limits defined via a YAML list. Example:
+  ```bash
+  export OLLAMA_NUM_PARALLEL_RULES='[{"pattern":"gemma.*","count":2},{"pattern":"qwen.*","count":3}]'
+  ```
+  These rules **override** the global `OLLAMA_NUM_PARALLEL` value for matching models; if no rule matches, the global `OLLAMA_NUM_PARALLEL` is used.
 - `OLLAMA_MAX_QUEUE` - The maximum number of requests Ollama will queue when busy before rejecting additional requests. The default is 512
 
 Note: Windows with Radeon GPUs currently default to 1 model maximum due to limitations in ROCm v5.7 for available VRAM reporting.  Once ROCm v6.2 is available, Windows Radeon will follow the defaults above.  You may enable concurrent model loads on Radeon on Windows, but ensure you don't load more models than will fit into your GPUs VRAM.

--- a/envconfig/parallel_rules_test.go
+++ b/envconfig/parallel_rules_test.go
@@ -1,0 +1,77 @@
+package envconfig
+
+import (
+	"testing"
+)
+
+func TestParallelRulesOrder(t *testing.T) {
+	// Valid YAML with ordered rules.
+	yamlValid := `
+- pattern: "gemma.*"
+  count: 3
+- pattern: "gemma3:.*"
+  count: 2
+`
+
+	NumParallelForModel.Set(yamlValid)
+	parallel := NumParallelForModel.Get("gemma3:1b")
+	if parallel != 3 {
+		t.Fatalf("expected first rule to apply (value 3), got %d", parallel)
+	}
+
+	// Test reading a model not present in the rules – should fall back to the global NumParallel.
+	if fallback := NumParallelForModel.Get("unknownmodel"); fallback != NumParallel() {
+		t.Fatalf("expected fallback to global NumParallel for unknown model, got %d", fallback)
+	}
+
+	// Invalid YAML should fall back to global NumParallel (default 1).
+	yamlInvalid := `invalid yaml`
+
+	NumParallelForModel.Set(yamlInvalid)
+	parallel = NumParallelForModel.Get("anymodel")
+	if parallel != NumParallel() {
+		t.Fatalf("expected fallback to global NumParallel, got %d", parallel)
+	}
+}
+
+func TestInvalidRegexpAndEmptyRules(t *testing.T) {
+	// --- Invalid regular expression ---
+	invalidYAML := `
+- pattern: "*invalid["
+  count: 5
+`
+	NumParallelForModel.Set(invalidYAML)
+
+	// Should fall back to the global value because the rule is invalid.
+	if got := NumParallelForModel.Get("anymodel"); got != NumParallel() {
+		t.Fatalf("expected fallback to global NumParallel on invalid regexp, got %d", got)
+	}
+
+	// --- Empty OLLAMA_NUM_PARALLEL_RULES ---
+	NumParallelForModel.Set("")
+	if got := NumParallelForModel.Get("modelX"); got != NumParallel() {
+		t.Fatalf("expected fallback to global NumParallel when rules are empty, got %d", got)
+	}
+}
+
+func TestRawMethodValidYAML(t *testing.T) {
+	// Valid YAML should be stored and returned unchanged.
+	yamlValid := `
+- pattern: "gemma.*"
+  count: 3
+- pattern: "gemma3:.*"
+  count: 2
+`
+	NumParallelForModel.Set(yamlValid)
+	if got := NumParallelForModel.Raw(); got != yamlValid {
+		t.Fatalf("expected Raw() to return the original YAML, got %q", got)
+	}
+}
+
+func TestRawMethodInvalidYAML(t *testing.T) {
+	// Invalid YAML should result in Raw() returning "[]" (fallback value).
+	NumParallelForModel.Set(`invalid yaml`)
+	if got := NumParallelForModel.Raw(); got != "[]" {
+		t.Fatalf("expected Raw() to return fallback \"[]\" on parse error, got %q", got)
+	}
+}

--- a/server/sched.go
+++ b/server/sched.go
@@ -382,7 +382,7 @@ func (pending *LlmRequest) useLoadedRunner(runner *runnerRef, finished chan *Llm
 // load creates a new model based on req and loads it. If requireFull is true then the model must be loaded fully onto GPUs
 // (if any). Returns whether the scheduler needs to evict a model to make this one fit.
 func (s *Scheduler) load(req *LlmRequest, f *ggml.GGML, gpus discover.GpuInfoList, requireFull bool) bool {
-	numParallel := max(int(envconfig.NumParallel()), 1)
+	numParallel := max(int(envconfig.NumParallelForModel.Get(req.model.ShortName)), 1)
 
 	// Embedding models should always be loaded with parallel=1
 	if req.model.CheckCapabilities(model.CapabilityCompletion) != nil {


### PR DESCRIPTION
close: #4894 

This PR introduces per‑model parallel request configuration using the `OLLAMA_NUM_PARALLEL_RULES` environment variable.

## What’s new
- New environment variable `OLLAMA_NUM_PARALLEL_RULES` allowing YAML‑defined parallel limits per model.
- Extended documentation in `docs/faq.md` with usage examples.
- Added parsing logic in `envconfig/config.go` with validation and regex support.
- Added comprehensive tests in `envconfig/parallel_rules_test.go`.
- Adjusted scheduler to respect per‑model limits.

## Why
Provides fine‑grained control over request concurrency per model, improving resource utilization and allowing different parallelism settings for different models.


