### PR TITLE
integration: replace deprecated ioutil.ReadFile with os.ReadFile

### DIFF
--- a/integration/model_arch_test.go
+++ b/integration/model_arch_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -123,7 +122,7 @@ func TestModelsEmbed(t *testing.T) {
 		slog.Warn("No VRAM info available, testing all models, so larger ones might timeout...")
 	}
 
-	data, err := ioutil.ReadFile(filepath.Join("testdata", "embed.json"))
+	data, err := os.ReadFile(filepath.Join("testdata", "embed.json"))
 	if err != nil {
 		t.Fatalf("failed to open test data file: %s", err)
 	}

--- a/integration/model_perf_test.go
+++ b/integration/model_perf_test.go
@@ -5,7 +5,6 @@ package integration
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log/slog"
 	"math"
 	"os"
@@ -71,7 +70,7 @@ func doModelPerfTest(t *testing.T, chatModels []string) {
 		slog.Warn("No VRAM info available, testing all models, so larger ones might timeout...")
 	}
 
-	data, err := ioutil.ReadFile(filepath.Join("testdata", "shakespeare.txt"))
+	data, err := os.ReadFile(filepath.Join("testdata", "shakespeare.txt"))
 	if err != nil {
 		t.Fatalf("failed to open test data file: %s", err)
 	}


### PR DESCRIPTION
## Summary

Replace deprecated `io/ioutil` package usage with the recommended `os.ReadFile` in integration test files. The `io/ioutil` package has been deprecated since Go 1.16 (released Feb 2021) and `ioutil.ReadFile` is a direct alias for `os.ReadFile`.

### Files changed
- `integration/model_perf_test.go`: `ioutil.ReadFile` -> `os.ReadFile`
- `integration/model_arch_test.go`: `ioutil.ReadFile` -> `os.ReadFile`

## Test plan

- [x] `go vet -tags integration,perf ./integration/` passes (no new issues)
- [x] `go vet -tags integration,models ./integration/` passes (no new issues)