### PR TITLE
cmd: populate model capabilities in launchInteractiveModel

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1975,8 +1975,61 @@ func launchInteractiveModel(cmd *cobra.Command, modelName string) error {
 		Options:     map[string]any{},
 		ShowConnect: true,
 	}
-	// loadOrUnloadModel is cloud-safe here: remote/cloud models skip local preload
-	// and only validate auth/connectivity before interactive chat starts.
+
+	client, err := api.ClientFromEnvironment()
+	if err != nil {
+		return err
+	}
+
+	requestedCloud := modelref.HasExplicitCloudSource(modelName)
+
+	info, err := func() (*api.ShowResponse, error) {
+		showReq := &api.ShowRequest{Name: modelName}
+		info, err := client.Show(cmd.Context(), showReq)
+		var se api.StatusError
+		if errors.As(err, &se) && se.StatusCode == http.StatusNotFound {
+			if requestedCloud {
+				return nil, err
+			}
+			if err := PullHandler(cmd, []string{modelName}); err != nil {
+				return nil, err
+			}
+			return client.Show(cmd.Context(), &api.ShowRequest{Name: modelName})
+		}
+		return info, err
+	}()
+	if err != nil {
+		if handleCloudAuthorizationError(err) {
+			return nil
+		}
+		return err
+	}
+
+	ensureCloudStub(cmd.Context(), client, modelName)
+
+	opts.Think, err = inferThinkingOption(&info.Capabilities, &opts, false)
+	if err != nil {
+		return err
+	}
+
+	audioCapable := slices.Contains(info.Capabilities, model.CapabilityAudio)
+	opts.MultiModal = slices.Contains(info.Capabilities, model.CapabilityVision) || audioCapable
+
+	// TODO: remove the projector info and vision info checks below,
+	// these are left in for backwards compatibility with older servers
+	// that don't have the capabilities field in the model info
+	if len(info.ProjectorInfo) != 0 {
+		opts.MultiModal = true
+	}
+	for k := range info.ModelInfo {
+		if strings.Contains(k, ".vision.") {
+			opts.MultiModal = true
+			break
+		}
+	}
+
+	applyShowResponseToRunOptions(&opts, info)
+
 	if err := loadOrUnloadModel(cmd, &opts); err != nil {
 		return fmt.Errorf("error loading model: %w", err)
 	}


### PR DESCRIPTION
## Summary

- `launchInteractiveModel` (the TUI path, added in #14609) was missing the `client.Show()` capability-detection block that `RunHandler` uses
- This left `opts.MultiModal` always `false` in the TUI path, so image/audio file paths were always treated as unknown commands rather than loaded as multimodal attachments
- Mirrors the `Show()` call, pull-on-404 fallback, cloud auth handling, and `MultiModal`/`Think` population from `RunHandler` into `launchInteractiveModel`

Fixes #15711

## Test plan

- [x] `go test ./cmd/...` passes (1055 tests across 7 packages)
- [x] Manual: `ollama serve` + TUI — drag or type an image path into chat with a vision model; confirm it loads instead of printing "Unknown command"
- [ ] Manual: non-vision model in TUI — image path still shows "Unknown command" (correct behavior)
- [ ] Cloud model (`model:cloud`) in TUI — auth error handling preserved