### PR TITLE
fix: preserve partial download files during PruneLayers

### DIFF
--- a/server/images.go
+++ b/server/images.go
@@ -457,12 +457,17 @@ func PruneLayers() error {
 
 	for _, blob := range blobs {
 		name := blob.Name()
+
+		if strings.Contains(name, "-partial") {
+			continue
+		}
+
 		name = strings.ReplaceAll(name, "-", ":")
 
 		_, err := manifest.BlobsPath(name)
 		if err != nil {
 			if errors.Is(err, manifest.ErrInvalidDigestFormat) {
-				// remove invalid blobs (e.g. partial downloads)
+				// remove invalid blobs that are not partial downloads
 				if err := os.Remove(filepath.Join(p, blob.Name())); err != nil {
 					slog.Error("couldn't remove blob", "blob", blob.Name(), "error", err)
 				}


### PR DESCRIPTION
## Problem
When pulling a large model on an unstable connection (e.g. a mobile hotspot), downloads would always restart from 0% after a server restart instead of resuming from where they left off. This was extremely frustrating — a 4GB model interrupted at 80% would have to start over completely after reconnecting.
## Root Cause
`PruneLayers` runs on every server startup to clean up orphaned blobs. It identifies "invalid" files by replacing `-` with `:` in filenames and checking against the sha256 digest regex `^sha256[:-][0-9a-fA-F]{64}$`.
In-progress partial download files are named:
- `sha256-<digest>-partial` — the raw bytes being written
- `sha256-<digest>-partial-0`, `-partial-1`, ... — JSON metadata tracking progress per part
After the `-` → `:` substitution, these become `sha256:<digest>:partial` and `sha256:<digest>:partial:0`, which fail the regex. The code even had a comment acknowledging this: `// remove invalid blobs (e.g. partial downloads)` — but that was the wrong behaviour. These files are intentionally left on disk by `run()` so that `Prepare()` can restore progress on the next pull attempt.
The result: every server restart wiped all partial download state, making the resume mechanism in `download_types.go` completely ineffective in practice.
## Fix
Skip files containing `-partial` in `PruneLayers`. They are cleaned up naturally by `run()` upon successful download completion (metadata files are deleted, the data file is renamed to the final digest path). If a download never completes, the files remain available for `Prepare()` to resume from on the next `ollama pull`.
