### PR TITLE
gemma4: Disable FA on older CUDA GPUs

### DIFF
--- a/llm/server.go
+++ b/llm/server.go
@@ -210,6 +210,18 @@ func NewLlamaServer(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, modelPath st
 		fa = false
 	}
 
+	// Gemma 4's 512-dim attention heads require MMA FA kernels (Turing+, compute >= 7.5).
+	// Older CUDA GPUs only have tile/vec FA kernels which abort on dk512 non-GQA attention.
+	if fa && f.KV().Architecture() == "gemma4" {
+		for _, gpu := range gpus {
+			if gpu.Library == "CUDA" && (gpu.ComputeMajor < 7 || (gpu.ComputeMajor == 7 && gpu.ComputeMinor < 5)) {
+				slog.Debug("disabling flash attention for gemma4 on pre-Turing GPU", "compute", fmt.Sprintf("%d.%d", gpu.ComputeMajor, gpu.ComputeMinor))
+				fa = false
+				break
+			}
+		}
+	}
+
 	kvct := strings.ToLower(envconfig.KvCacheType())
 
 	if tok == nil {


### PR DESCRIPTION
CUDA older than 7.5 lack the support to enable flash attention for the model.

```
/ml/backend/ggml/ggml/src/ggml-cuda/template-instances/../fattn-tile.cuh:1247: fatal error
/tmp/daniel_ollama_test/lib/ollama/libggml-base.so.0(+0x1bae8)[0x7f7dfc02cae8]
/tmp/daniel_ollama_test/lib/ollama/libggml-base.so.0(ggml_print_backtrace+0x1e6)[0x7f7dfc02ceb6]
/tmp/daniel_ollama_test/lib/ollama/libggml-base.so.0(ggml_abort+0x11d)[0x7f7dfc02d03d]
/tmp/daniel_ollama_test/lib/ollama/cuda_v12/libggml-cuda.so(_Z34ggml_cuda_flash_attn_ext_tile_caseILi512ELi512EEvR25ggml_backend_cuda_contextP11ggml_tensor+0x31a)[0x7f7d757fd3ca]
/tmp/daniel_ollama_test/lib/ollama/cuda_v12/libggml-cuda.so(+0x16bf9d)[0x7f7d7562cf9d]
/tmp/daniel_ollama_test/lib/ollama/cuda_v12/libggml-cuda.so(+0x16ed0a)[0x7f7d7562fd0a]
/tmp/daniel_ollama_test/lib/ollama/cuda_v12/libggml-cuda.so(+0x171e56)[0x7f7d75632e56]
/tmp/daniel_ollama_test/bin/ollama(+0x15856d1)[0x557f231926d1]
/tmp/daniel_ollama_test/bin/ollama(+0x14f9f8b)[0x557f23106f8b]
/tmp/daniel_ollama_test/bin/ollama(+0x4001a1)[0x557f2200d1a1]
SIGABRT: abort
```