### PR TITLE
x/mlxrunner: apply config.json per-tensor quant overrides for mixed-precision MoE

### DIFF
--- a/x/mlxrunner/model/config_quant.go
+++ b/x/mlxrunner/model/config_quant.go
@@ -1,0 +1,80 @@
+package model
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/ollama/ollama/x/imagegen/manifest"
+)
+
+// readConfigQuantOverrides parses config.json's "quantization" (or
+// "quantization_config") block. Returns global defaults and per-path
+// overrides keyed by <path>.weight. Overrides that omit "mode" default to
+// "affine" (mx.nn.Linear.to_quantized's default). Missing or malformed
+// config is a silent fallback (zero values, nil error).
+func readConfigQuantOverrides(m *manifest.ModelManifest) (TensorQuantInfo, map[string]*TensorQuantInfo, error) {
+	data, err := m.ReadConfig("config.json")
+	if err != nil {
+		return TensorQuantInfo{}, nil, nil
+	}
+
+	var cfg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return TensorQuantInfo{}, nil, nil
+	}
+
+	raw, ok := cfg["quantization"]
+	if !ok {
+		raw, ok = cfg["quantization_config"]
+	}
+	if !ok {
+		return TensorQuantInfo{}, nil, nil
+	}
+
+	var block map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &block); err != nil {
+		return TensorQuantInfo{}, nil, nil
+	}
+
+	var defaults TensorQuantInfo
+	var overrides map[string]*TensorQuantInfo
+
+	for key, val := range block {
+		switch key {
+		case "group_size":
+			_ = json.Unmarshal(val, &defaults.GroupSize)
+		case "bits":
+			_ = json.Unmarshal(val, &defaults.Bits)
+		case "mode":
+			_ = json.Unmarshal(val, &defaults.Mode)
+		default:
+			var inner map[string]json.RawMessage
+			if err := json.Unmarshal(val, &inner); err != nil {
+				continue
+			}
+			info := &TensorQuantInfo{}
+			if v, ok := inner["group_size"]; ok {
+				_ = json.Unmarshal(v, &info.GroupSize)
+			}
+			if v, ok := inner["bits"]; ok {
+				_ = json.Unmarshal(v, &info.Bits)
+			}
+			if v, ok := inner["mode"]; ok {
+				_ = json.Unmarshal(v, &info.Mode)
+			}
+			if info.Mode == "" {
+				info.Mode = "affine"
+			}
+			info.QuantType = strings.ToUpper(info.Mode)
+			if overrides == nil {
+				overrides = make(map[string]*TensorQuantInfo)
+			}
+			overrides[key+".weight"] = info
+		}
+	}
+
+	if defaults.Mode != "" {
+		defaults.QuantType = strings.ToUpper(defaults.Mode)
+	}
+	return defaults, overrides, nil
+}

