### PR TITLE
server: add ThinkLevel capability

### DIFF
--- a/server/images.go
+++ b/server/images.go
@@ -40,6 +40,7 @@ var (
 	errCapabilityVision     = errors.New("vision")
 	errCapabilityEmbedding  = errors.New("embedding")
 	errCapabilityThinking   = errors.New("thinking")
+	errCapabilityThinkLevel = errors.New("thinklevel")
 	errInsecureProtocol     = errors.New("insecure protocol http")
 )
 
@@ -123,6 +124,11 @@ func (m *Model) Capabilities() []model.Capability {
 		capabilities = append(capabilities, model.CapabilityVision)
 	}
 
+	// Check for the ability to set the level of thinking
+	if slices.Contains(v, "thinklevel") {
+		capabilities = append(capabilities, model.CapabilityThinkLevel)
+	}
+
 	// Skip the thinking check if it's already set
 	if slices.Contains(capabilities, "thinking") {
 		return capabilities
@@ -134,6 +140,9 @@ func (m *Model) Capabilities() []model.Capability {
 	isGptoss := slices.Contains([]string{"gptoss", "gpt-oss"}, m.Config.ModelFamily)
 	if hasTags || isGptoss || (builtinParser != nil && builtinParser.HasThinkingSupport()) {
 		capabilities = append(capabilities, model.CapabilityThinking)
+	}
+	if isGptoss && !slices.Contains(capabilities, "thinklevel") {
+		capabilities = append(capabilities, model.CapabilityThinkLevel)
 	}
 
 	return capabilities
@@ -153,6 +162,7 @@ func (m *Model) CheckCapabilities(want ...model.Capability) error {
 		model.CapabilityVision:     errCapabilityVision,
 		model.CapabilityEmbedding:  errCapabilityEmbedding,
 		model.CapabilityThinking:   errCapabilityThinking,
+		model.CapabilityThinkLevel: errCapabilityThinkLevel,
 	}
 
 	for _, cap := range want {

--- a/server/routes.go
+++ b/server/routes.go
@@ -333,12 +333,6 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 		}
 	}
 
-	// Validate Think value: string values currently only allowed for harmony/gptoss models
-	if req.Think != nil && req.Think.IsString() && m.Config.Parser != "harmony" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("think value %q is not supported for this model", req.Think.String())})
-		return
-	}
-
 	caps := []model.Capability{model.CapabilityCompletion}
 	if req.Suffix != "" {
 		caps = append(caps, model.CapabilityInsert)
@@ -355,6 +349,12 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("%q does not support thinking", req.Model)})
 			return
 		}
+	}
+
+	// Validate Think value: string values currently only allowed for models with ThinkLevel capability
+	if req.Think != nil && req.Think.IsString() && !slices.Contains(modelCaps, model.CapabilityThinkLevel) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("think value %q is not supported for this model", req.Think.String())})
+		return
 	}
 
 	r, m, opts, err := s.scheduleRunner(c.Request.Context(), name.String(), caps, req.Options, req.KeepAlive)
@@ -2037,8 +2037,8 @@ func (s *Server) ChatHandler(c *gin.Context) {
 		return
 	}
 
-	// Validate Think value: string values currently only allowed for harmony/gptoss models
-	if req.Think != nil && req.Think.IsString() && m.Config.Parser != "harmony" {
+	// Validate Think value: string values currently only allowed for models with ThinkLevel capability
+	if req.Think != nil && req.Think.IsString() && !slices.Contains(modelCaps, model.CapabilityThinkLevel) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("think value %q is not supported for this model", req.Think.String())})
 		return
 	}

--- a/types/model/capability.go
+++ b/types/model/capability.go
@@ -9,6 +9,7 @@ const (
 	CapabilityVision     = Capability("vision")
 	CapabilityEmbedding  = Capability("embedding")
 	CapabilityThinking   = Capability("thinking")
+	CapabilityThinkLevel = Capability("thinklevel")
 )
 
 func (c Capability) String() string {


### PR DESCRIPTION
Currently the gpt-oss models support setting the thinking level.  Other models also support setting a thinking level (eg seed-oss) but currently this information can't be passed to the template. This PR uses the presence of `.ThinkLevel` in the template to determine whether the think level can be set. 