### PR TITLE
app/ui: fix model picker showing stale model after switching chats

### DIFF
--- a/app/ui/app/src/hooks/useChats.ts
+++ b/app/ui/app/src/hooks/useChats.ts
@@ -381,7 +381,7 @@ export const useSendMessage = (chatId: string) => {
                     role: "assistant",
                     content: "",
                     thinking: "",
-                    model: effectiveModel,
+                    model: effectiveModel.model,
                   }),
                 );
                 lastMessage = newMessages[newMessages.length - 1];
@@ -433,7 +433,7 @@ export const useSendMessage = (chatId: string) => {
                     role: "assistant",
                     content: "",
                     thinking: "",
-                    model: effectiveModel,
+                    model: effectiveModel.model,
                   }),
                 );
                 lastMessage = newMessages[newMessages.length - 1];
@@ -699,7 +699,7 @@ export const useSendMessage = (chatId: string) => {
             queryClient.setQueryData(["chat", newId], {
               chat: new Chat({
                 id: newId,
-                model: effectiveModel,
+                model: effectiveModel.model,
                 messages: [
                   new Message({
                     role: "user",

--- a/app/ui/app/src/hooks/useChats.ts
+++ b/app/ui/app/src/hooks/useChats.ts
@@ -520,7 +520,7 @@ export const useSendMessage = (chatId: string) => {
                     thinkingTimeStart:
                       lastMessage.thinkingTimeStart || event.thinkingTimeStart,
                     thinkingTimeEnd: event.thinkingTimeEnd,
-                    model: selectedModel,
+                    model: selectedModel.model,
                   });
                   newMessages[newMessages.length - 1] = updatedMessage;
                 } else {
@@ -533,7 +533,7 @@ export const useSendMessage = (chatId: string) => {
                       tool_calls: event.toolCalls,
                       thinkingTimeStart: event.thinkingTimeStart,
                       thinkingTimeEnd: event.thinkingTimeEnd,
-                      model: selectedModel,
+                      model: selectedModel.model,
                     }),
                   );
                 }


### PR DESCRIPTION
When switching between chats that use different models, the model picker can get stuck showing the previous chat's model. This happens specifically after streaming: optimistic messages created by the streaming batcher store a `Model` object in the `model` field instead of a string. When the restore effect in `useSelectedModel` reads these cached messages to determine the chat's model, the object/string mismatch causes the comparison and settings update to fail silently.

The fix passes `effectiveModel.model` (the name string) instead of `effectiveModel` (the full object) when constructing optimistic `Message` instances during streaming.

To reproduce:
1. Start a chat with model A (e.g. llama3) and send a message
2. While the response is streaming (or after), switch to a different chat using model B
3. Switch back to the first chat — the model picker stays on model B

Fixes #14504