### PR TITLE
docs: fix tool name mismatch in api.md example

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -895,11 +895,11 @@ curl http://localhost:11434/api/chat -d '{
       "tool_calls": [
         {
           "function": {
-            "name": "get_temperature",
+            "name": "get_weather",
             "arguments": {
               "city": "Toronto"
             }
-          },
+          }
         }
       ]
     },
@@ -907,7 +907,7 @@ curl http://localhost:11434/api/chat -d '{
     {
       "role": "tool",
       "content": "11 degrees celsius",
-      "tool_name": "get_temperature",
+      "tool_name": "get_weather"
     }
   ],
   "stream": false,


### PR DESCRIPTION
The tool calling example used `get_temperature` in the tool_calls but
defined the tool as `get_weather`. Also removed trailing commas that
made the JSON invalid.

Fixes #13031