### PR TITLE
readme: add spell to Terminal & CLI community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ console.log(response.message.content);
 - [LLM-X](https://github.com/mrdjohnson/llm-x) - Progressive web app for LLMs
 - [cmdh](https://github.com/pgibler/cmdh) - Natural language to shell commands
 - [VT](https://github.com/vinhnx/vt.ai) - Minimal multimodal AI chat app
+- [spell](https://github.com/rockscy/spell) - Inline AI command palette: type plain English, get a shell command in the same input box, edit and run
 
 ### Productivity & Apps
 


### PR DESCRIPTION
Adds [spell](https://github.com/rockscy/spell) to the **Terminal & CLI** community integrations.

**spell** is a small Go CLI that turns natural-language requests into shell commands. The generated command lands directly in the same input box the user typed their intent into, so it can be edited inline before pressing enter to run. Renders inline (no alt-screen) so the whole transcript stays in shell scrollback.

Ollama support is first-class — the setup wizard has an "Ollama (local, no key needed)" preset that points at \`http://localhost:11434/v1\` out of the box. I've been running it daily against \`llama3.2\`, \`qwen2.5\`, and \`mistral\` for a few weeks.

- Single 7 MB Go binary, MIT licensed, no telemetry
- Built with Bubble Tea + Lip Gloss + huh
- Reasoning-style local models (e.g. DeepSeek-R1 distills) get their \`reasoning_content\` streamed as dimmed italic
- Works with any other OpenAI-compatible endpoint as well, but Ollama is the recommended local default

Demo: 13-second GIF in the README. Happy to revise the entry text if you'd like a different framing.