### PR TITLE
fix: prevent overwriting existing systemd service file

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -130,8 +130,9 @@ configure_systemd() {
     status "Adding current user to ollama group..."
     $SUDO usermod -a -G ollama $(whoami)
 
-    status "Creating ollama systemd service..."
-    cat <<EOF | $SUDO tee /etc/systemd/system/ollama.service >/dev/null
+    if [ ! -f /etc/systemd/system/ollama.service ]; then
+        status "Creating ollama systemd service..."
+        cat <<EOF | $SUDO tee /etc/systemd/system/ollama.service >/dev/null
 [Unit]
 Description=Ollama Service
 After=network-online.target
@@ -147,6 +148,9 @@ Environment="PATH=$PATH"
 [Install]
 WantedBy=default.target
 EOF
+    else
+        status "Ollama systemd service already exists, skipping creation..."
+    fi
     SYSTEMCTL_RUNNING="$(systemctl is-system-running || true)"
     case $SYSTEMCTL_RUNNING in
         running|degraded)


### PR DESCRIPTION
### Changes
- Added existence check before creating ollama.service
- Display informative message when service file already exists
- Prevents accidental overwrite of custom systemd configurations

### Motivation
During installation/upgrade, the script was unconditionally overwriting
the systemd service file, which could destroy user customizations such as:
- Custom environment variables
- Modified resource limits
- Custom startup parameters

### Impact
- Safer upgrades that preserve user configurations
- Better user experience for those who have customized the service
- No breaking changes for fresh installations