### PR TITLE
tools: add tool call id to qwen3coder parser

### DIFF
--- a/model/parsers/qwen3coder.go
+++ b/model/parsers/qwen3coder.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/logutil"
+	"github.com/ollama/ollama/tools"
 )
 
 type qwenParserState int
@@ -246,7 +247,7 @@ type XMLParameter struct {
 // celsius
 // </parameter>
 // </function>
-func parseToolCall(raw qwenEventRawToolCall, tools []api.Tool) (api.ToolCall, error) {
+func parseToolCall(raw qwenEventRawToolCall, toolList []api.Tool) (api.ToolCall, error) {
 	toolCall := api.ToolCall{}
 
 	xmlString := transformToXML(raw.raw)
@@ -263,9 +264,9 @@ func parseToolCall(raw qwenEventRawToolCall, tools []api.Tool) (api.ToolCall, er
 
 	// Find the matching tool to get parameter types
 	var matchedTool *api.Tool
-	for i := range tools {
-		if tools[i].Function.Name == functionCall.Name {
-			matchedTool = &tools[i]
+	for i := range toolList {
+		if toolList[i].Function.Name == functionCall.Name {
+			matchedTool = &toolList[i]
 			break
 		}
 	}
@@ -289,6 +290,7 @@ func parseToolCall(raw qwenEventRawToolCall, tools []api.Tool) (api.ToolCall, er
 
 		toolCall.Function.Arguments[parameter.Name] = parseValue(parameter.Value, paramType)
 	}
+	toolCall.ID = tools.ToolCallID()
 
 	return toolCall, nil
 }

--- a/server/routes.go
+++ b/server/routes.go
@@ -13,7 +13,6 @@ import (
 	"io/fs"
 	"log/slog"
 	"math"
-	"math/rand"
 	"net"
 	"net/http"
 	"net/netip"
@@ -1832,15 +1831,6 @@ func (s *Server) PsHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, api.ProcessResponse{Models: models})
 }
 
-func toolCallId() string {
-	const letterBytes = "abcdefghijklmnopqrstuvwxyz0123456789"
-	b := make([]byte, 8)
-	for i := range b {
-		b[i] = letterBytes[rand.Intn(len(letterBytes))]
-	}
-	return "call_" + strings.ToLower(string(b))
-}
-
 func (s *Server) ChatHandler(c *gin.Context) {
 	checkpointStart := time.Now()
 
@@ -2174,7 +2164,7 @@ func (s *Server) ChatHandler(c *gin.Context) {
 					res.Message.Content = content
 					res.Message.Thinking = thinking
 					for i := range toolCalls {
-						toolCalls[i].ID = toolCallId()
+						toolCalls[i].ID = tools.ToolCallID()
 					}
 					res.Message.ToolCalls = toolCalls
 
@@ -2221,7 +2211,7 @@ func (s *Server) ChatHandler(c *gin.Context) {
 						res.Message.Content = content
 					} else if len(toolCalls) > 0 {
 						for i := range toolCalls {
-							toolCalls[i].ID = toolCallId()
+							toolCalls[i].ID = tools.ToolCallID()
 						}
 						res.Message.ToolCalls = toolCalls
 						res.Message.Content = ""

--- a/tools/tools_utils.go
+++ b/tools/tools_utils.go
@@ -1,0 +1,15 @@
+package tools
+
+import (
+	"math/rand"
+	"strings"
+)
+
+func ToolCallID() string {
+	const letterBytes = "abcdefghijklmnopqrstuvwxyz0123456789"
+	b := make([]byte, 8)
+	for i := range b {
+		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+	return "call_" + strings.ToLower(string(b))
+}


### PR DESCRIPTION
In order to use parsers as independent packages, they must conform to the Ollama API spec. 

Currently we add tool call ids in the api layer in routes.go, but these field must come from the parsing layer. 