### PR TITLE
fix(fileutil): use user-scoped temp directory for backups

### DIFF
--- a/cmd/internal/fileutil/files.go
+++ b/cmd/internal/fileutil/files.go
@@ -36,14 +36,16 @@ func copyFile(src, dst string) error {
 	return os.WriteFile(dst, data, info.Mode().Perm())
 }
 
-// BackupDir returns the shared backup directory used before overwriting files.
+// BackupDir returns the user-scoped backup directory used before overwriting files.
+// Each user on the system gets a separate directory to avoid permission conflicts
+// in shared temp directories like /tmp.
 func BackupDir() string {
-	return filepath.Join(os.TempDir(), "ollama-backups")
+	return filepath.Join(os.TempDir(), fmt.Sprintf("ollama-backups-%d", os.Getuid()))
 }
 
 func backupToTmp(srcPath string) (string, error) {
 	dir := BackupDir()
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return "", err
 	}
 

--- a/cmd/launch/droid_test.go
+++ b/cmd/launch/droid_test.go
@@ -1172,7 +1172,7 @@ func TestDroidEdit_BackupCreated(t *testing.T) {
 
 	settingsDir := filepath.Join(tmpDir, ".factory")
 	settingsPath := filepath.Join(settingsDir, "settings.json")
-	backupDir := filepath.Join(os.TempDir(), "ollama-backups")
+	backupDir := fileutil.BackupDir()
 
 	os.MkdirAll(settingsDir, 0o755)
 

--- a/cmd/launch/openclaw_test.go
+++ b/cmd/launch/openclaw_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/cmd/internal/fileutil"
 )
 
 func TestOpenclawIntegration(t *testing.T) {
@@ -632,7 +633,7 @@ func TestOpenclawEdit_BackupCreated(t *testing.T) {
 	setTestHome(t, tmpDir)
 	configDir := filepath.Join(tmpDir, ".openclaw")
 	configPath := filepath.Join(configDir, "openclaw.json")
-	backupDir := filepath.Join(os.TempDir(), "ollama-backups")
+	backupDir := fileutil.BackupDir()
 
 	os.MkdirAll(configDir, 0o755)
 	uniqueMarker := fmt.Sprintf("test-marker-%d", os.Getpid())


### PR DESCRIPTION
On multi-user systems the shared /tmp/ollama-backups directory causes two problems:

1. Permission conflict: the first user creates the directory with mode 755, so a second user gets EACCES when trying to write their own backup files.
2. Privacy: backup files (which may contain user configuration) are readable by any local user.

Use os.Getuid() to make each user's backup directory unique, e.g. /tmp/ollama-backups-1000. Set the directory mode to 0700 so only the owning user can access it.

Update tests to call fileutil.BackupDir() instead of reproducing the path construction inline, so they stay in sync with future changes.

Fixes #15130