### PR TITLE
ml: skip init validation for MIG GPU devices

### DIFF
--- a/ml/device.go
+++ b/ml/device.go
@@ -538,6 +538,14 @@ func GetVisibleDevicesEnv(l []DeviceInfo, mustFilter bool) map[string]string {
 func (d DeviceInfo) NeedsInitValidation() bool {
 	// ROCm: rocblas will crash on unsupported devices.
 	// CUDA: verify CC is supported by the version of the library
+	//
+	// MIG (Multi-Instance GPU) devices are excluded from validation because:
+	// 1. They are enterprise-grade hardware (A100/H100) unlikely to have CC issues
+	// 2. The validation sets CUDA_VISIBLE_DEVICES to the parent GPU UUID, but MIG
+	//    partitions require MIG-specific UUIDs or index formats which we don't have
+	if d.Library == "CUDA" && strings.Contains(d.Description, " MIG ") {
+		return false
+	}
 	return d.Library == "ROCm" || d.Library == "CUDA"
 }
 

--- a/ml/device_test.go
+++ b/ml/device_test.go
@@ -1,0 +1,85 @@
+package ml
+
+import "testing"
+
+func TestNeedsInitValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		device      DeviceInfo
+		wantValidation bool
+	}{
+		{
+			name: "regular CUDA device needs validation",
+			device: DeviceInfo{
+				DeviceID:    DeviceID{Library: "CUDA"},
+				Description: "NVIDIA GeForce RTX 3080",
+			},
+			wantValidation: true,
+		},
+		{
+			name: "ROCm device needs validation",
+			device: DeviceInfo{
+				DeviceID:    DeviceID{Library: "ROCm"},
+				Description: "AMD Radeon RX 7900 XTX",
+			},
+			wantValidation: true,
+		},
+		{
+			name: "Metal device does not need validation",
+			device: DeviceInfo{
+				DeviceID:    DeviceID{Library: "Metal"},
+				Description: "Apple M1 Pro",
+			},
+			wantValidation: false,
+		},
+		{
+			name: "CPU does not need validation",
+			device: DeviceInfo{
+				DeviceID:    DeviceID{Library: "cpu"},
+				Description: "CPU",
+			},
+			wantValidation: false,
+		},
+		{
+			name: "MIG device does not need validation",
+			device: DeviceInfo{
+				DeviceID:    DeviceID{Library: "CUDA"},
+				Description: "NVIDIA A100 80GB PCIe MIG 7g.80gb",
+			},
+			wantValidation: false,
+		},
+		{
+			name: "MIG device with different partition does not need validation",
+			device: DeviceInfo{
+				DeviceID:    DeviceID{Library: "CUDA"},
+				Description: "NVIDIA A100-SXM4-40GB MIG 3g.20gb",
+			},
+			wantValidation: false,
+		},
+		{
+			name: "H100 MIG device does not need validation",
+			device: DeviceInfo{
+				DeviceID:    DeviceID{Library: "CUDA"},
+				Description: "NVIDIA H100 PCIe MIG 1g.10gb",
+			},
+			wantValidation: false,
+		},
+		{
+			name: "regular A100 without MIG needs validation",
+			device: DeviceInfo{
+				DeviceID:    DeviceID{Library: "CUDA"},
+				Description: "NVIDIA A100 80GB PCIe",
+			},
+			wantValidation: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.device.NeedsInitValidation()
+			if got != tt.wantValidation {
+				t.Errorf("NeedsInitValidation() = %v, want %v", got, tt.wantValidation)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Skip GPU init validation for MIG (Multi-Instance GPU) devices to fix GPU detection failures in Kubernetes environments.

## Problem
MIG partitions fail the second-pass device validation introduced in v0.13.2:

1. Initial discovery correctly detects the MIG device via `cudaGetDeviceProperties()`
2. The validation subprocess sets `CUDA_VISIBLE_DEVICES` to the parent GPU UUID (e.g., `GPU-7327fca2-...`)
3. For MIG devices, this UUID format doesn't work - CUDA requires `MIG-<uuid>` or `GPU-<uuid>/<gi>/<ci>` formats
4. The subprocess fails with "no CUDA-capable device is detected"
5. The MIG device is filtered out, forcing CPU-only inference

## Solution
Detect MIG devices by checking for `" MIG "` in the device description and skip validation for them. This is safe because:
- MIG is only available on enterprise A100/H100 GPUs
- These GPUs have well-supported compute capabilities
- The validation was designed to catch old GPUs with unsupported CC - not applicable to MIG hardware

## Changes
- `ml/device.go`: Skip validation for CUDA devices with MIG in description
- `x/ml/device.go`: Same change (duplicate file)
- `ml/device_test.go`: Unit tests for `NeedsInitValidation()`

## Test plan
- Added unit tests covering MIG and non-MIG device detection
- Test cases match real MIG device descriptions from the issue

Fixes #13800