### PR TITLE
parser: allow multiple spaces after PARAMETER and MESSAGE keywords

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -434,16 +434,24 @@ func ParseFile(r io.Reader) (*Modelfile, error) {
 					cmd.Name = s
 				}
 			case stateParameter:
-				cmd.Name = b.String()
-			case stateMessage:
-				if !isValidMessageRole(b.String()) {
-					return nil, &ParserError{
-						LineNumber: currLine,
-						Msg:        errInvalidMessageRole.Error(),
-					}
+				if b.Len() == 0 {
+					next = stateParameter
+				} else {
+					cmd.Name = b.String()
 				}
+			case stateMessage:
+				if b.Len() == 0 {
+					next = stateMessage
+				} else {
+					if !isValidMessageRole(b.String()) {
+						return nil, &ParserError{
+							LineNumber: currLine,
+							Msg:        errInvalidMessageRole.Error(),
+						}
+					}
 
-				role = b.String()
+					role = b.String()
+				}
 			case stateComment, stateNil:
 				// pass
 			case stateValue:

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -65,6 +65,8 @@ ADAPTER      adapter3
 LICENSE "MIT       "
 PARAMETER param1        value1
 PARAMETER param2    value2
+PARAMETER   param3 value3
+PARAMETER     param4    value4
 TEMPLATE """   {{ if .System }}<|start_header_id|>system<|end_header_id|>
 
 {{ .System }}<|eot_id|>{{ end }}{{ if .Prompt }}<|start_header_id|>user<|end_header_id|>
@@ -85,6 +87,8 @@ TEMPLATE """   {{ if .System }}<|start_header_id|>system<|end_header_id|>
 		{Name: "license", Args: "MIT       "},
 		{Name: "param1", Args: "value1"},
 		{Name: "param2", Args: "value2"},
+		{Name: "param3", Args: "value3"},
+		{Name: "param4", Args: "value4"},
 		{Name: "template", Args: "   {{ if .System }}<|start_header_id|>system<|end_header_id|>\n\n{{ .System }}<|eot_id|>{{ end }}{{ if .Prompt }}<|start_header_id|>user<|end_header_id|>\n\n{{ .Prompt }}<|eot_id|>{{ end }}<|start_header_id|>assistant<|end_header_id|>\n\n{{ .Response }}<|eot_id|>   "},
 	}
 
@@ -281,6 +285,30 @@ You are a multiline file parser. Always parse things.
 			[]Command{
 				{Name: "model", Args: "foo"},
 				{Name: "message", Args: "system: \nYou are a multiline file parser. Always parse things.\n"},
+			},
+			nil,
+		},
+		{
+			`
+FROM foo
+MESSAGE   user   Hello with extra spaces!
+`,
+			[]Command{
+				{Name: "model", Args: "foo"},
+				{Name: "message", Args: "user: Hello with extra spaces!"},
+			},
+			nil,
+		},
+		{
+			`
+FROM foo
+MESSAGE     system     You are a parser.
+MESSAGE     user       Parse this!
+`,
+			[]Command{
+				{Name: "model", Args: "foo"},
+				{Name: "message", Args: "system: You are a parser."},
+				{Name: "message", Args: "user: Parse this!"},
 			},
 			nil,
 		},


### PR DESCRIPTION
## Summary

Fixes #13359

The Modelfile parser fails when there are multiple spaces between `PARAMETER`/`MESSAGE` keywords and their arguments:

- `PARAMETER temperature 0.5` works
- `PARAMETER   temperature 0.5` fails with "unknown parameter ''"
- `MESSAGE   user hello` fails with "message role must be one of..."

**Root cause:** In `ParseFile()`, when `stateParameter` or `stateMessage` transitions on a space character, the accumulated buffer is used as `cmd.Name` or role. If only spaces have been read since entering the state (buffer is empty), the transition fires prematurely with an empty string.

**Fix:** Check if the buffer is empty before transitioning out of `stateParameter`/`stateMessage`. If empty, stay in the current state to skip leading whitespace. This is a minimal change (6 lines of logic) that only affects these two states — it does not touch `SYSTEM`, `FROM`, `ADAPTER`, or any triple-quote handling.

## Test plan

- [x] Added test cases to `TestParseFileTrimSpace` with multiple spaces after `PARAMETER`
- [x] Added test cases to `TestParseFileMessages` with multiple spaces after `MESSAGE`
- [x] All existing parser tests pass (`go test ./parser/ -v` — 60+ tests)