### PR TITLE
server: show pull summary after resolving manifest

### DIFF
--- a/server/images.go
+++ b/server/images.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/envconfig"
+	"github.com/ollama/ollama/format"
 	"github.com/ollama/ollama/fs/gguf"
 	"github.com/ollama/ollama/manifest"
 	"github.com/ollama/ollama/model/parsers"
@@ -610,6 +611,8 @@ func PullModel(ctx context.Context, name string, regOpts *registryOptions, fn fu
 	if mf.Config.Digest != "" {
 		layers = append(layers, mf.Config)
 	}
+
+	fn(api.ProgressResponse{Status: fmt.Sprintf("pulling %s with %d files (%s total)", name, len(layers), format.HumanBytes(mf.Size()))})
 
 	// Use fast transfer for models with tensor layers (many small blobs)
 	if hasTensorLayers(layers) {


### PR DESCRIPTION
## Summary

- After pulling the manifest, displays the resolved model name, number of files, and total download size before starting layer downloads
- Uses the existing `format.HumanBytes` helper for human-readable sizes
- Single status line addition in `PullModel()`, works for both standard and tensor transfer paths

Example output:
```
pulling manifest
pulling llama3.2:latest with 9 files (4.9 GB total)
pulling 68e0ec597aee: 100% ...
```

Fixes #15275

## Test plan

- [x] Verified existing tests use `strings.Contains` assertions (not exact output matching), so the new status line does not break `server/internal/registry/server_test.go` or `server/routes_test.go`
- [ ] Manual test: `ollama pull <model>` should show the summary line between "pulling manifest" and the first layer download

🤖 Generated with [Claude Code](https://claude.com/claude-code)