### PR TITLE
docs: update web search param in examples

### DIFF
--- a/docs/capabilities/web-search.mdx
+++ b/docs/capabilities/web-search.mdx
@@ -110,7 +110,7 @@ More Ollama [Python example](https://github.com/ollama/ollama-python/blob/main/e
 import { Ollama } from "ollama";
 
 const client = new Ollama();
-const results = await client.webSearch({ query: "what is ollama?" });
+const results = await client.webSearch("what is ollama?");
 console.log(JSON.stringify(results, null, 2));
 ```
 
@@ -213,7 +213,7 @@ models](https://ollama.com/models)\n\nAvailable for macOS, Windows, and Linux',
 import { Ollama } from "ollama";
 
 const client = new Ollama();
-const fetchResult = await client.webFetch({ url: "https://ollama.com" });
+const fetchResult = await client.webFetch("https://ollama.com");
 console.log(JSON.stringify(fetchResult, null, 2));
 ```
 


### PR DESCRIPTION
> this pr updates the example docs in https://docs.ollama.com/capabilities/web-search

both functions [`client.webSearch`](https://github.com/ollama/ollama-js?tab=readme-ov-file#web-search) & [`client.webFetch`](https://github.com/ollama/ollama-js?tab=readme-ov-file#web-fetch) accepts a string as a param and not an object. 

```diff
+ client.webSearch("what is ollama?");
- client.webSearch({ query: "what is ollama?" });
```

```diff
+ client.webFetch("https://ollama.com");
- client.webFetch({ url: "https://ollama.com" });
```

reference: https://github.com/ollama/ollama-js

