### PR TITLE
llm: support multiple LoRA adapters and hot-swapping

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -919,6 +919,64 @@ type Tensor struct {
 	Shape []uint64 `json:"shape"`
 }
 
+// LoraAdapter represents a loaded LoRA adapter for hot-swap support.
+type LoraAdapter struct {
+	// ID is the unique identifier for the adapter (assigned at load time).
+	ID int `json:"id"`
+
+	// Path is the file path of the adapter.
+	Path string `json:"path"`
+
+	// Scale is the current scale factor for the adapter (0.0-2.0).
+	// A scale of 0.0 means the adapter is loaded but not applied.
+	Scale float32 `json:"scale"`
+}
+
+// LoraAdapterList is a collection of loaded LoRA adapters.
+type LoraAdapterList []LoraAdapter
+
+// LoraScaleRequest specifies a new scale for a loaded adapter.
+type LoraScaleRequest struct {
+	// ID is the adapter identifier to update.
+	ID int `json:"id"`
+
+	// Scale is the new scale factor to apply (0.0-2.0).
+	Scale float32 `json:"scale"`
+}
+
+// LoraAdaptersRequest is used to list adapters for a specific model.
+type LoraAdaptersRequest struct {
+	// Model is the model name to query.
+	Model string `json:"model"`
+}
+
+// LoraAdaptersResponse contains the list of loaded adapters for a model.
+type LoraAdaptersResponse struct {
+	// Model is the model name.
+	Model string `json:"model"`
+
+	// Adapters is the list of loaded adapters.
+	Adapters LoraAdapterList `json:"adapters"`
+}
+
+// SetLoraAdaptersRequest sets adapter scales for a loaded model.
+type SetLoraAdaptersRequest struct {
+	// Model is the model name.
+	Model string `json:"model"`
+
+	// Adapters specifies the new scales for each adapter.
+	Adapters []LoraScaleRequest `json:"adapters"`
+}
+
+// SetLoraAdaptersResponse is returned after updating adapter scales.
+type SetLoraAdaptersResponse struct {
+	// Success indicates if the scales were updated successfully.
+	Success bool `json:"success"`
+
+	// Error contains an error message if the operation failed.
+	Error string `json:"error,omitempty"`
+}
+
 func (m *Metrics) Summary() {
 	if m.TotalDuration > 0 {
 		fmt.Fprintf(os.Stderr, "total duration:       %v\n", m.TotalDuration)

--- a/docs/api.md
+++ b/docs/api.md
@@ -1854,6 +1854,85 @@ curl http://localhost:11434/api/embeddings -d '{
 }
 ```
 
+  ]
+}
+```
+
+## List LoRA Adapters
+
+```
+GET /api/lora-adapters
+```
+
+Returns a list of loaded LoRA adapters for a running model.
+
+### Parameters
+
+- `model`: (required) name of the loaded model
+
+### Example
+
+#### Request
+
+```shell
+curl http://localhost:11434/api/lora-adapters?model=llama3.2
+```
+
+#### Response
+
+```json
+{
+  "model": "llama3.2",
+  "adapters": [
+    {
+      "id": 0,
+      "path": "/path/to/math.gguf",
+      "scale": 1.0
+    },
+    {
+      "id": 1,
+      "path": "/path/to/science.gguf",
+      "scale": 0.0
+    }
+  ]
+}
+```
+
+## Set LoRA Adapters
+
+```
+POST /api/lora-adapters
+```
+
+Updates the scales of loaded LoRA adapters (hot-swap).
+
+### Parameters
+
+- `model`: (required) name of the loaded model
+- `adapters`: list of adapters with their new scales
+
+### Example
+
+#### Request
+
+```shell
+curl http://localhost:11434/api/lora-adapters -d '{
+  "model": "llama3.2",
+  "adapters": [
+    { "id": 0, "scale": 0.0 },
+    { "id": 1, "scale": 1.0 }
+  ]
+}'
+```
+
+#### Response
+
+```json
+{
+  "success": true
+}
+```
+
 ## Version
 
 ```

--- a/docs/modelfile.mdx
+++ b/docs/modelfile.mdx
@@ -212,6 +212,20 @@ Currently supported Safetensor adapters:
 ADAPTER ./ollama-lora.gguf
 ```
 
+### Multiple LoRA Adapters
+
+You can specify multiple LoRA adapters that will be loaded at startup:
+
+```dockerfile
+FROM llama3.2
+ADAPTER /path/to/math-adapter.gguf
+ADAPTER /path/to/science-adapter.gguf
+SYSTEM You are a helpful assistant.
+```
+
+All adapters are loaded with scale 0.0 by default. Use the API to 
+activate specific adapters at runtime.
+
 ### LICENSE
 
 The `LICENSE` instruction allows you to specify the legal license under which the model used with this Modelfile is shared or distributed.

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -94,7 +94,13 @@ func (f Modelfile) CreateRequest(relativeDir string) (*api.CreateRequest, error)
 				return nil, err
 			}
 
