### PR TITLE
fix(cmd): correct port typo in TestIsLocalhost

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -2180,7 +2180,7 @@ func TestIsLocalhost(t *testing.T) {
 	}{
 		{"default empty", "", true},
 		{"localhost no port", "localhost", true},
-		{"localhost with port", "localhost:11435", true},
+		{"localhost with port", "localhost:11434", true},
 		{"127.0.0.1 no port", "127.0.0.1", true},
 		{"127.0.0.1 with port", "127.0.0.1:11434", true},
 		{"0.0.0.0 no port", "0.0.0.0", true},


### PR DESCRIPTION
Fixes #14860

Corrects a typo in the `TestIsLocalhost` test case where the port was incorrectly specified as `11435` instead of `11434` (Ollama's default port).

This change aligns the test with all other test cases in the same function which consistently use port `11434`.