### PR TITLE
launch: update openclaw channel message

### DIFF
--- a/cmd/launch/openclaw.go
+++ b/cmd/launch/openclaw.go
@@ -193,7 +193,7 @@ func (c *Openclaw) runChannelSetupPreflight(bin string) error {
 		}
 
 		fmt.Fprintf(os.Stderr, "\nYour assistant can message you on WhatsApp, Telegram, Discord, and more.\n\n")
-		ok, err := ConfirmPromptWithOptions("Connect a messaging app now?", ConfirmOptions{
+		ok, err := ConfirmPromptWithOptions("Connect a channel (messaging app) now?", ConfirmOptions{
 			YesLabel: "Yes",
 			NoLabel:  "Set up later",
 		})

--- a/cmd/launch/openclaw_test.go
+++ b/cmd/launch/openclaw_test.go
@@ -143,7 +143,7 @@ fi
 	oldConfirmPrompt := DefaultConfirmPrompt
 	DefaultConfirmPrompt = func(prompt string, options ConfirmOptions) (bool, error) {
 		promptCount++
-		if prompt != "Connect a messaging app now?" {
+		if prompt != "Connect a channel (messaging app) now?" {
 			t.Fatalf("unexpected prompt: %q", prompt)
 		}
 		return true, nil


### PR DESCRIPTION
Changed the launch prompt from "Connect a messaging app now?" to "Connect a channel (messaging app) now?" to better reflect the support for multiple messaging platforms.
