### PR TITLE
docs: add Ollama App iOS to community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,6 +554,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [ConfiChat](https://github.com/1runeberg/confichat) (Lightweight, standalone, multi-platform, and privacy-focused LLM chat interface with optional encryption)
 - [Ollama Android Chat](https://github.com/sunshine0523/OllamaServer) (No need for Termux, start the Ollama service with one click on an Android device)
 - [Reins](https://github.com/ibrahimcetin/reins) (Easily tweak parameters, customize system prompts per chat, and enhance your AI experiments with reasoning model support.)
+- [Ollama App iOS](https://github.com/wang48/ollama-app-ios) (Ollama App for iOS)
 
 ### Extensions & Plugins
 


### PR DESCRIPTION
Hi there! We'd love it if you could add Ollama App iOS to the list of community integrations

Ollama App iOS is the iOS version of Ollama App, Modern and easy-to-use multi-platform client for Ollama

GitHub repository: https://github.com/wang48/ollama-app-ios

Related to this issue #12367 