### PR TITLE
cmd/pi: fix happy path model configuration

### DIFF
--- a/cmd/config/pi.go
+++ b/cmd/config/pi.go
@@ -155,6 +155,8 @@ func (p *Pi) Edit(models []string) error {
 
 	settings["defaultProvider"] = "ollama"
 	settings["defaultModel"] = models[0]
+	// TODO(parthsareen): temporary fix for happy path install. should treat thinking level as true for thinking when needed
+	settings["defaultThinkingLevel"] = "off"
 
 	settingsData, err := json.MarshalIndent(settings, "", "  ")
 	if err != nil {

--- a/cmd/config/pi_test.go
+++ b/cmd/config/pi_test.go
@@ -437,6 +437,11 @@ func TestPiEdit(t *testing.T) {
 			t.Errorf("defaultModel = %v, want llama3.2", settings["defaultModel"])
 		}
 
+		// Verify defaultThinkingLevel is set to off
+		if settings["defaultThinkingLevel"] != "off" {
+			t.Errorf("defaultThinkingLevel = %v, want off", settings["defaultThinkingLevel"])
+		}
+
 		// Verify other fields are preserved
 		if settings["theme"] != "dark" {
 			t.Errorf("theme = %v, want dark (preserved)", settings["theme"])


### PR DESCRIPTION
The default thinking level in pi is medium - this breaks the happy path model configuration. 

Adding a temporary patch to fix before evaluating API strictness