### PR TITLE
envconfig: fall back to default on invalid bool env values

### DIFF
--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -156,7 +156,7 @@ func BoolWithDefault(k string) func(defaultValue bool) bool {
 		if s := Var(k); s != "" {
 			b, err := strconv.ParseBool(s)
 			if err != nil {
-				return true
+				return defaultValue
 			}
 
 			return b

--- a/envconfig/config_test.go
+++ b/envconfig/config_test.go
@@ -157,9 +157,9 @@ func TestBool(t *testing.T) {
 		"false": false,
 		"1":     true,
 		"0":     false,
-		// invalid values
-		"random":    true,
-		"something": true,
+		// invalid values fall back to default (false for Bool)
+		"random":    false,
+		"something": false,
 	}
 
 	for k, v := range cases {
@@ -170,6 +170,44 @@ func TestBool(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBoolWithDefault(t *testing.T) {
+	bwd := BoolWithDefault("OLLAMA_BWD")
+
+	t.Run("valid true", func(t *testing.T) {
+		t.Setenv("OLLAMA_BWD", "true")
+		if b := bwd(false); !b {
+			t.Error("expected true")
+		}
+	})
+
+	t.Run("valid false", func(t *testing.T) {
+		t.Setenv("OLLAMA_BWD", "false")
+		if b := bwd(true); b {
+			t.Error("expected false")
+		}
+	})
+
+	t.Run("invalid value with default true", func(t *testing.T) {
+		t.Setenv("OLLAMA_BWD", "yes")
+		if b := bwd(true); !b {
+			t.Error("expected default true for invalid value")
+		}
+	})
+
+	t.Run("invalid value with default false", func(t *testing.T) {
+		t.Setenv("OLLAMA_BWD", "enabled")
+		if b := bwd(false); b {
+			t.Error("expected default false for invalid value")
+		}
+	})
+
+	t.Run("unset uses default", func(t *testing.T) {
+		if b := bwd(true); !b {
+			t.Error("expected default true for unset var")
+		}
+	})
 }
 
 func TestUint(t *testing.T) {


### PR DESCRIPTION
BoolWithDefault returned true when strconv.ParseBool failed instead of returning the provided default value. This caused boolean flags to be silently enabled when a user set an env var to a common but invalid string like "yes", "on", or "enabled".

The fix changes the error fallback from `return true` to `return defaultValue`.

Fixes #14389