### PR TITLE
create: route quantize through MLX worker thread

### DIFF
--- a/x/create/client/mlxworker.go
+++ b/x/create/client/mlxworker.go
@@ -1,0 +1,57 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/ollama/ollama/x/internal/mlxthread"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+)
+
+// MLX requires its CGO calls to run on a thread that has been initialized
+// with a default device (see x/mlxrunner/server.go for the inference-side
+// pattern). Without this, MLX panics with "There is no Stream(gpu, 1) in
+// current thread" the first time it tries to schedule work on the GPU.
+//
+// Create-time quantization originally called mlx.* directly from arbitrary
+// goroutines, which violated that invariant once the per-thread state
+// requirement was tightened. This worker exists so all create-time MLX work
+// runs on a single, properly-initialized OS thread, mirroring the runner.
+var (
+	workerOnce sync.Once
+	workerInst *mlxthread.Thread
+	workerErr  error
+)
+
+// mlxWorker returns the package-level MLX worker thread, starting it lazily
+// on first use. Callers must wrap any mlx.* call in worker.Do(...).
+func mlxWorker() (*mlxthread.Thread, error) {
+	workerOnce.Do(func() {
+		workerInst, workerErr = mlxthread.Start("create", func() error {
+			if err := mlx.CheckInit(); err != nil {
+				return fmt.Errorf("MLX not available: %w", err)
+			}
+			if mlx.GPUIsAvailable() {
+				mlx.SetDefaultDeviceGPU()
+				slog.Debug("create: MLX worker initialized", "device", "gpu", "version", mlx.Version())
+			} else {
+				slog.Debug("create: MLX worker initialized", "device", "cpu", "version", mlx.Version())
+			}
+			return nil
+		})
+	})
+	return workerInst, workerErr
+}
+
+// runOnMLXWorker executes fn on the package-level MLX worker thread.
+// Any function that calls mlx.* must use this (or be called transitively
+// from a function that does).
+func runOnMLXWorker(fn func() error) error {
+	worker, err := mlxWorker()
+	if err != nil {
+		return fmt.Errorf("failed to start MLX worker: %w", err)
+	}
+	return worker.Do(context.Background(), fn)
+}

