### PR TITLE
launch: add codex model metadata catalog

### DIFF
--- a/cmd/launch/codex.go
+++ b/cmd/launch/codex.go
@@ -26,9 +26,8 @@ type Codex struct{}
 func (c *Codex) String() string { return "Codex" }
 
 const (
-	codexProfileName     = "ollama-launch"
-	codexProviderName    = "Ollama"
-	codexCatalogFileName = "ollama-launch-models.json"
+	codexProfileName  = "ollama-launch"
+	codexProviderName = "Ollama"
 
 	codexRootProfileKey          = "profile"
 	codexRootModelKey            = "model"
@@ -36,11 +35,8 @@ const (
 	codexRootModelCatalogJSONKey = "model_catalog_json"
 )
 
-func (c *Codex) args(model, catalogPath string, extra []string) []string {
+func (c *Codex) args(model string, extra []string) []string {
 	args := []string{"--profile", codexProfileName}
-	if catalogPath != "" {
-		args = append(args, "-c", fmt.Sprintf("model_catalog_json=%q", catalogPath))
-	}
 	if model != "" {
 		args = append(args, "-m", model)
 	}
@@ -53,12 +49,11 @@ func (c *Codex) Run(model string, args []string) error {
 		return err
 	}
 
-	catalogPath, err := ensureCodexConfig(model)
-	if err != nil {
+	if err := ensureCodexConfig(model); err != nil {
 		return fmt.Errorf("failed to configure codex: %w", err)
 	}
 
-	cmd := exec.Command("codex", c.args(model, catalogPath, args)...)
+	cmd := exec.Command("codex", c.args(model, args)...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -68,29 +63,25 @@ func (c *Codex) Run(model string, args []string) error {
 	return cmd.Run()
 }
 
-// ensureCodexConfig writes a minimal Codex profile plus the model catalog used
-// for Ollama-managed launches.
-func ensureCodexConfig(modelName string) (string, error) {
+// ensureCodexConfig writes a Codex profile and model catalog so Codex uses the
+// local Ollama server and has model metadata available.
+func ensureCodexConfig(modelName string) error {
 	configPath, err := codexConfigPath()
 	if err != nil {
-		return "", err
+		return err
 	}
 
 	codexDir := filepath.Dir(configPath)
 	if err := os.MkdirAll(codexDir, 0o755); err != nil {
-		return "", err
+		return err
 	}
 
-	catalogPath := filepath.Join(codexDir, codexCatalogFileName)
+	catalogPath := filepath.Join(codexDir, "model.json")
 	if err := writeCodexModelCatalog(catalogPath, modelName); err != nil {
-		return "", err
+		return err
 	}
 
-	if err := writeCodexProfile(configPath); err != nil {
-		return "", err
-	}
-
-	return catalogPath, nil
+	return writeCodexProfile(configPath, catalogPath)
 }
 
 func codexConfigPath() (string, error) {
@@ -103,10 +94,14 @@ func codexConfigPath() (string, error) {
 
 // writeCodexProfile ensures ~/.codex/config.toml has the ollama-launch profile
 // and model provider sections with the correct base URL.
-func writeCodexProfile(configPath string) error {
-	return writeCodexLaunchProfile(configPath, codexLaunchProfileOptions{
+func writeCodexProfile(configPath string, modelCatalogPath ...string) error {
+	opts := codexLaunchProfileOptions{
 		forceAPIAuth: true,
-	})
+	}
+	if len(modelCatalogPath) > 0 {
+		opts.modelCatalogPath = modelCatalogPath[0]
+	}
+	return writeCodexLaunchProfile(configPath, opts)
 }
 
 type codexLaunchProfileOptions struct {
@@ -142,6 +137,9 @@ func writeCodexLaunchProfile(configPath string, opts codexLaunchProfileOptions) 
 		model = parsed.ProfileString(profileName, codexRootModelKey)
 	}
 	modelCatalogPath := strings.TrimSpace(opts.modelCatalogPath)
+	if modelCatalogPath == "" {
+		modelCatalogPath = parsed.ProfileString(profileName, codexRootModelCatalogJSONKey)
+	}
 
 	profileLines := []string{}
 	if model != "" {
@@ -561,14 +559,9 @@ func codexRootLineHasKey(line, key string) bool {
 func writeCodexModelCatalog(catalogPath, modelName string) error {
 	entry := buildCodexModelEntry(modelName)
 
-	catalog := map[string]any{}
-	if content, err := os.ReadFile(catalogPath); err == nil {
-		if err := json.Unmarshal(content, &catalog); err != nil {
-			catalog = map[string]any{}
-		}
+	catalog := map[string]any{
+		"models": []any{entry},
 	}
-
-	catalog["models"] = mergeCodexModelEntries(catalog["models"], entry)
 
 	data, err := json.MarshalIndent(catalog, "", "  ")
 	if err != nil {
@@ -576,32 +569,6 @@ func writeCodexModelCatalog(catalogPath, modelName string) error {
 	}
 
 	return os.WriteFile(catalogPath, data, 0o644)
-}
-
-func mergeCodexModelEntries(existing any, entry map[string]any) []any {
-	models, _ := existing.([]any)
-	merged := make([]any, 0, len(models)+1)
-	replaced := false
-	slug, _ := entry["slug"].(string)
-
-	for _, model := range models {
-		current, ok := model.(map[string]any)
-		if !ok {
-			continue
-		}
-		if currentSlug, _ := current["slug"].(string); currentSlug == slug {
-			merged = append(merged, entry)
-			replaced = true
-			continue
-		}
-		merged = append(merged, current)
-	}
-
-	if !replaced {
-		merged = append(merged, entry)
-	}
-
-	return merged
 }
 
 func buildCodexModelEntry(modelName string) map[string]any {

--- a/cmd/launch/codex.go
+++ b/cmd/launch/codex.go
@@ -36,8 +36,11 @@ const (
 	codexRootModelCatalogJSONKey = "model_catalog_json"
 )
 
-func (c *Codex) args(model string, extra []string) []string {
+func (c *Codex) args(model, catalogPath string, extra []string) []string {
 	args := []string{"--profile", codexProfileName}
+	if catalogPath != "" {
+		args = append(args, "-c", fmt.Sprintf("model_catalog_json=%q", catalogPath))
+	}
 	if model != "" {
 		args = append(args, "-m", model)
 	}
@@ -50,11 +53,12 @@ func (c *Codex) Run(model string, args []string) error {
 		return err
 	}
 
-	if err := ensureCodexConfig(model); err != nil {
+	catalogPath, err := ensureCodexConfig(model)
+	if err != nil {
 		return fmt.Errorf("failed to configure codex: %w", err)
 	}
 
-	cmd := exec.Command("codex", c.args(model, args)...)
+	cmd := exec.Command("codex", c.args(model, catalogPath, args)...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -64,24 +68,29 @@ func (c *Codex) Run(model string, args []string) error {
 	return cmd.Run()
 }
 
-// ensureCodexConfig writes a Codex profile and model catalog so Codex uses the
-// local Ollama server and has model metadata available.
-func ensureCodexConfig(modelName string) error {
+// ensureCodexConfig writes a minimal Codex profile plus the model catalog used
+// for Ollama-managed launches.
+func ensureCodexConfig(modelName string) (string, error) {
 	configPath, err := codexConfigPath()
 	if err != nil {
-		return err
+		return "", err
 	}
 
-	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
-		return err
+	codexDir := filepath.Dir(configPath)
+	if err := os.MkdirAll(codexDir, 0o755); err != nil {
+		return "", err
 	}
 
-	catalogPath := filepath.Join(filepath.Dir(configPath), codexCatalogFileName)
+	catalogPath := filepath.Join(codexDir, codexCatalogFileName)
 	if err := writeCodexModelCatalog(catalogPath, modelName); err != nil {
-		return err
+		return "", err
 	}
 
-	return writeCodexProfile(configPath, catalogPath)
+	if err := writeCodexProfile(configPath); err != nil {
+		return "", err
+	}
+
+	return catalogPath, nil
 }
 
 func codexConfigPath() (string, error) {
@@ -94,14 +103,10 @@ func codexConfigPath() (string, error) {
 
 // writeCodexProfile ensures ~/.codex/config.toml has the ollama-launch profile
 // and model provider sections with the correct base URL.
-func writeCodexProfile(configPath string, modelCatalogPath ...string) error {
-	opts := codexLaunchProfileOptions{
+func writeCodexProfile(configPath string) error {
+	return writeCodexLaunchProfile(configPath, codexLaunchProfileOptions{
 		forceAPIAuth: true,
-	}
-	if len(modelCatalogPath) > 0 {
-		opts.modelCatalogPath = modelCatalogPath[0]
-	}
-	return writeCodexLaunchProfile(configPath, opts)
+	})
 }
 
 type codexLaunchProfileOptions struct {
@@ -137,9 +142,6 @@ func writeCodexLaunchProfile(configPath string, opts codexLaunchProfileOptions) 
 		model = parsed.ProfileString(profileName, codexRootModelKey)
 	}
 	modelCatalogPath := strings.TrimSpace(opts.modelCatalogPath)
-	if modelCatalogPath == "" {
-		modelCatalogPath = parsed.ProfileString(profileName, codexRootModelCatalogJSONKey)
-	}
 
 	profileLines := []string{}
 	if model != "" {

--- a/cmd/launch/codex.go
+++ b/cmd/launch/codex.go
@@ -1,14 +1,21 @@
 package launch
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
+	"strconv"
 	"strings"
 
+	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/cmd/internal/fileutil"
 	"github.com/ollama/ollama/envconfig"
+	"github.com/ollama/ollama/types/model"
 	"github.com/pelletier/go-toml/v2"
 	"golang.org/x/mod/semver"
 )
@@ -42,7 +49,7 @@ func (c *Codex) Run(model string, args []string) error {
 		return err
 	}
 
-	if err := ensureCodexConfig(); err != nil {
+	if err := ensureCodexConfig(model); err != nil {
 		return fmt.Errorf("failed to configure codex: %w", err)
 	}
 
@@ -56,9 +63,9 @@ func (c *Codex) Run(model string, args []string) error {
 	return cmd.Run()
 }
 
-// ensureCodexConfig writes a [profiles.ollama-launch] section to ~/.codex/config.toml
-// with openai_base_url pointing to the local Ollama server.
-func ensureCodexConfig() error {
+// ensureCodexConfig writes a Codex profile and model catalog so Codex uses the
+// local Ollama server and has model metadata available.
+func ensureCodexConfig(modelName string) error {
 	configPath, err := codexConfigPath()
 	if err != nil {
 		return err
@@ -67,7 +74,13 @@ func ensureCodexConfig() error {
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
 		return err
 	}
-	return writeCodexProfile(configPath)
+
+	catalogPath := filepath.Join(filepath.Dir(configPath), "model.json")
+	if err := writeCodexModelCatalog(catalogPath, modelName); err != nil {
+		return err
+	}
+
+	return writeCodexProfile(configPath, catalogPath)
 }
 
 func codexConfigPath() (string, error) {
@@ -80,10 +93,14 @@ func codexConfigPath() (string, error) {
 
 // writeCodexProfile ensures ~/.codex/config.toml has the ollama-launch profile
 // and model provider sections with the correct base URL.
-func writeCodexProfile(configPath string) error {
-	return writeCodexLaunchProfile(configPath, codexLaunchProfileOptions{
+func writeCodexProfile(configPath string, modelCatalogPath ...string) error {
+	opts := codexLaunchProfileOptions{
 		forceAPIAuth: true,
-	})
+	}
+	if len(modelCatalogPath) > 0 {
+		opts.modelCatalogPath = modelCatalogPath[0]
+	}
+	return writeCodexLaunchProfile(configPath, opts)
 }
 
 type codexLaunchProfileOptions struct {
@@ -536,6 +553,110 @@ func codexRootLineHasKey(line, key string) bool {
 	}
 	_, ok := cfg[key]
 	return ok
+}
+
+func writeCodexModelCatalog(catalogPath, modelName string) error {
+	entry := buildCodexModelEntry(modelName)
+
+	catalog := map[string]any{
+		"models": []any{entry},
+	}
+
+	data, err := json.MarshalIndent(catalog, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(catalogPath, data, 0o644)
+}
+
+func buildCodexModelEntry(modelName string) map[string]any {
+	contextWindow := 0
+	hasVision := false
+	hasThinking := false
+	systemPrompt := ""
+
+	if l, ok := lookupCloudModelLimit(modelName); ok {
+		contextWindow = l.Context
+	}
+
+	client := api.NewClient(envconfig.Host(), http.DefaultClient)
+	resp, err := client.Show(context.Background(), &api.ShowRequest{Model: modelName})
+	if err == nil {
+		systemPrompt = resp.System
+		if slices.Contains(resp.Capabilities, model.CapabilityVision) {
+			hasVision = true
+		}
+		if slices.Contains(resp.Capabilities, model.CapabilityThinking) {
+			hasThinking = true
+		}
+
+		if !isCloudModelName(modelName) {
+			if n, ok := modelInfoContextLength(resp.ModelInfo); ok {
+				contextWindow = n
+			}
+			if resp.Details.Format != "safetensors" {
+				if ctxLen := envconfig.ContextLength(); ctxLen > 0 {
+					contextWindow = int(ctxLen)
+				}
+				if numCtx := parseNumCtx(resp.Parameters); numCtx > 0 {
+					contextWindow = numCtx
+				}
+			}
+		}
+	}
+
+	modalities := []string{"text"}
+	if hasVision {
+		modalities = append(modalities, "image")
+	}
+
+	reasoningLevels := []any{}
+	if hasThinking {
+		reasoningLevels = []any{
+			map[string]any{"effort": "low", "description": "Fast responses with lighter reasoning"},
+			map[string]any{"effort": "medium", "description": "Balances speed and reasoning depth"},
+			map[string]any{"effort": "high", "description": "Greater reasoning depth for complex problems"},
+		}
+	}
+
+	truncationMode := "bytes"
+	if isCloudModelName(modelName) {
+		truncationMode = "tokens"
+	}
+
+	return map[string]any{
+		"slug":                         modelName,
+		"display_name":                 modelName,
+		"context_window":               contextWindow,
+		"apply_patch_tool_type":        "function",
+		"shell_type":                   "default",
+		"visibility":                   "list",
+		"supported_in_api":             true,
+		"priority":                     0,
+		"truncation_policy":            map[string]any{"mode": truncationMode, "limit": 10000},
+		"input_modalities":             modalities,
+		"base_instructions":            systemPrompt,
+		"support_verbosity":            true,
+		"default_verbosity":            "low",
+		"supports_parallel_tool_calls": false,
+		"supports_reasoning_summaries": hasThinking,
+		"supported_reasoning_levels":   reasoningLevels,
+		"experimental_supported_tools": []any{},
+	}
+}
+
+func parseNumCtx(parameters string) int {
+	for _, line := range strings.Split(parameters, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 2 && fields[0] == "num_ctx" {
+			if v, err := strconv.ParseFloat(fields[1], 64); err == nil {
+				return int(v)
+			}
+		}
+	}
+
+	return 0
 }
 
 func checkCodexVersion() error {

--- a/cmd/launch/codex.go
+++ b/cmd/launch/codex.go
@@ -559,9 +559,14 @@ func codexRootLineHasKey(line, key string) bool {
 func writeCodexModelCatalog(catalogPath, modelName string) error {
 	entry := buildCodexModelEntry(modelName)
 
-	catalog := map[string]any{
-		"models": []any{entry},
+	catalog := map[string]any{}
+	if content, err := os.ReadFile(catalogPath); err == nil {
+		if err := json.Unmarshal(content, &catalog); err != nil {
+			catalog = map[string]any{}
+		}
 	}
+
+	catalog["models"] = mergeCodexModelEntries(catalog["models"], entry)
 
 	data, err := json.MarshalIndent(catalog, "", "  ")
 	if err != nil {
@@ -569,6 +574,32 @@ func writeCodexModelCatalog(catalogPath, modelName string) error {
 	}
 
 	return os.WriteFile(catalogPath, data, 0o644)
+}
+
+func mergeCodexModelEntries(existing any, entry map[string]any) []any {
+	models, _ := existing.([]any)
+	merged := make([]any, 0, len(models)+1)
+	replaced := false
+	slug, _ := entry["slug"].(string)
+
+	for _, model := range models {
+		current, ok := model.(map[string]any)
+		if !ok {
+			continue
+		}
+		if currentSlug, _ := current["slug"].(string); currentSlug == slug {
+			merged = append(merged, entry)
+			replaced = true
+			continue
+		}
+		merged = append(merged, current)
+	}
+
+	if !replaced {
+		merged = append(merged, entry)
+	}
+
+	return merged
 }
 
 func buildCodexModelEntry(modelName string) map[string]any {

--- a/cmd/launch/codex.go
+++ b/cmd/launch/codex.go
@@ -36,8 +36,11 @@ const (
 	codexRootModelCatalogJSONKey = "model_catalog_json"
 )
 
-func (c *Codex) args(model string, extra []string) []string {
+func (c *Codex) args(model, modelCatalogPath string, extra []string) []string {
 	args := []string{"--profile", codexProfileName}
+	if modelCatalogPath != "" {
+		args = append(args, "-c", fmt.Sprintf("%s=%q", codexRootModelCatalogJSONKey, modelCatalogPath))
+	}
 	if model != "" {
 		args = append(args, "-m", model)
 	}
@@ -54,7 +57,12 @@ func (c *Codex) Run(model string, args []string) error {
 		return fmt.Errorf("failed to configure codex: %w", err)
 	}
 
-	cmd := exec.Command("codex", c.args(model, args)...)
+	catalogPath, err := codexModelCatalogPath()
+	if err != nil {
+		return fmt.Errorf("failed to configure codex: %w", err)
+	}
+
+	cmd := exec.Command("codex", c.args(model, catalogPath, args)...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -77,7 +85,7 @@ func ensureCodexConfig(modelName string) error {
 		return err
 	}
 
-	catalogPath := filepath.Join(codexDir, "model.json")
+	catalogPath := codexModelCatalogPathForConfig(configPath)
 	if err := writeCodexModelCatalog(catalogPath, modelName); err != nil {
 		return err
 	}
@@ -91,6 +99,18 @@ func codexConfigPath() (string, error) {
 		return "", err
 	}
 	return filepath.Join(home, ".codex", "config.toml"), nil
+}
+
+func codexModelCatalogPath() (string, error) {
+	configPath, err := codexConfigPath()
+	if err != nil {
+		return "", err
+	}
+	return codexModelCatalogPathForConfig(configPath), nil
+}
+
+func codexModelCatalogPathForConfig(configPath string) string {
+	return filepath.Join(filepath.Dir(configPath), "model.json")
 }
 
 // writeCodexProfile ensures ~/.codex/config.toml has the ollama-launch profile

--- a/cmd/launch/codex.go
+++ b/cmd/launch/codex.go
@@ -26,8 +26,9 @@ type Codex struct{}
 func (c *Codex) String() string { return "Codex" }
 
 const (
-	codexProfileName  = "ollama-launch"
-	codexProviderName = "Ollama"
+	codexProfileName     = "ollama-launch"
+	codexProviderName    = "Ollama"
+	codexCatalogFileName = "ollama-launch-models.json"
 
 	codexRootProfileKey          = "profile"
 	codexRootModelKey            = "model"
@@ -75,7 +76,7 @@ func ensureCodexConfig(modelName string) error {
 		return err
 	}
 
-	catalogPath := filepath.Join(filepath.Dir(configPath), "model.json")
+	catalogPath := filepath.Join(filepath.Dir(configPath), codexCatalogFileName)
 	if err := writeCodexModelCatalog(catalogPath, modelName); err != nil {
 		return err
 	}

--- a/cmd/launch/codex.go
+++ b/cmd/launch/codex.go
@@ -26,8 +26,9 @@ type Codex struct{}
 func (c *Codex) String() string { return "Codex" }
 
 const (
-	codexProfileName  = "ollama-launch"
-	codexProviderName = "Ollama"
+	codexProfileName           = "ollama-launch"
+	codexProviderName          = "Ollama"
+	codexFallbackContextWindow = 128_000
 
 	codexRootProfileKey          = "profile"
 	codexRootModelKey            = "model"
@@ -572,9 +573,8 @@ func writeCodexModelCatalog(catalogPath, modelName string) error {
 }
 
 func buildCodexModelEntry(modelName string) map[string]any {
-	contextWindow := 0
+	contextWindow := codexFallbackContextWindow
 	hasVision := false
-	hasThinking := false
 	systemPrompt := ""
 
 	if l, ok := lookupCloudModelLimit(modelName); ok {
@@ -587,9 +587,6 @@ func buildCodexModelEntry(modelName string) map[string]any {
 		systemPrompt = resp.System
 		if slices.Contains(resp.Capabilities, model.CapabilityVision) {
 			hasVision = true
-		}
-		if slices.Contains(resp.Capabilities, model.CapabilityThinking) {
-			hasThinking = true
 		}
 
 		if !isCloudModelName(modelName) {
@@ -612,15 +609,6 @@ func buildCodexModelEntry(modelName string) map[string]any {
 		modalities = append(modalities, "image")
 	}
 
-	reasoningLevels := []any{}
-	if hasThinking {
-		reasoningLevels = []any{
-			map[string]any{"effort": "low", "description": "Fast responses with lighter reasoning"},
-			map[string]any{"effort": "medium", "description": "Balances speed and reasoning depth"},
-			map[string]any{"effort": "high", "description": "Greater reasoning depth for complex problems"},
-		}
-	}
-
 	truncationMode := "bytes"
 	if isCloudModelName(modelName) {
 		truncationMode = "tokens"
@@ -641,8 +629,8 @@ func buildCodexModelEntry(modelName string) map[string]any {
 		"support_verbosity":            true,
 		"default_verbosity":            "low",
 		"supports_parallel_tool_calls": false,
-		"supports_reasoning_summaries": hasThinking,
-		"supported_reasoning_levels":   reasoningLevels,
+		"supports_reasoning_summaries": false,
+		"supported_reasoning_levels":   []any{},
 		"experimental_supported_tools": []any{},
 	}
 }

--- a/cmd/launch/codex_test.go
+++ b/cmd/launch/codex_test.go
@@ -553,7 +553,17 @@ func TestBuildCodexModelEntryContextWindow(t *testing.T) {
 			wantContext:   262144,
 		},
 		{
-			name:      "vision and thinking capabilities",
+			name:      "unknown cloud model uses fallback context",
+			modelName: "deepseek-v4-pro:cloud",
+			showResponse: `{
+				"model_info": {"deepseek.context_length": 131072},
+				"details": {"format": "gguf"}
+			}`,
+			envContextLen: "64000",
+			wantContext:   codexFallbackContextWindow,
+		},
+		{
+			name:      "vision capability without reasoning advertisement",
 			modelName: "llama3.2",
 			showResponse: `{
 				"model_info": {"llama.context_length": 131072},
@@ -600,14 +610,17 @@ func TestBuildCodexModelEntryContextWindow(t *testing.T) {
 				t.Errorf("context_window = %d, want %d", gotContext, tt.wantContext)
 			}
 
-			if tt.name == "vision and thinking capabilities" {
+			if tt.name == "vision capability without reasoning advertisement" {
 				modalities, _ := entry["input_modalities"].([]string)
 				if !slices.Contains(modalities, "image") {
 					t.Error("expected image in input_modalities")
 				}
 				levels, _ := entry["supported_reasoning_levels"].([]any)
-				if len(levels) == 0 {
-					t.Error("expected non-empty supported_reasoning_levels")
+				if len(levels) != 0 {
+					t.Errorf("supported_reasoning_levels length = %d, want 0", len(levels))
+				}
+				if got, _ := entry["supports_reasoning_summaries"].(bool); got {
+					t.Error("supports_reasoning_summaries = true, want false")
 				}
 			}
 

--- a/cmd/launch/codex_test.go
+++ b/cmd/launch/codex_test.go
@@ -43,7 +43,7 @@ func TestWriteCodexProfile(t *testing.T) {
 	t.Run("creates new file when none exists", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		configPath := filepath.Join(tmpDir, "config.toml")
-		catalogPath := filepath.Join(tmpDir, "model.json")
+		catalogPath := filepath.Join(tmpDir, codexCatalogFileName)
 
 		if err := writeCodexProfile(configPath, catalogPath); err != nil {
 			t.Fatal(err)
@@ -87,7 +87,7 @@ func TestWriteCodexProfile(t *testing.T) {
 	t.Run("appends profile to existing file without profile", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		configPath := filepath.Join(tmpDir, "config.toml")
-		catalogPath := filepath.Join(tmpDir, "model.json")
+		catalogPath := filepath.Join(tmpDir, codexCatalogFileName)
 		existing := "[some_other_section]\nkey = \"value\"\n"
 		os.WriteFile(configPath, []byte(existing), 0o644)
 
@@ -109,7 +109,7 @@ func TestWriteCodexProfile(t *testing.T) {
 	t.Run("replaces existing profile section", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		configPath := filepath.Join(tmpDir, "config.toml")
-		catalogPath := filepath.Join(tmpDir, "model.json")
+		catalogPath := filepath.Join(tmpDir, codexCatalogFileName)
 		existing := "[profiles.ollama-launch]\nopenai_base_url = \"http://old:1234/v1/\"\n\n[model_providers.ollama-launch]\nname = \"Ollama\"\nbase_url = \"http://old:1234/v1/\"\n"
 		os.WriteFile(configPath, []byte(existing), 0o644)
 
@@ -278,7 +278,7 @@ func TestWriteCodexProfile(t *testing.T) {
 	t.Run("replaces profile while preserving following sections", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		configPath := filepath.Join(tmpDir, "config.toml")
-		catalogPath := filepath.Join(tmpDir, "model.json")
+		catalogPath := filepath.Join(tmpDir, codexCatalogFileName)
 		existing := "[profiles.ollama-launch]\nopenai_base_url = \"http://old:1234/v1/\"\n[another_section]\nfoo = \"bar\"\n"
 		os.WriteFile(configPath, []byte(existing), 0o644)
 
@@ -303,7 +303,7 @@ func TestWriteCodexProfile(t *testing.T) {
 	t.Run("appends newline to file not ending with newline", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		configPath := filepath.Join(tmpDir, "config.toml")
-		catalogPath := filepath.Join(tmpDir, "model.json")
+		catalogPath := filepath.Join(tmpDir, codexCatalogFileName)
 		existing := "[other]\nkey = \"val\""
 		os.WriteFile(configPath, []byte(existing), 0o644)
 
@@ -327,7 +327,7 @@ func TestWriteCodexProfile(t *testing.T) {
 		t.Setenv("OLLAMA_HOST", "http://myhost:9999")
 		tmpDir := t.TempDir()
 		configPath := filepath.Join(tmpDir, "config.toml")
-		catalogPath := filepath.Join(tmpDir, "model.json")
+		catalogPath := filepath.Join(tmpDir, codexCatalogFileName)
 
 		if err := writeCodexProfile(configPath, catalogPath); err != nil {
 			t.Fatal(err)
@@ -385,7 +385,7 @@ func TestEnsureCodexConfig(t *testing.T) {
 			t.Error("missing openai_base_url key")
 		}
 
-		catalogPath := filepath.Join(tmpDir, ".codex", "model.json")
+		catalogPath := filepath.Join(tmpDir, ".codex", codexCatalogFileName)
 		data, err = os.ReadFile(catalogPath)
 		if err != nil {
 			t.Fatalf("model.json not created: %v", err)
@@ -415,6 +415,37 @@ func TestEnsureCodexConfig(t *testing.T) {
 		}
 		if strings.Count(content, "[model_providers.ollama-launch]") != 1 {
 			t.Errorf("expected exactly one [model_providers.ollama-launch] section after two calls, got %d", strings.Count(content, "[model_providers.ollama-launch]"))
+		}
+	})
+
+	t.Run("does not overwrite user's default model catalog", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setTestHome(t, tmpDir)
+
+		userCatalogPath := filepath.Join(tmpDir, ".codex", "model.json")
+		if err := os.MkdirAll(filepath.Dir(userCatalogPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		original := `{"models":[{"slug":"user-custom"}]}`
+		if err := os.WriteFile(userCatalogPath, []byte(original), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := ensureCodexConfig("llama3.2"); err != nil {
+			t.Fatal(err)
+		}
+
+		data, err := os.ReadFile(userCatalogPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(data) != original {
+			t.Errorf("default model catalog was modified: got %q want %q", string(data), original)
+		}
+
+		ollamaCatalogPath := filepath.Join(tmpDir, ".codex", codexCatalogFileName)
+		if _, err := os.Stat(ollamaCatalogPath); err != nil {
+			t.Fatalf("ollama catalog not created: %v", err)
 		}
 	})
 }

--- a/cmd/launch/codex_test.go
+++ b/cmd/launch/codex_test.go
@@ -448,6 +448,95 @@ func TestEnsureCodexConfig(t *testing.T) {
 			t.Fatalf("ollama catalog not created: %v", err)
 		}
 	})
+
+	t.Run("merges additional models into ollama catalog", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setTestHome(t, tmpDir)
+
+		if err := ensureCodexConfig("llama3.2"); err != nil {
+			t.Fatal(err)
+		}
+		if err := ensureCodexConfig("qwen3.5"); err != nil {
+			t.Fatal(err)
+		}
+
+		catalogPath := filepath.Join(tmpDir, ".codex", codexCatalogFileName)
+		data, err := os.ReadFile(catalogPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var catalog struct {
+			Models []struct {
+				Slug string `json:"slug"`
+			} `json:"models"`
+		}
+		if err := json.Unmarshal(data, &catalog); err != nil {
+			t.Fatalf("failed to parse catalog: %v", err)
+		}
+
+		if len(catalog.Models) != 2 {
+			t.Fatalf("expected 2 merged models, got %d", len(catalog.Models))
+		}
+		if catalog.Models[0].Slug != "llama3.2" {
+			t.Fatalf("first merged model = %q, want %q", catalog.Models[0].Slug, "llama3.2")
+		}
+		if catalog.Models[1].Slug != "qwen3.5" {
+			t.Fatalf("second merged model = %q, want %q", catalog.Models[1].Slug, "qwen3.5")
+		}
+	})
+
+	t.Run("refreshes existing model entry in place", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setTestHome(t, tmpDir)
+
+		catalogPath := filepath.Join(tmpDir, ".codex", codexCatalogFileName)
+		if err := os.MkdirAll(filepath.Dir(catalogPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		original := `{
+			"models": [
+				{"slug":"llama3.2","display_name":"stale","context_window":1},
+				{"slug":"qwen3.5","display_name":"keep","context_window":2}
+			]
+		}`
+		if err := os.WriteFile(catalogPath, []byte(original), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := ensureCodexConfig("llama3.2"); err != nil {
+			t.Fatal(err)
+		}
+
+		data, err := os.ReadFile(catalogPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var catalog struct {
+			Models []struct {
+				Slug          string `json:"slug"`
+				DisplayName   string `json:"display_name"`
+				ContextWindow int    `json:"context_window"`
+			} `json:"models"`
+		}
+		if err := json.Unmarshal(data, &catalog); err != nil {
+			t.Fatalf("failed to parse catalog: %v", err)
+		}
+
+		if len(catalog.Models) != 2 {
+			t.Fatalf("expected 2 models after refresh, got %d", len(catalog.Models))
+		}
+		if catalog.Models[0].Slug != "llama3.2" {
+			t.Fatalf("first refreshed model = %q, want %q", catalog.Models[0].Slug, "llama3.2")
+		}
+		if catalog.Models[0].DisplayName != "llama3.2" {
+			t.Fatalf("refreshed display_name = %q, want %q", catalog.Models[0].DisplayName, "llama3.2")
+		}
+		if catalog.Models[1].Slug != "qwen3.5" {
+			t.Fatalf("preserved second model = %q, want %q", catalog.Models[1].Slug, "qwen3.5")
+		}
+	})
 }
 
 func assertBackupContains(t *testing.T, pattern, marker string) {

--- a/cmd/launch/codex_test.go
+++ b/cmd/launch/codex_test.go
@@ -16,7 +16,6 @@ import (
 
 func TestCodexArgs(t *testing.T) {
 	c := &Codex{}
-	catalogPath := "/tmp/ollama-launch-models.json"
 
 	tests := []struct {
 		name  string
@@ -24,15 +23,15 @@ func TestCodexArgs(t *testing.T) {
 		args  []string
 		want  []string
 	}{
-		{"with model", "llama3.2", nil, []string{"--profile", "ollama-launch", "-c", `model_catalog_json="/tmp/ollama-launch-models.json"`, "-m", "llama3.2"}},
-		{"empty model", "", nil, []string{"--profile", "ollama-launch", "-c", `model_catalog_json="/tmp/ollama-launch-models.json"`}},
-		{"with model and extra args", "qwen3.5", []string{"-p", "myprofile"}, []string{"--profile", "ollama-launch", "-c", `model_catalog_json="/tmp/ollama-launch-models.json"`, "-m", "qwen3.5", "-p", "myprofile"}},
-		{"with sandbox flag", "llama3.2", []string{"--sandbox", "workspace-write"}, []string{"--profile", "ollama-launch", "-c", `model_catalog_json="/tmp/ollama-launch-models.json"`, "-m", "llama3.2", "--sandbox", "workspace-write"}},
+		{"with model", "llama3.2", nil, []string{"--profile", "ollama-launch", "-m", "llama3.2"}},
+		{"empty model", "", nil, []string{"--profile", "ollama-launch"}},
+		{"with model and extra args", "qwen3.5", []string{"-p", "myprofile"}, []string{"--profile", "ollama-launch", "-m", "qwen3.5", "-p", "myprofile"}},
+		{"with sandbox flag", "llama3.2", []string{"--sandbox", "workspace-write"}, []string{"--profile", "ollama-launch", "-m", "llama3.2", "--sandbox", "workspace-write"}},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := c.args(tt.model, catalogPath, tt.args)
+			got := c.args(tt.model, tt.args)
 			if !slices.Equal(got, tt.want) {
 				t.Errorf("args(%q, %v) = %v, want %v", tt.model, tt.args, got, tt.want)
 			}
@@ -44,8 +43,9 @@ func TestWriteCodexProfile(t *testing.T) {
 	t.Run("creates new file when none exists", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		configPath := filepath.Join(tmpDir, "config.toml")
+		catalogPath := filepath.Join(tmpDir, "model.json")
 
-		if err := writeCodexProfile(configPath); err != nil {
+		if err := writeCodexProfile(configPath, catalogPath); err != nil {
 			t.Fatal(err)
 		}
 
@@ -70,6 +70,9 @@ func TestWriteCodexProfile(t *testing.T) {
 		if !strings.Contains(content, `model_provider = "ollama-launch"`) {
 			t.Error("missing model_provider key")
 		}
+		if !strings.Contains(content, fmt.Sprintf("model_catalog_json = %q", catalogPath)) {
+			t.Error("missing model_catalog_json key")
+		}
 		if !strings.Contains(content, "[model_providers.ollama-launch]") {
 			t.Error("missing [model_providers.ollama-launch] section")
 		}
@@ -84,10 +87,11 @@ func TestWriteCodexProfile(t *testing.T) {
 	t.Run("appends profile to existing file without profile", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		configPath := filepath.Join(tmpDir, "config.toml")
+		catalogPath := filepath.Join(tmpDir, "model.json")
 		existing := "[some_other_section]\nkey = \"value\"\n"
 		os.WriteFile(configPath, []byte(existing), 0o644)
 
-		if err := writeCodexProfile(configPath); err != nil {
+		if err := writeCodexProfile(configPath, catalogPath); err != nil {
 			t.Fatal(err)
 		}
 
@@ -105,10 +109,11 @@ func TestWriteCodexProfile(t *testing.T) {
 	t.Run("replaces existing profile section", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		configPath := filepath.Join(tmpDir, "config.toml")
+		catalogPath := filepath.Join(tmpDir, "model.json")
 		existing := "[profiles.ollama-launch]\nopenai_base_url = \"http://old:1234/v1/\"\n\n[model_providers.ollama-launch]\nname = \"Ollama\"\nbase_url = \"http://old:1234/v1/\"\n"
 		os.WriteFile(configPath, []byte(existing), 0o644)
 
-		if err := writeCodexProfile(configPath); err != nil {
+		if err := writeCodexProfile(configPath, catalogPath); err != nil {
 			t.Fatal(err)
 		}
 
@@ -273,10 +278,11 @@ func TestWriteCodexProfile(t *testing.T) {
 	t.Run("replaces profile while preserving following sections", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		configPath := filepath.Join(tmpDir, "config.toml")
+		catalogPath := filepath.Join(tmpDir, "model.json")
 		existing := "[profiles.ollama-launch]\nopenai_base_url = \"http://old:1234/v1/\"\n[another_section]\nfoo = \"bar\"\n"
 		os.WriteFile(configPath, []byte(existing), 0o644)
 
-		if err := writeCodexProfile(configPath); err != nil {
+		if err := writeCodexProfile(configPath, catalogPath); err != nil {
 			t.Fatal(err)
 		}
 
@@ -297,10 +303,11 @@ func TestWriteCodexProfile(t *testing.T) {
 	t.Run("appends newline to file not ending with newline", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		configPath := filepath.Join(tmpDir, "config.toml")
+		catalogPath := filepath.Join(tmpDir, "model.json")
 		existing := "[other]\nkey = \"val\""
 		os.WriteFile(configPath, []byte(existing), 0o644)
 
-		if err := writeCodexProfile(configPath); err != nil {
+		if err := writeCodexProfile(configPath, catalogPath); err != nil {
 			t.Fatal(err)
 		}
 
@@ -320,8 +327,9 @@ func TestWriteCodexProfile(t *testing.T) {
 		t.Setenv("OLLAMA_HOST", "http://myhost:9999")
 		tmpDir := t.TempDir()
 		configPath := filepath.Join(tmpDir, "config.toml")
+		catalogPath := filepath.Join(tmpDir, "model.json")
 
-		if err := writeCodexProfile(configPath); err != nil {
+		if err := writeCodexProfile(configPath, catalogPath); err != nil {
 			t.Fatal(err)
 		}
 
@@ -359,8 +367,7 @@ func TestEnsureCodexConfig(t *testing.T) {
 		tmpDir := t.TempDir()
 		setTestHome(t, tmpDir)
 
-		catalogPath, err := ensureCodexConfig("llama3.2")
-		if err != nil {
+		if err := ensureCodexConfig("llama3.2"); err != nil {
 			t.Fatal(err)
 		}
 
@@ -377,12 +384,8 @@ func TestEnsureCodexConfig(t *testing.T) {
 		if !strings.Contains(content, "openai_base_url") {
 			t.Error("missing openai_base_url key")
 		}
-		if strings.Contains(content, "model_catalog_json") {
-			t.Error("config.toml should not persist model_catalog_json")
-		}
-		if catalogPath != filepath.Join(tmpDir, ".codex", codexCatalogFileName) {
-			t.Fatalf("catalog path = %q, want %q", catalogPath, filepath.Join(tmpDir, ".codex", codexCatalogFileName))
-		}
+
+		catalogPath := filepath.Join(tmpDir, ".codex", "model.json")
 		data, err = os.ReadFile(catalogPath)
 		if err != nil {
 			t.Fatalf("model.json not created: %v", err)
@@ -396,10 +399,10 @@ func TestEnsureCodexConfig(t *testing.T) {
 		tmpDir := t.TempDir()
 		setTestHome(t, tmpDir)
 
-		if _, err := ensureCodexConfig("llama3.2"); err != nil {
+		if err := ensureCodexConfig("llama3.2"); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := ensureCodexConfig("llama3.2"); err != nil {
+		if err := ensureCodexConfig("llama3.2"); err != nil {
 			t.Fatal(err)
 		}
 
@@ -412,126 +415,6 @@ func TestEnsureCodexConfig(t *testing.T) {
 		}
 		if strings.Count(content, "[model_providers.ollama-launch]") != 1 {
 			t.Errorf("expected exactly one [model_providers.ollama-launch] section after two calls, got %d", strings.Count(content, "[model_providers.ollama-launch]"))
-		}
-	})
-
-	t.Run("does not overwrite user's default model catalog", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		setTestHome(t, tmpDir)
-
-		userCatalogPath := filepath.Join(tmpDir, ".codex", "model.json")
-		if err := os.MkdirAll(filepath.Dir(userCatalogPath), 0o755); err != nil {
-			t.Fatal(err)
-		}
-		original := `{"models":[{"slug":"user-custom"}]}`
-		if err := os.WriteFile(userCatalogPath, []byte(original), 0o644); err != nil {
-			t.Fatal(err)
-		}
-
-		if _, err := ensureCodexConfig("llama3.2"); err != nil {
-			t.Fatal(err)
-		}
-
-		data, err := os.ReadFile(userCatalogPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if string(data) != original {
-			t.Errorf("default model catalog was modified: got %q want %q", string(data), original)
-		}
-
-		ollamaCatalogPath := filepath.Join(tmpDir, ".codex", codexCatalogFileName)
-		if _, err := os.Stat(ollamaCatalogPath); err != nil {
-			t.Fatalf("ollama catalog not created: %v", err)
-		}
-	})
-
-	t.Run("merges additional models into ollama catalog", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		setTestHome(t, tmpDir)
-
-		if _, err := ensureCodexConfig("llama3.2"); err != nil {
-			t.Fatal(err)
-		}
-		if _, err := ensureCodexConfig("qwen3.5"); err != nil {
-			t.Fatal(err)
-		}
-
-		catalogPath := filepath.Join(tmpDir, ".codex", codexCatalogFileName)
-		data, err := os.ReadFile(catalogPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		var catalog struct {
-			Models []struct {
-				Slug string `json:"slug"`
-			} `json:"models"`
-		}
-		if err := json.Unmarshal(data, &catalog); err != nil {
-			t.Fatalf("failed to parse catalog: %v", err)
-		}
-
-		if len(catalog.Models) != 2 {
-			t.Fatalf("expected 2 merged models, got %d", len(catalog.Models))
-		}
-		if catalog.Models[0].Slug != "llama3.2" {
-			t.Fatalf("first merged model = %q, want %q", catalog.Models[0].Slug, "llama3.2")
-		}
-		if catalog.Models[1].Slug != "qwen3.5" {
-			t.Fatalf("second merged model = %q, want %q", catalog.Models[1].Slug, "qwen3.5")
-		}
-	})
-
-	t.Run("refreshes existing model entry in place", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		setTestHome(t, tmpDir)
-
-		catalogPath := filepath.Join(tmpDir, ".codex", codexCatalogFileName)
-		if err := os.MkdirAll(filepath.Dir(catalogPath), 0o755); err != nil {
-			t.Fatal(err)
-		}
-		original := `{
-			"models": [
-				{"slug":"llama3.2","display_name":"stale","context_window":1},
-				{"slug":"qwen3.5","display_name":"keep","context_window":2}
-			]
-		}`
-		if err := os.WriteFile(catalogPath, []byte(original), 0o644); err != nil {
-			t.Fatal(err)
-		}
-
-		if _, err := ensureCodexConfig("llama3.2"); err != nil {
-			t.Fatal(err)
-		}
-
-		data, err := os.ReadFile(catalogPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		var catalog struct {
-			Models []struct {
-				Slug          string `json:"slug"`
-				DisplayName   string `json:"display_name"`
-				ContextWindow int    `json:"context_window"`
-			} `json:"models"`
-		}
-		if err := json.Unmarshal(data, &catalog); err != nil {
-			t.Fatalf("failed to parse catalog: %v", err)
-		}
-
-		if len(catalog.Models) != 2 {
-			t.Fatalf("expected 2 models after refresh, got %d", len(catalog.Models))
-		}
-		if catalog.Models[0].Slug != "llama3.2" {
-			t.Fatalf("first refreshed model = %q, want %q", catalog.Models[0].Slug, "llama3.2")
-		}
-		if catalog.Models[0].DisplayName != "llama3.2" {
-			t.Fatalf("refreshed display_name = %q, want %q", catalog.Models[0].DisplayName, "llama3.2")
-		}
-		if catalog.Models[1].Slug != "qwen3.5" {
-			t.Fatalf("preserved second model = %q, want %q", catalog.Models[1].Slug, "qwen3.5")
 		}
 	})
 }

--- a/cmd/launch/codex_test.go
+++ b/cmd/launch/codex_test.go
@@ -16,6 +16,8 @@ import (
 
 func TestCodexArgs(t *testing.T) {
 	c := &Codex{}
+	catalogPath := filepath.Join("tmp", "model.json")
+	catalogArg := fmt.Sprintf("%s=%q", codexRootModelCatalogJSONKey, catalogPath)
 
 	tests := []struct {
 		name  string
@@ -23,15 +25,15 @@ func TestCodexArgs(t *testing.T) {
 		args  []string
 		want  []string
 	}{
-		{"with model", "llama3.2", nil, []string{"--profile", "ollama-launch", "-m", "llama3.2"}},
-		{"empty model", "", nil, []string{"--profile", "ollama-launch"}},
-		{"with model and extra args", "qwen3.5", []string{"-p", "myprofile"}, []string{"--profile", "ollama-launch", "-m", "qwen3.5", "-p", "myprofile"}},
-		{"with sandbox flag", "llama3.2", []string{"--sandbox", "workspace-write"}, []string{"--profile", "ollama-launch", "-m", "llama3.2", "--sandbox", "workspace-write"}},
+		{"with model", "llama3.2", nil, []string{"--profile", "ollama-launch", "-c", catalogArg, "-m", "llama3.2"}},
+		{"empty model", "", nil, []string{"--profile", "ollama-launch", "-c", catalogArg}},
+		{"with model and extra args", "qwen3.5", []string{"-p", "myprofile"}, []string{"--profile", "ollama-launch", "-c", catalogArg, "-m", "qwen3.5", "-p", "myprofile"}},
+		{"with sandbox flag", "llama3.2", []string{"--sandbox", "workspace-write"}, []string{"--profile", "ollama-launch", "-c", catalogArg, "-m", "llama3.2", "--sandbox", "workspace-write"}},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := c.args(tt.model, tt.args)
+			got := c.args(tt.model, catalogPath, tt.args)
 			if !slices.Equal(got, tt.want) {
 				t.Errorf("args(%q, %v) = %v, want %v", tt.model, tt.args, got, tt.want)
 			}

--- a/cmd/launch/codex_test.go
+++ b/cmd/launch/codex_test.go
@@ -16,6 +16,7 @@ import (
 
 func TestCodexArgs(t *testing.T) {
 	c := &Codex{}
+	catalogPath := "/tmp/ollama-launch-models.json"
 
 	tests := []struct {
 		name  string
@@ -23,15 +24,15 @@ func TestCodexArgs(t *testing.T) {
 		args  []string
 		want  []string
 	}{
-		{"with model", "llama3.2", nil, []string{"--profile", "ollama-launch", "-m", "llama3.2"}},
-		{"empty model", "", nil, []string{"--profile", "ollama-launch"}},
-		{"with model and extra args", "qwen3.5", []string{"-p", "myprofile"}, []string{"--profile", "ollama-launch", "-m", "qwen3.5", "-p", "myprofile"}},
-		{"with sandbox flag", "llama3.2", []string{"--sandbox", "workspace-write"}, []string{"--profile", "ollama-launch", "-m", "llama3.2", "--sandbox", "workspace-write"}},
+		{"with model", "llama3.2", nil, []string{"--profile", "ollama-launch", "-c", `model_catalog_json="/tmp/ollama-launch-models.json"`, "-m", "llama3.2"}},
+		{"empty model", "", nil, []string{"--profile", "ollama-launch", "-c", `model_catalog_json="/tmp/ollama-launch-models.json"`}},
+		{"with model and extra args", "qwen3.5", []string{"-p", "myprofile"}, []string{"--profile", "ollama-launch", "-c", `model_catalog_json="/tmp/ollama-launch-models.json"`, "-m", "qwen3.5", "-p", "myprofile"}},
+		{"with sandbox flag", "llama3.2", []string{"--sandbox", "workspace-write"}, []string{"--profile", "ollama-launch", "-c", `model_catalog_json="/tmp/ollama-launch-models.json"`, "-m", "llama3.2", "--sandbox", "workspace-write"}},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := c.args(tt.model, tt.args)
+			got := c.args(tt.model, catalogPath, tt.args)
 			if !slices.Equal(got, tt.want) {
 				t.Errorf("args(%q, %v) = %v, want %v", tt.model, tt.args, got, tt.want)
 			}
@@ -43,9 +44,8 @@ func TestWriteCodexProfile(t *testing.T) {
 	t.Run("creates new file when none exists", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		configPath := filepath.Join(tmpDir, "config.toml")
-		catalogPath := filepath.Join(tmpDir, codexCatalogFileName)
 
-		if err := writeCodexProfile(configPath, catalogPath); err != nil {
+		if err := writeCodexProfile(configPath); err != nil {
 			t.Fatal(err)
 		}
 
@@ -70,9 +70,6 @@ func TestWriteCodexProfile(t *testing.T) {
 		if !strings.Contains(content, `model_provider = "ollama-launch"`) {
 			t.Error("missing model_provider key")
 		}
-		if !strings.Contains(content, fmt.Sprintf("model_catalog_json = %q", catalogPath)) {
-			t.Error("missing model_catalog_json key")
-		}
 		if !strings.Contains(content, "[model_providers.ollama-launch]") {
 			t.Error("missing [model_providers.ollama-launch] section")
 		}
@@ -87,11 +84,10 @@ func TestWriteCodexProfile(t *testing.T) {
 	t.Run("appends profile to existing file without profile", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		configPath := filepath.Join(tmpDir, "config.toml")
-		catalogPath := filepath.Join(tmpDir, codexCatalogFileName)
 		existing := "[some_other_section]\nkey = \"value\"\n"
 		os.WriteFile(configPath, []byte(existing), 0o644)
 
-		if err := writeCodexProfile(configPath, catalogPath); err != nil {
+		if err := writeCodexProfile(configPath); err != nil {
 			t.Fatal(err)
 		}
 
@@ -109,11 +105,10 @@ func TestWriteCodexProfile(t *testing.T) {
 	t.Run("replaces existing profile section", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		configPath := filepath.Join(tmpDir, "config.toml")
-		catalogPath := filepath.Join(tmpDir, codexCatalogFileName)
 		existing := "[profiles.ollama-launch]\nopenai_base_url = \"http://old:1234/v1/\"\n\n[model_providers.ollama-launch]\nname = \"Ollama\"\nbase_url = \"http://old:1234/v1/\"\n"
 		os.WriteFile(configPath, []byte(existing), 0o644)
 
-		if err := writeCodexProfile(configPath, catalogPath); err != nil {
+		if err := writeCodexProfile(configPath); err != nil {
 			t.Fatal(err)
 		}
 
@@ -278,11 +273,10 @@ func TestWriteCodexProfile(t *testing.T) {
 	t.Run("replaces profile while preserving following sections", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		configPath := filepath.Join(tmpDir, "config.toml")
-		catalogPath := filepath.Join(tmpDir, codexCatalogFileName)
 		existing := "[profiles.ollama-launch]\nopenai_base_url = \"http://old:1234/v1/\"\n[another_section]\nfoo = \"bar\"\n"
 		os.WriteFile(configPath, []byte(existing), 0o644)
 
-		if err := writeCodexProfile(configPath, catalogPath); err != nil {
+		if err := writeCodexProfile(configPath); err != nil {
 			t.Fatal(err)
 		}
 
@@ -303,11 +297,10 @@ func TestWriteCodexProfile(t *testing.T) {
 	t.Run("appends newline to file not ending with newline", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		configPath := filepath.Join(tmpDir, "config.toml")
-		catalogPath := filepath.Join(tmpDir, codexCatalogFileName)
 		existing := "[other]\nkey = \"val\""
 		os.WriteFile(configPath, []byte(existing), 0o644)
 
-		if err := writeCodexProfile(configPath, catalogPath); err != nil {
+		if err := writeCodexProfile(configPath); err != nil {
 			t.Fatal(err)
 		}
 
@@ -327,9 +320,8 @@ func TestWriteCodexProfile(t *testing.T) {
 		t.Setenv("OLLAMA_HOST", "http://myhost:9999")
 		tmpDir := t.TempDir()
 		configPath := filepath.Join(tmpDir, "config.toml")
-		catalogPath := filepath.Join(tmpDir, codexCatalogFileName)
 
-		if err := writeCodexProfile(configPath, catalogPath); err != nil {
+		if err := writeCodexProfile(configPath); err != nil {
 			t.Fatal(err)
 		}
 
@@ -367,7 +359,8 @@ func TestEnsureCodexConfig(t *testing.T) {
 		tmpDir := t.TempDir()
 		setTestHome(t, tmpDir)
 
-		if err := ensureCodexConfig("llama3.2"); err != nil {
+		catalogPath, err := ensureCodexConfig("llama3.2")
+		if err != nil {
 			t.Fatal(err)
 		}
 
@@ -384,8 +377,12 @@ func TestEnsureCodexConfig(t *testing.T) {
 		if !strings.Contains(content, "openai_base_url") {
 			t.Error("missing openai_base_url key")
 		}
-
-		catalogPath := filepath.Join(tmpDir, ".codex", codexCatalogFileName)
+		if strings.Contains(content, "model_catalog_json") {
+			t.Error("config.toml should not persist model_catalog_json")
+		}
+		if catalogPath != filepath.Join(tmpDir, ".codex", codexCatalogFileName) {
+			t.Fatalf("catalog path = %q, want %q", catalogPath, filepath.Join(tmpDir, ".codex", codexCatalogFileName))
+		}
 		data, err = os.ReadFile(catalogPath)
 		if err != nil {
 			t.Fatalf("model.json not created: %v", err)
@@ -399,10 +396,10 @@ func TestEnsureCodexConfig(t *testing.T) {
 		tmpDir := t.TempDir()
 		setTestHome(t, tmpDir)
 
-		if err := ensureCodexConfig("llama3.2"); err != nil {
+		if _, err := ensureCodexConfig("llama3.2"); err != nil {
 			t.Fatal(err)
 		}
-		if err := ensureCodexConfig("llama3.2"); err != nil {
+		if _, err := ensureCodexConfig("llama3.2"); err != nil {
 			t.Fatal(err)
 		}
 
@@ -431,7 +428,7 @@ func TestEnsureCodexConfig(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := ensureCodexConfig("llama3.2"); err != nil {
+		if _, err := ensureCodexConfig("llama3.2"); err != nil {
 			t.Fatal(err)
 		}
 
@@ -453,10 +450,10 @@ func TestEnsureCodexConfig(t *testing.T) {
 		tmpDir := t.TempDir()
 		setTestHome(t, tmpDir)
 
-		if err := ensureCodexConfig("llama3.2"); err != nil {
+		if _, err := ensureCodexConfig("llama3.2"); err != nil {
 			t.Fatal(err)
 		}
-		if err := ensureCodexConfig("qwen3.5"); err != nil {
+		if _, err := ensureCodexConfig("qwen3.5"); err != nil {
 			t.Fatal(err)
 		}
 
@@ -504,7 +501,7 @@ func TestEnsureCodexConfig(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := ensureCodexConfig("llama3.2"); err != nil {
+		if _, err := ensureCodexConfig("llama3.2"); err != nil {
 			t.Fatal(err)
 		}
 

--- a/cmd/launch/codex_test.go
+++ b/cmd/launch/codex_test.go
@@ -1,6 +1,10 @@
 package launch
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"slices"
@@ -39,8 +43,9 @@ func TestWriteCodexProfile(t *testing.T) {
 	t.Run("creates new file when none exists", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		configPath := filepath.Join(tmpDir, "config.toml")
+		catalogPath := filepath.Join(tmpDir, "model.json")
 
-		if err := writeCodexProfile(configPath); err != nil {
+		if err := writeCodexProfile(configPath, catalogPath); err != nil {
 			t.Fatal(err)
 		}
 
@@ -65,6 +70,9 @@ func TestWriteCodexProfile(t *testing.T) {
 		if !strings.Contains(content, `model_provider = "ollama-launch"`) {
 			t.Error("missing model_provider key")
 		}
+		if !strings.Contains(content, fmt.Sprintf("model_catalog_json = %q", catalogPath)) {
+			t.Error("missing model_catalog_json key")
+		}
 		if !strings.Contains(content, "[model_providers.ollama-launch]") {
 			t.Error("missing [model_providers.ollama-launch] section")
 		}
@@ -79,10 +87,11 @@ func TestWriteCodexProfile(t *testing.T) {
 	t.Run("appends profile to existing file without profile", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		configPath := filepath.Join(tmpDir, "config.toml")
+		catalogPath := filepath.Join(tmpDir, "model.json")
 		existing := "[some_other_section]\nkey = \"value\"\n"
 		os.WriteFile(configPath, []byte(existing), 0o644)
 
-		if err := writeCodexProfile(configPath); err != nil {
+		if err := writeCodexProfile(configPath, catalogPath); err != nil {
 			t.Fatal(err)
 		}
 
@@ -100,10 +109,11 @@ func TestWriteCodexProfile(t *testing.T) {
 	t.Run("replaces existing profile section", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		configPath := filepath.Join(tmpDir, "config.toml")
+		catalogPath := filepath.Join(tmpDir, "model.json")
 		existing := "[profiles.ollama-launch]\nopenai_base_url = \"http://old:1234/v1/\"\n\n[model_providers.ollama-launch]\nname = \"Ollama\"\nbase_url = \"http://old:1234/v1/\"\n"
 		os.WriteFile(configPath, []byte(existing), 0o644)
 
-		if err := writeCodexProfile(configPath); err != nil {
+		if err := writeCodexProfile(configPath, catalogPath); err != nil {
 			t.Fatal(err)
 		}
 
@@ -268,10 +278,11 @@ func TestWriteCodexProfile(t *testing.T) {
 	t.Run("replaces profile while preserving following sections", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		configPath := filepath.Join(tmpDir, "config.toml")
+		catalogPath := filepath.Join(tmpDir, "model.json")
 		existing := "[profiles.ollama-launch]\nopenai_base_url = \"http://old:1234/v1/\"\n[another_section]\nfoo = \"bar\"\n"
 		os.WriteFile(configPath, []byte(existing), 0o644)
 
-		if err := writeCodexProfile(configPath); err != nil {
+		if err := writeCodexProfile(configPath, catalogPath); err != nil {
 			t.Fatal(err)
 		}
 
@@ -292,10 +303,11 @@ func TestWriteCodexProfile(t *testing.T) {
 	t.Run("appends newline to file not ending with newline", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		configPath := filepath.Join(tmpDir, "config.toml")
+		catalogPath := filepath.Join(tmpDir, "model.json")
 		existing := "[other]\nkey = \"val\""
 		os.WriteFile(configPath, []byte(existing), 0o644)
 
-		if err := writeCodexProfile(configPath); err != nil {
+		if err := writeCodexProfile(configPath, catalogPath); err != nil {
 			t.Fatal(err)
 		}
 
@@ -315,8 +327,9 @@ func TestWriteCodexProfile(t *testing.T) {
 		t.Setenv("OLLAMA_HOST", "http://myhost:9999")
 		tmpDir := t.TempDir()
 		configPath := filepath.Join(tmpDir, "config.toml")
+		catalogPath := filepath.Join(tmpDir, "model.json")
 
-		if err := writeCodexProfile(configPath); err != nil {
+		if err := writeCodexProfile(configPath, catalogPath); err != nil {
 			t.Fatal(err)
 		}
 
@@ -354,7 +367,7 @@ func TestEnsureCodexConfig(t *testing.T) {
 		tmpDir := t.TempDir()
 		setTestHome(t, tmpDir)
 
-		if err := ensureCodexConfig(); err != nil {
+		if err := ensureCodexConfig("llama3.2"); err != nil {
 			t.Fatal(err)
 		}
 
@@ -371,16 +384,25 @@ func TestEnsureCodexConfig(t *testing.T) {
 		if !strings.Contains(content, "openai_base_url") {
 			t.Error("missing openai_base_url key")
 		}
+
+		catalogPath := filepath.Join(tmpDir, ".codex", "model.json")
+		data, err = os.ReadFile(catalogPath)
+		if err != nil {
+			t.Fatalf("model.json not created: %v", err)
+		}
+		if !strings.Contains(string(data), `"slug": "llama3.2"`) {
+			t.Error("missing model catalog entry for selected model")
+		}
 	})
 
 	t.Run("is idempotent", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		setTestHome(t, tmpDir)
 
-		if err := ensureCodexConfig(); err != nil {
+		if err := ensureCodexConfig("llama3.2"); err != nil {
 			t.Fatal(err)
 		}
-		if err := ensureCodexConfig(); err != nil {
+		if err := ensureCodexConfig("llama3.2"); err != nil {
 			t.Fatal(err)
 		}
 
@@ -413,4 +435,205 @@ func assertBackupContains(t *testing.T, pattern, marker string) {
 		}
 	}
 	t.Fatalf("backup matching %q with marker %q not found", pattern, marker)
+}
+
+func TestParseNumCtx(t *testing.T) {
+	tests := []struct {
+		name       string
+		parameters string
+		want       int
+	}{
+		{"num_ctx set", "num_ctx 8192", 8192},
+		{"num_ctx with other params", "temperature 0.7\nnum_ctx 4096\ntop_p 0.9", 4096},
+		{"no num_ctx", "temperature 0.7\ntop_p 0.9", 0},
+		{"empty string", "", 0},
+		{"malformed value", "num_ctx abc", 0},
+		{"float value", "num_ctx 8192.0", 8192},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseNumCtx(tt.parameters); got != tt.want {
+				t.Errorf("parseNumCtx(%q) = %d, want %d", tt.parameters, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestModelInfoContextLength(t *testing.T) {
+	tests := []struct {
+		name      string
+		modelInfo map[string]any
+		want      int
+	}{
+		{"float64 value", map[string]any{"qwen3_5_moe.context_length": float64(262144)}, 262144},
+		{"int value", map[string]any{"llama.context_length": 131072}, 131072},
+		{"no context_length key", map[string]any{"llama.embedding_length": float64(4096)}, 0},
+		{"empty map", map[string]any{}, 0},
+		{"nil map", nil, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := modelInfoContextLength(tt.modelInfo)
+			if got != tt.want {
+				t.Errorf("modelInfoContextLength() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildCodexModelEntryContextWindow(t *testing.T) {
+	tests := []struct {
+		name          string
+		modelName     string
+		showResponse  string
+		envContextLen string
+		wantContext   int
+	}{
+		{
+			name:      "architectural context length as fallback",
+			modelName: "llama3.2",
+			showResponse: `{
+				"model_info": {"llama.context_length": 131072},
+				"details": {"format": "gguf"}
+			}`,
+			wantContext: 131072,
+		},
+		{
+			name:      "OLLAMA_CONTEXT_LENGTH overrides architectural",
+			modelName: "llama3.2",
+			showResponse: `{
+				"model_info": {"llama.context_length": 131072},
+				"details": {"format": "gguf"}
+			}`,
+			envContextLen: "64000",
+			wantContext:   64000,
+		},
+		{
+			name:      "num_ctx overrides OLLAMA_CONTEXT_LENGTH",
+			modelName: "llama3.2",
+			showResponse: `{
+				"model_info": {"llama.context_length": 131072},
+				"parameters": "num_ctx 8192",
+				"details": {"format": "gguf"}
+			}`,
+			envContextLen: "64000",
+			wantContext:   8192,
+		},
+		{
+			name:      "num_ctx overrides architectural",
+			modelName: "llama3.2",
+			showResponse: `{
+				"model_info": {"llama.context_length": 131072},
+				"parameters": "num_ctx 32768",
+				"details": {"format": "gguf"}
+			}`,
+			wantContext: 32768,
+		},
+		{
+			name:      "safetensors uses architectural context only",
+			modelName: "llama3.2",
+			showResponse: `{
+				"model_info": {"llama.context_length": 131072},
+				"parameters": "num_ctx 8192",
+				"details": {"format": "safetensors"}
+			}`,
+			envContextLen: "64000",
+			wantContext:   131072,
+		},
+		{
+			name:      "cloud model uses hardcoded limits",
+			modelName: "qwen3.5:cloud",
+			showResponse: `{
+				"model_info": {"qwen3_5_moe.context_length": 131072},
+				"details": {"format": "gguf"}
+			}`,
+			envContextLen: "64000",
+			wantContext:   262144,
+		},
+		{
+			name:      "vision and thinking capabilities",
+			modelName: "llama3.2",
+			showResponse: `{
+				"model_info": {"llama.context_length": 131072},
+				"details": {"format": "gguf"},
+				"capabilities": ["vision", "thinking"]
+			}`,
+			wantContext: 131072,
+		},
+		{
+			name:      "system prompt passed through",
+			modelName: "llama3.2",
+			showResponse: `{
+				"model_info": {"llama.context_length": 131072},
+				"details": {"format": "gguf"},
+				"system": "You are a helpful assistant."
+			}`,
+			wantContext: 131072,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/show":
+					fmt.Fprint(w, tt.showResponse)
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer srv.Close()
+			t.Setenv("OLLAMA_HOST", srv.URL)
+
+			if tt.envContextLen != "" {
+				t.Setenv("OLLAMA_CONTEXT_LENGTH", tt.envContextLen)
+			} else {
+				t.Setenv("OLLAMA_CONTEXT_LENGTH", "")
+			}
+
+			entry := buildCodexModelEntry(tt.modelName)
+
+			gotContext, _ := entry["context_window"].(int)
+			if gotContext != tt.wantContext {
+				t.Errorf("context_window = %d, want %d", gotContext, tt.wantContext)
+			}
+
+			if tt.name == "vision and thinking capabilities" {
+				modalities, _ := entry["input_modalities"].([]string)
+				if !slices.Contains(modalities, "image") {
+					t.Error("expected image in input_modalities")
+				}
+				levels, _ := entry["supported_reasoning_levels"].([]any)
+				if len(levels) == 0 {
+					t.Error("expected non-empty supported_reasoning_levels")
+				}
+			}
+
+			if tt.name == "system prompt passed through" {
+				if got, _ := entry["base_instructions"].(string); got != "You are a helpful assistant." {
+					t.Errorf("base_instructions = %q, want %q", got, "You are a helpful assistant.")
+				}
+			}
+
+			if tt.name == "cloud model uses hardcoded limits" {
+				truncationPolicy, _ := entry["truncation_policy"].(map[string]any)
+				if mode, _ := truncationPolicy["mode"].(string); mode != "tokens" {
+					t.Errorf("truncation_policy mode = %q, want %q", mode, "tokens")
+				}
+			}
+
+			requiredKeys := []string{"slug", "display_name", "apply_patch_tool_type", "shell_type"}
+			for _, key := range requiredKeys {
+				if _, ok := entry[key]; !ok {
+					t.Errorf("missing required key %q", key)
+				}
+			}
+
+			if _, err := json.Marshal(entry); err != nil {
+				t.Errorf("entry is not JSON serializable: %v", err)
+			}
+		})
+	}
 }

--- a/docs/integrations/codex.mdx
+++ b/docs/integrations/codex.mdx
@@ -21,6 +21,9 @@ npm install -g @openai/codex
 ollama launch codex
 ```
 
+When launched through `ollama launch codex`, Ollama refreshes the model catalog
+and passes it to Codex for that session.
+
 To configure without launching:
 
 ```shell
@@ -59,10 +62,12 @@ base_url = "http://localhost:11434/v1"
 [profiles.ollama-launch]
 model = "gpt-oss:120b"
 model_provider = "ollama-launch"
+model_catalog_json = "~/.codex/ollama-launch-models.json"
 
 [profiles.ollama-cloud]
 model = "gpt-oss:120b-cloud"
 model_provider = "ollama-launch"
+model_catalog_json = "~/.codex/ollama-launch-models.json"
 ```
 
 Then run:

--- a/docs/integrations/codex.mdx
+++ b/docs/integrations/codex.mdx
@@ -62,12 +62,10 @@ base_url = "http://localhost:11434/v1"
 [profiles.ollama-launch]
 model = "gpt-oss:120b"
 model_provider = "ollama-launch"
-model_catalog_json = "~/.codex/ollama-launch-models.json"
 
 [profiles.ollama-cloud]
 model = "gpt-oss:120b-cloud"
 model_provider = "ollama-launch"
-model_catalog_json = "~/.codex/ollama-launch-models.json"
 ```
 
 Then run:


### PR DESCRIPTION
## Summary
- generate ~/.codex/model.json for the selected Ollama model before launching Codex
- wire the generated catalog into the ollama-launch Codex profile
- derive model metadata from show data and shared cloud limits so Codex does not fall back to generic metadata

## Testing
- go test ./cmd/launch -run TestCodex\|TestParseNumCtx\|TestModelInfoContextLength\|TestBuildCodexModelEntryContextWindow

## User impact
This removes the model metadata fallback warning users are seeing in launched Codex sessions and provides better context window, modality, and reasoning metadata for Ollama models.