### PR TITLE
server: remove duplicate template parse and debug print in create

### DIFF
--- a/server/create.go
+++ b/server/create.go
@@ -697,9 +697,6 @@ func setTemplate(layers []manifest.Layer, t string) ([]manifest.Layer, error) {
 	if _, err := template.Parse(t); err != nil {
 		return nil, fmt.Errorf("%w: %s", errBadTemplate, err)
 	}
-	if _, err := template.Parse(t); err != nil {
-		return nil, fmt.Errorf("%w: %s", errBadTemplate, err)
-	}
 
 	blob := strings.NewReader(t)
 	layer, err := manifest.NewLayer(blob, "application/vnd.ollama.image.template")
@@ -792,7 +789,6 @@ func setMessages(layers []manifest.Layer, m []api.Message) ([]manifest.Layer, er
 		return layers, nil
 	}
 
-	fmt.Printf("removing old messages\n")
 	layers = removeLayer(layers, "application/vnd.ollama.image.messages")
 	var b bytes.Buffer
 	if err := json.NewEncoder(&b).Encode(m); err != nil {


### PR DESCRIPTION
## Summary

- Remove duplicate `template.Parse` call in `setTemplate` (called twice on the same input)
- Remove leftover `fmt.Printf("removing old messages\n")` debug statement in `setMessages`

## Test plan

- [x] All existing `TestCreate*` tests pass without regression