### PR TITLE
fix: allow app to build without UI dist directory

### DIFF
--- a/app/ui/app.go
+++ b/app/ui/app.go
@@ -33,7 +33,10 @@ func (s *Server) appHandler() http.Handler {
 		data, err := fs.ReadFile(fsys, "index.html")
 		if err != nil {
 			if errors.Is(err, fs.ErrNotExist) {
-				http.NotFound(w, r)
+				// Development mode: UI not built
+				w.Header().Set("Content-Type", "text/plain")
+				w.WriteHeader(http.StatusNotFound)
+				w.Write([]byte("UI not built. Run 'npm run build' in app/ui/app directory."))
 			} else {
 				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			}

--- a/app/ui/app/dist/README.md
+++ b/app/ui/app/dist/README.md
@@ -1,0 +1,1 @@
+This directory contains the built React app. Run `npm run build` in the app directory to generate the build.


### PR DESCRIPTION
Add a placeholder README.md in app/ui/app/dist so the go:embed directive doesn't fail when the UI hasn't been built. Also improve the error message when index.html is not found to help developers understand they need to run 'npm run build'.