### PR TITLE
ci: fix windows cgo compiler error

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -64,6 +64,7 @@ jobs:
             container: nvidia/cuda:13.0.0-devel-ubuntu22.04
             extra-packages: libcudnn9-dev-cuda-13 libopenblas-dev liblapack-dev liblapacke-dev git curl
             flags: '-DCMAKE_CUDA_ARCHITECTURES=87 -DBLAS_INCLUDE_DIRS=/usr/include/x86_64-linux-gnu -DLAPACK_INCLUDE_DIRS=/usr/include/x86_64-linux-gnu'
+            install-go: true
     runs-on: linux
     container: ${{ matrix.container }}
     steps:
@@ -90,6 +91,12 @@ jobs:
           fi
         env:
           DEBIAN_FRONTEND: noninteractive
+      - if: matrix.install-go
+        name: Install Go
+        run: |
+          GO_VERSION=$(awk '/^go / { print $2 }' go.mod)
+          curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-$(dpkg --print-architecture).tar.gz" | tar xz -C /usr/local
+          echo "/usr/local/go/bin" >> $GITHUB_PATH
       - uses: actions/cache@v4
         with:
           path: /github/home/.cache/ccache

--- a/x/imagegen/mlx/CMakeLists.txt
+++ b/x/imagegen/mlx/CMakeLists.txt
@@ -101,11 +101,24 @@ file(COPY ${_mlx_c_hdrs} DESTINATION "${CMAKE_SOURCE_DIR}/x/mlxrunner/mlx/includ
 # Regenerate Go/C shim wrappers from the (possibly updated) headers.
 find_program(GO_EXECUTABLE go REQUIRED)
 message(STATUS "Regenerating MLX Go wrappers")
+
+# Go's cgo splits CC on whitespace, so a CC like "C:/Program Files/…/cl.exe"
+# (set by cmake on Windows) breaks with "C:/Program" not found.  Clear CC
+# when it contains spaces so cgo falls back to its default (gcc).
+if(WIN32 AND "$ENV{CC}" MATCHES " ")
+    set(_SAVE_CC "$ENV{CC}")
+    set(ENV{CC} "")
+endif()
+
 execute_process(
     COMMAND ${GO_EXECUTABLE} generate ./x/...
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     COMMAND_ERROR_IS_FATAL ANY
 )
+
+if(DEFINED _SAVE_CC)
+    set(ENV{CC} "${_SAVE_CC}")
+endif()
 
 # For local dev builds, override MLX_VERSION with git describe output
 if(TARGET mlx_version AND DEFINED FETCHCONTENT_SOURCE_DIR_MLX)


### PR DESCRIPTION
cmake calls generate, but without the env vars set, winds up trying to use an absolute compiler path with spaces and gets confused.