### PR TITLE
routes: fix missing logprobs in tool calls

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -2186,7 +2186,7 @@ func (s *Server) ChatHandler(c *gin.Context) {
 						return
 					}
 
-					if res.Message.Content != "" || res.Message.Thinking != "" || len(res.Message.ToolCalls) > 0 || r.Done {
+					if res.Message.Content != "" || res.Message.Thinking != "" || len(res.Message.ToolCalls) > 0 || r.Done || len(res.Logprobs) > 0 {
 						slog.Log(context.TODO(), logutil.LevelTrace, "builtin parser output", "parser", m.Config.Parser, "content", content, "thinking", thinking, "toolCalls", toolCalls, "done", r.Done)
 						ch <- res
 					} else {
@@ -2226,8 +2226,16 @@ func (s *Server) ChatHandler(c *gin.Context) {
 						res.Message.ToolCalls = toolCalls
 						res.Message.Content = ""
 					} else if res.Message.Thinking != "" {
-						// don't return
+						// don't return, fall through to send
 					} else {
+						//  Send logprobs while content is being buffered by the parser for tool calls
+						if len(res.Logprobs) > 0 && !r.Done {
+							logprobRes := res
+							logprobRes.Message.Content = ""
+							logprobRes.Message.ToolCalls = nil
+							ch <- logprobRes
+						}
+
 						if r.Done {
 							res.Message.Content = toolParser.Content()
 							ch <- res


### PR DESCRIPTION
### Summary
Fixes #13092.

This PR ensures that `logprobs` are correctly returned when the model generates tool calls.

### Problem
Previously, when `toolParser` or `builtinParser` buffered content to parse JSON tool calls, the intermediate chunks containing `logprobs` were dropped because the content was temporarily empty.

### Solution
Modified `server/routes.go` (`ChatHandler`) to explicitly forward chunks containing only `logprobs` when the parser is active and buffering content.

### Test
Tested with `llama3.1` (toolParser). (On Windows)
```Powershell
$body = @{
    model = "llama3.1"
    messages = @(@{ role = "user"; content = "What is the weather in Taipei?" })
    tools = @(@{
        type = "function"
        function = @{
            name = "get_current_weather"
            description = "Get the current weather"
            parameters = @{
                type = "object"
                properties = @{ location = @{ type = "string" } }
                required = @("location")
            }
        }
    })
    options = @{ temperature = 0 }
    logprobs = $true
    stream = $false
} | ConvertTo-Json -Depth 10

$response = Invoke-RestMethod -Uri "http://localhost:11434/api/chat" -Method Post -Body $body -ContentType "application/json"
Write-Host "------------------------------------------------"
Write-Host "Model generated Token num (Eval Count): " $response.eval_count
Write-Host "Received Logprobs num: " $response.logprobs.Count
Write-Host "------------------------------------------------"
```

**Before:**
```bash
------------------------------------------------
Model generated Token num (Eval Count):  19
Received Logprobs num: 1
------------------------------------------------
```
**After:**
```bash
------------------------------------------------
Model generated Token num (Eval Count):  19
Received Logprobs num: 18
------------------------------------------------
```
Note to assignees: I noticed this issue was assigned to @ParthSareen and @jmorganca, but since I encountered this problem and found a fix, I went ahead and submitted this PR. Hope this helps!