### PR TITLE
progress: suppress ANSI escape sequences when not connected to a terminal

### DIFF
--- a/progress/progress.go
+++ b/progress/progress.go
@@ -29,10 +29,14 @@ type Progress struct {
 
 	ticker *time.Ticker
 	states []State
+	isTerm bool
 }
 
 func NewProgress(w io.Writer) *Progress {
 	p := &Progress{w: bufio.NewWriter(w)}
+	if f, ok := w.(interface{ Fd() uintptr }); ok {
+		p.isTerm = term.IsTerminal(int(f.Fd()))
+	}
 	go p.start()
 	return p
 }
@@ -56,7 +60,7 @@ func (p *Progress) stop() bool {
 
 func (p *Progress) Stop() bool {
 	stopped := p.stop()
-	if stopped {
+	if stopped && p.isTerm {
 		fmt.Fprint(p.w, "\n")
 		p.w.Flush()
 	}
@@ -64,6 +68,10 @@ func (p *Progress) Stop() bool {
 }
 
 func (p *Progress) StopAndClear() bool {
+	if !p.isTerm {
+		return p.stop()
+	}
+
 	defer p.w.Flush()
 
 	fmt.Fprint(p.w, "\033[?25l")
@@ -91,6 +99,10 @@ func (p *Progress) Add(key string, state State) {
 }
 
 func (p *Progress) render() {
+	if !p.isTerm {
+		return
+	}
+
 	_, termHeight, err := term.GetSize(int(os.Stderr.Fd()))
 	if err != nil {
 		termHeight = defaultTermHeight

--- a/progress/progress_test.go
+++ b/progress/progress_test.go
@@ -1,0 +1,54 @@
+package progress
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewProgressNonTTY(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewProgress(&buf)
+	p.Add("test", NewSpinner("loading"))
+
+	// let the ticker fire a few times
+	time.Sleep(350 * time.Millisecond)
+	p.Stop()
+
+	output := buf.String()
+	if strings.Contains(output, "\033[") {
+		t.Errorf("non-TTY progress should not contain ANSI escape sequences, got: %q", output)
+	}
+}
+
+func TestNewProgressNonTTYStopAndClear(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewProgress(&buf)
+	p.Add("test", NewSpinner("loading"))
+
+	time.Sleep(350 * time.Millisecond)
+	p.StopAndClear()
+
+	output := buf.String()
+	if strings.Contains(output, "\033[") {
+		t.Errorf("non-TTY StopAndClear should not contain ANSI escape sequences, got: %q", output)
+	}
+}
+
+func TestNewProgressTTYDetection(t *testing.T) {
+	// bytes.Buffer does not implement Fd(), so isTerm should be false
+	var buf bytes.Buffer
+	p := NewProgress(&buf)
+	if p.isTerm {
+		t.Error("expected isTerm=false for bytes.Buffer")
+	}
+	p.Stop()
+
+	// os.Stderr implements Fd(), isTerm depends on environment
+	// in CI/test it's typically not a TTY
+	p2 := NewProgress(os.Stderr)
+	p2.Stop()
+	// just verify it doesn't panic
+}


### PR DESCRIPTION
## Summary

Suppress ANSI escape sequences in the `progress` package when stderr is not connected to a terminal. This prevents control character garbage when piping `ollama run` output.

Fixes #14571

## Changes

- Add TTY detection in `NewProgress()` via `term.IsTerminal()` (already a dependency)
- Skip `render()` entirely when not a TTY
- Skip ANSI output in `Stop()` and `StopAndClear()` when not a TTY

## Test plan

- Added `progress/progress_test.go` with 3 tests verifying non-TTY behavior
- `go test ./progress/ -v` passes