### PR TITLE
Fix broken Swollama links after repository transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,7 +555,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Parakeet](https://github.com/parakeet-nest/parakeet) is a GoLang library, made to simplify the development of small generative AI applications with Ollama.
 - [Haverscript](https://github.com/andygill/haverscript) with [examples](https://github.com/andygill/haverscript/tree/main/examples)
 - [Ollama for Swift](https://github.com/mattt/ollama-swift)
-- [Swollama for Swift](https://github.com/marcusziade/Swollama) with [DocC](https://marcusziade.github.io/Swollama/documentation/swollama/)
+- [Swollama for Swift]([https://github.com/marcusziade/Swollama](https://github.com/guitaripod/Swollama) with [DocC]( https://guitaripod.github.io/Swollama/documentation/swollama)
 - [GoLamify](https://github.com/prasad89/golamify)
 - [Ollama for Haskell](https://github.com/tusharad/ollama-haskell)
 - [multi-llm-ts](https://github.com/nbonamy/multi-llm-ts) (A Typescript/JavaScript library allowing access to different LLM in a unified API)


### PR DESCRIPTION
Fix broken Swollama links after repository transfer

The Swollama repository was transferred from marcusziade to guitaripod. While GitHub auto-redirects the repo URL, the GitHub Pages documentation link is broken and needs to be updated manually.

Changes:
- Update repo link: marcusziade/Swollama → guitaripod/Swollama
- Update docs link: marcusziade.github.io → guitaripod.github.io

The repository link still works due to GitHub's automatic redirect, but updating it prevents confusion and ensures future link stability. The documentation link returns 404 and needs to be updated.