### PR TITLE
fix(imagegen): wire --negative through to runner so CFG actually runs

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -141,6 +141,10 @@ type GenerateRequest struct {
 	// Steps is the number of diffusion steps for image generation.
 	// Only used for image generation models.
 	Steps int32 `json:"steps,omitempty"`
+
+	// Negative is the negative prompt used by classifier-free guidance for image
+	// generation. Models that do not implement CFG will ignore this field.
+	Negative string `json:"negative,omitempty"`
 }
 
 // ChatRequest describes a request sent by [Client.Chat].

--- a/llm/server.go
+++ b/llm/server.go
@@ -1513,10 +1513,11 @@ type CompletionRequest struct {
 	TopLogprobs int
 
 	// Image generation fields
-	Width  int32 `json:"width,omitempty"`
-	Height int32 `json:"height,omitempty"`
-	Steps  int32 `json:"steps,omitempty"`
-	Seed   int64 `json:"seed,omitempty"`
+	Width    int32  `json:"width,omitempty"`
+	Height   int32  `json:"height,omitempty"`
+	Steps    int32  `json:"steps,omitempty"`
+	Seed     int64  `json:"seed,omitempty"`
+	Negative string `json:"negative,omitempty"`
 }
 
 // DoneReason represents the reason why a completion response is done

