### PR TITLE
envconfig: return defaultValue on invalid boolean env var

### DIFF
--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -156,7 +156,8 @@ func BoolWithDefault(k string) func(defaultValue bool) bool {
 		if s := Var(k); s != "" {
 			b, err := strconv.ParseBool(s)
 			if err != nil {
-				return true
+				slog.Warn("invalid boolean value, using default", "key", k, "value", s, "default", defaultValue)
+				return defaultValue
 			}
 
 			return b


### PR DESCRIPTION
## Problem

`BoolWithDefault` returns hardcoded `true` when `strconv.ParseBool` fails to parse the environment variable value, instead of returning `defaultValue`:

```go
b, err := strconv.ParseBool(s)
if err != nil {
    return true  // bug: should be defaultValue
}
```

`strconv.ParseBool` only accepts `"1"`, `"0"`, `"t"`, `"f"`, `"true"`, `"false"`, `"True"`, `"False"`, `"TRUE"`, `"FALSE"`. Any other value — including the common `"yes"`, `"on"`, `"enabled"` — triggers the bug and **silently enables** boolean feature flags like `OLLAMA_FLASH_ATTENTION`, `OLLAMA_NEW_ENGINE`, etc.

Fixes #14389

## Fix

- `return true` → `return defaultValue` so the caller's intended default is respected
- Add `slog.Warn` to notify users of the misconfigured value, consistent with how `Uint` handles invalid input (see `envconfig/config.go:238`)

## Tests

- Updated `TestBool` to correct the expected values for invalid inputs (`"random"`, `"something"`) and added new cases for the most common invalid strings: `"yes"`, `"on"`, `"enabled"`
- Added `TestBoolWithDefault` which explicitly tests both `true` and `false` defaults with invalid input values — something `TestBool` couldn't cover since `Bool` always uses `false` as the default