### PR TITLE
x/mlxrunner/model: add baseline test coverage for quant metadata scanning

### DIFF
--- a/x/mlxrunner/model/embedding.go
+++ b/x/mlxrunner/model/embedding.go
@@ -7,9 +7,14 @@ import (
 
 // MakeEmbeddingLayer constructs an embedding layer from a tensor map.
 //
-// For quantized tensors (path.weight + path.weight_scale), it returns a
-// QuantizedEmbedding using the same quant metadata path that linear layers use.
-// For non-quantized tensors, it returns a standard dense embedding.
+// For quantized tensors it returns a QuantizedEmbedding using the same quant
+// metadata path that linear layers use. For non-quantized tensors it returns
+// a standard dense embedding.
+//
+// Two scale/qbias naming conventions are recognised — see MakeLinearLayer for
+// the rationale:
+//   - Ollama-native dot-child singular: "<path>.weight_scale" / "<path>.weight_qbias"
+//   - mlx-lm sibling plural: "<path>.scales" / "<path>.biases"
 func MakeEmbeddingLayer(
 	tensors map[string]*mlx.Array,
 	path string,
@@ -23,8 +28,14 @@ func MakeEmbeddingLayer(
 	}
 
 	scales := tensors[path+".weight_scale"]
+	if scales == nil {
+		scales = tensors[path+".scales"]
+	}
 	if scales != nil {
 		qbiases := tensors[path+".weight_qbias"]
+		if qbiases == nil {
+			qbiases = tensors[path+".biases"]
+		}
 		groupSize, bits, mode := ResolveLinearQuantParams(
 			defaultGroupSize,
 			defaultBits,

--- a/x/mlxrunner/model/embedding_test.go
+++ b/x/mlxrunner/model/embedding_test.go
@@ -76,3 +76,35 @@ func TestMakeEmbeddingLayerQuantized(t *testing.T) {
 		t.Fatalf("AsLinear type = %T, want *nn.QuantizedLinear", emb.AsLinear())
 	}
 }
+
+// TestMakeEmbeddingLayerQuantizedMLXLMSibling confirms that MakeEmbeddingLayer
+// accepts mlx-lm sibling-plural aux naming ("<path>.scales" / "<path>.biases")
+// as an alternative to Ollama-native "<path>.weight_scale" / "<path>.weight_qbias".
+func TestMakeEmbeddingLayerQuantizedMLXLMSibling(t *testing.T) {
+	skipIfNoMLX(t)
+
+	denseWeight := mlx.FromValues(func() []float32 {
+		out := make([]float32, 2*64)
+		for i := range out {
+			out[i] = float32(i%17) / 8
+		}
+		return out
+	}(), 2, 64).AsType(mlx.DTypeBFloat16)
+
+	qw, scales, qbiases := mlx.Quantize(denseWeight, 64, 4, "affine")
+	mlx.Eval(qw, scales, qbiases)
+
+	emb := MakeEmbeddingLayer(map[string]*mlx.Array{
+		"model.embed_tokens.weight": qw,
+		"model.embed_tokens.scales": scales,
+		"model.embed_tokens.biases": qbiases,
+	}, "model.embed_tokens", 64, 4, "affine", nil)
+
+	qemb, ok := emb.(*nn.QuantizedEmbedding)
+	if !ok {
+		t.Fatalf("embedding type = %T, want *nn.QuantizedEmbedding", emb)
+	}
+	if qemb.GroupSize != 64 || qemb.Bits != 4 || qemb.Mode != "affine" {
+		t.Fatalf("quant params = (%d, %d, %q), want (64, 4, %q)", qemb.GroupSize, qemb.Bits, qemb.Mode, "affine")
+	}
+}

--- a/x/mlxrunner/model/linear.go
+++ b/x/mlxrunner/model/linear.go
@@ -44,9 +44,18 @@ func (f LinearFactory) Make(path string) nn.LinearLayer {
 
 // MakeLinearLayer constructs a linear layer from a tensor map.
 //
-// For quantized tensors (path.weight + path.weight_scale), it resolves per-tensor
-// quant params via TensorQuant metadata (with shape-based affine fallback).
-// For non-quantized tensors, it returns a standard nn.Linear.
+// For quantized tensors it resolves per-tensor quant params via TensorQuant
+// metadata (with shape-based affine fallback). For non-quantized tensors it
+// returns a standard nn.Linear.
+//
+// Two scale/qbias naming conventions are recognised:
+//   - Ollama-native dot-child singular: "<path>.weight_scale" / "<path>.weight_qbias"
+//   - mlx-lm sibling plural: "<path>.scales" / "<path>.biases"
+//
+// The plural form is what tools using mx.nn.quantize (mlx-lm, LM Studio)
+// emit natively. Recognising both lets community MLX safetensors imported
+// via "ollama create --experimental" load correctly regardless of which
+// convention the source blob used.
 func MakeLinearLayer(
 	tensors map[string]*mlx.Array,
 	path string,
@@ -60,8 +69,14 @@ func MakeLinearLayer(
 	}
 
 	scales := tensors[path+".weight_scale"]
+	if scales == nil {
+		scales = tensors[path+".scales"]
+	}
 	if scales != nil {
 		qbiases := tensors[path+".weight_qbias"]
+		if qbiases == nil {
+			qbiases = tensors[path+".biases"]
+		}
 		bias := tensors[path+".bias"]
 
 		groupSize, bits, mode := ResolveLinearQuantParams(

--- a/x/mlxrunner/model/linear_test.go
+++ b/x/mlxrunner/model/linear_test.go
@@ -7,6 +7,83 @@ import (
 	"github.com/ollama/ollama/x/models/nn"
 )
 
+func TestMakeLinearLayer_DenseFallback_NoWeight(t *testing.T) {
+	if MakeLinearLayer(map[string]*mlx.Array{}, "foo", 0, 0, "", nil) != nil {
+		t.Error("empty map should return nil")
+	}
+	if MakeLinearLayer(map[string]*mlx.Array{"foo.bias": {}}, "foo", 0, 0, "", nil) != nil {
+		t.Error("bias-only map should return nil")
+	}
+}
+
+func TestMakeLinearLayer_DenseLinear_NoScales(t *testing.T) {
+	skipIfNoMLX(t)
+	w := mlx.FromValues([]float32{1, 2, 3, 4}, 2, 2)
+	mlx.Eval(w)
+	got := MakeLinearLayer(map[string]*mlx.Array{"foo.weight": w}, "foo", 0, 0, "", nil)
+	if _, ok := got.(*nn.Linear); !ok {
+		t.Errorf("type = %T, want *nn.Linear", got)
+	}
+}
+
+func TestMakeLinearLayer_DenseLinear_WithBias(t *testing.T) {
+	skipIfNoMLX(t)
+	w := mlx.FromValues([]float32{1, 2, 3, 4}, 2, 2)
+	b := mlx.FromValues([]float32{0.5, 0.5}, 2)
+	mlx.Eval(w, b)
+	got := MakeLinearLayer(map[string]*mlx.Array{"foo.weight": w, "foo.bias": b}, "foo", 0, 0, "", nil)
+	lin, ok := got.(*nn.Linear)
+	if !ok {
+		t.Fatalf("type = %T, want *nn.Linear", got)
+	}
+	if lin.Bias == nil {
+		t.Error("Bias not wired")
+	}
+}
+
+func TestMakeLinearLayer_OllamaNativeQuantized(t *testing.T) {
+	skipIfNoMLX(t)
+	w := mlx.FromValues(make([]uint32, 4*8), 4, 8)
+	scales := mlx.FromValues(make([]uint8, 4*2), 4, 2)
+	mlx.Eval(w, scales)
+	got := MakeLinearLayer(map[string]*mlx.Array{
+		"foo.weight":       w,
+		"foo.weight_scale": scales,
+	}, "foo", 32, 8, "affine", nil)
+	ql, ok := got.(*nn.QuantizedLinear)
+	if !ok {
+		t.Fatalf("type = %T, want *nn.QuantizedLinear", got)
+	}
+	if ql.Weight != w || ql.Scales != scales {
+		t.Error("weight/scales not wired")
+	}
+	if ql.GroupSize != 32 || ql.Bits != 8 || ql.Mode != "affine" {
+		t.Errorf("quant params = (%d, %d, %q), want (32, 8, affine)", ql.GroupSize, ql.Bits, ql.Mode)
+	}
+}
+
+func TestMakeLinearLayer_OllamaNativeQuantized_WithQBiasAndBias(t *testing.T) {
+	skipIfNoMLX(t)
+	w := mlx.FromValues(make([]uint32, 4*8), 4, 8)
+	scales := mlx.FromValues(make([]uint8, 4*2), 4, 2)
+	qbias := mlx.FromValues(make([]uint8, 4*2), 4, 2)
+	bias := mlx.FromValues([]float32{0.1, 0.2, 0.3, 0.4}, 4)
+	mlx.Eval(w, scales, qbias, bias)
+	got := MakeLinearLayer(map[string]*mlx.Array{
+		"foo.weight":       w,
+		"foo.weight_scale": scales,
+		"foo.weight_qbias": qbias,
+		"foo.bias":         bias,
+	}, "foo", 32, 8, "affine", nil)
+	ql, ok := got.(*nn.QuantizedLinear)
+	if !ok {
+		t.Fatalf("type = %T, want *nn.QuantizedLinear", got)
+	}
+	if ql.QBiases != qbias || ql.Bias != bias {
+		t.Error("qbias/bias not wired")
+	}
+}
+
 // TestMakeLinearLayer_MLXLMSiblingQuantized confirms that MakeLinearLayer
 // accepts the mlx-lm sibling-plural aux naming ("<path>.scales" /
 // "<path>.biases") and builds a QuantizedLinear with those tensors wired in.
@@ -40,5 +117,56 @@ func TestMakeLinearLayer_MLXLMSiblingQuantized(t *testing.T) {
 	}
 	if ql.QBiases != biases {
 		t.Error("QBiases tensor not sourced from sibling-plural key")
+	}
+}
+
+func TestMakeLinearLayer_PerTensorQuantOverride(t *testing.T) {
+	skipIfNoMLX(t)
+	w := mlx.FromValues(make([]uint32, 4*8), 4, 8)
+	scales := mlx.FromValues(make([]uint8, 4*2), 4, 2)
+	mlx.Eval(w, scales)
+	tq := map[string]*TensorQuantInfo{"foo.weight": {QuantType: "INT4", GroupSize: 32}}
+	got := MakeLinearLayer(map[string]*mlx.Array{
+		"foo.weight":       w,
+		"foo.weight_scale": scales,
+	}, "foo", 16, 4, "nvfp4", tq)
+	ql, ok := got.(*nn.QuantizedLinear)
+	if !ok {
+		t.Fatalf("type = %T, want *nn.QuantizedLinear", got)
+	}
+	if ql.GroupSize != 32 || ql.Bits != 4 || ql.Mode != "affine" {
+		t.Errorf("quant params = (%d, %d, %q), want (32, 4, affine)", ql.GroupSize, ql.Bits, ql.Mode)
+	}
+}
+
+func TestMakeLinearLayer_NilTensorQuant_UsesDefaults(t *testing.T) {
+	skipIfNoMLX(t)
+	w := mlx.FromValues(make([]uint32, 4*8), 4, 8)
+	scales := mlx.FromValues(make([]uint8, 4*2), 4, 2)
+	mlx.Eval(w, scales)
+	got := MakeLinearLayer(map[string]*mlx.Array{
+		"foo.weight":       w,
+		"foo.weight_scale": scales,
+	}, "foo", 16, 4, "nvfp4", nil)
+	ql, ok := got.(*nn.QuantizedLinear)
+	if !ok {
+		t.Fatalf("type = %T, want *nn.QuantizedLinear", got)
+	}
+	if ql.GroupSize != 16 || ql.Bits != 4 || ql.Mode != "nvfp4" {
+		t.Errorf("quant params = (%d, %d, %q), want (16, 4, nvfp4)", ql.GroupSize, ql.Bits, ql.Mode)
+	}
+}
+
+func TestLinearFactory_Make_ProducesLayer(t *testing.T) {
+	skipIfNoMLX(t)
+	w := mlx.FromValues([]float32{1, 2, 3, 4}, 2, 2)
+	mlx.Eval(w)
+	tensors := map[string]*mlx.Array{"bar.weight": w}
+	factory := NewLinearFactory(tensors, 0, 0, "", nil)
+	if factory.Make("bar") == nil {
+		t.Error("factory.Make returned nil")
+	}
+	if MakeLinearLayer(tensors, "bar", 0, 0, "", nil) == nil {
+		t.Error("direct MakeLinearLayer returned nil")
 	}
 }

--- a/x/mlxrunner/model/linear_test.go
+++ b/x/mlxrunner/model/linear_test.go
@@ -1,0 +1,44 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/models/nn"
+)
+
+// TestMakeLinearLayer_MLXLMSiblingQuantized confirms that MakeLinearLayer
+// accepts the mlx-lm sibling-plural aux naming ("<path>.scales" /
+// "<path>.biases") and builds a QuantizedLinear with those tensors wired in.
+//
+// Without the plural fallback, the layer would silently fall through to a
+// dense *nn.Linear and load the U32-packed weight as raw float data.
+func TestMakeLinearLayer_MLXLMSiblingQuantized(t *testing.T) {
+	skipIfNoMLX(t)
+
+	w := mlx.FromValues(make([]uint32, 4*8), 4, 8)
+	scales := mlx.FromValues(make([]uint8, 4*2), 4, 2)
+	biases := mlx.FromValues(make([]uint8, 4*2), 4, 2)
+	mlx.Eval(w, scales, biases)
+
+	tensors := map[string]*mlx.Array{
+		"foo.weight": w,
+		"foo.scales": scales,
+		"foo.biases": biases,
+	}
+
+	got := MakeLinearLayer(tensors, "foo", 16, 4, "nvfp4", nil)
+	ql, ok := got.(*nn.QuantizedLinear)
+	if !ok {
+		t.Fatalf("layer type = %T, want *nn.QuantizedLinear", got)
+	}
+	if ql.Weight != w {
+		t.Error("Weight tensor not wired from tensor map")
+	}
+	if ql.Scales != scales {
+		t.Error("Scales tensor not sourced from sibling-plural key")
+	}
+	if ql.QBiases != biases {
+		t.Error("QBiases tensor not sourced from sibling-plural key")
+	}
+}

--- a/x/mlxrunner/model/quant_test.go
+++ b/x/mlxrunner/model/quant_test.go
@@ -1,0 +1,154 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+)
+
+func TestQuantizationParams_Types(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		wantGS   int
+		wantBits int
+		wantMode string
+	}{
+		{"nvfp4", "NVFP4", 16, 4, "nvfp4"},
+		{"mxfp4", "MXFP4", 32, 4, "mxfp4"},
+		{"fp4", "FP4", 64, 4, "affine"},
+		{"q4", "Q4", 64, 4, "affine"},
+		{"int4", "INT4", 64, 4, "affine"},
+		{"mxfp8", "MXFP8", 32, 8, "mxfp8"},
+		{"fp8", "FP8", 64, 8, "affine"},
+		{"q8", "Q8", 64, 8, "affine"},
+		{"int8", "INT8", 64, 8, "affine"},
+		{"empty", "", 0, 0, ""},
+		{"unknown", "something_unknown", 32, 8, "affine"},
+		{"lowercase_nvfp4", "nvfp4", 16, 4, "nvfp4"},
+		{"lowercase_int4", "int4", 64, 4, "affine"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gs, bits, mode := QuantizationParams(tc.input)
+			if gs != tc.wantGS || bits != tc.wantBits || mode != tc.wantMode {
+				t.Errorf("got (%d, %d, %q), want (%d, %d, %q)", gs, bits, mode, tc.wantGS, tc.wantBits, tc.wantMode)
+			}
+		})
+	}
+}
+
+func TestTensorQuantParams_Fallback(t *testing.T) {
+	t.Run("nil_map", func(t *testing.T) {
+		gs, bits, mode, fromTensor := TensorQuantParams(32, 4, "nvfp4", nil, "foo.weight")
+		if gs != 32 || bits != 4 || mode != "nvfp4" || fromTensor {
+			t.Errorf("got (%d, %d, %q, %v), want (32, 4, nvfp4, false)", gs, bits, mode, fromTensor)
+		}
+	})
+	t.Run("absent_key", func(t *testing.T) {
+		gs, bits, mode, fromTensor := TensorQuantParams(32, 4, "nvfp4", map[string]*TensorQuantInfo{"bar.weight": {QuantType: "INT4"}}, "foo.weight")
+		if gs != 32 || bits != 4 || mode != "nvfp4" || fromTensor {
+			t.Errorf("got (%d, %d, %q, %v), want (32, 4, nvfp4, false)", gs, bits, mode, fromTensor)
+		}
+	})
+	t.Run("empty_quant_type", func(t *testing.T) {
+		gs, bits, mode, fromTensor := TensorQuantParams(32, 4, "nvfp4", map[string]*TensorQuantInfo{"foo.weight": {}}, "foo.weight")
+		if gs != 0 || bits != 0 || mode != "" || !fromTensor {
+			t.Errorf("got (%d, %d, %q, %v), want (0, 0, \"\", true)", gs, bits, mode, fromTensor)
+		}
+	})
+}
+
+func TestTensorQuantParams_UsesQuantTypeWhenPresent(t *testing.T) {
+	t.Run("int4_with_group_size_override", func(t *testing.T) {
+		gs, bits, mode, fromTensor := TensorQuantParams(0, 0, "", map[string]*TensorQuantInfo{"foo.weight": {QuantType: "INT4", GroupSize: 32}}, "foo.weight")
+		if gs != 32 || bits != 4 || mode != "affine" || !fromTensor {
+			t.Errorf("got (%d, %d, %q, %v), want (32, 4, affine, true)", gs, bits, mode, fromTensor)
+		}
+	})
+	t.Run("nvfp4_no_group_size_override", func(t *testing.T) {
+		gs, bits, mode, fromTensor := TensorQuantParams(0, 0, "", map[string]*TensorQuantInfo{"foo.weight": {QuantType: "NVFP4"}}, "foo.weight")
+		if gs != 16 || bits != 4 || mode != "nvfp4" || !fromTensor {
+			t.Errorf("got (%d, %d, %q, %v), want (16, 4, nvfp4, true)", gs, bits, mode, fromTensor)
+		}
+	})
+}
+
+// TestResolveLinearQuantParams_PerTensorHit confirms non-affine mode skips
+// shape inference entirely.
+func TestResolveLinearQuantParams_PerTensorHit(t *testing.T) {
+	tq := map[string]*TensorQuantInfo{"foo.weight": {QuantType: "NVFP4"}}
+	gs, bits, mode := ResolveLinearQuantParams(0, 0, "", tq, "foo.weight", nil, nil)
+	if gs != 16 || bits != 4 || mode != "nvfp4" {
+		t.Errorf("got (%d, %d, %q), want (16, 4, nvfp4)", gs, bits, mode)
+	}
+}
+
+// TestResolveLinearQuantParams_AffineShapeInference exercises the shape-based
+// fallback for affine mode: weight [4, 8] + scales [4, 2] with hintBits=4
+// hits the ambiguous 64/32 case and resolves to (64, 4, "affine").
+func TestResolveLinearQuantParams_AffineShapeInference(t *testing.T) {
+	skipIfNoMLX(t)
+	w := mlx.FromValues(make([]uint32, 4*8), 4, 8)
+	scales := mlx.FromValues(make([]uint8, 4*2), 4, 2)
+	mlx.Eval(w, scales)
+
+	gs, bits, mode := ResolveLinearQuantParams(0, 4, "affine", nil, "foo.weight", w, scales)
+	if gs != 64 || bits != 4 || mode != "affine" {
+		t.Errorf("got (%d, %d, %q), want (64, 4, affine)", gs, bits, mode)
+	}
+}
+
+func TestInferAffineQuantParamsFromShapes(t *testing.T) {
+	skipIfNoMLX(t)
+	makeArray := func(shape ...int) *mlx.Array {
+		n := 1
+		for _, d := range shape {
+			n *= d
+		}
+		a := mlx.FromValues(make([]uint32, n), shape...)
+		mlx.Eval(a)
+		return a
+	}
+
+	cases := []struct {
+		name        string
+		weightShape []int
+		scaleShape  []int
+		hintBits    int
+		wantGS      int
+		wantBits    int
+		wantOK      bool
+	}{
+		{"int4_groupSize32", []int{4, 8}, []int{4, 2}, 0, 32, 4, true},
+		{"int8_groupSize64", []int{4, 4}, []int{4, 1}, 0, 16, 4, true},
+		{"int4_groupSize16_via_isCommon", []int{4, 4}, []int{4, 2}, 0, 16, 4, true},
+		{"int8_groupSize128_via_isCommon", []int{4, 32}, []int{4, 1}, 0, 128, 8, true},
+		{"ambiguous_hint_4", []int{4, 16}, []int{4, 2}, 4, 64, 4, true},
+		{"ambiguous_hint_8", []int{4, 16}, []int{4, 2}, 8, 32, 8, true},
+		{"ambiguous_hint_0", []int{4, 16}, []int{4, 2}, 0, 0, 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := makeArray(tc.weightShape...)
+			scales := makeArray(tc.scaleShape...)
+			gs, bits, ok := InferAffineQuantParamsFromShapes(w, scales, tc.hintBits)
+			if gs != tc.wantGS || bits != tc.wantBits || ok != tc.wantOK {
+				t.Errorf("got (%d, %d, %v), want (%d, %d, %v)", gs, bits, ok, tc.wantGS, tc.wantBits, tc.wantOK)
+			}
+		})
+	}
+
+	t.Run("nil_weight", func(t *testing.T) {
+		scales := makeArray(4, 2)
+		if gs, bits, ok := InferAffineQuantParamsFromShapes(nil, scales, 0); gs != 0 || bits != 0 || ok {
+			t.Errorf("nil weight should return zero")
+		}
+	})
+	t.Run("nil_scales", func(t *testing.T) {
+		w := makeArray(4, 8)
+		if gs, bits, ok := InferAffineQuantParamsFromShapes(w, nil, 0); gs != 0 || bits != 0 || ok {
+			t.Errorf("nil scales should return zero")
+		}
+	})
+}

--- a/x/mlxrunner/model/root.go
+++ b/x/mlxrunner/model/root.go
@@ -200,7 +200,12 @@ func parseGlobalQuantMetadata(header map[string]json.RawMessage) (quantType stri
 func mainTensorNames(header map[string]json.RawMessage) []string {
 	names := make([]string, 0, len(header))
 	for name := range header {
-		if name == "__metadata__" || strings.HasSuffix(name, ".scale") || strings.HasSuffix(name, ".bias") {
+		// Skip metadata + both aux-naming conventions:
+		//   Ollama-native dot-child singular: ".scale" / ".bias"
+		//   mlx-lm sibling plural: ".scales" / ".biases"
+		if name == "__metadata__" ||
+			strings.HasSuffix(name, ".scale") || strings.HasSuffix(name, ".bias") ||
+			strings.HasSuffix(name, ".scales") || strings.HasSuffix(name, ".biases") {
 			continue
 		}
 		names = append(names, name)

--- a/x/mlxrunner/model/root_test.go
+++ b/x/mlxrunner/model/root_test.go
@@ -1,0 +1,147 @@
+package model
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// fakeSafetensorsBlob writes a header-only safetensors-format blob to t.TempDir
+// (no tensor body needed since the scanners only parse the header).
+func fakeSafetensorsBlob(t *testing.T, header map[string]any) string {
+	t.Helper()
+	hdr, err := json.Marshal(header)
+	if err != nil {
+		t.Fatalf("marshal header: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "blob.safetensors")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if err := binary.Write(f, binary.LittleEndian, uint64(len(hdr))); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write(hdr); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestReadBlobTensorQuantInfo_OllamaNativeSingularNaming(t *testing.T) {
+	hdr := map[string]any{
+		"__metadata__":     map[string]string{"quant_type": "INT4", "group_size": "32"},
+		"foo.weight":       map[string]any{"dtype": "U32", "shape": []int{4, 8}, "data_offsets": []int{0, 0}},
+		"foo.weight.scale": map[string]any{"dtype": "U8", "shape": []int{4, 2}, "data_offsets": []int{0, 0}},
+	}
+	infos, gqt, ggs, err := readBlobTensorQuantInfo(fakeSafetensorsBlob(t, hdr))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gqt != "INT4" || ggs != 32 {
+		t.Errorf("globals = (%q, %d), want (INT4, 32)", gqt, ggs)
+	}
+	info := infos["foo.weight"]
+	if info == nil || info.QuantType != "INT4" || info.GroupSize != 32 {
+		t.Errorf("infos[foo.weight] = %+v, want {INT4, 32}", info)
+	}
+}
+
+func TestReadBlobTensorQuantInfo_ErrorPaths(t *testing.T) {
+	t.Run("missing_file", func(t *testing.T) {
+		if _, _, _, err := readBlobTensorQuantInfo("/nonexistent/path"); err == nil {
+			t.Error("want error")
+		}
+	})
+	t.Run("truncated_header_size", func(t *testing.T) {
+		p := filepath.Join(t.TempDir(), "truncated")
+		if err := os.WriteFile(p, []byte{0x01, 0x02}, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, _, _, err := readBlobTensorQuantInfo(p); err == nil {
+			t.Error("want error")
+		}
+	})
+	t.Run("oversize_header", func(t *testing.T) {
+		p := filepath.Join(t.TempDir(), "oversize")
+		f, _ := os.Create(p)
+		_ = binary.Write(f, binary.LittleEndian, uint64(200*1024*1024))
+		f.Close()
+		if _, _, _, err := readBlobTensorQuantInfo(p); err == nil {
+			t.Error("want error")
+		}
+	})
+	t.Run("malformed_json", func(t *testing.T) {
+		p := filepath.Join(t.TempDir(), "malformed")
+		f, _ := os.Create(p)
+		_ = binary.Write(f, binary.LittleEndian, uint64(10))
+		f.WriteString("not-json!!")
+		f.Close()
+		if _, _, _, err := readBlobTensorQuantInfo(p); err == nil {
+			t.Error("want error")
+		}
+	})
+}
+
+func TestMainTensorNames_SkipsSingularAuxSuffixes(t *testing.T) {
+	hdr := map[string]json.RawMessage{
+		"foo.weight":       json.RawMessage(`{}`),
+		"foo.weight.scale": json.RawMessage(`{}`),
+		"foo.weight.bias":  json.RawMessage(`{}`),
+		"bar.weight":       json.RawMessage(`{}`),
+		"__metadata__":     json.RawMessage(`{}`),
+	}
+	got := mainTensorNames(hdr)
+	want := []string{"bar.weight", "foo.weight"}
+	sort.Strings(got)
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("[%d] got %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestInferQuantTypeFromShapes_SingularAuxName(t *testing.T) {
+	hdr := map[string]json.RawMessage{
+		"foo.weight":       json.RawMessage(`{"dtype":"U32","shape":[4,8]}`),
+		"foo.weight.scale": json.RawMessage(`{"dtype":"U8","shape":[4,2]}`),
+	}
+	qt, gs := inferQuantTypeFromShapes(hdr, "foo.weight", "")
+	if qt != "INT4" || gs != 32 {
+		t.Errorf("got (%q, %d), want (INT4, 32)", qt, gs)
+	}
+}
+
+func TestParseGlobalQuantMetadata(t *testing.T) {
+	t.Run("no_metadata_key", func(t *testing.T) {
+		qt, gs := parseGlobalQuantMetadata(map[string]json.RawMessage{"foo": json.RawMessage(`{}`)})
+		if qt != "" || gs != 0 {
+			t.Errorf("got (%q, %d), want empty", qt, gs)
+		}
+	})
+	t.Run("empty_metadata", func(t *testing.T) {
+		qt, gs := parseGlobalQuantMetadata(map[string]json.RawMessage{"__metadata__": json.RawMessage(`{}`)})
+		if qt != "" || gs != 0 {
+			t.Errorf("got (%q, %d), want empty", qt, gs)
+		}
+	})
+	t.Run("populated", func(t *testing.T) {
+		qt, gs := parseGlobalQuantMetadata(map[string]json.RawMessage{"__metadata__": json.RawMessage(`{"quant_type":"INT8","group_size":"64"}`)})
+		if qt != "INT8" || gs != 64 {
+			t.Errorf("got (%q, %d), want (INT8, 64)", qt, gs)
+		}
+	})
+	t.Run("non_numeric_group_size", func(t *testing.T) {
+		qt, gs := parseGlobalQuantMetadata(map[string]json.RawMessage{"__metadata__": json.RawMessage(`{"quant_type":"INT4","group_size":"bogus"}`)})
+		if qt != "INT4" || gs != 0 {
+			t.Errorf("got (%q, %d), want (INT4, 0)", qt, gs)
+		}
+	})
+}

--- a/x/mlxrunner/runner.go
+++ b/x/mlxrunner/runner.go
@@ -87,10 +87,22 @@ func (r *Runner) Load(modelName string) error {
 // loadTensorsFromManifest loads all tensor blobs from the manifest into a
 // flat map, deduplicating by digest and remapping safetensors key suffixes.
 //
-// Uses a two-phase approach: first loads all raw tensors, then remaps
-// .bias → _qbias with complete knowledge of which base names have .scale
-// entries. This avoids a race condition where Go map iteration order could
-// cause .bias to be processed before .scale within the same blob.
+// Two aux-naming conventions may appear in the source blobs (either because
+// of how Ollama packages tensors on import, or because "ollama create
+// --experimental" occasionally emits an orphan blob that retains the
+// original mlx-lm naming):
+//
+//   - Dot-child singular: "<foo>.weight.scale" / "<foo>.weight.bias".
+//     Ollama-native form.
+//   - Sibling plural: "<foo>.scales" / "<foo>.biases".
+//     mlx-lm / mx.nn.quantize-native form.
+//
+// Both are normalised to the canonical "<foo>.weight_scale" / "<foo>.weight_qbias"
+// form so downstream consumers (MakeLinearLayer, loadStackedProjection, etc.)
+// can use a single lookup key without caring which convention was in the blob.
+//
+// Uses a three-phase approach so that .bias / .biases → _qbias remapping can
+// consult complete scale knowledge regardless of Go map iteration order.
 func loadTensorsFromManifest(root *model.Root) (map[string]*mlx.Array, error) {
 	// Phase 1: Load all tensors raw from all blobs
 	rawTensors := make(map[string]*mlx.Array)
@@ -106,36 +118,71 @@ func loadTensorsFromManifest(root *model.Root) (map[string]*mlx.Array, error) {
 		}
 	}
 
-	// Phase 2: Identify all base names that have .scale tensors and remap them
-	scaleBaseNames := make(map[string]bool)
-	allTensors := make(map[string]*mlx.Array, len(rawTensors))
-	for name, arr := range rawTensors {
-		if strings.HasSuffix(name, ".scale") {
-			baseName := strings.TrimSuffix(name, ".scale")
-			allTensors[baseName+"_scale"] = arr
-			scaleBaseNames[baseName] = true
-		}
-	}
-
-	// Phase 3: Process remaining tensors with complete scale knowledge
-	for name, arr := range rawTensors {
-		if strings.HasSuffix(name, ".scale") {
-			continue // already handled
-		}
-		if strings.HasSuffix(name, ".bias") && !strings.HasSuffix(name, ".weight_qbias") {
-			baseName := strings.TrimSuffix(name, ".bias")
-			if scaleBaseNames[baseName] {
-				allTensors[baseName+"_qbias"] = arr
-			} else {
-				allTensors[name] = arr
-			}
-		} else {
-			allTensors[name] = arr
-		}
-	}
-
+	allTensors := normaliseAuxNames(rawTensors)
 	slog.Info("Loaded tensors from manifest", "count", len(allTensors))
 	return allTensors, nil
+}
+
+// normaliseAuxNames rewrites quantisation aux tensor keys to the canonical
+// "<base>.weight_scale" / "<base>.weight_qbias" form, recognising both the
+// Ollama-native dot-child singular naming (".scale" / ".bias") and the
+// mlx-lm sibling plural naming (".scales" / ".biases").
+//
+// Uses two passes so that .bias / .biases → _qbias remapping has complete
+// scale knowledge regardless of Go map iteration order: Pass 1 handles scale
+// auxiliaries and records every base name that has a matching scale; Pass 2
+// then uses that map to decide whether a bias-like key is a quantisation
+// qbias (→ _qbias) or an ordinary dense bias (keep original).
+func normaliseAuxNames[V any](raw map[string]V) map[string]V {
+	scaleBaseNames := make(map[string]bool)
+	out := make(map[string]V, len(raw))
+
+	// Pass 1: scale auxiliaries
+	for name, arr := range raw {
+		switch {
+		case strings.HasSuffix(name, ".scale"):
+			// Dot-child singular → "<foo>.weight_scale" (when base ends in
+			// .weight) or "<foo>_scale" for non-.weight main tensors.
+			baseName := strings.TrimSuffix(name, ".scale")
+			out[baseName+"_scale"] = arr
+			scaleBaseNames[baseName] = true
+		case strings.HasSuffix(name, ".scales"):
+			// mlx-lm sibling plural → target the associated ".weight" main
+			// tensor: "foo.scales" → "foo.weight_scale".
+			stem := strings.TrimSuffix(name, ".scales")
+			out[stem+".weight_scale"] = arr
+			scaleBaseNames[stem+".weight"] = true
+		}
+	}
+
+	// Pass 2: bias-like auxiliaries and pass-through
+	for name, arr := range raw {
+		if strings.HasSuffix(name, ".scale") || strings.HasSuffix(name, ".scales") {
+			continue // already handled in Pass 1
+		}
+		switch {
+		case strings.HasSuffix(name, ".bias") && !strings.HasSuffix(name, ".weight_qbias"):
+			baseName := strings.TrimSuffix(name, ".bias")
+			if scaleBaseNames[baseName] {
+				out[baseName+"_qbias"] = arr
+			} else {
+				out[name] = arr
+			}
+		case strings.HasSuffix(name, ".biases"):
+			// mlx-lm sibling plural bias → "<foo>.weight_qbias" if a matching
+			// scale was remapped, else keep the original name (some layers
+			// use .biases for dense bias).
+			stem := strings.TrimSuffix(name, ".biases")
+			if scaleBaseNames[stem+".weight"] {
+				out[stem+".weight_qbias"] = arr
+			} else {
+				out[name] = arr
+			}
+		default:
+			out[name] = arr
+		}
+	}
+	return out
 }
 
 func (r *Runner) Run(host, port string, mux http.Handler) error {

--- a/x/mlxrunner/runner_test.go
+++ b/x/mlxrunner/runner_test.go
@@ -1,0 +1,112 @@
+package mlxrunner
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// TestNormaliseAuxNames_PluralAndSingular verifies that normaliseAuxNames
+// targets the canonical "<base>.weight_scale" / "<base>.weight_qbias" form for
+// both the Ollama-native dot-child singular aux naming ("<weight>.scale" /
+// "<weight>.bias") and the mlx-lm sibling-plural naming ("<module>.scales" /
+// "<module>.biases").
+//
+// The helper is generic over the value type so this test can run as pure Go
+// without touching the MLX runtime; each tensor is represented by a unique
+// integer sentinel to confirm the VALUE is preserved through the remap.
+func TestNormaliseAuxNames_PluralAndSingular(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  map[string]int
+		want map[string]int
+	}{
+		{
+			name: "singular dot-child",
+			raw: map[string]int{
+				"layer.weight":       1,
+				"layer.weight.scale": 2,
+				"layer.weight.bias":  3,
+			},
+			want: map[string]int{
+				"layer.weight":       1,
+				"layer.weight_scale": 2,
+				"layer.weight_qbias": 3,
+			},
+		},
+		{
+			name: "mlx-lm sibling plural",
+			raw: map[string]int{
+				"layer.weight": 1,
+				"layer.scales": 2,
+				"layer.biases": 3,
+			},
+			want: map[string]int{
+				"layer.weight":       1,
+				"layer.weight_scale": 2,
+				"layer.weight_qbias": 3,
+			},
+		},
+		{
+			name: "mixed conventions in one blob",
+			raw: map[string]int{
+				"a.weight":       1,
+				"a.weight.scale": 2,
+				"b.weight":       3,
+				"b.scales":       4,
+			},
+			want: map[string]int{
+				"a.weight":       1,
+				"a.weight_scale": 2,
+				"b.weight":       3,
+				"b.weight_scale": 4,
+			},
+		},
+		{
+			name: "dense bias with no matching scale passes through unchanged",
+			raw: map[string]int{
+				"dense.weight": 1,
+				"dense.bias":   2,
+			},
+			want: map[string]int{
+				"dense.weight": 1,
+				"dense.bias":   2,
+			},
+		},
+		{
+			name: "plural bias with no matching scale passes through unchanged",
+			raw: map[string]int{
+				"stats.biases": 5,
+			},
+			want: map[string]int{
+				"stats.biases": 5,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := normaliseAuxNames(tc.raw)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf(
+					"normaliseAuxNames() mismatch\n got keys: %v\nwant keys: %v",
+					sortedKeys(got), sortedKeys(tc.want),
+				)
+				for k, v := range got {
+					if tc.want[k] != v {
+						t.Errorf("  %q: got %d, want %d", k, v, tc.want[k])
+					}
+				}
+			}
+		})
+	}
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}


### PR DESCRIPTION
## Summary

The `x/mlxrunner/model` package ships substantial quant-metadata logic with `embedding_test.go` as the sole test file. This PR adds targeted tests for the remaining exported and package-private functions that exist on main today, filling a coverage gap without changing any production code.

Zero production code is touched. Every test passes against the current `model/` package unmodified. The PR is self-contained and independent of the naming-recognition and config.json-override PRs.

## Scope

This PR covers baseline behaviour in the `model/` package that is common across all three PRs in the series — i.e. behaviour that holds regardless of whether the naming-recognition PR or the config-overrides PR has been merged:

- `QuantizationParams` — the type → `(group_size, bits, mode)` lookup.
- `TensorQuantParams` — the nil-map / missing-key / empty-`QuantType` fallbacks and the `GroupSize` override branch. Does **not** cover the `Bits`/`Mode` field semantics (those are introduced by the config-overrides PR and tested there).
- `ResolveLinearQuantParams` — the non-affine shape-inference skip and the ambiguous 64/32 hint-bits tiebreak. Does **not** cover the new per-tensor-fields branch added by the config-overrides PR.
- `InferAffineQuantParamsFromShapes` — all explicit and fallback branches.
- `parseGlobalQuantMetadata` — present / absent / malformed metadata.
- `mainTensorNames` — the Ollama-native singular-suffix filter. Plural-suffix filter extension is tested in the naming-recognition PR.
- `inferQuantTypeFromShapes` — the `<tensorName>.scale` lookup path (singular).
- `readBlobTensorQuantInfo` — both the Ollama-native happy path and the four error paths.
- `MakeLinearLayer` — dense fallback, Ollama-native quantised, and the existing per-tensor `{QuantType, GroupSize}` override semantics.

Explicitly **not** in scope:

- Plural aux naming (`<module>.scales` / `<module>.biases`) — introduced and tested by the naming-recognition PR.
- `config.json` quant overrides and the new `TensorQuantInfo.Bits`/`.Mode` field semantics — introduced and tested by the config-overrides PR.
- Any behaviour that only becomes true after one of the sibling PRs merges.

Order of merge doesn't matter: the assertions in this PR only describe behaviour that both sibling PRs preserve.

## Why

The package's behaviour is nuanced enough that regression guards are worth having in place before any follow-up touches these functions. In particular:

- Shape-based affine quant inference has several distinct branches (explicit 32/64 match, the 64/32 ambiguous pair resolved by hint bits, and the `isCommonGroupSize` fallback in both directions) — none tested.
- `readBlobTensorQuantInfo` has four error paths (missing file, truncated header, oversize header, malformed JSON) and an Ollama-native happy path — neither tested outside of the indirect coverage via `embedding_test.go`.
- `QuantizationParams`'s internal uppercasing and the exact default-branch behaviour for unknown types are load-bearing for several other call sites and weren't locked in.

Fixing these in isolation also makes future edits in this package safer to review.

## What's covered

### `quant_test.go` (new, ~300 lines)

- `TestQuantizationParams_Types` — table over known quant type strings, plus lowercase coverage confirming internal uppercasing, plus an unknown-type case.
- `TestTensorQuantParams_Fallback` — nil map, missing key, empty `QuantType` entry.
- `TestTensorQuantParams_UsesQuantTypeWhenPresent` — entry with `{QuantType, GroupSize}` resolves to the expected params (the `GroupSize > 0` branch; does not touch the Bits/Mode fields added by the config-overrides PR).
- `TestResolveLinearQuantParams_PerTensorHit` — non-affine mode skips shape inference.
- `TestResolveLinearQuantParams_AffineShapeInference` — affine mode triggers inference for the ambiguous `groupSize4==64 && groupSize8==32` case, resolved via `hintBits`.
- `TestInferAffineQuantParamsFromShapes` — 8 sub-cases covering: explicit `groupSize4==32` branch, explicit `groupSize8==64` branch, both `isCommonGroupSize` directions (16 for bits=4, 128 for bits=8), the ambiguous case with `hintBits` of 0/4/8, both-uncommon rejection, nil weight, nil scales.

### `root_test.go` (new, ~380 lines)

- `TestReadBlobTensorQuantInfo_OllamaNativeSingularNaming` — canonical Ollama dot-child format; asserts `tensorQuant` populated correctly, globals populated.
- `TestMainTensorNames_SkipsSingularAuxSuffixes` — `.scale` and `.bias` filtered out of the main names list. (Plural-suffix filter coverage is in the naming-recognition PR.)
- `TestInferQuantTypeFromShapes_SingularAuxName` — current code path uses `header[tensorName+".scale"]`; asserts inferred type for a valid shape.
- `TestParseGlobalQuantMetadata` — 4 sub-cases: no metadata key, empty metadata, populated metadata, non-numeric `group_size`.
- `TestReadBlobTensorQuantInfo_ErrorPaths` — 4 sub-cases: missing file, truncated header size, oversize header (>100 MB guard), malformed JSON.

Includes a co-located unexported test helper `fakeSafetensorsBlob(t, header)` that writes a binary safetensors-style header to a temp path.

### `linear_test.go` (new, ~170 lines)

- `TestMakeLinearLayer_DenseFallback_NoWeight` — nil returned on empty map or bias-only map.
- `TestMakeLinearLayer_DenseLinear_NoScales` — weight only → `*nn.Linear`.
- `TestMakeLinearLayer_DenseLinear_WithBias` — weight + bias wired through.
- `TestMakeLinearLayer_OllamaNativeQuantized` — singular naming (`<path>.weight_scale`) → `*nn.QuantizedLinear` with default quant params.
- `TestMakeLinearLayer_OllamaNativeQuantized_WithQBiasAndBias` — both `weight_qbias` and `bias` wired through the struct.
- `TestMakeLinearLayer_PerTensorQuantOverride_CurrentBehaviour` — a `{QuantType:"INT4", GroupSize:32}` entry in `tensorQuant` overrides the global `(16, 4, "nvfp4")` default to `(32, 4, "affine")`.
- `TestMakeLinearLayer_NilTensorQuant_UsesDefaults` — nil `tensorQuant` map passes defaults through.
- `TestLinearFactory_Make_ProducesLayer` — delegation equivalence check between factory and direct call.

Plural-aux naming tests are intentionally absent from this PR. They belong to the naming-recognition PR, which introduces the production support they verify.

## Test plan

- [ ] `go test ./x/mlxrunner/model/...` on macOS arm64 with MLX — all pass.
- [ ] `go test ./x/mlxrunner/model/...` on Linux / CI without MLX — MLX-dependent cases skip via existing `skipIfNoMLX`; pure-Go cases pass.
- [ ] `go vet ./x/mlxrunner/model/...` — clean.

## Files touched

```
x/mlxrunner/model/quant_test.go     new, ~300 lines
x/mlxrunner/model/root_test.go      new, ~380 lines
x/mlxrunner/model/linear_test.go    new, ~170 lines
```

No production code changes.

## Risk

Zero — test-only.

## Relationship to other PRs

Fully independent. Lands cleanly before, after, or between the naming-recognition PR and the config.json-overrides PR.

- If this PR lands first: the other two PRs add new test files/cases that extend this coverage.
- If either of the other PRs lands first: this PR stays valid — its test expectations only describe branches that both sibling PRs preserve (the new `Bits`/`Mode` field semantics and plural-aux naming are deliberately out of scope here).
