### PR TITLE
fix(registry): avoid panic in statusCodeRecorder on non-Flusher/Close…

### DIFF
--- a/server/internal/registry/server.go
+++ b/server/internal/registry/server.go
@@ -89,17 +89,21 @@ var (
 )
 
 // CloseNotify implements the http.CloseNotifier interface, for Gin. Remove with Gin.
-//
-// It panics if the underlying ResponseWriter is not a CloseNotifier.
 func (r *statusCodeRecorder) CloseNotify() <-chan bool {
-	return r.ResponseWriter.(http.CloseNotifier).CloseNotify()
+	c, ok := r.ResponseWriter.(http.CloseNotifier)
+	if !ok {
+		// Connection close notifications are optional; if not supported,
+		// return a channel that never signals.
+		return make(chan bool)
+	}
+	return c.CloseNotify()
 }
 
 // Flush implements the http.Flusher interface, for Gin. Remove with Gin.
-//
-// It panics if the underlying ResponseWriter is not a Flusher.
 func (r *statusCodeRecorder) Flush() {
-	r.ResponseWriter.(http.Flusher).Flush()
+	if fl, ok := r.ResponseWriter.(http.Flusher); ok {
+		fl.Flush()
+	}
 }
 
 func (r *statusCodeRecorder) status() int {

--- a/server/internal/registry/server_test.go
+++ b/server/internal/registry/server_test.go
@@ -100,6 +100,57 @@ func (r *invalidReader) Read(p []byte) (int, error) {
 	return 0, os.ErrInvalid
 }
 
+type noNotifyFlusherWriter struct {
+	head http.Header
+	buf  []byte
+	code int
+}
+
+func (w *noNotifyFlusherWriter) Header() http.Header {
+	if w.head == nil {
+		w.head = make(http.Header)
+	}
+	return w.head
+}
+
+func (w *noNotifyFlusherWriter) Write(b []byte) (int, error) {
+	w.buf = append(w.buf, b...)
+	if w.code == 0 {
+		w.code = http.StatusOK
+	}
+	return len(b), nil
+}
+
+func (w *noNotifyFlusherWriter) WriteHeader(statusCode int) {
+	w.code = statusCode
+}
+
+func TestStatusCodeRecorderNoNotifyFlush(t *testing.T) {
+	w := &noNotifyFlusherWriter{}
+	r := &statusCodeRecorder{ResponseWriter: w}
+
+	// should not panic when underlying response writer does not support CloseNotifier/Flusher
+	assertNotPanic(t, func() { _ = r.CloseNotify() })
+	assertNotPanic(t, func() { r.Flush() })
+
+	ch := r.CloseNotify()
+	select {
+	case <-ch:
+		t.Fatal("close channel should not be signaled")
+	default:
+	}
+}
+
+func assertNotPanic(t *testing.T, fn func()) {
+	t.Helper()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("unexpected panic: %v", r)
+		}
+	}()
+	fn()
+}
+
 // captureLogs is a helper to capture logs from the server. It returns a
 // shallow copy of the server with a new logger and a bytesResetter for the
 // logs.


### PR DESCRIPTION
…Notifier

The statusCodeRecorder type implements http.Flusher and http.CloseNotifier interfaces by delegating to the underlying ResponseWriter. However, calling these methods would panic if the underlying writer didn't support them.

This fix adds safe type checks:
- CloseNotify() returns a non-signaling channel if not supported
- Flush() becomes a no-op if not supported

Includes regression test to prevent future crashes.