### PR TITLE
server: cancel pull on client disconnect

### DIFF
--- a/server/download.go
+++ b/server/download.go
@@ -34,6 +34,7 @@ var (
 	errMaxRetriesExceeded   = errors.New("max retries exceeded")
 	errPartStalled          = errors.New("part stalled")
 	errMaxRedirectsExceeded = errors.New("maximum redirects exceeded (10) for directURL")
+	errBlobDownloadCanceled = errors.New("blob download canceled")
 )
 
 var blobDownloadManager sync.Map
@@ -49,9 +50,11 @@ type blobDownload struct {
 
 	context.CancelFunc
 
-	done       chan struct{}
-	err        error
-	references atomic.Int32
+	done         chan struct{}
+	err          error
+	referencesMu sync.Mutex
+	references   atomic.Int32
+	canceled     bool
 }
 
 type blobDownloadPart struct {
@@ -133,8 +136,6 @@ func (b *blobDownload) Prepare(ctx context.Context, requestURL *url.URL, opts *r
 		return err
 	}
 
-	b.done = make(chan struct{})
-
 	for _, partFilePath := range partFilePaths {
 		part, err := b.readPart(partFilePath)
 		if err != nil {
@@ -186,6 +187,12 @@ func (b *blobDownload) Prepare(ctx context.Context, requestURL *url.URL, opts *r
 
 func (b *blobDownload) Run(ctx context.Context, requestURL *url.URL, opts *registryOptions) {
 	defer close(b.done)
+	defer blobDownloadManager.CompareAndDelete(b.Digest, b)
+	if err := ctx.Err(); err != nil {
+		b.err = err
+		return
+	}
+
 	b.err = b.run(ctx, requestURL, opts)
 }
 
@@ -216,9 +223,6 @@ func newBackoff(maxBackoff time.Duration) func(ctx context.Context) error {
 }
 
 func (b *blobDownload) run(ctx context.Context, requestURL *url.URL, opts *registryOptions) error {
-	defer blobDownloadManager.Delete(b.Digest)
-	ctx, b.CancelFunc = context.WithCancel(ctx)
-
 	file, err := os.OpenFile(b.Name+"-partial", os.O_CREATE|os.O_RDWR, 0o644)
 	if err != nil {
 		return err
@@ -433,21 +437,63 @@ func (b *blobDownload) writePart(partName string, part *blobDownloadPart) error 
 	return json.NewEncoder(partFile).Encode(part)
 }
 
-func (b *blobDownload) acquire() {
+func (b *blobDownload) acquire() bool {
+	b.referencesMu.Lock()
+	defer b.referencesMu.Unlock()
+
+	if b.canceled {
+		return false
+	}
+
 	b.references.Add(1)
+	return true
 }
 
 func (b *blobDownload) release() {
+	b.referencesMu.Lock()
+	defer b.referencesMu.Unlock()
+
 	if b.references.Add(-1) == 0 {
-		b.CancelFunc()
+		b.canceled = true
+		if b.CancelFunc != nil {
+			b.CancelFunc()
+		}
 	}
 }
 
+func (b *blobDownload) isCanceled() bool {
+	b.referencesMu.Lock()
+	defer b.referencesMu.Unlock()
+	return b.canceled
+}
+
+func (b *blobDownload) releaseOnContextDone(ctx context.Context, done <-chan struct{}) func() {
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() {
+			b.release()
+		})
+	}
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			release()
+		case <-done:
+		}
+	}()
+
+	return release
+}
+
 func (b *blobDownload) Wait(ctx context.Context, fn func(api.ProgressResponse)) error {
-	b.acquire()
+	if !b.acquire() {
+		return errBlobDownloadCanceled
+	}
 	defer b.release()
 
 	ticker := time.NewTicker(60 * time.Millisecond)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-b.done:
@@ -462,6 +508,15 @@ func (b *blobDownload) Wait(ctx context.Context, fn func(api.ProgressResponse)) 
 		case <-ctx.Done():
 			return ctx.Err()
 		}
+	}
+}
+
+func (b *blobDownload) waitDone(ctx context.Context) error {
+	select {
+	case <-b.done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 
@@ -499,19 +554,73 @@ func downloadBlob(ctx context.Context, opts downloadOpts) (cacheHit bool, _ erro
 		return true, nil
 	}
 
-	data, ok := blobDownloadManager.LoadOrStore(opts.digest, &blobDownload{Name: fp, Digest: opts.digest})
-	download := data.(*blobDownload)
-	if !ok {
-		requestURL := opts.n.BaseURL()
-		requestURL = requestURL.JoinPath("v2", opts.n.DisplayNamespaceModel(), "blobs", opts.digest)
-		if err := download.Prepare(ctx, requestURL, opts.regOpts); err != nil {
-			blobDownloadManager.Delete(opts.digest)
-			return false, err
+	for {
+		runCtx, cancel := context.WithCancel(context.Background())
+		candidate := &blobDownload{
+			Name:       fp,
+			Digest:     opts.digest,
+			CancelFunc: cancel,
+			done:       make(chan struct{}),
+		}
+		candidate.acquire()
+
+		data, ok := blobDownloadManager.LoadOrStore(opts.digest, candidate)
+		download := data.(*blobDownload)
+		releaseCreator := func() {}
+		if !ok {
+			requestURL := opts.n.BaseURL()
+			requestURL = requestURL.JoinPath("v2", opts.n.DisplayNamespaceModel(), "blobs", opts.digest)
+			prepareDone := make(chan struct{})
+			releaseCreator = download.releaseOnContextDone(ctx, prepareDone)
+			err := download.Prepare(runCtx, requestURL, opts.regOpts)
+			close(prepareDone)
+			if err != nil {
+				download.err = err
+				close(download.done)
+				cancel()
+				blobDownloadManager.CompareAndDelete(opts.digest, download)
+				releaseCreator()
+				return false, err
+			}
+
+			if err := ctx.Err(); err != nil {
+				releaseCreator()
+			}
+			if err := runCtx.Err(); err != nil || download.isCanceled() {
+				if err == nil {
+					err = context.Canceled
+				}
+				download.err = err
+				close(download.done)
+				blobDownloadManager.CompareAndDelete(opts.digest, download)
+				releaseCreator()
+				return false, err
+			}
+
+			go download.Run(runCtx, requestURL, opts.regOpts)
+		} else {
+			cancel()
+			if download.isCanceled() {
+				if err := download.waitDone(ctx); err != nil {
+					return false, err
+				}
+				blobDownloadManager.CompareAndDelete(opts.digest, download)
+				continue
+			}
 		}
 
-		//nolint:contextcheck
-		go download.Run(context.Background(), requestURL, opts.regOpts)
-	}
+		err = download.Wait(ctx, opts.fn)
+		if !ok {
+			releaseCreator()
+		}
+		if ok && errors.Is(err, errBlobDownloadCanceled) {
+			if err := download.waitDone(ctx); err != nil {
+				return false, err
+			}
+			blobDownloadManager.CompareAndDelete(opts.digest, download)
+			continue
+		}
 
-	return false, download.Wait(ctx, opts.fn)
+		return false, err
+	}
 }

--- a/server/download_test.go
+++ b/server/download_test.go
@@ -6,12 +6,18 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/types/model"
 )
 
 func BenchmarkDownloadChunkCompletion(b *testing.B) {
@@ -38,6 +44,292 @@ func BenchmarkDownloadChunkCompletion(b *testing.B) {
 		part := &blobDownloadPart{Size: int64(len(data)), blobDownload: download}
 		if err := download.downloadChunk(b.Context(), requestURL, io.Discard, part); err != nil {
 			b.Fatal(err)
+		}
+	}
+}
+
+func TestBlobDownloadCreatorReferencePreventsTransientCancel(t *testing.T) {
+	runCtx, cancel := context.WithCancel(context.Background())
+	b := &blobDownload{
+		Digest:     "sha256:123456789012",
+		CancelFunc: cancel,
+		done:       make(chan struct{}),
+	}
+	b.acquire()
+
+	waitCtx, waitCancel := context.WithCancel(context.Background())
+	waitCancel()
+
+	if err := b.Wait(waitCtx, func(api.ProgressResponse) {}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Wait() error = %v, want context.Canceled", err)
+	}
+
+	select {
+	case <-runCtx.Done():
+		t.Fatal("transient waiter canceled download while creator reference was held")
+	default:
+	}
+
+	b.release()
+
+	select {
+	case <-runCtx.Done():
+	default:
+		t.Fatal("download was not canceled after creator released final reference")
+	}
+}
+
+func TestDownloadBlobCreatorCancelDuringPrepareKeepsActiveWaiter(t *testing.T) {
+	t.Setenv("OLLAMA_MODELS", t.TempDir())
+
+	digest := "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	blobDownloadManager.Delete(digest)
+	t.Cleanup(func() {
+		blobDownloadManager.Delete(digest)
+		testMakeRequestDialContext = nil
+	})
+	defaultTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = defaultTransport
+	})
+
+	headStarted := make(chan struct{})
+	headCanceled := make(chan struct{})
+	allowHead := make(chan struct{})
+	var headStartedOnce sync.Once
+	var headCanceledOnce sync.Once
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodHead && r.URL.Path == "/v2/library/test/blobs/"+digest:
+			headStartedOnce.Do(func() { close(headStarted) })
+			select {
+			case <-allowHead:
+				w.Header().Set("Content-Length", "1")
+			case <-r.Context().Done():
+				headCanceledOnce.Do(func() { close(headCanceled) })
+			}
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/library/test/blobs/"+digest:
+			w.Header().Set("Location", "http://direct.example.com/blob")
+			w.WriteHeader(http.StatusTemporaryRedirect)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	directHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/blob" {
+			http.NotFound(w, r)
+			return
+		}
+
+		w.Header().Set("Content-Length", "1")
+		_, _ = w.Write([]byte("x"))
+	})
+
+	testMakeRequestDialContext = pipeDial(handler)
+	http.DefaultTransport = &http.Transport{
+		DialContext:       pipeDial(directHandler),
+		DisableKeepAlives: true,
+	}
+
+	opts := downloadOpts{
+		n:       model.ParseName("registry.example.com/library/test:latest"),
+		digest:  digest,
+		regOpts: &registryOptions{Insecure: true},
+		fn:      func(api.ProgressResponse) {},
+	}
+
+	creatorCtx, creatorCancel := context.WithCancel(context.Background())
+	creatorErr := make(chan error, 1)
+	go func() {
+		_, err := downloadBlob(creatorCtx, opts)
+		creatorErr <- err
+	}()
+
+	select {
+	case <-headStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for creator to start blob preparation")
+	}
+
+	waiterErr := make(chan error, 1)
+	go func() {
+		_, err := downloadBlob(context.Background(), opts)
+		waiterErr <- err
+	}()
+
+	waitForBlobDownloadReferences(t, digest, 2)
+	creatorCancel()
+	waitForBlobDownloadReferences(t, digest, 1)
+
+	select {
+	case <-headCanceled:
+		t.Fatal("creator cancellation canceled shared preparation with an active waiter")
+	default:
+	}
+	select {
+	case err := <-waiterErr:
+		t.Fatalf("waiter downloadBlob() returned before shared preparation continued: %v", err)
+	default:
+	}
+
+	close(allowHead)
+
+	if err := <-creatorErr; !errors.Is(err, context.Canceled) {
+		t.Fatalf("creator downloadBlob() error = %v, want context.Canceled", err)
+	}
+
+	if err := <-waiterErr; err != nil {
+		t.Fatalf("waiter downloadBlob() error = %v, want nil", err)
+	}
+}
+
+func TestDownloadBlobWaitsForCanceledSharedDownloadToFinish(t *testing.T) {
+	t.Setenv("OLLAMA_MODELS", t.TempDir())
+
+	digest := "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+	blobDownloadManager.Delete(digest)
+	t.Cleanup(func() {
+		blobDownloadManager.Delete(digest)
+		testMakeRequestDialContext = nil
+	})
+	defaultTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = defaultTransport
+	})
+
+	_, oldCancel := context.WithCancel(context.Background())
+	stale := &blobDownload{
+		Digest:     digest,
+		CancelFunc: oldCancel,
+		done:       make(chan struct{}),
+	}
+	stale.acquire()
+	blobDownloadManager.Store(digest, stale)
+	stale.release()
+
+	headStarted := make(chan struct{})
+	var headStartedOnce sync.Once
+
+	registryHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodHead && r.URL.Path == "/v2/library/test/blobs/"+digest:
+			headStartedOnce.Do(func() { close(headStarted) })
+			w.Header().Set("Content-Length", "1")
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/library/test/blobs/"+digest:
+			w.Header().Set("Location", "http://direct.example.com/blob")
+			w.WriteHeader(http.StatusTemporaryRedirect)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	directHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/blob" {
+			http.NotFound(w, r)
+			return
+		}
+
+		w.Header().Set("Content-Length", "1")
+		_, _ = w.Write([]byte("x"))
+	})
+
+	testMakeRequestDialContext = pipeDial(registryHandler)
+	http.DefaultTransport = &http.Transport{
+		DialContext:       pipeDial(directHandler),
+		DisableKeepAlives: true,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	errCh := make(chan error, 1)
+	cacheHitCh := make(chan bool, 1)
+	go func() {
+		cacheHit, err := downloadBlob(ctx, downloadOpts{
+			n:       model.ParseName("registry.example.com/library/test:latest"),
+			digest:  digest,
+			regOpts: &registryOptions{Insecure: true},
+			fn:      func(api.ProgressResponse) {},
+		})
+		cacheHitCh <- cacheHit
+		errCh <- err
+	}()
+
+	select {
+	case <-headStarted:
+		t.Fatal("replacement download started before canceled shared download finished")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(stale.done)
+
+	select {
+	case <-headStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for replacement download to start")
+	}
+
+	err := <-errCh
+	if err != nil {
+		t.Fatalf("downloadBlob() error = %v, want nil", err)
+	}
+	if cacheHit := <-cacheHitCh; cacheHit {
+		t.Fatal("downloadBlob() cacheHit = true, want false")
+	}
+}
+
+func TestBlobDownloadRunCanceledContextDoesNotCreatePartialFile(t *testing.T) {
+	name := filepath.Join(t.TempDir(), "sha256-333333333333")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	download := &blobDownload{
+		Name:   name,
+		Digest: "sha256:333333333333",
+		done:   make(chan struct{}),
+	}
+	blobDownloadManager.Store(download.Digest, download)
+	t.Cleanup(func() {
+		blobDownloadManager.Delete(download.Digest)
+	})
+
+	download.Run(ctx, &url.URL{}, &registryOptions{})
+
+	if !errors.Is(download.err, context.Canceled) {
+		t.Fatalf("Run() error = %v, want context.Canceled", download.err)
+	}
+	if _, err := os.Stat(name + "-partial"); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("Run() created partial file after cancellation: %v", err)
+	}
+	if _, ok := blobDownloadManager.Load(download.Digest); ok {
+		t.Fatal("Run() left canceled download in manager")
+	}
+}
+
+func waitForBlobDownloadReferences(t *testing.T, digest string, want int32) {
+	t.Helper()
+
+	deadline := time.After(time.Second)
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+
+	var got int32
+	var found bool
+	for {
+		if data, ok := blobDownloadManager.Load(digest); ok {
+			found = true
+			got = data.(*blobDownload).references.Load()
+			if got == want {
+				return
+			}
+		} else {
+			found = false
+			got = 0
+		}
+
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for blob references = %d; found=%t got=%d", want, found, got)
+		case <-ticker.C:
 		}
 	}
 }
