### PR TITLE
app: fix visible scrollbar rail on macOS

### DIFF
--- a/app/ui/app/src/index.css
+++ b/app/ui/app/src/index.css
@@ -17,6 +17,35 @@
   }
 }
 
+/* Hide scrollbar track/rail to prevent visible white rail on macOS */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background-color: rgba(0, 0, 0, 0.2);
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(0, 0, 0, 0.35);
+}
+
+@media (prefers-color-scheme: dark) {
+  ::-webkit-scrollbar-thumb {
+    background-color: rgba(255, 255, 255, 0.2);
+  }
+
+  ::-webkit-scrollbar-thumb:hover {
+    background-color: rgba(255, 255, 255, 0.35);
+  }
+}
+
 /* messaging-style typing indicator animation */
 @keyframes typing {
   0%,


### PR DESCRIPTION
## Summary

- Adds webkit scrollbar styling with transparent track and semi-transparent thumb
- Prevents the white scrollbar rail from being permanently visible on macOS when the system setting is "Automatically based on mouse or trackpad"
- Supports both light and dark mode with appropriate thumb colors

Fixes #13327