### PR TITLE
Repair an integer division by zero vulnerability in ggufPadding

### DIFF
--- a/fs/ggml/gguf.go
+++ b/fs/ggml/gguf.go
@@ -237,6 +237,11 @@ func (llm *gguf) Decode(rs io.ReadSeeker) error {
 
 	alignment := llm.kv.Uint("general.alignment", 32)
 
+	// Validate alignment
+	if alignment == 0 {
+		return fmt.Errorf("invalid general.alignment: cannot be zero")
+	}
+
 	offset, err := rs.Seek(0, io.SeekCurrent)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixed the divide-by-zero issue caused by directly using alignment in gguf. Added the following code:
	// Validate alignment
	if alignment == 0 {
		return fmt.Errorf("invalid general.alignment: cannot be zero")
	}