### PR TITLE
docs: Fix uninstallation instruction on macOS

### DIFF
--- a/docs/macos.mdx
+++ b/docs/macos.mdx
@@ -35,8 +35,8 @@ To fully remove Ollama from your system, remove the following files and folders:
 ```
 sudo rm -rf /Applications/Ollama.app
 sudo rm /usr/local/bin/ollama
-rm -rf "~/Library/Application Support/Ollama"
-rm -rf "~/Library/Saved Application State/com.electron.ollama.savedState"
+rm -rf "${HOME}/Library/Application Support/Ollama"
+rm -rf "${HOME}/Library/Saved Application State/com.electron.ollama.savedState"
 rm -rf ~/Library/Caches/com.electron.ollama/
 rm -rf ~/Library/Caches/ollama
 rm -rf ~/Library/WebKit/com.electron.ollama


### PR DESCRIPTION
Tilde does not expand to the home directory path when quoted. Use `$HOME` instead.