### PR TITLE
fix(app): prevent sidebar animation on initial page load

### DIFF
--- a/app/ui/app/src/components/layout/layout.tsx
+++ b/app/ui/app/src/components/layout/layout.tsx
@@ -1,5 +1,6 @@
 import { Link } from "@tanstack/react-router";
 import { useSettings } from "@/hooks/useSettings";
+import { useState, useEffect } from "react";
 
 export function SidebarLayout({
   sidebar,
@@ -12,10 +13,18 @@ export function SidebarLayout({
   const { settings, setSettings } = useSettings();
   const isWindows = navigator.platform.toLowerCase().includes("win");
 
+  // Track initial render to prevent sidebar animation on page load
+  const [isInitialRender, setIsInitialRender] = useState(true);
+  useEffect(() => {
+    // After first render, enable transitions
+    const timeout = setTimeout(() => setIsInitialRender(false), 0);
+    return () => clearTimeout(timeout);
+  }, []);
+
   return (
-    <div className={`flex transition-[width] duration-300 dark:bg-neutral-900`}>
+    <div className={`flex ${isInitialRender ? "" : "transition-[width] duration-300"} dark:bg-neutral-900`}>
       <div
-        className={`absolute flex mx-2 py-2 z-20 items-center transition-[left] duration-375 text-neutral-500 dark:text-neutral-400 ${settings.sidebarOpen ? (isWindows ? "left-2" : "left-[204px]") : isWindows ? "left-2" : "left-20"}`}
+        className={`absolute flex mx-2 py-2 z-20 items-center ${isInitialRender ? "" : "transition-[left] duration-375"} text-neutral-500 dark:text-neutral-400 ${settings.sidebarOpen ? (isWindows ? "left-2" : "left-[204px]") : isWindows ? "left-2" : "left-20"}`}
       >
         <button
           onClick={() => setSettings({ SidebarOpen: !settings.sidebarOpen })}
@@ -57,7 +66,7 @@ export function SidebarLayout({
         </Link>
       </div>
       <div
-        className={`flex flex-col transition-[width] duration-300 max-h-screen ${settings.sidebarOpen ? "w-64" : "w-0"}`}
+        className={`flex flex-col ${isInitialRender ? "" : "transition-[width] duration-300"} max-h-screen ${settings.sidebarOpen ? "w-64" : "w-0"}`}
       >
         <div
           onDoubleClick={() => window.doubleClick && window.doubleClick()}
@@ -67,7 +76,7 @@ export function SidebarLayout({
         {settings.sidebarOpen && sidebar}
       </div>
       <main
-        className={`flex flex-1 flex-col min-w-0 transition-all duration-300`}
+        className={`flex flex-1 flex-col min-w-0 ${isInitialRender ? "" : "transition-all duration-300"}`}
       >
         <div
           className={`h-13 flex-none w-full z-10 flex items-center bg-white dark:bg-neutral-900 ${isWindows ? "xl:hidden" : "xl:fixed xl:bg-transparent xl:dark:bg-transparent"}`}


### PR DESCRIPTION
## Summary

Fixes the sidebar animating open when the app first loads instead of appearing in its correct state immediately.

## Problem

When the app loads, the sidebar defaults to `sidebarOpen: false` until the actual settings are fetched. Once settings load with `sidebarOpen: true`, the CSS transition causes the sidebar to animate from closed to open.

## Solution

Track the initial render state and only enable CSS transitions after the first render completes. This allows the sidebar to appear in its correct position immediately without animation on page load, while preserving the smooth animation when users manually toggle the sidebar.

## Changes

- Add `isInitialRender` state to track first render
- Conditionally apply transition classes based on render state
- Transitions are enabled after the first render via `useEffect`

## Test Plan

- [x] Sidebar appears open immediately on page load (no animation)
- [x] Toggling sidebar still animates smoothly
- [x] Works on both Windows and non-Windows platforms

Fixes #12954