### PR TITLE
conf: support human-readable context length format

### DIFF
--- a/docs/context-length.mdx
+++ b/docs/context-length.mdx
@@ -27,6 +27,11 @@ If editing the context length for Ollama is not possible, the context length can
 OLLAMA_CONTEXT_LENGTH=32000 ollama serve
 ```
 
+k/m/K/M in human-readable format is supported. (k = 1000, K = 1024)
+```
+OLLAMA_CONTEXT_LENGTH=32k ollama serve
+```
+
 ### Check allocated context length and model offloading
 For best performance, use the maximum context length for a model, and avoid offloading the model to CPU. Verify the split under `PROCESSOR` using `ollama ps`.
 ```

--- a/envconfig/config_test.go
+++ b/envconfig/config_test.go
@@ -282,8 +282,19 @@ func TestVar(t *testing.T) {
 
 func TestContextLength(t *testing.T) {
 	cases := map[string]uint{
-		"":     4096,
-		"2048": 2048,
+		"":        4096,
+		"2048":    2048,
+		"8192":    8192,
+		"8k":      8000,
+		"8K":      8192,
+		"16k":     16000,
+		"16K":     16384,
+		"1.5k":    4096,
+		"25.6k":   4096,
+		"1g":      4096,
+		"1G":      4096,
+		"invalid": 4096,
+		"xk":      4096,
 	}
 
 	for k, v := range cases {


### PR DESCRIPTION
before:
```shell
(base) ➜  ollama git:(main) OLLAMA_CONTEXT_LENGTH=8k ./ollama serve
2025/11/26 14:48:39 config.go:232: WARN invalid environment variable, using default key=OLLAMA_CONTEXT_LENGTH value=8k default=4096

(base) ➜  ollama git:(main) ./ollama ps
NAME                  ID              SIZE      PROCESSOR    CONTEXT    UNTIL
qwen2.5-coder:1.5b    6d3abb8d2d53    1.1 GB    100% CPU     4096       4 minutes from now
```
after:
```shell
(base) ➜  ollama git:(readable-ctx-len) OLLAMA_CONTEXT_LENGTH=8k ./ollama serve

NAME                  ID              SIZE      PROCESSOR    CONTEXT    UNTIL
qwen2.5-coder:1.5b    6d3abb8d2d53    1.2 GB    100% CPU     8000       4 minutes from now
```