### PR TITLE
mlx: warm up MLX compile paths on load

### DIFF
--- a/x/mlxrunner/cache.go
+++ b/x/mlxrunner/cache.go
@@ -65,14 +65,28 @@ func (c *kvCache) ensureCaches(m base.Model) {
 	if len(c.caches) != 0 {
 		return
 	}
+	c.caches = newModelCaches(m)
+}
+
+func newModelCaches(m base.Model) []cache.Cache {
 	if cacheFactory, ok := m.(interface{ NewCaches() []cache.Cache }); ok {
-		c.caches = cacheFactory.NewCaches()
-		return
+		return cacheFactory.NewCaches()
 	}
-	c.caches = make([]cache.Cache, m.NumLayers())
-	for i := range c.caches {
-		c.caches[i] = cache.NewKVCache()
+	caches := make([]cache.Cache, m.NumLayers())
+	for i := range caches {
+		caches[i] = cache.NewKVCache()
 	}
+	return caches
+}
+
+func cacheStateArrays(caches []cache.Cache) []*mlx.Array {
+	state := make([]*mlx.Array, 0, 2*len(caches))
+	for _, c := range caches {
+		if c != nil {
+			state = append(state, c.State()...)
+		}
+	}
+	return state
 }
 
 func (c *kvCache) ensureRoot() {

--- a/x/mlxrunner/runner.go
+++ b/x/mlxrunner/runner.go
@@ -7,11 +7,13 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"time"
 
 	"golang.org/x/sync/errgroup"
 
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/x/internal/mlxthread"
+	"github.com/ollama/ollama/x/mlxrunner/batch"
 	"github.com/ollama/ollama/x/mlxrunner/mlx"
 	"github.com/ollama/ollama/x/mlxrunner/model"
 	"github.com/ollama/ollama/x/mlxrunner/model/base"
@@ -103,7 +105,69 @@ func (r *Runner) Load(modelName string) error {
 	r.Sampler = sample.New(r.contextLength)
 
 	mlx.EnableCompile()
+	r.warmup()
 	return nil
+}
+
+func (r *Runner) warmup() {
+	if r.contextLength <= 1 {
+		return
+	}
+
+	// Exercise the common prefill and first-token decode graphs without
+	// committing synthetic tokens to the request cache.
+	promptTokens := r.warmupTokens()
+	promptLen := min(len(promptTokens), max(1, r.contextLength-1))
+	promptTokens = promptTokens[:promptLen]
+	token := promptTokens[len(promptTokens)-1]
+
+	caches := newModelCaches(r.Model)
+	defer func() {
+		for _, c := range caches {
+			c.Free()
+		}
+		mlx.Sweep()
+		mlx.ClearCache()
+	}()
+
+	start := time.Now()
+	slog.Debug("warming up MLX model", "prompt_tokens", promptLen)
+
+	r.Model.Forward(&batch.Batch{
+		InputIDs:     mlx.FromValues(promptTokens, 1, promptLen),
+		SeqOffsets:   []int32{0},
+		SeqQueryLens: []int32{int32(promptLen)},
+	}, caches)
+	mlx.Sweep()
+	mlx.Eval(cacheStateArrays(caches)...)
+
+	hidden := r.Model.Forward(&batch.Batch{
+		InputIDs:     mlx.FromValues([]int32{token}, 1, 1),
+		SeqOffsets:   []int32{int32(promptLen)},
+		SeqQueryLens: []int32{1},
+	}, caches)
+	next := greedyTokenFromLogits(r.lastLogits(hidden))
+	state := append([]*mlx.Array{next}, cacheStateArrays(caches)...)
+	mlx.Eval(state...)
+
+	slog.Info("finished warming up MLX model", "duration", time.Since(start), "prompt_tokens", promptLen)
+}
+
+func (r *Runner) warmupTokens() []int32 {
+	if r.Tokenizer == nil {
+		return []int32{0}
+	}
+	var tokens []int32
+	if bos := r.Tokenizer.BOS(); bos >= 0 {
+		tokens = append(tokens, bos)
+	}
+	if eos := r.Tokenizer.EOS(); eos >= 0 {
+		tokens = append(tokens, eos)
+	}
+	if len(tokens) == 0 {
+		tokens = append(tokens, 0)
+	}
+	return tokens
 }
 
 // loadTensorsFromManifest loads all tensor blobs from the manifest into a


### PR DESCRIPTION
Run a small throwaway BOS/EOS prefill plus one decode after model load so MLX compile caches are populated before the first real request.

Use isolated caches and clear MLX state afterward so synthetic tokens do not enter the request cache.

Fixes #16051

TTFT remains roughly the same on cold load, but this takes the expensive compile operations out of the first prompt timing and shifts into the load category.  That this doesn't fully exercise all shapes so some models may still have additional compiles that trigger on the first larger prompt.