--- a/x/create/client/quantize.go
+++ b/x/create/client/quantize.go
@@ -135,7 +135,24 @@ func loadAndQuantizeArray(r io.Reader, name, quantize string, arrays map[string]
 // Tensor keys use the original tensor name: name, name.scale, name.bias.
 // The blob includes __metadata__ with quant_type and group_size.
 // Supported quantization types: "int4", "nvfp4", "mxfp4", "int8", "mxfp8".
+//
+// All MLX work is dispatched to the package-level MLX worker thread to satisfy
+// the per-thread MLX state requirement (see mlxworker.go).
 func quantizeTensor(r io.Reader, tensorName, dtype string, shape []int32, quantize string) (blobData []byte, err error) {
+	werr := runOnMLXWorker(func() error {
+		data, ferr := quantizeTensorOnMLXThread(r, tensorName, dtype, shape, quantize)
+		blobData = data
+		return ferr
+	})
+	if werr != nil {
+		return nil, werr
+	}
+	return blobData, nil
+}
+
+// quantizeTensorOnMLXThread is the implementation; must be called from the
+// MLX worker thread (via runOnMLXWorker).
+func quantizeTensorOnMLXThread(r io.Reader, tensorName, dtype string, shape []int32, quantize string) (blobData []byte, err error) {
 	arrays := make(map[string]*mlx.Array)
 	tmpPath, toEval, st, err := loadAndQuantizeArray(r, tensorName, quantize, arrays)
 	if tmpPath != "" {
@@ -190,7 +207,25 @@ func quantizeTensor(r io.Reader, tensorName, dtype string, shape []int32, quanti
 // they are stacked into 3D switch_mlp tensors before quantization.
 // Each tensor may have a different quantization type (mixed-precision).
 // Returns the blob bytes.
+//
+// All MLX work is dispatched to the package-level MLX worker thread to satisfy
+// the per-thread MLX state requirement (see mlxworker.go).
 func quantizePackedGroup(groupName string, inputs []create.PackedTensorInput) ([]byte, error) {
+	var blobData []byte
+	werr := runOnMLXWorker(func() error {
+		data, ferr := quantizePackedGroupOnMLXThread(groupName, inputs)
+		blobData = data
+		return ferr
+	})
+	if werr != nil {
+		return nil, werr
+	}
+	return blobData, nil
+}
+
+// quantizePackedGroupOnMLXThread is the implementation; must be called from
+// the MLX worker thread (via runOnMLXWorker).
+func quantizePackedGroupOnMLXThread(groupName string, inputs []create.PackedTensorInput) ([]byte, error) {
 	// Check if inputs are per-expert tensors that should be stacked into 3D
 	if projGroups, projQuantize := parsePerExpertInputs(groupName, inputs); projGroups != nil {
 		return stackAndQuantizeExpertGroup(groupName, projGroups, projQuantize)


### PR DESCRIPTION
Fixes #16070.

## Problem

Since v0.23.1, `ollama create --experimental --quantize <any>` panics with `mlx: There is no Stream(gpu, 1) in current thread` on macOS Apple Silicon. v0.23.0 worked correctly with the same Modelfile and same input safetensors.

The root cause is that #15845 tightened MLX's per-thread state requirement: every CGO entry point now runs on a `runtime.LockOSThread()`-locked OS thread, and MLX expects that thread to have been initialized with `SetDefaultDeviceGPU` (which is what registers `Stream(gpu, *)` for the current thread).

The inference path was migrated to satisfy this invariant via a long-lived `mlxthread.Thread` worker started in `x/mlxrunner/server.go`. The create-quantize path, however, still calls `mlx.Eval` / `mlx.Quantize` / `mlx.Contiguous` directly from whatever goroutine the caller happens to use:

```
$ grep -rn "mlxthread" x/mlxrunner/
x/mlxrunner/server.go:37: worker, err := mlxthread.Start("mlxrunner", ...)
x/mlxrunner/runner.go:44: mlxThread     *mlxthread.Thread

$ grep -rn "mlxthread" x/create/
(no matches)
```

The first MLX call from such a goroutine locks a fresh OS thread, that thread has no MLX state, and `mlx_eval` panics inside `transforms.cpp:73`.

## Fix

This PR adds the same pattern in `x/create/client`: a package-level `mlxthread.Thread`, lazily started, whose `init` callback runs `mlx.CheckInit` + `mlx.SetDefaultDeviceGPU`. The two public entry points that call MLX — `quantizeTensor` and `quantizePackedGroup` — are now thin wrappers that dispatch the real work via `runOnMLXWorker`.

Internal helpers (`loadAndQuantizeArray`, `stackAndQuantizeExpertGroup`, `decodeSourceFP8Tensor`) are unchanged because they always run inside one of the two entry points and therefore on the worker thread.

Diff is two files:

- `x/create/client/mlxworker.go` (new, ~60 lines): worker singleton + `runOnMLXWorker` helper.
- `x/create/client/quantize.go` (~35 lines added): wrap `quantizeTensor` / `quantizePackedGroup`; rename their bodies to `*OnMLXThread`.

## Verification

Tested on M3 Air 16 GB (the host that hit the regression).

Inputs: [`google/gemma-4-E4B-it`](https://huggingface.co/google/gemma-4-E4B-it) (target, 15 GB BF16 safetensors) and [`google/gemma-4-E4B-it-assistant`](https://huggingface.co/google/gemma-4-E4B-it-assistant) (drafter, 152 MB).

| Scenario | Before | After |
|---|---|---|
| `ollama create test -f Modelfile --experimental --quantize int4` (no DRAFT) | panic | ✅ creates 9.7 GB int4 model, digest `aab76c72c49c` (matches v0.23.0 output from same inputs) |
| Same with `DRAFT ./gemma-4-E4B-it-assistant` (MTP) | panic | ✅ creates 9.9 GB model `cd730619b202` |
| `ollama run gemma4-mtp` after | n/a | ✅ generates tokens at ~36 tok/s vs ~28 tok/s for stock `gemma4:e4b` (the expected ~1.3× E4B drafter speedup, in line with the docs) |

## Other notes

- `gofmt` clean, `go vet` clean.
- Existing `client` package tests still pass (`go test ./x/create/client/...`).
- I considered a smaller fix (adding `SetDefaultDeviceGPU` inside `mlxCheck`), but that conflicts with the existing architectural decision in #15845 to centralize MLX work on a dedicated worker — applying the same pattern here keeps `x/create/client` consistent with `x/mlxrunner`.
- The worker is lazily initialized so there is no startup-time cost for non-quantize create paths.
