### PR TITLE
tokenizer: merge pre-tok REs to prevent multiple matches

### DIFF
--- a/tokenizer/bytepairencoding.go
+++ b/tokenizer/bytepairencoding.go
@@ -27,6 +27,8 @@ func NewBytePairEncoding(vocab *Vocabulary, pretokenizer ...string) BytePairEnco
 		pretokenizer = []string{`'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+`}
 	}
 
+	pretokenizer = []string{strings.Join(pretokenizer, "|")}
+
 	return BytePairEncoding{
 		vocab: vocab,
 		regexps: slices.Collect(func(yield func(*regexp2.Regexp) bool) {


### PR DESCRIPTION
NewBytePairEncoding() takes a list of REs for pre-tokenization.  If the REs are not mutually exclusive, this causes token duplication.  Models affected:

deepseek-v3.1:671b
deepseek-r1:671b
cogito-2.1:671b
r1-1776:671b
deepseek-ocr

If ported to the ollama engine, the following models would also be affected:

granite-code
granite3-dense
granite3-moe
granite3-guardian
granite3.1-dense
granite3.1-moe
granite-3.2
granite3.3

Test:
```console
$ ollama run deepseek-v3.1:671b '"1 2 3 4" repeat the previous string'
Thinking...
First, the user said: "1" then "1 2" then "1 "1 2 3" but that seems messy. Let me read carefully.

The user said: "1" then "1 2" then "1 "1 2 3" but that doesn't make sense. Perhaps it's a pattern.

Perhaps it's a sequence of strings. Let me see the user's message: "1" then "1 2" then "1 "1 2 3"
but that seems off. Maybe it's "1" then "1 2" then "1 2 3" but the user wrote "1 "1 2 3" which might
be a typo.
...
```

This PR merges the list into a single RE with alternation.  An alternative approach would be to modify the call to NewBytePairEncoding() in the model.go file of affected models to pass a pre-concatenated string, or modify the parsing in
[split](https://github.com/ollama/ollama/blob/379fd64fa837e51eddeda6c32f5c812d912a6751/tokenizer/bytepairencoding.go#L50) to exit early on a match.

Fixes: #13388