### PR TITLE
docs: add RDNA4 / gfx1201 ROCm build instructions to development.md

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -125,6 +125,41 @@ Lastly, run Ollama:
 go run . serve
 ```
 
+
+### Building with ROCm for RDNA4 (gfx1200 / gfx1201)
+
+The official `ollama-linux-amd64` binary in 0.20.6 ships CPU and CUDA backends only — no `rocm/` runner directory. RDNA4 users (RX 9000-series, Radeon AI PRO R9700, gfx1200/gfx1201) must build from source until the official build pipeline updates to ROCm 6.4+ (tracked in [#10676](https://github.com/ollama/ollama/pull/10676)).
+
+The source already lists gfx1200 and gfx1201 in `AMDGPU_TARGETS` (see the `ROCm 7` preset in `CMakePresets.json`), so no patching is required — ROCm ≥ 6.3 is sufficient for gfx1201; ROCm ≥ 7.0 is recommended for hipBLASLt-tuned kernels.
+
+Prerequisites (Ubuntu 24.04 example):
+
+```shell
+sudo apt install build-essential cmake ninja-build git
+# Install ROCm 7.x — see https://rocm.docs.amd.com/projects/install-on-linux/
+```
+
+Build (targeting gfx1201 only — drop or expand `AMDGPU_TARGETS` for a multi-arch build):
+
+```shell
+git clone https://github.com/ollama/ollama.git && cd ollama
+PATH=/opt/rocm/lib/llvm/bin:$PATH cmake --preset 'ROCm 7' \
+    -DAMDGPU_TARGETS=gfx1201 \
+    -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
+    -DCMAKE_PREFIX_PATH=/opt/rocm
+cmake --build build --config Release -j$(nproc)
+go build .
+cmake --install build --prefix dist
+```
+
+Verify ROCm detection:
+
+```shell
+HIP_VISIBLE_DEVICES=0 ./dist/bin/ollama serve 2>&1 | grep "inference compute"
+```
+
+Look for `library=ROCm compute=gfx1201` in the output. See [#14927](https://github.com/ollama/ollama/issues/14927) for benchmarks and a full troubleshooting transcript.
+
 ## MLX Engine (Optional)
 
 The MLX engine enables running safetensor based models. It requires building the [MLX](https://github.com/ml-explore/mlx) and [MLX-C](https://github.com/ml-explore/mlx-c) shared libraries separately via CMake.  On MacOS, MLX leverages the Metal library to run on the GPU, and on Windows and Linux, runs on NVIDIA GPUs via CUDA v13.


### PR DESCRIPTION
## Summary

The official `ollama-linux-amd64` binary in 0.20.6 ships CPU and CUDA backends only — `/usr/local/lib/ollama/` has `cuda_v12/`, `cuda_v13/`, and CPU variants, but no `rocm/` runner directory. RDNA4 users (RX 9000-series, Radeon AI PRO R9700, gfx1200/gfx1201) hitting the install script today get a CPU-only experience and have no in-tree pointer telling them they need to build from source.

The source already supports gfx1200/gfx1201 (`CMakeLists.txt` L141 regex and the `"ROCm 7"` preset in `CMakePresets.json`), so this is a docs-only change — no code touched. It adds a short subsection to `docs/development.md` covering:

- The reason a from-source build is needed today (linking back to #10676 for when the official Linux ROCm build resumes)
- ROCm version requirements (≥ 6.3 for gfx1201; ≥ 7.0 recommended for hipBLASLt-tuned kernels)
- The exact `cmake --preset 'ROCm 7' -DAMDGPU_TARGETS=gfx1201 …` command set
- A verification step (`grep "inference compute"` in serve output, looking for `library=ROCm compute=gfx1201`)

## Verified end-to-end

Tested on Ubuntu 24.04 + kernel 6.17 + ROCm 7.2.1 against an AMD Radeon AI PRO R9700:

- `library=ROCm compute=gfx1201 name=ROCm0 description="AMD Radeon Graphics" pci_id=0000:0d:00.0 type=discrete total="31.9 GiB" available="31.8 GiB"`
- 33/33 layers offloaded
- 92.99 tok/s on `llama3.1:8b-q4_K_M` (vs 88.59 tok/s on Vulkan/RADV and 8.77 tok/s on CPU)

## Test plan

- [x] Cloned `ollama/ollama` HEAD, ran the documented build commands verbatim, confirmed `library=ROCm compute=gfx1201` in the journal
- [x] Confirmed link targets resolve: #10676 (build pipeline tracker), #14927 (matching-symptom bug + repro), `CMakePresets.json` "ROCm 7" preset
- [x] Markdown lint: section sits between the existing "## Linux" body and "## MLX Engine (Optional)" heading; doesn't disturb adjacent content

## Refs

- #14927 — RDNA4 gfx1201 not detected, falls back to CPU (the matching-symptom bug)
- #10430 — canonical RDNA4 9070/9070 XT support tracker
- #10676 — draft PR to bump official build pipeline to ROCm 6.4+ (stalled on Windows)
- #13236 — R9700-specific ROCm discovery timeout