### PR TITLE
docs: clarify ROCm visible device behavior

### DIFF
--- a/docs/gpu.mdx
+++ b/docs/gpu.mdx
@@ -45,6 +45,11 @@ Numeric IDs may be used, however ordering may vary, so UUIDs are more reliable.
 You can discover the UUID of your GPUs by running `nvidia-smi -L` If you want to
 ignore the GPUs and force CPU usage, use an invalid GPU ID (e.g., "-1")
 
+On systems with both NVIDIA and AMD GPUs, ROCm may also honor
+`CUDA_VISIBLE_DEVICES` for HIP compatibility. Setting `CUDA_VISIBLE_DEVICES=-1`
+can hide AMD GPUs as well. To prefer ROCm over CUDA, set `OLLAMA_LLM_LIBRARY=rocm`
+instead.
+
 ### Linux Suspend Resume
 
 On linux, after a suspend/resume cycle, sometimes Ollama will fail to discover
@@ -129,6 +134,11 @@ subset, you can set `ROCR_VISIBLE_DEVICES` to a comma separated list of GPUs.
 You can see the list of devices with `rocminfo`. If you want to ignore the GPUs
 and force CPU usage, use an invalid GPU ID (e.g., "-1"). When available, use the
 `Uuid` to uniquely identify the device instead of numeric value.
+
+On systems with both AMD and NVIDIA GPUs, ROCm may also honor
+`CUDA_VISIBLE_DEVICES` for HIP compatibility. If AMD GPUs disappear
+unexpectedly, unset `CUDA_VISIBLE_DEVICES` and use `ROCR_VISIBLE_DEVICES` to
+select AMD devices.
 
 ### Container Permission
 

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -351,7 +351,7 @@ func AsMap() map[string]EnvVar {
 	}
 
 	if runtime.GOOS != "darwin" {
-		ret["CUDA_VISIBLE_DEVICES"] = EnvVar{"CUDA_VISIBLE_DEVICES", CudaVisibleDevices(), "Set which NVIDIA devices are visible"}
+		ret["CUDA_VISIBLE_DEVICES"] = EnvVar{"CUDA_VISIBLE_DEVICES", CudaVisibleDevices(), "Set which CUDA devices are visible; ROCm may also honor this variable"}
 		ret["HIP_VISIBLE_DEVICES"] = EnvVar{"HIP_VISIBLE_DEVICES", HipVisibleDevices(), "Set which AMD devices are visible by numeric ID"}
 		ret["ROCR_VISIBLE_DEVICES"] = EnvVar{"ROCR_VISIBLE_DEVICES", RocrVisibleDevices(), "Set which AMD devices are visible by UUID or numeric ID"}
 		ret["GGML_VK_VISIBLE_DEVICES"] = EnvVar{"GGML_VK_VISIBLE_DEVICES", VkVisibleDevices(), "Set which Vulkan devices are visible by numeric ID"}


### PR DESCRIPTION
## Summary

- Clarify that ROCm may honor `CUDA_VISIBLE_DEVICES` for HIP compatibility on hybrid NVIDIA/AMD systems
- Point users toward `OLLAMA_LLM_LIBRARY=rocm` when they want to prefer ROCm over CUDA
- Update the server config description for `CUDA_VISIBLE_DEVICES` so it no longer implies NVIDIA-only behavior

## Duplicate check

- Searched all PR states for `#15752`, `CUDA_VISIBLE_DEVICES ROCm`, `CUDA_VISIBLE_DEVICES AMD`, `HIP_VISIBLE_DEVICES`, and `ROCR_VISIBLE_DEVICES`
- Found related GPU discovery/configuration work, but no PR documenting this specific ROCm/HIP compatibility behavior

## Validation

- `gofmt -w envconfig/config.go`
- `git diff --check`
- `GOCACHE=/private/tmp/ollama-go-build GOMODCACHE=/private/tmp/ollama-go-mod go test ./envconfig`

Refs #15752