### PR TITLE
Add command-r tool call parser for Cohere models

### DIFF
--- a/model/parsers/commandr.go
+++ b/model/parsers/commandr.go
@@ -1,0 +1,266 @@
+package parsers
+
+import (
+	"encoding/json"
+	"log/slog"
+	"strings"
+
+	"github.com/ollama/ollama/api"
+)
+
+type commandRParserState int
+
+const (
+	commandRStateContent commandRParserState = iota
+	commandRStateToolCalls
+)
+
+const (
+	// Command-R outputs tool calls as: Action: ```json\n[...]\n```
+	commandRActionTag     = "Action:"
+	commandRJSONBlockOpen = "```json"
+	commandRJSONBlockEnd  = "```"
+)
+
+type CommandRParser struct {
+	state  commandRParserState
+	buffer strings.Builder
+}
+
+func (p *CommandRParser) HasToolSupport() bool {
+	return true
+}
+
+func (p *CommandRParser) HasThinkingSupport() bool {
+	return false
+}
+
+func (p *CommandRParser) Init(tools []api.Tool, lastMessage *api.Message, thinkValue *api.ThinkValue) []api.Tool {
+	p.state = commandRStateContent
+	return tools
+}
+
+func (p *CommandRParser) Add(s string, done bool) (content string, thinking string, calls []api.ToolCall, err error) {
+	p.buffer.WriteString(s)
+
+	if done {
+		bufStr := p.buffer.String()
+		p.buffer.Reset()
+		if p.state == commandRStateContent && len(bufStr) > 0 {
+			return bufStr, "", nil, nil
+		}
+		// If we were collecting tool calls but never found the closing tag,
+		// try to parse what we have
+		if p.state == commandRStateToolCalls && len(bufStr) > 0 {
+			if toolCalls, parseErr := parseCommandRToolCalls(bufStr); parseErr == nil && len(toolCalls) > 0 {
+				return "", "", toolCalls, nil
+			}
+			// Failed to parse as tool calls, return as content
+			return bufStr, "", nil, nil
+		}
+		return "", "", nil, nil
+	}
+
+	var allContent strings.Builder
+	var allCalls []api.ToolCall
+
+	for {
+		events, cont := p.eat()
+		for _, event := range events {
+			switch e := event.(type) {
+			case commandREventContent:
+				allContent.WriteString(e.content)
+			case commandREventToolCalls:
+				allCalls = append(allCalls, e.calls...)
+			}
+		}
+		if !cont {
+			break
+		}
+	}
+
+	return allContent.String(), "", allCalls, nil
+}
+
+type commandREvent interface {
+	isCommandREvent()
+}
+
+type commandREventContent struct {
+	content string
+}
+
+type commandREventToolCalls struct {
+	calls []api.ToolCall
+}
+
+func (commandREventContent) isCommandREvent()   {}
+func (commandREventToolCalls) isCommandREvent() {}
+
+func (p *CommandRParser) eat() ([]commandREvent, bool) {
+	var events []commandREvent
+	bufStr := p.buffer.String()
+	if bufStr == "" {
+		return events, false
+	}
+
+	switch p.state {
+	case commandRStateContent:
+		// Look for "Action:" which signals the start of tool calls
+		if idx := strings.Index(bufStr, commandRActionTag); idx != -1 {
+			content := strings.TrimRight(bufStr[:idx], " \t\n\r")
+			remaining := bufStr[idx+len(commandRActionTag):]
+
+			p.buffer.Reset()
+			p.buffer.WriteString(remaining)
+			p.state = commandRStateToolCalls
+
+			if len(content) > 0 {
+				events = append(events, commandREventContent{content: content})
+			}
+			return events, true
+		}
+
+		// Check for partial overlap with "Action:"
+		if overlapLen := overlap(bufStr, commandRActionTag); overlapLen > 0 {
+			unambiguous := bufStr[:len(bufStr)-overlapLen]
+			ambiguous := bufStr[len(bufStr)-overlapLen:]
+			p.buffer.Reset()
+			p.buffer.WriteString(ambiguous)
+			if len(unambiguous) > 0 {
+				events = append(events, commandREventContent{content: unambiguous})
+			}
+			return events, false
+		}
+
+		// Regular content
+		p.buffer.Reset()
+		if len(bufStr) > 0 {
+			events = append(events, commandREventContent{content: bufStr})
+		}
+		return events, false
+
+	case commandRStateToolCalls:
+		// We're after "Action:" — look for the closing ``` after ```json\n[...]\n```
+		// First, we need to find the opening ```json
+		jsonBlockStart := strings.Index(bufStr, commandRJSONBlockOpen)
+		if jsonBlockStart == -1 {
+			// Haven't found ```json yet, keep buffering
+			return events, false
+		}
+
+		// Find content after ```json
+		afterOpen := bufStr[jsonBlockStart+len(commandRJSONBlockOpen):]
+
+		// Find the closing ``` (but not the opening one)
+		// The closing ``` must come after newline or content
+		closeIdx := findClosingCodeFence(afterOpen)
+		if closeIdx == -1 {
+			// Haven't found closing ``` yet, keep buffering
+			return events, false
+		}
+
+		// Extract the JSON content between ```json and closing ```
+		jsonContent := strings.TrimSpace(afterOpen[:closeIdx])
+		remaining := afterOpen[closeIdx+len(commandRJSONBlockEnd):]
+
+		p.buffer.Reset()
+		p.buffer.WriteString(remaining)
+		p.state = commandRStateContent
+
+		toolCalls, err := parseCommandRToolCalls(jsonContent)
+		if err != nil {
+			slog.Warn("command-r tool call parsing failed", "error", err, "content", jsonContent)
+			// Return the raw content since we couldn't parse it
+			raw := bufStr[:jsonBlockStart+len(commandRJSONBlockOpen)+closeIdx+len(commandRJSONBlockEnd)]
+			events = append(events, commandREventContent{content: raw})
+		} else if len(toolCalls) > 0 {
+			events = append(events, commandREventToolCalls{calls: toolCalls})
+		}
+
+		return events, true
+	}
+
+	return events, false
+}
+
+// findClosingCodeFence finds the position of the closing ``` in content that
+// comes after a ```json opening. It skips the first character to avoid matching
+// immediately, and looks for ``` preceded by a newline or at the very end.
+func findClosingCodeFence(s string) int {
+	// The content after ```json typically starts with a newline.
+	// We need to find ``` that is NOT part of the opening.
+	// Search for \n``` or just ``` after some content.
+	searchStart := 0
+	for {
+		idx := strings.Index(s[searchStart:], commandRJSONBlockEnd)
+		if idx == -1 {
+			return -1
+		}
+		absIdx := searchStart + idx
+		// Make sure this isn't at position 0 (which would be empty content)
+		if absIdx > 0 {
+			return absIdx
+		}
+		searchStart = absIdx + 1
+		if searchStart >= len(s) {
+			return -1
+		}
+	}
+}
+
+// commandRToolCall represents the JSON structure command-r uses for tool calls
+type commandRToolCall struct {
+	ToolName   string         `json:"tool_name"`
+	Parameters map[string]any `json:"parameters"`
+}
+
+// parseCommandRToolCalls parses command-r's JSON tool call format:
+//
+//	[{"tool_name": "func_name", "parameters": {"arg1": "val1"}}]
+//
+// Also handles the single-object case without array wrapper.
+func parseCommandRToolCalls(jsonStr string) ([]api.ToolCall, error) {
+	jsonStr = strings.TrimSpace(jsonStr)
+	if jsonStr == "" {
+		return nil, nil
+	}
+
+	// Try parsing as array first (most common)
+	var calls []commandRToolCall
+	if err := json.Unmarshal([]byte(jsonStr), &calls); err != nil {
+		// Try parsing as single object
+		var single commandRToolCall
+		if err2 := json.Unmarshal([]byte(jsonStr), &single); err2 != nil {
+			return nil, err
+		}
+		calls = []commandRToolCall{single}
+	}
+
+	var toolCalls []api.ToolCall
+	for i, call := range calls {
+		if call.ToolName == "" && call.ToolName != "directly-answer" {
+			continue
+		}
+		// Skip the "directly-answer" pseudo-tool that command-r uses
+		// when it wants to respond without calling any tools
+		if call.ToolName == "directly-answer" {
+			continue
+		}
+
+		args := api.NewToolCallFunctionArguments()
+		for k, v := range call.Parameters {
+			args.Set(k, v)
+		}
+
+		toolCalls = append(toolCalls, api.ToolCall{
+			Function: api.ToolCallFunction{
+				Name:      call.ToolName,
+				Arguments: args,
+				Index:     i,
+			},
+		})
+	}
+
+	return toolCalls, nil
+}

