### PR TITLE
linux: enhance docker build for mlx arm64

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -112,7 +112,23 @@
       "name": "MLX CUDA 13",
       "inherits": [ "MLX", "CUDA 13" ],
       "cacheVariables": {
-        "MLX_CUDA_ARCHITECTURES": "86;89;90;90a;100;103;75-virtual;80-virtual;110-virtual;120-virtual;121-virtual",
+        "MLX_CUDA_ARCHITECTURES": "86;89;90;90a;100;103;120;75-virtual;80-virtual;110-virtual;121-virtual",
+        "OLLAMA_RUNNER_DIR": "mlx_cuda_v13"
+      }
+    },
+    {
+      "name": "MLX CUDA 13 arm64",
+      "inherits": [ "MLX", "CUDA 13" ],
+      "cacheVariables": {
+        "MLX_CUDA_ARCHITECTURES": "90a;100;120;80-virtual;110-virtual;121-virtual",
+        "OLLAMA_RUNNER_DIR": "mlx_cuda_v13"
+      }
+    },
+    {
+      "name": "MLX CUDA 13 arm64",
+      "inherits": [ "MLX", "CUDA 13" ],
+      "cacheVariables": {
+        "MLX_CUDA_ARCHITECTURES": "90a;100;120;80-virtual;110-virtual;121-virtual",
         "OLLAMA_RUNNER_DIR": "mlx_cuda_v13"
       }
     }
@@ -192,6 +208,11 @@
       "name": "MLX CUDA 13",
       "targets": [ "mlx", "mlxc" ],
       "configurePreset": "MLX CUDA 13"
+    },
+    {
+      "name": "MLX CUDA 13 arm64",
+      "targets": [ "mlx", "mlxc" ],
+      "configurePreset": "MLX CUDA 13 arm64"
     }
   ]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -143,15 +143,18 @@ RUN --mount=type=cache,target=/root/.ccache \
         && cmake --install build --component Vulkan --strip
 
 FROM base AS mlx
+ARG TARGETARCH
 ARG CUDA13VERSION=13.0
