### PR TITLE
updater: add cross-platform SHA-256 integrity verification for downloaded installers

### DIFF
--- a/app/updater/updater.go
+++ b/app/updater/updater.go
@@ -3,342 +3,384 @@
 package updater
 
 import (
-	"context"
-	"crypto/rand"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io"
-	"log/slog"
-	"mime"
-	"net/http"
-	"net/url"
-	"os"
-	"path"
-	"path/filepath"
-	"runtime"
-	"strconv"
-	"strings"
-	"sync"
-	"time"
+"context"
+"crypto/rand"
+"crypto/sha256"
+"encoding/hex"
+"encoding/json"
+"errors"
+"fmt"
+"io"
+"log/slog"
+"mime"
+"net/http"
+"net/url"
+"os"
+"path"
+"path/filepath"
+"runtime"
+"strconv"
+"strings"
+"sync"
+"time"
 
-	"github.com/ollama/ollama/app/store"
-	"github.com/ollama/ollama/app/version"
-	"github.com/ollama/ollama/auth"
+"github.com/ollama/ollama/app/store"
+"github.com/ollama/ollama/app/version"
+"github.com/ollama/ollama/auth"
 )
 
 var (
-	UpdateCheckURLBase      = "https://ollama.com/api/update"
-	UpdateDownloaded        = false
-	UpdateCheckInterval     = 60 * 60 * time.Second
-	UpdateCheckInitialDelay = 3 * time.Second // 30 * time.Second
+UpdateCheckURLBase      = "https://ollama.com/api/update"
+UpdateDownloaded        = false
+UpdateCheckInterval     = 60 * 60 * time.Second
+UpdateCheckInitialDelay = 3 * time.Second // 30 * time.Second
 
-	UpdateStageDir    string
-	UpgradeLogFile    string
-	UpgradeMarkerFile string
-	Installer         string
-	UserAgentOS       string
+UpdateStageDir    string
+UpgradeLogFile    string
+UpgradeMarkerFile string
+Installer         string
+UserAgentOS       string
 
-	VerifyDownload func() error
+VerifyDownload func() error
 )
 
 // TODO - maybe move up to the API package?
 type UpdateResponse struct {
-	UpdateURL     string `json:"url"`
-	UpdateVersion string `json:"version"`
+UpdateURL     string `json:"url"`
+UpdateVersion string `json:"version"`
+// UpdateChecksum is the expected SHA-256 digest of the installer artifact,
+// expressed as a bare hex string or with a "sha256:" prefix.
+// When present, it is verified against the downloaded file before any
+// platform-specific signature check (Authenticode / notarisation) runs.
+// Omitted on older server versions — verification degrades gracefully.
+UpdateChecksum string `json:"checksum,omitempty"`
 }
 
 func (u *Updater) checkForUpdate(ctx context.Context) (bool, UpdateResponse) {
-	var updateResp UpdateResponse
+var updateResp UpdateResponse
 
-	requestURL, err := url.Parse(UpdateCheckURLBase)
-	if err != nil {
-		return false, updateResp
-	}
+requestURL, err := url.Parse(UpdateCheckURLBase)
+if err != nil {
+return false, updateResp
+}
 
-	query := requestURL.Query()
-	query.Add("os", runtime.GOOS)
-	query.Add("arch", runtime.GOARCH)
-	currentVersion := version.Version
-	query.Add("version", currentVersion)
-	query.Add("ts", strconv.FormatInt(time.Now().Unix(), 10))
+query := requestURL.Query()
+query.Add("os", runtime.GOOS)
+query.Add("arch", runtime.GOARCH)
+currentVersion := version.Version
+query.Add("version", currentVersion)
+query.Add("ts", strconv.FormatInt(time.Now().Unix(), 10))
 
-	// The original macOS app used to use the device ID
-	// to check for updates so include it if present
-	if runtime.GOOS == "darwin" {
-		if id, err := u.Store.ID(); err == nil && id != "" {
-			query.Add("id", id)
-		}
-	}
+// The original macOS app used to use the device ID
+// to check for updates so include it if present
+if runtime.GOOS == "darwin" {
+if id, err := u.Store.ID(); err == nil && id != "" {
+query.Add("id", id)
+}
+}
 
-	var signature string
+var signature string
 
-	nonce, err := auth.NewNonce(rand.Reader, 16)
-	if err != nil {
-		// Don't sign if we haven't yet generated a key pair for the server
-		slog.Debug("unable to generate nonce for update check request", "error", err)
-	} else {
-		query.Add("nonce", nonce)
-		requestURL.RawQuery = query.Encode()
+nonce, err := auth.NewNonce(rand.Reader, 16)
+if err != nil {
+// Don't sign if we haven't yet generated a key pair for the server
+slog.Debug("unable to generate nonce for update check request", "error", err)
+} else {
+query.Add("nonce", nonce)
+requestURL.RawQuery = query.Encode()
 
-		data := []byte(fmt.Sprintf("%s,%s", http.MethodGet, requestURL.RequestURI()))
-		signature, err = auth.Sign(ctx, data)
-		if err != nil {
-			slog.Debug("unable to generate signature for update check request", "error", err)
-		}
-	}
+data := []byte(fmt.Sprintf("%s,%s", http.MethodGet, requestURL.RequestURI()))
+signature, err = auth.Sign(ctx, data)
+if err != nil {
+slog.Debug("unable to generate signature for update check request", "error", err)
+}
+}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL.String(), nil)
-	if err != nil {
-		slog.Warn(fmt.Sprintf("failed to check for update: %s", err))
-		return false, updateResp
-	}
-	if signature != "" {
-		req.Header.Set("Authorization", signature)
-	}
-	ua := fmt.Sprintf("ollama/%s %s Go/%s %s", version.Version, runtime.GOARCH, runtime.Version(), UserAgentOS)
-	req.Header.Set("User-Agent", ua)
+req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL.String(), nil)
+if err != nil {
+slog.Warn(fmt.Sprintf("failed to check for update: %s", err))
+return false, updateResp
+}
+if signature != "" {
+req.Header.Set("Authorization", signature)
+}
+ua := fmt.Sprintf("ollama/%s %s Go/%s %s", version.Version, runtime.GOARCH, runtime.Version(), UserAgentOS)
+req.Header.Set("User-Agent", ua)
 
-	slog.Debug("checking for available update", "requestURL", requestURL, "User-Agent", ua)
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		slog.Warn(fmt.Sprintf("failed to check for update: %s", err))
-		return false, updateResp
-	}
-	defer resp.Body.Close()
+slog.Debug("checking for available update", "requestURL", requestURL, "User-Agent", ua)
+resp, err := http.DefaultClient.Do(req)
+if err != nil {
+slog.Warn(fmt.Sprintf("failed to check for update: %s", err))
+return false, updateResp
+}
+defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusNoContent {
-		slog.Debug("check update response 204 (current version is up to date)")
-		return false, updateResp
-	}
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		slog.Warn(fmt.Sprintf("failed to read body response: %s", err))
-	}
+if resp.StatusCode == http.StatusNoContent {
+slog.Debug("check update response 204 (current version is up to date)")
+return false, updateResp
+}
+body, err := io.ReadAll(resp.Body)
+if err != nil {
+slog.Warn(fmt.Sprintf("failed to read body response: %s", err))
+}
 
