### PR TITLE
mlx: enhance multimodal pipeline with snapshot scheduling and diagnostics

### DIFF
--- a/x/mlxrunner/cache.go
+++ b/x/mlxrunner/cache.go
@@ -20,6 +20,7 @@ import (
 	"cmp"
 	"fmt"
 	"log/slog"
+	"slices"
 	"time"
 
 	"github.com/ollama/ollama/logutil"
@@ -37,6 +38,12 @@ type kvCache struct {
 	pagedOutBytes int64 // total bytes in paged-out snapshots across the trie
 }
 
+// pendingSnapshot is a snapshot scheduled to be taken during prefill.
+type pendingSnapshot struct {
+	offset int
+	user   bool
+}
+
 // cacheSession manages caches for a single pipeline run.
 // Callers should append generated tokens to outputs and
 // defer close to save the cache state.
@@ -48,11 +55,10 @@ type cacheSession struct {
 	caches    []cache.Cache
 	remaining []int32
 
-	// snapshotOffset, if > 0, is a trie node boundary where we need to
-	// capture a snapshot during prefill. This enables future requests
-	// branching at this point to restore non-rewindable caches (e.g.
-	// RecurrentCache) instead of re-evaluating from scratch.
-	snapshotOffset int
+	// pendingSnapshots lists offsets where snapshots should be captured
+	// during prefill, sorted by offset. Entries are consumed as the
+	// cache advances past them.
+	pendingSnapshots []pendingSnapshot
 }
 
 func (c *kvCache) ensureCaches(m base.Model) {
@@ -93,56 +99,38 @@ func (c *kvCache) begin(m base.Model, inputs []int32) *cacheSession {
 		matchPath, matched = findBestMatch(c.root, inputs[:len(inputs)-1])
 	}
 
-	// Check for partial match within a node's edge — truncate path
-	// to the parent boundary. snapshot() will split the node and
-	// create the branch point during prefill when caches are ready.
-	partialMatch := false
-	if len(matchPath) > 1 {
-		lastNode := matchPath[len(matchPath)-1]
-		matchedInEdge := matched - lastNode.startOffset()
-		if matchedInEdge > 0 && matchedInEdge < len(lastNode.tokens) {
-			matchPath = matchPath[:len(matchPath)-1]
-			partialMatch = true
-		}
-	}
-
 	// Switch to the matched path, paging in/out as needed.
-	c.switchToPath(matchPath)
+	c.switchToPath(matchPath, matched)
 
 	// switchToPath aligns caches to a common offset
 	prefix := c.minCacheOffset()
 	remaining := inputs[prefix:]
 
+	session := &cacheSession{
+		cache:     c,
+		inputs:    inputs,
+		caches:    c.caches,
+		remaining: remaining,
+	}
+
 	// Schedule a snapshot at the branch point during prefill so future
 	// requests diverging here can restore instead of re-evaluating.
-	var snapshotAt int
-	if partialMatch || (prefix == 0 && matched > 0) {
-		snapshotAt = matched
+	if prefix < matched {
+		session.pendingSnapshots = append(session.pendingSnapshots, pendingSnapshot{offset: matched, user: false})
 	}
 
-	args := []any{"total", len(inputs), "matched", originalMatched}
-	args = append(args, "cached", prefix, "left", len(remaining))
-	if snapshotAt > 0 {
-		args = append(args, "pending_snapshot", snapshotAt)
-	}
+	msg := "cache hit"
 	if prefix == 0 {
-		slog.Info("cache miss", args...)
-	} else {
-		slog.Info("cache hit", args...)
+		msg = "cache miss"
 	}
+	slog.Info(msg, "total", len(inputs), "matched", originalMatched, "cached", prefix, "left", len(remaining))
 
-	return &cacheSession{
-		cache:          c,
-		inputs:         inputs,
-		snapshotOffset: snapshotAt,
-		caches:         c.caches,
-		remaining:      remaining,
-	}
+	return session
 }
 
 // switchToPath transitions from the current active path to a new path,
 // paging out diverging segments and paging in the new path.
-func (c *kvCache) switchToPath(newPath []*trieNode) {
+func (c *kvCache) switchToPath(newPath []*trieNode, matched int) {
 	defer c.enforceEvictionPolicy()
 
 	// Find common ancestor index.
@@ -167,7 +155,10 @@ func (c *kvCache) switchToPath(newPath []*trieNode) {
 	// non-leaf nodes here would produce wrong results for non-rewindable
 	// caches (e.g. RecurrentCache) whose state reflects the leaf, not
 	// the intermediate boundary.
-	if leaf := len(c.activePath) - 1; leaf >= commonLen {
+	leaf := len(c.activePath) - 1
+	leafDiverges := leaf >= commonLen
+	leafNeedsRewind := matched < c.activePath[leaf].endOffset
+	if leafDiverges || leafNeedsRewind {
 		node := c.activePath[leaf]
 		if !node.hasAllSnapshots() {
 			fromOffset := node.startOffset()
@@ -184,14 +175,16 @@ func (c *kvCache) switchToPath(newPath []*trieNode) {
 		}
 	}
 
-	// Rewind each cache to the ancestor offset or free it. Freed
-	// caches (e.g. RecurrentCache that can't rewind) will be restored
-	// from snapshots during page-in.
+	// Rewind each cache to the target offset or free it. When matched
+	// falls within the ancestor's range (same-path case), we rewind
+	// directly to the match point. Otherwise we rewind to the ancestor
+	// and let page-in bring us forward to matched.
+	rewindTarget := min(ancestorOffset, matched)
 	for _, kv := range c.caches {
 		if kv == nil {
 			continue
 		}
-		if !kv.Restore(nil, ancestorOffset) {
+		if !kv.Restore(nil, rewindTarget) {
 			kv.Free()
 		}
 	}
@@ -199,10 +192,12 @@ func (c *kvCache) switchToPath(newPath []*trieNode) {
 	// Page in — walk the full new path, restoring from snapshots.
 	// Freed caches naturally pick up the first available snapshot.
 	// Caches already past a node skip it via offset check.
+pageIn:
 	for _, node := range newPath {
-		if len(node.snapshots) == 0 {
+		if !node.hasSnapshots() {
 			continue
 		}
+		nodeTarget := min(node.endOffset, matched)
 		for j, kv := range c.caches {
 			if kv == nil {
 				continue
@@ -210,19 +205,18 @@ func (c *kvCache) switchToPath(newPath []*trieNode) {
 			if j >= len(node.snapshots) || node.snapshots[j] == nil {
 				continue
 			}
-			if kv.Offset() >= node.endOffset {
+			if kv.Offset() >= nodeTarget {
 				continue
 			}
-			if !kv.Restore(node.snapshots[j], node.endOffset) {
-				slog.Warn("cache restore failure during page-in, freeing all caches", "layer", j, "offset", node.startOffset())
-				c.freeAll()
-				c.activePath = []*trieNode{c.root}
-				return
+			if !kv.Restore(node.snapshots[j], nodeTarget) {
+				// Restore failed — stop page-in and let alignment
+				// bring all caches to a consistent offset.
+				break pageIn
 			}
 		}
 		if node.endOffset > ancestorOffset {
 			pageInCount++
-			logutil.Trace(fmt.Sprintf("page in: [%d, %d)", node.startOffset(), node.endOffset))
+			logutil.Trace(fmt.Sprintf("page in: [%d, %d)", node.startOffset(), nodeTarget))
 		}
 	}
 
@@ -245,25 +239,66 @@ func (c *kvCache) switchToPath(newPath []*trieNode) {
 		}
 	}
 
+	// Update last-used time on only the final used node. For recurrent
+	// caches we don't need the intermediate snapshots and for KV caches
+	// we can reslice the data out of merged edges.
+	if len(c.activePath) > 0 {
+		c.activePath[len(c.activePath)-1].lastUsed = time.Now()
+	}
+
 	if pageOutCount > 0 || pageInCount > 0 {
 		slog.Debug("switching cache path", "page_out", pageOutCount, "page_in", pageInCount)
 	}
 }
 
-// snapshot creates a snapshot at the current cache position. During prefill,
-// it is called at branch points (user=false) to create restore points for
-// future diverging requests and with user=true to mark an explicit reusable
-// restore point.
-func (s *cacheSession) snapshot(user bool) {
+// requestSnapshot schedules a user snapshot at the given absolute token
+// offset. The snapshot will be captured during prefill when the cache
+// reaches this offset.
+func (s *cacheSession) requestSnapshot(offset int) {
+	baseOffset := len(s.inputs) - len(s.remaining)
+	if offset <= baseOffset || offset > len(s.inputs) {
+		return
+	}
+	// Deduplicate: if this offset already exists, upgrade to user.
+	for i := range s.pendingSnapshots {
+		if s.pendingSnapshots[i].offset == offset {
+			s.pendingSnapshots[i].user = true
+			return
+		}
+	}
+	s.pendingSnapshots = append(s.pendingSnapshots, pendingSnapshot{offset: offset, user: true})
+	slices.SortFunc(s.pendingSnapshots, func(a, b pendingSnapshot) int {
+		return a.offset - b.offset
+	})
+}
+
+// nextPendingSnapshot returns the offset of the next pending snapshot,
+// or 0 if there are none.
+func (s *cacheSession) nextPendingSnapshot() int {
+	if len(s.pendingSnapshots) == 0 {
+		return 0
+	}
+	return s.pendingSnapshots[0].offset
+}
+
+// snapshot creates a snapshot at the current cache position. It determines
+// whether this is a user snapshot by consuming pending entries whose offset
+// has been reached.
+func (s *cacheSession) snapshot() {
 	c := s.cache
 	cacheOffset := c.minCacheOffset()
 	if cacheOffset <= 0 {
 		return
 	}
 
-	// Clear pending intermediate snapshot if we've reached or passed it.
-	if s.snapshotOffset > 0 && cacheOffset >= s.snapshotOffset {
-		s.snapshotOffset = 0
+	// Consume pending snapshots up to the current offset and derive
+	// the user flag from them.
+	user := false
+	for len(s.pendingSnapshots) > 0 && cacheOffset >= s.pendingSnapshots[0].offset {
+		if s.pendingSnapshots[0].user {
+			user = true
+		}
+		s.pendingSnapshots = s.pendingSnapshots[1:]
 	}
 
 	// The last node in activePath is the frontier where caches are advancing.
@@ -362,6 +397,7 @@ func (s *cacheSession) attachSnapshots(node *trieNode, cacheOffset int) {
 		}
 	}
 	node.setSnapshots(snaps, &c.pagedOutBytes)
+	node.lastUsed = time.Now()
 	slog.Debug("created snapshot", "offset", cacheOffset)
 	c.enforceEvictionPolicy()
 }
@@ -371,12 +407,7 @@ func (s *cacheSession) attachSnapshots(node *trieNode, cacheOffset int) {
 func (c *kvCache) clear() {
 	c.freeAll()
 	walkNodes(c.root, func(n *trieNode) bool {
-		for _, s := range n.snapshots {
-			if s != nil {
-				s.Close()
-			}
-		}
-		n.snapshots = nil
+		n.setSnapshots(nil, &c.pagedOutBytes)
 		return true
 	})
 	c.root = nil
@@ -436,10 +467,7 @@ func (s *cacheSession) close() {
 			newTokens := stored[frontier.endOffset:offset]
 			c.advancePath(frontier, newTokens, offset)
 		}
-		now := time.Now()
-		for _, node := range c.activePath {
-			node.lastUsed = now
-		}
+		c.activePath[len(c.activePath)-1].lastUsed = time.Now()
 	}
 }
 
@@ -457,7 +485,7 @@ func (c *kvCache) enforceEvictionPolicy() {
 	for c.pagedOutBytes > maxPagedOutBytes {
 		var best *trieNode
 		walkNodes(c.root, func(n *trieNode) bool {
-			if n == c.root || activeSet[n] || !n.hasSnapshots() {
+			if n == c.root || activeSet[n] || len(n.children) > 1 {
 				return true
 			}
 			// Evict: oldest, then deepest, then largest.
@@ -481,27 +509,16 @@ func (c *kvCache) enforceEvictionPolicy() {
 func (c *kvCache) evictNode(node *trieNode) {
 	if len(node.children) == 0 {
 		// Leaf: remove entirely.
-		parent := node.parent
-		kind := "evicting leaf"
-		if node.user {
-			kind = "evicting user snapshot"
-		}
-		slog.Debug(kind, "offset", node.startOffset(), "tokens", len(node.tokens), "freed", mlx.PrettyBytes(int(node.snapshotBytes())))
+		slog.Debug("evicting leaf", "offset", node.startOffset(), "tokens", len(node.tokens), "freed", mlx.PrettyBytes(int(node.snapshotBytes())))
 		removeNode(node, &c.pagedOutBytes)
-
-		// If parent is a regular (non-user-snapshot) node with one remaining child, auto-merge.
-		if parent != nil && !parent.user && len(parent.children) == 1 && parent != c.root {
-			logutil.Trace(fmt.Sprintf("auto-merging parent at offset %d with single child", parent.endOffset))
-			mergeWithChild(parent, c.caches, &c.pagedOutBytes)
-		}
 	} else if len(node.children) == 1 {
-		// Interior snapshot node with one child: merge with child.
-		slog.Debug("evicting snapshot node", "offset", node.endOffset, "tokens", len(node.tokens), "freed", mlx.PrettyBytes(int(node.snapshotBytes())))
+		// Interior node with one child: merge with child.
+		before := c.pagedOutBytes
+		tokens := len(node.tokens)
 		mergeWithChild(node, c.caches, &c.pagedOutBytes)
+		slog.Debug("evicting interior node", "offset", node.startOffset(), "tokens", tokens, "freed", mlx.PrettyBytes(int(before-c.pagedOutBytes)))
 	} else {
-		// Multi-child branch point: drop snapshots but keep the node.
-		slog.Debug("evicting branch snapshot", "offset", node.endOffset, "tokens", len(node.tokens), "freed", mlx.PrettyBytes(int(node.snapshotBytes())))
-		node.setSnapshots(nil, &c.pagedOutBytes)
+		panic("evictNode called on multi-child branch point")
 	}
 }
 
@@ -552,6 +569,9 @@ func (c *kvCache) dumpTree() {
 		label := fmt.Sprintf("[%d,%d) %dt", n.startOffset(), n.endOffset, len(n.tokens))
 		if nodeBytes > 0 {
 			label += " " + mlx.PrettyBytes(int(nodeBytes)).String()
+		}
+		if !n.lastUsed.IsZero() {
+			label += fmt.Sprintf(" %s ago", time.Since(n.lastUsed).Truncate(time.Millisecond))
 		}
 		var flags []string
 		if n.user {

--- a/x/mlxrunner/client.go
+++ b/x/mlxrunner/client.go
@@ -2,6 +2,7 @@ package mlxrunner
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -36,12 +37,67 @@ type Client struct {
 	modelName     string
 	contextLength atomic.Int64
 	memory        atomic.Uint64
-	done          chan error
+	done          chan struct{}
+	doneErr       error // valid after done is closed
 	client        *http.Client
-	lastErr       string
-	lastErrLock   sync.Mutex
+	status        *statusWriter
 	mu            sync.Mutex
 	cmd           *exec.Cmd
+}
+
+// statusWriter captures the last stderr line from the subprocess while
+// forwarding all output to os.Stderr. Lines longer than maxStatusLen are
+// truncated to the first maxStatusLen bytes.
+type statusWriter struct {
+	lastErrMsg string
+	buf        []byte
+	discarding bool
+	mu         sync.Mutex
+	out        *os.File
+}
+
+const maxStatusLen = 256
+
+func (w *statusWriter) Write(b []byte) (int, error) {
+	n, err := w.out.Write(b)
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	w.buf = append(w.buf, b...)
+	for {
+		i := bytes.IndexByte(w.buf, '\n')
+		if i < 0 {
+			break
+		}
+		if !w.discarding {
+			line := bytes.TrimSpace(w.buf[:i])
+			if len(line) > 0 {
+				if len(line) > maxStatusLen {
+					line = line[:maxStatusLen]
+				}
+				w.lastErrMsg = string(line)
+			}
+		}
+		w.buf = w.buf[i+1:]
+		w.discarding = false
+	}
+	// if the buffer grows past maxStatusLen without a newline, keep the front
+	if len(w.buf) > maxStatusLen {
+		if !w.discarding {
+			w.lastErrMsg = string(bytes.TrimSpace(w.buf[:maxStatusLen]))
+			w.discarding = true
+		}
+		w.buf = w.buf[:0]
+	}
+
+	return n, err
+}
+
+func (w *statusWriter) getLastErr() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.lastErrMsg
 }
 
 // NewClient prepares a new MLX runner client for LLM models.
@@ -53,7 +109,7 @@ func NewClient(modelName string) (*Client, error) {
 
 	c := &Client{
 		modelName: modelName,
-		done:      make(chan error, 1),
+		done:      make(chan struct{}),
 		client:    &http.Client{Timeout: 10 * time.Minute},
 	}
 
@@ -66,12 +122,6 @@ func NewClient(modelName string) (*Client, error) {
 	return c, nil
 }
 
-func (c *Client) getLastErr() string {
-	c.lastErrLock.Lock()
-	defer c.lastErrLock.Unlock()
-	return c.lastErr
-}
-
 // WaitUntilRunning waits for the subprocess to be ready.
 func (c *Client) WaitUntilRunning(ctx context.Context) error {
 	timeout := time.After(2 * time.Minute)
@@ -82,16 +132,14 @@ func (c *Client) WaitUntilRunning(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case err := <-c.done:
-			errMsg := c.getLastErr()
-			if errMsg != "" {
-				return fmt.Errorf("mlx runner failed: %s (exit: %v)", errMsg, err)
+		case <-c.done:
+			if msg := c.status.getLastErr(); msg != "" {
+				return fmt.Errorf("mlx runner failed: %s (exit: %v)", msg, c.doneErr)
 			}
-			return fmt.Errorf("mlx runner exited unexpectedly: %w", err)
+			return fmt.Errorf("mlx runner exited unexpectedly: %w", c.doneErr)
 		case <-timeout:
-			errMsg := c.getLastErr()
-			if errMsg != "" {
-				return fmt.Errorf("timeout waiting for mlx runner: %s", errMsg)
+			if msg := c.status.getLastErr(); msg != "" {
+				return fmt.Errorf("timeout waiting for mlx runner: %s", msg)
 			}
 			return errors.New("timeout waiting for mlx runner to start")
 		case <-ticker.C:
@@ -184,6 +232,9 @@ func (c *Client) Completion(ctx context.Context, req llm.CompletionRequest, fn f
 
 	resp, err := c.client.Do(httpReq)
 	if err != nil {
+		if errMsg := c.status.getLastErr(); errMsg != "" {
+			return fmt.Errorf("mlx runner failed: %s", errMsg)
+		}
 		return err
 	}
 	defer resp.Body.Close()
@@ -221,7 +272,13 @@ func (c *Client) Completion(ctx context.Context, req llm.CompletionRequest, fn f
 		}
 	}
 
-	return scanner.Err()
+	if err := scanner.Err(); err != nil {
+		if errMsg := c.status.getLastErr(); errMsg != "" {
+			return fmt.Errorf("mlx runner failed: %s", errMsg)
+		}
+		return err
+	}
+	return nil
 }
 
 func (c *Client) ContextLength() int {
@@ -345,23 +402,33 @@ func (c *Client) Load(ctx context.Context, _ ml.SystemInfo, gpus []ml.DeviceInfo
 		slog.Debug("mlx subprocess library path", libPathEnvVar, pathEnvVal)
 	}
 
+	// Point MLX's JIT compiler at our bundled CUDA runtime headers.
+	// MLX resolves headers via $CUDA_PATH/include/*.h (and checks CUDA_HOME first).
+	// Always use bundled headers to avoid version mismatches with any
+	// system-installed CUDA toolkit.
+	if mlxDirs, err := filepath.Glob(filepath.Join(ml.LibOllamaPath, "mlx_cuda_*")); err == nil {
+		for _, d := range mlxDirs {
+			if _, err := os.Stat(filepath.Join(d, "include")); err == nil {
+				setEnv(cmd, "CUDA_PATH", d)
+				setEnv(cmd, "CUDA_HOME", d)
+				slog.Debug("mlx subprocess CUDA headers", "CUDA_PATH", d)
+				break
+			}
+		}
+	}
+
 	c.cmd = cmd
 
 	// Forward subprocess stdout/stderr to server logs
 	stdout, _ := cmd.StdoutPipe()
 	stderr, _ := cmd.StderrPipe()
+	status := &statusWriter{out: os.Stderr}
+	c.status = status
 	go func() {
 		io.Copy(os.Stderr, stdout) //nolint:errcheck
 	}()
 	go func() {
-		scanner := bufio.NewScanner(stderr)
-		for scanner.Scan() {
-			line := scanner.Text()
-			fmt.Fprintln(os.Stderr, line)
-			c.lastErrLock.Lock()
-			c.lastErr = line
-			c.lastErrLock.Unlock()
-		}
+		io.Copy(status, stderr) //nolint:errcheck
 	}()
 
 	slog.Info("starting mlx runner subprocess", "model", c.modelName, "port", c.port)
@@ -371,8 +438,8 @@ func (c *Client) Load(ctx context.Context, _ ml.SystemInfo, gpus []ml.DeviceInfo
 
 	// Reap subprocess when it exits
 	go func() {
-		err := cmd.Wait()
-		c.done <- err
+		c.doneErr = cmd.Wait()
+		close(c.done)
 	}()
 
 	return nil, nil
@@ -469,3 +536,16 @@ func (c *Client) VRAMByGPU(id ml.DeviceID) uint64 {
 }
 
 var _ llm.LlamaServer = (*Client)(nil)
+
+// setEnv sets or replaces an environment variable in cmd.Env.
+func setEnv(cmd *exec.Cmd, key, value string) {
+	entry := key + "=" + value
+	prefix := strings.ToUpper(key + "=")
+	for i, e := range cmd.Env {
+		if strings.HasPrefix(strings.ToUpper(e), prefix) {
+			cmd.Env[i] = entry
+			return
+		}
+	}
+	cmd.Env = append(cmd.Env, entry)
+}

--- a/x/mlxrunner/model/base/multimodal.go
+++ b/x/mlxrunner/model/base/multimodal.go
@@ -18,9 +18,14 @@ type PromptTokenization struct {
 	State  any
 }
 
-// MultimodalPromptTokenizerWithState is an optional model interface used by
-// mlxrunner to expand tagged multimodal prompts into token IDs, returning
-// request-scoped state to be attached to the forward pass.
+// MultimodalPromptTokenizer is an optional model interface used by mlxrunner
+// to expand tagged multimodal prompts into token IDs.
+type MultimodalPromptTokenizer interface {
+	TokenizePromptWithImages(prompt string, images []ImageInput) ([]int32, error)
+}
+
+// MultimodalPromptTokenizerWithState is a richer tokenizer variant that can
+// return request-scoped state to be attached to the forward pass.
 type MultimodalPromptTokenizerWithState interface {
 	TokenizePromptWithImagesState(prompt string, images []ImageInput) (*PromptTokenization, error)
 }

--- a/x/mlxrunner/pipeline.go
+++ b/x/mlxrunner/pipeline.go
@@ -45,6 +45,19 @@ func (r *Runner) tokenizeRequest(request Request) ([]int32, any, error) {
 		return out.Tokens, out.State, nil
 	}
 
+	if multimodalTokenizer, ok := r.Model.(base.MultimodalPromptTokenizer); ok && len(request.Images) > 0 {
+		images := make([]base.ImageInput, len(request.Images))
+		for i := range request.Images {
+			images[i] = base.ImageInput{
+				ID:   request.Images[i].ID,
+				Data: request.Images[i].Data,
+			}
+		}
+
+		toks, err := multimodalTokenizer.TokenizePromptWithImages(request.Prompt, images)
+		return toks, nil, err
+	}
+
 	return r.Tokenizer.Encode(request.Prompt, true), nil, nil
 }
 
@@ -62,6 +75,7 @@ func (r *Runner) TextGenerationPipeline(request Request) error {
 	} else {
 		mlx.DisableCompile()
 	}
+	slog.Debug("compile mode", "enabled", enableCompile)
 	mlx.ResetPeakMemory()
 	ctx := request.Ctx
 	var (
@@ -112,16 +126,37 @@ func (r *Runner) TextGenerationPipeline(request Request) error {
 
 	session := r.cache.begin(r.Model, inputs)
 	defer session.close()
+
 	caches := session.caches
 	tokens := session.remaining
 	prefillChunk := prefillChunkSize()
 
+	// Request periodic snapshots during prefill and near the end of the
+	// prompt so that long prompts can be partially restored and
+	// thinking/generation can be retried without full reprocessing.
+	const snapshotInterval = 8192
+	for offset := snapshotInterval; offset < len(inputs); offset += snapshotInterval {
+		session.requestSnapshot(offset)
+	}
+
+	const preThinking = 4
+	if end := len(inputs) - preThinking; end > 0 {
+		session.requestSnapshot(end)
+	}
+
+	// During prefill, use ForwardWithState to handle multimodal segments.
+	// During generation, use Forward directly for compile compatibility.
 	modelForward := func(tokens *mlx.Array) *mlx.Array {
-		if withState, ok := r.Model.(base.ForwardWithStateModel); ok {
-			return withState.ForwardWithState(tokens, caches, promptState)
+		if promptState != nil {
+			if withState, ok := r.Model.(base.ForwardWithStateModel); ok {
+				return withState.ForwardWithState(tokens, caches, promptState)
+			}
 		}
 		return r.Model.Forward(tokens, caches)
 	}
+
+	// After prefill, clear promptState so generation uses the fast path.
+	clearPromptState := func() { promptState = nil }
 
 	materializeCaches := func() {
 		state := make([]*mlx.Array, 0, 2*len(caches))
@@ -143,12 +178,11 @@ func (r *Runner) TextGenerationPipeline(request Request) error {
 
 		n := min(prefillChunk, total-processed-1)
 
-		// If there's a pending intermediate snapshot, split the batch
-		// so we can capture it at the exact offset. The cache offset
-		// after this batch will be: baseOffset + processed + n.
-		if session.snapshotOffset > 0 {
+		// If there's a pending snapshot, split the batch so we can
+		// capture it at the exact offset.
+		if snapOffset := session.nextPendingSnapshot(); snapOffset > 0 {
 			baseOffset := len(session.inputs) - len(tokens)
-			tokensUntilSnapshot := session.snapshotOffset - (baseOffset + processed)
+			tokensUntilSnapshot := snapOffset - (baseOffset + processed)
 			if tokensUntilSnapshot > 0 && tokensUntilSnapshot < n {
 				n = tokensUntilSnapshot
 			}
@@ -160,16 +194,20 @@ func (r *Runner) TextGenerationPipeline(request Request) error {
 		processed += n
 		slog.Info("Prompt processing progress", "processed", processed, "total", total)
 
-		// Create snapshot at branch point for future diverging requests.
-		if session.snapshotOffset > 0 {
+		// Create snapshot if we've reached a pending offset.
+		if snapOffset := session.nextPendingSnapshot(); snapOffset > 0 {
 			baseOffset := len(session.inputs) - len(tokens)
-			if baseOffset+processed >= session.snapshotOffset {
-				session.snapshot(false)
+			if baseOffset+processed >= snapOffset {
+				session.snapshot()
 			}
 		}
 
 		mlx.ClearCache()
 	}
+
+	// Multimodal segments are fully consumed during prefill.
+	// Clear state so generation uses the direct Forward path (compile-friendly).
+	clearPromptState()
 
 	step := func(token *mlx.Array) (*mlx.Array, *mlx.Array) {
 		fwd := modelForward(token.ExpandDims(0))
@@ -191,12 +229,14 @@ func (r *Runner) TextGenerationPipeline(request Request) error {
 	var b bytes.Buffer
 
 	final := CompletionResponse{Done: true, PromptEvalCount: len(inputs), EvalCount: request.Options.MaxTokens, DoneReason: 1}
+
 	for i := range request.Options.MaxTokens {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
 
 		request.Sampler.AppendToken(sample)
+
 		nextSample, nextLogprobs = step(sample)
 
 		if i == 0 {
@@ -207,6 +247,19 @@ func (r *Runner) TextGenerationPipeline(request Request) error {
 
 		output := int32(sample.Int())
 		session.outputs = append(session.outputs, output)
+
+		// Log generation diagnostics at trace level for first 10 tokens.
+		if i < 10 && slog.Default().Enabled(context.TODO(), logutil.LevelTrace) {
+			lpF32 := logprobs.AsType(mlx.DTypeFloat32)
+			mlx.Eval(lpF32)
+			lf := lpF32.Floats()
+			sampledLP := float32(0)
+			if int(output) < len(lf) {
+				sampledLP = lf[output]
+			}
+			logutil.Trace(fmt.Sprintf("gen step=%d sampled=%d sampled_lp=%.4f lp_at_pad=%.4f lp_at_eos=%.4f vocab=%d",
+				i, output, sampledLP, lf[0], lf[1], len(lf)))
+		}
 
 		if r.Tokenizer.IsEOS(output) {
 			final.DoneReason = 0


### PR DESCRIPTION
Enhancements on top of the multimodal infrastructure from #14968:

- Cache: multi-snapshot system (pendingSnapshots) with requestSnapshot() and nextPendingSnapshot(), refined switchToPath with partial-match awareness, improved eviction policy
- Pipeline: periodic snapshots every 8192 tokens, pre-thinking snapshot, stateless MultimodalPromptTokenizer fallback, clearPromptState() for compile-friendly generation, generation trace diagnostics
- Client: statusWriter with circular buffer replacing lastErr/lock, CUDA header detection for MLX JIT compiler, done channel refactor
- Multimodal: added MultimodalPromptTokenizer (stateless variant)