### PR TITLE
mlx: remove noisy error output from dynamic library loading

### DIFF
--- a/x/mlxrunner/mlx/dynamic.c
+++ b/x/mlxrunner/mlx/dynamic.c
@@ -18,7 +18,9 @@
 
 static int mlx_dynamic_open(mlx_dynamic_handle* handle, const char* path) {
     handle->ctx = (void*) DLOPEN(path);
-    CHECK(handle->ctx != NULL);
+    if (handle->ctx == NULL) {
+        return 1;
+    }
     return 0;
 }
 


### PR DESCRIPTION
The recent change in #14322 added tryLoadByName() which attempts to load libmlxc.dylib via rpath before searching directories. This is an optimization for Homebrew installations where rpath is correctly set.

However, when rpath isn't set (which is the common case for app bundle installations), dlopen fails and the CHECK macro prints an error to stderr:

  ERROR - dynamic.c:21 - CHECK failed: handle->ctx != NULL

This error is misleading because it's an expected failure path - the code correctly falls back to searching the executable directory and loads the library successfully. The error message causes user confusion and makes it appear that something is broken.

Replace the CHECK macro with a simple return code so the C code fails silently. The Go code already handles error logging appropriately: tryLoadByName() fails silently (intentional fallback), while tryLoadFromDir() logs via slog.Error() when explicit path loading fails.