### PR TITLE
Update installation command for OpenCode CLI

### DIFF
--- a/docs/integrations/opencode.mdx
+++ b/docs/integrations/opencode.mdx
@@ -9,7 +9,7 @@ OpenCode is an open-source AI coding assistant that runs in your terminal.
 Install the [OpenCode CLI](https://opencode.ai):
 
 ```bash
-curl -fsSL https://opencode.ai/install.sh | bash
+curl -fsSL https://opencode.ai/install | bash
 ```
 
 <Note>OpenCode requires a larger context window. It is recommended to use a context window of at least 64k tokens. See [Context length](/context-length) for more information.</Note>


### PR DESCRIPTION
This pull request updates the installation instructions for the OpenCode CLI in the documentation to use the correct installation script URL.

Documentation update:

* Updated the installation command in `docs/integrations/opencode.mdx` to use `https://opencode.ai/install` instead of `https://opencode.ai/install.sh` for installing the OpenCode CLI.