### PR TITLE
docs: add LlamaPen to community web integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ console.log(response.message.content);
 - [chat](https://github.com/swuecho/chat) - Chat web app for teams
 - [Ollama RAG Chatbot](https://github.com/datvodinh/rag-chatbot.git) - Chat with multiple PDFs using RAG
 - [Tkinter-based client](https://github.com/chyok/ollama-gui) - Python desktop client
+- [LlamaPen](https://llamapen.app/) - A no-install needed web-GUI for Ollama
 
 #### Desktop
 


### PR DESCRIPTION
This pull request adds LlamaPen to the Community Integrations in the README under the web chat interfaces section.

LlamaPen is a no-install-needed web-GUI for Ollama. It provides a:

* Chat interface
    - Reasoning toggles
    - Attachment support
    - Tool call support
    - Model selection list
    - Generation parameter customization
    - Sidebar for multiple chats
* Model management page
    - Manage installed models
    - Download new models
    - Rename models
* Tools page
    - Add/manage custom tools
    - Built-in support for self-hosted search integration
* Highly customizable settings 
* Integration guide
* Mobile & PWA support

As of writing LlamaPen has over 400 stars and has been actively maintained for over a year.

- GitHub: https://github.com/ImDarkTom/LlamaPen
- Site: https://llamapen.app/