### PR TITLE
feat(launch): add paperclip integration

### DIFF
--- a/cmd/launch/paperclip.go
+++ b/cmd/launch/paperclip.go
@@ -1,0 +1,87 @@
+package launch
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// Paperclip implements Runner for the Paperclip integration
+// (https://github.com/paperclipai/paperclip) — a control plane for AI-agent
+// companies that ships a first-class `ollama_local` adapter (running an agent
+// loop on /api/chat with native tool calling) as of paperclipai/paperclip#5249.
+type Paperclip struct{}
+
+const paperclipNpmPackage = "paperclipai"
+
+func (p *Paperclip) String() string { return "Paperclip" }
+
+func (p *Paperclip) args(model string, extra []string) []string {
+	args := []string{"onboard", "--bind", "loopback", "-y", "--run"}
+	return append(args, extra...)
+}
+
+func (p *Paperclip) Run(model string, args []string) error {
+	if err := ensureNpmInstalled(); err != nil {
+		return fmt.Errorf("npm (Node.js) is required to launch paperclip\n\nInstall it first:\n  https://nodejs.org/\n\nThen re-run:\n  ollama launch paperclip")
+	}
+
+	bin, err := ensurePaperclipInstalled()
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.Command(bin, p.args(model, args)...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	// Paperclip's `ollama_local` adapter reads OLLAMA_HOST and OLLAMA_API_KEY
+	// directly. Setting them here lets `ollama launch paperclip` work without
+	// any Paperclip-side configuration: the onboard wizard picks up the host
+	// and the adapter pre-fills the right values.
+	env := append(os.Environ(),
+		"OLLAMA_HOST="+ollamaHostFromEnv(),
+		"PAPERCLIP_DEFAULT_ADAPTER=ollama_local",
+	)
+	if model != "" {
+		env = append(env, "PAPERCLIP_DEFAULT_MODEL="+model)
+	}
+	cmd.Env = env
+	return cmd.Run()
+}
+
+func ensurePaperclipInstalled() (string, error) {
+	if _, err := exec.LookPath("paperclipai"); err == nil {
+		return "paperclipai", nil
+	}
+
+	ok, err := ConfirmPrompt("Paperclip is not installed. Install with npm?")
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		return "", fmt.Errorf("paperclip installation cancelled")
+	}
+
+	fmt.Fprintf(os.Stderr, "\nInstalling Paperclip...\n")
+	cmd := exec.Command("npm", "install", "-g", paperclipNpmPackage+"@latest")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("failed to install paperclip: %w", err)
+	}
+
+	if _, err := exec.LookPath("paperclipai"); err != nil {
+		return "", fmt.Errorf("paperclip was installed but the binary was not found on PATH\n\nYou may need to restart your shell")
+	}
+	return "paperclipai", nil
+}
+
+// ollamaHostFromEnv returns the configured Ollama host string for the child
+// process. Mirrors the lookup pattern other integrations use.
+func ollamaHostFromEnv() string {
+	if v := os.Getenv("OLLAMA_HOST"); v != "" {
+		return v
+	}
+	return "http://localhost:11434"
+}

--- a/cmd/launch/paperclip_test.go
+++ b/cmd/launch/paperclip_test.go
@@ -1,0 +1,45 @@
+package launch
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPaperclipString(t *testing.T) {
+	p := &Paperclip{}
+	if got := p.String(); got != "Paperclip" {
+		t.Fatalf("String() = %q, want %q", got, "Paperclip")
+	}
+}
+
+func TestPaperclipArgs(t *testing.T) {
+	p := &Paperclip{}
+	got := p.args("qwen3:14b", []string{"--extra"})
+	want := []string{"onboard", "--bind", "loopback", "-y", "--run", "--extra"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("args = %v, want %v", got, want)
+	}
+}
+
+func TestPaperclipArgsNoExtra(t *testing.T) {
+	p := &Paperclip{}
+	got := p.args("", nil)
+	want := []string{"onboard", "--bind", "loopback", "-y", "--run"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("args = %v, want %v", got, want)
+	}
+}
+
+func TestOllamaHostFromEnvDefault(t *testing.T) {
+	t.Setenv("OLLAMA_HOST", "")
+	if got := ollamaHostFromEnv(); got != "http://localhost:11434" {
+		t.Fatalf("default = %q, want %q", got, "http://localhost:11434")
+	}
+}
+
+func TestOllamaHostFromEnvOverride(t *testing.T) {
+	t.Setenv("OLLAMA_HOST", "http://my-host:9999")
+	if got := ollamaHostFromEnv(); got != "http://my-host:9999" {
+		t.Fatalf("override = %q, want %q", got, "http://my-host:9999")
+	}
+}

--- a/cmd/launch/registry.go
+++ b/cmd/launch/registry.go
@@ -33,7 +33,7 @@ type IntegrationInfo struct {
 	Description string
 }
 
