### PR TITLE
mlx: use default http client

### DIFF
--- a/x/mlxrunner/client.go
+++ b/x/mlxrunner/client.go
@@ -110,7 +110,7 @@ func NewClient(modelName string) (*Client, error) {
 	c := &Client{
 		modelName: modelName,
 		done:      make(chan struct{}),
-		client:    &http.Client{Timeout: 10 * time.Minute},
+		client:    http.DefaultClient,
 	}
 
 	modelManifest, err := manifest.LoadManifest(modelName)


### PR DESCRIPTION
Change the mlxrunner client to not time out after 10 mins. This mimics the existing behaviour of the ollama/llamacpp runners.

We may want to bring this back and add an explicit setting for this in the future.

Fixes #15334 