### PR TITLE
cmd: auto-detect image generation models during create

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -101,67 +101,6 @@ func CreateHandler(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid model name: %s", modelName)
 	}
 
-	// Check for --experimental flag for safetensors model creation
-	experimental, _ := cmd.Flags().GetBool("experimental")
-	if experimental {
-		// Get Modelfile content - either from -f flag or default to "FROM ."
-		var reader io.Reader
-		filename, err := getModelfileName(cmd)
-		if os.IsNotExist(err) || filename == "" {
-			// No Modelfile specified or found - use default
-			reader = strings.NewReader("FROM .\n")
-		} else if err != nil {
-			return err
-		} else {
-			f, err := os.Open(filename)
-			if err != nil {
-				return err
-			}
-			defer f.Close()
-			reader = f
-		}
-
-		// Parse the Modelfile
-		modelfile, err := parser.ParseFile(reader)
-		if err != nil {
-			return fmt.Errorf("failed to parse Modelfile: %w", err)
-		}
-
-		// Extract FROM path and configuration
-		var modelDir string
-		mfConfig := &xcreateclient.ModelfileConfig{}
-
-		for _, cmd := range modelfile.Commands {
-			switch cmd.Name {
-			case "model":
-				modelDir = cmd.Args
-			case "template":
-				mfConfig.Template = cmd.Args
-			case "system":
-				mfConfig.System = cmd.Args
-			case "license":
-				mfConfig.License = cmd.Args
-			}
-		}
-
-		if modelDir == "" {
-			modelDir = "."
-		}
-
-		// Resolve relative paths based on Modelfile location
-		if !filepath.IsAbs(modelDir) && filename != "" {
-			modelDir = filepath.Join(filepath.Dir(filename), modelDir)
-		}
-
-		quantize, _ := cmd.Flags().GetString("quantize")
-		return xcreateclient.CreateModel(xcreateclient.CreateOptions{
-			ModelName: modelName,
-			ModelDir:  modelDir,
-			Quantize:  quantize,
-			Modelfile: mfConfig,
-		}, p)
-	}
-
 	var reader io.Reader
 
 	filename, err := getModelfileName(cmd)
@@ -197,6 +136,14 @@ func CreateHandler(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Check if this is an image generation model and handle it directly
+	quantize, _ := cmd.Flags().GetString("quantize")
+	if err := xcreateclient.TryCreateImageGen(modelfile, filepath.Dir(filename), modelName, quantize, p); err == nil {
+		return nil
+	} else if !errors.Is(err, xcreateclient.ErrNotImageGenModel) {
+		return err
+	}
+
 	status := "gathering model components"
 	spinner := progress.NewSpinner(status)
 	p.Add(status, spinner)
@@ -208,7 +155,6 @@ func CreateHandler(cmd *cobra.Command, args []string) error {
 	spinner.Stop()
 
 	req.Model = modelName
-	quantize, _ := cmd.Flags().GetString("quantize")
 	if quantize != "" {
 		req.Quantize = quantize
 	}
@@ -1815,22 +1761,15 @@ func NewCLI() *cobra.Command {
 	rootCmd.Flags().BoolP("version", "v", false, "Show version information")
 
 	createCmd := &cobra.Command{
-		Use:   "create MODEL",
-		Short: "Create a model",
-		Args:  cobra.ExactArgs(1),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			// Skip server check for experimental mode (writes directly to disk)
-			if experimental, _ := cmd.Flags().GetBool("experimental"); experimental {
-				return nil
-			}
-			return checkServerHeartbeat(cmd, args)
-		},
-		RunE: CreateHandler,
+		Use:     "create MODEL",
+		Short:   "Create a model",
+		Args:    cobra.ExactArgs(1),
+		PreRunE: checkServerHeartbeat,
+		RunE:    CreateHandler,
 	}
 
 	createCmd.Flags().StringP("file", "f", "", "Name of the Modelfile (default \"Modelfile\")")
 	createCmd.Flags().StringP("quantize", "q", "", "Quantize model to this level (e.g. q4_K_M)")
-	createCmd.Flags().Bool("experimental", false, "Enable experimental safetensors model creation")
 
 	showCmd := &cobra.Command{
 		Use:     "show MODEL",

--- a/x/create/client/create.go
+++ b/x/create/client/create.go
@@ -9,10 +9,8 @@ package client
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
-	"path/filepath"
 
 	"github.com/ollama/ollama/parser"
 	"github.com/ollama/ollama/progress"
@@ -284,34 +282,8 @@ func createModelfileLayers(mf *ModelfileConfig) ([]server.Layer, error) {
 	return layers, nil
 }
 
-// ErrNotImageGenModel is returned when TryCreateImageGen is called with a non-imagegen model.
-var ErrNotImageGenModel = errors.New("not an image generation model")
-
-// TryCreateImageGen attempts to create an image generation model from a parsed Modelfile.
-// Returns ErrNotImageGenModel if the model directory is not an imagegen model.
-// Returns nil on success, or another error on failure.
-func TryCreateImageGen(modelfile *parser.Modelfile, modelfileDir, modelName, quantize string, p *progress.Progress) error {
-	// Extract model directory from Modelfile
-	var modelDir string
-	for _, cmd := range modelfile.Commands {
-		if cmd.Name == "model" {
-			modelDir = cmd.Args
-			break
-		}
-	}
-	if modelDir == "" {
-		modelDir = "."
-	}
-	if !filepath.IsAbs(modelDir) && modelfileDir != "" {
-		modelDir = filepath.Join(modelfileDir, modelDir)
-	}
-
-	// Check if this is an imagegen model
-	if !create.IsTensorModelDir(modelDir) {
-		return ErrNotImageGenModel
-	}
-
-	// Extract Modelfile config
+// ExtractModelfileConfig extracts template, system, and license from a parsed Modelfile.
+func ExtractModelfileConfig(modelfile *parser.Modelfile) *ModelfileConfig {
 	mfConfig := &ModelfileConfig{}
 	for _, cmd := range modelfile.Commands {
 		switch cmd.Name {
@@ -323,11 +295,5 @@ func TryCreateImageGen(modelfile *parser.Modelfile, modelfileDir, modelName, qua
 			mfConfig.License = cmd.Args
 		}
 	}
-
-	return CreateModel(CreateOptions{
-		ModelName: modelName,
-		ModelDir:  modelDir,
-		Quantize:  quantize,
-		Modelfile: mfConfig,
-	}, p)
+	return mfConfig
 }


### PR DESCRIPTION
Remove the `--experimental` flag requirement for creating image generation models. Now `ollama create` automatically detects image generation models by checking for model_index.json in the model directory and routes them to the direct creation path.
