### PR TITLE
Vulkan Use Mmap (disable Vulkan MMap opt out)

### DIFF
--- a/llm/server.go
+++ b/llm/server.go
@@ -688,7 +688,6 @@ func (s *llamaServer) Load(ctx context.Context, systemInfo ml.SystemInfo, system
 	if (runtime.GOOS == "windows" && len(gpus) > 0 && gpus[0].Library == "CUDA" && s.options.UseMMap == nil) ||
 		(runtime.GOOS == "linux" && systemInfo.FreeMemory < totalSize && s.options.UseMMap == nil) ||
 		(len(gpus) == 0 && s.options.UseMMap == nil) ||
-		(len(gpus) > 0 && gpus[0].Library == "Vulkan" && s.options.UseMMap == nil) ||
 		(s.options.UseMMap != nil && !*s.options.UseMMap) {
 		s.loadRequest.UseMmap = false
 	}


### PR DESCRIPTION
Vulkan Use Mmap (disable Vulkan MMAp opt out)

Draft until new Vendor sync because in newer llama.cpp Versions mmap works without problems in Vulkan (It shows that it uses more memory but in reality it doesn't) It shows more used memory in Process and gpu but in effect there is more free memory.

The reason it seems that the Memory is duplicated is that the Shared Memory used in the GPU is also reported to be used by ollama (But it is the same memory) So for example 6GB Shared Memory used Ollama although "uses" 6GB Memory. This hapens on iGPU where the shared Memory is used for GPU offload.
