### PR TITLE
fix(server): implement robust truncation loop for embeddings

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -757,9 +757,31 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 		}
 
 		truncatedTokens := tokens[:ctxLen]
-		truncated, err := r.Detokenize(ctx, truncatedTokens)
-		if err != nil {
-			return nil, 0, err
+		var truncated string
+
+		for {
+			truncated, err = r.Detokenize(ctx, truncatedTokens)
+			if err != nil {
+				return nil, 0, err
+			}
+
+			reTokenized, err := r.Tokenize(ctx, truncated)
+			if err != nil {
+				return nil, 0, err
+			}
+
+			if len(reTokenized) <= ctxLen {
+				break
+			}
+
+			overshoot := len(reTokenized) - ctxLen
+			reduction := max(1, overshoot+(overshoot/10))
+
+			if len(truncatedTokens) <= reduction {
+				return nil, 0, fmt.Errorf("input cannot be truncated to fit context length %d (current: %d tokens)", ctxLen, len(reTokenized))
+			}
+
+			truncatedTokens = truncatedTokens[:len(truncatedTokens)-reduction]
 		}
 		return r.Embedding(ctx, truncated)
 	}


### PR DESCRIPTION
### Description:
### The Issue
Currently, the /api/embed endpoint can return a 400 Bad Request with the error the input length exceeds the context length, even when truncate: true is provided.

This happens because of token expansion during the detokenization-to-retokenization cycle. When input contains special characters, emojis, or specific multilingual strings (e.g., Turkish or Japanese), the initial truncation to ctxLen may result in a string that, when re-tokenized by the runner, exceeds the limit by a few tokens.

The Solution
I have implemented a robust verification loop in server/routes.go within the embedWithRetry function.
---
### Key features of this fix:

1. Validation Loop: After the initial truncation and detokenization, the code re-tokenizes the resulting string to verify the actual token count.
2. Dynamic Reduction: If the count still exceeds ctxLen, it calculates the overshoot and reduces the token slice. I've added a small buffer (overshoot / 10) to the reduction to minimize loop iterations while staying as close to the limit as possible.
63 Strict Enforcement: It guarantees that the final payload sent to the model will never exceed the context limit, regardless of character encoding complexities.
---
### Testing & Verification
Tested on Windows/WSL2 using the all-minilm model (256 context limit).

- Test Input: A 1000+ token string containing Turkish text, Japanese characters, and 150+ emojis (🌟🌀).
- Result Before Fix: Failed with 400 Bad Request.
- Result After Fix: Successfully returns embeddings with prompt_eval_count consistently at 256.
Fixes #14186