### PR TITLE
launch: Refactor model list sort.

### DIFF
--- a/cmd/internal/cmputil/cmp.go
+++ b/cmd/internal/cmputil/cmp.go
@@ -1,0 +1,15 @@
+package cmputil
+
+// A Compare function for booleans as they aren't strictly comparable.
+// Sorts True before False.
+// Returns 0 if equal, -1 if a is true, and 1 if b is true.
+func CompareBool(a, b bool) int {
+	switch {
+	case a == b:
+		return 0
+	case a:
+		return -1
+	default:
+		return 1
+	}
+}

--- a/cmd/internal/cmputil/cmp_test.go
+++ b/cmd/internal/cmputil/cmp_test.go
@@ -1,0 +1,24 @@
+package cmputil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompareBool(t *testing.T) {
+	testCases := []struct {
+		a        bool
+		b        bool
+		expected int
+	}{
+		{true, true, 0},
+		{false, false, 0},
+		{true, false, -1},
+		{false, true, 1},
+	}
+
+	for _, tc := range testCases {
+		require.Equal(t, tc.expected, CompareBool(tc.a, tc.b))
+	}
+}

--- a/cmd/launch/models.go
+++ b/cmd/launch/models.go
@@ -1,6 +1,7 @@
 package launch
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/cmd/config"
+	"github.com/ollama/ollama/cmd/internal/cmputil"
 	"github.com/ollama/ollama/cmd/internal/fileutil"
 	"github.com/ollama/ollama/format"
 	internalcloud "github.com/ollama/ollama/internal/cloud"
@@ -348,7 +350,6 @@ func buildModelListWithRecommendations(existing []modelInfo, recommendations []M
 	existingModels = make(map[string]bool)
 	cloudModels = make(map[string]bool)
 	recommended := make(map[string]bool)
-	var hasLocalModel, hasCloudModel bool
 
 	recDesc := make(map[string]string)
 	for _, rec := range recommendations {
@@ -360,9 +361,6 @@ func buildModelListWithRecommendations(existing []modelInfo, recommendations []M
 		existingModels[m.Name] = true
 		if m.Remote {
 			cloudModels[m.Name] = true
-			hasCloudModel = true
-		} else {
-			hasLocalModel = true
 		}
 		displayName := strings.TrimSuffix(m.Name, ":latest")
 		existingModels[displayName] = true
@@ -424,55 +422,56 @@ func buildModelListWithRecommendations(existing []modelInfo, recommendations []M
 		}
 	}
 
-	recRank := make(map[string]int)
-	for i, rec := range recommendations {
-		recRank[rec.Name] = i + 1
-	}
-
-	if hasLocalModel || hasCloudModel {
-		// Keep the Recommended section pinned to recommendation order. Checked
-		// and default-model priority only apply within the More section.
-		slices.SortStableFunc(items, func(a, b ModelItem) int {
-			ac, bc := checked[a.Name], checked[b.Name]
-			aNew, bNew := notInstalled[a.Name], notInstalled[b.Name]
-			aRec, bRec := recRank[a.Name] > 0, recRank[b.Name] > 0
-			if aRec != bRec {
-				if aRec {
-					return -1
-				}
-				return 1
-			}
-			if aRec && bRec {
-				return recRank[a.Name] - recRank[b.Name]
-			}
-			if ac != bc {
-				if ac {
-					return -1
-				}
-				return 1
-			}
-			// Among checked non-recommended items - put the default first
-			if ac && !aRec && current != "" {
-				aCurrent := a.Name == current
-				bCurrent := b.Name == current
-				if aCurrent != bCurrent {
-					if aCurrent {
-						return -1
-					}
-					return 1
-				}
-			}
-			if aNew != bNew {
-				if aNew {
-					return 1
-				}
-				return -1
-			}
-			return strings.Compare(strings.ToLower(a.Name), strings.ToLower(b.Name))
-		})
-	}
+	sortModelList(items, recommendations, current, checked, notInstalled)
 
 	return items, preChecked, existingModels, cloudModels
+}
+
+// Sort the model list, according to the following criteria:
+//
+// - Recommended models are pinned to the top of the list, and ordered by rank
+// - Checked models appear before unchecked models
+// - Checked, un-recommended models appear first if they are the current model
+// - Installed models appear before uninstalled models
+// - Without other heuristics, models are sorted alphabetically by name
+//
+// We assume that the models are unique by name, and they have non-blank names.
+func sortModelList(models []ModelItem, recommendations []ModelItem, current string, checked map[string]bool, notInstalled map[string]bool) {
+	if len(models) == 0 {
+		return
+	}
+
+	recommendedModelRanks := make(map[string]int)
+	for i, rec := range recommendations {
+		recommendedModelRanks[rec.Name] = len(recommendations) - i
+	}
+
+	slices.SortStableFunc(models, func(a, b ModelItem) int {
+		if recommendedModelRanks[a.Name] > 0 || recommendedModelRanks[b.Name] > 0 {
+			return -1 * cmp.Compare(recommendedModelRanks[a.Name], recommendedModelRanks[b.Name])
+		}
+
+		if checked[a.Name] != checked[b.Name] {
+			return cmputil.CompareBool(checked[a.Name], checked[b.Name])
+		}
+
+		if checked[a.Name] && checked[b.Name] {
+			switch {
+			case a.Name == current:
+				return -1
+			case b.Name == current:
+				return 1
+			}
+		}
+
+		if notInstalled[a.Name] != notInstalled[b.Name] {
+			return -1 * cmputil.CompareBool(notInstalled[a.Name], notInstalled[b.Name])
+		}
+
+		return strings.Compare(strings.ToLower(a.Name), strings.ToLower(b.Name))
+	})
+
+	return
 }
 
 // isCloudModelName reports whether the model name has an explicit cloud source.

--- a/cmd/launch/models_test.go
+++ b/cmd/launch/models_test.go
@@ -1,0 +1,49 @@
+package launch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSortModelList(t *testing.T) {
+	models := []ModelItem{
+		{Name: "Recommended1"},
+		{Name: "Recommended2"},
+		{Name: "Model1"},
+		{Name: "Model2"},
+		{Name: "Model3"},
+		{Name: "Model4"},
+		{Name: "Model5"},
+	}
+	recommendations := []ModelItem{
+		{Name: "Recommended2"},
+		{Name: "Recommended1"},
+	}
+	current := "Model2"
+	checked := map[string]bool{"Model2": true, "Model3": true}
+	notInstalled := map[string]bool{"Model4": true}
+
+	sortModelList(models, recommendations, current, checked, notInstalled)
+
+	expectedOrder := []string{
+		"Recommended2", // Recommended, highest rank
+		"Recommended1", // Recommended
+		"Model2",       // Checked, current
+		"Model3",       // Checked
+		"Model1",       // Installed, alphabetical
+		"Model5",       // Installed, alphabetical
+		"Model4",       // Not installed
+	}
+
+	assert.Equal(t, expectedOrder, mapModelNames(models))
+}
+
+func mapModelNames(models []ModelItem) []string {
+	names := []string{}
+	for _, m := range models {
+		names = append(names, m.Name)
+	}
+
+	return names
+}


### PR DESCRIPTION
The sorting of the recommended models was written in a rather confusing way - this refactors the sort to make better use of comparability and remove redundant checks to increase readability.