### PR TITLE
middleware: improve ID entropy for OpenAI-compatible response IDs

### DIFF
--- a/middleware/openai.go
+++ b/middleware/openai.go
@@ -345,7 +345,7 @@ func CompletionsMiddleware() gin.HandlerFunc {
 		w := &CompleteWriter{
 			BaseWriter:    BaseWriter{ResponseWriter: c.Writer},
 			stream:        req.Stream,
-			id:            fmt.Sprintf("cmpl-%d", rand.Intn(999)),
+			id:            fmt.Sprintf("cmpl-%x", rand.Int63()),
 			streamOptions: req.StreamOptions,
 		}
 
@@ -437,7 +437,7 @@ func ChatMiddleware() gin.HandlerFunc {
 		w := &ChatWriter{
 			BaseWriter:    BaseWriter{ResponseWriter: c.Writer},
 			stream:        req.Stream,
-			id:            fmt.Sprintf("chatcmpl-%d", rand.Intn(999)),
+			id:            fmt.Sprintf("chatcmpl-%x", rand.Int63()),
 			streamOptions: req.StreamOptions,
 		}
 
@@ -545,8 +545,8 @@ func ResponsesMiddleware() gin.HandlerFunc {
 
 		c.Request.Body = io.NopCloser(&b)
 
-		responseID := fmt.Sprintf("resp_%d", rand.Intn(999999))
-		itemID := fmt.Sprintf("msg_%d", rand.Intn(999999))
+		responseID := fmt.Sprintf("resp_%x", rand.Int63())
+		itemID := fmt.Sprintf("msg_%x", rand.Int63())
 
 		w := &ResponsesWriter{
 			BaseWriter: BaseWriter{ResponseWriter: c.Writer},


### PR DESCRIPTION
### What is the Bug?
Every OpenAI-compatible chat and completion request generates a unique ID. However, the IDs are currently generated using `rand.Intn(999)` and `rand.Intn(999999)`, which gives a severely limited number of possible values. On any moderately busy server, concurrent requests will routinely collide on the same ID.

Additionally, OpenAI uses high-entropy globally unique identifiers. Ollama currently produces very short IDs like `chatcmpl-42` or `resp_7`.

### The Fix
Replaced `rand.Intn(999)` and `rand.Intn(999999)` with `rand.Int63()` and formatted the output as a hex string (`%x`) in the `ChatMiddleware`, `CompletionsMiddleware`, and `ResponsesMiddleware`.

This vastly improves the entropy (providing ~9.2 quintillion possible values) and produces more authentic-looking IDs (e.g., `chatcmpl-7fffffffffffffff`) without requiring any new external dependencies or impacting performance.