### PR TITLE
fix(mlxrunner): preserve fp32 precision in gated_delta_step recurrent state

### DIFF
--- a/x/mlxrunner/cache/recurrent.go
+++ b/x/mlxrunner/cache/recurrent.go
@@ -53,9 +53,17 @@ func (c *RecurrentCache) ensure(batch int, dtype mlx.DType) {
 		batch = 1
 	}
 
+	// Conv state matches the activation dtype (typically bf16). Delta state
+	// is held in fp32 because it accumulates across many recurrent steps and
+	// precision matters more than the modest memory cost (a few small tensors
+	// per layer). This matches MLX-LM's reference implementation, which always
+	// allocates the recurrent state as fp32, and pairs with the kernel storing
+	// state via static_cast<StT>(...) in gated_delta.go.
+	const deltaDType = mlx.DTypeFloat32
+
 	needConv := c.convState == nil || !c.convState.Valid() || c.convState.DType() != dtype ||
 		c.convState.Dim(0) != batch || c.convState.Dim(1) != c.convTail || c.convState.Dim(2) != c.convDim
-	needDelta := c.deltaState == nil || !c.deltaState.Valid() || c.deltaState.DType() != dtype ||
+	needDelta := c.deltaState == nil || !c.deltaState.Valid() || c.deltaState.DType() != deltaDType ||
 		c.deltaState.Dim(0) != batch || c.deltaState.Dim(1) != c.numVHeads || c.deltaState.Dim(2) != c.headVDim || c.deltaState.Dim(3) != c.headKDim
 	if !needConv && !needDelta {
 		return
@@ -65,7 +73,7 @@ func (c *RecurrentCache) ensure(batch int, dtype mlx.DType) {
 		c.convState = c.setState(c.convState, mlx.Zeros(dtype, batch, c.convTail, c.convDim), false)
 	}
 	if needDelta {
-		c.deltaState = c.setState(c.deltaState, mlx.Zeros(dtype, batch, c.numVHeads, c.headVDim, c.headKDim), false)
+		c.deltaState = c.setState(c.deltaState, mlx.Zeros(deltaDType, batch, c.numVHeads, c.headVDim, c.headKDim), false)
 	}
 }
 

