### PR TITLE
cmd,api,llm,app: capitalize Ollama in user-facing text

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -36,7 +36,7 @@ func (e StatusError) Error() string {
 		return e.ErrorMessage
 	default:
 		// this should not happen
-		return "something went wrong, please see the ollama server logs for details"
+		return "something went wrong, please see the Ollama server logs for details"
 	}
 }
 
@@ -50,7 +50,7 @@ func (e AuthorizationError) Error() string {
 	if e.Status != "" {
 		return e.Status
 	}
-	return "something went wrong, please see the ollama server logs for details"
+	return "something went wrong, please see the Ollama server logs for details"
 }
 
 // ImageData represents the raw binary data of an image file.

--- a/app/updater/updater.go
+++ b/app/updater/updater.go
@@ -198,7 +198,7 @@ func (u *Updater) DownloadNewRelease(ctx context.Context, updateResp UpdateRespo
 	_, err = os.Stat(filepath.Dir(stageFilename))
 	if errors.Is(err, os.ErrNotExist) {
 		if err := os.MkdirAll(filepath.Dir(stageFilename), 0o755); err != nil {
-			return fmt.Errorf("create ollama dir %s: %v", filepath.Dir(stageFilename), err)
+			return fmt.Errorf("create Ollama dir %s: %v", filepath.Dir(stageFilename), err)
 		}
 	}
 

--- a/app/updater/updater_windows.go
+++ b/app/updater/updater_windows.go
@@ -126,7 +126,7 @@ func DoUpgrade(interactive bool) error {
 	cmd := exec.Command(runningInstaller, installArgs...)
 
 	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("unable to start ollama app %w", err)
+		return fmt.Errorf("unable to start Ollama app %w", err)
 	}
 
 	if cmd.Process != nil {

--- a/cmd/bench/bench.go
+++ b/cmd/bench/bench.go
@@ -143,7 +143,7 @@ func BenchmarkChat(fOpt flagOptions) error {
 
 	client, err := api.ClientFromEnvironment()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "ERROR: Couldn't create ollama client: %v\n", err)
+		fmt.Fprintf(os.Stderr, "ERROR: Couldn't create Ollama client: %v\n", err)
 		return err
 	}
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -204,7 +204,7 @@ func CreateHandler(cmd *cobra.Command, args []string) error {
 
 	if err := client.Create(cmd.Context(), req, fn); err != nil {
 		if strings.Contains(err.Error(), "path or Modelfile are required") {
-			return fmt.Errorf("the ollama server must be updated to use `ollama create` with this client")
+			return fmt.Errorf("the Ollama server must be updated to use `ollama create` with this client")
 		}
 		return err
 	}
@@ -1651,7 +1651,7 @@ func checkServerHeartbeat(cmd *cobra.Command, _ []string) error {
 			return err
 		}
 		if err := startApp(cmd.Context(), client); err != nil {
-			return fmt.Errorf("ollama server not responding - %w", err)
+			return fmt.Errorf("Ollama server not responding - %w", err)
 		}
 	}
 	return nil
@@ -1778,7 +1778,7 @@ func NewCLI() *cobra.Command {
 	serveCmd := &cobra.Command{
 		Use:     "serve",
 		Aliases: []string{"start"},
-		Short:   "Start ollama",
+		Short:   "Start Ollama",
 		Args:    cobra.ExactArgs(0),
 		RunE:    RunServer,
 	}

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -80,7 +80,7 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 		fmt.Fprintln(os.Stderr, "")
 		fmt.Fprintln(os.Stderr, "  Ctrl + l            Clear the screen")
 		fmt.Fprintln(os.Stderr, "  Ctrl + c            Stop the model from responding")
-		fmt.Fprintln(os.Stderr, "  Ctrl + d            Exit ollama (/bye)")
+		fmt.Fprintln(os.Stderr, "  Ctrl + d            Exit Ollama (/bye)")
 		fmt.Fprintln(os.Stderr, "")
 	}
 
@@ -232,7 +232,7 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 
 			client, err := api.ClientFromEnvironment()
 			if err != nil {
-				fmt.Println("error: couldn't connect to ollama server")
+				fmt.Println("error: couldn't connect to Ollama server")
 				return err
 			}
 
@@ -381,7 +381,7 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 			if len(args) > 1 {
 				client, err := api.ClientFromEnvironment()
 				if err != nil {
-					fmt.Println("error: couldn't connect to ollama server")
+					fmt.Println("error: couldn't connect to Ollama server")
 					return err
 				}
 				req := &api.ShowRequest{

--- a/cmd/start_darwin.go
+++ b/cmd/start_darwin.go
@@ -22,7 +22,7 @@ func startApp(ctx context.Context, client *api.Client) error {
 	r := regexp.MustCompile(`^.*/Ollama\s?\d*.app`)
 	m := r.FindStringSubmatch(link)
 	if len(m) != 1 {
-		return errors.New("could not find ollama app")
+		return errors.New("could not find Ollama app")
 	}
 	if err := exec.Command("/usr/bin/open", "-j", "-a", m[0], "--args", "--fast-startup").Run(); err != nil {
 		return err

--- a/cmd/start_default.go
+++ b/cmd/start_default.go
@@ -10,5 +10,5 @@ import (
 )
 
 func startApp(ctx context.Context, client *api.Client) error {
-	return errors.New("could not connect to ollama server, run 'ollama serve' to start it")
+	return errors.New("could not connect to Ollama server, run 'ollama serve' to start it")
 }

--- a/cmd/start_windows.go
+++ b/cmd/start_windows.go
@@ -55,7 +55,7 @@ func startApp(ctx context.Context, client *api.Client) error {
 	cmd.Stderr = os.Stderr
 
 	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("unable to start ollama app %w", err)
+		return fmt.Errorf("unable to start Ollama app %w", err)
 	}
 
 	if cmd.Process != nil {

--- a/llm/server.go
+++ b/llm/server.go
@@ -1590,7 +1590,7 @@ func (s *llmServer) Completion(ctx context.Context, req CompletionRequest, fn fu
 		return err
 	} else if err != nil {
 		slog.Error("post predict", "error", err)
-		return errors.New("model runner has unexpectedly stopped, this may be due to resource limitations or an internal error, check ollama server logs for details")
+		return errors.New("model runner has unexpectedly stopped, this may be due to resource limitations or an internal error, check Ollama server logs for details")
 	}
 	defer res.Body.Close()
 


### PR DESCRIPTION
This change updates user-facing text to consistently capitalize 'Ollama' as a proper noun throughout the codebase, including:

- Help descriptions (serve command, keyboard shortcuts)
- Error messages shown to users
- Status messages

Fixes #10165