### PR TITLE
docker: add missing deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -205,7 +205,7 @@ COPY --from=build /bin/ollama /bin/ollama
 
 FROM ubuntu:24.04
 RUN apt-get update \
-    && apt-get install -y ca-certificates libvulkan1 \
+    && apt-get install -y ca-certificates libvulkan1 libopenblas0 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=archive /bin /usr/bin


### PR DESCRIPTION
The new MLX library has extra dependencies.

Verification using a temporary image I pushed with this change:
```
% docker run --rm -it --runtime=nvidia --gpus all -e LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/lib/ollama/mlx_cuda_v13/  --entrypoint /bin/imagegen dhiltgen/ollama:0.14.0-rc0-0-g33ee716-dirty --help
Usage of /bin/imagegen:
  -cfg-scale float
    	CFG scale for image editing (default 4)
  -cpuprofile string
    	Write CPU profile to file
  -gpu-capture string
    	Capture GPU trace to .gputrace file (run with MTL_CAPTURE_ENABLED=1)
  -height int
    	Image height (default 1024)
  -image string
    	Image path for multimodal models
  -input-image value
    	Input image for image editing (can be specified multiple times)
  -layer-cache
    	Enable layer caching for faster diffusion (Z-Image, Qwen-Image). Not compatible with CFG/negative prompts.
  -list
    	List tensors only
  -max-tokens int
    	Max tokens (default 100)
  -model string
    	Model directory
  -negative-prompt string
    	Negative prompt for CFG (empty = no CFG, matching Python)
  -output string
    	Output path (default "output.png")
  -prompt string
    	Prompt (default "Hello")
  -qwen-image
    	Qwen-Image text-to-image generation
  -qwen-image-edit
    	Qwen-Image-Edit image editing
  -seed int
    	Random seed (default 42)
  -steps int
    	Denoising steps (default 9)
  -temperature float
    	Temperature (default 0.7)
  -top-k int
    	Top-k sampling (default 40)
  -top-p float
    	Top-p sampling (default 0.9)
  -width int
    	Image width (default 1024)
  -wired-limit int
    	Metal wired memory limit in GB (default 32)
  -zimage
    	Z-Image generation
```