### PR TITLE
launch/openclaw: fix --yes flag behaviour to skip channels configuration

### DIFF
--- a/cmd/launch/openclaw.go
+++ b/cmd/launch/openclaw.go
@@ -186,6 +186,13 @@ func (c *Openclaw) runChannelSetupPreflight(bin string) error {
 	if !isInteractiveSession() {
 		return nil
 	}
+	// --yes is meant for headless/quick setup; channel config spawns an
+	// interactive subprocess (`openclaw channels add`), so auto-approving the
+	// prompt would block the user on a picker they cannot skip. Skip the whole
+	// preflight in --yes mode; users can run `openclaw channels add` later.
+	if currentLaunchConfirmPolicy.yes {
+		return nil
+	}
 
 	for {
 		if c.channelsConfigured() {

--- a/cmd/launch/openclaw.go
+++ b/cmd/launch/openclaw.go
@@ -186,10 +186,8 @@ func (c *Openclaw) runChannelSetupPreflight(bin string) error {
 	if !isInteractiveSession() {
 		return nil
 	}
-	// --yes is meant for headless/quick setup; channel config spawns an
-	// interactive subprocess (`openclaw channels add`), so auto-approving the
-	// prompt would block the user on a picker they cannot skip. Skip the whole
-	// preflight in --yes mode; users can run `openclaw channels add` later.
+	// --yes is headless; channel setup spawns an interactive picker we can't
+	// auto-answer, so skip it. Users can run `openclaw channels add` later.
 	if currentLaunchConfirmPolicy.yes {
 		return nil
 	}

--- a/cmd/launch/openclaw_test.go
+++ b/cmd/launch/openclaw_test.go
@@ -1304,6 +1304,46 @@ func TestOpenclawChannelSetupPreflight(t *testing.T) {
 		}
 	})
 
+	t.Run("--yes skips preflight without channels configured", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setTestHome(t, tmpDir)
+		t.Setenv("PATH", tmpDir)
+		configDir := filepath.Join(tmpDir, ".openclaw")
+		if err := os.MkdirAll(configDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		// Empty config = no channels configured. Without the --yes skip, the
+		// preflight would prompt and (on confirm) spawn `openclaw channels add`.
+		if err := os.WriteFile(filepath.Join(configDir, "openclaw.json"), []byte(`{}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		bin := filepath.Join(tmpDir, "openclaw")
+		if err := os.WriteFile(bin, []byte("#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$HOME/invocations.log\"\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		oldInteractive := isInteractiveSession
+		isInteractiveSession = func() bool { return true }
+		defer func() { isInteractiveSession = oldInteractive }()
+
+		restore := withLaunchConfirmPolicy(launchConfirmPolicy{yes: true})
+		defer restore()
+
+		oldConfirmPrompt := DefaultConfirmPrompt
+		DefaultConfirmPrompt = func(prompt string, options ConfirmOptions) (bool, error) {
+			t.Fatalf("did not expect prompt in --yes mode: %s", prompt)
+			return false, nil
+		}
+		defer func() { DefaultConfirmPrompt = oldConfirmPrompt }()
+
+		if err := c.runChannelSetupPreflight("openclaw"); err != nil {
+			t.Fatalf("runChannelSetupPreflight() error = %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(tmpDir, "invocations.log")); !os.IsNotExist(err) {
+			t.Fatalf("expected no channels add invocation in --yes mode, got err=%v", err)
+		}
+	})
+
 	t.Run("set up later prompts once and exits", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		setTestHome(t, tmpDir)


### PR DESCRIPTION
- `ollama launch openclaw --yes` was getting stuck at the "Connect a channel?" prompt when no channel was pre-configured. `--yes` auto-approved the prompt, which spawned the interactive openclaw channels add picker — the opposite of headless behaviour.
- Skip the channel preflight entirely when `--yes` is set. Users can run openclaw channels add manually when they want to configure a channel.

fixed: #15520 