### PR TITLE
launch: use vram bytes for model recommendations

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -813,7 +813,7 @@ type ModelRecommendation struct {
 	Description     string `json:"description"`
 	ContextLength   int    `json:"context_length,omitempty"`
 	MaxOutputTokens int    `json:"max_output_tokens,omitempty"`
-	VRAM            string `json:"vram,omitempty"`
+	VRAMBytes       int64  `json:"vram_bytes,omitempty"`
 }
 
 // ProcessResponse is the response from [Client.Process].

--- a/cmd/launch/integrations_test.go
+++ b/cmd/launch/integrations_test.go
@@ -1658,7 +1658,7 @@ func TestBuildModelList_Descriptions(t *testing.T) {
 
 		for _, item := range items {
 			if item.Name == "qwen3.5" {
-				if !strings.Contains(item.Description, "~11GB") {
+				if !strings.Contains(item.Description, "~14GB") {
 					t.Errorf("not-installed qwen3.5 should show VRAM hint, got %q", item.Description)
 				}
 				return
@@ -1675,7 +1675,7 @@ func TestBuildModelList_Descriptions(t *testing.T) {
 
 		for _, item := range items {
 			if item.Name == "qwen3.5" {
-				if strings.Contains(item.Description, "~11GB") {
+				if strings.Contains(item.Description, "~14GB") {
 					t.Errorf("installed qwen3.5 should not show VRAM hint, got %q", item.Description)
 				}
 				return

--- a/cmd/launch/launch.go
+++ b/cmd/launch/launch.go
@@ -186,7 +186,7 @@ type ModelItem struct {
 	Name            string
 	Description     string
 	Recommended     bool
-	VRAM            string
+	VRAMBytes       int64
 	ContextLength   int
 	MaxOutputTokens int
 }
@@ -783,7 +783,7 @@ func (c *launcherClient) requestRecommendations(ctx context.Context) ([]ModelIte
 			Name:            name,
 			Description:     description,
 			Recommended:     true,
-			VRAM:            strings.TrimSpace(rec.VRAM),
+			VRAMBytes:       rec.VRAMBytes,
 			ContextLength:   rec.ContextLength,
 			MaxOutputTokens: rec.MaxOutputTokens,
 		})

--- a/cmd/launch/models.go
+++ b/cmd/launch/models.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"os"
 	"os/exec"
@@ -26,8 +27,21 @@ var recommendedModels = []ModelItem{
 	{Name: "qwen3.5:cloud", Description: "Reasoning, coding, and agentic tool use with vision", Recommended: true, ContextLength: 262_144, MaxOutputTokens: 32_768},
 	{Name: "glm-5.1:cloud", Description: "Reasoning and code generation", Recommended: true, ContextLength: 202_752, MaxOutputTokens: 131_072},
 	{Name: "minimax-m2.7:cloud", Description: "Fast, efficient coding and real-world productivity", Recommended: true, ContextLength: 204_800, MaxOutputTokens: 128_000},
-	{Name: "gemma4", Description: "Reasoning and code generation locally", Recommended: true, VRAM: "~16GB"},
-	{Name: "qwen3.5", Description: "Reasoning, coding, and visual understanding locally", Recommended: true, VRAM: "~11GB"},
+	{Name: "gemma4", Description: "Reasoning and code generation locally", Recommended: true, VRAMBytes: 12 * bytesPerGB},
+	{Name: "qwen3.5", Description: "Reasoning, coding, and visual understanding locally", Recommended: true, VRAMBytes: 14 * bytesPerGB},
+}
+
+const bytesPerGB = 1_000_000_000
+
+func displayVRAM(vramBytes int64) string {
+	if vramBytes <= 0 {
+		return ""
+	}
+	gb := float64(vramBytes) / bytesPerGB
+	if gb == math.Trunc(gb) {
+		return fmt.Sprintf("~%.0fGB", gb)
+	}
+	return fmt.Sprintf("~%.1fGB", gb)
 }
 
 // cloudModelLimit holds context and output token limits for a cloud model.
@@ -403,8 +417,8 @@ func buildModelListWithRecommendations(existing []modelInfo, recommendations []M
 			if items[i].Description != "" {
 				parts = append(parts, items[i].Description)
 			}
-			if items[i].VRAM != "" {
-				parts = append(parts, items[i].VRAM)
+			if vram := displayVRAM(items[i].VRAMBytes); vram != "" {
+				parts = append(parts, vram)
 			}
 			parts = append(parts, "(not downloaded)")
 			items[i].Description = strings.Join(parts, ", ")

--- a/cmd/launch/models.go
+++ b/cmd/launch/models.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/cmd/config"
 	"github.com/ollama/ollama/cmd/internal/fileutil"
+	"github.com/ollama/ollama/format"
 	internalcloud "github.com/ollama/ollama/internal/cloud"
 	"github.com/ollama/ollama/internal/modelref"
 	"github.com/ollama/ollama/progress"
@@ -27,17 +28,15 @@ var recommendedModels = []ModelItem{
 	{Name: "qwen3.5:cloud", Description: "Reasoning, coding, and agentic tool use with vision", Recommended: true, ContextLength: 262_144, MaxOutputTokens: 32_768},
 	{Name: "glm-5.1:cloud", Description: "Reasoning and code generation", Recommended: true, ContextLength: 202_752, MaxOutputTokens: 131_072},
 	{Name: "minimax-m2.7:cloud", Description: "Fast, efficient coding and real-world productivity", Recommended: true, ContextLength: 204_800, MaxOutputTokens: 128_000},
-	{Name: "gemma4", Description: "Reasoning and code generation locally", Recommended: true, VRAMBytes: 12 * bytesPerGB},
-	{Name: "qwen3.5", Description: "Reasoning, coding, and visual understanding locally", Recommended: true, VRAMBytes: 14 * bytesPerGB},
+	{Name: "gemma4", Description: "Reasoning and code generation locally", Recommended: true, VRAMBytes: 12 * format.GigaByte},
+	{Name: "qwen3.5", Description: "Reasoning, coding, and visual understanding locally", Recommended: true, VRAMBytes: 14 * format.GigaByte},
 }
-
-const bytesPerGB = 1_000_000_000
 
 func displayVRAM(vramBytes int64) string {
 	if vramBytes <= 0 {
 		return ""
 	}
-	gb := float64(vramBytes) / bytesPerGB
+	gb := float64(vramBytes) / format.GigaByte
 	if gb == math.Trunc(gb) {
 		return fmt.Sprintf("~%.0fGB", gb)
 	}

--- a/server/model_recommendations.go
+++ b/server/model_recommendations.go
@@ -17,11 +17,11 @@ import (
 
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/envconfig"
+	"github.com/ollama/ollama/format"
 )
 
 const (
 	modelRecommendationsURL = "https://ollama.com/api/experimental/model-recommendations"
-	bytesPerGB              = 1_000_000_000
 )
 
 var (
@@ -393,11 +393,11 @@ var defaultModelRecommendations = []api.ModelRecommendation{
 	{
 		Model:       "gemma4",
 		Description: "Reasoning and code generation locally",
-		VRAMBytes:   12 * bytesPerGB,
+		VRAMBytes:   12 * format.GigaByte,
 	},
 	{
 		Model:       "qwen3.5",
 		Description: "Reasoning, coding, and visual understanding locally",
-		VRAMBytes:   14 * bytesPerGB,
+		VRAMBytes:   14 * format.GigaByte,
 	},
 }

--- a/server/model_recommendations.go
+++ b/server/model_recommendations.go
@@ -19,7 +19,10 @@ import (
 	"github.com/ollama/ollama/envconfig"
 )
 
-const modelRecommendationsURL = "https://ollama.com/api/experimental/model-recommendations"
+const (
+	modelRecommendationsURL = "https://ollama.com/api/experimental/model-recommendations"
+	bytesPerGB              = 1_000_000_000
+)
 
 var (
 	modelRecommendationsRefreshInterval     = 4 * time.Hour
@@ -320,7 +323,6 @@ func validateModelRecommendations(recs []api.ModelRecommendation) ([]api.ModelRe
 	for _, rec := range recs {
 		rec.Model = strings.TrimSpace(rec.Model)
 		rec.Description = strings.TrimSpace(rec.Description)
-		rec.VRAM = strings.TrimSpace(rec.VRAM)
 
 		if rec.Model == "" {
 			return nil, errors.New("recommendation missing model")
@@ -391,11 +393,11 @@ var defaultModelRecommendations = []api.ModelRecommendation{
 	{
 		Model:       "gemma4",
 		Description: "Reasoning and code generation locally",
-		VRAM:        "~16GB",
+		VRAMBytes:   12 * bytesPerGB,
 	},
 	{
 		Model:       "qwen3.5",
 		Description: "Reasoning, coding, and visual understanding locally",
-		VRAM:        "~11GB",
+		VRAMBytes:   14 * bytesPerGB,
 	},
 }

--- a/server/model_recommendations_test.go
+++ b/server/model_recommendations_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/envconfig"
+	"github.com/ollama/ollama/format"
 )
 
 func TestModelRecommendationsDefaultOrder(t *testing.T) {
@@ -41,11 +42,11 @@ func TestModelRecommendationsCacheRefreshAppliesServerSideChanges(t *testing.T) 
 
 	first := []api.ModelRecommendation{
 		{Model: " first-cloud:cloud ", Description: " first ", ContextLength: 2048, MaxOutputTokens: 512},
-		{Model: " first-local ", Description: " first local ", VRAMBytes: 3 * bytesPerGB},
+		{Model: " first-local ", Description: " first local ", VRAMBytes: 3 * format.GigaByte},
 	}
 	second := []api.ModelRecommendation{
 		{Model: "second-cloud:cloud", Description: "second", ContextLength: 4096, MaxOutputTokens: 1024},
-		{Model: "second-local", Description: "second local", VRAMBytes: 6 * bytesPerGB},
+		{Model: "second-local", Description: "second local", VRAMBytes: 6 * format.GigaByte},
 	}
 
 	calls := 0
@@ -76,7 +77,7 @@ func TestModelRecommendationsCacheRefreshAppliesServerSideChanges(t *testing.T) 
 	}
 	if got, want := cache.Get(), []api.ModelRecommendation{
 		{Model: "first-cloud:cloud", Description: "first", ContextLength: 2048, MaxOutputTokens: 512},
-		{Model: "first-local", Description: "first local", VRAMBytes: 3 * bytesPerGB},
+		{Model: "first-local", Description: "first local", VRAMBytes: 3 * format.GigaByte},
 	}; !slices.Equal(got, want) {
 		t.Fatalf("after first refresh recommendations = %#v, want %#v", got, want)
 	}
@@ -160,7 +161,7 @@ func TestModelRecommendationsCacheRefreshErrorCasesPreserveCurrentData(t *testin
 			setupModelRecommendationsTestEnv(t, "")
 
 			cache := newModelRecommendationsCache()
-			stable := []api.ModelRecommendation{{Model: "stable-local", Description: "stable desc", VRAMBytes: 2 * bytesPerGB}}
+			stable := []api.ModelRecommendation{{Model: "stable-local", Description: "stable desc", VRAMBytes: 2 * format.GigaByte}}
 			cache.set(stable)
 			cache.client = &http.Client{Transport: tc.transport}
 
@@ -211,7 +212,7 @@ func TestModelRecommendationsSnapshotPersistAndLoad(t *testing.T) {
 
 	want := []api.ModelRecommendation{
 		{Model: "persist-cloud:cloud", Description: "persisted", ContextLength: 8192, MaxOutputTokens: 2048},
-		{Model: "persist-local", Description: "persisted local", VRAMBytes: 5 * bytesPerGB},
+		{Model: "persist-local", Description: "persisted local", VRAMBytes: 5 * format.GigaByte},
 	}
 
 	writer := newModelRecommendationsCache()
@@ -256,7 +257,7 @@ func TestValidateModelRecommendationsTrimsAndDropsInvalidCloudEntries(t *testing
 	input := []api.ModelRecommendation{
 		{Model: " good-cloud:cloud ", Description: " good cloud ", ContextLength: 1024, MaxOutputTokens: 256},
 		{Model: "bad-cloud:cloud", Description: "missing limits"},
-		{Model: " good-local ", Description: " good local ", VRAMBytes: 2 * bytesPerGB},
+		{Model: " good-local ", Description: " good local ", VRAMBytes: 2 * format.GigaByte},
 	}
 
 	got, err := validateModelRecommendations(input)
@@ -266,7 +267,7 @@ func TestValidateModelRecommendationsTrimsAndDropsInvalidCloudEntries(t *testing
 
 	want := []api.ModelRecommendation{
 		{Model: "good-cloud:cloud", Description: "good cloud", ContextLength: 1024, MaxOutputTokens: 256},
-		{Model: "good-local", Description: "good local", VRAMBytes: 2 * bytesPerGB},
+		{Model: "good-local", Description: "good local", VRAMBytes: 2 * format.GigaByte},
 	}
 	if !slices.Equal(got, want) {
 		t.Fatalf("validated recommendations = %#v, want %#v", got, want)

--- a/server/model_recommendations_test.go
+++ b/server/model_recommendations_test.go
@@ -41,11 +41,11 @@ func TestModelRecommendationsCacheRefreshAppliesServerSideChanges(t *testing.T) 
 
 	first := []api.ModelRecommendation{
 		{Model: " first-cloud:cloud ", Description: " first ", ContextLength: 2048, MaxOutputTokens: 512},
-		{Model: " first-local ", Description: " first local ", VRAM: " ~3GB "},
+		{Model: " first-local ", Description: " first local ", VRAMBytes: 3 * bytesPerGB},
 	}
 	second := []api.ModelRecommendation{
 		{Model: "second-cloud:cloud", Description: "second", ContextLength: 4096, MaxOutputTokens: 1024},
-		{Model: "second-local", Description: "second local", VRAM: "~6GB"},
+		{Model: "second-local", Description: "second local", VRAMBytes: 6 * bytesPerGB},
 	}
 
 	calls := 0
@@ -76,7 +76,7 @@ func TestModelRecommendationsCacheRefreshAppliesServerSideChanges(t *testing.T) 
 	}
 	if got, want := cache.Get(), []api.ModelRecommendation{
 		{Model: "first-cloud:cloud", Description: "first", ContextLength: 2048, MaxOutputTokens: 512},
-		{Model: "first-local", Description: "first local", VRAM: "~3GB"},
+		{Model: "first-local", Description: "first local", VRAMBytes: 3 * bytesPerGB},
 	}; !slices.Equal(got, want) {
 		t.Fatalf("after first refresh recommendations = %#v, want %#v", got, want)
 	}
@@ -160,7 +160,7 @@ func TestModelRecommendationsCacheRefreshErrorCasesPreserveCurrentData(t *testin
 			setupModelRecommendationsTestEnv(t, "")
 
 			cache := newModelRecommendationsCache()
-			stable := []api.ModelRecommendation{{Model: "stable-local", Description: "stable desc", VRAM: "~2GB"}}
+			stable := []api.ModelRecommendation{{Model: "stable-local", Description: "stable desc", VRAMBytes: 2 * bytesPerGB}}
 			cache.set(stable)
 			cache.client = &http.Client{Transport: tc.transport}
 
@@ -211,7 +211,7 @@ func TestModelRecommendationsSnapshotPersistAndLoad(t *testing.T) {
 
 	want := []api.ModelRecommendation{
 		{Model: "persist-cloud:cloud", Description: "persisted", ContextLength: 8192, MaxOutputTokens: 2048},
-		{Model: "persist-local", Description: "persisted local", VRAM: "~5GB"},
+		{Model: "persist-local", Description: "persisted local", VRAMBytes: 5 * bytesPerGB},
 	}
 
 	writer := newModelRecommendationsCache()
@@ -256,7 +256,7 @@ func TestValidateModelRecommendationsTrimsAndDropsInvalidCloudEntries(t *testing
 	input := []api.ModelRecommendation{
 		{Model: " good-cloud:cloud ", Description: " good cloud ", ContextLength: 1024, MaxOutputTokens: 256},
 		{Model: "bad-cloud:cloud", Description: "missing limits"},
-		{Model: " good-local ", Description: " good local ", VRAM: " ~2GB "},
+		{Model: " good-local ", Description: " good local ", VRAMBytes: 2 * bytesPerGB},
 	}
 
 	got, err := validateModelRecommendations(input)
@@ -266,7 +266,7 @@ func TestValidateModelRecommendationsTrimsAndDropsInvalidCloudEntries(t *testing
 
 	want := []api.ModelRecommendation{
 		{Model: "good-cloud:cloud", Description: "good cloud", ContextLength: 1024, MaxOutputTokens: 256},
-		{Model: "good-local", Description: "good local", VRAM: "~2GB"},
+		{Model: "good-local", Description: "good local", VRAMBytes: 2 * bytesPerGB},
 	}
 	if !slices.Equal(got, want) {
 		t.Fatalf("validated recommendations = %#v, want %#v", got, want)


### PR DESCRIPTION
Updated the experimental interface to send bytes down instead of a string, updating endpoint locally to respect that