### PR TITLE
Add --private flag to ollama push

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -789,6 +789,7 @@ type ProgressResponse struct {
 type PushRequest struct {
 	Model    string `json:"model"`
 	Insecure bool   `json:"insecure,omitempty"`
+	Private  bool   `json:"private,omitempty"`
 	Username string `json:"username"`
 	Password string `json:"password"`
 	Stream   *bool  `json:"stream,omitempty"`

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -840,6 +840,11 @@ func PushHandler(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	private, err := cmd.Flags().GetBool("private")
+	if err != nil {
+		return err
+	}
+
 	n := model.ParseName(args[0])
 	if strings.HasSuffix(n.Host, ".ollama.ai") || strings.HasSuffix(n.Host, ".ollama.com") {
 		_, err := client.Whoami(cmd.Context())
@@ -897,7 +902,7 @@ func PushHandler(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	request := api.PushRequest{Name: args[0], Insecure: insecure}
+	request := api.PushRequest{Name: args[0], Insecure: insecure, Private: private}
 
 	if err := client.Push(cmd.Context(), &request, fn); err != nil {
 		if spinner != nil {
@@ -2255,6 +2260,7 @@ func NewCLI() *cobra.Command {
 	}
 
 	pushCmd.Flags().Bool("insecure", false, "Use an insecure registry")
+	pushCmd.Flags().Bool("private", false, "Create the repository as private on the registry")
 
 	signinCmd := &cobra.Command{
 		Use:     "signin",

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1152,6 +1152,7 @@ func TestPushHandler(t *testing.T) {
 	tests := []struct {
 		name           string
 		modelName      string
+		private        bool
 		serverResponse map[string]func(w http.ResponseWriter, r *http.Request)
 		expectedError  string
 		expectedOutput string
@@ -1241,6 +1242,39 @@ func TestPushHandler(t *testing.T) {
 			},
 			expectedError: "you are not authorized to push to this namespace, create the model under a namespace you own",
 		},
+		{
+			name:      "private push",
+			modelName: "test-model",
+			private:   true,
+			serverResponse: map[string]func(w http.ResponseWriter, r *http.Request){
+				"/api/push": func(w http.ResponseWriter, r *http.Request) {
+					var req api.PushRequest
+					if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+						http.Error(w, err.Error(), http.StatusBadRequest)
+						return
+					}
+
+					if !req.Private {
+						t.Error("expected Private to be true")
+					}
+
+					responses := []api.ProgressResponse{
+						{Status: "preparing manifest"},
+						{Digest: "sha256:abc123456789", Total: 100, Completed: 100},
+					}
+
+					for _, resp := range responses {
+						if err := json.NewEncoder(w).Encode(resp); err != nil {
+							http.Error(w, err.Error(), http.StatusInternalServerError)
+							return
+						}
+						w.(http.Flusher).Flush()
+					}
+				},
+				"/api/me": func(w http.ResponseWriter, r *http.Request) {},
+			},
+			expectedOutput: "\nYou can find your model at:\n\n\thttps://ollama.com/test-model\n",
+		},
 	}
 
 	for _, tt := range tests {
@@ -1262,6 +1296,12 @@ func TestPushHandler(t *testing.T) {
 
 			cmd := &cobra.Command{}
 			cmd.Flags().Bool("insecure", false, "")
+			cmd.Flags().Bool("private", false, "")
+			if tt.private {
+				if err := cmd.Flags().Set("private", "true"); err != nil {
+					t.Fatal(err)
+				}
+			}
 			cmd.SetContext(t.Context())
 
 			// Redirect stderr to capture progress output

--- a/server/images.go
+++ b/server/images.go
@@ -53,6 +53,7 @@ var (
 
 type registryOptions struct {
 	Insecure bool
+	Private  bool
 	Username string
 	Password string
 	Token    string
@@ -575,6 +576,12 @@ func PushModel(ctx context.Context, name string, regOpts *registryOptions, fn fu
 	requestURL := n.BaseURL()
 	requestURL = requestURL.JoinPath("v2", n.DisplayNamespaceModel(), "manifests", n.Tag)
 
+	if regOpts != nil && regOpts.Private {
+		q := requestURL.Query()
+		q.Set("private", "1")
+		requestURL.RawQuery = q.Encode()
+	}
+
 	manifestJSON, err := json.Marshal(mf)
 	if err != nil {
 		return err
@@ -847,6 +854,7 @@ func pushWithTransfer(ctx context.Context, n model.Name, layers []manifest.Layer
 		Manifest:    manifestJSON,
 		ManifestRef: n.Tag,
 		Repository:  n.DisplayNamespaceModel(),
+		Private:     regOpts != nil && regOpts.Private,
 	})
 }
 

--- a/server/internal/client/ollama/registry.go
+++ b/server/internal/client/ollama/registry.go
@@ -325,6 +325,10 @@ type PushParams struct {
 	// From is an optional destination name for the model. If empty, the
 	// destination name is the same as the source name.
 	From string
+
+	// Private signals the registry to create the repository as private
+	// when it is first initialized during push.
+	Private bool
 }
 
 // Push pushes the model with the name in the cache to the remote registry.
@@ -431,6 +435,9 @@ func (r *Registry) Push(ctx context.Context, name string, p *PushParams) error {
 		n.Model(),
 		n.Tag(),
 	)
+	if p.Private {
+		path += "?private=1"
+	}
 	res, err := r.send(ctx, "PUT", path, bytes.NewReader(m.Data))
 	if err == nil {
 		res.Body.Close()

--- a/server/internal/client/ollama/registry_test.go
+++ b/server/internal/client/ollama/registry_test.go
@@ -186,6 +186,21 @@ func TestPushSingle(t *testing.T) {
 	testutil.Check(t, err)
 }
 
+func TestPushPrivate(t *testing.T) {
+	var manifestPrivateParam string
+	rc, _ := newClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "PUT" && strings.Contains(r.URL.Path, "/manifests/") {
+			manifestPrivateParam = r.URL.Query().Get("private")
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	err := rc.Push(t.Context(), "single", &PushParams{Private: true})
+	testutil.Check(t, err)
+	if manifestPrivateParam != "1" {
+		t.Errorf("expected private=1 query param on manifest PUT, got %q", manifestPrivateParam)
+	}
+}
+
 func TestPushMultiple(t *testing.T) {
 	rc, _ := newClient(t, okHandler)
 	err := rc.Push(t.Context(), "multiple", nil)

--- a/server/routes.go
+++ b/server/routes.go
@@ -1008,6 +1008,7 @@ func (s *Server) PushHandler(c *gin.Context) {
 
 		regOpts := &registryOptions{
 			Insecure: req.Insecure,
+			Private:  req.Private,
 		}
 
 		ctx, cancel := context.WithCancel(c.Request.Context())

--- a/x/imagegen/transfer/transfer.go
+++ b/x/imagegen/transfer/transfer.go
@@ -85,6 +85,7 @@ type UploadOptions struct {
 	Manifest    []byte // Raw manifest JSON to push
 	ManifestRef string // Tag or digest for the manifest (e.g., "latest", "sha256:...")
 	Repository  string // Repository path for manifest URL (e.g., "library/model")
+	Private     bool   // If true, add ?private=1 to manifest PUT
 }
 
 // AuthChallenge represents a parsed WWW-Authenticate challenge.

--- a/x/imagegen/transfer/transfer_test.go
+++ b/x/imagegen/transfer/transfer_test.go
@@ -1577,6 +1577,59 @@ func TestManifestPush(t *testing.T) {
 	t.Logf("Manifest push test passed: received %d bytes at %s", len(manifestReceived), manifestPath)
 }
 
+func TestManifestPushPrivate(t *testing.T) {
+	clientDir := t.TempDir()
+	blob, _ := createTestBlob(t, clientDir, 1000)
+
+	testManifest := []byte(`{"schemaVersion":2,"mediaType":"application/vnd.docker.distribution.manifest.v2+json"}`)
+	testRepo := "library/test-model"
+	testRef := "latest"
+
+	var manifestPrivateParam string
+	var serverURL string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/blobs/uploads") {
+			w.Header().Set("Location", fmt.Sprintf("%s/v2/library/_/blobs/uploads/1", serverURL))
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		if r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/blobs/") {
+			w.WriteHeader(http.StatusCreated)
+			return
+		}
+		if r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/manifests/") {
+			manifestPrivateParam = r.URL.Query().Get("private")
+			w.WriteHeader(http.StatusCreated)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+	serverURL = server.URL
+
+	err := Upload(context.Background(), UploadOptions{
+		Blobs:       []Blob{blob},
+		BaseURL:     server.URL,
+		SrcDir:      clientDir,
+		Manifest:    testManifest,
+		ManifestRef: testRef,
+		Repository:  testRepo,
+		Private:     true,
+	})
+	if err != nil {
+		t.Fatalf("Upload failed: %v", err)
+	}
+
+	if manifestPrivateParam != "1" {
+		t.Errorf("expected private=1 query param on manifest PUT, got %q", manifestPrivateParam)
+	}
+}
+
 // ==================== Throughput Benchmarks ====================
 
 func BenchmarkDownloadThroughput(b *testing.B) {

--- a/x/imagegen/transfer/upload.go
+++ b/x/imagegen/transfer/upload.go
@@ -31,6 +31,7 @@ type uploader struct {
 	userAgent  string
 	progress   *progressTracker
 	logger     *slog.Logger
+	private    bool
 }
 
 func upload(ctx context.Context, opts UploadOptions) error {
@@ -48,6 +49,7 @@ func upload(ctx context.Context, opts UploadOptions) error {
 		getToken:   opts.GetToken,
 		userAgent:  cmp.Or(opts.UserAgent, defaultUserAgent),
 		logger:     opts.Logger,
+		private:    opts.Private,
 	}
 
 	if len(opts.Blobs) > 0 {
@@ -359,7 +361,15 @@ func (u *uploader) put(ctx context.Context, uploadURL string, f *os.File, size i
 }
 
 func (u *uploader) pushManifest(ctx context.Context, repo, ref string, manifest []byte) error {
-	req, _ := http.NewRequestWithContext(ctx, http.MethodPut, fmt.Sprintf("%s/v2/%s/manifests/%s", u.baseURL, repo, ref), bytes.NewReader(manifest))
+	manifestURL := fmt.Sprintf("%s/v2/%s/manifests/%s", u.baseURL, repo, ref)
+	if u.private {
+		parsed, _ := url.Parse(manifestURL)
+		q := parsed.Query()
+		q.Set("private", "1")
+		parsed.RawQuery = q.Encode()
+		manifestURL = parsed.String()
+	}
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPut, manifestURL, bytes.NewReader(manifest))
 	req.Header.Set("Content-Type", "application/vnd.docker.distribution.manifest.v2+json")
 	req.Header.Set("User-Agent", u.userAgent)
 	if *u.token != "" {


### PR DESCRIPTION
## Summary

Closes #8077 — cc @BruceMacD 

Adds a `--private` boolean flag to `ollama push` that tells the registry to create the repository as private when first initialized during push.

```
ollama push username/my-model:latest --private
```

The visibility signal is communicated via a `?private=1` query parameter on the manifest PUT request to the registry, threaded through all push paths.

---

## Changes

* **`api/types.go`**: Add `Private` field to `PushRequest`
* **`cmd/cmd.go`**: Register `--private` flag, extract and pass to request
* **`server/routes.go`**: Pass `Private` to `registryOptions`
* **`server/images.go`**: Append `?private=1` on standard push path; pass to `UploadOptions` on fast transfer path
* **`x/imagegen/transfer/`**: Thread `Private` through `UploadOptions` → `uploader` → `pushManifest`
* **`server/internal/client/ollama/registry.go`**: Add `Private` to `PushParams`, append to manifest commit URL
* **Tests added** in `cmd/cmd_test.go`, `registry_test.go`, and `transfer_test.go`
