### PR TITLE
server: preserve thinking in /api/generate and populate parameter_size in /api/tags for safetensors

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -374,17 +374,8 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 		return
 	}
 
-	var builtinParser parsers.Parser
 	if shouldUseHarmony(m) && m.Config.Parser == "" {
 		m.Config.Parser = "harmony"
-	}
-
-	if !req.Raw && m.Config.Parser != "" {
-		builtinParser = parsers.ParserForName(m.Config.Parser)
-		if builtinParser != nil {
-			// no tools or last message for generate endpoint
-			builtinParser.Init(nil, nil, req.Think)
-		}
 	}
 
 	caps := []model.Capability{model.CapabilityCompletion}
@@ -402,6 +393,18 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 		if req.Think != nil && req.Think.Bool() {
 			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("%q does not support thinking", req.Model)})
 			return
+		}
+	}
+
+	// Initialize the parser only after req.Think has been resolved, since
+	// parsers like gemma4 gate whether to surface thinking content on the
+	// value passed to Init. Matches the ordering used by ChatHandler.
+	var builtinParser parsers.Parser
+	if !req.Raw && m.Config.Parser != "" {
+		builtinParser = parsers.ParserForName(m.Config.Parser)
+		if builtinParser != nil {
+			// no tools or last message for generate endpoint
+			builtinParser.Init(nil, nil, req.Think)
 		}
 	}
 
@@ -1424,6 +1427,33 @@ func (s *Server) ListHandler(c *gin.Context) {
 			}
 		}
 
+		details := api.ModelDetails{
+			Format:            cf.ModelFormat,
+			Family:            cf.ModelFamily,
+			Families:          cf.ModelFamilies,
+			ParameterSize:     cf.ModelType,
+			QuantizationLevel: cf.FileType,
+		}
+
+		// Safetensors models do not populate ModelType/FileType on the
+		// manifest config, so mirror ShowHandler and derive the values from
+		// the safetensors headers. Keeps /api/tags consistent with /api/show.
+		if cf.ModelFormat == "safetensors" && slices.Contains(cf.Capabilities, "completion") {
+			if info, err := xserver.GetSafetensorsLLMInfo(n); err == nil {
+				if arch, ok := info["general.architecture"].(string); ok && arch != "" {
+					details.Family = arch
+				}
+				if paramCount, ok := info["general.parameter_count"].(int64); ok && paramCount > 0 {
+					details.ParameterSize = format.HumanNumber(uint64(paramCount))
+				}
+			}
+			if details.QuantizationLevel == "" {
+				if dtype, err := xserver.GetSafetensorsDtype(n); err == nil && dtype != "" {
+					details.QuantizationLevel = dtype
+				}
+			}
+		}
+
 		// tag should never be masked
 		models = append(models, api.ListModelResponse{
 			Model:       n.DisplayShortest(),
@@ -1433,13 +1463,7 @@ func (s *Server) ListHandler(c *gin.Context) {
 			Size:        m.Size(),
 			Digest:      m.Digest(),
 			ModifiedAt:  m.FileInfo().ModTime(),
-			Details: api.ModelDetails{
-				Format:            cf.ModelFormat,
-				Family:            cf.ModelFamily,
-				Families:          cf.ModelFamilies,
-				ParameterSize:     cf.ModelType,
-				QuantizationLevel: cf.FileType,
-			},
+			Details:     details,
 		})
 	}
 


### PR DESCRIPTION
## Summary

Fixes two independent bugs surfaced on `gemma4:26b-mxfp8` / `gemma4:26b-nvfp4`.

### 1. `/api/generate` silently drops thinking for models that think by default (#15681)

`GenerateHandler` initialized the builtin parser **before** the capability-gated default for `req.Think` was applied. Parsers that gate thinking output on the value passed to `Init` — notably `Gemma4Parser`, which has an explicit `// When thinking is disabled, silently discard channel content` branch — therefore saw `thinkValue == nil` and dropped the reasoning, even though the model was emitting it (visible via a large `eval_count` but short `response`).

Moving the capability check + default above the parser `Init` call so the parser sees the resolved `req.Think` value. This matches `ChatHandler`, which already does the two steps in the correct order — and is why `/api/chat` / `/v1/chat/completions` return `reasoning` correctly on the same model.

Callers that explicitly set `think: false` are unaffected — the default only kicks in when `req.Think == nil`.

### 2. `/api/tags` returns empty `parameter_size` for safetensors models (#15679)

`ListHandler` populated `Details` purely from the manifest's `ConfigV2`, whose `ModelType` / `FileType` are not written for safetensors models during create. `/api/show` already works around this by reading the safetensors headers via `xserver.GetSafetensorsLLMInfo` / `GetSafetensorsDtype`; mirror the same enrichment in `ListHandler` so the two endpoints stay consistent.

> Note: the separate observation in #15679 that the reported count (e.g. 8.7B) is the active-parameter count for MoE variants rather than a "26B-A4B"-style total is a deeper metadata question — out of scope for this PR. This change at minimum stops `/api/tags` from returning an empty string and makes it match the existing `/api/show` value.

## Verified locally

- [x] `go vet ./server/` — clean
- [x] `go build ./server/` — clean
- [x] `go test ./server/` — all pass (2.5s)
- [x] `go test ./model/parsers/` — all pass

## Needs manual verification by reviewer

Neither author has a machine with `gemma4:26b-mxfp8` / a safetensors model available, so these runtime checks weren't performed:

- [ ] `curl /api/generate -d '{"model":"gemma4:26b-mxfp8","prompt":"Moin","stream":false}'` → response now includes populated `thinking` field.
- [ ] Same request with `"think": false` → `thinking` empty (no regression for explicit opt-out).
- [ ] `curl /api/generate -d '{"model":"llama3.2","prompt":"hi"}'` (non-thinking model) → unchanged behaviour.
- [ ] `curl /api/tags` on a machine with a safetensors model → `details.parameter_size` is populated (matches `/api/show`).
- [ ] `curl /api/tags` on a machine with GGUF-only models → unchanged (manifest config still used).