### PR TITLE
win: revert CPU discovery logic to 0.12.3

### DIFF
--- a/discover/cpu_windows.go
+++ b/discover/cpu_windows.go
@@ -5,6 +5,8 @@ import (
 	"log/slog"
 	"syscall"
 	"unsafe"
+
+	"github.com/ollama/ollama/logutil"
 )
 
 type MEMORYSTATUSEX struct {
@@ -99,22 +101,29 @@ func (pkg *winPackage) IsMember(target *GROUP_AFFINITY) bool {
 }
 
 func getLogicalProcessorInformationEx() ([]byte, error) {
-	buf := make([]byte, 1024)
+	buf := make([]byte, 1)
 	bufSize := len(buf)
-	var err error
-	for range 3 {
-		var ret uintptr
-		ret, _, err = GetLogicalProcessorInformationEx.Call(
-			uintptr(RelationAll),
-			uintptr(unsafe.Pointer(&buf[0])),
-			uintptr(unsafe.Pointer(&bufSize)),
-		)
-		if ret == 1 && bufSize <= len(buf) {
-			return buf, nil
-		}
-		buf = make([]byte, bufSize)
+	ret, _, err := GetLogicalProcessorInformationEx.Call(
+		uintptr(RelationAll),
+		uintptr(unsafe.Pointer(&buf[0])),
+		uintptr(unsafe.Pointer(&bufSize)),
+	)
+	if ret != 0 {
+		logutil.Trace("failed to retrieve CPU payload size", "ret", ret, "size", bufSize, "error", err)
+		return nil, fmt.Errorf("failed to determine size info ret:%d %w", ret, err)
 	}
-	return nil, fmt.Errorf("unable to determine CPU details: %w", err)
+
+	buf = make([]byte, bufSize)
+	ret, _, err = GetLogicalProcessorInformationEx.Call(
+		uintptr(RelationAll),
+		uintptr(unsafe.Pointer(&buf[0])),
+		uintptr(unsafe.Pointer(&bufSize)),
+	)
+	if ret == 0 {
+		logutil.Trace("failed to retrieve CPU information", "ret", ret, "size", len(buf), "new_size", bufSize, "error", err)
+		return nil, fmt.Errorf("failed to gather processor information ret:%d buflen:%d %w", ret, bufSize, err)
+	}
+	return buf, nil
 }
 
 func processSystemLogicalProcessorInforationList(buf []byte) []*winPackage {


### PR DESCRIPTION
The behavior change in 0.12.4 is the most likely the root cause of hangs some users are seeing.  This reverts to the 0.12.3 code, with some added trace logging.

Fixes #12699 
Fixes #12640 
Fixes #12942