### PR TITLE
tools: fall back to raw JSON parsing when expected tag is missing

### DIFF
--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -756,6 +756,23 @@ func TestParser(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:    "qwen raw json fallback",
+			inputs:  []string{`{"name": "get_conditions", "arguments": {"location": "San Francisco"}}`},
+			content: "",
+			tmpl:    qwen,
+			calls: []api.ToolCall{
+				{
+					Function: api.ToolCallFunction{
+						Index: 0,
+						Name:  "get_conditions",
+						Arguments: testArgs(map[string]any{
+							"location": "San Francisco",
+						}),
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### Summary
Some models (e.g. qwen2.5-coder) have chat templates that instruct tool calls to be wrapped in <tool_call> tags, but the model emits bare JSON like {"name": "exec", "arguments": {"command": "ls"}} without the wrapper. The generic tools.Parser never finds the expected tag, so every token is flushed as plain-text content — the tool call is lost.
This PR adds a fallback in Parser.Add(): when findTag() fails and the accumulated content starts with {, switch p.tag to "{" and re-enter ToolCalling state. This reuses the existing raw-JSON code path (findTool / findArguments / done). If the content isn't a valid tool call, Content() returns it as regular text — safe fallback.
Changes: tools/tools.go (one method, ~15 lines)
Test: added qwen_raw_json_fallback case in tools/tools_test.go

### Related issues
Fixes #12174 — tool_calls missing from qwen2.5-coder
Related to #10899 — qwen2.5-coder returns empty content with tools
Related to #12064 — tool call parsing errors

### Test plan
[x] All existing TestParser cases pass (33 cases)
[x] All TestDone, TestContent, TestFindTag, TestFindArguments pass
[x] New qwen_raw_json_fallback test passes
[x] End-to-end: patched binary with qwen2.5-coder:32b returns proper tool_calls via /v1/chat/completions