### PR TITLE
Add LumaKit to Community Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ print(response.message.content)
 
 ### JavaScript
 
+```
+npm i ollama
+```
+
 ```javascript
 import ollama from "ollama";
 

--- a/README.md
+++ b/README.md
@@ -124,10 +124,6 @@ print(response.message.content)
 
 ### JavaScript
 
-```
-npm i ollama
-```
-
 ```javascript
 import ollama from "ollama";
 
@@ -268,6 +264,7 @@ console.log(response.message.content);
 - [Stakpak](https://github.com/stakpak/agent) - Open source DevOps agent
 - [Hexabot](https://github.com/hexastack/hexabot) - Conversational AI builder
 - [Neuro SAN](https://github.com/cognizant-ai-lab/neuro-san-studio) - Multi-agent orchestration ([docs](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/user_guide.md#ollama))
+- [LumaKit](https://github.com/patmakesapps/LumaKit) - Local-first AI agent for Ollama with a web UI, launcher flow, persistent tools, browser automation, reminders, and autonomous tasks
 
 ### RAG & Knowledge Bases
 


### PR DESCRIPTION
Adds LumaKit to the Community Integrations list under `Frameworks & Agents`.

LumaKit is a local-first AI agent built for Ollama with:
- a web UI
- a simple launcher flow via `lumakit open`
- persistent tools and browser automation
- reminders, memory, and autonomous task flows
- optional Telegram integration
- polished Linux and Windows onboarding, including launcher shortcuts and first-run model selection

Repository: https://github.com/patmakesapps/LumaKit