### PR TITLE
app/docs: remove out of date storybook instructions

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -48,16 +48,6 @@ The `-dev` flag enables:
 - CORS headers for cross-origin requests
 - Hot-reload support for UI development
 
-#### Run Storybook
-
-Inside the `ui/app` directory, run:
-
-```bash
-npm run storybook
-```
-
-For now we're writing stories as siblings of the component they're testing. So for example, `src/components/Message.stories.tsx` is the story for `src/components/Message.tsx`.
-
 ## Build
 
 


### PR DESCRIPTION
The storybook components were removed from the app as we found we do not use them that often. Remove this out of date information.