### PR TITLE
cmd: ollama launch autohand

### DIFF
--- a/cmd/config/autohand.go
+++ b/cmd/config/autohand.go
@@ -1,0 +1,69 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/ollama/ollama/envconfig"
+)
+
+// Autohand implements Runner for Autohand Code CLI integration
+type Autohand struct{}
+
+func (a *Autohand) String() string { return "Autohand Code" }
+
+func (a *Autohand) Run(model string, args []string) error {
+	if _, err := exec.LookPath("autohand"); err != nil {
+		return fmt.Errorf("autohand is not installed, install with: npm install -g autohand-cli")
+	}
+
+	// Configure Autohand to use Ollama before launching
+	if err := configureAutoHand(model); err != nil {
+		return fmt.Errorf("setup failed: %w", err)
+	}
+
+	cmd := exec.Command("autohand", args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// configureAutoHand writes Autohand's config.json to use the given Ollama model.
+func configureAutoHand(model string) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+
+	configPath := filepath.Join(home, ".autohand", "config.json")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		return err
+	}
+
+	config := make(map[string]any)
+	if data, err := os.ReadFile(configPath); err == nil {
+		_ = json.Unmarshal(data, &config)
+	}
+
+	config["provider"] = "ollama"
+
+	ollama, ok := config["ollama"].(map[string]any)
+	if !ok {
+		ollama = make(map[string]any)
+	}
+
+	ollama["baseUrl"] = envconfig.Host().String()
+	ollama["model"] = model
+
+	config["ollama"] = ollama
+
+	configData, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return err
+	}
+	return writeWithBackup(configPath, configData)
+}

