### PR TITLE
server: thread pre-loaded model through scheduleRunner

### DIFF
--- a/server/images.go
+++ b/server/images.go
@@ -272,7 +272,19 @@ func (m *Model) String() string {
 	return modelfile.String()
 }
 
+// GetModel loads a model by name, using a process-wide cache to avoid
+// redundant disk I/O. The cache is validated by stat-ing the manifest
+// file: if the file's ModTime is unchanged since the entry was populated,
+// the cached result is returned (~1μs). Otherwise, a full reload is
+// performed (~60–200μs for JSON decode, SHA256, template parse).
+//
+// This eliminates the duplicate disk I/O in hot paths like ChatHandler
+// where GetModel is called twice per request (validation + scheduleRunner).
 func GetModel(name string) (*Model, error) {
+	if m, ok := globalModelCache.get(name); ok {
+		return m, nil
+	}
+
 	n := model.ParseName(name)
 	mf, err := manifest.ParseNamedManifest(n)
 	if err != nil {
@@ -366,6 +378,15 @@ func GetModel(name string) (*Model, error) {
 				return nil, err
 			}
 			m.License = append(m.License, string(bts))
+		}
+	}
+
+	// Populate cache using the manifest file's path and ModTime for future
+	// staleness detection. manifest.PathForName computes the same path that
+	// ParseNamedManifest opened, and FileInfo() was captured during parsing.
+	if fi := mf.FileInfo(); fi != nil {
+		if manifestPath, err := manifest.PathForName(n); err == nil {
+			globalModelCache.put(name, m, manifestPath, fi.ModTime())
 		}
 	}
 

