### PR TITLE
fix: improve error handling for model loading in Scheduler

### DIFF
--- a/server/sched.go
+++ b/server/sched.go
@@ -471,8 +471,10 @@ func (s *Scheduler) load(req *LlmRequest, systemInfo ml.SystemInfo, gpus []ml.De
 		if wantPath == "" {
 			wantPath = req.model.ShortName
 		}
-		if s.activeLoading.ModelPath() != wantPath {
-			panic(fmt.Errorf("attempting to load different model after eviction (original %v new %v)", s.activeLoading.ModelPath(), wantPath))
+		loadedPath := s.activeLoading.ModelPath()
+		if loadedPath != wantPath {
+			s.loadedMu.Unlock()
+			panic(fmt.Errorf("attempting to load different model after eviction (original %v new %v)", loadedPath, wantPath))
 		}
 	}
 


### PR DESCRIPTION
Unlock mutex before panicking when attempting to load a different model after eviction, ensuring proper synchronization and preventing potential deadlocks.