--- a/model/parsers/commandr_test.go
+++ b/model/parsers/commandr_test.go
@@ -1,0 +1,214 @@
+package parsers
+
+import (
+	"testing"
+
+	"github.com/ollama/ollama/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommandRParser_SingleToolCall(t *testing.T) {
+	parser := &CommandRParser{}
+	parser.Init(nil, nil, nil)
+
+	// Simulate streaming: content comes in chunks
+	content, thinking, calls, err := parser.Add("Action: ```json\n", false)
+	require.NoError(t, err)
+	assert.Empty(t, content)
+	assert.Empty(t, thinking)
+	assert.Empty(t, calls)
+
+	content, thinking, calls, err = parser.Add(`[
+    {
+        "tool_name": "get_weather",
+        "parameters": {"location": "San Francisco", "unit": "celsius"}
+    }
+]`, false)
+	require.NoError(t, err)
+	assert.Empty(t, content)
+	assert.Empty(t, thinking)
+	assert.Empty(t, calls)
+
+	content, thinking, calls, err = parser.Add("\n```", false)
+	require.NoError(t, err)
+	assert.Empty(t, content)
+	assert.Empty(t, thinking)
+	require.Len(t, calls, 1)
+	assert.Equal(t, "get_weather", calls[0].Function.Name)
+
+	location, ok := calls[0].Function.Arguments.Get("location")
+	assert.True(t, ok)
+	assert.Equal(t, "San Francisco", location)
+
+	unit, ok := calls[0].Function.Arguments.Get("unit")
+	assert.True(t, ok)
+	assert.Equal(t, "celsius", unit)
+}
+
+func TestCommandRParser_MultipleToolCalls(t *testing.T) {
+	parser := &CommandRParser{}
+	parser.Init(nil, nil, nil)
+
+	input := `Action: ` + "```json\n" + `[
+    {
+        "tool_name": "get_weather",
+        "parameters": {"location": "New York"}
+    },
+    {
+        "tool_name": "get_time",
+        "parameters": {"timezone": "EST"}
+    }
+]` + "\n```"
+
+	content, thinking, calls, err := parser.Add(input, false)
+	require.NoError(t, err)
+	assert.Empty(t, content)
+	assert.Empty(t, thinking)
+	require.Len(t, calls, 2)
+	assert.Equal(t, "get_weather", calls[0].Function.Name)
+	assert.Equal(t, "get_time", calls[1].Function.Name)
+}
+
+func TestCommandRParser_DirectlyAnswer(t *testing.T) {
+	parser := &CommandRParser{}
+	parser.Init(nil, nil, nil)
+
+	// When command-r decides not to use tools, it outputs directly-answer
+	input := `Action: ` + "```json\n" + `[
+    {
+        "tool_name": "directly-answer",
+        "parameters": {}
+    }
+]` + "\n```"
+
+	_, thinking, calls, err := parser.Add(input, false)
+	require.NoError(t, err)
+	assert.Empty(t, thinking)
+	// directly-answer should be filtered out
+	assert.Empty(t, calls)
+}
+
+func TestCommandRParser_ContentBeforeAction(t *testing.T) {
+	parser := &CommandRParser{}
+	parser.Init(nil, nil, nil)
+
+	// Command-r sometimes outputs thinking text before the Action:
+	c, _, calls, err := parser.Add("I'll look up the weather for you.\n", false)
+	require.NoError(t, err)
+	assert.Equal(t, "I'll look up the weather for you.\n", c)
+	assert.Empty(t, calls)
+
+	c, _, calls, err = parser.Add("Action: ```json\n", false)
+	require.NoError(t, err)
+	assert.Empty(t, c)
+	assert.Empty(t, calls)
+
+	content, _, calls, err := parser.Add(`[{"tool_name": "get_weather", "parameters": {"location": "NYC"}}]`+"\n```", false)
+	require.NoError(t, err)
+	assert.Empty(t, content)
+	require.Len(t, calls, 1)
+	assert.Equal(t, "get_weather", calls[0].Function.Name)
+}
+
+func TestCommandRParser_PlainTextResponse(t *testing.T) {
+	parser := &CommandRParser{}
+	parser.Init(nil, nil, nil)
+
+	// When no tools are called, content should flow through
+	content, _, calls, err := parser.Add("Hello! How can I help you today?", false)
+	require.NoError(t, err)
+	assert.Equal(t, "Hello! How can I help you today?", content)
+	assert.Empty(t, calls)
+}
+
+func TestCommandRParser_StreamingTokenByToken(t *testing.T) {
+	parser := &CommandRParser{}
+	parser.Init(nil, nil, nil)
+
+	// Simulate token-by-token streaming like Ollama does
+	tokens := []string{
+		"Action", ":", " ```", "json", "\n",
+		"[\n    {\n", `        "tool_name": "bash",`, "\n",
+		`        "parameters": {"command": "ls -la"}`, "\n",
+		"    }\n]", "\n```",
+	}
+
+	var allContent string
+	var allCalls []api.ToolCall
+
+	for i, token := range tokens {
+		done := i == len(tokens)-1
+		content, _, calls, err := parser.Add(token, done && false)
+		require.NoError(t, err)
+		allContent += content
+		allCalls = append(allCalls, calls...)
+	}
+
+	assert.Empty(t, allContent)
+	require.Len(t, allCalls, 1)
+	assert.Equal(t, "bash", allCalls[0].Function.Name)
+	cmd, ok := allCalls[0].Function.Arguments.Get("command")
+	assert.True(t, ok)
+	assert.Equal(t, "ls -la", cmd)
+}
+
+func TestCommandRParser_DoneWithPendingToolCalls(t *testing.T) {
+	parser := &CommandRParser{}
+	parser.Init(nil, nil, nil)
+
+	// Simulate a case where the model output ends without closing ```
+	parser.Add("Action: ```json\n", false)
+	content, _, calls, err := parser.Add(`[{"tool_name": "bash", "parameters": {"command": "pwd"}}]`, true)
+	require.NoError(t, err)
+
+	// Should still parse the tool calls on done
+	if len(calls) > 0 {
+		assert.Equal(t, "bash", calls[0].Function.Name)
+	} else {
+		// Or return as content if parsing failed
+		assert.NotEmpty(t, content)
+	}
+}
+
+func TestCommandRParser_PartialActionTag(t *testing.T) {
+	parser := &CommandRParser{}
+	parser.Init(nil, nil, nil)
+
+	// Test partial overlap with "Action:"
+	content, _, calls, err := parser.Add("Here is my response. Act", false)
+	require.NoError(t, err)
+	// "Act" overlaps with "Action:" so it should be withheld
+	assert.Equal(t, "Here is my response. ", content)
+	assert.Empty(t, calls)
+
+	// Continue with non-matching text
+	content, _, calls, err = parser.Add("ually, let me think...", false)
+	require.NoError(t, err)
+	assert.Equal(t, "Actually, let me think...", content)
+	assert.Empty(t, calls)
+}
+
+func TestCommandRParser_SingleObject(t *testing.T) {
+	parser := &CommandRParser{}
+	parser.Init(nil, nil, nil)
+
+	// Some versions output single object without array wrapper
+	input := `Action: ` + "```json\n" + `{
+    "tool_name": "read_file",
+    "parameters": {"path": "/etc/hosts"}
+}` + "\n```"
+
+	content, _, calls, err := parser.Add(input, false)
+	require.NoError(t, err)
+	assert.Empty(t, content)
+	require.Len(t, calls, 1)
+	assert.Equal(t, "read_file", calls[0].Function.Name)
+}
+
+func TestParserForName_CommandR(t *testing.T) {
+	parser := ParserForName("command-r")
+	require.NotNil(t, parser)
+	assert.True(t, parser.HasToolSupport())
+	assert.False(t, parser.HasThinkingSupport())
+}

