### PR TITLE
docs: note Homebrew Linux lacks NVIDIA GPU support

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,7 +502,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 
 - [Pacman](https://archlinux.org/packages/extra/x86_64/ollama/)
 - [Gentoo](https://github.com/gentoo/guru/tree/master/app-misc/ollama)
-- [Homebrew](https://formulae.brew.sh/formula/ollama)
+- [Homebrew](https://formulae.brew.sh/formula/ollama) (Note: On Linux, Homebrew does not support NVIDIA GPU acceleration. Use the [install script](https://ollama.com/install.sh) for CUDA support)
 - [Helm Chart](https://artifacthub.io/packages/helm/ollama-helm/ollama)
 - [Guix channel](https://codeberg.org/tusharhero/ollama-guix)
 - [Nix package](https://search.nixos.org/packages?show=ollama&from=0&size=50&sort=relevance&type=packages&query=ollama)


### PR DESCRIPTION
## Summary
Add a note to the Package managers section clarifying that the Homebrew formula on Linux does not support NVIDIA GPU acceleration (CUDA), and direct users to the install script for CUDA support.

## Context
Users installing Ollama via Homebrew on Linux may not realize that GPU acceleration won't work, leading to confusion and wasted debugging time.

Reference: https://github.com/Homebrew/homebrew-core/issues/260946

Fixes #13657