### PR TITLE
cmd: validate safetensors architecture before uploading blob

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -41,6 +41,7 @@ import (
 	"github.com/ollama/ollama/cmd/config"
 	"github.com/ollama/ollama/cmd/launch"
 	"github.com/ollama/ollama/cmd/tui"
+	"github.com/ollama/ollama/convert"
 	"github.com/ollama/ollama/envconfig"
 	"github.com/ollama/ollama/format"
 	"github.com/ollama/ollama/internal/modelref"
@@ -249,6 +250,10 @@ func CreateHandler(cmd *cobra.Command, args []string) error {
 		req.Quantize = quantize
 	}
 
+	if err := validateSafetensorsArchitecture(req.Files); err != nil {
+		return err
+	}
+
 	client, err := api.ClientFromEnvironment()
 	if err != nil {
 		return err
@@ -323,6 +328,23 @@ func CreateHandler(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("the ollama server must be updated to use `ollama create` with this client")
 		}
 		return err
+	}
+
+	return nil
+}
+
+func validateSafetensorsArchitecture(files map[string]string) error {
+	for path := range files {
+		if filepath.Base(path) != "config.json" {
+			continue
+		}
+
+		bts, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		return convert.ValidateArchitecture(bts)
 	}
 
 	return nil

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -1402,6 +1403,7 @@ func TestCreateHandler(t *testing.T) {
 		name           string
 		modelName      string
 		modelFile      string
+		setupFiles     func(t *testing.T, dir string)
 		serverResponse map[string]func(w http.ResponseWriter, r *http.Request)
 		expectedError  string
 		expectedOutput string
@@ -1447,6 +1449,21 @@ func TestCreateHandler(t *testing.T) {
 			},
 			expectedOutput: "",
 		},
+		{
+			name:      "unsupported safetensors architecture fails before upload",
+			modelName: "test-model",
+			modelFile: "FROM {{DIR}}",
+			setupFiles: func(t *testing.T, dir string) {
+				if err := os.WriteFile(filepath.Join(dir, "model.safetensors"), nil, 0o644); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte(`{"architectures":["MistralForCausalLM"]}`), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			serverResponse: map[string]func(w http.ResponseWriter, r *http.Request){},
+			expectedError:  `unsupported architecture "MistralForCausalLM"`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1473,6 +1490,21 @@ func TestCreateHandler(t *testing.T) {
 			}
 			if err := tempFile.Close(); err != nil {
 				t.Fatal(err)
+			}
+
+			if tt.setupFiles != nil {
+				tt.setupFiles(t, filepath.Dir(tempFile.Name()))
+			}
+			modelFile := tt.modelFile
+			if strings.Contains(modelFile, "{{DIR}}") {
+				realDir, err := filepath.EvalSymlinks(filepath.Dir(tempFile.Name()))
+				if err != nil {
+					t.Fatal(err)
+				}
+				modelFile = strings.ReplaceAll(modelFile, "{{DIR}}", realDir)
+				if err := os.WriteFile(tempFile.Name(), []byte(modelFile), 0o644); err != nil {
+					t.Fatal(err)
+				}
 			}
 
 			cmd := &cobra.Command{}
@@ -1519,6 +1551,8 @@ func TestCreateHandler(t *testing.T) {
 						t.Errorf("expected output %q, got %q", tt.expectedOutput, got)
 					}
 				}
+			} else if err == nil || !strings.Contains(err.Error(), tt.expectedError) {
+				t.Fatalf("expected error containing %q, got %v", tt.expectedError, err)
 			}
 		})
 	}

--- a/convert/convert.go
+++ b/convert/convert.go
@@ -252,6 +252,91 @@ func ConvertAdapter(fsys fs.FS, f *os.File, baseKV ofs.Config) error {
 	return writeFile(f, conv.KV(baseKV), conv.Tensors(ts))
 }
 
