### PR TITLE
fix(server/create): validate quantize up-front before importing blobs

### DIFF
--- a/server/create.go
+++ b/server/create.go
@@ -89,6 +89,15 @@ func (s *Server) CreateHandler(c *gin.Context) {
 		return
 	}
 
+	// Validate the quantization argument up-front so a typo (e.g. "Q5_K_M") fails
+	// before importing/merging any blobs (#15925).
+	if quantType := strings.ToUpper(cmp.Or(r.Quantize, r.Quantization)); quantType != "" {
+		if _, err := ggml.ParseFileType(quantType); err != nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+	}
+
 	name, err := getExistingName(name)
 	if err != nil {
 		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})


### PR DESCRIPTION
Closes #15925.

`CreateHandler` accepted any string as the quantization argument and deferred validation until `quantizeLayer` -> `ggml.ParseFileType` ran at the *end* of the create flow, after all source files had already been imported into `blobs/` and merged into a single GGUF. A user who typed `Q5_K_M` instead of `Q4_K_M` therefore lost ~116GB of disk writes and several minutes of CPU before seeing `unsupported quantization type Q5_K_M`, with the orphan blobs left behind.

### Patch

Run the same `ggml.ParseFileType` check next to the existing `r.Model` / `r.Files` validations in `CreateHandler` so a typo returns HTTP 400 before any I/O. The downstream `quantizeLayer` call still runs the same parse, so the success path is unchanged.

### Verification

```
go vet ./server/
go test ./server/ -run TestCreate
```
both clean.

Reproduction (after the fix):
```
$ curl -X POST http://localhost:11434/api/create -d '{"model":"my-q5", "from":"safetensors-path", "quantize":"Q5_K_M"}'
{"error":"unsupported quantization type Q5_K_M - supported types are F32, F16, Q4_K_S, Q4_K_M, Q8_0"}
```
No blobs imported, no GGUF merge attempted.