### PR TITLE
envconfig: fallback to default for invalid boolean env values

### DIFF
--- a/app/server/server_test.go
+++ b/app/server/server_test.go
@@ -158,9 +158,9 @@ func TestServerCmdCloudSettingEnv(t *testing.T) {
 			want:          "OLLAMA_NO_CLOUD=1",
 		},
 		{
-			name:     "invalid env disables cloud",
+			name:     "invalid env keeps cloud enabled",
 			envValue: "invalid",
-			want:     "OLLAMA_NO_CLOUD=1",
+			want:     "OLLAMA_NO_CLOUD=0",
 		},
 	}
 

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -156,7 +156,7 @@ func BoolWithDefault(k string) func(defaultValue bool) bool {
 		if s := Var(k); s != "" {
 			b, err := strconv.ParseBool(s)
 			if err != nil {
-				return true
+				return defaultValue
 			}
 
 			return b

--- a/envconfig/config_test.go
+++ b/envconfig/config_test.go
@@ -158,8 +158,8 @@ func TestBool(t *testing.T) {
 		"1":     true,
 		"0":     false,
 		// invalid values
-		"random":    true,
-		"something": true,
+		"random":    false,
+		"something": false,
 	}
 
 	for k, v := range cases {
@@ -167,6 +167,32 @@ func TestBool(t *testing.T) {
 			t.Setenv("OLLAMA_BOOL", k)
 			if b := Bool("OLLAMA_BOOL")(); b != v {
 				t.Errorf("%s: expected %t, got %t", k, v, b)
+			}
+		})
+	}
+}
+
+func TestBoolWithDefault(t *testing.T) {
+	cases := []struct {
+		name         string
+		envValue     string
+		defaultValue bool
+		want         bool
+	}{
+		{name: "empty with false default", envValue: "", defaultValue: false, want: false},
+		{name: "empty with true default", envValue: "", defaultValue: true, want: true},
+		{name: "valid true", envValue: "true", defaultValue: false, want: true},
+		{name: "valid false", envValue: "false", defaultValue: true, want: false},
+		{name: "invalid with false default", envValue: "yes", defaultValue: false, want: false},
+		{name: "invalid with true default", envValue: "enabled", defaultValue: true, want: true},
+	}
+
+	readBool := BoolWithDefault("OLLAMA_BOOL_WITH_DEFAULT")
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("OLLAMA_BOOL_WITH_DEFAULT", tt.envValue)
+			if got := readBool(tt.defaultValue); got != tt.want {
+				t.Fatalf("BoolWithDefault() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -347,6 +373,12 @@ func TestNoCloud(t *testing.T) {
 			envValue:     "1",
 			wantDisabled: true,
 			wantSource:   "env",
+		},
+		{
+			name:         "invalid env value",
+			envValue:     "enabled",
+			wantDisabled: false,
+			wantSource:   "none",
 		},
 		{
 			name:          "config only",


### PR DESCRIPTION
## Summary
- fix `BoolWithDefault` to return the caller-provided default when an env var has an invalid boolean value
- add focused tests for `BoolWithDefault` covering valid, empty, and invalid values
- update existing behavior tests that depended on invalid values being treated as `true`

## Why
Issue #14389 reports that invalid values (for example `yes`, `enabled`) currently behave like `true`, which can silently enable features. This change makes invalid input fall back to the declared default as expected.

## Testing
- `go test ./envconfig ./app/server`
- `go test ./...` (fails locally only for `app/ui` and `app/cmd/app` due to missing generated `app/dist` assets; unaffected by this change)

Closes #14389
