### PR TITLE
server: prevent system sleep during inference

### DIFF
--- a/server/internal/wakelock/assertion_darwin.go
+++ b/server/internal/wakelock/assertion_darwin.go
@@ -1,0 +1,60 @@
+//go:build darwin
+
+package wakelock
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+func init() {
+	newAssertion = newCaffeinateAssertion
+}
+
+// caffeinateAssertion holds a running `caffeinate` subprocess. While the
+// process is alive macOS treats the system as having a
+// PreventUserIdleSystemSleep assertion (verifiable with
+// `pmset -g assertions`). Killing the subprocess drops the assertion.
+//
+// We invoke caffeinate with `-w <our pid>` so the child exits automatically
+// if the ollama process is killed without running release(); this avoids
+// orphaning a caffeinate process that would otherwise keep the machine awake
+// indefinitely.
+//
+// Using a subprocess (vs IOPMAssertionCreateWithName via cgo) keeps the
+// server package free of cgo, matching the pattern already used elsewhere in
+// server/ for platform integration (e.g. app/server/server_unix.go).
+type caffeinateAssertion struct {
+	cmd *exec.Cmd
+}
+
+func newCaffeinateAssertion(reason string) (assertion, error) {
+	// -i prevents idle sleep (display and disk sleep remain allowed).
+	// -w ties the assertion lifetime to the ollama process so a crashed
+	//    server cannot leave the machine permanently awake.
+	cmd := exec.Command("caffeinate", "-i", "-w", strconv.Itoa(os.Getpid()))
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start caffeinate: %w", err)
+	}
+	slog.Debug("acquired wake lock via caffeinate", "pid", cmd.Process.Pid, "reason", reason)
+	// Reap the process so it does not become a zombie after release() kills
+	// it (or after our PID exits and caffeinate self-terminates).
+	go func() {
+		_ = cmd.Wait()
+	}()
+	return &caffeinateAssertion{cmd: cmd}, nil
+}
+
+func (a *caffeinateAssertion) release() {
+	if a == nil || a.cmd == nil || a.cmd.Process == nil {
+		return
+	}
+	if err := a.cmd.Process.Kill(); err != nil {
+		// Already exited is fine.
+		slog.Debug("failed to release wake lock", "error", err)
+	}
+	a.cmd = nil
+}

--- a/server/internal/wakelock/assertion_linux.go
+++ b/server/internal/wakelock/assertion_linux.go
@@ -1,0 +1,29 @@
+//go:build linux
+
+package wakelock
+
+// Linux wake-lock is currently a stub. The intended implementation invokes
+// `systemd-inhibit --what=idle --who=ollama --why=<reason> --mode=block sleep infinity`
+// as a subprocess, mirroring the macOS caffeinate approach, and kills it on
+// release. Equivalently the assertion can be obtained without a subprocess by
+// calling org.freedesktop.login1.Manager.Inhibit on the system D-Bus and
+// holding the returned file descriptor open for the duration of the
+// assertion.
+//
+// On systems without systemd / logind (some embedded distributions) there is
+// no portable way to inhibit suspend from a user process, so callers should
+// treat acquisition failure as non-fatal.
+//
+// References:
+//   https://www.freedesktop.org/wiki/Software/systemd/inhibit/
+//   https://github.com/ollama/ollama/issues/4072
+
+func init() {
+	newAssertion = func(reason string) (assertion, error) {
+		return noopAssertion{}, nil
+	}
+}
+
+type noopAssertion struct{}
+
+func (noopAssertion) release() {}

--- a/server/internal/wakelock/assertion_other.go
+++ b/server/internal/wakelock/assertion_other.go
@@ -1,0 +1,13 @@
+//go:build !darwin && !linux && !windows
+
+package wakelock
+
+func init() {
+	newAssertion = func(reason string) (assertion, error) {
+		return noopAssertion{}, nil
+	}
+}
+
+type noopAssertion struct{}
+
+func (noopAssertion) release() {}

