### PR TITLE
fix: prevent image generation models from loading during deletion

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -899,11 +899,11 @@ func DeleteHandler(cmd *cobra.Command, args []string) error {
 	for _, arg := range args {
 		// Unload the model if it's running before deletion
 		if err := loadOrUnloadModel(cmd, &runOptions{
-			Model:     args[0],
+			Model:     arg,
 			KeepAlive: &api.Duration{Duration: 0},
 		}); err != nil {
 			if !strings.Contains(strings.ToLower(err.Error()), "not found") {
-				fmt.Fprintf(os.Stderr, "Warning: unable to stop model '%s'\n", args[0])
+				fmt.Fprintf(os.Stderr, "Warning: unable to stop model '%s'\n", arg)
 			}
 		}
 


### PR DESCRIPTION
Move the unload check (empty prompt + KeepAlive=0) before the image generation model dispatch in GenerateHandler, but after the remote model code. This prevents models like flux from being loaded into memory just to be immediately unloaded when running `ollama rm`.

Also fix a bug in DeleteHandler where `args[0]` was used instead of `arg` in the delete loop, causing only the first model to be unloaded when deleting multiple models.