### PR TITLE
llm: add automatic MOE expert weight offloading

### DIFF
--- a/llm/server.go
+++ b/llm/server.go
@@ -480,6 +480,7 @@ type LoadRequest struct {
 	KvCacheType    string
 	NumThreads     int
 	GPULayers      ml.GPULayersList
+	ExpertOffload  []int
 	MultiUserCache bool
 
 	// Legacy fields - not used with the Ollama engine
@@ -502,15 +503,17 @@ func (s *llamaServer) Load(ctx context.Context, systemInfo ml.SystemInfo, system
 
 	// Synthesize memory allocation information based on our estimates
 	s.mem = &ml.BackendMemory{CPU: ml.DeviceMemory{
-		Name:    "CPU",
-		Weights: make([]uint64, s.totalLayers),
-		Cache:   make([]uint64, s.totalLayers),
+		Name:          "CPU",
+		Weights:       make([]uint64, s.totalLayers),
+		ExpertWeights: make([]uint64, s.totalLayers),
+		Cache:         make([]uint64, s.totalLayers),
 	}, GPUs: make([]ml.DeviceMemory, len(gpus))}
 
 	for i := range s.mem.GPUs {
 		s.mem.GPUs[i].Name = gpus[i].Name
 		s.mem.GPUs[i].DeviceID = gpus[i].DeviceID
 		s.mem.GPUs[i].Weights = make([]uint64, s.totalLayers)
+		s.mem.GPUs[i].ExpertWeights = make([]uint64, s.totalLayers)
 		s.mem.GPUs[i].Cache = make([]uint64, s.totalLayers)
 	}
 
@@ -619,7 +622,7 @@ func (s *llamaServer) Load(ctx context.Context, systemInfo ml.SystemInfo, system
 		prevGPULayers := gpuLayers
 
 		var err error
-		gpuLayers, err = s.createLayout(systemInfo, gpus, s.mem, requireFull, 0)
+		gpuLayers, _, err = s.createLayout(systemInfo, gpus, s.mem, requireFull, 0)
 		if err != nil {
 			return nil, err
 		}
@@ -761,7 +764,7 @@ func (s *ollamaServer) Load(ctx context.Context, systemInfo ml.SystemInfo, gpus 
 	pastAllocations := make(map[uint64]struct{})
 	var backoff float32
 
-	gpuLayers, err := s.createLayout(systemInfo, gpus, s.mem, requireFull, backoff)
+	gpuLayers, expertOffload, err := s.createLayout(systemInfo, gpus, s.mem, requireFull, backoff)
 	if err != nil {
 		return nil, err
 	}
@@ -775,6 +778,7 @@ nextOperation:
 	nextLoad:
 		for {
 			s.loadRequest.GPULayers = gpuLayers
+			s.loadRequest.ExpertOffload = expertOffload
 			resp, err := s.initModel(ctx, s.loadRequest, operation)
 			if err != nil {
 				return nil, err
@@ -787,12 +791,17 @@ nextOperation:
 			s.mem = &resp.Memory
 
 			for {
-				newGPULayers, err := s.createLayout(systemInfo, gpus, s.mem, requireFull, backoff)
+				newGPULayers, newExpertOffload, err := s.createLayout(systemInfo, gpus, s.mem, requireFull, backoff)
 				if err != nil {
 					return nil, err
 				}
 
-				slog.Debug("new layout created", "layers", newGPULayers)
+				slog.Debug("new layout created", "layers", newGPULayers, "expert_offload", len(newExpertOffload))
+
+				// ExpertOffload is derived from the current memory data and may change
+				// even when GPULayers converges (e.g., first probe has no expert data,
+				// second probe has real expert weights). Always keep it in sync.
+				expertOffload = newExpertOffload
 
 				// We get additional memory information over time, which will reduce the number of
 				// layers that can fit, so fewer layers is actually better. As long as we haven't seen
@@ -820,7 +829,7 @@ nextOperation:
 						slog.Debug("exploring intermediate layers", "layer", i)
 
 						s.options.NumGPU = i
-						newGPULayers, err = s.createLayout(systemInfo, gpus, s.mem, requireFull, backoff)
+						newGPULayers, newExpertOffload, err = s.createLayout(systemInfo, gpus, s.mem, requireFull, backoff)
 						s.options.NumGPU = -1
 						if err != nil {
 							return nil, err
@@ -828,6 +837,7 @@ nextOperation:
 						slog.Debug("new layout created", "layers", newGPULayers)
 
 						s.loadRequest.GPULayers = newGPULayers
+						s.loadRequest.ExpertOffload = newExpertOffload
 						resp, err = s.initModel(ctx, s.loadRequest, operation)
 						if err != nil {
 							return nil, err
@@ -837,7 +847,7 @@ nextOperation:
 						slog.Debug("memory", "success", resp.Success, "required", resp.Memory)
 
 						if resp.Success {
-							verifyGPULayers, err := s.createLayout(systemInfo, gpus, &resp.Memory, requireFull, backoff)
+							verifyGPULayers, verifyExpertOffload, err := s.createLayout(systemInfo, gpus, &resp.Memory, requireFull, backoff)
 							if err != nil {
 								return nil, err
 							}
@@ -846,6 +856,7 @@ nextOperation:
 
 							if newGPULayers.Sum() <= verifyGPULayers.Sum() {
 								gpuLayers = newGPULayers
+								expertOffload = verifyExpertOffload
 
 								// Since we are going backwards (increasing the number of layers), ensure that
 								// we can come back down if needed
@@ -884,6 +895,7 @@ nextOperation:
 	}
 
 	s.loadRequest.GPULayers = gpuLayers
+	s.loadRequest.ExpertOffload = expertOffload
 	resp, err := s.initModel(ctx, s.loadRequest, LoadOperationCommit)
 	if err != nil {
 		return nil, err
@@ -923,61 +935,77 @@ func uniqueDeviceIDs(gpuLayers ml.GPULayersList) []ml.DeviceID {
 // - Calculating how much space each GPU has available for layers, based on free memory and space occupied by the graph
 // - Assigning layers
 // - Ensuring that we don't exceed limits, such as requirements about partial offloading or system memory
-func (s *llmServer) createLayout(systemInfo ml.SystemInfo, systemGPUs []ml.DeviceInfo, memory *ml.BackendMemory, requireFull bool, backoff float32) (ml.GPULayersList, error) {
+func (s *llmServer) createLayout(systemInfo ml.SystemInfo, systemGPUs []ml.DeviceInfo, memory *ml.BackendMemory, requireFull bool, backoff float32) (ml.GPULayersList, []int, error) {
 	if memory == nil {
 		memory = &ml.BackendMemory{CPU: ml.DeviceMemory{
-			Weights: make([]uint64, s.totalLayers),
-			Cache:   make([]uint64, s.totalLayers),
+			Weights:       make([]uint64, s.totalLayers),
+			ExpertWeights: make([]uint64, s.totalLayers),
+			Cache:         make([]uint64, s.totalLayers),
 		}}
 	}
-	gpuLayers, layers := s.buildLayout(systemGPUs, memory, requireFull, backoff)
-	err := s.verifyLayout(systemInfo, systemGPUs, memory, requireFull, gpuLayers, layers)
+	gpuLayers, expertOffload, layers := s.buildLayout(systemGPUs, memory, requireFull, backoff)
+	err := s.verifyLayout(systemInfo, systemGPUs, memory, requireFull, gpuLayers, expertOffload, layers)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return gpuLayers, nil
+	return gpuLayers, expertOffload, nil
 }
 
-func (s *llmServer) buildLayout(systemGPUs []ml.DeviceInfo, memory *ml.BackendMemory, requireFull bool, backoff float32) (ml.GPULayersList, []uint64) {
+func (s *llmServer) buildLayout(systemGPUs []ml.DeviceInfo, memory *ml.BackendMemory, requireFull bool, backoff float32) (ml.GPULayersList, []int, []uint64) {
 	gpus := append(make([]ml.DeviceInfo, 0, len(systemGPUs)), systemGPUs...)
 	sort.Sort(sort.Reverse(ml.ByFreeMemory(gpus)))
 
+	// Compute full layer sizes (base weights + expert weights + cache)
 	layers := make([]uint64, len(memory.CPU.Weights))
 	for i := range layers {
 		for j := range memory.GPUs {
 			layers[i] += memory.GPUs[j].Weights[i]
+			layers[i] += memory.GPUs[j].ExpertWeights[i]
 			layers[i] += memory.GPUs[j].Cache[i]
 		}
 		layers[i] += memory.CPU.Weights[i]
+		layers[i] += memory.CPU.ExpertWeights[i]
 		layers[i] += memory.CPU.Cache[i]
 		logutil.Trace("layer to assign", "layer", i, "size", format.HumanBytes2(layers[i]))
 	}
 
-	gpuLayers := ml.GPULayersList{}
-	for _, gl := range ml.ByLibrary(gpus) {
-		// If a GPU already has a graph allocated on it, then we should continue to use it.
-		// Otherwise, we lose information that we got from previous allocations, which can
-		// cause cycling. Plus, we get more information about required allocation from each
-		// iteration, so it doesn't make sense that a later iteration would use fewer GPUs.
+	// Compute per-layer expert weight sizes for potential offloading
+	expertSizes := make([]uint64, len(layers))
+	hasExperts := false
+	for i := range expertSizes {
+		for j := range memory.GPUs {
+			expertSizes[i] += memory.GPUs[j].ExpertWeights[i]
+		}
+		expertSizes[i] += memory.CPU.ExpertWeights[i]
+		if expertSizes[i] > 0 {
+			hasExperts = true
+		}
+	}
+
+	// adjustGPUs computes available VRAM per GPU after reserving overhead.
+	// Returns the adjusted GPU list and lastUsedGPU index.
+	adjustGPUs := func(gl []ml.DeviceInfo) ([]ml.DeviceInfo, int) {
+		adjusted := make([]ml.DeviceInfo, len(gl))
+		copy(adjusted, gl)
 		lastUsedGPU := 0
-		for i := range gl {
+		for i := range adjusted {
 			found := false
 			for j := range memory.GPUs {
-				if gl[i].DeviceID == memory.GPUs[j].DeviceID {
+				if adjusted[i].DeviceID == memory.GPUs[j].DeviceID {
 					if memory.GPUs[j].Graph != 0 {
 						lastUsedGPU = i
 					}
 
-					reserved := uint64(float32(gl[i].FreeMemory)*backoff) + gl[i].MinimumMemory() + envconfig.GpuOverhead() + memory.GPUs[j].Graph
-					if gl[i].FreeMemory > reserved {
-						gl[i].FreeMemory -= reserved
+					reserved := uint64(float32(adjusted[i].FreeMemory)*backoff) + adjusted[i].MinimumMemory() + envconfig.GpuOverhead() + memory.GPUs[j].Graph
+					if adjusted[i].FreeMemory > reserved {
+						adjusted[i].FreeMemory -= reserved
 					} else {
-						gl[i].FreeMemory = 0
+						adjusted[i].FreeMemory = 0
 					}
 
-					slog.Debug("available gpu", "id", gl[i].ID, "library", gl[i].Library,
-						"available layer vram", format.HumanBytes2(gl[i].FreeMemory),
-						"backoff", fmt.Sprintf("%.2f", backoff), "minimum", format.HumanBytes2(gl[i].MinimumMemory()),
+					slog.Debug("available gpu", "id", adjusted[i].ID, "library", adjusted[i].Library,
+						"available layer vram", format.HumanBytes2(adjusted[i].FreeMemory),
+						"backoff", fmt.Sprintf("%.2f", backoff), "minimum", format.HumanBytes2(adjusted[i].MinimumMemory()),
 						"overhead", format.HumanBytes2(envconfig.GpuOverhead()),
 						"graph", format.HumanBytes2(memory.GPUs[j].Graph))
 
@@ -986,21 +1014,124 @@ func (s *llmServer) buildLayout(systemGPUs []ml.DeviceInfo, memory *ml.BackendMe
 				}
 			}
 			if !found {
-				// The runner doesn't report seeing this GPU
-				gl[i].FreeMemory = 0
+				adjusted[i].FreeMemory = 0
 			}
 		}
+		return adjusted, lastUsedGPU
+	}
 
-		libraryGpuLayers := assignLayers(layers, gl, requireFull, s.options.NumGPU, lastUsedGPU)
+	// Pass 1: standard assignment with full layer sizes
+	gpuLayers := ml.GPULayersList{}
+	for _, gl := range ml.ByLibrary(gpus) {
+		adjusted, lastUsedGPU := adjustGPUs(gl)
+		libraryGpuLayers := assignLayers(layers, adjusted, requireFull, s.options.NumGPU, lastUsedGPU)
 		if libraryGpuLayers.Sum() > gpuLayers.Sum() {
 			gpuLayers = libraryGpuLayers
 		}
 	}
-	return gpuLayers, layers
+
+	// Pass 2: if not all layers fit and model has expert weights,
+	// use remaining VRAM after pass 1 to fit additional layers at
+	// base-only sizes (expert weights offloaded to CPU).
+	//
+	// We can't run assignLayers independently with base-only sizes
+	// because the pass 1 layers keep their full sizes on GPU. Instead,
+	// compute remaining VRAM per GPU and greedily add base-only layers.
+	var expertOffload []int
+	if gpuLayers.Sum() < len(layers) && hasExperts {
+		// Build set of layers already assigned by pass 1
+		assignedLayers := make(map[int]bool)
+		for _, g := range gpuLayers {
+			for _, l := range g.Layers {
+				assignedLayers[l] = true
+			}
+		}
+
+		// Compute remaining VRAM per GPU after pass 1 assignments
+		type gpuRemaining struct {
+			deviceID  ml.DeviceID
+			remaining uint64
+		}
+		var gpuSpace []gpuRemaining
+		for _, gl := range ml.ByLibrary(gpus) {
+			adjusted, _ := adjustGPUs(gl)
+			for _, g := range adjusted {
+				var used uint64
+				for _, gls := range gpuLayers {
+					if gls.DeviceID == g.DeviceID {
+						for _, l := range gls.Layers {
+							used += layers[l]
+						}
+						break
+					}
+				}
+				if g.FreeMemory > used {
+					gpuSpace = append(gpuSpace, gpuRemaining{
+						deviceID:  g.DeviceID,
+						remaining: g.FreeMemory - used,
+					})
+				}
+			}
+		}
+
+		// Greedily add unassigned layers at base-only size (from end to start,
+		// matching greedyFit's order) using remaining VRAM
+		for i := len(layers) - 1; i >= 0; i-- {
+			if assignedLayers[i] || expertSizes[i] == 0 {
+				continue
+			}
+			baseSize := layers[i] - expertSizes[i]
+			for gi := range gpuSpace {
+				if baseSize <= gpuSpace[gi].remaining {
+					// Add this layer to the GPU's assignment with expert offload
+					found := false
+					for gIdx := range gpuLayers {
+						if gpuLayers[gIdx].DeviceID == gpuSpace[gi].deviceID {
+							gpuLayers[gIdx].Layers = append(gpuLayers[gIdx].Layers, i)
+							found = true
+							break
+						}
+					}
+					if !found {
+						gpuLayers = append(gpuLayers, ml.GPULayers{
+							DeviceID: gpuSpace[gi].deviceID,
+							Layers:   []int{i},
+						})
+					}
+					gpuSpace[gi].remaining -= baseSize
+					expertOffload = append(expertOffload, i)
+					break
+				}
+			}
+		}
+
+		if len(expertOffload) > 0 {
+			slog.Info("moe expert offloading enabled",
+				"layers_with_expert_offload", len(expertOffload),
+				"total_gpu_layers", gpuLayers.Sum(),
+				"without_offload", gpuLayers.Sum()-len(expertOffload))
+		}
+	}
+
+	return gpuLayers, expertOffload, layers
 }
 
 // verifyLayout ensures that we don't exceed limits, such as requirements about partial offloading or system memory
-func (s *llmServer) verifyLayout(systemInfo ml.SystemInfo, systemGPUs []ml.DeviceInfo, memory *ml.BackendMemory, requireFull bool, gpuLayers ml.GPULayersList, layers []uint64) error {
+func (s *llmServer) verifyLayout(systemInfo ml.SystemInfo, systemGPUs []ml.DeviceInfo, memory *ml.BackendMemory, requireFull bool, gpuLayers ml.GPULayersList, expertOffload []int, layers []uint64) error {
+	// Compute per-layer expert sizes for correct accounting
+	expertSizes := make([]uint64, len(layers))
+	for i := range expertSizes {
+		for j := range memory.GPUs {
+			expertSizes[i] += memory.GPUs[j].ExpertWeights[i]
+		}
+		expertSizes[i] += memory.CPU.ExpertWeights[i]
+	}
+
+	expertOffloadSet := make(map[int]bool, len(expertOffload))
+	for _, l := range expertOffload {
+		expertOffloadSet[l] = true
+	}
+
 	// These sizes will only increase as we go through additional iterations and get additional information.
 	cpuSize := memory.InputWeights + memory.CPU.Graph
 	var vramSize uint64
@@ -1018,7 +1149,13 @@ nextLayer:
 		for _, g := range gpuLayers {
 			for _, gl := range g.Layers {
 				if i == gl {
-					vramSize += layers[i]
+					if expertOffloadSet[i] {
+						// Layer is on GPU but expert weights are offloaded to CPU
+						vramSize += layers[i] - expertSizes[i]
+						cpuSize += expertSizes[i]
+					} else {
+						vramSize += layers[i]
+					}
 					continue nextLayer
 				}
 			}
@@ -1865,7 +2002,7 @@ func (s *llmServer) MemorySize() (total, vram uint64) {
 	// on the GPU then include the CPU components as well, to represent complete offloading.
 	noCPULayers := true
 	for i := range s.mem.CPU.Weights {
-		if s.mem.CPU.Weights[i] != 0 || s.mem.CPU.Cache[i] != 0 {
+		if s.mem.CPU.Weights[i] != 0 || s.mem.CPU.ExpertWeights[i] != 0 || s.mem.CPU.Cache[i] != 0 {
 			noCPULayers = false
 			break
 		}

--- a/llm/server_test.go
+++ b/llm/server_test.go
@@ -195,8 +195,9 @@ func TestLLMServerFitGPU(t *testing.T) {
 			}
 
 			s.mem = &ml.BackendMemory{CPU: ml.DeviceMemory{
-				Weights: make([]uint64, s.totalLayers),
-				Cache:   make([]uint64, s.totalLayers),
+				Weights:       make([]uint64, s.totalLayers),
+				ExpertWeights: make([]uint64, s.totalLayers),
+				Cache:         make([]uint64, s.totalLayers),
 			}, GPUs: make([]ml.DeviceMemory, len(tt.gpus))}
 
 			for i := range tt.layers {
@@ -206,10 +207,11 @@ func TestLLMServerFitGPU(t *testing.T) {
 			for i := range s.mem.GPUs {
 				s.mem.GPUs[i].DeviceID = tt.gpus[i].DeviceID
 				s.mem.GPUs[i].Weights = make([]uint64, s.totalLayers)
+				s.mem.GPUs[i].ExpertWeights = make([]uint64, s.totalLayers)
 				s.mem.GPUs[i].Cache = make([]uint64, s.totalLayers)
 			}
 
-			gpuLayers, err := s.createLayout(systemInfo, tt.gpus, s.mem, tt.requireFull, 0)
+			gpuLayers, _, err := s.createLayout(systemInfo, tt.gpus, s.mem, tt.requireFull, 0)
 			if err != tt.expectedErr {
 				t.Fatalf("fitGPU returned error: %v", err)
 			}

--- a/ml/backend.go
+++ b/ml/backend.go
@@ -69,6 +69,12 @@ type BackendParams struct {
 	// GPULayers is the set of layers to offload to GPUs
 	GPULayers GPULayersList
 
+	// ExpertOffload is a set of layer indices whose MOE expert weights
+	// should be placed on CPU even though the layer itself is on GPU.
+	// This enables partial layer offloading where attention/routing stays
+	// on GPU but large expert weights go to CPU to save VRAM.
+	ExpertOffload []int
+
 	// FlashAttention indicates that we should use a fused flash attention kernel
 	FlashAttention FlashAttentionType
 }

--- a/ml/backend/ggml/ggml.go
+++ b/ml/backend/ggml/ggml.go
@@ -175,6 +175,7 @@ func New(modelPath string, params ml.BackendParams) (ml.Backend, error) {
 	requiredMemory.CPU.ID = C.GoString(props.id)
 	requiredMemory.CPU.Library = C.GoString(props.library)
 	requiredMemory.CPU.Weights = make([]uint64, blocks+1)
+	requiredMemory.CPU.ExpertWeights = make([]uint64, blocks+1)
 	requiredMemory.CPU.Cache = make([]uint64, blocks+1)
 
 	// create list of buffer types for each gpu
@@ -194,13 +195,29 @@ func New(modelPath string, params ml.BackendParams) (ml.Backend, error) {
 		requiredMemory.GPUs[i].ID = C.GoString(props.id)
 		requiredMemory.GPUs[i].Library = C.GoString(props.library)
 		requiredMemory.GPUs[i].Weights = make([]uint64, blocks+1)
+		requiredMemory.GPUs[i].ExpertWeights = make([]uint64, blocks+1)
 		requiredMemory.GPUs[i].Cache = make([]uint64, blocks+1)
 	}
 
 	// inputs always use cpu
 	input := cpuDeviceBufferType
 
-	assignLayer := func(layer int) deviceBufferType {
+	isExpertTensor := func(name string) bool {
+		for _, part := range strings.Split(name, ".") {
+			switch part {
+			case "ffn_gate_exps", "ffn_up_exps", "ffn_down_exps":
+				return true
+			}
+		}
+		return false
+	}
+
+	assignLayer := func(layer int, expert bool) deviceBufferType {
+		// Expert tensors on offloaded layers are forced to CPU
+		if expert && slices.Contains(params.ExpertOffload, layer) {
+			return cpuDeviceBufferType
+		}
+
 		for _, p := range params.GPULayers {
 			for _, l := range p.Layers {
 				if l == layer {
@@ -221,11 +238,11 @@ func New(modelPath string, params ml.BackendParams) (ml.Backend, error) {
 	// repeating layers are assigned based on their index in reverse order, e.g. i / (block_count + 1)
 	layers := make([]deviceBufferType, blocks)
 	for i := range layers {
-		layers[i] = assignLayer(i)
+		layers[i] = assignLayer(i, false)
 	}
 
 	// outputs are assigned iff allowed by splits and configured number of gpu layers
-	output := assignLayer(blocks)
+	output := assignLayer(blocks, false)
 
 	maxTensors := len(meta.Tensors().Items())
 	maxTensors += 1
@@ -281,6 +298,8 @@ func New(modelPath string, params ml.BackendParams) (ml.Backend, error) {
 			size := pad(C.ggml_backend_buft_get_alloc_size(bt, tt), C.ggml_backend_buft_get_alignment(bt))
 			if layer == -1 {
 				requiredMemory.InputWeights += uint64(size)
+			} else if isExpertTensor(t.source.Name) {
+				btDeviceMemory[bt].ExpertWeights[layer] += uint64(size)
 			} else {
 				btDeviceMemory[bt].Weights[layer] += uint64(size)
 			}
@@ -334,7 +353,11 @@ func New(modelPath string, params ml.BackendParams) (ml.Backend, error) {
 			}
 
 			if layerIndex >= 0 {
-				createTensor(tensor{source: t}, layers[layerIndex].bts, layerIndex)
+				lt := layers[layerIndex]
+				if isExpertTensor(t.Name) {
+					lt = assignLayer(layerIndex, true)
+				}
+				createTensor(tensor{source: t}, lt.bts, layerIndex)
 			} else {
 				// load all other tensors on the cpu
 				createTensor(tensor{source: t}, input.bts, -1)

--- a/ml/device.go
+++ b/ml/device.go
@@ -150,8 +150,14 @@ type DeviceMemory struct {
 	// may not be persistent across instances of the runner.
 	Name string
 
-	// Weights is the per-layer memory needed for the model weights.
+	// Weights is the per-layer memory needed for the model weights,
+	// excluding expert weights which are tracked separately.
 	Weights []uint64
+
+	// ExpertWeights is the per-layer memory needed for MOE expert
+	// weights (ffn_gate_exps, ffn_up_exps, ffn_down_exps). These are
+	// tracked separately to enable selective offloading to CPU.
+	ExpertWeights []uint64
 
 	// Cache is the per-layer memory needed for the KV cache.
 	Cache []uint64
@@ -172,7 +178,7 @@ func sumMemory(mem []uint64) uint64 {
 
 // Size returns the total size of the memory required by this device
 func (m DeviceMemory) Size() uint64 {
-	return sumMemory(m.Weights) + sumMemory(m.Cache) + m.Graph
+	return sumMemory(m.Weights) + sumMemory(m.ExpertWeights) + sumMemory(m.Cache) + m.Graph
 }
 
 func memoryPresent(mem []uint64) bool {
@@ -183,6 +189,10 @@ func (m DeviceMemory) LogValue() slog.Value {
 	var attrs []slog.Attr
 	if memoryPresent(m.Weights) {
 		attrs = append(attrs, slog.Any("Weights", m.Weights))
+	}
+
+	if memoryPresent(m.ExpertWeights) {
+		attrs = append(attrs, slog.Any("ExpertWeights", m.ExpertWeights))
 	}
 
 	if memoryPresent(m.Cache) {
@@ -240,9 +250,17 @@ func (m BackendMemory) Log(level slog.Level) {
 			slog.Log(context.TODO(), level, "model weights", "device", gpu.Name, "size", format.HumanBytes2(sum))
 			total += sum
 		}
+		if sum := sumMemory(gpu.ExpertWeights); sum > 0 {
+			slog.Log(context.TODO(), level, "expert weights", "device", gpu.Name, "size", format.HumanBytes2(sum))
+			total += sum
+		}
 	}
 	if sum := m.InputWeights + sumMemory(m.CPU.Weights); sum > 0 {
 		slog.Log(context.TODO(), level, "model weights", "device", m.CPU.Name, "size", format.HumanBytes2(sum))
+		total += sum
+	}
+	if sum := sumMemory(m.CPU.ExpertWeights); sum > 0 {
+		slog.Log(context.TODO(), level, "expert weights", "device", m.CPU.Name, "size", format.HumanBytes2(sum))
 		total += sum
 	}
 

--- a/runner/ollamarunner/runner.go
+++ b/runner/ollamarunner/runner.go
@@ -1303,6 +1303,7 @@ func (s *Server) load(w http.ResponseWriter, r *http.Request) {
 			AllocMemory:    req.Operation != llm.LoadOperationFit,
 			NumThreads:     req.NumThreads,
 			GPULayers:      req.GPULayers,
+			ExpertOffload:  req.ExpertOffload,
 			FlashAttention: req.FlashAttention,
 		}
 


### PR DESCRIPTION
## Summary

  Adds automatic partial layer offloading for Mixture-of-Experts models on the new engine. When a MOE model doesn't fully fit in VRAM, expert weights (`ffn_gate_exps`, `ffn_up_exps`, `ffn_down_exps`) can be selectively placed on CPU while the layer's
  attention, norms, and routing tensors remain on GPU.

  This addresses #11772 and the feedback on #12333:
  - Automatic based on available memory — no user configuration
  - Works with the existing multi-GPU layer assignment framework
  - Targets the new engine only (`ml/`, `runner/ollamarunner/`, `llm/`)

  ## How it works

  1. The GGML backend now classifies expert tensors separately, tracking their memory in a new `DeviceMemory.ExpertWeights` field
  2. After the standard layout assigns full layers to GPUs, remaining VRAM is greedily filled with additional layers at base-only size (expert weights on CPU)
  3. `ExpertOffload` layer indices are threaded through `LoadRequest` → `BackendParams` → GGML backend, which routes expert tensors to CPU buffers for those layers

  ## Benchmarks

  Tested with `qwen3:30b-a3b` (Q4_K_M, 19.3 GB) on an RTX 3060 (12 GB VRAM, 24 GB system RAM):

  | Metric | Baseline (main) | MOE offload | Delta |
  |--------|-----------------|-------------|-------|
  | VRAM | 11.84 GB (61.4%) | 11.98 GB (62.2%) | +0.8% |
  | Generate | 29.41 tok/s | 26.64 tok/s | -9.4% |
  | Prefill | 1264.76 tok/s | 646.05 tok/s | -48.9% |

  On this hardware the model already fits ~61% on GPU at full layer size, leaving little remaining VRAM for additional base-only layers. The few extra layers add cross-device transfer overhead that outweighs their benefit.

  The feature should have more impact on systems where VRAM is significantly more constrained relative to model size — e.g., 6-8 GB GPUs running large MOE models where many more layers would benefit from partial offloading. **Looking for feedback from users
  with more constrained setups.**

  ## Test plan

  - [x] Existing `TestLLMServerFitGPU` passes
  - [x] Dense models unaffected (pass 2 skipped when no expert weights detected)
  - [x] MOE model loads and runs correctly with expert offloading active
  - [ ] Testing on more VRAM-constrained hardware (6-8 GB GPU)
  - [ ] Multi-GPU testing
