### PR TITLE
Remove duplicated BOS token from functiongemma

### DIFF
--- a/model/renderers/functiongemma.go
+++ b/model/renderers/functiongemma.go
@@ -15,8 +15,6 @@ const defaultSystemMessage = "You can do function calling with the following fun
 func (r *FunctionGemmaRenderer) Render(messages []api.Message, tools []api.Tool, thinkValue *api.ThinkValue) (string, error) {
 	var sb strings.Builder
 
-	sb.WriteString("<bos>")
-
 	var systemMessage string
 	var loopMessages []api.Message
 	if len(messages) > 0 && (messages[0].Role == "system" || messages[0].Role == "developer") {


### PR DESCRIPTION
If Im not mistaken, only the gemma4 started using `add_bos_token=false` in their tokenizer config.

```
time=2026-04-03T02:30:26.020Z level=WARN source=vocabulary.go:49 msg="adding bos token to prompt which already has it" id=[2]
time=2026-04-03T02:30:26.020Z level=DEBUG source=vocabulary.go:52 msg="adding bos token to prompt" id=2
```