### PR TITLE
Add qwen3.5-next-moe support to MLX runner and models

### DIFF
--- a/x/mlxrunner/cache/cache_test.go
+++ b/x/mlxrunner/cache/cache_test.go
@@ -1,0 +1,17 @@
+//go:build mlx
+
+package cache
+
+import "testing"
+
+func TestKVCacheGrowDebugEnabled(t *testing.T) {
+	t.Setenv("OLLAMA_MLX_DEBUG_CACHE_GROW", "")
+	if kvCacheGrowDebugEnabled() {
+		t.Fatal("kvCacheGrowDebugEnabled() = true, want false")
+	}
+
+	t.Setenv("OLLAMA_MLX_DEBUG_CACHE_GROW", "1")
+	if !kvCacheGrowDebugEnabled() {
+		t.Fatal("kvCacheGrowDebugEnabled() = false, want true")
+	}
+}

--- a/x/mlxrunner/cache/recurrent.go
+++ b/x/mlxrunner/cache/recurrent.go
@@ -1,0 +1,162 @@
+//go:build mlx
+
+package cache
+
+import "github.com/ollama/ollama/x/mlxrunner/mlx"
+
+// RecurrentCache stores state for linear-recurrent layers.
+//
+// Conv state shape: [B, convTail, convDim]
+// Delta state shape: [B, numVHeads, headVDim, headKDim]
+type RecurrentCache struct {
+	convState  *mlx.Array
+	deltaState *mlx.Array
+	offset     int
+
+	convTail  int
+	convDim   int
+	numVHeads int
+	headVDim  int
+	headKDim  int
+}
+
+func (c *RecurrentCache) setStateMaterialized(dst **mlx.Array, v *mlx.Array) {
+	if v == nil || !v.Valid() {
+		return
+	}
+	if *dst == v {
+		return
+	}
+
+	// Break dependency chains so recurrent state does not retain the full
+	// per-token compute graph over time.
+	snap := mlx.Snapshot(v)
+	mlx.Eval(snap)
+
+	old := *dst
+	*dst = snap
+
+	// Release previous cached state root, then recursively free the transient
+	// incoming graph root now that a detached snapshot is retained in cache.
+	if old != nil && old != snap {
+		mlx.Release(old)
+	}
+	if v != snap && v != old {
+		mlx.Free(v)
+	}
+}
+
+func (c *RecurrentCache) setStateRaw(dst **mlx.Array, v *mlx.Array) {
+	if v == nil || !v.Valid() {
+		return
+	}
+	old := *dst
+	*dst = v
+	if old != nil && old != v {
+		mlx.Release(old)
+	}
+}
+
+func NewRecurrentCache(convTail, convDim, numVHeads, headVDim, headKDim int32) *RecurrentCache {
+	return &RecurrentCache{
+		convTail:  int(convTail),
+		convDim:   int(convDim),
+		numVHeads: int(numVHeads),
+		headVDim:  int(headVDim),
+		headKDim:  int(headKDim),
+	}
+}
+
+func (c *RecurrentCache) ensure(batch int, dtype mlx.DType) {
+	if batch <= 0 {
+		batch = 1
+	}
+
+	if c.convState == nil || c.convState.DType() != dtype ||
+		c.convState.Dim(0) != batch || c.convState.Dim(1) != c.convTail || c.convState.Dim(2) != c.convDim {
+		c.setStateRaw(&c.convState, mlx.Zeros(dtype, batch, c.convTail, c.convDim))
+	}
+
+	if c.deltaState == nil || c.deltaState.DType() != dtype ||
+		c.deltaState.Dim(0) != batch || c.deltaState.Dim(1) != c.numVHeads || c.deltaState.Dim(2) != c.headVDim || c.deltaState.Dim(3) != c.headKDim {
+		c.setStateRaw(&c.deltaState, mlx.Zeros(dtype, batch, c.numVHeads, c.headVDim, c.headKDim))
+	}
+}
+
+func (c *RecurrentCache) ConvState(batch int, dtype mlx.DType) *mlx.Array {
+	c.ensure(batch, dtype)
+	return c.convState
+}
+
+func (c *RecurrentCache) SetConvState(v *mlx.Array) {
+	c.setStateMaterialized(&c.convState, v)
+}
+
+func (c *RecurrentCache) DeltaState(batch int, dtype mlx.DType) *mlx.Array {
+	c.ensure(batch, dtype)
+	return c.deltaState
+}
+
+func (c *RecurrentCache) SetDeltaState(v *mlx.Array) {
+	c.setStateMaterialized(&c.deltaState, v)
+}
+
+func (c *RecurrentCache) Advance(n int) {
+	c.offset += n
+}
+
+func (c *RecurrentCache) Update(keys, values *mlx.Array) (*mlx.Array, *mlx.Array) {
+	return keys, values
+}
+
+func (c *RecurrentCache) State() (*mlx.Array, *mlx.Array) {
+	c.ensure(1, mlx.DTypeFloat32)
+	return c.convState, c.deltaState
+}
+
+func (c *RecurrentCache) Materialize() []*mlx.Array {
+	out := make([]*mlx.Array, 0, 2)
+	if c.convState != nil && c.convState.Valid() {
+		out = append(out, c.convState)
+	}
+	if c.deltaState != nil && c.deltaState.Valid() {
+		out = append(out, c.deltaState)
+	}
+	return out
+}
+
+func (c *RecurrentCache) Trim(n int) int {
+	n = min(c.offset, n)
+	c.offset -= n
+	// Recurrent state cannot be reversed cheaply; reset to a clean state when trimming.
+	if n > 0 {
+		if c.convState != nil {
+			c.setStateRaw(&c.convState, mlx.Zeros(c.convState.DType(), c.convState.Dim(0), c.convState.Dim(1), c.convState.Dim(2)))
+		}
+		if c.deltaState != nil {
+			c.setStateRaw(&c.deltaState, mlx.Zeros(c.deltaState.DType(), c.deltaState.Dim(0), c.deltaState.Dim(1), c.deltaState.Dim(2), c.deltaState.Dim(3)))
+		}
+	}
+	return n
+}
+
+func (c *RecurrentCache) Clone() Cache {
+	clone := &RecurrentCache{
+		offset:    c.offset,
+		convTail:  c.convTail,
+		convDim:   c.convDim,
+		numVHeads: c.numVHeads,
+		headVDim:  c.headVDim,
+		headKDim:  c.headKDim,
+	}
+	if c.convState != nil {
+		clone.convState = c.convState.Clone()
+	}
+	if c.deltaState != nil {
+		clone.deltaState = c.deltaState.Clone()
+	}
+	return clone
+}
+
+func (c *RecurrentCache) Offset() int { return c.offset }
+func (c *RecurrentCache) Len() int    { return c.offset }

--- a/x/mlxrunner/imports.go
+++ b/x/mlxrunner/imports.go
@@ -7,4 +7,6 @@ import (
 	_ "github.com/ollama/ollama/x/models/glm4_moe_lite"
 	_ "github.com/ollama/ollama/x/models/llama"
 	_ "github.com/ollama/ollama/x/models/qwen3"
+	_ "github.com/ollama/ollama/x/models/qwen3_5"
+	_ "github.com/ollama/ollama/x/models/qwen3_5_moe"
 )

--- a/x/mlxrunner/pipeline.go
+++ b/x/mlxrunner/pipeline.go
@@ -6,11 +6,42 @@ import (
 	"bytes"
 	"errors"
 	"log/slog"
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/ollama/ollama/x/mlxrunner/cache"
 	"github.com/ollama/ollama/x/mlxrunner/mlx"
 )
