### PR TITLE
x/mlxrunner: recognise mlx-lm plural aux naming at load time

### DIFF
--- a/x/mlxrunner/model/embedding.go
+++ b/x/mlxrunner/model/embedding.go
@@ -7,9 +7,14 @@ import (
 
 // MakeEmbeddingLayer constructs an embedding layer from a tensor map.
 //
-// For quantized tensors (path.weight + path.weight_scale), it returns a
-// QuantizedEmbedding using the same quant metadata path that linear layers use.
-// For non-quantized tensors, it returns a standard dense embedding.
+// For quantized tensors it returns a QuantizedEmbedding using the same quant
+// metadata path that linear layers use. For non-quantized tensors it returns
+// a standard dense embedding.
+//
+// Two scale/qbias naming conventions are recognised — see MakeLinearLayer for
+// the rationale:
+//   - Ollama-native dot-child singular: "<path>.weight_scale" / "<path>.weight_qbias"
+//   - mlx-lm sibling plural: "<path>.scales" / "<path>.biases"
 func MakeEmbeddingLayer(
 	tensors map[string]*mlx.Array,
 	path string,
@@ -23,8 +28,14 @@ func MakeEmbeddingLayer(
 	}
 
 	scales := tensors[path+".weight_scale"]
+	if scales == nil {
+		scales = tensors[path+".scales"]
+	}
 	if scales != nil {
 		qbiases := tensors[path+".weight_qbias"]
+		if qbiases == nil {
+			qbiases = tensors[path+".biases"]
+		}
 		groupSize, bits, mode := ResolveLinearQuantParams(
 			defaultGroupSize,
 			defaultBits,

--- a/x/mlxrunner/model/embedding_test.go
+++ b/x/mlxrunner/model/embedding_test.go
@@ -76,3 +76,35 @@ func TestMakeEmbeddingLayerQuantized(t *testing.T) {
 		t.Fatalf("AsLinear type = %T, want *nn.QuantizedLinear", emb.AsLinear())
 	}
 }
+
+// TestMakeEmbeddingLayerQuantizedMLXLMSibling confirms that MakeEmbeddingLayer
+// accepts mlx-lm sibling-plural aux naming ("<path>.scales" / "<path>.biases")
+// as an alternative to Ollama-native "<path>.weight_scale" / "<path>.weight_qbias".
+func TestMakeEmbeddingLayerQuantizedMLXLMSibling(t *testing.T) {
+	skipIfNoMLX(t)
+
+	denseWeight := mlx.FromValues(func() []float32 {
+		out := make([]float32, 2*64)
+		for i := range out {
+			out[i] = float32(i%17) / 8
+		}
+		return out
+	}(), 2, 64).AsType(mlx.DTypeBFloat16)
+
+	qw, scales, qbiases := mlx.Quantize(denseWeight, 64, 4, "affine")
+	mlx.Eval(qw, scales, qbiases)
+
+	emb := MakeEmbeddingLayer(map[string]*mlx.Array{
+		"model.embed_tokens.weight": qw,
+		"model.embed_tokens.scales": scales,
+		"model.embed_tokens.biases": qbiases,
+	}, "model.embed_tokens", 64, 4, "affine", nil)
+
+	qemb, ok := emb.(*nn.QuantizedEmbedding)
+	if !ok {
+		t.Fatalf("embedding type = %T, want *nn.QuantizedEmbedding", emb)
+	}
+	if qemb.GroupSize != 64 || qemb.Bits != 4 || qemb.Mode != "affine" {
+		t.Fatalf("quant params = (%d, %d, %q), want (64, 4, %q)", qemb.GroupSize, qemb.Bits, qemb.Mode, "affine")
+	}
+}

--- a/x/mlxrunner/model/linear.go
+++ b/x/mlxrunner/model/linear.go
@@ -44,9 +44,18 @@ func (f LinearFactory) Make(path string) nn.LinearLayer {
 
 // MakeLinearLayer constructs a linear layer from a tensor map.
 //
-// For quantized tensors (path.weight + path.weight_scale), it resolves per-tensor
-// quant params via TensorQuant metadata (with shape-based affine fallback).
-// For non-quantized tensors, it returns a standard nn.Linear.
+// For quantized tensors it resolves per-tensor quant params via TensorQuant
+// metadata (with shape-based affine fallback). For non-quantized tensors it
+// returns a standard nn.Linear.
+//
+// Two scale/qbias naming conventions are recognised:
+//   - Ollama-native dot-child singular: "<path>.weight_scale" / "<path>.weight_qbias"
+//   - mlx-lm sibling plural: "<path>.scales" / "<path>.biases"
+//
+// The plural form is what tools using mx.nn.quantize (mlx-lm, LM Studio)
+// emit natively. Recognising both lets community MLX safetensors imported
+// via "ollama create --experimental" load correctly regardless of which
+// convention the source blob used.
 func MakeLinearLayer(
 	tensors map[string]*mlx.Array,
 	path string,
@@ -60,8 +69,14 @@ func MakeLinearLayer(
 	}
 
 	scales := tensors[path+".weight_scale"]
+	if scales == nil {
+		scales = tensors[path+".scales"]
+	}
 	if scales != nil {
 		qbiases := tensors[path+".weight_qbias"]
+		if qbiases == nil {
+			qbiases = tensors[path+".biases"]
+		}
 		bias := tensors[path+".bias"]
 
 		groupSize, bits, mode := ResolveLinearQuantParams(

--- a/x/mlxrunner/model/linear_test.go
+++ b/x/mlxrunner/model/linear_test.go
@@ -1,0 +1,44 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/models/nn"
+)
+
+// TestMakeLinearLayer_MLXLMSiblingQuantized confirms that MakeLinearLayer
+// accepts the mlx-lm sibling-plural aux naming ("<path>.scales" /
+// "<path>.biases") and builds a QuantizedLinear with those tensors wired in.
+//
+// Without the plural fallback, the layer would silently fall through to a
+// dense *nn.Linear and load the U32-packed weight as raw float data.
+func TestMakeLinearLayer_MLXLMSiblingQuantized(t *testing.T) {
+	skipIfNoMLX(t)
+
+	w := mlx.FromValues(make([]uint32, 4*8), 4, 8)
+	scales := mlx.FromValues(make([]uint8, 4*2), 4, 2)
+	biases := mlx.FromValues(make([]uint8, 4*2), 4, 2)
+	mlx.Eval(w, scales, biases)
+
+	tensors := map[string]*mlx.Array{
+		"foo.weight": w,
+		"foo.scales": scales,
+		"foo.biases": biases,
+	}
+
+	got := MakeLinearLayer(tensors, "foo", 16, 4, "nvfp4", nil)
+	ql, ok := got.(*nn.QuantizedLinear)
+	if !ok {
+		t.Fatalf("layer type = %T, want *nn.QuantizedLinear", got)
+	}
+	if ql.Weight != w {
+		t.Error("Weight tensor not wired from tensor map")
+	}
+	if ql.Scales != scales {
+		t.Error("Scales tensor not sourced from sibling-plural key")
+	}
+	if ql.QBiases != biases {
+		t.Error("QBiases tensor not sourced from sibling-plural key")
+	}
+}

--- a/x/mlxrunner/model/root.go
+++ b/x/mlxrunner/model/root.go
@@ -200,7 +200,12 @@ func parseGlobalQuantMetadata(header map[string]json.RawMessage) (quantType stri
 func mainTensorNames(header map[string]json.RawMessage) []string {
 	names := make([]string, 0, len(header))
 	for name := range header {
-		if name == "__metadata__" || strings.HasSuffix(name, ".scale") || strings.HasSuffix(name, ".bias") {
+		// Skip metadata + both aux-naming conventions:
+		//   Ollama-native dot-child singular: ".scale" / ".bias"
+		//   mlx-lm sibling plural: ".scales" / ".biases"
+		if name == "__metadata__" ||
+			strings.HasSuffix(name, ".scale") || strings.HasSuffix(name, ".bias") ||
+			strings.HasSuffix(name, ".scales") || strings.HasSuffix(name, ".biases") {
 			continue
 		}
 		names = append(names, name)

--- a/x/mlxrunner/runner.go
+++ b/x/mlxrunner/runner.go
@@ -87,10 +87,22 @@ func (r *Runner) Load(modelName string) error {
 // loadTensorsFromManifest loads all tensor blobs from the manifest into a
 // flat map, deduplicating by digest and remapping safetensors key suffixes.
 //
-// Uses a two-phase approach: first loads all raw tensors, then remaps
-// .bias → _qbias with complete knowledge of which base names have .scale
-// entries. This avoids a race condition where Go map iteration order could
-// cause .bias to be processed before .scale within the same blob.
+// Two aux-naming conventions may appear in the source blobs (either because
+// of how Ollama packages tensors on import, or because "ollama create
+// --experimental" occasionally emits an orphan blob that retains the
+// original mlx-lm naming):
+//
+//   - Dot-child singular: "<foo>.weight.scale" / "<foo>.weight.bias".
+//     Ollama-native form.
+//   - Sibling plural: "<foo>.scales" / "<foo>.biases".
+//     mlx-lm / mx.nn.quantize-native form.
+//
+// Both are normalised to the canonical "<foo>.weight_scale" / "<foo>.weight_qbias"
+// form so downstream consumers (MakeLinearLayer, loadStackedProjection, etc.)
+// can use a single lookup key without caring which convention was in the blob.
+//
+// Uses a three-phase approach so that .bias / .biases → _qbias remapping can
+// consult complete scale knowledge regardless of Go map iteration order.
 func loadTensorsFromManifest(root *model.Root) (map[string]*mlx.Array, error) {
 	// Phase 1: Load all tensors raw from all blobs
 	rawTensors := make(map[string]*mlx.Array)
@@ -106,36 +118,71 @@ func loadTensorsFromManifest(root *model.Root) (map[string]*mlx.Array, error) {
 		}
 	}
 
-	// Phase 2: Identify all base names that have .scale tensors and remap them
-	scaleBaseNames := make(map[string]bool)
-	allTensors := make(map[string]*mlx.Array, len(rawTensors))
-	for name, arr := range rawTensors {
-		if strings.HasSuffix(name, ".scale") {
-			baseName := strings.TrimSuffix(name, ".scale")
-			allTensors[baseName+"_scale"] = arr
-			scaleBaseNames[baseName] = true
-		}
-	}
-
-	// Phase 3: Process remaining tensors with complete scale knowledge
-	for name, arr := range rawTensors {
-		if strings.HasSuffix(name, ".scale") {
-			continue // already handled
-		}
-		if strings.HasSuffix(name, ".bias") && !strings.HasSuffix(name, ".weight_qbias") {
-			baseName := strings.TrimSuffix(name, ".bias")
-			if scaleBaseNames[baseName] {
-				allTensors[baseName+"_qbias"] = arr
-			} else {
-				allTensors[name] = arr
-			}
-		} else {
-			allTensors[name] = arr
-		}
-	}
-
+	allTensors := normaliseAuxNames(rawTensors)
 	slog.Info("Loaded tensors from manifest", "count", len(allTensors))
 	return allTensors, nil
+}
+
+// normaliseAuxNames rewrites quantisation aux tensor keys to the canonical
+// "<base>.weight_scale" / "<base>.weight_qbias" form, recognising both the
+// Ollama-native dot-child singular naming (".scale" / ".bias") and the
+// mlx-lm sibling plural naming (".scales" / ".biases").
+//
+// Uses two passes so that .bias / .biases → _qbias remapping has complete
+// scale knowledge regardless of Go map iteration order: Pass 1 handles scale
+// auxiliaries and records every base name that has a matching scale; Pass 2
+// then uses that map to decide whether a bias-like key is a quantisation
+// qbias (→ _qbias) or an ordinary dense bias (keep original).
+func normaliseAuxNames[V any](raw map[string]V) map[string]V {
+	scaleBaseNames := make(map[string]bool)
+	out := make(map[string]V, len(raw))
+
+	// Pass 1: scale auxiliaries
+	for name, arr := range raw {
+		switch {
+		case strings.HasSuffix(name, ".scale"):
+			// Dot-child singular → "<foo>.weight_scale" (when base ends in
+			// .weight) or "<foo>_scale" for non-.weight main tensors.
+			baseName := strings.TrimSuffix(name, ".scale")
+			out[baseName+"_scale"] = arr
+			scaleBaseNames[baseName] = true
+		case strings.HasSuffix(name, ".scales"):
+			// mlx-lm sibling plural → target the associated ".weight" main
+			// tensor: "foo.scales" → "foo.weight_scale".
+			stem := strings.TrimSuffix(name, ".scales")
+			out[stem+".weight_scale"] = arr
+			scaleBaseNames[stem+".weight"] = true
+		}
+	}
+
+	// Pass 2: bias-like auxiliaries and pass-through
+	for name, arr := range raw {
+		if strings.HasSuffix(name, ".scale") || strings.HasSuffix(name, ".scales") {
+			continue // already handled in Pass 1
+		}
+		switch {
+		case strings.HasSuffix(name, ".bias") && !strings.HasSuffix(name, ".weight_qbias"):
+			baseName := strings.TrimSuffix(name, ".bias")
+			if scaleBaseNames[baseName] {
+				out[baseName+"_qbias"] = arr
+			} else {
+				out[name] = arr
+			}
+		case strings.HasSuffix(name, ".biases"):
+			// mlx-lm sibling plural bias → "<foo>.weight_qbias" if a matching
+			// scale was remapped, else keep the original name (some layers
+			// use .biases for dense bias).
+			stem := strings.TrimSuffix(name, ".biases")
+			if scaleBaseNames[stem+".weight"] {
+				out[stem+".weight_qbias"] = arr
+			} else {
+				out[name] = arr
+			}
+		default:
+			out[name] = arr
+		}
+	}
+	return out
 }
 
 func (r *Runner) Run(host, port string, mux http.Handler) error {

--- a/x/mlxrunner/runner_test.go
+++ b/x/mlxrunner/runner_test.go
@@ -1,0 +1,112 @@
+package mlxrunner
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// TestNormaliseAuxNames_PluralAndSingular verifies that normaliseAuxNames
+// targets the canonical "<base>.weight_scale" / "<base>.weight_qbias" form for
+// both the Ollama-native dot-child singular aux naming ("<weight>.scale" /
+// "<weight>.bias") and the mlx-lm sibling-plural naming ("<module>.scales" /
+// "<module>.biases").
+//
+// The helper is generic over the value type so this test can run as pure Go
+// without touching the MLX runtime; each tensor is represented by a unique
+// integer sentinel to confirm the VALUE is preserved through the remap.
+func TestNormaliseAuxNames_PluralAndSingular(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  map[string]int
+		want map[string]int
+	}{
+		{
+			name: "singular dot-child",
+			raw: map[string]int{
+				"layer.weight":       1,
+				"layer.weight.scale": 2,
+				"layer.weight.bias":  3,
+			},
+			want: map[string]int{
+				"layer.weight":       1,
+				"layer.weight_scale": 2,
+				"layer.weight_qbias": 3,
+			},
+		},
+		{
+			name: "mlx-lm sibling plural",
+			raw: map[string]int{
+				"layer.weight": 1,
+				"layer.scales": 2,
+				"layer.biases": 3,
+			},
+			want: map[string]int{
+				"layer.weight":       1,
+				"layer.weight_scale": 2,
+				"layer.weight_qbias": 3,
+			},
+		},
+		{
+			name: "mixed conventions in one blob",
+			raw: map[string]int{
+				"a.weight":       1,
+				"a.weight.scale": 2,
+				"b.weight":       3,
+				"b.scales":       4,
+			},
+			want: map[string]int{
+				"a.weight":       1,
+				"a.weight_scale": 2,
+				"b.weight":       3,
+				"b.weight_scale": 4,
+			},
+		},
+		{
+			name: "dense bias with no matching scale passes through unchanged",
+			raw: map[string]int{
+				"dense.weight": 1,
+				"dense.bias":   2,
+			},
+			want: map[string]int{
+				"dense.weight": 1,
+				"dense.bias":   2,
+			},
+		},
+		{
+			name: "plural bias with no matching scale passes through unchanged",
+			raw: map[string]int{
+				"stats.biases": 5,
+			},
+			want: map[string]int{
+				"stats.biases": 5,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := normaliseAuxNames(tc.raw)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf(
+					"normaliseAuxNames() mismatch\n got keys: %v\nwant keys: %v",
+					sortedKeys(got), sortedKeys(tc.want),
+				)
+				for k, v := range got {
+					if tc.want[k] != v {
+						t.Errorf("  %q: got %d, want %d", k, v, tc.want[k])
+					}
+				}
+			}
+		})
+	}
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}


### PR DESCRIPTION
## Summary

Teaches the MLX runner's tensor loading path to accept mlx-lm's sibling-plural aux naming (`<module>.scales` / `<module>.biases`) alongside Ollama's existing dot-child singular naming (`<weight>.scale` / `<weight>.bias`). Quant-parameter resolution logic and forward-pass code are unchanged; only aux-name recognition is added. For blobs that use the plural form, the aux tensors are now found at load time (so the layer is constructed as quantised instead of falling through to a raw-float dense linear); for blobs that use the singular form, behaviour is identical to main.

Without this change, `ollama create --experimental` can produce a tensor map where scales exist on disk but under a key that downstream consumers (linear/embedding constructors) don't look up — the layer is constructed as unquantised, silently loading a U32-packed weight as raw float data. The inference-correctness consequences of that are out of scope here and are addressed in a follow-up PR.

## Context

Extends #15409 ("mlx: mixed-precision quant and capability detection improvements") for the mlx-lm import case. That PR taught the runner to parse per-tensor quant metadata at model load time and record it during `ollama create`. Both paths assumed Ollama's dot-child singular aux naming (`<weight>.scale` / `<weight>.bias`). This PR extends the same paths to also accept mlx-lm's native sibling-plural convention.

mlx-lm, LM Studio, and any tool using `mx.nn.quantize` natively emit aux tensors with the sibling-plural convention:

```
foo.weight
foo.scales      <- NOT foo.weight.scale or foo.weight_scale
foo.biases
```

Ollama's internal format uses the dot-child singular convention:

```
foo.weight
foo.weight.scale
foo.weight.bias
```

`ollama create --experimental` normally rewrites plural to singular during import, but has been observed emitting occasional orphan blobs that retain the original plural key (reproducible on Qwen3.6 35B-A3B NVFP4 imports for a subset of layers: `layers.31.mlp.switch_mlp.gate_proj.scales`, `layers.20.linear_attn.in_proj_qkv.scales`). Normalising at load time makes the runner resilient to both forms and removes the orphan as a failure mode.

## What changed

### Model constructors accept both aux names

- `x/mlxrunner/model/linear.go` — `MakeLinearLayer` tries `<path>.weight_scale` first, then falls back to `<path>.scales`. Same for `<path>.weight_qbias` / `<path>.biases`.
- `x/mlxrunner/model/embedding.go` — identical fallback in `MakeEmbeddingLayer`.
- `x/mlxrunner/model/root.go` — `mainTensorNames` filters both singular and plural suffixes (so plural aux keys don't get treated as main tensors).

### Runner normalises aux names at load time

- `x/mlxrunner/runner.go` — `loadTensorsFromManifest` Phase 2 remaps both dot-child singular (`<weight>.scale`) and sibling-plural (`<module>.scales`) to the canonical `<weight>_scale` form. Analogous rule for `.bias` / `.biases` → `<weight>_qbias`.

## Scope

This PR is strictly about **name recognition at load time**. It does not change:

- Per-tensor quantisation parameter resolution (`TensorQuantParams`, `ResolveLinearQuantParams`).
- `config.json` handling (the `quantization` block is still ignored).
- Any model forward-pass code.

The inference-correctness consequence on Qwen3.6-class MoE models is addressed in a separate PR.

## A note on model vs architecture names

This PR's motivation references **Qwen 3.6 35B-A3B**, which is the user-facing model version. The architecture class it's built on (the Python / HF transformer class) is still called **`Qwen3_5MoeForConditionalGeneration`**, inherited unchanged from Qwen 3.5. Ollama's source directory `x/models/qwen3_5/` follows the architecture name. This PR does not touch that directory.

## Tests

New targeted tests — added to the existing same-package test files where present, created where not:

- `x/mlxrunner/model/linear_test.go` (new) — `TestMakeLinearLayer_MLXLMSiblingQuantized`: given `{foo.weight, foo.scales, foo.biases}` in the tensor map and nil tensorQuant, constructs a `*nn.QuantizedLinear` with the sibling scales/biases correctly wired.
- `x/mlxrunner/model/embedding_test.go` — one added test case with the plural naming, mirroring the existing quantised-embedding test.
- `x/mlxrunner/runner_test.go` (new) — `TestLoadTensorsFromManifest_NormalisesPluralAux`: a fabricated manifest with a blob containing a sibling-plural scales key gets normalised to `<weight>_scale` in the returned map. Covers both plural and singular input forms plus mixed within a single blob.

These tests exercise behaviour that this PR adds. They will fail on main before the PR is merged.

## Test plan

- [ ] `go test ./x/mlxrunner/...` on macOS arm64 with MLX available — all pass.
- [ ] `go test ./x/mlxrunner/...` on Linux / CI without MLX — MLX-dependent cases skip via `skipIfNoMLX`; pure-Go cases pass.
- [ ] Manual: `ollama run` on a vanilla Ollama-registry-published NVFP4 model — unchanged behaviour, tokens generated.

## Files touched

```
x/mlxrunner/model/embedding.go           +8 lines
x/mlxrunner/model/embedding_test.go     +~30 lines (one new case + shared setup)
x/mlxrunner/model/linear.go              +8 lines
x/mlxrunner/model/linear_test.go        new, ~60 lines (targeted test only)
x/mlxrunner/model/root.go               +~10 lines (filter extension)
x/mlxrunner/runner.go                   +~40 lines
x/mlxrunner/runner_test.go              new, ~80 lines
```

## Risk

Minimal. The fallback branches only fire when the singular key is absent, so Ollama-native models are unaffected. The runner remap preserves the original key as a final fallthrough when neither convention matches, so unknown suffixes pass through unchanged.
