### PR TITLE
feat: Handle the case where a tool call sends "arguments" or "parameters" as a serialized json string

### DIFF
--- a/tools/tools.go
+++ b/tools/tools.go
@@ -273,8 +273,20 @@ func findArguments(buffer []byte) (map[string]any, int) {
 						if args, ok := obj["arguments"].(map[string]any); ok {
 							return args, true
 						}
+						if argsStr, ok := obj["arguments"].(string); ok {
+							var argsData map[string]interface{}
+							if err := json.Unmarshal([]byte(argsStr), &argsData); err == nil {
+								return argsData, ok
+							}
+						}
 						if args, ok := obj["parameters"].(map[string]any); ok {
 							return args, true
+						}
+						if argsStr, ok := obj["parameters"].(string); ok {
+							var argsData map[string]interface{}
+							if err := json.Unmarshal([]byte(argsStr), &argsData); err == nil {
+								return argsData, ok
+							}
 						}
 						return nil, true
 					}

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -1274,6 +1274,22 @@ func TestFindArguments(t *testing.T) {
 				"items": []any{"{", "}", map[string]any{"key": "value"}},
 			},
 		},
+		{
+			name:   "stringified arguments",
+			buffer: []byte(`{"name": "get_temperature", "arguments": "{\"format\": \"fahrenheit\", \"location\": \"San Francisco, CA\"}"}`),
+			want: map[string]any{
+				"format":   "fahrenheit",
+				"location": "San Francisco, CA",
+			},
+		},
+		{
+			name:   "stringified parameters",
+			buffer: []byte(`{"name": "get_temperature", "parameters": "{\"format\": \"fahrenheit\", \"location\": \"San Francisco, CA\"}"}`),
+			want: map[string]any{
+				"format":   "fahrenheit",
+				"location": "San Francisco, CA",
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

Some models will return their tool calls with the arguments represented as a serialized json object (a string) rather than a nested object. This PR adds support for this case by attempting to parse a string under `"arguments"` or `"parameters"` as an object and using that as the arguments for the tool call.