### PR TITLE
docs(cmd/serve): list OLLAMA_DEBUG_LOG_REQUESTS in serve --help

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -2364,6 +2364,7 @@ func NewCLI() *cobra.Command {
 		case serveCmd:
 			appendEnvDocs(cmd, []envconfig.EnvVar{
 				envVars["OLLAMA_DEBUG"],
+				envVars["OLLAMA_DEBUG_LOG_REQUESTS"],
 				envVars["OLLAMA_HOST"],
 				envVars["OLLAMA_CONTEXT_LENGTH"],
 				envVars["OLLAMA_KEEP_ALIVE"],


### PR DESCRIPTION
## Summary

`OLLAMA_DEBUG_LOG_REQUESTS=1` is a supported env var (added in #14106) that turns on request-body logging and curl-replay-command emission for inference requests. It's registered in `envconfig/config.go` and consumed by `server/inference_request_log.go`, but it was not in the env-var list rendered by `ollama serve --help`, so users had no CLI-discoverable hint that it exists.

This PR adds it to the `serveCmd` env-doc block in `cmd/cmd.go`, placed right after `OLLAMA_DEBUG` since the two are conceptually paired (both control debug instrumentation).

After this change, `ollama serve --help` will include the line:

```
OLLAMA_DEBUG_LOG_REQUESTS  Log inference request bodies and replay curl commands to a temp directory
```

(description text comes from the existing registration in `envconfig/config.go:308`).

## Why

Without this entry, the only way to learn about `OLLAMA_DEBUG_LOG_REQUESTS` is reading source or finding the original PR — which is exactly what the reporter in #15945 had to do. Listing every supported env var in `--help` is the existing convention; this just closes the gap.

## Test plan

- [x] `git diff` shows a single +1/-0 change to `cmd/cmd.go`
- [ ] `go build ./...` passes (CI)
- [ ] `ollama serve --help` includes `OLLAMA_DEBUG_LOG_REQUESTS` between `OLLAMA_DEBUG` and `OLLAMA_HOST`

Fixes #15945

🤖 Generated with [Claude Code](https://claude.com/claude-code)