### PR TITLE
Draft: api: support multimodal embedding

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -615,6 +615,9 @@ type EmbedRequest struct {
 	// Input is the input to embed.
 	Input any `json:"input"`
 
+	// Inputs is an optional multimodal batch for embeddings.
+	Inputs []EmbedInput `json:"inputs,omitempty"`
+
 	// KeepAlive controls how long the model will stay loaded in memory following
 	// this request.
 	KeepAlive *Duration `json:"keep_alive,omitempty"`
@@ -627,6 +630,12 @@ type EmbedRequest struct {
 
 	// Options lists model-specific options.
 	Options map[string]any `json:"options"`
+}
+
+// EmbedInput is a single embedding item, optionally combining text and image.
+type EmbedInput struct {
+	Text  string    `json:"text,omitempty"`
+	Image ImageData `json:"image,omitempty"`
 }
 
 // EmbedResponse is the response from [Client.Embed].

--- a/cohere/cohere.go
+++ b/cohere/cohere.go
@@ -1,0 +1,387 @@
+package cohere
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"image"
+	_ "image/gif"
+	_ "image/jpeg"
+	_ "image/png"
+	"strings"
+
+	"golang.org/x/image/webp"
+
+	"github.com/ollama/ollama/api"
+)
+
+func init() {
+	image.RegisterFormat("webp", "RIFF????WEBP", webp.Decode, webp.DecodeConfig)
+}
+
+type ErrorResponse struct {
+	Message string `json:"message"`
+}
+
+type EmbedRequest struct {
+	Model           string       `json:"model"`
+	InputType       string       `json:"input_type,omitempty"`
+	Texts           []string     `json:"texts,omitempty"`
+	Images          []string     `json:"images,omitempty"`
+	Inputs          []EmbedInput `json:"inputs,omitempty"`
+	OutputDimension int          `json:"output_dimension,omitempty"`
+	EmbeddingTypes  []string     `json:"embedding_types,omitempty"`
+	Truncate        string       `json:"truncate,omitempty"`
+}
+
+type EmbedInput struct {
+	Content []EmbedContent `json:"content"`
+}
+
+type EmbedContent struct {
+	Type     string         `json:"type"`
+	Text     string         `json:"text,omitempty"`
+	ImageURL *EmbedImageURL `json:"image_url,omitempty"`
+}
+
+type EmbedImageURL struct {
+	URL string `json:"url"`
+}
+
+type EmbedResponse struct {
+	ID           string          `json:"id"`
+	Embeddings   EmbeddingTypes  `json:"embeddings"`
+	Texts        []string        `json:"texts,omitempty"`
+	Images       []ImageMetadata `json:"images,omitempty"`
+	Meta         Meta            `json:"meta"`
+	ResponseType string          `json:"response_type"`
+}
+
+type EmbeddingTypes struct {
+	Float  [][]float32 `json:"float,omitempty"`
+	Base64 []string    `json:"base64,omitempty"`
+}
+
+type ImageMetadata struct {
+	Width    int    `json:"width,omitempty"`
+	Height   int    `json:"height,omitempty"`
+	Format   string `json:"format,omitempty"`
+	BitDepth int    `json:"bit_depth,omitempty"`
+}
+
+type Meta struct {
+	APIVersion  APIVersion  `json:"api_version"`
+	BilledUnits BilledUnits `json:"billed_units"`
+	Tokens      any         `json:"tokens"`
+	Warnings    any         `json:"warnings"`
+}
+
+type APIVersion struct {
+	Version        string `json:"version"`
+	IsDeprecated   any    `json:"is_deprecated"`
+	IsExperimental any    `json:"is_experimental"`
+}
+
+type BilledUnits struct {
+	InputTokens     *int `json:"input_tokens"`
+	OutputTokens    any  `json:"output_tokens"`
+	SearchUnits     any  `json:"search_units"`
+	Classifications any  `json:"classifications"`
+	Images          *int `json:"images"`
+}
+
+func NewError(message string) ErrorResponse {
+	return ErrorResponse{Message: message}
+}
+
+func FromEmbedRequest(r EmbedRequest) (api.EmbedRequest, error) {
+	if len(r.Texts) > 0 && (len(r.Images) > 0 || len(r.Inputs) > 0) {
+		return api.EmbedRequest{}, errors.New("texts cannot be combined with images or inputs")
+	}
+	if len(r.Images) > 0 && len(r.Inputs) > 0 {
+		return api.EmbedRequest{}, errors.New("images cannot be combined with inputs")
+	}
+
+	req := api.EmbedRequest{
+		Model:      r.Model,
+		Dimensions: r.OutputDimension,
+	}
+
+	switch strings.ToUpper(strings.TrimSpace(r.Truncate)) {
+	case "", "END":
+		req.Truncate = ptr(true)
+	case "NONE":
+		req.Truncate = ptr(false)
+	case "START":
+		return api.EmbedRequest{}, errors.New("truncate=START is not supported")
+	default:
+		return api.EmbedRequest{}, fmt.Errorf("invalid truncate value: %s", r.Truncate)
+	}
+
+	switch {
+	case len(r.Texts) > 0:
+		if len(r.Texts) == 1 {
+			req.Input = r.Texts[0]
+		} else {
+			req.Input = stringsToAny(r.Texts)
+		}
+	case len(r.Images) > 0:
+		req.Inputs = make([]api.EmbedInput, 0, len(r.Images))
+		for _, raw := range r.Images {
+			img, err := decodeImageURL(raw)
+			if err != nil {
+				return api.EmbedRequest{}, err
+			}
+			req.Inputs = append(req.Inputs, api.EmbedInput{Image: img})
+		}
+	case len(r.Inputs) > 0:
+		req.Inputs = make([]api.EmbedInput, 0, len(r.Inputs))
+		for _, in := range r.Inputs {
+			parsed, err := parseInput(in)
+			if err != nil {
+				return api.EmbedRequest{}, err
+			}
+			req.Inputs = append(req.Inputs, parsed)
+		}
+	default:
+		return api.EmbedRequest{}, errors.New("must provide texts, images, or inputs")
+	}
+
+	return req, nil
+}
+
+func ToEmbedResponse(r EmbedRequest, resp api.EmbedResponse) (EmbedResponse, error) {
+	types := normalizedEmbeddingTypes(r.EmbeddingTypes)
+
+	out := EmbedResponse{
+		ID:         "embed-response",
+		Embeddings: EmbeddingTypes{},
+		Meta: Meta{
+			APIVersion:  APIVersion{Version: "2"},
+			BilledUnits: billedUnits(resp.PromptEvalCount, imageCount(r)),
+		},
+		ResponseType: "embeddings_by_type",
+	}
+
+	if containsType(types, "float") {
+		out.Embeddings.Float = resp.Embeddings
+	}
+	if containsType(types, "base64") {
+		out.Embeddings.Base64 = make([]string, 0, len(resp.Embeddings))
+		for _, e := range resp.Embeddings {
+			out.Embeddings.Base64 = append(out.Embeddings.Base64, floatsToBase64(e))
+		}
+	}
+
+	if len(r.Texts) > 0 {
+		out.Texts = append([]string(nil), r.Texts...)
+	} else if len(r.Inputs) > 0 {
+		for _, in := range r.Inputs {
+			text := strings.TrimSpace(extractText(in))
+			if text != "" {
+				out.Texts = append(out.Texts, text)
+			}
+		}
+	}
+
+	images, err := imageMetadata(r)
+	if err != nil {
+		return EmbedResponse{}, err
+	}
+	out.Images = images
+
+	return out, nil
+}
+
+func ValidateEmbeddingTypes(types []string) error {
+	for _, t := range normalizedEmbeddingTypes(types) {
+		if t != "float" && t != "base64" {
+			return fmt.Errorf("embedding type %q is not supported", t)
+		}
+	}
+	return nil
+}
+
+func parseInput(in EmbedInput) (api.EmbedInput, error) {
+	var out api.EmbedInput
+	var texts []string
+
+	for _, part := range in.Content {
+		switch part.Type {
+		case "text":
+			texts = append(texts, part.Text)
+		case "image_url":
+			if part.ImageURL == nil {
+				return api.EmbedInput{}, errors.New("image_url content requires image_url.url")
+			}
+			if len(out.Image) > 0 {
+				return api.EmbedInput{}, errors.New("only one image per input is supported")
+			}
+			img, err := decodeImageURL(part.ImageURL.URL)
+			if err != nil {
+				return api.EmbedInput{}, err
+			}
+			out.Image = img
+		default:
+			return api.EmbedInput{}, fmt.Errorf("unsupported content type: %s", part.Type)
+		}
+	}
+
+	out.Text = strings.Join(texts, "\n")
+	if out.Text == "" && len(out.Image) == 0 {
+		return api.EmbedInput{}, errors.New("input content cannot be empty")
+	}
+
+	return out, nil
+}
+
+func extractText(in EmbedInput) string {
+	var texts []string
+	for _, part := range in.Content {
+		if part.Type == "text" && part.Text != "" {
+			texts = append(texts, part.Text)
+		}
+	}
+	return strings.Join(texts, "\n")
+}
+
+func imageMetadata(r EmbedRequest) ([]ImageMetadata, error) {
+	var raws []string
+	raws = append(raws, r.Images...)
+	for _, in := range r.Inputs {
+		for _, part := range in.Content {
+			if part.Type == "image_url" && part.ImageURL != nil {
+				raws = append(raws, part.ImageURL.URL)
+			}
+		}
+	}
+
+	images := make([]ImageMetadata, 0, len(raws))
+	for _, raw := range raws {
+		img, err := decodeImageURL(raw)
+		if err != nil {
+			return nil, err
+		}
+		cfg, format, err := image.DecodeConfig(bytes.NewReader(img))
+		if err != nil {
+			return nil, err
+		}
+		images = append(images, ImageMetadata{
+			Width:  cfg.Width,
+			Height: cfg.Height,
+			Format: format,
+		})
+	}
+
+	return images, nil
+}
+
+func imageCount(r EmbedRequest) int {
+	count := len(r.Images)
+	for _, in := range r.Inputs {
+		for _, part := range in.Content {
+			if part.Type == "image_url" && part.ImageURL != nil {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func billedUnits(promptTokens int, images int) BilledUnits {
+	var inputTokens *int
+	if promptTokens > 0 {
+		inputTokens = &promptTokens
+	}
+
+	var billedImages *int
+	if images > 0 {
+		billedImages = &images
+	}
+
+	return BilledUnits{
+		InputTokens: inputTokens,
+		Images:      billedImages,
+	}
+}
+
+func normalizedEmbeddingTypes(types []string) []string {
+	if len(types) == 0 {
+		return []string{"float"}
+	}
+
+	out := make([]string, 0, len(types))
+	seen := map[string]struct{}{}
+	for _, t := range types {
+		key := strings.ToLower(strings.TrimSpace(t))
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, key)
+	}
+	return out
+}
+
+func containsType(types []string, want string) bool {
+	for _, t := range types {
+		if t == want {
+			return true
+		}
+	}
+	return false
+}
+
+func stringsToAny(values []string) []any {
+	out := make([]any, 0, len(values))
+	for _, v := range values {
+		out = append(out, v)
+	}
+	return out
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}
+
+func floatsToBase64(floats []float32) string {
+	var buf bytes.Buffer
+	_ = binary.Write(&buf, binary.LittleEndian, floats)
+	return base64.StdEncoding.EncodeToString(buf.Bytes())
+}
+
+func decodeImageURL(url string) (api.ImageData, error) {
+	if strings.HasPrefix(url, "http://") || strings.HasPrefix(url, "https://") {
+		return nil, errors.New("image URLs are not currently supported, please use base64 encoded data instead")
+	}
+
+	types := []string{"jpeg", "jpg", "png", "webp", "gif"}
+
+	if strings.HasPrefix(url, "data:;base64,") {
+		url = strings.TrimPrefix(url, "data:;base64,")
+	} else {
+		valid := false
+		for _, t := range types {
+			prefix := "data:image/" + t + ";base64,"
+			if strings.HasPrefix(url, prefix) {
+				url = strings.TrimPrefix(url, prefix)
+				valid = true
+				break
+			}
+		}
+		if !valid {
+			return nil, errors.New("invalid image input")
+		}
+	}
+
+	img, err := base64.StdEncoding.DecodeString(url)
+	if err != nil {
+		return nil, errors.New("invalid image input")
+	}
+	return img, nil
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -14,6 +14,7 @@
 - [Pull a Model](#pull-a-model)
 - [Push a Model](#push-a-model)
 - [Generate Embeddings](#generate-embeddings)
+- [Generate Embeddings (Cohere-compatible)](#generate-embeddings-cohere-compatible)
 - [List Running Models](#list-running-models)
 - [Version](#version)
 - [Experimental: Image Generation](#image-generation-experimental)
@@ -1704,6 +1705,9 @@ Generate embeddings from a model
 
 - `model`: name of model to generate embeddings from
 - `input`: text or list of text to generate embeddings for
+- `inputs`: optional multimodal list of embedding inputs. Each item may include:
+  - `text`: text to embed
+  - `image`: base64-encoded image bytes to embed, optionally alongside `text`
 
 Advanced parameters:
 
@@ -1765,6 +1769,109 @@ curl http://localhost:11434/api/embed -d '{
     ]
   ]
 }
+```
+
+#### Request (Multimodal input)
+
+Use `inputs` with models that support image embeddings. Each `image` value is the raw image bytes encoded as base64 in JSON.
+
+```shell
+curl http://localhost:11434/api/embed -d '{
+  "model": "llava",
+  "inputs": [
+    {
+      "text": "Describe this image for retrieval",
+      "image": "<base64-encoded-image>"
+    }
+  ]
+}'
+```
+
+## Generate Embeddings (Cohere-compatible)
+
+```
+POST /v2/embed
+```
+
+Generate embeddings using a Cohere-compatible API.
+
+### Parameters
+
+- `model`: name of model to generate embeddings from
+- `texts`: optional list of text inputs
+- `images`: optional list of base64-encoded image inputs
+- `inputs`: optional multimodal list of inputs using Cohere content blocks
+- `embedding_types`: optional list of output formats. Supported values: `float`, `base64`
+- `output_dimension`: optional output embedding dimension
+- `truncate`: truncation strategy. Supported values: `END` and `NONE`
+
+Notes:
+
+- Provide exactly one of `texts`, `images`, or `inputs`
+- `image_url.url` currently supports base64 data URIs, not remote URLs
+- `inputs` supports `text` and `image_url` content blocks
+
+### Examples
+
+#### Request (Text)
+
+```shell
+curl http://localhost:11434/v2/embed -d '{
+  "model": "all-minilm",
+  "texts": ["Why is the sky blue?"],
+  "embedding_types": ["float"]
+}'
+```
+
+#### Response
+
+```json
+{
+  "id": "embed-response",
+  "embeddings": {
+    "float": [
+      [
+        0.010071029, -0.0017594862, 0.05007221, 0.04692972, 0.054916814,
+        0.008599704, 0.105441414, -0.025878139, 0.12958129, 0.031952348
+      ]
+    ]
+  },
+  "texts": ["Why is the sky blue?"],
+  "meta": {
+    "api_version": {
+      "version": "2"
+    },
+    "billed_units": {
+      "input_tokens": 8
+    }
+  },
+  "response_type": "embeddings_by_type"
+}
+```
+
+#### Request (Multimodal)
+
+```shell
+curl http://localhost:11434/v2/embed -d '{
+  "model": "llava",
+  "inputs": [
+    {
+      "content": [
+        {
+          "type": "text",
+          "text": "Describe this image for retrieval"
+        },
+        {
+          "type": "image_url",
+          "image_url": {
+            "url": "data:image/png;base64,<base64-encoded-image>"
+          }
+        }
+      ]
+    }
+  ],
+  "embedding_types": ["float", "base64"]
+}'
 ```
 
 ## List Running Models

--- a/llm/server.go
+++ b/llm/server.go
@@ -70,7 +70,7 @@ type LlamaServer interface {
 	Ping(ctx context.Context) error
 	WaitUntilRunning(ctx context.Context) error
 	Completion(ctx context.Context, req CompletionRequest, fn func(CompletionResponse)) error
-	Embedding(ctx context.Context, input string) ([]float32, int, error)
+	Embedding(ctx context.Context, input string, image *ImageData) ([]float32, int, error)
 	Tokenize(ctx context.Context, content string) ([]int, error)
 	Detokenize(ctx context.Context, tokens []int) (string, error)
 	Close() error
@@ -1698,7 +1698,8 @@ func (s *llmServer) Completion(ctx context.Context, req CompletionRequest, fn fu
 }
 
 type EmbeddingRequest struct {
-	Content string `json:"content"`
+	Content string     `json:"content"`
+	Image   *ImageData `json:"image,omitempty"`
 }
 
 type EmbeddingResponse struct {
@@ -1706,7 +1707,7 @@ type EmbeddingResponse struct {
 	PromptEvalCount int       `json:"prompt_eval_count"`
 }
 
-func (s *llmServer) Embedding(ctx context.Context, input string) ([]float32, int, error) {
+func (s *llmServer) Embedding(ctx context.Context, input string, image *ImageData) ([]float32, int, error) {
 	logutil.Trace("embedding request", "input", input)
 
 	if err := s.sem.Acquire(ctx, 1); err != nil {
@@ -1727,7 +1728,7 @@ func (s *llmServer) Embedding(ctx context.Context, input string) ([]float32, int
 		return nil, 0, fmt.Errorf("unexpected server status: %s", status)
 	}
 
-	data, err := json.Marshal(EmbeddingRequest{Content: input})
+	data, err := json.Marshal(EmbeddingRequest{Content: input, Image: image})
 	if err != nil {
 		return nil, 0, fmt.Errorf("error marshaling embed data: %w", err)
 	}

--- a/middleware/cohere.go
+++ b/middleware/cohere.go
@@ -1,0 +1,94 @@
+package middleware
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/cohere"
+)
+
+type CohereEmbedWriter struct {
+	BaseWriter
+	req cohere.EmbedRequest
+}
+
+func (w *CohereEmbedWriter) writeError(data []byte) (int, error) {
+	var serr api.StatusError
+	if err := json.Unmarshal(data, &serr); err != nil {
+		serr.ErrorMessage = string(data)
+	}
+
+	w.ResponseWriter.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w.ResponseWriter).Encode(cohere.NewError(serr.Error())); err != nil {
+		return 0, err
+	}
+
+	return len(data), nil
+}
+
+func (w *CohereEmbedWriter) writeResponse(data []byte) (int, error) {
+	var embedResponse api.EmbedResponse
+	if err := json.Unmarshal(data, &embedResponse); err != nil {
+		return 0, err
+	}
+
+	resp, err := cohere.ToEmbedResponse(w.req, embedResponse)
+	if err != nil {
+		return 0, err
+	}
+
+	w.ResponseWriter.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w.ResponseWriter).Encode(resp); err != nil {
+		return 0, err
+	}
+
+	return len(data), nil
+}
+
+func (w *CohereEmbedWriter) Write(data []byte) (int, error) {
+	if w.ResponseWriter.Status() != http.StatusOK {
+		return w.writeError(data)
+	}
+
+	return w.writeResponse(data)
+}
+
+func CohereEmbedMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var req cohere.EmbedRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, cohere.NewError(err.Error()))
+			return
+		}
+
+		if err := cohere.ValidateEmbeddingTypes(req.EmbeddingTypes); err != nil {
+			c.AbortWithStatusJSON(http.StatusNotImplemented, cohere.NewError(err.Error()))
+			return
+		}
+
+		embedReq, err := cohere.FromEmbedRequest(req)
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, cohere.NewError(err.Error()))
+			return
+		}
+
+		var b bytes.Buffer
+		if err := json.NewEncoder(&b).Encode(embedReq); err != nil {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, cohere.NewError(err.Error()))
+			return
+		}
+
+		c.Request.Body = io.NopCloser(&b)
+		c.Writer = &CohereEmbedWriter{
+			BaseWriter: BaseWriter{ResponseWriter: c.Writer},
+			req:        req,
+		}
+
+		c.Next()
+	}
+}

--- a/middleware/cohere_test.go
+++ b/middleware/cohere_test.go
@@ -1,0 +1,171 @@
+package middleware
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/cohere"
+)
+
+func TestCohereEmbedMiddleware(t *testing.T) {
+	type testCase struct {
+		name string
+		body string
+		req  api.EmbedRequest
+		err  cohere.ErrorResponse
+	}
+
+	var capturedRequest *api.EmbedRequest
+
+	testCases := []testCase{
+		{
+			name: "texts request",
+			body: `{"model":"test-model","texts":["hello","world"]}`,
+			req: api.EmbedRequest{
+				Model: "test-model",
+				Input: []any{"hello", "world"},
+				Truncate: func() *bool {
+					v := true
+					return &v
+				}(),
+			},
+		},
+		{
+			name: "images request",
+			body: `{"model":"test-model","images":["` + prefix + image + `"],"input_type":"image"}`,
+			req: api.EmbedRequest{
+				Model:  "test-model",
+				Inputs: []api.EmbedInput{{Image: mustDecodeBase64(t, image)}},
+				Truncate: func() *bool {
+					v := true
+					return &v
+				}(),
+			},
+		},
+		{
+			name: "mixed inputs request",
+			body: `{"model":"test-model","inputs":[{"content":[{"type":"text","text":"hello"},{"type":"image_url","image_url":{"url":"` + prefix + image + `"}}]}],"embedding_types":["float","base64"],"output_dimension":512,"truncate":"NONE"}`,
+			req: api.EmbedRequest{
+				Model:      "test-model",
+				Dimensions: 512,
+				Inputs: []api.EmbedInput{{
+					Text:  "hello",
+					Image: mustDecodeBase64(t, image),
+				}},
+				Truncate: func() *bool {
+					v := false
+					return &v
+				}(),
+			},
+		},
+		{
+			name: "unsupported embedding type",
+			body: `{"model":"test-model","texts":["hello"],"embedding_types":["int8"]}`,
+			err:  cohere.NewError(`embedding type "int8" is not supported`),
+		},
+	}
+
+	endpoint := func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	}
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(CohereEmbedMiddleware(), captureRequestMiddleware(&capturedRequest))
+	router.Handle(http.MethodPost, "/v2/embed", endpoint)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, _ := http.NewRequest(http.MethodPost, "/v2/embed", strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+
+			resp := httptest.NewRecorder()
+			router.ServeHTTP(resp, req)
+
+			var errResp cohere.ErrorResponse
+			if resp.Code != http.StatusOK {
+				if err := json.Unmarshal(resp.Body.Bytes(), &errResp); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			if capturedRequest != nil && !reflect.DeepEqual(tc.req, *capturedRequest) {
+				t.Fatalf("requests did not match: got %#v want %#v", *capturedRequest, tc.req)
+			}
+
+			if !reflect.DeepEqual(tc.err, errResp) {
+				t.Fatalf("errors did not match: got %#v want %#v", errResp, tc.err)
+			}
+
+			capturedRequest = nil
+		})
+	}
+}
+
+func TestCohereEmbedWriter(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(recorder)
+
+	writer := &CohereEmbedWriter{
+		BaseWriter: BaseWriter{ResponseWriter: context.Writer},
+		req: cohere.EmbedRequest{
+			Model:          "test-model",
+			Images:         []string{prefix + image},
+			EmbeddingTypes: []string{"float", "base64"},
+		},
+	}
+
+	context.Writer.WriteHeader(http.StatusOK)
+	payload, err := json.Marshal(api.EmbedResponse{
+		Model:           "test-model",
+		Embeddings:      [][]float32{{0.1, 0.2}},
+		PromptEvalCount: 3,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := writer.Write(payload); err != nil {
+		t.Fatal(err)
+	}
+
+	var resp cohere.EmbedResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := len(resp.Embeddings.Float), 1; got != want {
+		t.Fatalf("len(float embeddings) = %d, want %d", got, want)
+	}
+	if got, want := len(resp.Embeddings.Base64), 1; got != want {
+		t.Fatalf("len(base64 embeddings) = %d, want %d", got, want)
+	}
+	if got, want := len(resp.Images), 1; got != want {
+		t.Fatalf("len(images) = %d, want %d", got, want)
+	}
+	if resp.ResponseType != "embeddings_by_type" {
+		t.Fatalf("response_type = %q, want embeddings_by_type", resp.ResponseType)
+	}
+}
+
+func mustDecodeBase64(t *testing.T, value string) []byte {
+	t.Helper()
+
+	data, err := cohere.FromEmbedRequest(cohere.EmbedRequest{
+		Model:  "test-model",
+		Images: []string{prefix + value},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return data.Inputs[0].Image
+}

--- a/runner/llamarunner/runner.go
+++ b/runner/llamarunner/runner.go
@@ -755,12 +755,17 @@ func (s *Server) embeddings(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
+
+	prompt := req.Content
+	var images []llm.ImageData
 	if req.Image != nil {
-		http.Error(w, "this model does not support image embeddings", http.StatusNotImplemented)
-		return
+		images = []llm.ImageData{*req.Image}
+		if prompt != "" {
+			prompt += " [img-0]"
+		}
 	}
 
-	seq, err := s.NewSequence(req.Content, nil, NewSequenceParams{
+	seq, err := s.NewSequence(req.Content, images, NewSequenceParams{
 		embedding: true,
 		truncate:  false,
 	})

--- a/runner/llamarunner/runner.go
+++ b/runner/llamarunner/runner.go
@@ -755,6 +755,10 @@ func (s *Server) embeddings(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
+	if req.Image != nil {
+		http.Error(w, "this model does not support image embeddings", http.StatusNotImplemented)
+		return
+	}
 
 	seq, err := s.NewSequence(req.Content, nil, NewSequenceParams{
 		embedding: true,

--- a/runner/ollamarunner/runner.go
+++ b/runner/ollamarunner/runner.go
@@ -136,6 +136,35 @@ func (s *Server) NewSequence(prompt string, images []llm.ImageData, params NewSe
 	if err != nil {
 		return nil, fmt.Errorf("failed to process inputs: %w", err)
 	} else if len(inputs) == 0 {
+		if params.embedding && len(images) > 0 {
+			multimodalProcessor, visionModel := s.model.(model.MultimodalProcessor)
+			if !visionModel {
+				return nil, errors.New("embedding only supported for multimodal models")
+			}
+			if len(images) > 1 {
+				return nil, errors.New("embedding only supported for single image")
+			}
+
+			ctx := s.model.Backend().NewContext()
+			runtime.SetFinalizer(ctx, func(c ml.Context) { c.Close() })
+			ctxs = append(ctxs, ctx)
+
+			imageEmbeddings, err := multimodalProcessor.EncodeMultimodal(ctx, images[0].Data)
+			if err != nil {
+				return nil, err
+			}
+
+			s.multimodalHash.Reset()
+			_, _ = s.multimodalHash.Write(images[0].Data)
+			imageHash := s.multimodalHash.Sum64()
+
+			mmStore = newMultimodalStore()
+			mmStore.addMultimodal(imageEmbeddings)
+			inputs = []*input.Input{{Multimodal: imageEmbeddings, MultimodalHash: imageHash}}
+		}
+	}
+
+	if len(inputs) == 0 {
 		return nil, errors.New("no input provided")
 	}
 
@@ -1000,7 +1029,16 @@ func (s *Server) embeddings(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	seq, err := s.NewSequence(req.Content, nil, NewSequenceParams{
+	prompt := req.Content
+	var images []llm.ImageData
+	if req.Image != nil {
+		images = []llm.ImageData{*req.Image}
+		if prompt != "" {
+			prompt += " [img-0]"
+		}
+	}
+
+	seq, err := s.NewSequence(prompt, images, NewSequenceParams{
 		embedding: true,
 		truncate:  false,
 	})

--- a/runner/ollamarunner/runner.go
+++ b/runner/ollamarunner/runner.go
@@ -1029,6 +1029,7 @@ func (s *Server) embeddings(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
+
 	prompt := req.Content
 	var images []llm.ImageData
 	if req.Image != nil {

--- a/server/routes.go
+++ b/server/routes.go
@@ -699,12 +699,12 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 		return
 	}
 
-	var input []string
+	var inputs []api.EmbedInput
 
 	switch i := req.Input.(type) {
 	case string:
 		if len(i) > 0 {
-			input = append(input, i)
+			inputs = append(inputs, api.EmbedInput{Text: i})
 		}
 	case []any:
 		for _, v := range i {
@@ -712,7 +712,7 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 				c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "invalid input type"})
 				return
 			}
-			input = append(input, v.(string))
+			inputs = append(inputs, api.EmbedInput{Text: v.(string)})
 		}
 	default:
 		if req.Input != nil {
@@ -720,6 +720,7 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 			return
 		}
 	}
+	inputs = append(inputs, req.Inputs...)
 
 	name, err := getExistingName(modelRef.Name)
 	if err != nil {
@@ -735,7 +736,7 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 
 	checkpointLoaded := time.Now()
 
-	if len(input) == 0 {
+	if len(inputs) == 0 {
 		c.JSON(http.StatusOK, api.EmbedResponse{Model: req.Model, Embeddings: [][]float32{}})
 		return
 	}
@@ -748,8 +749,13 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 
 	ctx := c.Request.Context()
 
-	embedWithRetry := func(text string) ([]float32, int, error) {
-		emb, tokCount, err := r.Embedding(ctx, text)
+	embedWithRetry := func(item api.EmbedInput) ([]float32, int, error) {
+		var image *llm.ImageData
+		if len(item.Image) > 0 {
+			image = &llm.ImageData{ID: 0, Data: item.Image}
+		}
+
+		emb, tokCount, err := r.Embedding(ctx, item.Text, image)
 		if err == nil {
 			return emb, tokCount, nil
 		}
@@ -762,7 +768,11 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 			return nil, 0, err
 		}
 
-		tokens, err := r.Tokenize(ctx, text)
+		if item.Text == "" {
+			return nil, 0, err
+		}
+
+		tokens, err := r.Tokenize(ctx, item.Text)
 		if err != nil {
 			return nil, 0, err
 		}
@@ -788,15 +798,15 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 		if err != nil {
 			return nil, 0, err
 		}
-		return r.Embedding(ctx, truncated)
+		return r.Embedding(ctx, truncated, image)
 	}
 
 	var g errgroup.Group
-	embeddings := make([][]float32, len(input))
+	embeddings := make([][]float32, len(inputs))
 	var totalTokens uint64
-	for i, text := range input {
+	for i, item := range inputs {
 		g.Go(func() error {
-			embedding, tokenCount, err := embedWithRetry(text)
+			embedding, tokenCount, err := embedWithRetry(item)
 			if err != nil {
 				return err
 			}
@@ -894,7 +904,7 @@ func (s *Server) EmbeddingsHandler(c *gin.Context) {
 		return
 	}
 
-	embedding, _, err := r.Embedding(c.Request.Context(), req.Prompt)
+	embedding, _, err := r.Embedding(c.Request.Context(), req.Prompt, nil)
 	if err != nil {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": strings.TrimSpace(err.Error())})
 		return
@@ -1721,6 +1731,9 @@ func (s *Server) GenerateRoutes(rc *ollama.Registry) (http.Handler, error) {
 
 	// Inference (Anthropic compatibility)
 	r.POST("/v1/messages", s.withInferenceRequestLogging("/v1/messages", cloudPassthroughMiddleware(cloudErrRemoteInferenceUnavailable), middleware.AnthropicMessagesMiddleware(), s.ChatHandler)...)
+
+	// Inference (Cohere compatibility)
+	r.POST("/v2/embed", cloudPassthroughMiddleware(cloudErrRemoteInferenceUnavailable), middleware.CohereEmbedMiddleware(), s.EmbedHandler)
 
 	if rc != nil {
 		// wrap old with new

--- a/server/routes_cloud_test.go
+++ b/server/routes_cloud_test.go
@@ -342,6 +342,49 @@ func TestExplicitCloudPassthroughAPIAndV1(t *testing.T) {
 		}
 	})
 
+	t.Run("cohere embed", func(t *testing.T) {
+		upstream, capture := newUpstream(t, `{"id":"embed","embeddings":{"float":[[0.1,0.2]]}}`)
+		defer upstream.Close()
+
+		original := cloudProxyBaseURL
+		cloudProxyBaseURL = upstream.URL
+		t.Cleanup(func() { cloudProxyBaseURL = original })
+
+		s := &Server{}
+		router, err := s.GenerateRoutes(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		local := httptest.NewServer(router)
+		defer local.Close()
+
+		reqBody := `{"model":"kimi-k2.5:cloud","texts":["hello"]}`
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, local.URL+"/v2/embed", bytes.NewBufferString(reqBody))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := local.Client().Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200, got %d (%s)", resp.StatusCode, string(body))
+		}
+
+		if capture.path != "/v2/embed" {
+			t.Fatalf("expected upstream path /v2/embed, got %q", capture.path)
+		}
+
+		if !strings.Contains(capture.body, `"model":"kimi-k2.5"`) {
+			t.Fatalf("expected normalized model in upstream body, got %q", capture.body)
+		}
+	})
+
 	t.Run("api show", func(t *testing.T) {
 		upstream, capture := newUpstream(t, `{"details":{"format":"gguf"}}`)
 		defer upstream.Close()

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -882,7 +882,7 @@ func (s *mockLlm) Completion(ctx context.Context, req llm.CompletionRequest, fn 
 	return s.completionResp
 }
 
-func (s *mockLlm) Embedding(ctx context.Context, input string) ([]float32, int, error) {
+func (s *mockLlm) Embedding(ctx context.Context, input string, image *llm.ImageData) ([]float32, int, error) {
 	return s.embeddingResp, 0, s.embeddingRespErr
 }
 

--- a/x/imagegen/server.go
+++ b/x/imagegen/server.go
@@ -390,7 +390,7 @@ func (s *Server) ContextLength() int {
 }
 
 // Embedding returns embeddings for the input.
-func (s *Server) Embedding(ctx context.Context, input string) ([]float32, int, error) {
+func (s *Server) Embedding(ctx context.Context, input string, image *llm.ImageData) ([]float32, int, error) {
 	return nil, 0, errors.New("embeddings not supported for MLX models")
 }
 

--- a/x/mlxrunner/client.go
+++ b/x/mlxrunner/client.go
@@ -289,7 +289,7 @@ func (c *Client) Detokenize(ctx context.Context, tokens []int) (string, error) {
 }
 
 // Embedding implements llm.LlamaServer.
-func (c *Client) Embedding(ctx context.Context, input string) ([]float32, int, error) {
+func (c *Client) Embedding(ctx context.Context, input string, image *llm.ImageData) ([]float32, int, error) {
 	return nil, 0, errors.New("not supported")
 }
 


### PR DESCRIPTION
Fix https://github.com/ollama/ollama/issues/4296

This is the latest implementation of https://github.com/ollama/ollama/pull/10728.

It supports the cohere embedding API (/v2/embed).

It is not working yet. because of the runner does not support the multimodal embedding model.

Related:
- https://github.com/ollama/ollama/issues/5304




---

# Updated Docs

## Generate Embedding

> Note: this endpoint has been superseded by `/api/embed`

```
POST /api/embeddings
```

Generate embeddings from a model

### Parameters

- `model`: name of model to generate embeddings from
- `prompt`: text to generate embeddings for

Advanced parameters:

- `options`: additional model parameters listed in the documentation for the [Modelfile](./modelfile.mdx#valid-parameters-and-values) such as `temperature`
- `keep_alive`: controls how long the model will stay loaded into memory following the request (default: `5m`)

### Examples

#### Request

```shell
curl http://localhost:11434/api/embed -d '{
  "model": "llava",
  "inputs": [
    {
      "text": "Describe this image for retrieval",
      "image": "<base64-encoded-image>"
    }
  ]
}'
```


## Generate Embeddings (Cohere-compatible)

```
POST /v2/embed
```

Generate embeddings using a Cohere-compatible API.

### Parameters

- `model`: name of model to generate embeddings from
- `texts`: optional list of text inputs
- `images`: optional list of base64-encoded image inputs
- `inputs`: optional multimodal list of inputs using Cohere content blocks
- `embedding_types`: optional list of output formats. Supported values: `float`, `base64`
- `output_dimension`: optional output embedding dimension
- `truncate`: truncation strategy. Supported values: `END` and `NONE`

Notes:

- Provide exactly one of `texts`, `images`, or `inputs`
- `image_url.url` currently supports base64 data URIs, not remote URLs
- `inputs` supports `text` and `image_url` content blocks

### Examples

#### Request (Text)

```shell
curl http://localhost:11434/v2/embed -d '{
  "model": "all-minilm",
  "texts": ["Why is the sky blue?"],
  "embedding_types": ["float"]
}'
```

#### Response

```json
{
  "id": "embed-response",
  "embeddings": {
    "float": [
      [
        0.010071029, -0.0017594862, 0.05007221, 0.04692972, 0.054916814,
        0.008599704, 0.105441414, -0.025878139, 0.12958129, 0.031952348
      ]
    ]
  },
  "texts": ["Why is the sky blue?"],
  "meta": {
    "api_version": {
      "version": "2"
    },
    "billed_units": {
      "input_tokens": 8
    }
  },
  "response_type": "embeddings_by_type"
}
```

#### Request (Multimodal)

```shell
curl http://localhost:11434/v2/embed -d '{
  "model": "llava",
  "inputs": [
    {
      "content": [
        {
          "type": "text",
          "text": "Describe this image for retrieval"
        },
        {
          "type": "image_url",
          "image_url": {
            "url": "data:image/png;base64,<base64-encoded-image>"
          }
        }
      ]
    }
  ],
  "embedding_types": ["float", "base64"]
}'
```