### PR TITLE
fix(app): skip sidebar animation on initial load

### DIFF
--- a/app/ui/app/src/components/layout/layout.tsx
+++ b/app/ui/app/src/components/layout/layout.tsx
@@ -1,5 +1,6 @@
 import { Link } from "@tanstack/react-router";
 import { useSettings } from "@/hooks/useSettings";
+import { useState, useEffect } from "react";
 
 export function SidebarLayout({
   sidebar,
@@ -12,10 +13,18 @@ export function SidebarLayout({
   const { settings, setSettings } = useSettings();
   const isWindows = navigator.platform.toLowerCase().includes("win");
 
+  // Track if the component has mounted to skip animation on initial render
+  const [hasMounted, setHasMounted] = useState(false);
+  useEffect(() => {
+    // Use requestAnimationFrame to ensure we're past the initial paint
+    const id = requestAnimationFrame(() => setHasMounted(true));
+    return () => cancelAnimationFrame(id);
+  }, []);
+
   return (
-    <div className={`flex transition-[width] duration-300 dark:bg-neutral-900`}>
+    <div className={`flex ${hasMounted ? "transition-[width] duration-300" : ""} dark:bg-neutral-900`}>
       <div
-        className={`absolute flex mx-2 py-2 z-20 items-center transition-[left] duration-375 text-neutral-500 dark:text-neutral-400 ${settings.sidebarOpen ? (isWindows ? "left-2" : "left-[204px]") : isWindows ? "left-2" : "left-20"}`}
+        className={`absolute flex mx-2 py-2 z-20 items-center ${hasMounted ? "transition-[left] duration-375" : ""} text-neutral-500 dark:text-neutral-400 ${settings.sidebarOpen ? (isWindows ? "left-2" : "left-[204px]") : isWindows ? "left-2" : "left-20"}`}
       >
         <button
           onClick={() => setSettings({ SidebarOpen: !settings.sidebarOpen })}
@@ -39,7 +48,7 @@ export function SidebarLayout({
           to="/c/$chatId"
           params={{ chatId: "new" }}
           title="New chat"
-          className={`flex ml-1 items-center justify-center rounded-full transition-opacity duration-375 h-9 w-9 hover:bg-neutral-100 dark:hover:bg-neutral-700 ${
+          className={`flex ml-1 items-center justify-center rounded-full ${hasMounted ? "transition-opacity duration-375" : ""} h-9 w-9 hover:bg-neutral-100 dark:hover:bg-neutral-700 ${
             settings.sidebarOpen
               ? "opacity-0 pointer-events-none"
               : "opacity-100"
@@ -57,7 +66,7 @@ export function SidebarLayout({
         </Link>
       </div>
       <div
-        className={`flex flex-col transition-[width] duration-300 max-h-screen ${settings.sidebarOpen ? "w-64" : "w-0"}`}
+        className={`flex flex-col ${hasMounted ? "transition-[width] duration-300" : ""} max-h-screen ${settings.sidebarOpen ? "w-64" : "w-0"}`}
       >
         <div
           onDoubleClick={() => window.doubleClick && window.doubleClick()}
@@ -67,7 +76,7 @@ export function SidebarLayout({
         {settings.sidebarOpen && sidebar}
       </div>
       <main
-        className={`flex flex-1 flex-col min-w-0 transition-all duration-300`}
+        className={`flex flex-1 flex-col min-w-0 ${hasMounted ? "transition-all duration-300" : ""}`}
       >
         <div
           className={`h-13 flex-none w-full z-10 flex items-center bg-white dark:bg-neutral-900 ${isWindows ? "xl:hidden" : "xl:fixed xl:bg-transparent xl:dark:bg-transparent"}`}

--- a/app/ui/app/src/components/layout/layout.tsx
+++ b/app/ui/app/src/components/layout/layout.tsx
@@ -1,7 +1,7 @@
 import { Link } from "@tanstack/react-router";
 import { ChatIcon } from "@/components/ChatIcon";
 import { isWindowsPlatform } from "@/lib/platform";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 let sessionSidebarOpen = false;
 
@@ -14,7 +14,13 @@ export function SidebarLayout({
   title?: string;
 }>) {
   const [sidebarOpen, setSidebarOpen] = useState(sessionSidebarOpen);
+  const [hasMounted, setHasMounted] = useState(false);
   const isWindows = isWindowsPlatform();
+
+  useEffect(() => {
+    const id = requestAnimationFrame(() => setHasMounted(true));
+    return () => cancelAnimationFrame(id);
+  }, []);
 
   const toggleSidebar = () => {
     sessionSidebarOpen = !sidebarOpen;
@@ -24,7 +30,7 @@ export function SidebarLayout({
   return (
     <div className="flex h-screen w-full overflow-hidden dark:bg-neutral-900">
       <div
-        className={`absolute flex mx-2 py-2 z-20 items-center transition-[left] duration-375 text-neutral-500 dark:text-neutral-400 ${sidebarOpen ? (isWindows ? "left-2" : "left-[140px]") : isWindows ? "left-2" : "left-20"}`}
+        className={`absolute flex mx-2 py-2 z-20 items-center ${hasMounted ? "transition-[left] duration-375" : ""} text-neutral-500 dark:text-neutral-400 ${sidebarOpen ? (isWindows ? "left-2" : "left-[140px]") : isWindows ? "left-2" : "left-20"}`}
       >
         <button
           onClick={toggleSidebar}
@@ -49,7 +55,7 @@ export function SidebarLayout({
             to="/c/$chatId"
             params={{ chatId: "new" }}
             title="New chat"
-            className={`flex ml-1 items-center justify-center rounded-full transition-opacity duration-375 h-9 w-9 hover:bg-neutral-100 dark:hover:bg-neutral-700 ${
+            className={`flex ml-1 items-center justify-center rounded-full ${hasMounted ? "transition-opacity duration-375" : ""} h-9 w-9 hover:bg-neutral-100 dark:hover:bg-neutral-700 ${
               sidebarOpen ? "opacity-0 pointer-events-none" : "opacity-100"
             }`}
           >
@@ -58,7 +64,7 @@ export function SidebarLayout({
         )}
       </div>
       <div
-        className={`flex max-h-screen flex-col transition-[width] duration-300 ${
+        className={`flex max-h-screen flex-col ${hasMounted ? "transition-[width] duration-300" : ""} ${
           sidebarOpen
             ? "w-48 border-r border-neutral-200 bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-950/40"
             : "w-0"
@@ -71,7 +77,7 @@ export function SidebarLayout({
         ></div>
         {sidebarOpen && sidebar}
       </div>
-      <main className="flex min-w-0 flex-1 flex-col transition-all duration-300">
+      <main className={`flex min-w-0 flex-1 flex-col ${hasMounted ? "transition-all duration-300" : ""}`}>
         <div
           className={`h-13 z-10 flex w-full flex-none items-center bg-white dark:bg-neutral-900 ${title ? "" : isWindows ? "xl:hidden" : "xl:fixed xl:bg-transparent xl:dark:bg-transparent"}`}
           onDoubleClick={() => window.doubleClick && window.doubleClick()}


### PR DESCRIPTION
## Summary

Fixes #12954 - The sidebar was animating open on first load instead of appearing open immediately.

## Problem

When the app loads, CSS transitions are applied immediately while settings are being fetched asynchronously. The sidebar starts with sidebarOpen: false (default), then transitions to sidebarOpen: true when settings load, causing an unwanted animation.

## Solution

Added a hasMounted state that tracks whether the component has completed its initial render. CSS transition classes are only applied after the first paint using requestAnimationFrame.

This ensures:
- Initial render: Sidebar appears in correct state instantly (no animation)
- Subsequent toggles: Sidebar animates smoothly as expected

## Testing

- Open the app fresh - sidebar should appear open instantly without animation
- Toggle sidebar button - should still animate smoothly