### PR TITLE
ggml: fix mem_hip reporting zero GPU memory on AMD APUs (MI300A)

### DIFF
--- a/ml/backend/ggml/ggml/src/mem_hip.cpp
+++ b/ml/backend/ggml/ggml/src/mem_hip.cpp
@@ -461,6 +461,8 @@ int ggml_hip_get_device_memory(const char *id, size_t *free, size_t *total) {
     const std::string drmTotalMemoryFile = "mem_info_vram_total";
     const std::string drmUsedMemoryFile = "mem_info_vram_used";
     const std::string drmUeventPCISlotLabel = "PCI_SLOT_NAME=";
+    const std::string drmGttTotalMemoryFile = "mem_info_gtt_total";
+    const std::string drmGttUsedMemoryFile = "mem_info_gtt_used";
 
     glob_t glob_result;
     glob(drmDeviceGlob.c_str(), GLOB_NOSORT, NULL, &glob_result);
@@ -497,7 +499,29 @@ int ggml_hip_get_device_memory(const char *id, size_t *free, size_t *total) {
                     totalFileStream >> memory;
                     *total = memory;
 
-                    std::string usedFile = dir + "/" + drmUsedMemoryFile;
+                    // AMD APUs report zero VRAM due to unified CPU/GPU memory
+                    // GPU-accessible memory is exposed via GTT
+                    if (memory == 0) {
+                        std::string gttTotalFile = dir + "/" + drmGttTotalMemoryFile;
+                        std::ifstream gttTotalFileStream(gttTotalFile.c_str());
+                        if (!gttTotalFileStream.is_open()) {
+                            GGML_LOG_DEBUG("%s Failed to read sysfs node %s\n", __func__, gttTotalFile.c_str());
+                            file.close();
+                            globfree(&glob_result);
+                            return 1;
+                        }
+
+                        gttTotalFileStream >> memory;
+                        *total = memory;
+                    }
+
+                    std::string usedFile;
+                    if (*total == 0) {
+                        usedFile = dir + "/" + drmGttUsedMemoryFile;
+                    } else {
+                        usedFile = dir + "/" + drmUsedMemoryFile;
+                    }
+
                     std::ifstream usedFileStream(usedFile.c_str());
                     if (!usedFileStream.is_open()) {
                         GGML_LOG_DEBUG("%s Failed to read sysfs node %s\n", __func__, usedFile.c_str());


### PR DESCRIPTION
AMD APUs (e.g. MI300A) use unified CPU/GPU memory and therefore report zero VRAM.

This regression affects MI300A starting in v0.13.0. (v0.12.11 works fine). As a result the MI300A GPU can't be used with newer ollama versions as reported in issue #8735.

The issue is caused by relying on `mem_info_vram_total` to determine total GPU memory. On AMD APUs such as MI300A GPU-accessible memory is only exposed via GTT (`mem_info_gtt_total`), which represents the unified memory pool available to the GPU.

This PR updates `mem_hip` to take this into account.

Tested on MI300A.

Fixes #8735