### PR TITLE
docs: add GPU-to-CPU fallback troubleshooting section

### DIFF
--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -120,6 +120,38 @@ If you experience gibberish responses when models load across multiple AMD GPUs 
 
 - https://rocm.docs.amd.com/projects/radeon/en/latest/docs/install/native_linux/mgpu.html#mgpu-known-issues-and-limitations
 
+## GPU-to-CPU Fallback
+
+Ollama may silently fall back to running on the CPU if the model does not fit in available GPU VRAM. To check whether your model is running on the GPU or CPU:
+
+```shell
+ollama ps
+```
+
+The `PROCESSOR` column shows where the model is running. If it shows `100% CPU` when you expect GPU acceleration, the model may be too large for your available VRAM.
+
+### Diagnosing VRAM Issues
+
+1. Check available VRAM with `nvidia-smi` (NVIDIA) or `rocm-smi` (AMD)
+2. Compare against model size shown by `ollama list`
+3. Enable debug logging with `OLLAMA_DEBUG=1` to see detailed GPU memory allocation in the server logs
+4. Consider using a smaller quantization (e.g., Q4 instead of Q8) or a smaller model if VRAM is limited
+5. Use `OLLAMA_GPU_OVERHEAD` to reserve VRAM for other applications
+
+### Forcing GPU Layers
+
+Use the `num_gpu` parameter to control how many layers are offloaded to the GPU:
+
+```shell
+# In a Modelfile
+PARAMETER num_gpu 35
+
+# Or via the API
+curl http://localhost:11434/api/generate -d '{"model": "llama3.2", "prompt": "hello", "options": {"num_gpu": 35}}'
+```
+
+Set `num_gpu` to `0` to force CPU-only inference, or to a specific number to partially offload layers to the GPU.
+
 ## Windows Terminal Errors
 
 Older versions of Windows 10 (e.g., 21H1) are known to have a bug where the standard terminal program does not display control characters correctly. This can result in a long string of strings like `←[?25h←[?25l` being displayed, sometimes erroring with `The parameter is incorrect` To resolve this problem, please update to Win 10 22H1 or newer.


### PR DESCRIPTION
## Summary
- Add a new "GPU-to-CPU Fallback" section to the troubleshooting docs
- Documents how to diagnose when models silently fall back from GPU to CPU inference
- Includes instructions for checking processor usage, diagnosing VRAM issues, and controlling GPU layer offloading

## Details
Users frequently encounter situations where Ollama silently falls back to CPU inference when a model doesn't fit in available VRAM. This can be confusing because there's no warning. This section helps users:

1. Check if their model is running on GPU or CPU with `ollama ps`
2. Diagnose VRAM issues with `nvidia-smi`/`rocm-smi`
3. Control GPU offloading with the `num_gpu` parameter
4. Use debug logging to see detailed memory allocation

Fixes #14258
Fixes #14260

🤖 Generated with [Claude Code](https://claude.com/claude-code)