### PR TITLE
x/tools/mcp: add MCP protocol support for external tool servers

### DIFF
--- a/x/cmd/run.go
+++ b/x/cmd/run.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ollama/ollama/types/model"
 	"github.com/ollama/ollama/x/agent"
 	"github.com/ollama/ollama/x/tools"
+	"github.com/ollama/ollama/x/tools/mcp"
 )
 
 // MultilineState tracks the state of multiline input
@@ -674,6 +675,7 @@ func GenerateInteractive(cmd *cobra.Command, modelName string, wordWrap bool, op
 
 	// Create tool registry only if model supports tools
 	var toolRegistry *tools.Registry
+	var mcpManager *mcp.Manager
 	if supportsTools {
 		toolRegistry = tools.DefaultRegistry()
 
@@ -681,6 +683,21 @@ func GenerateInteractive(cmd *cobra.Command, modelName string, wordWrap bool, op
 		if enableWebsearch {
 			toolRegistry.RegisterWebSearch()
 			toolRegistry.RegisterWebFetch()
+		}
+
+		// Initialize MCP tools from config file (~/.ollama/mcp-servers.json)
+		mcpManager = mcp.NewManager()
+		if err := mcp.RegisterFromConfig(toolRegistry, mcpManager); err != nil {
+			fmt.Fprintf(os.Stderr, "\033[1mwarning:\033[0m failed to load MCP config: %v\n", err)
+		}
+
+		// Group MCP tools by server for display
+		mcpServers := make(map[string]int)
+		for _, name := range toolRegistry.Names() {
+			if idx := strings.Index(name, ":"); idx > 0 {
+				serverName := name[:idx]
+				mcpServers[serverName]++
+			}
 		}
 
 		if toolRegistry.Has("bash") {
@@ -695,6 +712,13 @@ func GenerateInteractive(cmd *cobra.Command, modelName string, wordWrap bool, op
 			fmt.Fprintln(os.Stderr)
 		}
 
+		for serverName, toolCount := range mcpServers {
+			fmt.Fprintf(os.Stderr, "\033[1m%s\033[0m (%d tools) loaded from MCP config.\n", serverName, toolCount)
+		}
+		if len(mcpServers) > 0 {
+			fmt.Fprintln(os.Stderr)
+		}
+
 		if yoloMode {
 			fmt.Fprintf(os.Stderr, "\033[1mwarning:\033[0m yolo mode - all tool approvals will be skipped\n")
 		}
@@ -702,6 +726,11 @@ func GenerateInteractive(cmd *cobra.Command, modelName string, wordWrap bool, op
 
 	// Create approval manager for session
 	approval := agent.NewApprovalManager()
+
+	// Ensure MCP servers are cleaned up on exit
+	if mcpManager != nil {
+		defer mcpManager.Close()
+	}
 
 	var messages []api.Message
 	var sb strings.Builder

--- a/x/tools/mcp/client.go
+++ b/x/tools/mcp/client.go
@@ -1,0 +1,525 @@
+// Package mcp provides MCP (Model Context Protocol) client support.
+// MCP enables ollama to connect to external tool servers using JSON-RPC over stdio.
+package mcp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Client manages communication with a single MCP server via JSON-RPC over stdio.
+type Client struct {
+	name    string
+	command string
+	args    []string
+	env     map[string]string
+
+	// Process management
+	cmd    *exec.Cmd
+	stdin  io.WriteCloser
+	stdout *bufio.Reader
+	stderr *bufio.Reader
+
+	// Pipe handles for clean shutdown
+	stdoutPipe io.ReadCloser
+	stderrPipe io.ReadCloser
+
+	// State
+	mu          sync.RWMutex
+	initialized bool
+	tools       []ToolInfo
+	requestID   int64
+	responses   map[int64]chan *jsonRPCResponse
+
+	// Lifecycle
+	ctx    context.Context
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+// ToolInfo holds information about a tool from an MCP server.
+type ToolInfo struct {
+	Name        string
+	Description string
+	InputSchema map[string]any
+}
+
+// JSON-RPC 2.0 message types
+type jsonRPCRequest struct {
+	JSONRPC string `json:"jsonrpc"`
+	ID      *int64 `json:"id,omitempty"`
+	Method  string `json:"method"`
+	Params  any    `json:"params,omitempty"`
+}
+
+type jsonRPCResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      *int64          `json:"id"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *jsonRPCError   `json:"error,omitempty"`
+}
+
+type jsonRPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    any    `json:"data,omitempty"`
+}
+
+// MCP protocol types
+type mcpInitializeRequest struct {
+	ProtocolVersion string         `json:"protocolVersion"`
+	Capabilities    map[string]any `json:"capabilities"`
+	ClientInfo      mcpClientInfo  `json:"clientInfo"`
+}
+
+type mcpClientInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type mcpInitializeResponse struct {
+	ProtocolVersion string         `json:"protocolVersion"`
+	Capabilities    map[string]any `json:"capabilities"`
+	ServerInfo      mcpServerInfo  `json:"serverInfo"`
+}
+
+type mcpServerInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type mcpListToolsResponse struct {
+	Tools []mcpTool `json:"tools"`
+}
+
+type mcpTool struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	InputSchema map[string]any `json:"inputSchema"`
+}
+
+type mcpCallToolRequest struct {
+	Name      string         `json:"name"`
+	Arguments map[string]any `json:"arguments"`
+}
+
+type mcpCallToolResponse struct {
+	Content []mcpContent `json:"content"`
+	IsError bool         `json:"isError,omitempty"`
+}
+
+type mcpContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// NewClient creates a new MCP client for the specified server.
+func NewClient(name, command string, args []string, env map[string]string) *Client {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Client{
+		name:      name,
+		command:   command,
+		args:      args,
+		env:       env,
+		responses: make(map[int64]chan *jsonRPCResponse),
+		ctx:       ctx,
+		cancel:    cancel,
+		done:      make(chan struct{}),
+	}
+}
+
+// Name returns the server name.
+func (c *Client) Name() string {
+	return c.name
+}
+
+// Start spawns the MCP server process.
+func (c *Client) Start() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.cmd != nil {
+		return errors.New("MCP client already started")
+	}
+
+	// Handle commands with spaces (like "pnpm dlx")
+	cmdParts := strings.Fields(c.command)
+	var cmdName string
+	var cmdArgs []string
+
+	if len(cmdParts) > 1 {
+		cmdName = cmdParts[0]
+		cmdArgs = append(cmdParts[1:], c.args...)
+	} else {
+		cmdName = c.command
+		cmdArgs = c.args
+	}
+
+	c.cmd = exec.CommandContext(c.ctx, cmdName, cmdArgs...)
+	c.cmd.Env = c.buildEnvironment()
+
+	// Set up pipes
+	stdin, err := c.cmd.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("failed to create stdin pipe: %w", err)
+	}
+	c.stdin = stdin
+
+	stdout, err := c.cmd.StdoutPipe()
+	if err != nil {
+		c.stdin.Close()
+		return fmt.Errorf("failed to create stdout pipe: %w", err)
+	}
+	c.stdoutPipe = stdout
+	c.stdout = bufio.NewReader(stdout)
+
+	stderr, err := c.cmd.StderrPipe()
+	if err != nil {
+		c.stdin.Close()
+		stdout.Close()
+		return fmt.Errorf("failed to create stderr pipe: %w", err)
+	}
+	c.stderrPipe = stderr
+	c.stderr = bufio.NewReader(stderr)
+
+	if err := c.cmd.Start(); err != nil {
+		c.stdin.Close()
+		stdout.Close()
+		stderr.Close()
+		return fmt.Errorf("failed to start MCP server: %w", err)
+	}
+
+	slog.Debug("MCP server started", "name", c.name, "pid", c.cmd.Process.Pid)
+
+	// Start message handlers
+	go c.handleResponses()
+	go c.handleErrors()
+
+	return nil
+}
+
+// Initialize performs the MCP handshake and discovers tools.
+func (c *Client) Initialize() error {
+	if err := c.Start(); err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(c.ctx, 10*time.Second)
+	defer cancel()
+
+	// Send initialize request
+	req := mcpInitializeRequest{
+		ProtocolVersion: "2024-11-05",
+		Capabilities:    map[string]any{"tools": map[string]any{}},
+		ClientInfo:      mcpClientInfo{Name: "ollama", Version: "0.1.0"},
+	}
+
+	var resp mcpInitializeResponse
+	if err := c.callWithContext(ctx, "initialize", req, &resp); err != nil {
+		return fmt.Errorf("MCP initialize failed: %w", err)
+	}
+
+	// Send initialized notification
+	if err := c.notify("notifications/initialized", nil); err != nil {
+		return fmt.Errorf("MCP initialized notification failed: %w", err)
+	}
+
+	// Discover tools
+	var toolsResp mcpListToolsResponse
+	if err := c.callWithContext(ctx, "tools/list", struct{}{}, &toolsResp); err != nil {
+		return fmt.Errorf("failed to list MCP tools: %w", err)
+	}
+
+	// Store tool info
+	c.mu.Lock()
+	c.initialized = true
+	c.tools = make([]ToolInfo, len(toolsResp.Tools))
+	for i, t := range toolsResp.Tools {
+		c.tools[i] = ToolInfo{
+			Name:        t.Name,
+			Description: t.Description,
+			InputSchema: t.InputSchema,
+		}
+	}
+	c.mu.Unlock()
+
+	slog.Debug("MCP client initialized", "name", c.name, "server", resp.ServerInfo.Name, "tools", len(c.tools))
+	return nil
+}
+
+// Tools returns the discovered tools.
+func (c *Client) Tools() []ToolInfo {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	tools := make([]ToolInfo, len(c.tools))
+	copy(tools, c.tools)
+	return tools
+}
+
+// CallTool executes a tool on the MCP server.
+func (c *Client) CallTool(name string, args map[string]any) (string, error) {
+	c.mu.RLock()
+	if !c.initialized {
+		c.mu.RUnlock()
+		return "", errors.New("MCP client not initialized")
+	}
+	c.mu.RUnlock()
+
+	if args == nil {
+		args = make(map[string]any)
+	}
+
+	ctx, cancel := context.WithTimeout(c.ctx, 30*time.Second)
+	defer cancel()
+
+	req := mcpCallToolRequest{Name: name, Arguments: args}
+	var resp mcpCallToolResponse
+
+	if err := c.callWithContext(ctx, "tools/call", req, &resp); err != nil {
+		return "", fmt.Errorf("MCP tool call failed: %w", err)
+	}
+
+	if resp.IsError {
+		slog.Debug("MCP tool error", "name", name, "content_count", len(resp.Content))
+		return "", fmt.Errorf("MCP tool returned error")
+	}
+
+	// Concatenate text content
+	var result strings.Builder
+	for _, content := range resp.Content {
+		if content.Type == "text" {
+			result.WriteString(content.Text)
+		}
+	}
+
+	return result.String(), nil
+}
+
+// Close shuts down the MCP client.
+func (c *Client) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.cmd == nil {
+		return nil
+	}
+
+	slog.Debug("Shutting down MCP client", "name", c.name)
+
+	c.cancel()
+
+	// Close pipes to unblock goroutines
+	if c.stdoutPipe != nil {
+		c.stdoutPipe.Close()
+	}
+	if c.stderrPipe != nil {
+		c.stderrPipe.Close()
+	}
+	if c.stdin != nil {
+		c.stdin.Close()
+	}
+
+	// Wait for process
+	done := make(chan error, 1)
+	go func() { done <- c.cmd.Wait() }()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		slog.Warn("Force killing MCP server", "name", c.name)
+		c.cmd.Process.Kill()
+		<-done
+	}
+
+	c.cmd = nil
+	c.initialized = false
+	close(c.done)
+
+	return nil
+}
+
+// callWithContext sends a JSON-RPC request and waits for response.
+func (c *Client) callWithContext(ctx context.Context, method string, params, result any) error {
+	id := atomic.AddInt64(&c.requestID, 1)
+
+	req := jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      &id,
+		Method:  method,
+		Params:  params,
+	}
+
+	respChan := make(chan *jsonRPCResponse, 1)
+	c.mu.Lock()
+	c.responses[id] = respChan
+	c.mu.Unlock()
+
+	defer func() {
+		c.mu.Lock()
+		delete(c.responses, id)
+		c.mu.Unlock()
+		close(respChan)
+	}()
+
+	if err := c.sendRequest(req); err != nil {
+		return err
+	}
+
+	select {
+	case resp := <-respChan:
+		if resp.Error != nil {
+			return fmt.Errorf("JSON-RPC error %d: %s", resp.Error.Code, resp.Error.Message)
+		}
+		if result != nil && resp.Result != nil {
+			if err := json.Unmarshal(resp.Result, result); err != nil {
+				return fmt.Errorf("failed to unmarshal response: %w", err)
+			}
+		}
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-c.done:
+		return errors.New("MCP client closed")
+	}
+}
+
+func (c *Client) notify(method string, params any) error {
+	req := jsonRPCRequest{JSONRPC: "2.0", Method: method, Params: params}
+	return c.sendRequest(req)
+}
+
+func (c *Client) sendRequest(req jsonRPCRequest) error {
+	if c.stdin == nil {
+		return errors.New("client not started")
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+	if _, err := c.stdin.Write(append(data, '\n')); err != nil {
+		return fmt.Errorf("failed to write request: %w", err)
+	}
+	return nil
+}
+
+func (c *Client) handleResponses() {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("MCP response handler panic", "name", c.name, "error", r)
+		}
+	}()
+
+	scanner := bufio.NewScanner(c.stdout)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+
+	for {
+		select {
+		case <-c.done:
+			return
+		default:
+			if !scanner.Scan() {
+				if err := scanner.Err(); err != nil {
+					slog.Debug("MCP response reader ended", "name", c.name, "error", err)
+				}
+				return
+			}
+
+			line := scanner.Bytes()
+			var resp jsonRPCResponse
+			if err := json.Unmarshal(line, &resp); err != nil {
+				slog.Debug("Invalid JSON-RPC response", "name", c.name, "error", err)
+				continue
+			}
+
+			if resp.ID != nil {
+				c.mu.RLock()
+				if respChan, exists := c.responses[*resp.ID]; exists {
+					select {
+					case respChan <- &resp:
+					default:
+					}
+				}
+				c.mu.RUnlock()
+			}
+		}
+	}
+}
+
+func (c *Client) handleErrors() {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("MCP error handler panic", "name", c.name, "error", r)
+		}
+	}()
+
+	for {
+		select {
+		case <-c.done:
+			return
+		default:
+			line, _, err := c.stderr.ReadLine()
+			if err != nil {
+				if err != io.EOF {
+					slog.Debug("MCP stderr reader ended", "name", c.name, "error", err)
+				}
+				return
+			}
+			// Truncate long messages
+			msg := string(line)
+			if len(msg) > 200 {
+				msg = msg[:200] + "..."
+			}
+			slog.Debug("MCP server stderr", "name", c.name, "message", msg)
+		}
+	}
+}
+
+func (c *Client) buildEnvironment() []string {
+	// Start with minimal safe environment
+	env := []string{}
+
+	allowed := map[string]bool{
+		"PATH": true, "HOME": true, "USER": true,
+		"LANG": true, "LC_ALL": true, "TZ": true,
+		"TMPDIR": true, "TEMP": true, "TMP": true,
+	}
+
+	for _, e := range os.Environ() {
+		parts := strings.SplitN(e, "=", 2)
+		if len(parts) == 2 && allowed[parts[0]] {
+			env = append(env, e)
+		}
+	}
+
+	// Add custom env vars
+	for k, v := range c.env {
+		env = append(env, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	if !hasEnvVar(env, "PATH") {
+		env = append(env, "PATH=/usr/local/bin:/usr/bin:/bin")
+	}
+
+	return env
+}
+
+func hasEnvVar(env []string, key string) bool {
+	prefix := key + "="
+	for _, e := range env {
+		if strings.HasPrefix(e, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/x/tools/mcp/config.go
+++ b/x/tools/mcp/config.go
@@ -1,0 +1,118 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ollama/ollama/x/tools"
+)
+
+// Config holds MCP server configurations loaded from file.
+type Config struct {
+	Servers []ServerConfig `json:"servers"`
+}
+
+// blockedCommands are commands that cannot be used as MCP servers.
+// These are shells and interpreters that could be used to bypass security.
+// Runtime security for tool execution is handled by the approval system.
+var blockedCommands = []string{
+	// Shells - these could execute arbitrary commands
+	"sh", "bash", "zsh", "fish", "csh", "ksh", "dash",
+	"cmd", "cmd.exe", "powershell", "powershell.exe", "pwsh",
+}
+
+// blockedMetacharacters prevent shell injection in server arguments.
+var blockedMetacharacters = []string{
+	";", "|", "&", "$(", "`", ">", "<", ">>", "<<",
+	"||", "&&", "\n", "\r",
+}
+
+// LoadConfig loads MCP server configurations from standard locations.
+// Priority: ~/.ollama/mcp-servers.json > /etc/ollama/mcp-servers.json
+func LoadConfig() (*Config, error) {
+	paths := []string{
+		filepath.Join(os.Getenv("HOME"), ".ollama", "mcp-servers.json"),
+		"/etc/ollama/mcp-servers.json",
+	}
+
+	for _, path := range paths {
+		config, err := loadConfigFromFile(path)
+		if err == nil {
+			slog.Debug("Loaded MCP config", "path", path, "servers", len(config.Servers))
+			return config, nil
+		}
+		if !os.IsNotExist(err) {
+			slog.Warn("Error loading MCP config", "path", path, "error", err)
+		}
+	}
+
+	// Return empty config if no file found
+	return &Config{Servers: []ServerConfig{}}, nil
+}
+
+// loadConfigFromFile loads MCP configuration from a specific file.
+func loadConfigFromFile(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var config Config
+	if err := json.Unmarshal(data, &config); err != nil {
+		return nil, err
+	}
+
+	return &config, nil
+}
+
+// validateServerConfig checks if an MCP server configuration is safe.
+func validateServerConfig(config ServerConfig) error {
+	// Check command against blocklist
+	cmdLower := strings.ToLower(config.Command)
+	for _, blocked := range blockedCommands {
+		if cmdLower == blocked || strings.HasSuffix(cmdLower, "/"+blocked) {
+			return fmt.Errorf("command '%s' is blocked: shells cannot be MCP servers", config.Command)
+		}
+	}
+
+	// Check args for shell metacharacters
+	for _, arg := range config.Args {
+		for _, meta := range blockedMetacharacters {
+			if strings.Contains(arg, meta) {
+				return fmt.Errorf("argument contains blocked character '%s'", meta)
+			}
+		}
+	}
+
+	return nil
+}
+
+// RegisterFromConfig loads MCP config and registers all servers.
+func RegisterFromConfig(registry *tools.Registry, manager *Manager) error {
+	config, err := LoadConfig()
+	if err != nil {
+		return err
+	}
+
+	for _, serverConfig := range config.Servers {
+		// Validate security
+		if err := validateServerConfig(serverConfig); err != nil {
+			slog.Warn("Skipping MCP server due to security validation",
+				"name", serverConfig.Name, "error", err)
+			continue
+		}
+
+		// Register server
+		if err := manager.RegisterServer(registry, serverConfig); err != nil {
+			slog.Warn("Failed to register MCP server",
+				"name", serverConfig.Name, "error", err)
+			continue
+		}
+	}
+
+	return nil
+}

--- a/x/tools/mcp/integration_test.go
+++ b/x/tools/mcp/integration_test.go
@@ -1,0 +1,137 @@
+//go:build integration
+
+package mcp
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ollama/ollama/x/tools"
+)
+
+// TestFilesystemIntegration tests the MCP client with a real filesystem server.
+// Run with: go test ./x/tools/mcp/... -tags=integration -run TestFilesystemIntegration -v
+func TestFilesystemIntegration(t *testing.T) {
+	// Check if npx is available
+	if _, err := exec.LookPath("npx"); err != nil {
+		t.Skip("npx not available, skipping integration test")
+	}
+
+	// Create test directory and file
+	testDir := "/tmp/mcp-integration-test"
+	testFile := testDir + "/hello.txt"
+	testContent := "Hello from MCP integration test!"
+
+	if err := os.MkdirAll(testDir, 0755); err != nil {
+		t.Fatalf("Failed to create test directory: %v", err)
+	}
+	defer os.RemoveAll(testDir)
+
+	if err := os.WriteFile(testFile, []byte(testContent), 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	// Create registry and manager
+	registry := tools.NewRegistry()
+	manager := NewManager()
+	defer manager.Close()
+
+	// Register filesystem MCP server
+	config := ServerConfig{
+		Name:    "filesystem",
+		Command: "npx",
+		Args:    []string{"-y", "@modelcontextprotocol/server-filesystem", testDir},
+	}
+
+	t.Log("Registering MCP filesystem server...")
+	if err := manager.RegisterServer(registry, config); err != nil {
+		t.Fatalf("Failed to register MCP server: %v", err)
+	}
+
+	// Check that tools were registered
+	toolNames := registry.Names()
+	t.Logf("Registered tools: %v", toolNames)
+
+	if len(toolNames) == 0 {
+		t.Fatal("No tools registered from MCP server")
+	}
+
+	// Find the read_file tool
+	var readFileTool tools.Tool
+	for _, name := range toolNames {
+		if strings.HasSuffix(name, ":read_file") {
+			tool, _ := registry.Get(name)
+			readFileTool = tool
+			break
+		}
+	}
+
+	if readFileTool == nil {
+		t.Fatal("read_file tool not found in registry")
+	}
+
+	t.Logf("Found tool: %s", readFileTool.Name())
+	t.Logf("Description: %s", readFileTool.Description())
+
+	// Execute the read_file tool
+	t.Log("Executing read_file tool...")
+	result, err := readFileTool.Execute(map[string]any{
+		"path": testFile,
+	})
+
+	if err != nil {
+		t.Fatalf("Failed to execute read_file: %v", err)
+	}
+
+	t.Logf("Result: %s", result)
+
+	if !strings.Contains(result, testContent) {
+		t.Errorf("Expected result to contain %q, got %q", testContent, result)
+	}
+
+	t.Log("Integration test passed!")
+}
+
+// TestServerLifecycle tests server startup and shutdown.
+func TestServerLifecycle(t *testing.T) {
+	if _, err := exec.LookPath("npx"); err != nil {
+		t.Skip("npx not available, skipping integration test")
+	}
+
+	testDir := "/tmp/mcp-lifecycle-test"
+	os.MkdirAll(testDir, 0755)
+	defer os.RemoveAll(testDir)
+
+	manager := NewManager()
+	registry := tools.NewRegistry()
+
+	config := ServerConfig{
+		Name:    "lifecycle-test",
+		Command: "npx",
+		Args:    []string{"-y", "@modelcontextprotocol/server-filesystem", testDir},
+	}
+
+	// Register
+	t.Log("Starting MCP server...")
+	start := time.Now()
+	if err := manager.RegisterServer(registry, config); err != nil {
+		t.Fatalf("Failed to register: %v", err)
+	}
+	t.Logf("Server started in %v", time.Since(start))
+
+	// Verify tools
+	if registry.Count() == 0 {
+		t.Error("No tools registered")
+	}
+
+	// Close
+	t.Log("Closing MCP server...")
+	start = time.Now()
+	if err := manager.Close(); err != nil {
+		t.Errorf("Failed to close: %v", err)
+	}
+	t.Logf("Server closed in %v", time.Since(start))
+}

--- a/x/tools/mcp/mcp_test.go
+++ b/x/tools/mcp/mcp_test.go
@@ -1,0 +1,108 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/ollama/ollama/x/tools"
+)
+
+func TestSecurityValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  ServerConfig
+		wantErr bool
+	}{
+		{
+			name: "valid npx command",
+			config: ServerConfig{
+				Name:    "test",
+				Command: "npx",
+				Args:    []string{"-y", "@modelcontextprotocol/server-filesystem"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid python command",
+			config: ServerConfig{
+				Name:    "test",
+				Command: "python",
+				Args:    []string{"-m", "mcp_server"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "blocked bash command",
+			config: ServerConfig{
+				Name:    "test",
+				Command: "bash",
+				Args:    []string{"-c", "echo hello"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "blocked sh command",
+			config: ServerConfig{
+				Name:    "test",
+				Command: "sh",
+				Args:    []string{"-c", "echo hello"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "shell metacharacter in args",
+			config: ServerConfig{
+				Name:    "test",
+				Command: "npx",
+				Args:    []string{"-y", "package; rm -rf /"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "pipe in args",
+			config: ServerConfig{
+				Name:    "test",
+				Command: "npx",
+				Args:    []string{"-y", "package | cat"},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateServerConfig(tt.config)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateServerConfig() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestToolName(t *testing.T) {
+	client := NewClient("filesystem", "npx", nil, nil)
+	tool := &Tool{
+		client:   client,
+		toolName: "read_file",
+	}
+
+	expected := "filesystem:read_file"
+	if got := tool.Name(); got != expected {
+		t.Errorf("Tool.Name() = %v, want %v", got, expected)
+	}
+}
+
+func TestManagerBasics(t *testing.T) {
+	manager := NewManager()
+	_ = tools.NewRegistry() // Would be used with real MCP server
+
+	// Can't actually test registration without a real MCP server
+	// But we can test the manager structure
+	if manager.clients == nil {
+		t.Error("Manager.clients should be initialized")
+	}
+
+	// Close should work on empty manager
+	if err := manager.Close(); err != nil {
+		t.Errorf("Close() on empty manager should not error: %v", err)
+	}
+}

--- a/x/tools/mcp/tool.go
+++ b/x/tools/mcp/tool.go
@@ -1,0 +1,179 @@
+package mcp
+
+import (
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/x/tools"
+)
+
+// Tool wraps an MCP server tool to implement the tools.Tool interface.
+// This allows MCP tools to be registered in the standard tool registry
+// alongside native tools like bash and websearch.
+type Tool struct {
+	client      *Client
+	toolName    string
+	description string
+	schema      api.ToolFunction
+}
+
+// Ensure Tool implements tools.Tool interface
+var _ tools.Tool = (*Tool)(nil)
+
+// Name returns the tool's unique identifier, namespaced by server name.
+func (t *Tool) Name() string {
+	return fmt.Sprintf("%s:%s", t.client.Name(), t.toolName)
+}
+
+// Description returns a human-readable description.
+func (t *Tool) Description() string {
+	return t.description
+}
+
+// Schema returns the tool's parameter schema for the LLM.
+func (t *Tool) Schema() api.ToolFunction {
+	return t.schema
+}
+
+// Execute runs the tool with the given arguments.
+func (t *Tool) Execute(args map[string]any) (string, error) {
+	slog.Debug("Executing MCP tool", "server", t.client.Name(), "tool", t.toolName)
+	result, err := t.client.CallTool(t.toolName, args)
+	if err != nil {
+		slog.Debug("MCP tool execution failed", "server", t.client.Name(), "tool", t.toolName, "error", err)
+		return "", err
+	}
+	slog.Debug("MCP tool executed", "server", t.client.Name(), "tool", t.toolName, "result_length", len(result))
+	return result, nil
+}
+
+// ServerConfig defines configuration for an MCP server.
+type ServerConfig struct {
+	Name    string            `json:"name"`
+	Command string            `json:"command"`
+	Args    []string          `json:"args,omitempty"`
+	Env     map[string]string `json:"env,omitempty"`
+}
+
+// Manager manages multiple MCP server connections.
+type Manager struct {
+	mu      sync.RWMutex
+	clients map[string]*Client
+}
+
+// NewManager creates a new MCP manager.
+func NewManager() *Manager {
+	return &Manager{
+		clients: make(map[string]*Client),
+	}
+}
+
+// RegisterServer connects to an MCP server and registers all its tools
+// with the provided registry. Tools are namespaced as "servername:toolname".
+func (m *Manager) RegisterServer(registry *tools.Registry, config ServerConfig) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Check if already registered
+	if _, exists := m.clients[config.Name]; exists {
+		return fmt.Errorf("MCP server '%s' already registered", config.Name)
+	}
+
+	// Create and initialize client
+	client := NewClient(config.Name, config.Command, config.Args, config.Env)
+	if err := client.Initialize(); err != nil {
+		client.Close()
+		return fmt.Errorf("failed to initialize MCP server '%s': %w", config.Name, err)
+	}
+
+	// Register each tool from the server
+	serverTools := client.Tools()
+	for _, toolInfo := range serverTools {
+		mcpTool := &Tool{
+			client:      client,
+			toolName:    toolInfo.Name,
+			description: toolInfo.Description,
+			schema:      convertSchema(config.Name, toolInfo),
+		}
+		registry.Register(mcpTool)
+		slog.Debug("Registered MCP tool", "server", config.Name, "tool", toolInfo.Name)
+	}
+
+	m.clients[config.Name] = client
+	slog.Debug("MCP server registered", "name", config.Name, "tools", len(serverTools))
+	return nil
+}
+
+// Close shuts down all MCP servers.
+func (m *Manager) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var lastErr error
+	for name, client := range m.clients {
+		if err := client.Close(); err != nil {
+			slog.Warn("Error closing MCP client", "name", name, "error", err)
+			lastErr = err
+		}
+	}
+	m.clients = make(map[string]*Client)
+	return lastErr
+}
+
+// convertSchema converts MCP tool schema to ollama's ToolFunction format.
+func convertSchema(serverName string, info ToolInfo) api.ToolFunction {
+	schema := api.ToolFunction{
+		Name:        fmt.Sprintf("%s:%s", serverName, info.Name),
+		Description: info.Description,
+		Parameters: api.ToolFunctionParameters{
+			Type:       "object",
+			Properties: api.NewToolPropertiesMap(),
+			Required:   []string{},
+		},
+	}
+
+	// Convert properties
+	if props, ok := info.InputSchema["properties"].(map[string]any); ok {
+		for propName, propDef := range props {
+			if propDefMap, ok := propDef.(map[string]any); ok {
+				prop := api.ToolProperty{
+					Description: getStringFromMap(propDefMap, "description"),
+				}
+
+				if propType, ok := propDefMap["type"].(string); ok {
+					prop.Type = api.PropertyType{propType}
+				}
+
+				if items, ok := propDefMap["items"]; ok {
+					prop.Items = items
+				}
+
+				if enumVal, ok := propDefMap["enum"].([]any); ok {
+					prop.Enum = enumVal
+				}
+
+				schema.Parameters.Properties.Set(propName, prop)
+			}
+		}
+	}
+
+	// Convert required fields
+	if required, ok := info.InputSchema["required"].([]any); ok {
+		for _, req := range required {
+			if reqStr, ok := req.(string); ok {
+				schema.Parameters.Required = append(schema.Parameters.Required, reqStr)
+			}
+		}
+	}
+
+	return schema
+}
+
+func getStringFromMap(m map[string]any, key string) string {
+	if val, ok := m[key].(string); ok {
+		return val
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary

Adds support for [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers, enabling ollama to connect to external tool providers via JSON-RPC over stdio. This integrates with the existing experimental agent loop (`--experimental` flag).

- MCP servers are configured via `~/.ollama/mcp-servers.json`
- Tools from MCP servers are registered alongside native tools (bash, websearch)
- Tools are namespaced as `servername:toolname` to avoid conflicts
- Runtime security is handled by the existing approval system

## Example Configuration

```json
{
  "servers": [
    {
      "name": "memory",
      "command": "npx",
      "args": ["-y", "@modelcontextprotocol/server-memory"]
    }
  ]
}
```

## Changes

1. **x/tools/mcp/client.go** - JSON-RPC 2.0 client for MCP protocol
2. **x/tools/mcp/tool.go** - Tool adapter implementing `tools.Tool` interface
3. **x/tools/mcp/config.go** - Configuration loading and validation
4. **x/cmd/run.go** - Integration with experimental agent loop (+29 lines)

Closes #7865