### PR TITLE
ggml: add -ffast-math to HIP build for CUDA parity

### DIFF
--- a/ml/backend/ggml/ggml/src/ggml-hip/CMakeLists.txt
+++ b/ml/backend/ggml/ggml/src/ggml-hip/CMakeLists.txt
@@ -52,6 +52,10 @@ message(STATUS "HIP and hipBLAS found")
 # Workaround old compilers
 set(CMAKE_HIP_FLAGS "${CMAKE_HIP_FLAGS} --gpu-max-threads-per-block=1024")
 
+# Fast math for HIP - equivalent to CUDA's -use_fast_math
+# Enables FMA, flush denormals to zero, fast approximations for math functions
+set(CMAKE_HIP_FLAGS "${CMAKE_HIP_FLAGS} -ffast-math")
+
 file(GLOB   GGML_HEADERS_ROCM "../ggml-cuda/*.cuh")
 list(APPEND GGML_HEADERS_ROCM "../../include/ggml-cuda.h")
 


### PR DESCRIPTION
## Summary

CUDA builds use `-use_fast_math` (set in `ggml-cuda/CMakeLists.txt`) but HIP builds do not have the equivalent flag. This adds `-ffast-math` to `CMAKE_HIP_FLAGS` in `ggml-hip/CMakeLists.txt`, enabling:

- Fused multiply-add (FMA) instructions
- Flush denormals to zero
- Fast approximations for math functions (exp, log, sin, cos, etc.)

This brings HIP/ROCm builds to parity with what CUDA already does.

## Benchmarks

Tested on **AMD RX 7900 XTX** (gfx1100, RDNA3) with ROCm 6.4, using `qwen2.5-coder:14b` (Q4_K_M):

| Benchmark | Baseline (gen t/s) | With -ffast-math (gen t/s) | Change |
|---|---|---|---|
| code-gen | 60.81 | 64.20 | **+5.6%** |
| short-explanation | 61.01 | 63.44 | **+4.0%** |
| list-generation | 61.59 | 63.68 | **+3.4%** |

Prompt evaluation throughput was unchanged.

## Change

One line added to `ml/backend/ggml/ggml/src/ggml-hip/CMakeLists.txt`:

```cmake
set(CMAKE_HIP_FLAGS "${CMAKE_HIP_FLAGS} -ffast-math")
```

## Testing

- Built and ran on ROCm 6.4, gfx1100
- No correctness issues observed across multiple models and prompt types
- Output quality is unchanged (fast math approximations are well within acceptable tolerance for inference)