### PR TITLE
ggml: force flash attention off for grok

### DIFF
--- a/fs/ggml/ggml.go
+++ b/fs/ggml/ggml.go
@@ -874,7 +874,7 @@ func (f GGML) SupportsFlashAttention() bool {
 		return true
 	}
 
-	if slices.Contains([]string{"gemma2"}, arch) {
+	if slices.Contains([]string{"gemma2", "grok"}, arch) {
 		return false
 	}
 


### PR DESCRIPTION
By default, ollama supports FA for grok,  but llama.cpp [disables it](https://github.com/ollama/ollama/blob/4fda69809a3fecf73d0f71657ef50f8f7e8f43f7/llama/llama.cpp/src/llama-context.cpp#L2418).  If KV cache quantization has been set this causes the runner to crash.

Fixes: #15043