### PR TITLE
docs: add Void Editor to community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Ollama4j Web UI](https://github.com/ollama4j/ollama4j-web-ui) - Java-based Web UI for Ollama built with Vaadin, Spring Boot, and Ollama4j
 - [PyOllaMx](https://github.com/kspviswa/pyOllaMx) - macOS application capable of chatting with both Ollama and Apple MLX models.
 - [Cline](https://github.com/cline/cline) - Formerly known as Claude Dev is a VS Code extension for multi-file/whole-repo coding
+- [Void](https://github.com/voideditor/void) (Open source AI code editor and Cursor alternative)
 - [Cherry Studio](https://github.com/kangfenmao/cherry-studio) (Desktop client with Ollama support)
 - [ConfiChat](https://github.com/1runeberg/confichat) (Lightweight, standalone, multi-platform, and privacy-focused LLM chat interface with optional encryption)
 - [Archyve](https://github.com/nickthecook/archyve) (RAG-enabling document library)


### PR DESCRIPTION
Hi! This PR adds Void Editor to the community integrations list, addressing issue #12919.

## About Void Editor

Void is an open source AI code editor and Cursor alternative that provides excellent Ollama integration. It's built as a fork of VS Code, allowing users to transfer their themes, keybindings, and settings seamlessly.

## Why Add This Integration?

- **Direct Ollama Support**: Void connects directly to Ollama without routing through a private backend, giving users full control over their data
- **Open Source**: Fully open source alternative to proprietary AI code editors
- **VS Code Compatible**: Built on VS Code, so users can keep their familiar workflow
- **Feature Rich**: Includes Agent Mode, MCP support, autocomplete, inline editing, and chat features
- **Active Development**: Backed by Y Combinator and has an active community

## Integration Placement

I've placed Void right after Cline in the list, as both are VS Code-based editors with similar use cases for AI-assisted coding.

The addition follows the same format as other entries in the list and includes a brief, descriptive label.

Fixes #12919