### PR TITLE
app/ui: fix lint errors for unused vars, prefer-const, and empty catch

### DIFF
--- a/app/ui/app/src/components/Message.tsx
+++ b/app/ui/app/src/components/Message.tsx
@@ -536,7 +536,7 @@ function ToolCallDisplay({
     let args: Record<string, unknown> | null = null;
     try {
       args = JSON.parse(toolCall.function.arguments) as Record<string, unknown>;
-    } catch (e) {
+    } catch {
       args = null;
     }
     const query = args && typeof args.query === "string" ? args.query : "";
@@ -562,7 +562,7 @@ function ToolCallDisplay({
     let args: Record<string, unknown> | null = null;
     try {
       args = JSON.parse(toolCall.function.arguments) as Record<string, unknown>;
-    } catch (e) {
+    } catch {
       args = null;
     }
     const url = args && typeof args.url === "string" ? args.url : "";

--- a/app/ui/app/src/components/MessageList.tsx
+++ b/app/ui/app/src/components/MessageList.tsx
@@ -73,7 +73,7 @@ export default function MessageList({
                     ? String(args.url).trim()
                     : "";
               if (candidate) lastQuery = candidate;
-            } catch {}
+            } catch { /* ignored */ }
           }
         }
       }

--- a/app/ui/app/src/components/ui/badge.tsx
+++ b/app/ui/app/src/components/ui/badge.tsx
@@ -65,7 +65,7 @@ export const BadgeButton = forwardRef(function BadgeButton(
     ),
   ref: React.ForwardedRef<HTMLElement>,
 ) {
-  let classes = clsx(
+  const classes = clsx(
     className,
     "group relative inline-flex rounded-md focus:not-data-focus:outline-hidden data-focus:outline-2 data-focus:outline-offset-2 data-focus:outline-blue-500",
   );

--- a/app/ui/app/src/components/ui/button.tsx
+++ b/app/ui/app/src/components/ui/button.tsx
@@ -171,7 +171,7 @@ export const Button = forwardRef(function Button(
   { color, outline, plain, className, children, ...props }: ButtonProps,
   ref: React.ForwardedRef<HTMLElement>,
 ) {
-  let classes = clsx(
+  const classes = clsx(
     className,
     styles.base,
     outline


### PR DESCRIPTION
The frontend codebase currently has 117 ESLint errors. Most are no-explicit-any in auto-generated code, but 5 are simple lint issues that can be fixed without changing behavior:

- 2x `no-unused-vars`: catch parameter `e` declared but never used in `Message.tsx` JSON parsing blocks
- 1x `no-empty`: empty catch block in `MessageList.tsx` tool query parsing
- 2x `prefer-const`: `classes` variable declared with `let` but never reassigned in `badge.tsx` and `button.tsx`

This reduces the total ESLint error count from 117 to 112, making it easier to spot real issues in future changes.

Changes:
- `Message.tsx`: remove unused `e` parameter in two catch blocks
- `MessageList.tsx`: add comment to empty catch block
- `ui/badge.tsx`: use const for non-reassigned `classes` variable
- `ui/button.tsx`: use const for non-reassigned `classes` variable