### PR TITLE
cmd: preserve relative paths for files and adapters in CreateHandler

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -147,10 +147,7 @@ func CreateHandler(cmd *cobra.Command, args []string) error {
 				return err
 			}
 
-			// TODO: this is incorrect since the file might be in a subdirectory
-			//       instead this should take the path relative to the model directory
-			//       but the current implementation does not allow this
-			files.Store(filepath.Base(f), digest)
+			files.Store(f, digest)
 			return nil
 		})
 	}
@@ -162,8 +159,7 @@ func CreateHandler(cmd *cobra.Command, args []string) error {
 				return err
 			}
 
-			// TODO: same here
-			adapters.Store(filepath.Base(f), digest)
+			adapters.Store(f, digest)
 			return nil
 		})
 	}


### PR DESCRIPTION
Summary:

- Fixes file path handling in `CreateHandler` that was incorrectly using `filepath.Base()`
- This caused files in subdirectories with the same name to overwrite each other in the map
- Removes the TODO comments that documented this known issue

Problem:

When creating a model with files in different subdirectories that have the same filename:

MODEL models/lora/adapter.safetensors
MODEL models/lora2/adapter.safetensors

The second entry would overwrite the first because `filepath.Base()` stripped the directory path, leaving only `adapter.safetensors` as the key for both.

Solution:

Preserve the full relative path instead of extracting just the filename.
The server already expects and validates relative paths via `fs.ValidPath()`.

Fixes #10333