### PR TITLE
launch: skip unchanged integration rewrite configration

### DIFF
--- a/cmd/launch/integrations_test.go
+++ b/cmd/launch/integrations_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/cmd/config"
 )
 
 type stubEditorRunner struct {
@@ -719,6 +720,53 @@ func TestLauncherClientFilterDisabledCloudModels_ChecksStatusOncePerInvocation(t
 	}
 	if statusCalls != 1 {
 		t.Fatalf("expected one cloud status lookup, got %d", statusCalls)
+	}
+}
+
+func TestSavedMatchesModels(t *testing.T) {
+	tests := []struct {
+		name   string
+		saved  *config.IntegrationConfig
+		models []string
+		want   bool
+	}{
+		{
+			name:   "nil saved",
+			saved:  nil,
+			models: []string{"llama3.2"},
+			want:   false,
+		},
+		{
+			name:   "identical order",
+			saved:  &config.IntegrationConfig{Models: []string{"llama3.2", "qwen3:8b"}},
+			models: []string{"llama3.2", "qwen3:8b"},
+			want:   true,
+		},
+		{
+			name:   "different order",
+			saved:  &config.IntegrationConfig{Models: []string{"llama3.2", "qwen3:8b"}},
+			models: []string{"qwen3:8b", "llama3.2"},
+			want:   false,
+		},
+		{
+			name:   "subset",
+			saved:  &config.IntegrationConfig{Models: []string{"llama3.2", "qwen3:8b"}},
+			models: []string{"llama3.2"},
+			want:   false,
+		},
+		{
+			name:   "empty both",
+			saved:  &config.IntegrationConfig{Models: nil},
+			models: nil,
+			want:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := savedMatchesModels(tt.saved, tt.models); got != tt.want {
+				t.Fatalf("savedMatchesModels = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/cmd/launch/integrations_test.go
+++ b/cmd/launch/integrations_test.go
@@ -755,6 +755,12 @@ func TestSavedMatchesModels(t *testing.T) {
 			want:   false,
 		},
 		{
+			name:   "nil models in saved with non-nil models",
+			saved:  &config.IntegrationConfig{Models: nil},
+			models: []string{"llama3.2"},
+			want:   false,
+		},
+		{
 			name:   "empty both",
 			saved:  &config.IntegrationConfig{Models: nil},
 			models: nil,

--- a/cmd/launch/launch.go
+++ b/cmd/launch/launch.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/ollama/ollama/api"
@@ -500,7 +501,7 @@ func (c *launcherClient) launchEditorIntegration(ctx context.Context, name strin
 		return nil
 	}
 
-	if needsConfigure || req.ModelOverride != "" {
+	if (needsConfigure || req.ModelOverride != "") && !savedMatchesModels(saved, models) {
 		if err := prepareEditorIntegration(name, runner, editor, models); err != nil {
 			return err
 		}
@@ -844,6 +845,13 @@ func firstModel(models []string) string {
 		return ""
 	}
 	return models[0]
+}
+
+func savedMatchesModels(saved *config.IntegrationConfig, models []string) bool {
+	if saved == nil {
+		return false
+	}
+	return slices.Equal(saved.Models, models)
 }
 
 func editorPreCheckedModels(saved *config.IntegrationConfig, override string) []string {


### PR DESCRIPTION
**Summary**
- Skip prepareEditorIntegration when the resolved model list is identical (same models, same order) to what's already saved, so pressing → on a configured
multi-model integration or passing --model with the current primary no longer triggers the confirmation prompt, rewrites editor config files, or re-saves
config.json.
- Added savedMatchesModels helper (nil-safe — a nil saved config still falls through to the configure flow so first-time setup is unaffected).
- Added TestSavedMatchesModels covering nil, identical, reordered, subset, and empty cases.