### PR TITLE
fix(cmd): check digest length before slicing in list command

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -830,8 +830,12 @@ func ListHandler(cmd *cobra.Command, args []string) error {
 			} else {
 				size = format.HumanBytes(m.Size)
 			}
+			displayID := m.Digest
+			if len(displayID) > 12 {
+				displayID = displayID[:12]
+			}
 
-			data = append(data, []string{m.Name, m.Digest[:12], size, format.HumanTime(m.ModifiedAt, "Never")})
+			data = append(data, []string{m.Name, displayID, size, format.HumanTime(m.ModifiedAt, "Never")})
 		}
 	}
 


### PR DESCRIPTION
### This PR fixes a runtime panic in the list command when a model has a digest shorter than 12 characters. Added a length check before slicing.
Fixes #14250 
---
### Before the Development:
./ollama list
panic: runtime error: slice bounds out of range [:12] with length 3

goroutine 1 [running]:
github.com/ollama/ollama/cmd.ListHandler(0xc0004c8908, {0x24ca0a0, 0x0, 0x17d25fa?})
        /home/turko/ollama/cmd/cmd.go:839 +0x559
github.com/spf13/cobra.(*Command).execute(0xc0004c8908, {0x24ca0a0, 0x0, 0x0})
        /home/turko/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:940 +0x85c
github.com/spf13/cobra.(*Command).ExecuteC(0xc000482f08)
        /home/turko/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1068 +0x3a5
github.com/spf13/cobra.(*Command).Execute(...)
        /home/turko/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:992
github.com/spf13/cobra.(*Command).ExecuteContext(...)
        /home/turko/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:985
main.main()
        /home/turko/ollama/main.go:12 +0x4d
---

### After the Development:

./ollama list
NAME                 ID     SIZE     MODIFIED
all-minilm:latest    abc    45 MB    13 minutes ago
---
Type of Change: Bug fix
Testing: Manual verification by simulating a short digest (3 characters) to trigger the panic and verifying the fix.