### PR TITLE
cmd/tui: add interactive model browser for pull command

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -359,6 +359,31 @@ func (c *Client) Create(ctx context.Context, req *CreateRequest, fn CreateProgre
 	})
 }
 
+// ListRemote fetches a curated list of models from the ollama.com public registry
+// via the OpenAI-compatible /v1/models API.
+func ListRemote(ctx context.Context, timeout time.Duration) (*RemoteListResponse, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://ollama.com/v1/models", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var lr RemoteListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&lr); err != nil {
+		return nil, err
+	}
+	return &lr, nil
+}
+
 // List lists models that are available locally.
 func (c *Client) List(ctx context.Context) (*ListResponse, error) {
 	var lr ListResponse

--- a/api/client.go
+++ b/api/client.go
@@ -359,13 +359,18 @@ func (c *Client) Create(ctx context.Context, req *CreateRequest, fn CreateProgre
 	})
 }
 
+// RemoteModelsURL is the ollama.com endpoint for the curated model list.
+// Exposed as a variable so tests can override it with an httptest server URL.
+var RemoteModelsURL = "https://ollama.com/v1/models"
+
 // ListRemote fetches a curated list of models from the ollama.com public registry
-// via the OpenAI-compatible /v1/models API.
+// via the OpenAI-compatible /v1/models API. Note: this does not return all available
+// models or all available tags — it is a featured shortlist maintained by Ollama.
 func ListRemote(ctx context.Context, timeout time.Duration) (*RemoteListResponse, error) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://ollama.com/v1/models", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, RemoteModelsURL, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestClientFromEnvironment(t *testing.T) {
@@ -318,5 +319,75 @@ func TestClientDo(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestListRemote_Success(t *testing.T) {
+	want := RemoteListResponse{
+		Object: "list",
+		Data: []RemoteModel{
+			{ID: "gemma3:4b", Object: "model", OwnedBy: "library"},
+			{ID: "gemma3:12b", Object: "model", OwnedBy: "library"},
+		},
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(want)
+	}))
+	defer ts.Close()
+
+	orig := RemoteModelsURL
+	RemoteModelsURL = ts.URL + "/v1/models"
+	defer func() { RemoteModelsURL = orig }()
+
+	got, err := ListRemote(t.Context(), 5*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.Data) != len(want.Data) {
+		t.Fatalf("expected %d models, got %d", len(want.Data), len(got.Data))
+	}
+	for i, m := range got.Data {
+		if m.ID != want.Data[i].ID {
+			t.Errorf("model[%d].ID: got %q, want %q", i, m.ID, want.Data[i].ID)
+		}
+	}
+}
+
+func TestListRemote_Timeout(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// block until the request context is cancelled
+		<-r.Context().Done()
+	}))
+	defer ts.Close()
+
+	orig := RemoteModelsURL
+	RemoteModelsURL = ts.URL + "/v1/models"
+	defer func() { RemoteModelsURL = orig }()
+
+	_, err := ListRemote(t.Context(), 1*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+}
+
+func TestListRemote_BadJSON(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("not json"))
+	}))
+	defer ts.Close()
+
+	orig := RemoteModelsURL
+	RemoteModelsURL = ts.URL + "/v1/models"
+	defer func() { RemoteModelsURL = orig }()
+
+	_, err := ListRemote(t.Context(), 5*time.Second)
+	if err == nil {
+		t.Fatal("expected parse error, got nil")
 	}
 }

--- a/api/types.go
+++ b/api/types.go
@@ -835,6 +835,21 @@ type TokenResponse struct {
 	Token string `json:"token"`
 }
 
