### PR TITLE
launch: fix openclaw --model override handling

### DIFF
--- a/cmd/launch/launch.go
+++ b/cmd/launch/launch.go
@@ -489,8 +489,17 @@ func (c *launcherClient) launchEditorIntegration(ctx context.Context, name strin
 			return err
 		}
 		models = selected
-	} else if err := c.ensureModelsReady(ctx, models); err != nil {
-		return err
+	} else {
+		readyModels := models
+		if req.ModelOverride != "" && len(models) > 0 {
+			// An explicit --model override moves the launch target to the front.
+			// Preserve any saved secondary models in config, but don't block the
+			// readiness check on them.
+			readyModels = models[:1]
+		}
+		if err := c.ensureModelsReady(ctx, readyModels); err != nil {
+			return err
+		}
 	}
 
 	if len(models) == 0 {

--- a/cmd/launch/launch_test.go
+++ b/cmd/launch/launch_test.go
@@ -931,6 +931,65 @@ func TestLaunchIntegration_OpenclawPreservesExistingModelList(t *testing.T) {
 	}
 }
 
+func TestLaunchIntegration_OpenclawModelOverrideOnlyEnsuresPrimary(t *testing.T) {
+	tmpDir := t.TempDir()
+	setLaunchTestHome(t, tmpDir)
+	withLauncherHooks(t)
+
+	binDir := t.TempDir()
+	writeFakeBinary(t, binDir, "openclaw")
+	t.Setenv("PATH", binDir)
+
+	editor := &launcherEditorRunner{}
+	withIntegrationOverride(t, "openclaw", editor)
+
+	if err := config.SaveIntegration("openclaw", []string{"qwen3.5:35b"}); err != nil {
+		t.Fatalf("failed to seed config: %v", err)
+	}
+
+	var showRequests []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/show":
+			var req apiShowRequest
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			showRequests = append(showRequests, req.Model)
+			if req.Model != "kimi-k2.5:cloud" {
+				t.Fatalf("unexpected show request for saved extra model %q", req.Model)
+			}
+			fmt.Fprint(w, `{"remote_model":"kimi-k2.5"}`)
+		case "/api/me":
+			fmt.Fprint(w, `{"name":"test-user"}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	t.Setenv("OLLAMA_HOST", srv.URL)
+
+	if err := LaunchIntegration(context.Background(), IntegrationLaunchRequest{
+		Name:          "openclaw",
+		ModelOverride: "kimi-k2.5:cloud",
+	}); err != nil {
+		t.Fatalf("LaunchIntegration returned error: %v", err)
+	}
+
+	if diff := compareStrings(showRequests, []string{"kimi-k2.5:cloud"}); diff != "" {
+		t.Fatalf("unexpected model readiness checks (-want +got):\n%s", diff)
+	}
+	if editor.ranModel != "kimi-k2.5:cloud" {
+		t.Fatalf("expected launch to use override model, got %q", editor.ranModel)
+	}
+
+	saved, err := config.LoadIntegration("openclaw")
+	if err != nil {
+		t.Fatalf("failed to reload saved config: %v", err)
+	}
+	if diff := compareStrings(saved.Models, []string{"kimi-k2.5:cloud", "qwen3.5:35b"}); diff != "" {
+		t.Fatalf("unexpected saved models (-want +got):\n%s", diff)
+	}
+}
+
 func TestLaunchIntegration_OpenclawInstallsBeforeConfigSideEffects(t *testing.T) {
 	tmpDir := t.TempDir()
 	setLaunchTestHome(t, tmpDir)

--- a/cmd/launch/openclaw.go
+++ b/cmd/launch/openclaw.go
@@ -545,13 +545,14 @@ func (c *Openclaw) Edit(models []string) error {
 
 	var newModels []any
 	for _, m := range models {
-		entry, _ := openclawModelConfig(context.Background(), client, m)
-		// Merge existing fields (user customizations)
+		entry, _, probed := openclawModelConfigWithProbe(context.Background(), client, m)
 		if existing, ok := existingByID[m]; ok {
-			for k, v := range existing {
-				if _, isNew := entry[k]; !isNew {
-					entry[k] = v
-				}
+			// If capability probing fails for a saved model, preserve the full
+			// existing entry instead of rewriting it with fallback defaults.
+			if !probed {
+				entry = preserveOpenclawModelEntry(existing, m)
+			} else {
+				mergeOpenclawModelEntry(entry, existing)
 			}
 		}
 		newModels = append(newModels, entry)
@@ -588,15 +589,50 @@ func (c *Openclaw) Edit(models []string) error {
 		return err
 	}
 
-	// Clear any per-session model overrides so the new primary takes effect
-	// immediately rather than being shadowed by a cached modelOverride.
-	clearSessionModelOverride(models[0])
+	// Clear any per-session model state so the new primary takes effect
+	// immediately rather than being shadowed by cached session data.
+	clearSessionModelState(models[0])
 	return nil
 }
 
-// clearSessionModelOverride removes per-session model overrides from the main
-// agent session so the global primary model takes effect on the next TUI launch.
-func clearSessionModelOverride(primary string) {
+func mergeOpenclawModelEntry(entry, existing map[string]any) {
+	for k, v := range existing {
+		if _, isNew := entry[k]; !isNew {
+			entry[k] = v
+		}
+	}
+}
+
+func preserveOpenclawModelEntry(existing map[string]any, modelID string) map[string]any {
+	entry := cloneOpenclawModelEntry(existing)
+	defaults := openclawDefaultModelEntry(modelID)
+	if id, _ := entry["id"].(string); id == "" {
+		entry["id"] = defaults["id"]
+	}
+	if name, _ := entry["name"].(string); name == "" {
+		entry["name"] = defaults["name"]
+	}
+	if _, ok := entry["input"]; !ok {
+		entry["input"] = defaults["input"]
+	}
+	if _, ok := entry["cost"]; !ok {
+		entry["cost"] = defaults["cost"]
+	}
+	return entry
+}
+
+func cloneOpenclawModelEntry(src map[string]any) map[string]any {
+	dst := make(map[string]any, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}
+
+// clearSessionModelState removes per-session model overrides and normalizes
+// cached runtime model fields on the main agent session so the global primary
+// model takes effect on the next TUI launch.
+func clearSessionModelState(primary string) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return
@@ -611,13 +647,39 @@ func clearSessionModelOverride(primary string) {
 		return
 	}
 	changed := false
+	const ollamaProviderName = "ollama"
 	for _, sess := range sessions {
-		if override, _ := sess["modelOverride"].(string); override != "" && override != primary {
+		if _, ok := sess["modelOverride"]; ok {
 			delete(sess, "modelOverride")
-			delete(sess, "providerOverride")
+			changed = true
 		}
-		if model, _ := sess["model"].(string); model != "" && model != primary {
+		if _, ok := sess["providerOverride"]; ok {
+			delete(sess, "providerOverride")
+			changed = true
+		}
+
+		model, _ := sess["model"].(string)
+		provider, hasProvider := sess["modelProvider"].(string)
+		_, hasProviderField := sess["modelProvider"]
+
+		switch {
+		case model == "":
+			if hasProviderField {
+				delete(sess, "modelProvider")
+				changed = true
+			}
+		case model != primary:
 			sess["model"] = primary
+			changed = true
+			if !hasProviderField || provider != ollamaProviderName {
+				sess["modelProvider"] = ollamaProviderName
+				changed = true
+			}
+		case hasProvider && provider == "":
+			delete(sess, "modelProvider")
+			changed = true
+		case hasProvider && provider != ollamaProviderName:
+			sess["modelProvider"] = ollamaProviderName
 			changed = true
 		}
 	}
@@ -810,7 +872,12 @@ func registerWebSearchPlugin() {
 // openclawModelConfig builds an OpenClaw model config entry with capability detection.
 // The second return value indicates whether the model is a cloud (remote) model.
 func openclawModelConfig(ctx context.Context, client *api.Client, modelID string) (map[string]any, bool) {
-	entry := map[string]any{
+	entry, isCloud, _ := openclawModelConfigWithProbe(ctx, client, modelID)
+	return entry, isCloud
+}
+
+func openclawDefaultModelEntry(modelID string) map[string]any {
+	return map[string]any{
 		"id":    modelID,
 		"name":  modelID,
 		"input": []any{"text"},
@@ -821,9 +888,13 @@ func openclawModelConfig(ctx context.Context, client *api.Client, modelID string
 			"cacheWrite": 0,
 		},
 	}
+}
+
+func openclawModelConfigWithProbe(ctx context.Context, client *api.Client, modelID string) (map[string]any, bool, bool) {
+	entry := openclawDefaultModelEntry(modelID)
 
 	if client == nil {
-		return entry, false
+		return entry, false, false
 	}
 
 	showCtx := ctx
@@ -835,7 +906,7 @@ func openclawModelConfig(ctx context.Context, client *api.Client, modelID string
 
 	resp, err := client.Show(showCtx, &api.ShowRequest{Model: modelID})
 	if err != nil {
-		return entry, false
+		return entry, false, false
 	}
 
 	// Set input types based on vision capability
@@ -855,7 +926,7 @@ func openclawModelConfig(ctx context.Context, client *api.Client, modelID string
 			entry["contextWindow"] = l.Context
 			entry["maxTokens"] = l.Output
 		}
-		return entry, true
+		return entry, true, true
 	}
 
 	// Extract context window from ModelInfo (local models only)
@@ -868,7 +939,7 @@ func openclawModelConfig(ctx context.Context, client *api.Client, modelID string
 		}
 	}
 
-	return entry, false
+	return entry, false, true
 }
 
 func (c *Openclaw) Models() []string {

--- a/cmd/launch/openclaw_test.go
+++ b/cmd/launch/openclaw_test.go
@@ -178,6 +178,102 @@ func TestOpenclawEdit(t *testing.T) {
 		}
 	})
 
+	t.Run("preserve existing saved secondary when capability probe fails", func(t *testing.T) {
+		cleanup()
+		os.MkdirAll(configDir, 0o755)
+		if err := os.WriteFile(configPath, []byte(`{
+			"models": {
+				"providers": {
+					"ollama": {
+						"models": [
+							{
+								"id": "stale-secondary",
+								"name": "stale-secondary",
+								"input": ["text", "image"],
+								"reasoning": true,
+								"contextWindow": 32768,
+								"maxTokens": 8192,
+								"cost": {"input": 12, "output": 34, "cacheRead": 56, "cacheWrite": 78},
+								"customField": "preserved"
+							}
+						]
+					}
+				}
+			},
+			"agents": {"defaults": {"model": {"primary": "ollama/stale-secondary"}}}
+		}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/api/show" {
+				http.NotFound(w, r)
+				return
+			}
+			var req api.ShowRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode show request: %v", err)
+			}
+			switch req.Model {
+			case "primary-model":
+				fmt.Fprint(w, `{"model_info":{"llama.context_length":4096}}`)
+			case "stale-secondary":
+				http.Error(w, "model not found", http.StatusNotFound)
+			default:
+				t.Fatalf("unexpected model probe for %q", req.Model)
+			}
+		}))
+		defer srv.Close()
+		t.Setenv("OLLAMA_HOST", srv.URL)
+
+		if err := c.Edit([]string{"primary-model", "stale-secondary"}); err != nil {
+			t.Fatal(err)
+		}
+
+		data, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var cfg map[string]any
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			t.Fatal(err)
+		}
+
+		models := cfg["models"].(map[string]any)
+		providers := models["providers"].(map[string]any)
+		ollama := providers["ollama"].(map[string]any)
+		modelList := ollama["models"].([]any)
+
+		var stale map[string]any
+		for _, model := range modelList {
+			entry, _ := model.(map[string]any)
+			if entry["id"] == "stale-secondary" {
+				stale = entry
+				break
+			}
+		}
+		if stale == nil {
+			t.Fatal("stale-secondary not found after edit")
+		}
+
+		input, ok := stale["input"].([]any)
+		if !ok || len(input) != 2 || input[0] != "text" || input[1] != "image" {
+			t.Fatalf("input = %v, want [text image]", stale["input"])
+		}
+		if stale["reasoning"] != true {
+			t.Fatalf("reasoning = %v, want true", stale["reasoning"])
+		}
+		if stale["contextWindow"] != float64(32768) {
+			t.Fatalf("contextWindow = %v, want 32768", stale["contextWindow"])
+		}
+		if stale["maxTokens"] != float64(8192) {
+			t.Fatalf("maxTokens = %v, want 8192", stale["maxTokens"])
+		}
+		if stale["customField"] != "preserved" {
+			t.Fatalf("customField = %v, want preserved", stale["customField"])
+		}
+	})
+
 	t.Run("edit replaces models list", func(t *testing.T) {
 		cleanup()
 		c.Edit([]string{"llama3.2", "mistral"})
@@ -1769,7 +1865,7 @@ func TestRegisterWebSearchPlugin(t *testing.T) {
 	})
 }
 
