### PR TITLE
fix: treat unparseable qwen tool calls as content instead of aborting

### DIFF
--- a/model/parsers/qwen3coder.go
+++ b/model/parsers/qwen3coder.go
@@ -59,10 +59,13 @@ func (p *Qwen3CoderParser) Add(s string, done bool) (content string, thinking st
 	for _, event := range events {
 		switch event := event.(type) {
 		case qwenEventRawToolCall:
-			toolCall, err := parseToolCall(event, p.tools)
-			if err != nil {
-				slog.Warn("qwen tool call parsing failed", "error", err)
-				return "", "", nil, err
+			toolCall, parseErr := parseToolCall(event, p.tools)
+			if parseErr != nil {
+				slog.Warn("qwen tool call parsing failed, treating as content", "error", parseErr)
+				sb.WriteString(toolOpenTag)
+				sb.WriteString(event.raw)
+				sb.WriteString(toolCloseTag)
+				continue
 			}
 			toolCall.Function.Index = p.callIndex
 			p.callIndex++


### PR DESCRIPTION
## Summary

Fixes #14834

When the qwen3-coder model streams malformed or incomplete XML in a tool call tag, `xml.Unmarshal` fails and the `Add` function returns the error, aborting the entire request. Users see a cryptic "qwen tool call parsing failed" error and get no response at all.

## Root Cause

In `model/parsers/qwen3coder.go`, the `Add` method returns `(nil, nil, nil, err)` on any `parseToolCall` failure. This propagates the XML parse error up to the caller and terminates the generation.

## Fix

Instead of returning the error, emit the raw (unparseable) tool call content back as regular text content. The request completes normally and the user still sees the model output. The warning is still logged for debugging.

```go
// Before: returns error, aborting the request
if err != nil {
    return "", "", nil, err
}

// After: treats malformed XML as content, continues
if parseErr != nil {
    sb.WriteString(toolOpenTag)
    sb.WriteString(event.raw)
    sb.WriteString(toolCloseTag)
    continue
}
```

## Test Plan

1. Use qwen3-coder model with tool calling enabled
2. Send a prompt that triggers malformed XML in tool call output
3. Previously: request aborts with "qwen tool call parsing failed" error
4. Now: the raw content is returned as text, request completes successfully

Made with [Cursor](https://cursor.com)