### PR TITLE
feat: Add TencentOS Server to supported distributions in install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -403,7 +403,7 @@ fi
 
 if ! check_gpu nvidia-smi || [ -z "$(nvidia-smi | grep -o "CUDA Version: [0-9]*\.[0-9]*")" ]; then
     case $OS_NAME in
-        centos|rhel) install_cuda_driver_yum 'rhel' $(echo $OS_VERSION | cut -d '.' -f 1) ;;
+        centos|rhel|tencentos) install_cuda_driver_yum 'rhel' $(echo $OS_VERSION | cut -d '.' -f 1) ;;
         rocky) install_cuda_driver_yum 'rhel' $(echo $OS_VERSION | cut -c1) ;;
         fedora) [ $OS_VERSION -lt '39' ] && install_cuda_driver_yum $OS_NAME $OS_VERSION || install_cuda_driver_yum $OS_NAME '39';;
         amzn) install_cuda_driver_yum 'fedora' '37' ;;
@@ -417,7 +417,7 @@ if ! lsmod | grep -q nvidia || ! lsmod | grep -q nvidia_uvm; then
     KERNEL_RELEASE="$(uname -r)"
     case $OS_NAME in
         rocky) $SUDO $PACKAGE_MANAGER -y install kernel-devel kernel-headers ;;
-        centos|rhel|amzn) $SUDO $PACKAGE_MANAGER -y install kernel-devel-$KERNEL_RELEASE kernel-headers-$KERNEL_RELEASE ;;
+        centos|rhel|amzn|tencentos) $SUDO $PACKAGE_MANAGER -y install kernel-devel-$KERNEL_RELEASE kernel-headers-$KERNEL_RELEASE ;;
         fedora) $SUDO $PACKAGE_MANAGER -y install kernel-devel-$KERNEL_RELEASE ;;
         debian|ubuntu) $SUDO apt-get -y install linux-headers-$KERNEL_RELEASE ;;
         *) exit ;;


### PR DESCRIPTION
## Summary

The Ollama install script (`scripts/install.sh`) does not recognize TencentOS Server (`ID=tencentos`) in its CUDA driver installation logic. When a TencentOS user has an NVIDIA GPU, the script silently exits without installing CUDA drivers, leaving the GPU unusable for inference.

## Changes

Added `tencentos` to two `case` statements in `scripts/install.sh`:

1. **CUDA driver installation** (line ~405): `tencentos` is mapped to the `rhel` CUDA repository, same as `centos|rhel`, since TencentOS is fully RHEL-compatible.
2. **Kernel headers installation** (line ~419): `tencentos` is added alongside `centos|rhel|amzn` for installing `kernel-devel` and `kernel-headers`.

## TencentOS Server Info

- **OS Release**: `ID=tencentos`, `ID_LIKE="tencentos"`, `PLATFORM_ID="platform:el9"`
- **Package Manager**: dnf (yum compatible)
- **Ecosystem**: Fully RHEL/EL9 compatible
- **NVIDIA CUDA**: Uses the same RHEL CUDA repository
- **Note**: `/etc/redhat-release` is NOT present by default
- **Official site**: https://cloud.tencent.com/product/ts

## Testing

Verified on TencentOS Server V4.4 (x86_64) that:
- The install script correctly identifies TencentOS as a RHEL-family distribution
- CUDA driver repository is correctly configured using the RHEL path
- Kernel headers are installed with the correct version-specific packages
