### PR TITLE
cmd: config update to use native Ollama API for OpenClaw

### DIFF
--- a/cmd/config/openclaw.go
+++ b/cmd/config/openclaw.go
@@ -502,7 +502,7 @@ func (c *Openclaw) Edit(models []string) error {
 		ollama = make(map[string]any)
 	}
 
-	ollama["baseUrl"] = envconfig.Host().String() + "/v1"
+	ollama["baseUrl"] = envconfig.Host().String()
 	// needed to register provider
 	ollama["apiKey"] = "ollama-local"
 	ollama["api"] = "ollama"

--- a/cmd/config/openclaw_test.go
+++ b/cmd/config/openclaw_test.go
@@ -589,7 +589,7 @@ const testOpenclawFixture = `{
     "providers": {
       "anthropic": {"apiKey": "xxx"},
       "ollama": {
-        "baseUrl": "http://127.0.0.1:11434/v1",
+        "baseUrl": "http://127.0.0.1:11434",
         "models": [{"id": "old-model", "customField": "preserved"}]
       }
     }


### PR DESCRIPTION
**Summary**

- Remove /v1 suffix from the OpenClaw provider baseUrl to use Ollama's native API
(/api/chat) instead of the OpenAI-compatible endpoint (/v1/chat/completions)
- The api field is already set to "ollama", which expects the base URL without /v1

**Context**

The OpenClaw config validator rejects the current configuration with:

```
invalid config at C:\openclaw.json:
  models.providers.ollama.api: invalid input
```

The api: "ollama" type expects a base URL pointing to the native Ollama endpoint (e.g.
http://127.0.0.1:11434), not the OpenAI-compatible /v1 endpoint. The native API also has
 the advantage of properly supporting streaming with tool calls, which the
OpenAI-compatible endpoint drops ([openclaw#11828](https://github.com/openclaw/openclaw/issues/11828)).