### PR TITLE
Warn when image files are not found

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -620,6 +620,7 @@ func extractFileData(input string) (string, []api.ImageData, error) {
 		nfp := normalizeFilePath(fp)
 		data, err := getImageData(nfp)
 		if errors.Is(err, os.ErrNotExist) {
+			fmt.Fprintf(os.Stderr, "Warning: image file not found: %q (tried: %q)\n", fp, nfp)
 			continue
 		} else if err != nil {
 			fmt.Fprintf(os.Stderr, "Couldn't process file: %q\n", err)
@@ -733,3 +734,4 @@ func getImageData(filePath string) ([]byte, error) {
 
 	return buf, nil
 }
+


### PR DESCRIPTION
Fixes #10333

## Problem
When dragging image files into the CLI with paths containing special characters or escaped sequences, the normalized path might not match the actual file location. Ollama silently skips these files without any feedback, leaving users confused.

## Solution
Add warning message that shows:- Original path from user input- Normalized path that was attempted

This helps users debug path issues and understand why their images weren't included.

## Changes
- Modified extractFileData() in cmd/interactive.go- When os.ErrNotExist, print warning instead of silent continue

## Testing
Drag images with escaped paths (spaces, special chars) and verify warning appears in stderr