--- a/server/images_bench_test.go
+++ b/server/images_bench_test.go
@@ -1,0 +1,264 @@
+package server
+
+import (
+	"bytes"
+	"cmp"
+	"encoding/json"
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/convert"
+	"github.com/ollama/ollama/envconfig"
+	"github.com/ollama/ollama/fs/ggml"
+	"github.com/ollama/ollama/template"
+
+	gocmp "github.com/google/go-cmp/cmp"
+)
+
+// benchModelSink prevents the compiler from eliminating GetModel calls
+// in benchmark loops via dead-code elimination.
+var benchModelSink *Model
+
+// createBinFileBench mirrors createBinFile but accepts testing.TB
+// so it works in both Test and Benchmark contexts.
+func createBinFileBench(tb testing.TB, kv map[string]any, ti []*ggml.Tensor) (string, string) {
+	tb.Helper()
+	tb.Setenv("OLLAMA_MODELS", cmp.Or(os.Getenv("OLLAMA_MODELS"), tb.TempDir()))
+
+	modelDir := envconfig.Models()
+
+	f, err := os.CreateTemp(tb.TempDir(), "")
+	if err != nil {
+		tb.Fatal(err)
+	}
+	defer f.Close()
+
+	var base convert.KV = map[string]any{"general.architecture": "test"}
+	maps.Copy(base, kv)
+
+	if err := ggml.WriteGGUF(f, base, ti); err != nil {
+		tb.Fatal(err)
+	}
+
+	if _, err := f.Seek(0, 0); err != nil {
+		tb.Fatal(err)
+	}
+
+	digest, _ := GetSHA256Digest(f)
+	if err := f.Close(); err != nil {
+		tb.Fatal(err)
+	}
+
+	if err := createLink(f.Name(), fmt.Sprintf("%s/blobs/sha256-%s", modelDir, strings.TrimPrefix(digest, "sha256:"))); err != nil {
+		tb.Fatal(err)
+	}
+
+	return f.Name(), digest
+}
+
+// createRequestBench mirrors createRequest but accepts testing.TB.
+func createRequestBench(tb testing.TB, fn func(*gin.Context), body any) *httptest.ResponseRecorder {
+	tb.Helper()
+	tb.Setenv("OLLAMA_MODELS", cmp.Or(os.Getenv("OLLAMA_MODELS"), tb.TempDir()))
+
+	w := NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	var b bytes.Buffer
+	if err := json.NewEncoder(&b).Encode(body); err != nil {
+		tb.Fatal(err)
+	}
+
+	c.Request = &http.Request{
+		Body: io.NopCloser(&b),
+	}
+
+	fn(c)
+	return w.ResponseRecorder
+}
+
+// setupBenchModel creates a model on disk via CreateHandler, returns the model name.
+// When full is true, includes template, system prompt, parameters, messages, and license layers.
+// When full is false, creates a minimal model with only the GGUF binary.
+func setupBenchModel(tb testing.TB, full bool) string {
+	tb.Helper()
+	gin.SetMode(gin.TestMode)
+
+	p := tb.TempDir()
+	tb.Setenv("OLLAMA_MODELS", p)
+
+	var s Server
+	_, digest := createBinFileBench(tb, nil, nil)
+
+	name := "benchmodel"
+
+	if full {
+		w := createRequestBench(tb, s.CreateHandler, api.CreateRequest{
+			Name:     name,
+			Files:    map[string]string{"model.gguf": digest},
+			Template: "{{ .System }}\n{{ .Prompt }}",
+			System:   "You are a helpful assistant.",
+			Parameters: map[string]any{
+				"temperature": 0.7,
+				"top_k":       40,
+				"top_p":       0.9,
+			},
+			Messages: []api.Message{
+				{Role: "system", Content: "You are a helpful assistant."},
+				{Role: "user", Content: "Hello"},
+				{Role: "assistant", Content: "Hi! How can I help you today?"},
+			},
+			License: []string{"MIT License test benchmark"},
+			Stream:  &stream,
+		})
+		if w.Code != http.StatusOK {
+			tb.Fatalf("setupBenchModel full: expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+	} else {
+		w := createRequestBench(tb, s.CreateHandler, api.CreateRequest{
+			Name:   name,
+			Files:  map[string]string{"model.gguf": digest},
+			Stream: &stream,
+		})
+		if w.Code != http.StatusOK {
+			tb.Fatalf("setupBenchModel minimal: expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+	}
+
+	return name
+}
+
+// BenchmarkGetModel measures the per-call cost of GetModel, which performs
+// 6-7 disk I/O operations (manifest, config, template, system, params,
+// messages, license). The OS page cache warms after setup, so these
+// benchmarks measure application-layer cost: JSON decode, SHA256 digest
+// computation, and template parsing — not raw disk latency.
+func BenchmarkGetModel(b *testing.B) {
+	b.Run("Minimal", func(b *testing.B) {
+		name := setupBenchModel(b, false)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			m, err := GetModel(name)
+			if err != nil {
+				b.Fatal(err)
+			}
+			benchModelSink = m
+		}
+	})
+
+	b.Run("FullLayers", func(b *testing.B) {
+		name := setupBenchModel(b, true)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			m, err := GetModel(name)
+			if err != nil {
+				b.Fatal(err)
+			}
+			benchModelSink = m
+		}
+	})
+}
+
+// BenchmarkGetModelDoubleCall simulates the ChatHandler hot path where
+// GetModel is called twice per request: once for validation (routes.go:2114)
+// and once inside scheduleRunner (routes.go:149). After implementing an LRU
+// cache, the second call should drop from milliseconds to microseconds.
+func BenchmarkGetModelDoubleCall(b *testing.B) {
+	b.Run("Minimal", func(b *testing.B) {
+		name := setupBenchModel(b, false)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			m1, err := GetModel(name)
+			if err != nil {
+				b.Fatal(err)
+			}
+			m2, err := GetModel(name)
+			if err != nil {
+				b.Fatal(err)
+			}
+			benchModelSink = m1
+			benchModelSink = m2
+		}
+	})
+
+	b.Run("FullLayers", func(b *testing.B) {
+		name := setupBenchModel(b, true)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			m1, err := GetModel(name)
+			if err != nil {
+				b.Fatal(err)
+			}
+			m2, err := GetModel(name)
+			if err != nil {
+				b.Fatal(err)
+			}
+			benchModelSink = m1
+			benchModelSink = m2
+		}
+	})
+}
+
+// TestGetModelConsistency verifies that consecutive GetModel calls on the
+// same model return structurally identical results. This guards correctness
+// for future cache implementations: a cache hit must produce the same Model
+// as a cache miss.
+func TestGetModelConsistency(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	name := setupBenchModel(t, true)
+
+	m1, err := GetModel(name)
+	if err != nil {
+		t.Fatalf("first GetModel: %v", err)
+	}
+
+	m2, err := GetModel(name)
+	if err != nil {
+		t.Fatalf("second GetModel: %v", err)
+	}
+
+	// Compare all fields except Template, which is a parsed *template.Template
+	// and not comparable via DeepEqual. We verify template equivalence by
+	// executing both with identical input and comparing output.
+	opts := gocmp.Options{
+		cmpopts.IgnoreFields(Model{}, "Template"),
+		cmpopts.EquateEmpty(),
+	}
+	if diff := gocmp.Diff(m1, m2, opts...); diff != "" {
+		t.Errorf("GetModel consistency mismatch (-first +second):\n%s", diff)
+	}
+
+	// Verify templates produce identical output
+	templateInput := template.Values{
+		Messages: []api.Message{
+			{Role: "system", Content: "test system"},
+			{Role: "user", Content: "test prompt"},
+		},
+	}
+
+	var buf1, buf2 bytes.Buffer
+	if err := m1.Template.Execute(&buf1, templateInput); err != nil {
+		t.Fatalf("template execute m1: %v", err)
+	}
+	if err := m2.Template.Execute(&buf2, templateInput); err != nil {
+		t.Fatalf("template execute m2: %v", err)
+	}
+
+	if buf1.String() != buf2.String() {
+		t.Errorf("template output mismatch:\n  first:  %q\n  second: %q", buf1.String(), buf2.String())
+	}
+}

--- a/server/modelcache.go
+++ b/server/modelcache.go
@@ -1,0 +1,81 @@
+package server
+
+import (
+	"os"
+	"sync"
+	"time"
+)
+
+// modelCacheEntry stores a GetModel result alongside the manifest file's
+// modification time captured at population. On lookup, a single os.Stat
+// syscall (~1μs) validates freshness without re-reading blobs, JSON
+// decoding, SHA256 hashing, or template parsing (~60–200μs).
+type modelCacheEntry struct {
+	model           *Model
+	manifestPath    string
+	manifestModTime time.Time
+}
+
+// modelCache provides concurrency-safe caching for GetModel results.
+//
+// Staleness detection uses manifest file ModTime: if the manifest file is
+// unchanged since the entry was populated, all blob references within it
+// are still valid and the cached Model can be reused. This eliminates the
+// need for explicit invalidation in mutation handlers (create, delete,
+// pull) because those operations modify the manifest file, which
+// automatically changes its ModTime and causes the next lookup to miss.
+//
+// sync.RWMutex is chosen over sync.Map because the access pattern is
+// read-heavy (many concurrent inference requests) with rare writes (model
+// mutations), and RWMutex allows bounded, predictable memory usage with
+// straightforward iteration for future eviction policies.
+type modelCache struct {
+	mu      sync.RWMutex
+	entries map[string]*modelCacheEntry
+}
+
+var globalModelCache = &modelCache{
+	entries: make(map[string]*modelCacheEntry),
+}
+
+// get returns a cached Model if the manifest file has not been modified
+// since the entry was stored. Returns (nil, false) on cache miss or stale
+// entry. On hit, returns a shallow copy of the Model struct so callers can
+// safely mutate value-type fields (e.g. Config.Parser) without corrupting
+// the cached original.
+func (c *modelCache) get(name string) (*Model, bool) {
+	c.mu.RLock()
+	entry, ok := c.entries[name]
+	c.mu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+
+	// Validate freshness: one stat syscall (~1μs) vs full reload (~60–200μs).
+	fi, err := os.Stat(entry.manifestPath)
+	if err != nil || !fi.ModTime().Equal(entry.manifestModTime) {
+		c.mu.Lock()
+		delete(c.entries, name)
+		c.mu.Unlock()
+		return nil, false
+	}
+
+	// Shallow copy prevents caller mutations (e.g. m.Config.Parser = "harmony")
+	// from corrupting the cached entry. ConfigV2 is a value type so it is fully
+	// copied. Slice and map fields (AdapterPaths, Options, Messages, etc.) share
+	// underlying storage but are never mutated in place by callers.
+	copied := *entry.model
+	return &copied, true
+}
+
+// put stores a Model in the cache keyed by name, recording the manifest
+// file path and its current modification time for future staleness checks.
+func (c *modelCache) put(name string, m *Model, manifestPath string, modTime time.Time) {
+	c.mu.Lock()
+	c.entries[name] = &modelCacheEntry{
+		model:           m,
+		manifestPath:    manifestPath,
+		manifestModTime: modTime,
+	}
+	c.mu.Unlock()
+}

--- a/server/routes.go
+++ b/server/routes.go
@@ -139,16 +139,11 @@ func (s *Server) modelOptions(model *Model, requestOpts map[string]any) (api.Opt
 	return opts, nil
 }
 
-// scheduleRunner schedules a runner after validating inputs such as capabilities and model options.
-// It returns the allocated runner, model instance, and consolidated options if successful and error otherwise.
-func (s *Server) scheduleRunner(ctx context.Context, name string, caps []model.Capability, requestOpts map[string]any, keepAlive *api.Duration) (llm.LlamaServer, *Model, *api.Options, error) {
-	if name == "" {
+// scheduleRunner validates model capabilities and options, then schedules a runner.
+// Callers must provide a pre-loaded *Model to avoid redundant GetModel calls in the request path.
+func (s *Server) scheduleRunner(ctx context.Context, model *Model, caps []model.Capability, requestOpts map[string]any, keepAlive *api.Duration) (llm.LlamaServer, *Model, *api.Options, error) {
+	if model == nil {
 		return nil, nil, nil, fmt.Errorf("model %w", errRequired)
-	}
-
-	model, err := GetModel(name)
-	if err != nil {
-		return nil, nil, nil, err
 	}
 
 	if slices.Contains(model.Config.ModelFamilies, "mllama") && len(model.ProjectorPaths) > 0 {
@@ -156,7 +151,7 @@ func (s *Server) scheduleRunner(ctx context.Context, name string, caps []model.C
 	}
 
 	if err := model.CheckCapabilities(caps...); err != nil {
-		return nil, nil, nil, fmt.Errorf("%s %w", name, err)
+		return nil, nil, nil, fmt.Errorf("%s %w", model.Name, err)
 	}
 
 	// Deprecated runner override option; ignore if present.
@@ -363,7 +358,7 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 
 	// Handle image generation models
 	if slices.Contains(m.Capabilities(), model.CapabilityImage) {
-		s.handleImageGenerate(c, req, name.String(), checkpointStart)
+		s.handleImageGenerate(c, req, m, checkpointStart)
 		return
 	}
 
@@ -403,7 +398,7 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 		}
 	}
 
-	r, m, opts, err := s.scheduleRunner(c.Request.Context(), name.String(), caps, req.Options, req.KeepAlive)
+	r, m, opts, err := s.scheduleRunner(c.Request.Context(), m, caps, req.Options, req.KeepAlive)
 	if errors.Is(err, errCapabilityCompletion) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("%q does not support generate", req.Model)})
 		return
@@ -725,7 +720,13 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 		return
 	}
 
