### PR TITLE
x/imagegen/mlx: this fix stops ollama from failing to initialise when running on non-mlx supported hardware, it can continue with CPU

### DIFF
--- a/x/imagegen/mlx/mlx.go
+++ b/x/imagegen/mlx/mlx.go
@@ -1837,6 +1837,11 @@ func init() {
 		return
 	}
 
+	// Only proceed with C function calls if MLX was successfully initialized
+	if !mlxInitialized {
+		return
+	}
+
 	// Enter safe mode: replace the default exit(-1) error handler with one
 	// that logs and stores errors. This prevents a GPU init failure from
 	// killing the entire process during startup.


### PR DESCRIPTION
Issue: [#15253](https://github.com/ollama/ollama/issues/15253)

My computer is a windows machine running on an AMD CPU and an AMD Radeon RX 6750 XT, I am blessed with not having CUDA and running into problems when running local LLMs. Recently I downloaded Ollama and ran into the issue that I couldn't even get the command to return anything without instantly getting the bellow error:

```ps1
Exception 0xc0000005 0x8 0xffffffffffffffff 0xffffffffffffffff
PC=0xffffffffffffffff
signal arrived during external code execution

runtime.cgocall(0x7ff654cb1790, 0xc00004dda0)
        runtime/cgocall.go:167 +0x3e fp=0xc00004dd78 sp=0xc00004dd10 pc=0x7ff653b8243e
github.com/ollama/ollama/x/imagegen/mlx._Cfunc_mlx_random_key(0xc0000962e0, 0x19d6747566d)
        _cgo_gotypes.go:1978 +0x50 fp=0xc00004dda0 sp=0xc00004dd78 pc=0x7ff654210930
github.com/ollama/ollama/x/imagegen/mlx.RandomKey.func1(...)
        github.com/ollama/ollama/x/imagegen/mlx/mlx.go:1870
github.com/ollama/ollama/x/imagegen/mlx.RandomKey(0x19d6747566d)
        github.com/ollama/ollama/x/imagegen/mlx/mlx.go:1870 +0x5d fp=0xc00004ddd8 sp=0xc00004dda0 pc=0x7ff65421985d
github.com/ollama/ollama/x/imagegen/mlx.init.0()
        github.com/ollama/ollama/x/imagegen/mlx/mlx.go:1848 +0xa9 fp=0xc00004de28 sp=0xc00004ddd8 pc=0x7ff654219669
runtime.doInit1(0x7ff6560412c0)
        runtime/proc.go:7350 +0xdd fp=0xc00004df50 sp=0xc00004de28 pc=0x7ff653b6343d
runtime.doInit(...)
        runtime/proc.go:7317
runtime.main()
        runtime/proc.go:254 +0x325 fp=0xc00004dfe0 sp=0xc00004df50 pc=0x7ff653b54e85
runtime.goexit({})
        runtime/asm_amd64.s:1700 +0x1 fp=0xc00004dfe8 sp=0xc00004dfe0 pc=0x7ff653b8db21
```

The change I am proposing, protects the usage of the MLX lib in the event that it didn't happen to throw an error at time of init. Returning and continuing on should be ok as the application should fall back to using CPU in this scenario.

This fixes the issues some users have been recently experiencing.