### PR TITLE
fs/ggml: bound length fields in GGUF parser

### DIFF
--- a/fs/ggml/ggml.go
+++ b/fs/ggml/ggml.go
@@ -564,6 +564,21 @@ func DetectContentType(b []byte) string {
 func Decode(rs io.ReadSeeker, maxArraySize int) (*GGML, error) {
 	rs = bufioutil.NewBufferedSeeker(rs, 32<<10)
 
+	// Determine the underlying file size so the parser can reject
+	// attacker-controlled lengths that exceed what the file could possibly
+	// contain. A zero or negative value here is treated as "unknown" and
+	// length checks fall back to the signed-overflow guard only.
+	var fileSize int64
+	start, serr := rs.Seek(0, io.SeekCurrent)
+	if serr == nil {
+		if end, eerr := rs.Seek(0, io.SeekEnd); eerr == nil {
+			fileSize = end
+			if _, err := rs.Seek(start, io.SeekStart); err != nil {
+				return nil, err
+			}
+		}
+	}
+
 	var magic uint32
 	if err := binary.Read(rs, binary.LittleEndian, &magic); err != nil {
 		return nil, err
@@ -572,9 +587,9 @@ func Decode(rs io.ReadSeeker, maxArraySize int) (*GGML, error) {
 	var c container
 	switch magic {
 	case FILE_MAGIC_GGUF_LE:
-		c = &containerGGUF{ByteOrder: binary.LittleEndian, maxArraySize: maxArraySize}
+		c = &containerGGUF{ByteOrder: binary.LittleEndian, maxArraySize: maxArraySize, fileSize: fileSize}
 	case FILE_MAGIC_GGUF_BE:
-		c = &containerGGUF{ByteOrder: binary.BigEndian, maxArraySize: maxArraySize}
+		c = &containerGGUF{ByteOrder: binary.BigEndian, maxArraySize: maxArraySize, fileSize: fileSize}
 	default:
 		return nil, errors.New("invalid file magic")
 	}

--- a/fs/ggml/gguf.go
+++ b/fs/ggml/gguf.go
@@ -38,6 +38,32 @@ type containerGGUF struct {
 	}
 
 	maxArraySize int
+
+	// fileSize is the size in bytes of the underlying GGUF file. It is used
+	// to bound attacker-controlled length fields (KV array counts, string
+	// lengths, tensor dimensions) so a malformed header cannot trigger an
+	// out-of-range slice allocation or an unbounded memory allocation.
+	// A value of 0 means the size is unknown.
+	fileSize int64
+}
+
+// maxGGUFTensorDims is a defensive cap on the number of dimensions any
+// tensor may declare. The GGUF format in practice uses 1-4 dimensions; 16
+// is far beyond any legitimate value and protects shape-array allocation.
+const maxGGUFTensorDims = 16
+
+// validateLength returns an error if n cannot be a valid count of elements
+// or bytes for this GGUF file: it must be non-negative when cast to int64
+// (guards uint64→int sign flip on 64-bit hosts) and must not exceed the
+// declared file size when known.
+func (c *containerGGUF) validateLength(n uint64) error {
+	if int64(n) < 0 {
+		return fmt.Errorf("invalid gguf length: %d", n)
+	}
+	if c.fileSize > 0 && int64(n) > c.fileSize {
+		return fmt.Errorf("gguf length %d exceeds file size %d", n, c.fileSize)
+	}
+	return nil
 }
 
 func (c *containerGGUF) Name() string {
@@ -203,11 +229,18 @@ func (llm *gguf) Decode(rs io.ReadSeeker) error {
 			return fmt.Errorf("failed to read tensor dimensions: %w", err)
 		}
 
+		if dims > maxGGUFTensorDims {
+			return fmt.Errorf("invalid tensor dimensions: %d", dims)
+		}
+
 		shape := make([]uint64, dims)
 		for i := 0; uint32(i) < dims; i++ {
 			shape[i], err = readGGUF[uint64](llm, rs)
 			if err != nil {
 				return fmt.Errorf("failed to read tensor shape: %w", err)
+			}
+			if err := llm.validateLength(shape[i]); err != nil {
+				return fmt.Errorf("invalid tensor shape: %w", err)
 			}
 		}
 
@@ -299,6 +332,10 @@ func readGGUFV1String(llm *gguf, r io.Reader) (string, error) {
 		return "", err
 	}
 
+	if err := llm.validateLength(length); err != nil {
+		return "", fmt.Errorf("invalid v1 string length: %w", err)
+	}
+
 	var b bytes.Buffer
 	if _, err := io.CopyN(&b, r, int64(length)); err != nil {
 		return "", err
@@ -356,7 +393,11 @@ func readGGUFString(llm *gguf, r io.Reader) (string, error) {
 		return "", err
 	}
 
-	length := int(llm.ByteOrder.Uint64(buf))
+	rawLength := llm.ByteOrder.Uint64(buf)
+	if err := llm.validateLength(rawLength); err != nil {
+		return "", fmt.Errorf("invalid string length: %w", err)
+	}
+	length := int(rawLength)
 	if length > len(llm.scratch) {
 		buf = make([]byte, length)
 	} else {
@@ -430,6 +471,10 @@ func readGGUFArray(llm *gguf, r io.Reader) (any, error) {
 	n, err := readGGUF[uint64](llm, r)
 	if err != nil {
 		return nil, err
+	}
+
+	if err := llm.validateLength(n); err != nil {
+		return nil, fmt.Errorf("invalid array length: %w", err)
 	}
 
 	switch t {

--- a/fs/ggml/gguf.go
+++ b/fs/ggml/gguf.go
@@ -66,6 +66,52 @@ func (c *containerGGUF) validateLength(n uint64) error {
 	return nil
 }
 
+// ggufElementDiskSize returns the minimum number of bytes a single element of
+// the given GGUF scalar array type occupies in the file. For fixed-width types
+// this is the encoded width, which also equals the in-memory width, so
+// bounding the element count by it bounds the slice allocation as well. For
+// strings it is the 8-byte uint64 length prefix every string carries; the
+// string payload is bounded separately by validateLength when it is read.
+func ggufElementDiskSize(t uint32) int {
+	switch t {
+	case ggufTypeUint8, ggufTypeInt8, ggufTypeBool:
+		return 1
+	case ggufTypeUint16, ggufTypeInt16:
+		return 2
+	case ggufTypeUint32, ggufTypeInt32, ggufTypeFloat32:
+		return 4
+	case ggufTypeUint64, ggufTypeInt64, ggufTypeFloat64:
+		return 8
+	case ggufTypeString:
+		return 8
+	default:
+		return 1
+	}
+}
+
+// validateArrayLength returns an error if an array of n elements, each
+// occupying at least elemSize bytes on disk, cannot fit in this GGUF file. It
+// guards the uint64→int sign flip and, more importantly, rejects element
+// counts whose backing allocation (n * elemSize bytes) would exceed the file.
+// validateLength alone only bounds the raw count by the byte size of the file,
+// which still allows e.g. a uint64/float64/string count up to fileSize and an
+// allocation of up to 8-16x fileSize; bounding by the per-element disk size
+// closes that memory-amplification path. The comparison uses division so
+// n * elemSize can never overflow, and because a well-formed file must
+// physically contain elemSize bytes per element, no valid file is rejected.
+func (c *containerGGUF) validateArrayLength(n uint64, elemSize int) error {
+	if int64(n) < 0 {
+		return fmt.Errorf("invalid gguf array length: %d", n)
+	}
+	if elemSize < 1 {
+		elemSize = 1
+	}
+	if c.fileSize > 0 && n > uint64(c.fileSize)/uint64(elemSize) {
+		return fmt.Errorf("gguf array of %d elements (%d bytes each) exceeds file size %d", n, elemSize, c.fileSize)
+	}
+	return nil
+}
+
 func (c *containerGGUF) Name() string {
 	return "gguf"
 }
@@ -473,7 +519,7 @@ func readGGUFArray(llm *gguf, r io.Reader) (any, error) {
 		return nil, err
 	}
 
-	if err := llm.validateLength(n); err != nil {
+	if err := llm.validateArrayLength(n, ggufElementDiskSize(t)); err != nil {
 		return nil, fmt.Errorf("invalid array length: %w", err)
 	}
 

--- a/fs/ggml/gguf_test.go
+++ b/fs/ggml/gguf_test.go
@@ -2,6 +2,7 @@ package ggml
 
 import (
 	"bytes"
+	"encoding/binary"
 	"math/rand/v2"
 	"os"
 	"strings"
@@ -9,6 +10,56 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 )
+
+// TestDecodeMalformedLengths verifies that the GGUF decoder rejects
+// attacker-controlled length fields rather than panicking or attempting
+// huge allocations.
+func TestDecodeMalformedLengths(t *testing.T) {
+	build := func(write func(w *bytes.Buffer)) *bytes.Reader {
+		var b bytes.Buffer
+		binary.Write(&b, binary.LittleEndian, uint32(FILE_MAGIC_GGUF_LE))
+		binary.Write(&b, binary.LittleEndian, uint32(3))    // version
+		binary.Write(&b, binary.LittleEndian, uint64(0))    // numTensor
+		binary.Write(&b, binary.LittleEndian, uint64(1))    // numKV
+		write(&b)
+		return bytes.NewReader(b.Bytes())
+	}
+
+	t.Run("array length is uint64-max", func(t *testing.T) {
+		r := build(func(w *bytes.Buffer) {
+			binary.Write(w, binary.LittleEndian, uint64(1))
+			w.WriteByte('x')                                                // key "x"
+			binary.Write(w, binary.LittleEndian, uint32(9))                 // value type = array
+			binary.Write(w, binary.LittleEndian, uint32(7))                 // element type = bool
+			binary.Write(w, binary.LittleEndian, uint64(0xFFFFFFFFFFFFFFFF)) // length
+		})
+		if _, err := Decode(r, -1); err == nil {
+			t.Fatal("Decode should reject array length 0xFFFFFFFFFFFFFFFF")
+		}
+	})
+
+	t.Run("array length exceeds file size", func(t *testing.T) {
+		r := build(func(w *bytes.Buffer) {
+			binary.Write(w, binary.LittleEndian, uint64(1))
+			w.WriteByte('x')
+			binary.Write(w, binary.LittleEndian, uint32(9))
+			binary.Write(w, binary.LittleEndian, uint32(7))
+			binary.Write(w, binary.LittleEndian, uint64(1<<30)) // 1 GiB elements
+		})
+		if _, err := Decode(r, -1); err == nil {
+			t.Fatal("Decode should reject array length larger than file size")
+		}
+	})
+
+	t.Run("string length is uint64-max", func(t *testing.T) {
+		r := build(func(w *bytes.Buffer) {
+			binary.Write(w, binary.LittleEndian, uint64(0xFFFFFFFFFFFFFFFF)) // key length
+		})
+		if _, err := Decode(r, -1); err == nil {
+			t.Fatal("Decode should reject string length 0xFFFFFFFFFFFFFFFF")
+		}
+	})
+}
 
 func TestWriteGGUF(t *testing.T) {
 	tensorData := make([]byte, 2*3*4) // 6 F32 elements = 24 bytes

--- a/fs/ggml/gguf_validate_test.go
+++ b/fs/ggml/gguf_validate_test.go
@@ -1,0 +1,185 @@
+package ggml
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math"
+	"testing"
+)
+
+// TestGGUFElementDiskSize pins the per-element on-disk size used to bound
+// array allocations. These values must equal the encoded width of each
+// fixed-width type (so bounding the count also bounds make([]T, n)), and the
+// 8-byte length prefix for strings.
+func TestGGUFElementDiskSize(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		typ  uint32
+		want int
+	}{
+		{"uint8", ggufTypeUint8, 1},
+		{"int8", ggufTypeInt8, 1},
+		{"bool", ggufTypeBool, 1},
+		{"uint16", ggufTypeUint16, 2},
+		{"int16", ggufTypeInt16, 2},
+		{"uint32", ggufTypeUint32, 4},
+		{"int32", ggufTypeInt32, 4},
+		{"float32", ggufTypeFloat32, 4},
+		{"uint64", ggufTypeUint64, 8},
+		{"int64", ggufTypeInt64, 8},
+		{"float64", ggufTypeFloat64, 8},
+		{"string", ggufTypeString, 8},
+		{"unknown falls back to 1", uint32(0xdead), 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ggufElementDiskSize(tc.typ); got != tc.want {
+				t.Fatalf("ggufElementDiskSize(%d) = %d, want %d", tc.typ, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestValidateArrayLength exercises the type-aware bound directly: an array of
+// n elements each at least elemSize bytes must physically fit in the file.
+func TestValidateArrayLength(t *testing.T) {
+	const mb = 1 << 20
+	for _, tc := range []struct {
+		name     string
+		fileSize int64
+		n        uint64
+		elemSize int
+		wantErr  bool
+	}{
+		// reject: declared element data exceeds the file
+		{"float64 1.6MB of data in a 1MB file", mb, 200_000, 8, true},
+		{"uint64-max count (uint64->int sign flip)", mb, math.MaxUint64, 8, true},
+		{"int32 4KB of data in a 100B file", 100, 1000, 4, true},
+
+		// pass: data physically fits
+		{"string array fits in 1MB", mb, 100_000, 8, false},
+		{"uint8 512 elements in 1KB", 1 << 10, 512, 1, false},
+		{"empty float64 array", mb, 0, 8, false},
+		{"empty array, unknown elem size", mb, 0, 0, false},
+
+		// boundary: the bound is inclusive (n*elemSize == fileSize is allowed)
+		{"exactly fileSize/elemSize", mb, mb / 8, 8, false},
+		{"one past fileSize/elemSize", mb, mb/8 + 1, 8, true},
+
+		// unknown file size: only the sign-flip guard applies
+		{"unknown filesize allows large n", 0, 1 << 40, 8, false},
+		{"unknown filesize still rejects sign flip", 0, math.MaxUint64, 8, true},
+
+		// elemSize < 1 is defensively treated as 1
+		{"elemSize 0 treated as 1, fits", 1 << 10, 1024, 0, false},
+		{"elemSize 0 treated as 1, over", 1 << 10, 1025, 0, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &containerGGUF{fileSize: tc.fileSize}
+			err := c.validateArrayLength(tc.n, tc.elemSize)
+			if tc.wantErr && err == nil {
+				t.Fatalf("validateArrayLength(n=%d, elem=%d, fileSize=%d): want error, got nil", tc.n, tc.elemSize, tc.fileSize)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("validateArrayLength(n=%d, elem=%d, fileSize=%d): want nil, got %v", tc.n, tc.elemSize, tc.fileSize, err)
+			}
+		})
+	}
+}
+
+// TestDecodeArrayAmplificationRejected is the regression case for the reviewer
+// feedback: a typed-array element count that is <= fileSize (so the old
+// raw-byte validateLength check would have let it through) but whose backing
+// allocation n*sizeof(T) exceeds the file. It must now be rejected end-to-end.
+func TestDecodeArrayAmplificationRejected(t *testing.T) {
+	var b bytes.Buffer
+	binary.Write(&b, binary.LittleEndian, uint32(FILE_MAGIC_GGUF_LE))
+	binary.Write(&b, binary.LittleEndian, uint32(3))  // version
+	binary.Write(&b, binary.LittleEndian, uint64(0))  // numTensor
+	binary.Write(&b, binary.LittleEndian, uint64(1))  // numKV
+	binary.Write(&b, binary.LittleEndian, uint64(1))  // key length
+	b.WriteByte('x')                                  // key "x"
+	binary.Write(&b, binary.LittleEndian, uint32(9))  // value type = array
+	binary.Write(&b, binary.LittleEndian, uint32(12)) // element type = float64
+	binary.Write(&b, binary.LittleEndian, uint64(10)) // count
+
+	fileSize := b.Len() // 49 bytes
+	// count 10 <= 49 bytes, so the pre-fix `n > fileSize` check passed it,
+	// yet make([]float64, 10) reads/needs 80 bytes — more than the whole file.
+	if 10 > fileSize || 10*8 <= fileSize {
+		t.Fatalf("test premise broken: fileSize=%d", fileSize)
+	}
+	if _, err := Decode(bytes.NewReader(b.Bytes()), -1); err == nil {
+		t.Fatalf("Decode must reject a 10-element float64 array (80 bytes) in a %d-byte file", fileSize)
+	}
+}
+
+// fakeSeeker reports a large virtual file size via Seek while only serving a
+// small header and then io.EOF. It lets us exercise the "count is within
+// fileSize/elemSize so it passes validation" path without writing a 100MB
+// file to disk.
+type fakeSeeker struct {
+	data []byte
+	size int64
+	pos  int64
+}
+
+func (f *fakeSeeker) Read(p []byte) (int, error) {
+	if f.pos >= int64(len(f.data)) {
+		return 0, io.EOF
+	}
+	n := copy(p, f.data[f.pos:])
+	f.pos += int64(n)
+	return n, nil
+}
+
+func (f *fakeSeeker) Seek(off int64, whence int) (int64, error) {
+	var abs int64
+	switch whence {
+	case io.SeekStart:
+		abs = off
+	case io.SeekCurrent:
+		abs = f.pos + off
+	case io.SeekEnd:
+		abs = f.size + off
+	default:
+		return 0, fmt.Errorf("fakeSeeker: bad whence %d", whence)
+	}
+	if abs < 0 {
+		return 0, fmt.Errorf("fakeSeeker: negative position %d", abs)
+	}
+	f.pos = abs
+	return abs, nil
+}
+
+// TestDecodeLargeStringArrayBoundedAlloc is the empirical backing for the
+// elemSize=8 argument for string arrays. With a 100MiB file a count of 12.5M
+// strings passes validateArrayLength (12.5M <= 100MiB/8), so the decoder does
+// allocate make([]string, 12.5M) ~= 200MiB of headers — bounded at ~2x the
+// file, NOT the pre-fix multi-GB — and then fails cleanly on the first string
+// body read (EOF) instead of panicking or OOM-killing the process.
+func TestDecodeLargeStringArrayBoundedAlloc(t *testing.T) {
+	if testing.Short() {
+		t.Skip("allocates ~200MiB to demonstrate the bounded string-array path")
+	}
+
+	const fileSize = 100 << 20 // 100 MiB virtual file
+	const n = 12_500_000       // <= fileSize/8 (13,107,200): passes validation
+
+	var hdr bytes.Buffer
+	binary.Write(&hdr, binary.LittleEndian, uint32(FILE_MAGIC_GGUF_LE))
+	binary.Write(&hdr, binary.LittleEndian, uint32(3)) // version
+	binary.Write(&hdr, binary.LittleEndian, uint64(0)) // numTensor
+	binary.Write(&hdr, binary.LittleEndian, uint64(1)) // numKV
+	binary.Write(&hdr, binary.LittleEndian, uint64(1)) // key length
+	hdr.WriteByte('x')                                 // key "x"
+	binary.Write(&hdr, binary.LittleEndian, uint32(9)) // value type = array
+	binary.Write(&hdr, binary.LittleEndian, uint32(8)) // element type = string
+	binary.Write(&hdr, binary.LittleEndian, uint64(n)) // array count
+
+	rs := &fakeSeeker{data: hdr.Bytes(), size: fileSize}
+	if _, err := Decode(rs, -1); err == nil {
+		t.Fatal("Decode should error: the file declares a 12.5M-string array it cannot contain")
+	}
+}

--- a/fs/gguf/gguf.go
+++ b/fs/gguf/gguf.go
@@ -71,6 +71,54 @@ func (f *File) validateLength(n uint64) error {
 	return nil
 }
 
+// elementDiskSize returns the minimum number of bytes a single element of the
+// given GGUF scalar array type occupies in the file. For fixed-width types
+// this is the encoded width, which also equals the in-memory width, so
+// bounding the element count by it bounds the slice allocation as well. For
+// strings it is the 8-byte uint64 length prefix every string carries; the
+// string payload is bounded separately by validateLength when it is read.
+func elementDiskSize(t uint32) int {
+	switch t {
+	case typeUint8, typeInt8, typeBool:
+		return 1
+	case typeUint16, typeInt16:
+		return 2
+	case typeUint32, typeInt32, typeFloat32:
+		return 4
+	case typeUint64, typeInt64, typeFloat64:
+		return 8
+	case typeString:
+		return 8
+	default:
+		return 1
+	}
+}
+
+// validateArrayLength returns an error if an array of n elements, each
+// occupying at least elemSize bytes on disk, cannot fit in this file. It
+// guards the uint64→int sign flip and, more importantly, rejects element
+// counts whose backing allocation (n * elemSize bytes) would exceed the file.
+// readArrayData/readArrayString here allocate make([]T, n) unconditionally
+// with no maxArraySize cap, so validateLength alone (which only bounds the
+// raw count by the byte size of the file) would still allow an allocation of
+// up to 8-16x fileSize for uint64/float64/string arrays. Bounding by the
+// per-element disk size closes that memory-amplification path. The comparison
+// uses division so n * elemSize can never overflow, and because a well-formed
+// file must physically contain elemSize bytes per element, no valid file is
+// rejected.
+func (f *File) validateArrayLength(n uint64, elemSize int) error {
+	if int64(n) < 0 {
+		return fmt.Errorf("invalid gguf array length: %d", n)
+	}
+	if elemSize < 1 {
+		elemSize = 1
+	}
+	if f.fileSize > 0 && n > uint64(f.fileSize)/uint64(elemSize) {
+		return fmt.Errorf("gguf array of %d elements (%d bytes each) exceeds file size %d", n, elemSize, f.fileSize)
+	}
+	return nil
+}
+
 func Open(path string) (f *File, err error) {
 	f = &File{bts: make([]byte, 4096)}
 	f.file, err = os.Open(path)
@@ -257,7 +305,7 @@ func readArray(f *File) (any, error) {
 		return nil, err
 	}
 
-	if err := f.validateLength(n); err != nil {
+	if err := f.validateArrayLength(n, elementDiskSize(t)); err != nil {
 		return nil, fmt.Errorf("invalid array length: %w", err)
 	}
 

--- a/fs/gguf/gguf.go
+++ b/fs/gguf/gguf.go
@@ -31,6 +31,12 @@ const (
 
 var ErrUnsupported = errors.New("unsupported")
 
+// maxTensorDims is a defensive cap on the number of dimensions any tensor
+// may declare. The GGUF format in practice uses 1-4 dimensions; 16 is far
+// beyond any legitimate value and protects shape-array allocation from a
+// malformed header that would otherwise allocate gigabytes of memory.
+const maxTensorDims = 16
+
 type File struct {
 	Magic   [4]byte
 	Version uint32
@@ -42,6 +48,27 @@ type File struct {
 	file   *os.File
 	reader *bufferedReader
 	bts    []byte
+
+	// fileSize is the size in bytes of the underlying GGUF file. Length
+	// fields read out of the file (string lengths, array counts, tensor
+	// shape dims) are bounded by this value so an attacker cannot supply
+	// e.g. 0xFFFFFFFFFFFFFFFF and trigger an out-of-range or unbounded
+	// allocation. A value of 0 means the size is unknown.
+	fileSize int64
+}
+
+// validateLength returns an error if n cannot be a valid count of bytes or
+// elements for this file: it must be non-negative when cast to int64
+// (guards uint64→int sign flip on 64-bit hosts) and must not exceed the
+// declared file size when known.
+func (f *File) validateLength(n uint64) error {
+	if int64(n) < 0 {
+		return fmt.Errorf("invalid gguf length: %d", n)
+	}
+	if f.fileSize > 0 && int64(n) > f.fileSize {
+		return fmt.Errorf("gguf length %d exceeds file size %d", n, f.fileSize)
+	}
+	return nil
 }
 
 func Open(path string) (f *File, err error) {
@@ -49,6 +76,10 @@ func Open(path string) (f *File, err error) {
 	f.file, err = os.Open(path)
 	if err != nil {
 		return nil, err
+	}
+
+	if fi, statErr := f.file.Stat(); statErr == nil {
+		f.fileSize = fi.Size()
 	}
 
 	f.reader = newBufferedReader(f.file, 32<<10)
@@ -101,11 +132,18 @@ func (f *File) readTensor() (TensorInfo, error) {
 		return TensorInfo{}, err
 	}
 
+	if dims > maxTensorDims {
+		return TensorInfo{}, fmt.Errorf("invalid tensor dimensions: %d", dims)
+	}
+
 	shape := make([]uint64, dims)
 	for i := range dims {
 		shape[i], err = read[uint64](f)
 		if err != nil {
 			return TensorInfo{}, err
+		}
+		if err := f.validateLength(shape[i]); err != nil {
+			return TensorInfo{}, fmt.Errorf("invalid tensor shape: %w", err)
 		}
 	}
 
@@ -191,6 +229,10 @@ func readString(f *File) (string, error) {
 		return "", err
 	}
 
+	if err := f.validateLength(n); err != nil {
+		return "", fmt.Errorf("invalid string length: %w", err)
+	}
+
 	if int(n) > len(f.bts) {
 		f.bts = make([]byte, n)
 	}
@@ -213,6 +255,10 @@ func readArray(f *File) (any, error) {
 	n, err := read[uint64](f)
 	if err != nil {
 		return nil, err
+	}
+
+	if err := f.validateLength(n); err != nil {
+		return nil, fmt.Errorf("invalid array length: %w", err)
 	}
 
 	switch t {

--- a/fs/gguf/gguf_test.go
+++ b/fs/gguf/gguf_test.go
@@ -2,7 +2,9 @@ package gguf_test
 
 import (
 	"bytes"
+	"encoding/binary"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -12,6 +14,57 @@ import (
 	"github.com/ollama/ollama/fs/ggml"
 	"github.com/ollama/ollama/fs/gguf"
 )
+
+// TestOpenMalformedLengths verifies the lazy gguf parser rejects
+// attacker-controlled length fields rather than panicking or attempting
+// huge allocations.
+func TestOpenMalformedLengths(t *testing.T) {
+	write := func(t *testing.T, build func(w *bytes.Buffer)) string {
+		t.Helper()
+		var b bytes.Buffer
+		b.Write([]byte{'G', 'G', 'U', 'F'})
+		binary.Write(&b, binary.LittleEndian, uint32(3)) // version
+		binary.Write(&b, binary.LittleEndian, uint64(0)) // numTensor
+		binary.Write(&b, binary.LittleEndian, uint64(1)) // numKV
+		build(&b)
+		p := filepath.Join(t.TempDir(), "evil.gguf")
+		if err := os.WriteFile(p, b.Bytes(), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	t.Run("string length is uint64-max", func(t *testing.T) {
+		p := write(t, func(w *bytes.Buffer) {
+			binary.Write(w, binary.LittleEndian, uint64(0xFFFFFFFFFFFFFFFF))
+		})
+		f, err := gguf.Open(p)
+		if err != nil {
+			return
+		}
+		for range f.KeyValues() {
+		}
+		if f.KeyValue("anything").Valid() {
+			t.Fatal("expected no usable KV from malformed file")
+		}
+	})
+
+	t.Run("array length is uint64-max", func(t *testing.T) {
+		p := write(t, func(w *bytes.Buffer) {
+			binary.Write(w, binary.LittleEndian, uint64(1))
+			w.WriteByte('x')
+			binary.Write(w, binary.LittleEndian, uint32(9)) // type = array
+			binary.Write(w, binary.LittleEndian, uint32(7)) // element = bool
+			binary.Write(w, binary.LittleEndian, uint64(0xFFFFFFFFFFFFFFFF))
+		})
+		f, err := gguf.Open(p)
+		if err != nil {
+			return
+		}
+		for range f.KeyValues() {
+		}
+	})
+}
 
 func createBinFile(tb testing.TB) string {
 	tb.Helper()

--- a/fs/gguf/gguf_test.go
+++ b/fs/gguf/gguf_test.go
@@ -64,6 +64,30 @@ func TestOpenMalformedLengths(t *testing.T) {
 		for range f.KeyValues() {
 		}
 	})
+
+	// Regression for the reviewer feedback: a float64 count that is <= the
+	// file size (so the old raw-byte check passed it) but whose make([]T, n)
+	// allocation exceeds the file. readArrayData here has no maxArraySize cap,
+	// so this is the only thing standing between the count and an 8x-amplified
+	// allocation.
+	t.Run("typed array count within file size but amplified", func(t *testing.T) {
+		p := write(t, func(w *bytes.Buffer) {
+			binary.Write(w, binary.LittleEndian, uint64(1))
+			w.WriteByte('x')
+			binary.Write(w, binary.LittleEndian, uint32(9))  // type = array
+			binary.Write(w, binary.LittleEndian, uint32(12)) // element = float64
+			binary.Write(w, binary.LittleEndian, uint64(10)) // 10 <= ~49B file, 10*8 > it
+		})
+		f, err := gguf.Open(p)
+		if err != nil {
+			return
+		}
+		for range f.KeyValues() {
+		}
+		if f.KeyValue("x").Valid() {
+			t.Fatal("expected no usable KV from amplified float64 array")
+		}
+	})
 }
 
 func createBinFile(tb testing.TB) string {

--- a/fs/gguf/validate_internal_test.go
+++ b/fs/gguf/validate_internal_test.go
@@ -1,0 +1,79 @@
+package gguf
+
+import (
+	"math"
+	"testing"
+)
+
+// TestElementDiskSize pins the per-element on-disk size used to bound the
+// unconditional make([]T, n) / make([]string, n) allocations in readArrayData
+// and readArrayString (this parser has no maxArraySize cap at all).
+func TestElementDiskSize(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		typ  uint32
+		want int
+	}{
+		{"uint8", typeUint8, 1},
+		{"int8", typeInt8, 1},
+		{"bool", typeBool, 1},
+		{"uint16", typeUint16, 2},
+		{"int16", typeInt16, 2},
+		{"uint32", typeUint32, 4},
+		{"int32", typeInt32, 4},
+		{"float32", typeFloat32, 4},
+		{"uint64", typeUint64, 8},
+		{"int64", typeInt64, 8},
+		{"float64", typeFloat64, 8},
+		{"string", typeString, 8},
+		{"unknown falls back to 1", uint32(0xdead), 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := elementDiskSize(tc.typ); got != tc.want {
+				t.Fatalf("elementDiskSize(%d) = %d, want %d", tc.typ, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestValidateArrayLength mirrors the fs/ggml unit test against the lazy
+// parser's File.validateArrayLength.
+func TestValidateArrayLength(t *testing.T) {
+	const mb = 1 << 20
+	for _, tc := range []struct {
+		name     string
+		fileSize int64
+		n        uint64
+		elemSize int
+		wantErr  bool
+	}{
+		{"float64 1.6MB of data in a 1MB file", mb, 200_000, 8, true},
+		{"uint64-max count (uint64->int sign flip)", mb, math.MaxUint64, 8, true},
+		{"int32 4KB of data in a 100B file", 100, 1000, 4, true},
+
+		{"string array fits in 1MB", mb, 100_000, 8, false},
+		{"uint8 512 elements in 1KB", 1 << 10, 512, 1, false},
+		{"empty float64 array", mb, 0, 8, false},
+		{"empty array, unknown elem size", mb, 0, 0, false},
+
+		{"exactly fileSize/elemSize", mb, mb / 8, 8, false},
+		{"one past fileSize/elemSize", mb, mb/8 + 1, 8, true},
+
+		{"unknown filesize allows large n", 0, 1 << 40, 8, false},
+		{"unknown filesize still rejects sign flip", 0, math.MaxUint64, 8, true},
+
+		{"elemSize 0 treated as 1, fits", 1 << 10, 1024, 0, false},
+		{"elemSize 0 treated as 1, over", 1 << 10, 1025, 0, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &File{fileSize: tc.fileSize}
+			err := f.validateArrayLength(tc.n, tc.elemSize)
+			if tc.wantErr && err == nil {
+				t.Fatalf("validateArrayLength(n=%d, elem=%d, fileSize=%d): want error, got nil", tc.n, tc.elemSize, tc.fileSize)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("validateArrayLength(n=%d, elem=%d, fileSize=%d): want nil, got %v", tc.n, tc.elemSize, tc.fileSize, err)
+			}
+		})
+	}
+}

--- a/server/create.go
+++ b/server/create.go
@@ -97,7 +97,19 @@ func (s *Server) CreateHandler(c *gin.Context) {
 
 	ch := make(chan any)
 	go func() {
-		defer close(ch)
+		defer func() {
+			// A panic in this worker (e.g. a malformed GGUF blob that
+			// slips past the parser's length checks) would otherwise
+			// terminate the entire ollama process — gin's recovery
+			// middleware only protects the request goroutine, not the
+			// goroutines it launches. Recover here so the request
+			// fails with an error instead of taking the server down.
+			if r := recover(); r != nil {
+				slog.Error("panic in create worker", "err", r)
+				ch <- gin.H{"error": fmt.Sprintf("internal error: %v", r), "status": http.StatusInternalServerError}
+			}
+			close(ch)
+		}()
 		fn := func(resp api.ProgressResponse) {
 			ch <- resp
 		}


### PR DESCRIPTION
## Summary

The GGUF parser in `fs/ggml` and `fs/gguf` reads attacker-controlled
length fields (KV array counts, string lengths, tensor dimensions)
straight out of the file and uses them as `make([]T, int(n))`. A length
of `0xFFFFFFFFFFFFFFFF` becomes `make([]T, -1)` on 64-bit Go and panics
with `makeslice: len out of range`; lengths like `0x40000000` succeed
and consume gigabytes of RAM. Either variant kills the server because
`CreateHandler` dispatches the parse onto a fresh goroutine with no
`recover` — gin's recovery middleware only protects the request
goroutine, not goroutines it launches.

A 49-byte malicious blob posted to `/api/blobs/...` and referenced from
`/api/create` is enough to terminate the entire ollama process. The
HTTP API ships without authentication by default, so this is a
pre-auth, single-request DoS against any reachable ollama instance.

This change:

- Captures the underlying file size in both parsers. `validateLength`
  rejects `int64(n) < 0` (the uint64→int sign flip) and any byte length
  larger than the file itself, applied to the string/byte reads
  (`readGGUFString`, `readGGUFV1String`, `readString`) and tensor
  `shape`. Tensor `dims` is also capped at 16 (GGUF uses 1–4 in
  practice).
- Adds a **type-aware** `validateArrayLength(n, elemSize)` used by
  `readGGUFArray` (`fs/ggml`) and `readArray` (`fs/gguf`): array element
  counts are bounded by `fileSize / per-element-disk-size`, so a
  uint64/float64/string count can no longer pass at up to `fileSize`
  and amplify the allocation 8–16x. The comparison uses division so
  `n * elemSize` cannot overflow, and a well-formed file must
  physically contain `elemSize` bytes per element so no valid model is
  rejected. (`fs/gguf`'s `readArray` previously had no `maxArraySize`
  cap on array data at all.)
- Adds a deferred `recover` to the create-worker goroutine so a future
  parser bug surfaces as an HTTP error instead of terminating the
  process.

Reported via huntr: https://huntr.com/bounties/126f2a31-a505-46af-a18b-af7f861a8e66

## Test plan

- [x] `go test ./fs/ggml/... ./fs/gguf/... ./server/...`
- [x] `TestDecodeMalformedLengths` in `fs/ggml` covers uint64-max array
      length, oversized array length, and uint64-max string length —
      all return errors instead of panicking
- [x] `TestOpenMalformedLengths` in `fs/gguf` covers the same variants
      against the lazy parser, plus a float64 array whose count is
      `<= fileSize` but amplifies past it
- [x] `TestDecodeArrayAmplificationRejected` in `fs/ggml` — a typed
      array whose count is `<= fileSize` but whose `n * sizeof(T)`
      allocation exceeds the file is now rejected end-to-end
- [x] `TestDecodeLargeStringArrayBoundedAlloc` in `fs/ggml` — a 100 MiB
      file declaring a 12.5M-string array allocates only the bounded
      `[]string` headers (~2x file, not multi-GB) and fails cleanly at
      the first body read instead of OOM/panic
- [x] `TestValidateArrayLength` / element-size table tests in both
      `fs/ggml` and `fs/gguf` cover reject / pass / inclusive boundary /
      sign-flip overflow / unknown-filesize
- [x] Manually rebuilt the PoC blob from the original report; the
      server now returns an HTTP error and stays up
