### PR TITLE
logs: catch rocm errors

### DIFF
--- a/llm/status.go
+++ b/llm/status.go
@@ -23,6 +23,7 @@ func NewStatusWriter(out *os.File) *StatusWriter {
 var errorPrefixes = []string{
 	"error:",
 	"CUDA error",
+	"ROCm error",
 	"cudaMalloc failed",
 	"\"ERR\"",
 	"error loading model",


### PR DESCRIPTION
This will help bubble up more crash errors with the details instead of a generic message

example scenario on windows before this change.  Client sees:
```
llm_image_test.go:74: failed to load model qwen3-vl:8b: 500 Internal Server Error: do load request: Post "http://127.0.0.1:57617/load": read tcp 127.0.0.1:57621->127.0.0.1:57617: wsarecv: An existing connection was forcibly closed by the remote host.
```

server logs: (most likely an OOM)
```
time=2025-10-30T19:19:12.705-07:00 level=DEBUG source=vocabulary.go:52 msg="adding bos token to prompt" id=0
ROCm error: invalid argument
  current device: 0, in function ggml_cuda_op_mul_mat at C:/a/ollama/ollama/ml/backend/ggml/ggml/src/ggml-cuda/ggml-cuda.cu:1718
  hipMemsetAsync(dev[id].src0_dd + nbytes_data, 0, nbytes_padding, stream)
C:/a/ollama/ollama/ml/backend/ggml/ggml/src/ggml-cuda/ggml-cuda.cu:88: ROCm error
time=2025-10-30T19:19:12.811-07:00 level=INFO source=device.go:212 msg="model weights" device=ROCm0 size="5.3 GiB"
time=2025-10-30T19:19:12.811-07:00 level=INFO source=device.go:217 msg="model weights" device=CPU size="292.4 MiB"
time=2025-10-30T19:19:12.811-07:00 level=INFO source=device.go:223 msg="kv cache" device=ROCm0 size="224.0 MiB"
time=2025-10-30T19:19:12.811-07:00 level=INFO source=device.go:234 msg="compute graph" device=ROCm0 size="2.0 GiB"
time=2025-10-30T19:19:12.811-07:00 level=INFO source=device.go:239 msg="compute graph" device=CPU size="16.8 MiB"
time=2025-10-30T19:19:12.811-07:00 level=INFO source=device.go:244 msg="total memory" size="7.8 GiB"
time=2025-10-30T19:19:12.811-07:00 level=INFO source=sched.go:446 msg="Load failed" model=C:\Users\daniel\.ollama\models\blobs\sha256-a99b7f834d754b88f122d865f32758ba9f0994a83f8363df2c1e71c17605a025 error="do load request: Post \"http://127.0.0.1:57481/load\": read tcp 127.0.0.1:57485->127.0.0.1:57481: wsarecv: An existing connection was forcibly closed by the remote host."
time=2025-10-30T19:19:12.811-07:00 level=DEBUG source=server.go:1699 msg="stopping llama server" pid=17712
time=2025-10-30T19:19:12.826-07:00 level=ERROR source=server.go:273 msg="llama runner terminated" error="exit status 0xc0000409"
```