### PR TITLE
fix: correct error message for Metal shader compilation failure

### DIFF
--- a/ml/backend/ggml/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ml/backend/ggml/ggml/src/ggml-metal/ggml-metal-device.m
@@ -790,7 +790,7 @@ ggml_metal_device_t ggml_metal_device_init(void) {
 
             dev->library = ggml_metal_library_init(dev);
             if (!dev->library) {
-                GGML_LOG_ERROR("%s: error: failed to create library\n", __func__);
+                GGML_LOG_ERROR("%s: error: failed to create Metal library (Metal shader compilation failure)\n", __func__);
             }
 
             if (dev->props.use_residency_sets) {


### PR DESCRIPTION
The error message 'failed to create library' is misleading for the Metal shader compilation failure (MTLLibraryErrorDomain Code=3). Fix the error message to correctly describe the issue. Fixes #15599.