### PR TITLE
use default nvidia-smi as fallback when on WSL2

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -173,6 +173,11 @@ fi
 # WSL2 only supports GPUs via nvidia passthrough
 # so check for nvidia-smi to determine if GPU is available
 if [ "$IS_WSL2" = true ]; then
+    # WSL2 has nvidia-smi installed by default,
+    # we add its folder to the end of the PATH as a fallback.
+    if [ -x /usr/lib/wsl/lib/nvidia-smi ]; then
+        export PATH=${PATH}:/usr/lib/wsl/lib
+    fi
     if available nvidia-smi && [ -n "$(nvidia-smi | grep -o "CUDA Version: [0-9]*\.[0-9]*")" ]; then
         status "Nvidia GPU detected."
     fi
@@ -239,7 +244,7 @@ CUDA_REPO_ERR_MSG="NVIDIA GPU detected, but your OS and Architecture are not sup
 # ref: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#fedora
 install_cuda_driver_yum() {
     status 'Installing NVIDIA repository...'
-    
+
     case $PACKAGE_MANAGER in
         yum)
             $SUDO $PACKAGE_MANAGER -y install yum-utils


### PR DESCRIPTION
As described [here](https://docs.nvidia.com/cuda/wsl-user-guide/index.html#known-limitations-for-linux-cuda-applications), `nvidia-smi` may not be available via `PATH`. 

To fix the issue, `install.sh` now checks for the presence of `/usr/lib/wsl/lib/nvidia-smi` and adds `/usr/lib/wsl/lib/` as the final element of `PATH` to be used as a fallback.