### PR TITLE
app: remove ollama update url env var used for testing

### DIFF
--- a/app/cmd/app/app.go
+++ b/app/cmd/app/app.go
@@ -157,10 +157,6 @@ func main() {
 		}
 	}
 
-	if u := os.Getenv("OLLAMA_UPDATE_URL"); u != "" {
-		updater.UpdateCheckURLBase = u
-	}
-
 	// Detect if this is a first start after an upgrade, in
 	// which case we need to do some cleanup
 	var skipMove bool


### PR DESCRIPTION
This env var is not needed. Only used for development. 