### PR TITLE
llm: report runner status when Wait returns nil

### DIFF
--- a/llm/server.go
+++ b/llm/server.go
@@ -1371,7 +1371,14 @@ func (s *llmServer) WaitUntilRunning(ctx context.Context) error {
 			slog.Warn("client connection closed before server finished loading, aborting load")
 			return fmt.Errorf("timed out waiting for llama runner to start: %w", ctx.Err())
 		case <-s.done:
-			return fmt.Errorf("llama runner process has terminated: %w", s.doneErr)
+			if s.doneErr != nil {
+				return fmt.Errorf("llama runner process has terminated: %w", s.doneErr)
+			}
+			msg := ""
+			if s.status != nil && s.status.LastErrMsg != "" {
+				msg = s.status.LastErrMsg
+			}
+			return fmt.Errorf("llama runner process has terminated: %s", msg)
 		default:
 		}
 		if time.Now().After(stallTimer) {


### PR DESCRIPTION
Noticed in #15143: on the runner-has-exited path, `WaitUntilRunning` wraps `s.doneErr` with `%w`. When `cmd.Wait` returns nil the reaper stores nil there, so users see `%!w(<nil>)` in place of any real diagnostic.

Fall back to `status.LastErrMsg` using the same pattern used elsewhere in this file when a runner has exited. The non-nil path is unchanged so `errors.Is` / `errors.As` still work.