### PR TITLE
fix: respect absent thinking field in Anthropic compat endpoint

### DIFF
--- a/anthropic/anthropic.go
+++ b/anthropic/anthropic.go
@@ -375,6 +375,13 @@ func FromMessagesRequest(r MessagesRequest) (*api.ChatRequest, error) {
 	var think *api.ThinkValue
 	if r.Thinking != nil && r.Thinking.Type == "enabled" {
 		think = &api.ThinkValue{Value: true}
+	} else {
+		// Explicitly disable thinking when the Anthropic request omits the
+		// thinking field or sets it to disabled. Without this, the downstream
+		// route handler auto-enables thinking for capable models when Think
+		// is nil, which violates the Anthropic API spec where omitting the
+		// field means thinking is disabled.
+		think = &api.ThinkValue{Value: false}
 	}
 
 	stream := r.Stream

--- a/anthropic/anthropic_test.go
+++ b/anthropic/anthropic_test.go
@@ -399,6 +399,49 @@ func TestFromMessagesRequest_WithThinking(t *testing.T) {
 	}
 }
 
+func TestFromMessagesRequest_ThinkingAbsent(t *testing.T) {
+	req := MessagesRequest{
+		Model:     "test-model",
+		MaxTokens: 1024,
+		Messages:  []MessageParam{{Role: "user", Content: textContent("Hello")}},
+		// Thinking field is not set (nil) — per Anthropic API spec, this means
+		// thinking should be disabled.
+	}
+
+	result, err := FromMessagesRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Think == nil {
+		t.Fatal("expected Think to be explicitly set to false, got nil")
+	}
+	if v, ok := result.Think.Value.(bool); !ok || v {
+		t.Errorf("expected Think.Value to be false when thinking is absent, got %v", result.Think.Value)
+	}
+}
+
+func TestFromMessagesRequest_ThinkingDisabled(t *testing.T) {
+	req := MessagesRequest{
+		Model:     "test-model",
+		MaxTokens: 1024,
+		Messages:  []MessageParam{{Role: "user", Content: textContent("Hello")}},
+		Thinking:  &ThinkingConfig{Type: "disabled"},
+	}
+
+	result, err := FromMessagesRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Think == nil {
+		t.Fatal("expected Think to be explicitly set to false, got nil")
+	}
+	if v, ok := result.Think.Value.(bool); !ok || v {
+		t.Errorf("expected Think.Value to be false when thinking is disabled, got %v", result.Think.Value)
+	}
+}
+
 func TestFromMessagesRequest_ThinkingOnlyBlock(t *testing.T) {
 	req := MessagesRequest{
 		Model:     "test-model",


### PR DESCRIPTION
## Summary

- Fixes the Anthropic-compatible `/v1/messages` endpoint unconditionally enabling thinking for capable models (e.g. `qwen3.5`) even when the `thinking` field is absent from the request
- Explicitly sets `Think` to `false` in `FromMessagesRequest` when the Anthropic request omits the `thinking` field or sets it to `"disabled"`

## Motivation

Per the [Anthropic API spec](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking), omitting the `thinking` field means thinking is **disabled**. The native Ollama endpoint correctly respects `think: false`, but the Anthropic compat layer left `Think` as `nil`, which caused the route handler to auto-enable thinking for capable models.

This affected anyone using Ollama as an Anthropic API drop-in replacement (e.g. via `misanthropic`, Claude Code, or other Anthropic SDKs).

## Changes

- **`anthropic/anthropic.go`**: Added `else` branch in `FromMessagesRequest` to explicitly set `Think = false` when thinking is not enabled
- **`anthropic/anthropic_test.go`**: Added two new tests:
  - `TestFromMessagesRequest_ThinkingAbsent` — verifies `Think` is `false` when `thinking` field is omitted
  - `TestFromMessagesRequest_ThinkingDisabled` — verifies `Think` is `false` when `thinking.type` is `"disabled"`

## Reproduction

```bash
# Before fix — thinking enabled despite missing thinking field
curl http://localhost:11434/v1/messages \
  -H "Content-Type: application/json" \
  -H "x-api-key: dummy" \
  -d '{"model": "qwen3.5:9b", "max_tokens": 200, "messages": [{"role": "user", "content": "What is 2+2? One word."}]}'
# Returns: {"content": [{"type": "thinking", "thinking": "..."}]}

# After fix — thinking correctly disabled
# Returns: {"content": [{"type": "text", "text": "Four"}]}
```

## Testing

- New unit tests cover both the absent and explicitly-disabled cases
- Existing `TestFromMessagesRequest_WithThinking` test continues to pass (thinking enabled when requested)
- `TestAnthropicMessagesMiddleware_SetsRelaxThinkingFlag` unaffected (tests middleware flag, not conversion)

Fixes #15287