### PR TITLE
launch: disable claude attribution header to preserve KV cache

### DIFF
--- a/cmd/launch/claude.go
+++ b/cmd/launch/claude.go
@@ -59,6 +59,7 @@ func (c *Claude) Run(model string, args []string) error {
 		"ANTHROPIC_BASE_URL="+envconfig.Host().String(),
 		"ANTHROPIC_API_KEY=",
 		"ANTHROPIC_AUTH_TOKEN=ollama",
+		"CLAUDE_CODE_ATTRIBUTION_HEADER=0",
 	)
 
 	env = append(env, c.modelEnvVars(model)...)


### PR DESCRIPTION
Claude Code sends an x-anthropic-billing-header that changes on every request. This is embedded in the system prompt and consequently breaks the KV cache for every request. Given the size of the prompts that Claude Code usees, this has significant performance impact.