### PR TITLE
capitalized

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -1,7 +1,7 @@
 // Package api implements the client-side API for code wishing to interact
-// with the ollama service. The methods of the [Client] type correspond to
-// the ollama REST API as described in [the API documentation].
-// The ollama command-line client itself uses this package to interact with
+// with the Ollama service. The methods of the [Client] type correspond to
+// the Ollama REST API as described in [the API documentation].
+// The Ollama command-line client itself uses this package to interact with
 // the backend service.
 //
 // # Examples
@@ -33,7 +33,7 @@ import (
 	"github.com/ollama/ollama/version"
 )
 
-// Client encapsulates client state for interacting with the ollama
+// Client encapsulates client state for interacting with the Ollama
 // service. Use [ClientFromEnvironment] to create new Clients.
 type Client struct {
 	base *url.URL
@@ -64,12 +64,12 @@ func checkError(resp *http.Response, body []byte) error {
 
 // ClientFromEnvironment creates a new [Client] using configuration from the
 // environment variable OLLAMA_HOST, which points to the network host and
-// port on which the ollama service is listening. The format of this variable
+// port on which the Ollama service is listening. The format of this variable
 // is:
 //
 //	<scheme>://<host>:<port>
 //
-// If the variable is not specified, a default ollama host and port will be
+// If the variable is not specified, a default Ollama host and port will be
 // used.
 func ClientFromEnvironment() (*Client, error) {
 	return &Client{
@@ -306,7 +306,7 @@ func (c *Client) Chat(ctx context.Context, req *ChatRequest, fn ChatResponseFunc
 // returns an error, [Client.Pull] will stop the process and return this error.
 type PullProgressFunc func(ProgressResponse) error
 
-// Pull downloads a model from the ollama library. fn is called each time
+// Pull downloads a model from the Ollama library. fn is called each time
 // progress is made on the request and can be used to display a progress bar,
 // etc.
 func (c *Client) Pull(ctx context.Context, req *PullRequest, fn PullProgressFunc) error {
@@ -449,12 +449,12 @@ func (c *Client) Version(ctx context.Context) (string, error) {
 	return version.Version, nil
 }
 
-// Signout will signout a client for a local ollama server.
+// Signout will signout a client for a local Ollama server.
 func (c *Client) Signout(ctx context.Context) error {
 	return c.do(ctx, http.MethodPost, "/api/signout", nil, nil)
 }
 
-// Disconnect will disconnect an ollama instance from ollama.com.
+// Disconnect will disconnect an Ollama instance from ollama.com.
 func (c *Client) Disconnect(ctx context.Context, encodedKey string) error {
 	return c.do(ctx, http.MethodDelete, fmt.Sprintf("/api/user/keys/%s", encodedKey), nil, nil)
 }

--- a/api/types.go
+++ b/api/types.go
@@ -34,7 +34,7 @@ func (e StatusError) Error() string {
 		return e.ErrorMessage
 	default:
 		// this should not happen
-		return "something went wrong, please see the ollama server logs for details"
+		return "something went wrong, please see the Ollama server logs for details"
 	}
 }
 
@@ -48,7 +48,7 @@ func (e AuthorizationError) Error() string {
 	if e.Status != "" {
 		return e.Status
 	}
-	return "something went wrong, please see the ollama server logs for details"
+	return "something went wrong, please see the Ollama server logs for details"
 }
 
 // ImageData represents the raw binary data of an image file.
@@ -527,7 +527,7 @@ type CreateRequest struct {
 	// From is the name of the model or file to use as the source.
 	From string `json:"from,omitempty"`
 
-	// RemoteHost is the URL of the upstream ollama API for the model (if any).
+	// RemoteHost is the URL of the upstream Ollama API for the model (if any).
 	RemoteHost string `json:"remote_host,omitempty"`
 
 	// Files is a map of files include when creating the model.

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -203,7 +203,7 @@ func CreateHandler(cmd *cobra.Command, args []string) error {
 
 	if err := client.Create(cmd.Context(), req, fn); err != nil {
 		if strings.Contains(err.Error(), "path or Modelfile are required") {
-			return fmt.Errorf("the ollama server must be updated to use `ollama create` with this client")
+			return fmt.Errorf("the Ollama server must be updated to use `ollama create` with this client")
 		}
 		return err
 	}
@@ -1641,7 +1641,7 @@ func checkServerHeartbeat(cmd *cobra.Command, _ []string) error {
 			return err
 		}
 		if err := startApp(cmd.Context(), client); err != nil {
-			return fmt.Errorf("ollama server not responding - %w", err)
+			return fmt.Errorf("Ollama server not responding - %w", err)
 		}
 	}
 	return nil
@@ -1659,7 +1659,7 @@ func versionHandler(cmd *cobra.Command, _ []string) {
 	}
 
 	if serverVersion != "" {
-		fmt.Printf("ollama version is %s\n", serverVersion)
+		fmt.Printf("Ollama version is %s\n", serverVersion)
 	}
 
 	if serverVersion != version.Version {
@@ -1691,7 +1691,7 @@ func NewCLI() *cobra.Command {
 	}
 
 	rootCmd := &cobra.Command{
-		Use:           "ollama",
+		Use:           "Ollama",
 		Short:         "Large language model runner",
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -1766,7 +1766,7 @@ func NewCLI() *cobra.Command {
 	serveCmd := &cobra.Command{
 		Use:     "serve",
 		Aliases: []string{"start"},
-		Short:   "Start ollama",
+		Short:   "Start Ollama",
 		Args:    cobra.ExactArgs(0),
 		RunE:    RunServer,
 	}

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -79,7 +79,7 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 		fmt.Fprintln(os.Stderr, "")
 		fmt.Fprintln(os.Stderr, "  Ctrl + l            Clear the screen")
 		fmt.Fprintln(os.Stderr, "  Ctrl + c            Stop the model from responding")
-		fmt.Fprintln(os.Stderr, "  Ctrl + d            Exit ollama (/bye)")
+		fmt.Fprintln(os.Stderr, "  Ctrl + d            Exit Ollama (/bye)")
 		fmt.Fprintln(os.Stderr, "")
 	}
 
@@ -231,7 +231,7 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 
 			client, err := api.ClientFromEnvironment()
 			if err != nil {
-				fmt.Println("error: couldn't connect to ollama server")
+				fmt.Println("error: couldn't connect to Ollama server")
 				return err
 			}
 
@@ -380,7 +380,7 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 			if len(args) > 1 {
 				client, err := api.ClientFromEnvironment()
 				if err != nil {
-					fmt.Println("error: couldn't connect to ollama server")
+					fmt.Println("error: couldn't connect to Ollama server")
 					return err
 				}
 				req := &api.ShowRequest{

--- a/cmd/start_darwin.go
+++ b/cmd/start_darwin.go
@@ -22,7 +22,7 @@ func startApp(ctx context.Context, client *api.Client) error {
 	r := regexp.MustCompile(`^.*/Ollama\s?\d*.app`)
 	m := r.FindStringSubmatch(link)
 	if len(m) != 1 {
-		return errors.New("could not find ollama app")
+		return errors.New("could not find Ollama app")
 	}
 	if err := exec.Command("/usr/bin/open", "-j", "-a", m[0], "--args", "--fast-startup").Run(); err != nil {
 		return err

--- a/cmd/start_default.go
+++ b/cmd/start_default.go
@@ -10,5 +10,5 @@ import (
 )
 
 func startApp(ctx context.Context, client *api.Client) error {
-	return errors.New("could not connect to ollama server, run 'ollama serve' to start it")
+	return errors.New("could not connect to Ollama server, run 'ollama serve' to start it")
 }

--- a/cmd/start_windows.go
+++ b/cmd/start_windows.go
@@ -41,7 +41,7 @@ func startApp(ctx context.Context, client *api.Client) error {
 			// Finally look in the path
 			appExe, err = exec.LookPath(AppName)
 			if err != nil {
-				return errors.New("could not locate ollama app")
+				return errors.New("could not locate Ollama app")
 			}
 		}
 	}
@@ -55,7 +55,7 @@ func startApp(ctx context.Context, client *api.Client) error {
 	cmd.Stderr = os.Stderr
 
 	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("unable to start ollama app %w", err)
+		return fmt.Errorf("unable to start Ollama app %w", err)
 	}
 
 	if cmd.Process != nil {

--- a/discover/runner.go
+++ b/discover/runner.go
@@ -439,7 +439,7 @@ func bootstrapDevices(ctx context.Context, ollamaLibDirs []string, extraEnvs map
 
 	logutil.Trace("starting runner for device discovery", "libDirs", ollamaLibDirs, "extraEnvs", extraEnvs)
 	cmd, port, err := llm.StartRunner(
-		true, // ollama engine
+		true, // Ollama engine
 		"",   // no model
 		ollamaLibDirs,
 		out,

--- a/fs/ggml/type.go
+++ b/fs/ggml/type.go
@@ -203,26 +203,26 @@ const (
 	TensorTypeQ5_K
 	TensorTypeQ6_K
 	TensorTypeQ8_K
-	tensorTypeIQ2_XXS // not supported by ollama
-	tensorTypeIQ2_XS  // not supported by ollama
-	tensorTypeIQ3_XXS // not supported by ollama
-	tensorTypeIQ1_S   // not supported by ollama
-	tensorTypeIQ4_NL  // not supported by ollama
-	tensorTypeIQ3_S   // not supported by ollama
-	tensorTypeIQ2_S   // not supported by ollama
-	tensorTypeIQ4_XS  // not supported by ollama
+	tensorTypeIQ2_XXS // not supported by Ollama
+	tensorTypeIQ2_XS  // not supported by Ollama
+	tensorTypeIQ3_XXS // not supported by Ollama
+	tensorTypeIQ1_S   // not supported by Ollama
+	tensorTypeIQ4_NL  // not supported by Ollama
+	tensorTypeIQ3_S   // not supported by Ollama
+	tensorTypeIQ2_S   // not supported by Ollama
+	tensorTypeIQ4_XS  // not supported by Ollama
 	TensorTypeI8
 	TensorTypeI16
 	TensorTypeI32
 	TensorTypeI64
 	TensorTypeF64
-	tensorTypeIQ1_M // not supported by ollama
+	tensorTypeIQ1_M // not supported by Ollama
 	TensorTypeBF16
 	tensorTypeQ4_0_4_4   // unused by GGML
 	tensorTypeQ4_0_4_8   // unused by GGML
 	tensorTypeQ4_0_8_8   // unused by GGML
-	tensorTypeTQ1_0      // not supported by ollama
-	tensorTypeTQ2_0      // not supported by ollama
+	tensorTypeTQ1_0      // not supported by Ollama
+	tensorTypeTQ2_0      // not supported by Ollama
 	tensorTypeIQ4_NL_4_4 // unused by GGML
 	tensorTypeIQ4_NL_4_8 // unused by GGML
 	tensorTypeIQ4_NL_8_8 // unused by GGML

--- a/harmony/harmonyparser.go
+++ b/harmony/harmonyparser.go
@@ -261,7 +261,7 @@ const (
 )
 
 // HarmonyMessageHandler processes harmony events and accumulates content appropriately.
-// This is a higher level interface that maps harmony concepts into ollama concepts
+// This is a higher level interface that maps harmony concepts into Ollama concepts
 type HarmonyMessageHandler struct {
 	state           harmonyMessageState
 	HarmonyParser   *HarmonyParser


### PR DESCRIPTION
Issue: #10165

- [x] Do not capitalize `ollama` in the CLI when it is not a command-line prompt
- [x] Capitalize `ollama` in non-CLI contexts across the codebase
- [x] No changes to CLI commands, critical phrases, or identifiers
- [x] No functional or behavioral changes introduced
