### PR TITLE
cmd: improve error messages for missing model name

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -2072,6 +2072,16 @@ func runInteractiveTUI(cmd *cobra.Command) {
 	}
 }
 
+func requireModelArg(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return errors.New("missing model name")
+	}
+	if len(args) > 1 {
+		return fmt.Errorf("extra arguments: %v", args[1:])
+	}
+	return nil
+}
+
 func NewCLI() *cobra.Command {
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 	cobra.EnableCommandSorting = false
@@ -2105,7 +2115,7 @@ func NewCLI() *cobra.Command {
 	createCmd := &cobra.Command{
 		Use:   "create MODEL",
 		Short: "Create a model",
-		Args:  cobra.ExactArgs(1),
+		Args:  requireModelArg,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// Skip server check for experimental mode (writes directly to disk)
 			if experimental, _ := cmd.Flags().GetBool("experimental"); experimental {
@@ -2123,7 +2133,7 @@ func NewCLI() *cobra.Command {
 	showCmd := &cobra.Command{
 		Use:     "show MODEL",
 		Short:   "Show information for a model",
-		Args:    cobra.ExactArgs(1),
+		Args:    requireModelArg,
 		PreRunE: checkServerHeartbeat,
 		RunE:    ShowHandler,
 	}
@@ -2166,7 +2176,7 @@ func NewCLI() *cobra.Command {
 	stopCmd := &cobra.Command{
 		Use:     "stop MODEL",
 		Short:   "Stop a running model",
-		Args:    cobra.ExactArgs(1),
+		Args:    requireModelArg,
 		PreRunE: checkServerHeartbeat,
 		RunE:    StopHandler,
 	}
@@ -2182,7 +2192,7 @@ func NewCLI() *cobra.Command {
 	pullCmd := &cobra.Command{
 		Use:     "pull MODEL",
 		Short:   "Pull a model from a registry",
-		Args:    cobra.ExactArgs(1),
+		Args:    requireModelArg,
 		PreRunE: checkServerHeartbeat,
 		RunE:    PullHandler,
 	}
@@ -2192,7 +2202,7 @@ func NewCLI() *cobra.Command {
 	pushCmd := &cobra.Command{
 		Use:     "push MODEL",
 		Short:   "Push a model to a registry",
-		Args:    cobra.ExactArgs(1),
+		Args:    requireModelArg,
 		PreRunE: checkServerHeartbeat,
 		RunE:    PushHandler,
 	}
@@ -2250,7 +2260,15 @@ func NewCLI() *cobra.Command {
 	copyCmd := &cobra.Command{
 		Use:     "cp SOURCE DESTINATION",
 		Short:   "Copy a model",
-		Args:    cobra.ExactArgs(2),
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 2 {
+				return errors.New("missing source and/or destination model name")
+			}
+			if len(args) > 2 {
+				return fmt.Errorf("extra arguments: %v", args[2:])
+			}
+			return nil
+		},
 		PreRunE: checkServerHeartbeat,
 		RunE:    CopyHandler,
 	}


### PR DESCRIPTION
## Summary

- Replaces generic `accepts 1 arg(s), received 0` with descriptive `missing model name` error for `create`, `show`, `stop`, `pull`, and `push` commands
- Improves `cp` command to show `missing source and/or destination model name` instead of `accepts 2 arg(s), received 0`
- Also reports `extra arguments` when too many args are passed

### Before
```
$ ollama show
Error: accepts 1 arg(s), received 0
```

### After
```
$ ollama show
Error: missing model name
```

Fixes #2893