### PR TITLE
server: warn when chat history or embeddings are truncated

### DIFF
--- a/server/prompt.go
+++ b/server/prompt.go
@@ -70,7 +70,10 @@ func chatPrompt(ctx context.Context, m *Model, tokenize tokenizeFunc, opts *api.
 	}
 
 	if currMsgIdx > 0 {
-		slog.Debug("truncating input messages which exceed context length", "truncated", len(msgs[currMsgIdx:]))
+		slog.Warn("chat history truncated to fit context window",
+			"messages_dropped", currMsgIdx,
+			"messages_remaining", len(msgs[currMsgIdx:]),
+			"context_length", opts.NumCtx)
 	}
 
 	for cnt, msg := range msgs[currMsgIdx:] {

--- a/server/routes.go
+++ b/server/routes.go
@@ -759,6 +759,9 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 			return nil, 0, fmt.Errorf("input after truncation exceeds maximum context length")
 		}
 
+		slog.Warn("embedding input truncated to fit context window",
+			"original_tokens", len(tokens),
+			"truncated_to", ctxLen)
 		truncatedTokens := tokens[:ctxLen]
 		truncated, err := r.Detokenize(ctx, truncatedTokens)
 		if err != nil {


### PR DESCRIPTION
## Summary

- Upgrades chat history truncation log from `slog.Debug` to `slog.Warn` in `server/prompt.go`, adding messages dropped count and active context length
- Adds `slog.Warn` in `server/routes.go` when embedding input is silently truncated to fit context window

No behavior change, no API surface change — only log level and message improvements.

## Context

Resolves #14259

This addresses a pattern seen across 400+ open issues around context length confusion. Users currently have no way to know when their conversation history is being silently dropped. Related issues: #4967 #3839 #2208 #14173 #14116 #12407 #6286 #12474

## Test plan

- [x] `go test ./server/` passes
- [x] `go vet ./server/` clean
- [ ] Manual verification: send a long conversation that exceeds context length and confirm the warning appears in server logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)