### PR TITLE
docs: fix Linux uninstall command that mangles paths with tr

### DIFF
--- a/docs/linux.mdx
+++ b/docs/linux.mdx
@@ -181,7 +181,7 @@ sudo rm /etc/systemd/system/ollama.service
 Remove ollama libraries from your lib directory (either `/usr/local/lib`, `/usr/lib`, or `/lib`):
 
 ```shell
-sudo rm -r $(which ollama | tr 'bin' 'lib')
+sudo rm -r $(which ollama | sed 's|/bin/|/lib/|')
 ```
 
 Remove the ollama binary from your bin directory (either `/usr/local/bin`, `/usr/bin`, or `/bin`):


### PR DESCRIPTION
Fixes #14931

## Problem
The current Linux uninstall docs use `tr 'bin' 'lib'` to convert the binary path to the library path. However, `tr` performs **character-by-character** translation:
- b → l
- i → b
- n → i

This means paths like `/usr/local/bin/ollama` get mangled to `/usr/local/lbl/ollama`, which is completely wrong and could cause unexpected `rm -r` behavior.

## Fix
Replace `tr 'bin' 'lib'` with `sed 's|/bin/|/lib/|'` which performs proper string substitution of the `/bin/` directory component with `/\lib/`.