### PR TITLE
install: check for AMD GPU on hybrid systems before exiting

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -293,7 +293,9 @@ check_gpu() {
 
 if check_gpu nvidia-smi; then
     status "NVIDIA GPU installed."
-    exit 0
+    if ! check_gpu lspci amdgpu && ! check_gpu lshw amdgpu; then
+        exit 0
+    fi
 fi
 
 if ! check_gpu lspci nvidia && ! check_gpu lshw nvidia && ! check_gpu lspci amdgpu && ! check_gpu lshw amdgpu; then


### PR DESCRIPTION
## Problem

On hybrid systems with both an NVIDIA GPU (\`nvidia-smi\` present) and an AMD GPU, \`scripts/install.sh\` exits immediately after detecting \`nvidia-smi\` — before ever reaching the AMD GPU check. The ROCm bundle is never downloaded, leaving the AMD GPU unsupported.

Reported on Framework Laptop 16 (NVIDIA dGPU + AMD Radeon 890M iGPU) on Fedora 43.

## Fix

Rather than duplicating the ROCm download logic, only exit early from the \`nvidia-smi\` block when no AMD GPU is present. On hybrid systems it falls through to the existing AMD detection and install path.

## Test scenarios

| System | Before | After |
|--------|--------|-------|
| Hybrid NVIDIA+AMD | Exits, skips ROCm | Falls through to existing AMD block, downloads ROCm |
| NVIDIA only | Exits cleanly | Exits cleanly (no change) |
| AMD only | Downloads ROCm | Downloads ROCm (no change) |
| NVIDIA via lspci (no nvidia-smi) | Falls through to CUDA install | Falls through to CUDA install (no change) |
| No GPU | CPU-only warning | CPU-only warning (no change) |

Fixes #15665