### PR TITLE
cmd/launch: improve integration backup UX

### DIFF
--- a/cmd/internal/fileutil/files.go
+++ b/cmd/internal/fileutil/files.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -38,16 +39,24 @@ func copyFile(src, dst string) error {
 
 // BackupDir returns the shared backup directory used before overwriting files.
 func BackupDir() string {
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		return filepath.Join(home, ".ollama", "backups")
+	}
 	return filepath.Join(os.TempDir(), "ollama-backups")
 }
 
-func backupToTmp(srcPath string) (string, error) {
+func backupToTmp(srcPath string, hint string) (string, error) {
 	dir := BackupDir()
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return "", err
 	}
 
-	backupPath := filepath.Join(dir, fmt.Sprintf("%s.%d", filepath.Base(srcPath), time.Now().Unix()))
+	name := filepath.Base(srcPath)
+	if hint := sanitizeBackupHint(hint); hint != "" {
+		name = hint + "-" + name
+	}
+
+	backupPath := filepath.Join(dir, fmt.Sprintf("%s.%d", name, time.Now().Unix()))
 	if err := copyFile(srcPath, backupPath); err != nil {
 		return "", err
 	}
@@ -56,11 +65,22 @@ func backupToTmp(srcPath string) (string, error) {
 
 // WriteWithBackup writes data to path via temp file + rename, backing up any existing file first.
 func WriteWithBackup(path string, data []byte) error {
+	return writeWithBackup(path, data, "")
+}
+
+// WriteWithBackupHint writes data to path with the same safety guarantees as
+// WriteWithBackup, but prefixes backup filenames with <hint>- when a short
+// caller hint is provided.
+func WriteWithBackupHint(path string, data []byte, hint string) error {
+	return writeWithBackup(path, data, hint)
+}
+
+func writeWithBackup(path string, data []byte, hint string) error {
 	var backupPath string
 	// backup must be created before any writes to the target file
 	if existingContent, err := os.ReadFile(path); err == nil {
 		if !bytes.Equal(existingContent, data) {
-			backupPath, err = backupToTmp(path)
+			backupPath, err = backupToTmp(path, hint)
 			if err != nil {
 				return fmt.Errorf("backup failed: %w", err)
 			}
@@ -100,4 +120,29 @@ func WriteWithBackup(path string, data []byte) error {
 	}
 
 	return nil
+}
+
+func sanitizeBackupHint(hint string) string {
+	hint = strings.TrimSpace(strings.ToLower(hint))
+	if hint == "" {
+		return ""
+	}
+
+	var b strings.Builder
+	b.Grow(len(hint))
+	lastDash := false
+	for _, r := range hint {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			lastDash = false
+		case r == '-', r == '_', r == ' ':
+			if b.Len() > 0 && !lastDash {
+				b.WriteByte('-')
+				lastDash = true
+			}
+		}
+	}
+
+	return strings.Trim(b.String(), "-")
 }

--- a/cmd/internal/fileutil/files.go
+++ b/cmd/internal/fileutil/files.go
@@ -37,23 +37,23 @@ func copyFile(src, dst string) error {
 	return os.WriteFile(dst, data, info.Mode().Perm())
 }
 
-// BackupDir returns the shared backup directory used before overwriting files.
+// BackupDir returns the shared backup root used before overwriting files.
 func BackupDir() string {
 	if home, err := os.UserHomeDir(); err == nil && home != "" {
-		return filepath.Join(home, ".ollama", "backups")
+		return filepath.Join(home, ".ollama", "backup")
 	}
-	return filepath.Join(os.TempDir(), "ollama-backups")
+	return filepath.Join(os.TempDir(), "ollama-backup")
 }
 
-func backupToTmp(srcPath string, hint string) (string, error) {
+func writeBackupCopy(srcPath string, hint string) (string, error) {
 	dir := BackupDir()
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return "", err
-	}
-
 	name := filepath.Base(srcPath)
 	if hint := sanitizeBackupHint(hint); hint != "" {
-		name = hint + "-" + name
+		dir = filepath.Join(dir, hint)
+	}
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
 	}
 
 	backupPath := filepath.Join(dir, fmt.Sprintf("%s.%d", name, time.Now().Unix()))
@@ -69,8 +69,8 @@ func WriteWithBackup(path string, data []byte) error {
 }
 
 // WriteWithBackupHint writes data to path with the same safety guarantees as
-// WriteWithBackup, but prefixes backup filenames with <hint>- when a short
-// caller hint is provided.
+// WriteWithBackup, but stores backups under a sanitized <hint>/ subdirectory
+// when a short caller hint is provided.
 func WriteWithBackupHint(path string, data []byte, hint string) error {
 	return writeWithBackup(path, data, hint)
 }
@@ -80,7 +80,7 @@ func writeWithBackup(path string, data []byte, hint string) error {
 	// backup must be created before any writes to the target file
 	if existingContent, err := os.ReadFile(path); err == nil {
 		if !bytes.Equal(existingContent, data) {
-			backupPath, err = backupToTmp(path, hint)
+			backupPath, err = writeBackupCopy(path, hint)
 			if err != nil {
 				return fmt.Errorf("backup failed: %w", err)
 			}
@@ -122,6 +122,12 @@ func writeWithBackup(path string, data []byte, hint string) error {
 	return nil
 }
 
+// sanitizeBackupHint converts a caller-provided integration label into one
+// stable path segment for BackupDir()/.../<hint>/.
+//
+// We keep only lowercase ASCII letters and digits, and collapse common
+// separators to "-". That lets callers pass human-readable names without
+// accidentally creating nested paths or platform-specific directory names.
 func sanitizeBackupHint(hint string) string {
 	hint = strings.TrimSpace(strings.ToLower(hint))
 	if hint == "" {

--- a/cmd/internal/fileutil/files.go
+++ b/cmd/internal/fileutil/files.go
@@ -8,8 +8,15 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
 	"time"
 )
+
+// Keep a bounded number of backups per file so config backups do not grow
+// without limit. We keep the 5 most recent backups and do not pin the oldest.
+const maxBackupsPerFile = 5
 
 // ReadJSON reads a JSON object file into a generic map.
 func ReadJSON(path string) (map[string]any, error) {
@@ -44,11 +51,11 @@ func BackupDir() string {
 	return filepath.Join(os.TempDir(), "ollama-backup")
 }
 
-func writeBackupCopy(srcPath string, hint string) (string, error) {
+func writeBackupCopy(srcPath string, integration string) (string, error) {
 	dir := BackupDir()
 	name := filepath.Base(srcPath)
-	if hint != "" {
-		dir = filepath.Join(dir, hint)
+	if integration != "" {
+		dir = filepath.Join(dir, integration)
 	}
 
 	if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -59,29 +66,28 @@ func writeBackupCopy(srcPath string, hint string) (string, error) {
 	if err := copyFile(srcPath, backupPath); err != nil {
 		return "", err
 	}
+	pruneOldBackups(dir, name, maxBackupsPerFile)
 	return backupPath, nil
 }
 
 // WriteWithBackup writes data to path via temp file + rename, backing up any
-// existing file first. Callers may optionally pass one integration hint to
-// store backups under BackupDir()/.../<hint>/.
-func WriteWithBackup(path string, data []byte, hint ...string) error {
-	backupHint := ""
-	if len(hint) > 0 {
-		backupHint = hint[0]
+// existing file first. Callers may optionally pass one integration name to
+// store backups under BackupDir()/.../<integration>/.
+func WriteWithBackup(path string, data []byte, integration ...string) error {
+	backupIntegration := ""
+	if len(integration) > 0 {
+		backupIntegration = integration[0]
 	}
-	return writeWithBackup(path, data, backupHint)
-}
 
-func writeWithBackup(path string, data []byte, hint string) error {
 	var backupPath string
 	// backup must be created before any writes to the target file
 	if existingContent, err := os.ReadFile(path); err == nil {
-		if !bytes.Equal(existingContent, data) {
-			backupPath, err = writeBackupCopy(path, hint)
-			if err != nil {
-				return fmt.Errorf("backup failed: %w", err)
-			}
+		if bytes.Equal(existingContent, data) {
+			return nil
+		}
+		backupPath, err = writeBackupCopy(path, backupIntegration)
+		if err != nil {
+			return fmt.Errorf("backup failed: %w", err)
 		}
 	} else if !os.IsNotExist(err) {
 		return fmt.Errorf("read existing file: %w", err)
@@ -118,4 +124,53 @@ func writeWithBackup(path string, data []byte, hint string) error {
 	}
 
 	return nil
+}
+
+func pruneOldBackups(dir, name string, keep int) {
+	if keep < 1 {
+		return
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+
+	type backupEntry struct {
+		name      string
+		timestamp int64
+	}
+
+	prefix := name + "."
+	backups := make([]backupEntry, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasPrefix(entry.Name(), prefix) {
+			continue
+		}
+
+		timestamp, err := strconv.ParseInt(strings.TrimPrefix(entry.Name(), prefix), 10, 64)
+		if err != nil {
+			continue
+		}
+
+		backups = append(backups, backupEntry{
+			name:      entry.Name(),
+			timestamp: timestamp,
+		})
+	}
+
+	if len(backups) <= keep {
+		return
+	}
+
+	sort.Slice(backups, func(i, j int) bool {
+		if backups[i].timestamp != backups[j].timestamp {
+			return backups[i].timestamp > backups[j].timestamp
+		}
+		return backups[i].name > backups[j].name
+	})
+
+	for _, backup := range backups[keep:] {
+		_ = os.Remove(filepath.Join(dir, backup.name))
+	}
 }

--- a/cmd/internal/fileutil/files.go
+++ b/cmd/internal/fileutil/files.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 )
 
@@ -48,7 +47,7 @@ func BackupDir() string {
 func writeBackupCopy(srcPath string, hint string) (string, error) {
 	dir := BackupDir()
 	name := filepath.Base(srcPath)
-	if hint := sanitizeBackupHint(hint); hint != "" {
+	if hint != "" {
 		dir = filepath.Join(dir, hint)
 	}
 
@@ -119,35 +118,4 @@ func writeWithBackup(path string, data []byte, hint string) error {
 	}
 
 	return nil
-}
-
-// sanitizeBackupHint converts a caller-provided integration label into one
-// stable path segment for BackupDir()/.../<hint>/.
-//
-// We keep only lowercase ASCII letters and digits, and collapse common
-// separators to "-". That lets callers pass human-readable names without
-// accidentally creating nested paths or platform-specific directory names.
-func sanitizeBackupHint(hint string) string {
-	hint = strings.TrimSpace(strings.ToLower(hint))
-	if hint == "" {
-		return ""
-	}
-
-	var b strings.Builder
-	b.Grow(len(hint))
-	lastDash := false
-	for _, r := range hint {
-		switch {
-		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
-			b.WriteRune(r)
-			lastDash = false
-		case r == '-', r == '_', r == ' ':
-			if b.Len() > 0 && !lastDash {
-				b.WriteByte('-')
-				lastDash = true
-			}
-		}
-	}
-
-	return strings.Trim(b.String(), "-")
 }

--- a/cmd/internal/fileutil/files.go
+++ b/cmd/internal/fileutil/files.go
@@ -63,16 +63,15 @@ func writeBackupCopy(srcPath string, hint string) (string, error) {
 	return backupPath, nil
 }
 
-// WriteWithBackup writes data to path via temp file + rename, backing up any existing file first.
-func WriteWithBackup(path string, data []byte) error {
-	return writeWithBackup(path, data, "")
-}
-
-// WriteWithBackupHint writes data to path with the same safety guarantees as
-// WriteWithBackup, but stores backups under a sanitized <hint>/ subdirectory
-// when a short caller hint is provided.
-func WriteWithBackupHint(path string, data []byte, hint string) error {
-	return writeWithBackup(path, data, hint)
+// WriteWithBackup writes data to path via temp file + rename, backing up any
+// existing file first. Callers may optionally pass one integration hint to
+// store backups under BackupDir()/.../<hint>/.
+func WriteWithBackup(path string, data []byte, hint ...string) error {
+	backupHint := ""
+	if len(hint) > 0 {
+		backupHint = hint[0]
+	}
+	return writeWithBackup(path, data, backupHint)
 }
 
 func writeWithBackup(path string, data []byte, hint string) error {

--- a/cmd/internal/fileutil/files_test.go
+++ b/cmd/internal/fileutil/files_test.go
@@ -41,6 +41,17 @@ func isolatedTempDir(t *testing.T) string {
 func TestWriteWithBackup(t *testing.T) {
 	tmpDir := isolatedTempDir(t)
 
+	t.Run("uses ollama directory under home", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("USERPROFILE", home)
+
+		want := filepath.Join(home, ".ollama", "backups")
+		if got := BackupDir(); got != want {
+			t.Fatalf("BackupDir() = %q, want %q", got, want)
+		}
+	})
+
 	t.Run("creates file", func(t *testing.T) {
 		path := filepath.Join(tmpDir, "new.json")
 		data := mustMarshal(t, map[string]string{"key": "value"})
@@ -107,6 +118,35 @@ func TestWriteWithBackup(t *testing.T) {
 		json.Unmarshal(current, &currentData)
 		if !currentData["updated"] {
 			t.Error("file doesn't contain updated data")
+		}
+	})
+
+	t.Run("prefixes backup filename with hint when provided", func(t *testing.T) {
+		path := filepath.Join(tmpDir, "hinted.json")
+		os.WriteFile(path, []byte(`{"original": true}`), 0o644)
+
+		data := mustMarshal(t, map[string]bool{"updated": true})
+		if err := WriteWithBackupHint(path, data, "OpenClaw"); err != nil {
+			t.Fatal(err)
+		}
+
+		entries, err := os.ReadDir(BackupDir())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var found bool
+		for _, entry := range entries {
+			name := entry.Name()
+			if len(name) > len("openclaw-hinted.json.") && name[:len("openclaw-hinted.json.")] == "openclaw-hinted.json." {
+				found = true
+				_ = os.Remove(filepath.Join(BackupDir(), name))
+				break
+			}
+		}
+
+		if !found {
+			t.Error("backup filename did not include sanitized hint")
 		}
 	})
 
@@ -302,7 +342,7 @@ func TestBackupToTmp_SpecialCharsInFilename(t *testing.T) {
 	path := filepath.Join(tmpDir, "my config (backup).json")
 	os.WriteFile(path, []byte(`{"test": true}`), 0o644)
 
-	backupPath, err := backupToTmp(path)
+	backupPath, err := backupToTmp(path, "")
 	if err != nil {
 		t.Fatalf("backupToTmp with special chars failed: %v", err)
 	}

--- a/cmd/internal/fileutil/files_test.go
+++ b/cmd/internal/fileutil/files_test.go
@@ -132,7 +132,7 @@ func TestWriteWithBackup(t *testing.T) {
 		os.WriteFile(path, []byte(`{"original": true}`), 0o644)
 
 		data := mustMarshal(t, map[string]bool{"updated": true})
-		if err := WriteWithBackup(path, data, "OpenClaw"); err != nil {
+		if err := WriteWithBackup(path, data, "openclaw"); err != nil {
 			t.Fatal(err)
 		}
 
@@ -152,7 +152,7 @@ func TestWriteWithBackup(t *testing.T) {
 		}
 
 		if !found {
-			t.Error("backup file was not created under sanitized hint directory")
+			t.Error("backup file was not created under hint directory")
 		}
 	})
 

--- a/cmd/internal/fileutil/files_test.go
+++ b/cmd/internal/fileutil/files_test.go
@@ -18,6 +18,12 @@ func TestMain(m *testing.M) {
 	if err := os.Setenv("TMPDIR", tmpRoot); err != nil {
 		panic(err)
 	}
+	if err := os.Setenv("HOME", tmpRoot); err != nil {
+		panic(err)
+	}
+	if err := os.Setenv("USERPROFILE", tmpRoot); err != nil {
+		panic(err)
+	}
 
 	code := m.Run()
 	_ = os.RemoveAll(tmpRoot)
@@ -46,7 +52,7 @@ func TestWriteWithBackup(t *testing.T) {
 		t.Setenv("HOME", home)
 		t.Setenv("USERPROFILE", home)
 
-		want := filepath.Join(home, ".ollama", "backups")
+		want := filepath.Join(home, ".ollama", "backup")
 		if got := BackupDir(); got != want {
 			t.Fatalf("BackupDir() = %q, want %q", got, want)
 		}
@@ -74,7 +80,7 @@ func TestWriteWithBackup(t *testing.T) {
 		}
 	})
 
-	t.Run("creates backup in the temp backup directory", func(t *testing.T) {
+	t.Run("creates backup in the shared backup directory", func(t *testing.T) {
 		path := filepath.Join(tmpDir, "backup.json")
 
 		os.WriteFile(path, []byte(`{"original": true}`), 0o644)
@@ -121,7 +127,7 @@ func TestWriteWithBackup(t *testing.T) {
 		}
 	})
 
-	t.Run("prefixes backup filename with hint when provided", func(t *testing.T) {
+	t.Run("stores hinted backups under a subdirectory", func(t *testing.T) {
 		path := filepath.Join(tmpDir, "hinted.json")
 		os.WriteFile(path, []byte(`{"original": true}`), 0o644)
 
@@ -130,7 +136,7 @@ func TestWriteWithBackup(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		entries, err := os.ReadDir(BackupDir())
+		entries, err := os.ReadDir(filepath.Join(BackupDir(), "openclaw"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -138,15 +144,15 @@ func TestWriteWithBackup(t *testing.T) {
 		var found bool
 		for _, entry := range entries {
 			name := entry.Name()
-			if len(name) > len("openclaw-hinted.json.") && name[:len("openclaw-hinted.json.")] == "openclaw-hinted.json." {
+			if len(name) > len("hinted.json.") && name[:len("hinted.json.")] == "hinted.json." {
 				found = true
-				_ = os.Remove(filepath.Join(BackupDir(), name))
+				_ = os.Remove(filepath.Join(BackupDir(), "openclaw", name))
 				break
 			}
 		}
 
 		if !found {
-			t.Error("backup filename did not include sanitized hint")
+			t.Error("backup file was not created under sanitized hint directory")
 		}
 	})
 
@@ -342,9 +348,9 @@ func TestBackupToTmp_SpecialCharsInFilename(t *testing.T) {
 	path := filepath.Join(tmpDir, "my config (backup).json")
 	os.WriteFile(path, []byte(`{"test": true}`), 0o644)
 
-	backupPath, err := backupToTmp(path, "")
+	backupPath, err := writeBackupCopy(path, "")
 	if err != nil {
-		t.Fatalf("backupToTmp with special chars failed: %v", err)
+		t.Fatalf("writeBackupCopy with special chars failed: %v", err)
 	}
 
 	// Verify backup exists and has correct content

--- a/cmd/internal/fileutil/files_test.go
+++ b/cmd/internal/fileutil/files_test.go
@@ -235,6 +235,35 @@ func TestWriteWithBackup(t *testing.T) {
 			t.Error("backup file with timestamp not found")
 		}
 	})
+
+	t.Run("retains only the five newest backups per file", func(t *testing.T) {
+		path := filepath.Join(tmpDir, "pruned.json")
+		if err := os.WriteFile(path, []byte(`{"v": 0}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		for i := 1; i <= maxBackupsPerFile; i++ {
+			backupPath := filepath.Join(BackupDir(), fmt.Sprintf("pruned.json.%d", i))
+			if err := os.WriteFile(backupPath, []byte(fmt.Sprintf(`{"v": %d}`, i)), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		if err := WriteWithBackup(path, []byte(`{"v": 1}`)); err != nil {
+			t.Fatal(err)
+		}
+
+		backups, err := filepath.Glob(filepath.Join(BackupDir(), "pruned.json.*"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(backups) != maxBackupsPerFile {
+			t.Fatalf("expected %d backups after pruning, got %d", maxBackupsPerFile, len(backups))
+		}
+		if _, err := os.Stat(filepath.Join(BackupDir(), "pruned.json.1")); !os.IsNotExist(err) {
+			t.Fatalf("expected oldest backup to be pruned, stat err = %v", err)
+		}
+	})
 }
 
 // Edge case tests for files.go
@@ -294,6 +323,36 @@ func TestWriteWithBackup_PermissionDenied(t *testing.T) {
 
 	if err == nil {
 		t.Error("expected permission error, got nil")
+	}
+}
+
+func TestWriteWithBackup_UnchangedContentIsNoOp(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission tests unreliable on Windows")
+	}
+
+	tmpDir := isolatedTempDir(t)
+	path := filepath.Join(tmpDir, "unchanged-noop.json")
+	data := []byte(`{"same":true}`)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Chmod(tmpDir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chmod(tmpDir, 0o755)
+
+	if err := WriteWithBackup(path, data); err != nil {
+		t.Fatalf("expected unchanged write to be a no-op, got %v", err)
+	}
+
+	backups, err := filepath.Glob(filepath.Join(BackupDir(), "unchanged-noop.json.*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(backups) != 0 {
+		t.Fatalf("expected no backups for unchanged content, got %d", len(backups))
 	}
 }
 

--- a/cmd/internal/fileutil/files_test.go
+++ b/cmd/internal/fileutil/files_test.go
@@ -132,7 +132,7 @@ func TestWriteWithBackup(t *testing.T) {
 		os.WriteFile(path, []byte(`{"original": true}`), 0o644)
 
 		data := mustMarshal(t, map[string]bool{"updated": true})
-		if err := WriteWithBackupHint(path, data, "OpenClaw"); err != nil {
+		if err := WriteWithBackup(path, data, "OpenClaw"); err != nil {
 			t.Fatal(err)
 		}
 

--- a/cmd/launch/cline.go
+++ b/cmd/launch/cline.go
@@ -78,7 +78,7 @@ func (c *Cline) Edit(models []string) error {
 	if err != nil {
 		return err
 	}
-	return fileutil.WriteWithBackup(configPath, data)
+	return fileutil.WriteWithBackupHint(configPath, data, "cline")
 }
 
 func (c *Cline) Models() []string {

--- a/cmd/launch/cline.go
+++ b/cmd/launch/cline.go
@@ -78,7 +78,7 @@ func (c *Cline) Edit(models []string) error {
 	if err != nil {
 		return err
 	}
-	return fileutil.WriteWithBackupHint(configPath, data, "cline")
+	return fileutil.WriteWithBackup(configPath, data, "cline")
 }
 
 func (c *Cline) Models() []string {

--- a/cmd/launch/command_test.go
+++ b/cmd/launch/command_test.go
@@ -479,7 +479,7 @@ func TestLaunchCmdHeadlessWithYes_AutoPullsMissingLocalModel(t *testing.T) {
 	}
 }
 
-func TestLaunchCmdHeadlessWithoutYes_ReturnsActionableConfirmError(t *testing.T) {
+func TestLaunchCmdHeadlessWithoutYes_AllowsConfiguredLaunch(t *testing.T) {
 	tmpDir := t.TempDir()
 	setLaunchTestHome(t, tmpDir)
 	withLauncherHooks(t)
@@ -511,17 +511,14 @@ func TestLaunchCmdHeadlessWithoutYes_ReturnsActionableConfirmError(t *testing.T)
 	cmd := LaunchCmd(func(cmd *cobra.Command, args []string) error { return nil }, func(cmd *cobra.Command) {})
 	cmd.SetArgs([]string{"stubeditor", "--model", "llama3.2"})
 	err := cmd.Execute()
-	if err == nil {
-		t.Fatal("expected launch command to fail without --yes in headless mode")
+	if err != nil {
+		t.Fatalf("expected launch command to succeed without --yes when an explicit model is provided, got %v", err)
 	}
-	if !strings.Contains(err.Error(), "re-run with --yes") {
-		t.Fatalf("expected actionable --yes guidance, got %v", err)
+	if diff := compareStringSlices(stub.edited, [][]string{{"llama3.2"}}); diff != "" {
+		t.Fatalf("unexpected editor writes (-want +got):\n%s", diff)
 	}
-	if len(stub.edited) != 0 {
-		t.Fatalf("expected no editor writes when confirmation is blocked, got %v", stub.edited)
-	}
-	if stub.ranModel != "" {
-		t.Fatalf("expected launch to abort before run, got %q", stub.ranModel)
+	if stub.ranModel != "llama3.2" {
+		t.Fatalf("expected launch to run configured model, got %q", stub.ranModel)
 	}
 }
 

--- a/cmd/launch/droid.go
+++ b/cmd/launch/droid.go
@@ -96,7 +96,7 @@ func (d *Droid) Edit(models []string) error {
 	if err != nil {
 		return err
 	}
-	return fileutil.WriteWithBackup(settingsPath, data)
+	return fileutil.WriteWithBackupHint(settingsPath, data, "droid")
 }
 
 func updateDroidSettings(settingsMap map[string]any, settings droidSettings, models []string) map[string]any {

--- a/cmd/launch/droid.go
+++ b/cmd/launch/droid.go
@@ -96,7 +96,7 @@ func (d *Droid) Edit(models []string) error {
 	if err != nil {
 		return err
 	}
-	return fileutil.WriteWithBackupHint(settingsPath, data, "droid")
+	return fileutil.WriteWithBackup(settingsPath, data, "droid")
 }
 
 func updateDroidSettings(settingsMap map[string]any, settings droidSettings, models []string) map[string]any {

--- a/cmd/launch/droid_test.go
+++ b/cmd/launch/droid_test.go
@@ -1172,7 +1172,7 @@ func TestDroidEdit_BackupCreated(t *testing.T) {
 
 	settingsDir := filepath.Join(tmpDir, ".factory")
 	settingsPath := filepath.Join(settingsDir, "settings.json")
-	backupDir := filepath.Join(os.TempDir(), "ollama-backups")
+	backupDir := fileutil.BackupDir()
 
 	os.MkdirAll(settingsDir, 0o755)
 
@@ -1186,7 +1186,7 @@ func TestDroidEdit_BackupCreated(t *testing.T) {
 	}
 
 	// Find backup containing our unique marker
-	backups, _ := filepath.Glob(filepath.Join(backupDir, "settings.json.*"))
+	backups, _ := filepath.Glob(filepath.Join(backupDir, "droid-settings.json.*"))
 	foundBackup := false
 	for _, backup := range backups {
 		data, err := os.ReadFile(backup)

--- a/cmd/launch/droid_test.go
+++ b/cmd/launch/droid_test.go
@@ -1186,7 +1186,7 @@ func TestDroidEdit_BackupCreated(t *testing.T) {
 	}
 
 	// Find backup containing our unique marker
-	backups, _ := filepath.Glob(filepath.Join(backupDir, "droid-settings.json.*"))
+	backups, _ := filepath.Glob(filepath.Join(backupDir, "droid", "settings.json.*"))
 	foundBackup := false
 	for _, backup := range backups {
 		data, err := os.ReadFile(backup)

--- a/cmd/launch/hermes.go
+++ b/cmd/launch/hermes.go
@@ -132,7 +132,7 @@ func (h *Hermes) Configure(model string) error {
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
 		return err
 	}
-	return fileutil.WriteWithBackup(configPath, data)
+	return fileutil.WriteWithBackupHint(configPath, data, "hermes")
 }
 
 func (h *Hermes) CurrentModel() string {

--- a/cmd/launch/hermes.go
+++ b/cmd/launch/hermes.go
@@ -132,7 +132,7 @@ func (h *Hermes) Configure(model string) error {
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
 		return err
 	}
-	return fileutil.WriteWithBackupHint(configPath, data, "hermes")
+	return fileutil.WriteWithBackup(configPath, data, "hermes")
 }
 
 func (h *Hermes) CurrentModel() string {

--- a/cmd/launch/integrations_test.go
+++ b/cmd/launch/integrations_test.go
@@ -822,7 +822,7 @@ func TestPrepareEditorIntegration_SavesOnlyAfterSuccessfulEdit(t *testing.T) {
 	}
 
 	editor := &stubEditorRunner{editErr: errors.New("boom")}
-	err := prepareEditorIntegration("droid", editor, editor, []string{"new-model"})
+	err := prepareEditorIntegration("droid", editor, []string{"new-model"})
 	if err == nil || !strings.Contains(err.Error(), "setup failed") {
 		t.Fatalf("expected setup failure, got %v", err)
 	}

--- a/cmd/launch/launch.go
+++ b/cmd/launch/launch.go
@@ -734,7 +734,11 @@ func (c *launcherClient) launchManagedSingleIntegration(ctx context.Context, nam
 	}
 
 	if needsConfigure || req.ModelOverride != "" || (current != "" && target != current) || !savedMatchesModels(saved, []string{target}) {
-		if err := prepareManagedSingleIntegration(name, managed, target); err != nil {
+		models, err := c.managedSingleConfigureModels(ctx, managed, target)
+		if err != nil {
+			return err
+		}
+		if err := prepareManagedSingleIntegration(name, managed, target, models); err != nil {
 			return err
 		}
 		if refresher, ok := managed.(ManagedRuntimeRefresher); ok {
@@ -773,7 +777,7 @@ func (c *launcherClient) launchManagedAutodiscoveryIntegration(ctx context.Conte
 	needsConfigure := req.ForceConfigure || req.ConfigureOnly || !autodiscovery.AutodiscoveryConfigured() || !savedMatchesModels(saved, []string{target})
 
 	if needsConfigure {
-		if err := prepareManagedAutodiscoveryIntegration(name, runner, autodiscovery, target); err != nil {
+		if err := prepareManagedAutodiscoveryIntegration(name, autodiscovery, target); err != nil {
 			return err
 		}
 		if refresher, ok := autodiscovery.(ManagedRuntimeRefresher); ok {

--- a/cmd/launch/launch.go
+++ b/cmd/launch/launch.go
@@ -734,11 +734,11 @@ func (c *launcherClient) launchManagedSingleIntegration(ctx context.Context, nam
 	}
 
 	if needsConfigure || req.ModelOverride != "" || (current != "" && target != current) || !savedMatchesModels(saved, []string{target}) {
-		models, err := c.managedSingleConfigureModels(ctx, managed, target)
+		configureModels, err := c.managedSingleConfigureModels(ctx, managed, target)
 		if err != nil {
 			return err
 		}
-		if err := prepareManagedSingleIntegration(name, managed, target, models); err != nil {
+		if err := prepareManagedSingleIntegration(name, managed, target, configureModels); err != nil {
 			return err
 		}
 		if refresher, ok := managed.(ManagedRuntimeRefresher); ok {

--- a/cmd/launch/launch.go
+++ b/cmd/launch/launch.go
@@ -710,7 +710,7 @@ func (c *launcherClient) launchEditorIntegration(ctx context.Context, name strin
 	}
 
 	if (needsConfigure || req.ModelOverride != "") && !savedMatchesModels(saved, models) {
-		if err := prepareEditorIntegration(name, runner, editor, models); err != nil {
+		if err := prepareEditorIntegration(name, editor, models); err != nil {
 			return err
 		}
 	}
@@ -734,11 +734,7 @@ func (c *launcherClient) launchManagedSingleIntegration(ctx context.Context, nam
 	}
 
 	if needsConfigure || req.ModelOverride != "" || (current != "" && target != current) || !savedMatchesModels(saved, []string{target}) {
-		configureModels, err := c.managedSingleConfigureModels(ctx, managed, target)
-		if err != nil {
-			return err
-		}
-		if err := prepareManagedSingleIntegration(name, runner, managed, target, configureModels); err != nil {
+		if err := prepareManagedSingleIntegration(name, managed, target); err != nil {
 			return err
 		}
 		if refresher, ok := managed.(ManagedRuntimeRefresher); ok {

--- a/cmd/launch/launch_test.go
+++ b/cmd/launch/launch_test.go
@@ -1681,6 +1681,64 @@ func TestLaunchIntegration_EditorForceConfigure(t *testing.T) {
 	}
 }
 
+func TestConfirmConfigEdit_OmitsBackupMessageWhenFilesDoNotExist(t *testing.T) {
+	tmpDir := t.TempDir()
+	setLaunchTestHome(t, tmpDir)
+	withLauncherHooks(t)
+
+	var prompted bool
+	DefaultConfirmPrompt = func(prompt string, options ConfirmOptions) (bool, error) {
+		prompted = true
+		return true, nil
+	}
+
+	stderr := captureStderr(t, func() {
+		ok, err := confirmConfigEdit(&launcherEditorRunner{}, []string{filepath.Join(tmpDir, "missing.json")})
+		if err != nil {
+			t.Fatalf("confirmConfigEdit returned error: %v", err)
+		}
+		if !ok {
+			t.Fatal("expected confirmConfigEdit to continue")
+		}
+	})
+
+	if !prompted {
+		t.Fatal("expected confirmation prompt")
+	}
+	if strings.Contains(stderr, "backed up to") {
+		t.Fatalf("did not expect backup message for missing files, got %q", stderr)
+	}
+}
+
+func TestConfirmConfigEdit_ShowsBackupMessageWhenFilesExist(t *testing.T) {
+	tmpDir := t.TempDir()
+	setLaunchTestHome(t, tmpDir)
+	withLauncherHooks(t)
+
+	path := filepath.Join(tmpDir, "settings.json")
+	if err := os.WriteFile(path, []byte(`{}`), 0o644); err != nil {
+		t.Fatalf("failed to seed config file: %v", err)
+	}
+
+	DefaultConfirmPrompt = func(prompt string, options ConfirmOptions) (bool, error) {
+		return true, nil
+	}
+
+	stderr := captureStderr(t, func() {
+		ok, err := confirmConfigEdit(&launcherEditorRunner{}, []string{path})
+		if err != nil {
+			t.Fatalf("confirmConfigEdit returned error: %v", err)
+		}
+		if !ok {
+			t.Fatal("expected confirmConfigEdit to continue")
+		}
+	})
+
+	if !strings.Contains(stderr, "Existing files will be backed up to "+filepath.Join(tmpDir, ".ollama", "backups")+"/") {
+		t.Fatalf("expected backup message in stderr, got %q", stderr)
+	}
+}
+
 func TestLaunchIntegration_EditorForceConfigure_FloatsCheckedModelsInPicker(t *testing.T) {
 	tmpDir := t.TempDir()
 	setLaunchTestHome(t, tmpDir)

--- a/cmd/launch/launch_test.go
+++ b/cmd/launch/launch_test.go
@@ -1628,14 +1628,6 @@ func TestLaunchIntegration_EditorForceConfigure(t *testing.T) {
 		return []string{"llama3.2", "qwen3:8b"}, nil
 	}
 
-	var proceedPrompt bool
-	DefaultConfirmPrompt = func(prompt string, options ConfirmOptions) (bool, error) {
-		if prompt == "Proceed?" {
-			proceedPrompt = true
-		}
-		return true, nil
-	}
-
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/experimental/model-recommendations":
@@ -1663,9 +1655,6 @@ func TestLaunchIntegration_EditorForceConfigure(t *testing.T) {
 	if !multiCalled {
 		t.Fatal("expected multi selector to be used for forced editor configure")
 	}
-	if !proceedPrompt {
-		t.Fatal("expected backup warning confirmation before edit")
-	}
 	if diff := compareStringSlices(editor.edited, [][]string{{"llama3.2", "qwen3:8b"}}); diff != "" {
 		t.Fatalf("unexpected edited models (-want +got):\n%s", diff)
 	}
@@ -1678,64 +1667,6 @@ func TestLaunchIntegration_EditorForceConfigure(t *testing.T) {
 	}
 	if diff := compareStrings(saved.Models, []string{"llama3.2", "qwen3:8b"}); diff != "" {
 		t.Fatalf("unexpected saved models (-want +got):\n%s", diff)
-	}
-}
-
-func TestConfirmConfigEdit_OmitsBackupMessageWhenFilesDoNotExist(t *testing.T) {
-	tmpDir := t.TempDir()
-	setLaunchTestHome(t, tmpDir)
-	withLauncherHooks(t)
-
-	var prompted bool
-	DefaultConfirmPrompt = func(prompt string, options ConfirmOptions) (bool, error) {
-		prompted = true
-		return true, nil
-	}
-
-	stderr := captureStderr(t, func() {
-		ok, err := confirmConfigEdit(&launcherEditorRunner{}, []string{filepath.Join(tmpDir, "missing.json")})
-		if err != nil {
-			t.Fatalf("confirmConfigEdit returned error: %v", err)
-		}
-		if !ok {
-			t.Fatal("expected confirmConfigEdit to continue")
-		}
-	})
-
-	if !prompted {
-		t.Fatal("expected confirmation prompt")
-	}
-	if strings.Contains(stderr, "backed up to") {
-		t.Fatalf("did not expect backup message for missing files, got %q", stderr)
-	}
-}
-
-func TestConfirmConfigEdit_ShowsBackupMessageWhenFilesExist(t *testing.T) {
-	tmpDir := t.TempDir()
-	setLaunchTestHome(t, tmpDir)
-	withLauncherHooks(t)
-
-	path := filepath.Join(tmpDir, "settings.json")
-	if err := os.WriteFile(path, []byte(`{}`), 0o644); err != nil {
-		t.Fatalf("failed to seed config file: %v", err)
-	}
-
-	DefaultConfirmPrompt = func(prompt string, options ConfirmOptions) (bool, error) {
-		return true, nil
-	}
-
-	stderr := captureStderr(t, func() {
-		ok, err := confirmConfigEdit(&launcherEditorRunner{}, []string{path})
-		if err != nil {
-			t.Fatalf("confirmConfigEdit returned error: %v", err)
-		}
-		if !ok {
-			t.Fatal("expected confirmConfigEdit to continue")
-		}
-	})
-
-	if !strings.Contains(stderr, "Existing files will be backed up to "+filepath.Join(tmpDir, ".ollama", "backups")+"/") {
-		t.Fatalf("expected backup message in stderr, got %q", stderr)
 	}
 }
 
@@ -1924,9 +1855,6 @@ func TestLaunchIntegration_EditorConfigureMultiSkipsMissingLocalAndPersistsAccep
 		return []string{"glm-5:cloud", "missing-local"}, nil
 	}
 	DefaultConfirmPrompt = func(prompt string, options ConfirmOptions) (bool, error) {
-		if prompt == "Proceed?" {
-			return true, nil
-		}
 		if prompt == "Download missing-local?" {
 			return false, nil
 		}
@@ -2008,9 +1936,6 @@ func TestLaunchIntegration_EditorConfigureMultiSkipsUnauthedCloudAndPersistsAcce
 		return []string{"llama3.2", "glm-5:cloud"}, nil
 	}
 	DefaultConfirmPrompt = func(prompt string, options ConfirmOptions) (bool, error) {
-		if prompt == "Proceed?" {
-			return true, nil
-		}
 		t.Fatalf("unexpected prompt: %q", prompt)
 		return false, nil
 	}
@@ -2095,9 +2020,6 @@ func TestLaunchIntegration_EditorConfigureMultiRemovesReselectedFailingModel(t *
 		return append([]string(nil), preChecked...), nil
 	}
 	DefaultConfirmPrompt = func(prompt string, options ConfirmOptions) (bool, error) {
-		if prompt == "Proceed?" {
-			return true, nil
-		}
 		t.Fatalf("unexpected prompt: %q", prompt)
 		return false, nil
 	}
@@ -2186,9 +2108,6 @@ func TestLaunchIntegration_EditorConfigureMultiAllFailuresKeepsExistingAndSkipsL
 	DefaultConfirmPrompt = func(prompt string, options ConfirmOptions) (bool, error) {
 		if prompt == "Download missing-local-a?" || prompt == "Download missing-local-b?" {
 			return false, nil
-		}
-		if prompt == "Proceed?" {
-			t.Fatal("did not expect proceed prompt when no models are accepted")
 		}
 		t.Fatalf("unexpected prompt: %q", prompt)
 		return false, nil
@@ -2529,9 +2448,6 @@ func TestLaunchIntegration_ConfigureOnlyDoesNotRequireInstalledBinary(t *testing
 	}
 	if editor.ranModel != "" {
 		t.Fatalf("expected configure-only flow to skip launch, got %q", editor.ranModel)
-	}
-	if !slices.Contains(prompts, "Proceed?") {
-		t.Fatalf("expected editor warning prompt, got %v", prompts)
 	}
 	if !slices.Contains(prompts, "Launch LauncherEditor now?") {
 		t.Fatalf("expected configure-only launch prompt, got %v", prompts)

--- a/cmd/launch/models.go
+++ b/cmd/launch/models.go
@@ -361,9 +361,23 @@ func confirmConfigEdit(runner Runner, paths []string) (bool, error) {
 	for _, path := range paths {
 		fmt.Fprintf(os.Stderr, "  %s\n", path)
 	}
-	fmt.Fprintf(os.Stderr, "Backups will be saved to %s/\n\n", fileutil.BackupDir())
+	if countExistingPaths(paths) > 0 {
+		fmt.Fprintf(os.Stderr, "Existing files will be backed up to %s/\n\n", fileutil.BackupDir())
+	} else {
+		fmt.Fprintf(os.Stderr, "\n")
+	}
 
 	return ConfirmPrompt("Proceed?")
+}
+
+func countExistingPaths(paths []string) int {
+	var count int
+	for _, path := range paths {
+		if _, err := os.Stat(path); err == nil {
+			count++
+		}
+	}
+	return count
 }
 
 // buildModelList merges existing models with recommendations for selection UIs.

--- a/cmd/launch/models.go
+++ b/cmd/launch/models.go
@@ -309,13 +309,7 @@ func prepareEditorIntegration(name string, editor Editor, models []string) error
 	return nil
 }
 
-<<<<<<< HEAD
-func prepareManagedSingleIntegration(name string, runner Runner, managed ManagedSingleModel, model string, models []string) error {
-	if ok, err := confirmConfigEdit(runner, managed.Paths()); err != nil {
-		return err
-	} else if !ok {
-		return errCancelled
-	}
+func prepareManagedSingleIntegration(name string, managed ManagedSingleModel, model string, models []string) error {
 	models = dedupeModelList(append([]string{model}, models...))
 	var err error
 	if withModels, ok := managed.(ManagedModelListConfigurer); ok {
@@ -332,17 +326,8 @@ func prepareManagedSingleIntegration(name string, runner Runner, managed Managed
 	return nil
 }
 
-func prepareManagedAutodiscoveryIntegration(name string, runner Runner, autodiscovery ManagedAutodiscoveryIntegration, model string) error {
-	if ok, err := confirmConfigEdit(runner, autodiscovery.Paths()); err != nil {
-		return err
-	} else if !ok {
-		return errCancelled
-	}
+func prepareManagedAutodiscoveryIntegration(name string, autodiscovery ManagedAutodiscoveryIntegration, model string) error {
 	if err := autodiscovery.ConfigureAutodiscovery(); err != nil {
-=======
-func prepareManagedSingleIntegration(name string, managed ManagedSingleModel, model string) error {
-	if err := managed.Configure(model); err != nil {
->>>>>>> ed6e02b0 (clean up and simplify)
 		return fmt.Errorf("setup failed: %w", err)
 	}
 	if err := config.SaveIntegration(name, []string{model}); err != nil {

--- a/cmd/launch/models.go
+++ b/cmd/launch/models.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/cmd/config"
-	"github.com/ollama/ollama/cmd/internal/fileutil"
 	"github.com/ollama/ollama/format"
 	internalcloud "github.com/ollama/ollama/internal/cloud"
 	"github.com/ollama/ollama/internal/modelref"
@@ -300,12 +299,7 @@ func pullMissingModel(ctx context.Context, client *api.Client, model string) err
 }
 
 // prepareEditorIntegration persists models and applies editor-managed config files.
-func prepareEditorIntegration(name string, runner Runner, editor Editor, models []string) error {
-	if ok, err := confirmConfigEdit(runner, editor.Paths()); err != nil {
-		return err
-	} else if !ok {
-		return errCancelled
-	}
+func prepareEditorIntegration(name string, editor Editor, models []string) error {
 	if err := editor.Edit(models); err != nil {
 		return fmt.Errorf("setup failed: %w", err)
 	}
@@ -315,6 +309,7 @@ func prepareEditorIntegration(name string, runner Runner, editor Editor, models 
 	return nil
 }
 
+<<<<<<< HEAD
 func prepareManagedSingleIntegration(name string, runner Runner, managed ManagedSingleModel, model string, models []string) error {
 	if ok, err := confirmConfigEdit(runner, managed.Paths()); err != nil {
 		return err
@@ -344,40 +339,16 @@ func prepareManagedAutodiscoveryIntegration(name string, runner Runner, autodisc
 		return errCancelled
 	}
 	if err := autodiscovery.ConfigureAutodiscovery(); err != nil {
+=======
+func prepareManagedSingleIntegration(name string, managed ManagedSingleModel, model string) error {
+	if err := managed.Configure(model); err != nil {
+>>>>>>> ed6e02b0 (clean up and simplify)
 		return fmt.Errorf("setup failed: %w", err)
 	}
 	if err := config.SaveIntegration(name, []string{model}); err != nil {
 		return fmt.Errorf("failed to save: %w", err)
 	}
 	return nil
-}
-
-func confirmConfigEdit(runner Runner, paths []string) (bool, error) {
-	if len(paths) == 0 {
-		return true, nil
-	}
-
-	fmt.Fprintf(os.Stderr, "This will modify your %s configuration:\n", runner)
-	for _, path := range paths {
-		fmt.Fprintf(os.Stderr, "  %s\n", path)
-	}
-	if countExistingPaths(paths) > 0 {
-		fmt.Fprintf(os.Stderr, "Existing files will be backed up to %s/\n\n", fileutil.BackupDir())
-	} else {
-		fmt.Fprintf(os.Stderr, "\n")
-	}
-
-	return ConfirmPrompt("Proceed?")
-}
-
-func countExistingPaths(paths []string) int {
-	var count int
-	for _, path := range paths {
-		if _, err := os.Stat(path); err == nil {
-			count++
-		}
-	}
-	return count
 }
 
 // buildModelList merges existing models with recommendations for selection UIs.

--- a/cmd/launch/openclaw.go
+++ b/cmd/launch/openclaw.go
@@ -753,7 +753,7 @@ func (c *Openclaw) Edit(models []string) error {
 	if err != nil {
 		return err
 	}
-	if err := fileutil.WriteWithBackup(configPath, data); err != nil {
+	if err := fileutil.WriteWithBackupHint(configPath, data, "openclaw"); err != nil {
 		return err
 	}
 

--- a/cmd/launch/openclaw.go
+++ b/cmd/launch/openclaw.go
@@ -753,7 +753,7 @@ func (c *Openclaw) Edit(models []string) error {
 	if err != nil {
 		return err
 	}
-	if err := fileutil.WriteWithBackupHint(configPath, data, "openclaw"); err != nil {
+	if err := fileutil.WriteWithBackup(configPath, data, "openclaw"); err != nil {
 		return err
 	}
 

--- a/cmd/launch/openclaw_test.go
+++ b/cmd/launch/openclaw_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/cmd/internal/fileutil"
 )
 
 func TestOpenclawIntegration(t *testing.T) {
@@ -1154,7 +1155,7 @@ func TestOpenclawEdit_BackupCreated(t *testing.T) {
 	setTestHome(t, tmpDir)
 	configDir := filepath.Join(tmpDir, ".openclaw")
 	configPath := filepath.Join(configDir, "openclaw.json")
-	backupDir := filepath.Join(os.TempDir(), "ollama-backups")
+	backupDir := fileutil.BackupDir()
 
 	os.MkdirAll(configDir, 0o755)
 	uniqueMarker := fmt.Sprintf("test-marker-%d", os.Getpid())
@@ -1165,7 +1166,7 @@ func TestOpenclawEdit_BackupCreated(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	backups, _ := filepath.Glob(filepath.Join(backupDir, "openclaw.json.*"))
+	backups, _ := filepath.Glob(filepath.Join(backupDir, "openclaw-openclaw.json.*"))
 	foundBackup := false
 	for _, backup := range backups {
 		data, _ := os.ReadFile(backup)

--- a/cmd/launch/openclaw_test.go
+++ b/cmd/launch/openclaw_test.go
@@ -1166,7 +1166,7 @@ func TestOpenclawEdit_BackupCreated(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	backups, _ := filepath.Glob(filepath.Join(backupDir, "openclaw-openclaw.json.*"))
+	backups, _ := filepath.Glob(filepath.Join(backupDir, "openclaw", "openclaw.json.*"))
 	foundBackup := false
 	for _, backup := range backups {
 		data, _ := os.ReadFile(backup)

--- a/cmd/launch/opencode.go
+++ b/cmd/launch/opencode.go
@@ -163,7 +163,7 @@ func (o *OpenCode) Edit(modelList []string) error {
 	if err != nil {
 		return err
 	}
-	return fileutil.WriteWithBackup(statePath, stateData)
+	return fileutil.WriteWithBackupHint(statePath, stateData, "opencode")
 }
 
 func (o *OpenCode) Models() []string {

--- a/cmd/launch/opencode.go
+++ b/cmd/launch/opencode.go
@@ -163,7 +163,7 @@ func (o *OpenCode) Edit(modelList []string) error {
 	if err != nil {
 		return err
 	}
-	return fileutil.WriteWithBackupHint(statePath, stateData, "opencode")
+	return fileutil.WriteWithBackup(statePath, stateData, "opencode")
 }
 
 func (o *OpenCode) Models() []string {

--- a/cmd/launch/pi.go
+++ b/cmd/launch/pi.go
@@ -272,7 +272,7 @@ func (p *Pi) Edit(models []string) error {
 	if err != nil {
 		return err
 	}
-	if err := fileutil.WriteWithBackup(configPath, configData); err != nil {
+	if err := fileutil.WriteWithBackupHint(configPath, configData, "pi"); err != nil {
 		return err
 	}
 
@@ -290,7 +290,7 @@ func (p *Pi) Edit(models []string) error {
 	if err != nil {
 		return err
 	}
-	return fileutil.WriteWithBackup(settingsPath, settingsData)
+	return fileutil.WriteWithBackupHint(settingsPath, settingsData, "pi")
 }
 
 func (p *Pi) Models() []string {

--- a/cmd/launch/pi.go
+++ b/cmd/launch/pi.go
@@ -272,7 +272,7 @@ func (p *Pi) Edit(models []string) error {
 	if err != nil {
 		return err
 	}
-	if err := fileutil.WriteWithBackupHint(configPath, configData, "pi"); err != nil {
+	if err := fileutil.WriteWithBackup(configPath, configData, "pi"); err != nil {
 		return err
 	}
 
@@ -290,7 +290,7 @@ func (p *Pi) Edit(models []string) error {
 	if err != nil {
 		return err
 	}
-	return fileutil.WriteWithBackupHint(settingsPath, settingsData, "pi")
+	return fileutil.WriteWithBackup(settingsPath, settingsData, "pi")
 }
 
 func (p *Pi) Models() []string {

--- a/cmd/launch/pi_test.go
+++ b/cmd/launch/pi_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/cmd/internal/fileutil"
 	"github.com/ollama/ollama/types/model"
 )
 
@@ -885,6 +886,62 @@ func TestPiEdit(t *testing.T) {
 			t.Errorf("defaultModel = %v, want test-model", settings["defaultModel"])
 		}
 	})
+}
+
+func TestPiEdit_CreatesDistinctBackupsForEachManagedFile(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/show" {
+			fmt.Fprint(w, `{"capabilities":[],"model_info":{}}`)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	t.Setenv("OLLAMA_HOST", srv.URL)
+
+	pi := &Pi{}
+	tmpDir := t.TempDir()
+	setTestHome(t, tmpDir)
+
+	configDir := filepath.Join(tmpDir, ".pi", "agent")
+	modelsPath := filepath.Join(configDir, "models.json")
+	settingsPath := filepath.Join(configDir, "settings.json")
+	backupDir := fileutil.BackupDir()
+
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	modelsOriginal := fmt.Sprintf(`{"marker":"models-%d","providers":{"ollama":{"models":[]}}}`, os.Getpid())
+	settingsOriginal := fmt.Sprintf(`{"marker":"settings-%d","defaultProvider":"other","defaultModel":"old"}`, os.Getpid())
+	if err := os.WriteFile(modelsPath, []byte(modelsOriginal), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(settingsPath, []byte(settingsOriginal), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := pi.Edit([]string{"llama3.2"}); err != nil {
+		t.Fatalf("Edit() error = %v", err)
+	}
+
+	assertBackupMatches := func(pattern, want string) {
+		t.Helper()
+		backups, err := filepath.Glob(filepath.Join(backupDir, pattern))
+		if err != nil {
+			t.Fatalf("glob %q failed: %v", pattern, err)
+		}
+		for _, backup := range backups {
+			data, err := os.ReadFile(backup)
+			if err == nil && string(data) == want {
+				return
+			}
+		}
+		t.Fatalf("backup matching %q with expected content not found", pattern)
+	}
+
+	assertBackupMatches("pi-models.json.*", modelsOriginal)
+	assertBackupMatches("pi-settings.json.*", settingsOriginal)
 }
 
 func TestPiModels(t *testing.T) {

--- a/cmd/launch/pi_test.go
+++ b/cmd/launch/pi_test.go
@@ -940,8 +940,8 @@ func TestPiEdit_CreatesDistinctBackupsForEachManagedFile(t *testing.T) {
 		t.Fatalf("backup matching %q with expected content not found", pattern)
 	}
 
-	assertBackupMatches("pi-models.json.*", modelsOriginal)
-	assertBackupMatches("pi-settings.json.*", settingsOriginal)
+	assertBackupMatches(filepath.Join("pi", "models.json.*"), modelsOriginal)
+	assertBackupMatches(filepath.Join("pi", "settings.json.*"), settingsOriginal)
 }
 
 func TestPiModels(t *testing.T) {

--- a/cmd/launch/vscode.go
+++ b/cmd/launch/vscode.go
@@ -273,7 +273,7 @@ func (v *VSCode) Edit(models []string) error {
 	if err != nil {
 		return err
 	}
-	if err := fileutil.WriteWithBackup(clmPath, data); err != nil {
+	if err := fileutil.WriteWithBackupHint(clmPath, data, "vscode"); err != nil {
 		return err
 	}
 
@@ -350,7 +350,7 @@ func (v *VSCode) updateSettings() {
 	if err != nil {
 		return
 	}
-	_ = fileutil.WriteWithBackup(settingsPath, updated)
+	_ = fileutil.WriteWithBackupHint(settingsPath, updated, "vscode")
 }
 
 func (v *VSCode) statePath() string {

--- a/cmd/launch/vscode.go
+++ b/cmd/launch/vscode.go
@@ -273,7 +273,7 @@ func (v *VSCode) Edit(models []string) error {
 	if err != nil {
 		return err
 	}
-	if err := fileutil.WriteWithBackupHint(clmPath, data, "vscode"); err != nil {
+	if err := fileutil.WriteWithBackup(clmPath, data, "vscode"); err != nil {
 		return err
 	}
 
@@ -350,7 +350,7 @@ func (v *VSCode) updateSettings() {
 	if err != nil {
 		return
 	}
-	_ = fileutil.WriteWithBackupHint(settingsPath, updated, "vscode")
+	_ = fileutil.WriteWithBackup(settingsPath, updated, "vscode")
 }
 
 func (v *VSCode) statePath() string {

--- a/cmd/launch/vscode_test.go
+++ b/cmd/launch/vscode_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
+	"github.com/ollama/ollama/cmd/internal/fileutil"
 )
 
 func TestVSCodeIntegration(t *testing.T) {
@@ -154,6 +155,52 @@ func TestVSCodeEditCleansUpOldSettings(t *testing.T) {
 	if settings["editor.fontSize"] != float64(14) {
 		t.Error("editor.fontSize should have been preserved")
 	}
+}
+
+func TestVSCodeEdit_CreatesDistinctBackupsForManagedFiles(t *testing.T) {
+	v := &VSCode{}
+	tmpDir := t.TempDir()
+	setTestHome(t, tmpDir)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	clmPath := testVSCodePath(t, tmpDir, "chatLanguageModels.json")
+	settingsPath := testVSCodePath(t, tmpDir, "settings.json")
+	backupDir := fileutil.BackupDir()
+
+	if err := os.MkdirAll(filepath.Dir(clmPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	clmOriginal := `[{"vendor":"ollama","name":"Ollama","url":"http://old:11434"}]`
+	settingsOriginal := `{"github.copilot.chat.byok.ollamaEndpoint":"http://old:11434","ollama.launch.configured":true,"editor.fontSize":14}`
+	if err := os.WriteFile(clmPath, []byte(clmOriginal), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(settingsPath, []byte(settingsOriginal), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := v.Edit([]string{"llama3.2"}); err != nil {
+		t.Fatal(err)
+	}
+
+	assertBackupMatches := func(pattern, want string) {
+		t.Helper()
+		backups, err := filepath.Glob(filepath.Join(backupDir, pattern))
+		if err != nil {
+			t.Fatalf("glob %q failed: %v", pattern, err)
+		}
+		for _, backup := range backups {
+			data, err := os.ReadFile(backup)
+			if err == nil && string(data) == want {
+				return
+			}
+		}
+		t.Fatalf("backup matching %q with expected content not found", pattern)
+	}
+
+	assertBackupMatches("vscode-chatLanguageModels.json.*", clmOriginal)
+	assertBackupMatches("vscode-settings.json.*", settingsOriginal)
 }
 
 func TestVSCodePaths(t *testing.T) {

--- a/cmd/launch/vscode_test.go
+++ b/cmd/launch/vscode_test.go
@@ -199,8 +199,8 @@ func TestVSCodeEdit_CreatesDistinctBackupsForManagedFiles(t *testing.T) {
 		t.Fatalf("backup matching %q with expected content not found", pattern)
 	}
 
-	assertBackupMatches("vscode-chatLanguageModels.json.*", clmOriginal)
-	assertBackupMatches("vscode-settings.json.*", settingsOriginal)
+	assertBackupMatches(filepath.Join("vscode", "chatLanguageModels.json.*"), clmOriginal)
+	assertBackupMatches(filepath.Join("vscode", "settings.json.*"), settingsOriginal)
 }
 
 func TestVSCodePaths(t *testing.T) {


### PR DESCRIPTION
## Summary

Simplify `ollama launch` backup handling for integration-managed config writes.

This change:
- stores launcher-created backups under `~/.ollama/backup`
- groups backups by integration directory instead of prefixing filenames
- removes the backup/config warning prompt before integration config edits
- keeps only the 5 most recent backups per file
- treats unchanged config writes as a true no-op

Examples:
- `~/.ollama/backup/droid/settings.json.<timestamp>`
- `~/.ollama/backup/openclaw/openclaw.json.<timestamp>`
- `~/.ollama/backup/pi/models.json.<timestamp>`
- `~/.ollama/backup/pi/settings.json.<timestamp>`
- `~/.ollama/backup/vscode/chatLanguageModels.json.<timestamp>`

## What changed

- Updated the backup root from the temp dir to `~/.ollama/backup`
- Stored integration-managed backups under per-integration subdirectories
- Kept backup filenames based on the original config filename
- Removed the config-edit backup/config prompt from `ollama launch`
- Capped backups at 5 per file
- Skipped writes and backups entirely when the config content is unchanged

## Testing

Ran:
- `go test ./cmd/internal/fileutil`
- `go test ./cmd/launch -run 'TestDroidEdit_BackupCreated|TestOpenclawEdit_BackupCreated|TestVSCodeEdit_CreatesDistinctBackupsForManagedFiles'`
- `go test ./cmd/launch -run '^TestDoesNotExist$'`
- `go test -count=1 -benchtime=1x ./cmd/launch/...`
