### PR TITLE
Prevent system sleep during inference (fixes #4072)

### DIFF
--- a/server/power_saver.go
+++ b/server/power_saver.go
@@ -1,0 +1,52 @@
+// Package server provides the Ollama API server
+package server
+
+import (
+	"os/exec"
+	"sync"
+	"runtime"
+)
+
+// Power management to prevent sleep during inference
+
+var (
+	preventSleepMu sync.Mutex
+	preventSleepCnt int
+	isActive       bool
+)
+
+// AcquirePowerLock prevents the system from sleeping while processing
+// Inference requests. Uses platform-specific commands.
+func AcquirePowerLock() {
+	preventSleepMu.Lock()
+	defer preventSleepMu.Unlock()
+	preventSleepCnt++
+	
+	if preventSleepCnt == 1 && !isActive {
+		isActive = true
+		if runtime.GOOS == "darwin" {
+			// macOS: use caffeinate to prevent idle sleep
+			exec.Command("sh", "-c", "caffeinate -i -s &").Start()
+		} else if runtime.GOOS == "linux" {
+			// Linux: use systemd-inhibit
+			exec.Command("sh", "-c", "systemd-inhibit --what=idle sleep infinity &").Start()
+		}
+	}
+}
+
+// ReleasePowerLock allows the system to sleep again
+func ReleasePowerLock() {
+	preventSleepMu.Lock()
+	defer preventSleepMu.Unlock()
+	preventSleepCnt--
+	
+	if preventSleepCnt <= 0 {
+		preventSleepCnt = 0
+		if isActive {
+			isActive = false
+			// Kill the power management processes
+			exec.Command("pkill", "-f", "caffeinate").Run()
+			exec.Command("pkill", "-f", "systemd-inhibit").Run()
+		}
+	}
+}

--- a/server/routes.go
+++ b/server/routes.go
@@ -193,6 +193,8 @@ func signinURL() (string, error) {
 
 func (s *Server) GenerateHandler(c *gin.Context) {
 	checkpointStart := time.Now()
+	AcquirePowerLock()          // Prevent sleep during inference
+	defer ReleasePowerLock()
 	var req api.GenerateRequest
 	if err := c.ShouldBindJSON(&req); errors.Is(err, io.EOF) {
 		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "missing request body"})
@@ -2101,6 +2103,8 @@ func toolCallId() string {
 func (s *Server) ChatHandler(c *gin.Context) {
 	checkpointStart := time.Now()
 
+	AcquirePowerLock()          // Prevent sleep during inference
+	defer ReleasePowerLock()
 	var req api.ChatRequest
 	if err := c.ShouldBindJSON(&req); errors.Is(err, io.EOF) {
 		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "missing request body"})


### PR DESCRIPTION
## Summary

This PR implements power management to prevent the system from sleeping during inference operations.

## Changes

- Added `server/power_saver.go` with `AcquirePowerLock()` and `ReleasePowerLock()` functions
- Uses `caffeinate` on macOS to prevent idle sleep
- Uses `systemd-inhibit` on Linux to prevent idle sleep  
- Integrated power locking into `GenerateHandler` and `ChatHandler`

## Motivation

Fixes issue #4072: Ollama should prevent sleep when working on heavy inference tasks.

## Testing

The implementation uses reference counting to handle concurrent inference requests - power is saved until all inference requests complete.

```
Fixes #4072
```