### PR TITLE
scripts/install.sh: fail more gracefully when `curl` fails to downloa…

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -79,9 +79,13 @@ status "Installing ollama to $OLLAMA_INSTALL_DIR"
 $SUDO install -o0 -g0 -m755 -d $BINDIR
 $SUDO install -o0 -g0 -m755 -d "$OLLAMA_INSTALL_DIR/lib/ollama"
 status "Downloading Linux ${ARCH} bundle"
-curl --fail --show-error --location --progress-bar \
-    "https://ollama.com/download/ollama-linux-${ARCH}.tgz${VER_PARAM}" | \
-    $SUDO tar -xzf - -C "$OLLAMA_INSTALL_DIR"
+if ! curl --fail --show-error --location --progress-bar --output "ollama-linux-${ARCH}.tgz${VER_PARAM}" \
+    "https://ollama.com/download/ollama-linux-${ARCH}.tgz${VER_PARAM}"; then
+    error "Failed to download or extract Ollama"
+fi
+status "Unpacking Ollama"
+$SUDO tar -xzf "ollama-linux-${ARCH}.tgz${VER_PARAM}" -C "$OLLAMA_INSTALL_DIR"
+rm "ollama-linux-${ARCH}.tgz${VER_PARAM}"
 
 if [ "$OLLAMA_INSTALL_DIR/bin/ollama" != "$BINDIR/ollama" ] ; then
     status "Making ollama accessible in the PATH in $BINDIR"


### PR DESCRIPTION
…d ollama.

previously, `curl` would download the assets and pipe it directly into `tar`. while effective, the bourne shell does not have a `pipefail` option, so if `curl` fails to download for some reason, `tar` continues to try to unpack an incomplete tarball, resulting in this:

```text
+ status Downloading Linux arm64 bundle
+ echo >>> Downloading Linux arm64 bundle
>>> Downloading Linux arm64 bundle
+ curl --fail --show-error --location --progress-bar https://ollama.com/download/ollama-linux-arm64.tgz
+ sudo tar -xzf - -C /usr/local

gzip: stdin: unexpected end of file
tar: Unexpected EOF in archive
tar: Unexpected EOF in archive
tar: Error is not recoverable: exiting now
+ cleanup
+ rm -rf /tmp/tmp.gumWtEeeSU
```

the new behavior now fails more gracefully:

```text
+ status Downloading Linux arm64 bundle
+ echo >>> Downloading Linux arm64 bundle
>>> Downloading Linux arm64 bundle
+ curl --fail --show-error --location --progress-bar --output ollama-linux-arm64.tgz https://ollama.com/download/ollama-linux-arm64.tgz

+ error Failed to download or extract Ollama
+ echo ERROR: Failed to download or extract Ollama
ERROR: Failed to download or extract Ollama
+ exit 1
+ cleanup
+ rm -rf /tmp/tmp.X3whvVjiUc
```

assuming the intent was to not leave assets behind by piping direct into `tar`, this is a more POSIX-compliant way to handle the situation when a piped command fails.  it will remove the tarball after unpacking.