### PR TITLE
fix: correctly count CRLF line endings in modelfile parser

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -383,6 +383,7 @@ func ParseFile(r io.Reader) (*Modelfile, error) {
 	var currLine int = 1
 	var b bytes.Buffer
 	var role string
+	var prev rune
 
 	var f Modelfile
 
@@ -397,9 +398,10 @@ func ParseFile(r io.Reader) (*Modelfile, error) {
 			return nil, err
 		}
 
-		if isNewline(r) {
+		if isNewline(r) && !(prev == '\r' && r == '\n') {
 			currLine++
 		}
+		prev = r
 
 		next, r, err := parseRuneForState(r, curr)
 		if errors.Is(err, io.ErrUnexpectedEOF) {


### PR DESCRIPTION
The parser was incorrectly counting Windows-style line endings (CRLF) as two separate lines, causing incorrect line numbers in error messages. This fix tracks the previous character and only increments the line counter when encountering a newline that is not part of a CRLF sequence.