### PR TITLE
Fix qwen35/qwen35moe architecture aliases in llama.cpp parser

### DIFF
--- a/llama/llama.cpp/src/llama-arch.cpp
+++ b/llama/llama.cpp/src/llama-arch.cpp
@@ -2442,6 +2442,14 @@ const char * llm_arch_name(llm_arch arch) {
 }
 
 llm_arch llm_arch_from_string(const std::string & name) {
+    // Compatibility aliases for newer architecture names
+    if (name == "qwen35") {
+        return LLM_ARCH_QWEN3NEXT;
+    }
+    if (name == "qwen35moe") {
+        return LLM_ARCH_QWEN3NEXT;
+    }
+
     for (const auto & kv : LLM_ARCH_NAMES) { // NOLINT
         if (kv.second == name) {
             return kv.first;


### PR DESCRIPTION
## Summary

Fixes GGUF models that declare `qwen35` or `qwen35moe` architectures.

## Problem

Some models failed with:

`unknown model architecture: 'qwen35moe'`

Although these architecture names were referenced in higher-level Ollama code, the llama.cpp string parser did not recognize them.

## Fix

Added compatibility aliases in `llm_arch_from_string()`:

* `qwen35` → `LLM_ARCH_QWEN3NEXT`
* `qwen35moe` → `LLM_ARCH_QWEN3NEXT`

## Validation

Before patch:

* `unknown model architecture: qwen35moe`

After patch:

* `ollama show hf.co/unsloth/Qwen3.6-35B-A3B-GGUF:UD-Q4_K_M` successfully proceeds and displays metadata.
