### PR TITLE
app/ui: add swift syntax highlighting support

### DIFF
--- a/app/ui/app/src/lib/highlighter.ts
+++ b/app/ui/app/src/lib/highlighter.ts
@@ -147,6 +147,7 @@ export const highlighterPromise = createHighlighter({
     "c",
     "cpp",
     "sql",
+    "swift",
     "yaml",
     "markdown",
   ],


### PR DESCRIPTION
Fixes #13476

Adds Swift as a supported language in the syntax highlighter for code blocks in the chat UI.