### PR TITLE
server: use error wrapping and check json.Marshal

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -80,7 +80,7 @@ func getAuthorizationToken(ctx context.Context, challenge registryChallenge, ori
 
 	body, err := io.ReadAll(response.Body)
 	if err != nil {
-		return "", fmt.Errorf("%d: %v", response.StatusCode, err)
+		return "", fmt.Errorf("%d: %w", response.StatusCode, err)
 	}
 
 	if response.StatusCode >= http.StatusBadRequest {

--- a/server/images.go
+++ b/server/images.go
@@ -580,7 +580,7 @@ func PullModel(ctx context.Context, name string, regOpts *registryOptions, fn fu
 
 	mf, err := pullModelManifest(ctx, n, regOpts)
 	if err != nil {
-		return fmt.Errorf("pull model manifest: %s", err)
+		return fmt.Errorf("pull model manifest: %w", err)
 	}
 
 	var layers []manifest.Layer
@@ -879,7 +879,7 @@ func makeRequestWithRetry(ctx context.Context, method string, requestURL *url.UR
 			defer resp.Body.Close()
 			responseBody, err := io.ReadAll(resp.Body)
 			if err != nil {
-				return nil, fmt.Errorf("%d: %s", resp.StatusCode, err)
+				return nil, fmt.Errorf("%d: %w", resp.StatusCode, err)
 			}
 			return nil, fmt.Errorf("%d: %s", resp.StatusCode, responseBody)
 		default:

--- a/server/internal/client/ollama/registry.go
+++ b/server/internal/client/ollama/registry.go
@@ -1184,11 +1184,11 @@ func parseChunk[S ~string | ~[]byte](s S) (blob.Chunk, error) {
 	}
 	start, err := strconv.ParseInt(startPart, 10, 64)
 	if err != nil {
-		return blob.Chunk{}, fmt.Errorf("chunks: invalid start to %q: %v", s, err)
+		return blob.Chunk{}, fmt.Errorf("chunks: invalid start to %q: %w", s, err)
 	}
 	end, err := strconv.ParseInt(endPart, 10, 64)
 	if err != nil {
-		return blob.Chunk{}, fmt.Errorf("chunks: invalid end to %q: %v", s, err)
+		return blob.Chunk{}, fmt.Errorf("chunks: invalid end to %q: %w", s, err)
 	}
 	if start > end {
 		return blob.Chunk{}, fmt.Errorf("chunks: invalid range %q: start > end", s)

--- a/server/quantization.go
+++ b/server/quantization.go
@@ -32,7 +32,7 @@ func (q quantizer) WriteTo(w io.Writer) (int64, error) {
 	data, err := io.ReadAll(sr)
 	if err != nil {
 		slog.Warn("file read error", "tensor", q.from.Name, "file", q.Name(), "error", err)
-		return 0, fmt.Errorf("unable to read tensor %s from %s: %s", q.from.Name, q.Name(), err)
+		return 0, fmt.Errorf("unable to read tensor %s from %s: %w", q.from.Name, q.Name(), err)
 	}
 	if uint64(len(data)) < q.from.Size() {
 		return 0, fmt.Errorf("tensor %s data size %d is less than expected %d from shape %v", q.from.Name, len(data), q.from.Size(), q.from.Shape)

--- a/server/routes.go
+++ b/server/routes.go
@@ -2728,7 +2728,11 @@ func (s *Server) handleImageGenerate(c *gin.Context, req api.GenerateRequest, mo
 			return
 		}
 
-		data, _ := json.Marshal(res)
+		data, err := json.Marshal(res)
+		if err != nil {
+			slog.Error("failed to marshal streaming response", "error", err)
+			return
+		}
 		c.Writer.Write(append(data, '\n'))
 		c.Writer.Flush()
 	}); err != nil {

--- a/server/sched.go
+++ b/server/sched.go
@@ -466,7 +466,7 @@ func (s *Scheduler) load(req *LlmRequest, f *ggml.GGML, systemInfo ml.SystemInfo
 			// show a generalized compatibility error until there is a better way to
 			// check for model compatibility
 			if errors.Is(err, ggml.ErrUnsupportedFormat) || strings.Contains(err.Error(), "failed to load model") {
-				err = fmt.Errorf("%v: this model may be incompatible with your version of Ollama. If you previously pulled this model, try updating it by running `ollama pull %s`", err, req.model.ShortName)
+				err = fmt.Errorf("%w: this model may be incompatible with your version of Ollama. If you previously pulled this model, try updating it by running `ollama pull %s`", err, req.model.ShortName)
 			}
 			slog.Info("NewLlamaServer failed", "model", req.model.ModelPath, "error", err)
 			req.errCh <- err


### PR DESCRIPTION
## Summary

- Replace %v and %s with %w in fmt.Errorf calls across server/ that wrap errors, enabling callers to use errors.Is/errors.As for programmatic error inspection.
- Add missing error check for json.Marshal in the image generate streaming path (server/routes.go), which previously discarded the error with _.

## Files changed

- server/auth.go - wrap io.ReadAll error with %w
- server/images.go - wrap pullModelManifest and HTTP response read errors with %w
- server/internal/client/ollama/registry.go - wrap strconv.ParseInt errors with %w in chunk parsing
- server/quantization.go - wrap tensor read error with %w
- server/sched.go - wrap model load error with %w to preserve errors.Is chain
- server/routes.go - check json.Marshal error in handleImageGenerate streaming path

## Test plan

- [ ] Verify go build ./... passes
- [ ] Verify go vet ./... passes
- [ ] Existing tests continue to pass (no behavioral change, only error chain preservation)
