### PR TITLE
feat: Add optional keepalive heartbeats for streaming endpoints

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -83,6 +83,9 @@ type GenerateRequest struct {
 	// Stream specifies whether the response is streaming; it is true by default.
 	Stream *bool `json:"stream,omitempty"`
 
+	// StreamOptions controls streaming keepalive behavior.
+	StreamOptions *StreamOptions `json:"stream_options,omitempty"`
+
 	// Raw set to true means that no formatting will be applied to the prompt.
 	Raw bool `json:"raw,omitempty"`
 
@@ -154,6 +157,9 @@ type ChatRequest struct {
 	// Stream enables streaming of returned responses; true by default.
 	Stream *bool `json:"stream,omitempty"`
 
+	// StreamOptions controls streaming keepalive behavior.
+	StreamOptions *StreamOptions `json:"stream_options,omitempty"`
+
 	// Format is the format to return the response in (e.g. "json").
 	Format json.RawMessage `json:"format,omitempty"`
 
@@ -194,6 +200,13 @@ type ChatRequest struct {
 }
 
 type Tools []Tool
+
+// StreamOptions controls optional behavior for streaming responses.
+type StreamOptions struct {
+	// HeartbeatMS controls server-side stream keepalive frequency in milliseconds.
+	// If omitted, the server default is used. Values <= 0 disable keepalives.
+	HeartbeatMS *int `json:"heartbeat_ms,omitempty"`
+}
 
 func (t Tools) String() string {
 	bts, _ := json.Marshal(t)

--- a/docs/api.md
+++ b/docs/api.md
@@ -32,6 +32,8 @@ All durations are returned in nanoseconds.
 
 Certain endpoints stream responses as JSON objects. Streaming can be disabled by providing `{"stream": false}` for these endpoints.
 
+To mitigate browser and WebView idle timeouts during long quiet model phases, streaming endpoints can emit keepalive chunks when no model output has been sent for a period of time. Configure this with `stream_options.heartbeat_ms` (milliseconds). If omitted, the server default is `10000` ms. Values `<= 0` disable keepalives.
+
 ## Generate a completion
 
 ```
@@ -55,6 +57,8 @@ Advanced parameters (optional):
 - `system`: system message to (overrides what is defined in the `Modelfile`)
 - `template`: the prompt template to use (overrides what is defined in the `Modelfile`)
 - `stream`: if `false` the response will be returned as a single response object, rather than a stream of objects
+- `stream_options`: options for streaming behavior
+  - `heartbeat_ms`: keepalive interval in milliseconds for idle streaming gaps (default `10000`, values `<=0` disable)
 - `raw`: if `true` no formatting will be applied to the prompt. You may choose to use the `raw` parameter if you are specifying a full templated prompt in your request to the API
 - `keep_alive`: controls how long the model will stay loaded into memory following the request (default: `5m`)
 - `context` (deprecated): the context parameter returned from a previous request to `/generate`, this can be used to keep a short conversational memory
@@ -519,6 +523,8 @@ Advanced parameters (optional):
 - `format`: the format to return a response in. Format can be `json` or a JSON schema.
 - `options`: additional model parameters listed in the documentation for the [Modelfile](./modelfile.mdx#valid-parameters-and-values) such as `temperature`
 - `stream`: if `false` the response will be returned as a single response object, rather than a stream of objects
+- `stream_options`: options for streaming behavior
+  - `heartbeat_ms`: keepalive interval in milliseconds for idle streaming gaps (default `10000`, values `<=0` disable)
 - `keep_alive`: controls how long the model will stay loaded into memory following the request (default: `5m`)
 
 ### Tool calling

--- a/docs/api/openai-compatibility.mdx
+++ b/docs/api/openai-compatibility.mdx
@@ -203,6 +203,7 @@ curl -X POST http://localhost:11434/v1/chat/completions \
 - [x] `stream`
 - [x] `stream_options`
   - [x] `include_usage`
+  - [x] `heartbeat_ms`
 - [x] `temperature`
 - [x] `top_p`
 - [x] `max_tokens`
@@ -233,6 +234,7 @@ curl -X POST http://localhost:11434/v1/chat/completions \
 - [x] `stream`
 - [x] `stream_options`
   - [x] `include_usage`
+  - [x] `heartbeat_ms`
 - [x] `temperature`
 - [x] `top_p`
 - [x] `max_tokens`

--- a/docs/api/streaming.mdx
+++ b/docs/api/streaming.mdx
@@ -14,6 +14,8 @@ Certain API endpoints stream responses by default, such as `/api/generate`. Thes
 {"model":"gemma3","created_at":"2025-10-26T17:15:24.166576Z","response":"!","done":true, "done_reason": "stop"}
 ```
 
+To reduce browser and WebView idle timeout failures, streaming endpoints can send keepalive chunks when output is quiet. Configure this per request with `stream_options.heartbeat_ms` (milliseconds). If not set, the default is `10000`; values `<= 0` disable keepalives.
+
 ## Disabling streaming
 
 Streaming can be disabled by providing `{"stream": false}` in the request body for any endpoint that support streaming. This will cause responses to be returned in the `application/json` format instead:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -65,6 +65,13 @@ components:
           type: integer
           description: Maximum number of tokens to generate
       additionalProperties: true
+    StreamOptions:
+      type: object
+      description: Optional controls for streaming responses
+      properties:
+        heartbeat_ms:
+          type: integer
+          description: Keepalive interval in milliseconds for idle streaming gaps (default 10000, values <=0 disable)
     GenerateRequest:
       type: object
       required: [model]
@@ -95,6 +102,8 @@ components:
           description: When true, returns a stream of partial responses
           type: boolean
           default: true
+        stream_options:
+          $ref: "#/components/schemas/StreamOptions"
         think:
           oneOf:
             - type: boolean
@@ -287,6 +296,8 @@ components:
         stream:
           type: boolean
           default: true
+        stream_options:
+          $ref: "#/components/schemas/StreamOptions"
         think:
           oneOf:
             - type: boolean

--- a/envconfig/config_test.go
+++ b/envconfig/config_test.go
@@ -262,6 +262,28 @@ func TestLoadTimeout(t *testing.T) {
 	}
 }
 
+func TestStreamHeartbeatMS(t *testing.T) {
+	cases := map[string]int{
+		"":      10000,
+		"1000":  1000,
+		"0":     0,
+		"-1":    -1,
+		"25000": 25000,
+		// invalid values fall back to default
+		"abc": 10000,
+		"1s":  10000,
+	}
+
+	for tt, expect := range cases {
+		t.Run(tt, func(t *testing.T) {
+			t.Setenv("OLLAMA_STREAM_HEARTBEAT_MS", tt)
+			if actual := StreamHeartbeatMS(); actual != expect {
+				t.Errorf("%s: expected %d, got %d", tt, expect, actual)
+			}
+		})
+	}
+}
+
 func TestVar(t *testing.T) {
 	cases := map[string]string{
 		"value":       "value",

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -89,6 +89,7 @@ type EmbedRequest struct {
 
 type StreamOptions struct {
 	IncludeUsage bool `json:"include_usage"`
+	HeartbeatMS  *int `json:"heartbeat_ms,omitempty"`
 }
 
 type Reasoning struct {
@@ -601,11 +602,20 @@ func FromChatRequest(r ChatCompletionRequest) (*api.ChatRequest, error) {
 	}
 
 	return &api.ChatRequest{
-		Model:           r.Model,
-		Messages:        messages,
-		Format:          format,
-		Options:         options,
-		Stream:          &r.Stream,
+		Model:    r.Model,
+		Messages: messages,
+		Format:   format,
+		Options:  options,
+		Stream:   &r.Stream,
+		StreamOptions: func() *api.StreamOptions {
+			if r.StreamOptions == nil || r.StreamOptions.HeartbeatMS == nil {
+				return nil
+			}
+
+			return &api.StreamOptions{
+				HeartbeatMS: r.StreamOptions.HeartbeatMS,
+			}
+		}(),
 		Tools:           r.Tools,
 		Think:           think,
 		Logprobs:        r.Logprobs != nil && *r.Logprobs,
@@ -727,10 +737,19 @@ func FromCompleteRequest(r CompletionRequest) (api.GenerateRequest, error) {
 	}
 
 	return api.GenerateRequest{
-		Model:           r.Model,
-		Prompt:          r.Prompt,
-		Options:         options,
-		Stream:          &r.Stream,
+		Model:   r.Model,
+		Prompt:  r.Prompt,
+		Options: options,
+		Stream:  &r.Stream,
+		StreamOptions: func() *api.StreamOptions {
+			if r.StreamOptions == nil || r.StreamOptions.HeartbeatMS == nil {
+				return nil
+			}
+
+			return &api.StreamOptions{
+				HeartbeatMS: r.StreamOptions.HeartbeatMS,
+			}
+		}(),
 		Suffix:          r.Suffix,
 		Logprobs:        logprobs,
 		TopLogprobs:     topLogprobs,

--- a/openai/openai_test.go
+++ b/openai/openai_test.go
@@ -531,3 +531,55 @@ func TestFromImageEditRequest_InvalidImage(t *testing.T) {
 		t.Error("expected error for invalid image")
 	}
 }
+
+func TestFromChatRequest_StreamHeartbeatOption(t *testing.T) {
+	heartbeat := 250
+	req := ChatCompletionRequest{
+		Model: "test-model",
+		Messages: []Message{
+			{Role: "user", Content: "Hello"},
+		},
+		Stream: true,
+		StreamOptions: &StreamOptions{
+			HeartbeatMS: &heartbeat,
+		},
+	}
+
+	result, err := FromChatRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.StreamOptions == nil || result.StreamOptions.HeartbeatMS == nil {
+		t.Fatal("expected stream heartbeat option to be mapped")
+	}
+
+	if *result.StreamOptions.HeartbeatMS != heartbeat {
+		t.Fatalf("expected heartbeat %d, got %d", heartbeat, *result.StreamOptions.HeartbeatMS)
+	}
+}
+
+func TestFromCompleteRequest_StreamHeartbeatOption(t *testing.T) {
+	heartbeat := 500
+	req := CompletionRequest{
+		Model:  "test-model",
+		Prompt: "Hello",
+		Stream: true,
+		StreamOptions: &StreamOptions{
+			HeartbeatMS: &heartbeat,
+		},
+	}
+
+	result, err := FromCompleteRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.StreamOptions == nil || result.StreamOptions.HeartbeatMS == nil {
+		t.Fatal("expected stream heartbeat option to be mapped")
+	}
+
+	if *result.StreamOptions.HeartbeatMS != heartbeat {
+		t.Fatalf("expected heartbeat %d, got %d", heartbeat, *result.StreamOptions.HeartbeatMS)
+	}
+}

--- a/server/routes.go
+++ b/server/routes.go
@@ -282,53 +282,101 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 			slog.Warn("embedded messages in the model not supported with '/api/generate'; try '/api/chat' instead")
 		}
 
+		isStreaming := req.Stream == nil || *req.Stream
 		contentType := "application/x-ndjson"
-		if req.Stream != nil && !*req.Stream {
+		if !isStreaming {
 			contentType = "application/json; charset=utf-8"
 		}
 		c.Header("Content-Type", contentType)
 
-		fn := func(resp api.GenerateResponse) error {
-			resp.Model = origModel
-			resp.RemoteModel = m.Config.RemoteModel
-			resp.RemoteHost = m.Config.RemoteHost
-
-			data, err := json.Marshal(resp)
-			if err != nil {
-				return err
-			}
-
-			if _, err = c.Writer.Write(append(data, '\n')); err != nil {
-				return err
-			}
-			c.Writer.Flush()
-			return nil
-		}
-
 		client := api.NewClient(remoteURL, http.DefaultClient)
-		err = client.Generate(c, &req, fn)
-		if err != nil {
-			var authError api.AuthorizationError
-			if errors.As(err, &authError) {
-				sURL, sErr := signinURL()
-				if sErr != nil {
-					slog.Error(sErr.Error())
-					c.JSON(http.StatusInternalServerError, gin.H{"error": "error getting authorization details"})
-					return
+		if !isStreaming {
+			fn := func(resp api.GenerateResponse) error {
+				resp.Model = origModel
+				resp.RemoteModel = m.Config.RemoteModel
+				resp.RemoteHost = m.Config.RemoteHost
+
+				data, err := json.Marshal(resp)
+				if err != nil {
+					return err
 				}
 
-				c.JSON(authError.StatusCode, gin.H{"error": "unauthorized", "signin_url": sURL})
+				if _, err = c.Writer.Write(append(data, '\n')); err != nil {
+					return err
+				}
+				c.Writer.Flush()
+				return nil
+			}
+
+			err = client.Generate(c, &req, fn)
+			if err != nil {
+				var authError api.AuthorizationError
+				if errors.As(err, &authError) {
+					sURL, sErr := signinURL()
+					if sErr != nil {
+						slog.Error(sErr.Error())
+						c.JSON(http.StatusInternalServerError, gin.H{"error": "error getting authorization details"})
+						return
+					}
+
+					c.JSON(authError.StatusCode, gin.H{"error": "unauthorized", "signin_url": sURL})
+					return
+				}
+				var apiError api.StatusError
+				if errors.As(err, &apiError) {
+					c.JSON(apiError.StatusCode, apiError)
+					return
+				}
+				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 				return
 			}
-			var apiError api.StatusError
-			if errors.As(err, &apiError) {
-				c.JSON(apiError.StatusCode, apiError)
-				return
-			}
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+
 			return
 		}
 
+		ctx := c.Request.Context()
+		ch := make(chan any)
+		go func() {
+			defer close(ch)
+
+			fn := func(resp api.GenerateResponse) error {
+				resp.Model = origModel
+				resp.RemoteModel = m.Config.RemoteModel
+				resp.RemoteHost = m.Config.RemoteHost
+				if !sendStreamItem(ctx, ch, resp) {
+					return context.Canceled
+				}
+				return nil
+			}
+
+			if err := client.Generate(c, &req, fn); err != nil {
+				var authError api.AuthorizationError
+				if errors.As(err, &authError) {
+					sURL, sErr := signinURL()
+					if sErr != nil {
+						slog.Error(sErr.Error())
+						sendStreamItem(ctx, ch, gin.H{"error": "error getting authorization details", "status": http.StatusInternalServerError})
+						return
+					}
+
+					sendStreamItem(ctx, ch, gin.H{"error": "unauthorized", "signin_url": sURL, "status": authError.StatusCode})
+					return
+				}
+
+				var apiError api.StatusError
+				if errors.As(err, &apiError) {
+					sendStreamItem(ctx, ch, gin.H{"error": apiError.ErrorMessage, "status": apiError.StatusCode})
+					return
+				}
+
+				sendStreamItem(ctx, ch, gin.H{"error": err.Error()})
+			}
+		}()
+
+		streamResponseWithOptions(c, ch, streamResponseOptions{
+			heartbeatInterval: streamHeartbeatInterval(req.StreamOptions),
+			heartbeatValue:    generateHeartbeatValue(origModel),
+		})
 		return
 	}
 
@@ -659,7 +707,10 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 		return
 	}
 
-	streamResponse(c, ch)
+	streamResponseWithOptions(c, ch, streamResponseOptions{
+		heartbeatInterval: streamHeartbeatInterval(req.StreamOptions),
+		heartbeatValue:    generateHeartbeatValue(req.Model),
+	})
 }
 
 func (s *Server) EmbedHandler(c *gin.Context) {
@@ -1804,53 +1855,162 @@ func waitForStream(c *gin.Context, ch chan any) {
 	c.JSON(http.StatusOK, latest)
 }
 
+type streamResponseOptions struct {
+	heartbeatInterval time.Duration
+	heartbeatValue    func() any
+}
+
+func streamHeartbeatInterval(options *api.StreamOptions) time.Duration {
+	ms := envconfig.StreamHeartbeatMS()
+	if options != nil && options.HeartbeatMS != nil {
+		ms = *options.HeartbeatMS
+	}
+
+	if ms <= 0 {
+		return 0
+	}
+
+	return time.Duration(ms) * time.Millisecond
+}
+
+func chatHeartbeatValue(model string) func() any {
+	return func() any {
+		return api.ChatResponse{
+			Model:     model,
+			CreatedAt: time.Now().UTC(),
+			Message:   api.Message{Role: "assistant"},
+			Done:      false,
+		}
+	}
+}
+
+func generateHeartbeatValue(model string) func() any {
+	return func() any {
+		return api.GenerateResponse{
+			Model:     model,
+			CreatedAt: time.Now().UTC(),
+			Done:      false,
+		}
+	}
+}
+
 func streamResponse(c *gin.Context, ch chan any) {
-	c.Header("Content-Type", "application/x-ndjson")
-	c.Stream(func(w io.Writer) bool {
-		val, ok := <-ch
-		if !ok {
-			return false
-		}
+	streamResponseWithOptions(c, ch, streamResponseOptions{})
+}
 
-		// errors are provided as a gin.H with an "error" field and
-		// an optional "status" field.  For errors that are streamed
-		// before any content, we need to set the status code and
-		// content type for the error.
-		if h, ok := val.(gin.H); ok {
-			if e, ok := h["error"].(string); ok {
-				status, ok := h["status"].(int)
-				if !ok {
-					status = http.StatusInternalServerError
-				}
-
-				if !c.Writer.Written() {
-					c.Header("Content-Type", "application/json")
-					c.JSON(status, gin.H{"error": e})
-				} else {
-					if err := json.NewEncoder(c.Writer).Encode(gin.H{"error": e}); err != nil {
-						slog.Error("streamResponse failed to encode json error", "error", err)
-					}
-				}
-
-				return false
-			}
-		}
-
-		bts, err := json.Marshal(val)
-		if err != nil {
-			slog.Info(fmt.Sprintf("streamResponse: json.Marshal failed with %s", err))
-			return false
-		}
-
-		// Delineate chunks with new-line delimiter
-		bts = append(bts, '\n')
-		if _, err := w.Write(bts); err != nil {
-			slog.Info(fmt.Sprintf("streamResponse: w.Write failed with %s", err))
-			return false
-		}
-
+func sendStreamItem(ctx context.Context, ch chan<- any, val any) bool {
+	select {
+	case ch <- val:
 		return true
-	})
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func writeStreamValue(c *gin.Context, val any) bool {
+	w := c.Writer
+
+	// errors are provided as a gin.H with an "error" field and
+	// an optional "status" field. For errors that are streamed
+	// before any content, we need to set the status code and
+	// content type for the error.
+	if h, ok := val.(gin.H); ok {
+		if e, ok := h["error"].(string); ok {
+			status, ok := h["status"].(int)
+			if !ok {
+				status = http.StatusInternalServerError
+			}
+
+			payload := gin.H{"error": e}
+			if signinURL, ok := h["signin_url"].(string); ok {
+				payload["signin_url"] = signinURL
+			}
+
+			if !c.Writer.Written() {
+				c.Header("Content-Type", "application/json")
+				c.JSON(status, payload)
+			} else {
+				if err := json.NewEncoder(c.Writer).Encode(payload); err != nil {
+					slog.Error("streamResponse failed to encode json error", "error", err)
+				}
+				w.Flush()
+			}
+
+			return false
+		}
+	}
+
+	bts, err := json.Marshal(val)
+	if err != nil {
+		slog.Info(fmt.Sprintf("streamResponse: json.Marshal failed with %s", err))
+		return false
+	}
+
+	// Delineate chunks with new-line delimiter
+	bts = append(bts, '\n')
+	if _, err := w.Write(bts); err != nil {
+		slog.Info(fmt.Sprintf("streamResponse: w.Write failed with %s", err))
+		return false
+	}
+	w.Flush()
+
+	return true
+}
+
+func streamResponseWithOptions(c *gin.Context, ch <-chan any, opts streamResponseOptions) {
+	c.Header("Content-Type", "application/x-ndjson")
+
+	ctx := context.Background()
+	if c.Request != nil {
+		ctx = c.Request.Context()
+	}
+
+	lastRealOutputAt := time.Now()
+	lastWriteAt := lastRealOutputAt
+
+	var heartbeat *time.Ticker
+	if opts.heartbeatInterval > 0 && opts.heartbeatValue != nil {
+		heartbeat = time.NewTicker(opts.heartbeatInterval)
+		defer heartbeat.Stop()
+	}
+
+	for {
+		var heartbeatC <-chan time.Time
+		if heartbeat != nil {
+			heartbeatC = heartbeat.C
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-heartbeatC:
+			if heartbeat == nil {
+				continue
+			}
+
+			now := time.Now()
+			if now.Sub(lastRealOutputAt) < opts.heartbeatInterval || now.Sub(lastWriteAt) < opts.heartbeatInterval {
+				continue
+			}
+
+			if !writeStreamValue(c, opts.heartbeatValue()) {
+				return
+			}
+			lastWriteAt = time.Now()
+		case val, ok := <-ch:
+			if !ok {
+				return
+			}
+
+			if !writeStreamValue(c, val) {
+				return
+			}
+
+			now := time.Now()
+			lastRealOutputAt = now
+			lastWriteAt = now
+		}
+	}
 }
 
 func (s *Server) StatusHandler(c *gin.Context) {
@@ -2090,53 +2250,101 @@ func (s *Server) ChatHandler(c *gin.Context) {
 			}
 		}
 
+		isStreaming := req.Stream == nil || *req.Stream
 		contentType := "application/x-ndjson"
-		if req.Stream != nil && !*req.Stream {
+		if !isStreaming {
 			contentType = "application/json; charset=utf-8"
 		}
 		c.Header("Content-Type", contentType)
 
-		fn := func(resp api.ChatResponse) error {
-			resp.Model = origModel
-			resp.RemoteModel = m.Config.RemoteModel
-			resp.RemoteHost = m.Config.RemoteHost
-
-			data, err := json.Marshal(resp)
-			if err != nil {
-				return err
-			}
-
-			if _, err = c.Writer.Write(append(data, '\n')); err != nil {
-				return err
-			}
-			c.Writer.Flush()
-			return nil
-		}
-
 		client := api.NewClient(remoteURL, http.DefaultClient)
-		err = client.Chat(c, &req, fn)
-		if err != nil {
-			var authError api.AuthorizationError
-			if errors.As(err, &authError) {
-				sURL, sErr := signinURL()
-				if sErr != nil {
-					slog.Error(sErr.Error())
-					c.JSON(http.StatusInternalServerError, gin.H{"error": "error getting authorization details"})
-					return
+		if !isStreaming {
+			fn := func(resp api.ChatResponse) error {
+				resp.Model = origModel
+				resp.RemoteModel = m.Config.RemoteModel
+				resp.RemoteHost = m.Config.RemoteHost
+
+				data, err := json.Marshal(resp)
+				if err != nil {
+					return err
 				}
 
-				c.JSON(authError.StatusCode, gin.H{"error": "unauthorized", "signin_url": sURL})
+				if _, err = c.Writer.Write(append(data, '\n')); err != nil {
+					return err
+				}
+				c.Writer.Flush()
+				return nil
+			}
+
+			err = client.Chat(c, &req, fn)
+			if err != nil {
+				var authError api.AuthorizationError
+				if errors.As(err, &authError) {
+					sURL, sErr := signinURL()
+					if sErr != nil {
+						slog.Error(sErr.Error())
+						c.JSON(http.StatusInternalServerError, gin.H{"error": "error getting authorization details"})
+						return
+					}
+
+					c.JSON(authError.StatusCode, gin.H{"error": "unauthorized", "signin_url": sURL})
+					return
+				}
+				var apiError api.StatusError
+				if errors.As(err, &apiError) {
+					c.JSON(apiError.StatusCode, apiError)
+					return
+				}
+				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 				return
 			}
-			var apiError api.StatusError
-			if errors.As(err, &apiError) {
-				c.JSON(apiError.StatusCode, apiError)
-				return
-			}
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+
 			return
 		}
 
+		ctx := c.Request.Context()
+		ch := make(chan any)
+		go func() {
+			defer close(ch)
+
+			fn := func(resp api.ChatResponse) error {
+				resp.Model = origModel
+				resp.RemoteModel = m.Config.RemoteModel
+				resp.RemoteHost = m.Config.RemoteHost
+				if !sendStreamItem(ctx, ch, resp) {
+					return context.Canceled
+				}
+				return nil
+			}
+
+			if err := client.Chat(c, &req, fn); err != nil {
+				var authError api.AuthorizationError
+				if errors.As(err, &authError) {
+					sURL, sErr := signinURL()
+					if sErr != nil {
+						slog.Error(sErr.Error())
+						sendStreamItem(ctx, ch, gin.H{"error": "error getting authorization details", "status": http.StatusInternalServerError})
+						return
+					}
+
+					sendStreamItem(ctx, ch, gin.H{"error": "unauthorized", "signin_url": sURL, "status": authError.StatusCode})
+					return
+				}
+
+				var apiError api.StatusError
+				if errors.As(err, &apiError) {
+					sendStreamItem(ctx, ch, gin.H{"error": apiError.ErrorMessage, "status": apiError.StatusCode})
+					return
+				}
+
+				sendStreamItem(ctx, ch, gin.H{"error": err.Error()})
+			}
+		}()
+
+		streamResponseWithOptions(c, ch, streamResponseOptions{
+			heartbeatInterval: streamHeartbeatInterval(req.StreamOptions),
+			heartbeatValue:    chatHeartbeatValue(origModel),
+		})
 		return
 	}
 
@@ -2496,7 +2704,10 @@ func (s *Server) ChatHandler(c *gin.Context) {
 		return
 	}
 
-	streamResponse(c, ch)
+	streamResponseWithOptions(c, ch, streamResponseOptions{
+		heartbeatInterval: streamHeartbeatInterval(req.StreamOptions),
+		heartbeatValue:    chatHeartbeatValue(req.Model),
+	})
 }
 
 func handleScheduleError(c *gin.Context, name string, err error) {
@@ -2599,57 +2810,89 @@ func (s *Server) handleImageGenerate(c *gin.Context, req api.GenerateRequest, mo
 		images = append(images, llm.ImageData{ID: i, Data: imgData})
 	}
 
-	var streamStarted bool
 	var finalResponse api.GenerateResponse
+	if !isStreaming {
+		if err := runner.Completion(c.Request.Context(), llm.CompletionRequest{
+			Prompt: req.Prompt,
+			Width:  req.Width,
+			Height: req.Height,
+			Steps:  req.Steps,
+			Seed:   seed,
+			Images: images,
+		}, func(cr llm.CompletionResponse) {
+			res := api.GenerateResponse{
+				Model:     req.Model,
+				CreatedAt: time.Now().UTC(),
+				Done:      cr.Done,
+			}
 
-	if err := runner.Completion(c.Request.Context(), llm.CompletionRequest{
-		Prompt: req.Prompt,
-		Width:  req.Width,
-		Height: req.Height,
-		Steps:  req.Steps,
-		Seed:   seed,
-		Images: images,
-	}, func(cr llm.CompletionResponse) {
-		streamStarted = true
-		res := api.GenerateResponse{
-			Model:     req.Model,
-			CreatedAt: time.Now().UTC(),
-			Done:      cr.Done,
-		}
+			if cr.TotalSteps > 0 {
+				res.Completed = int64(cr.Step)
+				res.Total = int64(cr.TotalSteps)
+			}
 
-		if cr.TotalSteps > 0 {
-			res.Completed = int64(cr.Step)
-			res.Total = int64(cr.TotalSteps)
-		}
+			if cr.Image != "" {
+				res.Image = cr.Image
+			}
 
-		if cr.Image != "" {
-			res.Image = cr.Image
-		}
+			if cr.Done {
+				res.DoneReason = cr.DoneReason.String()
+				res.Metrics.TotalDuration = time.Since(checkpointStart)
+				res.Metrics.LoadDuration = checkpointLoaded.Sub(checkpointStart)
+			}
 
-		if cr.Done {
-			res.DoneReason = cr.DoneReason.String()
-			res.Metrics.TotalDuration = time.Since(checkpointStart)
-			res.Metrics.LoadDuration = checkpointLoaded.Sub(checkpointStart)
-		}
-
-		if !isStreaming {
 			finalResponse = res
+		}); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}
 
-		data, _ := json.Marshal(res)
-		c.Writer.Write(append(data, '\n'))
-		c.Writer.Flush()
-	}); err != nil {
-		// Only send JSON error if streaming hasn't started yet
-		// (once streaming starts, headers are committed and we can't change status code)
-		if !streamStarted {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		}
+		c.JSON(http.StatusOK, finalResponse)
 		return
 	}
 
-	if !isStreaming {
-		c.JSON(http.StatusOK, finalResponse)
-	}
+	ctx := c.Request.Context()
+	ch := make(chan any)
+	go func() {
+		defer close(ch)
+
+		if err := runner.Completion(ctx, llm.CompletionRequest{
+			Prompt: req.Prompt,
+			Width:  req.Width,
+			Height: req.Height,
+			Steps:  req.Steps,
+			Seed:   seed,
+			Images: images,
+		}, func(cr llm.CompletionResponse) {
+			res := api.GenerateResponse{
+				Model:     req.Model,
+				CreatedAt: time.Now().UTC(),
+				Done:      cr.Done,
+			}
+
+			if cr.TotalSteps > 0 {
+				res.Completed = int64(cr.Step)
+				res.Total = int64(cr.TotalSteps)
+			}
+
+			if cr.Image != "" {
+				res.Image = cr.Image
+			}
+
+			if cr.Done {
+				res.DoneReason = cr.DoneReason.String()
+				res.Metrics.TotalDuration = time.Since(checkpointStart)
+				res.Metrics.LoadDuration = checkpointLoaded.Sub(checkpointStart)
+			}
+
+			sendStreamItem(ctx, ch, res)
+		}); err != nil {
+			sendStreamItem(ctx, ch, gin.H{"error": err.Error()})
+		}
+	}()
+
+	streamResponseWithOptions(c, ch, streamResponseOptions{
+		heartbeatInterval: streamHeartbeatInterval(req.StreamOptions),
+		heartbeatValue:    generateHeartbeatValue(req.Model),
+	})
 }

--- a/server/stream_heartbeat_test.go
+++ b/server/stream_heartbeat_test.go
@@ -1,0 +1,212 @@
+package server
+
+import (
+	"bufio"
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/ollama/ollama/api"
+)
+
+func parseGenerateStream(t *testing.T, body string) []api.GenerateResponse {
+	t.Helper()
+
+	var events []api.GenerateResponse
+	scanner := bufio.NewScanner(strings.NewReader(body))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		var event api.GenerateResponse
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			t.Fatalf("failed to decode stream line %q: %v", line, err)
+		}
+		events = append(events, event)
+	}
+
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("failed to scan stream body: %v", err)
+	}
+
+	return events
+}
+
+func TestStreamResponseWithHeartbeat_EmitsDuringSilence(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest("GET", "/", nil)
+
+	ch := make(chan any)
+	done := make(chan struct{})
+	go func() {
+		streamResponseWithOptions(c, ch, streamResponseOptions{
+			heartbeatInterval: 15 * time.Millisecond,
+			heartbeatValue:    generateHeartbeatValue("test"),
+		})
+		close(done)
+	}()
+
+	time.Sleep(55 * time.Millisecond)
+	ch <- api.GenerateResponse{
+		Model:     "test",
+		CreatedAt: time.Now().UTC(),
+		Response:  "hello",
+		Done:      false,
+	}
+	ch <- api.GenerateResponse{
+		Model:      "test",
+		CreatedAt:  time.Now().UTC(),
+		Response:   "",
+		Done:       true,
+		DoneReason: "stop",
+	}
+	close(ch)
+	<-done
+
+	events := parseGenerateStream(t, rec.Body.String())
+	var keepalives int
+	var final int
+	for _, event := range events {
+		if !event.Done && event.Response == "" {
+			keepalives++
+		}
+		if event.Done {
+			final++
+		}
+	}
+
+	if keepalives == 0 {
+		t.Fatalf("expected at least one heartbeat event, got %d events", len(events))
+	}
+	if final != 1 {
+		t.Fatalf("expected exactly one final done event, got %d", final)
+	}
+}
+
+func TestStreamResponseWithHeartbeat_NoKeepaliveWhenFrequent(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest("GET", "/", nil)
+
+	ch := make(chan any)
+	done := make(chan struct{})
+	go func() {
+		streamResponseWithOptions(c, ch, streamResponseOptions{
+			heartbeatInterval: 40 * time.Millisecond,
+			heartbeatValue:    generateHeartbeatValue("test"),
+		})
+		close(done)
+	}()
+
+	for i := 0; i < 3; i++ {
+		ch <- api.GenerateResponse{
+			Model:     "test",
+			CreatedAt: time.Now().UTC(),
+			Response:  "x",
+			Done:      false,
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	ch <- api.GenerateResponse{
+		Model:      "test",
+		CreatedAt:  time.Now().UTC(),
+		Response:   "",
+		Done:       true,
+		DoneReason: "stop",
+	}
+	close(ch)
+	<-done
+
+	events := parseGenerateStream(t, rec.Body.String())
+	for _, event := range events {
+		if !event.Done && event.Response == "" {
+			t.Fatalf("did not expect heartbeat event when output is frequent: %+v", event)
+		}
+	}
+}
+
+func TestStreamResponseWithHeartbeat_Disabled(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest("GET", "/", nil)
+
+	ch := make(chan any)
+	done := make(chan struct{})
+	go func() {
+		streamResponseWithOptions(c, ch, streamResponseOptions{
+			heartbeatInterval: 0,
+			heartbeatValue:    generateHeartbeatValue("test"),
+		})
+		close(done)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	ch <- api.GenerateResponse{
+		Model:     "test",
+		CreatedAt: time.Now().UTC(),
+		Response:  "hello",
+		Done:      false,
+	}
+	ch <- api.GenerateResponse{
+		Model:      "test",
+		CreatedAt:  time.Now().UTC(),
+		Response:   "",
+		Done:       true,
+		DoneReason: "stop",
+	}
+	close(ch)
+	<-done
+
+	events := parseGenerateStream(t, rec.Body.String())
+	var keepalives int
+	var finals int
+	for _, event := range events {
+		if !event.Done && event.Response == "" {
+			keepalives++
+		}
+		if event.Done {
+			finals++
+		}
+	}
+
+	if keepalives != 0 {
+		t.Fatalf("expected no keepalive events when disabled, got %d", keepalives)
+	}
+	if finals != 1 {
+		t.Fatalf("expected exactly one final done event, got %d", finals)
+	}
+}
+
+func TestStreamHeartbeatInterval(t *testing.T) {
+	t.Setenv("OLLAMA_STREAM_HEARTBEAT_MS", "10000")
+
+	// default from env
+	if got := streamHeartbeatInterval(nil); got != 10*time.Second {
+		t.Fatalf("expected default heartbeat 10s, got %s", got)
+	}
+
+	// request-level override wins
+	override := 25
+	if got := streamHeartbeatInterval(&api.StreamOptions{HeartbeatMS: &override}); got != 25*time.Millisecond {
+		t.Fatalf("expected override heartbeat 25ms, got %s", got)
+	}
+
+	// request-level disable
+	disable := 0
+	if got := streamHeartbeatInterval(&api.StreamOptions{HeartbeatMS: &disable}); got != 0 {
+		t.Fatalf("expected disabled heartbeat, got %s", got)
+	}
+}


### PR DESCRIPTION
## Motivation
During long running streaming completions, such as those with extensive prefill times or from models with internal thoughts there are often periods where no data is transmitted over the wire for 60 seconds or more. These idle time triggers connection timeouts in infrastructure layers, and crucially for me in web browsers where I'm trying to talk to Ollama directly from, this makes interaction with ollama for non-trivial prompts impossible from a browser. Client-side retries are generally insufficient since the timeouts originate from intermediate layers while the LLM is still quietly working on the server. Re-running the request only results in the whole process starting over again. 

This PR adds an optional server-side keepalive heartbeat to streaming API endpoints. It ensures that data continues to flow through the TCP socket at regular intervals, preventing idle timeouts without affecting token semantics.

## What Changed
- **New Request Options**: Added `stream_options.heartbeat_ms` to core native request types (`api.GenerateRequest` and `api.ChatRequest`).
  - Values `> 0` configure the keepalive interval in milliseconds.
  - Values `<= 0` explicitly disable keepalives.
- **Global Default Configuration**: Added the `OLLAMA_STREAM_HEARTBEAT_MS` environment variable (defaults to `10000` / 10s) to transparently govern the keepalive interval globally if not overridden per-request.
- **OpenAI Compatibility**: Mapped `stream_options.heartbeat_ms` from `/v1/chat/completions` and `/v1/completions` into the native request stream options.
- **Unified Streaming Path**: Refactored the streaming writer within the server (`routes.go`) to use a heartbeat-aware `time.Ticker` via a background goroutine wrapper (`streamResponseWithOptions`). 
  - This handles multiplexing streaming frames and keepalives alongside `net/http` connection draining, Context cancelations, and cleanly aborting LLM work.
  - Applies universally across: `/api/chat`, `/api/generate`, remote streaming branches, image generation streaming, and OpenAI-compatible endpoints.
- **Keepalive Frame Behaviors**: 
  - Native endpoints emit a valid non-terminal JSON chunk (`"done": false`) with empty text content.
  - OpenAI-compatible endpoints emit a no-op SSE data chunk, preserving standard parser compatibility and `[DONE]` sequence semantics.
- **Documentation**: Updated the OpenAPI schema, API documentation, and streaming guides to reflect the new options.
- **Tests**: Added coverage for artificial silence interleaving, frequent output suppression, and disabled heartbeat behavior in `stream_heartbeat_test.go`, alongside updating OpenAI middleware validations.