### PR TITLE
feat: prevent system sleep while Ollama is processing requests

### DIFF
--- a/server/power.go
+++ b/server/power.go
@@ -1,0 +1,57 @@
+package server
+
+import (
+	"log/slog"
+	"sync"
+)
+
+// PowerManager prevents the system from sleeping while Ollama has active runners.
+// This is useful for long-running inference tasks that would be interrupted by sleep.
+type PowerManager struct {
+	mu       sync.Mutex
+	refCount int
+	active   bool
+}
+
+var globalPowerManager = &PowerManager{}
+
+// PreventSleep increments the reference count and prevents system sleep if not already prevented.
+// Call AllowSleep when the work is done.
+func (pm *PowerManager) PreventSleep() {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	pm.refCount++
+	if pm.refCount == 1 && !pm.active {
+		if err := platformPreventSleep(); err != nil {
+			slog.Debug("failed to prevent system sleep", "error", err)
+		} else {
+			pm.active = true
+			slog.Debug("system sleep prevented")
+		}
+	}
+}
+
+// AllowSleep decrements the reference count and allows system sleep when count reaches zero.
+func (pm *PowerManager) AllowSleep() {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	if pm.refCount > 0 {
+		pm.refCount--
+	}
+
+	if pm.refCount == 0 && pm.active {
+		if err := platformAllowSleep(); err != nil {
+			slog.Debug("failed to allow system sleep", "error", err)
+		} else {
+			pm.active = false
+			slog.Debug("system sleep allowed")
+		}
+	}
+}
+
+// GetPowerManager returns the global power manager instance.
+func GetPowerManager() *PowerManager {
+	return globalPowerManager
+}

--- a/server/power_darwin.go
+++ b/server/power_darwin.go
@@ -1,0 +1,57 @@
+//go:build darwin
+
+package server
+
+/*
+#cgo LDFLAGS: -framework IOKit -framework CoreFoundation
+#include <IOKit/pwr_mgt/IOPMLib.h>
+#include <CoreFoundation/CoreFoundation.h>
+
+static IOPMAssertionID assertionID = 0;
+
+int preventSleep() {
+    if (assertionID != 0) {
+        return 0; // Already preventing sleep
+    }
+
+    CFStringRef reasonForActivity = CFSTR("Ollama is processing requests");
+    IOReturn result = IOPMAssertionCreateWithName(
+        kIOPMAssertionTypeNoIdleSleep,
+        kIOPMAssertionLevelOn,
+        reasonForActivity,
+        &assertionID
+    );
+
+    return (result == kIOReturnSuccess) ? 0 : -1;
+}
+
+int allowSleep() {
+    if (assertionID == 0) {
+        return 0; // Not currently preventing sleep
+    }
+
+    IOReturn result = IOPMAssertionRelease(assertionID);
+    if (result == kIOReturnSuccess) {
+        assertionID = 0;
+        return 0;
+    }
+    return -1;
+}
+*/
+import "C"
+
+import "errors"
+
+func platformPreventSleep() error {
+	if C.preventSleep() != 0 {
+		return errors.New("failed to create IOPMAssertion")
+	}
+	return nil
+}
+
+func platformAllowSleep() error {
+	if C.allowSleep() != 0 {
+		return errors.New("failed to release IOPMAssertion")
+	}
+	return nil
+}

