### PR TITLE
fix(cli): normalize quoted and encoded image paths

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -563,6 +563,7 @@ func NewCreateRequest(name string, opts runOptions) *api.CreateRequest {
 func normalizeFilePath(fp string) string {
 	return strings.NewReplacer(
 		"\\ ", " ", // Escaped space
+		"%20", " ", // URL-encoded space from some terminal drag-and-drop flows
 		"\\(", "(", // Escaped left parenthesis
 		"\\)", ")", // Escaped right parenthesis
 		"\\[", "[", // Escaped left square bracket
@@ -604,6 +605,8 @@ func extractFileData(input string) (string, []api.ImageData, error) {
 			return "", imgs, err
 		}
 		fmt.Fprintf(os.Stderr, "Added image '%s'\n", nfp)
+		input = strings.ReplaceAll(input, "\""+nfp+"\"", "")
+		input = strings.ReplaceAll(input, "\""+fp+"\"", "")
 		input = strings.ReplaceAll(input, "'"+nfp+"'", "")
 		input = strings.ReplaceAll(input, "'"+fp+"'", "")
 		input = strings.ReplaceAll(input, fp, "")

--- a/cmd/interactive_test.go
+++ b/cmd/interactive_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -79,6 +80,49 @@ func TestExtractFileDataRemovesQuotedFilepath(t *testing.T) {
 	}
 
 	input := "before '" + fp + "' after"
+	cleaned, imgs, err := extractFileData(input)
+	assert.NoError(t, err)
+	assert.Len(t, imgs, 1)
+	assert.Equal(t, cleaned, "before  after")
+}
+
+// Ensure that file paths wrapped in double quotes are removed with the quotes.
+func TestExtractFileDataRemovesDoubleQuotedFilepath(t *testing.T) {
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "img.jpg")
+	data := make([]byte, 600)
+	copy(data, []byte{
+		0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 'J', 'F', 'I', 'F',
+		0x00, 0x01, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0xff, 0xd9,
+	})
+	if err := os.WriteFile(fp, data, 0o600); err != nil {
+		t.Fatalf("failed to write test image: %v", err)
+	}
+
+	input := "before \"" + fp + "\" after"
+	cleaned, imgs, err := extractFileData(input)
+	assert.NoError(t, err)
+	assert.Len(t, imgs, 1)
+	assert.Equal(t, cleaned, "before  after")
+}
+
+// Ensure URL-encoded spaces in paths are decoded so drag-and-drop paths resolve.
+func TestExtractFileDataDecodesPercent20Path(t *testing.T) {
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "my image.jpg")
+	data := make([]byte, 600)
+	copy(data, []byte{
+		0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 'J', 'F', 'I', 'F',
+		0x00, 0x01, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0xff, 0xd9,
+	})
+	if err := os.WriteFile(fp, data, 0o600); err != nil {
+		t.Fatalf("failed to write test image: %v", err)
+	}
+
+	encoded := strings.ReplaceAll(fp, " ", "%20")
+	input := "before " + encoded + " after"
 	cleaned, imgs, err := extractFileData(input)
 	assert.NoError(t, err)
 	assert.Len(t, imgs, 1)

--- a/x/imagegen/cli.go
+++ b/x/imagegen/cli.go
@@ -525,6 +525,27 @@ func extractFileNames(input string) []string {
 	return re.FindAllString(input, -1)
 }
 
+func normalizeFilePath(fp string) string {
+	return strings.NewReplacer(
+		"\\ ", " ", // Escaped space
+		"%20", " ", // URL-encoded space from some terminal drag-and-drop flows
+		"\\(", "(", // Escaped left parenthesis
+		"\\)", ")", // Escaped right parenthesis
+		"\\[", "[", // Escaped left square bracket
+		"\\]", "]", // Escaped right square bracket
+		"\\{", "{", // Escaped left curly brace
+		"\\}", "}", // Escaped right curly brace
+		"\\$", "$", // Escaped dollar sign
+		"\\&", "&", // Escaped ampersand
+		"\\;", ";", // Escaped semicolon
+		"\\'", "'", // Escaped single quote
+		"\\\\", "\\", // Escaped backslash
+		"\\*", "*", // Escaped asterisk
+		"\\?", "?", // Escaped question mark
+		"\\~", "~", // Escaped tilde
+	).Replace(fp)
+}
+
 // extractFileData extracts image data from file paths found in the input.
 // Returns the cleaned prompt (with file paths removed) and the image data.
 func extractFileData(input string) (string, []api.ImageData, error) {
@@ -532,11 +553,7 @@ func extractFileData(input string) (string, []api.ImageData, error) {
 	var imgs []api.ImageData
 
 	for _, fp := range filePaths {
-		// Normalize shell escapes
-		nfp := strings.ReplaceAll(fp, "\\ ", " ")
-		nfp = strings.ReplaceAll(nfp, "\\(", "(")
-		nfp = strings.ReplaceAll(nfp, "\\)", ")")
-		nfp = strings.ReplaceAll(nfp, "%20", " ")
+		nfp := normalizeFilePath(fp)
 
 		data, err := getImageData(nfp)
 		if errors.Is(err, os.ErrNotExist) {
@@ -545,6 +562,10 @@ func extractFileData(input string) (string, []api.ImageData, error) {
 			return "", nil, err
 		}
 		fmt.Fprintf(os.Stderr, "Added image '%s'\n", nfp)
+		input = strings.ReplaceAll(input, "\""+nfp+"\"", "")
+		input = strings.ReplaceAll(input, "\""+fp+"\"", "")
+		input = strings.ReplaceAll(input, "'"+nfp+"'", "")
+		input = strings.ReplaceAll(input, "'"+fp+"'", "")
 		input = strings.ReplaceAll(input, fp, "")
 		imgs = append(imgs, data)
 	}


### PR DESCRIPTION
Fixes #10333


## Summary
- normalize CLI image file paths more robustly during extraction
- decode `%20` (URL-encoded spaces) in file paths
- handle prompt cleanup for both single-quoted and double-quoted file paths
- align normalization behavior between `cmd` interactive flow and `x/imagegen` CLI flow
- add regression tests for quoted paths and `%20`-encoded paths

## Why
Dragging image paths into terminal input can include escaping/quoting/encoding variants.
This change makes path extraction resilient to those variants so image attachments are detected reliably.

## Changes
- `cmd/interactive.go`
  - add `%20` decoding in `normalizeFilePath`
  - remove `\"path\"` variants from prompt after successful extraction
- `x/imagegen/cli.go`

  - add shared-style `normalizeFilePath` helper
  - replace ad-hoc normalization with helper
  - remove both `'path'` and `\"path\"` variants from prompt after extraction
- `cmd/interactive_test.go`
  - `TestExtractFileDataRemovesDoubleQuotedFilepath`
  - `TestExtractFileDataDecodesPercent20Path`
