### PR TITLE
docs: add AgentField to Community Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ console.log(response.message.content);
 
 ### Frameworks & Agents
 
+- [AgentField](https://github.com/Agent-Field/agentfield) - Open-source control plane for building and orchestrating autonomous AI agents ([docs](https://agentfield.ai/docs))
 - [AutoGPT](https://github.com/Significant-Gravitas/AutoGPT/blob/master/docs/content/platform/ollama.md) - Autonomous AI agent platform
 - [crewAI](https://github.com/crewAIInc/crewAI) - Multi-agent orchestration framework
 - [Strands Agents](https://github.com/strands-agents/sdk-python) - Model-driven agent building by AWS
@@ -268,7 +269,6 @@ console.log(response.message.content);
 - [Stakpak](https://github.com/stakpak/agent) - Open source DevOps agent
 - [Hexabot](https://github.com/hexastack/hexabot) - Conversational AI builder
 - [Neuro SAN](https://github.com/cognizant-ai-lab/neuro-san-studio) - Multi-agent orchestration ([docs](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/user_guide.md#ollama))
-- [AgentField](https://github.com/Agent-Field/agentfield) - Open-source control plane for building and orchestrating autonomous AI agents ([docs](https://agentfield.ai/docs))
 
 ### RAG & Knowledge Bases
 


### PR DESCRIPTION
## Add AgentField to Community Integrations

Adds [AgentField](https://github.com/Agent-Field/agentfield) to the **Frameworks & Agents** section of Community Integrations.

AgentField is an open-source control plane for AI agents with SDKs in Python, TypeScript, and Go. All three SDKs support Ollama as an LLM provider.

### Usage

**Python** (via LiteLLM — uses the `ollama_chat/` model prefix):
```python
from agentfield import Agent, AIConfig

app = Agent(
    node_id="my-agent",
    ai_config=AIConfig(model="ollama_chat/llama3.2")
)

@app.reasoner
async def chat(message: str) -> str:
    return await app.ai(user=message)

app.serve()
```

**TypeScript:**
```typescript
import { Agent } from '@agentfield/sdk';

const agent = new Agent({
  nodeId: 'my-agent',
  aiConfig: {
    provider: 'ollama',
    model: 'llama3.2',
    baseUrl: 'http://localhost:11434/v1'
  }
});

agent.reasoner('chat', async (ctx) => {
  return await ctx.ai(ctx.input.message);
});

await agent.serve();
```

**Go** (env-var configuration, auto-detected as OpenAI-compatible):
```bash
export AI_BASE_URL=http://localhost:11434/v1
export AI_MODEL=llama3.2
```
```go
package main

import (
    "context"
    "log"

    "github.com/Agent-Field/agentfield/sdk/go/agent"
)

func main() {
    app, _ := agent.New(agent.Config{NodeID: "my-agent"})

    app.RegisterReasoner("chat", func(ctx context.Context, input map[string]any) (any, error) {
        response, err := app.AI(ctx, input["message"].(string))
        if err != nil {
            return nil, err
        }
        return map[string]any{"response": response}, nil
    })

    log.Fatal(app.Serve(":8001"))
}
```

### Links
- Repo: https://github.com/Agent-Field/agentfield
- Docs: https://agentfield.ai/docs

cc @AbirAbbas