### PR TITLE
rocm: fix prefiltering

### DIFF
--- a/discover/runner.go
+++ b/discover/runner.go
@@ -188,6 +188,9 @@ func GPUDevices(ctx context.Context, runners []FilteredRunnerDiscovery) []ml.Dev
 					// Replace the numeric ID with the post-filtered IDs
 					devices[i].FilteredID = devices[i].ID
 					devices[i].ID = strconv.Itoa(rocmID)
+				} else {
+					// The runner may have been pre-filtered, so it's FilteredIDs may be incorrect
+					devices[i].FilteredID = ""
 				}
 				rocmID++
 			}


### PR DESCRIPTION
If the user specifies a GPU filter via the visible devices env vars the filtered IDs returned by the runner are invalid and should be cleared to either favor the UUID or computed IDs in the higher level.