### PR TITLE
cuda: prevent Gemma 4 Dense FA hang for head_dim=512

### DIFF
--- a/fs/ggml/ggml.go
+++ b/fs/ggml/ggml.go
@@ -883,7 +883,27 @@ func (f GGML) SupportsFlashAttention() bool {
 	// Check head counts match and are non-zero
 	headCountK := f.KV().EmbeddingHeadCountK()
 	headCountV := f.KV().EmbeddingHeadCountV()
-	return headCountK != 0 && headCountV != 0 && headCountK == headCountV
+	if headCountK == 0 || headCountV == 0 || headCountK != headCountV {
+		return false
+	}
+
+	// Hybrid attention architectures (e.g. Gemma 4) have a second head_dim
+	// for sliding-window layers. The SWA head_dim must also be FA-compatible
+	// and its K/V dims must match. Without this check, a model with a
+	// FA-supported global head_dim but an unsupported SWA head_dim (or
+	// mismatched SWA K/V) silently runs FA on global layers while the SWA
+	// layers fall back, which can produce graph-scheduling stalls
+	// (see issue #15350).
+	swaK := f.KV().Uint(fmt.Sprintf("%s.attention.key_length_swa", arch), 0)
+	swaV := f.KV().Uint(fmt.Sprintf("%s.attention.value_length_swa", arch), 0)
+	if swaK != 0 || swaV != 0 {
+		// If either is set, both must be set, equal, and non-zero.
+		if swaK == 0 || swaV == 0 || swaK != swaV {
+			return false
+		}
+	}
+
+	return true
 }
 
 // FlashAttention checks if the model should enable flash attention

--- a/ml/backend/ggml/ggml/src/ggml-cuda/fattn.cu
+++ b/ml/backend/ggml/ggml/src/ggml-cuda/fattn.cu
@@ -256,7 +256,17 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
             }
             break;
         case 512:
-            if (!gqa_opt_applies) {
+            // The MMA F16 dispatcher in ggml_cuda_flash_attn_ext_mma_f16_switch_ncols2
+            // selects ncols2 in {1, 2, 4, 8} based on (gqa_ratio, use_gqa_opt).
+            // Only ncols2 \u2208 {4, 8} are explicitly instantiated for DKQ=DV=512
+            // (see fattn-mma-f16.cuh: extern DECL_FATTN_MMA_F16_CASE(512, 512, ...)).
+            // If we reach this kernel with ncols2 \u2208 {1, 2}, an implicit instantiation
+            // of an unvalidated template specialization is used, which can launch a
+            // kernel with shared-memory / launch-bound parameters that hang the GPU
+            // for large prefill batches (issue #15350: Gemma 4 31B Dense FA hang).
+            // Require gqa_ratio % 4 == 0 so the dispatcher always lands on an
+            // instantiated path (matches the existing case 576 guard below).
+            if (!gqa_opt_applies || gqa_ratio % 4 != 0) {
                 return BEST_FATTN_KERNEL_NONE;
             }
             break;


### PR DESCRIPTION
Fixes #15350.

## Root Cause

Template-instantiation gap in the FA MMA dispatcher: for DKQ=DV=512 only ncols2 in {4,8} are explicitly instantiated, but the dispatcher can select ncols2 in {1,2} when gqa_ratio % 4 != 0, producing implicit template instantiations that hang the GPU.

PR #15296 / revert #15311 disabled FA entirely for Gemma 4. This PR fixes the underlying dispatcher gap.

## Changes (32+ / 2-)

1. fattn.cu — tighten case 512 guard to require gqa_ratio % 4 == 0 (mirrors case 576 precedent)
2. ggml.go — extend SupportsFlashAttention() to inspect key_length_swa/value_length_swa for hybrid architectures

Full root-cause analysis in the issue comment.