### PR TITLE
Fix: Add VACUUM to database cleanup on shutdown

### DIFF
--- a/app/store/database.go
+++ b/app/store/database.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -51,7 +52,19 @@ func newDatabase(dbPath string) (*database, error) {
 }
 
 func (db *database) Close() error {
+	// Checkpoint WAL to ensure all writes are flushed
 	_, _ = db.conn.Exec("PRAGMA wal_checkpoint(TRUNCATE);")
+
+	// Vacuum database to reclaim disk space from deleted records
+	// This can fail if disk space is tight, but we still want to close cleanly
+	if _, err := db.conn.Exec("VACUUM;"); err != nil {
+		slog.Warn("failed to vacuum database during close", "error", err)
+	}
+
+	// Reindex to optimize query performance after vacuum
+	if _, err := db.conn.Exec("REINDEX;"); err != nil {
+		slog.Warn("failed to reindex database during close", "error", err)
+	}
 
 	return db.conn.Close()
 }


### PR DESCRIPTION
## Problem

SQLite databases grow indefinitely without VACUUM. Deleted chats and messages mark pages as free but don't return space to the OS. This leads to multi-gigabyte database files that never shrink.

**Fixes #15021**

## Root Cause

The `Close()` method in `app/store/database.go` only checkpoints the WAL but never runs VACUUM to reclaim space from deleted records.

## Solution

Added VACUUM and REINDEX to the database Close() method:
- `VACUUM` reclaims disk space from deleted records
- `REINDEX` optimizes query performance
- Both run on shutdown (safe, no concurrent access)
- Error handling logs warnings but doesn't fail close

## Testing

**Environment:**
- macOS 25.3.0
- M3 Ultra, 256GB RAM
- Ollama v0.18.2

**Results:**
- ✅ Built successfully (61MB binary, no warnings)
- ✅ Server starts and responds correctly
- ✅ Test database: **49% space reclaimed** after deleting half the data
  - Before delete: 0.56 MB
  - After delete (no VACUUM): 0.57 MB
  - After VACUUM: 0.29 MB
  - **Space reclaimed: 0.28 MB (49.0% reduction)**

**Test code:**
Created 10K rows, deleted 5K rows, ran VACUUM - confirmed space reclamation works as expected.

## Code Changes

**Before:**
```go
func (db *database) Close() error {
	_, _ = db.conn.Exec("PRAGMA wal_checkpoint(TRUNCATE);")
	return db.conn.Close()
}
```

**After:**
```go
func (db *database) Close() error {
	// Checkpoint WAL to ensure all writes are flushed
	_, _ = db.conn.Exec("PRAGMA wal_checkpoint(TRUNCATE);")

	// Vacuum database to reclaim disk space from deleted records
	if _, err := db.conn.Exec("VACUUM;"); err != nil {
		slog.Warn("failed to vacuum database during close", "error", err)
	}

	// Reindex to optimize query performance after vacuum
	if _, err := db.conn.Exec("REINDEX;"); err != nil {
		slog.Warn("failed to reindex database during close", "error", err)
	}

	return db.conn.Close()
}
```

## Questions

1. Is shutdown timing acceptable? (VACUUM can take seconds for very large DBs)
2. Should we add a configuration option?
3. Should we add a size threshold before running VACUUM?

Happy to test additional scenarios or adjust the approach based on your feedback!
