### PR TITLE
registry: add test to verify server logging behavior

### DIFF
--- a/server/internal/registry/server.go
+++ b/server/internal/registry/server.go
@@ -164,9 +164,6 @@ func (s *Local) serveHTTP(rec *statusCodeRecorder, r *http.Request) {
 		s.Logger.LogAttrs(r.Context(), level, "http",
 			errattr, // report first in line to make it easy to find
 
-			// TODO(bmizerany): Write a test to ensure that we are logging
-			// all of this correctly. That also goes for the level+error
-			// logic above.
 			slog.Int("status", rec.status()),
 			slog.String("method", r.Method),
 			slog.String("path", r.URL.Path),

--- a/server/internal/registry/server_test.go
+++ b/server/internal/registry/server_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/fs"
 	"net"
@@ -298,5 +299,93 @@ func checkErrorResponse(t *testing.T, got *httptest.ResponseRecorder, status int
 	}
 	if !strings.Contains(e.Message, msg) {
 		errorf("Message = %q; want to contain %q", e.Message, msg)
+	}
+}
+
+func TestServerLoggingBehavior(t *testing.T) {
+	check := testutil.Checker(t)
+
+	tests := []struct {
+		name           string
+		method         string
+		path           string
+		body           io.Reader
+		expectedLevel  string
+		expectedStatus string
+	}{
+		{
+			name:           "Logs INFO for 200",
+			method:         "DELETE",
+			path:           "/api/delete",
+			body:           strings.NewReader(`{"model": "smol"}`),
+			expectedLevel:  "INFO",
+			expectedStatus: "200",
+		},
+		{
+			name:           "Logs WARN for 400",
+			method:         "DELETE",
+			path:           "/api/delete",
+			body:           strings.NewReader(`!`),
+			expectedLevel:  "WARN",
+			expectedStatus: "400",
+		},
+		{
+			name:           "Logs ERROR for 500",
+			method:         "DELETE",
+			path:           "/api/delete",
+			body:           &invalidReader{},
+			expectedLevel:  "ERROR",
+			expectedStatus: "500",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newTestServer(t, nil)
+
+			if tt.expectedStatus == "200" {
+				_, err := s.Client.ResolveLocal("smol")
+				check(err)
+			}
+
+			sl, logs := captureLogs(t, s)
+
+			req := httptest.NewRequestWithContext(t.Context(), tt.method, tt.path, tt.body)
+
+			req.RemoteAddr = "127.0.0.1:12345"
+			req.URL.RawQuery = "foo=bar"
+
+			sl.sendRequest(t, req)
+
+			logOutput := string(logs.Bytes())
+
+			if !strings.Contains(logOutput, fmt.Sprintf("level=%s", tt.expectedLevel)) {
+				t.Errorf("Expected log level %s, got:\n%s", tt.expectedLevel, logOutput)
+			}
+
+			if !strings.Contains(logOutput, fmt.Sprintf("status=%s", tt.expectedStatus)) {
+				t.Errorf("Expected status %s, got:\n%s", tt.expectedStatus, logOutput)
+			}
+
+			if !strings.Contains(logOutput, "msg=http") {
+				t.Errorf("Expected log msg 'http', got:\n%s", logOutput)
+			}
+
+			if !strings.Contains(logOutput, fmt.Sprintf("method=%s", tt.method)) {
+				t.Errorf("Expected method %s, got:\n%s", tt.method, logOutput)
+			}
+
+			if !strings.Contains(logOutput, fmt.Sprintf("path=%s", tt.path)) {
+				t.Errorf("Expected path %s, got:\n%s", tt.path, logOutput)
+			}
+
+			if !strings.Contains(logOutput, "remote=127.0.0.1:12345") {
+				t.Errorf("Expected remote IP in log, got:\n%s", logOutput)
+			}
+
+			if !strings.Contains(logOutput, `query="foo=bar"`) {
+				t.Errorf("Expected query string in log, got:\n%s", logOutput)
+			}
+		})
 	}
 }


### PR DESCRIPTION
This PR addresses the `TODO(bmizerany)` in `server/internal/registry/server.go` by adding a dedicated test to verify the HTTP logging behavior of the local registry server.

**Changes:**
* Added `TestServerLoggingBehavior` in `server_test.go`.
* Utilized existing test utilities (`newTestServer` and `captureLogs`) to mock requests and intercept the `slog` output.
* Verified that the correct log levels (`INFO`, `WARN`, `ERROR`) are applied based on HTTP status codes (`200`, `400`, `500`).
* Confirmed that essential HTTP attributes (`status`, `method`, `path`, `remote`, `query`) are correctly recorded in the logs.
* Removed the resolved `TODO` comment from `server.go`.

All tests pass successfully locally via `go test -v ./server/internal/registry/`.