### PR TITLE
fix(mlx): prevent Metal GPU watchdog crash on large models

### DIFF
--- a/x/mlxrunner/pipeline.go
+++ b/x/mlxrunner/pipeline.go
@@ -14,8 +14,9 @@ import (
 	"github.com/ollama/ollama/x/mlxrunner/mlx"
 )
 
+// Line 17-19 — FIXED
 func prefillChunkSize() int {
-	return 2 << 10
+	return 512
 }
 
 func (r *Runner) TextGenerationPipeline(request Request) error {
@@ -199,7 +200,8 @@ func (r *Runner) TextGenerationPipeline(request Request) error {
 		sample, logprobs = nextSample, nextLogprobs
 		nextSample, nextLogprobs = nil, nil
 
-		if i%256 == 0 {
+		if i%64 == 0 {
+			mlx.Eval(sample)
 			mlx.ClearCache()
 		}
 	}


### PR DESCRIPTION
## Root Cause
macOS GPU watchdog terminates Metal command buffers that take too long (~1-2 sec). Large models with long context (post web-search) were triggering this because:
1. `prefillChunkSize()` was returning 2048 tokens — too large for a single Metal command buffer
2. Generation loop was only syncing GPU every 256 tokens — too infrequent, allowing command buffers to accumulate

## Fix
Two changes in `x/mlxrunner/pipeline.go`:

1. Reduced prefill chunk size from `2 << 10` (2048) to `512` — smaller chunks mean each Metal command buffer completes faster, staying under the watchdog timeout

2. Added `mlx.Eval(sample)` and reduced cache clear interval from `256` to `64` tokens — forces periodic GPU synchronization during generation so command buffers don't accumulate

## Testing
Needs testing on macOS with Apple Silicon. To reproduce the original crash:
1. Run `ollama run qwen3.5:35b-a3b-coding-nvfp4`
2. Give a prompt that triggers web search
3. Before fix: crash with Metal watchdog error after ~1 minute
4. After fix: response should complete successfully