### PR TITLE
docs: add Agent Platforms & Orchestration category with entry for AgentSystems

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,9 +430,6 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [ollama-co2](https://github.com/carbonatedWaterOrg/ollama-co2) (FastAPI web interface for monitoring and managing local and remote Ollama servers with real-time model monitoring and concurrent downloads)
 - [Hillnote](https://hillnote.com) (A Markdown-first workspace designed to supercharge your AI workflow. Create documents ready to integrate with Claude, ChatGPT, Gemini, Cursor, and more - all while keeping your work on your device.)
 
-### Agent Platforms & Orchestration
-  - [AgentSystems](https://github.com/agentsystems/agentsystems) (Discover and run third-party AI agents using your local Ollama models - self-hosted containerized platform with a federated agent ecosystem)
-
 ### Cloud
 
 - [Google Cloud](https://cloud.google.com/run/docs/tutorials/gpu-gemma2-with-ollama)
@@ -570,6 +567,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Neuro SAN](https://github.com/cognizant-ai-lab/neuro-san-studio) (Data-driven multi-agent orchestration framework) with [example](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/user_guide.md#ollama)
 - [achatbot-go](https://github.com/ai-bot-pro/achatbot-go) a multimodal(text/audio/image) chatbot.
 - [Ollama Bash Lib](https://github.com/attogram/ollama-bash-lib) - A Bash Library for Ollama. Run LLM prompts straight from your shell, and more
+- [AgentSystems](https://github.com/agentsystems/agentsystems) (Discover and run third-party AI agents using your local Ollama models - self-hosted containerized platform with a federated agent ecosystem)
 
 ### Mobile
 


### PR DESCRIPTION
Adding AgentSystems to the integrations list and proposing "Agent Platforms & Orchestration" as a new category to distinguish agent deployment platforms from chat interfaces.

**What is AgentSystems:**
A self-hosted platform that enables Ollama users to discover and run community-built AI agents using their own local models and compute resources.

Key features:
- Federated agent ecosystem (Git-based discovery)
- Runs third-party agents using local Ollama models
- Containerized deployment architecture
- Multi-provider support (Ollama, OpenAI, Anthropic, Bedrock)
- Self-hosted deployment

**Why a new category:**
The existing "Web & Desktop" section primarily contains chat interfaces and UI wrappers. AgentSystems is infrastructure for deploying and orchestrating agents, which serves a different use case. This seemed worth distinguishing.

Repo: https://github.com/agentsystems/agentsystems
Docs: https://docs.agentsystems.ai

(Full disclosure: I'm the author of AgentSystems and previously contributed to Ollama under this account)