### PR TITLE
server: fix response body leak in upload retry loop

### DIFF
--- a/server/upload.go
+++ b/server/upload.go
@@ -207,7 +207,7 @@ func (b *blobUpload) Run(ctx context.Context, opts *registryOptions) {
 			time.Sleep(sleep)
 			continue
 		}
-		defer resp.Body.Close()
+		resp.Body.Close()
 		break
 	}
 


### PR DESCRIPTION
## What

Fix a response body resource leak in `blobUpload.Run()`.

## Why

The `defer resp.Body.Close()` at line 210 is inside a `for` loop (the retry loop at line 199). In Go, `defer` is scoped to the enclosing function, not the loop iteration, so the response body is not closed until `Run()` returns. If retries occur, multiple response bodies accumulate without being closed, leaking HTTP connections.

Since this is a finalization PUT request with `Content-Length: 0`, the response body only needs to be drained and closed. Closing it immediately (without `defer`) is correct and prevents the leak.

## Change

Replace `defer resp.Body.Close()` with `resp.Body.Close()` since the function breaks out of the loop immediately after.