### PR TITLE
server: populate parameter_size in /api/tags for safetensors models

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -1424,6 +1424,32 @@ func (s *Server) ListHandler(c *gin.Context) {
 			}
 		}
 
+		modelDetails := api.ModelDetails{
+			Format:            cf.ModelFormat,
+			Family:            cf.ModelFamily,
+			Families:          cf.ModelFamilies,
+			ParameterSize:     cf.ModelType,
+			QuantizationLevel: cf.FileType,
+		}
+
+		// For safetensors LLM models (experimental), enrich details from config.json
+		// to match the behaviour of /api/show for these models.
+		if cf.ModelFormat == "safetensors" && slices.Contains(cf.Capabilities, "completion") {
+			if info, err := xserver.GetSafetensorsLLMInfo(n); err == nil {
+				if arch, ok := info["general.architecture"].(string); ok && arch != "" {
+					modelDetails.Family = arch
+				}
+				if paramCount, ok := info["general.parameter_count"].(int64); ok && paramCount > 0 {
+					modelDetails.ParameterSize = format.HumanNumber(uint64(paramCount))
+				}
+			}
+			if modelDetails.QuantizationLevel == "" {
+				if dtype, err := xserver.GetSafetensorsDtype(n); err == nil && dtype != "" {
+					modelDetails.QuantizationLevel = dtype
+				}
+			}
+		}
+
 		// tag should never be masked
 		models = append(models, api.ListModelResponse{
 			Model:       n.DisplayShortest(),
@@ -1433,13 +1459,7 @@ func (s *Server) ListHandler(c *gin.Context) {
 			Size:        m.Size(),
 			Digest:      m.Digest(),
 			ModifiedAt:  m.FileInfo().ModTime(),
-			Details: api.ModelDetails{
-				Format:            cf.ModelFormat,
-				Family:            cf.ModelFamily,
-				Families:          cf.ModelFamilies,
-				ParameterSize:     cf.ModelType,
-				QuantizationLevel: cf.FileType,
-			},
+			Details:     modelDetails,
 		})
 	}
 

--- a/server/routes_list_test.go
+++ b/server/routes_list_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"slices"
@@ -9,6 +10,8 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/manifest"
+	"github.com/ollama/ollama/types/model"
 )
 
 func TestList(t *testing.T) {
@@ -62,5 +65,56 @@ func TestList(t *testing.T) {
 
 	if !slices.Equal(actualNames, expectNames) {
 		t.Fatalf("expected slices to be equal %v", actualNames)
+	}
+}
+
+// TestListSafetensorsDetails verifies that /api/tags populates parameter_size and
+// quantization_level for safetensors models when those values are stored in the
+// manifest config, matching the behaviour of /api/show.
+func TestListSafetensorsDetails(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	t.Setenv("OLLAMA_MODELS", t.TempDir())
+
+	cfgData, err := json.Marshal(model.ConfigV2{
+		ModelFormat:  "safetensors",
+		ModelType:    "26B",
+		FileType:     "mxfp8",
+		Capabilities: []string{"completion"},
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal config: %v", err)
+	}
+
+	configLayer, err := manifest.NewLayer(bytes.NewReader(cfgData), "application/vnd.docker.container.image.v1+json")
+	if err != nil {
+		t.Fatalf("failed to create config layer: %v", err)
+	}
+
+	name := model.ParseName("gemma4:26b-mxfp8")
+	if err := manifest.WriteManifest(name, configLayer, nil); err != nil {
+		t.Fatalf("failed to write manifest: %v", err)
+	}
+
+	var s Server
+	w := createRequest(t, s.ListHandler, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status code 200, actual %d", w.Code)
+	}
+
+	var resp api.ListResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(resp.Models) != 1 {
+		t.Fatalf("expected 1 model, got %d", len(resp.Models))
+	}
+
+	got := resp.Models[0].Details
+	if got.ParameterSize == "" {
+		t.Errorf("ParameterSize is empty, want non-empty for safetensors model")
+	}
+	if got.QuantizationLevel != "mxfp8" {
+		t.Errorf("QuantizationLevel = %q, want %q", got.QuantizationLevel, "mxfp8")
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #15679

`ListHandler` only used the manifest config fields (`ModelType` / `FileType`) for `ParameterSize` / `QuantizationLevel`, which are **not** written for local safetensors models at creation time. This caused `/api/tags` to return an empty `parameter_size` (and mismatched `quantization_level`) for models like `gemma4:26b-mxfp8` and `gemma4:26b-nvfp4`.

`/api/show` already worked correctly by calling `xserver.GetSafetensorsLLMInfo` / `xserver.GetSafetensorsDtype`. This PR mirrors that same enrichment step in `ListHandler` so both endpoints stay consistent.

## Changes

**`server/routes.go`** — `ListHandler`:
- Build `modelDetails` before appending to the response slice.
- When `cf.ModelFormat == "safetensors"` and the model has the `"completion"` capability, call `xserver.GetSafetensorsLLMInfo(n)` to populate `Family` and `ParameterSize` from the model's `config.json`.
- Fall back to `xserver.GetSafetensorsDtype(n)` for `QuantizationLevel` when it isn't already set in the manifest config (matches the existing fall-back in `ShowHandler` for older manifests).

**`server/routes_list_test.go`** — `TestListSafetensorsDetails`:
- Creates a safetensors manifest with `ModelType`, `FileType`, and `Capabilities` set.
- Asserts that `ListHandler` returns a non-empty `ParameterSize` and the correct `QuantizationLevel`.

## Verification

- `go vet ./server/` — clean
- `go test ./server/` — all pass (4.4s)


Made with [Cursor](https://cursor.com)