### PR TITLE
model/qwen3next: fix CUDA crash with partial GPU offload in DeltaNet attention

### DIFF
--- a/model/models/qwen3next/deltanet.go
+++ b/model/models/qwen3next/deltanet.go
@@ -454,6 +454,17 @@ func (gdn *GatedDeltaNet) deltaNetChunked(
 	vT := v.Permute(ctx, 1, 0, 2, 3).Contiguous(ctx, chunkSize, headVDim, nChunks, numVHeads*nSeqs)
 	stateT := state.Permute(ctx, 1, 0, 2, 3).Contiguous(ctx, headVDim, headVDim, 1, numVHeads*nSeqs)
 
+	// Collect chunk outputs and concatenate at the end instead of using
+	// SetInplace. SetInplace creates GGML_OP_SET with a view of an
+	// intermediate (buffer-less) tensor. With partial GPU offload the ggml
+	// scheduler cannot determine the correct backend for that view, which
+	// can cause it to dispatch the op to CUDA while the data is in host
+	// memory, resulting in a cudaMemcpyDeviceToDevice crash.
+	// Concat creates fresh tensors whose backend is inferred from their
+	// inputs — the same layer's computation — so the scheduler always
+	// places them on the correct device.
+	chunkOutputs := make([]ml.Tensor, nChunks)
+
 	for chunk := range nChunks {
 		qChunk := q.Slice(ctx, 2, chunk, chunk+1, 1)
 		vTChunk := vT.Slice(ctx, 2, chunk, chunk+1, 1)
@@ -475,14 +486,7 @@ func (gdn *GatedDeltaNet) deltaNetChunked(
 		vAttn := vTNewChunk.Mulmat(ctx, attnChunk)
 		coreAttnOutChunk := attnInter.Add(ctx, vAttn)
 
-		v = v.SetInplace(
-			ctx,
-			coreAttnOutChunk,
-			v.Stride(1),
-			v.Stride(2),
-			v.Stride(3),
-			chunk*v.Stride(2),
-		)
+		chunkOutputs[chunk] = coreAttnOutChunk
 
 		// Update state for next chunk
 		gExpLastChunk := gLastExp.Slice(ctx, 2, chunk, chunk+1, 1)
@@ -493,6 +497,12 @@ func (gdn *GatedDeltaNet) deltaNetChunked(
 		// stateT = stateT * g_last + kgdmulvnew
 		stateT = stateT.Mul(ctx, gExpLastChunk)
 		stateT = stateT.Add(ctx, kgdMulVNew)
+	}
+
+	// Build the full output by concatenating chunks along the chunk dimension (dim 2).
+	v = chunkOutputs[0]
+	for i := 1; i < nChunks; i++ {
+		v = v.Concat(ctx, chunkOutputs[i], 2)
 	}
 
 	// Final reshape


### PR DESCRIPTION
Fixes https://github.com/ollama/ollama/issues/14444

## Problem

Models using the `qwen3next` architecture (qwen3.5:35b-a3b, qwen3.5:122b-a10b, etc.) crash with `CUDA error: invalid argument` when partially offloaded — i.e., when VRAM is insufficient for all layers and some remain on CPU.

```
CUDA error: invalid argument
  current device: 0, in function ggml_cuda_cpy at cpy.cu:438
  cudaMemcpyAsyncReserve(src1_ddc, src0_ddc, ggml_nbytes(src0), cudaMemcpyDeviceToDevice, main_stream)
```

The crash occurs during prompt evaluation on prompts long enough to fill multiple DeltaNet chunks.

## Root cause

`deltanet.go:478` uses `SetInplace` in the chunked attention loop:

```go
v = v.SetInplace(ctx, coreAttnOutChunk, ...)
```

`ggml_set_inplace` creates `GGML_OP_SET` with `result = ggml_view_tensor(ctx, v)`. Since `v` is an intermediate tensor with no pre-allocated buffer, the view also has no buffer. The ggml backend scheduler cannot determine the correct backend from the view — `ggml_backend_sched_backend_id_from_cur` checks `view_src->buffer`, finds NULL, and returns -1 (unassigned).

The scheduler's expansion pass then assigns the SET node based on adjacent graph nodes. With partial offload (e.g., layer 0 on CPU, layers 1-39 on GPU), GPU assignments from neighboring layers leak into CPU-layer DeltaNet operations. The CUDA backend receives a `GGML_OP_SET` with a host-memory pointer, and `set.cu → ggml_cuda_cpy → cudaMemcpyDeviceToDevice` crashes.

## Fix

Replace `SetInplace` with `Concat`. Instead of writing each chunk into `v` at an offset, collect chunk outputs in a slice and concatenate along the chunk dimension after the loop.

`Concat` creates `GGML_OP_CONCAT` — a fresh tensor (not a view of an unallocated intermediate), whose backend is correctly inferred from its inputs, which all belong to the same layer's computation.

## Test results

RTX 4090 24 GB, qwen3.5:35b-a3b (39/41 layers on GPU), CUDA 12.0, `num_ctx=4096`.

**Before fix** — long prompt triggers crash:
```
offloaded 39/41 layers to GPU

CUDA error: invalid argument
  current device: 0, in function ggml_cuda_cpy at cpy.cu:438
```

**After fix** — three consecutive prompts succeed, zero errors:
```
offloaded 39/41 layers to GPU

Prompt 1 (Hello, how are you?): exit 0
Prompt 2 (Talk to me like The Dude): exit 0
Prompt 3 (long essay — same prompt that crashed before): exit 0
CUDA errors in log: 0
```

No changes to any C/CUDA code. `cpy.cu` still uses `cudaMemcpyDeviceToDevice` — the fix is purely in the Go model code.