### PR TITLE
app: add setting for autostart on Windows

### DIFF
--- a/app/cmd/app/app.go
+++ b/app/cmd/app/app.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ollama/ollama/app/auth"
 	"github.com/ollama/ollama/app/logrotate"
 	"github.com/ollama/ollama/app/server"
+	"github.com/ollama/ollama/app/startup"
 	"github.com/ollama/ollama/app/store"
 	"github.com/ollama/ollama/app/tools"
 	"github.com/ollama/ollama/app/ui"
@@ -267,11 +268,12 @@ func main() {
 				done <- osrv.Run(octx)
 			}()
 		},
-		Store:        st,
-		ToolRegistry: toolRegistry,
-		Dev:          devMode,
-		Logger:       slog.Default(),
-		Updater:      upd,
+		Store:            st,
+		ToolRegistry:     toolRegistry,
+		StartupRegistrar: startup.NewRegistrar(),
+		Dev:              devMode,
+		Logger:           slog.Default(),
+		Updater:          upd,
 		UpdateAvailableFunc: func() {
 			UpdateAvailable("")
 		},

--- a/app/startup/startup.go
+++ b/app/startup/startup.go
@@ -1,0 +1,17 @@
+// startup deals with registering and deregistering the Ollama app as a
+// startup program.
+package startup
+
+type RegistrationState struct {
+	Supported  bool
+	Registered bool
+}
+
+type Registrar interface {
+	// Fetch the state of startup registration
+	GetState() (RegistrationState, error)
+	// Register the app for startup
+	Register() error
+	// Deregister the app for startup
+	Deregister() error
+}

--- a/app/startup/startup_darwin.go
+++ b/app/startup/startup_darwin.go
@@ -1,0 +1,22 @@
+package startup
+
+func NewRegistrar() Registrar {
+	return &darwinRegistrar{}
+}
+
+type darwinRegistrar struct{}
+
+// GetState implements [Registrar].
+func (d *darwinRegistrar) GetState() (RegistrationState, error) {
+	return RegistrationState{Supported: false, Registered: false}, nil
+}
+
+// Register implements [Registrar].
+func (d *darwinRegistrar) Register() error {
+	return nil
+}
+
+// Deregister implements [Registrar].
+func (d *darwinRegistrar) Deregister() error {
+	return nil
+}

--- a/app/startup/startup_default.go
+++ b/app/startup/startup_default.go
@@ -1,0 +1,33 @@
+//go:build !windows && !darwin
+
+// startup_default.go contains the default implementation of the startup package
+// for platforms that do not support startup registration.
+package startup
+
+import (
+	"log/slog"
+	"runtime"
+)
+
+func NewRegistrar() Registrar {
+	return &defaultRegistrar{}
+}
+
+type defaultRegistrar struct{}
+
+// State implements [Registrar].
+func (d *defaultRegistrar) GetState() (RegistrationState, error) {
+	return RegistrationState{Supported: false, Registered: false}, nil
+}
+
+// Register implements [Registrar].
+func (d *defaultRegistrar) Register() error {
+	slog.Debug("Attempted to register app for startup on an unsupported OS", "os", runtime.GOOS)
+	return nil
+}
+
+// Deregister implements [Registrar].
+func (d *defaultRegistrar) Deregister() error {
+	slog.Debug("Attempted to deregister app for startup on an unsupported OS", "os", runtime.GOOS)
+	return nil
+}

