### PR TITLE
fix: memory leak when when vocab loading from file failed

### DIFF
--- a/llama/sampling_ext.cpp
+++ b/llama/sampling_ext.cpp
@@ -76,6 +76,7 @@ struct llama_vocab * llama_load_vocab_from_file(const char * fname) {
         vocab->load(ml, kv);
     } catch (const std::exception & err) {
         LLAMA_LOG_ERROR("%s: error loading model: %s\n", __func__, err.what());
+        delete vocab;
         return nullptr;
     }
 


### PR DESCRIPTION
# Summary

There is a memory leak that happens when an exception is thrown during loading a vocab from file.

# Fix

Delete created object in catch block.