### PR TITLE
launch/fix: re-prompt Claude Desktop API key

### DIFF
--- a/cmd/launch/claude_desktop.go
+++ b/cmd/launch/claude_desktop.go
@@ -63,7 +63,7 @@ func (c *ClaudeDesktop) AutodiscoveredModel() string {
 	return claudeDesktopModelLabel
 }
 
-func (c *ClaudeDesktop) ConfigureAutodiscovery() error {
+func (c *ClaudeDesktop) ConfigureAutodiscovery(forceReconfigure bool) error {
 	if err := claudeDesktopSupported(); err != nil {
 		return err
 	}
@@ -73,7 +73,7 @@ func (c *ClaudeDesktop) ConfigureAutodiscovery() error {
 		return err
 	}
 
-	key, err := claudeDesktopValidatedAPIKey(context.Background(), claudeDesktopTargetProfilePaths(targets))
+	key, err := claudeDesktopValidatedAPIKey(context.Background(), claudeDesktopTargetProfilePaths(targets), forceReconfigure)
 	if err != nil {
 		return err
 	}
@@ -444,7 +444,11 @@ const (
 	claudeDesktopAPIKeySourceProfile
 )
 
-func claudeDesktopValidatedAPIKey(ctx context.Context, profilePaths []string) (string, error) {
+func claudeDesktopValidatedAPIKey(ctx context.Context, profilePaths []string, forcePrompt bool) (string, error) {
+	if forcePrompt {
+		return promptValidClaudeDesktopAPIKey(ctx)
+	}
+
 	key, source, err := claudeDesktopAPIKey(profilePaths)
 	if err != nil {
 		return "", err

--- a/cmd/launch/claude_desktop_test.go
+++ b/cmd/launch/claude_desktop_test.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/ollama/ollama/cmd/config"
 )
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
@@ -217,7 +219,7 @@ func TestClaudeDesktopConfigureWritesOllamaCloudProfile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := (&ClaudeDesktop{}).ConfigureAutodiscovery(); err != nil {
+	if err := (&ClaudeDesktop{}).ConfigureAutodiscovery(false); err != nil {
 		t.Fatalf("Configure returned error: %v", err)
 	}
 	if validatedKey != "test-api-key" {
@@ -284,7 +286,7 @@ func TestClaudeDesktopConfigureAutodiscoveryRemovesExistingModelCatalog(t *testi
 		t.Fatal(err)
 	}
 
-	if err := (&ClaudeDesktop{}).ConfigureAutodiscovery(); err != nil {
+	if err := (&ClaudeDesktop{}).ConfigureAutodiscovery(false); err != nil {
 		t.Fatalf("ConfigureAutodiscovery returned error: %v", err)
 	}
 
@@ -343,7 +345,7 @@ func TestClaudeDesktopAutodiscoveryConfiguredOnWindows(t *testing.T) {
 	withClaudeDesktopValidation(t, func(context.Context, string) error { return nil })
 
 	c := &ClaudeDesktop{}
-	if err := c.ConfigureAutodiscovery(); err != nil {
+	if err := c.ConfigureAutodiscovery(false); err != nil {
 		t.Fatalf("Configure returned error: %v", err)
 	}
 	if !c.AutodiscoveryConfigured() {
@@ -372,7 +374,7 @@ func TestClaudeDesktopConfigureAutodiscoveryTouchesAllWindowsProfileCandidates(t
 	}
 
 	c := &ClaudeDesktop{}
-	if err := c.ConfigureAutodiscovery(); err != nil {
+	if err := c.ConfigureAutodiscovery(false); err != nil {
 		t.Fatalf("ConfigureAutodiscovery returned error: %v", err)
 	}
 
@@ -530,7 +532,7 @@ func TestClaudeDesktopConfigureStopsBeforeWriteWhenKeyValidationFails(t *testing
 		return errors.New("invalid key")
 	})
 
-	err := (&ClaudeDesktop{}).ConfigureAutodiscovery()
+	err := (&ClaudeDesktop{}).ConfigureAutodiscovery(false)
 	if err == nil || !strings.Contains(err.Error(), "invalid key") {
 		t.Fatalf("Configure error = %v, want invalid key", err)
 	}
@@ -597,7 +599,7 @@ func TestClaudeDesktopConfigureRequiresAPIKey(t *testing.T) {
 		return nil
 	})
 
-	err := (&ClaudeDesktop{}).ConfigureAutodiscovery()
+	err := (&ClaudeDesktop{}).ConfigureAutodiscovery(false)
 	if err == nil || !strings.Contains(err.Error(), "OLLAMA_API_KEY is required") {
 		t.Fatalf("Configure error = %v, want missing key guidance", err)
 	}
@@ -636,11 +638,56 @@ func TestClaudeDesktopConfigureReusesExistingAPIKey(t *testing.T) {
 		return nil
 	})
 
-	if err := (&ClaudeDesktop{}).ConfigureAutodiscovery(); err != nil {
+	if err := (&ClaudeDesktop{}).ConfigureAutodiscovery(false); err != nil {
 		t.Fatalf("ConfigureAutodiscovery returned error: %v", err)
 	}
 	if validatedKey != "existing-key" {
 		t.Fatalf("validated key = %q, want existing-key", validatedKey)
+	}
+}
+
+func TestClaudeDesktopConfigureOnlyPromptsForAPIKeyEvenWhenEnvSet(t *testing.T) {
+	tmpDir := t.TempDir()
+	setTestHome(t, tmpDir)
+	withClaudeDesktopPlatform(t, "darwin")
+	withInteractiveSession(t, true)
+	t.Setenv("OLLAMA_API_KEY", "env-key")
+	if err := os.MkdirAll(filepath.Join(tmpDir, "Applications", "Claude.app"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var prompted int
+	withClaudeDesktopPrompt(t, func() (string, error) {
+		prompted++
+		return "prompt-key", nil
+	})
+	var validated []string
+	withClaudeDesktopValidation(t, func(_ context.Context, key string) error {
+		validated = append(validated, key)
+		return nil
+	})
+
+	if err := LaunchIntegration(context.Background(), IntegrationLaunchRequest{
+		Name:           "claude-desktop",
+		ForceConfigure: true,
+		ConfigureOnly:  true,
+	}); err != nil {
+		t.Fatalf("LaunchIntegration returned error: %v", err)
+	}
+	if prompted != 1 {
+		t.Fatalf("prompt calls = %d, want 1", prompted)
+	}
+	if diff := compareStrings(validated, []string{"prompt-key"}); diff != "" {
+		t.Fatalf("validated keys mismatch: %s", diff)
+	}
+
+	paths, err := claudeDesktopConfigPaths()
+	if err != nil {
+		t.Fatal(err)
+	}
+	profile := claudeDesktopReadJSON(t, paths.profile)
+	if profile["inferenceGatewayApiKey"] != "prompt-key" {
+		t.Fatalf("configured key = %v, want prompt-key", profile["inferenceGatewayApiKey"])
 	}
 }
 
@@ -674,7 +721,7 @@ func TestClaudeDesktopConfigureReplacesInvalidExistingAPIKey(t *testing.T) {
 		return "replacement-key", nil
 	})
 
-	if err := (&ClaudeDesktop{}).ConfigureAutodiscovery(); err != nil {
+	if err := (&ClaudeDesktop{}).ConfigureAutodiscovery(false); err != nil {
 		t.Fatalf("ConfigureAutodiscovery returned error: %v", err)
 	}
 	if diff := compareStrings(validated, []string{"stale-key", "replacement-key"}); diff != "" {
@@ -712,7 +759,7 @@ func TestClaudeDesktopConfigureReusesExistingAPIKeyFromAnyWindowsProfile(t *test
 		return nil
 	})
 
-	if err := (&ClaudeDesktop{}).ConfigureAutodiscovery(); err != nil {
+	if err := (&ClaudeDesktop{}).ConfigureAutodiscovery(false); err != nil {
 		t.Fatalf("ConfigureAutodiscovery returned error: %v", err)
 	}
 	if validatedKey != "fallback-key" {
@@ -734,7 +781,7 @@ func TestClaudeDesktopAutodiscoveryConfiguredRequiresAppliedOllamaProfile(t *tes
 	withClaudeDesktopValidation(t, func(context.Context, string) error { return nil })
 
 	c := &ClaudeDesktop{}
-	if err := c.ConfigureAutodiscovery(); err != nil {
+	if err := c.ConfigureAutodiscovery(false); err != nil {
 		t.Fatalf("Configure returned error: %v", err)
 	}
 	if !c.AutodiscoveryConfigured() {
@@ -761,7 +808,7 @@ func TestClaudeDesktopAutodiscoveryConfiguredRequiresAPIKey(t *testing.T) {
 	withClaudeDesktopValidation(t, func(context.Context, string) error { return nil })
 
 	c := &ClaudeDesktop{}
-	if err := c.ConfigureAutodiscovery(); err != nil {
+	if err := c.ConfigureAutodiscovery(false); err != nil {
 		t.Fatalf("Configure returned error: %v", err)
 	}
 
@@ -781,6 +828,85 @@ func TestClaudeDesktopAutodiscoveryConfiguredRequiresAPIKey(t *testing.T) {
 
 	if c.AutodiscoveryConfigured() {
 		t.Fatal("expected missing gateway API key to force Claude Desktop reconfiguration")
+	}
+}
+
+func TestLaunchIntegration_ClaudeDesktopEmptyStoredAPIKeyPromptsAgain(t *testing.T) {
+	tmpDir := t.TempDir()
+	setTestHome(t, tmpDir)
+	withClaudeDesktopPlatform(t, "darwin")
+	withInteractiveSession(t, true)
+	t.Setenv("OLLAMA_API_KEY", "")
+	if err := os.MkdirAll(filepath.Join(tmpDir, "Applications", "Claude.app"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	paths, err := claudeDesktopConfigPaths()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, dir := range []string{filepath.Dir(paths.normalConfig), filepath.Dir(paths.desktopConfig), filepath.Dir(paths.profile)} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(paths.normalConfig, []byte(`{"deploymentMode":"3p"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.desktopConfig, []byte(`{"deploymentMode":"3p"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.meta, []byte(`{"appliedId":"`+claudeDesktopProfileID+`","entries":[{"id":"`+claudeDesktopProfileID+`","name":"Ollama"}]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.profile, []byte(`{"disableDeploymentModeChooser":true,"inferenceProvider":"gateway","inferenceGatewayBaseUrl":"https://ollama.com","inferenceGatewayApiKey":"","inferenceGatewayAuthScheme":"bearer"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.SaveIntegration("claude-desktop", []string{claudeDesktopModelLabel}); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.MarkIntegrationOnboarded("claude-desktop"); err != nil {
+		t.Fatal(err)
+	}
+	if (&ClaudeDesktop{}).AutodiscoveryConfigured() {
+		t.Fatal("empty gateway API key should not count as configured")
+	}
+
+	var prompted int
+	withClaudeDesktopPrompt(t, func() (string, error) {
+		prompted++
+		return "replacement-key", nil
+	})
+	var validated []string
+	withClaudeDesktopValidation(t, func(_ context.Context, key string) error {
+		validated = append(validated, key)
+		return nil
+	})
+	var openCalls int
+	withClaudeDesktopProcessHooks(t,
+		func() bool { return false },
+		func() error { return nil },
+		func() error {
+			openCalls++
+			return nil
+		},
+	)
+
+	if err := LaunchIntegration(context.Background(), IntegrationLaunchRequest{Name: "claude-desktop"}); err != nil {
+		t.Fatalf("LaunchIntegration returned error: %v", err)
+	}
+	if prompted != 1 {
+		t.Fatalf("prompt calls = %d, want 1", prompted)
+	}
+	if diff := compareStrings(validated, []string{"replacement-key"}); diff != "" {
+		t.Fatalf("validated keys mismatch: %s", diff)
+	}
+	profile := claudeDesktopReadJSON(t, paths.profile)
+	if profile["inferenceGatewayApiKey"] != "replacement-key" {
+		t.Fatalf("configured key = %v, want replacement-key", profile["inferenceGatewayApiKey"])
+	}
+	if openCalls != 1 {
+		t.Fatalf("open calls = %d, want 1", openCalls)
 	}
 }
 

--- a/cmd/launch/launch.go
+++ b/cmd/launch/launch.go
@@ -167,7 +167,7 @@ type ManagedAutodiscoveryIntegration interface {
 	Paths() []string
 	AutodiscoveredModel() string
 	AutodiscoveryConfigured() bool
-	ConfigureAutodiscovery() error
+	ConfigureAutodiscovery(forceReconfigure bool) error
 	Onboard() error
 }
 
@@ -777,7 +777,7 @@ func (c *launcherClient) launchManagedAutodiscoveryIntegration(ctx context.Conte
 	needsConfigure := req.ForceConfigure || req.ConfigureOnly || !autodiscovery.AutodiscoveryConfigured() || !savedMatchesModels(saved, []string{target})
 
 	if needsConfigure {
-		if err := prepareManagedAutodiscoveryIntegration(name, runner, autodiscovery, target); err != nil {
+		if err := prepareManagedAutodiscoveryIntegration(name, runner, autodiscovery, target, req.ForceConfigure || req.ConfigureOnly); err != nil {
 			return err
 		}
 		if refresher, ok := autodiscovery.(ManagedRuntimeRefresher); ok {

--- a/cmd/launch/launch_test.go
+++ b/cmd/launch/launch_test.go
@@ -127,11 +127,12 @@ func (r *launcherManagedListRunner) ConfigureWithModels(primary string, models [
 
 type launcherManagedAutodiscoveryRunner struct {
 	launcherManagedRunner
-	autodiscoveryConfigures int
-	autodiscoveryConfigured bool
-	usesCloud               bool
-	restoreHint             string
-	configSuccessMessage    string
+	autodiscoveryConfigures        int
+	autodiscoveryForceReconfigures []bool
+	autodiscoveryConfigured        bool
+	usesCloud                      bool
+	restoreHint                    string
+	configSuccessMessage           string
 }
 
 func (r *launcherManagedAutodiscoveryRunner) AutodiscoveredModel() string { return "Ollama Cloud" }
@@ -148,8 +149,9 @@ func (r *launcherManagedAutodiscoveryRunner) AutodiscoveryConfigured() bool {
 	return r.autodiscoveryConfigured
 }
 
-func (r *launcherManagedAutodiscoveryRunner) ConfigureAutodiscovery() error {
+func (r *launcherManagedAutodiscoveryRunner) ConfigureAutodiscovery(forceReconfigure bool) error {
 	r.autodiscoveryConfigures++
+	r.autodiscoveryForceReconfigures = append(r.autodiscoveryForceReconfigures, forceReconfigure)
 	r.autodiscoveryConfigured = true
 	return nil
 }
@@ -749,6 +751,9 @@ func TestLaunchIntegration_ManagedAutodiscoverySkipsModelPicker(t *testing.T) {
 	if runner.autodiscoveryConfigures != 1 {
 		t.Fatalf("expected one autodiscovery configure, got %d", runner.autodiscoveryConfigures)
 	}
+	if diff := cmp.Diff([]bool{false}, runner.autodiscoveryForceReconfigures); diff != "" {
+		t.Fatalf("force reconfigure mismatch (-want +got):\n%s", diff)
+	}
 	if runner.ranModel != "Ollama Cloud" {
 		t.Fatalf("expected launch to run autodiscovery label, got %q", runner.ranModel)
 	}
@@ -927,6 +932,9 @@ func TestLaunchIntegration_ManagedAutodiscoveryForceConfigureRerunsSetup(t *test
 
 	if runner.autodiscoveryConfigures != 1 {
 		t.Fatalf("expected forced autodiscovery configure to rerun setup, got %d configures", runner.autodiscoveryConfigures)
+	}
+	if diff := cmp.Diff([]bool{true}, runner.autodiscoveryForceReconfigures); diff != "" {
+		t.Fatalf("force reconfigure mismatch (-want +got):\n%s", diff)
 	}
 	if runner.ranModel != "Ollama Cloud" {
 		t.Fatalf("expected launch to run autodiscovery label, got %q", runner.ranModel)

--- a/cmd/launch/models.go
+++ b/cmd/launch/models.go
@@ -337,13 +337,13 @@ func prepareManagedSingleIntegration(name string, runner Runner, managed Managed
 	return nil
 }
 
-func prepareManagedAutodiscoveryIntegration(name string, runner Runner, autodiscovery ManagedAutodiscoveryIntegration, model string) error {
+func prepareManagedAutodiscoveryIntegration(name string, runner Runner, autodiscovery ManagedAutodiscoveryIntegration, model string, forceReconfigure bool) error {
 	if ok, err := confirmConfigEdit(runner, autodiscovery.Paths()); err != nil {
 		return err
 	} else if !ok {
 		return errCancelled
 	}
-	if err := autodiscovery.ConfigureAutodiscovery(); err != nil {
+	if err := autodiscovery.ConfigureAutodiscovery(forceReconfigure); err != nil {
 		return fmt.Errorf("setup failed: %w", err)
 	}
 	if err := config.SaveIntegration(name, []string{model}); err != nil {

--- a/docs/integrations/claude-desktop.mdx
+++ b/docs/integrations/claude-desktop.mdx
@@ -15,7 +15,7 @@ Claude Desktop can use Ollama Cloud, including Claude Cowork and Claude Code ins
 - Claude Desktop for macOS or Windows
 - An [Ollama API key](https://ollama.com/settings/keys)
 
-Set the key in your shell before launching:
+Set the key in your shell before launching, or enter it when Ollama asks:
 
 ```shell
 export OLLAMA_API_KEY=your_api_key
@@ -46,6 +46,8 @@ The same models are also available to Claude Code inside Claude Desktop:
 ```shell
 ollama launch claude-desktop --config
 ```
+
+Use `--config` to re-enter your API key if setup was canceled or Claude Desktop opens without Ollama Cloud models.
 
 ## Restore normal Claude
 


### PR DESCRIPTION
## Summary
- detect empty Claude Desktop gateway API keys as unconfigured and run setup again
- make forced/config-only autodiscovery setup request a fresh Claude Desktop API key, even when OLLAMA_API_KEY is set
- document `ollama launch claude-desktop --config` as the recovery path for canceled setup or missing models

## Tests
- go test ./cmd/launch
- go test ./cmd -run 'Launcher|LaunchCmd'