### PR TITLE
fix: strip surrounding quotes from drag-dropped file paths in interactive CLI

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -603,13 +603,20 @@ func normalizeFilePath(fp string) string {
 }
 
 func extractFileNames(input string) []string {
-	// Regex to match file paths starting with optional drive letter, / ./ \ or .\ and include escaped or unescaped spaces (\ or %20)
-	// and followed by more characters and a file extension
-	// This will capture non filename strings, but we'll check for file existence to remove mismatches
-	regexPattern := `(?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp|wav)\b`
+	// Matches file paths that may be wrapped in single or double quotes (terminals often add these
+	// when dragging files with spaces), as well as unquoted paths with escaped or unescaped spaces.
+	// Quoted alternatives are listed first so the engine consumes the surrounding quotes and prevents
+	// a second match of the inner path by the unquoted alternative.
+	regexPattern := `(?:'(?:[a-zA-Z]:)?(?:\./|/|\\)[^']+?\.(?i:jpg|jpeg|png|webp|wav)'` +
+		`|"(?:[a-zA-Z]:)?(?:\./|/|\\)[^"]+?\.(?i:jpg|jpeg|png|webp|wav)"` +
+		`|(?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp|wav)\b)`
 	re := regexp.MustCompile(regexPattern)
 
-	return re.FindAllString(input, -1)
+	matches := re.FindAllString(input, -1)
+	for i, m := range matches {
+		matches[i] = strings.Trim(m, "\"'")
+	}
+	return matches
 }
 
 func extractFileData(input string) (string, []api.ImageData, error) {
@@ -617,7 +624,7 @@ func extractFileData(input string) (string, []api.ImageData, error) {
 	var imgs []api.ImageData
 
 	for _, fp := range filePaths {
-		nfp := normalizeFilePath(fp)
+		nfp := normalizeFilePath(strings.Trim(fp, "\"'"))
 		data, err := getImageData(nfp)
 		if errors.Is(err, os.ErrNotExist) {
 			continue
@@ -633,6 +640,7 @@ func extractFileData(input string) (string, []api.ImageData, error) {
 			fmt.Fprintf(os.Stderr, "Added image '%s'\n", nfp)
 		}
 		input = strings.ReplaceAll(input, "'"+nfp+"'", "")
+		input = strings.ReplaceAll(input, `"`+nfp+`"`, "")
 		input = strings.ReplaceAll(input, "'"+fp+"'", "")
 		input = strings.ReplaceAll(input, fp, "")
 		imgs = append(imgs, data)


### PR DESCRIPTION
## Fix: strip surrounding quotes from drag-dropped file paths in interactive CLI

### Problem

When a user drags and drops an image into a terminal running `ollama run <model>`, many terminals (zsh, fish, some GUI terminal emulators) automatically wrap the dropped path in single or double quotes — especially when the path contains spaces:

'/Users/jane/my photos/image.jpg'
"/Users/jane/my photos/image.jpg"


The previous regex only matched paths starting with `/`, `./`, or `\`, so the leading quote character was silently skipped and the match began from the `/` inside the quotes. This worked for simple cases but was fragile: the surrounding quotes were never consumed as part of the match, which meant paths could be matched twice (once via a quoted alternative, once via the unquoted fallback) and the cleanup step in `extractFileData` could leave stray quote characters in the message text. Additionally, if a quote character ever ended up on a matched path before reaching `os.Open`, the file-not-found error would be swallowed silently (`ErrNotExist` → `continue`), making the image appear to be ignored with no feedback.

### Fix

**`extractFileNames`** — the regex now has three explicit alternatives tried left-to-right:
1. `'<path>.ext'` — single-quoted path (allows unescaped spaces via `[^']+?`)
2. `"<path>.ext"` — double-quoted path (allows unescaped spaces via `[^"]+?`)
3. Original unquoted pattern (`[\S\\ ]+?`) for escaped-space and no-space paths

Quoted alternatives are listed first so the engine consumes the full `'...'` or `"..."` token as a single match, preventing the unquoted alternative from re-matching the inner path. After matching, `strings.Trim(m, "\"'")` strips any surrounding quotes before the path is returned.

**`extractFileData`** — adds `strings.Trim(fp, "\"'")` as a second defensive sanitization before `normalizeFilePath`, ensuring quotes never reach `os.Open`. Also adds a `strings.ReplaceAll` cleanup for double-quoted paths to mirror the existing single-quote cleanup.

### Test plan
- [ ] Existing `TestExtractFilenames`, `TestExtractFileDataRemovesQuotedFilepath`, and `TestExtractFileDataWAV` all pass unchanged
- [ ] Manually drag a file with spaces in its path into a zsh/fish terminal running `ollama run llava` — image is accepted and the quoted path is removed from the message text
- [ ] Same test with double-quoted path
- [ ] Unquoted path with escaped spaces (e.g. `/path/to/my\ image.jpg`) still works
- [ ] Unquoted path without spaces still works
