### PR TITLE
envconfig: fix BoolWithDefault to return defaultValue on parse error

### DIFF
--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -156,7 +156,7 @@ func BoolWithDefault(k string) func(defaultValue bool) bool {
 		if s := Var(k); s != "" {
 			b, err := strconv.ParseBool(s)
 			if err != nil {
-				return true
+				return defaultValue
 			}
 
 			return b

--- a/envconfig/config_test.go
+++ b/envconfig/config_test.go
@@ -158,8 +158,8 @@ func TestBool(t *testing.T) {
 		"1":     true,
 		"0":     false,
 		// invalid values
-		"random":    true,
-		"something": true,
+		"random":    false,
+		"something": false,
 	}
 
 	for k, v := range cases {


### PR DESCRIPTION
`BoolWithDefault` returned `true` for any value that `strconv.ParseBool` couldn't parse, ignoring the caller-supplied default. This meant `Bool` (which passes `false` as the default) would silently enable features when an env var contained a typo or unexpected string.

Now the function returns `defaultValue` on parse failure, so the fallback honours the caller's intent.