### PR TITLE
anthropic: support num_ctx parameter in /v1/messages endpoint

### DIFF
--- a/anthropic/anthropic.go
+++ b/anthropic/anthropic.go
@@ -78,6 +78,7 @@ type MessagesRequest struct {
 	ToolChoice    *ToolChoice     `json:"tool_choice,omitempty"`
 	Thinking      *ThinkingConfig `json:"thinking,omitempty"`
 	Metadata      *Metadata       `json:"metadata,omitempty"`
+	NumCtx        int             `json:"num_ctx,omitempty"`
 }
 
 // MessageParam represents a message in the request
@@ -311,6 +312,10 @@ func FromMessagesRequest(r MessagesRequest) (*api.ChatRequest, error) {
 	options := make(map[string]any)
 
 	options["num_predict"] = r.MaxTokens
+
+	if r.NumCtx > 0 {
+		options["num_ctx"] = r.NumCtx
+	}
 
 	if r.Temperature != nil {
 		options["temperature"] = *r.Temperature

--- a/anthropic/anthropic_test.go
+++ b/anthropic/anthropic_test.go
@@ -1554,3 +1554,68 @@ func TestCitation(t *testing.T) {
 		t.Errorf("cited_text mismatch: expected 'Some cited text...', got %q", unmarshaled.CitedText)
 	}
 }
+
+func TestFromMessagesRequest_WithNumCtx(t *testing.T) {
+	req := MessagesRequest{
+		Model:     "test-model",
+		MaxTokens: 1024,
+		Messages:  []MessageParam{{Role: "user", Content: "Hello"}},
+		NumCtx:    8192,
+	}
+
+	result, err := FromMessagesRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if numCtx, ok := result.Options["num_ctx"].(int); !ok || numCtx != 8192 {
+		t.Errorf("expected num_ctx 8192, got %v", result.Options["num_ctx"])
+	}
+}
+
+func TestFromMessagesRequest_NumCtxZeroOmitted(t *testing.T) {
+	req := MessagesRequest{
+		Model:     "test-model",
+		MaxTokens: 1024,
+		Messages:  []MessageParam{{Role: "user", Content: "Hello"}},
+		// NumCtx not set (zero value)
+	}
+
+	result, err := FromMessagesRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := result.Options["num_ctx"]; ok {
+		t.Errorf("expected num_ctx to be absent when zero, but it was set to %v", result.Options["num_ctx"])
+	}
+}
+
+func TestFromMessagesRequest_NumCtxJSONOmitEmpty(t *testing.T) {
+	// Verify num_ctx is omitted from JSON when zero
+	req := MessagesRequest{
+		Model:     "test-model",
+		MaxTokens: 1024,
+		Messages:  []MessageParam{{Role: "user", Content: "Hello"}},
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("failed to marshal MessagesRequest: %v", err)
+	}
+
+	if strings.Contains(string(data), "num_ctx") {
+		t.Errorf("expected num_ctx to be absent in JSON when zero, got: %s", data)
+	}
+
+	// With num_ctx set it should appear in JSON
+	req.NumCtx = 4096
+	data, err = json.Marshal(req)
+	if err != nil {
+		t.Fatalf("failed to marshal MessagesRequest with num_ctx: %v", err)
+	}
+
+	if !strings.Contains(string(data), `"num_ctx":4096`) {
+		t.Errorf("expected num_ctx in JSON, got: %s", data)
+	}
+}


### PR DESCRIPTION
## Problem

The Anthropic-compatible `/v1/messages` endpoint ignores `num_ctx`, always defaulting to 4096 tokens regardless of the model's Modelfile configuration. This causes silent prompt truncation when system prompts and tool definitions exceed 4096 tokens.

Example log showing the problem:
```
level=WARN source=runner.go:186 msg="truncating input prompt" limit=4096 prompt=42218 keep=4 new=4096
```

The native `/api/chat` endpoint correctly handles `num_ctx` via `request.Options`, but the Anthropic endpoint has no equivalent mechanism.

## Solution

Add a `num_ctx` field to `MessagesRequest` and forward it to the internal `ChatRequest` options, consistent with how the native endpoint works.

```json
{
  "model": "my-model",
  "max_tokens": 1024,
  "num_ctx": 131072,
  "messages": [{"role": "user", "content": "hello"}]
}
```

## Changes

- `anthropic/anthropic.go`: Add `NumCtx int` field to `MessagesRequest` struct
- `anthropic/anthropic.go`: Forward `num_ctx` to options in `FromMessagesRequest()` when set