### PR TITLE
readline: check errors from Flush and Close in history Save

### DIFF
--- a/readline/history.go
+++ b/readline/history.go
@@ -138,10 +138,18 @@ func (h *History) Save() error {
 	buf := bufio.NewWriter(f)
 	for cnt := range h.Size() {
 		line, _ := h.Buf.Get(cnt)
-		fmt.Fprintln(buf, line)
+		if _, err := fmt.Fprintln(buf, line); err != nil {
+			f.Close()
+			return err
+		}
 	}
-	buf.Flush()
-	f.Close()
+	if err := buf.Flush(); err != nil {
+		f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
 
 	if err = os.Rename(tmpFile, h.Filename); err != nil {
 		return err


### PR DESCRIPTION
## What

Check errors from `bufio.Writer.Flush()`, `fmt.Fprintln()`, and `os.File.Close()` in `History.Save()`.

## Why

Currently `Save()` ignores errors from `buf.Flush()` (line 143) and `f.Close()` (line 144). If writing fails (disk full, I/O error), the buffered data is silently lost and the incomplete/empty temp file is renamed over the existing history file, corrupting or destroying the user's command history.

The `f.Close()` error is also important because on some filesystems (e.g., NFS), `Close()` can return write errors that were deferred from earlier `Write()` calls.

## Change

- Check the error from `fmt.Fprintln()` during each line write
- Check the error from `buf.Flush()` before closing the file
- Check the error from `f.Close()` before renaming
- On any error, return early without renaming the temp file over the history