### PR TITLE
server: disable automatic redirects to fix CORS on redirect responses

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -1489,6 +1489,10 @@ func (s *Server) GenerateRoutes(rc *ollama.Registry) (http.Handler, error) {
 
 	r := gin.Default()
 	r.HandleMethodNotAllowed = true
+	// Disable automatic redirects to ensure CORS middleware processes all requests.
+	// Without this, paths like //api/tags get redirected to /api/tags without CORS headers.
+	r.RedirectTrailingSlash = false
+	r.RedirectFixedPath = false
 	r.Use(
 		cors.New(corsConfig),
 		allowedHostsMiddleware(s.addr),


### PR DESCRIPTION
Disable `RedirectTrailingSlash` and `RedirectFixedPath` in gin to ensure CORS middleware processes all requests.

Without this, paths like `//api/tags` get redirected to `/api/tags` with a 301 response that lacks CORS headers, causing browsers to block the redirect.

This is a known issue in gin-gonic where middleware doesn't apply to automatic redirects (see [gin-gonic/gin#3857](https://github.com/gin-gonic/gin/issues/3857)).

Fixes #13420