### PR TITLE
fix: improve error message for unknown input item type in responses API

### DIFF
--- a/openai/responses.go
+++ b/openai/responses.go
@@ -281,7 +281,10 @@ func unmarshalResponsesInputItem(data []byte) (ResponsesInputItem, error) {
 		}
 		return reasoning, nil
 	default:
-		return nil, fmt.Errorf("unknown input item type: %s", typeField.Type)
+		if itemType == "" {
+			return nil, fmt.Errorf("input item missing required 'type' field")
+		}
+		return nil, fmt.Errorf("unknown input item type: %q", itemType)
 	}
 }
 

--- a/openai/responses_test.go
+++ b/openai/responses_test.go
@@ -253,6 +253,29 @@ func TestUnmarshalResponsesInputItem(t *testing.T) {
 		if err == nil {
 			t.Error("expected error, got nil")
 		}
+		if err != nil && err.Error() != `unknown input item type: "unknown_type"` {
+			t.Errorf("unexpected error message: %v", err)
+		}
+	})
+
+	t.Run("missing type field", func(t *testing.T) {
+		_, err := unmarshalResponsesInputItem([]byte(`{"content": "hello"}`))
+		if err == nil {
+			t.Error("expected error for missing type, got nil")
+		}
+		if err != nil && err.Error() != "input item missing required 'type' field" {
+			t.Errorf("unexpected error message: %v", err)
+		}
+	})
+
+	t.Run("empty type field", func(t *testing.T) {
+		_, err := unmarshalResponsesInputItem([]byte(`{"type": ""}`))
+		if err == nil {
+			t.Error("expected error for empty type, got nil")
+		}
+		if err != nil && err.Error() != "input item missing required 'type' field" {
+			t.Errorf("unexpected error message: %v", err)
+		}
 	})
 }
 


### PR DESCRIPTION
## Bug

`unmarshalResponsesInputItem` had two problems in its `default` error branch:

**Wrong variable**: The error used `typeField.Type` instead of `itemType`. These differ when the shorthand role-based format (e.g. `{"role": "user", "content": "..."}`) is used — in that case `itemType` is promoted to `"message"` while `typeField.Type` remains `""`. So if an unhandled type value somehow passed through, the error could show a stale/wrong string.

**Unhelpful message on empty type**: When both `type` and `role` are absent, `itemType` stays `""`. The old `%s` format produced:
```
unknown input item type: 
```
That trailing space with nothing after it gives no useful signal.

## Fix

```go
default:
    if itemType == "" {
        return nil, fmt.Errorf("input item missing required 'type' field")
    }
    return nil, fmt.Errorf("unknown input item type: %q", itemType)
```

- Uses `itemType` (the resolved value after shorthand promotion) instead of `typeField.Type`
- Uses `%q` so the unknown value is always quoted and visible
- Special-cases the empty string with a descriptive message

## Tests

Added two test cases to `TestUnmarshalResponsesInputItem`:
- `missing type field` — `{"content": "hello"}` (no type key at all)
- `empty type field` — `{"type": ""}` (explicit empty string)

Both verify the error message is `"input item missing required 'type' field"`.

Also tightened the existing `unknown item type` test to assert the exact quoted error string.