### PR TITLE
x/imagegen/transfer: fix timeout and progress reporting

### DIFF
--- a/x/imagegen/transfer/transfer.go
+++ b/x/imagegen/transfer/transfer.go
@@ -110,8 +110,6 @@ var defaultClient = &http.Client{
 		MaxIdleConnsPerHost: 100,
 		IdleConnTimeout:     90 * time.Second,
 	},
-	Timeout: 5 * time.Minute,
-	// Don't follow redirects automatically - we handle them manually
 	CheckRedirect: func(req *http.Request, via []*http.Request) error {
 		return http.ErrUseLastResponse
 	},


### PR DESCRIPTION
This fixes two issues introduced in https://github.com/ollama/ollama/pull/13659

- Remove 5-minute HTTP client timeout that caused "context deadline exceeded" errors on large file downloads. This was unnecessary

- Fix progress bar total going down on resume by calculating total from all blobs upfront and reporting already-downloaded bytes as completed immediately.