### PR TITLE
bench: add support for OpenAI API benchmarks

### DIFF
--- a/cmd/bench/bench.go
+++ b/cmd/bench/bench.go
@@ -1,11 +1,15 @@
 package main
 
 import (
+	"bufio"
+	"bytes"
 	"cmp"
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"runtime"
 	"slices"
@@ -32,6 +36,9 @@ type flagOptions struct {
 	verbose      *bool
 	warmup       *int
 	promptTokens *int
+	numCtx       *int
+	openaiURL    *string
+	apiKey       *string
 }
 
 type Metrics struct {
@@ -89,6 +96,9 @@ func buildGenerateRequest(model string, fOpt flagOptions, imgData api.ImageData,
 	options["temperature"] = *fOpt.temperature
 	if fOpt.seed != nil && *fOpt.seed > 0 {
 		options["seed"] = *fOpt.seed
+	}
+	if fOpt.numCtx != nil && *fOpt.numCtx > 0 {
+		options["num_ctx"] = *fOpt.numCtx
 	}
 
 	var keepAliveDuration *api.Duration
@@ -224,26 +234,7 @@ func OutputMetrics(w io.Writer, format string, metrics []Metrics, verbose bool) 
 
 func BenchmarkModel(fOpt flagOptions) error {
 	models := strings.Split(*fOpt.models, ",")
-
-	var imgData api.ImageData
-	var err error
-	if *fOpt.imageFile != "" {
-		imgData, err = readImage(*fOpt.imageFile)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "ERROR: Couldn't read image '%s': %v\n", *fOpt.imageFile, err)
-			return err
-		}
-	}
-
-	if *fOpt.debug && imgData != nil {
-		fmt.Fprintf(os.Stderr, "Read file '%s'\n", *fOpt.imageFile)
-	}
-
-	client, err := api.ClientFromEnvironment()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "ERROR: Couldn't create ollama client: %v\n", err)
-		return err
-	}
+	useOpenAI := fOpt.openaiURL != nil && *fOpt.openaiURL != ""
 
 	var out io.Writer = os.Stdout
 	if fOpt.outputFile != nil && *fOpt.outputFile != "" {
@@ -263,6 +254,30 @@ func BenchmarkModel(fOpt flagOptions) error {
 		prompt := generatePromptForTokenCount(*fOpt.promptTokens, 0)
 		wordCount := len(strings.Fields(prompt))
 		fmt.Fprintf(os.Stderr, "Generated prompt targeting ~%d tokens (%d words, varied per epoch)\n", *fOpt.promptTokens, wordCount)
+	}
+
+	if useOpenAI {
+		return benchmarkOpenAI(fOpt, models, out)
+	}
+
+	var imgData api.ImageData
+	var err error
+	if *fOpt.imageFile != "" {
+		imgData, err = readImage(*fOpt.imageFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: Couldn't read image '%s': %v\n", *fOpt.imageFile, err)
+			return err
+		}
+	}
+
+	if *fOpt.debug && imgData != nil {
+		fmt.Fprintf(os.Stderr, "Read file '%s'\n", *fOpt.imageFile)
+	}
+
+	client, err := api.ClientFromEnvironment()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: Couldn't create ollama client: %v\n", err)
+		return err
 	}
 
 	for _, model := range models {
@@ -447,6 +462,284 @@ func unloadModel(client *api.Client, model string, timeout int) {
 	})
 }
 
