### PR TITLE
server: skip renderer/parser inheritance when custom template provided

### DIFF
--- a/server/create.go
+++ b/server/create.go
@@ -149,7 +149,7 @@ func (s *Server) CreateHandler(c *gin.Context) {
 							if cfgFile, fErr := os.Open(configPath); fErr == nil {
 								var baseConfig model.ConfigV2
 								if decErr := json.NewDecoder(cfgFile).Decode(&baseConfig); decErr == nil {
-									if config.Renderer == "" {
+									if config.Renderer == "" && r.Template == "" {
 										config.Renderer = baseConfig.Renderer
 									}
 									if config.Parser == "" {
@@ -516,11 +516,13 @@ func createModel(r api.CreateRequest, name model.Name, baseLayers []*layerGGML, 
 			// Auto-detect renderer, parser, and stop tokens from GGUF architecture.
 			// TODO: abstract this into a registry/lookup table when multiple models
 			// need architecture-based renderer/parser/stop defaults.
-			if config.Renderer == "" || config.Parser == "" {
+			if (config.Renderer == "" && r.Template == "") || config.Parser == "" {
 				arch := layer.GGML.KV().Architecture()
 				switch arch {
 				case "gemma4":
-					config.Renderer = cmp.Or(config.Renderer, "gemma4")
+					if r.Template == "" {
+						config.Renderer = cmp.Or(config.Renderer, "gemma4")
+					}
 					config.Parser = cmp.Or(config.Parser, "gemma4")
 					if _, ok := r.Parameters["stop"]; !ok {
 						if r.Parameters == nil {

--- a/server/routes_create_test.go
+++ b/server/routes_create_test.go
@@ -287,6 +287,74 @@ func TestCreateFromModelInheritsRendererParser(t *testing.T) {
 	}
 }
 
+func TestCreateFromModelSkipsRendererWithCustomTemplate(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	p := t.TempDir()
+	t.Setenv("OLLAMA_MODELS", p)
+	var s Server
+
+	const (
+		renderer = "custom-renderer"
+		parser   = "custom-parser"
+	)
+
+	_, digest := createBinFile(t, nil, nil)
+
+	w := createRequest(t, s.CreateHandler, api.CreateRequest{
+		Name:     "base",
+		Files:    map[string]string{"base.gguf": digest},
+		Renderer: renderer,
+		Parser:   parser,
+		Stream:   &stream,
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status code 200, actual %d", w.Code)
+	}
+
+	// Create child with custom template — should NOT inherit renderer, but SHOULD inherit parser
+	w = createRequest(t, s.CreateHandler, api.CreateRequest{
+		Name:     "child",
+		From:     "base",
+		Template: "{{ .Prompt }}",
+		Stream:   &stream,
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status code 200, actual %d", w.Code)
+	}
+
+	mf, err := manifest.ParseNamedManifest(model.ParseName("child"))
+	if err != nil {
+		t.Fatalf("parse manifest: %v", err)
+	}
+	if mf.Config.Digest == "" {
+		t.Fatalf("unexpected empty config digest for child manifest")
+	}
+
+	configPath, err := manifest.BlobsPath(mf.Config.Digest)
+	if err != nil {
+		t.Fatalf("config blob path: %v", err)
+	}
+
+	cfgFile, err := os.Open(configPath)
+	if err != nil {
+		t.Fatalf("open config blob: %v", err)
+	}
+	defer cfgFile.Close()
+
+	var cfg model.ConfigV2
+	if err := json.NewDecoder(cfgFile).Decode(&cfg); err != nil {
+		t.Fatalf("decode config: %v", err)
+	}
+
+	if cfg.Renderer != "" {
+		t.Fatalf("expected empty renderer when custom template provided, got %q", cfg.Renderer)
+	}
+	if cfg.Parser != parser {
+		t.Fatalf("expected parser %q to be inherited even with custom template, got %q", parser, cfg.Parser)
+	}
+}
+
 func TestCreateRemovesLayers(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 


### PR DESCRIPTION
## Summary

- When creating a model with `FROM` and a custom `TEMPLATE`, the parent model's `Renderer` and `Parser` were unconditionally inherited
- Built-in renderers take precedence over templates at inference time, so the custom template was silently ignored
- Only inherit `Renderer`/`Parser` from the parent when the child does not specify its own `TEMPLATE`

## Test plan

- [x] `TestCreateFromModelSkipsRendererParserWithCustomTemplate` — verifies renderer/parser are NOT inherited when custom template is provided
- [x] `TestCreateFromModelInheritsRendererParser` — existing test still passes (no regression for models without custom template)
- [x] `TestGenerateWithBuiltinRenderer` — existing renderer tests still pass

Fixes #14560