### PR TITLE
anthropic: `adaptive` thinking with the `effort` parameter

### DIFF
--- a/anthropic/anthropic.go
+++ b/anthropic/anthropic.go
@@ -12,7 +12,6 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -386,17 +385,18 @@ func FromMessagesRequest(r MessagesRequest) (*api.ChatRequest, error) {
 			think = &api.ThinkValue{Value: false}
 		case "adaptive", "enabled":
 			effort := "high" // default effort level for adaptive thinking
-
 			if r.OutputConfig != nil {
-				effort = r.OutputConfig.Effort
-
-				if effort == "xhigh" {
-					effort = "high" // map "xhigh" to "high" in the API, as "xhigh" is an Anthropic-specific value
-				} else if !slices.Contains([]string{"max", "high", "medium", "low"}, effort) {
-					return nil, fmt.Errorf("invalid effort value: '%s' (must be \"max\", \"xhigh\", \"high\", \"medium\", or \"low\")", effort)
+				normalizedEffort := strings.ToLower(strings.TrimSpace(r.OutputConfig.Effort))
+				switch normalizedEffort {
+				case "max", "high", "medium", "low":
+					effort = normalizedEffort
+				case "xhigh":
+					// map "xhigh" to "high", as "xhigh" is an Anthropic-specific value
+					effort = "high"
+				default:
+					return nil, fmt.Errorf("invalid effort value: '%s' (must be \"max\", \"xhigh\", \"high\", \"medium\", or \"low\")", r.OutputConfig.Effort)
 				}
 			}
-
 			think = &api.ThinkValue{Value: effort}
 		default:
 			return nil, fmt.Errorf("invalid thinking type: '%s' (must be \"enabled\", \"disabled\", or \"adaptive\")", r.Thinking.Type)

--- a/anthropic/anthropic.go
+++ b/anthropic/anthropic.go
@@ -408,7 +408,7 @@ func FromMessagesRequest(r MessagesRequest) (*api.ChatRequest, error) {
 		case "adaptive", "enabled":
 			// `enabled` + `budget_tokens` is deprecated and will be removed in the future. Treat `enabled` as `adaptive` for now.
 			// Actually, `adaptive` thinking will be the **only** supported thinking mode in the future.
-			think = &api.ThinkValue{Value: normalizedType}
+			think = &api.ThinkValue{Value: normalizedEffort}
 		default:
 			err := fmt.Errorf("invalid thinking type: '%s' (must be \"enabled\", \"disabled\", or \"adaptive\")", r.Thinking.Type)
 			logutil.Trace("anthropic: normalizing thinking type failed", "err", err)

--- a/anthropic/anthropic.go
+++ b/anthropic/anthropic.go
@@ -85,7 +85,6 @@ type OutputConfig struct {
 	Effort string `json:"effort,omitempty"` // "max", "xhigh", "high"(default), "medium", "low"
 }
 
-
 // MessageParam represents a message in the request
 type MessageParam struct {
 	Role    string         `json:"role"`    // "user" or "assistant"
@@ -378,29 +377,42 @@ func FromMessagesRequest(r MessagesRequest) (*api.ChatRequest, error) {
 		tools = append(tools, tool)
 	}
 
+	normalizedEffort := "high" // > Setting `effort` to "high" produces exactly the same behavior as omitting the `effort` parameter entirely.
+	if r.OutputConfig != nil {
+		normalizedEffort = strings.ToLower(strings.TrimSpace(r.OutputConfig.Effort))
+		switch normalizedEffort {
+		case "max", "high", "medium", "low":
+			// effort is already set correctly
+		case "xhigh":
+			// map "xhigh" to "high", as "xhigh" is an Anthropic-specific value
+			normalizedEffort = "high"
+		default:
+			err := fmt.Errorf("invalid effort value: '%s' (must be \"max\", \"xhigh\", \"high\", \"medium\", or \"low\")", r.OutputConfig.Effort)
+			logutil.Trace("anthropic: normalizing effort failed", "err", err)
+			return nil, err
+		}
+	}
+
 	var think *api.ThinkValue
-	if r.Thinking != nil {
+	if r.Thinking == nil {
+		// >  At `high` (default) and `max` effort, Claude will almost always think.
+		if normalizedEffort == "max" || normalizedEffort == "high" {
+			think = &api.ThinkValue{Value: normalizedEffort}
+		}
+		// else we leave think as nil to allow the model to decide when to think.
+	} else {
 		normalizedType := strings.ToLower(strings.TrimSpace(r.Thinking.Type))
 		switch normalizedType {
 		case "disabled":
 			think = &api.ThinkValue{Value: false}
 		case "adaptive", "enabled":
-			effort := "high" // default effort level for adaptive thinking
-			if r.OutputConfig != nil {
-				normalizedEffort := strings.ToLower(strings.TrimSpace(r.OutputConfig.Effort))
-				switch normalizedEffort {
-				case "max", "high", "medium", "low":
-					effort = normalizedEffort
-				case "xhigh":
-					// map "xhigh" to "high", as "xhigh" is an Anthropic-specific value
-					effort = "high"
-				default:
-					return nil, fmt.Errorf("invalid effort value: '%s' (must be \"max\", \"xhigh\", \"high\", \"medium\", or \"low\")", r.OutputConfig.Effort)
-				}
-			}
-			think = &api.ThinkValue{Value: effort}
+			// `enabled` + `budget_tokens` is deprecated and will be removed in the future. Treat `enabled` as `adaptive` for now.
+			// Actually, `adaptive` thinking will be the **only** supported thinking mode in the future.
+			think = &api.ThinkValue{Value: normalizedType}
 		default:
-			return nil, fmt.Errorf("invalid thinking type: '%s' (must be \"enabled\", \"disabled\", or \"adaptive\")", r.Thinking.Type)
+			err := fmt.Errorf("invalid thinking type: '%s' (must be \"enabled\", \"disabled\", or \"adaptive\")", r.Thinking.Type)
+			logutil.Trace("anthropic: normalizing thinking type failed", "err", err)
+			return nil, err
 		}
 	}
 

--- a/anthropic/anthropic.go
+++ b/anthropic/anthropic.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -82,8 +83,9 @@ type MessagesRequest struct {
 }
 
 type OutputConfig struct {
-	Effort string `json:"effort,omitempty"`
+	Effort string `json:"effort,omitempty"` // "max", "xhigh", "high"(default), "medium", "low"
 }
+
 
 // MessageParam represents a message in the request
 type MessageParam struct {
@@ -192,7 +194,7 @@ type ToolChoice struct {
 
 // ThinkingConfig controls extended thinking
 type ThinkingConfig struct {
-	Type         string `json:"type"` // "enabled" or "disabled"
+	Type         string `json:"type"` // "enabled", "disabled", "adaptive"
 	BudgetTokens int    `json:"budget_tokens,omitempty"`
 }
 
@@ -378,24 +380,26 @@ func FromMessagesRequest(r MessagesRequest) (*api.ChatRequest, error) {
 	}
 
 	var think *api.ThinkValue
-	normalizedEffort := ""
-	if r.OutputConfig != nil {
-		normalizedEffort = strings.ToLower(strings.TrimSpace(r.OutputConfig.Effort))
-		if normalizedEffort == "xhigh" {
-			normalizedEffort = "high"
-		}
-	}
+	if r.Thinking != nil {
+		switch r.Thinking.Type {
+		case "disabled":
+			think = &api.ThinkValue{Value: false}
+		case "adaptive", "enabled":
+			effort := "high" // default effort level for adaptive thinking
 
-	if r.Thinking != nil && r.Thinking.Type == "enabled" {
-		think = &api.ThinkValue{Value: true}
-	}
-	if r.Thinking != nil && r.Thinking.Type == "disabled" {
-		think = &api.ThinkValue{Value: false}
-	}
-	if think == nil && r.OutputConfig != nil {
-		switch normalizedEffort {
-		case "high", "medium", "low", "max":
-			think = &api.ThinkValue{Value: normalizedEffort}
+			if r.OutputConfig != nil {
+				effort = r.OutputConfig.Effort
+
+				if effort == "xhigh" {
+					effort = "high" // map "xhigh" to "high" in the API, as "xhigh" is an Anthropic-specific value
+				} else if !slices.Contains([]string{"max", "high", "medium", "low"}, effort) {
+					return nil, fmt.Errorf("invalid effort value: '%s' (must be \"max\", \"xhigh\", \"high\", \"medium\", or \"low\")", effort)
+				}
+			}
+
+			think = &api.ThinkValue{Value: effort}
+		default:
+			return nil, fmt.Errorf("invalid thinking type: '%s' (must be \"enabled\", \"disabled\", or \"adaptive\")", r.Thinking.Type)
 		}
 	}
 

--- a/anthropic/anthropic.go
+++ b/anthropic/anthropic.go
@@ -380,7 +380,8 @@ func FromMessagesRequest(r MessagesRequest) (*api.ChatRequest, error) {
 
 	var think *api.ThinkValue
 	if r.Thinking != nil {
-		switch r.Thinking.Type {
+		normalizedType := strings.ToLower(strings.TrimSpace(r.Thinking.Type))
+		switch normalizedType {
 		case "disabled":
 			think = &api.ThinkValue{Value: false}
 		case "adaptive", "enabled":

--- a/anthropic/anthropic_test.go
+++ b/anthropic/anthropic_test.go
@@ -384,128 +384,6 @@ func TestFromMessagesRequest_WithToolResultFollowedByUserText(t *testing.T) {
 	}
 }
 
-func TestFromMessagesRequest_WithOutputConfigEffort(t *testing.T) {
-	req := MessagesRequest{
-		Model:     "gemma4",
-		MaxTokens: 32000,
-		Messages: []MessageParam{
-			{
-				Role:    "user",
-				Content: textContent("Describe the image."),
-			},
-		},
-		OutputConfig: &OutputConfig{
-			Effort: "high",
-		},
-	}
-
-	result, err := FromMessagesRequest(req)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if result.Think == nil {
-		t.Fatal("expected think to be set from output_config.effort")
-	}
-
-	if got := result.Think.String(); got != "high" {
-		t.Fatalf("expected think level 'high', got %q", got)
-	}
-}
-
-func TestFromMessagesRequest_WithOutputConfigEffortXHighMapsToHigh(t *testing.T) {
-	req := MessagesRequest{
-		Model:     "gemma4",
-		MaxTokens: 32000,
-		Messages: []MessageParam{
-			{
-				Role:    "user",
-				Content: textContent("Describe the image."),
-			},
-		},
-		OutputConfig: &OutputConfig{
-			Effort: "xhigh",
-		},
-	}
-
-	result, err := FromMessagesRequest(req)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if result.Think == nil {
-		t.Fatal("expected think to be set from output_config.effort")
-	}
-
-	if got := result.Think.String(); got != "high" {
-		t.Fatalf("expected think level 'high' for xhigh effort, got %q", got)
-	}
-}
-
-func TestFromMessagesRequest_ThinkingDisabledOverridesOutputConfigEffort(t *testing.T) {
-	req := MessagesRequest{
-		Model:     "gemma4",
-		MaxTokens: 32000,
-		Messages: []MessageParam{
-			{
-				Role:    "user",
-				Content: textContent("Describe the image."),
-			},
-		},
-		Thinking: &ThinkingConfig{
-			Type: "disabled",
-		},
-		OutputConfig: &OutputConfig{
-			Effort: "high",
-		},
-	}
-
-	result, err := FromMessagesRequest(req)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if result.Think == nil {
-		t.Fatal("expected think to be set")
-	}
-
-	if got := result.Think.Value; got != false {
-		t.Fatalf("expected think=false when thinking is disabled, got %v", got)
-	}
-}
-
-func TestFromMessagesRequest_ThinkingAdaptiveUsesOutputConfigEffort(t *testing.T) {
-	req := MessagesRequest{
-		Model:     "gemma4",
-		MaxTokens: 32000,
-		Messages: []MessageParam{
-			{
-				Role:    "user",
-				Content: textContent("Describe the image."),
-			},
-		},
-		Thinking: &ThinkingConfig{
-			Type: "adaptive",
-		},
-		OutputConfig: &OutputConfig{
-			Effort: "high",
-		},
-	}
-
-	result, err := FromMessagesRequest(req)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if result.Think == nil {
-		t.Fatal("expected think to be set from output_config.effort")
-	}
-
-	if got := result.Think.String(); got != "high" {
-		t.Fatalf("expected think level 'high' for adaptive thinking, got %q", got)
-	}
-}
-
 func TestFromMessagesRequest_WithTools(t *testing.T) {
 	req := MessagesRequest{
 		Model:     "test-model",
@@ -627,6 +505,128 @@ func TestFromMessagesRequest_InvalidThinkingType(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "invalid thinking type") {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestFromMessagesRequest_WithOutputConfigEffort(t *testing.T) {
+	req := MessagesRequest{
+		Model:     "gemma4",
+		MaxTokens: 32000,
+		Messages: []MessageParam{
+			{
+				Role:    "user",
+				Content: textContent("Describe the image."),
+			},
+		},
+		OutputConfig: &OutputConfig{
+			Effort: "high",
+		},
+	}
+
+	result, err := FromMessagesRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Think == nil {
+		t.Fatal("expected think to be set from output_config.effort")
+	}
+
+	if got := result.Think.String(); got != "high" {
+		t.Fatalf("expected think level 'high', got %q", got)
+	}
+}
+
+func TestFromMessagesRequest_WithOutputConfigEffortXHighMapsToHigh(t *testing.T) {
+	req := MessagesRequest{
+		Model:     "gemma4",
+		MaxTokens: 32000,
+		Messages: []MessageParam{
+			{
+				Role:    "user",
+				Content: textContent("Describe the image."),
+			},
+		},
+		OutputConfig: &OutputConfig{
+			Effort: "xhigh",
+		},
+	}
+
+	result, err := FromMessagesRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Think == nil {
+		t.Fatal("expected think to be set from output_config.effort")
+	}
+
+	if got := result.Think.String(); got != "high" {
+		t.Fatalf("expected think level 'high' for xhigh effort, got %q", got)
+	}
+}
+
+func TestFromMessagesRequest_ThinkingDisabledOverridesOutputConfigEffort(t *testing.T) {
+	req := MessagesRequest{
+		Model:     "gemma4",
+		MaxTokens: 32000,
+		Messages: []MessageParam{
+			{
+				Role:    "user",
+				Content: textContent("Describe the image."),
+			},
+		},
+		Thinking: &ThinkingConfig{
+			Type: "disabled",
+		},
+		OutputConfig: &OutputConfig{
+			Effort: "high",
+		},
+	}
+
+	result, err := FromMessagesRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Think == nil {
+		t.Fatal("expected think to be set")
+	}
+
+	if got := result.Think.Value; got != false {
+		t.Fatalf("expected think=false when thinking is disabled, got %v", got)
+	}
+}
+
+func TestFromMessagesRequest_ThinkingAdaptiveUsesOutputConfigEffort(t *testing.T) {
+	req := MessagesRequest{
+		Model:     "gemma4",
+		MaxTokens: 32000,
+		Messages: []MessageParam{
+			{
+				Role:    "user",
+				Content: textContent("Describe the image."),
+			},
+		},
+		Thinking: &ThinkingConfig{
+			Type: "adaptive",
+		},
+		OutputConfig: &OutputConfig{
+			Effort: "high",
+		},
+	}
+
+	result, err := FromMessagesRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Think == nil {
+		t.Fatal("expected think to be set from output_config.effort")
+	}
+
+	if got := result.Think.String(); got != "high" {
+		t.Fatalf("expected think level 'high' for adaptive thinking, got %q", got)
 	}
 }
 

--- a/anthropic/anthropic_test.go
+++ b/anthropic/anthropic_test.go
@@ -613,24 +613,185 @@ func TestFromMessagesRequest_KeepsCustomWebSearchWhenBuiltinAbsent(t *testing.T)
 	}
 }
 
-func TestFromMessagesRequest_WithThinking(t *testing.T) {
+func TestFromMessagesRequest_InvalidThinkingType(t *testing.T) {
 	req := MessagesRequest{
 		Model:     "test-model",
 		MaxTokens: 1024,
 		Messages:  []MessageParam{{Role: "user", Content: textContent("Hello")}},
-		Thinking:  &ThinkingConfig{Type: "enabled", BudgetTokens: 1000},
+		Thinking:  &ThinkingConfig{Type: "bogus"},
 	}
 
-	result, err := FromMessagesRequest(req)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	_, err := FromMessagesRequest(req)
+	if err == nil {
+		t.Fatal("expected error for invalid thinking type")
+	}
+	if !strings.Contains(err.Error(), "invalid thinking type") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestFromMessagesRequest_EffortAcrossThinkingModes(t *testing.T) {
+	tests := []struct {
+		name         string
+		thinking     *ThinkingConfig
+		outputConfig *OutputConfig
+		wantThinkNil bool
+		wantValue    any
+		wantErr      string
+	}{
+		// enabled + effort: effort string overrides bool.
+		{
+			name:         "enabled + effort high",
+			thinking:     &ThinkingConfig{Type: "enabled"},
+			outputConfig: &OutputConfig{Effort: "high"},
+			wantValue:    "high",
+		},
+		{
+			name:         "enabled + effort medium",
+			thinking:     &ThinkingConfig{Type: "enabled"},
+			outputConfig: &OutputConfig{Effort: "medium"},
+			wantValue:    "medium",
+		},
+		{
+			name:         "enabled + effort low",
+			thinking:     &ThinkingConfig{Type: "enabled"},
+			outputConfig: &OutputConfig{Effort: "low"},
+			wantValue:    "low",
+		},
+		{
+			name:         "enabled + effort max",
+			thinking:     &ThinkingConfig{Type: "enabled"},
+			outputConfig: &OutputConfig{Effort: "max"},
+			wantValue:    "max",
+		},
+		{
+			name:         "enabled + effort xhigh maps to high",
+			thinking:     &ThinkingConfig{Type: "enabled"},
+			outputConfig: &OutputConfig{Effort: "xhigh"},
+			wantValue:    "high",
+		},
+		{
+			name:         "enabled + no effort stays bool true",
+			thinking:     &ThinkingConfig{Type: "enabled"},
+			outputConfig: nil,
+			wantValue:    "high",
+		},
+		{
+			name:         "enabled + invalid effort",
+			thinking:     &ThinkingConfig{Type: "enabled"},
+			outputConfig: &OutputConfig{Effort: "turbo"},
+			wantErr:      `invalid effort value: 'turbo'`,
+		},
+
+		// adaptive + effort: effort string overrides bool.
+		{
+			name:         "adaptive + effort high",
+			thinking:     &ThinkingConfig{Type: "adaptive"},
+			outputConfig: &OutputConfig{Effort: "high"},
+			wantValue:    "high",
+		},
+		{
+			name:         "adaptive + effort medium",
+			thinking:     &ThinkingConfig{Type: "adaptive"},
+			outputConfig: &OutputConfig{Effort: "medium"},
+			wantValue:    "medium",
+		},
+		{
+			name:         "adaptive + effort low",
+			thinking:     &ThinkingConfig{Type: "adaptive"},
+			outputConfig: &OutputConfig{Effort: "low"},
+			wantValue:    "low",
+		},
+		{
+			name:         "adaptive + effort max",
+			thinking:     &ThinkingConfig{Type: "adaptive"},
+			outputConfig: &OutputConfig{Effort: "max"},
+			wantValue:    "max",
+		},
+		{
+			name:         "adaptive + effort xhigh maps to high",
+			thinking:     &ThinkingConfig{Type: "adaptive"},
+			outputConfig: &OutputConfig{Effort: "xhigh"},
+			wantValue:    "high",
+		},
+		{
+			name:         "adaptive + no effort stays bool true",
+			thinking:     &ThinkingConfig{Type: "adaptive"},
+			outputConfig: nil,
+			wantValue:    "high",
+		},
+		{
+			name:         "adaptive + invalid effort",
+			thinking:     &ThinkingConfig{Type: "adaptive"},
+			outputConfig: &OutputConfig{Effort: "turbo"},
+			wantErr:      `invalid effort value: 'turbo'`,
+		},
+
+		// disabled: effort is silently ignored, value stays false.
+		{
+			name:         "disabled + effort silently ignored",
+			thinking:     &ThinkingConfig{Type: "disabled"},
+			outputConfig: &OutputConfig{Effort: "low"},
+			wantValue:    false,
+		},
+		{
+			name:         "disabled + no effort stays bool false",
+			thinking:     &ThinkingConfig{Type: "disabled"},
+			outputConfig: nil,
+			wantValue:    false,
+		},
+		{
+			name:         "disabled + invalid effort still errors",
+			thinking:     &ThinkingConfig{Type: "disabled"},
+			outputConfig: &OutputConfig{Effort: "turbo"},
+			wantValue:    false,
+		},
+
+		// no thinking field: effort is silently ignored, Think stays nil.
+		{
+			name:         "no thinking + effort is silently ignored",
+			thinking:     nil,
+			outputConfig: &OutputConfig{Effort: "low"},
+			wantThinkNil: true,
+		},
 	}
 
-	if result.Think == nil {
-		t.Fatal("expected Think to be set")
-	}
-	if v, ok := result.Think.Value.(bool); !ok || !v {
-		t.Errorf("expected Think.Value to be true, got %v", result.Think.Value)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := MessagesRequest{
+				Model:        "test-model",
+				MaxTokens:    1024,
+				Messages:     []MessageParam{{Role: "user", Content: textContent("Hello")}},
+				Thinking:     tt.thinking,
+				OutputConfig: tt.outputConfig,
+			}
+
+			result, err := FromMessagesRequest(req)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tt.wantErr, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantThinkNil {
+				if result.Think != nil {
+					t.Fatalf("expected Think to be nil, got %+v", result.Think)
+				}
+				return
+			}
+			if result.Think == nil {
+				t.Fatal("expected Think to be set")
+			}
+			if result.Think.Value != tt.wantValue {
+				t.Errorf("expected Think.Value = %v (%T), got %v (%T)", tt.wantValue, tt.wantValue, result.Think.Value, result.Think.Value)
+			}
+		})
 	}
 }
 

--- a/anthropic/anthropic_test.go
+++ b/anthropic/anthropic_test.go
@@ -639,7 +639,7 @@ func TestFromMessagesRequest_EffortAcrossThinkingModes(t *testing.T) {
 		wantValue    any
 		wantErr      string
 	}{
-		// enabled + effort: effort string overrides bool.
+		// enabled + effort: Think.Value is set to the effort string.
 		{
 			name:         "enabled + effort high",
 			thinking:     &ThinkingConfig{Type: "enabled"},
@@ -671,7 +671,7 @@ func TestFromMessagesRequest_EffortAcrossThinkingModes(t *testing.T) {
 			wantValue:    "high",
 		},
 		{
-			name:         "enabled + no effort stays bool true",
+			name:         "enabled + no effort defaults to high",
 			thinking:     &ThinkingConfig{Type: "enabled"},
 			outputConfig: nil,
 			wantValue:    "high",
@@ -683,7 +683,7 @@ func TestFromMessagesRequest_EffortAcrossThinkingModes(t *testing.T) {
 			wantErr:      `invalid effort value: 'turbo'`,
 		},
 
-		// adaptive + effort: effort string overrides bool.
+		// adaptive + effort: Think.Value is set to the effort string.
 		{
 			name:         "adaptive + effort high",
 			thinking:     &ThinkingConfig{Type: "adaptive"},
@@ -715,7 +715,7 @@ func TestFromMessagesRequest_EffortAcrossThinkingModes(t *testing.T) {
 			wantValue:    "high",
 		},
 		{
-			name:         "adaptive + no effort stays bool true",
+			name:         "adaptive + no effort defaults to high",
 			thinking:     &ThinkingConfig{Type: "adaptive"},
 			outputConfig: nil,
 			wantValue:    "high",
@@ -727,15 +727,16 @@ func TestFromMessagesRequest_EffortAcrossThinkingModes(t *testing.T) {
 			wantErr:      `invalid effort value: 'turbo'`,
 		},
 
-		// disabled: effort is silently ignored, value stays false.
+		// disabled: effort is ignored for the Think value (always false),
+		// but invalid effort still errors because effort validation runs first.
 		{
-			name:         "disabled + effort silently ignored",
+			name:         "disabled + effort low ignored, value stays false",
 			thinking:     &ThinkingConfig{Type: "disabled"},
 			outputConfig: &OutputConfig{Effort: "low"},
 			wantValue:    false,
 		},
 		{
-			name:         "disabled + no effort stays bool false",
+			name:         "disabled + no effort stays false",
 			thinking:     &ThinkingConfig{Type: "disabled"},
 			outputConfig: nil,
 			wantValue:    false,
@@ -744,15 +745,51 @@ func TestFromMessagesRequest_EffortAcrossThinkingModes(t *testing.T) {
 			name:         "disabled + invalid effort still errors",
 			thinking:     &ThinkingConfig{Type: "disabled"},
 			outputConfig: &OutputConfig{Effort: "turbo"},
-			wantValue:    false,
+			wantErr:      `invalid effort value: 'turbo'`,
 		},
 
-		// no thinking field: effort is silently ignored, Think stays nil.
+		// no thinking field: Think is set only when (defaulted/normalized) effort is "max" or "high".
 		{
-			name:         "no thinking + effort is silently ignored",
+			name:         "nil thinking + no effort defaults to high",
+			thinking:     nil,
+			outputConfig: nil,
+			wantValue:    "high",
+		},
+		{
+			name:         "nil thinking + effort high",
+			thinking:     nil,
+			outputConfig: &OutputConfig{Effort: "high"},
+			wantValue:    "high",
+		},
+		{
+			name:         "nil thinking + effort max",
+			thinking:     nil,
+			outputConfig: &OutputConfig{Effort: "max"},
+			wantValue:    "max",
+		},
+		{
+			name:         "nil thinking + effort xhigh maps to high",
+			thinking:     nil,
+			outputConfig: &OutputConfig{Effort: "xhigh"},
+			wantValue:    "high",
+		},
+		{
+			name:         "nil thinking + effort medium leaves Think nil",
+			thinking:     nil,
+			outputConfig: &OutputConfig{Effort: "medium"},
+			wantThinkNil: true,
+		},
+		{
+			name:         "nil thinking + effort low leaves Think nil",
 			thinking:     nil,
 			outputConfig: &OutputConfig{Effort: "low"},
 			wantThinkNil: true,
+		},
+		{
+			name:         "nil thinking + invalid effort errors",
+			thinking:     nil,
+			outputConfig: &OutputConfig{Effort: "turbo"},
+			wantErr:      `invalid effort value: 'turbo'`,
 		},
 	}
 

--- a/anthropic/trace.go
+++ b/anthropic/trace.go
@@ -111,6 +111,7 @@ func TraceMessagesRequest(r MessagesRequest) map[string]any {
 		"tools":          traceTools(r.Tools),
 		"tool_choice":    TraceJSON(r.ToolChoice),
 		"thinking":       TraceJSON(r.Thinking),
+		"output_config":  TraceJSON(r.OutputConfig),
 		"stop_sequences": r.StopSequences,
 		"temperature":    ptrVal(r.Temperature),
 		"top_p":          ptrVal(r.TopP),


### PR DESCRIPTION
**Title:** anthropic: support thinking effort levels in Messages API compatibility layer

**Description:**

Add support for the Anthropic `output_config.effort` field when converting Messages API requests to Ollama's chat format. This maps Anthropic's thinking effort levels (`max`, `high`, `medium`, `low`) to Ollama's `Think` option, allowing clients to control how much reasoning a model performs.

Behavior:
- `enabled`/`adaptive` thinking with an effort value sets `Think` to that effort string
- `enabled`/`adaptive` without effort defaults to `"high"`
- `disabled` thinking sets `Think` to `false` regardless of effort
- No thinking config leaves `Think` nil
- Invalid effort values return an error (except when thinking is disabled)
- Anthropic-specific `"xhigh"` is mapped to `"high"`

**Resolves:** #15831, #15952, #15287

**Conflicts with:** #15314, #15364, #16047