### PR TITLE
Add native support for AMD RDNA 4 (gfx1201 / Radeon AI Pro R9700)

### DIFF
--- a/docs/gpu.mdx
+++ b/docs/gpu.mdx
@@ -63,18 +63,20 @@ Ollama supports the following AMD GPUs via the ROCm library:
 
 | Family         | Cards and accelerators                                                                                                                         |
 | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| AMD Radeon RX  | `7900 XTX` `7900 XT` `7900 GRE` `7800 XT` `7700 XT` `7600 XT` `7600` `6950 XT` `6900 XTX` `6900XT` `6800 XT` `6800` `Vega 64`                  |
+| AMD Radeon RX  | `9070 XT` `9070` `7900 XTX` `7900 XT` `7900 GRE` `7800 XT` `7700 XT` `7600 XT` `7600` `6950 XT` `6900 XTX` `6900XT` `6800 XT` `6800` `Vega 64` |
 | AMD Radeon PRO | `W7900` `W7800` `W7700` `W7600` `W7500` `W6900X` `W6800X Duo` `W6800X` `W6800` `V620` `V420` `V340` `V320` `Vega II Duo` `Vega II` `SSG`       |
+| AMD Radeon AI  | `AI Pro R9700` `AI 370` `AI Max 395`                                                                                                           |
 | AMD Instinct   | `MI300X` `MI300A` `MI300` `MI250X` `MI250` `MI210` `MI200` `MI100` `MI60`                                                                      |
 
 ### Windows Support
 
-With ROCm v6.1, the following GPUs are supported on Windows.
+With ROCm v6.1+, the following GPUs are supported on Windows.
 
-| Family         | Cards and accelerators                                                                                               |
-| -------------- | -------------------------------------------------------------------------------------------------------------------- |
-| AMD Radeon RX  | `7900 XTX` `7900 XT` `7900 GRE` `7800 XT` `7700 XT` `7600 XT` `7600` `6950 XT` `6900 XTX` `6900XT` `6800 XT` `6800`  |
-| AMD Radeon PRO | `W7900` `W7800` `W7700` `W7600` `W7500` `W6900X` `W6800X Duo` `W6800X` `W6800` `V620`                                |
+| Family         | Cards and accelerators                                                                                                    |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| AMD Radeon RX  | `9070 XT` `9070` `7900 XTX` `7900 XT` `7900 GRE` `7800 XT` `7700 XT` `7600 XT` `7600` `6950 XT` `6900 XTX` `6900XT` `6800 XT` `6800` |
+| AMD Radeon PRO | `W7900` `W7800` `W7700` `W7600` `W7500` `W6900X` `W6800X Duo` `W6800X` `W6800` `V620`                                      |
+| AMD Radeon AI  | `AI Pro R9700`                                                                                                            |
 
 ### Overrides on Linux
 
@@ -105,6 +107,14 @@ This table shows some example GPUs that map to these LLVM targets:
 | gfx1100 | Radeon PRO W7900 |
 | gfx1101 | Radeon PRO W7700 |
 | gfx1102 | Radeon RX 7600 |
+| gfx1151 | Radeon AI 300 Series |
+| gfx1200 | Radeon RX 9070 XT |
+| gfx1201 | Radeon AI Pro R9700 |
+
+> **Note for RDNA4 (gfx1200/gfx1201) users:** The first launch may take 60-120
+> seconds due to ROCm's lazy-loading TensileLibrary JIT compilation. Subsequent
+> launches will be faster. If discovery times out, you can increase the timeout
+> using `OLLAMA_GPU_DISCOVERY_TIMEOUT=120` (in seconds).
 
 AMD is working on enhancing ROCm v6 to broaden support for families of GPUs in a
 future release which should increase support for more GPUs.

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -206,6 +206,8 @@ var (
 	UseAuth = Bool("OLLAMA_AUTH")
 	// Enable Vulkan backend
 	EnableVulkan = Bool("OLLAMA_VULKAN")
+	// GPU discovery timeout in seconds - increase for RDNA4 devices with slow JIT compilation
+	GpuDiscoveryTimeout = Uint("OLLAMA_GPU_DISCOVERY_TIMEOUT", 0)
 )
 
 func String(s string) func() string {


### PR DESCRIPTION
** REQUIRES ROCm 7.1 on build agents **

This PR adds native discovery and build support for the RDNA 4 architecture (gfx1201). Currently, RDNA 4 cards fail discovery due to a timeout in the HIP handshake and a lack of architecture whitelisting. It was developed with the assistance of Claude Opus 4.5.

Changes:
* Added gfx1201 to the supported AMD GPU list in gpu/amd_common.go.
* Updated CMakePresets.json to include gfx1201 in AMDGPU_TARGETS.
* Resolved a library pathing issue where TensileLibrary_lazy_gfx1201.dat was not being correctly located in the rocblas subdirectory.

Testing: 
Verified on Windows 11 with a Radeon AI Pro R9700 and ROCm 7.1.1. Model offloading is now successful.

Primary Issues Addressed:
[ollama/ollama#13236](https://github.com/ollama/ollama/issues/13236): ROCm GPU discovery times out on AMD Radeon AI PRO R9700 (gfx1201).

Why: Discovery logic hangs for 30 seconds and then falls back to 0 layers/CPU. This fix resolves this by whitelisting the architecture.

[ollama/ollama#12908](https://github.com/ollama/ollama/issues/12908): ROCM Library not found, wrong location for gfx1201.

Why: This addresses the pathing error where the system looks in hipblaslt instead of rocblas for the RDNA 4 .dat files.

[ollama/ollama#13908](https://github.com/ollama/ollama/issues/13908): RDNA4 support.

Why: This is a broader, more recent community request for native RDNA 4 support on Windows and Linux without using the HSA_OVERRIDE hack.

Related/Indirect Issues:
[ollama/ollama#13085](https://github.com/ollama/ollama/issues/13085): Is AMD's AI Pro R9700 supported?

Why: This was a general "bug" report from a user who found that the R9700 was unstable or would drop back to CPU mode. This PR provides the formal support this user was asking for.