### PR TITLE
Update Vulkan Sdk to 1.4.341.1

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -114,7 +114,7 @@ jobs:
           - os: windows
             arch: amd64
             preset: Vulkan
-            install: https://sdk.lunarg.com/sdk/download/1.4.335.0/windows/vulkansdk-windows-X64-1.4.335.0.exe
+            install: https://sdk.lunarg.com/sdk/download/1.4.341.1/windows/vulkansdk-windows-X64-1.4.341.1.exe
             flags: ''
             runner_dir: 'vulkan'
     runs-on: ${{ matrix.arch == 'arm64' && format('{0}-{1}', matrix.os, matrix.arch) || matrix.os }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -113,7 +113,7 @@ jobs:
             install: https://download.amd.com/developer/eula/rocm-hub/AMD-Software-PRO-Edition-24.Q4-WinSvr2022-For-HIP.exe
             flags: '-DAMDGPU_TARGETS=gfx1010 -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_FLAGS="-parallel-jobs=4 -Wno-ignored-attributes -Wno-deprecated-pragma" -DCMAKE_CXX_FLAGS="-parallel-jobs=4 -Wno-ignored-attributes -Wno-deprecated-pragma"'
           - preset: Vulkan
-            install: https://sdk.lunarg.com/sdk/download/1.4.335.0/windows/vulkansdk-windows-X64-1.4.335.0.exe
+            install: https://sdk.lunarg.com/sdk/download/1.4.341.1/windows/vulkansdk-windows-X64-1.4.341.1.exe
     runs-on: windows
     steps:
       - run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG ROCMVERSION=6.3.3
 ARG JETPACK5VERSION=r35.4.1
 ARG JETPACK6VERSION=r36.4.0
 ARG CMAKEVERSION=3.31.2
-ARG VULKANVERSION=1.4.335.0
+ARG VULKANVERSION=1.4.341.1
 
 # We require gcc v10 minimum.  v10.3 has regressions, so the rockylinux 8.5 AppStream has the latest compatible version
 FROM --platform=linux/amd64 rocm/dev-almalinux-8:${ROCMVERSION}-complete AS base-amd64


### PR DESCRIPTION
See discussion in this pull request: 
https://github.com/ggml-org/llama.cpp/pull/18047

And llama.cpp always uses latest Vulkan sdk see:

https://github.com/ggml-org/llama.cpp/blob/master/.github/workflows/build.yml

```
- name: Get latest Vulkan SDK version
        id: vulkan_sdk_version
        run: |
          echo "VULKAN_SDK_VERSION=$(curl https://vulkan.lunarg.com/sdk/latest/linux.txt)" >> "$GITHUB_ENV"
```

But I think because of reproducability of builds this should be done explicitly 

- [x] Update Vulkan Version in DockerFile