### PR TITLE
Fix missing error check in signinURL function

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -167,7 +167,10 @@ func signinURL() (string, error) {
 	}
 
 	encKey := base64.RawURLEncoding.EncodeToString([]byte(pubKey))
-	h, _ := os.Hostname()
+	h, err := os.Hostname()
+	if err != nil {
+		return "", fmt.Errorf("failed to get hostname: %w", err)
+	}
 	return fmt.Sprintf(signinURLStr, url.PathEscape(h), encKey), nil
 }
 


### PR DESCRIPTION
## Summary
Fix a missing error check in the `signinURL()` function in `server/routes.go`.

## Issue
The `os.Hostname()` call was ignoring its error return value:
```go
h, _ := os.Hostname()
```

If hostname retrieval fails, an empty string would be used in the signin URL, which could lead to incorrect authentication URLs being generated.

## Fix
Added proper error handling to return an error when hostname retrieval fails:
```go
h, err := os.Hostname()
if err != nil {
    return "", fmt.Errorf("failed to get hostname: %w", err)
}
```

This ensures that:
1. The caller is notified when hostname cannot be determined
2. Malformed URLs are not generated silently
3. Error handling is consistent with the rest of the function (which already returns errors for other failure cases)

## Impact
- Low risk: only affects error path when hostname retrieval fails
- Improves robustness of authentication URL generation
- Makes error handling explicit and consistent

## Test plan
This is a defensive fix that adds error checking. The change only affects the error path when `os.Hostname()` fails (which is rare in practice). The normal flow remains unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)