### PR TITLE
fitcheck: add hardware fit-check and model compatibility ranker

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -498,3 +498,46 @@ type AliasDeleteRequest struct {
 func (c *Client) DeleteAliasExperimental(ctx context.Context, req *AliasDeleteRequest) error {
 	return c.do(ctx, http.MethodDelete, "/api/experimental/aliases", req, nil)
 }
+
+// Fit queries the server for hardware capabilities and ranked model compatibility.
+func (c *Client) Fit(ctx context.Context, req FitRequest) (*FitResponse, error) {
+	requestURL := c.base.JoinPath("/api/fit")
+	q := requestURL.Query()
+	if req.All {
+		q.Set("all", "true")
+	}
+	if req.Family != "" {
+		q.Set("family", req.Family)
+	}
+	if req.Tags != "" {
+		q.Set("tags", req.Tags)
+	}
+	requestURL.RawQuery = q.Encode()
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Accept", "application/json")
+
+	respObj, err := c.http.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	defer respObj.Body.Close()
+
+	respBody, err := io.ReadAll(respObj.Body)
+	if err != nil {
+		return nil, err
+	}
+	if err := checkError(respObj, respBody); err != nil {
+		return nil, err
+	}
+
+	var resp FitResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/api/types.go
+++ b/api/types.go
@@ -922,6 +922,76 @@ type UserResponse struct {
 	Plan      string    `json:"plan,omitempty"`
 }
 
+// FitDeviceID identifies a GPU device.
+type FitDeviceID struct {
+	ID      string `json:"id"`
+	Library string `json:"backend,omitempty"`
+}
+
+// FitDeviceInfo describes a GPU device as seen by the fit subsystem.
+type FitDeviceInfo struct {
+	FitDeviceID
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	TotalMemory uint64 `json:"total_memory"`
+	FreeMemory  uint64 `json:"free_memory,omitempty"`
+	ComputeMajor int   `json:"-"`
+	ComputeMinor int   `json:"-"`
+}
+
+// FitHardwareProfile describes the hardware capabilities of the machine.
+type FitHardwareProfile struct {
+	GPUs                []FitDeviceInfo `json:"gpus"`
+	BestGPU             *FitDeviceInfo  `json:"best_gpu,omitempty"`
+	RAMTotalBytes       uint64          `json:"ram_total_bytes"`
+	RAMAvailableBytes   uint64          `json:"ram_available_bytes"`
+	DiskModelPathBytes  uint64          `json:"disk_model_path_bytes"`
+	DiskModelAvailBytes uint64          `json:"disk_model_avail_bytes"`
+	ModelsDir           string          `json:"models_dir"`
+	OS                  string          `json:"os"`
+	Arch                string          `json:"arch"`
+}
+
+// FitModelRequirement describes hardware requirements for one model variant.
+type FitModelRequirement struct {
+	Name       string   `json:"name"`
+	Family     string   `json:"family"`
+	Quant      string   `json:"quant"`
+	DiskSizeMB uint64   `json:"disk_size_mb,omitempty"`
+	VRAMMinMB  uint64   `json:"vram_min_mb,omitempty"`
+	RAMMinMB   uint64   `json:"ram_min_mb,omitempty"`
+	Tags       []string `json:"tags,omitempty"`
+}
+
+// FitModelCandidate is a scored model entry returned by GET /api/fit.
+type FitModelCandidate struct {
+	Req       FitModelRequirement `json:"req"`
+	Tier      int                 `json:"tier"`
+	Score     float64             `json:"score"`
+	RunMode   string              `json:"run_mode"`
+	EstTPS    int                 `json:"est_tps"`
+	Notes     []string            `json:"notes,omitempty"`
+	Installed bool                `json:"installed"`
+}
+
+// FitResponse is returned by GET /api/fit.
+type FitResponse struct {
+	System FitHardwareProfile  `json:"system"`
+	Models []FitModelCandidate `json:"models"`
+}
+
+// FitRequest carries optional query parameters for GET /api/fit.
+type FitRequest struct {
+	// All, when true, includes models that are too large to run on this hardware.
+	All bool
+
+	// Family filters results to a specific model family (case-insensitive substring match).
+	Family string
+
+	// Tags filters results to models with a specific tag (e.g. "code", "vision", "embed").
+	Tags string
+}
+
 // Tensor describes the metadata for a given tensor.
 type Tensor struct {
 	Name  string   `json:"name"`

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -2002,6 +2002,27 @@ func runInteractiveTUI(cmd *cobra.Command) {
 		case tui.SelectionNone:
 			// User quit
 			return
+		case tui.SelectionFitCheck:
+			// legacy path — no longer reached; fit check now runs inside the TUI loop
+			continue
+		case tui.SelectionFitCheckPull:
+			client, err := api.ClientFromEnvironment()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+				continue
+			}
+			for _, modelName := range result.Models {
+				if err := config.PullModel(cmd.Context(), client, modelName); err != nil {
+					if errors.Is(err, context.Canceled) {
+						break
+					}
+					fmt.Fprintf(os.Stderr, "Error pulling %s: %v\n", modelName, err)
+				} else {
+					fmt.Printf("✓ %s ready\n", modelName)
+				}
+			}
+			fmt.Print("\nAll models processed. Press Enter to return to the menu...")
+			fmt.Scanln()
 		case tui.SelectionRunModel:
 			_ = config.SetLastSelection("run")
 			if modelName := config.LastModel(); modelName != "" && !config.IsCloudModelDisabled(cmd.Context(), modelName) {
@@ -2358,6 +2379,7 @@ func NewCLI() *cobra.Command {
 		copyCmd,
 		deleteCmd,
 		runnerCmd,
+		fitCmd(),
 		config.LaunchCmd(checkServerHeartbeat, runInteractiveTUI),
 	)
 

--- a/cmd/config/integrations.go
+++ b/cmd/config/integrations.go
@@ -335,7 +335,7 @@ func SelectModelWithSelector(ctx context.Context, selector SingleSelector) (stri
 				return "", errCancelled
 			}
 			fmt.Fprintf(os.Stderr, "\n")
-			if err := pullModel(ctx, client, selected); err != nil {
+			if err := PullModel(ctx, client, selected); err != nil {
 				return "", fmt.Errorf("failed to pull %s: %w", selected, err)
 			}
 		}
@@ -535,7 +535,7 @@ func selectModelsWithSelectors(ctx context.Context, name, current string, single
 		}
 		for _, m := range toPull {
 			fmt.Fprintf(os.Stderr, "\n")
-			if err := pullModel(ctx, client, m); err != nil {
+			if err := PullModel(ctx, client, m); err != nil {
 				return nil, fmt.Errorf("failed to pull %s: %w", m, err)
 			}
 		}
@@ -575,7 +575,7 @@ func confirmAndPull(ctx context.Context, client *api.Client, model string) error
 		return errCancelled
 	}
 	fmt.Fprintf(os.Stderr, "\n")
-	if err := pullModel(ctx, client, model); err != nil {
+	if err := PullModel(ctx, client, model); err != nil {
 		return fmt.Errorf("failed to pull %s: %w", model, err)
 	}
 	return nil
@@ -1391,7 +1391,7 @@ func cloudStatusDisabled(ctx context.Context, client *api.Client) (disabled bool
 	return status.Cloud.Disabled, true
 }
 
-func pullModel(ctx context.Context, client *api.Client, model string) error {
+func PullModel(ctx context.Context, client *api.Client, model string) error {
 	p := progress.NewProgress(os.Stderr)
 	defer p.Stop()
 

--- a/cmd/fit.go
+++ b/cmd/fit.go
@@ -1,0 +1,153 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/ollama/ollama/api"
+)
+
+// Tier constants mirror fitcheck.CompatibilityTier values.
+const (
+	fitTierIdeal    = 0
+	fitTierGood     = 1
+	fitTierMarginal = 2
+	fitTierPossible = 3
+	fitTierTooLarge = 4
+)
+
+// RunFit is the cobra RunE handler for the "ollama fit" command.
+func RunFit(cmd *cobra.Command, args []string) error {
+	client, err := api.ClientFromEnvironment()
+	if err != nil {
+		return err
+	}
+
+	showAll, _ := cmd.Flags().GetBool("all")
+	family, _ := cmd.Flags().GetString("family")
+	tags, _ := cmd.Flags().GetString("tags")
+	jsonOut, _ := cmd.Flags().GetBool("json")
+
+	resp, err := client.Fit(cmd.Context(), api.FitRequest{
+		All:    showAll,
+		Family: family,
+		Tags:   tags,
+	})
+	if err != nil {
+		return err
+	}
+
+	if jsonOut {
+		return json.NewEncoder(os.Stdout).Encode(resp)
+	}
+
+	renderFitTTY(*resp)
+	return nil
+}
+
+func renderFitTTY(resp api.FitResponse) {
+	hw := resp.System
+
+	// Header: system info
+	fmt.Println("Ollama Fit Check")
+	fmt.Println(strings.Repeat("\u2500", 62))
+	fmt.Printf("  CPU  : %s (%s)\n", hw.OS, hw.Arch)
+	fmt.Printf("  RAM  : %s free / %s total\n",
+		fitHumanizeBytes(hw.RAMAvailableBytes), fitHumanizeBytes(hw.RAMTotalBytes))
+	if hw.BestGPU != nil {
+		fmt.Printf("  GPU  : %s %s  \u2022  %s free / %s total\n",
+			hw.BestGPU.Library, hw.BestGPU.Name,
+			fitHumanizeBytes(hw.BestGPU.FreeMemory), fitHumanizeBytes(hw.BestGPU.TotalMemory))
+	} else {
+		fmt.Println("  GPU  : None detected")
+	}
+	fmt.Printf("  Disk : %s free  \u2192  %s\n",
+		fitHumanizeBytes(hw.DiskModelAvailBytes), hw.ModelsDir)
+	fmt.Println(strings.Repeat("\u2500", 62))
+	fmt.Println()
+
+	// Group by tier (tier is an int matching fitcheck.CompatibilityTier iota values)
+	groups := map[int][]api.FitModelCandidate{}
+	for _, c := range resp.Models {
+		groups[c.Tier] = append(groups[c.Tier], c)
+	}
+
+	tiers := []struct {
+		tier  int
+		icon  string
+		label string
+	}{
+		{fitTierIdeal, "\u2705", "IDEAL \u2014 Full GPU inference, fast"},
+		{fitTierGood, "\U0001f7e1", "GOOD \u2014 Minor CPU offload"},
+		{fitTierMarginal, "\U0001f7e0", "MARGINAL \u2014 Significant CPU offload, slow"},
+		{fitTierPossible, "\u2b1c", "POSSIBLE \u2014 CPU only, very slow"},
+		{fitTierTooLarge, "\U0001f534", "TOO LARGE \u2014 Cannot run on this hardware"},
+	}
+
+	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	for _, tg := range tiers {
+		entries, ok := groups[tg.tier]
+		if !ok || len(entries) == 0 {
+			continue
+		}
+		fmt.Printf("  %s  %s\n", tg.icon, tg.label)
+		fmt.Println("  " + strings.Repeat("\u2500", 60))
+		for _, e := range entries {
+			diskStr := fitHumanizeBytes(e.Req.DiskSizeMB * 1024 * 1024)
+			if e.Installed {
+				diskStr = "installed"
+			}
+			tpsStr := fmt.Sprintf("~%d tok/s", e.EstTPS)
+			nameStr := e.Req.Name
+			if e.Installed {
+				nameStr += " ✓"
+			}
+			fmt.Fprintf(tw, "  %-28s\t%-8s\t%8s\t%12s\t%s\n",
+				nameStr, e.Req.Quant, diskStr, tpsStr, e.RunMode)
+			for _, note := range e.Notes {
+				fmt.Fprintf(tw, "       \u26a0  %s\n", note)
+			}
+		}
+		tw.Flush()
+		fmt.Println()
+	}
+}
+
+// fitHumanizeBytes formats byte counts in human-readable units.
+func fitHumanizeBytes(b uint64) string {
+	const (
+		kb  = uint64(1024)
+		mb  = uint64(1024 * 1024)
+		_gb = uint64(1024 * 1024 * 1024)
+	)
+	switch {
+	case b >= _gb:
+		return fmt.Sprintf("%.1f GB", float64(b)/float64(_gb))
+	case b >= mb:
+		return fmt.Sprintf("%.1f MB", float64(b)/float64(mb))
+	case b >= kb:
+		return fmt.Sprintf("%d KB", b/kb)
+	default:
+		return fmt.Sprintf("%d B", b)
+	}
+}
+
+// fitCmd returns the cobra command for "ollama fit".
+func fitCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "fit",
+		Short: "Check which models are compatible with this machine",
+		Long:  "Scans your hardware and ranks available models by how well they will run on your system.",
+		RunE:  RunFit,
+	}
+	cmd.Flags().Bool("all", false, "Show all models including ones too large to run")
+	cmd.Flags().String("family", "", "Filter to a specific model family (e.g. llama3, mistral)")
+	cmd.Flags().String("tags", "", "Filter by tag (e.g. code, vision, embed)")
+	cmd.Flags().Bool("json", false, "Output raw JSON")
+	return cmd
+}

--- a/cmd/tui/fitcheck_tui.go
+++ b/cmd/tui/fitcheck_tui.go
@@ -1,0 +1,400 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/ollama/ollama/api"
+)
+
+// ── styles ─────────────────────────────────────────────────────────────────
+
+var (
+	fitTabActiveStyle = lipgloss.NewStyle().
+				Bold(true).
+				Foreground(lipgloss.AdaptiveColor{Light: "235", Dark: "252"}).
+				Background(lipgloss.AdaptiveColor{Light: "254", Dark: "236"}).
+				PaddingLeft(1).
+				PaddingRight(1)
+
+	fitTabInactiveStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.AdaptiveColor{Light: "242", Dark: "246"}).
+				PaddingLeft(1).
+				PaddingRight(1)
+
+	fitTabBarStyle = lipgloss.NewStyle().
+			PaddingBottom(1)
+
+	fitModelSelectedStyle = lipgloss.NewStyle().
+				Bold(true).
+				Background(lipgloss.AdaptiveColor{Light: "254", Dark: "236"})
+
+	fitModelStyle = lipgloss.NewStyle().
+			PaddingLeft(2)
+
+	fitModelCheckedStyle = fitModelStyle.
+				Foreground(lipgloss.AdaptiveColor{Light: "28", Dark: "120"})
+
+	fitDescStyle = lipgloss.NewStyle().
+			PaddingLeft(6).
+			Foreground(lipgloss.AdaptiveColor{Light: "242", Dark: "246"})
+
+	fitInstalledStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.AdaptiveColor{Light: "28", Dark: "120"}).
+				Bold(true)
+
+	fitHelpStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.AdaptiveColor{Light: "244", Dark: "244"})
+
+	fitHWStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.AdaptiveColor{Light: "240", Dark: "249"}).
+			PaddingLeft(1)
+
+	fitErrorStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.AdaptiveColor{Light: "196", Dark: "196"})
+)
+
+// ── tiers ──────────────────────────────────────────────────────────────────
+
+const (
+	fitTabTooLarge = iota // index 0 = shown last
+	fitTabPossible
+	fitTabMarginal
+	fitTabGood
+	fitTabIdeal
+)
+
+// tabDefs defines the display order (Ideal first on screen → index 4 in API).
+// We reverse the iota above so Ideal tab is leftmost (#0 on screen).
+var fitTabDefs = []struct {
+	label  string
+	apiIdx int // api.FitModelCandidate.Tier value
+}{
+	{"✅ Ideal", 0},
+	{"🟡 Good", 1},
+	{"🟠 Marginal", 2},
+	{"⬜ Possible", 3},
+	{"🔴 Too Large", 4},
+}
+
+// ── messages ───────────────────────────────────────────────────────────────
+
+type fitLoadedMsg struct {
+	resp *api.FitResponse
+}
+
+type fitLoadErrMsg struct {
+	err error
+}
+
+// ── model ──────────────────────────────────────────────────────────────────
+
+// FitCheckModel is a bubbletea model for the interactive fit-check TUI.
+// It is embedded in the main TUI model and never run standalone.
+type FitCheckModel struct {
+	// data
+	resp *api.FitResponse
+	tabs [5][]api.FitModelCandidate // indexed by fitTab* constants (0=Ideal…4=TooLarge)
+	err  error
+
+	// navigation
+	activeTab int // 0 = Ideal
+	cursor    int
+
+	// selection (multi-select)
+	checked   map[string]bool
+	confirmed bool
+	cancelled bool
+
+	// ui
+	width int
+}
+
+func NewFitCheckModel() FitCheckModel {
+	return FitCheckModel{
+		checked: make(map[string]bool),
+	}
+}
+
+// ── init / load ─────────────────────────────────────────────────────────────
+
+func (m FitCheckModel) Init() tea.Cmd {
+	return loadFitData
+}
+
+func loadFitData() tea.Msg {
+	client, err := api.ClientFromEnvironment()
+	if err != nil {
+		return fitLoadErrMsg{err}
+	}
+	resp, err := client.Fit(context.Background(), api.FitRequest{All: true})
+	if err != nil {
+		return fitLoadErrMsg{err}
+	}
+	return fitLoadedMsg{resp}
+}
+
+// ── update ──────────────────────────────────────────────────────────────────
+
+func (m FitCheckModel) Update(msg tea.Msg) (FitCheckModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+
+	case fitLoadedMsg:
+		m.resp = msg.resp
+		// bucket models into tabs
+		for i := range m.tabs {
+			m.tabs[i] = nil
+		}
+		for _, c := range m.resp.Models {
+			if c.Tier >= 0 && c.Tier < len(m.tabs) {
+				m.tabs[c.Tier] = append(m.tabs[c.Tier], c)
+			}
+		}
+		// start on first non-empty tab (ideally Ideal)
+		m.activeTab = 0
+		m.cursor = 0
+		for i := range fitTabDefs {
+			if len(m.tabs[i]) > 0 {
+				m.activeTab = i
+				break
+			}
+		}
+
+	case fitLoadErrMsg:
+		m.err = msg.err
+
+	case tea.KeyMsg:
+		switch msg.Type {
+		case tea.KeyEsc:
+			m.cancelled = true
+
+		case tea.KeyLeft, tea.KeyShiftLeft:
+			if m.activeTab > 0 {
+				m.activeTab--
+				m.cursor = 0
+			}
+
+		case tea.KeyRight:
+			if m.activeTab < len(fitTabDefs)-1 {
+				m.activeTab++
+				m.cursor = 0
+			}
+
+		case tea.KeyUp:
+			if m.cursor > 0 {
+				m.cursor--
+			}
+
+		case tea.KeyDown:
+			if items := m.tabs[m.activeTab]; m.cursor < len(items)-1 {
+				m.cursor++
+			}
+
+		case tea.KeySpace:
+			if items := m.tabs[m.activeTab]; len(items) > 0 && m.cursor < len(items) {
+				name := items[m.cursor].Req.Name
+				if m.checked[name] {
+					delete(m.checked, name)
+				} else {
+					m.checked[name] = true
+				}
+			}
+
+		case tea.KeyEnter:
+			if len(m.checked) > 0 {
+				m.confirmed = true
+			}
+
+		case tea.KeyRunes:
+			// ←/→ via h/l vim keys
+			switch string(msg.Runes) {
+			case "h":
+				if m.activeTab > 0 {
+					m.activeTab--
+					m.cursor = 0
+				}
+			case "l":
+				if m.activeTab < len(fitTabDefs)-1 {
+					m.activeTab++
+					m.cursor = 0
+				}
+			}
+		}
+	}
+	return m, nil
+}
+
+// Selected returns the names of all checked models in selection order.
+func (m FitCheckModel) Selected() []string {
+	var out []string
+	for name := range m.checked {
+		out = append(out, name)
+	}
+	return out
+}
+
+// ── view ────────────────────────────────────────────────────────────────────
+
+func (m FitCheckModel) View() string {
+	if m.cancelled || m.confirmed {
+		return ""
+	}
+
+	var s strings.Builder
+
+	// title
+	s.WriteString(selectorTitleStyle.Render("Ollama Fit Check"))
+	s.WriteString("\n\n")
+
+	if m.resp == nil && m.err == nil {
+		s.WriteString("  Loading hardware profile...\n")
+		s.WriteString("\n" + fitHelpStyle.Render("esc  cancel"))
+		return m.maybeWrap(s.String())
+	}
+
+	if m.err != nil {
+		s.WriteString(fitErrorStyle.Render("  Error: "+m.err.Error()) + "\n")
+		s.WriteString("\n" + fitHelpStyle.Render("esc  back"))
+		return m.maybeWrap(s.String())
+	}
+
+	// hardware summary line
+	hw := m.resp.System
+	if hw.BestGPU != nil {
+		s.WriteString(fitHWStyle.Render(fmt.Sprintf(
+			"GPU: %s %s  •  %.1f GB free",
+			hw.BestGPU.Library, hw.BestGPU.Name,
+			float64(hw.BestGPU.FreeMemory)/(1024*1024*1024),
+		)) + "\n")
+	} else {
+		gpuMsg := "GPU: none detected"
+		s.WriteString(fitHWStyle.Render(fmt.Sprintf(
+			"%s   RAM: %.1f GB free   Disk: %.1f GB free",
+			gpuMsg,
+			float64(hw.RAMAvailableBytes)/(1024*1024*1024),
+			float64(hw.DiskModelAvailBytes)/(1024*1024*1024),
+		)) + "\n")
+	}
+	s.WriteString("\n")
+
+	// ── tab bar ─────────────────────────────────────────────────────────────
+	var tabs []string
+	for i, td := range fitTabDefs {
+		count := len(m.tabs[i])
+		label := fmt.Sprintf("%s (%d)", td.label, count)
+		if i == m.activeTab {
+			tabs = append(tabs, fitTabActiveStyle.Render(label))
+		} else {
+			tabs = append(tabs, fitTabInactiveStyle.Render(label))
+		}
+	}
+	s.WriteString(fitTabBarStyle.Render("  " + strings.Join(tabs, "  ")))
+	s.WriteString("\n\n")
+
+	// ── model list ───────────────────────────────────────────────────────────
+	items := m.tabs[m.activeTab]
+	if len(items) == 0 {
+		s.WriteString(selectorItemStyle.Render(selectorDescStyle.Render("(none)")) + "\n")
+	} else {
+		const maxVisible = 14
+		start := 0
+		if m.cursor >= maxVisible {
+			start = m.cursor - maxVisible + 1
+		}
+		end := start + maxVisible
+		if end > len(items) {
+			end = len(items)
+		}
+
+		for idx := start; idx < end; idx++ {
+			c := items[idx]
+			name := c.Req.Name
+
+			// checkbox prefix
+			check := "[ ] "
+			if m.checked[name] {
+				check = "[x] "
+			}
+
+			// installed marker
+			suffix := ""
+			if c.Installed {
+				suffix = " " + fitInstalledStyle.Render("✓ installed")
+			}
+
+			// row
+			row := check + name + suffix
+			if idx == m.cursor {
+				s.WriteString(fitModelSelectedStyle.Render("▸ "+row) + "\n")
+			} else if m.checked[name] {
+				s.WriteString(fitModelCheckedStyle.Render("  "+row) + "\n")
+			} else {
+				s.WriteString(fitModelStyle.Render(row) + "\n")
+			}
+
+			// description line
+			desc := buildFitDesc(c)
+			s.WriteString(fitDescStyle.Render(desc) + "\n")
+
+			// warning notes
+			for _, note := range c.Notes {
+				s.WriteString(fitDescStyle.Render("  ⚠  " + note) + "\n")
+			}
+		}
+
+		// scroll indicator
+		if start > 0 || end < len(items) {
+			remaining := len(items) - end
+			if remaining > 0 {
+				s.WriteString(selectorMoreStyle.Render(fmt.Sprintf("... and %d more ↓", remaining)) + "\n")
+			}
+		}
+	}
+
+	// ── footer ───────────────────────────────────────────────────────────────
+	s.WriteString("\n")
+	sel := len(m.checked)
+	if sel > 0 {
+		s.WriteString(selectorDescStyle.Render(fmt.Sprintf("  %d selected — press enter to pull", sel)) + "\n\n")
+		s.WriteString(fitHelpStyle.Render("←/→ tabs • ↑/↓ navigate • space toggle • enter pull • esc back"))
+	} else {
+		s.WriteString(fitHelpStyle.Render("←/→ tabs • ↑/↓ navigate • space select • enter pull • esc back"))
+	}
+
+	return m.maybeWrap(s.String())
+}
+
+func (m FitCheckModel) maybeWrap(s string) string {
+	if m.width > 0 {
+		return lipgloss.NewStyle().MaxWidth(m.width).Render(s)
+	}
+	return s
+}
+
+// buildFitDesc builds the single description line shown below a model row.
+func buildFitDesc(c api.FitModelCandidate) string {
+	size := fitFormatBytes(c.Req.DiskSizeMB * 1024 * 1024)
+	if c.Installed {
+		size = "installed"
+	}
+	return fmt.Sprintf("%s • %s • ~%d tok/s • %s",
+		c.Req.Quant, size, c.EstTPS, c.RunMode)
+}
+
+// fitFormatBytes formats MB-based byte count into a human string.
+func fitFormatBytes(b uint64) string {
+	const (
+		mb = uint64(1024 * 1024)
+		gb = uint64(1024 * 1024 * 1024)
+	)
+	if b >= gb {
+		return fmt.Sprintf("%.1f GB", float64(b)/float64(gb))
+	}
+	return fmt.Sprintf("%.0f MB", float64(b)/float64(mb))
+}