--- a/model/parsers/parsers.go
+++ b/model/parsers/parsers.go
@@ -83,6 +83,8 @@ func ParserForName(name string) Parser {
 		return &LFM2Parser{hasThinkingSupport: false}
 	case "lfm2-thinking":
 		return &LFM2Parser{hasThinkingSupport: true}
+	case "command-r":
+		return &CommandRParser{}
 	default:
 		return nil
 	}

--- a/server/routes.go
+++ b/server/routes.go
@@ -76,6 +76,13 @@ func writeModelRefParseError(c *gin.Context, err error, fallbackStatus int, fall
 	}
 }
 
+func shouldUseCommandR(model *Model) bool {
+	if model.Config.ModelFamily == "command-r" {
+		return true
+	}
+	return false
+}
+
 func shouldUseHarmony(model *Model) bool {
 	if slices.Contains([]string{"gptoss", "gpt-oss"}, model.Config.ModelFamily) {
 		// heuristic to check whether the template expects to be parsed via harmony:
@@ -376,6 +383,9 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 	var builtinParser parsers.Parser
 	if shouldUseHarmony(m) && m.Config.Parser == "" {
 		m.Config.Parser = "harmony"
+	}
+	if shouldUseCommandR(m) && m.Config.Parser == "" {
+		m.Config.Parser = "command-r"
 	}
 
 	if !req.Raw && m.Config.Parser != "" {
@@ -2298,6 +2308,9 @@ func (s *Server) ChatHandler(c *gin.Context) {
 
 	if shouldUseHarmony(m) && m.Config.Parser == "" {
 		m.Config.Parser = "harmony"
+	}
+	if shouldUseCommandR(m) && m.Config.Parser == "" {
+		m.Config.Parser = "command-r"
 	}
 
 	var builtinParser parsers.Parser


### PR DESCRIPTION
## Summary

- Command-R models output tool calls in Cohere's format: `Action: ```json [{"tool_name": "...", "parameters": {...}}]``` ` but the generic tool parser searches for literal function names in the output buffer. Since command-r wraps tool names in JSON (`"tool_name": "bash"`), the parser never finds a match and silently returns empty content.
- This adds a dedicated `CommandRParser` that correctly handles Cohere's tool call format, and auto-assigns it to models with `command-r` model family.

## Problem

When calling command-r via `/v1/chat/completions` with tools, the response comes back with `"content": ""` and no `tool_calls` field. The model generates ~31 tokens (the tool call output), but the generic parser in `tools/tools.go:findTool()` can't match tool names embedded in JSON strings. The output is silently discarded.

This affects all command-r variants accessed through the OpenAI-compatible API, breaking integration with tools like OpenCode, Continue, and other AI coding assistants.

## Changes

- **`model/parsers/commandr.go`**: New parser that handles Cohere's `Action:` + JSON code block format, parses `{"tool_name", "parameters"}` objects, filters `directly-answer` pseudo-tool, supports streaming
- **`model/parsers/commandr_test.go`**: 10 tests covering single/multiple tool calls, streaming, partial tags, directly-answer filtering, plain text passthrough
- **`model/parsers/parsers.go`**: Register `"command-r"` parser name
- **`server/routes.go`**: Auto-detect command-r models by model family and assign parser (same pattern as `shouldUseHarmony`)

## Test plan

- [x] All 10 new parser tests pass
- [x] All existing parser tests still pass
- [x] Server package compiles cleanly
- [ ] Manual test: `curl /v1/chat/completions` with command-r and tools returns populated `tool_calls`
- [ ] Manual test: command-r without tools still returns normal text content