### PR TITLE
docs: document reasoning_effort support in OpenAI-compatible API

### DIFF
--- a/docs/api/openai-compatibility.mdx
+++ b/docs/api/openai-compatibility.mdx
@@ -184,6 +184,7 @@ curl -X POST http://localhost:11434/v1/chat/completions \
 - [x] Reproducible outputs
 - [x] Vision
 - [x] Tools
+- [x] Reasoning/thinking control (for thinking models)
 - [ ] Logprobs
 
 #### Supported request fields
@@ -207,6 +208,9 @@ curl -X POST http://localhost:11434/v1/chat/completions \
 - [x] `top_p`
 - [x] `max_tokens`
 - [x] `tools`
+- [x] `reasoning_effort` (`"high"`, `"medium"`, `"low"`, `"none"`)
+- [x] `reasoning`
+  - [x] `effort` (`"high"`, `"medium"`, `"low"`, `"none"`)
 - [ ] `tool_choice`
 - [ ] `logit_bias`
 - [ ] `user`


### PR DESCRIPTION
Closes #14820

## Problem

The OpenAI-compatible `/v1/chat/completions` endpoint supports `reasoning_effort` and `reasoning` request fields for controlling thinking on thinking-capable models (e.g. `qwen3.5`), but this is not documented in the [OpenAI compatibility docs](https://docs.ollama.com/api/openai-compatibility).

Ollama auto-enables thinking for capable models when no `reasoning_effort` is provided. The only way to discover how to disable thinking via the OpenAI-compat API is to read the source code (`openai/openai.go`), where one can verify that `reasoning_effort` or `reasoning.effort` are mapped to the internal `Think` field:

- `"high"`, `"medium"`, `"low"` → thinking ON (with varying effort)
- `"none"` → thinking OFF

This is especially important because many users connect to Ollama through OpenAI-compatible SDKs and frameworks (PydanticAI, LangChain, etc.) via `/v1/chat/completions`, and the native Ollama parameter `think: true/false` does not work on this endpoint. Without documentation, there is no discoverable way to control thinking through the OpenAI-compat API.

## Changes

- Add `reasoning_effort` and `reasoning` to the supported features and request fields for `/v1/chat/completions` in `docs/api/openai-compatibility.mdx`
- Document accepted values (`"high"`, `"medium"`, `"low"`, `"none"`)

## Verification

- [x] Verified `reasoning_effort` values (`"high"`, `"medium"`, `"low"`, `"none"`) work against `/v1/chat/completions` with `qwen3.5:9b`
- [x] Verified nested `reasoning.effort` form works identically
- [x] Confirmed these fields are implemented in `openai/openai.go` but missing from docs