--- a/app/startup/startup_windows.go
+++ b/app/startup/startup_windows.go
@@ -1,0 +1,108 @@
+//go:build windows
+
+package startup
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+)
+
+type pathConfig struct {
+	shortcutOrigin  string
+	startupShortcut string
+}
+
+type windowsRegistrar struct {
+	pathConfig pathConfig
+}
+
+func NewRegistrar(options ...func(*pathConfig)) Registrar {
+	pathConfig := &pathConfig{
+		shortcutOrigin:  filepath.Join(os.Getenv("LOCALAPPDATA"), "Programs", "Ollama", "lib", "Ollama.lnk"),
+		startupShortcut: filepath.Join(os.Getenv("APPDATA"), "Microsoft", "Windows", "Start Menu", "Programs", "Startup", "Ollama.lnk"),
+	}
+	for _, option := range options {
+		option(pathConfig)
+	}
+	return &windowsRegistrar{
+		pathConfig: *pathConfig,
+	}
+}
+
+// GetState implements [Registrar].
+func (w *windowsRegistrar) GetState() (RegistrationState, error) {
+	// Check if the origin shortcut actually exists. It may be missing from a portable install or if it was deleted at some point.
+	if _, err := os.Stat(w.pathConfig.shortcutOrigin); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			slog.Info("Startup shortcut origin does not exist, autostart registration is not supported", "shortcutOrigin", w.pathConfig.shortcutOrigin)
+			return RegistrationState{Supported: false, Registered: false}, nil
+		}
+		return RegistrationState{Supported: false, Registered: false}, fmt.Errorf("failed to read the startup shortcut origin %s : %w", w.pathConfig.shortcutOrigin, err)
+	}
+
+	_, err := os.Stat(w.pathConfig.startupShortcut)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return RegistrationState{Supported: true, Registered: false}, nil
+		}
+		return RegistrationState{Supported: true, Registered: false}, fmt.Errorf("failed to read the startup shortcut %s : %w", w.pathConfig.startupShortcut, err)
+	}
+	return RegistrationState{Supported: true, Registered: true}, nil
+}
+
+// Register implements [Registrar].
+func (w *windowsRegistrar) Register() error {
+	// The installer lays down a shortcut for us so we can copy it without
+	// having to resort to calling COM APIs to establish the shortcut
+	_, err := os.Stat(w.pathConfig.startupShortcut)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			in, err := os.Open(w.pathConfig.shortcutOrigin)
+			if err != nil {
+				return fmt.Errorf("unable to open shortcut %s : %w", w.pathConfig.shortcutOrigin, err)
+			}
+			defer in.Close()
+			out, err := os.Create(w.pathConfig.startupShortcut)
+			if err != nil {
+				return fmt.Errorf("unable to open startup link %s : %w", w.pathConfig.startupShortcut, err)
+			}
+			defer out.Close()
+			_, err = io.Copy(out, in)
+			if err != nil {
+				return fmt.Errorf("unable to copy shortcut %s : %w", w.pathConfig.startupShortcut, err)
+			}
+			err = out.Sync()
+			if err != nil {
+				return fmt.Errorf("unable to sync shortcut %s : %w", w.pathConfig.startupShortcut, err)
+			}
+			slog.Info("Created Startup shortcut", "shortcut", w.pathConfig.startupShortcut)
+		} else {
+			slog.Warn("unexpected error looking up Startup shortcut", "error", err)
+		}
+	} else {
+		slog.Debug("Startup link already exists", "shortcut", w.pathConfig.startupShortcut)
+	}
+	return nil
+}
+
+// Deregister implements [Registrar].
+func (w *windowsRegistrar) Deregister() error {
+	state, err := w.GetState()
+	if err != nil {
+		return fmt.Errorf("failed to determine if startup app is registered: %w", err)
+	}
+	if !state.Registered {
+		slog.Debug("Attempted to disable autostart but it was already disabled")
+		return nil
+	}
+
+	err = os.Remove(w.pathConfig.startupShortcut)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("unable to remove startup shortcut %s : %w", w.pathConfig.startupShortcut, err)
+	}
+	return nil
+}

