### PR TITLE
fix: prevent head-of-line blocking in scheduler during model eviction

### DIFF
--- a/server/sched.go
+++ b/server/sched.go
@@ -261,15 +261,49 @@ func (s *Scheduler) processPending(ctx context.Context) {
 					s.expiredCh <- runnerToExpire
 				}
 				runnerToExpire.refMu.Unlock()
-				// Wait for the unload to happen
+				// Wait for the unload to happen, but keep dispatching
+				// requests for models that are already loaded. This prevents
+				// head-of-line blocking where a request for an idle, loaded
+				// model waits behind a slow eviction/load cycle.
+				// See: https://github.com/ollama/ollama/issues/14578
 				slog.Debug("waiting for pending requests to complete and unload to occur", "runner", runnerToExpire)
-				select {
-				case <-ctx.Done():
-					slog.Debug("shutting down scheduler pending loop")
-					return
-				case <-s.unloadedCh:
-					slog.Debug("unload completed", "runner", runnerToExpire)
-					continue
+				var deferred []*LlmRequest
+			waitForUnload:
+				for {
+					select {
+					case <-ctx.Done():
+						slog.Debug("shutting down scheduler pending loop")
+						return
+					case <-s.unloadedCh:
+						slog.Debug("unload completed", "runner", runnerToExpire)
+						break waitForUnload
+					case otherReq := <-s.pendingReqCh:
+						// While waiting for unload, service requests that can
+						// be fulfilled by runners that are already loaded.
+						if otherReq.ctx.Err() != nil {
+							slog.Debug("dequeued pending request already cancelled, skipping")
+							continue
+						}
+						otherKey := schedulerModelKey(otherReq.model)
+						s.loadedMu.Lock()
+						otherRunner := s.loaded[otherKey]
+						s.loadedMu.Unlock()
+						if otherRunner != nil && !otherRunner.needsReload(ctx, otherReq) {
+							logutil.Trace("dispatching ready request while waiting for unload", "model", otherKey)
+							otherReq.useLoadedRunner(otherRunner, s.finishedReqCh)
+						} else {
+							// Can't dispatch yet \u2014 buffer for re-enqueue
+							deferred = append(deferred, otherReq)
+						}
+					}
+				}
+				// Re-enqueue any requests that couldn't be dispatched immediately
+				for _, d := range deferred {
+					select {
+					case s.pendingReqCh <- d:
+					default:
+						d.errCh <- ErrMaxQueue
+					}
 				}
 			}
 		case <-s.unloadedCh:

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -996,3 +996,118 @@ func TestImageGenSchedulerCoexistence(t *testing.T) {
 	expectedFree := uint64(24*format.GigaByte) - uint64(8*format.GigaByte) - uint64(4*format.GigaByte)
 	require.Equal(t, expectedFree, gpus[0].FreeMemory)
 }
