### PR TITLE
cmd: capitalize Ollama in serve command help text

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1888,7 +1888,7 @@ func NewCLI() *cobra.Command {
 	serveCmd := &cobra.Command{
 		Use:     "serve",
 		Aliases: []string{"start"},
-		Short:   "Start ollama",
+		Short:   "Start Ollama",
 		Args:    cobra.ExactArgs(0),
 		RunE:    RunServer,
 	}


### PR DESCRIPTION
## Summary

Fixes #10165

The product name "Ollama" should be capitalized when referring to the application, while the CLI command `ollama` remains lowercase.

## Changes

Changed `"Start ollama"` to `"Start Ollama"` in the serve command's short description.

## Before
```
Available Commands:
  serve       Start ollama
```

## After
```
Available Commands:
  serve       Start Ollama
```