### PR TITLE
ggml-metal: probe tensor support with Metal 4

### DIFF
--- a/ml/backend/ggml/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ml/backend/ggml/ggml/src/ggml-metal/ggml-metal-device.m
@@ -763,6 +763,58 @@ ggml_metal_device_t ggml_metal_device_init(void) {
                 }
             }
 
+            // MPP cooperative tensor matmul currently requires matching input types.
+            // Probe the mixed bfloat/f16 case explicitly so source-built binaries can
+            // disable tensor mode before compiling the full Metal library.
+            if (dev->props.has_tensor && dev->props.has_bfloat) {
+                const char * src_tensor_bf16_f16 = "\n"
+                    "#include <metal_stdlib> \n"
+                    "#include <metal_tensor> \n"
+                    "#include <MetalPerformancePrimitives/MetalPerformancePrimitives.h> \n"
+                    " \n"
+                    "using namespace metal; \n"
+                    "using namespace mpp::tensor_ops; \n"
+                    " \n"
+                    "kernel void dummy_kernel( \n"
+                    "    tensor<device bfloat, dextents<int32_t, 2>> A [[buffer(0)]], \n"
+                    "    tensor<device   half, dextents<int32_t, 2>> B [[buffer(1)]], \n"
+                    "    device float * C [[buffer(2)]], \n"
+                    "    uint2 tgid [[threadgroup_position_in_grid]]) \n"
+                    "{ \n"
+                    "    auto tA = A.slice(0, (int) tgid.y); \n"
+                    "    auto tB = B.slice((int) tgid.x, 0); \n"
+                    " \n"
+                    "    matmul2d< \n"
+                    "        matmul2d_descriptor(8, 8, dynamic_extent), \n"
+                    "        execution_simdgroups<4>> mm; \n"
+                    " \n"
+                    "    auto cT = mm.get_destination_cooperative_tensor<decltype(tA), decltype(tB), float>(); \n"
+                    " \n"
+                    "    auto sA = tA.slice(0, 0); \n"
+                    "    auto sB = tB.slice(0, 0); \n"
+                    "    mm.run(sB, sA, cT); \n"
+                    " \n"
+                    "    auto tC = tensor<device float, dextents<int32_t, 2>, tensor_inline>(C, dextents<int32_t, 2>(4, 4)); \n"
+                    " \n"
+                    "    cT.store(tC); \n"
+                    "}";
+
+                GGML_LOG_INFO("%s: testing tensor API for mixed bfloat/f16 support\n", __func__);
+                ggml_metal_library_t lib = ggml_metal_library_init_from_source(dev, src_tensor_bf16_f16, false);
+                if (lib == NULL) {
+                    GGML_LOG_WARN("%s: - the tensor API does not support mixed bfloat/f16 inputs - disabling\n", __func__);
+                    dev->props.has_tensor = false;
+                } else {
+                    struct ggml_metal_pipeline_with_params ppl = ggml_metal_library_compile_pipeline(lib, "dummy_kernel", "dummy_kernel", nil);
+                    if (!ppl.pipeline) {
+                        GGML_LOG_WARN("%s: - the tensor API does not support mixed bfloat/f16 inputs - disabling\n", __func__);
+                        dev->props.has_tensor = false;
+                    }
+
+                    ggml_metal_library_free(lib);
+                }
+            }
+
             dev->props.use_residency_sets = true;
 #if defined(GGML_METAL_HAS_RESIDENCY_SETS)
             dev->props.use_residency_sets = getenv("GGML_METAL_NO_RESIDENCY") == nil;


### PR DESCRIPTION
Metal source compilation defaults to an older language mode unless `MTLCompileOptions.languageVersion` is set. On Apple M5 systems, that causes the tensor support probes to fail even when the `f16` and `bfloat` tensor paths are valid.

Compile tensor probes as Metal 4 when tensor support is available, and keep the mixed `bfloat`/`half` probe that disables tensor mode before the full library is compiled on systems that reject that combination.

Tested on an Apple M5 Pro MacBook:
- `f16` tensor probe succeeds
- `bfloat` tensor probe succeeds
- mixed `bfloat`/`half` probe fails and disables tensor mode as expected
- `glm-4.7-flash` loads and responds successfully

Related: #14432
Related: #13460

Fixes #13867.
