### PR TITLE
create: keep pending blobs fresh until manifest write

### DIFF
--- a/manifest/keepalive.go
+++ b/manifest/keepalive.go
@@ -1,0 +1,94 @@
+package manifest
+
+import (
+	"log/slog"
+	"os"
+	"sync"
+	"time"
+)
+
+// LayerKeepAliveInterval controls how often in-flight create operations refresh
+// blob mtimes so mark-and-sweep GC does not prune them before the manifest is
+// written. Tests may override this.
+var LayerKeepAliveInterval = 15 * time.Minute
+
+// LayerKeepAlive refreshes tracked blob mtimes until Close is called.
+type LayerKeepAlive struct {
+	mu      sync.Mutex
+	digests map[string]struct{}
+	stop    chan struct{}
+	done    chan struct{}
+}
+
+// StartLayerKeepAlive begins refreshing tracked blobs in the background.
+func StartLayerKeepAlive() *LayerKeepAlive {
+	k := &LayerKeepAlive{
+		digests: make(map[string]struct{}),
+		stop:    make(chan struct{}),
+		done:    make(chan struct{}),
+	}
+
+	go k.loop()
+	return k
+}
+
+// Track adds a blob digest to the keepalive set.
+func (k *LayerKeepAlive) Track(digest string) {
+	if k == nil || digest == "" {
+		return
+	}
+
+	k.mu.Lock()
+	k.digests[digest] = struct{}{}
+	k.mu.Unlock()
+}
+
+// Close stops the background refresh loop.
+func (k *LayerKeepAlive) Close() {
+	if k == nil {
+		return
+	}
+
+	close(k.stop)
+	<-k.done
+}
+
+func (k *LayerKeepAlive) loop() {
+	defer close(k.done)
+
+	ticker := time.NewTicker(LayerKeepAliveInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			k.touchTracked()
+		case <-k.stop:
+			return
+		}
+	}
+}
+
+func (k *LayerKeepAlive) touchTracked() {
+	k.mu.Lock()
+	digests := make([]string, 0, len(k.digests))
+	for digest := range k.digests {
+		digests = append(digests, digest)
+	}
+	k.mu.Unlock()
+
+	for _, digest := range digests {
+		if err := touchLayerDigest(digest); err != nil && !os.IsNotExist(err) {
+			slog.Debug("layer keepalive touch failed", "digest", digest, "error", err)
+		}
+	}
+}
+
+func touchLayerDigest(digest string) error {
+	blob, err := BlobsPath(digest)
+	if err != nil {
+		return err
+	}
+
+	return touchLayer(blob)
+}

--- a/manifest/keepalive_test.go
+++ b/manifest/keepalive_test.go
@@ -1,0 +1,9 @@
+package manifest
+
+import "testing"
+
+func TestTouchLayerDigestWithInvalidDigest(t *testing.T) {
+	if err := touchLayerDigest("not-a-digest"); err == nil {
+		t.Fatal("expected invalid digest error")
+	}
+}

