### PR TITLE
docs: Add GTX 960M to supported Nvidia GPU table

### DIFF
--- a/docs/gpu.mdx
+++ b/docs/gpu.mdx
@@ -31,10 +31,13 @@ Check your compute compatibility to see if your card is supported:
 | 5.2                | GeForce GTX         | `GTX TITAN X` `GTX 980 Ti` `GTX 980` `GTX 970` `GTX 960` `GTX 950`                                                             |
 |                    | Quadro              | `M6000 24GB` `M6000` `M5000` `M5500M` `M4000` `M2200` `M2000` `M620`                                                           |
 |                    | Tesla               | `M60` `M40`                                                                                                                    |
-| 5.0                | GeForce GTX         | `GTX 750 Ti` `GTX 750` `NVS 810`                                                                                               |
+| 5.0                | GeForce GTX         | `GTX 750 Ti` `GTX 750` `NVS 810` `GTX 960M`                                                                                    |
 |                    | Quadro              | `K2200` `K1200` `K620` `M1200` `M520` `M5000M` `M4000M` `M3000M` `M2000M` `M1000M` `K620M` `M600M` `M500M`                     |
 
 For building locally to support older GPUs, see [developer](./development#linux-cuda-nvidia)
+
+> Tip; `nvidia-smi --query-gpu=compute_cap --format=csv` may be more up-to-date
+> than above table
 
 ### GPU Selection
 


### PR DESCRIPTION
As well as note for how to obtain compute version locally via CLI, because the table saying `980` should use `5.2` vs CLI asserting `5.0` consumed a few hours of me chasing my own tail x-}

This has been tested successfully, partially successfully due to some models not playing nice, on NixOS with the following configuration snippets;

- `/etc/nixos/services/ollama.nix`
   ```nix
   { pkgs, ... }:

   {
     services.ollama = {
       enable = true;

       package = pkgs.ollama-cuda.override {
         cudaArches = [ "50" ];
       };

       loadModels = [
         "gemma3n:e4b"
       ];
     };
   }
   ```
- `/etc/nixos/flake/my-device.nix`
   ```nix
   {
     config,
     lib,
     modulesPath,
     ...
   }:

   {
     hardware.enableRedistributableFirmware = true;
     hardware.graphics.enable = true;

     nix.settings = {
       substituters = [
         "https://cache.nixos-cuda.org"
       ];
       trusted-public-keys = [
         "cache.nixos-cuda.org:74DUi4Ye579gUqzH4ziL9IyiJBlDpMRn9MBN8oNan9M="
       ];
     };
   }
   ```
