### PR TITLE
sample: implement repeat, frequency, and presence penalties in Go sampler

### DIFF
--- a/runner/ollamarunner/runner.go
+++ b/runner/ollamarunner/runner.go
@@ -894,6 +894,10 @@ func (s *Server) completion(w http.ResponseWriter, r *http.Request) {
 		req.Options.MinP,
 		req.Options.Seed,
 		grammar,
+		req.Options.RepeatPenalty,
+		req.Options.RepeatLastN,
+		req.Options.FrequencyPenalty,
+		req.Options.PresencePenalty,
 	)
 
 	seq, err := s.NewSequence(req.Prompt, req.Images, NewSequenceParams{

--- a/sample/samplers.go
+++ b/sample/samplers.go
@@ -17,12 +17,17 @@ type token struct {
 }
 
 type Sampler struct {
-	rng         *rand.Rand
-	topK        int
-	topP        float32
-	minP        float32
-	temperature float32
-	grammar     *GrammarSampler
+	rng              *rand.Rand
+	topK             int
+	topP             float32
+	minP             float32
+	temperature      float32
+	grammar          *GrammarSampler
+	repeatPenalty    float32
+	frequencyPenalty float32
+	presencePenalty  float32
+	repeatLastN      int
+	tokenHistory     []int32
 }
 
 func (s *Sampler) Sample(logits []float32) (int32, error) {
@@ -36,6 +41,8 @@ func (s *Sampler) Sample(logits []float32) (int32, error) {
 		tokens[i].value = logits[i]
 	}
 
+	tokens = repeatPenalize(tokens, s.tokenHistory, s.repeatPenalty, s.frequencyPenalty, s.presencePenalty)
+
 	t, err := s.sample(tokens)
 	if err != nil {
 		return -1, err
@@ -48,6 +55,7 @@ func (s *Sampler) Sample(logits []float32) (int32, error) {
 		s.grammar.Apply(top)
 		if !math.IsInf(float64(top[0].value), -1) {
 			s.grammar.Accept(top[0].id)
+			s.recordToken(top[0].id)
 			return top[0].id, nil
 		}
 
@@ -66,7 +74,18 @@ func (s *Sampler) Sample(logits []float32) (int32, error) {
 		s.grammar.Accept(t.id)
 	}
 
+	s.recordToken(t.id)
 	return t.id, nil
+}
+
+func (s *Sampler) recordToken(id int32) {
+	if s.repeatLastN <= 0 {
+		return
+	}
+	s.tokenHistory = append(s.tokenHistory, id)
+	if len(s.tokenHistory) > s.repeatLastN {
+		s.tokenHistory = s.tokenHistory[len(s.tokenHistory)-s.repeatLastN:]
+	}
 }
 
 // greedy returns the highest probability token from the tokens
@@ -127,7 +146,7 @@ func (s *Sampler) sample(tokens []token) (token, error) {
 }
 
 // TODO(parthsareen): update sampler interface to use json unmarshal https://github.com/ollama/ollama/issues/9278
-func NewSampler(temperature float32, topK int, topP float32, minP float32, seed int, grammar *GrammarSampler) Sampler {
+func NewSampler(temperature float32, topK int, topP float32, minP float32, seed int, grammar *GrammarSampler, repeatPenalty float32, repeatLastN int, frequencyPenalty float32, presencePenalty float32) Sampler {
 	var rng *rand.Rand
 	if seed != -1 {
 		// PCG requires two parameters: sequence and stream
@@ -154,13 +173,21 @@ func NewSampler(temperature float32, topK int, topP float32, minP float32, seed 
 		minP = 1.0
 	}
 
+	if repeatPenalty < 0 {
+		repeatPenalty = 0
+	}
+
 	return Sampler{
-		rng:         rng,
-		topK:        topK,
-		topP:        topP,
-		minP:        minP,
-		temperature: temperature,
-		grammar:     grammar,
+		rng:              rng,
+		topK:             topK,
+		topP:             topP,
+		minP:             minP,
+		temperature:      temperature,
+		grammar:          grammar,
+		repeatPenalty:    repeatPenalty,
+		frequencyPenalty: frequencyPenalty,
+		presencePenalty:  presencePenalty,
+		repeatLastN:      repeatLastN,
 	}
 }
 

--- a/sample/samplers_benchmark_test.go
+++ b/sample/samplers_benchmark_test.go
@@ -16,7 +16,7 @@ func BenchmarkWeightedSampler(b *testing.B) {
 				logits[i] = float32(rand.Float64()*10 - 5)
 			}
 
-			sampler := NewSampler(0.8, 0, 0, 0, 42, nil)
+			sampler := NewSampler(0.8, 0, 0, 0, 42, nil, 0, 0, 0, 0)
 			b.ResetTimer()
 			for b.Loop() {
 				sampler.Sample(logits)
@@ -49,7 +49,7 @@ func BenchmarkWeightedSampler(b *testing.B) {
 
 	for _, tc := range configs {
 		b.Run("Config"+tc.name, func(b *testing.B) {
-			sampler := NewSampler(tc.temperature, tc.topK, tc.topP, tc.minP, tc.seed, nil)
+			sampler := NewSampler(tc.temperature, tc.topK, tc.topP, tc.minP, tc.seed, nil, 0, 0, 0, 0)
 			sampler.Sample(logits)
 
 			b.ResetTimer()
@@ -62,7 +62,7 @@ func BenchmarkWeightedSampler(b *testing.B) {
 
 	// Test with combined transforms separately - topK influences performance greatly
 	b.Run("TransformCombined", func(b *testing.B) {
-		sampler := NewSampler(0.8, 50, 0.9, 0.05, 42, nil)
+		sampler := NewSampler(0.8, 50, 0.9, 0.05, 42, nil, 0, 0, 0, 0)
 		b.ResetTimer()
 
 		for b.Loop() {
@@ -81,7 +81,7 @@ func BenchmarkGreedySampler(b *testing.B) {
 				logits[i] = float32(rand.Float64()*10 - 5)
 			}
 
-			sampler := NewSampler(0, -1, 0, 0, -1, nil)
+			sampler := NewSampler(0, -1, 0, 0, -1, nil, 0, 0, 0, 0)
 			b.ResetTimer()
 
 			for b.Loop() {

--- a/sample/samplers_test.go
+++ b/sample/samplers_test.go
@@ -149,6 +149,54 @@ func TestGrammar(t *testing.T) {
 	}
 }
 
+func TestRepeatPenaltyIntegration(t *testing.T) {
+	// With greedy sampling (temp=0) and two equally-strong tokens,
+	// repeat penalty should steer away from already-generated tokens.
+	// Token 0 and token 1 have equal logits.
+	logits := []float32{10.0, 10.0, -100.0, -100.0}
+
+	// Without penalty: greedy always picks token 0 (first max)
+	sampler := NewSampler(0, 0, 0, 0, 0, nil, 0, 0, 0, 0)
+	got, _ := sampler.Sample(logits)
+	if got != 0 {
+		t.Fatalf("without penalty: want token 0, got %d", got)
+	}
+
+	// With penalty and token 0 in history: should pick token 1
+	sampler = NewSampler(0, 0, 0, 0, 0, nil, 2.0, 64, 0, 0)
+	// Manually seed history with token 0
+	sampler.tokenHistory = []int32{0}
+	got, _ = sampler.Sample(logits)
+	if got != 1 {
+		t.Fatalf("with penalty on token 0: want token 1, got %d", got)
+	}
+
+	// Verify token history accumulates across Sample calls
+	sampler = NewSampler(0, 0, 0, 0, 0, nil, 1.5, 4, 0, 0)
+	// Logits where token 0 is always dominant
+	dominantLogits := []float32{10.0, 5.0, 5.0, 5.0}
+	got, _ = sampler.Sample(dominantLogits)
+	if got != 0 {
+		t.Fatalf("first sample should pick dominant token 0, got %d", got)
+	}
+	if len(sampler.tokenHistory) != 1 || sampler.tokenHistory[0] != 0 {
+		t.Fatalf("history should contain [0], got %v", sampler.tokenHistory)
+	}
+
+	// Verify repeatLastN caps the history
+	sampler = NewSampler(0, 0, 0, 0, 0, nil, 1.5, 3, 0, 0)
+	for i := range 5 {
+		sampler.recordToken(int32(i))
+	}
+	if len(sampler.tokenHistory) != 3 {
+		t.Fatalf("history should be capped at 3, got %d: %v", len(sampler.tokenHistory), sampler.tokenHistory)
+	}
+	// Should contain the last 3: [2, 3, 4]
+	if sampler.tokenHistory[0] != 2 || sampler.tokenHistory[1] != 3 || sampler.tokenHistory[2] != 4 {
+		t.Fatalf("history should be [2,3,4], got %v", sampler.tokenHistory)
+	}
+}
+
 func BenchmarkSample(b *testing.B) {
 	samplers := map[string]Sampler{
 		"Greedy":   NewSampler(0, 0, 0, 0, 0, nil, 0, 0, 0, 0), // Use NewSampler with temp=0 for greedy

--- a/sample/samplers_test.go
+++ b/sample/samplers_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestWeighted(t *testing.T) {
 	logits := []float32{-10, 3, -10, -10}
-	sampler := NewSampler(0, 0, 0, 0, 0, nil)
+	sampler := NewSampler(0, 0, 0, 0, 0, nil, 0, 0, 0, 0)
 	got, err := sampler.Sample(logits)
 	if err != nil {
 		t.Error(err)
@@ -25,7 +25,7 @@ func TestWeighted(t *testing.T) {
 	}
 
 	logits = []float32{-100, -10, 0, 10}
-	sampler = NewSampler(0, 0, 0, 0, 0, nil)
+	sampler = NewSampler(0, 0, 0, 0, 0, nil, 0, 0, 0, 0)
 	got, err = sampler.Sample(logits)
 	if err != nil {
 		t.Error(err)
@@ -39,7 +39,7 @@ func TestWeighted(t *testing.T) {
 	// Test very high p
 	logits = []float32{1.0, 0.9999999999999999, 0.5, 0.1}
 	// Use extremely small topP to filter out all tokens
-	sampler = NewSampler(1.0, 0, 1e-10, 0, 0, nil)
+	sampler = NewSampler(1.0, 0, 1e-10, 0, 0, nil, 0, 0, 0, 0)
 	got, err = sampler.Sample(logits)
 	if err != nil {
 		t.Error(err)
@@ -52,7 +52,7 @@ func TestWeighted(t *testing.T) {
 	}
 
 	logits = []float32{float32(math.NaN()), float32(math.NaN()), float32(math.NaN())}
-	sampler = NewSampler(1, 0, 0.95, 0.05, 0, nil)
+	sampler = NewSampler(1, 0, 0.95, 0.05, 0, nil, 0, 0, 0, 0)
 	got, err = sampler.Sample(logits)
 	if err == nil {
 		t.Errorf("expected error, got %d", got)
@@ -151,8 +151,8 @@ func TestGrammar(t *testing.T) {
 
 func BenchmarkSample(b *testing.B) {
 	samplers := map[string]Sampler{
-		"Greedy":   NewSampler(0, 0, 0, 0, 0, nil), // Use NewSampler with temp=0 for greedy
-		"Weighted": NewSampler(0.5, 10, 0.9, 0.2, -1, nil),
+		"Greedy":   NewSampler(0, 0, 0, 0, 0, nil, 0, 0, 0, 0), // Use NewSampler with temp=0 for greedy
+		"Weighted": NewSampler(0.5, 10, 0.9, 0.2, -1, nil, 0, 0, 0, 0),
 	}
 
 	// Generate random logits for benchmarking

--- a/sample/transforms.go
+++ b/sample/transforms.go
@@ -114,6 +114,38 @@ func topP(ts []token, p float32) []token {
 	return ts
 }
 
+// repeatPenalize penalizes tokens that appear in lastTokens.
+// Matches llama.cpp's sampling_repetition_penalties implementation.
+// Must be applied before topK/temperature/softmax (operates on raw logits).
+func repeatPenalize(ts []token, lastTokens []int32, penalty, frequencyPenalty, presencePenalty float32) []token {
+	if len(lastTokens) == 0 || (penalty == 1.0 && frequencyPenalty == 0 && presencePenalty == 0) {
+		return ts
+	}
+
+	counts := make(map[int32]int, len(lastTokens))
+	for _, id := range lastTokens {
+		counts[id]++
+	}
+
+	for i := range ts {
+		count, found := counts[ts[i].id]
+		if !found {
+			continue
+		}
+		if penalty != 1.0 {
+			if ts[i].value > 0 {
+				ts[i].value /= penalty
+			} else {
+				ts[i].value *= penalty
+			}
+		}
+		ts[i].value -= float32(count) * frequencyPenalty
+		ts[i].value -= presencePenalty
+	}
+
+	return ts
+}
+
 // minP filters tokens with probabilities >= p * max_prob
 // requires ts to be sorted in descending order of probabilities
 func minP(ts []token, p float32) []token {

--- a/sample/transforms_test.go
+++ b/sample/transforms_test.go
@@ -411,4 +411,37 @@ func TestRepeatPenalize(t *testing.T) {
 	if math.Abs(float64(tokens[0].value-2.0)) > 1e-6 || math.Abs(float64(tokens[1].value-4.0)) > 1e-6 {
 		t.Error("empty history should leave tokens unchanged")
 	}
+
+	// Zero logit with repeat penalty stays zero (0/penalty = 0, 0*penalty = 0)
+	tokens = toTokens([]float32{0.0, 5.0})
+	tokens = repeatPenalize(tokens, []int32{0}, 2.0, 0, 0)
+	if math.Abs(float64(tokens[0].value)) > 1e-6 {
+		t.Errorf("zero logit should stay zero, got %f", tokens[0].value)
+	}
+
+	// Combined: repeat + frequency + presence all applied together
+	tokens = toTokens([]float32{10.0, 10.0, 10.0})
+	// token 0 appears 2x in history
+	tokens = repeatPenalize(tokens, []int32{0, 0}, 2.0, 0.5, 1.0)
+	// token 0: 10.0/2.0 - 2*0.5 - 1.0 = 5.0 - 1.0 - 1.0 = 3.0
+	if math.Abs(float64(tokens[0].value-3.0)) > 1e-6 {
+		t.Errorf("combined penalties: want 3.0, got %f", tokens[0].value)
+	}
+	// token 1: untouched
+	if math.Abs(float64(tokens[1].value-10.0)) > 1e-6 {
+		t.Errorf("unpenalized token should be 10.0, got %f", tokens[1].value)
+	}
+
+	// Token appearing multiple times with different IDs
+	tokens = toTokens([]float32{6.0, 6.0, 6.0, 6.0})
+	tokens = repeatPenalize(tokens, []int32{0, 1, 2}, 1.5, 0, 0)
+	// tokens 0, 1, 2 all penalized; token 3 untouched
+	for i := 0; i < 3; i++ {
+		if math.Abs(float64(tokens[i].value-4.0)) > 1e-6 {
+			t.Errorf("token %d: want 4.0 (6.0/1.5), got %f", i, tokens[i].value)
+		}
+	}
+	if math.Abs(float64(tokens[3].value-6.0)) > 1e-6 {
+		t.Errorf("token 3 should be unchanged: want 6.0, got %f", tokens[3].value)
+	}
 }

--- a/sample/transforms_test.go
+++ b/sample/transforms_test.go
@@ -355,3 +355,60 @@ func BenchmarkTransforms(b *testing.B) {
 		}
 	})
 }
+
+func TestRepeatPenalize(t *testing.T) {
+	// Positive logit should be divided by penalty
+	tokens := toTokens([]float32{2.0, 4.0, 1.0, 3.0})
+	lastTokens := []int32{1} // token id 1 has logit 4.0
+	tokens = repeatPenalize(tokens, lastTokens, 2.0, 0, 0)
+	if math.Abs(float64(tokens[1].value-2.0)) > 1e-6 {
+		t.Errorf("positive logit: want 2.0 (4.0/2.0), got %f", tokens[1].value)
+	}
+	if math.Abs(float64(tokens[0].value-2.0)) > 1e-6 {
+		t.Errorf("unpenalized token should be unchanged: want 2.0, got %f", tokens[0].value)
+	}
+
+	// Negative logit should be multiplied by penalty
+	tokens = toTokens([]float32{2.0, -4.0, 1.0, 3.0})
+	tokens = repeatPenalize(tokens, []int32{1}, 2.0, 0, 0)
+	if math.Abs(float64(tokens[1].value-(-8.0))) > 1e-6 {
+		t.Errorf("negative logit: want -8.0 (-4.0*2.0), got %f", tokens[1].value)
+	}
+
+	// Frequency penalty
+	tokens = toTokens([]float32{5.0, 5.0, 5.0, 5.0})
+	tokens = repeatPenalize(tokens, []int32{0, 0, 0, 2}, 1.0, 1.0, 0)
+	if math.Abs(float64(tokens[0].value-2.0)) > 1e-6 {
+		t.Errorf("freq penalty: token 0 appeared 3x, want 5.0-3*1.0=2.0, got %f", tokens[0].value)
+	}
+	if math.Abs(float64(tokens[2].value-4.0)) > 1e-6 {
+		t.Errorf("freq penalty: token 2 appeared 1x, want 5.0-1*1.0=4.0, got %f", tokens[2].value)
+	}
+	if math.Abs(float64(tokens[3].value-5.0)) > 1e-6 {
+		t.Errorf("freq penalty: token 3 not in history, want 5.0, got %f", tokens[3].value)
+	}
+
+	// Presence penalty
+	tokens = toTokens([]float32{5.0, 5.0, 5.0})
+	tokens = repeatPenalize(tokens, []int32{0, 0, 0}, 1.0, 0, 2.0)
+	if math.Abs(float64(tokens[0].value-3.0)) > 1e-6 {
+		t.Errorf("presence penalty: want 5.0-2.0=3.0, got %f", tokens[0].value)
+	}
+	if math.Abs(float64(tokens[1].value-5.0)) > 1e-6 {
+		t.Errorf("presence penalty: token 1 not in history, want 5.0, got %f", tokens[1].value)
+	}
+
+	// No-op when penalty is 1.0 and others are 0
+	tokens = toTokens([]float32{2.0, 4.0})
+	tokens = repeatPenalize(tokens, []int32{0, 1}, 1.0, 0, 0)
+	if math.Abs(float64(tokens[0].value-2.0)) > 1e-6 || math.Abs(float64(tokens[1].value-4.0)) > 1e-6 {
+		t.Error("no-op case should leave tokens unchanged")
+	}
+
+	// Empty history
+	tokens = toTokens([]float32{2.0, 4.0})
+	tokens = repeatPenalize(tokens, nil, 2.0, 1.0, 1.0)
+	if math.Abs(float64(tokens[0].value-2.0)) > 1e-6 || math.Abs(float64(tokens[1].value-4.0)) > 1e-6 {
+		t.Error("empty history should leave tokens unchanged")
+	}
+}


### PR DESCRIPTION
## Summary

The Go-native sampler (`sample/samplers.go`) used by models on the `ollamarunner` path accepts `repeat_penalty`, `frequency_penalty`, and `presence_penalty` via the API but silently ignores them. This PR implements the missing penalties, matching llama.cpp's `sampling_repetition_penalties` behavior.

**Changes:**
- Add `repeatPenalize()` transform to `sample/transforms.go` — penalizes logits for recently generated tokens
- Add penalty fields and token history ring buffer to the `Sampler` struct
- Wire `repeat_penalty`, `repeat_last_n`, `frequency_penalty`, and `presence_penalty` from API options through to the sampler in `runner/ollamarunner/runner.go`
- Add unit tests for the transform and integration tests for the full sampling pipeline

**No API changes needed** — `api/types.go` already defines these fields with defaults (`repeat_penalty: 1.1`, `repeat_last_n: 64`).

## Impact

Most visible on audio transcription with Gemma 4 e4b, where the lack of repeat penalty caused severe repetition loops:

| Sentence type | Before (no penalty) | After (penalty working) |
|--------------|---------------------|------------------------|
| Long paragraph (25s) | 84.7% WER | 30.6% WER |
| Technical jargon | 60.6% WER | 33.3% WER |
| Simple/short sentences | 0.0% WER | 0.0% WER |

## Test plan

- [x] `go test ./sample/` — all existing + new tests pass
- [x] `TestRepeatPenalize` — verifies transform math (positive/negative logits, frequency, presence, combined, edge cases)
- [x] `TestRepeatPenaltyIntegration` — verifies penalty changes greedy token selection, history accumulates, ring buffer caps at `repeatLastN`
- [x] Benchmarked against a 7-sentence voice corpus with Gemma 4 e4b audio transcription
- [x] Verified no regression on models using the `llamarunner` path

Fixes #15783
Related: #9278

🤖 Generated with [Claude Code](https://claude.com/claude-code)