### PR TITLE
fix: handle os.MkdirAll errors in download and quantize

### DIFF
--- a/x/create/client/quantize.go
+++ b/x/create/client/quantize.go
@@ -28,7 +28,10 @@ func loadAndQuantizeArray(r io.Reader, name, quantize string, arrays map[string]
 		}
 	}
 
-	tmpDir := ensureTempDir()
+	tmpDir, err := ensureTempDir()
+	if err != nil {
+		return "", nil, nil, err
+	}
 
 	tmpFile, err := os.CreateTemp(tmpDir, "quant-*.safetensors")
 	if err != nil {
@@ -157,7 +160,10 @@ func quantizeTensor(r io.Reader, tensorName, dtype string, shape []int32, quanti
 		"group_size": strconv.Itoa(groupSize),
 	}
 
-	tmpDir := ensureTempDir()
+	tmpDir, err := ensureTempDir()
+	if err != nil {
+		return nil, err
+	}
 	outPath := filepath.Join(tmpDir, "combined.safetensors")
 	defer os.Remove(outPath)
 	if err := mlx.SaveSafetensorsWithMetadata(outPath, arrays, metadata); err != nil {
@@ -239,7 +245,10 @@ func quantizePackedGroup(groupName string, inputs []create.PackedTensorInput) ([
 
 	// Save combined blob. Add global metadata only when every packed tensor uses
 	// the same quantization mode and group size.
-	tmpDir := ensureTempDir()
+	tmpDir, err := ensureTempDir()
+	if err != nil {
+		return nil, err
+	}
 	outPath := filepath.Join(tmpDir, "packed-combined.safetensors")
 	defer os.Remove(outPath)
 	if err := mlx.SaveSafetensorsWithMetadata(outPath, allArrays, metadata); err != nil {
@@ -421,7 +430,10 @@ func stackAndQuantizeExpertGroup(groupName string, projGroups map[string][]exper
 
 	defer cleanup()
 
-	tmpDir := ensureTempDir()
+	tmpDir, err := ensureTempDir()
+	if err != nil {
+		return nil, err
+	}
 	outPath := filepath.Join(tmpDir, "stacked-combined.safetensors")
 	defer os.Remove(outPath)
 	if err := mlx.SaveSafetensorsWithMetadata(outPath, allArrays, metadata); err != nil {
@@ -441,10 +453,12 @@ func QuantizeSupported() bool {
 }
 
 // ensureTempDir creates the temp directory for quantization if it doesn't exist
-func ensureTempDir() string {
+func ensureTempDir() (string, error) {
 	tmpDir := filepath.Join(os.TempDir(), "ollama-quantize")
-	os.MkdirAll(tmpDir, 0755)
-	return tmpDir
+	if err := os.MkdirAll(tmpDir, 0755); err != nil {
+		return "", fmt.Errorf("creating quantization temp directory: %w", err)
+	}
+	return tmpDir, nil
 }
 
 type safetensorsHeaderEntry struct {

--- a/x/imagegen/transfer/download.go
+++ b/x/imagegen/transfer/download.go
@@ -176,7 +176,9 @@ func (d *downloader) downloadOnce(ctx context.Context, blob Blob) (int64, error)
 func (d *downloader) save(ctx context.Context, blob Blob, r io.Reader) (int64, error) {
 	dest := filepath.Join(d.destDir, digestToPath(blob.Digest))
 	tmp := dest + ".tmp"
-	os.MkdirAll(filepath.Dir(dest), 0o755)
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return 0, fmt.Errorf("creating destination directory: %w", err)
+	}
 
 	f, err := os.Create(tmp)
 	if err != nil {


### PR DESCRIPTION
## Summary

`os.MkdirAll` errors were silently ignored in two places, causing confusing downstream failures:

- **`x/imagegen/transfer/download.go` (line 179):** The ignored error from `os.MkdirAll(filepath.Dir(dest), 0o755)` caused the subsequent `os.Create(tmp)` call to fail with a misleading `no such file or directory` instead of a clear directory-creation error. Wrapped with a `fmt.Errorf` and returned early.

- **`x/create/client/quantize.go` (line 446):** `ensureTempDir()` silently swallowed the `MkdirAll` error and returned the path regardless. Changed the function signature from `() string` to `() (string, error)`, and propagated the error through all four call sites (`loadAndQuantizeArray`, `quantizeTensor`, `quantizePackedGroup`, `stackAndQuantizeExpertGroup`).

## Consistency with existing codebase

The rest of the codebase already handles `MkdirAll` errors correctly — for example, `server/images.go` lines 415, 668, and 765 all check and return the error. This change brings the two missing cases in line with that pattern.

## Changes

- No logic changes — pure error propagation.
- Minimal diff: only the two files involved in the bug.