### PR TITLE
server: fix download stall watchdog not firing when no bytes arrive

### DIFF
--- a/server/download.go
+++ b/server/download.go
@@ -30,6 +30,10 @@ import (
 
 const maxRetries = 6
 
+// stallDuration is the no-progress window after which a part is declared
+// stalled. A package var (not a const) so tests can shorten it.
+var stallDuration = 30 * time.Second
+
 var (
 	errMaxRetriesExceeded   = errors.New("max retries exceeded")
 	errPartStalled          = errors.New("part stalled")
@@ -359,6 +363,13 @@ func (b *blobDownload) downloadChunk(ctx context.Context, requestURL *url.URL, w
 	})
 
 	g.Go(func() error {
+		// Initialize at watchdog entry so the stall timer fires even when
+		// no bytes ever arrive from the server (otherwise lastUpdated stays
+		// zero and the stall check never triggers on that retry).
+		part.lastUpdatedMu.Lock()
+		part.lastUpdated = time.Now()
+		part.lastUpdatedMu.Unlock()
+
 		ticker := time.NewTicker(time.Second)
 		for {
 			select {
@@ -371,13 +382,9 @@ func (b *blobDownload) downloadChunk(ctx context.Context, requestURL *url.URL, w
 				lastUpdated := part.lastUpdated
 				part.lastUpdatedMu.Unlock()
 
-				if !lastUpdated.IsZero() && time.Since(lastUpdated) > 30*time.Second {
+				if time.Since(lastUpdated) > stallDuration {
 					const msg = "%s part %d stalled; retrying. If this persists, press ctrl-c to exit, then 'ollama pull' to find a faster connection."
 					slog.Info(fmt.Sprintf(msg, b.Digest[7:19], part.N))
-					// reset last updated
-					part.lastUpdatedMu.Lock()
-					part.lastUpdated = time.Time{}
-					part.lastUpdatedMu.Unlock()
 					return errPartStalled
 				}
 			case <-ctx.Done():

--- a/server/download_test.go
+++ b/server/download_test.go
@@ -1,0 +1,63 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestDownloadChunkStallWatchdogFiresWithoutProgress verifies that the
+// chunk watchdog fires when the server sends response headers but never
+// writes any body bytes. Previously the watchdog's IsZero guard caused
+// it to permanently skip stall detection in this case, leaving the
+// reader goroutine blocked on a dead TCP stream.
+func TestDownloadChunkStallWatchdogFiresWithoutProgress(t *testing.T) {
+	origStall := stallDuration
+	stallDuration = 200 * time.Millisecond
+	t.Cleanup(func() { stallDuration = origStall })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "1024")
+		w.Header().Set("Content-Range", "bytes 0-1023/1024")
+		w.WriteHeader(http.StatusPartialContent)
+		w.(http.Flusher).Flush()
+		<-r.Context().Done()
+	}))
+	t.Cleanup(srv.Close)
+
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b := &blobDownload{
+		Name:   filepath.Join(t.TempDir(), "blob"),
+		Digest: "sha256:deadbeef1234567890abcdef",
+	}
+	part := &blobDownloadPart{
+		blobDownload: b,
+		N:            0,
+		Offset:       0,
+		Size:         1024,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	err = b.downloadChunk(ctx, u, io.Discard, part)
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, errPartStalled) {
+		t.Fatalf("want errPartStalled, got %v (elapsed %v)", err, elapsed)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("watchdog took too long to fire: %v (want ~stallDuration=%v)", elapsed, stallDuration)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a client-side watchdog bug in `downloadChunk` that matches the "99% hang" symptom tracked in #1736 and the maintainer-described pattern of *"certain parts stall completely and zero data is received from the backend. The connection itself is still healthy so it doesn't trigger a retry"*.

## Root cause

The per-part stall watchdog in `server/download.go` was gated by two conditions that, together, silently disabled it on the cases where it was most needed:

1. **The initial-byte guard** — `if !lastUpdated.IsZero() && time.Since(lastUpdated) > 30*time.Second` means the stall timer only starts after the first byte is written. A stream that never delivers a byte is never checked.
2. **The reset-to-zero on stall** — after firing `errPartStalled` the watchdog wrote `part.lastUpdated = time.Time{}`. The outer retry loop then calls `downloadChunk` again. The new watchdog instance re-reads the zero-value `lastUpdated`, the guard above fails, and if the new connection *also* stalls before producing any bytes, no timeout ever fires and the goroutine blocks forever on a dead TCP stream.

In practice this is what users see as the "99% hang": after the first stall is detected and retried, the retry's new stream opens successfully but streams zero bytes (Cloudflare / R2 byte-range stream goes dead, TCP stays open, no FIN). With no watchdog, only Ctrl+C recovers.

## Fix

- Initialize `part.lastUpdated = time.Now()` at watchdog entry so the stall timer has a reference point even before the first byte arrives.
- Drop the `!lastUpdated.IsZero()` guard and the subsequent reset-to-zero block — both were the mechanism of the bug.
- Extract the magic `30 * time.Second` into a package var `stallDuration` so tests can shorten it. Production default is unchanged.

Diff is 10 lines of code change in `server/download.go` and 63 lines of new test.

## Test plan

New test `TestDownloadChunkStallWatchdogFiresWithoutProgress` in `server/download_test.go`:

- Starts an `httptest.Server` whose handler writes `206 Partial Content` headers, flushes, then blocks on `r.Context().Done()` — i.e. it accepts the connection but streams zero body bytes. This mirrors the mxyng-described pattern exactly.
- Calls `b.downloadChunk` with a short `stallDuration` (200 ms) and a 5 s outer context deadline.
- Asserts that `downloadChunk` returns `errPartStalled` in under 2 s.

**Before the fix**: the test returns `context deadline exceeded` at 5 s (watchdog never fires).
**After the fix**: the test returns `errPartStalled` at ~1 s (first ticker tick).

Verification run locally (go 1.26, darwin/arm64):

```
go test ./server/                                    → ok   4.97s
go test -race ./server/ -run TestDownload -count=5   → ok   (no races)
go vet ./server/                                     → clean
gofmt -l server/download.go server/download_test.go  → clean
```

(Pre-existing race-detector failures in `TestQuantizeModel` and `TestSchedRequests*` are present on unmodified `main` and are unrelated to this change — confirmed by checking out `main` and reproducing them.)

## Notes on behaviour change

The old watchdog *intentionally* did not tick until the first byte arrived, which meant a very slow initial-byte server response (e.g. cold CDN origin fetch) would not trigger a stall. With this fix, a 30 s no-data window at the start of a part will now surface as `errPartStalled` and the outer retry loop will open a fresh connection — which is almost certainly the desired behaviour and matches what users expect when `ollama pull` looks frozen. The outer retry logic treats `errPartStalled` as `try--; continue`, so a genuinely slow (but not dead) server still converges rather than exhausting retries.

Refs #1736