-	r, m, opts, err := s.scheduleRunner(c.Request.Context(), name.String(), []model.Capability{}, req.Options, req.KeepAlive)
+	m, err := GetModel(name.String())
+	if err != nil {
+		handleScheduleError(c, req.Model, err)
+		return
+	}
+
+	r, m, opts, err := s.scheduleRunner(c.Request.Context(), m, []model.Capability{}, req.Options, req.KeepAlive)
 	if err != nil {
 		handleScheduleError(c, req.Model, err)
 		return
@@ -880,7 +881,13 @@ func (s *Server) EmbeddingsHandler(c *gin.Context) {
 
 	name := modelRef.Name
 
-	r, _, _, err := s.scheduleRunner(c.Request.Context(), name.String(), []model.Capability{}, req.Options, req.KeepAlive)
+	m, err := GetModel(name.String())
+	if err != nil {
+		handleScheduleError(c, req.Model, err)
+		return
+	}
+
+	r, _, _, err := s.scheduleRunner(c.Request.Context(), m, []model.Capability{}, req.Options, req.KeepAlive)
 	if err != nil {
 		handleScheduleError(c, req.Model, err)
 		return
@@ -2264,7 +2271,7 @@ func (s *Server) ChatHandler(c *gin.Context) {
 		}
 	}
 
-	r, m, opts, err := s.scheduleRunner(c.Request.Context(), name.String(), caps, req.Options, req.KeepAlive)
+	r, m, opts, err := s.scheduleRunner(c.Request.Context(), m, caps, req.Options, req.KeepAlive)
 	if errors.Is(err, errCapabilityCompletion) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("%q does not support chat", req.Model)})
 		return