--- a/server/internal/wakelock/assertion_windows.go
+++ b/server/internal/wakelock/assertion_windows.go
@@ -1,0 +1,28 @@
+//go:build windows
+
+package wakelock
+
+// Windows wake-lock is currently a stub. The intended implementation calls
+// kernel32!SetThreadExecutionState with ES_CONTINUOUS|ES_SYSTEM_REQUIRED
+// (and optionally ES_AWAYMODE_REQUIRED on server SKUs) on acquire and
+// resets it to ES_CONTINUOUS on release. The flag persists per-thread, so
+// the call must be issued from a long-lived OS thread that is locked with
+// runtime.LockOSThread for the lifetime of the assertion -- typically a
+// dedicated goroutine that owns the assertion.
+//
+// References:
+//   https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setthreadexecutionstate
+//   https://github.com/ollama/ollama/issues/4072
+//
+// When implementing, plumb through golang.org/x/sys/windows.NewLazySystemDLL
+// rather than adding a new direct cgo dependency.
+
+func init() {
+	newAssertion = func(reason string) (assertion, error) {
+		return noopAssertion{}, nil
+	}
+}
+
+type noopAssertion struct{}
+
+func (noopAssertion) release() {}

--- a/server/internal/wakelock/wakelock.go
+++ b/server/internal/wakelock/wakelock.go
@@ -1,0 +1,130 @@
+// Package wakelock provides a reference-counted wake lock that prevents the
+// host system from going to sleep while inference requests are in flight.
+//
+// The wake lock is acquired on the first Acquire call (count 0 -> 1) and
+// released when the count returns to zero. Concurrent callers are safe.
+//
+// Each supported platform provides an [assertion] implementation that
+// interacts with the OS power-management facility. Unsupported platforms
+// receive a no-op stub so callers do not need to branch on GOOS.
+package wakelock
+
+import (
+	"log/slog"
+	"sync"
+)
+
+// WakeLock is a reference-counted wake lock. The zero value is not usable;
+// construct one with [New].
+type WakeLock struct {
+	reason string
+
+	mu        sync.Mutex
+	count     int
+	assertion assertion
+	closed    bool
+}
+
+// assertion is the platform-specific OS power assertion. Implementations
+// must be safe to construct and release exactly once; double release must
+// be a no-op.
+type assertion interface {
+	release()
+}
+
+// newAssertion is set by per-platform files and returns the OS power
+// assertion (or an error if it could not be obtained). Stub platforms
+// return a no-op assertion and a nil error.
+var newAssertion func(reason string) (assertion, error)
+
+// Disable replaces the platform assertion with a no-op. Intended for tests
+// that need a real *WakeLock but don't want to touch the OS.
+func Disable() {
+	newAssertion = func(reason string) (assertion, error) {
+		return noopForDisable{}, nil
+	}
+}
+
+type noopForDisable struct{}
+
+func (noopForDisable) release() {}
+
+// New returns a new wake lock. The reason string is supplied to the OS
+// when an assertion is taken; it appears in tools such as
+// `pmset -g assertions` on macOS.
+func New(reason string) *WakeLock {
+	return &WakeLock{reason: reason}
+}
+
+// Acquire increments the in-flight reference count. When the count
+// transitions from zero to one, the underlying OS assertion is taken.
+// Errors from the OS are logged but not returned: failing to prevent
+// sleep should never fail an inference request.
+func (w *WakeLock) Acquire() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return
+	}
+	w.count++
+	if w.count != 1 || w.assertion != nil {
+		return
+	}
+	if newAssertion == nil {
+		return
+	}
+	a, err := newAssertion(w.reason)
+	if err != nil {
+		slog.Debug("failed to acquire wake lock", "error", err)
+		return
+	}
+	w.assertion = a
+}
+
+// Release decrements the in-flight reference count. When the count
+// returns to zero the underlying OS assertion is released. Releasing
+// below zero is a no-op so callers don't have to worry about over-release
+// during shutdown.
+func (w *WakeLock) Release() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.count == 0 {
+		return
+	}
+	w.count--
+	if w.count > 0 {
+		return
+	}
+	if w.assertion != nil {
+		w.assertion.release()
+		w.assertion = nil
+	}
+}
+
+// Close releases any held OS assertion and prevents further acquires.
+// It is safe to call multiple times. Use this from a signal handler or
+// process-exit path so the OS-level assertion isn't orphaned.
+func (w *WakeLock) Close() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.closed = true
+	w.count = 0
+	if w.assertion != nil {
+		w.assertion.release()
+		w.assertion = nil
+	}
+}
+
+// Count returns the current reference count. Exposed for tests.
+func (w *WakeLock) Count() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.count
+}
+
+// Held reports whether an OS assertion is currently held. Exposed for tests.
+func (w *WakeLock) Held() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.assertion != nil
+}

