### PR TITLE
Workaround broken NVIDIA iGPU free VRAM data

### DIFF
--- a/discover/runner.go
+++ b/discover/runner.go
@@ -330,6 +330,9 @@ func GPUDevices(ctx context.Context, runners []FilteredRunnerDiscovery) []ml.Dev
 		}
 	}
 
+	// Apply any iGPU workarounds
+	iGPUWorkarounds(devices)
+
 	return devices
 }
 
@@ -537,6 +540,35 @@ func GetDevicesFromRunner(ctx context.Context, runner BaseRunner) ([]ml.DeviceIn
 				continue
 			}
 			return moreDevices, nil
+		}
+	}
+}
+
+func iGPUWorkarounds(devices []ml.DeviceInfo) {
+	// short circuit if we have no iGPUs
+	anyiGPU := false
+	for i := range devices {
+		if devices[i].Integrated {
+			anyiGPU = true
+			break
+		}
+	}
+	if !anyiGPU {
+		return
+	}
+
+	memInfo, err := GetCPUMem()
+	if err != nil {
+		slog.Debug("failed to fetch system memory information for iGPU", "error", err)
+		return
+	}
+	for i := range devices {
+		if !devices[i].Integrated {
+			continue
+		}
+		// NVIDIA iGPUs return useless free VRAM data which ignores system buff/cache
+		if devices[i].Library == "CUDA" {
+			devices[i].FreeMemory = memInfo.FreeMemory
 		}
 	}
 }


### PR DESCRIPTION
The CUDA APIs for reporting free VRAM are useless on NVIDIA iGPU systems as they only return the kernels actual free memory and ignore buff/cache allocations which on a typical system will quickly fill up most of the free system memory.  As a result, we incorrectly think there's very little available for GPU allocations which is wrong.

Without this change, on a "warm" system:
```
time=2025-10-03T16:52:19.742Z level=INFO source=types.go:111 msg="inference compute" id=GPU-190c986e-21ac-c241-342f-fc9235808ccd library=CUDA compute=12.1 name=CUDA0 description="NVIDIA GB10" libdirs=ollama,cuda_v13 driver=13.0 pci_id=01:00.f type=iGPU total="119.7 GiB" available="2.9 GiB"
```

With this change:
```
time=2025-10-03T18:23:24.889Z level=INFO source=types.go:111 msg="inference compute" id=GPU-190c986e-21ac-c241-342f-fc9235808ccd library=CUDA compute=12.1 name=CUDA0 description="NVIDIA GB10" libdirs=ollama,cuda_v13 driver=13.0 pci_id=01:00.f type=iGPU total="119.7 GiB" available="115.8 GiB"
```

For comparison:
```
% free -h
               total        used        free      shared  buff/cache   available
Mem:           119Gi       3.5Gi       4.6Gi       2.1Mi       112Gi       116Gi
Swap:             0B          0B          0B
```