### PR TITLE
fs/gguf: validate tensor dimension count in readTensor

### DIFF
--- a/fs/gguf/gguf.go
+++ b/fs/gguf/gguf.go
@@ -101,6 +101,11 @@ func (f *File) readTensor() (TensorInfo, error) {
 		return TensorInfo{}, err
 	}
 
+	const maxDims = 4
+	if dims > maxDims {
+		return TensorInfo{}, fmt.Errorf("invalid tensor dimension count: %d", dims)
+	}
+
 	shape := make([]uint64, dims)
 	for i := range dims {
 		shape[i], err = read[uint64](f)


### PR DESCRIPTION
*Vulnerability identified and fix provided by [Kolega.dev](https://kolega.dev/)*

## Unbounded Tensor Shape Dimension Allocation

## Location
`fs/gguf/gguf.go:93-128` — `readTensor()` function

## Description
The `readTensor()` function reads a `uint32` dimension count from a GGUF file and directly allocates a `[]uint64` slice of that size without bounds checking. Since GGUF files can be supplied by users via `/api/create`, an attacker can craft a malicious file with `dims=4294967295` (max uint32), attempting to allocate 32GB+ of memory. This is a denial-of-service via memory exhaustion.

## Analysis Notes
Real tensor dimensions in ML models are limited to at most 4, consistent with the `GGML_MAX_DIMS` constant defined in `ml/backend/ggml/ggml/include/ggml.h`. The C++ GGUF parser (`ml/backend/ggml/ggml/src/gguf.cpp:528`) already validates `n_dims > GGML_MAX_DIMS`, but the Go parser did not.

## Fix Applied
Added a bounds check on the `dims` value before slice allocation, rejecting any value greater than 4. This matches the `GGML_MAX_DIMS` limit enforced by the C/C++ GGML library and the C++ GGUF parser, ensuring consistency across both parsers. The error message follows the existing pattern in the file.

## Tests/Linters Ran
- `gofmt -d fs/gguf/gguf.go` — no formatting changes needed
- `go vet ./fs/gguf/...` — passed with no issues
- `go test ./fs/gguf/... -v -count=1` — all 3 tests passed (TestValue, TestValues, TestRead)

## Contribution Notes
- Commit message follows the `<package>: <short description>` convention specified in CONTRIBUTING.md
- No new dependencies added
- Existing tests confirm valid GGUF files with 2-dimension tensors continue to parse correctly