--- a/server/routes.go
+++ b/server/routes.go
@@ -2816,12 +2816,13 @@ func (s *Server) handleImageGenerate(c *gin.Context, req api.GenerateRequest, mo
 	var finalResponse api.GenerateResponse
 
 	if err := runner.Completion(c.Request.Context(), llm.CompletionRequest{
-		Prompt: req.Prompt,
-		Width:  req.Width,
-		Height: req.Height,
-		Steps:  req.Steps,
-		Seed:   seed,
-		Images: images,
+		Prompt:   req.Prompt,
+		Width:    req.Width,
+		Height:   req.Height,
+		Steps:    req.Steps,
+		Seed:     seed,
+		Images:   images,
+		Negative: req.Negative,
 	}, func(cr llm.CompletionResponse) {
 		streamStarted = true
 		res := api.GenerateResponse{

--- a/x/imagegen/cli.go
+++ b/x/imagegen/cli.go
@@ -122,12 +122,13 @@ func generateImageWithOptions(cmd *cobra.Command, modelName, prompt string, keep
 	}
 
 	req := &api.GenerateRequest{
-		Model:  modelName,
-		Prompt: prompt,
-		Images: images,
-		Width:  int32(opts.Width),
-		Height: int32(opts.Height),
-		Steps:  int32(opts.Steps),
+		Model:    modelName,
+		Prompt:   prompt,
+		Images:   images,
+		Width:    int32(opts.Width),
+		Height:   int32(opts.Height),
+		Steps:    int32(opts.Steps),
+		Negative: opts.NegativePrompt,
 	}
 	if opts.Seed != 0 {
 		req.Options = map[string]any{"seed": opts.Seed}
@@ -289,12 +290,13 @@ func runInteractive(cmd *cobra.Command, modelName string, keepAlive *api.Duratio
 
 		// Generate image with current options
 		req := &api.GenerateRequest{
-			Model:  modelName,
-			Prompt: prompt,
-			Images: images,
-			Width:  int32(opts.Width),
-			Height: int32(opts.Height),
-			Steps:  int32(opts.Steps),
+			Model:    modelName,
+			Prompt:   prompt,
+			Images:   images,
+			Width:    int32(opts.Width),
+			Height:   int32(opts.Height),
+			Steps:    int32(opts.Steps),
+			Negative: opts.NegativePrompt,
 		}
 		if opts.Seed != 0 {
 			req.Options = map[string]any{"seed": opts.Seed}

--- a/x/imagegen/imagegen.go
+++ b/x/imagegen/imagegen.go
@@ -20,6 +20,16 @@ type ImageModel interface {
 	GenerateImage(ctx context.Context, prompt string, width, height int32, steps int, seed int64, progress func(step, total int)) (*mlx.Array, error)
 }
 
+// cfgImageModel is implemented by image models that support classifier-free
+// guidance with a negative prompt. The signature matches zimage.Model.GenerateWithCFG.
+type cfgImageModel interface {
+	GenerateWithCFG(prompt, negativePrompt string, width, height int32, steps int, seed int64, cfgScale float32, progress func(step, totalSteps int)) (*mlx.Array, error)
+}
+
+// defaultCFGScale matches the in-model default in x/imagegen/models/zimage and
+// is used when the runner request does not override it.
+const defaultCFGScale float32 = 4.0
+
 var imageGenMu sync.Mutex
 
 // loadImageModel loads an image generation model.
@@ -91,8 +101,21 @@ func (s *server) handleImageCompletion(w http.ResponseWriter, r *http.Request, r
 		flusher.Flush()
 	}
 
-	// Generate image
-	img, err := s.imageModel.GenerateImage(ctx, req.Prompt, req.Width, req.Height, req.Steps, req.Seed, progress)
+	// Generate image. When the request carries a negative prompt, prefer the
+	// CFG entry point on models that implement it; non-CFG models fall through
+	// to the legacy GenerateImage path.
+	var img *mlx.Array
+	var err error
+	if req.Negative != "" {
+		if cfgModel, ok := s.imageModel.(cfgImageModel); ok {
+			img, err = cfgModel.GenerateWithCFG(req.Prompt, req.Negative, req.Width, req.Height, req.Steps, req.Seed, defaultCFGScale, progress)
+		} else {
+			slog.Warn("image model does not support classifier-free guidance; ignoring negative prompt", "model", s.modelName)
+			img, err = s.imageModel.GenerateImage(ctx, req.Prompt, req.Width, req.Height, req.Steps, req.Seed, progress)
+		}
+	} else {
+		img, err = s.imageModel.GenerateImage(ctx, req.Prompt, req.Width, req.Height, req.Steps, req.Seed, progress)
+	}
 	if err != nil {
 		// Don't send error for cancellation
 		if ctx.Err() != nil {

--- a/x/imagegen/types.go
+++ b/x/imagegen/types.go
@@ -13,11 +13,12 @@ type Request struct {
 	Options *RequestOptions `json:"options,omitempty"`
 
 	// Image generation fields
-	Width  int32    `json:"width,omitempty"`
-	Height int32    `json:"height,omitempty"`
-	Steps  int      `json:"steps,omitempty"`
-	Seed   int64    `json:"seed,omitempty"`
-	Images [][]byte `json:"images,omitempty"` // Input images for image editing/conditioning
+	Width    int32    `json:"width,omitempty"`
+	Height   int32    `json:"height,omitempty"`
+	Steps    int      `json:"steps,omitempty"`
+	Seed     int64    `json:"seed,omitempty"`
+	Images   [][]byte `json:"images,omitempty"` // Input images for image editing/conditioning
+	Negative string   `json:"negative,omitempty"` // Negative prompt for classifier-free guidance (CFG-capable models only)
 }
 
 // RequestOptions contains LLM-specific generation options.


### PR DESCRIPTION
## Summary

Fixes #16068.

The CLI flag `--negative` and the in-model CFG path (`zimage.Model.GenerateWithCFG`) both already exist. The wire schema between them did not — neither `api.GenerateRequest`, `llm.CompletionRequest`, nor the runner's `imagegen.Request` carried a negative-prompt field, and the imagegen handler always called the legacy `GenerateImage(...)` (which constructs a `GenerateConfig` with `NegativePrompt=""`). Result: `--negative` was a no-op on every model — seed-locked output PNGs hash identically with and without the flag.

## Changes

- **`api/types.go`**: add `Negative string \`json:"negative,omitempty"\`` to `GenerateRequest` (next to the existing `Width`/`Height`/`Steps` image-gen fields, similarly tagged experimental).
- **`llm/server.go`**: add `Negative string \`json:"negative,omitempty"\`` to `CompletionRequest` so the value crosses the JSON boundary to the runner.
- **`x/imagegen/types.go`**: add the matching field to the runner's `Request` struct.
- **`server/routes.go`** (`handleImageGenerate`): forward `req.Negative` into the `llm.CompletionRequest` it builds.
- **`x/imagegen/cli.go`**: copy `opts.NegativePrompt` into the outgoing request body in both the one-shot and interactive REPL paths.
- **`x/imagegen/imagegen.go`**: when `req.Negative != ""`, dispatch via a small private `cfgImageModel` interface to `GenerateWithCFG(prompt, negativePrompt, ..., cfgScale, progress)`. Models that don't implement CFG (currently `flux2`) keep working — they fall through to `GenerateImage` and `slog.Warn` notes the ignored prompt instead of silently dropping it. The CFG scale defaults to `4.0`, matching the in-model default in `zimage`.

The interface assertion is private to the `imagegen` package so the public `ImageModel` interface stays unchanged and `flux2.Model` doesn't need a no-op shim.

## Test plan

- [ ] Build `ollama serve` and a Z-Image model (`x/z-image-turbo:latest`).
- [ ] Run two seed-locked generations, one with `--negative`, one without:

```bash
ollama run x/z-image-turbo:latest "an apple" \
  --width 384 --height 384 --steps 4 --seed 42 \
  --negative "red, crimson, scarlet, dark color" > /tmp/with_neg.raw

ollama run x/z-image-turbo:latest "an apple" \
  --width 384 --height 384 --steps 4 --seed 42 > /tmp/no_neg.raw
```

Before this PR: SHA-256 of the extracted PNGs are identical.
After this PR: hashes differ — the CFG pass at `x/imagegen/models/zimage/zimage.go:170` actually runs.

- [ ] Run with `flux2-klein` + `--negative`: image generates as before, server logs `image model does not support classifier-free guidance; ignoring negative prompt` once.

## Notes

- `Negative` is added with `omitempty` JSON tags everywhere so existing API clients that don't know about the field continue to round-trip cleanly.
- I deliberately did **not** expose `cfg_scale` on the wire here. The model's default (`4.0` in `zimage`) is what users get today via the documented flag, so a one-line fix to make `--negative` actually do something is the smallest change that resolves the reported behavior. Happy to add a follow-up that exposes `--cfg-scale` if maintainers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
