### PR TITLE
Add Spring AI Playground to Frameworks & Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ console.log(response.message.content);
 - [Stakpak](https://github.com/stakpak/agent) - Open source DevOps agent
 - [Hexabot](https://github.com/hexastack/hexabot) - Conversational AI builder
 - [Neuro SAN](https://github.com/cognizant-ai-lab/neuro-san-studio) - Multi-agent orchestration ([docs](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/user_guide.md#ollama))
+- [Spring AI Playground](https://github.com/spring-ai-community/spring-ai-playground) - Local-first, sandboxed MCP tools with risk levels, an MCP proxy for external servers, agentic chat, and built-in observability
 
 ### RAG & Knowledge Bases
 


### PR DESCRIPTION
This adds [Spring AI Playground](https://github.com/spring-ai-community/spring-ai-playground) to **Community Integrations > Frameworks & Agents**.

Spring AI Playground is a local-first, cross-platform (macOS / Windows / Linux) desktop app - a safe local execution layer for AI agent tools - built around local models served by Ollama:

- **Safe tools** - build low-code MCP tools in JavaScript (Tool Studio), each gated by "no pass, no run" (a Local Pass test-run), running inside a defense-in-depth sandbox with a visible per-tool Risk Level (L0-L5) and human-in-the-loop approval
- **MCP proxy** - select tools from any connected external MCP server and re-expose them on the built-in /mcp endpoint, composing multiple servers into one surface, with a risk score on each connected server and every call gated by per-tool human-in-the-loop
- **Agentic chat** - local, tool-using conversations grounded in your own documents (RAG), running against your Ollama models
- **Built-in observability** - twelve dashboards plus per-call trace timelines for every chat, tool call, vector query, and MCP invocation, with live token cost and latency
- Also ships with 86 default tools and 57 preset external MCP server connections; provider-agnostic (Ollama-first, plus OpenAI and OpenAI-compatible APIs)

Docs: https://spring-ai-community.github.io/spring-ai-playground/

Single added line, mergeable with no conflicts. Thanks for maintaining Ollama!