+// RemoteModel is a single model entry returned by the ollama.com /v1/models API.
+type RemoteModel struct {
+	ID      string `json:"id"`
+	Object  string `json:"object"`
+	Created int64  `json:"created"`
+	OwnedBy string `json:"owned_by"`
+}
+
+// RemoteListResponse is the OpenAI-compatible response from the ollama.com /v1/models endpoint,
+// used by ListRemote to surface a curated list of models for the pull menu.
+type RemoteListResponse struct {
+	Object string        `json:"object"`
+	Data   []RemoteModel `json:"data"`
+}
+
 type CloudStatus struct {
 	Disabled bool   `json:"disabled"`
 	Source   string `json:"source"`

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1344,6 +1344,23 @@ func PullHandler(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	modelName := ""
+	if len(args) == 0 {
+		if !term.IsTerminal(int(os.Stdin.Fd())) || !term.IsTerminal(int(os.Stdout.Fd())) {
+			return fmt.Errorf("model name required in non-interactive mode; use: ollama pull <model>")
+		}
+		selected, err := tui.RunPullMenu()
+		if errors.Is(err, tui.ErrCancelled) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		modelName = selected
+	} else {
+		modelName = args[0]
+	}
+
 	p := progress.NewProgress(os.Stderr)
 	defer p.Stop()
 
@@ -1404,7 +1421,7 @@ func PullHandler(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	request := api.PullRequest{Name: args[0], Insecure: insecure}
+	request := api.PullRequest{Name: modelName, Insecure: insecure}
 	return client.Pull(cmd.Context(), &request, fn)
 }
 
@@ -2184,9 +2201,9 @@ func NewCLI() *cobra.Command {
 	}
 
 	pullCmd := &cobra.Command{
-		Use:     "pull MODEL",
+		Use:     "pull [MODEL]",
 		Short:   "Pull a model from a registry",
-		Args:    cobra.ExactArgs(1),
+		Args:    cobra.MaximumNArgs(1),
 		PreRunE: checkServerHeartbeat,
 		RunE:    PullHandler,
 	}

--- a/cmd/tui/pull_menu.go
+++ b/cmd/tui/pull_menu.go
@@ -1,0 +1,269 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/ollama/ollama/api"
+)
+
+const pullMenuTimeout = 5 * time.Second
+
+type pullMenuState int
+
+const (
+	pullStateLoading pullMenuState = iota
+	pullStateBaseList
+	pullStateTagList
+	pullStateError
+)
+
+type remoteModelsMsg struct {
+	baseModels []SelectItem
+	tagsByBase map[string][]SelectItem
+	err        error
+}
+
+type pullMenuModel struct {
+	state      pullMenuState
+	baseModels []SelectItem
+	tagsByBase map[string][]SelectItem
+
+	baseSelector selectorModel
+	tagSelector  selectorModel
+	selectedBase string
+
+	err      error
+	selected string
+	width    int
+}
+
+func newPullMenuModel() pullMenuModel {
+	return pullMenuModel{state: pullStateLoading}
+}
+
+func (m pullMenuModel) Init() tea.Cmd {
+	return fetchRemoteModelsCmd
+}
+
+// fetchRemoteModelsCmd is a Bubble Tea command that calls the ollama.com /v1/models API
+// Models are grouped client-side by base name; no additional network calls are made.
+func fetchRemoteModelsCmd() tea.Msg {
+	resp, err := api.ListRemote(context.Background(), pullMenuTimeout)
+	if err != nil {
+		return remoteModelsMsg{err: err}
+	}
+
+	baseOrder := []string{}
+	seenBase := map[string]bool{}
+	tagsByBase := map[string][]SelectItem{}
+
+	for _, rm := range resp.Data {
+		id := strings.TrimSpace(rm.ID)
+		if id == "" {
+			continue
+		}
+
+		base := id
+		if idx := strings.LastIndex(id, ":"); idx >= 0 {
+			base = id[:idx]
+		}
+
+		tagsByBase[base] = append(tagsByBase[base], SelectItem{Name: id})
+
+		if !seenBase[base] {
+			seenBase[base] = true
+			baseOrder = append(baseOrder, base)
+		}
+	}
+
+	baseModels := make([]SelectItem, 0, len(baseOrder))
+	for _, base := range baseOrder {
+		tags := tagsByBase[base]
+		desc := ""
+		if len(tags) > 1 {
+			variants := make([]string, len(tags))
+			for i, t := range tags {
+				if idx := strings.LastIndex(t.Name, ":"); idx >= 0 {
+					variants[i] = t.Name[idx+1:]
+				} else {
+					variants[i] = t.Name
+				}
+			}
+			desc = strings.Join(variants, ", ")
+		}
+		baseModels = append(baseModels, SelectItem{Name: base, Description: desc})
+	}
+
+	return remoteModelsMsg{baseModels: baseModels, tagsByBase: tagsByBase}
+}
+
+func (m pullMenuModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		return m, nil
+
+	case remoteModelsMsg:
+		if msg.err != nil {
+			m.state = pullStateError
+			m.err = msg.err
+			return m, nil
+		}
+		m.baseModels = msg.baseModels
+		m.tagsByBase = msg.tagsByBase
+		m.state = pullStateBaseList
+		m.baseSelector = selectorModel{
+			title:    "Pull a Model",
+			items:    m.baseModels,
+			helpText: "↑/↓ navigate • enter select • → view tags • esc cancel",
+		}
+		return m, nil
+
+	case tea.KeyMsg:
+		switch m.state {
+		case pullStateError:
+			switch msg.Type {
+			case tea.KeyEsc, tea.KeyCtrlC:
+				m.selected = ""
+				return m, tea.Quit
+			}
+			return m, nil
+
+		case pullStateBaseList:
+			switch msg.Type {
+			case tea.KeyCtrlC, tea.KeyEsc:
+				m.selected = ""
+				return m, tea.Quit
+
+			case tea.KeyEnter:
+				filtered := m.baseSelector.filteredItems()
+				if len(filtered) == 0 {
+					return m, nil
+				}
+				chosen := filtered[m.baseSelector.cursor]
+				tags := m.tagsByBase[chosen.Name]
+				if len(tags) == 1 {
+					m.selected = tags[0].Name
+					return m, tea.Quit
+				}
+				m.selectedBase = chosen.Name
+				m.tagSelector = selectorModel{
+					title:    "Pull a Model › " + chosen.Name,
+					items:    tags,
+					helpText: "↑/↓ navigate • enter pull • ← back • esc cancel",
+				}
+				m.state = pullStateTagList
+				return m, nil
+
+			case tea.KeyRight:
+				filtered := m.baseSelector.filteredItems()
+				if len(filtered) == 0 {
+					return m, nil
+				}
+				chosen := filtered[m.baseSelector.cursor]
+				tags := m.tagsByBase[chosen.Name]
+				m.selectedBase = chosen.Name
+				m.tagSelector = selectorModel{
+					title:    "Pull a Model › " + chosen.Name,
+					items:    tags,
+					helpText: "↑/↓ navigate • enter pull • ← back • esc cancel",
+				}
+				m.state = pullStateTagList
+				return m, nil
+
+			default:
+				m.baseSelector.updateNavigation(msg)
+				return m, nil
+			}
+
+		case pullStateTagList:
+			switch msg.Type {
+			case tea.KeyCtrlC, tea.KeyEsc:
+				m.selected = ""
+				return m, tea.Quit
+
+			case tea.KeyLeft:
+				m.state = pullStateBaseList
+				return m, nil
+
+			case tea.KeyEnter:
+				filtered := m.tagSelector.filteredItems()
+				if len(filtered) == 0 {
+					return m, nil
+				}
+				m.selected = filtered[m.tagSelector.cursor].Name
+				return m, tea.Quit
+
+			default:
+				m.tagSelector.updateNavigation(msg)
+				return m, nil
+			}
+		}
+	}
+
+	return m, nil
+}
+
+func (m pullMenuModel) View() string {
+	if m.selected != "" {
+		return ""
+	}
+
+	var s string
+
+	switch m.state {
+	case pullStateLoading:
+		s = selectorTitleStyle.Render("Pull a Model") + "\n\n"
+		s += selectorItemStyle.Render("Fetching available models...")
+		s += "\n\n" + selectorHelpStyle.Render("esc cancel")
+
+	case pullStateError:
+		s = selectorTitleStyle.Render("Pull a Model") + "\n\n"
+		s += lipgloss.NewStyle().
+			Foreground(lipgloss.AdaptiveColor{Light: "1", Dark: "9"}).
+			PaddingLeft(2).
+			Render("⚠  Could not fetch model list") + "\n\n"
+		s += selectorItemStyle.Render(fmt.Sprintf("Run %s directly", selectorInputStyle.Render("`ollama pull <model>`"))) + "\n\n"
+		s += selectorHelpStyle.Render("esc cancel")
+
+	case pullStateBaseList:
+		s = m.baseSelector.renderContent()
+
+	case pullStateTagList:
+		s = m.tagSelector.renderContent()
+	}
+
+	if m.width > 0 {
+		return lipgloss.NewStyle().MaxWidth(m.width).Render(s)
+	}
+	return s
+}
+
+// RunPullMenu runs the interactive pull menu and returns the selected model name.
+// Returns ("", ErrCancelled) if the user cancels, or ("", err) on fetch failure.
+func RunPullMenu() (string, error) {
+	m := newPullMenuModel()
+	p := tea.NewProgram(m)
+
+	final, err := p.Run()
+	if err != nil {
+		return "", fmt.Errorf("pull menu: %w", err)
+	}
+
+	fm := final.(pullMenuModel)
+
+	if fm.state == pullStateError {
+		return "", ErrCancelled
+	}
+
+	if fm.selected == "" {
+		return "", ErrCancelled
+	}
+
+	return fm.selected, nil
+}

