### PR TITLE
Add OLLAMA_SKIP_GPU_VALIDATION env var to bypass broken GPU validation on Strix Halo (gfx1151)

### DIFF
--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -236,6 +236,11 @@ var (
 	EnableVulkan = Bool("OLLAMA_VULKAN")
 	// NoCloudEnv checks the OLLAMA_NO_CLOUD environment variable.
 	NoCloudEnv = Bool("OLLAMA_NO_CLOUD")
+	// SkipGPUValidation bypasses the rocblas_initialize() check during GPU discovery.
+	// Useful for AMD GPUs (like Strix Halo gfx1151) where rocblas validation crashes
+	// even though the GPU is actually supported. The user takes responsibility for
+	// ensuring the GPU is compatible.
+	SkipGPUValidation = Bool("OLLAMA_SKIP_GPU_VALIDATION")
 )
 
 func String(s string) func() string {
@@ -349,6 +354,7 @@ func AsMap() map[string]EnvVar {
 		ret["GPU_DEVICE_ORDINAL"] = EnvVar{"GPU_DEVICE_ORDINAL", GpuDeviceOrdinal(), "Set which AMD devices are visible by numeric ID"}
 		ret["HSA_OVERRIDE_GFX_VERSION"] = EnvVar{"HSA_OVERRIDE_GFX_VERSION", HsaOverrideGfxVersion(), "Override the gfx used for all detected AMD GPUs"}
 		ret["OLLAMA_VULKAN"] = EnvVar{"OLLAMA_VULKAN", EnableVulkan(), "Enable experimental Vulkan support"}
+		ret["OLLAMA_SKIP_GPU_VALIDATION"] = EnvVar{"OLLAMA_SKIP_GPU_VALIDATION", SkipGPUValidation(), "Bypass GPU init validation (for AMD GPUs that crash during validation but actually work, e.g. Strix Halo gfx1151)"}
 	}
 
 	return ret

--- a/ml/device.go
+++ b/ml/device.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ollama/ollama/envconfig"
 	"github.com/ollama/ollama/format"
 	"github.com/ollama/ollama/logutil"
 )
@@ -536,6 +537,11 @@ func GetVisibleDevicesEnv(l []DeviceInfo, mustFilter bool) map[string]string {
 // to crash at inference time and requires deeper validation before we include
 // it in the supported devices list.
 func (d DeviceInfo) NeedsInitValidation() bool {
+	// Allow users to bypass validation for known-good GPUs that crash during validation
+	// (e.g. AMD Strix Halo gfx1151 where rocblas_initialize() fails even though the GPU works).
+	if envconfig.SkipGPUValidation() {
+		return false
+	}
 	// ROCm: rocblas will crash on unsupported devices.
 	// CUDA: verify CC is supported by the version of the library
 	return d.Library == "ROCm" || d.Library == "CUDA"

--- a/runner/ollamarunner/runner.go
+++ b/runner/ollamarunner/runner.go
@@ -1229,6 +1229,15 @@ func (s *Server) allocModel(
 	s.seqs = make([]*Sequence, s.parallel)
 	s.seqsSem = semaphore.NewWeighted(int64(s.parallel))
 
+	// Allow skipping worst-case graph reservation. Some GPUs (e.g. AMD Strix Halo gfx1151)
+	// crash during ggml_backend_sched_reserve due to bugs in the HIP runtime memory allocator.
+	// Skipping this means memory is allocated lazily during inference, which works fine
+	// in practice for most workloads.
+	if envconfig.SkipGPUValidation() {
+		slog.Info("skipping worst-case graph reservation (OLLAMA_SKIP_GPU_VALIDATION=1)")
+		return nil
+	}
+
 	err = s.reserveWorstCaseGraph(true)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Problem

The GPU validation subprocess added in 0.18+ silently filters out AMD GPUs that crash during the deep init check. This affects AMD Strix Halo (gfx1151) and is reported in:

- #15336 — "ollama 17.7 last version working on strix halo, all 18.x fallback to cpu"
- #13589 — "gfx1151 silently falls back to CPU on Linux despite rocminfo detecting GPU"
- #15261 — "Vulkan causing unrelated output with gemma4:e4b (AMD/Ryzen iGPU)"

## Root cause

Two separate crashes prevent gfx1151 from working on 0.18+:

**1. Bootstrap validation crash**

`NeedsInitValidation()` triggers a runner subprocess with `GGML_CUDA_INIT=1` that calls `rocblas_initialize()`. On gfx1151 with the bundled ROCm libraries, this crashes because `TensileLibrary_lazy_gfx1151.dat` cannot be loaded from the expected hipblaslt path. The Go discovery code interprets the empty subprocess output as `"filtering device which didn't fully initialize"` and removes the GPU.

**2. Worst-case graph reservation crash**

Even after working around the bootstrap, `reserveWorstCaseGraph()` in the new `ollamarunner` calls `ggml_backend_sched_reserve()` which crashes with SIGSEGV inside libamdhip64 — a HIP runtime memory allocator bug specific to gfx1151.

## Fix

This patch adds an `OLLAMA_SKIP_GPU_VALIDATION` env var that:

1. Skips `NeedsInitValidation()` for ROCm/CUDA devices (so the bootstrap subprocess uses bare device enumeration without the crashing rocblas init)
2. Skips `reserveWorstCaseGraph()` in `ollamarunner.allocModel()` (memory is allocated lazily during inference instead, which works fine in practice)

The user takes responsibility for ensuring their GPU is actually compatible. This is documented in the env var description.

## Tested

- **Hardware**: AMD Ryzen AI MAX+ PRO 395 (Strix Halo, gfx1151), 96GB GTT
- **OS**: Debian 12 in unprivileged Proxmox LXC, kernel 6.17
- **Drivers**: mesa-vulkan-drivers 25.0.7 from bookworm-backports
- **Ollama**: built from this branch

**Results with `OLLAMA_SKIP_GPU_VALIDATION=1` and `OLLAMA_VULKAN=1`**:

| Model | Backend | Avg latency (warm) | Tokens/call |
|---|---|---|---|
| qwen3.5:4b | Vulkan (gfx1151) | **1.89s** | ~63 |
| qwen3.5:4b | CPU (without patch) | 15.6s | ~155 |

Performance via Vulkan is comparable to or faster than 0.17.7 with native ROCm support. Full 33/33 layers offload to GPU. `KHR_coopmat` cooperative matrix support is active.

## Risk

- **Low blast radius**: opt-in via env var, no behavior change for users who don't set it
- **No new dependencies**: uses existing `envconfig` package
- **Backwards compatible**: existing GPU validation logic untouched

## Future work

The underlying bugs in rocblas tensile loading and HIP memory allocator should ideally be fixed upstream, but this gives Strix Halo users a working escape hatch in the meantime without forking.