### PR TITLE
envconfig: default to port 443 when connecting to ollama.com

### DIFF
--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -24,6 +24,9 @@ func Host() *url.URL {
 	switch {
 	case !ok:
 		scheme, hostport = "http", s
+		if s == "ollama.com" {
+			scheme, hostport = "https", "ollama.com:443"
+		}
 	case scheme == "http":
 		defaultPort = "80"
 	case scheme == "https":

--- a/envconfig/config_test.go
+++ b/envconfig/config_test.go
@@ -37,6 +37,7 @@ func TestHost(t *testing.T) {
 		"https":               {"https://1.2.3.4", "https://1.2.3.4:443"},
 		"https port":          {"https://1.2.3.4:4321", "https://1.2.3.4:4321"},
 		"proxy path":          {"https://example.com/ollama", "https://example.com:443/ollama"},
+		"ollama.com":          {"ollama.com", "https://ollama.com:443"},
 	}
 
 	for name, tt := range cases {


### PR DESCRIPTION
This helps the case where a user sets `OLLAMA_HOST=ollama.com ollama run <model>`