### PR TITLE
chore: simplify server tests

### DIFF
--- a/server/routes_debug_test.go
+++ b/server/routes_debug_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/discover"
 	"github.com/ollama/ollama/fs/ggml"
@@ -15,8 +14,6 @@ import (
 )
 
 func TestGenerateDebugRenderOnly(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-
 	mock := mockRunner{
 		CompletionResponse: llm.CompletionResponse{
 			Done:               true,
@@ -208,8 +205,6 @@ func TestGenerateDebugRenderOnly(t *testing.T) {
 }
 
 func TestChatDebugRenderOnly(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-
 	mock := mockRunner{
 		CompletionResponse: llm.CompletionResponse{
 			Done:               true,

--- a/server/routes_generate_renderer_test.go
+++ b/server/routes_generate_renderer_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/ollama/ollama/api"
@@ -20,8 +19,6 @@ import (
 // TestGenerateWithBuiltinRenderer tests that api/generate uses built-in renderers
 // when in chat-like flow (messages present, no suffix, no template)
 func TestGenerateWithBuiltinRenderer(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-
 	mock := mockRunner{
 		CompletionResponse: llm.CompletionResponse{
 			Done:               true,
@@ -204,8 +201,6 @@ func TestGenerateWithBuiltinRenderer(t *testing.T) {
 
 // TestGenerateWithDebugRenderOnly tests that debug_render_only works with built-in renderers
 func TestGenerateWithDebugRenderOnly(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-
 	mock := mockRunner{
 		CompletionResponse: llm.CompletionResponse{
 			Done:               true,

--- a/server/routes_generate_test.go
+++ b/server/routes_generate_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/ollama/ollama/api"
@@ -53,8 +52,6 @@ func newMockServer(mock *mockRunner) func(discover.GpuInfoList, string, *ggml.GG
 }
 
 func TestGenerateChat(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-
 	mock := mockRunner{
 		CompletionResponse: llm.CompletionResponse{
 			Done:               true,
@@ -664,8 +661,6 @@ func TestGenerateChat(t *testing.T) {
 }
 
 func TestGenerate(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-
 	mock := mockRunner{
 		CompletionResponse: llm.CompletionResponse{
 			Done:               true,
@@ -1087,8 +1082,6 @@ func TestGenerate(t *testing.T) {
 }
 
 func TestChatWithPromptEndingInThinkTag(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-
 	// Helper to create a standard thinking test setup
 	setupThinkingTest := func(t *testing.T) (*mockRunner, *Server) {
 		mock := &mockRunner{

--- a/server/routes_harmony_streaming_test.go
+++ b/server/routes_harmony_streaming_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/discover"
 	"github.com/ollama/ollama/fs/ggml"
@@ -100,8 +99,6 @@ func createHarmonyTestModel(t *testing.T) (string, string) {
 
 // TestChatHarmonyParserStreamingRealtime verifies that chunks are emitted as soon as they're available
 func TestChatHarmonyParserStreamingRealtime(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-
 	type step struct {
 		input         llm.CompletionResponse
 		wantContent   string
@@ -397,8 +394,6 @@ func TestChatHarmonyParserStreamingRealtime(t *testing.T) {
 
 // TestChatHarmonyParserStreamingSimple is a simpler test that just verifies basic streaming
 func TestChatHarmonyParserStreamingSimple(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-
 	mockResponses := []llm.CompletionResponse{
 		{Content: "<|message|>First ", Done: false},
 		{Content: "chunk ", Done: false},
@@ -509,8 +504,6 @@ func TestChatHarmonyParserStreamingSimple(t *testing.T) {
 }
 
 func TestChatHarmonyParserStreaming(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-
 	type expectedChunk struct {
 		afterResponse int    // Which mock response this chunk should appear after
 		content       string // Expected content in this chunk

--- a/server/routes_list_test.go
+++ b/server/routes_list_test.go
@@ -6,14 +6,10 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/gin-gonic/gin"
-
 	"github.com/ollama/ollama/api"
 )
 
 func TestList(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-
 	t.Setenv("OLLAMA_MODELS", t.TempDir())
 
 	expectNames := []string{

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -882,8 +882,6 @@ func TestFilterThinkTags(t *testing.T) {
 }
 
 func TestWaitForStream(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-
 	cases := []struct {
 		name       string
 		messages   []any

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -5,26 +5,18 @@ import (
 	"context"
 	"errors"
 	"log/slog"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/ollama/ollama/api"
-	"github.com/ollama/ollama/app/lifecycle"
 	"github.com/ollama/ollama/discover"
 	"github.com/ollama/ollama/format"
 	"github.com/ollama/ollama/fs/ggml"
 	"github.com/ollama/ollama/llm"
 	"github.com/ollama/ollama/ml"
 )
-
-func TestMain(m *testing.M) {
-	os.Setenv("OLLAMA_DEBUG", "1")
-	lifecycle.InitLogging()
-	os.Exit(m.Run())
-}
 
 func TestInitScheduler(t *testing.T) {
 	ctx, done := context.WithCancel(t.Context())

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,0 +1,13 @@
+package server
+
+import (
+	"os"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestMain(m *testing.M) {
+	gin.SetMode(gin.TestMode)
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
- set commonly used test options in `TestMain`
- simplify path matching using `filepath.FromSlash` so calls don't have to use `filepath.Join` everywhere