### PR TITLE
fix: preserve partial chunk progress before returning fatal download errors

### DIFF
--- a/server/download.go
+++ b/server/download.go
@@ -343,14 +343,15 @@ func (b *blobDownload) downloadChunk(ctx context.Context, requestURL *url.URL, w
 		defer resp.Body.Close()
 
 		n, err := io.CopyN(w, io.TeeReader(resp.Body, part), part.Size-part.Completed.Load())
-		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, io.ErrUnexpectedEOF) {
-			// rollback progress
-			b.Completed.Add(-n)
-			return err
-		}
 
 		part.Completed.Add(n)
 		if err := b.writePart(part.Name(), part); err != nil {
+			return err
+		}
+
+		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, io.ErrUnexpectedEOF) {
+			// rollback progress
+			b.Completed.Add(-n)
 			return err
 		}
 


### PR DESCRIPTION
## Problem

When `downloadChunk` encountered a fatal error (e.g. unexpected network failure), it rolled back `b.Completed` and returned immediately without saving the bytes already received to the part file. On the next retry, the chunk would restart from the beginning, wasting bandwidth — particularly costly for large model files.

## Fix

Move `part.Completed.Add(n)` and `writePart` before the fatal error check so partial progress is always flushed to disk first. The `b.Completed` rollback is kept for fatal errors to maintain an accurate global progress counter, but the chunk bytes are no longer discarded.