### PR TITLE
docs: add missing message field to chat streaming final response

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -876,6 +876,10 @@ Final response:
 {
   "model": "llama3.2",
   "created_at": "2023-08-04T19:22:45.499127Z",
+  "message": {
+    "role": "assistant",
+    "content": ""
+  },
   "done": true,
   "total_duration": 8113331500,
   "load_duration": 6396458,


### PR DESCRIPTION
## Summary

- Adds the missing `message` field to the streaming chat API example's final response
- The actual API always includes `message: { role: "assistant", content: "" }` in the final streaming response, but the documentation omitted it
- This mismatch caused confusion for client library authors implementing strict response parsing (e.g., Pydantic validation)

Fixes #9900