### PR TITLE
openai: honor reasoning_effort in /v1/responses endpoint

### DIFF
--- a/openai/responses.go
+++ b/openai/responses.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"slices"
 	"strings"
 	"time"
 
@@ -546,12 +547,25 @@ func FromResponsesRequest(r ResponsesRequest) (*api.ChatRequest, error) {
 		}
 	}
 
+	var think *api.ThinkValue
+	if effort := r.Reasoning.Effort; effort != "" {
+		if !slices.Contains([]string{"high", "medium", "low", "none"}, effort) {
+			return nil, fmt.Errorf("invalid reasoning value: '%s' (must be \"high\", \"medium\", \"low\", or \"none\")", effort)
+		}
+		if effort == "none" {
+			think = &api.ThinkValue{Value: false}
+		} else {
+			think = &api.ThinkValue{Value: effort}
+		}
+	}
+
 	return &api.ChatRequest{
 		Model:    r.Model,
 		Messages: messages,
 		Options:  options,
 		Tools:    tools,
 		Format:   format,
+		Think:    think,
 	}, nil
 }
 

--- a/openai/responses_test.go
+++ b/openai/responses_test.go
@@ -1492,6 +1492,79 @@ func TestFromResponsesRequest_MaxOutputTokens(t *testing.T) {
 	}
 }
 
+func TestFromResponsesRequest_ReasoningEffort(t *testing.T) {
+	tests := []struct {
+		name      string
+		reqJSON   string
+		wantThink *api.ThinkValue
+		wantErr   bool
+	}{
+		{
+			name:      "effort none disables thinking",
+			reqJSON:   `{"model": "gpt-oss:20b", "input": "hi", "reasoning": {"effort": "none"}}`,
+			wantThink: &api.ThinkValue{Value: false},
+		},
+		{
+			name:      "effort low sets string value",
+			reqJSON:   `{"model": "gpt-oss:20b", "input": "hi", "reasoning": {"effort": "low"}}`,
+			wantThink: &api.ThinkValue{Value: "low"},
+		},
+		{
+			name:      "effort medium sets string value",
+			reqJSON:   `{"model": "gpt-oss:20b", "input": "hi", "reasoning": {"effort": "medium"}}`,
+			wantThink: &api.ThinkValue{Value: "medium"},
+		},
+		{
+			name:      "effort high sets string value",
+			reqJSON:   `{"model": "gpt-oss:20b", "input": "hi", "reasoning": {"effort": "high"}}`,
+			wantThink: &api.ThinkValue{Value: "high"},
+		},
+		{
+			name:      "missing reasoning leaves Think unset",
+			reqJSON:   `{"model": "gpt-oss:20b", "input": "hi"}`,
+			wantThink: nil,
+		},
+		{
+			name:    "invalid effort returns error",
+			reqJSON: `{"model": "gpt-oss:20b", "input": "hi", "reasoning": {"effort": "maximum"}}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var req ResponsesRequest
+			if err := json.Unmarshal([]byte(tt.reqJSON), &req); err != nil {
+				t.Fatalf("failed to unmarshal request: %v", err)
+			}
+
+			chatReq, err := FromResponsesRequest(req)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("failed to convert request: %v", err)
+			}
+
+			if tt.wantThink == nil {
+				if chatReq.Think != nil {
+					t.Errorf("Think = %+v, want nil", chatReq.Think)
+				}
+				return
+			}
+			if chatReq.Think == nil {
+				t.Fatal("expected Think to be set")
+			}
+			if chatReq.Think.Value != tt.wantThink.Value {
+				t.Errorf("Think.Value = %v, want %v", chatReq.Think.Value, tt.wantThink.Value)
+			}
+		})
+	}
+}
+
 func TestFromResponsesRequest_TextFormatJsonSchema(t *testing.T) {
 	reqJSON := `{
 		"model": "gpt-oss:20b",


### PR DESCRIPTION
Fixes #15635.

## Problem

`/v1/chat/completions` correctly disables thinking when `reasoning_effort: "none"` is passed, but `/v1/responses` ignores `reasoning.effort` entirely. Reproduction from the issue:

```bash
# Chat Completions — works (0.5s, no reasoning)
curl -s http://localhost:11434/v1/chat/completions \
  -d '{"model":"gemma4:e2b","messages":[{"role":"user","content":"Reply with ONLY: [1,3]"}],"reasoning_effort":"none","stream":false}'

# Responses — thinking NOT disabled (4.7s, full reasoning)
curl -s http://localhost:11434/v1/responses \
  -d '{"model":"gemma4:e2b","input":"Reply with ONLY: [1,3]","reasoning":{"effort":"none"},"stream":false}'
```

## Root cause

`openai/responses.go:FromResponsesRequest` deserializes `r.Reasoning.Effort` (it is already used later for echoing reasoning config back to the client) but never converts it into the `api.ChatRequest.Think` field. The Chat Completions path at `openai/openai.go:625-644` already performs this mapping.

## Fix

Mirror the existing Chat Completions logic in `FromResponsesRequest`:

- `effort == "none"` → `Think{Value: false}` (suppresses thinking)
- `effort == "high" | "medium" | "low"` → `Think{Value: <effort>}`
- any other value → the same validation error the Chat Completions path returns

Validation, error message, and accepted effort values are identical across the two endpoints, so behavior stays consistent.

## Tests

`TestFromResponsesRequest_ReasoningEffort` covers:
- `"none"` disables thinking (`Think.Value == false`)
- `"low"`, `"medium"`, `"high"` set the string value
- missing `reasoning` leaves `Think` unset
- invalid effort returns an error

All existing `./openai/...` and `./middleware/...` tests still pass.

## Notes

- Only `reasoning.effort` is handled here — OpenAI's Responses API does not expose a flat `reasoning_effort` (that is a Chat Completions shape). Clients that sent `{"reasoning_effort": "none"}` on `/v1/responses` before this PR were effectively sending an unknown field; after the PR they should move to the canonical `{"reasoning": {"effort": "none"}}` form (which also did not work before).