--- a/cmd/config/autohand_test.go
+++ b/cmd/config/autohand_test.go
@@ -1,0 +1,261 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAutohandIntegration(t *testing.T) {
+	ah := &Autohand{}
+
+	t.Run("String", func(t *testing.T) {
+		if got := ah.String(); got != "Autohand Code" {
+			t.Errorf("String() = %q, want %q", got, "Autohand Code")
+		}
+	})
+
+	t.Run("implements Runner", func(t *testing.T) {
+		var _ Runner = ah
+	})
+}
+
+func TestConfigureAutohand(t *testing.T) {
+	t.Run("creates config with provider and model", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setTestHome(t, tmpDir)
+		t.Setenv("OLLAMA_HOST", "http://localhost:11434")
+
+		if err := configureAutoHand("llama3.2"); err != nil {
+			t.Fatalf("configureAutoHand() error = %v", err)
+		}
+
+		configPath := filepath.Join(tmpDir, ".autohand", "config.json")
+		data, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("Failed to read config: %v", err)
+		}
+
+		var cfg map[string]any
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			t.Fatalf("Failed to parse config: %v", err)
+		}
+
+		if cfg["provider"] != "ollama" {
+			t.Errorf("provider = %v, want ollama", cfg["provider"])
+		}
+
+		ollama, ok := cfg["ollama"].(map[string]any)
+		if !ok {
+			t.Fatal("Config missing ollama section")
+		}
+
+		if ollama["baseUrl"] != "http://localhost:11434" {
+			t.Errorf("baseUrl = %v, want http://localhost:11434", ollama["baseUrl"])
+		}
+		if ollama["model"] != "llama3.2" {
+			t.Errorf("model = %v, want llama3.2", ollama["model"])
+		}
+	})
+
+	t.Run("preserves existing fields", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setTestHome(t, tmpDir)
+		t.Setenv("OLLAMA_HOST", "http://localhost:11434")
+
+		configDir := filepath.Join(tmpDir, ".autohand")
+		if err := os.MkdirAll(configDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		configPath := filepath.Join(configDir, "config.json")
+
+		existingConfig := `{
+			"provider": "openai",
+			"openai": {
+				"apiKey": "sk-test",
+				"model": "gpt-4o"
+			},
+			"theme": "dark"
+		}`
+		if err := os.WriteFile(configPath, []byte(existingConfig), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := configureAutoHand("qwen3:8b"); err != nil {
+			t.Fatalf("configureAutoHand() error = %v", err)
+		}
+
+		data, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("Failed to read config: %v", err)
+		}
+
+		var cfg map[string]any
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			t.Fatalf("Failed to parse config: %v", err)
+		}
+
+		// Provider should be updated to ollama
+		if cfg["provider"] != "ollama" {
+			t.Errorf("provider = %v, want ollama", cfg["provider"])
+		}
+
+		// OpenAI config should be preserved
+		openai, ok := cfg["openai"].(map[string]any)
+		if !ok {
+			t.Error("openai config should be preserved")
+		} else {
+			if openai["apiKey"] != "sk-test" {
+				t.Errorf("openai.apiKey = %v, want sk-test", openai["apiKey"])
+			}
+		}
+
+		// Custom fields should be preserved
+		if cfg["theme"] != "dark" {
+			t.Errorf("theme = %v, want dark (preserved)", cfg["theme"])
+		}
+
+		// Ollama config should be set
+		ollama := cfg["ollama"].(map[string]any)
+		if ollama["model"] != "qwen3:8b" {
+			t.Errorf("ollama.model = %v, want qwen3:8b", ollama["model"])
+		}
+	})
+
+	t.Run("preserves existing ollama fields", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setTestHome(t, tmpDir)
+		t.Setenv("OLLAMA_HOST", "http://custom:8080")
+
+		configDir := filepath.Join(tmpDir, ".autohand")
+		if err := os.MkdirAll(configDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		configPath := filepath.Join(configDir, "config.json")
+
+		existingConfig := `{
+			"provider": "ollama",
+			"ollama": {
+				"baseUrl": "http://old:11434",
+				"model": "old-model",
+				"customField": "preserved"
+			}
+		}`
+		if err := os.WriteFile(configPath, []byte(existingConfig), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := configureAutoHand("new-model"); err != nil {
+			t.Fatalf("configureAutoHand() error = %v", err)
+		}
+
+		data, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("Failed to read config: %v", err)
+		}
+
+		var cfg map[string]any
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			t.Fatalf("Failed to parse config: %v", err)
+		}
+
+		ollama := cfg["ollama"].(map[string]any)
+
+		// baseUrl should be updated to current OLLAMA_HOST
+		if ollama["baseUrl"] != "http://custom:8080" {
+			t.Errorf("baseUrl = %v, want http://custom:8080", ollama["baseUrl"])
+		}
+		// model should be updated
+		if ollama["model"] != "new-model" {
+			t.Errorf("model = %v, want new-model", ollama["model"])
+		}
+		// custom fields should be preserved
+		if ollama["customField"] != "preserved" {
+			t.Errorf("customField = %v, want preserved", ollama["customField"])
+		}
+	})
+
+	t.Run("handles corrupt config gracefully", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setTestHome(t, tmpDir)
+		t.Setenv("OLLAMA_HOST", "http://localhost:11434")
+
+		configDir := filepath.Join(tmpDir, ".autohand")
+		if err := os.MkdirAll(configDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		configPath := filepath.Join(configDir, "config.json")
+		if err := os.WriteFile(configPath, []byte("{invalid json}"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := configureAutoHand("test-model"); err != nil {
+			t.Fatalf("configureAutoHand() should not fail with corrupt config, got %v", err)
+		}
+
+		data, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("Failed to read config: %v", err)
+		}
+
+		var cfg map[string]any
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			t.Fatalf("Config should be valid after configureAutoHand, got parse error: %v", err)
+		}
+
+		if cfg["provider"] != "ollama" {
+			t.Errorf("provider = %v, want ollama", cfg["provider"])
+		}
+		ollama := cfg["ollama"].(map[string]any)
+		if ollama["model"] != "test-model" {
+			t.Errorf("model = %v, want test-model", ollama["model"])
+		}
+	})
+
+	t.Run("creates config directory if missing", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setTestHome(t, tmpDir)
+		t.Setenv("OLLAMA_HOST", "http://localhost:11434")
+
+		// Don't create .autohand directory - let configureAutoHand do it
+		if err := configureAutoHand("test-model"); err != nil {
+			t.Fatalf("configureAutoHand() error = %v", err)
+		}
+
+		configPath := filepath.Join(tmpDir, ".autohand", "config.json")
+		if _, err := os.Stat(configPath); os.IsNotExist(err) {
+			t.Error("config.json should be created")
+		}
+	})
+
+	t.Run("updates model on subsequent calls", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setTestHome(t, tmpDir)
+		t.Setenv("OLLAMA_HOST", "http://localhost:11434")
+
+		if err := configureAutoHand("model-1"); err != nil {
+			t.Fatalf("first configureAutoHand() error = %v", err)
+		}
+
+		if err := configureAutoHand("model-2"); err != nil {
+			t.Fatalf("second configureAutoHand() error = %v", err)
+		}
+
+		configPath := filepath.Join(tmpDir, ".autohand", "config.json")
+		data, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("Failed to read config: %v", err)
+		}
+
+		var cfg map[string]any
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			t.Fatalf("Failed to parse config: %v", err)
+		}
+
+		ollama := cfg["ollama"].(map[string]any)
+		if ollama["model"] != "model-2" {
+			t.Errorf("model = %v, want model-2 (should be updated)", ollama["model"])
+		}
+	})
+}

