### PR TITLE
runner: replace panics with graceful error handling in sample/decode

### DIFF
--- a/llm/server.go
+++ b/llm/server.go
@@ -1485,6 +1485,8 @@ const (
 	DoneReasonLength
 	// DoneReasonConnectionClosed indicates the completion stopped due to the connection being closed
 	DoneReasonConnectionClosed
+	// DoneReasonError indicates the completion stopped due to an internal error
+	DoneReasonError
 )
 
 func (d DoneReason) String() string {
@@ -1493,6 +1495,8 @@ func (d DoneReason) String() string {
 		return "length"
 	case DoneReasonStop:
 		return "stop"
+	case DoneReasonError:
+		return "error"
 	default:
 		return "" // closed
 	}

--- a/runner/ollamarunner/runner.go
+++ b/runner/ollamarunner/runner.go
@@ -766,7 +766,9 @@ func (s *Server) computeBatch(activeBatch batchState) {
 		logits := outputs[iBatches[i]*vocabSize : (iBatches[i]+1)*vocabSize]
 		token, err := seq.sampler.Sample(logits)
 		if err != nil {
-			panic("failed to sample token")
+			slog.Error("failed to sample token", "seq", seq.cache.Id, "error", err)
+			s.removeSequence(i, llm.DoneReasonError)
+			continue
 		}
 
 		nextBatchTokens[i].Token = token
@@ -783,7 +785,9 @@ func (s *Server) computeBatch(activeBatch batchState) {
 
 		piece, err := s.model.(tokenizer.Tokenizer).Decode([]int32{token})
 		if err != nil {
-			panic("failed to decode token")
+			slog.Error("failed to decode token", "seq", seq.cache.Id, "token", token, "error", err)
+			s.removeSequence(i, llm.DoneReasonError)
+			continue
 		}
 
 		// Calculate logprobs if requested (after EOS check to avoid logprobs for EOS tokens)


### PR DESCRIPTION
## Summary

Fixes #14718

Replace `panic("failed to sample token")` and `panic("failed to decode token")` in `runner/ollamarunner/runner.go` with graceful error handling that terminates only the failing sequence instead of crashing the entire runner process.

## Problem

When `seq.sampler.Sample(logits)` or `Decode([]int32{token})` returns an error, the current code calls `panic(...)`, which kills the entire runner process — including all other active sequences being served concurrently. This is unnecessarily destructive since the error is scoped to a single sequence.

## Solution

- Log the error with `slog.Error` including the sequence ID and error details
- Call `s.removeSequence(i, llm.DoneReasonError)` to cleanly terminate just the failing sequence
- `continue` to process remaining sequences in the batch

This matches the existing error handling pattern used throughout the same function, e.g.:

```go
// EOS handling (line 780)
s.removeSequence(i, llm.DoneReasonStop)
continue

// Length limit (line 799)
s.removeSequence(i, llm.DoneReasonLength)
continue

// Connection closed (line 852)
s.removeSequence(i, llm.DoneReasonConnectionClosed)
continue
```

A new `DoneReasonError` constant is added to `llm.DoneReason` to distinguish error terminations from normal stop reasons.

## Test plan

- [ ] Verify `go vet ./llm/...` passes (confirmed locally)
- [ ] Verify existing tests pass
- [ ] Manual: trigger a sample error and confirm the runner continues serving other sequences

🤖 Generated with [Claude Code](https://claude.com/claude-code)