### PR TITLE
docs: improve python code in tool calling examples

### DIFF
--- a/docs/capabilities/tool-calling.mdx
+++ b/docs/capabilities/tool-calling.mdx
@@ -470,7 +470,7 @@ It also might help to tell the model that it is in a loop and can make multiple 
         response: ChatResponse = chat(
             model='qwen3',
             messages=messages,
-            tools=[add, multiply],
+            tools=available_functions.values(),
             think=True,
         )
         messages.append(response.message)
@@ -769,6 +769,7 @@ def get_temperature(city: str) -> str:
   }
   return temperatures.get(city, 'Unknown')
 
+messages = [{"role": "user", "content": "What is the temperature in New York?"}]
 available_functions = {
   'get_temperature': get_temperature,
 }


### PR DESCRIPTION
1. use dict's `.values()` method to avoid duplicating function names
1. add missing `messages[]` array in final example