### PR TITLE
README: Update the "Ollama for ruby" to the most popular and maintained ruby gem. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,7 +558,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [LiteLLM](https://github.com/BerriAI/litellm)
 - [OllamaFarm for Go](https://github.com/presbrey/ollamafarm)
 - [OllamaSharp for .NET](https://github.com/awaescher/OllamaSharp)
-- [Ollama for Ruby](https://rubyllm.com/)
+- [Ollama for Ruby](https://github.com/crmne/ruby_llm)
 - [Ollama-rs for Rust](https://github.com/pepperoni21/ollama-rs)
 - [Ollama-hpp for C++](https://github.com/jmont-dev/ollama-hpp)
 - [Ollama4j for Java](https://github.com/ollama4j/ollama4j)


### PR DESCRIPTION
The ollama-ai ruby gem is vastly less popular and seems unmaintained:
https://rubygems.org/gems/ollama-ai

The defacto standard with the most downloads in the ruby ecosystem is ruby_llm
https://rubygems.org/gems/ruby_llm

I would link to ruby_llm to avoid complication and guarantee feature compatibility with ollama.

Otherwise people using ruby might get lost on the way.