### PR TITLE
app: sort conversations by last user message

### DIFF
--- a/app/store/database.go
+++ b/app/store/database.go
@@ -513,7 +513,7 @@ func (db *database) getAllChats() ([]Chat, error) {
 			WHERE role = 'user'
 			GROUP BY chat_id
 		) first_msg ON c.id = first_msg.chat_id
-		LEFT JOIN messages m ON c.id = m.chat_id
+		LEFT JOIN messages m ON c.id = m.chat_id AND m.role = 'user'
 		GROUP BY c.id, c.title, c.created_at, first_msg.content
 		ORDER BY last_updated DESC
 	`

--- a/app/ui/ui.go
+++ b/app/ui/ui.go
@@ -1365,8 +1365,9 @@ func chatInfoFromChat(chat store.Chat) responses.ChatInfo {
 		if msg.Role == "user" && userExcerpt == "" {
 			userExcerpt = msg.Content
 		}
-		// update the updated at time
-		if msg.UpdatedAt.After(updatedAt) {
+		// update the updated at time based on user messages only
+		// this ensures conversations are sorted by last user message, not last response
+		if msg.Role == "user" && msg.UpdatedAt.After(updatedAt) {
 			updatedAt = msg.UpdatedAt
 		}
 	}


### PR DESCRIPTION
Conversations were being sorted by the last message timestamp, which includes assistant responses. This felt off compared to other chat tools like ChatGPT and Claude.

Now conversations are sorted by the last user message instead.

Fixes #12958