### PR TITLE
doc: add links to 'How do I configure Ollama server?' when talking about context window size

### DIFF
--- a/docs/context-length.mdx
+++ b/docs/context-length.mdx
@@ -27,6 +27,8 @@ If editing the context length for Ollama is not possible, the context length can
 OLLAMA_CONTEXT_LENGTH=64000 ollama serve
 ```
 
+If you used the installer, Ollama is likely running as a service and you may need to refer to [How do I configure Ollama server?](./faq#how-do-i-configure-ollama-server) for setting environment variables.
+
 ### Check allocated context length and model offloading
 For best performance, use the maximum context length for a model, and avoid offloading the model to CPU. Verify the split under `PROCESSOR` using `ollama ps`.
 ```

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -30,7 +30,9 @@ This can be overridden with the `OLLAMA_CONTEXT_LENGTH` environment variable. Fo
 OLLAMA_CONTEXT_LENGTH=8192 ollama serve
 ```
 
-To change this when using `ollama run`, use `/set parameter`:
+If you used the installer, Ollama is likely running as a service and you may need to refer to [How do I configure Ollama server?](#how-do-i-configure-ollama-server) below.
+
+To change the context window size when using `ollama run`, use `/set parameter`:
 
 ```shell
 /set parameter num_ctx 4096


### PR DESCRIPTION
I spent an embarrassing amount of time trying things like:
`OLLAMA_CONTEXT_LENGTH=64000 ollama run gpt-oss:20b`
`OLLAMA_CONTEXT_LENGTH=64000 ollama launch codex --model gpt-oss:20b`
and even got ChatGPT to hallucinate and tell me there's a config file in my home directory with OLLAMA_CONTEXT_LENGTH :). **I didn't know ollama was running as a system service and thought 'run' was handling the LLM lifetime.**

there exists lots of doc saying you *must* change OLLAMA_CONTEXT_LENGTH, but none explaining *how* to change it.

probably similar tips for Windows/Mac/etc are needed, but don't know don't care

thank you for this awesome project!