### PR TITLE
anthropic: set Think to false when thinking type is disabled

### DIFF
--- a/anthropic/anthropic.go
+++ b/anthropic/anthropic.go
@@ -375,6 +375,8 @@ func FromMessagesRequest(r MessagesRequest) (*api.ChatRequest, error) {
 	var think *api.ThinkValue
 	if r.Thinking != nil && r.Thinking.Type == "enabled" {
 		think = &api.ThinkValue{Value: true}
+	} else if r.Thinking != nil && r.Thinking.Type == "disabled" {
+		think = &api.ThinkValue{Value: false}
 	}
 
 	stream := r.Stream

--- a/anthropic/anthropic_test.go
+++ b/anthropic/anthropic_test.go
@@ -399,6 +399,27 @@ func TestFromMessagesRequest_WithThinking(t *testing.T) {
 	}
 }
 
+func TestFromMessagesRequest_WithThinkingDisabled(t *testing.T) {
+	req := MessagesRequest{
+		Model:     "test-model",
+		MaxTokens: 1024,
+		Messages:  []MessageParam{{Role: "user", Content: textContent("Hello")}},
+		Thinking:  &ThinkingConfig{Type: "disabled"},
+	}
+
+	result, err := FromMessagesRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Think == nil {
+		t.Fatal("expected Think to be set")
+	}
+	if v, ok := result.Think.Value.(bool); !ok || v {
+		t.Errorf("expected Think.Value to be false, got %v", result.Think.Value)
+	}
+}
+
 func TestFromMessagesRequest_ThinkingOnlyBlock(t *testing.T) {
 	req := MessagesRequest{
 		Model:     "test-model",


### PR DESCRIPTION
## Summary
- When an Anthropic API request includes `"thinking": {"type": "disabled"}`, the adapter now explicitly sets `Think` to `&ThinkValue{Value: false}` instead of leaving it as `nil`
- This distinguishes between "not set" (nil) and "explicitly disabled" (false), ensuring the user's intent to disable thinking is properly forwarded to the Ollama API
- Added test case for the disabled thinking path

## Test plan
- [x] Existing `TestFromMessagesRequest_WithThinking` still passes
- [x] New `TestFromMessagesRequest_WithThinkingDisabled` passes
- [ ] Manual: send Anthropic-compatible request with `"thinking": {"type": "disabled"}` and verify `Think` is explicitly `false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)