### PR TITLE
Add orla links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [ogpt.nvim](https://github.com/huynle/ogpt.nvim)
 - [gptel Emacs client](https://github.com/karthink/gptel)
 - [Oatmeal](https://github.com/dustinblackman/oatmeal)
+- [orla](https://github.com/dorcha-inc/orla)(Use ollama agents as UNIX tools)
 - [cmdh](https://github.com/pgibler/cmdh)
 - [ooo](https://github.com/npahlfer/ooo)
 - [shell-pilot](https://github.com/reid41/shell-pilot)(Interact with models via pure shell scripts on Linux or macOS)


### PR DESCRIPTION
Orla allows you to use Ollama models as lightweight agents on bash. t is easy to add to a script, use with pipes, or build things on top of.