### PR TITLE
launch/opencode: add image modalities for vision models

### DIFF
--- a/cmd/launch/opencode.go
+++ b/cmd/launch/opencode.go
@@ -1,6 +1,7 @@
 package launch
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -8,9 +9,12 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"time"
 
+	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/cmd/internal/fileutil"
 	"github.com/ollama/ollama/envconfig"
+	"github.com/ollama/ollama/types/model"
 )
 
 // OpenCode implements Runner and Editor for OpenCode integration.
@@ -19,6 +23,8 @@ import (
 type OpenCode struct {
 	configContent string // JSON config built by Edit, passed to Run via env var
 }
+
+const openCodeModelShowTimeout = 2 * time.Second
 
 func (o *OpenCode) String() string { return "OpenCode" }
 
@@ -176,6 +182,12 @@ func buildInlineConfig(primary string, models []string) (string, error) {
 	if primary == "" || len(models) == 0 {
 		return "", fmt.Errorf("buildInlineConfig: primary and models are required")
 	}
+
+	client, err := api.ClientFromEnvironment()
+	if err != nil {
+		client = nil
+	}
+
 	config := map[string]any{
 		"$schema": "https://opencode.ai/config.json",
 		"provider": map[string]any{
@@ -185,7 +197,7 @@ func buildInlineConfig(primary string, models []string) (string, error) {
 				"options": map[string]any{
 					"baseURL": envconfig.Host().String() + "/v1",
 				},
-				"models": buildModelEntries(models),
+				"models": buildModelEntries(context.Background(), client, models),
 			},
 		},
 		"model": "ollama/" + primary,
@@ -228,21 +240,40 @@ func readModelJSONModels() []string {
 	return models
 }
 
-func buildModelEntries(modelList []string) map[string]any {
+func buildModelEntries(ctx context.Context, client *api.Client, modelList []string) map[string]any {
 	models := make(map[string]any)
-	for _, model := range modelList {
+	for _, modelID := range modelList {
 		entry := map[string]any{
-			"name": model,
+			"name": modelID,
 		}
-		if isCloudModelName(model) {
-			if l, ok := lookupCloudModelLimit(model); ok {
+		if client != nil {
+			showCtx := ctx
+			var cancel context.CancelFunc
+			if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+				showCtx, cancel = context.WithTimeout(ctx, openCodeModelShowTimeout)
+			}
+
+			if resp, err := client.Show(showCtx, &api.ShowRequest{Model: modelID}); err == nil {
+				if slices.Contains(resp.Capabilities, model.CapabilityVision) {
+					entry["modalities"] = map[string]any{
+						"input":  []string{"text", "image"},
+						"output": []string{"text"},
+					}
+				}
+			}
+			if cancel != nil {
+				cancel()
+			}
+		}
+		if isCloudModelName(modelID) {
+			if l, ok := lookupCloudModelLimit(modelID); ok {
 				entry["limit"] = map[string]any{
 					"context": l.Context,
 					"output":  l.Output,
 				}
 			}
 		}
-		models[model] = entry
+		models[modelID] = entry
 	}
 	return models
 }

--- a/cmd/launch/opencode.go
+++ b/cmd/launch/opencode.go
@@ -241,28 +241,27 @@ func readModelJSONModels() []string {
 }
 
 func buildModelEntries(ctx context.Context, client *api.Client, modelList []string) map[string]any {
+	if client != nil {
+		var cancel context.CancelFunc
+		if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+			ctx, cancel = context.WithTimeout(ctx, openCodeModelShowTimeout)
+			defer cancel()
+		}
+	}
+
 	models := make(map[string]any)
 	for _, modelID := range modelList {
 		entry := map[string]any{
 			"name": modelID,
 		}
 		if client != nil {
-			showCtx := ctx
-			var cancel context.CancelFunc
-			if _, hasDeadline := ctx.Deadline(); !hasDeadline {
-				showCtx, cancel = context.WithTimeout(ctx, openCodeModelShowTimeout)
-			}
-
-			if resp, err := client.Show(showCtx, &api.ShowRequest{Model: modelID}); err == nil {
+			if resp, err := client.Show(ctx, &api.ShowRequest{Model: modelID}); err == nil {
 				if slices.Contains(resp.Capabilities, model.CapabilityVision) {
 					entry["modalities"] = map[string]any{
 						"input":  []string{"text", "image"},
 						"output": []string{"text"},
 					}
 				}
-			}
-			if cancel != nil {
-				cancel()
 			}
 		}
 		if isCloudModelName(modelID) {

--- a/cmd/launch/opencode_test.go
+++ b/cmd/launch/opencode_test.go
@@ -1,12 +1,19 @@
 package launch
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
+
+	"github.com/ollama/ollama/api"
 )
 
 func TestOpenCodeIntegration(t *testing.T) {
@@ -155,6 +162,70 @@ func TestOpenCodeEdit(t *testing.T) {
 
 		if entry["limit"] != nil {
 			t.Errorf("local model should not have limit, got %v", entry["limit"])
+		}
+	})
+
+	t.Run("vision model gets image input modalities", func(t *testing.T) {
+		u, err := url.Parse("http://ollama.example")
+		if err != nil {
+			t.Fatalf("parse test URL: %v", err)
+		}
+		client := api.NewClient(u, &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.URL.Path != "/api/show" {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader("not found")),
+					Header:     make(http.Header),
+				}, nil
+			}
+
+			var body struct {
+				Model string `json:"model"`
+			}
+			if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+				t.Fatalf("decode show request: %v", err)
+			}
+			if body.Model != "gemma4:26b" {
+				t.Fatalf("show request model = %q, want gemma4:26b", body.Model)
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"capabilities":["vision"],"model_info":{}}`)),
+				Header:     make(http.Header),
+			}, nil
+		})})
+
+		models := buildModelEntries(context.Background(), client, []string{"gemma4:26b"})
+		entry, _ := models["gemma4:26b"].(map[string]any)
+		modalities, _ := entry["modalities"].(map[string]any)
+		input, _ := modalities["input"].([]string)
+		output, _ := modalities["output"].([]string)
+
+		if len(input) != 2 || input[0] != "text" || input[1] != "image" {
+			t.Fatalf("modalities.input = %v, want [text image]", input)
+		}
+		if len(output) != 1 || output[0] != "text" {
+			t.Fatalf("modalities.output = %v, want [text]", output)
+		}
+	})
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestBuildModelEntries(t *testing.T) {
+	t.Run("defaults to model name when capabilities cannot be probed", func(t *testing.T) {
+		models := buildModelEntries(context.Background(), nil, []string{"llama3.2"})
+		entry, _ := models["llama3.2"].(map[string]any)
+		if entry["name"] != "llama3.2" {
+			t.Fatalf("name = %v, want llama3.2", entry["name"])
+		}
+		if _, ok := entry["modalities"]; ok {
+			t.Fatalf("modalities should not be set without an API client, got %v", entry["modalities"])
 		}
 	})
 }

--- a/cmd/launch/opencode_test.go
+++ b/cmd/launch/opencode_test.go
@@ -211,12 +211,6 @@ func TestOpenCodeEdit(t *testing.T) {
 	})
 }
 
-type roundTripFunc func(*http.Request) (*http.Response, error)
-
-func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
-	return f(req)
-}
-
 func TestBuildModelEntries(t *testing.T) {
 	t.Run("defaults to model name when capabilities cannot be probed", func(t *testing.T) {
 		models := buildModelEntries(context.Background(), nil, []string{"llama3.2"})

--- a/cmd/launch/opencode_test.go
+++ b/cmd/launch/opencode_test.go
@@ -11,7 +11,9 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/ollama/ollama/api"
 )
@@ -220,6 +222,47 @@ func TestBuildModelEntries(t *testing.T) {
 		}
 		if _, ok := entry["modalities"]; ok {
 			t.Fatalf("modalities should not be set without an API client, got %v", entry["modalities"])
+		}
+	})
+
+	t.Run("uses one timeout budget across capability probes", func(t *testing.T) {
+		u, err := url.Parse("http://ollama.example")
+		if err != nil {
+			t.Fatalf("parse test URL: %v", err)
+		}
+
+		var mu sync.Mutex
+		waited := 0
+
+		client := api.NewClient(u, &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			mu.Lock()
+			if req.Context().Err() == nil {
+				waited++
+			}
+			mu.Unlock()
+
+			<-req.Context().Done()
+			return nil, req.Context().Err()
+		})})
+
+		ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+		defer cancel()
+
+		models := buildModelEntries(ctx, client, []string{"slow-1", "slow-2"})
+		for _, modelID := range []string{"slow-1", "slow-2"} {
+			entry, _ := models[modelID].(map[string]any)
+			if entry["name"] != modelID {
+				t.Fatalf("name for %q = %v, want %q", modelID, entry["name"], modelID)
+			}
+			if _, ok := entry["modalities"]; ok {
+				t.Fatalf("modalities for %q should not be set after probe timeout, got %v", modelID, entry["modalities"])
+			}
+		}
+
+		mu.Lock()
+		defer mu.Unlock()
+		if waited != 1 {
+			t.Fatalf("expected shared timeout to block one probe, waited on %d probes", waited)
 		}
 	})
 }


### PR DESCRIPTION
## Summary
Teach the OpenCode launch integration to advertise image input for vision-capable Ollama models.
Previously, the inline OpenCode config only emitted basic model entries like:
```json
"gemma4:26b": {}

```
This meant OpenCode had no capability metadata to indicate that a model could accept images, even when Ollama reported vision support.

This change updates the OpenCode config builder to:
- probe model capabilities via Show()
- add modalities.input = ["text", "image"] and modalities.output = ["text"] for vision-capable models
- preserve the existing fallback behavior when capability probing is unavailable
- keep the current behavior of not writing ~/.config/opencode/opencode.json

## Example
A vision-capable model entry now looks like:
```json
"gemma4:26b": {
  "name": "gemma4:26b",
  "modalities": {
    "input": ["text", "image"],
    "output": ["text"]
  }
}
```

## Testing

- added regression coverage for vision-capable OpenCode model entries
- added fallback coverage when capability probing is unavailable
- ran: `env GOCACHE=/tmp/gocache go test ./cmd/launch -run 'TestOpenCode|TestBuildModelEntries' -count=1`

## Notes
This change intentionally only adds image support for models that report vision. It does not advertise pdf support.