### PR TITLE
server: preserve chat metrics across buffered tool chunks

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -2433,6 +2433,7 @@ func (s *Server) ChatHandler(c *gin.Context) {
 
 			// sets up new context given parent context per request
 			ctx, cancel := context.WithCancel(c.Request.Context())
+			var observedMetrics api.Metrics
 			err := r.Completion(ctx, llm.CompletionRequest{
 				Prompt:      prompt,
 				Images:      images,
@@ -2456,6 +2457,23 @@ func (s *Server) ChatHandler(c *gin.Context) {
 					},
 					Logprobs: toAPILogprobs(r.Logprobs),
 				}
+
+				if res.Metrics.PromptEvalCount > 0 {
+					observedMetrics.PromptEvalCount = res.Metrics.PromptEvalCount
+				}
+				if res.Metrics.PromptEvalDuration > 0 {
+					observedMetrics.PromptEvalDuration = res.Metrics.PromptEvalDuration
+				}
+				if res.Metrics.EvalCount > 0 {
+					observedMetrics.EvalCount = res.Metrics.EvalCount
+				}
+				if res.Metrics.EvalDuration > 0 {
+					observedMetrics.EvalDuration = res.Metrics.EvalDuration
+				}
+				res.Metrics.PromptEvalCount = observedMetrics.PromptEvalCount
+				res.Metrics.PromptEvalDuration = observedMetrics.PromptEvalDuration
+				res.Metrics.EvalCount = observedMetrics.EvalCount
+				res.Metrics.EvalDuration = observedMetrics.EvalDuration
 
 				if r.Done {
 					res.DoneReason = r.DoneReason.String()

--- a/server/routes_generate_test.go
+++ b/server/routes_generate_test.go
@@ -600,6 +600,90 @@ func TestGenerateChat(t *testing.T) {
 		}
 	})
 
+	t.Run("messages with tools preserves prompt metrics from buffered chunks", func(t *testing.T) {
+		tools := []api.Tool{
+			{
+				Type: "function",
+				Function: api.ToolFunction{
+					Name: "get_weather",
+					Parameters: api.ToolFunctionParameters{
+						Type: "object",
+						Properties: testPropsMap(map[string]api.ToolProperty{
+							"location": {Type: api.PropertyType{"string"}},
+						}),
+					},
+				},
+			},
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+
+		mock.CompletionFn = func(ctx context.Context, r llm.CompletionRequest, fn func(r llm.CompletionResponse)) error {
+			defer wg.Done()
+
+			responses := []llm.CompletionResponse{
+				{
+					Content:            `{"name":"get_weather",`,
+					PromptEvalCount:    42,
+					PromptEvalDuration: 7,
+				},
+				{
+					Content:    `"arguments":{"location":"Seattle"}}`,
+					Done:       true,
+					DoneReason: llm.DoneReasonStop,
+					EvalCount:  5,
+				},
+			}
+
+			for _, resp := range responses {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				default:
+					fn(resp)
+				}
+			}
+			return nil
+		}
+
+		w := createRequest(t, s.ChatHandler, api.ChatRequest{
+			Model: "test-system",
+			Messages: []api.Message{
+				{Role: "user", Content: "What's the weather in Seattle?"},
+			},
+			Tools:  tools,
+			Stream: &stream,
+		})
+
+		wg.Wait()
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", w.Code)
+		}
+
+		decoder := json.NewDecoder(w.Body)
+		var final api.ChatResponse
+		for {
+			var resp api.ChatResponse
+			if err := decoder.Decode(&resp); err == io.EOF {
+				break
+			} else if err != nil {
+				t.Fatal(err)
+			}
+			if resp.Done {
+				final = resp
+			}
+		}
+
+		if final.Metrics.PromptEvalCount != 42 {
+			t.Fatalf("expected prompt eval count 42, got %d", final.Metrics.PromptEvalCount)
+		}
+		if final.Metrics.PromptEvalDuration != 7 {
+			t.Fatalf("expected prompt eval duration 7, got %s", final.Metrics.PromptEvalDuration)
+		}
+	})
+
 	t.Run("messages with tools (streaming)", func(t *testing.T) {
 		tools := []api.Tool{
 			{


### PR DESCRIPTION
## Summary
- preserve observed chat metrics across streamed chunks before they are emitted
- keep `prompt_eval_count`/prompt duration available on the final tool-call response when earlier chunks were buffered by the tool parser
- add a regression test covering buffered tool-call chunks with prompt metrics only on the first chunk

Fixes #15850.

## Tests
- `go test ./server -run 'TestGenerateChat/messages_with_tools_preserves_prompt_metrics_from_buffered_chunks' -count=1`
- `go test ./server -run TestGenerateChat -count=1`
