### PR TITLE
fix: handle missing verbose flag in launch command context

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1640,10 +1640,7 @@ func chat(cmd *cobra.Command, opts runOptions) (*api.Message, error) {
 		fmt.Println()
 	}
 
-	verbose, err := cmd.Flags().GetBool("verbose")
-	if err != nil {
-		return nil, err
-	}
+	verbose, _ := cmd.Flags().GetBool("verbose")
 
 	if verbose {
 		latest.Summary()
@@ -1768,10 +1765,7 @@ func generate(cmd *cobra.Command, opts runOptions) error {
 		return nil
 	}
 
-	verbose, err := cmd.Flags().GetBool("verbose")
-	if err != nil {
-		return err
-	}
+	verbose, _ := cmd.Flags().GetBool("verbose")
 
 	if verbose {
 		latest.Summary()

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -286,11 +286,17 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 					opts.WordWrap = false
 					fmt.Println("Set 'nowordwrap' mode.")
 				case "verbose":
+					if cmd.Flags().Lookup("verbose") == nil {
+						cmd.Flags().Bool("verbose", false, "Show timings for response")
+					}
 					if err := cmd.Flags().Set("verbose", "true"); err != nil {
 						return err
 					}
 					fmt.Println("Set 'verbose' mode.")
 				case "quiet":
+					if cmd.Flags().Lookup("verbose") == nil {
+						cmd.Flags().Bool("verbose", false, "Show timings for response")
+					}
 					if err := cmd.Flags().Set("verbose", "false"); err != nil {
 						return err
 					}


### PR DESCRIPTION
**Note: This PR was authored by Claude (AI), operated by @maxwellcalkin.**

Fixes #14654

## Summary

When running a model via `ollama launch`, the app crashes with:

```
Error running model: flag accessed but not defined: verbose
```

This happens because the `verbose` flag is registered on the `run` and root commands, but not on the `launch` command. When the shared `chat()` and `generate()` functions try to access the flag via `cmd.Flags().GetBool("verbose")`, it panics/errors because the flag does not exist in the launch command context.

## Changes

### `cmd/cmd.go`
- In `chat()`: ignore the error from `GetBool("verbose")` instead of returning it. When the flag is not registered, `GetBool` returns `false` (the zero value), which is the correct default behavior.
- In `generate()`: same fix.

### `cmd/interactive.go`
- In the `/set verbose` and `/set quiet` interactive commands: register the `verbose` flag on the command if it does not already exist before attempting to set it. This ensures these interactive commands work correctly regardless of which command (`run` or `launch`) started the interactive session.

## Test plan
- Run `ollama launch`, select "Run a model", send a message — should complete without the verbose flag error
- Run `ollama launch`, run a model, type `/set verbose` then send a message — should show timing stats
- Run `ollama launch`, run a model, type `/set quiet` — should suppress timing stats
- Run `ollama run <model>` — existing behavior unchanged
- Run `ollama run <model> --verbose` — existing verbose behavior unchanged