### PR TITLE
envconfig: add OLLAMA_HOME environment variable

### DIFF
--- a/app/cmd/app/app_darwin.go
+++ b/app/cmd/app/app_darwin.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/ollama/ollama/app/updater"
 	"github.com/ollama/ollama/app/version"
+	"github.com/ollama/ollama/envconfig"
 )
 
 var ollamaPath = func() string {
@@ -37,7 +38,7 @@ var ollamaPath = func() string {
 
 var (
 	isApp           = updater.BundlePath != ""
-	appLogPath      = filepath.Join(os.Getenv("HOME"), ".ollama", "logs", "app.log")
+	appLogPath      = filepath.Join(envconfig.Home(), "logs", "app.log")
 	launchAgentPath = filepath.Join(os.Getenv("HOME"), "Library", "LaunchAgents", "com.ollama.ollama.plist")
 )
 

--- a/app/server/server_unix.go
+++ b/app/server/server_unix.go
@@ -13,11 +13,13 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+
+	"github.com/ollama/ollama/envconfig"
 )
 
 var (
 	pidFile       = filepath.Join(os.Getenv("HOME"), "Library", "Application Support", "Ollama", "ollama.pid")
-	serverLogPath = filepath.Join(os.Getenv("HOME"), ".ollama", "logs", "server.log")
+	serverLogPath = filepath.Join(envconfig.Home(), "logs", "server.log")
 )
 
 func commandContext(ctx context.Context, name string, arg ...string) *exec.Cmd {

--- a/app/store/cloud_config.go
+++ b/app/store/cloud_config.go
@@ -107,11 +107,7 @@ func readServerConfigCloudDisabled() (bool, error) {
 }
 
 func serverConfigPath() (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("resolve home directory: %w", err)
-	}
-	return filepath.Join(home, ".ollama", serverConfigFilename), nil
+	return filepath.Join(envconfig.Home(), serverConfigFilename), nil
 }
 
 func cloudStatusSource(envDisabled bool, configDisabled bool) string {

--- a/app/store/store.go
+++ b/app/store/store.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/ollama/ollama/app/types/not"
+	"github.com/ollama/ollama/envconfig"
 )
 
 type File struct {
@@ -187,7 +188,7 @@ var defaultDBPath = func() string {
 	case "darwin":
 		return filepath.Join(os.Getenv("HOME"), "Library", "Application Support", "Ollama", "db.sqlite")
 	default:
-		return filepath.Join(os.Getenv("HOME"), ".ollama", "db.sqlite")
+		return filepath.Join(envconfig.Home(), "db.sqlite")
 	}
 }()
 
@@ -199,7 +200,7 @@ var legacyConfigPath = func() string {
 	case "darwin":
 		return filepath.Join(os.Getenv("HOME"), "Library", "Application Support", "Ollama", "config.json")
 	default:
-		return filepath.Join(os.Getenv("HOME"), ".ollama", "config.json")
+		return filepath.Join(envconfig.Home(), "config.json")
 	}
 }()
 
