### PR TITLE
docs: add truncate parameter to generate and chat endpoints

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -57,6 +57,7 @@ Advanced parameters (optional):
 - `stream`: if `false` the response will be returned as a single response object, rather than a stream of objects
 - `raw`: if `true` no formatting will be applied to the prompt. You may choose to use the `raw` parameter if you are specifying a full templated prompt in your request to the API
 - `keep_alive`: controls how long the model will stay loaded into memory following the request (default: `5m`)
+- `truncate`: if `true`, truncates the prompt when it exceeds the context length. Defaults to `true`
 - `context` (deprecated): the context parameter returned from a previous request to `/generate`, this can be used to keep a short conversational memory
 
 Experimental image generation parameters (for image generation models only):
@@ -520,6 +521,7 @@ Advanced parameters (optional):
 - `options`: additional model parameters listed in the documentation for the [Modelfile](./modelfile.mdx#valid-parameters-and-values) such as `temperature`
 - `stream`: if `false` the response will be returned as a single response object, rather than a stream of objects
 - `keep_alive`: controls how long the model will stay loaded into memory following the request (default: `5m`)
+- `truncate`: if `true`, truncates the chat history when it exceeds the context length. Defaults to `true`
 
 ### Tool calling
 


### PR DESCRIPTION
## Description

Document the `truncate` parameter for `/api/generate` and `/api/chat` endpoints. This parameter controls whether the prompt/chat history is truncated when it exceeds the context length limit.

The parameter is already implemented in [`GenerateRequest`](https://github.com/ollama/ollama/blob/main/api/types.go#L107-L113) and [`ChatRequest`](https://github.com/ollama/ollama/blob/main/api/types.go#L173-L177), and used in both endpoints, but was only documented for `/api/embed`.

## Changes

- Added `truncate` parameter documentation to the Generate endpoint's advanced parameters section
- Added `truncate` parameter documentation to the Chat endpoint's advanced parameters section

Fixes #13959