### PR TITLE
progress: fix data race on shared fields in stop/start

### DIFF
--- a/progress/progress.go
+++ b/progress/progress.go
@@ -38,6 +38,9 @@ func NewProgress(w io.Writer) *Progress {
 }
 
 func (p *Progress) stop() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	for _, state := range p.states {
 		if spinner, ok := state.(*Spinner); ok {
 			spinner.Stop()
@@ -47,7 +50,7 @@ func (p *Progress) stop() bool {
 	if p.ticker != nil {
 		p.ticker.Stop()
 		p.ticker = nil
-		p.render()
+		p.renderLocked()
 		return true
 	}
 
@@ -71,6 +74,7 @@ func (p *Progress) StopAndClear() bool {
 
 	stopped := p.stop()
 	if stopped {
+		p.mu.Lock()
 		// clear all progress lines
 		for i := range p.pos {
 			if i > 0 {
@@ -78,6 +82,7 @@ func (p *Progress) StopAndClear() bool {
 			}
 			fmt.Fprint(p.w, "\033[2K\033[1G")
 		}
+		p.mu.Unlock()
 	}
 
 	return stopped
@@ -91,13 +96,17 @@ func (p *Progress) Add(key string, state State) {
 }
 
 func (p *Progress) render() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.renderLocked()
+}
+
+// renderLocked performs the actual render. The caller must hold p.mu.
+func (p *Progress) renderLocked() {
 	_, termHeight, err := term.GetSize(int(os.Stderr.Fd()))
 	if err != nil {
 		termHeight = defaultTermHeight
 	}
-
-	p.mu.Lock()
-	defer p.mu.Unlock()
 
 	defer p.w.Flush()
 
@@ -127,7 +136,9 @@ func (p *Progress) render() {
 }
 
 func (p *Progress) start() {
+	p.mu.Lock()
 	p.ticker = time.NewTicker(100 * time.Millisecond)
+	p.mu.Unlock()
 	for range p.ticker.C {
 		p.render()
 	}


### PR DESCRIPTION
## What

Fix data races in `progress.Progress` between the background render goroutine and `Stop()`/`StopAndClear()` calls.

## Why

The `stop()` method accesses `p.states` (iterating to stop spinners) and `p.ticker` (reading + writing) without holding `p.mu`. Meanwhile:
- `Add()` appends to `p.states` under the mutex
- `render()` reads/writes `p.pos` and reads `p.states` under the mutex  
- `start()` writes `p.ticker` without the mutex

This is a data race detectable by `go test -race`. Since `Stop()` and `StopAndClear()` are called from the main goroutine while `start()`/`render()` run in a background goroutine, concurrent access is expected.

Additionally, `StopAndClear()` reads `p.pos` (line 75) without the mutex while `render()` writes it.

## Change

- Hold `p.mu` in `stop()` when accessing `p.states`, `p.ticker`
- Hold `p.mu` in `start()` when writing `p.ticker`
- Hold `p.mu` in `StopAndClear()` when reading `p.pos`
- Extract `renderLocked()` so `stop()` can render while already holding the mutex