### PR TITLE
install: check team identifier after download

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -95,7 +95,7 @@ if [ "$OS" = "Darwin" ]; then
         open -a Ollama --args hidden
     fi
 
-    status "Install complete. Run 'ollama' to get started."
+    status "Install complete. You can now run 'ollama'."
     exit 0
 fi
 


### PR DESCRIPTION
After downloading the ollama application from ollama.com verify that the team ID is what we expect in the MacOS install. Also a small wording change to make the end of the install script more informative.