### PR TITLE
app/ui: prevent sidebar animation on initial load

### DIFF
--- a/app/ui/app/src/components/layout/layout.tsx
+++ b/app/ui/app/src/components/layout/layout.tsx
@@ -67,7 +67,7 @@ export function SidebarLayout({
         {settings.sidebarOpen && sidebar}
       </div>
       <main
-        className={`flex flex-1 flex-col min-w-0 transition-all duration-300`}
+        className={`flex flex-1 flex-col min-w-0 ${mounted ? "transition-all duration-300" : "transition-none"}`}
       >
         <div
           className={`h-13 flex-none w-full z-10 flex items-center bg-white dark:bg-neutral-900 ${isWindows ? "xl:hidden" : "xl:fixed xl:bg-transparent xl:dark:bg-transparent"}`}


### PR DESCRIPTION
This PR fixes https://github.com/ollama/ollama/issues/12954.

The main content area was using an unconditional transition-all class, which caused it to animate on page load.

This fix applies the existing mounted state (from the useEffect hook in SidebarLayout) to the <main> component, adding the transition class only after the initial render.