### PR TITLE
logutil: add JSON logging format support via OLLAMA_LOG_FORMAT

### DIFF
--- a/logutil/logutil.go
+++ b/logutil/logutil.go
@@ -4,15 +4,17 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 )
 
 const LevelTrace slog.Level = -8
 
 func NewLogger(w io.Writer, level slog.Level) *slog.Logger {
-	return slog.New(slog.NewTextHandler(w, &slog.HandlerOptions{
+	handlerOptions := &slog.HandlerOptions{
 		Level:     level,
 		AddSource: true,
 		ReplaceAttr: func(_ []string, attr slog.Attr) slog.Attr {
@@ -28,7 +30,14 @@ func NewLogger(w io.Writer, level slog.Level) *slog.Logger {
 			}
 			return attr
 		},
-	}))
+	}
+
+	logFormat := strings.ToLower(os.Getenv("OLLAMA_LOG_FORMAT"))
+	if logFormat == "json" {
+		return slog.New(slog.NewJSONHandler(w, handlerOptions))
+	}
+
+	return slog.New(slog.NewTextHandler(w, handlerOptions))
 }
 
 type key string


### PR DESCRIPTION
Add configurable log output format to support both human-readable text and machine-parsable JSON formats. When OLLAMA_LOG_FORMAT=json is set, the logger uses slog.NewJSONHandler instead of the default text handler. Maintains backward compatibility with existing text format as default and preserves all existing handler options for both formats.

fixes #14018 