### PR TITLE
ci: Fix windows build

### DIFF
--- a/x/mlxrunner/mlx/generator/main.go
+++ b/x/mlxrunner/mlx/generator/main.go
@@ -97,8 +97,18 @@ func main() {
 	qc := tree_sitter.NewQueryCursor()
 	defer qc.Close()
 
-	var funs []Function
+	var files []string
 	for _, arg := range flag.Args() {
+		matches, err := filepath.Glob(arg)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error expanding glob %s: %v\n", arg, err)
+			continue
+		}
+		files = append(files, matches...)
+	}
+
+	var funs []Function
+	for _, arg := range files {
 		bts, err := os.ReadFile(arg)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error reading file %s: %v\n", arg, err)

--- a/x/mlxrunner/mlx/mlx.go
+++ b/x/mlxrunner/mlx/mlx.go
@@ -1,6 +1,6 @@
 package mlx
 
-//go:generate sh -c "go run generator/main.go -output=. ./include/mlx/c/*.h"
+//go:generate go run generator/main.go -output=. ./include/mlx/c/*.h
 
 // #cgo CXXFLAGS: -std=c++17
 // #cgo CPPFLAGS: -I${SRCDIR}/include


### PR DESCRIPTION
Instead of relying on sh for wildcard, do it in Go for better windows compatibility.