### PR TITLE
ci: add explicit least-privilege workflow permissions

### DIFF
--- a/.github/workflows/latest.yaml
+++ b/.github/workflows/latest.yaml
@@ -4,6 +4,9 @@ on:
   release:
     types: [released]
 
+permissions:
+  contents: read
+
 jobs:
   update-latest:
     environment: release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,9 @@ env:
   CGO_CFLAGS: '-O3'
   CGO_CXXFLAGS: '-O3'
 
+permissions:
+  contents: read
+
 jobs:
   setup-environment:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-install.yaml
+++ b/.github/workflows/test-install.yaml
@@ -6,6 +6,9 @@ on:
       - 'scripts/install.sh'
       - '.github/workflows/test-install.yaml'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,9 @@ on:
       - '!docs/**'
       - '!README.md'
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add explicit top-level workflow token permissions (`contents: read`) to:
  - `.github/workflows/test.yaml`
  - `.github/workflows/test-install.yaml`
  - `.github/workflows/latest.yaml`
  - `.github/workflows/release.yaml`
- keep release publishing behavior intact by preserving the existing job-level `contents: write` override in the `release` job

## Why
These workflows currently inherit repository default `GITHUB_TOKEN` scope. Setting explicit least-privilege defaults reduces blast radius for CI supply-chain incidents while preserving required release permissions.

## Validation
- `rg -n "^permissions:|^\s+contents:\s" .github/workflows/*.yaml`
- inspected `release` job to confirm existing `contents: write` remains in place for release publishing