--- a/cmd/config/integrations.go
+++ b/cmd/config/integrations.go
@@ -51,6 +51,7 @@ type AliasConfigurer interface {
 
 // integrations is the registry of available integrations.
 var integrations = map[string]Runner{
+	"autohand": &Autohand{},
 	"claude":   &Claude{},
 	"clawdbot": &Openclaw{},
 	"cline":    &Cline{},
@@ -106,6 +107,7 @@ var integrationAliases = map[string]bool{
 
 // integrationInstallHints maps integration names to install URLs.
 var integrationInstallHints = map[string]string{
+	"autohand": "https://github.com/autohandai/code-cli",
 	"claude":   "https://code.claude.com/docs/en/quickstart",
 	"cline":    "https://cline.bot/cli",
 	"openclaw": "https://docs.openclaw.ai",
@@ -129,6 +131,7 @@ type IntegrationInfo struct {
 
 // integrationDescriptions maps integration names to short descriptions.
 var integrationDescriptions = map[string]string{
+	"autohand": "Autonomous AI coding agent in your terminal",
 	"claude":   "Anthropic's coding tool with subagents",
 	"cline":    "Autonomous coding agent with parallel execution",
 	"codex":    "OpenAI's open-source coding agent",
@@ -141,7 +144,7 @@ var integrationDescriptions = map[string]string{
 // integrationOrder defines a custom display order for integrations.
 // Integrations listed here are placed at the end in the given order;
 // all others appear first, sorted alphabetically.
-var integrationOrder = []string{"opencode", "droid", "pi", "cline"}
+var integrationOrder = []string{"opencode", "droid", "pi", "autohand", "cline"}
 
 // ListIntegrationInfos returns all non-alias registered integrations, sorted by name
 // with integrationOrder entries placed at the end.
@@ -219,6 +222,9 @@ func IsIntegrationInstalled(name string) bool {
 		return err == nil
 	case "opencode":
 		_, err := exec.LookPath("opencode")
+		return err == nil
+	case "autohand":
+		_, err := exec.LookPath("autohand")
 		return err == nil
 	case "pi":
 		_, err := exec.LookPath("pi")
@@ -887,6 +893,7 @@ func LaunchCmd(checkServerHeartbeat func(cmd *cobra.Command, args []string) erro
 Without arguments, this is equivalent to running 'ollama' directly.
 
 Supported integrations:
+  autohand  Autohand Code
   claude    Claude Code
   cline     Cline
   codex     Codex

--- a/docs/integrations/autohand.mdx
+++ b/docs/integrations/autohand.mdx
@@ -1,0 +1,41 @@
+---
+title: AutoHand
+---
+
+AutoHand is an autonomous AI coding agent that lives in your terminal.
+
+## Install
+
+Install [AutoHand](https://github.com/autohandai/code-cli):
+
+```bash
+npm install -g autohand-cli
+```
+
+## Usage with Ollama
+
+### Quick setup
+
+```bash
+ollama launch autohand
+```
+
+To configure without launching:
+
+```shell
+ollama launch autohand --config
+```
+
+### Manual setup
+
+Edit `~/.autohand/config.json`:
+
+```json
+{
+  "provider": "ollama",
+  "ollama": {
+    "baseUrl": "http://localhost:11434",
+    "model": "qwen3-coder"
+  }
+}
+```


### PR DESCRIPTION
Adds support for launching Autohand Code via `ollama launch`. Autohand Code is an open source coding self-evolving agent in your terminal, distributed via npm that can use Ollama models.

## Usage

```bash
ollama launch autohand
ollama launch autohand --model glm-4.7-flash
ollama launch autohand --config
```

## Changes

- `cmd/config/autohand.go` — `Runner` implementation that configures `~/.autohand/config.json` with the Ollama provider and model before launching
- `cmd/config/autohand_test.go` — tests for config creation, field preservation, corrupt config handling, and model updates
- `cmd/config/integrations.go` — register autohand in the integration registry, descriptions, install hints, and help text
- `docs/integrations/autohand.mdx` — integration documentation

## Install

```bash
npm install -g autohand-cli
```

More info: https://github.com/autohandai/code-cli