### PR TITLE
docs: replace deprecated zod-to-json-schema with Zod v4 native

### DIFF
--- a/docs/capabilities/structured-outputs.mdx
+++ b/docs/capabilities/structured-outputs.mdx
@@ -96,12 +96,11 @@ Provide a JSON schema to the `format` field.
     ```
   </Tab>
   <Tab title="JavaScript">
-    Serialize a Zod schema with `zodToJsonSchema()` and parse the structured response:
+    Convert a Zod schema to JSON Schema with Zod's native `.toJsonSchema()` and parse the structured response:
 
     ```javascript
     import ollama from 'ollama'
-    import { z } from 'zod'
-    import { zodToJsonSchema } from 'zod-to-json-schema'
+    import { z } from 'zod/v4'
 
     const Country = z.object({
       name: z.string(),
@@ -112,7 +111,7 @@ Provide a JSON schema to the `format` field.
     const response = await ollama.chat({
       model: 'gpt-oss',
       messages: [{ role: 'user', content: 'Tell me about Canada.' }],
-      format: zodToJsonSchema(Country),
+      format: z.toJSONSchema(Country),
     })
 
     const country = Country.parse(JSON.parse(response.message.content))


### PR DESCRIPTION
Fixes #14734

## Summary
- Replaced deprecated `zod-to-json-schema` library with Zod v4's native `z.toJSONSchema()` method in the structured outputs documentation
- Updated import from `import { z } from 'zod'` to `import { z } from 'zod/v4'`
- The `zod-to-json-schema` package is deprecated as Zod v4 includes built-in JSON Schema support

This contribution was developed with AI assistance (Claude Code).