### PR TITLE
log: instrument CPU discovery timing

### DIFF
--- a/discover/gpu.go
+++ b/discover/gpu.go
@@ -7,7 +7,9 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
+	"github.com/ollama/ollama/logutil"
 	"github.com/ollama/ollama/ml"
 )
 
@@ -17,6 +19,12 @@ var CudaTegra string = os.Getenv("JETSON_JETPACK")
 
 // GetSystemInfo returns the last cached state of the GPUs on the system
 func GetSystemInfo() ml.SystemInfo {
+	logutil.Trace("performing CPU discovery")
+	startDiscovery := time.Now()
+	defer func() {
+		logutil.Trace("CPU discovery completed", "duration", time.Since(startDiscovery))
+	}()
+
 	memInfo, err := GetCPUMem()
 	if err != nil {
 		slog.Warn("error looking up system memory", "error", err)


### PR DESCRIPTION
Some windows users with CPU only systems seem to be hitting a hang.  The logs aren't obvious, but it's possible they may be getting stuck in the windows specific CPU discovery.  If I can't root cause it before the next release, this will at least help narrow down if they are getting stuck in this area.