-			req.Adapters = digestMap
+			if req.Adapters == nil {
+				req.Adapters = digestMap
+			} else {
+				for k, v := range digestMap {
+					req.Adapters[k] = v
+				}
+			}
 		case "template":
 			req.Template = c.Args
 		case "system":

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -58,6 +58,28 @@ TEMPLATE """{{ if .System }}<|start_header_id|>system<|end_header_id|>
 	assert.Equal(t, expectedCommands, modelfile.Commands)
 }
 
+func TestParseFileMultipleAdapters(t *testing.T) {
+	input := `
+FROM model1
+ADAPTER adapter1
+ADAPTER adapter2
+LICENSE MIT
+`
+	reader := strings.NewReader(input)
+
+	modelfile, err := ParseFile(reader)
+	require.NoError(t, err)
+
+	expectedCommands := []Command{
+		{Name: "model", Args: "model1"},
+		{Name: "adapter", Args: "adapter1"},
+		{Name: "adapter", Args: "adapter2"},
+		{Name: "license", Args: "MIT"},
+	}
+
+	assert.Equal(t, expectedCommands, modelfile.Commands)
+}
+
 func TestParseFileTrimSpace(t *testing.T) {
 	input := `
 FROM "     model 1"

--- a/server/create.go
+++ b/server/create.go
@@ -168,7 +168,7 @@ func (s *Server) CreateHandler(c *gin.Context) {
 		if !remote && r.Adapters != nil {
 			adapterLayers, err = convertModelFromFiles(r.Adapters, baseLayers, true, fn)
 			if err != nil {
-				for _, badReq := range []error{errNoFilesProvided, errOnlyOneAdapterSupported, errOnlyGGUFSupported, errUnknownType, errFilePath} {
+				for _, badReq := range []error{errNoFilesProvided, errOnlyGGUFSupported, errUnknownType, errFilePath} {
 					if errors.Is(err, badReq) {
 						ch <- gin.H{"error": err.Error(), "status": http.StatusBadRequest}
 						return
@@ -315,9 +315,8 @@ func convertModelFromFiles(files map[string]string, baseLayers []*layerGGML, isA
 	case "gguf":
 		if len(files) == 0 {
 			return nil, errNoFilesProvided
-		} else if len(files) > 1 && isAdapter {
-			return nil, errOnlyOneAdapterSupported
 		}
+		// Multi-adapter support: allow multiple GGUF adapter files
 
 		var digest string
 		var allLayers []*layerGGML

--- a/server/routes_lora_test.go
+++ b/server/routes_lora_test.go
@@ -1,0 +1,131 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/fs/ggml"
+	"github.com/ollama/ollama/llm"
+	"github.com/ollama/ollama/ml"
+)
+
+// MockLoraRunner extends mockLlm to support LoRA operations
+type MockLoraRunner struct {
+	*mockLlm
+	adapters []api.LoraAdapter
+}
+
+func (m *MockLoraRunner) GetLoraAdapters(ctx context.Context) (api.LoraAdapterList, error) {
+	return api.LoraAdapterList(m.adapters), nil
+}
+
+func (m *MockLoraRunner) SetLoraAdapterScales(ctx context.Context, adapters []api.LoraScaleRequest) (api.LoraAdapterList, error) {
+	for _, req := range adapters {
+		for i, existing := range m.adapters {
+			if existing.ID == req.ID {
+				m.adapters[i].Scale = req.Scale
+			}
+		}
+	}
+	return api.LoraAdapterList(m.adapters), nil
+}
+
+func TestLoraAdaptersHandler(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// Setup Server with mocked Scheduler
+	ctx := context.Background()
+	sched := InitScheduler(ctx)
+
+	// Create a mock runner with pre-loaded adapters
+	mockRunner := &MockLoraRunner{
+		mockLlm: &mockLlm{},
+		adapters: []api.LoraAdapter{
+			{ID: 0, Path: "/path/to/adapter1.gguf", Scale: 1.0},
+			{ID: 1, Path: "/path/to/adapter2.gguf", Scale: 0.0},
+		},
+	}
+
+	// Manually inject the runner into the scheduler's loaded map
+	// We use the same model name key as we will request
+	modelName := "test-model"
+	modelPath := "/tmp/test-model"
+
+	sched.loadedMu.Lock()
+	sched.loaded[modelPath] = &runnerRef{
+		llama:    mockRunner,
+		model:    &Model{ModelPath: modelPath, Name: modelName, ShortName: modelName},
+		refCount: 1, // Ensure it's not evicted immediately if we were using real scheduling loop
+	}
+	sched.loadedMu.Unlock()
+
+	// Intercept newServerFn just in case, though we manually injected result
+	sched.newServerFn = func(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, model string, f *ggml.GGML, adapters []string, projectors []string, opts api.Options, numParallel int) (llm.LlamaServer, error) {
+		return mockRunner, nil
+	}
+
+	s := &Server{sched: sched}
+
+	// We need to mount the routes.
+	// Since GenerateRoutes takes a Registry which we don't want to mock fully if unnecessary,
+	// we can just construct a router and register the handlers directly for this unit test.
+	// This avoids dependency on Registry and other middleware.
+	router := gin.New()
+	router.GET("/api/lora-adapters", s.GetLoraAdaptersHandler)
+	router.POST("/api/lora-adapters", s.SetLoraAdaptersHandler)
+
+	t.Run("Get Adapters", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/lora-adapters?model=test-model", nil)
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("expected status 200, got %d", w.Code)
+		}
+
+		var resp api.LoraAdaptersResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatal(err)
+		}
+
+		if len(resp.Adapters) != 2 {
+			t.Errorf("expected 2 adapters, got %d", len(resp.Adapters))
+		}
+		if resp.Adapters[0].Path != "/path/to/adapter1.gguf" || resp.Adapters[0].Scale != 1.0 {
+			t.Errorf("unexpected adapter 0 data: %v", resp.Adapters[0])
+		}
+	})
+
+	t.Run("Set Adapters", func(t *testing.T) {
+		payload := api.SetLoraAdaptersRequest{
+			Model: "test-model",
+			Adapters: []api.LoraScaleRequest{
+				{ID: 0, Scale: 0.5},
+				{ID: 1, Scale: 0.8},
+			},
+		}
+		body, _ := json.Marshal(payload)
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("POST", "/api/lora-adapters", bytes.NewReader(body))
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("expected status 200, got %d", w.Code)
+		}
+
+		// Verify scales were updated in the mock
+		if mockRunner.adapters[0].Scale != 0.5 {
+			t.Errorf("expected adapter 0 scale 0.5, got %f", mockRunner.adapters[0].Scale)
+		}
+		if mockRunner.adapters[1].Scale != 0.8 {
+			t.Errorf("expected adapter 1 scale 0.8, got %f", mockRunner.adapters[1].Scale)
+		}
+	})
+}

--- a/server/sched.go
+++ b/server/sched.go
@@ -917,3 +917,20 @@ func (s *Scheduler) expireRunner(model *Model) {
 		runner.refMu.Unlock()
 	}
 }
+
+// GetRunnerByModelName looks up a loaded runner by model name.
+// Returns the runner if found, nil otherwise.
+func (s *Scheduler) GetRunnerByModelName(name model.Name) llm.LlamaServer {
+	s.loadedMu.Lock()
+	defer s.loadedMu.Unlock()
+
+	for path, runner := range s.loaded {
+		if runner.model != nil && (runner.model.Name == name.String() || strings.HasSuffix(path, name.Model)) {
+			runner.refMu.Lock()
+			llama := runner.llama
+			runner.refMu.Unlock()
+			return llama
+		}
+	}
+	return nil
+}

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -805,6 +805,13 @@ func (s *mockLlm) GetDeviceInfos(ctx context.Context) []ml.DeviceInfo { return n
 func (s *mockLlm) HasExited() bool                                    { return false }
 func (s *mockLlm) GetActiveDeviceIDs() []ml.DeviceID                  { return nil }
 
+func (s *mockLlm) GetLoraAdapters(ctx context.Context) (api.LoraAdapterList, error) {
+	return nil, nil
+}
+func (s *mockLlm) SetLoraAdapterScales(ctx context.Context, adapters []api.LoraScaleRequest) (api.LoraAdapterList, error) {
+	return nil, nil
+}
+
 // TestImageGenRunnerCanBeEvicted verifies that an image generation model
 // loaded in the scheduler can be evicted when idle.
 func TestImageGenRunnerCanBeEvicted(t *testing.T) {

--- a/types/model/capability.go
+++ b/types/model/capability.go
@@ -3,13 +3,13 @@ package model
 type Capability string
 
 const (
-	CapabilityCompletion      = Capability("completion")
-	CapabilityTools           = Capability("tools")
-	CapabilityInsert          = Capability("insert")
-	CapabilityVision          = Capability("vision")
-	CapabilityEmbedding       = Capability("embedding")
-	CapabilityThinking        = Capability("thinking")
-	CapabilityImage = Capability("image")
+	CapabilityCompletion = Capability("completion")
+	CapabilityTools      = Capability("tools")
+	CapabilityInsert     = Capability("insert")
+	CapabilityVision     = Capability("vision")
+	CapabilityEmbedding  = Capability("embedding")
+	CapabilityThinking   = Capability("thinking")
+	CapabilityImage      = Capability("image")
 )
 
 func (c Capability) String() string {

--- a/x/imagegen/safetensors/safetensors.go
+++ b/x/imagegen/safetensors/safetensors.go
@@ -310,4 +310,3 @@ func (mw *ModelWeights) ReleaseAll() {
 		delete(mw.nativeCache, path)
 	}
 }
-

--- a/x/imagegen/server.go
+++ b/x/imagegen/server.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/llm"
 	"github.com/ollama/ollama/ml"
 )
@@ -378,6 +379,16 @@ func (s *Server) HasExited() bool {
 	default:
 		return false
 	}
+}
+
+// GetLoraAdapters returns empty list - image models don't support LoRA
+func (s *Server) GetLoraAdapters(ctx context.Context) (api.LoraAdapterList, error) {
+	return nil, nil
+}
+
+// SetLoraAdapterScales is not supported for image models
+func (s *Server) SetLoraAdapterScales(ctx context.Context, adapters []api.LoraScaleRequest) (api.LoraAdapterList, error) {
+	return nil, errors.New("LoRA adapters not supported for image generation models")
 }
 
 // Ensure Server implements llm.LlamaServer

--- a/x/imagegen/weights.go
+++ b/x/imagegen/weights.go
@@ -15,9 +15,9 @@ import (
 type ManifestWeights struct {
 	manifest    *ModelManifest
 	component   string
-	tensors     map[string]ManifestLayer      // name -> layer
-	cache       map[string]*mlx.Array         // name -> loaded array
-	nativeCache []*mlx.SafetensorsFile        // keep native handles alive
+	tensors     map[string]ManifestLayer // name -> layer
+	cache       map[string]*mlx.Array    // name -> loaded array
+	nativeCache []*mlx.SafetensorsFile   // keep native handles alive
 }
 
 // LoadWeightsFromManifest creates a weight loader for a component from manifest storage.


### PR DESCRIPTION
# llm: support multiple LoRA adapters and hot-swapping

This PR removes the single-adapter limitation and exposes llama.cpp's  LoRA hot-swap API through Ollama, enabling dynamic multi-adapter workflows.

## Background

llama.cpp added multi-LoRA support in August 2024 (PRs #8332, #8857), 
but Ollama still had a hardcoded single-adapter limit. This PR bridges that gap.

Closes #9548

Closes #7627

## Why This Should Be Accepted

1. **Parity, not novelty** — llama.cpp already supports this; we're exposing it
2. **Minimal API surface** — Only 2 endpoints, mirroring upstream's design
3. **Backward compatible** — Single-adapter Modelfiles work unchanged
4. **Community requested** — Issues #9548 and #7627 show user demand

## Features

-   **Multi-Adapter Model Creation**: Removes the single-adapter limitation. You can now specify multiple `ADAPTER` instructions in a `Modelfile`.
-   **Runtime Hot-Swapping**: New API endpoints to list loaded adapters and adjust their scales dynamically (0.0 to 1.0) without reloading the model.
-   **Stability Improvements**: Patched the bundled `llama.cpp` to significantly increase graph node capacity, resolving crashes when using multiple concurrent adapters.

## Usage Guide

### 1. Create a Multi-Adapter Model

Create a `Modelfile` with multiple adapters (using Canis.teach adapters as an example):

```dockerfile
FROM mistralai/Ministral-3-3B-Instruct-2512.gguf

TEMPLATE """<s>{{- if .System }}[SYSTEM_PROMPT]{{ .System }}[/SYSTEM_PROMPT]{{ end }}
{{- range .Messages }}
{{- if eq .Role "user" }}[INST]{{ .Content }}[/INST]
{{- else if eq .Role "assistant" }}{{ .Content }}</s>
{{- end }}
{{- end }}"""

PARAMETER stop "[INST]"
PARAMETER stop "[/INST]"
PARAMETER stop "</s>"
PARAMETER stop "[SYSTEM_PROMPT]"
PARAMETER stop "[/SYSTEM_PROMPT]"

ADAPTER CanisAI/teach-generalist-ministral-3b-r2.gguf
ADAPTER CanisAI/teach-humanities-ministral-3b-r2.gguf
ADAPTER CanisAI/teach-language-ministral-3b-r2.gguf
ADAPTER CanisAI/teach-math-ministral-3b-r2.gguf
ADAPTER CanisAI/teach-science-ministral-3b-r2.gguf
```

Create the model:
```bash
ollama create my-multi-lora -f Modelfile
```

### 2. List Loaded Adapters

Use the new API endpoint to see which adapters are available and their current status:

```bash
curl http://localhost:11434/api/lora-adapters?model=my-multi-lora
```

**Response:**
```json
{
  "model": "my-multi-lora",
  "adapters": [
    {"id": 0, "path": ".../math.gguf", "scale": 0.0},
    {"id": 1, "path": ".../science.gguf", "scale": 0.0}
  ]
}
```
*Note: Adapters load with scale 0.0 (disabled) by default if not specified otherwise.*

### 3. Hot-Swap Adapters

Activate specific adapters by sending a POST request. You can set the scale between `0.0` (off) and `1.0` (full strength), or any value in between.

**Enable Math Adapter:**
```bash
curl -X POST http://localhost:11434/api/lora-adapters -d '{
  "model": "my-multi-lora",
  "adapters": [
    {"id": 0, "scale": 1.0}, 
    {"id": 1, "scale": 0.0}
  ]
}'
```

Now, any subsequent inference requests will use the active adapter(s). This change is instantaneous and does not require model reloading.

## Testing

**Manual Testing:**
- Base Model: Ministral-3B-Instruct (Q4_K_M)
- Adapters: 5 TEACH adapters
- Memory stable with 5 concurrent adapters

**Unit Tests:** To be added based on reviewer feedback.

## Known Limitations

-   **Engine Bypass**: Uses the legacy runner when adapters are present because `ollama-engine` does not yet support the LoRA API. Future work could add native engine support.

## Implementation Details

-   **`server/create.go` & `parser/parser.go`**: Logic updated to parse and merge multiple `ADAPTER` commands correctly.
-   **`llama.cpp` Patch**: Increased `graph_max_nodes` buffer (3x) in `llama-context.cpp` to handle the expanded computation graph size required by multiple adapters.
-   **`runner/llamarunner`**: Added `GetLoraAdapters` and `SetLoraAdapters` interfaces properly mapped to `llama_set_adapter_lora`.
-   **Engine**: Bypassed `ollama-engine` (which lacks complete LoRA support) to use the legacy runner when adapters are present.

## Draft Documentation

### Modelfile Reference (addition)

**ADAPTER**

Multiple `ADAPTER` instructions can now be specified:

ADAPTER ./math.gguf

ADAPTER ./science.gguf

Adapters load with scale 0.0 (disabled) by default

### API Reference (new endpoints)

**GET /api/lora-adapters**
Returns loaded adapters for a model.

**POST /api/lora-adapters**
Sets adapter scales at runtime (hot-swap).