@@ -110,4 +402,57 @@ func TestDownloadChunkDetectsStallBeforeFirstByte(t *testing.T) {
 	if elapsed >= 5*downloadStallTimeout {
 		t.Fatalf("downloadChunk() detected the stall after %v, want less than %v", elapsed, 5*downloadStallTimeout)
 	}
+}
+
+func pipeDial(handler http.Handler) func(context.Context, string, string) (net.Conn, error) {
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		client, server := net.Pipe()
+		go func() {
+			_ = http.Serve(&singleConnListener{conn: server}, handler)
+		}()
+		return client, nil
+	}
+}
+
+type singleConnListener struct {
+	mu   sync.Mutex
+	conn net.Conn
+}
+
+func (l *singleConnListener) Accept() (net.Conn, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.conn == nil {
+		return nil, io.EOF
+	}
+
+	conn := l.conn
+	l.conn = nil
+	return conn, nil
+}
+
+func (l *singleConnListener) Close() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.conn == nil {
+		return nil
+	}
+
+	err := l.conn.Close()
+	l.conn = nil
+	return err
+}
+
+func (l *singleConnListener) Addr() net.Addr {
+	return pipeAddr("pipe")
+}
+
+type pipeAddr string
+
+func (p pipeAddr) Network() string {
+	return string(p)
+}
+
+func (p pipeAddr) String() string {
+	return string(p)
 }

