### PR TITLE
fix: nil-guard optional embedding components + use exact GELU for BERT

### DIFF
--- a/model/models/bert/embed.go
+++ b/model/models/bert/embed.go
@@ -111,7 +111,8 @@ type MLP struct {
 }
 
 func (m *MLP) Forward(ctx ml.Context, hiddenStates ml.Tensor, opts *Options) ml.Tensor {
-	return m.Down.Forward(ctx, m.Up.Forward(ctx, hiddenStates).GELU(ctx))
+	// BERT uses exact GELU (erf-based), not the tanh approximation
+	return m.Down.Forward(ctx, m.Up.Forward(ctx, hiddenStates).GELU_ERF(ctx))
 }
 
 type Options struct {

--- a/model/models/gemma3/embed.go
+++ b/model/models/gemma3/embed.go
@@ -24,7 +24,9 @@ func (m *embedModel) Forward(ctx ml.Context, batch input.Batch) (ml.Tensor, erro
 	hiddenStates := m.TextModel.Forward(ctx, batch, m.Cache)
 	hiddenStates = m.poolingType.Forward(ctx, hiddenStates)
 	for _, dense := range m.Dense {
-		hiddenStates = dense.Forward(ctx, hiddenStates)
+		if dense != nil {
+			hiddenStates = dense.Forward(ctx, hiddenStates)
+		}
 	}
 	hiddenStates = hiddenStates.L2Norm(ctx, 1e-12)
 	return hiddenStates, nil

--- a/model/models/qwen3/model.go
+++ b/model/models/qwen3/model.go
@@ -69,8 +69,12 @@ func (sa *Attention) Forward(ctx ml.Context, hiddenStates, positions ml.Tensor, 
 	key = key.Reshape(ctx, opts.headDim(), opts.numKVHeads, batchSize)
 	value = value.Reshape(ctx, opts.headDim(), opts.numKVHeads, batchSize)
 
-	query = sa.QueryNorm.Forward(ctx, query, opts.eps)
-	key = sa.KeyNorm.Forward(ctx, key, opts.eps)
+	if sa.QueryNorm != nil {
+		query = sa.QueryNorm.Forward(ctx, query, opts.eps)
+	}
+	if sa.KeyNorm != nil {
+		key = sa.KeyNorm.Forward(ctx, key, opts.eps)
+	}
 
 	query = opts.applyRotaryPositionEmbeddings(ctx, query, positions)
 	key = opts.applyRotaryPositionEmbeddings(ctx, key, positions)


### PR DESCRIPTION
## Summary

Three small, backwards-compatible fixes for embedding models:

1. **Qwen3 QK-norm nil-guard** (`model/models/qwen3/model.go`): Qwen3 attention unconditionally calls `QueryNorm.Forward()` and `KeyNorm.Forward()`, causing nil pointer panic for models that don't have QK-norm tensors (e.g. Jina v5 Nano and other Qwen-based models without QK-norm).

2. **Gemma3 Dense nil-guard** (`model/models/gemma3/embed.go`): Gemma3 embed model unconditionally calls `dense.Forward()`, causing nil pointer panic for models without Dense projection layers (e.g. Harrier-270M).

3. **BERT GELU_ERF** (`model/models/bert/embed.go`): BERT was trained with exact GELU (erf-based), but the implementation uses `GELU()` which is the tanh approximation. Switching to `GELU_ERF()` improves cosine similarity vs HuggingFace from 0.996 to 1.000.

## Test plan

- [x] Verified all-MiniLM-L6-v2 Q8_0 embeddings match HuggingFace at cos=0.9998
- [x] Verified gte-small, arctic-embed-xs match at cos>0.999
- [x] Jina v5 Nano (Qwen3 without QK-norm) loads and produces embeddings
- [x] Harrier-270M (Gemma3 without Dense) loads and produces embeddings

Related issue: #15620

🤖 Generated with [Claude Code](https://claude.com/claude-code)