### PR TITLE
app/ui: prevent sidebar animation on initial load patch

### DIFF
--- a/app/ui/app/src/components/layout/layout.tsx
+++ b/app/ui/app/src/components/layout/layout.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from "react";
 import { Link } from "@tanstack/react-router";
 import { useSettings } from "@/hooks/useSettings";
 
@@ -11,7 +12,11 @@ export function SidebarLayout({
 }>) {
   const { settings, setSettings } = useSettings();
   const isWindows = navigator.platform.toLowerCase().includes("win");
-
+  const [mounted, setMounted] = useState(false);
+    useEffect(() => {
+      setMounted(true);
+    }, []);
+  
   return (
     <div className={`flex transition-[width] duration-300 dark:bg-neutral-900`}>
       <div


### PR DESCRIPTION
This PR fixes https://github.com/ollama/ollama/issues/12954.

The main content area was using an unconditional transition-all class, which caused it to animate on page load.

This fix applies the existing mounted state (from the useEffect hook in SidebarLayout) to the

component, adding the transition class only after the initial render.