--- a/cmd/tui/pull_menu.go
+++ b/cmd/tui/pull_menu.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ollama/ollama/api"
 )
 
-const pullMenuTimeout = 5 * time.Second
+var pullMenuTimeout = 5 * time.Second
 
 type pullMenuState int
 

--- a/cmd/tui/pull_menu_test.go
+++ b/cmd/tui/pull_menu_test.go
@@ -1,0 +1,322 @@
+package tui
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/ollama/ollama/api"
+)
+
+// serveModels starts an httptest server that returns the given models as a
+// RemoteListResponse and overrides remoteModelsURL for the duration of the test.
+func serveModels(t *testing.T, models []api.RemoteModel) {
+	t.Helper()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(api.RemoteListResponse{Object: "list", Data: models})
+	}))
+	t.Cleanup(ts.Close)
+
+	origURL := api.RemoteModelsURL
+	api.RemoteModelsURL = ts.URL + "/v1/models"
+	t.Cleanup(func() { api.RemoteModelsURL = origURL })
+}
+
+// sendKey drives a pullMenuModel through a single key press and returns the result.
+func sendKey(m pullMenuModel, k tea.KeyType) (pullMenuModel, tea.Cmd) {
+	updated, cmd := m.Update(tea.KeyMsg{Type: k})
+	return updated.(pullMenuModel), cmd
+}
+
+// baseListModel returns a pullMenuModel already in pullStateBaseList with the
+// given base models and their tags pre-populated.
+func baseListModel(baseModels []SelectItem, tagsByBase map[string][]SelectItem) pullMenuModel {
+	m := newPullMenuModel()
+	m.state = pullStateBaseList
+	m.baseModels = baseModels
+	m.tagsByBase = tagsByBase
+	m.baseSelector = selectorModel{
+		title:    "Pull a Model",
+		items:    baseModels,
+		helpText: "↑/↓ navigate • enter select • → view tags • esc cancel",
+	}
+	return m
+}
+
+// --- fetchRemoteModelsCmd grouping logic ---
+
+func TestFetchRemoteModels_GroupsTagsByBase(t *testing.T) {
+	serveModels(t, []api.RemoteModel{
+		{ID: "gemma3:4b"},
+		{ID: "gemma3:12b"},
+		{ID: "llama3:8b"},
+	})
+
+	msg := fetchRemoteModelsCmd().(remoteModelsMsg)
+	if msg.err != nil {
+		t.Fatalf("unexpected error: %v", msg.err)
+	}
+	if len(msg.baseModels) != 2 {
+		t.Fatalf("expected 2 base models, got %d", len(msg.baseModels))
+	}
+	if len(msg.tagsByBase["gemma3"]) != 2 {
+		t.Errorf("expected 2 tags for gemma3, got %d", len(msg.tagsByBase["gemma3"]))
+	}
+	if len(msg.tagsByBase["llama3"]) != 1 {
+		t.Errorf("expected 1 tag for llama3, got %d", len(msg.tagsByBase["llama3"]))
+	}
+}
+
+func TestFetchRemoteModels_SingleTagNoDescription(t *testing.T) {
+	serveModels(t, []api.RemoteModel{{ID: "llama3:8b"}})
+
+	msg := fetchRemoteModelsCmd().(remoteModelsMsg)
+	if msg.err != nil {
+		t.Fatalf("unexpected error: %v", msg.err)
+	}
+	if len(msg.baseModels) != 1 {
+		t.Fatalf("expected 1 base model, got %d", len(msg.baseModels))
+	}
+	if msg.baseModels[0].Description != "" {
+		t.Errorf("expected empty description for single-tag model, got %q", msg.baseModels[0].Description)
+	}
+}
+
+func TestFetchRemoteModels_MultiTagHasDescription(t *testing.T) {
+	serveModels(t, []api.RemoteModel{
+		{ID: "gemma3:4b"},
+		{ID: "gemma3:12b"},
+	})
+
+	msg := fetchRemoteModelsCmd().(remoteModelsMsg)
+	if msg.err != nil {
+		t.Fatalf("unexpected error: %v", msg.err)
+	}
+	desc := msg.baseModels[0].Description
+	if !strings.Contains(desc, "4b") || !strings.Contains(desc, "12b") {
+		t.Errorf("expected description to contain tag variants, got %q", desc)
+	}
+}
+
+func TestFetchRemoteModels_EmptyIDSkipped(t *testing.T) {
+	serveModels(t, []api.RemoteModel{
+		{ID: ""},
+		{ID: "llama3:8b"},
+	})
+
+	msg := fetchRemoteModelsCmd().(remoteModelsMsg)
+	if msg.err != nil {
+		t.Fatalf("unexpected error: %v", msg.err)
+	}
+	if len(msg.baseModels) != 1 {
+		t.Errorf("expected 1 base model (empty ID skipped), got %d", len(msg.baseModels))
+	}
+}
+
+func TestFetchRemoteModels_Timeout(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done() // block until request context is cancelled
+	}))
+	t.Cleanup(ts.Close)
+
+	origURL := api.RemoteModelsURL
+	api.RemoteModelsURL = ts.URL + "/v1/models"
+	t.Cleanup(func() { api.RemoteModelsURL = origURL })
+
+	origTimeout := pullMenuTimeout
+	pullMenuTimeout = 1 * time.Millisecond
+	t.Cleanup(func() { pullMenuTimeout = origTimeout })
+
+	msg := fetchRemoteModelsCmd().(remoteModelsMsg)
+	if msg.err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+}
+
+// --- pullMenuModel.Update() state transitions ---
+
+func TestPullMenu_LoadingToBaseList(t *testing.T) {
+	m := newPullMenuModel()
+	baseModels := []SelectItem{{Name: "llama3"}}
+	tagsByBase := map[string][]SelectItem{"llama3": {{Name: "llama3:8b"}}}
+
+	updated, _ := m.Update(remoteModelsMsg{baseModels: baseModels, tagsByBase: tagsByBase})
+	fm := updated.(pullMenuModel)
+
+	if fm.state != pullStateBaseList {
+		t.Errorf("expected pullStateBaseList, got %v", fm.state)
+	}
+}
+
+func TestPullMenu_LoadingToError(t *testing.T) {
+	m := newPullMenuModel()
+
+	updated, _ := m.Update(remoteModelsMsg{err: errTest})
+	fm := updated.(pullMenuModel)
+
+	if fm.state != pullStateError {
+		t.Errorf("expected pullStateError, got %v", fm.state)
+	}
+}
+
+func TestPullMenu_EscCancels(t *testing.T) {
+	m := baseListModel(
+		[]SelectItem{{Name: "llama3"}},
+		map[string][]SelectItem{"llama3": {{Name: "llama3:8b"}}},
+	)
+
+	fm, cmd := sendKey(m, tea.KeyEsc)
+
+	if fm.selected != "" {
+		t.Errorf("expected empty selected, got %q", fm.selected)
+	}
+	if cmd == nil {
+		t.Error("expected tea.Quit cmd, got nil")
+	}
+}
+
+func TestPullMenu_EnterSingleTagPulls(t *testing.T) {
+	m := baseListModel(
+		[]SelectItem{{Name: "llama3"}},
+		map[string][]SelectItem{"llama3": {{Name: "llama3:8b"}}},
+	)
+
+	fm, cmd := sendKey(m, tea.KeyEnter)
+
+	if fm.selected != "llama3:8b" {
+		t.Errorf("expected selected %q, got %q", "llama3:8b", fm.selected)
+	}
+	if cmd == nil {
+		t.Error("expected tea.Quit cmd, got nil")
+	}
+}
+
+func TestPullMenu_EnterMultiTagGoesToTagList(t *testing.T) {
+	m := baseListModel(
+		[]SelectItem{{Name: "gemma3"}},
+		map[string][]SelectItem{"gemma3": {{Name: "gemma3:4b"}, {Name: "gemma3:12b"}}},
+	)
+
+	fm, _ := sendKey(m, tea.KeyEnter)
+
+	if fm.state != pullStateTagList {
+		t.Errorf("expected pullStateTagList, got %v", fm.state)
+	}
+}
+
+func TestPullMenu_RightArrowGoesToTagList(t *testing.T) {
+	m := baseListModel(
+		[]SelectItem{{Name: "gemma3"}},
+		map[string][]SelectItem{"gemma3": {{Name: "gemma3:4b"}, {Name: "gemma3:12b"}}},
+	)
+
+	fm, _ := sendKey(m, tea.KeyRight)
+
+	if fm.state != pullStateTagList {
+		t.Errorf("expected pullStateTagList, got %v", fm.state)
+	}
+}
+
+func TestPullMenu_LeftArrowGoesBack(t *testing.T) {
+	m := baseListModel(
+		[]SelectItem{{Name: "gemma3"}},
+		map[string][]SelectItem{"gemma3": {{Name: "gemma3:4b"}, {Name: "gemma3:12b"}}},
+	)
+	m, _ = sendKey(m, tea.KeyRight)
+	if m.state != pullStateTagList {
+		t.Fatalf("setup failed: expected pullStateTagList")
+	}
+
+	fm, _ := sendKey(m, tea.KeyLeft)
+
+	if fm.state != pullStateBaseList {
+		t.Errorf("expected pullStateBaseList, got %v", fm.state)
+	}
+}
+
+func TestPullMenu_EnterInTagListPulls(t *testing.T) {
+	m := baseListModel(
+		[]SelectItem{{Name: "gemma3"}},
+		map[string][]SelectItem{"gemma3": {{Name: "gemma3:4b"}, {Name: "gemma3:12b"}}},
+	)
+	m, _ = sendKey(m, tea.KeyRight)
+
+	fm, cmd := sendKey(m, tea.KeyEnter)
+
+	if fm.selected != "gemma3:4b" {
+		t.Errorf("expected selected %q, got %q", "gemma3:4b", fm.selected)
+	}
+	if cmd == nil {
+		t.Error("expected tea.Quit cmd, got nil")
+	}
+}
+
+func TestPullMenu_EscInTagListCancels(t *testing.T) {
+	m := baseListModel(
+		[]SelectItem{{Name: "gemma3"}},
+		map[string][]SelectItem{"gemma3": {{Name: "gemma3:4b"}, {Name: "gemma3:12b"}}},
+	)
+	m, _ = sendKey(m, tea.KeyRight)
+
+	fm, cmd := sendKey(m, tea.KeyEsc)
+
+	if fm.selected != "" {
+		t.Errorf("expected empty selected, got %q", fm.selected)
+	}
+	if cmd == nil {
+		t.Error("expected tea.Quit cmd, got nil")
+	}
+}
+
+func TestPullMenu_WindowSizeUpdatesWidth(t *testing.T) {
+	m := newPullMenuModel()
+
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	fm := updated.(pullMenuModel)
+
+	if fm.width != 120 {
+		t.Errorf("expected width 120, got %d", fm.width)
+	}
+}
+
+// --- pullMenuModel.View() rendering ---
+
+func TestPullMenuView_LoadingContainsFetching(t *testing.T) {
+	m := newPullMenuModel()
+	view := m.View()
+	if !strings.Contains(view, "Fetching available models") {
+		t.Errorf("loading view missing fetch message, got:\n%s", view)
+	}
+}
+
+func TestPullMenuView_ErrorContainsMessage(t *testing.T) {
+	m := newPullMenuModel()
+	m.state = pullStateError
+	m.err = errTest
+
+	view := m.View()
+	if !strings.Contains(view, "Could not fetch model list") {
+		t.Errorf("error view missing error message, got:\n%s", view)
+	}
+	if !strings.Contains(view, "ollama pull") {
+		t.Errorf("error view missing fallback instruction, got:\n%s", view)
+	}
+}
+
+func TestPullMenuView_SelectedReturnsEmpty(t *testing.T) {
+	m := newPullMenuModel()
+	m.selected = "gemma3:4b"
+
+	if view := m.View(); view != "" {
+		t.Errorf("expected empty view when selected, got:\n%s", view)
+	}
+}
+
+// errTest is a sentinel error for use in tests.
+var errTest = fmt.Errorf("test error")


