### PR TITLE
docs: fix linux tar.zst extraction

### DIFF
--- a/docs/linux.mdx
+++ b/docs/linux.mdx
@@ -17,11 +17,13 @@ curl -fsSL https://ollama.com/install.sh | sh
   with `sudo rm -rf /usr/lib/ollama` first.
 </Note>
 
-Download and extract the package:
+Install `zstd` if it is not already available, then download and extract the
+package:
 
 ```shell
 curl -fsSL https://ollama.com/download/ollama-linux-amd64.tar.zst \
-    | sudo tar x -C /usr
+    | zstd -dc \
+    | sudo tar -x -C /usr
 ```
 
 Start Ollama:
@@ -42,7 +44,8 @@ If you have an AMD GPU, also download and extract the additional ROCm package:
 
 ```shell
 curl -fsSL https://ollama.com/download/ollama-linux-amd64-rocm.tar.zst \
-    | sudo tar x -C /usr
+    | zstd -dc \
+    | sudo tar -x -C /usr
 ```
 
 ### ARM64 install
@@ -51,7 +54,8 @@ Download and extract the ARM64-specific package:
 
 ```shell
 curl -fsSL https://ollama.com/download/ollama-linux-arm64.tar.zst \
-    | sudo tar x -C /usr
+    | zstd -dc \
+    | sudo tar -x -C /usr
 ```
 
 ### Adding Ollama as a startup service (recommended)
@@ -147,7 +151,8 @@ Or by re-downloading Ollama:
 
 ```shell
 curl -fsSL https://ollama.com/download/ollama-linux-amd64.tar.zst \
-    | sudo tar x -C /usr
+    | zstd -dc \
+    | sudo tar -x -C /usr
 ```
 
 ## Installing specific versions


### PR DESCRIPTION
Fixes #15693.

## Summary
- document that manual Linux tarball installs require `zstd`
- pipe `.tar.zst` downloads through `zstd -dc` before extracting with `tar`
- update the amd64, ROCm, ARM64, and manual update examples consistently

## Duplicate check
I checked the issue page before opening this; GitHub showed no linked branches or pull requests for #15693. I also searched for existing PRs mentioning the issue and `tar.zst` extraction before making the change.

## Testing
- `git diff --cached --check`
- `zstd -dc --version`