### PR TITLE
fix: handle backslash-escaped spaces and tildes in CLI image paths

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -583,7 +583,11 @@ func NewCreateRequest(name string, opts runOptions) *api.CreateRequest {
 }
 
 func normalizeFilePath(fp string) string {
-	return strings.NewReplacer(
+	// Handle shell-escaped single quotes: '\'' (end quote, escaped quote, start quote)
+	// This pattern appears in Linux drag-and-drop paths with embedded single quotes
+	fp = strings.ReplaceAll(fp, "'\\''", "'")
+
+	fp = strings.NewReplacer(
 		"\\ ", " ", // Escaped space
 		"\\(", "(", // Escaped left parenthesis
 		"\\)", ")", // Escaped right parenthesis
@@ -600,13 +604,22 @@ func normalizeFilePath(fp string) string {
 		"\\?", "?", // Escaped question mark
 		"\\~", "~", // Escaped tilde
 	).Replace(fp)
+
+	// Expand tilde to user's home directory
+	if strings.HasPrefix(fp, "~/") || fp == "~" {
+		if home, err := os.UserHomeDir(); err == nil {
+			fp = home + fp[1:]
+		}
+	}
+
+	return fp
 }
 
 func extractFileNames(input string) []string {
-	// Regex to match file paths starting with optional drive letter, / ./ \ or .\ and include escaped or unescaped spaces (\ or %20)
+	// Regex to match file paths starting with optional drive letter, / ./ ~ or ~/ and include escaped or unescaped spaces (\ or %20)
 	// and followed by more characters and a file extension
 	// This will capture non filename strings, but we'll check for file existence to remove mismatches
-	regexPattern := `(?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp|wav)\b`
+	regexPattern := `(?:[a-zA-Z]:)?(?:~/?|\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp|wav)\b`
 	re := regexp.MustCompile(regexPattern)
 
 	return re.FindAllString(input, -1)

--- a/cmd/interactive_test.go
+++ b/cmd/interactive_test.go
@@ -64,6 +64,40 @@ d:\path with\spaces\thirteen.WEBP some ending
 	assert.Contains(t, res[12], "d:")
 }
 
+func TestExtractFilenamesEscapedPaths(t *testing.T) {
+	// macOS drag-and-drop: backslash-escaped spaces and tildes
+	input := `/Users/ollama/Library/Mobile\ Documents/com\~apple\~CloudDocs/screenshots/CleanShot\ 2025-04-17\ at\ 21.26.40@2x.png`
+	res := extractFileNames(input)
+	assert.Len(t, res, 1)
+	assert.Contains(t, res[0], "CleanShot")
+	assert.Contains(t, res[0], ".png")
+	nfp := normalizeFilePath(res[0])
+	assert.Equal(t, "/Users/ollama/Library/Mobile Documents/com~apple~CloudDocs/screenshots/CleanShot 2025-04-17 at 21.26.40@2x.png", nfp)
+
+	// Linux drag-and-drop: single-quoted path with spaces
+	input = `'/home/rick/filename with spaces.jpg'`
+	res = extractFileNames(input)
+	assert.Len(t, res, 1)
+	nfp = normalizeFilePath(res[0])
+	assert.Equal(t, "/home/rick/filename with spaces.jpg", nfp)
+
+	// Linux drag-and-drop: single-quoted path with embedded single quote
+	input = `'/home/rick/file'\''name.jpg'`
+	res = extractFileNames(input)
+	assert.Len(t, res, 1)
+	nfp = normalizeFilePath(res[0])
+	assert.Equal(t, "/home/rick/file'name.jpg", nfp)
+
+	// Tilde home directory paths are matched and expanded
+	input = `~/Desktop/photo.png`
+	res = extractFileNames(input)
+	assert.Len(t, res, 1)
+	assert.Equal(t, "~/Desktop/photo.png", res[0])
+	nfp = normalizeFilePath(res[0])
+	home, _ := os.UserHomeDir()
+	assert.Equal(t, home+"/Desktop/photo.png", nfp)
+}
+
 // Ensure that file paths wrapped in single quotes are removed with the quotes.
 func TestExtractFileDataRemovesQuotedFilepath(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary

- Handle shell-escaped single quotes (`'\''`) in file paths from Linux drag-and-drop
- Support tilde (`~`) prefix in file paths, expanding to user's home directory
- Add regex support for `~/` path prefix so `~/Desktop/photo.png` is recognized

## Test plan

- [x] Existing `TestExtractFilenames` passes (Unix and Windows paths)
- [x] Existing `TestExtractFileDataRemovesQuotedFilepath` passes
- [x] Existing `TestExtractFileDataWAV` passes
- [x] New `TestExtractFilenamesEscapedPaths` covers:
  - macOS drag-and-drop paths with `\ ` and `\~` (e.g. `Mobile\ Documents/com\~apple\~CloudDocs`)
  - Linux single-quoted paths with spaces
  - Linux single-quoted paths with embedded single quotes (`'\''`)
  - Tilde home directory expansion (`~/Desktop/photo.png`)

Fixes #10333