### PR TITLE
server: add experimental web search and web fetch routes

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -1961,8 +1961,6 @@ func (s *Server) webExperimentalProxyHandler(c *gin.Context, proxyPath, disabled
 		return
 	}
 
-	// Experimental web endpoints always use server-side cloud signing.
-	c.Request.Header.Del("Authorization")
 	proxyCloudRequestWithPath(c, body, proxyPath, disabledOperation)
 }
 

--- a/server/routes_web_experimental_test.go
+++ b/server/routes_web_experimental_test.go
@@ -90,7 +90,7 @@ func TestExperimentalWebEndpointsPassthrough(t *testing.T) {
 				t.Fatal(err)
 			}
 			req.Header.Set("Content-Type", "application/json")
-			req.Header.Set("Authorization", "Bearer should-not-forward")
+			req.Header.Set("Authorization", "Bearer should-forward")
 			req.Header.Set("X-Test-Header", "web-experimental")
 
 			resp, err := local.Client().Do(req)
@@ -109,8 +109,8 @@ func TestExperimentalWebEndpointsPassthrough(t *testing.T) {
 			if !bytes.Contains([]byte(capture.body), []byte(tt.assertBody)) {
 				t.Fatalf("expected upstream body to contain %q, got %q", tt.assertBody, capture.body)
 			}
-			if got := capture.header.Get("Authorization"); got != "" {
-				t.Fatalf("expected no forwarded Authorization header, got %q", got)
+			if got := capture.header.Get("Authorization"); got != "Bearer should-forward" {
+				t.Fatalf("expected forwarded Authorization header, got %q", got)
 			}
 			if got := capture.header.Get("X-Test-Header"); got != "web-experimental" {
 				t.Fatalf("expected forwarded X-Test-Header=web-experimental, got %q", got)


### PR DESCRIPTION
Allow easy access to the web search and fetch APIs on the cloud to not require API keys.

Manages no cloud behavior as well:
```
{
  "error": "ollama cloud is disabled: web search is unavailable"
}
```