### PR TITLE
docs: Description for the coding agents in the Integration section

### DIFF
--- a/docs/integrations/codex.mdx
+++ b/docs/integrations/codex.mdx
@@ -2,6 +2,7 @@
 title: Codex
 ---
 
+Codex CLI is OpenAI’s coding agent that you can run locally from your terminal. It is built in Rust for speed and efficiency and is also open source. 
 
 ## Install
 

--- a/docs/integrations/droid.mdx
+++ b/docs/integrations/droid.mdx
@@ -2,6 +2,7 @@
 title: Droid
 ---
 
+Droid CLI is a coding agent by Factory.ai. It features Parallel execution, CI/CD integration and Observability.
 
 ## Install
 

--- a/docs/integrations/goose.mdx
+++ b/docs/integrations/goose.mdx
@@ -2,9 +2,11 @@
 title: Goose
 ---
 
+Goose is an extensible open source AI agent. It features a Desktop app, CLI, and API; that can be used for a variety of tasks such as Coding, Research, Writing, Automation, Data analysis, etc.
+
 ## Goose Desktop
 
-Install [Goose](https://block.github.io/goose/docs/getting-started/installation/) Desktop.
+Install [Goose](https://goose-docs.ai/docs/getting-started/installation/) Desktop.
 
 ### Usage with Ollama
 1. In Goose, open **Settings** → **Configure Provider**.  


### PR DESCRIPTION
Problem:

The docs of Ollama has a section called Integrations containing a list of Coding Agents. Some of the coding agents were not having an introductory description, which was leading me to perform a google search on each of the coding agents. 

Solution:
- We have tried to solve this problem by adding a one liner introduction of each agents (wherever it was missing) 
- Also, updated one link to the latest Goose docs which has been changed and is redirecting the users.

Thank you for your review.

Cheers to Ollama