### PR TITLE
parsers: handle truncated and invalid tool calls gracefully in qwen parsers

### DIFF
--- a/model/parsers/qwen3.go
+++ b/model/parsers/qwen3.go
@@ -105,8 +105,9 @@ func (p *Qwen3Parser) Add(s string, done bool) (content string, thinking string,
 		case qwen3EventRawToolCall:
 			toolCall, err := parseQwen3ToolCall(event, p.tools)
 			if err != nil {
-				slog.Warn("qwen3 tool call parsing failed", "error", err)
-				return "", "", nil, err
+				slog.Warn("qwen3 tool call parsing failed, falling back to content", "error", err)
+				contentSb.WriteString(event.raw)
+				continue
 			}
 			toolCall.Function.Index = p.callIndex
 			p.callIndex++
@@ -115,6 +116,20 @@ func (p *Qwen3Parser) Add(s string, done bool) (content string, thinking string,
 			thinkingSb.WriteString(event.content)
 		case qwen3EventContent:
 			contentSb.WriteString(event.content)
+		}
+	}
+
+	// When generation is complete, drain any remaining buffered content
+	// that was held back by the streaming parser (e.g. trailing whitespace,
+	// partial tags, or incomplete tool call content).
+	if done && p.buffer.Len() > 0 {
+		remaining := p.buffer.String()
+		p.buffer.Reset()
+		switch p.state {
+		case qwen3ParserStateCollectingToolContent, qwen3ParserStateToolStartedEatingWhitespace, qwen3ParserStateCollectingContent:
+			contentSb.WriteString(remaining)
+		case qwen3ParserStateCollectingThinking, qwen3ParserStateThinkingStartedEatingWhitespace:
+			thinkingSb.WriteString(remaining)
 		}
 	}
 

--- a/model/parsers/qwen35_test.go
+++ b/model/parsers/qwen35_test.go
@@ -380,3 +380,49 @@ func TestQwen35ParserThinkingTruncatedWithoutCloseTag(t *testing.T) {
 		t.Fatalf("expected no tool calls, got %d", len(calls))
 	}
 }
+
+func TestQwen35ParserTruncatedToolCall(t *testing.T) {
+	parser := ParserForName("qwen3.5")
+	if parser == nil {
+		t.Fatal("expected qwen3.5 parser")
+	}
+
+	parser.Init(nil, nil, &api.ThinkValue{Value: true})
+
+	// Thinking followed by truncated tool call (no close tag)
+	input := "Let me help</think>\n<tool_call><function=write_file><parameter=content>print('hel"
+	content, thinking, calls, err := parser.Add(input, true)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if thinking != "Let me help" {
+		t.Fatalf("expected thinking %q, got %q", "Let me help", thinking)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("expected no tool calls, got %d", len(calls))
+	}
+	if content != "<function=write_file><parameter=content>print('hel" {
+		t.Fatalf("expected truncated content as fallback, got %q", content)
+	}
+}
+
+func TestQwen35ParserInvalidToolCallFallsBackToContent(t *testing.T) {
+	parser := ParserForName("qwen3.5")
+	if parser == nil {
+		t.Fatal("expected qwen3.5 parser")
+	}
+
+	parser.Init(nil, nil, &api.ThinkValue{Value: false})
+
+	// Tool call with invalid XML content
+	content, _, calls, err := parser.Add("<tool_call>not valid xml</tool_call>", true)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("expected no tool calls, got %d", len(calls))
+	}
+	if content != "not valid xml" {
+		t.Fatalf("expected raw content as fallback, got %q", content)
+	}
+}

--- a/model/parsers/qwen3_test.go
+++ b/model/parsers/qwen3_test.go
@@ -291,6 +291,151 @@ func TestQwen3ParserToolCallIndexingStreaming(t *testing.T) {
 	}
 }
 
