### PR TITLE
create: prune imported blobs and startup invalid leftovers

### DIFF
--- a/server/create.go
+++ b/server/create.go
@@ -103,6 +103,8 @@ func (s *Server) CreateHandler(c *gin.Context) {
 		}
 
 		oldManifest, _ := manifest.ParseNamedManifest(name)
+		defer pruneCreateInputBlobs(r.Files)
+		defer pruneCreateInputBlobs(r.Adapters)
 
 		var baseLayers []*layerGGML
 		var err error
@@ -280,6 +282,40 @@ func (s *Server) CreateHandler(c *gin.Context) {
 	}
 
 	streamResponse(c, ch)
+}
+
+// pruneCreateInputBlobs removes uploaded create inputs that are not referenced by
+// any manifest once the request completes. This keeps converted safetensors and
+// re-quantized GGUF imports from leaving their original upload blobs behind while
+// preserving any inputs that became part of a model manifest.
+func pruneCreateInputBlobs(files map[string]string) {
+	if envconfig.NoPrune() || len(files) == 0 {
+		return
+	}
+
+	m := &manifest.Manifest{}
+	seen := make(map[string]struct{}, len(files))
+
+	for _, digest := range files {
+		if digest == "" {
+			continue
+		}
+
+		if _, ok := seen[digest]; ok {
+			continue
+		}
+
+		seen[digest] = struct{}{}
+		m.Layers = append(m.Layers, manifest.Layer{Digest: digest})
+	}
+
+	if len(m.Layers) == 0 {
+		return
+	}
+
+	if err := m.RemoveLayers(); err != nil {
+		slog.Warn("couldn't remove imported blobs", "error", err)
+	}
 }
 
 func remoteURL(raw string) (string, error) {

--- a/server/images.go
+++ b/server/images.go
@@ -487,27 +487,26 @@ func PruneLayers() error {
 			continue
 		}
 
+		name := strings.ReplaceAll(blob.Name(), "-", ":")
+
+		_, err = manifest.BlobsPath(name)
+		if err != nil {
+			if errors.Is(err, manifest.ErrInvalidDigestFormat) {
+				// remove invalid blobs (e.g. partial downloads or interrupted uploads)
+				if err := os.Remove(filepath.Join(p, blob.Name())); err != nil {
+					slog.Error("couldn't remove blob", "blob", blob.Name(), "error", err)
+				}
+			}
+
+			continue
+		}
+
 		info, err := blob.Info()
 		if err != nil {
 			slog.Error("couldn't stat blob", "blob", blob.Name(), "error", err)
 			continue
 		}
 		if time.Since(info.ModTime()) < layerPruneGracePeriod {
-			continue
-		}
-
-		name := blob.Name()
-		name = strings.ReplaceAll(name, "-", ":")
-
-		_, err = manifest.BlobsPath(name)
-		if err != nil {
-			if errors.Is(err, manifest.ErrInvalidDigestFormat) {
-				// remove invalid blobs (e.g. partial downloads)
-				if err := os.Remove(filepath.Join(p, blob.Name())); err != nil {
-					slog.Error("couldn't remove blob", "blob", blob.Name(), "error", err)
-				}
-			}
-
 			continue
 		}
 

--- a/server/images_test.go
+++ b/server/images_test.go
@@ -57,6 +57,28 @@ func TestPruneLayersSkipsRecentOrphans(t *testing.T) {
 	}
 }
 
+func TestPruneLayersRemovesRecentInvalidBlobs(t *testing.T) {
+	t.Setenv("OLLAMA_MODELS", t.TempDir())
+
+	blobsDir, err := manifest.BlobsPath("")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	invalidPath := filepath.Join(blobsDir, "sha256-deadbeef-partial")
+	if err := os.WriteFile(invalidPath, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := PruneLayers(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(invalidPath); !os.IsNotExist(err) {
+		t.Fatalf("recent invalid blob still exists: %v", err)
+	}
+}
+
 func TestModelCapabilities(t *testing.T) {
 	// Create completion model (llama architecture without vision)
 	completionModelPath, _ := createBinFile(t, ggml.KV{

--- a/server/routes_create_test.go
+++ b/server/routes_create_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"cmp"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -1121,6 +1122,67 @@ func createSafetensorsTestModel(t *testing.T, modelName string, config model.Con
 	name := model.ParseName(modelName)
 	if err := manifest.WriteManifest(name, *configLayer, layers); err != nil {
 		t.Fatalf("failed to write manifest: %v", err)
+	}
+}
+
+func TestCreatePrunesImportedSafetensorBlobs(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	p := t.TempDir()
+	t.Setenv("OLLAMA_MODELS", p)
+	var s Server
+
+	var buf bytes.Buffer
+	headerSize := int64(len("{}"))
+	if err := binary.Write(&buf, binary.LittleEndian, headerSize); err != nil {
+		t.Fatal(err)
+	}
+	buf.WriteString("{}")
+
+	modelDigest := createTestBlob(t, buf.Bytes())
+	configDigest := createTestBlob(t, []byte(`{"architectures":["LlamaForCausalLM"],"vocab_size":32000}`))
+	tokenizerDigest := createTestBlob(t, []byte(`{"version":"1.0"}`))
+
+	w := createRequest(t, s.CreateHandler, api.CreateRequest{
+		Name: "test-safetensors-cleanup",
+		Files: map[string]string{
+			"model.safetensors": modelDigest,
+			"config.json":       configDigest,
+			"tokenizer.json":    tokenizerDigest,
+		},
+		Stream: &stream,
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	for _, digest := range []string{modelDigest, configDigest, tokenizerDigest} {
+		path, err := manifest.BlobsPath(digest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("imported blob %s still exists: %v", digest, err)
+		}
+	}
+
+	mf, err := manifest.ParseNamedManifest(model.ParseName("test-safetensors-cleanup"))
+	if err != nil {
+		t.Fatalf("parse manifest: %v", err)
+	}
+
+	for _, layer := range append(mf.Layers, mf.Config) {
+		if layer.Digest == "" {
+			continue
+		}
+		path, err := manifest.BlobsPath(layer.Digest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("manifest blob %s missing: %v", layer.Digest, err)
+		}
 	}
 }
 


### PR DESCRIPTION
Solves #15803 

- Fixes the main regression from the issue body: successful safetensors imports no longer leave their uploaded source blobs behind.
- Restores restart-time cleanup for broken temporary blob files by pruning invalid blob names before applying the recent-blob grace period.
- Keeps the current race-avoidance behavior for valid recent blobs, so it should not undo the newer create-vs-gc protection.
- Stays tightly scoped to create/prune behavior with focused tests.

What changed
1. In server/create.go, defer cleanup of request Files and Adapters blobs after create completes.
   - Uses manifest.RemoveLayers(), so blobs that are referenced by any manifest are preserved.
   - This safely handles reused GGUF inputs while removing converted/replaced imports.
2. In server/images.go, validate blob names before applying the one-hour grace period.
   - Invalid blob files like *-partial or interrupted temp uploads are removed immediately during startup prune.
   - Valid digest-named blobs still keep the grace period.
3. Added tests for:
   - safetensors create cleanup of imported source blobs
   - immediate pruning of recent invalid blob files