### PR TITLE
CORS: allow all headers

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -1453,28 +1453,7 @@ func (s *Server) GenerateRoutes(rc *ollama.Registry) (http.Handler, error) {
 	corsConfig := cors.DefaultConfig()
 	corsConfig.AllowWildcard = true
 	corsConfig.AllowBrowserExtensions = true
-	corsConfig.AllowHeaders = []string{
-		"Authorization",
-		"Content-Type",
-		"User-Agent",
-		"Accept",
-		"X-Requested-With",
-
-		// OpenAI compatibility headers
-		"OpenAI-Beta",
-		"x-stainless-arch",
-		"x-stainless-async",
-		"x-stainless-custom-poll-interval",
-		"x-stainless-helper-method",
-		"x-stainless-lang",
-		"x-stainless-os",
-		"x-stainless-package-version",
-		"x-stainless-poll-helper",
-		"x-stainless-retry-count",
-		"x-stainless-runtime",
-		"x-stainless-runtime-version",
-		"x-stainless-timeout",
-	}
+	corsConfig.AllowAllHeaders = true
 	corsConfig.AllowOrigins = envconfig.AllowedOrigins()
 
 	r := gin.Default()


### PR DESCRIPTION
Chasing after CORS headers (eg https://github.com/ollama/ollama/pull/10276 ) is a cat and mouse game, and security theater. Virtually all public OpenAI-compatible API's I've tested (OpenRouter, xAI, OpenRouter... even OpenAI itself!) allow all CORS headers

My usecase is that I want to pass OpenRouter's [App Attribution headers](https://openrouter.ai/docs/app-attribution) (X-Title and HTTP-Referer) without a conditional. I have 12 different AI providers configured and **all** of them work except for ollama. Therefore, I conclude Ollama does not correctly implement an OpenAI-compatible API unless it accepts all headers.