### PR TITLE
refactor: inject logger dependency into GenerateRoutes

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -1643,7 +1643,7 @@ func allowedHostsMiddleware(addr net.Addr) gin.HandlerFunc {
 	}
 }
 
-func (s *Server) GenerateRoutes(rc *ollama.Registry) (http.Handler, error) {
+func (s *Server) GenerateRoutes(logger *slog.Logger, rc *ollama.Registry) (http.Handler, error) {
 	corsConfig := cors.DefaultConfig()
 	corsConfig.AllowWildcard = true
 	corsConfig.AllowBrowserExtensions = true
@@ -1736,7 +1736,7 @@ func (s *Server) GenerateRoutes(rc *ollama.Registry) (http.Handler, error) {
 		// wrap old with new
 		rs := &registry.Local{
 			Client:   rc,
-			Logger:   slog.Default(), // TODO(bmizerany): Take a logger, do not use slog.Default()
+			Logger:   logger,
 			Fallback: r,
 
 			Prune: PruneLayers,
@@ -1795,7 +1795,7 @@ func Serve(ln net.Listener) error {
 		}
 	}
 
-	h, err := s.GenerateRoutes(rc)
+	h, err := s.GenerateRoutes(slog.Default(), rc)
 	if err != nil {
 		return err
 	}

--- a/server/routes_cloud_test.go
+++ b/server/routes_cloud_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"log/slog"
 
 	"github.com/gin-gonic/gin"
 	"github.com/ollama/ollama/api"
@@ -171,7 +172,7 @@ func TestExplicitCloudPassthroughAPIAndV1(t *testing.T) {
 		t.Cleanup(func() { cloudProxyBaseURL = original })
 
 		s := &Server{}
-		router, err := s.GenerateRoutes(nil)
+		router, err := s.GenerateRoutes(slog.Default(), nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -222,7 +223,7 @@ func TestExplicitCloudPassthroughAPIAndV1(t *testing.T) {
 		t.Cleanup(func() { cloudProxyBaseURL = original })
 
 		s := &Server{}
-		router, err := s.GenerateRoutes(nil)
+		router, err := s.GenerateRoutes(slog.Default(), nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -265,7 +266,7 @@ func TestExplicitCloudPassthroughAPIAndV1(t *testing.T) {
 		t.Cleanup(func() { cloudProxyBaseURL = original })
 
 		s := &Server{}
-		router, err := s.GenerateRoutes(nil)
+		router, err := s.GenerateRoutes(slog.Default(), nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -308,7 +309,7 @@ func TestExplicitCloudPassthroughAPIAndV1(t *testing.T) {
 		t.Cleanup(func() { cloudProxyBaseURL = original })
 
 		s := &Server{}
-		router, err := s.GenerateRoutes(nil)
+		router, err := s.GenerateRoutes(slog.Default(), nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -351,7 +352,7 @@ func TestExplicitCloudPassthroughAPIAndV1(t *testing.T) {
 		t.Cleanup(func() { cloudProxyBaseURL = original })
 
 		s := &Server{}
-		router, err := s.GenerateRoutes(nil)
+		router, err := s.GenerateRoutes(slog.Default(), nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -394,7 +395,7 @@ func TestExplicitCloudPassthroughAPIAndV1(t *testing.T) {
 		t.Cleanup(func() { cloudProxyBaseURL = original })
 
 		s := &Server{}
-		router, err := s.GenerateRoutes(nil)
+		router, err := s.GenerateRoutes(slog.Default(), nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -450,7 +451,7 @@ func TestExplicitCloudPassthroughAPIAndV1(t *testing.T) {
 		t.Cleanup(func() { cloudProxyBaseURL = original })
 
 		s := &Server{}
-		router, err := s.GenerateRoutes(nil)
+		router, err := s.GenerateRoutes(slog.Default(), nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -506,7 +507,7 @@ func TestExplicitCloudPassthroughAPIAndV1(t *testing.T) {
 		t.Cleanup(func() { cloudProxyBaseURL = original })
 
 		s := &Server{}
-		router, err := s.GenerateRoutes(nil)
+		router, err := s.GenerateRoutes(slog.Default(), nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -557,7 +558,7 @@ func TestExplicitCloudPassthroughAPIAndV1(t *testing.T) {
 		t.Cleanup(func() { cloudProxyBaseURL = original })
 
 		s := &Server{}
-		router, err := s.GenerateRoutes(nil)
+		router, err := s.GenerateRoutes(slog.Default(), nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -608,7 +609,7 @@ func TestExplicitCloudPassthroughAPIAndV1(t *testing.T) {
 		t.Cleanup(func() { cloudProxyBaseURL = original })
 
 		s := &Server{}
-		router, err := s.GenerateRoutes(nil)
+		router, err := s.GenerateRoutes(slog.Default(), nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -675,7 +676,7 @@ func TestExplicitCloudPassthroughAPIAndV1(t *testing.T) {
 		t.Cleanup(func() { cloudProxyBaseURL = original })
 
 		s := &Server{}
-		router, err := s.GenerateRoutes(nil)
+		router, err := s.GenerateRoutes(slog.Default(), nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -722,7 +723,7 @@ func TestExplicitCloudPassthroughAPIAndV1(t *testing.T) {
 		t.Cleanup(func() { cloudProxyBaseURL = original })
 
 		s := &Server{}
-		router, err := s.GenerateRoutes(nil)
+		router, err := s.GenerateRoutes(slog.Default(), nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -768,7 +769,7 @@ func TestExplicitCloudPassthroughAPIAndV1(t *testing.T) {
 		t.Cleanup(func() { cloudProxyBaseURL = original })
 
 		s := &Server{}
-		router, err := s.GenerateRoutes(nil)
+		router, err := s.GenerateRoutes(slog.Default(), nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -803,7 +804,7 @@ func TestCloudDisabledBlocksExplicitCloudPassthrough(t *testing.T) {
 	t.Setenv("OLLAMA_NO_CLOUD", "1")
 
 	s := &Server{}
-	router, err := s.GenerateRoutes(nil)
+	router, err := s.GenerateRoutes(slog.Default(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -864,7 +865,7 @@ func TestCloudPassthroughStreamsPromptly(t *testing.T) {
 	t.Cleanup(func() { cloudProxyBaseURL = original })
 
 	s := &Server{}
-	router, err := s.GenerateRoutes(nil)
+	router, err := s.GenerateRoutes(slog.Default(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1048,7 +1049,7 @@ func TestCloudPassthroughSigningFailureReturnsUnauthorized(t *testing.T) {
 	})
 
 	s := &Server{}
-	router, err := s.GenerateRoutes(nil)
+	router, err := s.GenerateRoutes(slog.Default(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1106,7 +1107,7 @@ func TestCloudPassthroughSigningFailureWithoutSigninURL(t *testing.T) {
 	})
 
 	s := &Server{}
-	router, err := s.GenerateRoutes(nil)
+	router, err := s.GenerateRoutes(slog.Default(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 	"unicode"
+	"log/slog"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/go-cmp/cmp"
@@ -515,7 +516,7 @@ func TestRoutes(t *testing.T) {
 	}
 
 	s := &Server{}
-	router, err := s.GenerateRoutes(rc)
+	router, err := s.GenerateRoutes(slog.Default(), rc)
 	if err != nil {
 		t.Fatalf("failed to generate routes: %v", err)
 	}
@@ -808,7 +809,7 @@ func TestShowCopilotUserAgentOverwritesExistingBasename(t *testing.T) {
 		t.Fatalf("expected status code 200 creating model, actual %d", w.Code)
 	}
 
-	h, err := s.GenerateRoutes(nil)
+	h, err := s.GenerateRoutes(slog.Default(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -865,7 +866,7 @@ func TestShowCopilotUserAgentSetsBasenameWhenModelInfoIsEmpty(t *testing.T) {
 		t.Fatalf("expected status code 200 creating model, actual %d", w.Code)
 	}
 
-	h, err := s.GenerateRoutes(nil)
+	h, err := s.GenerateRoutes(slog.Default(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/routes_web_experimental_test.go
+++ b/server/routes_web_experimental_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"log/slog"
 
 	"github.com/gin-gonic/gin"
 	internalcloud "github.com/ollama/ollama/internal/cloud"
@@ -79,7 +80,7 @@ func TestExperimentalWebEndpointsPassthrough(t *testing.T) {
 			t.Cleanup(func() { cloudProxyBaseURL = original })
 
 			s := &Server{}
-			router, err := s.GenerateRoutes(nil)
+			router, err := s.GenerateRoutes(slog.Default(), nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -129,7 +130,7 @@ func TestExperimentalWebEndpointsMissingBody(t *testing.T) {
 	setTestHome(t, t.TempDir())
 
 	s := &Server{}
-	router, err := s.GenerateRoutes(nil)
+	router, err := s.GenerateRoutes(slog.Default(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -173,7 +174,7 @@ func TestExperimentalWebEndpointsCloudDisabled(t *testing.T) {
 	t.Setenv("OLLAMA_NO_CLOUD", "1")
 
 	s := &Server{}
-	router, err := s.GenerateRoutes(nil)
+	router, err := s.GenerateRoutes(slog.Default(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -249,7 +250,7 @@ func TestExperimentalWebEndpointSigningFailureReturnsUnauthorized(t *testing.T) 
 	})
 
 	s := &Server{}
-	router, err := s.GenerateRoutes(nil)
+	router, err := s.GenerateRoutes(slog.Default(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -303,7 +304,7 @@ func TestExperimentalWebEndpointSigningFailureWithoutSigninURL(t *testing.T) {
 	})
 
 	s := &Server{}
-	router, err := s.GenerateRoutes(nil)
+	router, err := s.GenerateRoutes(slog.Default(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR refactors GenerateRoutes to accept an explicit *slog.Logger dependency, removing the reliance on the global slog.Default() within the registry.Local initialization. This addresses an internal TODO and improves the testability and architecture of the server routing layer.

Motivation Previously, registry.Local was initialized with slog.Default() inside GenerateRoutes. As noted in the existing code comments (now removed), it was better to pass a logger explicitly to avoid side effects and allow for better dependency injection.

Changes

server/routes.go: Updated GenerateRoutes signature to include logger *slog.Logger.
server/routes.go: Replaced slog.Default() with the provided logger when initializing registry.Local.
server/routes.go: Updated the Serve function to pass slog.Default() into the routing pipeline.
Testing: Updated several test files (routes_test.go, routes_cloud_test.go, and routes_web_experimental_test.go) to inject slog.Default() into the router setup, ensuring full compatibility with existing test suites.
Verification

Code was manually reviewed for correctness.
All affected files were updated to ensure the compilation of the server and its tests remains stable under the new function signature.