### PR TITLE
Fix: NameError in Python example in docs/capabilities/streaming.mdx

### DIFF
--- a/docs/capabilities/streaming.mdx
+++ b/docs/capabilities/streaming.mdx
@@ -50,7 +50,7 @@ To enable streaming in the SDKs, set the `stream` parameter to `True`.
         content += chunk.message.content
 
       # append the accumulated fields to the messages for the next request
-      new_messages = [{ role: 'assistant', thinking: thinking, content: content }]
+      new_messages = [{ 'role': 'assistant', 'thinking': thinking, 'content': content }]
     ```
   </Tab>
   <Tab title="JavaScript">


### PR DESCRIPTION
In the Python example in [here](https://docs.ollama.com/capabilities/streaming), the dictionary created within the `new_messages` raises `NameError` and prevents the program from running. The problem is that quotations for the keys of that dictionary is forgotten. Therefore, when you run this example, it will throw `NameError: name 'role' is not defined`.

The fix is simple though, by just adding quotations around the dictionary keys, the problem will be fixed.