### PR DESCRIPTION
Closes #286

## What this does

Running `ollama pull` with no arguments now launches an interactive TUI
model browser. Use ↑/↓ to navigate, → to drill into available tags for
a model, ← to go back, and Enter to pull. The existing `ollama pull
<model>` flow is completely unchanged — the menu only activates when no
arguments are provided.

This was inspired by the experience described in
https://github.com/ollama/ollama/issues/286#issuecomment-1785960671,
where a user wished they could interactively explore what's available
rather than having to already know what to type.

## The honest caveat

There's a limitation worth calling out upfront: Ollama's public
`/v1/models` API (OpenAI-compatible) is the **cloud models endpoint** —
it surfaces models available via Ollama's cloud service, not a general
registry catalog. Some of these are also locally pullable, but many are
cloud-only. Either way it is not a comprehensive list of what's
available to download locally.

This means the browser won't show you everything — and some of what it
does show may not be locally pullable at all. It's a significant
limitation and does reduce the usefulness of this feature. That said,
the plumbing is here: if Ollama ever exposes a proper registry endpoint
that returns locally-pullable models and their full tag lists, this menu
could be updated quickly to take advantage of it. For now the full tag
list for any model is always accessible at `ollama.com/library/<model>/tags`.

## Details

- 5-second timeout on the remote fetch; error state instructs the user
  to fall back to `ollama pull <model>` directly
- Tag grouping is done client-side from the single API response — no
  additional network calls during navigation
- Pull progress display is untouched; after selection the existing
  progress bars render identically to `ollama pull <model>`
- Non-interactive environments (piped stdin/stdout) skip the menu and
  return an error asking for an explicit model name

## Files changed

- `api/types.go` — `RemoteModel` and `RemoteListResponse` types
- `api/client.go` — `ListRemote()` with 5s timeout
- `cmd/cmd.go` — relaxes `cobra.ExactArgs(1)` to `cobra.MaximumNArgs(1)`;
  adds zero-arg path in `PullHandler`
- `cmd/tui/pull_menu.go` — new file; Bubble Tea pull menu