### PR TITLE
mlx: add multimodal pipeline infrastructure for vision and audio models

### DIFF
--- a/x/mlxrunner/client.go
+++ b/x/mlxrunner/client.go
@@ -106,7 +106,13 @@ func (c *Client) WaitUntilRunning(ctx context.Context) error {
 // completionRequest is a properly-tagged version of llm.CompletionRequest for JSON serialization.
 type completionRequest struct {
 	Prompt  string          `json:"prompt"`
+	Images  []imageData     `json:"images,omitempty"`
 	Options *completionOpts `json:"options,omitempty"`
+}
+
+type imageData struct {
+	Data []byte `json:"data"`
+	ID   int    `json:"id"`
 }
 
 type completionOpts struct {
@@ -155,6 +161,9 @@ func (c *Client) Close() error {
 func (c *Client) Completion(ctx context.Context, req llm.CompletionRequest, fn func(llm.CompletionResponse)) error {
 	creq := completionRequest{
 		Prompt: req.Prompt,
+	}
+	for _, img := range req.Images {
+		creq.Images = append(creq.Images, imageData{Data: img.Data, ID: img.ID})
 	}
 	if req.Options != nil {
 		creq.Options = &completionOpts{

--- a/x/mlxrunner/model/base/base.go
+++ b/x/mlxrunner/model/base/base.go
@@ -26,6 +26,66 @@ type Model interface {
 	LoadWeights(tensors map[string]*mlx.Array) error
 }
 
+// MultimodalModel extends Model with multimodal capabilities (vision, audio, etc.).
+//
+// Each model owns its full multimodal pipeline: decoding, preprocessing,
+// encoding, and embedding construction.
+//
+// The interface is modality-agnostic: EncodeMultimodal accepts raw bytes
+// (JPEG/PNG for images, WAV/PCM for audio, etc.) and the model determines
+// what to do based on its own configuration. For models that support
+// multiple modalities (e.g., models with both vision and audio), the
+// model can inspect the data format or use separate placeholder token IDs
+// to distinguish modalities.
+type MultimodalModel interface {
+	Model
+
+	// EncodeMultimodal decodes raw bytes (image, audio, etc.) and preprocesses
+	// them into a tensor ready for the model's encoder. The model inspects
+	// the data to determine its modality (e.g., JPEG magic bytes → image,
+	// WAV header → audio) and returns the appropriate placeholder token ID.
+	//
+	// Returns:
+	//   - data: preprocessed tensor ready for the model's encoder
+	//   - placeholderID: token ID to use as placeholder (e.g., image_token_id
+	//     or audio_token_id — each modality may use a different ID)
+	//   - numTokens: number of soft tokens this input will produce
+	//   - err: any error during decoding or preprocessing
+	EncodeMultimodal(data []byte) (EncodedMultimodal, error)
+
+	// Prefill runs multimodal encoding and the embedding-based forward pass
+	// for the prefill phase. The model handles embedding construction,
+	// soft token replacement, and any model-specific logic (e.g.,
+	// spatial position embeddings for vision, etc.).
+	//
+	// tokens: full remaining token sequence (after cache prefix removal).
+	// segments: describes where placeholder tokens are and their encoded data.
+	// caches: KV caches for each layer.
+	// chunkSize: maximum number of tokens to process per forward call.
+	// materializeCaches: callback to evaluate cache state between chunks.
+	//
+	// Returns the number of tokens processed (all but the last token).
+	Prefill(tokens []int32, segments []MultimodalSegment, caches []cache.Cache, chunkSize int, materializeCaches func()) (int, error)
+}
+
+// EncodedMultimodal is the result of preprocessing a single multimodal input.
+type EncodedMultimodal struct {
+	Data          *mlx.Array // preprocessed tensor ready for the encoder
+	PlaceholderID int32      // token ID to insert as placeholder (model-determined)
+	NumTokens     int        // number of soft tokens this input will produce
+	PrefixTokens  []int32    // tokens to insert before the placeholder run (e.g., begin-of-audio)
+	SuffixTokens  []int32    // tokens to insert after the placeholder run (e.g., end-of-audio)
+}
+
+// MultimodalSegment describes where a multimodal input's placeholder tokens
+// are in the token sequence and holds the preprocessed data for encoding.
+type MultimodalSegment struct {
+	Data      *mlx.Array // preprocessed tensor from EncodeMultimodal
+	ID        int        // input ID for logging
+	StartPos  int        // position in token sequence where placeholders begin
+	NumTokens int        // number of placeholder tokens
+}
+
 var (
 	mu       sync.Mutex
 	registry = make(map[string]func(root *model.Root) (Model, error))

--- a/x/mlxrunner/pipeline.go
+++ b/x/mlxrunner/pipeline.go
@@ -7,16 +7,21 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"regexp"
+	"strconv"
 	"time"
 
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/logutil"
 	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/mlxrunner/model/base"
 )
 
 func prefillChunkSize() int {
 	return 2 << 10
 }
+
+var imgTagRe = regexp.MustCompile(`\[img-(\d+)\]`)
 
 func (r *Runner) TextGenerationPipeline(request Request) error {
 	if r.Model == nil {
@@ -55,7 +60,25 @@ func (r *Runner) TextGenerationPipeline(request Request) error {
 		slog.Info("peak memory", "size", mlx.PrettyBytes(mlx.PeakMemory()))
 	}()
 
-	inputs := r.Tokenizer.Encode(request.Prompt, true)
+	// Check for multimodal model with images.
+	mmModel, isMultimodal := r.Model.(base.MultimodalModel)
+	hasImages := isMultimodal && len(request.Images) > 0
+
+	// Tokenize prompt. For multimodal models with images, parse [img-N]
+	// tags and build a token sequence with placeholder tokens.
+	var inputs []int32
+	var mmSegments []base.MultimodalSegment
+
+	if hasImages {
+		var err error
+		inputs, mmSegments, err = r.tokenizeWithImages(request.Prompt, request.Images, mmModel)
+		if err != nil {
+			return err
+		}
+	} else {
+		inputs = r.Tokenizer.Encode(request.Prompt, true)
+	}
+
 	if len(inputs) == 0 {
 		return errors.New("empty prompt")
 	}
@@ -67,7 +90,7 @@ func (r *Runner) TextGenerationPipeline(request Request) error {
 		}
 	}
 
-	// Cap generation to stay within the model's context length
+	// Cap generation to stay within the model's context length.
 	maxGenerate := r.contextLength - len(inputs)
 	if request.Options.MaxTokens <= 0 {
 		request.Options.MaxTokens = maxGenerate
@@ -96,6 +119,33 @@ func (r *Runner) TextGenerationPipeline(request Request) error {
 
 	now := time.Now()
 	total, processed := len(tokens), 0
+
+	if hasImages && len(mmSegments) > 0 {
+		// Check if remaining tokens contain any multimodal placeholders.
+		// If not, the KV cache already covers them from a prior turn
+		// and we can skip encoding entirely.
+		offset := len(inputs) - len(tokens)
+		adjustedSegments := make([]base.MultimodalSegment, 0, len(mmSegments))
+		for _, seg := range mmSegments {
+			if seg.StartPos >= offset && seg.StartPos+seg.NumTokens <= offset+len(tokens) {
+				adjusted := seg
+				adjusted.StartPos -= offset
+				adjustedSegments = append(adjustedSegments, adjusted)
+			}
+		}
+
+		if len(adjustedSegments) > 0 {
+			n, err := mmModel.Prefill(tokens, adjustedSegments, caches, prefillChunk, materializeCaches)
+			if err != nil {
+				return err
+			}
+			processed = n
+			slog.Info("Multimodal prefill complete", "processed", processed, "total", total, "segments", len(adjustedSegments))
+		} else {
+			slog.Info("Multimodal tokens cached from prior turn, skipping encoding")
+		}
+	}
+
 	for total-processed > 1 {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -177,6 +227,66 @@ func (r *Runner) TextGenerationPipeline(request Request) error {
 	case request.Responses <- final:
 		return nil
 	}
+}
+
+// tokenizeWithImages parses [img-N] tags from the prompt and builds a token
+// sequence with multimodal placeholder tokens at the right positions.
+// Preprocessing is delegated to the model via EncodeMultimodal.
+func (r *Runner) tokenizeWithImages(prompt string, images []imageData, vm base.MultimodalModel) ([]int32, []base.MultimodalSegment, error) {
+	// Split prompt on [img-N] tags.
+	parts := imgTagRe.Split(prompt, -1)
+	matches := imgTagRe.FindAllStringSubmatch(prompt, -1)
+
+	// Encode each input via the model's EncodeMultimodal. The model
+	// determines the modality from the data and returns the appropriate
+	// placeholder token ID (e.g., image_token_id vs audio_token_id).
+	encoded := make(map[int]base.EncodedMultimodal)
+
+	for _, img := range images {
+		enc, err := vm.EncodeMultimodal(img.Data)
+		if err != nil {
+			return nil, nil, fmt.Errorf("encode multimodal input %d: %w", img.ID, err)
+		}
+		encoded[img.ID] = enc
+		slog.Info("Multimodal input encoded", "id", img.ID, "tokens", enc.NumTokens)
+	}
+
+	// Build token sequence: tokenize text parts, insert placeholder runs.
+	var allTokens []int32
+	var segments []base.MultimodalSegment
+
+	for i, part := range parts {
+		if part != "" {
+			tokens := r.Tokenizer.Encode(part, i == 0)
+			allTokens = append(allTokens, tokens...)
+		} else if i == 0 {
+			tokens := r.Tokenizer.Encode("", true)
+			allTokens = append(allTokens, tokens...)
+		}
+
+		if i < len(matches) {
+			imgID, _ := strconv.Atoi(matches[i][1])
+			enc, ok := encoded[imgID]
+			if !ok {
+				return nil, nil, fmt.Errorf("multimodal input %d referenced in prompt but not provided", imgID)
+			}
+
+			allTokens = append(allTokens, enc.PrefixTokens...)
+			startPos := len(allTokens)
+			for range enc.NumTokens {
+				allTokens = append(allTokens, enc.PlaceholderID)
+			}
+			allTokens = append(allTokens, enc.SuffixTokens...)
+			segments = append(segments, base.MultimodalSegment{
+				Data:      enc.Data,
+				ID:        imgID,
+				StartPos:  startPos,
+				NumTokens: enc.NumTokens,
+			})
+		}
+	}
+
+	return allTokens, segments, nil
 }
 
 func (r Runner) Decode(sample int32, b *bytes.Buffer) string {

--- a/x/mlxrunner/runner.go
+++ b/x/mlxrunner/runner.go
@@ -29,7 +29,8 @@ type Request struct {
 }
 
 type TextCompletionsRequest struct {
-	Prompt  string `json:"prompt"`
+	Prompt  string      `json:"prompt"`
+	Images  []imageData `json:"images,omitempty"`
 	Options struct {
 		Temperature     float32 `json:"temperature"`
 		TopP            float32 `json:"top_p"`


### PR DESCRIPTION
Add a modality-agnostic multimodal framework to the MLX runner:
- MultimodalModel interface: extends Model with EncodeMultimodal() for preprocessing raw bytes (images, audio) and Prefill() for multimodal embedding construction and chunked forward passes.
- Pipeline support: parse [img-N] placeholder tags in prompts, route multimodal inputs through model-specific encoding, and handle multimodal prefill with KV cache awareness.
- Client plumbing: forward image/audio data from completion requests through to the runner pipeline.