### PR TITLE
Add fuzz tests for parsers

### DIFF
--- a/openai/responses_test.go
+++ b/openai/responses_test.go
@@ -8,6 +8,56 @@ import (
 	"github.com/ollama/ollama/api"
 )
 
+// FuzzResponsesInputMessage tests ResponsesInputMessage JSON unmarshaling
+func FuzzResponsesInputMessage(f *testing.F) {
+	seeds := []string{
+		`{"type": "message", "role": "user", "content": "hello"}`,
+		`{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hello"}]}`,
+		`{"type": "message", "role": "user", "content": [{"type": "input_image", "detail": "auto"}]}`,
+		`{"type": "message", "role": "system", "content": []}`,
+		`{}`,
+		`{"content": null}`,
+		`{"content": 123}`,
+		`{"content": [{"type": "unknown"}]}`,
+		`{"role": "user"}`,
+		`{"type": "message", "role": "user", "content": [{"type": "output_text", "text": "hi"}]}`,
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, input string) {
+		var m ResponsesInputMessage
+		_ = json.Unmarshal([]byte(input), &m)
+	})
+}
+
+// FuzzResponsesInput tests ResponsesInput JSON unmarshaling
+func FuzzResponsesInput(f *testing.F) {
+	seeds := []string{
+		`"hello world"`,
+		`[]`,
+		`[{"type": "message", "role": "user", "content": "hi"}]`,
+		`[{"type": "function_call", "call_id": "123", "name": "test"}]`,
+		`[{"type": "function_call_output", "call_id": "123", "output": "result"}]`,
+		`[{"type": "reasoning", "id": "r1"}]`,
+		`[{"type": "unknown"}]`,
+		`null`,
+		`123`,
+		`{}`,
+		`[null]`,
+		`[{"type": "message"}, {"type": "function_call"}]`,
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, input string) {
+		var r ResponsesInput
+		_ = json.Unmarshal([]byte(input), &r)
+	})
+}
+
 func TestResponsesInputMessage_UnmarshalJSON(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Summary

Adds 16 fuzz tests covering various parsing functions.

### Fuzz Tests

| Package | Fuzzer | Target |
|---------|--------|--------|
| `fs/ggml` | `FuzzGGUFDecode` | GGUF binary format parser |
| `fs/ggml` | `FuzzParseFileType` | File type string parser |
| `fs/ggml` | `FuzzParseTensorType` | Tensor type string parser |
| `fs/ggml` | `FuzzDetectContentType` | Content type detection |
| `server/internal/cache/blob` | `FuzzParseDigest` | Digest string parsing |
| `server` | `FuzzParseModelPath` | Model path parsing |
| `parser` | `FuzzParseFile` | Modelfile parsing |
| `template` | `FuzzParse` | Template parsing |
| `api` | `FuzzDurationUnmarshal` | Duration JSON parsing |
| `api` | `FuzzMessageUnmarshal` | Message JSON parsing |
| `api` | `FuzzPropertyTypeUnmarshal` | PropertyType JSON parsing |
| `api` | `FuzzThinkValueUnmarshal` | ThinkValue JSON parsing |
| `openai` | `FuzzResponsesInputMessage` | OpenAI responses message parsing |
| `openai` | `FuzzResponsesInput` | OpenAI responses input parsing |
| `convert` | `FuzzSafetensorsMetadata` | Safetensors metadata parsing |

### How to Run

```bash
# Example: run GGUF fuzzer for 60 seconds
go test -fuzz=FuzzGGUFDecode -fuzztime=60s ./fs/ggml/

# Run all fuzzers (one at a time)
go test -fuzz=Fuzz -fuzztime=60s ./api/
go test -fuzz=Fuzz -fuzztime=60s ./openai/
go test -fuzz=Fuzz -fuzztime=60s ./fs/ggml/
go test -fuzz=Fuzz -fuzztime=60s ./server/
go test -fuzz=Fuzz -fuzztime=60s ./server/internal/cache/blob/
go test -fuzz=Fuzz -fuzztime=60s ./parser/
go test -fuzz=Fuzz -fuzztime=60s ./template/
go test -fuzz=Fuzz -fuzztime=60s ./convert/
```