### PR TITLE
fix: propagate error from reserveWorstCaseGraph in allocModel

### DIFF
--- a/runner/ollamarunner/runner.go
+++ b/runner/ollamarunner/runner.go
@@ -1231,7 +1231,7 @@ func (s *Server) allocModel(
 
 	err = s.reserveWorstCaseGraph(true)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	return s.reserveWorstCaseGraph(false)


### PR DESCRIPTION
## Summary

Fixes a bug where `allocModel()` silently discards errors from `reserveWorstCaseGraph(true)` (prompt graph reservation).

## Changes

- Changed `return nil` to `return err` when `reserveWorstCaseGraph(true)` fails

## Testing

- Go compilation passes

Fixes ollama/ollama#14839