### PR TITLE
Add CAJAL to Community Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,8 @@ console.log(response.message.content);
 ### Productivity & Apps
 
 - [AppFlowy](https://github.com/AppFlowy-IO/AppFlowy) - AI collaborative workspace, self-hostable Notion alternative
+- [CAJAL](https://github.com/Agnuxo1/CAJAL) - Scientific paper generation with structured output and peer-review tribunal scoring. Runs 100% locally via Ollama
+- [CAJAL](https://github.com/Agnuxo1/CAJAL) - Scientific paper generation with structured output and peer-review tribunal scoring. Runs 100% locally via Ollama
 - [Screenpipe](https://github.com/mediar-ai/screenpipe) - 24/7 screen and mic recording with AI-powered search
 - [Vibe](https://github.com/thewh1teagle/vibe) - Transcribe and analyze meetings
 - [Page Assist](https://github.com/n4ze3m/page-assist) - Chrome extension for AI-powered browsing


### PR DESCRIPTION
## Summary

Adds [CAJAL](https://github.com/Agnuxo1/CAJAL) to the Community Integrations list under **Productivity & Apps**.

### What is CAJAL?

- Scientific paper generation with structured output (Abstract, Introduction, Methodology, Results, Discussion, Conclusion, References)
- Peer-review tribunal scoring system (3 reviewers, 0-10 scale)
- All citations verified via arXiv API
- 100% local via Ollama — zero API cost, full privacy
- MIT licensed

### Links
- **GitHub:** https://github.com/Agnuxo1/CAJAL
- **HuggingFace:** https://huggingface.co/Agnuxo/CAJAL-9B-P2PCLAW
- **Paper:** https://arxiv.org/pdf/2604.19792
- **PyPI:** https://pypi.org/project/cajal-p2pclaw/
- **Ollama Modelfile:** https://github.com/Agnuxo1/CAJAL/blob/main/Modelfile

### Why this fits

CAJAL is built to run locally via Ollama. Adding it helps researchers discover a privacy-first academic writing tool that works out-of-the-box with their existing Ollama setup.

cc @rick-github (from #15933 — link fixed and ready!)