### PR TITLE
fix: ollama launchAgent plist

### DIFF
--- a/app/cmd/squirrel/Info.plist
+++ b/app/cmd/squirrel/Info.plist
@@ -5,15 +5,15 @@
     <key>CFBundleDevelopmentRegion</key>
     <string>English</string>
     <key>CFBundleExecutable</key>
-    <string>Squirrel</string>
+    <string>Ollama</string>
     <key>CFBundleIconFile</key>
     <string/>
     <key>CFBundleIdentifier</key>
-    <string>com.github.Squirrel</string>
+    <string>ai.ollama.ollama</string>
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string>
     <key>CFBundleName</key>
-    <string>Squirrel</string>
+    <string>Ollama</string>
     <key>CFBundlePackageType</key>
     <string>FMWK</string>
     <key>CFBundleShortVersionString</key>


### PR DESCRIPTION
This PR resolved https://github.com/ollama/ollama/issues/12778

This PR changed couple things in the `Info.plist` to ensure that the information is displayed correctly in the system settings.
- CFBundleIdentifier: ai.ollama.ollama (Ollama's proper identifier)
- CFBundleName: Ollama
- CFBundleExecutable: Ollama 
