### PR TITLE
template: add JSON String() methods for tool struct types

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -411,10 +411,20 @@ type templateTool struct {
 	Function templateToolFunction `json:"function"`
 }
 
+func (t templateTool) String() string {
+	bts, _ := json.Marshal(t)
+	return string(bts)
+}
+
 type templateToolFunction struct {
 	Name        string                         `json:"name"`
 	Description string                         `json:"description"`
 	Parameters  templateToolFunctionParameters `json:"parameters"`
+}
+
+func (t templateToolFunction) String() string {
+	bts, _ := json.Marshal(t)
+	return string(bts)
 }
 
 type templateToolFunctionParameters struct {
@@ -423,6 +433,11 @@ type templateToolFunctionParameters struct {
 	Items      any                `json:"items,omitempty"`
 	Required   []string           `json:"required,omitempty"`
 	Properties templateProperties `json:"properties"`
+}
+
+func (t templateToolFunctionParameters) String() string {
+	bts, _ := json.Marshal(t)
+	return string(bts)
 }
 
 // templateToolCall is a template-compatible representation of api.ToolCall

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -769,3 +769,141 @@ func TestTemplatePropertiesRange(t *testing.T) {
 		t.Errorf("Range over Properties failed, got: %s, want: location:string;", got)
 	}
 }
+
+func TestTemplateToolFunctionJSON(t *testing.T) {
+	// Test that {{ .Function }} outputs valid JSON, not Go struct format.
+	// This is critical for models like Qwen3 whose templates use {{ .Function }} directly.
+	tmpl := `{{- range .Messages }}{{- end }}{{- range .Tools }}{{ .Function }}{{- end }}`
+
+	template, err := Parse(tmpl)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	props := api.NewToolPropertiesMap()
+	props.Set("city", api.ToolProperty{Type: api.PropertyType{"string"}, Description: "The name of the city"})
+
+	var buf bytes.Buffer
+	err = template.Execute(&buf, Values{
+		Messages: []api.Message{{Role: "user", Content: "test"}},
+		Tools: api.Tools{{
+			Type: "function",
+			Function: api.ToolFunction{
+				Name:        "get_weather",
+				Description: "Get the current weather for a city",
+				Parameters: api.ToolFunctionParameters{
+					Type:       "object",
+					Required:   []string{"city"},
+					Properties: props,
+				},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := strings.TrimSpace(buf.String())
+	// Should be valid JSON, not Go struct format like "{get_weather Get the current weather ...}"
+	if strings.HasPrefix(got, "{get_weather") {
+		t.Errorf("Function output as Go struct format: %s", got)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(got), &parsed); err != nil {
+		t.Errorf("Function not valid JSON: %s, error: %v", got, err)
+	}
+
+	if parsed["name"] != "get_weather" {
+		t.Errorf("Function name not correct, got: %v", parsed["name"])
+	}
+	if parsed["description"] != "Get the current weather for a city" {
+		t.Errorf("Function description not correct, got: %v", parsed["description"])
+	}
+}
+
+func TestTemplateToolJSON(t *testing.T) {
+	// Test that {{ . }} on a tool outputs valid JSON (the whole tool object).
+	tmpl := `{{- range .Messages }}{{- end }}{{- range .Tools }}{{ . }}{{- end }}`
+
+	template, err := Parse(tmpl)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	props := api.NewToolPropertiesMap()
+	props.Set("city", api.ToolProperty{Type: api.PropertyType{"string"}, Description: "City name"})
+
+	var buf bytes.Buffer
+	err = template.Execute(&buf, Values{
+		Messages: []api.Message{{Role: "user", Content: "test"}},
+		Tools: api.Tools{{
+			Type: "function",
+			Function: api.ToolFunction{
+				Name:        "get_weather",
+				Description: "Get weather",
+				Parameters: api.ToolFunctionParameters{
+					Type:       "object",
+					Required:   []string{"city"},
+					Properties: props,
+				},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := strings.TrimSpace(buf.String())
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(got), &parsed); err != nil {
+		t.Errorf("Tool not valid JSON: %s, error: %v", got, err)
+	}
+
+	if parsed["type"] != "function" {
+		t.Errorf("Tool type not correct, got: %v", parsed["type"])
+	}
+}
+
+func TestTemplateToolParametersJSON(t *testing.T) {
+	// Test that {{ .Function.Parameters }} outputs valid JSON.
+	tmpl := `{{- range .Messages }}{{- end }}{{- range .Tools }}{{ .Function.Parameters }}{{- end }}`
+
+	template, err := Parse(tmpl)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	props := api.NewToolPropertiesMap()
+	props.Set("city", api.ToolProperty{Type: api.PropertyType{"string"}, Description: "City name"})
+
+	var buf bytes.Buffer
+	err = template.Execute(&buf, Values{
+		Messages: []api.Message{{Role: "user", Content: "test"}},
+		Tools: api.Tools{{
+			Type: "function",
+			Function: api.ToolFunction{
+				Name:        "get_weather",
+				Description: "Get weather",
+				Parameters: api.ToolFunctionParameters{
+					Type:       "object",
+					Required:   []string{"city"},
+					Properties: props,
+				},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := strings.TrimSpace(buf.String())
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(got), &parsed); err != nil {
+		t.Errorf("Parameters not valid JSON: %s, error: %v", got, err)
+	}
+
+	if parsed["type"] != "object" {
+		t.Errorf("Parameters type not correct, got: %v", parsed["type"])
+	}
+}


### PR DESCRIPTION
## Summary

Adds `String()` methods to `templateTool`, `templateToolFunction`, and `templateToolFunctionParameters` so they serialize as valid JSON when referenced directly in Go templates.

## Problem

When a model template uses `{{ .Function }}` to render a tool's function object (as Qwen3's template does), the output is Go's default struct format:

```
{get_weather Get the current weather for a city {object [city] {"city":{"type":"string",...}}}}
```

Instead of valid JSON:

```json
{"name":"get_weather","description":"Get the current weather for a city","parameters":{"type":"object","required":["city"],"properties":{"city":{"type":"string",...}}}}
```

This breaks tool calling for any model whose template renders tool structs directly rather than accessing individual fields.

## Fix

The existing map types (`templateArgs`, `templateProperties`) and slice type (`templateTools`) already implement `String()` with JSON marshaling. This PR extends the same pattern to the three struct types that were missing it:

- `templateTool` — the full tool object (`{{ . }}` in a tools range)
- `templateToolFunction` — the function sub-object (`{{ .Function }}`)
- `templateToolFunctionParameters` — the parameters sub-object (`{{ .Function.Parameters }}`)

## Tests

Added three new test cases:
- `TestTemplateToolFunctionJSON` — verifies `{{ .Function }}` outputs valid JSON
- `TestTemplateToolJSON` — verifies `{{ . }}` on a tool outputs valid JSON
- `TestTemplateToolParametersJSON` — verifies `{{ .Function.Parameters }}` outputs valid JSON

All existing tests continue to pass.

Fixes #14601