### PR TITLE
thinking: allow `"think": false` for non-thinking models

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -332,13 +332,15 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 	}
 
 	modelCaps := m.Capabilities()
-	if req.Think != nil {
+	if slices.Contains(modelCaps, model.CapabilityThinking) {
 		caps = append(caps, model.CapabilityThinking)
-	} else {
-		// add thinking if the model supports it
-		if slices.Contains(modelCaps, model.CapabilityThinking) {
-			caps = append(caps, model.CapabilityThinking)
+		if req.Think == nil {
 			req.Think = &api.ThinkValue{Value: true}
+		}
+	} else {
+		if req.Think != nil && req.Think.Bool() {
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("%q does not support thinking", req.Model)})
+			return
 		}
 	}
 
@@ -1877,13 +1879,15 @@ func (s *Server) ChatHandler(c *gin.Context) {
 	}
 
 	modelCaps := m.Capabilities()
-	if req.Think != nil {
+	if slices.Contains(modelCaps, model.CapabilityThinking) {
 		caps = append(caps, model.CapabilityThinking)
-	} else {
-		// add thinking if the model supports it
-		if slices.Contains(modelCaps, model.CapabilityThinking) {
-			caps = append(caps, model.CapabilityThinking)
+		if req.Think == nil {
 			req.Think = &api.ThinkValue{Value: true}
+		}
+	} else {
+		if req.Think != nil && req.Think.Bool() {
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("%q does not support thinking", req.Model)})
+			return
 		}
 	}
 

--- a/server/routes_generate_test.go
+++ b/server/routes_generate_test.go
@@ -158,8 +158,23 @@ func TestGenerateChat(t *testing.T) {
 			t.Errorf("expected status 400, got %d", w.Code)
 		}
 
-		if diff := cmp.Diff(w.Body.String(), `{"error":"registry.ollama.ai/library/test:latest does not support thinking"}`); diff != "" {
+		if diff := cmp.Diff(w.Body.String(), `{"error":"\"test\" does not support thinking"}`); diff != "" {
 			t.Errorf("mismatch (-got +want):\n%s", diff)
+		}
+	})
+
+	t.Run("model can't think but think set false", func(t *testing.T) {
+		think := false
+		w := createRequest(t, s.ChatHandler, api.ChatRequest{
+			Model: "test",
+			Messages: []api.Message{
+				{Role: "user", Content: "Hello!"},
+			},
+			Think: &api.ThinkValue{Value: think},
+		})
+
+		if w.Code != http.StatusOK {
+			t.Errorf("expected status 200, got %d", w.Code)
 		}
 	})
 


### PR DESCRIPTION
This change moves back to allowing non-thinking models to call the `/api/chat` and `/api/generate` endpoints w/ `"think": false` set.