### PR TITLE
cmd: show help when stop and show are called without a model argument

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -443,6 +443,9 @@ func loadOrUnloadModel(cmd *cobra.Command, opts *runOptions) error {
 }
 
 func StopHandler(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return cmd.Help()
+	}
 	opts := &runOptions{
 		Model:     args[0],
 		KeepAlive: &api.Duration{Duration: 0},
@@ -1044,6 +1047,10 @@ func DeleteHandler(cmd *cobra.Command, args []string) error {
 }
 
 func ShowHandler(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return cmd.Help()
+	}
+
 	client, err := api.ClientFromEnvironment()
 	if err != nil {
 		return err
@@ -2178,11 +2185,16 @@ func NewCLI() *cobra.Command {
 	createCmd.Flags().Bool("experimental", false, "Enable experimental safetensors model creation")
 
 	showCmd := &cobra.Command{
-		Use:     "show MODEL",
-		Short:   "Show information for a model",
-		Args:    cobra.ExactArgs(1),
-		PreRunE: checkServerHeartbeat,
-		RunE:    ShowHandler,
+		Use:  "show MODEL",
+		Short: "Show information for a model",
+		Args: cobra.MaximumNArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return nil
+			}
+			return checkServerHeartbeat(cmd, args)
+		},
+		RunE: ShowHandler,
 	}
 
 	showCmd.Flags().Bool("license", false, "Show license of a model")
@@ -2221,11 +2233,16 @@ func NewCLI() *cobra.Command {
 	runCmd.Flags().MarkHidden("imagegen")
 
 	stopCmd := &cobra.Command{
-		Use:     "stop MODEL",
-		Short:   "Stop a running model",
-		Args:    cobra.ExactArgs(1),
-		PreRunE: checkServerHeartbeat,
-		RunE:    StopHandler,
+		Use:  "stop MODEL",
+		Short: "Stop a running model",
+		Args: cobra.MaximumNArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return nil
+			}
+			return checkServerHeartbeat(cmd, args)
+		},
+		RunE: StopHandler,
 	}
 
 	serveCmd := &cobra.Command{


### PR DESCRIPTION
`ollama stop` and `ollama show` both use `cobra.ExactArgs(1)`, which causes cobra to return the unhelpful error "accepts 1 arg(s), received 0" when the user runs either command without a model name. This is confusing because the user does not see the command's usage text.

The fix changes both commands to use `cobra.MaximumNArgs(1)` and adds an early return in `StopHandler` and `ShowHandler` that prints the command help when no arguments are provided. The `PreRunE` server heartbeat check is also skipped when no args are given, so users don't get a spurious server connection error before seeing the help text.

Tested manually: `ollama stop` and `ollama show` without arguments now print the usage text instead of erroring, while `ollama stop <model>` and `ollama show <model>` continue to work correctly.

Fixes #15769
