### PR TITLE
docs: add missing usage fields to ChatStreamEvent in OpenAPI spec

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -401,6 +401,27 @@ components:
         done:
           type: boolean
           description: True for the final event in the stream
+        done_reason:
+          type: string
+          description: Reason the stream finished
+        total_duration:
+          type: integer
+          description: Total time spent generating in nanoseconds
+        load_duration:
+          type: integer
+          description: Time spent loading the model in nanoseconds
+        prompt_eval_count:
+          type: integer
+          description: Number of tokens in the prompt
+        prompt_eval_duration:
+          type: integer
+          description: Time spent evaluating the prompt in nanoseconds
+        eval_count:
+          type: integer
+          description: Number of tokens generated in the response
+        eval_duration:
+          type: integer
+          description: Time spent generating tokens in nanoseconds
     StatusEvent:
       type: object
       properties:


### PR DESCRIPTION
## Summary

- Adds the missing `done_reason`, `total_duration`, `load_duration`, `prompt_eval_count`, `prompt_eval_duration`, `eval_count`, and `eval_duration` fields to the `ChatStreamEvent` schema in `docs/openapi.yaml`
- These fields are returned by the API in the final streaming chunk (when `done: true`) but were not documented in the schema
- Aligns `ChatStreamEvent` with `GenerateStreamEvent` and `ChatResponse`, which already include these fields

Fixes #14680

## Verification

Confirmed the Go source (`api/types.go`) uses a single `ChatResponse` struct (which embeds `Metrics`) for both streaming and non-streaming chat responses, so these fields are indeed sent in the final stream event.

| Schema | Has usage fields? |
|---|---|
| `GenerateResponse` | ✅ |
| `GenerateStreamEvent` | ✅ |
| `ChatResponse` | ✅ |
| `ChatStreamEvent` | ✅ (this PR) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)