### PR TITLE
Improve error message for unsupported model architectures

### DIFF
--- a/llama/llama.cpp/src/llama-model.cpp
+++ b/llama/llama.cpp/src/llama-model.cpp
@@ -473,7 +473,7 @@ void llama_model::load_stats(llama_model_loader & ml) {
 void llama_model::load_arch(llama_model_loader & ml) {
     arch = ml.get_arch();
     if (arch == LLM_ARCH_UNKNOWN) {
-        throw std::runtime_error("unknown model architecture: '" + ml.get_arch_name() + "'");
+        throw std::runtime_error("unsupported model architecture: '" + ml.get_arch_name() + "' (this Ollama version may not support it yet)");
     }
 }
 

--- a/llama/llama.go
+++ b/llama/llama.go
@@ -107,7 +107,7 @@ func GetModelArch(modelPath string) (string, error) {
 	defer C.free(unsafe.Pointer(key))
 	arch_index := C.gguf_find_key(gguf_ctx, key)
 	if int(arch_index) < 0 {
-		return "", errors.New("unknown model architecture")
+		return "", errors.New("unsupported model architecture")
 	}
 
 	arch := C.gguf_get_val_str(gguf_ctx, arch_index)


### PR DESCRIPTION
## Summary

Updates error wording when loading unsupported GGUF model architectures.

Changes:

* `unknown model architecture`
  to
* `unsupported model architecture`

## Why

The previous message can be confusing and may imply corruption or detection failure.

This wording better communicates that the architecture was recognized from metadata but is not supported by the current Ollama runtime.

Related to issue #15824.
