### PR TITLE
docs: add MLJAR Studio integration

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -159,6 +159,7 @@
               {
                 "group": "Notebooks",
                 "pages": [
+                  "/integrations/mljar-studio",
                   "/integrations/marimo"
                 ]
               }

--- a/docs/integrations/index.mdx
+++ b/docs/integrations/index.mdx
@@ -51,4 +51,5 @@ Workflow automation platforms with AI integration.
 
 Interactive computing environments with AI capabilities.
 
+- [MLJAR Studio](/integrations/mljar-studio)
 - [marimo](/integrations/marimo)

--- a/docs/integrations/mljar-studio.mdx
+++ b/docs/integrations/mljar-studio.mdx
@@ -17,6 +17,14 @@ ollama pull qwen3.5
 4. Set the endpoint to `http://localhost:11434`.
 5. Enter the model name you downloaded and test the connection.
 
+<div style={{ display: 'flex', justifyContent: 'center' }}>
+  <img
+    src="https://mljar.com/_next/static/media/ollama-local.e7cb54ec.webp"
+    alt="Ollama local provider settings in MLJAR Studio"
+    width="65%"
+  />
+</div>
+
 See the [MLJAR Studio Ollama Local Setup](https://mljar.com/docs/llm-providers/ollama-local/) guide for full setup instructions.
 
 ## Connecting to ollama.com
@@ -25,5 +33,13 @@ See the [MLJAR Studio Ollama Local Setup](https://mljar.com/docs/llm-providers/o
 2. In MLJAR Studio, open AI provider settings and select **Ollama Cloud**.
 3. Enter your API key and model name.
 4. Test the connection and save the provider.
+
+<div style={{ display: 'flex', justifyContent: 'center' }}>
+  <img
+    src="https://mljar.com/_next/static/media/ollama-cloud.633cdc30.webp"
+    alt="Ollama Cloud provider settings in MLJAR Studio"
+    width="65%"
+  />
+</div>
 
 See the [MLJAR Studio Ollama Cloud Setup](https://mljar.com/docs/llm-providers/ollama-cloud/) guide for full setup instructions.

--- a/docs/integrations/mljar-studio.mdx
+++ b/docs/integrations/mljar-studio.mdx
@@ -1,0 +1,29 @@
+---
+title: MLJAR Studio
+---
+
+[MLJAR Studio](https://mljar.com) is a desktop application for AI-powered data analysis built on top of Python notebooks. It supports Ollama as an LLM provider for local models and Ollama Cloud.
+
+## Using Ollama Locally
+
+1. Install Ollama and make sure it is running.
+2. Pull a model that fits your hardware:
+
+```shell
+ollama pull qwen3.5
+```
+
+3. In MLJAR Studio, open AI provider settings and select **Ollama**.
+4. Set the endpoint to `http://localhost:11434`.
+5. Enter the model name you downloaded and test the connection.
+
+See the [MLJAR Studio Ollama Local Setup](https://mljar.com/docs/llm-providers/ollama-local/) guide for full setup instructions.
+
+## Connecting to ollama.com
+
+1. Create an [API key](https://ollama.com/settings/keys) on ollama.com.
+2. In MLJAR Studio, open AI provider settings and select **Ollama Cloud**.
+3. Enter your API key and model name.
+4. Test the connection and save the provider.
+
+See the [MLJAR Studio Ollama Cloud Setup](https://mljar.com/docs/llm-providers/ollama-cloud/) guide for full setup instructions.


### PR DESCRIPTION
## Summary

- add MLJAR Studio to the integrations overview
- add a new MLJAR Studio integration page with local Ollama and Ollama Cloud setup links
- add the page to the docs navigation

Refs #15578

## Testing

- `git diff --check`
- verified `docs/docs.json` parses locally

