### PR TITLE
docs: document API error response format

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -32,6 +32,18 @@ All durations are returned in nanoseconds.
 
 Certain endpoints stream responses as JSON objects. Streaming can be disabled by providing `{"stream": false}` for these endpoints.
 
+### Error responses
+
+Error responses use HTTP status codes and, when returned as JSON, include an `error` field with a human-readable message:
+
+```json
+{
+  "error": "model 'llama3.2' not found"
+}
+```
+
+Some endpoints may include additional fields, such as `signin_url` for authentication flows. Clients should use the HTTP status code together with the `error` message.
+
 ## Generate a completion
 
 ```


### PR DESCRIPTION
Closes #1464

## Summary

Documents the common API error response shape in `docs/api.md`. The server returns HTTP status codes and, when returning JSON errors, uses an `error` field with a human-readable message. Some endpoints may include additional fields such as `signin_url`, so the docs now call that out without over-specifying endpoint-specific behavior.

## Validation

- `git diff --check` passed
- Verified current server handlers commonly return JSON error bodies using `error`

## Notes

This is documentation-only and does not change API behavior.