### PR TITLE
server: verify blob downloads with an inline sha256 hasher

### DIFF
--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -222,6 +222,13 @@ var (
 	NoHistory = Bool("OLLAMA_NOHISTORY")
 	// NoPrune disables pruning of model blobs on startup.
 	NoPrune = Bool("OLLAMA_NOPRUNE")
+	// VerifyInlineHash switches blob downloads to a single-stream path
+	// that computes the sha256 while bytes flow in from the network,
+	// instead of re-reading the file from disk to verify after download.
+	// Enable this on systems where the Linux page-cache read path
+	// returns corrupt bytes for very large files and causes
+	// "digest mismatch, file must be downloaded again" on every pull.
+	VerifyInlineHash = Bool("OLLAMA_VERIFY_INLINE_HASH")
 	// SchedSpread allows scheduling models across all GPUs.
 	SchedSpread = Bool("OLLAMA_SCHED_SPREAD")
 	// MultiUserCache optimizes prompt caching for multi-user scenarios
@@ -319,6 +326,7 @@ func AsMap() map[string]EnvVar {
 		"OLLAMA_NO_CLOUD":           {"OLLAMA_NO_CLOUD", NoCloud(), "Disable Ollama cloud features (remote inference and web search)"},
 		"OLLAMA_NOHISTORY":          {"OLLAMA_NOHISTORY", NoHistory(), "Do not preserve readline history"},
 		"OLLAMA_NOPRUNE":            {"OLLAMA_NOPRUNE", NoPrune(), "Do not prune model blobs on startup"},
+		"OLLAMA_VERIFY_INLINE_HASH": {"OLLAMA_VERIFY_INLINE_HASH", VerifyInlineHash(), "Verify blob downloads with an inline sha256 hasher instead of re-reading from disk (workaround for kernel read-path bugs on large files)"},
 		"OLLAMA_NUM_PARALLEL":       {"OLLAMA_NUM_PARALLEL", NumParallel(), "Maximum number of parallel requests"},
 		"OLLAMA_ORIGINS":            {"OLLAMA_ORIGINS", AllowedOrigins(), "A comma separated list of allowed origins"},
 		"OLLAMA_SCHED_SPREAD":       {"OLLAMA_SCHED_SPREAD", SchedSpread(), "Always schedule model across all GPUs"},

--- a/server/download.go
+++ b/server/download.go
@@ -2,9 +2,11 @@ package server
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash"
 	"io"
 	"log/slog"
 	"math"
@@ -23,6 +25,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/envconfig"
 	"github.com/ollama/ollama/format"
 	"github.com/ollama/ollama/manifest"
 	"github.com/ollama/ollama/types/model"
@@ -52,6 +55,14 @@ type blobDownload struct {
 	done       chan struct{}
 	err        error
 	references atomic.Int32
+
+	// inlineHash computes the SHA256 of the blob bytes as they flow in
+	// from the network. Used instead of re-reading the file after download
+	// to avoid a Linux kernel read-path bug that intermittently returns
+	// corrupted bytes when reading very large files. Only safe because we
+	// force single-part sequential downloads (no concurrent writers) in
+	// Prepare below.
+	inlineHash hash.Hash
 }
 
 type blobDownloadPart struct {
@@ -126,6 +137,10 @@ func (p *blobDownloadPart) Write(b []byte) (n int, err error) {
 }
 
 func (b *blobDownload) Prepare(ctx context.Context, requestURL *url.URL, opts *registryOptions) error {
+	if envconfig.VerifyInlineHash() {
+		return b.prepareInline(ctx, requestURL, opts)
+	}
+
 	partFilePaths, err := filepath.Glob(b.Name + "-partial-*")
 	if err != nil {
 		return err
@@ -179,6 +194,46 @@ func (b *blobDownload) Prepare(ctx context.Context, requestURL *url.URL, opts *r
 		slog.Info(fmt.Sprintf("downloading %s in %d %s part(s)", b.Digest[7:19], len(b.Parts), format.HumanBytes(b.Parts[0].Size)))
 	}
 
+	return nil
+}
+
+// prepareInline sets up an opt-in single-part download with an inline
+// sha256 hasher. This avoids re-reading the file from disk to verify the
+// digest after download, which is necessary on Linux kernels where the
+// read path returns corrupted bytes for sequential reads larger than a
+// few GiB even though the bytes on disk are correct. Enabled by setting
+// OLLAMA_VERIFY_INLINE_HASH=1. Trades multi-part parallelism and
+// cross-invocation resume for correctness on affected systems.
+func (b *blobDownload) prepareInline(ctx context.Context, requestURL *url.URL, opts *registryOptions) error {
+	// Fresh start every invocation. Existing partial bytes can't be
+	// incorporated into the inline hasher after the fact, so resume is
+	// not supported in this mode.
+	_ = os.Remove(b.Name + "-partial")
+	if oldParts, _ := filepath.Glob(b.Name + "-partial-*"); len(oldParts) > 0 {
+		for _, p := range oldParts {
+			_ = os.Remove(p)
+		}
+	}
+
+	b.done = make(chan struct{})
+
+	resp, err := makeRequestWithRetry(ctx, http.MethodHead, requestURL, nil, nil, opts)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	b.Total, _ = strconv.ParseInt(resp.Header.Get("Content-Length"), 10, 64)
+	b.inlineHash = sha256.New()
+
+	// Single part covering the entire blob. Only one goroutine writes to
+	// b.inlineHash, sequentially, so the final digest is authoritative
+	// without ever re-reading the file.
+	if err := b.newPart(0, b.Total); err != nil {
+		return err
+	}
+
+	slog.Info(fmt.Sprintf("downloading %s (%s, inline-hash single stream)", b.Digest[7:19], format.HumanBytes(b.Total)))
 	return nil
 }
 
@@ -280,19 +335,32 @@ func (b *blobDownload) run(ctx context.Context, requestURL *url.URL, opts *regis
 			continue
 		}
 
+		// In inline-hash mode a mid-stream error leaves the hasher with
+		// partial state that can't be cleanly resumed, so we fail fast
+		// and let the next pull invocation start over from scratch.
+		maxTries := maxRetries
+		if b.inlineHash != nil {
+			maxTries = 1
+		}
+
 		g.Go(func() error {
 			var err error
-			for try := 0; try < maxRetries; try++ {
+			for try := 0; try < maxTries; try++ {
 				w := io.NewOffsetWriter(file, part.StartsAt())
 				err = b.downloadChunk(inner, directURL, w, part)
 				switch {
 				case errors.Is(err, context.Canceled), errors.Is(err, syscall.ENOSPC):
-					// return immediately if the context is canceled or the device is out of space
 					return err
 				case errors.Is(err, errPartStalled):
+					if b.inlineHash != nil {
+						return err
+					}
 					try--
 					continue
 				case err != nil:
+					if b.inlineHash != nil {
+						return err
+					}
 					sleep := time.Second * time.Duration(math.Pow(2, float64(try)))
 					slog.Info(fmt.Sprintf("%s part %d attempt %d failed: %v, retrying in %s", b.Digest[7:19], part.N, try, err, sleep))
 					time.Sleep(sleep)
@@ -306,8 +374,32 @@ func (b *blobDownload) run(ctx context.Context, requestURL *url.URL, opts *regis
 		})
 	}
 
+	cleanupPartials := func() {
+		_ = os.Remove(file.Name())
+		for i := range b.Parts {
+			_ = os.Remove(file.Name() + "-" + strconv.Itoa(i))
+		}
+	}
+
 	if err := g.Wait(); err != nil {
+		if b.inlineHash != nil {
+			_ = file.Close()
+			cleanupPartials()
+		}
 		return err
+	}
+
+	// Verify the inline hash before promoting the partial file to its
+	// final blob path. This replaces the previous re-read-from-disk check
+	// in verifyBlob() which is unreliable on kernels where the page cache
+	// returns inconsistent bytes for large files.
+	if b.inlineHash != nil {
+		got := fmt.Sprintf("sha256:%x", b.inlineHash.Sum(nil))
+		if got != b.Digest {
+			_ = file.Close()
+			cleanupPartials()
+			return fmt.Errorf("%w: want %s, got %s (inline)", errDigestMismatch, b.Digest, got)
+		}
 	}
 
 	// explicitly close the file so we can rename it
@@ -342,7 +434,25 @@ func (b *blobDownload) downloadChunk(ctx context.Context, requestURL *url.URL, w
 		}
 		defer resp.Body.Close()
 
-		n, err := io.CopyN(w, io.TeeReader(resp.Body, part), part.Size-part.Completed.Load())
+		// Reject anything that isn't a real body response. Catches cases
+		// where an expired CDN signed URL returns 403, a gateway returns
+		// an error page, or a proxy injects a redirect - any of which
+		// would otherwise be silently written into the blob file.
+		if resp.StatusCode != http.StatusPartialContent && resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("unexpected status code %d for range request", resp.StatusCode)
+		}
+
+		// Bytes flow: HTTP body -> inline hasher -> progress writer -> file.
+		// Nested TeeReaders guarantee each byte is seen by every sink in
+		// the same order, so the inline hash represents exactly what was
+		// written to disk.
+		src := io.Reader(resp.Body)
+		if b.inlineHash != nil {
+			src = io.TeeReader(src, b.inlineHash)
+		}
+		src = io.TeeReader(src, part)
+
+		n, err := io.CopyN(w, src, part.Size-part.Completed.Load())
 		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, io.ErrUnexpectedEOF) {
 			// rollback progress
 			b.Completed.Add(-n)
@@ -464,22 +574,26 @@ type downloadOpts struct {
 	fn      func(api.ProgressResponse)
 }
 
-// downloadBlob downloads a blob from the registry and stores it in the blobs directory
-func downloadBlob(ctx context.Context, opts downloadOpts) (cacheHit bool, _ error) {
+// downloadBlob downloads a blob from the registry and stores it in the
+// blobs directory. It returns cacheHit=true if the blob was already
+// present on disk, and inlineVerified=true if the blob's sha256 was
+// verified by an inline hasher during download (so the caller can skip
+// the separate verifyBlob() pass).
+func downloadBlob(ctx context.Context, opts downloadOpts) (cacheHit bool, inlineVerified bool, _ error) {
 	if opts.digest == "" {
-		return false, fmt.Errorf(("%s: %s"), opts.n.DisplayNamespaceModel(), "digest is empty")
+		return false, false, fmt.Errorf(("%s: %s"), opts.n.DisplayNamespaceModel(), "digest is empty")
 	}
 
 	fp, err := manifest.BlobsPath(opts.digest)
 	if err != nil {
-		return false, err
+		return false, false, err
 	}
 
 	fi, err := os.Stat(fp)
 	switch {
 	case errors.Is(err, os.ErrNotExist):
 	case err != nil:
-		return false, err
+		return false, false, err
 	default:
 		opts.fn(api.ProgressResponse{
 			Status:    fmt.Sprintf("pulling %s", opts.digest[7:19]),
@@ -488,7 +602,7 @@ func downloadBlob(ctx context.Context, opts downloadOpts) (cacheHit bool, _ erro
 			Completed: fi.Size(),
 		})
 
-		return true, nil
+		return true, false, nil
 	}
 
 	data, ok := blobDownloadManager.LoadOrStore(opts.digest, &blobDownload{Name: fp, Digest: opts.digest})
@@ -498,12 +612,15 @@ func downloadBlob(ctx context.Context, opts downloadOpts) (cacheHit bool, _ erro
 		requestURL = requestURL.JoinPath("v2", opts.n.DisplayNamespaceModel(), "blobs", opts.digest)
 		if err := download.Prepare(ctx, requestURL, opts.regOpts); err != nil {
 			blobDownloadManager.Delete(opts.digest)
-			return false, err
+			return false, false, err
 		}
 
 		//nolint:contextcheck
 		go download.Run(context.Background(), requestURL, opts.regOpts)
 	}
 
-	return false, download.Wait(ctx, opts.fn)
+	if err := download.Wait(ctx, opts.fn); err != nil {
+		return false, false, err
+	}
+	return false, download.inlineHash != nil, nil
 }

--- a/server/images.go
+++ b/server/images.go
@@ -622,7 +622,7 @@ func PullModel(ctx context.Context, name string, regOpts *registryOptions, fn fu
 
 	skipVerify := make(map[string]bool)
 	for _, layer := range layers {
-		cacheHit, err := downloadBlob(ctx, downloadOpts{
+		cacheHit, inlineVerified, err := downloadBlob(ctx, downloadOpts{
 			n:       n,
 			digest:  layer.Digest,
 			regOpts: regOpts,
@@ -631,7 +631,12 @@ func PullModel(ctx context.Context, name string, regOpts *registryOptions, fn fu
 		if err != nil {
 			return err
 		}
-		skipVerify[layer.Digest] = cacheHit
+		// Skip the post-download re-read verification for:
+		//   - blobs that were already on disk (previously verified)
+		//   - blobs that downloadBlob verified inline while the bytes
+		//     were streaming in from the network, which bypasses the
+		//     unreliable read-back path on affected kernels
+		skipVerify[layer.Digest] = cacheHit || inlineVerified
 		delete(deleteMap, layer.Digest)
 	}
 


### PR DESCRIPTION
## Summary

Adds an opt-in `OLLAMA_VERIFY_INLINE_HASH=1` mode that computes a blob's sha256 via `io.TeeReader` on the HTTP response body as it streams into the file, and compares the resulting digest to the expected one before renaming the `-partial` file. When the env var is set, the download path never reads the file back from disk to verify.

The default code path is unchanged.

## Motivation

On one machine I see a reproducible `Error: digest mismatch, file must be downloaded again: want sha256:AAA..., got sha256:BBB...` on `ollama run gemma4:31b` (19.8 GB), where `BBB` is a different wrong hash on every retry. Retries don't converge, and neither does `ollama pull`.

I traced the failure to the post-download `verifyBlob()` call in `server/images.go`, which re-opens the blob file and hashes it via `io.Copy(sha256.New(), f)`. While debugging I confirmed, separately:

- The HTTP response body on the wire delivers the correct bytes (an inline `sha256.New()` tee'd off `resp.Body` during download matches the expected digest).
- `curl` piped to `sha256sum` of the same URL produces the expected digest.
- The blob on disk is at least functional: `ollama run gemma4:31b "hi"` loads and generates a coherent response, so llama.cpp's mmap-based tensor access reads enough of the file correctly to run inference.

But `sha256sum file`, `io.Copy(sha256.New(), f)`, and several other read-based hashing approaches against the exact same file return different wrong hashes on the same system. I wasn't able to fully isolate where the read path goes wrong — it's somewhere below ollama and I ran out of ladder. Since I can't fix the underlying cause from here, this PR provides a way to sidestep the re-read entirely for users who hit the same symptom.

The "digest mismatch, `got:` different on every retry" pattern shows up repeatedly in #941, #8105, #13775, #14554, #11831, #3931, #3326, and several of those reporters also mention that `memtest86+` comes up clean and retries don't help. I can't say whether their root cause is the same as mine, and this PR does not claim to fix any of those issues — it just gives affected users a workaround to try.

## Changes

**`envconfig/config.go`** — adds `VerifyInlineHash = Bool("OLLAMA_VERIFY_INLINE_HASH")` and a corresponding entry in the `EnvVar` description map.

**`server/download.go`**:

- `Prepare()` branches on `envconfig.VerifyInlineHash()`. The default branch is the existing multi-part code, untouched. The new `prepareInline()` method wipes any pre-existing `-partial*` files, initializes `b.inlineHash = sha256.New()`, and creates a single part covering the entire blob (required because SHA256 state can't be shared across concurrent writers).
- `downloadChunk()` now rejects any response whose status is not `206 Partial Content` or `200 OK`, unconditionally — this applies to both code paths and catches cases like expired CDN signed URLs returning `403` or gateway error pages that would otherwise be silently written into the blob file.
- When `b.inlineHash != nil`, `downloadChunk()` wraps the response body in `io.TeeReader(resp.Body, b.inlineHash)` so the hasher receives exactly the bytes being written to the file.
- When `b.inlineHash != nil`, `run()` disables the retry loop (`maxTries = 1`) because a mid-stream retry can't cleanly resume an in-progress SHA256 state, and compares the inline digest to the expected one before renaming; on mismatch or error it cleans up all partial files.
- `downloadBlob()` now returns `(cacheHit bool, inlineVerified bool, err error)` so callers can tell whether the post-download verify pass is still needed.

**`server/images.go`** — `PullModel()` still runs the `verifyBlob()` loop by default and skips it for blobs that came back with `inlineVerified=true`. Cached blobs continue to skip verification as before.

## Trade-offs (opt-in mode only)

These apply only when `OLLAMA_VERIFY_INLINE_HASH=1` is set:

- **No multi-part parallelism.** Downloads run as a single sequential stream.
- **No cross-invocation resume.** `Prepare` wipes any pre-existing `-partial*` files because the inline hasher can't incorporate pre-existing bytes.
- **No mid-stream retries.** A network error fails the whole download; the caller has to re-invoke `ollama pull`.

Users unaffected by whatever is breaking the re-read don't need to set the env var and see none of these trade-offs.

## Testing

- All 388 existing tests in the `server` package pass (`go test ./server/ -count=1`).
- `go build ./...`, `gofmt -l`, and `go vet ./server/` clean.
- End-to-end verified on the affected machine: with `OLLAMA_VERIFY_INLINE_HASH=1`, `POST /api/pull` for `gemma4:31b` completes in ~4m40s, the partial file is promoted to its final blob path, the manifest is written, the normal v0.20.2 daemon sees `gemma4:31b` in `ollama list` as soon as it's restarted, and `ollama run gemma4:31b "hi"` returns a coherent response. Without the env var, the same pull on the same machine fails at the verify step every time with a different wrong `got:` hash.

## Relationship to #15028

#15028 adds pre-rename verification via a new `verifyBlobFile()` helper, which opens the file and runs `GetSHA256Digest(f)` — the same buffered `read()` path as the existing `verifyBlob()`. On systems where that read path is the source of the mismatch, #15028 would catch the problem one step earlier but would still fail at the same underlying operation. Its HTTP status code check and partial cleanup on mismatch are both independently valuable, and this PR incorporates the status code check. The inline-hash opt-in is orthogonal to both and could land alongside either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
