### PR TITLE
feat: skip certificate verify for insecure registries

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -50,7 +50,7 @@ func (r registryChallenge) URL() (*url.URL, error) {
 	return redirectURL, nil
 }
 
-func getAuthorizationToken(ctx context.Context, challenge registryChallenge) (string, error) {
+func getAuthorizationToken(ctx context.Context, challenge registryChallenge, regOpts *registryOptions) (string, error) {
 	redirectURL, err := challenge.URL()
 	if err != nil {
 		return "", err
@@ -67,7 +67,7 @@ func getAuthorizationToken(ctx context.Context, challenge registryChallenge) (st
 
 	headers.Add("Authorization", signature)
 
-	response, err := makeRequest(ctx, http.MethodGet, redirectURL, headers, nil, &registryOptions{})
+	response, err := makeRequest(ctx, http.MethodGet, redirectURL, headers, nil, regOpts)
 	if err != nil {
 		return "", err
 	}

--- a/server/upload.go
+++ b/server/upload.go
@@ -279,7 +279,7 @@ func (b *blobUpload) uploadPart(ctx context.Context, method string, requestURL *
 	case resp.StatusCode == http.StatusUnauthorized:
 		w.Rollback()
 		challenge := parseRegistryChallenge(resp.Header.Get("www-authenticate"))
-		token, err := getAuthorizationToken(ctx, challenge)
+		token, err := getAuthorizationToken(ctx, challenge, opts)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
  fixes #11272
  Pass the insecure option when initiate a https request to the registry with self-signed certificate.

Testing done:
  Before:
```
ollama pull --insecure 192.168.1.2/library/qwen:0.5b
pulling manifest 
Error: pull model manifest: Get "https://192.168.1.2:443/v2/library/qwen/manifests/0.5b": tls: failed to verify certificate: x509: “HarborManager” certificate is not trusted
```
  After change:
```
go run . pull --insecure 192.168.1.2/library/qwen:0.5b
# github.com/ollama/ollama
ld: warning: ignoring duplicate libraries: '-lobjc'
pulling manifest 
pulling fad2a06e4cc7: 100% ▕█████████████████████████████████████████████████████████████████████████████████████████████████████▏ 394 MB                         
pulling 41c2cf8c272f: 100% ▕█████████████████████████████████████████████████████████████████████████████████████████████████████▏ 7.3 KB                         
pulling 1da0581fd4ce: 100% ▕█████████████████████████████████████████████████████████████████████████████████████████████████████▏  130 B                         
pulling f02dd72bb242: 100% ▕█████████████████████████████████████████████████████████████████████████████████████████████████████▏   59 B                         
pulling ea0a531a015b: 100% ▕█████████████████████████████████████████████████████████████████████████████████████████████████████▏  485 B                         
verifying sha256 digest 
writing manifest 
success 
```
