### PR TITLE
feat: add PARAMETER think support for Modelfile

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -124,6 +124,21 @@ func (f Modelfile) CreateRequest(relativeDir string) (*api.CreateRequest, error)
 				break
 			}
 
+			// Handle "think" parameter specially since it's not part of Options
+			if c.Name == "think" {
+				switch strings.ToLower(strings.TrimSpace(c.Args)) {
+				case "false", "off", "no", "0":
+					params["think"] = false
+				case "true", "on", "yes", "1":
+					params["think"] = true
+				case "high", "medium", "low":
+					params["think"] = strings.ToLower(strings.TrimSpace(c.Args))
+				default:
+					return nil, fmt.Errorf("invalid think value: %q (must be true, false, high, medium, or low)", c.Args)
+				}
+				break
+			}
+
 			ps, err := api.FormatParams(map[string][]string{c.Name: {c.Args}})
 			if err != nil {
 				return nil, err

--- a/server/routes.go
+++ b/server/routes.go
@@ -369,6 +369,17 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 	if slices.Contains(modelCaps, model.CapabilityThinking) {
 		caps = append(caps, model.CapabilityThinking)
 		if req.Think == nil {
+			// Check for stored think default in model options
+			if thinkVal, ok := m.Options["think"]; ok {
+				switch v := thinkVal.(type) {
+				case bool:
+					req.Think = &api.ThinkValue{Value: v}
+				case string:
+					req.Think = &api.ThinkValue{Value: v}
+				}
+			}
+		}
+		if req.Think == nil {
 			req.Think = &api.ThinkValue{Value: true}
 		}
 	} else {
@@ -2084,6 +2095,17 @@ func (s *Server) ChatHandler(c *gin.Context) {
 	modelCaps := m.Capabilities()
 	if slices.Contains(modelCaps, model.CapabilityThinking) {
 		caps = append(caps, model.CapabilityThinking)
+		if req.Think == nil {
+			// Check for stored think default in model options
+			if thinkVal, ok := m.Options["think"]; ok {
+				switch v := thinkVal.(type) {
+				case bool:
+					req.Think = &api.ThinkValue{Value: v}
+				case string:
+					req.Think = &api.ThinkValue{Value: v}
+				}
+			}
+		}
 		if req.Think == nil {
 			req.Think = &api.ThinkValue{Value: true}
 		}


### PR DESCRIPTION
## Summary

Adds support for `PARAMETER think false|true|high|medium|low` in Modelfiles, allowing thinking-capable models to persist a default thinking mode.

**Problem**: Currently, thinking-capable models always auto-enable thinking when no explicit `think` value is provided in the request. There's no way to create a model variant that defaults to thinking disabled. Users must pass `think: false` in every API request or use `--think=false` on every CLI invocation. This is especially problematic for apps like Open WebUI that don't expose the think parameter.

**Solution**: Allow `PARAMETER think` in Modelfiles with a clear priority chain:
1. **Request-level** `think` (API/CLI flag) — highest priority, always wins
2. **Model-level** `PARAMETER think` — used when request doesn't specify
3. **Auto-enable** — fallback for thinking-capable models (existing behavior preserved)

## Example Usage

```
# Create a no-think variant
FROM nemotron-3-nano:30b
PARAMETER think false
```

```bash
ollama create nemotron-3-nano:30b-nothink -f Modelfile
ollama run nemotron-3-nano:30b-nothink  # No thinking by default
ollama run nemotron-3-nano:30b           # Still thinks as before
```

API requests can still override:
```json
{"model": "nemotron-3-nano:30b-nothink", "think": true}
```

## Changes

- **parser/parser.go**: Intercepts `think` parameter before `FormatParams()` (since it's not in the `Options` struct), validates values, and stores it as a model parameter
- **server/routes.go**: Both `GenerateHandler` and `ChatHandler` check `m.Options["think"]` when `req.Think` is nil, before falling back to auto-enabling thinking
- **cmd/cmd.go**: `inferThinkingOption()` checks the model's stored parameters for a think default before auto-enabling thinking client-side

## Backward Compatibility

- Models without `PARAMETER think` behave exactly as before (thinking auto-enabled)
- Existing `--think=false` CLI flag and `"think": false` API parameter still work
- Request-level always overrides model-level
- No changes to the `Options` struct or `FormatParams()` — the think parameter is handled separately, consistent with how `ThinkValue` is already a separate field on request types

## Test Matrix

| Model | Request `think` | Result |
|-------|----------------|--------|
| Standard model | *(none)* | Thinking ON (unchanged) |
| Standard model | `false` | Thinking OFF (unchanged) |
| `PARAMETER think false` model | *(none)* | **Thinking OFF** (new) |
| `PARAMETER think false` model | `true` | Thinking ON (override works) |

Fixes #10961