### PR TITLE
anthropic: fix empty inputs in content blocks

### DIFF
--- a/anthropic/anthropic.go
+++ b/anthropic/anthropic.go
@@ -121,9 +121,9 @@ type ContentBlock struct {
 	Source *ImageSource `json:"source,omitempty"`
 
 	// For tool_use and server_tool_use blocks
-	ID    string                         `json:"id,omitempty"`
-	Name  string                         `json:"name,omitempty"`
-	Input *api.ToolCallFunctionArguments `json:"input,omitempty"`
+	ID    string                        `json:"id,omitempty"`
+	Name  string                        `json:"name,omitempty"`
+	Input api.ToolCallFunctionArguments `json:"input,omitzero"`
 
 	// For tool_result and web_search_tool_result blocks
 	ToolUseID string `json:"tool_use_id,omitempty"`
@@ -447,15 +447,11 @@ func convertMessage(msg MessageParam) ([]api.Message, error) {
 				logutil.Trace("anthropic: tool_use block missing name", "role", role)
 				return nil, errors.New("tool_use block missing required 'name' field")
 			}
-			var args api.ToolCallFunctionArguments
-			if block.Input != nil {
-				args = *block.Input
-			}
 			toolCalls = append(toolCalls, api.ToolCall{
 				ID: block.ID,
 				Function: api.ToolCallFunction{
 					Name:      block.Name,
-					Arguments: args,
+					Arguments: block.Input,
 				},
 			})
 
@@ -492,15 +488,11 @@ func convertMessage(msg MessageParam) ([]api.Message, error) {
 
 		case "server_tool_use":
 			serverToolUseBlocks++
-			var args api.ToolCallFunctionArguments
-			if block.Input != nil {
-				args = *block.Input
-			}
 			toolCalls = append(toolCalls, api.ToolCall{
 				ID: block.ID,
 				Function: api.ToolCallFunction{
 					Name:      block.Name,
-					Arguments: args,
+					Arguments: block.Input,
 				},
 			})
 
@@ -666,12 +658,11 @@ func ToMessagesResponse(id string, r api.ChatResponse) MessagesResponse {
 	}
 
 	for _, tc := range r.Message.ToolCalls {
-		args := tc.Function.Arguments
 		content = append(content, ContentBlock{
 			Type:  "tool_use",
 			ID:    tc.ID,
 			Name:  tc.Function.Name,
-			Input: &args,
+			Input: tc.Function.Arguments,
 		})
 	}
 
@@ -877,8 +868,6 @@ func (c *StreamConverter) Process(r api.ChatResponse) []StreamEvent {
 			slog.Error("failed to marshal tool arguments", "error", err, "tool_id", tc.ID)
 			continue
 		}
-		emptyInput := api.NewToolCallFunctionArguments()
-
 		events = append(events, StreamEvent{
 			Event: "content_block_start",
 			Data: ContentBlockStartEvent{
@@ -888,7 +877,7 @@ func (c *StreamConverter) Process(r api.ChatResponse) []StreamEvent {
 					Type:  "tool_use",
 					ID:    tc.ID,
 					Name:  tc.Function.Name,
-					Input: &emptyInput,
+					Input: api.NewToolCallFunctionArguments(),
 				},
 			},
 		})

--- a/anthropic/anthropic_test.go
+++ b/anthropic/anthropic_test.go
@@ -191,7 +191,6 @@ func TestFromMessagesRequest_WithImage(t *testing.T) {
 }
 
 func TestFromMessagesRequest_WithToolUse(t *testing.T) {
-	toolInput := makeArgs("location", "Paris")
 	req := MessagesRequest{
 		Model:     "test-model",
 		MaxTokens: 1024,
@@ -204,7 +203,7 @@ func TestFromMessagesRequest_WithToolUse(t *testing.T) {
 						Type:  "tool_use",
 						ID:    "call_123",
 						Name:  "get_weather",
-						Input: &toolInput,
+						Input: makeArgs("location", "Paris"),
 					},
 				},
 			},
@@ -1221,9 +1220,7 @@ func TestStreamConverter_ContentBlockStartIncludesEmptyFields(t *testing.T) {
 				if start, ok := e.Data.(ContentBlockStartEvent); ok {
 					if start.ContentBlock.Type == "tool_use" {
 						foundToolStart = true
-						if start.ContentBlock.Input == nil {
-							t.Error("content_block_start for tool_use should include 'input' field")
-						} else if start.ContentBlock.Input.Len() != 0 {
+						if start.ContentBlock.Input.Len() != 0 {
 							t.Errorf("expected empty input object, got len=%d", start.ContentBlock.Input.Len())
 						}
 
@@ -1425,7 +1422,6 @@ func TestConvertTool_RegularTool(t *testing.T) {
 }
 
 func TestConvertMessage_ServerToolUse(t *testing.T) {
-	serverToolInput := makeArgs("query", "test query")
 	msg := MessageParam{
 		Role: "assistant",
 		Content: []ContentBlock{
@@ -1433,7 +1429,7 @@ func TestConvertMessage_ServerToolUse(t *testing.T) {
 				Type:  "server_tool_use",
 				ID:    "srvtoolu_123",
 				Name:  "web_search",
-				Input: &serverToolInput,
+				Input: makeArgs("query", "test query"),
 			},
 		},
 	}

--- a/middleware/anthropic.go
+++ b/middleware/anthropic.go
@@ -943,10 +943,10 @@ func writeSSE(w http.ResponseWriter, eventType string, data any) error {
 }
 
 // queryArgs creates a ToolCallFunctionArguments with a single "query" key.
-func queryArgs(query string) *api.ToolCallFunctionArguments {
+func queryArgs(query string) api.ToolCallFunctionArguments {
 	args := api.NewToolCallFunctionArguments()
 	args.Set("query", query)
-	return &args
+	return args
 }
 
 // serverToolUseID derives a server tool use ID from a message ID


### PR DESCRIPTION
When we switched to `api.ToolCallFunctionArguments`, `omitempty` stopped doing what we were relying on it for before. This would cause non-tool content blocks to have an `"input": {}` field, which doesn't match our old behavior.