### PR TITLE
doc: correct instructions for Goose CLI and Goose Desktop

### DIFF
--- a/docs/integrations/goose.mdx
+++ b/docs/integrations/goose.mdx
@@ -21,8 +21,9 @@ Install [Goose](https://block.github.io/goose/docs/getting-started/installation/
 
 ### Connecting to ollama.com
 
-1. Create an [API key](https://ollama.com/settings/keys) on ollama.com and save it in your `.env` 
-2. In Goose, set **API Host** to `https://ollama.com`
+1. Create an [API key](https://ollama.com/settings/keys) on ollama.com.
+2. Sign in with `ollama signin`, or `export OLLAMA_API_KEY=xxxxxxxxxxxxxxxx` in a `.env` file that is sourced before `ollama serve`
+2. In Goose, set **API Host** to `http://localhost:11434` (the local `ollama` will proxy it)
 
 
 ## Goose CLI
@@ -43,7 +44,7 @@ Install [Goose](https://block.github.io/goose/docs/getting-started/installation/
 
 ### Connecting to ollama.com
 
-1. Create an [API key](https://ollama.com/settings/keys) on ollama.com and save it in your `.env` 
-2. Run `goose configure`
+1. Create an [API key](https://ollama.com/settings/keys) on ollama.com.
+2. Sign in with `ollama signin`, or `export OLLAMA_API_KEY=xxxxxxxxxxxxxxxx` in a `.env` file that is sourced before `ollama serve`2. Run `goose configure`
 3. Select **Configure Providers** and select **Ollama**
-4. Update **OLLAMA_HOST** to `https://ollama.com`
+4. Update **OLLAMA_HOST** to `http://localhost:11434`


### PR DESCRIPTION
Goose only works with Ollama Cloud by proxying it through local `ollama serve`.

Goose does NOT support `OLLAMA_API_KEY`.
It does NOT use any `.env` (config is at `~/.config/goose/config.yaml` and keys are stored in the OS keychain). Ollama Cloud MUST be proxied through the local ollama instance via `ollama serve`.

None of the _OpenAi_, _Ollama_, nor _Custom Provider_ options work with Ollama Cloud directly in any configuration that I was able to test.

Here are some of those flows for reference:

<img width="1052" height="912" alt="Screenshot 2026-02-23 at 8 33 11 PM" src="https://github.com/user-attachments/assets/4f586bea-b6a4-472a-a5eb-7b554132116f" />

<img width="1524" height="1444" alt="image" src="https://github.com/user-attachments/assets/a4c6e540-d853-4570-95ec-7612dafc98ee" />

Trying with any option other than Ollama and `localhost` lead to authentication errors.

In once case I did have a single working session using Custom Provider in the terminal, but when opening in Goose Desktop, or a second Goose CLI instance, it had the authentication errors.