### PR TITLE
fix: return defaultValue on parse error in BoolWithDefault

### DIFF
--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -156,7 +156,7 @@ func BoolWithDefault(k string) func(defaultValue bool) bool {
 		if s := Var(k); s != "" {
 			b, err := strconv.ParseBool(s)
 			if err != nil {
-				return true
+				return defaultValue
 			}
 
 			return b


### PR DESCRIPTION
Fixes #14389

`BoolWithDefault` returns `true` when `strconv.ParseBool` fails to parse the environment variable value, instead of returning `defaultValue`. This causes boolean feature flags to be silently enabled when a user sets an env var to a common-but-invalid string like `"yes"`, `"on"`, or `"enabled"`.

The fix changes the error fallback from `return true` to `return defaultValue`, which is the intended behavior.