### PR TITLE
app/ui: fix browser tools not registering for gptoss models with custom names

### DIFF
--- a/app/ui/app/src/components/ChatForm.tsx
+++ b/app/ui/app/src/components/ChatForm.tsx
@@ -149,11 +149,7 @@ function ChatForm({
   } = useSettings();
 
   // current supported models for web search
-  const modelLower = selectedModel?.model.toLowerCase() || "";
-  const supportsWebSearch =
-    modelLower.startsWith("gpt-oss") ||
-    modelLower.startsWith("qwen3") ||
-    modelLower.startsWith("deepseek-v3");
+  const supportsWebSearch = selectedModel?.supportsWebSearch() ?? false;
   // Use per-chat thinking level instead of global
   const thinkLevel: ThinkingLevel =
     settingsThinkLevel === "none" || !settingsThinkLevel

--- a/app/ui/ui.go
+++ b/app/ui/ui.go
@@ -828,7 +828,7 @@ func (s *Server) chat(w http.ResponseWriter, r *http.Request) error {
 		WebSearchEnabled := req.WebSearch != nil && *req.WebSearch
 
 		if WebSearchEnabled {
-			if supportsBrowserTools(req.Model) {
+			if supportsBrowserTools(details.Details.Family) {
 				browserState, ok := s.browserState(chat)
 				if !ok {
 					browserState = reconstructBrowserState(chat.Messages, tools.DefaultViewTokens)
@@ -1611,8 +1611,10 @@ func isImageAttachment(filename string) bool {
 func ptr[T any](v T) *T { return &v }
 
 // Browser tools simulate a full browser environment, allowing for actions like searching, opening, and interacting with web pages (e.g., "browser_search", "browser_open", "browser_find"). Currently only gpt-oss models support browser tools.
-func supportsBrowserTools(model string) bool {
-	return strings.HasPrefix(strings.ToLower(model), "gpt-oss")
+// modelFamily should be the model's architecture family (e.g., from ShowResponse.Details.Family).
+func supportsBrowserTools(modelFamily string) bool {
+	family := strings.ToLower(modelFamily)
+	return family == "gptoss" || family == "gpt-oss"
 }
 
 // Web search tools are simpler, providing only basic web search and fetch capabilities (e.g., "web_search", "web_fetch") without simulating a browser. Currently only qwen3 and deepseek-v3 support web search tools.

--- a/app/ui/ui_test.go
+++ b/app/ui/ui_test.go
@@ -421,3 +421,124 @@ func TestUserAgentTransport(t *testing.T) {
 
 	t.Logf("User-Agent transport successfully set: %s", receivedUA)
 }
+
+func TestSupportsBrowserTools(t *testing.T) {
+	tests := []struct {
+		name        string
+		modelFamily string
+		want        bool
+	}{
+		{
+			name:        "gptoss family (lowercase)",
+			modelFamily: "gptoss",
+			want:        true,
+		},
+		{
+			name:        "gpt-oss family (with hyphen)",
+			modelFamily: "gpt-oss",
+			want:        true,
+		},
+		{
+			name:        "GPTOSS family (uppercase)",
+			modelFamily: "GPTOSS",
+			want:        true,
+		},
+		{
+			name:        "GPT-OSS family (uppercase with hyphen)",
+			modelFamily: "GPT-OSS",
+			want:        true,
+		},
+		{
+			name:        "GptOss family (mixed case)",
+			modelFamily: "GptOss",
+			want:        true,
+		},
+		{
+			name:        "llama family",
+			modelFamily: "llama",
+			want:        false,
+		},
+		{
+			name:        "qwen3 family",
+			modelFamily: "qwen3",
+			want:        false,
+		},
+		{
+			name:        "empty family",
+			modelFamily: "",
+			want:        false,
+		},
+		{
+			name:        "gptoss-like but not exact (gptoss2)",
+			modelFamily: "gptoss2",
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := supportsBrowserTools(tt.modelFamily)
+			if got != tt.want {
+				t.Errorf("supportsBrowserTools(%q) = %v, want %v", tt.modelFamily, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSupportsWebSearchTools(t *testing.T) {
+	tests := []struct {
+		name      string
+		modelName string
+		want      bool
+	}{
+		{
+			name:      "qwen3 model",
+			modelName: "qwen3",
+			want:      true,
+		},
+		{
+			name:      "qwen3-coder model",
+			modelName: "qwen3-coder",
+			want:      true,
+		},
+		{
+			name:      "deepseek-v3 model",
+			modelName: "deepseek-v3",
+			want:      true,
+		},
+		{
+			name:      "deepseek-v3:latest model",
+			modelName: "deepseek-v3:latest",
+			want:      true,
+		},
+		{
+			name:      "QWEN3 model (uppercase)",
+			modelName: "QWEN3",
+			want:      true,
+		},
+		{
+			name:      "llama model",
+			modelName: "llama",
+			want:      false,
+		},
+		{
+			name:      "gpt-oss model",
+			modelName: "gpt-oss",
+			want:      false,
+		},
+		{
+			name:      "empty model",
+			modelName: "",
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := supportsWebSearchTools(tt.modelName)
+			if got != tt.want {
+				t.Errorf("supportsWebSearchTools(%q) = %v, want %v", tt.modelName, got, tt.want)
+			}
+		})
+	}
+}

--- a/server/images.go
+++ b/server/images.go
@@ -105,12 +105,15 @@ func (m *Model) Capabilities() []model.Capability {
 	}
 
 	builtinParser := parsers.ParserForName(m.Config.Parser)
+	isGptoss := slices.Contains([]string{"gptoss", "gpt-oss"}, m.Config.ModelFamily)
+
 	// Check for tools capability
+	// gptoss models use harmony parser which supports tools via browser.search, browser.open, etc.
 	v, err := m.Template.Vars()
 	if err != nil {
 		slog.Warn("model template contains errors", "error", err)
 	}
-	if slices.Contains(v, "tools") || (builtinParser != nil && builtinParser.HasToolSupport()) {
+	if slices.Contains(v, "tools") || isGptoss || (builtinParser != nil && builtinParser.HasToolSupport()) {
 		capabilities = append(capabilities, model.CapabilityTools)
 	}
 
@@ -132,7 +135,6 @@ func (m *Model) Capabilities() []model.Capability {
 	// Check for thinking capability
 	openingTag, closingTag := thinking.InferTags(m.Template.Template)
 	hasTags := openingTag != "" && closingTag != ""
-	isGptoss := slices.Contains([]string{"gptoss", "gpt-oss"}, m.Config.ModelFamily)
 	if hasTags || isGptoss || (builtinParser != nil && builtinParser.HasThinkingSupport()) {
 		capabilities = append(capabilities, model.CapabilityThinking)
 	}

--- a/server/images_test.go
+++ b/server/images_test.go
@@ -269,6 +269,28 @@ func TestModelCheckCapabilities(t *testing.T) {
 			},
 			checkCaps: []model.Capability{model.CapabilityImage},
 		},
+		{
+			name: "gptoss model has tools capability",
+			model: Model{
+				ModelPath: completionModelPath,
+				Template:  chatTemplate, // no tools in template
+				Config: model.ConfigV2{
+					ModelFamily: "gptoss",
+				},
+			},
+			checkCaps: []model.Capability{model.CapabilityTools},
+		},
+		{
+			name: "gpt-oss model has tools capability",
+			model: Model{
+				ModelPath: completionModelPath,
+				Template:  chatTemplate, // no tools in template
+				Config: model.ConfigV2{
+					ModelFamily: "gpt-oss",
+				},
+			},
+			checkCaps: []model.Capability{model.CapabilityTools},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Fixes #14095

This PR fixes web search/browser tools not working for gptoss models with custom names. The bug had two locations:

### Backend fix (server/images.go)
- Added `isGptoss` check to the tools capability detection in `Capabilities()`
- Previously, the thinking capability check correctly detected gptoss models by family, but tools capability didn't
- Now both tool and thinking capabilities are properly detected for gptoss models regardless of model name

### Backend fix (app/ui/ui.go)
- Changed `supportsBrowserTools()` to check the model's architecture family instead of the model name string
- Now uses `details.Details.Family` from the `ShowResponse` to determine browser tools support

### Frontend fix (app/ui/app/src/api.ts, ChatForm.tsx)
- Added `supportsWebSearch()` method to Model class that checks model families
- Preserved families array when mapping models from ollama.list()
- Fixed model name handling to keep `:latest` suffix for proper settings matching

## Problem

1. `Capabilities()` in `server/images.go` checked `isGptoss` for thinking capability but not for tools capability, causing "does not support tools" errors
2. `supportsBrowserTools()` in `app/ui/ui.go` was checking if the model name starts with "gpt-oss", but models with `gptoss` architecture can have any name
3. Frontend was also checking model name instead of architecture family for the web search globe icon

## Solution

- Added `isGptoss` to the tools capability check in `Capabilities()`, matching how thinking capability works
- Changed `supportsBrowserTools()` to accept the model family string and check for exact matches of "gptoss" or "gpt-oss"
- Added `supportsWebSearch()` method to frontend Model class that checks families array

## Test plan

- [x] Added unit tests for `supportsBrowserTools()` covering various model families
- [x] Added unit tests for `supportsWebSearchTools()` for completeness
- [x] Verified web search works with official `gpt-oss:120b-cloud` model
- [x] Verified web search works with custom gptoss model `Raiff1982/codette-ultimate-v2:latest`
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)