--- a/x/mlxrunner/model/config_quant_test.go
+++ b/x/mlxrunner/model/config_quant_test.go
@@ -1,0 +1,212 @@
+package model
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ollama/ollama/x/imagegen/manifest"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+)
+
+// fakeManifestWithConfig returns a ModelManifest whose config.json layer
+// points at a real blob file in t.TempDir. Pass nil for configData to get
+// a manifest without a config.json layer.
+func fakeManifestWithConfig(t *testing.T, configData []byte) *manifest.ModelManifest {
+	t.Helper()
+	blobDir := filepath.Join(t.TempDir(), "blobs")
+	if err := os.MkdirAll(blobDir, 0o755); err != nil {
+		t.Fatalf("mkdir blobs: %v", err)
+	}
+
+	m := &manifest.Manifest{SchemaVersion: 2}
+	if configData != nil {
+		sum := sha256.Sum256(configData)
+		hexSum := hex.EncodeToString(sum[:])
+		blobPath := filepath.Join(blobDir, "sha256-"+hexSum)
+		if err := os.WriteFile(blobPath, configData, 0o644); err != nil {
+			t.Fatalf("write blob: %v", err)
+		}
+		m.Layers = []manifest.ManifestLayer{{
+			MediaType: "application/vnd.ollama.image.json",
+			Digest:    "sha256:" + hexSum,
+			Size:      int64(len(configData)),
+			Name:      "config.json",
+		}}
+	}
+	return &manifest.ModelManifest{Manifest: m, BlobDir: blobDir}
+}
+
+func TestReadConfigQuantOverrides_NoConfig(t *testing.T) {
+	m := fakeManifestWithConfig(t, nil)
+	defaults, overrides, err := readConfigQuantOverrides(m)
+	if err != nil || defaults.QuantType != "" || overrides != nil {
+		t.Fatalf("got (%+v, %v, %v), want zero values", defaults, overrides, err)
+	}
+}
+
+func TestReadConfigQuantOverrides_NoQuantizationBlock(t *testing.T) {
+	m := fakeManifestWithConfig(t, []byte(`{"hidden_size":2048}`))
+	defaults, overrides, err := readConfigQuantOverrides(m)
+	if err != nil || defaults.QuantType != "" || overrides != nil {
+		t.Fatalf("got (%+v, %v, %v), want zero values", defaults, overrides, err)
+	}
+}
+
+func TestReadConfigQuantOverrides_FlatQuantization(t *testing.T) {
+	m := fakeManifestWithConfig(t, []byte(`{"quantization":{"group_size":16,"bits":4,"mode":"nvfp4"}}`))
+	defaults, overrides, err := readConfigQuantOverrides(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if defaults.QuantType != "NVFP4" || defaults.GroupSize != 16 || defaults.Bits != 4 || defaults.Mode != "nvfp4" {
+		t.Errorf("defaults = %+v", defaults)
+	}
+	if overrides != nil {
+		t.Errorf("overrides = %v, want nil", overrides)
+	}
+}
+
+func TestReadConfigQuantOverrides_PerPathOverrideWithExplicitMode(t *testing.T) {
+	m := fakeManifestWithConfig(t, []byte(`{"quantization":{
+		"group_size":16,"bits":4,"mode":"nvfp4",
+		"foo.mlp.gate":{"group_size":64,"bits":8,"mode":"affine"}
+	}}`))
+	_, overrides, err := readConfigQuantOverrides(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info := overrides["foo.mlp.gate.weight"]
+	if info == nil {
+		t.Fatal("override for foo.mlp.gate.weight missing")
+	}
+	if info.QuantType != "AFFINE" || info.GroupSize != 64 || info.Bits != 8 || info.Mode != "affine" {
+		t.Errorf("override = %+v", info)
+	}
+}
+
+func TestReadConfigQuantOverrides_PerPathOverrideOmittedModeIsAffine(t *testing.T) {
+	m := fakeManifestWithConfig(t, []byte(`{"quantization":{
+		"group_size":16,"bits":4,"mode":"nvfp4",
+		"foo.mlp.gate":{"group_size":64,"bits":8}
+	}}`))
+	_, overrides, err := readConfigQuantOverrides(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info := overrides["foo.mlp.gate.weight"]
+	if info == nil || info.Mode != "affine" || info.QuantType != "AFFINE" || info.GroupSize != 64 || info.Bits != 8 {
+		t.Errorf("override = %+v, want {AFFINE,64,8,affine}", info)
+	}
+}
+
+func TestReadConfigQuantOverrides_QuantizationConfigAliasAccepted(t *testing.T) {
+	m := fakeManifestWithConfig(t, []byte(`{"quantization_config":{"group_size":32,"bits":4,"mode":"mxfp4"}}`))
+	defaults, _, err := readConfigQuantOverrides(m)
+	if err != nil || defaults.Mode != "mxfp4" || defaults.GroupSize != 32 || defaults.Bits != 4 {
+		t.Errorf("got %+v, err=%v", defaults, err)
+	}
+}
+
+func TestReadConfigQuantOverrides_MultipleOverrides(t *testing.T) {
+	m := fakeManifestWithConfig(t, []byte(`{"quantization":{
+		"group_size":16,"bits":4,"mode":"nvfp4",
+		"layers.0.gate":{"group_size":64,"bits":8},
+		"layers.1.gate":{"group_size":64,"bits":8}
+	}}`))
+	_, overrides, err := readConfigQuantOverrides(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{"layers.0.gate.weight", "layers.1.gate.weight"} {
+		if overrides[path] == nil {
+			t.Errorf("override for %q missing", path)
+		}
+	}
+}
+
+func TestReadConfigQuantOverrides_MalformedJSON(t *testing.T) {
+	m := fakeManifestWithConfig(t, []byte(`{this is not valid json!`))
+	defaults, overrides, err := readConfigQuantOverrides(m)
+	if err != nil || defaults.QuantType != "" || overrides != nil {
+		t.Fatalf("want silent fallback, got (%+v, %v, %v)", defaults, overrides, err)
+	}
+}
+
+// TestRoot_OpenPopulatesFromConfigAndBlobs is the regression guard for the
+// metadata/override path that caused the Qwen3.6 NVFP4 panic.
+func TestRoot_OpenPopulatesFromConfigAndBlobs(t *testing.T) {
+	m := fakeManifestWithConfig(t, []byte(`{"quantization":{
+		"group_size":16,"bits":4,"mode":"nvfp4",
+		"language_model.model.layers.0.mlp.gate":{"group_size":64,"bits":8}
+	}}`))
+
+	root, err := openFromManifest(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if root.QuantType() != "NVFP4" || root.GroupSize() != 16 {
+		t.Errorf("globals = (%q, %d), want (NVFP4, 16)", root.QuantType(), root.GroupSize())
+	}
+	info := root.TensorQuant("language_model.model.layers.0.mlp.gate.weight")
+	if info == nil {
+		t.Fatal("override not applied")
+	}
+	if info.Mode != "affine" || info.GroupSize != 64 || info.Bits != 8 {
+		t.Errorf("gate override = %+v, want {affine,64,8}", info)
+	}
+}
+
+func TestTensorQuantParams_ExplicitBitsMode(t *testing.T) {
+	cases := []struct {
+		name     string
+		tq       *TensorQuantInfo
+		wantGS   int
+		wantBits int
+		wantMode string
+	}{
+		{"mode_override_nvfp4", &TensorQuantInfo{QuantType: "INT4", GroupSize: 16, Bits: 4, Mode: "nvfp4"}, 16, 4, "nvfp4"},
+		{"empty_quant_type_bits_mode_explicit", &TensorQuantInfo{GroupSize: 16, Bits: 4, Mode: "nvfp4"}, 16, 4, "nvfp4"},
+		{"zero_fields_fallback_to_quant_type", &TensorQuantInfo{QuantType: "INT4"}, 64, 4, "affine"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gs, bits, mode, fromTensor := TensorQuantParams(0, 0, "", map[string]*TensorQuantInfo{"foo.weight": tc.tq}, "foo.weight")
+			if gs != tc.wantGS || bits != tc.wantBits || mode != tc.wantMode || !fromTensor {
+				t.Errorf("got (%d, %d, %q, %v), want (%d, %d, %q, true)", gs, bits, mode, fromTensor, tc.wantGS, tc.wantBits, tc.wantMode)
+			}
+		})
+	}
+}
+
+func TestResolveLinearQuantParams_PerTensorOverridesGlobalViaBitsMode(t *testing.T) {
+	skipIfNoMLX(t)
+	w := mlx.FromValues(make([]uint32, 4*8), 4, 8)
+	scales := mlx.FromValues(make([]uint8, 4*2), 4, 2)
+	mlx.Eval(w, scales)
+
+	tq := map[string]*TensorQuantInfo{"foo.weight": {GroupSize: 64, Bits: 8, Mode: "affine"}}
+	gs, bits, mode := ResolveLinearQuantParams(16, 4, "nvfp4", tq, "foo.weight", w, scales)
+	if gs != 64 || bits != 8 || mode != "affine" {
+		t.Errorf("got (%d, %d, %q), want (64, 8, affine)", gs, bits, mode)
+	}
+}
+
+// TestResolveLinearQuantParams_InferenceSkippedWhenAffineFromTensorWithValidParams
+// guards against shape inference accidentally overwriting a valid per-tensor
+// entry when mode="affine".
+func TestResolveLinearQuantParams_InferenceSkippedWhenAffineFromTensorWithValidParams(t *testing.T) {
+	skipIfNoMLX(t)
+	// Shapes that would infer (32, 4) if inference ran.
+	w := mlx.FromValues(make([]uint32, 4*8), 4, 8)
+	scales := mlx.FromValues(make([]uint8, 4*2), 4, 2)
+	mlx.Eval(w, scales)
+
+	tq := map[string]*TensorQuantInfo{"foo.weight": {QuantType: "INT4", GroupSize: 64}}
+	gs, bits, mode := ResolveLinearQuantParams(0, 0, "", tq, "foo.weight", w, scales)
+	if gs != 64 || bits != 4 || mode != "affine" {
+		t.Errorf("got (%d, %d, %q), want (64, 4, affine)", gs, bits, mode)
+	}
+}

--- a/x/mlxrunner/model/embedding.go
+++ b/x/mlxrunner/model/embedding.go
@@ -7,9 +7,14 @@ import (
 
 // MakeEmbeddingLayer constructs an embedding layer from a tensor map.
 //
-// For quantized tensors (path.weight + path.weight_scale), it returns a
-// QuantizedEmbedding using the same quant metadata path that linear layers use.
-// For non-quantized tensors, it returns a standard dense embedding.
+// For quantized tensors it returns a QuantizedEmbedding using the same quant
+// metadata path that linear layers use. For non-quantized tensors it returns
+// a standard dense embedding.
+//
+// Two scale/qbias naming conventions are recognised — see MakeLinearLayer for
+// the rationale:
+//   - Ollama-native dot-child singular: "<path>.weight_scale" / "<path>.weight_qbias"
+//   - mlx-lm sibling plural: "<path>.scales" / "<path>.biases"
 func MakeEmbeddingLayer(
 	tensors map[string]*mlx.Array,
 	path string,
@@ -23,8 +28,14 @@ func MakeEmbeddingLayer(
 	}
 
 	scales := tensors[path+".weight_scale"]
+	if scales == nil {
+		scales = tensors[path+".scales"]
+	}
 	if scales != nil {
 		qbiases := tensors[path+".weight_qbias"]
+		if qbiases == nil {
+			qbiases = tensors[path+".biases"]
+		}
 		groupSize, bits, mode := ResolveLinearQuantParams(
 			defaultGroupSize,
 			defaultBits,

--- a/x/mlxrunner/model/embedding_test.go
+++ b/x/mlxrunner/model/embedding_test.go
@@ -76,3 +76,35 @@ func TestMakeEmbeddingLayerQuantized(t *testing.T) {
 		t.Fatalf("AsLinear type = %T, want *nn.QuantizedLinear", emb.AsLinear())
 	}
 }
+
+// TestMakeEmbeddingLayerQuantizedMLXLMSibling confirms that MakeEmbeddingLayer
+// accepts mlx-lm sibling-plural aux naming ("<path>.scales" / "<path>.biases")
+// as an alternative to Ollama-native "<path>.weight_scale" / "<path>.weight_qbias".
+func TestMakeEmbeddingLayerQuantizedMLXLMSibling(t *testing.T) {
+	skipIfNoMLX(t)
+
+	denseWeight := mlx.FromValues(func() []float32 {
+		out := make([]float32, 2*64)
+		for i := range out {
+			out[i] = float32(i%17) / 8
+		}
+		return out
+	}(), 2, 64).AsType(mlx.DTypeBFloat16)
+
+	qw, scales, qbiases := mlx.Quantize(denseWeight, 64, 4, "affine")
+	mlx.Eval(qw, scales, qbiases)
+
+	emb := MakeEmbeddingLayer(map[string]*mlx.Array{
+		"model.embed_tokens.weight": qw,
+		"model.embed_tokens.scales": scales,
+		"model.embed_tokens.biases": qbiases,
+	}, "model.embed_tokens", 64, 4, "affine", nil)
+
+	qemb, ok := emb.(*nn.QuantizedEmbedding)
+	if !ok {
+		t.Fatalf("embedding type = %T, want *nn.QuantizedEmbedding", emb)
+	}
+	if qemb.GroupSize != 64 || qemb.Bits != 4 || qemb.Mode != "affine" {
+		t.Fatalf("quant params = (%d, %d, %q), want (64, 4, %q)", qemb.GroupSize, qemb.Bits, qemb.Mode, "affine")
+	}
+}

--- a/x/mlxrunner/model/linear.go
+++ b/x/mlxrunner/model/linear.go
@@ -44,9 +44,18 @@ func (f LinearFactory) Make(path string) nn.LinearLayer {
 
 // MakeLinearLayer constructs a linear layer from a tensor map.
 //
-// For quantized tensors (path.weight + path.weight_scale), it resolves per-tensor
-// quant params via TensorQuant metadata (with shape-based affine fallback).
-// For non-quantized tensors, it returns a standard nn.Linear.
+// For quantized tensors it resolves per-tensor quant params via TensorQuant
+// metadata (with shape-based affine fallback). For non-quantized tensors it
+// returns a standard nn.Linear.
+//
+// Two scale/qbias naming conventions are recognised:
+//   - Ollama-native dot-child singular: "<path>.weight_scale" / "<path>.weight_qbias"
+//   - mlx-lm sibling plural: "<path>.scales" / "<path>.biases"
+//
+// The plural form is what tools using mx.nn.quantize (mlx-lm, LM Studio)
+// emit natively. Recognising both lets community MLX safetensors imported
+// via "ollama create --experimental" load correctly regardless of which
+// convention the source blob used.
 func MakeLinearLayer(
 	tensors map[string]*mlx.Array,
 	path string,
@@ -60,8 +69,14 @@ func MakeLinearLayer(
 	}
 
 	scales := tensors[path+".weight_scale"]
+	if scales == nil {
+		scales = tensors[path+".scales"]
+	}
 	if scales != nil {
 		qbiases := tensors[path+".weight_qbias"]
+		if qbiases == nil {
+			qbiases = tensors[path+".biases"]
+		}
 		bias := tensors[path+".bias"]
 
 		groupSize, bits, mode := ResolveLinearQuantParams(

--- a/x/mlxrunner/model/linear_test.go
+++ b/x/mlxrunner/model/linear_test.go
@@ -1,0 +1,44 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/models/nn"
+)
+
+// TestMakeLinearLayer_MLXLMSiblingQuantized confirms that MakeLinearLayer
+// accepts the mlx-lm sibling-plural aux naming ("<path>.scales" /
+// "<path>.biases") and builds a QuantizedLinear with those tensors wired in.
+//
+// Without the plural fallback, the layer would silently fall through to a
+// dense *nn.Linear and load the U32-packed weight as raw float data.
+func TestMakeLinearLayer_MLXLMSiblingQuantized(t *testing.T) {
+	skipIfNoMLX(t)
+
+	w := mlx.FromValues(make([]uint32, 4*8), 4, 8)
+	scales := mlx.FromValues(make([]uint8, 4*2), 4, 2)
+	biases := mlx.FromValues(make([]uint8, 4*2), 4, 2)
+	mlx.Eval(w, scales, biases)
+
+	tensors := map[string]*mlx.Array{
+		"foo.weight": w,
+		"foo.scales": scales,
+		"foo.biases": biases,
+	}
+
+	got := MakeLinearLayer(tensors, "foo", 16, 4, "nvfp4", nil)
+	ql, ok := got.(*nn.QuantizedLinear)
+	if !ok {
+		t.Fatalf("layer type = %T, want *nn.QuantizedLinear", got)
+	}
+	if ql.Weight != w {
+		t.Error("Weight tensor not wired from tensor map")
+	}
+	if ql.Scales != scales {
+		t.Error("Scales tensor not sourced from sibling-plural key")
+	}
+	if ql.QBiases != biases {
+		t.Error("QBiases tensor not sourced from sibling-plural key")
+	}
+}

--- a/x/mlxrunner/model/quant.go
+++ b/x/mlxrunner/model/quant.go
@@ -40,6 +40,12 @@ func TensorQuantParams(
 			if tq.GroupSize > 0 {
 				groupSize = tq.GroupSize
 			}
+			if tq.Bits != 0 {
+				bits = tq.Bits
+			}
+			if tq.Mode != "" {
+				mode = tq.Mode
+			}
 			return groupSize, bits, mode, true
 		}
 	}

--- a/x/mlxrunner/model/root.go
+++ b/x/mlxrunner/model/root.go
@@ -200,7 +200,12 @@ func parseGlobalQuantMetadata(header map[string]json.RawMessage) (quantType stri
 func mainTensorNames(header map[string]json.RawMessage) []string {
 	names := make([]string, 0, len(header))
 	for name := range header {
-		if name == "__metadata__" || strings.HasSuffix(name, ".scale") || strings.HasSuffix(name, ".bias") {
+		// Skip metadata + both aux-naming conventions:
+		//   Ollama-native dot-child singular: ".scale" / ".bias"
+		//   mlx-lm sibling plural: ".scales" / ".biases"
+		if name == "__metadata__" ||
+			strings.HasSuffix(name, ".scale") || strings.HasSuffix(name, ".bias") ||
+			strings.HasSuffix(name, ".scales") || strings.HasSuffix(name, ".biases") {
 			continue
 		}
 		names = append(names, name)

--- a/x/mlxrunner/model/root.go
+++ b/x/mlxrunner/model/root.go
@@ -14,9 +14,12 @@ import (
 )
 
 // TensorQuantInfo describes per-tensor quantization metadata.
+// Bits and Mode default to the QuantType lookup when zero.
 type TensorQuantInfo struct {
 	QuantType string
 	GroupSize int
+	Bits      int
+	Mode      string
 }
 
 // Root wraps a ModelManifest with pre-scanned quantization metadata.
@@ -38,10 +41,24 @@ func Open(modelName string) (*Root, error) {
 	if err != nil {
 		return nil, err
 	}
+	return openFromManifest(m)
+}
 
+// openFromManifest builds a Root from an already-loaded manifest. Split from
+// Open so tests can inject a fake manifest.
+func openFromManifest(m *manifest.ModelManifest) (*Root, error) {
 	root := &Root{
 		Manifest:    m,
 		tensorQuant: make(map[string]*TensorQuantInfo),
+	}
+
+	configDefaults, configOverrides, _ := readConfigQuantOverrides(m)
+	if configDefaults.QuantType != "" {
+		root.quantType = configDefaults.QuantType
+		root.groupSize = configDefaults.GroupSize
+		if root.groupSize == 0 {
+			root.groupSize = defaultGroupSize(root.quantType)
+		}
 	}
 
 	for _, layer := range m.GetTensorLayers("") {
@@ -63,6 +80,13 @@ func Open(modelName string) (*Root, error) {
 				root.groupSize = defaultGroupSize(root.quantType)
 			}
 		}
+	}
+
+	// config.json overrides are authoritative for paths they specify: ollama
+	// create fills each blob's __metadata__ from the config.json *globals*,
+	// so blob entries for override paths are definitionally wrong.
+	for name, info := range configOverrides {
+		root.tensorQuant[name] = info
 	}
 
 	return root, nil

--- a/x/mlxrunner/runner.go
+++ b/x/mlxrunner/runner.go
@@ -87,10 +87,22 @@ func (r *Runner) Load(modelName string) error {
 // loadTensorsFromManifest loads all tensor blobs from the manifest into a
 // flat map, deduplicating by digest and remapping safetensors key suffixes.
 //
-// Uses a two-phase approach: first loads all raw tensors, then remaps
-// .bias → _qbias with complete knowledge of which base names have .scale
-// entries. This avoids a race condition where Go map iteration order could
-// cause .bias to be processed before .scale within the same blob.
+// Two aux-naming conventions may appear in the source blobs (either because
+// of how Ollama packages tensors on import, or because "ollama create
+// --experimental" occasionally emits an orphan blob that retains the
+// original mlx-lm naming):
+//
+//   - Dot-child singular: "<foo>.weight.scale" / "<foo>.weight.bias".
+//     Ollama-native form.
+//   - Sibling plural: "<foo>.scales" / "<foo>.biases".
+//     mlx-lm / mx.nn.quantize-native form.
+//
+// Both are normalised to the canonical "<foo>.weight_scale" / "<foo>.weight_qbias"
+// form so downstream consumers (MakeLinearLayer, loadStackedProjection, etc.)
+// can use a single lookup key without caring which convention was in the blob.
+//
+// Uses a three-phase approach so that .bias / .biases → _qbias remapping can
+// consult complete scale knowledge regardless of Go map iteration order.
 func loadTensorsFromManifest(root *model.Root) (map[string]*mlx.Array, error) {
 	// Phase 1: Load all tensors raw from all blobs
 	rawTensors := make(map[string]*mlx.Array)
@@ -106,36 +118,71 @@ func loadTensorsFromManifest(root *model.Root) (map[string]*mlx.Array, error) {
 		}
 	}
 
-	// Phase 2: Identify all base names that have .scale tensors and remap them
-	scaleBaseNames := make(map[string]bool)
-	allTensors := make(map[string]*mlx.Array, len(rawTensors))
-	for name, arr := range rawTensors {
-		if strings.HasSuffix(name, ".scale") {
-			baseName := strings.TrimSuffix(name, ".scale")
-			allTensors[baseName+"_scale"] = arr
-			scaleBaseNames[baseName] = true
-		}
-	}
-
-	// Phase 3: Process remaining tensors with complete scale knowledge
-	for name, arr := range rawTensors {
-		if strings.HasSuffix(name, ".scale") {
-			continue // already handled
-		}
-		if strings.HasSuffix(name, ".bias") && !strings.HasSuffix(name, ".weight_qbias") {
-			baseName := strings.TrimSuffix(name, ".bias")
-			if scaleBaseNames[baseName] {
-				allTensors[baseName+"_qbias"] = arr
-			} else {
-				allTensors[name] = arr
-			}
-		} else {
-			allTensors[name] = arr
-		}
-	}
-
+	allTensors := normaliseAuxNames(rawTensors)
 	slog.Info("Loaded tensors from manifest", "count", len(allTensors))
 	return allTensors, nil
+}
+
+// normaliseAuxNames rewrites quantisation aux tensor keys to the canonical
+// "<base>.weight_scale" / "<base>.weight_qbias" form, recognising both the
+// Ollama-native dot-child singular naming (".scale" / ".bias") and the
+// mlx-lm sibling plural naming (".scales" / ".biases").
+//
+// Uses two passes so that .bias / .biases → _qbias remapping has complete
+// scale knowledge regardless of Go map iteration order: Pass 1 handles scale
+// auxiliaries and records every base name that has a matching scale; Pass 2
+// then uses that map to decide whether a bias-like key is a quantisation
+// qbias (→ _qbias) or an ordinary dense bias (keep original).
+func normaliseAuxNames[V any](raw map[string]V) map[string]V {
+	scaleBaseNames := make(map[string]bool)
+	out := make(map[string]V, len(raw))
+
+	// Pass 1: scale auxiliaries
+	for name, arr := range raw {
+		switch {
+		case strings.HasSuffix(name, ".scale"):
+			// Dot-child singular → "<foo>.weight_scale" (when base ends in
+			// .weight) or "<foo>_scale" for non-.weight main tensors.
+			baseName := strings.TrimSuffix(name, ".scale")
+			out[baseName+"_scale"] = arr
+			scaleBaseNames[baseName] = true
+		case strings.HasSuffix(name, ".scales"):
+			// mlx-lm sibling plural → target the associated ".weight" main
+			// tensor: "foo.scales" → "foo.weight_scale".
+			stem := strings.TrimSuffix(name, ".scales")
+			out[stem+".weight_scale"] = arr
+			scaleBaseNames[stem+".weight"] = true
+		}
+	}
+
+	// Pass 2: bias-like auxiliaries and pass-through
+	for name, arr := range raw {
+		if strings.HasSuffix(name, ".scale") || strings.HasSuffix(name, ".scales") {
+			continue // already handled in Pass 1
+		}
+		switch {
+		case strings.HasSuffix(name, ".bias") && !strings.HasSuffix(name, ".weight_qbias"):
+			baseName := strings.TrimSuffix(name, ".bias")
+			if scaleBaseNames[baseName] {
+				out[baseName+"_qbias"] = arr
+			} else {
+				out[name] = arr
+			}
+		case strings.HasSuffix(name, ".biases"):
+			// mlx-lm sibling plural bias → "<foo>.weight_qbias" if a matching
+			// scale was remapped, else keep the original name (some layers
+			// use .biases for dense bias).
+			stem := strings.TrimSuffix(name, ".biases")
+			if scaleBaseNames[stem+".weight"] {
+				out[stem+".weight_qbias"] = arr
+			} else {
+				out[name] = arr
+			}
+		default:
+			out[name] = arr
+		}
+	}
+	return out
 }
 
 func (r *Runner) Run(host, port string, mux http.Handler) error {

--- a/x/mlxrunner/runner_test.go
+++ b/x/mlxrunner/runner_test.go
@@ -1,0 +1,112 @@
+package mlxrunner
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// TestNormaliseAuxNames_PluralAndSingular verifies that normaliseAuxNames
+// targets the canonical "<base>.weight_scale" / "<base>.weight_qbias" form for
+// both the Ollama-native dot-child singular aux naming ("<weight>.scale" /
+// "<weight>.bias") and the mlx-lm sibling-plural naming ("<module>.scales" /
+// "<module>.biases").
+//
+// The helper is generic over the value type so this test can run as pure Go
+// without touching the MLX runtime; each tensor is represented by a unique
+// integer sentinel to confirm the VALUE is preserved through the remap.
+func TestNormaliseAuxNames_PluralAndSingular(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  map[string]int
+		want map[string]int
+	}{
+		{
+			name: "singular dot-child",
+			raw: map[string]int{
+				"layer.weight":       1,
+				"layer.weight.scale": 2,
+				"layer.weight.bias":  3,
+			},
+			want: map[string]int{
+				"layer.weight":       1,
+				"layer.weight_scale": 2,
+				"layer.weight_qbias": 3,
+			},
+		},
+		{
+			name: "mlx-lm sibling plural",
+			raw: map[string]int{
+				"layer.weight": 1,
+				"layer.scales": 2,
+				"layer.biases": 3,
+			},
+			want: map[string]int{
+				"layer.weight":       1,
+				"layer.weight_scale": 2,
+				"layer.weight_qbias": 3,
+			},
+		},
+		{
+			name: "mixed conventions in one blob",
+			raw: map[string]int{
+				"a.weight":       1,
+				"a.weight.scale": 2,
+				"b.weight":       3,
+				"b.scales":       4,
+			},
+			want: map[string]int{
+				"a.weight":       1,
+				"a.weight_scale": 2,
+				"b.weight":       3,
+				"b.weight_scale": 4,
+			},
+		},
+		{
+			name: "dense bias with no matching scale passes through unchanged",
+			raw: map[string]int{
+				"dense.weight": 1,
+				"dense.bias":   2,
+			},
+			want: map[string]int{
+				"dense.weight": 1,
+				"dense.bias":   2,
+			},
+		},
+		{
+			name: "plural bias with no matching scale passes through unchanged",
+			raw: map[string]int{
+				"stats.biases": 5,
+			},
+			want: map[string]int{
+				"stats.biases": 5,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := normaliseAuxNames(tc.raw)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf(
+					"normaliseAuxNames() mismatch\n got keys: %v\nwant keys: %v",
+					sortedKeys(got), sortedKeys(tc.want),
+				)
+				for k, v := range got {
+					if tc.want[k] != v {
+						t.Errorf("  %q: got %d, want %d", k, v, tc.want[k])
+					}
+				}
+			}
+		})
+	}
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}


### PR DESCRIPTION
## Summary

Fixes #15746 — `panic: runtime error: index out of range [0] with length 0` in `SparseMoE.Forward` when running mlx-lm mixed-precision NVFP4 MoE models imported via `ollama create --experimental`. Concretely: Qwen 3.6 35B-A3B NVFP4 crashes on the first token without this change.

Root cause: mlx-lm stores **per-path** quantisation overrides in `config.json`'s `quantization` block, not in the tensor blob `__metadata__`. Ollama's MLX runner only reads blob metadata, which `ollama create` fills from the **global** quant params. The MoE router gate (stored as affine 8-bit, BF16 scales+biases, group_size 64) is therefore fed to the NVFP4 dequant kernel at the global group_size 16, producing a zero-shape output; `Argpartition` on the zero-shape tensor panics.

This PR makes the runner read `config.json`'s quant block, apply per-path overrides to `tensorQuant`, and route each linear/embedding layer through the correct dequant kernel.

## Stacking and prior art

Depends on the naming-recognition PR (load-time plural aux acceptance). Reviewers who want to look at this PR in isolation can use the base branch; the CI run and the regression guard below both require the naming PR's changes to be present first.

Depends on: #15743

Extends #15409 ("mlx: mixed-precision quant and capability detection improvements"). That PR put the per-tensor-quant-metadata machinery in place on the assumption that overrides live in the blob `__metadata__`. For mlx-lm-produced imports, overrides actually live in `config.json`'s `quantization` block and are not round-tripped into blob `__metadata__`, so the override path introduced by #15409 is never populated for those models. This PR plugs `config.json` in as the second source.

This PR does **not** fix #15632 (`qwen3.6:35b-a3b-nvfp4 fails to load: layer 0 missing linear attention projections`) — that failure is on a different code path (attention-tensor loading, before the quant-metadata code runs).

## What changed

### `TensorQuantInfo` carries explicit bits and mode

`x/mlxrunner/model/root.go`

```go
type TensorQuantInfo struct {
    QuantType string
    GroupSize int
    Bits      int    // NEW — 0 = inherit from QuantType lookup
    Mode      string // NEW — "" = inherit from QuantType lookup
}
```

Zero-value of the new fields preserves existing behaviour: callers that set only `QuantType`/`GroupSize` get the same result as before.

### Resolver honours the new fields

`x/mlxrunner/model/quant.go` — three lines added to `TensorQuantParams`. When `tq.Bits != 0`, use it instead of `QuantizationParams(tq.QuantType).bits`. Same for `tq.Mode`.

### New: `config.json` quant override parser

`x/mlxrunner/model/config_quant.go` (new)

```go
func readConfigQuantOverrides(m *manifest.ModelManifest) (
    TensorQuantInfo,             // globals
    map[string]*TensorQuantInfo, // per-path overrides, keyed by <path>.weight
    error,
)
```

- Reads `config.json` via `manifest.ReadConfig`. Returns zero values + `nil` error on missing/malformed config (silent fallback).
- Accepts both `"quantization"` and `"quantization_config"` as the top-level key — mlx-lm writes both, depending on version.
- Scalar children of the block → globals.
- Object children whose keys are dotted module paths → per-path overrides keyed as `<path>.weight`.
- **Mode rule**: if override specifies `mode`, use it; if omitted, use `"affine"`. This matches `mlx.nn.Linear.to_quantized`'s default (verified by reading the MLX source).

### `Root.Open` merges overrides over blob metadata

`x/mlxrunner/model/root.go`

The blob scan populates `tensorQuant` from `__metadata__` as before. Afterwards, `readConfigQuantOverrides` runs and the per-path entries **overwrite** blob entries for the paths config.json specifies.

This direction is deliberate: `ollama create` fills every blob's `__metadata__` from the config.json *globals*, not from per-path overrides. So for any path config.json overrides, the blob metadata entry is definitionally wrong. Paths not overridden by config.json still come from blob metadata (which is correct for those paths). Ollama-registry-published models don't ship a `quantization` block, so the override map is empty for them and their behaviour is untouched.

`Open(modelName)` keeps its existing public signature; internal work moves to `openFromManifest(m)` so tests can inject a fake manifest without touching the filesystem model store.

## A note on model vs architecture names

The repro model is **Qwen 3.6 35B-A3B** (the user-facing release name). Its Python/HF architecture class is still **`Qwen3_5MoeForConditionalGeneration`**, inherited unchanged from Qwen 3.5 — which is why Ollama's source for it sits in `x/models/qwen3_5/`. The crash in `SparseMoE.Forward` at `x/models/qwen3_5/qwen3_5.go:~1320` is the symptom; this PR fixes it upstream in `x/mlxrunner/model` so no `x/models/qwen3_5/` code is touched.

## Tests

All new tests live in `x/mlxrunner/model/`:

**In `config_quant_test.go` (new file):**

- `TestReadConfigQuantOverrides_NoConfig` — manifest without `config.json` → zero values.
- `TestReadConfigQuantOverrides_NoQuantizationBlock` — config.json without quantization block → zero values.
- `TestReadConfigQuantOverrides_FlatQuantization` — globals populated, no per-path.
- `TestReadConfigQuantOverrides_PerPathOverrideWithExplicitMode` — explicit `mode` respected.
- `TestReadConfigQuantOverrides_PerPathOverrideOmittedModeIsAffine` — the Qwen 3.6 path; override without `mode` coerces to `"affine"`.
- `TestReadConfigQuantOverrides_QuantizationConfigAliasAccepted` — both top-level keys recognised.
- `TestReadConfigQuantOverrides_MultipleOverrides` — several paths captured.
- `TestReadConfigQuantOverrides_MalformedJSON` — silent fallback.
- `TestRoot_OpenPopulatesFromConfigAndBlobs` — **regression guard for the metadata/override path that caused the panic**: fake manifest with a global NVFP4 default plus a per-path affine-g64-b8 gate override; `root.TensorQuant("…mlp.gate.weight")` returns the override, not the global. (End-to-end "model runs without panic" verification is the manual step in the test plan.)

**In `quant_test.go`:**

- `TestTensorQuantParams_ExplicitBitsMode` — new fields override `QuantizationParams` lookup.
- `TestResolveLinearQuantParams_PerTensorOverridesGlobalViaBitsMode` — end-to-end resolver with the new fields.
- `TestResolveLinearQuantParams_InferenceSkippedWhenAffineFromTensorWithValidParams` — guards against shape inference overriding a valid per-tensor entry.

## Test plan

- [ ] `go test ./x/mlxrunner/model/...` on macOS arm64 — all green (targeted + regression).
- [ ] `go test ./x/mlxrunner/model/...` on Linux / CI — MLX cases skip, pure-Go cases pass.
- [ ] Manual: `ollama run` on a vanilla Ollama-registry-published NVFP4 model — no regression.
- [ ] Manual: `ollama create --experimental` + `ollama run` on an mlx-lm mixed-precision NVFP4 MoE model (Qwen 3.6 35B-A3B NVFP4 is a straightforward repro) — tokens generated without panic.

## Files touched

```
x/mlxrunner/model/config_quant.go         new
x/mlxrunner/model/config_quant_test.go    new
x/mlxrunner/model/quant.go                +6 lines
x/mlxrunner/model/quant_test.go           +~100 lines (3 new tests)
x/mlxrunner/model/root.go                 +~30 lines (struct fields, Open refactor, merge loop)
```

## Risk

- **Ollama-registry-published models** — `readConfigQuantOverrides` returns empty when `config.json` has no `quantization` block. Their behaviour is unchanged. Covered by `TestReadConfigQuantOverrides_NoQuantizationBlock`.
- **Merge direction** — overrides win for the paths they specify, which is the intended correction. Non-overridden paths still come from blob metadata.
- **MLX kernel support** — `mlx.QuantizedMatmul(mode="affine", gs=64, b=8)` with BF16 scales+biases was verified against the MLX version linked in the build with a fabricated tensor of the exact on-disk shape; no C-side changes needed.

## Known follow-ups

- Vision tower wiring for `Qwen3_5MoeForConditionalGeneration` is still absent in the runner (images go through `mlx-vlm` only). Separate, larger work.
- The override parser currently only supports dotted-path string keys at the top of the quantisation block. Future mlx-lm versions that emit true-nested dict structures would need a parser extension; trivially forward-compatible.
