### PR TITLE
server: use conservative VRAM-based default context lengths

### DIFF
--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -297,7 +297,7 @@ func AsMap() map[string]EnvVar {
 		"OLLAMA_ORIGINS":           {"OLLAMA_ORIGINS", AllowedOrigins(), "A comma separated list of allowed origins"},
 		"OLLAMA_SCHED_SPREAD":      {"OLLAMA_SCHED_SPREAD", SchedSpread(), "Always schedule model across all GPUs"},
 		"OLLAMA_MULTIUSER_CACHE":   {"OLLAMA_MULTIUSER_CACHE", MultiUserCache(), "Optimize prompt caching for multi-user scenarios"},
-		"OLLAMA_CONTEXT_LENGTH":    {"OLLAMA_CONTEXT_LENGTH", ContextLength(), "Context length to use unless otherwise specified (default: 4k/32k/256k based on VRAM)"},
+		"OLLAMA_CONTEXT_LENGTH":    {"OLLAMA_CONTEXT_LENGTH", ContextLength(), "Context length to use unless otherwise specified (default: 4k/8k/16k/64k based on VRAM)"},
 		"OLLAMA_EDITOR":            {"OLLAMA_EDITOR", Editor(), "Path to editor for interactive prompt editing (Ctrl+G)"},
 		"OLLAMA_NEW_ENGINE":        {"OLLAMA_NEW_ENGINE", NewEngine(), "Enable the new Ollama engine"},
 		"OLLAMA_REMOTES":           {"OLLAMA_REMOTES", Remotes(), "Allowed hosts for remote models (default \"ollama.com\")"},

--- a/server/routes.go
+++ b/server/routes.go
@@ -1830,12 +1830,15 @@ func Serve(ln net.Listener) error {
 	}
 
 	// Set default context based on VRAM tier
-	// Use slightly lower thresholds (47/23 GiB vs. 48/24 GiB) to account for small differences in the exact value
+	// Use conservative values to prevent large models from spilling to CPU
+	// due to oversized KV cache, which causes severe performance degradation.
 	switch {
+	case totalVRAM >= 72*format.GibiByte:
+		s.defaultNumCtx = 65536
 	case totalVRAM >= 47*format.GibiByte:
-		s.defaultNumCtx = 262144
+		s.defaultNumCtx = 16384
 	case totalVRAM >= 23*format.GibiByte:
-		s.defaultNumCtx = 32768
+		s.defaultNumCtx = 8192
 	default:
 		s.defaultNumCtx = 4096
 	}

--- a/server/routes_options_test.go
+++ b/server/routes_options_test.go
@@ -78,12 +78,20 @@ func TestModelOptionsNumCtxPriority(t *testing.T) {
 			expectedNumCtx: 4096,
 		},
 		{
-			name:           "high vram tier default",
+			name:           "mid vram tier default",
 			envContextLen:  "",
-			defaultNumCtx:  262144,
+			defaultNumCtx:  16384,
 			modelNumCtx:    0,
 			requestNumCtx:  0,
-			expectedNumCtx: 262144,
+			expectedNumCtx: 16384,
+		},
+		{
+			name:           "high vram tier default",
+			envContextLen:  "",
+			defaultNumCtx:  65536,
+			modelNumCtx:    0,
+			requestNumCtx:  0,
+			expectedNumCtx: 65536,
 		},
 	}
 


### PR DESCRIPTION
The previous tiered defaults (4k/32k/256k) were too aggressive for large models, causing CPU offload and severe performance degradation.

Tested worst-case models at each VRAM tier to find spill points:

  ~24 GiB VRAM: qwq 32B spills at 16k  → default 8k
  51.8 GiB VRAM (64GB Mac): llama3.1:70b spills at 32k → default 16k
  96.0 GiB VRAM (128GB Mac): deepseek-r1:70b spills at 128k → default 64k

New tiers: 4k / 8k / 16k / 64k (was 4k / 32k / 256k)