### PR TITLE
mlxrunner: add decode checkpoints for exact-restore caches

### DIFF
--- a/x/mlxrunner/cache.go
+++ b/x/mlxrunner/cache.go
@@ -59,6 +59,8 @@ type cacheSession struct {
 	// during prefill, sorted by offset. Entries are consumed as the
 	// cache advances past them.
 	pendingSnapshots []pendingSnapshot
+
+	lastDecodeCheckpointOffset int
 }
 
 func (c *kvCache) ensureCaches(m base.Model) {
@@ -281,24 +283,66 @@ func (s *cacheSession) nextPendingSnapshot() int {
 	return s.pendingSnapshots[0].offset
 }
 
+func (s *cacheSession) tokenCount() int {
+	return len(s.inputs) + len(s.outputs)
+}
+
+func (s *cacheSession) tokensBetween(start, end int) []int32 {
+	if start < 0 || end < start || end > s.tokenCount() {
+		return nil
+	}
+	if end <= len(s.inputs) {
+		return s.inputs[start:end]
+	}
+	if start >= len(s.inputs) {
+		return s.outputs[start-len(s.inputs) : end-len(s.inputs)]
+	}
+
+	tokens := make([]int32, 0, end-start)
+	tokens = append(tokens, s.inputs[start:]...)
+	tokens = append(tokens, s.outputs[:end-len(s.inputs)]...)
+	return tokens
+}
+
 // snapshot creates a snapshot at the current cache position. It determines
 // whether this is a user snapshot by consuming pending entries whose offset
 // has been reached.
 func (s *cacheSession) snapshot() {
-	c := s.cache
-	cacheOffset := c.minCacheOffset()
-	if cacheOffset <= 0 {
-		return
-	}
-
 	// Consume pending snapshots up to the current offset and derive
 	// the user flag from them.
 	user := false
+	cacheOffset := s.cache.minCacheOffset()
 	for len(s.pendingSnapshots) > 0 && cacheOffset >= s.pendingSnapshots[0].offset {
 		if s.pendingSnapshots[0].user {
 			user = true
 		}
 		s.pendingSnapshots = s.pendingSnapshots[1:]
+	}
+
+	s.snapshotCurrent(user)
+}
+
+func (s *cacheSession) decodeCheckpoint() bool {
+	cacheOffset := s.cache.minCacheOffset()
+	if cacheOffset <= 0 || cacheOffset == s.lastDecodeCheckpointOffset {
+		return false
+	}
+	if !s.snapshotCurrent(true) {
+		return false
+	}
+	s.lastDecodeCheckpointOffset = cacheOffset
+	return true
+}
+
+func (s *cacheSession) snapshotCurrent(user bool) bool {
+	c := s.cache
+	cacheOffset := c.minCacheOffset()
+	if cacheOffset <= 0 {
+		return false
+	}
+	if cacheOffset > s.tokenCount() {
+		slog.Warn("snapshot skipped: cacheOffset is beyond stored tokens", "cacheOffset", cacheOffset, "storedTokens", s.tokenCount())
+		return false
 	}
 
 	// The last node in activePath is the frontier where caches are advancing.
@@ -314,16 +358,16 @@ func (s *cacheSession) snapshot() {
 		if !frontier.hasAllSnapshots() {
 			s.attachSnapshots(frontier, cacheOffset)
 		}
-		return
+		return true
 	}
 
 	if frontier.endOffset > cacheOffset {
 		slog.Warn("snapshot skipped: cacheOffset is behind frontier", "cacheOffset", cacheOffset, "frontierEndOffset", frontier.endOffset)
-		return
+		return false
 	}
 
 	// Advance the trie to cacheOffset — find or create a node there.
-	edgeTokens := append(s.inputs, s.outputs...)[frontier.endOffset:cacheOffset]
+	edgeTokens := s.tokensBetween(frontier.endOffset, cacheOffset)
 	frontier = c.advancePath(frontier, edgeTokens, cacheOffset)
 
 	// Attach fresh snapshots from the live caches. Always use fresh
@@ -334,6 +378,7 @@ func (s *cacheSession) snapshot() {
 		frontier.user = true
 	}
 	s.attachSnapshots(frontier, cacheOffset)
+	return true
 }
 
 // advancePath advances the active path from the current frontier by matching
@@ -449,10 +494,9 @@ func (s *cacheSession) close() {
 	c := s.cache
 	if len(c.activePath) > 0 {
 		frontier := c.activePath[len(c.activePath)-1]
-		stored := append(s.inputs, s.outputs...)
 
 		if offset > frontier.endOffset {
-			newTokens := stored[frontier.endOffset:offset]
+			newTokens := s.tokensBetween(frontier.endOffset, offset)
 			c.advancePath(frontier, newTokens, offset)
 		}
 		c.activePath[len(c.activePath)-1].lastUsed = time.Now()

--- a/x/mlxrunner/cache.go
+++ b/x/mlxrunner/cache.go
@@ -41,7 +41,7 @@ type kvCache struct {
 // pendingSnapshot is a snapshot scheduled to be taken during prefill.
 type pendingSnapshot struct {
 	offset int
-	user   bool
+	kind   restorePointKind
 }
 
 // cacheSession manages caches for a single pipeline run.
@@ -103,6 +103,7 @@ func (c *kvCache) begin(m base.Model, inputs []int32) *cacheSession {
 
 	// Switch to the matched path, paging in/out as needed.
 	c.switchToPath(matchPath, matched)
+	c.pruneInactiveEphemeralRestorePoints()
 
 	// switchToPath aligns caches to a common offset
 	prefix := c.minCacheOffset()
@@ -118,7 +119,7 @@ func (c *kvCache) begin(m base.Model, inputs []int32) *cacheSession {
 	// Schedule a snapshot at the branch point during prefill so future
 	// requests diverging here can restore instead of re-evaluating.
 	if prefix < matched {
-		session.pendingSnapshots = append(session.pendingSnapshots, pendingSnapshot{offset: matched, user: false})
+		session.pendingSnapshots = append(session.pendingSnapshots, pendingSnapshot{offset: matched, kind: restorePointNone})
 	}
 
 	msg := "cache hit"
@@ -253,6 +254,80 @@ pageIn:
 	}
 }
 
+// pruneInactiveEphemeralRestorePoints releases decode checkpoints that were
+// useful for the previous active branch but are not on the newly matched path.
+// Token edges are left in place; only expensive snapshot arrays and ephemeral
+// restore-point marks are cleared. Durable restore-point subtrees are kept
+// intact because KV snapshots in descendants may rely on ancestor snapshots.
+func (c *kvCache) pruneInactiveEphemeralRestorePoints() {
+	if c.root == nil {
+		return
+	}
+
+	activeSet := make(map[*trieNode]bool, len(c.activePath))
+	for _, n := range c.activePath {
+		activeSet[n] = true
+	}
+
+	durableMemo := make(map[*trieNode]bool)
+	var subtreeHasDurable func(*trieNode) bool
+	subtreeHasDurable = func(n *trieNode) bool {
+		if v, ok := durableMemo[n]; ok {
+			return v
+		}
+		if n.restore == restorePointDurable {
+			durableMemo[n] = true
+			return true
+		}
+		for _, child := range n.children {
+			if subtreeHasDurable(child) {
+				durableMemo[n] = true
+				return true
+			}
+		}
+		durableMemo[n] = false
+		return false
+	}
+
+	var prunedNodes, prunedSnapshotNodes int
+	var freedBytes int64
+
+	var pruneSubtree func(*trieNode)
+	pruneSubtree = func(n *trieNode) {
+		if activeSet[n] || subtreeHasDurable(n) {
+			return
+		}
+		if n.restore == restorePointEphemeral {
+			n.restore = restorePointNone
+			prunedNodes++
+		}
+		if n.hasSnapshots() {
+			freedBytes += n.snapshotBytes()
+			prunedSnapshotNodes++
+			n.setSnapshots(nil, &c.pagedOutBytes)
+		}
+		for _, child := range n.children {
+			pruneSubtree(child)
+		}
+	}
+
+	var walk func(*trieNode)
+	walk = func(n *trieNode) {
+		for _, child := range n.children {
+			if child.restore == restorePointEphemeral && !activeSet[child] && !subtreeHasDurable(child) {
+				pruneSubtree(child)
+				continue
+			}
+			walk(child)
+		}
+	}
+	walk(c.root)
+
+	if prunedNodes > 0 || prunedSnapshotNodes > 0 {
+		slog.Debug("pruned ephemeral decode checkpoints", "nodes", prunedNodes, "snapshot_nodes", prunedSnapshotNodes, "freed", mlx.PrettyBytes(int(freedBytes)))
+	}
+}
+
 // requestSnapshot schedules a user snapshot at the given absolute token
 // offset. The snapshot will be captured during prefill when the cache
 // reaches this offset.
@@ -261,14 +336,16 @@ func (s *cacheSession) requestSnapshot(offset int) {
 	if offset <= baseOffset || offset > len(s.inputs) {
 		return
 	}
-	// Deduplicate: if this offset already exists, upgrade to user.
+	// Deduplicate: if this offset already exists, upgrade to durable.
 	for i := range s.pendingSnapshots {
 		if s.pendingSnapshots[i].offset == offset {
-			s.pendingSnapshots[i].user = true
+			if s.pendingSnapshots[i].kind < restorePointDurable {
+				s.pendingSnapshots[i].kind = restorePointDurable
+			}
 			return
 		}
 	}
-	s.pendingSnapshots = append(s.pendingSnapshots, pendingSnapshot{offset: offset, user: true})
+	s.pendingSnapshots = append(s.pendingSnapshots, pendingSnapshot{offset: offset, kind: restorePointDurable})
 	slices.SortFunc(s.pendingSnapshots, func(a, b pendingSnapshot) int {
 		return a.offset - b.offset
 	})
@@ -305,21 +382,21 @@ func (s *cacheSession) tokensBetween(start, end int) []int32 {
 }
 
 // snapshot creates a snapshot at the current cache position. It determines
-// whether this is a user snapshot by consuming pending entries whose offset
-// has been reached.
+// the restore point kind by consuming pending entries whose offset has been
+// reached.
 func (s *cacheSession) snapshot() {
 	// Consume pending snapshots up to the current offset and derive
-	// the user flag from them.
-	user := false
+	// the strongest restore point kind from them.
+	kind := restorePointNone
 	cacheOffset := s.cache.minCacheOffset()
 	for len(s.pendingSnapshots) > 0 && cacheOffset >= s.pendingSnapshots[0].offset {
-		if s.pendingSnapshots[0].user {
-			user = true
+		if s.pendingSnapshots[0].kind > kind {
+			kind = s.pendingSnapshots[0].kind
 		}
 		s.pendingSnapshots = s.pendingSnapshots[1:]
 	}
 
-	s.snapshotCurrent(user)
+	s.snapshotCurrent(kind)
 }
 
 func (s *cacheSession) decodeCheckpoint() bool {
@@ -327,14 +404,14 @@ func (s *cacheSession) decodeCheckpoint() bool {
 	if cacheOffset <= 0 || cacheOffset == s.lastDecodeCheckpointOffset {
 		return false
 	}
-	if !s.snapshotCurrent(true) {
+	if !s.snapshotCurrent(restorePointEphemeral) {
 		return false
 	}
 	s.lastDecodeCheckpointOffset = cacheOffset
 	return true
 }
 
-func (s *cacheSession) snapshotCurrent(user bool) bool {
+func (s *cacheSession) snapshotCurrent(kind restorePointKind) bool {
 	c := s.cache
 	cacheOffset := c.minCacheOffset()
 	if cacheOffset <= 0 {
@@ -352,9 +429,7 @@ func (s *cacheSession) snapshotCurrent(user bool) bool {
 
 	// If the frontier already ends at cacheOffset, just ensure it has snapshots.
 	if frontier.endOffset == cacheOffset {
-		if user {
-			frontier.user = true
-		}
+		frontier.markRestorePoint(kind)
 		if !frontier.hasAllSnapshots() {
 			s.attachSnapshots(frontier, cacheOffset)
 		}
@@ -374,9 +449,7 @@ func (s *cacheSession) snapshotCurrent(user bool) bool {
 	// snapshots even if the node already has some (e.g. from splitNode's
 	// Cache.Split which may be incomplete for non-splittable caches
 	// like RecurrentCache).
-	if user {
-		frontier.user = true
-	}
+	frontier.markRestorePoint(kind)
 	s.attachSnapshots(frontier, cacheOffset)
 	return true
 }
@@ -406,9 +479,9 @@ func (c *kvCache) advancePath(frontier *trieNode, tokens []int32, endOffset int)
 	dest := matchPath[len(matchPath)-1]
 
 	if len(remaining) > 0 {
-		// Drop non-user snapshots so appendTokens can extend in-place
+		// Drop non-restore-point snapshots so appendTokens can extend in-place
 		// rather than creating a new child node.
-		if len(dest.children) == 0 && !dest.user {
+		if len(dest.children) == 0 && !dest.isRestorePoint() {
 			dest.setSnapshots(nil, &c.pagedOutBytes)
 		}
 		newDest := dest.appendTokens(c.root, remaining, endOffset)
@@ -517,7 +590,7 @@ func (c *kvCache) enforceEvictionPolicy() {
 	for c.pagedOutBytes > maxPagedOutBytes {
 		var best *trieNode
 		walkNodes(c.root, func(n *trieNode) bool {
-			if n == c.root || activeSet[n] || len(n.children) > 1 {
+			if n == c.root || activeSet[n] || n.isRestorePoint() || len(n.children) > 1 {
 				return true
 			}
 			// Evict: oldest, then deepest, then largest.
@@ -606,8 +679,8 @@ func (c *kvCache) dumpTree() {
 			label += fmt.Sprintf(" %s ago", time.Since(n.lastUsed).Truncate(time.Millisecond))
 		}
 		var flags []string
-		if n.user {
-			flags = append(flags, "user")
+		if n.restore != restorePointNone {
+			flags = append(flags, n.restore.String())
 		}
 		if n.hasAllSnapshots() {
 			snapshotCount++

--- a/x/mlxrunner/cache/cache.go
+++ b/x/mlxrunner/cache/cache.go
@@ -36,6 +36,21 @@ type Cache interface {
 	Split(snapshot Snapshot, at int) (parent, child Snapshot)
 }
 
+// ExactRestorePointCache marks cache types that cannot cheaply restore to an
+// arbitrary matched offset without a snapshot at that exact point.
+type ExactRestorePointCache interface {
+	RequiresExactRestorePoint() bool
+}
+
+func RequiresExactRestorePoint(caches []Cache) bool {
+	for _, c := range caches {
+		if exact, ok := c.(ExactRestorePointCache); ok && exact.RequiresExactRestorePoint() {
+			return true
+		}
+	}
+	return false
+}
+
 // Snapshot is paged-out cache state that can be restored later.
 type Snapshot interface {
 	// Size returns the byte size of the paged-out data (in VRAM).
@@ -260,6 +275,10 @@ type RotatingKVCache struct {
 
 func NewRotatingKVCache(maxSize int) *RotatingKVCache {
 	return &RotatingKVCache{maxSize: maxSize, KVCache: NewKVCache()}
+}
+
+func (c *RotatingKVCache) RequiresExactRestorePoint() bool {
+	return true
 }
 
 // Assumes B = 1; heterogeneous batches are not supported.

--- a/x/mlxrunner/cache/recurrent.go
+++ b/x/mlxrunner/cache/recurrent.go
@@ -48,6 +48,10 @@ func NewRecurrentCache(convTail, convDim, numVHeads, headVDim, headKDim int32) *
 	}
 }
 
+func (c *RecurrentCache) RequiresExactRestorePoint() bool {
+	return true
+}
+
 func (c *RecurrentCache) ensure(batch int, dtype mlx.DType) {
 	if batch <= 0 {
 		batch = 1

--- a/x/mlxrunner/cache_test.go
+++ b/x/mlxrunner/cache_test.go
@@ -177,6 +177,9 @@ func (c *fakeSlidingWindowCache) Update(keys, values *mlx.Array) (*mlx.Array, *m
 }
 func (c *fakeSlidingWindowCache) State() []*mlx.Array { return nil }
 func (c *fakeSlidingWindowCache) Offset() int         { return len(c.tokens) }
+func (c *fakeSlidingWindowCache) RequiresExactRestorePoint() bool {
+	return true
+}
 
 func (c *fakeSlidingWindowCache) Free() {
 	c.tokens = nil
@@ -257,6 +260,9 @@ func (c *fakeRecurrentCache) Update(keys, values *mlx.Array) (*mlx.Array, *mlx.A
 }
 func (c *fakeRecurrentCache) State() []*mlx.Array { return nil }
 func (c *fakeRecurrentCache) Offset() int         { return len(c.tokens) }
+func (c *fakeRecurrentCache) RequiresExactRestorePoint() bool {
+	return true
+}
 
 func (c *fakeRecurrentCache) Free() {
 	c.tokens = nil
@@ -385,6 +391,16 @@ type requestResult struct {
 // a user snapshot is requested at that offset during prefill.
 func simulateRequest(t *testing.T, kvc *kvCache, inputs, generated []int32, userSnapshotAt ...int) requestResult {
 	t.Helper()
+	return simulateRequestWithOptions(t, kvc, inputs, generated, false, userSnapshotAt...)
+}
+
+func simulateRequestWithDecodeCheckpoints(t *testing.T, kvc *kvCache, inputs, generated []int32, userSnapshotAt ...int) requestResult {
+	t.Helper()
+	return simulateRequestWithOptions(t, kvc, inputs, generated, true, userSnapshotAt...)
+}
+
+func simulateRequestWithOptions(t *testing.T, kvc *kvCache, inputs, generated []int32, decodeCheckpoints bool, userSnapshotAt ...int) requestResult {
+	t.Helper()
 
 	session := kvc.begin(nil, inputs)
 	for _, at := range userSnapshotAt {
@@ -426,10 +442,28 @@ func simulateRequest(t *testing.T, kvc *kvCache, inputs, generated []int32, user
 
 	assertCacheOffsetAlignment(t, kvc, "after prefill")
 
+	decodeCheckpointBaseOffset := 0
+	if decodeCheckpoints && cache.RequiresExactRestorePoint(kvc.caches) && len(kvc.activePath) > 0 {
+		decodeCheckpointBaseOffset = kvc.activePath[len(kvc.activePath)-1].endOffset
+	}
+
 	// Generate tokens.
 	if len(generated) > 0 {
-		session.outputs = generated
-		feedAll(kvc.caches, generated)
+		if decodeCheckpoints && cache.RequiresExactRestorePoint(kvc.caches) {
+			for _, token := range generated {
+				session.outputs = append(session.outputs, token)
+				feedAll(kvc.caches, []int32{token})
+				if shouldDecodeCheckpoint(kvc.minCacheOffset() - decodeCheckpointBaseOffset) {
+					session.decodeCheckpoint()
+				}
+			}
+			if shouldFinalDecodeCheckpoint(len(session.outputs)) {
+				session.decodeCheckpoint()
+			}
+		} else {
+			session.outputs = generated
+			feedAll(kvc.caches, generated)
+		}
 	}
 
 	assertCacheOffsetAlignment(t, kvc, "before close")
@@ -832,6 +866,106 @@ func TestUserSnapshotResistsAutoMerge(t *testing.T) {
 	})
 }
 
+func TestDecodeCheckpointsRestoreExactCachesInsideGeneratedBranch(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		env  *testEnv
+	}{
+		{name: "SlidingWindow", env: newSlidingWindowEnv()},
+		{name: "Recurrent", env: newRecurrentEnv()},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			env := tt.env
+			t.Cleanup(func() {
+				checkSnapshotLeaks(t, env.tracker, env.kvc.root)
+			})
+
+			prompt := int32Range(1, 30)
+			generated := int32Range(1000, 240)
+			simulateRequestWithDecodeCheckpoints(t, env.kvc, prompt, generated, len(prompt))
+
+			followup := slices.Clone(prompt)
+			followup = append(followup, generated[:80]...)
+			followup = append(followup, 9999)
+
+			res := simulateRequestWithDecodeCheckpoints(t, env.kvc, followup, nil)
+			wantCached := len(prompt) + 64
+			if got, want := len(res.remaining), len(followup)-wantCached; got != want {
+				t.Fatalf("remaining = %d, want %d (restore to decode checkpoint %d)", got, want, wantCached)
+			}
+			env.assertAllTokens(t, "after followup", followup)
+
+			deeperFollowup := slices.Clone(prompt)
+			deeperFollowup = append(deeperFollowup, generated[:150]...)
+			deeperFollowup = append(deeperFollowup, 9998)
+			res = simulateRequestWithDecodeCheckpoints(t, env.kvc, deeperFollowup, nil)
+			wantCached = len(prompt) + 128
+			if got, want := len(res.remaining), len(deeperFollowup)-wantCached; got != want {
+				t.Fatalf("deeper remaining = %d, want %d (restore to decode checkpoint %d)", got, want, wantCached)
+			}
+			env.assertAllTokens(t, "after deeper followup", deeperFollowup)
+			checkTrieInvariants(t, env.kvc.root)
+		})
+	}
+}
+
+func TestDecodeCheckpointsSkippedForTransformerCaches(t *testing.T) {
+	env := newTransformerEnv()
+	t.Cleanup(func() {
+		checkSnapshotLeaks(t, env.tracker, env.kvc.root)
+	})
+
+	prompt := int32Range(1, 30)
+	generated := int32Range(1000, 120)
+	simulateRequestWithDecodeCheckpoints(t, env.kvc, prompt, generated, len(prompt))
+
+	if countUserNodesAt(env.kvc, len(prompt)+64) != 0 {
+		t.Fatalf("unexpected decode checkpoint at offset %d for pure KV cache", len(prompt)+64)
+	}
+	if countUserNodesAt(env.kvc, len(prompt)+len(generated)) != 0 {
+		t.Fatalf("unexpected final decode checkpoint at offset %d for pure KV cache", len(prompt)+len(generated))
+	}
+	checkTrieInvariants(t, env.kvc.root)
+}
+
+func TestFinalDecodeCheckpointPreservesGeneratedTail(t *testing.T) {
+	env := newRecurrentEnv()
+	t.Cleanup(func() {
+		checkSnapshotLeaks(t, env.tracker, env.kvc.root)
+	})
+
+	prompt := int32Range(1, 30)
+	generated := int32Range(1000, 90)
+	simulateRequestWithDecodeCheckpoints(t, env.kvc, prompt, generated, len(prompt))
+
+	if countUserNodesAt(env.kvc, len(prompt)+64) != 1 {
+		t.Fatalf("decode checkpoint at offset %d not found", len(prompt)+64)
+	}
+	if countUserNodesAt(env.kvc, len(prompt)+len(generated)) != 1 {
+		t.Fatalf("final decode checkpoint at offset %d not found", len(prompt)+len(generated))
+	}
+	checkTrieInvariants(t, env.kvc.root)
+}
+
+func TestDecodeCheckpointProgressStartsAtActiveFrontier(t *testing.T) {
+	env := newRecurrentEnv()
+	t.Cleanup(func() {
+		checkSnapshotLeaks(t, env.tracker, env.kvc.root)
+	})
+
+	prompt := int32Range(1, 34)
+	generated := int32Range(1000, 60)
+	simulateRequestWithDecodeCheckpoints(t, env.kvc, prompt, generated, 30)
+
+	if countUserNodesAt(env.kvc, 94) != 1 {
+		t.Fatalf("decode checkpoint at offset 94 not found")
+	}
+	if countUserNodesAt(env.kvc, len(prompt)+64) != 0 {
+		t.Fatalf("unexpected generated-token based checkpoint at offset %d", len(prompt)+64)
+	}
+	checkTrieInvariants(t, env.kvc.root)
+}
+
 func findUserNode(t *testing.T, kvc *kvCache) *trieNode {
 	t.Helper()
 	var found *trieNode
@@ -859,6 +993,25 @@ func assertUserNodeExists(t *testing.T, kvc *kvCache, label string) {
 	if !exists {
 		t.Fatalf("%s: no user-marked node found", label)
 	}
+}
+
+func countUserNodesAt(kvc *kvCache, offset int) int {
+	var count int
+	walkNodes(kvc.root, func(n *trieNode) bool {
+		if n.user && n.endOffset == offset {
+			count++
+		}
+		return true
+	})
+	return count
+}
+
+func int32Range(start, count int) []int32 {
+	values := make([]int32, count)
+	for i := range values {
+		values[i] = int32(start + i)
+	}
+	return values
 }
 
 // TestBranchSwitchRestoresCorrectState exercises switching back to an older

--- a/x/mlxrunner/cache_test.go
+++ b/x/mlxrunner/cache_test.go
@@ -868,45 +868,80 @@ func TestUserSnapshotResistsAutoMerge(t *testing.T) {
 
 func TestDecodeCheckpointsRestoreExactCachesInsideGeneratedBranch(t *testing.T) {
 	for _, tt := range []struct {
-		name string
-		env  *testEnv
+		name   string
+		newEnv func() *testEnv
 	}{
-		{name: "SlidingWindow", env: newSlidingWindowEnv()},
-		{name: "Recurrent", env: newRecurrentEnv()},
+		{name: "SlidingWindow", newEnv: newSlidingWindowEnv},
+		{name: "Recurrent", newEnv: newRecurrentEnv},
 	} {
-		t.Run(tt.name, func(t *testing.T) {
-			env := tt.env
-			t.Cleanup(func() {
-				checkSnapshotLeaks(t, env.tracker, env.kvc.root)
+		for _, tc := range []struct {
+			name        string
+			matchTokens int
+			wantCached  int
+		}{
+			{name: "first checkpoint", matchTokens: 2500, wantCached: 2048},
+			{name: "second checkpoint", matchTokens: 4300, wantCached: 4096},
+		} {
+			t.Run(tt.name+"/"+tc.name, func(t *testing.T) {
+				env := tt.newEnv()
+				t.Cleanup(func() {
+					checkSnapshotLeaks(t, env.tracker, env.kvc.root)
+				})
+
+				prompt := int32Range(1, 30)
+				generated := int32Range(1000, 4600)
+				simulateRequestWithDecodeCheckpoints(t, env.kvc, prompt, generated, len(prompt))
+
+				followup := slices.Clone(prompt)
+				followup = append(followup, generated[:tc.matchTokens]...)
+				followup = append(followup, 9999)
+
+				res := simulateRequestWithDecodeCheckpoints(t, env.kvc, followup, nil)
+				wantCached := len(prompt) + tc.wantCached
+				if got, want := len(res.remaining), len(followup)-wantCached; got != want {
+					t.Fatalf("remaining = %d, want %d (restore to decode checkpoint %d)", got, want, wantCached)
+				}
+				if countEphemeralNodesAt(env.kvc, wantCached) != 1 {
+					t.Fatalf("active decode checkpoint at offset %d was pruned", wantCached)
+				}
+				env.assertAllTokens(t, "after followup", followup)
+				checkTrieInvariants(t, env.kvc.root)
 			})
-
-			prompt := int32Range(1, 30)
-			generated := int32Range(1000, 240)
-			simulateRequestWithDecodeCheckpoints(t, env.kvc, prompt, generated, len(prompt))
-
-			followup := slices.Clone(prompt)
-			followup = append(followup, generated[:80]...)
-			followup = append(followup, 9999)
-
-			res := simulateRequestWithDecodeCheckpoints(t, env.kvc, followup, nil)
-			wantCached := len(prompt) + 64
-			if got, want := len(res.remaining), len(followup)-wantCached; got != want {
-				t.Fatalf("remaining = %d, want %d (restore to decode checkpoint %d)", got, want, wantCached)
-			}
-			env.assertAllTokens(t, "after followup", followup)
-
-			deeperFollowup := slices.Clone(prompt)
-			deeperFollowup = append(deeperFollowup, generated[:150]...)
-			deeperFollowup = append(deeperFollowup, 9998)
-			res = simulateRequestWithDecodeCheckpoints(t, env.kvc, deeperFollowup, nil)
-			wantCached = len(prompt) + 128
-			if got, want := len(res.remaining), len(deeperFollowup)-wantCached; got != want {
-				t.Fatalf("deeper remaining = %d, want %d (restore to decode checkpoint %d)", got, want, wantCached)
-			}
-			env.assertAllTokens(t, "after deeper followup", deeperFollowup)
-			checkTrieInvariants(t, env.kvc.root)
-		})
+		}
 	}
+}
+
+func TestInactiveEphemeralDecodeCheckpointsArePruned(t *testing.T) {
+	env := newRecurrentEnv()
+	t.Cleanup(func() {
+		checkSnapshotLeaks(t, env.tracker, env.kvc.root)
+	})
+
+	prompt := int32Range(1, 30)
+	generated := int32Range(1000, 4200)
+	simulateRequestWithDecodeCheckpoints(t, env.kvc, prompt, generated, len(prompt))
+
+	for _, offset := range []int{len(prompt) + 2048, len(prompt) + 4096, len(prompt) + len(generated)} {
+		if countEphemeralNodesAt(env.kvc, offset) != 1 {
+			t.Fatalf("decode checkpoint at offset %d not found before cleanup", offset)
+		}
+	}
+
+	followup := append(slices.Clone(prompt), 9999)
+	simulateRequestWithDecodeCheckpoints(t, env.kvc, followup, nil)
+
+	for _, offset := range []int{len(prompt) + 2048, len(prompt) + 4096, len(prompt) + len(generated)} {
+		if countEphemeralNodesAt(env.kvc, offset) != 0 {
+			t.Fatalf("stale decode checkpoint at offset %d survived cleanup", offset)
+		}
+		if countSnapshotNodesAt(env.kvc, offset) != 0 {
+			t.Fatalf("stale decode checkpoint snapshot at offset %d survived cleanup", offset)
+		}
+	}
+	if countUserNodesAt(env.kvc, len(prompt)) != 1 {
+		t.Fatalf("durable prompt checkpoint at offset %d was pruned", len(prompt))
+	}
+	checkTrieInvariants(t, env.kvc.root)
 }
 
 func TestDecodeCheckpointsSkippedForTransformerCaches(t *testing.T) {
@@ -916,13 +951,13 @@ func TestDecodeCheckpointsSkippedForTransformerCaches(t *testing.T) {
 	})
 
 	prompt := int32Range(1, 30)
-	generated := int32Range(1000, 120)
+	generated := int32Range(1000, 2200)
 	simulateRequestWithDecodeCheckpoints(t, env.kvc, prompt, generated, len(prompt))
 
-	if countUserNodesAt(env.kvc, len(prompt)+64) != 0 {
-		t.Fatalf("unexpected decode checkpoint at offset %d for pure KV cache", len(prompt)+64)
+	if countEphemeralNodesAt(env.kvc, len(prompt)+2048) != 0 {
+		t.Fatalf("unexpected decode checkpoint at offset %d for pure KV cache", len(prompt)+2048)
 	}
-	if countUserNodesAt(env.kvc, len(prompt)+len(generated)) != 0 {
+	if countEphemeralNodesAt(env.kvc, len(prompt)+len(generated)) != 0 {
 		t.Fatalf("unexpected final decode checkpoint at offset %d for pure KV cache", len(prompt)+len(generated))
 	}
 	checkTrieInvariants(t, env.kvc.root)
@@ -938,10 +973,10 @@ func TestFinalDecodeCheckpointPreservesGeneratedTail(t *testing.T) {
 	generated := int32Range(1000, 90)
 	simulateRequestWithDecodeCheckpoints(t, env.kvc, prompt, generated, len(prompt))
 
-	if countUserNodesAt(env.kvc, len(prompt)+64) != 1 {
-		t.Fatalf("decode checkpoint at offset %d not found", len(prompt)+64)
+	if countEphemeralNodesAt(env.kvc, len(prompt)+64) != 0 {
+		t.Fatalf("unexpected periodic decode checkpoint at offset %d", len(prompt)+64)
 	}
-	if countUserNodesAt(env.kvc, len(prompt)+len(generated)) != 1 {
+	if countEphemeralNodesAt(env.kvc, len(prompt)+len(generated)) != 1 {
 		t.Fatalf("final decode checkpoint at offset %d not found", len(prompt)+len(generated))
 	}
 	checkTrieInvariants(t, env.kvc.root)
@@ -954,14 +989,14 @@ func TestDecodeCheckpointProgressStartsAtActiveFrontier(t *testing.T) {
 	})
 
 	prompt := int32Range(1, 34)
-	generated := int32Range(1000, 60)
+	generated := int32Range(1000, 2044)
 	simulateRequestWithDecodeCheckpoints(t, env.kvc, prompt, generated, 30)
 
-	if countUserNodesAt(env.kvc, 94) != 1 {
-		t.Fatalf("decode checkpoint at offset 94 not found")
+	if countEphemeralNodesAt(env.kvc, 2078) != 1 {
+		t.Fatalf("decode checkpoint at offset 2078 not found")
 	}
-	if countUserNodesAt(env.kvc, len(prompt)+64) != 0 {
-		t.Fatalf("unexpected generated-token based checkpoint at offset %d", len(prompt)+64)
+	if countEphemeralNodesAt(env.kvc, len(prompt)+2048) != 0 {
+		t.Fatalf("unexpected generated-token based checkpoint at offset %d", len(prompt)+2048)
 	}
 	checkTrieInvariants(t, env.kvc.root)
 }
@@ -970,7 +1005,7 @@ func findUserNode(t *testing.T, kvc *kvCache) *trieNode {
 	t.Helper()
 	var found *trieNode
 	walkNodes(kvc.root, func(n *trieNode) bool {
-		if n.user {
+		if n.restore == restorePointDurable {
 			found = n
 		}
 		return true
@@ -985,7 +1020,7 @@ func assertUserNodeExists(t *testing.T, kvc *kvCache, label string) {
 	t.Helper()
 	var exists bool
 	walkNodes(kvc.root, func(n *trieNode) bool {
-		if n.user {
+		if n.restore == restorePointDurable {
 			exists = true
 		}
 		return true
@@ -996,9 +1031,28 @@ func assertUserNodeExists(t *testing.T, kvc *kvCache, label string) {
 }
 
 func countUserNodesAt(kvc *kvCache, offset int) int {
+	return countRestorePointNodesAt(kvc, offset, restorePointDurable)
+}
+
+func countEphemeralNodesAt(kvc *kvCache, offset int) int {
+	return countRestorePointNodesAt(kvc, offset, restorePointEphemeral)
+}
+
+func countRestorePointNodesAt(kvc *kvCache, offset int, kind restorePointKind) int {
 	var count int
 	walkNodes(kvc.root, func(n *trieNode) bool {
-		if n.user && n.endOffset == offset {
+		if n.restore == kind && n.endOffset == offset {
+			count++
+		}
+		return true
+	})
+	return count
+}
+
+func countSnapshotNodesAt(kvc *kvCache, offset int) int {
+	var count int
+	walkNodes(kvc.root, func(n *trieNode) bool {
+		if n.endOffset == offset && n.hasSnapshots() {
 			count++
 		}
 		return true

--- a/x/mlxrunner/cache_trie.go
+++ b/x/mlxrunner/cache_trie.go
@@ -18,7 +18,36 @@ type trieNode struct {
 	children  []*trieNode
 	lastUsed  time.Time        // for LRU eviction
 	snapshots []cache.Snapshot // per-layer paged-out snapshot data (nil if not paged out)
-	user      bool             // true = explicit restore point (resist auto-merge)
+	restore   restorePointKind // explicit restore point kind, if any
+}
+
+type restorePointKind uint8
+
+const (
+	restorePointNone restorePointKind = iota
+	restorePointEphemeral
+	restorePointDurable
+)
+
+func (k restorePointKind) String() string {
+	switch k {
+	case restorePointEphemeral:
+		return "ephemeral"
+	case restorePointDurable:
+		return "durable"
+	default:
+		return "none"
+	}
+}
+
+func (n *trieNode) isRestorePoint() bool {
+	return n.restore != restorePointNone
+}
+
+func (n *trieNode) markRestorePoint(kind restorePointKind) {
+	if kind > n.restore {
+		n.restore = kind
+	}
 }
 
 // startOffset returns the cumulative token offset at the start of this node's edge.
@@ -262,8 +291,9 @@ func mergeWithChild(node *trieNode, caches []cache.Cache, counter *int64) {
 		gc.parent = node
 	}
 
-	// Inherit user flag from child if child was a user-created snapshot node.
-	node.user = child.user
+	// After merging, the node's endOffset moves to the child boundary, so only
+	// the child's restore point can remain semantically valid.
+	node.restore = child.restore
 
 	// Update lastUsed to the more recent of the two.
 	if child.lastUsed.After(node.lastUsed) {

--- a/x/mlxrunner/cache_trie_test.go
+++ b/x/mlxrunner/cache_trie_test.go
@@ -138,7 +138,7 @@ func TestSplitNodeWithSnapshots(t *testing.T) {
 
 	rc := &fakeRewindableCache{tracker: &snapshotTracker{}, tokens: []int32{1, 2, 3, 4, 5}}
 	child.snapshots = []cache.Snapshot{rc.Snapshot(0)}
-	child.user = true
+	child.restore = restorePointDurable
 
 	caches := []cache.Cache{rc}
 
@@ -147,14 +147,14 @@ func TestSplitNodeWithSnapshots(t *testing.T) {
 	if !newParent.hasSnapshots() {
 		t.Fatal("newParent should have snapshots after split")
 	}
-	if newParent.user {
-		t.Fatal("newParent should not be a user snapshot after splitNode")
+	if newParent.restore != restorePointNone {
+		t.Fatal("newParent should not be a restore point after splitNode")
 	}
 	if !child.hasSnapshots() {
 		t.Fatal("child should have snapshots after split")
 	}
-	if !child.user {
-		t.Fatal("child should remain a user snapshot")
+	if child.restore != restorePointDurable {
+		t.Fatal("child should remain a durable restore point")
 	}
 }
 
@@ -291,23 +291,23 @@ func TestMergeWithChild(t *testing.T) {
 		checkTrieInvariants(t, root)
 	})
 
-	t.Run("UserFlag", func(t *testing.T) {
+	t.Run("RestorePointKind", func(t *testing.T) {
 		root := &trieNode{lastUsed: time.Now()}
 		parent := &trieNode{
 			tokens: []int32{1, 2}, endOffset: 2, parent: root,
-			lastUsed: time.Now(), user: false,
+			lastUsed: time.Now(),
 		}
 		child := &trieNode{
 			tokens: []int32{3, 4}, endOffset: 4, parent: parent,
-			lastUsed: time.Now(), user: true,
+			lastUsed: time.Now(), restore: restorePointEphemeral,
 		}
 		root.children = []*trieNode{parent}
 		parent.children = []*trieNode{child}
 
 		mergeWithChild(parent, nil, nil)
 
-		if !parent.user {
-			t.Fatal("merged node should inherit user=true from child")
+		if parent.restore != restorePointEphemeral {
+			t.Fatal("merged node should inherit restore point from child")
 		}
 	})
 

--- a/x/mlxrunner/pipeline.go
+++ b/x/mlxrunner/pipeline.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ollama/ollama/llm"
 	"github.com/ollama/ollama/logutil"
 	"github.com/ollama/ollama/x/mlxrunner/batch"
+	cachepkg "github.com/ollama/ollama/x/mlxrunner/cache"
 	"github.com/ollama/ollama/x/mlxrunner/mlx"
 	sampler "github.com/ollama/ollama/x/mlxrunner/sample"
 	"github.com/ollama/ollama/x/tokenizer"
@@ -19,6 +20,25 @@ import (
 
 func prefillChunkSize() int {
 	return 2 << 10
+}
+
+const minDecodeCheckpointTokens = 64
+
+func shouldDecodeCheckpoint(generated int) bool {
+	switch {
+	case generated <= 0:
+		return false
+	case generated <= 512:
+		return generated%64 == 0
+	case generated <= 2048:
+		return generated%256 == 0
+	default:
+		return generated%1024 == 0
+	}
+}
+
+func shouldFinalDecodeCheckpoint(generated int) bool {
+	return generated >= minDecodeCheckpointTokens
 }
 
 // Prepare tokenizes the prompt and validates it against the model's
@@ -79,6 +99,10 @@ func (r *Runner) TextGenerationPipeline(ctx context.Context, request Request) er
 	caches := session.caches
 	tokens := session.remaining
 	prefillChunk := prefillChunkSize()
+	decodeCheckpoints := cachepkg.RequiresExactRestorePoint(caches)
+	if decodeCheckpoints {
+		slog.Debug("decode cache checkpoints enabled")
+	}
 
 	// Request periodic snapshots during prefill and near the end of the
 	// prompt so that long prompts can be partially restored and
@@ -165,6 +189,10 @@ func (r *Runner) TextGenerationPipeline(ctx context.Context, request Request) er
 	}
 
 	sample = step(mlx.FromValues(tokens[processed:], 1, total-processed))
+	decodeCheckpointBaseOffset := 0
+	if decodeCheckpoints && len(session.cache.activePath) > 0 {
+		decodeCheckpointBaseOffset = session.cache.activePath[len(session.cache.activePath)-1].endOffset
+	}
 
 	dec := decoder{
 		tokenizer:       r.Tokenizer,
@@ -189,6 +217,10 @@ func (r *Runner) TextGenerationPipeline(ctx context.Context, request Request) er
 		output := int32(sample.Token.Int())
 		session.outputs = append(session.outputs, output)
 
+		if decodeCheckpoints && shouldDecodeCheckpoint(session.cache.minCacheOffset()-decodeCheckpointBaseOffset) {
+			session.decodeCheckpoint()
+		}
+
 		if r.Tokenizer.IsEOS(output) {
 			final.DoneReason = 0
 			final.EvalCount = i
@@ -209,6 +241,10 @@ func (r *Runner) TextGenerationPipeline(ctx context.Context, request Request) er
 		if i%256 == 0 {
 			mlx.ClearCache()
 		}
+	}
+
+	if decodeCheckpoints && shouldFinalDecodeCheckpoint(len(session.outputs)) {
+		session.decodeCheckpoint()
 	}
 
 	final.EvalDuration = time.Since(now)

--- a/x/mlxrunner/pipeline.go
+++ b/x/mlxrunner/pipeline.go
@@ -22,19 +22,13 @@ func prefillChunkSize() int {
 	return 2 << 10
 }
 
-const minDecodeCheckpointTokens = 64
+const (
+	decodeCheckpointInterval  = 2048
+	minDecodeCheckpointTokens = 64
+)
 
 func shouldDecodeCheckpoint(generated int) bool {
-	switch {
-	case generated <= 0:
-		return false
-	case generated <= 512:
-		return generated%64 == 0
-	case generated <= 2048:
-		return generated%256 == 0
-	default:
-		return generated%1024 == 0
-	}
+	return generated > 0 && generated%decodeCheckpointInterval == 0
 }
 
 func shouldFinalDecodeCheckpoint(generated int) bool {


### PR DESCRIPTION
## Summary

I was suspicious that MLX cache reuse was falling apart specifically around long generations and follow-up turns. The trie remembered generated history as tokens, but recurrent/sliding-window cache state was not always restorable at the matched offset because decode did not create exact restore points. That meant we could "match" a prior assistant response but still replay most of it.

This PR adds decode-time checkpoints for MLX cache stacks that need exact restore points, currently recurrent and rotating/sliding-window caches. Plain `KVCache` stays on the existing path because it can usually slice/rewind without needing exact generated-token snapshots.

After live memory testing, the final design is intentionally sparse:

```text
periodic decode checkpoint every 2048 generated tokens
final decode checkpoint if generation produced at least 64 tokens
inactive decode checkpoints are ephemeral and pruned when a later request switches away
```

Prompt checkpoint behavior is unchanged.

## Probe

I tested the original suspicion with `pi` in headless mode and direct API probes using:

- `qwen3.6:35b-a3b-coding-nvfp4`
- `qwen3.6:27b-coding-nvfp4`
- `gemma4:26b-nvfp4`
- MLX worktree server with debug logs
- small prompts, exact repeats, prefix variants
- long prompt repeats and mid-prompt variants
- long generations followed by follow-up turns
- fake mid-generation divergence histories
- real `pi` multi-step tool-calling flows with thinking enabled

The key pre-fix signal:

```text
long_generation_exact_followup:
total=430 matched=96 cached=30 left=400
```

So the trie matched into generated assistant history (`matched=96`), but cache restore fell back to the prompt-side checkpoint at `cached=30`.

Long prompt caching was already healthy:

```text
long_prompt_exact_repeat:
total=49623 matched=49623 cached=49619 left=4
```

That made this look like a decode checkpointing problem, not a general prefill checkpointing problem.

## Findings

Recurrent and rotating/sliding-window caches cannot cheaply restore to arbitrary matched offsets:

- `KVCache` can slice/rewind in many cases.
- `RecurrentCache` needs cumulative state at the exact target.
- `RotatingKVCache` can lose arbitrary earlier positions once the window has rotated.

Before this PR, generated tokens advanced the trie on `close()`, but decode did not proactively create restore snapshots. That left long assistant outputs structurally matchable but not cheaply restorable.

## What Changed

This PR adds an internal exact-restore capability:

- `RecurrentCache` opts in.
- `RotatingKVCache` opts in.
- plain `KVCache` stays default/no-op.

It also distinguishes restore point lifetimes:

- prompt/user-requested checkpoints are durable restore points
- decode checkpoints are ephemeral restore points
- stale ephemeral decode checkpoints are pruned when a later request switches away from that generated branch
- durable restore-point nodes remain protected from merge/eviction

The decode loop now creates checkpoints only when any cache layer requires exact restore points:

```text
every 2048 generated tokens
final checkpoint if generation produced at least 64 tokens
```

This replaced the earlier dense experimental cadence:

```text
every 64 generated tokens through 512
every 256 generated tokens from 513 through 2048
every 1024 generated tokens after 2048
```

The dense cadence fixed the restore issue, but live runs showed checkpoint memory was high enough that the first version was too eager.

## Live Validation

Dense checkpoints proved the original restore issue could be fixed: the same generated-history follow-up improved from the prompt checkpoint to the first decode checkpoint:

```text
before: total=430 matched=96 cached=30 left=400
after:  total=430 matched=96 cached=94 left=336
```

Then I changed the final design to the 2048-token cadence plus final checkpoint and reran live probes.

### Qwen3.6 27B Coding

Sparse generation probe on `qwen3.6:27b-coding-nvfp4` showed the intended checkpoint cadence:

```text
short generation, 220 tokens:
created snapshot offset=253
pruned ephemeral decode checkpoints nodes=1 snapshot_nodes=1 freed="88.81 MiB"
peak memory: 17.74 GiB

long generation, 2300 tokens:
created snapshot offset=2082
created snapshot offset=2338
pruned ephemeral decode checkpoints nodes=2 snapshot_nodes=2 freed="293.62 MiB"
peak memory: 18.69 GiB

long generation, 2100 tokens:
created snapshot offset=2087
created snapshot offset=2143
pruned ephemeral decode checkpoints nodes=2 snapshot_nodes=2 freed="281.12 MiB"
peak memory: 19.40 GiB
```

A real `pi` multi-step tool-calling run with `--thinking high` round-tripped generated/tool-call history and restored exactly from decode checkpoints:

```text
request 1:
cache miss total=2351 matched=355 cached=0 left=2351
created snapshot offset=2618
peak memory: 20.61 GiB

request 2 after Pi tool turn:
cache hit total=5996 matched=2618 cached=2618 left=3378
created snapshot offset=6194
peak memory: 21.28 GiB

request 3:
cache hit total=6535 matched=6194 cached=6194 left=341
created snapshot offset=6629
peak memory: 19.77 GiB

request 4:
cache hit total=7173 matched=6629 cached=6629 left=544
peak memory: 20.28 GiB
```

Pruning also behaved as intended: it pruned stale ephemeral checkpoints when starting a different branch, but did not prune active generated/tool-call history while `pi` continued the same trajectory.

### Gemma4 26B

I reran the same `pi` multi-step tool-calling benchmark with `gemma4:26b-nvfp4`.

The model enabled decode checkpoints and created generation-side checkpoints, but its first follow-up stopped just before the final generated checkpoint. That caused the stale final checkpoint to be pruned and restore fell back to the prompt-side checkpoint for that turn:

```text
request 1:
cache miss total=6434 matched=0 cached=0 left=6434
created snapshot offset=6430   # prompt-side
created snapshot offset=6651   # final decode checkpoint
peak memory: 16.79 GiB

request 2:
pruned ephemeral decode checkpoints nodes=1 snapshot_nodes=1 freed="204.32 MiB"
cache hit total=9528 matched=6630 cached=6430 left=3098
created snapshot offset=6630
created snapshot offset=8192
created snapshot offset=9524
created snapshot offset=9739   # final decode checkpoint
peak memory: 17.64 GiB
```

After that first rendering mismatch, subsequent Gemma4 tool turns did round-trip and restored exactly from generated/tool-call checkpoints:

```text
request 3:
cache hit total=10659 matched=9739 cached=9739 left=920
created snapshot offset=10795
peak memory: 18.21 GiB

request 4:
cache hit total=10832 matched=10795 cached=10795 left=37
created snapshot offset=11055
peak memory: 18.00 GiB

request 5:
cache hit total=11151 matched=11055 cached=11055 left=96
peak memory: 18.41 GiB

request 6:
cache hit total=11217 matched=11203 cached=11203 left=14
created snapshot offset=11865
peak memory: 18.63 GiB
```

So Gemma4 has a larger observed decode checkpoint footprint in this run: one stale ephemeral decode checkpoint freed about `204.32 MiB`, compared with about `84-89 MiB` for a short qwen3.6 27B checkpoint. The exact value depends on the cache stack and where the checkpoint lands.

A synthetic raw prompt paste did not always token-roundtrip deeply enough to reach the checkpoint, which is expected: the trie matches token IDs, not decoded text. The Gemma4 first follow-up shows the same class of caveat in a real client path: if rendering diverges before a decode checkpoint, the checkpoint is correctly pruned and cannot help that turn.

## Tradeoffs

This intentionally only enables decode checkpoints for exact-restore cache stacks.

Costs:

- More paged-out snapshot memory for recurrent/sliding-window models.
- More snapshot work on the decode hot path.
- More preserved trie nodes, though ephemeral cleanup limits stale generated branches.
- The sparse 2048-token cadence can replay up to ~2047 generated tokens for a mid-branch follow-up.
- Short generations now rely on the final tail checkpoint rather than early 64-token interior checkpoints.
- This does not fix rendered-history drift from clients. If a client reserializes hidden context, tool results, thinking text, or assistant text differently, the token trie may diverge before a useful decode checkpoint.

I did not expose an option or env knob in this PR. The goal is to fix the measured recurrent/sliding-window failure mode without expanding API/config surface.

## Tests

Added unit coverage for:

- recurrent cache restoring inside generated history via decode checkpoints
- sliding-window cache restoring inside generated history
- pure KV cache not creating decode checkpoints in auto mode
- final decode checkpoint creation
- inactive ephemeral decode checkpoint pruning
- durable prompt checkpoints surviving pruning
- no snapshot leaks or double closes
- checkpoint progress starting from the active restore frontier
- trie restore-point behavior across split/merge paths

Ran:

```sh
go test ./x/mlxrunner -run 'Test.*Cache|Test.*Snapshot|Test.*Decode|TestInactiveEphemeral|TestDecodeCheckpoints|TestFinalDecodeCheckpoint|TestUserSnapshot|TestSplitNodeWithSnapshots|TestMergeWithChild' -count=1
go test ./x/mlxrunner/cache -count=1
go test ./x/mlxrunner -count=1
go test ./x/mlxrunner/... -count=1
```

Also ran live MLX server probes with `qwen3.6:27b-coding-nvfp4` and `gemma4:26b-nvfp4`, including real `pi` multi-step tool-calling runs with thinking enabled.