### PR TITLE
Preserve thought signatures in tool calls and messages (fix #14567)

### DIFF
--- a/anthropic/anthropic.go
+++ b/anthropic/anthropic.go
@@ -386,6 +386,7 @@ func convertMessage(msg MessageParam) ([]api.Message, error) {
 		var images []api.ImageData
 		var toolCalls []api.ToolCall
 		var thinking string
+		var signature string
 		var toolResults []api.Message
 		textBlocks := 0
 		imageBlocks := 0
@@ -489,6 +490,9 @@ func convertMessage(msg MessageParam) ([]api.Message, error) {
 				if t, ok := blockMap["thinking"].(string); ok {
 					thinking = t
 				}
+				if s, ok := blockMap["signature"].(string); ok {
+					signature = s
+				}
 
 			case "server_tool_use":
 				serverToolUseBlocks++
@@ -525,6 +529,7 @@ func convertMessage(msg MessageParam) ([]api.Message, error) {
 				Images:    images,
 				ToolCalls: toolCalls,
 				Thinking:  thinking,
+				Signature: signature,
 			}
 			messages = append(messages, m)
 		}
@@ -659,8 +664,9 @@ func ToMessagesResponse(id string, r api.ChatResponse) MessagesResponse {
 
 	if r.Message.Thinking != "" {
 		content = append(content, ContentBlock{
-			Type:     "thinking",
-			Thinking: ptr(r.Message.Thinking),
+			Type:      "thinking",
+			Thinking:  ptr(r.Message.Thinking),
+			Signature: r.Message.Signature,
 		})
 	}
 
@@ -801,6 +807,35 @@ func (c *StreamConverter) Process(r api.ChatResponse) []StreamEvent {
 				Delta: Delta{
 					Type:     "thinking_delta",
 					Thinking: r.Message.Thinking,
+				},
+			},
+		})
+	}
+
+	if r.Message.Signature != "" && !c.thinkingDone {
+		if !c.thinkingStarted {
+			c.thinkingStarted = true
+			events = append(events, StreamEvent{
+				Event: "content_block_start",
+				Data: ContentBlockStartEvent{
+					Type:  "content_block_start",
+					Index: c.contentIndex,
+					ContentBlock: ContentBlock{
+						Type:     "thinking",
+						Thinking: ptr(""),
+					},
+				},
+			})
+		}
+
+		events = append(events, StreamEvent{
+			Event: "content_block_delta",
+			Data: ContentBlockDeltaEvent{
+				Type:  "content_block_delta",
+				Index: c.contentIndex,
+				Delta: Delta{
+					Type:      "signature_delta",
+					Signature: r.Message.Signature,
 				},
 			},
 		})

--- a/anthropic/anthropic_test.go
+++ b/anthropic/anthropic_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ollama/ollama/api"
 )
