### PR TITLE
logutil: support JSON log output via OLLAMA_LOG_FORMAT

### DIFF
--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -216,6 +216,8 @@ var (
 	FlashAttention = BoolWithDefault("OLLAMA_FLASH_ATTENTION")
 	// DebugLogRequests logs inference requests to disk for replay/debugging.
 	DebugLogRequests = Bool("OLLAMA_DEBUG_LOG_REQUESTS")
+	// LogFormat sets the log output format. Supported values: "json", "text" (default).
+	LogFormat = String("OLLAMA_LOG_FORMAT")
 	// KvCacheType is the quantization type for the K/V cache.
 	KvCacheType = String("OLLAMA_KV_CACHE_TYPE")
 	// NoHistory disables readline history.
@@ -306,6 +308,7 @@ func AsMap() map[string]EnvVar {
 	ret := map[string]EnvVar{
 		"OLLAMA_DEBUG":              {"OLLAMA_DEBUG", LogLevel(), "Show additional debug information (e.g. OLLAMA_DEBUG=1)"},
 		"OLLAMA_DEBUG_LOG_REQUESTS": {"OLLAMA_DEBUG_LOG_REQUESTS", DebugLogRequests(), "Log inference request bodies and replay curl commands to a temp directory"},
+		"OLLAMA_LOG_FORMAT":         {"OLLAMA_LOG_FORMAT", LogFormat(), "Log output format: text (default) or json"},
 		"OLLAMA_FLASH_ATTENTION":    {"OLLAMA_FLASH_ATTENTION", FlashAttention(false), "Enabled flash attention"},
 		"OLLAMA_KV_CACHE_TYPE":      {"OLLAMA_KV_CACHE_TYPE", KvCacheType(), "Quantization type for the K/V cache (default: f16)"},
 		"OLLAMA_GPU_OVERHEAD":       {"OLLAMA_GPU_OVERHEAD", GpuOverhead(), "Reserve a portion of VRAM per GPU (bytes)"},

--- a/logutil/logutil.go
+++ b/logutil/logutil.go
@@ -4,15 +4,17 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 )
 
 const LevelTrace slog.Level = -8
 
 func NewLogger(w io.Writer, level slog.Level) *slog.Logger {
-	return slog.New(slog.NewTextHandler(w, &slog.HandlerOptions{
+	opts := &slog.HandlerOptions{
 		Level:     level,
 		AddSource: true,
 		ReplaceAttr: func(_ []string, attr slog.Attr) slog.Attr {
@@ -28,7 +30,14 @@ func NewLogger(w io.Writer, level slog.Level) *slog.Logger {
 			}
 			return attr
 		},
-	}))
+	}
+	var handler slog.Handler
+	if strings.EqualFold(os.Getenv("OLLAMA_LOG_FORMAT"), "json") {
+		handler = slog.NewJSONHandler(w, opts)
+	} else {
+		handler = slog.NewTextHandler(w, opts)
+	}
+	return slog.New(handler)
 }
 
 type key string

--- a/logutil/logutil_test.go
+++ b/logutil/logutil_test.go
@@ -1,0 +1,61 @@
+package logutil
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestNewLoggerDefaultIsText(t *testing.T) {
+	t.Setenv("OLLAMA_LOG_FORMAT", "")
+	var buf bytes.Buffer
+	logger := NewLogger(&buf, slog.LevelInfo)
+	logger.Info("hello")
+	out := buf.String()
+	if strings.Contains(out, `"msg"`) {
+		t.Errorf("expected text format but got JSON-like output: %s", out)
+	}
+	if !strings.Contains(out, "hello") {
+		t.Errorf("expected message in output: %s", out)
+	}
+}
+
+func TestNewLoggerJSONFormat(t *testing.T) {
+	t.Setenv("OLLAMA_LOG_FORMAT", "json")
+	var buf bytes.Buffer
+	logger := NewLogger(&buf, slog.LevelInfo)
+	logger.Info("hello")
+	out := buf.String()
+	if !strings.Contains(out, `"msg"`) {
+		t.Errorf("expected JSON format but got: %s", out)
+	}
+	if !strings.Contains(out, "hello") {
+		t.Errorf("expected message in output: %s", out)
+	}
+}
+
+func TestNewLoggerJSONFormatCaseInsensitive(t *testing.T) {
+	for _, val := range []string{"JSON", "Json", "jSoN"} {
+		t.Run(val, func(t *testing.T) {
+			t.Setenv("OLLAMA_LOG_FORMAT", val)
+			var buf bytes.Buffer
+			logger := NewLogger(&buf, slog.LevelInfo)
+			logger.Info("test")
+			if !strings.Contains(buf.String(), `"msg"`) {
+				t.Errorf("OLLAMA_LOG_FORMAT=%q: expected JSON output, got: %s", val, buf.String())
+			}
+		})
+	}
+}
+
+func TestNewLoggerUnknownFormatFallsBackToText(t *testing.T) {
+	t.Setenv("OLLAMA_LOG_FORMAT", "yaml")
+	var buf bytes.Buffer
+	logger := NewLogger(&buf, slog.LevelInfo)
+	logger.Info("hello")
+	out := buf.String()
+	if strings.Contains(out, `"msg"`) {
+		t.Errorf("unknown format should fall back to text, got: %s", out)
+	}
+}


### PR DESCRIPTION
Closes #14018

Add support for structured JSON log output by setting:

```
OLLAMA_LOG_FORMAT=json
```

The default text format is unchanged. The value is case-insensitive (`JSON`, `json`, `Json` all work). Any unrecognised value falls back to text.

The env var is read directly via `os.Getenv` in `logutil` to avoid a circular import with `envconfig`. A `LogFormat` var is also added to `envconfig` so the variable appears in `ollama serve` env var listings.