### PR TITLE
create: keep linear_attn in_proj_qkv and in_proj_z in BF16 for NVFP4/MXFP4/MXFP8

### DIFF
--- a/x/create/create_test.go
+++ b/x/create/create_test.go
@@ -1544,6 +1544,8 @@ func TestCreateSafetensorsModel_Qwen35DirectNonAffineKeepsSensitiveWeightsBF16(t
 				st.NewTensorDataFromBytes("lm_head.weight", "BF16", []int32{64, 64}, make([]byte, 64*64*2)),
 				st.NewTensorDataFromBytes("model.language_model.layers.0.linear_attn.in_proj_a.weight", "BF16", []int32{32, 64}, make([]byte, 32*64*2)),
 				st.NewTensorDataFromBytes("model.language_model.layers.0.linear_attn.in_proj_b.weight", "BF16", []int32{32, 64}, make([]byte, 32*64*2)),
+				st.NewTensorDataFromBytes("model.language_model.layers.0.linear_attn.in_proj_qkv.weight", "BF16", []int32{64, 64}, make([]byte, 64*64*2)),
+				st.NewTensorDataFromBytes("model.language_model.layers.0.linear_attn.in_proj_z.weight", "BF16", []int32{64, 64}, make([]byte, 64*64*2)),
 				st.NewTensorDataFromBytes("model.language_model.layers.0.mlp.gate.weight", "BF16", []int32{64, 64}, make([]byte, 64*64*2)),
 				st.NewTensorDataFromBytes("model.language_model.layers.0.mlp.shared_expert_gate.weight", "BF16", []int32{1, 64}, make([]byte, 64*2)),
 				st.NewTensorDataFromBytes("model.language_model.layers.0.self_attn.q_proj.weight", "BF16", []int32{64, 64}, make([]byte, 64*64*2)),
@@ -1598,6 +1600,8 @@ func TestCreateSafetensorsModel_Qwen35DirectNonAffineKeepsSensitiveWeightsBF16(t
 				"language_model.lm_head.weight",
 				"language_model.model.layers.0.linear_attn.in_proj_a.weight",
 				"language_model.model.layers.0.linear_attn.in_proj_b.weight",
+				"language_model.model.layers.0.linear_attn.in_proj_qkv.weight",
+				"language_model.model.layers.0.linear_attn.in_proj_z.weight",
 				"language_model.model.layers.0.mlp.gate.weight",
 				"language_model.model.layers.0.mlp.shared_expert_gate.weight",
 			} {

--- a/x/create/qwen35.go
+++ b/x/create/qwen35.go
@@ -99,6 +99,10 @@ func qwen35ShouldKeepBF16ForDirectNonAffine(name string) bool {
 		return true
 	case strings.HasSuffix(name, ".linear_attn.in_proj_ba.weight"):
 		return true
+	case strings.HasSuffix(name, ".linear_attn.in_proj_qkv.weight"):
+		return true
+	case strings.HasSuffix(name, ".linear_attn.in_proj_z.weight"):
+		return true
 	case strings.HasSuffix(name, ".mlp.gate.weight") && !strings.Contains(name, "_proj"):
 		return true
 	case strings.HasSuffix(name, ".mlp.shared_expert_gate.weight"):


### PR DESCRIPTION
## Summary

Adds `in_proj_qkv.weight` and `in_proj_z.weight` to the BF16 exemption
list in `qwen35ShouldKeepBF16ForDirectNonAffine`. The upstream source
(RedHatAI/Qwen3.6-35B-A3B-NVFP4) keeps all `linear_attn` projections in
BF16 -- `in_proj_a` and `in_proj_b` were already exempted but `in_proj_qkv`
and `in_proj_z` were missing, so they got NVFP4-quantized.

The K-projection rows in `in_proj_qkv` have small magnitudes (0.01-0.04)
in early layers that fall below the smallest FP4 codepoint at group_size=16,
zeroing out layers 0-1 entirely.

### Weight magnitude analysis (source BF16, Qwen/Qwen3.6-35B-A3B)

| Tensor | Layer | Median abs | % < 0.01 | % < 0.05 |
|--------|-------|-----------|----------|----------|
| in_proj_qkv | 0 | 0.0093 | 52.7% | 99.5% |
| in_proj_z | 0 | 0.0109 | 46.3% | 99.4% |
| in_proj_qkv | 1 | 0.0100 | 49.8% | 99.4% |
| in_proj_z | 1 | 0.0101 | 49.4% | 99.5% |

Both tensors have ~50% of weights below the smallest FP4 codepoint at group_size=16. in_proj_z has the same zero-collapse risk as in_proj_qkv.

Test updated, passes locally for nvfp4/mxfp8/mxfp4.


Fixes #15866