### PR TITLE
fix: leaf alt name

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -187,15 +187,17 @@ func populateFields(base Base, v reflect.Value, tags ...Tag) reflect.Value {
 								names = append(names, prefix+n+suffix)
 							}
 						}
-
-						if childNames := fn(tags[1:], tags[0].prefix, tags[0].suffix); len(childNames) == 0 {
-							// no child names, append current names
-							fullNames = append(fullNames, names)
-						} else if len(names) == 0 {
-							// no current names, append child names
+						childNames := fn(tags[1:], tags[0].prefix, tags[0].suffix)
+						if len(names) == 0 {
+							// current tag has no name, use child names only
 							fullNames = append(fullNames, childNames...)
+						} else if len(childNames) == 0 {
+							// current tag has names but no children, create branches for each name
+							for _, name := range names {
+								fullNames = append(fullNames, []string{name})
+							}
 						} else {
-							// combine current and child names
+							// merge each name with each child
 							for _, name := range names {
 								for _, childName := range childNames {
 									fullNames = append(fullNames, append([]string{name}, childName...))

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -125,6 +125,7 @@ func TestPopulateFieldsAlternateName(t *testing.T) {
 		Input  *nn.Embedding `gguf:"input"`
 		Output *nn.Linear    `gguf:"output,alt:input"`
 		Nested *nested       `gguf:"nested"`
+		Tensor ml.Tensor     `gguf:"leaf,alt:tensor"`
 	}
 
 	var m fakeModel
@@ -133,6 +134,7 @@ func TestPopulateFieldsAlternateName(t *testing.T) {
 		names: []string{
 			"input.weight",
 			"nested.b.weight",
+			"leaf",
 		},
 	}}, v.Elem()))
 
@@ -142,6 +144,7 @@ func TestPopulateFieldsAlternateName(t *testing.T) {
 		Nested: &nested{
 			Weight: &nn.Linear{Weight: &fakeTensor{Name: "nested.b.weight"}},
 		},
+		Tensor: &fakeTensor{Name: "leaf"},
 	}, m); diff != "" {
 		t.Errorf("populateFields() set incorrect values (-want +got):\n%s", diff)
 	}


### PR DESCRIPTION
a leaf node with an alternative name gets all its alternatives names added into the same branch rather than creating branches themselves

this fixes the issue with gptoss where the attention sink tensor contains a leaf with an alternative name. this code incorrectly looks for `blk.%d.attn_sinks.attn_sinks.weight` rather than `blk.%d.attn_sinks` and `blk.%d.attn_sinks.weight`