### PR TITLE
Expose numeric parameter_count in model details

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -908,6 +908,7 @@ type ModelDetails struct {
 	Family            string   `json:"family"`
 	Families          []string `json:"families"`
 	ParameterSize     string   `json:"parameter_size"`
+	ParameterCount    int64    `json:"parameter_count,omitempty"`
 	QuantizationLevel string   `json:"quantization_level"`
 }
 

--- a/server/routes.go
+++ b/server/routes.go
@@ -25,6 +25,7 @@ import (
 	"sync/atomic"
 	"syscall"
 	"time"
+	"strconv"
 
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
@@ -1210,7 +1211,10 @@ func GetModelInfo(req api.ShowRequest) (*api.ShowResponse, error) {
 	if slices.Contains(m.Capabilities(), model.CapabilityImage) {
 		if info, err := imagegenmanifest.GetModelInfo(name.String()); err == nil {
 			modelDetails.Family = info.Architecture
-			modelDetails.ParameterSize = format.HumanNumber(uint64(info.ParameterCount))
+			if info.ParameterCount > 0 {
+				modelDetails.ParameterCount = info.ParameterCount
+				modelDetails.ParameterSize = format.HumanNumber(uint64(info.ParameterCount))
+			}
 			modelDetails.QuantizationLevel = info.Quantization
 		}
 	}
@@ -1222,6 +1226,7 @@ func GetModelInfo(req api.ShowRequest) (*api.ShowResponse, error) {
 				modelDetails.Family = arch
 			}
 			if paramCount, ok := info["general.parameter_count"].(int64); ok && paramCount > 0 {
+				modelDetails.ParameterCount = paramCount
 				modelDetails.ParameterSize = format.HumanNumber(uint64(paramCount))
 			}
 		}
@@ -1231,6 +1236,13 @@ func GetModelInfo(req api.ShowRequest) (*api.ShowResponse, error) {
 				modelDetails.QuantizationLevel = dtype
 			}
 		}
+	}
+
+	// If we still don't have an explicit parameter count but do have a
+	// human-readable size, derive an approximate numeric count so clients can
+	// make capability-aware decisions based on model scale.
+	if modelDetails.ParameterCount == 0 && modelDetails.ParameterSize != "" {
+		modelDetails.ParameterCount = parseParameterSize(modelDetails.ParameterSize)
 	}
 
 	if req.System != "" {
@@ -1281,6 +1293,46 @@ func GetModelInfo(req api.ShowRequest) (*api.ShowResponse, error) {
 				resp.ModelInfo[fmt.Sprintf("%s.embedding_length", m.Config.ModelFamily)] = m.Config.EmbedLen
 			}
 		}
+
+		return resp, nil
+	}
+
+	// parseParameterSize converts a human-readable parameter size (for example,
+	// "7B", "2.1B", or "430M") into an approximate numeric parameter count. It
+	// mirrors the formatting used by format.HumanNumber so clients can make
+	// capability decisions based on model scale without needing to reverse-engineer
+	// the string representation themselves.
+	func parseParameterSize(s string) int64 {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			return 0
+		}
+
+		multiplier := int64(1)
+		last := s[len(s)-1]
+		switch last {
+		case 'K', 'k':
+			multiplier = format.Thousand
+			s = s[:len(s)-1]
+		case 'M', 'm':
+			multiplier = format.Million
+			s = s[:len(s)-1]
+		case 'B', 'b':
+			multiplier = format.Billion
+			s = s[:len(s)-1]
+		}
+
+		value, err := strconv.ParseFloat(s, 64)
+		if err != nil {
+			return 0
+		}
+
+		count := int64(math.Round(value * float64(multiplier)))
+		if count < 0 {
+			return 0
+		}
+
+		return count
 	}
 
 	var params []string
@@ -1430,6 +1482,7 @@ func (s *Server) ListHandler(c *gin.Context) {
 				Family:            cf.ModelFamily,
 				Families:          cf.ModelFamilies,
 				ParameterSize:     cf.ModelType,
+				ParameterCount:    parseParameterSize(cf.ModelType),
 				QuantizationLevel: cf.FileType,
 			},
 		})
@@ -2050,6 +2103,7 @@ func (s *Server) PsHandler(c *gin.Context) {
 			Family:            model.Config.ModelFamily,
 			Families:          model.Config.ModelFamilies,
 			ParameterSize:     model.Config.ModelType,
+			ParameterCount:    parseParameterSize(model.Config.ModelType),
 			QuantizationLevel: model.Config.FileType,
 		}
 

--- a/server/routes_create_test.go
+++ b/server/routes_create_test.go
@@ -762,6 +762,7 @@ func TestCreateAndShowRemoteModel(t *testing.T) {
 		Family:            "gptoss",
 		Families:          []string{"gptoss"},
 		ParameterSize:     "20.9B",
+		ParameterCount:    parseParameterSize("20.9B"),
 		QuantizationLevel: "MXFP4",
 	}
 


### PR DESCRIPTION
Fixes #15067

## Summary

Expose a numeric `parameter_count` field in model metadata so clients can adapt tool definitions based on model size (Option B from the issue: expose model metadata to clients).

## Changes

- API:
  - Extend `ModelDetails` with a new `parameter_count` field (in addition to the existing human-readable `parameter_size`).
- Server:
  - `/api/show`:
    - Populate `details.parameter_count` from:
      - Safetensors LLM metadata (`general.parameter_count`), when available.
      - Image generation manifest `ParameterCount`, when available.
      - Otherwise, derive an approximate numeric count from `details.parameter_size` (e.g., `"7B"`, `"430M"`, `"15K"`).
  - `/api/ps`:
    - Include `details.parameter_count` by deriving it from the existing `details.parameter_size`.
  - `/api/tags`:
    - Include `details.parameter_count` for listed models, also derived from `details.parameter_size`.
- Tests:
  - Update existing `ShowHandler` test expectations to account for the new `parameter_count` field while keeping prior behavior unchanged.

## Rationale

Clients that use `/api/chat` with tools can now call `/api/show` (or reuse `/api/ps` / `/api/tags`) to read a numeric `parameter_count` and implement capability-aware tool presentation on their side (e.g., different tool tiers for small vs. large models), without changing the current chat/tool prompting behavior on the server.