### PR TITLE
cmd: fix panic when model digest is shorter than 12 characters

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -881,7 +881,11 @@ func ListHandler(cmd *cobra.Command, args []string) error {
 				size = format.HumanBytes(m.Size)
 			}
 
-			data = append(data, []string{m.Name, m.Digest[:12], size, format.HumanTime(m.ModifiedAt, "Never")})
+			displayID := m.Digest
+			if len(displayID) > 12 {
+				displayID = displayID[:12]
+			}
+			data = append(data, []string{m.Name, displayID, size, format.HumanTime(m.ModifiedAt, "Never")})
 		}
 	}
 
@@ -936,7 +940,11 @@ func ListRunningHandler(cmd *cobra.Command, args []string) error {
 				until = format.HumanTime(m.ExpiresAt, "Never")
 			}
 			ctxStr := strconv.Itoa(m.ContextLength)
-			data = append(data, []string{m.Name, m.Digest[:12], format.HumanBytes(m.Size), procStr, ctxStr, until})
+			displayID := m.Digest
+			if len(displayID) > 12 {
+				displayID = displayID[:12]
+			}
+			data = append(data, []string{m.Name, displayID, format.HumanBytes(m.Size), procStr, ctxStr, until})
 		}
 	}
 

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -18,7 +18,7 @@ Review the [Troubleshooting](./troubleshooting.mdx) docs for more about using lo
 
 ## Is my GPU compatible with Ollama?
 
-Please refer to the [GPU docs](./gpu.mdx).
+Please refer to the [GPU docs](./gpu).
 
 ## How can I specify the context window size?
 


### PR DESCRIPTION
## Summary

Two bug fixes:

### 1. Fix panic in `ollama list` / `ollama ps` with short digests (Fixes #14250)

`ListHandler` and `ProcessHandler` unconditionally slice `m.Digest[:12]` without checking the string length. If a model has a digest shorter than 12 characters (e.g. malformed manifest), this causes:

```
panic: runtime error: slice bounds out of range [:12] with length 3
```

**Fix:** Add a bounds check before slicing — show the full digest if it's shorter than 12 characters.

### 2. Fix broken GPU docs link in FAQ (Fixes #14243)

The FAQ links to `./gpu.mdx` which results in a 404 on the docs site. Changed to `./gpu` to match the docs routing.

## Testing

- Verified the digest slicing logic handles short strings correctly
- Verified the docs link format matches other working links in the docs