--- a/server/internal/wakelock/wakelock_test.go
+++ b/server/internal/wakelock/wakelock_test.go
@@ -1,0 +1,203 @@
+package wakelock
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// fakeAssertion is a test double that counts acquire/release calls and
+// guards against double release.
+type fakeAssertion struct {
+	released atomic.Bool
+	releases atomic.Int32
+}
+
+func (f *fakeAssertion) release() {
+	f.released.Store(true)
+	f.releases.Add(1)
+}
+
+func TestAcquireReleaseHoldsAssertionOnlyWhenPositive(t *testing.T) {
+	prev := newAssertion
+	var acquires atomic.Int32
+	var current *fakeAssertion
+	newAssertion = func(reason string) (assertion, error) {
+		acquires.Add(1)
+		current = &fakeAssertion{}
+		return current, nil
+	}
+	t.Cleanup(func() { newAssertion = prev })
+
+	w := New("test")
+	if w.Held() {
+		t.Fatal("expected wake lock to be released initially")
+	}
+
+	w.Acquire()
+	if got := w.Count(); got != 1 {
+		t.Fatalf("count = %d, want 1", got)
+	}
+	if !w.Held() {
+		t.Fatal("expected wake lock to be held after first acquire")
+	}
+	if got := acquires.Load(); got != 1 {
+		t.Fatalf("acquires = %d, want 1", got)
+	}
+
+	w.Acquire()
+	if got := w.Count(); got != 2 {
+		t.Fatalf("count = %d, want 2", got)
+	}
+	if got := acquires.Load(); got != 1 {
+		t.Fatalf("acquires = %d, want 1 (re-entry should not take a new assertion)", got)
+	}
+
+	w.Release()
+	if got := w.Count(); got != 1 {
+		t.Fatalf("count = %d, want 1", got)
+	}
+	if current.released.Load() {
+		t.Fatal("assertion released too early")
+	}
+	if !w.Held() {
+		t.Fatal("expected wake lock still held while count > 0")
+	}
+
+	w.Release()
+	if got := w.Count(); got != 0 {
+		t.Fatalf("count = %d, want 0", got)
+	}
+	if !current.released.Load() {
+		t.Fatal("expected assertion released when count reached zero")
+	}
+	if w.Held() {
+		t.Fatal("expected wake lock released")
+	}
+}
+
+func TestReleaseBelowZeroIsNoop(t *testing.T) {
+	prev := newAssertion
+	newAssertion = func(reason string) (assertion, error) {
+		return &fakeAssertion{}, nil
+	}
+	t.Cleanup(func() { newAssertion = prev })
+
+	w := New("test")
+	w.Release()
+	w.Release()
+	if got := w.Count(); got != 0 {
+		t.Fatalf("count = %d, want 0", got)
+	}
+	if w.Held() {
+		t.Fatal("expected wake lock released")
+	}
+}
+
+func TestCloseReleasesAndPreventsAcquire(t *testing.T) {
+	prev := newAssertion
+	var current *fakeAssertion
+	newAssertion = func(reason string) (assertion, error) {
+		current = &fakeAssertion{}
+		return current, nil
+	}
+	t.Cleanup(func() { newAssertion = prev })
+
+	w := New("test")
+	w.Acquire()
+	w.Acquire()
+	w.Close()
+	if !current.released.Load() {
+		t.Fatal("expected assertion released on Close")
+	}
+	if w.Held() {
+		t.Fatal("expected wake lock not held after Close")
+	}
+
+	// After close, Acquire should be a no-op.
+	w.Acquire()
+	if w.Held() {
+		t.Fatal("expected Acquire after Close to be a no-op")
+	}
+	if got := w.Count(); got != 0 {
+		t.Fatalf("count after Acquire-post-Close = %d, want 0", got)
+	}
+
+	// Close is idempotent.
+	w.Close()
+	if got := current.releases.Load(); got != 1 {
+		t.Fatalf("releases = %d, want 1 (Close should not double-release)", got)
+	}
+}
+
+func TestConcurrentAcquireRelease(t *testing.T) {
+	prev := newAssertion
+	var acquires atomic.Int32
+	var releases atomic.Int32
+	newAssertion = func(reason string) (assertion, error) {
+		acquires.Add(1)
+		return &fakeAssertionCounted{releases: &releases}, nil
+	}
+	t.Cleanup(func() { newAssertion = prev })
+
+	w := New("test")
+	const workers = 64
+	const iterations = 1000
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				w.Acquire()
+				w.Release()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := w.Count(); got != 0 {
+		t.Fatalf("count = %d, want 0", got)
+	}
+	if w.Held() {
+		t.Fatal("expected wake lock released after all workers finished")
+	}
+	// Whatever the interleaving was, every acquire must be paired with a release.
+	if acquires.Load() != releases.Load() {
+		t.Fatalf("acquires = %d, releases = %d (expected equal)", acquires.Load(), releases.Load())
+	}
+}
+
+func TestAssertionFailureDoesNotPanic(t *testing.T) {
+	prev := newAssertion
+	newAssertion = func(reason string) (assertion, error) {
+		return nil, errFake
+	}
+	t.Cleanup(func() { newAssertion = prev })
+
+	w := New("test")
+	w.Acquire()
+	if w.Held() {
+		t.Fatal("expected wake lock not held when underlying assertion fails")
+	}
+	if got := w.Count(); got != 1 {
+		t.Fatalf("count = %d, want 1 (refcount still tracked even when OS assertion failed)", got)
+	}
+	// Release path must not blow up when no assertion was taken.
+	w.Release()
+	if got := w.Count(); got != 0 {
+		t.Fatalf("count = %d, want 0", got)
+	}
+}
+
+type fakeAssertionCounted struct {
+	releases *atomic.Int32
+}
+
+func (f *fakeAssertionCounted) release() { f.releases.Add(1) }
+
+type fakeErr struct{}
+
+func (fakeErr) Error() string { return "fake" }
+
+var errFake = fakeErr{}

