### PR TITLE
templates: fix crash in improperly defined templates

### DIFF
--- a/server/images.go
+++ b/server/images.go
@@ -105,12 +105,16 @@ func (m *Model) Capabilities() []model.Capability {
 
 	builtinParser := parsers.ParserForName(m.Config.Parser)
 	// Check for tools capability
-	if slices.Contains(m.Template.Vars(), "tools") || (builtinParser != nil && builtinParser.HasToolSupport()) {
+	v, err := m.Template.Vars()
+	if err != nil {
+		slog.Warn("model template contains errors", "error", err)
+	}
+	if slices.Contains(v, "tools") || (builtinParser != nil && builtinParser.HasToolSupport()) {
 		capabilities = append(capabilities, model.CapabilityTools)
 	}
 
 	// Check for insert capability
-	if slices.Contains(m.Template.Vars(), "suffix") {
+	if slices.Contains(v, "suffix") {
 		capabilities = append(capabilities, model.CapabilityInsert)
 	}
 

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -192,7 +192,11 @@ func TestParse(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if diff := cmp.Diff(tmpl.Vars(), tt.vars); diff != "" {
+			v, err := tmpl.Vars()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(v, tt.vars); diff != "" {
 				t.Errorf("mismatch (-got +want):\n%s", diff)
 			}
 		})


### PR DESCRIPTION
It's possible to pass in an improperly defined template which causes the server to crash when a model is being created. This fix propagates an error back from `Identifiers()` which is caught and returns a Bad Request error back to the caller.