### PR TITLE
model/parsers/qwen3coder: prevent tag regex from matching across newlines

### DIFF
--- a/model/parsers/qwen3coder.go
+++ b/model/parsers/qwen3coder.go
@@ -392,7 +392,9 @@ func parseValue(raw string, paramType api.PropertyType) any {
 }
 
 var (
-	qwenTagRegex    = regexp.MustCompile(`<(\w+)=([^>]+)>`)
+	qwenTagRegex = regexp.MustCompile(`<(\w+)=([^>\r\n]+)>`)
+	// [^"] is safe here because xml.EscapeText has already encoded any literal
+	// newlines in attribute values as &#xA; before this regex runs.
 	qwenXMLTagRegex = regexp.MustCompile(`</?(?:function|parameter)(?:\s+name="[^"]*")?>`)
 )
 

--- a/model/parsers/qwen3coder_test.go
+++ b/model/parsers/qwen3coder_test.go
@@ -1121,6 +1121,34 @@ func TestQwen3CoderParserToolCallIndexResetOnInit(t *testing.T) {
 	}
 }
 
+func TestQwen3CoderParserAngleBracketsInParameterValue(t *testing.T) {
+	tools := []api.Tool{tool("run_code", map[string]api.ToolProperty{
+		"source": {Type: api.PropertyType{"string"}},
+	})}
+	parser := Qwen3CoderParser{}
+	parser.Init(tools, nil, nil)
+
+	// Parameter value contains "<word=expr" — previously caused the tag regex to
+	// greedily match across newlines, consuming the real </parameter> closing tag
+	// and producing "element <parameter> closed by </function>" from xml.Unmarshal.
+	input := "<tool_call>\n<function=run_code>\n<parameter=source>\nIF C<1w=P-SQR(1-C)\nNEXT\n</parameter>\n</function>\n</tool_call>"
+	_, _, calls, err := parser.Add(input, true)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(calls))
+	}
+	want := "IF C<1w=P-SQR(1-C)\nNEXT"
+	got, ok := calls[0].Function.Arguments.Get("source")
+	if !ok {
+		t.Fatal("missing source argument")
+	}
+	if got != want {
+		t.Errorf("source: got %q, want %q", got, want)
+	}
+}
+
 func TestQwenXMLTransform(t *testing.T) {
 	cases := []struct {
 		desc string
@@ -1180,6 +1208,41 @@ celsius
 		San Francisco &amp; San Jose
 		</parameter>
 		</function>`,
+		},
+		{
+			// qwenTagRegex must not match across newlines: a pattern like <1w=expr
+			// with no ">" on the same line should not greedily consume the real
+			// </parameter> and </function> closing tags that appear on later lines.
+			desc: "angle brackets in parameter values do not corrupt closing tags",
+			raw: `<function=run_code>
+<parameter=source>
+IF C<1w=P-SQR(1-C)
+NEXT
+</parameter>
+</function>`,
+			want: `<function name="run_code">
+<parameter name="source">
+IF C&lt;1w=P-SQR(1-C)
+NEXT
+</parameter>
+</function>`,
+		},
+		{
+			desc: "multiple angle-bracket patterns in same parameter value",
+			raw: `<function=run_code>
+<parameter=source>
+IF A<1x=FOO(A)
+IF B<2y=BAR(B)
+NEXT
+</parameter>
+</function>`,
+			want: `<function name="run_code">
+<parameter name="source">
+IF A&lt;1x=FOO(A)
+IF B&lt;2y=BAR(B)
+NEXT
+</parameter>
+</function>`,
 		},
 	}
 


### PR DESCRIPTION
## Summary

Fixes #15574.

The `qwenTagRegex` pattern `<(\w+)=([^>]+)>` was used to transform Qwen3-coder's custom XML-like tag syntax (e.g. `<parameter=name>`) into valid XML. The character class `[^>]` matches any character except `>`, including newlines. When a parameter value contains a `<word=` pattern (e.g. BBC BASIC code like `IF C<1w=P-SQR(1-C)`), the regex would greedily span multiple lines—consuming the actual `</parameter>` closing tag—until it hit the `>` in `</function>`. This produced malformed XML that failed to parse with: `element <parameter> closed by </function>`.

The fix is a one-character change: `[^>]+` → `[^>\n]+`, restricting the regex to single-line matching. Since Qwen3-coder's format always puts each tag on its own line, this is the correct constraint.

## Test plan

- `TestQwenXMLTransform`: new case verifies `<` in parameter values is escaped correctly and closing tags are not consumed
- `TestQwen3CoderParserAngleBracketsInParameterValue`: end-to-end test using BBC BASIC code from the issue report
- Both tests fail against the old regex and pass with the fix
- `go test ./model/parsers/...` passes