### PR TITLE
Fix: resource leak and formatting issues

### DIFF
--- a/server/create.go
+++ b/server/create.go
@@ -140,6 +140,7 @@ func (s *Server) CreateHandler(c *gin.Context) {
 						configPath, pErr := manifest.BlobsPath(mf.Config.Digest)
 						if pErr == nil {
 							if cfgFile, fErr := os.Open(configPath); fErr == nil {
+								defer cfgFile.Close()
 								var baseConfig model.ConfigV2
 								if decErr := json.NewDecoder(cfgFile).Decode(&baseConfig); decErr == nil {
 									if config.Renderer == "" {
@@ -152,7 +153,6 @@ func (s *Server) CreateHandler(c *gin.Context) {
 										config.Requires = baseConfig.Requires
 									}
 								}
-								cfgFile.Close()
 							}
 						}
 					}

--- a/server/download.go
+++ b/server/download.go
@@ -467,7 +467,7 @@ type downloadOpts struct {
 // downloadBlob downloads a blob from the registry and stores it in the blobs directory
 func downloadBlob(ctx context.Context, opts downloadOpts) (cacheHit bool, _ error) {
 	if opts.digest == "" {
-		return false, fmt.Errorf(("%s: %s"), opts.n.DisplayNamespaceModel(), "digest is empty")
+		return false, fmt.Errorf("%s: %s", opts.n.DisplayNamespaceModel(), "digest is empty")
 	}
 
 	fp, err := manifest.BlobsPath(opts.digest)


### PR DESCRIPTION
## Summary
This PR fixes two minor issues found in the codebase:

### 1. Fix potential file descriptor leak in `server/create.go`
- Changed `cfgFile.Close()` to `defer cfgFile.Close()` 
- Ensures the file is always closed, even if panic occurs during JSON decoding
- Follows Go best practices for resource management

### 2. Fix incorrect `fmt.Errorf` syntax in `server/download.go`
- Removed redundant parentheses around format string
- Changed `fmt.Errorf(("%s: %s"), ...)` to `fmt.Errorf("%s: %s", ...)`

## Test plan
- [ ] Code review confirms the changes are correct
- [ ] No functional behavior changes expected
- [ ] Follows Go idioms for resource cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)