### PR TITLE
Fix single directory selector

### DIFF
--- a/app/dialog/cocoa/dlg.m
+++ b/app/dialog/cocoa/dlg.m
@@ -169,7 +169,7 @@ DlgResult fileDlg(FileDlgParams* params) {
 	}
 	
 	NSArray* urls = [panel URLs];
-	if(urls count] >= 1) {
+	if ([urls count] >= 1) {
 		// For multiple files, we need to return all paths separated by null bytes
 		char* bufPtr = self->params->buf;
 		int remainingBuf = self->params->nbuf;


### PR DESCRIPTION
app: fix singledirectory selection returning empty path.      
  
Fixed a bug in the Cocoa dialog implementation where single directory
selection was not writing the selected path to the output buffer, causing
directory selection dialogs to always return empty strings to JavaScript
callbacks despite successful user selection.
Added the single file case to the existing code by eliminating the check of select multiple.  

Fix Issue #12883