### PR TITLE
app/ui: await ensureQueryData in chat route loader

### DIFF
--- a/app/ui/app/src/routes/c.$chatId.tsx
+++ b/app/ui/app/src/routes/c.$chatId.tsx
@@ -35,7 +35,7 @@ export const Route = createFileRoute("/c/$chatId")({
   loader: async ({ context, params }) => {
     // Skip loading for special non-chat views
     if (params.chatId !== "new" && params.chatId !== "launch") {
-      context.queryClient.ensureQueryData({
+      await context.queryClient.ensureQueryData({
         queryKey: ["chat", params.chatId],
         queryFn: () => getChat(params.chatId),
         staleTime: 1500,


### PR DESCRIPTION
The route loader fires ensureQueryData without await, so the component mounts before the cache is populated and briefly shows 'Loading chat...' on every navigation. Adding await makes TanStack Router wait for the data to be ready before rendering.

Fixes #15996