-	if resp.StatusCode != http.StatusOK {
-		slog.Info(fmt.Sprintf("check update error %d - %.96s", resp.StatusCode, string(body)))
-		return false, updateResp
-	}
-	err = json.Unmarshal(body, &updateResp)
-	if err != nil {
-		slog.Warn(fmt.Sprintf("malformed response checking for update: %s", err))
-		return false, updateResp
-	}
-	// Extract the version string from the URL in the github release artifact path
-	updateResp.UpdateVersion = path.Base(path.Dir(updateResp.UpdateURL))
+if resp.StatusCode != http.StatusOK {
+slog.Info(fmt.Sprintf("check update error %d - %.96s", resp.StatusCode, string(body)))
+return false, updateResp
+}
+err = json.Unmarshal(body, &updateResp)
+if err != nil {
+slog.Warn(fmt.Sprintf("malformed response checking for update: %s", err))
+return false, updateResp
+}
+// Extract the version string from the URL in the github release artifact path
+updateResp.UpdateVersion = path.Base(path.Dir(updateResp.UpdateURL))
 
-	slog.Info("New update available at " + updateResp.UpdateURL)
-	return true, updateResp
+slog.Info("New update available at " + updateResp.UpdateURL)
+return true, updateResp
+}
+
+// verifySHA256 checks the SHA-256 digest of the file at path against expected.
+// expected may be a bare hex string or carry a "sha256:" prefix.
+// Returns nil when the digest matches or when expected is empty (server did not
+// supply a checksum — maintains backward compatibility).
+func verifySHA256(path, expected string) error {
+if expected == "" {
+return nil
+}
+want := strings.TrimPrefix(strings.ToLower(expected), "sha256:")
+f, err := os.Open(path)
+if err != nil {
+return fmt.Errorf("open for SHA-256 check: %w", err)
+}
+defer f.Close()
+
+h := sha256.New()
+if _, err := io.Copy(h, f); err != nil {
+return fmt.Errorf("hash staged update: %w", err)
+}
+got := hex.EncodeToString(h.Sum(nil))
+if got != want {
+return fmt.Errorf("SHA-256 mismatch: got %s, want %s", got, want)
+}
+slog.Info("update SHA-256 verified", "file", path)
+return nil
 }
 
 func (u *Updater) DownloadNewRelease(ctx context.Context, updateResp UpdateResponse) error {
-	// Create a cancellable context for this download
-	downloadCtx, cancel := context.WithCancel(ctx)
-	u.cancelDownloadLock.Lock()
-	u.cancelDownload = cancel
-	u.cancelDownloadLock.Unlock()
-	defer func() {
-		u.cancelDownloadLock.Lock()
-		u.cancelDownload = nil
-		u.cancelDownloadLock.Unlock()
-		cancel()
-	}()
+// Create a cancellable context for this download
+downloadCtx, cancel := context.WithCancel(ctx)
+u.cancelDownloadLock.Lock()
+u.cancelDownload = cancel
+u.cancelDownloadLock.Unlock()
+defer func() {
+u.cancelDownloadLock.Lock()
+u.cancelDownload = nil
+u.cancelDownloadLock.Unlock()
+cancel()
+}()
 
-	// Do a head first to check etag info
-	req, err := http.NewRequestWithContext(downloadCtx, http.MethodHead, updateResp.UpdateURL, nil)
-	if err != nil {
-		return err
-	}
+// Do a head first to check etag info
+req, err := http.NewRequestWithContext(downloadCtx, http.MethodHead, updateResp.UpdateURL, nil)
+if err != nil {
+return err
+}
 
-	// In case of slow downloads, continue the update check in the background
-	bgctx, bgcancel := context.WithCancel(downloadCtx)
-	defer bgcancel()
-	go func() {
-		for {
-			select {
-			case <-bgctx.Done():
-				return
-			case <-time.After(UpdateCheckInterval):
-				u.checkForUpdate(bgctx)
-			}
-		}
-	}()
+// In case of slow downloads, continue the update check in the background
+bgctx, bgcancel := context.WithCancel(downloadCtx)
+defer bgcancel()
+go func() {
+for {
+select {
+case <-bgctx.Done():
+return
+case <-time.After(UpdateCheckInterval):
+u.checkForUpdate(bgctx)
+}
+}
+}()
 
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("error checking update: %w", err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected status attempting to download update %d", resp.StatusCode)
-	}
-	resp.Body.Close()
-	etag := strings.Trim(resp.Header.Get("etag"), "\"")
-	if etag == "" {
-		slog.Debug("no etag detected, falling back to filename based dedup")
-		etag = "_"
-	}
-	filename := Installer
-	_, params, err := mime.ParseMediaType(resp.Header.Get("content-disposition"))
-	if err == nil {
-		filename = params["filename"]
-	}
+resp, err := http.DefaultClient.Do(req)
+if err != nil {
+return fmt.Errorf("error checking update: %w", err)
+}
+if resp.StatusCode != http.StatusOK {
+return fmt.Errorf("unexpected status attempting to download update %d", resp.StatusCode)
+}
+resp.Body.Close()
+etag := strings.Trim(resp.Header.Get("etag"), "\"")
+if etag == "" {
+slog.Debug("no etag detected, falling back to filename based dedup")
+etag = "_"
+}
+filename := Installer
+_, params, err := mime.ParseMediaType(resp.Header.Get("content-disposition"))
+if err == nil {
+filename = params["filename"]
+}
 
-	stageFilename := filepath.Join(UpdateStageDir, etag, filename)
+stageFilename := filepath.Join(UpdateStageDir, etag, filename)
 
-	// Check to see if we already have it downloaded
-	_, err = os.Stat(stageFilename)
-	if err == nil {
-		slog.Info("update already downloaded", "bundle", stageFilename)
-		UpdateDownloaded = true
-		return nil
-	}
+// Check to see if we already have it downloaded
+_, err = os.Stat(stageFilename)
+if err == nil {
+slog.Info("update already downloaded", "bundle", stageFilename)
+UpdateDownloaded = true
+return nil
+}
 
-	cleanupOldDownloads(UpdateStageDir)
+cleanupOldDownloads(UpdateStageDir)
 
-	req.Method = http.MethodGet
-	resp, err = http.DefaultClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("error checking update: %w", err)
-	}
-	defer resp.Body.Close()
-	etag = strings.Trim(resp.Header.Get("etag"), "\"")
-	if etag == "" {
-		slog.Debug("no etag detected, falling back to filename based dedup") // TODO probably can get rid of this redundant log
-		etag = "_"
-	}
+req.Method = http.MethodGet
+resp, err = http.DefaultClient.Do(req)
+if err != nil {
+return fmt.Errorf("error checking update: %w", err)
+}
+defer resp.Body.Close()
+etag = strings.Trim(resp.Header.Get("etag"), "\"")
+if etag == "" {
+slog.Debug("no etag detected, falling back to filename based dedup") // TODO probably can get rid of this redundant log
+etag = "_"
+}
 
-	stageFilename = filepath.Join(UpdateStageDir, etag, filename)
+stageFilename = filepath.Join(UpdateStageDir, etag, filename)
 
-	_, err = os.Stat(filepath.Dir(stageFilename))
-	if errors.Is(err, os.ErrNotExist) {
-		if err := os.MkdirAll(filepath.Dir(stageFilename), 0o755); err != nil {
-			return fmt.Errorf("create ollama dir %s: %v", filepath.Dir(stageFilename), err)
-		}
-	}
+_, err = os.Stat(filepath.Dir(stageFilename))
+if errors.Is(err, os.ErrNotExist) {
+if err := os.MkdirAll(filepath.Dir(stageFilename), 0o755); err != nil {
+return fmt.Errorf("create ollama dir %s: %v", filepath.Dir(stageFilename), err)
+}
+}
 
