### PR TITLE
docs: Update linux documentation to use zstd

### DIFF
--- a/docs/linux.mdx
+++ b/docs/linux.mdx
@@ -21,7 +21,7 @@ Download and extract the package:
 
 ```shell
 curl -fsSL https://ollama.com/download/ollama-linux-amd64.tar.zst \
-   | zstd -d | sudo tar x -C /usr
+    | zstd -d | sudo tar x -C /usr
 ```
 
 Start Ollama:
@@ -42,7 +42,7 @@ If you have an AMD GPU, also download and extract the additional ROCm package:
 
 ```shell
 curl -fsSL https://ollama.com/download/ollama-linux-amd64-rocm.tar.zst \
-    | sudo tar x -C /usr
+    | zstd -d | sudo tar x -C /usr
 ```
 
 ### ARM64 install
@@ -51,7 +51,7 @@ Download and extract the ARM64-specific package:
 
 ```shell
 curl -fsSL https://ollama.com/download/ollama-linux-arm64.tar.zst \
-    | sudo tar x -C /usr
+    | zstd -d | sudo tar x -C /usr
 ```
 
 ### Adding Ollama as a startup service (recommended)


### PR DESCRIPTION
This PR updates the linux.mdx manual install documentation to use `zstd` when curling the Ollama tar.zst file.

When trying to use the current documentation as-is I encountered the following issue:

<img width="1844" height="1018" alt="Screenshot from 2026-02-01 18-48-56" src="https://github.com/user-attachments/assets/885ad019-b466-4253-8e4e-54c30998e831" />

The install.sh file for installing Ollama on Linux uses `zstd` for decompressing the curled file in the [download_and_extract()](https://github.com/ollama/ollama/blob/d8cc798c2bda2cd76ad3fc108b06d04916abd51f/scripts/install.sh#L70) function.

If this solution is undesirable, another alternative would be to update the documentation to use a regular `tar` instead of `tar.zst`