### PR TITLE
fix: use fallback hostname when os.Hostname() fails

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -186,7 +186,11 @@ func signinURL() (string, error) {
 	}
 
 	encKey := base64.RawURLEncoding.EncodeToString([]byte(pubKey))
-	h, _ := os.Hostname()
+	h, err := os.Hostname()
+	if err != nil {
+		slog.Warn("os.Hostname() failed, using fallback", "error", err)
+		h = "unknown"
+	}
 	return fmt.Sprintf(signinURLStr, url.PathEscape(h), encKey), nil
 }
 


### PR DESCRIPTION
## Summary

Fixes #14956

Per @guicybercode feedback on #14975, this version adds a warning log when the fallback triggers.

## Changes

- Capture the error from `os.Hostname()`
- Log a warning with `slog.Warn()` when hostname cannot be determined
- Use `"unknown"` as fallback value
- This allows operators to detect when `os.Hostname()` fails, which usually indicates a deeper system misconfiguration

## Example Log Output

```
WARN os.Hostname() failed, using fallback error="gethostname: hostname too long"
```