### PR TITLE
README: Re-add handy-ollama to community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,11 @@ console.log(response.message.content);
 
 > Want to add your project? Open a pull request.
 
+### Tutorial
+
+- [handy-ollama](https://github.com/datawhalechina/handy-ollama) (Chinese Tutorial for Ollama by [Datawhale ](https://github.com/datawhalechina) - China's Largest Open Source AI Learning Community)
+
+
 ### Chat Interfaces
 
 #### Web


### PR DESCRIPTION
This PR restores the link to the Chinese Ollama tutorial [handy-ollama](https://github.com/datawhalechina/handy-ollama) in the README.md's Tutorial section, which was originally added via the commit [8bbc739](https://github.com/ollama/ollama/commit/8bbc7395dbe6993a058e28ccf35e14089ff55e0d) but has since been removed from the documentation.

This tutorial is maintained by [Datawhale](https://github.com/datawhalechina), China's largest open source AI learning community, and provides localized guidance for Chinese users to get started with Ollama. Re-adding this resource will better serve the large Chinese user base of Ollama and enrich the project's community tutorial ecosystem.