### PR TITLE
openai: normalize colliding tool call indices in ToToolCalls

### DIFF
--- a/openai/openai.go
+++ b/openai/openai.go
@@ -240,6 +240,25 @@ func ToUsage(r api.ChatResponse) Usage {
 
 // ToToolCalls converts api.ToolCall to OpenAI ToolCall format
 func ToToolCalls(tc []api.ToolCall) []ToolCall {
+	// Normalize indices when all tool calls have the same index (e.g., all 0),
+	// which happens with the legacy parser when tool calls span multiple chunks.
+	// Built-in parsers maintain a persistent callIndex across chunks; the legacy
+	// parser resets its counter on each Add() call, causing all to collide at 0.
+	if len(tc) > 1 {
+		allSame := true
+		for i := 1; i < len(tc); i++ {
+			if tc[i].Function.Index != tc[0].Function.Index {
+				allSame = false
+				break
+			}
+		}
+		if allSame {
+			for i := range tc {
+				tc[i].Function.Index = i
+			}
+		}
+	}
+
 	toolCalls := make([]ToolCall, len(tc))
 	for i, tc := range tc {
 		toolCalls[i].ID = tc.ID

--- a/openai/openai_test.go
+++ b/openai/openai_test.go
@@ -234,6 +234,47 @@ func TestToToolCallsPreservesIDs(t *testing.T) {
 	}
 }
 
+func TestToToolCallsNormalizesCollidingIndices(t *testing.T) {
+	// Regression test: the legacy parser resets its counter on each Add() call,
+	// causing all tool calls that arrive in separate chunks to have Index=0.
+	// Normalization reassigns them to sequential indices.
+	original := []api.ToolCall{
+		{
+			ID: "call_1",
+			Function: api.ToolCallFunction{
+				Index: 0,
+				Name:  "file_write",
+				Arguments: testArgs(map[string]any{
+					"filePath": "hello.py",
+					"content":  `print("hello")`,
+				}),
+			},
+		},
+		{
+			ID: "call_2",
+			Function: api.ToolCallFunction{
+				Index: 0, // same as first — collision from legacy parser across chunks
+				Name:  "file_write",
+				Arguments: testArgs(map[string]any{
+					"filePath": "world.py",
+					"content":  `print("world")`,
+				}),
+			},
+		},
+	}
+
+	got := ToToolCalls(original)
+
+	// Original indices were both 0; they should now be 0, 1
+	if got[0].Index != 0 || got[1].Index != 1 {
+		t.Errorf("expected indices [0, 1], got [%d, %d]", got[0].Index, got[1].Index)
+	}
+	// IDs must be preserved
+	if got[0].ID != "call_1" || got[1].ID != "call_2" {
+		t.Errorf("IDs were mutated: got [%s, %s]", got[0].ID, got[1].ID)
+	}
+}
+
 func TestFromChatRequest_WithLogprobs(t *testing.T) {
 	trueVal := true
 


### PR DESCRIPTION
## Summary

The legacy `tools.Parser` resets its internal counter (`p.n`) on each `Add()` call, which is invoked per streaming chunk in `server/routes.go`. When tool calls span multiple chunks, all arrive with `Index=0`, violating the OpenAI API requirement that each tool call have a distinct index.

Built-in parsers (cogito, gemma4, etc.) were fixed in #15467 to maintain a persistent `callIndex` across chunks. This applies the same safeguard at the OpenAI conversion layer.

## Root cause

In `routes.go:2501`, `toolParser.Add()` is called per streaming chunk. The legacy parser's counter starts at 0 for each call, so tool calls from separate chunks all get `Index=0`. These are accumulated into a single `[]api.ToolCall` slice that then gets passed to `ToToolCalls`.

## Fix

In `openai/openai.go:ToToolCalls`, detect when all tool calls share the same index (always 0 in practice) and reassign them to `0..n` sequentially before converting to the OpenAI format.

## Changes

- `openai/openai.go`: +19 lines — normalization logic in `ToToolCalls`
- `openai/openai_test.go`: +41 lines — regression test `TestToToolCallsNormalizesCollidingIndices`

## Validation

```bash
go test ./openai/... -run TestToToolCalls -v
# ✓ TestToToolCallsPreservesIDs      (existing test — distinct indices unchanged)
# ✓ TestToToolCallsNormalizesCollidingIndices (new test — collision fixed)
```

Fixes #15497