### PR TITLE
imagegen: respect OLLAMA_MODELS for manifests and blobs

### DIFF
--- a/x/imagegen/manifest.go
+++ b/x/imagegen/manifest.go
@@ -6,8 +6,9 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
+
+	"github.com/ollama/ollama/envconfig"
 )
 
 // ManifestLayer represents a layer in the manifest.
@@ -32,31 +33,15 @@ type ModelManifest struct {
 	BlobDir  string
 }
 
-// DefaultBlobDir returns the default blob storage directory.
 func DefaultBlobDir() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		home = "."
-	}
-	switch runtime.GOOS {
-	case "darwin":
-		return filepath.Join(home, ".ollama", "models", "blobs")
-	case "linux":
-		return filepath.Join(home, ".ollama", "models", "blobs")
-	case "windows":
-		return filepath.Join(home, ".ollama", "models", "blobs")
-	default:
-		return filepath.Join(home, ".ollama", "models", "blobs")
-	}
+	return filepath.Join(envconfig.Models(), "blobs")
 }
 
-// DefaultManifestDir returns the default manifest storage directory.
+// DefaultManifestDir returns the manifest storage directory.
+// Respects OLLAMA_MODELS.
+
 func DefaultManifestDir() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		home = "."
-	}
-	return filepath.Join(home, ".ollama", "models", "manifests")
+	return filepath.Join(envconfig.Models(), "manifests")
 }
 
 // LoadManifest loads a manifest for the given model name.

--- a/x/imagegen/manifest_test.go
+++ b/x/imagegen/manifest_test.go
@@ -1,0 +1,26 @@
+package imagegen
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestManifestAndBlobDirsRespectOLLAMAModels(t *testing.T) {
+	modelsDir := filepath.Join(t.TempDir(), "models")
+
+	// Simulate packaged/systemd environment
+	t.Setenv("OLLAMA_MODELS", modelsDir)
+	t.Setenv("HOME", "/usr/share/ollama")
+
+	// Manifest dir must respect OLLAMA_MODELS
+	wantManifest := filepath.Join(modelsDir, "manifests")
+	if got := DefaultManifestDir(); got != wantManifest {
+		t.Fatalf("DefaultManifestDir() = %q, want %q", got, wantManifest)
+	}
+
+	// Blob dir must respect OLLAMA_MODELS
+	wantBlobs := filepath.Join(modelsDir, "blobs")
+	if got := DefaultBlobDir(); got != wantBlobs {
+		t.Fatalf("DefaultBlobDir() = %q, want %q", got, wantBlobs)
+	}
+}


### PR DESCRIPTION
Image generation previously resolved manifests and blobs using a hard-coded
path based on $HOME (e.g., $HOME/.ollama/models). When OLLAMA_MODELS is
overridden (for example under systemd with a custom models dir), the image
runner would still fall back to the default path, leading to failures
like:

    open /usr/share/ollama/.ollama/models/manifests/...: no such file

This change updates imagegen to use envconfig.Models(), aligning it with
classic model behavior so that OLLAMA_MODELS is correctly respected
for both manifests and blobs.

A regression test is included that simulates a packaged/systemd
environment (HOME=/usr/share/ollama) and asserts the correct paths.

Fixes: #13795