### PR TITLE
docs: fix tar decompression flags

### DIFF
--- a/docs/linux.mdx
+++ b/docs/linux.mdx
@@ -21,7 +21,7 @@ Download and extract the package:
 
 ```shell
 curl -fsSL https://ollama.com/download/ollama-linux-amd64.tar.zst \
-    | sudo tar x -C /usr
+    | sudo tar --zstd -x -C /usr
 ```
 
 Start Ollama:
@@ -42,7 +42,7 @@ If you have an AMD GPU, also download and extract the additional ROCm package:
 
 ```shell
 curl -fsSL https://ollama.com/download/ollama-linux-amd64-rocm.tar.zst \
-    | sudo tar x -C /usr
+    | sudo tar --zstd -x -C /usr
 ```
 
 ### ARM64 install
@@ -51,7 +51,7 @@ Download and extract the ARM64-specific package:
 
 ```shell
 curl -fsSL https://ollama.com/download/ollama-linux-arm64.tar.zst \
-    | sudo tar x -C /usr
+    | sudo tar --zstd -x -C /usr
 ```
 
 ### Adding Ollama as a startup service (recommended)
@@ -147,7 +147,7 @@ Or by re-downloading Ollama:
 
 ```shell
 curl -fsSL https://ollama.com/download/ollama-linux-amd64.tar.zst \
-    | sudo tar x -C /usr
+    | sudo tar --zstd -x -C /usr
 ```
 
 ## Installing specific versions


### PR DESCRIPTION
The tar's decompression flags are causing errors which ask for the "--zstd" flag. With the fixes of this pull request, these errors will disappear and the commands will run properly.

Here is an example of the current behavior:

```shell
root@fedora:/home/persioqq# curl -fsSL https://ollama.com/download/ollama-linux-amd64.tar.zst \
    | sudo tar x -C /usr
tar: Archive is compressed. Use --zstd option
tar: Error is not recoverable: exiting now
curl: (23) Failure writing output to destination, passed 16366 returned 0
```   

Thank you for your attention.