### PR TITLE
cmd: guard TUI launch against non-interactive terminals

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1988,6 +1988,11 @@ func launchInteractiveModel(cmd *cobra.Command, modelName string) error {
 
 // runInteractiveTUI runs the main interactive TUI menu.
 func runInteractiveTUI(cmd *cobra.Command) {
+	if !term.IsTerminal(int(os.Stdin.Fd())) || !term.IsTerminal(int(os.Stdout.Fd())) {
+		fmt.Fprintln(os.Stderr, "Error: interactive terminal required. To start the server, run: ollama serve")
+		return
+	}
+
 	// Ensure the server is running before showing the TUI
 	if err := ensureServerRunning(cmd.Context()); err != nil {
 		fmt.Fprintf(os.Stderr, "Error starting server: %v\n", err)


### PR DESCRIPTION
Running `ollama` without a subcommand on systems where stdin/stdout isn't a proper PTY (e.g. Devuan/sysvinit) crashes with a raw mode error from bubbletea. Added the same `term.IsTerminal` check that already exists for the model selectors, so the command exits with a clear message pointing to `ollama serve` instead. Fixes #15649.