### PR TITLE
all: restore previous rules in golangci-lint behavior while keeping v2

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,76 +1,51 @@
 version: "2"
 linters:
-  default: none
   enable:
     - asasalint
     - bidichk
     - bodyclose
     - containedctx
-    - copyloopvar
-    - errcheck
-    - errorlint
-    - exptostd
     - gocheckcompilerdirectives
-    - govet
-    - ineffassign
     - intrange
     - makezero
     - misspell
-    - modernize
     - nilerr
-    - nilnil
     - nolintlint
     - nosprintfhostport
-    - perfsprint
-    - prealloc
-    - sloglint
-    - staticcheck
     - unconvert
-    - unused
-    - usestdlibvars
     - usetesting
     - wastedassign
     - whitespace
+  disable:
+    - errcheck
+    - usestdlibvars
   settings:
-    errcheck:
-      exclude-functions:
-        - fmt.Fprintf
-    perfsprint:
-      strconcat: false
-      concat-loop: false
+    govet:
+      disable:
+        - unusedresult
     staticcheck:
       checks:
         - all
-        # Using a deprecated function, variable, constant or field.
-        # https://staticcheck.dev/docs/checks/#SA1019
+        - -QF* # disable quick fix suggestions
         - -SA1019
-        # Incorrect or missing package comment.
-        # https://staticcheck.dev/docs/checks/#ST1000
-        - -ST1000
-        # Poorly chosen identifier.
-        # https://staticcheck.dev/docs/checks/#ST1003
-        - -ST1003
-        # The documentation of an exported function should start with the function's name.
-        # https://staticcheck.dev/docs/checks/#ST1020
-        - -ST1020
-        # The documentation of an exported type should start with type's name.
-        # https://staticcheck.dev/docs/checks/#ST1021
-        - -ST1021
-        # The documentation of an exported variable or constant should start with variable's name.
-        # https://staticcheck.dev/docs/checks/#ST1022
-        - -ST1022
-    usestdlibvars:
-      http-method: false
-      http-status-code: false
-
+        - -ST1000 # package comment format
+        - -ST1003 # underscores in package names
+        - -ST1005 # error strings should not be capitalized
+        - -ST1012 # error var naming (ErrFoo)
+        - -ST1016 # receiver name consistency
+        - -ST1020 # comment on exported function format
+        - -ST1021 # comment on exported type format
+        - -ST1022 # comment on exported var format
+        - -ST1023 # omit type from declaration
+severity:
+  default: error
+  rules:
+    - linters:
+        - gofmt
+        - goimports
+        - intrange
+      severity: info
 formatters:
   enable:
-    - gci
     - gofmt
     - gofumpt
-  settings:
-    gci:
-      sections:
-        - standard
-        - default
-        - localmodule

--- a/api/examples/chat/main.go
+++ b/api/examples/chat/main.go
@@ -15,19 +15,19 @@ func main() {
 	}
 
 	messages := []api.Message{
-		api.Message{
+		{
 			Role:    "system",
 			Content: "Provide very brief, concise responses",
 		},
-		api.Message{
+		{
 			Role:    "user",
 			Content: "Name some unusual animals",
 		},
-		api.Message{
+		{
 			Role:    "assistant",
 			Content: "Monotreme, platypus, echidna",
 		},
-		api.Message{
+		{
 			Role:    "user",
 			Content: "which of these is the most dangerous?",
 		},


### PR DESCRIPTION
A few new PRs are getting stuck on the new lint rules. While good, we should run them on the existing code before adding to CI since it's easy to make a small modification then be responsible for a much larger change