### PR TITLE
runner: expose prompt cache hit count in completion response

### DIFF
--- a/llm/server.go
+++ b/llm/server.go
@@ -1530,6 +1530,7 @@ type CompletionResponse struct {
 	Done               bool          `json:"done"`
 	PromptEvalCount    int           `json:"prompt_eval_count"`
 	PromptEvalDuration time.Duration `json:"prompt_eval_duration"`
+	PromptCachedCount  int           `json:"prompt_cached_count,omitempty"`
 	EvalCount          int           `json:"eval_count"`
 	EvalDuration       time.Duration `json:"eval_duration"`
 

--- a/runner/ollamarunner/runner.go
+++ b/runner/ollamarunner/runner.go
@@ -113,6 +113,7 @@ type Sequence struct {
 	samplingDuration         time.Duration
 	numPredicted             int
 	numPromptInputs          int
+	numCachedInputs          int
 }
 
 type NewSequenceParams struct {
@@ -937,6 +938,7 @@ func (s *Server) completion(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, fmt.Sprintf("Failed to load cache: %v", err), http.StatusInternalServerError)
 				return
 			}
+			seq.numCachedInputs = len(seq.cache.Inputs)
 
 			s.seqs[i] = seq
 			s.cond.Signal()
@@ -975,6 +977,7 @@ func (s *Server) completion(w http.ResponseWriter, r *http.Request) {
 					DoneReason:         seq.doneReason,
 					PromptEvalCount:    seq.numPromptInputs,
 					PromptEvalDuration: seq.processingDuration,
+					PromptCachedCount:  seq.numCachedInputs,
 					EvalCount:          seq.numPredicted,
 					EvalDuration:       seq.lastUpdatedAt.Sub(seq.startedAt) - seq.samplingDuration,
 				}); err != nil {


### PR DESCRIPTION
When the runner processes a completion request it consults the KV cache to skip re-evaluating prompt tokens that were already processed in a previous turn. The number of tokens actually served from that cache was tracked internally but never returned to callers, making it impossible to observe cache efficiency.

A new `numCachedInputs` field is added to the `Sequence` struct in `runner/ollamarunner/runner.go`. Immediately after `loadCache` populates `seq.cache.Inputs`, the length of that slice is captured as `seq.numCachedInputs`. That value is then included in the outgoing `CompletionResponse` as `PromptCachedCount` (omitted when zero so existing clients see no change).

On the server side, `llm/server.go` gains the corresponding `PromptCachedCount int` field with the `prompt_cached_count,omitempty` JSON tag so the information surfaces through the HTTP API without breaking backward compatibility.

Fixes #15758