-var launcherIntegrationOrder = []string{"claude-desktop", "claude", "openclaw", "hermes", "opencode", "codex", "copilot", "droid", "pi", "pool"}
+var launcherIntegrationOrder = []string{"claude-desktop", "claude", "openclaw", "hermes", "opencode", "codex", "copilot", "droid", "pi", "pool", "paperclip"}
 
 var integrationSpecs = []*IntegrationSpec{
 	{
@@ -188,6 +188,24 @@ var integrationSpecs = []*IntegrationSpec{
 				return err == nil
 			},
 			URL: "https://github.com/poolsideai/pool",
+		},
+	},
+	{
+		Name:        "paperclip",
+		Aliases:     []string{"paperclipai"},
+		Runner:      &Paperclip{},
+		Description: "Control plane for AI-agent companies — orchestrates multi-agent runs",
+		Install: IntegrationInstallSpec{
+			CheckInstalled: func() bool {
+				_, err := exec.LookPath("paperclipai")
+				return err == nil
+			},
+			EnsureInstalled: func() error {
+				_, err := ensurePaperclipInstalled()
+				return err
+			},
+			Command: []string{"npm", "install", "-g", "paperclipai@latest"},
+			URL:     "https://github.com/paperclipai/paperclip",
 		},
 	},
 	{


### PR DESCRIPTION
### What this adds

A new first-class `ollama launch paperclip` integration alongside Codex / OpenCode / Droid / Claude / Pi / etc.

```sh
ollama launch paperclip                 # uses OLLAMA_HOST or localhost:11434
ollama launch paperclip --model qwen3:14b
```

### Why

Paperclip ([github.com/paperclipai/paperclip](https://github.com/paperclipai/paperclip)) is a control plane for AI-agent companies (multi-agent orchestration, runs, heartbeats, approvals). It just shipped a first-class `ollama_local` adapter ([paperclipai/paperclip#5249](https://github.com/paperclipai/paperclip/pull/5249)) that drives Ollama's `/api/chat` directly with native tool calling — so the Paperclip side of this integration loop is already in place. This PR completes the loop on the Ollama side.

### Files

- `cmd/launch/paperclip.go` — `Paperclip{}` runner + `ensurePaperclipInstalled()` helper. Modeled on `codex.go` (simple Runner that spawns a Node CLI). Reuses the existing `ensureNpmInstalled()` helper from `pi.go` and `ConfirmPrompt()` from `selector_hooks.go`. No `Edit()` phase needed because Paperclip's `ollama_local` adapter reads `OLLAMA_HOST` directly at runtime — the runner just needs to set the env on spawn.
- `cmd/launch/paperclip_test.go` — covers `String()`, `args()` with and without extras, and host resolution.
- `cmd/launch/registry.go` — registers `paperclip` (alias `paperclipai`) with `Command: ["npm", "install", "-g", "paperclipai@latest"]` and adds `paperclip` to `launcherIntegrationOrder`.

### Behavior

`Run(model, args)`:

1. Verifies `npm` is on PATH (re-uses `ensureNpmInstalled()`).
2. If `paperclipai` isn't installed, prompts via `ConfirmPrompt` and installs `paperclipai@latest` globally.
3. Spawns `paperclipai onboard --bind loopback -y --run` with extra args appended, forwarding stdio.
4. Sets in the child env:
   - `OLLAMA_HOST` (from `os.Getenv("OLLAMA_HOST")`, fallback `http://localhost:11434`)
   - `PAPERCLIP_DEFAULT_ADAPTER=ollama_local`
   - `PAPERCLIP_DEFAULT_MODEL=<model>` if `--model` was passed

The Paperclip `ollama_local` adapter reads `OLLAMA_HOST` and `OLLAMA_API_KEY` directly, so this works for both local Ollama and Ollama Cloud without further config.

### Companion

- Tracking issue: [ollama/ollama#15976](https://github.com/ollama/ollama/issues/15976)
- Paperclip PR (the `ollama_local` adapter, ready-for-review): [paperclipai/paperclip#5249](https://github.com/paperclipai/paperclip/pull/5249)

### Open questions / happy to iterate

- The current approach uses a simple `Runner`-only pattern (no `Editor`). If maintainers prefer Paperclip also write a config file the way `Droid` / `OpenCode` do, happy to add `Paths()` / `Edit()` / `Models()` and write `~/.paperclip/...` instead.
- The `--bind loopback -y --run` flags assume the trusted-local-loopback quickstart. If maintainers prefer `ollama launch paperclip` defer to interactive onboarding (drop `-y`), I can change that.
- Tested on a Windows host without a local Go toolchain, so build verification is via CI on this PR. `paperclip.go` is patterned closely on `claude.go` / `codex.go` and the test file uses only `t.Setenv` + `reflect.DeepEqual`.

cc — happy to address any review.
