### PR TITLE
docs(linux): add --zstd flag to tar commands for .tar.zst archives

### DIFF
--- a/docs/linux.mdx
+++ b/docs/linux.mdx
@@ -21,7 +21,7 @@ Download and extract the package:
 
 ```shell
 curl -fsSL https://ollama.com/download/ollama-linux-amd64.tar.zst \
-    | sudo tar x -C /usr
+    | sudo tar --zstd -x -C /usr
 ```
 
 Start Ollama:
@@ -42,7 +42,7 @@ If you have an AMD GPU, also download and extract the additional ROCm package:
 
 ```shell
 curl -fsSL https://ollama.com/download/ollama-linux-amd64-rocm.tar.zst \
-    | sudo tar x -C /usr
+    | sudo tar --zstd -x -C /usr
 ```
 
 ### ARM64 install
@@ -51,7 +51,7 @@ Download and extract the ARM64-specific package:
 
 ```shell
 curl -fsSL https://ollama.com/download/ollama-linux-arm64.tar.zst \
-    | sudo tar x -C /usr
+    | sudo tar --zstd -x -C /usr
 ```
 
 ### Adding Ollama as a startup service (recommended)
@@ -147,7 +147,7 @@ Or by re-downloading Ollama:
 
 ```shell
 curl -fsSL https://ollama.com/download/ollama-linux-amd64.tar.zst \
-    | sudo tar x -C /usr
+    | sudo tar --zstd -x -C /usr
 ```
 
 ## Installing specific versions


### PR DESCRIPTION
The manual install instructions pipe .tar.zst archives into `tar x`, but GNU tar requires the `--zstd` option to decompress zstd-compressed archives. Without it, users get:

```
tar: Archive is compressed. Use --zstd option
tar: Error is not recoverable: exiting now
```

Added `--zstd` to all four tar invocations in docs/linux.mdx (amd64, amd64-rocm, arm64, and the update section).

Fixes #15693