### PR TITLE
launch: add thinking capability detection to opencode

### DIFF
--- a/cmd/launch/opencode.go
+++ b/cmd/launch/opencode.go
@@ -297,7 +297,7 @@ func applyOpenCodeReasoning(resp *api.ShowResponse, modelName string, entry map[
 	if slices.Contains(resp.Capabilities, model.CapabilityThinking) {
 		entry["reasoning"] = true
 
-		if openCodeSupportsReasoningLevels(resp, modelName) {
+		if strings.Contains(modelName, "gpt-oss") {
 			// GPT-OSS models support variable thinking effort levels
 			// and cannot turn thinking off. Keep the built-in
 			// low/medium/high variants as-is and default to medium.
@@ -318,21 +318,4 @@ func applyOpenCodeReasoning(resp *api.ShowResponse, modelName string, entry map[
 			}
 		}
 	}
-}
-
-func openCodeSupportsReasoningLevels(resp *api.ShowResponse, modelName string) bool {
-	if resp != nil {
-		families := append([]string{resp.Details.Family}, resp.Details.Families...)
-		if arch, ok := resp.ModelInfo["general.architecture"].(string); ok {
-			families = append(families, arch)
-		}
-		for _, family := range families {
-			if family == "gptoss" || family == "gpt-oss" {
-				return true
-			}
-		}
-	}
-
-	// Fallback for older servers or sparse test responses that do not include family data.
-	return strings.Contains(modelName, "gpt-oss")
 }

--- a/cmd/launch/opencode.go
+++ b/cmd/launch/opencode.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strings"
 
 	"github.com/ollama/ollama/cmd/internal/fileutil"
 	"github.com/ollama/ollama/envconfig"
@@ -278,6 +279,25 @@ func buildModelEntries(modelList []LaunchModel) map[string]any {
 				"output": []string{"text"},
 			}
 		}
+		if model.HasCapability("thinking") {
+			entry["reasoning"] = true
+			if openCodeModelSupportsThinkingLevels(model) {
+				entry["options"] = map[string]any{"reasoningEffort": "medium"}
+				entry["variants"] = map[string]any{
+					"low":    map[string]any{"reasoningEffort": "low"},
+					"medium": map[string]any{"reasoningEffort": "medium"},
+					"high":   map[string]any{"reasoningEffort": "high"},
+					"max":    map[string]any{"reasoningEffort": "max"},
+				}
+			} else {
+				entry["variants"] = map[string]any{
+					"none":   map[string]any{"reasoningEffort": "none"},
+					"low":    map[string]any{"disabled": true},
+					"medium": map[string]any{"disabled": true},
+					"high":   map[string]any{"disabled": true},
+				}
+			}
+		}
 		if model.MaxOutputTokens > 0 {
 			limit := make(map[string]any)
 			if model.ContextLength > 0 {
@@ -289,4 +309,21 @@ func buildModelEntries(modelList []LaunchModel) map[string]any {
 		models[model.Name] = entry
 	}
 	return models
+}
+
+func openCodeModelSupportsThinkingLevels(model LaunchModel) bool {
+	for _, family := range append([]string{model.Details.Family}, model.Details.Families...) {
+		if normalizeOpenCodeModelFamily(family) == "gptoss" {
+			return true
+		}
+	}
+
+	return strings.Contains(normalizeOpenCodeModelFamily(model.Name), "gptoss")
+}
+
+func normalizeOpenCodeModelFamily(s string) string {
+	s = strings.ToLower(s)
+	s = strings.ReplaceAll(s, "-", "")
+	s = strings.ReplaceAll(s, "_", "")
+	return s
 }

--- a/cmd/launch/opencode.go
+++ b/cmd/launch/opencode.go
@@ -1,6 +1,7 @@
 package launch
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -8,9 +9,13 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strings"
+	"time"
 
+	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/cmd/internal/fileutil"
 	"github.com/ollama/ollama/envconfig"
+	"github.com/ollama/ollama/types/model"
 )
 
 // OpenCode implements Runner and Editor for OpenCode integration.
@@ -19,6 +24,8 @@ import (
 type OpenCode struct {
 	configContent string // JSON config built by Edit, passed to Run via env var
 }
+
+const openCodeModelShowTimeout = 2 * time.Second
 
 func (o *OpenCode) String() string { return "OpenCode" }
 
@@ -43,7 +50,7 @@ func findOpenCode() (string, bool) {
 	return "", false
 }
 
-func (o *OpenCode) Run(model string, models []LaunchModel, args []string) error {
+func (o *OpenCode) Run(model string, args []string) error {
 	opencodePath, ok := findOpenCode()
 	if !ok {
 		return fmt.Errorf("opencode is not installed, install from https://opencode.ai")
@@ -54,7 +61,7 @@ func (o *OpenCode) Run(model string, models []LaunchModel, args []string) error 
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Env = os.Environ()
-	if content := o.resolveContent(model, models); content != "" {
+	if content := o.resolveContent(model); content != "" {
 		cmd.Env = append(cmd.Env, "OPENCODE_CONFIG_CONTENT="+content)
 	}
 	return cmd.Run()
@@ -63,55 +70,19 @@ func (o *OpenCode) Run(model string, models []LaunchModel, args []string) error 
 // resolveContent returns the inline config to send via OPENCODE_CONFIG_CONTENT.
 // Returns content built by Edit if available, otherwise builds from model.json
 // with the requested model as primary (e.g. re-launch with saved config).
-func (o *OpenCode) resolveContent(model string, models []LaunchModel) string {
+func (o *OpenCode) resolveContent(model string) string {
 	if o.configContent != "" {
 		return o.configContent
 	}
-	resolvedModels := resolveOpenCodeRunModels(model, models, readModelJSONModels())
-	if len(resolvedModels) == 0 {
-		return ""
+	models := readModelJSONModels()
+	if !slices.Contains(models, model) {
+		models = append([]string{model}, models...)
 	}
-	content, err := buildInlineConfig(resolvedModels[0], resolvedModels)
+	content, err := buildInlineConfig(model, models)
 	if err != nil {
 		return ""
 	}
 	return content
-}
-
-func resolveOpenCodeRunModels(primary string, models []LaunchModel, stateModels []string) []LaunchModel {
-	if primary == "" {
-		return nil
-	}
-
-	resolved := make([]LaunchModel, 0, 1+len(models)+len(stateModels))
-	appendModel := func(name string) {
-		if name == "" || hasLaunchModel(resolved, name) {
-			return
-		}
-		if model, ok := findLaunchModel(models, name); ok {
-			resolved = append(resolved, model)
-			return
-		}
-		resolved = append(resolved, fallbackLaunchModel(name))
-	}
-
-	appendModel(primary)
-	for _, model := range models {
-		appendModel(model.Name)
-	}
-	for _, model := range stateModels {
-		appendModel(model)
-	}
-	return resolved
-}
-
-func hasLaunchModel(models []LaunchModel, name string) bool {
-	for _, model := range models {
-		if launchModelMatches(model.Name, name) || launchModelMatches(name, model.Name) {
-			return true
-		}
-	}
-	return false
 }
 
 func (o *OpenCode) Paths() []string {
@@ -136,13 +107,12 @@ func openCodeStatePath() (string, error) {
 	return filepath.Join(home, ".local", "state", "opencode", "model.json"), nil
 }
 
-func (o *OpenCode) Edit(models []LaunchModel) error {
-	modelList := launchModelNames(models)
+func (o *OpenCode) Edit(modelList []string) error {
 	if len(modelList) == 0 {
 		return nil
 	}
 
-	content, err := buildInlineConfig(models[0], models)
+	content, err := buildInlineConfig(modelList[0], modelList)
 	if err != nil {
 		return err
 	}
@@ -209,9 +179,14 @@ func (o *OpenCode) Models() []string {
 
 // buildInlineConfig produces the JSON string for OPENCODE_CONFIG_CONTENT.
 // primary is the model to launch with, models is the full list of available models.
-func buildInlineConfig(primary LaunchModel, models []LaunchModel) (string, error) {
-	if primary.Name == "" || len(models) == 0 {
+func buildInlineConfig(primary string, models []string) (string, error) {
+	if primary == "" || len(models) == 0 {
 		return "", fmt.Errorf("buildInlineConfig: primary and models are required")
+	}
+
+	client, err := api.ClientFromEnvironment()
+	if err != nil {
+		client = nil
 	}
 
 	config := map[string]any{
@@ -223,10 +198,10 @@ func buildInlineConfig(primary LaunchModel, models []LaunchModel) (string, error
 				"options": map[string]any{
 					"baseURL": envconfig.Host().String() + "/v1",
 				},
-				"models": buildModelEntries(models),
+				"models": buildModelEntries(context.Background(), client, models),
 			},
 		},
-		"model": "ollama/" + primary.Name,
+		"model": "ollama/" + primary,
 	}
 	data, err := json.Marshal(config)
 	if err != nil {
@@ -266,27 +241,81 @@ func readModelJSONModels() []string {
 	return models
 }
 
-func buildModelEntries(modelList []LaunchModel) map[string]any {
+func buildModelEntries(ctx context.Context, client *api.Client, modelList []string) map[string]any {
 	models := make(map[string]any)
-	for _, model := range modelList {
+	for _, modelID := range modelList {
 		entry := map[string]any{
-			"name": model.Name,
+			"name": modelID,
 		}
-		if model.HasCapability("vision") {
-			entry["modalities"] = map[string]any{
-				"input":  []string{"text", "image"},
-				"output": []string{"text"},
+		if client != nil {
+			showCtx := ctx
+			var cancel context.CancelFunc
+			if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+				showCtx, cancel = context.WithTimeout(ctx, openCodeModelShowTimeout)
+			}
+
+			if resp, err := client.Show(showCtx, &api.ShowRequest{Model: modelID}); err == nil {
+				if slices.Contains(resp.Capabilities, model.CapabilityVision) {
+					entry["modalities"] = map[string]any{
+						"input":  []string{"text", "image"},
+						"output": []string{"text"},
+					}
+				}
+				applyOpenCodeReasoning(resp, modelID, entry)
+			}
+			if cancel != nil {
+				cancel()
 			}
 		}
-		if model.MaxOutputTokens > 0 {
-			limit := make(map[string]any)
-			if model.ContextLength > 0 {
-				limit["context"] = model.ContextLength
+		if isCloudModelName(modelID) {
+			if l, ok := lookupCloudModelLimit(modelID); ok {
+				entry["limit"] = map[string]any{
+					"context": l.Context,
+					"output":  l.Output,
+				}
 			}
-			limit["output"] = model.MaxOutputTokens
-			entry["limit"] = limit
 		}
-		models[model.Name] = entry
+		models[modelID] = entry
 	}
 	return models
+}
+
+// applyOpenCodeReasoning detects thinking capability and sets reasoning config
+// on the model entry. When the model supports thinking, it sets "reasoning": true
+// and configures variants for the OpenCode TUI:
+//   - GPT-OSS: supports variable effort levels (low/medium/high) and defaults to
+//     medium via options. Thinking cannot be turned off.
+//   - Other models: only support on/off. Disables built-in low/medium/high variants
+//     and adds a "none" variant so users can toggle thinking off via Ctrl+T.
+//
+// When the model does not support thinking, no reasoning config is set.
+func applyOpenCodeReasoning(resp *api.ShowResponse, modelName string, entry map[string]any) {
+	if resp == nil {
+		return
+	}
+
+	if slices.Contains(resp.Capabilities, model.CapabilityThinking) {
+		entry["reasoning"] = true
+
+		if strings.Contains(modelName, "gpt-oss") {
+			// GPT-OSS models support variable thinking effort levels
+			// and cannot turn thinking off. Keep the built-in
+			// low/medium/high variants as-is and default to medium.
+			options, ok := entry["options"].(map[string]any)
+			if !ok {
+				options = make(map[string]any)
+			}
+			options["reasoningEffort"] = "medium"
+			entry["options"] = options
+		} else {
+			// Most models only support thinking on or off.
+			// Disable the built-in low/medium/high variants and add none.
+			entry["variants"] = map[string]any{
+				"none":   map[string]any{"reasoningEffort": "none"},
+				"low":    map[string]any{"disabled": true},
+				"medium": map[string]any{"disabled": true},
+				"high":   map[string]any{"disabled": true},
+			}
+		}
+	}
 }

--- a/cmd/launch/opencode.go
+++ b/cmd/launch/opencode.go
@@ -1,7 +1,6 @@
 package launch
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -9,13 +8,9 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
-	"strings"
-	"time"
 
-	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/cmd/internal/fileutil"
 	"github.com/ollama/ollama/envconfig"
-	"github.com/ollama/ollama/types/model"
 )
 
 // OpenCode implements Runner and Editor for OpenCode integration.
@@ -24,8 +19,6 @@ import (
 type OpenCode struct {
 	configContent string // JSON config built by Edit, passed to Run via env var
 }
-
-const openCodeModelShowTimeout = 2 * time.Second
 
 func (o *OpenCode) String() string { return "OpenCode" }
 
@@ -50,7 +43,7 @@ func findOpenCode() (string, bool) {
 	return "", false
 }
 
-func (o *OpenCode) Run(model string, args []string) error {
+func (o *OpenCode) Run(model string, models []LaunchModel, args []string) error {
 	opencodePath, ok := findOpenCode()
 	if !ok {
 		return fmt.Errorf("opencode is not installed, install from https://opencode.ai")
@@ -61,7 +54,7 @@ func (o *OpenCode) Run(model string, args []string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Env = os.Environ()
-	if content := o.resolveContent(model); content != "" {
+	if content := o.resolveContent(model, models); content != "" {
 		cmd.Env = append(cmd.Env, "OPENCODE_CONFIG_CONTENT="+content)
 	}
 	return cmd.Run()
@@ -70,19 +63,55 @@ func (o *OpenCode) Run(model string, args []string) error {
 // resolveContent returns the inline config to send via OPENCODE_CONFIG_CONTENT.
 // Returns content built by Edit if available, otherwise builds from model.json
 // with the requested model as primary (e.g. re-launch with saved config).
-func (o *OpenCode) resolveContent(model string) string {
+func (o *OpenCode) resolveContent(model string, models []LaunchModel) string {
 	if o.configContent != "" {
 		return o.configContent
 	}
-	models := readModelJSONModels()
-	if !slices.Contains(models, model) {
-		models = append([]string{model}, models...)
+	resolvedModels := resolveOpenCodeRunModels(model, models, readModelJSONModels())
+	if len(resolvedModels) == 0 {
+		return ""
 	}
-	content, err := buildInlineConfig(model, models)
+	content, err := buildInlineConfig(resolvedModels[0], resolvedModels)
 	if err != nil {
 		return ""
 	}
 	return content
+}
+
+func resolveOpenCodeRunModels(primary string, models []LaunchModel, stateModels []string) []LaunchModel {
+	if primary == "" {
+		return nil
+	}
+
+	resolved := make([]LaunchModel, 0, 1+len(models)+len(stateModels))
+	appendModel := func(name string) {
+		if name == "" || hasLaunchModel(resolved, name) {
+			return
+		}
+		if model, ok := findLaunchModel(models, name); ok {
+			resolved = append(resolved, model)
+			return
+		}
+		resolved = append(resolved, fallbackLaunchModel(name))
+	}
+
+	appendModel(primary)
+	for _, model := range models {
+		appendModel(model.Name)
+	}
+	for _, model := range stateModels {
+		appendModel(model)
+	}
+	return resolved
+}
+
+func hasLaunchModel(models []LaunchModel, name string) bool {
+	for _, model := range models {
+		if launchModelMatches(model.Name, name) || launchModelMatches(name, model.Name) {
+			return true
+		}
+	}
+	return false
 }
 
 func (o *OpenCode) Paths() []string {
@@ -107,12 +136,13 @@ func openCodeStatePath() (string, error) {
 	return filepath.Join(home, ".local", "state", "opencode", "model.json"), nil
 }
 
-func (o *OpenCode) Edit(modelList []string) error {
+func (o *OpenCode) Edit(models []LaunchModel) error {
+	modelList := launchModelNames(models)
 	if len(modelList) == 0 {
 		return nil
 	}
 
-	content, err := buildInlineConfig(modelList[0], modelList)
+	content, err := buildInlineConfig(models[0], models)
 	if err != nil {
 		return err
 	}
@@ -179,14 +209,9 @@ func (o *OpenCode) Models() []string {
 
 // buildInlineConfig produces the JSON string for OPENCODE_CONFIG_CONTENT.
 // primary is the model to launch with, models is the full list of available models.
-func buildInlineConfig(primary string, models []string) (string, error) {
-	if primary == "" || len(models) == 0 {
+func buildInlineConfig(primary LaunchModel, models []LaunchModel) (string, error) {
+	if primary.Name == "" || len(models) == 0 {
 		return "", fmt.Errorf("buildInlineConfig: primary and models are required")
-	}
-
-	client, err := api.ClientFromEnvironment()
-	if err != nil {
-		client = nil
 	}
 
 	config := map[string]any{
@@ -198,10 +223,10 @@ func buildInlineConfig(primary string, models []string) (string, error) {
 				"options": map[string]any{
 					"baseURL": envconfig.Host().String() + "/v1",
 				},
-				"models": buildModelEntries(context.Background(), client, models),
+				"models": buildModelEntries(models),
 			},
 		},
-		"model": "ollama/" + primary,
+		"model": "ollama/" + primary.Name,
 	}
 	data, err := json.Marshal(config)
 	if err != nil {
@@ -241,81 +266,27 @@ func readModelJSONModels() []string {
 	return models
 }
 
-func buildModelEntries(ctx context.Context, client *api.Client, modelList []string) map[string]any {
+func buildModelEntries(modelList []LaunchModel) map[string]any {
 	models := make(map[string]any)
-	for _, modelID := range modelList {
+	for _, model := range modelList {
 		entry := map[string]any{
-			"name": modelID,
+			"name": model.Name,
 		}
-		if client != nil {
-			showCtx := ctx
-			var cancel context.CancelFunc
-			if _, hasDeadline := ctx.Deadline(); !hasDeadline {
-				showCtx, cancel = context.WithTimeout(ctx, openCodeModelShowTimeout)
-			}
-
-			if resp, err := client.Show(showCtx, &api.ShowRequest{Model: modelID}); err == nil {
-				if slices.Contains(resp.Capabilities, model.CapabilityVision) {
-					entry["modalities"] = map[string]any{
-						"input":  []string{"text", "image"},
-						"output": []string{"text"},
-					}
-				}
-				applyOpenCodeReasoning(resp, modelID, entry)
-			}
-			if cancel != nil {
-				cancel()
+		if model.HasCapability("vision") {
+			entry["modalities"] = map[string]any{
+				"input":  []string{"text", "image"},
+				"output": []string{"text"},
 			}
 		}
-		if isCloudModelName(modelID) {
-			if l, ok := lookupCloudModelLimit(modelID); ok {
-				entry["limit"] = map[string]any{
-					"context": l.Context,
-					"output":  l.Output,
-				}
+		if model.MaxOutputTokens > 0 {
+			limit := make(map[string]any)
+			if model.ContextLength > 0 {
+				limit["context"] = model.ContextLength
 			}
+			limit["output"] = model.MaxOutputTokens
+			entry["limit"] = limit
 		}
-		models[modelID] = entry
+		models[model.Name] = entry
 	}
 	return models
-}
-
-// applyOpenCodeReasoning detects thinking capability and sets reasoning config
-// on the model entry. When the model supports thinking, it sets "reasoning": true
-// and configures variants for the OpenCode TUI:
-//   - GPT-OSS: supports variable effort levels (low/medium/high) and defaults to
-//     medium via options. Thinking cannot be turned off.
-//   - Other models: only support on/off. Disables built-in low/medium/high variants
-//     and adds a "none" variant so users can toggle thinking off via Ctrl+T.
-//
-// When the model does not support thinking, no reasoning config is set.
-func applyOpenCodeReasoning(resp *api.ShowResponse, modelName string, entry map[string]any) {
-	if resp == nil {
-		return
-	}
-
-	if slices.Contains(resp.Capabilities, model.CapabilityThinking) {
-		entry["reasoning"] = true
-
-		if strings.Contains(modelName, "gpt-oss") {
-			// GPT-OSS models support variable thinking effort levels
-			// and cannot turn thinking off. Keep the built-in
-			// low/medium/high variants as-is and default to medium.
-			options, ok := entry["options"].(map[string]any)
-			if !ok {
-				options = make(map[string]any)
-			}
-			options["reasoningEffort"] = "medium"
-			entry["options"] = options
-		} else {
-			// Most models only support thinking on or off.
-			// Disable the built-in low/medium/high variants and add none.
-			entry["variants"] = map[string]any{
-				"none":   map[string]any{"reasoningEffort": "none"},
-				"low":    map[string]any{"disabled": true},
-				"medium": map[string]any{"disabled": true},
-				"high":   map[string]any{"disabled": true},
-			}
-		}
-	}
 }

--- a/cmd/launch/opencode.go
+++ b/cmd/launch/opencode.go
@@ -297,7 +297,7 @@ func applyOpenCodeReasoning(resp *api.ShowResponse, modelName string, entry map[
 	if slices.Contains(resp.Capabilities, model.CapabilityThinking) {
 		entry["reasoning"] = true
 
-		if strings.Contains(modelName, "gpt-oss") {
+		if openCodeSupportsReasoningLevels(resp, modelName) {
 			// GPT-OSS models support variable thinking effort levels
 			// and cannot turn thinking off. Keep the built-in
 			// low/medium/high variants as-is and default to medium.
@@ -318,4 +318,21 @@ func applyOpenCodeReasoning(resp *api.ShowResponse, modelName string, entry map[
 			}
 		}
 	}
+}
+
+func openCodeSupportsReasoningLevels(resp *api.ShowResponse, modelName string) bool {
+	if resp != nil {
+		families := append([]string{resp.Details.Family}, resp.Details.Families...)
+		if arch, ok := resp.ModelInfo["general.architecture"].(string); ok {
+			families = append(families, arch)
+		}
+		for _, family := range families {
+			if family == "gptoss" || family == "gpt-oss" {
+				return true
+			}
+		}
+	}
+
+	// Fallback for older servers or sparse test responses that do not include family data.
+	return strings.Contains(modelName, "gpt-oss")
 }

--- a/cmd/launch/opencode_test.go
+++ b/cmd/launch/opencode_test.go
@@ -1,22 +1,14 @@
 package launch
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
-	"net/http/httptest"
-	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
-	"sync"
 	"testing"
-	"time"
 
-	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/types/model"
 )
 
 func TestOpenCodeIntegration(t *testing.T) {
@@ -41,7 +33,7 @@ func TestOpenCodeEdit(t *testing.T) {
 	t.Run("builds config content with provider", func(t *testing.T) {
 		setTestHome(t, t.TempDir())
 		o := &OpenCode{}
-		if err := o.Edit([]string{"llama3.2"}); err != nil {
+		if err := o.Edit(testLaunchModels("llama3.2")); err != nil {
 			t.Fatal(err)
 		}
 
@@ -75,7 +67,7 @@ func TestOpenCodeEdit(t *testing.T) {
 	t.Run("multiple models", func(t *testing.T) {
 		setTestHome(t, t.TempDir())
 		o := &OpenCode{}
-		if err := o.Edit([]string{"llama3.2", "qwen3:32b"}); err != nil {
+		if err := o.Edit(testLaunchModels("llama3.2", "qwen3:32b")); err != nil {
 			t.Fatal(err)
 		}
 
@@ -100,7 +92,7 @@ func TestOpenCodeEdit(t *testing.T) {
 	t.Run("empty models is no-op", func(t *testing.T) {
 		setTestHome(t, t.TempDir())
 		o := &OpenCode{}
-		if err := o.Edit([]string{}); err != nil {
+		if err := o.Edit(testLaunchModels()); err != nil {
 			t.Fatal(err)
 		}
 		if o.configContent != "" {
@@ -112,7 +104,7 @@ func TestOpenCodeEdit(t *testing.T) {
 		tmpDir := t.TempDir()
 		setTestHome(t, tmpDir)
 		o := &OpenCode{}
-		o.Edit([]string{"llama3.2"})
+		o.Edit(testLaunchModels("llama3.2"))
 
 		configDir := filepath.Join(tmpDir, ".config", "opencode")
 
@@ -127,7 +119,7 @@ func TestOpenCodeEdit(t *testing.T) {
 	t.Run("cloud model has limits", func(t *testing.T) {
 		setTestHome(t, t.TempDir())
 		o := &OpenCode{}
-		if err := o.Edit([]string{"glm-4.7:cloud"}); err != nil {
+		if err := o.Edit(testLaunchModels("glm-4.7:cloud")); err != nil {
 			t.Fatal(err)
 		}
 
@@ -154,7 +146,7 @@ func TestOpenCodeEdit(t *testing.T) {
 	t.Run("local model has no limits", func(t *testing.T) {
 		setTestHome(t, t.TempDir())
 		o := &OpenCode{}
-		o.Edit([]string{"llama3.2"})
+		o.Edit(testLaunchModels("llama3.2"))
 
 		var cfg map[string]any
 		json.Unmarshal([]byte(o.configContent), &cfg)
@@ -169,37 +161,7 @@ func TestOpenCodeEdit(t *testing.T) {
 	})
 
 	t.Run("vision model gets image input modalities", func(t *testing.T) {
-		u, err := url.Parse("http://ollama.example")
-		if err != nil {
-			t.Fatalf("parse test URL: %v", err)
-		}
-		client := api.NewClient(u, &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-			if req.URL.Path != "/api/show" {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader("not found")),
-					Header:     make(http.Header),
-				}, nil
-			}
-
-			var body struct {
-				Model string `json:"model"`
-			}
-			if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
-				t.Fatalf("decode show request: %v", err)
-			}
-			if body.Model != "gemma4:26b" {
-				t.Fatalf("show request model = %q, want gemma4:26b", body.Model)
-			}
-
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(strings.NewReader(`{"capabilities":["vision"],"model_info":{}}`)),
-				Header:     make(http.Header),
-			}, nil
-		})})
-
-		models := buildModelEntries(context.Background(), client, []string{"gemma4:26b"})
+		models := buildModelEntries([]LaunchModel{{Name: "gemma4:26b", Capabilities: []model.Capability{"vision"}}})
 		entry, _ := models["gemma4:26b"].(map[string]any)
 		modalities, _ := entry["modalities"].(map[string]any)
 		input, _ := modalities["input"].([]string)
@@ -215,90 +177,23 @@ func TestOpenCodeEdit(t *testing.T) {
 }
 
 func TestBuildModelEntries(t *testing.T) {
-	t.Run("defaults to model name when capabilities cannot be probed", func(t *testing.T) {
-		models := buildModelEntries(context.Background(), nil, []string{"llama3.2"})
+	t.Run("defaults to model name without capabilities", func(t *testing.T) {
+		models := buildModelEntries(testLaunchModels("llama3.2"))
 		entry, _ := models["llama3.2"].(map[string]any)
 		if entry["name"] != "llama3.2" {
 			t.Fatalf("name = %v, want llama3.2", entry["name"])
 		}
 		if _, ok := entry["modalities"]; ok {
-			t.Fatalf("modalities should not be set without an API client, got %v", entry["modalities"])
-		}
-		if _, ok := entry["reasoning"]; ok {
-			t.Fatalf("reasoning should not be set without an API client, got %v", entry["reasoning"])
+			t.Fatalf("modalities should not be set without capabilities, got %v", entry["modalities"])
 		}
 	})
 
-	t.Run("uses one timeout budget across capability probes", func(t *testing.T) {
-		u, err := url.Parse("http://ollama.example")
-		if err != nil {
-			t.Fatalf("parse test URL: %v", err)
-		}
-
-		var mu sync.Mutex
-		waited := 0
-
-		client := api.NewClient(u, &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-			mu.Lock()
-			if req.Context().Err() == nil {
-				waited++
-			}
-			mu.Unlock()
-
-			<-req.Context().Done()
-			return nil, req.Context().Err()
-		})})
-
-		ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
-		defer cancel()
-
-		models := buildModelEntries(ctx, client, []string{"slow-1", "slow-2"})
-		for _, modelID := range []string{"slow-1", "slow-2"} {
-			entry, _ := models[modelID].(map[string]any)
-			if entry["name"] != modelID {
-				t.Fatalf("name for %q = %v, want %q", modelID, entry["name"], modelID)
-			}
-			if _, ok := entry["modalities"]; ok {
-				t.Fatalf("modalities for %q should not be set after probe timeout, got %v", modelID, entry["modalities"])
-			}
-		}
-
-		mu.Lock()
-		defer mu.Unlock()
-		if waited != 1 {
-			t.Fatalf("expected shared timeout to block one probe, waited on %d probes", waited)
-		}
-	})
-}
-
-func TestBuildModelEntriesTimeoutWithBackgroundContext(t *testing.T) {
-	t.Run("uses timeout when probing capabilities with background context", func(t *testing.T) {
-		u, err := url.Parse("http://ollama.example")
-		if err != nil {
-			t.Fatalf("parse test URL: %v", err)
-		}
-
-		client := api.NewClient(u, &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-			<-req.Context().Done()
-			return nil, req.Context().Err()
-		})})
-
-		done := make(chan map[string]any, 1)
-		go func() {
-			done <- buildModelEntries(context.Background(), client, []string{"gpt-oss:120b-cloud"})
-		}()
-
-		select {
-		case models := <-done:
-			entry, _ := models["gpt-oss:120b-cloud"].(map[string]any)
-			if _, ok := entry["reasoning"]; ok {
-				t.Fatalf("reasoning should not be set after timed out capability probe, got %v", entry["reasoning"])
-			}
-			if entry["limit"] == nil {
-				t.Fatalf("cloud model limit should still be set after timed out capability probe")
-			}
-		case <-time.After(openCodeModelShowTimeout + time.Second):
-			t.Fatalf("buildModelEntries did not return within %v", openCodeModelShowTimeout+time.Second)
+	t.Run("uses context and output limits from metadata", func(t *testing.T) {
+		models := buildModelEntries([]LaunchModel{{Name: "glm-5:cloud", ContextLength: 202_752, MaxOutputTokens: 131_072}})
+		entry, _ := models["glm-5:cloud"].(map[string]any)
+		limit, _ := entry["limit"].(map[string]any)
+		if limit["context"] != 202_752 || limit["output"] != 131_072 {
+			t.Fatalf("limit = %v, want context/output", limit)
 		}
 	})
 }
@@ -385,133 +280,6 @@ func TestLookupCloudModelLimit(t *testing.T) {
 	}
 }
 
-// inlineConfigModel extracts a model entry from the inline config content.
-func inlineConfigModel(t *testing.T, content, model string) map[string]any {
-	t.Helper()
-	var cfg map[string]any
-	if err := json.Unmarshal([]byte(content), &cfg); err != nil {
-		t.Fatalf("configContent is not valid JSON: %v", err)
-	}
-	provider, _ := cfg["provider"].(map[string]any)
-	ollama, _ := provider["ollama"].(map[string]any)
-	models, _ := ollama["models"].(map[string]any)
-	entry, ok := models[model].(map[string]any)
-	if !ok {
-		t.Fatalf("model %s not found in inline config", model)
-	}
-	return entry
-}
-
-func TestOpenCodeEdit_ReasoningOnThinkingModel(t *testing.T) {
-	setTestHome(t, t.TempDir())
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/api/show" {
-			fmt.Fprintf(w, `{"capabilities":["thinking"],"model_info":{}}`)
-			return
-		}
-		w.WriteHeader(http.StatusNotFound)
-	}))
-	defer srv.Close()
-	t.Setenv("OLLAMA_HOST", srv.URL)
-
-	o := &OpenCode{}
-	if err := o.Edit([]string{"qwq"}); err != nil {
-		t.Fatal(err)
-	}
-
-	entry := inlineConfigModel(t, o.configContent, "qwq")
-	if entry["reasoning"] != true {
-		t.Error("expected reasoning = true for thinking model")
-	}
-	variants, ok := entry["variants"].(map[string]any)
-	if !ok {
-		t.Fatal("expected variants to be set")
-	}
-	none, ok := variants["none"].(map[string]any)
-	if !ok {
-		t.Fatal("expected none variant to be set")
-	}
-	if none["reasoningEffort"] != "none" {
-		t.Errorf("none variant reasoningEffort = %v, want none", none["reasoningEffort"])
-	}
-	// Built-in low/medium/high should be disabled
-	for _, level := range []string{"low", "medium", "high"} {
-		v, ok := variants[level].(map[string]any)
-		if !ok {
-			t.Errorf("expected %s variant to exist", level)
-			continue
-		}
-		if v["disabled"] != true {
-			t.Errorf("expected %s variant to be disabled", level)
-		}
-	}
-}
-
-func TestOpenCodeEdit_ReasoningLevelsOnGptOss(t *testing.T) {
-	setTestHome(t, t.TempDir())
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/api/show" {
-			fmt.Fprintf(w, `{"capabilities":["thinking"],"model_info":{}}`)
-			return
-		}
-		w.WriteHeader(http.StatusNotFound)
-	}))
-	defer srv.Close()
-	t.Setenv("OLLAMA_HOST", srv.URL)
-
-	o := &OpenCode{}
-	if err := o.Edit([]string{"gpt-oss:120b-cloud"}); err != nil {
-		t.Fatal(err)
-	}
-
-	entry := inlineConfigModel(t, o.configContent, "gpt-oss:120b-cloud")
-	if entry["reasoning"] != true {
-		t.Error("expected reasoning = true")
-	}
-	// GPT-OSS cannot turn thinking off and supports levels,
-	// so no custom variants should be written.
-	if entry["variants"] != nil {
-		t.Errorf("expected no variants for gpt-oss, got %v", entry["variants"])
-	}
-	// Should default to medium reasoning effort
-	opts, ok := entry["options"].(map[string]any)
-	if !ok {
-		t.Fatal("expected options to be set for gpt-oss")
-	}
-	if opts["reasoningEffort"] != "medium" {
-		t.Errorf("reasoningEffort = %v, want medium", opts["reasoningEffort"])
-	}
-}
-
-func TestOpenCodeEdit_NoReasoningOnNonThinkingModel(t *testing.T) {
-	setTestHome(t, t.TempDir())
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/api/show" {
-			fmt.Fprintf(w, `{"capabilities":[],"model_info":{}}`)
-			return
-		}
-		w.WriteHeader(http.StatusNotFound)
-	}))
-	defer srv.Close()
-	t.Setenv("OLLAMA_HOST", srv.URL)
-
-	o := &OpenCode{}
-	if err := o.Edit([]string{"llama3.2"}); err != nil {
-		t.Fatal(err)
-	}
-
-	entry := inlineConfigModel(t, o.configContent, "llama3.2")
-	if entry["reasoning"] != nil {
-		t.Errorf("expected no reasoning for non-thinking model, got %v", entry["reasoning"])
-	}
-	if entry["variants"] != nil {
-		t.Errorf("expected no variants for non-thinking model, got %v", entry["variants"])
-	}
-}
-
 func TestFindOpenCode(t *testing.T) {
 	t.Run("fallback to ~/.opencode/bin", func(t *testing.T) {
 		tmpDir := t.TempDir()
@@ -555,7 +323,7 @@ func TestOpenCodeEdit_CloudModelLimitStructure(t *testing.T) {
 
 	expected := cloudModelLimits["glm-4.7"]
 
-	if err := o.Edit([]string{"glm-4.7:cloud"}); err != nil {
+	if err := o.Edit(testLaunchModels("glm-4.7:cloud")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -585,7 +353,7 @@ func TestOpenCodeEdit_SpecialCharsInModelName(t *testing.T) {
 
 	specialModel := `model-with-"quotes"`
 
-	err := o.Edit([]string{specialModel})
+	err := o.Edit(testLaunchModels(specialModel))
 	if err != nil {
 		t.Fatalf("Edit with special chars failed: %v", err)
 	}
@@ -678,7 +446,7 @@ func TestOpenCodeResolveContent(t *testing.T) {
 		setTestHome(t, tmpDir)
 
 		o := &OpenCode{}
-		if err := o.Edit([]string{"gemma4"}); err != nil {
+		if err := o.Edit(testLaunchModels("gemma4")); err != nil {
 			t.Fatal(err)
 		}
 		editContent := o.configContent
@@ -693,7 +461,7 @@ func TestOpenCodeResolveContent(t *testing.T) {
 		data, _ := json.MarshalIndent(state, "", "  ")
 		os.WriteFile(filepath.Join(stateDir, "model.json"), data, 0o644)
 
-		got := o.resolveContent("gemma4")
+		got := o.resolveContent("gemma4", nil)
 		if got != editContent {
 			t.Errorf("resolveContent returned different content than Edit set\ngot:  %s\nwant: %s", got, editContent)
 		}
@@ -715,7 +483,7 @@ func TestOpenCodeResolveContent(t *testing.T) {
 		os.WriteFile(filepath.Join(stateDir, "model.json"), data, 0o644)
 
 		o := &OpenCode{}
-		content := o.resolveContent("llama3.2")
+		content := o.resolveContent("llama3.2", nil)
 		if content == "" {
 			t.Fatal("resolveContent returned empty")
 		}
@@ -749,7 +517,7 @@ func TestOpenCodeResolveContent(t *testing.T) {
 		os.WriteFile(filepath.Join(stateDir, "model.json"), data, 0o644)
 
 		o := &OpenCode{}
-		content := o.resolveContent("qwen3:32b")
+		content := o.resolveContent("qwen3:32b", nil)
 
 		var cfg map[string]any
 		json.Unmarshal([]byte(content), &cfg)
@@ -773,7 +541,7 @@ func TestOpenCodeResolveContent(t *testing.T) {
 		os.WriteFile(filepath.Join(stateDir, "model.json"), data, 0o644)
 
 		o := &OpenCode{}
-		content := o.resolveContent("gemma4")
+		content := o.resolveContent("gemma4", nil)
 
 		var cfg map[string]any
 		json.Unmarshal([]byte(content), &cfg)
@@ -793,8 +561,53 @@ func TestOpenCodeResolveContent(t *testing.T) {
 		setTestHome(t, tmpDir)
 
 		o := &OpenCode{}
-		if got := o.resolveContent(""); got != "" {
+		if got := o.resolveContent("", nil); got != "" {
 			t.Errorf("resolveContent(\"\") = %q, want empty", got)
+		}
+	})
+
+	t.Run("uses run model metadata when Edit was not called", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setTestHome(t, tmpDir)
+
+		stateDir := filepath.Join(tmpDir, ".local", "state", "opencode")
+		os.MkdirAll(stateDir, 0o755)
+		state := map[string]any{
+			"recent": []any{
+				map[string]any{"providerID": "ollama", "modelID": "llama3.2"},
+			},
+		}
+		data, _ := json.MarshalIndent(state, "", "  ")
+		os.WriteFile(filepath.Join(stateDir, "model.json"), data, 0o644)
+
+		o := &OpenCode{}
+		content := o.resolveContent("gemma4", []LaunchModel{
+			{
+				Name:            "gemma4",
+				Capabilities:    []model.Capability{model.CapabilityVision},
+				ContextLength:   65_536,
+				MaxOutputTokens: 8_192,
+			},
+		})
+		if content == "" {
+			t.Fatal("resolveContent returned empty")
+		}
+
+		var cfg map[string]any
+		json.Unmarshal([]byte(content), &cfg)
+		provider, _ := cfg["provider"].(map[string]any)
+		ollama, _ := provider["ollama"].(map[string]any)
+		cfgModels, _ := ollama["models"].(map[string]any)
+		entry, _ := cfgModels["gemma4"].(map[string]any)
+		limit, _ := entry["limit"].(map[string]any)
+		if limit["context"] != float64(65_536) || limit["output"] != float64(8_192) {
+			t.Fatalf("limit = %v, want context/output from launch metadata", limit)
+		}
+		if _, ok := entry["modalities"].(map[string]any); !ok {
+			t.Fatalf("modalities should be set from launch metadata, got %v", entry["modalities"])
+		}
+		if cfgModels["llama3.2"] == nil {
+			t.Fatalf("state model missing from fallback config: %v", cfgModels)
 		}
 	})
 
@@ -813,7 +626,7 @@ func TestOpenCodeResolveContent(t *testing.T) {
 		os.WriteFile(filepath.Join(stateDir, "model.json"), data, 0o644)
 
 		o := &OpenCode{}
-		_ = o.resolveContent("llama3.2")
+		_ = o.resolveContent("llama3.2", nil)
 		if o.configContent != "" {
 			t.Errorf("resolveContent should not mutate configContent, got %q", o.configContent)
 		}
@@ -822,19 +635,19 @@ func TestOpenCodeResolveContent(t *testing.T) {
 
 func TestBuildInlineConfig(t *testing.T) {
 	t.Run("returns error for empty primary", func(t *testing.T) {
-		if _, err := buildInlineConfig("", []string{"llama3.2"}); err == nil {
+		if _, err := buildInlineConfig(LaunchModel{}, testLaunchModels("llama3.2")); err == nil {
 			t.Error("expected error for empty primary")
 		}
 	})
 
 	t.Run("returns error for empty models", func(t *testing.T) {
-		if _, err := buildInlineConfig("llama3.2", nil); err == nil {
+		if _, err := buildInlineConfig(fallbackLaunchModel("llama3.2"), nil); err == nil {
 			t.Error("expected error for empty models")
 		}
 	})
 
 	t.Run("primary differs from first model in list", func(t *testing.T) {
-		content, err := buildInlineConfig("qwen3:32b", []string{"llama3.2", "qwen3:32b"})
+		content, err := buildInlineConfig(fallbackLaunchModel("qwen3:32b"), testLaunchModels("llama3.2", "qwen3:32b"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -863,7 +676,7 @@ func TestOpenCodeEdit_PreservesRecentEntries(t *testing.T) {
 		os.WriteFile(filepath.Join(stateDir, "model.json"), data, 0o644)
 
 		o := &OpenCode{}
-		if err := o.Edit([]string{"new-X"}); err != nil {
+		if err := o.Edit(testLaunchModels("new-X")); err != nil {
 			t.Fatal(err)
 		}
 
@@ -897,7 +710,7 @@ func TestOpenCodeEdit_PreservesRecentEntries(t *testing.T) {
 		os.WriteFile(filepath.Join(stateDir, "model.json"), data, 0o644)
 
 		o := &OpenCode{}
-		if err := o.Edit([]string{"X", "Y", "Z"}); err != nil {
+		if err := o.Edit(testLaunchModels("X", "Y", "Z")); err != nil {
 			t.Fatal(err)
 		}
 
@@ -934,7 +747,7 @@ func TestOpenCodeEdit_PreservesRecentEntries(t *testing.T) {
 		os.WriteFile(filepath.Join(stateDir, "model.json"), data, 0o644)
 
 		o := &OpenCode{}
-		if err := o.Edit([]string{"qwen3:32b"}); err != nil {
+		if err := o.Edit(testLaunchModels("qwen3:32b")); err != nil {
 			t.Fatal(err)
 		}
 
@@ -971,7 +784,7 @@ func TestOpenCodeEdit_PreservesRecentEntries(t *testing.T) {
 		os.WriteFile(filepath.Join(stateDir, "model.json"), data, 0o644)
 
 		o := &OpenCode{}
-		if err := o.Edit([]string{"llama3.2"}); err != nil {
+		if err := o.Edit(testLaunchModels("llama3.2")); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1013,7 +826,7 @@ func TestOpenCodeEdit_PreservesRecentEntries(t *testing.T) {
 
 		// Add 5 new models — should cap at 10 total
 		o := &OpenCode{}
-		if err := o.Edit([]string{"new-0", "new-1", "new-2", "new-3", "new-4"}); err != nil {
+		if err := o.Edit(testLaunchModels("new-0", "new-1", "new-2", "new-3", "new-4")); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1034,7 +847,7 @@ func TestOpenCodeEdit_BaseURL(t *testing.T) {
 	setTestHome(t, tmpDir)
 
 	// Default OLLAMA_HOST
-	o.Edit([]string{"llama3.2"})
+	o.Edit(testLaunchModels("llama3.2"))
 
 	var cfg map[string]any
 	json.Unmarshal([]byte(o.configContent), &cfg)

--- a/cmd/launch/opencode_test.go
+++ b/cmd/launch/opencode_test.go
@@ -245,6 +245,14 @@ func TestBuildModelEntries(t *testing.T) {
 			t.Fatalf("limit = %v, want context/output", limit)
 		}
 	})
+
+	t.Run("omits context-only limits", func(t *testing.T) {
+		models := buildModelEntries([]LaunchModel{{Name: "qwen2.5:0.5b", ContextLength: 32768}})
+		entry, _ := models["qwen2.5:0.5b"].(map[string]any)
+		if _, ok := entry["limit"]; ok {
+			t.Fatalf("limit should be omitted when output limit is unknown, got %v", entry["limit"])
+		}
+	})
 }
 
 func TestOpenCodeModels_ReturnsNil(t *testing.T) {

--- a/cmd/launch/opencode_test.go
+++ b/cmd/launch/opencode_test.go
@@ -1,14 +1,22 @@
 package launch
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
-	"github.com/ollama/ollama/types/model"
+	"github.com/ollama/ollama/api"
 )
 
 func TestOpenCodeIntegration(t *testing.T) {
@@ -33,7 +41,7 @@ func TestOpenCodeEdit(t *testing.T) {
 	t.Run("builds config content with provider", func(t *testing.T) {
 		setTestHome(t, t.TempDir())
 		o := &OpenCode{}
-		if err := o.Edit(testLaunchModels("llama3.2")); err != nil {
+		if err := o.Edit([]string{"llama3.2"}); err != nil {
 			t.Fatal(err)
 		}
 
@@ -67,7 +75,7 @@ func TestOpenCodeEdit(t *testing.T) {
 	t.Run("multiple models", func(t *testing.T) {
 		setTestHome(t, t.TempDir())
 		o := &OpenCode{}
-		if err := o.Edit(testLaunchModels("llama3.2", "qwen3:32b")); err != nil {
+		if err := o.Edit([]string{"llama3.2", "qwen3:32b"}); err != nil {
 			t.Fatal(err)
 		}
 
@@ -92,7 +100,7 @@ func TestOpenCodeEdit(t *testing.T) {
 	t.Run("empty models is no-op", func(t *testing.T) {
 		setTestHome(t, t.TempDir())
 		o := &OpenCode{}
-		if err := o.Edit(testLaunchModels()); err != nil {
+		if err := o.Edit([]string{}); err != nil {
 			t.Fatal(err)
 		}
 		if o.configContent != "" {
@@ -104,7 +112,7 @@ func TestOpenCodeEdit(t *testing.T) {
 		tmpDir := t.TempDir()
 		setTestHome(t, tmpDir)
 		o := &OpenCode{}
-		o.Edit(testLaunchModels("llama3.2"))
+		o.Edit([]string{"llama3.2"})
 
 		configDir := filepath.Join(tmpDir, ".config", "opencode")
 
@@ -119,7 +127,7 @@ func TestOpenCodeEdit(t *testing.T) {
 	t.Run("cloud model has limits", func(t *testing.T) {
 		setTestHome(t, t.TempDir())
 		o := &OpenCode{}
-		if err := o.Edit(testLaunchModels("glm-4.7:cloud")); err != nil {
+		if err := o.Edit([]string{"glm-4.7:cloud"}); err != nil {
 			t.Fatal(err)
 		}
 
@@ -146,7 +154,7 @@ func TestOpenCodeEdit(t *testing.T) {
 	t.Run("local model has no limits", func(t *testing.T) {
 		setTestHome(t, t.TempDir())
 		o := &OpenCode{}
-		o.Edit(testLaunchModels("llama3.2"))
+		o.Edit([]string{"llama3.2"})
 
 		var cfg map[string]any
 		json.Unmarshal([]byte(o.configContent), &cfg)
@@ -161,7 +169,37 @@ func TestOpenCodeEdit(t *testing.T) {
 	})
 
 	t.Run("vision model gets image input modalities", func(t *testing.T) {
-		models := buildModelEntries([]LaunchModel{{Name: "gemma4:26b", Capabilities: []model.Capability{"vision"}}})
+		u, err := url.Parse("http://ollama.example")
+		if err != nil {
+			t.Fatalf("parse test URL: %v", err)
+		}
+		client := api.NewClient(u, &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.URL.Path != "/api/show" {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader("not found")),
+					Header:     make(http.Header),
+				}, nil
+			}
+
+			var body struct {
+				Model string `json:"model"`
+			}
+			if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+				t.Fatalf("decode show request: %v", err)
+			}
+			if body.Model != "gemma4:26b" {
+				t.Fatalf("show request model = %q, want gemma4:26b", body.Model)
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"capabilities":["vision"],"model_info":{}}`)),
+				Header:     make(http.Header),
+			}, nil
+		})})
+
+		models := buildModelEntries(context.Background(), client, []string{"gemma4:26b"})
 		entry, _ := models["gemma4:26b"].(map[string]any)
 		modalities, _ := entry["modalities"].(map[string]any)
 		input, _ := modalities["input"].([]string)
@@ -177,31 +215,90 @@ func TestOpenCodeEdit(t *testing.T) {
 }
 
 func TestBuildModelEntries(t *testing.T) {
-	t.Run("defaults to model name without capabilities", func(t *testing.T) {
-		models := buildModelEntries(testLaunchModels("llama3.2"))
+	t.Run("defaults to model name when capabilities cannot be probed", func(t *testing.T) {
+		models := buildModelEntries(context.Background(), nil, []string{"llama3.2"})
 		entry, _ := models["llama3.2"].(map[string]any)
 		if entry["name"] != "llama3.2" {
 			t.Fatalf("name = %v, want llama3.2", entry["name"])
 		}
 		if _, ok := entry["modalities"]; ok {
-			t.Fatalf("modalities should not be set without capabilities, got %v", entry["modalities"])
+			t.Fatalf("modalities should not be set without an API client, got %v", entry["modalities"])
+		}
+		if _, ok := entry["reasoning"]; ok {
+			t.Fatalf("reasoning should not be set without an API client, got %v", entry["reasoning"])
 		}
 	})
 
-	t.Run("uses context and output limits from metadata", func(t *testing.T) {
-		models := buildModelEntries([]LaunchModel{{Name: "glm-5:cloud", ContextLength: 202_752, MaxOutputTokens: 131_072}})
-		entry, _ := models["glm-5:cloud"].(map[string]any)
-		limit, _ := entry["limit"].(map[string]any)
-		if limit["context"] != 202_752 || limit["output"] != 131_072 {
-			t.Fatalf("limit = %v, want context/output", limit)
+	t.Run("uses one timeout budget across capability probes", func(t *testing.T) {
+		u, err := url.Parse("http://ollama.example")
+		if err != nil {
+			t.Fatalf("parse test URL: %v", err)
+		}
+
+		var mu sync.Mutex
+		waited := 0
+
+		client := api.NewClient(u, &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			mu.Lock()
+			if req.Context().Err() == nil {
+				waited++
+			}
+			mu.Unlock()
+
+			<-req.Context().Done()
+			return nil, req.Context().Err()
+		})})
+
+		ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+		defer cancel()
+
+		models := buildModelEntries(ctx, client, []string{"slow-1", "slow-2"})
+		for _, modelID := range []string{"slow-1", "slow-2"} {
+			entry, _ := models[modelID].(map[string]any)
+			if entry["name"] != modelID {
+				t.Fatalf("name for %q = %v, want %q", modelID, entry["name"], modelID)
+			}
+			if _, ok := entry["modalities"]; ok {
+				t.Fatalf("modalities for %q should not be set after probe timeout, got %v", modelID, entry["modalities"])
+			}
+		}
+
+		mu.Lock()
+		defer mu.Unlock()
+		if waited != 1 {
+			t.Fatalf("expected shared timeout to block one probe, waited on %d probes", waited)
 		}
 	})
+}
 
-	t.Run("omits context-only limits", func(t *testing.T) {
-		models := buildModelEntries([]LaunchModel{{Name: "qwen2.5:0.5b", ContextLength: 32768}})
-		entry, _ := models["qwen2.5:0.5b"].(map[string]any)
-		if _, ok := entry["limit"]; ok {
-			t.Fatalf("limit should be omitted when output limit is unknown, got %v", entry["limit"])
+func TestBuildModelEntriesTimeoutWithBackgroundContext(t *testing.T) {
+	t.Run("uses timeout when probing capabilities with background context", func(t *testing.T) {
+		u, err := url.Parse("http://ollama.example")
+		if err != nil {
+			t.Fatalf("parse test URL: %v", err)
+		}
+
+		client := api.NewClient(u, &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			<-req.Context().Done()
+			return nil, req.Context().Err()
+		})})
+
+		done := make(chan map[string]any, 1)
+		go func() {
+			done <- buildModelEntries(context.Background(), client, []string{"gpt-oss:120b-cloud"})
+		}()
+
+		select {
+		case models := <-done:
+			entry, _ := models["gpt-oss:120b-cloud"].(map[string]any)
+			if _, ok := entry["reasoning"]; ok {
+				t.Fatalf("reasoning should not be set after timed out capability probe, got %v", entry["reasoning"])
+			}
+			if entry["limit"] == nil {
+				t.Fatalf("cloud model limit should still be set after timed out capability probe")
+			}
+		case <-time.After(openCodeModelShowTimeout + time.Second):
+			t.Fatalf("buildModelEntries did not return within %v", openCodeModelShowTimeout+time.Second)
 		}
 	})
 }
@@ -288,6 +385,133 @@ func TestLookupCloudModelLimit(t *testing.T) {
 	}
 }
 
+// inlineConfigModel extracts a model entry from the inline config content.
+func inlineConfigModel(t *testing.T, content, model string) map[string]any {
+	t.Helper()
+	var cfg map[string]any
+	if err := json.Unmarshal([]byte(content), &cfg); err != nil {
+		t.Fatalf("configContent is not valid JSON: %v", err)
+	}
+	provider, _ := cfg["provider"].(map[string]any)
+	ollama, _ := provider["ollama"].(map[string]any)
+	models, _ := ollama["models"].(map[string]any)
+	entry, ok := models[model].(map[string]any)
+	if !ok {
+		t.Fatalf("model %s not found in inline config", model)
+	}
+	return entry
+}
+
+func TestOpenCodeEdit_ReasoningOnThinkingModel(t *testing.T) {
+	setTestHome(t, t.TempDir())
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/show" {
+			fmt.Fprintf(w, `{"capabilities":["thinking"],"model_info":{}}`)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	t.Setenv("OLLAMA_HOST", srv.URL)
+
+	o := &OpenCode{}
+	if err := o.Edit([]string{"qwq"}); err != nil {
+		t.Fatal(err)
+	}
+
+	entry := inlineConfigModel(t, o.configContent, "qwq")
+	if entry["reasoning"] != true {
+		t.Error("expected reasoning = true for thinking model")
+	}
+	variants, ok := entry["variants"].(map[string]any)
+	if !ok {
+		t.Fatal("expected variants to be set")
+	}
+	none, ok := variants["none"].(map[string]any)
+	if !ok {
+		t.Fatal("expected none variant to be set")
+	}
+	if none["reasoningEffort"] != "none" {
+		t.Errorf("none variant reasoningEffort = %v, want none", none["reasoningEffort"])
+	}
+	// Built-in low/medium/high should be disabled
+	for _, level := range []string{"low", "medium", "high"} {
+		v, ok := variants[level].(map[string]any)
+		if !ok {
+			t.Errorf("expected %s variant to exist", level)
+			continue
+		}
+		if v["disabled"] != true {
+			t.Errorf("expected %s variant to be disabled", level)
+		}
+	}
+}
+
+func TestOpenCodeEdit_ReasoningLevelsOnGptOss(t *testing.T) {
+	setTestHome(t, t.TempDir())
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/show" {
+			fmt.Fprintf(w, `{"capabilities":["thinking"],"model_info":{}}`)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	t.Setenv("OLLAMA_HOST", srv.URL)
+
+	o := &OpenCode{}
+	if err := o.Edit([]string{"gpt-oss:120b-cloud"}); err != nil {
+		t.Fatal(err)
+	}
+
+	entry := inlineConfigModel(t, o.configContent, "gpt-oss:120b-cloud")
+	if entry["reasoning"] != true {
+		t.Error("expected reasoning = true")
+	}
+	// GPT-OSS cannot turn thinking off and supports levels,
+	// so no custom variants should be written.
+	if entry["variants"] != nil {
+		t.Errorf("expected no variants for gpt-oss, got %v", entry["variants"])
+	}
+	// Should default to medium reasoning effort
+	opts, ok := entry["options"].(map[string]any)
+	if !ok {
+		t.Fatal("expected options to be set for gpt-oss")
+	}
+	if opts["reasoningEffort"] != "medium" {
+		t.Errorf("reasoningEffort = %v, want medium", opts["reasoningEffort"])
+	}
+}
+
+func TestOpenCodeEdit_NoReasoningOnNonThinkingModel(t *testing.T) {
+	setTestHome(t, t.TempDir())
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/show" {
+			fmt.Fprintf(w, `{"capabilities":[],"model_info":{}}`)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	t.Setenv("OLLAMA_HOST", srv.URL)
+
+	o := &OpenCode{}
+	if err := o.Edit([]string{"llama3.2"}); err != nil {
+		t.Fatal(err)
+	}
+
+	entry := inlineConfigModel(t, o.configContent, "llama3.2")
+	if entry["reasoning"] != nil {
+		t.Errorf("expected no reasoning for non-thinking model, got %v", entry["reasoning"])
+	}
+	if entry["variants"] != nil {
+		t.Errorf("expected no variants for non-thinking model, got %v", entry["variants"])
+	}
+}
+
 func TestFindOpenCode(t *testing.T) {
 	t.Run("fallback to ~/.opencode/bin", func(t *testing.T) {
 		tmpDir := t.TempDir()
@@ -331,7 +555,7 @@ func TestOpenCodeEdit_CloudModelLimitStructure(t *testing.T) {
 
 	expected := cloudModelLimits["glm-4.7"]
 
-	if err := o.Edit(testLaunchModels("glm-4.7:cloud")); err != nil {
+	if err := o.Edit([]string{"glm-4.7:cloud"}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -361,7 +585,7 @@ func TestOpenCodeEdit_SpecialCharsInModelName(t *testing.T) {
 
 	specialModel := `model-with-"quotes"`
 
-	err := o.Edit(testLaunchModels(specialModel))
+	err := o.Edit([]string{specialModel})
 	if err != nil {
 		t.Fatalf("Edit with special chars failed: %v", err)
 	}
@@ -454,7 +678,7 @@ func TestOpenCodeResolveContent(t *testing.T) {
 		setTestHome(t, tmpDir)
 
 		o := &OpenCode{}
-		if err := o.Edit(testLaunchModels("gemma4")); err != nil {
+		if err := o.Edit([]string{"gemma4"}); err != nil {
 			t.Fatal(err)
 		}
 		editContent := o.configContent
@@ -469,7 +693,7 @@ func TestOpenCodeResolveContent(t *testing.T) {
 		data, _ := json.MarshalIndent(state, "", "  ")
 		os.WriteFile(filepath.Join(stateDir, "model.json"), data, 0o644)
 
-		got := o.resolveContent("gemma4", nil)
+		got := o.resolveContent("gemma4")
 		if got != editContent {
 			t.Errorf("resolveContent returned different content than Edit set\ngot:  %s\nwant: %s", got, editContent)
 		}
@@ -491,7 +715,7 @@ func TestOpenCodeResolveContent(t *testing.T) {
 		os.WriteFile(filepath.Join(stateDir, "model.json"), data, 0o644)
 
 		o := &OpenCode{}
-		content := o.resolveContent("llama3.2", nil)
+		content := o.resolveContent("llama3.2")
 		if content == "" {
 			t.Fatal("resolveContent returned empty")
 		}
@@ -525,7 +749,7 @@ func TestOpenCodeResolveContent(t *testing.T) {
 		os.WriteFile(filepath.Join(stateDir, "model.json"), data, 0o644)
 
 		o := &OpenCode{}
-		content := o.resolveContent("qwen3:32b", nil)
+		content := o.resolveContent("qwen3:32b")
 
 		var cfg map[string]any
 		json.Unmarshal([]byte(content), &cfg)
@@ -549,7 +773,7 @@ func TestOpenCodeResolveContent(t *testing.T) {
 		os.WriteFile(filepath.Join(stateDir, "model.json"), data, 0o644)
 
 		o := &OpenCode{}
-		content := o.resolveContent("gemma4", nil)
+		content := o.resolveContent("gemma4")
 
 		var cfg map[string]any
 		json.Unmarshal([]byte(content), &cfg)
@@ -569,53 +793,8 @@ func TestOpenCodeResolveContent(t *testing.T) {
 		setTestHome(t, tmpDir)
 
 		o := &OpenCode{}
-		if got := o.resolveContent("", nil); got != "" {
+		if got := o.resolveContent(""); got != "" {
 			t.Errorf("resolveContent(\"\") = %q, want empty", got)
-		}
-	})
-
-	t.Run("uses run model metadata when Edit was not called", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		setTestHome(t, tmpDir)
-
-		stateDir := filepath.Join(tmpDir, ".local", "state", "opencode")
-		os.MkdirAll(stateDir, 0o755)
-		state := map[string]any{
-			"recent": []any{
-				map[string]any{"providerID": "ollama", "modelID": "llama3.2"},
-			},
-		}
-		data, _ := json.MarshalIndent(state, "", "  ")
-		os.WriteFile(filepath.Join(stateDir, "model.json"), data, 0o644)
-
-		o := &OpenCode{}
-		content := o.resolveContent("gemma4", []LaunchModel{
-			{
-				Name:            "gemma4",
-				Capabilities:    []model.Capability{model.CapabilityVision},
-				ContextLength:   65_536,
-				MaxOutputTokens: 8_192,
-			},
-		})
-		if content == "" {
-			t.Fatal("resolveContent returned empty")
-		}
-
-		var cfg map[string]any
-		json.Unmarshal([]byte(content), &cfg)
-		provider, _ := cfg["provider"].(map[string]any)
-		ollama, _ := provider["ollama"].(map[string]any)
-		cfgModels, _ := ollama["models"].(map[string]any)
-		entry, _ := cfgModels["gemma4"].(map[string]any)
-		limit, _ := entry["limit"].(map[string]any)
-		if limit["context"] != float64(65_536) || limit["output"] != float64(8_192) {
-			t.Fatalf("limit = %v, want context/output from launch metadata", limit)
-		}
-		if _, ok := entry["modalities"].(map[string]any); !ok {
-			t.Fatalf("modalities should be set from launch metadata, got %v", entry["modalities"])
-		}
-		if cfgModels["llama3.2"] == nil {
-			t.Fatalf("state model missing from fallback config: %v", cfgModels)
 		}
 	})
 
@@ -634,7 +813,7 @@ func TestOpenCodeResolveContent(t *testing.T) {
 		os.WriteFile(filepath.Join(stateDir, "model.json"), data, 0o644)
 
 		o := &OpenCode{}
-		_ = o.resolveContent("llama3.2", nil)
+		_ = o.resolveContent("llama3.2")
 		if o.configContent != "" {
 			t.Errorf("resolveContent should not mutate configContent, got %q", o.configContent)
 		}
@@ -643,19 +822,19 @@ func TestOpenCodeResolveContent(t *testing.T) {
 
 func TestBuildInlineConfig(t *testing.T) {
 	t.Run("returns error for empty primary", func(t *testing.T) {
-		if _, err := buildInlineConfig(LaunchModel{}, testLaunchModels("llama3.2")); err == nil {
+		if _, err := buildInlineConfig("", []string{"llama3.2"}); err == nil {
 			t.Error("expected error for empty primary")
 		}
 	})
 
 	t.Run("returns error for empty models", func(t *testing.T) {
-		if _, err := buildInlineConfig(fallbackLaunchModel("llama3.2"), nil); err == nil {
+		if _, err := buildInlineConfig("llama3.2", nil); err == nil {
 			t.Error("expected error for empty models")
 		}
 	})
 
 	t.Run("primary differs from first model in list", func(t *testing.T) {
-		content, err := buildInlineConfig(fallbackLaunchModel("qwen3:32b"), testLaunchModels("llama3.2", "qwen3:32b"))
+		content, err := buildInlineConfig("qwen3:32b", []string{"llama3.2", "qwen3:32b"})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -684,7 +863,7 @@ func TestOpenCodeEdit_PreservesRecentEntries(t *testing.T) {
 		os.WriteFile(filepath.Join(stateDir, "model.json"), data, 0o644)
 
 		o := &OpenCode{}
-		if err := o.Edit(testLaunchModels("new-X")); err != nil {
+		if err := o.Edit([]string{"new-X"}); err != nil {
 			t.Fatal(err)
 		}
 
@@ -718,7 +897,7 @@ func TestOpenCodeEdit_PreservesRecentEntries(t *testing.T) {
 		os.WriteFile(filepath.Join(stateDir, "model.json"), data, 0o644)
 
 		o := &OpenCode{}
-		if err := o.Edit(testLaunchModels("X", "Y", "Z")); err != nil {
+		if err := o.Edit([]string{"X", "Y", "Z"}); err != nil {
 			t.Fatal(err)
 		}
 
@@ -755,7 +934,7 @@ func TestOpenCodeEdit_PreservesRecentEntries(t *testing.T) {
 		os.WriteFile(filepath.Join(stateDir, "model.json"), data, 0o644)
 
 		o := &OpenCode{}
-		if err := o.Edit(testLaunchModels("qwen3:32b")); err != nil {
+		if err := o.Edit([]string{"qwen3:32b"}); err != nil {
 			t.Fatal(err)
 		}
 
@@ -792,7 +971,7 @@ func TestOpenCodeEdit_PreservesRecentEntries(t *testing.T) {
 		os.WriteFile(filepath.Join(stateDir, "model.json"), data, 0o644)
 
 		o := &OpenCode{}
-		if err := o.Edit(testLaunchModels("llama3.2")); err != nil {
+		if err := o.Edit([]string{"llama3.2"}); err != nil {
 			t.Fatal(err)
 		}
 
@@ -834,7 +1013,7 @@ func TestOpenCodeEdit_PreservesRecentEntries(t *testing.T) {
 
 		// Add 5 new models — should cap at 10 total
 		o := &OpenCode{}
-		if err := o.Edit(testLaunchModels("new-0", "new-1", "new-2", "new-3", "new-4")); err != nil {
+		if err := o.Edit([]string{"new-0", "new-1", "new-2", "new-3", "new-4"}); err != nil {
 			t.Fatal(err)
 		}
 
@@ -855,7 +1034,7 @@ func TestOpenCodeEdit_BaseURL(t *testing.T) {
 	setTestHome(t, tmpDir)
 
 	// Default OLLAMA_HOST
-	o.Edit(testLaunchModels("llama3.2"))
+	o.Edit([]string{"llama3.2"})
 
 	var cfg map[string]any
 	json.Unmarshal([]byte(o.configContent), &cfg)

--- a/cmd/launch/opencode_test.go
+++ b/cmd/launch/opencode_test.go
@@ -224,9 +224,6 @@ func TestBuildModelEntries(t *testing.T) {
 		if _, ok := entry["modalities"]; ok {
 			t.Fatalf("modalities should not be set without an API client, got %v", entry["modalities"])
 		}
-		if _, ok := entry["reasoning"]; ok {
-			t.Fatalf("reasoning should not be set without an API client, got %v", entry["reasoning"])
-		}
 	})
 
 	t.Run("uses one timeout budget across capability probes", func(t *testing.T) {
@@ -267,38 +264,6 @@ func TestBuildModelEntries(t *testing.T) {
 		defer mu.Unlock()
 		if waited != 1 {
 			t.Fatalf("expected shared timeout to block one probe, waited on %d probes", waited)
-		}
-	})
-}
-
-func TestBuildModelEntriesTimeoutWithBackgroundContext(t *testing.T) {
-	t.Run("uses timeout when probing capabilities with background context", func(t *testing.T) {
-		u, err := url.Parse("http://ollama.example")
-		if err != nil {
-			t.Fatalf("parse test URL: %v", err)
-		}
-
-		client := api.NewClient(u, &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-			<-req.Context().Done()
-			return nil, req.Context().Err()
-		})})
-
-		done := make(chan map[string]any, 1)
-		go func() {
-			done <- buildModelEntries(context.Background(), client, []string{"gpt-oss:120b-cloud"})
-		}()
-
-		select {
-		case models := <-done:
-			entry, _ := models["gpt-oss:120b-cloud"].(map[string]any)
-			if _, ok := entry["reasoning"]; ok {
-				t.Fatalf("reasoning should not be set after timed out capability probe, got %v", entry["reasoning"])
-			}
-			if entry["limit"] == nil {
-				t.Fatalf("cloud model limit should still be set after timed out capability probe")
-			}
-		case <-time.After(openCodeModelShowTimeout + time.Second):
-			t.Fatalf("buildModelEntries did not return within %v", openCodeModelShowTimeout+time.Second)
 		}
 	})
 }

--- a/cmd/launch/opencode_test.go
+++ b/cmd/launch/opencode_test.go
@@ -456,12 +456,12 @@ func TestOpenCodeEdit_ReasoningOnThinkingModel(t *testing.T) {
 	}
 }
 
-func TestOpenCodeEdit_ReasoningLevelsOnGptOssFamily(t *testing.T) {
+func TestOpenCodeEdit_ReasoningLevelsOnGptOss(t *testing.T) {
 	setTestHome(t, t.TempDir())
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/api/show" {
-			fmt.Fprintf(w, `{"capabilities":["thinking"],"details":{"family":"gptoss"},"model_info":{"general.architecture":"gptoss"}}`)
+			fmt.Fprintf(w, `{"capabilities":["thinking"],"model_info":{}}`)
 			return
 		}
 		w.WriteHeader(http.StatusNotFound)
@@ -470,23 +470,23 @@ func TestOpenCodeEdit_ReasoningLevelsOnGptOssFamily(t *testing.T) {
 	t.Setenv("OLLAMA_HOST", srv.URL)
 
 	o := &OpenCode{}
-	if err := o.Edit([]string{"my-gpt-alias"}); err != nil {
+	if err := o.Edit([]string{"gpt-oss:120b-cloud"}); err != nil {
 		t.Fatal(err)
 	}
 
-	entry := inlineConfigModel(t, o.configContent, "my-gpt-alias")
+	entry := inlineConfigModel(t, o.configContent, "gpt-oss:120b-cloud")
 	if entry["reasoning"] != true {
 		t.Error("expected reasoning = true")
 	}
-	// GPT-OSS cannot turn thinking off and supports levels, even when
-	// launched through an alias.
+	// GPT-OSS cannot turn thinking off and supports levels,
+	// so no custom variants should be written.
 	if entry["variants"] != nil {
-		t.Errorf("expected no variants for gpt-oss family, got %v", entry["variants"])
+		t.Errorf("expected no variants for gpt-oss, got %v", entry["variants"])
 	}
 	// Should default to medium reasoning effort
 	opts, ok := entry["options"].(map[string]any)
 	if !ok {
-		t.Fatal("expected options to be set for gpt-oss family")
+		t.Fatal("expected options to be set for gpt-oss")
 	}
 	if opts["reasoningEffort"] != "medium" {
 		t.Errorf("reasoningEffort = %v, want medium", opts["reasoningEffort"])

--- a/cmd/launch/opencode_test.go
+++ b/cmd/launch/opencode_test.go
@@ -268,6 +268,49 @@ func TestBuildModelEntries(t *testing.T) {
 	})
 }
 
+func TestBuildModelEntries(t *testing.T) {
+	t.Run("defaults to model name when capabilities cannot be probed", func(t *testing.T) {
+		models := buildModelEntries(context.Background(), nil, []string{"llama3.2"})
+		entry, _ := models["llama3.2"].(map[string]any)
+		if entry["name"] != "llama3.2" {
+			t.Fatalf("name = %v, want llama3.2", entry["name"])
+		}
+		if _, ok := entry["reasoning"]; ok {
+			t.Fatalf("reasoning should not be set without an API client, got %v", entry["reasoning"])
+		}
+	})
+
+	t.Run("uses timeout when probing capabilities with background context", func(t *testing.T) {
+		u, err := url.Parse("http://ollama.example")
+		if err != nil {
+			t.Fatalf("parse test URL: %v", err)
+		}
+
+		client := api.NewClient(u, &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			<-req.Context().Done()
+			return nil, req.Context().Err()
+		})})
+
+		done := make(chan map[string]any, 1)
+		go func() {
+			done <- buildModelEntries(context.Background(), client, []string{"gpt-oss:120b-cloud"})
+		}()
+
+		select {
+		case models := <-done:
+			entry, _ := models["gpt-oss:120b-cloud"].(map[string]any)
+			if _, ok := entry["reasoning"]; ok {
+				t.Fatalf("reasoning should not be set after timed out capability probe, got %v", entry["reasoning"])
+			}
+			if entry["limit"] == nil {
+				t.Fatalf("cloud model limit should still be set after timed out capability probe")
+			}
+		case <-time.After(openCodeModelShowTimeout + time.Second):
+			t.Fatalf("buildModelEntries did not return within %v", openCodeModelShowTimeout+time.Second)
+		}
+	})
+}
+
 func TestOpenCodeModels_ReturnsNil(t *testing.T) {
 	o := &OpenCode{}
 	if models := o.Models(); models != nil {
@@ -413,12 +456,12 @@ func TestOpenCodeEdit_ReasoningOnThinkingModel(t *testing.T) {
 	}
 }
 
-func TestOpenCodeEdit_ReasoningLevelsOnGptOss(t *testing.T) {
+func TestOpenCodeEdit_ReasoningLevelsOnGptOssFamily(t *testing.T) {
 	setTestHome(t, t.TempDir())
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/api/show" {
-			fmt.Fprintf(w, `{"capabilities":["thinking"],"model_info":{}}`)
+			fmt.Fprintf(w, `{"capabilities":["thinking"],"details":{"family":"gptoss"},"model_info":{"general.architecture":"gptoss"}}`)
 			return
 		}
 		w.WriteHeader(http.StatusNotFound)
@@ -427,23 +470,23 @@ func TestOpenCodeEdit_ReasoningLevelsOnGptOss(t *testing.T) {
 	t.Setenv("OLLAMA_HOST", srv.URL)
 
 	o := &OpenCode{}
-	if err := o.Edit([]string{"gpt-oss:120b-cloud"}); err != nil {
+	if err := o.Edit([]string{"my-gpt-alias"}); err != nil {
 		t.Fatal(err)
 	}
 
-	entry := inlineConfigModel(t, o.configContent, "gpt-oss:120b-cloud")
+	entry := inlineConfigModel(t, o.configContent, "my-gpt-alias")
 	if entry["reasoning"] != true {
 		t.Error("expected reasoning = true")
 	}
-	// GPT-OSS cannot turn thinking off and supports levels,
-	// so no custom variants should be written.
+	// GPT-OSS cannot turn thinking off and supports levels, even when
+	// launched through an alias.
 	if entry["variants"] != nil {
-		t.Errorf("expected no variants for gpt-oss, got %v", entry["variants"])
+		t.Errorf("expected no variants for gpt-oss family, got %v", entry["variants"])
 	}
 	// Should default to medium reasoning effort
 	opts, ok := entry["options"].(map[string]any)
 	if !ok {
-		t.Fatal("expected options to be set for gpt-oss")
+		t.Fatal("expected options to be set for gpt-oss family")
 	}
 	if opts["reasoningEffort"] != "medium" {
 		t.Errorf("reasoningEffort = %v, want medium", opts["reasoningEffort"])

--- a/cmd/launch/opencode_test.go
+++ b/cmd/launch/opencode_test.go
@@ -224,6 +224,9 @@ func TestBuildModelEntries(t *testing.T) {
 		if _, ok := entry["modalities"]; ok {
 			t.Fatalf("modalities should not be set without an API client, got %v", entry["modalities"])
 		}
+		if _, ok := entry["reasoning"]; ok {
+			t.Fatalf("reasoning should not be set without an API client, got %v", entry["reasoning"])
+		}
 	})
 
 	t.Run("uses one timeout budget across capability probes", func(t *testing.T) {
@@ -268,18 +271,7 @@ func TestBuildModelEntries(t *testing.T) {
 	})
 }
 
-func TestBuildModelEntries(t *testing.T) {
-	t.Run("defaults to model name when capabilities cannot be probed", func(t *testing.T) {
-		models := buildModelEntries(context.Background(), nil, []string{"llama3.2"})
-		entry, _ := models["llama3.2"].(map[string]any)
-		if entry["name"] != "llama3.2" {
-			t.Fatalf("name = %v, want llama3.2", entry["name"])
-		}
-		if _, ok := entry["reasoning"]; ok {
-			t.Fatalf("reasoning should not be set without an API client, got %v", entry["reasoning"])
-		}
-	})
-
+func TestBuildModelEntriesTimeoutWithBackgroundContext(t *testing.T) {
 	t.Run("uses timeout when probing capabilities with background context", func(t *testing.T) {
 		u, err := url.Parse("http://ollama.example")
 		if err != nil {

--- a/cmd/launch/opencode_test.go
+++ b/cmd/launch/opencode_test.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/types/model"
 )
 
@@ -172,6 +173,54 @@ func TestOpenCodeEdit(t *testing.T) {
 		}
 		if len(output) != 1 || output[0] != "text" {
 			t.Fatalf("modalities.output = %v, want [text]", output)
+		}
+	})
+
+	t.Run("thinking model gets on off reasoning variants", func(t *testing.T) {
+		models := buildModelEntries([]LaunchModel{{Name: "thinking-model", Capabilities: []model.Capability{model.CapabilityThinking}}})
+		entry, _ := models["thinking-model"].(map[string]any)
+
+		if entry["reasoning"] != true {
+			t.Fatalf("reasoning = %v, want true", entry["reasoning"])
+		}
+		variants, _ := entry["variants"].(map[string]any)
+		none, _ := variants["none"].(map[string]any)
+		if none["reasoningEffort"] != "none" {
+			t.Fatalf("variants.none.reasoningEffort = %v, want none", none["reasoningEffort"])
+		}
+		for _, level := range []string{"low", "medium", "high"} {
+			variant, _ := variants[level].(map[string]any)
+			if variant["disabled"] != true {
+				t.Fatalf("variants.%s.disabled = %v, want true", level, variant["disabled"])
+			}
+		}
+	})
+
+	t.Run("gpt oss gets reasoning level variants", func(t *testing.T) {
+		models := buildModelEntries([]LaunchModel{{Name: "gpt-oss:120b-cloud", Capabilities: []model.Capability{model.CapabilityThinking}}})
+		entry, _ := models["gpt-oss:120b-cloud"].(map[string]any)
+		options, _ := entry["options"].(map[string]any)
+
+		if options["reasoningEffort"] != "medium" {
+			t.Fatalf("options.reasoningEffort = %v, want medium", options["reasoningEffort"])
+		}
+		variants, _ := entry["variants"].(map[string]any)
+		for _, level := range []string{"low", "medium", "high", "max"} {
+			variant, _ := variants[level].(map[string]any)
+			if variant["reasoningEffort"] != level {
+				t.Fatalf("variants.%s.reasoningEffort = %v, want %s", level, variant["reasoningEffort"], level)
+			}
+		}
+	})
+
+	t.Run("gpt oss family gets reasoning level variants", func(t *testing.T) {
+		models := buildModelEntries([]LaunchModel{{Name: "reasoning-model", Capabilities: []model.Capability{model.CapabilityThinking}, Details: api.ModelDetails{Families: []string{"gptoss"}}}})
+		entry, _ := models["reasoning-model"].(map[string]any)
+		variants, _ := entry["variants"].(map[string]any)
+		max, _ := variants["max"].(map[string]any)
+
+		if max["reasoningEffort"] != "max" {
+			t.Fatalf("variants.max.reasoningEffort = %v, want max", max["reasoningEffort"])
 		}
 	})
 }

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -986,15 +986,35 @@ func TestLlamaServerWaitUntilRunningTimesOutWhenLoadStalls(t *testing.T) {
 }
 
 func TestLlamaServerWaitUntilRunningExtendsTimeoutOnOutputActivity(t *testing.T) {
-	t.Setenv("OLLAMA_LOAD_TIMEOUT", "20ms")
+	t.Setenv("OLLAMA_LOAD_TIMEOUT", "100ms")
 
 	var activityCount atomic.Int32
+	var activityStarted atomic.Bool
+	var runner *llamaServerRunner
+	done := make(chan struct{})
+	defer close(done)
+
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/health" {
 			t.Errorf("unexpected path: %s", r.URL.Path)
 			return
 		}
-		if activityCount.Load() < 5 {
+		if !activityStarted.Swap(true) {
+			go func() {
+				ticker := time.NewTicker(10 * time.Millisecond)
+				defer ticker.Stop()
+				for {
+					select {
+					case <-done:
+						return
+					case <-ticker.C:
+						activityCount.Add(1)
+						_, _ = runner.output.Write([]byte("."))
+					}
+				}
+			}()
+		}
+		if activityCount.Load() < 3 {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			fmt.Fprint(w, `{"error":{"message":"Loading model","type":"unavailable_error","code":503}}`)
 			return
@@ -1007,27 +1027,11 @@ func TestLlamaServerWaitUntilRunningExtendsTimeoutOnOutputActivity(t *testing.T)
 	var portInt int
 	fmt.Sscanf(parts[len(parts)-1], "%d", &portInt)
 
-	runner := &llamaServerRunner{
+	runner = &llamaServerRunner{
 		port: portInt,
 		cmd:  fakeRunningCmd(),
 	}
 	runner.output = &memoryParsingWriter{inner: io.Discard, runner: runner}
-
-	done := make(chan struct{})
-	defer close(done)
-	go func() {
-		ticker := time.NewTicker(5 * time.Millisecond)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-done:
-				return
-			case <-ticker.C:
-				activityCount.Add(1)
-				_, _ = runner.output.Write([]byte("."))
-			}
-		}
-	}()
 
 	if err := runner.WaitUntilRunning(t.Context()); err != nil {
 		t.Fatalf("WaitUntilRunning error: %v", err)


### PR DESCRIPTION
- Detect model thinking capability during `ollama launch opencode` and write reasoning config to OpenCode config file.
- Enable users to toggle thinking on and off via `ctrl+T` in OpenCode's tui for thinking models
- Default GPT-OSS models to medium reasoning effort with full level support
