### PR TITLE
server: fix thinking not enabled by default for /api/generate

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -374,19 +374,6 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 		return
 	}
 
-	var builtinParser parsers.Parser
-	if shouldUseHarmony(m) && m.Config.Parser == "" {
-		m.Config.Parser = "harmony"
-	}
-
-	if !req.Raw && m.Config.Parser != "" {
-		builtinParser = parsers.ParserForName(m.Config.Parser)
-		if builtinParser != nil {
-			// no tools or last message for generate endpoint
-			builtinParser.Init(nil, nil, req.Think)
-		}
-	}
-
 	caps := []model.Capability{model.CapabilityCompletion}
 	if req.Suffix != "" {
 		caps = append(caps, model.CapabilityInsert)
@@ -402,6 +389,19 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 		if req.Think != nil && req.Think.Bool() {
 			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("%q does not support thinking", req.Model)})
 			return
+		}
+	}
+
+	var builtinParser parsers.Parser
+	if shouldUseHarmony(m) && m.Config.Parser == "" {
+		m.Config.Parser = "harmony"
+	}
+
+	if !req.Raw && m.Config.Parser != "" {
+		builtinParser = parsers.ParserForName(m.Config.Parser)
+		if builtinParser != nil {
+			// no tools or last message for generate endpoint
+			builtinParser.Init(nil, nil, req.Think)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fixes #15268

The `/api/generate` endpoint was not enabling thinking by default for models with thinking capability (e.g., gemma4), while `/api/chat` worked correctly.

**Root cause:** `builtinParser.Init(nil, nil, req.Think)` was called *before* `req.Think` was defaulted to `true` for thinking-capable models. This meant the parser was always initialized with `req.Think = nil` unless the user explicitly passed `think: true`.

**Fix:** Reorder the parser initialization block to come *after* the thinking capability check, matching the ordering already used in the `/api/chat` endpoint.

## Test plan

- [x] Existing tests pass (`TestGenerate`, `TestGenerateChat`, `TestChatWithPromptEndingInThinkTag`, `TestGenerateWithBuiltinRenderer`)
- Verify with a thinking-capable model (e.g., gemma4):
  - `POST /api/generate` without `think` param → should include thinking output
  - `POST /api/generate` with `think: false` → should not include thinking output
  - `POST /api/generate` with `think: true` → should include thinking output (unchanged behavior)