### PR TITLE
CI: workaround broken clang on windows temporarily

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -186,7 +186,8 @@ jobs:
         if: matrix.arch == 'amd64'
         run: |
           $ErrorActionPreference = "Stop"
-          Start-Process "C:\msys64\usr\bin\pacman.exe" -ArgumentList @("-S", "--noconfirm", "mingw-w64-clang-x86_64-gcc-compat", "mingw-w64-clang-x86_64-clang") -NoNewWindow -Wait
+          # TODO mingw-w64-clang-x86_64-clang v21 is currently broken for cgo build, but v20 + gcc-compat isn't available
+          # Start-Process "C:\msys64\usr\bin\pacman.exe" -ArgumentList @("-S", "--noconfirm", "mingw-w64-clang-x86_64-gcc-compat", "mingw-w64-clang-x86_64-clang") -NoNewWindow -Wait
           echo "C:\msys64\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           echo "C:\msys64\clang64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Install ARM64 system dependencies


### PR DESCRIPTION
It looks like mingw-w64-clang-x86_64-clang 21.1.1-1 is broken for CGO compiles on windows right now, but I haven't found a way to install v20 + gcc-compat which we need.  To unblock the build, we'll switch back to the default compiler (gcc) which likely breaks unicode handling on windows due to known bugs in the c++ library.  Assuming that's confirmed, we'll need a different fix for CI before we finalize 0.12.4.

CI from a few days ago worked fine with clang 20.1.8-2
