### PR TITLE
docs: add how to build documentation

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -177,3 +177,17 @@ Ollama looks for acceleration libraries in the following paths relative to the `
 * `build/lib/ollama` (for development)
 
 If the libraries are not found, Ollama will not run with any acceleration libraries.
+
+## Documentation
+
+Install the prerequisites:
+
+- [NodeJS](https://nodejs.org/en).
+- [Mint](https://www.mintlify.com/) via `npm i -g mint`.
+
+Then change to the `/docs` directory and build a local preview:
+
+```shell
+cd docs
+mint dev # This will launch a tab in your browser
+```


### PR DESCRIPTION
Addresses https://github.com/ollama/ollama/issues/13850.

This will add a section to explain how to build the documentation locally.