### PR TITLE
docs: fix Linux uninstall command using sed instead of tr

### DIFF
--- a/docs/linux.mdx
+++ b/docs/linux.mdx
@@ -181,7 +181,7 @@ sudo rm /etc/systemd/system/ollama.service
 Remove ollama libraries from your lib directory (either `/usr/local/lib`, `/usr/lib`, or `/lib`):
 
 ```shell
-sudo rm -r $(which ollama | tr 'bin' 'lib')
+sudo rm -r $(which ollama | sed 's|bin|lib|')
 ```
 
 Remove the ollama binary from your bin directory (either `/usr/local/bin`, `/usr/bin`, or `/bin`):


### PR DESCRIPTION
## Problem

The Linux uninstall command in docs uses `tr 'bin' 'lib'` which performs character-by-character translation, not string replacement.

`tr` maps: b→l, i→i, n→g

So `/usr/local/bin/ollama` becomes `/usr/local/lig/ollama` — a nonsensical path.

## Fix

Replace `tr 'bin' 'lib'` with `sed 's|bin|lib|'` which correctly substitutes the string "bin" with "lib".

## Example

Before: `which ollama | tr 'bin' 'lib'` → `/sbap/lig/ollama` (snap) or `/usr/local/lig/ollama`
After: `which ollama | sed 's|bin|lib|'` → `/snap/lib/ollama` or `/usr/local/lib/ollama`

Fixes #14931