### PR TITLE
app/ui: fix ResizeObserver recreation and skip hidden markdown rendering

### DIFF
--- a/app/ui/app/src/components/Thinking.tsx
+++ b/app/ui/app/src/components/Thinking.tsx
@@ -36,16 +36,16 @@ export default function Thinking({
 
   // Measure content height for animations
   useEffect(() => {
-    if (contentRef.current) {
-      const resizeObserver = new ResizeObserver(() => {
-        if (contentRef.current) {
-          setContentHeight(contentRef.current.scrollHeight);
-        }
-      });
-      resizeObserver.observe(contentRef.current);
-      return () => resizeObserver.disconnect();
-    }
-  }, [thinking]);
+    if (!contentRef.current) return;
+    const resizeObserver = new ResizeObserver(() => {
+      if (contentRef.current) {
+        setContentHeight(contentRef.current.scrollHeight);
+      }
+    });
+    resizeObserver.observe(contentRef.current);
+    return () => resizeObserver.disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Position content to show bottom when collapsed
   useEffect(() => {
@@ -156,11 +156,13 @@ export default function Thinking({
           ref={contentRef}
           className="transition-transform duration-300 opacity-75 select-text"
         >
-          <StreamingMarkdownContent
-            content={thinking}
-            isStreaming={activelyThinking}
-            size="sm"
-          />
+          {!(isCollapsed && finishedThinking) && (
+            <StreamingMarkdownContent
+              content={thinking}
+              isStreaming={activelyThinking}
+              size="sm"
+            />
+          )}
         </div>
 
         {/* Gradient overlay for fade effect when collapsed and scrolled */}


### PR DESCRIPTION
1. The ResizeObserver in `Thinking.tsx` was being torn down and re-created on every single streamed token because of the [thinking] dependency. Changed it to empty deps so the observer persists.
2. The `StreamingMarkdownContent` inside the thinking section was rendering full markdown even when the section was completely collapsed and finished (invisible to the user), wasting CPU. Added a conditional check to skip rendering in this state.

Fixes #16003