### PR TITLE
gemma4: enable flash attention

### DIFF
--- a/fs/ggml/ggml.go
+++ b/fs/ggml/ggml.go
@@ -890,6 +890,7 @@ func (f GGML) FlashAttention() bool {
 	return slices.Contains([]string{
 		"bert",
 		"gemma3",
+		"gemma4",
 		"glm4moelite",
 		"glmocr",
 		"gptoss", "gpt-oss",


### PR DESCRIPTION
~~This patches additional code paths in the GGML CUDA backend for the memory prediction flow.~~

~~Fixes #15249~~

Enable flash attention for gemma4