### PR TITLE
mlx: bundle openblas dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,7 +190,7 @@ if(MLX_ENGINE)
     install(TARGETS mlx mlxc
         RUNTIME_DEPENDENCIES
             DIRECTORIES ${CUDAToolkit_BIN_DIR} ${CUDAToolkit_BIN_DIR}/x64 ${CUDAToolkit_LIBRARY_DIR}
-            PRE_INCLUDE_REGEXES cublas cublasLt cudart nvrtc cudnn nccl
+            PRE_INCLUDE_REGEXES cublas cublasLt cudart nvrtc nvrtc-builtins cudnn nccl openblas gfortran
             PRE_EXCLUDE_REGEXES ".*"
         RUNTIME DESTINATION ${OLLAMA_INSTALL_DIR} COMPONENT MLX
         LIBRARY DESTINATION ${OLLAMA_INSTALL_DIR} COMPONENT MLX


### PR DESCRIPTION
This should fix the error:
```
    imagegen_test.go:64: failed to generate image: unexpected status code 500: {"error":{"message":"image runner failed: /tmp/daniel_ollama_test/bin/ollama-mlx: error while loading shared libraries: libopenblas.so.0: cannot open shared object file: No such file or directory (exit: exit status 127)"}}
--- FAIL: TestImageGeneration (5.77s)
    --- FAIL: TestImageGeneration/jmorgan/z-image-turbo->llama3.2-vision (5.77s)
```