### PR TITLE
server/images: always verify blob hashes regardless of cache hit

### DIFF
--- a/server/images.go
+++ b/server/images.go
@@ -620,9 +620,8 @@ func PullModel(ctx context.Context, name string, regOpts *registryOptions, fn fu
 		return nil
 	}
 
-	skipVerify := make(map[string]bool)
 	for _, layer := range layers {
-		cacheHit, err := downloadBlob(ctx, downloadOpts{
+		_, err := downloadBlob(ctx, downloadOpts{
 			n:       n,
 			digest:  layer.Digest,
 			regOpts: regOpts,
@@ -631,15 +630,12 @@ func PullModel(ctx context.Context, name string, regOpts *registryOptions, fn fu
 		if err != nil {
 			return err
 		}
-		skipVerify[layer.Digest] = cacheHit
 		delete(deleteMap, layer.Digest)
 	}
 
+	// verify every blob sha256 to prevent arbitrary data being stored
 	fn(api.ProgressResponse{Status: "verifying sha256 digest"})
 	for _, layer := range layers {
-		if skipVerify[layer.Digest] {
-			continue
-		}
 		if err := verifyBlob(layer.Digest); err != nil {
 			if errors.Is(err, errDigestMismatch) {
 				fp, err := manifest.BlobsPath(layer.Digest)

--- a/server/images_test.go
+++ b/server/images_test.go
@@ -2,13 +2,17 @@ package server
 
 import (
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/ollama/ollama/fs/ggml"
+	"github.com/ollama/ollama/manifest"
 	"github.com/ollama/ollama/template"
 	"github.com/ollama/ollama/types/model"
 )
@@ -351,5 +355,27 @@ func TestPullModelManifest(t *testing.T) {
 				t.Fatal("expected at least one layer")
 			}
 		})
+	}
+}
+
+func TestVerifyBlobRejectsMismatch(t *testing.T) {
+	fakeDigest := "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	fp, err := manifest.BlobsPath(fakeDigest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(fp), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(fp, []byte("this content does not match the digest"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(fp)
+
+	err = verifyBlob(fakeDigest)
+	if !errors.Is(err, errDigestMismatch) {
+		t.Fatalf("expected errDigestMismatch, got: %v", err)
 	}
 }


### PR DESCRIPTION
Fixes #15485

Removes the `skipVerify` map from `PullModel` and verifies all blobs unconditionally.

When a manifest uses the same digest for config and layer, the map value gets overwritten from false to true, causing hash verification to be skipped. Combined with the 307 redirect behavior in blob downloads, a rogue OCI registry can redirect blob fetches to internal endpoints. The response is written to disk and persists because verification is skipped. An attacker can then exfiltrate the response via /api/copy and/api/push.

This fix ensures all blobs are verified regardless of cache state, so SSRF responses that don't match the advertised digest are deleted.

Test included.
