### PR TITLE
Prototype: online split vision model merging for ollama engine

### DIFF
--- a/llm/server.go
+++ b/llm/server.go
@@ -146,6 +146,16 @@ func NewLlamaServer(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, modelPath st
 	if envconfig.NewEngine() || f.KV().OllamaEngineRequired() {
 		if len(projectors) == 0 {
 			textProcessor, err = model.NewTextProcessor(modelPath)
+		} else if len(projectors) == 1 {
+			var canMerge bool
+			canMerge, err = model.CanMergeProjector(modelPath)
+			if err == nil {
+				if !canMerge {
+					err = errors.New("split vision models aren't supported")
+				} else {
+					textProcessor, err = model.NewTextProcessor(modelPath)
+				}
+			}
 		} else {
 			err = errors.New("split vision models aren't supported")
 		}
@@ -479,10 +489,10 @@ type LoadRequest struct {
 	GPULayers      ml.GPULayersList
 	MultiUserCache bool
 
-	// Legacy fields - not used with the Ollama engine
 	ProjectorPath string
-	MainGPU       int
-	UseMmap       bool
+	// Legacy fields - not used with the Ollama engine
+	MainGPU int
+	UseMmap bool
 }
 
 type LoadResponse struct {

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -38,7 +38,7 @@ func TestParseTags(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.value, func(t *testing.T) {
-			got := parseTag(tt.value)
+			got := ParseTag(tt.value)
 			if diff := cmp.Diff(tt.want, got, cmp.AllowUnexported((Tag{}))); diff != "" {
 				t.Errorf("ParseTags() returned unexpected values (-want +got):\n%s", diff)
 			}
@@ -81,7 +81,7 @@ func TestPopulateFields(t *testing.T) {
 
 	var m fakeModel
 	v := reflect.ValueOf(&m)
-	v.Elem().Set(populateFields(Base{b: &fakeBackend{
+	v.Elem().Set(PopulateFields(Base{b: &fakeBackend{
 		names: []string{
 			"input.weight",
 			"blk.0.attn_q.weight",
@@ -130,7 +130,7 @@ func TestPopulateFieldsAlternateName(t *testing.T) {
 
 	var m fakeModel
 	v := reflect.ValueOf(&m)
-	v.Elem().Set(populateFields(Base{b: &fakeBackend{
+	v.Elem().Set(PopulateFields(Base{b: &fakeBackend{
 		names: []string{
 			"input.weight",
 			"nested.b.weight",
@@ -166,7 +166,7 @@ func TestPopulateFieldsPrefixSuffixName(t *testing.T) {
 		Blocks: make([]fakeBlock, 2),
 	}
 	v := reflect.ValueOf(&m)
-	v.Elem().Set(populateFields(Base{b: &fakeBackend{
+	v.Elem().Set(PopulateFields(Base{b: &fakeBackend{
 		names: []string{
 			"blk.0.a.weight",
 			"blk.0.b_weight",

--- a/model/models/gemma3/model.go
+++ b/model/models/gemma3/model.go
@@ -164,6 +164,10 @@ func (m *Model) Forward(ctx ml.Context, batch input.Batch) (ml.Tensor, error) {
 	return hiddenState, nil
 }
 
+func (m *Model) IsOnlineProjectorMergingSupported() bool {
+	return true
+}
+
 func init() {
 	model.Register("gemma3", New)
 	model.Register("gemma3_embed", newEmbedModel)

--- a/model/models/gemma3/model_vision.go
+++ b/model/models/gemma3/model_vision.go
@@ -76,9 +76,9 @@ type VisionModelOptions struct {
 }
 
 type VisionModel struct {
-	PatchEmbedding    *nn.Conv2D    `gguf:"patch_embedding"`
-	PositionEmbedding *nn.Embedding `gguf:"position_embedding"`
-	PostLayerNorm     *nn.LayerNorm `gguf:"post_layernorm"`
+	PatchEmbedding    *nn.Conv2D    `gguf:"patch_embedding,alt:patch_embd"`
+	PositionEmbedding *nn.Embedding `gguf:"position_embedding,alt:position_embd"`
+	PostLayerNorm     *nn.LayerNorm `gguf:"post_layernorm,alt:post_ln"`
 
 	Layers []VisionEncoderLayer `gguf:"blk"`
 

--- a/model/models/mistral3/model.go
+++ b/model/models/mistral3/model.go
@@ -59,7 +59,7 @@ func New(c fs.Config) (model.Model, error) {
 }
 
 type PatchMerger struct {
-	MergingLayer *nn.Linear `gguf:"merging_layer"`
+	MergingLayer *nn.Linear `gguf:"merging_layer,alt:"`
 }
 
 func (pm *PatchMerger) Forward(ctx ml.Context, visionOutputs ml.Tensor, size image.Point, spatialMergeSize int) ml.Tensor {
@@ -72,9 +72,9 @@ func (pm *PatchMerger) Forward(ctx ml.Context, visionOutputs ml.Tensor, size ima
 }
 
 type MultiModalProjector struct {
-	Norm        *nn.RMSNorm  `gguf:"norm"`
-	Linear1     *nn.Linear   `gguf:"linear_1"`
-	Linear2     *nn.Linear   `gguf:"linear_2"`
+	Norm        *nn.RMSNorm  `gguf:"norm,alt:input_norm"`
+	Linear1     *nn.Linear   `gguf:"linear_1,alt:1"`
+	Linear2     *nn.Linear   `gguf:"linear_2,alt:2"`
 	PatchMerger *PatchMerger `gguf:"patch_merger"`
 
 	spatialMergeSize int
@@ -162,6 +162,10 @@ func (m *Model) Forward(ctx ml.Context, batch input.Batch) (ml.Tensor, error) {
 	positionsScale := m.getScale(ctx, batch.Positions)
 
 	return m.TextModel.Forward(ctx, batch.Inputs, positions, positionsScale, batch.Outputs, batch, m.Cache), nil
+}
+
+func (m *Model) IsOnlineProjectorMergingSupported() bool {
+	return true
 }
 
 func init() {

--- a/model/models/mistral3/model_vision.go
+++ b/model/models/mistral3/model_vision.go
@@ -87,8 +87,8 @@ type VisionModelOptions struct {
 }
 
 type VisionModel struct {
-	PatchEmbedding *nn.Conv2D           `gguf:"patch_conv"`
-	EncoderNorm    *nn.RMSNorm          `gguf:"encoder_norm"`
+	PatchEmbedding *nn.Conv2D           `gguf:"patch_conv,alt:patch_embd"`
+	EncoderNorm    *nn.RMSNorm          `gguf:"encoder_norm,alt:pre_ln"`
 	Layers         []VisionEncoderLayer `gguf:"blk"`
 
 	*VisionModelOptions

--- a/runner/ollamarunner/runner.go
+++ b/runner/ollamarunner/runner.go
@@ -1171,6 +1171,7 @@ func (s *Server) allocModel(
 	mpath string,
 	params ml.BackendParams,
 	loraPath []string,
+	projectorPath string,
 	parallel int,
 	kvCacheType string,
 	kvSize int,
@@ -1302,7 +1303,7 @@ func (s *Server) load(w http.ResponseWriter, r *http.Request) {
 
 		s.batchSize = req.BatchSize
 
-		err := s.allocModel(s.modelPath, params, req.LoraPath, req.Parallel, req.KvCacheType, req.KvSize, req.MultiUserCache)
+		err := s.allocModel(s.modelPath, params, req.LoraPath, req.ProjectorPath, req.Parallel, req.KvCacheType, req.KvSize, req.MultiUserCache)
 		if err != nil {
 			s.closeModel()
 


### PR DESCRIPTION
## Summery
This PR provides functionality for ollama engine to load split vision model (i.e. a model with base model weight and a "mmproj" weight) by merging them when they are loaded (online merging). As most (if not all) of quantized models in the community follows the convention from llama.cpp where multi-modal projector is saved into a separated file, while ollama engine will only load GGUF multi-modal models converted from ollama itself, merging is needed for community model to be enable to load in ollama engine.
## Changes
1. Add `Model.PostPopulate()`. This method allows models to perform model-specific loading step after ggml tensors are populated into the model. This is useful if llama.cpp has changed too much in the naming of projector tensors like in Qwen2.5VL and Qwen3VL, which cannot be simply adding alternative name for tensors.
2. Add `Model.IsOnlineProjectorMergingSupported()`. This method provides information for serve server if the model to load is ready for projector merging or not.
3. Add alternative names of gemma3 projector used in mmproj.
4. Add alternative names of mistral3 projector used in mmproj.
5. Add post populate logic for qwen2.5vl and qwen3vl for mmproj loading.
## This PR is WIP
Note that this PR only contains information for mmproj projector merging as of today (19 Dec). Following functions are still working on progress:
1. Merging metadata of projector into main model
2. Allows GGML backend to load multiple model weight files

Which is also (mostly) covered by #13259, a PR that is for general gguf split model. This PR shall proceed after that PR is merged. Nevertheless, The functionality for this PR to work can be cherrypicked if that PR cannot be merged in short time. Please leave your comment if you have any suggestions or anything to share.
