### PR TITLE
fix: check ComputeMajor instead of DriverMajor for flash attention support

### DIFF
--- a/ml/device.go
+++ b/ml/device.go
@@ -481,7 +481,7 @@ func FlashAttentionSupported(l []DeviceInfo) bool {
 	for _, gpu := range l {
 		supportsFA := gpu.Library == "cpu" ||
 			gpu.Name == "Metal" || gpu.Library == "Metal" ||
-			(gpu.Library == "CUDA" && gpu.DriverMajor >= 7 && !(gpu.ComputeMajor == 7 && gpu.ComputeMinor == 2)) ||
+			(gpu.Library == "CUDA" && gpu.ComputeMajor >= 7 && !(gpu.ComputeMajor == 7 && gpu.ComputeMinor == 2)) ||
 			gpu.Library == "ROCm" ||
 			gpu.Library == "Vulkan"
 


### PR DESCRIPTION
## Summary

Fixes a bug where `FlashAttentionSupported()` checks `gpu.DriverMajor` (CUDA driver version) instead of `gpu.ComputeMajor` (GPU compute capability), causing crashes on older NVIDIA GPUs.

## Problem

On Maxwell-era GPUs like the GTX 970:
- **Driver version**: 12.2 (passes the `>= 7` check ✅)
- **Compute capability**: 5.2 (should fail the check ❌)

This causes flash attention to be incorrectly enabled on GPUs that don't support it, resulting in crashes with "exit status 2" when running any model on Ollama 0.12.6+.

## The Fix

```diff
- (gpu.Library == "CUDA" && gpu.DriverMajor >= 7 && !(gpu.ComputeMajor == 7 && gpu.ComputeMinor == 2)) ||
+ (gpu.Library == "CUDA" && gpu.ComputeMajor >= 7 && !(gpu.ComputeMajor == 7 && gpu.ComputeMinor == 2)) ||
```

Flash attention on CUDA requires compute capability 7.0+ (Volta architecture and newer). The existing exclusion for CC 7.2 (Jetson Xavier) is preserved.

## Affected GPUs

- Maxwell (CC 5.x): GTX 970, GTX 980, GTX Titan X, etc.
- Pascal (CC 6.x): GTX 1080, GTX 1070, GTX 1060, etc.

## Testing

Tested on NVIDIA GeForce GTX 970 (CC 5.2) with CUDA driver 12.2:
- **Before fix**: Crashes with "exit status 2" on any model
- **After fix**: Works correctly (flash attention auto-disabled)

## Workaround for affected users

Until this fix is released, set `OLLAMA_FLASH_ATTENTION=false` in your environment or systemd service file.