@@ -378,15 +379,7 @@ func (s *Store) Settings() (Settings, error) {
 
 	// Set default models directory if not set
 	if settings.Models == "" {
-		dir := os.Getenv("OLLAMA_MODELS")
-		if dir != "" {
-			settings.Models = dir
-		} else {
-			home, err := os.UserHomeDir()
-			if err == nil {
-				settings.Models = filepath.Join(home, ".ollama", "models")
-			}
-		}
+		settings.Models = envconfig.Models()
 	}
 
 	return settings, nil

--- a/app/updater/updater_darwin.go
+++ b/app/updater/updater_darwin.go
@@ -19,6 +19,7 @@ import (
 	"syscall"
 	"unsafe"
 
+	"github.com/ollama/ollama/envconfig"
 	"golang.org/x/sys/unix"
 )
 
@@ -55,10 +56,6 @@ var BundlePath = func() string {
 func init() {
 	VerifyDownload = verifyDownload
 	Installer = "Ollama-darwin.zip"
-	home, err := os.UserHomeDir()
-	if err != nil {
-		panic(err)
-	}
 
 	var uts unix.Utsname
 	if err := unix.Uname(&uts); err == nil {
@@ -74,7 +71,7 @@ func init() {
 
 	// Executable = Ollama.app/Contents/MacOS/Ollama
 
-	UpgradeLogFile = filepath.Join(home, ".ollama", "logs", "upgrade.log")
+	UpgradeLogFile = filepath.Join(envconfig.Home(), "logs", "upgrade.log")
 
 	cacheDir, err := os.UserCacheDir()
 	if err != nil {

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -13,18 +13,14 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/ollama/ollama/envconfig"
 	"golang.org/x/crypto/ssh"
 )
 
 const defaultPrivateKey = "id_ed25519"
 
 func GetPublicKey() (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-
-	keyPath := filepath.Join(home, ".ollama", defaultPrivateKey)
+	keyPath := filepath.Join(envconfig.Home(), defaultPrivateKey)
 	privateKeyFile, err := os.ReadFile(keyPath)
 	if err != nil {
 		slog.Info(fmt.Sprintf("Failed to load private key: %v", err))
@@ -51,12 +47,7 @@ func NewNonce(r io.Reader, length int) (string, error) {
 }
 
 func Sign(ctx context.Context, bts []byte) (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-
-	keyPath := filepath.Join(home, ".ollama", defaultPrivateKey)
+	keyPath := filepath.Join(envconfig.Home(), defaultPrivateKey)
 	privateKeyFile, err := os.ReadFile(keyPath)
 	if err != nil {
 		slog.Info(fmt.Sprintf("Failed to load private key: %v", err))

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1837,15 +1837,10 @@ func RunServer(_ *cobra.Command, _ []string) error {
 }
 
 func initializeKeypair() error {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return err
-	}
+	privKeyPath := filepath.Join(envconfig.Home(), "id_ed25519")
+	pubKeyPath := filepath.Join(envconfig.Home(), "id_ed25519.pub")
 
-	privKeyPath := filepath.Join(home, ".ollama", "id_ed25519")
-	pubKeyPath := filepath.Join(home, ".ollama", "id_ed25519.pub")
-
-	_, err = os.Stat(privKeyPath)
+	_, err := os.Stat(privKeyPath)
 	if os.IsNotExist(err) {
 		fmt.Printf("Couldn't find '%s'. Generating new private key.\n", privKeyPath)
 		cryptoPublicKey, cryptoPrivateKey, err := ed25519.GenerateKey(rand.Reader)

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/ollama/ollama/cmd/internal/fileutil"
+	"github.com/ollama/ollama/envconfig"
 )
 
 type integration struct {
@@ -29,19 +30,11 @@ type config struct {
 }
 
 func configPath() (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(home, ".ollama", "config.json"), nil
+	return filepath.Join(envconfig.Home(), "config.json"), nil
 }
 
 func legacyConfigPath() (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(home, ".ollama", "config", "config.json"), nil
+	return filepath.Join(envconfig.Home(), "config", "config.json"), nil
 }
 
 // migrateConfig moves the config from the legacy path to ~/.ollama/config.json

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -108,10 +108,10 @@ func AllowedOrigins() (origins []string) {
 	return origins
 }
 
-// Models returns the path to the models directory. Models directory can be configured via the OLLAMA_MODELS environment variable.
-// Default is $HOME/.ollama/models
-func Models() string {
-	if s := Var("OLLAMA_MODELS"); s != "" {
+// Home returns the path to the Ollama home directory. Home can be configured via the OLLAMA_HOME environment variable.
+// Default is $HOME/.ollama
+func Home() string {
+	if s := Var("OLLAMA_HOME"); s != "" {
 		return s
 	}
 
@@ -120,7 +120,17 @@ func Models() string {
 		panic(err)
 	}
 
-	return filepath.Join(home, ".ollama", "models")
+	return filepath.Join(home, ".ollama")
+}
+
+// Models returns the path to the models directory. Models directory can be configured via the OLLAMA_MODELS environment variable.
+// Default is $OLLAMA_HOME/models
+func Models() string {
+	if s := Var("OLLAMA_MODELS"); s != "" {
+		return s
+	}
+
+	return filepath.Join(Home(), "models")
 }
 
 // KeepAlive returns the duration that models stay loaded in memory. KeepAlive can be configured via the OLLAMA_KEEP_ALIVE environment variable.
@@ -309,6 +319,7 @@ func AsMap() map[string]EnvVar {
 		"OLLAMA_FLASH_ATTENTION":    {"OLLAMA_FLASH_ATTENTION", FlashAttention(false), "Enabled flash attention"},
 		"OLLAMA_KV_CACHE_TYPE":      {"OLLAMA_KV_CACHE_TYPE", KvCacheType(), "Quantization type for the K/V cache (default: f16)"},
 		"OLLAMA_GPU_OVERHEAD":       {"OLLAMA_GPU_OVERHEAD", GpuOverhead(), "Reserve a portion of VRAM per GPU (bytes)"},
+		"OLLAMA_HOME":               {"OLLAMA_HOME", Home(), "The path to the Ollama home directory (default \"~/.ollama\")"},
 		"OLLAMA_HOST":               {"OLLAMA_HOST", Host(), "IP Address for the ollama server (default 127.0.0.1:11434)"},
 		"OLLAMA_KEEP_ALIVE":         {"OLLAMA_KEEP_ALIVE", KeepAlive(), "The duration that models stay loaded in memory (default \"5m\")"},
 		"OLLAMA_LLM_LIBRARY":        {"OLLAMA_LLM_LIBRARY", LLMLibrary(), "Set LLM library to bypass autodetection"},
@@ -387,17 +398,14 @@ func loadServerConfig() {
 	serverCfgMu.RUnlock()
 
 	cfg := serverConfigData{}
-	home, err := os.UserHomeDir()
-	if err == nil {
-		path := filepath.Join(home, ".ollama", "server.json")
-		data, err := os.ReadFile(path)
-		if err != nil {
-			if !errors.Is(err, os.ErrNotExist) {
-				slog.Debug("envconfig: could not read server config", "error", err)
-			}
-		} else if err := json.Unmarshal(data, &cfg); err != nil {
-			slog.Debug("envconfig: could not parse server config", "error", err)
+	path := filepath.Join(Home(), "server.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			slog.Debug("envconfig: could not read server config", "error", err)
 		}
+	} else if err := json.Unmarshal(data, &cfg); err != nil {
+		slog.Debug("envconfig: could not parse server config", "error", err)
 	}
 
 	serverCfgMu.Lock()

--- a/readline/history.go
+++ b/readline/history.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/emirpasic/gods/v2/lists/arraylist"
+	"github.com/ollama/ollama/envconfig"
 )
 
 type History struct {
@@ -38,12 +39,7 @@ func NewHistory() (*History, error) {
 }
 
 func (h *History) Init() error {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return err
-	}
-
-	path := filepath.Join(home, ".ollama", "history")
+	path := filepath.Join(envconfig.Home(), "history")
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}

--- a/server/internal/client/ollama/registry.go
+++ b/server/internal/client/ollama/registry.go
@@ -36,6 +36,7 @@ import (
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/ollama/ollama/envconfig"
 	"github.com/ollama/ollama/server/internal/cache/blob"
 	"github.com/ollama/ollama/server/internal/internal/names"
 
@@ -74,13 +75,7 @@ const (
 )
 
 var defaultCache = sync.OnceValues(func() (*blob.DiskCache, error) {
-	dir := os.Getenv("OLLAMA_MODELS")
-	if dir == "" {
-		home, _ := os.UserHomeDir()
-		home = cmp.Or(home, ".")
-		dir = filepath.Join(home, ".ollama", "models")
-	}
-	return blob.Open(dir)
+	return blob.Open(envconfig.Models())
 })
 
 // DefaultCache returns the default cache used by the registry. It is
@@ -260,16 +255,12 @@ func (r *Registry) parseName(name string) (names.Name, error) {
 }
 
 // DefaultRegistry returns a new Registry configured from the environment. The
-// key is read from $HOME/.ollama/id_ed25519, MaxStreams is set to the
+// key is read from $OLLAMA_HOME/id_ed25519, MaxStreams is set to the
 // value of OLLAMA_REGISTRY_MAXSTREAMS, and ReadTimeout is set to 30 seconds.
 //
 // It returns an error if any configuration in the environment is invalid.
 func DefaultRegistry() (*Registry, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return nil, err
-	}
-	keyPEM, err := os.ReadFile(filepath.Join(home, ".ollama/id_ed25519"))
+	keyPEM, err := os.ReadFile(filepath.Join(envconfig.Home(), "id_ed25519"))
 	if err != nil && errors.Is(err, fs.ErrNotExist) {
 		return nil, err
 	}


### PR DESCRIPTION
Adds an `OLLAMA_HOME` environment variable to configure the Ollama home directory. This allows users to relocate all Ollama data (models, config, logs, keys, history, etc.) to a custom location.

It does this using a `Home()` function in envconfig that checks the `OLLAMA_HOME` env var, with the default being the previously hardcoded value of `~/.ollama`. All code that previously hardcoded this value has been updated to use `envconfig.Home()`

In future it may make sense to set this and OLLAMA_MODELS to default to respecting the XDG standard, however as that would mean either moving the directories or breaking compatibility I have not included it in this pull request.