### PR TITLE
Set runner subprocess working directory to temp dir for GPU discovery

### DIFF
--- a/llm/server.go
+++ b/llm/server.go
@@ -369,6 +369,7 @@ func StartRunner(ollamaEngine bool, modelPath string, gpuLibs []string, out io.W
 	}
 
 	cmd = exec.Command(exe, params...)
+	cmd.Dir = os.TempDir()
 
 	cmd.Env = os.Environ()
 


### PR DESCRIPTION
Fixes #15079

When ollama runs as a service user (e.g. www-data) and the current working directory is inaccessible, GPU discovery silently fails because the runner subprocess inherits the parent's cwd. CUDA initialization accesses the working directory for JIT kernel cache and fails when it can't write there.

Sets `cmd.Dir` to `os.TempDir()` so the runner process always starts in an accessible directory.