### PR TITLE
logutil: add JSON logging format via OLLAMA_LOG_FORMAT

### DIFF
--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -280,6 +280,7 @@ type EnvVar struct {
 func AsMap() map[string]EnvVar {
 	ret := map[string]EnvVar{
 		"OLLAMA_DEBUG":             {"OLLAMA_DEBUG", LogLevel(), "Show additional debug information (e.g. OLLAMA_DEBUG=1)"},
+		"OLLAMA_LOG_FORMAT":        {"OLLAMA_LOG_FORMAT", Var("OLLAMA_LOG_FORMAT"), "Log output format: \"text\" (default) or \"json\""},
 		"OLLAMA_FLASH_ATTENTION":   {"OLLAMA_FLASH_ATTENTION", FlashAttention(false), "Enabled flash attention"},
 		"OLLAMA_KV_CACHE_TYPE":     {"OLLAMA_KV_CACHE_TYPE", KvCacheType(), "Quantization type for the K/V cache (default: f16)"},
 		"OLLAMA_GPU_OVERHEAD":      {"OLLAMA_GPU_OVERHEAD", GpuOverhead(), "Reserve a portion of VRAM per GPU (bytes)"},

--- a/logutil/logutil.go
+++ b/logutil/logutil.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"runtime"
 	"time"
@@ -12,7 +13,7 @@ import (
 const LevelTrace slog.Level = -8
 
 func NewLogger(w io.Writer, level slog.Level) *slog.Logger {
-	return slog.New(slog.NewTextHandler(w, &slog.HandlerOptions{
+	opts := &slog.HandlerOptions{
 		Level:     level,
 		AddSource: true,
 		ReplaceAttr: func(_ []string, attr slog.Attr) slog.Attr {
@@ -28,7 +29,15 @@ func NewLogger(w io.Writer, level slog.Level) *slog.Logger {
 			}
 			return attr
 		},
-	}))
+	}
+
+	var handler slog.Handler
+	if os.Getenv("OLLAMA_LOG_FORMAT") == "json" {
+		handler = slog.NewJSONHandler(w, opts)
+	} else {
+		handler = slog.NewTextHandler(w, opts)
+	}
+	return slog.New(handler)
 }
 
 type key string


### PR DESCRIPTION
## Summary

- Adds support for structured JSON log output by setting `OLLAMA_LOG_FORMAT=json`
- Uses Go's standard `slog.JSONHandler` for the JSON format
- Registers `OLLAMA_LOG_FORMAT` in the environment variable display (`ollama serve` startup output)
- Default behavior (text format) is unchanged

### Usage

```bash
OLLAMA_LOG_FORMAT=json ollama serve
```

### Example JSON output

```json
{"time":"2026-02-27T10:00:00.000Z","level":"INFO","source":{"function":"...","file":"routes.go","line":1663},"msg":"server config","env":{...}}
```

This enables integration with structured log aggregation systems like ELK, Splunk, Grafana Loki, or any system that consumes JSON logs.

Fixes #14018