### PR TITLE
fix(macos): prevent fullscreen Space affinity from persisting after close

### DIFF
--- a/app/webview/webview.h
+++ b/app/webview/webview.h
@@ -1575,6 +1575,11 @@ enum NSWindowStyleMask : NSUInteger {
   NSWindowStyleMaskResizable = 8
 };
 
+enum NSWindowCollectionBehavior : NSUInteger {
+  NSWindowCollectionBehaviorDefault = 0,
+  NSWindowCollectionBehaviorCanJoinAllSpaces = 1 << 3,
+};
+
 enum NSApplicationActivationPolicy : NSInteger {
   NSApplicationActivationPolicyRegular = 0
 };
@@ -1959,6 +1964,15 @@ private:
       m_window = objc::msg_send<id>(
           m_window, "initWithContentRect:styleMask:backing:defer:"_sel,
           CGRectMake(0, 0, 0, 0), style, NSBackingStoreBuffered, NO);
+
+      // Allow the window to appear on all Spaces, preventing fullscreen Space
+      // affinity from persisting after the window is closed and reopened.
+      // Without this, macOS ties the window to the Space where it entered
+      // fullscreen, causing it to reopen in the wrong Space.
+      auto collectionBehavior =
+          static_cast<NSWindowCollectionBehavior>(NSWindowCollectionBehaviorCanJoinAllSpaces);
+      objc::msg_send<void>(m_window, "setCollectionBehavior:"_sel,
+                           collectionBehavior);
 
       m_window_delegate = create_window_delegate();
       objc_setAssociatedObject(m_window_delegate, "webview", (id)this,


### PR DESCRIPTION
When a macOS window enters fullscreen, it creates a Space affinity that persists after the window is closed. On next launch, the window reopens in that fullscreen Space instead of the currently active Space.

Set NSWindowCollectionBehaviorCanJoinAllSpaces on the webview window so it can appear on any Space, preventing the affinity from being retained.

Fixes #15002