### PR TITLE
mlx: defer runtime initialization until imagegen use

### DIFF
--- a/x/imagegen/cmd/engine/main.go
+++ b/x/imagegen/cmd/engine/main.go
@@ -74,9 +74,9 @@ func main() {
 		return
 	}
 
-	// Check if MLX initialized successfully
-	if !mlx.IsMLXAvailable() {
-		log.Fatalf("MLX initialization failed: %v", mlx.GetMLXInitError())
+	// Initialize MLX only after the image generation CLI has parsed arguments.
+	if err := mlx.InitRuntime(); err != nil {
+		log.Fatalf("MLX initialization failed: %v", err)
 	}
 
 	// Restore strict error handling now that we know MLX is working.

--- a/x/imagegen/mlx/mlx.go
+++ b/x/imagegen/mlx/mlx.go
@@ -1703,8 +1703,12 @@ var (
 )
 
 var (
-	mlxInitialized bool
-	mlxInitError   error
+	mlxInitMu         sync.Mutex
+	mlxInitialized    bool
+	mlxInitError      error
+	mlxRuntimeInitMu  sync.Mutex
+	mlxRuntimeInited  bool
+	mlxRuntimeInitErr error
 )
 
 // mlxLibName returns the platform-specific shared library filename.
@@ -1787,6 +1791,9 @@ func findMLXLibrary() string {
 // This must be called before using any MLX functions.
 // Returns an error if the library cannot be loaded.
 func InitMLX() error {
+	mlxInitMu.Lock()
+	defer mlxInitMu.Unlock()
+
 	if mlxInitialized {
 		return mlxInitError
 	}
@@ -1818,6 +1825,45 @@ func InitMLX() error {
 	return nil
 }
 
+// InitRuntime initializes MLX runtime state that performs native MLX work.
+// Keep this out of package init so regular Ollama CLI/server startup does not
+// touch CUDA/MLX devices before an image generation runner actually needs them.
+func InitRuntime() error {
+	mlxRuntimeInitMu.Lock()
+	defer mlxRuntimeInitMu.Unlock()
+
+	if mlxRuntimeInited {
+		return mlxRuntimeInitErr
+	}
+
+	if err := InitMLX(); err != nil {
+		mlxRuntimeInitErr = err
+		return mlxRuntimeInitErr
+	}
+
+	// Enter safe mode: replace the default exit(-1) error handler with one
+	// that logs and stores errors. This handles MLX-reported errors, but cannot
+	// recover from native access violations.
+	C.mlx_set_safe_init_mode()
+
+	// Lock the imagegen runner goroutine to an OS thread for CUDA context
+	// stability. CUDA contexts are bound to threads; Go can migrate goroutines.
+	runtime.LockOSThread()
+	RandomState[0] = RandomKey(uint64(time.Now().UnixMilli()))
+	Keep(RandomState[0]) // Global state should persist
+
+	if C.mlx_had_init_error() != 0 {
+		msg := C.GoString(C.mlx_get_init_error())
+		mlxRuntimeInitErr = fmt.Errorf("MLX GPU init failed: %s", msg)
+		mlxInitialized = false
+		return mlxRuntimeInitErr
+	}
+
+	mlxRuntimeInited = true
+	mlxRuntimeInitErr = nil
+	return nil
+}
+
 // IsMLXAvailable returns whether MLX was successfully initialized
 func IsMLXAvailable() bool {
 	return mlxInitialized && mlxInitError == nil
@@ -1825,36 +1871,10 @@ func IsMLXAvailable() bool {
 
 // GetMLXInitError returns any error that occurred during MLX initialization
 func GetMLXInitError() error {
+	if mlxRuntimeInitErr != nil {
+		return mlxRuntimeInitErr
+	}
 	return mlxInitError
-}
-
-func init() {
-	// Initialize MLX dynamic library first
-	if err := InitMLX(); err != nil {
-		// Don't panic in init - let the caller handle the error
-		// Store the error for later retrieval
-		mlxInitError = err
-		return
-	}
-
-	// Enter safe mode: replace the default exit(-1) error handler with one
-	// that logs and stores errors. This prevents a GPU init failure from
-	// killing the entire process during startup.
-	C.mlx_set_safe_init_mode()
-
-	// Lock main goroutine to OS thread for CUDA context stability.
-	// CUDA contexts are bound to threads; Go can migrate goroutines between threads.
-	runtime.LockOSThread()
-	RandomState[0] = RandomKey(uint64(time.Now().UnixMilli()))
-	Keep(RandomState[0]) // Global state should persist
-
-	// Check if the RandomKey call silently failed under safe mode
-	if C.mlx_had_init_error() != 0 {
-		msg := C.GoString(C.mlx_get_init_error())
-		mlxInitError = fmt.Errorf("MLX GPU init failed: %s", msg)
-		mlxInitialized = false
-		return
-	}
 }
 
 // RestoreDefaultErrorHandler restores the default MLX error handler (exit on error).

--- a/x/imagegen/mlx/mlx_test.go
+++ b/x/imagegen/mlx/mlx_test.go
@@ -19,7 +19,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	if err := InitMLX(); err != nil {
+	if err := InitRuntime(); err != nil {
 		fmt.Printf("Skipping MLX tests: %v\n", err)
 		os.Exit(0)
 	}
@@ -989,10 +989,10 @@ func BenchmarkLayerLike(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		x := Ones(1, hidden)
 		// Simulate attention-like ops with proper shapes
-		h := Matmul(x, w)                  // [1, 256] @ [256, 256] = [1, 256]
-		h = Add(h, Matmul(h, w))           // residual
-		h = Mul(h, Sigmoid(Matmul(h, w)))  // gating
-		h = Matmul(h, w)                   // output projection
+		h := Matmul(x, w)                    // [1, 256] @ [256, 256] = [1, 256]
+		h = Add(h, Matmul(h, w))             // residual
+		h = Mul(h, Sigmoid(Matmul(h, w)))    // gating
+		h = Matmul(h, w)                     // output projection
 		h = Add(x, RMSNormNoWeight(h, 1e-5)) // residual + norm
 		Keep(h)
 		AsyncEval(h)

--- a/x/imagegen/nn/nn_test.go
+++ b/x/imagegen/nn/nn_test.go
@@ -22,7 +22,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	if err := mlx.InitMLX(); err != nil {
+	if err := mlx.InitRuntime(); err != nil {
 		fmt.Printf("Skipping nn tests: %v\n", err)
 		os.Exit(0)
 	}

--- a/x/imagegen/runner.go
+++ b/x/imagegen/runner.go
@@ -45,8 +45,9 @@ func Execute(args []string) error {
 		return fmt.Errorf("imagegen runner only supports image generation models")
 	}
 
-	// Initialize MLX only for image generation mode.
-	if err := mlx.InitMLX(); err != nil {
+	// Initialize MLX only for image generation mode. This does native MLX/CUDA
+	// work and must not happen during regular Ollama startup.
+	if err := mlx.InitRuntime(); err != nil {
 		slog.Error("unable to initialize MLX", "error", err)
 		return err
 	}


### PR DESCRIPTION
## Summary

This defers MLX runtime initialization until the image generation runner actually needs MLX work.
Fixes #15481

Regular Ollama startup currently imports the imagegen packages and can reach MLX package initialization, which loads MLX and creates the global random state. On Windows systems with only an integrated GPU, or systems that only use cloud models and do not have a usable CUDA runtime, that startup-time MLX/CUDA work can fail before the user gets to use non-MLX paths.

This is not intended to make integrated GPUs support MLX image generation. It keeps MLX/CUDA runtime work out of ordinary CLI/server startup so cloud-only and non-imagegen users are not blocked by a local MLX runtime failure.

## Changes

- Split MLX initialization into library/symbol loading (`InitMLX`) and runtime work (`InitRuntime`).
- Removed MLX runtime work from package initialization.
- Updated imagegen runner entry points to call `InitRuntime` explicitly.
- Updated MLX and NN tests to initialize the runtime before exercising MLX operations.

## Validation

- `git diff --check HEAD~1..HEAD`
- `go test -run '^$' ./cmd`
- `go test -run '^$' ./runner`
- `go test -run '^$' ./server`
- `go test -run '^$' ./x/imagegen/mlx ./x/imagegen/nn ./x/imagegen/safetensors ./x/imagegen/models/...`
- `go run . --version`
- `OLLAMA_LIBRARY_PATH=%LOCALAPPDATA%\Programs\Ollama\lib\ollama go run . --version`