-	payload, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read body response: %w", err)
-	}
-	fp, err := os.OpenFile(stageFilename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o755)
-	if err != nil {
-		return fmt.Errorf("write payload %s: %w", stageFilename, err)
-	}
-	defer fp.Close()
-	if n, err := fp.Write(payload); err != nil || n != len(payload) {
-		return fmt.Errorf("write payload %s: %d vs %d -- %w", stageFilename, n, len(payload), err)
-	}
-	slog.Info("new update downloaded " + stageFilename)
+payload, err := io.ReadAll(resp.Body)
+if err != nil {
+return fmt.Errorf("failed to read body response: %w", err)
+}
+fp, err := os.OpenFile(stageFilename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o755)
+if err != nil {
+return fmt.Errorf("write payload %s: %w", stageFilename, err)
+}
+defer fp.Close()
+if n, err := fp.Write(payload); err != nil || n != len(payload) {
+return fmt.Errorf("write payload %s: %d vs %d -- %w", stageFilename, n, len(payload), err)
+}
+slog.Info("new update downloaded " + stageFilename)
 
-	if err := VerifyDownload(); err != nil {
-		_ = os.Remove(stageFilename)
-		return fmt.Errorf("%s - %s", resp.Request.URL.String(), err)
-	}
-	UpdateDownloaded = true
-	return nil
+// SHA-256 integrity check runs on all platforms before the platform-specific
+// signature verification (Authenticode on Windows, notarisation on macOS).
+if err := verifySHA256(stageFilename, updateResp.UpdateChecksum); err != nil {
+_ = os.Remove(stageFilename)
+return fmt.Errorf("integrity check failed for %s: %w", resp.Request.URL.String(), err)
+}
+
+if err := VerifyDownload(); err != nil {
+_ = os.Remove(stageFilename)
+return fmt.Errorf("%s - %s", resp.Request.URL.String(), err)
+}
+UpdateDownloaded = true
+return nil
 }
 
 func cleanupOldDownloads(stageDir string) {
-	files, err := os.ReadDir(stageDir)
-	if err != nil && errors.Is(err, os.ErrNotExist) {
-		// Expected behavior on first run
-		return
-	} else if err != nil {
-		slog.Warn(fmt.Sprintf("failed to list stage dir: %s", err))
-		return
-	}
-	for _, file := range files {
-		fullname := filepath.Join(stageDir, file.Name())
-		slog.Debug("cleaning up old download: " + fullname)
-		err = os.RemoveAll(fullname)
-		if err != nil {
-			slog.Warn(fmt.Sprintf("failed to cleanup stale update download %s", err))
-		}
-	}
+files, err := os.ReadDir(stageDir)
+if err != nil && errors.Is(err, os.ErrNotExist) {
+// Expected behavior on first run
+return
+} else if err != nil {
+slog.Warn(fmt.Sprintf("failed to list stage dir: %s", err))
+return
+}
+for _, file := range files {
+fullname := filepath.Join(stageDir, file.Name())
+slog.Debug("cleaning up old download: " + fullname)
+err = os.RemoveAll(fullname)
+if err != nil {
+slog.Warn(fmt.Sprintf("failed to cleanup stale update download %s", err))
+}
+}
 }
 
 type Updater struct {
-	Store              *store.Store
-	cancelDownload     context.CancelFunc
-	cancelDownloadLock sync.Mutex
-	checkNow           chan struct{}
+Store              *store.Store
+cancelDownload     context.CancelFunc
+cancelDownloadLock sync.Mutex
+checkNow           chan struct{}
 }
 
 // CancelOngoingDownload cancels any currently running download
 func (u *Updater) CancelOngoingDownload() {
-	u.cancelDownloadLock.Lock()
-	defer u.cancelDownloadLock.Unlock()
-	if u.cancelDownload != nil {
-		slog.Info("cancelling ongoing update download")
-		u.cancelDownload()
-		u.cancelDownload = nil
-	}
+u.cancelDownloadLock.Lock()
+defer u.cancelDownloadLock.Unlock()
+if u.cancelDownload != nil {
+slog.Info("cancelling ongoing update download")
+u.cancelDownload()
+u.cancelDownload = nil
+}
 }
 
 // TriggerImmediateCheck signals the background checker to check for updates immediately
 func (u *Updater) TriggerImmediateCheck() {
-	if u.checkNow != nil {
-		select {
-		case u.checkNow <- struct{}{}:
-		default:
-			// Check already pending, no need to queue another
-		}
-	}
+if u.checkNow != nil {
+select {
+case u.checkNow <- struct{}{}:
+default:
+// Check already pending, no need to queue another
+}
+}
 }
 
 func (u *Updater) StartBackgroundUpdaterChecker(ctx context.Context, cb func(string) error) {
-	u.checkNow = make(chan struct{}, 1)
-	u.checkNow <- struct{}{} // Trigger first check after initial delay
-	go func() {
-		// Don't blast an update message immediately after startup
-		time.Sleep(UpdateCheckInitialDelay)
-		slog.Info("beginning update checker", "interval", UpdateCheckInterval)
-		ticker := time.NewTicker(UpdateCheckInterval)
-		defer ticker.Stop()
+u.checkNow = make(chan struct{}, 1)
+u.checkNow <- struct{}{} // Trigger first check after initial delay
+go func() {
+// Don't blast an update message immediately after startup
+time.Sleep(UpdateCheckInitialDelay)
+slog.Info("beginning update checker", "interval", UpdateCheckInterval)
+ticker := time.NewTicker(UpdateCheckInterval)
+defer ticker.Stop()
 
-		for {
-			select {
-			case <-ctx.Done():
-				slog.Debug("stopping background update checker")
-				return
-			case <-u.checkNow:
-				// Immediate check triggered
-			case <-ticker.C:
-				// Regular interval check
-			}
+for {
+select {
+case <-ctx.Done():
+slog.Debug("stopping background update checker")
+return
+case <-u.checkNow:
+// Immediate check triggered
+case <-ticker.C:
+// Regular interval check
+}
 
-			// Always check for updates
-			available, resp := u.checkForUpdate(ctx)
-			if !available {
-				continue
-			}
+// Always check for updates
+available, resp := u.checkForUpdate(ctx)
+if !available {
+continue
+}
 
-			// Update is available - check if auto-update is enabled for downloading
-			settings, err := u.Store.Settings()
-			if err != nil {
-				slog.Error("failed to load settings", "error", err)
-				continue
-			}
+// Update is available - check if auto-update is enabled for downloading
+settings, err := u.Store.Settings()
+if err != nil {
+slog.Error("failed to load settings", "error", err)
+continue
+}
 
-			if !settings.AutoUpdateEnabled {
-				// Auto-update disabled - don't download, just log
-				slog.Debug("update available but auto-update disabled", "version", resp.UpdateVersion)
-				continue
-			}
+if !settings.AutoUpdateEnabled {
+// Auto-update disabled - don't download, just log
+slog.Debug("update available but auto-update disabled", "version", resp.UpdateVersion)
+continue
+}
 
-			// Auto-update is enabled - download
-			err = u.DownloadNewRelease(ctx, resp)
-			if err != nil {
-				slog.Error("failed to download new release", "error", err)
-				continue
-			}
+// Auto-update is enabled - download
+err = u.DownloadNewRelease(ctx, resp)
+if err != nil {
+slog.Error("failed to download new release", "error", err)
+continue
+}
 
-			// Download successful - show tray notification
-			err = cb(resp.UpdateVersion)
-			if err != nil {
-				slog.Warn("failed to register update available with tray", "error", err)
-			}
-		}
-	}()
+// Download successful - show tray notification
+err = cb(resp.UpdateVersion)
+if err != nil {
+slog.Warn("failed to register update available with tray", "error", err)
+}
+}
+}()
 }

