### PR TITLE
fix: forward think:true to deepseek-r1 via /v1/chat/completions

### DIFF
--- a/openai/openai.go
+++ b/openai/openai.go
@@ -111,6 +111,7 @@ type ChatCompletionRequest struct {
 	Tools            []api.Tool      `json:"tools"`
 	Reasoning        *Reasoning      `json:"reasoning,omitempty"`
 	ReasoningEffort  *string         `json:"reasoning_effort,omitempty"`
+	Think            *bool           `json:"think,omitempty"`
 	Logprobs         *bool           `json:"logprobs"`
 	TopLogprobs      int             `json:"top_logprobs"`
 	DebugRenderOnly  bool            `json:"_debug_render_only"`
@@ -611,21 +612,25 @@ func FromChatRequest(r ChatCompletionRequest) (*api.ChatRequest, error) {
 	var think *api.ThinkValue
 	var effort string
 
-	if r.Reasoning != nil {
-		effort = r.Reasoning.Effort
-	} else if r.ReasoningEffort != nil {
-		effort = *r.ReasoningEffort
-	}
-
-	if effort != "" {
-		if !slices.Contains([]string{"high", "medium", "low", "none"}, effort) {
-			return nil, fmt.Errorf("invalid reasoning value: '%s' (must be \"high\", \"medium\", \"low\", or \"none\")", effort)
+	if r.Think != nil {
+		think = &api.ThinkValue{Value: *r.Think}
+	} else {
+		if r.Reasoning != nil {
+			effort = r.Reasoning.Effort
+		} else if r.ReasoningEffort != nil {
+			effort = *r.ReasoningEffort
 		}
 
-		if effort == "none" {
-			think = &api.ThinkValue{Value: false}
-		} else {
-			think = &api.ThinkValue{Value: effort}
+		if effort != "" {
+			if !slices.Contains([]string{"high", "medium", "low", "none"}, effort) {
+				return nil, fmt.Errorf("invalid reasoning value: '%s' (must be \"high\", \"medium\", \"low\", or \"none\")", effort)
+			}
+
+			if effort == "none" {
+				think = &api.ThinkValue{Value: false}
+			} else {
+				think = &api.ThinkValue{Value: effort}
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description

When a client sends `think:true` (boolean) via `/v1/chat/completions`, the value was silently ignored because `ChatCompletionRequest` had no field to capture it and `toApiChatRequest` only handled `reasoning_effort` (string effort values). This breaks deepseek-r1 which requires `think=true` to produce output.

## Root Cause

In `openai/openai.go`, the `ChatCompletionRequest` struct lacked a `Think *bool` field, and the `toApiChatRequest` function only processed `reasoning` (effort string). The `think` parameter from the OpenAI API was being dropped.

## Fix

1. Added `Think *bool `json:"think,omitempty"` field to `ChatCompletionRequest`
2. Updated `toApiChatRequest` to forward the boolean `think` value to the internal `api.ChatRequest` when present, before falling back to the `reasoning_effort` logic

This mirrors how the native Ollama API handles `think` as a boolean (see `api.ChatRequest` and `api.ThinkValue`).

## Testing

- `think:true` is now forwarded to deepseek-r1 via the `/v1/chat/completions` endpoint
- Existing `reasoning_effort` logic is preserved as a fallback

Fixes ollama/ollama#15029