### PR TITLE
cmake: use CMAKE_SYSTEM_PROCESSOR instead of CMAKE_OSX_ARCHITECTURES for mlx.metallib install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,7 +199,7 @@ if(MLX_ENGINE)
 
     # Install the Metal library for macOS arm64 (must be colocated with the binary)
     # Metal backend is only built for arm64, not x86_64
-    if(APPLE AND CMAKE_OSX_ARCHITECTURES MATCHES "arm64")
+    if(APPLE AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
         install(FILES ${CMAKE_BINARY_DIR}/_deps/mlx-build/mlx/backend/metal/kernels/mlx.metallib
             DESTINATION ${OLLAMA_INSTALL_DIR}
             COMPONENT MLX)

--- a/scripts/build_darwin.sh
+++ b/scripts/build_darwin.sh
@@ -64,7 +64,6 @@ _build_darwin() {
         else
             BUILD_DIR=build
             cmake --preset MLX \
-                -DCMAKE_OSX_ARCHITECTURES=arm64 \
                 -DOLLAMA_RUNNER_DIR=./ \
                 -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0 \
                 -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX


### PR DESCRIPTION
Change mlx.metallib install condition from checking `CMAKE_OSX_ARCHITECTURES` to`CMAKE_SYSTEM_PROCESSOR`

`CMAKE_OSX_ARCHITECTURES` is a user-defined variable that may not be set for native builds. `CMAKE_SYSTEM_PROCESSOR` reflects the actual target architecture and is already overridden by the cross-compilation logic at the top of CMakeLists.txt when `CMAKE_OSX_ARCHITECTURES` is explicitly set.

This makes the install condition work correctly for:
  - Native arm64 builds (no explicit architecture flag needed)
  - Cross-compiled arm64 builds (architecture flag triggers the override)