### PR TITLE
fs/ggml: prevent runtime panics on malformed or corrupt GGUF inputs

### DIFF
--- a/fs/ggml/gguf_test.go
+++ b/fs/ggml/gguf_test.go
@@ -2,6 +2,8 @@ package ggml
 
 import (
 	"bytes"
+	"encoding/binary"
+	"math"
 	"math/rand/v2"
 	"os"
 	"strings"
@@ -98,6 +100,121 @@ func TestWriteGGUF(t *testing.T) {
 			}
 		})
 	}
+
+	// writeMinimalGGUF writes a minimal GGUF v3 file with one KV pair of the
+	// given raw key/value bytes (caller is responsible for correct framing).
+	// The KV byte slice must include the 8-byte length-prefixed key and 4-byte
+	// type followed by whatever value bytes the caller provides.  n_kv is set
+	// to 1; n_tensors is set to 0.
+	writeMinimalGGUF := func(t *testing.T, kvBytes []byte) *os.File {
+		t.Helper()
+		f, err := os.CreateTemp(t.TempDir(), "minimal_*.bin")
+		if err != nil {
+			t.Fatal(err)
+		}
+		le := binary.LittleEndian
+		binary.Write(f, le, []byte("GGUF")) // magic
+		binary.Write(f, le, uint32(3))      // version
+		binary.Write(f, le, uint64(0))      // n_tensors
+		binary.Write(f, le, uint64(1))      // n_kv
+		f.Write(kvBytes)
+		return f
+	}
+
+	// writeKVString builds the raw bytes for a single string KV pair where the
+	// value length is rawLength (written as a uint64).
+	writeKVString := func(key string, rawLength uint64) []byte {
+		var buf bytes.Buffer
+		le := binary.LittleEndian
+		binary.Write(&buf, le, uint64(len(key)))
+		buf.WriteString(key)
+		binary.Write(&buf, le, uint32(ggufTypeString)) // value type = string
+		binary.Write(&buf, le, rawLength)              // string length (possibly invalid)
+		// Omit the string payload so the file ends here; Decode will either
+		// error on the oversized length before any read or on an unexpected EOF.
+		return buf.Bytes()
+	}
+
+	t.Run("oversized_string_length_returns_error", func(t *testing.T) {
+		t.Parallel()
+
+		// maxUint64 cast to int on 64-bit gives -1: previously caused
+		// make([]byte, -1) → runtime panic "makeslice: len out of range".
+		for _, rawLen := range []uint64{
+			math.MaxUint64,
+			math.MaxInt64 + 1,
+			1<<30 + 1, // just over the 1 GiB cap
+		} {
+			f := writeMinimalGGUF(t, writeKVString("general.architecture", rawLen))
+			f.Seek(0, 0)
+			_, err := Decode(f, -1)
+			if err == nil {
+				t.Errorf("rawLength=%d: expected error, got nil", rawLen)
+			}
+		}
+	})
+
+	t.Run("oversized_array_length_returns_error", func(t *testing.T) {
+		t.Parallel()
+
+		// Build a KV pair whose value is an array with a huge element count.
+		var buf bytes.Buffer
+		le := binary.LittleEndian
+		key := "tokenizer.ggml.tokens"
+		binary.Write(&buf, le, uint64(len(key)))
+		buf.WriteString(key)
+		binary.Write(&buf, le, uint32(ggufTypeArray))  // value type = array
+		binary.Write(&buf, le, uint32(ggufTypeString)) // array element type = string
+		binary.Write(&buf, le, uint64(math.MaxUint64)) // n elements (huge)
+		// No element data follows.
+
+		f := writeMinimalGGUF(t, buf.Bytes())
+		f.Seek(0, 0)
+		_, err := Decode(f, -1)
+		if err == nil {
+			t.Error("expected error for oversized array, got nil")
+		}
+	})
+
+	t.Run("too_many_tensor_dims_returns_error", func(t *testing.T) {
+		t.Parallel()
+
+		// Write a GGUF with one tensor whose dims field is 5 (> GGML_MAX_DIMS=4).
+		f, err := os.CreateTemp(t.TempDir(), "bad_dims_*.bin")
+		if err != nil {
+			t.Fatal(err)
+		}
+		le := binary.LittleEndian
+		binary.Write(f, le, []byte("GGUF"))
+		binary.Write(f, le, uint32(3)) // version
+		binary.Write(f, le, uint64(1)) // n_tensors = 1
+		binary.Write(f, le, uint64(1)) // n_kv = 1
+
+		// Write a minimal KV pair: general.architecture = "test"
+		arch := "test"
+		binary.Write(f, le, uint64(len("general.architecture")))
+		f.WriteString("general.architecture")
+		binary.Write(f, le, uint32(ggufTypeString))
+		binary.Write(f, le, uint64(len(arch)))
+		f.WriteString(arch)
+
+		// Write one tensor info with dims = 5.
+		name := "blk.0.weight"
+		binary.Write(f, le, uint64(len(name)))
+		f.WriteString(name)
+		binary.Write(f, le, uint32(5)) // dims = 5, exceeds GGML_MAX_DIMS
+		for i := 0; i < 5; i++ {
+			binary.Write(f, le, uint64(4)) // shape dimension
+		}
+		binary.Write(f, le, uint32(0))  // kind = F32
+		binary.Write(f, le, uint64(0))  // offset
+
+		f.Seek(0, 0)
+		_, err = Decode(f, -1)
+		if err == nil {
+			t.Error("expected error for tensor with >4 dims, got nil")
+		}
+	})
 
 	t.Run("truncated_tensor_data", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
## Summary

`readGGUFString`, `readGGUFArray`, and the tensor-info decoder all cast user-supplied `uint64` values to `int` without first validating them. On 64-bit platforms any value larger than `math.MaxInt64` wraps to a negative integer, which then causes `make()` to panic at runtime with:

```
panic: runtime error: makeslice: len out of range
    github.com/ollama/ollama/fs/ggml/gguf.go:361 +0xc5
github.com/ollama/ollama/fs/ggml.(*gguf).Decode ...
    github.com/ollama/ollama/fs/ggml/gguf.go:195 +0x45a
```

This was reproduced loading multi-shard [Unsloth UD-Q3_K_XL GGUFs](https://huggingface.co/unsloth/Qwen3.5-122B-A10B-GGUF) that contain `mxfp4` tensors: prior to the separation of tensor-info reads from size-validation seeks (now in a dedicated post-processing loop), a misaligned file reader could land on raw weight data whose bytes decoded as an enormous string length, crashing the entire Ollama server process instead of returning a descriptive error.

## Changes

- **`readGGUFString`**: validate the raw `uint64` length before casting to `int`; return a descriptive error if it exceeds 1 GiB (far beyond any legitimate GGUF string).
- **`readGGUFArray`**: validate the element count before casting to `int`; return an error if it exceeds `2^32`.
- **`gguf.Decode` tensor loop**: validate that `dims` does not exceed `GGML_MAX_DIMS` (4) before allocating the shape slice, matching the [llama.cpp spec](https://github.com/ggml-org/ggml/blob/master/docs/gguf.md).

All three fixes convert would-be runtime panics into well-formed errors that propagate up cleanly.

## Tests

Three new sub-tests added to `TestWriteGGUF`:
- `oversized_string_length_returns_error` — covers both `maxUint64` and `maxInt64+1` (the overflow boundary), and just over the 1 GiB cap
- `oversized_array_length_returns_error` — `maxUint64` element count
- `too_many_tensor_dims_returns_error` — `dims = 5 > GGML_MAX_DIMS`

## Test plan

- [ ] `go test ./fs/ggml/...` passes (all new sub-tests return errors rather than panicking)
- [ ] Existing `TestWriteGGUF` round-trip tests still pass
- [ ] Smoke test with an Unsloth UD-Q3_K_XL merged GGUF: `ollama create` completes without server panic