### PR TITLE
integration: allow env overrides for slow runners

### DIFF
--- a/integration/api_test.go
+++ b/integration/api_test.go
@@ -32,9 +32,9 @@ func assertBytesMatchToken(t *testing.T, label, token string, ints []int) {
 }
 
 func TestAPIGenerate(t *testing.T) {
-	initialTimeout := 60 * time.Second
-	streamTimeout := 30 * time.Second
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	initialTimeout := testDurationEnv("OLLAMA_TEST_INITIAL_TIMEOUT", 60*time.Second)
+	streamTimeout := testDurationEnv("OLLAMA_TEST_STREAM_TIMEOUT", 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testDurationEnv("OLLAMA_TEST_CONTEXT_TIMEOUT", 1*time.Minute))
 	defer cancel()
 	// Set up the test data
 	req := api.GenerateRequest{
@@ -45,6 +45,7 @@ func TestAPIGenerate(t *testing.T) {
 			"seed":        123,
 		},
 	}
+	req.Options = applyTestRunnerOptions(req.Options)
 
 	client, _, cleanup := InitServerConnection(ctx, t)
 	defer cleanup()
@@ -187,9 +188,9 @@ func TestAPIGenerate(t *testing.T) {
 }
 
 func TestAPIChat(t *testing.T) {
-	initialTimeout := 60 * time.Second
-	streamTimeout := 30 * time.Second
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	initialTimeout := testDurationEnv("OLLAMA_TEST_INITIAL_TIMEOUT", 60*time.Second)
+	streamTimeout := testDurationEnv("OLLAMA_TEST_STREAM_TIMEOUT", 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testDurationEnv("OLLAMA_TEST_CONTEXT_TIMEOUT", 1*time.Minute))
 	defer cancel()
 	// Set up the test data
 	req := api.ChatRequest{
@@ -205,6 +206,7 @@ func TestAPIChat(t *testing.T) {
 			"seed":        123,
 		},
 	}
+	req.Options = applyTestRunnerOptions(req.Options)
 
 	client, _, cleanup := InitServerConnection(ctx, t)
 	defer cleanup()

--- a/integration/basic_test.go
+++ b/integration/basic_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestBlueSky(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), testDurationEnv("OLLAMA_TEST_CONTEXT_TIMEOUT", 2*time.Minute))
 	defer cancel()
 	// Set up the test data
 	req := api.ChatRequest{

--- a/integration/utils_test.go
+++ b/integration/utils_test.go
@@ -308,6 +308,65 @@ func init() {
 	}
 }
 
+func testDurationEnv(name string, fallback time.Duration) time.Duration {
+	raw := os.Getenv(name)
+	if raw == "" {
+		return fallback
+	}
+
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		slog.Warn("invalid integration duration override", "env", name, "value", raw, "error", err)
+		return fallback
+	}
+
+	return d
+}
+
+func testIntEnv(name string, fallback int) int {
+	raw := os.Getenv(name)
+	if raw == "" {
+		return fallback
+	}
+
+	v, err := strconv.Atoi(raw)
+	if err != nil {
+		slog.Warn("invalid integration integer override", "env", name, "value", raw, "error", err)
+		return fallback
+	}
+
+	return v
+}
+
+func applyTestRunnerOptions(opts map[string]any) map[string]any {
+	if opts == nil {
+		opts = map[string]any{}
+	}
+
+	if _, ok := opts["num_ctx"]; !ok {
+		numCtx := testIntEnv("OLLAMA_TEST_NUM_CTX", testIntEnv("OLLAMA_CONTEXT_LENGTH", 0))
+		if numCtx > 0 {
+			opts["num_ctx"] = numCtx
+		}
+	}
+
+	if _, ok := opts["num_batch"]; !ok {
+		numBatch := testIntEnv("OLLAMA_TEST_NUM_BATCH", 0)
+		if numBatch > 0 {
+			opts["num_batch"] = numBatch
+		}
+	}
+
+	if _, ok := opts["num_predict"]; !ok {
+		numPredict := testIntEnv("OLLAMA_TEST_NUM_PREDICT", 0)
+		if numPredict > 0 {
+			opts["num_predict"] = numPredict
+		}
+	}
+
+	return opts
+}
+
 func FindPort() string {
 	port := 0
 	if a, err := net.ResolveTCPAddr("tcp", "localhost:0"); err == nil {
@@ -540,6 +599,7 @@ func InitServerConnection(ctx context.Context, t *testing.T) (*api.Client, strin
 func ChatTestHelper(ctx context.Context, t *testing.T, req api.ChatRequest, anyResp []string) {
 	client, _, cleanup := InitServerConnection(ctx, t)
 	defer cleanup()
+	req.Options = applyTestRunnerOptions(req.Options)
 	if err := PullIfMissing(ctx, client, req.Model); err != nil {
 		t.Fatal(err)
 	}
@@ -547,6 +607,9 @@ func ChatTestHelper(ctx context.Context, t *testing.T, req api.ChatRequest, anyR
 }
 
 func DoGenerate(ctx context.Context, t *testing.T, client *api.Client, genReq api.GenerateRequest, anyResp []string, initialTimeout, streamTimeout time.Duration) []int {
+	genReq.Options = applyTestRunnerOptions(genReq.Options)
+	initialTimeout = testDurationEnv("OLLAMA_TEST_INITIAL_TIMEOUT", initialTimeout)
+	streamTimeout = testDurationEnv("OLLAMA_TEST_STREAM_TIMEOUT", streamTimeout)
 	stallTimer := time.NewTimer(initialTimeout)
 	var buf bytes.Buffer
 	var context []int
@@ -655,6 +718,9 @@ func GenerateRequests() ([]api.GenerateRequest, [][]string) {
 }
 
 func DoChat(ctx context.Context, t *testing.T, client *api.Client, req api.ChatRequest, anyResp []string, initialTimeout, streamTimeout time.Duration) *api.Message {
+	req.Options = applyTestRunnerOptions(req.Options)
+	initialTimeout = testDurationEnv("OLLAMA_TEST_INITIAL_TIMEOUT", initialTimeout)
+	streamTimeout = testDurationEnv("OLLAMA_TEST_STREAM_TIMEOUT", streamTimeout)
 	stallTimer := time.NewTimer(initialTimeout)
 	var buf bytes.Buffer
 	role := "assistant"


### PR DESCRIPTION
## Summary

This makes the integration test harness configurable via environment variables so the opt-in tests can run on slower systems without changing the default behavior for normal runs.

It adds support for overriding:
- request context timeout
- initial no-token timeout
- streaming stall timeout
- runner options such as `num_ctx`, `num_batch`, and `num_predict`

Defaults remain unchanged when the new env vars are not set.

## Why

The current integration helpers bake in fixed time budgets and runner settings. That works for many local runs, but it makes the opt-in integration suite difficult to use on slower GPU stacks where the tests are still making progress and eventually succeed.

This keeps the default expectations intact while giving local runners a supported escape hatch.

## New env vars

- `OLLAMA_TEST_CONTEXT_TIMEOUT`
- `OLLAMA_TEST_INITIAL_TIMEOUT`
- `OLLAMA_TEST_STREAM_TIMEOUT`
- `OLLAMA_TEST_NUM_CTX`
- `OLLAMA_TEST_NUM_BATCH`
- `OLLAMA_TEST_NUM_PREDICT`

## Testing

Passed locally:

```bash
go test ./...
GOEXPERIMENT=synctest go test ./...
```

Also passed locally with the new overrides enabled against an existing local server:

```bash
OLLAMA_TEST_EXISTING=1 \
OLLAMA_HOST=127.0.0.1:11443 \
OLLAMA_TEST_DEFAULT_MODEL=qwen25-0.5b-local:latest \
OLLAMA_TEST_NUM_CTX=4096 \
OLLAMA_TEST_NUM_PREDICT=16 \
OLLAMA_TEST_INITIAL_TIMEOUT=120s \
OLLAMA_TEST_STREAM_TIMEOUT=120s \
OLLAMA_TEST_CONTEXT_TIMEOUT=5m \
go test -tags=integration ./integration \
  -run '^(TestBlueSky|TestAPIGenerate|TestAPIChat)$' \
  -count=1 -timeout 20m -v
```

On this WSL2 Vulkan setup, that completed successfully with:
- `TestAPIGenerate`: `129.54s`
- `TestAPIChat`: `107.85s`
- `TestBlueSky`: `55.90s`
