### PR TITLE
Disambiguate identical error messages in paths.go

### DIFF
--- a/manifest/paths.go
+++ b/manifest/paths.go
@@ -17,7 +17,7 @@ var ErrInvalidDigestFormat = errors.New("invalid digest format")
 func Path() (string, error) {
 	path := filepath.Join(envconfig.Models(), "manifests")
 	if err := os.MkdirAll(path, 0o755); err != nil {
-		return "", fmt.Errorf("%w: ensure path elements are traversable", err)
+		return "", fmt.Errorf("%w: Ensure path elements are traversable", err)
 	}
 
 	return path, nil
@@ -54,7 +54,7 @@ func BlobsPath(digest string) (string, error) {
 	}
 
 	if err := os.MkdirAll(dirPath, 0o755); err != nil {
-		return "", fmt.Errorf("%w: ensure path elements are traversable", err)
+		return "", fmt.Errorf("%w: Path elements must be traversable", err)
 	}
 
 	return path, nil


### PR DESCRIPTION
Disambiguating identical error messages.

There are multiple issues currently, open and closed, related to the change of model storage location. The method described in the documentation does not work as indicated, and an alternative method using BindPath mentioned in some issues not properly documented. This PR just adds a minor and harmless change to track down the source of the error.