### PR TITLE
runner: Adds `prompt_eval_progress` argument to stream prompt completion progress with ollama streaming API 

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -568,13 +568,13 @@ type ChatResponse struct {
 	// if requested via the Logprobs parameter.
 	Logprobs []Logprob `json:"logprobs,omitempty"`
 
-	// Completed is the number of tokens processed during prompt evaluation.
+	// PromptEvalCompleted is the number of tokens processed during prompt evaluation.
 	// Only present when prompt_eval_progress is set in the request.
-	Completed int64 `json:"completed,omitempty"`
+	PromptEvalCompleted int64 `json:"prompt_eval_completed,omitempty"`
 
-	// Total is the total number of tokens to process during prompt evaluation.
+	// PromptEvalTotal is the total number of tokens to process during prompt evaluation.
 	// Only present when prompt_eval_progress is set in the request.
-	Total int64 `json:"total,omitempty"`
+	PromptEvalTotal int64 `json:"prompt_eval_total,omitempty"`
 
 	Metrics
 }
@@ -906,6 +906,14 @@ type GenerateResponse struct {
 	// Total is the total number of steps for image generation.
 	// Only present for image generation models during streaming.
 	Total int64 `json:"total,omitempty"`
+
+	// PromptEvalCompleted is the number of tokens processed during prompt evaluation.
+	// Only present when prompt_eval_progress is set in the request.
+	PromptEvalCompleted int64 `json:"prompt_eval_completed,omitempty"`
+
+	// PromptEvalTotal is the total number of tokens to process during prompt evaluation.
+	// Only present when prompt_eval_progress is set in the request.
+	PromptEvalTotal int64 `json:"prompt_eval_total,omitempty"`
 }
 
 // ModelDetails provides details about a model.

