### PR TITLE
fix: exit on critical sudo failures in install.sh

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -187,6 +187,12 @@ if [ -f /etc/nv_tegra_release ] ; then
 fi
 
 install_success() {
+    local exit_code=$?
+    trap - EXIT
+    if [ $exit_code -ne 0 ]; then
+        echo "${red}ERROR:${plain} Install failed. One or more critical steps did not complete successfully." >&2
+        exit $exit_code
+    fi
     status 'The Ollama API is now available at 127.0.0.1:11434.'
     status 'Install complete. Run "ollama" from the command line.'
 }
@@ -197,19 +203,19 @@ trap install_success EXIT
 configure_systemd() {
     if ! id ollama >/dev/null 2>&1; then
         status "Creating ollama user..."
-        $SUDO useradd -r -s /bin/false -U -m -d /usr/share/ollama ollama
+        $SUDO useradd -r -s /bin/false -U -m -d /usr/share/ollama ollama || error "Failed to create ollama user. Is sudo working?"
     fi
     if getent group render >/dev/null 2>&1; then
         status "Adding ollama user to render group..."
-        $SUDO usermod -a -G render ollama
+        $SUDO usermod -a -G render ollama || error "Failed to add ollama user to render group."
     fi
     if getent group video >/dev/null 2>&1; then
         status "Adding ollama user to video group..."
-        $SUDO usermod -a -G video ollama
+        $SUDO usermod -a -G video ollama || error "Failed to add ollama user to video group."
     fi
 
     status "Adding current user to ollama group..."
-    $SUDO usermod -a -G ollama $(whoami)
+    $SUDO usermod -a -G ollama $(whoami) || error "Failed to add current user to ollama group."
 
     status "Creating ollama systemd service..."
     cat <<EOF | $SUDO tee /etc/systemd/system/ollama.service >/dev/null
@@ -228,14 +234,26 @@ Environment="PATH=$PATH"
 [Install]
 WantedBy=default.target
 EOF
+    if [ $? -ne 0 ]; then
+        error "Failed to write systemd service file."
+    fi
     SYSTEMCTL_RUNNING="$(systemctl is-system-running || true)"
     case $SYSTEMCTL_RUNNING in
         running|degraded)
             status "Enabling and starting ollama service..."
-            $SUDO systemctl daemon-reload
-            $SUDO systemctl enable ollama
+            $SUDO systemctl daemon-reload || error "Failed to reload systemd daemon."
+            $SUDO systemctl enable ollama || error "Failed to enable ollama service."
 
-            start_service() { $SUDO systemctl restart ollama; }
+            start_service() {
+                local exit_code=$?
+                trap - EXIT
+                if [ $exit_code -ne 0 ]; then
+                    echo "${red}ERROR:${plain} Install failed. One or more critical steps did not complete successfully." >&2
+                    exit $exit_code
+                fi
+                $SUDO systemctl restart ollama || error "Failed to start ollama service."
+                install_success
+            }
             trap start_service EXIT
             ;;
         *)


### PR DESCRIPTION
## Summary

- Fixes the `install.sh` script silently reporting "Install complete" even when critical `sudo` commands fail (e.g., sudo timeout, wrong password)
- Adds explicit `|| error "..."` checks after each critical sudo command in `configure_systemd()`: `useradd`, `usermod`, `tee` (service file), `systemctl daemon-reload`, `systemctl enable`, and `systemctl restart`
- Makes the `install_success` EXIT trap check the exit code (`$?`) so it does not print a false success message when the script exits due to a prior failure

Fixes #14998

## Test plan

- [ ] Run `install.sh` normally on a Linux system with systemd — verify it completes successfully and prints "Install complete"
- [ ] Run `install.sh` and let the sudo password prompt time out — verify the script exits with an error message instead of "Install complete"
- [ ] Run `install.sh` on a system without systemd — verify it still works (the `configure_systemd` path is skipped)
- [ ] Run `sh -n scripts/install.sh` to confirm no syntax errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)