### PR TITLE
Add Agentic Signal, ScribePal, Local LLM NPC to Community Integrations list

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,9 @@ See the [API documentation](./docs/api.md) for all endpoints.
 
 ### Web & Desktop
 
-- [Agentic Signal](https://github.com/code-forge-temple/agentic-signal) (Visual AI workflow automation platform with local Ollama integration)
+- [Agentic Signal](https://github.com/code-forge-temple/agentic-signal) (Visual AI agent workflow automation platform with local LLM integration - build intelligent workflows using drag-and-drop interface, no cloud dependencies required)
+- [ScribePal](https://github.com/code-forge-temple/scribe-pal) (Open Source intelligent browser extension that leverages AI to empower your web experience by providing contextual insights, efficient content summarization, and seamless interaction while you browse)
+- [Local LLM NPC](https://github.com/code-forge-temple/local-llm-npc) (An interactive educational AI game built for the Google Gemma 3n Impact Challenge)
 - [Onyx](https://github.com/onyx-dot-app/onyx)
 - [Open WebUI](https://github.com/open-webui/open-webui)
 - [SwiftChat (macOS with ReactNative)](https://github.com/aws-samples/swift-chat)


### PR DESCRIPTION
Adds the  Agentic Signal, ScribePal, Local LLM NPC projects to the Ollama GitHub README under the 'Web & Desktop' community integrations section.

This update helps users find alternative interfaces and client apps for Ollama, expanding the ecosystem.

GitHub: https://github.com/code-forge-temple/agentic-signal