### PR TITLE
model/parsers: treating failed parsing of tool calls as content for qwen models instead of aborting

### DIFF
--- a/model/parsers/qwen3.go
+++ b/model/parsers/qwen3.go
@@ -105,8 +105,11 @@ func (p *Qwen3Parser) Add(s string, done bool) (content string, thinking string,
 		case qwen3EventRawToolCall:
 			toolCall, err := parseQwen3ToolCall(event, p.tools)
 			if err != nil {
-				slog.Warn("qwen3 tool call parsing failed", "error", err)
-				return "", "", nil, err
+				slog.Warn("qwen3 tool call parsing failed, treating as content", "error", err)
+				contentSb.WriteString(toolOpenTag)
+				contentSb.WriteString(event.raw)
+				contentSb.WriteString(toolCloseTag)
+				continue
 			}
 			toolCall.Function.Index = p.callIndex
 			p.callIndex++

--- a/model/parsers/qwen35.go
+++ b/model/parsers/qwen35.go
@@ -92,8 +92,9 @@ func (p *Qwen35Parser) Add(s string, done bool) (content string, thinking string
 		case qwen35EventContent:
 			parsedContent, _, parsedCalls, err := p.toolParser.Add(event.content, done)
 			if err != nil {
-				slog.Warn("qwen3.5 tool call parsing failed", "error", err)
-				return "", "", nil, err
+				slog.Warn("qwen3.5 tool call parsing failed, treating as content", "error", err)
+				contentSb.WriteString(event.content)
+				continue
 			}
 			contentSb.WriteString(parsedContent)
 			calls = append(calls, parsedCalls...)

--- a/model/parsers/qwen3coder.go
+++ b/model/parsers/qwen3coder.go
@@ -61,8 +61,11 @@ func (p *Qwen3CoderParser) Add(s string, done bool) (content string, thinking st
 		case qwenEventRawToolCall:
 			toolCall, err := parseToolCall(event, p.tools)
 			if err != nil {
-				slog.Warn("qwen tool call parsing failed", "error", err)
-				return "", "", nil, err
+				slog.Warn("qwen tool call parsing failed, treating as content", "error", err)
+				sb.WriteString(toolOpenTag)
+				sb.WriteString(event.raw)
+				sb.WriteString(toolCloseTag)
+				continue
 			}
 			toolCall.Function.Index = p.callIndex
 			p.callIndex++

--- a/model/parsers/qwen3vl.go
+++ b/model/parsers/qwen3vl.go
@@ -77,8 +77,11 @@ func (p *Qwen3VLParser) Add(s string, done bool) (content string, thinking strin
 		case qwenEventRawToolCall:
 			toolCall, err := parseJSONToolCall(event, p.tools)
 			if err != nil {
-				slog.Warn("qwen tool call parsing failed", "error", err)
-				return "", "", nil, err
+				slog.Warn("qwen tool call parsing failed, treating as content", "error", err)
+				contentSb.WriteString(toolOpenTag)
+				contentSb.WriteString(event.raw)
+				contentSb.WriteString(toolCloseTag)
+				continue
 			}
 			calls = append(calls, toolCall)
 		case qwenEventThinkingContent:


### PR DESCRIPTION
## Summary

Fixes cases where Qwen models (in particular `qwen3-coder` and the `qwen3` / `qwen3vl` / `qwen3.5` variants) stream malformed or incomplete tool call output (e.g. broken XML-like tags).  
Previously, this caused errors like `"qwen tool call parsing failed"` and aborted the entire request, so the user received no response at all.  
With this change, unparseable tool calls are treated as regular text content so the request can complete and the user still sees the model output.

Related: [Issue #14834](https://github.com/ollama/ollama/issues/14834)

---

## Root Cause

- The Qwen parsers (`qwen3.go`, `qwen3vl.go`, `qwen3coder.go`, `qwen35.go`) attempted to strictly parse tool calls.
- When the model produced invalid or truncated tool call payloads (for example, incomplete XML inside a `<tool_call>` block), the parsing step failed (`xml.Unmarshal` or the tool parser) and `Add` returned an error.
- That error was propagated up to the caller and terminated the request, resulting in a `"qwen tool call parsing failed"` error with no usable response for the end user.

---

## Fix

- **Qwen3 / Qwen3VL / Qwen3Coder**
  - When parsing a tool call fails, the raw tool call block is emitted back as regular text content:
    - The original content between `<tool_call>` and `</tool_call>` is written back, wrapped with the same tags.
  - The parse error is logged as a warning but is no longer returned from `Add`, so the request is not aborted.

- **Qwen3.5**
  - When the underlying tool parser (`toolParser.Add`) fails while processing content, that segment is treated as plain content instead of failing the whole request.
  - Any tool calls extracted from that segment are discarded, but the user still receives the textual answer.
  - The error is still logged as a warning for debugging, without being propagated to the caller.

Valid tool calls continue to be parsed and emitted as before; only malformed tool calls are downgraded to plain content, which is safer and more robust for users.

---

## Test Plan

- **Unit tests for parsers**

  ```bash
  # Run only Qwen-related tests in the parser package
  go test ./model/parsers -run Qwen

  # Run the full parser package tests
  go test ./model/parsers