### PR TITLE
fix: close sqlite connection on app shutdown to prevent memory leak

### DIFF
--- a/app/cmd/app/app.go
+++ b/app/cmd/app/app.go
@@ -357,6 +357,10 @@ func main() {
 	slog.Info("shutting down ollama server")
 	cancel()
 	<-done
+
+	if err := appStore.Close(); err != nil {
+		slog.Warn("error closing app store", "error", err)
+	}
 }
 
 func startHiddenTasks() {


### PR DESCRIPTION
When the Ollama desktop app shuts down, the sqlite database connection was never closed, causing WAL journal files and deleted data pages to not be reclaimed, leading to db.sqlite file size bloat on Windows (ollama/ollama#15021). This fix adds appStore.Close() to the shutdown sequence after the ollama server goroutine exits, ensuring WAL checkpoint runs and the connection is properly closed.