### PR TITLE
fix: add num_thread to /set parameter help text in interactive mode

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -110,6 +110,7 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 		fmt.Fprintln(os.Stderr, "  /set parameter repeat_penalty <float> How strongly to penalize repetitions")
 		fmt.Fprintln(os.Stderr, "  /set parameter repeat_last_n <int>    Set how far back to look for repetitions")
 		fmt.Fprintln(os.Stderr, "  /set parameter num_gpu <int>          The number of layers to send to the GPU")
+		fmt.Fprintln(os.Stderr, "  /set parameter num_thread <int>       Number of threads to use during generation")
 		fmt.Fprintln(os.Stderr, "  /set parameter stop <string> <string> ...   Set the stop parameters")
 		fmt.Fprintln(os.Stderr, "")
 	}


### PR DESCRIPTION
## Summary
- Add `num_thread` to the list of parameters shown by `/set parameter` help in interactive mode
- This is a valid Runner option (defined in `api/types.go`) that was missing from the help output

## Test plan
- [x] Verified `num_thread` is a valid parameter in `api/types.go` Runner struct
- [x] Verified the `/set parameter` handler accepts arbitrary parameter names via `api.FormatParams`

Fixes #10035

🤖 Generated with [Claude Code](https://claude.com/claude-code)