### PR TITLE
feat: add skills commands and runtime support

### DIFF
--- a/app/ui/ui.go
+++ b/app/ui/ui.go
@@ -1672,7 +1672,6 @@ func supportsBrowserTools(model string) bool {
 	return strings.HasPrefix(strings.ToLower(model), "gpt-oss")
 }
 
-
 // buildChatRequest converts store.Chat to api.ChatRequest
 func (s *Server) buildChatRequest(chat *store.Chat, model string, think any, availableTools []map[string]any) (*api.ChatRequest, error) {
 	var msgs []api.Message

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -682,6 +682,10 @@ func RunHandler(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
+		if err := printActiveSkills(os.Stderr, false); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: couldn't load active skills: %v\n", err)
+		}
+
 		for _, msg := range info.Messages {
 			switch msg.Role {
 			case "user":
@@ -2252,6 +2256,56 @@ func NewCLI() *cobra.Command {
 		RunE:    DeleteHandler,
 	}
 
+	skillsCmd := &cobra.Command{
+		Use:   "skills",
+		Short: "Manage local skills",
+	}
+
+	skillsListCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List installed skills",
+		Args:  cobra.ExactArgs(0),
+		RunE:  SkillsListHandler,
+	}
+
+	skillsInstallCmd := &cobra.Command{
+		Use:   "install PATH",
+		Short: "Install a skill from a local directory",
+		Args:  cobra.ExactArgs(1),
+		RunE:  SkillsInstallHandler,
+	}
+	skillsInstallCmd.Flags().Bool("enable", false, "Enable the skill after installing")
+
+	skillsEnableCmd := &cobra.Command{
+		Use:   "enable NAME",
+		Short: "Enable a skill",
+		Args:  cobra.ExactArgs(1),
+		RunE:  SkillsEnableHandler,
+	}
+
+	skillsDisableCmd := &cobra.Command{
+		Use:   "disable NAME",
+		Short: "Disable a skill",
+		Args:  cobra.ExactArgs(1),
+		RunE:  SkillsDisableHandler,
+	}
+
+	skillsRunCmd := &cobra.Command{
+		Use:   "run NAME [ARGS...]",
+		Short: "Run an enabled skill",
+		Args:  cobra.MinimumNArgs(1),
+		RunE:  SkillsRunHandler,
+	}
+	skillsRunCmd.Flags().StringSlice("allow", nil, "Grant permissions for this run (repeatable or comma-separated)")
+
+	skillsCmd.AddCommand(
+		skillsListCmd,
+		skillsInstallCmd,
+		skillsEnableCmd,
+		skillsDisableCmd,
+		skillsRunCmd,
+	)
+
 	runnerCmd := &cobra.Command{
 		Use:    "runner",
 		Hidden: true,
@@ -2326,6 +2380,7 @@ func NewCLI() *cobra.Command {
 		psCmd,
 		copyCmd,
 		deleteCmd,
+		skillsCmd,
 		runnerCmd,
 		config.LaunchCmd(checkServerHeartbeat, runInteractiveTUI),
 	)

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -35,6 +35,7 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 		fmt.Fprintln(os.Stderr, "Available Commands:")
 		fmt.Fprintln(os.Stderr, "  /set            Set session variables")
 		fmt.Fprintln(os.Stderr, "  /show           Show model information")
+		fmt.Fprintln(os.Stderr, "  /skills         Show active skills")
 		fmt.Fprintln(os.Stderr, "  /load <model>   Load a session or model")
 		fmt.Fprintln(os.Stderr, "  /save <model>   Save your current session")
 		fmt.Fprintln(os.Stderr, "  /clear          Clear session context")
@@ -458,6 +459,10 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 				}
 			} else {
 				usageShow()
+			}
+		case strings.HasPrefix(line, "/skills"):
+			if err := printActiveSkills(os.Stderr, true); err != nil {
+				fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			}
 		case strings.HasPrefix(line, "/help"), strings.HasPrefix(line, "/?"):
 			args := strings.Fields(line)

--- a/cmd/skills_cli.go
+++ b/cmd/skills_cli.go
@@ -1,0 +1,149 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+
+	"github.com/ollama/ollama/skills"
+)
+
+func SkillsListHandler(cmd *cobra.Command, args []string) error {
+	all, err := skills.List()
+	if err != nil {
+		return err
+	}
+
+	if len(all) == 0 {
+		fmt.Fprintln(os.Stdout, "No skills installed. Use `ollama skills install <path>` to add one.")
+		return nil
+	}
+
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"NAME", "ENABLED", "INPUTS", "OUTPUTS", "PERMISSIONS", "DESCRIPTION"})
+	table.SetAutoWrapText(false)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	for _, skill := range all {
+		table.Append([]string{
+			skill.Spec.Name,
+			boolToYesNo(skill.Enabled),
+			joinOrDash(skill.Spec.IO.Inputs),
+			joinOrDash(skill.Spec.IO.Outputs),
+			joinOrDash(skill.Spec.Permissions.Required),
+			valueOrDash(skill.Spec.Description),
+		})
+	}
+	table.Render()
+
+	return nil
+}
+
+func SkillsInstallHandler(cmd *cobra.Command, args []string) error {
+	installed, err := skills.Install(args[0])
+	if err != nil {
+		return err
+	}
+
+	autoEnable, _ := cmd.Flags().GetBool("enable")
+	if autoEnable {
+		if err := skills.Enable(installed.Spec.Name); err != nil {
+			return err
+		}
+	}
+
+	fmt.Fprintf(os.Stdout, "Installed skill '%s'.\n", installed.Spec.Name)
+	if autoEnable {
+		fmt.Fprintf(os.Stdout, "Enabled skill '%s'.\n", installed.Spec.Name)
+	}
+
+	return nil
+}
+
+func SkillsEnableHandler(cmd *cobra.Command, args []string) error {
+	if err := skills.Enable(args[0]); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stdout, "Enabled skill '%s'.\n", args[0])
+	return nil
+}
+
+func SkillsDisableHandler(cmd *cobra.Command, args []string) error {
+	if err := skills.Disable(args[0]); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stdout, "Disabled skill '%s'.\n", args[0])
+	return nil
+}
+
+func SkillsRunHandler(cmd *cobra.Command, args []string) error {
+	name := args[0]
+	runArgs := args[1:]
+	allow, err := cmd.Flags().GetStringSlice("allow")
+	if err != nil {
+		return err
+	}
+
+	return skills.RunWithOptions(cmd.Context(), name, runArgs, os.Stdin, os.Stdout, os.Stderr, skills.RunOptions{
+		GrantedPermissions: allow,
+	})
+}
+
+func printActiveSkills(w io.Writer, showEmpty bool) error {
+	active, err := skills.Enabled()
+	if err != nil {
+		return err
+	}
+
+	if len(active) == 0 {
+		if showEmpty {
+			fmt.Fprintln(w, "No active skills. Use `ollama skills enable <name>` to activate one.")
+		}
+		return nil
+	}
+
+	fmt.Fprintln(w, "Active skills in this chat:")
+	for _, skill := range active {
+		fmt.Fprintf(w, "  - %s\n", describeSkill(skill))
+	}
+	fmt.Fprintln(w)
+
+	return nil
+}
+
+func describeSkill(skill skills.Skill) string {
+	return fmt.Sprintf("%s: %s (inputs: %s; outputs: %s; permissions: %s)",
+		skill.Spec.Name,
+		valueOrDash(skill.Spec.Description),
+		joinOrDash(skill.Spec.IO.Inputs),
+		joinOrDash(skill.Spec.IO.Outputs),
+		joinOrDash(skill.Spec.Permissions.Required),
+	)
+}
+
+func boolToYesNo(v bool) string {
+	if v {
+		return "yes"
+	}
+	return "no"
+}
+
+func joinOrDash(items []string) string {
+	if len(items) == 0 {
+		return "-"
+	}
+	return strings.Join(items, ", ")
+}
+
+func valueOrDash(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return "-"
+	}
+	return v
+}