-func TestClearSessionModelOverride(t *testing.T) {
+func TestClearSessionModelState(t *testing.T) {
 	tmpDir := t.TempDir()
 	setTestHome(t, tmpDir)
 
@@ -1807,7 +1903,7 @@ func TestClearSessionModelOverride(t *testing.T) {
 		writeSessionsFile(t, map[string]map[string]any{
 			"sess1": {"model": "ollama/old-model", "modelOverride": "old-model", "providerOverride": "ollama"},
 		})
-		clearSessionModelOverride("new-model")
+		clearSessionModelState("new-model")
 		sessions := readSessionsFile(t)
 		sess := sessions["sess1"]
 		if _, ok := sess["modelOverride"]; ok {
@@ -1819,6 +1915,27 @@ func TestClearSessionModelOverride(t *testing.T) {
 		if sess["model"] != "new-model" {
 			t.Errorf("model = %q, want %q", sess["model"], "new-model")
 		}
+		if sess["modelProvider"] != "ollama" {
+			t.Errorf("modelProvider = %q, want %q", sess["modelProvider"], "ollama")
+		}
+	})
+
+	t.Run("clears override-only session even when override matches primary", func(t *testing.T) {
+		writeSessionsFile(t, map[string]map[string]any{
+			"sess1": {"modelOverride": "new-model", "providerOverride": "anthropic"},
+		})
+		clearSessionModelState("new-model")
+		sessions := readSessionsFile(t)
+		sess := sessions["sess1"]
+		if _, ok := sess["modelOverride"]; ok {
+			t.Error("modelOverride should have been deleted")
+		}
+		if _, ok := sess["providerOverride"]; ok {
+			t.Error("providerOverride should have been deleted")
+		}
+		if _, ok := sess["model"]; ok {
+			t.Error("model field should not have been added")
+		}
 	})
 
 	t.Run("updates model field in sessions without modelOverride", func(t *testing.T) {
@@ -1828,10 +1945,13 @@ func TestClearSessionModelOverride(t *testing.T) {
 		writeSessionsFile(t, map[string]map[string]any{
 			"sess1": {"model": "ollama/old-model"},
 		})
-		clearSessionModelOverride("new-model")
+		clearSessionModelState("new-model")
 		sessions := readSessionsFile(t)
 		if sessions["sess1"]["model"] != "new-model" {
 			t.Errorf("model = %q, want %q", sessions["sess1"]["model"], "new-model")
+		}
+		if sessions["sess1"]["modelProvider"] != "ollama" {
+			t.Errorf("modelProvider = %q, want %q", sessions["sess1"]["modelProvider"], "ollama")
 		}
 	})
 
@@ -1839,7 +1959,7 @@ func TestClearSessionModelOverride(t *testing.T) {
 		writeSessionsFile(t, map[string]map[string]any{
 			"sess1": {"model": "current-model"},
 		})
-		clearSessionModelOverride("current-model")
+		clearSessionModelState("current-model")
 		sessions := readSessionsFile(t)
 		if sessions["sess1"]["model"] != "current-model" {
 			t.Errorf("model = %q, want %q", sessions["sess1"]["model"], "current-model")
@@ -1850,10 +1970,35 @@ func TestClearSessionModelOverride(t *testing.T) {
 		writeSessionsFile(t, map[string]map[string]any{
 			"sess1": {"other": "data"},
 		})
-		clearSessionModelOverride("new-model")
+		clearSessionModelState("new-model")
 		sessions := readSessionsFile(t)
 		if _, ok := sessions["sess1"]["model"]; ok {
 			t.Error("model field should not have been added to session with no model")
+		}
+	})
+
+	t.Run("clears orphan runtime provider without model", func(t *testing.T) {
+		writeSessionsFile(t, map[string]map[string]any{
+			"sess1": {"modelProvider": "anthropic"},
+		})
+		clearSessionModelState("new-model")
+		sessions := readSessionsFile(t)
+		if _, ok := sessions["sess1"]["modelProvider"]; ok {
+			t.Error("modelProvider should have been deleted when no model is present")
+		}
+	})
+
+	t.Run("rewrites stale runtime provider when model already matches primary", func(t *testing.T) {
+		writeSessionsFile(t, map[string]map[string]any{
+			"sess1": {"modelProvider": "anthropic", "model": "new-model"},
+		})
+		clearSessionModelState("new-model")
+		sessions := readSessionsFile(t)
+		if sessions["sess1"]["model"] != "new-model" {
+			t.Errorf("model = %q, want %q", sessions["sess1"]["model"], "new-model")
+		}
+		if sessions["sess1"]["modelProvider"] != "ollama" {
+			t.Errorf("modelProvider = %q, want %q", sessions["sess1"]["modelProvider"], "ollama")
 		}
 	})
 
@@ -1864,7 +2009,7 @@ func TestClearSessionModelOverride(t *testing.T) {
 			"already-current":  {"model": "new-model"},
 			"no-model":         {"other": "data"},
 		})
-		clearSessionModelOverride("new-model")
+		clearSessionModelState("new-model")
 		sessions := readSessionsFile(t)
 
 		if sessions["with-override"]["model"] != "new-model" {
@@ -1886,6 +2031,6 @@ func TestClearSessionModelOverride(t *testing.T) {
 
 	t.Run("no-op when sessions file missing", func(t *testing.T) {
 		os.RemoveAll(sessionsDir)
-		clearSessionModelOverride("new-model") // should not panic or error
+		clearSessionModelState("new-model") // should not panic or error
 	})
 }


### PR DESCRIPTION
`ollama launch openclaw --model <model>` was still running readiness checks against saved secondary models, so an explicit launch like `--model kimi-k2.5:cloud` could still prompt to download `qwen3.5:35b`.

Only ensure the override model during launch while preserving saved secondary models in config. Also normalize cached OpenClaw session model state (`modelOverride` / `providerOverride` and runtime `model` / `modelProvider`) so the new primary model takes effect immediately instead of being shadowed by stale session data.

Fixes #14990.