### PR TITLE
docs, scripts: Prevent useradd(8) from failing on Fedora Silverblue

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -209,7 +209,7 @@ Refer to the section [above](#how-do-i-configure-ollama-server) for how to set e
 ## Where are models stored?
 
 - macOS: `~/.ollama/models`
-- Linux: `/usr/share/ollama/.ollama/models`
+- Linux: `/var/lib/ollama/.ollama/models`
 - Windows: `C:\Users\%username%\.ollama\models`
 
 ### How do I set them to a different location?

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -60,7 +60,7 @@ sudo tar -C /usr -xzf ollama-linux-arm64.tgz
 Create a user and group for Ollama:
 
 ```shell
-sudo useradd -r -s /bin/false -U -m -d /usr/share/ollama ollama
+sudo useradd -r -s /bin/false -U -m -d /var/lib/ollama ollama
 sudo usermod -a -G ollama $(whoami)
 ```
 
@@ -187,7 +187,7 @@ sudo rm $(which ollama)
 Remove the downloaded models and Ollama service user and group:
 
 ```shell
-sudo rm -r /usr/share/ollama
+sudo rm -r /var/lib/ollama
 sudo userdel ollama
 sudo groupdel ollama
 ```

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -116,7 +116,7 @@ trap install_success EXIT
 configure_systemd() {
     if ! id ollama >/dev/null 2>&1; then
         status "Creating ollama user..."
-        $SUDO useradd -r -s /bin/false -U -m -d /usr/share/ollama ollama
+        $SUDO useradd -r -s /bin/false -U -m -d /var/lib/ollama ollama
     fi
     if getent group render >/dev/null 2>&1; then
         status "Adding ollama user to render group..."


### PR DESCRIPTION
On OSTree based operating systems like Fedora Siverblue [1], the `/usr/share` directory is part of the read-only `/usr` mount point.  This causes the `install.sh` script to fail when adding the `ollama` user with its home directory at `/usr/share/ollama`, because `useradd(8)` is unable to create the directory:
```
  $ curl -fsSL https://ollama.com/install.sh | sh
  >>> Installing ollama to /usr/local
  >>> Downloading Linux amd64 bundle
  ######################################################### 100.0%
  >>> Creating ollama user...
  useradd: cannot create directory /usr/share/ollama
  >>> The Ollama API is now available at 127.0.0.1:11434.
  >>> Install complete. Run "ollama" from the command line.
```
The `/var/lib` directory is an alternative for this, because `/var` is a read-write mount point.  eg., this is used by Geoclue [2] and the GNOME Display Manager [3] for their users' home directories on Linux distributions like Arch, Fedora and Ubuntu.

With this change the `install.sh` script is able to proceed further:
```
  $ sh scripts/install.sh
  >>> Installing ollama to /usr/local
  >>> Downloading Linux amd64 bundle
  ######################################################### 100.0%
  >>> Creating ollama user...
  >>> Adding ollama user to render group...
  >>> Adding ollama user to video group...
  >>> Adding current user to ollama group...
  >>> Creating ollama systemd service...
  >>> Enabling and starting ollama service...
  Created symlink
      '/etc/systemd/system/default.target.wants/ollama.service' →
      '/etc/systemd/system/ollama.service'.
  >>> The Ollama API is now available at 127.0.0.1:11434.
  >>> Install complete. Run "ollama" from the command line.
  WARNING: No NVIDIA/AMD GPU detected. Ollama will run in CPU-only mode.
```

The `install.sh` script is able to use `/usr/local` on Fedora Silverblue, because `/usr/local` is not considered part of the read-only OS image, and is a symbolic link to `/var/usrlocal` to make it read-write.

[1] https://fedoraproject.org/silverblue/

[2] https://gitlab.freedesktop.org/geoclue/geoclue/-/wikis/home

[3] https://wiki.gnome.org/Projects/GDM/