### PR TITLE
app/server: fix desktop app startup killing active `ollama launch` sessions

### DIFF
--- a/app/server/server.go
+++ b/app/server/server.go
@@ -94,10 +94,13 @@ func ollamaServeArgs(args []string) bool {
 		return false
 	}
 
-	for _, arg := range args[1:] {
-		if strings.Trim(arg, `"`) == "serve" {
-			return true
+	for _, rawArg := range args[1:] {
+		arg := strings.Trim(rawArg, `"`)
+		if strings.HasPrefix(arg, "-") {
+			continue
 		}
+
+		return arg == "serve" || arg == "start"
 	}
 
 	return false

--- a/app/server/server.go
+++ b/app/server/server.go
@@ -83,6 +83,26 @@ func resolvePath(name string) string {
 	return name
 }
 
+func ollamaServeArgs(args []string) bool {
+	if len(args) < 2 {
+		return false
+	}
+
+	switch strings.Trim(filepath.Base(args[0]), `"`) {
+	case "ollama", "ollama.exe":
+	default:
+		return false
+	}
+
+	for _, arg := range args[1:] {
+		if strings.Trim(arg, `"`) == "serve" {
+			return true
+		}
+	}
+
+	return false
+}
+
 // cleanup checks the pid file for a running ollama process
 // and shuts it down gracefully if it is running
 func cleanup() error {

--- a/app/server/server.go
+++ b/app/server/server.go
@@ -18,11 +18,15 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/app/logrotate"
 	"github.com/ollama/ollama/app/store"
 )
 
 const restartDelay = time.Second
+const externalServerHeartbeatTimeout = 2 * time.Second
+const externalServerHeartbeatInterval = time.Second
+const externalServerStartupWait = 5 * time.Second
 
 // Server is a managed ollama server process
 type Server struct {
@@ -152,6 +156,49 @@ func stop(proc *os.Process) error {
 	}
 }
 
+func externalServerAvailable(ctx context.Context) bool {
+	client, err := api.ClientFromEnvironment()
+	if err != nil {
+		slog.Debug("failed to create ollama client", "err", err)
+		return false
+	}
+
+	heartbeatCtx, cancel := context.WithTimeout(ctx, externalServerHeartbeatTimeout)
+	defer cancel()
+
+	if err := client.Heartbeat(heartbeatCtx); err != nil {
+		slog.Debug("external ollama server heartbeat failed", "err", err)
+		return false
+	}
+
+	return true
+}
+
+func waitForExternalServerAvailable(ctx context.Context, timeout time.Duration) bool {
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+
+	ticker := time.NewTicker(externalServerHeartbeatInterval)
+	defer ticker.Stop()
+
+	if externalServerAvailable(ctx) {
+		return true
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-deadline.C:
+			return false
+		case <-ticker.C:
+			if externalServerAvailable(ctx) {
+				return true
+			}
+		}
+	}
+}
+
 func (s *Server) Run(ctx context.Context) error {
 	l, err := openRotatingLog()
 	if err != nil {
@@ -189,6 +236,12 @@ func (s *Server) Run(ctx context.Context) error {
 		if err = cmd.Wait(); err != nil && !errors.Is(err, context.Canceled) {
 			var exitErr *exec.ExitError
 			if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 && !s.dev && !reaped {
+				if waitForExternalServerAvailable(ctx, externalServerStartupWait) {
+					slog.Info("using existing ollama server")
+					<-ctx.Done()
+					return ctx.Err()
+				}
+
 				reaped = true
 				// This could be a port conflict, try to kill any existing ollama processes
 				if err := reapServers(); err != nil {

--- a/app/server/server.go
+++ b/app/server/server.go
@@ -18,15 +18,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/app/logrotate"
 	"github.com/ollama/ollama/app/store"
 )
 
 const restartDelay = time.Second
-const externalServerHeartbeatTimeout = 2 * time.Second
-const externalServerHeartbeatInterval = time.Second
-const externalServerStartupWait = 5 * time.Second
 
 // Server is a managed ollama server process
 type Server struct {
@@ -156,49 +152,6 @@ func stop(proc *os.Process) error {
 	}
 }
 
-func externalServerAvailable(ctx context.Context) bool {
-	client, err := api.ClientFromEnvironment()
-	if err != nil {
-		slog.Debug("failed to create ollama client", "err", err)
-		return false
-	}
-
-	heartbeatCtx, cancel := context.WithTimeout(ctx, externalServerHeartbeatTimeout)
-	defer cancel()
-
-	if err := client.Heartbeat(heartbeatCtx); err != nil {
-		slog.Debug("external ollama server heartbeat failed", "err", err)
-		return false
-	}
-
-	return true
-}
-
-func waitForExternalServerAvailable(ctx context.Context, timeout time.Duration) bool {
-	deadline := time.NewTimer(timeout)
-	defer deadline.Stop()
-
-	ticker := time.NewTicker(externalServerHeartbeatInterval)
-	defer ticker.Stop()
-
-	if externalServerAvailable(ctx) {
-		return true
-	}
-
-	for {
-		select {
-		case <-ctx.Done():
-			return false
-		case <-deadline.C:
-			return false
-		case <-ticker.C:
-			if externalServerAvailable(ctx) {
-				return true
-			}
-		}
-	}
-}
-
 func (s *Server) Run(ctx context.Context) error {
 	l, err := openRotatingLog()
 	if err != nil {
@@ -236,12 +189,6 @@ func (s *Server) Run(ctx context.Context) error {
 		if err = cmd.Wait(); err != nil && !errors.Is(err, context.Canceled) {
 			var exitErr *exec.ExitError
 			if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 && !s.dev && !reaped {
-				if waitForExternalServerAvailable(ctx, externalServerStartupWait) {
-					slog.Info("using existing ollama server")
-					<-ctx.Done()
-					return ctx.Err()
-				}
-
 				reaped = true
 				// This could be a port conflict, try to kill any existing ollama processes
 				if err := reapServers(); err != nil {

--- a/app/server/server_test.go
+++ b/app/server/server_test.go
@@ -227,8 +227,23 @@ func TestOllamaServeArgs(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "start alias",
+			args: []string{"ollama", "start"},
+			want: true,
+		},
+		{
 			name: "launch command",
 			args: []string{"ollama", "launch", "opencode"},
+			want: false,
+		},
+		{
+			name: "run command with model named serve",
+			args: []string{"ollama", "run", "serve"},
+			want: false,
+		},
+		{
+			name: "launch command with serve in passthrough args",
+			args: []string{"ollama", "launch", "codex", "--", "-p", "serve"},
 			want: false,
 		},
 		{

--- a/app/server/server_test.go
+++ b/app/server/server_test.go
@@ -4,8 +4,6 @@ package server
 
 import (
 	"context"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -205,37 +203,6 @@ func TestServerCmdCloudSettingEnv(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestExternalServerAvailable(t *testing.T) {
-	t.Run("healthy server", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.Method != http.MethodHead || r.URL.Path != "/" {
-				t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
-			}
-			w.WriteHeader(http.StatusOK)
-		}))
-		defer srv.Close()
-
-		t.Setenv("OLLAMA_HOST", srv.URL)
-
-		if !externalServerAvailable(t.Context()) {
-			t.Fatal("expected external server to be available")
-		}
-	})
-
-	t.Run("unhealthy server", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			http.Error(w, "nope", http.StatusInternalServerError)
-		}))
-		defer srv.Close()
-
-		t.Setenv("OLLAMA_HOST", srv.URL)
-
-		if externalServerAvailable(t.Context()) {
-			t.Fatal("expected external server to be unavailable")
-		}
-	})
 }
 
 func TestGetInferenceInfo(t *testing.T) {

--- a/app/server/server_test.go
+++ b/app/server/server_test.go
@@ -205,6 +205,48 @@ func TestServerCmdCloudSettingEnv(t *testing.T) {
 	}
 }
 
+func TestOllamaServeArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{
+			name: "system ollama serve",
+			args: []string{"ollama", "serve"},
+			want: true,
+		},
+		{
+			name: "relative path ollama serve",
+			args: []string{"./ollama", "serve"},
+			want: true,
+		},
+		{
+			name: "serve after other flags",
+			args: []string{"./ollama", "--verbose", "serve"},
+			want: true,
+		},
+		{
+			name: "launch command",
+			args: []string{"ollama", "launch", "opencode"},
+			want: false,
+		},
+		{
+			name: "different executable",
+			args: []string{"go", "run", "serve"},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ollamaServeArgs(tt.args); got != tt.want {
+				t.Fatalf("ollamaServeArgs(%v) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGetInferenceInfo(t *testing.T) {
 	tests := []struct {
 		name             string

--- a/app/server/server_test.go
+++ b/app/server/server_test.go
@@ -4,6 +4,8 @@ package server
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -203,6 +205,37 @@ func TestServerCmdCloudSettingEnv(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestExternalServerAvailable(t *testing.T) {
+	t.Run("healthy server", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodHead || r.URL.Path != "/" {
+				t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		t.Setenv("OLLAMA_HOST", srv.URL)
+
+		if !externalServerAvailable(t.Context()) {
+			t.Fatal("expected external server to be available")
+		}
+	})
+
+	t.Run("unhealthy server", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "nope", http.StatusInternalServerError)
+		}))
+		defer srv.Close()
+
+		t.Setenv("OLLAMA_HOST", srv.URL)
+
+		if externalServerAvailable(t.Context()) {
+			t.Fatal("expected external server to be unavailable")
+		}
+	})
 }
 
 func TestGetInferenceInfo(t *testing.T) {

--- a/app/server/server_unix.go
+++ b/app/server/server_unix.go
@@ -46,7 +46,22 @@ func terminated(pid int) (bool, error) {
 	return false, nil
 }
 
-// reapServers kills all ollama processes except our own
+func ollamaServeProcess(pid int) bool {
+	output, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "args=").Output()
+	if err != nil {
+		slog.Debug("failed to inspect ollama process", "pid", pid, "err", err)
+		return false
+	}
+
+	args := strings.Fields(strings.TrimSpace(string(output)))
+	if len(args) < 2 {
+		return false
+	}
+
+	return filepath.Base(args[0]) == "ollama" && args[1] == "serve"
+}
+
+// reapServers kills external ollama serve processes except our own.
 func reapServers() error {
 	// Get our own PID to avoid killing ourselves
 	currentPID := os.Getpid()
@@ -80,6 +95,10 @@ func reapServers() error {
 			continue
 		}
 		if pid == currentPID {
+			continue
+		}
+		if !ollamaServeProcess(pid) {
+			slog.Debug("skipping non-server ollama process", "pid", pid)
 			continue
 		}
 

--- a/app/server/server_unix.go
+++ b/app/server/server_unix.go
@@ -56,20 +56,6 @@ func ollamaServeProcess(pid int) bool {
 	return ollamaServeArgs(strings.Fields(strings.TrimSpace(string(output))))
 }
 
-func ollamaServeArgs(args []string) bool {
-	if len(args) < 2 || filepath.Base(args[0]) != "ollama" {
-		return false
-	}
-
-	for _, arg := range args[1:] {
-		if arg == "serve" {
-			return true
-		}
-	}
-
-	return false
-}
-
 // reapServers kills external ollama serve processes except our own.
 func reapServers() error {
 	// Get our own PID to avoid killing ourselves

--- a/app/server/server_unix.go
+++ b/app/server/server_unix.go
@@ -53,12 +53,21 @@ func ollamaServeProcess(pid int) bool {
 		return false
 	}
 
-	args := strings.Fields(strings.TrimSpace(string(output)))
-	if len(args) < 2 {
+	return ollamaServeArgs(strings.Fields(strings.TrimSpace(string(output))))
+}
+
+func ollamaServeArgs(args []string) bool {
+	if len(args) < 2 || filepath.Base(args[0]) != "ollama" {
 		return false
 	}
 
-	return filepath.Base(args[0]) == "ollama" && args[1] == "serve"
+	for _, arg := range args[1:] {
+		if arg == "serve" {
+			return true
+		}
+	}
+
+	return false
 }
 
 // reapServers kills external ollama serve processes except our own.
@@ -98,7 +107,6 @@ func reapServers() error {
 			continue
 		}
 		if !ollamaServeProcess(pid) {
-			slog.Debug("skipping non-server ollama process", "pid", pid)
 			continue
 		}
 

--- a/app/server/server_windows.go
+++ b/app/server/server_windows.go
@@ -117,12 +117,7 @@ func ollamaServeProcess(pid int) bool {
 			continue
 		}
 
-		fields := strings.Fields(strings.ToLower(commandLine))
-		for i, field := range fields {
-			if strings.Trim(field, `"`) == "serve" && i > 0 {
-				return true
-			}
-		}
+		return ollamaServeArgs(strings.Fields(strings.ToLower(commandLine)))
 	}
 
 	return false

--- a/app/server/server_windows.go
+++ b/app/server/server_windows.go
@@ -101,7 +101,34 @@ func terminated(pid int) (bool, error) {
 	return true, nil
 }
 
-// reapServers kills all ollama processes except our own
+func ollamaServeProcess(pid int) bool {
+	cmd := exec.Command("wmic", "process", "where", fmt.Sprintf("ProcessId=%d", pid), "get", "CommandLine", "/value")
+	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	output, err := cmd.Output()
+	if err != nil {
+		slog.Debug("failed to inspect ollama process", "pid", pid, "err", err)
+		return false
+	}
+
+	for _, line := range strings.Split(string(output), "\n") {
+		line = strings.TrimSpace(line)
+		commandLine, ok := strings.CutPrefix(line, "CommandLine=")
+		if !ok {
+			continue
+		}
+
+		fields := strings.Fields(strings.ToLower(commandLine))
+		for i, field := range fields {
+			if strings.Trim(field, `"`) == "serve" && i > 0 {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// reapServers kills external ollama serve processes except our own.
 func reapServers() error {
 	// Get current process ID to avoid killing ourselves
 	currentPID := os.Getpid()
@@ -136,6 +163,10 @@ func reapServers() error {
 		}
 
 		if pid == currentPID {
+			continue
+		}
+		if !ollamaServeProcess(pid) {
+			slog.Debug("skipping non-server ollama process", "pid", pid)
 			continue
 		}
 

--- a/app/server/server_windows.go
+++ b/app/server/server_windows.go
@@ -166,7 +166,6 @@ func reapServers() error {
 			continue
 		}
 		if !ollamaServeProcess(pid) {
-			slog.Debug("skipping non-server ollama process", "pid", pid)
 			continue
 		}
 


### PR DESCRIPTION
Fix desktop app startup terminating active ollama launch workflows.

When the desktop app starts, it launches its own managed ollama serve. If another Ollama server is already running, the managed server can exit on startup due to a port conflict. Previously, the app fallback cleanup path reaped all ollama processes, which could kill foreground CLI workflows like ollama launch opencode.

This change narrows the cleanup logic on macOS and Windows so that it only targets ollama serve processes. That allows the app to replace the conflicting server process without terminating the launcher process.

**What changed**
macOS: reapServers() now inspects process arguments and only stops processes that look like ollama serve
Windows: reapServers() now does the same via process command line inspection
foreground CLI commands like `ollama launch, ollama run & ollama pull` are no longer matched by the fallback reaper