### PR TITLE
scripts: wait for graphical.target in systemd service

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -215,7 +215,7 @@ configure_systemd() {
     cat <<EOF | $SUDO tee /etc/systemd/system/ollama.service >/dev/null
 [Unit]
 Description=Ollama Service
-After=network-online.target
+After=network-online.target graphical.target
 
 [Service]
 ExecStart=$BINDIR/ollama serve


### PR DESCRIPTION
The ollama systemd service starts before the GPU drivers are ready, causing it to fall back to CPU mode.

Changed the service dependency from `After=network-online.target` to `After=network-online.target graphical.target` to ensure the GPU is available before starting.

Fixes #14874