+
+// TestSchedNoHeadOfLineBlocking verifies that requests for already-loaded
+// models are dispatched while the scheduler is waiting for an eviction to
+// complete, preventing head-of-line blocking.
+// Regression test for https://github.com/ollama/ollama/issues/14578
+//
+// Scenario:
+//   - Model A is loaded and actively processing (refCount > 0, can't be evicted)
+//   - Model B is loaded and actively processing (refCount > 0)
+//   - Request for model D arrives (needs space → scheduler picks B to evict)
+//   - B has refCount > 0, so eviction blocks waiting for B's request to finish
+//   - While blocked, a request for model A arrives in the pending queue
+//   - With the fix: A's request is dispatched immediately using the loaded runner
+//   - Without the fix: A's request waits behind B's eviction (head-of-line blocking)
+func TestSchedNoHeadOfLineBlocking(t *testing.T) {
+	ctx, done := context.WithTimeout(t.Context(), 5000*time.Millisecond)
+	defer done()
+	s := InitScheduler(ctx)
+	s.waitForRecovery = 10 * time.Millisecond
+	s.getGpuFn = getGpuFn
+	s.getSystemInfoFn = getSystemInfoFn
+
+	// Load model A (small, keep-alive long)
+	a := newScenarioRequest(t, ctx, "model-resident", 1*format.GigaByte, &api.Duration{Duration: 30 * time.Second}, map[ml.DeviceID]uint64{{Library: "Metal"}: 1 * format.GigaByte})
+	s.newServerFn = a.newServer
+	slog.Info("Loading resident model A")
+	s.pendingReqCh <- a.req
+	s.Run(ctx)
+	select {
+	case resp := <-a.req.successCh:
+		require.Equal(t, resp.llama, a.srv)
+	case err := <-a.req.errCh:
+		t.Fatal(err.Error())
+	case <-ctx.Done():
+		t.Fatal("timeout loading A")
+	}
+	// DO NOT call a.ctxDone — keep A's refCount > 0 so it can't be evicted
+
+	// Load model B (also with active request)
+	t.Setenv("OLLAMA_MAX_LOADED_MODELS", "0")
+	b := newScenarioRequest(t, ctx, "model-to-evict", 10*format.GigaByte, &api.Duration{Duration: 5 * time.Millisecond}, map[ml.DeviceID]uint64{{Library: "Metal"}: 10 * format.GigaByte})
+	s.newServerFn = b.newServer
+	slog.Info("Loading model B")
+	s.pendingReqCh <- b.req
+	select {
+	case resp := <-b.req.successCh:
+		require.Equal(t, resp.llama, b.srv)
+	case err := <-b.req.errCh:
+		t.Fatal(err.Error())
+	case <-ctx.Done():
+		t.Fatal("timeout loading B")
+	}
+	// DO NOT call b.ctxDone — B has refCount > 0, eviction will block
+
+	s.loadedMu.Lock()
+	require.Len(t, s.loaded, 2)
+	s.loadedMu.Unlock()
+
+	// Request model D that won't fit — triggers eviction.
+	// Scheduler picks B (shorter duration) to evict, but B has refCount > 0
+	// so processPending blocks on <-s.unloadedCh.
+	d := newScenarioRequest(t, ctx, "model-new-big", 8*format.GigaByte, nil, map[ml.DeviceID]uint64{{Library: "Metal"}: 8 * format.GigaByte})
+	s.newServerFn = d.newServer
+
+	// Prepare a second request for model A (already loaded)
+	a2 := newScenarioRequest(t, ctx, "model-resident", 1*format.GigaByte, nil, map[ml.DeviceID]uint64{{Library: "Metal"}: 1 * format.GigaByte})
+	a2.req.model = a.req.model // Same model, so it's already loaded
+	a2.srv = a.srv
+
+	slog.Info("Submitting D (triggers eviction of B, which will block)")
+	s.pendingReqCh <- d.req
+	time.Sleep(5 * time.Millisecond) // Let processPending pick up D and enter the eviction wait
+
+	slog.Info("Submitting A2 (for already-loaded model A)")
+	s.pendingReqCh <- a2.req
+
+	// A2 should be dispatched quickly by our fix (which drains pending while
+	// waiting for unload). Without the fix, A2 is stuck until B's eviction
+	// completes — which won't happen until we call b.ctxDone below.
+	a2Timer := time.NewTimer(500 * time.Millisecond)
+	select {
+	case resp := <-a2.req.successCh:
+		a2Timer.Stop()
+		require.Equal(t, resp.llama, a.srv)
+		slog.Info("SUCCESS: request for loaded model A dispatched while eviction blocked")
+	case err := <-a2.req.errCh:
+		a2Timer.Stop()
+		t.Fatalf("unexpected error for A2: %v", err)
+	case <-a2Timer.C:
+		t.Fatal("FAIL: request for already-loaded model A was blocked by eviction (head-of-line blocking)")
+	}
+
+	// Now unblock B's eviction so D can load
+	b.ctxDone()
+	time.Sleep(2 * time.Millisecond)
+	s.getGpuFn = func(ctx context.Context, runners []ml.FilteredRunnerDiscovery) []ml.DeviceInfo {
+		g := ml.DeviceInfo{DeviceID: ml.DeviceID{Library: "Metal"}}
+		g.TotalMemory = 24 * format.GigaByte
+		g.FreeMemory = 24 * format.GigaByte
+		return []ml.DeviceInfo{g}
+	}
+	select {
+	case resp := <-d.req.successCh:
+		require.Equal(t, resp.llama, d.srv)
+	case err := <-d.req.errCh:
+		t.Fatal(err.Error())
+	case <-ctx.Done():
+		t.Fatal("timeout loading D")
+	}
+
+	// Cleanup
+	a.ctxDone()
+	a2.ctxDone()
+	d.ctxDone()
+}


### PR DESCRIPTION
## Problem

When the scheduler needs to evict a model to make room for a new one, `processPending` blocks on `<-s.unloadedCh`. During this wait, **all** other pending requests are frozen — even requests for models that are already loaded and ready to serve.

This is classic head-of-line blocking: a request for an idle, loaded model waits behind a slow eviction/load cycle that has nothing to do with it.

Fixes #14578

## Root Cause

In `server/sched.go`, the `processPending` goroutine processes requests single-threaded from `pendingReqCh`. When it decides to evict a runner, it enters a blocking `select` that only listens for `ctx.Done()` or `s.unloadedCh`. Any new requests that arrive on `pendingReqCh` during this window are stuck in the channel buffer until the eviction completes.

## Solution

Replace the simple blocking `select` with a `for/select` loop that **also drains `pendingReqCh`** while waiting for the eviction:

- Requests for **already-loaded models** are dispatched immediately via `useLoadedRunner`
- - Requests that **cannot be served yet** (model not loaded) are buffered in a `deferred` slice
- - After the eviction completes, deferred requests are **re-enqueued** back into `pendingReqCh`
- - Cancelled requests are detected and skipped via `ctx.Err()` check
The fix is surgical — it only changes the eviction-wait code path and preserves all existing scheduler invariants.

## Test

Added `TestSchedNoHeadOfLineBlocking` which:
1. Loads model A (active, refCount > 0, cannot be evicted)
2. 2. Loads model B (active, refCount > 0)
3. 3. Submits request for model D (triggers B eviction, which blocks because B is active)
4. 4. Submits request for model A (already loaded)
5. 5. Asserts A's request is dispatched within 500ms (would timeout without the fix)
6. 6. Then unblocks B's eviction and confirms D loads successfully
All 17 existing scheduler tests pass with zero regressions.