### PR TITLE
ggml: check for overflow when computing tensor byte strides

### DIFF
--- a/ml/backend/ggml/ggml/src/gguf.cpp
+++ b/ml/backend/ggml/ggml/src/gguf.cpp
@@ -587,9 +587,15 @@ struct gguf_context * gguf_init_from_file_impl(FILE * file, struct gguf_init_par
 
             // calculate byte offsets given the tensor shape and type
             info.t.nb[0] = type_size;
-            info.t.nb[1] = info.t.nb[0]*(info.t.ne[0]/blck_size);
-            for (int j = 2; j < GGML_MAX_DIMS; ++j) {
-                info.t.nb[j] = info.t.nb[j - 1]*info.t.ne[j - 1];
+            for (int j = 1; j < GGML_MAX_DIMS; ++j) {
+                const size_t mul = (size_t) (j == 1 ? info.t.ne[0]/blck_size : info.t.ne[j - 1]);
+                if (mul != 0 && info.t.nb[j - 1] > SIZE_MAX/mul) {
+                    GGML_LOG_ERROR("%s: tensor '%s' byte stride overflow at dimension %d\n",
+                        __func__, info.t.name, j);
+                    ok = false;
+                    break;
+                }
+                info.t.nb[j] = info.t.nb[j - 1]*mul;
             }
         }
         if (!ok) {


### PR DESCRIPTION
gguf_init_from_file_impl validates that the product of ne[0..3] fits in
int64_t, but the subsequent byte-stride math
(nb[1] = type_size * ne[0]/blck_size and nb[j] = nb[j-1] * ne[j-1])
carries an additional factor of type_size that the upstream check does
not cover. For large ne[0], nb[1] (and the downstream strides) wraps
past SIZE_MAX, so ggml_nbytes() under-reports the tensor and the
allocation that later receives its data is sized against a truncated
stride rather than the shape stored in the header.

Guard each multiplication with the same SIZE_MAX/factor pattern already
used a few lines below for accumulating ctx->size, and surface a parse
error naming the offending dimension. Well-formed shapes hit the same
arithmetic path as before.