### PR TITLE
docs: fix typo (VSCode -> VS Code)

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [PartCAD](https://github.com/openvmp/partcad/) (CAD model generation with OpenSCAD and CadQuery)
 - [Ollama4j Web UI](https://github.com/ollama4j/ollama4j-web-ui) - Java-based Web UI for Ollama built with Vaadin, Spring Boot, and Ollama4j
 - [PyOllaMx](https://github.com/kspviswa/pyOllaMx) - macOS application capable of chatting with both Ollama and Apple MLX models.
-- [Cline](https://github.com/cline/cline) - Formerly known as Claude Dev is a VSCode extension for multi-file/whole-repo coding
+- [Cline](https://github.com/cline/cline) - Formerly known as Claude Dev is a VS Code extension for multi-file/whole-repo coding
 - [Cherry Studio](https://github.com/kangfenmao/cherry-studio) (Desktop client with Ollama support)
 - [ConfiChat](https://github.com/1runeberg/confichat) (Lightweight, standalone, multi-platform, and privacy-focused LLM chat interface with optional encryption)
 - [Archyve](https://github.com/nickthecook/archyve) (RAG-enabling document library)
@@ -398,7 +398,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [aidful-ollama-model-delete](https://github.com/AidfulAI/aidful-ollama-model-delete) (User interface for simplified model cleanup)
 - [Perplexica](https://github.com/ItzCrazyKns/Perplexica) (An AI-powered search engine & an open-source alternative to Perplexity AI)
 - [Ollama Chat WebUI for Docker ](https://github.com/oslook/ollama-webui) (Support for local docker deployment, lightweight ollama webui)
-- [AI Toolkit for Visual Studio Code](https://aka.ms/ai-tooklit/ollama-docs) (Microsoft-official VSCode extension to chat, test, evaluate models with Ollama support, and use them in your AI applications.)
+- [AI Toolkit for Visual Studio Code](https://aka.ms/ai-tooklit/ollama-docs) (Microsoft-official VS Code extension to chat, test, evaluate models with Ollama support, and use them in your AI applications.)
 - [MinimalNextOllamaChat](https://github.com/anilkay/MinimalNextOllamaChat) (Minimal Web UI for Chat and Model Control)
 - [Chipper](https://github.com/TilmanGriesel/chipper) AI interface for tinkerers (Ollama, Haystack RAG, Python)
 - [ChibiChat](https://github.com/CosmicEventHorizon/ChibiChat) (Kotlin-based Android app to chat with Ollama and Koboldcpp API endpoints)

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -223,7 +223,7 @@ Refer to the section [above](#how-do-i-configure-ollama-server) for how to set e
 
 ## How can I use Ollama in Visual Studio Code?
 
-There is already a large collection of plugins available for VSCode as well as other editors that leverage Ollama. See the list of [extensions & plugins](https://github.com/ollama/ollama#extensions--plugins) at the bottom of the main repository readme.
+There is already a large collection of plugins available for VS Code as well as other editors that leverage Ollama. See the list of [extensions & plugins](https://github.com/ollama/ollama#extensions--plugins) at the bottom of the main repository readme.
 
 ## How do I use Ollama with GPU acceleration in Docker?
 

--- a/docs/integrations/vscode.mdx
+++ b/docs/integrations/vscode.mdx
@@ -4,7 +4,7 @@ title: VS Code
 
 ## Install
 
-Install [VSCode](https://code.visualstudio.com/download). 
+Install [VS Code](https://code.visualstudio.com/download). 
 
 ## Usage with Ollama 
 
@@ -12,7 +12,7 @@ Install [VSCode](https://code.visualstudio.com/download).
 <div style={{ display: 'flex', justifyContent: 'center' }}>
   <img 
     src="/images/vscode-sidebar.png" 
-    alt="VSCode chat Sidebar"
+    alt="VS Code chat Sidebar"
     width="75%"
   />
 </div>
@@ -20,7 +20,7 @@ Install [VSCode](https://code.visualstudio.com/download).
 <div style={{ display: 'flex', justifyContent: 'center' }}>
   <img 
     src="/images/vscode-models.png" 
-    alt="VSCode model picker"
+    alt="VS Code model picker"
     width="75%"
   />
 </div>
@@ -28,7 +28,7 @@ Install [VSCode](https://code.visualstudio.com/download).
 <div style={{ display: 'flex', justifyContent: 'center' }}>
   <img 
     src="/images/vscode-model-options.png" 
-    alt="VSCode model options dropdown"
+    alt="VS Code model options dropdown"
     width="75%"
   />
 </div>


### PR DESCRIPTION
https://code.visualstudio.com/docs/setup/setup-overview

In this PR, "VSCode" is corrected to "VS Code", to be consistent with the spelling of VS Code's official docs.