--- a/cmd/skills_cli_test.go
+++ b/cmd/skills_cli_test.go
@@ -1,0 +1,150 @@
+package cmd
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func writeSkillFixture(t *testing.T) string {
+	t.Helper()
+
+	src := t.TempDir()
+
+	skillToml := `name = "echoer"
+description = "Echoes text input"
+version = "0.1.0"
+command = "./run.sh"
+args = ["--static"]
+
+[io]
+inputs = ["text"]
+outputs = ["text"]
+
+[permissions]
+required = ["filesystem.read"]
+`
+	if err := os.WriteFile(filepath.Join(src, "skill.toml"), []byte(skillToml), 0o644); err != nil {
+		t.Fatalf("write skill.toml: %v", err)
+	}
+
+	script := "#!/bin/sh\nprintf 'run:%s %s\\n' \"$1\" \"$2\"\n"
+	if err := os.WriteFile(filepath.Join(src, "run.sh"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write run.sh: %v", err)
+	}
+
+	return src
+}
+
+func runCLI(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+
+	root := NewCLI()
+	root.SetContext(t.Context())
+	root.SetArgs(args)
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	defer func() {
+		os.Stdout = oldStdout
+	}()
+
+	err := root.Execute()
+	w.Close()
+	data, _ := io.ReadAll(r)
+
+	return string(data), err
+}
+
+func TestSkillsCommandLifecycle(t *testing.T) {
+	t.Setenv("OLLAMA_SKILLS", t.TempDir())
+	src := writeSkillFixture(t)
+
+	out, err := runCLI(t, "skills", "install", src)
+	if err != nil {
+		t.Fatalf("skills install failed: %v", err)
+	}
+	if !strings.Contains(out, "Installed skill 'echoer'.") {
+		t.Fatalf("skills install output = %q", out)
+	}
+
+	out, err = runCLI(t, "skills", "list")
+	if err != nil {
+		t.Fatalf("skills list failed: %v", err)
+	}
+	if !strings.Contains(out, "echoer") || !strings.Contains(out, "no") {
+		t.Fatalf("skills list output = %q", out)
+	}
+
+	out, err = runCLI(t, "skills", "enable", "echoer")
+	if err != nil {
+		t.Fatalf("skills enable failed: %v", err)
+	}
+	if !strings.Contains(out, "Enabled skill 'echoer'.") {
+		t.Fatalf("skills enable output = %q", out)
+	}
+
+	out, err = runCLI(t, "skills", "list")
+	if err != nil {
+		t.Fatalf("skills list failed: %v", err)
+	}
+	if !strings.Contains(out, "echoer") || !strings.Contains(out, "yes") {
+		t.Fatalf("skills list output after enable = %q", out)
+	}
+
+	out, err = runCLI(t, "skills", "disable", "echoer")
+	if err != nil {
+		t.Fatalf("skills disable failed: %v", err)
+	}
+	if !strings.Contains(out, "Disabled skill 'echoer'.") {
+		t.Fatalf("skills disable output = %q", out)
+	}
+}
+
+func TestSkillsRunCommand(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script execution not supported in this test on windows")
+	}
+
+	t.Setenv("OLLAMA_SKILLS", t.TempDir())
+	src := writeSkillFixture(t)
+
+	if _, err := runCLI(t, "skills", "install", src); err != nil {
+		t.Fatalf("skills install failed: %v", err)
+	}
+	if _, err := runCLI(t, "skills", "enable", "echoer"); err != nil {
+		t.Fatalf("skills enable failed: %v", err)
+	}
+
+	out, err := runCLI(t, "skills", "run", "echoer", "--allow", "filesystem.read", "hello")
+	if err != nil {
+		t.Fatalf("skills run failed: %v", err)
+	}
+	if got, want := out, "run:--static hello\n"; got != want {
+		t.Fatalf("skills run output = %q, want %q", got, want)
+	}
+}
+
+func TestSkillsRunCommandRequiresPermission(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script execution not supported in this test on windows")
+	}
+
+	t.Setenv("OLLAMA_SKILLS", t.TempDir())
+	src := writeSkillFixture(t)
+
+	if _, err := runCLI(t, "skills", "install", src); err != nil {
+		t.Fatalf("skills install failed: %v", err)
+	}
+	if _, err := runCLI(t, "skills", "enable", "echoer"); err != nil {
+		t.Fatalf("skills enable failed: %v", err)
+	}
+
+	if _, err := runCLI(t, "skills", "run", "echoer", "hello"); err == nil {
+		t.Fatalf("skills run expected permission error, got nil")
+	}
+}

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -66,6 +66,37 @@ I'm a basic program that prints the famous "Hello, world!" message to the consol
 ollama run gemma3 "What's in this image? /Users/jmorgan/Desktop/smile.png"
 ```
 
+### Manage skills (MVP)
+
+```
+ollama skills list
+ollama skills install ./my-skill
+ollama skills enable my-skill
+ollama skills disable my-skill
+ollama skills run my-skill --allow filesystem.read -- arg1 arg2
+```
+
+`skill.toml` schema:
+
+```toml
+name = "my-skill"
+description = "What this skill does"
+version = "0.1.0"
+command = "./run.sh"
+args = ["--flag"]
+
+[io]
+inputs = ["text"]
+outputs = ["text"]
+
+[permissions]
+required = ["filesystem.read"]
+```
+
+When you run `ollama run <model>` interactively, Ollama shows active skills and what each one can do.
+Use `/skills` in chat to re-display the current active skills.
+You can also grant permissions via `OLLAMA_SKILL_ALLOW` (comma-separated), e.g. `OLLAMA_SKILL_ALLOW=filesystem.read,network.fetch`.
+
 ### Generate embeddings
 
 ```

