### PR TITLE
Revert "enable flash attention for gemma4 (#15296)"

### DIFF
--- a/fs/ggml/ggml.go
+++ b/fs/ggml/ggml.go
@@ -890,7 +890,6 @@ func (f GGML) FlashAttention() bool {
 	return slices.Contains([]string{
 		"bert",
 		"gemma3",
-		"gemma4",
 		"glm4moelite",
 		"glmocr",
 		"gptoss", "gpt-oss",


### PR DESCRIPTION
This reverts commit c8e0878814b4d19200d65571d3d2d35b4b48fd3e.

Fixes a performance regression - Perf run comparison:
```
                                    │ /tmp/0.20.0.log │       /tmp/0.20.1-flash.log        │     /tmp/0.20.1-no-flash.log      │
                                    │    token/sec    │  token/sec   vs base               │  token/sec   vs base              │
Model/name=gemma4:e2b/step=prefill        3.035k ± 1%   1.227k ± 2%  -59.57% (p=0.002 n=6)   3.040k ± 1%       ~ (p=0.310 n=6)
Model/name=gemma4:e2b/step=generate       144.92 ± 3%    95.09 ± 6%  -34.39% (p=0.002 n=6)   146.20 ± 2%  +0.89% (p=0.026 n=6)
Model/name=gemma4:e4b/step=prefill        1508.1 ± 5%    827.4 ± 3%  -45.14% (p=0.002 n=6)   1533.3 ± 2%       ~ (p=0.180 n=6)
Model/name=gemma4:e4b/step=generate        93.55 ± 1%    66.75 ± 5%  -28.64% (p=0.002 n=6)    94.75 ± 2%  +1.29% (p=0.026 n=6)
Model/name=gemma4:26b/step=prefill        1497.5 ± 1%    689.7 ± 1%  -53.95% (p=0.002 n=6)   1556.9 ± 1%  +3.97% (p=0.002 n=6)
Model/name=gemma4:26b/step=generate        86.95 ± 3%    70.63 ± 4%  -18.77% (p=0.002 n=6)    88.78 ± 1%  +2.09% (p=0.009 n=6)
geomean                                    447.9         260.7       -41.80%                  455.4       +1.67%
```