### PR TITLE
cmd/config: register verbose flag in LaunchCmd

### DIFF
--- a/cmd/config/integrations.go
+++ b/cmd/config/integrations.go
@@ -1143,6 +1143,7 @@ Examples:
 
 	cmd.Flags().StringVar(&modelFlag, "model", "", "Model to use")
 	cmd.Flags().BoolVar(&configFlag, "config", false, "Configure without launching")
+	cmd.Flags().Bool("verbose", false, "Show timings for response")
 	return cmd
 }
 

--- a/cmd/config/integrations_test.go
+++ b/cmd/config/integrations_test.go
@@ -141,6 +141,11 @@ func TestLaunchCmd(t *testing.T) {
 		if configFlag == nil {
 			t.Error("--config flag should exist")
 		}
+
+		verboseFlag := cmd.Flags().Lookup("verbose")
+		if verboseFlag == nil {
+			t.Error("--verbose flag should exist")
+		}
 	})
 
 	t.Run("PreRunE is set", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Register the `verbose` flag on `LaunchCmd` so that the interactive chat flow (which reads and sets this flag) works correctly when launched via `ollama launch`

## Problem

Running a model through `ollama launch` triggers: `Error running model: flag accessed but not defined: verbose`. The interactive chat code (`generateInteractive` / `chat`) accesses `cmd.Flags().GetBool("verbose")`, but `LaunchCmd` never registered that flag.

## Test plan

- Added `verbose` flag existence check to `TestLaunchCmd/flags_exist`
- All existing `cmd/config` tests pass

Fixes #14654