### PR TITLE
parsers/ministral: fix nested tool call parsing by counting brace nesting

### DIFF
--- a/model/parsers/ministral.go
+++ b/model/parsers/ministral.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"unicode"
 
 	"github.com/ollama/ollama/api"
 )
@@ -17,12 +18,34 @@ const (
 	ministralCollectingToolArgs
 )
 
+// ministralEvent represents an event emitted during parsing
+type ministralEvent interface {
+	isMinistralEvent()
+}
+
+type ministralEventContent struct {
+	content string
+}
+
+type ministralEventThinking struct {
+	thinking string
+}
+
+type ministralEventToolCall struct {
+	name string
+	args string // raw JSON string
+}
+
+func (ministralEventContent) isMinistralEvent()  {}
+func (ministralEventThinking) isMinistralEvent() {}
+func (ministralEventToolCall) isMinistralEvent() {}
+
 type MinistralParser struct {
 	state              ministralParserState
 	buffer             strings.Builder
 	tools              []api.Tool
 	hasThinkingSupport bool
-	currentTool        *api.Tool
+	pendingToolName    string // stores tool name while collecting args
 }
 
 func (p *MinistralParser) HasToolSupport() bool {
@@ -63,79 +86,209 @@ func toolByName(tools []api.Tool, n string) (*api.Tool, error) {
 	return nil, fmt.Errorf("tool '%s' not found", n)
 }
 
-func (p *MinistralParser) Add(s string, done bool) (content string, thinking string, calls []api.ToolCall, err error) {
-	p.buffer.WriteString(s)
+const (
+	ministralToolCallsTag = "[TOOL_CALLS]"
+	ministralThinkTag     = "[THINK]"
+	ministralThinkEndTag  = "[/THINK]"
+	ministralArgsTag      = "[ARGS]"
+)
+
+// eat consumes the parser's buffer, and returns a list of any unambiguous
+// events from the current parser state. The second return value indicates
+// whether to keep looping (true when state transitions, false when waiting
+// for more data).
+func (p *MinistralParser) eat() ([]ministralEvent, bool) {
+	var events []ministralEvent
 
 	switch p.state {
 	case ministralCollectingContent:
-		if strings.Contains(p.buffer.String(), "[TOOL_CALLS]") {
-			before, _ := splitAtTag(&p.buffer, "[TOOL_CALLS]", false)
-			if before != "" {
-				return before, "", calls, nil
+		bufStr := p.buffer.String()
+
+		// Check for [TOOL_CALLS] tag
+		if strings.Contains(bufStr, ministralToolCallsTag) {
+			split := strings.SplitN(bufStr, ministralToolCallsTag, 2)
+			before := strings.TrimRightFunc(split[0], unicode.IsSpace)
+			if len(before) > 0 {
+				events = append(events, ministralEventContent{content: before})
 			}
+			after := split[1]
+			p.buffer.Reset()
+			p.buffer.WriteString(after)
 			p.state = ministralCollectingToolName
-		} else if strings.Contains(p.buffer.String(), "[THINK]") {
+			return events, true
+		}
+
+		// Check for [THINK] tag
+		if strings.Contains(bufStr, ministralThinkTag) {
+			split := strings.SplitN(bufStr, ministralThinkTag, 2)
+			before := strings.TrimRightFunc(split[0], unicode.IsSpace)
+			if len(before) > 0 {
+				events = append(events, ministralEventContent{content: before})
+			}
+			after := split[1]
+			p.buffer.Reset()
+			p.buffer.WriteString(after)
 			p.state = ministralCollectingThinkingContent
-			return "", "", calls, nil
-		} else {
-			p.buffer.Reset()
-			return s, "", calls, nil
+			return events, true
 		}
+
+		// Check for partial tag overlap with [TOOL_CALLS] or [THINK]
+		overlapToolCalls := overlap(bufStr, ministralToolCallsTag)
+		overlapThink := overlap(bufStr, ministralThinkTag)
+		maxOverlap := max(overlapToolCalls, overlapThink)
+
+		if maxOverlap > 0 {
+			// Withhold the potential partial tag
+			beforePartialTag := bufStr[:len(bufStr)-maxOverlap]
+			trailingWS := trailingWhitespaceLen(beforePartialTag)
+			ambiguousStart := len(beforePartialTag) - trailingWS
+			unambiguous := bufStr[:ambiguousStart]
+			ambiguous := bufStr[ambiguousStart:]
+			p.buffer.Reset()
+			p.buffer.WriteString(ambiguous)
+			if len(unambiguous) > 0 {
+				events = append(events, ministralEventContent{content: unambiguous})
+			}
+			return events, false
+		}
+
+		// No tag found: emit content but withhold trailing whitespace
+		whitespaceLen := trailingWhitespaceLen(bufStr)
+		ambiguousStart := len(bufStr) - whitespaceLen
+		unambiguous := bufStr[:ambiguousStart]
+		ambiguous := bufStr[ambiguousStart:]
+		p.buffer.Reset()
+		p.buffer.WriteString(ambiguous)
+		if len(unambiguous) > 0 {
+			events = append(events, ministralEventContent{content: unambiguous})
+		}
+		return events, false
+
 	case ministralCollectingThinkingContent:
-		if strings.Contains(p.buffer.String(), "[/THINK]") {
-			thinkingContent, after := splitAtTag(&p.buffer, "[/THINK]", true)
-			p.state = ministralCollectingContent
-			if after != "" {
-				p.buffer.Reset()
-				return after, thinkingContent, calls, nil
-			}
-			return "", thinkingContent, calls, nil
-		} else {
+		bufStr := p.buffer.String()
+
+		if strings.Contains(bufStr, ministralThinkEndTag) {
+			split := strings.SplitN(bufStr, ministralThinkEndTag, 2)
+			thinkingContent := split[0]
+			after := strings.TrimLeftFunc(split[1], unicode.IsSpace)
 			p.buffer.Reset()
-			return "", s, calls, nil
+			p.buffer.WriteString(after)
+			if len(thinkingContent) > 0 {
+				events = append(events, ministralEventThinking{thinking: thinkingContent})
+			}
+			p.state = ministralCollectingContent
+			return events, true
 		}
+
+		// Check for partial overlap with [/THINK]
+		if overlapLen := overlap(bufStr, ministralThinkEndTag); overlapLen > 0 {
+			unambiguous := bufStr[:len(bufStr)-overlapLen]
+			ambiguous := bufStr[len(bufStr)-overlapLen:]
+			p.buffer.Reset()
+			p.buffer.WriteString(ambiguous)
+			if len(unambiguous) > 0 {
+				events = append(events, ministralEventThinking{thinking: unambiguous})
+			}
+			return events, false
+		}
+
+		// No tag found: emit all thinking content
+		p.buffer.Reset()
+		if len(bufStr) > 0 {
+			events = append(events, ministralEventThinking{thinking: bufStr})
+		}
+		return events, false
+
 	case ministralCollectingToolName:
-		if strings.Contains(p.buffer.String(), "[ARGS]") {
-			name, _ := splitAtTag(&p.buffer, "[ARGS]", false)
+		bufStr := p.buffer.String()
 
-			t, err := toolByName(p.tools, name)
-			if err != nil {
-				return "", "", calls, err
-			}
-			p.currentTool = t
+		if strings.Contains(bufStr, ministralArgsTag) {
+			split := strings.SplitN(bufStr, ministralArgsTag, 2)
+			toolName := split[0]
+			after := split[1]
+			p.pendingToolName = toolName
+			p.buffer.Reset()
+			p.buffer.WriteString(after)
 			p.state = ministralCollectingToolArgs
-			return "", "", calls, nil
+			return events, true
 		}
-		return "", "", calls, nil
+		// Wait for more data
+		return events, false
+
 	case ministralCollectingToolArgs:
-		bufferString := p.buffer.String()
-		jsonEnd := findJSONEnd(bufferString)
+		bufStr := p.buffer.String()
+		jsonEnd := findJSONEnd(bufStr)
+
 		if jsonEnd != -1 {
-			jsonStr := bufferString[:jsonEnd+1]
-			remaining := bufferString[jsonEnd+1:]
+			jsonStr := bufStr[:jsonEnd+1]
+			remaining := bufStr[jsonEnd+1:]
 
-			var args api.ToolCallFunctionArguments
-			if err := json.Unmarshal([]byte(jsonStr), &args); err != nil {
-				return "", "", calls, err
-			}
+			events = append(events, ministralEventToolCall{
+				name: p.pendingToolName,
+				args: jsonStr,
+			})
 
+			p.pendingToolName = ""
 			p.buffer.Reset()
 			p.buffer.WriteString(remaining)
 			p.state = ministralCollectingContent
+			return events, true
+		}
+		// Wait for more data
+		return events, false
 
-			call := api.ToolCall{
+	default:
+		panic("unexpected ministral event")
+	}
+}
+
+// parseEvents loops calling eat() until it returns false
+func (p *MinistralParser) parseEvents() []ministralEvent {
+	var all []ministralEvent
+	keepLooping := true
+	for keepLooping {
+		var events []ministralEvent
+		events, keepLooping = p.eat()
+		all = append(all, events...)
+	}
+	return all
+}
+
+func (p *MinistralParser) Add(s string, done bool) (content string, thinking string, calls []api.ToolCall, err error) {
+	p.buffer.WriteString(s)
+
+	events := p.parseEvents()
+
+	var contentBuilder, thinkingBuilder strings.Builder
+	var toolCalls []api.ToolCall
+
+	for _, event := range events {
+		switch e := event.(type) {
+		case ministralEventContent:
+			contentBuilder.WriteString(e.content)
+		case ministralEventThinking:
+			thinkingBuilder.WriteString(e.thinking)
+		case ministralEventToolCall:
+			// Validate tool exists
+			tool, toolErr := toolByName(p.tools, e.name)
+			if toolErr != nil {
+				return contentBuilder.String(), thinkingBuilder.String(), toolCalls, toolErr
+			}
+			// Parse JSON arguments
+			var args api.ToolCallFunctionArguments
+			if jsonErr := json.Unmarshal([]byte(e.args), &args); jsonErr != nil {
+				return contentBuilder.String(), thinkingBuilder.String(), toolCalls, jsonErr
+			}
+			toolCalls = append(toolCalls, api.ToolCall{
 				Function: api.ToolCallFunction{
-					Name:      p.currentTool.Function.Name,
+					Name:      tool.Function.Name,
 					Arguments: args,
 				},
-			}
-			calls = append(calls, call)
-			return "", "", calls, nil
+			})
 		}
-		return "", "", calls, nil
 	}
 
-	return p.buffer.String(), thinking, calls, nil
+	return contentBuilder.String(), thinkingBuilder.String(), toolCalls, nil
 }
 
 // findJSONEnd finds the index of the closing brace that completes a JSON object.

--- a/model/parsers/ministral_test.go
+++ b/model/parsers/ministral_test.go
@@ -1,317 +1,420 @@
 package parsers
 
 import (
+	"reflect"
 	"testing"
-
-	"github.com/google/go-cmp/cmp"
 
 	"github.com/ollama/ollama/api"
 )
 
-// processAll keeps calling Add until no more progress is made.
-// This simulates the behavior of feeding all input at once and letting
-// the parser process through multiple states.
-func processAll(p *MinistralParser, input string) (content, thinking string, calls []api.ToolCall, err error) {
-	// Feed the input
-	c, th, cl, err := p.Add(input, false)
-	if err != nil {
-		return c, th, cl, err
-	}
-	content += c
-	thinking += th
-	calls = append(calls, cl...)
-
-	// Keep calling Add with empty string until parser settles
-	// This allows state transitions to complete
-	for range 10 { // max 10 iterations to prevent infinite loop
-		c, th, cl, err := p.Add("", false)
-		if err != nil {
-			return content + c, thinking + th, append(calls, cl...), err
-		}
-		if c == "" && th == "" && len(cl) == 0 {
-			break
-		}
-		content += c
-		thinking += th
-		calls = append(calls, cl...)
+func TestMinistralParserStreaming(t *testing.T) {
+	type step struct {
+		input      string
+		wantEvents []ministralEvent
 	}
 
-	// Final drain
-	c, th, cl, err = p.Add("", true)
-	if err != nil {
-		return content + c, thinking + th, append(calls, cl...), err
-	}
-	content += c
-	thinking += th
-	calls = append(calls, cl...)
-
-	return content, thinking, calls, nil
-}
-
-func TestMinistralParser(t *testing.T) {
-	tests := []struct {
-		name             string
-		tools            []api.Tool
-		input            string
-		expectedContent  string
-		expectedThinking string
-		expectedCalls    []api.ToolCall
+	cases := []struct {
+		desc  string
+		tools []api.Tool
+		steps []step
+		think bool // whether to enable thinking support
 	}{
+		// Content streaming
 		{
-			name:            "simple content",
-			input:           "Hello, how can I help you?",
-			expectedContent: "Hello, how can I help you?",
+			desc: "simple content",
+			steps: []step{
+				{input: "Hello, how can I help you?", wantEvents: []ministralEvent{
+					ministralEventContent{content: "Hello, how can I help you?"},
+				}},
+			},
 		},
 		{
-			name: "simple tool call",
+			desc: "streaming content word by word",
+			steps: []step{
+				{input: "Hello,", wantEvents: []ministralEvent{ministralEventContent{content: "Hello,"}}},
+				{input: " how", wantEvents: []ministralEvent{ministralEventContent{content: " how"}}},
+				{input: " can I help?", wantEvents: []ministralEvent{ministralEventContent{content: " can I help?"}}},
+			},
+		},
+
+		// Simple tool calls
+		{
+			desc:  "simple tool call",
+			tools: []api.Tool{{Function: api.ToolFunction{Name: "get_weather"}}},
+			steps: []step{
+				{input: `[TOOL_CALLS]get_weather[ARGS]{"location": "San Francisco"}`, wantEvents: []ministralEvent{
+					ministralEventToolCall{name: "get_weather", args: `{"location": "San Francisco"}`},
+				}},
+			},
+		},
+		{
+			desc:  "tool call with nested object",
+			tools: []api.Tool{{Function: api.ToolFunction{Name: "create_entities"}}},
+			steps: []step{
+				{input: `[TOOL_CALLS]create_entities[ARGS]{"entities": [{"entityType": "Person", "name": "Jack", "observations": ["Works as a baker"]}]}`, wantEvents: []ministralEvent{
+					ministralEventToolCall{name: "create_entities", args: `{"entities": [{"entityType": "Person", "name": "Jack", "observations": ["Works as a baker"]}]}`},
+				}},
+			},
+		},
+		{
+			desc:  "tool call with deeply nested objects",
+			tools: []api.Tool{{Function: api.ToolFunction{Name: "update_config"}}},
+			steps: []step{
+				{input: `[TOOL_CALLS]update_config[ARGS]{"settings": {"user": {"profile": {"name": "John", "age": 30}}, "theme": "dark"}}`, wantEvents: []ministralEvent{
+					ministralEventToolCall{name: "update_config", args: `{"settings": {"user": {"profile": {"name": "John", "age": 30}}, "theme": "dark"}}`},
+				}},
+			},
+		},
+		{
+			desc:  "tool call with array of objects",
+			tools: []api.Tool{{Function: api.ToolFunction{Name: "process_items"}}},
+			steps: []step{
+				{input: `[TOOL_CALLS]process_items[ARGS]{"items": [{"id": 1}, {"id": 2}, {"id": 3}]}`, wantEvents: []ministralEvent{
+					ministralEventToolCall{name: "process_items", args: `{"items": [{"id": 1}, {"id": 2}, {"id": 3}]}`},
+				}},
+			},
+		},
+		{
+			desc:  "tool call with escaped quotes in string",
+			tools: []api.Tool{{Function: api.ToolFunction{Name: "search"}}},
+			steps: []step{
+				{input: `[TOOL_CALLS]search[ARGS]{"query": "say \"hello\""}`, wantEvents: []ministralEvent{
+					ministralEventToolCall{name: "search", args: `{"query": "say \"hello\""}`},
+				}},
+			},
+		},
+		{
+			desc:  "tool call with braces inside string",
+			tools: []api.Tool{{Function: api.ToolFunction{Name: "format"}}},
+			steps: []step{
+				{input: `[TOOL_CALLS]format[ARGS]{"template": "Hello {name}!"}`, wantEvents: []ministralEvent{
+					ministralEventToolCall{name: "format", args: `{"template": "Hello {name}!"}`},
+				}},
+			},
+		},
+		{
+			desc:  "empty JSON object",
+			tools: []api.Tool{{Function: api.ToolFunction{Name: "no_args"}}},
+			steps: []step{
+				{input: `[TOOL_CALLS]no_args[ARGS]{}`, wantEvents: []ministralEvent{
+					ministralEventToolCall{name: "no_args", args: `{}`},
+				}},
+			},
+		},
+		{
+			desc:  "JSON with newlines in string",
+			tools: []api.Tool{{Function: api.ToolFunction{Name: "write"}}},
+			steps: []step{
+				{input: `[TOOL_CALLS]write[ARGS]{"content": "line1\nline2\nline3"}`, wantEvents: []ministralEvent{
+					ministralEventToolCall{name: "write", args: `{"content": "line1\nline2\nline3"}`},
+				}},
+			},
+		},
+		{
+			desc:  "backslash in string value",
+			tools: []api.Tool{{Function: api.ToolFunction{Name: "path"}}},
+			steps: []step{
+				{input: `[TOOL_CALLS]path[ARGS]{"dir": "C:\\Users\\test"}`, wantEvents: []ministralEvent{
+					ministralEventToolCall{name: "path", args: `{"dir": "C:\\Users\\test"}`},
+				}},
+			},
+		},
+
+		// Content after tool call
+		{
+			desc:  "content after tool call",
+			tools: []api.Tool{{Function: api.ToolFunction{Name: "test"}}},
+			steps: []step{
+				// NOTE: It's unclear if this is valid Ministral output, but the parser
+				// currently treats text after a tool call as regular content. This test
+				// documents that behavior so we notice if it changes.
+				{input: `[TOOL_CALLS]test[ARGS]{"a": 1}some content after`, wantEvents: []ministralEvent{
+					ministralEventToolCall{name: "test", args: `{"a": 1}`},
+					ministralEventContent{content: "some content after"},
+				}},
+			},
+		},
+
+		// Multiple tool calls
+		{
+			desc: "multiple tool calls in sequence",
 			tools: []api.Tool{
 				{Function: api.ToolFunction{Name: "get_weather"}},
+				{Function: api.ToolFunction{Name: "get_time"}},
 			},
-			input:           `[TOOL_CALLS]get_weather[ARGS]{"location": "San Francisco"}`,
-			expectedContent: `get_weather[ARGS]{"location": "San Francisco"}`,
-			expectedCalls: []api.ToolCall{
-				{
-					Function: api.ToolCallFunction{
-						Name:      "get_weather",
-						Arguments: testArgs(map[string]any{"location": "San Francisco"}),
-					},
-				},
+			steps: []step{
+				{input: `[TOOL_CALLS]get_weather[ARGS]{"location": "NYC"}[TOOL_CALLS]get_time[ARGS]{"timezone": "EST"}`, wantEvents: []ministralEvent{
+					ministralEventToolCall{name: "get_weather", args: `{"location": "NYC"}`},
+					ministralEventToolCall{name: "get_time", args: `{"timezone": "EST"}`},
+				}},
 			},
 		},
 		{
-			name: "tool call with nested object",
+			desc: "multiple tool calls streamed separately",
 			tools: []api.Tool{
-				{Function: api.ToolFunction{Name: "create_entities"}},
+				{Function: api.ToolFunction{Name: "tool_a"}},
+				{Function: api.ToolFunction{Name: "tool_b"}},
 			},
-			input:           `[TOOL_CALLS]create_entities[ARGS]{"entities": [{"entityType": "Person", "name": "Jack", "observations": ["Works as a baker at Big Baker Co."]}]}`,
-			expectedContent: `create_entities[ARGS]{"entities": [{"entityType": "Person", "name": "Jack", "observations": ["Works as a baker at Big Baker Co."]}]}`,
-			expectedCalls: []api.ToolCall{
-				{
-					Function: api.ToolCallFunction{
-						Name: "create_entities",
-						Arguments: testArgs(map[string]any{
-							"entities": []any{
-								map[string]any{
-									"entityType":   "Person",
-									"name":         "Jack",
-									"observations": []any{"Works as a baker at Big Baker Co."},
-								},
-							},
-						}),
-					},
-				},
+			steps: []step{
+				{input: `[TOOL_CALLS]tool_a[ARGS]{"x": 1}`, wantEvents: []ministralEvent{
+					ministralEventToolCall{name: "tool_a", args: `{"x": 1}`},
+				}},
+				{input: `[TOOL_CALLS]tool_b[ARGS]{"y": 2}`, wantEvents: []ministralEvent{
+					ministralEventToolCall{name: "tool_b", args: `{"y": 2}`},
+				}},
+			},
+		},
+
+		// Streaming tool calls
+		{
+			desc:  "streaming tool call with nested objects",
+			tools: []api.Tool{{Function: api.ToolFunction{Name: "create_entities"}}},
+			steps: []step{
+				{input: "[TOOL_CALLS]create_entities[ARGS]", wantEvents: []ministralEvent{}},
+				{input: `{"entities": [{"entityType": "Person",`, wantEvents: []ministralEvent{}},
+				{input: ` "name": "Jack",`, wantEvents: []ministralEvent{}},
+				{input: ` "observations": ["Works`, wantEvents: []ministralEvent{}},
+				{input: ` as a baker"]}`, wantEvents: []ministralEvent{}},
+				{input: `]}`, wantEvents: []ministralEvent{
+					ministralEventToolCall{name: "create_entities", args: `{"entities": [{"entityType": "Person", "name": "Jack", "observations": ["Works as a baker"]}]}`},
+				}},
 			},
 		},
 		{
-			name: "tool call with deeply nested objects",
-			tools: []api.Tool{
-				{Function: api.ToolFunction{Name: "update_config"}},
+			desc:  "streaming with incomplete JSON waits for completion",
+			tools: []api.Tool{{Function: api.ToolFunction{Name: "test"}}},
+			steps: []step{
+				{input: "[TOOL_CALLS]test[ARGS]{", wantEvents: []ministralEvent{}},
+				{input: `"a": {`, wantEvents: []ministralEvent{}},
+				{input: `"b": 1`, wantEvents: []ministralEvent{}},
+				{input: `}`, wantEvents: []ministralEvent{}},
+				{input: `}`, wantEvents: []ministralEvent{
+					ministralEventToolCall{name: "test", args: `{"a": {"b": 1}}`},
+				}},
 			},
-			input:           `[TOOL_CALLS]update_config[ARGS]{"settings": {"user": {"profile": {"name": "John", "age": 30}}, "theme": "dark"}}`,
-			expectedContent: `update_config[ARGS]{"settings": {"user": {"profile": {"name": "John", "age": 30}}, "theme": "dark"}}`,
-			expectedCalls: []api.ToolCall{
-				{
-					Function: api.ToolCallFunction{
-						Name: "update_config",
-						Arguments: testArgs(map[string]any{
-							"settings": map[string]any{
-								"user": map[string]any{
-									"profile": map[string]any{
-										"name": "John",
-										"age":  float64(30),
-									},
-								},
-								"theme": "dark",
-							},
-						}),
-					},
-				},
+		},
+
+		// Partial tag handling
+		{
+			desc: "partial tool tag fakeout",
+			steps: []step{
+				{input: "abc[TOOL", wantEvents: []ministralEvent{ministralEventContent{content: "abc"}}},
+				{input: " not a tag", wantEvents: []ministralEvent{ministralEventContent{content: "[TOOL not a tag"}}},
 			},
 		},
 		{
-			name: "tool call with array of objects",
-			tools: []api.Tool{
-				{Function: api.ToolFunction{Name: "process_items"}},
-			},
-			input:           `[TOOL_CALLS]process_items[ARGS]{"items": [{"id": 1}, {"id": 2}, {"id": 3}]}`,
-			expectedContent: `process_items[ARGS]{"items": [{"id": 1}, {"id": 2}, {"id": 3}]}`,
-			expectedCalls: []api.ToolCall{
-				{
-					Function: api.ToolCallFunction{
-						Name: "process_items",
-						Arguments: testArgs(map[string]any{
-							"items": []any{
-								map[string]any{"id": float64(1)},
-								map[string]any{"id": float64(2)},
-								map[string]any{"id": float64(3)},
-							},
-						}),
-					},
-				},
+			desc:  "tool call tag split across chunks",
+			tools: []api.Tool{{Function: api.ToolFunction{Name: "test"}}},
+			steps: []step{
+				{input: "[TOOL_", wantEvents: []ministralEvent{}},
+				{input: "CALLS]test[ARGS]{}", wantEvents: []ministralEvent{
+					ministralEventToolCall{name: "test", args: `{}`},
+				}},
 			},
 		},
 		{
-			name: "tool call with escaped quotes in string",
-			tools: []api.Tool{
-				{Function: api.ToolFunction{Name: "search"}},
-			},
-			input:           `[TOOL_CALLS]search[ARGS]{"query": "say \"hello\""}`,
-			expectedContent: `search[ARGS]{"query": "say \"hello\""}`,
-			expectedCalls: []api.ToolCall{
-				{
-					Function: api.ToolCallFunction{
-						Name:      "search",
-						Arguments: testArgs(map[string]any{"query": `say "hello"`}),
-					},
-				},
+			desc:  "content before tool call",
+			tools: []api.Tool{{Function: api.ToolFunction{Name: "get_weather"}}},
+			steps: []step{
+				{input: "hello [TOOL_CALLS]get_weather[ARGS]{}", wantEvents: []ministralEvent{
+					ministralEventContent{content: "hello"},
+					ministralEventToolCall{name: "get_weather", args: `{}`},
+				}},
 			},
 		},
 		{
-			name: "tool call with braces inside string",
-			tools: []api.Tool{
-				{Function: api.ToolFunction{Name: "format"}},
+			desc:  "whitespace between content and tool call is trimmed",
+			tools: []api.Tool{{Function: api.ToolFunction{Name: "test"}}},
+			steps: []step{
+				{input: "content \n [TOOL_CALLS]test[ARGS]{}", wantEvents: []ministralEvent{
+					ministralEventContent{content: "content"},
+					ministralEventToolCall{name: "test", args: `{}`},
+				}},
 			},
-			input:           `[TOOL_CALLS]format[ARGS]{"template": "Hello {name}!"}`,
-			expectedContent: `format[ARGS]{"template": "Hello {name}!"}`,
-			expectedCalls: []api.ToolCall{
-				{
-					Function: api.ToolCallFunction{
-						Name:      "format",
-						Arguments: testArgs(map[string]any{"template": "Hello {name}!"}),
-					},
-				},
+		},
+		{
+			desc:  "tabs and newlines before tool call are trimmed",
+			tools: []api.Tool{{Function: api.ToolFunction{Name: "test"}}},
+			steps: []step{
+				{input: "content\t\n\t[TOOL_CALLS]test[ARGS]{}", wantEvents: []ministralEvent{
+					ministralEventContent{content: "content"},
+					ministralEventToolCall{name: "test", args: `{}`},
+				}},
+			},
+		},
+		{
+			desc:  "non-breaking space before tool call is trimmed",
+			tools: []api.Tool{{Function: api.ToolFunction{Name: "test"}}},
+			steps: []step{
+				// \u00a0 is non-breaking space, which unicode.IsSpace considers whitespace
+				{input: "content\u00a0[TOOL_CALLS]test[ARGS]{}", wantEvents: []ministralEvent{
+					ministralEventContent{content: "content"},
+					ministralEventToolCall{name: "test", args: `{}`},
+				}},
+			},
+		},
+		{
+			desc: "whitespace before THINK tag is trimmed",
+			steps: []step{
+				{input: "content \n [THINK]thinking[/THINK]after", wantEvents: []ministralEvent{
+					ministralEventContent{content: "content"},
+					ministralEventThinking{thinking: "thinking"},
+					ministralEventContent{content: "after"},
+				}},
+			},
+		},
+		{
+			desc: "trailing whitespace withheld then emitted",
+			steps: []step{
+				{input: "Hello ", wantEvents: []ministralEvent{ministralEventContent{content: "Hello"}}},
+				{input: "world", wantEvents: []ministralEvent{ministralEventContent{content: " world"}}},
+			},
+		},
+		{
+			desc: "trailing newline withheld then emitted",
+			steps: []step{
+				{input: "Hello\n", wantEvents: []ministralEvent{ministralEventContent{content: "Hello"}}},
+				{input: "world", wantEvents: []ministralEvent{ministralEventContent{content: "\nworld"}}},
+			},
+		},
+
+		// Thinking support
+		{
+			desc:  "thinking content",
+			think: true,
+			steps: []step{
+				{input: "thinking here[/THINK]", wantEvents: []ministralEvent{
+					ministralEventThinking{thinking: "thinking here"},
+				}},
+				{input: "content after", wantEvents: []ministralEvent{
+					ministralEventContent{content: "content after"},
+				}},
+			},
+		},
+		{
+			desc:  "thinking with whitespace after end tag",
+			think: true,
+			steps: []step{
+				{input: "my thoughts[/THINK]  \n  response", wantEvents: []ministralEvent{
+					ministralEventThinking{thinking: "my thoughts"},
+					ministralEventContent{content: "response"},
+				}},
+			},
+		},
+		{
+			desc:  "non-breaking space after think end tag is trimmed",
+			think: true,
+			steps: []step{
+				// \u00a0 is non-breaking space
+				{input: "thinking[/THINK]\u00a0response", wantEvents: []ministralEvent{
+					ministralEventThinking{thinking: "thinking"},
+					ministralEventContent{content: "response"},
+				}},
+			},
+		},
+		{
+			desc:  "partial think end tag",
+			think: true,
+			steps: []step{
+				{input: "thinking[/THI", wantEvents: []ministralEvent{ministralEventThinking{thinking: "thinking"}}},
+				{input: "NK]after", wantEvents: []ministralEvent{ministralEventContent{content: "after"}}},
+			},
+		},
+		{
+			desc:  "think tag fakeout",
+			think: true,
+			steps: []step{
+				{input: "thinking[/THI", wantEvents: []ministralEvent{ministralEventThinking{thinking: "thinking"}}},
+				{input: "not end tag", wantEvents: []ministralEvent{ministralEventThinking{thinking: "[/THInot end tag"}}},
+			},
+		},
+		{
+			desc:  "thinking then tool call",
+			think: true,
+			tools: []api.Tool{{Function: api.ToolFunction{Name: "test"}}},
+			steps: []step{
+				{input: "let me think[/THINK][TOOL_CALLS]test[ARGS]{}", wantEvents: []ministralEvent{
+					ministralEventThinking{thinking: "let me think"},
+					ministralEventToolCall{name: "test", args: `{}`},
+				}},
+			},
+		},
+
+		// Content then THINK tag transition
+		{
+			desc: "content then think tag",
+			steps: []step{
+				{input: "content[THINK]thinking[/THINK]more", wantEvents: []ministralEvent{
+					ministralEventContent{content: "content"},
+					ministralEventThinking{thinking: "thinking"},
+					ministralEventContent{content: "more"},
+				}},
+			},
+		},
+
+		// Unicode handling
+		{
+			desc: "unicode content",
+			steps: []step{
+				{input: "你好 🌍 مرحبا", wantEvents: []ministralEvent{
+					ministralEventContent{content: "你好 🌍 مرحبا"},
+				}},
+			},
+		},
+		{
+			desc:  "unicode in tool args",
+			tools: []api.Tool{{Function: api.ToolFunction{Name: "greet"}}},
+			steps: []step{
+				{input: `[TOOL_CALLS]greet[ARGS]{"message": "你好 🌍"}`, wantEvents: []ministralEvent{
+					ministralEventToolCall{name: "greet", args: `{"message": "你好 🌍"}`},
+				}},
 			},
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			p := &MinistralParser{}
-			p.Init(tt.tools, nil, nil)
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			parser := MinistralParser{}
+			parser.hasThinkingSupport = tc.think
+			parser.Init(tc.tools, nil, nil)
 
-			content, thinking, calls, err := processAll(p, tt.input)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+			for i, step := range tc.steps {
+				parser.buffer.WriteString(step.input)
+				gotEvents := parser.parseEvents()
 
-			if diff := cmp.Diff(content, tt.expectedContent); diff != "" {
-				t.Errorf("content mismatch (-got +want):\n%s", diff)
-			}
-			if diff := cmp.Diff(thinking, tt.expectedThinking); diff != "" {
-				t.Errorf("thinking mismatch (-got +want):\n%s", diff)
-			}
-			if diff := cmp.Diff(calls, tt.expectedCalls, argsComparer); diff != "" {
-				t.Errorf("calls mismatch (-got +want):\n%s", diff)
+				if len(gotEvents) == 0 && len(step.wantEvents) == 0 {
+					// avoid deep equal on empty vs. nil slices
+					continue
+				}
+
+				if !reflect.DeepEqual(gotEvents, step.wantEvents) {
+					t.Errorf("step %d: input %q: got events %#v, want %#v", i, step.input, gotEvents, step.wantEvents)
+				}
 			}
 		})
 	}
 }
 
-func TestMinistralParser_Streaming(t *testing.T) {
-	tests := []struct {
-		name            string
-		tools           []api.Tool
-		chunks          []string
-		expectedContent string
-		expectedCalls   []api.ToolCall
-	}{
-		{
-			name:            "streaming content",
-			chunks:          []string{"Hello, ", "how ", "can I help?"},
-			expectedContent: "Hello, how can I help?",
-		},
-		{
-			name: "streaming tool call with nested objects",
-			tools: []api.Tool{
-				{Function: api.ToolFunction{Name: "create_entities"}},
-			},
-			chunks: []string{
-				"[TOOL_CALLS]create_entities[ARGS]",
-				`{"entities": [{"entityType": "Person",`,
-				` "name": "Jack",`,
-				` "observations": ["Works`,
-				` as a baker at Big Baker Co."]}`,
-				`]}`,
-			},
-			expectedContent: "create_entities[ARGS]",
-			expectedCalls: []api.ToolCall{
-				{
-					Function: api.ToolCallFunction{
-						Name: "create_entities",
-						Arguments: testArgs(map[string]any{
-							"entities": []any{
-								map[string]any{
-									"entityType":   "Person",
-									"name":         "Jack",
-									"observations": []any{"Works as a baker at Big Baker Co."},
-								},
-							},
-						}),
-					},
-				},
-			},
-		},
-		{
-			name: "streaming with incomplete JSON waits for completion",
-			tools: []api.Tool{
-				{Function: api.ToolFunction{Name: "test"}},
-			},
-			chunks: []string{
-				"[TOOL_CALLS]test[ARGS]{",
-				`"a": {`,
-				`"b": 1`,
-				`}`,
-				`}`,
-			},
-			expectedContent: "test[ARGS]{",
-			expectedCalls: []api.ToolCall{
-				{
-					Function: api.ToolCallFunction{
-						Name: "test",
-						Arguments: testArgs(map[string]any{
-							"a": map[string]any{
-								"b": float64(1),
-							},
-						}),
-					},
-				},
-			},
-		},
-	}
+func TestMinistralParser_Errors(t *testing.T) {
+	t.Run("unknown tool returns error", func(t *testing.T) {
+		p := &MinistralParser{}
+		p.Init([]api.Tool{{Function: api.ToolFunction{Name: "known_tool"}}}, nil, nil)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			p := &MinistralParser{}
-			p.Init(tt.tools, nil, nil)
+		_, _, _, err := p.Add(`[TOOL_CALLS]unknown_tool[ARGS]{"a": 1}`, true)
+		if err == nil {
+			t.Fatal("expected error for unknown tool")
+		}
+	})
 
-			var allContent string
-			var allCalls []api.ToolCall
+	t.Run("invalid JSON returns error", func(t *testing.T) {
+		p := &MinistralParser{}
+		p.Init([]api.Tool{{Function: api.ToolFunction{Name: "test"}}}, nil, nil)
 
-			for _, chunk := range tt.chunks {
-				content, _, calls, err := p.Add(chunk, false)
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				allContent += content
-				allCalls = append(allCalls, calls...)
-			}
-
-			// Drain
-			content, _, calls, err := p.Add("", true)
-			if err != nil {
-				t.Fatalf("unexpected error on done: %v", err)
-			}
-			allContent += content
-			allCalls = append(allCalls, calls...)
-
-			if diff := cmp.Diff(allContent, tt.expectedContent); diff != "" {
-				t.Errorf("content mismatch (-got +want):\n%s", diff)
-			}
-			if diff := cmp.Diff(allCalls, tt.expectedCalls, argsComparer); diff != "" {
-				t.Errorf("calls mismatch (-got +want):\n%s", diff)
-			}
-		})
-	}
+		_, _, _, err := p.Add(`[TOOL_CALLS]test[ARGS]{invalid json}`, true)
+		if err == nil {
+			t.Fatal("expected error for invalid JSON")
+		}
+	})
 }
 
 func TestFindJSONEnd(t *testing.T) {
@@ -438,114 +541,5 @@ func TestMinistralParser_HasThinkingSupport(t *testing.T) {
 	p = &MinistralParser{hasThinkingSupport: true}
 	if !p.HasThinkingSupport() {
 		t.Error("expected HasThinkingSupport to return true")
-	}
-}
-
-func TestMinistralParser_EdgeCases(t *testing.T) {
-	tests := []struct {
-		name             string
-		tools            []api.Tool
-		input            string
-		expectedContent  string
-		expectedThinking string
-		expectedCalls    []api.ToolCall
-		expectError      bool
-	}{
-		{
-			name: "unknown tool returns error",
-			tools: []api.Tool{
-				{Function: api.ToolFunction{Name: "known_tool"}},
-			},
-			input:       `[TOOL_CALLS]unknown_tool[ARGS]{"a": 1}`,
-			expectError: true,
-		},
-		{
-			name: "invalid JSON returns error",
-			tools: []api.Tool{
-				{Function: api.ToolFunction{Name: "test"}},
-			},
-			input:       `[TOOL_CALLS]test[ARGS]{invalid json}`,
-			expectError: true,
-		},
-		{
-			name: "empty JSON object",
-			tools: []api.Tool{
-				{Function: api.ToolFunction{Name: "no_args"}},
-			},
-			input:           `[TOOL_CALLS]no_args[ARGS]{}`,
-			expectedContent: "no_args[ARGS]{}",
-			expectedCalls: []api.ToolCall{
-				{
-					Function: api.ToolCallFunction{
-						Name:      "no_args",
-						Arguments: testArgs(map[string]any{}),
-					},
-				},
-			},
-		},
-		{
-			name: "JSON with newlines in string",
-			tools: []api.Tool{
-				{Function: api.ToolFunction{Name: "write"}},
-			},
-			input:           `[TOOL_CALLS]write[ARGS]{"content": "line1\nline2\nline3"}`,
-			expectedContent: "write[ARGS]{\"content\": \"line1\\nline2\\nline3\"}",
-			expectedCalls: []api.ToolCall{
-				{
-					Function: api.ToolCallFunction{
-						Name:      "write",
-						Arguments: testArgs(map[string]any{"content": "line1\nline2\nline3"}),
-					},
-				},
-			},
-		},
-		{
-			name: "backslash in string value",
-			tools: []api.Tool{
-				{Function: api.ToolFunction{Name: "path"}},
-			},
-			input:           `[TOOL_CALLS]path[ARGS]{"dir": "C:\\Users\\test"}`,
-			expectedContent: "path[ARGS]{\"dir\": \"C:\\\\Users\\\\test\"}",
-			expectedCalls: []api.ToolCall{
-				{
-					Function: api.ToolCallFunction{
-						Name:      "path",
-						Arguments: testArgs(map[string]any{"dir": "C:\\Users\\test"}),
-					},
-				},
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			p := &MinistralParser{}
-			p.state = ministralCollectingContent
-			p.Init(tt.tools, nil, nil)
-			p.state = ministralCollectingContent
-
-			content, thinking, calls, err := processAll(p, tt.input)
-
-			if tt.expectError {
-				if err == nil {
-					t.Fatalf("expected error but got none")
-				}
-				return
-			}
-
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-
-			if diff := cmp.Diff(content, tt.expectedContent); diff != "" {
-				t.Errorf("content mismatch (-got +want):\n%s", diff)
-			}
-			if diff := cmp.Diff(thinking, tt.expectedThinking); diff != "" {
-				t.Errorf("thinking mismatch (-got +want):\n%s", diff)
-			}
-			if diff := cmp.Diff(calls, tt.expectedCalls, argsComparer); diff != "" {
-				t.Errorf("calls mismatch (-got +want):\n%s", diff)
-			}
-		})
 	}
 }

--- a/model/parsers/qwen3coder.go
+++ b/model/parsers/qwen3coder.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 	"unicode"
-	"unicode/utf8"
 
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/logutil"
@@ -192,36 +191,6 @@ func eat(p *Qwen3CoderParser) ([]qwenEvent, bool) {
 	default:
 		panic("unreachable")
 	}
-}
-
-// TODO(drifkin): move this to a shared location
-// longest overlap between suffix of s and prefix of delim
-func overlap(s, delim string) int {
-	max := min(len(delim), len(s))
-	for i := max; i > 0; i-- {
-		if strings.HasSuffix(s, delim[:i]) {
-			return i
-		}
-	}
-	return 0
-}
-
-func trailingWhitespaceLen(s string) int {
-	remaining := s
-	total := 0
-	for len(remaining) > 0 {
-		r, size := utf8.DecodeLastRuneInString(remaining)
-		// if it's an invalid utf8 rune, assume it isn't whitespace
-		if r == utf8.RuneError && size == 1 {
-			break
-		}
-		if !unicode.IsSpace(r) {
-			break
-		}
-		total += size
-		remaining = remaining[:len(remaining)-size]
-	}
-	return total
 }
 
 type XMLFunctionCall struct {


### PR DESCRIPTION
This PR fixes parsing error in ministral.

- Implement `findJSONEnd` to correctly identify the end of tool arguments
- Add support for nested objects, arrays, and escaped characters in strings
- Improve buffer management to prevent data loss after tool calls
- Add tests for various JSON edge cases

Fixes #13705 