### PR TITLE
cmd/launch: add guards for headless mode

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -62,6 +62,9 @@ import (
 func init() {
 	// Override default selectors to use Bubbletea TUI instead of raw terminal I/O.
 	launch.DefaultSingleSelector = func(title string, items []launch.ModelItem, current string) (string, error) {
+		if !term.IsTerminal(int(os.Stdin.Fd())) || !term.IsTerminal(int(os.Stdout.Fd())) {
+			return "", fmt.Errorf("model selection requires an interactive terminal; use --model to run in headless mode")
+		}
 		tuiItems := tui.ReorderItems(tui.ConvertItems(items))
 		result, err := tui.SelectSingle(title, tuiItems, current)
 		if errors.Is(err, tui.ErrCancelled) {
@@ -71,6 +74,9 @@ func init() {
 	}
 
 	launch.DefaultMultiSelector = func(title string, items []launch.ModelItem, preChecked []string) ([]string, error) {
+		if !term.IsTerminal(int(os.Stdin.Fd())) || !term.IsTerminal(int(os.Stdout.Fd())) {
+			return nil, fmt.Errorf("model selection requires an interactive terminal; use --model to run in headless mode")
+		}
 		tuiItems := tui.ReorderItems(tui.ConvertItems(items))
 		result, err := tui.SelectMultiple(title, tuiItems, preChecked)
 		if errors.Is(err, tui.ErrCancelled) {

--- a/cmd/launch/models.go
+++ b/cmd/launch/models.go
@@ -199,7 +199,7 @@ func showOrPullWithPolicy(ctx context.Context, client *api.Client, model string,
 	case missingModelAutoPull:
 		return pullMissingModel(ctx, client, model)
 	case missingModelFail:
-		return fmt.Errorf("model %q not found; run 'ollama pull %s' first", model, model)
+		return fmt.Errorf("model %q not found; run 'ollama pull %s' first, or use --yes to auto-pull", model, model)
 	default:
 		return confirmAndPull(ctx, client, model)
 	}


### PR DESCRIPTION
Should have had a couple more guards to make sure that any tui element is guarded on detecting terminal