--- a/x/mlxrunner/mlx/gated_delta.go
+++ b/x/mlxrunner/mlx/gated_delta.go
@@ -83,7 +83,7 @@ for (int t = 0; t < T; ++t) {
 
 for (int i = 0; i < n_per_t; ++i) {
   auto s_idx = n_per_t * dk_idx + i;
-  o_state[s_idx] = static_cast<InT>(state[i]);
+  o_state[s_idx] = static_cast<StT>(state[i]);
 }
 `
 
@@ -163,7 +163,7 @@ for (int t = 0; t < T_val; ++t) {
 
 for (int i = 0; i < n_per_t; ++i) {
   auto s_idx = n_per_t * dk_idx + i;
-  o_state[s_idx] = static_cast<InT>(state[i]);
+  o_state[s_idx] = static_cast<StT>(state[i]);
 }
 `
 
@@ -263,9 +263,11 @@ func gatedDeltaKernel(q, k, v, g, beta, state *Array) (y, nextState *Array, ok b
 	}
 
 	dtype := q.DType()
-	if k.DType() != dtype || v.DType() != dtype || g.DType() != dtype || beta.DType() != dtype || state.DType() != dtype {
+	if k.DType() != dtype || v.DType() != dtype || g.DType() != dtype || beta.DType() != dtype {
 		return nil, nil, false
 	}
+	// state may have a different dtype than the inputs (typically fp32 vs bf16)
+	// to preserve precision in the recurrent accumulator across many steps.
 
 	gatedDeltaMetalKernelOnce.Do(initGatedDeltaMetalKernel)
 	if gatedDeltaMetalDisabled {
@@ -278,6 +280,12 @@ func gatedDeltaKernel(q, k, v, g, beta, state *Array) (y, nextState *Array, ok b
 	cInT := C.CString("InT")
 	defer C.free(unsafe.Pointer(cInT))
 	if C.mlx_fast_metal_kernel_config_add_template_arg_dtype(cfg, cInT, C.mlx_dtype(dtype)) != 0 {
+		gatedDeltaMetalDisabled = true
+		return nil, nil, false
+	}
+	cStT := C.CString("StT")
+	defer C.free(unsafe.Pointer(cStT))
+	if C.mlx_fast_metal_kernel_config_add_template_arg_dtype(cfg, cStT, C.mlx_dtype(state.DType())) != 0 {
 		gatedDeltaMetalDisabled = true
 		return nil, nil, false
 	}
@@ -305,7 +313,7 @@ func gatedDeltaKernel(q, k, v, g, beta, state *Array) (y, nextState *Array, ok b
 		gatedDeltaMetalDisabled = true
 		return nil, nil, false
 	}
-	if C.mlx_fast_metal_kernel_config_add_output_arg(cfg, unsafe.SliceData(stateShape), C.size_t(len(stateShape)), C.mlx_dtype(dtype)) != 0 {
+	if C.mlx_fast_metal_kernel_config_add_output_arg(cfg, unsafe.SliceData(stateShape), C.size_t(len(stateShape)), C.mlx_dtype(state.DType())) != 0 {
 		gatedDeltaMetalDisabled = true
 		return nil, nil, false
 	}
@@ -517,9 +525,11 @@ func gatedDeltaCUDAKernelApply(q, k, v, g, beta, state *Array) (y, nextState *Ar
 	}
 
 	dtype := q.DType()
-	if k.DType() != dtype || v.DType() != dtype || g.DType() != dtype || beta.DType() != dtype || state.DType() != dtype {
+	if k.DType() != dtype || v.DType() != dtype || g.DType() != dtype || beta.DType() != dtype {
 		return nil, nil, false
 	}
+	// state may have a different dtype than the inputs (typically fp32 vs bf16)
+	// to preserve precision in the recurrent accumulator across many steps.
 
 	gatedDeltaCUDAKernelOnce.Do(initGatedDeltaCUDAKernel)
 	if gatedDeltaCUDADisabled {
@@ -532,6 +542,12 @@ func gatedDeltaCUDAKernelApply(q, k, v, g, beta, state *Array) (y, nextState *Ar
 	cInT := C.CString("InT")
 	defer C.free(unsafe.Pointer(cInT))
 	if C.mlx_fast_cuda_kernel_config_add_template_arg_dtype(cfg, cInT, C.mlx_dtype(dtype)) != 0 {
+		gatedDeltaCUDADisabled = true
+		return nil, nil, false
+	}
+	cStT := C.CString("StT")
+	defer C.free(unsafe.Pointer(cStT))
+	if C.mlx_fast_cuda_kernel_config_add_template_arg_dtype(cfg, cStT, C.mlx_dtype(state.DType())) != 0 {
 		gatedDeltaCUDADisabled = true
 		return nil, nil, false
 	}
@@ -559,7 +575,7 @@ func gatedDeltaCUDAKernelApply(q, k, v, g, beta, state *Array) (y, nextState *Ar
 		gatedDeltaCUDADisabled = true
 		return nil, nil, false
 	}
-	if C.mlx_fast_cuda_kernel_config_add_output_arg(cfg, unsafe.SliceData(stateShape), C.size_t(len(stateShape)), C.mlx_dtype(dtype)) != 0 {
+	if C.mlx_fast_cuda_kernel_config_add_output_arg(cfg, unsafe.SliceData(stateShape), C.size_t(len(stateShape)), C.mlx_dtype(state.DType())) != 0 {
 		gatedDeltaCUDADisabled = true
 		return nil, nil, false
 	}


### PR DESCRIPTION
## Summary

Fixes incoherent generation in Qwen3.5/3.6 GatedDeltaNet (linear-attention) layers by preserving the fp32 recurrent-state accumulator across kernel invocations, matching MLX-LM's reference. Refs #15865, #15866.

The `gated_delta_step` Metal/CUDA kernel computed state in `float` (fp32) inside the inner loop but cast it back to `InT` (the input dtype, typically bf16) when writing to `o_state`. That truncated 16 mantissa bits to 7 every recurrent step. Across 30 linear-attention layers and N tokens of a real prompt the state degrades enough that generation becomes incoherent (e.g. `"Copyright ofusr ="` for a `"What is 2+2?"` prompt against `mlx-community/Qwen3.6-35B-A3B-4bit`).

## Changes

Two surgical changes in two files:

### `x/mlxrunner/mlx/gated_delta.go`
- Add an `StT` template arg to both Metal and CUDA kernels (separate from `InT`)
- Cast state writes via `static_cast<StT>(state[i])` instead of `static_cast<InT>(state[i])`
- Loosen the `state.DType() == dtype` precondition so the kernel accepts fp32 state alongside bf16 inputs
- Set the state output_arg dtype to `state.DType()` instead of the input dtype

### `x/mlxrunner/cache/recurrent.go`
- Hardcode `deltaState` to fp32 in `ensure()`. Conv state continues to track the activation dtype (typically bf16); only the recurrent accumulator is widened.
- Documented why with a comment pointing at the kernel side and the MLX-LM reference.

No API changes, no `qwen3_5.go` changes -- call sites still pass a single dtype to `RecurrentCache.Get(b, dtype)`, which now applies only to conv state. Full-attention layers and other models that don't use `RecurrentCache` are unaffected.

## Why hardcode fp32 vs. add a parameter

MLX-LM's reference always allocates the recurrent state as `mx.float32`. There's no current model that wants a different precision for it, and adding a knob would just push the decision to every call site without a use case to justify it. Easier to revisit if a model ever needs bf16 state for memory reasons.

## Memory cost

Delta state is `[B, num_v_heads, head_v_dim, head_k_dim]`. For Qwen3.6-35B-A3B (32 v-heads x 128 dim x 128 dim per head x 30 linear layers x B=1 = ~63 MB at fp32 vs ~16 MB at bf16). Negligible relative to the model weights.

## Verification

- `go build ./x/...` -- clean
- `go test ./x/mlxrunner/cache/... ./x/mlxrunner/mlx/...` -- all pass

Functional verification (M4 Max / 36 GB / macOS 26.4) using `mlx-community/Qwen3.6-35B-A3B-4bit` imported via `ollama create --experimental`:

| | Before | After |
|---|---|---|
| `"What is 2+2?"` | `"\n\n// Copyright ofusr = ..."` | `"<think>\n\n</think>\n\nThe result of $2 + 2$ is **4**."` |
| `"Reverse a string in Go"` | gibberish | clean idiomatic Go one-liner |
| Throughput | 110 tok/s | 110 tok/s |
| `nomic-embed-text` (regression check) | works | works |

mlx-lm's reference on the same checkpoint runs ~112 tok/s for comparison.

## Test plan

- [ ] Reviewer can reproduce on Apple Silicon by importing any `mlx-community/Qwen3.*` MoE checkpoint via `ollama create --experimental` and running a short prompt -- output should be coherent rather than the `Copyright/static/-1999...` pattern reported in #15866.
- [ ] CI: existing cache + mlx tests should continue to pass (verified locally).

Generated with [Claude Code](https://claude.com/claude-code)
</content>
</invoke>