### PR TITLE
readline: harden history persistence

### DIFF
--- a/readline/history.go
+++ b/readline/history.go
@@ -8,17 +8,20 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/emirpasic/gods/v2/lists/arraylist"
 )
 
 type History struct {
-	Buf      *arraylist.List[string]
-	Autosave bool
-	Pos      int
-	Limit    int
-	Filename string
-	Enabled  bool
+	Buf            *arraylist.List[string]
+	Autosave       bool
+	Pos            int
+	Limit          int
+	Filename       string
+	Enabled        bool
+	Lock           sync.Mutex
+	FileDescriptor *os.File
 }
 
 func NewHistory() (*History, error) {
@@ -38,6 +41,9 @@ func NewHistory() (*History, error) {
 }
 
 func (h *History) Init() error {
+	h.Lock.Lock()
+	defer h.Lock.Unlock()
+
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return err
@@ -50,6 +56,10 @@ func (h *History) Init() error {
 
 	h.Filename = path
 
+	if err := h.closeLocked(); err != nil {
+		return err
+	}
+
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDONLY, 0o600)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -57,9 +67,16 @@ func (h *History) Init() error {
 		}
 		return err
 	}
-	defer f.Close()
+	h.FileDescriptor = f
 
-	r := bufio.NewReader(f)
+	h.Buf.Clear()
+	h.Pos = 0
+
+	if h.FileDescriptor == nil {
+		return nil
+	}
+
+	r := bufio.NewReader(h.FileDescriptor)
 	for {
 		line, err := r.ReadString('\n')
 		if err != nil {
@@ -74,22 +91,30 @@ func (h *History) Init() error {
 			continue
 		}
 
-		h.Add(line)
+		h.addLocked(line)
 	}
 
 	return nil
 }
 
 func (h *History) Add(s string) {
-	h.Buf.Add(s)
-	h.Compact()
-	h.Pos = h.Size()
+	h.Lock.Lock()
+	defer h.Lock.Unlock()
+
+	h.addLocked(s)
 	if h.Autosave {
-		_ = h.Save()
+		_ = h.saveLocked()
 	}
 }
 
 func (h *History) Compact() {
+	h.Lock.Lock()
+	defer h.Lock.Unlock()
+
+	h.compactLocked()
+}
+
+func (h *History) compactLocked() {
 	s := h.Buf.Size()
 	if s > h.Limit {
 		for range s - h.Limit {
@@ -99,10 +124,16 @@ func (h *History) Compact() {
 }
 
 func (h *History) Clear() {
+	h.Lock.Lock()
+	defer h.Lock.Unlock()
+
 	h.Buf.Clear()
 }
 
 func (h *History) Prev() (line string) {
+	h.Lock.Lock()
+	defer h.Lock.Unlock()
+
 	if h.Pos > 0 {
 		h.Pos -= 1
 	}
@@ -111,6 +142,9 @@ func (h *History) Prev() (line string) {
 }
 
 func (h *History) Next() (line string) {
+	h.Lock.Lock()
+	defer h.Lock.Unlock()
+
 	if h.Pos < h.Buf.Size() {
 		h.Pos += 1
 		line, _ = h.Buf.Get(h.Pos)
@@ -119,33 +153,90 @@ func (h *History) Next() (line string) {
 }
 
 func (h *History) Size() int {
+	h.Lock.Lock()
+	defer h.Lock.Unlock()
+
 	return h.Buf.Size()
 }
 
 func (h *History) Save() error {
+	h.Lock.Lock()
+	defer h.Lock.Unlock()
+
+	return h.saveLocked()
+}
+
+func (h *History) saveLocked() error {
 	if !h.Enabled {
 		return nil
+	}
+	if h.Filename == "" {
+		return errors.New("history filename not initialized")
 	}
 
 	tmpFile := h.Filename + ".tmp"
 
-	f, err := os.OpenFile(tmpFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC|os.O_APPEND, 0o600)
+	f, err := os.OpenFile(tmpFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
 		return err
 	}
-	defer f.Close()
 
 	buf := bufio.NewWriter(f)
-	for cnt := range h.Size() {
+	for cnt := range h.Buf.Size() {
 		line, _ := h.Buf.Get(cnt)
-		fmt.Fprintln(buf, line)
+		if _, err := fmt.Fprintln(buf, line); err != nil {
+			return errors.Join(err, closeFile(f))
+		}
 	}
-	buf.Flush()
-	f.Close()
+	if err := buf.Flush(); err != nil {
+		return errors.Join(err, closeFile(f))
+	}
+	if err := closeFile(f); err != nil {
+		return err
+	}
+
+	if err := h.closeLocked(); err != nil {
+		return err
+	}
 
 	if err = os.Rename(tmpFile, h.Filename); err != nil {
 		return err
 	}
 
+	h.FileDescriptor, err = os.OpenFile(h.Filename, os.O_RDONLY, 0o600)
+	if err != nil {
+		return err
+	}
+
 	return nil
+}
+
+func (h *History) addLocked(s string) {
+	h.Buf.Add(s)
+	h.compactLocked()
+	h.Pos = h.Buf.Size()
+}
+
+func (h *History) closeLocked() error {
+	if h.FileDescriptor == nil {
+		return nil
+	}
+
+	err := h.FileDescriptor.Close()
+	h.FileDescriptor = nil
+	return err
+}
+
+func (h *History) setEnabled(enabled bool) {
+	h.Lock.Lock()
+	defer h.Lock.Unlock()
+
+	h.Enabled = enabled
+}
+
+func closeFile(f *os.File) error {
+	if f == nil {
+		return nil
+	}
+	return f.Close()
 }

--- a/readline/readline.go
+++ b/readline/readline.go
@@ -341,11 +341,11 @@ func (i *Instance) Readline() (string, error) {
 }
 
 func (i *Instance) HistoryEnable() {
-	i.History.Enabled = true
+	i.History.setEnabled(true)
 }
 
 func (i *Instance) HistoryDisable() {
-	i.History.Enabled = false
+	i.History.setEnabled(false)
 }
 
 func (i *Instance) historyPrev(buf *Buffer, currentLineBuf *[]rune) {


### PR DESCRIPTION
Guard history state with a lock, track the history file handle, and check flush and close errors when saving.