### PR TITLE
fix(docs): replace incorrect tr command in Linux uninstall instructions

### DIFF
--- a/docs/linux.mdx
+++ b/docs/linux.mdx
@@ -181,7 +181,7 @@ sudo rm /etc/systemd/system/ollama.service
 Remove ollama libraries from your lib directory (either `/usr/local/lib`, `/usr/lib`, or `/lib`):
 
 ```shell
-sudo rm -r $(which ollama | tr 'bin' 'lib')
+sudo rm -r $(dirname $(dirname $(which ollama)))/lib/ollama
 ```
 
 Remove the ollama binary from your bin directory (either `/usr/local/bin`, `/usr/bin`, or `/bin`):


### PR DESCRIPTION
## Summary
- Replaces `tr 'bin' 'lib'` with `$(dirname $(dirname $(which ollama)))/lib/ollama` in Linux uninstall docs
- `tr` performs character-by-character translation, mangling paths like `/snap/bin` → `/sbap/lib`
- Uses `dirname` to reliably construct the corresponding lib path

Closes #14931