### PR TITLE
fix: avoid Nemotron v2 MoE crash (llama.cpp #18309, 0b0ceb5)

### DIFF
--- a/llama/llama.cpp/src/llama-model.cpp
+++ b/llama/llama.cpp/src/llama-model.cpp
@@ -5196,9 +5196,6 @@ bool llama_model::load_tensors(llama_model_loader & ml) {
                     const int64_t n_group    = hparams.ssm_n_group;
                     const int64_t d_in_proj  = 2*d_inner + 2*n_group*d_state + n_ssm_head;
 
-                    const int64_t n_ff_exp = hparams.n_ff_exp ? hparams.n_ff_exp : n_ff / n_expert_used;
-                    const int64_t n_ff_shexp = hparams.n_ff_shexp;
-
                     // embeddings
                     tok_embd = create_tensor(tn(LLM_TENSOR_TOKEN_EMBD, "weight"), {n_embd, n_vocab}, 0);
 
@@ -5250,6 +5247,9 @@ bool llama_model::load_tensors(llama_model_loader & ml) {
                             layer.bo = create_tensor(tn(LLM_TENSOR_ATTN_OUT, "bias",   i), {n_embd},         TENSOR_NOT_REQUIRED);
                         }  else {
                             if (n_expert != 0) {
+                                const int64_t n_ff_exp = hparams.n_ff_exp ? hparams.n_ff_exp : n_ff / n_expert_used;
+                                const int64_t n_ff_shexp = hparams.n_ff_shexp;
+                                
                                 layer.ffn_gate_inp    = create_tensor(tn(LLM_TENSOR_FFN_GATE_INP,  "weight", i), { n_embd, n_expert}, 0);
                                 layer.ffn_exp_probs_b = create_tensor(tn(LLM_TENSOR_FFN_EXP_PROBS_B, "bias", i), {n_expert         }, 0);
 


### PR DESCRIPTION
### Pull upstream llama.cpp fix for Nemotron v2 MoE parameter handling

This PR pulls the upstream llama.cpp fix that resolves incorrect parameter handling for Nemotron v2 MoE models.

Upstream fix:
https://github.com/ggml-org/llama.cpp/pull/18309

Impact
- Fixes 500 Internal Server Error / runner exit status 2 when loading Nemotron v2 MoE models
- No behavioral or performance regressions observed in non-MoE models
- Unblocks Nemotron v2 usage without downstream workarounds

Verification

- mirage335/NVIDIA-Nemotron-Nano-9B-v2-virtuoso now loads and runs correctly
- Regression-tested against:
  - gpt-oss:20b
  - deepseek-r1:14b
  - devstral:latest

Full reproduction details and before/after evidence are documented in issue #13547.