### PR TITLE
Fix Gemma4 generation prompt after tool responses

### DIFF
--- a/model/renderers/gemma4.go
+++ b/model/renderers/gemma4.go
@@ -62,6 +62,7 @@ func (r *Gemma4Renderer) Render(messages []api.Message, tools []api.Tool, thinkV
 	}
 
 	var prevMessageType string
+	lastTurnClosed := true
 
 	// Consecutive tool messages are folded into the preceding assistant turn,
 	// and adjacent assistant messages continue in the same model turn.
@@ -116,13 +117,17 @@ func (r *Gemma4Renderer) Render(messages []api.Message, tools []api.Tool, thinkV
 
 		if prevMessageType == "tool_call" && !toolResponsesEmitted {
 			sb.WriteString("<|tool_response>")
+			lastTurnClosed = false
 		} else if !(toolResponsesEmitted && !messageHadContent) {
 			sb.WriteString("<turn|>\n")
+			lastTurnClosed = true
+		} else {
+			lastTurnClosed = false
 		}
 	}
 
 	// Generation prompt.
-	if prevMessageType != "tool_response" && prevMessageType != "tool_call" {
+	if lastTurnClosed {
 		sb.WriteString("<|turn>model\n")
 	}
 

--- a/model/renderers/gemma4_reference_test.go
+++ b/model/renderers/gemma4_reference_test.go
@@ -799,6 +799,28 @@ func TestGemma4RendererMatchesReference(t *testing.T) {
 				"<|turn>model\n<|tool_call>call:bash{command:" + q + "ls" + q + "}<tool_call|>Let me check.<|tool_response>",
 		},
 		{
+			name: "tool_call_response_with_prefill_content_needs_generation_prompt",
+			messages: []api.Message{
+				{Role: "system", Content: "You are helpful."},
+				{Role: "user", Content: "List files"},
+				{Role: "assistant", Content: "thought\n<channel|>", ToolCalls: []api.ToolCall{{
+					Function: api.ToolCallFunction{
+						Name:      "bash",
+						Arguments: testArgs(map[string]any{"command": "ls"}),
+					},
+				}}},
+				{Role: "tool", ToolName: "bash", Content: "file1.txt\nfile2.txt"},
+			},
+			tools:      bashRefTool(),
+			skipJinja2: true,
+			expected: "<bos><|turn>system\nYou are helpful." + bashDeclRef + "<turn|>\n" +
+				"<|turn>user\nList files<turn|>\n" +
+				"<|turn>model\n<|tool_call>call:bash{command:" + q + "ls" + q + "}<tool_call|>" +
+				"<|tool_response>response:bash{value:" + q + "file1.txt\nfile2.txt" + q + "}<tool_response|>" +
+				"thought\n<channel|><turn|>\n" +
+				"<|turn>model\n",
+		},
+		{
 			// Full round trip: call → response → assistant reply → user follow-up
 			name: "full_round_trip",
 			messages: []api.Message{
@@ -874,7 +896,9 @@ func TestGemma4RendererMatchesReference(t *testing.T) {
 				"<|turn>user\nWeather?<turn|>\n" +
 				"<|turn>model\n<|tool_call>call:get_weather{city:" + q + "Paris" + q + "}<tool_call|>" +
 				"<|tool_response>response:get_weather{value:" + q + "Sunny" + q + "}<tool_response|>" +
-				"Let me check.<turn|>\n",
+				"Let me check.<turn|>\n" +
+				"<|turn>model\n",
+			skipJinja2: true,
 		},
 		{
 			// Numeric tool call arguments


### PR DESCRIPTION
Fix a Gemma4 renderer bug around whether to append a new model generation prompt after tool responses.

If the last input message was a tool response, the renderer assumed we were still inside the model turn and did not add `<|turn>model` But some tool-response cases are actually closed and need a fresh model generation prompt, especially when the tool response is followed by assistant prefill/content or when the tool-response block has been closed with `<tool_response|> and <turn|>`