### PR TITLE
api: add audios field for audio input in multimodal models

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -97,6 +97,10 @@ type GenerateRequest struct {
 	// request, for multimodal models.
 	Images []ImageData `json:"images,omitempty"`
 
+	// Audios is an optional list of raw audio bytes (WAV format) accompanying
+	// this request, for multimodal models that support audio input.
+	Audios []ImageData `json:"audios,omitempty"`
+
 	// Options lists model-specific options. For example, temperature can be
 	// set through this field, if the model supports it.
 	Options map[string]any `json:"options"`
@@ -207,7 +211,7 @@ func (t Tool) String() string {
 
 // Message is a single message in a chat sequence. The message contains the
 // role ("system", "user", or "assistant"), the content and an optional list
-// of images.
+// of images or audio.
 type Message struct {
 	Role    string `json:"role"`
 	Content string `json:"content"`
@@ -215,6 +219,7 @@ type Message struct {
 	// original model output when ChatRequest.Think is enabled.
 	Thinking   string      `json:"thinking,omitempty"`
 	Images     []ImageData `json:"images,omitempty"`
+	Audios     []ImageData `json:"audios,omitempty"`
 	ToolCalls  []ToolCall  `json:"tool_calls,omitempty"`
 	ToolName   string      `json:"tool_name,omitempty"`
 	ToolCallID string      `json:"tool_call_id,omitempty"`

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1435,6 +1435,7 @@ type runOptions struct {
 	Format       string
 	System       string
 	Images       []api.ImageData
+	Audios       []api.ImageData
 	Options      map[string]any
 	MultiModal   bool
 	KeepAlive    *api.Duration
@@ -1454,6 +1455,12 @@ func (r runOptions) Copy() runOptions {
 	if r.Images != nil {
 		images = make([]api.ImageData, len(r.Images))
 		copy(images, r.Images)
+	}
+
+	var audios []api.ImageData
+	if r.Audios != nil {
+		audios = make([]api.ImageData, len(r.Audios))
+		copy(audios, r.Audios)
 	}
 
 	var opts map[string]any
@@ -1479,6 +1486,7 @@ func (r runOptions) Copy() runOptions {
 		Format:       r.Format,
 		System:       r.System,
 		Images:       images,
+		Audios:       audios,
 		Options:      opts,
 		MultiModal:   r.MultiModal,
 		KeepAlive:    r.KeepAlive,
@@ -1769,7 +1777,7 @@ func generate(cmd *cobra.Command, opts runOptions) error {
 	}
 
 	if opts.MultiModal {
-		opts.Prompt, opts.Images, err = extractFileData(opts.Prompt)
+		opts.Prompt, opts.Images, opts.Audios, err = extractFileData(opts.Prompt)
 		if err != nil {
 			return err
 		}
@@ -1784,6 +1792,7 @@ func generate(cmd *cobra.Command, opts runOptions) error {
 		Prompt:    opts.Prompt,
 		Context:   generateContext,
 		Images:    opts.Images,
+		Audios:    opts.Audios,
 		Format:    json.RawMessage(opts.Format),
 		System:    opts.System,
 		Options:   opts.Options,

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1821,6 +1821,7 @@ func TestRunOptions_Copy_EmptySlicesAndMaps(t *testing.T) {
 	original := runOptions{
 		Messages: []api.Message{},
 		Images:   []api.ImageData{},
+		Audios:   []api.ImageData{},
 		Options:  map[string]any{},
 	}
 
@@ -1834,6 +1835,10 @@ func TestRunOptions_Copy_EmptySlicesAndMaps(t *testing.T) {
 		t.Error("Empty Images slice should remain empty, not nil")
 	}
 
+	if copied.Audios == nil {
+		t.Error("Empty Audios slice should remain empty, not nil")
+	}
+
 	if copied.Options == nil {
 		t.Error("Empty Options map should remain empty, not nil")
 	}
@@ -1844,6 +1849,10 @@ func TestRunOptions_Copy_EmptySlicesAndMaps(t *testing.T) {
 
 	if len(copied.Images) != 0 {
 		t.Error("Empty Images slice should remain empty")
+	}
+
+	if len(copied.Audios) != 0 {
+		t.Error("Empty Audios slice should remain empty")
 	}
 
 	if len(copied.Options) != 0 {

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -503,13 +503,14 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 			newMessage := api.Message{Role: "user", Content: sb.String()}
 
 			if opts.MultiModal {
-				msg, images, err := extractFileData(sb.String())
+				msg, images, audios, err := extractFileData(sb.String())
 				if err != nil {
 					return err
 				}
 
 				newMessage.Content = msg
 				newMessage.Images = images
+				newMessage.Audios = audios
 			}
 
 			opts.Messages = append(opts.Messages, newMessage)
@@ -598,9 +599,10 @@ func extractFileNames(input string) []string {
 	return re.FindAllString(input, -1)
 }
 
-func extractFileData(input string) (string, []api.ImageData, error) {
+func extractFileData(input string) (string, []api.ImageData, []api.ImageData, error) {
 	filePaths := extractFileNames(input)
 	var imgs []api.ImageData
+	var audios []api.ImageData
 
 	for _, fp := range filePaths {
 		nfp := normalizeFilePath(fp)
@@ -609,21 +611,22 @@ func extractFileData(input string) (string, []api.ImageData, error) {
 			continue
 		} else if err != nil {
 			fmt.Fprintf(os.Stderr, "Couldn't process file: %q\n", err)
-			return "", imgs, err
+			return "", imgs, audios, err
 		}
 		ext := strings.ToLower(filepath.Ext(nfp))
 		switch ext {
 		case ".wav":
 			fmt.Fprintf(os.Stderr, "Added audio '%s'\n", nfp)
+			audios = append(audios, data)
 		default:
 			fmt.Fprintf(os.Stderr, "Added image '%s'\n", nfp)
+			imgs = append(imgs, data)
 		}
 		input = strings.ReplaceAll(input, "'"+nfp+"'", "")
 		input = strings.ReplaceAll(input, "'"+fp+"'", "")
 		input = strings.ReplaceAll(input, fp, "")
-		imgs = append(imgs, data)
 	}
-	return strings.TrimSpace(input), imgs, nil
+	return strings.TrimSpace(input), imgs, audios, nil
 }
 
 func editInExternalEditor(content string) (string, error) {

--- a/cmd/interactive_test.go
+++ b/cmd/interactive_test.go
@@ -79,9 +79,10 @@ func TestExtractFileDataRemovesQuotedFilepath(t *testing.T) {
 	}
 
 	input := "before '" + fp + "' after"
-	cleaned, imgs, err := extractFileData(input)
+	cleaned, imgs, audios, err := extractFileData(input)
 	assert.NoError(t, err)
 	assert.Len(t, imgs, 1)
+	assert.Len(t, audios, 0)
 	assert.Equal(t, cleaned, "before  after")
 }
 
@@ -109,8 +110,9 @@ func TestExtractFileDataWAV(t *testing.T) {
 	}
 
 	input := "before " + fp + " after"
-	cleaned, imgs, err := extractFileData(input)
+	cleaned, imgs, audios, err := extractFileData(input)
 	assert.NoError(t, err)
-	assert.Len(t, imgs, 1)
+	assert.Len(t, imgs, 0)
+	assert.Len(t, audios, 1)
 	assert.Equal(t, "before  after", cleaned)
 }

--- a/integration/audio_test.go
+++ b/integration/audio_test.go
@@ -68,7 +68,7 @@ func TestAudioTranscription(t *testing.T) {
 					{
 						Role:    "user",
 						Content: "Transcribe this audio.",
-						Images:  []api.ImageData{audio},
+						Audios:  []api.ImageData{audio},
 					},
 				},
 				Stream: &stream,
@@ -105,7 +105,7 @@ func TestAudioResponse(t *testing.T) {
 					{
 						Role:    "user",
 						Content: "",
-						Images:  []api.ImageData{audio},
+						Audios:  []api.ImageData{audio},
 					},
 				},
 				Stream: &stream,

--- a/model/renderers/gemma4.go
+++ b/model/renderers/gemma4.go
@@ -113,12 +113,13 @@ func stripThinking(text string) string {
 	return strings.TrimSpace(result.String())
 }
 
-// renderContent writes a message's content, interleaving [img-N] tags for images.
+// renderContent writes a message's content, interleaving [img-N] tags for multimodal data.
 // When trim is true, leading/trailing whitespace is stripped (matching the Jinja2
 // template's | trim filter applied to non-model content).
 func (r *Gemma4Renderer) renderContent(sb *strings.Builder, msg api.Message, imageOffset *int, trim bool) {
-	if len(msg.Images) > 0 && r.useImgTags {
-		for range msg.Images {
+	multimodalCount := len(msg.Images) + len(msg.Audios)
+	if multimodalCount > 0 && r.useImgTags {
+		for range multimodalCount {
 			sb.WriteString(fmt.Sprintf("[img-%d]", *imageOffset))
 			*imageOffset++
 		}

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -527,6 +527,9 @@ func FromChatRequest(r ChatCompletionRequest) (*api.ChatRequest, error) {
 					if !ok {
 						return nil, errors.New("invalid input_audio format")
 					}
+					if format, ok := audioMap["format"].(string); ok && format != "wav" {
+						return nil, fmt.Errorf("unsupported audio format %q: only \"wav\" is supported", format)
+					}
 					b64Data, ok := audioMap["data"].(string)
 					if !ok {
 						return nil, errors.New("invalid input_audio format: missing data")
@@ -535,7 +538,7 @@ func FromChatRequest(r ChatCompletionRequest) (*api.ChatRequest, error) {
 					if err != nil {
 						return nil, fmt.Errorf("invalid input_audio base64 data: %w", err)
 					}
-					messages = append(messages, api.Message{Role: msg.Role, Images: []api.ImageData{audioBytes}})
+					messages = append(messages, api.Message{Role: msg.Role, Audios: []api.ImageData{audioBytes}})
 				default:
 					return nil, errors.New("invalid message format")
 				}
@@ -868,7 +871,7 @@ func FromTranscriptionRequest(r TranscriptionRequest) (*api.ChatRequest, error) 
 		Model: r.Model,
 		Messages: []api.Message{
 			{Role: "system", Content: systemPrompt},
-			{Role: "user", Content: "Transcribe this audio.", Images: []api.ImageData{r.AudioData}},
+			{Role: "user", Content: "Transcribe this audio.", Audios: []api.ImageData{r.AudioData}},
 		},
 		Stream: &stream,
 		Options: map[string]any{

--- a/openai/openai_test.go
+++ b/openai/openai_test.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"encoding/base64"
+	"strings"
 	"testing"
 	"time"
 
@@ -94,6 +95,206 @@ func TestFromChatRequest_WithImage(t *testing.T) {
 	if string(result.Messages[1].Images[0]) != string(imgData) {
 		t.Error("image data mismatch")
 	}
+}
+
+func TestFromChatRequest_WithAudio(t *testing.T) {
+	validB64 := base64.StdEncoding.EncodeToString([]byte("fake-wav-data"))
+
+	t.Run("valid wav audio", func(t *testing.T) {
+		req := ChatCompletionRequest{
+			Model: "test-model",
+			Messages: []Message{
+				{
+					Role: "user",
+					Content: []any{
+						map[string]any{"type": "text", "text": "Transcribe this"},
+						map[string]any{
+							"type":        "input_audio",
+							"input_audio": map[string]any{"data": validB64, "format": "wav"},
+						},
+					},
+				},
+			},
+		}
+
+		result, err := FromChatRequest(req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// text + audio become separate messages
+		if len(result.Messages) != 2 {
+			t.Fatalf("expected 2 messages, got %d", len(result.Messages))
+		}
+
+		if result.Messages[0].Content != "Transcribe this" {
+			t.Errorf("expected text content, got %q", result.Messages[0].Content)
+		}
+
+		if len(result.Messages[1].Audios) != 1 {
+			t.Fatalf("expected 1 audio, got %d", len(result.Messages[1].Audios))
+		}
+
+		if len(result.Messages[1].Audios[0]) == 0 {
+			t.Error("expected non-empty audio data")
+		}
+	})
+
+	t.Run("non-wav format rejected", func(t *testing.T) {
+		req := ChatCompletionRequest{
+			Model: "test-model",
+			Messages: []Message{
+				{
+					Role: "user",
+					Content: []any{
+						map[string]any{
+							"type":        "input_audio",
+							"input_audio": map[string]any{"data": validB64, "format": "mp3"},
+						},
+					},
+				},
+			},
+		}
+
+		_, err := FromChatRequest(req)
+		if err == nil {
+			t.Fatal("expected error for non-wav format, got nil")
+		}
+
+		if !strings.Contains(err.Error(), "unsupported audio format") {
+			t.Errorf("expected unsupported audio format error, got: %v", err)
+		}
+	})
+
+	t.Run("missing data field", func(t *testing.T) {
+		req := ChatCompletionRequest{
+			Model: "test-model",
+			Messages: []Message{
+				{
+					Role: "user",
+					Content: []any{
+						map[string]any{
+							"type":        "input_audio",
+							"input_audio": map[string]any{"format": "wav"},
+						},
+					},
+				},
+			},
+		}
+
+		_, err := FromChatRequest(req)
+		if err == nil {
+			t.Fatal("expected error for missing data, got nil")
+		}
+
+		if !strings.Contains(err.Error(), "missing data") {
+			t.Errorf("expected missing data error, got: %v", err)
+		}
+	})
+
+	t.Run("non-string data field", func(t *testing.T) {
+		req := ChatCompletionRequest{
+			Model: "test-model",
+			Messages: []Message{
+				{
+					Role: "user",
+					Content: []any{
+						map[string]any{
+							"type":        "input_audio",
+							"input_audio": map[string]any{"data": 12345, "format": "wav"},
+						},
+					},
+				},
+			},
+		}
+
+		_, err := FromChatRequest(req)
+		if err == nil {
+			t.Fatal("expected error for non-string data, got nil")
+		}
+
+		if !strings.Contains(err.Error(), "missing data") {
+			t.Errorf("expected missing data error, got: %v", err)
+		}
+	})
+
+	t.Run("invalid base64 data", func(t *testing.T) {
+		req := ChatCompletionRequest{
+			Model: "test-model",
+			Messages: []Message{
+				{
+					Role: "user",
+					Content: []any{
+						map[string]any{
+							"type":        "input_audio",
+							"input_audio": map[string]any{"data": "not-valid-base64!!!", "format": "wav"},
+						},
+					},
+				},
+			},
+		}
+
+		_, err := FromChatRequest(req)
+		if err == nil {
+			t.Fatal("expected error for invalid base64, got nil")
+		}
+
+		if !strings.Contains(err.Error(), "invalid input_audio base64 data") {
+			t.Errorf("expected base64 error, got: %v", err)
+		}
+	})
+
+	t.Run("missing format field still accepted", func(t *testing.T) {
+		req := ChatCompletionRequest{
+			Model: "test-model",
+			Messages: []Message{
+				{
+					Role: "user",
+					Content: []any{
+						map[string]any{
+							"type":        "input_audio",
+							"input_audio": map[string]any{"data": validB64},
+						},
+					},
+				},
+			},
+		}
+
+		result, err := FromChatRequest(req)
+		if err != nil {
+			t.Fatalf("expected no error when format is omitted, got: %v", err)
+		}
+
+		if len(result.Messages) != 1 {
+			t.Fatalf("expected 1 message, got %d", len(result.Messages))
+		}
+
+		if len(result.Messages[0].Audios) != 1 {
+			t.Fatalf("expected 1 audio, got %d", len(result.Messages[0].Audios))
+		}
+	})
+
+	t.Run("invalid input_audio map", func(t *testing.T) {
+		req := ChatCompletionRequest{
+			Model: "test-model",
+			Messages: []Message{
+				{
+					Role: "user",
+					Content: []any{
+						map[string]any{
+							"type":        "input_audio",
+							"input_audio": "not-a-map",
+						},
+					},
+				},
+			},
+		}
+
+		_, err := FromChatRequest(req)
+		if err == nil {
+			t.Fatal("expected error for invalid input_audio map, got nil")
+		}
+	})
 }
 
 func TestFromCompleteRequest_Basic(t *testing.T) {

--- a/server/prompt.go
+++ b/server/prompt.go
@@ -54,7 +54,7 @@ func chatPrompt(ctx context.Context, m *Model, tokenize tokenizeFunc, opts *api.
 			ctxLen := len(s)
 			if m.ProjectorPaths != nil {
 				for _, msg := range msgs[i:] {
-					ctxLen += imageNumTokens * len(msg.Images)
+					ctxLen += imageNumTokens * (len(msg.Images) + len(msg.Audios))
 				}
 			}
 
@@ -76,14 +76,20 @@ func chatPrompt(ctx context.Context, m *Model, tokenize tokenizeFunc, opts *api.
 	}
 
 	for cnt, msg := range msgs[currMsgIdx:] {
-		if slices.Contains(m.Config.ModelFamilies, "mllama") && len(msg.Images) > 1 {
+		// Merge audios into images so models receive all multimodal data
+		// through the same pipeline. Models detect audio by WAV magic bytes.
+		allMultimodal := make([]api.ImageData, 0, len(msg.Images)+len(msg.Audios))
+		allMultimodal = append(allMultimodal, msg.Images...)
+		allMultimodal = append(allMultimodal, msg.Audios...)
+
+		if slices.Contains(m.Config.ModelFamilies, "mllama") && len(allMultimodal) > 1 {
 			return "", nil, errors.New("this model only supports one image while more than one image requested")
 		}
 
 		var prefix string
 		prompt := msg.Content
 
-		for _, i := range msg.Images {
+		for _, i := range allMultimodal {
 			imgData := llm.ImageData{
 				ID:   len(images),
 				Data: i,

--- a/server/prompt_test.go
+++ b/server/prompt_test.go
@@ -218,6 +218,32 @@ func TestChatPrompt(t *testing.T) {
 			},
 		},
 		{
+			name:     "message with audios",
+			model:    visionModel,
+			limit:    2048,
+			truncate: true,
+			msgs: []api.Message{
+				{Role: "user", Content: "Transcribe this audio", Audios: []api.ImageData{[]byte("audio-data")}},
+			},
+			expect: expect{
+				prompt: "[img-0]Transcribe this audio ",
+				images: [][]byte{[]byte("audio-data")},
+			},
+		},
+		{
+			name:     "message with images and audios merged",
+			model:    visionModel,
+			limit:    2048,
+			truncate: true,
+			msgs: []api.Message{
+				{Role: "user", Content: "Describe both", Images: []api.ImageData{[]byte("image-data")}, Audios: []api.ImageData{[]byte("audio-data")}},
+			},
+			expect: expect{
+				prompt: "[img-0][img-1]Describe both ",
+				images: [][]byte{[]byte("image-data"), []byte("audio-data")},
+			},
+		},
+		{
 			name:     "no truncate with limit exceeded",
 			model:    visionModel,
 			limit:    10,

--- a/server/routes.go
+++ b/server/routes.go
@@ -416,8 +416,8 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 
 	checkpointLoaded := time.Now()
 
-	// load the model
-	if req.Prompt == "" {
+	// load the model (only if there's no prompt AND no multimodal data)
+	if req.Prompt == "" && len(req.Images) == 0 && len(req.Audios) == 0 {
 		c.JSON(http.StatusOK, api.GenerateResponse{
 			Model:      req.Model,
 			CreatedAt:  time.Now().UTC(),
@@ -427,14 +427,20 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 		return
 	}
 
-	if slices.Contains(m.Config.ModelFamilies, "mllama") && len(req.Images) > 1 {
+	// Merge audios into images so models receive all multimodal data
+	// through the same pipeline. Models detect audio by WAV magic bytes.
+	allMultimodal := make([]api.ImageData, 0, len(req.Images)+len(req.Audios))
+	allMultimodal = append(allMultimodal, req.Images...)
+	allMultimodal = append(allMultimodal, req.Audios...)
+
+	if slices.Contains(m.Config.ModelFamilies, "mllama") && len(allMultimodal) > 1 {
 		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "this model only supports one image while more than one image requested"})
 		return
 	}
 
-	images := make([]llm.ImageData, len(req.Images))
-	for i := range req.Images {
-		images[i] = llm.ImageData{ID: i, Data: req.Images[i]}
+	images := make([]llm.ImageData, len(allMultimodal))
+	for i := range allMultimodal {
+		images[i] = llm.ImageData{ID: i, Data: allMultimodal[i]}
 	}
 
 	prompt := req.Prompt

--- a/server/routes_debug_test.go
+++ b/server/routes_debug_test.go
@@ -347,6 +347,41 @@ func TestChatDebugRenderOnly(t *testing.T) {
 			expectNumImages: 1,
 		},
 		{
+			name: "chat debug with audios",
+			request: api.ChatRequest{
+				Model: "test-model",
+				Messages: []api.Message{
+					{
+						Role:    "user",
+						Content: "Transcribe this audio",
+						Audios:  []api.ImageData{[]byte("fake-audio-data")},
+					},
+				},
+				DebugRenderOnly: true,
+			},
+			expectDebug:     true,
+			expectTemplate:  "user: [img-0]Transcribe this audio\n",
+			expectNumImages: 1,
+		},
+		{
+			name: "chat debug with images and audios",
+			request: api.ChatRequest{
+				Model: "test-model",
+				Messages: []api.Message{
+					{
+						Role:    "user",
+						Content: "Describe both",
+						Images:  []api.ImageData{[]byte("fake-image-data")},
+						Audios:  []api.ImageData{[]byte("fake-audio-data")},
+					},
+				},
+				DebugRenderOnly: true,
+			},
+			expectDebug:     true,
+			expectTemplate:  "user: [img-0][img-1]Describe both\n",
+			expectNumImages: 2,
+		},
+		{
 			name: "chat debug with tools",
 			request: api.ChatRequest{
 				Model: "test-model",

--- a/server/routes_generate_test.go
+++ b/server/routes_generate_test.go
@@ -2354,6 +2354,163 @@ func TestGenerateWithImages(t *testing.T) {
 	})
 }
 
+func TestGenerateWithAudios(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	mock := mockRunner{
+		CompletionResponse: llm.CompletionResponse{
+			Done:               true,
+			DoneReason:         llm.DoneReasonStop,
+			PromptEvalCount:    1,
+			PromptEvalDuration: 1,
+			EvalCount:          1,
+			EvalDuration:       1,
+		},
+	}
+
+	s := Server{
+		sched: &Scheduler{
+			pendingReqCh:    make(chan *LlmRequest, 1),
+			finishedReqCh:   make(chan *LlmRequest, 1),
+			expiredCh:       make(chan *runnerRef, 1),
+			unloadedCh:      make(chan any, 1),
+			loaded:          make(map[string]*runnerRef),
+			newServerFn:     newMockServer(&mock),
+			getGpuFn:        getGpuFn,
+			getSystemInfoFn: getSystemInfoFn,
+			waitForRecovery: 250 * time.Millisecond,
+			loadFn: func(req *LlmRequest, _ ml.SystemInfo, _ []ml.DeviceInfo, _ bool) bool {
+				time.Sleep(time.Millisecond)
+				req.successCh <- &runnerRef{
+					llama: &mock,
+				}
+				return false
+			},
+		},
+	}
+
+	go s.sched.Run(t.Context())
+
+	_, digest := createBinFile(t, ggml.KV{
+		"general.architecture":          "llama",
+		"llama.block_count":             uint32(1),
+		"llama.context_length":          uint32(8192),
+		"llama.embedding_length":        uint32(4096),
+		"llama.attention.head_count":    uint32(32),
+		"llama.attention.head_count_kv": uint32(8),
+		"tokenizer.ggml.tokens":         []string{""},
+		"tokenizer.ggml.scores":         []float32{0},
+		"tokenizer.ggml.token_type":     []int32{0},
+	}, []*ggml.Tensor{
+		{Name: "token_embd.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.attn_norm.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.ffn_down.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.ffn_gate.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.ffn_up.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.ffn_norm.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.attn_k.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.attn_output.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.attn_q.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.attn_v.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "output.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+	})
+
+	w := createRequest(t, s.CreateHandler, api.CreateRequest{
+		Model:  "test",
+		Files:  map[string]string{"file.gguf": digest},
+		Stream: &stream,
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	t.Run("audios passed to completion request", func(t *testing.T) {
+		testAudio := []byte("test-audio-data")
+
+		mock.CompletionResponse.Content = "Audio processed"
+		w := createRequest(t, s.GenerateHandler, api.GenerateRequest{
+			Model:  "test",
+			Prompt: "Describe this audio",
+			Audios: []api.ImageData{testAudio},
+			Stream: &stream,
+		})
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+		}
+
+		if len(mock.CompletionRequest.Images) != 1 {
+			t.Fatalf("expected 1 entry in completion request images, got %d", len(mock.CompletionRequest.Images))
+		}
+
+		if !bytes.Equal(mock.CompletionRequest.Images[0].Data, testAudio) {
+			t.Errorf("audio data mismatch in completion request")
+		}
+	})
+
+	t.Run("audio-only generate is not treated as load-only", func(t *testing.T) {
+		testAudio := []byte("test-audio-data")
+
+		mock.CompletionResponse.Content = "Audio transcribed"
+		w := createRequest(t, s.GenerateHandler, api.GenerateRequest{
+			Model:  "test",
+			Prompt: "",
+			Audios: []api.ImageData{testAudio},
+			Stream: &stream,
+		})
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+		}
+
+		// Must NOT be a load-only response
+		var resp api.GenerateResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+
+		if resp.DoneReason == "load" {
+			t.Errorf("audio-only request was treated as load-only; expected inference")
+		}
+	})
+
+	t.Run("mixed images and audios passed to completion request", func(t *testing.T) {
+		testImage := []byte("test-image-data")
+		testAudio := []byte("test-audio-data")
+
+		mock.CompletionResponse.Content = "Mixed processed"
+		w := createRequest(t, s.GenerateHandler, api.GenerateRequest{
+			Model:  "test",
+			Prompt: "Describe both",
+			Images: []api.ImageData{testImage},
+			Audios: []api.ImageData{testAudio},
+			Stream: &stream,
+		})
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+		}
+
+		if len(mock.CompletionRequest.Images) != 2 {
+			t.Fatalf("expected 2 entries in completion request images, got %d", len(mock.CompletionRequest.Images))
+		}
+
+		if !bytes.Equal(mock.CompletionRequest.Images[0].Data, testImage) {
+			t.Errorf("first entry should be image data")
+		}
+
+		if !bytes.Equal(mock.CompletionRequest.Images[1].Data, testAudio) {
+			t.Errorf("second entry should be audio data")
+		}
+
+		if mock.CompletionRequest.Images[0].ID != 0 || mock.CompletionRequest.Images[1].ID != 1 {
+			t.Errorf("expected IDs 0 and 1, got %d and %d",
+				mock.CompletionRequest.Images[0].ID, mock.CompletionRequest.Images[1].ID)
+		}
+	})
+}
+
 // TestImageGenerateStreamFalse tests that image generation respects stream=false
 // and returns a single JSON response instead of streaming ndjson.
 func TestImageGenerateStreamFalse(t *testing.T) {

--- a/template/template.go
+++ b/template/template.go
@@ -494,11 +494,16 @@ func convertMessagesForTemplate(messages []*api.Message) []*templateMessage {
 				},
 			})
 		}
+		// Merge images and audios for template rendering so templates
+		// that iterate over Images see all multimodal data.
+		allImages := make([]api.ImageData, 0, len(msg.Images)+len(msg.Audios))
+		allImages = append(allImages, msg.Images...)
+		allImages = append(allImages, msg.Audios...)
 		result[i] = &templateMessage{
 			Role:       msg.Role,
 			Content:    msg.Content,
 			Thinking:   msg.Thinking,
-			Images:     msg.Images,
+			Images:     allImages,
 			ToolCalls:  toolCalls,
 			ToolName:   msg.ToolName,
 			ToolCallID: msg.ToolCallID,


### PR DESCRIPTION
Add a dedicated Audios field to Message and GenerateRequest so that API consumers can send audio data without stuffing it into the Images field. Audio bytes are merged into the existing multimodal pipeline at the server layer since models already detect WAV format by magic bytes.

Changes:
- Add Audios []ImageData to GenerateRequest and Message structs
- Merge audios into the images pipeline in prompt.go and routes.go
- Update Gemma4 renderer and template rendering to count audios
- Route OpenAI input_audio content to the new Audios field
- Validate input_audio format and reject non-WAV with a clear error
- Fix audio-only generate being treated as a load-only request
- Separate WAV files from images in CLI extractFileData
- Add server, OpenAI, prompt, and debug-render tests for audio

Backward compatible: the images field continues to accept audio data.

Fixes #11798