### PR TITLE
fix(api): correct Content-Type header for /api/chat and /api/generate when using cloud models

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -262,9 +262,9 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 			slog.Warn("embedded messages in the model not supported with '/api/generate'; try '/api/chat' instead")
 		}
 
-		contentType := "application/json; charset=utf-8"
-		if req.Stream != nil && *req.Stream {
-			contentType = "application/x-ndjson"
+		contentType := "application/x-ndjson"
+		if req.Stream != nil && !*req.Stream {
+			contentType = "application/json; charset=utf-8"
 		}
 		c.Header("Content-Type", contentType)
 
@@ -1939,9 +1939,9 @@ func (s *Server) ChatHandler(c *gin.Context) {
 			}
 		}
 
-		contentType := "application/json; charset=utf-8"
-		if req.Stream != nil && *req.Stream {
-			contentType = "application/x-ndjson"
+		contentType := "application/x-ndjson"
+		if req.Stream != nil && !*req.Stream {
+			contentType = "application/json; charset=utf-8"
 		}
 		c.Header("Content-Type", contentType)
 


### PR DESCRIPTION
Problem:
When using cloud models, the Content-Type header was not properly set, even though the code at line 1983 (now 1948) attempted to set it.

Cause:
Execution order was the issue:
At line 1968, client.Chat(c, &req, fn) is called.
Inside client.Chat, the callback fn (at line 1950) calls c.Writer.Write() (line 1960) to write data.
On the first Write(), Gin sends HTTP headers if they haven’t been sent yet.

At line 1987, there is an attempt to set the header after data was written — too late.
HTTP headers must be set before the response body is written; after that, headers cannot be changed.
Additionally, if client.Chat returns an error (lines 1976, 1980, 1985, 1988), the header was never set.

Solution:
The header is now set before calling client.Chat (lines 1942–1948), ensuring:
The header is set before writing data.
The header is set regardless of success.
Duplicate code that ran after writing data was removed.

Closes #13258