### PR TITLE
ggml-metal: fix mixed bf16/f16 cooperative tensor operand order

### DIFF
--- a/llama/patches/0037-ggml-metal-match-cooperative-tensor-operand-order.patch
+++ b/llama/patches/0037-ggml-metal-match-cooperative-tensor-operand-order.patch
@@ -1,0 +1,33 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Horacehxw <horacehxw@gmail.com>
+Date: Wed, 22 Apr 2026 16:40:00 +0800
+Subject: [PATCH] ggml-metal: match cooperative tensor operand order
+
+---
+ ggml/src/ggml-metal/ggml-metal.metal | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/ggml/src/ggml-metal/ggml-metal.metal b/ggml/src/ggml-metal/ggml-metal.metal
+index 398c80717b68d7bacc93dd66b7fd3e6444ecabc7..ab902475a955b834796eee64a8a3f54fad0496aa 100644
+--- a/ggml/src/ggml-metal/ggml-metal.metal
++++ b/ggml/src/ggml-metal/ggml-metal.metal
+@@ -9149,7 +9149,7 @@ kernel void kernel_mul_mm(
+         mpp::tensor_ops::matmul2d_descriptor(NR1, NR0, NK, false, true, false, mpp::tensor_ops::matmul2d_descriptor::mode::multiply_accumulate),
+         execution_simdgroups<4>> mm;
+ 
+-    auto cT = mm.get_destination_cooperative_tensor<decltype(tA), decltype(tB), float>();
++    auto cT = mm.get_destination_cooperative_tensor<decltype(tB), decltype(tA), float>();
+ #endif
+ 
+     for (int loop_k = 0; loop_k < args.ne00; loop_k += NK) {
+@@ -9534,7 +9534,7 @@ kernel void kernel_mul_mm_id(
+         mpp::tensor_ops::matmul2d_descriptor(NR1, NR0, NK, false, true, false, mpp::tensor_ops::matmul2d_descriptor::mode::multiply_accumulate),
+         execution_simdgroups<4>> mm;
+ 
+-    auto cT = mm.get_destination_cooperative_tensor<decltype(tA), decltype(tB), float>();
++    auto cT = mm.get_destination_cooperative_tensor<decltype(tB), decltype(tA), float>();
+ #endif
+ 
+     for (int loop_k = 0; loop_k < args.ne00; loop_k += NK) {
+-- 
+2.39.5

--- a/ml/backend/ggml/ggml/src/ggml-metal/ggml-metal-embed.metal
+++ b/ml/backend/ggml/ggml/src/ggml-metal/ggml-metal-embed.metal
@@ -11971,7 +11971,7 @@ kernel void kernel_mul_mm(
         mpp::tensor_ops::matmul2d_descriptor(NR1, NR0, NK, false, true, false, mpp::tensor_ops::matmul2d_descriptor::mode::multiply_accumulate),
         execution_simdgroups<4>> mm;
 
-    auto cT = mm.get_destination_cooperative_tensor<decltype(tA), decltype(tB), float>();
+    auto cT = mm.get_destination_cooperative_tensor<decltype(tB), decltype(tA), float>();
 #endif
 
     for (int loop_k = 0; loop_k < args.ne00; loop_k += NK) {
@@ -12356,7 +12356,7 @@ kernel void kernel_mul_mm_id(
         mpp::tensor_ops::matmul2d_descriptor(NR1, NR0, NK, false, true, false, mpp::tensor_ops::matmul2d_descriptor::mode::multiply_accumulate),
         execution_simdgroups<4>> mm;
 
-    auto cT = mm.get_destination_cooperative_tensor<decltype(tA), decltype(tB), float>();
+    auto cT = mm.get_destination_cooperative_tensor<decltype(tB), decltype(tA), float>();
 #endif
 
     for (int loop_k = 0; loop_k < args.ne00; loop_k += NK) {

--- a/ml/backend/ggml/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ml/backend/ggml/ggml/src/ggml-metal/ggml-metal.metal
@@ -9149,7 +9149,7 @@ kernel void kernel_mul_mm(
         mpp::tensor_ops::matmul2d_descriptor(NR1, NR0, NK, false, true, false, mpp::tensor_ops::matmul2d_descriptor::mode::multiply_accumulate),
         execution_simdgroups<4>> mm;
 
-    auto cT = mm.get_destination_cooperative_tensor<decltype(tA), decltype(tB), float>();
+    auto cT = mm.get_destination_cooperative_tensor<decltype(tB), decltype(tA), float>();
 #endif
 
     for (int loop_k = 0; loop_k < args.ne00; loop_k += NK) {
@@ -9534,7 +9534,7 @@ kernel void kernel_mul_mm_id(
         mpp::tensor_ops::matmul2d_descriptor(NR1, NR0, NK, false, true, false, mpp::tensor_ops::matmul2d_descriptor::mode::multiply_accumulate),
         execution_simdgroups<4>> mm;
 
-    auto cT = mm.get_destination_cooperative_tensor<decltype(tA), decltype(tB), float>();
+    auto cT = mm.get_destination_cooperative_tensor<decltype(tB), decltype(tA), float>();
 #endif
 
     for (int loop_k = 0; loop_k < args.ne00; loop_k += NK) {


### PR DESCRIPTION
## Summary

This fixes a mixed `bf16`/`f16` cooperative tensor compile failure in the Metal backend on Apple M5 / Metal 4 systems.

The failure shows up as:

```text
static_assert failed due to requirement '__tensor_ops_detail::__is_same_v<bfloat, half>'
"Input types must match cooperative tensor types"
```

## Root cause

In both `kernel_mul_mm` and `kernel_mul_mm_id`, the destination cooperative tensor is instantiated as if the operand order were `(tA, tB)`:

```cpp
auto cT = mm.get_destination_cooperative_tensor<decltype(tA), decltype(tB), float>();
```

but the actual matmul call uses `(sB, sA, cT)`:

```cpp
mm.run(sB, sA, cT);
```

That mismatch is benign for same-type pairs, but it breaks mixed `bf16`/`f16` cooperative tensor instantiations under the stricter MetalPerformancePrimitives checks on Apple10 / Metal 4.

This patch makes the destination tensor type match the actual operand order passed to `mm.run`.

## Scope

Files changed:
- `ml/backend/ggml/ggml/src/ggml-metal/ggml-metal.metal`
- `ml/backend/ggml/ggml/src/ggml-metal/ggml-metal-embed.metal`

## Relationship to existing work

This addresses the same user-visible failure as #14432.

It is also related to #14604, but takes a different approach:
- `#14604` works around the problem by removing the mixed `bf16`/`f16` kernels and forcing fallback behavior
- this PR fixes the operand-order mismatch directly, so the mixed cooperative tensor path can compile and run

## Verification

Tested locally on:
- Apple M5 Pro
- macOS 26.4
- latest `main` as of 2026-04-15

### Reproduction on unpatched `main`

Built `dist/darwin-arm64/ollama`, then ran:

```bash
env -u GGML_METAL_TENSOR_DISABLE \
  ./dist/darwin-arm64/ollama runner --ollama-engine \
  --model ~/.ollama/models/blobs/sha256-7121486771cbfe218851513210c40b35dbdee93ab1ef43fe36283c883980f0df \
  --port 64150

curl http://127.0.0.1:64150/info
```

Result:
- runner crashes during tensor probe / Metal library initialization
- stderr contains the `Input types must match cooperative tensor types` static_assert from `MPPTensorOpsMatMul2dImpl.h`

### Verification on this patch

After rebuilding with this change, the same `/info` request succeeds.

Observed runner log:

```text
ggml_metal_device_init: testing tensor API for f16 support
ggml_metal_device_init: testing tensor API for bfloat support
ggml_metal_library_init: loaded in 7.085 sec
ggml_metal_device_init: has bfloat            = true
ggml_metal_device_init: has tensor            = true
```

I also verified model load on the patched runner using the same Gemma 4 26B blob:
- `fit` succeeds
- `alloc` succeeds
- `commit` succeeds
- `/health` reaches `{"status":0,"progress":1}`
- log shows:

```text
offloaded 31/31 layers to GPU
```

This was verified with `GGML_METAL_TENSOR_DISABLE` unset.

Fixes #14432.
