### PR TITLE
fix: correct cursor positioning when backspacing over line wrap

### DIFF
--- a/readline/buffer.go
+++ b/readline/buffer.go
@@ -56,7 +56,7 @@ func (b *Buffer) MoveLeft() {
 			rLength := runewidth.RuneWidth(r)
 
 			if b.DisplayPos%b.LineWidth == 0 {
-				fmt.Print(CursorUp + CursorBOL + CursorRightN(b.Width))
+				fmt.Print(CursorUp + CursorBOL + CursorRightN(b.Width-1))
 				if rLength == 2 {
 					fmt.Print(CursorLeft)
 				}
@@ -340,7 +340,7 @@ func (b *Buffer) Remove() {
 			if b.DisplayPos%b.LineWidth == 0 {
 				// if the user backspaces over the word boundary, do this magic to clear the line
 				// and move to the end of the previous line
-				fmt.Print(CursorBOL + ClearToEOL + CursorUp + CursorBOL + CursorRightN(b.Width))
+				fmt.Print(CursorBOL + ClearToEOL + CursorUp + CursorBOL + CursorRightN(b.Width-1))
 
 				if b.DisplaySize()%b.LineWidth < (b.DisplaySize()-rLength)%b.LineWidth {
 					b.LineHasSpace.Remove(b.DisplayPos/b.LineWidth - 1)
@@ -357,7 +357,7 @@ func (b *Buffer) Remove() {
 					fmt.Print(" " + CursorLeft)
 				}
 			} else if (b.DisplayPos-rLength)%b.LineWidth == 0 && hasSpace {
-				fmt.Print(CursorBOL + ClearToEOL + CursorUp + CursorBOL + CursorRightN(b.Width))
+				fmt.Print(CursorBOL + ClearToEOL + CursorUp + CursorBOL + CursorRightN(b.Width-1))
 
 				if b.Pos == b.Buf.Size() {
 					b.LineHasSpace.Remove(b.DisplayPos/b.LineWidth - 1)


### PR DESCRIPTION
Fixes #13587

## Summary
When backspacing over a line wrap, the cursor was positioned at column `Width` (one past the last valid column) instead of `Width-1` (the last character position). This caused the visual state and buffer to go out of sync - the original character remained visible on screen while the buffer correctly had it deleted.

## Changes
- Change `CursorRightN(b.Width)` to `CursorRightN(b.Width-1)` in `MoveLeft()` and `Remove()` functions
- Ensures cursor positions at the actual last column when moving up a line