### PR TITLE
fix typos in runner README and llama4 comment

### DIFF
--- a/model/models/llama4/model_vision.go
+++ b/model/models/llama4/model_vision.go
@@ -16,7 +16,7 @@ type VisionAttention struct {
 }
 
 // applyVisionRotaryEmbedding applies 2D rotary embedding to the input tensor.
-// This is equivalent to the Pytorch implmentation using half rotations:
+// This is equivalent to the Pytorch implementation using half rotations:
 //
 //	cos, sin = torch.cos(freqs), torch.sin(freqs)
 //	cos = cos.unsqueeze(-1)

--- a/runner/README.md
+++ b/runner/README.md
@@ -2,7 +2,7 @@
 
 > Note: this is a work in progress
 
-A minimial runner for loading a model and running inference via a http web server.
+A minimal runner for loading a model and running inference via a http web server.
 
 ```shell
 ./runner -model <model binary>


### PR DESCRIPTION
Fix two spelling mistakes:
- runner/README.md: "minimial" → "minimal"
- model/models/llama4/model_vision.go: "implmentation" → "implementation"