### PR TITLE
fix(openai): coerce unsupported think levels for openai-compat chat

### DIFF
--- a/middleware/openai.go
+++ b/middleware/openai.go
@@ -416,6 +416,8 @@ func ChatMiddleware() gin.HandlerFunc {
 			return
 		}
 
+		c.Set("openai_compat", true)
+
 		if err := json.NewEncoder(&b).Encode(chatReq); err != nil {
 			c.AbortWithStatusJSON(http.StatusInternalServerError, openai.NewError(http.StatusInternalServerError, err.Error()))
 			return

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -582,6 +582,10 @@ func FromChatRequest(r ChatCompletionRequest) (*api.ChatRequest, error) {
 	var think *api.ThinkValue
 	var effort string
 
+	if r.Reasoning != nil && r.ReasoningEffort != nil && r.Reasoning.Effort != "" && *r.ReasoningEffort != "" && r.Reasoning.Effort != *r.ReasoningEffort {
+		slog.Warn("reasoning effort mismatch: using reasoning.effort over reasoning_effort", "reasoning_effort", *r.ReasoningEffort, "reasoning.effort", r.Reasoning.Effort)
+	}
+
 	if r.Reasoning != nil {
 		effort = r.Reasoning.Effort
 	} else if r.ReasoningEffort != nil {

--- a/server/routes.go
+++ b/server/routes.go
@@ -93,6 +93,17 @@ type Server struct {
 	aliasesErr    error
 }
 
+func coerceOpenAICompatThink(c *gin.Context, model string, parser string, think *api.ThinkValue) *api.ThinkValue {
+	if think == nil || !think.IsString() || parser == "harmony" {
+		return think
+	}
+	if _, ok := c.Get("openai_compat"); !ok {
+		return think
+	}
+	slog.Warn("coercing unsupported think level to boolean for openai compatibility", "model", model, "parser", parser, "think", think.String())
+	return &api.ThinkValue{Value: true}
+}
+
 func init() {
 	switch mode {
 	case gin.DebugMode:
@@ -369,6 +380,8 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 			builtinParser.Init(nil, nil, req.Think)
 		}
 	}
+
+	req.Think = coerceOpenAICompatThink(c, req.Model, m.Config.Parser, req.Think)
 
 	// Validate Think value: string values currently only allowed for harmony/gptoss models
 	if req.Think != nil && req.Think.IsString() && m.Config.Parser != "harmony" {
@@ -2232,6 +2245,8 @@ func (s *Server) ChatHandler(c *gin.Context) {
 		})
 		return
 	}
+
+	req.Think = coerceOpenAICompatThink(c, req.Model, m.Config.Parser, req.Think)
 
 	// Validate Think value: string values currently only allowed for harmony/gptoss models
 	if req.Think != nil && req.Think.IsString() && m.Config.Parser != "harmony" {


### PR DESCRIPTION
## Summary
- Set an `openai_compat` request context flag in OpenAI chat middleware and add parser-aware coercion in `ChatHandler`/`GenerateHandler` via `coerceOpenAICompatThink`.
- Coerce non-harmony string think levels (`high|medium|low`) to boolean `true` only for OpenAI-compatible requests, preserving strict behavior for native API requests.
- Add coverage for reasoning precedence conversion, OpenAI middleware context flagging, and coercion helper behavior in server tests.

## Why
OpenAI-compatible `/v1/chat/completions` requests currently map `reasoning_effort: \"high\"` to a string `think` value, but boolean-only thinking models reject string think levels with `think value \"high\" is not supported for this model`.

This change keeps GPT-OSS/harmony level semantics intact while making boolean-only models treat level effort intent as "thinking enabled" in the OpenAI-compat path.

## Validation
- `go test ./openai -run "FromChatRequest|Reasoning|Think" -v`
- `go test ./middleware -run "ChatMiddleware|OpenAICompat" -v`
- `go test ./server -run "TestCoerceOpenAICompatThink|TestGenerateChat/missing_thinking_capability" -v`
- Manual runtime check on patched build (`qwen3:8b`):
  - `reasoning_effort: \"high\"` now succeeds (previously failed)
  - `reasoning_effort: \"none\"` still disables thinking
  - omitted effort still uses default thinking behavior

## Related
- ollama/ollama#12004
- ollama/ollama#12561