### PR TITLE
Improve error message for unsupported model architectures with actionable guidance

### DIFF
--- a/llama/llama.cpp/src/llama-model.cpp
+++ b/llama/llama.cpp/src/llama-model.cpp
@@ -473,7 +473,7 @@ void llama_model::load_stats(llama_model_loader & ml) {
 void llama_model::load_arch(llama_model_loader & ml) {
     arch = ml.get_arch();
     if (arch == LLM_ARCH_UNKNOWN) {
-        throw std::runtime_error("unknown model architecture: '" + ml.get_arch_name() + "'");
+        throw std::runtime_error("unsupported model architecture: '" + ml.get_arch_name() + "'\nThis architecture may exist in upstream llama.cpp but is not yet supported in this Ollama version.\nTry:\n- updating Ollama\n- checking if the model requires a newer llama.cpp backend");
     }
 }
 


### PR DESCRIPTION
## Summary

Improves the error message shown when loading unsupported model architectures.

## Changes

* Includes the detected architecture name in the error message
* Clarifies that the architecture may exist in upstream llama.cpp but is not yet supported in the current Ollama version
* Provides actionable suggestions (update Ollama or check backend compatibility)

## Motivation

Users encountering errors like `unknown model architecture` may misinterpret the issue as a corrupted model or configuration problem.

In cases like #15824, the real issue is that the architecture (e.g., `glm-dsa`) exists upstream but has not yet been integrated into Ollama.

This change improves clarity and reduces confusion.

## Example

Before:

```
unknown model architecture: 'glm-dsa'
```

After:

```
unsupported model architecture: 'glm-dsa'
This architecture may exist in upstream llama.cpp but is not yet supported in this Ollama version.
Try:
- updating Ollama
- checking if the model requires a newer llama.cpp backend
```

## Related

Closes confusion in #15824
