### PR TITLE
mlx: prevent remote creation mismatch

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -145,6 +145,12 @@ func CreateHandler(cmd *cobra.Command, args []string) error {
 	// Check for --experimental flag for safetensors model creation
 	experimental, _ := cmd.Flags().GetBool("experimental")
 	if experimental {
+		host := envconfig.Host()
+		h, _, _ := net.SplitHostPort(host.Host)
+		ip := net.ParseIP(h)
+		if ip == nil || (!ip.IsLoopback() && !ip.IsUnspecified()) {
+			return errors.New("remote safetensor model creation not yet supported")
+		}
 		// Get Modelfile content - either from -f flag or default to "FROM ."
 		var reader io.Reader
 		filename, err := getModelfileName(cmd)
@@ -214,6 +220,12 @@ func CreateHandler(cmd *cobra.Command, args []string) error {
 		if filename == "" {
 			// No Modelfile found - check if current directory is an image gen model
 			if create.IsTensorModelDir(".") {
+				host := envconfig.Host()
+				h, _, _ := net.SplitHostPort(host.Host)
+				ip := net.ParseIP(h)
+				if ip == nil || (!ip.IsLoopback() && !ip.IsUnspecified()) {
+					return errors.New("remote safetensor model creation not yet supported")
+				}
 				quantize, _ := cmd.Flags().GetString("quantize")
 				return xcreateclient.CreateModel(xcreateclient.CreateOptions{
 					ModelName: modelName,


### PR DESCRIPTION
If the user is pointing at a remote OLLAMA_HOST, fail experimental safetensor based create operations as we only support local creation currently.