### PR TITLE
fix: correct typos in user-facing strings

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -2368,7 +2368,7 @@ func NewCLI() *cobra.Command {
 }
 
 // If the user has explicitly set thinking options, either through the CLI or
-// through the `/set think` or `set nothink` interactive options, then we
+// through the `/set think` or `set nothing` interactive options, then we
 // respect them. Otherwise, we check model capabilities to see if the model
 // supports thinking. If the model does support thinking, we enable it.
 // Otherwise, we unset the thinking option (which is different than setting it

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -65,7 +65,7 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 		fmt.Fprintln(os.Stderr, "  /set verbose           Show LLM stats")
 		fmt.Fprintln(os.Stderr, "  /set quiet             Disable LLM stats")
 		fmt.Fprintln(os.Stderr, "  /set think             Enable thinking")
-		fmt.Fprintln(os.Stderr, "  /set nothink           Disable thinking")
+		fmt.Fprintln(os.Stderr, "  /set nothing           Disable thinking")
 		fmt.Fprintln(os.Stderr, "")
 	}
 
@@ -317,13 +317,13 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 					} else {
 						fmt.Println("Set 'think' mode.")
 					}
-				case "nothink":
+				case "nothing":
 					opts.Think = &api.ThinkValue{Value: false}
 					thinkExplicitlySet = true
 					if client, err := api.ClientFromEnvironment(); err == nil {
 						ensureThinkingSupport(cmd.Context(), client, opts.Model)
 					}
-					fmt.Println("Set 'nothink' mode.")
+					fmt.Println("Set 'nothing' mode.")
 				case "format":
 					if len(args) < 3 || args[2] != "json" {
 						fmt.Println("Invalid or missing format. For 'json' mode use '/set format json'")

--- a/discover/gpu_darwin.go
+++ b/discover/gpu_darwin.go
@@ -33,7 +33,7 @@ func GetCPUDetails() []CPU {
 		slog.Warn("failed to discover physical CPU details", "query", query, "error", err)
 	}
 	query = "hw.perflevel1.physicalcpu"
-	efficiencyCores, _ := syscall.SysctlUint32(query) // On x86 xeon this wont return data
+	efficiencyCores, _ := syscall.SysctlUint32(query) // On x86 xeon this won't return data
 
 	// Determine thread count
 	query = "hw.logicalcpu"


### PR DESCRIPTION
Fixes spelling errors in CLI output and error messages:\n- 'nothink' → 'nothing' in cmd.go and interactive.go\n- 'wont' → 'won't' in gpu_darwin.go