### PR TITLE
 server: account for OLLAMA_NUM_PARALLEL in VRAM-based default context length  

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -1736,6 +1736,12 @@ func Serve(ln net.Listener) error {
 	default:
 		s.defaultNumCtx = 4096
 	}
+
+	// Adjust for parallelism since KV cache allocates NumCtx * NumParallel
+	if numParallel := max(int(envconfig.NumParallel()), 1); numParallel > 1 {
+		s.defaultNumCtx /= numParallel
+	}
+
 	slog.Info("vram-based default context", "total_vram", format.HumanBytes2(totalVRAM), "default_num_ctx", s.defaultNumCtx)
 
 	err = srvr.Serve(ln)


### PR DESCRIPTION
  - Fix VRAM-based default context length to divide by OLLAMA_NUM_PARALLEL, preventing VRAM exhaustion when parallel > 1
  - The KV cache allocates NumCtx * NumParallel but the tiered defaults only considered total VRAM, ignoring the parallelism multiplier
  - Add tests for the new behavior

  Problem

  Fixes #14116, #14088, #14073

  The tiered VRAM-based default context lengths (4K / 32K / 256K) introduced in 0.15.5 don't account for OLLAMA_NUM_PARALLEL. Since KV cache is allocated as
  NumCtx * NumParallel (llm/server.go:175), setting NUM_PARALLEL > 1 causes VRAM exhaustion and model loading failures.

  Example: 24 GiB GPU with NUM_PARALLEL=4 gets default ctx=32768, resulting in KV cache = 32768 * 4 = 131072 tokens worth of VRAM — far exceeding what fits.

  Fix

  Divide s.defaultNumCtx by numParallel at startup, immediately after tier selection. This only affects the VRAM-based default — explicit settings via
  OLLAMA_CONTEXT_LENGTH, model config, or API request are unchanged.

