### PR TITLE
fix: reduce vertical spacing in collated assistant messages

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -364,7 +364,7 @@ func collate(msgs []api.Message) (string, []*api.Message) {
 
 		// merges consecutive messages of the same role into a single message (except for tool messages)
 		if len(collated) > 0 && collated[len(collated)-1].Role == msgs[i].Role && msgs[i].Role != "tool" {
-			collated[len(collated)-1].Content += "\n\n" + msgs[i].Content
+			collated[len(collated)-1].Content += "\n" + msgs[i].Content
 		} else {
 			collated = append(collated, &msgs[i])
 		}


### PR DESCRIPTION
### Description:
This PR fixes an issue where numbered lists (and other consecutive assistant messages) appear with excessive vertical whitespace in GUIs.
---
### The Problem:
In template/template.go, the collate function merges consecutive messages of the same role using \n\n as a separator. When an LLM generates a numbered list across multiple turns or when messages are merged, this double newline forces Markdown renderers to treat each list item as a separate paragraph block, creating large gaps.
---
### The Fix:
Changed the message separator in the collate function from \n\n to \n. This ensures that consecutive messages maintain a "tight" list structure in Markdown while still providing a clear line break.
---
### Verification:

Before: Two assistant messages "1. Item" and "2. Item" merged as "1. Item\n\n2. Item", causing UI padding issues.

After: They merge as "1. Item\n2. Item", resulting in a clean, compact numbered list.
---
### Before the Development
curl http://localhost:11434/api/chat -d '{l http://localhost:11434/api/chat -d '{
  "model": "gemma3:4b",
  "messages": [
    { "role": "user", "content": "Test isteği" },
    { "role": "assistant", "content": "1. Birinci madde" },
    { "role": "assistant", "content": "2. İkinci madde" }
  ],
  "stream": false
}'
{"model":"gemma3:4b","created_at":"2026-02-14T07:49:16.912032932Z","message":{"role":"assistant","content":"\n\n3. Üçüncü madde\n\nTest tamamlandı. Başka bir test yapmak ister misiniz?\n"},"done":true,"done_reason":"stop","total_duration":15553528734,"load_duration":14343479814,"prompt_eval_count":24,"prompt_eval_duration":207596227,"eval_count":24,"eval_duration":854874092}
---
### After the Development
curl http://localhost:11434/api/chat -d '{
  "model": "gemma3:4b",
  "messages": [
    { "role": "user", "content": "Test isteği" },
    { "role": "assistant", "content": "1. Birinci madde" },
    { "role": "assistant", "content": "2. İkinci madde" }
  ],
  "stream": false
}'
{"model":"gemma3:4b","created_at":"2026-02-14T07:52:30.050331549Z","message":{"role":"assistant","content":"\n3. Üçüncü madde\n\nBu, basit bir test isteğiydi. Başka bir şey test etmek mi istersiniz? Örneğin, belirli bir konuda bilgi test edebilirim, bir problem çözebilirim veya bir konuyu açıklayabilirim.\n"},"done":true,"done_reason":"stop","total_duration":15661340756,"load_duration":12678836526,"prompt_eval_count":24,"prompt_eval_duration":230992784,"eval_count":56,"eval_duration":2005354518}

Fixes: #14239