### PR TITLE
docs: add version note for /v1/responses API

### DIFF
--- a/docs/api/openai-compatibility.mdx
+++ b/docs/api/openai-compatibility.mdx
@@ -277,6 +277,8 @@ curl -X POST http://localhost:11434/v1/chat/completions \
 
 ### `/v1/responses`
 
+> Note: Added in Ollama v0.13.3
+
 Ollama supports the [OpenAI Responses API](https://platform.openai.com/docs/api-reference/responses). Only the non-stateful flavor is supported (i.e., there is no `previous_response_id` or `conversation` support).
 
 #### Supported features


### PR DESCRIPTION
Fixes #13595

## Changes
- Added version note (v0.13.3) for /v1/responses endpoint in OpenAI compatibility docs