### PR TITLE
cmd: use native Ollama API endpoint for OpenClaw

### DIFF
--- a/cmd/config/openclaw.go
+++ b/cmd/config/openclaw.go
@@ -502,7 +502,7 @@ func (c *Openclaw) Edit(models []string) error {
 		ollama = make(map[string]any)
 	}
 
-	ollama["baseUrl"] = envconfig.Host().String() + "/v1"
+	ollama["baseUrl"] = envconfig.Host().String()
 	// needed to register provider
 	ollama["apiKey"] = "ollama-local"
 	ollama["api"] = "ollama"

--- a/cmd/config/openclaw_test.go
+++ b/cmd/config/openclaw_test.go
@@ -589,7 +589,7 @@ const testOpenclawFixture = `{
     "providers": {
       "anthropic": {"apiKey": "xxx"},
       "ollama": {
-        "baseUrl": "http://127.0.0.1:11434/v1",
+        "baseUrl": "http://127.0.0.1:11434",
         "models": [{"id": "old-model", "customField": "preserved"}]
       }
     }


### PR DESCRIPTION
Remove the /v1 suffix from the OpenClaw provider baseUrl so it uses the native Ollama API instead of the OpenAI-compatible endpoint. The /v1 endpoint my break tool calling in OpenClaw.

Seems this was being automatically corrected by Openclaw itself, but good to clean up.

https://github.com/openclaw/openclaw/blob/main/docs/providers/ollama.md