### PR TITLE
push: OLLAMA_REGISTRY_MAXSTREAMS for mlx push

### DIFF
--- a/server/images.go
+++ b/server/images.go
@@ -785,6 +785,11 @@ func pushWithTransfer(ctx context.Context, n model.Name, layers []manifest.Layer
 		}
 	}
 
+	maxStreams, err := registryMaxStreams()
+	if err != nil {
+		return err
+	}
+
 	srcDir, err := manifest.BlobsPath("")
 	if err != nil {
 		return err
@@ -825,11 +830,26 @@ func pushWithTransfer(ctx context.Context, n model.Name, layers []manifest.Layer
 		Progress:    progress,
 		Token:       regOpts.Token,
 		GetToken:    getToken,
+		Concurrency: maxStreams,
 		Logger:      slog.Default(),
 		Manifest:    manifestJSON,
 		ManifestRef: n.Tag,
 		Repository:  n.DisplayNamespaceModel(),
 	})
+}
+
+func registryMaxStreams() (int, error) {
+	maxStreams := os.Getenv("OLLAMA_REGISTRY_MAXSTREAMS")
+	if maxStreams == "" {
+		return 0, nil
+	}
+
+	n, err := strconv.Atoi(maxStreams)
+	if err != nil {
+		return 0, fmt.Errorf("invalid OLLAMA_REGISTRY_MAXSTREAMS: %w", err)
+	}
+
+	return n, nil
 }
 
 func pullModelManifest(ctx context.Context, n model.Name, regOpts *registryOptions) (*manifest.Manifest, []byte, error) {

--- a/server/images_test.go
+++ b/server/images_test.go
@@ -13,6 +13,44 @@ import (
 	"github.com/ollama/ollama/types/model"
 )
 
+func TestRegistryMaxStreams(t *testing.T) {
+	t.Setenv("OLLAMA_REGISTRY_MAXSTREAMS", "")
+	n, err := registryMaxStreams()
+	if err != nil {
+		t.Fatalf("registryMaxStreams() error = %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("registryMaxStreams() = %d, want 0", n)
+	}
+
+	t.Setenv("OLLAMA_REGISTRY_MAXSTREAMS", "4")
+	n, err = registryMaxStreams()
+	if err != nil {
+		t.Fatalf("registryMaxStreams() error = %v", err)
+	}
+	if n != 4 {
+		t.Fatalf("registryMaxStreams() = %d, want 4", n)
+	}
+
+	t.Setenv("OLLAMA_REGISTRY_MAXSTREAMS", "-1")
+	n, err = registryMaxStreams()
+	if err != nil {
+		t.Fatalf("registryMaxStreams() error = %v", err)
+	}
+	if n != -1 {
+		t.Fatalf("registryMaxStreams() = %d, want -1", n)
+	}
+
+	t.Setenv("OLLAMA_REGISTRY_MAXSTREAMS", "nope")
+	_, err = registryMaxStreams()
+	if err == nil {
+		t.Fatal("registryMaxStreams() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "invalid OLLAMA_REGISTRY_MAXSTREAMS") {
+		t.Fatalf("registryMaxStreams() error = %q, want env var context", err)
+	}
+}
+
 func TestModelCapabilities(t *testing.T) {
 	// Create completion model (llama architecture without vision)
 	completionModelPath, _ := createBinFile(t, ggml.KV{

--- a/x/imagegen/transfer/transfer.go
+++ b/x/imagegen/transfer/transfer.go
@@ -73,7 +73,7 @@ type UploadOptions struct {
 	Blobs       []Blob                                                             // Blobs to upload
 	BaseURL     string                                                             // Registry base URL
 	SrcDir      string                                                             // Source directory containing blobs
-	Concurrency int                                                                // Max parallel uploads (default 32)
+	Concurrency int                                                                // Max parallel upload requests and preflight checks (default 32 uploads, 128 checks)
 	Progress    func(completed, total int64)                                       // Progress callback (optional)
 	Client      *http.Client                                                       // HTTP client (optional, uses default)
 	Token       string                                                             // Auth token (optional)

--- a/x/imagegen/transfer/transfer_test.go
+++ b/x/imagegen/transfer/transfer_test.go
@@ -950,6 +950,66 @@ func TestUploadParallelism(t *testing.T) {
 	t.Logf("Uploaded %d blobs in %v with max %d concurrent requests", numBlobs, elapsed, maxConcurrent.Load())
 }
 
+func TestUploadConcurrencyCapsRequests(t *testing.T) {
+	clientDir := t.TempDir()
+	const numBlobs = 8
+	const concurrency = 2
+
+	blobs := make([]Blob, numBlobs)
+	for i := range numBlobs {
+		blobs[i], _ = createTestBlob(t, clientDir, 1024+i*100)
+	}
+
+	var activeRequests atomic.Int32
+	var maxConcurrent atomic.Int32
+	var uploadID atomic.Int32
+
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		current := activeRequests.Add(1)
+		defer activeRequests.Add(-1)
+
+		for {
+			old := maxConcurrent.Load()
+			if current <= old || maxConcurrent.CompareAndSwap(old, current) {
+				break
+			}
+		}
+
+		time.Sleep(10 * time.Millisecond)
+
+		switch r.Method {
+		case http.MethodHead:
+			http.NotFound(w, r)
+		case http.MethodPost:
+			id := uploadID.Add(1)
+			w.Header().Set("Location", fmt.Sprintf("%s/v2/library/_/blobs/uploads/%d", serverURL, id))
+			w.WriteHeader(http.StatusAccepted)
+		case http.MethodPut:
+			io.Copy(io.Discard, r.Body)
+			w.WriteHeader(http.StatusCreated)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	serverURL = server.URL
+
+	err := Upload(context.Background(), UploadOptions{
+		Blobs:       blobs,
+		BaseURL:     server.URL,
+		SrcDir:      clientDir,
+		Concurrency: concurrency,
+	})
+	if err != nil {
+		t.Fatalf("Upload failed: %v", err)
+	}
+
+	if maxConcurrent.Load() > concurrency {
+		t.Fatalf("max concurrent requests = %d, want <= %d", maxConcurrent.Load(), concurrency)
+	}
+}
+
 // ==================== Stall Detection Test ====================
 
 func TestDownloadStallDetection(t *testing.T) {

--- a/x/imagegen/transfer/upload.go
+++ b/x/imagegen/transfer/upload.go
@@ -54,7 +54,7 @@ func upload(ctx context.Context, opts UploadOptions) error {
 		// Phase 1: Fast parallel HEAD checks to find which blobs need uploading
 		needsUpload := make([]bool, len(opts.Blobs))
 		{
-			sem := semaphore.NewWeighted(128) // High concurrency for HEAD checks
+			sem := semaphore.NewWeighted(int64(uploadHeadConcurrency(opts)))
 			g, gctx := errgroup.WithContext(ctx)
 			for i, blob := range opts.Blobs {
 				g.Go(func() error {
@@ -103,7 +103,7 @@ func upload(ctx context.Context, opts UploadOptions) error {
 			}
 		} else {
 			// Phase 2: Upload blobs that don't exist
-			concurrency := cmp.Or(opts.Concurrency, DefaultUploadConcurrency)
+			concurrency := uploadConcurrency(opts, len(toUpload))
 			sem := semaphore.NewWeighted(int64(concurrency))
 
 			g, gctx := errgroup.WithContext(ctx)
@@ -131,6 +131,23 @@ func upload(ctx context.Context, opts UploadOptions) error {
 		logutil.Trace("manifest push succeeded", "repo", opts.Repository, "ref", opts.ManifestRef)
 	}
 	return nil
+}
+
+func uploadHeadConcurrency(opts UploadOptions) int {
+	if opts.Concurrency < 0 {
+		return len(opts.Blobs)
+	}
+	if opts.Concurrency > 0 {
+		return opts.Concurrency
+	}
+	return 128
+}
+
+func uploadConcurrency(opts UploadOptions, blobs int) int {
+	if opts.Concurrency < 0 {
+		return blobs
+	}
+	return cmp.Or(opts.Concurrency, DefaultUploadConcurrency)
 }
 
 func (u *uploader) upload(ctx context.Context, blob Blob) error {


### PR DESCRIPTION
Wire up the env var to allow throttling of the safetensors push.