### PR TITLE
docs: add Agent Platforms & Orchestration category with AgentSystems

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,9 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Clueless](https://github.com/KashyapTan/clueless) (Open Source & Local Cluely: A desktop application LLM assistant to help you talk to anything on your screen using locally served Ollama models. Also undetectable to screenshare)
 - [ollama-co2](https://github.com/carbonatedWaterOrg/ollama-co2) (FastAPI web interface for monitoring and managing local and remote Ollama servers with real-time model monitoring and concurrent downloads)
 
+### Agent Platforms & Orchestration
+  - [AgentSystems](https://github.com/agentsystems/agentsystems) (Discover and run third-party AI agents using your local Ollama models - self-hosted containerized platform with a federated agent ecosystem)
+
 ### Cloud
 
 - [Google Cloud](https://cloud.google.com/run/docs/tutorials/gpu-gemma2-with-ollama)


### PR DESCRIPTION
Adding AgentSystems to the integrations list and proposing "Agent Platforms & Orchestration" as a new category to distinguish agent deployment platforms from chat interfaces.

  **What is AgentSystems:**
  A self-hosted platform that enables Ollama users to discover and run community-built AI agents using their own local models and compute resources.

  Key features:
  - Federated agent ecosystem (Git-based discovery, no gatekeepers)
  - Run third-party agents on local Ollama models (no cloud, no API fees)
  - Containerized deployment for running untrusted code
  - Multi-provider support (Ollama, OpenAI, Anthropic, Bedrock)
  - Self-hosted with full data privacy

  **Why a new category:**
  The existing "Web & Desktop" section primarily contains chat interfaces and UI wrappers. AgentSystems is infrastructure for deploying and orchestrating agents, which serves a different use case. This
  seemed worth distinguishing.

  Repo: https://github.com/agentsystems/agentsystems
  Docs: https://docs.agentsystems.ai

  (Full disclosure: I'm the author of AgentSystems and previously contributed to Ollama under this account)