--- a/server/sched.go
+++ b/server/sched.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ollama/ollama/llm"
 	"github.com/ollama/ollama/logutil"
 	"github.com/ollama/ollama/ml"
+	"github.com/ollama/ollama/server/internal/wakelock"
 	"github.com/ollama/ollama/types/model"
 	"github.com/ollama/ollama/x/imagegen"
 	"github.com/ollama/ollama/x/mlxrunner"
@@ -56,6 +57,10 @@ type Scheduler struct {
 	getGpuFn        func(ctx context.Context, runners []ml.FilteredRunnerDiscovery) []ml.DeviceInfo
 	getSystemInfoFn func() ml.SystemInfo
 	waitForRecovery time.Duration
+
+	// wakeLock prevents the host OS from sleeping while at least one
+	// inference request is in flight. See issue #4072.
+	wakeLock *wakelock.WakeLock
 }
 
 // Default automatic value for number of models we allow per GPU
@@ -77,6 +82,7 @@ func InitScheduler(ctx context.Context) *Scheduler {
 		getGpuFn:        discover.GPUDevices,
 		getSystemInfoFn: discover.GetSystemInfo,
 		waitForRecovery: 5 * time.Second,
+		wakeLock:        wakelock.New("ollama inference"),
 	}
 	sched.loadFn = sched.load
 	return sched
