### PR TITLE
Handle large Gemma4 thinking prompt defaults

### DIFF
--- a/model/renderers/gemma4.go
+++ b/model/renderers/gemma4.go
@@ -12,7 +12,8 @@ import (
 // <|turn>/<turn|> markers, <|"|> string delimiters, and <|tool>/
 // <|tool_call>/<|tool_response> tags for function calling.
 type Gemma4Renderer struct {
-	useImgTags bool
+	useImgTags               bool
+	disableThinkingByDefault bool
 }
 
 const (
@@ -124,6 +125,9 @@ func (r *Gemma4Renderer) Render(messages []api.Message, tools []api.Tool, thinkV
 	// Generation prompt.
 	if prevMessageType != "tool_response" && prevMessageType != "tool_call" {
 		sb.WriteString("<|turn>model\n")
+		if !hasThink && r.disableThinkingByDefault {
+			sb.WriteString("<|channel>thought\n<channel|>")
+		}
 	}
 
 	return sb.String(), nil

--- a/model/renderers/gemma4_reference_test.go
+++ b/model/renderers/gemma4_reference_test.go
@@ -1751,6 +1751,23 @@ func TestGemma4SizeTemplateFixturesDifferAtGenerationPrompt(t *testing.T) {
 	assert.Contains(t, string(thirtyOneB), "{{- '<|channel>thought\\n<channel|>' -}}")
 }
 
+func TestGemma4LargeRendererDisablesThinkingByDefault(t *testing.T) {
+	messages := []api.Message{{Role: "user", Content: "Hi"}}
+
+	got, err := RenderWithRendererOptions("gemma4", messages, nil, nil, RenderOptions{Gemma4DisableThinkingByDefault: true})
+	assert.NoError(t, err)
+	assert.Equal(t, "<bos><|turn>user\nHi<turn|>\n<|turn>model\n<|channel>thought\n<channel|>", got)
+}
+
+func TestGemma4LargeRendererThinkingEnabled(t *testing.T) {
+	messages := []api.Message{{Role: "user", Content: "Hi"}}
+
+	got, err := RenderWithRendererOptions("gemma4", messages, nil, thinkTrue(), RenderOptions{Gemma4DisableThinkingByDefault: true})
+	assert.NoError(t, err)
+	assert.Contains(t, got, "<|turn>system\n<|think|>\n<turn|>\n")
+	assert.Equal(t, "<bos><|turn>system\n<|think|>\n<turn|>\n<|turn>user\nHi<turn|>\n<|turn>model\n", got)
+}
+
 // renderWithJinja2 shells out to uv + Python to render messages through the
 // E2B Jinja2 chat template. Returns the rendered string.
 func renderWithJinja2(t *testing.T, messages []api.Message, tools []api.Tool, think *api.ThinkValue) string {

--- a/model/renderers/renderer.go
+++ b/model/renderers/renderer.go
@@ -10,6 +10,10 @@ type Renderer interface {
 	Render(messages []api.Message, tools []api.Tool, think *api.ThinkValue) (string, error)
 }
 
+type RenderOptions struct {
+	Gemma4DisableThinkingByDefault bool
+}
+
 type (
 	RendererConstructor func() Renderer
 	RendererRegistry    struct {
@@ -35,9 +39,16 @@ func Register(name string, renderer RendererConstructor) {
 }
 
 func RenderWithRenderer(name string, msgs []api.Message, tools []api.Tool, think *api.ThinkValue) (string, error) {
+	return RenderWithRendererOptions(name, msgs, tools, think, RenderOptions{})
+}
+
+func RenderWithRendererOptions(name string, msgs []api.Message, tools []api.Tool, think *api.ThinkValue, opts RenderOptions) (string, error) {
 	renderer := rendererForName(name)
 	if renderer == nil {
 		return "", fmt.Errorf("unknown renderer %q", name)
+	}
+	if r, ok := renderer.(*Gemma4Renderer); ok {
+		r.disableThinkingByDefault = opts.Gemma4DisableThinkingByDefault
 	}
 	return renderer.Render(msgs, tools, think)
 }

--- a/server/create.go
+++ b/server/create.go
@@ -523,6 +523,8 @@ func createModel(r api.CreateRequest, name model.Name, baseLayers []*layerGGML, 
 				arch := layer.GGML.KV().Architecture()
 				switch arch {
 				case "gemma4":
+					config.KVSharedLayers = cmp.Or(config.KVSharedLayers, int(layer.GGML.KV().Uint("attention.shared_kv_layers", 0)))
+					config.SlidingWindow = cmp.Or(config.SlidingWindow, int(layer.GGML.KV().Uint("attention.sliding_window", 0)))
 					config.Renderer = cmp.Or(config.Renderer, "gemma4")
 					config.Parser = cmp.Or(config.Parser, "gemma4")
 					if _, ok := r.Parameters["stop"]; !ok {

--- a/server/prompt.go
+++ b/server/prompt.go
@@ -115,7 +115,12 @@ func chatPrompt(ctx context.Context, m *Model, tokenize tokenizeFunc, opts *api.
 
 func renderPrompt(m *Model, msgs []api.Message, tools []api.Tool, think *api.ThinkValue) (string, error) {
 	if m.Config.Renderer != "" {
-		rendered, err := renderers.RenderWithRenderer(m.Config.Renderer, msgs, tools, think)
+		opts := renderers.RenderOptions{}
+		if m.Config.Renderer == "gemma4" {
+			opts.Gemma4DisableThinkingByDefault = isLargeGemma4(m)
+		}
+
+		rendered, err := renderers.RenderWithRendererOptions(m.Config.Renderer, msgs, tools, think, opts)
 		if err != nil {
 			return "", err
 		}
@@ -133,4 +138,13 @@ func renderPrompt(m *Model, msgs []api.Message, tools []api.Tool, think *api.Thi
 		return "", err
 	}
 	return b.String(), nil
+}
+
+func isLargeGemma4(m *Model) bool {
+	if m.Config.KVSharedLayers == 0 && m.Config.SlidingWindow == 1024 {
+		return true
+	}
+
+	sizeHint := strings.ToLower(m.Config.ModelType + " " + m.Name + " " + m.ShortName)
+	return strings.Contains(sizeHint, "26b") || strings.Contains(sizeHint, "31b")
 }

--- a/server/prompt_test.go
+++ b/server/prompt_test.go
@@ -368,6 +368,65 @@ func TestChatPromptRendererDoesNotRewriteMessageContent(t *testing.T) {
 	}
 }
 
+func TestRenderPromptGemma4LargeDisablesThinkingByDefault(t *testing.T) {
+	m := Model{
+		Config: model.ConfigV2{
+			Renderer:       "gemma4",
+			KVSharedLayers: 0,
+			SlidingWindow:  1024,
+		},
+	}
+
+	prompt, err := renderPrompt(&m, []api.Message{{Role: "user", Content: "Hi"}}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.HasSuffix(prompt, "<|turn>model\n<|channel>thought\n<channel|>") {
+		t.Fatalf("prompt missing empty thought prefill: %q", prompt)
+	}
+}
+
+func TestRenderPromptGemma4SmallKeepsDefaultGenerationPrompt(t *testing.T) {
+	m := Model{
+		Config: model.ConfigV2{
+			Renderer:       "gemma4",
+			KVSharedLayers: 18,
+			SlidingWindow:  512,
+		},
+	}
+
+	prompt, err := renderPrompt(&m, []api.Message{{Role: "user", Content: "Hi"}}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.HasSuffix(prompt, "<|turn>model\n") {
+		t.Fatalf("prompt has unexpected generation prompt: %q", prompt)
+	}
+	if strings.Contains(prompt, "<|channel>thought\n<channel|>") {
+		t.Fatalf("small Gemma4 prompt should not include empty thought prefill: %q", prompt)
+	}
+}
+
+func TestRenderPromptGemma4LargeNameFallback(t *testing.T) {
+	m := Model{
+		Name: "gemma4:26b-nvfp4",
+		Config: model.ConfigV2{
+			Renderer: "gemma4",
+		},
+	}
+
+	prompt, err := renderPrompt(&m, []api.Message{{Role: "user", Content: "Hi"}}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.HasSuffix(prompt, "<|turn>model\n<|channel>thought\n<channel|>") {
+		t.Fatalf("prompt missing empty thought prefill: %q", prompt)
+	}
+}
+
 func TestChatPromptGLMOcrRendererAddsImageTags(t *testing.T) {
 	msgs := []api.Message{
 		{

--- a/types/model/config.go
+++ b/types/model/config.go
@@ -2,14 +2,16 @@ package model
 
 // ConfigV2 represents the configuration metadata for a model.
 type ConfigV2 struct {
-	ModelFormat   string   `json:"model_format"`
-	ModelFamily   string   `json:"model_family"`
-	ModelFamilies []string `json:"model_families"`
-	ModelType     string   `json:"model_type"` // shown as Parameter Size
-	FileType      string   `json:"file_type"`  // shown as Quantization Level
-	Renderer      string   `json:"renderer,omitempty"`
-	Parser        string   `json:"parser,omitempty"`
-	Requires      string   `json:"requires,omitempty"`
+	ModelFormat    string   `json:"model_format"`
+	ModelFamily    string   `json:"model_family"`
+	ModelFamilies  []string `json:"model_families"`
+	ModelType      string   `json:"model_type"` // shown as Parameter Size
+	FileType       string   `json:"file_type"`  // shown as Quantization Level
+	Renderer       string   `json:"renderer,omitempty"`
+	Parser         string   `json:"parser,omitempty"`
+	Requires       string   `json:"requires,omitempty"`
+	SlidingWindow  int      `json:"sliding_window,omitempty"`
+	KVSharedLayers int      `json:"kv_shared_layers,omitempty"`
 
 	RemoteHost  string `json:"remote_host,omitempty"`
 	RemoteModel string `json:"remote_model,omitempty"`

--- a/x/create/client/create.go
+++ b/x/create/client/create.go
@@ -350,13 +350,16 @@ func newManifestWriter(opts CreateOptions, capabilities []string, parserName, re
 		}
 
 		// Create config blob with version requirement
+		hfConfig, _ := readHFConfig(opts.ModelDir)
 		configData := model.ConfigV2{
-			ModelFormat:  "safetensors",
-			FileType:     strings.ToLower(strings.TrimSpace(opts.Quantize)),
-			Capabilities: caps,
-			Requires:     MinOllamaVersion,
-			Parser:       resolveParserName(opts.Modelfile, parserName),
-			Renderer:     resolveRendererName(opts.Modelfile, rendererName),
+			ModelFormat:    "safetensors",
+			FileType:       strings.ToLower(strings.TrimSpace(opts.Quantize)),
+			Capabilities:   caps,
+			Requires:       MinOllamaVersion,
+			Parser:         resolveParserName(opts.Modelfile, parserName),
+			Renderer:       resolveRendererName(opts.Modelfile, rendererName),
+			KVSharedLayers: hfConfig.TextConfig.NumKVSharedLayers,
+			SlidingWindow:  hfConfig.TextConfig.SlidingWindow,
 		}
 		configJSON, err := json.Marshal(configData)
 		if err != nil {
@@ -591,17 +594,8 @@ func getParserName(modelDir string) string {
 // getRendererName returns the renderer name for a model based on its architecture.
 // This reads the config.json from the model directory and determines the appropriate renderer.
 func getRendererName(modelDir string) string {
-	configPath := filepath.Join(modelDir, "config.json")
-	data, err := os.ReadFile(configPath)
-	if err != nil {
-		return ""
-	}
-
-	var cfg struct {
-		Architectures []string `json:"architectures"`
-		ModelType     string   `json:"model_type"`
-	}
-	if err := json.Unmarshal(data, &cfg); err != nil {
+	cfg, ok := readHFConfig(modelDir)
+	if !ok {
 		return ""
 	}
 
@@ -640,4 +634,27 @@ func getRendererName(modelDir string) string {
 	}
 
 	return ""
+}
+
+type hfConfig struct {
+	Architectures []string `json:"architectures"`
+	ModelType     string   `json:"model_type"`
+	TextConfig    struct {
+		NumKVSharedLayers int `json:"num_kv_shared_layers"`
+		SlidingWindow     int `json:"sliding_window"`
+	} `json:"text_config"`
+}
+
+func readHFConfig(modelDir string) (hfConfig, bool) {
+	configPath := filepath.Join(modelDir, "config.json")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return hfConfig{}, false
+	}
+
+	var cfg hfConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return hfConfig{}, false
+	}
+	return cfg, true
 }

--- a/x/create/client/create_test.go
+++ b/x/create/client/create_test.go
@@ -656,6 +656,24 @@ func TestGetRendererName(t *testing.T) {
 			want:       "glm-4.7",
 		},
 		{
+			name: "gemma4 e4b model",
+			configJSON: `{
+				"architectures": ["Gemma4ForConditionalGeneration"],
+				"model_type": "gemma4",
+				"text_config": {"num_kv_shared_layers": 18, "sliding_window": 512}
+			}`,
+			want: "gemma4",
+		},
+		{
+			name: "gemma4 26b model",
+			configJSON: `{
+				"architectures": ["Gemma4ForConditionalGeneration"],
+				"model_type": "gemma4",
+				"text_config": {"num_kv_shared_layers": 0, "sliding_window": 1024}
+			}`,
+			want: "gemma4",
+		},
+		{
 			name:       "llama model (no renderer)",
 			configJSON: `{"architectures": ["LlamaForCausalLM"]}`,
 			want:       "",


### PR DESCRIPTION
The ConfigV2 allow runtime selection of the renderers.  If we want to bake different renderer names into the created models we can avoid that change.

For large Gemma4 models, when the request does not explicitly ask for thinking, the renderer appends this after the generation prompt:
```
<|channel>thought
<channel|>
```
That primes an empty thought channel so the model transitions into the response channel instead of emitting raw control fragments like thought, <channel|>, etc. into user-visible text.

