### PR TITLE
ps: report actual layer counts instead of percentage

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -673,14 +673,16 @@ type ListModelResponse struct {
 
 // ProcessModelResponse is a single model description in [ProcessResponse].
 type ProcessModelResponse struct {
-	Name          string       `json:"name"`
-	Model         string       `json:"model"`
-	Size          int64        `json:"size"`
-	Digest        string       `json:"digest"`
-	Details       ModelDetails `json:"details,omitempty"`
-	ExpiresAt     time.Time    `json:"expires_at"`
-	SizeVRAM      int64        `json:"size_vram"`
-	ContextLength int          `json:"context_length"`
+	Name            string       `json:"name"`
+	Model           string       `json:"model"`
+	Size            int64        `json:"size"`
+	Digest          string       `json:"digest"`
+	Details         ModelDetails `json:"details,omitempty"`
+	ExpiresAt       time.Time    `json:"expires_at"`
+	SizeVRAM        int64        `json:"size_vram"`
+	ContextLength   int          `json:"context_length"`
+	GPULayers       int          `json:"gpu_layers"`
+	TotalLayers     int          `json:"total_layers"`
 }
 
 type TokenResponse struct {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"math"
 	"net"
 	"net/http"
 	"os"
@@ -746,18 +745,14 @@ func ListRunningHandler(cmd *cobra.Command, args []string) error {
 
 	for _, m := range models.Models {
 		if len(args) == 0 || strings.HasPrefix(m.Name, args[0]) {
-			var procStr string
+		var procStr string
 			switch {
-			case m.SizeVRAM == 0:
-				procStr = "100% CPU"
-			case m.SizeVRAM == m.Size:
-				procStr = "100% GPU"
-			case m.SizeVRAM > m.Size || m.Size == 0:
-				procStr = "Unknown"
+			case m.GPULayers == 0:
+				procStr = fmt.Sprintf("%d/%d CPU", m.TotalLayers, m.TotalLayers)
+			case m.GPULayers >= m.TotalLayers:
+				procStr = fmt.Sprintf("%d/%d GPU", m.TotalLayers, m.TotalLayers)
 			default:
-				sizeCPU := m.Size - m.SizeVRAM
-				cpuPercent := math.Round(float64(sizeCPU) / float64(m.Size) * 100)
-				procStr = fmt.Sprintf("%d%%/%d%% CPU/GPU", int(cpuPercent), int(100-cpuPercent))
+				procStr = fmt.Sprintf("%d/%d CPU/GPU", m.GPULayers, m.TotalLayers)
 			}
 
 			var until string

--- a/docs/api.md
+++ b/docs/api.md
@@ -1794,7 +1794,9 @@ A single JSON object will be returned.
         "quantization_level": "Q4_0"
       },
       "expires_at": "2024-06-04T14:38:31.83753-07:00",
-      "size_vram": 5137025024
+      "size_vram": 5137025024,
+      "gpu_layers": 33,
+      "total_layers": 33
     }
   ]
 }

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -61,16 +61,16 @@ ollama ps
 **Output**:
 
 ```
-NAME        ID            SIZE    PROCESSOR   UNTIL
-llama3:70b  bcfb190ca3a7  42 GB   100% GPU    4 minutes from now
+NAME        ID            SIZE    PROCESSOR    UNTIL
+llama3:70b  bcfb190ca3a7  42 GB   81/81 GPU    4 minutes from now
 ```
 </Info>
 
-The `Processor` column will show which memory the model was loaded in to:
+The `Processor` column will show how many model layers are offloaded:
 
-- `100% GPU` means the model was loaded entirely into the GPU
-- `100% CPU` means the model was loaded entirely in system memory
-- `48%/52% CPU/GPU` means the model was loaded partially onto both the GPU and into system memory
+- `33/33 GPU` means all 33 layers were loaded entirely into the GPU
+- `33/33 CPU` means all 33 layers were loaded entirely in system memory
+- `16/33 CPU/GPU` means 16 out of 33 layers were offloaded to the GPU
 
 ## How do I configure Ollama server?
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -657,6 +657,12 @@ components:
         context_length:
           type: integer
           description: Context length for the running model
+        gpu_layers:
+          type: integer
+          description: Number of model layers offloaded to GPU
+        total_layers:
+          type: integer
+          description: Total number of layers in the model
     PsResponse:
       type: object
       properties:

--- a/llm/server.go
+++ b/llm/server.go
@@ -76,6 +76,8 @@ type LlamaServer interface {
 	VRAMSize() uint64 // Total VRAM across all GPUs
 	TotalSize() uint64
 	VRAMByGPU(id ml.DeviceID) uint64
+	GPULayerCount() int
+	TotalLayerCount() int
 	Pid() int
 	GetPort() int
 	GetDeviceInfos(ctx context.Context) []ml.DeviceInfo
@@ -1870,6 +1872,14 @@ func (s *llmServer) TotalSize() uint64 {
 	}
 
 	return mem
+}
+
+func (s *llmServer) GPULayerCount() int {
+	return s.loadRequest.GPULayers.Sum()
+}
+
+func (s *llmServer) TotalLayerCount() int {
+	return int(s.totalLayers)
 }
 
 func (s *llmServer) VRAMByGPU(id ml.DeviceID) uint64 {

--- a/server/routes.go
+++ b/server/routes.go
@@ -1813,13 +1813,15 @@ func (s *Server) PsHandler(c *gin.Context) {
 		}
 
 		mr := api.ProcessModelResponse{
-			Model:     model.ShortName,
-			Name:      model.ShortName,
-			Size:      int64(v.totalSize),
-			SizeVRAM:  int64(v.vramSize),
-			Digest:    model.Digest,
-			Details:   modelDetails,
-			ExpiresAt: v.expiresAt,
+			Model:       model.ShortName,
+			Name:        model.ShortName,
+			Size:        int64(v.totalSize),
+			SizeVRAM:    int64(v.vramSize),
+			Digest:      model.Digest,
+			Details:     modelDetails,
+			ExpiresAt:   v.expiresAt,
+			GPULayers:   v.gpuLayerCount,
+			TotalLayers: v.totalLayerCount,
 		}
 		if v.Options != nil {
 			mr.ContextLength = v.Options.NumCtx

--- a/server/sched.go
+++ b/server/sched.go
@@ -498,6 +498,8 @@ iGPUScan:
 		discreteGPUs:    discreteGPUs,
 		vramSize:        llama.VRAMSize(),
 		totalSize:       llama.TotalSize(),
+		gpuLayerCount:   llama.GPULayerCount(),
+		totalLayerCount: llama.TotalLayerCount(),
 		loading:         true,
 		pid:             llama.Pid(),
 	}
@@ -595,8 +597,10 @@ type runnerRef struct {
 	loading      bool          // True only during initial load, then false forever
 	gpus         []ml.DeviceID // Recorded at time of provisioning
 	discreteGPUs bool          // True if all devices are discrete GPUs - used to skip VRAM recovery check for iGPUs
-	vramSize     uint64
-	totalSize    uint64
+	vramSize        uint64
+	totalSize       uint64
+	gpuLayerCount   int
+	totalLayerCount int
 
 	sessionDuration time.Duration
 	expireTimer     *time.Timer

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -799,6 +799,8 @@ func (s *mockLlm) Close() error {
 func (s *mockLlm) VRAMSize() uint64                                   { return s.vramSize }
 func (s *mockLlm) TotalSize() uint64                                  { return s.totalSize }
 func (s *mockLlm) VRAMByGPU(id ml.DeviceID) uint64                    { return s.vramByGPU[id] }
+func (s *mockLlm) GPULayerCount() int                                 { return 0 }
+func (s *mockLlm) TotalLayerCount() int                               { return 0 }
 func (s *mockLlm) Pid() int                                           { return -1 }
 func (s *mockLlm) GetPort() int                                       { return -1 }
 func (s *mockLlm) GetDeviceInfos(ctx context.Context) []ml.DeviceInfo { return nil }


### PR DESCRIPTION


### Summary

Changes `ollama ps` to display the number of GPU-offloaded layers out of
total layers (e.g. `33/35 GPU`) instead of a percentage (e.g. `100% GPU`).

This provides more actionable information when tuning the `num_gpu` parameter,
and makes the total layer count of a model visible at a glance.

### Before

```
NAME        ID            SIZE    PROCESSOR         UNTIL
llama3:70b  bcfb190ca3a7  42 GB   100% GPU          4 minutes from now
llama3:8b   ab2c3d4e5f67  5 GB    48%/52% CPU/GPU   3 minutes from now
```

### After

```
NAME        ID            SIZE    PROCESSOR        UNTIL
llama3:70b  bcfb190ca3a7  42 GB   81/81 GPU        4 minutes from now
llama3:8b   ab2c3d4e5f67  5 GB    16/33 CPU/GPU    3 minutes from now
```

### Changes

- **`llm/server.go`**: Add `GPULayerCount()` and `TotalLayerCount()` to `LlamaServer` interface, implemented on `llmServer`
- **`server/sched.go`**: Store layer counts in `runnerRef` at load time
- **`api/types.go`**: Add `gpu_layers` and `total_layers` fields to `ProcessModelResponse`
- **`server/routes.go`**: Populate new fields in `PsHandler`
- **`cmd/cmd.go`**: Update `ListRunningHandler` to display `N/M GPU|CPU|CPU/GPU` format
- **Docs**: Updated `api.md`, `openapi.yaml`, `faq.mdx`
- **Tests**: Updated `mockLlm` in `sched_test.go`

### API Changes

The `/api/ps` response now includes two new fields per model:

```json
{
  "models": [
    {
      "name": "llama3:70b",
      "size": 42000000000,
      "size_vram": 42000000000,
      "gpu_layers": 81,
      "total_layers": 81,
      "context_length": 2048
    }
  ]
}
```

### How to Build

```bash
go build ./...
```

### How to Test

**Unit tests:**

```bash
go test ./server/ -run TestSched -count=1 -timeout 30s
go test ./api/ -count=1 -timeout 30s
```

**Manual testing:**

1. Start the server: `go run . serve`
2. Load a model: `go run . run llama3.2:1b --keepalive 5m`
3. Check output: `go run . ps`
4. Check API: `curl -s http://localhost:11434/api/ps | python3 -m json.tool`

**Partial offload** (set `num_gpu` lower than total layers):
```
PROCESSOR
5/17 CPU/GPU
```

**CPU-only** (`CUDA_VISIBLE_DEVICES=""`):
```
PROCESSOR
17/17 CPU
```

