### PR TITLE
fs/gguf: close file on parsing errors in Open

### DIFF
--- a/fs/gguf/gguf.go
+++ b/fs/gguf/gguf.go
@@ -51,6 +51,12 @@ func Open(path string) (f *File, err error) {
 		return nil, err
 	}
 
+	defer func() {
+		if err != nil {
+			f.file.Close()
+		}
+	}()
+
 	f.reader = newBufferedReader(f.file, 32<<10)
 
 	if err := binary.Read(f.reader, binary.LittleEndian, &f.Magic); err != nil {


### PR DESCRIPTION
*Vulnerability identified and fix provided by [Kolega.dev](https://kolega.dev/)*

## File Descriptor Leak on Parsing Errors

## Location
`fs/gguf/gguf.go:47-91`

## Description
The `Open()` function opens a file with `os.Open()` but fails to close it on multiple error return paths. If magic number validation, version check, or lazy loader initialization fails, the opened file descriptor is leaked.

GGUF files can be uploaded by users via the `/api/create` endpoint. An attacker could repeatedly upload malformed GGUF files that fail validation checks, causing file descriptor exhaustion and denial of service. File descriptors are a finite system resource.

## Analysis Notes
The `Open()` function at lines 47-91 opens a file with `os.Open()` at line 49 but fails to close it on error paths at lines 57, 61, 65, 69, 74, and 87. All callers (e.g. `server/images.go:79`) properly call `defer f.Close()` on success, but the error paths in `Open` itself were not covered.

## Fix Applied
Added a deferred closure immediately after the successful `os.Open` call that checks the named `err` return value. If `Open` returns an error on any subsequent validation step, the file is closed automatically. On the success path, `err` is nil so the file remains open for the caller to manage via `File.Close()`. This is a standard Go cleanup pattern.

## Tests/Linters Ran
- `go vet ./fs/gguf/...` — passed, no issues
- `gofmt -d fs/gguf/gguf.go` — passed, no formatting differences
- `go test ./fs/gguf/... -v -count=1` — all 3 tests passed (TestValue, TestValues, TestRead)
- `golangci-lint` and `gofumpt` are configured in `.golangci.yaml` but not available in the build environment; the code follows the same formatting and style conventions

## Contribution Notes
- Commit message follows the project's `<package>: <short description>` convention per `CONTRIBUTING.md`
- No new dependencies added
- Fix is minimal: 6 lines added, no unrelated changes
- This is a security bug fix (file descriptor leak / DoS vector), which is listed as an ideal contribution type in `CONTRIBUTING.md`