### PR TITLE
llm: use %w instead of %v for proper error wrapping

### DIFF
--- a/llm/server.go
+++ b/llm/server.go
@@ -288,7 +288,7 @@ func NewLlamaServer(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, modelPath st
 		if s.status != nil && s.status.LastErrMsg != "" {
 			msg = s.status.LastErrMsg
 		}
-		err := fmt.Errorf("error starting runner: %v %s", err, msg)
+		err := fmt.Errorf("error starting runner: %w %s", err, msg)
 		if llamaModel != nil {
 			llama.FreeModel(llamaModel)
 		}
@@ -1274,7 +1274,7 @@ func (s *llmServer) getServerStatus(ctx context.Context) (ServerStatus, error) {
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d/health", s.port), nil)
 	if err != nil {
-		return ServerStatusError, fmt.Errorf("error creating GET request: %v", err)
+		return ServerStatusError, fmt.Errorf("error creating GET request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 
@@ -1592,13 +1592,13 @@ func (s *llmServer) Completion(ctx context.Context, req CompletionRequest, fn fu
 	enc.SetEscapeHTML(false)
 
 	if err := enc.Encode(req); err != nil {
-		return fmt.Errorf("failed to marshal data: %v", err)
+		return fmt.Errorf("failed to marshal data: %w", err)
 	}
 
 	endpoint := fmt.Sprintf("http://127.0.0.1:%d/completion", s.port)
 	serverReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, buffer)
 	if err != nil {
-		return fmt.Errorf("error creating POST request: %v", err)
+		return fmt.Errorf("error creating POST request: %w", err)
 	}
 	serverReq.Header.Set("Content-Type", "application/json")
 
@@ -1647,7 +1647,7 @@ func (s *llmServer) Completion(ctx context.Context, req CompletionRequest, fn fu
 
 			var c CompletionResponse
 			if err := json.Unmarshal(evt, &c); err != nil {
-				return fmt.Errorf("error unmarshalling llm prediction response: %v", err)
+				return fmt.Errorf("error unmarshalling llm prediction response: %w", err)
 			}
 			switch {
 			case strings.TrimSpace(c.Content) == lastToken:
@@ -1689,7 +1689,7 @@ func (s *llmServer) Completion(ctx context.Context, req CompletionRequest, fn fu
 			return fmt.Errorf("an error was encountered while running the model: %s", msg)
 		}
 
-		return fmt.Errorf("error reading llm response: %v", err)
+		return fmt.Errorf("error reading llm response: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
## What

Replace `%v` with `%w` in `fmt.Errorf` calls throughout `llm/server.go`.

## Why

Using `%v` to format errors in `fmt.Errorf` discards the error chain, making it impossible for callers to use `errors.Is()` or `errors.As()` to inspect the underlying cause. This matters for error handling in several cases:

- **Runner startup errors** (line 291): callers can't check if the underlying error is a specific type like `exec.Error` or `context.DeadlineExceeded`
- **HTTP request creation errors** (lines 1277, 1601): callers can't detect `url.Error` or similar
- **JSON marshaling/unmarshaling errors** (lines 1595, 1650): callers can't distinguish between different JSON error types
- **Response reading errors** (line 1692): callers can't check for `io.EOF` or network errors

The `%w` verb was introduced in Go 1.13 specifically to preserve the error chain in wrapped errors.

## Change

Six `%v` → `%w` replacements in `fmt.Errorf` calls in `llm/server.go`.