### PR TITLE
harmony: don't sanitize built-ins

### DIFF
--- a/harmony/harmonyparser.go
+++ b/harmony/harmonyparser.go
@@ -463,6 +463,10 @@ func (h *HarmonyMessageHandler) HasThinkingSupport() bool {
 
 func (m *FunctionNameMap) ConvertAndAdd(userFunctionName string) string {
 	harmonyFunctionName := m.deriveName(userFunctionName)
+	// built-in functions should not be renamed
+	if userFunctionName == "browser.open" || userFunctionName == "browser.search" || userFunctionName == "browser.find" || userFunctionName == "python" {
+		harmonyFunctionName = userFunctionName
+	}
 	m.userToHarmony[userFunctionName] = harmonyFunctionName
 	m.harmonyToUser[harmonyFunctionName] = userFunctionName
 	return harmonyFunctionName

--- a/harmony/harmonyparser_test.go
+++ b/harmony/harmonyparser_test.go
@@ -513,6 +513,7 @@ func TestFunctionConvertAndAdd(t *testing.T) {
 		{name: "dupes from different user-specified names", in: []string{"get weather", "get_weather", "get-weather"}, want: []string{"get_weather", "get_weather_2", "get_weather_3"}},
 		{name: "non dupes after dupes", in: []string{"get weather", "get_weather", "get-weather", "something-different"}, want: []string{"get_weather", "get_weather_2", "get_weather_3", "something_different"}},
 		{name: "multiple sets of dupes", in: []string{"a", "a", "b", "a", "a", "b", "a"}, want: []string{"a", "a_2", "b", "a_3", "a_4", "b_2", "a_5"}},
+		{name: "built-in functions should not be renamed", in: []string{"browser.open", "python", "not.a.built-in.function", "browser.not_a_real_built_in"}, want: []string{"browser.open", "python", "not_a_built_in_function", "browser_not_a_real_built_in"}},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
In #11910 we started sanitizing function names, but we accidentally were modifying built-ins like `browser.open` to `browser_open`. This was removing the special prompt rendering for built-ins, but this wasn't immediately apparent since the models seem to be reasonably good at remembering the built-ins even when presented with these slightly renamed version. This fix prevents built-ins from ever being renamed.