### PR TITLE
app/ui: centralize theme detection and tokenize only the active theme in code blocks

### DIFF
--- a/app/ui/app/src/components/StreamingMarkdownContent.tsx
+++ b/app/ui/app/src/components/StreamingMarkdownContent.tsx
@@ -2,8 +2,9 @@ import React from "react";
 import { Streamdown, defaultRemarkPlugins } from "streamdown";
 import remarkCitationParser from "@/utils/remarkCitationParser";
 import CopyButton from "./CopyButton";
-import type { BundledLanguage } from "shiki";
-import { highlighter } from "@/lib/highlighter";
+import type { BundledLanguage, ThemedToken } from "shiki";
+import { highlighter, THEME_LIGHT, THEME_DARK } from "@/lib/highlighter";
+import { useTheme } from "@/hooks/useTheme";
 
 interface StreamingMarkdownContentProps {
   content: string;
@@ -31,6 +32,7 @@ const extractText = (node: React.ReactNode): string => {
 
 const CodeBlock = React.memo(
   ({ children }: React.HTMLAttributes<HTMLPreElement>) => {
+    const theme = useTheme();
     // Extract code and language from children
     const codeElement = children as React.ReactElement<{
       className?: string;
@@ -40,26 +42,38 @@ const CodeBlock = React.memo(
       codeElement.props.className?.replace(/language-/, "") || "";
     const codeText = extractText(codeElement.props.children);
 
+    const tokenCacheRef = React.useRef<{
+      light?: ThemedToken[][];
+      dark?: ThemedToken[][];
+    }>({});
+
     // Synchronously highlight code using the pre-loaded highlighter
     const tokens = React.useMemo(() => {
       if (!highlighter) return null;
 
+      const themeKey = theme === "dark" ? "dark" : "light";
+      if (tokenCacheRef.current[themeKey]) {
+        return tokenCacheRef.current[themeKey];
+      }
+
+      // Skip unsupported languages
+      const loadedLangs = highlighter.getLoadedLanguages();
+      if (language && !loadedLangs.includes(language as BundledLanguage)) {
+        return null;
+      }
+
       try {
-        return {
-          light: highlighter.codeToTokensBase(codeText, {
-            lang: language as BundledLanguage,
-            theme: "one-light" as any,
-          }),
-          dark: highlighter.codeToTokensBase(codeText, {
-            lang: language as BundledLanguage,
-            theme: "one-dark" as any,
-          }),
-        };
+        const result = highlighter.codeToTokensBase(codeText, {
+          lang: language as BundledLanguage,
+          theme: theme === "dark" ? THEME_DARK : THEME_LIGHT,
+        });
+        tokenCacheRef.current[themeKey] = result;
+        return result;
       } catch (error) {
         console.error("Failed to highlight code:", error);
         return null;
       }
-    }, [codeText, language]);
+    }, [codeText, language, theme]);
 
     return (
       <div className="relative bg-neutral-100 dark:bg-neutral-800 rounded-2xl overflow-hidden my-6">
@@ -75,13 +89,12 @@ const CodeBlock = React.memo(
             className="copy-button text-neutral-500 dark:text-neutral-400 bg-neutral-100 dark:bg-neutral-800 ml-auto"
           />
         </div>
-        {/* Light mode */}
-        <pre className="dark:hidden m-0 bg-neutral-100 text-sm overflow-x-auto p-4">
+        <pre className="m-0 bg-neutral-100 dark:bg-neutral-800 text-sm overflow-x-auto p-4">
           <code className="font-mono text-sm">
-            {tokens?.light
-              ? tokens.light.map((line: any, i: number) => (
+            {tokens
+              ? tokens.map((line: ThemedToken[], i: number) => (
                   <React.Fragment key={i}>
-                    {line.map((token: any, j: number) => (
+                    {line.map((token: ThemedToken, j: number) => (
                       <span
                         key={j}
                         style={{
@@ -91,29 +104,7 @@ const CodeBlock = React.memo(
                         {token.content}
                       </span>
                     ))}
-                    {i < tokens.light.length - 1 && "\n"}
-                  </React.Fragment>
-                ))
-              : codeText}
-          </code>
-        </pre>
-        {/* Dark mode */}
-        <pre className="hidden dark:block m-0 bg-neutral-800 text-sm overflow-x-auto p-4">
-          <code className="font-mono text-sm">
-            {tokens?.dark
-              ? tokens.dark.map((line: any, i: number) => (
-                  <React.Fragment key={i}>
-                    {line.map((token: any, j: number) => (
-                      <span
-                        key={j}
-                        style={{
-                          color: token.color,
-                        }}
-                      >
-                        {token.content}
-                      </span>
-                    ))}
-                    {i < tokens.dark.length - 1 && "\n"}
+                    {i < tokens.length - 1 && "\n"}
                   </React.Fragment>
                 ))
               : codeText}

--- a/app/ui/app/src/components/StreamingMarkdownContent.tsx
+++ b/app/ui/app/src/components/StreamingMarkdownContent.tsx
@@ -2,7 +2,8 @@ import React from "react";
 import { Streamdown, defaultRemarkPlugins } from "streamdown";
 import remarkCitationParser from "@/utils/remarkCitationParser";
 import CopyButton from "./CopyButton";
-import type { BundledLanguage, ThemedToken } from "shiki";
+import type { BundledLanguage } from "shiki";
+import type { ThemeRegistrationAny, ThemedToken } from "@shikijs/types";
 import { highlighter, THEME_LIGHT, THEME_DARK } from "@/lib/highlighter";
 import { useTheme } from "@/hooks/useTheme";
 
@@ -63,9 +64,10 @@ const CodeBlock = React.memo(
       }
 
       try {
+        const shikiTheme = theme === "dark" ? THEME_DARK : THEME_LIGHT;
         const result = highlighter.codeToTokensBase(codeText, {
           lang: language as BundledLanguage,
-          theme: theme === "dark" ? THEME_DARK : THEME_LIGHT,
+          theme: shikiTheme as ThemeRegistrationAny,
         });
         tokenCacheRef.current[themeKey] = result;
         return result;

--- a/app/ui/app/src/hooks/useTheme.ts
+++ b/app/ui/app/src/hooks/useTheme.ts
@@ -1,0 +1,18 @@
+import { useSyncExternalStore } from "react";
+
+export type Theme = "light" | "dark";
+
+const mql = window.matchMedia("(prefers-color-scheme: dark)");
+
+function subscribe(callback: () => void): () => void {
+  mql.addEventListener("change", callback);
+  return () => mql.removeEventListener("change", callback);
+}
+
+function getSnapshot(): Theme {
+  return mql.matches ? "dark" : "light";
+}
+
+export function useTheme(): Theme {
+  return useSyncExternalStore(subscribe, getSnapshot);
+}

--- a/app/ui/app/src/lib/highlighter.ts
+++ b/app/ui/app/src/lib/highlighter.ts
@@ -1,8 +1,11 @@
 import { createHighlighter } from "shiki";
 import type { ThemeRegistration } from "shiki";
 
+export const THEME_LIGHT = "one-light";
+export const THEME_DARK = "one-dark";
+
 const oneLightTheme: ThemeRegistration = {
-  name: "one-light",
+  name: THEME_LIGHT,
   type: "light",
   colors: {
     "editor.background": "#fafafa",
@@ -64,7 +67,7 @@ const oneLightTheme: ThemeRegistration = {
 };
 
 const oneDarkTheme: ThemeRegistration = {
-  name: "one-dark",
+  name: THEME_DARK,
   type: "dark",
   colors: {
     "editor.background": "#282c34",


### PR DESCRIPTION
Every code block in a chat message previously ran syntax highlighting twice (once for light mode, once for dark mode), doubling the Shiki processing time. Theme names were also hardcoded across files.

This change:
1. Exports THEME_LIGHT and THEME_DARK from highlighter.ts.
2. Creates a useTheme hook to detect and react to system theme changes.
3. Refactors CodeBlock to tokenize only the active theme on mount, lazily caching tokens per theme for instant switching.
4. Skips tokenization for languages not registered in the highlighter.

Fixes #15998