### PR TITLE
fix(cmd): avoid panic in ps when digest is empty

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -935,8 +935,13 @@ func ListRunningHandler(cmd *cobra.Command, args []string) error {
 			} else {
 				until = format.HumanTime(m.ExpiresAt, "Never")
 			}
+			displayDigest := m.Digest
+			if len(displayDigest) > 12 {
+				displayDigest = displayDigest[:12]
+			}
+
 			ctxStr := strconv.Itoa(m.ContextLength)
-			data = append(data, []string{m.Name, m.Digest[:12], format.HumanBytes(m.Size), procStr, ctxStr, until})
+			data = append(data, []string{m.Name, displayDigest, format.HumanBytes(m.Size), procStr, ctxStr, until})
 		}
 	}
 


### PR DESCRIPTION
Fixes #13754

## Summary
- avoid slicing digest with [:12] when digest is empty or shorter than 12 chars in ollama ps`n- add regression test covering empty digest in ListRunningHandler