### PR TITLE
fix: use consistent binary units (TiB/GiB/MiB/KiB) in HumanBytes

### DIFF
--- a/format/bytes.go
+++ b/format/bytes.go
@@ -25,16 +25,16 @@ func HumanBytes(b int64) string {
 	switch {
 	case b >= TeraByte:
 		value = float64(b) / TeraByte
-		unit = "TB"
+		unit = "TiB"
 	case b >= GigaByte:
 		value = float64(b) / GigaByte
-		unit = "GB"
+		unit = "GiB"
 	case b >= MegaByte:
 		value = float64(b) / MegaByte
-		unit = "MB"
+		unit = "MiB"
 	case b >= KiloByte:
 		value = float64(b) / KiloByte
-		unit = "KB"
+		unit = "KiB"
 	default:
 		return fmt.Sprintf("%d B", b)
 	}


### PR DESCRIPTION
## Description
The `HumanBytes` function uses 1024-based multipliers (TeraByte, GigaByte, etc.) but displays decimal units (TB, GB, MB, KB). This fix updates the display to use binary units (TiB/GiB/MiB/KiB) to be consistent with the calculation.

## Changes
- Changed unit display from TB/GB/MB/KB to TiB/GiB/MiB/KiB in `format/bytes.go`

This ensures consistency between the calculation (using 1024-based values) and the displayed units (binary notation).