### PR TITLE
openai: use crypto/rand for unique request IDs

### DIFF
--- a/middleware/openai.go
+++ b/middleware/openai.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"math/rand"
 	"net/http"
 	"strings"
 	"time"
@@ -333,7 +332,7 @@ func CompletionsMiddleware() gin.HandlerFunc {
 		w := &CompleteWriter{
 			BaseWriter:    BaseWriter{ResponseWriter: c.Writer},
 			stream:        req.Stream,
-			id:            fmt.Sprintf("cmpl-%d", rand.Intn(999)),
+			id:            openai.GenerateID("cmpl"),
 			streamOptions: req.StreamOptions,
 		}
 
@@ -425,7 +424,7 @@ func ChatMiddleware() gin.HandlerFunc {
 		w := &ChatWriter{
 			BaseWriter:    BaseWriter{ResponseWriter: c.Writer},
 			stream:        req.Stream,
-			id:            fmt.Sprintf("chatcmpl-%d", rand.Intn(999)),
+			id:            openai.GenerateID("chatcmpl"),
 			streamOptions: req.StreamOptions,
 		}
 
@@ -522,8 +521,8 @@ func ResponsesMiddleware() gin.HandlerFunc {
 
 		c.Request.Body = io.NopCloser(&b)
 
-		responseID := fmt.Sprintf("resp_%d", rand.Intn(999999))
-		itemID := fmt.Sprintf("msg_%d", rand.Intn(999999))
+		responseID := openai.GenerateID("resp")
+		itemID := openai.GenerateID("msg")
 
 		w := &ResponsesWriter{
 			BaseWriter: BaseWriter{ResponseWriter: c.Writer},

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -3,6 +3,7 @@ package openai
 
 import (
 	"bytes"
+	cryptorand "crypto/rand"
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
@@ -837,4 +838,15 @@ func FromImageEditRequest(r ImageEditRequest) (api.GenerateRequest, error) {
 	}
 
 	return req, nil
+}
+
+// GenerateID generates a unique ID with the given prefix using crypto/rand.
+// The format matches OpenAI-style IDs (e.g., "chatcmpl-7Z3nR4v8T2b1...").
+func GenerateID(prefix string) string {
+	b := make([]byte, 18)
+	if _, err := cryptorand.Read(b); err != nil {
+		// Fallback to time-based ID if crypto/rand fails
+		return fmt.Sprintf("%s-%d", prefix, time.Now().UnixNano())
+	}
+	return fmt.Sprintf("%s-%s", prefix, base64.RawURLEncoding.EncodeToString(b))
 }

--- a/openai/openai_test.go
+++ b/openai/openai_test.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"encoding/base64"
+	"strings"
 	"testing"
 	"time"
 
@@ -530,4 +531,48 @@ func TestFromImageEditRequest_InvalidImage(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for invalid image")
 	}
+}
+
+func TestGenerateID(t *testing.T) {
+	t.Run("has correct prefix", func(t *testing.T) {
+		id := GenerateID("chatcmpl")
+		if !strings.HasPrefix(id, "chatcmpl-") {
+			t.Errorf("expected prefix 'chatcmpl-', got %q", id)
+		}
+	})
+
+	t.Run("has sufficient length", func(t *testing.T) {
+		id := GenerateID("chatcmpl")
+		// "chatcmpl-" (9) + 24 base64 chars = 33 total
+		if len(id) < 30 {
+			t.Errorf("expected ID length >= 30, got %d (%q)", len(id), id)
+		}
+	})
+
+	t.Run("unique IDs", func(t *testing.T) {
+		seen := make(map[string]bool)
+		for range 1000 {
+			id := GenerateID("test")
+			if seen[id] {
+				t.Fatalf("duplicate ID generated: %q", id)
+			}
+			seen[id] = true
+		}
+	})
+
+	t.Run("different prefixes", func(t *testing.T) {
+		id1 := GenerateID("cmpl")
+		id2 := GenerateID("chatcmpl")
+		id3 := GenerateID("resp")
+
+		if !strings.HasPrefix(id1, "cmpl-") {
+			t.Errorf("expected prefix 'cmpl-', got %q", id1)
+		}
+		if !strings.HasPrefix(id2, "chatcmpl-") {
+			t.Errorf("expected prefix 'chatcmpl-', got %q", id2)
+		}
+		if !strings.HasPrefix(id3, "resp-") {
+			t.Errorf("expected prefix 'resp-', got %q", id3)
+		}
+	})
 }

--- a/openai/responses.go
+++ b/openai/responses.go
@@ -3,7 +3,6 @@ package openai
 import (
 	"encoding/json"
 	"fmt"
-	"math/rand"
 	"time"
 
 	"github.com/ollama/ollama/api"
@@ -978,7 +977,7 @@ func (c *ResponsesStreamConverter) processThinking(thinking string) []ResponsesS
 	// Start reasoning item if not started
 	if !c.reasoningStarted {
 		c.reasoningStarted = true
-		c.reasoningItemID = fmt.Sprintf("rs_%d", rand.Intn(999999))
+		c.reasoningItemID = GenerateID("rs")
 
 		events = append(events, c.newEvent("response.output_item.added", map[string]any{
 			"output_index": c.outputIndex,
@@ -1046,7 +1045,7 @@ func (c *ResponsesStreamConverter) processToolCalls(toolCalls []api.ToolCall) []
 	converted := ToToolCalls(toolCalls)
 
 	for i, tc := range converted {
-		fcItemID := fmt.Sprintf("fc_%d_%d", rand.Intn(999999), i)
+		fcItemID := GenerateID("fc")
 
 		// Store for final output (with status: completed)
 		toolCallItem := map[string]any{


### PR DESCRIPTION
## Summary

Replace weak `math/rand`-based ID generation with `crypto/rand`-based IDs that are both unique and match the format used by the OpenAI API more closely.

## Problem

The current ID generation for OpenAI-compatible endpoints uses `rand.Intn(999)` which only produces **1,000 possible values**:
- `chatcmpl-42`
- `cmpl-123`

And `rand.Intn(999999)` for responses API producing **1,000,000 possible values**:
- `resp_456789`
- `msg_123456`

This is problematic because:
1. **ID collisions** are likely in concurrent usage scenarios
2. Clients that use IDs for deduplication or request tracking may see incorrect behavior
3. The format doesn't match OpenAI's actual ID format

## Solution

Add `openai.GenerateID()` which uses `crypto/rand` to generate 18 random bytes (2^144 possible values) encoded as base64url. This produces IDs like:
- `chatcmpl-7Z3nR4v8T2b1eLqXyZAbCd`
- `resp-Kf2mN9pQ4rS6tU8vW0xYzA`

This follows the same pattern already used in the Anthropic middleware (`anthropic/anthropic.go:generateID`).

## Changes

- Add `openai.GenerateID()` using `crypto/rand` with base64url encoding
- Update `middleware/openai.go` to use `GenerateID` for chat completions, completions, and responses API IDs
- Update `openai/responses.go` to use `GenerateID` for reasoning and function call item IDs
- Remove unused `math/rand` imports
- Add tests for `GenerateID`