--- a/server/power_linux.go
+++ b/server/power_linux.go
@@ -1,0 +1,70 @@
+//go:build linux
+
+package server
+
+import (
+	"errors"
+	"log/slog"
+	"os"
+	"os/exec"
+	"sync"
+)
+
+var (
+	inhibitMu   sync.Mutex
+	inhibitProc *os.Process
+)
+
+// platformPreventSleep uses systemd-inhibit to prevent system sleep on Linux.
+// This works on systems with systemd (most modern Linux distributions).
+func platformPreventSleep() error {
+	inhibitMu.Lock()
+	defer inhibitMu.Unlock()
+
+	if inhibitProc != nil {
+		return nil // Already inhibiting
+	}
+
+	// Check if systemd-inhibit is available
+	path, err := exec.LookPath("systemd-inhibit")
+	if err != nil {
+		slog.Debug("systemd-inhibit not available, sleep prevention not supported on this system")
+		return nil // Not an error, just not supported
+	}
+
+	// Start systemd-inhibit with a blocking command (cat without input will block forever)
+	// The inhibit lock is held as long as this process runs
+	cmd := exec.Command(path,
+		"--what=idle:sleep",
+		"--who=ollama",
+		"--why=Ollama is processing requests",
+		"--mode=block",
+		"cat",
+	)
+
+	if err := cmd.Start(); err != nil {
+		return errors.New("failed to start systemd-inhibit: " + err.Error())
+	}
+
+	inhibitProc = cmd.Process
+	return nil
+}
+
+// platformAllowSleep stops the systemd-inhibit process, allowing system sleep.
+func platformAllowSleep() error {
+	inhibitMu.Lock()
+	defer inhibitMu.Unlock()
+
+	if inhibitProc == nil {
+		return nil // Not currently inhibiting
+	}
+
+	if err := inhibitProc.Kill(); err != nil {
+		return errors.New("failed to stop systemd-inhibit: " + err.Error())
+	}
+
+	// Wait for the process to exit to avoid zombies
+	_, _ = inhibitProc.Wait()
+	inhibitProc = nil
+	return nil
+}

--- a/server/power_other.go
+++ b/server/power_other.go
@@ -1,0 +1,13 @@
+//go:build !windows && !darwin && !linux
+
+package server
+
+// platformPreventSleep is a no-op on unsupported platforms.
+func platformPreventSleep() error {
+	return nil
+}
+
+// platformAllowSleep is a no-op on unsupported platforms.
+func platformAllowSleep() error {
+	return nil
+}

--- a/server/power_test.go
+++ b/server/power_test.go
@@ -1,0 +1,53 @@
+package server
+
+import (
+	"testing"
+)
+
+func TestPowerManagerRefCount(t *testing.T) {
+	pm := &PowerManager{}
+
+	// Initial state
+	if pm.refCount != 0 {
+		t.Errorf("expected refCount to be 0, got %d", pm.refCount)
+	}
+
+	// First PreventSleep should increment refCount
+	pm.PreventSleep()
+	if pm.refCount != 1 {
+		t.Errorf("expected refCount to be 1, got %d", pm.refCount)
+	}
+
+	// Second PreventSleep should increment refCount
+	pm.PreventSleep()
+	if pm.refCount != 2 {
+		t.Errorf("expected refCount to be 2, got %d", pm.refCount)
+	}
+
+	// First AllowSleep should decrement refCount
+	pm.AllowSleep()
+	if pm.refCount != 1 {
+		t.Errorf("expected refCount to be 1, got %d", pm.refCount)
+	}
+
+	// Second AllowSleep should decrement refCount to 0
+	pm.AllowSleep()
+	if pm.refCount != 0 {
+		t.Errorf("expected refCount to be 0, got %d", pm.refCount)
+	}
+
+	// Extra AllowSleep should not go negative
+	pm.AllowSleep()
+	if pm.refCount != 0 {
+		t.Errorf("expected refCount to stay at 0, got %d", pm.refCount)
+	}
+}
+
+func TestGetPowerManager(t *testing.T) {
+	pm1 := GetPowerManager()
+	pm2 := GetPowerManager()
+
+	if pm1 != pm2 {
+		t.Error("expected GetPowerManager to return the same instance")
+	}
+}

