### PR TITLE
Fix: image path not recognized correctly with escaped spaces

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -592,7 +592,7 @@ func extractFileNames(input string) []string {
 	// Regex to match file paths starting with optional drive letter, / ./ \ or .\ and include escaped or unescaped spaces (\ or %20)
 	// and followed by more characters and a file extension
 	// This will capture non filename strings, but we'll check for file existence to remove mismatches
-	regexPattern := `(?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp)\b`
+	regexPattern := `(?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+\.(?i:jpg|jpeg|png|webp)\b`
 	re := regexp.MustCompile(regexPattern)
 
 	return re.FindAllString(input, -1)

--- a/x/imagegen/cli.go
+++ b/x/imagegen/cli.go
@@ -520,7 +520,7 @@ func displayImageInTerminal(imagePath string) bool {
 // extractFileNames finds image file paths in the input string.
 func extractFileNames(input string) []string {
 	// Regex to match file paths with image extensions
-	regexPattern := `(?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp)\b`
+	regexPattern := `(?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+\.(?i:jpg|jpeg|png|webp)\b`
 	re := regexp.MustCompile(regexPattern)
 	return re.FindAllString(input, -1)
 }


### PR DESCRIPTION
## Problem

When dragging an image in the CLI, file paths with escaped spaces are not properly recognized.

Example:
```
/Users/ollama/Library/Mobile\ Documents/com~apple~CloudDocs/screenshots/CleanShot\ 2025-04-17\ at\ 21.26.40@2x.png
```

## Solution

Changed the regex pattern in `extractFileNames` from non-greedy (`+?`) to greedy (`+`) matching to ensure paths with escaped spaces are fully captured.

The non-greedy quantifier could cause premature matching when encountering escaped spaces (`\ `) in file paths, resulting in incomplete path extraction.

## Changes

- `cmd/interactive.go`: Changed `[\S\\ ]+?` to `[\S\\ ]+`
- `x/imagegen/cli.go`: Same fix for consistency

Fixes #10333