### PR TITLE
server: structured outputs for thinking models in /api/generate

### DIFF
--- a/middleware/openai_test.go
+++ b/middleware/openai_test.go
@@ -187,6 +187,32 @@ func TestChatMiddleware(t *testing.T) {
 			},
 		},
 		{
+			name: "chat handler with json_schema response format",
+			body: `{
+				"model": "test-model",
+				"messages": [
+					{"role": "user", "content": "Hello"}
+				],
+				"stream":            true,
+				"response_format":   {"type": "json_schema", "json_schema": {"name": "Response", "strict": true, "schema": {"type": "object", "properties": {"response": {"type": "string"}}, "required": ["response"], "additionalProperties": false}}}
+			}`,
+			req: api.ChatRequest{
+				Model: "test-model",
+				Messages: []api.Message{
+					{
+						Role:    "user",
+						Content: "Hello",
+					},
+				},
+				Options: map[string]any{
+					"temperature": 1.0,
+					"top_p":       1.0,
+				},
+				Format: json.RawMessage(`{"type":"object","properties":{"response":{"type":"string"}},"required":["response"],"additionalProperties":false}`),
+				Stream: &True,
+			},
+		},
+		{
 			name: "chat handler with image content",
 			body: `{
 				"model": "test-model",


### PR DESCRIPTION
## What

Adds the double-request structured outputs approach to the `/api/generate` endpoint, matching the existing implementation in `/api/chat`.

## Why

The `/api/chat` endpoint got structured output support for thinking models (gpt-oss, etc.) in #12460, but `/api/generate` was left behind. This meant that any client using the generate endpoint with a format constraint on a thinking model would get either garbage output or empty responses — the format grammar was being applied during the thinking phase, corrupting the output.

Several users in #11691 confirmed that `ollama-rs` and other clients that go through `/api/generate` are still broken, even though `/api/chat` works.

## How

Same pattern as the chat handler:

1. When a format constraint is set and the model has thinking capability, the first completion request runs **without** the format constraint so the model can think freely.
2. Once the parser detects that thinking is done and content is starting, the request is cancelled.
3. The prompt is rebuilt with the thinking content appended as an assistant message (using `chatPrompt`), and for Harmony models the `<|end|><|start|>assistant<|channel|>final<|message|>` header is added.
4. A second completion request runs **with** the format constraint active, producing valid structured output.

This only activates when:
- A format constraint is set (`req.Format != nil`)
- The model supports thinking (`model.CapabilityThinking`)
- A builtin parser or thinking state parser is active
- We're in the chat-like flow (have messages to rebuild the prompt)

For non-thinking models or raw mode, behavior is unchanged — the format is applied directly as before.

## Tests

- Added test for `json_schema` response format conversion in `openai/openai_test.go`
- Added test for `json_schema` request handling in `middleware/openai_test.go`
- All existing tests pass: `go test ./server/ ./openai/ ./middleware/`

Fixes #11691