### PR TITLE
nomic-embed: nomic-embed-text defaulted to ollama runner 

### DIFF
--- a/fs/ggml/ggml.go
+++ b/fs/ggml/ggml.go
@@ -251,7 +251,7 @@ func (kv KV) OllamaEngineRequired() bool {
 		"qwen3vl", "qwen3vlmoe",
 		"deepseekocr",
 		"deepseek2",
-		"nomicbert",
+		"nomic-bert",
 	}, kv.Architecture())
 }
 


### PR DESCRIPTION
This PR makes all models with nomic bert architecture run on the Ollama engine