### PR TITLE
server: remove duplicate top_logprobs validation

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -251,11 +251,6 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 		return
 	}
 
-	if req.TopLogprobs < 0 || req.TopLogprobs > 20 {
-		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "top_logprobs must be between 0 and 20"})
-		return
-	}
-
 	if modelRef.Source == modelSourceLocal && m.Config.RemoteHost != "" && m.Config.RemoteModel != "" {
 		c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("model '%s' not found", req.Model)})
 		return
@@ -2115,11 +2110,6 @@ func (s *Server) ChatHandler(c *gin.Context) {
 		default:
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		}
-		return
-	}
-
-	if req.TopLogprobs < 0 || req.TopLogprobs > 20 {
-		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "top_logprobs must be between 0 and 20"})
 		return
 	}
 


### PR DESCRIPTION
Both GenerateHandler and ChatHandler validated `top_logprobs` twice: once early after parsing the request and again after loading the model. The second check is unreachable dead code since the first already returns on invalid values.

Removed the duplicate checks at lines 236 and 2038 (before this change).