### PR TITLE
model: normalize case for nomic-embed-text

### DIFF
--- a/model/models/nomicbert/model.go
+++ b/model/models/nomicbert/model.go
@@ -217,7 +217,7 @@ func New(c fs.Config) (model.Model, error) {
 					)),
 				},
 			},
-			false,
+			true,
 		),
 		Layers: layers,
 		Options: Options{


### PR DESCRIPTION
The vocabulary for nomic-embed-text is lowercase. Without this flag set to true, all words with uppercase return the same token.

Fixes #13942