### PR TITLE
server: prevent system sleep during active inference on Windows

### DIFF
--- a/server/sched.go
+++ b/server/sched.go
@@ -56,6 +56,7 @@ type Scheduler struct {
 	getGpuFn        func(ctx context.Context, runners []ml.FilteredRunnerDiscovery) []ml.DeviceInfo
 	getSystemInfoFn func() ml.SystemInfo
 	waitForRecovery time.Duration
+	sleepInhibitor  *sleepInhibitor
 }
 
 // Default automatic value for number of models we allow per GPU
@@ -79,6 +80,7 @@ func InitScheduler(ctx context.Context) *Scheduler {
 		waitForRecovery: 5 * time.Second,
 	}
 	sched.loadFn = sched.load
+	sched.sleepInhibitor = &sleepInhibitor{}
 	return sched
 }
 
@@ -129,7 +131,7 @@ func (s *Scheduler) GetRunner(c context.Context, m *Model, opts api.Options, ses
 	runner := s.loaded[key]
 	s.loadedMu.Unlock()
 	if runner != nil && !runner.needsReload(c, req) {
-		req.useLoadedRunner(runner, s.finishedReqCh)
+		req.useLoadedRunner(runner, s.finishedReqCh, s.sleepInhibitor)
 	} else {
 		select {
 		case s.pendingReqCh <- req:
@@ -189,7 +191,7 @@ func (s *Scheduler) processPending(ctx context.Context) {
 					} else {
 						// Runner is usable, return it
 						logutil.Trace("using existing loaded runner", "model", pendingKey)
-						pending.useLoadedRunner(runner, s.finishedReqCh)
+						pending.useLoadedRunner(runner, s.finishedReqCh, s.sleepInhibitor)
 						break
 					}
 				} else if maxRunners > 0 && loadedCount >= int(maxRunners) {
@@ -298,6 +300,7 @@ func (s *Scheduler) processCompleted(ctx context.Context) {
 			runner.refMu.Lock()
 			runner.refCount--
 			if runner.refCount <= 0 {
+				s.sleepInhibitor.AllowSleep()
 				if runner.sessionDuration <= 0 {
 					slog.Debug("runner with zero duration has gone idle, expiring to unload", "runner", runner)
 					if runner.expireTimer != nil {
@@ -387,9 +390,12 @@ func (s *Scheduler) processCompleted(ctx context.Context) {
 // Complete the pending request and send the runner back to the requester
 // Wires up a finished event after the request context is completed
 // Updates session duration, and resets expiration timer
-func (pending *LlmRequest) useLoadedRunner(runner *runnerRef, finished chan *LlmRequest) {
+func (pending *LlmRequest) useLoadedRunner(runner *runnerRef, finished chan *LlmRequest, si *sleepInhibitor) {
 	runner.refMu.Lock()
 	defer runner.refMu.Unlock()
+	if runner.refCount == 0 {
+		si.PreventSleep()
+	}
 	runner.refCount++
 	if runner.expireTimer != nil {
 		runner.expireTimer.Stop()
@@ -574,6 +580,7 @@ iGPUScan:
 		if runner.pid < 0 {
 			runner.pid = llama.Pid()
 		}
+		s.sleepInhibitor.PreventSleep()
 		runner.refCount++
 		runner.loading = false
 		go func() {
@@ -894,6 +901,7 @@ func (s *Scheduler) findRunnerToUnload() *runnerRef {
 }
 
 func (s *Scheduler) unloadAllRunners() {
+	s.sleepInhibitor.Close()
 	s.loadedMu.Lock()
 	defer s.loadedMu.Unlock()
 

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -655,7 +655,7 @@ func TestSchedUseLoadedRunner(t *testing.T) {
 	finished := make(chan *LlmRequest)
 	llm1 := &mockLlm{vramByGPU: map[ml.DeviceID]uint64{}}
 	r1 := &runnerRef{llama: llm1, sessionDuration: 1, numParallel: 1}
-	req.useLoadedRunner(r1, finished)
+	req.useLoadedRunner(r1, finished, &sleepInhibitor{})
 	require.Equal(t, uint(1), r1.refCount)
 	require.Equal(t, time.Duration(2), r1.sessionDuration)
 	select {

--- a/server/sleep_other.go
+++ b/server/sleep_other.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package server
+
+type sleepInhibitor struct{}
+
+func (si *sleepInhibitor) PreventSleep() {}
+func (si *sleepInhibitor) AllowSleep()   {}
+func (si *sleepInhibitor) Close()        {}

--- a/server/sleep_test.go
+++ b/server/sleep_test.go
@@ -1,0 +1,55 @@
+package server
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestSleepInhibitorRefCounting(t *testing.T) {
+	si := &sleepInhibitor{}
+
+	// First PreventSleep should transition 0→1
+	si.PreventSleep()
+	// Second PreventSleep should increment to 2
+	si.PreventSleep()
+
+	// First AllowSleep should decrement to 1 (still preventing)
+	si.AllowSleep()
+	// Second AllowSleep should transition 1→0 (allow sleep)
+	si.AllowSleep()
+
+	// Extra AllowSleep should be a no-op (not go negative)
+	si.AllowSleep()
+}
+
+func TestSleepInhibitorConcurrent(t *testing.T) {
+	si := &sleepInhibitor{}
+	var wg sync.WaitGroup
+
+	for range 100 {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			si.PreventSleep()
+		}()
+		go func() {
+			defer wg.Done()
+			si.AllowSleep()
+		}()
+	}
+
+	wg.Wait()
+	si.Close()
+}
+
+func TestSleepInhibitorClose(t *testing.T) {
+	si := &sleepInhibitor{}
+
+	// Close with active prevention should not panic
+	si.PreventSleep()
+	si.PreventSleep()
+	si.Close()
+
+	// Close when already closed should not panic
+	si.Close()
+}

--- a/server/sleep_windows.go
+++ b/server/sleep_windows.go
@@ -1,0 +1,72 @@
+package server
+
+import (
+	"log/slog"
+	"sync"
+	"syscall"
+)
+
+var (
+	kernel32                   = syscall.NewLazyDLL("kernel32.dll")
+	procSetThreadExecutionState = kernel32.NewProc("SetThreadExecutionState")
+)
+
+const (
+	esContinuous      = 0x80000000
+	esSystemRequired  = 0x00000001
+)
+
+type sleepInhibitor struct {
+	mu       sync.Mutex
+	refCount int
+}
+
+func (si *sleepInhibitor) PreventSleep() {
+	if si == nil {
+		return
+	}
+	si.mu.Lock()
+	defer si.mu.Unlock()
+	si.refCount++
+	if si.refCount == 1 {
+		r, _, _ := procSetThreadExecutionState.Call(uintptr(esContinuous | esSystemRequired))
+		if r == 0 {
+			slog.Warn("failed to prevent system sleep")
+		} else {
+			slog.Debug("system sleep prevented")
+		}
+	}
+}
+
+func (si *sleepInhibitor) AllowSleep() {
+	if si == nil {
+		return
+	}
+	si.mu.Lock()
+	defer si.mu.Unlock()
+	if si.refCount <= 0 {
+		return
+	}
+	si.refCount--
+	if si.refCount == 0 {
+		r, _, _ := procSetThreadExecutionState.Call(uintptr(esContinuous))
+		if r == 0 {
+			slog.Warn("failed to allow system sleep")
+		} else {
+			slog.Debug("system sleep allowed")
+		}
+	}
+}
+
+func (si *sleepInhibitor) Close() {
+	if si == nil {
+		return
+	}
+	si.mu.Lock()
+	defer si.mu.Unlock()
+	if si.refCount > 0 {
+		si.refCount = 0
+		procSetThreadExecutionState.Call(uintptr(esContinuous)) //nolint:errcheck
+		slog.Debug("system sleep allowed on close")
+	}
+}


### PR DESCRIPTION
On Windows, the system can enter sleep mode while Ollama is actively
processing inference requests, interrupting long-running generations.

Use SetThreadExecutionState to prevent sleep while runners are active.
A reference-counted sleepInhibitor is wired into the scheduler: sleep
is prevented when the first runner becomes active and allowed again
when all runners go idle. The Win32 API is only called on 0↔1
transitions, not on every request. Non-Windows platforms get a no-op
stub.

Fixes #4072