### PR TITLE
launch: add compact window for claude code

### DIFF
--- a/cmd/launch/claude.go
+++ b/cmd/launch/claude.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 
 	"github.com/ollama/ollama/envconfig"
 )
@@ -68,10 +69,18 @@ func (c *Claude) Run(model string, args []string) error {
 
 // modelEnvVars returns Claude Code env vars that route all model tiers through Ollama.
 func (c *Claude) modelEnvVars(model string) []string {
-	return []string{
+	env := []string{
 		"ANTHROPIC_DEFAULT_OPUS_MODEL=" + model,
 		"ANTHROPIC_DEFAULT_SONNET_MODEL=" + model,
 		"ANTHROPIC_DEFAULT_HAIKU_MODEL=" + model,
 		"CLAUDE_CODE_SUBAGENT_MODEL=" + model,
 	}
+
+	if isCloudModelName(model) {
+		if l, ok := lookupCloudModelLimit(model); ok {
+			env = append(env, "CLAUDE_CODE_AUTO_COMPACT_WINDOW="+strconv.Itoa(l.Context))
+		}
+	}
+
+	return env
 }

--- a/cmd/launch/claude_test.go
+++ b/cmd/launch/claude_test.go
@@ -131,6 +131,9 @@ func TestClaudeModelEnvVars(t *testing.T) {
 		if got["CLAUDE_CODE_SUBAGENT_MODEL"] != "llama3.2" {
 			t.Errorf("SUBAGENT = %q, want llama3.2", got["CLAUDE_CODE_SUBAGENT_MODEL"])
 		}
+		if got["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] != "" {
+			t.Errorf("AUTO_COMPACT_WINDOW = %q, want empty for local models", got["CLAUDE_CODE_AUTO_COMPACT_WINDOW"])
+		}
 	})
 
 	t.Run("supports empty model", func(t *testing.T) {
@@ -146,6 +149,23 @@ func TestClaudeModelEnvVars(t *testing.T) {
 		}
 		if got["CLAUDE_CODE_SUBAGENT_MODEL"] != "" {
 			t.Errorf("SUBAGENT = %q, want empty", got["CLAUDE_CODE_SUBAGENT_MODEL"])
+		}
+		if got["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] != "" {
+			t.Errorf("AUTO_COMPACT_WINDOW = %q, want empty", got["CLAUDE_CODE_AUTO_COMPACT_WINDOW"])
+		}
+	})
+
+	t.Run("sets auto compact window for known cloud models", func(t *testing.T) {
+		got := envMap(c.modelEnvVars("glm-5:cloud"))
+		if got["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] != "202752" {
+			t.Errorf("AUTO_COMPACT_WINDOW = %q, want 202752", got["CLAUDE_CODE_AUTO_COMPACT_WINDOW"])
+		}
+	})
+
+	t.Run("does not set auto compact window for unknown cloud models", func(t *testing.T) {
+		got := envMap(c.modelEnvVars("unknown-model:cloud"))
+		if got["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] != "" {
+			t.Errorf("AUTO_COMPACT_WINDOW = %q, want empty", got["CLAUDE_CODE_AUTO_COMPACT_WINDOW"])
 		}
 	})
 }


### PR DESCRIPTION
Leverage `CLAUDE_CODE_AUTO_COMPACT_WINDOW` and set for cloud models for now. Local models will be updated in a follow up. 

It currently triggers almost every other message even when set to ~50k tokens. Probably some stuff to figure out there. CC @hoyyeva 