### PR TITLE
server: prevent image generation models from reloading on every request

### DIFF
--- a/server/sched.go
+++ b/server/sched.go
@@ -571,6 +571,7 @@ func (s *Scheduler) loadImageGen(req *LlmRequest) bool {
 		model:           req.model,
 		modelPath:       req.model.ModelPath,
 		llama:           server,
+		Options:         &req.opts,
 		loading:         false,
 		sessionDuration: sessionDuration,
 		totalSize:       server.TotalSize(),


### PR DESCRIPTION
The loadImageGen function was not setting Options on the runnerRef, causing needsReload() to always return true (since it checks if runner.Options == nil). This resulted in the image generation subprocess being killed and restarted for every request.