### PR TITLE
server: add model name validation and alias resolution to EmbedHandler

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -699,7 +699,20 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 		}
 	}
 
-	name, err := getExistingName(model.ParseName(req.Model))
+	name := model.ParseName(req.Model)
+	if !name.IsValid() {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "model is required"})
+		return
+	}
+
+	resolvedName, _, err := s.resolveAlias(name)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	name = resolvedName
+
+	name, err = getExistingName(name)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("model '%s' not found", req.Model)})
 		return


### PR DESCRIPTION
EmbedHandler was missing two steps that both GenerateHandler and ChatHandler perform:

1. **Model name validation** (`name.IsValid()` check) — an empty or invalid model name went straight to `getExistingName`, producing a confusing "model not found" error instead of the expected "model is required".

2. **Alias resolution** (`resolveAlias`) — model aliases were silently ignored for `/api/embed` requests while working correctly for `/api/generate` and `/api/chat`.

This aligns EmbedHandler's validation flow with the other handlers.