+// openaiMetrics holds performance data extracted from an OpenAI-compatible streaming response.
+type openaiMetrics struct {
+	PromptTokens     int
+	CompletionTokens int
+	TTFT             time.Duration
+	TotalDuration    time.Duration
+
+	// Server-reported timings (when available). Zero if not provided.
+	ServerPromptMS    float64
+	ServerPredictedMS float64
+	HasTimings        bool
+}
+
+func openaiGenerate(ctx context.Context, baseURL, apiKey, model string, fOpt flagOptions, epoch int, keepAlive *float64) (*openaiMetrics, error) {
+	prompt := *fOpt.prompt
+	if *fOpt.promptTokens > 0 {
+		prompt = generatePromptForTokenCount(*fOpt.promptTokens, epoch)
+	} else {
+		prompt = fmt.Sprintf("[%d] %s", epoch, prompt)
+	}
+
+	body := map[string]any{
+		"model":      model,
+		"stream":     true,
+		"max_tokens": *fOpt.maxTokens,
+		"messages": []map[string]string{
+			{"role": "user", "content": prompt},
+		},
+	}
+	if *fOpt.temperature > 0 {
+		body["temperature"] = *fOpt.temperature
+	}
+	if fOpt.seed != nil && *fOpt.seed > 0 {
+		body["seed"] = *fOpt.seed
+	}
+	if keepAlive != nil {
+		body["keep_alive"] = *keepAlive
+	}
+	body["stream_options"] = map[string]any{"include_usage": true}
+
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	url := strings.TrimRight(baseURL, "/") + "/chat/completions"
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+
+	start := time.Now()
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	metrics := &openaiMetrics{}
+	var ttftOnce sync.Once
+	chunkTokens := 0
+
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		data := strings.TrimPrefix(line, "data: ")
+		if data == "[DONE]" {
+			break
+		}
+
+		var chunk struct {
+			Choices []struct {
+				Delta struct {
+					Content   string `json:"content"`
+					Reasoning string `json:"reasoning"`
+				} `json:"delta"`
+			} `json:"choices"`
+			Usage *struct {
+				PromptTokens     int `json:"prompt_tokens"`
+				CompletionTokens int `json:"completion_tokens"`
+			} `json:"usage"`
+			Timings *struct {
+				PromptMS    float64 `json:"prompt_ms"`
+				PredictedMS float64 `json:"predicted_ms"`
+			} `json:"timings"`
+		}
+		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+			continue
+		}
+
+		if len(chunk.Choices) > 0 {
+			text := cmp.Or(chunk.Choices[0].Delta.Content, chunk.Choices[0].Delta.Reasoning)
+			if text != "" {
+				ttftOnce.Do(func() {
+					metrics.TTFT = time.Since(start)
+				})
+				chunkTokens++
+				if *fOpt.debug {
+					fmt.Fprint(os.Stderr, text)
+				}
+			}
+		}
+
+		if chunk.Usage != nil {
+			metrics.PromptTokens = chunk.Usage.PromptTokens
+			metrics.CompletionTokens = chunk.Usage.CompletionTokens
+		}
+
+		if chunk.Timings != nil {
+			metrics.ServerPromptMS = chunk.Timings.PromptMS
+			metrics.ServerPredictedMS = chunk.Timings.PredictedMS
+			metrics.HasTimings = true
+		}
+	}
+
+	metrics.TotalDuration = time.Since(start)
+
+	if *fOpt.debug {
+		fmt.Fprintln(os.Stderr)
+	}
+
+	if metrics.CompletionTokens == 0 {
+		metrics.CompletionTokens = chunkTokens
+	}
+
+	return metrics, nil
+}
+
+func benchmarkOpenAI(fOpt flagOptions, models []string, out io.Writer) error {
+	apiKey := *fOpt.apiKey
+	if apiKey == "" {
+		apiKey = os.Getenv("OPENAI_API_KEY")
+	}
+
+	keepAliveForever := float64(-1)
+	keepAliveUnload := float64(0)
+
+	for _, model := range models {
+		info := ModelInfo{Name: model}
+		outputModelInfo(out, *fOpt.format, info)
+
+		for i := range *fOpt.warmup {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(*fOpt.timeout)*time.Second)
+			_, err := openaiGenerate(ctx, *fOpt.openaiURL, apiKey, model, fOpt, -(i + 1), &keepAliveForever)
+			cancel()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "WARNING: Warmup %d/%d for %s failed: %v\n", i+1, *fOpt.warmup, model, err)
+			} else if *fOpt.debug {
+				fmt.Fprintf(os.Stderr, "Warmup %d/%d for %s complete\n", i+1, *fOpt.warmup, model)
+			}
+		}
+
+		hasTimings := false
+		shortCount := 0
+		for epoch := range *fOpt.epochs {
+			var oaiMetrics *openaiMetrics
+			var err error
+			short := false
+
+			isLast := epoch == *fOpt.epochs-1
+			ka := &keepAliveForever
+			if isLast {
+				ka = &keepAliveUnload
+			}
+
+			const maxRetries = 3
+			for attempt := range maxRetries + 1 {
+				ctx, cancel := context.WithTimeout(context.Background(), time.Duration(*fOpt.timeout)*time.Second)
+				oaiMetrics, err = openaiGenerate(ctx, *fOpt.openaiURL, apiKey, model, fOpt, epoch+attempt*1000, ka)
+				cancel()
+
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "ERROR: Couldn't generate with model '%s': %v\n", model, err)
+					break
+				}
+
+				short = *fOpt.maxTokens > 0 && oaiMetrics.CompletionTokens < *fOpt.maxTokens
+				if !short || attempt == maxRetries {
+					break
+				}
+
+				if *fOpt.debug {
+					fmt.Fprintf(os.Stderr, "Short response (%d/%d tokens), retrying with different prompt (attempt %d/%d)\n",
+						oaiMetrics.CompletionTokens, *fOpt.maxTokens, attempt+1, maxRetries)
+				}
+			}
+
+			if err != nil || oaiMetrics == nil {
+				continue
+			}
+
+			if short {
+				shortCount++
+				if *fOpt.debug {
+					fmt.Fprintf(os.Stderr, "WARNING: Short response (%d/%d tokens) after %d retries for epoch %d\n",
+						oaiMetrics.CompletionTokens, *fOpt.maxTokens, maxRetries, epoch+1)
+				}
+			}
+
+			var metrics []Metrics
+
+			if oaiMetrics.HasTimings {
+				hasTimings = true
+				metrics = []Metrics{
+					{
+						Model:    model,
+						Step:     "prefill",
+						Count:    oaiMetrics.PromptTokens,
+						Duration: time.Duration(oaiMetrics.ServerPromptMS * float64(time.Millisecond)),
+					},
+					{
+						Model:    model,
+						Step:     "generate",
+						Count:    oaiMetrics.CompletionTokens,
+						Duration: time.Duration(oaiMetrics.ServerPredictedMS * float64(time.Millisecond)),
+					},
+				}
+			} else {
+				// No server timings — only report generate derived from stream timing
+				generateDuration := oaiMetrics.TotalDuration - oaiMetrics.TTFT
+				metrics = []Metrics{
+					{
+						Model:    model,
+						Step:     "generate",
+						Count:    oaiMetrics.CompletionTokens,
+						Duration: generateDuration,
+					},
+				}
+			}
+
+			metrics = append(metrics,
+				Metrics{
+					Model:    model,
+					Step:     "ttft",
+					Count:    1,
+					Duration: oaiMetrics.TTFT,
+				},
+				Metrics{
+					Model:    model,
+					Step:     "total",
+					Count:    1,
+					Duration: oaiMetrics.TotalDuration,
+				},
+			)
+
+			OutputMetrics(out, *fOpt.format, metrics, *fOpt.verbose)
+
+			if *fOpt.debug && *fOpt.promptTokens > 0 {
+				fmt.Fprintf(os.Stderr, "Generated prompt targeting ~%d tokens (actual prompt_tokens: %d)\n",
+					*fOpt.promptTokens, oaiMetrics.PromptTokens)
+			}
+		}
+
+		if !hasTimings {
+			fmt.Fprintf(os.Stderr, "# NOTE: Server did not report timings; prefill rate not available\n")
+		}
+
+		if shortCount > 0 {
+			fmt.Fprintf(os.Stderr, "WARNING: %d/%d epochs for '%s' had short responses (<%d tokens). Generation metrics may be unreliable.\n",
+				shortCount, *fOpt.epochs, model, *fOpt.maxTokens)
+		}
+	}
+
+	return nil
+}
+
 func readImage(filePath string) (api.ImageData, error) {
 	file, err := os.Open(filePath)
 	if err != nil {
@@ -479,6 +772,9 @@ func main() {
 		debug:        flag.Bool("debug", false, "Show debug information"),
 		warmup:       flag.Int("warmup", 1, "Number of warmup requests before timing"),
 		promptTokens: flag.Int("prompt-tokens", 0, "Generate prompt targeting ~N tokens (0 = use -p prompt)"),
+		numCtx:       flag.Int("num-ctx", 0, "Context size (0 = server default)"),
+		openaiURL:    flag.String("openai", "", "OpenAI-compatible API base URL (e.g. http://localhost:11434/v1)"),
+		apiKey:       flag.String("api-key", "", "API key for OpenAI endpoint (default: OPENAI_API_KEY env)"),
 	}
 
 	flag.Usage = func() {
@@ -490,6 +786,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "\nExamples:\n")
 		fmt.Fprintf(os.Stderr, "  bench -model gemma3,llama3 -epochs 6\n")
 		fmt.Fprintf(os.Stderr, "  bench -model gemma3 -epochs 6 -prompt-tokens 512 -format csv\n")
+		fmt.Fprintf(os.Stderr, "  bench -model gemma3 -openai http://localhost:11434/v1\n")
 	}
 	flag.Parse()
 

--- a/cmd/bench/bench.go
+++ b/cmd/bench/bench.go
@@ -55,6 +55,7 @@ type ModelInfo struct {
 	Family            string
 	SizeBytes         int64
 	VRAMBytes         int64
+	NumCtx            int64
 }
 
 const DefaultPrompt = `Please write a descriptive story about a llama named Alonso who grows up to be President of the Land of Llamas. Include details about Alonso's childhood, adolescent years, and how he grew up to be a political mover and shaker. Write the story with a sense of whimsy.`
@@ -71,9 +72,12 @@ var promptWordList = []string{
 	"old", "stone", "bridge", "that", "crosses", "winding", "river",
 }
 
+// tokensPerWord is the calibrated ratio of tokens to words for the current model.
+// Initialized with a heuristic, then updated during warmup based on actual tokenization.
+var tokensPerWord = 1.3
+
 func generatePromptForTokenCount(targetTokens int, epoch int) string {
-	// ~1.3 tokens per word heuristic
-	targetWords := int(float64(targetTokens) / 1.3)
+	targetWords := int(float64(targetTokens) / tokensPerWord)
 	if targetWords < 1 {
 		targetWords = 1
 	}
@@ -86,6 +90,17 @@ func generatePromptForTokenCount(targetTokens int, epoch int) string {
 		words[i] = promptWordList[((i+offset)%n+n)%n]
 	}
 	return strings.Join(words, " ")
+}
+
+// calibratePromptTokens adjusts tokensPerWord based on actual tokenization from a warmup run.
+func calibratePromptTokens(targetTokens, actualTokens, wordCount int) {
+	if actualTokens <= 0 || wordCount <= 0 {
+		return
+	}
+	tokensPerWord = float64(actualTokens) / float64(wordCount)
+	newWords := int(float64(targetTokens) / tokensPerWord)
+	fmt.Fprintf(os.Stderr, "bench: calibrated %.2f tokens/word (target=%d, got=%d, words=%d → %d)\n",
+		tokensPerWord, targetTokens, actualTokens, wordCount, newWords)
 }
 
 func buildGenerateRequest(model string, fOpt flagOptions, imgData api.ImageData, epoch int) *api.GenerateRequest {
@@ -156,13 +171,25 @@ func fetchMemoryUsage(ctx context.Context, client *api.Client, model string) (si
 			return m.Size, m.SizeVRAM
 		}
 	}
-	// Try prefix match (model names may include :latest or tags)
 	for _, m := range resp.Models {
 		if strings.HasPrefix(m.Name, model) || strings.HasPrefix(m.Model, model) {
 			return m.Size, m.SizeVRAM
 		}
 	}
 	return 0, 0
+}
+
+func fetchContextLength(ctx context.Context, client *api.Client, model string) int64 {
+	resp, err := client.ListRunning(ctx)
+	if err != nil {
+		return 0
+	}
+	for _, m := range resp.Models {
+		if m.Name == model || m.Model == model || strings.HasPrefix(m.Name, model) || strings.HasPrefix(m.Model, model) {
+			return int64(m.ContextLength)
+		}
+	}
+	return 0
 }
 
 func outputFormatHeader(w io.Writer, format string, verbose bool) {
@@ -187,8 +214,12 @@ func outputModelInfo(w io.Writer, format string, info ModelInfo) {
 	if info.SizeBytes > 0 {
 		memStr = fmt.Sprintf(" | Size: %d | VRAM: %d", info.SizeBytes, info.VRAMBytes)
 	}
-	fmt.Fprintf(w, "# Model: %s | Params: %s | Quant: %s | Family: %s%s\n",
-		info.Name, params, quant, family, memStr)
+	ctxStr := ""
+	if info.NumCtx > 0 {
+		ctxStr = fmt.Sprintf(" | NumCtx: %d", info.NumCtx)
+	}
+	fmt.Fprintf(w, "# Model: %s | Params: %s | Quant: %s | Family: %s%s%s\n",
+		info.Name, params, quant, family, memStr, ctxStr)
 }
 
 func OutputMetrics(w io.Writer, format string, metrics []Metrics, verbose bool) {
@@ -291,21 +322,38 @@ func BenchmarkModel(fOpt flagOptions) error {
 			req := buildGenerateRequest(model, fOpt, imgData, -(i + 1))
 			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(*fOpt.timeout)*time.Second)
 
+			var warmupMetrics *api.Metrics
 			err = client.Generate(ctx, req, func(resp api.GenerateResponse) error {
+				if resp.Done {
+					warmupMetrics = &resp.Metrics
+				}
 				return nil
 			})
 			cancel()
 
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "WARNING: Warmup %d/%d for %s failed: %v\n", i+1, *fOpt.warmup, model, err)
-			} else if *fOpt.debug {
-				fmt.Fprintf(os.Stderr, "Warmup %d/%d for %s complete\n", i+1, *fOpt.warmup, model)
+			} else {
+				if *fOpt.debug {
+					fmt.Fprintf(os.Stderr, "Warmup %d/%d for %s complete\n", i+1, *fOpt.warmup, model)
+				}
+				// Calibrate prompt token count on last warmup run
+				if i == *fOpt.warmup-1 && *fOpt.promptTokens > 0 && warmupMetrics != nil {
+					prompt := generatePromptForTokenCount(*fOpt.promptTokens, -(i + 1))
+					wordCount := len(strings.Fields(prompt))
+					calibratePromptTokens(*fOpt.promptTokens, warmupMetrics.PromptEvalCount, wordCount)
+				}
 			}
 		}
 
