### PR TITLE
docs: fix Linux uninstall command using sed instead of tr

### DIFF
--- a/docs/linux.mdx
+++ b/docs/linux.mdx
@@ -181,7 +181,7 @@ sudo rm /etc/systemd/system/ollama.service
 Remove ollama libraries from your lib directory (either `/usr/local/lib`, `/usr/lib`, or `/lib`):
 
 ```shell
-sudo rm -r $(which ollama | tr 'bin' 'lib')
+sudo rm -r $(which ollama | sed 's|/bin/|/lib/|')
 ```
 
 Remove the ollama binary from your bin directory (either `/usr/local/bin`, `/usr/bin`, or `/bin`):


### PR DESCRIPTION
## Problem

The Linux uninstall docs use  to replace the directory component of the ollama path. However,  performs character-by-character translation, so it replaces:
- b → l
- i → i (unchanged)
- n → b

This mangles paths like  → .

## Fix

Use  which correctly replaces the directory component of the path:
-  →  ✅
-  →  ✅