-RUN dnf install -y cuda-toolkit-${CUDA13VERSION//./-} \
+RUN dnf install -y gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ gcc-toolset-11-binutils \
+    && dnf install -y cuda-toolkit-${CUDA13VERSION//./-} \
+    && yum-config-manager --enable powertools \
     && dnf install -y openblas-devel lapack-devel \
     && dnf install -y libcudnn9-cuda-13 libcudnn9-devel-cuda-13 \
     && dnf install -y libnccl libnccl-devel
-ENV PATH=/usr/local/cuda-13/bin:$PATH
+ENV PATH=/opt/rh/gcc-toolset-11/root/usr/bin:/usr/local/cuda-13/bin:$PATH
+ENV CC=gcc CXX=g++
 ENV BLAS_INCLUDE_DIRS=/usr/include/openblas
 ENV LAPACK_INCLUDE_DIRS=/usr/include/openblas
-ENV CGO_LDFLAGS="-L/usr/local/cuda-13/lib64 -L/usr/local/cuda-13/targets/x86_64-linux/lib/stubs"
 WORKDIR /go/src/github.com/ollama/ollama
 COPY CMakeLists.txt CMakePresets.json .
 COPY ml/backend/ggml/ggml ml/backend/ggml/ggml
@@ -164,14 +167,17 @@ RUN go mod download
 RUN --mount=type=cache,target=/root/.ccache \
     --mount=type=bind,from=local-mlx,target=/tmp/local-mlx \
     --mount=type=bind,from=local-mlx-c,target=/tmp/local-mlx-c \
-    if [ -f /tmp/local-mlx/CMakeLists.txt ]; then \
+    export CGO_LDFLAGS="-L/usr/local/cuda-13/lib64 -L/usr/local/cuda-13/targets/$(uname -m | sed 's/aarch64/sbsa/')-linux/lib/stubs" \
+    && if [ -f /tmp/local-mlx/CMakeLists.txt ]; then \
         export OLLAMA_MLX_SOURCE=/tmp/local-mlx; \
     fi \
     && if [ -f /tmp/local-mlx-c/CMakeLists.txt ]; then \
         export OLLAMA_MLX_C_SOURCE=/tmp/local-mlx-c; \
     fi \
-    && cmake --preset 'MLX CUDA 13' -DBLAS_INCLUDE_DIRS=/usr/include/openblas -DLAPACK_INCLUDE_DIRS=/usr/include/openblas \
-        && cmake --build --preset 'MLX CUDA 13' -- -l $(nproc) \
+    && MLX_PRESET="MLX CUDA 13" \
+    && if [ "${TARGETARCH}" != "amd64" ]; then MLX_PRESET="MLX CUDA 13 ${TARGETARCH}"; fi \
+    && cmake --preset "${MLX_PRESET}" -DBLAS_INCLUDE_DIRS=/usr/include/openblas -DLAPACK_INCLUDE_DIRS=/usr/include/openblas \
+        && cmake --build --preset "${MLX_PRESET}" -- -l $(nproc) \
         && cmake --install build --component MLX --strip
 
 FROM base AS build
@@ -195,12 +201,13 @@ FROM --platform=linux/amd64 scratch AS amd64
 COPY --from=cuda-12 dist/lib/ollama /lib/ollama/
 COPY --from=cuda-13 dist/lib/ollama /lib/ollama/
 COPY --from=vulkan  dist/lib/ollama  /lib/ollama/
-COPY --from=mlx     /go/src/github.com/ollama/ollama/dist/lib/ollama /lib/ollama/
+COPY --from=mlx     dist/lib/ollama /lib/ollama/
 
 FROM --platform=linux/arm64 scratch AS arm64
 # COPY --from=cuda-11 dist/lib/ollama/ /lib/ollama/
 COPY --from=cuda-12 dist/lib/ollama /lib/ollama/
 COPY --from=cuda-13 dist/lib/ollama/ /lib/ollama/
+COPY --from=mlx     dist/lib/ollama /lib/ollama/
 COPY --from=jetpack-5 dist/lib/ollama/ /lib/ollama/
 COPY --from=jetpack-6 dist/lib/ollama/ /lib/ollama/
 
@@ -209,6 +216,9 @@ COPY --from=rocm-7 dist/lib/ollama /lib/ollama
 
 FROM ${FLAVOR} AS archive
 COPY --from=cpu dist/lib/ollama /lib/ollama
+COPY --from=build /bin/ollama /bin/ollama
+
+FROM scratch AS archive-ollama-only
 COPY --from=build /bin/ollama /bin/ollama
 
 FROM ubuntu:24.04

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -33,7 +33,7 @@ docker buildx build \
         -f Dockerfile \
         .
 
-if echo $PLATFORM | grep "amd64" > /dev/null; then
+if echo $PLATFORM | grep "amd64" > /dev/null && [ "${OLLAMA_SKIP_ROCM:-}" != "1" ]; then
     outDir="./dist"
     if echo $PLATFORM | grep "," > /dev/null ; then
        outDir="./dist/linux_amd64"
@@ -59,16 +59,20 @@ fi
 # buildx behavior changes for single vs. multiplatform
 echo "Compressing linux tar bundles..."
 if echo $PLATFORM | grep "," > /dev/null ; then
-        tar c -C ./dist/linux_arm64 --exclude cuda_jetpack5 --exclude cuda_jetpack6 . | zstd --ultra -22 -T0 >./dist/ollama-linux-arm64.tar.zst
-        tar c -C ./dist/linux_arm64 ./lib/ollama/cuda_jetpack5  | zstd --ultra -22 -T0 >./dist/ollama-linux-arm64-jetpack5.tar.zst
-        tar c -C ./dist/linux_arm64 ./lib/ollama/cuda_jetpack6  | zstd --ultra -22 -T0 >./dist/ollama-linux-arm64-jetpack6.tar.zst
-        tar c -C ./dist/linux_amd64 --exclude rocm . | zstd --ultra -22 -T0 >./dist/ollama-linux-amd64.tar.zst
-        tar c -C ./dist/linux_amd64 ./lib/ollama/rocm  | zstd --ultra -22 -T0 >./dist/ollama-linux-amd64-rocm.tar.zst
+        tar c -C ./dist/linux_arm64 --exclude cuda_jetpack5 --exclude cuda_jetpack6 . | zstd -9 -T0 >./dist/ollama-linux-arm64.tar.zst
+        tar c -C ./dist/linux_arm64 ./lib/ollama/cuda_jetpack5  | zstd -9 -T0 >./dist/ollama-linux-arm64-jetpack5.tar.zst
+        tar c -C ./dist/linux_arm64 ./lib/ollama/cuda_jetpack6  | zstd -9 -T0 >./dist/ollama-linux-arm64-jetpack6.tar.zst
+        tar c -C ./dist/linux_amd64 --exclude rocm . | zstd -9 -T0 >./dist/ollama-linux-amd64.tar.zst
+        if [ "${OLLAMA_SKIP_ROCM:-}" != "1" ]; then
+        tar c -C ./dist/linux_amd64 ./lib/ollama/rocm  | zstd -9 -T0 >./dist/ollama-linux-amd64-rocm.tar.zst
+        fi
 elif echo $PLATFORM | grep "arm64" > /dev/null ; then
-        tar c -C ./dist/ --exclude cuda_jetpack5 --exclude cuda_jetpack6 bin lib | zstd --ultra -22 -T0 >./dist/ollama-linux-arm64.tar.zst
-        tar c -C ./dist/ ./lib/ollama/cuda_jetpack5  | zstd --ultra -22 -T0 >./dist/ollama-linux-arm64-jetpack5.tar.zst
-        tar c -C ./dist/ ./lib/ollama/cuda_jetpack6  | zstd --ultra -22 -T0 >./dist/ollama-linux-arm64-jetpack6.tar.zst
+        tar c -C ./dist/ --exclude cuda_jetpack5 --exclude cuda_jetpack6 bin lib | zstd -9 -T0 >./dist/ollama-linux-arm64.tar.zst
+        tar c -C ./dist/ ./lib/ollama/cuda_jetpack5  | zstd -9 -T0 >./dist/ollama-linux-arm64-jetpack5.tar.zst
+        tar c -C ./dist/ ./lib/ollama/cuda_jetpack6  | zstd -9 -T0 >./dist/ollama-linux-arm64-jetpack6.tar.zst
 elif echo $PLATFORM | grep "amd64" > /dev/null ; then
-        tar c -C ./dist/ --exclude rocm bin lib | zstd --ultra -22 -T0 >./dist/ollama-linux-amd64.tar.zst
-        tar c -C ./dist/ ./lib/ollama/rocm  | zstd --ultra -22 -T0 >./dist/ollama-linux-amd64-rocm.tar.zst
+        tar c -C ./dist/ --exclude rocm bin lib | zstd -9 -T0 >./dist/ollama-linux-amd64.tar.zst
+        if [ "${OLLAMA_SKIP_ROCM:-}" != "1" ]; then
+        tar c -C ./dist/ ./lib/ollama/rocm  | zstd -9 -T0 >./dist/ollama-linux-amd64-rocm.tar.zst
+        fi
 fi

--- a/scripts/build_linux_ollama_only.sh
+++ b/scripts/build_linux_ollama_only.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+# Incremental build script - rebuilds only the ollama binary after a full build_linux.sh run
+# Use this when you've only changed Go code and don't want to rebuild the native libraries
+
+set -eu
+
+. $(dirname $0)/env.sh
+
+# Ensure a full build has been run first
+echo "WARNING: This script is for incremental builds after running build_linux.sh"
+echo "It will only replace the ollama binary, not the native libraries"
+echo ""
+
+mkdir -p .tmp/build_output
+
+# Build the ollama binary only
+docker buildx build \
+    --output type=local,dest=./.tmp/build_output/ \
+    --platform=${PLATFORM} \
+    ${OLLAMA_COMMON_BUILD_ARGS} \
+    --target archive-ollama-only \
+    -f Dockerfile \
+    .
+
+# Copy binaries to correct locations
+if echo $PLATFORM | grep "," > /dev/null; then
+    # Multi-arch build - subdirectories created by buildx
+    for arch_dir in .tmp/build_output/linux_amd64 .tmp/build_output/linux_arm64; do
+        if [ -d "${arch_dir}" ]; then
+            arch=$(basename ${arch_dir})
+            target_dir="./dist/${arch}"
+            if [ ! -d "${target_dir}" ]; then
+                echo "ERROR: ${target_dir} does not exist. Run build_linux.sh first." >&2
+                exit 1
+            fi
+            cp "${arch_dir}/bin/ollama" "${target_dir}/bin/ollama"
+            echo "Updated ${target_dir}/bin/ollama"
+        fi
+    done
+else
+    # Single-arch build
+    if [ ! -d "./dist" ]; then
+        echo "ERROR: ./dist does not exist. Run build_linux.sh first." >&2
+        exit 1
+    fi
+    cp .tmp/build_output/bin/ollama "./dist/bin/ollama"
+    echo "Updated ./dist/bin/ollama"
+fi
+
+rm -rf .tmp/build_output
+
+echo ""
+echo "=========================================="
+echo "Incremental build complete!"
+echo "=========================================="
+echo ""
+echo "NOTE: Tar files in ./dist have NOT been updated."
+echo "To update the tar files, run build_linux.sh after committing your changes."
+echo ""

--- a/x/imagegen/mlx/CMakeLists.txt
+++ b/x/imagegen/mlx/CMakeLists.txt
@@ -58,6 +58,10 @@ if(DEFINED ENV{CUDNN_LIBRARY_PATH} AND NOT CUDNN_LIBRARY_PATH)
     message(STATUS "Using CUDNN_LIBRARY_PATH from environment: ${CUDNN_LIBRARY_PATH}")
 endif()
 
+# MLX's CUDA backend requires C++20 for CUDA (CCCL/Thrust + template lambdas)
+set(CMAKE_CUDA_STANDARD 20)
+set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+
 # Enable CUDA backend if CUDA architectures are specified and CUDA compiler is available
 if(MLX_CUDA_ARCHITECTURES AND CMAKE_CUDA_COMPILER)
     set(MLX_BUILD_CUDA ON CACHE BOOL "Build CUDA backend for MLX" FORCE)


### PR DESCRIPTION
This adds support for the MLX build on arm64, and creates a new incremental build short-cut to speed up dev/test cycles.  It also drops compression slightly to speed up developer builds.