-		// Fetch memory usage once after warmup (model is loaded and stable)
+		// Fetch memory/context info once after warmup (model is loaded and stable)
 		memCtx, memCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		info.SizeBytes, info.VRAMBytes = fetchMemoryUsage(memCtx, client, model)
+		if fOpt.numCtx != nil && *fOpt.numCtx > 0 {
+			info.NumCtx = int64(*fOpt.numCtx)
+		} else {
+			info.NumCtx = fetchContextLength(memCtx, client, model)
+		}
 		memCancel()
 
 		outputModelInfo(out, *fOpt.format, info)

--- a/middleware/openai.go
+++ b/middleware/openai.go
@@ -106,6 +106,7 @@ func (w *ChatWriter) writeResponse(data []byte) (int, error) {
 			if w.streamOptions != nil && w.streamOptions.IncludeUsage {
 				u := openai.ToUsage(chatResponse)
 				c.Usage = &u
+				c.Timings = openai.ToTimings(chatResponse.Metrics)
 				c.Choices = []openai.ChunkChoice{}
 				d, err := json.Marshal(c)
 				if err != nil {
@@ -172,6 +173,7 @@ func (w *CompleteWriter) writeResponse(data []byte) (int, error) {
 			if w.streamOptions != nil && w.streamOptions.IncludeUsage {
 				u := openai.ToUsageGenerate(generateResponse)
 				c.Usage = &u
+				c.Timings = openai.ToTimings(generateResponse.Metrics)
 				c.Choices = []openai.CompleteChunkChoice{}
 				d, err := json.Marshal(c)
 				if err != nil {

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -116,6 +116,18 @@ type ChatCompletionRequest struct {
 	DebugRenderOnly  bool            `json:"_debug_render_only"`
 }
 
+// Timings reports server-side inference performance metrics.
+type Timings struct {
+	PromptN             int     `json:"prompt_n"`
+	PromptMS            float64 `json:"prompt_ms"`
+	PromptPerTokenMS    float64 `json:"prompt_per_token_ms"`
+	PromptPerSecond     float64 `json:"prompt_per_second"`
+	PredictedN          int     `json:"predicted_n"`
+	PredictedMS         float64 `json:"predicted_ms"`
+	PredictedPerTokenMS float64 `json:"predicted_per_token_ms"`
+	PredictedPerSecond  float64 `json:"predicted_per_second"`
+}
+
 type ChatCompletion struct {
 	Id                string         `json:"id"`
 	Object            string         `json:"object"`
@@ -124,6 +136,7 @@ type ChatCompletion struct {
 	SystemFingerprint string         `json:"system_fingerprint"`
 	Choices           []Choice       `json:"choices"`
 	Usage             Usage          `json:"usage,omitempty"`
+	Timings           *Timings       `json:"timings,omitempty"`
 	DebugInfo         *api.DebugInfo `json:"_debug_info,omitempty"`
 }
 
@@ -135,6 +148,7 @@ type ChatCompletionChunk struct {
 	SystemFingerprint string        `json:"system_fingerprint"`
 	Choices           []ChunkChoice `json:"choices"`
 	Usage             *Usage        `json:"usage,omitempty"`
+	Timings           *Timings      `json:"timings,omitempty"`
 }
 
 // TODO (https://github.com/ollama/ollama/issues/5259): support []string, []int and [][]int
@@ -163,6 +177,7 @@ type Completion struct {
 	SystemFingerprint string                `json:"system_fingerprint"`
 	Choices           []CompleteChunkChoice `json:"choices"`
 	Usage             Usage                 `json:"usage,omitempty"`
+	Timings           *Timings              `json:"timings,omitempty"`
 }
 
 type CompletionChunk struct {
@@ -173,6 +188,7 @@ type CompletionChunk struct {
 	Model             string                `json:"model"`
 	SystemFingerprint string                `json:"system_fingerprint"`
 	Usage             *Usage                `json:"usage,omitempty"`
+	Timings           *Timings              `json:"timings,omitempty"`
 }
 
 type ToolCall struct {
@@ -238,6 +254,29 @@ func ToUsage(r api.ChatResponse) Usage {
 	}
 }
 
+// ToTimings converts api.Metrics to Timings
+func ToTimings(m api.Metrics) *Timings {
+	promptMS := float64(m.PromptEvalDuration.Milliseconds())
+	predictedMS := float64(m.EvalDuration.Milliseconds())
+	return &Timings{
+		PromptN:             m.PromptEvalCount,
+		PromptMS:            promptMS,
+		PromptPerTokenMS:    safeDiv(promptMS, float64(m.PromptEvalCount)),
+		PromptPerSecond:     safeDiv(float64(m.PromptEvalCount)*1000, promptMS),
+		PredictedN:          m.EvalCount,
+		PredictedMS:         predictedMS,
+		PredictedPerTokenMS: safeDiv(predictedMS, float64(m.EvalCount)),
+		PredictedPerSecond:  safeDiv(float64(m.EvalCount)*1000, predictedMS),
+	}
+}
+
+func safeDiv(a, b float64) float64 {
+	if b == 0 {
+		return 0
+	}
+	return a / b
+}
+
 // ToToolCalls converts api.ToolCall to OpenAI ToolCall format
 func ToToolCalls(tc []api.ToolCall) []ToolCall {
 	toolCalls := make([]ToolCall, len(tc))
@@ -287,6 +326,7 @@ func ToChatCompletion(id string, r api.ChatResponse) ChatCompletion {
 			}(r.DoneReason),
 			Logprobs: logprobs,
 		}}, Usage: ToUsage(r),
+		Timings:   ToTimings(r.Metrics),
 		DebugInfo: r.DebugInfo,
 	}
 }
@@ -379,7 +419,8 @@ func ToCompletion(id string, r api.GenerateResponse) Completion {
 				return nil
 			}(r.DoneReason),
 		}},
-		Usage: ToUsageGenerate(r),
+		Usage:   ToUsageGenerate(r),
+		Timings: ToTimings(r.Metrics),
 	}
 }
 


### PR DESCRIPTION
Favor Timings in the API if available.  If not, only TTFT and generate are exposed.  Also adds support to adjust context size.

```
go run ./cmd/bench -model gemma3:1b
go run ./cmd/bench -model gemma3:1b -openai http://localhost:11434/v1
```

Optional `-api-key` if needed for the endpoint.