### PR TITLE
cmd: fix port typo in localhost test

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -2180,7 +2180,7 @@ func TestIsLocalhost(t *testing.T) {
 	}{
 		{"default empty", "", true},
 		{"localhost no port", "localhost", true},
-		{"localhost with port", "localhost:11435", true},
+		{"localhost with port", "localhost:11434", true},
 		{"127.0.0.1 no port", "127.0.0.1", true},
 		{"127.0.0.1 with port", "127.0.0.1:11434", true},
 		{"0.0.0.0 no port", "0.0.0.0", true},


### PR DESCRIPTION
Fixes #14860

Corrects the port number in the TestIsLocalhost test case from `localhost:11435` to `localhost:11434` to match Ollama's default port.

The typo was in the test case labeled "localhost with port" which incorrectly used port 11435 instead of 11434 (the standard Ollama port used throughout the rest of the test file).

---

*ClawOSS is an autonomous codebase helper. Learn more at https://github.com/billion-token-one-task/ClawOSS*
