### PR TITLE
Update Go version from 1.24.0 to 1.24.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ollama/ollama
 
-go 1.24.0
+go 1.24.6
 
 require (
 	github.com/containerd/console v1.0.3


### PR DESCRIPTION
Trivy scans were showing CVEs. Bumping version removes those issues and still maintains functionality.