### PR TITLE
app/darwin/Ollama.app/Contents/Library/LaunchAgents: allow configuring ollama's start behavior

### DIFF
--- a/app/darwin/Ollama.app/Contents/Library/LaunchAgents/com.ollama.ollama.plist
+++ b/app/darwin/Ollama.app/Contents/Library/LaunchAgents/com.ollama.ollama.plist
@@ -12,7 +12,7 @@
         <string>background</string>
     </array>
     <key>RunAtLoad</key>
-    <true/>
+    <false/>
     <key>LimitLoadToSessionType</key>
 	<string>Aqua</string>
 	<key>POSIXSpawnType</key>


### PR DESCRIPTION
In the current version, Ollama automatically launches with Mac startup after the background activity is enabled in system settings, which is a little annoying. Could you please add the changes in the attached com.ollama.ollama.plist screenshot file to the official Ollama Mac Release? I changed "RunAtLoad" to "false" in the plist file, which allows users to configure Ollama's background activity and startup on macOS separately.
![524307105-c8a61802-465d-4593-8fe5-eeb416524a94](https://github.com/user-attachments/assets/9c734108-d76c-45c2-ba04-81f6d7eb642a)
![524310608-c15c86fb-24fb-4eb0-b999-5cc3d33f5d32](https://github.com/user-attachments/assets/76c2c190-e5c6-42f8-ade8-13af07304799)