--- a/app/updater/updater.go
+++ b/app/updater/updater.go
@@ -48,11 +48,10 @@ VerifyDownload func() error
 type UpdateResponse struct {
 UpdateURL     string `json:"url"`
 UpdateVersion string `json:"version"`
-// UpdateChecksum is the expected SHA-256 digest of the installer artifact,
-// expressed as a bare hex string or with a "sha256:" prefix.
-// When present, it is verified against the downloaded file before any
-// platform-specific signature check (Authenticode / notarisation) runs.
-// Omitted on older server versions — verification degrades gracefully.
+// UpdateChecksum optionally provides the expected SHA-256 digest of the
+// installer artifact (bare hex or "sha256:<hex>").  When absent the updater
+// falls back to fetching the digest from the GitHub Releases API, which
+// already publishes per-asset SHA-256 values.
 UpdateChecksum string `json:"checksum,omitempty"`
 }
 
@@ -140,15 +139,82 @@ slog.Info("New update available at " + updateResp.UpdateURL)
 return true, updateResp
 }
 
+// githubReleaseAsset is the subset of the GitHub Releases API asset object
+// that we care about.
+type githubReleaseAsset struct {
+Name   string `json:"name"`
+Digest string `json:"digest"` // "sha256:<hex>" — set by GitHub for every asset
+}
+
+// fetchGitHubReleaseChecksum derives the GitHub Releases API URL from a
+// standard GitHub release download URL and returns the SHA-256 digest for the
+// matching asset.
+//
+// downloadURL is expected to be of the form:
+//
+//https://github.com/{owner}/{repo}/releases/download/{tag}/{filename}
+//
+// The digest is returned as a bare lowercase hex string so it can be passed
+// directly to verifySHA256.
+func fetchGitHubReleaseChecksum(ctx context.Context, downloadURL string) (string, error) {
+u, err := url.Parse(downloadURL)
+if err != nil {
+return "", fmt.Errorf("parse download URL: %w", err)
+}
+
+// path segments: ["", owner, repo, "releases", "download", tag, filename]
+parts := strings.Split(u.Path, "/")
+if len(parts) < 7 || parts[3] != "releases" || parts[4] != "download" {
+return "", fmt.Errorf("not a GitHub release download URL: %s", downloadURL)
+}
+owner, repo, tag, filename := parts[1], parts[2], parts[5], parts[6]
+
+apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/releases/tags/%s", owner, repo, tag)
+req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+if err != nil {
+return "", err
+}
+req.Header.Set("Accept", "application/vnd.github+json")
+req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+resp, err := http.DefaultClient.Do(req)
+if err != nil {
+return "", fmt.Errorf("GitHub releases API request: %w", err)
+}
+defer resp.Body.Close()
+if resp.StatusCode != http.StatusOK {
+return "", fmt.Errorf("GitHub releases API returned %d for %s", resp.StatusCode, apiURL)
+}
+
+var release struct {
+Assets []githubReleaseAsset `json:"assets"`
+}
+if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+return "", fmt.Errorf("decode GitHub releases response: %w", err)
+}
+
+for _, asset := range release.Assets {
+if asset.Name == filename {
+// GitHub returns "sha256:<hex>"; strip the prefix.
+digest := strings.TrimPrefix(asset.Digest, "sha256:")
+if digest == "" {
+return "", fmt.Errorf("GitHub asset %q has empty digest", filename)
+}
+return digest, nil
+}
+}
+return "", fmt.Errorf("asset %q not found in GitHub release %s", filename, tag)
+}
+
 // verifySHA256 checks the SHA-256 digest of the file at path against expected.
 // expected may be a bare hex string or carry a "sha256:" prefix.
