### PR TITLE
x/agent: fix false positive deny pattern matching in heredocs

### DIFF
--- a/x/agent/approval.go
+++ b/x/agent/approval.go
@@ -233,8 +233,9 @@ func stripHeredocs(command string) string {
 	return result.String()
 }
 
-// commandPrefixes are characters that can precede a command name in shell.
-var commandPrefixes = []string{"|", "&&", "||", ";", "(", "\n", "\t"}
+// commandPrefixes are shell operators/syntax that can precede a command name.
+// This covers pipelines, logical operators, subshells, and command substitution.
+var commandPrefixes = []string{"|", "&&", "||", ";", "(", "$(", "`", "\n", "\t"}
 
 // matchesAtCommandPosition checks whether a pattern appears at a position
 // where it could be an actual command (start of string or after a shell operator).
@@ -266,6 +267,8 @@ func matchesAtCommandPosition(commandLower, patternLower string) bool {
 
 // commandPatterns are deny patterns that should only match at command
 // positions to avoid false positives from substrings in code/data.
+// When adding new deny patterns to denyPatterns, consider whether the pattern
+// could appear as a substring in normal code and add it here if so.
 var commandPatterns = map[string]bool{
 	"sudo ":   true,
 	"su ":     true,

--- a/x/agent/approval_test.go
+++ b/x/agent/approval_test.go
@@ -472,6 +472,11 @@ func TestIsDenied(t *testing.T) {
 		{"echo 'visual result ensure'", false, ""},
 		{"grep -r 'substitution' .", false, ""},
 		{"echo 'document_history_log'", false, ""},
+		// Command substitution should still catch dangerous commands
+		{"echo $(sudo cat /etc/shadow)", true, "sudo "},
+		{"echo `nc localhost 4444`", true, "nc "},
+		// Pattern after semicolon with no space
+		{"echo test;sudo rm -rf /", true, "rm -rf"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
The `IsDenied` function uses naive substring matching against the full command string, which causes false positives when heredoc bodies contain substrings matching deny patterns (e.g. `su ` matching inside words like "result" or "ensure").

Two changes to fix this:
- Strip heredoc bodies before checking deny patterns
- Require command-like patterns (`su`, `nc`, `sudo`, etc.) to appear at a shell command position rather than anywhere in the string

Fixes #14766