### PR TITLE
fix: print better error message when a new version of Ollama is required

### DIFF
--- a/server/sched.go
+++ b/server/sched.go
@@ -21,8 +21,10 @@ import (
 	"github.com/ollama/ollama/logutil"
 	"github.com/ollama/ollama/ml"
 	"github.com/ollama/ollama/types/model"
+	"github.com/ollama/ollama/version"
 	"github.com/ollama/ollama/x/imagegen"
 	"github.com/ollama/ollama/x/mlxrunner"
+	"golang.org/x/mod/semver"
 )
 
 type LlmRequest struct {
@@ -421,6 +423,19 @@ func (s *Scheduler) load(req *LlmRequest, systemInfo ml.SystemInfo, gpus []ml.De
 	if slices.Contains([]string{"mllama", "qwen3vl", "qwen3vlmoe", "qwen35", "qwen35moe", "qwen3next", "lfm2", "lfm2moe", "nemotron_h", "nemotron_h_moe", "nemotron_h_omni"}, req.model.Config.ModelFamily) && numParallel != 1 {
 		numParallel = 1
 		slog.Warn("model architecture does not currently support parallel requests", "architecture", req.model.Config.ModelFamily)
+	}
+
+	// Check if model requires a newer version of Ollama
+	if req.model.Config.Requires != "" {
+		currentVersion := version.Version
+		requiredVersion := req.model.Config.Requires
+		// Add 'v' prefix for semver comparison
+		currentV := "v" + currentVersion
+		requiredV := "v" + requiredVersion
+		if semver.IsValid(currentV) && semver.IsValid(requiredV) && semver.Compare(currentV, requiredV) < 0 {
+			req.errCh <- fmt.Errorf("a new version of Ollama is required to run this model (minimum version: %s, current version: %s)", requiredVersion, currentVersion)
+			return false
+		}
 	}
 
 	sessionDuration := envconfig.KeepAlive()


### PR DESCRIPTION
## Problem

When a model requires a newer version of Ollama, users see cryptic error messages that are hard to recognize. Issue #3395 requested a clearer error message.

## Solution

This PR adds a version check in the scheduler before loading a model. If the current Ollama version is older than what the model requires, a clear error message is displayed:

```
a new version of Ollama is required to run this model (minimum version: X.Y.Z, current version: A.B.C)
```

The fix:
1. Checks `req.model.Config.Requires` against `version.Version` using semantic versioning
2. Uses `golang.org/x/mod/semver` for proper version comparison
3. Returns early with a descriptive error message if the version check fails

## Changes

- `server/sched.go`: Added version check logic in the `load()` function
  - Added imports for `version` and `semver` packages
  - Added version comparison before model loading

## Testing

The Go syntax has been verified using `gofmt`. Full build and test should be run in CI.

This contribution was developed with AI assistance.