### PR TITLE
cmd/bench: support writing benchmark output to file

### DIFF
--- a/cmd/bench/bench.go
+++ b/cmd/bench/bench.go
@@ -149,7 +149,7 @@ func BenchmarkChat(fOpt flagOptions) error {
 
 	var out io.Writer = os.Stdout
 	if fOpt.outputFile != nil && *fOpt.outputFile != "" {
-		f, err := os.OpenFile(*fOpt.outputFile, os.O_CREATE|os.O_WRONLY, 0644)
+		f, err := os.OpenFile(*fOpt.outputFile, os.O_CREATE|os.O_WRONLY, 0o644)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "ERROR: cannot open output file %s: %v\n", *fOpt.outputFile, err)
 			return err


### PR DESCRIPTION
This changes Ollama to allow the bench command to write benchmark results to a user-specified output file instead of stdout when the --output flag is provided.