### PR TITLE
openai: fix inconsistent created timestamp across streaming chunks

### DIFF
--- a/middleware/openai.go
+++ b/middleware/openai.go
@@ -29,6 +29,7 @@ type ChatWriter struct {
 	stream        bool
 	streamOptions *openai.StreamOptions
 	id            string
+	createdAt     int64
 	toolCallSent  bool
 	BaseWriter
 }
@@ -37,6 +38,7 @@ type CompleteWriter struct {
 	stream        bool
 	streamOptions *openai.StreamOptions
 	id            string
+	createdAt     int64
 	BaseWriter
 }
 
@@ -80,7 +82,7 @@ func (w *ChatWriter) writeResponse(data []byte) (int, error) {
 
 	// chat chunk
 	if w.stream {
-		chunks := openai.ToChunks(w.id, chatResponse, w.toolCallSent)
+		chunks := openai.ToChunks(w.id, chatResponse, w.toolCallSent, w.createdAt)
 		w.ResponseWriter.Header().Set("Content-Type", "text/event-stream")
 		for _, c := range chunks {
 			d, err := json.Marshal(c)
@@ -97,7 +99,7 @@ func (w *ChatWriter) writeResponse(data []byte) (int, error) {
 		}
 
 		if chatResponse.Done {
-			c := openai.ToChunk(w.id, chatResponse, w.toolCallSent)
+			c := openai.ToChunk(w.id, chatResponse, w.toolCallSent, w.createdAt)
 			if len(chunks) > 0 {
 				c = chunks[len(chunks)-1]
 			} else {
@@ -153,7 +155,7 @@ func (w *CompleteWriter) writeResponse(data []byte) (int, error) {
 
 	// completion chunk
 	if w.stream {
-		c := openai.ToCompleteChunk(w.id, generateResponse)
+		c := openai.ToCompleteChunk(w.id, generateResponse, w.createdAt)
 		if w.streamOptions != nil && w.streamOptions.IncludeUsage {
 			c.Usage = &openai.Usage{}
 		}
@@ -346,6 +348,7 @@ func CompletionsMiddleware() gin.HandlerFunc {
 			BaseWriter:    BaseWriter{ResponseWriter: c.Writer},
 			stream:        req.Stream,
 			id:            fmt.Sprintf("cmpl-%d", rand.Intn(999)),
+			createdAt:     time.Now().Unix(),
 			streamOptions: req.StreamOptions,
 		}
 
@@ -438,6 +441,7 @@ func ChatMiddleware() gin.HandlerFunc {
 			BaseWriter:    BaseWriter{ResponseWriter: c.Writer},
 			stream:        req.Stream,
 			id:            fmt.Sprintf("chatcmpl-%d", rand.Intn(999)),
+			createdAt:     time.Now().Unix(),
 			streamOptions: req.StreamOptions,
 		}
 

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"slices"
 	"strings"
-	"time"
 
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/types/model"
@@ -291,65 +290,65 @@ func ToChatCompletion(id string, r api.ChatResponse) ChatCompletion {
 	}
 }
 
-func toChunk(id string, r api.ChatResponse, toolCallSent bool) ChatCompletionChunk {
-	toolCalls := ToToolCalls(r.Message.ToolCalls)
+func toChunk(id string, r api.ChatResponse, toolCallSent bool, createdAt int64) ChatCompletionChunk {
+    toolCalls := ToToolCalls(r.Message.ToolCalls)
 
-	var logprobs *ChoiceLogprobs
-	if len(r.Logprobs) > 0 {
-		logprobs = &ChoiceLogprobs{Content: r.Logprobs}
-	}
+    var logprobs *ChoiceLogprobs
+    if len(r.Logprobs) > 0 {
+        logprobs = &ChoiceLogprobs{Content: r.Logprobs}
+    }
 
-	return ChatCompletionChunk{
-		Id:                id,
-		Object:            "chat.completion.chunk",
-		Created:           time.Now().Unix(),
-		Model:             r.Model,
-		SystemFingerprint: "fp_ollama",
-		Choices: []ChunkChoice{{
-			Index: 0,
-			Delta: Message{Role: "assistant", Content: r.Message.Content, ToolCalls: toolCalls, Reasoning: r.Message.Thinking},
-			FinishReason: func(reason string) *string {
-				if len(reason) > 0 {
-					if toolCallSent || len(toolCalls) > 0 {
-						return &finishReasonToolCalls
-					}
-					return &reason
-				}
-				return nil
-			}(r.DoneReason),
-			Logprobs: logprobs,
-		}},
-	}
+    return ChatCompletionChunk{
+        Id:                id,
+        Object:            "chat.completion.chunk",
+        Created:           createdAt,
+        Model:             r.Model,
+        SystemFingerprint: "fp_ollama",
+        Choices: []ChunkChoice{{
+            Index: 0,
+            Delta: Message{Role: "assistant", Content: r.Message.Content, ToolCalls: toolCalls, Reasoning: r.Message.Thinking},
+            FinishReason: func(reason string) *string {
+                if len(reason) > 0 {
+                    if toolCallSent || len(toolCalls) > 0 {
+                        return &finishReasonToolCalls
+                    }
+                    return &reason
+                }
+                return nil
+            }(r.DoneReason),
+            Logprobs: logprobs,
+        }},
+    }
 }
 
 // ToChunks converts an api.ChatResponse to one or more ChatCompletionChunk values.
-func ToChunks(id string, r api.ChatResponse, toolCallSent bool) []ChatCompletionChunk {
-	hasMixedResponse := r.Message.Thinking != "" && (r.Message.Content != "" || len(r.Message.ToolCalls) > 0)
-	if !hasMixedResponse {
-		return []ChatCompletionChunk{toChunk(id, r, toolCallSent)}
-	}
+func ToChunks(id string, r api.ChatResponse, toolCallSent bool, createdAt int64) []ChatCompletionChunk {
+    hasMixedResponse := r.Message.Thinking != "" && (r.Message.Content != "" || len(r.Message.ToolCalls) > 0)
+    if !hasMixedResponse {
+        return []ChatCompletionChunk{toChunk(id, r, toolCallSent, createdAt)}
+    }
 
-	reasoningChunk := toChunk(id, r, toolCallSent)
-	// The logprobs here might include tokens not in this chunk because we now split between thinking and content/tool calls.
-	reasoningChunk.Choices[0].Delta.Content = ""
-	reasoningChunk.Choices[0].Delta.ToolCalls = nil
-	reasoningChunk.Choices[0].FinishReason = nil
+    reasoningChunk := toChunk(id, r, toolCallSent, createdAt)
+    // The logprobs here might include tokens not in this chunk because we now split between thinking and content/tool calls.
+    reasoningChunk.Choices[0].Delta.Content = ""
+    reasoningChunk.Choices[0].Delta.ToolCalls = nil
+    reasoningChunk.Choices[0].FinishReason = nil
 
-	contentOrToolCallsChunk := toChunk(id, r, toolCallSent)
-	// Keep both split chunks on the same timestamp since they represent one logical emission.
-	contentOrToolCallsChunk.Created = reasoningChunk.Created
-	contentOrToolCallsChunk.Choices[0].Delta.Reasoning = ""
-	contentOrToolCallsChunk.Choices[0].Logprobs = nil
+    contentOrToolCallsChunk := toChunk(id, r, toolCallSent, createdAt)
+    // Keep both split chunks on the same timestamp since they represent one logical emission.
+    contentOrToolCallsChunk.Created = reasoningChunk.Created
+    contentOrToolCallsChunk.Choices[0].Delta.Reasoning = ""
+    contentOrToolCallsChunk.Choices[0].Logprobs = nil
 
-	return []ChatCompletionChunk{
-		reasoningChunk,
-		contentOrToolCallsChunk,
-	}
+    return []ChatCompletionChunk{
+        reasoningChunk,
+        contentOrToolCallsChunk,
+    }
 }
 
 // Deprecated: use ToChunks for streaming conversion.
-func ToChunk(id string, r api.ChatResponse, toolCallSent bool) ChatCompletionChunk {
-	return toChunk(id, r, toolCallSent)
+func ToChunk(id string, r api.ChatResponse, toolCallSent bool, createdAt int64) ChatCompletionChunk {
+    return toChunk(id, r, toolCallSent, createdAt)
 }
 
 // ToUsageGenerate converts an api.GenerateResponse to Usage
@@ -384,24 +383,24 @@ func ToCompletion(id string, r api.GenerateResponse) Completion {
 }
 
 // ToCompleteChunk converts an api.GenerateResponse to CompletionChunk
-func ToCompleteChunk(id string, r api.GenerateResponse) CompletionChunk {
-	return CompletionChunk{
-		Id:                id,
-		Object:            "text_completion",
-		Created:           time.Now().Unix(),
-		Model:             r.Model,
-		SystemFingerprint: "fp_ollama",
-		Choices: []CompleteChunkChoice{{
-			Text:  r.Response,
-			Index: 0,
-			FinishReason: func(reason string) *string {
-				if len(reason) > 0 {
-					return &reason
-				}
-				return nil
-			}(r.DoneReason),
-		}},
-	}
+func ToCompleteChunk(id string, r api.GenerateResponse, createdAt int64) CompletionChunk {
+    return CompletionChunk{
+        Id:                id,
+        Object:            "text_completion",
+        Created:           createdAt,
+        Model:             r.Model,
+        SystemFingerprint: "fp_ollama",
+        Choices: []CompleteChunkChoice{{
+            Text:  r.Response,
+            Index: 0,
+            FinishReason: func(reason string) *string {
+                if len(reason) > 0 {
+                    return &reason
+                }
+                return nil
+            }(r.DoneReason),
+        }},
+    }
 }
 
 // ToListCompletion converts an api.ListResponse to ListCompletion

--- a/openai/openai_test.go
+++ b/openai/openai_test.go
@@ -414,145 +414,145 @@ func TestToChatCompletion_WithoutLogprobs(t *testing.T) {
 }
 
 func TestToChunks_SplitsThinkingAndContent(t *testing.T) {
-	resp := api.ChatResponse{
-		Model: "test-model",
-		Message: api.Message{
-			Thinking: "step-by-step",
-			Content:  "final answer",
-		},
-		Done:       true,
-		DoneReason: "stop",
-	}
+    resp := api.ChatResponse{
+        Model: "test-model",
+        Message: api.Message{
+            Thinking: "step-by-step",
+            Content:  "final answer",
+        },
+        Done:       true,
+        DoneReason: "stop",
+    }
 
-	chunks := ToChunks("test-id", resp, false)
-	if len(chunks) != 2 {
-		t.Fatalf("expected 2 chunks, got %d", len(chunks))
-	}
+    chunks := ToChunks("test-id", resp, false, 1234567890)
+    if len(chunks) != 2 {
+        t.Fatalf("expected 2 chunks, got %d", len(chunks))
+    }
 
-	reasoning := chunks[0].Choices[0]
-	if reasoning.Delta.Reasoning != "step-by-step" {
-		t.Fatalf("expected reasoning chunk to contain thinking, got %q", reasoning.Delta.Reasoning)
-	}
-	if reasoning.Delta.Content != "" {
-		t.Fatalf("expected reasoning chunk content to be empty, got %v", reasoning.Delta.Content)
-	}
-	if len(reasoning.Delta.ToolCalls) != 0 {
-		t.Fatalf("expected reasoning chunk tool calls to be empty, got %d", len(reasoning.Delta.ToolCalls))
-	}
-	if reasoning.FinishReason != nil {
-		t.Fatalf("expected reasoning chunk finish reason to be nil, got %q", *reasoning.FinishReason)
-	}
+    reasoning := chunks[0].Choices[0]
+    if reasoning.Delta.Reasoning != "step-by-step" {
+        t.Fatalf("expected reasoning chunk to contain thinking, got %q", reasoning.Delta.Reasoning)
+    }
+    if reasoning.Delta.Content != "" {
+        t.Fatalf("expected reasoning chunk content to be empty, got %v", reasoning.Delta.Content)
+    }
+    if len(reasoning.Delta.ToolCalls) != 0 {
+        t.Fatalf("expected reasoning chunk tool calls to be empty, got %d", len(reasoning.Delta.ToolCalls))
+    }
+    if reasoning.FinishReason != nil {
+        t.Fatalf("expected reasoning chunk finish reason to be nil, got %q", *reasoning.FinishReason)
+    }
 
-	content := chunks[1].Choices[0]
-	if content.Delta.Reasoning != "" {
-		t.Fatalf("expected content chunk reasoning to be empty, got %q", content.Delta.Reasoning)
-	}
-	if content.Delta.Content != "final answer" {
-		t.Fatalf("expected content chunk content %q, got %v", "final answer", content.Delta.Content)
-	}
-	if content.FinishReason == nil || *content.FinishReason != "stop" {
-		t.Fatalf("expected content chunk finish reason %q, got %v", "stop", content.FinishReason)
-	}
+    content := chunks[1].Choices[0]
+    if content.Delta.Reasoning != "" {
+        t.Fatalf("expected content chunk reasoning to be empty, got %q", content.Delta.Reasoning)
+    }
+    if content.Delta.Content != "final answer" {
+        t.Fatalf("expected content chunk content %q, got %v", "final answer", content.Delta.Content)
+    }
+    if content.FinishReason == nil || *content.FinishReason != "stop" {
+        t.Fatalf("expected content chunk finish reason %q, got %v", "stop", content.FinishReason)
+    }
 }
 
 func TestToChunks_SplitsThinkingAndToolCalls(t *testing.T) {
-	resp := api.ChatResponse{
-		Model: "test-model",
-		Message: api.Message{
-			Thinking: "need a tool",
-			ToolCalls: []api.ToolCall{
-				{
-					ID: "call_123",
-					Function: api.ToolCallFunction{
-						Index: 0,
-						Name:  "get_weather",
-						Arguments: testArgs(map[string]any{
-							"location": "Seattle",
-						}),
-					},
-				},
-			},
-		},
-		Done:       true,
-		DoneReason: "stop",
-	}
+    resp := api.ChatResponse{
+        Model: "test-model",
+        Message: api.Message{
+            Thinking: "need a tool",
+            ToolCalls: []api.ToolCall{
+                {
+                    ID: "call_123",
+                    Function: api.ToolCallFunction{
+                        Index: 0,
+                        Name:  "get_weather",
+                        Arguments: testArgs(map[string]any{
+                            "location": "Seattle",
+                        }),
+                    },
+                },
+            },
+        },
+        Done:       true,
+        DoneReason: "stop",
+    }
 
-	chunks := ToChunks("test-id", resp, false)
-	if len(chunks) != 2 {
-		t.Fatalf("expected 2 chunks, got %d", len(chunks))
-	}
+    chunks := ToChunks("test-id", resp, false, 1234567890)
+    if len(chunks) != 2 {
+        t.Fatalf("expected 2 chunks, got %d", len(chunks))
+    }
 
-	reasoning := chunks[0].Choices[0]
-	if reasoning.Delta.Reasoning != "need a tool" {
-		t.Fatalf("expected reasoning chunk to contain thinking, got %q", reasoning.Delta.Reasoning)
-	}
-	if len(reasoning.Delta.ToolCalls) != 0 {
-		t.Fatalf("expected reasoning chunk tool calls to be empty, got %d", len(reasoning.Delta.ToolCalls))
-	}
-	if reasoning.FinishReason != nil {
-		t.Fatalf("expected reasoning chunk finish reason to be nil, got %q", *reasoning.FinishReason)
-	}
+    reasoning := chunks[0].Choices[0]
+    if reasoning.Delta.Reasoning != "need a tool" {
+        t.Fatalf("expected reasoning chunk to contain thinking, got %q", reasoning.Delta.Reasoning)
+    }
+    if len(reasoning.Delta.ToolCalls) != 0 {
+        t.Fatalf("expected reasoning chunk tool calls to be empty, got %d", len(reasoning.Delta.ToolCalls))
+    }
+    if reasoning.FinishReason != nil {
+        t.Fatalf("expected reasoning chunk finish reason to be nil, got %q", *reasoning.FinishReason)
+    }
 
-	toolCallChunk := chunks[1].Choices[0]
-	if toolCallChunk.Delta.Reasoning != "" {
-		t.Fatalf("expected tool-call chunk reasoning to be empty, got %q", toolCallChunk.Delta.Reasoning)
-	}
-	if len(toolCallChunk.Delta.ToolCalls) != 1 {
-		t.Fatalf("expected one tool call in second chunk, got %d", len(toolCallChunk.Delta.ToolCalls))
-	}
-	if toolCallChunk.Delta.ToolCalls[0].ID != "call_123" {
-		t.Fatalf("expected tool call id %q, got %q", "call_123", toolCallChunk.Delta.ToolCalls[0].ID)
-	}
-	if toolCallChunk.FinishReason == nil || *toolCallChunk.FinishReason != finishReasonToolCalls {
-		t.Fatalf("expected tool-call chunk finish reason %q, got %v", finishReasonToolCalls, toolCallChunk.FinishReason)
-	}
+    toolCallChunk := chunks[1].Choices[0]
+    if toolCallChunk.Delta.Reasoning != "" {
+        t.Fatalf("expected tool-call chunk reasoning to be empty, got %q", toolCallChunk.Delta.Reasoning)
+    }
+    if len(toolCallChunk.Delta.ToolCalls) != 1 {
+        t.Fatalf("expected one tool call in second chunk, got %d", len(toolCallChunk.Delta.ToolCalls))
+    }
+    if toolCallChunk.Delta.ToolCalls[0].ID != "call_123" {
+        t.Fatalf("expected tool call id %q, got %q", "call_123", toolCallChunk.Delta.ToolCalls[0].ID)
+    }
+    if toolCallChunk.FinishReason == nil || *toolCallChunk.FinishReason != finishReasonToolCalls {
+        t.Fatalf("expected tool-call chunk finish reason %q, got %v", finishReasonToolCalls, toolCallChunk.FinishReason)
+    }
 }
 
 func TestToChunks_SingleChunkForNonMixedResponses(t *testing.T) {
-	toolCalls := []api.ToolCall{
-		{
-			ID: "call_456",
-			Function: api.ToolCallFunction{
-				Index: 0,
-				Name:  "get_time",
-				Arguments: testArgs(map[string]any{
-					"timezone": "UTC",
-				}),
-			},
-		},
-	}
+    toolCalls := []api.ToolCall{
+        {
+            ID: "call_456",
+            Function: api.ToolCallFunction{
+                Index: 0,
+                Name:  "get_time",
+                Arguments: testArgs(map[string]any{
+                    "timezone": "UTC",
+                }),
+            },
+        },
+    }
 
-	tests := []struct {
-		name    string
-		message api.Message
-	}{
-		{
-			name:    "thinking-only",
-			message: api.Message{Thinking: "pondering"},
-		},
-		{
-			name:    "content-only",
-			message: api.Message{Content: "hello"},
-		},
-		{
-			name:    "toolcalls-only",
-			message: api.Message{ToolCalls: toolCalls},
-		},
-	}
+    tests := []struct {
+        name    string
+        message api.Message
+    }{
+        {
+            name:    "thinking-only",
+            message: api.Message{Thinking: "pondering"},
+        },
+        {
+            name:    "content-only",
+            message: api.Message{Content: "hello"},
+        },
+        {
+            name:    "toolcalls-only",
+            message: api.Message{ToolCalls: toolCalls},
+        },
+    }
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			resp := api.ChatResponse{
-				Model:   "test-model",
-				Message: tt.message,
-			}
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            resp := api.ChatResponse{
+                Model:   "test-model",
+                Message: tt.message,
+            }
 
-			chunks := ToChunks("test-id", resp, false)
-			if len(chunks) != 1 {
-				t.Fatalf("expected 1 chunk, got %d", len(chunks))
-			}
-		})
-	}
+            chunks := ToChunks("test-id", resp, false, 1234567890)
+            if len(chunks) != 1 {
+                t.Fatalf("expected 1 chunk, got %d", len(chunks))
+            }
+        })
+    }
 }
 
 func TestToChunks_SplitsThinkingAndToolCallsWhenNotDone(t *testing.T) {
@@ -576,7 +576,7 @@ func TestToChunks_SplitsThinkingAndToolCallsWhenNotDone(t *testing.T) {
 		Done: false,
 	}
 
-	chunks := ToChunks("test-id", resp, false)
+	chunks := ToChunks("test-id", resp, false, 1234567890)
 	if len(chunks) != 2 {
 		t.Fatalf("expected 2 chunks, got %d", len(chunks))
 	}
@@ -611,7 +611,7 @@ func TestToChunks_SplitsThinkingAndContentWhenNotDone(t *testing.T) {
 		Done: false,
 	}
 
-	chunks := ToChunks("test-id", resp, false)
+	chunks := ToChunks("test-id", resp, false, 1234567890)
 	if len(chunks) != 2 {
 		t.Fatalf("expected 2 chunks, got %d", len(chunks))
 	}
@@ -652,7 +652,7 @@ func TestToChunks_SplitSendsLogprobsOnlyOnFirstChunk(t *testing.T) {
 		DoneReason: "stop",
 	}
 
-	chunks := ToChunks("test-id", resp, false)
+	chunks := ToChunks("test-id", resp, false, 1234567890)
 	if len(chunks) != 2 {
 		t.Fatalf("expected 2 chunks, got %d", len(chunks))
 	}
@@ -682,7 +682,7 @@ func TestToChunk_LegacyMixedThinkingAndContentSingleChunk(t *testing.T) {
 		DoneReason: "stop",
 	}
 
-	chunk := ToChunk("test-id", resp, false)
+	chunk := ToChunk("test-id", resp, false, 1234567890) 
 	if len(chunk.Choices) != 1 {
 		t.Fatalf("expected 1 choice, got %d", len(chunk.Choices))
 	}


### PR DESCRIPTION
### What is the Bug?
Currently, the `created` field in every streaming chunk (`ChatCompletionChunk`) uses `time.Now().Unix()`, while the non-streaming final response uses `r.CreatedAt.Unix()`. 

This violates the OpenAI specification, which states that all streaming chunks for the same request must share the same `created` timestamp. With `time.Now()` called independently on every chunk via `ToChunk`, a long response produces chunks with sliding timestamps.

### The Fix
1. Added a `createdAt` `int64` field to both `ChatWriter` and `CompleteWriter` structs in `middleware/openai.go`.
2. Initialized it exactly once with `time.Now().Unix()` when the middleware sets up the writer.
3. Passed this static timestamp down through `ToChunks`, `ToChunk`, and `ToCompleteChunk` in `openai/openai.go` to ensure absolute timestamp consistency across the entire stream.
4. Updated existing tests in `openai_test.go` to pass a static timestamp.