### PR TITLE
cmd: hide thinking output when nothink mode is set

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -292,6 +292,7 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 						thinkValue.Value = maybeLevel
 					}
 					opts.Think = &thinkValue
+					opts.HideThinking = false
 					thinkExplicitlySet = true
 					if client, err := api.ClientFromEnvironment(); err == nil {
 						ensureThinkingSupport(cmd.Context(), client, opts.Model)
@@ -303,6 +304,7 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 					}
 				case "nothink":
 					opts.Think = &api.ThinkValue{Value: false}
+					opts.HideThinking = true
 					thinkExplicitlySet = true
 					if client, err := api.ClientFromEnvironment(); err == nil {
 						ensureThinkingSupport(cmd.Context(), client, opts.Model)


### PR DESCRIPTION
When `/set nothink` is called, also set `HideThinking` to `true` so that
thinking output is not displayed even if the model still generates it.

Some models (like deepseek-r1) continue to generate thinking content regardless
of the `think: false` API setting. This change ensures the thinking output
is hidden from the user when they explicitly set nothink mode.

Similarly, `/set think` now sets `HideThinking` to `false` to ensure
thinking is shown when enabled.

Fixes #13493