### PR TITLE
Add killport to Terminal & CLI community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ console.log(response.message.content);
 - [ShellOracle](https://github.com/djcopley/ShellOracle) - Shell command suggestions
 - [LLM-X](https://github.com/mrdjohnson/llm-x) - Progressive web app for LLMs
 - [cmdh](https://github.com/pgibler/cmdh) - Natural language to shell commands
+- [killport](https://github.com/skosari/killport) - Kill whatever is running on a port — macOS, Windows, and Linux, with AI-powered port scanning and vulnerability reporting via Ollama
 - [VT](https://github.com/vinhnx/vt.ai) - Minimal multimodal AI chat app
 
 ### Productivity & Apps


### PR DESCRIPTION
## Summary

Adds [killport](https://github.com/skosari/killport) to the Terminal & CLI section.

killport is a cross-platform CLI tool (macOS, Windows, Linux) that kills whatever process is running on a given port. It includes AI-powered port scanning and vulnerability reporting powered by a local Ollama model — no data leaves the machine.

Platform repos:
- [skosari/killport-mac](https://github.com/skosari/killport-mac)
- [skosari/killport-win](https://github.com/skosari/killport-win)
- [skosari/killport-linux](https://github.com/skosari/killport-linux)