### PR TITLE
fix: remove premature addition of mlx Cuda in windows builds

### DIFF
--- a/scripts/build_windows.ps1
+++ b/scripts/build_windows.ps1
@@ -528,7 +528,6 @@ try {
         cuda13
         rocm6
         vulkan
-        mlxCuda13
         ollama
         app
         deps


### PR DESCRIPTION
Just removes mlxCuda from the default build on windows until it's stable and not getting confused devs in the discord.