### PR TITLE
fix(scripts): add OS detection and fix null path error in install.ps1

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -42,6 +42,19 @@ $ErrorActionPreference = "Stop"
 $ProgressPreference = "SilentlyContinue"
 
 # --------------------------------------------------------------------------
+# OS Detection
+# --------------------------------------------------------------------------
+
+if ($IsLinux -or $IsMacOS) {
+    Write-Host ">>> This script is for installing Ollama on Windows." -ForegroundColor Yellow
+    Write-Host ">>> To install Ollama on Linux or macOS, run:"
+    Write-Host "    curl -fsSL https://ollama.com/install.sh | sh"
+    Write-Host ""
+    Write-Host ">>> For more information, visit https://ollama.com/download"
+    return
+}
+
+# --------------------------------------------------------------------------
 # Configuration from environment variables
 # --------------------------------------------------------------------------
 
@@ -257,7 +270,8 @@ function Invoke-Install {
         Write-Host ">>> Downloading Ollama for Windows..."
     }
 
-    $tempInstaller = Join-Path $env:TEMP "OllamaSetup.exe"
+    $tempDir = [System.IO.Path]::GetTempPath()
+    $tempInstaller = Join-Path $tempDir "OllamaSetup.exe"
     Invoke-Download -Url $installerUrl -OutFile $tempInstaller
 
     # Verify signature


### PR DESCRIPTION
This pull request improves the `scripts/install.ps1` installation script for Ollama by adding OS detection and making a minor adjustment to how the temporary installer path is determined.

OS detection and user guidance:

* Added a check at the start of the script to detect if it's being run on Linux or macOS, and if so, prints a clear message directing users to the appropriate installation command and documentation for those platforms.

Temporary installer path handling:

* Changed the way the temporary installer path is constructed by explicitly using `[System.IO.Path]::GetTempPath()` to determine the temp directory, ensuring compatibility and clarity.

closes: #16139