### PR TITLE
anthropic: allow non-thinking models when using Anthropic API

### DIFF
--- a/middleware/anthropic.go
+++ b/middleware/anthropic.go
@@ -118,7 +118,8 @@ func AnthropicMessagesMiddleware() gin.HandlerFunc {
 			return
 		}
 
-		c.Set("anthropic_api", true)
+		// Set think to nil when being used with Anthropic API to connect to tools like claude code
+		c.Set("relax_thinking", true)
 
 		var b bytes.Buffer
 		if err := json.NewEncoder(&b).Encode(chatReq); err != nil {

--- a/middleware/anthropic_test.go
+++ b/middleware/anthropic_test.go
@@ -583,14 +583,14 @@ func TestAnthropicWriter_ErrorFromRoutes(t *testing.T) {
 	}
 }
 
-func TestAnthropicMessagesMiddleware_SetsAnthropicAPIFlag(t *testing.T) {
+func TestAnthropicMessagesMiddleware_SetsRelaxThinkingFlag(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	var flagSet bool
 	router := gin.New()
 	router.Use(AnthropicMessagesMiddleware())
 	router.POST("/v1/messages", func(c *gin.Context) {
-		_, flagSet = c.Get("anthropic_api")
+		_, flagSet = c.Get("relax_thinking")
 		c.Status(http.StatusOK)
 	})
 
@@ -602,6 +602,6 @@ func TestAnthropicMessagesMiddleware_SetsAnthropicAPIFlag(t *testing.T) {
 	router.ServeHTTP(resp, req)
 
 	if !flagSet {
-		t.Error("expected anthropic_api flag to be set in context")
+		t.Error("expected relax_thinking flag to be set in context")
 	}
 }

--- a/server/routes.go
+++ b/server/routes.go
@@ -2060,8 +2060,8 @@ func (s *Server) ChatHandler(c *gin.Context) {
 	} else {
 		if req.Think != nil && req.Think.Bool() {
 			// Set think to nil when being used with Anthropic API to connect to tools like claude code
-			if _, ok := c.Get("anthropic_api"); ok {
-				slog.Warn("model does not support thinking", "model", req.Model)
+			if _, ok := c.Get("relax_thinking"); ok {
+				slog.Warn("model does not support thinking, relaxing thinking to nil", "model", req.Model)
 				req.Think = nil
 			} else {
 				c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("%q does not support thinking", req.Model)})


### PR DESCRIPTION
Set anthropic_api flag in middleware context and modify ChatHandler to gracefully ignore the 'think' parameter for requests originating from the Anthropic API. This allows tools like claude code to work with models that don't support thinking without errors.

Changes:
- Add anthropic_api flag to context in AnthropicMessagesMiddleware
- Add test for anthropic_api flag setting
- Update ChatHandler to check anthropic_api flag and set req.Think=nil
- Log warnings when thinking is ignored for non-thinking models