### PR TITLE
Add /api/models/size endpoint to report total storage usage

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -361,6 +361,20 @@ func (c *Client) List(ctx context.Context) (*ListResponse, error) {
 	return &lr, nil
 }
 
+type ModelsSizeResponse struct {
+	TotalSizeBytes int64 `json:"total_size_bytes"`
+	ModelsCount    int   `json:"models_count"`
+}
+
+func (c *Client) ModelsSize(ctx context.Context) (*ModelsSizeResponse, error) {
+	var resp ModelsSizeResponse
+	if err := c.do(ctx, http.MethodGet, "/api/models/size", nil, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
 // ListRunning lists running models.
 func (c *Client) ListRunning(ctx context.Context) (*ProcessResponse, error) {
 	var lr ProcessResponse

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -262,3 +262,110 @@ func TestClientDo(t *testing.T) {
 		})
 	}
 }
+
+func TestClientModelsSizeHandler(t *testing.T) {
+	testCases := []struct {
+		name     string
+		response any
+		wantErr  string
+		validate func(t *testing.T, resp *ModelsSizeResponse)
+	}{
+		{
+			name: "successful response with models",
+			response: ModelsSizeResponse{
+				TotalSizeBytes: 5368709120,
+				ModelsCount:    3,
+			},
+			validate: func(t *testing.T, resp *ModelsSizeResponse) {
+				if resp.TotalSizeBytes != 5368709120 {
+					t.Errorf("expected TotalSizeBytes 5368709120, got %d", resp.TotalSizeBytes)
+				}
+				if resp.ModelsCount != 3 {
+					t.Errorf("expected ModelsCount 3, got %d", resp.ModelsCount)
+				}
+			},
+		},
+		{
+			name: "successful response with no models",
+			response: ModelsSizeResponse{
+				TotalSizeBytes: 0,
+				ModelsCount:    0,
+			},
+			validate: func(t *testing.T, resp *ModelsSizeResponse) {
+				if resp.TotalSizeBytes != 0 {
+					t.Errorf("expected TotalSizeBytes 0, got %d", resp.TotalSizeBytes)
+				}
+				if resp.ModelsCount != 0 {
+					t.Errorf("expected ModelsCount 0, got %d", resp.ModelsCount)
+				}
+			},
+		},
+		{
+			name: "server error response",
+			response: testError{
+				message:    "internal server error",
+				statusCode: http.StatusInternalServerError,
+			},
+			wantErr: "internal server error",
+		},
+		{
+			name: "bad request response",
+			response: testError{
+				message:    "bad request",
+				statusCode: http.StatusBadRequest,
+			},
+			wantErr: "bad request",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet {
+					t.Errorf("expected GET method, got %s", r.Method)
+				}
+				if r.URL.Path != "/api/models/size" {
+					t.Errorf("expected /api/models/size path, got %s", r.URL.Path)
+				}
+
+				if errResp, ok := tc.response.(testError); ok {
+					w.WriteHeader(errResp.statusCode)
+					err := json.NewEncoder(w).Encode(map[string]string{
+						"error": errResp.message,
+					})
+					if err != nil {
+						t.Fatal("failed to encode error response:", err)
+					}
+					return
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				if err := json.NewEncoder(w).Encode(tc.response); err != nil {
+					t.Fatalf("failed to encode response: %v", err)
+				}
+			}))
+			defer ts.Close()
+
+			client := NewClient(&url.URL{Scheme: "http", Host: ts.Listener.Addr().String()}, http.DefaultClient)
+			resp, err := client.ModelsSize(t.Context())
+
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("got nil, want error %q", tc.wantErr)
+				}
+				if err.Error() != tc.wantErr {
+					t.Errorf("error message mismatch: got %q, want %q", err.Error(), tc.wantErr)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("got error %q, want nil", err)
+			}
+
+			if tc.validate != nil {
+				tc.validate(t, resp)
+			}
+		})
+	}
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -16,6 +16,7 @@
 - [Generate Embeddings](#generate-embeddings)
 - [List Running Models](#list-running-models)
 - [Version](#version)
+- [List Total Disk Space Used By Models](#list-total-disk-space-used-by-models)
 
 ## Conventions
 
@@ -1865,5 +1866,29 @@ curl http://localhost:11434/api/version
 ```json
 {
   "version": "0.5.1"
+}
+```
+
+## List Total Disk Space Used by Models
+```
+GET /api/models/size
+```
+
+Fetch the actual disk space used by all the models running on your machine as well as a count of the models
+
+### Examples
+
+#### Request
+
+```shell
+curl -sS http://localhost:11434/api/models/size
+```
+
+#### Response
+
+```json
+{
+  "models_count": 0,
+  "total_size_bytes": 0
 }
 ```

--- a/server/routes.go
+++ b/server/routes.go
@@ -1257,6 +1257,22 @@ func (s *Server) ListHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, api.ListResponse{Models: models})
 }
 
+func (s *Server) ModelsSizeHandler(c *gin.Context) {
+
+	manifests, err := Manifests(true)
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	var bytes_size int64
+	for _, m := range manifests {
+		bytes_size += m.Size()
+	}
+
+	c.JSON(http.StatusOK, gin.H{"total_size_bytes": bytes_size, "models_count": len(manifests)})
+}
+
 func (s *Server) CopyHandler(c *gin.Context) {
 	var r api.CopyRequest
 	if err := c.ShouldBindJSON(&r); errors.Is(err, io.EOF) {
@@ -1497,6 +1513,7 @@ func (s *Server) GenerateRoutes(rc *ollama.Registry) (http.Handler, error) {
 	r.GET("/api/tags", s.ListHandler)
 	r.POST("/api/show", s.ShowHandler)
 	r.DELETE("/api/delete", s.DeleteHandler)
+	r.GET("/api/models/size", s.ModelsSizeHandler)
 
 	r.POST("/api/me", s.WhoamiHandler)
 

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -964,3 +964,182 @@ func TestWaitForStream(t *testing.T) {
 		})
 	}
 }
+
+
+func TestModelsSizeHandler(t *testing.T) {
+	t.Setenv("OLLAMA_MODELS", t.TempDir())
+
+	createTestModel := func(t *testing.T, name string) {
+		t.Helper()
+
+		_, digest := createTestFile(t, "ollama-model")
+
+		fn := func(resp api.ProgressResponse) {
+			t.Logf("Status: %s", resp.Status)
+		}
+
+		r := api.CreateRequest{
+			Name:  name,
+			Files: map[string]string{"test.gguf": digest},
+			Parameters: map[string]any{
+				"seed":  42,
+				"top_p": 0.9,
+				"stop":  []string{"foo", "bar"},
+			},
+		}
+
+		modelName := model.ParseName(name)
+
+		baseLayers, err := ggufLayers(digest, fn)
+		if err != nil {
+			t.Fatalf("failed to create model: %v", err)
+		}
+
+		config := &ConfigV2{
+			OS:           "linux",
+			Architecture: "amd64",
+			RootFS: RootFS{
+				Type: "layers",
+			},
+		}
+
+		if err := createModel(r, modelName, baseLayers, config, fn); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	testCases := []struct {
+		Name     string
+		Setup    func(t *testing.T)
+		Expected func(t *testing.T, resp *http.Response)
+	}{
+		{
+			Name:  "Models Size Handler (no models)",
+			Setup: func(t *testing.T) {},
+			Expected: func(t *testing.T, resp *http.Response) {
+				if resp.StatusCode != http.StatusOK {
+					t.Errorf("expected status 200, got %d", resp.StatusCode)
+				}
+
+				contentType := resp.Header.Get("Content-Type")
+				if contentType != "application/json; charset=utf-8" {
+					t.Errorf("expected content type application/json; charset=utf-8, got %s", contentType)
+				}
+
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					t.Fatalf("failed to read response body: %v", err)
+				}
+
+				var result map[string]interface{}
+				err = json.Unmarshal(body, &result)
+				if err != nil {
+					t.Fatalf("failed to unmarshal response body: %v", err)
+				}
+
+				totalSizeBytes := result["total_size_bytes"]
+				modelsCount := result["models_count"]
+
+				if totalSizeBytes == nil {
+					t.Errorf("expected total_size_bytes in response")
+				}
+
+				if modelsCount == nil {
+					t.Errorf("expected models_count in response")
+				}
+
+				if int(modelsCount.(float64)) != 0 {
+					t.Errorf("expected 0 models, got %v", modelsCount)
+				}
+
+				if int64(totalSizeBytes.(float64)) != 0 {
+					t.Errorf("expected 0 bytes, got %v", totalSizeBytes)
+				}
+			},
+		},
+		{
+			Name: "Models Size Handler (with models)",
+			Setup: func(t *testing.T) {
+				createTestModel(t, "test-model-1")
+				createTestModel(t, "test-model-2")
+			},
+			Expected: func(t *testing.T, resp *http.Response) {
+				if resp.StatusCode != http.StatusOK {
+					t.Errorf("expected status 200, got %d", resp.StatusCode)
+				}
+
+				contentType := resp.Header.Get("Content-Type")
+				if contentType != "application/json; charset=utf-8" {
+					t.Errorf("expected content type application/json; charset=utf-8, got %s", contentType)
+				}
+
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					t.Fatalf("failed to read response body: %v", err)
+				}
+
+				var result map[string]interface{}
+				err = json.Unmarshal(body, &result)
+				if err != nil {
+					t.Fatalf("failed to unmarshal response body: %v", err)
+				}
+
+				totalSizeBytes := result["total_size_bytes"]
+				modelsCount := result["models_count"]
+
+				if totalSizeBytes == nil {
+					t.Errorf("expected total_size_bytes in response")
+				}
+
+				if modelsCount == nil {
+					t.Errorf("expected models_count in response")
+				}
+
+				if int(modelsCount.(float64)) != 2 {
+					t.Errorf("expected 2 models, got %v", modelsCount)
+				}
+
+				if int64(totalSizeBytes.(float64)) <= 0 {
+					t.Errorf("expected positive total_size_bytes, got %v", totalSizeBytes)
+				}
+			},
+		},
+	}
+
+	rc := &ollama.Registry{
+		HTTPClient: panicOnRoundTrip,
+	}
+
+	s := &Server{}
+	router, err := s.GenerateRoutes(rc)
+	if err != nil {
+		t.Fatalf("failed to generate routes: %v", err)
+	}
+
+	httpSrv := httptest.NewServer(router)
+	t.Cleanup(httpSrv.Close)
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			if tc.Setup != nil {
+				tc.Setup(t)
+			}
+
+			u := httpSrv.URL + "/api/models/size"
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, u, nil)
+			if err != nil {
+				t.Fatalf("failed to create request: %v", err)
+			}
+
+			resp, err := httpSrv.Client().Do(req)
+			if err != nil {
+				t.Fatalf("failed to do request: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if tc.Expected != nil {
+				tc.Expected(t, resp)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
Adds a new `/api/models/size` endpoint that returns the total disk space used by all downloaded models.

## Motivation
Users often need to quickly check how much storage their Ollama models are consuming without parsing the full model list. This endpoint provides a simple way to get total storage metrics.

## Changes
- Added `ModelsStorageHandler` server handler
- Registered new GET endpoint at `/api/models/size`
- Returns JSON with `total_size_bytes` and `models_count`
- Added unit tests
- Updated API documentation

## Testing
- [x] Manual testing with local endpoint
- [x] Unit tests pass (`go test ./server/...`)
- [x] Documentation updated

## Example Response
```json
{
  "total_size_bytes": 4661229568,
  "models_count": 3
}
```