### PR TITLE
runner: avoid full pending joins for stop checks

### DIFF
--- a/runner/common/stop.go
+++ b/runner/common/stop.go
@@ -22,23 +22,11 @@ func FindStopAfterAppend(pieces []string, stops []string) (bool, string) {
 	}
 
 	last := pieces[len(pieces)-1]
-	maxStop := 0
 	for _, stop := range stops {
 		if stop == "" || strings.Contains(last, stop) {
 			return true, stop
 		}
-		if len(stop) > maxStop {
-			maxStop = len(stop)
-		}
-	}
-
-	if maxStop <= 1 || len(pieces) == 1 {
-		return false, ""
-	}
-
-	tail := joinPreviousSuffixAndLast(pieces, maxStop-1)
-	for _, stop := range stops {
-		if strings.Contains(tail, stop) {
+		if len(stop) > 1 && strings.Contains(joinPreviousSuffixAndLast(pieces, len(stop)-1), stop) {
 			return true, stop
 		}
 	}

--- a/runner/common/stop.go
+++ b/runner/common/stop.go
@@ -14,6 +14,38 @@ func FindStop(sequence string, stops []string) (bool, string) {
 	return false, ""
 }
 
+// FindStopAfterAppend finds stop sequences that could have become visible after
+// appending the last piece to a previously checked sequence.
+func FindStopAfterAppend(pieces []string, stops []string) (bool, string) {
+	if len(pieces) == 0 {
+		return false, ""
+	}
+
+	last := pieces[len(pieces)-1]
+	maxStop := 0
+	for _, stop := range stops {
+		if stop == "" || strings.Contains(last, stop) {
+			return true, stop
+		}
+		if len(stop) > maxStop {
+			maxStop = len(stop)
+		}
+	}
+
+	if maxStop <= 1 || len(pieces) == 1 {
+		return false, ""
+	}
+
+	tail := joinPreviousSuffixAndLast(pieces, maxStop-1)
+	for _, stop := range stops {
+		if strings.Contains(tail, stop) {
+			return true, stop
+		}
+	}
+
+	return false, ""
+}
+
 func ContainsStopSuffix(sequence string, stops []string) bool {
 	for _, stop := range stops {
 		for i := 1; i <= len(stop); i++ {
@@ -24,6 +56,17 @@ func ContainsStopSuffix(sequence string, stops []string) bool {
 	}
 
 	return false
+}
+
+func ContainsStopSuffixInPieces(pieces []string, stops []string) bool {
+	maxStop := 0
+	for _, stop := range stops {
+		if len(stop) > maxStop {
+			maxStop = len(stop)
+		}
+	}
+
+	return ContainsStopSuffix(suffixString(pieces, maxStop), stops)
 }
 
 // TruncateStop removes the provided stop string from pieces,
@@ -65,6 +108,10 @@ func TruncateStop(pieces []string, stop string) ([]string, bool) {
 	return result, tokenTruncated
 }
 
+func IncompleteUnicodeInPieces(pieces []string) bool {
+	return IncompleteUnicode(suffixString(pieces, 4))
+}
+
 func IncompleteUnicode(token string) bool {
 	incomplete := false
 
@@ -93,4 +140,58 @@ func IncompleteUnicode(token string) bool {
 	}
 
 	return incomplete
+}
+
+func joinPreviousSuffixAndLast(pieces []string, n int) string {
+	if len(pieces) == 0 {
+		return ""
+	}
+
+	last := pieces[len(pieces)-1]
+	prefix := suffixString(pieces[:len(pieces)-1], n)
+	if prefix == "" {
+		return last
+	}
+
+	var b strings.Builder
+	b.Grow(len(prefix) + len(last))
+	b.WriteString(prefix)
+	b.WriteString(last)
+	return b.String()
+}
+
+func suffixString(pieces []string, n int) string {
+	if n <= 0 || len(pieces) == 0 {
+		return ""
+	}
+
+	total := 0
+	start := len(pieces)
+	for start > 0 && total < n {
+		start--
+		total += len(pieces[start])
+	}
+	if total == 0 {
+		return ""
+	}
+
+	skip := total - n
+	if skip < 0 {
+		skip = 0
+	}
+
+	var b strings.Builder
+	b.Grow(total - skip)
+	for _, piece := range pieces[start:] {
+		if skip >= len(piece) {
+			skip -= len(piece)
+			continue
+		}
+		if skip > 0 {
+			piece = piece[skip:]
+			skip = 0
+		}
+		b.WriteString(piece)
+	}
+	return b.String()
 }

--- a/runner/common/stop_test.go
+++ b/runner/common/stop_test.go
@@ -47,6 +47,19 @@ func TestFindStopAfterAppend(t *testing.T) {
 			stops: []string{""},
 			want:  true,
 		},
+		{
+			name:  "preserves stop list priority across boundary",
+			piece: []string{"ab", "cd zz"},
+			stops: []string{"abcd", "zz"},
+			want:  true,
+			stop:  "abcd",
+		},
+		{
+			name:  "ignores previous only shorter stop",
+			piece: []string{"abc", "d"},
+			stops: []string{"bc", "unmatched-long-stop"},
+			want:  false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/runner/common/stop_test.go
+++ b/runner/common/stop_test.go
@@ -2,8 +2,121 @@ package common
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
+
+func TestFindStopAfterAppend(t *testing.T) {
+	tests := []struct {
+		name  string
+		piece []string
+		stops []string
+		want  bool
+		stop  string
+	}{
+		{
+			name:  "within last piece",
+			piece: []string{"hello ", "stop and more"},
+			stops: []string{"stop"},
+			want:  true,
+			stop:  "stop",
+		},
+		{
+			name:  "spans previous suffix",
+			piece: []string{"hello st", "op"},
+			stops: []string{"stop"},
+			want:  true,
+			stop:  "stop",
+		},
+		{
+			name:  "spans multiple previous pieces",
+			piece: []string{"hello ", "s", "t", "op"},
+			stops: []string{"stop"},
+			want:  true,
+			stop:  "stop",
+		},
+		{
+			name:  "already checked prefix is ignored",
+			piece: []string{"stop", " and more"},
+			stops: []string{"stop"},
+			want:  false,
+		},
+		{
+			name:  "empty stop",
+			piece: []string{"anything"},
+			stops: []string{""},
+			want:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, stop := FindStopAfterAppend(tt.piece, tt.stops)
+			if got != tt.want || stop != tt.stop {
+				t.Fatalf("FindStopAfterAppend(%q, %q) = %v, %q; want %v, %q", tt.piece, tt.stops, got, stop, tt.want, tt.stop)
+			}
+		})
+	}
+}
+
+func TestPieceStopChecksMatchJoinedSuffixChecks(t *testing.T) {
+	tests := []struct {
+		name   string
+		pieces []string
+		stops  []string
+	}{
+		{
+			name:   "simple suffix",
+			pieces: []string{"hello ", "st"},
+			stops:  []string{"stop"},
+		},
+		{
+			name:   "full stop across pieces",
+			pieces: []string{"hello ", "st", "op"},
+			stops:  []string{"stop"},
+		},
+		{
+			name:   "stop inside newest piece",
+			pieces: []string{"hello ", "stop and more"},
+			stops:  []string{"stop"},
+		},
+		{
+			name:   "unicode suffix",
+			pieces: []string{"hello", string([]byte{0xe0, 0xa0})},
+			stops:  []string{"world"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for i := range tt.pieces {
+				pieces := tt.pieces[:i+1]
+				joined := strings.Join(pieces, "")
+
+				if got, want := ContainsStopSuffixInPieces(pieces, tt.stops), ContainsStopSuffix(joined, tt.stops); got != want {
+					t.Fatalf("ContainsStopSuffixInPieces(%q, %q) = %v; want %v", pieces, tt.stops, got, want)
+				}
+				if got, want := IncompleteUnicodeInPieces(pieces), IncompleteUnicode(joined); got != want {
+					t.Fatalf("IncompleteUnicodeInPieces(%q) = %v; want %v", pieces, got, want)
+				}
+
+				previousStop := false
+				if i > 0 {
+					previousStop, _ = FindStop(strings.Join(tt.pieces[:i], ""), tt.stops)
+				}
+				if previousStop {
+					continue
+				}
+
+				got, gotStop := FindStopAfterAppend(pieces, tt.stops)
+				want, wantStop := FindStop(joined, tt.stops)
+				if got != want || gotStop != wantStop {
+					t.Fatalf("FindStopAfterAppend(%q, %q) = %v, %q; want %v, %q", pieces, tt.stops, got, gotStop, want, wantStop)
+				}
+			}
+		})
+	}
+}
 
 func TestTruncateStop(t *testing.T) {
 	tests := []struct {
@@ -58,6 +171,32 @@ func TestTruncateStop(t *testing.T) {
 			}
 		})
 	}
+}
+
+func BenchmarkPendingStopChecks(b *testing.B) {
+	pieces := make([]string, 256)
+	for i := range pieces {
+		pieces[i] = "partial "
+	}
+	pieces[len(pieces)-1] = "sto"
+	stops := []string{"stop sequence", "another stop"}
+
+	b.Run("join", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			joined := strings.Join(pieces, "")
+			FindStop(joined, stops)
+			ContainsStopSuffix(joined, stops)
+			IncompleteUnicode(joined)
+		}
+	})
+
+	b.Run("pieces", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			FindStopAfterAppend(pieces, stops)
+			ContainsStopSuffixInPieces(pieces, stops)
+			IncompleteUnicodeInPieces(pieces)
+		}
+	})
 }
 
 func TestIncompleteUnicode(t *testing.T) {

--- a/runner/llamarunner/runner.go
+++ b/runner/llamarunner/runner.go
@@ -564,9 +564,8 @@ func (s *Server) processBatch(tokenBatch *llama.Batch, embedBatch *llama.Batch) 
 		seq.inputs = []input{{token: token}}
 
 		seq.pendingResponses = append(seq.pendingResponses, piece)
-		sequence := strings.Join(seq.pendingResponses, "")
 
-		if ok, stop := common.FindStop(sequence, seq.stop); ok {
+		if ok, stop := common.FindStopAfterAppend(seq.pendingResponses, seq.stop); ok {
 			slog.Debug("hit stop token", "pending", seq.pendingResponses, "stop", stop)
 
 			var tokenTruncated bool
@@ -603,11 +602,11 @@ func (s *Server) processBatch(tokenBatch *llama.Batch, embedBatch *llama.Batch) 
 			continue
 		}
 
-		if common.ContainsStopSuffix(sequence, seq.stop) {
+		if common.ContainsStopSuffixInPieces(seq.pendingResponses, seq.stop) {
 			continue
 		}
 
-		if common.IncompleteUnicode(sequence) {
+		if common.IncompleteUnicodeInPieces(seq.pendingResponses) {
 			continue
 		}
 

--- a/runner/ollamarunner/runner.go
+++ b/runner/ollamarunner/runner.go
@@ -793,9 +793,7 @@ func (s *Server) computeBatch(activeBatch batchState) {
 			continue
 		}
 
-		sequence := strings.Join(seq.pendingResponses, "")
-
-		if ok, stop := common.FindStop(sequence, seq.stop); ok {
+		if ok, stop := common.FindStopAfterAppend(seq.pendingResponses, seq.stop); ok {
 			slog.Debug("hit stop token", "pending", seq.pendingResponses, "stop", stop)
 
 			var tokenTruncated bool
@@ -833,11 +831,11 @@ func (s *Server) computeBatch(activeBatch batchState) {
 			continue
 		}
 
-		if common.ContainsStopSuffix(sequence, seq.stop) {
+		if common.ContainsStopSuffixInPieces(seq.pendingResponses, seq.stop) {
 			continue
 		}
 
-		if common.IncompleteUnicode(sequence) {
+		if common.IncompleteUnicodeInPieces(seq.pendingResponses) {
 			continue
 		}
 


### PR DESCRIPTION
## Summary

- Avoid repeatedly joining the full pending response buffer when checking stop strings in the runner hot path.
- Add piece-aware stop matching helpers and regression coverage for stop-list priority across piece boundaries.
- Preserve existing runner behavior while reducing avoidable allocation/work in the common pending-response check.

## Validation

- `go test ./runner/common ./runner/llamarunner ./runner/ollamarunner`
- `go test ./runner/common -run '^$' -bench '^BenchmarkPendingStopChecks$' -benchmem -count=1`

Benchmark on my machine:

- `join`: `3325 ns/op`, `2048 B/op`, `1 allocs/op`
- `pieces`: `279.0 ns/op`, `88 B/op`, `6 allocs/op`
