### PR TITLE
fix: handle HTTP 200 OK directly in OCI blob download (no Location header)

### DIFF
--- a/server/download.go
+++ b/server/download.go
@@ -265,6 +265,12 @@ func (b *blobDownload) run(ctx context.Context, requestURL *url.URL, opts *regis
 			if resp.StatusCode != http.StatusTemporaryRedirect && resp.StatusCode != http.StatusOK {
 				return nil, fmt.Errorf("unexpected status code %d", resp.StatusCode)
 			}
+            
+			if resp.StatusCode == http.StatusOK {
+				// If the registry serves the blob directly, return the request URL instead of looking for a missing Location header
+				return resp.Request.URL, nil
+			}
+
 			return resp.Location()
 		}
 	}()


### PR DESCRIPTION
Hi everyone! 👋 This is my first ever pull request on GitHub, so please let me know if I need to adjust anything.

I was trying to set up my own local **registry:2** to host my models and kept running into this error during pulls: `http: no Location header in response`. After debugging this for a while, I found the issue in `server/download.go`.

**What's causing the bug?**
Right now, the code explicitly allows `http.StatusOK` alongside `http.StatusTemporaryRedirect`. But right after that check, it blindly calls `resp.Location()`.
If a registry serves the blob directly with a 200 OK response, there is no Location header. This causes net/http to throw an error, and the pull just fails entirely.

**The Fix**
This PR simply returns the original `resp.Request.URL` if a 200 OK is received. This bypasses the strict location header check when the registry serves the blob directly.

**Steps to reproduce the issue:**
1. Host a standard **registry:2** image and set `REGISTRY_STORAGE_REDIRECT_DISABLE=true`.
2. Run `ollama push` to upload a model to it.
3. Run `ollama pull` for the same model. It fails instantly with the Location header error.

**Testing:**
I compiled and tested this locally on macOS. With this small change, the pull smoothly downloads the chunks via the direct URL instead of failing on the header check. **registry:2** is sitting behind a Nginx Proxy Manager in my setup, so I was using it's URL and https when testing.

Hope this helps! Let me know if you need me to change anything.