### PR TITLE
runner: fix swallowed error in allocModel graph reservation

### DIFF
--- a/runner/ollamarunner/runner.go
+++ b/runner/ollamarunner/runner.go
@@ -1231,7 +1231,7 @@ func (s *Server) allocModel(
 
 	err = s.reserveWorstCaseGraph(true)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	return s.reserveWorstCaseGraph(false)


### PR DESCRIPTION
## Summary

Fixes #14839

`allocModel()` silently discards the error from the first `reserveWorstCaseGraph(true)` call by returning `nil` instead of `err`. This means a failed prompt graph reservation goes unnoticed — the model appears to load successfully but may behave unexpectedly during inference.

**Before (bug):**
```go
err = s.reserveWorstCaseGraph(true)
if err != nil {
    return nil  // error swallowed
}
```

**After (fix):**
```go
err = s.reserveWorstCaseGraph(true)
if err != nil {
    return err  // error properly propagated
}
```

The second call `reserveWorstCaseGraph(false)` already returns its error correctly, so this was likely a typo.

## Test plan

- [x] Verified the fix is a single-character change (`nil` -> `err`) with no side effects
- [ ] Existing tests continue to pass (the change only affects the error path)
- [ ] Under memory pressure, `allocModel` now correctly reports failure instead of silently proceeding

🤖 Generated with [Claude Code](https://claude.com/claude-code)