### PR TITLE
api/create: always propagate `:cloud` source for cloud models

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1346,6 +1346,20 @@ func TestNewCreateRequest(t *testing.T) {
 			},
 		},
 		{
+			"explicit cloud model preserves source when parent lacks it",
+			"newmodel",
+			runOptions{
+				Model:       "qwen3.5:cloud",
+				ParentModel: "qwen3.5",
+				Messages:    []api.Message{},
+				WordWrap:    true,
+			},
+			&api.CreateRequest{
+				From:  "qwen3.5:cloud",
+				Model: "newmodel",
+			},
+		},
+		{
 			"parent model as filepath test",
 			"newmodel",
 			runOptions{

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/envconfig"
+	"github.com/ollama/ollama/internal/modelref"
 	"github.com/ollama/ollama/readline"
 	"github.com/ollama/ollama/types/errtypes"
 	"github.com/ollama/ollama/types/model"
@@ -537,6 +538,13 @@ func NewCreateRequest(name string, opts runOptions) *api.CreateRequest {
 
 	modelName := model.ParseName(parentModel)
 	if !modelName.IsValid() {
+		parentModel = ""
+	}
+
+	// Preserve explicit cloud intent for sessions started with `:cloud`.
+	// Cloud model metadata can return a source-less parent_model (for example
+	// "qwen3.5"), which would otherwise make `/save` create a local derivative.
+	if modelref.HasExplicitCloudSource(opts.Model) && !modelref.HasExplicitCloudSource(parentModel) {
 		parentModel = ""
 	}
 


### PR DESCRIPTION
Otherwise, using `/save` would try to run the local model instead