### PR TITLE
docs: fix typos in documentation

### DIFF
--- a/docs/api/introduction.mdx
+++ b/docs/api/introduction.mdx
@@ -2,7 +2,7 @@
 title: Introduction
 ---
 
-Ollama's API allows you to run and interact with models programatically.
+Ollama's API allows you to run and interact with models programmatically.
 
 ## Get started
 

--- a/docs/capabilities/thinking.mdx
+++ b/docs/capabilities/thinking.mdx
@@ -147,7 +147,7 @@ Thinking streams interleave reasoning tokens before answer tokens. Detect the fi
 - Enable thinking for a single run: `ollama run deepseek-r1 --think "Where should I visit in Lisbon?"`
 - Disable thinking: `ollama run deepseek-r1 --think=false "Summarize this article"`
 - Hide the trace while still using a thinking model: `ollama run deepseek-r1 --hidethinking "Is 9.9 bigger or 9.11?"`
-- Inside interactive sessions, toggle with `/set think` or `/set nothink`.
+- Inside interactive sessions, toggle with `/set think` or `/set nothing`.
 - GPT-OSS only accepts levels: `ollama run gpt-oss --think=low "Draft a headline"` (replace `low` with `medium` or `high` as needed).
 
 <Note>Thinking is enabled by default in the CLI and API for supported models.</Note>

--- a/docs/capabilities/vision.mdx
+++ b/docs/capabilities/vision.mdx
@@ -7,7 +7,7 @@ Vision models accept images alongside text so the model can describe, classify, 
 ## Quick start
 
 ```shell
-ollama run gemma3 ./image.png whats in this image?
+ollama run gemma3 ./image.png what's in this image?
 ```
 
 


### PR DESCRIPTION
Fixes three spelling errors in docs:\n- 'nothink' → 'nothing' in thinking.mdx\n- 'whats' → 'what's' in vision.mdx\n- 'programatically' → 'programmatically' in api/introduction.mdx