### PR TITLE
docs(context-length): add Linux (systemd) section for OLLAMA_CONTEXT_LENGTH

### DIFF
--- a/docs/context-length.mdx
+++ b/docs/context-length.mdx
@@ -30,6 +30,30 @@ If editing the context length for Ollama is not possible, the context length can
 OLLAMA_CONTEXT_LENGTH=64000 ollama serve
 ```
 
+### Linux (systemd)
+
+If Ollama is running as a systemd service (the default after installing via the Linux install script), `OLLAMA_CONTEXT_LENGTH` must be set in the unit file — exporting it in your shell will not affect the service.
+
+1. Edit the systemd service by calling `systemctl edit ollama.service`. This will open an editor.
+
+2. Under section `[Service]`, add an `Environment` line:
+
+   ```ini
+   [Service]
+   Environment="OLLAMA_CONTEXT_LENGTH=64000"
+   ```
+
+3. Save and exit.
+
+4. Reload `systemd` and restart Ollama:
+
+   ```shell
+   systemctl daemon-reload
+   systemctl restart ollama
+   ```
+
+For other environment variables, see [Setting environment variables on Linux](./faq#setting-environment-variables-on-linux).
+
 ### Check allocated context length and model offloading
 For best performance, use the maximum context length for a model, and avoid offloading the model to CPU. Verify the split under `PROCESSOR` using `ollama ps`.
 ```


### PR DESCRIPTION
## Summary

Adds a "Linux (systemd)" subsection to `docs/context-length.mdx` describing how to set `OLLAMA_CONTEXT_LENGTH` when Ollama runs as a systemd service — the default after installing via the Linux install script.

## Why

The current page only documents two paths:
- **App** (slider) — not present on a headless Linux server.
- **CLI** (`OLLAMA_CONTEXT_LENGTH=64000 ollama serve`) — won't take effect when the service is already running under systemd; exporting an env var in the shell does not affect the service.

Linux server users need the systemd unit-file approach. The information exists in the FAQ ([Setting environment variables on Linux](https://docs.ollama.com/faq#setting-environment-variables-on-linux)) but is generic and not linked from the context-length page, so users discovering the context-length docs first don't know to look there.

Reported in [#15848](https://github.com/ollama/ollama/issues/15848).

## Change

Adds a new `### Linux (systemd)` subsection between the existing `### CLI` and `### Check allocated context length and model offloading` sections, with:
- A 4-step `systemctl edit` walkthrough (mirroring the FAQ pattern, but specialized to `OLLAMA_CONTEXT_LENGTH`).
- A note that shell-exported env vars don't reach the service.
- A back-reference to the FAQ for other env vars, so this page stays focused.

## Test plan

- [x] Markdown renders cleanly (verified locally — no MDX syntax issues).
- [x] Internal link `./faq#setting-environment-variables-on-linux` matches the existing anchor in `docs/faq.mdx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)