### PR TITLE
install: do not remove existing install until after download

### DIFF
--- a/app/ui/ui_test.go
+++ b/app/ui/ui_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/app/store"
@@ -804,8 +805,13 @@ func TestSettingsToggleAutoUpdateOn_NoPendingUpdate_TriggersCheck(t *testing.T) 
 	// Initialize the checkNow channel by starting (and immediately stopping) the checker
 	// so TriggerImmediateCheck doesn't panic on nil channel
 	ctx, cancel := context.WithCancel(t.Context())
-	upd.StartBackgroundUpdaterChecker(ctx, func(string) error { return nil })
-	defer cancel()
+	stopped := upd.StartBackgroundUpdaterChecker(ctx, func(string) error { return nil })
+	cancel()
+	select {
+	case <-stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("background updater did not stop")
+	}
 
 	var notificationCalled atomic.Bool
 	server := &Server{

--- a/app/updater/updater.go
+++ b/app/updater/updater.go
@@ -287,12 +287,22 @@ func (u *Updater) TriggerImmediateCheck() {
 	}
 }
 
-func (u *Updater) StartBackgroundUpdaterChecker(ctx context.Context, cb func(string) error) {
+func (u *Updater) StartBackgroundUpdaterChecker(ctx context.Context, cb func(string) error) <-chan struct{} {
+	stopped := make(chan struct{})
 	u.checkNow = make(chan struct{}, 1)
 	u.checkNow <- struct{}{} // Trigger first check after initial delay
 	go func() {
+		defer close(stopped)
+
 		// Don't blast an update message immediately after startup
-		time.Sleep(UpdateCheckInitialDelay)
+		initialDelay := time.NewTimer(UpdateCheckInitialDelay)
+		select {
+		case <-ctx.Done():
+			initialDelay.Stop()
+			slog.Debug("stopping background update checker")
+			return
+		case <-initialDelay.C:
+		}
 		slog.Info("beginning update checker", "interval", UpdateCheckInterval)
 		ticker := time.NewTicker(UpdateCheckInterval)
 		defer ticker.Stop()
@@ -341,4 +351,5 @@ func (u *Updater) StartBackgroundUpdaterChecker(ctx context.Context, cb func(str
 			}
 		}
 	}()
+	return stopped
 }

--- a/app/updater/updater_test.go
+++ b/app/updater/updater_test.go
@@ -49,23 +49,26 @@ func TestIsNewReleaseAvailable(t *testing.T) {
 
 func TestBackgoundChecker(t *testing.T) {
 	UpdateStageDir = t.TempDir()
-	haveUpdate := false
-	verified := false
-	done := make(chan int)
+	haveUpdate := atomic.Bool{}
+	verified := atomic.Bool{}
+	updateDone := make(chan struct{}, 1)
 	cb := func(ver string) error {
-		haveUpdate = true
-		done <- 0
+		haveUpdate.Store(true)
+		select {
+		case updateDone <- struct{}{}:
+		default:
+		}
 		return nil
 	}
 	stallTimer := time.NewTimer(5 * time.Second)
+	defer stallTimer.Stop()
 	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
 	UpdateCheckInitialDelay = 5 * time.Millisecond
 	UpdateCheckInterval = 5 * time.Millisecond
-	VerifyDownload = func() error {
-		verified = true
+	setVerifyDownload(t, func() error {
+		verified.Store(true)
 		return nil
-	}
+	})
 
 	var server *httptest.Server
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -98,15 +101,16 @@ func TestBackgoundChecker(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	updater.StartBackgroundUpdaterChecker(ctx, cb)
+	stopped := updater.StartBackgroundUpdaterChecker(ctx, cb)
+	defer waitForBackgroundUpdater(t, cancel, stopped)
 	select {
 	case <-stallTimer.C:
 		t.Fatal("stalled")
-	case <-done:
-		if !haveUpdate {
+	case <-updateDone:
+		if !haveUpdate.Load() {
 			t.Fatal("no update received")
 		}
-		if !verified {
+		if !verified.Load() {
 			t.Fatal("unverified")
 		}
 	}
@@ -115,15 +119,14 @@ func TestBackgoundChecker(t *testing.T) {
 func TestAutoUpdateDisabledSkipsDownload(t *testing.T) {
 	UpdateStageDir = t.TempDir()
 	var downloadAttempted atomic.Bool
-	done := make(chan struct{})
+	var callbackCalled atomic.Bool
 
 	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
 	UpdateCheckInitialDelay = 5 * time.Millisecond
 	UpdateCheckInterval = 5 * time.Millisecond
-	VerifyDownload = func() error {
+	setVerifyDownload(t, func() error {
 		return nil
-	}
+	})
 
 	var server *httptest.Server
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -156,18 +159,21 @@ func TestAutoUpdateDisabledSkipsDownload(t *testing.T) {
 	}
 
 	cb := func(ver string) error {
-		t.Fatal("callback should not be called when auto-update is disabled")
+		callbackCalled.Store(true)
 		return nil
 	}
 
-	updater.StartBackgroundUpdaterChecker(ctx, cb)
+	stopped := updater.StartBackgroundUpdaterChecker(ctx, cb)
 
 	// Wait enough time for multiple check cycles
 	time.Sleep(50 * time.Millisecond)
-	close(done)
+	waitForBackgroundUpdater(t, cancel, stopped)
 
 	if downloadAttempted.Load() {
 		t.Fatal("download should not be attempted when auto-update is disabled")
+	}
+	if callbackCalled.Load() {
+		t.Fatal("callback should not be called when auto-update is disabled")
 	}
 }
 
@@ -177,12 +183,11 @@ func TestAutoUpdateReenabledDownloadsUpdate(t *testing.T) {
 	callbackCalled := make(chan struct{}, 1)
 
 	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
 	UpdateCheckInitialDelay = 5 * time.Millisecond
 	UpdateCheckInterval = 5 * time.Millisecond
-	VerifyDownload = func() error {
+	setVerifyDownload(t, func() error {
 		return nil
-	}
+	})
 
 	var server *httptest.Server
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -222,7 +227,8 @@ func TestAutoUpdateReenabledDownloadsUpdate(t *testing.T) {
 		return nil
 	}
 
-	upd.StartBackgroundUpdaterChecker(ctx, cb)
+	stopped := upd.StartBackgroundUpdaterChecker(ctx, cb)
+	defer waitForBackgroundUpdater(t, cancel, stopped)
 
 	// Wait for a few cycles with auto-update disabled - no download should happen
 	time.Sleep(50 * time.Millisecond)
@@ -254,9 +260,9 @@ func TestCancelOngoingDownload(t *testing.T) {
 	downloadCancelled := make(chan struct{})
 
 	ctx := t.Context()
-	VerifyDownload = func() error {
+	setVerifyDownload(t, func() error {
 		return nil
-	}
+	})
 
 	var server *httptest.Server
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -320,13 +326,12 @@ func TestTriggerImmediateCheck(t *testing.T) {
 	checkDone := make(chan struct{}, 10)
 
 	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
 	// Set a very long interval so only TriggerImmediateCheck causes checks
 	UpdateCheckInitialDelay = 1 * time.Millisecond
 	UpdateCheckInterval = 1 * time.Hour
-	VerifyDownload = func() error {
+	setVerifyDownload(t, func() error {
 		return nil
-	}
+	})
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/update.json" {
@@ -349,7 +354,8 @@ func TestTriggerImmediateCheck(t *testing.T) {
 		return nil
 	}
 
-	updater.StartBackgroundUpdaterChecker(ctx, cb)
+	stopped := updater.StartBackgroundUpdaterChecker(ctx, cb)
+	defer waitForBackgroundUpdater(t, cancel, stopped)
 
 	// Wait for the initial check that fires after the initial delay
 	select {
@@ -374,4 +380,23 @@ func TestTriggerImmediateCheck(t *testing.T) {
 	if finalCount <= initialCount {
 		t.Fatalf("TriggerImmediateCheck did not cause additional check: initial=%d, final=%d", initialCount, finalCount)
 	}
+}
+
+func waitForBackgroundUpdater(t *testing.T, cancel context.CancelFunc, stopped <-chan struct{}) {
+	t.Helper()
+	cancel()
+	select {
+	case <-stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("background updater did not stop")
+	}
+}
+
+func setVerifyDownload(t *testing.T, fn func() error) {
+	t.Helper()
+	old := VerifyDownload
+	VerifyDownload = fn
+	t.Cleanup(func() {
+		VerifyDownload = old
+	})
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -57,23 +57,23 @@ if [ "$OS" = "Darwin" ]; then
 
     DOWNLOAD_URL="https://ollama.com/download/Ollama-darwin.zip${VER_PARAM}"
 
+    status "Downloading Ollama for macOS..."
+    curl --fail --show-error --location --progress-bar \
+        -o "$TEMP_DIR/Ollama-darwin.zip" "$DOWNLOAD_URL"
+
+    unzip -q "$TEMP_DIR/Ollama-darwin.zip" -d "$TEMP_DIR"
+
+    # Download succeeded, now stop and replace the existing installation
     if pgrep -x Ollama >/dev/null 2>&1; then
         status "Stopping running Ollama instance..."
         pkill -x Ollama 2>/dev/null || true
         sleep 2
     fi
 
+    status "Installing Ollama to /Applications..."
     if [ -d "/Applications/Ollama.app" ]; then
-        status "Removing existing Ollama installation..."
         rm -rf "/Applications/Ollama.app"
     fi
-
-    status "Downloading Ollama for macOS..."
-    curl --fail --show-error --location --progress-bar \
-        -o "$TEMP_DIR/Ollama-darwin.zip" "$DOWNLOAD_URL"
-
-    status "Installing Ollama to /Applications..."
-    unzip -q "$TEMP_DIR/Ollama-darwin.zip" -d "$TEMP_DIR"
     mv "$TEMP_DIR/Ollama.app" "/Applications/"
 
     if [ ! -L "/usr/local/bin/ollama" ] || [ "$(readlink "/usr/local/bin/ollama")" != "/Applications/Ollama.app/Contents/Resources/ollama" ]; then
@@ -145,7 +145,7 @@ download_and_extract() {
         status "Downloading ${filename}.tar.zst"
         curl --fail --show-error --location --progress-bar \
             "${url_base}/${filename}.tar.zst${VER_PARAM}" | \
-            zstd -d | $SUDO tar -xf - -C "${dest_dir}"
+            zstd -d | tar -xf - -C "${dest_dir}"
         return 0
     fi
 
@@ -153,13 +153,46 @@ download_and_extract() {
     status "Downloading ${filename}.tgz"
     curl --fail --show-error --location --progress-bar \
         "${url_base}/${filename}.tgz${VER_PARAM}" | \
-        $SUDO tar -xzf - -C "${dest_dir}"
+        tar -xzf - -C "${dest_dir}"
 }
 
 for BINDIR in /usr/local/bin /usr/bin /bin; do
     echo $PATH | grep -q $BINDIR && break || continue
 done
 OLLAMA_INSTALL_DIR=$(dirname ${BINDIR})
+
+# Create download directory on the install filesystem to avoid space issues
+# with /tmp (which may be a small tmpfs, especially on WSL2)
+$SUDO mkdir -p "$OLLAMA_INSTALL_DIR"
+DOWNLOAD_DIR=$($SUDO mktemp -d "${OLLAMA_INSTALL_DIR}/.ollama-install.XXXXXX")
+$SUDO chown "$(id -u):$(id -g)" "$DOWNLOAD_DIR"
+cleanup() { $SUDO rm -rf "$DOWNLOAD_DIR"; rm -rf "$TEMP_DIR"; }
+
+status "Downloading ollama..."
+download_and_extract "https://ollama.com/download" "$DOWNLOAD_DIR" "ollama-linux-${ARCH}"
+
+# Check for NVIDIA JetPack systems with additional downloads
+if [ -f /etc/nv_tegra_release ] ; then
+    if grep R36 /etc/nv_tegra_release > /dev/null ; then
+        download_and_extract "https://ollama.com/download" "$DOWNLOAD_DIR" "ollama-linux-${ARCH}-jetpack6"
+    elif grep R35 /etc/nv_tegra_release > /dev/null ; then
+        download_and_extract "https://ollama.com/download" "$DOWNLOAD_DIR" "ollama-linux-${ARCH}-jetpack5"
+    else
+        warning "Unsupported JetPack version detected.  GPU may not be supported"
+    fi
+fi
+
+# All downloads succeeded, now stop and replace the existing installation
+if available systemctl; then
+    if systemctl is-active --quiet ollama; then
+        status "Stopping running ollama service..."
+        $SUDO systemctl stop ollama
+    fi
+elif pgrep -x ollama >/dev/null 2>&1; then
+    status "Stopping running ollama instance..."
+    $SUDO pkill -x ollama 2>/dev/null || true
+    sleep 2
+fi
 
 if [ -d "$OLLAMA_INSTALL_DIR/lib/ollama" ] ; then
     status "Cleaning up old version at $OLLAMA_INSTALL_DIR/lib/ollama"
@@ -168,22 +201,11 @@ fi
 status "Installing ollama to $OLLAMA_INSTALL_DIR"
 $SUDO install -o0 -g0 -m755 -d $BINDIR
 $SUDO install -o0 -g0 -m755 -d "$OLLAMA_INSTALL_DIR/lib/ollama"
-download_and_extract "https://ollama.com/download" "$OLLAMA_INSTALL_DIR" "ollama-linux-${ARCH}"
+$SUDO cp -a "$DOWNLOAD_DIR"/. "$OLLAMA_INSTALL_DIR/"
 
 if [ "$OLLAMA_INSTALL_DIR/bin/ollama" != "$BINDIR/ollama" ] ; then
     status "Making ollama accessible in the PATH in $BINDIR"
     $SUDO ln -sf "$OLLAMA_INSTALL_DIR/ollama" "$BINDIR/ollama"
-fi
-
-# Check for NVIDIA JetPack systems with additional downloads
-if [ -f /etc/nv_tegra_release ] ; then
-    if grep R36 /etc/nv_tegra_release > /dev/null ; then
-        download_and_extract "https://ollama.com/download" "$OLLAMA_INSTALL_DIR" "ollama-linux-${ARCH}-jetpack6"
-    elif grep R35 /etc/nv_tegra_release > /dev/null ; then
-        download_and_extract "https://ollama.com/download" "$OLLAMA_INSTALL_DIR" "ollama-linux-${ARCH}-jetpack5"
-    else
-        warning "Unsupported JetPack version detected.  GPU may not be supported"
-    fi
 fi
 
 install_success() {
@@ -303,7 +325,8 @@ if ! check_gpu lspci nvidia && ! check_gpu lshw nvidia && ! check_gpu lspci amdg
 fi
 
 if check_gpu lspci amdgpu || check_gpu lshw amdgpu; then
-    download_and_extract "https://ollama.com/download" "$OLLAMA_INSTALL_DIR" "ollama-linux-${ARCH}-rocm"
+    download_and_extract "https://ollama.com/download" "$DOWNLOAD_DIR" "ollama-linux-${ARCH}-rocm"
+    $SUDO cp -a "$DOWNLOAD_DIR"/. "$OLLAMA_INSTALL_DIR/"
 
     install_success
     status "AMD GPU ready."


### PR DESCRIPTION
Previously, the install script would stop ollama and delete the existing installation before downloading the new version. If the download failed (network error, disk full, etc.), the user was left with no working ollama.

**Changes**

- Download-then-replace (macOS and Linux): All downloads now complete to a temp directory first. Only after success does the script stop the running instance, remove the old installation, and move the new files into place.
- Remove $SUDO from download_and_extract tar commands: Since extraction now targets a user-owned temp directory instead of the root-owned install directory, $SUDO is no longer needed at this point.
- Use install filesystem for temp directory (Linux): Instead of extracting to /tmp (which may be a small RAM-backed tmpfs, especially on WSL2), the temp directory is created on the same filesystem as the install directory (/usr/local/.ollama-install.XXXXXX). This avoids "No space left on device" errors from the ~7GB of CUDA libraries.
- Stop ollama before replacing binaries (Linux): Added a step to stop the running ollama service (via systemctl stop or pkill) after the download but before the copy. This prevents "Text file busy" errors when overwriting the running binary.
- Wait for server readiness (macOS): After open -a Ollama, the script now polls localhost:11434 for up to 5 seconds so the user doesn't get a terminated process if they run ollama immediately after install.