### PR TITLE
fix: prevent panic when model digest is shorter than 12 characters

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -885,7 +885,11 @@ func ListHandler(cmd *cobra.Command, args []string) error {
 				size = format.HumanBytes(m.Size)
 			}
 
-			data = append(data, []string{m.Name, m.Digest[:12], size, format.HumanTime(m.ModifiedAt, "Never")})
+			displayID := m.Digest
+		if len(displayID) > 12 {
+			displayID = displayID[:12]
+		}
+		data = append(data, []string{m.Name, displayID, size, format.HumanTime(m.ModifiedAt, "Never")})
 		}
 	}
 
@@ -940,7 +944,11 @@ func ListRunningHandler(cmd *cobra.Command, args []string) error {
 				until = format.HumanTime(m.ExpiresAt, "Never")
 			}
 			ctxStr := strconv.Itoa(m.ContextLength)
-			data = append(data, []string{m.Name, m.Digest[:12], format.HumanBytes(m.Size), procStr, ctxStr, until})
+			displayID := m.Digest
+		if len(displayID) > 12 {
+			displayID = displayID[:12]
+		}
+		data = append(data, []string{m.Name, displayID, format.HumanBytes(m.Size), procStr, ctxStr, until})
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Add bounds check before slicing model digest strings in `ListHandler` and `ListRunningHandler`
- If digest is shorter than 12 characters, display the full digest instead of panicking

## Details
The `ollama list` and `ollama ps` commands unconditionally slice `m.Digest[:12]` to display a truncated model ID. If a model has a digest shorter than 12 characters (e.g., from a malformed manifest), this causes a runtime panic:

```
panic: runtime error: slice bounds out of range [:12] with length 3
```

This fix adds a simple length check at both call sites in `cmd/cmd.go`.

## Test plan
- [x] Verified the fix handles short digests by showing full digest
- [x] Normal digests (>12 chars) continue to be truncated as before

Fixes #14250

🤖 Generated with [Claude Code](https://claude.com/claude-code)