### PR TITLE
server: continue to handle gin.H values until they are removed

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -555,6 +555,15 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 			case error:
 				c.JSON(http.StatusInternalServerError, gin.H{"error": t.Error()})
 				return
+			// TODO (jmorganca): remove use of gin.H here and instead expect
+			// api.StatusError to be send in the channel
+			case gin.H:
+				if msg, ok := t["error"].(string); ok {
+					c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
+					return
+				}
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "unexpected response"})
+				return
 			default:
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "unexpected response"})
 				return
@@ -2098,6 +2107,15 @@ func (s *Server) ChatHandler(c *gin.Context) {
 				return
 			case error:
 				c.JSON(http.StatusInternalServerError, gin.H{"error": t.Error()})
+				return
+			// TODO (jmorganca): remove use of gin.H here and instead expect
+			// api.StatusError to be send in the channel
+			case gin.H:
+				if msg, ok := t["error"].(string); ok {
+					c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
+					return
+				}
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "unexpected response"})
 				return
 			default:
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "unexpected response"})


### PR DESCRIPTION
Handlers will send `gin.H` values with the `"error"` key set into the streaming channels in ChatHandler and GenerateHandler. This change continues to honor these values until we replace them by actual `api.StatusError` values or similar.