### PR TITLE
fix(app): prevent sidebar animation on initial load

### DIFF
--- a/app/ui/app/src/components/layout/layout.tsx
+++ b/app/ui/app/src/components/layout/layout.tsx
@@ -1,5 +1,6 @@
 import { Link } from "@tanstack/react-router";
 import { useSettings } from "@/hooks/useSettings";
+import { useState, useEffect } from "react";
 
 export function SidebarLayout({
   sidebar,
@@ -12,10 +13,19 @@ export function SidebarLayout({
   const { settings, setSettings } = useSettings();
   const isWindows = navigator.platform.toLowerCase().includes("win");
 
+  // Prevent sidebar from animating on initial page load.
+  // Transitions are only enabled after the first render.
+  const [enableTransitions, setEnableTransitions] = useState(false);
+  useEffect(() => {
+    requestAnimationFrame(() => {
+      setEnableTransitions(true);
+    });
+  }, []);
+
   return (
-    <div className={`flex transition-[width] duration-300 dark:bg-neutral-900`}>
+    <div className={`flex ${enableTransitions ? "transition-[width] duration-300" : ""} dark:bg-neutral-900`}>
       <div
-        className={`absolute flex mx-2 py-2 z-20 items-center transition-[left] duration-375 text-neutral-500 dark:text-neutral-400 ${settings.sidebarOpen ? (isWindows ? "left-2" : "left-[204px]") : isWindows ? "left-2" : "left-20"}`}
+        className={`absolute flex mx-2 py-2 z-20 items-center ${enableTransitions ? "transition-[left] duration-375" : ""} text-neutral-500 dark:text-neutral-400 ${settings.sidebarOpen ? (isWindows ? "left-2" : "left-[204px]") : isWindows ? "left-2" : "left-20"}`}
       >
         <button
           onClick={() => setSettings({ SidebarOpen: !settings.sidebarOpen })}
@@ -39,7 +49,7 @@ export function SidebarLayout({
           to="/c/$chatId"
           params={{ chatId: "new" }}
           title="New chat"
-          className={`flex ml-1 items-center justify-center rounded-full transition-opacity duration-375 h-9 w-9 hover:bg-neutral-100 dark:hover:bg-neutral-700 ${
+          className={`flex ml-1 items-center justify-center rounded-full ${enableTransitions ? "transition-opacity duration-375" : ""} h-9 w-9 hover:bg-neutral-100 dark:hover:bg-neutral-700 ${
             settings.sidebarOpen
               ? "opacity-0 pointer-events-none"
               : "opacity-100"
@@ -57,7 +67,7 @@ export function SidebarLayout({
         </Link>
       </div>
       <div
-        className={`flex flex-col transition-[width] duration-300 max-h-screen ${settings.sidebarOpen ? "w-64" : "w-0"}`}
+        className={`flex flex-col ${enableTransitions ? "transition-[width] duration-300" : ""} max-h-screen ${settings.sidebarOpen ? "w-64" : "w-0"}`}
       >
         <div
           onDoubleClick={() => window.doubleClick && window.doubleClick()}
@@ -67,7 +77,7 @@ export function SidebarLayout({
         {settings.sidebarOpen && sidebar}
       </div>
       <main
-        className={`flex flex-1 flex-col min-w-0 transition-all duration-300`}
+        className={`flex flex-1 flex-col min-w-0 ${enableTransitions ? "transition-all duration-300" : ""}`}
       >
         <div
           className={`h-13 flex-none w-full z-10 flex items-center bg-white dark:bg-neutral-900 ${isWindows ? "xl:hidden" : "xl:fixed xl:bg-transparent xl:dark:bg-transparent"}`}


### PR DESCRIPTION
## Summary

When the app loads with the sidebar in its open state, the sidebar animates from collapsed to open instead of appearing open immediately. This is because CSS transitions (`transition-[width]`, `transition-[left]`, `transition-opacity`, `transition-all`) are always active, including during the initial render.

This PR introduces an `enableTransitions` state that starts as `false` and flips to `true` after the first paint via `requestAnimationFrame`. All transition classes in the `SidebarLayout` component are conditionally applied only after this flag is set, so the sidebar renders in its correct position instantly on load while still animating smoothly on subsequent user interactions.

## Test plan

- Open the app with the sidebar setting saved as open — sidebar should appear immediately without sliding in
- Toggle the sidebar closed and open — transitions should animate smoothly as before
- Refresh with the sidebar closed — main content should fill the space immediately without animating
- Test on both macOS and Windows layouts (the toggle button positioning differs)

Fixes #12954