### PR TITLE
adding ios chat client to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ console.log(response.message.content);
 #### Mobile
 
 - [Ollama Android Chat](https://github.com/sunshine0523/OllamaServer) - One-click Ollama on Android
+- [Poly_Chat](https://github.com/georgehunn/poly_chat_project) - AI chat client for iOS
 
 > SwiftChat, Enchanted, Maid, Ollama App, Reins, and ConfiChat listed above also support mobile platforms.
 


### PR DESCRIPTION
Adding an open-source iOS app to the README that lets users configure their own Ollama Cloud API key, browse available models, and use features like web search, document/image upload, and full Markdown support.