### PR TITLE
runner: always truncate embeddings requests

### DIFF
--- a/integration/embed_test.go
+++ b/integration/embed_test.go
@@ -258,6 +258,19 @@ func TestAllMiniLMEmbedTruncate(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "boundary truncation",
+			request: api.EmbedRequest{
+				Model:   "all-minilm",
+				Input:   "why is the sky blue? Why is the sky blue? hi there my",
+				Options: map[string]any{"num_ctx": 16},
+			},
+			check: func(res *api.EmbedResponse, err error) {
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
 	}
 
 	for _, req := range cases {

--- a/runner/llamarunner/runner.go
+++ b/runner/llamarunner/runner.go
@@ -697,7 +697,14 @@ func (s *Server) embeddings(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 
-	seq, err := s.NewSequence(req.Content, nil, NewSequenceParams{embedding: true})
+	seq, err := s.NewSequence(req.Content, nil, NewSequenceParams{
+		embedding: true,
+
+		// TODO (jmorganca): this should be provided by the server via the
+		// request options and truncated here in the runner, instead of relying on
+		// the server's truncate logic
+		truncate: true,
+	})
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Failed to create new sequence: %v", err), http.StatusInternalServerError)
 		return

--- a/runner/ollamarunner/runner.go
+++ b/runner/ollamarunner/runner.go
@@ -946,7 +946,14 @@ func (s *Server) embeddings(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	seq, err := s.NewSequence(req.Content, nil, NewSequenceParams{embedding: true})
+	seq, err := s.NewSequence(req.Content, nil, NewSequenceParams{
+		embedding: true,
+
+		// TODO (jmorganca): this should be provided by the server via the
+		// request options and truncated here in the runner, instead of relying on
+		// the server's truncate logic
+		truncate: true,
+	})
 	if err != nil {
 		http.Error(w, fmt.Sprintf("failed to create new sequence: %v", err), http.StatusInternalServerError)
 		return


### PR DESCRIPTION
Fixes https://github.com/ollama/ollama/issues/12710

Truncation currently happens in two places: in `routes.go` in the `server` package and also in the `runner` packages. However, the truncation logic isn't completely aligned, causing an error when truncation does occur. This change defaults the runner to always truncate (as it should have in https://github.com/ollama/ollama/pull/12582) until we remove truncation from the `server` package in order to only rely on truncation in the runner.