### PR TITLE
launch: hide vs code

### DIFF
--- a/cmd/launch/registry.go
+++ b/cmd/launch/registry.go
@@ -33,7 +33,7 @@ type IntegrationInfo struct {
 	Description string
 }
 
-var launcherIntegrationOrder = []string{"vscode", "opencode", "droid", "pi", "cline"}
+var launcherIntegrationOrder = []string{"opencode", "droid", "pi", "cline"}
 
 var integrationSpecs = []*IntegrationSpec{
 	{
@@ -136,6 +136,7 @@ var integrationSpecs = []*IntegrationSpec{
 		Runner:      &VSCode{},
 		Aliases:     []string{"code"},
 		Description: "Microsoft's open-source AI code editor",
+		Hidden:      true,
 		Install: IntegrationInstallSpec{
 			CheckInstalled: func() bool {
 				return (&VSCode{}).findBinary() != ""

--- a/cmd/tui/tui.go
+++ b/cmd/tui/tui.go
@@ -60,9 +60,6 @@ var mainMenuItems = []menuItem{
 	{
 		integration: "openclaw",
 	},
-	{
-		integration: "vscode",
-	},
 }
 
 var othersMenuItem = menuItem{
@@ -142,7 +139,6 @@ func otherIntegrationItems(state *launch.LauncherState) []menuItem {
 		"claude":   true,
 		"codex":    true,
 		"openclaw": true,
-		"vscode":   true,
 	}
 
 	var items []menuItem


### PR DESCRIPTION
Hide VS Code integration for now while leaving it accessible through `ollama launch vscode`