--- a/server/create.go
+++ b/server/create.go
@@ -490,6 +490,15 @@ func kvFromLayers(baseLayers []*layerGGML) (ofs.Config, error) {
 }
 
 func createModel(r api.CreateRequest, name model.Name, baseLayers []*layerGGML, config *model.ConfigV2, fn func(resp api.ProgressResponse)) (err error) {
+	keepAlive := manifest.StartLayerKeepAlive()
+	defer keepAlive.Close()
+
+	trackLayers := func(layers []manifest.Layer) {
+		for _, layer := range layers {
+			keepAlive.Track(layer.Digest)
+		}
+	}
+
 	var layers []manifest.Layer
 	for _, layer := range baseLayers {
 		if layer.GGML != nil {
@@ -536,12 +545,14 @@ func createModel(r api.CreateRequest, name model.Name, baseLayers []*layerGGML, 
 		}
 		layers = append(layers, layer.Layer)
 	}
+	trackLayers(layers)
 
 	if r.Template != "" {
 		layers, err = setTemplate(layers, r.Template)
 		if err != nil {
 			return err
 		}
+		trackLayers(layers)
 	}
 
 	if r.System != "" {
@@ -549,6 +560,7 @@ func createModel(r api.CreateRequest, name model.Name, baseLayers []*layerGGML, 
 		if err != nil {
 			return err
 		}
+		trackLayers(layers)
 	}
 
 	if r.License != nil {
@@ -559,6 +571,7 @@ func createModel(r api.CreateRequest, name model.Name, baseLayers []*layerGGML, 
 				if err != nil {
 					return err
 				}
+				trackLayers(layers)
 			}
 		case any:
 			var licenses []string
@@ -571,6 +584,7 @@ func createModel(r api.CreateRequest, name model.Name, baseLayers []*layerGGML, 
 				if err != nil {
 					return err
 				}
+				trackLayers(layers)
 			}
 		default:
 			return fmt.Errorf("unknown license type: %T", l)
@@ -581,16 +595,19 @@ func createModel(r api.CreateRequest, name model.Name, baseLayers []*layerGGML, 
 	if err != nil {
 		return err
 	}
+	trackLayers(layers)
 
 	layers, err = setMessages(layers, r.Messages)
 	if err != nil {
 		return err
 	}
+	trackLayers(layers)
 
 	configLayer, err := createConfigLayer(layers, *config)
 	if err != nil {
 		return err
 	}
+	keepAlive.Track(configLayer.Digest)
 
 	for _, layer := range layers {
 		if layer.Status != "" {

--- a/server/create.go
+++ b/server/create.go
@@ -501,6 +501,10 @@ func createModel(r api.CreateRequest, name model.Name, baseLayers []*layerGGML, 
 
 	var layers []manifest.Layer
 	for _, layer := range baseLayers {
+		// Track before per-iteration work: quantization can take hours, so
+		// layers processed early must be kept fresh by the keepalive loop
+		// rather than waiting on the batch trackLayers call below.
+		keepAlive.Track(layer.Layer.Digest)
 		if layer.GGML != nil {
 			quantType := strings.ToUpper(cmp.Or(r.Quantize, r.Quantization))
 			if quantType != "" && layer.GGML.Name() == "gguf" && layer.MediaType == "application/vnd.ollama.image.model" {
@@ -517,6 +521,7 @@ func createModel(r api.CreateRequest, name model.Name, baseLayers []*layerGGML, 
 					if err != nil {
 						return err
 					}
+					keepAlive.Track(layer.Layer.Digest)
 				}
 			}
 			config.ModelFormat = cmp.Or(config.ModelFormat, layer.GGML.Name())

--- a/server/images_test.go
+++ b/server/images_test.go
@@ -57,6 +57,58 @@ func TestPruneLayersSkipsRecentOrphans(t *testing.T) {
 	}
 }
 
+func TestPruneLayersKeepsTrackedPendingBlobAlive(t *testing.T) {
+	t.Setenv("OLLAMA_MODELS", t.TempDir())
+
+	origInterval := manifest.LayerKeepAliveInterval
+	manifest.LayerKeepAliveInterval = 10 * time.Millisecond
+	defer func() {
+		manifest.LayerKeepAliveInterval = origInterval
+	}()
+
+	layer, err := manifest.NewLayer(strings.NewReader("pending-create-data"), manifest.MediaTypeImageTensor)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	blobPath, err := manifest.BlobsPath(layer.Digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	oldTime := time.Now().Add(-layerPruneGracePeriod - time.Hour)
+	if err := os.Chtimes(blobPath, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+
+	keepAlive := manifest.StartLayerKeepAlive()
+	keepAlive.Track(layer.Digest)
+	defer keepAlive.Close()
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		info, err := os.Stat(blobPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.ModTime().After(oldTime) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("blob mtime was not refreshed before deadline")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if err := PruneLayers(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(blobPath); err != nil {
+		t.Fatalf("tracked pending blob was pruned: %v", err)
+	}
+}
+
 func TestModelCapabilities(t *testing.T) {
 	// Create completion model (llama architecture without vision)
 	completionModelPath, _ := createBinFile(t, ggml.KV{

--- a/x/create/create.go
+++ b/x/create/create.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/ollama/ollama/envconfig"
+	"github.com/ollama/ollama/manifest"
 	"github.com/ollama/ollama/x/safetensors"
 )
 
@@ -653,6 +654,21 @@ func newTensorImportTransform(modelDir string, cfg sourceModelConfig) (tensorImp
 func CreateSafetensorsModel(modelName, modelDir, quantize string, createLayer LayerCreator, createTensorLayer QuantizingTensorLayerCreator, writeManifest ManifestWriter, fn func(status string), createPackedLayer ...PackedTensorLayerCreator) error {
 	var layers []LayerInfo
 	var configLayer LayerInfo
+	keepAlive := manifest.StartLayerKeepAlive()
+	defer keepAlive.Close()
+
+	appendLayer := func(layer LayerInfo) {
+		keepAlive.Track(layer.Digest)
+		layers = append(layers, layer)
+	}
+
+	appendLayers := func(created []LayerInfo) {
+		for _, layer := range created {
+			keepAlive.Track(layer.Digest)
+		}
+		layers = append(layers, created...)
+	}
+
 	sourceConfig, err := readSourceModelConfig(modelDir)
 	if err != nil {
 		return fmt.Errorf("failed to read source config.json: %w", err)
@@ -750,7 +766,7 @@ func CreateSafetensorsModel(modelName, modelDir, quantize string, createLayer La
 					return err
 				}
 				if ok {
-					layers = append(layers, layer)
+					appendLayer(layer)
 					continue
 				}
 			}
@@ -826,7 +842,7 @@ func CreateSafetensorsModel(modelName, modelDir, quantize string, createLayer La
 						closeExtractors()
 						return fmt.Errorf("failed to create layer for %s: %w", outTD.Name, err)
 					}
-					layers = append(layers, newLayers...)
+					appendLayers(newLayers)
 				}
 			}
 		}
@@ -850,7 +866,7 @@ func CreateSafetensorsModel(modelName, modelDir, quantize string, createLayer La
 				closeExtractors()
 				return fmt.Errorf("failed to create packed layer for %s: %w", groupName, err)
 			}
-			layers = append(layers, layer)
+			appendLayer(layer)
 		}
 	}
 	closeExtractors()
@@ -887,7 +903,7 @@ func CreateSafetensorsModel(modelName, modelDir, quantize string, createLayer La
 			configLayer = layer
 		}
 
-		layers = append(layers, layer)
+		appendLayer(layer)
 	}
 
 	if configLayer.Digest == "" {


### PR DESCRIPTION
## Summary

Fixes #15651

This changes Ollama to keep in-flight create blobs fresh until the manifest is written, so long-running create/import paths do not age into GC eligibility before they are referenced by a manifest.

The scope stays intentionally narrow:
- add a small manifest layer keepalive helper that periodically refreshes tracked blob mtimes
- track active create blobs in `server/create.go`
- track active safetensors-import blobs in `x/create/create.go`
- add regression coverage for the prune/keepalive interaction

I chose this direction because it matches the existing mtime-based GC mechanism instead of introducing a broader pending-manifest index or new on-disk state in the first fix.

## Testing

```shell
go test ./manifest ./server ./x/create -count=1
```
