### PR TITLE
bug: fix loading non-mlx models when ollama is built with mlx support

### DIFF
--- a/x/mlxrunner/server.go
+++ b/x/mlxrunner/server.go
@@ -7,6 +7,7 @@ import (
 	"cmp"
 	"encoding/json"
 	"flag"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -16,11 +17,16 @@ import (
 
 	"github.com/ollama/ollama/envconfig"
 	"github.com/ollama/ollama/logutil"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
 	"github.com/ollama/ollama/x/mlxrunner/sample"
 )
 
 func Execute(args []string) error {
 	slog.SetDefault(logutil.NewLogger(os.Stderr, envconfig.LogLevel()))
+
+	if err := mlx.CheckInit(); err != nil {
+		return fmt.Errorf("MLX not available: %w", err)
+	}
 
 	var (
 		modelName string


### PR DESCRIPTION
This change fixes an issue where GGML based models (for either the Ollama runner or the legacy llama.cpp runner) would try to load the mlx library. That would panic and the model fails to start.