### PR TITLE
feat: include cached token count in API responses for local models

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -571,6 +571,7 @@ type DebugInfo struct {
 type Metrics struct {
 	TotalDuration      time.Duration `json:"total_duration,omitempty"`
 	LoadDuration       time.Duration `json:"load_duration,omitempty"`
+	PromptCachedCount  int           `json:"prompt_cached_count,omitempty"`
 	PromptEvalCount    int           `json:"prompt_eval_count,omitempty"`
 	PromptEvalDuration time.Duration `json:"prompt_eval_duration,omitempty"`
 	EvalCount          int           `json:"eval_count,omitempty"`
@@ -952,6 +953,10 @@ func (m *Metrics) Summary() {
 
 	if m.LoadDuration > 0 {
 		fmt.Fprintf(os.Stderr, "load duration:        %v\n", m.LoadDuration)
+	}
+
+	if m.PromptCachedCount > 0 {
+		fmt.Fprintf(os.Stderr, "prompt cached count:  %d token(s)\n", m.PromptCachedCount)
 	}
 
 	if m.PromptEvalCount > 0 {

--- a/docs/api.md
+++ b/docs/api.md
@@ -109,6 +109,7 @@ The final response in the stream also includes additional data about the generat
 
 - `total_duration`: time spent generating the response
 - `load_duration`: time spent in nanoseconds loading the model
+- `prompt_cached_count`: number of tokens served from KV cache
 - `prompt_eval_count`: number of tokens in the prompt
 - `prompt_eval_duration`: time spent in nanoseconds evaluating the prompt
 - `eval_count`: number of tokens in the response
@@ -127,6 +128,7 @@ To calculate how fast the response is generated in tokens per second (token/s), 
   "context": [1, 2, 3],
   "total_duration": 10706818083,
   "load_duration": 6338219291,
+  "prompt_cached_count": 10,
   "prompt_eval_count": 26,
   "prompt_eval_duration": 130079000,
   "eval_count": 259,
@@ -161,6 +163,7 @@ If `stream` is set to `false`, the response will be a single JSON object:
   "context": [1, 2, 3],
   "total_duration": 5043500667,
   "load_duration": 5025959,
+  "prompt_cached_count": 10,
   "prompt_eval_count": 26,
   "prompt_eval_duration": 325953000,
   "eval_count": 290,
@@ -583,6 +586,7 @@ Final response:
   "done": true,
   "total_duration": 4883583458,
   "load_duration": 1334875,
+  "prompt_cached_count": 10,
   "prompt_eval_count": 26,
   "prompt_eval_duration": 342546000,
   "eval_count": 282,
@@ -997,6 +1001,7 @@ curl http://localhost:11434/api/chat -d '{
   "done": true,
   "total_duration": 1668506709,
   "load_duration": 1986209,
+  "prompt_cached_count": 10,
   "prompt_eval_count": 26,
   "prompt_eval_duration": 359682000,
   "eval_count": 83,

--- a/docs/api/usage.mdx
+++ b/docs/api/usage.mdx
@@ -6,6 +6,7 @@ Ollama's API responses include metrics that can be used for measuring performanc
 
 * `total_duration`: How long the response took to generate
 * `load_duration`: How long the model took to load
+* `prompt_cached_count`: How many input tokens were served from KV cache
 * `prompt_eval_count`: How many input tokens were processed
 * `prompt_eval_duration`: How long it took to evaluate the prompt
 * `eval_count`: How many output tokens were processes
@@ -26,6 +27,7 @@ For endpoints that return usage metrics, the response body will include the usag
   "done_reason": "stop",
   "total_duration": 174560334,
   "load_duration": 101397084,
+  "prompt_cached_count": 5,
   "prompt_eval_count": 11,
   "prompt_eval_duration": 13074791,
   "eval_count": 18,

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -144,9 +144,12 @@ components:
         load_duration:
           type: integer
           description: Time spent loading the model in nanoseconds
+        prompt_cached_count:
+          type: integer
+          description: Number of input tokens served from KV cache
         prompt_eval_count:
           type: integer
-          description: Number of input tokens in the prompt
+          description: Total number of input tokens in the prompt
         prompt_eval_duration:
           type: integer
           description: Time spent evaluating the prompt in nanoseconds
@@ -188,9 +191,12 @@ components:
         load_duration:
           type: integer
           description: Time spent loading the model in nanoseconds
+        prompt_cached_count:
+          type: integer
+          description: Number of input tokens served from KV cache
         prompt_eval_count:
           type: integer
-          description: Number of input tokens in the prompt
+          description: Total number of input tokens in the prompt
         prompt_eval_duration:
           type: integer
           description: Time spent evaluating the prompt in nanoseconds
@@ -349,9 +355,12 @@ components:
         load_duration:
           type: integer
           description: Time spent loading the model in nanoseconds
+        prompt_cached_count:
+          type: integer
+          description: Number of input tokens served from KV cache
         prompt_eval_count:
           type: integer
-          description: Number of tokens in the prompt
+          description: Total number of tokens in the prompt
         prompt_eval_duration:
           type: integer
           description: Time spent evaluating the prompt in nanoseconds
@@ -887,6 +896,7 @@ paths:
                 done_reason: "stop"
                 total_duration: 174560334
                 load_duration: 101397084
+                prompt_cached_count: 5
                 prompt_eval_count: 11
                 prompt_eval_duration: 13074791
                 eval_count: 18
@@ -1045,6 +1055,7 @@ paths:
                 done_reason: "stop"
                 total_duration: 174560334
                 load_duration: 101397084
+                prompt_cached_count: 5
                 prompt_eval_count: 11
                 prompt_eval_duration: 13074791
                 eval_count: 18

--- a/integration/api_test.go
+++ b/integration/api_test.go
@@ -97,12 +97,10 @@ func TestAPIGenerate(t *testing.T) {
 					if len(response.Context) == 0 {
 						t.Errorf("final response missing context: %#v", response)
 					}
-
-					// Note: caching can result in no prompt eval count, so this can't be verified reliably
-					// if response.Metrics.PromptEvalCount == 0 {
-					// 	t.Errorf("final response missing prompt_eval_count: %#v", response)
-					// }
-
+					// Caching can result in no prompt eval count, so testing sum
+					if response.Metrics.PromptCachedCount + response.Metrics.PromptEvalCount == 0 {
+						t.Errorf("final response has prompt_eval_count + prompt_cached_count == 0: %#v", response)
+					}
 				} // else incremental response, nothing to check right now...
 				buf.Write([]byte(response.Response))
 				if !stallTimer.Reset(streamTimeout) {
@@ -260,8 +258,8 @@ func TestAPIChat(t *testing.T) {
 						t.Errorf("final response missing eval_duration: %#v", response)
 					}
 
-					if response.Metrics.PromptEvalCount == 0 {
-						t.Errorf("final response missing prompt_eval_count: %#v", response)
+					if response.Metrics.PromptCachedCount + response.Metrics.PromptEvalCount == 0 {
+						t.Errorf("final response has prompt_cached_count + prompt_eval_count == 0: %#v", response)
 					}
 				} // else incremental response, nothing to check right now...
 				buf.Write([]byte(response.Message.Content))

--- a/llm/server.go
+++ b/llm/server.go
@@ -1558,6 +1558,7 @@ type CompletionResponse struct {
 	Content            string        `json:"content"`
 	DoneReason         DoneReason    `json:"done_reason"`
 	Done               bool          `json:"done"`
+	PromptCachedCount  int           `json:"prompt_cached_count"`
 	PromptEvalCount    int           `json:"prompt_eval_count"`
 	PromptEvalDuration time.Duration `json:"prompt_eval_duration"`
 	EvalCount          int           `json:"eval_count"`

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -66,9 +66,14 @@ type CompleteChunkChoice struct {
 }
 
 type Usage struct {
-	PromptTokens     int `json:"prompt_tokens"`
-	CompletionTokens int `json:"completion_tokens"`
-	TotalTokens      int `json:"total_tokens"`
+	PromptTokens       int                `json:"prompt_tokens"`
+	CompletionTokens   int                `json:"completion_tokens"`
+	TotalTokens        int                `json:"total_tokens"`
+	InputTokensDetails InputTokensDetails `json:"input_tokens_details,omitempty"`
+}
+
+type InputTokensDetails struct {
+	CachedTokens int `json:"cached_tokens"`
 }
 
 type ResponseFormat struct {
@@ -235,6 +240,9 @@ func ToUsage(r api.ChatResponse) Usage {
 		PromptTokens:     r.Metrics.PromptEvalCount,
 		CompletionTokens: r.Metrics.EvalCount,
 		TotalTokens:      r.Metrics.PromptEvalCount + r.Metrics.EvalCount,
+		InputTokensDetails: InputTokensDetails{
+			CachedTokens: r.Metrics.PromptCachedCount,
+		},
 	}
 }
 
@@ -358,6 +366,9 @@ func ToUsageGenerate(r api.GenerateResponse) Usage {
 		PromptTokens:     r.Metrics.PromptEvalCount,
 		CompletionTokens: r.Metrics.EvalCount,
 		TotalTokens:      r.Metrics.PromptEvalCount + r.Metrics.EvalCount,
+		InputTokensDetails: InputTokensDetails{
+			CachedTokens: r.Metrics.PromptCachedCount,
+		},
 	}
 }
 

--- a/openai/openai_test.go
+++ b/openai/openai_test.go
@@ -176,12 +176,17 @@ func TestFromCompleteRequest_Basic(t *testing.T) {
 func TestToUsage(t *testing.T) {
 	resp := api.ChatResponse{
 		Metrics: api.Metrics{
-			PromptEvalCount: 10,
-			EvalCount:       20,
+			PromptCachedCount: 5,
+			PromptEvalCount:   10,
+			EvalCount:         20,
 		},
 	}
 
 	usage := ToUsage(resp)
+
+	if usage.InputTokensDetails.CachedTokens != 5 {
+		t.Errorf("expected CachedTokens 5, got %d", usage.InputTokensDetails.CachedTokens)
+	}
 
 	if usage.PromptTokens != 10 {
 		t.Errorf("expected PromptTokens 10, got %d", usage.PromptTokens)

--- a/openai/responses.go
+++ b/openai/responses.go
@@ -859,8 +859,9 @@ func ToResponse(model, responseID, itemID string, chatResponse api.ChatResponse,
 			InputTokens:  chatResponse.PromptEvalCount,
 			OutputTokens: chatResponse.EvalCount,
 			TotalTokens:  chatResponse.PromptEvalCount + chatResponse.EvalCount,
-			// TODO(drifkin): wire through the actual values
-			InputTokensDetails: ResponsesInputTokensDetails{CachedTokens: 0},
+			InputTokensDetails: ResponsesInputTokensDetails{CachedTokens:
+				chatResponse.PromptCachedCount,
+			},
 			// TODO(drifkin): wire through the actual values
 			OutputTokensDetails: ResponsesOutputTokensDetails{ReasoningTokens: 0},
 		},

--- a/runner/llamarunner/runner.go
+++ b/runner/llamarunner/runner.go
@@ -104,6 +104,7 @@ type Sequence struct {
 	generationDuration time.Duration
 	numDecoded         int
 	numPromptInputs    int
+	numCachedInputs    int
 }
 
 type NewSequenceParams struct {
@@ -698,6 +699,7 @@ func (s *Server) completion(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
+			seq.numCachedInputs = len(seq.cache.Inputs)
 			s.seqs[i] = seq
 			s.cond.Signal()
 			found = true
@@ -733,6 +735,7 @@ func (s *Server) completion(w http.ResponseWriter, r *http.Request) {
 				if err := json.NewEncoder(w).Encode(&llm.CompletionResponse{
 					Done:               true,
 					DoneReason:         seq.doneReason,
+					PromptCachedCount:  seq.numCachedInputs,
 					PromptEvalCount:    seq.numPromptInputs,
 					PromptEvalDuration: seq.processingDuration,
 					EvalCount:          seq.numDecoded,

--- a/runner/ollamarunner/runner.go
+++ b/runner/ollamarunner/runner.go
@@ -113,6 +113,7 @@ type Sequence struct {
 	samplingDuration         time.Duration
 	numPredicted             int
 	numPromptInputs          int
+	numCachedInputs          int
 }
 
 type NewSequenceParams struct {
@@ -945,6 +946,7 @@ func (s *Server) completion(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
+			seq.numCachedInputs = len(seq.cache.Inputs)
 			s.seqs[i] = seq
 			s.cond.Signal()
 			found = true
@@ -980,6 +982,7 @@ func (s *Server) completion(w http.ResponseWriter, r *http.Request) {
 				if err := json.NewEncoder(w).Encode(&llm.CompletionResponse{
 					Done:               true,
 					DoneReason:         seq.doneReason,
+					PromptCachedCount:  seq.numCachedInputs,
 					PromptEvalCount:    seq.numPromptInputs,
 					PromptEvalDuration: seq.processingDuration,
 					EvalCount:          seq.numPredicted,

--- a/server/routes.go
+++ b/server/routes.go
@@ -574,6 +574,7 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 				Response:  cr.Content,
 				Done:      cr.Done,
 				Metrics: api.Metrics{
+					PromptCachedCount:  cr.PromptCachedCount,
 					PromptEvalCount:    cr.PromptEvalCount,
 					PromptEvalDuration: cr.PromptEvalDuration,
 					EvalCount:          cr.EvalCount,
@@ -2518,6 +2519,7 @@ func (s *Server) ChatHandler(c *gin.Context) {
 					Message:   api.Message{Role: "assistant", Content: r.Content},
 					Done:      r.Done,
 					Metrics: api.Metrics{
+						PromptCachedCount:  r.PromptCachedCount,
 						PromptEvalCount:    r.PromptEvalCount,
 						PromptEvalDuration: r.PromptEvalDuration,
 						EvalCount:          r.EvalCount,


### PR DESCRIPTION
Thread the actual KV cache prompt hit count from runners through to API responses:

- Native API (POST /api/chat, /api/generate): prompt_eval_cached_count
- OpenAI Chat Completions & Responses (POST /v1/completions, /v1/responses, /v1/chat/completions): usage.input_tokens_details.cached_tokens