### PR TITLE
fix(server): support nested model names in v1/models/ endpoint

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -1066,8 +1066,10 @@ func (s *Server) DeleteHandler(c *gin.Context) {
 func (s *Server) ShowHandler(c *gin.Context) {
 	var req api.ShowRequest
 	err := c.ShouldBindJSON(&req)
+
+	model := strings.TrimPrefix(c.Param("model"), "/")
 	switch {
-	case errors.Is(err, io.EOF):
+	case errors.Is(err, io.EOF) && model == "":
 		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "missing request body"})
 		return
 	case err != nil:
@@ -1079,6 +1081,8 @@ func (s *Server) ShowHandler(c *gin.Context) {
 		// noop
 	} else if req.Name != "" {
 		req.Model = req.Name
+	} else if model != "" {
+		req.Model = model
 	} else {
 		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "model is required"})
 		return
@@ -1585,7 +1589,7 @@ func (s *Server) GenerateRoutes(rc *ollama.Registry) (http.Handler, error) {
 	r.POST("/v1/completions", middleware.CompletionsMiddleware(), s.GenerateHandler)
 	r.POST("/v1/embeddings", middleware.EmbeddingsMiddleware(), s.EmbedHandler)
 	r.GET("/v1/models", middleware.ListMiddleware(), s.ListHandler)
-	r.GET("/v1/models/:model", middleware.RetrieveMiddleware(), s.ShowHandler)
+	r.GET("/v1/models/*model", middleware.RetrieveMiddleware(), s.ShowHandler)
 	r.POST("/v1/responses", middleware.ResponsesMiddleware(), s.ChatHandler)
 
 	// Inference (Anthropic compatibility)


### PR DESCRIPTION
### Summary
This PR fixes issue #13715 by allowing the `/v1/models/:model` endpoint to handle model names with slashes (e.g., HuggingFace models).

### Changes
- Changed the route from `:model` to `*model` to support nested paths.
- Updated `ShowHandler` to fall back to the URL path parameter if the JSON body is missing (as seen in OpenAI-compatible GET requests).
- Handled the leading slash captured by the wildcard parameter using `strings.TrimPrefix`.

### Fixes
Fixes #13715