### PR TITLE
sample: reduce greedy and top-k sampler allocations

### DIFF
--- a/sample/samplers.go
+++ b/sample/samplers.go
@@ -30,6 +30,16 @@ func (s *Sampler) Sample(logits []float32) (int32, error) {
 		return -1, errors.New("sample: no logits provided to sample")
 	}
 
+	if s.temperature == 0 && s.grammar == nil {
+		max := 0
+		for i := 1; i < len(logits); i++ {
+			if logits[i] > logits[max] {
+				max = i
+			}
+		}
+		return int32(max), nil
+	}
+
 	tokens := make([]token, len(logits))
 	for i := range logits {
 		tokens[i].id = int32(i)

--- a/sample/samplers_test.go
+++ b/sample/samplers_test.go
@@ -60,6 +60,26 @@ func TestWeighted(t *testing.T) {
 	}
 }
 
+func TestGreedySamplerNoAllocation(t *testing.T) {
+	logits := []float32{-1, 3, 2, 4}
+	sampler := NewSampler(0, 0, 0, 0, -1, nil)
+
+	var got int32
+	var err error
+	allocs := testing.AllocsPerRun(1000, func() {
+		got, err = sampler.Sample(logits)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 3 {
+		t.Fatalf("index mismatch: want 3, got %d", got)
+	}
+	if allocs != 0 {
+		t.Fatalf("allocs = %v; want 0", allocs)
+	}
+}
+
 func modelHelper(t testing.TB) tokenizer.Tokenizer {
 	t.Helper()
 

--- a/sample/transforms.go
+++ b/sample/transforms.go
@@ -67,16 +67,10 @@ func topK(ts []token, k int) []token {
 		}
 	}
 
-	slices.SortFunc(h, func(a, b token) int {
-		switch {
-		case a.value < b.value:
-			return 1
-		case a.value > b.value:
-			return -1
-		default:
-			return 0
-		}
-	})
+	for i := len(h) - 1; i > 0; i-- {
+		h[0], h[i] = h[i], h[0]
+		siftDownMin(h[:i], 0)
+	}
 
 	return h
 }
@@ -90,7 +84,7 @@ func siftDownMin(ts []token, i int) {
 		if right := child + 1; right < len(ts) && ts[right].value < ts[child].value {
 			child = right
 		}
-		if ts[i].value <= ts[child].value {
+		if !(ts[child].value < ts[i].value) {
 			return
 		}
 		ts[i], ts[child] = ts[child], ts[i]

--- a/sample/transforms.go
+++ b/sample/transforms.go
@@ -1,29 +1,9 @@
 package sample
 
 import (
-	"container/heap"
 	"math"
 	"slices"
 )
-
-// tokenHeap implements heap.Interface and holds tokens as a min-heap to track k largest elements
-type tokenHeap []token
-
-func (h tokenHeap) Len() int           { return len(h) }
-func (h tokenHeap) Less(i, j int) bool { return h[i].value < h[j].value }
-func (h tokenHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
-
-func (h *tokenHeap) Push(x any) {
-	*h = append(*h, x.(token))
-}
-
-func (h *tokenHeap) Pop() any {
-	old := *h
-	n := len(old)
-	x := old[n-1]
-	*h = old[0 : n-1]
-	return x
-}
 
 // temperature applies scaling to the logits
 func temperature(ts []token, temp float32) {
@@ -74,25 +54,48 @@ func topK(ts []token, k int) []token {
 	}
 
 	// Initialize min-heap with first k elements
-	h := make(tokenHeap, k)
-	copy(h, ts[:k])
-	heap.Init(&h)
+	h := ts[:k]
+	for i := k/2 - 1; i >= 0; i-- {
+		siftDownMin(h, i)
+	}
 
 	// Process remaining elements
 	for i := k; i < len(ts); i++ {
 		if ts[i].value > h[0].value {
-			heap.Pop(&h)
-			heap.Push(&h, ts[i])
+			h[0] = ts[i]
+			siftDownMin(h, 0)
 		}
 	}
 
-	// Convert heap to sorted slice in descending order
-	result := make([]token, len(h))
-	for i := k - 1; i >= 0; i-- {
-		result[i] = heap.Pop(&h).(token)
-	}
+	slices.SortFunc(h, func(a, b token) int {
+		switch {
+		case a.value < b.value:
+			return 1
+		case a.value > b.value:
+			return -1
+		default:
+			return 0
+		}
+	})
 
-	return result
+	return h
+}
+
+func siftDownMin(ts []token, i int) {
+	for {
+		child := 2*i + 1
+		if child >= len(ts) {
+			return
+		}
+		if right := child + 1; right < len(ts) && ts[right].value < ts[child].value {
+			child = right
+		}
+		if ts[i].value <= ts[child].value {
+			return
+		}
+		ts[i], ts[child] = ts[child], ts[i]
+		i = child
+	}
 }
 
 // topP limits tokens to those with cumulative probability p

--- a/sample/transforms_test.go
+++ b/sample/transforms_test.go
@@ -160,6 +160,26 @@ func TestTopK(t *testing.T) {
 	}
 }
 
+func TestTopKTieOrder(t *testing.T) {
+	input := []float32{5, 1, 5, 4, 5, 3}
+	tokens := topK(toTokens(input), 3)
+	wantIDs := []int32{0, 2, 4}
+	for i, want := range wantIDs {
+		if tokens[i].id != want {
+			t.Fatalf("topK tie id at index %d: want %d, got %d", i, want, tokens[i].id)
+		}
+	}
+
+	input = []float32{4, 4, 4, 3, 4, 2}
+	tokens = topK(toTokens(input), 3)
+	wantIDs = []int32{1, 2, 0}
+	for i, want := range wantIDs {
+		if tokens[i].id != want {
+			t.Fatalf("topK tie id at index %d: want %d, got %d", i, want, tokens[i].id)
+		}
+	}
+}
+
 func TestTopP(t *testing.T) {
 	input := []float32{-3, -2, -1, 0, 1, 2, 4}
 	tokens := toTokens(input)


### PR DESCRIPTION
## Summary

This reduces sampler overhead in two focused paths:

- add a no-allocation greedy fast path when temperature is zero and no grammar sampler is active
- replace positive top-k sampling's generic `container/heap` path with an in-place typed min-heap over the existing token slice
- add regression coverage for greedy allocations and top-k tie ordering

The top-p/full-sort path is intentionally left unchanged to avoid changing broader sampling semantics.

## Validation

- `go test ./sample`
- `go test ./sample -run '^$' -bench 'Benchmark(GreedySampler|WeightedSampler|Transforms)' -benchmem -count=1`
- `git diff --check upstream/main..HEAD`

Benchmark signals from the replayed current-upstream branch:

- `BenchmarkWeightedSampler/ConfigGreedy`: `83574 ns/op`, `0 B/op`, `0 allocs/op`
- `BenchmarkGreedySampler/Size_100000`: `81878 ns/op`, `0 B/op`, `0 allocs/op`
- `BenchmarkWeightedSampler/ConfigTopK`: `548624 ns/op`, `1024023 B/op`, `1 alloc/op`
- `BenchmarkTransforms/TopK`: `28393 ns/op`, `0 B/op`, `0 allocs/op`
