### PR TITLE
app/ui: add global thinking toggle

### DIFF
--- a/app/ui/app/src/components/ChatForm.tsx
+++ b/app/ui/app/src/components/ChatForm.tsx
@@ -492,11 +492,13 @@ function ChatForm({
 
     const useWebSearch =
       supportsWebSearch && webSearchEnabled && !cloudDisabled;
-    const useThink = modelSupportsThinkingLevels
-      ? thinkLevel
-      : supportsThinkToggling
-        ? thinkEnabled
-        : undefined;
+    const useThink = !thinkEnabled
+      ? false
+      : modelSupportsThinkingLevels
+        ? thinkLevel
+        : supportsThinkToggling
+          ? thinkEnabled
+          : undefined;
 
     if (onSubmit) {
       onSubmit(message.content, {

--- a/app/ui/app/src/components/ChatForm.tsx
+++ b/app/ui/app/src/components/ChatForm.tsx
@@ -20,6 +20,7 @@ import { useSelectedModel } from "@/hooks/useSelectedModel";
 import {
   useHasVisionCapability,
   useHasToolsCapability,
+  useHasThinkingCapability,
   useCanToggleThinking,
   useHasThinkingLevels,
 } from "@/hooks/useModelCapabilities";
@@ -155,6 +156,7 @@ function ChatForm({
   const { cloudDisabled } = useCloudStatus();
 
   const supportsWebSearch = useHasToolsCapability(selectedModel?.model);
+  const supportsThinking = useHasThinkingCapability(selectedModel?.model);
   const supportsThinkToggling = useCanToggleThinking(selectedModel?.model);
   const modelSupportsThinkingLevels = useHasThinkingLevels(
     selectedModel?.model,
@@ -498,13 +500,15 @@ function ChatForm({
 
     const useWebSearch =
       supportsWebSearch && webSearchEnabled && !cloudDisabled;
-    const useThink = supportsThinkToggling
-      ? thinkEnabled
+    const useThink = thinkEnabled
+      ? supportsThinkToggling
         ? modelSupportsThinkingLevels
           ? thinkLevel
           : true
-        : false
-      : undefined;
+        : undefined
+      : supportsThinking
+        ? false
+        : undefined;
 
     if (onSubmit) {
       onSubmit(message.content, {

--- a/app/ui/app/src/components/ChatForm.tsx
+++ b/app/ui/app/src/components/ChatForm.tsx
@@ -148,7 +148,7 @@ function ChatForm({
   const {
     settings: {
       webSearchEnabled,
-      thinkEnabled,
+      thinkEnabled: defaultThinkEnabled,
       thinkLevel: settingsThinkLevel,
     },
     setSettings,
@@ -161,22 +161,32 @@ function ChatForm({
   const modelSupportsThinkingLevels = useHasThinkingLevels(
     selectedModel?.model,
   );
-  // Use per-chat thinking level instead of global
-  const thinkLevel: ThinkingLevel =
+  const defaultThinkLevel: ThinkingLevel =
     settingsThinkLevel === "none" || !settingsThinkLevel
       ? "medium"
       : (settingsThinkLevel as ThinkingLevel);
+  const [chatThinkEnabled, setChatThinkEnabled] =
+    useState(defaultThinkEnabled);
+  const [chatThinkLevel, setChatThinkLevel] =
+    useState<ThinkingLevel>(defaultThinkLevel);
+
+  useEffect(() => {
+    setChatThinkEnabled(defaultThinkEnabled);
+    setChatThinkLevel(defaultThinkLevel);
+  }, [chatId, defaultThinkEnabled, defaultThinkLevel]);
+
   const setThinkingLevel = (newLevel: ThinkingLevel) => {
-    setSettings({ ThinkLevel: newLevel });
+    setChatThinkEnabled(true);
+    setChatThinkLevel(newLevel);
   };
   useEffect(() => {
-    if (supportsThinkToggling && thinkEnabled && webSearchEnabled) {
+    if (supportsThinkToggling && chatThinkEnabled && webSearchEnabled) {
       setSettings({ WebSearchEnabled: false });
     }
   }, [
     selectedModel?.model,
     supportsThinkToggling,
-    thinkEnabled,
+    chatThinkEnabled,
     webSearchEnabled,
     setSettings,
   ]);
@@ -500,10 +510,10 @@ function ChatForm({
 
     const useWebSearch =
       supportsWebSearch && webSearchEnabled && !cloudDisabled;
-    const useThink = thinkEnabled
+    const useThink = chatThinkEnabled
       ? supportsThinkToggling
         ? modelSupportsThinkingLevels
-          ? thinkLevel
+          ? chatThinkLevel
           : true
         : undefined
       : supportsThinking
@@ -906,7 +916,9 @@ function ChatForm({
                       mode="thinkingLevel"
                       ref={thinkingLevelButtonRef}
                       isVisible={modelSupportsThinkingLevels}
-                      currentLevel={thinkLevel}
+                      isActive={chatThinkEnabled}
+                      currentLevel={chatThinkLevel}
+                      onToggle={() => setChatThinkEnabled(false)}
                       onLevelChange={setThinkingLevel}
                       onDropdownToggle={handleThinkingLevelDropdownToggle}
                     />
@@ -921,18 +933,16 @@ function ChatForm({
                       isVisible={
                         supportsThinkToggling && !modelSupportsThinkingLevels
                       }
-                      isActive={thinkEnabled}
+                      isActive={chatThinkEnabled}
                       onToggle={() => {
                         // DeepSeek-v3 specific - thinking and web search are mutually exclusive
                         if (supportsThinkToggling) {
-                          const enable = !thinkEnabled;
-                          setSettings({
-                            ThinkEnabled: enable,
-                            ...(enable ? { WebSearchEnabled: false } : {}),
-                          });
+                          const enable = !chatThinkEnabled;
+                          setChatThinkEnabled(enable);
+                          if (enable) setSettings({ WebSearchEnabled: false });
                           return;
                         }
-                        setSettings({ ThinkEnabled: !thinkEnabled });
+                        setChatThinkEnabled(!chatThinkEnabled);
                       }}
                     />
                   </>
@@ -947,9 +957,9 @@ function ChatForm({
                     }
                     const enable = !webSearchEnabled;
                     if (supportsThinkToggling && enable) {
+                      setChatThinkEnabled(false);
                       setSettings({
                         WebSearchEnabled: true,
-                        ThinkEnabled: false,
                       });
                       return;
                     }

--- a/app/ui/app/src/components/ChatForm.tsx
+++ b/app/ui/app/src/components/ChatForm.tsx
@@ -20,6 +20,8 @@ import { useSelectedModel } from "@/hooks/useSelectedModel";
 import {
   useHasVisionCapability,
   useHasToolsCapability,
+  useCanToggleThinking,
+  useHasThinkingLevels,
 } from "@/hooks/useModelCapabilities";
 import { useUser } from "@/hooks/useUser";
 import { DisplayLogin } from "@/components/DisplayLogin";
@@ -153,6 +155,10 @@ function ChatForm({
   const { cloudDisabled } = useCloudStatus();
 
   const supportsWebSearch = useHasToolsCapability(selectedModel?.model);
+  const supportsThinkToggling = useCanToggleThinking(selectedModel?.model);
+  const modelSupportsThinkingLevels = useHasThinkingLevels(
+    selectedModel?.model,
+  );
   // Use per-chat thinking level instead of global
   const thinkLevel: ThinkingLevel =
     settingsThinkLevel === "none" || !settingsThinkLevel
@@ -161,12 +167,6 @@ function ChatForm({
   const setThinkingLevel = (newLevel: ThinkingLevel) => {
     setSettings({ ThinkLevel: newLevel });
   };
-
-  const modelSupportsThinkingLevels =
-    selectedModel?.model.toLowerCase().startsWith("gpt-oss") || false;
-  const supportsThinkToggling =
-    selectedModel?.model.toLowerCase().startsWith("deepseek-v3.1") || false;
-
   useEffect(() => {
     if (supportsThinkToggling && thinkEnabled && webSearchEnabled) {
       setSettings({ WebSearchEnabled: false });
@@ -228,7 +228,7 @@ function ChatForm({
         }));
       }
     },
-    [],
+    [modelSupportsThinkingLevels],
   );
 
   useEffect(() => {
@@ -466,7 +466,13 @@ function ChatForm({
       window.removeEventListener("keydown", handleKeyDown);
       document.removeEventListener("paste", handlePaste);
     };
-  }, [isStreaming, editingMessage, onCancelEdit, navigateToNextElement]);
+  }, [
+    isStreaming,
+    editingMessage,
+    onCancelEdit,
+    navigateToNextElement,
+    modelSupportsThinkingLevels,
+  ]);
 
   const handleSubmit = async () => {
     if (!message.content.trim() || isStreaming || isDownloading) return;
@@ -492,13 +498,13 @@ function ChatForm({
 
     const useWebSearch =
       supportsWebSearch && webSearchEnabled && !cloudDisabled;
-    const useThink = !thinkEnabled
-      ? false
-      : modelSupportsThinkingLevels
-        ? thinkLevel
-        : supportsThinkToggling
-          ? thinkEnabled
-          : undefined;
+    const useThink = supportsThinkToggling
+      ? thinkEnabled
+        ? modelSupportsThinkingLevels
+          ? thinkLevel
+          : true
+        : false
+      : undefined;
 
     if (onSubmit) {
       onSubmit(message.content, {

--- a/app/ui/app/src/components/Settings.tsx
+++ b/app/ui/app/src/components/Settings.tsx
@@ -16,6 +16,7 @@ import {
   CogIcon,
   ArrowLeftIcon,
   ArrowDownTrayIcon,
+  LightBulbIcon,
 } from "@heroicons/react/20/solid";
 import { Settings as SettingsType } from "@/gotypes";
 import { useNavigate } from "@tanstack/react-router";
@@ -560,6 +561,29 @@ export default function Settings() {
                         ]}
                       />
                     </div>
+                  </div>
+                </div>
+              </Field>
+
+              {/* Reasoning / Thinking */}
+              <Field>
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex items-start space-x-3 flex-1">
+                    <LightBulbIcon className="mt-1 h-5 w-5 flex-shrink-0 text-black dark:text-neutral-100" />
+                    <div>
+                      <Label>Reasoning/Thinking</Label>
+                      <Description>
+                        Enable reasoning/thinking on all supported models.
+                      </Description>
+                    </div>
+                  </div>
+                  <div className="flex-shrink-0">
+                    <Switch
+                      checked={settings.ThinkEnabled}
+                      onChange={(checked) =>
+                        handleChange("ThinkEnabled", checked)
+                      }
+                    />
                   </div>
                 </div>
               </Field>

--- a/app/ui/app/src/components/ThinkButton.tsx
+++ b/app/ui/app/src/components/ThinkButton.tsx
@@ -69,16 +69,18 @@ export const ThinkButton = forwardRef<HTMLButtonElement, ThinkButtonProps>(
 
     if (!isVisible) return null;
 
+    const activeClass =
+      "text-[rgba(0,115,255,1)] dark:text-[rgba(70,155,255,1)] ring-2 ring-[rgba(0,115,255,0.28)] dark:ring-[rgba(70,155,255,0.32)]";
+    const inactiveClass = "text-neutral-500 dark:text-neutral-400 ring-0";
+
     if (mode === "think") {
       return (
         <button
           ref={ref}
           title={isActive ? "Disable think mode" : "Enable think mode"}
           onClick={onToggle}
-          className={`select-none flex items-center justify-center rounded-full h-9 w-9 bg-white dark:bg-neutral-700 focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-pointer transition-all whitespace-nowrap border border-transparent ${
-            isActive
-              ? "text-[rgba(0,115,255,1)] dark:text-[rgba(70,155,255,1)]"
-              : "text-neutral-500 dark:text-neutral-400"
+          className={`select-none flex items-center justify-center rounded-full h-9 w-9 bg-white dark:bg-neutral-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 cursor-pointer transition-all whitespace-nowrap border border-transparent ${
+            isActive ? activeClass : inactiveClass
           }`}
         >
           <svg
@@ -94,20 +96,25 @@ export const ThinkButton = forwardRef<HTMLButtonElement, ThinkButtonProps>(
     }
 
     // thinkingLevel mode
-    const displayLabel = currentLevel
-      ? THINKING_LEVEL_LABELS[currentLevel]
-      : "";
+    const displayLabel =
+      isActive && currentLevel ? THINKING_LEVEL_LABELS[currentLevel] : "Off";
     return (
       <div className="relative" ref={dropdownRef}>
         <button
           ref={ref}
-          title={`Thinking level: ${displayLabel}`}
+          title={
+            isActive
+              ? `Thinking level: ${displayLabel}`
+              : "Thinking disabled"
+          }
           onClick={() => {
             const newState = !isDropdownOpen;
             setIsDropdownOpen(newState);
             onDropdownToggle?.(newState);
           }}
-          className={`select-none flex items-center justify-center gap-1 rounded-full h-9 px-3 bg-white dark:bg-neutral-700 focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-pointer transition-all whitespace-nowrap border border-transparent text-[rgba(0,115,255,1)] dark:text-[rgba(70,155,255,1)]`}
+          className={`select-none flex items-center justify-center gap-1 rounded-full h-9 px-3 bg-white dark:bg-neutral-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 cursor-pointer transition-all whitespace-nowrap border border-transparent ${
+            isActive ? activeClass : inactiveClass
+          }`}
         >
           <div className="justify-center items-center flex space-x-2">
             <svg
@@ -137,6 +144,17 @@ export const ThinkButton = forwardRef<HTMLButtonElement, ThinkButtonProps>(
 
         {isDropdownOpen && (
           <div className="absolute bottom-full mb-2 text-[15px] rounded-2xl overflow-hidden bg-white border border-neutral-100 text-neutral-800 shadow-xl shadow-black/5 backdrop-blur-lg dark:border-neutral-600/40 dark:bg-neutral-800 dark:text-white dark:ring-black/20 min-w-[120px]">
+            <button
+              className={`w-full text-left px-3 py-2 cursor-pointer hover:bg-neutral-100 dark:hover:bg-neutral-700 transition-colors text-neutral-700 dark:text-neutral-300 ${
+                !isActive ? "bg-neutral-100 dark:bg-neutral-700/60" : ""
+              }`}
+              onClick={() => {
+                onToggle?.();
+                setIsDropdownOpen(false);
+              }}
+            >
+              Off
+            </button>
             {Object.entries(THINKING_LEVELS).map(([, level]) => (
               <button
                 key={level}

--- a/app/ui/app/src/hooks/useModelCapabilities.ts
+++ b/app/ui/app/src/hooks/useModelCapabilities.ts
@@ -25,3 +25,13 @@ export function useHasToolsCapability(modelName: string | undefined) {
   const { data: capabilitiesResponse } = useModelCapabilities(modelName);
   return capabilitiesResponse?.capabilities?.includes("tools") ?? false;
 }
+
+export function useCanToggleThinking(modelName: string | undefined) {
+  const { data: capabilitiesResponse } = useModelCapabilities(modelName);
+  return capabilitiesResponse?.capabilities?.includes("thinking_toggle") ?? false;
+}
+
+export function useHasThinkingLevels(modelName: string | undefined) {
+  const { data: capabilitiesResponse } = useModelCapabilities(modelName);
+  return capabilitiesResponse?.capabilities?.includes("thinking_levels") ?? false;
+}

--- a/app/ui/app/src/hooks/useModelCapabilities.ts
+++ b/app/ui/app/src/hooks/useModelCapabilities.ts
@@ -26,6 +26,11 @@ export function useHasToolsCapability(modelName: string | undefined) {
   return capabilitiesResponse?.capabilities?.includes("tools") ?? false;
 }
 
+export function useHasThinkingCapability(modelName: string | undefined) {
+  const { data: capabilitiesResponse } = useModelCapabilities(modelName);
+  return capabilitiesResponse?.capabilities?.includes("thinking") ?? false;
+}
+
 export function useCanToggleThinking(modelName: string | undefined) {
   const { data: capabilitiesResponse } = useModelCapabilities(modelName);
   return capabilitiesResponse?.capabilities?.includes("thinking_toggle") ?? false;

--- a/app/ui/ui.go
+++ b/app/ui/ui.go
@@ -33,6 +33,7 @@ import (
 	ollamaAuth "github.com/ollama/ollama/auth"
 	"github.com/ollama/ollama/envconfig"
 	"github.com/ollama/ollama/manifest"
+	"github.com/ollama/ollama/model/parsers"
 	"github.com/ollama/ollama/types/model"
 	_ "github.com/tkrajina/typescriptify-golang-structs/typescriptify"
 )
@@ -296,7 +297,7 @@ func (s *Server) Handler() http.Handler {
 	// Ollama proxy endpoints
 	ollamaProxy := s.ollamaProxy()
 	mux.Handle("GET /api/tags", ollamaProxy)
-	mux.Handle("POST /api/show", ollamaProxy)
+	mux.Handle("POST /api/show", handle(s.showModel))
 	mux.Handle("GET /api/version", ollamaProxy)
 	mux.Handle("GET /api/status", ollamaProxy)
 	mux.Handle("HEAD /api/version", ollamaProxy)
@@ -350,6 +351,32 @@ func (s *Server) httpClient() *http.Client {
 // long requests aren't truncated
 func (s *Server) inferenceClient() *api.Client {
 	return api.NewClient(envconfig.Host(), userAgentHTTPClient(0))
+}
+
+func (s *Server) showModel(w http.ResponseWriter, r *http.Request) error {
+	if err := WaitForServer(r.Context(), 10*time.Second); err != nil {
+		return err
+	}
+
+	var req api.ShowRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return fmt.Errorf("invalid request body: %w", err)
+	}
+	if req.Model == "" {
+		req.Model = req.Name
+	}
+	if req.Model == "" {
+		return fmt.Errorf("model is required")
+	}
+
+	resp, err := s.inferenceClient().Show(r.Context(), &req)
+	if err != nil {
+		return err
+	}
+
+	normalizeAppShowCapabilities(resp)
+	w.Header().Set("Content-Type", "application/json")
+	return json.NewEncoder(w).Encode(resp)
 }
 
 func userAgentHTTPClient(timeout time.Duration) *http.Client {
@@ -1691,13 +1718,94 @@ func supportsBrowserTools(model string) bool {
 }
 
 func resolveChatThinkValue(settings store.Settings, requestThink any, modelSupportsThinking bool) any {
-	if !settings.ThinkEnabled {
-		return false
-	}
 	if requestThink != nil {
 		return requestThink
 	}
+	if !settings.ThinkEnabled {
+		return false
+	}
 	return modelSupportsThinking
+}
+
+func normalizeAppShowCapabilities(resp *api.ShowResponse) {
+	if resp == nil || !slices.Contains(resp.Capabilities, model.CapabilityThinking) {
+		return
+	}
+
+	if isGptOSSShowResponse(resp) {
+		appendShowCapability(resp, model.CapabilityThinkingToggle)
+		appendShowCapability(resp, model.CapabilityThinkingLevels)
+		return
+	}
+
+	if slices.Contains(resp.Capabilities, model.CapabilityThinkingToggle) {
+		return
+	}
+
+	for _, parserName := range showCapabilityParserCandidates(resp) {
+		parser := parsers.ParserForName(parserName)
+		if parser == nil {
+			parser = parsers.ParserForArchitecture(parserName)
+		}
+		if parser == nil {
+			continue
+		}
+		if parser.HasThinkingSupport() && parser.CanToggleThinking() {
+			appendShowCapability(resp, model.CapabilityThinkingToggle)
+			return
+		}
+	}
+}
+
+func appendShowCapability(resp *api.ShowResponse, cap model.Capability) {
+	if !slices.Contains(resp.Capabilities, cap) {
+		resp.Capabilities = append(resp.Capabilities, cap)
+	}
+}
+
+func isGptOSSShowResponse(resp *api.ShowResponse) bool {
+	for _, candidate := range showCapabilityParserCandidates(resp) {
+		if candidate == "gptoss" || candidate == "gpt-oss" {
+			return true
+		}
+	}
+	return false
+}
+
+func showCapabilityParserCandidates(resp *api.ShowResponse) []string {
+	rawCandidates := []string{
+		resp.Parser,
+		resp.Details.Family,
+		resp.Details.ParentModel,
+		resp.RemoteModel,
+	}
+	for _, key := range []string{"general.architecture", "general.basename"} {
+		if value, ok := resp.ModelInfo[key].(string); ok {
+			rawCandidates = append(rawCandidates, value)
+		}
+	}
+
+	candidates := make([]string, 0, len(rawCandidates)*2)
+	seen := map[string]struct{}{}
+	add := func(s string) {
+		s = strings.TrimSpace(strings.ToLower(s))
+		if s == "" {
+			return
+		}
+		if base, _, ok := strings.Cut(s, ":"); ok {
+			s = base
+		}
+		if _, ok := seen[s]; ok {
+			return
+		}
+		seen[s] = struct{}{}
+		candidates = append(candidates, s)
+	}
+
+	for _, candidate := range rawCandidates {
+		add(candidate)
+	}
+	return candidates
 }
 
 // buildChatRequest converts store.Chat to api.ChatRequest

--- a/app/ui/ui.go
+++ b/app/ui/ui.go
@@ -1755,11 +1755,8 @@ func (s *Server) buildChatRequest(chat *store.Chat, model string, think any, ava
 
 	var thinkValue *api.ThinkValue
 	if think != nil {
-		// Only set Think if it's actually requesting thinking
 		if boolValue, ok := think.(bool); ok {
-			if boolValue {
-				thinkValue = &api.ThinkValue{Value: boolValue}
-			}
+			thinkValue = &api.ThinkValue{Value: boolValue}
 		} else if stringValue, ok := think.(string); ok {
 			if stringValue != "" && stringValue != "none" {
 				thinkValue = &api.ThinkValue{Value: stringValue}

--- a/app/ui/ui.go
+++ b/app/ui/ui.go
@@ -816,14 +816,15 @@ func (s *Server) chat(w http.ResponseWriter, r *http.Request) error {
 		return nil
 	}
 	think := slices.Contains(details.Capabilities, model.CapabilityThinking)
-
-	var thinkValue any
-
-	if req.Think != nil {
-		thinkValue = req.Think
-	} else {
-		thinkValue = think
+	settings, err := s.Store.Settings()
+	if err != nil {
+		errorEvent := s.getError(err)
+		json.NewEncoder(w).Encode(errorEvent)
+		flusher.Flush()
+		return fmt.Errorf("failed to get settings: %w", err)
 	}
+
+	thinkValue := resolveChatThinkValue(settings, req.Think, think)
 
 	// Check if the last user message has attachments
 	// TODO (parthsareen): this logic will change with directory drag and drop
@@ -1687,6 +1688,16 @@ func ptr[T any](v T) *T { return &v }
 // Browser tools simulate a full browser environment, allowing for actions like searching, opening, and interacting with web pages (e.g., "browser_search", "browser_open", "browser_find"). Currently only gpt-oss models support browser tools.
 func supportsBrowserTools(model string) bool {
 	return strings.HasPrefix(strings.ToLower(model), "gpt-oss")
+}
+
+func resolveChatThinkValue(settings store.Settings, requestThink any, modelSupportsThinking bool) any {
+	if !settings.ThinkEnabled {
+		return false
+	}
+	if requestThink != nil {
+		return requestThink
+	}
+	return modelSupportsThinking
 }
 
 // buildChatRequest converts store.Chat to api.ChatRequest

--- a/app/ui/ui_test.go
+++ b/app/ui/ui_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -18,6 +19,7 @@ import (
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/app/store"
 	"github.com/ollama/ollama/app/updater"
+	"github.com/ollama/ollama/types/model"
 )
 
 func TestHandlePostApiSettings(t *testing.T) {
@@ -676,9 +678,15 @@ func TestResolveChatThinkValue(t *testing.T) {
 			want:                  false,
 		},
 		{
-			name:         "global setting off overrides explicit request",
+			name:         "explicit request overrides global setting off",
 			settings:     store.Settings{ThinkEnabled: false},
 			requestThink: true,
+			want:         true,
+		},
+		{
+			name:         "explicit false overrides global setting on",
+			settings:     store.Settings{ThinkEnabled: true},
+			requestThink: false,
 			want:         false,
 		},
 		{
@@ -706,6 +714,82 @@ func TestResolveChatThinkValue(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := resolveChatThinkValue(tt.settings, tt.requestThink, tt.modelSupportsThinking); got != tt.want {
 				t.Errorf("resolveChatThinkValue() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeAppShowCapabilitiesThinkingControls(t *testing.T) {
+	tests := []struct {
+		name string
+		resp *api.ShowResponse
+		want []model.Capability
+	}{
+		{
+			name: "qwen adds thinking toggle",
+			resp: &api.ShowResponse{
+				Capabilities: []model.Capability{model.CapabilityCompletion, model.CapabilityThinking},
+				Details:      api.ModelDetails{Family: "qwen3.5"},
+			},
+			want: []model.Capability{model.CapabilityCompletion, model.CapabilityThinking, model.CapabilityThinkingToggle},
+		},
+		{
+			name: "gemma parent adds thinking toggle",
+			resp: &api.ShowResponse{
+				Capabilities: []model.Capability{model.CapabilityCompletion, model.CapabilityThinking},
+				Details:      api.ModelDetails{ParentModel: "gemma4:31b"},
+			},
+			want: []model.Capability{model.CapabilityCompletion, model.CapabilityThinking, model.CapabilityThinkingToggle},
+		},
+		{
+			name: "nemotron architecture adds thinking toggle",
+			resp: &api.ShowResponse{
+				Capabilities: []model.Capability{model.CapabilityCompletion, model.CapabilityThinking, model.CapabilityTools},
+				Details:      api.ModelDetails{Family: "nemotron_h_moe"},
+				ModelInfo:    map[string]any{"general.architecture": "nemotron_h_moe"},
+			},
+			want: []model.Capability{model.CapabilityCompletion, model.CapabilityThinking, model.CapabilityTools, model.CapabilityThinkingToggle},
+		},
+		{
+			name: "gpt oss adds thinking toggle and levels",
+			resp: &api.ShowResponse{
+				Capabilities: []model.Capability{model.CapabilityCompletion, model.CapabilityThinking},
+				Details:      api.ModelDetails{Family: "gptoss"},
+			},
+			want: []model.Capability{model.CapabilityCompletion, model.CapabilityThinking, model.CapabilityThinkingToggle, model.CapabilityThinkingLevels},
+		},
+		{
+			name: "non-toggle thinking model stays unchanged",
+			resp: &api.ShowResponse{
+				Capabilities: []model.Capability{model.CapabilityCompletion, model.CapabilityThinking},
+				Details:      api.ModelDetails{Family: "qwen3-vl-thinking"},
+			},
+			want: []model.Capability{model.CapabilityCompletion, model.CapabilityThinking},
+		},
+		{
+			name: "unknown cloud thinking architecture stays unchanged",
+			resp: &api.ShowResponse{
+				Capabilities: []model.Capability{model.CapabilityCompletion, model.CapabilityThinking, model.CapabilityTools},
+				Details:      api.ModelDetails{Family: "kimi-k2"},
+				ModelInfo:    map[string]any{"general.architecture": "kimi-k2"},
+			},
+			want: []model.Capability{model.CapabilityCompletion, model.CapabilityThinking, model.CapabilityTools},
+		},
+		{
+			name: "non-thinking model stays unchanged",
+			resp: &api.ShowResponse{
+				Capabilities: []model.Capability{model.CapabilityCompletion},
+				Details:      api.ModelDetails{Family: "gemma4"},
+			},
+			want: []model.Capability{model.CapabilityCompletion},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			normalizeAppShowCapabilities(tt.resp)
+			if !slices.Equal(tt.resp.Capabilities, tt.want) {
+				t.Fatalf("capabilities = %v, want %v", tt.resp.Capabilities, tt.want)
 			}
 		})
 	}

--- a/app/ui/ui_test.go
+++ b/app/ui/ui_test.go
@@ -661,6 +661,56 @@ func TestWebSearchToolRegistration(t *testing.T) {
 	}
 }
 
+func TestResolveChatThinkValue(t *testing.T) {
+	tests := []struct {
+		name                  string
+		settings              store.Settings
+		requestThink          any
+		modelSupportsThinking bool
+		want                  any
+	}{
+		{
+			name:                  "global setting off overrides model thinking default",
+			settings:              store.Settings{ThinkEnabled: false},
+			modelSupportsThinking: true,
+			want:                  false,
+		},
+		{
+			name:         "global setting off overrides explicit request",
+			settings:     store.Settings{ThinkEnabled: false},
+			requestThink: true,
+			want:         false,
+		},
+		{
+			name:                  "global setting on uses explicit request",
+			settings:              store.Settings{ThinkEnabled: true},
+			requestThink:          "high",
+			modelSupportsThinking: true,
+			want:                  "high",
+		},
+		{
+			name:                  "global setting on defaults to model thinking capability",
+			settings:              store.Settings{ThinkEnabled: true},
+			modelSupportsThinking: true,
+			want:                  true,
+		},
+		{
+			name:                  "global setting on defaults to false without model thinking capability",
+			settings:              store.Settings{ThinkEnabled: true},
+			modelSupportsThinking: false,
+			want:                  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveChatThinkValue(tt.settings, tt.requestThink, tt.modelSupportsThinking); got != tt.want {
+				t.Errorf("resolveChatThinkValue() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSettingsToggleAutoUpdateOff_CancelsDownload(t *testing.T) {
 	testStore := &store.Store{
 		DBPath: filepath.Join(t.TempDir(), "db.sqlite"),

--- a/harmony/harmonyparser.go
+++ b/harmony/harmonyparser.go
@@ -461,6 +461,11 @@ func (h *HarmonyMessageHandler) HasThinkingSupport() bool {
 	return true
 }
 
+// CanToggleThinking implements the Parser interface.
+func (h *HarmonyMessageHandler) CanToggleThinking() bool {
+	return false
+}
+
 func (m *FunctionNameMap) ConvertAndAdd(userFunctionName string) string {
 	harmonyFunctionName := m.deriveName(userFunctionName)
 	// built-in functions should not be renamed

--- a/model/parsers/cogito.go
+++ b/model/parsers/cogito.go
@@ -46,6 +46,10 @@ func (p *CogitoParser) HasThinkingSupport() bool {
 	return true
 }
 
+func (p *CogitoParser) CanToggleThinking() bool {
+	return true
+}
+
 func (p *CogitoParser) setInitialState(lastMessage *api.Message, tools []api.Tool, thinkValue *api.ThinkValue) {
 	prefill := lastMessage != nil && lastMessage.Role == "assistant"
 

--- a/model/parsers/deepseek3.go
+++ b/model/parsers/deepseek3.go
@@ -45,6 +45,10 @@ func (p *DeepSeek3Parser) HasThinkingSupport() bool {
 	return p.hasThinkingSupport
 }
 
+func (p *DeepSeek3Parser) CanToggleThinking() bool {
+	return p.hasThinkingSupport
+}
+
 func (p *DeepSeek3Parser) setInitialState(lastMessage *api.Message, tools []api.Tool, thinkValue *api.ThinkValue) {
 	prefill := lastMessage != nil && lastMessage.Role == "assistant"
 

--- a/model/parsers/functiongemma.go
+++ b/model/parsers/functiongemma.go
@@ -30,6 +30,7 @@ type FunctionGemmaParser struct {
 
 func (p *FunctionGemmaParser) HasToolSupport() bool     { return true }
 func (p *FunctionGemmaParser) HasThinkingSupport() bool { return false }
+func (p *FunctionGemmaParser) CanToggleThinking() bool  { return false }
 
 func (p *FunctionGemmaParser) Init(tools []api.Tool, lastMessage *api.Message, thinkValue *api.ThinkValue) []api.Tool {
 	p.tools = tools

--- a/model/parsers/gemma4.go
+++ b/model/parsers/gemma4.go
@@ -52,6 +52,10 @@ func (p *Gemma4Parser) HasThinkingSupport() bool {
 	return p.hasThinkingSupport
 }
 
+func (p *Gemma4Parser) CanToggleThinking() bool {
+	return p.hasThinkingSupport
+}
+
 func (p *Gemma4Parser) Init(tools []api.Tool, lastMessage *api.Message, thinkValue *api.ThinkValue) []api.Tool {
 	p.tools = tools
 	p.callIndex = 0

--- a/model/parsers/glm46.go
+++ b/model/parsers/glm46.go
@@ -46,6 +46,10 @@ func (p *GLM46Parser) HasThinkingSupport() bool {
 	return true
 }
 
+func (p *GLM46Parser) CanToggleThinking() bool {
+	return false
+}
+
 // func (p *GLM46Parser) Init(tools []api.Tool, lastMessage *api.Message) []api.Tool {
 func (p *GLM46Parser) Init(tools []api.Tool, lastMessage *api.Message, thinkValue *api.ThinkValue) []api.Tool {
 	p.tools = tools

--- a/model/parsers/glm47.go
+++ b/model/parsers/glm47.go
@@ -9,6 +9,10 @@ type GLM47Parser struct {
 	GLM46Parser
 }
 
+func (p *GLM47Parser) CanToggleThinking() bool {
+	return true
+}
+
 func (p *GLM47Parser) Init(tools []api.Tool, lastMessage *api.Message, thinkValue *api.ThinkValue) []api.Tool {
 	p.tools = tools
 	p.callIndex = 0

--- a/model/parsers/glmocr.go
+++ b/model/parsers/glmocr.go
@@ -11,6 +11,10 @@ func (p *GlmOcrParser) HasThinkingSupport() bool {
 	return false
 }
 
+func (p *GlmOcrParser) CanToggleThinking() bool {
+	return false
+}
+
 func (p *GlmOcrParser) Init(tools []api.Tool, _ *api.Message, _ *api.ThinkValue) []api.Tool {
 	p.tools = tools
 	return tools

--- a/model/parsers/laguna.go
+++ b/model/parsers/laguna.go
@@ -45,6 +45,10 @@ func (p *LagunaParser) HasThinkingSupport() bool {
 	return true
 }
 
+func (p *LagunaParser) CanToggleThinking() bool {
+	return true
+}
+
 func (p *LagunaParser) Init(tools []api.Tool, lastMessage *api.Message, thinkValue *api.ThinkValue) []api.Tool {
 	p.tools = tools
 	p.callIndex = 0

--- a/model/parsers/lfm2.go
+++ b/model/parsers/lfm2.go
@@ -45,6 +45,10 @@ func (p *LFM2Parser) HasThinkingSupport() bool {
 	return p.hasThinkingSupport
 }
 
+func (p *LFM2Parser) CanToggleThinking() bool {
+	return p.hasThinkingSupport
+}
+
 func (p *LFM2Parser) setInitialState(lastMessage *api.Message, thinkValue *api.ThinkValue) {
 	prefill := lastMessage != nil && lastMessage.Role == "assistant"
 

--- a/model/parsers/ministral.go
+++ b/model/parsers/ministral.go
@@ -57,6 +57,10 @@ func (p *MinistralParser) HasThinkingSupport() bool {
 	return p.hasThinkingSupport
 }
 
+func (p *MinistralParser) CanToggleThinking() bool {
+	return false
+}
+
 func (p *MinistralParser) setInitialState(lastMessage *api.Message) {
 	prefill := lastMessage != nil && lastMessage.Role == "assistant"
 	if !p.HasThinkingSupport() {

--- a/model/parsers/nemotron3nano.go
+++ b/model/parsers/nemotron3nano.go
@@ -31,6 +31,7 @@ type Nemotron3NanoParser struct {
 
 func (p *Nemotron3NanoParser) HasToolSupport() bool     { return true }
 func (p *Nemotron3NanoParser) HasThinkingSupport() bool { return true }
+func (p *Nemotron3NanoParser) CanToggleThinking() bool  { return true }
 
 func (p *Nemotron3NanoParser) Init(tools []api.Tool, lastMessage *api.Message, thinkValue *api.ThinkValue) []api.Tool {
 	p.toolParser = &Qwen3CoderParser{}

--- a/model/parsers/olmo3.go
+++ b/model/parsers/olmo3.go
@@ -39,6 +39,10 @@ func (p *Olmo3Parser) HasThinkingSupport() bool {
 	return false
 }
 
+func (p *Olmo3Parser) CanToggleThinking() bool {
+	return false
+}
+
 func (p *Olmo3Parser) Init(tools []api.Tool, lastMessage *api.Message, thinkValue *api.ThinkValue) []api.Tool {
 	p.state = olmo3StateContent
 	p.callIndex = 0

--- a/model/parsers/olmo3_think.go
+++ b/model/parsers/olmo3_think.go
@@ -34,6 +34,10 @@ func (p *Olmo3ThinkParser) HasThinkingSupport() bool {
 	return true
 }
 
+func (p *Olmo3ThinkParser) CanToggleThinking() bool {
+	return false
+}
+
 func (p *Olmo3ThinkParser) setInitialState(lastMessage *api.Message) {
 	prefill := lastMessage != nil && lastMessage.Role == "assistant"
 

--- a/model/parsers/parsers.go
+++ b/model/parsers/parsers.go
@@ -18,6 +18,7 @@ type Parser interface {
 	Add(s string, done bool) (content string, thinking string, calls []api.ToolCall, err error)
 	HasToolSupport() bool
 	HasThinkingSupport() bool
+	CanToggleThinking() bool
 }
 
 type ParserConstructor func() Parser
@@ -110,6 +111,10 @@ func (p *PassthroughParser) HasToolSupport() bool {
 }
 
 func (p *PassthroughParser) HasThinkingSupport() bool {
+	return false
+}
+
+func (p *PassthroughParser) CanToggleThinking() bool {
 	return false
 }
 

--- a/model/parsers/parsers.go
+++ b/model/parsers/parsers.go
@@ -39,6 +39,26 @@ func Register(name string, constructor ParserConstructor) {
 	registry.Register(name, constructor)
 }
 
+func ParserNameForArchitecture(arch string) string {
+	switch strings.TrimSpace(arch) {
+	case "gemma4":
+		return "gemma4"
+	case "laguna":
+		return "laguna"
+	case "nemotron_h", "nemotron_h_moe", "nemotron_h_omni":
+		return "nemotron-3-nano"
+	default:
+		return ""
+	}
+}
+
+func ParserForArchitecture(arch string) Parser {
+	if name := ParserNameForArchitecture(arch); name != "" {
+		return ParserForName(name)
+	}
+	return nil
+}
+
 func ParserForName(name string) Parser {
 	if parser, ok := registry.constructors[name]; ok {
 		return parser()

--- a/model/parsers/parsers_test.go
+++ b/model/parsers/parsers_test.go
@@ -27,6 +27,52 @@ func (m *mockParser) HasThinkingSupport() bool {
 	return false
 }
 
+func (m *mockParser) CanToggleThinking() bool {
+	return false
+}
+
+func TestCanToggleThinking(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{name: "qwen3", want: false},
+		{name: "qwen3-thinking", want: true},
+		{name: "qwen3.5", want: true},
+		{name: "qwen3-coder", want: false},
+		{name: "qwen3-vl-instruct", want: false},
+		{name: "qwen3-vl-thinking", want: false},
+		{name: "ministral", want: false},
+		{name: "passthrough", want: false},
+		{name: "harmony", want: false},
+		{name: "cogito", want: true},
+		{name: "deepseek3", want: true},
+		{name: "olmo3", want: false},
+		{name: "olmo3-think", want: false},
+		{name: "nemotron-3-nano", want: true},
+		{name: "functiongemma", want: false},
+		{name: "glm-4.7", want: true},
+		{name: "gemma4", want: true},
+		{name: "gemma4-no-thinking", want: false},
+		{name: "glm-ocr", want: false},
+		{name: "lfm2", want: false},
+		{name: "lfm2-thinking", want: true},
+		{name: "laguna", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := ParserForName(tt.name)
+			if parser == nil {
+				t.Fatalf("expected parser %q to exist", tt.name)
+			}
+			if got := parser.CanToggleThinking(); got != tt.want {
+				t.Errorf("CanToggleThinking() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRegisterCustomParser(t *testing.T) {
 	// Register a custom parser
 	Register("custom-parser", func() Parser {

--- a/model/parsers/parsers_test.go
+++ b/model/parsers/parsers_test.go
@@ -73,6 +73,44 @@ func TestCanToggleThinking(t *testing.T) {
 	}
 }
 
+func TestParserForArchitecture(t *testing.T) {
+	tests := []struct {
+		arch       string
+		wantParser string
+		wantToggle bool
+	}{
+		{arch: "gemma4", wantParser: "gemma4", wantToggle: true},
+		{arch: "laguna", wantParser: "laguna", wantToggle: true},
+		{arch: "nemotron_h", wantParser: "nemotron-3-nano", wantToggle: true},
+		{arch: "nemotron_h_moe", wantParser: "nemotron-3-nano", wantToggle: true},
+		{arch: "nemotron_h_omni", wantParser: "nemotron-3-nano", wantToggle: true},
+		{arch: "glm5.1"},
+		{arch: "kimi-k2"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.arch, func(t *testing.T) {
+			if got := ParserNameForArchitecture(tt.arch); got != tt.wantParser {
+				t.Fatalf("ParserNameForArchitecture() = %q, want %q", got, tt.wantParser)
+			}
+
+			parser := ParserForArchitecture(tt.arch)
+			if tt.wantParser == "" {
+				if parser != nil {
+					t.Fatalf("ParserForArchitecture() = %#v, want nil", parser)
+				}
+				return
+			}
+			if parser == nil {
+				t.Fatalf("ParserForArchitecture() = nil, want parser")
+			}
+			if got := parser.CanToggleThinking(); got != tt.wantToggle {
+				t.Fatalf("CanToggleThinking() = %v, want %v", got, tt.wantToggle)
+			}
+		})
+	}
+}
+
 func TestRegisterCustomParser(t *testing.T) {
 	// Register a custom parser
 	Register("custom-parser", func() Parser {

--- a/model/parsers/qwen3.go
+++ b/model/parsers/qwen3.go
@@ -52,6 +52,10 @@ func (p *Qwen3Parser) HasThinkingSupport() bool {
 	return p.hasThinkingSupport
 }
 
+func (p *Qwen3Parser) CanToggleThinking() bool {
+	return p.hasThinkingSupport
+}
+
 func (p *Qwen3Parser) Init(tools []api.Tool, lastMessage *api.Message, thinkValue *api.ThinkValue) []api.Tool {
 	p.tools = tools
 	p.buffer.Reset()

--- a/model/parsers/qwen35.go
+++ b/model/parsers/qwen35.go
@@ -44,6 +44,10 @@ func (p *Qwen35Parser) HasThinkingSupport() bool {
 	return true
 }
 
+func (p *Qwen35Parser) CanToggleThinking() bool {
+	return true
+}
+
 func (p *Qwen35Parser) Init(tools []api.Tool, lastMessage *api.Message, thinkValue *api.ThinkValue) []api.Tool {
 	p.buffer.Reset()
 	p.toolParser = Qwen3CoderParser{}

--- a/model/parsers/qwen3coder.go
+++ b/model/parsers/qwen3coder.go
@@ -43,6 +43,10 @@ func (p *Qwen3CoderParser) HasThinkingSupport() bool {
 	return false
 }
 
+func (p *Qwen3CoderParser) CanToggleThinking() bool {
+	return false
+}
+
 func (p *Qwen3CoderParser) Init(tools []api.Tool, lastMessage *api.Message, thinkValue *api.ThinkValue) []api.Tool {
 	p.tools = tools
 	p.callIndex = 0

--- a/model/parsers/qwen3vl.go
+++ b/model/parsers/qwen3vl.go
@@ -40,6 +40,10 @@ func (p *Qwen3VLParser) HasThinkingSupport() bool {
 	return p.hasThinkingSupport
 }
 
+func (p *Qwen3VLParser) CanToggleThinking() bool {
+	return false
+}
+
 func (p *Qwen3VLParser) setInitialState(lastMessage *api.Message) {
 	prefill := lastMessage != nil && lastMessage.Role == "assistant"
 	if !p.HasThinkingSupport() {

--- a/server/images.go
+++ b/server/images.go
@@ -146,17 +146,21 @@ func (m *Model) Capabilities() []model.Capability {
 		capabilities = append(capabilities, model.CapabilityVision)
 	}
 
-	// Skip the thinking check if it's already set
-	if slices.Contains(capabilities, "thinking") {
-		return capabilities
-	}
-
 	// Check for thinking capability
 	openingTag, closingTag := thinking.InferTags(m.Template.Template)
 	hasTags := openingTag != "" && closingTag != ""
 	isGptoss := slices.Contains([]string{"gptoss", "gpt-oss"}, m.Config.ModelFamily)
 	if hasTags || isGptoss || (builtinParser != nil && builtinParser.HasThinkingSupport()) {
-		capabilities = append(capabilities, model.CapabilityThinking)
+		if !slices.Contains(capabilities, model.CapabilityThinking) {
+			capabilities = append(capabilities, model.CapabilityThinking)
+		}
+		canToggleThinking := hasTags || isGptoss || (builtinParser != nil && builtinParser.CanToggleThinking())
+		if !slices.Contains(capabilities, model.CapabilityThinkingToggle) && canToggleThinking {
+			capabilities = append(capabilities, model.CapabilityThinkingToggle)
+		}
+		if !slices.Contains(capabilities, model.CapabilityThinkingLevels) && isGptoss {
+			capabilities = append(capabilities, model.CapabilityThinkingLevels)
+		}
 	}
 
 	// Temporary workaround — suppress vision/audio for gemma4 MLX models

--- a/server/images_test.go
+++ b/server/images_test.go
@@ -90,6 +90,11 @@ func TestModelCapabilities(t *testing.T) {
 		t.Fatalf("Failed to parse template: %v", err)
 	}
 
+	thinkingTemplate, err := template.Parse("{{ range .Messages }}{{ if .Thinking }}<think>{{ .Thinking }}</think>{{ end }}{{ end }}{{ .prompt }}")
+	if err != nil {
+		t.Fatalf("Failed to parse template: %v", err)
+	}
+
 	testModels := []struct {
 		name         string
 		model        Model
@@ -161,6 +166,39 @@ func TestModelCapabilities(t *testing.T) {
 				Template:  chatTemplate,
 			},
 			expectedCaps: []model.Capability{model.CapabilityEmbedding},
+		},
+		{
+			name: "parser thinking support with toggle support",
+			model: Model{
+				ModelPath: completionModelPath,
+				Template:  chatTemplate,
+				Config: model.ConfigV2{
+					Parser: "gemma4",
+				},
+			},
+			expectedCaps: []model.Capability{model.CapabilityCompletion, model.CapabilityTools, model.CapabilityThinking, model.CapabilityThinkingToggle},
+		},
+		{
+			name: "parser thinking support without toggle support",
+			model: Model{
+				ModelPath: completionModelPath,
+				Template:  chatTemplate,
+				Config: model.ConfigV2{
+					Parser: "qwen3-vl-thinking",
+				},
+			},
+			expectedCaps: []model.Capability{model.CapabilityCompletion, model.CapabilityTools, model.CapabilityThinking},
+		},
+		{
+			name: "config thinking support with template toggle support",
+			model: Model{
+				ModelPath: completionModelPath,
+				Template:  thinkingTemplate,
+				Config: model.ConfigV2{
+					Capabilities: []string{"thinking"},
+				},
+			},
+			expectedCaps: []model.Capability{model.CapabilityCompletion, model.CapabilityThinking, model.CapabilityThinkingToggle},
 		},
 		{
 			name: "gemma4 small safetensors suppresses vision and audio",

--- a/server/routes.go
+++ b/server/routes.go
@@ -1154,6 +1154,14 @@ func (s *Server) ShowHandler(c *gin.Context) {
 				ctx = c.Request.Context()
 			}
 			if resp, ok := s.modelCaches.show.GetCloudSWR(ctx, req); ok {
+				normalizeShowCapabilities(resp)
+				c.JSON(http.StatusOK, resp)
+				return
+			}
+			resp, err := s.modelCaches.show.fetchCloudShow(ctx, req.Model, req.Verbose)
+			if err == nil {
+				normalizeShowCapabilities(resp)
+				s.modelCaches.show.setCloud(modelShowCloudKeyForModel(req.Model, req.Verbose), resp)
 				c.JSON(http.StatusOK, resp)
 				return
 			}
@@ -1184,6 +1192,7 @@ func (s *Server) ShowHandler(c *gin.Context) {
 		}
 		return
 	}
+	normalizeShowCapabilities(resp)
 
 	if modelRef.Source == modelSourceLocal && resp.RemoteHost != "" {
 		c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("model '%s' not found", modelRef.Original)})
@@ -1202,6 +1211,87 @@ func (s *Server) ShowHandler(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, resp)
+}
+
+func normalizeShowCapabilities(resp *api.ShowResponse) {
+	if resp == nil || !slices.Contains(resp.Capabilities, model.CapabilityThinking) {
+		return
+	}
+
+	if isGptOSSFamily(resp) {
+		appendCapability(resp, model.CapabilityThinkingToggle)
+		appendCapability(resp, model.CapabilityThinkingLevels)
+		return
+	}
+
+	if slices.Contains(resp.Capabilities, model.CapabilityThinkingToggle) {
+		return
+	}
+
+	for _, parserName := range showCapabilityParserCandidates(resp) {
+		parser := parsers.ParserForName(parserName)
+		if parser == nil {
+			parser = parsers.ParserForArchitecture(parserName)
+		}
+		if parser == nil {
+			continue
+		}
+		if parser.HasThinkingSupport() && parser.CanToggleThinking() {
+			appendCapability(resp, model.CapabilityThinkingToggle)
+			return
+		}
+	}
+}
+
+func appendCapability(resp *api.ShowResponse, cap model.Capability) {
+	if !slices.Contains(resp.Capabilities, cap) {
+		resp.Capabilities = append(resp.Capabilities, cap)
+	}
+}
+
+func isGptOSSFamily(resp *api.ShowResponse) bool {
+	for _, candidate := range showCapabilityParserCandidates(resp) {
+		if candidate == "gptoss" || candidate == "gpt-oss" {
+			return true
+		}
+	}
+	return false
+}
+
+func showCapabilityParserCandidates(resp *api.ShowResponse) []string {
+	rawCandidates := []string{
+		resp.Parser,
+		resp.Details.Family,
+		resp.Details.ParentModel,
+		resp.RemoteModel,
+	}
+	for _, key := range []string{"general.architecture", "general.basename"} {
+		if value, ok := resp.ModelInfo[key].(string); ok {
+			rawCandidates = append(rawCandidates, value)
+		}
+	}
+
+	candidates := make([]string, 0, len(rawCandidates)*2)
+	seen := map[string]struct{}{}
+	add := func(s string) {
+		s = strings.TrimSpace(strings.ToLower(s))
+		if s == "" {
+			return
+		}
+		if base, _, ok := strings.Cut(s, ":"); ok {
+			s = base
+		}
+		if _, ok := seen[s]; ok {
+			return
+		}
+		seen[s] = struct{}{}
+		candidates = append(candidates, s)
+	}
+
+	for _, candidate := range rawCandidates {
+		add(candidate)
+	}
+	return candidates
 }
 
 func GetModelInfo(req api.ShowRequest) (*api.ShowResponse, error) {

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -789,6 +789,82 @@ func TestShow(t *testing.T) {
 	}
 }
 
+func TestNormalizeShowCapabilitiesThinkingControls(t *testing.T) {
+	tests := []struct {
+		name string
+		resp api.ShowResponse
+		want []model.Capability
+	}{
+		{
+			name: "known qwen3.5 cloud family gets toggle",
+			resp: api.ShowResponse{
+				Details:      api.ModelDetails{Family: "qwen3.5"},
+				Capabilities: []model.Capability{model.CapabilityCompletion, model.CapabilityThinking},
+			},
+			want: []model.Capability{model.CapabilityCompletion, model.CapabilityThinking, model.CapabilityThinkingToggle},
+		},
+		{
+			name: "known gemma4 parent model gets toggle",
+			resp: api.ShowResponse{
+				Details:      api.ModelDetails{ParentModel: "gemma4:31b"},
+				Capabilities: []model.Capability{model.CapabilityCompletion, model.CapabilityThinking},
+			},
+			want: []model.Capability{model.CapabilityCompletion, model.CapabilityThinking, model.CapabilityThinkingToggle},
+		},
+		{
+			name: "known nemotron architecture gets toggle",
+			resp: api.ShowResponse{
+				Details:      api.ModelDetails{Family: "nemotron_h_moe"},
+				ModelInfo:    map[string]any{"general.architecture": "nemotron_h_moe"},
+				Capabilities: []model.Capability{model.CapabilityCompletion, model.CapabilityThinking, model.CapabilityTools},
+			},
+			want: []model.Capability{model.CapabilityCompletion, model.CapabilityThinking, model.CapabilityTools, model.CapabilityThinkingToggle},
+		},
+		{
+			name: "gpt oss gets toggle and levels",
+			resp: api.ShowResponse{
+				Details:      api.ModelDetails{Family: "gptoss"},
+				Capabilities: []model.Capability{model.CapabilityCompletion, model.CapabilityThinking},
+			},
+			want: []model.Capability{model.CapabilityCompletion, model.CapabilityThinking, model.CapabilityThinkingToggle, model.CapabilityThinkingLevels},
+		},
+		{
+			name: "known non-toggle parser stays thinking only",
+			resp: api.ShowResponse{
+				Details:      api.ModelDetails{Family: "qwen3-vl-thinking"},
+				Capabilities: []model.Capability{model.CapabilityCompletion, model.CapabilityThinking},
+			},
+			want: []model.Capability{model.CapabilityCompletion, model.CapabilityThinking},
+		},
+		{
+			name: "unknown cloud thinking architecture stays unchanged",
+			resp: api.ShowResponse{
+				Details:      api.ModelDetails{Family: "kimi-k2"},
+				ModelInfo:    map[string]any{"general.architecture": "kimi-k2"},
+				Capabilities: []model.Capability{model.CapabilityCompletion, model.CapabilityThinking, model.CapabilityTools},
+			},
+			want: []model.Capability{model.CapabilityCompletion, model.CapabilityThinking, model.CapabilityTools},
+		},
+		{
+			name: "non-thinking model is unchanged",
+			resp: api.ShowResponse{
+				Details:      api.ModelDetails{Family: "gemma4"},
+				Capabilities: []model.Capability{model.CapabilityCompletion},
+			},
+			want: []model.Capability{model.CapabilityCompletion},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			normalizeShowCapabilities(&tt.resp)
+			if !slices.Equal(tt.resp.Capabilities, tt.want) {
+				t.Fatalf("capabilities = %v, want %v", tt.resp.Capabilities, tt.want)
+			}
+		})
+	}
+}
+
 func TestShowCopilotUserAgentOverwritesExistingBasename(t *testing.T) {
 	t.Setenv("OLLAMA_MODELS", t.TempDir())
 

--- a/types/model/capability.go
+++ b/types/model/capability.go
@@ -3,14 +3,16 @@ package model
 type Capability string
 
 const (
-	CapabilityCompletion = Capability("completion")
-	CapabilityTools      = Capability("tools")
-	CapabilityInsert     = Capability("insert")
-	CapabilityVision     = Capability("vision")
-	CapabilityEmbedding  = Capability("embedding")
-	CapabilityThinking   = Capability("thinking")
-	CapabilityImage      = Capability("image")
-	CapabilityAudio      = Capability("audio")
+	CapabilityCompletion     = Capability("completion")
+	CapabilityTools          = Capability("tools")
+	CapabilityInsert         = Capability("insert")
+	CapabilityVision         = Capability("vision")
+	CapabilityEmbedding      = Capability("embedding")
+	CapabilityThinking       = Capability("thinking")
+	CapabilityThinkingToggle = Capability("thinking_toggle")
+	CapabilityThinkingLevels = Capability("thinking_levels")
+	CapabilityImage          = Capability("image")
+	CapabilityAudio          = Capability("audio")
 )
 
 func (c Capability) String() string {


### PR DESCRIPTION
Closes #16016

## Summary

Adds a global Reasoning/Thinking setting in the desktop app UI.

When the setting is disabled, the app backend forces `think: false` for chat requests so thinking is disabled globally for thinking-capable models. This makes the setting authoritative even when the frontend does not send an explicit `think` value.

This also moves the enable path toward model capabilities instead of frontend model-name checks:

- adds `thinking_toggle` and `thinking_levels` capabilities
- exposes parser-level `CanToggleThinking()` support
- uses capabilities in the chat form for thinking toggle / thinking level UI behavior

## Testing

- Manually tested with `qwen3.5:cloud` and other thinking-capable models
- Confirmed responses no longer include thinking when the setting is toggled off
- Observed improved response time with thinking disabled
- `go test ./app/ui -run "TestResolveChatThinkValue|TestHandlePostApiSettings"`
- `go test ./model/parsers ./server -run "TestCanToggleThinking|TestModelCapabilities"`
- `npm test -- --runInBand`