### PR TITLE
envconfig: fix BoolWithDefault returning true on parse error

### DIFF
--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -156,7 +156,8 @@ func BoolWithDefault(k string) func(defaultValue bool) bool {
 		if s := Var(k); s != "" {
 			b, err := strconv.ParseBool(s)
 			if err != nil {
-				return true
+				slog.Warn("invalid boolean value for environment variable, using default", "variable", k, "value", s, "default", defaultValue)
+				return defaultValue
 			}
 
 			return b

--- a/envconfig/config_test.go
+++ b/envconfig/config_test.go
@@ -157,9 +157,9 @@ func TestBool(t *testing.T) {
 		"false": false,
 		"1":     true,
 		"0":     false,
-		// invalid values
-		"random":    true,
-		"something": true,
+		// invalid values should return the default (false for Bool)
+		"random":    false,
+		"something": false,
 	}
 
 	for k, v := range cases {
@@ -170,6 +170,36 @@ func TestBool(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBoolWithDefault(t *testing.T) {
+	t.Run("invalid value returns default true", func(t *testing.T) {
+		t.Setenv("OLLAMA_BOOL", "invalid")
+		if b := BoolWithDefault("OLLAMA_BOOL")(true); !b {
+			t.Errorf("expected true (default), got false")
+		}
+	})
+
+	t.Run("invalid value returns default false", func(t *testing.T) {
+		t.Setenv("OLLAMA_BOOL", "invalid")
+		if b := BoolWithDefault("OLLAMA_BOOL")(false); b {
+			t.Errorf("expected false (default), got true")
+		}
+	})
+
+	t.Run("valid value overrides default", func(t *testing.T) {
+		t.Setenv("OLLAMA_BOOL", "true")
+		if b := BoolWithDefault("OLLAMA_BOOL")(false); !b {
+			t.Errorf("expected true, got false")
+		}
+	})
+
+	t.Run("empty uses default", func(t *testing.T) {
+		t.Setenv("OLLAMA_BOOL", "")
+		if b := BoolWithDefault("OLLAMA_BOOL")(true); !b {
+			t.Errorf("expected true (default), got false")
+		}
+	})
 }
 
 func TestUint(t *testing.T) {


### PR DESCRIPTION
## Summary

`BoolWithDefault` in `envconfig/config.go` returns hardcoded `true` when `strconv.ParseBool` fails on an invalid environment variable value. This means setting something like `OLLAMA_FLASH_ATTENTION=banana` would silently **enable** flash attention instead of falling back to the default value (`false`).

This fix:
- Returns `defaultValue` instead of `true` on parse error
- Logs a warning so users can identify misconfigured environment variables
- Updates tests to reflect the corrected behavior and adds explicit `BoolWithDefault` test cases

## Reproduction

```bash
OLLAMA_FLASH_ATTENTION=banana ollama serve
# Before: flash attention silently enabled
# After: flash attention uses default (off), with a warning logged
```

## Test plan

- [x] `go test ./envconfig/ -run TestBool` passes
- [x] `go test ./envconfig/ -run TestBoolWithDefault` passes
- [ ] Manual verification with invalid env var values