### PR TITLE
Add token usage for cloud model streaming (inject stream_options.include_usage)

### DIFF
--- a/server/cloud_proxy.go
+++ b/server/cloud_proxy.go
@@ -55,6 +55,11 @@ var hopByHopHeaders = map[string]struct{}{
 	"upgrade":             {},
 }
 
+var openAIStreamUsagePaths = map[string]struct{}{
+	"/v1/chat/completions": {},
+	"/v1/completions":      {},
+}
+
 func init() {
 	baseURL, signingHost, overridden, err := resolveCloudProxyBaseURL(envconfig.Var(cloudProxyBaseURLEnv), mode)
 	if err != nil {
@@ -114,6 +119,13 @@ func cloudPassthroughMiddleware(disabledOperation string) gin.HandlerFunc {
 		}
 
 		normalizedBody, err := replaceJSONModelField(body, modelRef.Base)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			c.Abort()
+			return
+		}
+
+		normalizedBody, err = injectOpenAIStreamUsage(normalizedBody, c.Request.URL.Path)
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			c.Abort()
@@ -286,6 +298,37 @@ func replaceJSONModelField(body []byte, model string) ([]byte, error) {
 	return json.Marshal(payload)
 }
 
+func injectOpenAIStreamUsage(body []byte, path string) ([]byte, error) {
+	if len(body) == 0 {
+		return body, nil
+	}
+	if _, ok := openAIStreamUsagePaths[path]; !ok {
+		return body, nil
+	}
+
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, err
+	}
+
+	rawStream, ok := payload["stream"]
+	if !ok || isJSONNull(rawStream) {
+		return body, nil
+	}
+
+	var stream bool
+	if err := json.Unmarshal(rawStream, &stream); err != nil || !stream {
+		return body, nil
+	}
+
+	if rawOptions, ok := payload["stream_options"]; ok && !isJSONNull(rawOptions) {
+		return body, nil
+	}
+
+	payload["stream_options"] = json.RawMessage(`{"include_usage":true}`)
+	return json.Marshal(payload)
+}
+
 func readRequestBody(r *http.Request) ([]byte, error) {
 	if r.Body == nil {
 		return nil, nil
@@ -298,6 +341,13 @@ func readRequestBody(r *http.Request) ([]byte, error) {
 
 	r.Body = io.NopCloser(bytes.NewReader(body))
 	return body, nil
+}
+
+func isJSONNull(raw json.RawMessage) bool {
+	if len(raw) == 0 {
+		return true
+	}
+	return bytes.Equal(bytes.TrimSpace(raw), []byte("null"))
 }
 
 func extractModelField(body []byte) (string, bool) {

--- a/server/routes_cloud_test.go
+++ b/server/routes_cloud_test.go
@@ -441,6 +441,48 @@ func TestExplicitCloudPassthroughAPIAndV1(t *testing.T) {
 		}
 	})
 
+	t.Run("v1 chat completions streaming injects usage option", func(t *testing.T) {
+		upstream, capture := newUpstream(t, `{"id":"chatcmpl_test","object":"chat.completion"}`)
+		defer upstream.Close()
+
+		original := cloudProxyBaseURL
+		cloudProxyBaseURL = upstream.URL
+		t.Cleanup(func() { cloudProxyBaseURL = original })
+
+		s := &Server{}
+		router, err := s.GenerateRoutes(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		local := httptest.NewServer(router)
+		defer local.Close()
+
+		reqBody := `{"model":"gpt-oss:120b:cloud","messages":[{"role":"user","content":"hi"}],"stream":true}`
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, local.URL+"/v1/chat/completions", bytes.NewBufferString(reqBody))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := local.Client().Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200, got %d (%s)", resp.StatusCode, string(body))
+		}
+
+		if !strings.Contains(capture.body, `"stream":true`) {
+			t.Fatalf("expected stream=true in upstream body, got %q", capture.body)
+		}
+		if !strings.Contains(capture.body, `"stream_options":{"include_usage":true}`) {
+			t.Fatalf("expected stream_options include_usage in upstream body, got %q", capture.body)
+		}
+	})
+
 	t.Run("v1 chat completions bypasses conversion with legacy cloud suffix", func(t *testing.T) {
 		upstream, capture := newUpstream(t, `{"id":"chatcmpl_test","object":"chat.completion"}`)
 		defer upstream.Close()


### PR DESCRIPTION
Inject include_usage stream_options for proxied OpenAI streaming requests when missing. Add a cloud passthrough test to ensure usage options are forwarded for stream=true chat completions.

Summary: 
- Ensure cloud OpenAI-compatible streaming requests include token usage by injecting stream_options.include_usage=true when [stream:true](vscode-file://vscode-app/home/msr/Desktop/VSCode-linux-x64/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and no stream options are provided.
- Files changed: [cloud_proxy.go](vscode-file://vscode-app/home/msr/Desktop/VSCode-linux-x64/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [routes_cloud_test.go](vscode-file://vscode-app/home/msr/Desktop/VSCode-linux-x64/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- Tests: added a proxy test that verifies stream_options.include_usage is forwarded for [stream:true](vscode-file://vscode-app/home/msr/Desktop/VSCode-linux-x64/resources/app/out/vs/code/electron-browser/workbench/workbench.html) chat completions.
- Note: Local full test run can fail in minimal environments due to native linker requirements; server tests pass. CI should run the full suite.

Closes: #15169