### PR TITLE
test: fix timouts on embedding tests

### DIFF
--- a/integration/embed_test.go
+++ b/integration/embed_test.go
@@ -73,7 +73,7 @@ func manhattanDistance[V float32 | float64](v1, v2 []V) V {
 }
 
 func TestEmbedCosineDistanceCorrelation(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
 	defer cancel()
 	client, _, cleanup := InitServerConnection(ctx, t)
 	defer cleanup()

--- a/integration/utils_test.go
+++ b/integration/utils_test.go
@@ -250,7 +250,6 @@ var (
 		"zephyr",
 	}
 	libraryEmbedModels = []string{
-		"qwen3-embedding",
 		"embeddinggemma",
 		"nomic-embed-text",
 		"all-minilm",
@@ -261,6 +260,7 @@ var (
 		"paraphrase-multilingual",
 		"snowflake-arctic-embed",
 		"snowflake-arctic-embed2",
+		"qwen3-embedding",
 	}
 	libraryToolsModels = []string{
 		"qwen3-vl",


### PR DESCRIPTION
On smaller VRAM systems, qwen3-embedding takes a long time.  This moves it to the end of the list after the smaller embedding models, and increases the timeout.