### PR TITLE
fix(app): skip sidebar transition animation on initial page load

### DIFF
--- a/app/ui/app/src/components/layout/layout.tsx
+++ b/app/ui/app/src/components/layout/layout.tsx
@@ -1,4 +1,5 @@
 import { Link } from "@tanstack/react-router";
+import { useEffect, useState } from "react";
 import { useSettings } from "@/hooks/useSettings";
 
 export function SidebarLayout({
@@ -10,12 +11,20 @@ export function SidebarLayout({
   chatId?: string;
 }>) {
   const { settings, setSettings } = useSettings();
+  const [hasMounted, setHasMounted] = useState(false);
+
+  useEffect(() => {
+    // Skip transition animation on initial page load
+    requestAnimationFrame(() => {
+      setHasMounted(true);
+    });
+  }, []);
   const isWindows = navigator.platform.toLowerCase().includes("win");
 
   return (
-    <div className={`flex transition-[width] duration-300 dark:bg-neutral-900`}>
+    <div className={`flex ${hasMounted ? "transition-[width] duration-300" : ""} dark:bg-neutral-900`}>
       <div
-        className={`absolute flex mx-2 py-2 z-20 items-center transition-[left] duration-375 text-neutral-500 dark:text-neutral-400 ${settings.sidebarOpen ? (isWindows ? "left-2" : "left-[204px]") : isWindows ? "left-2" : "left-20"}`}
+        className={`absolute flex mx-2 py-2 z-20 items-center ${hasMounted ? "transition-[left] duration-375" : ""} text-neutral-500 dark:text-neutral-400 ${settings.sidebarOpen ? (isWindows ? "left-2" : "left-[204px]") : isWindows ? "left-2" : "left-20"}`}
       >
         <button
           onClick={() => setSettings({ SidebarOpen: !settings.sidebarOpen })}
@@ -57,7 +66,7 @@ export function SidebarLayout({
         </Link>
       </div>
       <div
-        className={`flex flex-col transition-[width] duration-300 max-h-screen ${settings.sidebarOpen ? "w-64" : "w-0"}`}
+        className={`flex flex-col max-h-screen ${hasMounted ? "transition-[width] duration-300" : ""} ${settings.sidebarOpen ? "w-64" : "w-0"}`}
       >
         <div
           onDoubleClick={() => window.doubleClick && window.doubleClick()}


### PR DESCRIPTION
## Summary

The sidebar animates open when the page first loads instead of appearing instantly. This PR defers CSS transitions until after the first mount, so the sidebar renders in its correct state without animation on initial load.

## Changes

- Added `hasMounted` state that becomes `true` after first `requestAnimationFrame`
- CSS transition classes (`transition-[width]`, `transition-[left]`) are only applied after mount
- Subsequent sidebar toggles still animate smoothly

## Before
Sidebar slides open from collapsed state on every page load.

## After
Sidebar appears instantly in its saved state on load. Toggle animations work normally after mount.

Fixes #12954