### PR TITLE
`/api/show`: default to empty model_info

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -749,7 +749,7 @@ type ShowResponse struct {
 	Messages      []Message          `json:"messages,omitempty"`
 	RemoteModel   string             `json:"remote_model,omitempty"`
 	RemoteHost    string             `json:"remote_host,omitempty"`
-	ModelInfo     map[string]any     `json:"model_info,omitempty"`
+	ModelInfo     map[string]any     `json:"model_info"`
 	ProjectorInfo map[string]any     `json:"projector_info,omitempty"`
 	Tensors       []Tensor           `json:"tensors,omitempty"`
 	Capabilities  []model.Capability `json:"capabilities,omitempty"`

--- a/server/routes.go
+++ b/server/routes.go
@@ -1149,6 +1149,9 @@ func GetModelInfo(req api.ShowRequest) (*api.ShowResponse, error) {
 		Capabilities: m.Capabilities(),
 		ModifiedAt:   manifest.fi.ModTime(),
 		Requires:     m.Config.Requires,
+		// Several integrations crash on a nil/omitempty+empty ModelInfo, so by
+		// default we return an empty map.
+		ModelInfo: make(map[string]any),
 	}
 
 	if m.Config.RemoteHost != "" {


### PR DESCRIPTION
For `/api/show`, a fully missing `model_info` field trips up various integrators (including a recent Android Studio integration).

The primary source of missing info tends to come from models with a remote that are also missing other data. It seems better to me to return an empty `model_info` than making up some other fields within `model_info` (like saying the architecture is `remote` or something like that). So this does slightly change `/api/show`'s behavior that possibly someone is relying on, but it seems more important to ensure the field is always there (from a quick sampling integrations seem to be robust to missing fields _within_ it).

Fixes: https://github.com/ollama/ollama/issues/13783