-// Returns nil when the digest matches or when expected is empty (server did not
-// supply a checksum — maintains backward compatibility).
+// Returns nil when the digest matches or when expected is empty (no checksum
+// available — maintains backward compatibility).
 func verifySHA256(path, expected string) error {
 if expected == "" {
 return nil
 }
-want := strings.TrimPrefix(strings.ToLower(expected), "sha256:")
+want := strings.ToLower(strings.TrimPrefix(expected, "sha256:"))
 f, err := os.Open(path)
 if err != nil {
 return fmt.Errorf("open for SHA-256 check: %w", err)
@@ -266,9 +332,23 @@ return fmt.Errorf("write payload %s: %d vs %d -- %w", stageFilename, n, len(payl
 }
 slog.Info("new update downloaded " + stageFilename)
 
+// Determine the expected SHA-256 checksum.  Prefer an explicit value from
+// the update-check response; fall back to fetching it from the GitHub
+// Releases API (which publishes per-asset digests for every release).
+checksum := updateResp.UpdateChecksum
+if checksum == "" {
+if digest, err := fetchGitHubReleaseChecksum(downloadCtx, updateResp.UpdateURL); err != nil {
+// Non-fatal: log and continue so a transient GitHub API outage
+// does not block users from receiving security updates.
+slog.Warn("unable to fetch checksum from GitHub releases API, skipping SHA-256 check", "error", err)
+} else {
+checksum = digest
+}
+}
+
 // SHA-256 integrity check runs on all platforms before the platform-specific
 // signature verification (Authenticode on Windows, notarisation on macOS).
-if err := verifySHA256(stageFilename, updateResp.UpdateChecksum); err != nil {
+if err := verifySHA256(stageFilename, checksum); err != nil {
 _ = os.Remove(stageFilename)
 return fmt.Errorf("integrity check failed for %s: %w", resp.Request.URL.String(), err)
 }

--- a/app/updater/updater.go
+++ b/app/updater/updater.go
@@ -3,147 +3,147 @@
 package updater
 
 import (
-"context"
-"crypto/rand"
-"crypto/sha256"
-"encoding/hex"
-"encoding/json"
-"errors"
-"fmt"
-"io"
-"log/slog"
-"mime"
-"net/http"
-"net/url"
-"os"
-"path"
-"path/filepath"
-"runtime"
-"strconv"
-"strings"
-"sync"
-"time"
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"mime"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
 
-"github.com/ollama/ollama/app/store"
-"github.com/ollama/ollama/app/version"
-"github.com/ollama/ollama/auth"
+	"github.com/ollama/ollama/app/store"
+	"github.com/ollama/ollama/app/version"
+	"github.com/ollama/ollama/auth"
 )
 
 var (
-UpdateCheckURLBase      = "https://ollama.com/api/update"
-UpdateDownloaded        = false
-UpdateCheckInterval     = 60 * 60 * time.Second
-UpdateCheckInitialDelay = 3 * time.Second // 30 * time.Second
+	UpdateCheckURLBase      = "https://ollama.com/api/update"
+	UpdateDownloaded        = false
+	UpdateCheckInterval     = 60 * 60 * time.Second
+	UpdateCheckInitialDelay = 3 * time.Second // 30 * time.Second
 
-UpdateStageDir    string
-UpgradeLogFile    string
-UpgradeMarkerFile string
-Installer         string
-UserAgentOS       string
+	UpdateStageDir    string
+	UpgradeLogFile    string
+	UpgradeMarkerFile string
+	Installer         string
+	UserAgentOS       string
 
-VerifyDownload func() error
+	VerifyDownload func() error
 )
 
 // TODO - maybe move up to the API package?
 type UpdateResponse struct {
-UpdateURL     string `json:"url"`
-UpdateVersion string `json:"version"`
-// UpdateChecksum optionally provides the expected SHA-256 digest of the
-// installer artifact (bare hex or "sha256:<hex>").  When absent the updater
-// falls back to fetching the digest from the GitHub Releases API, which
-// already publishes per-asset SHA-256 values.
-UpdateChecksum string `json:"checksum,omitempty"`
+	UpdateURL     string `json:"url"`
+	UpdateVersion string `json:"version"`
+	// UpdateChecksum optionally provides the expected SHA-256 digest of the
+	// installer artifact (bare hex or "sha256:<hex>").  When absent the updater
+	// falls back to fetching the digest from the GitHub Releases API, which
+	// already publishes per-asset SHA-256 values.
+	UpdateChecksum string `json:"checksum,omitempty"`
 }
 
 func (u *Updater) checkForUpdate(ctx context.Context) (bool, UpdateResponse) {
-var updateResp UpdateResponse
+	var updateResp UpdateResponse
 
-requestURL, err := url.Parse(UpdateCheckURLBase)
-if err != nil {
-return false, updateResp
-}
+	requestURL, err := url.Parse(UpdateCheckURLBase)
+	if err != nil {
+		return false, updateResp
+	}
 
-query := requestURL.Query()
-query.Add("os", runtime.GOOS)
-query.Add("arch", runtime.GOARCH)
-currentVersion := version.Version
-query.Add("version", currentVersion)
-query.Add("ts", strconv.FormatInt(time.Now().Unix(), 10))
+	query := requestURL.Query()
+	query.Add("os", runtime.GOOS)
+	query.Add("arch", runtime.GOARCH)
+	currentVersion := version.Version
+	query.Add("version", currentVersion)
+	query.Add("ts", strconv.FormatInt(time.Now().Unix(), 10))
 
-// The original macOS app used to use the device ID
-// to check for updates so include it if present
-if runtime.GOOS == "darwin" {
-if id, err := u.Store.ID(); err == nil && id != "" {
-query.Add("id", id)
-}
-}
+	// The original macOS app used to use the device ID
+	// to check for updates so include it if present
+	if runtime.GOOS == "darwin" {
+		if id, err := u.Store.ID(); err == nil && id != "" {
+			query.Add("id", id)
+		}
+	}
 
-var signature string
+	var signature string
 
-nonce, err := auth.NewNonce(rand.Reader, 16)
-if err != nil {
-// Don't sign if we haven't yet generated a key pair for the server
-slog.Debug("unable to generate nonce for update check request", "error", err)
-} else {
-query.Add("nonce", nonce)
-requestURL.RawQuery = query.Encode()
+	nonce, err := auth.NewNonce(rand.Reader, 16)
+	if err != nil {
+		// Don't sign if we haven't yet generated a key pair for the server
+		slog.Debug("unable to generate nonce for update check request", "error", err)
+	} else {
+		query.Add("nonce", nonce)
+		requestURL.RawQuery = query.Encode()
 
-data := []byte(fmt.Sprintf("%s,%s", http.MethodGet, requestURL.RequestURI()))
-signature, err = auth.Sign(ctx, data)
-if err != nil {
-slog.Debug("unable to generate signature for update check request", "error", err)
-}
-}
+		data := []byte(fmt.Sprintf("%s,%s", http.MethodGet, requestURL.RequestURI()))
+		signature, err = auth.Sign(ctx, data)
+		if err != nil {
+			slog.Debug("unable to generate signature for update check request", "error", err)
+		}
+	}
 
-req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL.String(), nil)
-if err != nil {
-slog.Warn(fmt.Sprintf("failed to check for update: %s", err))
-return false, updateResp
-}
-if signature != "" {
-req.Header.Set("Authorization", signature)
-}
-ua := fmt.Sprintf("ollama/%s %s Go/%s %s", version.Version, runtime.GOARCH, runtime.Version(), UserAgentOS)
-req.Header.Set("User-Agent", ua)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL.String(), nil)
+	if err != nil {
+		slog.Warn(fmt.Sprintf("failed to check for update: %s", err))
+		return false, updateResp
+	}
+	if signature != "" {
+		req.Header.Set("Authorization", signature)
+	}
+	ua := fmt.Sprintf("ollama/%s %s Go/%s %s", version.Version, runtime.GOARCH, runtime.Version(), UserAgentOS)
+	req.Header.Set("User-Agent", ua)
 
-slog.Debug("checking for available update", "requestURL", requestURL, "User-Agent", ua)
-resp, err := http.DefaultClient.Do(req)
-if err != nil {
-slog.Warn(fmt.Sprintf("failed to check for update: %s", err))
-return false, updateResp
-}
-defer resp.Body.Close()
+	slog.Debug("checking for available update", "requestURL", requestURL, "User-Agent", ua)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		slog.Warn(fmt.Sprintf("failed to check for update: %s", err))
+		return false, updateResp
+	}
+	defer resp.Body.Close()
 
-if resp.StatusCode == http.StatusNoContent {
-slog.Debug("check update response 204 (current version is up to date)")
-return false, updateResp
-}
-body, err := io.ReadAll(resp.Body)
-if err != nil {
-slog.Warn(fmt.Sprintf("failed to read body response: %s", err))
-}
+	if resp.StatusCode == http.StatusNoContent {
+		slog.Debug("check update response 204 (current version is up to date)")
+		return false, updateResp
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		slog.Warn(fmt.Sprintf("failed to read body response: %s", err))
+	}
 
-if resp.StatusCode != http.StatusOK {
-slog.Info(fmt.Sprintf("check update error %d - %.96s", resp.StatusCode, string(body)))
-return false, updateResp
-}
-err = json.Unmarshal(body, &updateResp)
-if err != nil {
-slog.Warn(fmt.Sprintf("malformed response checking for update: %s", err))
-return false, updateResp
-}
-// Extract the version string from the URL in the github release artifact path
-updateResp.UpdateVersion = path.Base(path.Dir(updateResp.UpdateURL))
+	if resp.StatusCode != http.StatusOK {
+		slog.Info(fmt.Sprintf("check update error %d - %.96s", resp.StatusCode, string(body)))
+		return false, updateResp
+	}
+	err = json.Unmarshal(body, &updateResp)
+	if err != nil {
+		slog.Warn(fmt.Sprintf("malformed response checking for update: %s", err))
+		return false, updateResp
+	}
+	// Extract the version string from the URL in the github release artifact path
+	updateResp.UpdateVersion = path.Base(path.Dir(updateResp.UpdateURL))
 
-slog.Info("New update available at " + updateResp.UpdateURL)
-return true, updateResp
+	slog.Info("New update available at " + updateResp.UpdateURL)
+	return true, updateResp
 }
 
 // githubReleaseAsset is the subset of the GitHub Releases API asset object
 // that we care about.
 type githubReleaseAsset struct {
-Name   string `json:"name"`
-Digest string `json:"digest"` // "sha256:<hex>" — set by GitHub for every asset
+	Name   string `json:"name"`
+	Digest string `json:"digest"` // "sha256:<hex>" — set by GitHub for every asset
 }
 
 // fetchGitHubReleaseChecksum derives the GitHub Releases API URL from a
@@ -152,58 +152,58 @@ Digest string `json:"digest"` // "sha256:<hex>" — set by GitHub for every asse
 //
 // downloadURL is expected to be of the form:
 //
-//https://github.com/{owner}/{repo}/releases/download/{tag}/{filename}
+// https://github.com/{owner}/{repo}/releases/download/{tag}/{filename}
 //
 // The digest is returned as a bare lowercase hex string so it can be passed
 // directly to verifySHA256.
 func fetchGitHubReleaseChecksum(ctx context.Context, downloadURL string) (string, error) {
-u, err := url.Parse(downloadURL)
-if err != nil {
-return "", fmt.Errorf("parse download URL: %w", err)
-}
+	u, err := url.Parse(downloadURL)
+	if err != nil {
+		return "", fmt.Errorf("parse download URL: %w", err)
+	}
 
-// path segments: ["", owner, repo, "releases", "download", tag, filename]
-parts := strings.Split(u.Path, "/")
-if len(parts) < 7 || parts[3] != "releases" || parts[4] != "download" {
-return "", fmt.Errorf("not a GitHub release download URL: %s", downloadURL)
-}
-owner, repo, tag, filename := parts[1], parts[2], parts[5], parts[6]
+	// path segments: ["", owner, repo, "releases", "download", tag, filename]
+	parts := strings.Split(u.Path, "/")
+	if len(parts) < 7 || parts[3] != "releases" || parts[4] != "download" {
+		return "", fmt.Errorf("not a GitHub release download URL: %s", downloadURL)
+	}
+	owner, repo, tag, filename := parts[1], parts[2], parts[5], parts[6]
 
-apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/releases/tags/%s", owner, repo, tag)
-req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
-if err != nil {
-return "", err
-}
-req.Header.Set("Accept", "application/vnd.github+json")
-req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/releases/tags/%s", owner, repo, tag)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
 
-resp, err := http.DefaultClient.Do(req)
-if err != nil {
-return "", fmt.Errorf("GitHub releases API request: %w", err)
-}
-defer resp.Body.Close()
-if resp.StatusCode != http.StatusOK {
-return "", fmt.Errorf("GitHub releases API returned %d for %s", resp.StatusCode, apiURL)
-}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("GitHub releases API request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("GitHub releases API returned %d for %s", resp.StatusCode, apiURL)
+	}
 
-var release struct {
-Assets []githubReleaseAsset `json:"assets"`
-}
-if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
-return "", fmt.Errorf("decode GitHub releases response: %w", err)
-}
+	var release struct {
+		Assets []githubReleaseAsset `json:"assets"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return "", fmt.Errorf("decode GitHub releases response: %w", err)
+	}
 
-for _, asset := range release.Assets {
-if asset.Name == filename {
-// GitHub returns "sha256:<hex>"; strip the prefix.
-digest := strings.TrimPrefix(asset.Digest, "sha256:")
-if digest == "" {
-return "", fmt.Errorf("GitHub asset %q has empty digest", filename)
-}
-return digest, nil
-}
-}
-return "", fmt.Errorf("asset %q not found in GitHub release %s", filename, tag)
+	for _, asset := range release.Assets {
+		if asset.Name == filename {
+			// GitHub returns "sha256:<hex>"; strip the prefix.
+			digest := strings.TrimPrefix(asset.Digest, "sha256:")
+			if digest == "" {
+				return "", fmt.Errorf("GitHub asset %q has empty digest", filename)
+			}
+			return digest, nil
+		}
+	}
+	return "", fmt.Errorf("asset %q not found in GitHub release %s", filename, tag)
 }
 
 // verifySHA256 checks the SHA-256 digest of the file at path against expected.
@@ -211,256 +211,256 @@ return "", fmt.Errorf("asset %q not found in GitHub release %s", filename, tag)
 // Returns nil when the digest matches or when expected is empty (no checksum
 // available — maintains backward compatibility).
 func verifySHA256(path, expected string) error {
-if expected == "" {
-return nil
-}
-want := strings.ToLower(strings.TrimPrefix(expected, "sha256:"))
-f, err := os.Open(path)
-if err != nil {
-return fmt.Errorf("open for SHA-256 check: %w", err)
-}
-defer f.Close()
+	if expected == "" {
+		return nil
+	}
+	want := strings.ToLower(strings.TrimPrefix(expected, "sha256:"))
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open for SHA-256 check: %w", err)
+	}
+	defer f.Close()
 
-h := sha256.New()
-if _, err := io.Copy(h, f); err != nil {
-return fmt.Errorf("hash staged update: %w", err)
-}
-got := hex.EncodeToString(h.Sum(nil))
-if got != want {
-return fmt.Errorf("SHA-256 mismatch: got %s, want %s", got, want)
-}
-slog.Info("update SHA-256 verified", "file", path)
-return nil
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return fmt.Errorf("hash staged update: %w", err)
+	}
+	got := hex.EncodeToString(h.Sum(nil))
+	if got != want {
+		return fmt.Errorf("SHA-256 mismatch: got %s, want %s", got, want)
+	}
+	slog.Info("update SHA-256 verified", "file", path)
+	return nil
 }
 
 func (u *Updater) DownloadNewRelease(ctx context.Context, updateResp UpdateResponse) error {
-// Create a cancellable context for this download
-downloadCtx, cancel := context.WithCancel(ctx)
-u.cancelDownloadLock.Lock()
-u.cancelDownload = cancel
-u.cancelDownloadLock.Unlock()
-defer func() {
-u.cancelDownloadLock.Lock()
-u.cancelDownload = nil
-u.cancelDownloadLock.Unlock()
-cancel()
-}()
+	// Create a cancellable context for this download
+	downloadCtx, cancel := context.WithCancel(ctx)
+	u.cancelDownloadLock.Lock()
+	u.cancelDownload = cancel
+	u.cancelDownloadLock.Unlock()
+	defer func() {
+		u.cancelDownloadLock.Lock()
+		u.cancelDownload = nil
+		u.cancelDownloadLock.Unlock()
+		cancel()
+	}()
 
-// Do a head first to check etag info
-req, err := http.NewRequestWithContext(downloadCtx, http.MethodHead, updateResp.UpdateURL, nil)
-if err != nil {
-return err
-}
+	// Do a head first to check etag info
+	req, err := http.NewRequestWithContext(downloadCtx, http.MethodHead, updateResp.UpdateURL, nil)
+	if err != nil {
+		return err
+	}
 
-// In case of slow downloads, continue the update check in the background
-bgctx, bgcancel := context.WithCancel(downloadCtx)
-defer bgcancel()
-go func() {
-for {
-select {
-case <-bgctx.Done():
-return
-case <-time.After(UpdateCheckInterval):
-u.checkForUpdate(bgctx)
-}
-}
-}()
+	// In case of slow downloads, continue the update check in the background
+	bgctx, bgcancel := context.WithCancel(downloadCtx)
+	defer bgcancel()
+	go func() {
+		for {
+			select {
+			case <-bgctx.Done():
+				return
+			case <-time.After(UpdateCheckInterval):
+				u.checkForUpdate(bgctx)
+			}
+		}
+	}()
 
-resp, err := http.DefaultClient.Do(req)
-if err != nil {
-return fmt.Errorf("error checking update: %w", err)
-}
-if resp.StatusCode != http.StatusOK {
-return fmt.Errorf("unexpected status attempting to download update %d", resp.StatusCode)
-}
-resp.Body.Close()
-etag := strings.Trim(resp.Header.Get("etag"), "\"")
-if etag == "" {
-slog.Debug("no etag detected, falling back to filename based dedup")
-etag = "_"
-}
-filename := Installer
-_, params, err := mime.ParseMediaType(resp.Header.Get("content-disposition"))
-if err == nil {
-filename = params["filename"]
-}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("error checking update: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status attempting to download update %d", resp.StatusCode)
+	}
+	resp.Body.Close()
+	etag := strings.Trim(resp.Header.Get("etag"), "\"")
+	if etag == "" {
+		slog.Debug("no etag detected, falling back to filename based dedup")
+		etag = "_"
+	}
+	filename := Installer
+	_, params, err := mime.ParseMediaType(resp.Header.Get("content-disposition"))
+	if err == nil {
+		filename = params["filename"]
+	}
 
-stageFilename := filepath.Join(UpdateStageDir, etag, filename)
+	stageFilename := filepath.Join(UpdateStageDir, etag, filename)
 
-// Check to see if we already have it downloaded
-_, err = os.Stat(stageFilename)
-if err == nil {
-slog.Info("update already downloaded", "bundle", stageFilename)
-UpdateDownloaded = true
-return nil
-}
+	// Check to see if we already have it downloaded
+	_, err = os.Stat(stageFilename)
+	if err == nil {
+		slog.Info("update already downloaded", "bundle", stageFilename)
+		UpdateDownloaded = true
+		return nil
+	}
 
-cleanupOldDownloads(UpdateStageDir)
+	cleanupOldDownloads(UpdateStageDir)
 
-req.Method = http.MethodGet
-resp, err = http.DefaultClient.Do(req)
-if err != nil {
-return fmt.Errorf("error checking update: %w", err)
-}
-defer resp.Body.Close()
-etag = strings.Trim(resp.Header.Get("etag"), "\"")
-if etag == "" {
-slog.Debug("no etag detected, falling back to filename based dedup") // TODO probably can get rid of this redundant log
-etag = "_"
-}
+	req.Method = http.MethodGet
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("error checking update: %w", err)
+	}
+	defer resp.Body.Close()
+	etag = strings.Trim(resp.Header.Get("etag"), "\"")
+	if etag == "" {
+		slog.Debug("no etag detected, falling back to filename based dedup") // TODO probably can get rid of this redundant log
+		etag = "_"
+	}
 
-stageFilename = filepath.Join(UpdateStageDir, etag, filename)
+	stageFilename = filepath.Join(UpdateStageDir, etag, filename)
 
-_, err = os.Stat(filepath.Dir(stageFilename))
-if errors.Is(err, os.ErrNotExist) {
-if err := os.MkdirAll(filepath.Dir(stageFilename), 0o755); err != nil {
-return fmt.Errorf("create ollama dir %s: %v", filepath.Dir(stageFilename), err)
-}
-}
+	_, err = os.Stat(filepath.Dir(stageFilename))
+	if errors.Is(err, os.ErrNotExist) {
+		if err := os.MkdirAll(filepath.Dir(stageFilename), 0o755); err != nil {
+			return fmt.Errorf("create ollama dir %s: %v", filepath.Dir(stageFilename), err)
+		}
+	}
 
-payload, err := io.ReadAll(resp.Body)
-if err != nil {
-return fmt.Errorf("failed to read body response: %w", err)
-}
-fp, err := os.OpenFile(stageFilename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o755)
-if err != nil {
-return fmt.Errorf("write payload %s: %w", stageFilename, err)
-}
-defer fp.Close()
-if n, err := fp.Write(payload); err != nil || n != len(payload) {
-return fmt.Errorf("write payload %s: %d vs %d -- %w", stageFilename, n, len(payload), err)
-}
-slog.Info("new update downloaded " + stageFilename)
+	payload, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read body response: %w", err)
+	}
+	fp, err := os.OpenFile(stageFilename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o755)
+	if err != nil {
+		return fmt.Errorf("write payload %s: %w", stageFilename, err)
+	}
+	defer fp.Close()
+	if n, err := fp.Write(payload); err != nil || n != len(payload) {
+		return fmt.Errorf("write payload %s: %d vs %d -- %w", stageFilename, n, len(payload), err)
+	}
+	slog.Info("new update downloaded " + stageFilename)
 
-// Determine the expected SHA-256 checksum.  Prefer an explicit value from
-// the update-check response; fall back to fetching it from the GitHub
-// Releases API (which publishes per-asset digests for every release).
-checksum := updateResp.UpdateChecksum
-if checksum == "" {
-if digest, err := fetchGitHubReleaseChecksum(downloadCtx, updateResp.UpdateURL); err != nil {
-// Non-fatal: log and continue so a transient GitHub API outage
-// does not block users from receiving security updates.
-slog.Warn("unable to fetch checksum from GitHub releases API, skipping SHA-256 check", "error", err)
-} else {
-checksum = digest
-}
-}
+	// Determine the expected SHA-256 checksum.  Prefer an explicit value from
+	// the update-check response; fall back to fetching it from the GitHub
+	// Releases API (which publishes per-asset digests for every release).
+	checksum := updateResp.UpdateChecksum
+	if checksum == "" {
+		if digest, err := fetchGitHubReleaseChecksum(downloadCtx, updateResp.UpdateURL); err != nil {
+			// Non-fatal: log and continue so a transient GitHub API outage
+			// does not block users from receiving security updates.
+			slog.Warn("unable to fetch checksum from GitHub releases API, skipping SHA-256 check", "error", err)
+		} else {
+			checksum = digest
+		}
+	}
 
-// SHA-256 integrity check runs on all platforms before the platform-specific
-// signature verification (Authenticode on Windows, notarisation on macOS).
-if err := verifySHA256(stageFilename, checksum); err != nil {
-_ = os.Remove(stageFilename)
-return fmt.Errorf("integrity check failed for %s: %w", resp.Request.URL.String(), err)
-}
+	// SHA-256 integrity check runs on all platforms before the platform-specific
+	// signature verification (Authenticode on Windows, notarisation on macOS).
+	if err := verifySHA256(stageFilename, checksum); err != nil {
+		_ = os.Remove(stageFilename)
+		return fmt.Errorf("integrity check failed for %s: %w", resp.Request.URL.String(), err)
+	}
 
-if err := VerifyDownload(); err != nil {
-_ = os.Remove(stageFilename)
-return fmt.Errorf("%s - %s", resp.Request.URL.String(), err)
-}
-UpdateDownloaded = true
-return nil
+	if err := VerifyDownload(); err != nil {
+		_ = os.Remove(stageFilename)
+		return fmt.Errorf("%s - %s", resp.Request.URL.String(), err)
+	}
+	UpdateDownloaded = true
+	return nil
 }
 
 func cleanupOldDownloads(stageDir string) {
-files, err := os.ReadDir(stageDir)
-if err != nil && errors.Is(err, os.ErrNotExist) {
-// Expected behavior on first run
-return
-} else if err != nil {
-slog.Warn(fmt.Sprintf("failed to list stage dir: %s", err))
-return
-}
-for _, file := range files {
-fullname := filepath.Join(stageDir, file.Name())
-slog.Debug("cleaning up old download: " + fullname)
-err = os.RemoveAll(fullname)
-if err != nil {
-slog.Warn(fmt.Sprintf("failed to cleanup stale update download %s", err))
-}
-}
+	files, err := os.ReadDir(stageDir)
+	if err != nil && errors.Is(err, os.ErrNotExist) {
+		// Expected behavior on first run
+		return
+	} else if err != nil {
+		slog.Warn(fmt.Sprintf("failed to list stage dir: %s", err))
+		return
+	}
+	for _, file := range files {
+		fullname := filepath.Join(stageDir, file.Name())
+		slog.Debug("cleaning up old download: " + fullname)
+		err = os.RemoveAll(fullname)
+		if err != nil {
+			slog.Warn(fmt.Sprintf("failed to cleanup stale update download %s", err))
+		}
+	}
 }
 
 type Updater struct {
-Store              *store.Store
-cancelDownload     context.CancelFunc
-cancelDownloadLock sync.Mutex
-checkNow           chan struct{}
+	Store              *store.Store
+	cancelDownload     context.CancelFunc
+	cancelDownloadLock sync.Mutex
+	checkNow           chan struct{}
 }
 
 // CancelOngoingDownload cancels any currently running download
 func (u *Updater) CancelOngoingDownload() {
-u.cancelDownloadLock.Lock()
-defer u.cancelDownloadLock.Unlock()
-if u.cancelDownload != nil {
-slog.Info("cancelling ongoing update download")
-u.cancelDownload()
-u.cancelDownload = nil
-}
+	u.cancelDownloadLock.Lock()
+	defer u.cancelDownloadLock.Unlock()
+	if u.cancelDownload != nil {
+		slog.Info("cancelling ongoing update download")
+		u.cancelDownload()
+		u.cancelDownload = nil
+	}
 }
 
 // TriggerImmediateCheck signals the background checker to check for updates immediately
 func (u *Updater) TriggerImmediateCheck() {
-if u.checkNow != nil {
-select {
-case u.checkNow <- struct{}{}:
-default:
-// Check already pending, no need to queue another
-}
-}
+	if u.checkNow != nil {
+		select {
+		case u.checkNow <- struct{}{}:
+		default:
+			// Check already pending, no need to queue another
+		}
+	}
 }
 
 func (u *Updater) StartBackgroundUpdaterChecker(ctx context.Context, cb func(string) error) {
-u.checkNow = make(chan struct{}, 1)
-u.checkNow <- struct{}{} // Trigger first check after initial delay
-go func() {
-// Don't blast an update message immediately after startup
-time.Sleep(UpdateCheckInitialDelay)
-slog.Info("beginning update checker", "interval", UpdateCheckInterval)
-ticker := time.NewTicker(UpdateCheckInterval)
-defer ticker.Stop()
+	u.checkNow = make(chan struct{}, 1)
+	u.checkNow <- struct{}{} // Trigger first check after initial delay
+	go func() {
+		// Don't blast an update message immediately after startup
+		time.Sleep(UpdateCheckInitialDelay)
+		slog.Info("beginning update checker", "interval", UpdateCheckInterval)
+		ticker := time.NewTicker(UpdateCheckInterval)
+		defer ticker.Stop()
 
-for {
-select {
-case <-ctx.Done():
-slog.Debug("stopping background update checker")
-return
-case <-u.checkNow:
-// Immediate check triggered
-case <-ticker.C:
-// Regular interval check
-}
+		for {
+			select {
+			case <-ctx.Done():
+				slog.Debug("stopping background update checker")
+				return
+			case <-u.checkNow:
+			// Immediate check triggered
+			case <-ticker.C:
+				// Regular interval check
+			}
 
-// Always check for updates
-available, resp := u.checkForUpdate(ctx)
-if !available {
-continue
-}
+			// Always check for updates
+			available, resp := u.checkForUpdate(ctx)
+			if !available {
+				continue
+			}
 
-// Update is available - check if auto-update is enabled for downloading
-settings, err := u.Store.Settings()
-if err != nil {
-slog.Error("failed to load settings", "error", err)
-continue
-}
+			// Update is available - check if auto-update is enabled for downloading
+			settings, err := u.Store.Settings()
+			if err != nil {
+				slog.Error("failed to load settings", "error", err)
+				continue
+			}
 
-if !settings.AutoUpdateEnabled {
-// Auto-update disabled - don't download, just log
-slog.Debug("update available but auto-update disabled", "version", resp.UpdateVersion)
-continue
-}
+			if !settings.AutoUpdateEnabled {
+				// Auto-update disabled - don't download, just log
+				slog.Debug("update available but auto-update disabled", "version", resp.UpdateVersion)
+				continue
+			}
 
-// Auto-update is enabled - download
-err = u.DownloadNewRelease(ctx, resp)
-if err != nil {
-slog.Error("failed to download new release", "error", err)
-continue
-}
+			// Auto-update is enabled - download
+			err = u.DownloadNewRelease(ctx, resp)
+			if err != nil {
+				slog.Error("failed to download new release", "error", err)
+				continue
+			}
 
-// Download successful - show tray notification
-err = cb(resp.UpdateVersion)
-if err != nil {
-slog.Warn("failed to register update available with tray", "error", err)
-}
-}
-}()
+			// Download successful - show tray notification
+			err = cb(resp.UpdateVersion)
+			if err != nil {
+				slog.Warn("failed to register update available with tray", "error", err)
+			}
+		}
+	}()
 }


### PR DESCRIPTION
## Problem

The Windows auto-updater's `verifyDownload()` was a no-op — `return nil`. The auto-updater downloaded an installer `.exe`, wrote it to disk, and executed it with **zero integrity verification**. A compromised CDN, DNS hijack, or MITM could silently replace the installer with arbitrary code.

macOS had notarisation/Gatekeeper verification but also lacked a content-hash check.

## Fix

GitHub already publishes a `digest: sha256:<hex>` field for every release asset via its Releases API. This PR uses that to verify the downloaded installer on **all platforms** (Windows and macOS) without requiring any server-side changes to `ollama.com/api/update`.

### How it works

The download URL is always of the form:
```
https://github.com/ollama/ollama/releases/download/{tag}/{filename}
```

We parse `owner`, `repo`, `tag`, and `filename` from it, then call:
```
https://api.github.com/repos/ollama/ollama/releases/tags/{tag}
```

Each asset in that response already has `"digest": "sha256:<hex>"` — we match on filename and verify the downloaded file against that digest.

### Verification flow (after this PR)

```
download installer
      │
      ▼
fetchGitHubReleaseChecksum   ◄── reads asset digest from GitHub Releases API
      │
      ▼
verifySHA256                 ◄── new, shared Windows + macOS
      │
      ▼
VerifyDownload               ◄── existing (Authenticode on Windows, notarisation on macOS)
      │
      ▼
mark UpdateDownloaded = true
```

### Graceful degradation

- If the GitHub Releases API is unreachable (transient outage), a warning is logged and the update proceeds — a network blip won't block users from receiving security fixes.
- If the Ollama update-check API ever adds an explicit `checksum` field, that takes priority over the GitHub API lookup.

### Changes

- `UpdateResponse` gains `UpdateChecksum string \`json:"checksum,omitempty"\`` for future explicit server-supplied digests.
- `fetchGitHubReleaseChecksum(ctx, downloadURL)` fetches the SHA-256 digest from the GitHub Releases API.
- `verifySHA256(path, expected)` computes the file hash and compares (strips optional `sha256:` prefix; no-op when expected is empty).
- Both helpers live in `updater.go` (shared build tag `windows || darwin`) so both platforms get the check.
- No changes to `updater_windows.go`, `updater_darwin.go`, or any tests — existing signatures are untouched.

## Testing

All existing tests pass unchanged. The `VerifyDownload` function signature is untouched; `verifySHA256` is called only when a non-empty checksum is resolved.