### PR TITLE
app/cmd: restrict ollama:// URL scheme to supported paths

### DIFF
--- a/app/cmd/app/app_windows.go
+++ b/app/cmd/app/app_windows.go
@@ -138,7 +138,7 @@ func (app *appCallbacks) HandleURLScheme(urlScheme string) {
 
 // handleURLSchemeRequest processes URL scheme requests from other instances
 func handleURLSchemeRequest(urlScheme string) {
-	isConnect, uiPath, err := parseURLScheme(urlScheme)
+	isConnect, err := parseURLScheme(urlScheme)
 	if err != nil {
 		slog.Error("failed to parse URL scheme request", "url", urlScheme, "error", err)
 		return
@@ -147,7 +147,7 @@ func handleURLSchemeRequest(urlScheme string) {
 	if isConnect {
 		handleConnectURLScheme()
 	} else {
-		sendUIRequestMessage(uiPath)
+		sendUIRequestMessage("/")
 	}
 }
 


### PR DESCRIPTION
This PR refactors the `ollama://` URL scheme handler to explicitly support only the URL patterns that are actually used in practice. This makes the code simpler and more maintainable.

Updated `parseURLScheme()` to support the two external URL patterns currently in use:
- `ollama://` - Opens the application
- `ollama://connect` - OAuth authentication flow