### PR TITLE
app/ui: use requestAnimationFrame to prevent bottom line cutoff in streaming thinking display

### DIFF
--- a/app/ui/app/src/components/Thinking.tsx
+++ b/app/ui/app/src/components/Thinking.tsx
@@ -50,20 +50,32 @@ export default function Thinking({
   // Position content to show bottom when collapsed
   useEffect(() => {
     if (isCollapsed && contentRef.current && wrapperRef.current) {
-      const contentHeight = contentRef.current.scrollHeight;
-      const wrapperHeight = wrapperRef.current.clientHeight;
-      if (contentHeight > wrapperHeight) {
-        const translateY = -(contentHeight - wrapperHeight);
-        contentRef.current.style.transform = `translateY(${translateY}px)`;
-        setHasOverflow(true);
-      } else {
-        setHasOverflow(false);
-      }
+      requestAnimationFrame(() => {
+        if (!contentRef.current || !wrapperRef.current) return;
+
+        const contentHeight = contentRef.current.scrollHeight;
+        const wrapperHeight = wrapperRef.current.clientHeight;
+        if (contentHeight > wrapperHeight) {
+          const translateY = -(contentHeight - wrapperHeight);
+          contentRef.current.style.transform = `translateY(${translateY}px)`;
+          setHasOverflow(true);
+        } else {
+          contentRef.current.style.transform = "translateY(0)";
+          setHasOverflow(false);
+        }
+      });
     } else if (contentRef.current) {
       contentRef.current.style.transform = "translateY(0)";
       setHasOverflow(false);
     }
   }, [thinking, isCollapsed]);
+
+  useEffect(() => {
+    if (activelyThinking && wrapperRef.current && !isCollapsed) {
+      // When expanded and actively thinking, scroll to bottom
+      wrapperRef.current.scrollTop = wrapperRef.current.scrollHeight;
+    }
+  }, [thinking, activelyThinking, isCollapsed]);
 
   const handleToggle = () => {
     setIsCollapsed(!isCollapsed);


### PR DESCRIPTION
When models with thinking capability stream their reasoning in real-time, the bottomline of thinking content is cut off and not visible to users in the collapsed thinking panel.

The reason why is because the thinking component uses CSS `translateY()` transform to position content and show the bottom portion in collapsed mode. During active streaming, a race condition occurs where the transform calculation happens before the browser completes layout of newly added content, resulting in positioning based on stale dimensions.

This PR modified 2 things: 
1. Wrapped transform calculations in `requestAnimationFrame`: Ensures DOM layout is complete before calculating content dimensions and positioning (to avoid race condition)
2. Added auto-scroll for expanded mode: When the thinking panel is expanded during active streaming, automatically scrolls to show the latest content

This PR is resolving #13094 