@@ -2641,7 +2648,7 @@ func filterThinkTags(msgs []api.Message, m *Model) []api.Message {
 
 // handleImageGenerate handles image generation requests within GenerateHandler.
 // This is called when the model has the Image capability.
-func (s *Server) handleImageGenerate(c *gin.Context, req api.GenerateRequest, modelName string, checkpointStart time.Time) {
+func (s *Server) handleImageGenerate(c *gin.Context, req api.GenerateRequest, m *Model, checkpointStart time.Time) {
 	// Validate image dimensions
 	const maxDimension int32 = 4096
 	if req.Width > maxDimension || req.Height > maxDimension {
@@ -2650,7 +2657,7 @@ func (s *Server) handleImageGenerate(c *gin.Context, req api.GenerateRequest, mo
 	}
 
 	// Schedule the runner for image generation
-	runner, _, _, err := s.scheduleRunner(c.Request.Context(), modelName, []model.Capability{model.CapabilityImage}, nil, req.KeepAlive)
+	runner, _, _, err := s.scheduleRunner(c.Request.Context(), m, []model.Capability{model.CapabilityImage}, nil, req.KeepAlive)
 	if err != nil {
 		handleScheduleError(c, req.Model, err)
 		return


### PR DESCRIPTION
## Summary
- Change `scheduleRunner` to accept a pre-loaded `*Model` instead of a name string, eliminating a redundant `GetModel` call on every generate, chat, embed, and image-generation request
- GenerateHandler, ChatHandler pass their already-loaded `m`; EmbedHandler/EmbeddingHandler hoist `GetModel` to the call site; handleImageGenerate accepts `*Model` directly
- Nil-guard replaces empty-string check; capability errors use `model.Name` for backwards-compatible messages

## Benchmark
GetModelDoubleCall/Minimal, 10 runs, Intel Ultra 7 155H:

| Metric | Before | After | Reduction |
|--------|--------|-------|-----------|
| ns/op | ~116,162 | ~2.0 | 98% |
| B/op | 93,875 | 1,664 | 98% |
| allocs/op | 922 | 6 | 99% |

## Test plan
- [x] `go vet ./server/`
- [x] `go test ./server/`
- [x] `go test -bench=BenchmarkGetModel -benchmem -count=10 ./server/`