### PR TITLE
docs(openapi): add missing usage fields to ChatStreamEvent

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -401,6 +401,27 @@ components:
         done:
           type: boolean
           description: True for the final event in the stream
+        done_reason:
+          type: string
+          description: Reason the response finished
+        total_duration:
+          type: integer
+          description: Total time spent generating in nanoseconds
+        load_duration:
+          type: integer
+          description: Time spent loading the model in nanoseconds
+        prompt_eval_count:
+          type: integer
+          description: Number of tokens in the prompt
+        prompt_eval_duration:
+          type: integer
+          description: Time spent evaluating the prompt in nanoseconds
+        eval_count:
+          type: integer
+          description: Number of tokens generated in the response
+        eval_duration:
+          type: integer
+          description: Time spent generating tokens in nanoseconds
     StatusEvent:
       type: object
       properties:


### PR DESCRIPTION
## Summary

The OpenAPI specification for `ChatStreamEvent` was missing the usage/timing fields that the API actually sends in the final streaming chunk (when `done: true`).

## What was incorrect in the spec

The `ChatStreamEvent` schema only defined 4 fields: `model`, `created_at`, `message`, and `done`.

However, the Ollama API sends additional usage/timing fields in the final streaming chunk, similar to `GenerateStreamEvent` and `ChatResponse`.

## What's now correct

Added the following 7 fields to `ChatStreamEvent`:

| Field | Type | Description |
|-------|------|-------------|
| `done_reason` | string | Reason the response finished |
| `total_duration` | integer | Total time spent generating in nanoseconds |
| `load_duration` | integer | Time spent loading the model in nanoseconds |
| `prompt_eval_count` | integer | Number of tokens in the prompt |
| `prompt_eval_duration` | integer | Time spent evaluating the prompt in nanoseconds |
| `eval_count` | integer | Number of tokens generated in the response |
| `eval_duration` | integer | Time spent generating tokens in nanoseconds |

## Verification

Verified by examining the Go source code (`api/types.go`):
- `ChatResponse` struct embeds `Metrics` which contains all these fields
- `GenerateStreamEvent` already has these fields in the spec
- The API behavior is consistent across streaming and non-streaming responses

YAML syntax validated with Python yaml.safe_load().

Fixes #14680

---

**CLA Confirmation:**

I have read, understood, and agree to the Ollama Contributor License Agreement (CLA). I understand that this contribution may be used under the terms of the MIT license.
