### PR TITLE
server: remove debug print statement from setMessages

### DIFF
--- a/server/create.go
+++ b/server/create.go
@@ -799,7 +799,6 @@ func setMessages(layers []manifest.Layer, m []api.Message) ([]manifest.Layer, er
 		return layers, nil
 	}
 
-	fmt.Printf("removing old messages\n")
 	layers = removeLayer(layers, "application/vnd.ollama.image.messages")
 	var b bytes.Buffer
 	if err := json.NewEncoder(&b).Encode(m); err != nil {


### PR DESCRIPTION
## Summary

Remove leftover `fmt.Printf("removing old messages\n")` debug output in `server/create.go` that prints to stdout during model creation when messages are being replaced.

This debug statement was likely left in during development and produces unexpected output during normal `ollama create` operations.

## Test plan

- [ ] Run `ollama create` with MESSAGE instructions and verify no "removing old messages" output appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)