### PR TITLE
docs: clarify streaming format as JSONL and document error responses

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -30,7 +30,26 @@ All durations are returned in nanoseconds.
 
 ### Streaming responses
 
-Certain endpoints stream responses as JSON objects. Streaming can be disabled by providing `{"stream": false}` for these endpoints.
+Certain endpoints stream responses as JSON objects in [JSON Lines (JSONL)](https://jsonlines.org/) format, where each JSON object is separated by a newline. Streaming can be disabled by providing `{"stream": false}` for these endpoints.
+
+### Errors
+
+If a request fails, the response will include an HTTP error status code and a JSON body with an `error` field:
+
+```json
+{
+  "error": "model 'missing-model' not found"
+}
+```
+
+Common HTTP status codes:
+
+| Status Code | Description |
+| ----------- | ----------- |
+| 200 | Success |
+| 400 | Bad request (e.g., invalid parameters) |
+| 404 | Not found (e.g., model does not exist) |
+| 500 | Internal server error |
 
 ## Generate a completion
 


### PR DESCRIPTION
## Summary
- Specify that streaming endpoints return [JSON Lines (JSONL)](https://jsonlines.org/) format where each JSON object is separated by a newline
- Add error response documentation with example JSON body and common HTTP status codes table

## Details
The API documentation previously stated streaming returns "a stream of JSON objects" without specifying the exact wire format. This clarifies it as JSONL, making it easier for client implementors to use line-buffered parsing.

Additionally, the API documentation had no section explaining how errors are reported. This adds documentation for the error JSON format and common HTTP status codes.

## Test plan
- [x] Verified error format matches actual server behavior
- [x] Verified streaming format description is accurate

Fixes #7703
Fixes #9905

🤖 Generated with [Claude Code](https://claude.com/claude-code)