### PR TITLE
docs: clarify transfer package interruption semantics

### DIFF
--- a/x/transfer/transfer.go
+++ b/x/transfer/transfer.go
@@ -22,9 +22,12 @@
 //   - Stall and speed detection (downloads): cancels on no data (stall) or
 //     speed below 10% of median.
 //
-// For large models (multi-GB), use the server's download/upload code which
-// has resumable downloads with JSON state files, async hashing from OS page
-// cache, and per-part speed tracking with rolling median.
+// This means interruption behavior here differs from the standard downloader in
+// server/download.go. For large models (multi-GB), use the server's
+// download/upload code which has resumable downloads with JSON state files,
+// async hashing from OS page cache, and per-part speed tracking with rolling
+// median. This transfer path intentionally prefers simpler whole-blob retries
+// for many-small-blob workloads.
 package transfer
 
 import (


### PR DESCRIPTION
This clarifies the package-level comment in `x/imagegen/transfer/transfer.go` to make the interruption semantics more explicit for contributors.

In particular, it now calls out that this transfer path intentionally prefers whole-blob retries for many-small-blob workloads, and that its behavior differs from `server/download.go`, which supports resumable part-based downloads.

This is a small contributor-facing clarification tied to the current discussion around interrupted pull behavior.