### PR TITLE
runner/ollamarunner: handle sampling errors gracefully

### DIFF
--- a/runner/ollamarunner/runner.go
+++ b/runner/ollamarunner/runner.go
@@ -759,7 +759,9 @@ func (s *Server) computeBatch(activeBatch batchState) {
 		logits := outputs[iBatches[i]*vocabSize : (iBatches[i]+1)*vocabSize]
 		token, err := seq.sampler.Sample(logits)
 		if err != nil {
-			panic("failed to sample token")
+			slog.Error("failed to sample token", "error", err, "seqIdx", i, "batchID", activeBatch.id)
+			s.removeSequence(i, llm.DoneReasonStop)
+			continue
 		}
 
 		nextBatchTokens[i].Token = token
@@ -776,7 +778,9 @@ func (s *Server) computeBatch(activeBatch batchState) {
 
 		piece, err := s.model.(tokenizer.Tokenizer).Decode([]int32{token})
 		if err != nil {
-			panic("failed to decode token")
+			slog.Error("failed to decode token", "error", err, "token", token, "seqIdx", i, "batchID", activeBatch.id)
+			s.removeSequence(i, llm.DoneReasonStop)
+			continue
 		}
 
 		// Calculate logprobs if requested (after EOS check to avoid logprobs for EOS tokens)


### PR DESCRIPTION
Fixes #14882

Replace panics with proper error handling when token sampling or decoding fails. Previously, the server would crash with "panic: failed to sample token" when models like nemotron-3-nano returned invalid logits (e.g., NaN values).

Changes:
- Log the error with context instead of panicking
- Remove the sequence gracefully using DoneReasonStop
- Continue processing other sequences normally

This prevents the entire server from crashing when a single sequence encounters a sampling error, which can happen with certain models or under specific conditions.