### PR TITLE
fix: use MemAvailable equivalent in cgroup memory check

### DIFF
--- a/discover/cpu_linux.go
+++ b/discover/cpu_linux.go
@@ -73,9 +73,31 @@ func getCPUMemByCgroups(mem memInfo) memInfo {
 	}
 	used, err := getUint64ValueFromFile("/sys/fs/cgroup/memory.current")
 	if err == nil {
-		mem.FreeMemory = mem.TotalMemory - used
+		inactiveFile, _ := getCgroupMemStat("inactive_file")
+		reclaimable := min(inactiveFile, used)
+		mem.FreeMemory = mem.TotalMemory - used + reclaimable
 	}
 	return mem
+}
+
+func getCgroupMemStat(key string) (uint64, error) {
+	return cgroupMemStatFromFile("/sys/fs/cgroup/memory.stat", key)
+}
+
+func cgroupMemStatFromFile(path, key string) (uint64, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		fields := strings.Fields(s.Text())
+		if len(fields) == 2 && fields[0] == key {
+			return strconv.ParseUint(fields[1], 10, 64)
+		}
+	}
+	return 0, fmt.Errorf("key %q not found in memory.stat", key)
 }
 
 func getUint64ValueFromFile(path string) (uint64, error) {

--- a/discover/cpu_linux_test.go
+++ b/discover/cpu_linux_test.go
@@ -2086,14 +2086,14 @@ power management:
 
 func TestGetCgroupMemStatInactiveFile(t *testing.T) {
 	tests := []struct {
-		name     string
-		content  string
-		key      string
-		wantVal  uint64
-		wantErr  bool
+		name    string
+		content string
+		key     string
+		wantVal uint64
+		wantErr bool
 	}{
 		{
-			name: "finds inactive_file",
+			name:    "finds inactive_file",
 			content: "anon 36884480\nfile 21266915328\ninactive_file 21189849088\nactive_file 77045760\n",
 			key:     "inactive_file",
 			wantVal: 21189849088,

--- a/discover/cpu_linux_test.go
+++ b/discover/cpu_linux_test.go
@@ -3,6 +3,7 @@ package discover
 import (
 	"bytes"
 	"log/slog"
+	"os"
 	"testing"
 )
 
@@ -2078,6 +2079,60 @@ power management:
 				if c.ThreadCount != v.expCPUs[i].threads {
 					t.Fatalf("incorrect number of threads: expected:%v got:%v", v.expCPUs[i], c)
 				}
+			}
+		})
+	}
+}
+
+func TestGetCgroupMemStatInactiveFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		key      string
+		wantVal  uint64
+		wantErr  bool
+	}{
+		{
+			name: "finds inactive_file",
+			content: "anon 36884480\nfile 21266915328\ninactive_file 21189849088\nactive_file 77045760\n",
+			key:     "inactive_file",
+			wantVal: 21189849088,
+		},
+		{
+			name:    "key not present",
+			content: "anon 36884480\nfile 21266915328\n",
+			key:     "inactive_file",
+			wantErr: true,
+		},
+		{
+			name:    "empty file",
+			content: "",
+			key:     "inactive_file",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Write a temp file and redirect the function via a wrapper
+			f, err := os.CreateTemp(t.TempDir(), "memory.stat")
+			if err != nil {
+				t.Fatal(err)
+			}
+			f.WriteString(tt.content)
+			f.Close()
+
+			val, err := cgroupMemStatFromFile(f.Name(), tt.key)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got val=%d", val)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if val != tt.wantVal {
+				t.Errorf("got %d, want %d", val, tt.wantVal)
 			}
 		})
 	}


### PR DESCRIPTION
In LXC and Docker containers, `memory.current` includes reclaimable page cache, so computing free memory as `memory.max - memory.current` was giving a result closer to `MemFree` than `MemAvailable`, causing false "insufficient memory" errors even when Linux could reclaim enough cache to load the model.

The fix reads `inactive_file` from `/sys/fs/cgroup/memory.stat` and subtracts it from the used total before computing free memory, matching how the kernel calculates `MemAvailable`. Fixes #15704