### PR TITLE
Fix verbose flag not defined in launch command

### DIFF
--- a/cmd/config/integrations.go
+++ b/cmd/config/integrations.go
@@ -1133,6 +1133,7 @@ Examples:
 
 	cmd.Flags().StringVar(&modelFlag, "model", "", "Model to use")
 	cmd.Flags().BoolVar(&configFlag, "config", false, "Configure without launching")
+	cmd.Flags().Bool("verbose", false, "Show timings for response")
 	return cmd
 }
 


### PR DESCRIPTION
Fixes #14654. The verbose flag was not registered in the launch command, causing an error when /set verbose or /set quiet commands were used during interactive mode launched from 'ollama launch'.