@@ -1553,4 +1555,122 @@ func TestCitation(t *testing.T) {
 	if unmarshaled.CitedText != "Some cited text..." {
 		t.Errorf("cited_text mismatch: expected 'Some cited text...', got %q", unmarshaled.CitedText)
 	}
+}
+
+func TestConvertMessage_WithThinkingSignature(t *testing.T) {
+	msg := MessageParam{
+		Role: "assistant",
+		Content: []any{
+			map[string]any{
+				"type":      "thinking",
+				"thinking":  "I am thinking...",
+				"signature": "sig_abc123",
+			},
+			map[string]any{
+				"type": "text",
+				"text": "Hello!",
+			},
+		},
+	}
+
+	messages, err := convertMessage(msg)
+	require.NoError(t, err)
+
+	if len(messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(messages))
+	}
+
+	if messages[0].Thinking != "I am thinking..." {
+		t.Errorf("expected thinking 'I am thinking...', got %q", messages[0].Thinking)
+	}
+
+	if messages[0].Signature != "sig_abc123" {
+		t.Errorf("expected signature 'sig_abc123', got %q", messages[0].Signature)
+	}
+}
+
+func TestToMessagesResponse_WithThinkingSignature(t *testing.T) {
+	resp := api.ChatResponse{
+		Model: "test-model",
+		Message: api.Message{
+			Role:      "assistant",
+			Content:   "Hello!",
+			Thinking:  "I am thinking...",
+			Signature: "sig_abc123",
+		},
+	}
+
+	result := ToMessagesResponse("msg_123", resp)
+
+	foundThinking := false
+	for _, block := range result.Content {
+		if block.Type == "thinking" {
+			foundThinking = true
+			if block.Signature != "sig_abc123" {
+				t.Errorf("expected signature 'sig_abc123', got %q", block.Signature)
+			}
+		}
+	}
+
+	if !foundThinking {
+		t.Error("expected thinking block in response")
+	}
+}
+
+func TestStreamConverter_WithThinkingAndSignature(t *testing.T) {
+	conv := NewStreamConverter("msg_123", "test-model", 0)
+
+	// First chunk with thinking
+	resp1 := api.ChatResponse{
+		Model: "test-model",
+		Message: api.Message{
+			Role:     "assistant",
+			Thinking: "Let me think",
+		},
+		Metrics: api.Metrics{PromptEvalCount: 10},
+	}
+
+	events1 := conv.Process(resp1)
+	// message_start, content_block_start (thinking), content_block_delta (thinking)
+	require.Len(t, events1, 3)
+	assert.Equal(t, "message_start", events1[0].Event)
+	assert.Equal(t, "content_block_start", events1[1].Event)
+	assert.Equal(t, "content_block_delta", events1[2].Event)
+	assert.Equal(t, "thinking_delta", events1[2].Data.(ContentBlockDeltaEvent).Delta.Type)
+
+	// Second chunk with signature
+	resp2 := api.ChatResponse{
+		Model: "test-model",
+		Message: api.Message{
+			Role:      "assistant",
+			Signature: "sig123",
+		},
+	}
+
+	events2 := conv.Process(resp2)
+	// content_block_delta (signature)
+	require.Len(t, events2, 1)
+	assert.Equal(t, "content_block_delta", events2[0].Event)
+	assert.Equal(t, "signature_delta", events2[0].Data.(ContentBlockDeltaEvent).Delta.Type)
+	assert.Equal(t, "sig123", events2[0].Data.(ContentBlockDeltaEvent).Delta.Signature)
+
+	// Final chunk with content
+	resp3 := api.ChatResponse{
+		Model: "test-model",
+		Message: api.Message{
+			Role:    "assistant",
+			Content: "Hello",
+		},
+		Done:       true,
+		DoneReason: "stop",
+		Metrics:    api.Metrics{EvalCount: 5},
+	}
+
+	events3 := conv.Process(resp3)
+	// content_block_stop (thinking), content_block_start (text), content_block_delta (text),
+	// content_block_stop (text), message_delta, message_stop
+	require.Len(t, events3, 6)
+	assert.Equal(t, "content_block_stop", events3[0].Event)
+	assert.Equal(t, "content_block_start", events3[1].Event)
+	assert.Equal(t, "content_block_delta", events3[2].Event)
 }

--- a/api/types.go
+++ b/api/types.go
@@ -214,6 +214,7 @@ type Message struct {
 	// Thinking contains the text that was inside thinking tags in the
 	// original model output when ChatRequest.Think is enabled.
 	Thinking   string      `json:"thinking,omitempty"`
+	Signature  string      `json:"signature,omitempty"`
 	Images     []ImageData `json:"images,omitempty"`
 	ToolCalls  []ToolCall  `json:"tool_calls,omitempty"`
 	ToolName   string      `json:"tool_name,omitempty"`
@@ -238,9 +239,10 @@ type ToolCall struct {
 }
 
 type ToolCallFunction struct {
-	Index     int                       `json:"index"`
-	Name      string                    `json:"name"`
-	Arguments ToolCallFunctionArguments `json:"arguments"`
+	Index            int                       `json:"index"`
+	Name             string                    `json:"name"`
+	Arguments        ToolCallFunctionArguments `json:"arguments"`
+	ThoughtSignature string                    `json:"thought_signature,omitempty"`
 }
 
 // ToolCallFunctionArguments holds tool call arguments in insertion order.

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -910,3 +910,30 @@ func TestToolPropertiesMap_NestedProperties(t *testing.T) {
 		assert.Equal(t, expected, string(data))
 	})
 }
+
+func TestMessage_SignaturePreservation(t *testing.T) {
+	input := `{"role":"assistant","content":"hello","thinking":"reasoning","signature":"sig123"}`
+	var msg Message
+	err := json.Unmarshal([]byte(input), &msg)
+	require.NoError(t, err)
+
+	assert.Equal(t, "sig123", msg.Signature)
+	assert.Equal(t, "reasoning", msg.Thinking)
+
+	output, err := json.Marshal(msg)
+	require.NoError(t, err)
+	assert.JSONEq(t, input, string(output))
+}
+
+func TestToolCallFunction_ThoughtSignaturePreservation(t *testing.T) {
+	input := `{"index":1,"name":"test","arguments":{"arg1":"val1"},"thought_signature":"tsig456"}`
+	var fn ToolCallFunction
+	err := json.Unmarshal([]byte(input), &fn)
+	require.NoError(t, err)
+
+	assert.Equal(t, "tsig456", fn.ThoughtSignature)
+
+	output, err := json.Marshal(fn)
+	require.NoError(t, err)
+	assert.JSONEq(t, input, string(output))
+}

