### PR TITLE
app: fix reset to defaults disabling auto-update

### DIFF
--- a/app/ui/app/src/components/Settings.tsx
+++ b/app/ui/app/src/components/Settings.tsx
@@ -214,6 +214,7 @@ export default function Settings() {
         Agent: false,
         Tools: false,
         ContextLength: 0,
+        AutoUpdateEnabled: true,
       });
       updateSettingsMutation.mutate(defaultSettings);
     }


### PR DESCRIPTION
- The "Reset to defaults" button in Settings was not explicitly setting AutoUpdateEnabled, causing it to default to false
- Added AutoUpdateEnabled: true to the default settings object so auto-update remains enabled after reset