### PR TITLE
fix: properly propagate error from reserveWorstCaseGraph in allocModel

### DIFF
--- a/runner/ollamarunner/runner.go
+++ b/runner/ollamarunner/runner.go
@@ -1231,7 +1231,7 @@ func (s *Server) allocModel(
 
 	err = s.reserveWorstCaseGraph(true)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	return s.reserveWorstCaseGraph(false)


### PR DESCRIPTION
## Description

The `allocModel()` function in `runner/ollamarunner/runner.go` was silently discarding errors from `reserveWorstCaseGraph(true)` by returning `nil` instead of `err`.

## The Bug

```go
err = s.reserveWorstCaseGraph(true)
if err != nil {
    return nil  // BUG: should be return err
}
```

This could cause issues when prompt graph reservation fails due to memory pressure, because:
1. `allocModel` reports success to its caller
2. The model appears to load correctly
3. But the worst-case prompt graph was never reserved
4. Subsequent inference may fail in unexpected ways

## The Fix

Changed `return nil` to `return err` on line 1234.

## Testing

This is a straightforward bug fix - the error was always computed but just not returned. The fix ensures the error is properly propagated to the caller.

Fixes #14839