### PR TITLE
fix(macos): prevent fullscreen Space affinity from persisting after close

### DIFF
--- a/app/cmd/app/app_darwin.m
+++ b/app/cmd/app/app_darwin.m
@@ -1075,6 +1075,12 @@ void styleWindow(uintptr_t wndPtr) {
         w.styleMask = desiredStyleMask;
     }
 
+    // Prevent the window from being assigned to a fullscreen Space automatically.
+    // Without this, closing the window while in a fullscreen Space causes macOS
+    // to remember that affinity, so the next open lands in that Space instead
+    // of the currently active Space.
+    w.collectionBehavior = NSWindowCollectionBehaviorFullScreenAuxiliary | NSWindowCollectionBehaviorTransient;
+
     if (w.toolbar == nil) {
         NSToolbar *tb = [[NSToolbar alloc] initWithIdentifier:@"OllamaToolbar"];
         tb.displayMode            = NSToolbarDisplayModeIconOnly;


### PR DESCRIPTION
When the Ollama window is closed while in a fullscreen Space, macOS remembers that Space affinity and re-opens the window in that Space instead of the currently active Space.

**Root cause:** The window's `collectionBehavior` was never set, so macOS assigned it fullscreen Space affinity by default. When the window was closed and reopened, macOS tried to restore it to that Space.

**Fix:** Set `NSWindowCollectionBehaviorFullScreenAuxiliary` on the window in `styleWindow()` in `app_darwin.m`. Auxiliary fullscreen windows are not automatically moved to a fullscreen Space. Also include `NSWindowCollectionBehaviorTransient` to prevent persistence in Spaces preferences.

Fixes #15002