--- a/integration/api_test.go
+++ b/integration/api_test.go
@@ -610,10 +610,10 @@ func TestAPIGeneratePromptEvalProgress(t *testing.T) {
 	var finalResponse api.GenerateResponse
 
 	err := client.Generate(ctx, &req, func(resp api.GenerateResponse) error {
-		// Track progress updates (responses with Completed > 0 and not Done)
-		if resp.Completed > 0 && !resp.Done {
+		// Track progress updates (responses with PromptEvalCompleted > 0 and not Done)
+		if resp.PromptEvalCompleted > 0 && !resp.Done {
 			progressUpdates = append(progressUpdates, resp)
-			t.Logf("Progress update: %d/%d tokens", resp.Completed, resp.Total)
+			t.Logf("Progress update: %d/%d tokens", resp.PromptEvalCompleted, resp.PromptEvalTotal)
 		}
 		if resp.Done {
 			finalResponse = resp
@@ -634,21 +634,21 @@ func TestAPIGeneratePromptEvalProgress(t *testing.T) {
 
 		// Verify progress updates have valid values
 		for i, update := range progressUpdates {
-			if update.Total <= 0 {
-				t.Errorf("progress update %d has invalid Total: %d", i, update.Total)
+			if update.PromptEvalTotal <= 0 {
+				t.Errorf("progress update %d has invalid PromptEvalTotal: %d", i, update.PromptEvalTotal)
 			}
-			if update.Completed <= 0 {
-				t.Errorf("progress update %d has invalid Completed: %d", i, update.Completed)
+			if update.PromptEvalCompleted <= 0 {
+				t.Errorf("progress update %d has invalid PromptEvalCompleted: %d", i, update.PromptEvalCompleted)
 			}
-			if update.Completed > update.Total {
-				t.Errorf("progress update %d has Completed (%d) > Total (%d)", i, update.Completed, update.Total)
+			if update.PromptEvalCompleted > update.PromptEvalTotal {
+				t.Errorf("progress update %d has PromptEvalCompleted (%d) > PromptEvalTotal (%d)", i, update.PromptEvalCompleted, update.PromptEvalTotal)
 			}
 		}
 
 		// Verify progress is monotonically increasing
 		for i := 1; i < len(progressUpdates); i++ {
-			if progressUpdates[i].Completed < progressUpdates[i-1].Completed {
-				t.Errorf("progress decreased: %d -> %d", progressUpdates[i-1].Completed, progressUpdates[i].Completed)
+			if progressUpdates[i].PromptEvalCompleted < progressUpdates[i-1].PromptEvalCompleted {
+				t.Errorf("progress decreased: %d -> %d", progressUpdates[i-1].PromptEvalCompleted, progressUpdates[i].PromptEvalCompleted)
 			}
 		}
 	}
@@ -692,10 +692,10 @@ func TestAPIChatPromptEvalProgress(t *testing.T) {
 	var finalResponse api.ChatResponse
 
 	err := client.Chat(ctx, &req, func(resp api.ChatResponse) error {
-		// Track progress updates (responses with Completed > 0 and not Done)
-		if resp.Completed > 0 && !resp.Done {
+		// Track progress updates (responses with PromptEvalCompleted > 0 and not Done)
+		if resp.PromptEvalCompleted > 0 && !resp.Done {
 			progressUpdates = append(progressUpdates, resp)
-			t.Logf("Progress update: %d/%d tokens", resp.Completed, resp.Total)
+			t.Logf("Progress update: %d/%d tokens", resp.PromptEvalCompleted, resp.PromptEvalTotal)
 		}
 		if resp.Done {
 			finalResponse = resp
@@ -714,21 +714,21 @@ func TestAPIChatPromptEvalProgress(t *testing.T) {
 
 		// Verify progress updates have valid values
 		for i, update := range progressUpdates {
-			if update.Total <= 0 {
-				t.Errorf("progress update %d has invalid Total: %d", i, update.Total)
+			if update.PromptEvalTotal <= 0 {
+				t.Errorf("progress update %d has invalid PromptEvalTotal: %d", i, update.PromptEvalTotal)
 			}
-			if update.Completed <= 0 {
-				t.Errorf("progress update %d has invalid Completed: %d", i, update.Completed)
+			if update.PromptEvalCompleted <= 0 {
+				t.Errorf("progress update %d has invalid PromptEvalCompleted: %d", i, update.PromptEvalCompleted)
 			}
-			if update.Completed > update.Total {
-				t.Errorf("progress update %d has Completed (%d) > Total (%d)", i, update.Completed, update.Total)
+			if update.PromptEvalCompleted > update.PromptEvalTotal {
+				t.Errorf("progress update %d has PromptEvalCompleted (%d) > PromptEvalTotal (%d)", i, update.PromptEvalCompleted, update.PromptEvalTotal)
 			}
 		}
 
 		// Verify progress is monotonically increasing
 		for i := 1; i < len(progressUpdates); i++ {
-			if progressUpdates[i].Completed < progressUpdates[i-1].Completed {
-				t.Errorf("progress decreased: %d -> %d", progressUpdates[i-1].Completed, progressUpdates[i].Completed)
+			if progressUpdates[i].PromptEvalCompleted < progressUpdates[i-1].PromptEvalCompleted {
+				t.Errorf("progress decreased: %d -> %d", progressUpdates[i-1].PromptEvalCompleted, progressUpdates[i].PromptEvalCompleted)
 			}
 		}
 	}

--- a/llm/server.go
+++ b/llm/server.go
@@ -1531,11 +1531,11 @@ type CompletionResponse struct {
 	// TotalSteps is the total number of steps for image generation
 	TotalSteps int `json:"total_steps,omitempty"`
 
-	// Completed is the number of tokens processed during prompt evaluation
-	Completed int `json:"completed,omitempty"`
+	// PromptEvalCompleted is the number of tokens processed during prompt evaluation
+	PromptEvalCompleted int `json:"prompt_eval_completed,omitempty"`
 
-	// Total is the total number of tokens to process during prompt evaluation
-	Total int `json:"total,omitempty"`
+	// PromptEvalTotal is the total number of tokens to process during prompt evaluation
+	PromptEvalTotal int `json:"prompt_eval_total,omitempty"`
 }
 
 func (s *llmServer) Completion(ctx context.Context, req CompletionRequest, fn func(CompletionResponse)) error {
@@ -1669,12 +1669,12 @@ func (s *llmServer) Completion(ctx context.Context, req CompletionRequest, fn fu
 				return ctx.Err()
 			}
 
-			if c.Content != "" || c.Completed > 0 {
+			if c.Content != "" || c.PromptEvalCompleted > 0 {
 				fn(CompletionResponse{
-					Content:   c.Content,
-					Logprobs:  c.Logprobs,
-					Completed: c.Completed,
-					Total:     c.Total,
+					Content:             c.Content,
+					Logprobs:            c.Logprobs,
+					PromptEvalCompleted: c.PromptEvalCompleted,
+					PromptEvalTotal:     c.PromptEvalTotal,
 				})
 			}
 

--- a/runner/llamarunner/runner.go
+++ b/runner/llamarunner/runner.go
@@ -32,10 +32,10 @@ import (
 
 // response contains a piece of generated text along with optional logprobs
 type response struct {
-	content   string
-	logprobs  []llm.Logprob
-	completed int // prompt eval progress: tokens processed so far
-	total     int // prompt eval progress: total tokens to process
+	content             string
+	logprobs            []llm.Logprob
+	promptEvalCompleted int // prompt eval progress: tokens processed so far
+	promptEvalTotal     int // prompt eval progress: total tokens to process
 }
 
 // input is an element of the prompt to process, either
@@ -526,15 +526,14 @@ func (s *Server) processBatch(tokenBatch *llama.Batch, embedBatch *llama.Batch) 
 			if seq.promptEvalProgress > 0 {
 				processed := seq.numPromptInputs - len(seq.inputs)
 				if processed-seq.lastProgressSent >= seq.promptEvalProgress {
-					// Non-blocking send to avoid blocking while holding mutex
 					select {
 					case seq.responses <- response{
-						completed: processed,
-						total:     seq.numPromptInputs,
+						promptEvalCompleted: processed,
+						promptEvalTotal:     seq.numPromptInputs,
 					}:
 						seq.lastProgressSent = processed
-					default:
-						// Channel full, skip this update
+					case <-seq.quit:
+						continue
 					}
 				}
 			}
@@ -746,10 +745,10 @@ func (s *Server) completion(w http.ResponseWriter, r *http.Request) {
 		case resp, ok := <-seq.responses:
 			if ok {
 				if err := json.NewEncoder(w).Encode(&llm.CompletionResponse{
-					Content:   resp.content,
-					Logprobs:  resp.logprobs,
-					Completed: resp.completed,
-					Total:     resp.total,
+					Content:             resp.content,
+					Logprobs:            resp.logprobs,
+					PromptEvalCompleted: resp.promptEvalCompleted,
+					PromptEvalTotal:     resp.promptEvalTotal,
 				}); err != nil {
 					http.Error(w, fmt.Sprintf("failed to encode response: %v", err), http.StatusInternalServerError)
 					close(seq.quit)

--- a/server/routes.go
+++ b/server/routes.go
@@ -533,12 +533,12 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 			PromptEvalProgress: req.PromptEvalProgress,
 		}, func(cr llm.CompletionResponse) {
 			res := api.GenerateResponse{
-				Model:     req.Model,
-				CreatedAt: time.Now().UTC(),
-				Response:  cr.Content,
-				Done:      cr.Done,
-				Completed: int64(cr.Completed),
-				Total:     int64(cr.Total),
+				Model:               req.Model,
+				CreatedAt:           time.Now().UTC(),
+				Response:            cr.Content,
+				Done:                cr.Done,
+				PromptEvalCompleted: int64(cr.PromptEvalCompleted),
+				PromptEvalTotal:     int64(cr.PromptEvalTotal),
 				Metrics: api.Metrics{
 					PromptEvalCount:    cr.PromptEvalCount,
 					PromptEvalDuration: cr.PromptEvalDuration,
@@ -2240,12 +2240,12 @@ func (s *Server) ChatHandler(c *gin.Context) {
 				PromptEvalProgress: req.PromptEvalProgress,
 			}, func(r llm.CompletionResponse) {
 				res := api.ChatResponse{
-					Model:     req.Model,
-					CreatedAt: time.Now().UTC(),
-					Message:   api.Message{Role: "assistant", Content: r.Content},
-					Done:      r.Done,
-					Completed: int64(r.Completed),
-					Total:     int64(r.Total),
+					Model:               req.Model,
+					CreatedAt:           time.Now().UTC(),
+					Message:             api.Message{Role: "assistant", Content: r.Content},
+					Done:                r.Done,
+					PromptEvalCompleted: int64(r.PromptEvalCompleted),
+					PromptEvalTotal:     int64(r.PromptEvalTotal),
 					Metrics: api.Metrics{
 						PromptEvalCount:    r.PromptEvalCount,
 						PromptEvalDuration: r.PromptEvalDuration,

--- a/server/routes_generate_test.go
+++ b/server/routes_generate_test.go
@@ -2447,8 +2447,8 @@ func TestChatPromptEvalProgress(t *testing.T) {
 	// Track the CompletionRequest to verify PromptEvalProgress is passed through
 	var capturedRequest llm.CompletionRequest
 	progressResponses := []llm.CompletionResponse{
-		{Completed: 10, Total: 100},
-		{Completed: 50, Total: 100},
+		{PromptEvalCompleted: 10, PromptEvalTotal: 100},
+		{PromptEvalCompleted: 50, PromptEvalTotal: 100},
 		{Content: "Hello!", Done: true, DoneReason: llm.DoneReasonStop, PromptEvalCount: 100, PromptEvalDuration: 1, EvalCount: 1, EvalDuration: 1},
 	}
 
@@ -2557,15 +2557,15 @@ func TestChatPromptEvalProgress(t *testing.T) {
 		}
 
 		// First response should have progress info
-		if responses[0].Completed != 10 || responses[0].Total != 100 {
-			t.Errorf("first response: expected Completed=10, Total=100, got Completed=%d, Total=%d",
-				responses[0].Completed, responses[0].Total)
+		if responses[0].PromptEvalCompleted != 10 || responses[0].PromptEvalTotal != 100 {
+			t.Errorf("first response: expected PromptEvalCompleted=10, PromptEvalTotal=100, got PromptEvalCompleted=%d, PromptEvalTotal=%d",
+				responses[0].PromptEvalCompleted, responses[0].PromptEvalTotal)
 		}
 
 		// Second response should have more progress
-		if responses[1].Completed != 50 || responses[1].Total != 100 {
-			t.Errorf("second response: expected Completed=50, Total=100, got Completed=%d, Total=%d",
-				responses[1].Completed, responses[1].Total)
+		if responses[1].PromptEvalCompleted != 50 || responses[1].PromptEvalTotal != 100 {
+			t.Errorf("second response: expected PromptEvalCompleted=50, PromptEvalTotal=100, got PromptEvalCompleted=%d, PromptEvalTotal=%d",
+				responses[1].PromptEvalCompleted, responses[1].PromptEvalTotal)
 		}
 
 		// Final response should be done
@@ -2612,9 +2612,9 @@ func TestGeneratePromptEvalProgress(t *testing.T) {
 
 	var capturedRequest llm.CompletionRequest
 	progressResponses := []llm.CompletionResponse{
-		{Completed: 25, Total: 200},
-		{Completed: 100, Total: 200},
-		{Completed: 200, Total: 200},
+		{PromptEvalCompleted: 25, PromptEvalTotal: 200},
+		{PromptEvalCompleted: 100, PromptEvalTotal: 200},
+		{PromptEvalCompleted: 200, PromptEvalTotal: 200},
 		{Content: "Response text", Done: true, DoneReason: llm.DoneReasonStop, PromptEvalCount: 200, PromptEvalDuration: 1, EvalCount: 1, EvalDuration: 1},
 	}
 
@@ -2721,19 +2721,19 @@ func TestGeneratePromptEvalProgress(t *testing.T) {
 		}
 
 		// Check progress values in responses
-		if responses[0].Completed != 25 || responses[0].Total != 200 {
-			t.Errorf("first response: expected Completed=25, Total=200, got Completed=%d, Total=%d",
-				responses[0].Completed, responses[0].Total)
+		if responses[0].PromptEvalCompleted != 25 || responses[0].PromptEvalTotal != 200 {
+			t.Errorf("first response: expected PromptEvalCompleted=25, PromptEvalTotal=200, got PromptEvalCompleted=%d, PromptEvalTotal=%d",
+				responses[0].PromptEvalCompleted, responses[0].PromptEvalTotal)
 		}
 
-		if responses[1].Completed != 100 || responses[1].Total != 200 {
-			t.Errorf("second response: expected Completed=100, Total=200, got Completed=%d, Total=%d",
-				responses[1].Completed, responses[1].Total)
+		if responses[1].PromptEvalCompleted != 100 || responses[1].PromptEvalTotal != 200 {
+			t.Errorf("second response: expected PromptEvalCompleted=100, PromptEvalTotal=200, got PromptEvalCompleted=%d, PromptEvalTotal=%d",
+				responses[1].PromptEvalCompleted, responses[1].PromptEvalTotal)
 		}
 
-		if responses[2].Completed != 200 || responses[2].Total != 200 {
-			t.Errorf("third response: expected Completed=200, Total=200, got Completed=%d, Total=%d",
-				responses[2].Completed, responses[2].Total)
+		if responses[2].PromptEvalCompleted != 200 || responses[2].PromptEvalTotal != 200 {
+			t.Errorf("third response: expected PromptEvalCompleted=200, PromptEvalTotal=200, got PromptEvalCompleted=%d, PromptEvalTotal=%d",
+				responses[2].PromptEvalCompleted, responses[2].PromptEvalTotal)
 		}
 
 		// Final response should be done with content


### PR DESCRIPTION
This is a messy proof of concept draft. 

I have workloads with long prompts on a weak ollama server. As a result of this, a progress indicator on prompt processing should significantly improve frontend user experience. To this end, this PR proposes an optional flag to allow prompt processing updates to be added to streaming endpoints before response tokens are generated. This is in a rough state, and I will clean it up before requesting review, though I would love to hear people's thoughts on this. I will also make an accompanying issue.

I tested manually with the following curl commands, I will look into automated tests.

## With new `prompt_eval_progress` argument
````
curl -N http://localhost:11434/api/generate -d "{\"model\": \"gemma3:270m\", \"prompt\": \"$(python3 -c "print('The quick brown fox jumps over the lazy dog. ' * 200)")\", \"prompt_eval_progress\": 100, \"stream\": true}"

````
## Response from ollama
````
{"model":"gemma3:270m","created_at":"2026-01-26T05:50:52.817104393Z","response":"","done":false,"prompt_eval_completed":512,"prompt_eval_total":2010}
{"model":"gemma3:270m","created_at":"2026-01-26T05:51:01.287749423Z","response":"","done":false,"prompt_eval_completed":1024,"prompt_eval_total":2010}
{"model":"gemma3:270m","created_at":"2026-01-26T05:51:12.605503033Z","response":"","done":false,"prompt_eval_completed":1536,"prompt_eval_total":2010}
{"model":"gemma3:270m","created_at":"2026-01-26T05:51:39.533355083Z","response":"The","done":false}
{"model":"gemma3:270m","created_at":"2026-01-26T05:51:39.596124743Z","response":" quick","done":false}
{"model":"gemma3:270m","created_at":"2026-01-26T05:51:39.659647952Z","response":" brown","done":false}
{"model":"gemma3:270m","created_at":"2026-01-26T05:51:39.749931059Z","response":" fox","done":false}
{"model":"gemma3:270m","created_at":"2026-01-26T05:51:39.819387197Z","response":" jumps","done":false}
{"model":"gemma3:270m","created_at":"2026-01-26T05:51:39.895974067Z","response":" over","done":false}
{"model":"gemma3:270m","created_at":"2026-01-26T05:51:39.965382281Z","response":" the","done":false}
{"model":"gemma3:270m","created_at":"2026-01-26T05:51:40.052979529Z","response":" lazy","done":false}
{"model":"gemma3:270m","created_at":"2026-01-26T05:51:40.146880588Z","response":" dog","done":false}
{"model":"gemma3:270m","created_at":"2026-01-26T05:51:40.2099141Z","response":".","done":false}
{"model":"gemma3:270m","created_at":"2026-01-26T05:51:40.29996901Z","response":"\n","done":false}
...

````

## Without new `prompt_eval_progress` argument

````
 curl -N http://localhost:11434/api/generate -d "{\"model\": \"gemma3:270m\", \"prompt\": \"$(python3 -c "print('The quick brown fox jumps over the lazy dog. ' * 200)")\",  \"stream\": true}"
````
## Response from Ollama

````
{"model":"gemma3:270m","created_at":"2026-01-26T05:50:52.817104393Z","response":"","done":false,"prompt_eval_completed":512,"prompt_eval_total":2010}
{"model":"gemma3:270m","created_at":"2026-01-26T05:51:01.287749423Z","response":"","done":false,"prompt_eval_completed":1024,"prompt_eval_total":2010}
{"model":"gemma3:270m","created_at":"2026-01-26T05:51:12.605503033Z","response":"","done":false,"prompt_eval_completed":1536,"prompt_eval_total":2010}
{"model":"gemma3:270m","created_at":"2026-01-26T05:51:39.533355083Z","response":"The","done":false}
{"model":"gemma3:270m","created_at":"2026-01-26T05:51:39.596124743Z","response":" quick","done":false}
{"model":"gemma3:270m","created_at":"2026-01-26T05:51:39.659647952Z","response":" brown","done":false}
{"model":"gemma3:270m","created_at":"2026-01-26T05:51:39.749931059Z","response":" fox","done":false}
{"model":"gemma3:270m","created_at":"2026-01-26T05:51:39.819387197Z","response":" jumps","done":false}
{"model":"gemma3:270m","created_at":"2026-01-26T05:51:39.895974067Z","response":" over","done":false}
{"model":"gemma3:270m","created_at":"2026-01-26T05:51:39.965382281Z","response":" the","done":false}
{"model":"gemma3:270m","created_at":"2026-01-26T05:51:40.052979529Z","response":" lazy","done":false}
{"model":"gemma3:270m","created_at":"2026-01-26T05:51:40.146880588Z","response":" dog","done":false}
{"model":"gemma3:270m","created_at":"2026-01-26T05:51:40.2099141Z","response":".","done":false}
{"model":"gemma3:270m","created_at":"2026-01-26T05:51:40.29996901Z","response":"\n","done":false}

...
````

