### PR TITLE
server: fix ticker leak in download chunk stall monitor

### DIFF
--- a/server/download.go
+++ b/server/download.go
@@ -360,6 +360,7 @@ func (b *blobDownload) downloadChunk(ctx context.Context, requestURL *url.URL, w
 
 	g.Go(func() error {
 		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:


### PR DESCRIPTION
## What

Add missing `defer ticker.Stop()` in `downloadChunk`'s stall-detection goroutine.

## Why

In `blobDownload.downloadChunk()`, a `time.NewTicker(time.Second)` is created at line 362 but never stopped. This goroutine runs for every download chunk part, and when it exits (via `return` on completion, stall, or context cancellation), the ticker continues to fire, leaking its internal goroutine and channel.

During large model downloads with many parts, this can accumulate a significant number of leaked tickers.

## Change

Add `defer ticker.Stop()` immediately after creating the ticker, consistent with how tickers are handled elsewhere in the codebase (e.g., `sched.go:803`, `cmd.go:388`).