### PR TITLE
scripts: fix installer exiting early when nvidia-smi is found

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -287,7 +287,7 @@ check_gpu() {
                 nvidia) available lshw && $SUDO lshw -c display -numeric -disable network | grep -q 'vendor: .* \[10DE\]' || return 1 ;;
                 amdgpu) available lshw && $SUDO lshw -c display -numeric -disable network | grep -q 'vendor: .* \[1002\]' || return 1 ;;
             esac ;;
-        nvidia-smi) available nvidia-smi || return 1 ;;
+        nvidia-smi) nvidia-smi > /dev/null 2>&1 || return 1 ;;
     esac
 }
 


### PR DESCRIPTION
## Summary

Fixes the Linux install script exiting immediately after detecting `nvidia-smi`, which prevents AMD ROCm installation.

## Problem

The install script calls `exit 0` right after finding `nvidia-smi`:

```bash
if check_gpu nvidia-smi; then
    status "NVIDIA GPU installed."
    exit 0  # exits before checking for AMD GPUs
fi
```

This breaks two scenarios:
1. **Mixed GPU systems** — NVIDIA + AMD GPUs present, but ROCm is never installed for the AMD GPU
2. **Orphaned nvidia-smi** — `nvidia-smi` left over from a previous driver install (no actual NVIDIA hardware), causing the script to skip all GPU detection

## Fix

Instead of exiting, set a `HAS_CUDA` flag and continue to the AMD GPU detection:

1. If `nvidia-smi` is found, set `HAS_CUDA=true` and continue
2. AMD GPU detection proceeds normally — ROCm is downloaded if AMD hardware is found
3. After AMD is handled, if `HAS_CUDA` was true, skip redundant CUDA driver installation and exit
4. The misleading "No NVIDIA/AMD GPU detected" warning is suppressed when `nvidia-smi` is present

Fixes #15184