+
+func prefillChunkSize(lowMemoryDecode bool) int {
+	if v := os.Getenv("OLLAMA_MLX_PREFILL_CHUNK"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+
+	if lowMemoryDecode {
+		// Recurrent/no-prompt-cache path favors lower peak memory over prefill throughput.
+		// Keep this conservative to avoid transient prefill spikes and allocator thrash.
+		return 32
+	}
+	return 2 << 10
+}
+
+func mlxDebugMemoryEnabled() bool {
+	return os.Getenv("OLLAMA_MLX_DEBUG_MEMORY") != ""
+}
+
+func finalizeRequestCaches(usePromptCache bool, insertCache func(), freeCaches func(), logMemory func(string, int)) {
+	if usePromptCache {
+		insertCache()
+		logMemory("request_done_cached", -1)
+		return
+	}
+	freeCaches()
+	logMemory("request_done_freed", -1)
+}
 
 func (r *Runner) TextGenerationPipeline(request Request) error {
 	if r.Model == nil {
@@ -29,7 +60,21 @@ func (r *Runner) TextGenerationPipeline(request Request) error {
 
 	inputs := r.Tokenizer.Encode(request.Prompt, true)
 
-	caches, tokens := r.FindNearestCache(inputs)
+	usePromptCache := true
+	if m, ok := r.Model.(interface{ DisablePromptCache() bool }); ok && m.DisablePromptCache() {
+		usePromptCache = false
+	}
+	lowMemoryDecode := !usePromptCache
+	prefillChunk := prefillChunkSize(lowMemoryDecode)
+
+	var caches []cache.Cache
+	var tokens []int32
+	if usePromptCache {
+		caches, tokens = r.FindNearestCache(inputs)
+	} else {
+		tokens = inputs
+	}
+
 	if len(caches) == 0 {
 		if cacheFactory, ok := r.Model.(interface{ NewCaches() []cache.Cache }); ok {
 			caches = cacheFactory.NewCaches()
@@ -41,23 +86,54 @@ func (r *Runner) TextGenerationPipeline(request Request) error {
 		}
 	}
 
+	materializeCaches := func() {
+		state := make([]*mlx.Array, 0, 2*len(caches))
+		for _, c := range caches {
+			state = append(state, c.Materialize()...)
+		}
+		if len(state) == 0 {
+			return
+		}
+		mlx.Eval(state...)
+	}
+	freeCaches := func() {
+		state := make([]*mlx.Array, 0, 2*len(caches))
+		for _, c := range caches {
+			state = append(state, c.Materialize()...)
+		}
+		if len(state) == 0 {
+			return
+		}
+		// Non-prompt-cache requests allocate fresh caches every generation.
+		// Explicitly free cache roots so graph chains are reclaimed promptly.
+		mlx.Free(state...)
+		mlx.ClearCache()
+	}
+	debugMemory := mlxDebugMemoryEnabled()
+	logMemory := func(phase string, token int) {
+		if !debugMemory {
+			return
+		}
+		if token >= 0 {
+			slog.Info("MLX memory", "phase", phase, "token", token, "memory", mlx.Memory{})
+			return
+		}
+		slog.Info("MLX memory", "phase", phase, "memory", mlx.Memory{})
+	}
+	logMemory("prefill_start", -1)
+
 	total, processed := len(tokens), 0
 	slog.Info("Prompt processing progress", "processed", processed, "total", total)
 	for total-processed > 1 {
-		n := min(2<<10, total-processed-1)
+		n := min(prefillChunk, total-processed-1)
 		temp := r.Model.Forward(mlx.FromValues(tokens[processed:processed+n], n).ExpandDims(0), caches)
-		defer mlx.Free(temp)
-		mlx.Eval(func() []*mlx.Array {
-			s := make([]*mlx.Array, 2*len(caches))
-			for i, c := range caches {
-				s[2*i], s[2*i+1] = c.State()
-			}
-			return s
-		}()...)
+		materializeCaches()
+		mlx.Free(temp)
 		processed += n
 		slog.Info("Prompt processing progress", "processed", processed, "total", total)
 		mlx.ClearCache()
 	}
+	logMemory("prefill_done", -1)
 
 	step := func(token *mlx.Array) (*mlx.Array, *mlx.Array) {
 		fwd := r.Model.Forward(token.ExpandDims(0), caches)
@@ -69,7 +145,13 @@ func (r *Runner) TextGenerationPipeline(request Request) error {
 	}
 
 	sample, logprobs := step(mlx.FromValues(tokens[processed:], total-processed))
-	mlx.AsyncEval(sample, logprobs)
+	if !lowMemoryDecode {
+		mlx.AsyncEval(sample, logprobs)
+	} else {
+		// Materialize cache updates to prevent transform graph growth.
+		materializeCaches()
+	}
+	logMemory("decode_init", -1)
 
 	var b bytes.Buffer
 
@@ -77,12 +159,10 @@ func (r *Runner) TextGenerationPipeline(request Request) error {
 	final := Response{Done: true, PromptTokens: total, CompletionTokens: request.Options.MaxTokens, DoneReason: 1}
 	outputs := make([]int32, 0, request.Options.MaxTokens)
 	for i := range request.Options.MaxTokens {
-		nextSample, nextLogprobs := step(sample)
-		mlx.AsyncEval(nextSample, nextLogprobs)
-
 		if i == 0 {
 			slog.Info("Prompt processing progress", "processed", total, "total", total)
 			mlx.Eval(sample)
+			logMemory("decode_first_eval", i)
 			final.PromptTokensDuration = time.Since(now)
 			now = time.Now()
 		}
@@ -94,6 +174,7 @@ func (r *Runner) TextGenerationPipeline(request Request) error {
 			final.Token = int(output)
 			final.DoneReason = 0
 			final.CompletionTokens = i
+			mlx.Free(sample, logprobs)
 			break
 		}
 
@@ -102,18 +183,43 @@ func (r *Runner) TextGenerationPipeline(request Request) error {
 			Token: int(output),
 		}
 
+		// For recurrent linear-attention models, avoid async prefetch to reduce
+		// peak memory and clear allocator cache every token.
+		if lowMemoryDecode {
+			mlx.Free(sample, logprobs)
+			if i+1 >= request.Options.MaxTokens {
+				break
+			}
+			mlx.ClearCache()
+			sample, logprobs = step(mlx.FromValues([]int32{output}, 1))
+			// Materialize cache updates to avoid unbounded transform chains.
+			materializeCaches()
+			if i%32 == 0 {
+				logMemory("decode_lowmem_step", i)
+			}
+			continue
+		}
+
+		nextSample, nextLogprobs := step(sample)
+		mlx.AsyncEval(nextSample, nextLogprobs)
+
 		mlx.Free(sample, logprobs)
 		if i%256 == 0 {
 			mlx.ClearCache()
 		}
+		if i%64 == 0 {
+			logMemory("decode_async_step", i)
+		}
 
 		sample, logprobs = nextSample, nextLogprobs
 	}
-
-	mlx.Free(sample, logprobs)
 	final.CompletionTokensDuration = time.Since(now)
 	request.Responses <- final
-	r.InsertCache(append(inputs, outputs...), caches)
+	finalizeRequestCaches(usePromptCache,
+		func() { r.InsertCache(append(inputs, outputs...), caches) },
+		freeCaches,
+		logMemory,
+	)
 	return nil
 }
 

--- a/x/mlxrunner/pipeline_helpers_test.go
+++ b/x/mlxrunner/pipeline_helpers_test.go
@@ -1,0 +1,83 @@
+//go:build mlx
+
+package mlxrunner
+
+import "testing"
+
+func TestPrefillChunkSize(t *testing.T) {
+	t.Setenv("OLLAMA_MLX_PREFILL_CHUNK", "")
+	if got := prefillChunkSize(false); got != 2<<10 {
+		t.Fatalf("prefillChunkSize(false) = %d, want %d", got, 2<<10)
+	}
+	if got := prefillChunkSize(true); got != 32 {
+		t.Fatalf("prefillChunkSize(true) = %d, want %d", got, 32)
+	}
+}
+
+func TestPrefillChunkSizeEnvOverride(t *testing.T) {
+	t.Setenv("OLLAMA_MLX_PREFILL_CHUNK", "96")
+	if got := prefillChunkSize(false); got != 96 {
+		t.Fatalf("prefillChunkSize(false) with env = %d, want %d", got, 96)
+	}
+	if got := prefillChunkSize(true); got != 96 {
+		t.Fatalf("prefillChunkSize(true) with env = %d, want %d", got, 96)
+	}
+}
+
+func TestMLXDebugMemoryEnabled(t *testing.T) {
+	t.Setenv("OLLAMA_MLX_DEBUG_MEMORY", "")
+	if mlxDebugMemoryEnabled() {
+		t.Fatal("mlxDebugMemoryEnabled() = true, want false")
+	}
+
+	t.Setenv("OLLAMA_MLX_DEBUG_MEMORY", "1")
+	if !mlxDebugMemoryEnabled() {
+		t.Fatal("mlxDebugMemoryEnabled() = false, want true")
+	}
+}
+
+func TestFinalizeRequestCachesUsesPromptCachePath(t *testing.T) {
+	insertCalls := 0
+	freeCalls := 0
+	logPhase := ""
+
+	finalizeRequestCaches(
+		true,
+		func() { insertCalls++ },
+		func() { freeCalls++ },
+		func(phase string, _ int) { logPhase = phase },
+	)
+
+	if insertCalls != 1 {
+		t.Fatalf("insert calls = %d, want 1", insertCalls)
+	}
+	if freeCalls != 0 {
+		t.Fatalf("free calls = %d, want 0", freeCalls)
+	}
+	if logPhase != "request_done_cached" {
+		t.Fatalf("log phase = %q, want %q", logPhase, "request_done_cached")
+	}
+}
+
+func TestFinalizeRequestCachesUsesFreePath(t *testing.T) {
+	insertCalls := 0
+	freeCalls := 0
+	logPhase := ""
+
+	finalizeRequestCaches(
+		false,
+		func() { insertCalls++ },
+		func() { freeCalls++ },
+		func(phase string, _ int) { logPhase = phase },
+	)
+
+	if insertCalls != 0 {
+		t.Fatalf("insert calls = %d, want 0", insertCalls)
+	}
+	if freeCalls != 1 {
+		t.Fatalf("free calls = %d, want 1", freeCalls)
+	}
+	if logPhase != "request_done_freed" {
+		t.Fatalf("log phase = %q, want %q", logPhase, "request_done_freed")
+	}
+}

--- a/x/models/qwen3_5/qwen3_5.go
+++ b/x/models/qwen3_5/qwen3_5.go
@@ -1,0 +1,1254 @@
+//go:build mlx
+
+// Package qwen3_5 provides the Qwen 3.5 text and MoE implementation for MLX.
+package qwen3_5
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/ollama/ollama/x/mlxrunner/cache"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/mlxrunner/model"
+	"github.com/ollama/ollama/x/mlxrunner/model/base"
+	"github.com/ollama/ollama/x/models/nn"
+	"github.com/ollama/ollama/x/tokenizer"
+)
+
+func init() {
+	base.Register("Qwen3_5ForCausalLM", NewModel)
+	base.Register("Qwen3_5ForConditionalGeneration", NewModel)
+	base.Register("Qwen3NextForCausalLM", NewModel)
+	base.Register("Qwen3NextForConditionalGeneration", NewModel)
+}
+
+// RopeParameters carries optional rope metadata embedded under rope_parameters.
+type RopeParameters struct {
+	Type                string  `json:"type"`
+	RopeType            string  `json:"rope_type"`
+	RopeTheta           float32 `json:"rope_theta"`
+	PartialRotaryFactor float32 `json:"partial_rotary_factor"`
+}
+
+// Config holds Qwen 3.5 text config (top-level or nested text_config).
+type Config struct {
+	ModelType             string   `json:"model_type"`
+	HiddenSize            int32    `json:"hidden_size"`
+	IntermediateSize      int32    `json:"intermediate_size"`
+	NumHiddenLayers       int32    `json:"num_hidden_layers"`
+	NumAttentionHeads     int32    `json:"num_attention_heads"`
+	NumKeyValueHeads      int32    `json:"num_key_value_heads"`
+	HeadDim               int32    `json:"head_dim"`
+	RMSNormEps            float32  `json:"rms_norm_eps"`
+	VocabSize             int32    `json:"vocab_size"`
+	MaxPositionEmbeddings int32    `json:"max_position_embeddings"`
+	AttentionBias         bool     `json:"attention_bias"`
+	TieWordEmbeddings     bool     `json:"tie_word_embeddings"`
+	LayerTypes            []string `json:"layer_types"`
+
+	FullAttentionInterval int32 `json:"full_attention_interval"`
+
+	LinearNumValueHeads  int32 `json:"linear_num_value_heads"`
+	LinearNumKeyHeads    int32 `json:"linear_num_key_heads"`
+	LinearKeyHeadDim     int32 `json:"linear_key_head_dim"`
+	LinearValueHeadDim   int32 `json:"linear_value_head_dim"`
+	LinearConvKernelDim  int32 `json:"linear_conv_kernel_dim"`
+	DecoderSparseStep    int32 `json:"decoder_sparse_step"`
+	SharedExpertGateRank int32 `json:"-"`
+
+	NumExperts                   int32   `json:"num_experts"`
+	NumExpertsPerTok             int32   `json:"num_experts_per_tok"`
+	SharedExpertIntermediateSize int32   `json:"shared_expert_intermediate_size"`
+	MoeIntermediateSize          int32   `json:"moe_intermediate_size"`
+	NormTopKProb                 bool    `json:"norm_topk_prob"`
+	MLPOnlyLayers                []int32 `json:"mlp_only_layers"`
+
+	RopeTheta           float32         `json:"rope_theta"`
+	PartialRotaryFactor float32         `json:"partial_rotary_factor"`
+	RopeScaling         map[string]any  `json:"rope_scaling"`
+	RopeParameters      *RopeParameters `json:"rope_parameters"`
+
+	// Quantization metadata.
+	QuantGroupSize int                               `json:"-"`
+	QuantBits      int                               `json:"-"`
+	QuantMode      string                            `json:"-"`
+	TensorQuant    map[string]*model.TensorQuantInfo `json:"-"`
+
+	// Computed fields.
+	Scale   float32 `json:"-"`
+	RopeDim int32   `json:"-"`
+}
+
+// Model is the Qwen 3.5 model.
+type Model struct {
+	EmbedTokens *nn.Embedding
+	Layers      []*Layer
+	Norm        *nn.RMSNorm
+	LMHead      nn.LinearLayer
+
+	tok *tokenizer.Tokenizer
+	*Config
+
+	weightPrefix string
+}
+
+// Layer is a transformer decoder layer.
+type Layer struct {
+	InputNorm         *nn.RMSNorm
+	PostAttentionNorm *nn.RMSNorm
+
+	IsLinear bool
+	FullAttn *FullAttention
+	Linear   *GatedDeltaNet
+	MLP      MLPBlock
+}
+
+// FullAttention is the full-attention branch used every N layers.
+type FullAttention struct {
+	QProj nn.LinearLayer
+	KProj nn.LinearLayer
+	VProj nn.LinearLayer
+	OProj nn.LinearLayer
+
+	QNorm *nn.RMSNorm
+	KNorm *nn.RMSNorm
+}
+
+// GatedDeltaNet is the recurrent linear-attention branch.
+type GatedDeltaNet struct {
+	InProjQKV  nn.LinearLayer
+	InProjZ    nn.LinearLayer
+	InProjB    nn.LinearLayer
+	InProjA    nn.LinearLayer
+	InProjQKVZ nn.LinearLayer
+	InProjBA   nn.LinearLayer
+	OutProj    nn.LinearLayer
+
+	ConvWeight *mlx.Array
+	NormWeight *mlx.Array
+	DtBias     *mlx.Array
+	ALog       *mlx.Array
+	AExp       *mlx.Array
+}
+
+// MLPBlock is the feed-forward interface for dense and MoE blocks.
+type MLPBlock interface {
+	Forward(x *mlx.Array, cfg *Config) *mlx.Array
+}
+
+// DenseMLP is SwiGLU feed-forward.
+type DenseMLP struct {
+	GateProj nn.LinearLayer
+	UpProj   nn.LinearLayer
+	DownProj nn.LinearLayer
+}
+
+// SparseMoE is Qwen3.5's sparse MoE with shared expert.
+type SparseMoE struct {
+	Gate             nn.LinearLayer
+	SwitchMLP        *SwitchMLP
+	SharedExpert     *DenseMLP
+	SharedExpertGate nn.LinearLayer
+}
+
+// SwitchMLP executes selected expert MLPs.
+type SwitchMLP struct {
+	GateWeight *mlx.Array
+	UpWeight   *mlx.Array
+	DownWeight *mlx.Array
+
+	GateWeightQ, GateScales, GateBiases *mlx.Array
+	UpWeightQ, UpScales, UpBiases       *mlx.Array
+	DownWeightQ, DownScales, DownBiases *mlx.Array
+
+	GateBits int
+	UpBits   int
+	DownBits int
+
+	GateGroupSize int
+	UpGroupSize   int
+	DownGroupSize int
+
+	UseQuantized bool
+}
+
+type stackedExpertWeights struct {
+	Weight    *mlx.Array
+	Scales    *mlx.Array
+	Biases    *mlx.Array
+	Bits      int
+	GroupSize int
+	Mode      string
+}
+
+func parseConfig(configData []byte) (Config, error) {
+	var rawTop map[string]json.RawMessage
+	if err := json.Unmarshal(configData, &rawTop); err != nil {
+		return Config{}, fmt.Errorf("parse config envelope: %w", err)
+	}
+
+	var cfg Config
+	activeRaw := rawTop
+	if textRaw, ok := rawTop["text_config"]; ok {
+		if err := json.Unmarshal(textRaw, &cfg); err != nil {
+			return Config{}, fmt.Errorf("parse text_config: %w", err)
+		}
+		if err := json.Unmarshal(textRaw, &activeRaw); err != nil {
+			return Config{}, fmt.Errorf("parse text_config envelope: %w", err)
+		}
+	} else {
+		if err := json.Unmarshal(configData, &cfg); err != nil {
+			return Config{}, fmt.Errorf("parse config: %w", err)
+		}
+	}
+
+	if cfg.HiddenSize <= 0 {
+		return Config{}, fmt.Errorf("invalid hidden_size: %d", cfg.HiddenSize)
+	}
+	if cfg.NumHiddenLayers <= 0 {
+		return Config{}, fmt.Errorf("invalid num_hidden_layers: %d", cfg.NumHiddenLayers)
+	}
+	if cfg.NumAttentionHeads <= 0 {
+		return Config{}, fmt.Errorf("invalid num_attention_heads: %d", cfg.NumAttentionHeads)
+	}
+	if cfg.NumKeyValueHeads <= 0 {
+		cfg.NumKeyValueHeads = cfg.NumAttentionHeads
+	}
+	if cfg.HeadDim <= 0 {
+		if cfg.HiddenSize%cfg.NumAttentionHeads != 0 {
+			return Config{}, fmt.Errorf("hidden_size (%d) must be divisible by num_attention_heads (%d)", cfg.HiddenSize, cfg.NumAttentionHeads)
+		}
+		cfg.HeadDim = cfg.HiddenSize / cfg.NumAttentionHeads
+	}
+	if cfg.HeadDim <= 0 {
+		return Config{}, fmt.Errorf("invalid head_dim: %d", cfg.HeadDim)
+	}
+
+	if cfg.RMSNormEps == 0 {
+		cfg.RMSNormEps = 1e-6
+	}
+	if cfg.LinearConvKernelDim <= 0 {
+		cfg.LinearConvKernelDim = 4
+	}
+	if cfg.LinearNumKeyHeads <= 0 || cfg.LinearNumValueHeads <= 0 || cfg.LinearKeyHeadDim <= 0 || cfg.LinearValueHeadDim <= 0 {
+		return Config{}, fmt.Errorf("invalid linear attention config (k_heads=%d v_heads=%d k_dim=%d v_dim=%d)",
+			cfg.LinearNumKeyHeads, cfg.LinearNumValueHeads, cfg.LinearKeyHeadDim, cfg.LinearValueHeadDim)
+	}
+	if cfg.LinearNumValueHeads%cfg.LinearNumKeyHeads != 0 {
+		return Config{}, fmt.Errorf("linear_num_value_heads (%d) must be divisible by linear_num_key_heads (%d)", cfg.LinearNumValueHeads, cfg.LinearNumKeyHeads)
+	}
+
+	if cfg.RopeParameters != nil {
+		if cfg.RopeParameters.RopeTheta > 0 {
+			cfg.RopeTheta = cfg.RopeParameters.RopeTheta
+		}
+		if cfg.RopeParameters.PartialRotaryFactor > 0 {
+			cfg.PartialRotaryFactor = cfg.RopeParameters.PartialRotaryFactor
+		}
+	}
+	if cfg.RopeTheta == 0 {
+		cfg.RopeTheta = 100000.0
+	}
+	if cfg.PartialRotaryFactor == 0 {
+		cfg.PartialRotaryFactor = 0.25
+	}
+	if cfg.PartialRotaryFactor < 0 {
+		cfg.PartialRotaryFactor = 0.25
+	}
+	ropeDim := int32(float32(cfg.HeadDim) * cfg.PartialRotaryFactor)
+	if ropeDim <= 0 {
+		ropeDim = cfg.HeadDim
+	}
+	if ropeDim > cfg.HeadDim {
+		ropeDim = cfg.HeadDim
+	}
+	cfg.RopeDim = ropeDim
+
+	if cfg.FullAttentionInterval <= 0 {
+		for i, lt := range cfg.LayerTypes {
+			if strings.Contains(strings.ToLower(lt), "full") {
+				cfg.FullAttentionInterval = int32(i + 1)
+				break
+			}
+		}
+		if cfg.FullAttentionInterval <= 0 {
+			cfg.FullAttentionInterval = 4
+		}
+	}
+	if cfg.FullAttentionInterval > cfg.NumHiddenLayers {
+		cfg.FullAttentionInterval = cfg.NumHiddenLayers
+	}
+
+	if cfg.NumExperts > 0 {
+		if cfg.NumExpertsPerTok <= 0 {
+			cfg.NumExpertsPerTok = 1
+		}
+		if cfg.MoeIntermediateSize <= 0 {
+			cfg.MoeIntermediateSize = cfg.IntermediateSize
+		}
+		if cfg.SharedExpertIntermediateSize <= 0 {
+			cfg.SharedExpertIntermediateSize = cfg.IntermediateSize
+		}
+		if _, ok := activeRaw["norm_topk_prob"]; !ok {
+			cfg.NormTopKProb = true
+		}
+		if cfg.DecoderSparseStep <= 0 {
+			cfg.DecoderSparseStep = 1
+		}
+	}
+
+	cfg.Scale = float32(1.0 / math.Sqrt(float64(cfg.HeadDim)))
+	return cfg, nil
+}
+
+func resolveWeightPrefix(tensors map[string]*mlx.Array) string {
+	for _, prefix := range []string{"", "language_model.", "model.language_model."} {
+		if tensors[prefix+"model.embed_tokens.weight"] != nil {
+			return prefix
+		}
+	}
+	return ""
+}
+
+func layerIsLinear(cfg *Config, layer int32) bool {
+	if len(cfg.LayerTypes) == int(cfg.NumHiddenLayers) {
+		t := strings.ToLower(cfg.LayerTypes[layer])
+		return !strings.Contains(t, "full")
+	}
+	if cfg.FullAttentionInterval <= 0 {
+		return true
+	}
+	return (layer+1)%cfg.FullAttentionInterval != 0
+}
+
+func layerUsesMoE(cfg *Config, layer int32) bool {
+	if cfg.NumExperts <= 0 {
+		return false
+	}
+	for _, l := range cfg.MLPOnlyLayers {
+		if l == layer {
+			return false
+		}
+	}
+	if cfg.DecoderSparseStep <= 1 {
+		return true
+	}
+	return (layer+1)%cfg.DecoderSparseStep == 0
+}
+
+// NewModel creates a Qwen 3.5 model from a manifest root.
+func NewModel(root *model.Root) (base.Model, error) {
+	configData, err := root.Manifest.ReadConfig("config.json")
+	if err != nil {
+		return nil, fmt.Errorf("load config: %w", err)
+	}
+
+	cfg, err := parseConfig(configData)
+	if err != nil {
+		return nil, err
+	}
+
+	if qt := root.QuantType(); qt != "" {
+		cfg.QuantGroupSize, cfg.QuantBits, cfg.QuantMode = model.QuantizationParams(qt)
+		if gs := root.GroupSize(); gs > 0 {
+			cfg.QuantGroupSize = gs
+		}
+	} else {
+		cfg.QuantGroupSize, cfg.QuantBits, cfg.QuantMode = model.QuantizationParams("")
+	}
+	cfg.TensorQuant = root.AllTensorQuant()
+
+	tokData, err := root.Manifest.ReadConfig("tokenizer.json")
+	if err != nil {
+		return nil, fmt.Errorf("load tokenizer config: %w", err)
+	}
+
+	tokConfig := &tokenizer.TokenizerConfig{ConfigJSON: configData}
+	if genConfigData, err := root.Manifest.ReadConfig("generation_config.json"); err == nil {
+		tokConfig.GenerationConfigJSON = genConfigData
+	}
+	if tokConfigData, err := root.Manifest.ReadConfig("tokenizer_config.json"); err == nil {
+		tokConfig.TokenizerConfigJSON = tokConfigData
+	}
+
+	tok, err := tokenizer.LoadFromBytesWithConfig(tokData, tokConfig)
+	if err != nil {
+		return nil, fmt.Errorf("parse tokenizer: %w", err)
+	}
+
+	m := &Model{
+		Layers: make([]*Layer, cfg.NumHiddenLayers),
+		Config: &cfg,
+		tok:    tok,
+	}
+
+	for i := int32(0); i < cfg.NumHiddenLayers; i++ {
+		m.Layers[i] = &Layer{IsLinear: layerIsLinear(&cfg, i)}
+	}
+
+	return m, nil
+}
+
+func tensorAny(tensors map[string]*mlx.Array, keys ...string) (*mlx.Array, string) {
+	for _, k := range keys {
+		if v := tensors[k]; v != nil {
+			return v, k
+		}
+	}
+	return nil, ""
+}
+
+func tensorByBase(tensors map[string]*mlx.Array, base string) (*mlx.Array, string) {
+	return tensorAny(tensors, base+".weight", base)
+}
+
+func supportsGatherQMM(mode string, bits int) bool {
+	return mode == "affine" && (bits == 4 || bits == 8)
+}
+
+func freeTensorKeys(tensors map[string]*mlx.Array, keys ...string) {
+	for _, k := range keys {
+		if k == "" {
+			continue
+		}
+		if t := tensors[k]; t != nil {
+			mlx.Release(t)
+			delete(tensors, k)
+		}
+	}
+}
+
+func stackAndDetach(parts []*mlx.Array) *mlx.Array {
+	if len(parts) == 0 {
+		return nil
+	}
+	stacked := mlx.Stack(parts, 0)
+	detached := mlx.Detach(stacked)
+	mlx.Eval(detached)
+	mlx.Free(stacked)
+	return detached
+}
+
+func loadStackedProjection(tensors map[string]*mlx.Array, cfg *Config, useQuantized bool, bases ...string) *stackedExpertWeights {
+	for _, base := range bases {
+		w, key := tensorByBase(tensors, base)
+		if w == nil {
+			continue
+		}
+
+		scales := tensors[key+"_scale"]
+		if scales == nil {
+			return &stackedExpertWeights{Weight: w}
+		}
+
+		qbiases := tensors[key+"_qbias"]
+		groupSize, bits, mode := model.ResolveLinearQuantParams(
+			cfg.QuantGroupSize,
+			cfg.QuantBits,
+			cfg.QuantMode,
+			cfg.TensorQuant,
+			key,
+			w,
+			scales,
+		)
+		if useQuantized && supportsGatherQMM(mode, bits) {
+			return &stackedExpertWeights{
+				Weight:    w,
+				Scales:    scales,
+				Biases:    qbiases,
+				Bits:      bits,
+				GroupSize: groupSize,
+				Mode:      mode,
+			}
+		}
+
+		return &stackedExpertWeights{Weight: mlx.Dequantize(w, scales, qbiases, groupSize, bits, mode)}
+	}
+
+	return nil
+}
+
+func collectPerExpertProjection(tensors map[string]*mlx.Array, cfg *Config, useQuantized bool, layerPrefix, proj string, numExperts int32) *stackedExpertWeights {
+	weights := make([]*mlx.Array, 0, numExperts)
+	scales := make([]*mlx.Array, 0, numExperts)
+	biases := make([]*mlx.Array, 0, numExperts)
+	consumedKeys := make([]string, 0, numExperts*3)
+	bits := 0
+	groupSize := 0
+	mode := cfg.QuantMode
+
+	for e := int32(0); e < numExperts; e++ {
+		base := fmt.Sprintf("%s.mlp.experts.%d.%s", layerPrefix, e, proj)
+		w, key := tensorByBase(tensors, base)
+		if w == nil {
+			continue
+		}
+		consumedKeys = append(consumedKeys, key)
+
+		s := tensors[key+"_scale"]
+		if s == nil {
+			weights = append(weights, w)
+			continue
+		}
+		consumedKeys = append(consumedKeys, key+"_scale")
+		qb := tensors[key+"_qbias"]
+		if qb != nil {
+			consumedKeys = append(consumedKeys, key+"_qbias")
+		}
+		gs, b, m := model.ResolveLinearQuantParams(
+			cfg.QuantGroupSize,
+			cfg.QuantBits,
+			cfg.QuantMode,
+			cfg.TensorQuant,
+			key,
+			w,
+			s,
+		)
+		if bits == 0 {
+			bits = b
+			groupSize = gs
+			mode = m
+		}
+		if useQuantized && supportsGatherQMM(m, b) {
+			weights = append(weights, w)
+			scales = append(scales, s)
+			if qb != nil {
+				biases = append(biases, qb)
+			}
+		} else {
+			weights = append(weights, mlx.Dequantize(w, s, qb, gs, b, m))
+		}
+	}
+
+	if len(weights) == 0 {
+		return nil
+	}
+
+	out := &stackedExpertWeights{Weight: stackAndDetach(weights), Bits: bits, GroupSize: groupSize, Mode: mode}
+	if len(scales) == len(weights) {
+		out.Scales = stackAndDetach(scales)
+	}
+	if len(biases) == len(weights) {
+		out.Biases = stackAndDetach(biases)
+	}
+	freeTensorKeys(tensors, consumedKeys...)
+	return out
+}
+
+func splitGateUpProjection(tensors map[string]*mlx.Array, cfg *Config, layerPrefix string) (gate, up, down *stackedExpertWeights) {
+	gateUp, key := tensorAny(
+		tensors,
+		layerPrefix+".mlp.experts.gate_up_proj.weight",
+		layerPrefix+".mlp.experts.gate_up_proj",
+	)
+	if gateUp == nil {
+		return nil, nil, nil
+	}
+
+	if scales := tensors[key+"_scale"]; scales != nil {
+		qbiases := tensors[key+"_qbias"]
+		groupSize, bits, mode := model.ResolveLinearQuantParams(
+			cfg.QuantGroupSize,
+			cfg.QuantBits,
+			cfg.QuantMode,
+			cfg.TensorQuant,
+			key,
+			gateUp,
+			scales,
+		)
+		gateUp = mlx.Dequantize(gateUp, scales, qbiases, groupSize, bits, mode)
+	}
+
+	if gateUp.NumDims() != 3 {
+		return nil, nil, nil
+	}
+	shape := gateUp.Dims()
+	nExperts, twoHidden, inHidden := int32(shape[0]), int32(shape[1]), int32(shape[2])
+	mid := twoHidden / 2
+
+	gateW := mlx.SliceStartStop(gateUp, []int32{0, 0, 0}, []int32{nExperts, mid, inHidden})
+	upW := mlx.SliceStartStop(gateUp, []int32{0, mid, 0}, []int32{nExperts, twoHidden, inHidden})
+	gate = &stackedExpertWeights{Weight: gateW}
+	up = &stackedExpertWeights{Weight: upW}
+
+	downW, downKey := tensorAny(
+		tensors,
+		layerPrefix+".mlp.experts.down_proj.weight",
+		layerPrefix+".mlp.experts.down_proj",
+	)
+	if downW == nil {
+		return gate, up, nil
+	}
+	if scales := tensors[downKey+"_scale"]; scales != nil {
+		qbiases := tensors[downKey+"_qbias"]
+		groupSize, bits, mode := model.ResolveLinearQuantParams(
+			cfg.QuantGroupSize,
+			cfg.QuantBits,
+			cfg.QuantMode,
+			cfg.TensorQuant,
+			downKey,
+			downW,
+			scales,
+		)
+		downW = mlx.Dequantize(downW, scales, qbiases, groupSize, bits, mode)
+	}
+	down = &stackedExpertWeights{Weight: downW}
+	return gate, up, down
+}
+
+func sanitizeConvWeight(w *mlx.Array) *mlx.Array {
+	if w == nil {
+		return nil
+	}
+	if w.NumDims() == 3 {
+		if w.Dim(1) == 1 {
+			return mlx.Squeeze(w, 1)
+		}
+		if w.Dim(2) == 1 {
+			return mlx.Squeeze(w, 2)
+		}
+	}
+	return w
+}
+
+func shouldShiftNormKey(key string) bool {
+	for _, suffix := range []string{
+		".input_layernorm.weight",
+		".post_attention_layernorm.weight",
+		"model.norm.weight",
+		".self_attn.q_norm.weight",
+		".self_attn.k_norm.weight",
+	} {
+		if strings.HasSuffix(key, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func maybeShiftNormWeight(key string, w *mlx.Array, shouldShift bool) *mlx.Array {
+	if !shouldShift || w == nil || w.NumDims() != 1 || !shouldShiftNormKey(key) {
+		return w
+	}
+	return mlx.AddScalar(w, 1.0)
+}
+
+// LoadWeights assigns tensors to model fields.
+func (m *Model) LoadWeights(tensors map[string]*mlx.Array) error {
+	m.weightPrefix = resolveWeightPrefix(tensors)
+	prefix := m.weightPrefix
+	cfg := m.Config
+
+	linears := model.NewLinearFactory(tensors, cfg.QuantGroupSize, cfg.QuantBits, cfg.QuantMode, cfg.TensorQuant)
+
+	shouldShiftNormWeights := false
+	mtpKeys := make([]string, 0)
+	for name, t := range tensors {
+		if strings.Contains(name, "mtp.") {
+			shouldShiftNormWeights = true
+			mtpKeys = append(mtpKeys, name)
+			continue
+		}
+		if !shouldShiftNormWeights && strings.Contains(name, ".linear_attn.conv1d.weight") && t != nil && t.NumDims() == 3 && t.Dim(2) != 1 {
+			shouldShiftNormWeights = true
+		}
+	}
+	if len(mtpKeys) > 0 {
+		freeTensorKeys(tensors, mtpKeys...)
+	}
+
+	embedWeight := tensors[prefix+"model.embed_tokens.weight"]
+	if embedWeight == nil {
+		return fmt.Errorf("missing embedding weight: %smodel.embed_tokens.weight", prefix)
+	}
+	m.EmbedTokens = nn.NewEmbedding(embedWeight)
+
+	normKey := prefix + "model.norm.weight"
+	normWeight := maybeShiftNormWeight(normKey, tensors[normKey], shouldShiftNormWeights)
+	if normWeight == nil {
+		return fmt.Errorf("missing final norm weight: %smodel.norm.weight", prefix)
+	}
+	m.Norm = nn.NewRMSNorm(normWeight, cfg.RMSNormEps)
+
+	if cfg.TieWordEmbeddings {
+		m.LMHead = nn.NewLinear(embedWeight, nil)
+	} else if lmHead := linears.Make(prefix + "lm_head"); lmHead != nil {
+		m.LMHead = lmHead
+	} else if lmHead := linears.Make("lm_head"); lmHead != nil {
+		m.LMHead = lmHead
+	} else {
+		m.LMHead = nn.NewLinear(embedWeight, nil)
+	}
+
+	useQuantizedExperts := supportsGatherQMM(cfg.QuantMode, cfg.QuantBits)
+	if !useQuantizedExperts && cfg.TensorQuant != nil {
+		for _, tq := range cfg.TensorQuant {
+			if tq == nil {
+				continue
+			}
+			_, bits, mode := model.QuantizationParams(tq.QuantType)
+			if supportsGatherQMM(mode, bits) {
+				useQuantizedExperts = true
+				break
+			}
+		}
+	}
+
+	for i := int32(0); i < cfg.NumHiddenLayers; i++ {
+		layerPrefix := fmt.Sprintf("%smodel.layers.%d", prefix, i)
+		layer := &Layer{IsLinear: layerIsLinear(cfg, i)}
+
+		if w := maybeShiftNormWeight(layerPrefix+".input_layernorm.weight", tensors[layerPrefix+".input_layernorm.weight"], shouldShiftNormWeights); w != nil {
+			layer.InputNorm = nn.NewRMSNorm(w, cfg.RMSNormEps)
+		}
+		if w := maybeShiftNormWeight(layerPrefix+".post_attention_layernorm.weight", tensors[layerPrefix+".post_attention_layernorm.weight"], shouldShiftNormWeights); w != nil {
+			layer.PostAttentionNorm = nn.NewRMSNorm(w, cfg.RMSNormEps)
+		}
+		if layer.InputNorm == nil || layer.PostAttentionNorm == nil {
+			return fmt.Errorf("layer %d: missing layer norms", i)
+		}
+
+		if layer.IsLinear {
+			lin := &GatedDeltaNet{}
+			lin.InProjQKV = linears.Make(layerPrefix + ".linear_attn.in_proj_qkv")
+			lin.InProjZ = linears.Make(layerPrefix + ".linear_attn.in_proj_z")
+			lin.InProjB = linears.Make(layerPrefix + ".linear_attn.in_proj_b")
+			lin.InProjA = linears.Make(layerPrefix + ".linear_attn.in_proj_a")
+			lin.InProjQKVZ = linears.Make(layerPrefix + ".linear_attn.in_proj_qkvz")
+			lin.InProjBA = linears.Make(layerPrefix + ".linear_attn.in_proj_ba")
+			lin.OutProj = linears.Make(layerPrefix + ".linear_attn.out_proj")
+
+			lin.ConvWeight = sanitizeConvWeight(tensors[layerPrefix+".linear_attn.conv1d.weight"])
+			if lin.ConvWeight == nil {
+				lin.ConvWeight = sanitizeConvWeight(tensors[layerPrefix+".linear_attn.conv1d"])
+			}
+			lin.NormWeight, _ = tensorAny(tensors,
+				layerPrefix+".linear_attn.norm.weight",
+				layerPrefix+".linear_attn.norm",
+			)
+			lin.DtBias, _ = tensorAny(tensors,
+				layerPrefix+".linear_attn.dt_bias",
+				layerPrefix+".linear_attn.dt_proj",
+			)
+			lin.ALog, _ = tensorAny(tensors,
+				layerPrefix+".linear_attn.A_log",
+				layerPrefix+".linear_attn.a_log",
+			)
+			if lin.ALog != nil {
+				lin.AExp = mlx.Exp(lin.ALog.AsType(mlx.DTypeFloat32))
+			}
+
+			hasSplit := lin.InProjQKV != nil && lin.InProjZ != nil && lin.InProjB != nil && lin.InProjA != nil
+			hasCombined := lin.InProjQKVZ != nil && lin.InProjBA != nil
+			if (!hasSplit && !hasCombined) || lin.OutProj == nil {
+				return fmt.Errorf("layer %d: missing linear attention projections", i)
+			}
+			if lin.ConvWeight == nil || lin.NormWeight == nil || lin.DtBias == nil || lin.ALog == nil || lin.AExp == nil {
+				return fmt.Errorf("layer %d: missing linear attention state tensors", i)
+			}
+			if lin.ConvWeight.NumDims() != 2 {
+				return fmt.Errorf("layer %d: conv1d weight must be 2D after sanitization, got %dD", i, lin.ConvWeight.NumDims())
+			}
+
+			layer.Linear = lin
+		} else {
+			attn := &FullAttention{}
+			attn.QProj = linears.Make(layerPrefix + ".self_attn.q_proj")
+			attn.KProj = linears.Make(layerPrefix + ".self_attn.k_proj")
+			attn.VProj = linears.Make(layerPrefix + ".self_attn.v_proj")
+			attn.OProj = linears.Make(layerPrefix + ".self_attn.o_proj")
+
+			if w := maybeShiftNormWeight(layerPrefix+".self_attn.q_norm.weight", tensors[layerPrefix+".self_attn.q_norm.weight"], shouldShiftNormWeights); w != nil {
+				attn.QNorm = nn.NewRMSNorm(w, cfg.RMSNormEps)
+			}
+			if w := maybeShiftNormWeight(layerPrefix+".self_attn.k_norm.weight", tensors[layerPrefix+".self_attn.k_norm.weight"], shouldShiftNormWeights); w != nil {
+				attn.KNorm = nn.NewRMSNorm(w, cfg.RMSNormEps)
+			}
+
+			if attn.QProj == nil || attn.KProj == nil || attn.VProj == nil || attn.OProj == nil {
+				return fmt.Errorf("layer %d: missing full attention projections", i)
+			}
+			if attn.QNorm == nil || attn.KNorm == nil {
+				return fmt.Errorf("layer %d: missing full attention q/k norms", i)
+			}
+			layer.FullAttn = attn
+		}
+
+		if layerUsesMoE(cfg, i) {
+			moe := &SparseMoE{}
+			moe.Gate = linears.Make(layerPrefix + ".mlp.gate")
+			if moe.Gate == nil {
+				return fmt.Errorf("layer %d: missing moe gate", i)
+			}
+
+			gateW := loadStackedProjection(tensors, cfg, useQuantizedExperts,
+				layerPrefix+".mlp.switch_mlp.gate_proj",
+				layerPrefix+".mlp.experts.gate_proj",
+			)
+			upW := loadStackedProjection(tensors, cfg, useQuantizedExperts,
+				layerPrefix+".mlp.switch_mlp.up_proj",
+				layerPrefix+".mlp.experts.up_proj",
+			)
+			downW := loadStackedProjection(tensors, cfg, useQuantizedExperts,
+				layerPrefix+".mlp.switch_mlp.down_proj",
+				layerPrefix+".mlp.experts.down_proj",
+			)
+			if gateW == nil || upW == nil || downW == nil {
+				g2, u2, d2 := splitGateUpProjection(tensors, cfg, layerPrefix)
+				if gateW == nil {
+					gateW = g2
+				}
+				if upW == nil {
+					upW = u2
+				}
+				if downW == nil {
+					downW = d2
+				}
+			}
+			if gateW == nil || upW == nil || downW == nil {
+				gateW = collectPerExpertProjection(tensors, cfg, useQuantizedExperts, layerPrefix, "gate_proj", cfg.NumExperts)
+				upW = collectPerExpertProjection(tensors, cfg, useQuantizedExperts, layerPrefix, "up_proj", cfg.NumExperts)
+				downW = collectPerExpertProjection(tensors, cfg, useQuantizedExperts, layerPrefix, "down_proj", cfg.NumExperts)
+			}
+
+			if gateW == nil || upW == nil || downW == nil {
+				return fmt.Errorf("layer %d: missing switch expert weights", i)
+			}
+
+			switchMLP := &SwitchMLP{}
+			if gateW.Scales != nil && upW.Scales != nil && downW.Scales != nil {
+				switchMLP.UseQuantized = true
+				switchMLP.GateWeightQ = gateW.Weight
+				switchMLP.GateScales = gateW.Scales
+				switchMLP.GateBiases = gateW.Biases
+				switchMLP.GateBits = gateW.Bits
+				switchMLP.GateGroupSize = gateW.GroupSize
+				switchMLP.UpWeightQ = upW.Weight
+				switchMLP.UpScales = upW.Scales
+				switchMLP.UpBiases = upW.Biases
+				switchMLP.UpBits = upW.Bits
+				switchMLP.UpGroupSize = upW.GroupSize
+				switchMLP.DownWeightQ = downW.Weight
+				switchMLP.DownScales = downW.Scales
+				switchMLP.DownBiases = downW.Biases
+				switchMLP.DownBits = downW.Bits
+				switchMLP.DownGroupSize = downW.GroupSize
+			} else {
+				switchMLP.GateWeight = gateW.Weight
+				switchMLP.UpWeight = upW.Weight
+				switchMLP.DownWeight = downW.Weight
+			}
+			moe.SwitchMLP = switchMLP
+
+			sharedGateProj := linears.Make(layerPrefix + ".mlp.shared_expert.gate_proj")
+			sharedUpProj := linears.Make(layerPrefix + ".mlp.shared_expert.up_proj")
+			sharedDownProj := linears.Make(layerPrefix + ".mlp.shared_expert.down_proj")
+			if sharedGateProj != nil && sharedUpProj != nil && sharedDownProj != nil {
+				moe.SharedExpert = &DenseMLP{
+					GateProj: sharedGateProj,
+					UpProj:   sharedUpProj,
+					DownProj: sharedDownProj,
+				}
+				moe.SharedExpertGate = linears.Make(layerPrefix + ".mlp.shared_expert_gate")
+			}
+
+			layer.MLP = moe
+		} else {
+			mlp := &DenseMLP{
+				GateProj: linears.Make(layerPrefix + ".mlp.gate_proj"),
+				UpProj:   linears.Make(layerPrefix + ".mlp.up_proj"),
+				DownProj: linears.Make(layerPrefix + ".mlp.down_proj"),
+			}
+			if mlp.GateProj == nil || mlp.UpProj == nil || mlp.DownProj == nil {
+				return fmt.Errorf("layer %d: missing dense mlp projections", i)
+			}
+			layer.MLP = mlp
+		}
+
+		m.Layers[i] = layer
+	}
+
+	collected := mlx.Collect(m)
+	mlx.Eval(collected...)
+	return nil
+}
+
+func rmsNormNoWeight(x *mlx.Array, eps float32) *mlx.Array {
+	sq := mlx.Mul(x, x)
+	mean := mlx.Mean(sq, -1, true)
+	inv := mlx.RSqrt(mlx.AddScalar(mean, eps))
+	return mlx.Mul(x, inv)
+}
+
+func softplus(x *mlx.Array) *mlx.Array {
+	return mlx.Log(mlx.AddScalar(mlx.Exp(x), 1.0))
+}
+
+func repeatHeads(x *mlx.Array, repeatFactor int32) *mlx.Array {
+	if repeatFactor <= 1 {
+		return x
+	}
+	shape := x.Dims()
+	x = mlx.ExpandDims(x, 3)
+	x = mlx.Tile(x, []int32{1, 1, 1, repeatFactor, 1})
+	return mlx.Reshape(x, int32(shape[0]), int32(shape[1]), int32(shape[2])*repeatFactor, int32(shape[3]))
+}
+
+func depthwiseCausalConv1d(x, w *mlx.Array, outLen int32) *mlx.Array {
+	if x == nil || w == nil {
+		return nil
+	}
+	if w.NumDims() != 2 {
+		return nil
+	}
+	B := int32(x.Dim(0))
+	C := int32(w.Dim(0))
+	K := int32(w.Dim(1))
+	var out *mlx.Array
+	for i := int32(0); i < K; i++ {
+		seg := mlx.SliceStartStop(x, []int32{0, i, 0}, []int32{B, i + outLen, C})
+		wi := mlx.SliceStartStop(w, []int32{0, i}, []int32{C, i + 1})
+		wi = mlx.Reshape(wi, 1, 1, C)
+		term := mlx.Mul(seg, wi)
+		if out == nil {
+			out = term
+		} else {
+			out = mlx.Add(out, term)
+		}
+	}
+	return out
+}
+
+func splitQKVZBA(mixedQKVZ, mixedBA *mlx.Array, cfg *Config, B, L int32) (q, k, v, z, b, a *mlx.Array) {
+	nk := cfg.LinearNumKeyHeads
+	nv := cfg.LinearNumValueHeads
+	dk := cfg.LinearKeyHeadDim
+	dv := cfg.LinearValueHeadDim
+	vPerK := nv / nk
+
+	mixedQKVZ = mlx.Reshape(mixedQKVZ, B, L, nk, 2*dk+2*vPerK*dv)
+	q = mlx.SliceStartStop(mixedQKVZ, []int32{0, 0, 0, 0}, []int32{B, L, nk, dk})
+	k = mlx.SliceStartStop(mixedQKVZ, []int32{0, 0, 0, dk}, []int32{B, L, nk, 2 * dk})
+	v = mlx.SliceStartStop(mixedQKVZ, []int32{0, 0, 0, 2 * dk}, []int32{B, L, nk, 2*dk + vPerK*dv})
+	z = mlx.SliceStartStop(mixedQKVZ, []int32{0, 0, 0, 2*dk + vPerK*dv}, []int32{B, L, nk, 2*dk + 2*vPerK*dv})
+
+	v = mlx.Reshape(v, B, L, nv, dv)
+	z = mlx.Reshape(z, B, L, nv, dv)
+
+	mixedBA = mlx.Reshape(mixedBA, B, L, nk, 2*vPerK)
+	b = mlx.SliceStartStop(mixedBA, []int32{0, 0, 0, 0}, []int32{B, L, nk, vPerK})
+	a = mlx.SliceStartStop(mixedBA, []int32{0, 0, 0, vPerK}, []int32{B, L, nk, 2 * vPerK})
+	b = mlx.Reshape(b, B, L, nv)
+	a = mlx.Reshape(a, B, L, nv)
+
+	return q, k, v, z, b, a
+}
+
+func (a *FullAttention) Forward(x *mlx.Array, c cache.Cache, B, L int32, cfg *Config) *mlx.Array {
+	qg := a.QProj.Forward(x)
+	qg = mlx.Reshape(qg, B, L, cfg.NumAttentionHeads, cfg.HeadDim*2)
+	q := mlx.SliceStartStop(qg, []int32{0, 0, 0, 0}, []int32{B, L, cfg.NumAttentionHeads, cfg.HeadDim})
+	gate := mlx.SliceStartStop(qg, []int32{0, 0, 0, cfg.HeadDim}, []int32{B, L, cfg.NumAttentionHeads, cfg.HeadDim * 2})
+	gate = mlx.Reshape(gate, B, L, cfg.NumAttentionHeads*cfg.HeadDim)
+
+	k := a.KProj.Forward(x)
+	v := a.VProj.Forward(x)
+	k = mlx.Reshape(k, B, L, cfg.NumKeyValueHeads, cfg.HeadDim)
+	v = mlx.Reshape(v, B, L, cfg.NumKeyValueHeads, cfg.HeadDim)
+
+	q = a.QNorm.Forward(q, cfg.RMSNormEps)
+	k = a.KNorm.Forward(k, cfg.RMSNormEps)
+
+	q = mlx.Transpose(q, 0, 2, 1, 3)
+	k = mlx.Transpose(k, 0, 2, 1, 3)
+	v = mlx.Transpose(v, 0, 2, 1, 3)
+
+	offset := 0
+	if c != nil {
+		offset = c.Offset()
+	}
+	q = mlx.RoPEWithBase(q, int(cfg.RopeDim), false, cfg.RopeTheta, 1.0, offset)
+	k = mlx.RoPEWithBase(k, int(cfg.RopeDim), false, cfg.RopeTheta, 1.0, offset)
+
+	if c != nil {
+		k, v = c.Update(k, v)
+	}
+
+	out := mlx.ScaledDotProductAttentionCausal(q, k, v, cfg.Scale, L > 1)
+	out = mlx.Reshape(mlx.Transpose(out, 0, 2, 1, 3), B, L, cfg.NumAttentionHeads*cfg.HeadDim)
+	out = mlx.Mul(out, mlx.Sigmoid(gate))
+	return a.OProj.Forward(out)
+}
+
+func (g *GatedDeltaNet) Forward(x *mlx.Array, c cache.Cache, B, L int32, cfg *Config) *mlx.Array {
+	var qkv, z, b, a *mlx.Array
+	useSplitProj := g.InProjQKV != nil && g.InProjZ != nil && g.InProjB != nil && g.InProjA != nil
+	if useSplitProj {
+		qkv = g.InProjQKV.Forward(x)
+		z = g.InProjZ.Forward(x)
+		z = mlx.Reshape(z, B, L, cfg.LinearNumValueHeads, cfg.LinearValueHeadDim)
+		b = g.InProjB.Forward(x)
+		a = g.InProjA.Forward(x)
+	} else {
+		mixedQKVZ := g.InProjQKVZ.Forward(x)
+		mixedBA := g.InProjBA.Forward(x)
+		var q, k, v *mlx.Array
+		q, k, v, z, b, a = splitQKVZBA(mixedQKVZ, mixedBA, cfg, B, L)
+		qkv = mlx.Concatenate([]*mlx.Array{
+			mlx.Reshape(q, B, L, cfg.LinearNumKeyHeads*cfg.LinearKeyHeadDim),
+			mlx.Reshape(k, B, L, cfg.LinearNumKeyHeads*cfg.LinearKeyHeadDim),
+			mlx.Reshape(v, B, L, cfg.LinearNumValueHeads*cfg.LinearValueHeadDim),
+		}, -1)
+	}
+
+	convTail := cfg.LinearConvKernelDim - 1
+	var convState *mlx.Array
+	var rc *cache.RecurrentCache
+	if c != nil {
+		if typed, ok := c.(*cache.RecurrentCache); ok {
+			rc = typed
+			convState = rc.ConvState(int(B), x.DType())
+		}
+	}
+	if convState == nil {
+		convState = mlx.Zeros(x.DType(), int(B), int(convTail), int(2*cfg.LinearNumKeyHeads*cfg.LinearKeyHeadDim+cfg.LinearNumValueHeads*cfg.LinearValueHeadDim))
+	}
+
+	convInput := mlx.Concatenate([]*mlx.Array{convState, qkv}, 1)
+	convOut := depthwiseCausalConv1d(convInput, g.ConvWeight, L)
+	convOut = mlx.SiLU(convOut)
+	if rc != nil {
+		total := int32(convInput.Dim(1))
+		start := total - convTail
+		nextConv := mlx.SliceStartStop(convInput, []int32{0, start, 0}, []int32{B, total, int32(convInput.Dim(2))})
+		// Always snapshot/materialize recurrent state so prefill does not retain
+		// full token-unrolled graphs across requests.
+		rc.SetConvState(nextConv)
+	}
+
+	keyDim := cfg.LinearNumKeyHeads * cfg.LinearKeyHeadDim
+	valueDim := cfg.LinearNumValueHeads * cfg.LinearValueHeadDim
+	q := mlx.SliceStartStop(convOut, []int32{0, 0, 0}, []int32{B, L, keyDim})
+	k := mlx.SliceStartStop(convOut, []int32{0, 0, keyDim}, []int32{B, L, 2 * keyDim})
+	v := mlx.SliceStartStop(convOut, []int32{0, 0, 2 * keyDim}, []int32{B, L, 2*keyDim + valueDim})
+
+	q = mlx.Reshape(q, B, L, cfg.LinearNumKeyHeads, cfg.LinearKeyHeadDim)
+	k = mlx.Reshape(k, B, L, cfg.LinearNumKeyHeads, cfg.LinearKeyHeadDim)
+	v = mlx.Reshape(v, B, L, cfg.LinearNumValueHeads, cfg.LinearValueHeadDim)
+
+	invScale := float32(1.0 / math.Sqrt(float64(cfg.LinearKeyHeadDim)))
+	q = mlx.MulScalar(rmsNormNoWeight(q, 1e-6), invScale*invScale)
+	k = mlx.MulScalar(rmsNormNoWeight(k, 1e-6), invScale)
+
+	repeatFactor := cfg.LinearNumValueHeads / cfg.LinearNumKeyHeads
+	q = repeatHeads(q, repeatFactor)
+	k = repeatHeads(k, repeatFactor)
+
+	aF32 := a.AsType(mlx.DTypeFloat32)
+	dtBiasF32 := g.DtBias.AsType(mlx.DTypeFloat32)
+	gDecay := softplus(mlx.Add(aF32, dtBiasF32))
+	gDecay = mlx.Mul(gDecay, g.AExp)
+	gDecay = mlx.Exp(mlx.MulScalar(gDecay, -1))
+	gDecay = gDecay.AsType(a.DType())
+
+	beta := mlx.Sigmoid(b)
+
+	var state *mlx.Array
+	if rc != nil {
+		state = rc.DeltaState(int(B), x.DType())
+	}
+	if state == nil {
+		state = mlx.Zeros(x.DType(), int(B), int(cfg.LinearNumValueHeads), int(cfg.LinearValueHeadDim), int(cfg.LinearKeyHeadDim))
+	}
+
+	var out *mlx.Array
+	if L == 1 {
+		// Fast decode path: avoid per-token slice/append graph construction.
+		qt := mlx.Squeeze(q, 1)
+		kt := mlx.Squeeze(k, 1)
+		vt := mlx.Squeeze(v, 1)
+		gt := mlx.Squeeze(gDecay, 1)
+		bt := mlx.Squeeze(beta, 1)
+
+		state = mlx.Mul(state, mlx.ExpandDims(mlx.ExpandDims(gt, -1), -1))
+		kvMem := mlx.Sum(mlx.Mul(state, mlx.ExpandDims(kt, 2)), -1, false)
+		delta := mlx.Mul(mlx.Sub(vt, kvMem), mlx.ExpandDims(bt, -1))
+		state = mlx.Add(state, mlx.Mul(mlx.ExpandDims(kt, 2), mlx.ExpandDims(delta, -1)))
+		yt := mlx.Sum(mlx.Mul(state, mlx.ExpandDims(qt, 2)), -1, false)
+		out = mlx.ExpandDims(yt, 1)
+	} else {
+		outs := make([]*mlx.Array, 0, L)
+		for t := int32(0); t < L; t++ {
+			qt := mlx.Squeeze(mlx.SliceStartStop(q, []int32{0, t, 0, 0}, []int32{B, t + 1, cfg.LinearNumValueHeads, cfg.LinearKeyHeadDim}), 1)
+			kt := mlx.Squeeze(mlx.SliceStartStop(k, []int32{0, t, 0, 0}, []int32{B, t + 1, cfg.LinearNumValueHeads, cfg.LinearKeyHeadDim}), 1)
+			vt := mlx.Squeeze(mlx.SliceStartStop(v, []int32{0, t, 0, 0}, []int32{B, t + 1, cfg.LinearNumValueHeads, cfg.LinearValueHeadDim}), 1)
+			gt := mlx.Squeeze(mlx.SliceStartStop(gDecay, []int32{0, t, 0}, []int32{B, t + 1, cfg.LinearNumValueHeads}), 1)
+			bt := mlx.Squeeze(mlx.SliceStartStop(beta, []int32{0, t, 0}, []int32{B, t + 1, cfg.LinearNumValueHeads}), 1)
+
+			state = mlx.Mul(state, mlx.ExpandDims(mlx.ExpandDims(gt, -1), -1))
+			kvMem := mlx.Sum(mlx.Mul(state, mlx.ExpandDims(kt, 2)), -1, false)
+			delta := mlx.Mul(mlx.Sub(vt, kvMem), mlx.ExpandDims(bt, -1))
+			state = mlx.Add(state, mlx.Mul(mlx.ExpandDims(kt, 2), mlx.ExpandDims(delta, -1)))
+			yt := mlx.Sum(mlx.Mul(state, mlx.ExpandDims(qt, 2)), -1, false)
+			outs = append(outs, mlx.ExpandDims(yt, 1))
+		}
+		out = mlx.Concatenate(outs, 1)
+	}
+	out = mlx.RMSNormFn(out, g.NormWeight, cfg.RMSNormEps)
+	out = mlx.Mul(out, mlx.SiLU(z))
+	out = mlx.Reshape(out, B, L, valueDim)
+	out = g.OutProj.Forward(out)
+	if rc != nil {
+		rc.SetDeltaState(state)
+		rc.Advance(int(L))
+	}
+	return out
+}
+
+func (m *DenseMLP) Forward(x *mlx.Array, _ *Config) *mlx.Array {
+	return m.DownProj.Forward(mlx.Mul(mlx.SiLU(m.GateProj.Forward(x)), m.UpProj.Forward(x)))
+}
+
+func (s *SwitchMLP) Forward(x *mlx.Array, indices *mlx.Array, cfg *Config) *mlx.Array {
+	dims := x.Dims()
+	B, L := int32(dims[0]), int32(dims[1])
+	topK := cfg.NumExpertsPerTok
+
+	xExpanded := mlx.ExpandDims(mlx.ExpandDims(x, -2), -2)
+	xFlat := mlx.Reshape(xExpanded, B*L, 1, 1, cfg.HiddenSize)
+	idxFlat := mlx.Reshape(indices, B*L, topK)
+
+	doSort := B*L >= 64
+	var invOrder *mlx.Array
+	n := B * L * topK
+
+	if doSort {
+		idxAll := mlx.Flatten(idxFlat)
+		order := mlx.Argsort(idxAll, 0)
+		invOrder = mlx.Argsort(order, 0)
+		xFlat = mlx.ExpandDims(mlx.Take(mlx.Squeeze(xFlat, 1), mlx.FloorDivideScalar(order, topK), 0), 1)
+		idxFlat = mlx.Reshape(mlx.Take(idxAll, order, 0), n, 1)
+	}
+
+	var gate, up, hidden, down *mlx.Array
+	if s.UseQuantized {
+		gate = mlx.GatherQMM(xFlat, s.GateWeightQ, s.GateScales, s.GateBiases,
+			nil, idxFlat, true, s.GateGroupSize, s.GateBits, cfg.QuantMode, doSort)
+		up = mlx.GatherQMM(xFlat, s.UpWeightQ, s.UpScales, s.UpBiases,
+			nil, idxFlat, true, s.UpGroupSize, s.UpBits, cfg.QuantMode, doSort)
+		hidden = mlx.Mul(mlx.SiLU(gate), up)
+		down = mlx.GatherQMM(hidden, s.DownWeightQ, s.DownScales, s.DownBiases,
+			nil, idxFlat, true, s.DownGroupSize, s.DownBits, cfg.QuantMode, doSort)
+	} else {
+		gate = mlx.GatherMM(xFlat, mlx.Transpose(s.GateWeight, 0, 2, 1), nil, idxFlat, doSort)
+		up = mlx.GatherMM(xFlat, mlx.Transpose(s.UpWeight, 0, 2, 1), nil, idxFlat, doSort)
+		hidden = mlx.Mul(mlx.SiLU(gate), up)
+		down = mlx.GatherMM(hidden, mlx.Transpose(s.DownWeight, 0, 2, 1), nil, idxFlat, doSort)
+	}
+
+	if doSort {
+		down = mlx.Reshape(mlx.Take(mlx.Squeeze(mlx.Squeeze(down, 2), 1), invOrder, 0), B*L, topK, cfg.HiddenSize)
+	} else {
+		down = mlx.Squeeze(down, 2)
+	}
+
+	return mlx.Reshape(down, B, L, topK, cfg.HiddenSize)
+}
+
+func (m *SparseMoE) Forward(x *mlx.Array, cfg *Config) *mlx.Array {
+	dims := x.Dims()
+	B, L := int32(dims[0]), int32(dims[1])
+
+	probs := mlx.SoftmaxAxis(m.Gate.Forward(x), -1, true)
+	neg := mlx.Neg(probs)
+	inds := mlx.Argpartition(neg, int(cfg.NumExpertsPerTok)-1, -1)
+	shape := inds.Dims()
+	inds = mlx.SliceStartStop(inds, []int32{0, 0, 0}, []int32{int32(shape[0]), int32(shape[1]), cfg.NumExpertsPerTok})
+
+	scores := mlx.TakeAlongAxis(probs, inds, -1)
+	if cfg.NormTopKProb && cfg.NumExpertsPerTok > 1 {
+		sumScores := mlx.Sum(scores, -1, true)
+		scores = mlx.Div(scores, sumScores)
+	}
+
+	expertOut := m.SwitchMLP.Forward(x, inds, cfg)
+	y := mlx.Sum(mlx.Mul(expertOut, mlx.ExpandDims(scores, -1)), 2, false)
+
+	if m.SharedExpert != nil {
+		shared := m.SharedExpert.Forward(x, cfg)
+		if m.SharedExpertGate != nil {
+			shared = mlx.Mul(shared, mlx.Sigmoid(m.SharedExpertGate.Forward(x)))
+		}
+		y = mlx.Add(y, shared)
+	}
+
+	return mlx.Reshape(y, B, L, cfg.HiddenSize)
+}
+
+func (l *Layer) Forward(x *mlx.Array, c cache.Cache, B, L int32, cfg *Config) *mlx.Array {
+	var r *mlx.Array
+	normed := l.InputNorm.Forward(x, cfg.RMSNormEps)
+	if l.IsLinear {
+		r = l.Linear.Forward(normed, c, B, L, cfg)
+	} else {
+		r = l.FullAttn.Forward(normed, c, B, L, cfg)
+	}
+	h := mlx.Add(x, r)
+	r = l.MLP.Forward(l.PostAttentionNorm.Forward(h, cfg.RMSNormEps), cfg)
+	return mlx.Add(h, r)
+}
+
+func (m *Model) Forward(tokens *mlx.Array, caches []cache.Cache) *mlx.Array {
+	dims := tokens.Dims()
+	B, L := int32(dims[0]), int32(dims[1])
+
+	h := m.EmbedTokens.Forward(tokens)
+	for i, layer := range m.Layers {
+		var c cache.Cache
+		if caches != nil && i < len(caches) {
+			c = caches[i]
+		}
+		h = layer.Forward(h, c, B, L, m.Config)
+	}
+
+	return m.Norm.Forward(h, m.RMSNormEps)
+}
+
+func (m *Model) Unembed(x *mlx.Array) *mlx.Array {
+	return m.LMHead.Forward(x)
+}
+
+func (m *Model) NumLayers() int {
+	return len(m.Layers)
+}
+
+func (m *Model) Tokenizer() *tokenizer.Tokenizer {
+	return m.tok
+}
+
+func (m *Model) NewCaches() []cache.Cache {
+	caches := make([]cache.Cache, len(m.Layers))
+	convTail := m.LinearConvKernelDim - 1
+	convDim := 2*m.LinearNumKeyHeads*m.LinearKeyHeadDim + m.LinearNumValueHeads*m.LinearValueHeadDim
+	for i, layer := range m.Layers {
+		if layer.IsLinear {
+			caches[i] = cache.NewRecurrentCache(convTail, convDim, m.LinearNumValueHeads, m.LinearValueHeadDim, m.LinearKeyHeadDim)
+		} else {
+			caches[i] = cache.NewKVCache()
+		}
+	}
+	return caches
+}
+
+// DisablePromptCache disables prefix-trim prompt caching because recurrent
+// states are not safely rewindable with simple Trim semantics.
+func (m *Model) DisablePromptCache() bool {
+	return true
+}
+
+// EnableCompile disables MLX compile for this model path for now.
+func (m *Model) EnableCompile() bool {
+	return false
+}

--- a/x/models/qwen3_5/qwen3_5_test.go
+++ b/x/models/qwen3_5/qwen3_5_test.go
@@ -1,0 +1,120 @@
+//go:build mlx
+
+package qwen3_5
+
+import (
+	"testing"
+
+	"github.com/ollama/ollama/x/mlxrunner/cache"
+)
+
+func TestParseConfigNestedDefaults(t *testing.T) {
+	data := []byte(`{
+		"model_type": "Qwen3_5MoeForConditionalGeneration",
+		"text_config": {
+			"hidden_size": 4096,
+			"intermediate_size": 14336,
+			"num_hidden_layers": 8,
+			"num_attention_heads": 32,
+			"num_key_value_heads": 8,
+			"head_dim": 128,
+			"linear_num_value_heads": 64,
+			"linear_num_key_heads": 16,
+			"linear_key_head_dim": 128,
+			"linear_value_head_dim": 128,
+			"linear_conv_kernel_dim": 4,
+			"num_experts": 16,
+			"num_experts_per_tok": 4,
+			"moe_intermediate_size": 2048,
+			"shared_expert_intermediate_size": 4096,
+			"rope_parameters": {
+				"rope_theta": 500000,
+				"partial_rotary_factor": 0.5
+			}
+		}
+	}`)
+
+	cfg, err := parseConfig(data)
+	if err != nil {
+		t.Fatalf("parseConfig failed: %v", err)
+	}
+
+	if cfg.RopeTheta != 500000 {
+		t.Fatalf("rope theta mismatch: got %v", cfg.RopeTheta)
+	}
+	if cfg.RopeDim != 64 {
+		t.Fatalf("rope dim mismatch: got %d want 64", cfg.RopeDim)
+	}
+	if cfg.FullAttentionInterval != 4 {
+		t.Fatalf("full_attention_interval default mismatch: got %d want 4", cfg.FullAttentionInterval)
+	}
+	if !cfg.NormTopKProb {
+		t.Fatalf("norm_topk_prob should default to true for MoE")
+	}
+}
+
+func TestLayerSelectionHelpers(t *testing.T) {
+	cfg := &Config{
+		NumHiddenLayers:       6,
+		FullAttentionInterval: 3,
+		NumExperts:            8,
+		DecoderSparseStep:     2,
+		MLPOnlyLayers:         []int32{1},
+	}
+
+	if !layerIsLinear(cfg, 0) {
+		t.Fatalf("layer 0 should be linear")
+	}
+	if layerIsLinear(cfg, 2) {
+		t.Fatalf("layer 2 should be full attention")
+	}
+
+	if layerUsesMoE(cfg, 1) {
+		t.Fatalf("layer 1 should be forced dense by mlp_only_layers")
+	}
+	if !layerUsesMoE(cfg, 3) {
+		t.Fatalf("layer 3 should use moe with decoder_sparse_step=2")
+	}
+}
+
+func TestModelRuntimeToggles(t *testing.T) {
+	m := &Model{}
+	if !m.DisablePromptCache() {
+		t.Fatal("DisablePromptCache() = false, want true")
+	}
+	if m.EnableCompile() {
+		t.Fatal("EnableCompile() = true, want false")
+	}
+}
+
+func TestNewCachesLayout(t *testing.T) {
+	m := &Model{
+		Config: &Config{
+			LinearConvKernelDim: 4,
+			LinearNumKeyHeads:   2,
+			LinearKeyHeadDim:    8,
+			LinearNumValueHeads: 4,
+			LinearValueHeadDim:  16,
+		},
+		Layers: []*Layer{
+			{IsLinear: true},
+			{IsLinear: false},
+			{IsLinear: true},
+		},
+	}
+
+	caches := m.NewCaches()
+	if len(caches) != len(m.Layers) {
+		t.Fatalf("len(caches) = %d, want %d", len(caches), len(m.Layers))
+	}
+
+	if _, ok := caches[0].(*cache.RecurrentCache); !ok {
+		t.Fatalf("cache[0] = %T, want *cache.RecurrentCache", caches[0])
+	}
+	if _, ok := caches[1].(*cache.KVCache); !ok {
+		t.Fatalf("cache[1] = %T, want *cache.KVCache", caches[1])
+	}
+	if _, ok := caches[2].(*cache.RecurrentCache); !ok {
+		t.Fatalf("cache[2] = %T, want *cache.RecurrentCache", caches[2])
+	}
+}

--- a/x/models/qwen3_5_moe/qwen3_5_moe.go
+++ b/x/models/qwen3_5_moe/qwen3_5_moe.go
@@ -1,0 +1,16 @@
+//go:build mlx
+
+// Package qwen3_5_moe registers Qwen 3.5 MoE architecture aliases.
+package qwen3_5_moe
+
+import (
+	"github.com/ollama/ollama/x/mlxrunner/model/base"
+	"github.com/ollama/ollama/x/models/qwen3_5"
+)
+
+func init() {
+	base.Register("Qwen3_5MoeForConditionalGeneration", qwen3_5.NewModel)
+	base.Register("Qwen3_5MoeForCausalLM", qwen3_5.NewModel)
+	base.Register("Qwen3NextMoeForConditionalGeneration", qwen3_5.NewModel)
+	base.Register("Qwen3NextMoeForCausalLM", qwen3_5.NewModel)
+}


### PR DESCRIPTION
This change:
  * adds support for qwen3.5-next-moe models (qwen3-next/qwen3.5-next/qwen3-coder) to the MLX runner
  * introduces recurrent cache support and related MLX ops
  * updates pipeline/runner integration and adds tests