### PR TITLE
Revert "Workaround broken NVIDIA iGPU free VRAM data (#12490)"

### DIFF
--- a/discover/runner.go
+++ b/discover/runner.go
@@ -349,9 +349,6 @@ func GPUDevices(ctx context.Context, runners []FilteredRunnerDiscovery) []ml.Dev
 		}
 	}
 
-	// Apply any iGPU workarounds
-	iGPUWorkarounds(devices)
-
 	return devices
 }
 
@@ -605,35 +602,6 @@ func GetDevicesFromRunner(ctx context.Context, runner BaseRunner) ([]ml.DeviceIn
 				continue
 			}
 			return moreDevices, nil
-		}
-	}
-}
-
-func iGPUWorkarounds(devices []ml.DeviceInfo) {
-	// short circuit if we have no iGPUs
-	anyiGPU := false
-	for i := range devices {
-		if devices[i].Integrated {
-			anyiGPU = true
-			break
-		}
-	}
-	if !anyiGPU {
-		return
-	}
-
-	memInfo, err := GetCPUMem()
-	if err != nil {
-		slog.Debug("failed to fetch system memory information for iGPU", "error", err)
-		return
-	}
-	for i := range devices {
-		if !devices[i].Integrated {
-			continue
-		}
-		// NVIDIA iGPUs return useless free VRAM data which ignores system buff/cache
-		if devices[i].Library == "CUDA" {
-			devices[i].FreeMemory = memInfo.FreeMemory
 		}
 	}
 }


### PR DESCRIPTION
The workaround has been moved into the underlying C++ code.

This reverts commit e4340667e33e0efa5dee471917d71ad6011e59ba.