### PR TITLE
auth, logutil: add unit tests

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -1,0 +1,289 @@
+package auth
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+)
+
+func TestNewNonce(t *testing.T) {
+	t.Run("generates nonce of specified length", func(t *testing.T) {
+		tests := []struct {
+			length   int
+			expected int
+		}{
+			{16, 22},
+			{32, 43},
+			{64, 86},
+		}
+
+		for _, tt := range tests {
+			nonce, err := NewNonce(rand.Reader, tt.length)
+			if err != nil {
+				t.Fatalf("NewNonce(%d) returned error: %v", tt.length, err)
+			}
+			if len(nonce) != tt.expected {
+				t.Errorf("NewNonce(%d) = %q, want length %d", tt.length, nonce, tt.expected)
+			}
+
+			decoded, err := base64.RawURLEncoding.DecodeString(nonce)
+			if err != nil {
+				t.Fatalf("Failed to decode nonce: %v", err)
+			}
+			if len(decoded) != tt.length {
+				t.Errorf("Decoded nonce length = %d, want %d", len(decoded), tt.length)
+			}
+		}
+	})
+
+	t.Run("generates unique nonces", func(t *testing.T) {
+		nonces := make(map[string]bool)
+		for i := 0; i < 100; i++ {
+			nonce, err := NewNonce(rand.Reader, 32)
+			if err != nil {
+				t.Fatalf("NewNonce returned error: %v", err)
+			}
+			if nonces[nonce] {
+				t.Error("Generated duplicate nonce")
+			}
+			nonces[nonce] = true
+		}
+	})
+
+	t.Run("propagates reader errors", func(t *testing.T) {
+		errReader := &errorReader{err: errors.New("read error")}
+		_, err := NewNonce(errReader, 16)
+		if err == nil {
+			t.Error("NewNonce with error reader should return error")
+		}
+		if !strings.Contains(err.Error(), "read error") {
+			t.Errorf("NewNonce error = %v, want to contain 'read error'", err)
+		}
+	})
+}
+
+type errorReader struct {
+	err error
+}
+
+func (e *errorReader) Read(p []byte) (n int, err error) {
+	return 0, e.err
+}
+
+func setupHomeDir(t *testing.T) string {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+
+	homeKey := "HOME"
+	if _, homeExists := os.LookupEnv("HOME"); !homeExists {
+		if _, userProfileExists := os.LookupEnv("USERPROFILE"); userProfileExists {
+			homeKey = "USERPROFILE"
+		}
+	}
+
+	origHome := os.Getenv(homeKey)
+	t.Cleanup(func() {
+		if origHome == "" {
+			os.Unsetenv(homeKey)
+		} else {
+			os.Setenv(homeKey, origHome)
+		}
+	})
+
+	os.Setenv(homeKey, tmpDir)
+	return tmpDir
+}
+
+func writeSSHEd25519PrivateKey(t *testing.T, path string) ed25519.PrivateKey {
+	t.Helper()
+
+	_, privKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("Failed to generate key: %v", err)
+	}
+
+	pemBlock, err := ssh.MarshalPrivateKey(privKey, "")
+	if err != nil {
+		t.Fatalf("Failed to marshal private key: %v", err)
+	}
+
+	privKeyPEM := pem.EncodeToMemory(pemBlock)
+	if err := os.WriteFile(path, privKeyPEM, 0o600); err != nil {
+		t.Fatalf("Failed to write private key: %v", err)
+	}
+
+	return privKey
+}
+
+func TestGetPublicKey(t *testing.T) {
+	t.Run("returns error when key file does not exist", func(t *testing.T) {
+		setupHomeDir(t)
+
+		_, err := GetPublicKey()
+		if err == nil {
+			t.Error("GetPublicKey with missing key should return error")
+		}
+	})
+
+	t.Run("returns valid public key from private key", func(t *testing.T) {
+		tmpDir := setupHomeDir(t)
+
+		ollamaDir := filepath.Join(tmpDir, ".ollama")
+		if err := os.MkdirAll(ollamaDir, 0o755); err != nil {
+			t.Fatalf("Failed to create .ollama dir: %v", err)
+		}
+
+		privKeyFile := filepath.Join(ollamaDir, "id_ed25519")
+		_ = writeSSHEd25519PrivateKey(t, privKeyFile)
+
+		pubKey, err := GetPublicKey()
+		if err != nil {
+			t.Fatalf("GetPublicKey returned error: %v", err)
+		}
+
+		if pubKey == "" {
+			t.Error("GetPublicKey returned empty string")
+		}
+
+		if !strings.HasPrefix(pubKey, "ssh-ed25519") {
+			t.Errorf("GetPublicKey = %q, want to start with 'ssh-ed25519'", pubKey)
+		}
+	})
+}
+
+func TestSign(t *testing.T) {
+	t.Run("returns error when key file does not exist", func(t *testing.T) {
+		setupHomeDir(t)
+
+		_, err := Sign(nil, []byte("test"))
+		if err == nil {
+			t.Error("Sign with missing key should return error")
+		}
+	})
+
+	t.Run("signs data and returns valid signature format", func(t *testing.T) {
+		tmpDir := setupHomeDir(t)
+
+		ollamaDir := filepath.Join(tmpDir, ".ollama")
+		if err := os.MkdirAll(ollamaDir, 0o755); err != nil {
+			t.Fatalf("Failed to create .ollama dir: %v", err)
+		}
+
+		privKeyFile := filepath.Join(ollamaDir, "id_ed25519")
+		privKey := writeSSHEd25519PrivateKey(t, privKeyFile)
+
+		signer, err := ssh.NewSignerFromSigner(privKey)
+		if err != nil {
+			t.Fatalf("Failed to create signer: %v", err)
+		}
+		sshPubKey := string(ssh.MarshalAuthorizedKey(signer.PublicKey()))
+		sshPubKey = strings.TrimSpace(sshPubKey)
+		sshPubKeyParts := strings.Split(sshPubKey, " ")
+		if len(sshPubKeyParts) < 2 {
+			t.Fatalf("Unexpected SSH public key format: %q", sshPubKey)
+		}
+		expectedPubKey := sshPubKeyParts[1]
+
+		data := []byte("test message to sign")
+		signature, err := Sign(nil, data)
+		if err != nil {
+			t.Fatalf("Sign returned error: %v", err)
+		}
+
+		parts := strings.SplitN(signature, ":", 2)
+		if len(parts) != 2 {
+			t.Fatalf("Sign returned %q, want 'pubkey:signature' format", signature)
+		}
+
+		if parts[0] != expectedPubKey {
+			t.Errorf("Public key in signature = %q, want %q", parts[0], expectedPubKey)
+		}
+
+		sigBytes, err := base64.StdEncoding.DecodeString(parts[1])
+		if err != nil {
+			t.Fatalf("Failed to decode signature: %v", err)
+		}
+
+		pubKey, ok := signer.PublicKey().(ssh.CryptoPublicKey)
+		if !ok {
+			t.Fatalf("Failed to get crypto public key")
+		}
+		cryptoPubKey := pubKey.CryptoPublicKey()
+		ed25519PubKey, ok := cryptoPubKey.(ed25519.PublicKey)
+		if !ok {
+			t.Fatalf("Failed to get ed25519 public key")
+		}
+
+		if !ed25519.Verify(ed25519PubKey, data, sigBytes) {
+			t.Error("Signature verification failed")
+		}
+	})
+
+	t.Run("generates unique signatures for different data", func(t *testing.T) {
+		tmpDir := setupHomeDir(t)
+
+		ollamaDir := filepath.Join(tmpDir, ".ollama")
+		if err := os.MkdirAll(ollamaDir, 0o755); err != nil {
+			t.Fatalf("Failed to create .ollama dir: %v", err)
+		}
+
+		privKeyFile := filepath.Join(ollamaDir, "id_ed25519")
+		writeSSHEd25519PrivateKey(t, privKeyFile)
+
+		sig1, err := Sign(nil, []byte("message1"))
+		if err != nil {
+			t.Fatalf("Sign message1 error: %v", err)
+		}
+
+		sig2, err := Sign(nil, []byte("message2"))
+		if err != nil {
+			t.Fatalf("Sign message2 error: %v", err)
+		}
+
+		if sig1 == sig2 {
+			t.Error("Signatures for different messages should differ")
+		}
+	})
+}
+
+func TestSignPublicKeyFormat(t *testing.T) {
+	tmpDir := setupHomeDir(t)
+
+	ollamaDir := filepath.Join(tmpDir, ".ollama")
+	if err := os.MkdirAll(ollamaDir, 0o755); err != nil {
+		t.Fatalf("Failed to create .ollama dir: %v", err)
+	}
+
+	privKeyFile := filepath.Join(ollamaDir, "id_ed25519")
+	writeSSHEd25519PrivateKey(t, privKeyFile)
+
+	data := []byte("test")
+	signature, err := Sign(nil, data)
+	if err != nil {
+		t.Fatalf("Sign returned error: %v", err)
+	}
+
+	parts := strings.SplitN(signature, ":", 2)
+	if len(parts) != 2 {
+		t.Fatalf("Signature format = %q, want pubkey:base64sig", signature)
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Errorf("Signature is not valid base64: %v", err)
+	}
+
+	expectedSigLen := ed25519.SignatureSize
+	if len(decoded) != expectedSigLen {
+		t.Errorf("Signature length = %d, want %d", len(decoded), expectedSigLen)
+	}
+}

