### PR TITLE
docs: add kbot integration

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -122,6 +122,7 @@
                   "/integrations/opencode",
                   "/integrations/droid",
                   "/integrations/goose",
+                  "/integrations/kbot",
                   "/integrations/pi"
                 ]
               },

--- a/docs/integrations/index.mdx
+++ b/docs/integrations/index.mdx
@@ -13,6 +13,7 @@ Coding assistants that can read, modify, and execute code in your projects.
 - [OpenCode](/integrations/opencode)
 - [Droid](/integrations/droid)
 - [Goose](/integrations/goose)
+- [kbot](/integrations/kbot)
 - [Pi](/integrations/pi)
 
 ## Assistants

--- a/docs/integrations/kbot.mdx
+++ b/docs/integrations/kbot.mdx
@@ -1,0 +1,105 @@
+---
+title: kbot
+---
+
+kbot is an open-source terminal AI agent with 670+ built-in tools, 35 specialist agents, and a learning engine that improves over time.
+
+## Install
+
+Install [kbot](https://github.com/isaacsight/kernel):
+
+```bash
+npm install -g @kernel.chat/kbot
+```
+
+## Usage with Ollama
+
+### Quick setup
+
+```bash
+ollama launch kbot
+```
+
+This installs kbot, configures Ollama as the AI provider, and starts an interactive session with all 670+ tools available.
+
+To configure without launching:
+
+```shell
+ollama launch kbot --config
+```
+
+### Run directly with a model
+
+```shell
+ollama launch kbot --model qwen2.5-coder:32b
+```
+
+Cloud models are also available at [ollama.com](https://ollama.com/search?c=cloud).
+
+## What makes kbot different
+
+kbot ships with 670+ tools out of the box across coding, science, finance, security, music production, and more. It auto-routes requests to 35 specialist agents (coder, researcher, writer, guardian, quant, etc.) and learns your patterns over time.
+
+### Built-in tools (670+)
+
+| Category | Examples |
+|----------|---------|
+| **Files & Code** | read, write, glob, grep, lint, format, type-check |
+| **Shell** | bash, parallel execute, background tasks |
+| **Git & GitHub** | commit, diff, PR, issues, code search |
+| **Web** | search, fetch, browser automation |
+| **Science** | 114 tools — physics, chemistry, biology, neuroscience, math |
+| **Finance** | market data, technical analysis, paper trading, DeFi |
+| **Security** | vulnerability scanning, secret detection, SSL checks |
+| **Research** | arXiv, Semantic Scholar, PubMed, literature review |
+| **Music** | Ableton Live control, Serum 2 presets, DJ set builder |
+
+### 35 specialist agents
+
+kbot auto-routes each request to the right expert: `coder`, `researcher`, `writer`, `analyst`, `guardian`, `quant`, `investigator`, `oracle`, and 27 more. Override with `--agent <name>`.
+
+### Learning engine
+
+kbot extracts patterns and solutions from every session, building a profile that makes it faster and more accurate over time. All learning data stays local.
+
+## Manual setup
+
+Run kbot with Ollama directly:
+
+```bash
+kbot local
+```
+
+This auto-detects Ollama, lists available models, and configures kbot to use local AI at $0 cost.
+
+To specify a model:
+
+```bash
+kbot local --model qwen2.5-coder:32b
+```
+
+Or set the environment variable:
+
+```bash
+export OLLAMA_HOST=http://localhost:11434
+kbot --ollama-launch
+```
+
+### Recommended models
+
+| Model | Best for | Size |
+|-------|----------|------|
+| `qwen2.5-coder:32b` | Coding tasks | 18 GB |
+| `qwen2.5-coder:7b` | Fast coding | 4.7 GB |
+| `deepseek-r1:32b` | Reasoning | 19 GB |
+| `llama3.3:70b` | General | 40 GB |
+| `gemma3:12b` | Balanced | 8 GB |
+
+kbot requires models with at least 8K context. For best results, use 64K+ context models.
+
+## Additional features
+
+- **MCP server** — use kbot as a tool provider in Claude Code, Cursor, VS Code, or any MCP client: `kbot ide mcp`
+- **SDK** — use kbot programmatically: `import { agent } from '@kernel.chat/kbot'`
+- **20 providers** — switch between Ollama, Anthropic, OpenAI, Google, and 16 more with one command
+- **Web companion** — [kernel.chat](https://kernel.chat) provides a visual interface with the same agents


### PR DESCRIPTION
## Summary

Add [kbot](https://github.com/isaacsight/kernel) to the Ollama integrations page.

kbot is an open-source terminal AI agent (MIT license) with:
- **670+ built-in tools** across coding, science, finance, security, music production
- **35 specialist agents** with automatic routing
- **Learning engine** that improves over time
- **20 AI providers** including deep Ollama integration
- **3,400+ weekly npm downloads**

kbot connects to Ollama via the OpenAI-compatible API at `localhost:11434/v1` and supports `ollama launch kbot` via the `--ollama-launch` flag.

## Changes

- `docs/integrations/kbot.mdx` — New integration page with install, usage, model recommendations, and feature overview
- `docs/integrations/index.mdx` — Add kbot to Coding Agents list
- `docs/docs.json` — Add kbot to sidebar navigation

## Links

- **npm**: [@kernel.chat/kbot](https://www.npmjs.com/package/@kernel.chat/kbot)
- **GitHub**: [isaacsight/kernel](https://github.com/isaacsight/kernel)
- **Web**: [kernel.chat](https://kernel.chat)