--- a/go.mod
+++ b/go.mod
@@ -95,7 +95,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
+	github.com/pelletier/go-toml/v2 v2.2.2
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect

--- a/model/models/lfm2/cache.go
+++ b/model/models/lfm2/cache.go
@@ -31,10 +31,6 @@ func NewHybridCache(shift func(ctx ml.Context, layer int, key, shift ml.Tensor) 
 	return &HybridCache{Recurrent: base}
 }
 
-func (c *HybridCache) slotsTensor() ml.Tensor {
-	return c.SlotsTensor()
-}
-
 func (c *HybridCache) seqTokens() int {
 	return c.SeqTokens()
 }

--- a/readline/errors.go
+++ b/readline/errors.go
@@ -1,11 +1,11 @@
 package readline
 
-import (
-	"errors"
-)
+import "errors"
 
-var ErrInterrupt = errors.New("Interrupt")
-var ErrEditPrompt = errors.New("EditPrompt")
+var (
+	ErrInterrupt  = errors.New("Interrupt")
+	ErrEditPrompt = errors.New("EditPrompt")
+)
 
 type InterruptError struct {
 	Line []rune

--- a/skills/skills.go
+++ b/skills/skills.go
@@ -1,0 +1,647 @@
+package skills
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+const (
+	envSkillsDir      = "OLLAMA_SKILLS"
+	envSkillAllow     = "OLLAMA_SKILL_ALLOW"
+	skillManifestFile = "skill.toml"
+	installedDirName  = "installed"
+	enabledStateFile  = "enabled.json"
+)
+
+var (
+	// ErrSkillNotFound indicates a requested skill has not been installed.
+	ErrSkillNotFound = errors.New("skill not found")
+	// ErrSkillNotEnabled indicates a requested skill is installed but disabled.
+	ErrSkillNotEnabled = errors.New("skill not enabled")
+	// ErrPermissionDenied indicates required permissions were not granted.
+	ErrPermissionDenied = errors.New("permission denied")
+
+	validSkillName  = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+	validPermission = regexp.MustCompile(`^[a-z][a-z0-9_.-]*$`)
+)
+
+// Spec describes the skill.toml MVP schema.
+type Spec struct {
+	Name        string         `toml:"name"`
+	Description string         `toml:"description,omitempty"`
+	Version     string         `toml:"version,omitempty"`
+	Command     string         `toml:"command"`
+	Args        []string       `toml:"args,omitempty"`
+	IO          IOSpec         `toml:"io"`
+	Permissions PermissionSpec `toml:"permissions"`
+}
+
+type IOSpec struct {
+	Inputs  []string `toml:"inputs,omitempty"`
+	Outputs []string `toml:"outputs,omitempty"`
+}
+
+type PermissionSpec struct {
+	Required []string `toml:"required,omitempty"`
+}
+
+type Skill struct {
+	Spec    Spec
+	Dir     string
+	Enabled bool
+}
+
+// RunOptions controls how a skill is executed.
+type RunOptions struct {
+	// GrantedPermissions are permissions allowed for this execution.
+	// If empty, OLLAMA_SKILL_ALLOW is used.
+	GrantedPermissions []string
+}
+
+func RootDir() (string, error) {
+	if v := strings.TrimSpace(os.Getenv(envSkillsDir)); v != "" {
+		return filepath.Clean(v), nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(home, ".ollama", "skills"), nil
+}
+
+func installedDir() (string, error) {
+	root, err := RootDir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(root, installedDirName), nil
+}
+
+func enabledPath() (string, error) {
+	root, err := RootDir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(root, enabledStateFile), nil
+}
+
+func ensureLayout() error {
+	root, err := RootDir()
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		return err
+	}
+
+	installed, err := installedDir()
+	if err != nil {
+		return err
+	}
+
+	return os.MkdirAll(installed, 0o755)
+}
+
+func (s *Spec) normalize(fallbackName string) error {
+	s.Name = strings.TrimSpace(s.Name)
+	if s.Name == "" {
+		s.Name = strings.TrimSpace(fallbackName)
+	}
+	if s.Name == "" {
+		return errors.New("skill name is required")
+	}
+	if !validSkillName.MatchString(s.Name) {
+		return fmt.Errorf("invalid skill name %q: only letters, numbers, '.', '_' and '-' are allowed", s.Name)
+	}
+
+	s.Description = strings.TrimSpace(s.Description)
+	s.Version = strings.TrimSpace(s.Version)
+	s.Command = strings.TrimSpace(s.Command)
+	if s.Command == "" {
+		return errors.New("skill command is required")
+	}
+
+	s.IO.Inputs = normalizeStringList(s.IO.Inputs)
+	s.IO.Outputs = normalizeStringList(s.IO.Outputs)
+
+	requiredPerms, err := normalizePermissions(s.Permissions.Required)
+	if err != nil {
+		return err
+	}
+	s.Permissions.Required = requiredPerms
+
+	return nil
+}
+
+func LoadSpec(path string) (Spec, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Spec{}, err
+	}
+
+	var spec Spec
+	if err := toml.Unmarshal(data, &spec); err != nil {
+		return Spec{}, fmt.Errorf("parse %s: %w", path, err)
+	}
+
+	if err := spec.normalize(filepath.Base(filepath.Dir(path))); err != nil {
+		return Spec{}, err
+	}
+
+	return spec, nil
+}
+
+func Install(source string) (Skill, error) {
+	src := strings.TrimSpace(source)
+	if src == "" {
+		return Skill{}, errors.New("source path is required")
+	}
+
+	absSource, err := filepath.Abs(src)
+	if err != nil {
+		return Skill{}, err
+	}
+
+	stat, err := os.Stat(absSource)
+	if err != nil {
+		if isGitLikeSource(src) {
+			return Skill{}, errors.New("skill install currently supports local directories only")
+		}
+		return Skill{}, err
+	}
+	if !stat.IsDir() {
+		return Skill{}, fmt.Errorf("source %q is not a directory", source)
+	}
+
+	specPath := filepath.Join(absSource, skillManifestFile)
+	spec, err := LoadSpec(specPath)
+	if err != nil {
+		return Skill{}, err
+	}
+
+	if err := ensureLayout(); err != nil {
+		return Skill{}, err
+	}
+
+	root, err := installedDir()
+	if err != nil {
+		return Skill{}, err
+	}
+
+	tmpDir, err := os.MkdirTemp(root, spec.Name+"-tmp-")
+	if err != nil {
+		return Skill{}, err
+	}
+	defer os.RemoveAll(tmpDir)
+
+	if err := copyDir(absSource, tmpDir); err != nil {
+		return Skill{}, err
+	}
+
+	copiedSpecPath := filepath.Join(tmpDir, skillManifestFile)
+	copiedSpec, err := LoadSpec(copiedSpecPath)
+	if err != nil {
+		return Skill{}, err
+	}
+
+	dest := filepath.Join(root, copiedSpec.Name)
+	backup := ""
+	if _, err := os.Stat(dest); err == nil {
+		backup = filepath.Join(root, copiedSpec.Name+".backup")
+		for i := 0; ; i++ {
+			candidate := backup
+			if i > 0 {
+				candidate = fmt.Sprintf("%s-%d", backup, i)
+			}
+
+			if _, err := os.Stat(candidate); errors.Is(err, os.ErrNotExist) {
+				backup = candidate
+				break
+			}
+		}
+
+		if err := os.Rename(dest, backup); err != nil {
+			return Skill{}, fmt.Errorf("prepare install swap: %w", err)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return Skill{}, err
+	}
+
+	if err := os.Rename(tmpDir, dest); err != nil {
+		if backup != "" {
+			_ = os.Rename(backup, dest)
+		}
+		return Skill{}, fmt.Errorf("finalize install swap: %w", err)
+	}
+
+	if backup != "" {
+		if err := os.RemoveAll(backup); err != nil {
+			return Skill{}, fmt.Errorf("cleanup previous install backup: %w", err)
+		}
+	}
+
+	state, err := readEnabledState()
+	if err != nil {
+		return Skill{}, err
+	}
+
+	return Skill{
+		Spec:    copiedSpec,
+		Dir:     dest,
+		Enabled: state[copiedSpec.Name],
+	}, nil
+}
+
+func List() ([]Skill, error) {
+	if err := ensureLayout(); err != nil {
+		return nil, err
+	}
+
+	root, err := installedDir()
+	if err != nil {
+		return nil, err
+	}
+
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil, err
+	}
+
+	state, err := readEnabledState()
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]Skill, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		dir := filepath.Join(root, entry.Name())
+		spec, err := LoadSpec(filepath.Join(dir, skillManifestFile))
+		if err != nil {
+			return nil, err
+		}
+
+		out = append(out, Skill{
+			Spec:    spec,
+			Dir:     dir,
+			Enabled: state[spec.Name],
+		})
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Spec.Name < out[j].Spec.Name
+	})
+
+	return out, nil
+}
+
+func Enabled() ([]Skill, error) {
+	all, err := List()
+	if err != nil {
+		return nil, err
+	}
+
+	enabled := all[:0]
+	for _, skill := range all {
+		if skill.Enabled {
+			enabled = append(enabled, skill)
+		}
+	}
+
+	return slices.Clip(enabled), nil
+}
+
+func Enable(name string) error {
+	skill, err := Get(name)
+	if err != nil {
+		return err
+	}
+
+	state, err := readEnabledState()
+	if err != nil {
+		return err
+	}
+
+	state[skill.Spec.Name] = true
+	return writeEnabledState(state)
+}
+
+func Disable(name string) error {
+	skill, err := Get(name)
+	if err != nil {
+		return err
+	}
+
+	state, err := readEnabledState()
+	if err != nil {
+		return err
+	}
+
+	delete(state, skill.Spec.Name)
+	return writeEnabledState(state)
+}
+
+func Get(name string) (Skill, error) {
+	n := strings.TrimSpace(name)
+	if n == "" {
+		return Skill{}, fmt.Errorf("%w: %q", ErrSkillNotFound, name)
+	}
+
+	all, err := List()
+	if err != nil {
+		return Skill{}, err
+	}
+
+	for _, skill := range all {
+		if skill.Spec.Name == n {
+			return skill, nil
+		}
+	}
+
+	return Skill{}, fmt.Errorf("%w: %s", ErrSkillNotFound, n)
+}
+
+func Run(ctx context.Context, name string, args []string, stdin io.Reader, stdout, stderr io.Writer) error {
+	return RunWithOptions(ctx, name, args, stdin, stdout, stderr, RunOptions{})
+}
+
+func RunWithOptions(ctx context.Context, name string, args []string, stdin io.Reader, stdout, stderr io.Writer, opts RunOptions) error {
+	skill, err := Get(name)
+	if err != nil {
+		return err
+	}
+
+	if !skill.Enabled {
+		return fmt.Errorf("%w: %s", ErrSkillNotEnabled, skill.Spec.Name)
+	}
+
+	grantedPerms, err := grantedPermissions(opts.GrantedPermissions)
+	if err != nil {
+		return err
+	}
+	if err := ensurePermissionsGranted(skill.Spec.Permissions.Required, grantedPerms); err != nil {
+		return err
+	}
+
+	command := resolveCommand(skill.Dir, skill.Spec.Command)
+	cmd := exec.CommandContext(ctx, command, append(skill.Spec.Args, args...)...)
+	cmd.Dir = skill.Dir
+	cmd.Stdin = stdin
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	return cmd.Run()
+}
+
+func resolveCommand(skillDir, command string) string {
+	if command == "" || filepath.IsAbs(command) {
+		return command
+	}
+
+	if strings.Contains(command, string(filepath.Separator)) ||
+		strings.HasPrefix(command, ".") {
+		return filepath.Join(skillDir, command)
+	}
+
+	return command
+}
+
+func isGitLikeSource(source string) bool {
+	s := strings.ToLower(strings.TrimSpace(source))
+	return strings.HasPrefix(s, "http://") ||
+		strings.HasPrefix(s, "https://") ||
+		strings.HasPrefix(s, "git@") ||
+		strings.HasSuffix(s, ".git")
+}
+
+func normalizeStringList(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+
+	seen := map[string]bool{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		v := strings.TrimSpace(value)
+		if v == "" || seen[v] {
+			continue
+		}
+		seen[v] = true
+		out = append(out, v)
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func normalizePermissions(values []string) ([]string, error) {
+	return normalizePermissionsInternal(values, false)
+}
+
+func normalizeGrantedPermissions(values []string) ([]string, error) {
+	return normalizePermissionsInternal(values, true)
+}
+
+func normalizePermissionsInternal(values []string, allowWildcard bool) ([]string, error) {
+	values = normalizeStringList(values)
+	for _, permission := range values {
+		if allowWildcard && permission == "*" {
+			continue
+		}
+		if !validPermission.MatchString(permission) {
+			return nil, fmt.Errorf("invalid permission %q", permission)
+		}
+	}
+	return values, nil
+}
+
+func grantedPermissions(overrides []string) ([]string, error) {
+	base := normalizeStringList(overrides)
+	if len(base) == 0 {
+		base = splitCommaList(os.Getenv(envSkillAllow))
+	}
+	return normalizeGrantedPermissions(base)
+}
+
+func splitCommaList(raw string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+
+	parts := strings.Split(raw, ",")
+	return normalizeStringList(parts)
+}
+
+func ensurePermissionsGranted(required, granted []string) error {
+	if len(required) == 0 {
+		return nil
+	}
+
+	grantedSet := map[string]bool{}
+	hasWildcard := false
+	for _, permission := range granted {
+		grantedSet[permission] = true
+		if permission == "*" {
+			hasWildcard = true
+		}
+	}
+
+	if hasWildcard {
+		return nil
+	}
+
+	var missing []string
+	for _, permission := range required {
+		if !grantedSet[permission] {
+			missing = append(missing, permission)
+		}
+	}
+
+	if len(missing) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf("%w: missing required permissions: %s (grant with --allow or %s)", ErrPermissionDenied, strings.Join(missing, ", "), envSkillAllow)
+}
+
+func readEnabledState() (map[string]bool, error) {
+	if err := ensureLayout(); err != nil {
+		return nil, err
+	}
+
+	path, err := enabledPath()
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return map[string]bool{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	state := map[string]bool{}
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+
+	return state, nil
+}
+
+func writeEnabledState(state map[string]bool) error {
+	if err := ensureLayout(); err != nil {
+		return err
+	}
+
+	path, err := enabledPath()
+	if err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+
+	tmpFile, err := os.CreateTemp(filepath.Dir(path), "enabled-*.json")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmpFile.Name()
+	defer os.Remove(tmpPath)
+
+	if _, err := tmpFile.Write(data); err != nil {
+		tmpFile.Close()
+		return err
+	}
+	if err := tmpFile.Close(); err != nil {
+		return err
+	}
+
+	return os.Rename(tmpPath, path)
+}
+
+func copyDir(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+
+		if d.IsDir() {
+			// Avoid copying Git metadata into installed skills.
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return os.MkdirAll(filepath.Join(dst, rel), 0o755)
+		}
+
+		if !d.Type().IsRegular() {
+			return nil
+		}
+
+		srcInfo, err := d.Info()
+		if err != nil {
+			return err
+		}
+
+		return copyFile(path, filepath.Join(dst, rel), srcInfo.Mode())
+	})
+}
+
+func copyFile(src, dst string, mode fs.FileMode) error {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcFile.Close()
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+
+	dstFile, err := os.OpenFile(dst, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mode.Perm())
+	if err != nil {
+		return err
+	}
+	defer dstFile.Close()
+
+	if _, err := io.Copy(dstFile, srcFile); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/skills/skills_test.go
+++ b/skills/skills_test.go
@@ -1,0 +1,251 @@
+package skills
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func writeSkillSource(t *testing.T) string {
+	t.Helper()
+
+	src := t.TempDir()
+
+	skillToml := `name = "echoer"
+description = "Echoes text input"
+version = "0.1.0"
+command = "./run.sh"
+args = ["--static"]
+
+[io]
+inputs = ["text"]
+outputs = ["text"]
+
+[permissions]
+required = ["filesystem.read"]
+`
+
+	if err := os.WriteFile(filepath.Join(src, "skill.toml"), []byte(skillToml), 0o644); err != nil {
+		t.Fatalf("write skill.toml: %v", err)
+	}
+
+	script := "#!/bin/sh\nprintf 'run:%s %s\\n' \"$1\" \"$2\"\n"
+	if err := os.WriteFile(filepath.Join(src, "run.sh"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write run.sh: %v", err)
+	}
+
+	return src
+}
+
+func writeSkillSourceWithScript(t *testing.T, scriptBody string) string {
+	t.Helper()
+
+	src := t.TempDir()
+
+	skillToml := `name = "echoer"
+description = "Echoes text input"
+version = "0.1.0"
+command = "./run.sh"
+args = ["--static"]
+
+[io]
+inputs = ["text"]
+outputs = ["text"]
+
+[permissions]
+required = ["filesystem.read"]
+`
+
+	if err := os.WriteFile(filepath.Join(src, "skill.toml"), []byte(skillToml), 0o644); err != nil {
+		t.Fatalf("write skill.toml: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(src, "run.sh"), []byte(scriptBody), 0o755); err != nil {
+		t.Fatalf("write run.sh: %v", err)
+	}
+
+	return src
+}
+
+func TestInstallListEnableDisable(t *testing.T) {
+	t.Setenv("OLLAMA_SKILLS", t.TempDir())
+
+	src := writeSkillSource(t)
+
+	installed, err := Install(src)
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	if installed.Spec.Name != "echoer" {
+		t.Fatalf("Install() name = %q, want %q", installed.Spec.Name, "echoer")
+	}
+	if installed.Enabled {
+		t.Fatalf("Install() enabled = true, want false")
+	}
+
+	all, err := List()
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("List() len = %d, want 1", len(all))
+	}
+	if all[0].Enabled {
+		t.Fatalf("List()[0].Enabled = true, want false")
+	}
+
+	if err := Enable("echoer"); err != nil {
+		t.Fatalf("Enable() error = %v", err)
+	}
+
+	enabled, err := Enabled()
+	if err != nil {
+		t.Fatalf("Enabled() error = %v", err)
+	}
+	if len(enabled) != 1 {
+		t.Fatalf("Enabled() len = %d, want 1", len(enabled))
+	}
+	if !enabled[0].Enabled {
+		t.Fatalf("Enabled()[0].Enabled = false, want true")
+	}
+
+	if err := Disable("echoer"); err != nil {
+		t.Fatalf("Disable() error = %v", err)
+	}
+
+	enabled, err = Enabled()
+	if err != nil {
+		t.Fatalf("Enabled() after disable error = %v", err)
+	}
+	if len(enabled) != 0 {
+		t.Fatalf("Enabled() after disable len = %d, want 0", len(enabled))
+	}
+}
+
+func TestRunRequiresEnabledSkill(t *testing.T) {
+	t.Setenv("OLLAMA_SKILLS", t.TempDir())
+	src := writeSkillSource(t)
+
+	if _, err := Install(src); err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+
+	err := Run(context.Background(), "echoer", []string{"hello"}, nil, &bytes.Buffer{}, &bytes.Buffer{})
+	if !errors.Is(err, ErrSkillNotEnabled) {
+		t.Fatalf("Run() error = %v, want ErrSkillNotEnabled", err)
+	}
+}
+
+func TestRun(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script execution not supported in this test on windows")
+	}
+
+	t.Setenv("OLLAMA_SKILLS", t.TempDir())
+	t.Setenv("OLLAMA_SKILL_ALLOW", "filesystem.read")
+	src := writeSkillSource(t)
+
+	if _, err := Install(src); err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	if err := Enable("echoer"); err != nil {
+		t.Fatalf("Enable() error = %v", err)
+	}
+
+	var out bytes.Buffer
+	if err := Run(context.Background(), "echoer", []string{"hello"}, nil, &out, &out); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if got, want := out.String(), "run:--static hello\n"; got != want {
+		t.Fatalf("Run() output = %q, want %q", got, want)
+	}
+}
+
+func TestRunRequiresPermissionGrant(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script execution not supported in this test on windows")
+	}
+
+	t.Setenv("OLLAMA_SKILLS", t.TempDir())
+	src := writeSkillSource(t)
+
+	if _, err := Install(src); err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	if err := Enable("echoer"); err != nil {
+		t.Fatalf("Enable() error = %v", err)
+	}
+
+	err := Run(context.Background(), "echoer", []string{"hello"}, nil, &bytes.Buffer{}, &bytes.Buffer{})
+	if !errors.Is(err, ErrPermissionDenied) {
+		t.Fatalf("Run() error = %v, want ErrPermissionDenied", err)
+	}
+}
+
+func TestLoadSpecRequiresCommand(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "skill.toml"), []byte("name = \"bad\"\n"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	_, err := LoadSpec(filepath.Join(tmp, "skill.toml"))
+	if err == nil {
+		t.Fatalf("LoadSpec() expected error, got nil")
+	}
+}
+
+func TestLoadSpecRejectsInvalidPermission(t *testing.T) {
+	tmp := t.TempDir()
+	bad := `name = "bad"
+command = "./run.sh"
+[permissions]
+required = ["bad permission"]
+`
+	if err := os.WriteFile(filepath.Join(tmp, "skill.toml"), []byte(bad), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	_, err := LoadSpec(filepath.Join(tmp, "skill.toml"))
+	if err == nil {
+		t.Fatalf("LoadSpec() expected error, got nil")
+	}
+}
+
+func TestInstallReplacesExistingAndKeepsEnabledState(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script execution not supported in this test on windows")
+	}
+
+	t.Setenv("OLLAMA_SKILLS", t.TempDir())
+	t.Setenv("OLLAMA_SKILL_ALLOW", "filesystem.read")
+
+	first := writeSkillSourceWithScript(t, "#!/bin/sh\nprintf 'v1:%s\\n' \"$1\"\n")
+	if _, err := Install(first); err != nil {
+		t.Fatalf("Install(first) error = %v", err)
+	}
+	if err := Enable("echoer"); err != nil {
+		t.Fatalf("Enable() error = %v", err)
+	}
+
+	second := writeSkillSourceWithScript(t, "#!/bin/sh\nprintf 'v2:%s\\n' \"$1\"\n")
+	installed, err := Install(second)
+	if err != nil {
+		t.Fatalf("Install(second) error = %v", err)
+	}
+	if !installed.Enabled {
+		t.Fatalf("Install(second) enabled = false, want true")
+	}
+
+	var out bytes.Buffer
+	if err := Run(context.Background(), "echoer", []string{"hello"}, nil, &out, &out); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if got, want := out.String(), "v2:--static\n"; got != want {
+		t.Fatalf("Run() output = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- add ollama skills CLI commands: list, install, enable, disable, and run
- add skills runtime support with skill.toml parsing, validation, and permission enforcement
- add in-chat visibility for active skills and documented CLI usage
- add tests for skills package and CLI commands

## Validation
- go test ./...
- golangci-lint run
- npm ci && npm test (in app/ui/app)
