### PR TITLE
darwin: improve free memory reporting

### DIFF
--- a/discover/gpu_info_darwin.m
+++ b/discover/gpu_info_darwin.m
@@ -26,10 +26,14 @@ uint64_t getFreeMemory() {
   if (host_statistics64(host_port, HOST_VM_INFO64, (host_info64_t)&vm_stat, &host_size) != KERN_SUCCESS) {
     return 0;
   }
+  uint64_t used = (uint64_t)vm_stat.active_count * pagesize
+    + (uint64_t)vm_stat.inactive_count * pagesize
+    + (uint64_t)vm_stat.speculative_count * pagesize
+    + (uint64_t)vm_stat.wire_count * pagesize
+    + (uint64_t)vm_stat.compressor_page_count * pagesize
+    - (uint64_t)vm_stat.purgeable_count * pagesize
+    - (uint64_t)vm_stat.external_page_count * pagesize;
 
-  uint64_t free_memory = (uint64_t)vm_stat.free_count * pagesize;
-  free_memory += (uint64_t)vm_stat.speculative_count * pagesize;
-  free_memory += (uint64_t)vm_stat.inactive_count * pagesize;
-
+  uint64_t free_memory = [NSProcessInfo processInfo].physicalMemory - used;
   return free_memory;
 }

--- a/discover/runner.go
+++ b/discover/runner.go
@@ -259,11 +259,6 @@ func GPUDevices(ctx context.Context, runners []ml.FilteredRunnerDiscovery) []ml.
 
 		bootstrapped = true
 	} else {
-		if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
-			// metal never updates free VRAM
-			return devices
-		}
-
 		slog.Debug("refreshing free memory")
 		updated := make([]bool, len(devices))
 		allDone := func() bool {

--- a/llama/patches/0030-reduce-metal-free-memory-based-on-system-free-memory.patch
+++ b/llama/patches/0030-reduce-metal-free-memory-based-on-system-free-memory.patch
@@ -1,0 +1,49 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Daniel Hiltgen <daniel@ollama.com>
+Date: Tue, 28 Oct 2025 13:24:02 -0700
+Subject: [PATCH] reduce metal free memory based on system free memory
+
+Metals currentAllocatedSize only reports the current process, so
+using that to derive available VRAM is incorrect.
+---
+ ggml/src/ggml-metal/ggml-metal-device.m | 27 ++++++++++++++++++++++++-
+ 1 file changed, 26 insertions(+), 1 deletion(-)
+
+diff --git a/ggml/src/ggml-metal/ggml-metal-device.m b/ggml/src/ggml-metal/ggml-metal-device.m
+index fc5083043..9064d969c 100644
+--- a/ggml/src/ggml-metal/ggml-metal-device.m
++++ b/ggml/src/ggml-metal/ggml-metal-device.m
+@@ -572,7 +572,32 @@ ggml_metal_library_t ggml_metal_device_get_library(ggml_metal_device_t dev) {
+ void ggml_metal_device_get_memory(ggml_metal_device_t dev, size_t * free, size_t * total) {
+     if (@available(macOS 10.12, iOS 16.0, *)) {
+         *total = dev->mtl_device.recommendedMaxWorkingSetSize;
+-        *free  = *total - dev->mtl_device.currentAllocatedSize;
++        // Note: dev->mtl_device.currentAllocatedSize only looks at the current process so we use system free memory instead
++        mach_port_t host_port = mach_host_self();
++        mach_msg_type_number_t host_size = sizeof(vm_statistics64_data_t) / sizeof(integer_t);
++        vm_size_t pagesize;
++        vm_statistics64_data_t vm_stat;
++
++        host_page_size(host_port, &pagesize);
++        if (host_statistics64(host_port, HOST_VM_INFO64, (host_info64_t)&vm_stat, &host_size) != KERN_SUCCESS) {
++            *free = 0;
++            *total = 0;
++            return;
++        }
++        uint64_t used = (uint64_t)vm_stat.active_count * pagesize
++            + (uint64_t)vm_stat.inactive_count * pagesize
++            + (uint64_t)vm_stat.speculative_count * pagesize
++            + (uint64_t)vm_stat.wire_count * pagesize
++            + (uint64_t)vm_stat.compressor_page_count * pagesize
++            - (uint64_t)vm_stat.purgeable_count * pagesize
++            - (uint64_t)vm_stat.external_page_count * pagesize;
++
++        uint64_t free_memory = [NSProcessInfo processInfo].physicalMemory - used;
++        if (free_memory < *total) {
++            *free = free_memory;
++        } else {
++            *free = dev->mtl_device.recommendedMaxWorkingSetSize;
++        }
+     } else {
+         *free = 0;
+         *total = 0;

--- a/llama/patches/0032-interleave-multi-rope.patch
+++ b/llama/patches/0032-interleave-multi-rope.patch
@@ -1,6 +1,6 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Michael Yang <git@mxy.ng>
-Date: Web, 16 Oct 2025 20:37:19 -0700
+Date: Thu, 16 Oct 2025 20:37:19 -0700
 Subject: [PATCH] interleave multi rope
 
 since ollama doesn't use mrope for anything else, change it to mean the
@@ -85,7 +85,7 @@ index 375a0c7fd..9866c96b4 100644
              // end of mrope
  
 diff --git a/ggml/src/ggml-vulkan/vulkan-shaders/rope_multi.comp b/ggml/src/ggml-vulkan/vulkan-shaders/rope_multi.comp
-index 111286b49..6fc2b42f8 100644
+index 111286b49..633dc20ff 100644
 --- a/ggml/src/ggml-vulkan/vulkan-shaders/rope_multi.comp
 +++ b/ggml/src/ggml-vulkan/vulkan-shaders/rope_multi.comp
 @@ -31,19 +31,13 @@ void main() {


### PR DESCRIPTION
We have been incorrectly reporting free space which can lead to stability problems if excessive VRAM is allocated. (graphics flickering, windows failing to render properly, which only clear up after a reboot.)

Before this change, on a 128G M3 mac I saw log lines like the following:
```
time=2025-10-28T13:30:11.774-07:00 level=INFO source=types.go:40 msg="inference compute" id=0 library=Metal compute=0.0 name=Metal description="Apple M3 Max" libdirs="" driver=0.0 pci_id=00:00.0 type=discrete total="96.0 GiB" available="96.0 GiB"
...
time=2025-10-28T13:30:37.564-07:00 level=INFO source=server.go:455 msg="system memory" total="128.0 GiB" free="69.2 GiB" free_swap="0 B"
```
However, other tools show ~77% used memory, and only ~29G free which is more accurate.

With this change:
```
time=2025-10-28T13:32:14.566-07:00 level=INFO source=types.go:40 msg="inference compute" id=0 library=Metal compute=0.0 name=Metal description="Apple M3 Max" libdirs="" driver=0.0 pci_id=00:00.0 type=discrete total="96.0 GiB" available="29.0 GiB"
...
time=2025-10-28T13:32:28.495-07:00 level=INFO source=server.go:455 msg="system memory" total="128.0 GiB" free="29.1 GiB" free_swap="0 B"
```

Before we would be more aggressive in causing the OS to start swapping, up to a point, but sometimes this causes stability problems.  With this change, systems that are low on free space will load fewer layers into GPU, and use more CPU, so it's possible this might have a performance impact in some cases if the swapping would have worked.