### PR TITLE
anthropic: handle images in tool_result content blocks

### DIFF
--- a/anthropic/anthropic.go
+++ b/anthropic/anthropic.go
@@ -391,6 +391,39 @@ func FromMessagesRequest(r MessagesRequest) (*api.ChatRequest, error) {
 	return convertedRequest, nil
 }
 
+func extractBase64ImageSource(source *ImageSource) (api.ImageData, error) {
+	if source == nil {
+		return nil, errors.New("invalid image source")
+	}
+
+	if source.Type == "base64" {
+		decoded, err := base64.StdEncoding.DecodeString(source.Data)
+		if err != nil {
+			return nil, fmt.Errorf("invalid base64 image data: %w", err)
+		}
+		return decoded, nil
+	}
+	return nil, fmt.Errorf("invalid image source type: %s. Only base64 images are supported", source.Type)
+}
+
+func extractBase64Image(blockMap map[string]any) (api.ImageData, error) {
+	source, ok := blockMap["source"].(map[string]any)
+	if !ok {
+		return nil, errors.New("invalid image source")
+	}
+
+	sourceType, _ := source["type"].(string)
+	if sourceType == "base64" {
+		data, _ := source["data"].(string)
+		decoded, err := base64.StdEncoding.DecodeString(data)
+		if err != nil {
+			return nil, fmt.Errorf("invalid base64 image data: %w", err)
+		}
+		return decoded, nil
+	}
+	return nil, fmt.Errorf("invalid image source type: %s. Only base64 images are supported", sourceType)
+}
+
 // convertMessage converts an Anthropic MessageParam to Ollama api.Message(s)
 func convertMessage(msg MessageParam) ([]api.Message, error) {
 	var messages []api.Message
@@ -420,22 +453,12 @@ func convertMessage(msg MessageParam) ([]api.Message, error) {
 
 		case "image":
 			imageBlocks++
-			if block.Source == nil {
-				logutil.Trace("anthropic: invalid image source", "role", role)
-				return nil, errors.New("invalid image source")
+			decoded, err := extractBase64ImageSource(block.Source)
+			if err != nil {
+				logutil.Trace("anthropic: failed to extract image", "role", role, "error", err)
+				return nil, err
 			}
-
-			if block.Source.Type == "base64" {
-				decoded, err := base64.StdEncoding.DecodeString(block.Source.Data)
-				if err != nil {
-					logutil.Trace("anthropic: invalid base64 image data", "role", role, "error", err)
-					return nil, fmt.Errorf("invalid base64 image data: %w", err)
-				}
-				images = append(images, decoded)
-			} else {
-				logutil.Trace("anthropic: unsupported image source type", "role", role, "source_type", block.Source.Type)
-				return nil, fmt.Errorf("invalid image source type: %s. Only base64 images are supported.", block.Source.Type)
-			}
+			images = append(images, decoded)
 
 		case "tool_use":
 			toolUseBlocks++
@@ -458,17 +481,42 @@ func convertMessage(msg MessageParam) ([]api.Message, error) {
 		case "tool_result":
 			toolResultBlocks++
 			var resultContent string
+			var resultImages []api.ImageData
 
 			switch c := block.Content.(type) {
 			case string:
 				resultContent = c
+			case []ContentBlock:
+				for _, cb := range c {
+					switch cb.Type {
+					case "text":
+						if cb.Text != nil {
+							resultContent += *cb.Text
+						}
+					case "image":
+						decoded, err := extractBase64ImageSource(cb.Source)
+						if err != nil {
+							logutil.Trace("anthropic: failed to extract image from tool_result", "role", role, "error", err)
+							return nil, err
+						}
+						resultImages = append(resultImages, decoded)
+					}
+				}
 			case []any:
 				for _, cb := range c {
 					if cbMap, ok := cb.(map[string]any); ok {
-						if cbMap["type"] == "text" {
+						switch cbMap["type"] {
+						case "text":
 							if text, ok := cbMap["text"].(string); ok {
 								resultContent += text
 							}
+						case "image":
+							decoded, err := extractBase64Image(cbMap)
+							if err != nil {
+								logutil.Trace("anthropic: failed to extract image from tool_result", "role", role, "error", err)
+								return nil, err
+							}
+							resultImages = append(resultImages, decoded)
 						}
 					}
 				}
@@ -477,6 +525,7 @@ func convertMessage(msg MessageParam) ([]api.Message, error) {
 			toolResults = append(toolResults, api.Message{
 				Role:       "tool",
 				Content:    resultContent,
+				Images:     resultImages,
 				ToolCallID: block.ToolUseID,
 			})
 

--- a/anthropic/anthropic_test.go
+++ b/anthropic/anthropic_test.go
@@ -271,6 +271,124 @@ func TestFromMessagesRequest_WithToolResult(t *testing.T) {
 	}
 }
 
+func TestFromMessagesRequest_WithToolResultContainingImage(t *testing.T) {
+	imgData, _ := base64.StdEncoding.DecodeString(testImage)
+
+	req := MessagesRequest{
+		Model:     "test-model",
+		MaxTokens: 1024,
+		Messages: []MessageParam{
+			{
+				Role: "user",
+				Content: []ContentBlock{
+					{
+						Type:      "tool_result",
+						ToolUseID: "call_456",
+						Content: []any{
+							map[string]any{"type": "text", "text": "Here is the screenshot:"},
+							map[string]any{
+								"type": "image",
+								"source": map[string]any{
+									"type":       "base64",
+									"media_type": "image/png",
+									"data":       testImage,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := FromMessagesRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(result.Messages))
+	}
+
+	msg := result.Messages[0]
+	if msg.Role != "tool" {
+		t.Errorf("expected role 'tool', got %q", msg.Role)
+	}
+	if msg.ToolCallID != "call_456" {
+		t.Errorf("expected tool_call_id 'call_456', got %q", msg.ToolCallID)
+	}
+	if msg.Content != "Here is the screenshot:" {
+		t.Errorf("expected content 'Here is the screenshot:', got %q", msg.Content)
+	}
+	if len(msg.Images) != 1 {
+		t.Fatalf("expected 1 image in tool result, got %d", len(msg.Images))
+	}
+	if string(msg.Images[0]) != string(imgData) {
+		t.Error("image data mismatch in tool result")
+	}
+}
+
+func TestFromMessagesRequest_WithToolResultContainingMultipleImages(t *testing.T) {
+	imgData, _ := base64.StdEncoding.DecodeString(testImage)
+
+	req := MessagesRequest{
+		Model:     "test-model",
+		MaxTokens: 1024,
+		Messages: []MessageParam{
+			{
+				Role: "user",
+				Content: []ContentBlock{
+					{
+						Type:      "tool_result",
+						ToolUseID: "call_789",
+						Content: []any{
+							map[string]any{
+								"type": "image",
+								"source": map[string]any{
+									"type":       "base64",
+									"media_type": "image/png",
+									"data":       testImage,
+								},
+							},
+							map[string]any{"type": "text", "text": "First image above, second below:"},
+							map[string]any{
+								"type": "image",
+								"source": map[string]any{
+									"type":       "base64",
+									"media_type": "image/png",
+									"data":       testImage,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := FromMessagesRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(result.Messages))
+	}
+
+	msg := result.Messages[0]
+	if msg.Role != "tool" {
+		t.Errorf("expected role 'tool', got %q", msg.Role)
+	}
+	if len(msg.Images) != 2 {
+		t.Fatalf("expected 2 images in tool result, got %d", len(msg.Images))
+	}
+	for i, img := range msg.Images {
+		if string(img) != string(imgData) {
+			t.Errorf("image %d data mismatch in tool result", i)
+		}
+	}
+}
+
 func TestFromMessagesRequest_WithTools(t *testing.T) {
 	req := MessagesRequest{
 		Model:     "test-model",

--- a/model/renderers/glmocr.go
+++ b/model/renderers/glmocr.go
@@ -54,10 +54,10 @@ func (r *GlmOcrRenderer) Render(messages []api.Message, tools []api.Tool, thinkV
 
 	imageOffset := 0
 	for i, message := range messages {
+		content, nextOffset := r.renderContent(message, imageOffset)
 		switch message.Role {
 		case "user":
 			sb.WriteString("<|user|>\n")
-			content, nextOffset := r.renderContent(message, imageOffset)
 			imageOffset = nextOffset
 			sb.WriteString(content)
 			if thinkingExplicitlySet && !enableThinking && !strings.HasSuffix(message.Content, "/nothink") {
@@ -85,8 +85,9 @@ func (r *GlmOcrRenderer) Render(messages []api.Message, tools []api.Tool, thinkV
 			if i == 0 || messages[i-1].Role != "tool" {
 				sb.WriteString("<|observation|>")
 			}
+			imageOffset = nextOffset
 			sb.WriteString("\n<tool_response>\n")
-			sb.WriteString(message.Content)
+			sb.WriteString(content)
 			sb.WriteString("\n</tool_response>\n")
 		case "system":
 			sb.WriteString("<|system|>\n")

--- a/model/renderers/glmocr_test.go
+++ b/model/renderers/glmocr_test.go
@@ -83,6 +83,33 @@ func TestGlmOcrRenderer_Images(t *testing.T) {
 			},
 			expected: "[gMASK]<sop><|user|>\nText only message.<|assistant|>\n",
 		},
+		{
+			name:     "tool response image uses next image offset",
+			renderer: &GlmOcrRenderer{useImgTags: true},
+			messages: []api.Message{
+				{
+					Role:    "user",
+					Content: "Analyze this image file.",
+				},
+				{
+					Role: "assistant",
+					ToolCalls: []api.ToolCall{
+						{
+							Function: api.ToolCallFunction{
+								Name:      "Read",
+								Arguments: testArgsOrdered([]orderedArg{{Key: "file_path", Value: "/tmp/hello.png"}}),
+							},
+						},
+					},
+				},
+				{
+					Role:    "tool",
+					Content: "",
+					Images:  []api.ImageData{api.ImageData("img1")},
+				},
+			},
+			expected: "[gMASK]<sop><|user|>\nAnalyze this image file.<|assistant|>\n<think></think>\n<tool_call>Read<arg_key>file_path</arg_key><arg_value>/tmp/hello.png</arg_value></tool_call>\n<|observation|>\n<tool_response>\n[img-0]\n</tool_response>\n<|assistant|>\n",
+		},
 	}
 
 	for _, tt := range tests {

--- a/model/renderers/qwen3vl.go
+++ b/model/renderers/qwen3vl.go
@@ -126,7 +126,7 @@ func (r *Qwen3VLRenderer) Render(messages []api.Message, tools []api.Tool, think
 			if i == 0 || messages[i-1].Role != "tool" {
 				sb.WriteString("<|im_start|>user")
 			}
-			sb.WriteString("\n<tool_response>\n" + message.Content + "\n</tool_response>")
+			sb.WriteString("\n<tool_response>\n" + content + "\n</tool_response>")
 			if i == len(messages)-1 || messages[i+1].Role != "tool" {
 				sb.WriteString("<|im_end|>\n")
 			}

--- a/model/renderers/qwen3vl_nonthinking_test.go
+++ b/model/renderers/qwen3vl_nonthinking_test.go
@@ -106,6 +106,71 @@ Let me analyze this image.`,
 Let me analyze this image.`,
 		},
 		{
+			name: "tool response image",
+			msgs: []api.Message{
+				{Role: "user", Content: "Analyze this image file."},
+				{
+					Role: "assistant",
+					ToolCalls: []api.ToolCall{
+						{
+							Function: api.ToolCallFunction{
+								Name: "Read",
+								Arguments: testArgsOrdered([]orderedArg{
+									{Key: "file_path", Value: "/tmp/hello.png"},
+								}),
+							},
+						},
+					},
+				},
+				{Role: "tool", Content: "", Images: []api.ImageData{api.ImageData("img2")}},
+			},
+			expected: `<|im_start|>user
+Analyze this image file.<|im_end|>
+<|im_start|>assistant
+<tool_call>
+{"name": "Read", "arguments": {"file_path": "/tmp/hello.png"}}
+</tool_call><|im_end|>
+<|im_start|>user
+<tool_response>
+<|vision_start|><|image_pad|><|vision_end|>
+</tool_response><|im_end|>
+<|im_start|>assistant
+`,
+		},
+		{
+			name: "tool response image with image tags",
+			msgs: []api.Message{
+				{Role: "user", Content: "Analyze this image file."},
+				{
+					Role: "assistant",
+					ToolCalls: []api.ToolCall{
+						{
+							Function: api.ToolCallFunction{
+								Name: "Read",
+								Arguments: testArgsOrdered([]orderedArg{
+									{Key: "file_path", Value: "/tmp/hello.png"},
+								}),
+							},
+						},
+					},
+				},
+				{Role: "tool", Content: "", Images: []api.ImageData{api.ImageData("img2")}},
+			},
+			useImgTags: true,
+			expected: `<|im_start|>user
+Analyze this image file.<|im_end|>
+<|im_start|>assistant
+<tool_call>
+{"name": "Read", "arguments": {"file_path": "/tmp/hello.png"}}
+</tool_call><|im_end|>
+<|im_start|>user
+<tool_response>
+[img-0]
+</tool_response><|im_end|>
+<|im_start|>assistant
+`,
+		},
+		{
 			name: "Multiple images",
 			msgs: []api.Message{
 				{Role: "user", Content: "Describe these images.", Images: []api.ImageData{api.ImageData("img1"), api.ImageData("img2")}},

--- a/server/cloud_proxy.go
+++ b/server/cloud_proxy.go
@@ -348,10 +348,10 @@ func requiresCloudAnthropicChatFallback(path string, body []byte) bool {
 		return false
 	}
 
-	return hasAnthropicWebSearchTool(body) || hasAnthropicToolResultImage(body)
+	return hasAnthropicWebSearchTool(body) || hasAnthropicToolResultBase64Image(body)
 }
 
-func hasAnthropicToolResultImage(body []byte) bool {
+func hasAnthropicToolResultBase64Image(body []byte) bool {
 	if len(body) == 0 {
 		return false
 	}
@@ -378,7 +378,7 @@ func hasAnthropicToolResultImage(body []byte) bool {
 			if strings.TrimSpace(block.Type) != "tool_result" {
 				continue
 			}
-			if anthropicToolResultContentHasImage(block.Content) {
+			if anthropicToolResultContentHasBase64Image(block.Content) {
 				return true
 			}
 		}
@@ -387,26 +387,32 @@ func hasAnthropicToolResultImage(body []byte) bool {
 	return false
 }
 
-func anthropicToolResultContentHasImage(raw json.RawMessage) bool {
+func anthropicToolResultContentHasBase64Image(raw json.RawMessage) bool {
 	if len(raw) == 0 || bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
 		return false
 	}
 
 	var blocks []struct {
-		Type string `json:"type"`
+		Type   string `json:"type"`
+		Source *struct {
+			Type string `json:"type"`
+		} `json:"source"`
 	}
 	if err := json.Unmarshal(raw, &blocks); err == nil {
 		for _, block := range blocks {
-			if strings.TrimSpace(block.Type) == "image" {
+			if strings.TrimSpace(block.Type) == "image" && block.Source != nil && strings.TrimSpace(block.Source.Type) == "base64" {
 				return true
 			}
 		}
 	}
 
 	var block struct {
-		Type string `json:"type"`
+		Type   string `json:"type"`
+		Source *struct {
+			Type string `json:"type"`
+		} `json:"source"`
 	}
-	if err := json.Unmarshal(raw, &block); err == nil && strings.TrimSpace(block.Type) == "image" {
+	if err := json.Unmarshal(raw, &block); err == nil && strings.TrimSpace(block.Type) == "image" && block.Source != nil && strings.TrimSpace(block.Source.Type) == "base64" {
 		return true
 	}
 

--- a/server/cloud_proxy.go
+++ b/server/cloud_proxy.go
@@ -28,7 +28,7 @@ const (
 	defaultCloudProxyBaseURL      = "https://ollama.com:443"
 	defaultCloudProxySigningHost  = "ollama.com"
 	cloudProxyBaseURLEnv          = "OLLAMA_CLOUD_BASE_URL"
-	legacyCloudAnthropicKey       = "legacy_cloud_anthropic_web_search"
+	cloudAnthropicChatFallbackKey = "cloud_anthropic_chat_fallback"
 	cloudProxyClientVersionHeader = "X-Ollama-Client-Version"
 
 	// maxDecompressedBodySize limits the size of a decompressed request body
@@ -120,14 +120,13 @@ func cloudPassthroughMiddleware(disabledOperation string) gin.HandlerFunc {
 			return
 		}
 
-		// TEMP(drifkin): keep Anthropic web search requests on the local middleware
-		// path so WebSearchAnthropicWriter can orchestrate follow-up calls.
-		if c.Request.URL.Path == "/v1/messages" {
-			if hasAnthropicWebSearchTool(body) {
-				c.Set(legacyCloudAnthropicKey, true)
-				c.Next()
-				return
-			}
+		// Some Anthropic `/v1/messages` cloud requests need local normalization
+		// before they can be proxied upstream. Keep those requests on the local
+		// middleware path so they are converted into `/api/chat` first.
+		if requiresCloudAnthropicChatFallback(c.Request.URL.Path, body) {
+			c.Set(cloudAnthropicChatFallbackKey, true)
+			c.Next()
+			return
 		}
 
 		proxyCloudRequest(c, normalizedBody, disabledOperation)
@@ -156,9 +155,8 @@ func cloudModelPathPassthroughMiddleware(disabledOperation string) gin.HandlerFu
 }
 
 func proxyCloudJSONRequest(c *gin.Context, payload any, disabledOperation string) {
-	// TEMP(drifkin): we currently split out this `WithPath` method because we are
-	// mapping `/v1/messages` + web_search to `/api/chat` temporarily. Once we
-	// stop doing this, we can inline this method.
+	// Some cloud Anthropic requests are normalized locally and then proxied to
+	// a different upstream path (`/api/chat`), so we keep the `WithPath` helper.
 	proxyCloudJSONRequestWithPath(c, payload, c.Request.URL.Path, disabledOperation)
 }
 
@@ -228,13 +226,11 @@ func proxyCloudRequestWithPath(c *gin.Context, body []byte, path string, disable
 
 	var bodyWriter http.ResponseWriter = c.Writer
 	var framedWriter *jsonlFramingResponseWriter
-	// TEMP(drifkin): only needed on the cloud-proxied first leg of Anthropic
-	// web_search fallback (which is a path we're removing soon). Local
-	// /v1/messages writes one JSON value per streamResponse callback directly
-	// into WebSearchAnthropicWriter, but this proxy copy loop may coalesce
-	// multiple jsonl records into one Write.  WebSearchAnthropicWriter currently
-	// unmarshals one JSON value per Write.
-	if path == "/api/chat" && resp.StatusCode == http.StatusOK && c.GetBool(legacyCloudAnthropicKey) {
+	// Local `/v1/messages` writers expect one JSON object per Write, but the
+	// cloud proxy copy loop may coalesce multiple `/api/chat` JSONL records into
+	// one chunk. Re-split them whenever we are proxying a locally normalized
+	// Anthropic request through `/api/chat`.
+	if path == "/api/chat" && resp.StatusCode == http.StatusOK && c.GetBool(cloudAnthropicChatFallbackKey) {
 		framedWriter = &jsonlFramingResponseWriter{ResponseWriter: c.Writer}
 		bodyWriter = framedWriter
 	}
@@ -342,6 +338,76 @@ func hasAnthropicWebSearchTool(body []byte) bool {
 		if strings.HasPrefix(strings.TrimSpace(tool.Type), "web_search") {
 			return true
 		}
+	}
+
+	return false
+}
+
+func requiresCloudAnthropicChatFallback(path string, body []byte) bool {
+	if path != "/v1/messages" {
+		return false
+	}
+
+	return hasAnthropicWebSearchTool(body) || hasAnthropicToolResultImage(body)
+}
+
+func hasAnthropicToolResultImage(body []byte) bool {
+	if len(body) == 0 {
+		return false
+	}
+
+	var payload struct {
+		Messages []struct {
+			Content json.RawMessage `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return false
+	}
+
+	for _, message := range payload.Messages {
+		var blocks []struct {
+			Type    string          `json:"type"`
+			Content json.RawMessage `json:"content"`
+		}
+		if err := json.Unmarshal(message.Content, &blocks); err != nil {
+			continue
+		}
+
+		for _, block := range blocks {
+			if strings.TrimSpace(block.Type) != "tool_result" {
+				continue
+			}
+			if anthropicToolResultContentHasImage(block.Content) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func anthropicToolResultContentHasImage(raw json.RawMessage) bool {
+	if len(raw) == 0 || bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return false
+	}
+
+	var blocks []struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(raw, &blocks); err == nil {
+		for _, block := range blocks {
+			if strings.TrimSpace(block.Type) == "image" {
+				return true
+			}
+		}
+	}
+
+	var block struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(raw, &block); err == nil && strings.TrimSpace(block.Type) == "image" {
+		return true
 	}
 
 	return false

--- a/server/routes.go
+++ b/server/routes.go
@@ -2177,7 +2177,7 @@ func (s *Server) ChatHandler(c *gin.Context) {
 
 	if modelRef.Source == modelSourceCloud {
 		req.Model = modelRef.Base
-		if c.GetBool(legacyCloudAnthropicKey) {
+		if c.GetBool(cloudAnthropicChatFallbackKey) {
 			proxyCloudJSONRequestWithPath(c, req, "/api/chat", cloudErrRemoteInferenceUnavailable)
 			return
 		}

--- a/server/routes_cloud_test.go
+++ b/server/routes_cloud_test.go
@@ -863,6 +863,72 @@ func TestExplicitCloudPassthroughAPIAndV1(t *testing.T) {
 		}
 	})
 
+	t.Run("v1 messages tool_result url image bypasses conversion", func(t *testing.T) {
+		upstream, capture := newUpstream(t, `{"id":"msg_1","type":"message"}`)
+		defer upstream.Close()
+
+		original := cloudProxyBaseURL
+		cloudProxyBaseURL = upstream.URL
+		t.Cleanup(func() { cloudProxyBaseURL = original })
+
+		s := &Server{}
+		router, err := s.GenerateRoutes(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		local := httptest.NewServer(router)
+		defer local.Close()
+
+		reqBody := `{
+				"model":"gpt-oss:120b-cloud",
+				"max_tokens":10,
+				"messages":[{
+					"role":"user",
+					"content":[{
+						"type":"tool_result",
+						"tool_use_id":"call_456",
+						"content":[
+							{"type":"text","text":"Here is the screenshot:"},
+							{"type":"image","source":{"type":"url","url":"https://example.com/image.png"}}
+						]
+					}]
+				}],
+				"stream":false
+			}`
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, local.URL+"/v1/messages?beta=true", bytes.NewBufferString(reqBody))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := local.Client().Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200, got %d (%s)", resp.StatusCode, string(body))
+		}
+
+		if capture.path != "/v1/messages" {
+			t.Fatalf("expected upstream path /v1/messages for url image passthrough, got %q", capture.path)
+		}
+
+		if !strings.Contains(capture.body, `"type":"tool_result"`) {
+			t.Fatalf("expected original anthropic request body, got %q", capture.body)
+		}
+
+		if !strings.Contains(capture.body, `"type":"url"`) {
+			t.Fatalf("expected url image source in upstream body, got %q", capture.body)
+		}
+
+		if strings.Contains(capture.body, `"num_predict":10`) {
+			t.Fatalf("expected no converted ollama options in upstream body, got %q", capture.body)
+		}
+	})
+
 	t.Run("v1 model retrieve bypasses conversion", func(t *testing.T) {
 		upstream, capture := newUpstream(t, `{"id":"kimi-k2.5:cloud","object":"model","created":1,"owned_by":"ollama"}`)
 		defer upstream.Close()
@@ -1245,6 +1311,74 @@ func TestCloudPassthroughSkipsAnthropicToolResultImages(t *testing.T) {
 
 	if capture.path != "" {
 		t.Fatalf("expected no passthrough for tool_result image requests, got upstream path %q", capture.path)
+	}
+}
+
+func TestCloudPassthroughDoesNotSkipAnthropicToolResultURLImages(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setTestHome(t, t.TempDir())
+
+	type upstreamCapture struct {
+		path string
+	}
+	capture := &upstreamCapture{}
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capture.path = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message"}`))
+	}))
+	defer upstream.Close()
+
+	original := cloudProxyBaseURL
+	cloudProxyBaseURL = upstream.URL
+	t.Cleanup(func() { cloudProxyBaseURL = original })
+
+	router := gin.New()
+	router.POST(
+		"/v1/messages",
+		cloudPassthroughMiddleware(cloudErrRemoteInferenceUnavailable),
+		middleware.AnthropicMessagesMiddleware(),
+		func(c *gin.Context) { c.Status(http.StatusTeapot) },
+	)
+
+	local := httptest.NewServer(router)
+	defer local.Close()
+
+	reqBody := `{
+		"model":"kimi-k2.5:cloud",
+		"max_tokens":10,
+		"messages":[{
+			"role":"user",
+			"content":[{
+				"type":"tool_result",
+				"tool_use_id":"call_456",
+				"content":[
+					{"type":"text","text":"Here is the screenshot:"},
+					{"type":"image","source":{"type":"url","url":"https://example.com/image.png"}}
+				]
+			}]
+		}]
+	}`
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, local.URL+"/v1/messages", bytes.NewBufferString(reqBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := local.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected passthrough response status 200, got %d (%s)", resp.StatusCode, string(body))
+	}
+
+	if capture.path != "/v1/messages" {
+		t.Fatalf("expected passthrough to upstream /v1/messages for url images, got %q", capture.path)
 	}
 }
 

--- a/server/routes_cloud_test.go
+++ b/server/routes_cloud_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/ollama/ollama/version"
 )
 
+const testAnthropicImageBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+
 func TestStatusHandler(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	setTestHome(t, t.TempDir())
@@ -713,6 +715,154 @@ func TestExplicitCloudPassthroughAPIAndV1(t *testing.T) {
 		}
 	})
 
+	t.Run("v1 messages tool_result image fallback uses /api/chat path", func(t *testing.T) {
+		upstream, capture := newUpstream(t, `{"model":"gpt-oss:120b","created_at":"2024-01-01T00:00:00Z","message":{"role":"assistant","content":"hello"},"done":true}`)
+		defer upstream.Close()
+
+		original := cloudProxyBaseURL
+		cloudProxyBaseURL = upstream.URL
+		t.Cleanup(func() { cloudProxyBaseURL = original })
+
+		s := &Server{}
+		router, err := s.GenerateRoutes(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		local := httptest.NewServer(router)
+		defer local.Close()
+
+		reqBody := `{
+				"model":"gpt-oss:120b-cloud",
+				"max_tokens":10,
+				"messages":[{
+					"role":"user",
+					"content":[{
+						"type":"tool_result",
+						"tool_use_id":"call_456",
+						"content":[
+							{"type":"text","text":"Here is the screenshot:"},
+							{"type":"image","source":{"type":"base64","media_type":"image/png","data":"` + testAnthropicImageBase64 + `"}}
+						]
+					}]
+				}],
+				"stream":false
+			}`
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, local.URL+"/v1/messages?beta=true", bytes.NewBufferString(reqBody))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := local.Client().Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200, got %d (%s)", resp.StatusCode, string(body))
+		}
+
+		if capture.path != "/api/chat" {
+			t.Fatalf("expected upstream path /api/chat for tool_result image fallback, got %q", capture.path)
+		}
+
+		if !strings.Contains(capture.body, `"model":"gpt-oss:120b"`) {
+			t.Fatalf("expected normalized model in upstream body, got %q", capture.body)
+		}
+
+		if !strings.Contains(capture.body, `"num_predict":10`) {
+			t.Fatalf("expected converted ollama options in upstream body, got %q", capture.body)
+		}
+
+		if !strings.Contains(capture.body, `"role":"tool"`) {
+			t.Fatalf("expected converted tool message in upstream body, got %q", capture.body)
+		}
+
+		if !strings.Contains(capture.body, `"tool_call_id":"call_456"`) {
+			t.Fatalf("expected tool_call_id in upstream body, got %q", capture.body)
+		}
+
+		if !strings.Contains(capture.body, `"images":["`+testAnthropicImageBase64+`"]`) {
+			t.Fatalf("expected image bytes in upstream body, got %q", capture.body)
+		}
+
+		if strings.Contains(capture.body, `"tool_result"`) {
+			t.Fatalf("expected anthropic tool_result block to be converted, got %q", capture.body)
+		}
+	})
+
+	t.Run("v1 messages tool_result image fallback frames coalesced jsonl chunks", func(t *testing.T) {
+		type upstreamCapture struct {
+			path string
+		}
+		capture := &upstreamCapture{}
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capture.path = r.URL.Path
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			w.WriteHeader(http.StatusOK)
+
+			combined := strings.Join([]string{
+				`{"model":"gpt-oss:120b","created_at":"2024-01-01T00:00:00Z","message":{"role":"assistant","content":"Hel"},"done":false}`,
+				`{"model":"gpt-oss:120b","created_at":"2024-01-01T00:00:00Z","message":{"role":"assistant","content":"lo"},"done":true}`,
+			}, "\n") + "\n"
+			_, _ = w.Write([]byte(combined))
+		}))
+		defer upstream.Close()
+
+		original := cloudProxyBaseURL
+		cloudProxyBaseURL = upstream.URL
+		t.Cleanup(func() { cloudProxyBaseURL = original })
+
+		s := &Server{}
+		router, err := s.GenerateRoutes(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		local := httptest.NewServer(router)
+		defer local.Close()
+
+		reqBody := `{
+					"model":"gpt-oss:120b-cloud",
+					"max_tokens":10,
+					"stream":true,
+					"messages":[{
+						"role":"user",
+						"content":[{
+							"type":"tool_result",
+							"tool_use_id":"call_456",
+							"content":[
+								{"type":"text","text":"Here is the screenshot:"},
+								{"type":"image","source":{"type":"base64","media_type":"image/png","data":"` + testAnthropicImageBase64 + `"}}
+							]
+						}]
+					}]
+				}`
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, local.URL+"/v1/messages?beta=true", bytes.NewBufferString(reqBody))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := local.Client().Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200, got %d (%s)", resp.StatusCode, string(body))
+		}
+		if capture.path != "/api/chat" {
+			t.Fatalf("expected upstream path /api/chat for tool_result image fallback, got %q", capture.path)
+		}
+		if !strings.Contains(string(body), "event: message_stop") {
+			t.Fatalf("expected anthropic streaming message_stop event, got body %q", string(body))
+		}
+	})
+
 	t.Run("v1 model retrieve bypasses conversion", func(t *testing.T) {
 		upstream, capture := newUpstream(t, `{"id":"kimi-k2.5:cloud","object":"model","created":1,"owned_by":"ollama"}`)
 		defer upstream.Close()
@@ -1027,6 +1177,74 @@ func TestCloudPassthroughSkipsAnthropicWebSearchLegacySuffix(t *testing.T) {
 
 	if capture.path != "" {
 		t.Fatalf("expected no passthrough for web_search requests, got upstream path %q", capture.path)
+	}
+}
+
+func TestCloudPassthroughSkipsAnthropicToolResultImages(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setTestHome(t, t.TempDir())
+
+	type upstreamCapture struct {
+		path string
+	}
+	capture := &upstreamCapture{}
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capture.path = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message"}`))
+	}))
+	defer upstream.Close()
+
+	original := cloudProxyBaseURL
+	cloudProxyBaseURL = upstream.URL
+	t.Cleanup(func() { cloudProxyBaseURL = original })
+
+	router := gin.New()
+	router.POST(
+		"/v1/messages",
+		cloudPassthroughMiddleware(cloudErrRemoteInferenceUnavailable),
+		middleware.AnthropicMessagesMiddleware(),
+		func(c *gin.Context) { c.Status(http.StatusTeapot) },
+	)
+
+	local := httptest.NewServer(router)
+	defer local.Close()
+
+	reqBody := `{
+		"model":"kimi-k2.5:cloud",
+		"max_tokens":10,
+		"messages":[{
+			"role":"user",
+			"content":[{
+				"type":"tool_result",
+				"tool_use_id":"call_456",
+				"content":[
+					{"type":"text","text":"Here is the screenshot:"},
+					{"type":"image","source":{"type":"base64","media_type":"image/png","data":"` + testAnthropicImageBase64 + `"}}
+				]
+			}]
+		}]
+	}`
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, local.URL+"/v1/messages", bytes.NewBufferString(reqBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := local.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusTeapot {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected local middleware path status %d, got %d (%s)", http.StatusTeapot, resp.StatusCode, string(body))
+	}
+
+	if capture.path != "" {
+		t.Fatalf("expected no passthrough for tool_result image requests, got upstream path %q", capture.path)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fix Claude Code image-path prompts so they behave the same as drag-and-drop image attachments.

Claude Code does not send `/path/to/image.png` as a normal image attachment. It first calls `Read`, then returns the image inside an Anthropic `tool_result` content block. Ollama was not handling that path end to end consistently, so the model behaved as if no image had been provided.

## Root Cause

Drag-and-drop worked because the image arrived as a standard multimodal attachment.

File-path prompts failed because the image came back through the `Read` tool as a `tool_result`, and that flow had gaps:
- Anthropic `tool_result` image blocks were not always preserved through request conversion
- cloud `/v1/messages` requests could bypass the local Anthropic normalization path
- some multimodal renderers dropped images attached to `tool` role messages

## Changes

- parse Anthropic `tool_result` image blocks into `api.Message.Images`
- route cloud `/v1/messages` requests containing image-bearing `tool_result` blocks through local Anthropic normalization before proxying to `/api/chat`
- preserve `tool` role images in multimodal renderers
- add regression coverage for parsing, cloud fallback, streaming framing, and renderer output

## Why This Matters

This makes these two Claude Code flows equivalent:
- drag-and-drop image -> model can see image
- file path -> `Read` tool -> `tool_result` image -> model can see image

## Testing

- `go test ./anthropic -run ToolResultContainingImage`
- `go test ./server -run 'TestExplicitCloudPassthroughAPIAndV1|TestCloudPassthroughSkipsAnthropic'`
- `go test ./model/renderers -run 'Qwen3VL|GlmOcr'`

## Repro

Before:
- `can you describe this image /path/to/image.png`
- Claude calls `Read`
- `Read` returns an image
- model replies as if no image was provided

After:
- the same path-based flow is preserved and reaches the model as a real image input
