### PR TITLE
fix: define GGML_VERSION variables for proper SOVERSION expansion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,13 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/ml/backend/ggml/ggml/src/ggml-cp
 
 add_compile_definitions(NDEBUG GGML_VERSION=0x0 GGML_COMMIT=0x0)
 
+# Define GGML version variables for shared library SOVERSION
+# These are required by ggml/src/CMakeLists.txt for proper library versioning
+set(GGML_VERSION_MAJOR 0)
+set(GGML_VERSION_MINOR 0)
+set(GGML_VERSION_PATCH 0)
+set(GGML_VERSION "${GGML_VERSION_MAJOR}.${GGML_VERSION_MINOR}.${GGML_VERSION_PATCH}")
+
 set(GGML_CPU ON)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/ml/backend/ggml/ggml/src)
 set_property(TARGET ggml PROPERTY EXCLUDE_FROM_ALL TRUE)


### PR DESCRIPTION
## Summary
Fixes the issue where `libggml-base.so` was being installed with a literal "SOVERSION" suffix instead of the actual version number.

**Before:** `libggml-base.so.SOVERSION` (broken)
**After:** `libggml-base.so.0` (correct)

## Problem
The `ggml/src/CMakeLists.txt` uses `${GGML_VERSION_MAJOR}` for the shared library SOVERSION property:
```cmake
set_target_properties(ggml-base PROPERTIES
    VERSION ${GGML_VERSION}
    SOVERSION ${GGML_VERSION_MAJOR}
)
```

However, ollama's `CMakeLists.txt` directly includes the `ggml/src` subdirectory without the parent CMakeLists.txt that defines these variables in the upstream ggml project.

Since `GGML_VERSION_MAJOR` was undefined, CMake used an empty/literal string, resulting in the malformed library name.

## Solution
Added the required GGML_VERSION variables before including the ggml subdirectory:
```cmake
set(GGML_VERSION_MAJOR 0)
set(GGML_VERSION_MINOR 0)
set(GGML_VERSION_PATCH 0)
set(GGML_VERSION "${GGML_VERSION_MAJOR}.${GGML_VERSION_MINOR}.${GGML_VERSION_PATCH}")
```

## Test plan
- [x] Go tests pass
- [ ] Linux build produces correctly named library files (needs CI verification)

Fixes #13436