### PR TITLE
cmd: prevent division by zero panic in createBlob progress

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -389,7 +389,9 @@ func createBlob(cmd *cobra.Command, client *api.Client, path string, digest stri
 		for {
 			select {
 			case <-ticker.C:
-				spinner.SetMessage(fmt.Sprintf("copying file %s %d%%", digest, int(100*pw.n.Load()/fileSize)))
+				if fileSize > 0 {
+					spinner.SetMessage(fmt.Sprintf("copying file %s %d%%", digest, int(100*pw.n.Load()/fileSize)))
+				}
 			case <-done:
 				spinner.SetMessage(fmt.Sprintf("copying file %s 100%%", digest))
 				return


### PR DESCRIPTION
## Summary

The `createBlob` function in `cmd/cmd.go` has a goroutine that computes upload progress percentage using:

```go
int(100 * pw.n.Load() / fileSize)
```

When `fileSize` is 0 (empty file), this causes a **runtime panic** due to integer division by zero. While uploading empty files is uncommon, it can happen with placeholder files or edge cases in model creation pipelines.

This fix guards the division with a `fileSize > 0` check, skipping the percentage update for zero-length files (the "100%" message is still shown on completion via the `done` channel).

## Test plan

- [x] `go build ./cmd/...` compiles without errors
- [ ] Manual test: create a blob from an empty file (previously panics, now shows spinner without percentage until complete)