### PR TITLE
feat: Set params.embeddings according to the pooling_type in GGUF

### DIFF
--- a/llama/llama.go
+++ b/llama/llama.go
@@ -117,7 +117,11 @@ func NewContextParams(numCtx int, batchSize int, numSeqMax int, threads int, fla
 	params.n_seq_max = C.uint(numSeqMax)
 	params.n_threads = C.int(threads)
 	params.n_threads_batch = params.n_threads
-	params.embeddings = C.bool(true)
+	if params.pooling_type > 0 {
+		params.embeddings = C.bool(true)
+	} else {
+		params.embeddings = C.bool(false)
+	}
 	if flashAttention {
 		params.flash_attn_type = C.LLAMA_FLASH_ATTN_TYPE_ENABLED
 	} else {


### PR DESCRIPTION
This resolves #12689 in another way to #12761. Alongside with this, I submitted a PR to llama.cpp addressing this issue at https://github.com/ggml-org/llama.cpp/pull/16766. However, there appears to be an alternative approach possible. One could argue that the issue occurs because `params.embeddings` is hardcoded to `true` in 
https://github.com/ollama/ollama/blob/ad6f6a1d29f45a5c7266bcd7edb5671621e86810/llama/llama.go#L120
Therefore, even if the loaded model is not an embedding model (i.e., when GGUF specifies `pooling_type = 0`), the `build_pooling()` is always called but nothing is performed because it goes through this part: 
https://github.com/ollama/ollama/blob/ad6f6a1d29f45a5c7266bcd7edb5671621e86810/llama/llama.cpp/src/llama-graph.cpp#L1899-L1902
So, I think it's fine to set `params.embeddings` to `false` when `pooling_type <= 0`.