### PR TITLE
model: fix unused result in BenchmarkBytePairEncoding

### DIFF
--- a/model/bytepairencoding_test.go
+++ b/model/bytepairencoding_test.go
@@ -277,7 +277,7 @@ func BenchmarkBytePairEncoding(b *testing.B) {
 		b.Run("split"+strconv.Itoa(n), func(b *testing.B) {
 			b.ResetTimer()
 			for b.Loop() {
-				slices.Collect(tokenizer.split(string(bts)))
+				_ = slices.Collect(tokenizer.split(string(bts)))
 			}
 		})
 	}


### PR DESCRIPTION
`go vet` reported a "result of slices.Collect call not used" warning in `model/bytepairencoding_test.go`.

Since this is a benchmark ensuring the iterator is fully consumed and collected, I've assigned the result to the blank identifier `_` to silence the linter while preserving the benchmark's behavior.

```
# Before Fix:
[uzqw@uzqw-lenovo25 ollama]$ go version
go version go1.25.1 X:nodwarf5 linux/amd64
[uzqw@uzqw-lenovo25 ollama]$ go vet ./model/...
# github.com/ollama/ollama/model
# [github.com/ollama/ollama/model]
model/bytepairencoding_test.go:280:5: result of slices.Collect call not used

# After Fix:
[uzqw@uzqw-lenovo25 ollama]$ go vet ./model/...
[uzqw@uzqw-lenovo25 ollama]$ 

```