### PR TITLE
fix(docs): correct AMD linux drivers link in linux.mdx

### DIFF
--- a/docs/linux.mdx
+++ b/docs/linux.mdx
@@ -116,7 +116,7 @@ sudo systemctl status ollama
   While AMD has contributed the `amdgpu` driver upstream to the official linux
   kernel source, the version is older and may not support all ROCm features. We
   recommend you install the latest driver from
-  https://www.amd.com/en/support/linux-drivers for best support of your Radeon
+  https://www.amd.com/en/support/download/linux-drivers.html for best support of your Radeon
   GPU.
 </Note>
 


### PR DESCRIPTION
The link  https://www.amd.com/en/support/linux-drivers redirects to a 404 page. https://www.amd.com/en/support/download/linux-drivers.html is the correct link.