### PR TITLE
fix: BoolWithDefault returns defaultValue on invalid env var values

### DIFF
--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -156,7 +156,8 @@ func BoolWithDefault(k string) func(defaultValue bool) bool {
 		if s := Var(k); s != "" {
 			b, err := strconv.ParseBool(s)
 			if err != nil {
-				return true
+				slog.Warn("invalid boolean environment variable, using default", "key", k, "value", s, "default", defaultValue)
+				return defaultValue
 			}
 
 			return b


### PR DESCRIPTION
## Summary
- Fix `BoolWithDefault` to return the provided `defaultValue` instead of hardcoded `true` when `strconv.ParseBool` fails on invalid environment variable values
- Add a warning log message when an invalid boolean value is encountered, helping users diagnose misconfigured env vars
- Update existing `TestBool` expectations and add new `TestBoolWithDefault` test cases covering invalid values like "yes", "on", "enabled"

## Details
The bug is on [this line](https://github.com/ollama/ollama/blob/main/envconfig/config.go#L159) where `return true` should be `return defaultValue`. This causes feature flags like `OLLAMA_FLASH_ATTENTION` to be silently enabled when set to common-but-invalid values (e.g., "yes", "on", "enabled") instead of falling back to their default.

`strconv.ParseBool` only accepts: "1", "0", "t", "f", "T", "F", "TRUE", "FALSE", "true", "false", "True", "False".

## Test plan
- [x] Updated `TestBool` to expect `false` for invalid values (since `Bool` wraps `BoolWithDefault` with default `false`)
- [x] Added `TestBoolWithDefault` covering valid values, and invalid values with both `true` and `false` defaults

Fixes #14389

🤖 Generated with [Claude Code](https://claude.com/claude-code)