### PR TITLE
docs: update Zod example to use native toJSONSchema

### DIFF
--- a/docs/capabilities/structured-outputs.mdx
+++ b/docs/capabilities/structured-outputs.mdx
@@ -96,12 +96,11 @@ Provide a JSON schema to the `format` field.
     ```
   </Tab>
   <Tab title="JavaScript">
-    Serialize a Zod schema with `zodToJsonSchema()` and parse the structured response:
+    Serialize a Zod schema with `z.toJSONSchema()` and parse the structured response:
 
     ```javascript
     import ollama from 'ollama'
-    import { z } from 'zod'
-    import { zodToJsonSchema } from 'zod-to-json-schema'
+    import * as z from 'zod'
 
     const Country = z.object({
       name: z.string(),
@@ -112,7 +111,7 @@ Provide a JSON schema to the `format` field.
     const response = await ollama.chat({
       model: 'gpt-oss',
       messages: [{ role: 'user', content: 'Tell me about Canada.' }],
-      format: zodToJsonSchema(Country),
+      format: z.toJSONSchema(Country),
     })
 
     const country = Country.parse(JSON.parse(response.message.content))


### PR DESCRIPTION
## Summary

Updates the JavaScript structured outputs example to use Zod v4's native `z.toJSONSchema()` method instead of the deprecated `zod-to-json-schema` library.

## Changes

- Updated import to use `import * as z from "zod"`
- Changed `zodToJsonSchema(Country)` to `z.toJSONSchema(Country)`
- Removed deprecated `zod-to-json-schema` import

## Testing

- Verified the syntax is correct for Zod v4
- Documentation change only, no code changes required

Fixes ollama/ollama#14734