### PR TITLE
envconfig: add OLLAMA_DEFAULT_THINK for server-wide thinking control

### DIFF
--- a/app/ui/app/src/components/ChatForm.tsx
+++ b/app/ui/app/src/components/ChatForm.tsx
@@ -166,7 +166,9 @@ function ChatForm({
   const modelSupportsThinkingLevels =
     selectedModel?.model.toLowerCase().startsWith("gpt-oss") || false;
   const supportsThinkToggling =
-    selectedModel?.model.toLowerCase().startsWith("deepseek-v3.1") || false;
+    selectedModel?.model.toLowerCase().startsWith("deepseek-v3.1") ||
+    selectedModel?.model.toLowerCase().startsWith("qwen3") ||
+    false;
 
   useEffect(() => {
     if (supportsThinkToggling && thinkEnabled && webSearchEnabled) {

--- a/app/ui/app/src/components/Settings.tsx
+++ b/app/ui/app/src/components/Settings.tsx
@@ -150,6 +150,7 @@ export default function Settings() {
         Tools: false,
         ContextLength: 4096,
         AirplaneMode: false,
+        ThinkEnabled: false,
       });
       updateSettingsMutation.mutate(defaultSettings);
     }
@@ -464,6 +465,36 @@ export default function Settings() {
                       checked={settings.AirplaneMode}
                       onChange={(checked) =>
                         handleChange("AirplaneMode", checked)
+                      }
+                    />
+                  </div>
+                </div>
+              </Field>
+
+              {/* Default Thinking Mode */}
+              <Field>
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex items-start space-x-3 flex-1">
+                    <svg
+                      className="mt-1 h-5 w-5 flex-shrink-0 text-black dark:text-neutral-100"
+                      viewBox="0 0 11 19"
+                      fill="currentColor"
+                    >
+                      <path d="M0 4.8125C0 7.8125 1.79688 8.55469 2.29688 13.7656C2.32812 14.0469 2.48438 14.2266 2.78125 14.2266H7.67188C7.97656 14.2266 8.13281 14.0469 8.16406 13.7656C8.66406 8.55469 10.4531 7.8125 10.4531 4.8125C10.4531 2.11719 8.14844 0 5.22656 0C2.30469 0 0 2.11719 0 4.8125ZM1.17969 4.8125C1.17969 2.70312 3.03125 1.17969 5.22656 1.17969C7.42188 1.17969 9.27344 2.70312 9.27344 4.8125C9.27344 7.05469 7.78906 7.58594 7.08594 13.0469H3.375C2.66406 7.58594 1.17969 7.05469 1.17969 4.8125ZM2.75781 15.9141H7.70312C7.96094 15.9141 8.15625 15.7109 8.15625 15.4531C8.15625 15.2031 7.96094 15 7.70312 15H2.75781C2.5 15 2.29688 15.2031 2.29688 15.4531C2.29688 15.7109 2.5 15.9141 2.75781 15.9141ZM5.22656 18.1797C6.4375 18.1797 7.44531 17.5859 7.52344 16.6875H2.9375C2.99219 17.5859 4.00781 18.1797 5.22656 18.1797Z" />
+                    </svg>
+                    <div>
+                      <Label>Enable thinking by default</Label>
+                      <Description>
+                        When enabled, reasoning models will use thinking mode by
+                        default. You can still toggle thinking per chat.
+                      </Description>
+                    </div>
+                  </div>
+                  <div className="flex-shrink-0">
+                    <Switch
+                      checked={settings.ThinkEnabled}
+                      onChange={(checked) =>
+                        handleChange("ThinkEnabled", checked)
                       }
                     />
                   </div>

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1948,44 +1948,14 @@ func NewCLI() *cobra.Command {
 	return rootCmd
 }
 
-// If the user has explicitly set thinking options, either through the CLI or
-// through the `/set think` or `set nothink` interactive options, then we
-// respect them. Otherwise, we check model capabilities to see if the model
-// supports thinking. If the model does support thinking, we enable it.
-// Otherwise, we unset the thinking option (which is different than setting it
-// to false).
-//
-// If capabilities are not provided, we fetch them from the server.
+// inferThinkingOption returns the user's explicit Think setting if set (via CLI --think flag
+// or interactive /set think command), otherwise returns nil to let the server apply the
+// OLLAMA_DEFAULT_THINK environment variable default.
 func inferThinkingOption(caps *[]model.Capability, runOpts *runOptions, explicitlySetByUser bool) (*api.ThinkValue, error) {
 	if explicitlySetByUser {
 		return runOpts.Think, nil
 	}
-
-	if caps == nil {
-		client, err := api.ClientFromEnvironment()
-		if err != nil {
-			return nil, err
-		}
-		ret, err := client.Show(context.Background(), &api.ShowRequest{
-			Model: runOpts.Model,
-		})
-		if err != nil {
-			return nil, err
-		}
-		caps = &ret.Capabilities
-	}
-
-	thinkingSupported := false
-	for _, cap := range *caps {
-		if cap == model.CapabilityThinking {
-			thinkingSupported = true
-		}
-	}
-
-	if thinkingSupported {
-		return &api.ThinkValue{Value: true}, nil
-	}
-
+	// Return nil to let the server apply OLLAMA_DEFAULT_THINK environment variable default
 	return nil, nil
 }
 

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -348,6 +348,26 @@ How much the cache quantization impacts the model's response quality will depend
 
 You may need to experiment with different quantization types to find the best balance between memory usage and quality.
 
+## How can I disable thinking mode by default?
+
+Some models (like Qwen3) support "thinking mode" which shows the model's reasoning process. By default, thinking is enabled for models that support it. To disable thinking by default server-wide, set the `OLLAMA_DEFAULT_THINK` environment variable:
+
+```shell
+OLLAMA_DEFAULT_THINK=false ollama serve
+```
+
+Supported values:
+- `true` or `1` - Enable thinking by default
+- `false` or `0` - Disable thinking by default
+- `high`, `medium`, `low` - Set thinking budget level
+
+Users can still override this per-request using the `think` parameter in the API or `--think` flag in the CLI:
+
+```shell
+# Override to enable thinking for this request
+ollama run --think=true qwen3:8b "explain quantum computing"
+```
+
 ## Where can I find my Ollama Public Key?
 
 Your **Ollama Public Key** is the public part of the key pair that lets your local Ollama instance talk to [ollama.com](https://ollama.com).

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -206,6 +206,9 @@ var (
 	UseAuth = Bool("OLLAMA_AUTH")
 	// Enable Vulkan backend
 	EnableVulkan = Bool("OLLAMA_VULKAN")
+	// DefaultThink sets the default thinking behavior when not explicitly specified in API requests
+	// Can be "true", "false", "high", "medium", or "low"
+	DefaultThink = String("OLLAMA_DEFAULT_THINK")
 )
 
 func String(s string) func() string {
@@ -274,6 +277,7 @@ type EnvVar struct {
 func AsMap() map[string]EnvVar {
 	ret := map[string]EnvVar{
 		"OLLAMA_DEBUG":             {"OLLAMA_DEBUG", LogLevel(), "Show additional debug information (e.g. OLLAMA_DEBUG=1)"},
+		"OLLAMA_DEFAULT_THINK":     {"OLLAMA_DEFAULT_THINK", DefaultThink(), "Default thinking behavior for reasoning models (values: true, false, high, medium, low)"},
 		"OLLAMA_FLASH_ATTENTION":   {"OLLAMA_FLASH_ATTENTION", FlashAttention(false), "Enabled flash attention"},
 		"OLLAMA_KV_CACHE_TYPE":     {"OLLAMA_KV_CACHE_TYPE", KvCacheType(), "Quantization type for the K/V cache (default: f16)"},
 		"OLLAMA_GPU_OVERHEAD":      {"OLLAMA_GPU_OVERHEAD", GpuOverhead(), "Reserve a portion of VRAM per GPU (bytes)"},


### PR DESCRIPTION
## Summary

Add support for `OLLAMA_DEFAULT_THINK` environment variable to control default thinking behavior for reasoning models (like Qwen3) at the server level.

- Add `OLLAMA_DEFAULT_THINK` to envconfig (supports `true`/`false`/`high`/`medium`/`low`)
- Update server routes to apply default when `think` is not specified in request
- Fix CLI to not override server default (return nil instead of forcing true)
- Add UI toggle in Settings page for default thinking preference
- Enable think toggle for Qwen3 models in chat interface
- Add documentation in FAQ

## Use Case

Users running Ollama as a backend for automation tools (like n8n) cannot easily disable thinking mode per-request. This allows server-wide configuration:

```bash
OLLAMA_DEFAULT_THINK=false ollama serve
```

Users can still override per-request via API `think` parameter or CLI `--think` flag.

## Test Plan

- [x] Server respects `OLLAMA_DEFAULT_THINK=false` (no thinking in API response)
- [x] CLI respects server default (no thinking with `ollama run`)
- [x] Explicit `--think=true` overrides server default
- [x] UI toggle works for Qwen3 models
- [x] Documentation added to FAQ