### PR TITLE
AMD: block running on unsupported gfx900/gfx906

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -163,6 +163,7 @@ jobs:
           cmake --preset "${{ matrix.preset }}" ${{ matrix.flags }} -DOLLAMA_RUNNER_DIR="${{ matrix.runner_dir }}"
           cmake --build --parallel --preset "${{ matrix.preset }}"
           cmake --install build --component "${{ startsWith(matrix.preset, 'CUDA ') && 'CUDA' || startsWith(matrix.preset, 'ROCm ') && 'HIP' || 'CPU' }}" --strip --parallel 8
+          rm -f dist\lib\ollama\rocm\rocblas\library\*gfx906*
         env:
           CMAKE_GENERATOR: Ninja
       - uses: actions/upload-artifact@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,7 @@ RUN --mount=type=cache,target=/root/.ccache \
     cmake --preset 'ROCm 6' -DOLLAMA_RUNNER_DIR="rocm" \
         && cmake --build --parallel ${PARALLEL} --preset 'ROCm 6' \
         && cmake --install build --component HIP --strip --parallel ${PARALLEL}
+RUN rm -f dist/lib/ollama/rocm/rocblas/library/*gfx90[06]*
 
 FROM --platform=linux/arm64 nvcr.io/nvidia/l4t-jetpack:${JETPACK5VERSION} AS jetpack-5
 ARG CMAKEVERSION

--- a/scripts/build_windows.ps1
+++ b/scripts/build_windows.ps1
@@ -179,6 +179,7 @@ function buildROCm() {
             if ($LASTEXITCODE -ne 0) { exit($LASTEXITCODE)}
             & cmake --install build --component "HIP" --strip
             if ($LASTEXITCODE -ne 0) { exit($LASTEXITCODE)}
+            rm -f $script:DIST_DIR\lib\ollama\rocm\rocblas\library\*gfx906*
         }
     }
 }


### PR DESCRIPTION
With the recent GGML bump, we no longer can support AMD gfx900/gfx906, however the engine discovery code currently requires rocblas to reject the GPU to correctly fall back to CPU.  This approach works.

With trace debugging enabled, running on a system with a dual setup consisting of gfx1030 and gfx906 it now correctly rejects the gfx906 instead of crashing during inference
```
ggml_cuda_init: initializing rocBLAS on device 0

rocBLAS error: Cannot read /home/daniel/tmp/lib/ollama/rocm/rocblas/library/TensileLibrary.dat: Illegal seek for GPU arch : gfx906
 List of available TensileLibrary Files :
...
time=2025-10-02T23:39:17.093Z level=TRACE source=runner.go:163 msg="removing unsupported or overlapping GPU combination" libDir=/home/daniel/tmp/lib/ollama/rocm description="AMD Radeon Graphics" compute=gfx906 pci_id=0d:00.0
...
time=2025-10-02T23:39:17.093Z level=INFO source=types.go:111 msg="inference compute" id=GPU-9abb57639fa80c50 library=ROCm compute=gfx1030 name=ROCm0 description="AMD Radeon Graphics" libdirs=ollama,rocm driver=60342.13 pci_id=06:00.0 type=discrete total="16.0 GiB" available="16.0 GiB"
```