+func newConverter(arch string) ModelConverter {
+	switch arch {
+	case "LlamaForCausalLM":
+		return &llamaModel{}
+	case "MllamaForConditionalGeneration":
+		return &mllamaModel{}
+	case "Llama4ForConditionalGeneration":
+		return &llama4Model{}
+	case "Mistral3ForConditionalGeneration":
+		return &mistral3Model{}
+	case "Ministral3ForCausalLM":
+		return &mistral3CausalModel{}
+	case "MixtralForCausalLM":
+		return &mixtralModel{}
+	case "GemmaForCausalLM":
+		return &gemmaModel{}
+	case "Gemma2ForCausalLM":
+		return &gemma2Model{}
+	case "Gemma3ForCausalLM", "Gemma3ForConditionalGeneration":
+		return &gemma3Model{Architecture: arch}
+	case "Gemma3nForConditionalGeneration":
+		return &gemma3nModel{}
+	case "Gemma4ForCausalLM", "Gemma4ForConditionalGeneration":
+		return &gemma4Model{Architecture: arch}
+	case "Phi3ForCausalLM":
+		return &phi3Model{}
+	case "Qwen2ForCausalLM":
+		return &qwen2Model{}
+	case "Qwen2_5_VLForConditionalGeneration":
+		return &qwen25VLModel{}
+	case "Qwen3VLForConditionalGeneration", "Qwen3VLMoeForConditionalGeneration":
+		return &qwen3VLModel{}
+	case "Olmo3ForCausalLM":
+		return &olmoModel{}
+	case "BertModel":
+		return &bertModel{}
+	case "NomicBertModel", "NomicBertMoEModel":
+		return &nomicbertModel{}
+	case "CohereForCausalLM":
+		return &commandrModel{}
+	case "GptOssForCausalLM":
+		return &gptossModel{}
+	case "DeepseekOCRForCausalLM":
+		return &deepseekocr{}
+	case "DeepseekV3ForCausalLM":
+		return &deepseek2Model{}
+	case "Glm4MoeLiteForCausalLM":
+		return &glm4MoeLiteModel{}
+	case "LagunaForCausalLM":
+		return &lagunaModel{}
+	case "GlmOcrForConditionalGeneration":
+		return &glmOcrModel{}
+	case "Lfm2ForCausalLM", "Lfm2MoeForCausalLM":
+		return &lfm2Model{}
+	case "Lfm2VlForConditionalGeneration":
+		return &lfm2VLTextModel{}
+	case "Qwen3NextForCausalLM", "Qwen3_5ForConditionalGeneration", "Qwen3_5MoeForConditionalGeneration":
+		return &qwen3NextModel{}
+	case "NemotronH_Nano_VL_V2", "NemotronH_Nano_Omni_Reasoning_V3":
+		return &nemotronHNanoVLModel{}
+	case "NemotronHForCausalLM":
+		return &nemotronHModel{}
+	default:
+		return nil
+	}
+}
+
+func ValidateArchitecture(bts []byte) error {
+	bts = sanitizeNonFiniteJSON(bts)
+
+	var p ModelParameters
+	if err := json.Unmarshal(bts, &p); err != nil {
+		return fmt.Errorf("parse config.json: %w", err)
+	}
+
+	if len(p.Architectures) < 1 {
+		return errors.New("unknown architecture")
+	}
+
+	if newConverter(p.Architectures[0]) == nil {
+		return fmt.Errorf("unsupported architecture %q", p.Architectures[0])
+	}
+	return nil
+}
+
 func LoadModelMetadata(fsys fs.FS) (ModelKV, *Tokenizer, error) {
 	bts, err := fs.ReadFile(fsys, "config.json")
 	if err != nil {
@@ -268,69 +353,8 @@ func LoadModelMetadata(fsys fs.FS) (ModelKV, *Tokenizer, error) {
 		return nil, nil, errors.New("unknown architecture")
 	}
 
-	var conv ModelConverter
-	switch p.Architectures[0] {
-	case "LlamaForCausalLM":
-		conv = &llamaModel{}
-	case "MllamaForConditionalGeneration":
-		conv = &mllamaModel{}
-	case "Llama4ForConditionalGeneration":
-		conv = &llama4Model{}
-	case "Mistral3ForConditionalGeneration":
-		conv = &mistral3Model{}
-	case "Ministral3ForCausalLM":
-		conv = &mistral3CausalModel{}
-	case "MixtralForCausalLM":
-		conv = &mixtralModel{}
-	case "GemmaForCausalLM":
-		conv = &gemmaModel{}
-	case "Gemma2ForCausalLM":
-		conv = &gemma2Model{}
-	case "Gemma3ForCausalLM", "Gemma3ForConditionalGeneration":
-		conv = &gemma3Model{Architecture: p.Architectures[0]}
-	case "Gemma3nForConditionalGeneration":
-		conv = &gemma3nModel{}
-	case "Gemma4ForCausalLM", "Gemma4ForConditionalGeneration":
-		conv = &gemma4Model{Architecture: p.Architectures[0]}
-	case "Phi3ForCausalLM":
-		conv = &phi3Model{}
-	case "Qwen2ForCausalLM":
-		conv = &qwen2Model{}
-	case "Qwen2_5_VLForConditionalGeneration":
-		conv = &qwen25VLModel{}
-	case "Qwen3VLForConditionalGeneration", "Qwen3VLMoeForConditionalGeneration":
-		conv = &qwen3VLModel{}
-	case "Olmo3ForCausalLM":
-		conv = &olmoModel{}
-	case "BertModel":
-		conv = &bertModel{}
-	case "NomicBertModel", "NomicBertMoEModel":
-		conv = &nomicbertModel{}
-	case "CohereForCausalLM":
-		conv = &commandrModel{}
-	case "GptOssForCausalLM":
-		conv = &gptossModel{}
-	case "DeepseekOCRForCausalLM":
-		conv = &deepseekocr{}
-	case "DeepseekV3ForCausalLM":
-		conv = &deepseek2Model{}
-	case "Glm4MoeLiteForCausalLM":
-		conv = &glm4MoeLiteModel{}
-	case "LagunaForCausalLM":
-		conv = &lagunaModel{}
-	case "GlmOcrForConditionalGeneration":
-		conv = &glmOcrModel{}
-	case "Lfm2ForCausalLM", "Lfm2MoeForCausalLM":
-		conv = &lfm2Model{}
-	case "Lfm2VlForConditionalGeneration":
-		conv = &lfm2VLTextModel{}
-	case "Qwen3NextForCausalLM", "Qwen3_5ForConditionalGeneration", "Qwen3_5MoeForConditionalGeneration":
-		conv = &qwen3NextModel{}
-	case "NemotronH_Nano_VL_V2", "NemotronH_Nano_Omni_Reasoning_V3":
-		conv = &nemotronHNanoVLModel{}
-	case "NemotronHForCausalLM":
-		conv = &nemotronHModel{}
-	default:
+	conv := newConverter(p.Architectures[0])
+	if conv == nil {
 		return nil, nil, fmt.Errorf("unsupported architecture %q", p.Architectures[0])
 	}
 

--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -469,3 +469,62 @@ func generateLoraTestData(t *testing.T, tempDir string) {
 		t.Fatal(err)
 	}
 }
+
+func TestValidateArchitecture(t *testing.T) {
+	cases := []struct {
+		name    string
+		config  string
+		wantErr string
+	}{
+		{
+			name:   "supported architecture",
+			config: `{"architectures": ["LlamaForCausalLM"]}`,
+		},
+		{
+			name:   "supported architecture (multimodal)",
+			config: `{"architectures": ["Qwen3VLForConditionalGeneration"]}`,
+		},
+		{
+			name:    "unsupported architecture",
+			config:  `{"architectures": ["BertForMaskedLM"]}`,
+			wantErr: `unsupported architecture "BertForMaskedLM"`,
+		},
+		{
+			name:    "empty architectures",
+			config:  `{"architectures": []}`,
+			wantErr: "unknown architecture",
+		},
+		{
+			name:    "missing architectures field",
+			config:  `{}`,
+			wantErr: "unknown architecture",
+		},
+		{
+			name:    "invalid json",
+			config:  `{not valid json`,
+			wantErr: "parse config.json",
+		},
+		{
+			name:   "config with non-finite values",
+			config: `{"architectures": ["LlamaForCausalLM"], "value": NaN}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateArchitecture([]byte(tc.config))
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Fatal("expected error but got none")
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("expected error containing %q, got %v", tc.wantErr, err)
+				}
+			}
+		})
+	}
+}

--- a/server/create.go
+++ b/server/create.go
@@ -410,26 +410,6 @@ func convertFromSafetensors(files map[string]string, baseLayers []*layerGGML, is
 	}
 	defer root.Close()
 
-	if !isAdapter {
-		digest, ok := files["config.json"]
-		if !ok {
-			return nil, errors.New("not found config.json")
-		}
-
-		blobPath, err := manifest.BlobsPath(digest)
-		if err != nil {
-			return nil, err
-		}
-
-		bts, err := os.ReadFile(blobPath)
-		if err != nil {
-			return nil, err
-		}
-		if err := convert.ValidateArchitecture(bts); err != nil {
-			return nil, err
-		}
-	}
-
 	for fp, digest := range files {
 		if !fs.ValidPath(fp) {
 			return nil, fmt.Errorf("%w: %s", errFilePath, fp)

--- a/server/create.go
+++ b/server/create.go
@@ -410,6 +410,26 @@ func convertFromSafetensors(files map[string]string, baseLayers []*layerGGML, is
 	}
 	defer root.Close()
 
+	if !isAdapter {
+		digest, ok := files["config.json"]
+		if !ok {
+			return nil, errors.New("not found config.json")
+		}
+
+		blobPath, err := manifest.BlobsPath(digest)
+		if err != nil {
+			return nil, err
+		}
+
+		bts, err := os.ReadFile(blobPath)
+		if err != nil {
+			return nil, err
+		}
+		if err := convert.ValidateArchitecture(bts); err != nil {
+			return nil, err
+		}
+	}
+
 	for fp, digest := range files {
 		if !fs.ValidPath(fp) {
 			return nil, fmt.Errorf("%w: %s", errFilePath, fp)


### PR DESCRIPTION
## Summary

Fix a issue where `ollama create` uploaded safetensors blobs before rejecting unsupported architectures.

This PR reuses converter-side architecture validation and moves the check earlier into the client create path, so unsupported models fail fast before any blob upload.

## Problem

Issue: #15949

Previously, unsupported safetensors models could fail only after their blobs had already been uploaded into `blobs`, wasting time and disk space.

## Changes

This PR:
- adds reusable architecture validation in `convert`
- validates `config.json` before upload in `ollama create`
- adds regression coverage for unsupported architectures

## Testing

- `go test ./cmd -run 'TestCreateHandler'`
- `go test ./convert/...`
- `go test ./server -run 'TestCreate'`
