### PR TITLE
app/store: VACUUM and REINDEX SQLite on close

### DIFF
--- a/app/store/database.go
+++ b/app/store/database.go
@@ -53,6 +53,11 @@ func newDatabase(dbPath string) (*database, error) {
 func (db *database) Close() error {
 	_, _ = db.conn.Exec("PRAGMA wal_checkpoint(TRUNCATE);")
 
+	// Compact the database to reclaim space from deleted rows (e.g. removed chats)
+	// and rebuild indexes for consistent performance.
+	_, _ = db.conn.Exec("VACUUM;")
+	_, _ = db.conn.Exec("REINDEX;")
+
 	return db.conn.Close()
 }
 


### PR DESCRIPTION
## Summary

Fixes #15021 — after deleting chats the SQLite database file retains its peak size because SQLite does not automatically reclaim space from deleted rows.

This adds `VACUUM` and `REINDEX` calls to the database shutdown path (right after the existing WAL checkpoint). On quit, the database is compacted and indexes are rebuilt, keeping the on-disk footprint proportional to actual stored data.

## Details

- `VACUUM` rewrites the database file, reclaiming unused pages left behind by deleted rows (e.g. removed chats and their messages/attachments).
- `REINDEX` rebuilds all indexes for consistent query performance after compaction.
- Both operations run during graceful shutdown only, so there is zero impact on runtime performance.
- Errors from VACUUM/REINDEX are intentionally discarded (matching the existing pattern for the WAL checkpoint) since a failure here should not prevent the application from closing.

## Test plan

- Create several long chats, note `db.sqlite` file size
- Delete all chats from the UI
- Quit Ollama
- Verify `db.sqlite` is significantly smaller after restart