### PR TITLE
fix(cmd): avoid panic when digest is shorter than 12 chars

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -881,7 +881,7 @@ func ListHandler(cmd *cobra.Command, args []string) error {
 				size = format.HumanBytes(m.Size)
 			}
 
-			data = append(data, []string{m.Name, m.Digest[:12], size, format.HumanTime(m.ModifiedAt, "Never")})
+			data = append(data, []string{m.Name, displayDigestID(m.Digest), size, format.HumanTime(m.ModifiedAt, "Never")})
 		}
 	}
 
@@ -936,7 +936,7 @@ func ListRunningHandler(cmd *cobra.Command, args []string) error {
 				until = format.HumanTime(m.ExpiresAt, "Never")
 			}
 			ctxStr := strconv.Itoa(m.ContextLength)
-			data = append(data, []string{m.Name, m.Digest[:12], format.HumanBytes(m.Size), procStr, ctxStr, until})
+			data = append(data, []string{m.Name, displayDigestID(m.Digest), format.HumanBytes(m.Size), procStr, ctxStr, until})
 		}
 	}
 
@@ -952,6 +952,14 @@ func ListRunningHandler(cmd *cobra.Command, args []string) error {
 	table.Render()
 
 	return nil
+}
+
+func displayDigestID(digest string) string {
+	if len(digest) > 12 {
+		return digest[:12]
+	}
+
+	return digest
 }
 
 func DeleteHandler(cmd *cobra.Command, args []string) error {

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -989,6 +989,15 @@ func TestListHandler(t *testing.T) {
 				"model1    sha256:abc12    1.0 KB    24 hours ago    \n",
 		},
 		{
+			name: "handles short digest without panic",
+			args: []string{},
+			serverResponse: []api.ListModelResponse{
+				{Name: "model1", Digest: "abc", Size: 1024, ModifiedAt: time.Now().Add(-24 * time.Hour)},
+			},
+			expectedOutput: "NAME      ID     SIZE      MODIFIED     \n" +
+				"model1    abc    1.0 KB    24 hours ago    \n",
+		},
+		{
 			name:          "server error",
 			args:          []string{},
 			expectedError: "server error",


### PR DESCRIPTION
Fixes #14250

## Summary
- guard digest display in list/ps output to avoid out-of-range slicing
- add regression test for short digest handling in list