### PR TITLE
ollama/ollama: adding Arize to Read.me

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,12 +636,14 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [llama.cpp](https://github.com/ggml-org/llama.cpp) project founded by Georgi Gerganov.
 
 ### Observability
+- [Arize AX](https://arize.com/docs/ax/integrations/llm-providers/llama/ollama-tracing) is an AI engineering platform that helps teams trace, evaluate and observe agents and LLM apps. Arize AX supports Ollama.
 - [Opik](https://www.comet.com/docs/opik/cookbook/ollama) is an open-source platform to debug, evaluate, and monitor your LLM applications, RAG systems, and agentic workflows with comprehensive tracing, automated evaluations, and production-ready dashboards. Opik supports native integration to Ollama.
 - [Lunary](https://lunary.ai/docs/integrations/ollama) is the leading open-source LLM observability platform. It provides a variety of enterprise-grade features such as real-time analytics, prompt templates management, PII masking, and comprehensive agent tracing.
 - [OpenLIT](https://github.com/openlit/openlit) is an OpenTelemetry-native tool for monitoring Ollama Applications & GPUs using traces and metrics.
 - [HoneyHive](https://docs.honeyhive.ai/integrations/ollama) is an AI observability and evaluation platform for AI agents. Use HoneyHive to evaluate agent performance, interrogate failures, and monitor quality in production.
 - [Langfuse](https://langfuse.com/docs/integrations/ollama) is an open source LLM observability platform that enables teams to collaboratively monitor, evaluate and debug AI applications.
 - [MLflow Tracing](https://mlflow.org/docs/latest/llms/tracing/index.html#automatic-tracing) is an open source LLM observability tool with a convenient API to log and visualize traces, making it easy to debug and evaluate GenAI applications.
+- [Arize Phoenix](https://arize.com/docs/phoenix/release-notes/06.2025/06.04.2025-ollama-support-in-playground) is an open source LLM evaluation and testing platform that offers playground support for Ollama.
 
 ### Security
 - [Ollama Fortress](https://github.com/ParisNeo/ollama_proxy_server)


### PR DESCRIPTION
Adds links to docs examples for Arize AX (free) and Arize Phoenix (open source) under observability