### PR TITLE
fix: improve image path regex for special characters

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -599,6 +599,7 @@ func normalizeFilePath(fp string) string {
 		"\\*", "*", // Escaped asterisk
 		"\\?", "?", // Escaped question mark
 		"\\~", "~", // Escaped tilde
+		"\\@", "@", // Escaped at sign
 	).Replace(fp)
 }
 
@@ -606,7 +607,7 @@ func extractFileNames(input string) []string {
 	// Regex to match file paths starting with optional drive letter, / ./ \ or .\ and include escaped or unescaped spaces (\ or %20)
 	// and followed by more characters and a file extension
 	// This will capture non filename strings, but we'll check for file existence to remove mismatches
-	regexPattern := `(?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp|wav)\b`
+	regexPattern := `(?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp|wav)(?:\b|$)`
 	re := regexp.MustCompile(regexPattern)
 
 	return re.FindAllString(input, -1)


### PR DESCRIPTION
Fixes #10333. Removes word boundary constraint that broke paths with @ before extension (e.g. CleanShot@2x.png). Also handles escaped @ characters from shell drag-and-drop.