### PR TITLE
cmd/internal/fileutil: avoid backup filename collisions

### DIFF
--- a/cmd/internal/fileutil/files.go
+++ b/cmd/internal/fileutil/files.go
@@ -62,12 +62,38 @@ func writeBackupCopy(srcPath string, integration string) (string, error) {
 		return "", err
 	}
 
-	backupPath := filepath.Join(dir, fmt.Sprintf("%s.%d", name, time.Now().Unix()))
-	if err := copyFile(srcPath, backupPath); err != nil {
+	info, err := os.Stat(srcPath)
+	if err != nil {
 		return "", err
 	}
-	pruneOldBackups(dir, name, maxBackupsPerFile)
-	return backupPath, nil
+	data, err := os.ReadFile(srcPath)
+	if err != nil {
+		return "", err
+	}
+
+	timestamp := time.Now().UnixNano()
+	for i := int64(0); ; i++ {
+		backupPath := filepath.Join(dir, fmt.Sprintf("%s.%d", name, timestamp+i))
+		file, err := os.OpenFile(backupPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, info.Mode().Perm())
+		if os.IsExist(err) {
+			continue
+		}
+		if err != nil {
+			return "", err
+		}
+
+		if _, err := file.Write(data); err != nil {
+			_ = file.Close()
+			_ = os.Remove(backupPath)
+			return "", err
+		}
+		if err := file.Close(); err != nil {
+			_ = os.Remove(backupPath)
+			return "", err
+		}
+		pruneOldBackups(dir, name, maxBackupsPerFile)
+		return backupPath, nil
+	}
 }
 
 // WriteWithBackup writes data to path via temp file + rename, backing up any

--- a/cmd/internal/fileutil/files_test.go
+++ b/cmd/internal/fileutil/files_test.go
@@ -538,16 +538,28 @@ func TestWriteWithBackup_RapidSuccessiveWrites(t *testing.T) {
 		t.Errorf("expected final content {\"v\": 3}, got %s", string(content))
 	}
 
-	// Verify at least one backup exists
+	// Verify each overwritten version has its own backup
 	entries, _ := os.ReadDir(BackupDir())
 	var backupCount int
+	backupContents := map[string]bool{}
 	for _, e := range entries {
 		if len(e.Name()) > len("rapid.json.") && e.Name()[:len("rapid.json.")] == "rapid.json." {
 			backupCount++
+			content, err := os.ReadFile(filepath.Join(BackupDir(), e.Name()))
+			if err != nil {
+				t.Fatal(err)
+			}
+			backupContents[string(content)] = true
 		}
 	}
-	if backupCount == 0 {
-		t.Error("expected at least one backup file from rapid writes")
+	if backupCount != 3 {
+		t.Fatalf("expected 3 backup files from rapid writes, got %d", backupCount)
+	}
+	for i := 0; i < 3; i++ {
+		content := fmt.Sprintf(`{"v": %d}`, i)
+		if !backupContents[content] {
+			t.Errorf("expected backup containing %s", content)
+		}
 	}
 }
 


### PR DESCRIPTION
## What changed

WriteWithBackup now creates backup files with nanosecond-based numeric suffixes and O_EXCL, retrying if a generated backup name already exists. This prevents rapid successive writes from overwriting earlier backups.

The rapid-write regression test now verifies that every overwritten version is preserved as its own backup.

## Why

The previous backup filename used time.Now().Unix(), so multiple writes to the same file within one second could reuse the same backup path and replace the prior backup.

## How tested

- Ran go test ./cmd/internal/fileutil -count=1
- Ran go test ./cmd/internal/fileutil ./cmd/launch -count=1