### PR TITLE
docs(api): document error response format

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -32,6 +32,41 @@ All durations are returned in nanoseconds.
 
 Certain endpoints stream responses as JSON objects. Streaming can be disabled by providing `{"stream": false}` for these endpoints.
 
+### Errors
+
+When a request fails, the server responds with a JSON body containing an `error` field describing what went wrong:
+
+```json
+{
+  "error": "model 'llama3.99' not found"
+}
+```
+
+Standard HTTP status codes are used to indicate the kind of failure:
+
+- `400 Bad Request` — the request body is missing, malformed, references an invalid model name, or otherwise fails validation
+- `401 Unauthorized` — the request requires authentication. The response body includes a `signin_url` field that points to the page where the user can sign in
+- `403 Forbidden` — the requested operation isn't permitted (for example, remote inference is not available for the model)
+- `404 Not Found` — the referenced model or blob does not exist
+- `500 Internal Server Error` — an unexpected server-side failure
+
+A `401 Unauthorized` response has the following shape:
+
+```json
+{
+  "error": "unauthorized",
+  "signin_url": "https://ollama.com/signin/..."
+}
+```
+
+For [streaming endpoints](#streaming-responses), an error that occurs **before** any chunk has been written is delivered as a regular HTTP error (the body has the same `{"error": "..."}` shape). An error that occurs **after** the response has already started is appended to the stream as a JSON object with an `error` field:
+
+```json
+{"error": "<message>"}
+```
+
+Clients should treat any streamed object containing an `error` field as terminal and stop reading from the stream.
+
 ## Generate a completion
 
 ```


### PR DESCRIPTION
## Summary

Adds an `### Errors` subsection to `docs/api.md` (right after `### Streaming responses`) that documents how the API returns failures.

The Ollama HTTP API returns a uniform `{"error": "<message>"}` JSON body for every non-2xx response, but `docs/api.md` doesn't currently say so anywhere — readers have to discover the response shape, the status codes that are actually used, and the streaming-error semantics by trial and error or by reading `server/routes.go`. This PR closes that documentation gap.

## What the new section covers

- The `{"error": "..."}` body shape used by all error responses
- The HTTP status codes used by the server and what each signals:
  - `400 Bad Request` — missing/malformed body, invalid model name, parameter validation failure
  - `401 Unauthorized` — auth required; body also includes `signin_url`
  - `403 Forbidden` — operation not permitted (e.g. remote inference disabled for the model)
  - `404 Not Found` — referenced model or blob does not exist
  - `500 Internal Server Error` — unexpected server-side failure
- The `signin_url` field on `401` responses
- Streaming-endpoint error semantics:
  - If the failure happens **before** any chunk is written, the client gets a regular HTTP error response.
  - If the failure happens **after** the stream has started, a JSON object with an `error` field is appended to the stream. Clients should treat this object as terminal.

Each statement is verifiable in the source:

- `{"error": "..."}` shape is the only non-2xx body shape the server emits via `c.JSON(..., gin.H{"error": ...})` / `c.AbortWithStatusJSON(..., gin.H{"error": ...})` — see `server/routes.go` and `server/create.go`.
- The status codes are exactly the ones used by the handlers (e.g. `server/routes.go:72, 231, 260, 268, 274, 412, 419, 737, 756`, `server/create.go:57-94`).
- The `signin_url` field on 401 responses is the canonical shape at `server/routes.go:338, 2061, 2078, 2333`.
- The streaming behavior is implemented in `server/routes.go:1953` (`streamResponse`): the `status` field is consumed by the server to set the HTTP status code if no content has been written; only `{"error": "..."}` is ever sent to the client.

## Closes

Fixes #9840

## Test plan

- [x] Pure docs change to `docs/api.md` (no source/test changes)
- [x] Local Markdown render verified — section sits cleanly between `### Streaming responses` and `## Generate a completion`
- [x] Cross-checked every claim against `server/routes.go` and `server/create.go` at HEAD (`6bdb730`)