### PR TITLE
mlx: respect tokenizer add_bos_token setting in pipeline

### DIFF
--- a/x/mlxrunner/pipeline.go
+++ b/x/mlxrunner/pipeline.go
@@ -55,7 +55,7 @@ func (r *Runner) TextGenerationPipeline(request Request) error {
 		slog.Info("peak memory", "size", mlx.PrettyBytes(mlx.PeakMemory()))
 	}()
 
-	inputs := r.Tokenizer.Encode(request.Prompt, true)
+	inputs := r.Tokenizer.Encode(request.Prompt, r.Tokenizer.AddBOS())
 	if len(inputs) == 0 {
 		return errors.New("empty prompt")
 	}


### PR DESCRIPTION
Replace hardcoded Encode(prompt, true) with
Encode(prompt, r.Tokenizer.AddBOS()) so the pipeline respects each model's tokenizer configuration.

Models with add_bos_token=true (gemma3, llama): unchanged, tokenizer still prepends BOS.

Models with bos_token=null (qwen3, qwen3.5): unchanged, the BOS guard (vocab.BOS >= 0) already prevented prepending regardless of the flag.

This aligns the pipeline with the /v1/tokenize endpoint which already uses Tokenizer.AddBOS().