### PR TITLE
win: avoid ID mixups on refresh

### DIFF
--- a/discover/runner.go
+++ b/discover/runner.go
@@ -335,11 +335,14 @@ func GPUDevices(ctx context.Context, runners []ml.FilteredRunnerDiscovery) []ml.
 			ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 			defer cancel()
 
+			// Apply any dev filters to avoid re-discovering unsupported devices, and get IDs correct
+			devFilter := ml.GetVisibleDevicesEnv(devices)
+
 			for dir := range libDirs {
-				updatedDevices := bootstrapDevices(ctx, []string{LibOllamaPath, dir}, nil)
+				updatedDevices := bootstrapDevices(ctx, []string{LibOllamaPath, dir}, devFilter)
 				for _, u := range updatedDevices {
 					for i := range devices {
-						if u.DeviceID == devices[i].DeviceID {
+						if u.DeviceID == devices[i].DeviceID && u.PCIID == devices[i].PCIID {
 							updated[i] = true
 							devices[i].FreeMemory = u.FreeMemory
 							break


### PR DESCRIPTION
On Windows AMD IDs are numeric, and can reorder based on the filter environment. By passing in the filter env on a full discovery refresh, we'll only look at the actual devices and ignore unsupported iGPUs.  Without this, on some systems iGPU VRAM information was incorrectly being used to populate the dGPU.

Fixes #12564 
Fixes #12754 