### PR TITLE
Fix: Resolve incorrect GGUF magic validation in fs/gguf/gguf.go

### DIFF
--- a/fs/gguf/gguf.go
+++ b/fs/gguf/gguf.go
@@ -57,7 +57,7 @@ func Open(path string) (f *File, err error) {
 		return nil, err
 	}
 
-	if bytes.Equal(f.Magic[:], []byte("gguf")) {
+	if !bytes.Equal(f.Magic[:], []byte("GGUF")) {
 		return nil, fmt.Errorf("%w file type %v", ErrUnsupported, f.Magic)
 	}
 


### PR DESCRIPTION
## Summary

The GGUF magic validation in `fs/gguf/gguf.go` had two issues:

1. **Wrong case**: The check compared against lowercase `gguf` but the actual GGUF magic is uppercase `GGUF` (ASCII: 0x47 0x47 0x55 0x46)
2. **Inverted logic**: The check returned an error when magic equaled `gguf`, but it should return an error when magic does NOT equal the valid `GGUF` magic

## Fix

Changed the condition to properly validate the GGUF magic:
- Before: `if bytes.Equal(f.Magic[:], []byte("gguf"))`
- After: `if !bytes.Equal(f.Magic[:], []byte("GGUF"))`

This ensures valid GGUF files are accepted and invalid/non-GGUF files are properly rejected.
