### PR TITLE
fix: use fallback hostname when os.Hostname() fails

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -186,7 +186,10 @@ func signinURL() (string, error) {
 	}
 
 	encKey := base64.RawURLEncoding.EncodeToString([]byte(pubKey))
-	h, _ := os.Hostname()
+	h, err := os.Hostname()
+	if err != nil {
+		h = "unknown"
+	}
 	return fmt.Sprintf(signinURLStr, url.PathEscape(h), encKey), nil
 }
 


### PR DESCRIPTION
## Summary

Fixes #14956

The `signinURL()` function in `server/routes.go` was silently ignoring errors from `os.Hostname()`, which could result in an empty `name` parameter in the sign-in URL.

## Changes

- Capture the error from `os.Hostname()`
- Use `"unknown"` as a fallback when hostname cannot be determined
- This ensures the sign-in URL always has a valid name parameter

## Before

```go
h, _ := os.Hostname()
return fmt.Sprintf(signinURLStr, url.PathEscape(h), encKey), nil
// h could be empty string if os.Hostname() fails
```

## After

```go
h, err := os.Hostname()
if err != nil {
    h = "unknown"
}
return fmt.Sprintf(signinURLStr, url.PathEscape(h), encKey), nil
// h is always a valid string
```