### PR TITLE
Add Yaw Terminal to community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ console.log(response.message.content);
 - [LLM-X](https://github.com/mrdjohnson/llm-x) - Progressive web app for LLMs
 - [cmdh](https://github.com/pgibler/cmdh) - Natural language to shell commands
 - [VT](https://github.com/vinhnx/vt.ai) - Minimal multimodal AI chat app
+- [Yaw Terminal](https://yaw.sh) - Cross-platform terminal with built-in Ollama support, auto-detects local models
 
 ### Productivity & Apps
 


### PR DESCRIPTION
Adds [Yaw Terminal](https://yaw.sh) to the Terminal & CLI section of community integrations.

Yaw is a cross-platform terminal emulator with built-in Ollama support — it auto-detects local models with no API key needed.