### PR TITLE
install: use explicit path to launch Ollama after install

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -85,7 +85,7 @@ if [ "$OS" = "Darwin" ]; then
 
     if [ -z "${OLLAMA_NO_START:-}" ]; then
         status "Starting Ollama..."
-        open -a Ollama --args hidden
+        open "/Applications/Ollama.app" --args hidden
     fi
 
     status "Install complete. You can now run 'ollama'."


### PR DESCRIPTION
`open -a Ollama` uses Launch Services to resolve the application by name, which can find a stale Ollama.app in ~/Downloads (or elsewhere) instead of the one we just installed to /Applications. When that old copy launches, it prompts "Move to Applications?" and overwrites the new installation with the old version.

Use `open "/Applications/Ollama.app"` to launch the exact copy we just installed.