### PR TITLE
fix: prevent sidebar from animating on initial app load

### DIFF
--- a/app/ui/app/src/components/layout/layout.tsx
+++ b/app/ui/app/src/components/layout/layout.tsx
@@ -1,5 +1,6 @@
 import { Link } from "@tanstack/react-router";
 import { useSettings } from "@/hooks/useSettings";
+import { useState, useEffect } from "react";
 
 export function SidebarLayout({
   sidebar,
@@ -11,11 +12,19 @@ export function SidebarLayout({
 }>) {
   const { settings, setSettings } = useSettings();
   const isWindows = navigator.platform.toLowerCase().includes("win");
+  const [enableTransition, setEnableTransition] = useState(false);
+
+  // Disable sidebar transition on initial load to prevent the sidebar
+  // from animating open when settings are first fetched
+  useEffect(() => {
+    const id = requestAnimationFrame(() => setEnableTransition(true));
+    return () => cancelAnimationFrame(id);
+  }, []);
 
   return (
-    <div className={`flex transition-[width] duration-300 dark:bg-neutral-900`}>
+    <div className={`flex ${enableTransition ? "transition-[width] duration-300" : ""} dark:bg-neutral-900`}>
       <div
-        className={`absolute flex mx-2 py-2 z-20 items-center transition-[left] duration-375 text-neutral-500 dark:text-neutral-400 ${settings.sidebarOpen ? (isWindows ? "left-2" : "left-[204px]") : isWindows ? "left-2" : "left-20"}`}
+        className={`absolute flex mx-2 py-2 z-20 items-center ${enableTransition ? "transition-[left] duration-375" : ""} text-neutral-500 dark:text-neutral-400 ${settings.sidebarOpen ? (isWindows ? "left-2" : "left-[204px]") : isWindows ? "left-2" : "left-20"}`}
       >
         <button
           onClick={() => setSettings({ SidebarOpen: !settings.sidebarOpen })}
@@ -57,7 +66,7 @@ export function SidebarLayout({
         </Link>
       </div>
       <div
-        className={`flex flex-col transition-[width] duration-300 max-h-screen ${settings.sidebarOpen ? "w-64" : "w-0"}`}
+        className={`flex flex-col ${enableTransition ? "transition-[width] duration-300" : ""} max-h-screen ${settings.sidebarOpen ? "w-64" : "w-0"}`}
       >
         <div
           onDoubleClick={() => window.doubleClick && window.doubleClick()}
@@ -67,7 +76,7 @@ export function SidebarLayout({
         {settings.sidebarOpen && sidebar}
       </div>
       <main
-        className={`flex flex-1 flex-col min-w-0 transition-all duration-300`}
+        className={`flex flex-1 flex-col min-w-0 ${enableTransition ? "transition-all duration-300" : ""}`}
       >
         <div
           className={`h-13 flex-none w-full z-10 flex items-center bg-white dark:bg-neutral-900 ${isWindows ? "xl:hidden" : "xl:fixed xl:bg-transparent xl:dark:bg-transparent"}`}


### PR DESCRIPTION
## Summary
- Disable CSS transitions on the sidebar layout during initial render
- Transitions are re-enabled after the first paint via `requestAnimationFrame`
- Subsequent sidebar open/close toggles still animate smoothly

## Details
The sidebar has `transition-[width] duration-300` CSS classes that animate its width. When the app loads, settings are fetched asynchronously via React Query, so `sidebarOpen` transitions from `false` (default) to `true` (persisted setting). This causes the sidebar to visually slide in from width 0 to 256px.

The fix uses a `useState`/`useEffect` pattern to suppress transitions until after the initial render is complete. Once `requestAnimationFrame` fires after the first paint, transitions are enabled for all subsequent user interactions.

## Test plan
- [x] Sidebar appears instantly on app load (no slide-in animation)
- [x] Clicking the sidebar toggle button still animates open/close
- [x] Sidebar button position transitions correctly after initial load

Fixes #12954

🤖 Generated with [Claude Code](https://claude.com/claude-code)