### PR TITLE
docs: fix metal gpu section header

### DIFF
--- a/docs/gpu.mdx
+++ b/docs/gpu.mdx
@@ -121,6 +121,6 @@ In some Linux distributions, SELinux can prevent containers from
 accessing the AMD GPU devices. On the host system you can run
 `sudo setsebool container_use_devices=1` to allow containers to use devices.
 
-### Metal (Apple GPUs)
+## Metal (Apple GPUs)
 
 Ollama supports GPU acceleration on Apple devices via the Metal API.


### PR DESCRIPTION
Metal is definitely not an AMD Radeon product...

<img width="247" height="393" alt="image" src="https://github.com/user-attachments/assets/9cc8e04e-2e98-43f1-b8e9-6c907d1e8fbb" />

https://docs.ollama.com/gpu#metal-apple-gpus