### PR TITLE
app/ui: fix to point ollama client to ui backend in dev mode

### DIFF
--- a/app/ui/app/src/api.ts
+++ b/app/ui/app/src/api.ts
@@ -15,6 +15,7 @@ import {
 import { parseJsonlFromResponse } from "./util/jsonl-parsing";
 import { ollamaClient as ollama } from "./lib/ollama-client";
 import type { ModelResponse } from "ollama/browser";
+import { API_BASE } from "./lib/config";
 
 // Extend Model class with utility methods
 declare module "@/gotypes" {
@@ -26,8 +27,6 @@ declare module "@/gotypes" {
 Model.prototype.isCloud = function (): boolean {
   return this.model.endsWith("cloud");
 };
-
-const API_BASE = import.meta.env.DEV ? "http://127.0.0.1:3001" : "";
 
 // Helper function to convert Uint8Array to base64
 function uint8ArrayToBase64(uint8Array: Uint8Array): string {

--- a/app/ui/app/src/lib/config.ts
+++ b/app/ui/app/src/lib/config.ts
@@ -1,0 +1,10 @@
+// API configuration
+const DEV_API_URL = "http://127.0.0.1:3001";
+
+// Base URL for fetch API calls (can be relative in production)
+export const API_BASE = import.meta.env.DEV ? DEV_API_URL : "";
+
+// Full host URL for Ollama client (needs full origin in production)
+export const OLLAMA_HOST = import.meta.env.DEV
+  ? DEV_API_URL
+  : window.location.origin;

--- a/app/ui/app/src/lib/ollama-client.ts
+++ b/app/ui/app/src/lib/ollama-client.ts
@@ -1,16 +1,13 @@
 import { Ollama } from "ollama/browser";
+import { OLLAMA_HOST } from "./config";
 
 let _ollamaClient: Ollama | null = null;
 
 export const ollamaClient = new Proxy({} as Ollama, {
   get(_target, prop) {
     if (!_ollamaClient) {
-      const host = import.meta.env.DEV
-        ? "http://127.0.0.1:3001"
-        : window.location.origin;
-
       _ollamaClient = new Ollama({
-        host,
+        host: OLLAMA_HOST,
       });
     }
     const value = _ollamaClient[prop as keyof Ollama];


### PR DESCRIPTION
In development mode, the Ollama client was using window.location.origin (http://localhost:5173 since frontend is running on 5173), causing it to call APIs on the Vite dev server instead of the UI backend proxy server. This resulted in 404 errors for some API calls (/tags, /show).

This PR fix to configure the Ollama client to use http://127.0.0.1:3001 in dev mode, which is where the UI backend server (started with -dev flag) listens and proxies requests to the Ollama server.