### PR TITLE
docs: add MindMap to community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Clueless](https://github.com/KashyapTan/clueless) (Open Source & Local Cluely: A desktop application LLM assistant to help you talk to anything on your screen using locally served Ollama models. Also undetectable to screenshare)
 - [ollama-co2](https://github.com/carbonatedWaterOrg/ollama-co2) (FastAPI web interface for monitoring and managing local and remote Ollama servers with real-time model monitoring and concurrent downloads)
 - [Hillnote](https://hillnote.com) (A Markdown-first workspace designed to supercharge your AI workflow. Create documents ready to integrate with Claude, ChatGPT, Gemini, Cursor, and more - all while keeping your work on your device.)
+- [MindMap](https://github.com/azula1A89/mindmap) (A simple yet fast mind map editor written in C++. You can also call Ollama to get some inspiration.)
 
 ### Cloud
 


### PR DESCRIPTION
Hello! I would be very grateful if you could add the MindMap app to the community integration list.

MindMap is a simple yet fast mindmap editor written in C++. You can call Ollama to get some inspiration.

GitHub repository: https://github.com/azula1A89/mindmap

Thanks!