@@ -129,7 +135,7 @@ func (s *Scheduler) GetRunner(c context.Context, m *Model, opts api.Options, ses
 	runner := s.loaded[key]
 	s.loadedMu.Unlock()
 	if runner != nil && !runner.needsReload(c, req) {
-		req.useLoadedRunner(runner, s.finishedReqCh)
+		req.useLoadedRunner(runner, s.finishedReqCh, s.wakeLock)
 	} else {
 		select {
 		case s.pendingReqCh <- req:
@@ -189,7 +195,7 @@ func (s *Scheduler) processPending(ctx context.Context) {
 					} else {
 						// Runner is usable, return it
 						logutil.Trace("using existing loaded runner", "model", pendingKey)
-						pending.useLoadedRunner(runner, s.finishedReqCh)
+						pending.useLoadedRunner(runner, s.finishedReqCh, s.wakeLock)
 						break
 					}
 				} else if maxRunners > 0 && loadedCount >= int(maxRunners) {
@@ -287,6 +293,12 @@ func (s *Scheduler) processCompleted(ctx context.Context) {
 			slog.Debug("shutting down scheduler completed loop")
 			return
 		case finished := <-s.finishedReqCh:
+			// Every finished request corresponds to a wake-lock Acquire from
+			// useLoadedRunner or load; release even if the runner was already
+			// unloaded so the count stays balanced.
+			if s.wakeLock != nil {
+				s.wakeLock.Release()
+			}
 			finishedKey := schedulerModelKey(finished.model)
 			s.loadedMu.Lock()
 			runner := s.loaded[finishedKey]
@@ -387,10 +399,13 @@ func (s *Scheduler) processCompleted(ctx context.Context) {
 // Complete the pending request and send the runner back to the requester
 // Wires up a finished event after the request context is completed
 // Updates session duration, and resets expiration timer
-func (pending *LlmRequest) useLoadedRunner(runner *runnerRef, finished chan *LlmRequest) {
+func (pending *LlmRequest) useLoadedRunner(runner *runnerRef, finished chan *LlmRequest, wake *wakelock.WakeLock) {
 	runner.refMu.Lock()
 	defer runner.refMu.Unlock()
 	runner.refCount++
+	if wake != nil {
+		wake.Acquire()
+	}
 	if runner.expireTimer != nil {
 		runner.expireTimer.Stop()
 		runner.expireTimer = nil
@@ -575,6 +590,9 @@ iGPUScan:
 			runner.pid = llama.Pid()
 		}
 		runner.refCount++
+		if s.wakeLock != nil {
+			s.wakeLock.Acquire()
+		}
 		runner.loading = false
 		go func() {
 			<-req.ctx.Done()
@@ -908,6 +926,12 @@ func (s *Scheduler) unloadAllRunners() {
 			slog.Debug("shutting down runner", "model", model)
 			runner.llama.Close()
 		}
+	}
+
+	// Drop any held wake-lock so we don't leave a caffeinate subprocess
+	// (or future platform assertion) orphaned after shutdown.
+	if s.wakeLock != nil {
+		s.wakeLock.Close()
 	}
 }
 

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -16,12 +16,16 @@ import (
 	"github.com/ollama/ollama/fs/ggml"
 	"github.com/ollama/ollama/llm"
 	"github.com/ollama/ollama/ml"
+	"github.com/ollama/ollama/server/internal/wakelock"
 )
 
 func TestMain(m *testing.M) {
 	os.Setenv("OLLAMA_DEBUG", "1")
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	slog.SetDefault(logger)
+	// Don't take a real OS sleep-prevention assertion (e.g. spawn
+	// `caffeinate` on macOS) during unit tests.
+	wakelock.Disable()
 	os.Exit(m.Run())
 }
 
@@ -655,7 +659,7 @@ func TestSchedUseLoadedRunner(t *testing.T) {
 	finished := make(chan *LlmRequest)
 	llm1 := &mockLlm{vramByGPU: map[ml.DeviceID]uint64{}}
 	r1 := &runnerRef{llama: llm1, sessionDuration: 1, numParallel: 1}
-	req.useLoadedRunner(r1, finished)
+	req.useLoadedRunner(r1, finished, nil)
 	require.Equal(t, uint(1), r1.refCount)
 	require.Equal(t, time.Duration(2), r1.sessionDuration)
 	select {


### PR DESCRIPTION
Adds a reference-counted wake lock owned by the scheduler so the host OS cannot enter idle sleep while inference requests are pending. The first acquired request takes an OS sleep-prevention assertion; the assertion is dropped once the in-flight count returns to zero, including during scheduler shutdown so we don't orphan the OS handle.

On macOS the assertion is held via a `caffeinate -i -w <pid>` subprocess so the assertion is automatically released if ollama exits without running cleanup. Windows and Linux ship no-op stubs with documented implementation paths (`SetThreadExecutionState` and `systemd-inhibit` / `org.freedesktop.login1.Manager.Inhibit` respectively). Subprocess was chosen over cgo to keep the server package free of platform-specific cgo, matching the existing pattern in `app/server/server_unix.go`.

Fixes #4072