### PR TITLE
cmd/config: fix openclaw api field to use openai-completions

### DIFF
--- a/cmd/config/openclaw.go
+++ b/cmd/config/openclaw.go
@@ -505,7 +505,7 @@ func (c *Openclaw) Edit(models []string) error {
 	ollama["baseUrl"] = envconfig.Host().String() + "/v1"
 	// needed to register provider
 	ollama["apiKey"] = "ollama-local"
-	ollama["api"] = "ollama"
+	ollama["api"] = "openai-completions"
 
 	// Build map of existing models to preserve user customizations
 	existingModels, _ := ollama["models"].([]any)


### PR DESCRIPTION
  ## What

  changed the `api` field in the generated OpenClaw config
  from `"openai-completions"` to `"ollama"`. OpenClaw does not recognize
  `"ollama"` as a valid API type, causing `ollama launch openclaw` to
  fail on v0.17.0 with:

      Invalid config at /root/.openclaw/openclaw.json:
      - models.providers.ollama.api: Invalid input

  ## Fix

  Restore the `api` field to `"openai-completions"`, which matches the
  OpenAI-compatible `/v1` endpoint that Ollama exposes.

  ## Steps to reproduce

  1. Install ollama v0.17.0
  2. Run `ollama launch openclaw`
  3. Observe "Invalid input" error for `models.providers.ollama.api`