### PR TITLE
Docs: get rid of unnecessary quote in a code snippet related to vision capabilities

### DIFF
--- a/docs/capabilities/vision.mdx
+++ b/docs/capabilities/vision.mdx
@@ -36,7 +36,6 @@ Provide an `images` array. SDKs accept file paths, URLs or raw bytes while the R
         }],
         "stream": false
     }'
-    "
     ```
   </Tab>
   <Tab title="Python">


### PR DESCRIPTION
This pull request addresses a syntax error in a code snippet used for working with example of the Vision capabilities models. The original example contained an unnecessary trailing double quote at the end of the curl command. This resulted in the shell hanging indefinitely, waiting for the quote to close, and preventing the example from executing correctly.

This revision removes the extraneous quote, resolving the syntax error and ensuring the curl command functions as intended. The corrected code snippet provides a reliable example for users to interact with vision models via curl.

**Steps Taken:**

1.  Reviewed the provided code snippet in the Vision capabilities documentation.
2.  Identified the trailing double quote as the source of the error.
3.  Removed the quote from the curl command.
4.  Tested the corrected code snippet in a terminal environment to confirm successful execution.

**Expected Behavior:**

The corrected curl command should execute without errors and successfully retrieve the desired data from LLM.

| Before | After |
| ------------- | ------------- |
| <img width="1148" height="968" alt="Screenshot 2026-01-04 at 01-06-26 Vision - Ollama" src="https://github.com/user-attachments/assets/d127e7eb-06b1-41f4-8e4d-2ef78b8a04f3" /> | <img width="1148" height="968" alt="Screenshot 2026-01-04 at 01-08-18 Vision - Ollama" src="https://github.com/user-attachments/assets/be050de1-6628-4add-97b7-64bfe35c975d" /> |