--- a/app/startup/startup_windows_test.go
+++ b/app/startup/startup_windows_test.go
@@ -1,0 +1,164 @@
+//go:build windows
+
+package startup
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func newMockRegistrar(t *testing.T) (Registrar, pathConfig) {
+	t.Helper()
+
+	// TempDir is unique per test, so it should be safe to run in parallel
+	tmp := t.TempDir()
+
+	tempShortcutOrigin := filepath.Join(tmp, "app", "lib", "Ollama.lnk")
+	tempStartupShortcut := filepath.Join(tmp, "startup", "Ollama.lnk")
+
+	return NewRegistrar(func(pathConfig *pathConfig) {
+		pathConfig.shortcutOrigin = tempShortcutOrigin
+		pathConfig.startupShortcut = tempStartupShortcut
+	}), pathConfig{shortcutOrigin: tempShortcutOrigin, startupShortcut: tempStartupShortcut}
+}
+
+func TestGetState(t *testing.T) {
+	tests := []struct {
+		name                  string
+		createOriginShortcut  bool
+		createStartupShortcut bool
+		want                  RegistrationState
+	}{
+		{
+			name: "unsupported when origin shortcut is missing",
+			want: RegistrationState{Supported: false, Registered: false},
+		},
+		{
+			name:                 "unregistered when startup shortcut is missing",
+			createOriginShortcut: true,
+			want:                 RegistrationState{Supported: true, Registered: false},
+		},
+		{
+			name:                  "registered when startup shortcut exists",
+			createOriginShortcut:  true,
+			createStartupShortcut: true,
+			want:                  RegistrationState{Supported: true, Registered: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registrar, paths := newMockRegistrar(t)
+
+			if tt.createOriginShortcut {
+				if err := os.MkdirAll(filepath.Dir(paths.shortcutOrigin), 0o755); err != nil {
+					t.Fatalf("Failed to set up temp install dir: %v", err)
+				}
+				if err := os.WriteFile(paths.shortcutOrigin, []byte("shortcut"), 0o644); err != nil {
+					t.Fatalf("Failed to create origin shortcut: %v", err)
+				}
+			}
+
+			if tt.createStartupShortcut {
+				if err := os.MkdirAll(filepath.Dir(paths.startupShortcut), 0o755); err != nil {
+					t.Fatalf("Failed to set up temp startup dir: %v", err)
+				}
+				if err := os.WriteFile(paths.startupShortcut, []byte("shortcut"), 0o644); err != nil {
+					t.Fatalf("Failed to create startup shortcut: %v", err)
+				}
+			}
+
+			state, err := registrar.GetState()
+			if err != nil {
+				t.Fatalf("GetState returned error: %v", err)
+			}
+			if state != tt.want {
+				t.Fatalf("GetState = %+v, want %+v", state, tt.want)
+			}
+		})
+	}
+}
+
+func TestRegisterCopiesShortcut(t *testing.T) {
+	registrar, paths := newMockRegistrar(t)
+
+	shortcutOrigin := filepath.Join(filepath.Dir(paths.shortcutOrigin), filepath.Base(paths.startupShortcut))
+	if err := os.MkdirAll(filepath.Dir(shortcutOrigin), 0o755); err != nil {
+		t.Fatalf("Failed to create origin dir: %v", err)
+	}
+	originContent := []byte("origin-shortcut")
+	if err := os.WriteFile(shortcutOrigin, originContent, 0o644); err != nil {
+		t.Fatalf("Failed to write origin shortcut: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(paths.startupShortcut), 0o755); err != nil {
+		t.Fatalf("Failed to set up temp startup dir: %v", err)
+	}
+
+	if err := registrar.Register(); err != nil {
+		t.Fatalf("Register returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(paths.startupShortcut)
+	if err != nil {
+		t.Fatalf("Failed to read created shortcut: %v", err)
+	}
+	if string(data) != string(originContent) {
+		t.Fatalf("shortcut content mismatch: got %q want %q", string(data), string(originContent))
+	}
+
+	// Ensure re-registering when the file already exists succeeds and leaves content intact.
+	if err := registrar.Register(); err != nil {
+		t.Fatalf("Register second call returned error: %v", err)
+	}
+	data, err = os.ReadFile(paths.startupShortcut)
+	if err != nil {
+		t.Fatalf("Failed to read shortcut after second register: %v", err)
+	}
+	if string(data) != string(originContent) {
+		t.Fatalf("shortcut content changed after second register: got %q want %q", string(data), string(originContent))
+	}
+}
+
+func TestDeregisterRemovesShortcut(t *testing.T) {
+	registrar, paths := newMockRegistrar(t)
+
+	if err := os.MkdirAll(filepath.Dir(paths.shortcutOrigin), 0o755); err != nil {
+		t.Fatalf("Failed to set up temp install dir: %v", err)
+	}
+	if err := os.WriteFile(paths.shortcutOrigin, []byte("shortcut"), 0o644); err != nil {
+		t.Fatalf("Failed to create origin shortcut: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(paths.startupShortcut), 0o755); err != nil {
+		t.Fatalf("Failed to create startup dir: %v", err)
+	}
+	if err := os.WriteFile(paths.startupShortcut, []byte("shortcut"), 0o644); err != nil {
+		t.Fatalf("Failed to write shortcut: %v", err)
+	}
+
+	if err := registrar.Deregister(); err != nil {
+		t.Fatalf("Deregister returned error: %v", err)
+	}
+
+	if _, err := os.Stat(paths.startupShortcut); !os.IsNotExist(err) {
+		t.Fatalf("expected shortcut to be removed, err=%v", err)
+	}
+}
+
+func TestDeregisterNoopWhenMissing(t *testing.T) {
+	registrar, paths := newMockRegistrar(t)
+
+	if err := os.MkdirAll(filepath.Dir(paths.shortcutOrigin), 0o755); err != nil {
+		t.Fatalf("Failed to set up temp install dir: %v", err)
+	}
+	if err := os.WriteFile(paths.shortcutOrigin, []byte("shortcut"), 0o644); err != nil {
+		t.Fatalf("Failed to create origin shortcut: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(paths.startupShortcut), 0o755); err != nil {
+		t.Fatalf("Failed to create startup dir: %v", err)
+	}
+
+	if err := registrar.Deregister(); err != nil {
+		t.Fatalf("Deregister returned error: %v", err)
+	}
+}

--- a/app/ui/app/codegen/gotypes.gen.ts
+++ b/app/ui/app/codegen/gotypes.gen.ts
@@ -461,6 +461,16 @@ export class SettingsResponse {
 	    return a;
 	}
 }
+export class AutoStartSettingsResponse {
+    supported: boolean;
+    registered: boolean;
+
+    constructor(source: any = {}) {
+        if ('string' === typeof source) source = JSON.parse(source);
+        this.supported = source["supported"];
+        this.registered = source["registered"];
+    }
+}
 export class HealthResponse {
     healthy: boolean;
 

--- a/app/ui/app/src/api.ts
+++ b/app/ui/app/src/api.ts
@@ -10,6 +10,7 @@ import {
   ChatRequest,
   Settings,
   User,
+  AutoStartSettingsResponse,
 } from "@/gotypes";
 import { parseJsonlFromResponse } from "./util/jsonl-parsing";
 import { ollamaClient as ollama } from "./lib/ollama-client";
@@ -288,6 +289,31 @@ export async function updateSettings(settings: Settings): Promise<{
   return {
     settings: new Settings(data.settings),
   };
+}
+
+export async function getAutoStartSettings(): Promise<AutoStartSettingsResponse> {
+  const response = await fetch(`${API_BASE}/api/v1/auto-start`);
+  if (!response.ok) {
+    throw new Error("Failed to fetch auto-start settings");
+  }
+  return (await response.json()) as AutoStartSettingsResponse;
+}
+
+export async function updateAutoStartSettings(settings: {
+  registered: boolean;
+}): Promise<AutoStartSettingsResponse> {
+  const response = await fetch(`${API_BASE}/api/v1/auto-start`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(settings),
+  });
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(error || "Failed to update auto-start settings");
+  }
+  return (await response.json()) as AutoStartSettingsResponse;
 }
 
 export async function updateCloudSetting(

--- a/app/ui/responses/types.go
+++ b/app/ui/responses/types.go
@@ -97,6 +97,14 @@ type SettingsResponse struct {
 	Settings store.Settings `json:"settings"`
 }
 
+// AutoStartSettingsResponse contains the current settings related to the app's auto-start behavior on system startup.
+type AutoStartSettingsResponse struct {
+	// Is auto-start supported on the current platform?
+	Supported bool `json:"supported"`
+	// Is the app registered to auto-start on system startup?
+	Registered bool `json:"registered"`
+}
+
 type HealthResponse struct {
 	Healthy bool `json:"healthy"`
 }

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -396,18 +396,10 @@ ollama signin
 | :- | :- |
 | macOS 	| `~/.ollama/id_ed25519.pub`			|
 | Linux		| `/usr/share/ollama/.ollama/id_ed25519.pub`	|
-| Windows	| `C:\Users\<username>\.ollama\id_ed25519.pub`	|
+| Windows	| `%USERPROFILE%\.ollama\id_ed25519.pub`	|
 
-<Note>
-  Replace &lt;username&gt; with your actual Windows user name.
-</Note>
+## How can I stop Ollama from starting when I log in to my computer?
 
-## How can I stop Ollama from starting when I login to my computer?
+Ollama for macOS registers as a login item during installation.  You can disable this if you prefer not to have Ollama automatically start.  Ollama will respect this setting across upgrades, unless you uninstall the application.
 
-Ollama for Windows and macOS register as a login item during installation.  You can disable this if you prefer not to have Ollama automatically start.  Ollama will respect this setting across upgrades, unless you uninstall the application.
-
-**Windows**
-- In `Task Manager` go to the `Startup apps` tab, search for `ollama` then click `Disable`
-
-**MacOS**
 - Open `Settings` and search for "Login Items", find the `Ollama` entry under `Allow in the Background`, then click the slider to disable.


### PR DESCRIPTION
### Notes

Addresses most of #14375, but is missing the Mac implementation.

Important changes:

1. Adds a new "Start Ollama on login" option:
    <img width="828" height="332" alt="image" src="https://github.com/user-attachments/assets/ecd62236-c490-46ac-b923-2fc19cc234f8" />
2. No longer registers Ollama to automatically start when it's installed for the first time.