--- a/middleware/anthropic.go
+++ b/middleware/anthropic.go
@@ -496,6 +496,9 @@ func buildWebSearchAssistantMessage(response api.ChatResponse, webSearchCall api
 	if response.Message.Thinking != "" {
 		assistantMsg.Thinking = response.Message.Thinking
 	}
+	if response.Message.Signature != "" {
+		assistantMsg.Signature = response.Message.Signature
+	}
 	return assistantMsg
 }
 

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -35,6 +35,7 @@ type Message struct {
 	Role       string     `json:"role"`
 	Content    any        `json:"content"`
 	Reasoning  string     `json:"reasoning,omitempty"`
+	Signature  string     `json:"signature,omitempty"`
 	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`
 	Name       string     `json:"name,omitempty"`
 	ToolCallID string     `json:"tool_call_id,omitempty"`
@@ -180,8 +181,9 @@ type ToolCall struct {
 	Index    int    `json:"index"`
 	Type     string `json:"type"`
 	Function struct {
-		Name      string `json:"name"`
-		Arguments string `json:"arguments"`
+		Name             string `json:"name"`
+		Arguments        string `json:"arguments"`
+		ThoughtSignature string `json:"thought_signature,omitempty"`
 	} `json:"function"`
 }
 
@@ -246,6 +248,7 @@ func ToToolCalls(tc []api.ToolCall) []ToolCall {
 		toolCalls[i].Type = "function"
 		toolCalls[i].Function.Name = tc.Function.Name
 		toolCalls[i].Index = tc.Function.Index
+		toolCalls[i].Function.ThoughtSignature = tc.Function.ThoughtSignature
 
 		args, err := json.Marshal(tc.Function.Arguments)
 		if err != nil {
@@ -275,7 +278,7 @@ func ToChatCompletion(id string, r api.ChatResponse) ChatCompletion {
 		SystemFingerprint: "fp_ollama",
 		Choices: []Choice{{
 			Index:   0,
-			Message: Message{Role: r.Message.Role, Content: r.Message.Content, ToolCalls: toolCalls, Reasoning: r.Message.Thinking},
+			Message: Message{Role: r.Message.Role, Content: r.Message.Content, ToolCalls: toolCalls, Reasoning: r.Message.Thinking, Signature: r.Message.Signature},
 			FinishReason: func(reason string) *string {
 				if len(toolCalls) > 0 {
 					reason = "tool_calls"
@@ -307,7 +310,7 @@ func toChunk(id string, r api.ChatResponse, toolCallSent bool) ChatCompletionChu
 		SystemFingerprint: "fp_ollama",
 		Choices: []ChunkChoice{{
 			Index: 0,
-			Delta: Message{Role: "assistant", Content: r.Message.Content, ToolCalls: toolCalls, Reasoning: r.Message.Thinking},
+			Delta: Message{Role: "assistant", Content: r.Message.Content, ToolCalls: toolCalls, Reasoning: r.Message.Thinking, Signature: r.Message.Signature},
 			FinishReason: func(reason string) *string {
 				if len(reason) > 0 {
 					if toolCallSent || len(toolCalls) > 0 {
@@ -490,7 +493,7 @@ func FromChatRequest(r ChatCompletionRequest) (*api.ChatRequest, error) {
 			if err != nil {
 				return nil, err
 			}
-			messages = append(messages, api.Message{Role: msg.Role, Content: content, Thinking: msg.Reasoning, ToolCalls: toolCalls, ToolName: toolName, ToolCallID: msg.ToolCallID})
+			messages = append(messages, api.Message{Role: msg.Role, Content: content, Thinking: msg.Reasoning, Signature: msg.Signature, ToolCalls: toolCalls, ToolName: toolName, ToolCallID: msg.ToolCallID})
 		case []any:
 			for _, c := range content {
 				data, ok := c.(map[string]any)
@@ -537,6 +540,7 @@ func FromChatRequest(r ChatCompletionRequest) (*api.ChatRequest, error) {
 				messages[len(messages)-1].ToolName = toolName
 				messages[len(messages)-1].ToolCallID = msg.ToolCallID
 				messages[len(messages)-1].Thinking = msg.Reasoning
+				messages[len(messages)-1].Signature = msg.Signature
 			}
 		default:
 			// content is only optional if tool calls are present
@@ -548,7 +552,7 @@ func FromChatRequest(r ChatCompletionRequest) (*api.ChatRequest, error) {
 			if err != nil {
 				return nil, err
 			}
-			messages = append(messages, api.Message{Role: msg.Role, Thinking: msg.Reasoning, ToolCalls: toolCalls, ToolCallID: msg.ToolCallID})
+			messages = append(messages, api.Message{Role: msg.Role, Thinking: msg.Reasoning, Signature: msg.Signature, ToolCalls: toolCalls, ToolCallID: msg.ToolCallID})
 		}
 	}
 
@@ -696,6 +700,7 @@ func FromCompletionToolCall(toolCalls []ToolCall) ([]api.ToolCall, error) {
 	for i, tc := range toolCalls {
 		apiToolCalls[i].ID = tc.ID
 		apiToolCalls[i].Function.Name = tc.Function.Name
+		apiToolCalls[i].Function.ThoughtSignature = tc.Function.ThoughtSignature
 		err := json.Unmarshal([]byte(tc.Function.Arguments), &apiToolCalls[i].Function.Arguments)
 		if err != nil {
 			return nil, errors.New("invalid tool call arguments")

--- a/openai/openai_test.go
+++ b/openai/openai_test.go
@@ -814,3 +814,50 @@ func TestFromImageEditRequest_InvalidImage(t *testing.T) {
 		t.Error("expected error for invalid image")
 	}
 }
+
+func TestToChatCompletion_Signature(t *testing.T) {
+	resp := api.ChatResponse{
+		Model: "test-model",
+		Message: api.Message{
+			Role:      "assistant",
+			Content:   "Hello",
+			Thinking:  "Thought...",
+			Signature: "sig123",
+			ToolCalls: []api.ToolCall{
+				{
+					ID: "call1",
+					Function: api.ToolCallFunction{
+						Name:             "test_tool",
+						Arguments:        testArgs(map[string]any{"arg1": "val1"}),
+						ThoughtSignature: "thought_sig456",
+					},
+				},
+			},
+		},
+		Done: true,
+	}
+
+	result := ToChatCompletion("test-id", resp)
+
+	if len(result.Choices) != 1 {
+		t.Fatalf("expected 1 choice, got %d", len(result.Choices))
+	}
+
+	msg := result.Choices[0].Message
+	if msg.Reasoning != "Thought..." {
+		t.Errorf("expected reasoning %q, got %q", "Thought...", msg.Reasoning)
+	}
+
+	if msg.Signature != "sig123" {
+		t.Errorf("expected signature %q, got %q", "sig123", msg.Signature)
+	}
+
+	if len(msg.ToolCalls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(msg.ToolCalls))
+	}
+
+	tc := msg.ToolCalls[0]
+	if tc.Function.ThoughtSignature != "thought_sig456" {
+		t.Errorf("expected thought_signature %q, got %q", "thought_sig456", tc.Function.ThoughtSignature)
+	}
+}


### PR DESCRIPTION
## Summary
This PR fixes Issue #14567 where tool calls with Gemini 3 models (and some Anthropic models) would fail with a "400 Bad Request" error.

The root cause was that Ollama's internal `api.Message` and `api.ToolCallFunction` structs were missing fields for reasoning signatures (`signature` and `thought_signature`). These signatures are mandatory for some models to link a reasoning block to a subsequent tool call in the conversation history. Because Ollama was "lossy" during JSON unmarshaling/remarshaling, these signatures were dropped, making the conversation history invalid for the next turn.

## Changes
- **`api/types.go`**: Added `Signature` to `Message` struct and `ThoughtSignature` to `ToolCallFunction` struct.
- **`anthropic/anthropic.go`**: Updated conversion logic to extract and pass through signatures.
- **`openai/openai.go`**: Updated OpenAI compatibility layer to preserve signatures and reasoning blocks.
- **`middleware/anthropic.go`**: Updated assistant message building and stream conversion to include signatures.
- **Tests**: Added regression tests in `api`, `anthropic`, and `openai` packages to ensure these fields are correctly preserved across API boundaries.

## Test plan
- Verified that all modified packages pass tests with `go test ./api ./anthropic ./openai`.
- Added specific test cases to `api/types_test.go`, `anthropic/anthropic_test.go`, and `openai/openai_test.go` that verify signature preservation through JSON round-trips.

Fixes #14567

🤖 Generated with [Claude Code](https://claude.com/claude-code)