### PR TITLE
win: warn if ggml-base detected in PATH

### DIFF
--- a/discover/runner.go
+++ b/discover/runner.go
@@ -65,6 +65,7 @@ func GPUDevices(ctx context.Context, runners []ml.FilteredRunnerDiscovery) []ml.
 		}
 
 		slog.Info("discovering available GPUs...")
+		detectIncompatibleLibraries()
 
 		// Warn if any user-overrides are set which could lead to incorrect GPU discovery
 		overrideWarnings()
@@ -485,5 +486,18 @@ func overrideWarnings() {
 	}
 	if anyFound {
 		slog.Warn("if GPUs are not correctly discovered, unset and try again")
+	}
+}
+
+func detectIncompatibleLibraries() {
+	if runtime.GOOS != "windows" {
+		return
+	}
+	basePath, err := exec.LookPath("ggml-base.dll")
+	if err != nil || basePath == "" {
+		return
+	}
+	if !strings.HasPrefix(basePath, ml.LibOllamaPath) {
+		slog.Warn("potentially incompatible library detected in PATH", "location", basePath)
 	}
 }


### PR DESCRIPTION
If the user has somehow installed another GGML based app which places a ggml-base lib somewhere in their PATH, we can experience runtime problems due to incompatibilities.  This change adds a warning message if we detect a ggml-base outside of our install location to aid in troubleshooting.

Example:  (manually copied the library to `c:\Windows`)
```
time=2025-12-01T13:07:07.764-08:00 level=INFO source=runner.go:67 msg="discovering available GPUs..."
time=2025-12-01T13:07:07.769-08:00 level=WARN source=runner.go:501 msg="potentially incompatible library detected in PATH" location=C:\WINDOWS\ggml-base.dll
```

Fixes #12618 