### PR TITLE
fix(install.sh): always ensure ollama home directory ownership

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -199,6 +199,12 @@ configure_systemd() {
         status "Creating ollama user..."
         $SUDO useradd -r -s /bin/false -U -m -d /usr/share/ollama ollama
     fi
+    # Ensure the ollama user's home directory exists and is owned by ollama:ollama,
+    # even if the user already existed (re-running the script) or the directory
+    # was pre-created by the system before useradd ran. Without this, on systems
+    # where /usr/share/ollama exists with root ownership the service fails at
+    # startup with "could not create directory mkdir /usr/share/ollama: permission denied".
+    $SUDO install -d -o ollama -g ollama -m 0755 /usr/share/ollama
     if getent group render >/dev/null 2>&1; then
         status "Adding ollama user to render group..."
         $SUDO usermod -a -G render ollama


### PR DESCRIPTION
Closes #15940

## What

When the install script runs `useradd -r -s /bin/false -U -m -d /usr/share/ollama ollama`, the `-m` flag only creates `/usr/share/ollama` (and gives it the right ownership) **if it does not already exist**. On Ubuntu 24.04 / Debian trixie systems where `/usr/share/ollama` may be pre-created with root ownership (or when the script is re-run with the user already existing — the entire `useradd` call is skipped by the surrounding `if ! id ollama` guard), the directory is left owned by `root:root` with `0755`. The systemd service then fails at startup:

```
Error: could not create directory mkdir /usr/share/ollama: permission denied
```

## Fix

After the user-creation block, run

```sh
$SUDO install -d -o ollama -g ollama -m 0755 /usr/share/ollama
```

unconditionally. `install -d` is idempotent — it creates the directory if missing and applies the requested ownership/mode either way — so this is safe on every code path (fresh install, re-run with existing user, dir pre-created by something else).

## Why this approach over the alternatives

- **`mkdir -p` + `chown -R`** would also work but `chown -R` could touch large existing model trees the user has placed under `/usr/share/ollama`, which is undesirable. `install -d` only acts on the directory itself.
- **Adding `Environment="HOME=/usr/share/ollama"` to the service unit** is unnecessary: systemd already derives `HOME` from `/etc/passwd` for `User=ollama`, so the env var is correct — the only failure is the ownership of the directory itself.
- **Verification via `systemctl is-active`** belongs in a separate change; this PR keeps the scope to the root cause reported in the issue.

## Test plan

- Fresh Ubuntu 24.04 box, `/usr/share/ollama` does not exist → behavior unchanged from before (useradd creates it; `install -d` is a no-op for ownership).
- Box where `/usr/share/ollama` already exists owned by `root:root` (the bug repro) → after this patch, ownership flips to `ollama:ollama` and the service starts cleanly.
- Re-running the installer (`id ollama` succeeds, useradd is skipped) → `install -d` still re-asserts ownership, so a manual `chown` performed earlier as a workaround keeps working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)