+func TestQwen3ParserTruncatedToolCallNoCloseTag(t *testing.T) {
+	parser := &Qwen3Parser{hasThinkingSupport: false, defaultThinking: false}
+	parser.Init(nil, nil, &api.ThinkValue{Value: false})
+
+	// Simulate truncated output: model emits tool call open tag and partial JSON,
+	// but generation ends before closing tag (e.g. hit num_predict limit).
+	content, thinking, calls, err := parser.Add(`<tool_call>{"name":"write_file","arguments":{"path":"/tmp/test.py","content":"print('hel`, true)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if thinking != "" {
+		t.Fatalf("expected no thinking, got %q", thinking)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("expected no tool calls, got %d", len(calls))
+	}
+	if content != `{"name":"write_file","arguments":{"path":"/tmp/test.py","content":"print('hel` {
+		t.Fatalf("expected truncated JSON as content, got %q", content)
+	}
+}
+
+func TestQwen3ParserTruncatedToolCallNoCloseTagStreaming(t *testing.T) {
+	parser := &Qwen3Parser{hasThinkingSupport: false, defaultThinking: false}
+	parser.Init(nil, nil, &api.ThinkValue{Value: false})
+
+	// First chunk: content before tool call
+	content, _, calls, err := parser.Add("Here is the code:\n<tool_call>", false)
+	if err != nil {
+		t.Fatalf("step 1: unexpected error: %v", err)
+	}
+	if content != "Here is the code:" {
+		t.Fatalf("step 1: expected content %q, got %q", "Here is the code:", content)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("step 1: expected no calls, got %d", len(calls))
+	}
+
+	// Second chunk: partial tool JSON, generation done (truncated)
+	content, _, calls, err = parser.Add(`{"name":"write_file","arguments":{"content":"...`, true)
+	if err != nil {
+		t.Fatalf("step 2: unexpected error: %v", err)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("step 2: expected no calls, got %d", len(calls))
+	}
+	if content != `{"name":"write_file","arguments":{"content":"...` {
+		t.Fatalf("step 2: expected truncated JSON as content, got %q", content)
+	}
+}
+
+func TestQwen3ParserInvalidToolCallJSON(t *testing.T) {
+	parser := &Qwen3Parser{hasThinkingSupport: false, defaultThinking: false}
+	parser.Init(nil, nil, &api.ThinkValue{Value: false})
+
+	// Tool call tags present but JSON inside is truncated/invalid
+	content, thinking, calls, err := parser.Add(`<tool_call>{"name":"write_file","arguments":{"content":"incomplete...</tool_call>`, true)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if thinking != "" {
+		t.Fatalf("expected no thinking, got %q", thinking)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("expected no tool calls, got %d", len(calls))
+	}
+	if content != `{"name":"write_file","arguments":{"content":"incomplete...` {
+		t.Fatalf("expected raw JSON as content fallback, got %q", content)
+	}
+}
+
+func TestQwen3ParserThinkingWithTruncatedToolCall(t *testing.T) {
+	parser := &Qwen3Parser{hasThinkingSupport: true, defaultThinking: true}
+	parser.Init(nil, nil, &api.ThinkValue{Value: true})
+
+	// Thinking followed by truncated tool call (no close tag)
+	content, thinking, calls, err := parser.Add("Let me help</think>\n<tool_call>{\"name\":\"write_file\",\"arguments\":{\"content\":\"truncated", true)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if thinking != "Let me help" {
+		t.Fatalf("expected thinking %q, got %q", "Let me help", thinking)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("expected no tool calls, got %d", len(calls))
+	}
+	if content != `{"name":"write_file","arguments":{"content":"truncated` {
+		t.Fatalf("expected truncated JSON as content, got %q", content)
+	}
+}
+
+func TestQwen3ParserValidToolCallAfterInvalid(t *testing.T) {
+	parser := &Qwen3Parser{hasThinkingSupport: false, defaultThinking: false}
+	parser.Init(nil, nil, &api.ThinkValue{Value: false})
+
+	// Invalid tool call followed by valid one — invalid falls back to content,
+	// valid one is still parsed correctly.
+	input := `<tool_call>invalid json</tool_call>
+<tool_call>{"name":"get_weather","arguments":{"location":"SF"}}</tool_call>`
+	content, _, calls, err := parser.Add(input, true)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if content != "invalid json" {
+		t.Fatalf("expected invalid JSON as content, got %q", content)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(calls))
+	}
+	if calls[0].Function.Name != "get_weather" {
+		t.Fatalf("expected tool name %q, got %q", "get_weather", calls[0].Function.Name)
+	}
+}
+
+func TestQwen3ParserTruncatedContentDone(t *testing.T) {
+	parser := &Qwen3Parser{hasThinkingSupport: false, defaultThinking: false}
+	parser.Init(nil, nil, &api.ThinkValue{Value: false})
+
+	// Content with trailing whitespace — on done, should be flushed
+	content, _, _, err := parser.Add("Hello world\n", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if content != "Hello world\n" {
+		t.Fatalf("expected %q, got %q", "Hello world\n", content)
+	}
+}
+
+func TestQwen3ParserPartialToolTagAtEndDone(t *testing.T) {
+	parser := &Qwen3Parser{hasThinkingSupport: false, defaultThinking: false}
+	parser.Init(nil, nil, &api.ThinkValue{Value: false})
+
+	// Model outputs partial <tool_call> tag and then generation ends.
+	// The partial tag should be flushed as content since done=true.
+	content, _, calls, err := parser.Add("Hello\n<tool_c", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("expected no tool calls, got %d", len(calls))
+	}
+	if content != "Hello\n<tool_c" {
+		t.Fatalf("expected %q, got %q", "Hello\n<tool_c", content)
+	}
+}
+
 func TestQwen3ParserToolCallIndexResetOnInit(t *testing.T) {
 	parser := &Qwen3Parser{hasThinkingSupport: false, defaultThinking: false}
 	parser.Init(nil, nil, &api.ThinkValue{Value: false})

--- a/model/parsers/qwen3coder.go
+++ b/model/parsers/qwen3coder.go
@@ -61,8 +61,9 @@ func (p *Qwen3CoderParser) Add(s string, done bool) (content string, thinking st
 		case qwenEventRawToolCall:
 			toolCall, err := parseToolCall(event, p.tools)
 			if err != nil {
-				slog.Warn("qwen tool call parsing failed", "error", err)
-				return "", "", nil, err
+				slog.Warn("qwen tool call parsing failed, falling back to content", "error", err)
+				sb.WriteString(event.raw)
+				continue
 			}
 			toolCall.Function.Index = p.callIndex
 			p.callIndex++
@@ -73,6 +74,15 @@ func (p *Qwen3CoderParser) Add(s string, done bool) (content string, thinking st
 			// `qwenEvent`s for more details
 			sb.WriteString(event.content)
 		}
+	}
+
+	// When generation is complete, drain any remaining buffered content
+	// that was held back by the streaming parser (e.g. trailing whitespace,
+	// partial tags, or incomplete tool call content).
+	if done && p.acc.Len() > 0 {
+		remaining := p.acc.String()
+		p.acc.Reset()
+		sb.WriteString(remaining)
 	}
 
 	return sb.String(), "", toolCalls, nil

--- a/model/parsers/qwen3coder_test.go
+++ b/model/parsers/qwen3coder_test.go
@@ -1035,6 +1035,105 @@ func TestQwenToolCallValueParsing(t *testing.T) {
 	}
 }
 
+func TestQwen3CoderParserTruncatedToolCallNoCloseTag(t *testing.T) {
+	parser := Qwen3CoderParser{}
+	parser.Init(nil, nil, nil)
+
+	// Simulate truncated output: tool call open tag and partial XML content,
+	// but generation ends before closing tag.
+	content, _, calls, err := parser.Add("<tool_call><function=write_file><parameter=path>/tmp/test.py</parameter><parameter=content>print('hel", true)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("expected no tool calls, got %d", len(calls))
+	}
+	if content != "<function=write_file><parameter=path>/tmp/test.py</parameter><parameter=content>print('hel" {
+		t.Fatalf("expected truncated content as fallback, got %q", content)
+	}
+}
+
+func TestQwen3CoderParserTruncatedToolCallNoCloseTagStreaming(t *testing.T) {
+	parser := Qwen3CoderParser{}
+	parser.Init(nil, nil, nil)
+
+	// First chunk: content before tool call
+	content, _, calls, err := parser.Add("Here is the code:\n<tool_call>", false)
+	if err != nil {
+		t.Fatalf("step 1: unexpected error: %v", err)
+	}
+	if content != "Here is the code:" {
+		t.Fatalf("step 1: expected content %q, got %q", "Here is the code:", content)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("step 1: expected no calls, got %d", len(calls))
+	}
+
+	// Second chunk: partial tool content, generation done (truncated)
+	content, _, calls, err = parser.Add("<function=write_file><parameter=content>incomplete...", true)
+	if err != nil {
+		t.Fatalf("step 2: unexpected error: %v", err)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("step 2: expected no calls, got %d", len(calls))
+	}
+	if content != "<function=write_file><parameter=content>incomplete..." {
+		t.Fatalf("step 2: expected truncated content as fallback, got %q", content)
+	}
+}
+
+func TestQwen3CoderParserInvalidToolCallXML(t *testing.T) {
+	parser := Qwen3CoderParser{}
+	parser.Init(nil, nil, nil)
+
+	// Tool call tags present but content inside is invalid XML
+	content, _, calls, err := parser.Add("<tool_call>this is not valid xml at all</tool_call>", true)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("expected no tool calls, got %d", len(calls))
+	}
+	if content != "this is not valid xml at all" {
+		t.Fatalf("expected raw content as fallback, got %q", content)
+	}
+}
+
+func TestQwen3CoderParserValidToolCallAfterInvalid(t *testing.T) {
+	parser := Qwen3CoderParser{}
+	parser.Init(nil, nil, nil)
+
+	// Invalid tool call followed by valid one
+	input := "<tool_call>invalid content</tool_call>\n<tool_call><function=get_weather><parameter=location>SF</parameter></function></tool_call>"
+	content, _, calls, err := parser.Add(input, true)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if content != "invalid content" {
+		t.Fatalf("expected invalid content as fallback, got %q", content)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(calls))
+	}
+	if calls[0].Function.Name != "get_weather" {
+		t.Fatalf("expected tool name %q, got %q", "get_weather", calls[0].Function.Name)
+	}
+}
+
+func TestQwen3CoderParserContentDrainOnDone(t *testing.T) {
+	parser := Qwen3CoderParser{}
+	parser.Init(nil, nil, nil)
+
+	// Content with trailing whitespace — on done, should be flushed
+	content, _, _, err := parser.Add("Hello world\n", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if content != "Hello world\n" {
+		t.Fatalf("expected %q, got %q", "Hello world\n", content)
+	}
+}
+
 func TestQwen3CoderParserToolCallIndexing(t *testing.T) {
 	parser := Qwen3CoderParser{}
 	parser.Init(nil, nil, nil)


### PR DESCRIPTION
## Summary

- Fixes truncated tool calls (e.g. from `num_predict` limits) causing a 500 error by converting tool call parse failures into content fallback instead of returning a fatal error
- Adds buffer drain on `done=true` so partial tool calls and trailing whitespace are flushed as content rather than silently discarded
- Applies to `Qwen3Parser` (qwen3, qwen3-thinking) and `Qwen3CoderParser` (qwen3-coder, qwen3.5)

Closes #14570

## Changes

### `model/parsers/qwen3.go`
- Changed `parseQwen3ToolCall` error handling from `return "", "", nil, err` to writing `event.raw` as content and continuing — prevents 500 responses on malformed JSON
- Added state-aware buffer drain when `done=true`: flushes remaining buffer as content (when collecting content/tool) or thinking (when collecting thinking)

### `model/parsers/qwen3coder.go`
- Same error fallback fix for `parseToolCall` failures
- Added buffer drain when `done=true`: flushes remaining buffer as content (this parser has no thinking support)

### Tests
- 15 new tests across `qwen3_test.go`, `qwen3coder_test.go`, and `qwen35_test.go`
- Covers: truncated tool calls (single chunk + streaming), invalid JSON/XML, valid-after-invalid recovery, buffer drain on done, partial tags at end of stream

## Test plan

- [x] `go test ./model/parsers/ -count=1` — all tests pass
- [x] `go vet ./model/parsers/` — no issues
- [x] Verify with a qwen3 model that truncated tool calls no longer produce 500 errors
- [x] Verify that valid tool calls continue to work correctly