### PR TITLE
model/parsers: fall back to content when qwen tool call XML parse fails

### DIFF
--- a/model/parsers/qwen35_test.go
+++ b/model/parsers/qwen35_test.go
@@ -380,3 +380,35 @@ func TestQwen35ParserThinkingTruncatedWithoutCloseTag(t *testing.T) {
 		t.Fatalf("expected no tool calls, got %d", len(calls))
 	}
 }
+
+func TestQwen35ParserToolCallAsPlainTextFallback(t *testing.T) {
+	// When a user prompt asks the model to emit <tool_call> XML as plain text
+	// (without registering native Ollama tools), the parser must not return an
+	// error. Instead it should surface the unparseable content as regular text
+	// so the server returns HTTP 200 instead of HTTP 500.
+	parser := ParserForName("qwen3.5")
+	if parser == nil {
+		t.Fatal("expected qwen3.5 parser")
+	}
+
+	// Initialise with no tools – matches the /api/generate code path.
+	parser.Init(nil, nil, &api.ThinkValue{Value: false})
+
+	// Malformed tool call that cannot be parsed as valid XML (mirrors the
+	// user-reported reproduction case from issue #14986).
+	input := "<tool_call>{\"name\": \"get_weather\", \"parameters\": {\"location\": \"Shanghai\"}}</tool_call>"
+	content, thinking, calls, err := parser.Add(input, true)
+	if err != nil {
+		t.Fatalf("expected no error for unparseable tool call, got: %v", err)
+	}
+	if thinking != "" {
+		t.Fatalf("expected no thinking, got %q", thinking)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("expected no tool calls, got %d", len(calls))
+	}
+	// The raw text (including the wrapping tags) must be returned as content.
+	if content == "" {
+		t.Fatalf("expected non-empty content fallback, got empty string")
+	}
+}

--- a/model/parsers/qwen3coder.go
+++ b/model/parsers/qwen3coder.go
@@ -61,8 +61,16 @@ func (p *Qwen3CoderParser) Add(s string, done bool) (content string, thinking st
 		case qwenEventRawToolCall:
 			toolCall, err := parseToolCall(event, p.tools)
 			if err != nil {
-				slog.Warn("qwen tool call parsing failed", "error", err)
-				return "", "", nil, err
+				// The model emitted something that looks like a tool call but
+				// could not be parsed (e.g. malformed XML, or a user prompt that
+				// contained <tool_call> tags as plain text). Fall back to
+				// treating it as regular content so the server can return a
+				// usable response instead of an HTTP 500 error.
+				slog.Warn("qwen tool call parsing failed, returning as content", "error", err)
+				sb.WriteString(toolOpenTag)
+				sb.WriteString(event.raw)
+				sb.WriteString(toolCloseTag)
+				break
 			}
 			toolCall.Function.Index = p.callIndex
 			p.callIndex++

--- a/model/parsers/qwen3coder.go
+++ b/model/parsers/qwen3coder.go
@@ -66,6 +66,14 @@ func (p *Qwen3CoderParser) Add(s string, done bool) (content string, thinking st
 				// contained <tool_call> tags as plain text). Fall back to
 				// treating it as regular content so the server can return a
 				// usable response instead of an HTTP 500 error.
+				//
+				// This fallback is intentional and also covers markup that is
+				// structurally valid XML but unusable as a tool call here (for
+				// example when it references a tool that was never registered).
+				// In those cases the assistant text will contain the literal
+				// <tool_call>...</tool_call> markup, mirroring exactly what the
+				// model produced; clients must not treat that substring as a
+				// parsed tool call.
 				slog.Warn("qwen tool call parsing failed, returning as content", "error", err)
 				sb.WriteString(toolOpenTag)
 				sb.WriteString(event.raw)


### PR DESCRIPTION
## Summary

Fixes #14986

## Root Cause

The Qwen3.5 model always has a builtin parser registered (`qwen3.5`). When a user prompt instructs the model to emit `<tool_call>...</tool_call>`-style XML as plain text — without registering native Ollama tools — the `Qwen3CoderParser` still scans for those delimiters in the model output, finds them, and calls `parseToolCall()`.

If the content between the tags is not valid Qwen3-coder XML (e.g. a JSON payload such as `{"name": "get_weather", ...}`), `xml.Unmarshal` returns an error (typically `EOF`). That error propagated all the way up to `GenerateHandler` / `ChatHandler`, which sent `{"error":"EOF"}` and returned HTTP 500.

## Fix

In `Qwen3CoderParser.Add()`, when `parseToolCall` fails:
- **Before:** return the error immediately  
- **After:** log a warning and write the raw tool-call text (including the wrapping tags) into the content `strings.Builder`, then `break`

This means the caller always receives a usable HTTP 200 response with the raw model output instead of an internal server error.

**Safety:** when real tools are registered and the model produces well-formed Qwen3-coder XML, `parseToolCall` succeeds and the existing path is taken unchanged.

## Changes

- `model/parsers/qwen3coder.go`: on parse failure, fall back to content instead of returning an error
- `model/parsers/qwen35_test.go`: add regression test that initialises the parser with no tools (matching the `/api/generate` code path) and feeds it a JSON-style `<tool_call>` block — expects no error and non-empty content

## Testing

New test: `TestQwen35ParserToolCallAsPlainTextFallback`

---

**CLA Confirmation:** I have read, understood, and agree to the Ollama Contributor License Agreement (CLA). I understand that this contribution may be used under the terms of the MIT license.