### PR TITLE
server: add phase-specific timeouts for cloud proxy

### DIFF
--- a/server/cloud_proxy.go
+++ b/server/cloud_proxy.go
@@ -40,6 +40,18 @@ var (
 	cloudProxySigningHost = defaultCloudProxySigningHost
 	cloudProxySignRequest = signCloudProxyRequest
 	cloudProxySigninURL   = signinURL
+
+	// cloudProxyHTTPClient uses phase-specific timeouts: tight bounds for
+	// connection, TLS, and time-to-first-byte, but no overall timeout so
+	// long-lived streaming responses are not killed mid-stream.
+	cloudProxyHTTPClient = &http.Client{
+		Transport: &http.Transport{
+			DialContext:           (&net.Dialer{Timeout: 10 * time.Second}).DialContext,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ResponseHeaderTimeout: 30 * time.Second,
+			IdleConnTimeout:       90 * time.Second,
+		},
+	}
 )
 
 var hopByHopHeaders = map[string]struct{}{
@@ -213,10 +225,7 @@ func proxyCloudRequestWithPath(c *gin.Context, body []byte, path string, disable
 		return
 	}
 
-	// TODO(drifkin): Add phase-specific proxy timeouts.
-	// Connect/TLS/TTFB should have bounded timeouts, but once streaming starts
-	// we should not enforce a short total timeout for long-lived responses.
-	resp, err := http.DefaultClient.Do(outReq)
+	resp, err := cloudProxyHTTPClient.Do(outReq)
 	if err != nil {
 		c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
 		return


### PR DESCRIPTION
## Summary
- Replaced `http.DefaultClient` with a dedicated `cloudProxyHTTPClient` that has phase-specific timeouts
- Connect and TLS handshake: 10s each (fail fast on unreachable servers)
- Response header (time-to-first-byte): 30s (detect unresponsive backends)
- No overall `Client.Timeout`, so long-lived streaming responses are never killed mid-stream
- Idle connection timeout: 90s (clean up stale keep-alive connections)

Resolves the TODO at `server/cloud_proxy.go:216` (added by @drifkin)

## Context
The cloud proxy previously used `http.DefaultClient`, which has no timeouts at all. This meant:
- Hung connections could block indefinitely during connect/TLS/TTFB
- Setting a single `Client.Timeout` would risk killing long-running streaming inference responses

The fix uses Go's `http.Transport` fields to set per-phase timeouts while leaving the overall request duration unbounded.

## Test plan
- [x] Existing `TestCopyProxyRequestHeaders` and `TestCopyProxyResponseHeaders` still pass (verified locally — build failures are pre-existing macOS-only mlx/imagegen issues unrelated to this change)
- [ ] Manual test: cloud model requests should connect within 10s or fail fast
- [ ] Manual test: long streaming responses should complete without timeout
- [ ] Manual test: requests to unreachable servers should fail after ~10s instead of hanging
