### PR TITLE
app/ui: fix scroll-to-bottom not triggering on page refresh or chat switch

### DIFF
--- a/app/ui/app/src/components/Chat.tsx
+++ b/app/ui/app/src/components/Chat.tsx
@@ -47,7 +47,7 @@ export default function Chat({ chatId }: { chatId: string }) {
     index: number;
     originalMessage: Message;
   } | null>(null);
-  const prevChatIdRef = useRef<string>(chatId);
+  const prevChatIdRef = useRef<string | null>(null);
 
   const chatFormCallbackRef = useRef<
     | ((
@@ -120,8 +120,8 @@ export default function Chat({ chatId }: { chatId: string }) {
     ) {
       // Always scroll to the bottom when opening a chat
       containerRef.current.scrollTop = containerRef.current.scrollHeight;
+      prevChatIdRef.current = chatId;
     }
-    prevChatIdRef.current = chatId;
   }, [chatId, messages.length]);
 
   // Simplified submit handler - ChatForm handles all the attachment logic


### PR DESCRIPTION
The useLayoutEffect that scrolls to the bottom on chat switch has two bugs:

1. prevChatIdRef is initialized with the current chatId, so on page refresh the 'did chatId change?' check immediately fails and the scroll never fires.

2. The ref is updated unconditionally on every effect run, even when messages haven't loaded yet (length === 0). When messages arrive and the effect re-runs, the check fails because the ref was already set.

Fix: initialize prevChatIdRef as null and move the ref update inside the scroll branch so it only fires after a successful scroll-to-bottom.

Fixes #15997