### PR TITLE
cmd/launch: fix doesn't wording in cleanup comment

### DIFF
--- a/cmd/launch/launch.go
+++ b/cmd/launch/launch.go
@@ -192,7 +192,7 @@ Examples:
 		PreRunE: checkServerHeartbeat,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			policy := defaultLaunchPolicy(isInteractiveSession(), yesFlag)
-			// reset when done to make sure state doens't leak between launches
+			// reset when done to make sure state doesn't leak between launches
 			restoreConfirmPolicy := withLaunchConfirmPolicy(policy.confirmPolicy())
 			defer restoreConfirmPolicy()
 


### PR DESCRIPTION
## Summary
- fix `doens't` -> `doesn't` in the launch cleanup comment

## Related issue
- N/A (trivial comment fix)

## Guideline alignment
- Reviewed https://github.com/ollama/ollama/blob/main/CONTRIBUTING.md and kept this to one focused comment-only change with no behavior change.

## Validation/testing note
- Not run (comment-only change)
