### PR TITLE
docs: fix import table of contents links

### DIFF
--- a/docs/import.mdx
+++ b/docs/import.mdx
@@ -4,10 +4,10 @@ title: Importing a Model
 
 ## Table of Contents
 
-- [Importing a Safetensors adapter](#Importing-a-fine-tuned-adapter-from-Safetensors-weights)
-- [Importing a Safetensors model](#Importing-a-model-from-Safetensors-weights)
-- [Importing a GGUF file](#Importing-a-GGUF-based-model-or-adapter)
-- [Sharing models on ollama.com](#Sharing-your-model-on-ollamacom)
+- [Importing a Safetensors adapter](#importing-a-fine-tuned-adapter-from-safetensors-weights)
+- [Importing a Safetensors model](#importing-a-model-from-safetensors-weights)
+- [Importing a GGUF file](#importing-a-gguf-based-model-or-adapter)
+- [Sharing models on ollama.com](#sharing-your-model-on-ollama-com)
 
 ## Importing a fine tuned adapter from Safetensors weights
 


### PR DESCRIPTION
Previous values didn't jump down the page. 