--- a/logutil/logutil_test.go
+++ b/logutil/logutil_test.go
@@ -1,0 +1,217 @@
+package logutil
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestLevelTrace(t *testing.T) {
+	if LevelTrace >= slog.LevelDebug {
+		t.Errorf("LevelTrace = %d, should be less than LevelDebug (%d)", LevelTrace, slog.LevelDebug)
+	}
+	if LevelTrace != -8 {
+		t.Errorf("LevelTrace = %d, want -8", LevelTrace)
+	}
+}
+
+func TestNewLogger(t *testing.T) {
+	t.Run("creates logger with specified level", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := NewLogger(&buf, slog.LevelDebug)
+
+		if logger == nil {
+			t.Fatal("NewLogger returned nil")
+		}
+
+		logger.Debug("test debug message")
+		output := buf.String()
+		if !strings.Contains(output, "test debug message") {
+			t.Errorf("Logger output = %q, want to contain 'test debug message'", output)
+		}
+	})
+
+	t.Run("respects level filtering", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := NewLogger(&buf, slog.LevelWarn)
+
+		logger.Debug("debug message")
+		logger.Info("info message")
+		logger.Warn("warn message")
+
+		output := buf.String()
+
+		if strings.Contains(output, "debug message") {
+			t.Error("Debug message should be filtered at Warn level")
+		}
+		if strings.Contains(output, "info message") {
+			t.Error("Info message should be filtered at Warn level")
+		}
+		if !strings.Contains(output, "warn message") {
+			t.Error("Warn message should appear at Warn level")
+		}
+	})
+
+	t.Run("formats trace level as TRACE", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := NewLogger(&buf, LevelTrace)
+
+		logger.Log(nil, LevelTrace, "trace message")
+		output := buf.String()
+
+		if !strings.Contains(output, "level=TRACE") {
+			t.Errorf("Logger output = %q, want to contain 'level=TRACE'", output)
+		}
+	})
+
+	t.Run("adds source information", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := NewLogger(&buf, slog.LevelInfo)
+
+		logger.Info("test message")
+		output := buf.String()
+
+		if !strings.Contains(output, "source=") {
+			t.Error("Logger should include source information")
+		}
+	})
+
+	t.Run("uses basename for source file", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := NewLogger(&buf, slog.LevelInfo)
+
+		logger.Info("test message")
+		output := buf.String()
+
+		if strings.Contains(output, string([]byte{'/', '\\'})+"logutil") || strings.Contains(output, "logutil"+string([]byte{'/', '\\'})) {
+			if strings.Contains(output, "logutil_test.go") {
+			}
+		}
+	})
+}
+
+func TestTrace(t *testing.T) {
+	t.Run("logs at trace level when enabled", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := NewLogger(&buf, LevelTrace)
+		slog.SetDefault(logger)
+		t.Cleanup(func() { slog.SetDefault(slog.Default()) })
+
+		Trace("trace test message")
+		output := buf.String()
+
+		if !strings.Contains(output, "trace test message") {
+			t.Errorf("Trace output = %q, want to contain 'trace test message'", output)
+		}
+	})
+
+	t.Run("does not log when level is higher", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := NewLogger(&buf, slog.LevelInfo)
+		slog.SetDefault(logger)
+		t.Cleanup(func() { slog.SetDefault(slog.Default()) })
+
+		Trace("should not appear")
+		output := buf.String()
+
+		if strings.Contains(output, "should not appear") {
+			t.Error("Trace should not log at Info level")
+		}
+	})
+}
+
+func TestTraceContext(t *testing.T) {
+	t.Run("logs with context at trace level", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := NewLogger(&buf, LevelTrace)
+		slog.SetDefault(logger)
+		t.Cleanup(func() { slog.SetDefault(slog.Default()) })
+
+		ctx := context.Background()
+		TraceContext(ctx, "context trace message", "key", "value")
+
+		output := buf.String()
+		if !strings.Contains(output, "context trace message") {
+			t.Errorf("TraceContext output = %q, want to contain 'context trace message'", output)
+		}
+		if !strings.Contains(output, "key=value") {
+			t.Errorf("TraceContext output = %q, want to contain 'key=value'", output)
+		}
+	})
+
+	t.Run("returns early when disabled", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := NewLogger(&buf, slog.LevelError)
+		slog.SetDefault(logger)
+		t.Cleanup(func() { slog.SetDefault(slog.Default()) })
+
+		TraceContext(context.Background(), "silent message", "key", "value")
+		output := buf.String()
+
+		if output != "" {
+			t.Errorf("TraceContext at Error level should produce no output, got %q", output)
+		}
+	})
+}
+
+func TestLoggerOutput(t *testing.T) {
+	t.Run("includes all standard fields", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := NewLogger(&buf, slog.LevelInfo)
+
+		logger.Info("test message", "key1", "value1", "key2", 42)
+
+		output := buf.String()
+
+		if !strings.Contains(output, `msg="test message"`) {
+			t.Errorf("Output missing message: %s", output)
+		}
+		if !strings.Contains(output, "key1=value1") {
+			t.Errorf("Output missing key1: %s", output)
+		}
+		if !strings.Contains(output, "key2=42") {
+			t.Errorf("Output missing key2: %s", output)
+		}
+	})
+
+	t.Run("handles multiple log calls", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := NewLogger(&buf, LevelTrace)
+
+		logger.Debug("debug msg")
+		logger.Info("info msg")
+		logger.Warn("warn msg")
+		logger.Error("error msg")
+
+		output := buf.String()
+
+		if !strings.Contains(output, "debug msg") {
+			t.Error("Missing debug message")
+		}
+		if !strings.Contains(output, "info msg") {
+			t.Error("Missing info message")
+		}
+		if !strings.Contains(output, "warn msg") {
+			t.Error("Missing warn message")
+		}
+		if !strings.Contains(output, "error msg") {
+			t.Error("Missing error message")
+		}
+	})
+}
+
+func TestTraceSkipCaller(t *testing.T) {
+	var buf bytes.Buffer
+	logger := NewLogger(&buf, LevelTrace)
+	slog.SetDefault(logger)
+	t.Cleanup(func() { slog.SetDefault(slog.Default()) })
+
+	Trace("direct trace call")
+
+	output := buf.String()
+	if !strings.Contains(output, "logutil_test.go") {
+		t.Errorf("Output should contain source file, got: %s", output)
+	}
+}


### PR DESCRIPTION
## Summary
Adds comprehensive unit test coverage for two previously untested packages:

- **auth**: Tests for nonce generation, SSH key parsing, public key extraction, and Ed25519 signing
- **logutil**: Tests for logger creation, level filtering, trace-level logging, and source attribution

## Test Coverage Added

### `auth/auth_test.go`
- `TestNewNonce`: Validates nonce generation, length encoding, uniqueness, and error propagation
- `TestGetPublicKey`: Tests error handling for missing keys and valid SSH key extraction  
- `TestSign`: Tests signing with missing keys, signature format validation, and uniqueness
- `TestSignPublicKeyFormat`: Validates Ed25519 signature length

### `logutil/logutil_test.go`
- `TestLevelTrace`: Validates trace level constant value
- `TestNewLogger`: Tests logger creation, level filtering, trace formatting, and source info
- `TestTrace`/`TestTraceContext`: Tests trace-level logging behavior with context
- `TestLoggerOutput`: Validates standard field output and multiple log calls

## Testing
All tests pass:
```
go test ./auth/... ./logutil/... -v
```