### PR TITLE
fix(discover): warn when GPU backend runner fails to start

### DIFF
--- a/discover/runner.go
+++ b/discover/runner.go
@@ -446,7 +446,7 @@ func bootstrapDevices(ctx context.Context, ollamaLibDirs []string, extraEnvs map
 		extraEnvs,
 	)
 	if err != nil {
-		slog.Debug("failed to start runner to discovery GPUs", "error", err)
+		slog.Warn("failed to start runner to discover GPUs", "error", err)
 		return nil
 	}
 


### PR DESCRIPTION
When llm.StartRunner returns an error during bootstrap device discovery, the failure was logged at Debug level and silently swallowed. Users with GPU hardware see ollama fall back to CPU with no visible indication of why.

Upgrade to Warn so that the cause is visible at the default log level.

Also fix a typo: 'to discovery' -> 'to discover'.

Fixes #15079