### PR TITLE
fix: check dst.Write error in transfer downloader copy() to prevent silent data corruption

### DIFF
--- a/x/imagegen/transfer/download.go
+++ b/x/imagegen/transfer/download.go
@@ -309,7 +309,13 @@ func (d *downloader) copy(ctx context.Context, dst io.Writer, src io.Reader, h i
 		nr, err := src.Read(buf)
 		if nr > 0 {
 			lastRead.Store(time.Now().UnixNano())
-			dst.Write(buf[:nr])
+			nw, werr := dst.Write(buf[:nr])
+			if werr != nil {
+				return n, werr
+			}
+			if nw != nr {
+				return n, io.ErrShortWrite
+			}
 			h.Write(buf[:nr])
 			d.progress.add(int64(nr))
 			n += int64(nr)


### PR DESCRIPTION
## Problem

In `x/imagegen/transfer/download.go`, the `copy()` function ignores the error returned by `dst.Write()`:

```go
nr, err := src.Read(buf)
if nr > 0 {
    lastRead.Store(time.Now().UnixNano())
    dst.Write(buf[:nr])   // ← error silently discarded!
    h.Write(buf[:nr])
    d.progress.add(int64(nr))
    n += int64(nr)
}
```

This causes **silent data corruption**:
1. If the disk is full or an I/O error occurs during download, writes fail silently
2. The SHA256 hash is computed over bytes **received from the network** (not bytes **written to disk**)
3. The final hash check passes — the download reports success
4. But the file on disk is incomplete or corrupt

## Fix

Check the error and byte count from `dst.Write()` and return immediately on failure:

```go
nw, werr := dst.Write(buf[:nr])
if werr != nil {
    return n, werr
}
if nw != nr {
    return n, io.ErrShortWrite
}
```

This follows the standard Go pattern for detecting short writes (as used in `io.Copy` in the standard library).

## Testing

The fix ensures:
- Disk-full scenarios cause download failure (not silent corruption)
- I/O errors propagate up and trigger the retry logic in `download()`
- Existing tests continue to pass (no behavior change under normal conditions)

Closes #15468