--- a/server/images.go
+++ b/server/images.go
@@ -1020,7 +1020,13 @@ func PullModel(ctx context.Context, name string, regOpts *registryOptions, fn fu
 	}
 
 	fn(api.ProgressResponse{Status: "verifying sha256 digest"})
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	for _, layer := range layers {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if skipVerify[layer.Digest] {
 			continue
 		}
@@ -1044,6 +1050,9 @@ func PullModel(ctx context.Context, name string, regOpts *registryOptions, fn fu
 	delete(deleteMap, mf.Config.Digest)
 
 	fn(api.ProgressResponse{Status: "writing manifest"})
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 
 	fp, err := manifest.PathForName(n)
 	if err != nil {
@@ -1063,6 +1072,9 @@ func PullModel(ctx context.Context, name string, regOpts *registryOptions, fn fu
 
 	if !envconfig.NoPrune() && len(deleteMap) > 0 {
 		fn(api.ProgressResponse{Status: "removing unused layers"})
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if err := deleteUnusedLayers(deleteMap); err != nil {
 			fn(api.ProgressResponse{Status: fmt.Sprintf("couldn't remove unused layers: %v", err)})
 		}
@@ -1142,6 +1154,9 @@ func pullWithTransfer(ctx context.Context, n model.Name, layers []manifest.Layer
 
 	// Write manifest
 	fn(api.ProgressResponse{Status: "writing manifest"})
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 
 	fp, err := manifest.PathForName(n)
 	if err != nil {

--- a/server/images_test.go
+++ b/server/images_test.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -10,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/fs/ggml"
 	"github.com/ollama/ollama/manifest"
 	"github.com/ollama/ollama/template"
@@ -721,6 +724,65 @@ func TestModelCheckCapabilities(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestPullModelStopsBeforeVerifyWhenProgressCannotStream(t *testing.T) {
+	t.Setenv("OLLAMA_MODELS", t.TempDir())
+
+	_, layerDigest := createBinFile(t, nil, nil)
+	_, configDigest := createBinFile(t, nil, nil)
+
+	blobSize := func(digest string) int64 {
+		t.Helper()
+		p, err := manifest.BlobsPath(digest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		info, err := os.Stat(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return info.Size()
+	}
+
+	manifestJSON := fmt.Sprintf(`{"schemaVersion":2,"mediaType":"application/vnd.docker.distribution.manifest.v2+json","config":{"digest":%q,"mediaType":"application/vnd.docker.container.image.v1+json","size":%d},"layers":[{"digest":%q,"mediaType":"application/vnd.ollama.image.model","size":%d}]}`,
+		configDigest, blobSize(configDigest), layerDigest, blobSize(layerDigest))
+
+	testMakeRequestDialContext = pipeDial(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/v2/library/test/manifests/latest" {
+			w.Header().Set("Content-Type", "application/vnd.docker.distribution.manifest.v2+json")
+			_, _ = w.Write([]byte(manifestJSON))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(func() { testMakeRequestDialContext = nil })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var sawVerify bool
+	name := "registry.example.com/library/test:latest"
+	err := PullModel(ctx, name, &registryOptions{Insecure: true}, func(r api.ProgressResponse) {
+		if r.Status == "verifying sha256 digest" {
+			sawVerify = true
+			cancel()
+		}
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("PullModel() error = %v, want context.Canceled", err)
+	}
+	if !sawVerify {
+		t.Fatal("PullModel() did not reach the verify progress point")
+	}
+
+	manifestPath, err := manifest.PathForName(model.ParseName(name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(manifestPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("PullModel() wrote manifest after cancellation: %v", err)
 	}
 }
 

--- a/server/routes.go
+++ b/server/routes.go
@@ -1120,19 +1120,23 @@ func (s *Server) PullHandler(c *gin.Context) {
 	ch := make(chan any)
 	go func() {
 		defer close(ch)
+		ctx, cancel := context.WithCancel(c.Request.Context())
+		defer cancel()
+
 		fn := func(r api.ProgressResponse) {
-			ch <- r
+			if !sendStreamValue(ctx, ch, r) {
+				cancel()
+			}
 		}
 
 		regOpts := &registryOptions{
 			Insecure: req.Insecure,
 		}
 
-		ctx, cancel := context.WithCancel(c.Request.Context())
-		defer cancel()
-
 		if err := PullModel(ctx, name.DisplayShortest(), regOpts, fn); err != nil {
-			ch <- gin.H{"error": err.Error()}
+			if !errors.Is(err, context.Canceled) {
+				sendStreamValue(ctx, ch, gin.H{"error": err.Error()})
+			}
 			return
 		}
 
@@ -2088,6 +2092,15 @@ func waitForStream(c *gin.Context, ch chan any) {
 	}
 
 	c.JSON(http.StatusOK, latest)
+}
+
+func sendStreamValue(ctx context.Context, ch chan<- any, v any) bool {
+	select {
+	case ch <- v:
+		return true
+	case <-ctx.Done():
+		return false
+	}
 }
 
 func streamResponse(c *gin.Context, ch chan any) {

--- a/server/routes_stream_test.go
+++ b/server/routes_stream_test.go
@@ -1,0 +1,28 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ollama/ollama/api"
+)
+
+func TestSendStreamValueReturnsAfterContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan bool)
+	go func() {
+		done <- sendStreamValue(ctx, make(chan any), api.ProgressResponse{Status: "pulling"})
+	}()
+
+	select {
+	case ok := <-done:
+		if ok {
+			t.Fatal("sendStreamValue succeeded after context cancellation")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("sendStreamValue blocked after context cancellation")
+	}
+}


### PR DESCRIPTION
Fixes #13142.

## Summary
- make `/api/pull` progress sends respect the request context so a disconnected streaming client does not wedge the pull goroutine
- cancel the pull when progress can no longer stream, and check the canceled context before post-download verify/write/prune stages
- keep shared blob preparation/download cancellation tied to the shared reference count so a canceled creator does not abort active waiters
- wait for canceled shared blob downloads to finish before removing/replacing manager entries, so immediate retries do not race on partial files
- prevent canceled shared downloads from launching stale `Run` work after preparation, and make canceled `Run` return before opening/truncating partial files
- use compare-and-delete for shared download cleanup so an old canceled goroutine cannot remove a replacement entry
- add focused tests for cancellation-aware stream sends, post-download cancellation, creator-reference handling, active-waiter completion, canceled shared download retry ordering, and canceled `Run` startup

## Duplicate check
Before opening this, I checked the issue discussion and searched existing PRs for #13142, cancel/abort pull, and download context cancellation. I did not find an existing PR for this exact Option A fix.

## Rebase note
Rebased onto `main` at `fce745f`. The only conflict was the independently added `server/download_test.go`; the resolution preserves the upstream first-byte stall benchmark/tests from #17259 alongside this PR's cancellation regression coverage.

## Testing
- `gofmt -w server/download.go server/download_test.go server/images.go server/images_test.go server/routes.go server/routes_stream_test.go`
- `gofmt -d server/download.go server/download_test.go server/images.go server/images_test.go server/routes.go server/routes_stream_test.go`
- `git diff --check origin/main...HEAD`
- `GOMODCACHE=/private/tmp/ollama-go-mod-fresh GOCACHE=/private/tmp/ollama-go-build-fresh go vet ./server`
- `GOMODCACHE=/private/tmp/ollama-go-mod-fresh GOCACHE=/private/tmp/ollama-go-build-fresh go test ./server -run 'TestBlobDownloadCreatorReferencePreventsTransientCancel|TestDownloadBlobCreatorCancelDuringPrepareKeepsActiveWaiter|TestDownloadBlobWaitsForCanceledSharedDownloadToFinish|TestBlobDownloadRunCanceledContextDoesNotCreatePartialFile|TestPullModelStopsBeforeVerifyWhenProgressCannotStream|TestSendStreamValueReturnsAfterContextCancel|TestDownloadChunkReturnsWhenTransferCompletes|TestDownloadChunkDetectsStallBeforeFirstByte' -count=1`
- `GOMODCACHE=/private/tmp/ollama-go-mod-fresh GOCACHE=/private/tmp/ollama-go-build-fresh go test ./server -run 'TestBlobDownloadCreatorReferencePreventsTransientCancel|TestDownloadBlobCreatorCancelDuringPrepareKeepsActiveWaiter|TestDownloadBlobWaitsForCanceledSharedDownloadToFinish|TestBlobDownloadRunCanceledContextDoesNotCreatePartialFile|TestPullModelStopsBeforeVerifyWhenProgressCannotStream|TestSendStreamValueReturnsAfterContextCancel' -count=20`
- `GOMODCACHE=/private/tmp/ollama-go-mod-fresh GOCACHE=/private/tmp/ollama-go-build-fresh go test -race ./server -run 'TestBlobDownloadCreatorReferencePreventsTransientCancel|TestDownloadBlobCreatorCancelDuringPrepareKeepsActiveWaiter|TestDownloadBlobWaitsForCanceledSharedDownloadToFinish|TestBlobDownloadRunCanceledContextDoesNotCreatePartialFile|TestPullModelStopsBeforeVerifyWhenProgressCannotStream|TestSendStreamValueReturnsAfterContextCancel' -count=1`
- `GOMODCACHE=/private/tmp/ollama-go-mod-fresh GOCACHE=/private/tmp/ollama-go-build-fresh go test ./server -count=1`
