### PR TITLE
Fix: prevent path disclosure in error messages for invalid digests (issue #13223)

### DIFF
--- a/server/create.go
+++ b/server/create.go
@@ -618,6 +618,11 @@ func ggufLayers(digest string, fn func(resp api.ProgressResponse)) ([]*layerGGML
 	var layers []*layerGGML
 
 	fn(api.ProgressResponse{Status: "parsing GGUF"})
+	// verify digest not empty
+	if digest == "" {
+		return nil, fmt.Errorf("invalid digest: empty")
+	}
+
 	blobPath, err := GetBlobsPath(digest)
 	if err != nil {
 		return nil, err
@@ -625,6 +630,10 @@ func ggufLayers(digest string, fn func(resp api.ProgressResponse)) ([]*layerGGML
 
 	blob, err := os.Open(blobPath)
 	if err != nil {
+		// remove path in err
+		if pathErr, ok := err.(*os.PathError); ok {
+			return nil, fmt.Errorf("%s: %w", pathErr.Op, pathErr.Err)
+		}
 		return nil, err
 	}
 	defer blob.Close()


### PR DESCRIPTION
Fixed issues caused by user-provided malformed digest parameters:

1. If the digest is empty, return an "invalid empty digest" error immediately
2. If the digest is a valid checksum format but the file path doesn't exist, 
   strip the file path from error messages before returning to the client