### PR TITLE
docs: add Libre WebUI to community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [StreamDeploy](https://github.com/StreamDeploy-DevRel/streamdeploy-llm-app-scaffold) (LLM Application Scaffold)
 - [chat](https://github.com/swuecho/chat) (chat web app for teams)
 - [Lobe Chat](https://github.com/lobehub/lobe-chat) with [Integrating Doc](https://lobehub.com/docs/self-hosting/examples/ollama)
+- [Libre WebUI](https://github.com/libre-webui/libre-webui) (Privacy-first web UI with multi-user support, personas, and plugins)
 - [Ollama RAG Chatbot](https://github.com/datvodinh/rag-chatbot.git) (Local Chat with multiple PDFs using Ollama and RAG)
 - [BrainSoup](https://www.nurgo-software.com/products/brainsoup) (Flexible native client with RAG & multi-agent automation)
 - [macai](https://github.com/Renset/macai) (macOS client for Ollama, ChatGPT, and other compatible API back-ends)


### PR DESCRIPTION
Adds [Libre WebUI](https://github.com/libre-webui/libre-webui) to the Web & Desktop community integrations list.

## Screenshots

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/eea9df3a-3f9f-4429-bff1-a94a5cc4550c" />

## Features

- Full Ollama integration (model management, pull, delete, chat)
- Multi-user authentication with role-based access
- Custom personas with memory
- Document chat (RAG) with PDF support
- Plugin system for additional providers
- Docker, Kubernetes (Helm), and native desktop apps
- 25+ languages
- Privacy-first, zero telemetry

## Links

- **Website:** https://librewebui.org
- **Docs:** https://docs.librewebui.org
- **Repository:** https://github.com/libre-webui/libre-webui
