### PR TITLE
cmd: improve think handling

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -306,6 +307,9 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 						// though... It will also be validated on the server once a call is
 						// made.
 						thinkValue.Value = maybeLevel
+						if b, err := strconv.ParseBool(maybeLevel); err == nil {
+							thinkValue.Value = b
+						}
 					}
 					opts.Think = &thinkValue
 					thinkExplicitlySet = true
@@ -516,7 +520,7 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 			assistant, err := chat(cmd, opts)
 			if err != nil {
 				if strings.Contains(err.Error(), "does not support thinking") ||
-					strings.Contains(err.Error(), "invalid think value") {
+					strings.Contains(err.Error(), "think value") {
 					fmt.Printf("error: %v\n", err)
 					sb.Reset()
 					continue


### PR DESCRIPTION
Prevent exit from the CLI by shortening the match string so it also matches the return error `think value %q is not supported for this model`.  There are no other error message that will match.

Do basic validation on the `think` value so that `/set think true` and `/set think false` work as expected.

Fixes: #14612
Fixes: #14614 