### PR TITLE
model/models/qwen3vl/model.go: Enhance condition for vision model validation

### DIFF
--- a/model/models/qwen3vl/model.go
+++ b/model/models/qwen3vl/model.go
@@ -25,7 +25,7 @@ type Model struct {
 }
 
 func (m *Model) EncodeMultimodal(ctx ml.Context, multimodalData []byte) ([]input.Multimodal, error) {
-	if len(m.VisionModel.Layers) == 0 {
+	if len(m.VisionModel.Layers) == 0 || m.VisionModel.PatchEmbedding == nil {
 		return nil, model.ErrNoVisionModel
 	}
 


### PR DESCRIPTION
Fix for issue [#13794 Qwen3-VL / Vision models crash with nil Conv3D pointer](https://github.com/ollama/ollama/issues/13794)
Prevents crash when a supposed vision model has no vision tensors.