### PR TITLE
refactor: use slices.Backward to simplify the code

### DIFF
--- a/cmd/tui/selector.go
+++ b/cmd/tui/selector.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -457,8 +458,8 @@ func newMultiSelectorModel(title string, items []SelectItem, preChecked []string
 
 	// Reverse order so preChecked[0] (the current default) ends up last
 	// in checkOrder, matching the "last checked = default" convention.
-	for i := len(preChecked) - 1; i >= 0; i-- {
-		if idx, ok := m.itemIndex[preChecked[i]]; ok {
+	for _, p := range slices.Backward(preChecked) {
+		if idx, ok := m.itemIndex[p]; ok {
 			m.checked[idx] = true
 			m.checkOrder = append(m.checkOrder, idx)
 		}

--- a/llm/server.go
+++ b/llm/server.go
@@ -1175,15 +1175,15 @@ func greedyFit(layers []uint64, gpus []ml.DeviceInfo, capacity float32, requeste
 	device := len(gpus) - 1
 	gpuLayers = ml.GPULayersList{{DeviceID: gpus[device].DeviceID}}
 	freeSpace := uint64(float32(gpus[device].FreeMemory) * capacity)
-	for i := len(layers) - 1; i >= 0; i-- {
+	for i, layer := range slices.Backward(layers) {
 		if requestedLayers >= 0 && len(layers)-1-i >= requestedLayers {
 			break
 		}
 
 		for {
-			if layers[i] <= freeSpace {
+			if layer <= freeSpace {
 				gpuLayers[0].Layers = append([]int{i}, gpuLayers[0].Layers...)
-				freeSpace -= layers[i]
+				freeSpace -= layer
 				break
 			}
 

--- a/model/renderers/deepseek3.go
+++ b/model/renderers/deepseek3.go
@@ -2,6 +2,7 @@ package renderers
 
 import (
 	"encoding/json"
+	"slices"
 	"strings"
 
 	"github.com/ollama/ollama/api"
@@ -72,8 +73,8 @@ func (r *DeepSeek3Renderer) Render(messages []api.Message, tools []api.Tool, thi
 
 	// Find the index of the last user message to determine which assistant message is "current"
 	lastUserIndex := -1
-	for i := len(messages) - 1; i >= 0; i-- {
-		if messages[i].Role == "user" {
+	for i, message := range slices.Backward(messages) {
+		if message.Role == "user" {
 			lastUserIndex = i
 			break
 		}

--- a/model/renderers/qwen35.go
+++ b/model/renderers/qwen35.go
@@ -2,6 +2,7 @@ package renderers
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/ollama/ollama/api"
@@ -114,8 +115,8 @@ func (r *Qwen35Renderer) Render(messages []api.Message, tools []api.Tool, think 
 	multiStepTool := true
 	lastQueryIndex := len(messages) - 1 // so this is the last user message
 
-	for i := len(messages) - 1; i >= 0; i-- {
-		message := messages[i]
+	for i, message := range slices.Backward(messages) {
+		message := message
 		if multiStepTool && message.Role == "user" {
 			content, _ := r.renderContent(message, 0)
 			content = strings.TrimSpace(content)

--- a/model/renderers/qwen3vl.go
+++ b/model/renderers/qwen3vl.go
@@ -2,6 +2,7 @@ package renderers
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/ollama/ollama/api"
@@ -61,8 +62,8 @@ func (r *Qwen3VLRenderer) Render(messages []api.Message, tools []api.Tool, think
 	multiStepTool := true
 	lastQueryIndex := len(messages) - 1 // so this is the last user message
 
-	for i := len(messages) - 1; i >= 0; i-- {
-		message := messages[i]
+	for i, message := range slices.Backward(messages) {
+		message := message
 		if multiStepTool && message.Role == "user" {
 			// Check if content starts with <tool_response> and ends with </tool_response>
 			content, _ := r.renderContent(message, 0)

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -660,8 +660,8 @@ func FromChatRequest(r ChatCompletionRequest) (*api.ChatRequest, error) {
 func nameFromToolCallID(messages []Message, toolCallID string) string {
 	// iterate backwards to be more resilient to duplicate tool call IDs (this
 	// follows "last one wins")
-	for i := len(messages) - 1; i >= 0; i-- {
-		msg := messages[i]
+	for _, message := range slices.Backward(messages) {
+		msg := message
 		for _, tc := range msg.ToolCalls {
 			if tc.ID == toolCallID {
 				return tc.Function.Name

--- a/thinking/template.go
+++ b/thinking/template.go
@@ -1,6 +1,7 @@
 package thinking
 
 import (
+	"slices"
 	"strings"
 	"text/template"
 	"text/template/parse"
@@ -72,8 +73,8 @@ func InferTags(t *template.Template) (string, string) {
 		case *parse.FieldNode:
 			if len(x.Ident) > 0 && x.Ident[0] == "Thinking" {
 				var mostRecentRange *parse.RangeNode
-				for i := len(ancestors) - 1; i >= 0; i-- {
-					if r, ok := ancestors[i].(*parse.RangeNode); ok {
+				for _, ancestor := range slices.Backward(ancestors) {
+					if r, ok := ancestor.(*parse.RangeNode); ok {
 						mostRecentRange = r
 						break
 					}
@@ -88,8 +89,8 @@ func InferTags(t *template.Template) (string, string) {
 				// necessary for our heuristic
 
 				// go up to the nearest ancestor that is a *parse.ListNode
-				for i := len(ancestors) - 1; i >= 0; i-- {
-					if l, ok := ancestors[i].(*parse.ListNode); ok {
+				for _, ancestor := range slices.Backward(ancestors) {
+					if l, ok := ancestor.(*parse.ListNode); ok {
 						firstNode := l.Nodes[0]
 						if t, ok := firstNode.(*parse.TextNode); ok {
 							openingTag = strings.TrimSpace(t.String())

--- a/x/mlxrunner/cache.go
+++ b/x/mlxrunner/cache.go
@@ -232,8 +232,8 @@ pageIn:
 			}
 		}
 	}
-	for i := len(c.activePath) - 1; i >= 0; i-- {
-		if c.activePath[i].endOffset <= minOff {
+	for i, c0 := range slices.Backward(c.activePath) {
+		if c0.endOffset <= minOff {
 			c.activePath = c.activePath[:i+1]
 			break
 		}

--- a/x/models/gemma4/gemma4.go
+++ b/x/models/gemma4/gemma4.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"slices"
 
 	"github.com/ollama/ollama/x/mlxrunner/batch"
 	"github.com/ollama/ollama/x/mlxrunner/cache"
@@ -446,8 +447,8 @@ func parseTextConfig(configData []byte) (TextConfig, error) {
 			layerType := cfg.LayerTypes[i]
 			// Find the last non-shared layer of the same type.
 			donor := int32(-1)
-			for j := len(prevLayers) - 1; j >= 0; j-- {
-				if prevLayers[j] == layerType {
+			for j, prevLayer := range slices.Backward(prevLayers) {
+				if prevLayer == layerType {
 					donor = int32(j)
 					break
 				}


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.23.0#Backward)  added in the go1.23 standard library, which can make the code more concise and easy to read.

More info can see  https://github.com/golang/go/issues/61899