### PR TITLE
  cmd: improve CLI error messages for missing model name arguments

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -58,6 +58,33 @@ import (
 	"github.com/ollama/ollama/x/imagegen"
 )
 
+// validateModelNameArg validates that exactly 1 argument is provided for model name commands
+func validateModelNameArg(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return errors.New("missing model name")
+	}
+	if len(args) > 1 {
+		return errors.New("extra arguments")
+	}
+	return nil
+}
+
+// validateModelNameArgs validates that exactly n arguments are provided for model name commands
+func validateModelNameArgs(n int) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		if len(args) < n {
+			if n == 2 {
+				return errors.New("missing source and/or destination model name")
+			}
+			return errors.New("missing model name")
+		}
+		if len(args) > n {
+			return errors.New("extra arguments")
+		}
+		return nil
+	}
+}
+
 func init() {
 	// Override default selectors to use Bubbletea TUI instead of raw terminal I/O.
 	launch.DefaultSingleSelector = func(title string, items []launch.ModelItem, current string) (string, error) {
@@ -923,7 +950,7 @@ func PushHandler(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func ListHandler(cmd *cobra.Command, args []string) error {
+func ListHandler(cmd *Command, args []string) error {
 	client, err := api.ClientFromEnvironment()
 	if err != nil {
 		return err
@@ -2109,7 +2136,7 @@ func NewCLI() *cobra.Command {
 	createCmd := &cobra.Command{
 		Use:   "create MODEL",
 		Short: "Create a model",
-		Args:  cobra.ExactArgs(1),
+		Args:  validateModelNameArg,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// Skip server check for experimental mode (writes directly to disk)
 			if experimental, _ := cmd.Flags().GetBool("experimental"); experimental {
@@ -2127,7 +2154,7 @@ func NewCLI() *cobra.Command {
 	showCmd := &cobra.Command{
 		Use:     "show MODEL",
 		Short:   "Show information for a model",
-		Args:    cobra.ExactArgs(1),
+		Args:    validateModelNameArg,
 		PreRunE: checkServerHeartbeat,
 		RunE:    ShowHandler,
 	}
@@ -2170,7 +2197,7 @@ func NewCLI() *cobra.Command {
 	stopCmd := &cobra.Command{
 		Use:     "stop MODEL",
 		Short:   "Stop a running model",
-		Args:    cobra.ExactArgs(1),
+		Args:    validateModelNameArg,
 		PreRunE: checkServerHeartbeat,
 		RunE:    StopHandler,
 	}
@@ -2186,7 +2213,7 @@ func NewCLI() *cobra.Command {
 	pullCmd := &cobra.Command{
 		Use:     "pull MODEL",
 		Short:   "Pull a model from a registry",
-		Args:    cobra.ExactArgs(1),
+		Args:    validateModelNameArg,
 		PreRunE: checkServerHeartbeat,
 		RunE:    PullHandler,
 	}
@@ -2196,7 +2223,7 @@ func NewCLI() *cobra.Command {
 	pushCmd := &cobra.Command{
 		Use:     "push MODEL",
 		Short:   "Push a model to a registry",
-		Args:    cobra.ExactArgs(1),
+		Args:    validateModelNameArg,
 		PreRunE: checkServerHeartbeat,
 		RunE:    PushHandler,
 	}
@@ -2254,7 +2281,7 @@ func NewCLI() *cobra.Command {
 	copyCmd := &cobra.Command{
 		Use:     "cp SOURCE DESTINATION",
 		Short:   "Copy a model",
-		Args:    cobra.ExactArgs(2),
+		Args:    validateModelNameArgs(2),
 		PreRunE: checkServerHeartbeat,
 		RunE:    CopyHandler,
 	}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -2277,3 +2277,76 @@ func TestIsLocalhost(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateModelNameArg(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+		errMsg  string
+	}{
+		{"no args", []string{}, true, "missing model name"},
+		{"one arg", []string{"model"}, false, ""},
+		{"extra arg", []string{"model", "extra"}, true, "extra arguments"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{}
+			err := validateModelNameArg(cmd, tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateModelNameArg() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil && tt.errMsg != "" && !strings.Contains(err.Error(), tt.errMsg) {
+				t.Errorf("validateModelNameArg() error = %v, want containing %v", err, tt.errMsg)
+			}
+		})
+	}
+}
+
+func TestValidateModelNameArgs(t *testing.T) {
+	t.Run("two args - missing both", func(t *testing.T) {
+		cmd := &cobra.Command{}
+		fn := validateModelNameArgs(2)
+		err := fn(cmd, []string{})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "missing source and/or destination model name") {
+			t.Errorf("expected 'missing source and/or destination model name', got %v", err)
+		}
+	})
+
+	t.Run("two args - one provided", func(t *testing.T) {
+		cmd := &cobra.Command{}
+		fn := validateModelNameArgs(2)
+		err := fn(cmd, []string{"model"})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "missing source and/or destination model name") {
+			t.Errorf("expected 'missing source and/or destination model name', got %v", err)
+		}
+	})
+
+	t.Run("two args - valid", func(t *testing.T) {
+		cmd := &cobra.Command{}
+		fn := validateModelNameArgs(2)
+		err := fn(cmd, []string{"source", "dest"})
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("two args - extra", func(t *testing.T) {
+		cmd := &cobra.Command{}
+		fn := validateModelNameArgs(2)
+		err := fn(cmd, []string{"a", "b", "c"})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "extra arguments") {
+			t.Errorf("expected 'extra arguments', got %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary                                                                                                                                                                              
                                                                                                                                                                                          
  Replaces generic argument validation errors with descriptive messages for the following commands:
  - `ollama create`
  - `ollama show`
  - `ollama stop`
  - `ollama pull`
  - `ollama push`
  - `ollama cp`

  ### Before
  Error: accepts 1 arg(s), received 0

  ### After
  Error: missing model name

  For `ollama cp`, the error now reads: `missing source and/or destination model name`

  When extra arguments are provided, all commands now return: `extra arguments`

  ## Motivation

  Users running commands like `ollama show` without specifying a model receive unclear error messages. Clear error messages improve UX and help users quickly understand and fix their
  mistakes.

  ## Testing

  Added unit tests in `cmd/cmd_test.go`:
  - `TestValidateModelNameArg` - tests single-arg validation
  - `TestValidateModelNameArgs` - tests two-arg validation (cp command)

  ## Related Issue

  Closes #2893