### PR TITLE
server: apply format constraint when thinking is disabled

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -2278,7 +2278,8 @@ func (s *Server) ChatHandler(c *gin.Context) {
 			// current approach uses the transition from parsed thinking content to
 			// parsed non-thinking content as the signal to turn constraining on
 
-			if req.Format != nil && structuredOutputsState == structuredOutputsState_None && ((builtinParser != nil || thinkingState != nil) && slices.Contains(m.Capabilities(), model.CapabilityThinking)) {
+			thinkEnabled := req.Think == nil || req.Think.Bool()
+			if req.Format != nil && structuredOutputsState == structuredOutputsState_None && thinkEnabled && ((builtinParser != nil || thinkingState != nil) && slices.Contains(m.Capabilities(), model.CapabilityThinking)) {
 				currentFormat = nil
 			}
 

--- a/server/routes_generate_test.go
+++ b/server/routes_generate_test.go
@@ -2106,6 +2106,69 @@ func TestChatWithPromptEndingInThinkTag(t *testing.T) {
 			t.Errorf("expected final done reason stop, got %s", last.DoneReason)
 		}
 	})
+
+	t.Run("format applied when think disabled", func(t *testing.T) {
+		var (
+			requestsMu sync.Mutex
+			requests   []llm.CompletionRequest
+		)
+
+		format := json.RawMessage(`{"type":"object","properties":{"answer":{"type":"string"}}}`)
+
+		mock.CompletionFn = func(ctx context.Context, r llm.CompletionRequest, fn func(r llm.CompletionResponse)) error {
+			requestsMu.Lock()
+			requests = append(requests, r)
+			requestsMu.Unlock()
+
+			fn(llm.CompletionResponse{
+				Content:            `{"answer":"42"}`,
+				Done:               true,
+				DoneReason:         llm.DoneReasonStop,
+				PromptEvalCount:    1,
+				PromptEvalDuration: 1,
+				EvalCount:          1,
+				EvalDuration:       1,
+			})
+			return nil
+		}
+
+		think := false
+		streamRequest := false
+		w := createRequest(t, s.ChatHandler, api.ChatRequest{
+			Model:    "test-thinking",
+			Messages: []api.Message{{Role: "user", Content: "respond in json"}},
+			Think:    &api.ThinkValue{Value: think},
+			Stream:   &streamRequest,
+			Format:   format,
+		})
+
+		mock.CompletionFn = nil
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", w.Code)
+		}
+
+		if len(requests) != 1 {
+			t.Fatalf("expected one completion call, got %d", len(requests))
+		}
+
+		if requests[0].Format == nil {
+			t.Error("expected format to be passed to completion when think is disabled")
+		}
+
+		if !bytes.Equal([]byte(format), []byte(requests[0].Format)) {
+			t.Errorf("expected completion format to match request format")
+		}
+
+		var resp api.ChatResponse
+		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+			t.Fatal(err)
+		}
+
+		if resp.Message.Content != `{"answer":"42"}` {
+			t.Errorf("expected content %q, got %q", `{"answer":"42"}`, resp.Message.Content)
+		}
+	})
 }
 
 func TestGenerateUnload(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fix format/structured outputs being silently ignored when `think=false` on thinking-capable models (e.g. qwen3.5)

## Problem

When sending `think=false` + `format=json`, the structured outputs logic still defers format masking (sets `currentFormat = nil`) because the condition only checks whether the model has a builtin parser or thinking capability, not whether thinking is actually enabled for the request. Since no thinking content is produced, the restart signal never fires, and format masking is never applied.

## Fix

Add a `thinkEnabled` check so that format masking is only deferred when thinking will actually produce content.

## Test plan

- Added `format applied when think disabled` test to `TestChatWithPromptEndingInThinkTag`
- Verifies that with `think=false` + format, the completion receives the format constraint directly (single call, format not nil)
- All existing structured outputs tests pass (think=true behavior unchanged)

Fixes #14645