### PR TITLE
Fixes common CVE on golang and golang.org/x/crypto

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ollama/ollama
 
-go 1.24.1
+go 1.24.13
 
 require (
 	github.com/TheTitanrain/w32 v0.0.0-20180517000239-4f5cfb03fabf
@@ -100,7 +100,7 @@ require (
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	golang.org/x/arch v0.8.0 // indirect
-	golang.org/x/crypto v0.43.0
+	golang.org/x/crypto v0.45.0
 	golang.org/x/exp v0.0.0-20250218142911-aa4b98e5adaa // indirect
 	golang.org/x/net v0.46.0 // indirect
 	golang.org/x/term v0.36.0


### PR DESCRIPTION

Golang v1.24.1
https://www.cvedetails.com/version/1985839/Golang-GO-1.24.1.html

golang.org/x/crypto v0.43.0
CVE-2025-47914 (MODERATE): golang.org/x/crypto/ssh/agent vulnerable to panic if message is malformed due to out of bounds read - Fixed in 0.45.0 (details) CVE-2025-58181 (MODERATE): golang.org/x/crypto/ssh allows an attacker to cause unbounded memory consumption - Fixed in 0.45.0 (details)