--- a/cmd/tui/tui.go
+++ b/cmd/tui/tui.go
@@ -49,6 +49,7 @@ type menuItem struct {
 	integration string // integration name for loading model config, empty if not an integration
 	isRunModel  bool
 	isOthers    bool
+	isFitCheck  bool
 }
 
 var mainMenuItems = []menuItem{
@@ -56,6 +57,11 @@ var mainMenuItems = []menuItem{
 		title:       "Run a model",
 		description: "Start an interactive chat with a model",
 		isRunModel:  true,
+	},
+	{
+		title:       "Fit Check",
+		description: "See which models are compatible with this machine",
+		isFitCheck:  true,
 	},
 	{
 		title:       "Launch Claude Code",
@@ -133,6 +139,9 @@ type model struct {
 	signInModel     string
 	signInSpinner   int
 	signInFromModal bool // true if sign-in was triggered from modal (not main menu)
+
+	showingFitCheck bool
+	fitCheckModel   FitCheckModel
 
 	width     int    // terminal width from WindowSizeMsg
 	statusMsg string // temporary status message shown near help text
@@ -420,6 +429,21 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	if m.showingFitCheck {
+		updated, cmd := m.fitCheckModel.Update(msg)
+		m.fitCheckModel = updated
+		if m.fitCheckModel.cancelled {
+			m.showingFitCheck = false
+			return m, nil
+		}
+		if m.fitCheckModel.confirmed {
+			m.selected = true
+			m.quitting = true
+			return m, tea.Quit
+		}
+		return m, cmd
+	}
+
 	if m.showingMultiModal {
 		switch msg := msg.(type) {
 		case tea.KeyMsg:
@@ -531,6 +555,14 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "enter", " ":
 			item := m.items[m.cursor]
 
+			// Fit Check: open the tabbed interactive screen
+			if item.isFitCheck {
+				m.fitCheckModel = NewFitCheckModel()
+				m.fitCheckModel.width = m.width
+				m.showingFitCheck = true
+				return m, m.fitCheckModel.Init()
+			}
+
 			if item.integration != "" && !config.IsIntegrationInstalled(item.integration) && !config.AutoInstallable(item.integration) {
 				return m, nil
 			}
@@ -591,6 +623,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m model) View() string {
 	if m.quitting {
 		return ""
+	}
+
+	if m.showingFitCheck {
+		return m.fitCheckModel.View()
 	}
 
 	if m.showingSignIn {
@@ -698,6 +734,8 @@ const (
 	SelectionChangeRunModel
 	SelectionIntegration       // Generic integration selection
 	SelectionChangeIntegration // Generic change model for integration
+	SelectionFitCheck          // Run the hardware fit-check
+	SelectionFitCheckPull      // Pull models chosen in the fit-check screen
 )
 
 type Result struct {
@@ -744,6 +782,17 @@ func Run() (Result, error) {
 
 	if item.isRunModel {
 		return Result{Selection: SelectionRunModel}, nil
+	}
+
+	if item.isFitCheck {
+		// User confirmed model selection inside fit check
+		if fm.fitCheckModel.confirmed {
+			return Result{
+				Selection: SelectionFitCheckPull,
+				Models:    fm.fitCheckModel.Selected(),
+			}, nil
+		}
+		return Result{Selection: SelectionNone}, nil
 	}
 
 	return Result{

--- a/fitcheck/disk_unix.go
+++ b/fitcheck/disk_unix.go
@@ -1,0 +1,19 @@
+//go:build linux || darwin
+
+package fitcheck
+
+import (
+	"syscall"
+)
+
+// diskStats returns the total and available bytes for the filesystem that
+// contains path. On Linux and macOS this uses syscall.Statfs.
+func diskStats(path string) (total, avail uint64, err error) {
+	var stat syscall.Statfs_t
+	if err = syscall.Statfs(path, &stat); err != nil {
+		return 0, 0, err
+	}
+	total = stat.Blocks * uint64(stat.Bsize)
+	avail = stat.Bavail * uint64(stat.Bsize)
+	return total, avail, nil
+}

--- a/fitcheck/disk_windows.go
+++ b/fitcheck/disk_windows.go
@@ -1,0 +1,36 @@
+//go:build windows
+
+package fitcheck
+
+import (
+	"log/slog"
+	"syscall"
+	"unsafe"
+)
+
+// diskStats returns the total and available bytes for the filesystem that
+// contains path. Uses GetDiskFreeSpaceExW on Windows.
+func diskStats(path string) (total, avail uint64, err error) {
+	kernel32 := syscall.NewLazyDLL("kernel32.dll")
+	getDiskFreeSpaceEx := kernel32.NewProc("GetDiskFreeSpaceExW")
+
+	pathPtr, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		slog.Warn("fitcheck: failed to convert models path for disk stats", "error", err)
+		return 0, 0, err
+	}
+
+	var freeBytesAvailable, totalBytes, totalFreeBytes uint64
+	r1, _, lastErr := getDiskFreeSpaceEx.Call(
+		uintptr(unsafe.Pointer(pathPtr)),
+		uintptr(unsafe.Pointer(&freeBytesAvailable)),
+		uintptr(unsafe.Pointer(&totalBytes)),
+		uintptr(unsafe.Pointer(&totalFreeBytes)),
+	)
+	if r1 == 0 {
+		slog.Warn("fitcheck: GetDiskFreeSpaceExW failed", "error", lastErr)
+		return 0, 0, lastErr
+	}
+
+	return totalBytes, freeBytesAvailable, nil
+}

--- a/fitcheck/hardware.go
+++ b/fitcheck/hardware.go
@@ -1,0 +1,82 @@
+package fitcheck
+
+import (
+	"context"
+	"runtime"
+	"sort"
+
+	"github.com/ollama/ollama/discover"
+	"github.com/ollama/ollama/ml"
+)
+
+// HardwareProfile is the consolidated view of this machine's capabilities.
+type HardwareProfile struct {
+	// GPUs is the list of detected GPU devices.
+	GPUs []ml.DeviceInfo `json:"gpus"`
+
+	// BestGPU is the GPU with the highest FreeMemory; nil if no GPU detected.
+	BestGPU *ml.DeviceInfo `json:"best_gpu,omitempty"`
+
+	// RAMTotalBytes is the total system RAM in bytes.
+	RAMTotalBytes uint64 `json:"ram_total_bytes"`
+
+	// RAMAvailableBytes is the currently available system RAM in bytes.
+	RAMAvailableBytes uint64 `json:"ram_available_bytes"`
+
+	// DiskModelPathBytes is the total capacity of the filesystem hosting the models directory.
+	DiskModelPathBytes uint64 `json:"disk_model_path_bytes"`
+
+	// DiskModelAvailBytes is the available space on the filesystem hosting the models directory.
+	DiskModelAvailBytes uint64 `json:"disk_model_avail_bytes"`
+
+	// ModelsDir is the path to the Ollama models directory.
+	ModelsDir string `json:"models_dir"`
+
+	// OS is the operating system (runtime.GOOS).
+	OS string `json:"os"`
+
+	// Arch is the CPU architecture (runtime.GOARCH).
+	Arch string `json:"arch"`
+}
+
+// Collect gathers hardware facts. Completes in under 3 seconds.
+// modelsDir should be the path returned by envconfig.Models().
+func Collect(modelsDir string) (HardwareProfile, error) {
+	var hw HardwareProfile
+	hw.ModelsDir = modelsDir
+	hw.OS = runtime.GOOS
+	hw.Arch = runtime.GOARCH
+
+	// RAM via discover.GetSystemInfo() which returns ml.SystemInfo
+	sysInfo := discover.GetSystemInfo()
+	hw.RAMTotalBytes = sysInfo.TotalMemory
+	hw.RAMAvailableBytes = sysInfo.FreeMemory
+
+	// GPU discovery — pass a background context and no active runners (discovery mode only).
+	gpus := discover.GPUDevices(context.Background(), nil)
+	hw.GPUs = gpus
+
+	// Pick the best GPU (highest FreeMemory among non-integrated GPUs, falling
+	// back to any GPU if all are integrated).
+	sort.Slice(hw.GPUs, func(i, j int) bool {
+		return hw.GPUs[i].FreeMemory > hw.GPUs[j].FreeMemory
+	})
+	for i := range hw.GPUs {
+		if hw.GPUs[i].FreeMemory > 0 {
+			hw.BestGPU = &hw.GPUs[i]
+			break
+		}
+	}
+	if hw.BestGPU == nil && len(hw.GPUs) > 0 {
+		hw.BestGPU = &hw.GPUs[0]
+	}
+
+	// Disk stats — platform-specific helper defined in disk_unix.go / disk_windows.go
+	total, avail, err := diskStats(modelsDir)
+	if err == nil {
+		hw.DiskModelPathBytes = total
+		hw.DiskModelAvailBytes = avail
+	}
+
+	return hw, nil
+}

--- a/fitcheck/requirements.go
+++ b/fitcheck/requirements.go
@@ -1,0 +1,570 @@
+// Package fitcheck provides hardware profiling and model compatibility scoring.
+package fitcheck
+
+// ModelRequirement describes the hardware needed to run one model variant.
+//
+// VRAM rule of thumb used for estimates:
+//
+//	Q4_K_M ~= params_B × 600 MB + 512 MB overhead
+//	Q8_0   ~= params_B × 1100 MB + 512 MB overhead
+//	F16    ~= params_B × 2000 MB + 512 MB overhead
+//
+// Tags: code, vision, embed, small (≤4B), reasoning, multilingual
+type ModelRequirement struct {
+	Name       string   `json:"name"`
+	Family     string   `json:"family"`
+	Quant      string   `json:"quant"`
+	DiskSizeMB uint64   `json:"disk_size_mb,omitempty"`
+	VRAMMinMB  uint64   `json:"vram_min_mb,omitempty"`
+	RAMMinMB   uint64   `json:"ram_min_mb,omitempty"`
+	Tags       []string `json:"tags,omitempty"`
+}
+
+// Requirements is the built-in model catalogue sourced from ollama.com/library.
+var Requirements = []ModelRequirement{
+
+	// ── Llama 3.2 ────────────────────────────────────────────────────────────
+	{Name: "llama3.2:1b", Family: "llama3.2", Quant: "Q4_K_M", DiskSizeMB: 1300, VRAMMinMB: 1536, RAMMinMB: 2048, Tags: []string{"small"}},
+	{Name: "llama3.2:3b", Family: "llama3.2", Quant: "Q4_K_M", DiskSizeMB: 2000, VRAMMinMB: 2560, RAMMinMB: 4096, Tags: []string{"small"}},
+
+	// ── Llama 3.1 ────────────────────────────────────────────────────────────
+	{Name: "llama3.1:8b", Family: "llama3.1", Quant: "Q4_K_M", DiskSizeMB: 4900, VRAMMinMB: 5632, RAMMinMB: 8192},
+	{Name: "llama3.1:8b-instruct-q8_0", Family: "llama3.1", Quant: "Q8_0", DiskSizeMB: 8600, VRAMMinMB: 9728, RAMMinMB: 12288},
+	{Name: "llama3.1:70b", Family: "llama3.1", Quant: "Q4_K_M", DiskSizeMB: 43008, VRAMMinMB: 45056, RAMMinMB: 64000},
+	{Name: "llama3.1:405b", Family: "llama3.1", Quant: "Q4_K_M", DiskSizeMB: 248832, VRAMMinMB: 262144, RAMMinMB: 512000},
+
+	// ── Llama 3.3 ────────────────────────────────────────────────────────────
+	{Name: "llama3.3:70b", Family: "llama3.3", Quant: "Q4_K_M", DiskSizeMB: 44032, VRAMMinMB: 46080, RAMMinMB: 64000},
+
+	// ── Llama 3 ──────────────────────────────────────────────────────────────
+	{Name: "llama3:8b", Family: "llama3", Quant: "Q4_K_M", DiskSizeMB: 4812, VRAMMinMB: 5632, RAMMinMB: 8192},
+	{Name: "llama3:70b", Family: "llama3", Quant: "Q4_K_M", DiskSizeMB: 40960, VRAMMinMB: 43008, RAMMinMB: 64000},
+
+	// ── Llama 2 ──────────────────────────────────────────────────────────────
+	{Name: "llama2:7b", Family: "llama2", Quant: "Q4_K_M", DiskSizeMB: 3891, VRAMMinMB: 5120, RAMMinMB: 8192},
+	{Name: "llama2:13b", Family: "llama2", Quant: "Q4_K_M", DiskSizeMB: 7578, VRAMMinMB: 9216, RAMMinMB: 16384},
+	{Name: "llama2:70b", Family: "llama2", Quant: "Q4_K_M", DiskSizeMB: 39936, VRAMMinMB: 43008, RAMMinMB: 64000},
+
+	// ── Llama 3.2 Vision ─────────────────────────────────────────────────────
+	{Name: "llama3.2-vision:11b", Family: "llama3.2-vision", Quant: "Q4_K_M", DiskSizeMB: 7987, VRAMMinMB: 8704, RAMMinMB: 16384, Tags: []string{"vision"}},
+	{Name: "llama3.2-vision:90b", Family: "llama3.2-vision", Quant: "Q4_K_M", DiskSizeMB: 56320, VRAMMinMB: 59392, RAMMinMB: 96000, Tags: []string{"vision"}},
+
+	// ── Mistral ───────────────────────────────────────────────────────────────
+	{Name: "mistral:7b", Family: "mistral", Quant: "Q4_K_M", DiskSizeMB: 4506, VRAMMinMB: 5632, RAMMinMB: 8192},
+	{Name: "mistral:7b-instruct-q8_0", Family: "mistral", Quant: "Q8_0", DiskSizeMB: 7700, VRAMMinMB: 9216, RAMMinMB: 12288},
+
+	// ── Mistral Nemo ──────────────────────────────────────────────────────────
+	{Name: "mistral-nemo:12b", Family: "mistral-nemo", Quant: "Q4_K_M", DiskSizeMB: 7270, VRAMMinMB: 8192, RAMMinMB: 16384, Tags: []string{"multilingual"}},
+
+	// ── Mistral Small ─────────────────────────────────────────────────────────
+	{Name: "mistral-small:22b", Family: "mistral-small", Quant: "Q4_K_M", DiskSizeMB: 13312, VRAMMinMB: 14336, RAMMinMB: 24576},
+	{Name: "mistral-small:24b", Family: "mistral-small", Quant: "Q4_K_M", DiskSizeMB: 14336, VRAMMinMB: 16384, RAMMinMB: 24576},
+
+	// ── Mixtral ───────────────────────────────────────────────────────────────
+	{Name: "mixtral:8x7b", Family: "mixtral", Quant: "Q4_K_M", DiskSizeMB: 26624, VRAMMinMB: 28672, RAMMinMB: 48000, Tags: []string{"multilingual"}},
+	{Name: "mixtral:8x22b", Family: "mixtral", Quant: "Q4_K_M", DiskSizeMB: 81920, VRAMMinMB: 86016, RAMMinMB: 128000, Tags: []string{"multilingual"}},
+
+	// ── Phi 3 ─────────────────────────────────────────────────────────────────
+	{Name: "phi3:3.8b", Family: "phi3", Quant: "Q4_K_M", DiskSizeMB: 2253, VRAMMinMB: 3072, RAMMinMB: 4096, Tags: []string{"small"}},
+	{Name: "phi3:14b", Family: "phi3", Quant: "Q4_K_M", DiskSizeMB: 8089, VRAMMinMB: 9216, RAMMinMB: 16384},
+
+	// ── Phi 3.5 ───────────────────────────────────────────────────────────────
+	{Name: "phi3.5:3.8b", Family: "phi3.5", Quant: "Q4_K_M", DiskSizeMB: 2253, VRAMMinMB: 3072, RAMMinMB: 4096, Tags: []string{"small"}},
+
+	// ── Phi 4 ─────────────────────────────────────────────────────────────────
+	{Name: "phi4:14b", Family: "phi4", Quant: "Q4_K_M", DiskSizeMB: 9318, VRAMMinMB: 10240, RAMMinMB: 16384},
+	{Name: "phi4:14b-q8_0", Family: "phi4", Quant: "Q8_0", DiskSizeMB: 15360, VRAMMinMB: 16896, RAMMinMB: 24576},
+
+	// ── Phi 4 Mini ────────────────────────────────────────────────────────────
+	{Name: "phi4-mini:3.8b", Family: "phi4-mini", Quant: "Q4_K_M", DiskSizeMB: 2560, VRAMMinMB: 3072, RAMMinMB: 4096, Tags: []string{"small"}},
+
+	// ── Gemma ─────────────────────────────────────────────────────────────────
+	{Name: "gemma:2b", Family: "gemma", Quant: "Q4_K_M", DiskSizeMB: 1741, VRAMMinMB: 2560, RAMMinMB: 4096, Tags: []string{"small"}},
+	{Name: "gemma:7b", Family: "gemma", Quant: "Q4_K_M", DiskSizeMB: 5120, VRAMMinMB: 6144, RAMMinMB: 8192},
+
+	// ── Gemma 2 ───────────────────────────────────────────────────────────────
+	{Name: "gemma2:2b", Family: "gemma2", Quant: "Q4_K_M", DiskSizeMB: 1638, VRAMMinMB: 2560, RAMMinMB: 4096, Tags: []string{"small"}},
+	{Name: "gemma2:9b", Family: "gemma2", Quant: "Q4_K_M", DiskSizeMB: 5530, VRAMMinMB: 6656, RAMMinMB: 10240},
+	{Name: "gemma2:27b", Family: "gemma2", Quant: "Q4_K_M", DiskSizeMB: 16384, VRAMMinMB: 18432, RAMMinMB: 32768},
+
+	// ── Gemma 3 ───────────────────────────────────────────────────────────────
+	{Name: "gemma3:1b", Family: "gemma3", Quant: "Q4_K_M", DiskSizeMB: 815, VRAMMinMB: 1536, RAMMinMB: 2048, Tags: []string{"small", "vision"}},
+	{Name: "gemma3:4b", Family: "gemma3", Quant: "Q4_K_M", DiskSizeMB: 3379, VRAMMinMB: 4096, RAMMinMB: 6144, Tags: []string{"small", "vision"}},
+	{Name: "gemma3:12b", Family: "gemma3", Quant: "Q4_K_M", DiskSizeMB: 8294, VRAMMinMB: 9728, RAMMinMB: 16384, Tags: []string{"vision"}},
+	{Name: "gemma3:27b", Family: "gemma3", Quant: "Q4_K_M", DiskSizeMB: 17408, VRAMMinMB: 19456, RAMMinMB: 32768, Tags: []string{"vision"}},
+
+	// ── Qwen 2 ────────────────────────────────────────────────────────────────
+	{Name: "qwen2:0.5b", Family: "qwen2", Quant: "Q4_K_M", DiskSizeMB: 352, VRAMMinMB: 1024, RAMMinMB: 2048, Tags: []string{"small", "multilingual"}},
+	{Name: "qwen2:1.5b", Family: "qwen2", Quant: "Q4_K_M", DiskSizeMB: 935, VRAMMinMB: 1536, RAMMinMB: 2048, Tags: []string{"small", "multilingual"}},
+	{Name: "qwen2:7b", Family: "qwen2", Quant: "Q4_K_M", DiskSizeMB: 4506, VRAMMinMB: 5632, RAMMinMB: 8192, Tags: []string{"multilingual"}},
+	{Name: "qwen2:72b", Family: "qwen2", Quant: "Q4_K_M", DiskSizeMB: 41984, VRAMMinMB: 45056, RAMMinMB: 64000, Tags: []string{"multilingual"}},
+
+	// ── Qwen 2.5 ──────────────────────────────────────────────────────────────
+	{Name: "qwen2.5:0.5b", Family: "qwen2.5", Quant: "Q4_K_M", DiskSizeMB: 398, VRAMMinMB: 1024, RAMMinMB: 2048, Tags: []string{"small", "multilingual"}},
+	{Name: "qwen2.5:1.5b", Family: "qwen2.5", Quant: "Q4_K_M", DiskSizeMB: 986, VRAMMinMB: 1536, RAMMinMB: 2048, Tags: []string{"small", "multilingual"}},
+	{Name: "qwen2.5:3b", Family: "qwen2.5", Quant: "Q4_K_M", DiskSizeMB: 1946, VRAMMinMB: 2560, RAMMinMB: 4096, Tags: []string{"small", "multilingual"}},
+	{Name: "qwen2.5:7b", Family: "qwen2.5", Quant: "Q4_K_M", DiskSizeMB: 4813, VRAMMinMB: 5632, RAMMinMB: 8192, Tags: []string{"multilingual"}},
+	{Name: "qwen2.5:14b", Family: "qwen2.5", Quant: "Q4_K_M", DiskSizeMB: 9216, VRAMMinMB: 10240, RAMMinMB: 16384, Tags: []string{"multilingual"}},
+	{Name: "qwen2.5:14b-instruct-q8_0", Family: "qwen2.5", Quant: "Q8_0", DiskSizeMB: 15360, VRAMMinMB: 16896, RAMMinMB: 24576, Tags: []string{"multilingual"}},
+	{Name: "qwen2.5:32b", Family: "qwen2.5", Quant: "Q4_K_M", DiskSizeMB: 20480, VRAMMinMB: 22528, RAMMinMB: 32768, Tags: []string{"multilingual"}},
+	{Name: "qwen2.5:72b", Family: "qwen2.5", Quant: "Q4_K_M", DiskSizeMB: 48128, VRAMMinMB: 51200, RAMMinMB: 80000, Tags: []string{"multilingual"}},
+
+	// ── Qwen 2.5 Coder ────────────────────────────────────────────────────────
+	{Name: "qwen2.5-coder:0.5b", Family: "qwen2.5-coder", Quant: "Q4_K_M", DiskSizeMB: 398, VRAMMinMB: 1024, RAMMinMB: 2048, Tags: []string{"code", "small"}},
+	{Name: "qwen2.5-coder:1.5b", Family: "qwen2.5-coder", Quant: "Q4_K_M", DiskSizeMB: 986, VRAMMinMB: 1536, RAMMinMB: 2048, Tags: []string{"code", "small"}},
+	{Name: "qwen2.5-coder:3b", Family: "qwen2.5-coder", Quant: "Q4_K_M", DiskSizeMB: 1946, VRAMMinMB: 2560, RAMMinMB: 4096, Tags: []string{"code", "small"}},
+	{Name: "qwen2.5-coder:7b", Family: "qwen2.5-coder", Quant: "Q4_K_M", DiskSizeMB: 4813, VRAMMinMB: 5632, RAMMinMB: 8192, Tags: []string{"code"}},
+	{Name: "qwen2.5-coder:14b", Family: "qwen2.5-coder", Quant: "Q4_K_M", DiskSizeMB: 9216, VRAMMinMB: 10240, RAMMinMB: 16384, Tags: []string{"code"}},
+	{Name: "qwen2.5-coder:32b", Family: "qwen2.5-coder", Quant: "Q4_K_M", DiskSizeMB: 20480, VRAMMinMB: 22528, RAMMinMB: 32768, Tags: []string{"code"}},
+
+	// ── Qwen 3 ────────────────────────────────────────────────────────────────
+	{Name: "qwen3:0.6b", Family: "qwen3", Quant: "Q4_K_M", DiskSizeMB: 523, VRAMMinMB: 1024, RAMMinMB: 2048, Tags: []string{"small", "multilingual", "reasoning"}},
+	{Name: "qwen3:1.7b", Family: "qwen3", Quant: "Q4_K_M", DiskSizeMB: 1434, VRAMMinMB: 2048, RAMMinMB: 3072, Tags: []string{"small", "multilingual", "reasoning"}},
+	{Name: "qwen3:4b", Family: "qwen3", Quant: "Q4_K_M", DiskSizeMB: 2560, VRAMMinMB: 3584, RAMMinMB: 6144, Tags: []string{"small", "multilingual", "reasoning"}},
+	{Name: "qwen3:8b", Family: "qwen3", Quant: "Q4_K_M", DiskSizeMB: 5325, VRAMMinMB: 6144, RAMMinMB: 10240, Tags: []string{"multilingual", "reasoning"}},
+	{Name: "qwen3:14b", Family: "qwen3", Quant: "Q4_K_M", DiskSizeMB: 9523, VRAMMinMB: 10752, RAMMinMB: 16384, Tags: []string{"multilingual", "reasoning"}},
+	{Name: "qwen3:32b", Family: "qwen3", Quant: "Q4_K_M", DiskSizeMB: 20480, VRAMMinMB: 22528, RAMMinMB: 32768, Tags: []string{"multilingual", "reasoning"}},
+	{Name: "qwen3:30b-a3b", Family: "qwen3", Quant: "Q4_K_M", DiskSizeMB: 19456, VRAMMinMB: 6144, RAMMinMB: 24576, Tags: []string{"multilingual", "reasoning"}},
+	{Name: "qwen3:235b-a22b", Family: "qwen3", Quant: "Q4_K_M", DiskSizeMB: 145408, VRAMMinMB: 28672, RAMMinMB: 192000, Tags: []string{"multilingual", "reasoning"}},
+
+	// ── DeepSeek R1 ───────────────────────────────────────────────────────────
+	{Name: "deepseek-r1:1.5b", Family: "deepseek-r1", Quant: "Q4_K_M", DiskSizeMB: 1127, VRAMMinMB: 2048, RAMMinMB: 3072, Tags: []string{"reasoning", "small"}},
+	{Name: "deepseek-r1:7b", Family: "deepseek-r1", Quant: "Q4_K_M", DiskSizeMB: 4813, VRAMMinMB: 5632, RAMMinMB: 8192, Tags: []string{"reasoning"}},
+	{Name: "deepseek-r1:8b", Family: "deepseek-r1", Quant: "Q4_K_M", DiskSizeMB: 5325, VRAMMinMB: 6144, RAMMinMB: 10240, Tags: []string{"reasoning"}},
+	{Name: "deepseek-r1:14b", Family: "deepseek-r1", Quant: "Q4_K_M", DiskSizeMB: 9216, VRAMMinMB: 10240, RAMMinMB: 16384, Tags: []string{"reasoning"}},
+	{Name: "deepseek-r1:32b", Family: "deepseek-r1", Quant: "Q4_K_M", DiskSizeMB: 20480, VRAMMinMB: 22528, RAMMinMB: 32768, Tags: []string{"reasoning"}},
+	{Name: "deepseek-r1:70b", Family: "deepseek-r1", Quant: "Q4_K_M", DiskSizeMB: 44032, VRAMMinMB: 46080, RAMMinMB: 80000, Tags: []string{"reasoning"}},
+	{Name: "deepseek-r1:671b", Family: "deepseek-r1", Quant: "Q4_K_M", DiskSizeMB: 413696, VRAMMinMB: 430080, RAMMinMB: 512000, Tags: []string{"reasoning"}},
+
+	// ── DeepSeek V3 ───────────────────────────────────────────────────────────
+	{Name: "deepseek-v3:671b", Family: "deepseek-v3", Quant: "Q4_K_M", DiskSizeMB: 413696, VRAMMinMB: 430080, RAMMinMB: 512000},
+
+	// ── DeepSeek Coder ────────────────────────────────────────────────────────
+	{Name: "deepseek-coder:1.3b", Family: "deepseek-coder", Quant: "Q4_K_M", DiskSizeMB: 776, VRAMMinMB: 1536, RAMMinMB: 2048, Tags: []string{"code", "small"}},
+	{Name: "deepseek-coder:6.7b", Family: "deepseek-coder", Quant: "Q4_K_M", DiskSizeMB: 3891, VRAMMinMB: 5120, RAMMinMB: 8192, Tags: []string{"code"}},
+	{Name: "deepseek-coder:33b", Family: "deepseek-coder", Quant: "Q4_K_M", DiskSizeMB: 19456, VRAMMinMB: 22528, RAMMinMB: 32768, Tags: []string{"code"}},
+
+	// ── DeepSeek Coder V2 ─────────────────────────────────────────────────────
+	{Name: "deepseek-coder-v2:16b", Family: "deepseek-coder-v2", Quant: "Q4_K_M", DiskSizeMB: 9114, VRAMMinMB: 10240, RAMMinMB: 16384, Tags: []string{"code"}},
+	{Name: "deepseek-coder-v2:236b", Family: "deepseek-coder-v2", Quant: "Q4_K_M", DiskSizeMB: 136192, VRAMMinMB: 143360, RAMMinMB: 192000, Tags: []string{"code"}},
+
+	// ── Code Llama ────────────────────────────────────────────────────────────
+	{Name: "codellama:7b", Family: "codellama", Quant: "Q4_K_M", DiskSizeMB: 3891, VRAMMinMB: 5120, RAMMinMB: 8192, Tags: []string{"code"}},
+	{Name: "codellama:13b", Family: "codellama", Quant: "Q4_K_M", DiskSizeMB: 7578, VRAMMinMB: 9216, RAMMinMB: 16384, Tags: []string{"code"}},
+	{Name: "codellama:34b", Family: "codellama", Quant: "Q4_K_M", DiskSizeMB: 19456, VRAMMinMB: 22528, RAMMinMB: 32768, Tags: []string{"code"}},
+	{Name: "codellama:70b", Family: "codellama", Quant: "Q4_K_M", DiskSizeMB: 39936, VRAMMinMB: 43008, RAMMinMB: 64000, Tags: []string{"code"}},
+
+	// ── StarCoder 2 ───────────────────────────────────────────────────────────
+	{Name: "starcoder2:3b", Family: "starcoder2", Quant: "Q4_K_M", DiskSizeMB: 1741, VRAMMinMB: 2560, RAMMinMB: 4096, Tags: []string{"code", "small"}},
+	{Name: "starcoder2:7b", Family: "starcoder2", Quant: "Q4_K_M", DiskSizeMB: 4096, VRAMMinMB: 5120, RAMMinMB: 8192, Tags: []string{"code"}},
+	{Name: "starcoder2:15b", Family: "starcoder2", Quant: "Q4_K_M", DiskSizeMB: 9318, VRAMMinMB: 10240, RAMMinMB: 16384, Tags: []string{"code"}},
+
+	// ── CodeGemma ─────────────────────────────────────────────────────────────
+	{Name: "codegemma:2b", Family: "codegemma", Quant: "Q4_K_M", DiskSizeMB: 1638, VRAMMinMB: 2560, RAMMinMB: 4096, Tags: []string{"code", "small"}},
+	{Name: "codegemma:7b", Family: "codegemma", Quant: "Q4_K_M", DiskSizeMB: 5120, VRAMMinMB: 6144, RAMMinMB: 8192, Tags: []string{"code"}},
+
+	// ── Codestral ─────────────────────────────────────────────────────────────
+	{Name: "codestral:22b", Family: "codestral", Quant: "Q4_K_M", DiskSizeMB: 13312, VRAMMinMB: 14336, RAMMinMB: 24576, Tags: []string{"code"}},
+
+	// ── Devstral ──────────────────────────────────────────────────────────────
+	{Name: "devstral:24b", Family: "devstral", Quant: "Q4_K_M", DiskSizeMB: 14336, VRAMMinMB: 16384, RAMMinMB: 32768, Tags: []string{"code"}},
+
+	// ── Granite Code ──────────────────────────────────────────────────────────
+	{Name: "granite-code:3b", Family: "granite-code", Quant: "Q4_K_M", DiskSizeMB: 2048, VRAMMinMB: 2560, RAMMinMB: 4096, Tags: []string{"code", "small"}},
+	{Name: "granite-code:8b", Family: "granite-code", Quant: "Q4_K_M", DiskSizeMB: 4710, VRAMMinMB: 5632, RAMMinMB: 8192, Tags: []string{"code"}},
+	{Name: "granite-code:20b", Family: "granite-code", Quant: "Q4_K_M", DiskSizeMB: 12288, VRAMMinMB: 13312, RAMMinMB: 24576, Tags: []string{"code"}},
+	{Name: "granite-code:34b", Family: "granite-code", Quant: "Q4_K_M", DiskSizeMB: 19456, VRAMMinMB: 22528, RAMMinMB: 32768, Tags: []string{"code"}},
+
+	// ── LLaVA ─────────────────────────────────────────────────────────────────
+	{Name: "llava:7b", Family: "llava", Quant: "Q4_K_M", DiskSizeMB: 4813, VRAMMinMB: 6144, RAMMinMB: 8192, Tags: []string{"vision"}},
+	{Name: "llava:13b", Family: "llava", Quant: "Q4_K_M", DiskSizeMB: 8192, VRAMMinMB: 10240, RAMMinMB: 16384, Tags: []string{"vision"}},
+	{Name: "llava:34b", Family: "llava", Quant: "Q4_K_M", DiskSizeMB: 20480, VRAMMinMB: 22528, RAMMinMB: 40960, Tags: []string{"vision"}},
+
+	// ── LLaVA Llama 3 ────────────────────────────────────────────────────────
+	{Name: "llava-llama3:8b", Family: "llava-llama3", Quant: "Q4_K_M", DiskSizeMB: 5632, VRAMMinMB: 6656, RAMMinMB: 10240, Tags: []string{"vision"}},
+
+	// ── LLaVA Phi-3 ───────────────────────────────────────────────────────────
+	{Name: "llava-phi3:3.8b", Family: "llava-phi3", Quant: "Q4_K_M", DiskSizeMB: 2970, VRAMMinMB: 4096, RAMMinMB: 6144, Tags: []string{"vision", "small"}},
+
+	// ── BakLLaVA ──────────────────────────────────────────────────────────────
+	{Name: "bakllava:7b", Family: "bakllava", Quant: "Q4_K_M", DiskSizeMB: 4813, VRAMMinMB: 6144, RAMMinMB: 8192, Tags: []string{"vision"}},
+
+	// ── Moondream ─────────────────────────────────────────────────────────────
+	{Name: "moondream:1.8b", Family: "moondream", Quant: "Q4_K_M", DiskSizeMB: 1741, VRAMMinMB: 2560, RAMMinMB: 4096, Tags: []string{"vision", "small"}},
+
+	// ── Granite 3.2 Vision ────────────────────────────────────────────────────
+	{Name: "granite3.2-vision:2b", Family: "granite3.2-vision", Quant: "Q4_K_M", DiskSizeMB: 2458, VRAMMinMB: 3584, RAMMinMB: 6144, Tags: []string{"vision", "small"}},
+
+	// ── Nomic Embed Text ──────────────────────────────────────────────────────
+	{Name: "nomic-embed-text:v1.5", Family: "nomic-embed-text", Quant: "F16", DiskSizeMB: 274, VRAMMinMB: 512, RAMMinMB: 1024, Tags: []string{"embed"}},
+
+	// ── Mxbai Embed Large ────────────────────────────────────────────────────
+	{Name: "mxbai-embed-large:335m", Family: "mxbai-embed-large", Quant: "F16", DiskSizeMB: 670, VRAMMinMB: 768, RAMMinMB: 1024, Tags: []string{"embed"}},
+
+	// ── All-MiniLM ────────────────────────────────────────────────────────────
+	{Name: "all-minilm:22m", Family: "all-minilm", Quant: "F16", DiskSizeMB: 46, VRAMMinMB: 256, RAMMinMB: 512, Tags: []string{"embed", "small"}},
+	{Name: "all-minilm:33m", Family: "all-minilm", Quant: "F16", DiskSizeMB: 67, VRAMMinMB: 256, RAMMinMB: 512, Tags: []string{"embed", "small"}},
+
+	// ── Snowflake Arctic Embed ────────────────────────────────────────────────
+	{Name: "snowflake-arctic-embed:22m", Family: "snowflake-arctic-embed", Quant: "F16", DiskSizeMB: 46, VRAMMinMB: 256, RAMMinMB: 512, Tags: []string{"embed", "small"}},
+	{Name: "snowflake-arctic-embed:110m", Family: "snowflake-arctic-embed", Quant: "F16", DiskSizeMB: 219, VRAMMinMB: 384, RAMMinMB: 512, Tags: []string{"embed", "small"}},
+	{Name: "snowflake-arctic-embed:335m", Family: "snowflake-arctic-embed", Quant: "F16", DiskSizeMB: 669, VRAMMinMB: 768, RAMMinMB: 1024, Tags: []string{"embed"}},
+
+	// ── Granite Embedding ─────────────────────────────────────────────────────
+	{Name: "granite-embedding:30m", Family: "granite-embedding", Quant: "F16", DiskSizeMB: 63, VRAMMinMB: 256, RAMMinMB: 512, Tags: []string{"embed", "small"}},
+	{Name: "granite-embedding:278m", Family: "granite-embedding", Quant: "F16", DiskSizeMB: 563, VRAMMinMB: 640, RAMMinMB: 1024, Tags: []string{"embed", "multilingual"}},
+
+	// ── BGE-M3 ────────────────────────────────────────────────────────────────
+	{Name: "bge-m3:567m", Family: "bge-m3", Quant: "F16", DiskSizeMB: 1140, VRAMMinMB: 1280, RAMMinMB: 2048, Tags: []string{"embed", "multilingual"}},
+
+	// ── Granite 3 Dense ───────────────────────────────────────────────────────
+	{Name: "granite3-dense:2b", Family: "granite3-dense", Quant: "Q4_K_M", DiskSizeMB: 1638, VRAMMinMB: 2560, RAMMinMB: 4096, Tags: []string{"small"}},
+	{Name: "granite3-dense:8b", Family: "granite3-dense", Quant: "Q4_K_M", DiskSizeMB: 5018, VRAMMinMB: 6144, RAMMinMB: 10240},
+
+	// ── Granite 3.1 Dense ─────────────────────────────────────────────────────
+	{Name: "granite3.1-dense:2b", Family: "granite3.1-dense", Quant: "Q4_K_M", DiskSizeMB: 1638, VRAMMinMB: 2560, RAMMinMB: 4096, Tags: []string{"small"}},
+	{Name: "granite3.1-dense:8b", Family: "granite3.1-dense", Quant: "Q4_K_M", DiskSizeMB: 5120, VRAMMinMB: 6144, RAMMinMB: 10240},
+
+	// ── Granite 3.1 MoE ───────────────────────────────────────────────────────
+	{Name: "granite3.1-moe:1b", Family: "granite3.1-moe", Quant: "Q4_K_M", DiskSizeMB: 1434, VRAMMinMB: 2048, RAMMinMB: 3072, Tags: []string{"small"}},
+	{Name: "granite3.1-moe:3b", Family: "granite3.1-moe", Quant: "Q4_K_M", DiskSizeMB: 2048, VRAMMinMB: 3072, RAMMinMB: 4096, Tags: []string{"small"}},
+
+	// ── Granite 3.2 ───────────────────────────────────────────────────────────
+	{Name: "granite3.2:2b", Family: "granite3.2", Quant: "Q4_K_M", DiskSizeMB: 1536, VRAMMinMB: 2560, RAMMinMB: 4096, Tags: []string{"small", "reasoning"}},
+	{Name: "granite3.2:8b", Family: "granite3.2", Quant: "Q4_K_M", DiskSizeMB: 5018, VRAMMinMB: 6144, RAMMinMB: 10240, Tags: []string{"reasoning"}},
+
+	// ── Command R ─────────────────────────────────────────────────────────────
+	{Name: "command-r:35b", Family: "command-r", Quant: "Q4_K_M", DiskSizeMB: 19456, VRAMMinMB: 22528, RAMMinMB: 40960, Tags: []string{"multilingual"}},
+
+	// ── Command R+ ────────────────────────────────────────────────────────────
+	{Name: "command-r-plus:104b", Family: "command-r-plus", Quant: "Q4_K_M", DiskSizeMB: 60416, VRAMMinMB: 65536, RAMMinMB: 128000, Tags: []string{"multilingual"}},
+
+	// ── Aya ───────────────────────────────────────────────────────────────────
+	{Name: "aya:8b", Family: "aya", Quant: "Q4_K_M", DiskSizeMB: 4915, VRAMMinMB: 6144, RAMMinMB: 10240, Tags: []string{"multilingual"}},
+	{Name: "aya:35b", Family: "aya", Quant: "Q4_K_M", DiskSizeMB: 20480, VRAMMinMB: 22528, RAMMinMB: 40960, Tags: []string{"multilingual"}},
+
+	// ── Solar ─────────────────────────────────────────────────────────────────
+	{Name: "solar:10.7b", Family: "solar", Quant: "Q4_K_M", DiskSizeMB: 6246, VRAMMinMB: 7168, RAMMinMB: 12288},
+
+	// ── SmolLM ────────────────────────────────────────────────────────────────
+	{Name: "smollm:135m", Family: "smollm", Quant: "Q4_K_M", DiskSizeMB: 92, VRAMMinMB: 512, RAMMinMB: 1024, Tags: []string{"small"}},
+	{Name: "smollm:360m", Family: "smollm", Quant: "Q4_K_M", DiskSizeMB: 229, VRAMMinMB: 512, RAMMinMB: 1024, Tags: []string{"small"}},
+	{Name: "smollm:1.7b", Family: "smollm", Quant: "Q4_K_M", DiskSizeMB: 991, VRAMMinMB: 1536, RAMMinMB: 2048, Tags: []string{"small"}},
+
+	// ── SmolLM 2 ──────────────────────────────────────────────────────────────
+	{Name: "smollm2:135m", Family: "smollm2", Quant: "Q4_K_M", DiskSizeMB: 271, VRAMMinMB: 512, RAMMinMB: 1024, Tags: []string{"small"}},
+	{Name: "smollm2:360m", Family: "smollm2", Quant: "Q4_K_M", DiskSizeMB: 726, VRAMMinMB: 768, RAMMinMB: 1024, Tags: []string{"small"}},
+	{Name: "smollm2:1.7b", Family: "smollm2", Quant: "Q4_K_M", DiskSizeMB: 1843, VRAMMinMB: 2048, RAMMinMB: 3072, Tags: []string{"small"}},
+
+	// ── TinyLlama ─────────────────────────────────────────────────────────────
+	{Name: "tinyllama:1.1b", Family: "tinyllama", Quant: "Q4_K_M", DiskSizeMB: 638, VRAMMinMB: 1024, RAMMinMB: 2048, Tags: []string{"small"}},
+
+	// ── StableLM 2 ────────────────────────────────────────────────────────────
+	{Name: "stablelm2:1.6b", Family: "stablelm2", Quant: "Q4_K_M", DiskSizeMB: 983, VRAMMinMB: 1536, RAMMinMB: 2048, Tags: []string{"small", "multilingual"}},
+	{Name: "stablelm2:12b", Family: "stablelm2", Quant: "Q4_K_M", DiskSizeMB: 7168, VRAMMinMB: 8192, RAMMinMB: 16384, Tags: []string{"multilingual"}},
+
+	// ── Zephyr ────────────────────────────────────────────────────────────────
+	{Name: "zephyr:7b", Family: "zephyr", Quant: "Q4_K_M", DiskSizeMB: 4198, VRAMMinMB: 5632, RAMMinMB: 8192},
+	{Name: "zephyr:141b", Family: "zephyr", Quant: "Q4_K_M", DiskSizeMB: 81920, VRAMMinMB: 86016, RAMMinMB: 128000},
+
+	// ── OpenChat ──────────────────────────────────────────────────────────────
+	{Name: "openchat:7b", Family: "openchat", Quant: "Q4_K_M", DiskSizeMB: 4198, VRAMMinMB: 5632, RAMMinMB: 8192},
+
+	// ── Neural Chat ───────────────────────────────────────────────────────────
+	{Name: "neural-chat:7b", Family: "neural-chat", Quant: "Q4_K_M", DiskSizeMB: 4198, VRAMMinMB: 5632, RAMMinMB: 8192},
+
+	// ── Dolphin variants ──────────────────────────────────────────────────────
+	{Name: "dolphin-mistral:7b", Family: "dolphin-mistral", Quant: "Q4_K_M", DiskSizeMB: 4198, VRAMMinMB: 5632, RAMMinMB: 8192},
+	{Name: "dolphin-llama3:8b", Family: "dolphin-llama3", Quant: "Q4_K_M", DiskSizeMB: 4813, VRAMMinMB: 5632, RAMMinMB: 8192},
+	{Name: "dolphin-llama3:70b", Family: "dolphin-llama3", Quant: "Q4_K_M", DiskSizeMB: 40960, VRAMMinMB: 43008, RAMMinMB: 64000},
+	{Name: "dolphin-phi:2.7b", Family: "dolphin-phi", Quant: "Q4_K_M", DiskSizeMB: 1638, VRAMMinMB: 2560, RAMMinMB: 4096, Tags: []string{"small"}},
+
+	// ── Nous Hermes 2 ─────────────────────────────────────────────────────────
+	{Name: "nous-hermes2:10.7b", Family: "nous-hermes2", Quant: "Q4_K_M", DiskSizeMB: 6246, VRAMMinMB: 7168, RAMMinMB: 12288},
+	{Name: "nous-hermes2:34b", Family: "nous-hermes2", Quant: "Q4_K_M", DiskSizeMB: 19456, VRAMMinMB: 22528, RAMMinMB: 32768},
+
+	// ── OpenHermes ────────────────────────────────────────────────────────────
+	{Name: "openhermes:7b", Family: "openhermes", Quant: "Q4_K_M", DiskSizeMB: 4506, VRAMMinMB: 5632, RAMMinMB: 8192},
+
+	// ── Wizard Vicuna Uncensored ──────────────────────────────────────────────
+	{Name: "wizard-vicuna-uncensored:7b", Family: "wizard-vicuna-uncensored", Quant: "Q4_K_M", DiskSizeMB: 3891, VRAMMinMB: 5120, RAMMinMB: 8192},
+	{Name: "wizard-vicuna-uncensored:13b", Family: "wizard-vicuna-uncensored", Quant: "Q4_K_M", DiskSizeMB: 7578, VRAMMinMB: 9216, RAMMinMB: 16384},
+	{Name: "wizard-vicuna-uncensored:30b", Family: "wizard-vicuna-uncensored", Quant: "Q4_K_M", DiskSizeMB: 18432, VRAMMinMB: 20480, RAMMinMB: 32768},
+
+	// ── Yi ────────────────────────────────────────────────────────────────────
+	{Name: "yi:6b", Family: "yi", Quant: "Q4_K_M", DiskSizeMB: 3584, VRAMMinMB: 5120, RAMMinMB: 8192},
+	{Name: "yi:9b", Family: "yi", Quant: "Q4_K_M", DiskSizeMB: 5120, VRAMMinMB: 6656, RAMMinMB: 10240},
+	{Name: "yi:34b", Family: "yi", Quant: "Q4_K_M", DiskSizeMB: 19456, VRAMMinMB: 22528, RAMMinMB: 40960},
+
+	// ── InternLM 2 ────────────────────────────────────────────────────────────
+	{Name: "internlm2:1.8b", Family: "internlm2", Quant: "Q4_K_M", DiskSizeMB: 1127, VRAMMinMB: 2048, RAMMinMB: 3072, Tags: []string{"small"}},
+	{Name: "internlm2:7b", Family: "internlm2", Quant: "Q4_K_M", DiskSizeMB: 4608, VRAMMinMB: 5632, RAMMinMB: 8192},
+	{Name: "internlm2:20b", Family: "internlm2", Quant: "Q4_K_M", DiskSizeMB: 11264, VRAMMinMB: 12288, RAMMinMB: 24576},
+
+	// ── Nemotron ──────────────────────────────────────────────────────────────
+	{Name: "nemotron-mini:4b", Family: "nemotron-mini", Quant: "Q4_K_M", DiskSizeMB: 2765, VRAMMinMB: 3584, RAMMinMB: 6144, Tags: []string{"small"}},
+	{Name: "nemotron:70b", Family: "nemotron", Quant: "Q4_K_M", DiskSizeMB: 44032, VRAMMinMB: 46080, RAMMinMB: 80000},
+
+	// ── Llama Guard 3 ─────────────────────────────────────────────────────────
+	{Name: "llama-guard3:1b", Family: "llama-guard3", Quant: "Q4_K_M", DiskSizeMB: 1638, VRAMMinMB: 2048, RAMMinMB: 3072, Tags: []string{"small"}},
+	{Name: "llama-guard3:8b", Family: "llama-guard3", Quant: "Q4_K_M", DiskSizeMB: 5018, VRAMMinMB: 5632, RAMMinMB: 8192},
+
+	// ── Falcon ────────────────────────────────────────────────────────────────
+	{Name: "falcon:7b", Family: "falcon", Quant: "Q4_K_M", DiskSizeMB: 4301, VRAMMinMB: 5632, RAMMinMB: 8192},
+	{Name: "falcon:40b", Family: "falcon", Quant: "Q4_K_M", DiskSizeMB: 24576, VRAMMinMB: 26624, RAMMinMB: 48000},
+
+	// ── Falcon 3 ──────────────────────────────────────────────────────────────
+	{Name: "falcon3:1b", Family: "falcon3", Quant: "Q4_K_M", DiskSizeMB: 1843, VRAMMinMB: 2048, RAMMinMB: 3072, Tags: []string{"small"}},
+	{Name: "falcon3:3b", Family: "falcon3", Quant: "Q4_K_M", DiskSizeMB: 2048, VRAMMinMB: 2560, RAMMinMB: 4096, Tags: []string{"small"}},
+	{Name: "falcon3:7b", Family: "falcon3", Quant: "Q4_K_M", DiskSizeMB: 4710, VRAMMinMB: 5632, RAMMinMB: 8192},
+	{Name: "falcon3:10b", Family: "falcon3", Quant: "Q4_K_M", DiskSizeMB: 6451, VRAMMinMB: 7168, RAMMinMB: 12288},
+
+	// ── QwQ ───────────────────────────────────────────────────────────────────
+	{Name: "qwq:32b", Family: "qwq", Quant: "Q4_K_M", DiskSizeMB: 20480, VRAMMinMB: 22528, RAMMinMB: 32768, Tags: []string{"reasoning"}},
+
+	// ── OLMo 2 ────────────────────────────────────────────────────────────────
+	{Name: "olmo2:7b", Family: "olmo2", Quant: "Q4_K_M", DiskSizeMB: 4608, VRAMMinMB: 5632, RAMMinMB: 8192},
+	{Name: "olmo2:13b", Family: "olmo2", Quant: "Q4_K_M", DiskSizeMB: 8602, VRAMMinMB: 9728, RAMMinMB: 16384},
+	{Name: "nomic-embed-text", Tags: []string{"embedding"}},
+	{Name: "gemma3:270m", Quant: "Q4_K_M", DiskSizeMB: 540, VRAMMinMB: 1052, RAMMinMB: 3100, Tags: []string{"vision", "cloud"}},
+	{Name: "qwen3:30b", Quant: "Q4_K_M", DiskSizeMB: 18000, VRAMMinMB: 18512, RAMMinMB: 20560, Tags: []string{"tools", "thinking"}},
+	{Name: "qwen3:235b", Quant: "Q4_K_M", DiskSizeMB: 141000, VRAMMinMB: 141512, RAMMinMB: 143560, Tags: []string{"tools", "thinking"}},
+	{Name: "gpt-oss:20b", Quant: "Q4_K_M", DiskSizeMB: 12000, VRAMMinMB: 12512, RAMMinMB: 14560, Tags: []string{"tools", "thinking", "cloud"}},
+	{Name: "gpt-oss:120b", Quant: "Q4_K_M", DiskSizeMB: 72000, VRAMMinMB: 72512, RAMMinMB: 74560, Tags: []string{"tools", "thinking", "cloud"}},
+	{Name: "qwen:0.5b", Quant: "Q4_K_M", DiskSizeMB: 1000, VRAMMinMB: 1512, RAMMinMB: 3560, Tags: nil},
+	{Name: "qwen:1.8b", Quant: "Q4_K_M", DiskSizeMB: 1080, VRAMMinMB: 1592, RAMMinMB: 3640, Tags: nil},
+	{Name: "qwen:4b", Quant: "Q4_K_M", DiskSizeMB: 2400, VRAMMinMB: 2912, RAMMinMB: 4960, Tags: nil},
+	{Name: "qwen:7b", Quant: "Q4_K_M", DiskSizeMB: 4200, VRAMMinMB: 4712, RAMMinMB: 6760, Tags: nil},
+	{Name: "qwen:14b", Quant: "Q4_K_M", DiskSizeMB: 8400, VRAMMinMB: 8912, RAMMinMB: 10960, Tags: nil},
+	{Name: "qwen:32b", Quant: "Q4_K_M", DiskSizeMB: 19200, VRAMMinMB: 19712, RAMMinMB: 21760, Tags: nil},
+	{Name: "qwen:72b", Quant: "Q4_K_M", DiskSizeMB: 43200, VRAMMinMB: 43712, RAMMinMB: 45760, Tags: nil},
+	{Name: "qwen:110b", Quant: "Q4_K_M", DiskSizeMB: 66000, VRAMMinMB: 66512, RAMMinMB: 68560, Tags: nil},
+	{Name: "minicpm-v:8b", Quant: "Q4_K_M", DiskSizeMB: 4800, VRAMMinMB: 5312, RAMMinMB: 7360, Tags: []string{"vision"}},
+	{Name: "dolphin3:8b", Quant: "Q4_K_M", DiskSizeMB: 4800, VRAMMinMB: 5312, RAMMinMB: 7360, Tags: nil},
+	{Name: "qwen3-coder:30b", Quant: "Q4_K_M", DiskSizeMB: 18000, VRAMMinMB: 18512, RAMMinMB: 20560, Tags: []string{"tools", "cloud"}},
+	{Name: "qwen3-coder:480b", Quant: "Q4_K_M", DiskSizeMB: 288000, VRAMMinMB: 288512, RAMMinMB: 290560, Tags: []string{"tools", "cloud"}},
+	{Name: "snowflake-arctic-embed:33m", Quant: "Q4_K_M", DiskSizeMB: 66, VRAMMinMB: 578, RAMMinMB: 2626, Tags: []string{"embedding"}},
+	{Name: "snowflake-arctic-embed:137m", Quant: "Q4_K_M", DiskSizeMB: 274, VRAMMinMB: 786, RAMMinMB: 2834, Tags: []string{"embedding"}},
+	{Name: "orca-mini:3b", Quant: "Q4_K_M", DiskSizeMB: 1800, VRAMMinMB: 2312, RAMMinMB: 4360, Tags: nil},
+	{Name: "orca-mini:7b", Quant: "Q4_K_M", DiskSizeMB: 4200, VRAMMinMB: 4712, RAMMinMB: 6760, Tags: nil},
+	{Name: "orca-mini:13b", Quant: "Q4_K_M", DiskSizeMB: 7800, VRAMMinMB: 8312, RAMMinMB: 10360, Tags: nil},
+	{Name: "orca-mini:70b", Quant: "Q4_K_M", DiskSizeMB: 42000, VRAMMinMB: 42512, RAMMinMB: 44560, Tags: nil},
+	{Name: "qwen3-vl:2b", Quant: "Q4_K_M", DiskSizeMB: 1200, VRAMMinMB: 1712, RAMMinMB: 3760, Tags: []string{"vision", "tools", "thinking", "cloud"}},
+	{Name: "qwen3-vl:4b", Quant: "Q4_K_M", DiskSizeMB: 2400, VRAMMinMB: 2912, RAMMinMB: 4960, Tags: []string{"vision", "tools", "thinking", "cloud"}},
+	{Name: "qwen3-vl:8b", Quant: "Q4_K_M", DiskSizeMB: 4800, VRAMMinMB: 5312, RAMMinMB: 7360, Tags: []string{"vision", "tools", "thinking", "cloud"}},
+	{Name: "qwen3-vl:30b", Quant: "Q4_K_M", DiskSizeMB: 18000, VRAMMinMB: 18512, RAMMinMB: 20560, Tags: []string{"vision", "tools", "thinking", "cloud"}},
+	{Name: "qwen3-vl:32b", Quant: "Q4_K_M", DiskSizeMB: 19200, VRAMMinMB: 19712, RAMMinMB: 21760, Tags: []string{"vision", "tools", "thinking", "cloud"}},
+	{Name: "qwen3-vl:235b", Quant: "Q4_K_M", DiskSizeMB: 141000, VRAMMinMB: 141512, RAMMinMB: 143560, Tags: []string{"vision", "tools", "thinking", "cloud"}},
+	{Name: "llama2-uncensored:7b", Quant: "Q4_K_M", DiskSizeMB: 4200, VRAMMinMB: 4712, RAMMinMB: 6760, Tags: nil},
+	{Name: "llama2-uncensored:70b", Quant: "Q4_K_M", DiskSizeMB: 42000, VRAMMinMB: 42512, RAMMinMB: 44560, Tags: nil},
+	{Name: "cogito:3b", Quant: "Q4_K_M", DiskSizeMB: 1800, VRAMMinMB: 2312, RAMMinMB: 4360, Tags: []string{"tools"}},
+	{Name: "cogito:8b", Quant: "Q4_K_M", DiskSizeMB: 4800, VRAMMinMB: 5312, RAMMinMB: 7360, Tags: []string{"tools"}},
+	{Name: "cogito:14b", Quant: "Q4_K_M", DiskSizeMB: 8400, VRAMMinMB: 8912, RAMMinMB: 10960, Tags: []string{"tools"}},
+	{Name: "cogito:32b", Quant: "Q4_K_M", DiskSizeMB: 19200, VRAMMinMB: 19712, RAMMinMB: 21760, Tags: []string{"tools"}},
+	{Name: "cogito:70b", Quant: "Q4_K_M", DiskSizeMB: 42000, VRAMMinMB: 42512, RAMMinMB: 44560, Tags: []string{"tools"}},
+	{Name: "qwen2.5vl:3b", Quant: "Q4_K_M", DiskSizeMB: 1800, VRAMMinMB: 2312, RAMMinMB: 4360, Tags: []string{"vision"}},
+	{Name: "qwen2.5vl:7b", Quant: "Q4_K_M", DiskSizeMB: 4200, VRAMMinMB: 4712, RAMMinMB: 6760, Tags: []string{"vision"}},
+	{Name: "qwen2.5vl:32b", Quant: "Q4_K_M", DiskSizeMB: 19200, VRAMMinMB: 19712, RAMMinMB: 21760, Tags: []string{"vision"}},
+	{Name: "qwen2.5vl:72b", Quant: "Q4_K_M", DiskSizeMB: 43200, VRAMMinMB: 43712, RAMMinMB: 45760, Tags: []string{"vision"}},
+	{Name: "mistral-small3.2:24b", Quant: "Q4_K_M", DiskSizeMB: 14400, VRAMMinMB: 14912, RAMMinMB: 16960, Tags: []string{"vision", "tools"}},
+	{Name: "gemma3n", Tags: nil},
+	{Name: "e2b", Tags: nil},
+	{Name: "e4b", Tags: nil},
+	{Name: "llama4:16x17b", Quant: "Q4_K_M", DiskSizeMB: 163200, VRAMMinMB: 163712, RAMMinMB: 165760, Tags: []string{"vision", "tools"}},
+	{Name: "llama4:128x17b", Quant: "Q4_K_M", DiskSizeMB: 1305600, VRAMMinMB: 1306112, RAMMinMB: 1308160, Tags: []string{"vision", "tools"}},
+	{Name: "phi4-reasoning:14b", Quant: "Q4_K_M", DiskSizeMB: 8400, VRAMMinMB: 8912, RAMMinMB: 10960, Tags: nil},
+	{Name: "qwen3.5:0.8b", Quant: "Q4_K_M", DiskSizeMB: 1600, VRAMMinMB: 2112, RAMMinMB: 4160, Tags: []string{"vision", "tools", "thinking", "cloud"}},
+	{Name: "qwen3.5:2b", Quant: "Q4_K_M", DiskSizeMB: 1200, VRAMMinMB: 1712, RAMMinMB: 3760, Tags: []string{"vision", "tools", "thinking", "cloud"}},
+	{Name: "qwen3.5:4b", Quant: "Q4_K_M", DiskSizeMB: 2400, VRAMMinMB: 2912, RAMMinMB: 4960, Tags: []string{"vision", "tools", "thinking", "cloud"}},
+	{Name: "qwen3.5:9b", Quant: "Q4_K_M", DiskSizeMB: 5400, VRAMMinMB: 5912, RAMMinMB: 7960, Tags: []string{"vision", "tools", "thinking", "cloud"}},
+	{Name: "qwen3.5:27b", Quant: "Q4_K_M", DiskSizeMB: 16200, VRAMMinMB: 16712, RAMMinMB: 18760, Tags: []string{"vision", "tools", "thinking", "cloud"}},
+	{Name: "qwen3.5:35b", Quant: "Q4_K_M", DiskSizeMB: 21000, VRAMMinMB: 21512, RAMMinMB: 23560, Tags: []string{"vision", "tools", "thinking", "cloud"}},
+	{Name: "qwen3.5:122b", Quant: "Q4_K_M", DiskSizeMB: 73200, VRAMMinMB: 73712, RAMMinMB: 75760, Tags: []string{"vision", "tools", "thinking", "cloud"}},
+	{Name: "magistral:24b", Quant: "Q4_K_M", DiskSizeMB: 14400, VRAMMinMB: 14912, RAMMinMB: 16960, Tags: []string{"tools", "thinking"}},
+	{Name: "qwen3-embedding:0.6b", Quant: "Q4_K_M", DiskSizeMB: 1200, VRAMMinMB: 1712, RAMMinMB: 3760, Tags: []string{"embedding"}},
+	{Name: "qwen3-embedding:4b", Quant: "Q4_K_M", DiskSizeMB: 2400, VRAMMinMB: 2912, RAMMinMB: 4960, Tags: []string{"embedding"}},
+	{Name: "qwen3-embedding:8b", Quant: "Q4_K_M", DiskSizeMB: 4800, VRAMMinMB: 5312, RAMMinMB: 7360, Tags: []string{"embedding"}},
+	{Name: "deepscaler:1.5b", Quant: "Q4_K_M", DiskSizeMB: 900, VRAMMinMB: 1412, RAMMinMB: 3460, Tags: nil},
+	{Name: "dolphin-mixtral:8x7b", Quant: "Q4_K_M", DiskSizeMB: 33600, VRAMMinMB: 34112, RAMMinMB: 36160, Tags: nil},
+	{Name: "dolphin-mixtral:8x22b", Quant: "Q4_K_M", DiskSizeMB: 105600, VRAMMinMB: 106112, RAMMinMB: 108160, Tags: nil},
+	{Name: "phi:2.7b", Quant: "Q4_K_M", DiskSizeMB: 1620, VRAMMinMB: 2132, RAMMinMB: 4180, Tags: nil},
+	{Name: "lfm2.5-thinking:1.2b", Quant: "Q4_K_M", DiskSizeMB: 720, VRAMMinMB: 1232, RAMMinMB: 3280, Tags: []string{"tools"}},
+	{Name: "lfm2:24b", Quant: "Q4_K_M", DiskSizeMB: 14400, VRAMMinMB: 14912, RAMMinMB: 16960, Tags: []string{"tools"}},
+	{Name: "granite3.3:2b", Quant: "Q4_K_M", DiskSizeMB: 1200, VRAMMinMB: 1712, RAMMinMB: 3760, Tags: []string{"tools"}},
+	{Name: "granite3.3:8b", Quant: "Q4_K_M", DiskSizeMB: 4800, VRAMMinMB: 5312, RAMMinMB: 7360, Tags: []string{"tools"}},
+	{Name: "openthinker:7b", Quant: "Q4_K_M", DiskSizeMB: 4200, VRAMMinMB: 4712, RAMMinMB: 6760, Tags: nil},
+	{Name: "openthinker:32b", Quant: "Q4_K_M", DiskSizeMB: 19200, VRAMMinMB: 19712, RAMMinMB: 21760, Tags: nil},
+	{Name: "granite4:350m", Quant: "Q4_K_M", DiskSizeMB: 700, VRAMMinMB: 1212, RAMMinMB: 3260, Tags: []string{"tools"}},
+	{Name: "granite4:1b", Quant: "Q4_K_M", DiskSizeMB: 600, VRAMMinMB: 1112, RAMMinMB: 3160, Tags: []string{"tools"}},
+	{Name: "granite4:3b", Quant: "Q4_K_M", DiskSizeMB: 1800, VRAMMinMB: 2312, RAMMinMB: 4360, Tags: []string{"tools"}},
+	{Name: "qwen3-coder-next", Tags: []string{"tools", "cloud"}},
+	{Name: "wizardlm2:7b", Quant: "Q4_K_M", DiskSizeMB: 4200, VRAMMinMB: 4712, RAMMinMB: 6760, Tags: nil},
+	{Name: "wizardlm2:8x22b", Quant: "Q4_K_M", DiskSizeMB: 105600, VRAMMinMB: 106112, RAMMinMB: 108160, Tags: nil},
+	{Name: "hermes3:3b", Quant: "Q4_K_M", DiskSizeMB: 1800, VRAMMinMB: 2312, RAMMinMB: 4360, Tags: []string{"tools"}},
+	{Name: "hermes3:8b", Quant: "Q4_K_M", DiskSizeMB: 4800, VRAMMinMB: 5312, RAMMinMB: 7360, Tags: []string{"tools"}},
+	{Name: "hermes3:70b", Quant: "Q4_K_M", DiskSizeMB: 42000, VRAMMinMB: 42512, RAMMinMB: 44560, Tags: []string{"tools"}},
+	{Name: "hermes3:405b", Quant: "Q4_K_M", DiskSizeMB: 243000, VRAMMinMB: 243512, RAMMinMB: 245560, Tags: []string{"tools"}},
+	{Name: "deepcoder:1.5b", Quant: "Q4_K_M", DiskSizeMB: 900, VRAMMinMB: 1412, RAMMinMB: 3460, Tags: nil},
+	{Name: "deepcoder:14b", Quant: "Q4_K_M", DiskSizeMB: 8400, VRAMMinMB: 8912, RAMMinMB: 10960, Tags: nil},
+	{Name: "mistral-small3.1:24b", Quant: "Q4_K_M", DiskSizeMB: 14400, VRAMMinMB: 14912, RAMMinMB: 16960, Tags: []string{"vision", "tools"}},
+	{Name: "mistral-large:123b", Quant: "Q4_K_M", DiskSizeMB: 73800, VRAMMinMB: 74312, RAMMinMB: 76360, Tags: []string{"tools"}},
+	{Name: "embeddinggemma:300m", Quant: "Q4_K_M", DiskSizeMB: 600, VRAMMinMB: 1112, RAMMinMB: 3160, Tags: []string{"embedding"}},
+	{Name: "paraphrase-multilingual:278m", Quant: "Q4_K_M", DiskSizeMB: 556, VRAMMinMB: 1068, RAMMinMB: 3116, Tags: []string{"embedding"}},
+	{Name: "ministral-3:3b", Quant: "Q4_K_M", DiskSizeMB: 1800, VRAMMinMB: 2312, RAMMinMB: 4360, Tags: []string{"vision", "tools", "cloud"}},
+	{Name: "ministral-3:8b", Quant: "Q4_K_M", DiskSizeMB: 4800, VRAMMinMB: 5312, RAMMinMB: 7360, Tags: []string{"vision", "tools", "cloud"}},
+	{Name: "ministral-3:14b", Quant: "Q4_K_M", DiskSizeMB: 8400, VRAMMinMB: 8912, RAMMinMB: 10960, Tags: []string{"vision", "tools", "cloud"}},
+	{Name: "starcoder:1b", Quant: "Q4_K_M", DiskSizeMB: 600, VRAMMinMB: 1112, RAMMinMB: 3160, Tags: nil},
+	{Name: "starcoder:3b", Quant: "Q4_K_M", DiskSizeMB: 1800, VRAMMinMB: 2312, RAMMinMB: 4360, Tags: nil},
+	{Name: "starcoder:7b", Quant: "Q4_K_M", DiskSizeMB: 4200, VRAMMinMB: 4712, RAMMinMB: 6760, Tags: nil},
+	{Name: "starcoder:15b", Quant: "Q4_K_M", DiskSizeMB: 9000, VRAMMinMB: 9512, RAMMinMB: 11560, Tags: nil},
+	{Name: "translategemma:4b", Quant: "Q4_K_M", DiskSizeMB: 2400, VRAMMinMB: 2912, RAMMinMB: 4960, Tags: []string{"vision"}},
+	{Name: "translategemma:12b", Quant: "Q4_K_M", DiskSizeMB: 7200, VRAMMinMB: 7712, RAMMinMB: 9760, Tags: []string{"vision"}},
+	{Name: "translategemma:27b", Quant: "Q4_K_M", DiskSizeMB: 16200, VRAMMinMB: 16712, RAMMinMB: 18760, Tags: []string{"vision"}},
+	{Name: "nous-hermes:7b", Quant: "Q4_K_M", DiskSizeMB: 4200, VRAMMinMB: 4712, RAMMinMB: 6760, Tags: nil},
+	{Name: "nous-hermes:13b", Quant: "Q4_K_M", DiskSizeMB: 7800, VRAMMinMB: 8312, RAMMinMB: 10360, Tags: nil},
+	{Name: "deepseek-llm:7b", Quant: "Q4_K_M", DiskSizeMB: 4200, VRAMMinMB: 4712, RAMMinMB: 6760, Tags: nil},
+	{Name: "deepseek-llm:67b", Quant: "Q4_K_M", DiskSizeMB: 40200, VRAMMinMB: 40712, RAMMinMB: 42760, Tags: nil},
+	{Name: "deepseek-v2:16b", Quant: "Q4_K_M", DiskSizeMB: 9600, VRAMMinMB: 10112, RAMMinMB: 12160, Tags: nil},
+	{Name: "deepseek-v2:236b", Quant: "Q4_K_M", DiskSizeMB: 141600, VRAMMinMB: 142112, RAMMinMB: 144160, Tags: nil},
+	{Name: "falcon:180b", Quant: "Q4_K_M", DiskSizeMB: 108000, VRAMMinMB: 108512, RAMMinMB: 110560, Tags: nil},
+	{Name: "vicuna:7b", Quant: "Q4_K_M", DiskSizeMB: 4200, VRAMMinMB: 4712, RAMMinMB: 6760, Tags: nil},
+	{Name: "vicuna:13b", Quant: "Q4_K_M", DiskSizeMB: 7800, VRAMMinMB: 8312, RAMMinMB: 10360, Tags: nil},
+	{Name: "vicuna:33b", Quant: "Q4_K_M", DiskSizeMB: 19800, VRAMMinMB: 20312, RAMMinMB: 22360, Tags: nil},
+	{Name: "glm4:9b", Quant: "Q4_K_M", DiskSizeMB: 5400, VRAMMinMB: 5912, RAMMinMB: 7960, Tags: nil},
+	{Name: "exaone-deep:2.4b", Quant: "Q4_K_M", DiskSizeMB: 1440, VRAMMinMB: 1952, RAMMinMB: 4000, Tags: nil},
+	{Name: "exaone-deep:7.8b", Quant: "Q4_K_M", DiskSizeMB: 4680, VRAMMinMB: 5192, RAMMinMB: 7240, Tags: nil},
+	{Name: "exaone-deep:32b", Quant: "Q4_K_M", DiskSizeMB: 19200, VRAMMinMB: 19712, RAMMinMB: 21760, Tags: nil},
+	{Name: "codeqwen:7b", Quant: "Q4_K_M", DiskSizeMB: 4200, VRAMMinMB: 4712, RAMMinMB: 6760, Tags: nil},
+	{Name: "openhermes", Tags: nil},
+	{Name: "qwen2-math:1.5b", Quant: "Q4_K_M", DiskSizeMB: 900, VRAMMinMB: 1412, RAMMinMB: 3460, Tags: nil},
+	{Name: "qwen2-math:7b", Quant: "Q4_K_M", DiskSizeMB: 4200, VRAMMinMB: 4712, RAMMinMB: 6760, Tags: nil},
+	{Name: "qwen2-math:72b", Quant: "Q4_K_M", DiskSizeMB: 43200, VRAMMinMB: 43712, RAMMinMB: 45760, Tags: nil},
+	{Name: "llama2-chinese:7b", Quant: "Q4_K_M", DiskSizeMB: 4200, VRAMMinMB: 4712, RAMMinMB: 6760, Tags: nil},
+	{Name: "llama2-chinese:13b", Quant: "Q4_K_M", DiskSizeMB: 7800, VRAMMinMB: 8312, RAMMinMB: 10360, Tags: nil},
+	{Name: "stable-code:3b", Quant: "Q4_K_M", DiskSizeMB: 1800, VRAMMinMB: 2312, RAMMinMB: 4360, Tags: nil},
+	{Name: "sqlcoder:7b", Quant: "Q4_K_M", DiskSizeMB: 4200, VRAMMinMB: 4712, RAMMinMB: 6760, Tags: nil},
+	{Name: "sqlcoder:15b", Quant: "Q4_K_M", DiskSizeMB: 9000, VRAMMinMB: 9512, RAMMinMB: 11560, Tags: nil},
+	{Name: "wizardcoder:33b", Quant: "Q4_K_M", DiskSizeMB: 19800, VRAMMinMB: 20312, RAMMinMB: 22360, Tags: nil},
+	{Name: "yi-coder:1.5b", Quant: "Q4_K_M", DiskSizeMB: 900, VRAMMinMB: 1412, RAMMinMB: 3460, Tags: nil},
+	{Name: "yi-coder:9b", Quant: "Q4_K_M", DiskSizeMB: 5400, VRAMMinMB: 5912, RAMMinMB: 7960, Tags: nil},
+	{Name: "llama3-chatqa:8b", Quant: "Q4_K_M", DiskSizeMB: 4800, VRAMMinMB: 5312, RAMMinMB: 7360, Tags: nil},
+	{Name: "llama3-chatqa:70b", Quant: "Q4_K_M", DiskSizeMB: 42000, VRAMMinMB: 42512, RAMMinMB: 44560, Tags: nil},
+	{Name: "dolphincoder:7b", Quant: "Q4_K_M", DiskSizeMB: 4200, VRAMMinMB: 4712, RAMMinMB: 6760, Tags: nil},
+	{Name: "dolphincoder:15b", Quant: "Q4_K_M", DiskSizeMB: 9000, VRAMMinMB: 9512, RAMMinMB: 11560, Tags: nil},
+	{Name: "wizard-math:7b", Quant: "Q4_K_M", DiskSizeMB: 4200, VRAMMinMB: 4712, RAMMinMB: 6760, Tags: nil},
+	{Name: "wizard-math:13b", Quant: "Q4_K_M", DiskSizeMB: 7800, VRAMMinMB: 8312, RAMMinMB: 10360, Tags: nil},
+	{Name: "wizard-math:70b", Quant: "Q4_K_M", DiskSizeMB: 42000, VRAMMinMB: 42512, RAMMinMB: 44560, Tags: nil},
+	{Name: "llama3-gradient:8b", Quant: "Q4_K_M", DiskSizeMB: 4800, VRAMMinMB: 5312, RAMMinMB: 7360, Tags: nil},
+	{Name: "llama3-gradient:70b", Quant: "Q4_K_M", DiskSizeMB: 42000, VRAMMinMB: 42512, RAMMinMB: 44560, Tags: nil},
+	{Name: "devstral-small-2:24b", Quant: "Q4_K_M", DiskSizeMB: 14400, VRAMMinMB: 14912, RAMMinMB: 16960, Tags: []string{"vision", "tools", "cloud"}},
+	{Name: "samantha-mistral:7b", Quant: "Q4_K_M", DiskSizeMB: 4200, VRAMMinMB: 4712, RAMMinMB: 6760, Tags: nil},
+	{Name: "opencoder:1.5b", Quant: "Q4_K_M", DiskSizeMB: 900, VRAMMinMB: 1412, RAMMinMB: 3460, Tags: nil},
+	{Name: "opencoder:8b", Quant: "Q4_K_M", DiskSizeMB: 4800, VRAMMinMB: 5312, RAMMinMB: 7360, Tags: nil},
+	{Name: "internlm2:1m", Quant: "Q4_K_M", DiskSizeMB: 2, VRAMMinMB: 514, RAMMinMB: 2562, Tags: nil},
+	{Name: "llama3-groq-tool-use:8b", Quant: "Q4_K_M", DiskSizeMB: 4800, VRAMMinMB: 5312, RAMMinMB: 7360, Tags: []string{"tools"}},
+	{Name: "llama3-groq-tool-use:70b", Quant: "Q4_K_M", DiskSizeMB: 42000, VRAMMinMB: 42512, RAMMinMB: 44560, Tags: []string{"tools"}},
+	{Name: "starling-lm:7b", Quant: "Q4_K_M", DiskSizeMB: 4200, VRAMMinMB: 4712, RAMMinMB: 6760, Tags: nil},
+	{Name: "phind-codellama:34b", Quant: "Q4_K_M", DiskSizeMB: 20400, VRAMMinMB: 20912, RAMMinMB: 22960, Tags: nil},
+	{Name: "xwinlm:7b", Quant: "Q4_K_M", DiskSizeMB: 4200, VRAMMinMB: 4712, RAMMinMB: 6760, Tags: nil},
+	{Name: "xwinlm:13b", Quant: "Q4_K_M", DiskSizeMB: 7800, VRAMMinMB: 8312, RAMMinMB: 10360, Tags: nil},
+	{Name: "deepseek-v3.1:671b", Quant: "Q4_K_M", DiskSizeMB: 402600, VRAMMinMB: 403112, RAMMinMB: 405160, Tags: []string{"tools", "thinking", "cloud"}},
+	{Name: "aya-expanse:8b", Quant: "Q4_K_M", DiskSizeMB: 4800, VRAMMinMB: 5312, RAMMinMB: 7360, Tags: []string{"tools"}},
+	{Name: "aya-expanse:32b", Quant: "Q4_K_M", DiskSizeMB: 19200, VRAMMinMB: 19712, RAMMinMB: 21760, Tags: []string{"tools"}},
+	{Name: "granite3-moe:1b", Quant: "Q4_K_M", DiskSizeMB: 600, VRAMMinMB: 1112, RAMMinMB: 3160, Tags: []string{"tools"}},
+	{Name: "granite3-moe:3b", Quant: "Q4_K_M", DiskSizeMB: 1800, VRAMMinMB: 2312, RAMMinMB: 4360, Tags: []string{"tools"}},
+	{Name: "yarn-llama2:7b", Quant: "Q4_K_M", DiskSizeMB: 4200, VRAMMinMB: 4712, RAMMinMB: 6760, Tags: nil},
+	{Name: "yarn-llama2:13b", Quant: "Q4_K_M", DiskSizeMB: 7800, VRAMMinMB: 8312, RAMMinMB: 10360, Tags: nil},
+	{Name: "glm-4.7-flash", Tags: []string{"tools", "thinking"}},
+	{Name: "orca2:7b", Quant: "Q4_K_M", DiskSizeMB: 4200, VRAMMinMB: 4712, RAMMinMB: 6760, Tags: nil},
+	{Name: "orca2:13b", Quant: "Q4_K_M", DiskSizeMB: 7800, VRAMMinMB: 8312, RAMMinMB: 10360, Tags: nil},
+	{Name: "stable-beluga:7b", Quant: "Q4_K_M", DiskSizeMB: 4200, VRAMMinMB: 4712, RAMMinMB: 6760, Tags: nil},
+	{Name: "stable-beluga:13b", Quant: "Q4_K_M", DiskSizeMB: 7800, VRAMMinMB: 8312, RAMMinMB: 10360, Tags: nil},
+	{Name: "stable-beluga:70b", Quant: "Q4_K_M", DiskSizeMB: 42000, VRAMMinMB: 42512, RAMMinMB: 44560, Tags: nil},
+	{Name: "reader-lm:0.5b", Quant: "Q4_K_M", DiskSizeMB: 1000, VRAMMinMB: 1512, RAMMinMB: 3560, Tags: nil},
+	{Name: "reader-lm:1.5b", Quant: "Q4_K_M", DiskSizeMB: 900, VRAMMinMB: 1412, RAMMinMB: 3460, Tags: nil},
+	{Name: "shieldgemma:2b", Quant: "Q4_K_M", DiskSizeMB: 1200, VRAMMinMB: 1712, RAMMinMB: 3760, Tags: nil},
+	{Name: "shieldgemma:9b", Quant: "Q4_K_M", DiskSizeMB: 5400, VRAMMinMB: 5912, RAMMinMB: 7960, Tags: nil},
+	{Name: "shieldgemma:27b", Quant: "Q4_K_M", DiskSizeMB: 16200, VRAMMinMB: 16712, RAMMinMB: 18760, Tags: nil},
+	{Name: "tinydolphin:1.1b", Quant: "Q4_K_M", DiskSizeMB: 660, VRAMMinMB: 1172, RAMMinMB: 3220, Tags: nil},
+	{Name: "codegeex4:9b", Quant: "Q4_K_M", DiskSizeMB: 5400, VRAMMinMB: 5912, RAMMinMB: 7960, Tags: nil},
+	{Name: "llama-pro", Tags: nil},
+	{Name: "mistral-openorca:7b", Quant: "Q4_K_M", DiskSizeMB: 4200, VRAMMinMB: 4712, RAMMinMB: 6760, Tags: nil},
+	{Name: "yarn-mistral:7b", Quant: "Q4_K_M", DiskSizeMB: 4200, VRAMMinMB: 4712, RAMMinMB: 6760, Tags: nil},
+	{Name: "nexusraven:13b", Quant: "Q4_K_M", DiskSizeMB: 7800, VRAMMinMB: 8312, RAMMinMB: 10360, Tags: nil},
+	{Name: "wizardlm", Tags: nil},
+	{Name: "qwen3-next:80b", Quant: "Q4_K_M", DiskSizeMB: 48000, VRAMMinMB: 48512, RAMMinMB: 50560, Tags: []string{"tools", "thinking", "cloud"}},
+	{Name: "rnj-1:8b", Quant: "Q4_K_M", DiskSizeMB: 4800, VRAMMinMB: 5312, RAMMinMB: 7360, Tags: []string{"tools", "cloud"}},
+	{Name: "meditron:7b", Quant: "Q4_K_M", DiskSizeMB: 4200, VRAMMinMB: 4712, RAMMinMB: 6760, Tags: nil},
+	{Name: "meditron:70b", Quant: "Q4_K_M", DiskSizeMB: 42000, VRAMMinMB: 42512, RAMMinMB: 44560, Tags: nil},
+	{Name: "deepseek-ocr:3b", Quant: "Q4_K_M", DiskSizeMB: 1800, VRAMMinMB: 2312, RAMMinMB: 4360, Tags: []string{"vision"}},
+	{Name: "reflection:70b", Quant: "Q4_K_M", DiskSizeMB: 42000, VRAMMinMB: 42512, RAMMinMB: 44560, Tags: nil},
+	{Name: "wizardlm-uncensored:13b", Quant: "Q4_K_M", DiskSizeMB: 7800, VRAMMinMB: 8312, RAMMinMB: 10360, Tags: nil},
+	{Name: "athene-v2:72b", Quant: "Q4_K_M", DiskSizeMB: 43200, VRAMMinMB: 43712, RAMMinMB: 45760, Tags: []string{"tools"}},
+	{Name: "exaone3.5:2.4b", Quant: "Q4_K_M", DiskSizeMB: 1440, VRAMMinMB: 1952, RAMMinMB: 4000, Tags: nil},
+	{Name: "exaone3.5:7.8b", Quant: "Q4_K_M", DiskSizeMB: 4680, VRAMMinMB: 5192, RAMMinMB: 7240, Tags: nil},
+	{Name: "exaone3.5:32b", Quant: "Q4_K_M", DiskSizeMB: 19200, VRAMMinMB: 19712, RAMMinMB: 21760, Tags: nil},
+	{Name: "nous-hermes2-mixtral:8x7b", Quant: "Q4_K_M", DiskSizeMB: 33600, VRAMMinMB: 34112, RAMMinMB: 36160, Tags: nil},
+	{Name: "medllama2:7b", Quant: "Q4_K_M", DiskSizeMB: 4200, VRAMMinMB: 4712, RAMMinMB: 6760, Tags: nil},
+	{Name: "snowflake-arctic-embed2:568m", Quant: "Q4_K_M", DiskSizeMB: 1136, VRAMMinMB: 1648, RAMMinMB: 3696, Tags: []string{"embedding"}},
+	{Name: "codeup:13b", Quant: "Q4_K_M", DiskSizeMB: 7800, VRAMMinMB: 8312, RAMMinMB: 10360, Tags: nil},
+	{Name: "r1-1776:70b", Quant: "Q4_K_M", DiskSizeMB: 42000, VRAMMinMB: 42512, RAMMinMB: 44560, Tags: nil},
+	{Name: "r1-1776:671b", Quant: "Q4_K_M", DiskSizeMB: 402600, VRAMMinMB: 403112, RAMMinMB: 405160, Tags: nil},
+	{Name: "everythinglm:13b", Quant: "Q4_K_M", DiskSizeMB: 7800, VRAMMinMB: 8312, RAMMinMB: 10360, Tags: nil},
+	{Name: "mathstral:7b", Quant: "Q4_K_M", DiskSizeMB: 4200, VRAMMinMB: 4712, RAMMinMB: 6760, Tags: nil},
+	{Name: "solar-pro:22b", Quant: "Q4_K_M", DiskSizeMB: 13200, VRAMMinMB: 13712, RAMMinMB: 15760, Tags: nil},
+	{Name: "magicoder:7b", Quant: "Q4_K_M", DiskSizeMB: 4200, VRAMMinMB: 4712, RAMMinMB: 6760, Tags: nil},
+	{Name: "megadolphin:120b", Quant: "Q4_K_M", DiskSizeMB: 72000, VRAMMinMB: 72512, RAMMinMB: 74560, Tags: nil},
+	{Name: "falcon2:11b", Quant: "Q4_K_M", DiskSizeMB: 6600, VRAMMinMB: 7112, RAMMinMB: 9160, Tags: nil},
+	{Name: "stablelm-zephyr:3b", Quant: "Q4_K_M", DiskSizeMB: 1800, VRAMMinMB: 2312, RAMMinMB: 4360, Tags: nil},
+	{Name: "duckdb-nsql:7b", Quant: "Q4_K_M", DiskSizeMB: 4200, VRAMMinMB: 4712, RAMMinMB: 6760, Tags: nil},
+	{Name: "nuextract:3.8b", Quant: "Q4_K_M", DiskSizeMB: 2280, VRAMMinMB: 2792, RAMMinMB: 4840, Tags: nil},
+	{Name: "mistrallite:7b", Quant: "Q4_K_M", DiskSizeMB: 4200, VRAMMinMB: 4712, RAMMinMB: 6760, Tags: nil},
+	{Name: "bespoke-minicheck:7b", Quant: "Q4_K_M", DiskSizeMB: 4200, VRAMMinMB: 4712, RAMMinMB: 6760, Tags: nil},
+	{Name: "notux:8x7b", Quant: "Q4_K_M", DiskSizeMB: 33600, VRAMMinMB: 34112, RAMMinMB: 36160, Tags: nil},
+	{Name: "notus:7b", Quant: "Q4_K_M", DiskSizeMB: 4200, VRAMMinMB: 4712, RAMMinMB: 6760, Tags: nil},
+	{Name: "wizard-vicuna:13b", Quant: "Q4_K_M", DiskSizeMB: 7800, VRAMMinMB: 8312, RAMMinMB: 10360, Tags: nil},
+	{Name: "firefunction-v2:70b", Quant: "Q4_K_M", DiskSizeMB: 42000, VRAMMinMB: 42512, RAMMinMB: 44560, Tags: []string{"tools"}},
+	{Name: "codebooga:34b", Quant: "Q4_K_M", DiskSizeMB: 20400, VRAMMinMB: 20912, RAMMinMB: 22960, Tags: nil},
+	{Name: "open-orca-platypus2:13b", Quant: "Q4_K_M", DiskSizeMB: 7800, VRAMMinMB: 8312, RAMMinMB: 10360, Tags: nil},
+	{Name: "tulu3:8b", Quant: "Q4_K_M", DiskSizeMB: 4800, VRAMMinMB: 5312, RAMMinMB: 7360, Tags: nil},
+	{Name: "tulu3:70b", Quant: "Q4_K_M", DiskSizeMB: 42000, VRAMMinMB: 42512, RAMMinMB: 44560, Tags: nil},
+	{Name: "goliath", Tags: nil},
+	{Name: "bge-large:335m", Quant: "Q4_K_M", DiskSizeMB: 670, VRAMMinMB: 1182, RAMMinMB: 3230, Tags: []string{"embedding"}},
+	{Name: "dbrx:132b", Quant: "Q4_K_M", DiskSizeMB: 79200, VRAMMinMB: 79712, RAMMinMB: 81760, Tags: nil},
+	{Name: "nemotron-3-nano:30b", Quant: "Q4_K_M", DiskSizeMB: 18000, VRAMMinMB: 18512, RAMMinMB: 20560, Tags: []string{"tools", "thinking", "cloud"}},
+	{Name: "olmo-3:7b", Quant: "Q4_K_M", DiskSizeMB: 4200, VRAMMinMB: 4712, RAMMinMB: 6760, Tags: nil},
+	{Name: "olmo-3:32b", Quant: "Q4_K_M", DiskSizeMB: 19200, VRAMMinMB: 19712, RAMMinMB: 21760, Tags: nil},
+	{Name: "sailor2:1b", Quant: "Q4_K_M", DiskSizeMB: 600, VRAMMinMB: 1112, RAMMinMB: 3160, Tags: nil},
+	{Name: "sailor2:8b", Quant: "Q4_K_M", DiskSizeMB: 4800, VRAMMinMB: 5312, RAMMinMB: 7360, Tags: nil},
+	{Name: "sailor2:20b", Quant: "Q4_K_M", DiskSizeMB: 12000, VRAMMinMB: 12512, RAMMinMB: 14560, Tags: nil},
+	{Name: "command-r7b:7b", Quant: "Q4_K_M", DiskSizeMB: 4200, VRAMMinMB: 4712, RAMMinMB: 6760, Tags: []string{"tools"}},
+	{Name: "deepseek-v2.5:236b", Quant: "Q4_K_M", DiskSizeMB: 141600, VRAMMinMB: 142112, RAMMinMB: 144160, Tags: nil},
+	{Name: "phi4-mini-reasoning:3.8b", Quant: "Q4_K_M", DiskSizeMB: 2280, VRAMMinMB: 2792, RAMMinMB: 4840, Tags: nil},
+	{Name: "granite3-guardian:2b", Quant: "Q4_K_M", DiskSizeMB: 1200, VRAMMinMB: 1712, RAMMinMB: 3760, Tags: nil},
+	{Name: "granite3-guardian:8b", Quant: "Q4_K_M", DiskSizeMB: 4800, VRAMMinMB: 5312, RAMMinMB: 7360, Tags: nil},
+	{Name: "smallthinker:3b", Quant: "Q4_K_M", DiskSizeMB: 1800, VRAMMinMB: 2312, RAMMinMB: 4360, Tags: nil},
+	{Name: "command-a:111b", Quant: "Q4_K_M", DiskSizeMB: 66600, VRAMMinMB: 67112, RAMMinMB: 69160, Tags: []string{"tools"}},
+	{Name: "kimi-k2.5", Tags: []string{"vision", "tools", "thinking", "cloud"}},
+	{Name: "marco-o1:7b", Quant: "Q4_K_M", DiskSizeMB: 4200, VRAMMinMB: 4712, RAMMinMB: 6760, Tags: nil},
+	{Name: "alfred:40b", Quant: "Q4_K_M", DiskSizeMB: 24000, VRAMMinMB: 24512, RAMMinMB: 26560, Tags: nil},
+	{Name: "olmo-3.1:32b", Quant: "Q4_K_M", DiskSizeMB: 19200, VRAMMinMB: 19712, RAMMinMB: 21760, Tags: []string{"tools"}},
+	{Name: "minimax-m2.5", Tags: []string{"tools", "thinking", "cloud"}},
+	{Name: "devstral-2:123b", Quant: "Q4_K_M", DiskSizeMB: 73800, VRAMMinMB: 74312, RAMMinMB: 76360, Tags: []string{"tools", "cloud"}},
+	{Name: "command-r7b-arabic:7b", Quant: "Q4_K_M", DiskSizeMB: 4200, VRAMMinMB: 4712, RAMMinMB: 6760, Tags: []string{"tools"}},
+	{Name: "nomic-embed-text-v2-moe", Tags: []string{"embedding"}},
+	{Name: "glm-5", Tags: []string{"tools", "thinking", "cloud"}},
+	{Name: "cogito-2.1:671b", Quant: "Q4_K_M", DiskSizeMB: 402600, VRAMMinMB: 403112, RAMMinMB: 405160, Tags: []string{"cloud"}},
+	{Name: "functiongemma:270m", Quant: "Q4_K_M", DiskSizeMB: 540, VRAMMinMB: 1052, RAMMinMB: 3100, Tags: []string{"tools"}},
+	{Name: "gpt-oss-safeguard:20b", Quant: "Q4_K_M", DiskSizeMB: 12000, VRAMMinMB: 12512, RAMMinMB: 14560, Tags: []string{"tools", "thinking"}},
+	{Name: "gpt-oss-safeguard:120b", Quant: "Q4_K_M", DiskSizeMB: 72000, VRAMMinMB: 72512, RAMMinMB: 74560, Tags: []string{"tools", "thinking"}},
+	{Name: "glm-4.6", Tags: []string{"tools", "thinking", "cloud"}},
+	{Name: "gemini-3-flash-preview", Tags: []string{"vision", "tools", "thinking", "cloud"}},
+	{Name: "minimax-m2", Tags: []string{"tools", "thinking", "cloud"}},
+	{Name: "glm-ocr", Tags: []string{"vision", "tools"}},
+	{Name: "glm-4.7", Tags: []string{"tools", "thinking", "cloud"}},
+	{Name: "deepseek-v3.2", Tags: []string{"tools", "thinking", "cloud"}},
+	{Name: "kimi-k2", Tags: []string{"tools", "cloud"}},
+	{Name: "kimi-k2-thinking", Tags: []string{"tools", "thinking", "cloud"}},
+	{Name: "mistral-large-3", Tags: []string{"vision", "tools", "cloud"}},
+	{Name: "minimax-m2.1", Tags: []string{"tools", "cloud"}},
+}

--- a/fitcheck/response.go
+++ b/fitcheck/response.go
@@ -1,0 +1,11 @@
+package fitcheck
+
+// FitResponse is returned by GET /api/fit and contains hardware capabilities
+// alongside a ranked list of model compatibility candidates.
+type FitResponse struct {
+	// System describes the hardware of the machine running Ollama.
+	System HardwareProfile `json:"system"`
+
+	// Models is the ranked list of model candidates for this hardware.
+	Models []ModelCandidate `json:"models"`
+}

--- a/fitcheck/scorer.go
+++ b/fitcheck/scorer.go
@@ -1,0 +1,271 @@
+package fitcheck
+
+import (
+	"fmt"
+	"sort"
+)
+
+const gb = uint64(1024 * 1024 * 1024)
+
+// CompatibilityTier ranks how well a model will run on the given hardware.
+type CompatibilityTier int
+
+const (
+	// TierIdeal means the model will run entirely on GPU with headroom to spare.
+	TierIdeal CompatibilityTier = iota
+	// TierGood means the model fits on GPU with minor CPU offloading.
+	TierGood
+	// TierMarginal means the model requires significant CPU offloading and will run slowly.
+	TierMarginal
+	// TierPossible means the model will run CPU-only, very slowly.
+	TierPossible
+	// TierTooLarge means the model cannot run on this hardware.
+	TierTooLarge
+)
+
+// String returns the human-readable name for the tier.
+func (t CompatibilityTier) String() string {
+	switch t {
+	case TierIdeal:
+		return "ideal"
+	case TierGood:
+		return "good"
+	case TierMarginal:
+		return "marginal"
+	case TierPossible:
+		return "possible"
+	case TierTooLarge:
+		return "too_large"
+	default:
+		return "unknown"
+	}
+}
+
+// ModelCandidate is a scored and annotated model entry.
+type ModelCandidate struct {
+	// Req is the original model requirement entry.
+	Req ModelRequirement `json:"req"`
+
+	// Tier is the compatibility tier for this hardware.
+	Tier CompatibilityTier `json:"tier"`
+
+	// Score is a 0.0–1.0 composite score (higher is better).
+	Score float64 `json:"score"`
+
+	// RunMode describes how the model will execute: "GPU", "GPU+CPU", or "CPU".
+	RunMode string `json:"run_mode"`
+
+	// EstTPS is the estimated tokens-per-second on this hardware.
+	EstTPS int `json:"est_tps"`
+
+	// Notes are human-readable warnings or suggestions about running this model.
+	Notes []string `json:"notes,omitempty"`
+
+	// Installed is true if the model blob is already present in ModelsDir.
+	Installed bool `json:"installed"`
+}
+
+// Score evaluates all reqs against hw and returns sorted candidates (best first).
+// Primary sort key: Tier ascending (lower tier = better). Secondary: Score descending.
+func Score(hw HardwareProfile, reqs []ModelRequirement) []ModelCandidate {
+	candidates := make([]ModelCandidate, 0, len(reqs))
+
+	for _, req := range reqs {
+		c := scoreOne(hw, req)
+		candidates = append(candidates, c)
+	}
+
+	sort.SliceStable(candidates, func(i, j int) bool {
+		if candidates[i].Tier != candidates[j].Tier {
+			return candidates[i].Tier < candidates[j].Tier
+		}
+		return candidates[i].Score > candidates[j].Score
+	})
+
+	return candidates
+}
+
+func scoreOne(hw HardwareProfile, req ModelRequirement) ModelCandidate {
+	var notes []string
+
+	hasGPU := hw.BestGPU != nil && hw.BestGPU.FreeMemory > 0
+	var vramFreeB uint64
+	if hasGPU {
+		vramFreeB = hw.BestGPU.FreeMemory
+	}
+	vramReqB := req.VRAMMinMB * 1024 * 1024
+	ramFreeB := hw.RAMAvailableBytes
+	ramReqB := req.RAMMinMB * 1024 * 1024
+	diskFreeB := hw.DiskModelAvailBytes
+	diskReqB := req.DiskSizeMB * 1024 * 1024
+
+	// --- vramScore & runMode ---
+	var vramScore float64
+	var runMode string
+	if !hasGPU {
+		vramScore = 0.0
+		runMode = "CPU"
+	} else if vramFreeB >= vramReqB {
+		vramScore = 1.0
+		runMode = "GPU"
+	} else if ramFreeB >= ramReqB {
+		ratio := float64(vramFreeB) / float64(vramReqB)
+		vramScore = 0.25 + (0.40 * ratio)
+		runMode = "GPU+CPU"
+	} else {
+		vramScore = 0.0
+		runMode = "CPU"
+	}
+
+	// --- ramScore ---
+	var ramScore float64
+	if ramFreeB >= ramReqB {
+		ramScore = 1.0
+	} else if hw.RAMTotalBytes >= uint64(float64(ramReqB)*0.85) {
+		ramScore = 0.5
+		notes = append(notes, "RAM is tight; close other apps")
+	} else {
+		ramScore = 0.0
+		notes = append(notes, fmt.Sprintf("Needs %s RAM, only %s available",
+			humanize(ramReqB), humanize(ramFreeB)))
+	}
+
+	// --- diskScore ---
+	var diskScore float64
+	if diskFreeB >= diskReqB {
+		diskScore = 1.0
+	} else {
+		diskScore = 0.0
+		notes = append(notes, fmt.Sprintf("Needs %s disk space, only %s free",
+			humanize(diskReqB), humanize(diskFreeB)))
+	}
+
+	// --- speedScore & estTPS ---
+	var speedScore float64
+	var estTPS int
+	if !hasGPU {
+		// Estimate CPU TPS based on ~45 GB/s memory bandwidth
+		if req.DiskSizeMB > 0 {
+			estTPS = int(45000.0 / float64(req.DiskSizeMB))
+		} else {
+			estTPS = 3
+		}
+		if estTPS > 100 {
+			estTPS = 100
+		}
+		if estTPS < 1 {
+			estTPS = 1
+		}
+		
+		switch {
+		case estTPS >= 30:
+			speedScore = 0.85
+		case estTPS >= 10:
+			speedScore = 0.60
+		case estTPS >= 4:
+			speedScore = 0.35
+		default:
+			speedScore = 0.15
+		}
+	} else {
+		switch hw.BestGPU.Library {
+		case "Metal":
+			total := hw.BestGPU.TotalMemory
+			switch {
+			case total >= 36*gb:
+				speedScore = 1.0
+				estTPS = 120
+			case total >= 18*gb:
+				speedScore = 0.85
+				estTPS = 90
+			default:
+				speedScore = 0.65
+				estTPS = 55
+			}
+		case "CUDA":
+			maj := hw.BestGPU.ComputeMajor
+			switch {
+			case maj >= 9:
+				speedScore = 1.0
+				estTPS = 150
+			case maj >= 8:
+				speedScore = 0.85
+				estTPS = 100
+			case maj >= 7:
+				speedScore = 0.65
+				estTPS = 60
+			default:
+				speedScore = 0.40
+				estTPS = 25
+			}
+		case "ROCm":
+			speedScore = 0.70
+			estTPS = 70
+		default:
+			speedScore = 0.20
+			estTPS = 8
+		}
+	}
+
+	finalScore := (vramScore * 0.40) + (ramScore * 0.25) + (diskScore * 0.15) + (speedScore * 0.20)
+
+	// For CPU-only runs, if it's super fast, give a little bump so tiny models can be 'Good'
+	if !hasGPU && estTPS >= 20 {
+		finalScore += 0.20
+	}
+
+	// --- tier ---
+	var tier CompatibilityTier
+	switch {
+	case ramScore == 0.0 || diskScore == 0.0:
+		tier = TierTooLarge
+	case finalScore >= 0.82:
+		tier = TierIdeal
+	case finalScore >= 0.62:
+		tier = TierGood
+	case finalScore >= 0.38:
+		tier = TierMarginal
+	case finalScore >= 0.15:
+		tier = TierPossible
+	default:
+		tier = TierTooLarge
+	}
+
+	// Scale estTPS by model size relative to GPU memory
+	if hasGPU && vramReqB > 0 {
+		usageRatio := float64(vramReqB) / float64(hw.BestGPU.TotalMemory)
+		scale := 1.0 - usageRatio*0.5
+		if scale < 0.3 {
+			scale = 0.3
+		}
+		estTPS = int(float64(estTPS) * scale)
+	}
+
+	return ModelCandidate{
+		Req:     req,
+		Tier:    tier,
+		Score:   finalScore,
+		RunMode: runMode,
+		EstTPS:  estTPS,
+		Notes:   notes,
+	}
+}
+
+// humanize formats byte counts in human-readable units.
+func humanize(bytes uint64) string {
+	const (
+		kb = uint64(1024)
+		mb = uint64(1024 * 1024)
+		_gb = uint64(1024 * 1024 * 1024)
+	)
+	switch {
+	case bytes < kb:
+		return fmt.Sprintf("%d B", bytes)
+	case bytes < mb:
+		return fmt.Sprintf("%d KB", bytes/kb)
+	case bytes < _gb:
+		return fmt.Sprintf("%.1f MB", float64(bytes)/float64(mb))
+	default:
+		return fmt.Sprintf("%.1f GB", float64(bytes)/float64(_gb))
+	}
+}

--- a/fitcheck/scorer_test.go
+++ b/fitcheck/scorer_test.go
@@ -1,0 +1,223 @@
+package fitcheck_test
+
+import (
+	"testing"
+
+	"github.com/ollama/ollama/fitcheck"
+	"github.com/ollama/ollama/ml"
+)
+
+const testGB = uint64(1024 * 1024 * 1024)
+
+// metalHW returns a hardware profile simulating an Apple Silicon machine.
+func metalHW(freeVRAMGB, totalVRAMGB, freeRAMGB, totalRAMGB, diskGB uint64) fitcheck.HardwareProfile {
+	return fitcheck.HardwareProfile{
+		BestGPU: &ml.DeviceInfo{
+			DeviceID:    ml.DeviceID{Library: "Metal"},
+			Name:        "Apple M-series",
+			FreeMemory:  freeVRAMGB * testGB,
+			TotalMemory: totalVRAMGB * testGB,
+		},
+		RAMAvailableBytes:   freeRAMGB * testGB,
+		RAMTotalBytes:       totalRAMGB * testGB,
+		DiskModelAvailBytes: diskGB * testGB,
+	}
+}
+
+// cudaHW returns a hardware profile simulating an NVIDIA CUDA machine.
+func cudaHW(computeMajor int, freeVRAMGB, totalVRAMGB, freeRAMGB, totalRAMGB, diskGB uint64) fitcheck.HardwareProfile {
+	return fitcheck.HardwareProfile{
+		BestGPU: &ml.DeviceInfo{
+			DeviceID:     ml.DeviceID{Library: "CUDA"},
+			Name:         "NVIDIA GPU",
+			FreeMemory:   freeVRAMGB * testGB,
+			TotalMemory:  totalVRAMGB * testGB,
+			ComputeMajor: computeMajor,
+		},
+		RAMAvailableBytes:   freeRAMGB * testGB,
+		RAMTotalBytes:       totalRAMGB * testGB,
+		DiskModelAvailBytes: diskGB * testGB,
+	}
+}
+
+// cpuHW returns a hardware profile with no GPU.
+func cpuHW(freeRAMGB, totalRAMGB, diskGB uint64) fitcheck.HardwareProfile {
+	return fitcheck.HardwareProfile{
+		BestGPU:             nil,
+		RAMAvailableBytes:   freeRAMGB * testGB,
+		RAMTotalBytes:       totalRAMGB * testGB,
+		DiskModelAvailBytes: diskGB * testGB,
+	}
+}
+
+// assertSorted verifies candidates are in non-decreasing tier order.
+func assertSorted(t *testing.T, candidates []fitcheck.ModelCandidate) {
+	t.Helper()
+	for i := 1; i < len(candidates); i++ {
+		if candidates[i-1].Tier > candidates[i].Tier {
+			t.Errorf("sort violation at index %d: %s > %s",
+				i, candidates[i-1].Tier, candidates[i].Tier)
+		}
+	}
+}
+
+// TestScore_IdealMetalMachine verifies that small models score Ideal on a
+// capable Apple Silicon machine and that results are sorted.
+func TestScore_IdealMetalMachine(t *testing.T) {
+	hw := metalHW(18, 18, 24, 36, 200)
+	candidates := fitcheck.Score(hw, fitcheck.Requirements)
+	if len(candidates) == 0 {
+		t.Fatal("expected candidates")
+	}
+	if candidates[0].Tier != fitcheck.TierIdeal {
+		t.Errorf("expected first candidate to be TierIdeal, got %s (model: %s)",
+			candidates[0].Tier, candidates[0].Req.Name)
+	}
+	assertSorted(t, candidates)
+}
+
+// TestScore_NoGPU_SmallModel verifies CPU-only machines report RunMode "CPU".
+func TestScore_NoGPU_SmallModel(t *testing.T) {
+	hw := cpuHW(16, 16, 200)
+	req := fitcheck.ModelRequirement{
+		Name: "test:small", VRAMMinMB: 0, RAMMinMB: 3000, DiskSizeMB: 800,
+	}
+	candidates := fitcheck.Score(hw, []fitcheck.ModelRequirement{req})
+	if len(candidates) == 0 {
+		t.Fatal("expected candidates")
+	}
+	if candidates[0].RunMode != "CPU" {
+		t.Errorf("expected RunMode=CPU, got %s", candidates[0].RunMode)
+	}
+}
+
+// TestScore_TooLarge verifies a model that exceeds both RAM and disk is TierTooLarge.
+func TestScore_TooLarge(t *testing.T) {
+	hw := cpuHW(4, 8, 10) // only 10 GB disk; model needs 40 GB
+	req := fitcheck.ModelRequirement{
+		Name: "test:huge", VRAMMinMB: 0, RAMMinMB: 64000, DiskSizeMB: 40000,
+	}
+	candidates := fitcheck.Score(hw, []fitcheck.ModelRequirement{req})
+	if len(candidates) == 0 {
+		t.Fatal("expected candidates")
+	}
+	if candidates[0].Tier != fitcheck.TierTooLarge {
+		t.Errorf("expected TierTooLarge, got %s", candidates[0].Tier)
+	}
+}
+
+// TestScore_GPUPlusOffload verifies partial-VRAM models land in GPU+CPU mode.
+func TestScore_GPUPlusOffload(t *testing.T) {
+	// GPU has 4 GB free; model needs 10 GB VRAM; RAM has 32 GB — offload is possible.
+	hw := cudaHW(8, 4, 10, 32, 64, 200)
+	req := fitcheck.ModelRequirement{
+		Name: "test:offload", VRAMMinMB: 10000, RAMMinMB: 16000, DiskSizeMB: 9000,
+	}
+	candidates := fitcheck.Score(hw, []fitcheck.ModelRequirement{req})
+	if len(candidates) == 0 {
+		t.Fatal("expected candidates")
+	}
+	c := candidates[0]
+	if c.RunMode != "GPU+CPU" {
+		t.Errorf("expected RunMode=GPU+CPU, got %s", c.RunMode)
+	}
+	if c.Tier == fitcheck.TierIdeal {
+		t.Errorf("partial-offload model should not be TierIdeal")
+	}
+}
+
+// TestScore_ExactVRAMBoundary verifies a model that exactly fits in VRAM scores GPU.
+func TestScore_ExactVRAMBoundary(t *testing.T) {
+	const vramMB = uint64(5000)
+	hw := cudaHW(8, vramMB/1024+1, vramMB/1024+2, 16, 32, 200)
+	req := fitcheck.ModelRequirement{
+		Name: "test:exact", VRAMMinMB: vramMB, RAMMinMB: 8000, DiskSizeMB: 4700,
+	}
+	candidates := fitcheck.Score(hw, []fitcheck.ModelRequirement{req})
+	if len(candidates) == 0 {
+		t.Fatal("expected candidates")
+	}
+	if candidates[0].RunMode != "GPU" {
+		t.Errorf("expected RunMode=GPU when VRAM just fits, got %s", candidates[0].RunMode)
+	}
+}
+
+// TestScore_NoDisk verifies that insufficient disk → TierTooLarge regardless of RAM/VRAM.
+func TestScore_NoDisk(t *testing.T) {
+	hw := metalHW(18, 18, 24, 36, 1) // only 1 GB disk
+	req := fitcheck.ModelRequirement{
+		Name: "test:nodisk", VRAMMinMB: 2000, RAMMinMB: 4000, DiskSizeMB: 5000,
+	}
+	candidates := fitcheck.Score(hw, []fitcheck.ModelRequirement{req})
+	if len(candidates) == 0 {
+		t.Fatal("expected candidates")
+	}
+	if candidates[0].Tier != fitcheck.TierTooLarge {
+		t.Errorf("no-disk model should be TierTooLarge, got %s", candidates[0].Tier)
+	}
+}
+
+// TestScore_SortStability verifies that within the same tier, higher score comes first.
+func TestScore_SortStability(t *testing.T) {
+	hw := metalHW(18, 18, 24, 36, 200)
+	// Two small models that both score Ideal; the smaller one should score higher.
+	reqs := []fitcheck.ModelRequirement{
+		{Name: "big:7b", VRAMMinMB: 5000, RAMMinMB: 8000, DiskSizeMB: 4700},
+		{Name: "small:1b", VRAMMinMB: 1100, RAMMinMB: 2000, DiskSizeMB: 800},
+	}
+	candidates := fitcheck.Score(hw, reqs)
+	if len(candidates) != 2 {
+		t.Fatalf("expected 2 candidates, got %d", len(candidates))
+	}
+	if candidates[0].Tier != fitcheck.TierIdeal || candidates[1].Tier != fitcheck.TierIdeal {
+		t.Skip("both models need to be Ideal for this test to be meaningful")
+	}
+	if candidates[0].Score < candidates[1].Score {
+		t.Errorf("within TierIdeal, higher score should come first: got %.3f before %.3f",
+			candidates[0].Score, candidates[1].Score)
+	}
+}
+
+// TestScore_CUDA_ComputeGenerations verifies that newer CUDA generations yield higher EstTPS.
+func TestScore_CUDA_ComputeGenerations(t *testing.T) {
+	req := fitcheck.ModelRequirement{
+		Name: "test:cuda", VRAMMinMB: 5000, RAMMinMB: 8000, DiskSizeMB: 4700,
+	}
+	sm7 := fitcheck.Score(cudaHW(7, 12, 12, 32, 64, 200), []fitcheck.ModelRequirement{req})
+	sm9 := fitcheck.Score(cudaHW(9, 12, 12, 32, 64, 200), []fitcheck.ModelRequirement{req})
+
+	if len(sm7) == 0 || len(sm9) == 0 {
+		t.Fatal("expected candidates")
+	}
+	if sm9[0].EstTPS <= sm7[0].EstTPS {
+		t.Errorf("SM9 should be faster than SM7: got %d vs %d tok/s",
+			sm9[0].EstTPS, sm7[0].EstTPS)
+	}
+}
+
+// TestScore_FullCatalogueNonempty verifies the built-in catalogue produces results.
+func TestScore_FullCatalogueNonempty(t *testing.T) {
+	hw := cpuHW(8, 16, 500)
+	candidates := fitcheck.Score(hw, fitcheck.Requirements)
+	if len(candidates) != len(fitcheck.Requirements) {
+		t.Errorf("expected %d candidates, got %d", len(fitcheck.Requirements), len(candidates))
+	}
+	assertSorted(t, candidates)
+}
+
+// TestScore_TierStringRoundtrip verifies all tiers have non-empty string representations.
+func TestScore_TierStringRoundtrip(t *testing.T) {
+	tiers := []fitcheck.CompatibilityTier{
+		fitcheck.TierIdeal,
+		fitcheck.TierGood,
+		fitcheck.TierMarginal,
+		fitcheck.TierPossible,
+		fitcheck.TierTooLarge,
+	}
+	for _, tier := range tiers {
+		s := tier.String()
+		if s == "" || s == "unknown" {
+			t.Errorf("tier %d has bad string: %q", tier, s)
+		}
+	}
+}

--- a/server/routes.go
+++ b/server/routes.go
@@ -36,6 +36,7 @@ import (
 	"github.com/ollama/ollama/auth"
 	"github.com/ollama/ollama/discover"
 	"github.com/ollama/ollama/envconfig"
+	"github.com/ollama/ollama/fitcheck"
 	"github.com/ollama/ollama/format"
 	"github.com/ollama/ollama/fs/ggml"
 	internalcloud "github.com/ollama/ollama/internal/cloud"
@@ -1439,6 +1440,69 @@ func (s *Server) ListHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, api.ListResponse{Models: models})
 }
 
+// FitHandler returns hardware capabilities and a ranked list of model compatibility candidates.
+func (s *Server) FitHandler(c *gin.Context) {
+	modelsDir := envconfig.Models()
+	hw, err := fitcheck.Collect(modelsDir)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	candidates := fitcheck.Score(hw, fitcheck.Requirements)
+
+	// Mark candidates that are already installed locally.
+	if ms, err := manifest.Manifests(true); err == nil {
+		installed := make(map[string]bool, len(ms))
+		for n := range ms {
+			installed[n.DisplayShortest()] = true
+		}
+		for i := range candidates {
+			if installed[candidates[i].Req.Name] {
+				candidates[i].Installed = true
+			}
+		}
+	}
+
+	// apply optional query filters
+	if family := c.Query("family"); family != "" {
+		var filtered []fitcheck.ModelCandidate
+		for _, c2 := range candidates {
+			if strings.Contains(strings.ToLower(c2.Req.Family), strings.ToLower(family)) {
+				filtered = append(filtered, c2)
+			}
+		}
+		candidates = filtered
+	}
+	if tag := c.Query("tags"); tag != "" {
+		var filtered []fitcheck.ModelCandidate
+		for _, c2 := range candidates {
+			for _, t2 := range c2.Req.Tags {
+				if strings.EqualFold(t2, tag) {
+					filtered = append(filtered, c2)
+					break
+				}
+			}
+		}
+		candidates = filtered
+	}
+	showAll := c.Query("all") == "true"
+	if !showAll {
+		var filtered []fitcheck.ModelCandidate
+		for _, c2 := range candidates {
+			if c2.Tier != fitcheck.TierTooLarge {
+				filtered = append(filtered, c2)
+			}
+		}
+		candidates = filtered
+	}
+
+	c.JSON(http.StatusOK, fitcheck.FitResponse{
+		System: hw,
+		Models: candidates,
+	})
+}
+
 func (s *Server) CopyHandler(c *gin.Context) {
 	var r api.CopyRequest
 	if err := c.ShouldBindJSON(&r); errors.Is(err, io.EOF) {
@@ -1672,6 +1736,7 @@ func (s *Server) GenerateRoutes(rc *ollama.Registry) (http.Handler, error) {
 	r.HEAD("/api/version", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"version": version.Version}) })
 	r.GET("/api/version", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"version": version.Version}) })
 	r.GET("/api/status", s.StatusHandler)
+	r.GET("/api/fit", s.FitHandler)
 
 	// Local model cache management (new implementation is at end of function)
 	r.POST("/api/pull", s.PullHandler)


### PR DESCRIPTION
Adds a new `fitcheck` package that scans the host machine's GPU VRAM, system RAM, and available disk space, then scores every model in a built-in catalogue against those resources. Each model receives a compatibility tier (Ideal / Good / Marginal / Possible / Too Large) and an estimated tokens-per-second derived from the GPU library and compute generation.

New surface area:
- GET /api/fit — returns hardware profile + ranked model list; supports ?all, ?family, ?tags query filters; marks already-installed models via manifest lookup
- api.Client.Fit() — thin HTTP wrapper for the endpoint
- `ollama fit` subcommand — renders a tiered table; supports --all, --family, --tags, --json flags
- Fit Check entry in the startup TUI — tabbed multi-select screen; press space to select models, enter to pull them via the standard progress display, esc to return to the main menu

The model catalogue covers 165 variants across 72 families sourced from ollama.com/library (Llama, Mistral, Phi, Gemma, Qwen, DeepSeek, Granite, embedding models, vision models, and more).

Disk stats use syscall.Statfs on Linux/macOS and GetDiskFreeSpaceExW on Windows. GPU detection delegates entirely to discover.GPUDevices() and ml.DeviceInfo — no hardware detection is reimplemented.