--- a/server/power_windows.go
+++ b/server/power_windows.go
@@ -1,0 +1,37 @@
+//go:build windows
+
+package server
+
+import (
+	"syscall"
+)
+
+var (
+	kernel32                  = syscall.NewLazyDLL("kernel32.dll")
+	procSetThreadExecutionState = kernel32.NewProc("SetThreadExecutionState")
+)
+
+// Execution state flags for SetThreadExecutionState
+const (
+	esSystemRequired  = 0x00000001
+	esContinuous      = 0x80000000
+)
+
+func platformPreventSleep() error {
+	// ES_CONTINUOUS | ES_SYSTEM_REQUIRED prevents the system from sleeping
+	// until we call SetThreadExecutionState with just ES_CONTINUOUS
+	_, _, err := procSetThreadExecutionState.Call(uintptr(esContinuous | esSystemRequired))
+	if err != syscall.Errno(0) {
+		return err
+	}
+	return nil
+}
+
+func platformAllowSleep() error {
+	// Clear the ES_SYSTEM_REQUIRED flag to allow sleep again
+	_, _, err := procSetThreadExecutionState.Call(uintptr(esContinuous))
+	if err != syscall.Errno(0) {
+		return err
+	}
+	return nil
+}

--- a/server/sched.go
+++ b/server/sched.go
@@ -279,6 +279,8 @@ func (s *Scheduler) processCompleted(ctx context.Context) {
 			runner.refMu.Lock()
 			runner.refCount--
 			if runner.refCount <= 0 {
+				// Runner is now idle, allow system sleep
+				GetPowerManager().AllowSleep()
 				if runner.sessionDuration <= 0 {
 					slog.Debug("runner with zero duration has gone idle, expiring to unload", "runner", runner)
 					if runner.expireTimer != nil {
@@ -371,7 +373,12 @@ func (s *Scheduler) processCompleted(ctx context.Context) {
 func (pending *LlmRequest) useLoadedRunner(runner *runnerRef, finished chan *LlmRequest) {
 	runner.refMu.Lock()
 	defer runner.refMu.Unlock()
+	wasIdle := runner.refCount == 0
 	runner.refCount++
+	if wasIdle {
+		// Runner is now active, prevent system sleep
+		GetPowerManager().PreventSleep()
+	}
 	if runner.expireTimer != nil {
 		runner.expireTimer.Stop()
 		runner.expireTimer = nil
@@ -531,6 +538,8 @@ iGPUScan:
 			runner.pid = llama.Pid()
 		}
 		runner.refCount++
+		// First request on new runner, prevent system sleep
+		GetPowerManager().PreventSleep()
 		runner.loading = false
 		go func() {
 			<-req.ctx.Done()


### PR DESCRIPTION
## Summary

Prevent the system from entering sleep mode while Ollama has active runners processing requests. This fixes the issue where long-running inference tasks could be interrupted by system sleep, especially when using Ollama over LAN.

## Changes

Added a `PowerManager` module with platform-specific implementations:

| Platform | Implementation |
|----------|----------------|
| **Windows** | `SetThreadExecutionState` API with `ES_SYSTEM_REQUIRED` flag |
| **macOS** | `IOPMAssertion` via IOKit framework |
| **Linux** | `systemd-inhibit` subprocess (gracefully degrades if unavailable) |

### Files Added
- `server/power.go` - Core PowerManager with reference counting
- `server/power_windows.go` - Windows implementation
- `server/power_darwin.go` - macOS implementation  
- `server/power_linux.go` - Linux implementation
- `server/power_other.go` - Stub for unsupported platforms
- `server/power_test.go` - Unit tests

### Scheduler Integration
Modified `server/sched.go` to:
- Call `PreventSleep()` when a runner becomes active (refCount: 0 → 1)
- Call `AllowSleep()` when a runner becomes idle (refCount: 1 → 0)

## How It Works

The PowerManager uses reference counting to handle multiple concurrent runners:
- Each active request increments the reference count and prevents sleep
- When all requests complete (refCount = 0), system sleep is allowed again
- Thread-safe via mutex protection

## Testing

- Added unit tests for PowerManager reference counting
- All existing scheduler tests pass
- Manually verified on macOS (IOPMAssertion logs visible)

## Example Log Output

```
time=... level=DEBUG msg="system sleep prevented"
time=... level=DEBUG msg="system sleep allowed"
```

Fixes #4072

🤖 Generated with [Claude Code](https://claude.com/claude-code)