### PR TITLE
imagegen: support other modelfile commands for image generation models in short-circuited workflow

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -123,6 +123,21 @@ func CreateHandler(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Check if FROM points to an imagegen model directory
+	for _, mfCmd := range modelfile.Commands {
+		if mfCmd.Name == "model" {
+			// Resolve the path relative to the Modelfile directory
+			fromPath := mfCmd.Args
+			if !filepath.IsAbs(fromPath) {
+				fromPath = filepath.Join(filepath.Dir(filename), fromPath)
+			}
+			if imagegen.IsTensorModelDir(fromPath) {
+				return imagegenclient.CreateModelFromModelfile(args[0], fromPath, modelfile.Commands, p)
+			}
+			break
+		}
+	}
+
 	status := "gathering model components"
 	spinner := progress.NewSpinner(status)
 	p.Add(status, spinner)

--- a/x/imagegen/client/create_test.go
+++ b/x/imagegen/client/create_test.go
@@ -1,0 +1,35 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/ollama/ollama/parser"
+)
+
+func TestCreateModelFromModelfileExtractsMetadata(t *testing.T) {
+	// Test that the command parsing works correctly
+	commands := []parser.Command{
+		{Name: "model", Args: "./weights/test"},
+		{Name: "license", Args: "Apache-2.0"},
+		{Name: "requires", Args: "0.15.0"},
+		{Name: "num_predict", Args: "12"},
+		{Name: "seed", Args: "42"},
+	}
+
+	// We can't easily test the full function without a real model dir,
+	// but we can verify the commands are valid parser.Command types
+	for _, c := range commands {
+		if c.Name == "" {
+			t.Error("Command name should not be empty")
+		}
+	}
+}
+
+func TestMinOllamaVersion(t *testing.T) {
+	if MinOllamaVersion == "" {
+		t.Error("MinOllamaVersion should not be empty")
+	}
+	if MinOllamaVersion[0] < '0' || MinOllamaVersion[0] > '9' {
+		t.Errorf("MinOllamaVersion should start with a number, got %q", MinOllamaVersion)
+	}
+}


### PR DESCRIPTION
While in experimental, image generation models support a "short circuited" `ollama create` workflow that doesn't require conversion to GGUF files or blob uploads to the Ollama API. This allows that workflow to support more commands like PARAMETER for `width`, `height`, `steps` and more.