### PR TITLE
Add Northflank to Cloud section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,6 +438,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Google Cloud](https://cloud.google.com/run/docs/tutorials/gpu-gemma2-with-ollama)
 - [Fly.io](https://fly.io/docs/python/do-more/add-ollama/)
 - [Koyeb](https://www.koyeb.com/deploy/ollama)
+- [Northflank](https://northflank.com/stacks/deploy-ollama)
 
 ### Tutorial
 


### PR DESCRIPTION
Adds Northflank to the README as another cloud option for deploying Ollama. #13624 
