### PR TITLE
fix: close temp file on Import error paths

### DIFF
--- a/server/internal/cache/blob/cache.go
+++ b/server/internal/cache/blob/cache.go
@@ -224,6 +224,7 @@ func (c *DiskCache) Import(r io.Reader, size int64) (Digest, error) {
 		return Digest{}, err
 	}
 	defer os.Remove(f.Name())
+	defer f.Close()
 
 	// Copy the blob to a temporary file.
 	h := sha256.New()


### PR DESCRIPTION
## Summary

In `server/internal/cache/blob/cache.go`, `DiskCache.Import()` creates a temp file with `os.CreateTemp` but if `io.Copy` fails or the size check fails, the function returns the error without closing the file handle. The `defer os.Remove(f.Name())` attempts cleanup of the file on disk, but the fd itself leaks.

## Fix

Added `defer f.Close()` immediately after the `os.CreateTemp` call. This ensures the fd is closed on all exit paths. The explicit `f.Close()` on the happy path (line 244) becomes a harmless no-op since `*os.File.Close` is safe to call multiple times.

## How to reproduce

```go
// Pass a reader that fails partway through:
r := io.LimitReader(bytes.NewReader(data), len(data)/2)
cache.Import(iotest.ErrReader(r), int64(len(data)))
// The temp file fd is leaked because f is never closed on the io.Copy error path
```

## AI Disclosure

This bug was found using static analysis tooling with AI assistance (pattern matching for `os.CreateTemp` without `defer Close` on error paths). The one-line fix was verified by reading the surrounding code.