### PR TITLE
cmd: show freed disk space after ollama rm

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1039,6 +1039,15 @@ func DeleteHandler(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Collect model sizes before deletion so we can report freed space
+	sizeByName := make(map[string]int64)
+	if list, err := client.List(cmd.Context()); err == nil {
+		for _, m := range list.Models {
+			sizeByName[m.Name] = m.Size
+		}
+	}
+
+	var totalFreed int64
 	for _, arg := range args {
 		// Unload the model if it's running before deletion
 		if err := loadOrUnloadModel(cmd, &runOptions{
@@ -1053,7 +1062,11 @@ func DeleteHandler(cmd *cobra.Command, args []string) error {
 		if err := client.Delete(cmd.Context(), &api.DeleteRequest{Name: arg}); err != nil {
 			return err
 		}
+		totalFreed += sizeByName[model.ParseName(arg).DisplayShortest()]
 		fmt.Printf("deleted '%s'\n", arg)
+	}
+	if totalFreed > 0 {
+		fmt.Printf("freed %s\n", format.HumanBytes(totalFreed))
 	}
 	return nil
 }

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -388,6 +388,59 @@ func TestDeleteHandler(t *testing.T) {
 	}
 }
 
+func TestDeleteHandlerFreedSpace(t *testing.T) {
+	const modelSize = 1_500_000_000 // 1.5 GB
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/tags" && r.Method == http.MethodGet:
+			if err := json.NewEncoder(w).Encode(api.ListResponse{
+				Models: []api.ListModelResponse{
+					{Name: "test-model:latest", Size: modelSize},
+				},
+			}); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+		case r.URL.Path == "/api/delete" && r.Method == http.MethodDelete:
+			w.WriteHeader(http.StatusOK)
+		case r.URL.Path == "/api/generate" && r.Method == http.MethodPost:
+			if err := json.NewEncoder(w).Encode(api.GenerateResponse{Done: true}); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+		}
+	}))
+	defer mockServer.Close()
+
+	t.Setenv("OLLAMA_HOST", mockServer.URL)
+
+	// Capture stdout to check freed message
+	origStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+	deleteErr := DeleteHandler(cmd, []string{"test-model"})
+
+	w.Close()
+	os.Stdout = origStdout
+
+	var buf bytes.Buffer
+	io.Copy(&buf, r) //nolint:errcheck
+	out := buf.String()
+
+	if deleteErr != nil {
+		t.Fatalf("DeleteHandler returned unexpected error: %v", deleteErr)
+	}
+	if !strings.Contains(out, "freed") {
+		t.Errorf("expected output to contain freed size, got: %q", out)
+	}
+}
+
 func TestRunEmbeddingModel(t *testing.T) {
 	reqCh := make(chan api.EmbedRequest, 1)
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Closes #14013

After deleting one or more models, print the total amount of disk space freed. The size is looked up via `/api/tags` before deletion and reported using the same human-readable format already used elsewhere in the CLI.

**Example:**
```
$ ollama rm llama3.2 gemma3:4b
deleted 'llama3.2'
deleted 'gemma3:4b'
freed 3.2 GB
```

If no size information is available (e.g. the server is unreachable before deletion), the freed line is not printed. Names are normalized so `ollama rm llama3.2` correctly matches the `llama3.2:latest` entry in the list.