### PR TITLE
updater: remove redundant debug log

### DIFF
--- a/app/updater/updater.go
+++ b/app/updater/updater.go
@@ -204,7 +204,6 @@ func (u *Updater) DownloadNewRelease(ctx context.Context, updateResp UpdateRespo
 	defer resp.Body.Close()
 	etag = strings.Trim(resp.Header.Get("etag"), "\"")
 	if etag == "" {
-		slog.Debug("no etag detected, falling back to filename based dedup") // TODO probably can get rid of this redundant log
 		etag = "_"
 	}
 


### PR DESCRIPTION
This PR removes a redundant debug log in `app/updater/updater.go` as suggested by the inline `TODO` comment.

This reduces unnecessary log noise during the update process when an etag is not detected.