### PR TITLE
build: call find_package to instantiate library paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,7 @@ if(CMAKE_HIP_COMPILER)
     endif()
 
     if(AMDGPU_TARGETS)
+        find_package(hip REQUIRED)
         add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/ml/backend/ggml/ggml/src/ggml-hip)
 
         if (WIN32)


### PR DESCRIPTION
moving the earlier `find_package(hip REQUIRED)` into the branch means when using presets and defining `AMDGPU_TARGETS` directly will skip this configuration step which affects dependency resolution when installing the target