### PR TITLE
MLX: add repeatable model porting workflow

### DIFF
--- a/integration/README.md
+++ b/integration/README.md
@@ -16,13 +16,44 @@ The integration tests have 2 modes of operating.
 
 ## Testing a New Model
 
-When implementing new model architecture, use `OLLAMA_TEST_MODEL` to run the
-integration suite against your model.
+When implementing a new model architecture, use `OLLAMA_TEST_MODEL` to run the
+integration suite against the created Ollama model tag. This should be final
+validation after the model-specific unit tests, reference activation tests, cache
+tests, and quality checks pass. Integration tests are much slower and should not
+be used as a substitute for focused coverage.
 
 ```bash
 # Build the binary first
 go build .
 
 # Run integration tests against it
-OLLAMA_TEST_MODEL=mymodel go test -tags integration -v -count 1 -timeout 15m ./integration/
+OLLAMA_TEST_MODEL=mymodel:base-mlx-bf16 \
+  go test -tags=integration -v -count=1 -timeout 30m ./integration
 ```
+
+To run against an existing server instead of letting the test harness start and
+stop one:
+
+```bash
+OLLAMA_TEST_EXISTING=1 \
+OLLAMA_HOST=http://127.0.0.1:11434 \
+OLLAMA_TEST_MODEL=mymodel:base-mlx-bf16 \
+  go test -tags=integration -v -count=1 -timeout 30m ./integration
+```
+
+The override relies on model capabilities. Tests for audio, vision, embeddings,
+tool calling, and thinking call `/api/show` and skip when the model does not
+advertise the required capability. Make sure the model manifest/config exposes
+only the capabilities the model actually supports:
+
+- `completion` for normal text generation
+- `vision` for image input
+- `audio` for audio input
+- `tools` for tool calling
+- `thinking` for thinking output
+- `embedding` for embedding models
+
+If a completion-only model runs audio, vision, or tool tests, fix the model's
+advertised capabilities. If a model supports one of those features but the
+related tests skip, fix the capability metadata before treating the integration
+run as complete.

--- a/integration/README.md
+++ b/integration/README.md
@@ -33,8 +33,12 @@ harness starts the server.
 
 ## Testing a New Model
 
-When implementing new model architecture, use `OLLAMA_TEST_MODEL` to run the
-integration suite against your model with either the `fast` or `release` coverage.
+When implementing a new model architecture, use `OLLAMA_TEST_MODEL` to run the
+integration suite against the created Ollama model tag with either the `fast` or
+`release` coverage. This should be final validation after the model-specific
+unit tests, reference activation tests, cache tests, and quality checks pass.
+Integration tests are much slower and should not be used as a substitute for
+focused coverage.
 
 ```bash
 # Build the binary first
@@ -43,3 +47,30 @@ go build .
 # Run integration tests against it
 OLLAMA_TEST_MODEL=mymodel go test -tags=integration,fast -v -count 1 ./integration/
 ```
+
+To run against an existing server instead of letting the test harness start and
+stop one:
+
+```bash
+OLLAMA_TEST_EXISTING=1 \
+OLLAMA_HOST=http://127.0.0.1:11434 \
+OLLAMA_TEST_MODEL=mymodel:base-mlx-bf16 \
+  go test -tags=integration -v -count=1 -timeout 30m ./integration
+```
+
+The override relies on model capabilities. Tests for audio, vision, embeddings,
+tool calling, and thinking call `/api/show` and skip when the model does not
+advertise the required capability. Make sure the model manifest/config exposes
+only the capabilities the model actually supports:
+
+- `completion` for normal text generation
+- `vision` for image input
+- `audio` for audio input
+- `tools` for tool calling
+- `thinking` for thinking output
+- `embedding` for embedding models
+
+If a completion-only model runs audio, vision, or tool tests, fix the model's
+advertised capabilities. If a model supports one of those features but the
+related tests skip, fix the capability metadata before treating the integration
+run as complete.

--- a/x/cmd/ppl/README.md
+++ b/x/cmd/ppl/README.md
@@ -1,0 +1,61 @@
+# ollama-ppl
+
+A perplexity measurement CLI for MLX-loaded language models.
+
+`ollama-ppl` loads any registered MLX model architecture directly (no
+HTTP server, no separate inference process) and runs end-to-end perplexity
+on a corpus. It supports two scoring methodologies:
+
+- **`harness`** (default): reproduces EleutherAI lm-evaluation-harness'
+  `wikitext` task. Document-level rolling loglikelihood with `context_len=1`,
+  scoring every prediction position in each window. The default corpus is
+  fetched from the canonical `EleutherAI/wikitext_document_level` Hugging Face
+  dataset.
+- **`llamacpp`**: reproduces llama.cpp's `llama-perplexity` tool. Concatenates
+  the corpus into one stream, splits into non-overlapping `n_ctx`-token chunks
+  with BOS substituted at chunk position 0, scores only the second half of
+  each chunk. The default corpus is the `wiki.test.raw` flat file from the
+  `ggml-org/ci` Hugging Face dataset (the source the llama.cpp community uses).
+
+Note: for optimal results, use the base trained model, not the instruction-tuned version.
+
+## Examples
+
+```bash
+# Default: harness mode on an ollama-stored model
+go run ./x/cmd/ppl -model mymodel:base-mlx-bf16
+
+# Llama.cpp-compatible mode for direct comparison with llama-perplexity
+go run ./x/cmd/ppl -model mymodel:base-mlx-bf16 -mode llamacpp
+
+# Load from a HuggingFace directory (no ollama tag required)
+go run ./x/cmd/ppl -model-dir models/SomeOrg/SomeModel-Base
+
+# Keep downloaded corpora in a sandbox-friendly cache
+go run ./x/cmd/ppl -model-dir models/SomeOrg/SomeModel-Base \
+  -cache-dir /tmp/ollama-ppl-cache
+
+# Compare against a prior JSON result and fail if relative token PPL drifts >1%
+go run ./x/cmd/ppl -model mymodel:base-mlx-bf16 \
+  -baseline /tmp/baseline-ppl.json \
+  -max-rel-delta 0.01
+```
+
+## Cross-validation
+
+To compare against a canonical reference:
+
+```bash
+# lm-evaluation-harness reference (default harness mode)
+pip install lm-eval
+python -m lm_eval --model hf \
+    --model_args pretrained=models/SomeOrg/SomeModel-Base,dtype=bfloat16,trust_remote_code=True,max_length=2048 \
+    --device mps --tasks wikitext
+
+# llama.cpp reference (llamacpp mode), after converting HF→GGUF
+python ~/code/llama.cpp/convert_hf_to_gguf.py models/SomeOrg/SomeModel-Base \
+    --outtype f16 --outfile /tmp/model-f16.gguf
+llama.cpp/build/bin/llama-perplexity \
+    -m /tmp/model-f16.gguf \
+    -f /tmp/ollama-bench-data/wiki.test.raw -c 512 -ngl 99
+```

--- a/x/cmd/ppl/README.md
+++ b/x/cmd/ppl/README.md
@@ -1,0 +1,59 @@
+# ollama-ppl
+
+A perplexity measurement CLI for MLX-loaded language models.
+
+`ollama-ppl` loads any registered MLX model architecture directly (no
+HTTP server, no separate inference process) and runs end-to-end perplexity
+on a corpus. It supports two scoring methodologies:
+
+- **`harness`** (default): reproduces EleutherAI lm-evaluation-harness'
+  `wikitext` task. Document-level rolling loglikelihood with `context_len=1`,
+  scoring every prediction position in each window. The default corpus is
+  fetched from the canonical `EleutherAI/wikitext_document_level` Hugging Face
+  dataset.
+- **`window`**: scores a concatenated token stream in fixed windows.
+  Concatenates the corpus into one stream, splits into non-overlapping
+  fixed-size chunks with BOS substituted at chunk position 0, and scores only
+  the second half of each chunk. This methodology is widely used by other
+  runtimes' perplexity tools, so results are directly comparable across
+  ecosystems. The default corpus is a standard `wiki.test.raw`
+  (wikitext-2-raw) mirror.
+
+Note: for optimal results, use the base trained model, not the instruction-tuned version.
+
+## Examples
+
+```bash
+# Default: harness mode on an ollama-stored model
+go run ./x/cmd/ppl -model mymodel:base-mlx-bf16
+
+# Window mode for cross-ecosystem comparison
+go run ./x/cmd/ppl -model mymodel:base-mlx-bf16 -mode window
+
+# Load from a HuggingFace directory (no ollama tag required)
+go run ./x/cmd/ppl -model-dir models/SomeOrg/SomeModel-Base
+
+# Keep downloaded corpora in a sandbox-friendly cache
+go run ./x/cmd/ppl -model-dir models/SomeOrg/SomeModel-Base \
+  -cache-dir /tmp/ollama-ppl-cache
+
+# Compare against a prior JSON result and fail if relative token PPL drifts >1%
+go run ./x/cmd/ppl -model mymodel:base-mlx-bf16 \
+  -baseline /tmp/baseline-ppl.json \
+  -max-rel-delta 0.01
+```
+
+## Cross-validation
+
+To compare harness mode against an independent reference:
+
+```bash
+pip install lm-eval
+python -m lm_eval --model hf \
+    --model_args pretrained=models/SomeOrg/SomeModel-Base,dtype=bfloat16,trust_remote_code=True,max_length=2048 \
+    --device mps --tasks wikitext
+```
+
+Window mode uses the same corpus, chunking, and scoring conventions as other
+runtimes' perplexity tools, so those numbers can be compared directly when a
+reference implementation publishes them.

--- a/x/cmd/ppl/ppl.go
+++ b/x/cmd/ppl/ppl.go
@@ -1,0 +1,496 @@
+// Command ppl measures perplexity of an MLX-loaded language model on a text
+// corpus. It supports two scoring methodologies:
+//
+//   - "harness" (default): reproduces EleutherAI lm-evaluation-harness'
+//     wikitext task. Document-level rolling loglikelihood with context_len=1.
+//     Default corpus is fetched from the canonical Hugging Face dataset
+//     (EleutherAI/wikitext_document_level, wikitext-2-raw-v1, test split).
+//
+//   - "llamacpp": reproduces llama.cpp's llama-perplexity tool. Concatenates
+//     the corpus into one stream, splits into non-overlapping n_ctx-token
+//     chunks with BOS substituted at chunk position 0, scores only the
+//     second half of each chunk. Default corpus is the wiki.test.raw flat
+//     file from the ggml-org/ci dataset (the source the llama.cpp community
+//     uses).
+//
+// In both modes, -corpus FILE overrides the default fetch with a local file.
+// In harness mode, the file is treated as one document per line; in llamacpp
+// mode, the entire file is one stream.
+//
+// The CLI imports the mlxrunner package transitively to register all
+// supported model architectures. Models are loaded via -model NAME (an
+// ollama tag from the local store) or -model-dir PATH (a HuggingFace-format
+// directory of weights and configs).
+//
+// Usage examples:
+//
+//	# Harness-mode (default) on an already-pulled ollama model
+//	go run ./x/cmd/ppl -model mymodel:base-mlx-bf16
+//
+//	# Llama.cpp-compatible mode for direct comparison with llama-perplexity
+//	go run ./x/cmd/ppl -model mymodel:base-mlx-bf16 -mode llamacpp
+//
+//	# Load straight from a safetensors directory (no ollama tag required)
+//	go run ./x/cmd/ppl -model-dir models/mymodel-Base
+//
+//	# Tighter context for quicker dev iteration
+//	go run ./x/cmd/ppl -model mymodel:base-mlx-bf16 -max-length 512 -max-docs 5
+package main
+
+import (
+	"archive/zip"
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	_ "github.com/ollama/ollama/x/mlxrunner" // register model architectures
+	"github.com/ollama/ollama/x/mlxrunner/model/base"
+	"github.com/ollama/ollama/x/models/testutil"
+)
+
+const (
+	// harnessDataset is the dataset lm-eval-harness uses for its `wikitext`
+	// task. Hosted on the HuggingFace datasets-server.
+	harnessDataset = "EleutherAI/wikitext_document_level"
+	harnessConfig  = "wikitext-2-raw-v1"
+	harnessSplit   = "test"
+
+	// llamacppCorpusURL is the flat-text wiki.test.raw corpus llama.cpp's
+	// llama-perplexity uses, distributed as a zip with a single file inside.
+	llamacppCorpusURL = "https://huggingface.co/datasets/ggml-org/ci/resolve/main/wikitext-2-raw-v1.zip"
+)
+
+func main() {
+	var (
+		modelName    = flag.String("model", "", "ollama model tag to load")
+		modelDir     = flag.String("model-dir", "", "Safetensors model directory (alternative to -model)")
+		modeFlag     = flag.String("mode", "harness", "scoring methodology: harness | llamacpp")
+		corpusPath   = flag.String("corpus", "", "local corpus file (one doc per line in harness mode, single stream in llamacpp mode); default fetches the canonical dataset for the chosen mode")
+		maxLength    = flag.Int("max-length", 0, "context window in tokens (default 2048 for harness, 512 for llamacpp)")
+		maxDocs      = flag.Int("max-docs", 0, "limit number of documents (harness) or chunks (llamacpp); 0 = process all")
+		baselinePath = flag.String("baseline", "", "optional path to a Python baseline JSON for comparison")
+		cacheDirFlag = flag.String("cache-dir", "", "cache directory for downloaded corpora (default: $OLLAMA_PPL_CACHE_DIR or user cache)")
+		maxRelDelta  = flag.Float64("max-rel-delta", 0, "optional maximum absolute relative token PPL delta vs -baseline; 0 disables")
+		outFormat    = flag.String("format", "text", "output format: text | json")
+		verbose      = flag.Bool("verbose", false, "enable per-document/chunk progress logging")
+	)
+	flag.Parse()
+
+	if *modelName == "" && *modelDir == "" {
+		fmt.Fprintln(os.Stderr, "ERROR: one of -model or -model-dir is required")
+		flag.Usage()
+		os.Exit(2)
+	}
+	if *modelName != "" && *modelDir != "" {
+		fmt.Fprintln(os.Stderr, "ERROR: -model and -model-dir are mutually exclusive")
+		os.Exit(2)
+	}
+
+	mode, err := testutil.ParseMode(*modeFlag)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
+		os.Exit(2)
+	}
+
+	cdir, err := resolveCacheDir(*cacheDirFlag)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: cannot resolve cache dir: %v\n", err)
+		os.Exit(1)
+	}
+	if err := os.MkdirAll(cdir, 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: cannot create cache dir %s: %v\n", cdir, err)
+		os.Exit(1)
+	}
+
+	// Logger writes progress to stderr so stdout stays clean for results.
+	var log testutil.Logger = testutil.NewWriterLogger(os.Stderr)
+	if !*verbose {
+		log = testutil.NewWriterLogger(nil) // discard
+	}
+
+	// Load the model.
+	startLoad := time.Now()
+	var (
+		model    base.Model
+		modelTag string
+		cleanup  func()
+	)
+	if *modelName != "" {
+		modelTag = *modelName
+		fmt.Fprintf(os.Stderr, "Loading ollama model %q...\n", *modelName)
+		m, c, err := testutil.LoadModelByNameOrErr(*modelName)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
+			os.Exit(1)
+		}
+		model = m
+		cleanup = c
+	} else {
+		modelTag = filepath.Base(*modelDir)
+		fmt.Fprintf(os.Stderr, "Loading model from %q...\n", *modelDir)
+		blobDir, err := os.MkdirTemp("", "ollama-ppl-blobs-*")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: tempdir: %v\n", err)
+			os.Exit(1)
+		}
+		cleanup = func() { os.RemoveAll(blobDir) }
+		m, err := testutil.LoadModelFromDirOrErr(*modelDir, blobDir)
+		if err != nil {
+			cleanup()
+			fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
+			os.Exit(1)
+		}
+		model = m
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	fmt.Fprintf(os.Stderr, "Loaded in %.1fs\n", time.Since(startLoad).Seconds())
+
+	// Fetch / load the corpus.
+	docs, corpusSource, err := loadCorpus(mode, *corpusPath, cdir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR loading corpus: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Fprintf(os.Stderr, "Corpus: %d documents from %s\n", len(docs), corpusSource)
+
+	// Run perplexity.
+	opts := testutil.PPLOptions{
+		Mode:            mode,
+		MaxLength:       *maxLength,
+		MaxDocs:         *maxDocs,
+		BOSSwapLlamaCpp: mode == testutil.ModeLlamaCpp,
+	}
+	startEval := time.Now()
+	result, err := testutil.RunPerplexity(model, docs, opts, log)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR running perplexity: %v\n", err)
+		os.Exit(1)
+	}
+	evalDur := time.Since(startEval)
+
+	baseline, err := loadBaseline(*baselinePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR loading baseline: %v\n", err)
+		os.Exit(1)
+	}
+	delta := compareBaseline(result, baseline)
+
+	// Print results.
+	if *outFormat == "json" {
+		printJSON(os.Stdout, modelTag, mode, opts, result, evalDur, delta)
+	} else if *outFormat == "text" {
+		printText(os.Stdout, modelTag, mode, opts, result, evalDur, delta)
+	} else {
+		fmt.Fprintf(os.Stderr, "ERROR: unknown -format %q (valid: text, json)\n", *outFormat)
+		os.Exit(2)
+	}
+
+	if *maxRelDelta > 0 && delta != nil && math.Abs(delta.TokenPerplexityRel) > *maxRelDelta {
+		fmt.Fprintf(os.Stderr, "ERROR: relative token PPL delta %.6f exceeds threshold %.6f\n", delta.TokenPerplexityRel, *maxRelDelta)
+		os.Exit(1)
+	}
+}
+
+// resolveCacheDir returns the corpus cache directory. Explicit CLI value wins,
+// then OLLAMA_PPL_CACHE_DIR, then the user's standard cache directory.
+func resolveCacheDir(flagValue string) (string, error) {
+	if flagValue != "" {
+		return flagValue, nil
+	}
+	if env := os.Getenv("OLLAMA_PPL_CACHE_DIR"); env != "" {
+		return env, nil
+	}
+	userCache, err := os.UserCacheDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(userCache, "ollama", "ppl"), nil
+}
+
+// loadCorpus returns documents for the chosen mode. If localPath is non-empty,
+// the local file is used and a humanized source string is returned. Otherwise
+// the canonical dataset for the mode is fetched (with on-disk cache).
+func loadCorpus(mode testutil.Mode, localPath, cacheDir string) ([]testutil.Document, string, error) {
+	if localPath != "" {
+		text, err := os.ReadFile(localPath)
+		if err != nil {
+			return nil, "", err
+		}
+		switch mode {
+		case testutil.ModeHarness:
+			// One document per line. Empty lines are skipped so users can
+			// keep blank separators if they like.
+			var docs []testutil.Document
+			scanner := bufio.NewScanner(bytes.NewReader(text))
+			scanner.Buffer(make([]byte, 1<<20), 1<<27)
+			for scanner.Scan() {
+				line := strings.TrimSpace(scanner.Text())
+				if line == "" {
+					continue
+				}
+				docs = append(docs, testutil.Document{Text: line})
+			}
+			if err := scanner.Err(); err != nil {
+				return nil, "", err
+			}
+			return docs, fmt.Sprintf("local file %s (%d lines)", localPath, len(docs)), nil
+		case testutil.ModeLlamaCpp:
+			return []testutil.Document{{Text: string(text)}}, fmt.Sprintf("local file %s", localPath), nil
+		}
+	}
+
+	switch mode {
+	case testutil.ModeHarness:
+		docs, src, err := fetchHarnessCorpus(cacheDir)
+		return docs, src, err
+	case testutil.ModeLlamaCpp:
+		text, src, err := fetchLlamaCppCorpus(cacheDir)
+		if err != nil {
+			return nil, "", err
+		}
+		return []testutil.Document{{Text: text}}, src, nil
+	}
+	return nil, "", fmt.Errorf("unhandled mode: %v", mode)
+}
+
+// fetchHarnessCorpus fetches the wikitext-2 test split via the HuggingFace
+// datasets-server JSON API. It returns 62 documents (entire test split).
+// Cached on disk after the first fetch.
+func fetchHarnessCorpus(cacheDir string) ([]testutil.Document, string, error) {
+	cachePath := filepath.Join(cacheDir, "wikitext-2-raw-v1-test-harness.json")
+	if data, err := os.ReadFile(cachePath); err == nil {
+		var docs []testutil.Document
+		if err := json.Unmarshal(data, &docs); err == nil && len(docs) > 0 {
+			return docs, fmt.Sprintf("cache %s", cachePath), nil
+		}
+		// fall through and refetch
+	}
+
+	q := url.Values{}
+	q.Set("dataset", harnessDataset)
+	q.Set("config", harnessConfig)
+	q.Set("split", harnessSplit)
+	q.Set("offset", "0")
+	q.Set("length", "100") // wikitext-2 test has 62 docs; 100 fits in one request
+	endpoint := "https://datasets-server.huggingface.co/rows?" + q.Encode()
+
+	fmt.Fprintf(os.Stderr, "Fetching corpus from %s ...\n", harnessDataset)
+	body, err := httpGet(endpoint)
+	if err != nil {
+		return nil, "", fmt.Errorf("fetch wikitext: %w", err)
+	}
+
+	var resp struct {
+		Rows []struct {
+			Row struct {
+				Page string `json:"page"`
+			} `json:"row"`
+			TruncatedCells []string `json:"truncated_cells"`
+		} `json:"rows"`
+		NumRowsTotal int `json:"num_rows_total"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, "", fmt.Errorf("parse wikitext json: %w", err)
+	}
+	if len(resp.Rows) == 0 {
+		return nil, "", fmt.Errorf("no rows returned from datasets-server")
+	}
+	if len(resp.Rows) < resp.NumRowsTotal {
+		return nil, "", fmt.Errorf("partial fetch: got %d of %d rows; pagination not implemented", len(resp.Rows), resp.NumRowsTotal)
+	}
+
+	docs := make([]testutil.Document, 0, len(resp.Rows))
+	for _, r := range resp.Rows {
+		if len(r.TruncatedCells) > 0 {
+			return nil, "", fmt.Errorf("dataset row was truncated by datasets-server; cannot proceed")
+		}
+		// Apply the wikitext detokenizer to what the model sees, but
+		// keep Text (= the original page) for word/byte denominators.
+		// Matches lm-evaluation-harness preprocess_wikitext exactly.
+		page := r.Row.Page
+		docs = append(docs, testutil.Document{
+			Text:        page,
+			ScoringText: testutil.WikitextDetokenize(page),
+		})
+	}
+
+	// Persist cache.
+	if data, err := json.Marshal(docs); err == nil {
+		_ = os.WriteFile(cachePath, data, 0o644)
+	}
+
+	return docs, fmt.Sprintf("HuggingFace %s/%s/%s (%d docs)", harnessDataset, harnessConfig, harnessSplit, len(docs)), nil
+}
+
+// fetchLlamaCppCorpus fetches the wikitext-2-raw-v1.zip from ggml-org/ci on
+// HuggingFace and extracts wiki.test.raw. The text is cached on disk after
+// the first fetch.
+func fetchLlamaCppCorpus(cacheDir string) (string, string, error) {
+	cachePath := filepath.Join(cacheDir, "wiki.test.raw")
+	if data, err := os.ReadFile(cachePath); err == nil && len(data) > 0 {
+		return string(data), fmt.Sprintf("cache %s", cachePath), nil
+	}
+
+	fmt.Fprintf(os.Stderr, "Fetching corpus from %s ...\n", llamacppCorpusURL)
+	body, err := httpGet(llamacppCorpusURL)
+	if err != nil {
+		return "", "", fmt.Errorf("fetch llamacpp corpus: %w", err)
+	}
+
+	zr, err := zip.NewReader(bytes.NewReader(body), int64(len(body)))
+	if err != nil {
+		return "", "", fmt.Errorf("open zip: %w", err)
+	}
+	for _, f := range zr.File {
+		if !strings.HasSuffix(f.Name, "wiki.test.raw") {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return "", "", err
+		}
+		text, err := io.ReadAll(rc)
+		rc.Close()
+		if err != nil {
+			return "", "", err
+		}
+		_ = os.WriteFile(cachePath, text, 0o644)
+		return string(text), fmt.Sprintf("HuggingFace ggml-org/ci %s", filepath.Base(f.Name)), nil
+	}
+	return "", "", fmt.Errorf("wiki.test.raw not found in zip")
+}
+
+// httpGet performs a one-shot GET with a sane timeout.
+func httpGet(rawURL string) ([]byte, error) {
+	client := &http.Client{Timeout: 5 * time.Minute}
+	req, err := http.NewRequest("GET", rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		return nil, fmt.Errorf("HTTP %d %s", resp.StatusCode, resp.Status)
+	}
+	return io.ReadAll(resp.Body)
+}
+
+type pplBaseline struct {
+	Model           string  `json:"model"`
+	Mode            string  `json:"mode"`
+	MaxLength       int     `json:"max_length"`
+	TokenPerplexity float64 `json:"token_perplexity"`
+}
+
+type pplBaselineDelta struct {
+	BaselineModel           string  `json:"baseline_model,omitempty"`
+	BaselineMode            string  `json:"baseline_mode,omitempty"`
+	BaselineMaxLength       int     `json:"baseline_max_length,omitempty"`
+	BaselineTokenPerplexity float64 `json:"baseline_token_perplexity"`
+	TokenPerplexityAbs      float64 `json:"token_perplexity_abs"`
+	TokenPerplexityRel      float64 `json:"token_perplexity_rel"`
+}
+
+func loadBaseline(path string) (*pplBaseline, error) {
+	if path == "" {
+		return nil, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var baseline pplBaseline
+	if err := json.Unmarshal(data, &baseline); err != nil {
+		return nil, err
+	}
+	if baseline.TokenPerplexity <= 0 {
+		return nil, fmt.Errorf("%s has invalid token_perplexity: %f", path, baseline.TokenPerplexity)
+	}
+	return &baseline, nil
+}
+
+func compareBaseline(r testutil.PPLResult, baseline *pplBaseline) *pplBaselineDelta {
+	if baseline == nil {
+		return nil
+	}
+	abs := r.TokenPerplexity - baseline.TokenPerplexity
+	rel := abs / baseline.TokenPerplexity
+	return &pplBaselineDelta{
+		BaselineModel:           baseline.Model,
+		BaselineMode:            baseline.Mode,
+		BaselineMaxLength:       baseline.MaxLength,
+		BaselineTokenPerplexity: baseline.TokenPerplexity,
+		TokenPerplexityAbs:      abs,
+		TokenPerplexityRel:      rel,
+	}
+}
+
+func printText(w io.Writer, modelTag string, mode testutil.Mode, opts testutil.PPLOptions, r testutil.PPLResult, dur time.Duration, delta *pplBaselineDelta) {
+	fmt.Fprintf(w, "\nModel:        %s\n", modelTag)
+	fmt.Fprintf(w, "Mode:         %s\n", mode)
+	fmt.Fprintf(w, "Max length:   %d\n", opts.MaxLength)
+	fmt.Fprintf(w, "Eval time:    %.1fs\n", dur.Seconds())
+	fmt.Fprintf(w, "Tokens:       %d scored\n", r.TotalTokens)
+	if r.TotalWords > 0 {
+		fmt.Fprintf(w, "Words:        %d\n", r.TotalWords)
+	}
+	if r.TotalChars > 0 {
+		fmt.Fprintf(w, "Bytes:        %d\n", r.TotalChars)
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "Token PPL:        %12.4f  +/- %.4f\n", r.TokenPerplexity, r.StderrTokenPPL)
+	if r.WordPerplexity > 0 {
+		fmt.Fprintf(w, "Word PPL:         %12.4f\n", r.WordPerplexity)
+	}
+	if r.BytePerplexity > 0 {
+		fmt.Fprintf(w, "Byte PPL:         %12.4f\n", r.BytePerplexity)
+		fmt.Fprintf(w, "Bits per byte:    %12.4f\n", r.BitsPerByte)
+	}
+	if delta != nil {
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "Baseline token PPL: %10.4f\n", delta.BaselineTokenPerplexity)
+		fmt.Fprintf(w, "Token PPL delta:    %+10.4f (%+.4f%%)\n",
+			delta.TokenPerplexityAbs,
+			delta.TokenPerplexityRel*100,
+		)
+	}
+	fmt.Fprintln(w)
+}
+
+func printJSON(w io.Writer, modelTag string, mode testutil.Mode, opts testutil.PPLOptions, r testutil.PPLResult, dur time.Duration, delta *pplBaselineDelta) {
+	out := map[string]any{
+		"model":            modelTag,
+		"mode":             mode.String(),
+		"max_length":       opts.MaxLength,
+		"eval_seconds":     dur.Seconds(),
+		"total_tokens":     r.TotalTokens,
+		"total_words":      r.TotalWords,
+		"total_bytes":      r.TotalChars,
+		"token_perplexity": r.TokenPerplexity,
+		"stderr_token_ppl": r.StderrTokenPPL,
+		"word_perplexity":  r.WordPerplexity,
+		"byte_perplexity":  r.BytePerplexity,
+		"bits_per_byte":    r.BitsPerByte,
+	}
+	if delta != nil {
+		out["baseline_delta"] = delta
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(out)
+}

--- a/x/cmd/ppl/ppl.go
+++ b/x/cmd/ppl/ppl.go
@@ -1,0 +1,510 @@
+// Command ppl measures perplexity of an MLX-loaded language model on a text
+// corpus. It supports two scoring methodologies:
+//
+//   - "harness" (default): reproduces EleutherAI lm-evaluation-harness'
+//     wikitext task. Document-level rolling loglikelihood with context_len=1.
+//     Default corpus is fetched from the canonical Hugging Face dataset
+//     (EleutherAI/wikitext_document_level, wikitext-2-raw-v1, test split).
+//
+//   - "window": scores a concatenated token stream in fixed windows.
+//     Concatenates the corpus into one stream, splits into non-overlapping
+//     fixed-size chunks with BOS substituted at chunk position 0, and scores
+//     only the second half of each chunk. This methodology is widely used by
+//     other runtimes' perplexity tools, so results are directly comparable
+//     across ecosystems. Default corpus is a standard wikitext-2-raw
+//     wiki.test.raw mirror.
+//
+// In both modes, -corpus FILE overrides the default fetch with a local file.
+// In harness mode, the file is treated as one document per line; in window
+// mode, the entire file is one stream.
+//
+// The CLI imports the mlxrunner package transitively to register all
+// supported model architectures. Models are loaded via -model NAME (an
+// ollama tag from the local store) or -model-dir PATH (a HuggingFace-format
+// directory of weights and configs).
+//
+// Usage examples:
+//
+//	# Harness-mode (default) on an already-pulled ollama model
+//	go run ./x/cmd/ppl -model mymodel:base-mlx-bf16
+//
+//	# Window mode for cross-ecosystem comparison
+//	go run ./x/cmd/ppl -model mymodel:base-mlx-bf16 -mode window
+//
+//	# Load straight from a safetensors directory (no ollama tag required)
+//	go run ./x/cmd/ppl -model-dir models/mymodel-Base
+//
+//	# Tighter context for quicker dev iteration
+//	go run ./x/cmd/ppl -model mymodel:base-mlx-bf16 -max-length 512 -max-docs 5
+package main
+
+import (
+	"archive/zip"
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	_ "github.com/ollama/ollama/x/mlxrunner" // register model architectures
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/mlxrunner/model/base"
+	"github.com/ollama/ollama/x/models/testutil"
+)
+
+const (
+	// harnessDataset is the dataset lm-eval-harness uses for its `wikitext`
+	// task. Hosted on the HuggingFace datasets-server.
+	harnessDataset = "EleutherAI/wikitext_document_level"
+	harnessConfig  = "wikitext-2-raw-v1"
+	harnessSplit   = "test"
+
+	// windowCorpusURL is the wikitext-2-raw distribution hosted by the
+	// dataset author. Using this exact file keeps window-mode results
+	// comparable across ecosystems, which mirror the same archive.
+	windowCorpusURL = "https://wikitext.smerity.com/wikitext-2-raw-v1.zip"
+)
+
+func main() {
+	// MLX default streams are thread-local: pin the main goroutine to its OS
+	// thread for the process lifetime, or lazy evaluation panics with
+	// "There is no Stream(...) in current thread" when Go migrates it.
+	runtime.LockOSThread()
+	if err := mlx.CheckInit(); err == nil {
+		if mlx.GPUIsAvailable() {
+			mlx.SetDefaultDeviceGPU()
+			fmt.Fprintln(os.Stderr, "MLX device: GPU")
+		} else {
+			fmt.Fprintln(os.Stderr, "MLX device: CPU (no GPU available)")
+		}
+	}
+
+	var (
+		modelName    = flag.String("model", "", "ollama model tag to load")
+		modelDir     = flag.String("model-dir", "", "Safetensors model directory (alternative to -model)")
+		modeFlag     = flag.String("mode", "harness", "scoring methodology: harness | window")
+		corpusPath   = flag.String("corpus", "", "local corpus file (one doc per line in harness mode, single stream in window mode); default fetches the canonical dataset for the chosen mode")
+		maxLength    = flag.Int("max-length", 0, "context window in tokens (default 2048 for harness, 512 for window)")
+		maxDocs      = flag.Int("max-docs", 0, "limit number of documents (harness) or chunks (window); 0 = process all")
+		baselinePath = flag.String("baseline", "", "optional path to a Python baseline JSON for comparison")
+		cacheDirFlag = flag.String("cache-dir", "", "cache directory for downloaded corpora (default: user cache dir)")
+		maxRelDelta  = flag.Float64("max-rel-delta", 0, "optional maximum absolute relative token PPL delta vs -baseline; 0 disables")
+		outFormat    = flag.String("format", "text", "output format: text | json")
+		verbose      = flag.Bool("verbose", false, "enable per-document/chunk progress logging")
+	)
+	flag.Parse()
+
+	if *modelName == "" && *modelDir == "" {
+		fmt.Fprintln(os.Stderr, "ERROR: one of -model or -model-dir is required")
+		flag.Usage()
+		os.Exit(2)
+	}
+	if *modelName != "" && *modelDir != "" {
+		fmt.Fprintln(os.Stderr, "ERROR: -model and -model-dir are mutually exclusive")
+		os.Exit(2)
+	}
+
+	mode, err := testutil.ParseMode(*modeFlag)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
+		os.Exit(2)
+	}
+
+	cdir, err := resolveCacheDir(*cacheDirFlag)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: cannot resolve cache dir: %v\n", err)
+		os.Exit(1)
+	}
+	if err := os.MkdirAll(cdir, 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: cannot create cache dir %s: %v\n", cdir, err)
+		os.Exit(1)
+	}
+
+	// Logger writes progress to stderr so stdout stays clean for results.
+	var log testutil.Logger = testutil.NewWriterLogger(os.Stderr)
+	if !*verbose {
+		log = testutil.NewWriterLogger(nil) // discard
+	}
+
+	// Load the model.
+	startLoad := time.Now()
+	var (
+		model    base.Model
+		modelTag string
+		cleanup  func()
+	)
+	if *modelName != "" {
+		modelTag = *modelName
+		fmt.Fprintf(os.Stderr, "Loading ollama model %q...\n", *modelName)
+		m, c, err := testutil.LoadModelByNameOrErr(*modelName)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
+			os.Exit(1)
+		}
+		model = m
+		cleanup = c
+	} else {
+		modelTag = filepath.Base(*modelDir)
+		fmt.Fprintf(os.Stderr, "Loading model from %q...\n", *modelDir)
+		blobDir, err := os.MkdirTemp("", "ollama-ppl-blobs-*")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: tempdir: %v\n", err)
+			os.Exit(1)
+		}
+		cleanup = func() { os.RemoveAll(blobDir) }
+		m, err := testutil.LoadModelFromDirOrErr(*modelDir, blobDir)
+		if err != nil {
+			cleanup()
+			fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
+			os.Exit(1)
+		}
+		model = m
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	fmt.Fprintf(os.Stderr, "Loaded in %.1fs\n", time.Since(startLoad).Seconds())
+
+	// Fetch / load the corpus.
+	docs, corpusSource, err := loadCorpus(mode, *corpusPath, cdir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR loading corpus: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Fprintf(os.Stderr, "Corpus: %d documents from %s\n", len(docs), corpusSource)
+
+	// Run perplexity.
+	opts := testutil.PPLOptions{
+		Mode:            mode,
+		MaxLength:       *maxLength,
+		MaxDocs:         *maxDocs,
+		BOSSubstitution: mode == testutil.ModeWindow,
+	}
+	startEval := time.Now()
+	result, err := testutil.RunPerplexity(model, docs, opts, log)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR running perplexity: %v\n", err)
+		os.Exit(1)
+	}
+	evalDur := time.Since(startEval)
+
+	baseline, err := loadBaseline(*baselinePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR loading baseline: %v\n", err)
+		os.Exit(1)
+	}
+	delta := compareBaseline(result, baseline)
+
+	// Print results.
+	if *outFormat == "json" {
+		printJSON(os.Stdout, modelTag, mode, opts, result, evalDur, delta)
+	} else if *outFormat == "text" {
+		printText(os.Stdout, modelTag, mode, opts, result, evalDur, delta)
+	} else {
+		fmt.Fprintf(os.Stderr, "ERROR: unknown -format %q (valid: text, json)\n", *outFormat)
+		os.Exit(2)
+	}
+
+	if *maxRelDelta > 0 && delta != nil && math.Abs(delta.TokenPerplexityRel) > *maxRelDelta {
+		fmt.Fprintf(os.Stderr, "ERROR: relative token PPL delta %.6f exceeds threshold %.6f\n", delta.TokenPerplexityRel, *maxRelDelta)
+		os.Exit(1)
+	}
+}
+
+// resolveCacheDir returns the corpus cache directory: the explicit CLI value
+// when set, otherwise the user's standard cache directory.
+func resolveCacheDir(flagValue string) (string, error) {
+	if flagValue != "" {
+		return flagValue, nil
+	}
+	userCache, err := os.UserCacheDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(userCache, "ollama", "ppl"), nil
+}
+
+// loadCorpus returns documents for the chosen mode. If localPath is non-empty,
+// the local file is used and a humanized source string is returned. Otherwise
+// the canonical dataset for the mode is fetched (with on-disk cache).
+func loadCorpus(mode testutil.Mode, localPath, cacheDir string) ([]testutil.Document, string, error) {
+	if localPath != "" {
+		text, err := os.ReadFile(localPath)
+		if err != nil {
+			return nil, "", err
+		}
+		switch mode {
+		case testutil.ModeHarness:
+			// One document per line. Empty lines are skipped so users can
+			// keep blank separators if they like.
+			var docs []testutil.Document
+			scanner := bufio.NewScanner(bytes.NewReader(text))
+			scanner.Buffer(make([]byte, 1<<20), 1<<27)
+			for scanner.Scan() {
+				line := strings.TrimSpace(scanner.Text())
+				if line == "" {
+					continue
+				}
+				docs = append(docs, testutil.Document{Text: line})
+			}
+			if err := scanner.Err(); err != nil {
+				return nil, "", err
+			}
+			return docs, fmt.Sprintf("local file %s (%d lines)", localPath, len(docs)), nil
+		case testutil.ModeWindow:
+			return []testutil.Document{{Text: string(text)}}, fmt.Sprintf("local file %s", localPath), nil
+		}
+	}
+
+	switch mode {
+	case testutil.ModeHarness:
+		docs, src, err := fetchHarnessCorpus(cacheDir)
+		return docs, src, err
+	case testutil.ModeWindow:
+		text, src, err := fetchWindowCorpus(cacheDir)
+		if err != nil {
+			return nil, "", err
+		}
+		return []testutil.Document{{Text: text}}, src, nil
+	}
+	return nil, "", fmt.Errorf("unhandled mode: %v", mode)
+}
+
+// fetchHarnessCorpus fetches the wikitext-2 test split via the HuggingFace
+// datasets-server JSON API. It returns 62 documents (entire test split).
+// Cached on disk after the first fetch.
+func fetchHarnessCorpus(cacheDir string) ([]testutil.Document, string, error) {
+	cachePath := filepath.Join(cacheDir, "wikitext-2-raw-v1-test-harness.json")
+	if data, err := os.ReadFile(cachePath); err == nil {
+		var docs []testutil.Document
+		if err := json.Unmarshal(data, &docs); err == nil && len(docs) > 0 {
+			return docs, fmt.Sprintf("cache %s", cachePath), nil
+		}
+		// fall through and refetch
+	}
+
+	q := url.Values{}
+	q.Set("dataset", harnessDataset)
+	q.Set("config", harnessConfig)
+	q.Set("split", harnessSplit)
+	q.Set("offset", "0")
+	q.Set("length", "100") // wikitext-2 test has 62 docs; 100 fits in one request
+	endpoint := "https://datasets-server.huggingface.co/rows?" + q.Encode()
+
+	fmt.Fprintf(os.Stderr, "Fetching corpus from %s ...\n", harnessDataset)
+	body, err := httpGet(endpoint)
+	if err != nil {
+		return nil, "", fmt.Errorf("fetch wikitext: %w", err)
+	}
+
+	var resp struct {
+		Rows []struct {
+			Row struct {
+				Page string `json:"page"`
+			} `json:"row"`
+			TruncatedCells []string `json:"truncated_cells"`
+		} `json:"rows"`
+		NumRowsTotal int `json:"num_rows_total"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, "", fmt.Errorf("parse wikitext json: %w", err)
+	}
+	if len(resp.Rows) == 0 {
+		return nil, "", fmt.Errorf("no rows returned from datasets-server")
+	}
+	if len(resp.Rows) < resp.NumRowsTotal {
+		return nil, "", fmt.Errorf("partial fetch: got %d of %d rows; pagination not implemented", len(resp.Rows), resp.NumRowsTotal)
+	}
+
+	docs := make([]testutil.Document, 0, len(resp.Rows))
+	for _, r := range resp.Rows {
+		if len(r.TruncatedCells) > 0 {
+			return nil, "", fmt.Errorf("dataset row was truncated by datasets-server; cannot proceed")
+		}
+		// Apply the wikitext detokenizer to what the model sees, but
+		// keep Text (= the original page) for word/byte denominators.
+		// Matches lm-evaluation-harness preprocess_wikitext exactly.
+		page := r.Row.Page
+		docs = append(docs, testutil.Document{
+			Text:        page,
+			ScoringText: testutil.WikitextDetokenize(page),
+		})
+	}
+
+	// Persist cache.
+	if data, err := json.Marshal(docs); err == nil {
+		_ = os.WriteFile(cachePath, data, 0o644)
+	}
+
+	return docs, fmt.Sprintf("HuggingFace %s/%s/%s (%d docs)", harnessDataset, harnessConfig, harnessSplit, len(docs)), nil
+}
+
+// fetchWindowCorpus fetches the standard wikitext-2-raw-v1.zip mirror on
+// HuggingFace and extracts wiki.test.raw. The text is cached on disk after
+// the first fetch.
+func fetchWindowCorpus(cacheDir string) (string, string, error) {
+	cachePath := filepath.Join(cacheDir, "wiki.test.raw")
+	if data, err := os.ReadFile(cachePath); err == nil && len(data) > 0 {
+		return string(data), fmt.Sprintf("cache %s", cachePath), nil
+	}
+
+	fmt.Fprintf(os.Stderr, "Fetching corpus from %s ...\n", windowCorpusURL)
+	body, err := httpGet(windowCorpusURL)
+	if err != nil {
+		return "", "", fmt.Errorf("fetch window-mode corpus: %w", err)
+	}
+
+	zr, err := zip.NewReader(bytes.NewReader(body), int64(len(body)))
+	if err != nil {
+		return "", "", fmt.Errorf("open zip: %w", err)
+	}
+	for _, f := range zr.File {
+		if !strings.HasSuffix(f.Name, "wiki.test.raw") {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return "", "", err
+		}
+		text, err := io.ReadAll(rc)
+		rc.Close()
+		if err != nil {
+			return "", "", err
+		}
+		_ = os.WriteFile(cachePath, text, 0o644)
+		return string(text), fmt.Sprintf("wikitext-2-raw %s", filepath.Base(f.Name)), nil
+	}
+	return "", "", fmt.Errorf("wiki.test.raw not found in zip")
+}
+
+// httpGet performs a one-shot GET with a sane timeout.
+func httpGet(rawURL string) ([]byte, error) {
+	client := &http.Client{Timeout: 5 * time.Minute}
+	req, err := http.NewRequest("GET", rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		return nil, fmt.Errorf("HTTP %d %s", resp.StatusCode, resp.Status)
+	}
+	return io.ReadAll(resp.Body)
+}
+
+type pplBaseline struct {
+	Model           string  `json:"model"`
+	Mode            string  `json:"mode"`
+	MaxLength       int     `json:"max_length"`
+	TokenPerplexity float64 `json:"token_perplexity"`
+}
+
+type pplBaselineDelta struct {
+	BaselineModel           string  `json:"baseline_model,omitempty"`
+	BaselineMode            string  `json:"baseline_mode,omitempty"`
+	BaselineMaxLength       int     `json:"baseline_max_length,omitempty"`
+	BaselineTokenPerplexity float64 `json:"baseline_token_perplexity"`
+	TokenPerplexityAbs      float64 `json:"token_perplexity_abs"`
+	TokenPerplexityRel      float64 `json:"token_perplexity_rel"`
+}
+
+func loadBaseline(path string) (*pplBaseline, error) {
+	if path == "" {
+		return nil, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var baseline pplBaseline
+	if err := json.Unmarshal(data, &baseline); err != nil {
+		return nil, err
+	}
+	if baseline.TokenPerplexity <= 0 {
+		return nil, fmt.Errorf("%s has invalid token_perplexity: %f", path, baseline.TokenPerplexity)
+	}
+	return &baseline, nil
+}
+
+func compareBaseline(r testutil.PPLResult, baseline *pplBaseline) *pplBaselineDelta {
+	if baseline == nil {
+		return nil
+	}
+	abs := r.TokenPerplexity - baseline.TokenPerplexity
+	rel := abs / baseline.TokenPerplexity
+	return &pplBaselineDelta{
+		BaselineModel:           baseline.Model,
+		BaselineMode:            baseline.Mode,
+		BaselineMaxLength:       baseline.MaxLength,
+		BaselineTokenPerplexity: baseline.TokenPerplexity,
+		TokenPerplexityAbs:      abs,
+		TokenPerplexityRel:      rel,
+	}
+}
+
+func printText(w io.Writer, modelTag string, mode testutil.Mode, opts testutil.PPLOptions, r testutil.PPLResult, dur time.Duration, delta *pplBaselineDelta) {
+	fmt.Fprintf(w, "\nModel:        %s\n", modelTag)
+	fmt.Fprintf(w, "Mode:         %s\n", mode)
+	fmt.Fprintf(w, "Max length:   %d\n", opts.MaxLength)
+	fmt.Fprintf(w, "Eval time:    %.1fs\n", dur.Seconds())
+	fmt.Fprintf(w, "Tokens:       %d scored\n", r.TotalTokens)
+	if r.TotalWords > 0 {
+		fmt.Fprintf(w, "Words:        %d\n", r.TotalWords)
+	}
+	if r.TotalChars > 0 {
+		fmt.Fprintf(w, "Bytes:        %d\n", r.TotalChars)
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "Token PPL:        %12.4f  +/- %.4f\n", r.TokenPerplexity, r.StderrTokenPPL)
+	if r.WordPerplexity > 0 {
+		fmt.Fprintf(w, "Word PPL:         %12.4f\n", r.WordPerplexity)
+	}
+	if r.BytePerplexity > 0 {
+		fmt.Fprintf(w, "Byte PPL:         %12.4f\n", r.BytePerplexity)
+		fmt.Fprintf(w, "Bits per byte:    %12.4f\n", r.BitsPerByte)
+	}
+	if delta != nil {
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "Baseline token PPL: %10.4f\n", delta.BaselineTokenPerplexity)
+		fmt.Fprintf(w, "Token PPL delta:    %+10.4f (%+.4f%%)\n",
+			delta.TokenPerplexityAbs,
+			delta.TokenPerplexityRel*100,
+		)
+	}
+	fmt.Fprintln(w)
+}
+
+func printJSON(w io.Writer, modelTag string, mode testutil.Mode, opts testutil.PPLOptions, r testutil.PPLResult, dur time.Duration, delta *pplBaselineDelta) {
+	out := map[string]any{
+		"model":            modelTag,
+		"mode":             mode.String(),
+		"max_length":       opts.MaxLength,
+		"eval_seconds":     dur.Seconds(),
+		"total_tokens":     r.TotalTokens,
+		"total_words":      r.TotalWords,
+		"total_bytes":      r.TotalChars,
+		"token_perplexity": r.TokenPerplexity,
+		"stderr_token_ppl": r.StderrTokenPPL,
+		"word_perplexity":  r.WordPerplexity,
+		"byte_perplexity":  r.BytePerplexity,
+		"bits_per_byte":    r.BitsPerByte,
+	}
+	if delta != nil {
+		out["baseline_delta"] = delta
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(out)
+}

--- a/x/cmd/ppl/ppl_test.go
+++ b/x/cmd/ppl/ppl_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ollama/ollama/x/models/testutil"
+)
+
+func TestResolveCacheDirPrecedence(t *testing.T) {
+	t.Setenv("OLLAMA_PPL_CACHE_DIR", "/env/cache")
+	got, err := resolveCacheDir("/flag/cache")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "/flag/cache" {
+		t.Fatalf("resolveCacheDir flag = %q, want /flag/cache", got)
+	}
+
+	got, err = resolveCacheDir("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "/env/cache" {
+		t.Fatalf("resolveCacheDir env = %q, want /env/cache", got)
+	}
+}
+
+func TestResolveCacheDirDefault(t *testing.T) {
+	t.Setenv("OLLAMA_PPL_CACHE_DIR", "")
+	got, err := resolveCacheDir("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantSuffix := filepath.Join("ollama", "ppl")
+	if !strings.HasSuffix(got, wantSuffix) {
+		t.Fatalf("resolveCacheDir default = %q, want suffix %q", got, wantSuffix)
+	}
+}
+
+func TestLoadAndCompareBaseline(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "baseline.json")
+	if err := os.WriteFile(path, []byte(`{"model":"hf","mode":"harness","max_length":128,"token_perplexity":10}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	baseline, err := loadBaseline(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	delta := compareBaseline(testutil.PPLResult{TokenPerplexity: 11}, baseline)
+	if delta == nil {
+		t.Fatal("expected delta")
+	}
+	if delta.TokenPerplexityAbs != 1 {
+		t.Fatalf("abs delta = %f, want 1", delta.TokenPerplexityAbs)
+	}
+	if delta.TokenPerplexityRel != 0.1 {
+		t.Fatalf("rel delta = %f, want 0.1", delta.TokenPerplexityRel)
+	}
+}
+
+func TestLoadBaselineRejectsInvalidPPL(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "baseline.json")
+	if err := os.WriteFile(path, []byte(`{"token_perplexity":0}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadBaseline(path); err == nil {
+		t.Fatal("expected invalid baseline error")
+	}
+}
+
+func TestPrintJSONIncludesBaselineDelta(t *testing.T) {
+	var buf bytes.Buffer
+	delta := &pplBaselineDelta{
+		BaselineModel:           "hf",
+		BaselineMode:            "harness",
+		BaselineMaxLength:       128,
+		BaselineTokenPerplexity: 10,
+		TokenPerplexityAbs:      1,
+		TokenPerplexityRel:      0.1,
+	}
+	printJSON(
+		&buf,
+		"mlx",
+		testutil.ModeHarness,
+		testutil.PPLOptions{MaxLength: 128},
+		testutil.PPLResult{TokenPerplexity: 11, TotalTokens: 20},
+		time.Second,
+		delta,
+	)
+
+	var out map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	rawDelta, ok := out["baseline_delta"].(map[string]any)
+	if !ok {
+		t.Fatalf("baseline_delta missing from JSON: %#v", out)
+	}
+	if rawDelta["token_perplexity_rel"] != 0.1 {
+		t.Fatalf("rel delta = %#v, want 0.1", rawDelta["token_perplexity_rel"])
+	}
+}
+
+func TestPrintTextIncludesBaselineDelta(t *testing.T) {
+	var buf bytes.Buffer
+	printText(
+		&buf,
+		"mlx",
+		testutil.ModeHarness,
+		testutil.PPLOptions{MaxLength: 128},
+		testutil.PPLResult{TokenPerplexity: 11, StderrTokenPPL: 0.2, TotalTokens: 20},
+		time.Second,
+		&pplBaselineDelta{
+			BaselineTokenPerplexity: 10,
+			TokenPerplexityAbs:      1,
+			TokenPerplexityRel:      0.1,
+		},
+	)
+	text := buf.String()
+	if !strings.Contains(text, "Baseline token PPL") {
+		t.Fatalf("baseline summary missing from text output:\n%s", text)
+	}
+	if !strings.Contains(text, "+10.0000%") {
+		t.Fatalf("relative delta missing from text output:\n%s", text)
+	}
+}

--- a/x/cmd/ppl/ppl_test.go
+++ b/x/cmd/ppl/ppl_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ollama/ollama/x/models/testutil"
+)
+
+func TestResolveCacheDirPrecedence(t *testing.T) {
+	got, err := resolveCacheDir("/flag/cache")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "/flag/cache" {
+		t.Fatalf("resolveCacheDir flag = %q, want /flag/cache", got)
+	}
+}
+
+func TestResolveCacheDirDefault(t *testing.T) {
+	got, err := resolveCacheDir("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantSuffix := filepath.Join("ollama", "ppl")
+	if !strings.HasSuffix(got, wantSuffix) {
+		t.Fatalf("resolveCacheDir default = %q, want suffix %q", got, wantSuffix)
+	}
+}
+
+func TestLoadAndCompareBaseline(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "baseline.json")
+	if err := os.WriteFile(path, []byte(`{"model":"hf","mode":"harness","max_length":128,"token_perplexity":10}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	baseline, err := loadBaseline(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	delta := compareBaseline(testutil.PPLResult{TokenPerplexity: 11}, baseline)
+	if delta == nil {
+		t.Fatal("expected delta")
+	}
+	if delta.TokenPerplexityAbs != 1 {
+		t.Fatalf("abs delta = %f, want 1", delta.TokenPerplexityAbs)
+	}
+	if delta.TokenPerplexityRel != 0.1 {
+		t.Fatalf("rel delta = %f, want 0.1", delta.TokenPerplexityRel)
+	}
+}
+
+func TestLoadBaselineRejectsInvalidPPL(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "baseline.json")
+	if err := os.WriteFile(path, []byte(`{"token_perplexity":0}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadBaseline(path); err == nil {
+		t.Fatal("expected invalid baseline error")
+	}
+}
+
+func TestPrintJSONIncludesBaselineDelta(t *testing.T) {
+	var buf bytes.Buffer
+	delta := &pplBaselineDelta{
+		BaselineModel:           "hf",
+		BaselineMode:            "harness",
+		BaselineMaxLength:       128,
+		BaselineTokenPerplexity: 10,
+		TokenPerplexityAbs:      1,
+		TokenPerplexityRel:      0.1,
+	}
+	printJSON(
+		&buf,
+		"mlx",
+		testutil.ModeHarness,
+		testutil.PPLOptions{MaxLength: 128},
+		testutil.PPLResult{TokenPerplexity: 11, TotalTokens: 20},
+		time.Second,
+		delta,
+	)
+
+	var out map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	rawDelta, ok := out["baseline_delta"].(map[string]any)
+	if !ok {
+		t.Fatalf("baseline_delta missing from JSON: %#v", out)
+	}
+	if rawDelta["token_perplexity_rel"] != 0.1 {
+		t.Fatalf("rel delta = %#v, want 0.1", rawDelta["token_perplexity_rel"])
+	}
+}
+
+func TestPrintTextIncludesBaselineDelta(t *testing.T) {
+	var buf bytes.Buffer
+	printText(
+		&buf,
+		"mlx",
+		testutil.ModeHarness,
+		testutil.PPLOptions{MaxLength: 128},
+		testutil.PPLResult{TokenPerplexity: 11, StderrTokenPPL: 0.2, TotalTokens: 20},
+		time.Second,
+		&pplBaselineDelta{
+			BaselineTokenPerplexity: 10,
+			TokenPerplexityAbs:      1,
+			TokenPerplexityRel:      0.1,
+		},
+	)
+	text := buf.String()
+	if !strings.Contains(text, "Baseline token PPL") {
+		t.Fatalf("baseline summary missing from text output:\n%s", text)
+	}
+	if !strings.Contains(text, "+10.0000%") {
+		t.Fatalf("relative delta missing from text output:\n%s", text)
+	}
+}

--- a/x/internal/mlxthread/thread.go
+++ b/x/internal/mlxthread/thread.go
@@ -1,3 +1,6 @@
+// Package mlxthread runs all MLX work through a single worker goroutine
+// locked to one OS thread, as the MLX threading contract requires (see
+// the x/mlxrunner/mlx package doc).
 package mlxthread
 
 import (

--- a/x/mlxrunner/mlx/doc.go
+++ b/x/mlxrunner/mlx/doc.go
@@ -1,0 +1,17 @@
+// Package mlx wraps the MLX C API.
+//
+// # Threading contract (read before calling from a new goroutine)
+//
+// MLX default streams are thread-local (since MLX 0.31.2): an array
+// records the default stream of the thread that created it and can only
+// be evaluated on that thread. Cross-thread evaluation panics with
+// "There is no Stream(gpu, N) in current thread". There are no defensive
+// checks — the panic is the enforcement.
+//
+// Callers must therefore do all MLX work from a single pinned goroutine
+// per component: production uses x/internal/mlxthread (inference) and
+// x/create's pinned thread (quantization); tests use x/internal/mlxtest.
+// DefaultStream resolves per thread. To pass arrays across threads, Eval
+// them first — an already-evaluated array is plain data and safe to read
+// from any thread (upstream behavior, ml-explore/mlx#3529).
+package mlx

--- a/x/mlxrunner/mlx/ops_extra.go
+++ b/x/mlxrunner/mlx/ops_extra.go
@@ -481,6 +481,13 @@ func Logaddexp(a, b *Array) *Array {
 	return out
 }
 
+// LogSumexpAxis computes log(sum(exp(a))) along the given axis.
+func LogSumexpAxis(a *Array, axis int, keepDims bool) *Array {
+	out := New("LOGSUMEXP_AXIS")
+	C.mlx_logsumexp_axis(&out.ctx, a.ctx, C.int(axis), C.bool(keepDims), DefaultStream().ctx)
+	return out
+}
+
 func SoftmaxAxis(a *Array, axis int, precise bool) *Array {
 	out := New("SOFTMAX_AXIS")
 	C.mlx_softmax_axis(&out.ctx, a.ctx, C.int(axis), C.bool(precise), DefaultStream().ctx)

--- a/x/mlxrunner/mlx/ops_extra.go
+++ b/x/mlxrunner/mlx/ops_extra.go
@@ -509,6 +509,13 @@ func Logaddexp(a, b *Array) *Array {
 	return out
 }
 
+// LogSumexpAxis computes log(sum(exp(a))) along the given axis.
+func LogSumexpAxis(a *Array, axis int, keepDims bool) *Array {
+	out := New("LOGSUMEXP_AXIS")
+	C.mlx_logsumexp_axis(&out.ctx, a.ctx, C.int(axis), C.bool(keepDims), DefaultStream().ctx)
+	return out
+}
+
 func SoftmaxAxis(a *Array, axis int, precise bool) *Array {
 	out := New("SOFTMAX_AXIS")
 	C.mlx_softmax_axis(&out.ctx, a.ctx, C.int(axis), C.bool(precise), DefaultStream().ctx)

--- a/x/models/AGENTS.md
+++ b/x/models/AGENTS.md
@@ -1,0 +1,72 @@
+# MLX Model Porting Agent Guide
+
+This directory contains experimental MLX model implementations and the tooling
+used to validate new architecture ports. Treat this file as the local process
+guide for humans and coding agents working under `x/models`.
+
+## Porting Standard
+
+- Use a reference-driven workflow. The source of truth is the canonical
+  `transformers` implementation for the target architecture unless a maintainer
+  explicitly names another reference.
+- Keep model ports readable and local to the new architecture. Do not refactor
+  shared utilities, cache behavior, tokenizer code, or existing model files
+  unless the task explicitly requires it.
+- Prefer the patterns already used by nearby MLX models (`llama`, `qwen3_5`,
+  `gemma4`) over new abstractions.
+- Preserve reviewer signal. Do not claim a port is complete without recording
+  the commands, model revision or local path, prompt, dtype, numerical
+  comparisons, perplexity results, generation samples, known skips, and known
+  limitations.
+
+## Required Workflow
+
+1. Read `x/models/PORTING_GUIDE.md`.
+2. Inspect the model before implementing:
+
+   ```bash
+   python3 x/models/scripts/inspect_model.py \
+       --model /path/to/hf/model-or-variant \
+       --output /tmp/ollama_port/<arch>
+   ```
+
+3. Generate PyTorch reference activations with `dump_activations.py`. Keep the
+   generated sidecar manifest next to the safetensors output. If reference
+   settings such as attention backend or cache mode are in question, compare
+   the resulting artifacts with `compare_activations.py`. For cache-specific
+   checks, use `dump_activations.py --decode-text` or `--decode-token-id` so
+   the reference captures a decode pass after cached prefill.
+4. Implement the smallest model-specific Go code needed to reproduce the
+   reference forward pass.
+5. Add forward-pass tests that load the reference activations and compare layer
+   outputs with `x/models/testutil`.
+6. Add long-sequence, cache, quantized, thinking, or multimodal validation when
+   the architecture has those risks.
+7. Run `x/cmd/ppl` for end-to-end quality once the forward pass matches.
+8. Run integration tests with `OLLAMA_TEST_MODEL` against a created local tag
+   as final validation. Do this after focused tests pass; integration tests are
+   too slow and broad to replace model-specific unit and reference tests.
+9. Produce a reviewer report with `summarize_validation.py`.
+
+## Validation Rules
+
+- Exact element-wise tolerance is appropriate for single operations such as
+  embedding lookup, matmul, and normalization.
+- Use cosine similarity for accumulated layer outputs and final hidden states.
+- Use per-position reports for RoPE, sliding-window, cache-offset, and
+  long-context failures.
+- Do not treat generation quality or perplexity deltas as hard CI gates unless
+  the task explicitly sets thresholds. Record the evidence and explain the
+  judgment.
+- For integration testing, make sure the created model advertises only the
+  capabilities it really supports. Audio, vision, tools, embedding, and
+  thinking tests rely on capabilities to decide whether to run or skip.
+
+## Review Discipline
+
+- Disclose agent assistance in PR notes when applicable.
+- Include exact commands and file paths for every generated artifact.
+- If a test skips because model weights, references, MLX libraries, or corpora
+  are unavailable, name the missing input and the command to regenerate it.
+- If a reviewer asks for a design change, reason from the code and evidence.
+  Do not blindly re-run an agent and paste the result.

--- a/x/models/AGENTS.md
+++ b/x/models/AGENTS.md
@@ -1,0 +1,47 @@
+# MLX Model Porting Agent Guide
+
+This directory contains experimental MLX model implementations and the tooling
+used to validate new architecture ports. Treat this file as the local conduct
+guide for humans and coding agents working under `x/models`.
+
+The porting process itself lives in exactly one place: read
+`x/models/PORTING_GUIDE.md` first and follow its workflow — each step links a
+deep-dive document in `x/models/bringup/`. Every artifact the work produces
+belongs under `x/models/bringup/<model>/` (see `bringup/artifacts.md`); never
+`/tmp` or scratch directories.
+
+## Working Rules
+
+- Use a reference-driven workflow. The source of truth is the implementation
+  the publisher designates as authoritative (or the one a maintainer
+  explicitly names); record that choice and its revision. See
+  `bringup/reference-capture.md`.
+- Keep model ports readable and local to the new architecture. Do not refactor
+  shared utilities, cache behavior, tokenizer code, or existing model files
+  unless the task explicitly requires it.
+- Prefer the patterns already used by nearby MLX models (`llama`, `qwen3_5`,
+  `gemma4`) over new abstractions.
+- Treat custom kernels as a last resort; follow the optimization order in
+  `bringup/performance.md` and keep a kernel only with measured incremental
+  benefit and explicit backend, OS, correctness, and fallback coverage.
+- Treat tensor namespaces and config-schema shape as artifact ABI, not
+  cosmetic metadata. A permissive loader that accepts two layouts does not
+  make those layouts interchangeable for published tags. See
+  `bringup/release-gates.md`.
+- Reference parity tests must not re-implement renderer policy in their
+  template-input converters, and must never override the template's
+  generation prompt. See `bringup/renderer-parity.md`.
+- Do not treat generation quality or perplexity deltas as hard CI gates unless
+  the task explicitly sets thresholds. Record the evidence and explain the
+  judgment.
+
+## Review Discipline
+
+- Disclose agent assistance in PR notes when applicable.
+- Include exact commands and file paths for every generated artifact.
+- Do not claim a port is complete without the evidence the guide's Definition
+  Of Done requires; the bring-up archive is that evidence.
+- If a test skips because model weights, references, MLX libraries, or corpora
+  are unavailable, name the missing input and the command to regenerate it.
+- If a reviewer asks for a design change, reason from the code and evidence.
+  Do not blindly re-run an agent and paste the result.

--- a/x/models/PORTING_GUIDE.md
+++ b/x/models/PORTING_GUIDE.md
@@ -1,0 +1,449 @@
+# MLX Model Porting Guide
+
+This guide describes the repeatable process for bringing a new language model
+architecture up on Ollama's MLX runner. The process is reference-driven: start
+from the canonical `transformers` implementation, generate reproducible
+reference artifacts, implement the same forward pass in Go/MLX, and collect
+enough evidence that a reviewer can understand both the code and the validation.
+Correctness comes before performance tuning: do not optimize the hot path until
+the BF16 reference comparisons, renderer/parser parity, create/import path, and
+basic runtime smoke tests are passing or have explicitly documented limitations.
+After each optimization, re-run the focused correctness checks that cover the
+changed path.
+
+The supporting pieces are:
+
+- `x/models/scripts/inspect_model.py`: inspects one or more Hugging Face model
+  directories or Hub IDs and writes a porting manifest.
+- `x/models/scripts/dump_activations.py`: captures per-submodule PyTorch
+  outputs into safetensors plus a deterministic sidecar manifest.
+- `x/models/scripts/compare_activations.py`: compares two activation artifacts
+  and ranks tensor or position drift.
+- `x/models/testutil`: Go helpers for loading safetensors directories or
+  Ollama tags, comparing tensors, and finding the first layer/position where
+  MLX drifts from the reference.
+- `x/cmd/ppl`: perplexity CLI for end-to-end quality validation against either
+  lm-evaluation-harness or llama.cpp methodology.
+- `x/models/scripts/summarize_validation.py`: builds a reviewer-ready Markdown
+  report from non-agentic validation artifacts.
+
+## Workflow
+
+### 1. Discovery
+
+Start by inspecting representative model variants:
+
+```bash
+python3 x/models/scripts/inspect_model.py \
+    --model models/<org>/<small-base> \
+    --model models/<org>/<larger-base> \
+    --output /tmp/ollama_port/<architecture>
+```
+
+Review `porting_manifest.md` before coding. Look for:
+
+- config fields that vary across variants
+- tensor prefixes and tied embedding behavior
+- RoPE parameters, partial rotation, and scaling
+- sliding-window or hybrid layer patterns
+- MoE expert shapes and routing config
+- attention bias, grouped-query attention, MLA, recurrent or convolution state
+- multimodal processor fields
+- thinking tags in chat templates
+- safetensors dtype histogram and quantization metadata
+
+### 2. Reference Capture
+
+Generate a PyTorch reference from the `transformers` implementation:
+
+```bash
+.venv/bin/python3 x/models/scripts/dump_activations.py \
+    --model models/<org>/<name> \
+    [--model-class MyModelForCausalLM] \
+    [--attn-implementation eager] \
+    [--transformers-path path/to/custom/transformers/src] \
+    --skip-logits
+```
+
+Default output:
+
+- `/tmp/ollama_ref/<variant>/activations.safetensors`
+- `/tmp/ollama_ref/<variant>/activations.safetensors.manifest.json`
+
+Use a short prompt first. Add a long prompt when the model has sliding-window,
+RoPE scaling, recurrent state, or other context-sensitive behavior. Re-run with
+filters when drilling into a failing layer:
+
+Pin `--attn-implementation` when the reference model supports multiple
+Transformers attention backends. Backends such as SDPA and eager can produce
+different long-context numerics even in the official implementation. The sidecar
+manifest records both the requested and resolved backend, plus whether the
+reference forward pass used cache state. Activation references default to
+`use_cache=false`; pass `--use-cache` only for cache-specific reference captures.
+
+For decode/cache references, use the prompt as a cached prefill and capture the
+follow-up token or text:
+
+```bash
+.venv/bin/python3 x/models/scripts/dump_activations.py \
+    --model models/<name> \
+    --attn-implementation eager \
+    --prompt "$(cat /tmp/long-prompt.txt)" \
+    --decode-text " the" \
+    --skip-logits
+```
+
+```bash
+.venv/bin/python3 x/models/scripts/dump_activations.py \
+    --model models/<name> \
+    --filter "model.layers.5.self_attn.*" \
+    --filter "model.layers.5.mlp.*"
+```
+
+Use `--list-modules` to map Python hook names to Go fields:
+
+```bash
+.venv/bin/python3 x/models/scripts/dump_activations.py \
+    --model models/<name> \
+    --list-modules
+```
+
+When a model is sensitive to reference settings, compare the resulting
+activation dumps directly:
+
+```bash
+python3 x/models/scripts/compare_activations.py \
+    --got /tmp/ollama_ref/<variant>/activations-eager.safetensors \
+    --want /tmp/ollama_ref/<variant>/activations-sdpa.safetensors \
+    --filter "model.layers.*" \
+    --json-output /tmp/ollama_port/<architecture>/activation-comparison.json \
+    --markdown-output /tmp/ollama_port/<architecture>/activation-comparison.md
+```
+
+This is a reference-quality check, not a replacement for Go unit tests. It
+helps distinguish an unstable reference from a model implementation defect.
+
+### 3. Implementation
+
+Implement the Go model in `x/models/<name>/` using nearby models as templates.
+Keep the first version self-contained and model-specific. Shared utility
+changes should be small, justified by more than one model, and called out in
+the review report.
+
+`testutil.LoadModelFromDir(t, dir)` loads any registered architecture from a
+directory containing `config.json`, `tokenizer.json`, and `*.safetensors`.
+It creates a synthetic manifest and uses the standard `base.New()` factory
+dispatch.
+
+### 4. Layer Comparison
+
+Write forward-pass tests using `testutil`:
+
+```go
+model := testutil.LoadModelFromDir(t, testutil.ModelDir(t, "MODEL_DIR", "models/<name>"))
+ref := testutil.LoadReference(t, filepath.Join(testutil.DefaultRefDir("variant"), "activations.safetensors"))
+
+h := model.Forward(tokens, caches)
+testutil.CompareArraysCosineSim(t, "final_hidden", h, ref["model.norm"], 0.999)
+
+embed := model.EmbedTokens.Forward(tokens)
+testutil.CompareArrays(t, "embed_tokens", embed, ref["model.embed_tokens"], testutil.BFloat16Tol())
+```
+
+Debug failures layer by layer. Use `CompareLayersPerPosition`,
+`LogDriftRanks`, and `EarliestOutlierPosition` to localize the first
+divergence. Per-position output is especially useful for sliding-window,
+attention-mask, cache-offset, and RoPE bugs.
+
+When a long-context run drifts but no single operation is obviously wrong,
+isolate candidate layers with reference inputs before changing the model. Load
+the reference output from layer `N-1`, cast it back to the model dtype, rebuild
+any side inputs from reference tensors when possible, and run only layer `N`.
+If the isolated layer passes but the chained run drifts, the evidence points to
+accumulated numerical drift or backend/reference sensitivity rather than a
+localized layer implementation bug. If the isolated layer still fails, drill
+into that layer's submodules and compare the smallest operation that reproduces
+the failure.
+
+### 5. Context, Cache, And Special Behavior
+
+Add focused tests when the architecture has the corresponding risk:
+
+- long-sequence test: sliding window, RoPE scaling, recurrent state, or sparse
+  layer schedules
+- cache test: generation-time KV offsets, shared KV layers, recurrent caches,
+  or sliding windows
+- quantized test: model-specific packed tensors, expert stacking, or mixed
+  quantization metadata
+- thinking test: chat templates or renderer behavior that affects thinking
+  delimiters
+- multimodal test: image/audio token accounting or processor-dependent inputs
+
+For cache patterns, see `x/mlxrunner/cache_test.go`.
+
+Renderer and parser tests should be treated as part of model correctness, not
+as API polish. When a model ships a `chat_template.jinja` or tokenizer chat
+template, walk every meaningful branch in that template and add renderer tests
+for it before creating the Ollama model. Cover at least:
+
+- first system message handling and additional system messages
+- plain user-only and multi-turn chat
+- generation prompt or assistant-prefill behavior
+- thinking enabled, disabled, and omitted, including exact delimiter prefill
+- tool registry rendering
+- assistant messages with content, thinking text, and tool calls
+- tool response messages
+- variant-specific template differences, such as BF16 and quantized drops with
+  different tool-call formats
+
+Prefer exact rendered-output tests over substring checks. For complex templates,
+follow the pattern in `model/renderers/gemma4_reference_test.go`: commit or
+locate the reference template, render representative messages through the
+reference template engine or `AutoTokenizer.apply_chat_template`, and compare it
+to the Go renderer. If Ollama intentionally diverges from the template, such as
+prefilling a thinking open or close tag to steer generation, normalize or assert
+that difference explicitly in a separate "known differences" test. Runtime
+smoke tests are not a substitute for this renderer coverage because parser
+fallbacks can hide malformed prompts until a user exercises a different chat
+flow.
+
+### 6. Perplexity Validation
+
+After layer comparisons pass, validate end-to-end quality with `x/cmd/ppl`:
+
+```bash
+# Default: lm-evaluation-harness wikitext task
+go run ./x/cmd/ppl -model mymodel:base-mlx-bf16 -cache-dir /tmp/ollama-ppl-cache
+
+# llama.cpp-compatible mode
+go run ./x/cmd/ppl -model mymodel:base-mlx-bf16 -mode llamacpp -cache-dir /tmp/ollama-ppl-cache
+
+# Load directly from a Hugging Face directory
+go run ./x/cmd/ppl -model-dir models/mymodel-Base -format json > /tmp/ollama_port/ppl.json
+```
+
+For model-quality comparisons, use the canonical downloaded corpus by omitting
+`-corpus`, and use either the full default run or an explicitly documented
+multi-document subset such as `-max-docs 8` for iteration. Do not use the tiny
+synthetic corpus from smoke tests for quality tables; it is only a finite-result
+sanity check and can give misleading ordering between quantization variants.
+
+Cross-check by running the same model through `lm-eval --tasks wikitext` for
+harness mode or `llama-perplexity` for llamacpp mode. A small PPL delta can be
+acceptable, but record the baseline, absolute delta, relative delta, corpus,
+mode, and context length.
+
+For new models, add a small CI smoke test like
+`x/models/gemma4/perplexity_test.go`: it should load a local tag when present,
+score a tiny synthetic corpus, and assert only that the result is finite and
+plausible.
+
+### 7. Integration Validation
+
+Run integration tests against the created Ollama model tag as final validation,
+after the focused reference, cache, quantized, thinking, multimodal, and
+perplexity checks above pass. Integration tests are slower and broader; they
+should catch API-level packaging and capability problems, not serve as a crutch
+for missing unit tests.
+
+Build the local binary first:
+
+```bash
+go build .
+```
+
+Then run the integration package with the new model override:
+
+```bash
+OLLAMA_TEST_MODEL=mymodel:base-mlx-bf16 \
+  go test -tags=integration -v -count=1 -timeout 30m ./integration
+```
+
+When testing against an already-running local or remote server:
+
+```bash
+OLLAMA_TEST_EXISTING=1 \
+OLLAMA_HOST=http://127.0.0.1:11434 \
+OLLAMA_TEST_MODEL=mymodel:base-mlx-bf16 \
+  go test -tags=integration -v -count=1 -timeout 30m ./integration
+```
+
+Capability metadata matters. The model manifest/config must advertise only the
+capabilities the port actually supports:
+
+- completion models should advertise `completion`
+- vision models should also advertise `vision`
+- audio models should also advertise `audio`
+- tool-capable chat models should advertise `tools`
+- thinking models should advertise `thinking`
+- embedding models should advertise `embedding`
+
+The integration tests use those capabilities to decide whether tests for
+vision, audio, tool calling, embeddings, and thinking should run or skip. If a
+completion-only model runs vision/audio/tool tests, fix the advertised
+capabilities. If a model supports one of those features but the related tests
+skip, fix the created model metadata before treating integration validation as
+complete.
+
+Record the integration command, whether `OLLAMA_TEST_EXISTING` was used, the
+model tag, and any capability-based skips in the review report.
+
+### 8. Performance Tuning
+
+Treat performance as a second pass after the correctness gate above. Start with
+a baseline rather than guesses:
+
+- use Ollama response timings (`prompt_eval_duration`, `eval_duration`, token
+  counts) to record prefill and decode throughput separately
+- keep prompts, `num_ctx`, `num_predict`, batch settings, model tag, dtype, and
+  hardware fixed across runs
+- unload other large models and record whether BF16, FP8, or another quantized
+  variant is under test
+
+Inspect the implementation for established MLX fast paths before writing custom
+kernels:
+
+- use `mlx.RMSNormFn` or `nn.RMSNorm` for RMSNorm, not hand-written variance
+  math
+- use `mlx.RoPEWithBase` or `mlx.RoPEWithFreqs` for rotary embeddings
+- use `mlx.ScaledDotProductAttentionCausal` or
+  `mlx.ScaledDotProductAttentionMasked` for attention when the model semantics
+  fit the fast SDPA path
+- use compiled activation helpers such as `mlx.SwiGLU`, `mlx.GeGLU`, and
+  `mlx.GELUApprox` instead of unfused element-wise chains
+- reuse per-forward artifacts such as sliding-window masks when every layer
+  sees the same shape and dtype
+- use `GatherMM` or `GatherQMM` for MoE dispatch and sort expert indices for
+  sufficiently large prefills when the model layout supports it
+
+For GPU-level profiling on Apple Silicon, prefer headless `xctrace` Metal
+System Trace captures. Capture prefill and decode separately; mixed captures
+hide the bottleneck because prefill is usually GEMM-heavy while decode is often
+memory-bandwidth bound. Look for many tiny dispatches, CPU gaps between GPU
+kernels, unexpected dtype upcasts, repeated host-side tensor construction, and
+manual element-wise sequences that should be compiled or replaced with
+`mlx.fast` operations.
+
+Only optimize with evidence. Record the before/after command, throughput,
+memory footprint when available, and any xctrace findings in the reviewer
+report. Then re-run the relevant layer/cache/quantized/renderer tests to prove
+the optimization did not change model behavior.
+
+### 9. Reviewer Report
+
+Collect validation artifacts into a Markdown report:
+
+```bash
+python3 x/models/scripts/summarize_validation.py \
+    --manifest /tmp/ollama_port/<architecture>/porting_manifest.json \
+    --activation-manifest /tmp/ollama_ref/<variant>/activations.safetensors.manifest.json \
+    --activation-comparison-json /tmp/ollama_port/activation-comparison.json \
+    --go-test-json /tmp/ollama_port/go-test.json \
+    --go-test-json /tmp/ollama_port/integration-test.json \
+    --ppl-json /tmp/ollama_port/ppl.json \
+    --generation-transcript /tmp/ollama_port/generation.md \
+    --output /tmp/ollama_port/review_report.md
+```
+
+The report should be factual. Do not use it to hide failed checks; list known
+skips and unresolved limitations explicitly.
+
+## Reference Key Naming
+
+The Python hooks capture outputs keyed by `model.named_modules()` paths. For
+multimodal models, the text model is often nested under
+`model.language_model.layers.0`. Map these paths to Go struct fields manually
+when writing tests.
+
+## Tolerance Guidelines
+
+| Scenario | Primary check | Threshold |
+| --- | --- | --- |
+| Single op (embedding, matmul, norm) | `CompareArrays` | `BFloat16Tol()` (atol=5e-3) |
+| Single decoder layer output, BF16 | `CompareArraysCosineSim` | 0.9999 |
+| Full forward pass, BF16, any depth | `CompareArraysCosineSim` | 0.999 |
+| Long-sequence accumulated output | `CompareArraysCosineSim` | 0.99, with diagnostics |
+| Quantized model end-to-end | `CompareArraysCosineSim` | 0.99 |
+
+For tensors that have been through a final per-channel scaled norm, use cosine
+similarity rather than element-wise tolerance. Element-wise diffs at those
+positions are dominated by per-channel norm weights and are not a useful bug
+signal. A real bug usually collapses cosine similarity well below 0.99.
+
+## Common Pitfalls
+
+- Embedding scaling: Hugging Face may include `sqrt(hidden_size)` scaling
+  inside the embedding module.
+- RoPE conventions: Hugging Face often uses `rotate_half` split at the
+  midpoint; MLX uses paired rotation. Check partial rotation dimensions.
+- Weight prefixes: models use `model.`, `language_model.`, or nested
+  multimodal prefixes. Do not hard-code one prefix until inspection confirms
+  it.
+- Norm scale shift: some norms use `1 + weight`, others use `weight` directly.
+- Logits comparison: full logits tensors are huge. Prefer final hidden state
+  or `--skip-logits` unless logits are specifically under investigation.
+- Dtype contamination: accidental float32 operations can preserve quality but
+  hurt speed. Check output dtype and profile if performance is unexpectedly
+  poor.
+- `Floats()` only works on float32 arrays. `testutil` casts automatically; if
+  comparing manually, use `.AsType(mlx.DTypeFloat32)` first.
+
+## Definition Of Done
+
+A new MLX model port is ready for review when:
+
+- representative variants have an inspection manifest
+- PyTorch activation references and sidecar manifests exist
+- forward-pass tests compare embedding, layer outputs, and final hidden state
+- long-context/cache/quantized/thinking/multimodal tests are added when the
+  architecture needs them, or the report explains why they are not applicable
+- `x/cmd/ppl` has been run against a base model and baseline when available
+- integration tests have been run with `OLLAMA_TEST_MODEL` against the created
+  tag, with capability-driven skips reviewed
+- at least one generation sample is captured for reviewer sanity checking
+- performance baseline and any tuning results are recorded after correctness
+  validation, or the report explains why performance tuning was deferred
+- all commands, model paths or revisions, prompts, dtype choices, skips, and
+  unresolved limitations are recorded
+
+## PR / Review Report Template
+
+````markdown
+## Summary
+- Architecture:
+- Source model(s):
+- Transformers revision or package version:
+- Agent-assisted: yes/no
+
+## Variant And Config Coverage
+- Variants inspected:
+- Config differences that affect implementation:
+- Tensor prefixes and dtype histogram:
+- Risk flags:
+
+## Validation Commands
+```bash
+# inspect_model
+# dump_activations
+# compare_activations
+# go test
+# OLLAMA_TEST_MODEL integration test
+# x/cmd/ppl
+```
+
+## Numerical Results
+- Forward/layer comparison:
+- Long-context/cache:
+- Quantized:
+- Perplexity:
+- Integration:
+
+## Generation Samples
+- Prompt:
+- Output:
+
+## Known Skips Or Limitations
+- Missing local artifacts:
+- Unsupported variants:
+- Follow-up work:
+````

--- a/x/models/PORTING_GUIDE.md
+++ b/x/models/PORTING_GUIDE.md
@@ -1,0 +1,122 @@
+# MLX Model Porting Guide
+
+This is the overview of the repeatable process for bringing a new model
+architecture up on Ollama's MLX runner. The process is reference-driven:
+start from the publisher's authoritative implementation, capture reproducible
+reference artifacts, implement the same forward pass in Go/MLX, and collect
+enough evidence that a reviewer can verify both the code and the validation.
+Correctness comes before performance tuning. Treat every discrepancy as a
+defect in the port until the evidence proves otherwise.
+
+Each step below links to a deep-dive document in `x/models/bringup/` — read
+the deep dive when you reach that step, not before. Every artifact the
+workflow produces lives under `x/models/bringup/<model>/` from day one
+(git-ignored, never committed, NOT disposable — it becomes the reviewer
+archive attached to the PR; see `bringup/artifacts.md`). Do not write
+bring-up evidence to `/tmp` or session scratch directories.
+
+Supporting tools: `x/models/scripts/` (inspect_model, dump_activations,
+compare_activations, summarize_validation — see `scripts/README.md`),
+`x/models/testutil` (Go comparison helpers), and `x/cmd/ppl` (perplexity CLI).
+Agent standards live in `x/models/AGENTS.md`.
+
+## Workflow
+
+1. **Discovery** — inspect representative variants with `inspect_model.py`;
+   review the porting manifest for config variance, tensor prefixes, RoPE,
+   sliding windows, MoE, multimodal fields, and dtype histograms before
+   coding. → `bringup/reference-capture.md`
+
+2. **Reference capture** — record the publisher's authority order, revisions,
+   and checkpoint hashes; build a forward-operation/dtype ledger; dump
+   PyTorch activations with sidecar manifests into the bring-up tree.
+   → `bringup/reference-capture.md`
+
+3. **Implementation** — implement the Go model in `x/models/<name>/` using
+   nearby models as templates; keep it self-contained and model-specific.
+   → `bringup/implementation.md`
+
+4. **Layer comparison** — forward-pass tests against the reference dumps;
+   localize the first divergence layer by layer, isolating layers with
+   reference inputs before blaming accumulation.
+   → `bringup/implementation.md`
+
+5. **Context, cache, and special behavior** — focused long-sequence, cache,
+   quantized, thinking, and multimodal tests where the architecture carries
+   the risk; renderer/parser parity is model correctness, with strict
+   anti-circularity rules for parity tests.
+   → `bringup/implementation.md`, `bringup/renderer-parity.md`
+
+6. **Reference equivalence gate** — mandatory on BF16 before quantization,
+   performance work, or any completeness claim: exact prompt bytes and token
+   IDs, prefill/cache/output-head parity, teacher-forced trajectories, parser
+   replay, deterministic replay, and a first-divergence discrepancy protocol.
+   → `bringup/equivalence-gate.md`
+
+7. **Perplexity validation** — `x/cmd/ppl` end-to-end quality scoring with a
+   recorded baseline and corpus methodology. → `bringup/validation.md`
+
+8. **Integration validation** — `OLLAMA_TEST_MODEL` against the created tag
+   as final validation; capability metadata drives test selection, so verify
+   the advertised capability set exactly. Before this step, produce the
+   artifact ABI report comparing publisher source metadata to the created
+   Ollama tag, and old public tag metadata to any replacement tag.
+   → `bringup/validation.md`, `bringup/release-gates.md`
+
+9. **Performance tuning** — second pass only: baseline first, prefer existing
+   MLX ops and compiled closures over custom kernels, audit host-side tensor
+   scaling, and re-run correctness after every optimization.
+   → `bringup/performance.md`
+
+10. **Reviewer report and archive** — build the validation report, complete
+    `MANIFEST.json`, and attach the bring-up archive to the PR.
+    → `bringup/artifacts.md`
+
+For models that ship as published tags (especially embargoed partner models),
+run the release gates — provenance pinning, codename hygiene, published
+sampling defaults, capability intent, shipping-stack benchmarks, artifact
+metadata — before any push. → `bringup/release-gates.md`
+
+Known traps live in `bringup/pitfalls.md`.
+
+## Definition Of Done
+
+A new MLX model port is ready for review when:
+
+- representative variants have an inspection manifest
+- the authoritative implementation and revision are recorded, and the
+  forward-operation ledger accounts for every explicit dtype cast and output
+  transform
+- PyTorch activation references and sidecar manifests exist
+- forward-pass tests compare embedding, layer outputs, and final hidden state
+- the reference equivalence gate has passed on BF16: exact prompt bytes and
+  production token IDs, prefill and cached decode, raw and transformed
+  logits, a teacher-forced trajectory, streaming parser round-trip, and
+  deterministic raw-token replay
+- every divergence is either fixed in the port or supported by a preserved
+  minimal reference-defect/backend-drift reproduction; there are no
+  unexplained high-margin token-ranking mismatches
+- long-context/cache/quantized/thinking/multimodal tests are added when the
+  architecture needs them, or the report explains why they are not applicable
+- `x/cmd/ppl` has been run against a base model and baseline when available
+- integration tests have been run with `OLLAMA_TEST_MODEL` against the created
+  tag, with capability-driven skips reviewed
+- the created artifact's tensor names, config schema, tokenizer/processor/
+  generation metadata, params, capabilities, auxiliary components, and
+  `REQUIRES` have been compared against the publisher source and any previous
+  public tag; every drift is explicitly approved or fixed
+- at least one generation sample is captured for reviewer sanity checking
+- performance baseline and any tuning results are recorded after correctness
+  validation, or the report explains why performance tuning was deferred
+- host-built tensors are audited for scaling class (nothing O(n²) in tokens
+  or patches is constructed CPU-side), and peak memory plus upload volume
+  were recorded for a representative large-media/long-context request
+- all commands, model paths or revisions, prompts, dtype choices, skips, and
+  unresolved limitations are recorded
+- the bring-up tree under `x/models/bringup/<model>/` is complete, its
+  `MANIFEST.json` lists every artifact as archived or regenerable, and the
+  archive is attached to the PR (template in `bringup/artifacts.md`)
+- for published tags, the release gates have run: provenance hashes pinned,
+  codename sweep clean, publisher sampling defaults asserted, capability
+  intent verified, artifact ABI report complete, and ship benchmarks taken
+  through the ollama stack

--- a/x/models/bringup/.gitignore
+++ b/x/models/bringup/.gitignore
@@ -1,0 +1,5 @@
+# Guide documents (top-level *.md) are tracked; every per-model bring-up
+# tree is ignored — it ships as a PR-attached archive instead (artifacts.md).
+/*
+!/.gitignore
+!/*.md

--- a/x/models/bringup/artifacts.md
+++ b/x/models/bringup/artifacts.md
@@ -1,0 +1,149 @@
+# Bring-Up Artifacts, Reviewer Report, And PR Archive
+
+Part of the MLX porting guide (`x/models/PORTING_GUIDE.md`). This directory
+holds the working evidence produced while porting a model; everything here
+except these guide documents and `.gitignore` is git-ignored.
+
+Bring-up evidence — reference activation dumps, parity and trajectory
+reports, disposable harness scripts, bench results, session notes — is
+deliberately kept out of repository history, but it is NOT disposable: the
+archive built from this tree is the artifact a reviewer or the model
+publisher uses to verify that the port faithfully implements the reference.
+
+## Rules
+
+- All bring-up work for a port lives under `x/models/bringup/<model>/` from
+  day one. Do not scatter evidence across `/tmp`, session scratch
+  directories, or ad-hoc cache paths — those do not survive to review time.
+- Nothing under `<model>/` is ever committed. The PR carries an archive
+  instead.
+
+Scaffold a new port's tree (layout below plus a LEDGER template):
+
+```bash
+x/models/scripts/new_port.sh <model>
+```
+
+## Layout
+
+```
+x/models/bringup/<model>/
+  LEDGER.md      # provenance: source repos, revisions, per-file content
+                 # hashes, authority order; the forward-operation/dtype
+                 # ledger; running decision log
+  MANIFEST.json  # every file: sha256, bytes, archived|regenerable, and the
+                 # command that regenerates it
+  reference/     # activation dumps + sidecar manifests, reference configs,
+                 # tokenizer/template captures
+  parity/        # artifact ABI reports, renderer byte/token-ID reports,
+                 # logit and teacher-forced trajectory comparisons, parser
+                 # replay outputs, quantization-vs-BF16 replays
+  perf/          # benchmark outputs, A/B results, profile summaries
+  scripts/       # every disposable harness written during bring-up
+  sessions/      # engineering/agent session notes (internal-only; excluded
+                 # from the external archive flavor)
+```
+
+## Reviewer Report
+
+Collect validation artifacts into a Markdown report:
+
+```bash
+python3 x/models/scripts/summarize_validation.py \
+    --manifest x/models/bringup/<model>/reference/porting_manifest.json \
+    --activation-manifest x/models/bringup/<model>/reference/<variant>/activations.safetensors.manifest.json \
+    --activation-comparison-json x/models/bringup/<model>/parity/activation-comparison.json \
+    --go-test-json x/models/bringup/<model>/parity/go-test.json \
+    --go-test-json x/models/bringup/<model>/parity/integration-test.json \
+    --artifact-abi-report x/models/bringup/<model>/parity/artifact-abi.md \
+    --ppl-json x/models/bringup/<model>/parity/ppl.json \
+    --generation-transcript x/models/bringup/<model>/parity/generation.md \
+    --output x/models/bringup/<model>/review_report.md
+```
+
+The report should be factual. Do not use it to hide failed checks; list known
+skips and unresolved limitations explicitly.
+
+## Archive
+
+Before opening the model-support PR, generate `MANIFEST.json`
+(`python3 x/models/scripts/make_manifest.py x/models/bringup/<model>`; large
+regenerable artifacts and their rebuild commands go in the tree's
+`ARCHIVE_EXCLUDE.json`), build the archive, and attach it:
+
+```bash
+tar --exclude='reference/*.safetensors' \
+    --exclude='sessions' \
+    -czf /tmp/<model>-bringup-$(date +%Y%m%d).tgz \
+    -C x/models/bringup <model>
+```
+
+- Target size is ~20MB or less: summaries, manifests, ledgers, and scripts
+  always go in; multi-GB raw tensor dumps stay out but must be listed in
+  `MANIFEST.json` as regenerable with the exact command.
+- Attach the archive to the PR. If it exceeds the attachment limit, place it
+  in the team artifact share and link it from the PR body.
+- Drop `--exclude='sessions'` only for internal review copies; the external
+  flavor (for the model publisher) always excludes `sessions/`.
+
+The archive — not the repository — is where reviewers and the model
+publisher verify the port against the reference implementation.
+
+## PR / Review Report Template
+
+````markdown
+## Summary
+- Architecture:
+- Source model(s):
+- Transformers revision or package version:
+- Agent-assisted: yes/no
+
+## Variant And Config Coverage
+- Variants inspected:
+- Config differences that affect implementation:
+- Tensor prefixes and dtype histogram:
+- Risk flags:
+
+## Validation Commands
+```bash
+# inspect_model
+# artifact ABI comparison
+# dump_activations
+# compare_activations
+# go test
+# OLLAMA_TEST_MODEL integration test
+# x/cmd/ppl
+```
+
+## Numerical Results
+- Forward/layer comparison:
+- Long-context/cache:
+- Quantized:
+- Perplexity:
+- Integration:
+
+## Artifact ABI
+- Publisher source vs created tag:
+- Previous public tag vs replacement tag:
+- Approved metadata drift:
+
+## Generation Samples
+- Prompt:
+- Output:
+
+## Known Skips Or Limitations
+- Missing local artifacts:
+- Unsupported variants:
+- Follow-up work:
+
+## Bring-Up Archive
+- Attachment or artifact-share link:
+- MANIFEST.json regenerable-artifact count:
+````
+
+## Tooling Gaps
+
+- **`summarize_validation.py` gate completeness.** Extend the report to mark
+  the equivalence gate INCOMPLETE whenever a required artifact (token-ID
+  parity, trajectory report, parser replay, raw-token replay) is missing, so
+  absent evidence is always visible to reviewers.

--- a/x/models/bringup/equivalence-gate.md
+++ b/x/models/bringup/equivalence-gate.md
@@ -1,0 +1,95 @@
+# Reference Equivalence Gate
+
+Part of the MLX porting guide (`x/models/PORTING_GUIDE.md`). Bring-up
+evidence lives beside these docs in `x/models/bringup/<model>/` — git-ignored,
+never committed; see `artifacts.md`.
+
+This gate must pass on unquantized BF16 before quantization, performance work,
+or a claim that the port is complete. Integration tests, perplexity, and
+generation samples are supporting evidence only. Treat every discrepancy as a
+defect in the port until the evidence proves otherwise.
+
+1. **Prompt bytes and token IDs**
+   - Compare exact reference-template bytes to the Go renderer.
+   - Tokenize those exact prompts with the reference training tokenizer and
+     Ollama's production tokenizer; require identical token IDs, including
+     special tokens, BOS/EOS, and the generation prompt.
+   - Decoded-text equality is not sufficient. Include code/tool output,
+     indentation, whitespace before punctuation, newlines, contractions,
+     non-ASCII text, empty content, and special-token-looking strings.
+   - For tools, cover multiple definitions and transcripts ending in user,
+     assistant, and tool roles, especially a tool result containing JSON or
+     source code followed by the next generation prompt.
+
+2. **Prefill, cache, and output-head parity**
+   - Run identical token IDs through short one-shot prefill,
+     production-style chunked prefill, and cached decode.
+   - Compare embeddings, selected layer boundaries, final hidden state, raw
+     LM-head output, and final post-transform logits.
+   - Assert every dtype transition from the operation ledger. Capturing
+     tensors as float32 for comparison must not erase original dtype metadata.
+   - `--skip-logits` is acceptable while localizing layers, never for the
+     final gate. Capture last-position logits when full-sequence logits are too
+     large.
+   - Report top-1 and its reference margin, top-k overlap, expected-token rank,
+     logprob delta p50/p95/max, and KL when stable. Cosine similarity alone
+     cannot validate output transforms or token ranking.
+
+3. **Teacher-forced trajectory parity**
+   - Force the same realistic continuation token IDs through both
+     implementations and compare post-transform logits at every position.
+   - Cover at least 128 positions across prose and code-like content. Tool
+     models must cross every supported channel, a tool call, a code/JSON tool
+     result, and the next assistant decision.
+   - Save top-1 agreement, mean top-k overlap, expected-token ranks and
+     logprob deltas, plus reference margins for every mismatch.
+   - Investigate every mismatch. Accept only low-margin swaps supported by
+     independently measured backend drift; do not label unexplained
+     high-margin differences "accumulation."
+   - After BF16 passes, replay the same trajectory on every production
+     quantization against the verified BF16 port. Quantized integration success
+     alone is not a quality-parity check.
+
+4. **Protocol and parser replay**
+   - Feed well-formed reference continuations through the production streaming
+     parser at every meaningful split point through control tokens, tool
+     wrappers, arguments, and UTF-8 text.
+   - Compare content, thinking, tool calls/arguments, turn actions, and
+     continuation prompts. Round-trip parsed messages into the next renderer
+     turn and repeat prompt-byte/token-ID parity.
+   - Include multiple calls, malformed/truncated output, and ordinary content
+     containing control-token-like strings. Hardening may improve malformed
+     recovery but must not alter well-formed reference output.
+
+5. **Deterministic reference replay**
+   - Use identical prompt token IDs and publisher-equivalent greedy sampling.
+     Record raw generated token IDs, not only decoded output.
+   - For tool models, replay a bounded multi-turn scenario with fixed tool
+     results. A bad realistic workload is a trigger for this analysis; a good
+     workload never proves parity.
+
+6. **Discrepancy protocol**
+   - Freeze prompt bytes, token/continuation IDs, model and reference hashes,
+     dtypes, sampling settings, and raw output before editing code.
+   - Locate the first divergence in order: rendered bytes, token IDs,
+     embedding, layer/submodule, raw LM head, transformed logits, sampler,
+     parser.
+   - Fix the earliest divergence and rerun the whole gate. Never mask an
+     upstream mismatch with renderer steering or parser recovery.
+   - If the reference appears defective, require a minimal native
+     reproduction, disagreement between publisher references, or publisher
+     confirmation. Missing tooling is not a waiver; extend it or build a
+     disposable reference harness.
+
+## Tooling Gaps
+
+Missing tooling is not a waiver — build a disposable harness and note it in
+the review report:
+
+- **Top-k/rank/KL report helpers.** Cosine similarity cannot see
+  token-ranking flips, and logprob diagnostics get re-invented per port.
+  Shared helpers should emit top-1 margin, top-k overlap, expected rank,
+  logprob deltas, and KL.
+- **Teacher-forced trajectory command.** The gate's strongest check (part 3)
+  is a bespoke script every time. One command should take prompt +
+  continuation token IDs and emit a per-position agreement report.

--- a/x/models/bringup/implementation.md
+++ b/x/models/bringup/implementation.md
@@ -1,0 +1,114 @@
+# Implementation And Layer Comparison
+
+Part of the MLX porting guide (`x/models/PORTING_GUIDE.md`). Bring-up
+evidence lives beside these docs in `x/models/bringup/<model>/` — git-ignored,
+never committed; see `artifacts.md`.
+
+## Implementation
+
+Implement the Go model in `x/models/<name>/` using nearby models as templates.
+Keep the first version self-contained and model-specific. Shared utility
+changes should be small, justified by more than one model, and called out in
+the review report.
+
+`testutil.LoadModelFromDir(t, dir)` loads any registered architecture from a
+directory containing `config.json`, `tokenizer.json`, and `*.safetensors`.
+It creates a synthetic manifest and uses the standard `base.New()` factory
+dispatch.
+
+## Layer Comparison
+
+Write forward-pass tests using `testutil`. Every MLX-touching test starts
+with `mlxtest.Setup(t)` — it skips when MLX is unavailable AND pins the test
+goroutine to its OS thread. The pin is load-bearing: MLX default streams are
+thread-local, and an unpinned goroutine panics at eval with "There is no
+Stream(...) in current thread" (threading contract: `x/mlxrunner/mlx` package
+doc).
+
+```go
+mlxtest.Setup(t)
+model := testutil.LoadModelFromDir(t, testutil.ModelDir(t, "MODEL_DIR", "models/<name>"))
+ref := testutil.LoadReference(t, filepath.Join(testutil.DefaultRefDir("variant"), "activations.safetensors"))
+
+h, _ := model.Forward(&batch.Batch{
+    InputIDs:     tokens,
+    SeqOffsets:   []int32{0},
+    SeqQueryLens: []int32{seqLen},
+}, caches)
+testutil.CompareArraysCosineSim(t, "final_hidden", h, ref["model.norm"], 0.999)
+
+embed := model.EmbedTokens.Forward(tokens)
+testutil.CompareArrays(t, "embed_tokens", embed, ref["model.embed_tokens"], testutil.BFloat16Tol())
+```
+
+Loader choice matters more than it looks:
+
+- **Prefer the production import path.** Create the Ollama tag first and load
+  it with `testutil.LoadModelByNameOrErr`. `LoadModelFromDir` on a raw HF
+  directory bypasses the create-path import transform — for architectures
+  whose runtime layout depends on it (renamed or synthesized tensors), the
+  dir-loaded model is silently wrong: it loads, runs, and produces garbage
+  (a final-hidden cosine of ~0.17 looks exactly like a model bug). Validate
+  through the tag path first; only use dir-loading once it's proven
+  equivalent for the architecture.
+  Loading through the production tag is still not an artifact metadata check:
+  it proves the loader accepts the tag, not that the tag preserves the
+  publisher or existing-public tensor namespace/config schema. Pair every
+  production-tag parity run with the artifact ABI report from
+  `release-gates.md`.
+- **Pin any array you reuse after a Compare call.** The Compare helpers sweep
+  their temporaries, which frees every unpinned array — the symptom is a
+  bizarre dtype error ("Floats requires DTypeFloat32, got BOOL") on a handle
+  that was healthy moments earlier. `mlx.Pin` it after Eval, `defer
+  mlx.Unpin`.
+- **Very large models: one test per process.** Each test that loads the model
+  holds its pinned weights until the process exits, so sequential loads of a
+  30B-class model OOM by the third test. Run them with `-run 'TestName'` per
+  invocation until testutil grows a real unload.
+
+`x/models/gemma4/forward_test.go` and `x/models/qwen3_5/forward_test.go` are
+maintained examples of this pattern, including per-layer walks that mirror the
+production forward loop.
+
+Debug failures layer by layer. Use `CompareLayersPerPosition`,
+`LogDriftRanks`, and `EarliestOutlierPosition` to localize the first
+divergence. Per-position output is especially useful for sliding-window,
+attention-mask, cache-offset, and RoPE bugs.
+
+When a long-context run drifts but no single operation is obviously wrong,
+isolate candidate layers with reference inputs before changing the model. Load
+the reference output from layer `N-1`, cast it back to the model dtype, rebuild
+any side inputs from reference tensors when possible, and run only layer `N`.
+If the isolated layer passes but the chained run drifts, the evidence points to
+accumulated numerical drift or backend/reference sensitivity rather than a
+localized layer implementation bug. If the isolated layer still fails, drill
+into that layer's submodules and compare the smallest operation that reproduces
+the failure.
+
+## Context, Cache, And Special Behavior
+
+Add focused tests when the architecture has the corresponding risk:
+
+- long-sequence test: sliding window, RoPE scaling, recurrent state, or sparse
+  layer schedules
+- cache test: generation-time KV offsets, shared KV layers, recurrent caches,
+  or sliding windows
+- quantized test: model-specific packed tensors, expert stacking, or mixed
+  quantization metadata
+- thinking test: chat templates or renderer behavior that affects thinking
+  delimiters
+- multimodal test: image/audio token accounting or processor-dependent inputs
+
+For cache patterns, see `x/mlxrunner/cache_test.go`. Renderer and parser
+coverage is model correctness too — see `renderer-parity.md`.
+
+For multimodal models, mind prefill buffer-lifetime ordering (see the
+commented block in `x/mlxrunner/pipeline.go`): the first eval that touches
+the media graph must run after the sweep — an eval before the sweep cannot
+free any buffer the chunk's live handles retain, which on media chunks pins
+the entire vision tower and shows up as a memory explosion, not a wrong
+answer. Release media buffers only after the drafter's committed callback,
+since a deferred draft flush may still embed rows from them. Memory-lifetime
+bugs like this pass every numerical-parity test; validate multimodal ports
+with a peak-memory check on a large-media request, not correctness tests
+alone.

--- a/x/models/bringup/performance.md
+++ b/x/models/bringup/performance.md
@@ -1,0 +1,88 @@
+# Performance Tuning
+
+Part of the MLX porting guide (`x/models/PORTING_GUIDE.md`). Bring-up
+evidence lives beside these docs in `x/models/bringup/<model>/` — git-ignored,
+never committed; see `artifacts.md`.
+
+Treat performance as a second pass after the correctness gate. Start with
+a baseline rather than guesses:
+
+- use Ollama response timings (`prompt_eval_duration`, `eval_duration`, token
+  counts) to record prefill and decode throughput separately
+- keep prompts, `num_ctx`, `num_predict`, batch settings, model tag, dtype, and
+  hardware fixed across runs
+- unload other large models and record whether BF16, FP8, or another quantized
+  variant is under test
+
+Rebase onto the current MLX revision before retaining an optimization. Kernel
+selection changes quickly, so a model-local workaround that was once necessary
+may now be slower than the maintained path.
+
+Use this optimization order:
+
+1. Reshape the model forward pass around existing MLX operations and layouts.
+2. Put model-specific compositions of existing operations in `mlx.Compile`
+   closures. Closures remain readable and let MLX JIT the graph for the active
+   backend and hardware.
+3. If the bottleneck is a special case of an existing MLX operation, propose or
+   validate an upstream MLX optimization instead of forking that operation in
+   Ollama.
+4. Add a custom kernel only when profiling and A/B benchmarks show that the
+   first three options cannot meet the target. Record its incremental benefit,
+   correctness evidence, supported backends and OS versions, and fallback.
+
+Start with established MLX fast paths:
+
+- use `mlx.RMSNormFn` or `nn.RMSNorm` for RMSNorm, not hand-written variance
+  math
+- use `mlx.RoPEWithBase` or `mlx.RoPEWithFreqs` for rotary embeddings
+- use `mlx.ScaledDotProductAttentionCausal` or
+  `mlx.ScaledDotProductAttentionMasked` for attention when the model semantics
+  fit the fast SDPA path
+- use compiled activation helpers such as `mlx.SwiGLU`, `mlx.GeGLU`, and
+  `mlx.GELUApprox` instead of unfused element-wise chains
+- reuse per-forward artifacts such as sliding-window masks when every layer
+  sees the same shape and dtype
+- use `GatherMM` or `GatherQMM` for MoE dispatch and sort expert indices for
+  sufficiently large prefills when the model layout supports it
+
+When replacing an element-wise chain, first compile the equivalent MLX graph
+and compare it against the eager graph. Do not translate the chain directly
+into Metal source. When an existing matrix operation is slow, inspect which
+shape or dtype selects the slow path and test current upstream MLX before
+adding a parallel matrix kernel to Ollama.
+
+Host-side tensor construction must be sub-quadratic in tokens, patches, or
+windows. Never materialize an O(n²) mask or table in Go and upload it: build
+the small O(n) or O(blocks²) precursors host-side and expand on device
+(`Take`, broadcast, `arange`, compiled closures). Audit every port for
+`make([]T, n*n)`-shaped allocations and `FromValues` payloads that scale with
+the square of sequence or patch count — a quadratic host-side mask passes
+every numerical-parity test and tok/s benchmark unnoticed, because neither
+instrument sees allocation shape. Record
+peak runner memory (the pipeline "peak memory" log line) and host→device
+upload volume for a representative large-media or long-context request
+alongside throughput.
+
+For GPU-level profiling on Apple Silicon, prefer headless `xctrace` Metal
+System Trace captures. Capture prefill and decode separately; mixed captures
+hide the bottleneck because prefill is usually GEMM-heavy while decode is often
+memory-bandwidth bound. Look for many tiny dispatches, CPU gaps between GPU
+kernels, unexpected dtype upcasts, repeated host-side tensor construction, and
+manual element-wise sequences that should be compiled or replaced with
+`mlx.fast` operations.
+
+Only optimize with evidence. Record each step's before/after command,
+throughput, memory footprint when available, and any xctrace findings in the
+reviewer report. Run correctness checks before every benchmark. If a custom
+kernel does not provide a material incremental win over compiled closures and
+current standard MLX operations, remove it. Then re-run the relevant
+layer/cache/quantized/renderer tests to prove the selected optimization did not
+change model behavior.
+
+Promote every cost quantified during profiling or a performance investigation
+that is not the current culprit to an explicit follow-up item in the bring-up
+artifacts and the review report — never leave it as narration.
+Measured-and-dismissed costs (an upload, a host allocation, a re-encode) are
+the cheapest future optimizations and are otherwise lost when the
+investigation closes.

--- a/x/models/bringup/pitfalls.md
+++ b/x/models/bringup/pitfalls.md
@@ -1,0 +1,48 @@
+# Common Pitfalls
+
+Part of the MLX porting guide (`x/models/PORTING_GUIDE.md`). Bring-up
+evidence lives beside these docs in `x/models/bringup/<model>/` — git-ignored,
+never committed; see `artifacts.md`.
+
+- Embedding scaling: Hugging Face may include `sqrt(hidden_size)` scaling
+  inside the embedding module.
+- RoPE conventions: Hugging Face often uses `rotate_half` split at the
+  midpoint; MLX uses paired rotation. Check partial rotation dimensions.
+- Weight prefixes: models use `model.`, `language_model.`, or nested
+  multimodal prefixes. Do not hard-code one prefix until inspection confirms
+  it.
+- Norm scale shift: some norms use `1 + weight`, others use `weight` directly.
+- Logits comparison: full logits tensors are huge. Prefer final hidden state
+  or `--skip-logits` unless logits are specifically under investigation.
+- Dtype contamination: accidental float32 operations can preserve quality but
+  hurt speed. Check output dtype and profile if performance is unexpectedly
+  poor.
+- `Floats()` only works on float32 arrays. `testutil` casts automatically; if
+  comparing manually, use `.AsType(mlx.DTypeFloat32)` first.
+- `ollama create` with `FROM <existing-tag>` preserves all layers and merges
+  PARAMETERs — the cheap way to add or adjust parameters on a finished tag.
+  Recreating with `FROM <file>` starts from scratch: every PARAMETER,
+  RENDERER, PARSER, REQUIRES, and DRAFT line must be respecified or it is
+  silently lost.
+- After renaming registered architecture strings or rewriting stored model
+  configs, rebuild and restart every serving binary (including side builds
+  used by benches and soak tests). A binary built before the rename cannot
+  load the renamed models and fails at model-load time, not at startup.
+- `hf download` applies `--include` to a single pattern; additional
+  arguments are treated as explicit filenames and the include filter is
+  skipped (a warning is printed). After any multi-file download, verify the
+  byte sizes of everything you expected.
+- Every MLX-touching entry point needs its goroutine pinned to an OS thread
+  (`mlxtest.Setup` in tests, `runtime.LockOSThread` at a CLI main, or the
+  `x/internal/mlxthread` worker in production). The failure is a runtime
+  panic on first eval, so a tool can compile and sit broken until someone
+  actually runs it — see the threading contract in the `x/mlxrunner/mlx`
+  package doc.
+- `testutil.LoadModelFromDir` bypasses the create-path import transform;
+  for architectures that need it, the dir-loaded model is silently wrong.
+  Validate via a created tag + `LoadModelByNameOrErr` first (see Layer
+  Comparison in `implementation.md`).
+- After rebasing this tooling onto a newer runner, execute at least one
+  exemplar test with real weights — compiling is not proof. Weights-gated
+  tests skip in CI, so interface-adjacent breakage (thread pins, changed
+  layer signatures, memory behavior) only surfaces on a live run.

--- a/x/models/bringup/reference-capture.md
+++ b/x/models/bringup/reference-capture.md
@@ -1,0 +1,166 @@
+# Discovery And Reference Capture
+
+Part of the MLX porting guide (`x/models/PORTING_GUIDE.md`). Bring-up
+evidence lives beside these docs in `x/models/bringup/<model>/` — git-ignored,
+never committed; see `artifacts.md`.
+
+## Discovery
+
+Start by inspecting representative model variants:
+
+```bash
+python3 x/models/scripts/inspect_model.py \
+    --model models/<org>/<small-base> \
+    --model models/<org>/<larger-base> \
+    --output x/models/bringup/<model>/reference
+```
+
+Review `porting_manifest.md` before coding. Look for:
+
+- config fields that vary across variants
+- tensor prefixes/namespaces, config-schema shape, and tied embedding behavior
+- RoPE parameters, partial rotation, and scaling
+- sliding-window or hybrid layer patterns
+- MoE expert shapes and routing config
+- attention bias, grouped-query attention, MLA, recurrent or convolution state
+- multimodal processor fields
+- thinking tags in chat templates
+- safetensors dtype histogram and quantization metadata
+
+## Reference Capture
+
+Identify the publisher-designated source of truth before capturing anything.
+Publishers often provide several implementations — native PyTorch,
+Transformers, vLLM, example runners — and they can differ in subtle ways.
+Use whichever one the publisher designates as authoritative, and record
+revisions, checkpoint hashes, and the stated authority order.
+
+Be especially careful with pre-release and partner drops: they typically
+aggregate contributions from multiple teams, so a download set can contain
+the primary reference alongside derived implementations — converted
+checkpoints, compatibility ports, example scripts — and multiple branches at
+different stages. Derived implementations can lag the primary or carry their
+own defects, and a checkout can silently include stale secondary copies.
+Identify the primary explicitly (exact repository, branch, and revision),
+treat it as the only source of truth, and validate every derived
+implementation against it before relying on one. Re-establish which artifact
+is primary on every refresh. Build a forward-operation ledger
+before coding: map each authoritative reference stage to Ollama code and a
+test, including input/output dtype, explicit casts, scales, normalization and
+residual order, masks, RoPE, cache updates, LM head, output
+multipliers/softcaps, and token suppression. On every publisher refresh, diff
+the authoritative code, config, tokenizer, template, and inference defaults
+before reusing reference artifacts; unchanged tensor shapes do not prove
+unchanged semantics.
+
+Tensor namespace and config-schema shape are part of the reference contract.
+Do not normalize names, flatten nested configs, or treat two publisher
+distributions as equivalent because the runtime can be taught to load both.
+If a derived checkpoint uses different tensor names or config key paths from
+the publisher-designated source, record that as artifact ABI drift and resolve
+which layout the shipped tag must preserve before writing model or create code.
+For replacements of existing public tags, the public tag's current layout is
+also a compatibility contract.
+
+Generate a PyTorch reference from the `transformers` implementation:
+
+```bash
+.venv/bin/python3 x/models/scripts/dump_activations.py \
+    --model models/<org>/<name> \
+    [--model-class MyModelForCausalLM] \
+    [--attn-implementation eager] \
+    [--transformers-path path/to/custom/transformers/src] \
+    --skip-logits
+```
+
+Pass `--output x/models/bringup/<model>/reference/<variant>/activations.safetensors`
+so the dump and its sidecar manifest land in the bring-up tree (the default
+is `/tmp/ollama_ref/<variant>/`, which does not survive to review time).
+
+Use a short prompt first. Add a long prompt when the model has sliding-window,
+RoPE scaling, recurrent state, or other context-sensitive behavior. Re-run with
+filters when drilling into a failing layer:
+
+Pin `--attn-implementation` when the reference model supports multiple
+Transformers attention backends. Backends such as SDPA and eager can produce
+different long-context numerics even in the official implementation. The sidecar
+manifest records both the requested and resolved backend, plus whether the
+reference forward pass used cache state. Activation references default to
+`use_cache=false`; pass `--use-cache` only for cache-specific reference captures.
+
+For decode/cache references, use the prompt as a cached prefill and capture the
+follow-up token or text:
+
+```bash
+.venv/bin/python3 x/models/scripts/dump_activations.py \
+    --model models/<name> \
+    --attn-implementation eager \
+    --prompt "$(cat /tmp/long-prompt.txt)" \
+    --decode-text " the" \
+    --skip-logits
+```
+
+```bash
+.venv/bin/python3 x/models/scripts/dump_activations.py \
+    --model models/<name> \
+    --filter "model.layers.5.self_attn.*" \
+    --filter "model.layers.5.mlp.*"
+```
+
+Use `--list-modules` to map Python hook names to Go fields:
+
+```bash
+.venv/bin/python3 x/models/scripts/dump_activations.py \
+    --model models/<name> \
+    --list-modules
+```
+
+When a model is sensitive to reference settings, compare the resulting
+activation dumps directly:
+
+```bash
+python3 x/models/scripts/compare_activations.py \
+    --got /tmp/ollama_ref/<variant>/activations-eager.safetensors \
+    --want /tmp/ollama_ref/<variant>/activations-sdpa.safetensors \
+    --filter "model.layers.*" \
+    --json-output x/models/bringup/<model>/parity/activation-comparison.json \
+    --markdown-output x/models/bringup/<model>/parity/activation-comparison.md
+```
+
+This is a reference-quality check, not a replacement for Go unit tests. It
+helps distinguish an unstable reference from a model implementation defect.
+
+## Reference Key Naming
+
+The Python hooks capture outputs keyed by `model.named_modules()` paths. For
+multimodal models, the text model is often nested under
+`model.language_model.layers.0`. Map these paths to Go struct fields manually
+when writing tests.
+
+## Tolerance Guidelines
+
+| Scenario | Primary check | Threshold |
+| --- | --- | --- |
+| Single op (embedding, matmul, norm) | `CompareArrays` | `BFloat16Tol()` (atol=5e-3) |
+| Single decoder layer output, BF16 | `CompareArraysCosineSim` | 0.9999 |
+| Full forward pass, BF16, any depth | `CompareArraysCosineSim` | 0.999 |
+| Long-sequence accumulated output | `CompareArraysCosineSim` | 0.99, with diagnostics |
+| Quantized model end-to-end | `CompareArraysCosineSim` | 0.99 |
+
+For tensors that have been through a final per-channel scaled norm, use cosine
+similarity rather than element-wise tolerance. Element-wise diffs at those
+positions are dominated by per-channel norm weights and are not a useful bug
+signal. A real bug usually collapses cosine similarity well below 0.99.
+
+## Tooling Gaps
+
+Known gaps in `dump_activations.py`; missing tooling is not a waiver — extend
+the script or build a disposable harness and note it in the review report:
+
+- **Original dtype metadata.** Captures re-cast to float32 can erase the
+  original dtypes, which hides cast differences on the output path. The
+  sidecar manifest should record each tensor's original dtype.
+- **Last-position logit capture.** Full-sequence logits are so large that
+  `--skip-logits` becomes the habit — which hides output-transform bugs. Add
+  a mode capturing raw LM-head and post-transform logits for just the last
+  position.

--- a/x/models/bringup/release-gates.md
+++ b/x/models/bringup/release-gates.md
@@ -1,0 +1,57 @@
+# Release Gates For Published Models
+
+Part of the MLX porting guide (`x/models/PORTING_GUIDE.md`). Bring-up
+evidence lives beside these docs in `x/models/bringup/<model>/` — git-ignored,
+never committed; see `artifacts.md`.
+
+These gates apply when the port ships as published tags, and matter most for
+embargoed partner models. Run them early and re-run them before any push —
+they are quick, and they make a launch predictable.
+
+- **Provenance pinning.** Identify the publisher's PRIMARY artifact (usually
+  the native training checkpoint) versus derived distributions (converted
+  checkpoints, quantized drops); record per-file content hashes for every
+  drop in the bring-up `LEDGER.md`. On any refresh, diff hashes per file
+  rather than relying on repository timestamps or commit messages. When a
+  derivation must be regenerated, run the publisher's own conversion tooling
+  from the primary and byte/numeric compare against the previously used
+  artifacts before shipping.
+- **Published artifact ABI.** Tensor names and namespaces, config-schema
+  shape, tokenizer/processor/generation metadata, params, capabilities,
+  auxiliary layers, and `REQUIRES` are part of the artifact ABI. Before any
+  push, produce a report comparing:
+  1. the publisher source artifact to the final Ollama tag, and
+  2. the existing public tag to the replacement tag when overwriting.
+  A loader that accepts multiple tensor layouts does not make those layouts
+  interchangeable for published models. If the created tag renames tensors,
+  flattens or nests config differently, drops or synthesizes metadata, changes
+  auxiliary-component layout, or changes the minimum runtime requirement, stop
+  until the drift is explicitly approved and documented. Replacing a public
+  tag must preserve its current ABI unless the release owner approves a
+  breaking metadata migration.
+- **Embargo and codename hygiene.** Before any push or code publication,
+  sweep for internal codenames across: source code, every JSON layer of every
+  model manifest (configs, processor configs, draft configs), embedded
+  artifact metadata (including chat templates), and user-visible surfaces
+  (`ollama show`, `/api/show` model_info). Take final naming from the
+  publisher's own tooling — their converter or transformers package defines
+  the intended class names and model_type.
+- **Published-defaults gate.** Extract the publisher's recommended sampling
+  parameters (model card best practices, generation_config) and assert that
+  every tag carries them as PARAMETERs, so users get the publisher's
+  recommended experience out of the box.
+- **Capability-intent assertion.** Write down the intended capability set per
+  tag and assert `show` reports exactly that. Some capabilities are derived
+  at load time from artifact contents and can change when an auxiliary
+  component (for example a vision projector) is absent — verify the full
+  intended set on every tag, and make sure the test harness reports
+  capability-based skips loudly so coverage gaps are visible.
+- **Benchmark through the shipping stack.** Ship/no-ship performance numbers
+  come from the full server path that users run, not from standalone runner
+  invocations. Standalone flag recipes can select different code paths —
+  speculative-decoding settings are especially sensitive — so treat them as
+  diagnostics only.
+- **Artifact metadata.** Conversion and quantization runs should set the
+  intended model name up front (`--model-name` or a properly named source
+  directory); tools embed the source name in artifact metadata, and embedded
+  metadata can only be changed by rewriting the artifact.

--- a/x/models/bringup/renderer-parity.md
+++ b/x/models/bringup/renderer-parity.md
@@ -1,0 +1,95 @@
+# Renderer And Parser Parity
+
+Part of the MLX porting guide (`x/models/PORTING_GUIDE.md`). Bring-up
+evidence lives beside these docs in `x/models/bringup/<model>/` — git-ignored,
+never committed; see `artifacts.md`.
+
+Renderer and parser tests should be treated as part of model correctness, not
+as API polish. When a model ships a `chat_template.jinja` or tokenizer chat
+template, walk every meaningful output-producing branch in that template and
+add renderer tests for it before creating the Ollama model. Cover at least:
+
+- first system message handling and additional system messages
+- plain user-only and multi-turn chat
+- generation prompt or assistant-prefill behavior
+- thinking enabled, disabled, and omitted, including exact delimiter prefill
+- tool registry rendering
+- assistant messages with content, thinking text, and tool calls
+- tool response messages
+- variant-specific template differences, such as BF16 and quantized drops with
+  different tool-call formats
+
+Prefer exact rendered-output tests over substring checks. For complex templates,
+follow the pattern in `model/renderers/gemma4_reference_test.go`: commit or
+locate the reference template, render representative messages through the
+reference template engine or `AutoTokenizer.apply_chat_template`, and compare it
+to the Go renderer.
+
+Reference parity applies to canonical transcripts the template supports; it
+does not make every publisher `raise_exception` branch Ollama product policy.
+Audit renderer hard failures separately. Normalize common API roles when their
+hierarchy and order can be preserved; otherwise, if a message can be serialized
+without dropping or corrupting it, warn and pass it through in the model's turn
+format. Reject only when faithful serialization is unsafe or ambiguous. Verify
+that application-shaped requests avoid the warning in integration tests, not
+with renderer unit tests that capture logs.
+
+The expanded parity suites are gated behind an env var and skip silently
+without it — the gate is only satisfied when they actually run against the
+live template engine:
+
+```bash
+VERIFY_JINJA2=1 go test -count=1 ./model/renderers/ -run '(?i)<model>'
+```
+
+(Requires a `.venv/bin/python` with transformers 5.x, or `uv` available to
+fetch one.) If Ollama intentionally diverges from the template, such as
+prefilling a thinking open or close tag to steer generation, assert that
+difference explicitly in a separate "known differences" test. Never normalize a
+divergence away inside the test harness — a converter that mirrors renderer
+policy turns the parity test into self-verification. Runtime smoke tests are
+not a substitute for this renderer coverage because parser fallbacks can hide
+malformed prompts until a user exercises a different chat flow.
+
+## Anti-Circularity Invariants
+
+These structure rules keep a parity test from drifting into
+self-verification, where a converter that mirrors renderer policy stays green
+while the renderer diverges from the template:
+
+- The converter feeding the reference template engine is a mechanical field
+  mapping only. It never injects messages, appends instruction text, or
+  wraps content. Note gemma4's converter is only safe because its template
+  natively accepts `tools` and `enable_thinking`.
+- When the template lacks an input Ollama needs (no tools argument, no
+  thinking control), centralize that policy in one documented production
+  function (e.g. `<model>PrepareMessages`) called by both the renderer and the
+  parity test.
+- Always render with `add_generation_prompt=True` and compare the template
+  output verbatim. The harness never overrides the generation prompt or
+  post-processes the reference side; a different prompt ending is a
+  known-difference case, not a harness override.
+- With tools present, cover transcripts ending in each terminal role (user,
+  assistant, tool). Tools + trailing tool result is every turn of a real
+  agentic loop.
+- Renderer-side invented behavior (guidance prose, prefills, injected
+  messages) gets the same discipline as parser leniency: mark it
+  Ollama-invented, keep it minimal and centralized, and validate it with
+  reference replay/logprob evidence. Structural transcript deviations are
+  presumptively wrong.
+- Capture the exact rendered prompt from a failing live session before
+  editing renderer code, so before/after renderings stay diffable.
+
+## Tooling Gaps
+
+Missing tooling is not a waiver — build a disposable harness and note it in
+the review report:
+
+- **Template-byte + token-ID compare tool.** Decoded-text equality cannot
+  detect pretokenizer differences (for example at ASCII-space boundaries
+  before punctuation). One command should compare exact rendered bytes AND
+  production token IDs against the reference tokenizer.
+- **Parser split/round-trip harness.** Streaming-parser bugs at chunk
+  boundaries (tool-call wrappers split mid-token) are found ad hoc. A harness
+  should replay a reference continuation at every split point and diff parsed
+  output (see the equivalence gate, part 4).

--- a/x/models/bringup/validation.md
+++ b/x/models/bringup/validation.md
@@ -1,0 +1,101 @@
+# Perplexity And Integration Validation
+
+Part of the MLX porting guide (`x/models/PORTING_GUIDE.md`). Bring-up
+evidence lives beside these docs in `x/models/bringup/<model>/` — git-ignored,
+never committed; see `artifacts.md`.
+
+## Perplexity Validation
+
+After layer comparisons pass, validate end-to-end quality with `x/cmd/ppl`:
+
+```bash
+# Default: lm-evaluation-harness wikitext task
+go run ./x/cmd/ppl -model mymodel:base-mlx-bf16 -cache-dir /tmp/ollama-ppl-cache
+
+# Window mode for cross-ecosystem comparison
+go run ./x/cmd/ppl -model mymodel:base-mlx-bf16 -mode window -cache-dir /tmp/ollama-ppl-cache
+
+# Load directly from a Hugging Face directory
+go run ./x/cmd/ppl -model-dir models/mymodel-Base -format json > x/models/bringup/<model>/parity/ppl.json
+```
+
+For model-quality comparisons, use the canonical downloaded corpus by omitting
+`-corpus`, and use either the full default run or an explicitly documented
+multi-document subset such as `-max-docs 8` for iteration. Do not use the tiny
+synthetic corpus from smoke tests for quality tables; it is only a finite-result
+sanity check and can give misleading ordering between quantization variants.
+
+Cross-check harness mode by running the same model through
+`lm-eval --tasks wikitext`; window mode is directly comparable with numbers
+published by other runtimes' perplexity tools. A small PPL delta can be
+acceptable, but record the baseline, absolute delta, relative delta, corpus,
+mode, and context length. Running both modes is itself a useful cross-check:
+their token PPLs should agree closely on the same model and corpus.
+
+Compare on **token perplexity** in window mode: its word/byte perplexity
+denominators span the whole corpus while only about half the tokens are
+scored, so those two sub-metrics are not meaningful there.
+
+For new models, add a small CI smoke test like
+`x/models/gemma4/perplexity_test.go`: it should load a local tag when present,
+score a tiny synthetic corpus, and assert only that the result is finite and
+plausible.
+
+## Integration Validation
+
+Run integration tests against the created Ollama model tag as final validation,
+after the focused reference, cache, quantized, thinking, multimodal, and
+perplexity checks above pass, and after the artifact ABI report has been
+produced. Integration tests are slower and broader; they should catch
+API-level packaging and capability problems, not serve as a crutch for missing
+unit tests or metadata compatibility checks.
+
+Before running integration, compare the created tag's manifest/config/tensor
+metadata against the publisher source and, for replacement tags, against the
+existing public tag. Record tensor namespace, config-schema, tokenizer/
+processor/generation metadata, params, capabilities, auxiliary-component, and
+`REQUIRES` deltas in `x/models/bringup/<model>/parity/artifact-abi.md`.
+Passing integration tests through a permissive loader does not prove the
+artifact ABI is compatible.
+
+Build the local binary first:
+
+```bash
+go build .
+```
+
+Then run the integration package with the new model override:
+
+```bash
+OLLAMA_TEST_MODEL=mymodel:base-mlx-bf16 \
+  go test -tags=integration -v -count=1 -timeout 30m ./integration
+```
+
+When testing against an already-running local or remote server:
+
+```bash
+OLLAMA_TEST_EXISTING=1 \
+OLLAMA_HOST=http://127.0.0.1:11434 \
+OLLAMA_TEST_MODEL=mymodel:base-mlx-bf16 \
+  go test -tags=integration -v -count=1 -timeout 30m ./integration
+```
+
+Capability metadata matters. The model manifest/config must advertise only the
+capabilities the port actually supports:
+
+- completion models should advertise `completion`
+- vision models should also advertise `vision`
+- audio models should also advertise `audio`
+- tool-capable chat models should advertise `tools`
+- thinking models should advertise `thinking`
+- embedding models should advertise `embedding`
+
+The integration tests use those capabilities to decide whether tests for
+vision, audio, tool calling, embeddings, and thinking should run or skip. If a
+completion-only model runs vision/audio/tool tests, fix the advertised
+capabilities. If a model supports one of those features but the related tests
+skip, fix the created model metadata before treating integration validation as
+complete.
+
+Record the integration command, whether `OLLAMA_TEST_EXISTING` was used, the
+model tag, and any capability-based skips in the review report.

--- a/x/models/gemma4/forward_test.go
+++ b/x/models/gemma4/forward_test.go
@@ -1,0 +1,213 @@
+package gemma4
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/ollama/ollama/x/mlxrunner/cache"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/models/testutil"
+)
+
+// Forward-pass validation against a PyTorch reference.
+//
+// Set GEMMA4_MODEL_DIR to point at a directory containing gemma-4-e2b base
+// weights (config.json + safetensors). The test skips when the directory is
+// not present.
+//
+// To regenerate the reference (one-time, then cached on disk):
+//
+//	.venv/bin/python3 x/models/scripts/dump_activations.py \
+//	    --model $GEMMA4_MODEL_DIR \
+//	    --model-class Gemma4ForConditionalGeneration \
+//	    [--transformers-path .tmp/transformers-5.5/transformers/src]
+//
+// Output: /tmp/ollama_ref/gemma-4-e2b/activations.safetensors
+
+const defaultModelDir = "models/gemma-4-e2b"
+
+func loadRefAndModel(t *testing.T) (ref map[string]*mlx.Array, m *Model) {
+	t.Helper()
+
+	// Load model FIRST: base.Weights() calls mlx.Sweep() which would
+	// destroy any unpinned arrays, including reference tensors.
+	modelDir := testutil.ModelDir(t, "GEMMA4_MODEL_DIR", defaultModelDir)
+	bm := testutil.LoadModelFromDir(t, modelDir)
+
+	var ok bool
+	m, ok = bm.(*Model)
+	if !ok {
+		t.Fatalf("expected *gemma4.Model, got %T", bm)
+	}
+
+	refPath := filepath.Join(testutil.DefaultRefDir("gemma-4-e2b"), "activations.safetensors")
+	ref = testutil.LoadReference(t, refPath)
+	return ref, m
+}
+
+// refKey returns the activation key used by the Python dumper. The hooks see
+// the full module path inside the multimodal wrapper, so layer outputs live
+// under "model.language_model.<suffix>".
+func refKey(suffix string) string {
+	return "model.language_model." + suffix
+}
+
+// TestForwardFinalHidden runs the full Forward() and asserts cosine
+// similarity (>= 0.999) against Python's final-norm output. Catches model
+// bugs that survive an early-layer check but are introduced later in the
+// stack.
+func TestForwardFinalHidden(t *testing.T) {
+	testutil.SkipIfNoMLX(t)
+	ref, m := loadRefAndModel(t)
+
+	tokens := ref["input_ids"].AsType(mlx.DTypeInt32)
+	mlx.Eval(tokens)
+
+	caches := m.NewCaches()
+	defer func() {
+		for _, c := range caches {
+			if c != nil {
+				c.Free()
+			}
+		}
+	}()
+	h := m.Forward(tokens, caches)
+	mlx.Eval(h)
+
+	want, ok := ref[refKey("norm")]
+	if !ok {
+		t.Skip("reference is missing final norm output")
+	}
+	testutil.CompareArraysCosineSim(t, "final_hidden", h, want, 0.999)
+}
+
+// TestForwardEmbedding compares the (scaled) embedding output against the
+// reference. Gemma4TextScaledWordEmbedding always multiplies the lookup by
+// sqrt(hidden_size), so the Python hook sees the scaled values.
+//
+// This is a single-op test (embedding lookup + scalar multiply), so tight
+// bf16 element-wise tolerance is appropriate.
+func TestForwardEmbedding(t *testing.T) {
+	testutil.SkipIfNoMLX(t)
+	ref, m := loadRefAndModel(t)
+
+	tokens := ref["input_ids"].AsType(mlx.DTypeInt32)
+	mlx.Eval(tokens)
+
+	h := m.EmbedTokens.Forward(tokens)
+	hScaled := mlx.MulScalar(h, m.EmbedScale)
+	mlx.Eval(hScaled)
+
+	want, ok := ref[refKey("embed_tokens")]
+	if !ok {
+		t.Skip("reference is missing embed_tokens")
+	}
+	testutil.CompareArrays(t, "embed_scaled", hScaled, want, testutil.BFloat16Tol())
+}
+
+// TestForwardLayersPerPosition replicates Forward() layer by layer and
+// asserts cosine similarity (>= 0.999) against the reference at each
+// layer. Logs a per-position drift report to localize a failure.
+func TestForwardLayersPerPosition(t *testing.T) {
+	testutil.SkipIfNoMLX(t)
+	ref, m := loadRefAndModel(t)
+
+	tokens := ref["input_ids"].AsType(mlx.DTypeInt32)
+	mlx.Eval(tokens)
+	dims := tokens.Dims()
+	B, L := int32(dims[0]), int32(dims[1])
+
+	h := m.EmbedTokens.Forward(tokens)
+	h = mlx.MulScalar(h, m.EmbedScale)
+
+	var perLayerInputs *mlx.Array
+	if m.HiddenSizePerLayer > 0 && m.EmbedTokensPerLayer != nil {
+		perLayerInputs = m.computePLEInputs(tokens, h)
+	}
+
+	caches := m.NewCaches()
+	defer func() {
+		for _, c := range caches {
+			if c != nil {
+				c.Free()
+			}
+		}
+	}()
+
+	var sharedKV map[int32]sharedKVEntry
+	if len(m.KVShareMap) > 0 {
+		sharedKV = make(map[int32]sharedKVEntry)
+	}
+
+	var smc *slidingMaskCache
+	if L > 1 && m.SlidingWindow > 0 {
+		smc = &slidingMaskCache{}
+	}
+
+	got := make(map[string]*mlx.Array)
+	want := make(map[string]*mlx.Array)
+
+	for i, layer := range m.Layers {
+		var c cache.Cache
+		if i < len(caches) {
+			c = caches[i]
+		}
+
+		var pleInput *mlx.Array
+		if perLayerInputs != nil {
+			pleInput = sliceLayerDim(perLayerInputs, int32(i), B, L, m.HiddenSizePerLayer)
+		}
+
+		var donorEntry *sharedKVEntry
+		if layer.KVShareDonor >= 0 && sharedKV != nil {
+			if entry, ok := sharedKV[layer.KVShareDonor]; ok {
+				donorEntry = &entry
+			}
+		}
+
+		var donorKV *sharedKVEntry
+		h, donorKV = layer.Forward(h, c, B, L, m.TextConfig, pleInput, donorEntry, smc)
+
+		if layer.IsDonor && donorKV != nil && sharedKV != nil {
+			sharedKV[layer.LayerIdx] = *donorKV
+		}
+
+		key := fmt.Sprintf("layers.%02d", i)
+		mlx.Eval(h)
+		mlx.Pin(h)
+		got[key] = h
+
+		refName := fmt.Sprintf("layers.%d", i)
+		if arr, ok := ref[refKey(refName)]; ok {
+			want[key] = arr
+		}
+	}
+	defer func() {
+		for _, a := range got {
+			mlx.Unpin(a)
+		}
+	}()
+
+	// Strict cosine-similarity assertion per layer.
+	const minCos = float32(0.999)
+	for i := range m.Layers {
+		key := fmt.Sprintf("layers.%02d", i)
+		w, ok := want[key]
+		if !ok {
+			continue
+		}
+		testutil.CompareArraysCosineSim(t, key, got[key], w, minCos)
+	}
+
+	// Per-position diagnostic — log only, used when an assertion above fails
+	// to localize where things went wrong.
+	loose := testutil.WithTolerance(0.5, 0.05)
+	report := testutil.CompareLayersPerPosition(t, got, want, 1, loose)
+	report.Summary(t)
+	testutil.LogDriftRanks(t, "\nTop 10 drifts (absolute):", report.TopDrifts(10))
+	if layerIdx, pos := report.EarliestOutlierPosition(5); layerIdx >= 0 {
+		layer := report.Layers[layerIdx]
+		t.Logf("\nEARLIEST OUTLIER: layer %s, position %d (rel_to_median ≥ 5×)", layer.Name, pos)
+	}
+}

--- a/x/models/gemma4/forward_test.go
+++ b/x/models/gemma4/forward_test.go
@@ -1,0 +1,223 @@
+package gemma4
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/ollama/ollama/x/internal/mlxtest"
+	"github.com/ollama/ollama/x/mlxrunner/batch"
+	"github.com/ollama/ollama/x/mlxrunner/cache"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/models/testutil"
+)
+
+// Forward-pass validation against a PyTorch reference.
+//
+// Set GEMMA4_MODEL_DIR to point at a directory containing gemma-4-e2b base
+// weights (config.json + safetensors). The test skips when the directory is
+// not present.
+//
+// To regenerate the reference (one-time, then cached on disk):
+//
+//	.venv/bin/python3 x/models/scripts/dump_activations.py \
+//	    --model $GEMMA4_MODEL_DIR \
+//	    --model-class Gemma4ForConditionalGeneration \
+//	    [--transformers-path .tmp/transformers-5.5/transformers/src]
+//
+// Output default: /tmp/ollama_ref/gemma-4-e2b/activations.safetensors (or point
+// --output and OLLAMA_REF_DIR at x/models/bringup/<model>/reference/)
+
+const defaultModelDir = "models/gemma-4-e2b"
+
+func loadRefAndModel(t *testing.T) (ref map[string]*mlx.Array, m *Model) {
+	t.Helper()
+
+	// Load model FIRST: base.Weights() calls mlx.Sweep() which would
+	// destroy any unpinned arrays, including reference tensors.
+	modelDir := testutil.ModelDir(t, "GEMMA4_MODEL_DIR", defaultModelDir)
+	bm := testutil.LoadModelFromDir(t, modelDir)
+
+	var ok bool
+	m, ok = bm.(*Model)
+	if !ok {
+		t.Fatalf("expected *gemma4.Model, got %T", bm)
+	}
+
+	refPath := filepath.Join(testutil.DefaultRefDir("gemma-4-e2b"), "activations.safetensors")
+	ref = testutil.LoadReference(t, refPath)
+	return ref, m
+}
+
+// refKey returns the activation key used by the Python dumper. The hooks see
+// the full module path inside the multimodal wrapper, so layer outputs live
+// under "model.language_model.<suffix>".
+func refKey(suffix string) string {
+	return "model.language_model." + suffix
+}
+
+// TestForwardFinalHidden runs the full Forward() and asserts cosine
+// similarity (>= 0.999) against Python's final-norm output. Catches model
+// bugs that survive an early-layer check but are introduced later in the
+// stack.
+func TestForwardFinalHidden(t *testing.T) {
+	mlxtest.Setup(t)
+	ref, m := loadRefAndModel(t)
+
+	tokens := ref["input_ids"].AsType(mlx.DTypeInt32)
+	mlx.Eval(tokens)
+	dims := tokens.Dims()
+
+	caches := m.NewCaches()
+	defer func() {
+		for _, c := range caches {
+			if c != nil {
+				c.Free()
+			}
+		}
+	}()
+	h, _ := m.Forward(&batch.Batch{
+		InputIDs:     tokens,
+		SeqOffsets:   []int32{0},
+		SeqQueryLens: []int32{int32(dims[1])},
+	}, caches)
+	mlx.Eval(h)
+
+	want, ok := ref[refKey("norm")]
+	if !ok {
+		t.Skip("reference is missing final norm output")
+	}
+	testutil.CompareArraysCosineSim(t, "final_hidden", h, want, 0.999)
+}
+
+// TestForwardEmbedding compares the (scaled) embedding output against the
+// reference. Gemma4TextScaledWordEmbedding always multiplies the lookup by
+// sqrt(hidden_size), so the Python hook sees the scaled values.
+//
+// This is a single-op test (embedding lookup + scalar multiply), so tight
+// bf16 element-wise tolerance is appropriate.
+func TestForwardEmbedding(t *testing.T) {
+	mlxtest.Setup(t)
+	ref, m := loadRefAndModel(t)
+
+	tokens := ref["input_ids"].AsType(mlx.DTypeInt32)
+	mlx.Eval(tokens)
+
+	h := m.EmbedTokens.Forward(tokens)
+	hScaled := mlx.MulScalar(h, m.EmbedScale)
+	mlx.Eval(hScaled)
+
+	want, ok := ref[refKey("embed_tokens")]
+	if !ok {
+		t.Skip("reference is missing embed_tokens")
+	}
+	testutil.CompareArrays(t, "embed_scaled", hScaled, want, testutil.BFloat16Tol())
+}
+
+// TestForwardLayersPerPosition replicates Forward() layer by layer and
+// asserts cosine similarity (>= 0.999) against the reference at each
+// layer. Logs a per-position drift report to localize a failure.
+func TestForwardLayersPerPosition(t *testing.T) {
+	mlxtest.Setup(t)
+	ref, m := loadRefAndModel(t)
+
+	tokens := ref["input_ids"].AsType(mlx.DTypeInt32)
+	mlx.Eval(tokens)
+	dims := tokens.Dims()
+	B, L := int32(dims[0]), int32(dims[1])
+
+	h := m.EmbedTokens.Forward(tokens)
+	h = mlx.MulScalar(h, m.EmbedScale)
+
+	var perLayerInputs *mlx.Array
+	if m.HiddenSizePerLayer > 0 && m.EmbedTokensPerLayer != nil {
+		perLayerInputs = m.computePLEInputs(tokens, h)
+	}
+
+	caches := m.NewCaches()
+	defer func() {
+		for _, c := range caches {
+			if c != nil {
+				c.Free()
+			}
+		}
+	}()
+
+	b := &batch.Batch{
+		InputIDs:     tokens,
+		SeqOffsets:   []int32{0},
+		SeqQueryLens: []int32{L},
+	}
+	positions := mlx.FromValues(b.SeqOffsets, len(b.SeqOffsets))
+
+	var sharedKV map[int32]sharedHistory
+	if len(m.KVShareMap) > 0 {
+		sharedKV = make(map[int32]sharedHistory)
+	}
+
+	got := make(map[string]*mlx.Array)
+	want := make(map[string]*mlx.Array)
+
+	for i, layer := range m.Layers {
+		var c cache.Cache
+		if i < len(caches) {
+			c = caches[i]
+		}
+
+		var pleInput *mlx.Array
+		if perLayerInputs != nil {
+			pleInput = sliceLayerDim(perLayerInputs, int32(i), B, L, m.HiddenSizePerLayer)
+		}
+
+		var donor *sharedHistory
+		if layer.KVShareDonor >= 0 && sharedKV != nil {
+			if d, ok := sharedKV[layer.KVShareDonor]; ok {
+				donor = &d
+			}
+		}
+
+		var donorKV *sharedHistory
+		h, donorKV = layer.Forward(h, b, c, positions, B, L, m.TextConfig, pleInput, donor)
+
+		if layer.IsDonor && donorKV != nil && sharedKV != nil {
+			sharedKV[layer.LayerIdx] = *donorKV
+		}
+
+		key := fmt.Sprintf("layers.%02d", i)
+		mlx.Eval(h)
+		mlx.Pin(h)
+		got[key] = h
+
+		refName := fmt.Sprintf("layers.%d", i)
+		if arr, ok := ref[refKey(refName)]; ok {
+			want[key] = arr
+		}
+	}
+	defer func() {
+		for _, a := range got {
+			mlx.Unpin(a)
+		}
+	}()
+
+	// Strict cosine-similarity assertion per layer.
+	const minCos = float32(0.999)
+	for i := range m.Layers {
+		key := fmt.Sprintf("layers.%02d", i)
+		w, ok := want[key]
+		if !ok {
+			continue
+		}
+		testutil.CompareArraysCosineSim(t, key, got[key], w, minCos)
+	}
+
+	// Per-position diagnostic — log only, used when an assertion above fails
+	// to localize where things went wrong.
+	loose := testutil.WithTolerance(0.5, 0.05)
+	report := testutil.CompareLayersPerPosition(t, got, want, 1, loose)
+	report.Summary(t)
+	testutil.LogDriftRanks(t, "\nTop 10 drifts (absolute):", report.TopDrifts(10))
+	if layerIdx, pos := report.EarliestOutlierPosition(5); layerIdx >= 0 {
+		layer := report.Layers[layerIdx]
+		t.Logf("\nEARLIEST OUTLIER: layer %s, position %d (rel_to_median ≥ 5×)", layer.Name, pos)
+	}
+}

--- a/x/models/gemma4/longseq_test.go
+++ b/x/models/gemma4/longseq_test.go
@@ -1,0 +1,183 @@
+package gemma4
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/ollama/ollama/x/mlxrunner/cache"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/models/testutil"
+)
+
+// TestLongSeqLayerDriftPerPosition is the regression fixture for the
+// long-sequence sliding-window forward pass. It loads a Python activation
+// reference produced from a prompt longer than the sliding window and walks
+// the MLX forward pass layer by layer, using `CompareLayersPerPosition` to
+// find the first (layer, position) where MLX drifts from the reference.
+//
+// This is the fixture that originally caught the SWA boundary bug fixed by
+// the gemma4 implementation commit: prefill scoring of positions past the
+// sliding window was attending to the entire prefix instead of only the last
+// `window` tokens, which produced a clean drift onset at position
+// `sliding_window` of layer 0 that compounded through every subsequent layer.
+//
+// Set GEMMA4_MODEL_DIR to point at a directory containing gemma-4-e2b base
+// weights. Override the reference dump path via GEMMA4_LONG_REFERENCE; the
+// test skips when either is unavailable.
+//
+// To regenerate the reference (typically a 6 KB slice of wiki.test.raw,
+// long enough to overflow the 512-token sliding window):
+//
+//	.venv/bin/python3 x/models/scripts/dump_activations.py \
+//	    --model $GEMMA4_MODEL_DIR \
+//	    --model-class Gemma4ForConditionalGeneration \
+//	    --prompt "$(head -c 6000 /tmp/ollama-bench-data/wiki.test.raw)" \
+//	    --skip-logits \
+//	    --output /tmp/ollama_ref/gemma-4-e2b/long_activations.safetensors
+func TestLongSeqLayerDriftPerPosition(t *testing.T) {
+	testutil.SkipIfNoMLX(t)
+
+	refPath := os.Getenv("GEMMA4_LONG_REFERENCE")
+	if refPath == "" {
+		refPath = "/tmp/ollama_ref/gemma-4-e2b/long_activations.safetensors"
+	}
+	if _, err := os.Stat(refPath); err != nil {
+		t.Skipf("long-seq reference not available at %s; see test docstring for how to regenerate", refPath)
+	}
+
+	// Load the model FIRST so base.Weights() pins all model tensors before
+	// we load the reference (otherwise the reference tensors would be
+	// Sweep'd away by the model load).
+	modelDir := testutil.ModelDir(t, "GEMMA4_MODEL_DIR", "models/gemma-4-e2b")
+	bm := testutil.LoadModelFromDir(t, modelDir)
+	m, ok := bm.(*Model)
+	if !ok {
+		t.Fatalf("expected *gemma4.Model, got %T", bm)
+	}
+
+	// Filter the dump down to just the tensors we compare against (input_ids,
+	// embed_tokens, final norm, and one tensor per decoder layer). The full
+	// dump captures every submodule — for a >sliding_window prompt that's
+	// gigabytes of pinned activations we don't need.
+	keep := map[string]bool{
+		"input_ids":                         true,
+		"model.language_model.embed_tokens": true,
+		"model.language_model.norm":         true,
+	}
+	for i := range m.NumLayers() {
+		keep[fmt.Sprintf("model.language_model.layers.%d", i)] = true
+	}
+	ref := testutil.LoadReferenceFiltered(t, refPath, keep)
+	t.Logf("loaded %d reference tensors (filtered from full dump)", len(ref))
+
+	inputIDs := ref["input_ids"]
+	if inputIDs == nil {
+		t.Fatal("reference is missing input_ids")
+	}
+	tokens := inputIDs.AsType(mlx.DTypeInt32)
+	mlx.Eval(tokens)
+
+	dims := tokens.Dims()
+	B, L := int32(dims[0]), int32(dims[1])
+	t.Logf("input length: %d tokens (sliding window: %d)", L, m.SlidingWindow)
+
+	h := m.EmbedTokens.Forward(tokens)
+	h = mlx.MulScalar(h, m.EmbedScale)
+
+	var perLayerInputs *mlx.Array
+	if m.HiddenSizePerLayer > 0 && m.EmbedTokensPerLayer != nil {
+		perLayerInputs = m.computePLEInputs(tokens, h)
+	}
+
+	caches := m.NewCaches()
+	defer func() {
+		for _, c := range caches {
+			if c != nil {
+				c.Free()
+			}
+		}
+	}()
+
+	var sharedKV map[int32]sharedKVEntry
+	if len(m.KVShareMap) > 0 {
+		sharedKV = make(map[int32]sharedKVEntry)
+	}
+
+	var smc *slidingMaskCache
+	if L > 1 && m.SlidingWindow > 0 {
+		smc = &slidingMaskCache{}
+	}
+
+	got := make(map[string]*mlx.Array)
+	want := make(map[string]*mlx.Array)
+
+	for i, layer := range m.Layers {
+		var c cache.Cache
+		if i < len(caches) {
+			c = caches[i]
+		}
+
+		var pleInput *mlx.Array
+		if perLayerInputs != nil {
+			pleInput = sliceLayerDim(perLayerInputs, int32(i), B, L, m.HiddenSizePerLayer)
+		}
+
+		var donorEntry *sharedKVEntry
+		if layer.KVShareDonor >= 0 && sharedKV != nil {
+			if entry, ok := sharedKV[layer.KVShareDonor]; ok {
+				donorEntry = &entry
+			}
+		}
+
+		var donorKV *sharedKVEntry
+		h, donorKV = layer.Forward(h, c, B, L, m.TextConfig, pleInput, donorEntry, smc)
+
+		if layer.IsDonor && donorKV != nil && sharedKV != nil {
+			sharedKV[layer.LayerIdx] = *donorKV
+		}
+
+		key := fmt.Sprintf("layers.%02d", i) // zero-padded so sort matches layer order
+		mlx.Eval(h)
+		mlx.Pin(h)
+		got[key] = h
+
+		refKey := fmt.Sprintf("model.language_model.layers.%d", i)
+		if arr, ok := ref[refKey]; ok {
+			want[key] = arr
+		} else {
+			t.Logf("note: reference missing %q; layer %d will be skipped in compare", refKey, i)
+		}
+	}
+	defer func() {
+		for _, a := range got {
+			mlx.Unpin(a)
+		}
+	}()
+
+	// Per-layer cosine-similarity assertion. Threshold is 0.99 rather than
+	// the short-prompt 0.999 because long-prompt bf16 accumulation across
+	// 35 layers is noisier; 0.99 still catches catastrophic divergence
+	// (the original SWA boundary bug drove these layers to ~0.6-0.9).
+	const minCos = float32(0.99)
+	for i := range m.Layers {
+		key := fmt.Sprintf("layers.%02d", i)
+		w, ok := want[key]
+		if !ok {
+			continue
+		}
+		testutil.CompareArraysCosineSim(t, key, got[key], w, minCos)
+	}
+
+	// Per-position drift diagnostic — log only, used to localize a failure
+	// from the assertions above.
+	loose := testutil.WithTolerance(0.5, 0.05)
+	report := testutil.CompareLayersPerPosition(t, got, want, 1, loose)
+	report.Summary(t)
+	testutil.LogDriftRanks(t, "\nTop 15 drifts (absolute):", report.TopDrifts(15))
+	testutil.LogDriftRanks(t, "\nTop 15 drifts (relative to layer median):", report.TopDriftsByRelative(15))
+	if layerIdx, pos := report.EarliestOutlierPosition(5); layerIdx >= 0 {
+		layer := report.Layers[layerIdx]
+		t.Logf("\nEARLIEST OUTLIER: layer %s, position %d (rel_to_median ≥ 5×)", layer.Name, pos)
+	}
+}

--- a/x/models/gemma4/longseq_test.go
+++ b/x/models/gemma4/longseq_test.go
@@ -1,0 +1,187 @@
+package gemma4
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/ollama/ollama/x/internal/mlxtest"
+	"github.com/ollama/ollama/x/mlxrunner/batch"
+	"github.com/ollama/ollama/x/mlxrunner/cache"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/models/testutil"
+)
+
+// TestLongSeqLayerDriftPerPosition is the regression fixture for the
+// long-sequence sliding-window forward pass. It loads a Python activation
+// reference produced from a prompt longer than the sliding window and walks
+// the MLX forward pass layer by layer, using `CompareLayersPerPosition` to
+// find the first (layer, position) where MLX drifts from the reference.
+//
+// This is the fixture that originally caught the SWA boundary bug fixed by
+// the gemma4 implementation commit: prefill scoring of positions past the
+// sliding window was attending to the entire prefix instead of only the last
+// `window` tokens, which produced a clean drift onset at position
+// `sliding_window` of layer 0 that compounded through every subsequent layer.
+//
+// Set GEMMA4_MODEL_DIR to point at a directory containing gemma-4-e2b base
+// weights. Override the reference dump path via GEMMA4_LONG_REFERENCE; the
+// test skips when either is unavailable.
+//
+// To regenerate the reference (typically a 6 KB slice of wiki.test.raw,
+// long enough to overflow the 512-token sliding window):
+//
+//	.venv/bin/python3 x/models/scripts/dump_activations.py \
+//	    --model $GEMMA4_MODEL_DIR \
+//	    --model-class Gemma4ForConditionalGeneration \
+//	    --prompt "$(head -c 6000 /tmp/ollama-bench-data/wiki.test.raw)" \
+//	    --skip-logits \
+//	    --output /tmp/ollama_ref/gemma-4-e2b/long_activations.safetensors
+func TestLongSeqLayerDriftPerPosition(t *testing.T) {
+	mlxtest.Setup(t)
+
+	refPath := os.Getenv("GEMMA4_LONG_REFERENCE")
+	if refPath == "" {
+		refPath = "/tmp/ollama_ref/gemma-4-e2b/long_activations.safetensors"
+	}
+	if _, err := os.Stat(refPath); err != nil {
+		t.Skipf("long-seq reference not available at %s; see test docstring for how to regenerate", refPath)
+	}
+
+	// Load the model FIRST so base.Weights() pins all model tensors before
+	// we load the reference (otherwise the reference tensors would be
+	// Sweep'd away by the model load).
+	modelDir := testutil.ModelDir(t, "GEMMA4_MODEL_DIR", "models/gemma-4-e2b")
+	bm := testutil.LoadModelFromDir(t, modelDir)
+	m, ok := bm.(*Model)
+	if !ok {
+		t.Fatalf("expected *gemma4.Model, got %T", bm)
+	}
+
+	// Filter the dump down to just the tensors we compare against (input_ids,
+	// embed_tokens, final norm, and one tensor per decoder layer). The full
+	// dump captures every submodule — for a >sliding_window prompt that's
+	// gigabytes of pinned activations we don't need.
+	keep := map[string]bool{
+		"input_ids":                         true,
+		"model.language_model.embed_tokens": true,
+		"model.language_model.norm":         true,
+	}
+	for i := range len(m.Layers) {
+		keep[fmt.Sprintf("model.language_model.layers.%d", i)] = true
+	}
+	ref := testutil.LoadReferenceFiltered(t, refPath, keep)
+	t.Logf("loaded %d reference tensors (filtered from full dump)", len(ref))
+
+	inputIDs := ref["input_ids"]
+	if inputIDs == nil {
+		t.Fatal("reference is missing input_ids")
+	}
+	tokens := inputIDs.AsType(mlx.DTypeInt32)
+	mlx.Eval(tokens)
+
+	dims := tokens.Dims()
+	B, L := int32(dims[0]), int32(dims[1])
+	t.Logf("input length: %d tokens (sliding window: %d)", L, m.SlidingWindow)
+
+	h := m.EmbedTokens.Forward(tokens)
+	h = mlx.MulScalar(h, m.EmbedScale)
+
+	var perLayerInputs *mlx.Array
+	if m.HiddenSizePerLayer > 0 && m.EmbedTokensPerLayer != nil {
+		perLayerInputs = m.computePLEInputs(tokens, h)
+	}
+
+	caches := m.NewCaches()
+	defer func() {
+		for _, c := range caches {
+			if c != nil {
+				c.Free()
+			}
+		}
+	}()
+
+	b := &batch.Batch{
+		InputIDs:     tokens,
+		SeqOffsets:   []int32{0},
+		SeqQueryLens: []int32{L},
+	}
+	positions := mlx.FromValues(b.SeqOffsets, len(b.SeqOffsets))
+
+	var sharedKV map[int32]sharedHistory
+	if len(m.KVShareMap) > 0 {
+		sharedKV = make(map[int32]sharedHistory)
+	}
+
+	got := make(map[string]*mlx.Array)
+	want := make(map[string]*mlx.Array)
+
+	for i, layer := range m.Layers {
+		var c cache.Cache
+		if i < len(caches) {
+			c = caches[i]
+		}
+
+		var pleInput *mlx.Array
+		if perLayerInputs != nil {
+			pleInput = sliceLayerDim(perLayerInputs, int32(i), B, L, m.HiddenSizePerLayer)
+		}
+
+		var donor *sharedHistory
+		if layer.KVShareDonor >= 0 && sharedKV != nil {
+			if d, ok := sharedKV[layer.KVShareDonor]; ok {
+				donor = &d
+			}
+		}
+
+		var donorKV *sharedHistory
+		h, donorKV = layer.Forward(h, b, c, positions, B, L, m.TextConfig, pleInput, donor)
+
+		if layer.IsDonor && donorKV != nil && sharedKV != nil {
+			sharedKV[layer.LayerIdx] = *donorKV
+		}
+
+		key := fmt.Sprintf("layers.%02d", i) // zero-padded so sort matches layer order
+		mlx.Eval(h)
+		mlx.Pin(h)
+		got[key] = h
+
+		refKey := fmt.Sprintf("model.language_model.layers.%d", i)
+		if arr, ok := ref[refKey]; ok {
+			want[key] = arr
+		} else {
+			t.Logf("note: reference missing %q; layer %d will be skipped in compare", refKey, i)
+		}
+	}
+	defer func() {
+		for _, a := range got {
+			mlx.Unpin(a)
+		}
+	}()
+
+	// Per-layer cosine-similarity assertion. Threshold is 0.99 rather than
+	// the short-prompt 0.999 because long-prompt bf16 accumulation across
+	// 35 layers is noisier; 0.99 still catches catastrophic divergence
+	// (the original SWA boundary bug drove these layers to ~0.6-0.9).
+	const minCos = float32(0.99)
+	for i := range m.Layers {
+		key := fmt.Sprintf("layers.%02d", i)
+		w, ok := want[key]
+		if !ok {
+			continue
+		}
+		testutil.CompareArraysCosineSim(t, key, got[key], w, minCos)
+	}
+
+	// Per-position drift diagnostic — log only, used to localize a failure
+	// from the assertions above.
+	loose := testutil.WithTolerance(0.5, 0.05)
+	report := testutil.CompareLayersPerPosition(t, got, want, 1, loose)
+	report.Summary(t)
+	testutil.LogDriftRanks(t, "\nTop 15 drifts (absolute):", report.TopDrifts(15))
+	testutil.LogDriftRanks(t, "\nTop 15 drifts (relative to layer median):", report.TopDriftsByRelative(15))
+	if layerIdx, pos := report.EarliestOutlierPosition(5); layerIdx >= 0 {
+		layer := report.Layers[layerIdx]
+		t.Logf("\nEARLIEST OUTLIER: layer %s, position %d (rel_to_median ≥ 5×)", layer.Name, pos)
+	}
+}

--- a/x/models/gemma4/perplexity_test.go
+++ b/x/models/gemma4/perplexity_test.go
@@ -1,0 +1,75 @@
+package gemma4
+
+import (
+	"os"
+	"testing"
+
+	"github.com/ollama/ollama/x/models/testutil"
+)
+
+// TestPerplexitySmoke is a small CI regression check that the gemma4 model
+// loads and produces a sane perplexity number on a few documents of
+// WikiText-2. It uses the new generic perplexity core (testutil.RunPerplexity)
+// in llamacpp mode, which limits forward-pass batch size to n_ctx and
+// avoids the long-sequence forward bug tracked as task #46.
+//
+// This is NOT meant to validate quality — for that, run ollama-ppl
+// (x/cmd/ppl) directly with -mode harness against an lm-evaluation-harness
+// reference. This test only catches gross regressions: the model loads, the
+// forward pass runs, and PPL is finite and not absurdly large.
+//
+// Set GEMMA4_OLLAMA_MODEL to override the default ollama model tag.
+func TestPerplexitySmoke(t *testing.T) {
+	testutil.SkipIfNoMLX(t)
+
+	modelName := os.Getenv("GEMMA4_OLLAMA_MODEL")
+	if modelName == "" {
+		modelName = "gemma4:e2b-base-mlx-bf16"
+	}
+
+	m, cleanup, err := testutil.LoadModelByNameOrErr(modelName)
+	if err != nil {
+		t.Skipf("model %q not available: %v", modelName, err)
+	}
+	defer cleanup()
+
+	// Build a self-contained synthetic corpus long enough for one
+	// reasonably-sized chunk. We don't care about the absolute PPL value
+	// here — just that the forward pass runs and the result is finite.
+	docs := []testutil.Document{
+		{Text: "The quick brown fox jumps over the lazy dog. " +
+			"A bright sunny day in the meadow where flowers bloom and " +
+			"birds sing their morning songs while a gentle breeze " +
+			"carries the sweet scent of pine trees across rolling " +
+			"hills toward distant mountains covered with fresh snow " +
+			"beneath a clear blue sky. Children play near the old " +
+			"stone bridge that crosses the winding river as it flows " +
+			"toward the great ocean. Once upon a time, in a kingdom " +
+			"far away, there lived a curious child who loved to read " +
+			"books about science and history and faraway places. " +
+			"Perplexity measures how well a language model predicts " +
+			"a held-out sequence of tokens, computed as the exponential " +
+			"of the average negative log likelihood per token."},
+	}
+
+	opts := testutil.PPLOptions{
+		Mode:            testutil.ModeLlamaCpp, // bounded chunk size keeps memory predictable
+		MaxLength:       64,                    // short context: smoke-test cost is minimal
+		BOSSwapLlamaCpp: true,
+	}
+	result, err := testutil.RunPerplexity(m, docs, opts, testutil.NewWriterLogger(nil))
+	if err != nil {
+		t.Fatalf("RunPerplexity: %v", err)
+	}
+
+	if result.TotalTokens == 0 {
+		t.Fatal("no tokens scored")
+	}
+	if result.TokenPerplexity <= 1.0 {
+		t.Errorf("token PPL too low to be plausible: %f", result.TokenPerplexity)
+	}
+	if result.TokenPerplexity >= 100000.0 {
+		t.Errorf("token PPL absurdly high: %f", result.TokenPerplexity)
+	}
+	t.Logf("smoke test PPL: %.4f over %d tokens", result.TokenPerplexity, result.TotalTokens)
+}

--- a/x/models/gemma4/perplexity_test.go
+++ b/x/models/gemma4/perplexity_test.go
@@ -1,0 +1,76 @@
+package gemma4
+
+import (
+	"os"
+	"testing"
+
+	"github.com/ollama/ollama/x/internal/mlxtest"
+	"github.com/ollama/ollama/x/models/testutil"
+)
+
+// TestPerplexitySmoke is a small CI regression check that the gemma4 model
+// loads and produces a sane perplexity number on a few documents of
+// WikiText-2. It uses the new generic perplexity core (testutil.RunPerplexity)
+// in window mode, which limits forward-pass batch size to n_ctx and
+// avoids the long-sequence forward bug tracked as task #46.
+//
+// This is NOT meant to validate quality — for that, run ollama-ppl
+// (x/cmd/ppl) directly with -mode harness against an lm-evaluation-harness
+// reference. This test only catches gross regressions: the model loads, the
+// forward pass runs, and PPL is finite and not absurdly large.
+//
+// Set GEMMA4_OLLAMA_MODEL to override the default ollama model tag.
+func TestPerplexitySmoke(t *testing.T) {
+	mlxtest.Setup(t)
+
+	modelName := os.Getenv("GEMMA4_OLLAMA_MODEL")
+	if modelName == "" {
+		modelName = "gemma4:e2b-base-mlx-bf16"
+	}
+
+	m, cleanup, err := testutil.LoadModelByNameOrErr(modelName)
+	if err != nil {
+		t.Skipf("model %q not available: %v", modelName, err)
+	}
+	defer cleanup()
+
+	// Build a self-contained synthetic corpus long enough for one
+	// reasonably-sized chunk. We don't care about the absolute PPL value
+	// here — just that the forward pass runs and the result is finite.
+	docs := []testutil.Document{
+		{Text: "The quick brown fox jumps over the lazy dog. " +
+			"A bright sunny day in the meadow where flowers bloom and " +
+			"birds sing their morning songs while a gentle breeze " +
+			"carries the sweet scent of pine trees across rolling " +
+			"hills toward distant mountains covered with fresh snow " +
+			"beneath a clear blue sky. Children play near the old " +
+			"stone bridge that crosses the winding river as it flows " +
+			"toward the great ocean. Once upon a time, in a kingdom " +
+			"far away, there lived a curious child who loved to read " +
+			"books about science and history and faraway places. " +
+			"Perplexity measures how well a language model predicts " +
+			"a held-out sequence of tokens, computed as the exponential " +
+			"of the average negative log likelihood per token."},
+	}
+
+	opts := testutil.PPLOptions{
+		Mode:            testutil.ModeWindow, // bounded chunk size keeps memory predictable
+		MaxLength:       64,                  // short context: smoke-test cost is minimal
+		BOSSubstitution: true,
+	}
+	result, err := testutil.RunPerplexity(m, docs, opts, testutil.NewWriterLogger(nil))
+	if err != nil {
+		t.Fatalf("RunPerplexity: %v", err)
+	}
+
+	if result.TotalTokens == 0 {
+		t.Fatal("no tokens scored")
+	}
+	if result.TokenPerplexity <= 1.0 {
+		t.Errorf("token PPL too low to be plausible: %f", result.TokenPerplexity)
+	}
+	if result.TokenPerplexity >= 100000.0 {
+		t.Errorf("token PPL absurdly high: %f", result.TokenPerplexity)
+	}
+	t.Logf("smoke test PPL: %.4f over %d tokens", result.TokenPerplexity, result.TotalTokens)
+}

--- a/x/models/gemma4/tokenizer_test.go
+++ b/x/models/gemma4/tokenizer_test.go
@@ -1,0 +1,113 @@
+package gemma4
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ollama/ollama/x/tokenizer"
+)
+
+// TestMLXTokenizerMatchesReference verifies the MLX tokenizer (x/tokenizer)
+// matches reference token IDs from the Rust tokenizers library for Gemma 4.
+//
+// Set GEMMA4_TOKENIZER_DIR to a model directory containing tokenizer.json.
+// The test skips when neither the env var nor the default
+// "models/gemma-4-e2b-it" path is present.
+func TestMLXTokenizerMatchesReference(t *testing.T) {
+	modelDir := os.Getenv("GEMMA4_TOKENIZER_DIR")
+	if modelDir == "" {
+		modelDir = filepath.Join("models", "gemma-4-e2b-it")
+	}
+
+	tokJSON := filepath.Join(modelDir, "tokenizer.json")
+	data, err := os.ReadFile(tokJSON)
+	if err != nil {
+		t.Skipf("skipping: cannot read %s: %v", tokJSON, err)
+	}
+
+	tok, err := tokenizer.LoadFromBytes(data)
+	if err != nil {
+		t.Fatalf("LoadFromBytes failed: %v", err)
+	}
+
+	// Reference token IDs from the Rust tokenizers library (add_special_tokens=False).
+	// Copied from model/models/gemma4/tokenizer_reference_test.go.
+	tests := []struct {
+		name  string
+		input string
+		want  []int32
+	}{
+		// Basic ASCII
+		{name: "basic word", input: "hello", want: []int32{23391}},
+		{name: "two words", input: "hello world", want: []int32{23391, 1902}},
+		{name: "punctuation", input: "Hello, World!", want: []int32{9259, 236764, 4109, 236888}},
+
+		// Space handling
+		{name: "leading space", input: " hello", want: []int32{29104}},
+		{name: "double leading space", input: "  hello", want: []int32{138, 23391}},
+		{name: "double space between words", input: "hello  world", want: []int32{23391, 138, 12392}},
+		{name: "only spaces", input: "   ", want: []int32{139}},
+		{name: "leading spaces phrase", input: " leading spaces", want: []int32{5830, 9952}},
+		{name: "multiple interior spaces", input: "multiple    spaces", want: []int32{43819, 140, 35220}},
+
+		// Polish diacritics (byte fallback)
+		{name: "polish diacritics", input: "ąęśćżźółń", want: []int32{237198, 237202, 14732, 237277, 238992, 24875, 238041}},
+		{name: "polish sentence", input: "Zażółć gęślą jaźń", want: []int32{236953, 40512, 24875, 237289, 549, 237202, 62081, 237198, 4828, 238992, 238041}},
+
+		// French accents
+		{name: "french accents", input: "café résumé naïve", want: []int32{123125, 236859, 118515, 120362}},
+
+		// CJK & Japanese
+		{name: "chinese", input: "你好世界", want: []int32{144626, 12811}},
+		{name: "japanese hiragana", input: "こんにちは", want: []int32{85141}},
+
+		// Special tokens
+		{
+			name: "special_tokens", input: "<|turn>user\nWhat is 2+2?<turn|>\n<|turn>model\n",
+			want: []int32{105, 2364, 107, 3689, 563, 236743, 236778, 236862, 236778, 236881, 106, 107, 105, 4368, 107},
+		},
+		{
+			name: "tool_declaration", input: "<|tool>declaration:bash{description:<|\"|>Run a command<|\"|>}<tool|>",
+			want: []int32{46, 163688, 236787, 42422, 236782, 7777, 236787, 52, 7306, 496, 4991, 52, 236783, 47},
+		},
+		{
+			name: "tool_call", input: "<|tool_call>call:bash{command:<|\"|>ls -la<|\"|>}<tool_call|>",
+			want: []int32{48, 6639, 236787, 42422, 236782, 7674, 236787, 52, 5629, 753, 2149, 52, 236783, 49},
+		},
+
+		// Code
+		{name: "python code", input: "def foo(x): return x + 1", want: []int32{2063, 46293, 236769, 236781, 1473, 994, 1123, 900, 236743, 236770}},
+		{name: "json", input: `{"key": "value"}`, want: []int32{14937, 2478, 1083, 623, 2394, 25938}},
+
+		// Misc
+		{name: "emoji", input: "hello 👋 world", want: []int32{23391, 155818, 1902}},
+		{name: "digits", input: "12345", want: []int32{236770, 236778, 236800, 236812, 236810}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tok.Encode(tt.input, false) // no BOS
+
+			if len(got) != len(tt.want) {
+				t.Errorf("token count mismatch: got %d, want %d", len(got), len(tt.want))
+				t.Logf("got:  %v", got)
+				t.Logf("want: %v", tt.want)
+				return
+			}
+
+			mismatches := 0
+			for i := range got {
+				if got[i] != tt.want[i] {
+					mismatches++
+					if mismatches <= 5 {
+						t.Errorf("mismatch at [%d]: got %d, want %d", i, got[i], tt.want[i])
+					}
+				}
+			}
+			if mismatches > 5 {
+				t.Errorf("... and %d more mismatches", mismatches-5)
+			}
+		})
+	}
+}

--- a/x/models/qwen3_5/forward_test.go
+++ b/x/models/qwen3_5/forward_test.go
@@ -1,0 +1,127 @@
+package qwen3_5
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ollama/ollama/x/mlxrunner/cache"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/models/testutil"
+)
+
+// TestForwardLayersPerPosition validates the Qwen 3.5 MLX forward pass against
+// a Python activation reference produced by `x/models/scripts/dump_activations.py`.
+// It walks the model layer by layer, captures each layer's output, and asks
+// `testutil.CompareLayersPerPosition` to find the first (layer, position)
+// where MLX drifts from the reference. This is the second-model validation
+// for the MLX porting tooling — Qwen 3.5 has a hybrid attention pattern
+// (mix of full and Mamba-style linear attention layers) that exercises a
+// different code path from the Gemma 4 fixture.
+//
+// Setup: set QWEN35_MODEL_DIR to a directory containing Qwen3.5-4B-Base
+// safetensors weights. The test skips when the directory or activation
+// reference is not present.
+//
+// To regenerate the reference:
+//
+//	.venv/bin/python3 x/models/scripts/dump_activations.py \
+//	    --model $QWEN35_MODEL_DIR \
+//	    --model-class Qwen3_5ForConditionalGeneration \
+//	    --prompt "The quick brown fox jumps over the lazy dog. A bright sunny day in the meadow." \
+//	    --skip-logits
+func TestForwardLayersPerPosition(t *testing.T) {
+	testutil.SkipIfNoMLX(t)
+
+	refPath := filepath.Join(testutil.DefaultRefDir("Qwen3.5-4B-Base"), "activations.safetensors")
+	if _, err := os.Stat(refPath); err != nil {
+		t.Skipf("Qwen3.5 reference not available at %s; see test docstring", refPath)
+	}
+
+	modelDir := testutil.ModelDir(t, "QWEN35_MODEL_DIR", "models/Qwen3.5-4B-Base")
+	bm := testutil.LoadModelFromDir(t, modelDir)
+	m, ok := bm.(*Model)
+	if !ok {
+		t.Fatalf("expected *qwen3_5.Model, got %T", bm)
+	}
+
+	keep := map[string]bool{
+		"input_ids":                         true,
+		"model.language_model.embed_tokens": true,
+		"model.language_model.norm":         true,
+	}
+	for i := range m.NumLayers() {
+		keep[fmt.Sprintf("model.language_model.layers.%d", i)] = true
+	}
+	ref := testutil.LoadReferenceFiltered(t, refPath, keep)
+	t.Logf("loaded %d reference tensors", len(ref))
+
+	inputIDs := ref["input_ids"]
+	if inputIDs == nil {
+		t.Fatal("reference is missing input_ids")
+	}
+	tokens := inputIDs.AsType(mlx.DTypeInt32)
+	mlx.Eval(tokens)
+
+	dims := tokens.Dims()
+	B, L := int32(dims[0]), int32(dims[1])
+	t.Logf("input length: %d tokens", L)
+
+	h := m.EmbedTokens.Forward(tokens)
+	caches := m.NewCaches()
+	defer func() {
+		for _, c := range caches {
+			if c != nil {
+				c.Free()
+			}
+		}
+	}()
+
+	got := make(map[string]*mlx.Array)
+	want := make(map[string]*mlx.Array)
+
+	for i, layer := range m.Layers {
+		var c cache.Cache
+		if i < len(caches) {
+			c = caches[i]
+		}
+		h = layer.Forward(h, c, B, L, m.Config)
+
+		key := fmt.Sprintf("layers.%02d", i)
+		mlx.Eval(h)
+		mlx.Pin(h)
+		got[key] = h
+
+		refKey := fmt.Sprintf("model.language_model.layers.%d", i)
+		if arr, ok := ref[refKey]; ok {
+			want[key] = arr
+		} else {
+			t.Logf("note: reference missing %q; layer %d will be skipped", refKey, i)
+		}
+	}
+	defer func() {
+		for _, a := range got {
+			mlx.Unpin(a)
+		}
+	}()
+
+	// Strict cosine-similarity assertion per layer. See
+	// testutil.CompareArraysCosineSim for why cosine is the right primary
+	// check here rather than element-wise tolerance.
+	const minCos = float32(0.999)
+	for i := range m.Layers {
+		key := fmt.Sprintf("layers.%02d", i)
+		w, ok := want[key]
+		if !ok {
+			continue
+		}
+		testutil.CompareArraysCosineSim(t, key, got[key], w, minCos)
+	}
+
+	// Per-position diagnostic — log only, used to localize a failure above.
+	report := testutil.CompareLayersPerPosition(t, got, want, 1, testutil.WithTolerance(0.5, 0.05))
+	report.Summary(t)
+	testutil.LogDriftRanks(t, "\nTop 10 drifts (absolute):", report.TopDrifts(10))
+	testutil.LogDriftRanks(t, "\nTop 10 drifts (relative to layer median):", report.TopDriftsByRelative(10))
+}

--- a/x/models/qwen3_5/forward_test.go
+++ b/x/models/qwen3_5/forward_test.go
@@ -1,0 +1,141 @@
+package qwen3_5
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ollama/ollama/x/internal/mlxtest"
+	"github.com/ollama/ollama/x/mlxrunner/batch"
+	"github.com/ollama/ollama/x/mlxrunner/cache"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/models/testutil"
+)
+
+// TestForwardLayersPerPosition validates the Qwen 3.5 MLX forward pass against
+// a Python activation reference produced by `x/models/scripts/dump_activations.py`.
+// It walks the model layer by layer, captures each layer's output, and asks
+// `testutil.CompareLayersPerPosition` to find the first (layer, position)
+// where MLX drifts from the reference. This is the second-model validation
+// for the MLX porting tooling — Qwen 3.5 has a hybrid attention pattern
+// (mix of full and Mamba-style linear attention layers) that exercises a
+// different code path from the Gemma 4 fixture.
+//
+// Setup: set QWEN35_MODEL_DIR to a directory containing Qwen3.5-4B-Base
+// safetensors weights. The test skips when the directory or activation
+// reference is not present.
+//
+// To regenerate the reference:
+//
+//	.venv/bin/python3 x/models/scripts/dump_activations.py \
+//	    --model $QWEN35_MODEL_DIR \
+//	    --model-class Qwen3_5ForConditionalGeneration \
+//	    --prompt "The quick brown fox jumps over the lazy dog. A bright sunny day in the meadow." \
+//	    --skip-logits
+func TestForwardLayersPerPosition(t *testing.T) {
+	mlxtest.Setup(t)
+
+	refPath := filepath.Join(testutil.DefaultRefDir("Qwen3.5-4B-Base"), "activations.safetensors")
+	if _, err := os.Stat(refPath); err != nil {
+		t.Skipf("Qwen3.5 reference not available at %s; see test docstring", refPath)
+	}
+
+	modelDir := testutil.ModelDir(t, "QWEN35_MODEL_DIR", "models/Qwen3.5-4B-Base")
+	bm := testutil.LoadModelFromDir(t, modelDir)
+	m, ok := bm.(*Model)
+	if !ok {
+		t.Fatalf("expected *qwen3_5.Model, got %T", bm)
+	}
+
+	keep := map[string]bool{
+		"input_ids":                         true,
+		"model.language_model.embed_tokens": true,
+		"model.language_model.norm":         true,
+	}
+	for i := range m.NumLayers() {
+		keep[fmt.Sprintf("model.language_model.layers.%d", i)] = true
+	}
+	ref := testutil.LoadReferenceFiltered(t, refPath, keep)
+	t.Logf("loaded %d reference tensors", len(ref))
+
+	inputIDs := ref["input_ids"]
+	if inputIDs == nil {
+		t.Fatal("reference is missing input_ids")
+	}
+	tokens := inputIDs.AsType(mlx.DTypeInt32)
+	mlx.Eval(tokens)
+
+	dims := tokens.Dims()
+	B, L := int32(dims[0]), int32(dims[1])
+	t.Logf("input length: %d tokens", L)
+
+	b := &batch.Batch{
+		InputIDs:     tokens,
+		SeqOffsets:   []int32{0},
+		SeqQueryLens: []int32{L},
+	}
+	positions := mlx.FromValues(b.SeqOffsets, len(b.SeqOffsets))
+
+	h := m.EmbedTokens.Forward(tokens)
+	caches := m.NewCaches()
+	defer func() {
+		for _, c := range caches {
+			if c != nil {
+				c.Free()
+			}
+		}
+	}()
+
+	var mropeCos, mropeSin *mlx.Array
+	if mp := ropePositions(b, L); mp != nil {
+		mropeCos, mropeSin = mropeCosSin(m.Config, mp, L)
+	}
+
+	got := make(map[string]*mlx.Array)
+	want := make(map[string]*mlx.Array)
+
+	for i, layer := range m.Layers {
+		var c cache.Cache
+		if i < len(caches) {
+			c = caches[i]
+		}
+		h = layer.Forward(h, b, c, positions, B, L, m.Config, mropeCos, mropeSin)
+
+		key := fmt.Sprintf("layers.%02d", i)
+		mlx.Eval(h)
+		mlx.Pin(h)
+		got[key] = h
+
+		refKey := fmt.Sprintf("model.language_model.layers.%d", i)
+		if arr, ok := ref[refKey]; ok {
+			want[key] = arr
+		} else {
+			t.Logf("note: reference missing %q; layer %d will be skipped", refKey, i)
+		}
+	}
+	defer func() {
+		for _, a := range got {
+			mlx.Unpin(a)
+		}
+	}()
+
+	// Strict cosine-similarity assertion per layer. See
+	// testutil.CompareArraysCosineSim for why cosine is the right primary
+	// check here rather than element-wise tolerance.
+	const minCos = float32(0.999)
+	for i := range m.Layers {
+		key := fmt.Sprintf("layers.%02d", i)
+		w, ok := want[key]
+		if !ok {
+			continue
+		}
+		testutil.CompareArraysCosineSim(t, key, got[key], w, minCos)
+	}
+
+	// Per-position diagnostic — log only, used to localize a failure above.
+	report := testutil.CompareLayersPerPosition(t, got, want, 1, testutil.WithTolerance(0.5, 0.05))
+	report.Summary(t)
+	testutil.LogDriftRanks(t, "\nTop 10 drifts (absolute):", report.TopDrifts(10))
+	testutil.LogDriftRanks(t, "\nTop 10 drifts (relative to layer median):", report.TopDriftsByRelative(10))
+}

--- a/x/models/scripts/README.md
+++ b/x/models/scripts/README.md
@@ -1,0 +1,89 @@
+# x/models/scripts
+
+Helper scripts for porting and validating MLX model implementations.
+None of these are required at runtime — they exist to support the
+implementation/debugging workflow described in
+[`../PORTING_GUIDE.md`](../PORTING_GUIDE.md).
+
+## Available scripts
+
+### `inspect_model.py`
+
+Reads one or more Hugging Face model directories (or Hub IDs when
+`huggingface_hub` is installed), inspects config/tokenizer files and
+safetensors headers, and writes `porting_manifest.json` plus
+`porting_manifest.md`.
+
+```
+python3 x/models/scripts/inspect_model.py \
+    --model models/MyOrg/MyModel-Base \
+    --output /tmp/ollama_port/my-model
+```
+
+### `dump_activations.py`
+
+Captures per-module forward outputs from a PyTorch reference
+implementation (any model loadable through `transformers`) and writes
+them to a `.safetensors` file. The Go-side `forward_test.go` files load
+this reference via `testutil.LoadReference` and compare it position by
+position against the MLX implementation's outputs.
+
+```
+.venv/bin/python3 x/models/scripts/dump_activations.py \
+    --model models/MyOrg/MyModel-Base \
+    --attn-implementation eager \
+    --model-class MyModelForCausalLM
+```
+
+See the script's `--help` for the full flag list, including filter
+patterns for capturing only a subset of submodules and a
+`--transformers-path` override for using a custom `transformers` source
+checkout. Pin the attention implementation when Transformers offers multiple
+backends for the model. The script also writes a deterministic sidecar manifest
+next to the safetensors output by default, including the resolved attention
+backend and whether the forward pass used cache state.
+
+For cache validation, run the prompt as a cached prefill and capture a
+follow-up decode pass:
+
+```
+.venv/bin/python3 x/models/scripts/dump_activations.py \
+    --model models/MyOrg/MyModel-Base \
+    --attn-implementation eager \
+    --prompt "$(cat /tmp/long-prompt.txt)" \
+    --decode-text " the" \
+    --skip-logits
+```
+
+### `compare_activations.py`
+
+Compares two safetensors activation artifacts one tensor at a time and writes
+ranked JSON/Markdown drift reports. Use it to compare two reference backends
+or to summarize a focused candidate-vs-reference activation dump without
+loading the whole artifact set into memory at once.
+
+```
+python3 x/models/scripts/compare_activations.py \
+    --got /tmp/ollama_ref/my-model/eager.safetensors \
+    --want /tmp/ollama_ref/my-model/sdpa.safetensors \
+    --filter "model.layers.*" \
+    --json-output /tmp/ollama_port/my-model/activation-comparison.json \
+    --markdown-output /tmp/ollama_port/my-model/activation-comparison.md
+```
+
+### `summarize_validation.py`
+
+Builds a reviewer-ready Markdown report from the non-agentic artifacts
+produced during a port: the inspection manifest, activation manifests,
+activation comparison JSON, `go test -json` output, `x/cmd/ppl -format json`
+output, and optional generation samples.
+
+```
+python3 x/models/scripts/summarize_validation.py \
+    --manifest /tmp/ollama_port/my-model/porting_manifest.json \
+    --activation-manifest /tmp/ollama_ref/my-model/activations.safetensors.manifest.json \
+    --activation-comparison-json /tmp/ollama_port/my-model/activation-comparison.json \
+    --go-test-json /tmp/ollama_port/my-model/go-test.json \
+    --ppl-json /tmp/ollama_port/my-model/ppl.json \
+    --output /tmp/ollama_port/my-model/review_report.md
+```

--- a/x/models/scripts/README.md
+++ b/x/models/scripts/README.md
@@ -1,0 +1,96 @@
+# x/models/scripts
+
+Helper scripts for porting and validating MLX model implementations.
+None of these are required at runtime — they exist to support the
+implementation/debugging workflow described in
+[`../PORTING_GUIDE.md`](../PORTING_GUIDE.md).
+
+## Available scripts
+
+### `inspect_model.py`
+
+Reads one or more Hugging Face model directories (or Hub IDs when
+`huggingface_hub` is installed), inspects config/tokenizer files and
+safetensors headers, and writes `porting_manifest.json` plus
+`porting_manifest.md`.
+
+```
+python3 x/models/scripts/inspect_model.py \
+    --model models/MyOrg/MyModel-Base \
+    --output /tmp/ollama_port/my-model
+```
+
+### `dump_activations.py`
+
+Captures per-module forward outputs from a PyTorch reference
+implementation (any model loadable through `transformers`) and writes
+them to a `.safetensors` file. The Go-side `forward_test.go` files load
+this reference via `testutil.LoadReference` and compare it position by
+position against the MLX implementation's outputs.
+
+```
+.venv/bin/python3 x/models/scripts/dump_activations.py \
+    --model models/MyOrg/MyModel-Base \
+    --attn-implementation eager \
+    --model-class MyModelForCausalLM
+```
+
+See the script's `--help` for the full flag list, including filter
+patterns for capturing only a subset of submodules and a
+`--transformers-path` override for using a custom `transformers` source
+checkout. Pin the attention implementation when Transformers offers multiple
+backends for the model. The script also writes a deterministic sidecar manifest
+next to the safetensors output by default, including the resolved attention
+backend and whether the forward pass used cache state.
+
+For cache validation, run the prompt as a cached prefill and capture a
+follow-up decode pass:
+
+```
+.venv/bin/python3 x/models/scripts/dump_activations.py \
+    --model models/MyOrg/MyModel-Base \
+    --attn-implementation eager \
+    --prompt "$(cat /tmp/long-prompt.txt)" \
+    --decode-text " the" \
+    --skip-logits
+```
+
+### `compare_activations.py`
+
+Compares two safetensors activation artifacts one tensor at a time and writes
+ranked JSON/Markdown drift reports. Use it to compare two reference backends
+or to summarize a focused candidate-vs-reference activation dump without
+loading the whole artifact set into memory at once.
+
+```
+python3 x/models/scripts/compare_activations.py \
+    --got /tmp/ollama_ref/my-model/eager.safetensors \
+    --want /tmp/ollama_ref/my-model/sdpa.safetensors \
+    --filter "model.layers.*" \
+    --json-output /tmp/ollama_port/my-model/activation-comparison.json \
+    --markdown-output /tmp/ollama_port/my-model/activation-comparison.md
+```
+
+### `summarize_validation.py`
+
+Builds a reviewer-ready Markdown report from the non-agentic artifacts
+produced during a port: the inspection manifest, activation manifests,
+activation comparison JSON, `go test -json` output, `x/cmd/ppl -format json`
+output, and optional generation samples.
+
+```
+python3 x/models/scripts/summarize_validation.py \
+    --manifest /tmp/ollama_port/my-model/porting_manifest.json \
+    --activation-manifest /tmp/ollama_ref/my-model/activations.safetensors.manifest.json \
+    --activation-comparison-json /tmp/ollama_port/my-model/activation-comparison.json \
+    --artifact-abi-report /tmp/ollama_port/my-model/artifact-abi.md \
+    --go-test-json /tmp/ollama_port/my-model/go-test.json \
+    --ppl-json /tmp/ollama_port/my-model/ppl.json \
+    --output /tmp/ollama_port/my-model/review_report.md
+```
+
+For published tags, the artifact ABI report is required evidence. It should
+compare publisher source metadata to the created Ollama tag, and compare the
+previous public tag to the replacement tag when overwriting. Include tensor
+names/namespaces, config-schema shape, tokenizer/processor/generation
+metadata, params, capabilities, auxiliary components, and `REQUIRES`.

--- a/x/models/scripts/compare_activations.py
+++ b/x/models/scripts/compare_activations.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Compare two safetensors activation artifacts.
+
+This is intentionally model-neutral: it compares tensors by key, reports
+global drift, and optionally scans one axis (usually sequence position) to find
+the first position that exceeds a tolerance. Use it to compare PyTorch
+reference variants, or any two activation dumps produced during a port.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import math
+import pathlib
+import statistics
+import sys
+from typing import Any
+
+import torch
+from safetensors import safe_open
+
+
+def matches_any(name: str, patterns: list[str]) -> bool:
+    return not patterns or any(fnmatch.fnmatch(name, pattern) for pattern in patterns)
+
+
+def tensor_keys(path: pathlib.Path) -> list[str]:
+    with safe_open(path, framework="pt", device="cpu") as handle:
+        return list(handle.keys())
+
+
+def load_tensor(path: pathlib.Path, name: str) -> torch.Tensor:
+    with safe_open(path, framework="pt", device="cpu") as handle:
+        return handle.get_tensor(name)
+
+
+def cosine_similarity(got: torch.Tensor, want: torch.Tensor) -> float:
+    got_flat = got.reshape(-1).to(torch.float64)
+    want_flat = want.reshape(-1).to(torch.float64)
+    denom = torch.linalg.vector_norm(got_flat) * torch.linalg.vector_norm(want_flat)
+    if float(denom) == 0.0:
+        return 1.0 if torch.equal(got_flat, want_flat) else 0.0
+    return float(torch.dot(got_flat, want_flat) / denom)
+
+
+def position_stats(
+    diff: torch.Tensor,
+    got: torch.Tensor,
+    want: torch.Tensor,
+    axis: int,
+    atol: float,
+    rtol: float,
+) -> dict[str, Any]:
+    if axis < 0 or axis >= diff.ndim:
+        return {}
+
+    moved_diff = torch.movedim(diff, axis, 0).reshape(diff.shape[axis], -1)
+    moved_got = torch.movedim(got, axis, 0).reshape(diff.shape[axis], -1).to(torch.float64)
+    moved_want = torch.movedim(want, axis, 0).reshape(diff.shape[axis], -1).to(torch.float64)
+    moved_tol = atol + rtol * torch.abs(moved_want)
+
+    pos_max = torch.amax(moved_diff, dim=1)
+    pos_mean = torch.mean(moved_diff, dim=1)
+    pos_passed = torch.all(moved_diff <= moved_tol, dim=1)
+
+    first_tol = -1
+    failing = torch.nonzero(~pos_passed, as_tuple=False)
+    if failing.numel() > 0:
+        first_tol = int(failing[0].item())
+
+    worst_pos = int(torch.argmax(pos_max).item()) if pos_max.numel() else -1
+    med = statistics.median(float(v) for v in pos_max.tolist()) if pos_max.numel() else 0.0
+    rel_to_median = float(pos_max[worst_pos]) / max(med, 1e-6) if worst_pos >= 0 else 0.0
+
+    pos_cos = None
+    if worst_pos >= 0:
+        g = moved_got[worst_pos]
+        w = moved_want[worst_pos]
+        denom = torch.linalg.vector_norm(g) * torch.linalg.vector_norm(w)
+        pos_cos = 1.0 if float(denom) == 0.0 and torch.equal(g, w) else 0.0
+        if float(denom) != 0.0:
+            pos_cos = float(torch.dot(g, w) / denom)
+
+    return {
+        "axis": axis,
+        "first_tol": first_tol,
+        "worst_pos": worst_pos,
+        "worst_pos_max_diff": float(pos_max[worst_pos]) if worst_pos >= 0 else 0.0,
+        "worst_pos_mean_diff": float(pos_mean[worst_pos]) if worst_pos >= 0 else 0.0,
+        "worst_pos_cos_sim": pos_cos,
+        "worst_pos_rel_to_median": rel_to_median,
+    }
+
+
+def compare_tensor(
+    name: str,
+    got: torch.Tensor,
+    want: torch.Tensor,
+    axis: int | None,
+    atol: float,
+    rtol: float,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "name": name,
+        "got_dtype": str(got.dtype),
+        "want_dtype": str(want.dtype),
+        "got_shape": list(got.shape),
+        "want_shape": list(want.shape),
+    }
+
+    if tuple(got.shape) != tuple(want.shape):
+        result["status"] = "shape_mismatch"
+        return result
+
+    got_f = got.to(torch.float32)
+    want_f = want.to(torch.float32)
+    diff = torch.abs(got_f - want_f)
+    tol = atol + rtol * torch.abs(want_f)
+    passed = bool(torch.all(diff <= tol).item())
+
+    result.update({
+        "status": "pass" if passed else "fail",
+        "max_diff": float(torch.max(diff).item()) if diff.numel() else 0.0,
+        "mean_diff": float(torch.mean(diff).item()) if diff.numel() else 0.0,
+        "cos_sim": cosine_similarity(got_f, want_f),
+    })
+    if axis is not None:
+        result.update(position_stats(diff, got_f, want_f, axis, atol, rtol))
+    return result
+
+
+def compare_files(
+    got_path: pathlib.Path,
+    want_path: pathlib.Path,
+    patterns: list[str],
+    axis: int | None,
+    atol: float,
+    rtol: float,
+) -> dict[str, Any]:
+    got_keys = set(tensor_keys(got_path))
+    want_keys = set(tensor_keys(want_path))
+    selected = sorted(k for k in got_keys & want_keys if matches_any(k, patterns))
+
+    results: list[dict[str, Any]] = []
+    for name in selected:
+        results.append(compare_tensor(
+            name,
+            load_tensor(got_path, name),
+            load_tensor(want_path, name),
+            axis,
+            atol,
+            rtol,
+        ))
+
+    missing_from_got = sorted(k for k in want_keys - got_keys if matches_any(k, patterns))
+    missing_from_want = sorted(k for k in got_keys - want_keys if matches_any(k, patterns))
+    for name in missing_from_got:
+        results.append({"name": name, "status": "missing_from_got"})
+    for name in missing_from_want:
+        results.append({"name": name, "status": "missing_from_want"})
+
+    counts: dict[str, int] = {}
+    for result in results:
+        counts[result["status"]] = counts.get(result["status"], 0) + 1
+
+    failed = [r for r in results if r["status"] != "pass"]
+    ranked_abs = sorted(
+        (r for r in results if "max_diff" in r),
+        key=lambda r: r["max_diff"],
+        reverse=True,
+    )
+    ranked_rel = sorted(
+        (r for r in results if "worst_pos_rel_to_median" in r),
+        key=lambda r: r["worst_pos_rel_to_median"],
+        reverse=True,
+    )
+
+    return {
+        "schema_version": 1,
+        "got": str(got_path),
+        "want": str(want_path),
+        "filters": patterns,
+        "axis": axis,
+        "atol": atol,
+        "rtol": rtol,
+        "counts": counts,
+        "all_passed": not failed,
+        "results": results,
+        "top_absolute": ranked_abs[:20],
+        "top_relative": ranked_rel[:20],
+    }
+
+
+def fmt_float(value: Any) -> str:
+    if isinstance(value, float):
+        if math.isnan(value) or math.isinf(value):
+            return str(value)
+        return f"{value:.6g}"
+    return str(value)
+
+
+def markdown_report(report: dict[str, Any], top: int) -> str:
+    lines = [
+        "# Activation Comparison",
+        "",
+        f"- got: `{report['got']}`",
+        f"- want: `{report['want']}`",
+        f"- filters: `{', '.join(report['filters']) if report['filters'] else '*'}`",
+        f"- axis: `{report['axis']}`",
+        f"- tolerance: `atol={report['atol']} rtol={report['rtol']}`",
+        f"- counts: `{json.dumps(report['counts'], sort_keys=True)}`",
+        "",
+        "## Top Absolute Drift",
+        "",
+        "| tensor | status | max_diff | mean_diff | cos_sim | first_tol | worst_pos | rel_to_median |",
+        "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for result in report["top_absolute"][:top]:
+        lines.append(
+            "| {name} | {status} | {max_diff} | {mean_diff} | {cos_sim} | {first_tol} | {worst_pos} | {rel} |".format(
+                name=result["name"],
+                status=result["status"],
+                max_diff=fmt_float(result.get("max_diff", "")),
+                mean_diff=fmt_float(result.get("mean_diff", "")),
+                cos_sim=fmt_float(result.get("cos_sim", "")),
+                first_tol=result.get("first_tol", ""),
+                worst_pos=result.get("worst_pos", ""),
+                rel=fmt_float(result.get("worst_pos_rel_to_median", "")),
+            )
+        )
+
+    lines += [
+        "",
+        "## Top Relative Position Drift",
+        "",
+        "| tensor | status | worst_pos | max_diff | mean_diff | cos_sim | rel_to_median |",
+        "| --- | --- | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for result in report["top_relative"][:top]:
+        lines.append(
+            "| {name} | {status} | {worst_pos} | {max_diff} | {mean_diff} | {cos_sim} | {rel} |".format(
+                name=result["name"],
+                status=result["status"],
+                worst_pos=result.get("worst_pos", ""),
+                max_diff=fmt_float(result.get("worst_pos_max_diff", result.get("max_diff", ""))),
+                mean_diff=fmt_float(result.get("worst_pos_mean_diff", result.get("mean_diff", ""))),
+                cos_sim=fmt_float(result.get("worst_pos_cos_sim", result.get("cos_sim", ""))),
+                rel=fmt_float(result.get("worst_pos_rel_to_median", "")),
+            )
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def run(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--got", required=True, help="candidate activation safetensors")
+    parser.add_argument("--want", required=True, help="reference activation safetensors")
+    parser.add_argument("--filter", action="append", default=[], help="fnmatch tensor pattern to compare; can repeat")
+    parser.add_argument("--axis", type=int, default=1, help="axis to scan for first tolerance drift; use -1 to disable")
+    parser.add_argument("--atol", type=float, default=0.5, help="absolute tolerance")
+    parser.add_argument("--rtol", type=float, default=0.05, help="relative tolerance")
+    parser.add_argument("--top", type=int, default=15, help="rows to include in Markdown tables")
+    parser.add_argument("--json-output", help="write structured JSON report")
+    parser.add_argument("--markdown-output", help="write Markdown report")
+    parser.add_argument("--require-pass", action="store_true", help="exit nonzero if any compared tensor fails")
+    args = parser.parse_args(argv)
+
+    axis = None if args.axis < 0 else args.axis
+    report = compare_files(
+        pathlib.Path(args.got),
+        pathlib.Path(args.want),
+        args.filter,
+        axis,
+        args.atol,
+        args.rtol,
+    )
+
+    if args.json_output:
+        path = pathlib.Path(args.json_output)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        print(f"Wrote {path}")
+
+    markdown = markdown_report(report, args.top)
+    if args.markdown_output:
+        path = pathlib.Path(args.markdown_output)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(markdown, encoding="utf-8")
+        print(f"Wrote {path}")
+    elif not args.json_output:
+        print(markdown)
+
+    if args.require_pass and not report["all_passed"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/x/models/scripts/dump_activations.py
+++ b/x/models/scripts/dump_activations.py
@@ -1,0 +1,487 @@
+#!/usr/bin/env python3
+"""Dump intermediate activations from a PyTorch reference model using forward
+hooks.
+
+Loads any model that the `transformers` library can construct, runs a single
+forward pass on a prompt, and saves every submodule's output tensor to a
+safetensors file. The Go-side `forward_test.go` files load this reference
+via `testutil.LoadReference` and compare it against the MLX implementation's
+outputs to find the first layer/position where the two diverge.
+
+The script does not assume anything about *where* the weights came from —
+they just need to live in a directory that `transformers` can load.
+
+Usage:
+    # Auto-detect model class (works for any model registered with
+    # AutoModelForCausalLM / AutoModelForConditionalGeneration):
+    python x/models/scripts/dump_activations.py --model models/<org>/<name>
+
+    # Filter to a subset of modules:
+    python x/models/scripts/dump_activations.py --model models/<org>/<name> \\
+        --filter "model.layers.*"
+
+    # Force a specific transformers class (when auto-detection picks the
+    # wrong one, or when the class isn't registered with AutoModel):
+    python x/models/scripts/dump_activations.py --model models/<org>/<name> \\
+        --model-class Qwen3MoeForCausalLM
+
+Output: /tmp/ollama_ref/<model_basename>/activations.safetensors
+"""
+
+import argparse
+import fnmatch
+import hashlib
+import inspect
+import json
+import os
+import struct
+import sys
+import warnings
+
+os.environ["TRANSFORMERS_NO_TQDM"] = "1"
+os.environ["TRANSFORMERS_VERBOSITY"] = "error"
+warnings.filterwarnings("ignore")
+
+
+DEFAULT_PROMPT = (
+    "The quick brown fox jumps over the lazy dog. A bright sunny day in the meadow. "
+    "Robert Boulter is an English film, television and theatre actor. He had a guest "
+    "starring role on the television series The Bill in 2000."
+)
+
+
+def file_sha256(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def safetensors_header_sha256(path):
+    with open(path, "rb") as f:
+        raw_size = f.read(8)
+        if len(raw_size) != 8:
+            raise ValueError(f"{path}: missing safetensors header size")
+        (header_size,) = struct.unpack("<Q", raw_size)
+        header = f.read(header_size)
+        if len(header) != header_size:
+            raise ValueError(f"{path}: truncated safetensors header")
+    parsed = json.loads(header.decode("utf-8"))
+    parsed.pop("__metadata__", None)
+    stable = json.dumps(parsed, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(stable.encode("utf-8")).hexdigest(), len(parsed)
+
+
+def model_file_digests(model_path):
+    digests = {}
+    for name in [
+        "config.json",
+        "tokenizer.json",
+        "generation_config.json",
+        "tokenizer_config.json",
+        "special_tokens_map.json",
+    ]:
+        path = os.path.join(model_path, name)
+        if os.path.exists(path):
+            digests[name] = file_sha256(path)
+
+    safetensors = []
+    for name in sorted(os.listdir(model_path)):
+        if not name.endswith(".safetensors"):
+            continue
+        path = os.path.join(model_path, name)
+        header_digest, tensor_count = safetensors_header_sha256(path)
+        safetensors.append({
+            "file": name,
+            "size_bytes": os.path.getsize(path),
+            "header_sha256": header_digest,
+            "tensor_count": tensor_count,
+        })
+    return digests, safetensors
+
+
+def tensor_info(tensor):
+    return {
+        "dtype": str(tensor.dtype),
+        "shape": [int(d) for d in tensor.shape],
+        "numel": int(tensor.nelement()),
+    }
+
+
+def config_value(model, name):
+    config = getattr(model, "config", None)
+    if config is None:
+        return None
+    text_config_getter = getattr(config, "get_text_config", None)
+    if callable(text_config_getter):
+        text_config = text_config_getter()
+        value = getattr(text_config, name, None)
+        if value is not None:
+            return value
+    return getattr(config, name, None)
+
+
+def accepts_forward_kwarg(model, name):
+    try:
+        parameters = inspect.signature(model.forward).parameters
+    except (TypeError, ValueError):
+        return True
+    return name in parameters or any(
+        parameter.kind == inspect.Parameter.VAR_KEYWORD
+        for parameter in parameters.values()
+    )
+
+
+def write_manifest(path, args, output_path, device, input_ids, save_tensors, actual_attn_implementation, prefill_input_ids=None):
+    import torch
+    import transformers
+
+    config_digests, safetensors_digests = model_file_digests(args.model)
+    manifest = {
+        "schema_version": 1,
+        "generated_by": "x/models/scripts/dump_activations.py",
+        "model_path": args.model,
+        "model_class": args.model_class or "auto",
+        "dtype": args.dtype,
+        "device": device,
+        "prompt": args.prompt,
+        "prompt_sha256": hashlib.sha256(args.prompt.encode("utf-8")).hexdigest(),
+        "num_tokens": int(input_ids.shape[1]),
+        "input_ids": input_ids.cpu().int().tolist(),
+        "prefill_num_tokens": int(prefill_input_ids.shape[1]) if prefill_input_ids is not None else 0,
+        "prefill_input_ids": prefill_input_ids.cpu().int().tolist() if prefill_input_ids is not None else [],
+        "decode_text": args.decode_text or "",
+        "decode_token_ids": args.decode_token_id or [],
+        "filters": args.filters or [],
+        "skip_logits": bool(args.skip_logits),
+        "output_path": output_path,
+        "torch_version": torch.__version__,
+        "transformers_version": transformers.__version__,
+        "transformers_path": args.transformers_path or os.environ.get("TRANSFORMERS_PATH") or "",
+        "requested_attn_implementation": args.attn_implementation or "",
+        "attn_implementation": actual_attn_implementation or "",
+        "use_cache": bool(args.use_cache),
+        "config_file_sha256": config_digests,
+        "safetensors_headers": safetensors_digests,
+        "tensors": {
+            name: tensor_info(tensor)
+            for name, tensor in sorted(save_tensors.items())
+        },
+    }
+    manifest_dir = os.path.dirname(path)
+    if manifest_dir:
+        os.makedirs(manifest_dir, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(manifest, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+
+def load_model_auto(model_path, dtype, attn_implementation=None, trust_remote_code=False):
+    """Load model via the auto classes that ship with transformers."""
+    from transformers import AutoModelForCausalLM, AutoModelForConditionalGeneration
+
+    kwargs = {"torch_dtype": dtype, "trust_remote_code": trust_remote_code}
+    if attn_implementation:
+        kwargs["attn_implementation"] = attn_implementation
+    for cls in [AutoModelForCausalLM, AutoModelForConditionalGeneration]:
+        try:
+            return cls.from_pretrained(model_path, **kwargs)
+        except (ValueError, OSError):
+            continue
+    raise RuntimeError(
+        f"Could not load model from {model_path} with auto classes; "
+        f"pass --model-class CLASSNAME to specify the transformers class "
+        f"explicitly."
+    )
+
+
+def load_model_class(model_path, dtype, class_name, attn_implementation=None, trust_remote_code=False):
+    """Load model using a specific transformers class by name.
+
+    The class must already be importable from `transformers` (i.e. either
+    upstream-supported or installed via a custom transformers source on
+    sys.path -- see --transformers-path / TRANSFORMERS_PATH).
+    """
+    import transformers
+
+    cls = getattr(transformers, class_name, None)
+    if cls is None:
+        if trust_remote_code:
+            from transformers.dynamic_module_utils import get_class_from_dynamic_module
+
+            config_path = os.path.join(model_path, "config.json")
+            with open(config_path, "r", encoding="utf-8") as f:
+                config = json.load(f)
+            auto_map = config.get("auto_map", {})
+            class_reference = auto_map.get("AutoModelForCausalLM") or auto_map.get("AutoModelForConditionalGeneration")
+            if class_reference and class_reference.endswith("." + class_name):
+                cls = get_class_from_dynamic_module(
+                    class_reference,
+                    model_path,
+                    local_files_only=True,
+                )
+        if cls is None:
+            raise RuntimeError(
+                f"transformers has no class named {class_name!r}. "
+                f"If this is a model that requires custom code, pass "
+                f"--trust-remote-code or set --transformers-path to a "
+                f"transformers source tree that exports the class."
+            )
+    kwargs = {"torch_dtype": dtype, "trust_remote_code": trust_remote_code}
+    if attn_implementation:
+        kwargs["attn_implementation"] = attn_implementation
+    return cls.from_pretrained(model_path, **kwargs)
+
+
+def attach_hooks(model, filters=None):
+    """Register forward hooks on all named modules.
+
+    Returns (captures dict, list of hook handles for cleanup).
+    Captures dict maps module name -> output tensor (float32, CPU).
+    """
+    import torch
+
+    captures = {}
+    handles = []
+
+    for name, module in model.named_modules():
+        if name == "":
+            continue  # skip root module
+
+        # Apply filters if specified
+        if filters:
+            if not any(fnmatch.fnmatch(name, f) for f in filters):
+                continue
+
+        def make_hook(hook_name):
+            def hook(mod, inp, output):
+                if isinstance(output, torch.Tensor):
+                    captures[hook_name] = output.detach().float().cpu()
+                elif isinstance(output, tuple) and len(output) > 0:
+                    # Decoder layers return (hidden_states, ...) tuples
+                    if isinstance(output[0], torch.Tensor):
+                        captures[hook_name] = output[0].detach().float().cpu()
+            return hook
+
+        handles.append(module.register_forward_hook(make_hook(name)))
+
+    return captures, handles
+
+
+def find_text_model(model):
+    """Navigate to the text-model submodule for multimodal architectures."""
+    # Multimodal wrappers commonly nest the text decoder under
+    # model.model.language_model. Plain CausalLMs expose model.model.
+    if hasattr(model, "model") and hasattr(model.model, "language_model"):
+        return model.model.language_model
+    if hasattr(model, "model"):
+        return model.model
+    return model
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Dump model activations as safetensors")
+    parser.add_argument("--model", required=True, help="Path to a model directory loadable by transformers (config.json + weights)")
+    parser.add_argument("--prompt", default=DEFAULT_PROMPT, help="Input prompt")
+    parser.add_argument("--decode-text", default=None,
+                        help="Run --prompt as a cached prefill, then capture activations for this text "
+                             "as the decode pass. Tokenized without special tokens.")
+    parser.add_argument("--decode-token-id", action="append", type=int, default=[],
+                        help="Token id to decode after cached prefill; can repeat. Mutually exclusive with --decode-text.")
+    parser.add_argument("--output", default=None, help="Output safetensors path (default: /tmp/ollama_ref/<model>/activations.safetensors)")
+    parser.add_argument("--manifest-output", default=None,
+                        help="Output JSON sidecar manifest path "
+                             "(default: <output>.manifest.json)")
+    parser.add_argument("--model-class", default=None,
+                        help="transformers class name to use for loading "
+                             "(e.g. Qwen3MoeForCausalLM). Default: auto-detect "
+                             "via AutoModelForCausalLM / AutoModelForConditionalGeneration.")
+    parser.add_argument("--filter", action="append", dest="filters", help="fnmatch patterns for module names to capture (can repeat)")
+    parser.add_argument("--transformers-path", default=None, help="Custom transformers source path")
+    parser.add_argument("--trust-remote-code", action="store_true",
+                        help="Allow local/Hub custom model code referenced by auto_map")
+    parser.add_argument("--skip-logits", action="store_true", help="Skip saving full logits tensor")
+    parser.add_argument("--dtype", default="bfloat16", choices=["float32", "bfloat16", "float16"], help="Model dtype")
+    parser.add_argument("--attn-implementation", default=None,
+                        help="Optional transformers attention backend to pass to from_pretrained "
+                             "(for example: eager, sdpa, flash_attention_2). Pin this for "
+                             "deterministic references when backends are numerically different.")
+    parser.add_argument("--use-cache", action="store_true",
+                        help="Run the reference forward pass with use_cache=True. "
+                             "By default references use use_cache=False so layer dumps "
+                             "compare the plain prefill graph.")
+    parser.add_argument("--list-modules", action="store_true", help="List all module names and exit")
+    args = parser.parse_args()
+    if args.decode_text is not None and args.decode_token_id:
+        parser.error("--decode-text and --decode-token-id are mutually exclusive")
+
+    # Custom transformers path
+    transformers_path = args.transformers_path or os.environ.get("TRANSFORMERS_PATH")
+    if transformers_path:
+        sys.path.insert(0, transformers_path)
+        print(f"Using custom transformers: {transformers_path}", flush=True)
+
+    import torch
+    import logging
+    logging.disable(logging.WARNING)
+
+    dtype_map = {
+        "float32": torch.float32,
+        "bfloat16": torch.bfloat16,
+        "float16": torch.float16,
+    }
+    dtype = dtype_map[args.dtype]
+
+    # Output path
+    model_basename = os.path.basename(os.path.normpath(args.model))
+    if args.output:
+        output_path = args.output
+    else:
+        output_path = os.path.join("/tmp", "ollama_ref", model_basename, "activations.safetensors")
+    manifest_output_path = args.manifest_output or output_path + ".manifest.json"
+
+    print(f"Model: {args.model}", flush=True)
+    print(f"Loader: {args.model_class or 'auto'}", flush=True)
+    if args.attn_implementation:
+        print(f"Attention: {args.attn_implementation}", flush=True)
+    print(f"Output: {output_path}", flush=True)
+    print(f"Manifest: {manifest_output_path}", flush=True)
+
+    # Load model
+    print("Loading model...", flush=True)
+    if args.model_class:
+        model = load_model_class(args.model, dtype, args.model_class, args.attn_implementation, args.trust_remote_code)
+    else:
+        model = load_model_auto(args.model, dtype, args.attn_implementation, args.trust_remote_code)
+    actual_attn_implementation = config_value(model, "_attn_implementation")
+    device = "mps" if torch.backends.mps.is_available() else "cpu"
+    model = model.to(device)
+    model.eval()
+    print(f"Device: {device}", flush=True)
+    if actual_attn_implementation:
+        print(f"Resolved attention: {actual_attn_implementation}", flush=True)
+
+    if args.list_modules:
+        print("\nAll modules:")
+        for name, mod in model.named_modules():
+            if name:
+                print(f"  {name} ({type(mod).__name__})")
+        return
+
+    # Tokenize
+    from transformers import AutoTokenizer
+    tokenizer = AutoTokenizer.from_pretrained(args.model, trust_remote_code=args.trust_remote_code)
+    input_ids = tokenizer(args.prompt, return_tensors="pt", add_special_tokens=True)["input_ids"]
+
+    # Prepend BOS if not already present
+    bos_id = getattr(tokenizer, "bos_token_id", None)
+    if bos_id is not None and input_ids[0, 0].item() != bos_id:
+        input_ids = torch.cat([torch.tensor([[bos_id]]), input_ids], dim=1)
+
+    input_ids = input_ids.to(device)
+    prefill_input_ids = None
+    if args.decode_text is not None or args.decode_token_id:
+        prefill_input_ids = input_ids
+        if args.decode_token_id:
+            input_ids = torch.tensor([args.decode_token_id], dtype=torch.long, device=device)
+        else:
+            input_ids = tokenizer(args.decode_text, return_tensors="pt", add_special_tokens=False)["input_ids"].to(device)
+        if input_ids.shape[1] == 0:
+            raise RuntimeError("decode input tokenized to an empty sequence")
+        print(f"Prefill prompt: {prefill_input_ids.shape[1]} tokens", flush=True)
+        print(f"Decode input: {input_ids.shape[1]} tokens", flush=True)
+    else:
+        print(f"Prompt: {input_ids.shape[1]} tokens", flush=True)
+
+    captures = {}
+    handles = []
+    past_key_values = None
+    if prefill_input_ids is not None:
+        print("Running cached prefill pass...", flush=True)
+        with torch.no_grad():
+            prefill_outputs = model(input_ids=prefill_input_ids, use_cache=True)
+        past_key_values = getattr(prefill_outputs, "past_key_values", None)
+        if past_key_values is None:
+            raise RuntimeError(f"{type(model).__name__} did not return past_key_values for cached prefill")
+
+    # Attach hooks (on the full model to capture all paths)
+    captures, handles = attach_hooks(model, args.filters)
+
+    # Run forward pass
+    print("Running forward pass...", flush=True)
+    forward_kwargs = {"input_ids": input_ids}
+    if past_key_values is not None:
+        forward_kwargs["past_key_values"] = past_key_values
+        forward_kwargs["use_cache"] = True
+    elif accepts_forward_kwarg(model, "use_cache"):
+        forward_kwargs["use_cache"] = args.use_cache
+    elif args.use_cache:
+        raise RuntimeError(f"{type(model).__name__}.forward does not accept use_cache")
+    with torch.no_grad():
+        outputs = model(**forward_kwargs)
+
+    # Remove hooks
+    for h in handles:
+        h.remove()
+
+    # Build output tensors
+    save_tensors = {
+        "input_ids": input_ids.cpu().int(),
+    }
+    if prefill_input_ids is not None:
+        save_tensors["prefill_input_ids"] = prefill_input_ids.cpu().int()
+
+    # Add logits
+    if not args.skip_logits:
+        logits = outputs.logits if hasattr(outputs, "logits") else outputs[0]
+        save_tensors["logits"] = logits.detach().float().cpu()
+
+    # Add all captured activations
+    for name, tensor in sorted(captures.items()):
+        save_tensors[name] = tensor
+
+    # Save
+    from safetensors.torch import save_file
+
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+
+    # safetensors requires contiguous tensors
+    for k in save_tensors:
+        save_tensors[k] = save_tensors[k].contiguous()
+
+    metadata = {
+        "prompt": args.prompt[:200],
+        "model_path": args.model,
+        "num_tokens": str(input_ids.shape[1]),
+        "dtype": args.dtype,
+        "model_class": args.model_class or "auto",
+    }
+
+    save_file(save_tensors, output_path, metadata=metadata)
+    write_manifest(
+        manifest_output_path,
+        args,
+        output_path,
+        device,
+        input_ids,
+        save_tensors,
+        actual_attn_implementation,
+        prefill_input_ids,
+    )
+
+    # Report
+    print(f"\nSaved {len(save_tensors)} tensors to {output_path}", flush=True)
+    print(f"Saved manifest to {manifest_output_path}", flush=True)
+    total_bytes = 0
+    for name in sorted(save_tensors.keys()):
+        t = save_tensors[name]
+        size = t.nelement() * t.element_size()
+        total_bytes += size
+        shape_str = "x".join(str(d) for d in t.shape)
+        print(f"  {name:50s} {str(t.dtype):12s} [{shape_str}]", flush=True)
+    print(f"\nTotal: {total_bytes / 1024 / 1024:.1f} MB", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/x/models/scripts/dump_activations.py
+++ b/x/models/scripts/dump_activations.py
@@ -1,0 +1,487 @@
+#!/usr/bin/env python3
+"""Dump intermediate activations from a PyTorch reference model using forward
+hooks.
+
+Loads any model that the `transformers` library can construct, runs a single
+forward pass on a prompt, and saves every submodule's output tensor to a
+safetensors file. The Go-side `forward_test.go` files load this reference
+via `testutil.LoadReference` and compare it against the MLX implementation's
+outputs to find the first layer/position where the two diverge.
+
+The script does not assume anything about *where* the weights came from —
+they just need to live in a directory that `transformers` can load.
+
+Usage:
+    # Auto-detect model class (works for any model registered with
+    # AutoModelForCausalLM / AutoModelForConditionalGeneration):
+    python x/models/scripts/dump_activations.py --model models/<org>/<name>
+
+    # Filter to a subset of modules:
+    python x/models/scripts/dump_activations.py --model models/<org>/<name> \\
+        --filter "model.layers.*"
+
+    # Force a specific transformers class (when auto-detection picks the
+    # wrong one, or when the class isn't registered with AutoModel):
+    python x/models/scripts/dump_activations.py --model models/<org>/<name> \\
+        --model-class Qwen3MoeForCausalLM
+
+Output: /tmp/ollama_ref/<model_basename>/activations.safetensors
+"""
+
+import argparse
+import fnmatch
+import hashlib
+import inspect
+import json
+import os
+import struct
+import sys
+import warnings
+
+os.environ["TRANSFORMERS_NO_TQDM"] = "1"
+os.environ["TRANSFORMERS_VERBOSITY"] = "error"
+warnings.filterwarnings("ignore")
+
+
+DEFAULT_PROMPT = (
+    "The quick brown fox jumps over the lazy dog. A bright sunny day in the meadow. "
+    "Robert Boulter is an English film, television and theatre actor. He had a guest "
+    "starring role on the television series The Bill in 2000."
+)
+
+
+def file_sha256(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def safetensors_header_sha256(path):
+    with open(path, "rb") as f:
+        raw_size = f.read(8)
+        if len(raw_size) != 8:
+            raise ValueError(f"{path}: missing safetensors header size")
+        (header_size,) = struct.unpack("<Q", raw_size)
+        header = f.read(header_size)
+        if len(header) != header_size:
+            raise ValueError(f"{path}: truncated safetensors header")
+    parsed = json.loads(header.decode("utf-8"))
+    parsed.pop("__metadata__", None)
+    stable = json.dumps(parsed, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(stable.encode("utf-8")).hexdigest(), len(parsed)
+
+
+def model_file_digests(model_path):
+    digests = {}
+    for name in [
+        "config.json",
+        "tokenizer.json",
+        "generation_config.json",
+        "tokenizer_config.json",
+        "special_tokens_map.json",
+    ]:
+        path = os.path.join(model_path, name)
+        if os.path.exists(path):
+            digests[name] = file_sha256(path)
+
+    safetensors = []
+    for name in sorted(os.listdir(model_path)):
+        if not name.endswith(".safetensors"):
+            continue
+        path = os.path.join(model_path, name)
+        header_digest, tensor_count = safetensors_header_sha256(path)
+        safetensors.append({
+            "file": name,
+            "size_bytes": os.path.getsize(path),
+            "header_sha256": header_digest,
+            "tensor_count": tensor_count,
+        })
+    return digests, safetensors
+
+
+def tensor_info(tensor):
+    return {
+        "dtype": str(tensor.dtype),
+        "shape": [int(d) for d in tensor.shape],
+        "numel": int(tensor.nelement()),
+    }
+
+
+def config_value(model, name):
+    config = getattr(model, "config", None)
+    if config is None:
+        return None
+    text_config_getter = getattr(config, "get_text_config", None)
+    if callable(text_config_getter):
+        text_config = text_config_getter()
+        value = getattr(text_config, name, None)
+        if value is not None:
+            return value
+    return getattr(config, name, None)
+
+
+def accepts_forward_kwarg(model, name):
+    try:
+        parameters = inspect.signature(model.forward).parameters
+    except (TypeError, ValueError):
+        return True
+    return name in parameters or any(
+        parameter.kind == inspect.Parameter.VAR_KEYWORD
+        for parameter in parameters.values()
+    )
+
+
+def write_manifest(path, args, output_path, device, input_ids, save_tensors, actual_attn_implementation, prefill_input_ids=None):
+    import torch
+    import transformers
+
+    config_digests, safetensors_digests = model_file_digests(args.model)
+    manifest = {
+        "schema_version": 1,
+        "generated_by": "x/models/scripts/dump_activations.py",
+        "model_path": args.model,
+        "model_class": args.model_class or "auto",
+        "dtype": args.dtype,
+        "device": device,
+        "prompt": args.prompt,
+        "prompt_sha256": hashlib.sha256(args.prompt.encode("utf-8")).hexdigest(),
+        "num_tokens": int(input_ids.shape[1]),
+        "input_ids": input_ids.cpu().int().tolist(),
+        "prefill_num_tokens": int(prefill_input_ids.shape[1]) if prefill_input_ids is not None else 0,
+        "prefill_input_ids": prefill_input_ids.cpu().int().tolist() if prefill_input_ids is not None else [],
+        "decode_text": args.decode_text or "",
+        "decode_token_ids": args.decode_token_id or [],
+        "filters": args.filters or [],
+        "skip_logits": bool(args.skip_logits),
+        "output_path": output_path,
+        "torch_version": torch.__version__,
+        "transformers_version": transformers.__version__,
+        "transformers_path": args.transformers_path or "",
+        "requested_attn_implementation": args.attn_implementation or "",
+        "attn_implementation": actual_attn_implementation or "",
+        "use_cache": bool(args.use_cache),
+        "config_file_sha256": config_digests,
+        "safetensors_headers": safetensors_digests,
+        "tensors": {
+            name: tensor_info(tensor)
+            for name, tensor in sorted(save_tensors.items())
+        },
+    }
+    manifest_dir = os.path.dirname(path)
+    if manifest_dir:
+        os.makedirs(manifest_dir, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(manifest, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+
+def load_model_auto(model_path, dtype, attn_implementation=None, trust_remote_code=False):
+    """Load model via the auto classes that ship with transformers."""
+    from transformers import AutoModelForCausalLM, AutoModelForConditionalGeneration
+
+    kwargs = {"torch_dtype": dtype, "trust_remote_code": trust_remote_code}
+    if attn_implementation:
+        kwargs["attn_implementation"] = attn_implementation
+    for cls in [AutoModelForCausalLM, AutoModelForConditionalGeneration]:
+        try:
+            return cls.from_pretrained(model_path, **kwargs)
+        except (ValueError, OSError):
+            continue
+    raise RuntimeError(
+        f"Could not load model from {model_path} with auto classes; "
+        f"pass --model-class CLASSNAME to specify the transformers class "
+        f"explicitly."
+    )
+
+
+def load_model_class(model_path, dtype, class_name, attn_implementation=None, trust_remote_code=False):
+    """Load model using a specific transformers class by name.
+
+    The class must already be importable from `transformers` (i.e. either
+    upstream-supported or installed via a custom transformers source on
+    sys.path -- see --transformers-path).
+    """
+    import transformers
+
+    cls = getattr(transformers, class_name, None)
+    if cls is None:
+        if trust_remote_code:
+            from transformers.dynamic_module_utils import get_class_from_dynamic_module
+
+            config_path = os.path.join(model_path, "config.json")
+            with open(config_path, "r", encoding="utf-8") as f:
+                config = json.load(f)
+            auto_map = config.get("auto_map", {})
+            class_reference = auto_map.get("AutoModelForCausalLM") or auto_map.get("AutoModelForConditionalGeneration")
+            if class_reference and class_reference.endswith("." + class_name):
+                cls = get_class_from_dynamic_module(
+                    class_reference,
+                    model_path,
+                    local_files_only=True,
+                )
+        if cls is None:
+            raise RuntimeError(
+                f"transformers has no class named {class_name!r}. "
+                f"If this is a model that requires custom code, pass "
+                f"--trust-remote-code or set --transformers-path to a "
+                f"transformers source tree that exports the class."
+            )
+    kwargs = {"torch_dtype": dtype, "trust_remote_code": trust_remote_code}
+    if attn_implementation:
+        kwargs["attn_implementation"] = attn_implementation
+    return cls.from_pretrained(model_path, **kwargs)
+
+
+def attach_hooks(model, filters=None):
+    """Register forward hooks on all named modules.
+
+    Returns (captures dict, list of hook handles for cleanup).
+    Captures dict maps module name -> output tensor (float32, CPU).
+    """
+    import torch
+
+    captures = {}
+    handles = []
+
+    for name, module in model.named_modules():
+        if name == "":
+            continue  # skip root module
+
+        # Apply filters if specified
+        if filters:
+            if not any(fnmatch.fnmatch(name, f) for f in filters):
+                continue
+
+        def make_hook(hook_name):
+            def hook(mod, inp, output):
+                if isinstance(output, torch.Tensor):
+                    captures[hook_name] = output.detach().float().cpu()
+                elif isinstance(output, tuple) and len(output) > 0:
+                    # Decoder layers return (hidden_states, ...) tuples
+                    if isinstance(output[0], torch.Tensor):
+                        captures[hook_name] = output[0].detach().float().cpu()
+            return hook
+
+        handles.append(module.register_forward_hook(make_hook(name)))
+
+    return captures, handles
+
+
+def find_text_model(model):
+    """Navigate to the text-model submodule for multimodal architectures."""
+    # Multimodal wrappers commonly nest the text decoder under
+    # model.model.language_model. Plain CausalLMs expose model.model.
+    if hasattr(model, "model") and hasattr(model.model, "language_model"):
+        return model.model.language_model
+    if hasattr(model, "model"):
+        return model.model
+    return model
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Dump model activations as safetensors")
+    parser.add_argument("--model", required=True, help="Path to a model directory loadable by transformers (config.json + weights)")
+    parser.add_argument("--prompt", default=DEFAULT_PROMPT, help="Input prompt")
+    parser.add_argument("--decode-text", default=None,
+                        help="Run --prompt as a cached prefill, then capture activations for this text "
+                             "as the decode pass. Tokenized without special tokens.")
+    parser.add_argument("--decode-token-id", action="append", type=int, default=[],
+                        help="Token id to decode after cached prefill; can repeat. Mutually exclusive with --decode-text.")
+    parser.add_argument("--output", default=None, help="Output safetensors path (default: /tmp/ollama_ref/<model>/activations.safetensors)")
+    parser.add_argument("--manifest-output", default=None,
+                        help="Output JSON sidecar manifest path "
+                             "(default: <output>.manifest.json)")
+    parser.add_argument("--model-class", default=None,
+                        help="transformers class name to use for loading "
+                             "(e.g. Qwen3MoeForCausalLM). Default: auto-detect "
+                             "via AutoModelForCausalLM / AutoModelForConditionalGeneration.")
+    parser.add_argument("--filter", action="append", dest="filters", help="fnmatch patterns for module names to capture (can repeat)")
+    parser.add_argument("--transformers-path", default=None, help="Custom transformers source path")
+    parser.add_argument("--trust-remote-code", action="store_true",
+                        help="Allow local/Hub custom model code referenced by auto_map")
+    parser.add_argument("--skip-logits", action="store_true", help="Skip saving full logits tensor")
+    parser.add_argument("--dtype", default="bfloat16", choices=["float32", "bfloat16", "float16"], help="Model dtype")
+    parser.add_argument("--attn-implementation", default=None,
+                        help="Optional transformers attention backend to pass to from_pretrained "
+                             "(for example: eager, sdpa, flash_attention_2). Pin this for "
+                             "deterministic references when backends are numerically different.")
+    parser.add_argument("--use-cache", action="store_true",
+                        help="Run the reference forward pass with use_cache=True. "
+                             "By default references use use_cache=False so layer dumps "
+                             "compare the plain prefill graph.")
+    parser.add_argument("--list-modules", action="store_true", help="List all module names and exit")
+    args = parser.parse_args()
+    if args.decode_text is not None and args.decode_token_id:
+        parser.error("--decode-text and --decode-token-id are mutually exclusive")
+
+    # Custom transformers path
+    transformers_path = args.transformers_path
+    if transformers_path:
+        sys.path.insert(0, transformers_path)
+        print(f"Using custom transformers: {transformers_path}", flush=True)
+
+    import torch
+    import logging
+    logging.disable(logging.WARNING)
+
+    dtype_map = {
+        "float32": torch.float32,
+        "bfloat16": torch.bfloat16,
+        "float16": torch.float16,
+    }
+    dtype = dtype_map[args.dtype]
+
+    # Output path
+    model_basename = os.path.basename(os.path.normpath(args.model))
+    if args.output:
+        output_path = args.output
+    else:
+        output_path = os.path.join("/tmp", "ollama_ref", model_basename, "activations.safetensors")
+    manifest_output_path = args.manifest_output or output_path + ".manifest.json"
+
+    print(f"Model: {args.model}", flush=True)
+    print(f"Loader: {args.model_class or 'auto'}", flush=True)
+    if args.attn_implementation:
+        print(f"Attention: {args.attn_implementation}", flush=True)
+    print(f"Output: {output_path}", flush=True)
+    print(f"Manifest: {manifest_output_path}", flush=True)
+
+    # Load model
+    print("Loading model...", flush=True)
+    if args.model_class:
+        model = load_model_class(args.model, dtype, args.model_class, args.attn_implementation, args.trust_remote_code)
+    else:
+        model = load_model_auto(args.model, dtype, args.attn_implementation, args.trust_remote_code)
+    actual_attn_implementation = config_value(model, "_attn_implementation")
+    device = "mps" if torch.backends.mps.is_available() else "cpu"
+    model = model.to(device)
+    model.eval()
+    print(f"Device: {device}", flush=True)
+    if actual_attn_implementation:
+        print(f"Resolved attention: {actual_attn_implementation}", flush=True)
+
+    if args.list_modules:
+        print("\nAll modules:")
+        for name, mod in model.named_modules():
+            if name:
+                print(f"  {name} ({type(mod).__name__})")
+        return
+
+    # Tokenize
+    from transformers import AutoTokenizer
+    tokenizer = AutoTokenizer.from_pretrained(args.model, trust_remote_code=args.trust_remote_code)
+    input_ids = tokenizer(args.prompt, return_tensors="pt", add_special_tokens=True)["input_ids"]
+
+    # Prepend BOS if not already present
+    bos_id = getattr(tokenizer, "bos_token_id", None)
+    if bos_id is not None and input_ids[0, 0].item() != bos_id:
+        input_ids = torch.cat([torch.tensor([[bos_id]]), input_ids], dim=1)
+
+    input_ids = input_ids.to(device)
+    prefill_input_ids = None
+    if args.decode_text is not None or args.decode_token_id:
+        prefill_input_ids = input_ids
+        if args.decode_token_id:
+            input_ids = torch.tensor([args.decode_token_id], dtype=torch.long, device=device)
+        else:
+            input_ids = tokenizer(args.decode_text, return_tensors="pt", add_special_tokens=False)["input_ids"].to(device)
+        if input_ids.shape[1] == 0:
+            raise RuntimeError("decode input tokenized to an empty sequence")
+        print(f"Prefill prompt: {prefill_input_ids.shape[1]} tokens", flush=True)
+        print(f"Decode input: {input_ids.shape[1]} tokens", flush=True)
+    else:
+        print(f"Prompt: {input_ids.shape[1]} tokens", flush=True)
+
+    captures = {}
+    handles = []
+    past_key_values = None
+    if prefill_input_ids is not None:
+        print("Running cached prefill pass...", flush=True)
+        with torch.no_grad():
+            prefill_outputs = model(input_ids=prefill_input_ids, use_cache=True)
+        past_key_values = getattr(prefill_outputs, "past_key_values", None)
+        if past_key_values is None:
+            raise RuntimeError(f"{type(model).__name__} did not return past_key_values for cached prefill")
+
+    # Attach hooks (on the full model to capture all paths)
+    captures, handles = attach_hooks(model, args.filters)
+
+    # Run forward pass
+    print("Running forward pass...", flush=True)
+    forward_kwargs = {"input_ids": input_ids}
+    if past_key_values is not None:
+        forward_kwargs["past_key_values"] = past_key_values
+        forward_kwargs["use_cache"] = True
+    elif accepts_forward_kwarg(model, "use_cache"):
+        forward_kwargs["use_cache"] = args.use_cache
+    elif args.use_cache:
+        raise RuntimeError(f"{type(model).__name__}.forward does not accept use_cache")
+    with torch.no_grad():
+        outputs = model(**forward_kwargs)
+
+    # Remove hooks
+    for h in handles:
+        h.remove()
+
+    # Build output tensors
+    save_tensors = {
+        "input_ids": input_ids.cpu().int(),
+    }
+    if prefill_input_ids is not None:
+        save_tensors["prefill_input_ids"] = prefill_input_ids.cpu().int()
+
+    # Add logits
+    if not args.skip_logits:
+        logits = outputs.logits if hasattr(outputs, "logits") else outputs[0]
+        save_tensors["logits"] = logits.detach().float().cpu()
+
+    # Add all captured activations
+    for name, tensor in sorted(captures.items()):
+        save_tensors[name] = tensor
+
+    # Save
+    from safetensors.torch import save_file
+
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+
+    # safetensors requires contiguous tensors
+    for k in save_tensors:
+        save_tensors[k] = save_tensors[k].contiguous()
+
+    metadata = {
+        "prompt": args.prompt[:200],
+        "model_path": args.model,
+        "num_tokens": str(input_ids.shape[1]),
+        "dtype": args.dtype,
+        "model_class": args.model_class or "auto",
+    }
+
+    save_file(save_tensors, output_path, metadata=metadata)
+    write_manifest(
+        manifest_output_path,
+        args,
+        output_path,
+        device,
+        input_ids,
+        save_tensors,
+        actual_attn_implementation,
+        prefill_input_ids,
+    )
+
+    # Report
+    print(f"\nSaved {len(save_tensors)} tensors to {output_path}", flush=True)
+    print(f"Saved manifest to {manifest_output_path}", flush=True)
+    total_bytes = 0
+    for name in sorted(save_tensors.keys()):
+        t = save_tensors[name]
+        size = t.nelement() * t.element_size()
+        total_bytes += size
+        shape_str = "x".join(str(d) for d in t.shape)
+        print(f"  {name:50s} {str(t.dtype):12s} [{shape_str}]", flush=True)
+    print(f"\nTotal: {total_bytes / 1024 / 1024:.1f} MB", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/x/models/scripts/inspect_model.py
+++ b/x/models/scripts/inspect_model.py
@@ -1,0 +1,422 @@
+#!/usr/bin/env python3
+"""Inspect Hugging Face model directories before porting them to Ollama MLX.
+
+The script reads config/tokenizer files and safetensors headers without loading
+weights. It writes:
+
+  - porting_manifest.json: structured data for later tooling
+  - porting_manifest.md: human-readable summary for contributors/reviewers
+
+Local directories require only the Python standard library. Hub model IDs are
+supported when `huggingface_hub` is installed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import hashlib
+import json
+import os
+import pathlib
+import struct
+import sys
+from typing import Any
+
+
+HEADER_LIMIT = 100 * 1024 * 1024
+
+
+def load_json(path: pathlib.Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def stable_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def file_sha256(path: pathlib.Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def flatten_config(value: Any, prefix: str = "") -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    if isinstance(value, dict):
+        for key in sorted(value):
+            child = f"{prefix}.{key}" if prefix else key
+            out.update(flatten_config(value[key], child))
+    else:
+        out[prefix] = value
+    return out
+
+
+def read_safetensors_header(path: pathlib.Path) -> dict[str, Any]:
+    with path.open("rb") as f:
+        raw_size = f.read(8)
+        if len(raw_size) != 8:
+            raise ValueError(f"{path}: missing safetensors header size")
+        (header_size,) = struct.unpack("<Q", raw_size)
+        if header_size > HEADER_LIMIT:
+            raise ValueError(f"{path}: safetensors header too large: {header_size}")
+        header = f.read(header_size)
+        if len(header) != header_size:
+            raise ValueError(f"{path}: truncated safetensors header")
+    parsed = json.loads(header.decode("utf-8"))
+    parsed.pop("__metadata__", None)
+    return parsed
+
+
+def resolve_model(spec: str, revision: str | None) -> tuple[pathlib.Path, str, str]:
+    path = pathlib.Path(spec).expanduser()
+    if path.exists():
+        return path.resolve(), spec, "local"
+
+    try:
+        from huggingface_hub import snapshot_download
+    except ImportError as e:
+        raise SystemExit(
+            f"{spec!r} is not a local path and huggingface_hub is not installed"
+        ) from e
+
+    patterns = [
+        "config.json",
+        "generation_config.json",
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "special_tokens_map.json",
+        "preprocessor_config.json",
+        "processor_config.json",
+        "image_processor_config.json",
+        "*.safetensors",
+        "*.safetensors.index.json",
+    ]
+    downloaded = snapshot_download(
+        repo_id=spec,
+        revision=revision,
+        allow_patterns=patterns,
+    )
+    return pathlib.Path(downloaded), spec, "hub"
+
+
+def safetensors_summary(model_dir: pathlib.Path) -> dict[str, Any]:
+    dtype_counts: collections.Counter[str] = collections.Counter()
+    dtype_bytes: collections.Counter[str] = collections.Counter()
+    prefix_counts: collections.Counter[str] = collections.Counter()
+    header_digests: list[dict[str, Any]] = []
+    tensor_count = 0
+
+    for path in sorted(model_dir.glob("*.safetensors")):
+        header = read_safetensors_header(path)
+        header_digests.append(
+            {
+                "file": path.name,
+                "size_bytes": path.stat().st_size,
+                "header_sha256": hashlib.sha256(
+                    stable_json(header).encode("utf-8")
+                ).hexdigest(),
+                "tensor_count": len(header),
+            }
+        )
+        for name, info in sorted(header.items()):
+            if not isinstance(info, dict):
+                continue
+            tensor_count += 1
+            dtype = str(info.get("dtype", "unknown"))
+            dtype_counts[dtype] += 1
+            offsets = info.get("data_offsets")
+            if isinstance(offsets, list) and len(offsets) == 2:
+                dtype_bytes[dtype] += int(offsets[1]) - int(offsets[0])
+            parts = name.split(".")
+            for depth in (1, 2, 3):
+                if len(parts) >= depth:
+                    prefix_counts[".".join(parts[:depth])] += 1
+
+    return {
+        "tensor_count": tensor_count,
+        "dtype_histogram": dict(sorted(dtype_counts.items())),
+        "dtype_bytes": dict(sorted(dtype_bytes.items())),
+        "tensor_prefixes": [
+            {"prefix": prefix, "count": count}
+            for prefix, count in prefix_counts.most_common(12)
+        ],
+        "safetensors_headers": header_digests,
+    }
+
+
+def selected_config(raw: dict[str, Any]) -> dict[str, Any]:
+    text = raw.get("text_config")
+    if isinstance(text, dict):
+        return text
+    return raw
+
+
+def tokenizer_summary(model_dir: pathlib.Path, raw_config: dict[str, Any]) -> dict[str, Any]:
+    files = {
+        "tokenizer_json": (model_dir / "tokenizer.json").exists(),
+        "tokenizer_config_json": (model_dir / "tokenizer_config.json").exists(),
+        "generation_config_json": (model_dir / "generation_config.json").exists(),
+        "special_tokens_map_json": (model_dir / "special_tokens_map.json").exists(),
+        "processor_config_json": (model_dir / "processor_config.json").exists(),
+        "preprocessor_config_json": (model_dir / "preprocessor_config.json").exists(),
+        "image_processor_config_json": (model_dir / "image_processor_config.json").exists(),
+    }
+    chat_template = ""
+    tokenizer_config_path = model_dir / "tokenizer_config.json"
+    if tokenizer_config_path.exists():
+        try:
+            chat_template = str(load_json(tokenizer_config_path).get("chat_template") or "")
+        except Exception:
+            chat_template = ""
+    if not chat_template:
+        chat_template = str(raw_config.get("chat_template") or "")
+
+    return {
+        **files,
+        "has_chat_template": bool(chat_template),
+        "chat_template_mentions_thinking": "think" in chat_template.lower(),
+    }
+
+
+def compact_detail(value: Any, limit: int = 160) -> str:
+    text = stable_json(value) if not isinstance(value, str) else value
+    if len(text) > limit:
+        return text[: limit - 3] + "..."
+    return text
+
+
+def risk_flags(
+    raw_config: dict[str, Any],
+    active_config: dict[str, Any],
+    tok: dict[str, Any],
+) -> list[dict[str, str]]:
+    flat_raw = flatten_config(raw_config)
+    flat_active = flatten_config(active_config)
+    risks: list[dict[str, str]] = []
+
+    rope = {k: v for k, v in flat_active.items() if "rope" in k.lower()}
+    if rope:
+        risks.append({"name": "rope", "detail": compact_detail(rope)})
+
+    layer_types = active_config.get("layer_types")
+    sliding = {
+        k: v
+        for k, v in flat_active.items()
+        if "sliding" in k.lower() or "window" in k.lower()
+    }
+    if sliding or (
+        isinstance(layer_types, list)
+        and any("sliding" in str(x).lower() for x in layer_types)
+    ):
+        risks.append({"name": "sliding_window", "detail": compact_detail(sliding)})
+
+    if any(
+        key in active_config
+        for key in (
+            "num_experts",
+            "n_routed_experts",
+            "num_local_experts",
+            "moe_intermediate_size",
+        )
+    ):
+        detail = {
+            k: active_config.get(k)
+            for k in (
+                "num_experts",
+                "n_routed_experts",
+                "num_local_experts",
+                "num_experts_per_tok",
+                "moe_intermediate_size",
+            )
+            if k in active_config
+        }
+        risks.append({"name": "moe", "detail": compact_detail(detail)})
+
+    if isinstance(layer_types, list) and len({str(x) for x in layer_types}) > 1:
+        risks.append(
+            {
+                "name": "hybrid_layers",
+                "detail": compact_detail(collections.Counter(map(str, layer_types))),
+            }
+        )
+
+    if active_config.get("tie_word_embeddings") is True:
+        risks.append({"name": "tied_embeddings", "detail": "tie_word_embeddings=true"})
+
+    if active_config.get("attention_bias") is True:
+        risks.append({"name": "attention_bias", "detail": "attention_bias=true"})
+
+    multimodal_keys = [
+        k
+        for k in flat_raw
+        if any(part in k.lower() for part in ("vision", "audio", "image", "processor"))
+    ]
+    if multimodal_keys or tok.get("processor_config_json") or tok.get("image_processor_config_json"):
+        risks.append(
+            {
+                "name": "multimodal",
+                "detail": compact_detail(multimodal_keys[:10] or "processor files present"),
+            }
+        )
+
+    if tok.get("chat_template_mentions_thinking"):
+        risks.append({"name": "thinking_template", "detail": "chat template mentions think"})
+
+    if "auto_map" in raw_config:
+        risks.append({"name": "custom_transformers_code", "detail": compact_detail(raw_config["auto_map"])})
+
+    return risks
+
+
+def inspect_one(spec: str, revision: str | None) -> dict[str, Any]:
+    model_dir, source, source_type = resolve_model(spec, revision)
+    config_path = model_dir / "config.json"
+    if not config_path.exists():
+        raise SystemExit(f"{model_dir}: missing config.json")
+
+    raw = load_json(config_path)
+    active = selected_config(raw)
+    tok = tokenizer_summary(model_dir, raw)
+    tensors = safetensors_summary(model_dir)
+
+    arch = raw.get("architectures") or active.get("architectures") or []
+    if isinstance(arch, str):
+        arch = [arch]
+
+    return {
+        "label": model_dir.name,
+        "source": source,
+        "source_type": source_type,
+        "path": str(model_dir),
+        "config_sha256": file_sha256(config_path),
+        "architectures": arch,
+        "model_type": active.get("model_type") or raw.get("model_type"),
+        "has_text_config": isinstance(raw.get("text_config"), dict),
+        "tokenizer": tok,
+        "safetensors": tensors,
+        "risk_flags": risk_flags(raw, active, tok),
+        "flat_config": flatten_config(active),
+        "suggested_dump_activations": suggested_dump_command(model_dir, arch),
+    }
+
+
+def suggested_dump_command(model_dir: pathlib.Path, architectures: list[str]) -> str:
+    parts = [
+        ".venv/bin/python3",
+        "x/models/scripts/dump_activations.py",
+        "--model",
+        str(model_dir),
+    ]
+    if architectures:
+        parts += ["--model-class", architectures[0]]
+    parts += ["--skip-logits"]
+    return " ".join(parts)
+
+
+def config_diffs(models: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    if len(models) < 2:
+        return {}
+    keys = sorted({k for m in models for k in m["flat_config"]})
+    out: dict[str, dict[str, Any]] = {}
+    for key in keys:
+        values = {m["label"]: m["flat_config"].get(key) for m in models}
+        encoded = {stable_json(v) for v in values.values()}
+        if len(encoded) > 1:
+            out[key] = values
+    return out
+
+
+def write_markdown(manifest: dict[str, Any], path: pathlib.Path) -> None:
+    lines: list[str] = ["# MLX Porting Manifest", ""]
+    for model in manifest["models"]:
+        lines += [
+            f"## {model['label']}",
+            "",
+            f"- Source: `{model['source']}` ({model['source_type']})",
+            f"- Path: `{model['path']}`",
+            f"- Architecture(s): {', '.join(model['architectures']) or 'unknown'}",
+            f"- Model type: `{model.get('model_type') or 'unknown'}`",
+            f"- Nested text_config: {model['has_text_config']}",
+            f"- Tensor count: {model['safetensors']['tensor_count']}",
+            f"- Dtype histogram: `{stable_json(model['safetensors']['dtype_histogram'])}`",
+            "",
+            "### Risk Flags",
+            "",
+        ]
+        if model["risk_flags"]:
+            lines += [
+                f"- `{risk['name']}`: {risk['detail']}" for risk in model["risk_flags"]
+            ]
+        else:
+            lines.append("- none detected")
+
+        lines += ["", "### Tensor Prefixes", ""]
+        prefixes = model["safetensors"]["tensor_prefixes"]
+        if prefixes:
+            lines += [f"- `{p['prefix']}`: {p['count']}" for p in prefixes]
+        else:
+            lines.append("- none found")
+
+        lines += [
+            "",
+            "### Suggested Reference Command",
+            "",
+            "```bash",
+            model["suggested_dump_activations"],
+            "```",
+            "",
+        ]
+
+    diffs = manifest.get("config_diffs") or {}
+    lines += ["## Config Differences Across Variants", ""]
+    if diffs:
+        for key in sorted(diffs):
+            lines.append(f"- `{key}`: `{stable_json(diffs[key])}`")
+    else:
+        lines.append("- none; only one variant inspected or no differences found")
+    lines.append("")
+
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def run(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--model", action="append", required=True, help="Local HF model dir or Hub repo ID")
+    parser.add_argument("--output", required=True, help="Output directory")
+    parser.add_argument("--revision", default=None, help="Hub revision used for repo IDs")
+    args = parser.parse_args(argv)
+
+    out_dir = pathlib.Path(args.output).expanduser()
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    full_models = [inspect_one(spec, args.revision) for spec in args.model]
+    models = []
+    for model in full_models:
+        emitted = dict(model)
+        emitted.pop("flat_config", None)
+        models.append(emitted)
+    manifest = {
+        "schema_version": 1,
+        "generated_by": "x/models/scripts/inspect_model.py",
+        "models": models,
+        "config_diffs": config_diffs(full_models),
+    }
+
+    json_path = out_dir / "porting_manifest.json"
+    md_path = out_dir / "porting_manifest.md"
+    json_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_markdown(manifest, md_path)
+    print(f"Wrote {json_path}")
+    print(f"Wrote {md_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/x/models/scripts/make_manifest.py
+++ b/x/models/scripts/make_manifest.py
@@ -1,0 +1,49 @@
+"""Generate MANIFEST.json for a bring-up tree.
+
+Records sha256 + byte size for every file and classifies each as archived
+(ships in the PR archive) or regenerable (excluded for size; the manifest
+records how to rebuild it). Regenerable patterns and commands are read from
+an optional ARCHIVE_EXCLUDE.json in the tree root:
+
+    {"reference/bf16/activations.safetensors": "<regeneration command>"}
+
+Usage: python3 x/models/scripts/make_manifest.py x/models/bringup/<model>
+"""
+import hashlib
+import json
+import os
+import sys
+
+ROOT = sys.argv[1] if len(sys.argv) > 1 else "."
+
+regenerable = {}
+exclude_path = os.path.join(ROOT, "ARCHIVE_EXCLUDE.json")
+if os.path.exists(exclude_path):
+    regenerable = json.load(open(exclude_path))
+
+manifest = {"files": {}, "root": os.path.basename(os.path.abspath(ROOT))}
+for dirpath, dirnames, filenames in os.walk(ROOT):
+    for f in sorted(filenames):
+        if f == "MANIFEST.json":
+            continue
+        p = os.path.join(dirpath, f)
+        rel = os.path.relpath(p, ROOT)
+        h = hashlib.sha256()
+        with open(p, "rb") as fh:
+            for chunk in iter(lambda: fh.read(1 << 22), b""):
+                h.update(chunk)
+        entry = {"sha256": h.hexdigest(), "bytes": os.path.getsize(p)}
+        regen = next((cmd for pref, cmd in regenerable.items() if rel.startswith(pref)), None)
+        if regen:
+            entry["archived"] = False
+            entry["regenerate"] = regen
+        else:
+            entry["archived"] = True
+        manifest["files"][rel] = entry
+
+out = os.path.join(ROOT, "MANIFEST.json")
+with open(out, "w") as fh:
+    json.dump(manifest, fh, indent=1, sort_keys=True)
+archived = sum(1 for e in manifest["files"].values() if e["archived"])
+regen = len(manifest["files"]) - archived
+print(f"{out}: {len(manifest['files'])} files ({archived} archived, {regen} regenerable)")

--- a/x/models/scripts/new_port.sh
+++ b/x/models/scripts/new_port.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# Scaffold a bring-up tree for a new model port:
+#   x/models/scripts/new_port.sh <model-name>
+# Creates x/models/bringup/<model-name>/ with the standard layout and a
+# LEDGER.md template. Everything under the tree is git-ignored by design;
+# see x/models/bringup/artifacts.md.
+set -e
+if [ -z "$1" ]; then
+    echo "usage: $0 <model-name>" >&2
+    exit 2
+fi
+ROOT="x/models/bringup/$1"
+if [ -e "$ROOT/LEDGER.md" ]; then
+    echo "$ROOT already scaffolded" >&2
+    exit 1
+fi
+mkdir -p "$ROOT/reference" "$ROOT/parity" "$ROOT/perf" "$ROOT/scripts" "$ROOT/sessions"
+cat > "$ROOT/LEDGER.md" <<'TEMPLATE'
+# <model> — provenance and operation ledger
+
+## Authority order (publisher-designated)
+
+1. PRIMARY: <artifact, repo, revision, per-file content hashes>
+2. Derived: <converted checkpoints and the tooling that produced them>
+
+Reference implementation for activation capture: <package/wheel + class>.
+
+## Architecture summary
+
+<layers, attention layout, dims, vocab, special scales/softcaps, modalities>
+
+## Forward-operation/dtype ledger
+
+| Stage | Reference behavior | Ollama code |
+| --- | --- | --- |
+| Embedding | | |
+| Norms / QK handling | | |
+| RoPE | | |
+| Attention schedule | | |
+| LM head + output transforms | | |
+
+## Verification log
+
+- [ ] Source provenance pinned (hashes recorded above)
+- [ ] Activation reference dump (publisher implementation, eager)
+- [ ] Forward-pass tests (embed, per-layer, final hidden)
+- [ ] Output-head parity (raw + post-transform logits)
+- [ ] Reference equivalence gate (see bringup/equivalence-gate.md)
+- [ ] Renderer/parser parity (VERIFY_JINJA2 run, not skipped)
+- [ ] Perplexity baselines (harness + window)
+- [ ] Artifact ABI report (publisher source vs created tag; old public tag vs replacement)
+- [ ] Integration pass with capability skips reviewed
+TEMPLATE
+echo "scaffolded $ROOT"

--- a/x/models/scripts/summarize_validation.py
+++ b/x/models/scripts/summarize_validation.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Build a reviewer-ready MLX port validation report from recorded artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+from typing import Any
+
+
+def load_json(path: pathlib.Path) -> Any:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def parse_go_test_json(path: pathlib.Path) -> dict[str, Any]:
+    counts = {"pass": 0, "fail": 0, "skip": 0}
+    failures: list[str] = []
+    skips: list[str] = []
+    packages: set[str] = set()
+
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        pkg = event.get("Package")
+        if pkg:
+            packages.add(pkg)
+        test = event.get("Test")
+        action = event.get("Action")
+        if not test or action not in counts:
+            continue
+        counts[action] += 1
+        name = f"{pkg}/{test}" if pkg else test
+        if action == "fail":
+            failures.append(name)
+        elif action == "skip":
+            skips.append(name)
+
+    return {
+        "counts": counts,
+        "packages": sorted(packages),
+        "failures": failures,
+        "skips": skips,
+    }
+
+
+def summarize_models(manifest: dict[str, Any]) -> list[str]:
+    lines: list[str] = []
+    for model in manifest.get("models", []):
+        risks = model.get("risk_flags") or []
+        risk_names = ", ".join(r["name"] for r in risks) if risks else "none detected"
+        lines += [
+            f"- {model.get('label', 'unknown')}:",
+            f"  - source: `{model.get('source', 'unknown')}`",
+            f"  - architecture(s): {', '.join(model.get('architectures') or []) or 'unknown'}",
+            f"  - model type: `{model.get('model_type') or 'unknown'}`",
+            f"  - dtypes: `{json.dumps(model.get('safetensors', {}).get('dtype_histogram', {}), sort_keys=True)}`",
+            f"  - risks: {risk_names}",
+        ]
+    return lines or ["- no models recorded"]
+
+
+def summarize_activation_manifests(paths: list[pathlib.Path]) -> list[str]:
+    if not paths:
+        return ["- no activation manifests provided"]
+    lines: list[str] = []
+    for path in paths:
+        data = load_json(path)
+        output = data.get("output_path") or data.get("activation_path") or str(path)
+        tensors = data.get("tensors") or {}
+        tensor_count = len(tensors) if isinstance(tensors, dict) else data.get("tensor_count", "unknown")
+        lines += [
+            f"- `{output}`",
+            f"  - model: `{data.get('model_path', 'unknown')}`",
+            f"  - class: `{data.get('model_class', 'auto')}`",
+            f"  - dtype: `{data.get('dtype', 'unknown')}`",
+            f"  - attention: `{data.get('attn_implementation') or 'unknown'}`",
+            f"  - use_cache: `{data.get('use_cache', 'unknown')}`",
+            f"  - tokens: {data.get('num_tokens', 'unknown')}",
+            f"  - tensors: {tensor_count}",
+            f"  - prompt_sha256: `{data.get('prompt_sha256', 'unknown')}`",
+        ]
+        if data.get("prefill_num_tokens"):
+            lines += [
+                f"  - cached prefill tokens: {data.get('prefill_num_tokens')}",
+                f"  - decode text: `{data.get('decode_text') or ''}`",
+                f"  - decode token ids: `{data.get('decode_token_ids') or []}`",
+            ]
+    return lines
+
+
+def summarize_activation_comparisons(paths: list[pathlib.Path]) -> list[str]:
+    if not paths:
+        return ["- no activation comparison JSON provided"]
+    lines: list[str] = []
+    for path in paths:
+        data = load_json(path)
+        counts = data.get("counts") or {}
+        lines += [
+            f"- `{path}`",
+            f"  - got: `{data.get('got', 'unknown')}`",
+            f"  - want: `{data.get('want', 'unknown')}`",
+            f"  - filters: `{', '.join(data.get('filters') or []) or '*'}`",
+            f"  - axis: `{data.get('axis', 'unknown')}`",
+            f"  - counts: `{json.dumps(counts, sort_keys=True)}`",
+        ]
+        top = data.get("top_absolute") or []
+        if top:
+            worst = top[0]
+            lines.append(
+                "  - worst absolute: "
+                f"`{worst.get('name', 'unknown')}` "
+                f"max_diff={worst.get('max_diff', 'unknown')} "
+                f"first_tol={worst.get('first_tol', 'unknown')}"
+            )
+    return lines
+
+
+def summarize_ppl(path: pathlib.Path | None) -> list[str]:
+    if path is None:
+        return ["- no perplexity JSON provided"]
+    data = load_json(path)
+    lines = [
+        f"- model: `{data.get('model', 'unknown')}`",
+        f"- mode: `{data.get('mode', 'unknown')}`",
+        f"- max length: {data.get('max_length', 'unknown')}",
+        f"- tokens: {data.get('total_tokens', 'unknown')}",
+        f"- token PPL: {data.get('token_perplexity', 'unknown')}",
+    ]
+    delta = data.get("baseline_delta")
+    if isinstance(delta, dict):
+        lines.append(
+            "- baseline delta: "
+            f"abs={delta.get('token_perplexity_abs')}, "
+            f"rel={delta.get('token_perplexity_rel')}"
+        )
+    return lines
+
+
+def summarize_go_tests(paths: list[pathlib.Path]) -> list[str]:
+    if not paths:
+        return ["- no go test JSON provided"]
+    summaries = [parse_go_test_json(path) for path in paths]
+    counts = {"pass": 0, "fail": 0, "skip": 0}
+    packages: set[str] = set()
+    failures: list[str] = []
+    skips: list[str] = []
+    for summary in summaries:
+        for key in counts:
+            counts[key] += summary["counts"][key]
+        packages.update(summary["packages"])
+        failures.extend(summary["failures"])
+        skips.extend(summary["skips"])
+
+    lines = [
+        f"- files: {', '.join(str(path) for path in paths)}",
+        f"- packages: {', '.join(sorted(packages)) or 'unknown'}",
+        f"- passed: {counts['pass']}",
+        f"- failed: {counts['fail']}",
+        f"- skipped: {counts['skip']}",
+    ]
+    if failures:
+        lines.append("- failures: " + ", ".join(failures))
+    if skips:
+        lines.append("- skips: " + ", ".join(skips))
+    return lines
+
+
+def read_transcript(path: pathlib.Path | None) -> str:
+    if path is None:
+        return "No generation transcript provided."
+    text = path.read_text(encoding="utf-8").strip()
+    if len(text) > 4000:
+        return text[:3997] + "..."
+    return text or "Generation transcript was empty."
+
+
+def build_report(
+    manifest: dict[str, Any],
+    activation_manifest_paths: list[pathlib.Path],
+    activation_comparison_paths: list[pathlib.Path],
+    go_test_json: list[pathlib.Path],
+    ppl_json: pathlib.Path | None,
+    generation_transcript: pathlib.Path | None,
+) -> str:
+    lines: list[str] = [
+        "# MLX Port Validation Report",
+        "",
+        "## Summary",
+        "",
+        *summarize_models(manifest),
+        "",
+        "## Variant And Config Coverage",
+        "",
+    ]
+    diffs = manifest.get("config_diffs") or {}
+    if diffs:
+        lines += [f"- `{key}`: `{json.dumps(value, sort_keys=True)}`" for key, value in sorted(diffs.items())]
+    else:
+        lines.append("- no config differences recorded")
+
+    lines += [
+        "",
+        "## Reference Activations",
+        "",
+        *summarize_activation_manifests(activation_manifest_paths),
+        "",
+        "## Activation Comparisons",
+        "",
+        *summarize_activation_comparisons(activation_comparison_paths),
+        "",
+        "## Go Test Results",
+        "",
+        *summarize_go_tests(go_test_json),
+        "",
+        "## Perplexity",
+        "",
+        *summarize_ppl(ppl_json),
+        "",
+        "## Generation Samples",
+        "",
+        read_transcript(generation_transcript),
+        "",
+        "## Known Skips Or Limitations",
+        "",
+        "- Review the Go test skips and missing artifacts above before merging.",
+        "- Treat generation quality and PPL deltas as review evidence, not automatic approval.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def run(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--manifest", required=True, help="porting_manifest.json from inspect_model.py")
+    parser.add_argument("--activation-manifest", action="append", default=[], help="activation sidecar manifest; can repeat")
+    parser.add_argument("--activation-comparison-json", action="append", default=[], help="compare_activations.py JSON output; can repeat")
+    parser.add_argument("--go-test-json", action="append", default=[], help="go test -json output; can repeat")
+    parser.add_argument("--ppl-json", default=None, help="x/cmd/ppl -format json output")
+    parser.add_argument("--generation-transcript", default=None, help="optional generation transcript Markdown/text")
+    parser.add_argument("--output", required=True, help="output Markdown report")
+    args = parser.parse_args(argv)
+
+    manifest_path = pathlib.Path(args.manifest)
+    activation_paths = [pathlib.Path(p) for p in args.activation_manifest]
+    activation_comparison_paths = [pathlib.Path(p) for p in args.activation_comparison_json]
+    go_test_paths = [pathlib.Path(p) for p in args.go_test_json]
+    ppl_path = pathlib.Path(args.ppl_json) if args.ppl_json else None
+    generation_path = pathlib.Path(args.generation_transcript) if args.generation_transcript else None
+    output_path = pathlib.Path(args.output)
+
+    report = build_report(
+        load_json(manifest_path),
+        activation_paths,
+        activation_comparison_paths,
+        go_test_paths,
+        ppl_path,
+        generation_path,
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(report, encoding="utf-8")
+    print(f"Wrote {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/x/models/scripts/summarize_validation.py
+++ b/x/models/scripts/summarize_validation.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Build a reviewer-ready MLX port validation report from recorded artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+from typing import Any
+
+
+def load_json(path: pathlib.Path) -> Any:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def parse_go_test_json(path: pathlib.Path) -> dict[str, Any]:
+    counts = {"pass": 0, "fail": 0, "skip": 0}
+    failures: list[str] = []
+    skips: list[str] = []
+    packages: set[str] = set()
+
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        pkg = event.get("Package")
+        if pkg:
+            packages.add(pkg)
+        test = event.get("Test")
+        action = event.get("Action")
+        if not test or action not in counts:
+            continue
+        counts[action] += 1
+        name = f"{pkg}/{test}" if pkg else test
+        if action == "fail":
+            failures.append(name)
+        elif action == "skip":
+            skips.append(name)
+
+    return {
+        "counts": counts,
+        "packages": sorted(packages),
+        "failures": failures,
+        "skips": skips,
+    }
+
+
+def summarize_models(manifest: dict[str, Any]) -> list[str]:
+    lines: list[str] = []
+    for model in manifest.get("models", []):
+        risks = model.get("risk_flags") or []
+        risk_names = ", ".join(r["name"] for r in risks) if risks else "none detected"
+        lines += [
+            f"- {model.get('label', 'unknown')}:",
+            f"  - source: `{model.get('source', 'unknown')}`",
+            f"  - architecture(s): {', '.join(model.get('architectures') or []) or 'unknown'}",
+            f"  - model type: `{model.get('model_type') or 'unknown'}`",
+            f"  - dtypes: `{json.dumps(model.get('safetensors', {}).get('dtype_histogram', {}), sort_keys=True)}`",
+            f"  - risks: {risk_names}",
+        ]
+    return lines or ["- no models recorded"]
+
+
+def summarize_activation_manifests(paths: list[pathlib.Path]) -> list[str]:
+    if not paths:
+        return ["- no activation manifests provided"]
+    lines: list[str] = []
+    for path in paths:
+        data = load_json(path)
+        output = data.get("output_path") or data.get("activation_path") or str(path)
+        tensors = data.get("tensors") or {}
+        tensor_count = len(tensors) if isinstance(tensors, dict) else data.get("tensor_count", "unknown")
+        lines += [
+            f"- `{output}`",
+            f"  - model: `{data.get('model_path', 'unknown')}`",
+            f"  - class: `{data.get('model_class', 'auto')}`",
+            f"  - dtype: `{data.get('dtype', 'unknown')}`",
+            f"  - attention: `{data.get('attn_implementation') or 'unknown'}`",
+            f"  - use_cache: `{data.get('use_cache', 'unknown')}`",
+            f"  - tokens: {data.get('num_tokens', 'unknown')}",
+            f"  - tensors: {tensor_count}",
+            f"  - prompt_sha256: `{data.get('prompt_sha256', 'unknown')}`",
+        ]
+        if data.get("prefill_num_tokens"):
+            lines += [
+                f"  - cached prefill tokens: {data.get('prefill_num_tokens')}",
+                f"  - decode text: `{data.get('decode_text') or ''}`",
+                f"  - decode token ids: `{data.get('decode_token_ids') or []}`",
+            ]
+    return lines
+
+
+def summarize_activation_comparisons(paths: list[pathlib.Path]) -> list[str]:
+    if not paths:
+        return ["- no activation comparison JSON provided"]
+    lines: list[str] = []
+    for path in paths:
+        data = load_json(path)
+        counts = data.get("counts") or {}
+        lines += [
+            f"- `{path}`",
+            f"  - got: `{data.get('got', 'unknown')}`",
+            f"  - want: `{data.get('want', 'unknown')}`",
+            f"  - filters: `{', '.join(data.get('filters') or []) or '*'}`",
+            f"  - axis: `{data.get('axis', 'unknown')}`",
+            f"  - counts: `{json.dumps(counts, sort_keys=True)}`",
+        ]
+        top = data.get("top_absolute") or []
+        if top:
+            worst = top[0]
+            lines.append(
+                "  - worst absolute: "
+                f"`{worst.get('name', 'unknown')}` "
+                f"max_diff={worst.get('max_diff', 'unknown')} "
+                f"first_tol={worst.get('first_tol', 'unknown')}"
+            )
+    return lines
+
+
+def summarize_ppl(path: pathlib.Path | None) -> list[str]:
+    if path is None:
+        return ["- no perplexity JSON provided"]
+    data = load_json(path)
+    lines = [
+        f"- model: `{data.get('model', 'unknown')}`",
+        f"- mode: `{data.get('mode', 'unknown')}`",
+        f"- max length: {data.get('max_length', 'unknown')}",
+        f"- tokens: {data.get('total_tokens', 'unknown')}",
+        f"- token PPL: {data.get('token_perplexity', 'unknown')}",
+    ]
+    delta = data.get("baseline_delta")
+    if isinstance(delta, dict):
+        lines.append(
+            "- baseline delta: "
+            f"abs={delta.get('token_perplexity_abs')}, "
+            f"rel={delta.get('token_perplexity_rel')}"
+        )
+    return lines
+
+
+def summarize_go_tests(paths: list[pathlib.Path]) -> list[str]:
+    if not paths:
+        return ["- no go test JSON provided"]
+    summaries = [parse_go_test_json(path) for path in paths]
+    counts = {"pass": 0, "fail": 0, "skip": 0}
+    packages: set[str] = set()
+    failures: list[str] = []
+    skips: list[str] = []
+    for summary in summaries:
+        for key in counts:
+            counts[key] += summary["counts"][key]
+        packages.update(summary["packages"])
+        failures.extend(summary["failures"])
+        skips.extend(summary["skips"])
+
+    lines = [
+        f"- files: {', '.join(str(path) for path in paths)}",
+        f"- packages: {', '.join(sorted(packages)) or 'unknown'}",
+        f"- passed: {counts['pass']}",
+        f"- failed: {counts['fail']}",
+        f"- skipped: {counts['skip']}",
+    ]
+    if failures:
+        lines.append("- failures: " + ", ".join(failures))
+    if skips:
+        lines.append("- skips: " + ", ".join(skips))
+    return lines
+
+
+def read_transcript(path: pathlib.Path | None) -> str:
+    if path is None:
+        return "No generation transcript provided."
+    text = path.read_text(encoding="utf-8").strip()
+    if len(text) > 4000:
+        return text[:3997] + "..."
+    return text or "Generation transcript was empty."
+
+
+def read_artifact_abi(path: pathlib.Path | None) -> str:
+    if path is None:
+        return (
+            "No artifact ABI report provided. For publishable model tags, this "
+            "means tensor/config metadata compatibility is not verified."
+        )
+    text = path.read_text(encoding="utf-8").strip()
+    return text or "Artifact ABI report was empty."
+
+
+def build_report(
+    manifest: dict[str, Any],
+    activation_manifest_paths: list[pathlib.Path],
+    activation_comparison_paths: list[pathlib.Path],
+    go_test_json: list[pathlib.Path],
+    artifact_abi_report: pathlib.Path | None,
+    ppl_json: pathlib.Path | None,
+    generation_transcript: pathlib.Path | None,
+) -> str:
+    lines: list[str] = [
+        "# MLX Port Validation Report",
+        "",
+        "## Summary",
+        "",
+        *summarize_models(manifest),
+        "",
+        "## Variant And Config Coverage",
+        "",
+    ]
+    diffs = manifest.get("config_diffs") or {}
+    if diffs:
+        lines += [f"- `{key}`: `{json.dumps(value, sort_keys=True)}`" for key, value in sorted(diffs.items())]
+    else:
+        lines.append("- no config differences recorded")
+
+    lines += [
+        "",
+        "## Reference Activations",
+        "",
+        *summarize_activation_manifests(activation_manifest_paths),
+        "",
+        "## Activation Comparisons",
+        "",
+        *summarize_activation_comparisons(activation_comparison_paths),
+        "",
+        "## Artifact ABI",
+        "",
+        read_artifact_abi(artifact_abi_report),
+        "",
+        "## Go Test Results",
+        "",
+        *summarize_go_tests(go_test_json),
+        "",
+        "## Perplexity",
+        "",
+        *summarize_ppl(ppl_json),
+        "",
+        "## Generation Samples",
+        "",
+        read_transcript(generation_transcript),
+        "",
+        "## Known Skips Or Limitations",
+        "",
+        "- Review the Go test skips and missing artifacts above before merging.",
+        "- Treat generation quality and PPL deltas as review evidence, not automatic approval.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def run(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--manifest", required=True, help="porting_manifest.json from inspect_model.py")
+    parser.add_argument("--activation-manifest", action="append", default=[], help="activation sidecar manifest; can repeat")
+    parser.add_argument("--activation-comparison-json", action="append", default=[], help="compare_activations.py JSON output; can repeat")
+    parser.add_argument("--go-test-json", action="append", default=[], help="go test -json output; can repeat")
+    parser.add_argument("--artifact-abi-report", default=None, help="artifact ABI Markdown/text report")
+    parser.add_argument("--ppl-json", default=None, help="x/cmd/ppl -format json output")
+    parser.add_argument("--generation-transcript", default=None, help="optional generation transcript Markdown/text")
+    parser.add_argument("--output", required=True, help="output Markdown report")
+    args = parser.parse_args(argv)
+
+    manifest_path = pathlib.Path(args.manifest)
+    activation_paths = [pathlib.Path(p) for p in args.activation_manifest]
+    activation_comparison_paths = [pathlib.Path(p) for p in args.activation_comparison_json]
+    go_test_paths = [pathlib.Path(p) for p in args.go_test_json]
+    artifact_abi_path = pathlib.Path(args.artifact_abi_report) if args.artifact_abi_report else None
+    ppl_path = pathlib.Path(args.ppl_json) if args.ppl_json else None
+    generation_path = pathlib.Path(args.generation_transcript) if args.generation_transcript else None
+    output_path = pathlib.Path(args.output)
+
+    report = build_report(
+        load_json(manifest_path),
+        activation_paths,
+        activation_comparison_paths,
+        go_test_paths,
+        artifact_abi_path,
+        ppl_path,
+        generation_path,
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(report, encoding="utf-8")
+    print(f"Wrote {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/x/models/scripts/test_compare_activations.py
+++ b/x/models/scripts/test_compare_activations.py
@@ -1,0 +1,92 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import torch
+from safetensors.torch import save_file
+
+import compare_activations
+
+
+class CompareActivationsTest(unittest.TestCase):
+    def test_reports_first_position_and_ranked_drift(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            want = root / "want.safetensors"
+            got = root / "got.safetensors"
+            report_json = root / "report.json"
+            report_md = root / "report.md"
+
+            save_file(
+                {
+                    "layers.0": torch.zeros((1, 4, 2), dtype=torch.float32),
+                    "layers.1": torch.ones((1, 4, 2), dtype=torch.float32),
+                    "skip.me": torch.zeros((1, 1), dtype=torch.float32),
+                },
+                want,
+            )
+            save_file(
+                {
+                    "layers.0": torch.tensor(
+                        [[[0.0, 0.0], [0.0, 0.0], [1.0, 0.0], [0.0, 0.0]]],
+                        dtype=torch.float32,
+                    ),
+                    "layers.1": torch.ones((1, 4, 2), dtype=torch.float32),
+                    "skip.me": torch.ones((1, 1), dtype=torch.float32),
+                },
+                got,
+            )
+
+            rc = compare_activations.run(
+                [
+                    "--got",
+                    str(got),
+                    "--want",
+                    str(want),
+                    "--filter",
+                    "layers.*",
+                    "--atol",
+                    "0.5",
+                    "--rtol",
+                    "0.0",
+                    "--json-output",
+                    str(report_json),
+                    "--markdown-output",
+                    str(report_md),
+                ]
+            )
+
+            self.assertEqual(rc, 0)
+            report = json.loads(report_json.read_text(encoding="utf-8"))
+            self.assertEqual(report["counts"], {"fail": 1, "pass": 1})
+            by_name = {result["name"]: result for result in report["results"]}
+            self.assertEqual(by_name["layers.0"]["first_tol"], 2)
+            self.assertEqual(by_name["layers.0"]["worst_pos"], 2)
+            self.assertEqual(by_name["layers.1"]["status"], "pass")
+            self.assertIn("layers.0", report_md.read_text(encoding="utf-8"))
+
+    def test_require_pass_returns_nonzero_for_drift(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            want = root / "want.safetensors"
+            got = root / "got.safetensors"
+            report_json = root / "report.json"
+            save_file({"x": torch.zeros((1, 1), dtype=torch.float32)}, want)
+            save_file({"x": torch.ones((1, 1), dtype=torch.float32)}, got)
+
+            rc = compare_activations.run([
+                "--got",
+                str(got),
+                "--want",
+                str(want),
+                "--json-output",
+                str(report_json),
+                "--require-pass",
+            ])
+
+            self.assertEqual(rc, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/x/models/scripts/test_inspect_model.py
+++ b/x/models/scripts/test_inspect_model.py
@@ -1,0 +1,105 @@
+import json
+import pathlib
+import struct
+import tempfile
+import unittest
+
+import inspect_model
+
+
+def write_json(path: pathlib.Path, value):
+    path.write_text(json.dumps(value), encoding="utf-8")
+
+
+def write_safetensors_header(path: pathlib.Path, header):
+    raw = json.dumps(header).encode("utf-8")
+    padding = (8 - len(raw) % 8) % 8
+    raw += b" " * padding
+    with path.open("wb") as f:
+        f.write(struct.pack("<Q", len(raw)))
+        f.write(raw)
+
+
+class InspectModelTest(unittest.TestCase):
+    def test_writes_manifest_and_detects_risks(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            model = root / "TinyModel"
+            out = root / "out"
+            model.mkdir()
+            write_json(
+                model / "config.json",
+                {
+                    "architectures": ["TinyForCausalLM"],
+                    "model_type": "tiny",
+                    "hidden_size": 8,
+                    "num_hidden_layers": 2,
+                    "num_experts": 4,
+                    "rope_theta": 10000,
+                    "sliding_window": 16,
+                    "tie_word_embeddings": True,
+                    "attention_bias": True,
+                    "layer_types": ["full_attention", "sliding_attention"],
+                },
+            )
+            write_json(
+                model / "tokenizer_config.json",
+                {"chat_template": "{% if thinking %}<think>{{ thinking }}</think>{% endif %}"},
+            )
+            write_safetensors_header(
+                model / "model.safetensors",
+                {
+                    "model.embed_tokens.weight": {
+                        "dtype": "BF16",
+                        "shape": [16, 8],
+                        "data_offsets": [0, 256],
+                    },
+                    "model.layers.0.self_attn.q_proj.weight": {
+                        "dtype": "F16",
+                        "shape": [8, 8],
+                        "data_offsets": [256, 384],
+                    },
+                },
+            )
+
+            rc = inspect_model.run(["--model", str(model), "--output", str(out)])
+            self.assertEqual(rc, 0)
+            manifest = json.loads((out / "porting_manifest.json").read_text())
+            self.assertEqual(manifest["schema_version"], 1)
+            self.assertEqual(manifest["models"][0]["architectures"], ["TinyForCausalLM"])
+            risks = {r["name"] for r in manifest["models"][0]["risk_flags"]}
+            self.assertIn("rope", risks)
+            self.assertIn("sliding_window", risks)
+            self.assertIn("moe", risks)
+            self.assertIn("thinking_template", risks)
+            self.assertEqual(
+                manifest["models"][0]["safetensors"]["dtype_histogram"],
+                {"BF16": 1, "F16": 1},
+            )
+            self.assertTrue((out / "porting_manifest.md").exists())
+
+    def test_config_diffs_across_variants(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            models = []
+            for name, hidden in [("small", 8), ("large", 16)]:
+                model = root / name
+                model.mkdir()
+                write_json(
+                    model / "config.json",
+                    {
+                        "architectures": ["TinyForCausalLM"],
+                        "model_type": "tiny",
+                        "hidden_size": hidden,
+                    },
+                )
+                write_safetensors_header(model / "model.safetensors", {})
+                models += ["--model", str(model)]
+            out = root / "out"
+            inspect_model.run([*models, "--output", str(out)])
+            manifest = json.loads((out / "porting_manifest.json").read_text())
+            self.assertIn("hidden_size", manifest["config_diffs"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/x/models/scripts/test_summarize_validation.py
+++ b/x/models/scripts/test_summarize_validation.py
@@ -1,0 +1,127 @@
+import json
+import pathlib
+import tempfile
+import unittest
+
+import summarize_validation
+
+
+def write_json(path: pathlib.Path, value):
+    path.write_text(json.dumps(value), encoding="utf-8")
+
+
+class SummarizeValidationTest(unittest.TestCase):
+    def test_writes_reviewer_report(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            manifest = root / "porting_manifest.json"
+            activation = root / "activations.manifest.json"
+            comparison = root / "activation-comparison.json"
+            go_test = root / "go-test.json"
+            ppl = root / "ppl.json"
+            transcript = root / "generation.md"
+            output = root / "report.md"
+
+            write_json(
+                manifest,
+                {
+                    "models": [
+                        {
+                            "label": "TinyModel",
+                            "source": "models/TinyModel",
+                            "architectures": ["TinyForCausalLM"],
+                            "model_type": "tiny",
+                            "safetensors": {"dtype_histogram": {"BF16": 2}},
+                            "risk_flags": [{"name": "rope", "detail": "rope_theta"}],
+                        }
+                    ],
+                    "config_diffs": {"hidden_size": {"small": 8, "large": 16}},
+                },
+            )
+            write_json(
+                activation,
+                {
+                    "output_path": "/tmp/ollama_ref/Tiny/activations.safetensors",
+                    "model_path": "models/TinyModel",
+                    "model_class": "TinyForCausalLM",
+                    "dtype": "bfloat16",
+                    "num_tokens": 12,
+                    "prefill_num_tokens": 1024,
+                    "decode_text": " the",
+                    "decode_token_ids": [],
+                    "prompt_sha256": "abc123",
+                    "tensors": {"input_ids": {"shape": [1, 12]}},
+                },
+            )
+            write_json(
+                comparison,
+                {
+                    "got": "/tmp/ollama_ref/Tiny/eager.safetensors",
+                    "want": "/tmp/ollama_ref/Tiny/sdpa.safetensors",
+                    "filters": ["layers.*"],
+                    "axis": 1,
+                    "counts": {"fail": 1, "pass": 3},
+                    "top_absolute": [
+                        {
+                            "name": "layers.2",
+                            "max_diff": 1.25,
+                            "first_tol": 9,
+                        }
+                    ],
+                },
+            )
+            go_test.write_text(
+                "\n".join(
+                    [
+                        json.dumps({"Action": "pass", "Package": "p", "Test": "TestForward"}),
+                        json.dumps({"Action": "skip", "Package": "p", "Test": "TestLong"}),
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            write_json(
+                ppl,
+                {
+                    "model": "tiny:bf16",
+                    "mode": "harness",
+                    "max_length": 128,
+                    "total_tokens": 42,
+                    "token_perplexity": 9.5,
+                    "baseline_delta": {
+                        "token_perplexity_abs": 0.1,
+                        "token_perplexity_rel": 0.0106,
+                    },
+                },
+            )
+            transcript.write_text("Prompt: hello\nOutput: world\n", encoding="utf-8")
+
+            rc = summarize_validation.run(
+                [
+                    "--manifest",
+                    str(manifest),
+                    "--activation-manifest",
+                    str(activation),
+                    "--activation-comparison-json",
+                    str(comparison),
+                    "--go-test-json",
+                    str(go_test),
+                    "--ppl-json",
+                    str(ppl),
+                    "--generation-transcript",
+                    str(transcript),
+                    "--output",
+                    str(output),
+                ]
+            )
+            self.assertEqual(rc, 0)
+            report = output.read_text(encoding="utf-8")
+            self.assertIn("TinyModel", report)
+            self.assertIn("cached prefill tokens", report)
+            self.assertIn("TestLong", report)
+            self.assertIn("layers.2", report)
+            self.assertIn("token PPL", report)
+            self.assertIn("Prompt: hello", report)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/x/models/scripts/test_summarize_validation.py
+++ b/x/models/scripts/test_summarize_validation.py
@@ -1,0 +1,132 @@
+import json
+import pathlib
+import tempfile
+import unittest
+
+import summarize_validation
+
+
+def write_json(path: pathlib.Path, value):
+    path.write_text(json.dumps(value), encoding="utf-8")
+
+
+class SummarizeValidationTest(unittest.TestCase):
+    def test_writes_reviewer_report(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            manifest = root / "porting_manifest.json"
+            activation = root / "activations.manifest.json"
+            comparison = root / "activation-comparison.json"
+            go_test = root / "go-test.json"
+            ppl = root / "ppl.json"
+            transcript = root / "generation.md"
+            abi = root / "artifact-abi.md"
+            output = root / "report.md"
+
+            write_json(
+                manifest,
+                {
+                    "models": [
+                        {
+                            "label": "TinyModel",
+                            "source": "models/TinyModel",
+                            "architectures": ["TinyForCausalLM"],
+                            "model_type": "tiny",
+                            "safetensors": {"dtype_histogram": {"BF16": 2}},
+                            "risk_flags": [{"name": "rope", "detail": "rope_theta"}],
+                        }
+                    ],
+                    "config_diffs": {"hidden_size": {"small": 8, "large": 16}},
+                },
+            )
+            write_json(
+                activation,
+                {
+                    "output_path": "/tmp/ollama_ref/Tiny/activations.safetensors",
+                    "model_path": "models/TinyModel",
+                    "model_class": "TinyForCausalLM",
+                    "dtype": "bfloat16",
+                    "num_tokens": 12,
+                    "prefill_num_tokens": 1024,
+                    "decode_text": " the",
+                    "decode_token_ids": [],
+                    "prompt_sha256": "abc123",
+                    "tensors": {"input_ids": {"shape": [1, 12]}},
+                },
+            )
+            write_json(
+                comparison,
+                {
+                    "got": "/tmp/ollama_ref/Tiny/eager.safetensors",
+                    "want": "/tmp/ollama_ref/Tiny/sdpa.safetensors",
+                    "filters": ["layers.*"],
+                    "axis": 1,
+                    "counts": {"fail": 1, "pass": 3},
+                    "top_absolute": [
+                        {
+                            "name": "layers.2",
+                            "max_diff": 1.25,
+                            "first_tol": 9,
+                        }
+                    ],
+                },
+            )
+            go_test.write_text(
+                "\n".join(
+                    [
+                        json.dumps({"Action": "pass", "Package": "p", "Test": "TestForward"}),
+                        json.dumps({"Action": "skip", "Package": "p", "Test": "TestLong"}),
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            write_json(
+                ppl,
+                {
+                    "model": "tiny:bf16",
+                    "mode": "harness",
+                    "max_length": 128,
+                    "total_tokens": 42,
+                    "token_perplexity": 9.5,
+                    "baseline_delta": {
+                        "token_perplexity_abs": 0.1,
+                        "token_perplexity_rel": 0.0106,
+                    },
+                },
+            )
+            transcript.write_text("Prompt: hello\nOutput: world\n", encoding="utf-8")
+            abi.write_text("Tensor namespace: preserved\n", encoding="utf-8")
+
+            rc = summarize_validation.run(
+                [
+                    "--manifest",
+                    str(manifest),
+                    "--activation-manifest",
+                    str(activation),
+                    "--activation-comparison-json",
+                    str(comparison),
+                    "--go-test-json",
+                    str(go_test),
+                    "--artifact-abi-report",
+                    str(abi),
+                    "--ppl-json",
+                    str(ppl),
+                    "--generation-transcript",
+                    str(transcript),
+                    "--output",
+                    str(output),
+                ]
+            )
+            self.assertEqual(rc, 0)
+            report = output.read_text(encoding="utf-8")
+            self.assertIn("TinyModel", report)
+            self.assertIn("cached prefill tokens", report)
+            self.assertIn("TestLong", report)
+            self.assertIn("layers.2", report)
+            self.assertIn("Tensor namespace: preserved", report)
+            self.assertIn("token PPL", report)
+            self.assertIn("Prompt: hello", report)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/x/models/testutil/compare_position.go
+++ b/x/models/testutil/compare_position.go
@@ -1,0 +1,523 @@
+package testutil
+
+import (
+	"fmt"
+	"math"
+	"slices"
+	"sort"
+	"testing"
+
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+)
+
+// PositionDrift summarizes how a single position-axis index of two tensors
+// diverged. It's the per-position equivalent of CompareEntry.
+type PositionDrift struct {
+	Index    int     // index along the scanned axis (typically the sequence dimension)
+	MaxDiff  float32 // max |got - want| across all elements at this position
+	MeanDiff float32 // mean |got - want| at this position
+	CosSim   float32 // cosine similarity between got and want at this position
+	Passed   bool    // true if MaxDiff <= atol + rtol * |want| for every element
+}
+
+// PerPositionReport is the result of comparing two tensors with a position-aware
+// scan. It's specifically designed to find the first index along an axis where
+// drift exceeds tolerance, which is the most common diagnostic question for
+// long-sequence / sliding-window / attention-mask bugs.
+//
+// FirstFailIndex is -1 if every position passed.
+type PerPositionReport struct {
+	Name           string
+	Axis           int
+	Length         int             // number of positions scanned
+	Drifts         []PositionDrift // one entry per scanned position
+	FirstFailIndex int             // -1 if all positions passed
+	WorstIndex     int             // position with the largest max_diff
+}
+
+// AllPassed returns true if every position satisfied the tolerance.
+func (r PerPositionReport) AllPassed() bool { return r.FirstFailIndex < 0 }
+
+// Summary writes a compact human-readable trace to the test logger. Useful when
+// you want to see how drift evolves across positions, not just where it starts.
+// Prints every Nth position (auto-bucketed to ~20 rows) plus the first failing
+// position and the worst position.
+func (r PerPositionReport) Summary(t *testing.T) {
+	t.Helper()
+	if len(r.Drifts) == 0 {
+		t.Logf("%s: no positions scored", r.Name)
+		return
+	}
+
+	step := max(r.Length/20, 1)
+
+	t.Logf("%s: scanned %d positions along axis %d", r.Name, r.Length, r.Axis)
+	t.Logf("  %-8s %12s %12s %10s %s", "pos", "max_diff", "mean_diff", "cos_sim", "status")
+	for i, d := range r.Drifts {
+		isInteresting := i%step == 0 || i == r.Length-1 || i == r.FirstFailIndex || i == r.WorstIndex
+		if !isInteresting {
+			continue
+		}
+		status := "ok"
+		if !d.Passed {
+			status = "FAIL"
+		}
+		t.Logf("  %-8d %12.6f %12.6f %10.6f %s", d.Index, d.MaxDiff, d.MeanDiff, d.CosSim, status)
+	}
+	if r.FirstFailIndex >= 0 {
+		t.Logf("  → first divergence at position %d", r.FirstFailIndex)
+	}
+	t.Logf("  → worst drift at position %d (max_diff=%.6f)", r.WorstIndex, r.Drifts[r.WorstIndex].MaxDiff)
+}
+
+// CompareArraysPerPosition compares two MLX arrays element-wise but reports
+// drift broken down per index along a chosen axis. Returns a PerPositionReport
+// with one entry per index. The first index where any element exceeds the
+// tolerance is recorded as FirstFailIndex.
+//
+// Typical use: for a [B, N, H] hidden-state tensor, pass axis=1 to scan along
+// the sequence dimension and find the first position where the model's output
+// drifts from a reference. This is the diagnostic primitive for sliding-window,
+// attention-mask, RoPE, and KV-cache bugs that manifest only after the input
+// length crosses some threshold.
+//
+// Both got and want must have identical shapes. The function reduces along all
+// non-axis dimensions to produce per-position statistics.
+func CompareArraysPerPosition(t *testing.T, name string, got, want *mlx.Array, axis int, opts ...CompareOption) PerPositionReport {
+	t.Helper()
+	cfg := defaultConfig()
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	gotDims := got.Dims()
+	wantDims := want.Dims()
+	report := PerPositionReport{
+		Name:           name,
+		Axis:           axis,
+		FirstFailIndex: -1,
+	}
+
+	if len(gotDims) != len(wantDims) {
+		t.Errorf("%s: shape rank mismatch: got %v, want %v", name, gotDims, wantDims)
+		return report
+	}
+	for i := range gotDims {
+		if gotDims[i] != wantDims[i] {
+			t.Errorf("%s: shape mismatch at dim %d: got %v, want %v", name, i, gotDims, wantDims)
+			return report
+		}
+	}
+	if axis < 0 || axis >= len(gotDims) {
+		t.Errorf("%s: axis %d out of range for shape %v", name, axis, gotDims)
+		return report
+	}
+
+	gotF32 := got.AsType(mlx.DTypeFloat32)
+	wantF32 := want.AsType(mlx.DTypeFloat32)
+	mlx.Eval(gotF32, wantF32)
+	gotData := gotF32.Floats()
+	wantData := wantF32.Floats()
+	if len(gotData) != len(wantData) {
+		t.Errorf("%s: tensor element count mismatch: got %d, want %d", name, len(gotData), len(wantData))
+		return report
+	}
+
+	// Compute strides so we can iterate per-axis-index efficiently.
+	rank := len(gotDims)
+	strides := make([]int, rank)
+	strides[rank-1] = 1
+	for i := rank - 2; i >= 0; i-- {
+		strides[i] = strides[i+1] * gotDims[i+1]
+	}
+	axisLen := gotDims[axis]
+	report.Length = axisLen
+	report.Drifts = make([]PositionDrift, axisLen)
+
+	// For each index along axis, walk every element whose coordinates have
+	// that index in the axis position and accumulate stats.
+	axisStride := strides[axis]
+	// Compute the size of one "slice" along axis: product of all other dims.
+	sliceSize := 1
+	for d, sz := range gotDims {
+		if d == axis {
+			continue
+		}
+		sliceSize *= sz
+	}
+
+	// Generate the sequence of element indices for a given axis index.
+	// We iterate the cartesian product of non-axis dimensions and add
+	// idx*axisStride.
+	nonAxisDims := make([]int, 0, rank-1)
+	nonAxisStrides := make([]int, 0, rank-1)
+	for d := range rank {
+		if d == axis {
+			continue
+		}
+		nonAxisDims = append(nonAxisDims, gotDims[d])
+		nonAxisStrides = append(nonAxisStrides, strides[d])
+	}
+	bases := make([]int, sliceSize)
+	{
+		coord := make([]int, len(nonAxisDims))
+		for k := range bases {
+			off := 0
+			for i, c := range coord {
+				off += c * nonAxisStrides[i]
+			}
+			bases[k] = off
+			// increment coord (last dim varies fastest)
+			for i := len(coord) - 1; i >= 0; i-- {
+				coord[i]++
+				if coord[i] < nonAxisDims[i] {
+					break
+				}
+				coord[i] = 0
+			}
+		}
+	}
+
+	worstIdx := 0
+	worstDiff := float32(-1)
+	for idx := range axisLen {
+		offset := idx * axisStride
+		var (
+			maxDiff  float32
+			sumDiff  float32
+			dot      float64
+			gotNorm  float64
+			wantNorm float64
+			passed   = true
+		)
+		for _, base := range bases {
+			pos := base + offset
+			g := gotData[pos]
+			w := wantData[pos]
+			diff := float32(math.Abs(float64(g - w)))
+			if diff > maxDiff {
+				maxDiff = diff
+			}
+			sumDiff += diff
+			dot += float64(g) * float64(w)
+			gotNorm += float64(g) * float64(g)
+			wantNorm += float64(w) * float64(w)
+			if diff > cfg.atol+cfg.rtol*float32(math.Abs(float64(w))) {
+				passed = false
+			}
+		}
+		mean := sumDiff / float32(sliceSize)
+		var cosSim float32
+		if denom := math.Sqrt(gotNorm) * math.Sqrt(wantNorm); denom > 0 {
+			cosSim = float32(dot / denom)
+		}
+		report.Drifts[idx] = PositionDrift{
+			Index:    idx,
+			MaxDiff:  maxDiff,
+			MeanDiff: mean,
+			CosSim:   cosSim,
+			Passed:   passed,
+		}
+		if !passed && report.FirstFailIndex < 0 {
+			report.FirstFailIndex = idx
+		}
+		if maxDiff > worstDiff {
+			worstDiff = maxDiff
+			worstIdx = idx
+		}
+	}
+	report.WorstIndex = worstIdx
+	return report
+}
+
+// LayerPositionReport is the per-(layer, position) result of comparing many
+// layer-output tensors against references with position-axis breakdown.
+type LayerPositionReport struct {
+	Layers []PerPositionReport
+}
+
+// FirstDivergentLayer returns the index into Layers of the first layer where
+// any position drifted, or -1 if all layers passed at all positions.
+func (r LayerPositionReport) FirstDivergentLayer() int {
+	for i, l := range r.Layers {
+		if !l.AllPassed() {
+			return i
+		}
+	}
+	return -1
+}
+
+// EarliestToleranceExceedance returns the layer index and position for the
+// earliest position that exceeded tolerance across the report. Ties keep report
+// order. Returns (-1, -1) if every layer passed at all positions.
+func (r LayerPositionReport) EarliestToleranceExceedance() (int, int) {
+	layerIdx := -1
+	pos := -1
+	for i, l := range r.Layers {
+		if l.FirstFailIndex < 0 {
+			continue
+		}
+		if pos < 0 || l.FirstFailIndex < pos {
+			layerIdx = i
+			pos = l.FirstFailIndex
+		}
+	}
+	return layerIdx, pos
+}
+
+// Summary prints a compact first tolerance-exceeding position trace across
+// layers, answering the question "at each layer, where does drift start?"
+// Useful for finding the layer where a position-dependent bug first manifests.
+func (r LayerPositionReport) Summary(t *testing.T) {
+	t.Helper()
+	t.Logf("Per-layer first-divergence-position summary:")
+	t.Logf("  %-32s %12s %12s %12s", "layer", "first_tol", "worst_pos", "worst_diff")
+	for _, l := range r.Layers {
+		first := "-"
+		if l.FirstFailIndex >= 0 {
+			first = fmt.Sprintf("%d", l.FirstFailIndex)
+		}
+		worstDiff := float32(0)
+		if l.WorstIndex < len(l.Drifts) {
+			worstDiff = l.Drifts[l.WorstIndex].MaxDiff
+		}
+		t.Logf("  %-32s %12s %12d %12.6f", l.Name, first, l.WorstIndex, worstDiff)
+	}
+	if first := r.FirstDivergentLayer(); first >= 0 {
+		layer := r.Layers[first]
+		t.Logf("  → first divergent layer in report order: %s, first tolerance-exceeding position: %d",
+			layer.Name, layer.FirstFailIndex)
+		if layerIdx, pos := r.EarliestToleranceExceedance(); layerIdx >= 0 && layerIdx != first {
+			layer := r.Layers[layerIdx]
+			t.Logf("  → earliest tolerance-exceeding position: %s, position %d", layer.Name, pos)
+		}
+	} else {
+		t.Logf("  → all layers passed at all positions")
+	}
+}
+
+// DriftRank is a single entry in a ranked drift listing. It identifies where
+// the drift occurred (layer name + position index) and how large it was in
+// both absolute terms and relative to the layer's own median drift.
+//
+// RelToMedian is the ratio max_diff / median(max_diff across all positions in
+// this layer). A value of ~1 means the position is typical for the layer; a
+// value of 50 means it's 50× the layer's median — a clear outlier regardless
+// of absolute scale. This lets you find the *most anomalous* positions even
+// in layers where everything has drifted.
+type DriftRank struct {
+	Layer       string
+	Position    int
+	MaxDiff     float32
+	MeanDiff    float32
+	CosSim      float32
+	RelToMedian float32
+}
+
+// TopDrifts returns the top-n positions ranked by MaxDiff, descending.
+// If n <= 0 or n > Length, all positions are returned. RelToMedian is
+// computed against the median of this tensor's per-position MaxDiff.
+func (r PerPositionReport) TopDrifts(n int) []DriftRank {
+	if len(r.Drifts) == 0 {
+		return nil
+	}
+	// Floor the median at a tiny epsilon so positions in layers with an
+	// essentially-zero median (most positions perfect, one big outlier) still
+	// produce a meaningful RelToMedian. Without the floor the outlier would
+	// divide by zero and be ranked *below* layers where everything drifts
+	// uniformly — exactly backwards from what we want.
+	median := max(medianMaxDiff(r.Drifts), 1e-6)
+	ranked := make([]DriftRank, len(r.Drifts))
+	for i, d := range r.Drifts {
+		rel := d.MaxDiff / median
+		ranked[i] = DriftRank{
+			Layer:       r.Name,
+			Position:    d.Index,
+			MaxDiff:     d.MaxDiff,
+			MeanDiff:    d.MeanDiff,
+			CosSim:      d.CosSim,
+			RelToMedian: rel,
+		}
+	}
+	sort.Slice(ranked, func(i, j int) bool { return ranked[i].MaxDiff > ranked[j].MaxDiff })
+	if n > 0 && n < len(ranked) {
+		ranked = ranked[:n]
+	}
+	return ranked
+}
+
+// TopDrifts returns the top-n (layer, position) pairs ranked by MaxDiff across
+// every layer in the report, descending. RelToMedian is computed against each
+// layer's own median, so it's meaningful to compare across layers: a position
+// with RelToMedian=50 in layer 3 and one with RelToMedian=2 in layer 17 tells
+// you the layer-3 site is the real anomaly even if its absolute MaxDiff is
+// smaller.
+//
+// This is the "iterate and squash" diagnostic: look at the top 10, fix the
+// worst offender, re-run, repeat until the list is uniform noise.
+func (r LayerPositionReport) TopDrifts(n int) []DriftRank {
+	var all []DriftRank
+	for _, l := range r.Layers {
+		all = append(all, l.TopDrifts(0)...)
+	}
+	sort.Slice(all, func(i, j int) bool { return all[i].MaxDiff > all[j].MaxDiff })
+	if n > 0 && n < len(all) {
+		all = all[:n]
+	}
+	return all
+}
+
+// TopDriftsByRelative returns the top-n entries ranked by RelToMedian (how
+// anomalous a position is within its own layer), descending. This surfaces
+// positions that are outliers relative to their layer's baseline drift, which
+// is often more diagnostic than raw MaxDiff when later layers have amplified
+// earlier bugs into uniform large drift.
+func (r LayerPositionReport) TopDriftsByRelative(n int) []DriftRank {
+	var all []DriftRank
+	for _, l := range r.Layers {
+		all = append(all, l.TopDrifts(0)...)
+	}
+	sort.Slice(all, func(i, j int) bool { return all[i].RelToMedian > all[j].RelToMedian })
+	if n > 0 && n < len(all) {
+		all = all[:n]
+	}
+	return all
+}
+
+// EarliestOutlier walks layers in order and returns the index of the first
+// layer that contains a tolerance-exceeding position whose RelToMedian exceeds
+// relCutoff. Since drift compounds forward, the top-ranked absolute drifts
+// always live in deep layers even when the bug originates earlier. This
+// primitive answers the complementary question: *where did it start?*
+//
+// A good relCutoff is 5–10× — high enough to skip bf16 rounding noise, low
+// enough to catch the first real anomaly before downstream amplification
+// pushes every layer above the cutoff. Returns -1 if no layer qualifies.
+//
+// Caveat: if a bug corrupts a *majority* of positions in its origin layer,
+// that layer's median is already elevated and the origin may not exceed the
+// cutoff. In that case use FirstDivergentLayer (which triggers on any single
+// failing position under the absolute tolerance) as the complementary signal.
+func (r LayerPositionReport) EarliestOutlier(relCutoff float32) int {
+	for i, l := range r.Layers {
+		median := max(medianMaxDiff(l.Drifts), 1e-6)
+		for _, d := range l.Drifts {
+			if !d.Passed && d.MaxDiff/median >= relCutoff {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// EarliestOutlierPosition returns (layerIdx, position) of the first
+// tolerance-exceeding (layer, position) pair whose RelToMedian exceeds
+// relCutoff, scanning layers in order and positions in order within each layer.
+// This is the single most useful drill-down pointer: "start your investigation
+// here." Returns (-1, -1) if nothing qualifies.
+func (r LayerPositionReport) EarliestOutlierPosition(relCutoff float32) (int, int) {
+	for i, l := range r.Layers {
+		median := max(medianMaxDiff(l.Drifts), 1e-6)
+		for _, d := range l.Drifts {
+			if !d.Passed && d.MaxDiff/median >= relCutoff {
+				return i, d.Index
+			}
+		}
+	}
+	return -1, -1
+}
+
+// LogDriftRanks prints a ranked drift table to the test logger. Caller
+// supplies the title so the same formatter works for absolute-ranked,
+// relative-ranked, and per-tensor listings.
+func LogDriftRanks(t *testing.T, title string, ranks []DriftRank) {
+	t.Helper()
+	t.Logf("%s", title)
+	t.Logf("  %-24s %8s %12s %12s %10s %12s", "layer", "pos", "max_diff", "mean_diff", "cos_sim", "rel_to_med")
+	for _, d := range ranks {
+		t.Logf("  %-24s %8d %12.6f %12.6f %10.6f %12.2fx", d.Layer, d.Position, d.MaxDiff, d.MeanDiff, d.CosSim, d.RelToMedian)
+	}
+}
+
+// medianMaxDiff returns the median of the per-position MaxDiff values.
+// Uses a copy so the caller's slice order is preserved.
+func medianMaxDiff(drifts []PositionDrift) float32 {
+	if len(drifts) == 0 {
+		return 0
+	}
+	vals := make([]float32, len(drifts))
+	for i, d := range drifts {
+		vals[i] = d.MaxDiff
+	}
+	slices.Sort(vals)
+	mid := len(vals) / 2
+	if len(vals)%2 == 1 {
+		return vals[mid]
+	}
+	return (vals[mid-1] + vals[mid]) / 2
+}
+
+// CompareLayersPerPosition runs CompareArraysPerPosition over a set of named
+// (got, want) tensor pairs and aggregates them. Layers are ordered by natural
+// name sort so "layers.10" follows "layers.2", keeping the report deterministic
+// and bisectable even when callers do not zero-pad layer numbers.
+func CompareLayersPerPosition(t *testing.T, got, want map[string]*mlx.Array, axis int, opts ...CompareOption) LayerPositionReport {
+	t.Helper()
+	var keys []string
+	for k := range want {
+		if _, ok := got[k]; ok {
+			keys = append(keys, k)
+		}
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return naturalLess(keys[i], keys[j])
+	})
+
+	report := LayerPositionReport{}
+	for _, k := range keys {
+		report.Layers = append(report.Layers, CompareArraysPerPosition(t, k, got[k], want[k], axis, opts...))
+	}
+	return report
+}
+
+func naturalLess(a, b string) bool {
+	i, j := 0, 0
+	for i < len(a) && j < len(b) {
+		ac, bc := a[i], b[j]
+		if asciiDigit(ac) && asciiDigit(bc) {
+			ai, bj := i, j
+			for i < len(a) && asciiDigit(a[i]) {
+				i++
+			}
+			for j < len(b) && asciiDigit(b[j]) {
+				j++
+			}
+			an := trimLeadingZeroes(a[ai:i])
+			bn := trimLeadingZeroes(b[bj:j])
+			if len(an) != len(bn) {
+				return len(an) < len(bn)
+			}
+			if an != bn {
+				return an < bn
+			}
+			continue
+		}
+		if ac != bc {
+			return ac < bc
+		}
+		i++
+		j++
+	}
+	return len(a) < len(b)
+}
+
+func asciiDigit(b byte) bool {
+	return b >= '0' && b <= '9'
+}
+
+func trimLeadingZeroes(s string) string {
+	for len(s) > 1 && s[0] == '0' {
+		s = s[1:]
+	}
+	return s
+}

--- a/x/models/testutil/loader.go
+++ b/x/models/testutil/loader.go
@@ -1,0 +1,186 @@
+package testutil
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/ollama/ollama/x/imagegen/manifest"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/mlxrunner/model"
+	"github.com/ollama/ollama/x/mlxrunner/model/base"
+)
+
+// LoadModelFromDirOrErr is the *testing.T-free counterpart of
+// LoadModelFromDir. It builds a synthetic manifest pointing at a HuggingFace-
+// format model directory (config.json + tokenizer.json + *.safetensors), runs
+// the architecture's registered factory, loads weights, and returns the
+// initialized model. Symlinks are placed in tmpBlobDir; the caller owns
+// cleanup of that directory.
+func LoadModelFromDirOrErr(modelDir, tmpBlobDir string) (base.Model, error) {
+	if err := mlx.CheckInit(); err != nil {
+		return nil, fmt.Errorf("MLX not available: %w", err)
+	}
+
+	if _, err := os.Stat(modelDir); err != nil {
+		return nil, fmt.Errorf("model dir %q: %w", modelDir, err)
+	}
+
+	if err := os.MkdirAll(tmpBlobDir, 0o755); err != nil {
+		return nil, fmt.Errorf("create blob dir: %w", err)
+	}
+
+	var layers []manifest.ManifestLayer
+
+	// Link config files (only the first two are required).
+	for _, name := range []string{
+		"config.json",
+		"tokenizer.json",
+		"generation_config.json",
+		"tokenizer_config.json",
+	} {
+		src := filepath.Join(modelDir, name)
+		if _, err := os.Stat(src); err != nil {
+			if name == "config.json" || name == "tokenizer.json" {
+				return nil, fmt.Errorf("required file missing: %s", src)
+			}
+			continue
+		}
+		digest := "sha256:" + name
+		dst := filepath.Join(tmpBlobDir, "sha256-"+name)
+		_ = os.Remove(dst) // tolerate stale symlinks from prior runs
+		if err := os.Symlink(src, dst); err != nil {
+			return nil, fmt.Errorf("symlink %s: %w", name, err)
+		}
+		layers = append(layers, manifest.ManifestLayer{
+			MediaType: "application/vnd.ollama.image.json",
+			Digest:    digest,
+			Name:      name,
+		})
+	}
+
+	// Link weight files.
+	matches, _ := filepath.Glob(filepath.Join(modelDir, "*.safetensors"))
+	sort.Strings(matches)
+	for _, src := range matches {
+		name := filepath.Base(src)
+		digest := "sha256:" + name
+		dst := filepath.Join(tmpBlobDir, "sha256-"+name)
+		_ = os.Remove(dst)
+		if err := os.Symlink(src, dst); err != nil {
+			return nil, fmt.Errorf("symlink %s: %w", name, err)
+		}
+		layers = append(layers, manifest.ManifestLayer{
+			MediaType: "application/vnd.ollama.image.tensor",
+			Digest:    digest,
+			Name:      name,
+		})
+	}
+
+	mm := &manifest.ModelManifest{
+		Manifest: &manifest.Manifest{
+			SchemaVersion: 2,
+			Layers:        layers,
+		},
+		BlobDir: tmpBlobDir,
+	}
+	root := &model.Root{Manifest: mm}
+
+	m, err := base.New(root)
+	if err != nil {
+		return nil, fmt.Errorf("base.New: %w", err)
+	}
+
+	tensors := loadTensorsFromManifestPlain(root)
+	if len(tensors) == 0 {
+		return nil, fmt.Errorf("no tensors loaded from manifest")
+	}
+
+	if err := base.Weights(m)(tensors); err != nil {
+		return nil, fmt.Errorf("LoadWeights: %w", err)
+	}
+	return m, nil
+}
+
+// LoadModelByNameOrErr is the *testing.T-free counterpart of LoadModelByName.
+// It opens an ollama model from the local store by tag (e.g.
+// "gemma4:e2b-base-mlx-bf16") and returns the initialized model. The caller
+// is responsible for closing the underlying root via the returned closer.
+func LoadModelByNameOrErr(modelName string) (base.Model, func(), error) {
+	if err := mlx.CheckInit(); err != nil {
+		return nil, func() {}, fmt.Errorf("MLX not available: %w", err)
+	}
+	if modelName == "" {
+		return nil, func() {}, fmt.Errorf("model name is required")
+	}
+
+	root, err := model.Open(modelName)
+	if err != nil {
+		return nil, func() {}, fmt.Errorf("open model %q: %w", modelName, err)
+	}
+	cleanup := func() { root.Close() }
+
+	m, err := base.New(root)
+	if err != nil {
+		cleanup()
+		return nil, func() {}, fmt.Errorf("base.New(%s): %w", modelName, err)
+	}
+
+	tensors := loadTensorsFromManifestPlain(root)
+	if len(tensors) == 0 {
+		cleanup()
+		return nil, func() {}, fmt.Errorf("no tensors loaded for %q", modelName)
+	}
+
+	if err := base.Weights(m)(tensors); err != nil {
+		cleanup()
+		return nil, func() {}, fmt.Errorf("LoadWeights(%s): %w", modelName, err)
+	}
+	return m, cleanup, nil
+}
+
+// loadTensorsFromManifestPlain mirrors loadTensorsFromManifest but does not
+// require *testing.T. The two share the same key-remap algorithm so callers
+// from CLI tools and tests behave identically.
+func loadTensorsFromManifestPlain(root *model.Root) map[string]*mlx.Array {
+	rawTensors := make(map[string]*mlx.Array)
+	seen := make(map[string]bool)
+	for _, layer := range root.Manifest.GetTensorLayers("") {
+		if seen[layer.Digest] {
+			continue
+		}
+		seen[layer.Digest] = true
+		blobPath := root.Manifest.BlobPath(layer.Digest)
+		for name, arr := range mlx.Load(blobPath) {
+			rawTensors[name] = arr
+		}
+	}
+
+	scaleBaseNames := make(map[string]bool)
+	allTensors := make(map[string]*mlx.Array, len(rawTensors))
+	for name, arr := range rawTensors {
+		if strings.HasSuffix(name, ".scale") {
+			baseName := strings.TrimSuffix(name, ".scale")
+			allTensors[baseName+"_scale"] = arr
+			scaleBaseNames[baseName] = true
+		}
+	}
+	for name, arr := range rawTensors {
+		if strings.HasSuffix(name, ".scale") {
+			continue
+		}
+		if strings.HasSuffix(name, ".bias") && !strings.HasSuffix(name, ".weight_qbias") {
+			baseName := strings.TrimSuffix(name, ".bias")
+			if scaleBaseNames[baseName] {
+				allTensors[baseName+"_qbias"] = arr
+			} else {
+				allTensors[name] = arr
+			}
+		} else {
+			allTensors[name] = arr
+		}
+	}
+	return allTensors
+}

--- a/x/models/testutil/loader.go
+++ b/x/models/testutil/loader.go
@@ -1,0 +1,192 @@
+package testutil
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/ollama/ollama/x/imagegen/manifest"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/mlxrunner/model"
+	"github.com/ollama/ollama/x/mlxrunner/model/base"
+)
+
+// LoadModelFromDirOrErr is the *testing.T-free counterpart of
+// LoadModelFromDir. It builds a synthetic manifest pointing at a HuggingFace-
+// format model directory (config.json + tokenizer.json + *.safetensors), runs
+// the architecture's registered factory, loads weights, and returns the
+// initialized model. Symlinks are placed in tmpBlobDir; the caller owns
+// cleanup of that directory.
+//
+// CAUTION: this bypasses the create-path import transform. Architectures
+// whose runtime layout depends on it (renamed or synthesized tensors) load
+// without error here but produce silently wrong outputs. Validate a new
+// architecture through a created tag (LoadModelByNameOrErr) before trusting
+// directory loading for it.
+func LoadModelFromDirOrErr(modelDir, tmpBlobDir string) (base.Model, error) {
+	if err := mlx.CheckInit(); err != nil {
+		return nil, fmt.Errorf("MLX not available: %w", err)
+	}
+
+	if _, err := os.Stat(modelDir); err != nil {
+		return nil, fmt.Errorf("model dir %q: %w", modelDir, err)
+	}
+
+	if err := os.MkdirAll(tmpBlobDir, 0o755); err != nil {
+		return nil, fmt.Errorf("create blob dir: %w", err)
+	}
+
+	var layers []manifest.ManifestLayer
+
+	// Link config files (only the first two are required).
+	for _, name := range []string{
+		"config.json",
+		"tokenizer.json",
+		"generation_config.json",
+		"tokenizer_config.json",
+	} {
+		src := filepath.Join(modelDir, name)
+		if _, err := os.Stat(src); err != nil {
+			if name == "config.json" || name == "tokenizer.json" {
+				return nil, fmt.Errorf("required file missing: %s", src)
+			}
+			continue
+		}
+		digest := "sha256:" + name
+		dst := filepath.Join(tmpBlobDir, "sha256-"+name)
+		_ = os.Remove(dst) // tolerate stale symlinks from prior runs
+		if err := os.Symlink(src, dst); err != nil {
+			return nil, fmt.Errorf("symlink %s: %w", name, err)
+		}
+		layers = append(layers, manifest.ManifestLayer{
+			MediaType: "application/vnd.ollama.image.json",
+			Digest:    digest,
+			Name:      name,
+		})
+	}
+
+	// Link weight files.
+	matches, _ := filepath.Glob(filepath.Join(modelDir, "*.safetensors"))
+	sort.Strings(matches)
+	for _, src := range matches {
+		name := filepath.Base(src)
+		digest := "sha256:" + name
+		dst := filepath.Join(tmpBlobDir, "sha256-"+name)
+		_ = os.Remove(dst)
+		if err := os.Symlink(src, dst); err != nil {
+			return nil, fmt.Errorf("symlink %s: %w", name, err)
+		}
+		layers = append(layers, manifest.ManifestLayer{
+			MediaType: "application/vnd.ollama.image.tensor",
+			Digest:    digest,
+			Name:      name,
+		})
+	}
+
+	mm := &manifest.ModelManifest{
+		Manifest: &manifest.Manifest{
+			SchemaVersion: 2,
+			Layers:        layers,
+		},
+		BlobDir: tmpBlobDir,
+	}
+	root := &model.Root{Manifest: mm}
+
+	m, err := base.New(root)
+	if err != nil {
+		return nil, fmt.Errorf("base.New: %w", err)
+	}
+
+	tensors := loadTensorsFromManifestPlain(root)
+	if len(tensors) == 0 {
+		return nil, fmt.Errorf("no tensors loaded from manifest")
+	}
+
+	if err := base.Weights(m)(tensors); err != nil {
+		return nil, fmt.Errorf("LoadWeights: %w", err)
+	}
+	return m, nil
+}
+
+// LoadModelByNameOrErr is the *testing.T-free counterpart of LoadModelByName.
+// It opens an ollama model from the local store by tag (e.g.
+// "gemma4:e2b-base-mlx-bf16") and returns the initialized model. The caller
+// is responsible for closing the underlying root via the returned closer.
+func LoadModelByNameOrErr(modelName string) (base.Model, func(), error) {
+	if err := mlx.CheckInit(); err != nil {
+		return nil, func() {}, fmt.Errorf("MLX not available: %w", err)
+	}
+	if modelName == "" {
+		return nil, func() {}, fmt.Errorf("model name is required")
+	}
+
+	root, err := model.Open(modelName)
+	if err != nil {
+		return nil, func() {}, fmt.Errorf("open model %q: %w", modelName, err)
+	}
+	cleanup := func() { root.Close() }
+
+	m, err := base.New(root)
+	if err != nil {
+		cleanup()
+		return nil, func() {}, fmt.Errorf("base.New(%s): %w", modelName, err)
+	}
+
+	tensors := loadTensorsFromManifestPlain(root)
+	if len(tensors) == 0 {
+		cleanup()
+		return nil, func() {}, fmt.Errorf("no tensors loaded for %q", modelName)
+	}
+
+	if err := base.Weights(m)(tensors); err != nil {
+		cleanup()
+		return nil, func() {}, fmt.Errorf("LoadWeights(%s): %w", modelName, err)
+	}
+	return m, cleanup, nil
+}
+
+// loadTensorsFromManifestPlain mirrors loadTensorsFromManifest but does not
+// require *testing.T. The two share the same key-remap algorithm so callers
+// from CLI tools and tests behave identically.
+func loadTensorsFromManifestPlain(root *model.Root) map[string]*mlx.Array {
+	rawTensors := make(map[string]*mlx.Array)
+	seen := make(map[string]bool)
+	for _, layer := range root.Manifest.GetTensorLayers("") {
+		if seen[layer.Digest] {
+			continue
+		}
+		seen[layer.Digest] = true
+		blobPath := root.Manifest.BlobPath(layer.Digest)
+		for name, arr := range mlx.Load(blobPath) {
+			rawTensors[name] = arr
+		}
+	}
+
+	scaleBaseNames := make(map[string]bool)
+	allTensors := make(map[string]*mlx.Array, len(rawTensors))
+	for name, arr := range rawTensors {
+		if strings.HasSuffix(name, ".scale") {
+			baseName := strings.TrimSuffix(name, ".scale")
+			allTensors[baseName+"_scale"] = arr
+			scaleBaseNames[baseName] = true
+		}
+	}
+	for name, arr := range rawTensors {
+		if strings.HasSuffix(name, ".scale") {
+			continue
+		}
+		if strings.HasSuffix(name, ".bias") && !strings.HasSuffix(name, ".weight_qbias") {
+			baseName := strings.TrimSuffix(name, ".bias")
+			if scaleBaseNames[baseName] {
+				allTensors[baseName+"_qbias"] = arr
+			} else {
+				allTensors[name] = arr
+			}
+		} else {
+			allTensors[name] = arr
+		}
+	}
+	return allTensors
+}

--- a/x/models/testutil/perplexity_core.go
+++ b/x/models/testutil/perplexity_core.go
@@ -1,0 +1,616 @@
+package testutil
+
+import (
+	"fmt"
+	"io"
+	"math"
+
+	"github.com/ollama/ollama/x/mlxrunner/cache"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/mlxrunner/model/base"
+)
+
+// Mode selects the perplexity scoring methodology. Different communities use
+// different conventions; this enum makes the choice explicit and lets a single
+// implementation reproduce numbers from each ecosystem.
+type Mode int
+
+const (
+	// ModeHarness reproduces EleutherAI lm-evaluation-harness' wikitext task:
+	// document-level rolling loglikelihood with context_len=1 (each window
+	// shares one token of context with the prior window). The prefix token
+	// (BOS or EOS, whichever the model has) is prepended once at document
+	// start, and every prediction position in each window is scored.
+	ModeHarness Mode = iota
+
+	// ModeLlamaCpp reproduces llama.cpp's llama-perplexity tool: non-overlapping
+	// chunks of n_ctx tokens fed as a flat stream, the first token of each
+	// chunk is replaced with BOS for the forward pass, and only the second
+	// half of each chunk is scored.
+	ModeLlamaCpp
+)
+
+func (m Mode) String() string {
+	switch m {
+	case ModeHarness:
+		return "harness"
+	case ModeLlamaCpp:
+		return "llamacpp"
+	default:
+		return fmt.Sprintf("Mode(%d)", int(m))
+	}
+}
+
+// ParseMode converts a CLI string into a Mode.
+func ParseMode(s string) (Mode, error) {
+	switch s {
+	case "harness", "":
+		return ModeHarness, nil
+	case "llamacpp":
+		return ModeLlamaCpp, nil
+	default:
+		return 0, fmt.Errorf("unknown perplexity mode %q (valid: harness, llamacpp)", s)
+	}
+}
+
+// Logger is the minimal logging surface used by the perplexity core. *log.Logger,
+// *testing.T (via an adapter), and any io.Writer-backed type can satisfy this.
+type Logger interface {
+	Logf(format string, args ...any)
+}
+
+// noopLogger discards everything.
+type noopLogger struct{}
+
+func (noopLogger) Logf(string, ...any) {}
+
+// stderrLogger writes to an io.Writer.
+type writerLogger struct {
+	w io.Writer
+}
+
+func (l writerLogger) Logf(format string, args ...any) {
+	fmt.Fprintf(l.w, format+"\n", args...)
+}
+
+// NewWriterLogger wraps an io.Writer (e.g. os.Stderr) as a Logger.
+func NewWriterLogger(w io.Writer) Logger {
+	if w == nil {
+		return noopLogger{}
+	}
+	return writerLogger{w: w}
+}
+
+// Document is a unit of corpus text to be evaluated. In ModeHarness each
+// document is processed independently with its own rolling-window pass; in
+// ModeLlamaCpp all documents are concatenated into a single token stream.
+//
+// Some corpora (notably wikitext-2-raw-v1) require dataset-specific
+// preprocessing of the model input that does NOT change the word/byte
+// counts used as denominators for word_perplexity and byte_perplexity.
+// To support that, Document distinguishes between Text (original text,
+// used for byte/word counting and as the default model input) and
+// ScoringText (optional alternative passed to the tokenizer). When
+// ScoringText is empty, Text is used unchanged.
+type Document struct {
+	// Text is the original document text, used for word and byte
+	// statistics. If TokenIDs is set, Text is only used for these
+	// denominators.
+	Text string
+
+	// ScoringText, if non-empty, is the text actually tokenized and fed
+	// to the model. Used by the wikitext task loader to apply the
+	// EleutherAI detokenizer transform without disturbing the
+	// word/byte denominators.
+	ScoringText string
+
+	// TokenIDs is the pre-tokenized form. If set it overrides Text /
+	// ScoringText for the forward-pass input. Word/byte counts still
+	// come from Text.
+	TokenIDs []int32
+}
+
+// PPLOptions configures a perplexity run.
+type PPLOptions struct {
+	// Mode selects the scoring methodology.
+	Mode Mode
+
+	// MaxLength is the per-window context length passed to the model
+	// (analogous to lm-eval-harness max_length or llama.cpp n_ctx).
+	// Defaults: 2048 for harness mode, 512 for llamacpp mode.
+	MaxLength int
+
+	// MaxDocs caps the number of documents processed (harness mode) or
+	// chunks evaluated (llamacpp mode). Zero or negative = process all.
+	MaxDocs int
+
+	// PrefixTokenID is the token prepended at document start in harness
+	// mode (typically BOS or EOS). If zero, the model tokenizer's BOS is
+	// used. Set to -1 to disable prefixing.
+	PrefixTokenID int32
+
+	// BOSSwapLlamaCpp enables the llama.cpp BOS substitution trick at the
+	// start of each chunk. Only meaningful in ModeLlamaCpp. Defaults to true
+	// when in that mode.
+	BOSSwapLlamaCpp bool
+
+	// LogEvery prints a running PPL message every N documents/chunks.
+	// Zero = use a sensible default.
+	LogEvery int
+}
+
+func (o *PPLOptions) defaultsFor() {
+	if o.MaxLength <= 0 {
+		switch o.Mode {
+		case ModeLlamaCpp:
+			o.MaxLength = 512
+		default:
+			o.MaxLength = 2048
+		}
+	}
+	if o.LogEvery == 0 {
+		o.LogEvery = 10
+	}
+}
+
+// PPLResult holds the aggregate output of a perplexity run. Per-token NLL and
+// NLL-squared sums are tracked so callers can compute confidence intervals
+// via the delta method.
+type PPLResult struct {
+	Mode Mode
+
+	TotalNLL    float64 // sum of -log P over all scored tokens
+	TotalNLL2   float64 // sum of (-log P)^2; for stderr via delta method
+	TotalTokens int     // number of scored tokens (denominator for token PPL)
+	TotalChars  int     // number of *original* characters across scored docs (for byte PPL / bpb)
+	TotalWords  int     // number of *original* words across scored docs (for word PPL)
+
+	// TokenPerplexity is exp(TotalNLL/TotalTokens). This is the
+	// "perplexity" most people mean when they say "PPL" without
+	// qualification.
+	TokenPerplexity float64
+
+	// StderrTokenPPL is the standard error of TokenPerplexity, propagated
+	// from per-token NLL variance via the delta method.
+	StderrTokenPPL float64
+
+	// WordPerplexity, BytePerplexity, and BitsPerByte are tokenizer-
+	// independent metrics computed from TotalNLL and the original
+	// (pre-tokenization) document text. Only populated when input
+	// documents include Text (or DocumentText is provided to score).
+	WordPerplexity float64
+	BytePerplexity float64
+	BitsPerByte    float64
+}
+
+// RunPerplexity is the pure entry point. It takes a loaded model, a sequence
+// of documents, and options, and returns a PPLResult plus an error. No
+// dependency on the testing package.
+func RunPerplexity(m base.Model, docs []Document, opts PPLOptions, log Logger) (PPLResult, error) {
+	if log == nil {
+		log = noopLogger{}
+	}
+	opts.defaultsFor()
+
+	// Resolve the prefix token from the tokenizer if not explicitly set.
+	if opts.PrefixTokenID == 0 {
+		if tok := m.Tokenizer(); tok != nil {
+			if bos := tok.BOS(); bos >= 0 {
+				opts.PrefixTokenID = bos
+			}
+		}
+	}
+
+	// Tokenize any documents that arrive as raw text. Prefer ScoringText
+	// (the model-facing variant) when set; fall back to Text otherwise.
+	tok := m.Tokenizer()
+	for i := range docs {
+		if len(docs[i].TokenIDs) > 0 {
+			continue
+		}
+		modelText := docs[i].ScoringText
+		if modelText == "" {
+			modelText = docs[i].Text
+		}
+		if modelText == "" {
+			continue
+		}
+		if tok == nil {
+			return PPLResult{}, fmt.Errorf("document %d has Text but model has no tokenizer", i)
+		}
+		docs[i].TokenIDs = tok.Encode(modelText, false)
+	}
+
+	switch opts.Mode {
+	case ModeHarness:
+		return runHarness(m, docs, opts, log)
+	case ModeLlamaCpp:
+		return runLlamaCpp(m, docs, opts, log)
+	default:
+		return PPLResult{}, fmt.Errorf("unknown perplexity mode: %v", opts.Mode)
+	}
+}
+
+// runHarness reproduces lm-evaluation-harness' loglikelihood_rolling: each
+// document is tokenized independently, prefixed with the model's BOS/EOS,
+// and split into a series of windows of length MaxLength. Consecutive
+// windows share `context_len=1` token of overlap. Every prediction position
+// in each window is scored. Results are aggregated across documents.
+func runHarness(m base.Model, docs []Document, opts PPLOptions, log Logger) (PPLResult, error) {
+	result := PPLResult{Mode: opts.Mode}
+
+	maxDocs := len(docs)
+	if opts.MaxDocs > 0 && opts.MaxDocs < maxDocs {
+		maxDocs = opts.MaxDocs
+	}
+
+	for i := range maxDocs {
+		doc := docs[i]
+		if len(doc.TokenIDs) == 0 {
+			continue
+		}
+
+		nll, nll2, n, err := scoreDocumentHarness(m, doc.TokenIDs, opts)
+		if err != nil {
+			return result, fmt.Errorf("doc %d: %w", i, err)
+		}
+
+		result.TotalNLL += nll
+		result.TotalNLL2 += nll2
+		result.TotalTokens += n
+		result.TotalChars += len(doc.Text)
+		result.TotalWords += countWords(doc.Text)
+
+		if (i+1)%opts.LogEvery == 0 || i == maxDocs-1 || i < 3 {
+			running := math.Exp(result.TotalNLL / float64(result.TotalTokens))
+			log.Logf("  [%d/%d] running token PPL=%.4f", i+1, maxDocs, running)
+		}
+
+		// Free intermediate tensors between docs to keep memory bounded.
+		mlx.Sweep()
+		mlx.ClearCache()
+	}
+
+	finalize(&result)
+	return result, nil
+}
+
+// scoreDocumentHarness implements lm-evaluation-harness'
+// `loglikelihood_rolling` for context_len=1, which is what the wikitext task
+// uses. The contract is the one in `lm_eval/utils.get_rolling_token_windows`:
+//
+//   - The first window's input is `[prefix, t_0, ..., t_{L-2}]` of length L
+//     (where L = min(maxLen, doc_len)). All L logits are scored against
+//     targets `[t_0, ..., t_{L-1}]`. The last logit predicts a token that is
+//     NOT in the input — that's the model's "next token after the input"
+//     distribution, evaluated against the actual next token from the doc.
+//
+//   - Each subsequent window slides forward by `pred_len = maxLen` newly
+//     scored tokens. Its input is `tokens[window_end - maxLen - 1 : window_end - 1]`
+//     (length maxLen, including 1 token of carry-over context from the prior
+//     window) and its targets are `tokens[window_end - pred_len : window_end]`.
+//     All maxLen logits are scored — every prediction has up to maxLen tokens
+//     of preceding context.
+//
+//   - The very last window of a doc has fewer new targets than `pred_len`. In
+//     that case the input is *padded backwards* into earlier doc tokens to
+//     keep the input length at maxLen, but only the last `windowPredLen` logits
+//     are scored. This is the critical detail: the prior algorithm in this
+//     file truncated the last-window input instead of padding back, which
+//     starved the early predictions of context and inflated NLL by ~13%.
+//
+// Returns (nll_sum, nll2_sum, scored_tokens).
+func scoreDocumentHarness(m base.Model, tokens []int32, opts PPLOptions) (float64, float64, int, error) {
+	if len(tokens) == 0 {
+		return 0, 0, 0, nil
+	}
+
+	maxLen := opts.MaxLength
+	predLen := maxLen // context_len=1 → pred_len = maxLen - context_len + 1 = maxLen
+
+	var (
+		totalNLL  float64
+		totalNLL2 float64
+		totalTok  int
+	)
+
+	// First window: input = [prefix] + tokens[:firstSeqLen-1], targets = tokens[:firstSeqLen]
+	firstSeqLen := min(maxLen, len(tokens))
+	var firstInput []int32
+	if opts.PrefixTokenID >= 0 {
+		firstInput = make([]int32, 0, firstSeqLen)
+		firstInput = append(firstInput, opts.PrefixTokenID)
+		firstInput = append(firstInput, tokens[:firstSeqLen-1]...)
+	} else {
+		// No prefix — can only score firstSeqLen-1 targets (positions 1..firstSeqLen-1
+		// of the input predict tokens 1..firstSeqLen-1; logit[firstSeqLen-1] would
+		// predict tokens[firstSeqLen] which may or may not exist).
+		firstInput = tokens[:firstSeqLen]
+	}
+	firstTargets := tokens[:firstSeqLen]
+	nll, nll2, scored, err := scoreLastN(m, firstInput, firstTargets, len(firstTargets))
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	totalNLL += nll
+	totalNLL2 += nll2
+	totalTok += scored
+	predicted := firstSeqLen
+	mlx.Sweep()
+	mlx.ClearCache()
+
+	// Subsequent windows.
+	for predicted < len(tokens) {
+		windowPredLen := min(len(tokens)-predicted, predLen)
+		windowEnd := predicted + windowPredLen
+
+		inputStart := max(windowEnd-maxLen-1, 0)
+		input := tokens[inputStart : windowEnd-1]
+		targets := tokens[windowEnd-windowPredLen : windowEnd]
+
+		nll, nll2, scored, err := scoreLastN(m, input, targets, len(targets))
+		if err != nil {
+			return 0, 0, 0, err
+		}
+		totalNLL += nll
+		totalNLL2 += nll2
+		totalTok += scored
+		predicted += windowPredLen
+		mlx.Sweep()
+		mlx.ClearCache()
+	}
+
+	return totalNLL, totalNLL2, totalTok, nil
+}
+
+// scoreLastN runs one forward pass on `input` and computes the negative
+// log-likelihood for the LAST `numTargets` positions. The model produces
+// logits at every input position; logit[i] is interpreted as the model's
+// distribution for the token that follows input[i] in the source sequence.
+// `targets` must contain exactly numTargets tokens, aligned so that
+// targets[k] is the prediction target for logit[inplen - numTargets + k].
+//
+// This shape (rather than "score positions [scoreFrom..N-1] of an
+// in-window slice") is what lets the caller use a back-padded window for
+// the last-window-of-doc case: input can be longer than the targets so the
+// model gets full preceding context, while only the last numTargets logits
+// contribute to the NLL.
+func scoreLastN(m base.Model, input, targets []int32, numTargets int) (float64, float64, int, error) {
+	inplen := len(input)
+	if inplen < 1 || numTargets < 1 || numTargets > inplen {
+		return 0, 0, 0, nil
+	}
+	if len(targets) != numTargets {
+		return 0, 0, 0, fmt.Errorf("scoreLastN: targets length %d != numTargets %d", len(targets), numTargets)
+	}
+
+	tokens := mlx.FromValues(input, 1, inplen)
+
+	caches := m.(interface{ NewCaches() []cache.Cache }).NewCaches()
+	// IMPORTANT: free per-window KV caches before returning. Several model
+	// implementations pin their cache k/v tensors internally so the global
+	// Sweep won't release them — without an explicit Free() they accumulate
+	// across windows and run the system out of memory long before the doc
+	// stream finishes.
+	defer func() {
+		for _, c := range caches {
+			if c != nil {
+				c.Free()
+			}
+		}
+	}()
+
+	h := m.Forward(tokens, caches)
+
+	// Slice the hidden states down to the positions we'll actually score, so
+	// the unembed step only produces logits for those rows. For typical
+	// "score every position" windows this is a no-op; for the last window of
+	// a doc with windowPredLen << inplen it's a real saving.
+	hScored := h.Slice(mlx.Slice(), mlx.Slice(inplen-numTargets, inplen), mlx.Slice())
+	mlx.Eval(hScored)
+	mlx.Pin(hScored)
+	defer mlx.Unpin(hScored)
+
+	return scoreHiddenChunked(m, hScored, targets, numTargets)
+}
+
+// scoreHiddenChunked runs the unembed + log-softmax + gather pipeline over a
+// sliced hidden-state tensor in chunks along the sequence axis, so the peak
+// per-window allocation never exceeds chunkSeqLen * vocab * 4 bytes (the
+// transient f32 logits chunk). This matters at large vocab (~250k) and full
+// 2048-token windows where the un-chunked approach materializes a ~2 GB f32
+// tensor and pushes the working set close to OOM on heavily-loaded systems.
+func scoreHiddenChunked(m base.Model, hScored *mlx.Array, targets []int32, numTargets int) (float64, float64, int, error) {
+	// Picked to keep one chunk's f32 logits well under 512 MB even at
+	// vocab=250k (256 * 250k * 4 = 256 MB). Larger chunks are faster but
+	// raise peak memory; 256 is a comfortable balance on 128 GB systems.
+	const chunkSeqLen = 256
+
+	var totalNLL, totalNLL2 float64
+
+	for k := 0; k < numTargets; k += chunkSeqLen {
+		end := min(k+chunkSeqLen, numTargets)
+		chunkLen := end - k
+
+		hChunk := hScored.Slice(mlx.Slice(), mlx.Slice(k, end), mlx.Slice())
+		logitsChunk := m.Unembed(hChunk)
+		logitsChunkF32 := logitsChunk.AsType(mlx.DTypeFloat32)
+
+		lseChunk := mlx.LogSumexpAxis(logitsChunkF32, 2, true) // [1, chunkLen, 1]
+
+		targetIDs := make([]int32, chunkLen)
+		copy(targetIDs, targets[k:end])
+		targetsArr := mlx.FromValues(targetIDs, 1, chunkLen, 1)
+
+		targetLogits := logitsChunkF32.TakeAlongAxis(targetsArr, 2) // [1, chunkLen, 1]
+		targetLogprobs := targetLogits.Subtract(lseChunk)           // [1, chunkLen, 1]
+
+		flat := targetLogprobs.Squeeze(2).Squeeze(0).Negative() // [chunkLen]
+		nllSum := flat.SumAxis(0, false)
+		nll2Sum := flat.Multiply(flat).SumAxis(0, false)
+
+		nllF32 := nllSum.AsType(mlx.DTypeFloat32)
+		nll2F32 := nll2Sum.AsType(mlx.DTypeFloat32)
+		mlx.Eval(nllF32, nll2F32)
+
+		totalNLL += float64(nllF32.Floats()[0])
+		totalNLL2 += float64(nll2F32.Floats()[0])
+
+		// Free the chunk's transient f32 logits + LSE before the next chunk.
+		mlx.Sweep()
+		mlx.ClearCache()
+	}
+
+	return totalNLL, totalNLL2, numTargets, nil
+}
+
+// runLlamaCpp implements llama-perplexity's algorithm: concatenate all docs
+// into one flat token stream, split into non-overlapping chunks of MaxLength,
+// substitute BOS at the start of each chunk for the forward pass, and score
+// only the second half of each chunk.
+func runLlamaCpp(m base.Model, docs []Document, opts PPLOptions, log Logger) (PPLResult, error) {
+	result := PPLResult{Mode: opts.Mode}
+
+	// Concatenate.
+	var stream []int32
+	for _, d := range docs {
+		stream = append(stream, d.TokenIDs...)
+		result.TotalChars += len(d.Text)
+		result.TotalWords += countWords(d.Text)
+	}
+
+	chunkSize := opts.MaxLength
+	maxChunks := len(stream) / chunkSize
+	if opts.MaxDocs > 0 && opts.MaxDocs < maxChunks {
+		maxChunks = opts.MaxDocs
+	}
+	if maxChunks == 0 {
+		return result, fmt.Errorf("not enough tokens for one chunk (need %d, have %d)", chunkSize, len(stream))
+	}
+
+	bosID := opts.PrefixTokenID
+	if !opts.BOSSwapLlamaCpp {
+		bosID = -1
+	}
+
+	for i := range maxChunks {
+		chunk := stream[i*chunkSize : (i+1)*chunkSize]
+
+		// Build forward-pass input with BOS at position 0 if requested.
+		// Original chunk is preserved for the scoring targets.
+		var window []int32
+		if bosID >= 0 {
+			window = make([]int32, chunkSize)
+			copy(window, chunk)
+			window[0] = bosID
+		} else {
+			window = chunk
+		}
+
+		// Score the second half: positions [chunkSize/2..chunkSize-1]
+		// using ORIGINAL chunk as the target source.
+		first := chunkSize / 2
+		nll, nll2, scored, err := scoreSecondHalf(m, window, chunk, first)
+		if err != nil {
+			return result, fmt.Errorf("chunk %d: %w", i, err)
+		}
+		result.TotalNLL += nll
+		result.TotalNLL2 += nll2
+		result.TotalTokens += scored
+
+		if (i+1)%opts.LogEvery == 0 || i == maxChunks-1 || i < 3 {
+			running := math.Exp(result.TotalNLL / float64(result.TotalTokens))
+			log.Logf("  [%d/%d] running token PPL=%.4f", i+1, maxChunks, running)
+		}
+		mlx.Sweep()
+		mlx.ClearCache()
+	}
+
+	finalize(&result)
+	return result, nil
+}
+
+// scoreSecondHalf is the llama-perplexity scoring kernel: predict
+// chunk[first..n-1] using logits at window[first-1..n-2]. The window is the
+// (possibly BOS-substituted) input to the forward pass; chunk is the original
+// untouched targets.
+func scoreSecondHalf(m base.Model, window, chunk []int32, first int) (float64, float64, int, error) {
+	n := len(window)
+	if first < 1 || first >= n {
+		return 0, 0, 0, fmt.Errorf("invalid first=%d for window of length %d", first, n)
+	}
+
+	tokens := mlx.FromValues(window, 1, n)
+	caches := m.(interface{ NewCaches() []cache.Cache }).NewCaches()
+	defer func() {
+		for _, c := range caches {
+			if c != nil {
+				c.Free()
+			}
+		}
+	}()
+	h := m.Forward(tokens, caches)
+
+	// Slice hidden states to the scored positions, then chunk the
+	// unembed/log-softmax/gather pipeline. See scoreHiddenChunked for the
+	// memory rationale.
+	numScored := n - first
+	hScored := h.Slice(mlx.Slice(), mlx.Slice(first-1, n-1), mlx.Slice())
+	mlx.Eval(hScored)
+	mlx.Pin(hScored)
+	defer mlx.Unpin(hScored)
+
+	return scoreHiddenChunked(m, hScored, chunk[first:n], numScored)
+}
+
+// finalize computes the aggregate metrics from the running totals.
+//
+//	token PPL = exp(NLL_total / N_tokens)
+//	stderr_PPL = stderr_NLL * PPL  via delta method
+//	word PPL = exp(NLL_total / N_words)
+//	byte PPL = exp(NLL_total / N_bytes)
+//	bits/byte = (NLL_total / N_bytes) / ln(2)
+func finalize(r *PPLResult) {
+	if r.TotalTokens > 1 {
+		meanNLL := r.TotalNLL / float64(r.TotalTokens)
+		r.TokenPerplexity = math.Exp(meanNLL)
+		varNLL := r.TotalNLL2/float64(r.TotalTokens) - meanNLL*meanNLL
+		if varNLL > 0 {
+			stderrNLL := math.Sqrt(varNLL / float64(r.TotalTokens-1))
+			r.StderrTokenPPL = stderrNLL * r.TokenPerplexity
+		}
+	}
+	if r.TotalWords > 0 {
+		r.WordPerplexity = math.Exp(r.TotalNLL / float64(r.TotalWords))
+	}
+	if r.TotalChars > 0 {
+		r.BytePerplexity = math.Exp(r.TotalNLL / float64(r.TotalChars))
+		r.BitsPerByte = (r.TotalNLL / float64(r.TotalChars)) / math.Ln2
+	}
+}
+
+// countWords counts whitespace-separated chunks in s, matching Python's
+// `re.split(r"\s+", s)` semantics. This is what
+// lm-evaluation-harness/preprocess_wikitext uses for word_perplexity:
+//
+//	_words = len(re.split(r"\s+", doc["page"]))
+//
+// Note: Python's re.split with a pattern includes an empty string at the
+// start of the result if the input begins with whitespace, and at the end
+// if it ends with whitespace. We replicate that exactly so word counts match.
+func countWords(s string) int {
+	// re.split with `\s+` produces (number of `\s+` runs) + 1 chunks,
+	// including empty strings at the start/end when s begins or ends
+	// with whitespace. We replicate that exactly: start at 1, increment
+	// once per whitespace run.
+	count := 1
+	inWS := false
+	for _, r := range s {
+		ws := r == ' ' || r == '\t' || r == '\n' || r == '\r' || r == '\v' || r == '\f'
+		if ws && !inWS {
+			count++
+		}
+		inWS = ws
+	}
+	return count
+}

--- a/x/models/testutil/perplexity_core.go
+++ b/x/models/testutil/perplexity_core.go
@@ -1,0 +1,632 @@
+package testutil
+
+import (
+	"fmt"
+	"io"
+	"math"
+
+	"github.com/ollama/ollama/x/mlxrunner/batch"
+	"github.com/ollama/ollama/x/mlxrunner/cache"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/mlxrunner/model/base"
+)
+
+// Mode selects the perplexity scoring methodology. Different communities use
+// different conventions; this enum makes the choice explicit and lets a single
+// implementation reproduce numbers from each ecosystem.
+type Mode int
+
+const (
+	// ModeHarness reproduces EleutherAI lm-evaluation-harness' wikitext task:
+	// document-level rolling loglikelihood with context_len=1 (each window
+	// shares one token of context with the prior window). The prefix token
+	// (BOS or EOS, whichever the model has) is prepended once at document
+	// start, and every prediction position in each window is scored.
+	ModeHarness Mode = iota
+
+	// ModeWindow scores a concatenated token stream in fixed windows: non-overlapping
+	// chunks of n_ctx tokens fed as a flat stream, the first token of each
+	// chunk is replaced with BOS for the forward pass, and only the second
+	// half of each chunk is scored.
+	ModeWindow
+)
+
+func (m Mode) String() string {
+	switch m {
+	case ModeHarness:
+		return "harness"
+	case ModeWindow:
+		return "window"
+	default:
+		return fmt.Sprintf("Mode(%d)", int(m))
+	}
+}
+
+// ParseMode converts a CLI string into a Mode.
+func ParseMode(s string) (Mode, error) {
+	switch s {
+	case "harness", "":
+		return ModeHarness, nil
+	case "window":
+		return ModeWindow, nil
+	default:
+		return 0, fmt.Errorf("unknown perplexity mode %q (valid: harness, window)", s)
+	}
+}
+
+// Logger is the minimal logging surface used by the perplexity core. *log.Logger,
+// *testing.T (via an adapter), and any io.Writer-backed type can satisfy this.
+type Logger interface {
+	Logf(format string, args ...any)
+}
+
+// noopLogger discards everything.
+type noopLogger struct{}
+
+func (noopLogger) Logf(string, ...any) {}
+
+// stderrLogger writes to an io.Writer.
+type writerLogger struct {
+	w io.Writer
+}
+
+func (l writerLogger) Logf(format string, args ...any) {
+	fmt.Fprintf(l.w, format+"\n", args...)
+}
+
+// NewWriterLogger wraps an io.Writer (e.g. os.Stderr) as a Logger.
+func NewWriterLogger(w io.Writer) Logger {
+	if w == nil {
+		return noopLogger{}
+	}
+	return writerLogger{w: w}
+}
+
+// Document is a unit of corpus text to be evaluated. In ModeHarness each
+// document is processed independently with its own rolling-window pass; in
+// ModeWindow all documents are concatenated into a single token stream.
+//
+// Some corpora (notably wikitext-2-raw-v1) require dataset-specific
+// preprocessing of the model input that does NOT change the word/byte
+// counts used as denominators for word_perplexity and byte_perplexity.
+// To support that, Document distinguishes between Text (original text,
+// used for byte/word counting and as the default model input) and
+// ScoringText (optional alternative passed to the tokenizer). When
+// ScoringText is empty, Text is used unchanged.
+type Document struct {
+	// Text is the original document text, used for word and byte
+	// statistics. If TokenIDs is set, Text is only used for these
+	// denominators.
+	Text string
+
+	// ScoringText, if non-empty, is the text actually tokenized and fed
+	// to the model. Used by the wikitext task loader to apply the
+	// EleutherAI detokenizer transform without disturbing the
+	// word/byte denominators.
+	ScoringText string
+
+	// TokenIDs is the pre-tokenized form. If set it overrides Text /
+	// ScoringText for the forward-pass input. Word/byte counts still
+	// come from Text.
+	TokenIDs []int32
+}
+
+// PPLOptions configures a perplexity run.
+type PPLOptions struct {
+	// Mode selects the scoring methodology.
+	Mode Mode
+
+	// MaxLength is the per-window context length passed to the model
+	// (the per-chunk context length).
+	// Defaults: 2048 for harness mode, 512 for window mode.
+	MaxLength int
+
+	// MaxDocs caps the number of documents processed (harness mode) or
+	// chunks evaluated (window mode). Zero or negative = process all.
+	MaxDocs int
+
+	// PrefixTokenID is the token prepended at document start in harness
+	// mode (typically BOS or EOS). If zero, the model tokenizer's BOS is
+	// used. Set to -1 to disable prefixing.
+	PrefixTokenID int32
+
+	// BOSSubstitution enables BOS substitution at the
+	// start of each chunk. Only meaningful in ModeWindow. Defaults to true
+	// when in that mode.
+	BOSSubstitution bool
+
+	// LogEvery prints a running PPL message every N documents/chunks.
+	// Zero = use a sensible default.
+	LogEvery int
+}
+
+func (o *PPLOptions) defaultsFor() {
+	if o.MaxLength <= 0 {
+		switch o.Mode {
+		case ModeWindow:
+			o.MaxLength = 512
+		default:
+			o.MaxLength = 2048
+		}
+	}
+	if o.LogEvery == 0 {
+		o.LogEvery = 10
+	}
+}
+
+// PPLResult holds the aggregate output of a perplexity run. Per-token NLL and
+// NLL-squared sums are tracked so callers can compute confidence intervals
+// via the delta method.
+type PPLResult struct {
+	Mode Mode
+
+	TotalNLL    float64 // sum of -log P over all scored tokens
+	TotalNLL2   float64 // sum of (-log P)^2; for stderr via delta method
+	TotalTokens int     // number of scored tokens (denominator for token PPL)
+	TotalChars  int     // number of *original* characters across scored docs (for byte PPL / bpb)
+	TotalWords  int     // number of *original* words across scored docs (for word PPL)
+
+	// TokenPerplexity is exp(TotalNLL/TotalTokens). This is the
+	// "perplexity" most people mean when they say "PPL" without
+	// qualification.
+	TokenPerplexity float64
+
+	// StderrTokenPPL is the standard error of TokenPerplexity, propagated
+	// from per-token NLL variance via the delta method.
+	StderrTokenPPL float64
+
+	// WordPerplexity, BytePerplexity, and BitsPerByte are tokenizer-
+	// independent metrics computed from TotalNLL and the original
+	// (pre-tokenization) document text. Only populated when input
+	// documents include Text (or DocumentText is provided to score).
+	WordPerplexity float64
+	BytePerplexity float64
+	BitsPerByte    float64
+}
+
+// RunPerplexity is the pure entry point. It takes a loaded model, a sequence
+// of documents, and options, and returns a PPLResult plus an error. No
+// dependency on the testing package.
+func RunPerplexity(m base.Model, docs []Document, opts PPLOptions, log Logger) (PPLResult, error) {
+	if log == nil {
+		log = noopLogger{}
+	}
+	opts.defaultsFor()
+
+	// Resolve the prefix token from the tokenizer if not explicitly set.
+	if opts.PrefixTokenID == 0 {
+		if tok := m.Tokenizer(); tok != nil {
+			if bos := tok.BOS(); bos >= 0 {
+				opts.PrefixTokenID = bos
+			}
+		}
+	}
+
+	// Tokenize any documents that arrive as raw text. Prefer ScoringText
+	// (the model-facing variant) when set; fall back to Text otherwise.
+	tok := m.Tokenizer()
+	for i := range docs {
+		if len(docs[i].TokenIDs) > 0 {
+			continue
+		}
+		modelText := docs[i].ScoringText
+		if modelText == "" {
+			modelText = docs[i].Text
+		}
+		if modelText == "" {
+			continue
+		}
+		if tok == nil {
+			return PPLResult{}, fmt.Errorf("document %d has Text but model has no tokenizer", i)
+		}
+		docs[i].TokenIDs = tok.Encode(modelText, false)
+	}
+
+	switch opts.Mode {
+	case ModeHarness:
+		return runHarness(m, docs, opts, log)
+	case ModeWindow:
+		return runWindow(m, docs, opts, log)
+	default:
+		return PPLResult{}, fmt.Errorf("unknown perplexity mode: %v", opts.Mode)
+	}
+}
+
+// runHarness reproduces lm-evaluation-harness' loglikelihood_rolling: each
+// document is tokenized independently, prefixed with the model's BOS/EOS,
+// and split into a series of windows of length MaxLength. Consecutive
+// windows share `context_len=1` token of overlap. Every prediction position
+// in each window is scored. Results are aggregated across documents.
+func runHarness(m base.Model, docs []Document, opts PPLOptions, log Logger) (PPLResult, error) {
+	result := PPLResult{Mode: opts.Mode}
+
+	maxDocs := len(docs)
+	if opts.MaxDocs > 0 && opts.MaxDocs < maxDocs {
+		maxDocs = opts.MaxDocs
+	}
+
+	for i := range maxDocs {
+		doc := docs[i]
+		if len(doc.TokenIDs) == 0 {
+			continue
+		}
+
+		nll, nll2, n, err := scoreDocumentHarness(m, doc.TokenIDs, opts)
+		if err != nil {
+			return result, fmt.Errorf("doc %d: %w", i, err)
+		}
+
+		result.TotalNLL += nll
+		result.TotalNLL2 += nll2
+		result.TotalTokens += n
+		result.TotalChars += len(doc.Text)
+		result.TotalWords += countWords(doc.Text)
+
+		if (i+1)%opts.LogEvery == 0 || i == maxDocs-1 || i < 3 {
+			running := math.Exp(result.TotalNLL / float64(result.TotalTokens))
+			log.Logf("  [%d/%d] running token PPL=%.4f", i+1, maxDocs, running)
+		}
+
+		// Free intermediate tensors between docs to keep memory bounded.
+		mlx.Sweep()
+		mlx.ClearCache()
+	}
+
+	finalize(&result)
+	return result, nil
+}
+
+// scoreDocumentHarness implements lm-evaluation-harness'
+// `loglikelihood_rolling` for context_len=1, which is what the wikitext task
+// uses. The contract is the one in `lm_eval/utils.get_rolling_token_windows`:
+//
+//   - The first window's input is `[prefix, t_0, ..., t_{L-2}]` of length L
+//     (where L = min(maxLen, doc_len)). All L logits are scored against
+//     targets `[t_0, ..., t_{L-1}]`. The last logit predicts a token that is
+//     NOT in the input — that's the model's "next token after the input"
+//     distribution, evaluated against the actual next token from the doc.
+//
+//   - Each subsequent window slides forward by `pred_len = maxLen` newly
+//     scored tokens. Its input is `tokens[window_end - maxLen - 1 : window_end - 1]`
+//     (length maxLen, including 1 token of carry-over context from the prior
+//     window) and its targets are `tokens[window_end - pred_len : window_end]`.
+//     All maxLen logits are scored — every prediction has up to maxLen tokens
+//     of preceding context.
+//
+//   - The very last window of a doc has fewer new targets than `pred_len`. In
+//     that case the input is *padded backwards* into earlier doc tokens to
+//     keep the input length at maxLen, but only the last `windowPredLen` logits
+//     are scored. This is the critical detail: the prior algorithm in this
+//     file truncated the last-window input instead of padding back, which
+//     starved the early predictions of context and inflated NLL by ~13%.
+//
+// Returns (nll_sum, nll2_sum, scored_tokens).
+func scoreDocumentHarness(m base.Model, tokens []int32, opts PPLOptions) (float64, float64, int, error) {
+	if len(tokens) == 0 {
+		return 0, 0, 0, nil
+	}
+
+	maxLen := opts.MaxLength
+	predLen := maxLen // context_len=1 → pred_len = maxLen - context_len + 1 = maxLen
+
+	var (
+		totalNLL  float64
+		totalNLL2 float64
+		totalTok  int
+	)
+
+	// First window: input = [prefix] + tokens[:firstSeqLen-1], targets = tokens[:firstSeqLen]
+	firstSeqLen := min(maxLen, len(tokens))
+	var firstInput []int32
+	if opts.PrefixTokenID >= 0 {
+		firstInput = make([]int32, 0, firstSeqLen)
+		firstInput = append(firstInput, opts.PrefixTokenID)
+		firstInput = append(firstInput, tokens[:firstSeqLen-1]...)
+	} else {
+		// No prefix — can only score firstSeqLen-1 targets (positions 1..firstSeqLen-1
+		// of the input predict tokens 1..firstSeqLen-1; logit[firstSeqLen-1] would
+		// predict tokens[firstSeqLen] which may or may not exist).
+		firstInput = tokens[:firstSeqLen]
+	}
+	firstTargets := tokens[:firstSeqLen]
+	nll, nll2, scored, err := scoreLastN(m, firstInput, firstTargets, len(firstTargets))
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	totalNLL += nll
+	totalNLL2 += nll2
+	totalTok += scored
+	predicted := firstSeqLen
+	mlx.Sweep()
+	mlx.ClearCache()
+
+	// Subsequent windows.
+	for predicted < len(tokens) {
+		windowPredLen := min(len(tokens)-predicted, predLen)
+		windowEnd := predicted + windowPredLen
+
+		inputStart := max(windowEnd-maxLen-1, 0)
+		input := tokens[inputStart : windowEnd-1]
+		targets := tokens[windowEnd-windowPredLen : windowEnd]
+
+		nll, nll2, scored, err := scoreLastN(m, input, targets, len(targets))
+		if err != nil {
+			return 0, 0, 0, err
+		}
+		totalNLL += nll
+		totalNLL2 += nll2
+		totalTok += scored
+		predicted += windowPredLen
+		mlx.Sweep()
+		mlx.ClearCache()
+	}
+
+	return totalNLL, totalNLL2, totalTok, nil
+}
+
+// scoreLastN runs one forward pass on `input` and computes the negative
+// log-likelihood for the LAST `numTargets` positions. The model produces
+// logits at every input position; logit[i] is interpreted as the model's
+// distribution for the token that follows input[i] in the source sequence.
+// `targets` must contain exactly numTargets tokens, aligned so that
+// targets[k] is the prediction target for logit[inplen - numTargets + k].
+//
+// This shape (rather than "score positions [scoreFrom..N-1] of an
+// in-window slice") is what lets the caller use a back-padded window for
+// the last-window-of-doc case: input can be longer than the targets so the
+// model gets full preceding context, while only the last numTargets logits
+// contribute to the NLL.
+func scoreLastN(m base.Model, input, targets []int32, numTargets int) (float64, float64, int, error) {
+	inplen := len(input)
+	if inplen < 1 || numTargets < 1 || numTargets > inplen {
+		return 0, 0, 0, nil
+	}
+	if len(targets) != numTargets {
+		return 0, 0, 0, fmt.Errorf("scoreLastN: targets length %d != numTargets %d", len(targets), numTargets)
+	}
+
+	tokens := mlx.FromValues(input, 1, inplen)
+
+	caches := m.(interface{ NewCaches() []cache.Cache }).NewCaches()
+	// IMPORTANT: free per-window KV caches before returning. Several model
+	// implementations pin their cache k/v tensors internally so the global
+	// Sweep won't release them — without an explicit Free() they accumulate
+	// across windows and run the system out of memory long before the doc
+	// stream finishes.
+	defer func() {
+		for _, c := range caches {
+			if c != nil {
+				c.Free()
+			}
+		}
+	}()
+
+	h, _ := m.Forward(&batch.Batch{
+		InputIDs:     tokens,
+		SeqOffsets:   []int32{0},
+		SeqQueryLens: []int32{int32(inplen)},
+	}, caches)
+
+	// Slice the hidden states down to the positions we'll actually score, so
+	// the unembed step only produces logits for those rows. For typical
+	// "score every position" windows this is a no-op; for the last window of
+	// a doc with windowPredLen << inplen it's a real saving.
+	hScored := h.Slice(mlx.Slice(), mlx.Slice(inplen-numTargets, inplen), mlx.Slice())
+	mlx.Eval(hScored)
+	mlx.Pin(hScored)
+	defer mlx.Unpin(hScored)
+	// Forward is lazy, and every intermediate array created while building the
+	// graph remains registered until Sweep. Once the scored hidden state is
+	// materialized and pinned, none of those handles are needed. Release them
+	// before unembedding the first chunk, whose f32 logits can otherwise overlap
+	// the entire forward working set and exhaust unified memory.
+	mlx.Sweep()
+
+	return scoreHiddenChunked(m, hScored, targets, numTargets)
+}
+
+// scoreHiddenChunked runs the unembed + log-softmax + gather pipeline over a
+// sliced hidden-state tensor in chunks along the sequence axis, so the peak
+// per-window allocation never exceeds chunkSeqLen * vocab * 4 bytes (the
+// transient f32 logits chunk). This matters at large vocab (~250k) and full
+// 2048-token windows where the un-chunked approach materializes a ~2 GB f32
+// tensor and pushes the working set close to OOM on heavily-loaded systems.
+func scoreHiddenChunked(m base.Model, hScored *mlx.Array, targets []int32, numTargets int) (float64, float64, int, error) {
+	// Picked to keep one chunk's f32 logits well under 512 MB even at
+	// vocab=250k (256 * 250k * 4 = 256 MB). Larger chunks are faster but
+	// raise peak memory; 256 is a comfortable balance on 128 GB systems.
+	const chunkSeqLen = 256
+
+	var totalNLL, totalNLL2 float64
+
+	for k := 0; k < numTargets; k += chunkSeqLen {
+		end := min(k+chunkSeqLen, numTargets)
+		chunkLen := end - k
+
+		hChunk := hScored.Slice(mlx.Slice(), mlx.Slice(k, end), mlx.Slice())
+		logitsChunk := m.Unembed(hChunk)
+		logitsChunkF32 := logitsChunk.AsType(mlx.DTypeFloat32)
+
+		lseChunk := mlx.LogSumexpAxis(logitsChunkF32, 2, true) // [1, chunkLen, 1]
+
+		targetIDs := make([]int32, chunkLen)
+		copy(targetIDs, targets[k:end])
+		targetsArr := mlx.FromValues(targetIDs, 1, chunkLen, 1)
+
+		targetLogits := logitsChunkF32.TakeAlongAxis(targetsArr, 2) // [1, chunkLen, 1]
+		targetLogprobs := targetLogits.Subtract(lseChunk)           // [1, chunkLen, 1]
+
+		flat := targetLogprobs.Squeeze(2).Squeeze(0).Negative() // [chunkLen]
+		nllSum := flat.SumAxis(0, false)
+		nll2Sum := flat.Multiply(flat).SumAxis(0, false)
+
+		nllF32 := nllSum.AsType(mlx.DTypeFloat32)
+		nll2F32 := nll2Sum.AsType(mlx.DTypeFloat32)
+		mlx.Eval(nllF32, nll2F32)
+
+		totalNLL += float64(nllF32.Floats()[0])
+		totalNLL2 += float64(nll2F32.Floats()[0])
+
+		// Free the chunk's transient f32 logits + LSE before the next chunk.
+		mlx.Sweep()
+		mlx.ClearCache()
+	}
+
+	return totalNLL, totalNLL2, numTargets, nil
+}
+
+// runWindow implements the fixed-window methodology: concatenate all docs
+// into one flat token stream, split into non-overlapping chunks of MaxLength,
+// substitute BOS at the start of each chunk for the forward pass, and score
+// only the second half of each chunk.
+func runWindow(m base.Model, docs []Document, opts PPLOptions, log Logger) (PPLResult, error) {
+	result := PPLResult{Mode: opts.Mode}
+
+	// Concatenate.
+	var stream []int32
+	for _, d := range docs {
+		stream = append(stream, d.TokenIDs...)
+		result.TotalChars += len(d.Text)
+		result.TotalWords += countWords(d.Text)
+	}
+
+	chunkSize := opts.MaxLength
+	maxChunks := len(stream) / chunkSize
+	if opts.MaxDocs > 0 && opts.MaxDocs < maxChunks {
+		maxChunks = opts.MaxDocs
+	}
+	if maxChunks == 0 {
+		return result, fmt.Errorf("not enough tokens for one chunk (need %d, have %d)", chunkSize, len(stream))
+	}
+
+	bosID := opts.PrefixTokenID
+	if !opts.BOSSubstitution {
+		bosID = -1
+	}
+
+	for i := range maxChunks {
+		chunk := stream[i*chunkSize : (i+1)*chunkSize]
+
+		// Build forward-pass input with BOS at position 0 if requested.
+		// Original chunk is preserved for the scoring targets.
+		var window []int32
+		if bosID >= 0 {
+			window = make([]int32, chunkSize)
+			copy(window, chunk)
+			window[0] = bosID
+		} else {
+			window = chunk
+		}
+
+		// Score the second half: positions [chunkSize/2..chunkSize-1]
+		// using ORIGINAL chunk as the target source.
+		first := chunkSize / 2
+		nll, nll2, scored, err := scoreSecondHalf(m, window, chunk, first)
+		if err != nil {
+			return result, fmt.Errorf("chunk %d: %w", i, err)
+		}
+		result.TotalNLL += nll
+		result.TotalNLL2 += nll2
+		result.TotalTokens += scored
+
+		if (i+1)%opts.LogEvery == 0 || i == maxChunks-1 || i < 3 {
+			running := math.Exp(result.TotalNLL / float64(result.TotalTokens))
+			log.Logf("  [%d/%d] running token PPL=%.4f", i+1, maxChunks, running)
+		}
+		mlx.Sweep()
+		mlx.ClearCache()
+	}
+
+	finalize(&result)
+	return result, nil
+}
+
+// scoreSecondHalf is the window-mode scoring kernel: predict
+// chunk[first..n-1] using logits at window[first-1..n-2]. The window is the
+// (possibly BOS-substituted) input to the forward pass; chunk is the original
+// untouched targets.
+func scoreSecondHalf(m base.Model, window, chunk []int32, first int) (float64, float64, int, error) {
+	n := len(window)
+	if first < 1 || first >= n {
+		return 0, 0, 0, fmt.Errorf("invalid first=%d for window of length %d", first, n)
+	}
+
+	tokens := mlx.FromValues(window, 1, n)
+	caches := m.(interface{ NewCaches() []cache.Cache }).NewCaches()
+	defer func() {
+		for _, c := range caches {
+			if c != nil {
+				c.Free()
+			}
+		}
+	}()
+	h, _ := m.Forward(&batch.Batch{
+		InputIDs:     tokens,
+		SeqOffsets:   []int32{0},
+		SeqQueryLens: []int32{int32(n)},
+	}, caches)
+
+	// Slice hidden states to the scored positions, then chunk the
+	// unembed/log-softmax/gather pipeline. See scoreHiddenChunked for the
+	// memory rationale.
+	numScored := n - first
+	hScored := h.Slice(mlx.Slice(), mlx.Slice(first-1, n-1), mlx.Slice())
+	mlx.Eval(hScored)
+	mlx.Pin(hScored)
+	defer mlx.Unpin(hScored)
+	mlx.Sweep()
+
+	return scoreHiddenChunked(m, hScored, chunk[first:n], numScored)
+}
+
+// finalize computes the aggregate metrics from the running totals.
+//
+//	token PPL = exp(NLL_total / N_tokens)
+//	stderr_PPL = stderr_NLL * PPL  via delta method
+//	word PPL = exp(NLL_total / N_words)
+//	byte PPL = exp(NLL_total / N_bytes)
+//	bits/byte = (NLL_total / N_bytes) / ln(2)
+func finalize(r *PPLResult) {
+	if r.TotalTokens > 1 {
+		meanNLL := r.TotalNLL / float64(r.TotalTokens)
+		r.TokenPerplexity = math.Exp(meanNLL)
+		varNLL := r.TotalNLL2/float64(r.TotalTokens) - meanNLL*meanNLL
+		if varNLL > 0 {
+			stderrNLL := math.Sqrt(varNLL / float64(r.TotalTokens-1))
+			r.StderrTokenPPL = stderrNLL * r.TokenPerplexity
+		}
+	}
+	if r.TotalWords > 0 {
+		r.WordPerplexity = math.Exp(r.TotalNLL / float64(r.TotalWords))
+	}
+	if r.TotalChars > 0 {
+		r.BytePerplexity = math.Exp(r.TotalNLL / float64(r.TotalChars))
+		r.BitsPerByte = (r.TotalNLL / float64(r.TotalChars)) / math.Ln2
+	}
+}
+
+// countWords counts whitespace-separated chunks in s, matching Python's
+// `re.split(r"\s+", s)` semantics. This is what
+// lm-evaluation-harness/preprocess_wikitext uses for word_perplexity:
+//
+//	_words = len(re.split(r"\s+", doc["page"]))
+//
+// Note: Python's re.split with a pattern includes an empty string at the
+// start of the result if the input begins with whitespace, and at the end
+// if it ends with whitespace. We replicate that exactly so word counts match.
+func countWords(s string) int {
+	// re.split with `\s+` produces (number of `\s+` runs) + 1 chunks,
+	// including empty strings at the start/end when s begins or ends
+	// with whitespace. We replicate that exactly: start at 1, increment
+	// once per whitespace run.
+	count := 1
+	inWS := false
+	for _, r := range s {
+		ws := r == ' ' || r == '\t' || r == '\n' || r == '\r' || r == '\v' || r == '\f'
+		if ws && !inWS {
+			count++
+		}
+		inWS = ws
+	}
+	return count
+}

--- a/x/models/testutil/perplexity_memory_test.go
+++ b/x/models/testutil/perplexity_memory_test.go
@@ -1,0 +1,78 @@
+package testutil
+
+import (
+	"testing"
+
+	"github.com/ollama/ollama/x/internal/mlxtest"
+	"github.com/ollama/ollama/x/mlxrunner/batch"
+	"github.com/ollama/ollama/x/mlxrunner/cache"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/tokenizer"
+)
+
+type perplexitySweepProbe struct {
+	forwardScratch       *mlx.Array
+	scratchLiveAtUnembed bool
+}
+
+func (*perplexitySweepProbe) LoadWeights(map[string]*mlx.Array) error { return nil }
+func (*perplexitySweepProbe) NewCaches() []cache.Cache                { return nil }
+func (*perplexitySweepProbe) Tokenizer() *tokenizer.Tokenizer         { return nil }
+func (*perplexitySweepProbe) MaxContextLength() int                   { return 32 }
+
+func (m *perplexitySweepProbe) Forward(b *batch.Batch, _ []cache.Cache) (*mlx.Array, *mlx.Array) {
+	length := b.InputIDs.Dim(1)
+	m.forwardScratch = mlx.Zeros(mlx.DTypeFloat32, 1, length, 4)
+	hidden := mlx.AddScalar(m.forwardScratch, 1)
+	return hidden, hidden
+}
+
+func (m *perplexitySweepProbe) Unembed(x *mlx.Array) *mlx.Array {
+	m.scratchLiveAtUnembed = m.forwardScratch.Valid()
+	return mlx.Zeros(mlx.DTypeFloat32, 1, x.Dim(1), 8)
+}
+
+func TestPerplexitySweepsForwardBeforeUnembed(t *testing.T) {
+	mlxtest.Setup(t)
+	if mlx.GPUIsAvailable() {
+		mlx.SetDefaultDeviceGPU()
+	}
+	t.Cleanup(func() {
+		mlx.Sweep()
+		mlx.ClearCache()
+	})
+
+	tests := []struct {
+		name  string
+		score func(*perplexitySweepProbe) error
+	}{
+		{
+			name: "harness",
+			score: func(m *perplexitySweepProbe) error {
+				_, _, _, err := scoreLastN(m, []int32{1, 2, 3, 4}, []int32{1, 2, 3, 4}, 4)
+				return err
+			},
+		},
+		{
+			name: "window",
+			score: func(m *perplexitySweepProbe) error {
+				_, _, _, err := scoreSecondHalf(m, []int32{1, 2, 3, 4}, []int32{1, 2, 3, 4}, 2)
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &perplexitySweepProbe{}
+			if err := tt.score(m); err != nil {
+				t.Fatal(err)
+			}
+			if m.scratchLiveAtUnembed {
+				t.Fatal("forward scratch remained live when unembed started")
+			}
+			mlx.Sweep()
+			mlx.ClearCache()
+		})
+	}
+}

--- a/x/models/testutil/testutil.go
+++ b/x/models/testutil/testutil.go
@@ -1,0 +1,573 @@
+// Package testutil provides reusable test utilities for validating MLX model
+// implementations against Python reference outputs.
+//
+// Typical workflow:
+//  1. Generate reference activations with x/models/scripts/dump_activations.py
+//  2. Load reference data with LoadReference
+//  3. Load model with LoadModelFromDir (BF16) or LoadModelByName (quantized)
+//  4. Compare layer-by-layer with CompareArrays or CompareManyArrays
+package testutil
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/ollama/ollama/x/imagegen/manifest"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/mlxrunner/model"
+	"github.com/ollama/ollama/x/mlxrunner/model/base"
+)
+
+// SkipIfNoMLX skips the test if the MLX dynamic library is not available.
+// Centralizes the pattern currently duplicated across multiple test files.
+func SkipIfNoMLX(t *testing.T) {
+	t.Helper()
+	if err := mlx.CheckInit(); err != nil {
+		t.Skipf("MLX not available: %v", err)
+	}
+}
+
+// DefaultRefDir returns /tmp/ollama_ref/<model>/ which matches the default
+// output location of dump_activations.py. Override with OLLAMA_REF_DIR env var.
+func DefaultRefDir(model string) string {
+	if dir := os.Getenv("OLLAMA_REF_DIR"); dir != "" {
+		return filepath.Join(dir, model)
+	}
+	return filepath.Join("/tmp", "ollama_ref", model)
+}
+
+// ModelDir returns a model directory path from an env var or default path.
+// Skips the test if the directory does not exist.
+func ModelDir(t *testing.T, envVar, defaultPath string) string {
+	t.Helper()
+	dir := os.Getenv(envVar)
+	if dir == "" {
+		dir = defaultPath
+		if strings.HasPrefix(dir, "~/") {
+			home, _ := os.UserHomeDir()
+			dir = filepath.Join(home, dir[2:])
+		}
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Skipf("model directory not available (%s=%s): %v", envVar, dir, err)
+	}
+	return dir
+}
+
+// LoadReference loads all tensors from a safetensors file.
+// Skips the test if the file does not exist (reference not yet generated).
+func LoadReference(t *testing.T, path string) map[string]*mlx.Array {
+	t.Helper()
+	return LoadReferenceFiltered(t, path, nil)
+}
+
+// LoadReferenceFiltered is like LoadReference but only retains tensors whose
+// names are in the keep set. Tensors not in the set are dropped via Sweep
+// after the file is loaded. If keep is nil or empty, every tensor is loaded
+// (equivalent to LoadReference).
+//
+// Use this when an activation dump is large and you only need a subset of
+// keys; loading the full file into pinned memory may exceed available unified
+// memory on the test machine.
+func LoadReferenceFiltered(t *testing.T, path string, keep map[string]bool) map[string]*mlx.Array {
+	t.Helper()
+	SkipIfNoMLX(t)
+
+	if _, err := os.Stat(path); err != nil {
+		t.Skipf("reference data not available: %s", path)
+	}
+
+	tensors := make(map[string]*mlx.Array)
+	for name, arr := range mlx.Load(path) {
+		if len(keep) > 0 && !keep[name] {
+			continue
+		}
+		tensors[name] = arr
+	}
+	if len(tensors) == 0 {
+		t.Fatalf("no tensors loaded from %s", path)
+	}
+
+	// Pin the kept arrays so the post-load Sweep doesn't free them, then
+	// run Sweep to discard the unpinned ones produced by mlx.Load. Without
+	// this, the dropped tensors would still occupy memory until the next
+	// model-driven Sweep().
+	arrays := make([]*mlx.Array, 0, len(tensors))
+	for _, arr := range tensors {
+		arrays = append(arrays, arr)
+	}
+	mlx.Pin(arrays...)
+	mlx.Sweep()
+	mlx.Eval(arrays...)
+
+	return tensors
+}
+
+// CompareOption configures tensor comparison behavior.
+type CompareOption func(*compareConfig)
+
+type compareConfig struct {
+	atol float32
+	rtol float32
+}
+
+func defaultConfig() compareConfig {
+	return compareConfig{atol: 1e-4, rtol: 1e-3}
+}
+
+// BFloat16Tol sets tolerances appropriate for BFloat16 precision.
+func BFloat16Tol() CompareOption {
+	return func(c *compareConfig) { c.atol = 5e-3; c.rtol = 5e-3 }
+}
+
+// Float32Tol sets tight tolerances for float32 precision.
+func Float32Tol() CompareOption {
+	return func(c *compareConfig) { c.atol = 1e-5; c.rtol = 1e-5 }
+}
+
+// QuantizedTol sets loose tolerances for quantized model comparison.
+func QuantizedTol() CompareOption {
+	return func(c *compareConfig) { c.atol = 1e-2; c.rtol = 1e-2 }
+}
+
+// WithTolerance sets custom absolute and relative tolerances.
+func WithTolerance(atol, rtol float32) CompareOption {
+	return func(c *compareConfig) { c.atol = atol; c.rtol = rtol }
+}
+
+// CompareEntry holds the result of comparing two tensors.
+type CompareEntry struct {
+	Name      string
+	Passed    bool
+	MaxDiff   float32
+	MaxDiffAt int
+	MeanDiff  float32
+	CosineSim float32
+	GotShape  []int
+	WantShape []int
+}
+
+// CompareReport holds results from comparing multiple tensor pairs.
+type CompareReport struct {
+	Entries []CompareEntry
+}
+
+// AllPassed returns true if every comparison passed.
+func (r CompareReport) AllPassed() bool {
+	for _, e := range r.Entries {
+		if !e.Passed {
+			return false
+		}
+	}
+	return true
+}
+
+// Summary logs a table of all comparisons to t.
+func (r CompareReport) Summary(t *testing.T) {
+	t.Helper()
+	t.Logf("%-40s %-6s %12s %12s %10s", "Name", "Status", "MaxDiff", "MeanDiff", "CosineSim")
+	t.Logf("%-40s %-6s %12s %12s %10s", strings.Repeat("-", 40), "------", "------------", "------------", "----------")
+	for _, e := range r.Entries {
+		status := "PASS"
+		if !e.Passed {
+			status = "FAIL"
+		}
+		t.Logf("%-40s %-6s %12.6f %12.6f %10.6f", e.Name, status, e.MaxDiff, e.MeanDiff, e.CosineSim)
+	}
+}
+
+// compareArraysInner performs the actual comparison and returns the entry.
+func compareArraysInner(name string, got, want *mlx.Array, cfg compareConfig) CompareEntry {
+	entry := CompareEntry{
+		Name:      name,
+		GotShape:  got.Dims(),
+		WantShape: want.Dims(),
+	}
+
+	// Shape check
+	gotDims := got.Dims()
+	wantDims := want.Dims()
+	if len(gotDims) != len(wantDims) {
+		return entry
+	}
+	for i := range gotDims {
+		if gotDims[i] != wantDims[i] {
+			return entry
+		}
+	}
+
+	// Cast to float32 for comparison -- Floats() requires float32 data.
+	gotF32 := got.AsType(mlx.DTypeFloat32)
+	wantF32 := want.AsType(mlx.DTypeFloat32)
+	mlx.Eval(gotF32, wantF32)
+	gotData := gotF32.Floats()
+	wantData := wantF32.Floats()
+
+	if len(gotData) != len(wantData) {
+		return entry
+	}
+
+	var maxDiff, sumDiff float32
+	maxDiffAt := 0
+	var dotProduct, gotNorm, wantNorm float64
+
+	for i := range gotData {
+		diff := float32(math.Abs(float64(gotData[i] - wantData[i])))
+		if diff > maxDiff {
+			maxDiff = diff
+			maxDiffAt = i
+		}
+		sumDiff += diff
+		dotProduct += float64(gotData[i]) * float64(wantData[i])
+		gotNorm += float64(gotData[i]) * float64(gotData[i])
+		wantNorm += float64(wantData[i]) * float64(wantData[i])
+	}
+
+	n := len(gotData)
+	entry.MaxDiff = maxDiff
+	entry.MaxDiffAt = maxDiffAt
+	entry.MeanDiff = sumDiff / float32(n)
+
+	denom := math.Sqrt(gotNorm) * math.Sqrt(wantNorm)
+	if denom > 0 {
+		entry.CosineSim = float32(dotProduct / denom)
+	}
+
+	// Check if within tolerance: |got - want| <= atol + rtol * |want|
+	entry.Passed = true
+	for i := range gotData {
+		threshold := cfg.atol + cfg.rtol*float32(math.Abs(float64(wantData[i])))
+		if float32(math.Abs(float64(gotData[i]-wantData[i]))) > threshold {
+			entry.Passed = false
+			break
+		}
+	}
+
+	return entry
+}
+
+// CompareArrays compares two MLX arrays with detailed error reporting.
+// Returns true if the arrays match within the configured tolerance.
+func CompareArrays(t *testing.T, name string, got, want *mlx.Array, opts ...CompareOption) bool {
+	t.Helper()
+	cfg := defaultConfig()
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	entry := compareArraysInner(name, got, want, cfg)
+
+	if !entry.Passed {
+		t.Errorf("%s mismatch:", name)
+
+		// Shape mismatch
+		if fmt.Sprint(entry.GotShape) != fmt.Sprint(entry.WantShape) {
+			t.Errorf("  shape: got %v, want %v", entry.GotShape, entry.WantShape)
+			return false
+		}
+
+		t.Errorf("  shape:      %v", entry.GotShape)
+		t.Errorf("  max_diff:   %.6f (at index %d)", entry.MaxDiff, entry.MaxDiffAt)
+		t.Errorf("  mean_diff:  %.6f", entry.MeanDiff)
+		t.Errorf("  cosine_sim: %.6f", entry.CosineSim)
+
+		// Print first 5 values
+		gf := got.AsType(mlx.DTypeFloat32)
+		wf := want.AsType(mlx.DTypeFloat32)
+		mlx.Eval(gf, wf)
+		gotData := gf.Floats()
+		wantData := wf.Floats()
+		n := min(5, len(gotData))
+		gotFirst := make([]string, n)
+		wantFirst := make([]string, n)
+		for i := range n {
+			gotFirst[i] = fmt.Sprintf("%.4f", gotData[i])
+			wantFirst[i] = fmt.Sprintf("%.4f", wantData[i])
+		}
+		t.Errorf("  got  first%d: [%s]", n, strings.Join(gotFirst, ", "))
+		t.Errorf("  want first%d: [%s]", n, strings.Join(wantFirst, ", "))
+	}
+
+	return entry.Passed
+}
+
+// CompareArraysCosineSim asserts that the cosine similarity between got and
+// want is at least minCosineSim. Prefer this for accumulated forward-pass
+// outputs (anything that has been through several layers and a final
+// per-channel scaled normalization): cosine similarity catches direction
+// errors and ignores per-channel scale, where element-wise atol gives
+// alarming false positives. Use CompareArrays with a tight tolerance for
+// single-op tests where element-wise comparison is meaningful.
+//
+// Note: cosine similarity does not detect a uniform scale error.
+func CompareArraysCosineSim(t *testing.T, name string, got, want *mlx.Array, minCosineSim float32) bool {
+	t.Helper()
+	entry := CompareEntry{
+		Name:      name,
+		GotShape:  got.Dims(),
+		WantShape: want.Dims(),
+	}
+
+	// Shape mismatch is always a failure regardless of cosine sim.
+	if fmt.Sprint(entry.GotShape) != fmt.Sprint(entry.WantShape) {
+		t.Errorf("%s shape mismatch: got %v, want %v", name, entry.GotShape, entry.WantShape)
+		return false
+	}
+
+	total := got.Size()
+	if total == 0 {
+		entry.Passed = true
+		entry.CosineSim = 1
+		return true
+	}
+
+	gotFlat := mlx.Reshape(got, 1, int32(total))
+	wantFlat := mlx.Reshape(want, 1, int32(total))
+	mlx.Pin(gotFlat, wantFlat)
+	defer func() {
+		mlx.Unpin(gotFlat, wantFlat)
+		mlx.Sweep()
+	}()
+
+	const chunkElems = 1 << 20
+	var maxDiff, sumDiff float32
+	maxDiffAt := 0
+	var dotProduct, gotNorm, wantNorm float64
+
+	for start := 0; start < total; start += chunkElems {
+		end := min(start+chunkElems, total)
+		gotChunk := gotFlat.Slice(mlx.Slice(), mlx.Slice(start, end))
+		wantChunk := wantFlat.Slice(mlx.Slice(), mlx.Slice(start, end))
+		gotF32 := gotChunk.AsType(mlx.DTypeFloat32)
+		wantF32 := wantChunk.AsType(mlx.DTypeFloat32)
+		mlx.Eval(gotF32, wantF32)
+		gotData := gotF32.Floats()
+		wantData := wantF32.Floats()
+		for i := range gotData {
+			diff := float32(math.Abs(float64(gotData[i] - wantData[i])))
+			if diff > maxDiff {
+				maxDiff = diff
+				maxDiffAt = start + i
+			}
+			sumDiff += diff
+			dotProduct += float64(gotData[i]) * float64(wantData[i])
+			gotNorm += float64(gotData[i]) * float64(gotData[i])
+			wantNorm += float64(wantData[i]) * float64(wantData[i])
+		}
+		mlx.Sweep()
+	}
+
+	entry.MaxDiff = maxDiff
+	entry.MaxDiffAt = maxDiffAt
+	entry.MeanDiff = sumDiff / float32(total)
+	denom := math.Sqrt(gotNorm) * math.Sqrt(wantNorm)
+	if denom > 0 {
+		entry.CosineSim = float32(dotProduct / denom)
+	}
+	if entry.CosineSim >= minCosineSim {
+		return true
+	}
+
+	t.Errorf("%s cosine similarity check failed:", name)
+	t.Errorf("  cosine_sim: %.6f (want >= %.6f)", entry.CosineSim, minCosineSim)
+	t.Errorf("  shape:      %v", entry.GotShape)
+	t.Errorf("  max_diff:   %.6f (at index %d)", entry.MaxDiff, entry.MaxDiffAt)
+	t.Errorf("  mean_diff:  %.6f", entry.MeanDiff)
+	return false
+}
+
+// CompareManyArrays compares all tensors present in both got and want maps.
+// Keys are sorted so layers are compared in order. Returns a report.
+func CompareManyArrays(t *testing.T, got, want map[string]*mlx.Array, opts ...CompareOption) CompareReport {
+	t.Helper()
+	cfg := defaultConfig()
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	// Find common keys
+	var keys []string
+	for k := range want {
+		if _, ok := got[k]; ok {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+
+	var report CompareReport
+	for _, k := range keys {
+		entry := compareArraysInner(k, got[k], want[k], cfg)
+		report.Entries = append(report.Entries, entry)
+	}
+
+	return report
+}
+
+// LoadModelFromDir loads any registered model architecture from a
+// HuggingFace-format directory containing config.json, tokenizer.json,
+// and *.safetensors weight files. Suitable for BF16 reference models.
+func LoadModelFromDir(t *testing.T, modelDir string) base.Model {
+	t.Helper()
+	SkipIfNoMLX(t)
+
+	// Build a synthetic manifest pointing to the real files via symlinks.
+	blobDir := t.TempDir()
+	var layers []manifest.ManifestLayer
+
+	// Link config files
+	for _, name := range []string{
+		"config.json",
+		"tokenizer.json",
+		"generation_config.json",
+		"tokenizer_config.json",
+	} {
+		src := filepath.Join(modelDir, name)
+		if _, err := os.Stat(src); err != nil {
+			if name == "config.json" || name == "tokenizer.json" {
+				t.Fatalf("required file missing: %s", src)
+			}
+			continue
+		}
+		digest := "sha256:" + name
+		blobName := "sha256-" + name
+		if err := os.Symlink(src, filepath.Join(blobDir, blobName)); err != nil {
+			t.Fatalf("symlink %s: %v", name, err)
+		}
+		layers = append(layers, manifest.ManifestLayer{
+			MediaType: "application/vnd.ollama.image.json",
+			Digest:    digest,
+			Name:      name,
+		})
+	}
+
+	// Link safetensors files
+	matches, _ := filepath.Glob(filepath.Join(modelDir, "*.safetensors"))
+	sort.Strings(matches)
+	for _, src := range matches {
+		name := filepath.Base(src)
+		digest := "sha256:" + name
+		blobName := "sha256-" + name
+		if err := os.Symlink(src, filepath.Join(blobDir, blobName)); err != nil {
+			t.Fatalf("symlink %s: %v", name, err)
+		}
+		layers = append(layers, manifest.ManifestLayer{
+			MediaType: "application/vnd.ollama.image.tensor",
+			Digest:    digest,
+			Name:      name,
+		})
+	}
+
+	mm := &manifest.ModelManifest{
+		Manifest: &manifest.Manifest{
+			SchemaVersion: 2,
+			Layers:        layers,
+		},
+		BlobDir: blobDir,
+	}
+
+	root := &model.Root{Manifest: mm}
+	t.Cleanup(root.Close)
+	m, err := base.New(root)
+	if err != nil {
+		t.Fatalf("base.New: %v", err)
+	}
+
+	// Load all safetensors and remap keys for quantized models
+	tensors := loadTensorsFromManifest(t, root)
+
+	loadFn := base.Weights(m)
+	if err := loadFn(tensors); err != nil {
+		t.Fatalf("LoadWeights: %v", err)
+	}
+
+	return m
+}
+
+// LoadModelByName loads an ollama model by name (e.g., "gemma4:e2b-nvfp4").
+// The model must already exist in the local ollama model store.
+func LoadModelByName(t *testing.T, modelName string) base.Model {
+	t.Helper()
+	SkipIfNoMLX(t)
+
+	if modelName == "" {
+		t.Skip("no model name provided")
+	}
+
+	root, err := model.Open(modelName)
+	if err != nil {
+		t.Skipf("model %q not available: %v", modelName, err)
+	}
+	t.Cleanup(root.Close)
+
+	m, err := base.New(root)
+	if err != nil {
+		t.Fatalf("base.New(%s): %v", modelName, err)
+	}
+
+	tensors := loadTensorsFromManifest(t, root)
+
+	loadFn := base.Weights(m)
+	if err := loadFn(tensors); err != nil {
+		t.Fatalf("LoadWeights(%s): %v", modelName, err)
+	}
+
+	return m
+}
+
+// loadTensorsFromManifest loads all tensor blobs from a manifest, deduplicating
+// by digest and remapping safetensors key suffixes (.scale → _scale, .bias → _qbias).
+func loadTensorsFromManifest(t *testing.T, root *model.Root) map[string]*mlx.Array {
+	t.Helper()
+
+	// Phase 1: Load all tensors raw
+	rawTensors := make(map[string]*mlx.Array)
+	seen := make(map[string]bool)
+	for _, layer := range root.Manifest.GetTensorLayers("") {
+		if seen[layer.Digest] {
+			continue
+		}
+		seen[layer.Digest] = true
+		blobPath := root.Manifest.BlobPath(layer.Digest)
+		for name, arr := range mlx.Load(blobPath) {
+			rawTensors[name] = arr
+		}
+	}
+
+	// Phase 2: Identify quantized base names (.scale entries)
+	scaleBaseNames := make(map[string]bool)
+	allTensors := make(map[string]*mlx.Array, len(rawTensors))
+	for name, arr := range rawTensors {
+		if strings.HasSuffix(name, ".scale") {
+			baseName := strings.TrimSuffix(name, ".scale")
+			allTensors[baseName+"_scale"] = arr
+			scaleBaseNames[baseName] = true
+		}
+	}
+
+	// Phase 3: Remap remaining tensors
+	for name, arr := range rawTensors {
+		if strings.HasSuffix(name, ".scale") {
+			continue
+		}
+		if strings.HasSuffix(name, ".bias") && !strings.HasSuffix(name, ".weight_qbias") {
+			baseName := strings.TrimSuffix(name, ".bias")
+			if scaleBaseNames[baseName] {
+				allTensors[baseName+"_qbias"] = arr
+			} else {
+				allTensors[name] = arr
+			}
+		} else {
+			allTensors[name] = arr
+		}
+	}
+
+	if len(allTensors) == 0 {
+		t.Fatalf("no tensors loaded from manifest")
+	}
+	return allTensors
+}

--- a/x/models/testutil/testutil.go
+++ b/x/models/testutil/testutil.go
@@ -1,0 +1,570 @@
+// Package testutil provides reusable test utilities for validating MLX model
+// implementations against Python reference outputs.
+//
+// Typical workflow:
+//  1. Generate reference activations with x/models/scripts/dump_activations.py
+//  2. Load reference data with LoadReference
+//  3. Load model with LoadModelFromDir (BF16) or LoadModelByName (quantized)
+//  4. Compare layer-by-layer with CompareArrays or CompareManyArrays
+package testutil
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/ollama/ollama/x/imagegen/manifest"
+	"github.com/ollama/ollama/x/internal/mlxtest"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/mlxrunner/model"
+	"github.com/ollama/ollama/x/mlxrunner/model/base"
+)
+
+// DefaultRefDir returns /tmp/ollama_ref/<model>/ which matches the default
+// output location of dump_activations.py. Override with OLLAMA_REF_DIR env var.
+func DefaultRefDir(model string) string {
+	if dir := os.Getenv("OLLAMA_REF_DIR"); dir != "" {
+		return filepath.Join(dir, model)
+	}
+	return filepath.Join("/tmp", "ollama_ref", model)
+}
+
+// ModelDir returns a model directory path from an env var or default path.
+// Skips the test if the directory does not exist.
+func ModelDir(t *testing.T, envVar, defaultPath string) string {
+	t.Helper()
+	dir := os.Getenv(envVar)
+	if dir == "" {
+		dir = defaultPath
+		if strings.HasPrefix(dir, "~/") {
+			home, _ := os.UserHomeDir()
+			dir = filepath.Join(home, dir[2:])
+		}
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Skipf("model directory not available (%s=%s): %v", envVar, dir, err)
+	}
+	return dir
+}
+
+// LoadReference loads all tensors from a safetensors file.
+// Skips the test if the file does not exist (reference not yet generated).
+func LoadReference(t *testing.T, path string) map[string]*mlx.Array {
+	t.Helper()
+	return LoadReferenceFiltered(t, path, nil)
+}
+
+// LoadReferenceFiltered is like LoadReference but only retains tensors whose
+// names are in the keep set. Tensors not in the set are dropped via Sweep
+// after the file is loaded. If keep is nil or empty, every tensor is loaded
+// (equivalent to LoadReference).
+//
+// Use this when an activation dump is large and you only need a subset of
+// keys; loading the full file into pinned memory may exceed available unified
+// memory on the test machine.
+func LoadReferenceFiltered(t *testing.T, path string, keep map[string]bool) map[string]*mlx.Array {
+	t.Helper()
+	mlxtest.Setup(t)
+
+	if _, err := os.Stat(path); err != nil {
+		t.Skipf("reference data not available: %s", path)
+	}
+
+	tensors := make(map[string]*mlx.Array)
+	for name, arr := range mlx.Load(path) {
+		if len(keep) > 0 && !keep[name] {
+			continue
+		}
+		tensors[name] = arr
+	}
+	if len(tensors) == 0 {
+		t.Fatalf("no tensors loaded from %s", path)
+	}
+
+	// Pin the kept arrays so the post-load Sweep doesn't free them, then
+	// run Sweep to discard the unpinned ones produced by mlx.Load. Without
+	// this, the dropped tensors would still occupy memory until the next
+	// model-driven Sweep().
+	arrays := make([]*mlx.Array, 0, len(tensors))
+	for _, arr := range tensors {
+		arrays = append(arrays, arr)
+	}
+	mlx.Pin(arrays...)
+	mlx.Sweep()
+	mlx.Eval(arrays...)
+
+	return tensors
+}
+
+// CompareOption configures tensor comparison behavior.
+type CompareOption func(*compareConfig)
+
+type compareConfig struct {
+	atol float32
+	rtol float32
+}
+
+func defaultConfig() compareConfig {
+	return compareConfig{atol: 1e-4, rtol: 1e-3}
+}
+
+// BFloat16Tol sets tolerances appropriate for BFloat16 precision.
+func BFloat16Tol() CompareOption {
+	return func(c *compareConfig) { c.atol = 5e-3; c.rtol = 5e-3 }
+}
+
+// Float32Tol sets tight tolerances for float32 precision.
+func Float32Tol() CompareOption {
+	return func(c *compareConfig) { c.atol = 1e-5; c.rtol = 1e-5 }
+}
+
+// QuantizedTol sets loose tolerances for quantized model comparison.
+func QuantizedTol() CompareOption {
+	return func(c *compareConfig) { c.atol = 1e-2; c.rtol = 1e-2 }
+}
+
+// WithTolerance sets custom absolute and relative tolerances.
+func WithTolerance(atol, rtol float32) CompareOption {
+	return func(c *compareConfig) { c.atol = atol; c.rtol = rtol }
+}
+
+// CompareEntry holds the result of comparing two tensors.
+type CompareEntry struct {
+	Name      string
+	Passed    bool
+	MaxDiff   float32
+	MaxDiffAt int
+	MeanDiff  float32
+	CosineSim float32
+	GotShape  []int
+	WantShape []int
+}
+
+// CompareReport holds results from comparing multiple tensor pairs.
+type CompareReport struct {
+	Entries []CompareEntry
+}
+
+// AllPassed returns true if every comparison passed.
+func (r CompareReport) AllPassed() bool {
+	for _, e := range r.Entries {
+		if !e.Passed {
+			return false
+		}
+	}
+	return true
+}
+
+// Summary logs a table of all comparisons to t.
+func (r CompareReport) Summary(t *testing.T) {
+	t.Helper()
+	t.Logf("%-40s %-6s %12s %12s %10s", "Name", "Status", "MaxDiff", "MeanDiff", "CosineSim")
+	t.Logf("%-40s %-6s %12s %12s %10s", strings.Repeat("-", 40), "------", "------------", "------------", "----------")
+	for _, e := range r.Entries {
+		status := "PASS"
+		if !e.Passed {
+			status = "FAIL"
+		}
+		t.Logf("%-40s %-6s %12.6f %12.6f %10.6f", e.Name, status, e.MaxDiff, e.MeanDiff, e.CosineSim)
+	}
+}
+
+// compareArraysInner performs the actual comparison and returns the entry.
+func compareArraysInner(name string, got, want *mlx.Array, cfg compareConfig) CompareEntry {
+	entry := CompareEntry{
+		Name:      name,
+		GotShape:  got.Dims(),
+		WantShape: want.Dims(),
+	}
+
+	// Shape check
+	gotDims := got.Dims()
+	wantDims := want.Dims()
+	if len(gotDims) != len(wantDims) {
+		return entry
+	}
+	for i := range gotDims {
+		if gotDims[i] != wantDims[i] {
+			return entry
+		}
+	}
+
+	// Cast to float32 for comparison -- Floats() requires float32 data.
+	gotF32 := got.AsType(mlx.DTypeFloat32)
+	wantF32 := want.AsType(mlx.DTypeFloat32)
+	mlx.Eval(gotF32, wantF32)
+	gotData := gotF32.Floats()
+	wantData := wantF32.Floats()
+
+	if len(gotData) != len(wantData) {
+		return entry
+	}
+
+	var maxDiff, sumDiff float32
+	maxDiffAt := 0
+	var dotProduct, gotNorm, wantNorm float64
+
+	for i := range gotData {
+		diff := float32(math.Abs(float64(gotData[i] - wantData[i])))
+		if diff > maxDiff {
+			maxDiff = diff
+			maxDiffAt = i
+		}
+		sumDiff += diff
+		dotProduct += float64(gotData[i]) * float64(wantData[i])
+		gotNorm += float64(gotData[i]) * float64(gotData[i])
+		wantNorm += float64(wantData[i]) * float64(wantData[i])
+	}
+
+	n := len(gotData)
+	entry.MaxDiff = maxDiff
+	entry.MaxDiffAt = maxDiffAt
+	entry.MeanDiff = sumDiff / float32(n)
+
+	denom := math.Sqrt(gotNorm) * math.Sqrt(wantNorm)
+	if denom > 0 {
+		entry.CosineSim = float32(dotProduct / denom)
+	}
+
+	// Check if within tolerance: |got - want| <= atol + rtol * |want|
+	entry.Passed = true
+	for i := range gotData {
+		threshold := cfg.atol + cfg.rtol*float32(math.Abs(float64(wantData[i])))
+		if float32(math.Abs(float64(gotData[i]-wantData[i]))) > threshold {
+			entry.Passed = false
+			break
+		}
+	}
+
+	return entry
+}
+
+// CompareArrays compares two MLX arrays with detailed error reporting.
+// Returns true if the arrays match within the configured tolerance.
+func CompareArrays(t *testing.T, name string, got, want *mlx.Array, opts ...CompareOption) bool {
+	t.Helper()
+	cfg := defaultConfig()
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	entry := compareArraysInner(name, got, want, cfg)
+
+	if !entry.Passed {
+		t.Errorf("%s mismatch:", name)
+
+		// Shape mismatch
+		if fmt.Sprint(entry.GotShape) != fmt.Sprint(entry.WantShape) {
+			t.Errorf("  shape: got %v, want %v", entry.GotShape, entry.WantShape)
+			return false
+		}
+
+		t.Errorf("  shape:      %v", entry.GotShape)
+		t.Errorf("  max_diff:   %.6f (at index %d)", entry.MaxDiff, entry.MaxDiffAt)
+		t.Errorf("  mean_diff:  %.6f", entry.MeanDiff)
+		t.Errorf("  cosine_sim: %.6f", entry.CosineSim)
+
+		// Print first 5 values
+		gf := got.AsType(mlx.DTypeFloat32)
+		wf := want.AsType(mlx.DTypeFloat32)
+		mlx.Eval(gf, wf)
+		gotData := gf.Floats()
+		wantData := wf.Floats()
+		n := min(5, len(gotData))
+		gotFirst := make([]string, n)
+		wantFirst := make([]string, n)
+		for i := range n {
+			gotFirst[i] = fmt.Sprintf("%.4f", gotData[i])
+			wantFirst[i] = fmt.Sprintf("%.4f", wantData[i])
+		}
+		t.Errorf("  got  first%d: [%s]", n, strings.Join(gotFirst, ", "))
+		t.Errorf("  want first%d: [%s]", n, strings.Join(wantFirst, ", "))
+	}
+
+	return entry.Passed
+}
+
+// CompareArraysCosineSim asserts that the cosine similarity between got and
+// want is at least minCosineSim. Prefer this for accumulated forward-pass
+// outputs (anything that has been through several layers and a final
+// per-channel scaled normalization): cosine similarity catches direction
+// errors and ignores per-channel scale, where element-wise atol gives
+// alarming false positives. Use CompareArrays with a tight tolerance for
+// single-op tests where element-wise comparison is meaningful.
+//
+// Note: cosine similarity does not detect a uniform scale error.
+func CompareArraysCosineSim(t *testing.T, name string, got, want *mlx.Array, minCosineSim float32) bool {
+	t.Helper()
+	entry := CompareEntry{
+		Name:      name,
+		GotShape:  got.Dims(),
+		WantShape: want.Dims(),
+	}
+
+	// Shape mismatch is always a failure regardless of cosine sim.
+	if fmt.Sprint(entry.GotShape) != fmt.Sprint(entry.WantShape) {
+		t.Errorf("%s shape mismatch: got %v, want %v", name, entry.GotShape, entry.WantShape)
+		return false
+	}
+
+	total := got.Size()
+	if total == 0 {
+		entry.Passed = true
+		entry.CosineSim = 1
+		return true
+	}
+
+	gotFlat := mlx.Reshape(got, 1, int32(total))
+	wantFlat := mlx.Reshape(want, 1, int32(total))
+	mlx.Pin(gotFlat, wantFlat)
+	defer func() {
+		mlx.Unpin(gotFlat, wantFlat)
+		mlx.Sweep()
+	}()
+
+	const chunkElems = 1 << 20
+	var maxDiff, sumDiff float32
+	maxDiffAt := 0
+	var dotProduct, gotNorm, wantNorm float64
+
+	for start := 0; start < total; start += chunkElems {
+		end := min(start+chunkElems, total)
+		gotChunk := gotFlat.Slice(mlx.Slice(), mlx.Slice(start, end))
+		wantChunk := wantFlat.Slice(mlx.Slice(), mlx.Slice(start, end))
+		gotF32 := gotChunk.AsType(mlx.DTypeFloat32)
+		wantF32 := wantChunk.AsType(mlx.DTypeFloat32)
+		mlx.Eval(gotF32, wantF32)
+		gotData := gotF32.Floats()
+		wantData := wantF32.Floats()
+		for i := range gotData {
+			diff := float32(math.Abs(float64(gotData[i] - wantData[i])))
+			if diff > maxDiff {
+				maxDiff = diff
+				maxDiffAt = start + i
+			}
+			sumDiff += diff
+			dotProduct += float64(gotData[i]) * float64(wantData[i])
+			gotNorm += float64(gotData[i]) * float64(gotData[i])
+			wantNorm += float64(wantData[i]) * float64(wantData[i])
+		}
+		mlx.Sweep()
+	}
+
+	entry.MaxDiff = maxDiff
+	entry.MaxDiffAt = maxDiffAt
+	entry.MeanDiff = sumDiff / float32(total)
+	denom := math.Sqrt(gotNorm) * math.Sqrt(wantNorm)
+	if denom > 0 {
+		entry.CosineSim = float32(dotProduct / denom)
+	}
+	if entry.CosineSim >= minCosineSim {
+		return true
+	}
+
+	t.Errorf("%s cosine similarity check failed:", name)
+	t.Errorf("  cosine_sim: %.6f (want >= %.6f)", entry.CosineSim, minCosineSim)
+	t.Errorf("  shape:      %v", entry.GotShape)
+	t.Errorf("  max_diff:   %.6f (at index %d)", entry.MaxDiff, entry.MaxDiffAt)
+	t.Errorf("  mean_diff:  %.6f", entry.MeanDiff)
+	return false
+}
+
+// CompareManyArrays compares all tensors present in both got and want maps.
+// Keys are sorted so layers are compared in order. Returns a report.
+func CompareManyArrays(t *testing.T, got, want map[string]*mlx.Array, opts ...CompareOption) CompareReport {
+	t.Helper()
+	cfg := defaultConfig()
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	// Find common keys
+	var keys []string
+	for k := range want {
+		if _, ok := got[k]; ok {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+
+	var report CompareReport
+	for _, k := range keys {
+		entry := compareArraysInner(k, got[k], want[k], cfg)
+		report.Entries = append(report.Entries, entry)
+	}
+
+	return report
+}
+
+// LoadModelFromDir loads any registered model architecture from a
+// HuggingFace-format directory containing config.json, tokenizer.json,
+// and *.safetensors weight files. Suitable for BF16 reference models.
+//
+// CAUTION: this bypasses the create-path import transform. Architectures
+// whose runtime layout depends on it load without error but produce
+// silently wrong outputs — validate a new architecture through a created
+// tag (LoadModelByNameOrErr) before trusting directory loading for it.
+func LoadModelFromDir(t *testing.T, modelDir string) base.Model {
+	t.Helper()
+	mlxtest.Setup(t)
+
+	// Build a synthetic manifest pointing to the real files via symlinks.
+	blobDir := t.TempDir()
+	var layers []manifest.ManifestLayer
+
+	// Link config files
+	for _, name := range []string{
+		"config.json",
+		"tokenizer.json",
+		"generation_config.json",
+		"tokenizer_config.json",
+	} {
+		src := filepath.Join(modelDir, name)
+		if _, err := os.Stat(src); err != nil {
+			if name == "config.json" || name == "tokenizer.json" {
+				t.Fatalf("required file missing: %s", src)
+			}
+			continue
+		}
+		digest := "sha256:" + name
+		blobName := "sha256-" + name
+		if err := os.Symlink(src, filepath.Join(blobDir, blobName)); err != nil {
+			t.Fatalf("symlink %s: %v", name, err)
+		}
+		layers = append(layers, manifest.ManifestLayer{
+			MediaType: "application/vnd.ollama.image.json",
+			Digest:    digest,
+			Name:      name,
+		})
+	}
+
+	// Link safetensors files
+	matches, _ := filepath.Glob(filepath.Join(modelDir, "*.safetensors"))
+	sort.Strings(matches)
+	for _, src := range matches {
+		name := filepath.Base(src)
+		digest := "sha256:" + name
+		blobName := "sha256-" + name
+		if err := os.Symlink(src, filepath.Join(blobDir, blobName)); err != nil {
+			t.Fatalf("symlink %s: %v", name, err)
+		}
+		layers = append(layers, manifest.ManifestLayer{
+			MediaType: "application/vnd.ollama.image.tensor",
+			Digest:    digest,
+			Name:      name,
+		})
+	}
+
+	mm := &manifest.ModelManifest{
+		Manifest: &manifest.Manifest{
+			SchemaVersion: 2,
+			Layers:        layers,
+		},
+		BlobDir: blobDir,
+	}
+
+	root := &model.Root{Manifest: mm}
+	t.Cleanup(root.Close)
+	m, err := base.New(root)
+	if err != nil {
+		t.Fatalf("base.New: %v", err)
+	}
+
+	// Load all safetensors and remap keys for quantized models
+	tensors := loadTensorsFromManifest(t, root)
+
+	loadFn := base.Weights(m)
+	if err := loadFn(tensors); err != nil {
+		t.Fatalf("LoadWeights: %v", err)
+	}
+
+	return m
+}
+
+// LoadModelByName loads an ollama model by name (e.g., "gemma4:e2b-nvfp4").
+// The model must already exist in the local ollama model store.
+func LoadModelByName(t *testing.T, modelName string) base.Model {
+	t.Helper()
+	mlxtest.Setup(t)
+
+	if modelName == "" {
+		t.Skip("no model name provided")
+	}
+
+	root, err := model.Open(modelName)
+	if err != nil {
+		t.Skipf("model %q not available: %v", modelName, err)
+	}
+	t.Cleanup(root.Close)
+
+	m, err := base.New(root)
+	if err != nil {
+		t.Fatalf("base.New(%s): %v", modelName, err)
+	}
+
+	tensors := loadTensorsFromManifest(t, root)
+
+	loadFn := base.Weights(m)
+	if err := loadFn(tensors); err != nil {
+		t.Fatalf("LoadWeights(%s): %v", modelName, err)
+	}
+
+	return m
+}
+
+// loadTensorsFromManifest loads all tensor blobs from a manifest, deduplicating
+// by digest and remapping safetensors key suffixes (.scale → _scale, .bias → _qbias).
+func loadTensorsFromManifest(t *testing.T, root *model.Root) map[string]*mlx.Array {
+	t.Helper()
+
+	// Phase 1: Load all tensors raw
+	rawTensors := make(map[string]*mlx.Array)
+	seen := make(map[string]bool)
+	for _, layer := range root.Manifest.GetTensorLayers("") {
+		if seen[layer.Digest] {
+			continue
+		}
+		seen[layer.Digest] = true
+		blobPath := root.Manifest.BlobPath(layer.Digest)
+		for name, arr := range mlx.Load(blobPath) {
+			rawTensors[name] = arr
+		}
+	}
+
+	// Phase 2: Identify quantized base names (.scale entries)
+	scaleBaseNames := make(map[string]bool)
+	allTensors := make(map[string]*mlx.Array, len(rawTensors))
+	for name, arr := range rawTensors {
+		if strings.HasSuffix(name, ".scale") {
+			baseName := strings.TrimSuffix(name, ".scale")
+			allTensors[baseName+"_scale"] = arr
+			scaleBaseNames[baseName] = true
+		}
+	}
+
+	// Phase 3: Remap remaining tensors
+	for name, arr := range rawTensors {
+		if strings.HasSuffix(name, ".scale") {
+			continue
+		}
+		if strings.HasSuffix(name, ".bias") && !strings.HasSuffix(name, ".weight_qbias") {
+			baseName := strings.TrimSuffix(name, ".bias")
+			if scaleBaseNames[baseName] {
+				allTensors[baseName+"_qbias"] = arr
+			} else {
+				allTensors[name] = arr
+			}
+		} else {
+			allTensors[name] = arr
+		}
+	}
+
+	if len(allTensors) == 0 {
+		t.Fatalf("no tensors loaded from manifest")
+	}
+	return allTensors
+}

--- a/x/models/testutil/testutil_test.go
+++ b/x/models/testutil/testutil_test.go
@@ -1,0 +1,498 @@
+package testutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+)
+
+func TestSkipIfNoMLX(t *testing.T) {
+	SkipIfNoMLX(t)
+}
+
+func TestDefaultRefDir(t *testing.T) {
+	// Without env var override
+	got := DefaultRefDir("test-model")
+	want := filepath.Join("/tmp", "ollama_ref", "test-model")
+	if got != want {
+		t.Errorf("DefaultRefDir = %q, want %q", got, want)
+	}
+
+	// With env var override
+	t.Setenv("OLLAMA_REF_DIR", "/custom/ref")
+	got = DefaultRefDir("test-model")
+	want = filepath.Join("/custom/ref", "test-model")
+	if got != want {
+		t.Errorf("DefaultRefDir with env = %q, want %q", got, want)
+	}
+}
+
+func TestModelDir_Missing(t *testing.T) {
+	// Verify the function returns the correct path when the directory exists.
+	dir := t.TempDir()
+	got := ModelDir(t, "TESTUTIL_MODEL_DIR_TEST", dir)
+	if got != dir {
+		t.Errorf("ModelDir = %q, want %q", got, dir)
+	}
+}
+
+func TestModelDir_EnvOverride(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("TESTUTIL_TEST_DIR", dir)
+	got := ModelDir(t, "TESTUTIL_TEST_DIR", "/nonexistent/default")
+	if got != dir {
+		t.Errorf("ModelDir = %q, want %q", got, dir)
+	}
+}
+
+func TestCompareArrays_Matching(t *testing.T) {
+	SkipIfNoMLX(t)
+
+	a := mlx.FromValues([]float32{1.0, 2.0, 3.0, 4.0}, 2, 2)
+	b := mlx.FromValues([]float32{1.0, 2.0, 3.0, 4.0}, 2, 2)
+	mlx.Eval(a, b)
+
+	if !CompareArrays(t, "exact_match", a, b) {
+		t.Error("identical arrays should match")
+	}
+}
+
+func TestCompareArrays_WithinTolerance(t *testing.T) {
+	SkipIfNoMLX(t)
+
+	a := mlx.FromValues([]float32{1.0, 2.0, 3.0, 4.0}, 2, 2)
+	b := mlx.FromValues([]float32{1.01, 2.01, 3.01, 4.01}, 2, 2)
+	mlx.Eval(a, b)
+
+	// Default tolerance (atol=1e-4, rtol=1e-3) should fail for diff=0.01
+	entry := compareArraysInner("tight", a, b, defaultConfig())
+	if entry.Passed {
+		t.Error("should fail with default tolerance")
+	}
+
+	// BFloat16 tolerance (atol=5e-3, rtol=5e-3) should pass for diff=0.01
+	cfg := defaultConfig()
+	BFloat16Tol()(&cfg)
+	entry = compareArraysInner("loose", a, b, cfg)
+	if !entry.Passed {
+		t.Error("should pass with BFloat16Tol")
+	}
+}
+
+func TestCompareArrays_ShapeMismatch(t *testing.T) {
+	SkipIfNoMLX(t)
+
+	a := mlx.FromValues([]float32{1.0, 2.0, 3.0, 4.0}, 2, 2)
+	b := mlx.FromValues([]float32{1.0, 2.0, 3.0, 4.0}, 4)
+	mlx.Eval(a, b)
+
+	entry := compareArraysInner("shape_mismatch", a, b, defaultConfig())
+	if entry.Passed {
+		t.Error("different shapes should not pass")
+	}
+}
+
+func TestCompareArrays_CosineSim(t *testing.T) {
+	SkipIfNoMLX(t)
+
+	a := mlx.FromValues([]float32{1.0, 0.0, 0.0}, 3)
+	b := mlx.FromValues([]float32{1.0, 0.0, 0.0}, 3)
+	mlx.Eval(a, b)
+
+	entry := compareArraysInner("parallel", a, b, defaultConfig())
+	if entry.CosineSim < 0.999 {
+		t.Errorf("parallel vectors cosine sim = %f, want ~1.0", entry.CosineSim)
+	}
+
+	// Orthogonal vectors
+	c := mlx.FromValues([]float32{0.0, 1.0, 0.0}, 3)
+	mlx.Eval(c)
+
+	entry = compareArraysInner("orthogonal", a, c, defaultConfig())
+	if entry.CosineSim > 0.001 {
+		t.Errorf("orthogonal vectors cosine sim = %f, want ~0.0", entry.CosineSim)
+	}
+}
+
+func TestCompareArraysCosineSim(t *testing.T) {
+	SkipIfNoMLX(t)
+
+	// Near-parallel vectors with one element wide in absolute terms but the
+	// overall direction unchanged — should pass the cosine check.
+	a := mlx.FromValues([]float32{50.0, 1.0, 1.0, 1.0}, 4)
+	b := mlx.FromValues([]float32{51.0, 1.0, 1.0, 1.0}, 4)
+	mlx.Eval(a, b)
+	if !CompareArraysCosineSim(t, "near_parallel", a, b, 0.999) {
+		t.Error("expected near-parallel vectors to pass")
+	}
+
+	// Diverged pair (one element sign-flipped) — should fail.
+	c := mlx.FromValues([]float32{1.0, 1.0, 1.0, 1.0}, 4)
+	d := mlx.FromValues([]float32{-1.0, 1.0, 1.0, 1.0}, 4)
+	mlx.Eval(c, d)
+	subT := &testing.T{}
+	if CompareArraysCosineSim(subT, "diverged", c, d, 0.999) {
+		t.Error("expected diverged vectors to fail")
+	}
+	if !subT.Failed() {
+		t.Error("expected sub-test to record a failure")
+	}
+}
+
+func TestCompareArrays_MaxDiffLocation(t *testing.T) {
+	SkipIfNoMLX(t)
+
+	a := mlx.FromValues([]float32{1.0, 2.0, 3.0, 4.0}, 4)
+	b := mlx.FromValues([]float32{1.0, 2.0, 3.5, 4.0}, 4)
+	mlx.Eval(a, b)
+
+	entry := compareArraysInner("max_at_2", a, b, defaultConfig())
+	if entry.MaxDiffAt != 2 {
+		t.Errorf("MaxDiffAt = %d, want 2", entry.MaxDiffAt)
+	}
+	if entry.MaxDiff < 0.49 || entry.MaxDiff > 0.51 {
+		t.Errorf("MaxDiff = %f, want ~0.5", entry.MaxDiff)
+	}
+}
+
+func TestCompareManyArrays(t *testing.T) {
+	SkipIfNoMLX(t)
+
+	got := map[string]*mlx.Array{
+		"layer_0": mlx.FromValues([]float32{1.0, 2.0}, 2),
+		"layer_1": mlx.FromValues([]float32{3.0, 4.0}, 2),
+		"extra":   mlx.FromValues([]float32{5.0}, 1),
+	}
+	want := map[string]*mlx.Array{
+		"layer_0": mlx.FromValues([]float32{1.0, 2.0}, 2),
+		"layer_1": mlx.FromValues([]float32{3.0, 4.5}, 2), // mismatch
+		"other":   mlx.FromValues([]float32{6.0}, 1),
+	}
+	for _, a := range got {
+		mlx.Eval(a)
+	}
+	for _, a := range want {
+		mlx.Eval(a)
+	}
+
+	report := CompareManyArrays(t, got, want)
+
+	if len(report.Entries) != 2 {
+		t.Fatalf("expected 2 entries (common keys), got %d", len(report.Entries))
+	}
+
+	// layer_0 should pass, layer_1 should fail
+	for _, e := range report.Entries {
+		switch e.Name {
+		case "layer_0":
+			if !e.Passed {
+				t.Error("layer_0 should pass")
+			}
+		case "layer_1":
+			if e.Passed {
+				t.Error("layer_1 should fail with default tolerance")
+			}
+		}
+	}
+
+	if report.AllPassed() {
+		t.Error("report should not pass when layer_1 fails")
+	}
+}
+
+func TestCompareReport_Summary(t *testing.T) {
+	SkipIfNoMLX(t)
+
+	// Just verify Summary doesn't panic
+	report := CompareReport{
+		Entries: []CompareEntry{
+			{Name: "layer_0", Passed: true, MaxDiff: 0.001, MeanDiff: 0.0005, CosineSim: 0.9999},
+			{Name: "layer_1", Passed: false, MaxDiff: 0.5, MeanDiff: 0.1, CosineSim: 0.95},
+		},
+	}
+	report.Summary(t)
+}
+
+func TestLoadReference_Missing(t *testing.T) {
+	SkipIfNoMLX(t)
+
+	// Should skip (not fail) when file doesn't exist
+	// We can't easily test t.Skip from within, but we can verify
+	// the function handles the path correctly
+	path := filepath.Join(t.TempDir(), "nonexistent.safetensors")
+	if _, err := os.Stat(path); err == nil {
+		t.Fatal("test setup error: file should not exist")
+	}
+}
+
+func TestWithTolerance(t *testing.T) {
+	SkipIfNoMLX(t)
+
+	a := mlx.FromValues([]float32{1.0, 2.0}, 2)
+	b := mlx.FromValues([]float32{1.1, 2.1}, 2)
+	mlx.Eval(a, b)
+
+	// Should fail with tight tolerance
+	entry := compareArraysInner("tight", a, b, defaultConfig())
+	if entry.Passed {
+		t.Error("should fail with default tolerance")
+	}
+
+	// Should pass with custom loose tolerance
+	cfg := defaultConfig()
+	WithTolerance(0.2, 0.2)(&cfg)
+	entry = compareArraysInner("loose", a, b, cfg)
+	if !entry.Passed {
+		t.Error("should pass with atol=0.2")
+	}
+}
+
+func TestModelDir_TildeExpansion(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home dir")
+	}
+
+	// Use a path that exists under home
+	got := ModelDir(t, "TESTUTIL_UNUSED_ENV", home)
+	if got != home {
+		t.Errorf("ModelDir = %q, want %q", got, home)
+	}
+}
+
+func TestCompareArraysPerPosition_AllMatch(t *testing.T) {
+	SkipIfNoMLX(t)
+
+	// [1, 4, 3] tensor: identical, every position should pass.
+	a := mlx.FromValues([]float32{
+		1, 2, 3,
+		4, 5, 6,
+		7, 8, 9,
+		10, 11, 12,
+	}, 1, 4, 3)
+	b := mlx.FromValues([]float32{
+		1, 2, 3,
+		4, 5, 6,
+		7, 8, 9,
+		10, 11, 12,
+	}, 1, 4, 3)
+	mlx.Eval(a, b)
+
+	r := CompareArraysPerPosition(t, "match", a, b, 1)
+	if r.Length != 4 {
+		t.Errorf("Length = %d, want 4", r.Length)
+	}
+	if !r.AllPassed() {
+		t.Errorf("expected all positions to pass, first fail at %d", r.FirstFailIndex)
+	}
+	for i, d := range r.Drifts {
+		if d.MaxDiff != 0 {
+			t.Errorf("position %d max_diff = %f, want 0", i, d.MaxDiff)
+		}
+	}
+}
+
+func TestCompareArraysPerPosition_FirstFailLocated(t *testing.T) {
+	SkipIfNoMLX(t)
+
+	// [1, 4, 3] tensor: positions 0 and 1 match, position 2 has a tiny diff
+	// (within tolerance), position 3 has a large diff (out of tolerance).
+	// FirstFailIndex must be exactly 3.
+	a := mlx.FromValues([]float32{
+		1.0, 2.0, 3.0,
+		4.0, 5.0, 6.0,
+		7.0001, 8.0, 9.0,
+		10.0, 11.0, 999.0,
+	}, 1, 4, 3)
+	b := mlx.FromValues([]float32{
+		1.0, 2.0, 3.0,
+		4.0, 5.0, 6.0,
+		7.0, 8.0, 9.0,
+		10.0, 11.0, 12.0,
+	}, 1, 4, 3)
+	mlx.Eval(a, b)
+
+	r := CompareArraysPerPosition(t, "find_drift", a, b, 1, BFloat16Tol())
+	if r.FirstFailIndex != 3 {
+		t.Errorf("FirstFailIndex = %d, want 3", r.FirstFailIndex)
+	}
+	if r.WorstIndex != 3 {
+		t.Errorf("WorstIndex = %d, want 3", r.WorstIndex)
+	}
+	if r.Drifts[0].Passed != true || r.Drifts[1].Passed != true {
+		t.Error("positions 0 and 1 should pass with tight tolerance (exact match)")
+	}
+	if r.Drifts[3].Passed {
+		t.Error("position 3 must fail (max_diff is 987)")
+	}
+	worst := r.Drifts[3].MaxDiff
+	if worst < 986 || worst > 988 {
+		t.Errorf("position 3 max_diff = %f, want ~987", worst)
+	}
+}
+
+func TestTopDrifts(t *testing.T) {
+	SkipIfNoMLX(t)
+
+	// layer_a: one big outlier at pos 2. layer_b: uniform small drift everywhere.
+	// Absolute ranking should put layer_a pos 2 first. Relative ranking should
+	// also put layer_a pos 2 first (it's 99×+ its layer's median, while layer_b
+	// is ~1× everywhere).
+	got := map[string]*mlx.Array{
+		"layer_a": mlx.FromValues([]float32{1, 2, 3, 4, 999, 6, 7, 8}, 1, 4, 2),
+		"layer_b": mlx.FromValues([]float32{1.1, 2.1, 3.1, 4.1, 5.1, 6.1, 7.1, 8.1}, 1, 4, 2),
+	}
+	want := map[string]*mlx.Array{
+		"layer_a": mlx.FromValues([]float32{1, 2, 3, 4, 5, 6, 7, 8}, 1, 4, 2),
+		"layer_b": mlx.FromValues([]float32{1, 2, 3, 4, 5, 6, 7, 8}, 1, 4, 2),
+	}
+	for _, a := range got {
+		mlx.Eval(a)
+	}
+	for _, a := range want {
+		mlx.Eval(a)
+	}
+
+	report := CompareLayersPerPosition(t, got, want, 1)
+
+	absTop := report.TopDrifts(3)
+	if len(absTop) != 3 {
+		t.Fatalf("expected 3 top drifts, got %d", len(absTop))
+	}
+	if absTop[0].Layer != "layer_a" || absTop[0].Position != 2 {
+		t.Errorf("top absolute drift = %s/pos%d, want layer_a/pos2", absTop[0].Layer, absTop[0].Position)
+	}
+	if absTop[0].MaxDiff < 990 {
+		t.Errorf("top drift max_diff = %f, want ~994", absTop[0].MaxDiff)
+	}
+
+	relTop := report.TopDriftsByRelative(3)
+	if relTop[0].Layer != "layer_a" || relTop[0].Position != 2 {
+		t.Errorf("top relative drift = %s/pos%d, want layer_a/pos2", relTop[0].Layer, relTop[0].Position)
+	}
+	if relTop[0].RelToMedian < 10 {
+		t.Errorf("top rel_to_median = %f, want >>1 (outlier)", relTop[0].RelToMedian)
+	}
+
+	// Per-tensor TopDrifts on a uniform layer: rel_to_median should be ~1.
+	bTop := report.Layers[1].TopDrifts(0)
+	for _, d := range bTop {
+		if d.RelToMedian < 0.5 || d.RelToMedian > 2.0 {
+			t.Errorf("uniform layer rel_to_median = %f, want ~1", d.RelToMedian)
+		}
+	}
+}
+
+func TestEarliestOutlier(t *testing.T) {
+	SkipIfNoMLX(t)
+
+	// Three "layers": layer_0 clean, layer_1 has an early outlier at pos 1
+	// (the "bug origin"), layer_2 has larger absolute drift everywhere (the
+	// amplified downstream effect). EarliestOutlier should return 1, not 2,
+	// because layer_1 is where the relative anomaly first appears.
+	got := map[string]*mlx.Array{
+		"layer_0": mlx.FromValues([]float32{1, 2, 3, 4, 5, 6}, 1, 3, 2),
+		"layer_1": mlx.FromValues([]float32{1, 2, 50, 4, 5, 6}, 1, 3, 2),
+		"layer_2": mlx.FromValues([]float32{100, 200, 300, 400, 500, 600}, 1, 3, 2),
+	}
+	want := map[string]*mlx.Array{
+		"layer_0": mlx.FromValues([]float32{1, 2, 3, 4, 5, 6}, 1, 3, 2),
+		"layer_1": mlx.FromValues([]float32{1, 2, 3, 4, 5, 6}, 1, 3, 2),
+		"layer_2": mlx.FromValues([]float32{1, 2, 3, 4, 5, 6}, 1, 3, 2),
+	}
+	for _, a := range got {
+		mlx.Eval(a)
+	}
+	for _, a := range want {
+		mlx.Eval(a)
+	}
+
+	report := CompareLayersPerPosition(t, got, want, 1)
+
+	if got := report.EarliestOutlier(5); got != 1 {
+		t.Errorf("EarliestOutlier = %d, want 1 (bug origin, not amplified downstream)", got)
+	}
+	layer, pos := report.EarliestOutlierPosition(5)
+	if layer != 1 || pos != 1 {
+		t.Errorf("EarliestOutlierPosition = (%d, %d), want (1, 1)", layer, pos)
+	}
+
+	// With a huge cutoff nothing should qualify.
+	if got := report.EarliestOutlier(1e9); got != -1 {
+		t.Errorf("EarliestOutlier with impossible cutoff = %d, want -1", got)
+	}
+}
+
+func TestEarliestOutlierIgnoresPassingPositions(t *testing.T) {
+	SkipIfNoMLX(t)
+
+	got := map[string]*mlx.Array{
+		"layer_0": mlx.FromValues([]float32{1, 1, 1, 1.1, 1, 1}, 1, 3, 2),
+	}
+	want := map[string]*mlx.Array{
+		"layer_0": mlx.FromValues([]float32{1, 1, 1, 1, 1, 1}, 1, 3, 2),
+	}
+	for _, a := range got {
+		mlx.Eval(a)
+	}
+	for _, a := range want {
+		mlx.Eval(a)
+	}
+
+	report := CompareLayersPerPosition(t, got, want, 1, WithTolerance(0.5, 0))
+	if got := report.EarliestOutlier(5); got != -1 {
+		t.Errorf("EarliestOutlier = %d, want -1 for all-passing positions", got)
+	}
+	layer, pos := report.EarliestOutlierPosition(5)
+	if layer != -1 || pos != -1 {
+		t.Errorf("EarliestOutlierPosition = (%d, %d), want (-1, -1)", layer, pos)
+	}
+}
+
+func TestCompareLayersPerPosition(t *testing.T) {
+	SkipIfNoMLX(t)
+
+	// Three "layers": layers.2 matches everywhere, layers.10 has drift
+	// starting at position 2, and layers.11 has drift starting at position 1.
+	// Aggregator should report FirstDivergentLayer = 1 because natural sort
+	// orders layers.2 before layers.10.
+	got := map[string]*mlx.Array{
+		"layers.2":  mlx.FromValues([]float32{1, 2, 3, 4, 5, 6}, 1, 3, 2),
+		"layers.10": mlx.FromValues([]float32{1, 2, 3, 4, 999, 999}, 1, 3, 2),
+		"layers.11": mlx.FromValues([]float32{1, 2, 999, 999, 999, 999}, 1, 3, 2),
+	}
+	want := map[string]*mlx.Array{
+		"layers.2":  mlx.FromValues([]float32{1, 2, 3, 4, 5, 6}, 1, 3, 2),
+		"layers.10": mlx.FromValues([]float32{1, 2, 3, 4, 5, 6}, 1, 3, 2),
+		"layers.11": mlx.FromValues([]float32{1, 2, 3, 4, 5, 6}, 1, 3, 2),
+	}
+	for _, a := range got {
+		mlx.Eval(a)
+	}
+	for _, a := range want {
+		mlx.Eval(a)
+	}
+
+	report := CompareLayersPerPosition(t, got, want, 1)
+	if got, want := report.FirstDivergentLayer(), 1; got != want {
+		t.Errorf("FirstDivergentLayer = %d, want %d", got, want)
+	}
+	if got, want := report.Layers[0].Name, "layers.2"; got != want {
+		t.Errorf("first layer = %q, want %q", got, want)
+	}
+	if got, want := report.Layers[1].Name, "layers.10"; got != want {
+		t.Errorf("second layer = %q, want %q", got, want)
+	}
+	if report.Layers[0].FirstFailIndex != -1 {
+		t.Errorf("layers.2 should pass, got first fail at %d", report.Layers[0].FirstFailIndex)
+	}
+	if report.Layers[1].FirstFailIndex != 2 {
+		t.Errorf("layers.10 first fail = %d, want 2", report.Layers[1].FirstFailIndex)
+	}
+	layer, pos := report.EarliestToleranceExceedance()
+	if layer != 2 || pos != 1 {
+		t.Errorf("EarliestToleranceExceedance = (%d, %d), want (2, 1)", layer, pos)
+	}
+}

--- a/x/models/testutil/testutil_test.go
+++ b/x/models/testutil/testutil_test.go
@@ -1,0 +1,495 @@
+package testutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ollama/ollama/x/internal/mlxtest"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+)
+
+func TestDefaultRefDir(t *testing.T) {
+	// Without env var override
+	got := DefaultRefDir("test-model")
+	want := filepath.Join("/tmp", "ollama_ref", "test-model")
+	if got != want {
+		t.Errorf("DefaultRefDir = %q, want %q", got, want)
+	}
+
+	// With env var override
+	t.Setenv("OLLAMA_REF_DIR", "/custom/ref")
+	got = DefaultRefDir("test-model")
+	want = filepath.Join("/custom/ref", "test-model")
+	if got != want {
+		t.Errorf("DefaultRefDir with env = %q, want %q", got, want)
+	}
+}
+
+func TestModelDir_Missing(t *testing.T) {
+	// Verify the function returns the correct path when the directory exists.
+	dir := t.TempDir()
+	got := ModelDir(t, "TESTUTIL_MODEL_DIR_TEST", dir)
+	if got != dir {
+		t.Errorf("ModelDir = %q, want %q", got, dir)
+	}
+}
+
+func TestModelDir_EnvOverride(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("TESTUTIL_TEST_DIR", dir)
+	got := ModelDir(t, "TESTUTIL_TEST_DIR", "/nonexistent/default")
+	if got != dir {
+		t.Errorf("ModelDir = %q, want %q", got, dir)
+	}
+}
+
+func TestCompareArrays_Matching(t *testing.T) {
+	mlxtest.Setup(t)
+
+	a := mlx.FromValues([]float32{1.0, 2.0, 3.0, 4.0}, 2, 2)
+	b := mlx.FromValues([]float32{1.0, 2.0, 3.0, 4.0}, 2, 2)
+	mlx.Eval(a, b)
+
+	if !CompareArrays(t, "exact_match", a, b) {
+		t.Error("identical arrays should match")
+	}
+}
+
+func TestCompareArrays_WithinTolerance(t *testing.T) {
+	mlxtest.Setup(t)
+
+	a := mlx.FromValues([]float32{1.0, 2.0, 3.0, 4.0}, 2, 2)
+	b := mlx.FromValues([]float32{1.01, 2.01, 3.01, 4.01}, 2, 2)
+	mlx.Eval(a, b)
+
+	// Default tolerance (atol=1e-4, rtol=1e-3) should fail for diff=0.01
+	entry := compareArraysInner("tight", a, b, defaultConfig())
+	if entry.Passed {
+		t.Error("should fail with default tolerance")
+	}
+
+	// BFloat16 tolerance (atol=5e-3, rtol=5e-3) should pass for diff=0.01
+	cfg := defaultConfig()
+	BFloat16Tol()(&cfg)
+	entry = compareArraysInner("loose", a, b, cfg)
+	if !entry.Passed {
+		t.Error("should pass with BFloat16Tol")
+	}
+}
+
+func TestCompareArrays_ShapeMismatch(t *testing.T) {
+	mlxtest.Setup(t)
+
+	a := mlx.FromValues([]float32{1.0, 2.0, 3.0, 4.0}, 2, 2)
+	b := mlx.FromValues([]float32{1.0, 2.0, 3.0, 4.0}, 4)
+	mlx.Eval(a, b)
+
+	entry := compareArraysInner("shape_mismatch", a, b, defaultConfig())
+	if entry.Passed {
+		t.Error("different shapes should not pass")
+	}
+}
+
+func TestCompareArrays_CosineSim(t *testing.T) {
+	mlxtest.Setup(t)
+
+	a := mlx.FromValues([]float32{1.0, 0.0, 0.0}, 3)
+	b := mlx.FromValues([]float32{1.0, 0.0, 0.0}, 3)
+	mlx.Eval(a, b)
+
+	entry := compareArraysInner("parallel", a, b, defaultConfig())
+	if entry.CosineSim < 0.999 {
+		t.Errorf("parallel vectors cosine sim = %f, want ~1.0", entry.CosineSim)
+	}
+
+	// Orthogonal vectors
+	c := mlx.FromValues([]float32{0.0, 1.0, 0.0}, 3)
+	mlx.Eval(c)
+
+	entry = compareArraysInner("orthogonal", a, c, defaultConfig())
+	if entry.CosineSim > 0.001 {
+		t.Errorf("orthogonal vectors cosine sim = %f, want ~0.0", entry.CosineSim)
+	}
+}
+
+func TestCompareArraysCosineSim(t *testing.T) {
+	mlxtest.Setup(t)
+
+	// Near-parallel vectors with one element wide in absolute terms but the
+	// overall direction unchanged — should pass the cosine check.
+	a := mlx.FromValues([]float32{50.0, 1.0, 1.0, 1.0}, 4)
+	b := mlx.FromValues([]float32{51.0, 1.0, 1.0, 1.0}, 4)
+	mlx.Eval(a, b)
+	if !CompareArraysCosineSim(t, "near_parallel", a, b, 0.999) {
+		t.Error("expected near-parallel vectors to pass")
+	}
+
+	// Diverged pair (one element sign-flipped) — should fail.
+	c := mlx.FromValues([]float32{1.0, 1.0, 1.0, 1.0}, 4)
+	d := mlx.FromValues([]float32{-1.0, 1.0, 1.0, 1.0}, 4)
+	mlx.Eval(c, d)
+	subT := &testing.T{}
+	if CompareArraysCosineSim(subT, "diverged", c, d, 0.999) {
+		t.Error("expected diverged vectors to fail")
+	}
+	if !subT.Failed() {
+		t.Error("expected sub-test to record a failure")
+	}
+}
+
+func TestCompareArrays_MaxDiffLocation(t *testing.T) {
+	mlxtest.Setup(t)
+
+	a := mlx.FromValues([]float32{1.0, 2.0, 3.0, 4.0}, 4)
+	b := mlx.FromValues([]float32{1.0, 2.0, 3.5, 4.0}, 4)
+	mlx.Eval(a, b)
+
+	entry := compareArraysInner("max_at_2", a, b, defaultConfig())
+	if entry.MaxDiffAt != 2 {
+		t.Errorf("MaxDiffAt = %d, want 2", entry.MaxDiffAt)
+	}
+	if entry.MaxDiff < 0.49 || entry.MaxDiff > 0.51 {
+		t.Errorf("MaxDiff = %f, want ~0.5", entry.MaxDiff)
+	}
+}
+
+func TestCompareManyArrays(t *testing.T) {
+	mlxtest.Setup(t)
+
+	got := map[string]*mlx.Array{
+		"layer_0": mlx.FromValues([]float32{1.0, 2.0}, 2),
+		"layer_1": mlx.FromValues([]float32{3.0, 4.0}, 2),
+		"extra":   mlx.FromValues([]float32{5.0}, 1),
+	}
+	want := map[string]*mlx.Array{
+		"layer_0": mlx.FromValues([]float32{1.0, 2.0}, 2),
+		"layer_1": mlx.FromValues([]float32{3.0, 4.5}, 2), // mismatch
+		"other":   mlx.FromValues([]float32{6.0}, 1),
+	}
+	for _, a := range got {
+		mlx.Eval(a)
+	}
+	for _, a := range want {
+		mlx.Eval(a)
+	}
+
+	report := CompareManyArrays(t, got, want)
+
+	if len(report.Entries) != 2 {
+		t.Fatalf("expected 2 entries (common keys), got %d", len(report.Entries))
+	}
+
+	// layer_0 should pass, layer_1 should fail
+	for _, e := range report.Entries {
+		switch e.Name {
+		case "layer_0":
+			if !e.Passed {
+				t.Error("layer_0 should pass")
+			}
+		case "layer_1":
+			if e.Passed {
+				t.Error("layer_1 should fail with default tolerance")
+			}
+		}
+	}
+
+	if report.AllPassed() {
+		t.Error("report should not pass when layer_1 fails")
+	}
+}
+
+func TestCompareReport_Summary(t *testing.T) {
+	mlxtest.Setup(t)
+
+	// Just verify Summary doesn't panic
+	report := CompareReport{
+		Entries: []CompareEntry{
+			{Name: "layer_0", Passed: true, MaxDiff: 0.001, MeanDiff: 0.0005, CosineSim: 0.9999},
+			{Name: "layer_1", Passed: false, MaxDiff: 0.5, MeanDiff: 0.1, CosineSim: 0.95},
+		},
+	}
+	report.Summary(t)
+}
+
+func TestLoadReference_Missing(t *testing.T) {
+	mlxtest.Setup(t)
+
+	// Should skip (not fail) when file doesn't exist
+	// We can't easily test t.Skip from within, but we can verify
+	// the function handles the path correctly
+	path := filepath.Join(t.TempDir(), "nonexistent.safetensors")
+	if _, err := os.Stat(path); err == nil {
+		t.Fatal("test setup error: file should not exist")
+	}
+}
+
+func TestWithTolerance(t *testing.T) {
+	mlxtest.Setup(t)
+
+	a := mlx.FromValues([]float32{1.0, 2.0}, 2)
+	b := mlx.FromValues([]float32{1.1, 2.1}, 2)
+	mlx.Eval(a, b)
+
+	// Should fail with tight tolerance
+	entry := compareArraysInner("tight", a, b, defaultConfig())
+	if entry.Passed {
+		t.Error("should fail with default tolerance")
+	}
+
+	// Should pass with custom loose tolerance
+	cfg := defaultConfig()
+	WithTolerance(0.2, 0.2)(&cfg)
+	entry = compareArraysInner("loose", a, b, cfg)
+	if !entry.Passed {
+		t.Error("should pass with atol=0.2")
+	}
+}
+
+func TestModelDir_TildeExpansion(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home dir")
+	}
+
+	// Use a path that exists under home
+	got := ModelDir(t, "TESTUTIL_UNUSED_ENV", home)
+	if got != home {
+		t.Errorf("ModelDir = %q, want %q", got, home)
+	}
+}
+
+func TestCompareArraysPerPosition_AllMatch(t *testing.T) {
+	mlxtest.Setup(t)
+
+	// [1, 4, 3] tensor: identical, every position should pass.
+	a := mlx.FromValues([]float32{
+		1, 2, 3,
+		4, 5, 6,
+		7, 8, 9,
+		10, 11, 12,
+	}, 1, 4, 3)
+	b := mlx.FromValues([]float32{
+		1, 2, 3,
+		4, 5, 6,
+		7, 8, 9,
+		10, 11, 12,
+	}, 1, 4, 3)
+	mlx.Eval(a, b)
+
+	r := CompareArraysPerPosition(t, "match", a, b, 1)
+	if r.Length != 4 {
+		t.Errorf("Length = %d, want 4", r.Length)
+	}
+	if !r.AllPassed() {
+		t.Errorf("expected all positions to pass, first fail at %d", r.FirstFailIndex)
+	}
+	for i, d := range r.Drifts {
+		if d.MaxDiff != 0 {
+			t.Errorf("position %d max_diff = %f, want 0", i, d.MaxDiff)
+		}
+	}
+}
+
+func TestCompareArraysPerPosition_FirstFailLocated(t *testing.T) {
+	mlxtest.Setup(t)
+
+	// [1, 4, 3] tensor: positions 0 and 1 match, position 2 has a tiny diff
+	// (within tolerance), position 3 has a large diff (out of tolerance).
+	// FirstFailIndex must be exactly 3.
+	a := mlx.FromValues([]float32{
+		1.0, 2.0, 3.0,
+		4.0, 5.0, 6.0,
+		7.0001, 8.0, 9.0,
+		10.0, 11.0, 999.0,
+	}, 1, 4, 3)
+	b := mlx.FromValues([]float32{
+		1.0, 2.0, 3.0,
+		4.0, 5.0, 6.0,
+		7.0, 8.0, 9.0,
+		10.0, 11.0, 12.0,
+	}, 1, 4, 3)
+	mlx.Eval(a, b)
+
+	r := CompareArraysPerPosition(t, "find_drift", a, b, 1, BFloat16Tol())
+	if r.FirstFailIndex != 3 {
+		t.Errorf("FirstFailIndex = %d, want 3", r.FirstFailIndex)
+	}
+	if r.WorstIndex != 3 {
+		t.Errorf("WorstIndex = %d, want 3", r.WorstIndex)
+	}
+	if r.Drifts[0].Passed != true || r.Drifts[1].Passed != true {
+		t.Error("positions 0 and 1 should pass with tight tolerance (exact match)")
+	}
+	if r.Drifts[3].Passed {
+		t.Error("position 3 must fail (max_diff is 987)")
+	}
+	worst := r.Drifts[3].MaxDiff
+	if worst < 986 || worst > 988 {
+		t.Errorf("position 3 max_diff = %f, want ~987", worst)
+	}
+}
+
+func TestTopDrifts(t *testing.T) {
+	mlxtest.Setup(t)
+
+	// layer_a: one big outlier at pos 2. layer_b: uniform small drift everywhere.
+	// Absolute ranking should put layer_a pos 2 first. Relative ranking should
+	// also put layer_a pos 2 first (it's 99×+ its layer's median, while layer_b
+	// is ~1× everywhere).
+	got := map[string]*mlx.Array{
+		"layer_a": mlx.FromValues([]float32{1, 2, 3, 4, 999, 6, 7, 8}, 1, 4, 2),
+		"layer_b": mlx.FromValues([]float32{1.1, 2.1, 3.1, 4.1, 5.1, 6.1, 7.1, 8.1}, 1, 4, 2),
+	}
+	want := map[string]*mlx.Array{
+		"layer_a": mlx.FromValues([]float32{1, 2, 3, 4, 5, 6, 7, 8}, 1, 4, 2),
+		"layer_b": mlx.FromValues([]float32{1, 2, 3, 4, 5, 6, 7, 8}, 1, 4, 2),
+	}
+	for _, a := range got {
+		mlx.Eval(a)
+	}
+	for _, a := range want {
+		mlx.Eval(a)
+	}
+
+	report := CompareLayersPerPosition(t, got, want, 1)
+
+	absTop := report.TopDrifts(3)
+	if len(absTop) != 3 {
+		t.Fatalf("expected 3 top drifts, got %d", len(absTop))
+	}
+	if absTop[0].Layer != "layer_a" || absTop[0].Position != 2 {
+		t.Errorf("top absolute drift = %s/pos%d, want layer_a/pos2", absTop[0].Layer, absTop[0].Position)
+	}
+	if absTop[0].MaxDiff < 990 {
+		t.Errorf("top drift max_diff = %f, want ~994", absTop[0].MaxDiff)
+	}
+
+	relTop := report.TopDriftsByRelative(3)
+	if relTop[0].Layer != "layer_a" || relTop[0].Position != 2 {
+		t.Errorf("top relative drift = %s/pos%d, want layer_a/pos2", relTop[0].Layer, relTop[0].Position)
+	}
+	if relTop[0].RelToMedian < 10 {
+		t.Errorf("top rel_to_median = %f, want >>1 (outlier)", relTop[0].RelToMedian)
+	}
+
+	// Per-tensor TopDrifts on a uniform layer: rel_to_median should be ~1.
+	bTop := report.Layers[1].TopDrifts(0)
+	for _, d := range bTop {
+		if d.RelToMedian < 0.5 || d.RelToMedian > 2.0 {
+			t.Errorf("uniform layer rel_to_median = %f, want ~1", d.RelToMedian)
+		}
+	}
+}
+
+func TestEarliestOutlier(t *testing.T) {
+	mlxtest.Setup(t)
+
+	// Three "layers": layer_0 clean, layer_1 has an early outlier at pos 1
+	// (the "bug origin"), layer_2 has larger absolute drift everywhere (the
+	// amplified downstream effect). EarliestOutlier should return 1, not 2,
+	// because layer_1 is where the relative anomaly first appears.
+	got := map[string]*mlx.Array{
+		"layer_0": mlx.FromValues([]float32{1, 2, 3, 4, 5, 6}, 1, 3, 2),
+		"layer_1": mlx.FromValues([]float32{1, 2, 50, 4, 5, 6}, 1, 3, 2),
+		"layer_2": mlx.FromValues([]float32{100, 200, 300, 400, 500, 600}, 1, 3, 2),
+	}
+	want := map[string]*mlx.Array{
+		"layer_0": mlx.FromValues([]float32{1, 2, 3, 4, 5, 6}, 1, 3, 2),
+		"layer_1": mlx.FromValues([]float32{1, 2, 3, 4, 5, 6}, 1, 3, 2),
+		"layer_2": mlx.FromValues([]float32{1, 2, 3, 4, 5, 6}, 1, 3, 2),
+	}
+	for _, a := range got {
+		mlx.Eval(a)
+	}
+	for _, a := range want {
+		mlx.Eval(a)
+	}
+
+	report := CompareLayersPerPosition(t, got, want, 1)
+
+	if got := report.EarliestOutlier(5); got != 1 {
+		t.Errorf("EarliestOutlier = %d, want 1 (bug origin, not amplified downstream)", got)
+	}
+	layer, pos := report.EarliestOutlierPosition(5)
+	if layer != 1 || pos != 1 {
+		t.Errorf("EarliestOutlierPosition = (%d, %d), want (1, 1)", layer, pos)
+	}
+
+	// With a huge cutoff nothing should qualify.
+	if got := report.EarliestOutlier(1e9); got != -1 {
+		t.Errorf("EarliestOutlier with impossible cutoff = %d, want -1", got)
+	}
+}
+
+func TestEarliestOutlierIgnoresPassingPositions(t *testing.T) {
+	mlxtest.Setup(t)
+
+	got := map[string]*mlx.Array{
+		"layer_0": mlx.FromValues([]float32{1, 1, 1, 1.1, 1, 1}, 1, 3, 2),
+	}
+	want := map[string]*mlx.Array{
+		"layer_0": mlx.FromValues([]float32{1, 1, 1, 1, 1, 1}, 1, 3, 2),
+	}
+	for _, a := range got {
+		mlx.Eval(a)
+	}
+	for _, a := range want {
+		mlx.Eval(a)
+	}
+
+	report := CompareLayersPerPosition(t, got, want, 1, WithTolerance(0.5, 0))
+	if got := report.EarliestOutlier(5); got != -1 {
+		t.Errorf("EarliestOutlier = %d, want -1 for all-passing positions", got)
+	}
+	layer, pos := report.EarliestOutlierPosition(5)
+	if layer != -1 || pos != -1 {
+		t.Errorf("EarliestOutlierPosition = (%d, %d), want (-1, -1)", layer, pos)
+	}
+}
+
+func TestCompareLayersPerPosition(t *testing.T) {
+	mlxtest.Setup(t)
+
+	// Three "layers": layers.2 matches everywhere, layers.10 has drift
+	// starting at position 2, and layers.11 has drift starting at position 1.
+	// Aggregator should report FirstDivergentLayer = 1 because natural sort
+	// orders layers.2 before layers.10.
+	got := map[string]*mlx.Array{
+		"layers.2":  mlx.FromValues([]float32{1, 2, 3, 4, 5, 6}, 1, 3, 2),
+		"layers.10": mlx.FromValues([]float32{1, 2, 3, 4, 999, 999}, 1, 3, 2),
+		"layers.11": mlx.FromValues([]float32{1, 2, 999, 999, 999, 999}, 1, 3, 2),
+	}
+	want := map[string]*mlx.Array{
+		"layers.2":  mlx.FromValues([]float32{1, 2, 3, 4, 5, 6}, 1, 3, 2),
+		"layers.10": mlx.FromValues([]float32{1, 2, 3, 4, 5, 6}, 1, 3, 2),
+		"layers.11": mlx.FromValues([]float32{1, 2, 3, 4, 5, 6}, 1, 3, 2),
+	}
+	for _, a := range got {
+		mlx.Eval(a)
+	}
+	for _, a := range want {
+		mlx.Eval(a)
+	}
+
+	report := CompareLayersPerPosition(t, got, want, 1)
+	if got, want := report.FirstDivergentLayer(), 1; got != want {
+		t.Errorf("FirstDivergentLayer = %d, want %d", got, want)
+	}
+	if got, want := report.Layers[0].Name, "layers.2"; got != want {
+		t.Errorf("first layer = %q, want %q", got, want)
+	}
+	if got, want := report.Layers[1].Name, "layers.10"; got != want {
+		t.Errorf("second layer = %q, want %q", got, want)
+	}
+	if report.Layers[0].FirstFailIndex != -1 {
+		t.Errorf("layers.2 should pass, got first fail at %d", report.Layers[0].FirstFailIndex)
+	}
+	if report.Layers[1].FirstFailIndex != 2 {
+		t.Errorf("layers.10 first fail = %d, want 2", report.Layers[1].FirstFailIndex)
+	}
+	layer, pos := report.EarliestToleranceExceedance()
+	if layer != 2 || pos != 1 {
+		t.Errorf("EarliestToleranceExceedance = (%d, %d), want (2, 1)", layer, pos)
+	}
+}

--- a/x/models/testutil/wikitext.go
+++ b/x/models/testutil/wikitext.go
@@ -1,0 +1,77 @@
+package testutil
+
+import (
+	"regexp"
+	"strings"
+)
+
+// wikitextDetokenizer is a faithful Go port of EleutherAI lm-evaluation-
+// harness' preprocess_wikitext.wikitext_detokenizer. It restores the natural
+// English form of a wikitext-2-raw-v1 document by reversing the dataset's
+// tokenization marks (e.g. " @-@ " → "-", " : " → ": ", "\\s*\\(\\s*x\\s*\\)" → "(x)").
+//
+// This transform is applied to the input the model sees, but NOT to the
+// text used as the denominator for word_perplexity / byte_perplexity --
+// matching lm-eval-harness exactly. Without this transform, our PPL
+// numbers will be ~2× higher than the canonical wikitext PPL because the
+// model is being asked to predict alignment artifacts.
+//
+// Source for the original Python:
+//
+//	https://github.com/EleutherAI/lm-evaluation-harness/blob/main/lm_eval/tasks/wikitext/preprocess_wikitext.py
+func WikitextDetokenize(s string) string {
+	// contractions
+	s = strings.ReplaceAll(s, "s '", "s'")
+	s = wikitextContractionRe.ReplaceAllStringFunc(s, func(m string) string {
+		// `' [0-9]` -> `'[0-9]`: drop the space.
+		return string([]byte{m[0], m[2]})
+	})
+
+	// number separators
+	s = strings.ReplaceAll(s, " @-@ ", "-")
+	s = strings.ReplaceAll(s, " @,@ ", ",")
+	s = strings.ReplaceAll(s, " @.@ ", ".")
+
+	// punctuation
+	s = strings.ReplaceAll(s, " : ", ": ")
+	s = strings.ReplaceAll(s, " ; ", "; ")
+	s = strings.ReplaceAll(s, " . ", ". ")
+	s = strings.ReplaceAll(s, " ! ", "! ")
+	s = strings.ReplaceAll(s, " ? ", "? ")
+	s = strings.ReplaceAll(s, " , ", ", ")
+
+	// double brackets — strip whitespace immediately inside ( ) [ ] { } " '
+	s = wikitextParensRe.ReplaceAllString(s, "($1)")
+	s = wikitextSquareRe.ReplaceAllString(s, "[$1]")
+	s = wikitextBraceRe.ReplaceAllString(s, "{$1}")
+	s = wikitextDQuoteRe.ReplaceAllString(s, `"$1"`)
+	s = wikitextSQuoteRe.ReplaceAllString(s, "'$1'")
+
+	// miscellaneous
+	s = strings.ReplaceAll(s, "= = = =", "====")
+	s = strings.ReplaceAll(s, "= = =", "===")
+	s = strings.ReplaceAll(s, "= =", "==")
+	s = strings.ReplaceAll(s, " "+"\u00b0"+" ", "\u00b0") // " ° " → "°"
+	s = strings.ReplaceAll(s, " \n", "\n")
+	s = strings.ReplaceAll(s, "\n ", "\n")
+	s = strings.ReplaceAll(s, " N ", " 1 ")
+	s = strings.ReplaceAll(s, " 's", "'s")
+
+	return s
+}
+
+var (
+	// `' [0-9]` → `'[0-9]`. Original Python: `re.sub(r"' [0-9]", r"'[0-9]", s)`
+	// (the original code uses `r"/' [0-9]/"` which is a slash-bracketed regex
+	// literal in another language; the Python source we're porting writes the
+	// pattern as `r"' [0-9]"`).
+	wikitextContractionRe = regexp.MustCompile(`' [0-9]`)
+
+	// Each of these strips inner whitespace from a balanced bracket pair.
+	// Python: re.sub(r"\(\s*([^\)]*?)\s*\)", r"(\1)", s) etc.
+	wikitextParensRe = regexp.MustCompile(`\(\s*([^)]*?)\s*\)`)
+	wikitextSquareRe = regexp.MustCompile(`\[\s*([^\]]*?)\s*\]`)
+	wikitextBraceRe  = regexp.MustCompile(`\{\s*([^}]*?)\s*\}`)
+	wikitextDQuoteRe = regexp.MustCompile(`"\s*([^"]*?)\s*"`)
+	wikitextSQuoteRe = regexp.MustCompile(`'\s*([^']*?)\s*'`)
+)


### PR DESCRIPTION
Note: This will stay in draft for a while since the MLX engine is still evolving while we flesh the capabilities out.  We're not quite ready for a large influx of new model coverage.  As the APIs stabilize we can take this out of draft and start porting more models over.

Add a reference-driven workflow for bringing Hugging Face / transformers model architectures up on Ollama's MLX runner.

This includes repo-local porting guidance for humans and coding agents, PyTorch activation dumping with sidecar manifests, model inspection and validation-report scripts, Go test utilities for layer and per-position comparison, and an end-to-end perplexity CLI with cache and baseline comparison support.

The change also adds Gemma 4 and Qwen 3.5 validation fixtures that exercise the workflow.