### PR TITLE
llm: add exact MoE expert offload controls

### DIFF
--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -223,6 +223,12 @@ var (
 	//   -1           = auto-compute from remaining VRAM after dense allocation
 	//   >0           = force this many layers to have MoE on GPU
 	MoeGpuLayers = Int("OLLAMA_MOE_GPU_LAYERS", 0)
+	// MoePinned enables cudaHostRegister for CPU-side MoE expert weight buffers.
+	// When enabled, the CUDA Copy Engine can DMA directly from mmap memory
+	// without CPU-side staging.
+	// Requires MoE split to be active (OLLAMA_MOE_GPU_LAYERS != 0).
+	// Default: false (original pageable behavior).
+	MoePinned = Bool("OLLAMA_MOE_PINNED")
 	// NoHistory disables readline history.
 	NoHistory = Bool("OLLAMA_NOHISTORY")
 	// NoPrune disables pruning of model blobs on startup.

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -218,6 +218,11 @@ var (
 	DebugLogRequests = Bool("OLLAMA_DEBUG_LOG_REQUESTS")
 	// KvCacheType is the quantization type for the K/V cache.
 	KvCacheType = String("OLLAMA_KV_CACHE_TYPE")
+	// MoeGpuLayers controls how many layers have MoE expert weights resident on GPU.
+	//    0 (default) = disable MoE split (default weight layout, useful for baseline comparison)
+	//   -1           = auto-compute from remaining VRAM after dense allocation
+	//   >0           = force this many layers to have MoE on GPU
+	MoeGpuLayers = Int("OLLAMA_MOE_GPU_LAYERS", 0)
 	// NoHistory disables readline history.
 	NoHistory = Bool("OLLAMA_NOHISTORY")
 	// NoPrune disables pruning of model blobs on startup.
@@ -266,6 +271,21 @@ func Uint(key string, defaultValue uint) func() uint {
 			}
 		}
 
+		return defaultValue
+	}
+}
+
+// Int returns a function that parses an integer environment variable.
+// Returns defaultValue if the variable is unset or invalid.
+func Int(key string, defaultValue int) func() int {
+	return func() int {
+		if s := Var(key); s != "" {
+			if n, err := strconv.ParseInt(s, 10, 64); err != nil {
+				slog.Warn("invalid environment variable, using default", "key", key, "value", s, "default", defaultValue)
+			} else {
+				return int(n)
+			}
+		}
 		return defaultValue
 	}
 }

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -218,15 +218,18 @@ var (
 	DebugLogRequests = Bool("OLLAMA_DEBUG_LOG_REQUESTS")
 	// KvCacheType is the quantization type for the K/V cache.
 	KvCacheType = String("OLLAMA_KV_CACHE_TYPE")
-	// MoeGpuLayers controls how many layers have MoE expert weights resident on GPU.
+	// MoeGpuLayers controls how many MoE expert layers have expert weights resident on GPU.
 	//    0 (default) = disable MoE split (default weight layout, useful for baseline comparison)
 	//   -1           = auto-compute from remaining VRAM after dense allocation
-	//   >0           = force this many layers to have MoE on GPU
+	//   >0           = force this many MoE expert layers to have MoE on GPU
 	MoeGpuLayers = Int("OLLAMA_MOE_GPU_LAYERS", 0)
+	// MoeCpuLayers keeps expert weights for the first N model layers on CPU.
+	// This mirrors llama.cpp --n-cpu-moe. It is mutually exclusive with OLLAMA_MOE_GPU_LAYERS.
+	MoeCpuLayers = Int("OLLAMA_MOE_CPU_LAYERS", 0)
 	// MoePinned enables cudaHostRegister for CPU-side MoE expert weight buffers.
 	// When enabled, the CUDA Copy Engine can DMA directly from mmap memory
 	// without CPU-side staging.
-	// Requires MoE split to be active (OLLAMA_MOE_GPU_LAYERS != 0).
+	// Requires MoE split to be active.
 	// Default: false (original pageable behavior).
 	MoePinned = Bool("OLLAMA_MOE_PINNED")
 	// MoePrefetch enables lookahead copy inside ggml_backend_sched_compute_splits:
@@ -345,6 +348,10 @@ func AsMap() map[string]EnvVar {
 		"OLLAMA_DEBUG":                {"OLLAMA_DEBUG", LogLevel(), "Show additional debug information (e.g. OLLAMA_DEBUG=1)"},
 		"OLLAMA_DEBUG_LOG_REQUESTS":   {"OLLAMA_DEBUG_LOG_REQUESTS", DebugLogRequests(), "Log inference request bodies and replay curl commands to a temp directory"},
 		"OLLAMA_FLASH_ATTENTION":      {"OLLAMA_FLASH_ATTENTION", FlashAttention(false), "Enabled flash attention"},
+		"OLLAMA_MOE_GPU_LAYERS":       {"OLLAMA_MOE_GPU_LAYERS", MoeGpuLayers(), "MoE split GPU expert layer count: 0 disables, -1 chooses automatically, >0 forces that many expert layers on GPU; errors if no MoE experts are detected"},
+		"OLLAMA_MOE_CPU_LAYERS":       {"OLLAMA_MOE_CPU_LAYERS", MoeCpuLayers(), "MoE split CPU layer count matching llama.cpp --n-cpu-moe; mutually exclusive with OLLAMA_MOE_GPU_LAYERS and errors if no MoE experts are detected"},
+		"OLLAMA_MOE_PINNED":           {"OLLAMA_MOE_PINNED", MoePinned(), "Pin CPU-resident MoE expert buffers for CUDA copy overlap when MoE split is active"},
+		"OLLAMA_MOE_PREFETCH":         {"OLLAMA_MOE_PREFETCH", MoePrefetch(), "Prefetch CPU-resident MoE expert tensors into CUDA staging buffers; requires OLLAMA_MOE_PINNED"},
 		"OLLAMA_KV_CACHE_TYPE":        {"OLLAMA_KV_CACHE_TYPE", KvCacheType(), "Quantization type for the K/V cache (default: f16)"},
 		"OLLAMA_GPU_OVERHEAD":         {"OLLAMA_GPU_OVERHEAD", GpuOverhead(), "Reserve a portion of VRAM per GPU (bytes)"},
 		"OLLAMA_HOST":                 {"OLLAMA_HOST", Host(), "IP Address for the ollama server (default 127.0.0.1:11434)"},

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -229,6 +229,12 @@ var (
 	// Requires MoE split to be active (OLLAMA_MOE_GPU_LAYERS != 0).
 	// Default: false (original pageable behavior).
 	MoePinned = Bool("OLLAMA_MOE_PINNED")
+	// MoePrefetch enables lookahead copy inside ggml_backend_sched_compute_splits:
+	// after submitting GPU compute for split N, immediately fires an async H2D copy
+	// of split N+1's MoE expert weights on an independent CUDA copy stream.
+	// Requires OLLAMA_MOE_PINNED=1 (pinned source memory for true copy/compute overlap).
+	// Default: false.
+	MoePrefetch = Bool("OLLAMA_MOE_PREFETCH")
 	// NoHistory disables readline history.
 	NoHistory = Bool("OLLAMA_NOHISTORY")
 	// NoPrune disables pruning of model blobs on startup.

--- a/llama/llama.cpp/common/common.h
+++ b/llama/llama.cpp/common/common.h
@@ -821,7 +821,7 @@ const char * const LLM_KV_SPLIT_TENSORS_COUNT = "split.tensors.count";
 // MoE utils
 //
 
-const char * const LLM_FFN_EXPS_REGEX = "\\.ffn_(up|down|gate)_(ch|)exps";
+const char * const LLM_FFN_EXPS_REGEX = "\\.ffn_(up|down|gate|gate_up)_(exps|chexps|ch_exps)";
 
 static std::string llm_ffn_exps_block_regex(int idx) {
     return string_format("blk\\.%d%s", idx, LLM_FFN_EXPS_REGEX);

--- a/llama/llama.cpp/src/llama.cpp
+++ b/llama/llama.cpp/src/llama.cpp
@@ -322,7 +322,7 @@ static void llama_params_fit_impl(
             case LAYER_FRACTION_MOE: {
                 static std::array<std::string, n_strings> patterns;
                 if (patterns[il].empty()) {
-                    patterns[il] = "blk\\." + std::to_string(il) + "\\.ffn_(up|down|gate)_(ch|)exps";
+                    patterns[il] = "blk\\." + std::to_string(il) + "\\.ffn_(up|down|gate|gate_up)_(exps|chexps|ch_exps)";
                 }
                 return patterns[il].c_str();
             }
@@ -417,7 +417,7 @@ static void llama_params_fit_impl(
 
     int64_t global_surplus_cpu_moe = 0;
     if (hp_nex > 0) {
-        const static std::string pattern_moe_all = "blk\\.\\d+\\.ffn_(up|down|gate)_(ch|)exps"; // matches all MoE tensors
+        const static std::string pattern_moe_all = "blk\\.\\d+\\.ffn_(up|down|gate|gate_up)_(exps|chexps|ch_exps)"; // matches all MoE tensors
         ggml_backend_buffer_type_t cpu_buft = ggml_backend_cpu_buffer_type();
         tensor_buft_overrides[0] = {pattern_moe_all.c_str(), cpu_buft};
         tensor_buft_overrides[1] = {nullptr, nullptr};
@@ -1067,4 +1067,3 @@ const char * llama_print_system_info(void) {
 
     return s.c_str();
 }
-

--- a/llama/patches/0037-ggml-cuda-add-MoE-prefetch-staging-buffers-and-helpe.patch
+++ b/llama/patches/0037-ggml-cuda-add-MoE-prefetch-staging-buffers-and-helpe.patch
@@ -25,8 +25,8 @@ with compute:
     staging resources as a safety net.
 ---
  ggml/src/ggml-cuda/common.cuh   |  11 ++
- ggml/src/ggml-cuda/ggml-cuda.cu | 260 ++++++++++++++++++++++++++++++++
- 2 files changed, 271 insertions(+)
+ ggml/src/ggml-cuda/ggml-cuda.cu | 269 ++++++++++++++++++++++++++++++++
+ 2 files changed, 280 insertions(+)
 
 diff --git a/ggml/src/ggml-cuda/common.cuh b/ggml/src/ggml-cuda/common.cuh
 index 79673ac2e..034c61d6d 100644
@@ -72,7 +72,7 @@ index b8ed3709b..4d95365f5 100644
      for (int i = 0; i < GGML_CUDA_MAX_DEVICES; ++i) {
          for (int j = 0; j < GGML_CUDA_MAX_STREAMS; ++j) {
              if (streams[i][j] != nullptr) {
-@@ -5073,6 +5084,228 @@ static ggml_backend_feature * ggml_backend_cuda_get_features(ggml_backend_reg_t
+@@ -5073,6 +5084,237 @@ static ggml_backend_feature * ggml_backend_cuda_get_features(ggml_backend_reg_t
      GGML_UNUSED(reg);
  }
  
@@ -123,22 +123,31 @@ index b8ed3709b..4d95365f5 100644
 +        return true;
 +    }
 +    ggml_cuda_set_device(cuda_ctx->device);
-+    // free any undersized prior allocation
-+    for (int i = 0; i < 2; i++) {
-+        if (cuda_ctx->moe_staging.buffers[i] != nullptr) {
-+            cudaFree(cuda_ctx->moe_staging.buffers[i]);
-+            cuda_ctx->moe_staging.buffers[i] = nullptr;
++    auto cleanup_staging = [&]() {
++        for (int i = 0; i < 2; i++) {
++            if (cuda_ctx->moe_staging.buffers[i] != nullptr) {
++                cudaFree(cuda_ctx->moe_staging.buffers[i]);
++                cuda_ctx->moe_staging.buffers[i] = nullptr;
++            }
++            if (cuda_ctx->moe_staging.h2d_done[i] != nullptr) {
++                cudaEventDestroy(cuda_ctx->moe_staging.h2d_done[i]);
++                cuda_ctx->moe_staging.h2d_done[i] = nullptr;
++            }
 +        }
-+    }
++        cuda_ctx->moe_staging.capacity = 0;
++    };
++    cleanup_staging();
 +    for (int i = 0; i < 2; i++) {
 +        if (cudaMalloc(&cuda_ctx->moe_staging.buffers[i], max_size) != cudaSuccess) {
 +            cuda_ctx->moe_staging.buffers[i] = nullptr;
++            cleanup_staging();
 +            return false;
 +        }
 +        if (cuda_ctx->moe_staging.h2d_done[i] == nullptr) {
 +            if (cudaEventCreateWithFlags(&cuda_ctx->moe_staging.h2d_done[i],
 +                                         cudaEventDisableTiming) != cudaSuccess) {
 +                cuda_ctx->moe_staging.h2d_done[i] = nullptr;
++                cleanup_staging();
 +                return false;
 +            }
 +        }
@@ -301,7 +310,7 @@ index b8ed3709b..4d95365f5 100644
  static void * ggml_backend_cuda_reg_get_proc_address(ggml_backend_reg_t reg, const char * name) {
      GGML_UNUSED(reg);
      if (strcmp(name, "ggml_backend_split_buffer_type") == 0) {
-@@ -5087,6 +5320,33 @@ static void * ggml_backend_cuda_reg_get_proc_address(ggml_backend_reg_t reg, con
+@@ -5087,6 +5329,33 @@ static void * ggml_backend_cuda_reg_get_proc_address(ggml_backend_reg_t reg, con
      if (strcmp(name, "ggml_backend_get_features") == 0) {
          return (void *)ggml_backend_cuda_get_features;
      }

--- a/llama/patches/0037-ggml-cuda-add-MoE-prefetch-staging-buffers-and-helpe.patch
+++ b/llama/patches/0037-ggml-cuda-add-MoE-prefetch-staging-buffers-and-helpe.patch
@@ -51,7 +51,7 @@ index 79673ac2e..034c61d6d 100644
  
      cudaStream_t stream(int device, int stream) {
 diff --git a/ggml/src/ggml-cuda/ggml-cuda.cu b/ggml/src/ggml-cuda/ggml-cuda.cu
-index b8ed3709b..4d95365f5 100644
+index b8ed3709b..33a8fadcf 100644
 --- a/ggml/src/ggml-cuda/ggml-cuda.cu
 +++ b/ggml/src/ggml-cuda/ggml-cuda.cu
 @@ -671,6 +671,17 @@ ggml_backend_cuda_context::~ggml_backend_cuda_context() {

--- a/llama/patches/0037-ggml-cuda-add-MoE-prefetch-staging-buffers-and-helpe.patch
+++ b/llama/patches/0037-ggml-cuda-add-MoE-prefetch-staging-buffers-and-helpe.patch
@@ -1,0 +1,337 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lingyun Cai <lingyun.cai@intel.com>
+Date: Fri, 24 Apr 2026 13:31:43 +0800
+Subject: [PATCH] ggml-cuda: add MoE prefetch staging buffers and helpers
+
+Introduce CUDA-side primitives for a double-buffered staging pipeline
+that an upper layer will use to overlap MoE expert weight H2D copies
+with compute:
+
+  * ggml_backend_cuda_context gains a moe_staging sub-struct holding
+    two VRAM buffers, two completion events, and their capacity.
+  * Three independent-stream helpers (create/destroy/synchronize) let
+    the scheduler run H2D work off the main compute stream.
+  * Four staging helpers (init/destroy/h2d/d2d) allocate/free the
+    buffers and perform full-tensor H2D pinned->staging with event
+    record, then D2D staging->input_cpy on the main stream with a
+    waitEvent, keeping the write to input_cpy single-stream.
+  * Two range-selective variants take a moe_expert_range[] so the
+    scheduler can copy only the expert rows the next split will
+    consume, at the same byte offsets used by the full-tensor path.
+  * All nine helpers are exported through
+    ggml_backend_cuda_reg_get_proc_address so ggml-backend.cpp can
+    dispatch them without depending on CUDA headers.
+  * The ggml_backend_cuda_context destructor frees any outstanding
+    staging resources as a safety net.
+---
+ ggml/src/ggml-cuda/common.cuh   |  11 ++
+ ggml/src/ggml-cuda/ggml-cuda.cu | 260 ++++++++++++++++++++++++++++++++
+ 2 files changed, 271 insertions(+)
+
+diff --git a/ggml/src/ggml-cuda/common.cuh b/ggml/src/ggml-cuda/common.cuh
+index 79673ac2e..034c61d6d 100644
+--- a/ggml/src/ggml-cuda/common.cuh
++++ b/ggml/src/ggml-cuda/common.cuh
+@@ -1263,6 +1263,17 @@ struct ggml_backend_cuda_context {
+ 
+     ggml_cuda_stream_context concurrent_stream_context;
+ 
++    // MoE prefetch: double-buffered staging for overlap-safe H2D.
++    // prefetch stream writes pinned CPU weights -> moe_staging_buffers[slot],
++    // then records moe_staging_h2d_done[slot]; main compute stream waits on the
++    // event and D2D-copies staging -> input_cpy. Prevents the cross-stream race
++    // with ggml-alloc-aliased input_cpy regions.
++    struct {
++        void *       buffers[2]    = {nullptr, nullptr};
++        cudaEvent_t  h2d_done[2]   = {nullptr, nullptr};
++        size_t       capacity      = 0;
++    } moe_staging;
++
+     ~ggml_backend_cuda_context();
+ 
+     cudaStream_t stream(int device, int stream) {
+diff --git a/ggml/src/ggml-cuda/ggml-cuda.cu b/ggml/src/ggml-cuda/ggml-cuda.cu
+index b8ed3709b..4d95365f5 100644
+--- a/ggml/src/ggml-cuda/ggml-cuda.cu
++++ b/ggml/src/ggml-cuda/ggml-cuda.cu
+@@ -671,6 +671,17 @@ ggml_backend_cuda_context::~ggml_backend_cuda_context() {
+     if (copy_event != nullptr) {
+         CUDA_CHECK(cudaEventDestroy(copy_event));
+     }
++    // MoE staging safety-net cleanup (sched normally destroys first)
++    for (int i = 0; i < 2; i++) {
++        if (moe_staging.buffers[i] != nullptr) {
++            CUDA_CHECK(cudaFree(moe_staging.buffers[i]));
++            moe_staging.buffers[i] = nullptr;
++        }
++        if (moe_staging.h2d_done[i] != nullptr) {
++            CUDA_CHECK(cudaEventDestroy(moe_staging.h2d_done[i]));
++            moe_staging.h2d_done[i] = nullptr;
++        }
++    }
+     for (int i = 0; i < GGML_CUDA_MAX_DEVICES; ++i) {
+         for (int j = 0; j < GGML_CUDA_MAX_STREAMS; ++j) {
+             if (streams[i][j] != nullptr) {
+@@ -5073,6 +5084,228 @@ static ggml_backend_feature * ggml_backend_cuda_get_features(ggml_backend_reg_t
+     GGML_UNUSED(reg);
+ }
+ 
++// ---------------------------------------------------------------------------
++// MoE prefetch CUDA helpers — exposed via proc address as void* handles
++// ---------------------------------------------------------------------------
++
++static void * ggml_backend_cuda_moe_stream_create() {
++    cudaStream_t stream;
++    if (cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking) != cudaSuccess) {
++        return nullptr;
++    }
++    return (void *)stream;
++}
++
++static void ggml_backend_cuda_moe_stream_destroy(void * stream_handle) {
++    if (stream_handle) {
++        cudaStreamDestroy((cudaStream_t)stream_handle);
++    }
++}
++
++static void ggml_backend_cuda_moe_stream_synchronize(void * stream_handle) {
++    if (stream_handle) {
++        cudaStreamSynchronize((cudaStream_t)stream_handle);
++    }
++}
++
++// ---------------------------------------------------------------------------
++// MoE prefetch — staging buffer path (overlap-safe)
++//
++// Two dedicated VRAM buffers (double-buffered) receive H2D copies on the
++// independent prefetch stream; the main compute stream later D2D-copies from
++// the matching staging slot into input_cpy. The staging VRAM is disjoint from
++// any input_cpy region, so the prefetch H2D cannot race with in-flight compute
++// reading an aliased input_cpy.
++// ---------------------------------------------------------------------------
++
++// Initialize double staging buffers of `max_size` bytes each on the given
++// backend's device. Returns true on success; leaves staging empty on failure.
++// Safe to call repeatedly — grows (but never shrinks) capacity.
++static bool ggml_backend_cuda_moe_staging_init(void * backend_handle, size_t max_size) {
++    if (!backend_handle || max_size == 0) return false;
++    ggml_backend_t backend = (ggml_backend_t)backend_handle;
++    ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *)backend->context;
++    if (cuda_ctx->moe_staging.capacity >= max_size &&
++        cuda_ctx->moe_staging.buffers[0] != nullptr &&
++        cuda_ctx->moe_staging.buffers[1] != nullptr) {
++        return true;
++    }
++    ggml_cuda_set_device(cuda_ctx->device);
++    // free any undersized prior allocation
++    for (int i = 0; i < 2; i++) {
++        if (cuda_ctx->moe_staging.buffers[i] != nullptr) {
++            cudaFree(cuda_ctx->moe_staging.buffers[i]);
++            cuda_ctx->moe_staging.buffers[i] = nullptr;
++        }
++    }
++    for (int i = 0; i < 2; i++) {
++        if (cudaMalloc(&cuda_ctx->moe_staging.buffers[i], max_size) != cudaSuccess) {
++            cuda_ctx->moe_staging.buffers[i] = nullptr;
++            return false;
++        }
++        if (cuda_ctx->moe_staging.h2d_done[i] == nullptr) {
++            if (cudaEventCreateWithFlags(&cuda_ctx->moe_staging.h2d_done[i],
++                                         cudaEventDisableTiming) != cudaSuccess) {
++                cuda_ctx->moe_staging.h2d_done[i] = nullptr;
++                return false;
++            }
++        }
++    }
++    cuda_ctx->moe_staging.capacity = max_size;
++    return true;
++}
++
++static void ggml_backend_cuda_moe_staging_destroy(void * backend_handle) {
++    if (!backend_handle) return;
++    ggml_backend_t backend = (ggml_backend_t)backend_handle;
++    ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *)backend->context;
++    ggml_cuda_set_device(cuda_ctx->device);
++    for (int i = 0; i < 2; i++) {
++        if (cuda_ctx->moe_staging.buffers[i] != nullptr) {
++            cudaFree(cuda_ctx->moe_staging.buffers[i]);
++            cuda_ctx->moe_staging.buffers[i] = nullptr;
++        }
++        if (cuda_ctx->moe_staging.h2d_done[i] != nullptr) {
++            cudaEventDestroy(cuda_ctx->moe_staging.h2d_done[i]);
++            cuda_ctx->moe_staging.h2d_done[i] = nullptr;
++        }
++    }
++    cuda_ctx->moe_staging.capacity = 0;
++}
++
++// H2D on the independent prefetch stream: CPU pinned `input` -> staging[slot],
++// then record h2d_done[slot]. The main-stream D2D must wait on that event.
++static bool ggml_backend_cuda_moe_staging_h2d(
++        void * backend_handle, void * prefetch_stream_handle, int slot,
++        struct ggml_tensor * input) {
++    if (!backend_handle || !prefetch_stream_handle || !input) return false;
++    if (slot < 0 || slot > 1) return false;
++    ggml_backend_t backend = (ggml_backend_t)backend_handle;
++    ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *)backend->context;
++    if (cuda_ctx->moe_staging.buffers[slot] == nullptr ||
++        cuda_ctx->moe_staging.h2d_done[slot] == nullptr) return false;
++    size_t nbytes = ggml_nbytes(input);
++    if (nbytes > cuda_ctx->moe_staging.capacity) return false;
++    cudaStream_t pstream = (cudaStream_t)prefetch_stream_handle;
++    if (cudaMemcpyAsync(cuda_ctx->moe_staging.buffers[slot], input->data, nbytes,
++                        cudaMemcpyHostToDevice, pstream) != cudaSuccess) return false;
++    return cudaEventRecord(cuda_ctx->moe_staging.h2d_done[slot], pstream) == cudaSuccess;
++}
++
++// D2D on the main compute stream: wait on h2d_done[slot], then copy
++// staging[slot] -> input_cpy. Size taken from input_cpy (must equal H2D size).
++static bool ggml_backend_cuda_moe_staging_d2d(
++        void * backend_handle, int slot, struct ggml_tensor * input_cpy) {
++    if (!backend_handle || !input_cpy) return false;
++    if (slot < 0 || slot > 1) return false;
++    ggml_backend_t backend = (ggml_backend_t)backend_handle;
++    ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *)backend->context;
++    if (cuda_ctx->moe_staging.buffers[slot] == nullptr ||
++        cuda_ctx->moe_staging.h2d_done[slot] == nullptr) return false;
++    size_t nbytes = ggml_nbytes(input_cpy);
++    if (nbytes > cuda_ctx->moe_staging.capacity) return false;
++    cudaStream_t main_stream = cuda_ctx->stream();
++    if (cudaStreamWaitEvent(main_stream, cuda_ctx->moe_staging.h2d_done[slot], 0) != cudaSuccess) return false;
++    return cudaMemcpyAsync(input_cpy->data, cuda_ctx->moe_staging.buffers[slot], nbytes,
++                           cudaMemcpyDeviceToDevice, main_stream) == cudaSuccess;
++}
++
++// Range descriptor for selective staging: [first_id, last_id] inclusive, along
++// the expert dimension (input->ne[2]) of a MUL_MAT_ID weight tensor.
++struct moe_expert_range {
++    int32_t first_id;
++    int32_t last_id;
++};
++
++// Selective H2D on the prefetch stream: for each range, copy the corresponding
++// contiguous expert rows from pinned CPU memory to staging[slot] at the SAME
++// byte offset (so the subsequent D2D can mirror the layout). After all ranges
++// are submitted, record h2d_done[slot] once. Mirrors the MMQ padding_end
++// behavior of the full-weight path.
++static bool ggml_backend_cuda_moe_staging_h2d_ranges(
++        void * backend_handle, void * prefetch_stream_handle, int slot,
++        struct ggml_tensor * input,
++        const struct moe_expert_range * ranges, int n_ranges) {
++    if (!backend_handle || !prefetch_stream_handle || !input) return false;
++    if (!ranges || n_ranges <= 0) return false;
++    if (slot < 0 || slot > 1) return false;
++    ggml_backend_t backend = (ggml_backend_t)backend_handle;
++    ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *)backend->context;
++    if (cuda_ctx->moe_staging.buffers[slot] == nullptr ||
++        cuda_ctx->moe_staging.h2d_done[slot] == nullptr) return false;
++    size_t tensor_nbytes = ggml_nbytes(input);
++    if (tensor_nbytes > cuda_ctx->moe_staging.capacity) return false;
++
++    const int32_t n_expert    = (int32_t)input->ne[2];
++    const size_t  expert_size = input->nb[2];
++    const size_t  padding     = expert_size < 512 ? expert_size : 512;
++
++    cudaStream_t pstream = (cudaStream_t)prefetch_stream_handle;
++    uint8_t *    staging = (uint8_t *)cuda_ctx->moe_staging.buffers[slot];
++
++    for (int r = 0; r < n_ranges; r++) {
++        const int32_t first_id = ranges[r].first_id;
++        const int32_t last_id  = ranges[r].last_id;
++        if (first_id < 0 || last_id < first_id || last_id >= n_expert) return false;
++
++        const size_t expert_offset    = (size_t)first_id * expert_size;
++        const size_t expert_size_copy = (size_t)(last_id - first_id + 1) * expert_size;
++        const size_t padding_end      = (n_expert > 1 && last_id < n_expert - 1) ? padding : 0;
++
++        const uint8_t * src = (const uint8_t *)input->data + expert_offset;
++        uint8_t       * dst = staging + expert_offset;
++        if (cudaMemcpyAsync(dst, src, expert_size_copy + padding_end,
++                            cudaMemcpyHostToDevice, pstream) != cudaSuccess) {
++            return false;
++        }
++    }
++    return cudaEventRecord(cuda_ctx->moe_staging.h2d_done[slot], pstream) == cudaSuccess;
++}
++
++// Selective D2D on the main compute stream: wait on h2d_done[slot] once, then
++// issue one cudaMemcpyAsync per range, reading from staging[slot] at the same
++// expert offset that the H2D wrote to.
++static bool ggml_backend_cuda_moe_staging_d2d_ranges(
++        void * backend_handle, int slot, struct ggml_tensor * input_cpy,
++        const struct moe_expert_range * ranges, int n_ranges) {
++    if (!backend_handle || !input_cpy) return false;
++    if (!ranges || n_ranges <= 0) return false;
++    if (slot < 0 || slot > 1) return false;
++    ggml_backend_t backend = (ggml_backend_t)backend_handle;
++    ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *)backend->context;
++    if (cuda_ctx->moe_staging.buffers[slot] == nullptr ||
++        cuda_ctx->moe_staging.h2d_done[slot] == nullptr) return false;
++    size_t tensor_nbytes = ggml_nbytes(input_cpy);
++    if (tensor_nbytes > cuda_ctx->moe_staging.capacity) return false;
++
++    const int32_t n_expert    = (int32_t)input_cpy->ne[2];
++    const size_t  expert_size = input_cpy->nb[2];
++    const size_t  padding     = expert_size < 512 ? expert_size : 512;
++
++    cudaStream_t main_stream = cuda_ctx->stream();
++    if (cudaStreamWaitEvent(main_stream, cuda_ctx->moe_staging.h2d_done[slot], 0) != cudaSuccess) return false;
++
++    const uint8_t * staging = (const uint8_t *)cuda_ctx->moe_staging.buffers[slot];
++    uint8_t *       dst_base = (uint8_t *)input_cpy->data;
++
++    for (int r = 0; r < n_ranges; r++) {
++        const int32_t first_id = ranges[r].first_id;
++        const int32_t last_id  = ranges[r].last_id;
++        if (first_id < 0 || last_id < first_id || last_id >= n_expert) return false;
++
++        const size_t expert_offset    = (size_t)first_id * expert_size;
++        const size_t expert_size_copy = (size_t)(last_id - first_id + 1) * expert_size;
++        const size_t padding_end      = (n_expert > 1 && last_id < n_expert - 1) ? padding : 0;
++
++        if (cudaMemcpyAsync(dst_base + expert_offset, staging + expert_offset,
++                            expert_size_copy + padding_end,
++                            cudaMemcpyDeviceToDevice, main_stream) != cudaSuccess) {
++            return false;
++        }
++    }
++    return true;
++}
++
+ static void * ggml_backend_cuda_reg_get_proc_address(ggml_backend_reg_t reg, const char * name) {
+     GGML_UNUSED(reg);
+     if (strcmp(name, "ggml_backend_split_buffer_type") == 0) {
+@@ -5087,6 +5320,33 @@ static void * ggml_backend_cuda_reg_get_proc_address(ggml_backend_reg_t reg, con
+     if (strcmp(name, "ggml_backend_get_features") == 0) {
+         return (void *)ggml_backend_cuda_get_features;
+     }
++    if (strcmp(name, "ggml_backend_cuda_moe_stream_create") == 0) {
++        return (void *)ggml_backend_cuda_moe_stream_create;
++    }
++    if (strcmp(name, "ggml_backend_cuda_moe_stream_destroy") == 0) {
++        return (void *)ggml_backend_cuda_moe_stream_destroy;
++    }
++    if (strcmp(name, "ggml_backend_cuda_moe_stream_synchronize") == 0) {
++        return (void *)ggml_backend_cuda_moe_stream_synchronize;
++    }
++    if (strcmp(name, "ggml_backend_cuda_moe_staging_init") == 0) {
++        return (void *)ggml_backend_cuda_moe_staging_init;
++    }
++    if (strcmp(name, "ggml_backend_cuda_moe_staging_destroy") == 0) {
++        return (void *)ggml_backend_cuda_moe_staging_destroy;
++    }
++    if (strcmp(name, "ggml_backend_cuda_moe_staging_h2d") == 0) {
++        return (void *)ggml_backend_cuda_moe_staging_h2d;
++    }
++    if (strcmp(name, "ggml_backend_cuda_moe_staging_d2d") == 0) {
++        return (void *)ggml_backend_cuda_moe_staging_d2d;
++    }
++    if (strcmp(name, "ggml_backend_cuda_moe_staging_h2d_ranges") == 0) {
++        return (void *)ggml_backend_cuda_moe_staging_h2d_ranges;
++    }
++    if (strcmp(name, "ggml_backend_cuda_moe_staging_d2d_ranges") == 0) {
++        return (void *)ggml_backend_cuda_moe_staging_d2d_ranges;
++    }
+     return nullptr;
+ }
+ 

--- a/llama/patches/0038-ggml-backend-add-MoE-lookahead-prefetch-with-double-.patch
+++ b/llama/patches/0038-ggml-backend-add-MoE-lookahead-prefetch-with-double-.patch
@@ -1,0 +1,510 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lingyun Cai <lingyun.cai@intel.com>
+Date: Fri, 24 Apr 2026 13:46:21 +0800
+Subject: [PATCH] ggml-backend: add MoE lookahead prefetch with double-buffered
+ staging
+
+Hook the new CUDA staging helpers into ggml_backend_sched_compute_splits
+so CPU-resident MoE expert weights can be pulled across to VRAM ahead
+of the split that will consume them, without racing with in-flight
+compute on aliased input_cpy regions.
+
+Orchestration, gated by the OLLAMA_MOE_PREFETCH env var:
+
+  * Resolve all nine CUDA helpers once at sched entry via the ggml
+    backend registry and cache them in locals; walk the splits to size
+    the staging buffer to the largest MoE weight tensor.
+  * After submitting compute for split N, if split N+1 is a CPU-MoE
+    MUL_MAT_ID split, fire its H2D on an independent prefetch stream
+    into staging[counter & 1]. When the next split's ids tensor is the
+    one just parsed for the current split, the fire issues per-range
+    H2D copies over the activated experts only; otherwise it falls
+    back to a full-tensor copy. Per-slot range caches drive a matching
+    selective D2D in the consume path.
+  * When reaching the prefetched split, skip the normal H2D and
+    instead issue a main-stream waitEvent + staging->input_cpy D2D,
+    keeping all writes to input_cpy on the compute stream.
+  * The per-split ids parse is moved above the prefetch-hit continue
+    so prev_ids_tensor and used_ids are current when the subsequent
+    fire block classifies the next split.
+  * ggml_backend_sched_free proactively releases the CUDA staging
+    buffers; ~ggml_backend_cuda_context retains them as a safety net.
+
+A helper is_moe_cpu_split matches the existing expert-granular copy
+condition so no new assumptions are introduced. Proc address failures,
+staging alloc failures, and compute errors all tear down the prefetch
+stream cleanly and fall back to the regular synchronous copy path.
+---
+ ggml/src/ggml-backend.cpp | 384 +++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 381 insertions(+), 3 deletions(-)
+
+diff --git a/ggml/src/ggml-backend.cpp b/ggml/src/ggml-backend.cpp
+index 189e97170..d95f1cae5 100644
+--- a/ggml/src/ggml-backend.cpp
++++ b/ggml/src/ggml-backend.cpp
+@@ -27,7 +27,6 @@
+ #include <sys/sysctl.h>
+ #endif
+ 
+-
+ // backend buffer type
+ 
+ const char * ggml_backend_buft_name(ggml_backend_buffer_type_t buft) {
+@@ -1477,6 +1476,79 @@ static bool ggml_backend_sched_alloc_splits(ggml_backend_sched_t sched) {
+     return true;
+ }
+ 
++// ---------------------------------------------------------------------------
++// MoE prefetch: function pointer types for CUDA helpers via proc address
++// ---------------------------------------------------------------------------
++
++typedef void *(*moe_stream_create_fn_t)();
++typedef void  (*moe_stream_destroy_fn_t)(void *);
++typedef void  (*moe_stream_synchronize_fn_t)(void *);
++
++// Staging buffer helpers (overlap-safe prefetch)
++typedef bool  (*moe_staging_init_fn_t)(void * backend, size_t max_size);
++typedef void  (*moe_staging_destroy_fn_t)(void * backend);
++typedef bool  (*moe_staging_h2d_fn_t)(void * backend, void * prefetch_stream, int slot, struct ggml_tensor * input);
++typedef bool  (*moe_staging_d2d_fn_t)(void * backend, int slot, struct ggml_tensor * input_cpy);
++
++// Selective variant range descriptor — must match the struct in ggml-cuda.cu.
++struct moe_expert_range {
++    int32_t first_id;
++    int32_t last_id;
++};
++typedef bool  (*moe_staging_h2d_ranges_fn_t)(void * backend, void * prefetch_stream, int slot,
++                                             struct ggml_tensor * input,
++                                             const struct moe_expert_range * ranges, int n_ranges);
++typedef bool  (*moe_staging_d2d_ranges_fn_t)(void * backend, int slot,
++                                             struct ggml_tensor * input_cpy,
++                                             const struct moe_expert_range * ranges, int n_ranges);
++
++// Looks up a MoE prefetch proc address via the ggml backend registry.
++// Iterates sched->backends to find the first GPU backend, then calls
++// ggml_backend_reg_get_proc_address on its reg. This is the correct path
++// for proc addresses registered in ggml-cuda.cu via the proc-address table —
++// static helper functions are not exported from the DLL, so OS-level
++// GetProcAddress / dlsym would fail.
++static void * moe_get_proc(ggml_backend_sched_t sched, const char * name) {
++    for (int i = 0; i < sched->n_backends; i++) {
++        ggml_backend_t backend = sched->backends[i];
++        if (!backend) continue;
++        ggml_backend_dev_t dev = ggml_backend_get_device(backend);
++        if (!dev) continue;
++        if (ggml_backend_dev_type(dev) != GGML_BACKEND_DEVICE_TYPE_GPU) continue;
++        ggml_backend_reg_t reg = ggml_backend_dev_backend_reg(dev);
++        if (!reg) continue;
++        void * fn = ggml_backend_reg_get_proc_address(reg, name);
++        if (fn) return fn;
++    }
++    return nullptr;
++}
++
++// Returns true if split_id refers to a CPU-side MoE expert weight split.
++// Detection criterion: the split's first node is GGML_OP_MUL_MAT_ID and its
++// weight input is a host (CPU) buffer marked GGML_BACKEND_BUFFER_USAGE_WEIGHTS.
++// This is identical to the condition used for expert-granular copy above, so
++// no new assumptions are introduced.
++static bool is_moe_cpu_split(ggml_backend_sched_t sched, int split_id) {
++    if (split_id < 0 || split_id >= sched->n_splits) return false;
++    struct ggml_backend_sched_split * split = &sched->splits[split_id];
++    if (split->n_inputs == 0 || split->graph.n_nodes == 0) return false;
++
++    struct ggml_tensor * node = split->graph.nodes[0];
++    if (node->op != GGML_OP_MUL_MAT_ID) return false;
++
++    for (int i = 0; i < split->n_inputs; i++) {
++        struct ggml_tensor * input = split->inputs[i];
++        struct ggml_tensor * input_cpy = tensor_copy(input, split->backend_id, sched->cur_copy);
++        if (node->src[0] == input_cpy &&
++            input->buffer != NULL &&
++            ggml_backend_buffer_get_usage(input->buffer) == GGML_BACKEND_BUFFER_USAGE_WEIGHTS &&
++            ggml_backend_buffer_is_host(input->buffer)) {
++            return true;
++        }
++    }
++    return false;
++}
++
+ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t sched) {
+     GGML_ASSERT(sched);
+     struct ggml_backend_sched_split * splits = sched->splits;
+@@ -1485,11 +1557,122 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
+     std::vector<int32_t> ids;
+     std::vector<ggml_bitset_t> used_ids;
+ 
++    // MoE prefetch (staging path): initialize independent prefetch stream
++    // and double staging buffers if OLLAMA_MOE_PREFETCH is set.
++    //
++    // Architecture:
++    //   prefetch stream: H2D pinned_CPU -> staging[slot], record h2d_done[slot]
++    //   main stream:     waitEvent(h2d_done[slot]), D2D staging[slot] -> input_cpy
++    // Double buffering (slot = counter & 1) lets the next H2D start while the
++    // current D2D is still draining, reclaiming copy/compute overlap without
++    // racing on ggml-alloc-aliased input_cpy regions.
++    bool     prefetch_enabled  = false;
++    void *   prefetch_stream   = nullptr;
++    bool     prefetch_pending  = false;
++    int      prefetch_split_id = -1;
++    int      prefetch_slot     = 0;   // which staging buffer was H2D-written
++    int      prefetch_counter  = 0;   // monotonic fire counter; slot = counter & 1
++    ggml_backend_t moe_cuda_backend = nullptr;  // backend that owns the staging buffers
++
++    // Per-slot selective-prefetch range cache. When a fire was issued via
++    // fn_staging_h2d_ranges, the corresponding slot remembers its ranges so the
++    // consume path can dispatch fn_staging_d2d_ranges with the exact same set.
++    // n_ranges == 0 means the slot was H2D'd full-tensor and should D2D full.
++    // The bound is one range per expert; MOE_MAX_EXPERTS_PER_LAYER is a
++    // generous cap (no current model uses more than a few hundred experts
++    // per layer) that keeps the range cache on the stack.
++    static const int MOE_MAX_EXPERTS_PER_LAYER = 1024;
++    struct moe_expert_range prefetch_ranges[2][MOE_MAX_EXPERTS_PER_LAYER] = {};
++    int    prefetch_n_ranges[2] = {0, 0};
++
++    moe_stream_destroy_fn_t     fn_prefetch_stream_destroy = nullptr;
++    moe_stream_synchronize_fn_t fn_prefetch_stream_sync    = nullptr;
++    moe_staging_init_fn_t       fn_staging_init            = nullptr;
++    moe_staging_destroy_fn_t    fn_staging_destroy         = nullptr;
++    moe_staging_h2d_fn_t        fn_staging_h2d             = nullptr;
++    moe_staging_d2d_fn_t        fn_staging_d2d             = nullptr;
++    moe_staging_h2d_ranges_fn_t fn_staging_h2d_ranges      = nullptr;
++    moe_staging_d2d_ranges_fn_t fn_staging_d2d_ranges      = nullptr;
++
++    static bool prefetch_init_logged = false;
++    if (getenv("OLLAMA_MOE_PREFETCH") != nullptr) {
++        auto fn_stream_create = (moe_stream_create_fn_t)moe_get_proc(sched, "ggml_backend_cuda_moe_stream_create");
++        fn_prefetch_stream_destroy = (moe_stream_destroy_fn_t)moe_get_proc(sched, "ggml_backend_cuda_moe_stream_destroy");
++        fn_prefetch_stream_sync    = (moe_stream_synchronize_fn_t)moe_get_proc(sched, "ggml_backend_cuda_moe_stream_synchronize");
++        fn_staging_init        = (moe_staging_init_fn_t)       moe_get_proc(sched, "ggml_backend_cuda_moe_staging_init");
++        fn_staging_destroy     = (moe_staging_destroy_fn_t)    moe_get_proc(sched, "ggml_backend_cuda_moe_staging_destroy");
++        fn_staging_h2d         = (moe_staging_h2d_fn_t)        moe_get_proc(sched, "ggml_backend_cuda_moe_staging_h2d");
++        fn_staging_d2d         = (moe_staging_d2d_fn_t)        moe_get_proc(sched, "ggml_backend_cuda_moe_staging_d2d");
++        fn_staging_h2d_ranges  = (moe_staging_h2d_ranges_fn_t) moe_get_proc(sched, "ggml_backend_cuda_moe_staging_h2d_ranges");
++        fn_staging_d2d_ranges  = (moe_staging_d2d_ranges_fn_t) moe_get_proc(sched, "ggml_backend_cuda_moe_staging_d2d_ranges");
++
++        if (fn_stream_create && fn_staging_init && fn_staging_h2d && fn_staging_d2d) {
++            // Walk splits to find the max MoE weight tensor size and the CUDA backend
++            size_t max_moe_split_size = 0;
++            for (int s = 0; s < sched->n_splits; s++) {
++                if (!is_moe_cpu_split(sched, s)) continue;
++                struct ggml_backend_sched_split * sp = &sched->splits[s];
++                for (int i = 0; i < sp->n_inputs; i++) {
++                    struct ggml_tensor * inp = sp->inputs[i];
++                    if (inp->buffer &&
++                        ggml_backend_buffer_is_host(inp->buffer) &&
++                        ggml_backend_buffer_get_usage(inp->buffer) == GGML_BACKEND_BUFFER_USAGE_WEIGHTS) {
++                        size_t nb = ggml_nbytes(inp);
++                        if (nb > max_moe_split_size) max_moe_split_size = nb;
++                        if (!moe_cuda_backend) moe_cuda_backend = sched->backends[sp->backend_id];
++                    }
++                }
++            }
++            if (max_moe_split_size > 0 && moe_cuda_backend) {
++                prefetch_stream = fn_stream_create();
++                if (prefetch_stream && fn_staging_init((void *)moe_cuda_backend, max_moe_split_size)) {
++                    prefetch_enabled = true;
++                    if (!prefetch_init_logged) {
++                        GGML_LOG_INFO("%s: MoE lookahead prefetch enabled (staging 2x%zu MiB)\n",
++                                      __func__, max_moe_split_size / (1024 * 1024));
++                        prefetch_init_logged = true;
++                    }
++                } else {
++                    if (fn_prefetch_stream_destroy && prefetch_stream) {
++                        fn_prefetch_stream_destroy(prefetch_stream);
++                    }
++                    prefetch_stream = nullptr;
++                    if (!prefetch_init_logged) {
++                        GGML_LOG_WARN("%s: MoE prefetch disabled — staging allocation failed\n", __func__);
++                        prefetch_init_logged = true;
++                    }
++                }
++            } else {
++                if (!prefetch_init_logged) {
++                    GGML_LOG_INFO("%s: MoE prefetch inactive — no CPU-MoE splits in graph\n", __func__);
++                    prefetch_init_logged = true;
++                }
++            }
++        } else {
++            if (!prefetch_init_logged) {
++                GGML_LOG_WARN("%s: MoE prefetch disabled — proc lookup failed\n", __func__);
++                prefetch_init_logged = true;
++            }
++        }
++    }
++
+     for (int split_id = 0; split_id < sched->n_splits; split_id++) {
+         struct ggml_backend_sched_split * split = &splits[split_id];
+         int split_backend_id = split->backend_id;
+         ggml_backend_t split_backend = sched->backends[split_backend_id];
+ 
++        // If this split was prefetched, the weights are already in staging VRAM.
++        // Remember the slot so the input_copy block below can issue a
++        // staging->input_cpy D2D instead of the regular H2D.
++        bool moe_prefetch_hit  = false;
++        int  moe_prefetch_slot = -1;
++        if (prefetch_enabled && prefetch_pending && split_id == prefetch_split_id) {
++            moe_prefetch_hit  = true;
++            moe_prefetch_slot = prefetch_slot;
++            prefetch_pending  = false;
++            GGML_LOG_DEBUG("%s: prefetch hit split=%d slot=%d\n", __func__, split_id, moe_prefetch_slot);
++        }
++
+         // copy the input tensors to the split backend
+         for (int input_id = 0; input_id < split->n_inputs; input_id++) {
+             ggml_backend_t input_backend = ggml_backend_sched_get_tensor_backend(sched, split->inputs[input_id]);
+@@ -1524,8 +1707,6 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
+                     const int64_t n_expert   = node->op == GGML_OP_MUL_MAT_ID ? input->ne[2] : input->ne[1];
+                     const size_t expert_size = node->op == GGML_OP_MUL_MAT_ID ? input->nb[2] : input->nb[1];
+ 
+-                    ggml_backend_synchronize(input_backend);
+-
+                     // get the ids
+                     ggml_tensor * ids_tensor = node->src[2];
+                     ggml_backend_t ids_backend = split_backend;
+@@ -1541,6 +1722,8 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
+                     }
+ 
+                     if (ids_tensor != prev_ids_tensor) {
++                        ggml_backend_synchronize(input_backend);
++
+                         ids.resize(ggml_nbytes(ids_tensor) / sizeof(int32_t));
+                         ggml_backend_tensor_get_async(ids_backend, ids_tensor, ids.data(), 0, ggml_nbytes(ids_tensor));
+                         ggml_backend_synchronize(ids_backend);
+@@ -1559,6 +1742,44 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
+                         prev_ids_tensor = ids_tensor;
+                     }
+ 
++                    // If this split was prefetched, the prefetch stream already
++                    // H2D'd the weight bytes into staging[slot] and recorded
++                    // h2d_done[slot]. Issue a main-stream waitEvent + D2D
++                    // staging->input_cpy. This keeps the write to input_cpy on
++                    // the same stream as the subsequent compute (no cross-stream
++                    // alias race) while allowing the H2D itself to overlap with
++                    // the previous split's compute.
++                    //
++                    // n_ranges == 0 means the slot was H2D'd full-tensor; >0
++                    // means selective, and we dispatch the mirror-range D2D so
++                    // only the same expert byte windows are transferred.
++                    //
++                    // NOTE: ids parse above must run FIRST so prev_ids_tensor
++                    // and used_ids are current when the fire block (after
++                    // compute submission below) picks up selective mode.
++                    if (moe_prefetch_hit && moe_prefetch_slot >= 0) {
++                        const int n_ranges = prefetch_n_ranges[moe_prefetch_slot];
++                        bool d2d_ok = false;
++                        const char * mode_str = "full";
++                        if (n_ranges > 0 && fn_staging_d2d_ranges) {
++                            d2d_ok = fn_staging_d2d_ranges((void *)split_backend,
++                                                           moe_prefetch_slot, input_cpy,
++                                                           prefetch_ranges[moe_prefetch_slot],
++                                                           n_ranges);
++                            mode_str = "selective";
++                        } else if (fn_staging_d2d) {
++                            d2d_ok = fn_staging_d2d((void *)split_backend, moe_prefetch_slot, input_cpy);
++                        }
++                        prefetch_n_ranges[moe_prefetch_slot] = 0;  // invalidate cached ranges
++                        if (d2d_ok) {
++                            GGML_LOG_DEBUG("%s: staging D2D split=%d slot=%d mode=%s ranges=%d\n",
++                                           __func__, split_id, moe_prefetch_slot, mode_str, n_ranges);
++                            continue;
++                        }
++                        GGML_LOG_WARN("%s: staging D2D failed split=%d slot=%d — falling back to selective copy\n",
++                                      __func__, split_id, moe_prefetch_slot);
++                    }
++
+                     // group consecutive experts and copy them together
+                     auto copy_experts = [&](int32_t first_id, int32_t last_id) {
+                         const size_t expert_offset = first_id * expert_size;
+@@ -1616,6 +1837,10 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
+         if (!sched->callback_eval) {
+             enum ggml_status ec = ggml_backend_graph_compute_async(split_backend, &split->graph, sched->batch_size);
+             if (ec != GGML_STATUS_SUCCESS) {
++                if (prefetch_enabled) {
++                    if (fn_prefetch_stream_sync)    fn_prefetch_stream_sync(prefetch_stream);
++                    if (fn_prefetch_stream_destroy) fn_prefetch_stream_destroy(prefetch_stream);
++                }
+                 return ec;
+             }
+         } else {
+@@ -1638,6 +1863,10 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
+ 
+                 enum ggml_status ec = ggml_backend_graph_compute_async(split_backend, &gv, sched->batch_size);
+                 if (ec != GGML_STATUS_SUCCESS) {
++                    if (prefetch_enabled) {
++                        if (fn_prefetch_stream_sync)    fn_prefetch_stream_sync(prefetch_stream);
++                        if (fn_prefetch_stream_destroy) fn_prefetch_stream_destroy(prefetch_stream);
++                    }
+                     return ec;
+                 }
+ 
+@@ -1652,6 +1881,130 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
+             }
+         }
+ 
++        // After submitting compute N, fire the next split's H2D on the
++        // INDEPENDENT prefetch stream, writing into the double-buffered
++        // staging[slot].
++        //
++        // Selective mode: when the next split's ids tensor matches the ids
++        // tensor consumed by the current split (same-layer A->B or B->C),
++        // used_ids was just built above. We reuse it to emit one memcpy per
++        // activated expert range (matching the full-weight selective layout).
++        // The consume path (fn_staging_d2d_ranges) mirrors the exact same
++        // ranges.
++        //
++        // Full-tensor fallback is used for:
++        //   - the first MoE split of a layer (cross-layer boundary; previous
++        //     split's ids don't apply)
++        //   - selective dispatch failure
++        //   - _ranges proc addresses not available (old DLL).
++        if (prefetch_enabled && !sched->callback_eval && !prefetch_pending) {
++            int next_id = split_id + 1;
++            if (is_moe_cpu_split(sched, next_id)) {
++                struct ggml_backend_sched_split * next_split = &sched->splits[next_id];
++                struct ggml_tensor * next_node = next_split->graph.nodes[0];
++                if (fn_staging_h2d) {
++                    bool fired = false;
++                    int  slot  = prefetch_counter & 1;
++                    const char * mode_str = "full";
++                    int    n_ranges_used  = 0;
++                    size_t bytes_to_copy  = 0;
++
++                    struct ggml_tensor * next_ids = next_node->src[2];
++                    const bool can_selective =
++                        (fn_staging_h2d_ranges != nullptr) &&
++                        (fn_staging_d2d_ranges != nullptr) &&
++                        (prev_ids_tensor != nullptr) &&
++                        (next_ids == prev_ids_tensor) &&
++                        !used_ids.empty();
++
++                    for (int i = 0; i < next_split->n_inputs; i++) {
++                        struct ggml_tensor * inp     = next_split->inputs[i];
++                        struct ggml_tensor * inp_cpy = tensor_copy(inp, next_split->backend_id, sched->cur_copy);
++                        if (next_node->src[0] == inp_cpy &&
++                            inp->buffer != NULL &&
++                            ggml_backend_buffer_get_usage(inp->buffer) == GGML_BACKEND_BUFFER_USAGE_WEIGHTS &&
++                            ggml_backend_buffer_is_host(inp->buffer) &&
++                            next_node->op == GGML_OP_MUL_MAT_ID) {
++
++                            const int64_t n_expert    = inp->ne[2];
++                            const size_t  expert_size = inp->nb[2];
++
++                            // bound check for the per-slot range cache; if a
++                            // future model ever exceeds this, bump the constant
++                            GGML_ASSERT(n_expert > 0 && n_expert <= MOE_MAX_EXPERTS_PER_LAYER &&
++                                        "n_expert exceeds MOE_MAX_EXPERTS_PER_LAYER");
++
++                            if (can_selective) {
++                                const int n_expert_i = (int)n_expert;
++                                struct moe_expert_range ranges[MOE_MAX_EXPERTS_PER_LAYER];
++                                int n_ranges = 0;
++
++                                int id = 0;
++                                while (id < n_expert_i && !ggml_bitset_get(used_ids.data(), id)) {
++                                    id++;
++                                }
++                                if (id < n_expert_i) {
++                                    int32_t first_id = (int32_t)id;
++                                    int32_t last_id  = first_id;
++                                    for (++id; id < n_expert_i; ++id) {
++                                        if (!ggml_bitset_get(used_ids.data(), id)) continue;
++                                        if (id == last_id + 1) {
++                                            last_id = (int32_t)id;
++                                            continue;
++                                        }
++                                        ranges[n_ranges].first_id = first_id;
++                                        ranges[n_ranges].last_id  = last_id;
++                                        n_ranges++;
++                                        first_id = (int32_t)id;
++                                        last_id  = first_id;
++                                    }
++                                    ranges[n_ranges].first_id = first_id;
++                                    ranges[n_ranges].last_id  = last_id;
++                                    n_ranges++;
++                                }
++
++                                if (n_ranges > 0 &&
++                                    fn_staging_h2d_ranges((void *)moe_cuda_backend, prefetch_stream,
++                                                          slot, inp, ranges, n_ranges)) {
++                                    memcpy(prefetch_ranges[slot], ranges, sizeof(ranges[0]) * n_ranges);
++                                    prefetch_n_ranges[slot] = n_ranges;
++                                    fired = true;
++                                    mode_str = "selective";
++                                    n_ranges_used = n_ranges;
++                                    for (int r = 0; r < n_ranges; r++) {
++                                        bytes_to_copy += (size_t)(ranges[r].last_id - ranges[r].first_id + 1) * expert_size;
++                                    }
++                                }
++                            }
++
++                            if (!fired) {
++                                if (fn_staging_h2d((void *)moe_cuda_backend, prefetch_stream, slot, inp)) {
++                                    prefetch_n_ranges[slot] = 0;  // flag as full-tensor
++                                    fired = true;
++                                    mode_str = "full";
++                                    n_ranges_used = 1;
++                                    bytes_to_copy = ggml_nbytes(inp);
++                                }
++                            }
++
++                            if (fired) {
++                                GGML_LOG_DEBUG("%s: moe prefetch fired: split=%d slot=%d mode=%s ids=%p bytes=%zu ranges=%d\n",
++                                               __func__, next_id, slot, mode_str, (void *)next_ids,
++                                               bytes_to_copy, n_ranges_used);
++                            }
++                            break;
++                        }
++                    }
++                    if (fired) {
++                        prefetch_pending  = true;
++                        prefetch_split_id = next_id;
++                        prefetch_slot     = slot;
++                        prefetch_counter++;
++                    }
++                }
++            }
++        }
++
+         // record the event of this copy
+         if (split->n_inputs > 0) {
+             if (sched->events[split_backend_id][sched->cur_copy] != NULL) {
+@@ -1660,6 +2013,14 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
+         }
+     }
+ 
++    // Cleanup: drain the prefetch stream and destroy it.
++    // (Staging buffers + per-slot events live on the CUDA backend context and
++    // are torn down in ggml_backend_sched_free / ~ggml_backend_cuda_context.)
++    if (prefetch_enabled) {
++        if (fn_prefetch_stream_sync)    fn_prefetch_stream_sync(prefetch_stream);
++        if (fn_prefetch_stream_destroy) fn_prefetch_stream_destroy(prefetch_stream);
++    }
++
+     return GGML_STATUS_SUCCESS;
+ }
+ 
+@@ -1751,6 +2112,23 @@ void ggml_backend_sched_free(ggml_backend_sched_t sched) {
+     if (sched == NULL) {
+         return;
+     }
++
++    // Release the MoE staging buffers on the CUDA backend before tearing down
++    // sched internals. Proactive cleanup avoids holding ~2 * max_split_size of
++    // VRAM across sched recreation; the CUDA context destructor remains as a
++    // safety net.
++    if (auto fn_staging_destroy =
++            (moe_staging_destroy_fn_t)moe_get_proc(sched, "ggml_backend_cuda_moe_staging_destroy")) {
++        for (int b = 0; b < sched->n_backends; b++) {
++            ggml_backend_t backend = sched->backends[b];
++            if (!backend) continue;
++            ggml_backend_dev_t dev = ggml_backend_get_device(backend);
++            if (!dev || ggml_backend_dev_type(dev) != GGML_BACKEND_DEVICE_TYPE_GPU) continue;
++            fn_staging_destroy((void *)backend);
++            break;
++        }
++    }
++
+     for (int b = 0; b < sched->n_backends; b++) {
+         for (int c = 0; c < sched->n_copies; c++) {
+             ggml_backend_event_free(sched->events[b][c]);

--- a/llama/patches/0039-ggml-tighten-MoE-prefetch-and-expert-detection.patch
+++ b/llama/patches/0039-ggml-tighten-MoE-prefetch-and-expert-detection.patch
@@ -1,0 +1,541 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jayson Espley <jayson@yorkshire3d.co.uk>
+Date: Thu, 14 May 2026 13:37:33 +0100
+Subject: [PATCH] ggml: tighten MoE prefetch and expert detection
+
+---
+ common/common.h                 |   2 +-
+ ggml/src/ggml-backend.cpp       | 233 ++++++++++++++++++--------------
+ ggml/src/ggml-cuda/common.cuh   |   1 +
+ ggml/src/ggml-cuda/ggml-cuda.cu |  42 +++---
+ src/llama.cpp                   |   5 +-
+ 5 files changed, 157 insertions(+), 126 deletions(-)
+
+diff --git a/common/common.h b/common/common.h
+index d70744840..ab62fa8d8 100644
+--- a/common/common.h
++++ b/common/common.h
+@@ -821,7 +821,7 @@ const char * const LLM_KV_SPLIT_TENSORS_COUNT = "split.tensors.count";
+ // MoE utils
+ //
+
+-const char * const LLM_FFN_EXPS_REGEX = "\\.ffn_(up|down|gate)_(ch|)exps";
++const char * const LLM_FFN_EXPS_REGEX = "\\.ffn_(up|down|gate|gate_up)_(exps|chexps|ch_exps)";
+
+ static std::string llm_ffn_exps_block_regex(int idx) {
+     return string_format("blk\\.%d%s", idx, LLM_FFN_EXPS_REGEX);
+diff --git a/ggml/src/ggml-backend.cpp b/ggml/src/ggml-backend.cpp
+index d95f1cae5..dfe0ab032 100644
+--- a/ggml/src/ggml-backend.cpp
++++ b/ggml/src/ggml-backend.cpp
+@@ -14,6 +14,7 @@
+ #include "ggml-impl.h"
+
+ #include <assert.h>
++#include <ctype.h>
+ #include <limits.h>
+ #include <stdarg.h>
+ #include <stdio.h>
+@@ -698,6 +699,36 @@ static bool ggml_is_view_op(enum ggml_op op) {
+ #define GGML_SCHED_MAX_COPIES 4
+ #endif
+
++typedef void *(*moe_stream_fn_t)(void * backend);
++typedef void  (*moe_stream_synchronize_fn_t)(void *);
++typedef bool  (*moe_staging_init_fn_t)(void * backend, size_t max_size);
++typedef void  (*moe_staging_destroy_fn_t)(void * backend);
++typedef bool  (*moe_staging_h2d_fn_t)(void * backend, void * prefetch_stream, int slot, struct ggml_tensor * input);
++typedef bool  (*moe_staging_d2d_fn_t)(void * backend, int slot, struct ggml_tensor * input_cpy);
++
++struct moe_expert_range {
++    int32_t first_id;
++    int32_t last_id;
++};
++typedef bool  (*moe_staging_h2d_ranges_fn_t)(void * backend, void * prefetch_stream, int slot,
++                                             struct ggml_tensor * input,
++                                             const struct moe_expert_range * ranges, int n_ranges);
++typedef bool  (*moe_staging_d2d_ranges_fn_t)(void * backend, int slot,
++                                             struct ggml_tensor * input_cpy,
++                                             const struct moe_expert_range * ranges, int n_ranges);
++
++struct moe_prefetch_fns {
++    moe_stream_fn_t              stream              = nullptr;
++    moe_stream_synchronize_fn_t  stream_synchronize  = nullptr;
++    moe_staging_init_fn_t        staging_init        = nullptr;
++    moe_staging_destroy_fn_t     staging_destroy     = nullptr;
++    moe_staging_h2d_fn_t         staging_h2d         = nullptr;
++    moe_staging_d2d_fn_t         staging_d2d         = nullptr;
++    moe_staging_h2d_ranges_fn_t  staging_h2d_ranges  = nullptr;
++    moe_staging_d2d_ranges_fn_t  staging_d2d_ranges  = nullptr;
++    bool                         resolved            = false;
++};
++
+ struct ggml_backend_sched_split {
+     int backend_id;
+     int i_start;
+@@ -770,6 +801,13 @@ struct ggml_backend_sched {
+     // the scheduler needs to be recreated with allocated buffers before it can be used
+     // for computation
+     bool alloc_buffers;
++
++    bool moe_prefetch_requested;
++    bool moe_prefetch_initialized;
++    void * moe_prefetch_stream;
++    ggml_backend_t moe_cuda_backend;
++    size_t moe_max_split_size;
++    struct moe_prefetch_fns moe_fns;
+ };
+
+ #define hash_id(tensor) ggml_hash_find_or_insert(&sched->hash_set, tensor)
+@@ -1476,38 +1514,9 @@ static bool ggml_backend_sched_alloc_splits(ggml_backend_sched_t sched) {
+     return true;
+ }
+
+-// ---------------------------------------------------------------------------
+-// MoE prefetch: function pointer types for CUDA helpers via proc address
+-// ---------------------------------------------------------------------------
+-
+-typedef void *(*moe_stream_create_fn_t)();
+-typedef void  (*moe_stream_destroy_fn_t)(void *);
+-typedef void  (*moe_stream_synchronize_fn_t)(void *);
+-
+-// Staging buffer helpers (overlap-safe prefetch)
+-typedef bool  (*moe_staging_init_fn_t)(void * backend, size_t max_size);
+-typedef void  (*moe_staging_destroy_fn_t)(void * backend);
+-typedef bool  (*moe_staging_h2d_fn_t)(void * backend, void * prefetch_stream, int slot, struct ggml_tensor * input);
+-typedef bool  (*moe_staging_d2d_fn_t)(void * backend, int slot, struct ggml_tensor * input_cpy);
+-
+-// Selective variant range descriptor — must match the struct in ggml-cuda.cu.
+-struct moe_expert_range {
+-    int32_t first_id;
+-    int32_t last_id;
+-};
+-typedef bool  (*moe_staging_h2d_ranges_fn_t)(void * backend, void * prefetch_stream, int slot,
+-                                             struct ggml_tensor * input,
+-                                             const struct moe_expert_range * ranges, int n_ranges);
+-typedef bool  (*moe_staging_d2d_ranges_fn_t)(void * backend, int slot,
+-                                             struct ggml_tensor * input_cpy,
+-                                             const struct moe_expert_range * ranges, int n_ranges);
+-
+ // Looks up a MoE prefetch proc address via the ggml backend registry.
+ // Iterates sched->backends to find the first GPU backend, then calls
+-// ggml_backend_reg_get_proc_address on its reg. This is the correct path
+-// for proc addresses registered in ggml-cuda.cu via the proc-address table —
+-// static helper functions are not exported from the DLL, so OS-level
+-// GetProcAddress / dlsym would fail.
++// ggml_backend_reg_get_proc_address on its reg.
+ static void * moe_get_proc(ggml_backend_sched_t sched, const char * name) {
+     for (int i = 0; i < sched->n_backends; i++) {
+         ggml_backend_t backend = sched->backends[i];
+@@ -1523,6 +1532,60 @@ static void * moe_get_proc(ggml_backend_sched_t sched, const char * name) {
+     return nullptr;
+ }
+
++static bool moe_resolve_prefetch_fns(ggml_backend_sched_t sched) {
++    struct moe_prefetch_fns * fns = &sched->moe_fns;
++    if (fns->resolved) {
++        return fns->stream && fns->staging_init && fns->staging_h2d && fns->staging_d2d;
++    }
++
++    fns->stream             = (moe_stream_fn_t)             moe_get_proc(sched, "ggml_backend_cuda_moe_stream");
++    fns->stream_synchronize = (moe_stream_synchronize_fn_t) moe_get_proc(sched, "ggml_backend_cuda_moe_stream_synchronize");
++    fns->staging_init       = (moe_staging_init_fn_t)       moe_get_proc(sched, "ggml_backend_cuda_moe_staging_init");
++    fns->staging_destroy    = (moe_staging_destroy_fn_t)    moe_get_proc(sched, "ggml_backend_cuda_moe_staging_destroy");
++    fns->staging_h2d        = (moe_staging_h2d_fn_t)        moe_get_proc(sched, "ggml_backend_cuda_moe_staging_h2d");
++    fns->staging_d2d        = (moe_staging_d2d_fn_t)        moe_get_proc(sched, "ggml_backend_cuda_moe_staging_d2d");
++    fns->staging_h2d_ranges = (moe_staging_h2d_ranges_fn_t) moe_get_proc(sched, "ggml_backend_cuda_moe_staging_h2d_ranges");
++    fns->staging_d2d_ranges = (moe_staging_d2d_ranges_fn_t) moe_get_proc(sched, "ggml_backend_cuda_moe_staging_d2d_ranges");
++    fns->resolved = true;
++
++    return fns->stream && fns->staging_init && fns->staging_h2d && fns->staging_d2d;
++}
++
++static bool moe_env_enabled(const char * name) {
++    const char * value = getenv(name);
++    if (value == nullptr) {
++        return false;
++    }
++
++    while (isspace((unsigned char) *value)) {
++        value++;
++    }
++
++    const char * end = value + strlen(value);
++    while (end > value && isspace((unsigned char) end[-1])) {
++        end--;
++    }
++
++    const size_t len = end - value;
++    if (len == 0) {
++        return false;
++    }
++    if (len == 1 && value[0] == '0') {
++        return false;
++    }
++    if (len == 5) {
++        const char false_value[] = "false";
++        for (size_t i = 0; i < len; i++) {
++            if (tolower((unsigned char) value[i]) != false_value[i]) {
++                return true;
++            }
++        }
++        return false;
++    }
++
++    return true;
++}
++
+ // Returns true if split_id refers to a CPU-side MoE expert weight split.
+ // Detection criterion: the split's first node is GGML_OP_MUL_MAT_ID and its
+ // weight input is a host (CPU) buffer marked GGML_BACKEND_BUFFER_USAGE_WEIGHTS.
+@@ -1558,7 +1621,8 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
+     std::vector<ggml_bitset_t> used_ids;
+
+     // MoE prefetch (staging path): initialize independent prefetch stream
+-    // and double staging buffers if OLLAMA_MOE_PREFETCH is set.
++    // and double staging buffers only when the runner set the internal
++    // OLLAMA_MOE_PREFETCH_ENABLED gate.
+     //
+     // Architecture:
+     //   prefetch stream: H2D pinned_CPU -> staging[slot], record h2d_done[slot]
+@@ -1585,29 +1649,11 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
+     struct moe_expert_range prefetch_ranges[2][MOE_MAX_EXPERTS_PER_LAYER] = {};
+     int    prefetch_n_ranges[2] = {0, 0};
+
+-    moe_stream_destroy_fn_t     fn_prefetch_stream_destroy = nullptr;
+-    moe_stream_synchronize_fn_t fn_prefetch_stream_sync    = nullptr;
+-    moe_staging_init_fn_t       fn_staging_init            = nullptr;
+-    moe_staging_destroy_fn_t    fn_staging_destroy         = nullptr;
+-    moe_staging_h2d_fn_t        fn_staging_h2d             = nullptr;
+-    moe_staging_d2d_fn_t        fn_staging_d2d             = nullptr;
+-    moe_staging_h2d_ranges_fn_t fn_staging_h2d_ranges      = nullptr;
+-    moe_staging_d2d_ranges_fn_t fn_staging_d2d_ranges      = nullptr;
+-
+-    static bool prefetch_init_logged = false;
+-    if (getenv("OLLAMA_MOE_PREFETCH") != nullptr) {
+-        auto fn_stream_create = (moe_stream_create_fn_t)moe_get_proc(sched, "ggml_backend_cuda_moe_stream_create");
+-        fn_prefetch_stream_destroy = (moe_stream_destroy_fn_t)moe_get_proc(sched, "ggml_backend_cuda_moe_stream_destroy");
+-        fn_prefetch_stream_sync    = (moe_stream_synchronize_fn_t)moe_get_proc(sched, "ggml_backend_cuda_moe_stream_synchronize");
+-        fn_staging_init        = (moe_staging_init_fn_t)       moe_get_proc(sched, "ggml_backend_cuda_moe_staging_init");
+-        fn_staging_destroy     = (moe_staging_destroy_fn_t)    moe_get_proc(sched, "ggml_backend_cuda_moe_staging_destroy");
+-        fn_staging_h2d         = (moe_staging_h2d_fn_t)        moe_get_proc(sched, "ggml_backend_cuda_moe_staging_h2d");
+-        fn_staging_d2d         = (moe_staging_d2d_fn_t)        moe_get_proc(sched, "ggml_backend_cuda_moe_staging_d2d");
+-        fn_staging_h2d_ranges  = (moe_staging_h2d_ranges_fn_t) moe_get_proc(sched, "ggml_backend_cuda_moe_staging_h2d_ranges");
+-        fn_staging_d2d_ranges  = (moe_staging_d2d_ranges_fn_t) moe_get_proc(sched, "ggml_backend_cuda_moe_staging_d2d_ranges");
+-
+-        if (fn_stream_create && fn_staging_init && fn_staging_h2d && fn_staging_d2d) {
+-            // Walk splits to find the max MoE weight tensor size and the CUDA backend
++    struct moe_prefetch_fns * fns = &sched->moe_fns;
++
++    if (sched->moe_prefetch_requested && moe_resolve_prefetch_fns(sched)) {
++        if (!sched->moe_prefetch_initialized) {
++            // Walk splits once to find the max MoE weight tensor size and CUDA backend.
+             size_t max_moe_split_size = 0;
+             for (int s = 0; s < sched->n_splits; s++) {
+                 if (!is_moe_cpu_split(sched, s)) continue;
+@@ -1619,41 +1665,30 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
+                         ggml_backend_buffer_get_usage(inp->buffer) == GGML_BACKEND_BUFFER_USAGE_WEIGHTS) {
+                         size_t nb = ggml_nbytes(inp);
+                         if (nb > max_moe_split_size) max_moe_split_size = nb;
+-                        if (!moe_cuda_backend) moe_cuda_backend = sched->backends[sp->backend_id];
++                        if (!sched->moe_cuda_backend) sched->moe_cuda_backend = sched->backends[sp->backend_id];
+                     }
+                 }
+             }
+-            if (max_moe_split_size > 0 && moe_cuda_backend) {
+-                prefetch_stream = fn_stream_create();
+-                if (prefetch_stream && fn_staging_init((void *)moe_cuda_backend, max_moe_split_size)) {
+-                    prefetch_enabled = true;
+-                    if (!prefetch_init_logged) {
+-                        GGML_LOG_INFO("%s: MoE lookahead prefetch enabled (staging 2x%zu MiB)\n",
+-                                      __func__, max_moe_split_size / (1024 * 1024));
+-                        prefetch_init_logged = true;
+-                    }
++            sched->moe_max_split_size = max_moe_split_size;
++            if (max_moe_split_size > 0 && sched->moe_cuda_backend) {
++                sched->moe_prefetch_stream = fns->stream((void *)sched->moe_cuda_backend);
++                if (sched->moe_prefetch_stream && fns->staging_init((void *)sched->moe_cuda_backend, max_moe_split_size)) {
++                    GGML_LOG_DEBUG("%s: MoE lookahead prefetch enabled (staging 2x%zu MiB)\n",
++                                   __func__, max_moe_split_size / (1024 * 1024));
+                 } else {
+-                    if (fn_prefetch_stream_destroy && prefetch_stream) {
+-                        fn_prefetch_stream_destroy(prefetch_stream);
+-                    }
+-                    prefetch_stream = nullptr;
+-                    if (!prefetch_init_logged) {
+-                        GGML_LOG_WARN("%s: MoE prefetch disabled — staging allocation failed\n", __func__);
+-                        prefetch_init_logged = true;
+-                    }
++                    sched->moe_prefetch_stream = nullptr;
++                    GGML_LOG_DEBUG("%s: MoE prefetch disabled - staging allocation failed\n", __func__);
+                 }
+             } else {
+-                if (!prefetch_init_logged) {
+-                    GGML_LOG_INFO("%s: MoE prefetch inactive — no CPU-MoE splits in graph\n", __func__);
+-                    prefetch_init_logged = true;
+-                }
+-            }
+-        } else {
+-            if (!prefetch_init_logged) {
+-                GGML_LOG_WARN("%s: MoE prefetch disabled — proc lookup failed\n", __func__);
+-                prefetch_init_logged = true;
++                GGML_LOG_DEBUG("%s: MoE prefetch inactive - no CPU-MoE splits in graph\n", __func__);
+             }
++            sched->moe_prefetch_initialized = true;
+         }
++        prefetch_stream = sched->moe_prefetch_stream;
++        moe_cuda_backend = sched->moe_cuda_backend;
++        prefetch_enabled = prefetch_stream != nullptr && moe_cuda_backend != nullptr && sched->moe_max_split_size > 0;
++    } else if (sched->moe_prefetch_requested && !sched->moe_fns.resolved) {
++        GGML_LOG_DEBUG("%s: MoE prefetch disabled - proc lookup failed\n", __func__);
+     }
+
+     for (int split_id = 0; split_id < sched->n_splits; split_id++) {
+@@ -1761,14 +1796,14 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
+                         const int n_ranges = prefetch_n_ranges[moe_prefetch_slot];
+                         bool d2d_ok = false;
+                         const char * mode_str = "full";
+-                        if (n_ranges > 0 && fn_staging_d2d_ranges) {
+-                            d2d_ok = fn_staging_d2d_ranges((void *)split_backend,
++                        if (n_ranges > 0 && fns->staging_d2d_ranges) {
++                            d2d_ok = fns->staging_d2d_ranges((void *)split_backend,
+                                                            moe_prefetch_slot, input_cpy,
+                                                            prefetch_ranges[moe_prefetch_slot],
+                                                            n_ranges);
+                             mode_str = "selective";
+-                        } else if (fn_staging_d2d) {
+-                            d2d_ok = fn_staging_d2d((void *)split_backend, moe_prefetch_slot, input_cpy);
++                        } else if (fns->staging_d2d) {
++                            d2d_ok = fns->staging_d2d((void *)split_backend, moe_prefetch_slot, input_cpy);
+                         }
+                         prefetch_n_ranges[moe_prefetch_slot] = 0;  // invalidate cached ranges
+                         if (d2d_ok) {
+@@ -1776,7 +1811,7 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
+                                            __func__, split_id, moe_prefetch_slot, mode_str, n_ranges);
+                             continue;
+                         }
+-                        GGML_LOG_WARN("%s: staging D2D failed split=%d slot=%d — falling back to selective copy\n",
++                        GGML_LOG_WARN("%s: staging D2D failed split=%d slot=%d - falling back to selective copy\n",
+                                       __func__, split_id, moe_prefetch_slot);
+                     }
+
+@@ -1838,8 +1873,7 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
+             enum ggml_status ec = ggml_backend_graph_compute_async(split_backend, &split->graph, sched->batch_size);
+             if (ec != GGML_STATUS_SUCCESS) {
+                 if (prefetch_enabled) {
+-                    if (fn_prefetch_stream_sync)    fn_prefetch_stream_sync(prefetch_stream);
+-                    if (fn_prefetch_stream_destroy) fn_prefetch_stream_destroy(prefetch_stream);
++                    if (fns->stream_synchronize) fns->stream_synchronize(prefetch_stream);
+                 }
+                 return ec;
+             }
+@@ -1864,8 +1898,7 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
+                 enum ggml_status ec = ggml_backend_graph_compute_async(split_backend, &gv, sched->batch_size);
+                 if (ec != GGML_STATUS_SUCCESS) {
+                     if (prefetch_enabled) {
+-                        if (fn_prefetch_stream_sync)    fn_prefetch_stream_sync(prefetch_stream);
+-                        if (fn_prefetch_stream_destroy) fn_prefetch_stream_destroy(prefetch_stream);
++                        if (fns->stream_synchronize) fns->stream_synchronize(prefetch_stream);
+                     }
+                     return ec;
+                 }
+@@ -1902,7 +1935,7 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
+             if (is_moe_cpu_split(sched, next_id)) {
+                 struct ggml_backend_sched_split * next_split = &sched->splits[next_id];
+                 struct ggml_tensor * next_node = next_split->graph.nodes[0];
+-                if (fn_staging_h2d) {
++                if (fns->staging_h2d) {
+                     bool fired = false;
+                     int  slot  = prefetch_counter & 1;
+                     const char * mode_str = "full";
+@@ -1911,8 +1944,8 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
+
+                     struct ggml_tensor * next_ids = next_node->src[2];
+                     const bool can_selective =
+-                        (fn_staging_h2d_ranges != nullptr) &&
+-                        (fn_staging_d2d_ranges != nullptr) &&
++                        (fns->staging_h2d_ranges != nullptr) &&
++                        (fns->staging_d2d_ranges != nullptr) &&
+                         (prev_ids_tensor != nullptr) &&
+                         (next_ids == prev_ids_tensor) &&
+                         !used_ids.empty();
+@@ -1964,7 +1997,7 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
+                                 }
+
+                                 if (n_ranges > 0 &&
+-                                    fn_staging_h2d_ranges((void *)moe_cuda_backend, prefetch_stream,
++                                    fns->staging_h2d_ranges((void *)moe_cuda_backend, prefetch_stream,
+                                                           slot, inp, ranges, n_ranges)) {
+                                     memcpy(prefetch_ranges[slot], ranges, sizeof(ranges[0]) * n_ranges);
+                                     prefetch_n_ranges[slot] = n_ranges;
+@@ -1978,7 +2011,7 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
+                             }
+
+                             if (!fired) {
+-                                if (fn_staging_h2d((void *)moe_cuda_backend, prefetch_stream, slot, inp)) {
++                                if (fns->staging_h2d((void *)moe_cuda_backend, prefetch_stream, slot, inp)) {
+                                     prefetch_n_ranges[slot] = 0;  // flag as full-tensor
+                                     fired = true;
+                                     mode_str = "full";
+@@ -2013,14 +2046,6 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
+         }
+     }
+
+-    // Cleanup: drain the prefetch stream and destroy it.
+-    // (Staging buffers + per-slot events live on the CUDA backend context and
+-    // are torn down in ggml_backend_sched_free / ~ggml_backend_cuda_context.)
+-    if (prefetch_enabled) {
+-        if (fn_prefetch_stream_sync)    fn_prefetch_stream_sync(prefetch_stream);
+-        if (fn_prefetch_stream_destroy) fn_prefetch_stream_destroy(prefetch_stream);
+-    }
+-
+     return GGML_STATUS_SUCCESS;
+ }
+
+@@ -2060,6 +2085,7 @@ ggml_backend_sched_t ggml_backend_sched_new_ext(
+
+     sched->n_backends = n_backends;
+     sched->n_copies = parallel ? GGML_SCHED_MAX_COPIES : 1;
++    sched->moe_prefetch_requested = moe_env_enabled("OLLAMA_MOE_PREFETCH_ENABLED");
+
+     // initialize hash table
+     // FIXME: needs to be size*2 to account for leafs (do it in graph_split instead)
+@@ -2125,7 +2151,6 @@ void ggml_backend_sched_free(ggml_backend_sched_t sched) {
+             ggml_backend_dev_t dev = ggml_backend_get_device(backend);
+             if (!dev || ggml_backend_dev_type(dev) != GGML_BACKEND_DEVICE_TYPE_GPU) continue;
+             fn_staging_destroy((void *)backend);
+-            break;
+         }
+     }
+
+diff --git a/ggml/src/ggml-cuda/common.cuh b/ggml/src/ggml-cuda/common.cuh
+index 034c61d6d..9534f3376 100644
+--- a/ggml/src/ggml-cuda/common.cuh
++++ b/ggml/src/ggml-cuda/common.cuh
+@@ -1272,6 +1272,7 @@ struct ggml_backend_cuda_context {
+         void *       buffers[2]    = {nullptr, nullptr};
+         cudaEvent_t  h2d_done[2]   = {nullptr, nullptr};
+         size_t       capacity      = 0;
++        cudaStream_t stream        = nullptr;
+     } moe_staging;
+
+     ~ggml_backend_cuda_context();
+diff --git a/ggml/src/ggml-cuda/ggml-cuda.cu b/ggml/src/ggml-cuda/ggml-cuda.cu
+index 33a8fadcf..d2bf5d0dc 100644
+--- a/ggml/src/ggml-cuda/ggml-cuda.cu
++++ b/ggml/src/ggml-cuda/ggml-cuda.cu
+@@ -672,6 +672,10 @@ ggml_backend_cuda_context::~ggml_backend_cuda_context() {
+         CUDA_CHECK(cudaEventDestroy(copy_event));
+     }
+     // MoE staging safety-net cleanup (sched normally destroys first)
++    if (moe_staging.stream != nullptr) {
++        CUDA_CHECK(cudaStreamDestroy(moe_staging.stream));
++        moe_staging.stream = nullptr;
++    }
+     for (int i = 0; i < 2; i++) {
+         if (moe_staging.buffers[i] != nullptr) {
+             CUDA_CHECK(cudaFree(moe_staging.buffers[i]));
+@@ -5085,21 +5089,22 @@ static ggml_backend_feature * ggml_backend_cuda_get_features(ggml_backend_reg_t
+ }
+
+ // ---------------------------------------------------------------------------
+-// MoE prefetch CUDA helpers — exposed via proc address as void* handles
++// MoE prefetch CUDA helpers exposed via proc address as void* handles.
+ // ---------------------------------------------------------------------------
+
+-static void * ggml_backend_cuda_moe_stream_create() {
+-    cudaStream_t stream;
+-    if (cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking) != cudaSuccess) {
+-        return nullptr;
++static void * ggml_backend_cuda_moe_stream(void * backend_handle) {
++    if (!backend_handle) return nullptr;
++    ggml_backend_t backend = (ggml_backend_t)backend_handle;
++    ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *)backend->context;
++    if (cuda_ctx->moe_staging.stream != nullptr) {
++        return (void *)cuda_ctx->moe_staging.stream;
+     }
+-    return (void *)stream;
+-}
+-
+-static void ggml_backend_cuda_moe_stream_destroy(void * stream_handle) {
+-    if (stream_handle) {
+-        cudaStreamDestroy((cudaStream_t)stream_handle);
++    ggml_cuda_set_device(cuda_ctx->device);
++    if (cudaStreamCreateWithFlags(&cuda_ctx->moe_staging.stream, cudaStreamNonBlocking) != cudaSuccess) {
++        cuda_ctx->moe_staging.stream = nullptr;
++        return nullptr;
+     }
++    return (void *)cuda_ctx->moe_staging.stream;
+ }
+
+ static void ggml_backend_cuda_moe_stream_synchronize(void * stream_handle) {
+@@ -5109,7 +5114,7 @@ static void ggml_backend_cuda_moe_stream_synchronize(void * stream_handle) {
+ }
+
+ // ---------------------------------------------------------------------------
+-// MoE prefetch — staging buffer path (overlap-safe)
++// MoE prefetch staging buffer path (overlap-safe).
+ //
+ // Two dedicated VRAM buffers (double-buffered) receive H2D copies on the
+ // independent prefetch stream; the main compute stream later D2D-copies from
+@@ -5120,7 +5125,7 @@ static void ggml_backend_cuda_moe_stream_synchronize(void * stream_handle) {
+
+ // Initialize double staging buffers of `max_size` bytes each on the given
+ // backend's device. Returns true on success; leaves staging empty on failure.
+-// Safe to call repeatedly — grows (but never shrinks) capacity.
++// Safe to call repeatedly, growing but never shrinking capacity.
+ static bool ggml_backend_cuda_moe_staging_init(void * backend_handle, size_t max_size) {
+     if (!backend_handle || max_size == 0) return false;
+     ggml_backend_t backend = (ggml_backend_t)backend_handle;
+@@ -5169,6 +5174,10 @@ static void ggml_backend_cuda_moe_staging_destroy(void * backend_handle) {
+     ggml_backend_t backend = (ggml_backend_t)backend_handle;
+     ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *)backend->context;
+     ggml_cuda_set_device(cuda_ctx->device);
++    if (cuda_ctx->moe_staging.stream != nullptr) {
++        cudaStreamDestroy(cuda_ctx->moe_staging.stream);
++        cuda_ctx->moe_staging.stream = nullptr;
++    }
+     for (int i = 0; i < 2; i++) {
+         if (cuda_ctx->moe_staging.buffers[i] != nullptr) {
+             cudaFree(cuda_ctx->moe_staging.buffers[i]);
+@@ -5329,11 +5338,8 @@ static void * ggml_backend_cuda_reg_get_proc_address(ggml_backend_reg_t reg, con
+     if (strcmp(name, "ggml_backend_get_features") == 0) {
+         return (void *)ggml_backend_cuda_get_features;
+     }
+-    if (strcmp(name, "ggml_backend_cuda_moe_stream_create") == 0) {
+-        return (void *)ggml_backend_cuda_moe_stream_create;
+-    }
+-    if (strcmp(name, "ggml_backend_cuda_moe_stream_destroy") == 0) {
+-        return (void *)ggml_backend_cuda_moe_stream_destroy;
++    if (strcmp(name, "ggml_backend_cuda_moe_stream") == 0) {
++        return (void *)ggml_backend_cuda_moe_stream;
+     }
+     if (strcmp(name, "ggml_backend_cuda_moe_stream_synchronize") == 0) {
+         return (void *)ggml_backend_cuda_moe_stream_synchronize;
+diff --git a/src/llama.cpp b/src/llama.cpp
+index 759152b76..9d676ddbe 100644
+--- a/src/llama.cpp
++++ b/src/llama.cpp
+@@ -322,7 +322,7 @@ static void llama_params_fit_impl(
+             case LAYER_FRACTION_MOE: {
+                 static std::array<std::string, n_strings> patterns;
+                 if (patterns[il].empty()) {
+-                    patterns[il] = "blk\\." + std::to_string(il) + "\\.ffn_(up|down|gate)_(ch|)exps";
++                    patterns[il] = "blk\\." + std::to_string(il) + "\\.ffn_(up|down|gate|gate_up)_(exps|chexps|ch_exps)";
+                 }
+                 return patterns[il].c_str();
+             }
+@@ -417,7 +417,7 @@ static void llama_params_fit_impl(
+
+     int64_t global_surplus_cpu_moe = 0;
+     if (hp_nex > 0) {
+-        const static std::string pattern_moe_all = "blk\\.\\d+\\.ffn_(up|down|gate)_(ch|)exps"; // matches all MoE tensors
++        const static std::string pattern_moe_all = "blk\\.\\d+\\.ffn_(up|down|gate|gate_up)_(exps|chexps|ch_exps)"; // matches all MoE tensors
+         ggml_backend_buffer_type_t cpu_buft = ggml_backend_cpu_buffer_type();
+         tensor_buft_overrides[0] = {pattern_moe_all.c_str(), cpu_buft};
+         tensor_buft_overrides[1] = {nullptr, nullptr};
+@@ -1067,4 +1067,3 @@ const char * llama_print_system_info(void) {
+
+     return s.c_str();
+ }
+-

--- a/llm/server.go
+++ b/llm/server.go
@@ -286,6 +286,12 @@ func NewLlamaServer(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, modelPath st
 		}
 		runnerEnvs["GGML_CUDA_REGISTER_HOST"] = "1"
 	}
+	if envconfig.MoePrefetch() && envconfig.MoePinned() && envconfig.MoeGpuLayers() != 0 {
+		if runnerEnvs == nil {
+			runnerEnvs = map[string]string{}
+		}
+		runnerEnvs["OLLAMA_MOE_PREFETCH"] = "1"
+	}
 	cmd, port, err := StartRunner(
 		tok != nil,
 		modelPath,

--- a/llm/server.go
+++ b/llm/server.go
@@ -1258,26 +1258,92 @@ func (s *llmServer) verifyLayout(systemInfo ml.SystemInfo, systemGPUs []ml.Devic
 	// These sizes will only increase as we go through additional iterations and get additional information.
 	cpuSize := memory.InputWeights + memory.CPU.Graph
 	var vramSize uint64
-	for _, gl := range gpuLayers {
-		for _, gpu := range memory.GPUs {
-			if gl.DeviceID == gpu.DeviceID {
-				vramSize += gpu.Graph
-				break
+	if len(denseGPULayers) > 0 {
+		gpuLayer := func(gpuLayers ml.GPULayersList, layer int) bool {
+			for _, g := range gpuLayers {
+				for _, gl := range g.Layers {
+					if layer == gl {
+						return true
+					}
+				}
 			}
+			return false
 		}
-	}
 
-nextLayer:
-	for i := range layers {
-		for _, g := range gpuLayers {
-			for _, gl := range g.Layers {
-				if i == gl {
-					vramSize += layers[i]
-					continue nextLayer
+		gpuGraphs := map[ml.DeviceID]struct{}{}
+		addGPUGraph := func(deviceID ml.DeviceID) {
+			if _, ok := gpuGraphs[deviceID]; ok {
+				return
+			}
+			for _, gpu := range memory.GPUs {
+				if deviceID == gpu.DeviceID {
+					vramSize += gpu.Graph
+					gpuGraphs[deviceID] = struct{}{}
+					break
 				}
 			}
 		}
-		cpuSize += layers[i]
+
+		for _, gl := range denseGPULayers {
+			if len(gl.Layers) > 0 {
+				addGPUGraph(gl.DeviceID)
+			}
+		}
+		for _, gl := range gpuLayers {
+			if len(gl.Layers) > 0 {
+				addGPUGraph(gl.DeviceID)
+			}
+		}
+
+		for i := range layers {
+			var weightSize, moeSize, cacheSize uint64
+			for _, gpu := range memory.GPUs {
+				weightSize += gpu.Weights[i]
+				cacheSize += gpu.Cache[i]
+				if len(gpu.MoEWeights) > i {
+					moeSize += gpu.MoEWeights[i]
+				}
+			}
+			weightSize += memory.CPU.Weights[i]
+			cacheSize += memory.CPU.Cache[i]
+			if len(memory.CPU.MoEWeights) > i {
+				moeSize += memory.CPU.MoEWeights[i]
+			}
+
+			denseSize := weightSize - moeSize
+			if gpuLayer(denseGPULayers, i) {
+				vramSize += denseSize + cacheSize
+			} else {
+				cpuSize += denseSize + cacheSize
+			}
+			if gpuLayer(gpuLayers, i) {
+				vramSize += moeSize
+			} else {
+				cpuSize += moeSize
+			}
+		}
+	} else {
+		for _, gl := range gpuLayers {
+			for _, gpu := range memory.GPUs {
+				if gl.DeviceID == gpu.DeviceID {
+					vramSize += gpu.Graph
+					break
+				}
+			}
+		}
+
+	nextLayer:
+		for i := range layers {
+			for _, g := range gpuLayers {
+				for _, gl := range g.Layers {
+					if i == gl {
+						vramSize += layers[i]
+						continue nextLayer
+					}
+				}
+			}
+			cpuSize += layers[i]
+		}
 	}
 
 	if requireFull {

--- a/llm/server.go
+++ b/llm/server.go
@@ -273,25 +273,7 @@ func NewLlamaServer(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, modelPath st
 
 	gpuLibs := ml.LibraryPaths(gpus)
 	status := NewStatusWriter(os.Stderr)
-	runnerEnvs := ml.GetVisibleDevicesEnv(gpus, false)
-	// When OLLAMA_MOE_PINNED is enabled, the ggml CUDA backend's internal
-	// cudaHostRegister wrapper checks getenv("GGML_CUDA_REGISTER_HOST") from
-	// the DLL's own CRT instance. Go's os.Setenv and CGo _putenv_s both update
-	// different CRT copies and are invisible to the DLL. The only reliable way
-	// to set a variable for all CRT instances in a process is to inject it into
-	// the child process env block before launch, which all CRTs read at init.
-	if envconfig.MoePinned() && envconfig.MoeGpuLayers() != 0 {
-		if runnerEnvs == nil {
-			runnerEnvs = map[string]string{}
-		}
-		runnerEnvs["GGML_CUDA_REGISTER_HOST"] = "1"
-	}
-	if envconfig.MoePrefetch() && envconfig.MoePinned() && envconfig.MoeGpuLayers() != 0 {
-		if runnerEnvs == nil {
-			runnerEnvs = map[string]string{}
-		}
-		runnerEnvs["OLLAMA_MOE_PREFETCH"] = "1"
-	}
+	runnerEnvs := runnerEnvOverrides(gpus)
 	cmd, port, err := StartRunner(
 		tok != nil,
 		modelPath,
@@ -1001,6 +983,126 @@ func uniqueDeviceIDs(gpuLayers ml.GPULayersList) []ml.DeviceID {
 	return devices
 }
 
+func moeSplitConfigured() bool {
+	return envconfig.MoeGpuLayers() != 0 || envconfig.MoeCpuLayers() != 0
+}
+
+func moePrefetchConfigured() bool {
+	return envconfig.MoePrefetch() && envconfig.MoePinned()
+}
+
+func runnerEnvOverrides(gpus []ml.DeviceInfo) map[string]string {
+	runnerEnvs := ml.GetDevicesEnv(gpus, false)
+	// When OLLAMA_MOE_PINNED is enabled, the ggml CUDA backend's internal
+	// cudaHostRegister wrapper checks getenv("GGML_CUDA_REGISTER_HOST") from
+	// the DLL's own CRT instance. Go's os.Setenv and CGo _putenv_s both update
+	// different CRT copies and are invisible to the DLL. The only reliable way
+	// to set a variable for all CRT instances in a process is to inject it into
+	// the child process env block before launch, which all CRTs read at init.
+	if envconfig.MoePinned() && moeSplitConfigured() {
+		if runnerEnvs == nil {
+			runnerEnvs = map[string]string{}
+		}
+		runnerEnvs["GGML_CUDA_REGISTER_HOST"] = "1"
+	}
+	if moePrefetchConfigured() && moeSplitConfigured() {
+		if runnerEnvs == nil {
+			runnerEnvs = map[string]string{}
+		}
+		runnerEnvs["OLLAMA_MOE_PREFETCH_ENABLED"] = "1"
+	}
+
+	return runnerEnvs
+}
+
+func requestedMoEGPULayers(totalLayers int, moeLayers []int) ([]int, string, error) {
+	gpuLayers := envconfig.MoeGpuLayers()
+	cpuLayers := envconfig.MoeCpuLayers()
+	if gpuLayers != 0 && cpuLayers != 0 {
+		return nil, "", errors.New("OLLAMA_MOE_GPU_LAYERS and OLLAMA_MOE_CPU_LAYERS are mutually exclusive")
+	}
+	if gpuLayers < -1 {
+		return nil, "", errors.New("OLLAMA_MOE_GPU_LAYERS must be -1 or greater")
+	}
+	if cpuLayers < 0 {
+		return nil, "", errors.New("OLLAMA_MOE_CPU_LAYERS must be greater than or equal to 0")
+	}
+	if cpuLayers > totalLayers {
+		return nil, "", fmt.Errorf("OLLAMA_MOE_CPU_LAYERS=%d exceeds model layer count %d", cpuLayers, totalLayers)
+	}
+	if cpuLayers > 0 {
+		gpuMoELayers := make([]int, 0, len(moeLayers))
+		for _, layer := range moeLayers {
+			if layer >= cpuLayers {
+				gpuMoELayers = append(gpuMoELayers, layer)
+			}
+		}
+		return gpuMoELayers, "user-cpu-override", nil
+	}
+	if gpuLayers > len(moeLayers) {
+		return nil, "", fmt.Errorf("OLLAMA_MOE_GPU_LAYERS=%d exceeds MoE expert layer count %d", gpuLayers, len(moeLayers))
+	}
+	if gpuLayers > 0 {
+		return slices.Clone(moeLayers[len(moeLayers)-gpuLayers:]), "user-gpu-override", nil
+	}
+	return nil, "auto", nil
+}
+
+func moeLayerIndexes(moeSize []uint64) []int {
+	layers := make([]int, 0, len(moeSize))
+	for i, size := range moeSize {
+		if size > 0 {
+			layers = append(layers, i)
+		}
+	}
+	return layers
+}
+
+func deviceMoEMaxTensor(device ml.DeviceMemory, layer int) uint64 {
+	if layer >= 0 && layer < len(device.MoEMaxTensor) {
+		return device.MoEMaxTensor[layer]
+	}
+	return 0
+}
+
+func moePrefetchReserve(memory *ml.BackendMemory, moeSize []uint64, moeLayers []int) uint64 {
+	if !moePrefetchConfigured() {
+		return 0
+	}
+	var maxSize uint64
+	for _, layer := range moeLayers {
+		for _, gpu := range memory.GPUs {
+			maxSize = max(maxSize, deviceMoEMaxTensor(gpu, layer))
+		}
+		maxSize = max(maxSize, deviceMoEMaxTensor(memory.CPU, layer))
+	}
+	if maxSize == 0 {
+		for _, layer := range moeLayers {
+			maxSize = max(maxSize, moeSize[layer])
+		}
+	}
+	return 2 * maxSize
+}
+
+func remapMoELayers(gpuLayers ml.GPULayersList, moeLayers []int) ml.GPULayersList {
+	for i := range gpuLayers {
+		for j, layer := range gpuLayers[i].Layers {
+			if layer >= 0 && layer < len(moeLayers) {
+				gpuLayers[i].Layers[j] = moeLayers[layer]
+			}
+		}
+	}
+	return gpuLayers
+}
+
+func moeGPUSetFromLayers(moeLayers []int) map[int]struct{} {
+	gpuSet := make(map[int]struct{}, len(moeLayers))
+	for _, layer := range moeLayers {
+		gpuSet[layer] = struct{}{}
+	}
+	return gpuSet
+}
+
 // createLayout uses the current best view of memory requirements and creates a layout of model layers on GPUs.
 // It does this by:
 // - Calculating how much space each layer requires
@@ -1010,13 +1112,17 @@ func uniqueDeviceIDs(gpuLayers ml.GPULayersList) []ml.DeviceID {
 func (s *llmServer) createLayout(systemInfo ml.SystemInfo, systemGPUs []ml.DeviceInfo, memory *ml.BackendMemory, requireFull bool, backoff float32) (ml.GPULayersList, ml.GPULayersList, error) {
 	if memory == nil {
 		memory = &ml.BackendMemory{CPU: ml.DeviceMemory{
-			Weights:    make([]uint64, s.totalLayers),
-			MoEWeights: make([]uint64, s.totalLayers),
-			Cache:      make([]uint64, s.totalLayers),
+			Weights:      make([]uint64, s.totalLayers),
+			MoEWeights:   make([]uint64, s.totalLayers),
+			MoEMaxTensor: make([]uint64, s.totalLayers),
+			Cache:        make([]uint64, s.totalLayers),
 		}}
 	}
-	gpuLayers, denseGPULayers, layers := s.buildLayout(systemGPUs, memory, requireFull, backoff)
-	err := s.verifyLayout(systemInfo, systemGPUs, memory, requireFull, gpuLayers, denseGPULayers, layers)
+	gpuLayers, denseGPULayers, layers, err := s.buildLayout(systemGPUs, memory, requireFull, backoff)
+	if err != nil {
+		return nil, nil, err
+	}
+	err = s.verifyLayout(systemInfo, systemGPUs, memory, requireFull, gpuLayers, denseGPULayers, layers)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1029,7 +1135,7 @@ func (s *llmServer) createLayout(systemInfo ml.SystemInfo, systemGPUs []ml.Devic
 //	gpuLayers      - layers used for iteration convergence (MoE-on-GPU count if MoE split active)
 //	denseGPULayers - layers with dense weights on GPU (all layers when MoE split active); nil otherwise
 //	layers         - total per-layer memory sizes
-func (s *llmServer) buildLayout(systemGPUs []ml.DeviceInfo, memory *ml.BackendMemory, requireFull bool, backoff float32) (gpuLayers ml.GPULayersList, denseGPULayers ml.GPULayersList, layers []uint64) {
+func (s *llmServer) buildLayout(systemGPUs []ml.DeviceInfo, memory *ml.BackendMemory, requireFull bool, backoff float32) (gpuLayers ml.GPULayersList, denseGPULayers ml.GPULayersList, layers []uint64, err error) {
 	gpus := append(make([]ml.DeviceInfo, 0, len(systemGPUs)), systemGPUs...)
 	sort.Sort(sort.Reverse(ml.ByFreeMemory(gpus)))
 
@@ -1044,9 +1150,10 @@ func (s *llmServer) buildLayout(systemGPUs []ml.DeviceInfo, memory *ml.BackendMe
 		logutil.Trace("layer to assign", "layer", i, "size", format.HumanBytes2(layers[i]))
 	}
 
-	// ── MoE split logic ───────────────────────────────────────────────────────
-	// Compute per-layer MoE sizes (sum across all devices, since probe puts weights
-	// on one device but we need the logical per-layer total).
+	// MoE split logic.
+	// Compute per-layer MoE sizes, summing across all devices. The probe can
+	// place weights on one device, but split planning needs the logical
+	// per-layer total.
 	moeSize := make([]uint64, len(layers))
 	for i := range moeSize {
 		for j := range memory.GPUs {
@@ -1066,9 +1173,23 @@ func (s *llmServer) buildLayout(systemGPUs []ml.DeviceInfo, memory *ml.BackendMe
 		cacheSize[i] += memory.CPU.Cache[i]
 	}
 
-	isMoEModel := slices.ContainsFunc(moeSize, func(s uint64) bool { return s > 0 })
+	moeExpertLayers := moeLayerIndexes(moeSize)
+	isMoEModel := len(moeExpertLayers) > 0
 
-	if isMoEModel && envconfig.MoeGpuLayers() != 0 {
+	if !isMoEModel && moeSplitConfigured() && slices.ContainsFunc(layers, func(size uint64) bool { return size > 0 }) {
+		return nil, nil, nil, errors.New("moe split requested but no MoE expert tensors were detected")
+	}
+
+	if isMoEModel && moeSplitConfigured() {
+		if len(gpus) > 1 {
+			return nil, nil, nil, fmt.Errorf("moe split currently supports one GPU; found %d", len(gpus))
+		}
+
+		requestedMoELayers, source, err := requestedMoEGPULayers(len(layers), moeExpertLayers)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
 		// Dense/cache is the baseline reservation; MoE expert weights are assigned separately.
 		denseSize := make([]uint64, len(layers))
 		for i := range denseSize {
@@ -1097,45 +1218,49 @@ func (s *llmServer) buildLayout(systemGPUs []ml.DeviceInfo, memory *ml.BackendMe
 			}
 		}
 
-		if totalDenseOverhead > availableVRAM {
+		prefetchReserve := moePrefetchReserve(memory, moeSize, moeExpertLayers)
+		totalDenseAndPrefetch := totalDenseOverhead + prefetchReserve
+
+		if totalDenseAndPrefetch > availableVRAM {
 			slog.Warn("moe split: dense weights and cache exceed available VRAM, falling back to standard layout",
 				"dense_cache_total", format.HumanBytes2(totalDenseOverhead),
+				"prefetch_reserve", format.HumanBytes2(prefetchReserve),
 				"available_vram", format.HumanBytes2(availableVRAM))
+			if source != "auto" {
+				return nil, nil, nil, fmt.Errorf("moe split cannot allocate requested %s; dense/cache/prefetch need %s but only %s is available",
+					source, format.HumanBytes2(totalDenseAndPrefetch), format.HumanBytes2(availableVRAM))
+			}
 			// Fall through to standard assignLayers below
 		} else {
 			slog.Info("moe split: dense weights and cache fit, activating split",
 				"dense_cache_total", format.HumanBytes2(totalDenseOverhead),
-				"vram_for_moe", format.HumanBytes2(availableVRAM-totalDenseOverhead))
+				"prefetch_reserve", format.HumanBytes2(prefetchReserve),
+				"vram_for_moe", format.HumanBytes2(availableVRAM-totalDenseAndPrefetch))
 
-			moeGPUCount := envconfig.MoeGpuLayers()
-			source := "auto"
-			if moeGPUCount >= 0 {
-				if moeGPUCount > len(moeSize) {
-					slog.Warn("moe split: OLLAMA_MOE_GPU_LAYERS exceeds total layers, clamped",
-						"requested", moeGPUCount, "clamped", len(moeSize))
-					moeGPUCount = len(moeSize)
-				}
-				source = "user-override"
-			} else {
-				remainingVRAM := availableVRAM - totalDenseOverhead
-				moeGPUCount = 0
-				for i := range moeSize {
-					if moeSize[i] > remainingVRAM {
+			if source == "auto" {
+				remainingVRAM := availableVRAM - totalDenseAndPrefetch
+				moeGPUCount := 0
+				for i := len(moeExpertLayers) - 1; i >= 0; i-- {
+					layer := moeExpertLayers[i]
+					if moeSize[layer] > remainingVRAM {
 						break
 					}
-					remainingVRAM -= moeSize[i]
+					remainingVRAM -= moeSize[layer]
 					moeGPUCount++
 				}
+				requestedMoELayers = slices.Clone(moeExpertLayers[len(moeExpertLayers)-moeGPUCount:])
 			}
 
 			slog.Info("moe split: layer budget",
-				"moe_gpu_layers", moeGPUCount,
-				"moe_cpu_layers", len(moeSize)-moeGPUCount,
+				"moe_layers", len(moeExpertLayers),
+				"moe_gpu_layers", len(requestedMoELayers),
+				"moe_cpu_layers", len(moeExpertLayers)-len(requestedMoELayers),
 				"cfg", source)
 
+			intendedMoEGPUSet := moeGPUSetFromLayers(requestedMoELayers)
 			for i := range layers {
 				loc := "cpu"
-				if i < moeGPUCount {
+				if _, ok := intendedMoEGPUSet[i]; ok {
 					loc = "gpu"
 				}
 				slog.Debug("moe split: layer layout",
@@ -1147,8 +1272,10 @@ func (s *llmServer) buildLayout(systemGPUs []ml.DeviceInfo, memory *ml.BackendMe
 			}
 
 			// Build adjusted layer sizes (MoE-only cost) and adjusted GPU free memory
-			adjustedLayers := make([]uint64, len(layers))
-			copy(adjustedLayers, moeSize)
+			adjustedLayers := make([]uint64, len(moeExpertLayers))
+			for i, layer := range moeExpertLayers {
+				adjustedLayers[i] = moeSize[layer]
+			}
 
 			adjustedGPUs := make([]ml.DeviceInfo, len(gpus))
 			copy(adjustedGPUs, gpus)
@@ -1167,26 +1294,25 @@ func (s *llmServer) buildLayout(systemGPUs []ml.DeviceInfo, memory *ml.BackendMe
 				} else {
 					adjustedGPUs[i].FreeMemory = 0
 				}
-				// Then subtract dense overhead (pre-allocated for all layers)
-				if adjustedGPUs[i].FreeMemory > totalDenseOverhead {
-					adjustedGPUs[i].FreeMemory -= totalDenseOverhead
+				// Then subtract dense overhead (pre-allocated for all layers) and staging reserve.
+				if adjustedGPUs[i].FreeMemory > totalDenseAndPrefetch {
+					adjustedGPUs[i].FreeMemory -= totalDenseAndPrefetch
 				} else {
 					adjustedGPUs[i].FreeMemory = 0
 				}
 			}
 
-			gpuLayersMoE := assignLayers(adjustedLayers, adjustedGPUs, requireFull, s.options.NumGPU, 0)
-
-			// Honor user-specified moe GPU layer count exactly.
-			// assignLayers always greedily fills; cap it when the user set a hard limit.
-			if source == "user-override" && gpuLayersMoE.Sum() > moeGPUCount {
-				var all []int
-				for _, g := range gpuLayersMoE {
-					all = append(all, g.Layers...)
+			gpuLayersMoE := findBestFit(adjustedLayers, adjustedGPUs, len(requestedMoELayers), false)
+			gpuLayersMoE = remapMoELayers(gpuLayersMoE, moeExpertLayers)
+			if gpuLayersMoE.Sum() != len(requestedMoELayers) {
+				if source != "auto" {
+					return nil, nil, nil, fmt.Errorf("moe split cannot allocate requested %d GPU MoE layers; allocated %d", len(requestedMoELayers), gpuLayersMoE.Sum())
 				}
-				slices.Sort(all)
-				gpuLayersMoE = ml.GPULayersList{{DeviceID: gpuLayersMoE[0].DeviceID, Layers: all[:moeGPUCount]}}
+				requestedMoELayers = requestedMoELayers[:gpuLayersMoE.Sum()]
 			}
+			slog.Info("moe split: actual layer assignment",
+				"moe_gpu_layers", gpuLayersMoE.Sum(),
+				"moe_cpu_layers", len(moeExpertLayers)-gpuLayersMoE.Sum())
 
 			// denseGPULayers: all layers on the same GPU(s) used by gpuLayersMoE
 			allLayerIndices := make([]int, len(layers))
@@ -1204,10 +1330,9 @@ func (s *llmServer) buildLayout(systemGPUs []ml.DeviceInfo, memory *ml.BackendMe
 				Layers:   allLayerIndices,
 			}}
 
-			return gpuLayersMoE, denseGPULayers, layers
+			return gpuLayersMoE, denseGPULayers, layers, nil
 		}
 	}
-	// ── End MoE split logic ──────────────────────────────────────────────────
 
 	gpuLayers = ml.GPULayersList{}
 	for _, gl := range ml.ByLibrary(gpus) {
@@ -1252,7 +1377,7 @@ func (s *llmServer) buildLayout(systemGPUs []ml.DeviceInfo, memory *ml.BackendMe
 			gpuLayers = libraryGpuLayers
 		}
 	}
-	return gpuLayers, nil, layers
+	return gpuLayers, nil, layers, nil
 }
 
 // verifyLayout ensures that we don't exceed limits, such as requirements about partial offloading or system memory
@@ -1312,7 +1437,10 @@ func (s *llmServer) verifyLayout(systemInfo ml.SystemInfo, systemGPUs []ml.Devic
 				moeSize += memory.CPU.MoEWeights[i]
 			}
 
-			denseSize := weightSize - moeSize
+			denseSize := uint64(0)
+			if weightSize > moeSize {
+				denseSize = weightSize - moeSize
+			}
 			if gpuLayer(denseGPULayers, i) {
 				vramSize += denseSize + cacheSize
 			} else {

--- a/llm/server.go
+++ b/llm/server.go
@@ -532,8 +532,11 @@ type LoadRequest struct {
 	KvCacheType    string
 	NumThreads     int
 	GPULayers      ml.GPULayersList
+	// MoESplit means dense weights and MoE expert weights can be routed separately.
+	// MoEGPULayers may be empty when all MoE expert weights are CPU-resident.
+	MoESplit bool
 	// MoEGPULayers is the subset of GPULayers where MoE expert weights
-	// are also resident on GPU. Nil means no MoE split.
+	// are also resident on GPU. Used only when MoESplit is true.
 	MoEGPULayers   ml.GPULayersList
 	MultiUserCache bool
 
@@ -831,9 +834,11 @@ nextOperation:
 		for {
 			if len(denseGPULayers) > 0 {
 				s.loadRequest.GPULayers = denseGPULayers
+				s.loadRequest.MoESplit = true
 				s.loadRequest.MoEGPULayers = gpuLayers
 			} else {
 				s.loadRequest.GPULayers = gpuLayers
+				s.loadRequest.MoESplit = false
 				s.loadRequest.MoEGPULayers = nil
 			}
 			resp, err := s.initModel(ctx, s.loadRequest, operation)
@@ -891,9 +896,11 @@ nextOperation:
 
 						if len(newDenseGPULayers) > 0 {
 							s.loadRequest.GPULayers = newDenseGPULayers
+							s.loadRequest.MoESplit = true
 							s.loadRequest.MoEGPULayers = newGPULayers
 						} else {
 							s.loadRequest.GPULayers = newGPULayers
+							s.loadRequest.MoESplit = false
 							s.loadRequest.MoEGPULayers = nil
 						}
 						resp, err = s.initModel(ctx, s.loadRequest, operation)
@@ -954,9 +961,11 @@ nextOperation:
 
 	if len(denseGPULayers) > 0 {
 		s.loadRequest.GPULayers = denseGPULayers
+		s.loadRequest.MoESplit = true
 		s.loadRequest.MoEGPULayers = gpuLayers
 	} else {
 		s.loadRequest.GPULayers = gpuLayers
+		s.loadRequest.MoESplit = false
 		s.loadRequest.MoEGPULayers = nil
 	}
 	resp, err := s.initModel(ctx, s.loadRequest, LoadOperationCommit)

--- a/llm/server.go
+++ b/llm/server.go
@@ -1192,10 +1192,10 @@ func (s *llmServer) buildLayout(systemGPUs []ml.DeviceInfo, memory *ml.BackendMe
 				allLayerIndices[i] = i
 			}
 			var denseDeviceID ml.DeviceID
-			if len(gpuLayersMoE) > 0 {
+			if gpuLayersMoE.Sum() > 0 {
 				denseDeviceID = gpuLayersMoE[0].DeviceID
 			} else if len(gpus) > 0 {
-				denseDeviceID = gpus[len(gpus)-1].DeviceID
+				denseDeviceID = gpus[0].DeviceID
 			}
 			denseGPULayers = ml.GPULayersList{{
 				DeviceID: denseDeviceID,

--- a/llm/server.go
+++ b/llm/server.go
@@ -273,12 +273,25 @@ func NewLlamaServer(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, modelPath st
 
 	gpuLibs := ml.LibraryPaths(gpus)
 	status := NewStatusWriter(os.Stderr)
+	runnerEnvs := ml.GetVisibleDevicesEnv(gpus, false)
+	// When OLLAMA_MOE_PINNED is enabled, the ggml CUDA backend's internal
+	// cudaHostRegister wrapper checks getenv("GGML_CUDA_REGISTER_HOST") from
+	// the DLL's own CRT instance. Go's os.Setenv and CGo _putenv_s both update
+	// different CRT copies and are invisible to the DLL. The only reliable way
+	// to set a variable for all CRT instances in a process is to inject it into
+	// the child process env block before launch, which all CRTs read at init.
+	if envconfig.MoePinned() && envconfig.MoeGpuLayers() != 0 {
+		if runnerEnvs == nil {
+			runnerEnvs = map[string]string{}
+		}
+		runnerEnvs["GGML_CUDA_REGISTER_HOST"] = "1"
+	}
 	cmd, port, err := StartRunner(
 		tok != nil,
 		modelPath,
 		gpuLibs,
 		status,
-		ml.GetDevicesEnv(gpus, false),
+		runnerEnvs,
 	)
 
 	s := llmServer{

--- a/llm/server.go
+++ b/llm/server.go
@@ -513,6 +513,9 @@ type LoadRequest struct {
 	KvCacheType    string
 	NumThreads     int
 	GPULayers      ml.GPULayersList
+	// MoEGPULayers is the subset of GPULayers where MoE expert weights
+	// are also resident on GPU. Nil means no MoE split.
+	MoEGPULayers   ml.GPULayersList
 	MultiUserCache bool
 
 	// Legacy fields - not used with the Ollama engine
@@ -652,7 +655,7 @@ func (s *llamaServer) Load(ctx context.Context, systemInfo ml.SystemInfo, system
 		prevGPULayers := gpuLayers
 
 		var err error
-		gpuLayers, err = s.createLayout(systemInfo, gpus, s.mem, requireFull, 0)
+		gpuLayers, _, err = s.createLayout(systemInfo, gpus, s.mem, requireFull, 0)
 		if err != nil {
 			return nil, err
 		}
@@ -794,7 +797,7 @@ func (s *ollamaServer) Load(ctx context.Context, systemInfo ml.SystemInfo, gpus 
 	pastAllocations := make(map[uint64]struct{})
 	var backoff float32
 
-	gpuLayers, err := s.createLayout(systemInfo, gpus, s.mem, requireFull, backoff)
+	gpuLayers, denseGPULayers, err := s.createLayout(systemInfo, gpus, s.mem, requireFull, backoff)
 	if err != nil {
 		return nil, err
 	}
@@ -807,7 +810,13 @@ nextOperation:
 	for operation := LoadOperationFit; operation < LoadOperationCommit; operation++ {
 	nextLoad:
 		for {
-			s.loadRequest.GPULayers = gpuLayers
+			if len(denseGPULayers) > 0 {
+				s.loadRequest.GPULayers = denseGPULayers
+				s.loadRequest.MoEGPULayers = gpuLayers
+			} else {
+				s.loadRequest.GPULayers = gpuLayers
+				s.loadRequest.MoEGPULayers = nil
+			}
 			resp, err := s.initModel(ctx, s.loadRequest, operation)
 			if err != nil {
 				return nil, err
@@ -820,7 +829,7 @@ nextOperation:
 			s.mem = &resp.Memory
 
 			for {
-				newGPULayers, err := s.createLayout(systemInfo, gpus, s.mem, requireFull, backoff)
+				newGPULayers, newDenseGPULayers, err := s.createLayout(systemInfo, gpus, s.mem, requireFull, backoff)
 				if err != nil {
 					return nil, err
 				}
@@ -833,6 +842,7 @@ nextOperation:
 				// trying to see if we can do better.
 				if _, ok := pastAllocations[newGPULayers.Hash()]; !ok && newGPULayers.Sum() <= gpuLayers.Sum() {
 					gpuLayers = newGPULayers
+					denseGPULayers = newDenseGPULayers
 					continue nextLoad
 				}
 
@@ -853,14 +863,20 @@ nextOperation:
 						slog.Debug("exploring intermediate layers", "layer", i)
 
 						s.options.NumGPU = i
-						newGPULayers, err = s.createLayout(systemInfo, gpus, s.mem, requireFull, backoff)
+						newGPULayers, newDenseGPULayers, err = s.createLayout(systemInfo, gpus, s.mem, requireFull, backoff)
 						s.options.NumGPU = -1
 						if err != nil {
 							return nil, err
 						}
 						slog.Debug("new layout created", "layers", newGPULayers)
 
-						s.loadRequest.GPULayers = newGPULayers
+						if len(newDenseGPULayers) > 0 {
+							s.loadRequest.GPULayers = newDenseGPULayers
+							s.loadRequest.MoEGPULayers = newGPULayers
+						} else {
+							s.loadRequest.GPULayers = newGPULayers
+							s.loadRequest.MoEGPULayers = nil
+						}
 						resp, err = s.initModel(ctx, s.loadRequest, operation)
 						if err != nil {
 							return nil, err
@@ -870,7 +886,7 @@ nextOperation:
 						slog.Debug("memory", "success", resp.Success, "required", resp.Memory)
 
 						if resp.Success {
-							verifyGPULayers, err := s.createLayout(systemInfo, gpus, &resp.Memory, requireFull, backoff)
+							verifyGPULayers, _, err := s.createLayout(systemInfo, gpus, &resp.Memory, requireFull, backoff)
 							if err != nil {
 								return nil, err
 							}
@@ -879,6 +895,7 @@ nextOperation:
 
 							if newGPULayers.Sum() <= verifyGPULayers.Sum() {
 								gpuLayers = newGPULayers
+								denseGPULayers = newDenseGPULayers
 
 								// Since we are going backwards (increasing the number of layers), ensure that
 								// we can come back down if needed
@@ -916,7 +933,13 @@ nextOperation:
 		}
 	}
 
-	s.loadRequest.GPULayers = gpuLayers
+	if len(denseGPULayers) > 0 {
+		s.loadRequest.GPULayers = denseGPULayers
+		s.loadRequest.MoEGPULayers = gpuLayers
+	} else {
+		s.loadRequest.GPULayers = gpuLayers
+		s.loadRequest.MoEGPULayers = nil
+	}
 	resp, err := s.initModel(ctx, s.loadRequest, LoadOperationCommit)
 	if err != nil {
 		return nil, err
@@ -956,26 +979,33 @@ func uniqueDeviceIDs(gpuLayers ml.GPULayersList) []ml.DeviceID {
 // - Calculating how much space each GPU has available for layers, based on free memory and space occupied by the graph
 // - Assigning layers
 // - Ensuring that we don't exceed limits, such as requirements about partial offloading or system memory
-func (s *llmServer) createLayout(systemInfo ml.SystemInfo, systemGPUs []ml.DeviceInfo, memory *ml.BackendMemory, requireFull bool, backoff float32) (ml.GPULayersList, error) {
+func (s *llmServer) createLayout(systemInfo ml.SystemInfo, systemGPUs []ml.DeviceInfo, memory *ml.BackendMemory, requireFull bool, backoff float32) (ml.GPULayersList, ml.GPULayersList, error) {
 	if memory == nil {
 		memory = &ml.BackendMemory{CPU: ml.DeviceMemory{
-			Weights: make([]uint64, s.totalLayers),
-			Cache:   make([]uint64, s.totalLayers),
+			Weights:    make([]uint64, s.totalLayers),
+			MoEWeights: make([]uint64, s.totalLayers),
+			Cache:      make([]uint64, s.totalLayers),
 		}}
 	}
-	gpuLayers, layers := s.buildLayout(systemGPUs, memory, requireFull, backoff)
-	err := s.verifyLayout(systemInfo, systemGPUs, memory, requireFull, gpuLayers, layers)
+	gpuLayers, denseGPULayers, layers := s.buildLayout(systemGPUs, memory, requireFull, backoff)
+	err := s.verifyLayout(systemInfo, systemGPUs, memory, requireFull, gpuLayers, denseGPULayers, layers)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return gpuLayers, nil
+	return gpuLayers, denseGPULayers, nil
 }
 
-func (s *llmServer) buildLayout(systemGPUs []ml.DeviceInfo, memory *ml.BackendMemory, requireFull bool, backoff float32) (ml.GPULayersList, []uint64) {
+// buildLayout computes layer assignments for GPU offload.
+// Returns:
+//
+//	gpuLayers      - layers used for iteration convergence (MoE-on-GPU count if MoE split active)
+//	denseGPULayers - layers with dense weights on GPU (all layers when MoE split active); nil otherwise
+//	layers         - total per-layer memory sizes
+func (s *llmServer) buildLayout(systemGPUs []ml.DeviceInfo, memory *ml.BackendMemory, requireFull bool, backoff float32) (gpuLayers ml.GPULayersList, denseGPULayers ml.GPULayersList, layers []uint64) {
 	gpus := append(make([]ml.DeviceInfo, 0, len(systemGPUs)), systemGPUs...)
 	sort.Sort(sort.Reverse(ml.ByFreeMemory(gpus)))
 
-	layers := make([]uint64, len(memory.CPU.Weights))
+	layers = make([]uint64, len(memory.CPU.Weights))
 	for i := range layers {
 		for j := range memory.GPUs {
 			layers[i] += memory.GPUs[j].Weights[i]
@@ -986,7 +1016,170 @@ func (s *llmServer) buildLayout(systemGPUs []ml.DeviceInfo, memory *ml.BackendMe
 		logutil.Trace("layer to assign", "layer", i, "size", format.HumanBytes2(layers[i]))
 	}
 
-	gpuLayers := ml.GPULayersList{}
+	// ── MoE split logic ───────────────────────────────────────────────────────
+	// Compute per-layer MoE sizes (sum across all devices, since probe puts weights
+	// on one device but we need the logical per-layer total).
+	moeSize := make([]uint64, len(layers))
+	for i := range moeSize {
+		for j := range memory.GPUs {
+			if memory.GPUs[j].MoEWeights != nil {
+				moeSize[i] += memory.GPUs[j].MoEWeights[i]
+			}
+		}
+		if memory.CPU.MoEWeights != nil {
+			moeSize[i] += memory.CPU.MoEWeights[i]
+		}
+	}
+
+	isMoEModel := slices.ContainsFunc(moeSize, func(s uint64) bool { return s > 0 })
+
+	if isMoEModel && envconfig.MoeGpuLayers() != 0 {
+		// dense size per layer = total layer size - MoE expert weights
+		denseSize := make([]uint64, len(layers))
+		for i := range denseSize {
+			denseSize[i] = layers[i] - moeSize[i]
+		}
+		var totalDenseOverhead uint64
+		for _, d := range denseSize {
+			totalDenseOverhead += d
+		}
+
+		// Estimate available VRAM (single-GPU, simple single-device budget).
+		var availableVRAM uint64
+		if len(gpus) > 0 {
+			g := gpus[0]
+			// Find matching GPU memory entry for graph overhead
+			var graphOverhead uint64
+			for _, gm := range memory.GPUs {
+				if gm.DeviceID == g.DeviceID {
+					graphOverhead = gm.Graph
+					break
+				}
+			}
+			reserved := uint64(float32(g.FreeMemory)*backoff) + g.MinimumMemory() + envconfig.GpuOverhead() + graphOverhead
+			if g.FreeMemory > reserved {
+				availableVRAM = g.FreeMemory - reserved
+			}
+		}
+
+		if totalDenseOverhead > availableVRAM {
+			slog.Warn("moe split: dense weights exceed available VRAM, falling back to standard layout",
+				"dense_total", format.HumanBytes2(totalDenseOverhead),
+				"available_vram", format.HumanBytes2(availableVRAM))
+			// Fall through to standard assignLayers below
+		} else {
+			slog.Info("moe split: dense weights fit, activating split",
+				"dense_total", format.HumanBytes2(totalDenseOverhead),
+				"vram_for_moe", format.HumanBytes2(availableVRAM-totalDenseOverhead))
+
+			moeGPUCount := envconfig.MoeGpuLayers()
+			source := "auto"
+			if moeGPUCount >= 0 {
+				if moeGPUCount > len(moeSize) {
+					slog.Warn("moe split: OLLAMA_MOE_GPU_LAYERS exceeds total layers, clamped",
+						"requested", moeGPUCount, "clamped", len(moeSize))
+					moeGPUCount = len(moeSize)
+				}
+				source = "user-override"
+			} else {
+				remainingVRAM := availableVRAM - totalDenseOverhead
+				moeGPUCount = 0
+				for i := range moeSize {
+					if moeSize[i] > remainingVRAM {
+						break
+					}
+					remainingVRAM -= moeSize[i]
+					moeGPUCount++
+				}
+			}
+
+			slog.Info("moe split: layer budget",
+				"moe_gpu_layers", moeGPUCount,
+				"moe_cpu_layers", len(moeSize)-moeGPUCount,
+				"cfg", source)
+
+			for i := range layers {
+				loc := "cpu"
+				if i < moeGPUCount {
+					loc = "gpu"
+				}
+				slog.Debug("moe split: layer layout",
+					"layer", i,
+					"dense_size", format.HumanBytes2(denseSize[i]),
+					"moe_size", format.HumanBytes2(moeSize[i]),
+					"moe_loc", loc)
+			}
+
+			// Build adjusted layer sizes (MoE-only cost) and adjusted GPU free memory
+			adjustedLayers := make([]uint64, len(layers))
+			for i := range adjustedLayers {
+				adjustedLayers[i] = moeSize[i]
+				for j := range memory.GPUs {
+					adjustedLayers[i] += memory.GPUs[j].Cache[i]
+				}
+				adjustedLayers[i] += memory.CPU.Cache[i]
+			}
+
+			adjustedGPUs := make([]ml.DeviceInfo, len(gpus))
+			copy(adjustedGPUs, gpus)
+			for i := range adjustedGPUs {
+				// Apply same overhead formula as availableVRAM estimate: backoff + fixed overheads
+				var graphOverhead uint64
+				for _, gm := range memory.GPUs {
+					if gm.DeviceID == adjustedGPUs[i].DeviceID {
+						graphOverhead = gm.Graph
+						break
+					}
+				}
+				reserved := uint64(float32(adjustedGPUs[i].FreeMemory)*backoff) + adjustedGPUs[i].MinimumMemory() + envconfig.GpuOverhead() + graphOverhead
+				if adjustedGPUs[i].FreeMemory > reserved {
+					adjustedGPUs[i].FreeMemory -= reserved
+				} else {
+					adjustedGPUs[i].FreeMemory = 0
+				}
+				// Then subtract dense overhead (pre-allocated for all layers)
+				if adjustedGPUs[i].FreeMemory > totalDenseOverhead {
+					adjustedGPUs[i].FreeMemory -= totalDenseOverhead
+				} else {
+					adjustedGPUs[i].FreeMemory = 0
+				}
+			}
+
+			gpuLayersMoE := assignLayers(adjustedLayers, adjustedGPUs, requireFull, s.options.NumGPU, 0)
+
+			// Honor user-specified moe GPU layer count exactly.
+			// assignLayers always greedily fills; cap it when the user set a hard limit.
+			if source == "user-override" && gpuLayersMoE.Sum() > moeGPUCount {
+				var all []int
+				for _, g := range gpuLayersMoE {
+					all = append(all, g.Layers...)
+				}
+				slices.Sort(all)
+				gpuLayersMoE = ml.GPULayersList{{DeviceID: gpuLayersMoE[0].DeviceID, Layers: all[:moeGPUCount]}}
+			}
+
+			// denseGPULayers: all layers on the same GPU(s) used by gpuLayersMoE
+			allLayerIndices := make([]int, len(layers))
+			for i := range allLayerIndices {
+				allLayerIndices[i] = i
+			}
+			var denseDeviceID ml.DeviceID
+			if len(gpuLayersMoE) > 0 {
+				denseDeviceID = gpuLayersMoE[0].DeviceID
+			} else if len(gpus) > 0 {
+				denseDeviceID = gpus[len(gpus)-1].DeviceID
+			}
+			denseGPULayers = ml.GPULayersList{{
+				DeviceID: denseDeviceID,
+				Layers:   allLayerIndices,
+			}}
+
+			return gpuLayersMoE, denseGPULayers, layers
+		}
+	}
+	// ── End MoE split logic ──────────────────────────────────────────────────
+
+	gpuLayers = ml.GPULayersList{}
 	for _, gl := range ml.ByLibrary(gpus) {
 		// If a GPU already has a graph allocated on it, then we should continue to use it.
 		// Otherwise, we lose information that we got from previous allocations, which can
@@ -1029,11 +1222,11 @@ func (s *llmServer) buildLayout(systemGPUs []ml.DeviceInfo, memory *ml.BackendMe
 			gpuLayers = libraryGpuLayers
 		}
 	}
-	return gpuLayers, layers
+	return gpuLayers, nil, layers
 }
 
 // verifyLayout ensures that we don't exceed limits, such as requirements about partial offloading or system memory
-func (s *llmServer) verifyLayout(systemInfo ml.SystemInfo, systemGPUs []ml.DeviceInfo, memory *ml.BackendMemory, requireFull bool, gpuLayers ml.GPULayersList, layers []uint64) error {
+func (s *llmServer) verifyLayout(systemInfo ml.SystemInfo, systemGPUs []ml.DeviceInfo, memory *ml.BackendMemory, requireFull bool, gpuLayers ml.GPULayersList, denseGPULayers ml.GPULayersList, layers []uint64) error {
 	// These sizes will only increase as we go through additional iterations and get additional information.
 	cpuSize := memory.InputWeights + memory.CPU.Graph
 	var vramSize uint64
@@ -1060,8 +1253,13 @@ nextLayer:
 	}
 
 	if requireFull {
-		if len(systemGPUs) > 0 && gpuLayers.Sum() < len(layers) && (s.options.NumGPU < 0 || gpuLayers.Sum() < s.options.NumGPU) {
-			slog.Info("model requires more gpu memory than is currently available, evicting a model to make space", "loaded layers", gpuLayers.Sum())
+		// When MoE split is active, use denseGPULayers (all layers) for the full-load check
+		checkLayers := gpuLayers
+		if len(denseGPULayers) > 0 {
+			checkLayers = denseGPULayers
+		}
+		if len(systemGPUs) > 0 && checkLayers.Sum() < len(layers) && (s.options.NumGPU < 0 || checkLayers.Sum() < s.options.NumGPU) {
+			slog.Info("model requires more gpu memory than is currently available, evicting a model to make space", "loaded layers", checkLayers.Sum())
 			return ErrLoadRequiredFull
 		}
 

--- a/llm/server.go
+++ b/llm/server.go
@@ -1058,18 +1058,25 @@ func (s *llmServer) buildLayout(systemGPUs []ml.DeviceInfo, memory *ml.BackendMe
 			moeSize[i] += memory.CPU.MoEWeights[i]
 		}
 	}
+	cacheSize := make([]uint64, len(layers))
+	for i := range cacheSize {
+		for j := range memory.GPUs {
+			cacheSize[i] += memory.GPUs[j].Cache[i]
+		}
+		cacheSize[i] += memory.CPU.Cache[i]
+	}
 
 	isMoEModel := slices.ContainsFunc(moeSize, func(s uint64) bool { return s > 0 })
 
 	if isMoEModel && envconfig.MoeGpuLayers() != 0 {
-		// dense size per layer = total layer size - MoE expert weights
+		// Dense/cache is the baseline reservation; MoE expert weights are assigned separately.
 		denseSize := make([]uint64, len(layers))
 		for i := range denseSize {
-			denseSize[i] = layers[i] - moeSize[i]
+			denseSize[i] = layers[i] - cacheSize[i] - moeSize[i]
 		}
 		var totalDenseOverhead uint64
-		for _, d := range denseSize {
-			totalDenseOverhead += d
+		for i, d := range denseSize {
+			totalDenseOverhead += d + cacheSize[i]
 		}
 
 		// Estimate available VRAM (single-GPU, simple single-device budget).
@@ -1091,13 +1098,13 @@ func (s *llmServer) buildLayout(systemGPUs []ml.DeviceInfo, memory *ml.BackendMe
 		}
 
 		if totalDenseOverhead > availableVRAM {
-			slog.Warn("moe split: dense weights exceed available VRAM, falling back to standard layout",
-				"dense_total", format.HumanBytes2(totalDenseOverhead),
+			slog.Warn("moe split: dense weights and cache exceed available VRAM, falling back to standard layout",
+				"dense_cache_total", format.HumanBytes2(totalDenseOverhead),
 				"available_vram", format.HumanBytes2(availableVRAM))
 			// Fall through to standard assignLayers below
 		} else {
-			slog.Info("moe split: dense weights fit, activating split",
-				"dense_total", format.HumanBytes2(totalDenseOverhead),
+			slog.Info("moe split: dense weights and cache fit, activating split",
+				"dense_cache_total", format.HumanBytes2(totalDenseOverhead),
 				"vram_for_moe", format.HumanBytes2(availableVRAM-totalDenseOverhead))
 
 			moeGPUCount := envconfig.MoeGpuLayers()
@@ -1134,19 +1141,14 @@ func (s *llmServer) buildLayout(systemGPUs []ml.DeviceInfo, memory *ml.BackendMe
 				slog.Debug("moe split: layer layout",
 					"layer", i,
 					"dense_size", format.HumanBytes2(denseSize[i]),
+					"cache_size", format.HumanBytes2(cacheSize[i]),
 					"moe_size", format.HumanBytes2(moeSize[i]),
 					"moe_loc", loc)
 			}
 
 			// Build adjusted layer sizes (MoE-only cost) and adjusted GPU free memory
 			adjustedLayers := make([]uint64, len(layers))
-			for i := range adjustedLayers {
-				adjustedLayers[i] = moeSize[i]
-				for j := range memory.GPUs {
-					adjustedLayers[i] += memory.GPUs[j].Cache[i]
-				}
-				adjustedLayers[i] += memory.CPU.Cache[i]
-			}
+			copy(adjustedLayers, moeSize)
 
 			adjustedGPUs := make([]ml.DeviceInfo, len(gpus))
 			copy(adjustedGPUs, gpus)

--- a/llm/server_test.go
+++ b/llm/server_test.go
@@ -220,6 +220,55 @@ func TestLLMServerFitGPU(t *testing.T) {
 	}
 }
 
+func TestLLMServerMoESplitDenseFallbackUsesLargestGPU(t *testing.T) {
+	t.Setenv("OLLAMA_MOE_GPU_LAYERS", "-1")
+
+	minMemory := uint64(457 * format.MebiByte)
+	gpus := []ml.DeviceInfo{
+		{DeviceID: ml.DeviceID{ID: "gpu-small"}, FreeMemory: minMemory + 320*format.MebiByte},
+		{DeviceID: ml.DeviceID{ID: "gpu-large"}, FreeMemory: minMemory + 360*format.MebiByte},
+	}
+
+	s := &ollamaServer{
+		llmServer: llmServer{
+			totalLayers: 2,
+			options: api.Options{
+				Runner: api.Runner{NumGPU: -1},
+			},
+		},
+	}
+
+	s.mem = &ml.BackendMemory{CPU: ml.DeviceMemory{
+		Weights:    []uint64{250 * format.MebiByte, 200 * format.MebiByte},
+		MoEWeights: []uint64{50 * format.MebiByte, 50 * format.MebiByte},
+		Cache:      make([]uint64, s.totalLayers),
+	}, GPUs: make([]ml.DeviceMemory, len(gpus))}
+
+	for i := range s.mem.GPUs {
+		s.mem.GPUs[i].DeviceID = gpus[i].DeviceID
+		s.mem.GPUs[i].Weights = make([]uint64, s.totalLayers)
+		s.mem.GPUs[i].MoEWeights = make([]uint64, s.totalLayers)
+		s.mem.GPUs[i].Cache = make([]uint64, s.totalLayers)
+	}
+
+	systemInfo := ml.SystemInfo{
+		TotalMemory: 4 * format.GibiByte,
+		FreeMemory:  2 * format.GibiByte,
+		FreeSwap:    2 * format.GibiByte,
+	}
+
+	gpuLayers, denseGPULayers, err := s.createLayout(systemInfo, gpus, s.mem, false, 0)
+	if err != nil {
+		t.Fatalf("createLayout returned error: %v", err)
+	}
+	if gpuLayers.Sum() != 0 {
+		t.Fatalf("MoE GPU layers = %v, want none", gpuLayers)
+	}
+	if len(denseGPULayers) != 1 || denseGPULayers[0].DeviceID.ID != "gpu-large" {
+		t.Fatalf("dense GPU layers = %v, want gpu-large", denseGPULayers)
+	}
+}
+
 func TestLLMServerCompletionFormat(t *testing.T) {
 	// This test was written to fix an already deployed issue. It is a bit
 	// of a mess, and but it's good enough, until we can refactoring the

--- a/llm/server_test.go
+++ b/llm/server_test.go
@@ -209,7 +209,7 @@ func TestLLMServerFitGPU(t *testing.T) {
 				s.mem.GPUs[i].Cache = make([]uint64, s.totalLayers)
 			}
 
-			gpuLayers, err := s.createLayout(systemInfo, tt.gpus, s.mem, tt.requireFull, 0)
+			gpuLayers, _, err := s.createLayout(systemInfo, tt.gpus, s.mem, tt.requireFull, 0)
 			if err != tt.expectedErr {
 				t.Fatalf("fitGPU returned error: %v", err)
 			}

--- a/llm/server_test.go
+++ b/llm/server_test.go
@@ -302,6 +302,46 @@ func TestLLMServerVerifyLayoutMoESplitCPUMemory(t *testing.T) {
 	}
 }
 
+func TestLLMServerMoESplitBudgetExcludesCacheFromMoELayers(t *testing.T) {
+	t.Setenv("OLLAMA_MOE_GPU_LAYERS", "-1")
+	t.Setenv("OLLAMA_GPU_OVERHEAD", "0")
+
+	gpuID := ml.DeviceID{ID: "gpu0"}
+	minMemory := uint64(457 * format.MebiByte)
+	denseSize := uint64(100 * format.MebiByte)
+	moeSize := uint64(50 * format.MebiByte)
+	cacheSize := uint64(40 * format.MebiByte)
+	denseCacheTotal := 2 * (denseSize + cacheSize)
+	gpus := []ml.DeviceInfo{{DeviceID: gpuID, FreeMemory: minMemory + denseCacheTotal + moeSize}}
+
+	s := &ollamaServer{
+		llmServer: llmServer{
+			totalLayers: 2,
+			options: api.Options{
+				Runner: api.Runner{NumGPU: -1},
+			},
+		},
+	}
+	s.mem = &ml.BackendMemory{CPU: ml.DeviceMemory{
+		Weights:    []uint64{denseSize + moeSize, denseSize + moeSize},
+		MoEWeights: []uint64{moeSize, moeSize},
+		Cache:      []uint64{cacheSize, cacheSize},
+	}, GPUs: []ml.DeviceMemory{{
+		DeviceID:   gpuID,
+		Weights:    make([]uint64, s.totalLayers),
+		MoEWeights: make([]uint64, s.totalLayers),
+		Cache:      make([]uint64, s.totalLayers),
+	}}}
+
+	gpuLayers, denseGPULayers, _ := s.buildLayout(gpus, s.mem, false, 0)
+	if gpuLayers.Sum() != 1 {
+		t.Fatalf("MoE GPU layers = %v, want one layer", gpuLayers)
+	}
+	if len(denseGPULayers) != 1 || denseGPULayers[0].DeviceID != gpuID || denseGPULayers.Sum() != 2 {
+		t.Fatalf("dense GPU layers = %v, want all layers on %v", denseGPULayers, gpuID)
+	}
+}
+
 func TestLLMServerCompletionFormat(t *testing.T) {
 	// This test was written to fix an already deployed issue. It is a bit
 	// of a mess, and but it's good enough, until we can refactoring the

--- a/llm/server_test.go
+++ b/llm/server_test.go
@@ -269,6 +269,39 @@ func TestLLMServerMoESplitDenseFallbackUsesLargestGPU(t *testing.T) {
 	}
 }
 
+func TestLLMServerVerifyLayoutMoESplitCPUMemory(t *testing.T) {
+	gpuID := ml.DeviceID{ID: "gpu0"}
+	gpus := []ml.DeviceInfo{{DeviceID: gpuID}}
+	layers := []uint64{1056 * format.MebiByte, 1056 * format.MebiByte}
+	memory := &ml.BackendMemory{
+		CPU: ml.DeviceMemory{
+			Weights:    []uint64{1024 * format.MebiByte, 1024 * format.MebiByte},
+			MoEWeights: []uint64{64 * format.MebiByte, 64 * format.MebiByte},
+			Cache:      []uint64{32 * format.MebiByte, 32 * format.MebiByte},
+		},
+		GPUs: []ml.DeviceMemory{{
+			DeviceID:   gpuID,
+			Weights:    make([]uint64, len(layers)),
+			MoEWeights: make([]uint64, len(layers)),
+			Cache:      make([]uint64, len(layers)),
+		}},
+	}
+	systemInfo := ml.SystemInfo{
+		TotalMemory: 4 * format.GibiByte,
+		FreeMemory:  200 * format.MebiByte,
+	}
+	s := &llmServer{}
+	denseGPULayers := ml.GPULayersList{{DeviceID: gpuID, Layers: []int{0, 1}}}
+
+	if err := s.verifyLayout(systemInfo, gpus, memory, false, nil, denseGPULayers, layers); err != nil {
+		t.Fatalf("verifyLayout with MoE split returned error: %v", err)
+	}
+
+	if err := s.verifyLayout(systemInfo, gpus, memory, false, nil, nil, layers); err == nil {
+		t.Fatal("verifyLayout without MoE split succeeded, want system memory error")
+	}
+}
+
 func TestLLMServerCompletionFormat(t *testing.T) {
 	// This test was written to fix an already deployed issue. It is a bit
 	// of a mess, and but it's good enough, until we can refactoring the

--- a/llm/server_test.go
+++ b/llm/server_test.go
@@ -220,7 +220,7 @@ func TestLLMServerFitGPU(t *testing.T) {
 	}
 }
 
-func TestLLMServerMoESplitDenseFallbackUsesLargestGPU(t *testing.T) {
+func TestLLMServerMoESplitRejectsMultipleGPUs(t *testing.T) {
 	t.Setenv("OLLAMA_MOE_GPU_LAYERS", "-1")
 
 	minMemory := uint64(457 * format.MebiByte)
@@ -257,15 +257,8 @@ func TestLLMServerMoESplitDenseFallbackUsesLargestGPU(t *testing.T) {
 		FreeSwap:    2 * format.GibiByte,
 	}
 
-	gpuLayers, denseGPULayers, err := s.createLayout(systemInfo, gpus, s.mem, false, 0)
-	if err != nil {
-		t.Fatalf("createLayout returned error: %v", err)
-	}
-	if gpuLayers.Sum() != 0 {
-		t.Fatalf("MoE GPU layers = %v, want none", gpuLayers)
-	}
-	if len(denseGPULayers) != 1 || denseGPULayers[0].DeviceID.ID != "gpu-large" {
-		t.Fatalf("dense GPU layers = %v, want gpu-large", denseGPULayers)
+	if _, _, err := s.createLayout(systemInfo, gpus, s.mem, false, 0); err == nil || !strings.Contains(err.Error(), "supports one GPU") {
+		t.Fatalf("createLayout error = %v, want single-GPU guard", err)
 	}
 }
 
@@ -333,12 +326,340 @@ func TestLLMServerMoESplitBudgetExcludesCacheFromMoELayers(t *testing.T) {
 		Cache:      make([]uint64, s.totalLayers),
 	}}}
 
-	gpuLayers, denseGPULayers, _ := s.buildLayout(gpus, s.mem, false, 0)
+	gpuLayers, denseGPULayers, _, _ := s.buildLayout(gpus, s.mem, false, 0)
 	if gpuLayers.Sum() != 1 {
 		t.Fatalf("MoE GPU layers = %v, want one layer", gpuLayers)
 	}
 	if len(denseGPULayers) != 1 || denseGPULayers[0].DeviceID != gpuID || denseGPULayers.Sum() != 2 {
 		t.Fatalf("dense GPU layers = %v, want all layers on %v", denseGPULayers, gpuID)
+	}
+}
+
+func TestLLMServerMoEPrefetchReserveUsesLargestExpertTensor(t *testing.T) {
+	t.Setenv("OLLAMA_MOE_PINNED", "1")
+	t.Setenv("OLLAMA_MOE_PREFETCH", "1")
+
+	memory := &ml.BackendMemory{
+		CPU: ml.DeviceMemory{
+			MoEMaxTensor: []uint64{20 * format.MebiByte, 4 * format.MebiByte},
+		},
+		GPUs: []ml.DeviceMemory{{
+			MoEMaxTensor: []uint64{8 * format.MebiByte, 12 * format.MebiByte},
+		}},
+	}
+	moeSize := []uint64{96 * format.MebiByte, 96 * format.MebiByte}
+
+	if got, want := moePrefetchReserve(memory, moeSize, []int{0, 1}), uint64(40*format.MebiByte); got != want {
+		t.Fatalf("moePrefetchReserve = %d, want %d", got, want)
+	}
+}
+
+func TestLLMServerMoERunnerEnvOverrides(t *testing.T) {
+	tests := []struct {
+		name           string
+		env            map[string]string
+		wantPinned     bool
+		wantPrefetch   bool
+		wantNoOverride bool
+	}{
+		{
+			name:           "no split leaves env unchanged",
+			env:            map[string]string{"OLLAMA_MOE_PINNED": "1", "OLLAMA_MOE_PREFETCH": "1"},
+			wantNoOverride: true,
+		},
+		{
+			name:         "prefetch false does not enable internal flag",
+			env:          map[string]string{"OLLAMA_MOE_CPU_LAYERS": "1", "OLLAMA_MOE_PINNED": "1", "OLLAMA_MOE_PREFETCH": "false"},
+			wantPinned:   true,
+			wantPrefetch: false,
+		},
+		{
+			name:         "prefetch requires pinned memory",
+			env:          map[string]string{"OLLAMA_MOE_CPU_LAYERS": "1", "OLLAMA_MOE_PREFETCH": "1"},
+			wantPrefetch: false,
+		},
+		{
+			name:         "pinned prefetch split enables internal flag",
+			env:          map[string]string{"OLLAMA_MOE_GPU_LAYERS": "-1", "OLLAMA_MOE_PINNED": "1", "OLLAMA_MOE_PREFETCH": "1"},
+			wantPinned:   true,
+			wantPrefetch: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for key, value := range tt.env {
+				t.Setenv(key, value)
+			}
+
+			env := runnerEnvOverrides(nil)
+			if tt.wantNoOverride {
+				if len(env) != 0 {
+					t.Fatalf("runnerEnvOverrides = %v, want no overrides", env)
+				}
+				return
+			}
+			if _, ok := env["GGML_CUDA_REGISTER_HOST"]; ok != tt.wantPinned {
+				t.Fatalf("GGML_CUDA_REGISTER_HOST present = %v, want %v in %v", ok, tt.wantPinned, env)
+			}
+			if _, ok := env["OLLAMA_MOE_PREFETCH_ENABLED"]; ok != tt.wantPrefetch {
+				t.Fatalf("OLLAMA_MOE_PREFETCH_ENABLED present = %v, want %v in %v", ok, tt.wantPrefetch, env)
+			}
+		})
+	}
+}
+
+func TestLLMServerMoECPULayersMatchesFirstExpertLayers(t *testing.T) {
+	t.Setenv("OLLAMA_MOE_CPU_LAYERS", "2")
+	t.Setenv("OLLAMA_GPU_OVERHEAD", "0")
+
+	gpuID := ml.DeviceID{ID: "gpu0"}
+	minMemory := uint64(457 * format.MebiByte)
+	denseSize := uint64(50 * format.MebiByte)
+	moeSize := uint64(10 * format.MebiByte)
+	cacheSize := uint64(5 * format.MebiByte)
+	gpus := []ml.DeviceInfo{{DeviceID: gpuID, FreeMemory: minMemory + 4*(denseSize+cacheSize) + 2*moeSize}}
+
+	s := &ollamaServer{
+		llmServer: llmServer{
+			totalLayers: 4,
+			options: api.Options{
+				Runner: api.Runner{NumGPU: -1},
+			},
+		},
+	}
+	s.mem = &ml.BackendMemory{CPU: ml.DeviceMemory{
+		Weights:    []uint64{denseSize + moeSize, denseSize, denseSize + moeSize, denseSize + moeSize},
+		MoEWeights: []uint64{moeSize, 0, moeSize, moeSize},
+		Cache:      []uint64{cacheSize, cacheSize, cacheSize, cacheSize},
+	}, GPUs: []ml.DeviceMemory{{
+		DeviceID:   gpuID,
+		Weights:    make([]uint64, s.totalLayers),
+		MoEWeights: make([]uint64, s.totalLayers),
+		Cache:      make([]uint64, s.totalLayers),
+	}}}
+
+	gpuLayers, denseGPULayers, _, err := s.buildLayout(gpus, s.mem, false, 0)
+	if err != nil {
+		t.Fatalf("buildLayout returned error: %v", err)
+	}
+	expectedMoE := ml.GPULayersList{{DeviceID: gpuID, Layers: []int{2, 3}}}
+	if gpuLayers.Hash() != expectedMoE.Hash() {
+		t.Fatalf("MoE GPU layers = %v, want %v", gpuLayers, expectedMoE)
+	}
+	if len(denseGPULayers) != 1 || denseGPULayers[0].DeviceID != gpuID || denseGPULayers.Sum() != 4 {
+		t.Fatalf("dense GPU layers = %v, want all model layers on %v", denseGPULayers, gpuID)
+	}
+}
+
+func TestLLMServerMoEGPULayersMatchesLastExpertLayers(t *testing.T) {
+	t.Setenv("OLLAMA_MOE_GPU_LAYERS", "2")
+	t.Setenv("OLLAMA_GPU_OVERHEAD", "0")
+
+	gpuID := ml.DeviceID{ID: "gpu0"}
+	minMemory := uint64(457 * format.MebiByte)
+	denseSize := uint64(50 * format.MebiByte)
+	moeSize := uint64(10 * format.MebiByte)
+	cacheSize := uint64(5 * format.MebiByte)
+	gpus := []ml.DeviceInfo{{DeviceID: gpuID, FreeMemory: minMemory + 4*(denseSize+cacheSize) + 2*moeSize}}
+
+	s := &ollamaServer{
+		llmServer: llmServer{
+			totalLayers: 4,
+			options: api.Options{
+				Runner: api.Runner{NumGPU: -1},
+			},
+		},
+	}
+	s.mem = &ml.BackendMemory{CPU: ml.DeviceMemory{
+		Weights:    []uint64{denseSize + moeSize, denseSize, denseSize + moeSize, denseSize + moeSize},
+		MoEWeights: []uint64{moeSize, 0, moeSize, moeSize},
+		Cache:      []uint64{cacheSize, cacheSize, cacheSize, cacheSize},
+	}, GPUs: []ml.DeviceMemory{{
+		DeviceID:   gpuID,
+		Weights:    make([]uint64, s.totalLayers),
+		MoEWeights: make([]uint64, s.totalLayers),
+		Cache:      make([]uint64, s.totalLayers),
+	}}}
+
+	gpuLayers, _, _, err := s.buildLayout(gpus, s.mem, false, 0)
+	if err != nil {
+		t.Fatalf("buildLayout returned error: %v", err)
+	}
+	expectedMoE := ml.GPULayersList{{DeviceID: gpuID, Layers: []int{2, 3}}}
+	if gpuLayers.Hash() != expectedMoE.Hash() {
+		t.Fatalf("MoE GPU layers = %v, want %v", gpuLayers, expectedMoE)
+	}
+}
+
+func TestLLMServerMoEForcedSplitFailsWhenItCannotFit(t *testing.T) {
+	t.Setenv("OLLAMA_MOE_CPU_LAYERS", "1")
+	t.Setenv("OLLAMA_GPU_OVERHEAD", "0")
+
+	gpuID := ml.DeviceID{ID: "gpu0"}
+	minMemory := uint64(457 * format.MebiByte)
+	denseSize := uint64(50 * format.MebiByte)
+	moeSize := uint64(10 * format.MebiByte)
+	cacheSize := uint64(5 * format.MebiByte)
+	gpus := []ml.DeviceInfo{{DeviceID: gpuID, FreeMemory: minMemory + 3*(denseSize+cacheSize) + moeSize}}
+
+	s := &ollamaServer{
+		llmServer: llmServer{
+			totalLayers: 3,
+			options: api.Options{
+				Runner: api.Runner{NumGPU: -1},
+			},
+		},
+	}
+	s.mem = &ml.BackendMemory{CPU: ml.DeviceMemory{
+		Weights:    []uint64{denseSize + moeSize, denseSize + moeSize, denseSize + moeSize},
+		MoEWeights: []uint64{moeSize, moeSize, moeSize},
+		Cache:      []uint64{cacheSize, cacheSize, cacheSize},
+	}, GPUs: []ml.DeviceMemory{{
+		DeviceID:   gpuID,
+		Weights:    make([]uint64, s.totalLayers),
+		MoEWeights: make([]uint64, s.totalLayers),
+		Cache:      make([]uint64, s.totalLayers),
+	}}}
+
+	if _, _, _, err := s.buildLayout(gpus, s.mem, false, 0); err == nil {
+		t.Fatal("buildLayout succeeded, want forced MoE split allocation error")
+	}
+}
+
+func TestLLMServerMoESplitRejectsConflictingOverrides(t *testing.T) {
+	t.Setenv("OLLAMA_MOE_CPU_LAYERS", "1")
+	t.Setenv("OLLAMA_MOE_GPU_LAYERS", "1")
+
+	_, _, err := (&llmServer{totalLayers: 1}).createLayout(ml.SystemInfo{}, nil, &ml.BackendMemory{
+		CPU: ml.DeviceMemory{
+			Weights:    []uint64{1},
+			MoEWeights: []uint64{1},
+			Cache:      []uint64{0},
+		},
+	}, false, 0)
+	if err == nil {
+		t.Fatal("createLayout succeeded, want conflicting MoE override error")
+	}
+}
+
+func TestLLMServerMoESplitRejectsInvalidNegativeGPULayers(t *testing.T) {
+	t.Setenv("OLLAMA_MOE_GPU_LAYERS", "-2")
+
+	_, _, err := (&llmServer{totalLayers: 1}).createLayout(ml.SystemInfo{}, nil, &ml.BackendMemory{
+		CPU: ml.DeviceMemory{
+			Weights:    []uint64{1},
+			MoEWeights: []uint64{1},
+			Cache:      []uint64{0},
+		},
+	}, false, 0)
+	if err == nil {
+		t.Fatal("createLayout succeeded, want invalid GPU override error")
+	}
+}
+
+func TestLLMServerMoESplitRejectsOutOfRangeOverrides(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		want string
+	}{
+		{
+			name: "gpu layers exceed expert layers",
+			env:  map[string]string{"OLLAMA_MOE_GPU_LAYERS": "3"},
+			want: "exceeds MoE expert layer count",
+		},
+		{
+			name: "cpu layers exceed model layers",
+			env:  map[string]string{"OLLAMA_MOE_CPU_LAYERS": "3"},
+			want: "exceeds model layer count",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for key, value := range tt.env {
+				t.Setenv(key, value)
+			}
+
+			_, _, err := (&llmServer{totalLayers: 2}).createLayout(ml.SystemInfo{}, nil, &ml.BackendMemory{
+				CPU: ml.DeviceMemory{
+					Weights:    []uint64{1, 1},
+					MoEWeights: []uint64{1, 1},
+					Cache:      []uint64{0, 0},
+				},
+			}, false, 0)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("createLayout error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestLLMServerMoEForcedSplitFailsWhenNoExpertsDetected(t *testing.T) {
+	t.Setenv("OLLAMA_MOE_GPU_LAYERS", "-1")
+
+	_, _, err := (&llmServer{totalLayers: 1}).createLayout(ml.SystemInfo{}, nil, &ml.BackendMemory{
+		CPU: ml.DeviceMemory{
+			Weights: []uint64{1},
+			Cache:   []uint64{0},
+		},
+	}, false, 0)
+	if err == nil || !strings.Contains(err.Error(), "no MoE expert tensors were detected") {
+		t.Fatalf("createLayout error = %v, want missing MoE tensor error", err)
+	}
+}
+
+func TestLLMServerMoEForcedSplitFailsWithoutDetectedExperts(t *testing.T) {
+	t.Setenv("OLLAMA_MOE_CPU_LAYERS", "1")
+
+	_, _, err := (&llmServer{totalLayers: 1}).createLayout(ml.SystemInfo{}, nil, &ml.BackendMemory{
+		CPU: ml.DeviceMemory{
+			Weights:    []uint64{1},
+			MoEWeights: []uint64{0},
+			Cache:      []uint64{0},
+		},
+	}, false, 0)
+	if err == nil {
+		t.Fatal("createLayout succeeded, want missing MoE expert tensor error")
+	}
+	if !strings.Contains(err.Error(), "no MoE expert tensors were detected") {
+		t.Fatalf("createLayout error = %v, want missing MoE expert tensor error", err)
+	}
+}
+
+func TestLLMServerMoEForcedSplitFailsWhenDenseCacheCannotFit(t *testing.T) {
+	t.Setenv("OLLAMA_MOE_CPU_LAYERS", "1")
+	t.Setenv("OLLAMA_GPU_OVERHEAD", "0")
+
+	gpuID := ml.DeviceID{ID: "gpu0"}
+	minMemory := uint64(457 * format.MebiByte)
+	denseSize := uint64(100 * format.MebiByte)
+	moeSize := uint64(10 * format.MebiByte)
+	cacheSize := uint64(10 * format.MebiByte)
+	gpus := []ml.DeviceInfo{{DeviceID: gpuID, FreeMemory: minMemory + denseSize + cacheSize}}
+
+	s := &ollamaServer{
+		llmServer: llmServer{
+			totalLayers: 2,
+			options: api.Options{
+				Runner: api.Runner{NumGPU: -1},
+			},
+		},
+	}
+	s.mem = &ml.BackendMemory{CPU: ml.DeviceMemory{
+		Weights:    []uint64{denseSize + moeSize, denseSize + moeSize},
+		MoEWeights: []uint64{moeSize, moeSize},
+		Cache:      []uint64{cacheSize, cacheSize},
+	}, GPUs: []ml.DeviceMemory{{
+		DeviceID:   gpuID,
+		Weights:    make([]uint64, s.totalLayers),
+		MoEWeights: make([]uint64, s.totalLayers),
+		Cache:      make([]uint64, s.totalLayers),
+	}}}
+
+	if _, _, _, err := s.buildLayout(gpus, s.mem, false, 0); err == nil {
+		t.Fatal("buildLayout succeeded, want dense/cache fit error")
 	}
 }
 

--- a/ml/backend.go
+++ b/ml/backend.go
@@ -69,10 +69,14 @@ type BackendParams struct {
 	// GPULayers is the set of layers to offload to GPUs
 	GPULayers GPULayersList
 
+	// MoESplit means dense weights and MoE expert weights can be routed separately.
+	// MoEGPULayers may be empty when all MoE expert weights are CPU-resident.
+	MoESplit bool
+
 	// MoEGPULayers is the subset of GPULayers where MoE expert weights
 	// are also resident on GPU. Layers in GPULayers but not here have
 	// their MoE expert tensors on CPU (copied on demand via op_offload).
-	// Nil means no MoE split is active.
+	// Used only when MoESplit is true.
 	MoEGPULayers GPULayersList
 
 	// FlashAttention indicates that we should use a fused flash attention kernel

--- a/ml/backend.go
+++ b/ml/backend.go
@@ -69,6 +69,12 @@ type BackendParams struct {
 	// GPULayers is the set of layers to offload to GPUs
 	GPULayers GPULayersList
 
+	// MoEGPULayers is the subset of GPULayers where MoE expert weights
+	// are also resident on GPU. Layers in GPULayers but not here have
+	// their MoE expert tensors on CPU (copied on demand via op_offload).
+	// Nil means no MoE split is active.
+	MoEGPULayers GPULayersList
+
 	// FlashAttention indicates that we should use a fused flash attention kernel
 	FlashAttention FlashAttentionType
 }

--- a/ml/backend/ggml/ggml.go
+++ b/ml/backend/ggml/ggml.go
@@ -20,6 +20,7 @@ import (
 	"log/slog"
 	"maps"
 	"os"
+	"regexp"
 	"runtime"
 	"slices"
 	"strconv"
@@ -154,6 +155,15 @@ func New(modelPath string, params ml.BackendParams) (ml.Backend, error) {
 
 	initDevices()
 
+	// moeExpertRE matches MoE expert weight tensors within a block
+	// (the per-layer ffn_{up,down,gate}_exps projections, optionally
+	// suffixed with .weight or prefixed with ch_ for channel-separated
+	// variants).
+	var moeExpertRE = regexp.MustCompile(`\.ffn_(up|down|gate)_(ch_)?exps(\.weight)?$`)
+	isMoEExpertTensor := func(name string) bool {
+		return moeExpertRE.MatchString(name)
+	}
+
 	var requiredMemory ml.BackendMemory
 	btDeviceMemory := make(map[C.ggml_backend_buffer_type_t]*ml.DeviceMemory)
 
@@ -183,6 +193,7 @@ func New(modelPath string, params ml.BackendParams) (ml.Backend, error) {
 	requiredMemory.CPU.ID = C.GoString(props.id)
 	requiredMemory.CPU.Library = C.GoString(props.library)
 	requiredMemory.CPU.Weights = make([]uint64, blocks+1)
+	requiredMemory.CPU.MoEWeights = make([]uint64, blocks+1)
 	requiredMemory.CPU.Cache = make([]uint64, blocks+1)
 
 	// create list of buffer types for each gpu
@@ -202,6 +213,7 @@ func New(modelPath string, params ml.BackendParams) (ml.Backend, error) {
 		requiredMemory.GPUs[i].ID = C.GoString(props.id)
 		requiredMemory.GPUs[i].Library = C.GoString(props.library)
 		requiredMemory.GPUs[i].Weights = make([]uint64, blocks+1)
+		requiredMemory.GPUs[i].MoEWeights = make([]uint64, blocks+1)
 		requiredMemory.GPUs[i].Cache = make([]uint64, blocks+1)
 	}
 
@@ -226,10 +238,56 @@ func New(modelPath string, params ml.BackendParams) (ml.Backend, error) {
 		return cpuDeviceBufferType
 	}
 
+	// assignMoELayer returns the buffer type for MoE expert tensors of a given layer.
+	// Uses params.MoEGPULayers: layers in this list get GPU, others get CPU.
+	assignMoELayer := func(layer int) deviceBufferType {
+		for _, p := range params.MoEGPULayers {
+			for _, l := range p.Layers {
+				if l == layer {
+					for i := range requiredMemory.GPUs {
+						if requiredMemory.GPUs[i].DeviceID == p.DeviceID {
+							return gpuDeviceBufferTypes[i]
+						}
+					}
+					return cpuDeviceBufferType
+				}
+			}
+		}
+
+		return cpuDeviceBufferType
+	}
+
 	// repeating layers are assigned based on their index in reverse order, e.g. i / (block_count + 1)
 	layers := make([]deviceBufferType, blocks)
 	for i := range layers {
 		layers[i] = assignLayer(i)
+	}
+
+	// moeLayers holds the buffer type for MoE expert tensors per layer.
+	// Only populated when MoEGPULayers is non-empty (MoE split active).
+	moeLayers := make([]deviceBufferType, blocks)
+	for i := range moeLayers {
+		moeLayers[i] = assignMoELayer(i)
+	}
+
+	// Log routing summary on formal allocation (AllocMemory=true) when MoE split is active
+	if params.AllocMemory && len(params.MoEGPULayers) > 0 {
+		moeGPUSet := make(map[int]bool)
+		for _, p := range params.MoEGPULayers {
+			for _, l := range p.Layers {
+				moeGPUSet[l] = true
+			}
+		}
+		for i := range layers {
+			moeLocation := "cpu"
+			if moeGPUSet[i] {
+				moeLocation = "gpu"
+			}
+			slog.Info("moe split: tensor routing",
+				"layer", i,
+				"dense", "gpu",
+				"moe", moeLocation)
+		}
 	}
 
 	// outputs are assigned iff allowed by splits and configured number of gpu layers
@@ -291,6 +349,14 @@ func New(modelPath string, params ml.BackendParams) (ml.Backend, error) {
 				requiredMemory.InputWeights += uint64(size)
 			} else {
 				btDeviceMemory[bt].Weights[layer] += uint64(size)
+				if isMoEExpertTensor(t.source.Name) {
+					btDeviceMemory[bt].MoEWeights[layer] += uint64(size)
+					logutil.Trace("moe split: tracked MoE tensor",
+						"name", t.source.Name,
+						"layer", layer,
+						"size", format.HumanBytes2(uint64(size)),
+						"buffer", C.GoString(C.ggml_backend_buft_name(bt)))
+				}
 			}
 
 			//nolint:staticcheck // TODO: check if buffer type supports this tensor
@@ -342,7 +408,12 @@ func New(modelPath string, params ml.BackendParams) (ml.Backend, error) {
 			}
 
 			if layerIndex >= 0 {
-				createTensor(tensor{source: t}, layers[layerIndex].bts, layerIndex)
+				bts := layers[layerIndex].bts
+				if isMoEExpertTensor(t.Name) && len(params.MoEGPULayers) > 0 {
+					// MoE expert tensor: route based on MoEGPULayers (subset of GPULayers)
+					bts = moeLayers[layerIndex].bts
+				}
+				createTensor(tensor{source: t}, bts, layerIndex)
 			} else {
 				// load all other tensors on the cpu
 				createTensor(tensor{source: t}, input.bts, -1)

--- a/ml/backend/ggml/ggml.go
+++ b/ml/backend/ggml/ggml.go
@@ -5,9 +5,54 @@ package ggml
 // #cgo CPPFLAGS: -I${SRCDIR}/ggml/include
 // #include <stdlib.h>
 // #include <stdint.h>
+// #include <stdbool.h>
 // #include "ggml.h"
 // #include "ggml-cpu.h"
 // #include "ggml-backend.h"
+//
+// // moe_pinned_register looks up the cudaHostRegister proc address from the
+// // first CUDA backend registry entry and calls it to pin a CPU memory region.
+// // Returns true on success, false if CUDA is unavailable or registration fails.
+// //
+// // GGML_CUDA_REGISTER_HOST must already be set in the process env block before
+// // this is called. The env var is injected by server.go into the runner child
+// // process at launch time when OLLAMA_MOE_PINNED=1, which ensures all CRT
+// // instances (including ggml-cuda.dll's own CRT) see it at init time.
+// static bool moe_pinned_register(void *ptr, size_t size) {
+//     typedef bool (*register_fn_t)(void *, size_t);
+//     for (int i = 0; i < (int)ggml_backend_dev_count(); i++) {
+//         ggml_backend_dev_t dev = ggml_backend_dev_get(i);
+//         if (ggml_backend_dev_type(dev) != GGML_BACKEND_DEVICE_TYPE_GPU) {
+//             continue;
+//         }
+//         ggml_backend_reg_t reg = ggml_backend_dev_backend_reg(dev);
+//         register_fn_t fn = (register_fn_t)ggml_backend_reg_get_proc_address(
+//             reg, "ggml_backend_register_host_buffer");
+//         if (fn == NULL) {
+//             return false;
+//         }
+//         return fn(ptr, size);
+//     }
+//     return false;
+// }
+//
+// // moe_pinned_unregister looks up the cudaHostUnregister proc address and calls it.
+// static void moe_pinned_unregister(void *ptr) {
+//     typedef void (*unregister_fn_t)(void *);
+//     for (int i = 0; i < (int)ggml_backend_dev_count(); i++) {
+//         ggml_backend_dev_t dev = ggml_backend_dev_get(i);
+//         if (ggml_backend_dev_type(dev) != GGML_BACKEND_DEVICE_TYPE_GPU) {
+//             continue;
+//         }
+//         ggml_backend_reg_t reg = ggml_backend_dev_backend_reg(dev);
+//         unregister_fn_t fn = (unregister_fn_t)ggml_backend_reg_get_proc_address(
+//             reg, "ggml_backend_unregister_host_buffer");
+//         if (fn != NULL) {
+//             fn(ptr);
+//         }
+//         return;
+//     }
+// }
 import "C"
 
 import (
@@ -30,6 +75,7 @@ import (
 	"unicode"
 	"unsafe"
 
+	"github.com/ollama/ollama/envconfig"
 	"github.com/ollama/ollama/format"
 	"github.com/ollama/ollama/fs"
 	fsggml "github.com/ollama/ollama/fs/ggml"
@@ -125,6 +171,11 @@ type Backend struct {
 
 	// weightBuffers are the GGML contexts and buffers for allocating weights
 	weightBuffers map[*C.struct_ggml_context]C.ggml_backend_buffer_t
+
+	// pinnedBuffers holds base pointers of CPU-MoE weight buffers that have been
+	// registered as pinned via cudaHostRegister (when OLLAMA_MOE_PINNED=1).
+	// Must be unregistered before the backing buffers are freed.
+	pinnedBuffers []unsafe.Pointer
 }
 
 var once sync.Once
@@ -270,6 +321,10 @@ func New(modelPath string, params ml.BackendParams) (ml.Backend, error) {
 		moeLayers[i] = assignMoELayer(i)
 	}
 
+	// cpuMoEBufTypes collects buffer types used by CPU-resident MoE expert tensors.
+	// Used after buffer allocation to register them as pinned when OLLAMA_MOE_PINNED=1.
+	cpuMoEBufTypes := make(map[C.ggml_backend_buffer_type_t]struct{})
+
 	// Log routing summary on formal allocation (AllocMemory=true) when MoE split is active
 	if params.AllocMemory && len(params.MoEGPULayers) > 0 {
 		moeGPUSet := make(map[int]bool)
@@ -412,6 +467,11 @@ func New(modelPath string, params ml.BackendParams) (ml.Backend, error) {
 				if isMoEExpertTensor(t.Name) && len(params.MoEGPULayers) > 0 {
 					// MoE expert tensor: route based on MoEGPULayers (subset of GPULayers)
 					bts = moeLayers[layerIndex].bts
+					// Track CPU-resident MoE buffer types for optional pinning.
+					// A layer is CPU-resident when its device matches the CPU device.
+					if moeLayers[layerIndex].d == cpuDeviceBufferType.d {
+						cpuMoEBufTypes[bts[0]] = struct{}{}
+					}
 				}
 				createTensor(tensor{source: t}, bts, layerIndex)
 			} else {
@@ -498,6 +558,36 @@ func New(modelPath string, params ml.BackendParams) (ml.Backend, error) {
 			"size", format.HumanBytes2(uint64(C.ggml_backend_buffer_get_size(bs))))
 	}
 
+	// When OLLAMA_MOE_PINNED=1 and MoE split is active, register CPU-side MoE
+	// weight buffers as pinned (page-locked) so that the CUDA Copy Engine can
+	// DMA directly from mmap memory without CPU-side staging.
+	var pinnedBuffers []unsafe.Pointer
+	if params.AllocMemory && envconfig.MoePinned() && len(params.MoEGPULayers) > 0 {
+		for bt, c := range ctxs {
+			if _, isCPUMoE := cpuMoEBufTypes[bt]; !isCPUMoE {
+				continue
+			}
+			b, ok := bbs[c]
+			if !ok {
+				continue
+			}
+			ptr := unsafe.Pointer(C.ggml_backend_buffer_get_base(b))
+			size := C.size_t(C.ggml_backend_buffer_get_size(b))
+			if bool(C.moe_pinned_register(ptr, size)) {
+				pinnedBuffers = append(pinnedBuffers, ptr)
+				slog.Info("moe pinned: registered CPU-MoE buffer",
+					"size", format.HumanBytes2(uint64(size)))
+			} else {
+				slog.Warn("moe pinned: cudaHostRegister failed, falling back to pageable",
+					"size", format.HumanBytes2(uint64(size)))
+			}
+		}
+		if len(pinnedBuffers) > 0 {
+			slog.Info("moe pinned: registered CPU-MoE weight buffers",
+				"count", len(pinnedBuffers))
+		}
+	}
+
 	return &Backend{
 		modelPath:         modelPath,
 		allocMemory:       params.AllocMemory,
@@ -524,6 +614,7 @@ func New(modelPath string, params ml.BackendParams) (ml.Backend, error) {
 		btDeviceMemory: btDeviceMemory,
 		maxGraphNodes:  maxGraphNodes,
 		weightBuffers:  bbs,
+		pinnedBuffers:  pinnedBuffers,
 	}, nil
 }
 
@@ -534,6 +625,12 @@ func init() {
 func (b *Backend) Close() {
 	if b == nil {
 		return
+	}
+
+	// Unregister pinned CPU-MoE buffers before freeing them.
+	// cudaHostUnregister must be called while the memory is still valid.
+	for _, ptr := range b.pinnedBuffers {
+		C.moe_pinned_unregister(ptr)
 	}
 
 	for ctx, b := range b.weightBuffers {

--- a/ml/backend/ggml/ggml.go
+++ b/ml/backend/ggml/ggml.go
@@ -91,6 +91,25 @@ var (
 	backends           map[C.ggml_backend_dev_t]C.ggml_backend_t
 )
 
+// moeExpertTensorRE matches MoE expert tensors within a block. Channel-separated
+// tensors are named chexps in llama.cpp; ch_exps is accepted for compatibility
+// with existing GGUF variants.
+var moeExpertTensorRE = regexp.MustCompile(`\.ffn_(up|down|gate|gate_up)_(exps|chexps|ch_exps)(\.(weight|bias|scale))?$`)
+
+func isMoEExpertTensor(name string) bool {
+	return moeExpertTensorRE.MatchString(name)
+}
+
+func layerIndexFromTensorName(name string) (int, bool) {
+	fields := strings.FieldsFunc(name, func(r rune) bool { return !unicode.IsNumber(r) })
+	if len(fields) == 0 {
+		return 0, false
+	}
+
+	i, err := strconv.Atoi(fields[0])
+	return i, err == nil
+}
+
 var initDevices = sync.OnceFunc(func() {
 	ggml.OnceLoad()
 
@@ -206,15 +225,6 @@ func New(modelPath string, params ml.BackendParams) (ml.Backend, error) {
 
 	initDevices()
 
-	// moeExpertRE matches MoE expert weight tensors within a block
-	// (the per-layer ffn_{up,down,gate}_exps projections, optionally
-	// suffixed with .weight or prefixed with ch_ for channel-separated
-	// variants).
-	var moeExpertRE = regexp.MustCompile(`\.ffn_(up|down|gate)_(ch_)?exps(\.weight)?$`)
-	isMoEExpertTensor := func(name string) bool {
-		return moeExpertRE.MatchString(name)
-	}
-
 	var requiredMemory ml.BackendMemory
 	btDeviceMemory := make(map[C.ggml_backend_buffer_type_t]*ml.DeviceMemory)
 
@@ -224,6 +234,15 @@ func New(modelPath string, params ml.BackendParams) (ml.Backend, error) {
 	}
 
 	blocks := int(meta.KV().BlockCount())
+	moeExpertTensorCount := 0
+	for _, t := range meta.Tensors().Items() {
+		if isMoEExpertTensor(t.Name) {
+			moeExpertTensorCount++
+		}
+	}
+	if params.MoESplit && moeExpertTensorCount == 0 {
+		return nil, errors.New("moe split requested but no MoE expert tensors were detected")
+	}
 
 	// create list of buffer types for the cpu
 	cpuDeviceBufferType := deviceBufferType{d: C.ggml_backend_dev_by_type(C.GGML_BACKEND_DEVICE_TYPE_CPU)}
@@ -245,6 +264,7 @@ func New(modelPath string, params ml.BackendParams) (ml.Backend, error) {
 	requiredMemory.CPU.Library = C.GoString(props.library)
 	requiredMemory.CPU.Weights = make([]uint64, blocks+1)
 	requiredMemory.CPU.MoEWeights = make([]uint64, blocks+1)
+	requiredMemory.CPU.MoEMaxTensor = make([]uint64, blocks+1)
 	requiredMemory.CPU.Cache = make([]uint64, blocks+1)
 
 	// create list of buffer types for each gpu
@@ -265,6 +285,7 @@ func New(modelPath string, params ml.BackendParams) (ml.Backend, error) {
 		requiredMemory.GPUs[i].Library = C.GoString(props.library)
 		requiredMemory.GPUs[i].Weights = make([]uint64, blocks+1)
 		requiredMemory.GPUs[i].MoEWeights = make([]uint64, blocks+1)
+		requiredMemory.GPUs[i].MoEMaxTensor = make([]uint64, blocks+1)
 		requiredMemory.GPUs[i].Cache = make([]uint64, blocks+1)
 	}
 
@@ -325,7 +346,7 @@ func New(modelPath string, params ml.BackendParams) (ml.Backend, error) {
 	// Used after buffer allocation to register them as pinned when OLLAMA_MOE_PINNED=1.
 	cpuMoEBufTypes := make(map[C.ggml_backend_buffer_type_t]struct{})
 
-	// Log routing summary on formal allocation (AllocMemory=true) when MoE split is active
+	// Keep per-layer routing at debug; large MoE models emit one line per block.
 	if params.AllocMemory && params.MoESplit {
 		moeGPUSet := make(map[int]bool)
 		for _, p := range params.MoEGPULayers {
@@ -338,7 +359,7 @@ func New(modelPath string, params ml.BackendParams) (ml.Backend, error) {
 			if moeGPUSet[i] {
 				moeLocation = "gpu"
 			}
-			slog.Info("moe split: tensor routing",
+			slog.Debug("moe split: tensor routing",
 				"layer", i,
 				"dense", "gpu",
 				"moe", moeLocation)
@@ -406,6 +427,7 @@ func New(modelPath string, params ml.BackendParams) (ml.Backend, error) {
 				btDeviceMemory[bt].Weights[layer] += uint64(size)
 				if isMoEExpertTensor(t.source.Name) {
 					btDeviceMemory[bt].MoEWeights[layer] += uint64(size)
+					btDeviceMemory[bt].MoEMaxTensor[layer] = max(btDeviceMemory[bt].MoEMaxTensor[layer], uint64(size))
 					logutil.Trace("moe split: tracked MoE tensor",
 						"name", t.source.Name,
 						"layer", layer,
@@ -456,10 +478,8 @@ func New(modelPath string, params ml.BackendParams) (ml.Backend, error) {
 			}
 		default:
 			layerIndex := -1
-			if fields := strings.FieldsFunc(t.Name, func(r rune) bool { return !unicode.IsNumber(r) }); len(fields) > 0 {
-				if i, err := strconv.Atoi(fields[0]); err == nil {
-					layerIndex = i
-				}
+			if i, ok := layerIndexFromTensorName(t.Name); ok {
+				layerIndex = i
 			}
 
 			if layerIndex >= 0 {

--- a/ml/backend/ggml/ggml.go
+++ b/ml/backend/ggml/ggml.go
@@ -315,7 +315,7 @@ func New(modelPath string, params ml.BackendParams) (ml.Backend, error) {
 	}
 
 	// moeLayers holds the buffer type for MoE expert tensors per layer.
-	// Only populated when MoEGPULayers is non-empty (MoE split active).
+	// Used when MoESplit is true.
 	moeLayers := make([]deviceBufferType, blocks)
 	for i := range moeLayers {
 		moeLayers[i] = assignMoELayer(i)
@@ -326,7 +326,7 @@ func New(modelPath string, params ml.BackendParams) (ml.Backend, error) {
 	cpuMoEBufTypes := make(map[C.ggml_backend_buffer_type_t]struct{})
 
 	// Log routing summary on formal allocation (AllocMemory=true) when MoE split is active
-	if params.AllocMemory && len(params.MoEGPULayers) > 0 {
+	if params.AllocMemory && params.MoESplit {
 		moeGPUSet := make(map[int]bool)
 		for _, p := range params.MoEGPULayers {
 			for _, l := range p.Layers {
@@ -464,7 +464,7 @@ func New(modelPath string, params ml.BackendParams) (ml.Backend, error) {
 
 			if layerIndex >= 0 {
 				bts := layers[layerIndex].bts
-				if isMoEExpertTensor(t.Name) && len(params.MoEGPULayers) > 0 {
+				if isMoEExpertTensor(t.Name) && params.MoESplit {
 					// MoE expert tensor: route based on MoEGPULayers (subset of GPULayers)
 					bts = moeLayers[layerIndex].bts
 					// Track CPU-resident MoE buffer types for optional pinning.
@@ -562,7 +562,7 @@ func New(modelPath string, params ml.BackendParams) (ml.Backend, error) {
 	// weight buffers as pinned (page-locked) so that the CUDA Copy Engine can
 	// DMA directly from mmap memory without CPU-side staging.
 	var pinnedBuffers []unsafe.Pointer
-	if params.AllocMemory && envconfig.MoePinned() && len(params.MoEGPULayers) > 0 {
+	if params.AllocMemory && envconfig.MoePinned() && params.MoESplit {
 		for bt, c := range ctxs {
 			if _, isCPUMoE := cpuMoEBufTypes[bt]; !isCPUMoE {
 				continue

--- a/ml/backend/ggml/ggml/src/ggml-backend.cpp
+++ b/ml/backend/ggml/ggml/src/ggml-backend.cpp
@@ -27,7 +27,6 @@
 #include <sys/sysctl.h>
 #endif
 
-
 // backend buffer type
 
 const char * ggml_backend_buft_name(ggml_backend_buffer_type_t buft) {
@@ -1477,6 +1476,79 @@ static bool ggml_backend_sched_alloc_splits(ggml_backend_sched_t sched) {
     return true;
 }
 
+// ---------------------------------------------------------------------------
+// MoE prefetch: function pointer types for CUDA helpers via proc address
+// ---------------------------------------------------------------------------
+
+typedef void *(*moe_stream_create_fn_t)();
+typedef void  (*moe_stream_destroy_fn_t)(void *);
+typedef void  (*moe_stream_synchronize_fn_t)(void *);
+
+// Staging buffer helpers (overlap-safe prefetch)
+typedef bool  (*moe_staging_init_fn_t)(void * backend, size_t max_size);
+typedef void  (*moe_staging_destroy_fn_t)(void * backend);
+typedef bool  (*moe_staging_h2d_fn_t)(void * backend, void * prefetch_stream, int slot, struct ggml_tensor * input);
+typedef bool  (*moe_staging_d2d_fn_t)(void * backend, int slot, struct ggml_tensor * input_cpy);
+
+// Selective variant range descriptor — must match the struct in ggml-cuda.cu.
+struct moe_expert_range {
+    int32_t first_id;
+    int32_t last_id;
+};
+typedef bool  (*moe_staging_h2d_ranges_fn_t)(void * backend, void * prefetch_stream, int slot,
+                                             struct ggml_tensor * input,
+                                             const struct moe_expert_range * ranges, int n_ranges);
+typedef bool  (*moe_staging_d2d_ranges_fn_t)(void * backend, int slot,
+                                             struct ggml_tensor * input_cpy,
+                                             const struct moe_expert_range * ranges, int n_ranges);
+
+// Looks up a MoE prefetch proc address via the ggml backend registry.
+// Iterates sched->backends to find the first GPU backend, then calls
+// ggml_backend_reg_get_proc_address on its reg. This is the correct path
+// for proc addresses registered in ggml-cuda.cu via the proc-address table —
+// static helper functions are not exported from the DLL, so OS-level
+// GetProcAddress / dlsym would fail.
+static void * moe_get_proc(ggml_backend_sched_t sched, const char * name) {
+    for (int i = 0; i < sched->n_backends; i++) {
+        ggml_backend_t backend = sched->backends[i];
+        if (!backend) continue;
+        ggml_backend_dev_t dev = ggml_backend_get_device(backend);
+        if (!dev) continue;
+        if (ggml_backend_dev_type(dev) != GGML_BACKEND_DEVICE_TYPE_GPU) continue;
+        ggml_backend_reg_t reg = ggml_backend_dev_backend_reg(dev);
+        if (!reg) continue;
+        void * fn = ggml_backend_reg_get_proc_address(reg, name);
+        if (fn) return fn;
+    }
+    return nullptr;
+}
+
+// Returns true if split_id refers to a CPU-side MoE expert weight split.
+// Detection criterion: the split's first node is GGML_OP_MUL_MAT_ID and its
+// weight input is a host (CPU) buffer marked GGML_BACKEND_BUFFER_USAGE_WEIGHTS.
+// This is identical to the condition used for expert-granular copy above, so
+// no new assumptions are introduced.
+static bool is_moe_cpu_split(ggml_backend_sched_t sched, int split_id) {
+    if (split_id < 0 || split_id >= sched->n_splits) return false;
+    struct ggml_backend_sched_split * split = &sched->splits[split_id];
+    if (split->n_inputs == 0 || split->graph.n_nodes == 0) return false;
+
+    struct ggml_tensor * node = split->graph.nodes[0];
+    if (node->op != GGML_OP_MUL_MAT_ID) return false;
+
+    for (int i = 0; i < split->n_inputs; i++) {
+        struct ggml_tensor * input = split->inputs[i];
+        struct ggml_tensor * input_cpy = tensor_copy(input, split->backend_id, sched->cur_copy);
+        if (node->src[0] == input_cpy &&
+            input->buffer != NULL &&
+            ggml_backend_buffer_get_usage(input->buffer) == GGML_BACKEND_BUFFER_USAGE_WEIGHTS &&
+            ggml_backend_buffer_is_host(input->buffer)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t sched) {
     GGML_ASSERT(sched);
     struct ggml_backend_sched_split * splits = sched->splits;
@@ -1485,10 +1557,121 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
     std::vector<int32_t> ids;
     std::vector<ggml_bitset_t> used_ids;
 
+    // MoE prefetch (staging path): initialize independent prefetch stream
+    // and double staging buffers if OLLAMA_MOE_PREFETCH is set.
+    //
+    // Architecture:
+    //   prefetch stream: H2D pinned_CPU -> staging[slot], record h2d_done[slot]
+    //   main stream:     waitEvent(h2d_done[slot]), D2D staging[slot] -> input_cpy
+    // Double buffering (slot = counter & 1) lets the next H2D start while the
+    // current D2D is still draining, reclaiming copy/compute overlap without
+    // racing on ggml-alloc-aliased input_cpy regions.
+    bool     prefetch_enabled  = false;
+    void *   prefetch_stream   = nullptr;
+    bool     prefetch_pending  = false;
+    int      prefetch_split_id = -1;
+    int      prefetch_slot     = 0;   // which staging buffer was H2D-written
+    int      prefetch_counter  = 0;   // monotonic fire counter; slot = counter & 1
+    ggml_backend_t moe_cuda_backend = nullptr;  // backend that owns the staging buffers
+
+    // Per-slot selective-prefetch range cache. When a fire was issued via
+    // fn_staging_h2d_ranges, the corresponding slot remembers its ranges so the
+    // consume path can dispatch fn_staging_d2d_ranges with the exact same set.
+    // n_ranges == 0 means the slot was H2D'd full-tensor and should D2D full.
+    // The bound is one range per expert; MOE_MAX_EXPERTS_PER_LAYER is a
+    // generous cap (no current model uses more than a few hundred experts
+    // per layer) that keeps the range cache on the stack.
+    static const int MOE_MAX_EXPERTS_PER_LAYER = 1024;
+    struct moe_expert_range prefetch_ranges[2][MOE_MAX_EXPERTS_PER_LAYER] = {};
+    int    prefetch_n_ranges[2] = {0, 0};
+
+    moe_stream_destroy_fn_t     fn_prefetch_stream_destroy = nullptr;
+    moe_stream_synchronize_fn_t fn_prefetch_stream_sync    = nullptr;
+    moe_staging_init_fn_t       fn_staging_init            = nullptr;
+    moe_staging_destroy_fn_t    fn_staging_destroy         = nullptr;
+    moe_staging_h2d_fn_t        fn_staging_h2d             = nullptr;
+    moe_staging_d2d_fn_t        fn_staging_d2d             = nullptr;
+    moe_staging_h2d_ranges_fn_t fn_staging_h2d_ranges      = nullptr;
+    moe_staging_d2d_ranges_fn_t fn_staging_d2d_ranges      = nullptr;
+
+    static bool prefetch_init_logged = false;
+    if (getenv("OLLAMA_MOE_PREFETCH") != nullptr) {
+        auto fn_stream_create = (moe_stream_create_fn_t)moe_get_proc(sched, "ggml_backend_cuda_moe_stream_create");
+        fn_prefetch_stream_destroy = (moe_stream_destroy_fn_t)moe_get_proc(sched, "ggml_backend_cuda_moe_stream_destroy");
+        fn_prefetch_stream_sync    = (moe_stream_synchronize_fn_t)moe_get_proc(sched, "ggml_backend_cuda_moe_stream_synchronize");
+        fn_staging_init        = (moe_staging_init_fn_t)       moe_get_proc(sched, "ggml_backend_cuda_moe_staging_init");
+        fn_staging_destroy     = (moe_staging_destroy_fn_t)    moe_get_proc(sched, "ggml_backend_cuda_moe_staging_destroy");
+        fn_staging_h2d         = (moe_staging_h2d_fn_t)        moe_get_proc(sched, "ggml_backend_cuda_moe_staging_h2d");
+        fn_staging_d2d         = (moe_staging_d2d_fn_t)        moe_get_proc(sched, "ggml_backend_cuda_moe_staging_d2d");
+        fn_staging_h2d_ranges  = (moe_staging_h2d_ranges_fn_t) moe_get_proc(sched, "ggml_backend_cuda_moe_staging_h2d_ranges");
+        fn_staging_d2d_ranges  = (moe_staging_d2d_ranges_fn_t) moe_get_proc(sched, "ggml_backend_cuda_moe_staging_d2d_ranges");
+
+        if (fn_stream_create && fn_staging_init && fn_staging_h2d && fn_staging_d2d) {
+            // Walk splits to find the max MoE weight tensor size and the CUDA backend
+            size_t max_moe_split_size = 0;
+            for (int s = 0; s < sched->n_splits; s++) {
+                if (!is_moe_cpu_split(sched, s)) continue;
+                struct ggml_backend_sched_split * sp = &sched->splits[s];
+                for (int i = 0; i < sp->n_inputs; i++) {
+                    struct ggml_tensor * inp = sp->inputs[i];
+                    if (inp->buffer &&
+                        ggml_backend_buffer_is_host(inp->buffer) &&
+                        ggml_backend_buffer_get_usage(inp->buffer) == GGML_BACKEND_BUFFER_USAGE_WEIGHTS) {
+                        size_t nb = ggml_nbytes(inp);
+                        if (nb > max_moe_split_size) max_moe_split_size = nb;
+                        if (!moe_cuda_backend) moe_cuda_backend = sched->backends[sp->backend_id];
+                    }
+                }
+            }
+            if (max_moe_split_size > 0 && moe_cuda_backend) {
+                prefetch_stream = fn_stream_create();
+                if (prefetch_stream && fn_staging_init((void *)moe_cuda_backend, max_moe_split_size)) {
+                    prefetch_enabled = true;
+                    if (!prefetch_init_logged) {
+                        GGML_LOG_INFO("%s: MoE lookahead prefetch enabled (staging 2x%zu MiB)\n",
+                                      __func__, max_moe_split_size / (1024 * 1024));
+                        prefetch_init_logged = true;
+                    }
+                } else {
+                    if (fn_prefetch_stream_destroy && prefetch_stream) {
+                        fn_prefetch_stream_destroy(prefetch_stream);
+                    }
+                    prefetch_stream = nullptr;
+                    if (!prefetch_init_logged) {
+                        GGML_LOG_WARN("%s: MoE prefetch disabled — staging allocation failed\n", __func__);
+                        prefetch_init_logged = true;
+                    }
+                }
+            } else {
+                if (!prefetch_init_logged) {
+                    GGML_LOG_INFO("%s: MoE prefetch inactive — no CPU-MoE splits in graph\n", __func__);
+                    prefetch_init_logged = true;
+                }
+            }
+        } else {
+            if (!prefetch_init_logged) {
+                GGML_LOG_WARN("%s: MoE prefetch disabled — proc lookup failed\n", __func__);
+                prefetch_init_logged = true;
+            }
+        }
+    }
+
     for (int split_id = 0; split_id < sched->n_splits; split_id++) {
         struct ggml_backend_sched_split * split = &splits[split_id];
         int split_backend_id = split->backend_id;
         ggml_backend_t split_backend = sched->backends[split_backend_id];
+
+        // If this split was prefetched, the weights are already in staging VRAM.
+        // Remember the slot so the input_copy block below can issue a
+        // staging->input_cpy D2D instead of the regular H2D.
+        bool moe_prefetch_hit  = false;
+        int  moe_prefetch_slot = -1;
+        if (prefetch_enabled && prefetch_pending && split_id == prefetch_split_id) {
+            moe_prefetch_hit  = true;
+            moe_prefetch_slot = prefetch_slot;
+            prefetch_pending  = false;
+            GGML_LOG_DEBUG("%s: prefetch hit split=%d slot=%d\n", __func__, split_id, moe_prefetch_slot);
+        }
 
         // copy the input tensors to the split backend
         for (int input_id = 0; input_id < split->n_inputs; input_id++) {
@@ -1524,8 +1707,6 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
                     const int64_t n_expert   = node->op == GGML_OP_MUL_MAT_ID ? input->ne[2] : input->ne[1];
                     const size_t expert_size = node->op == GGML_OP_MUL_MAT_ID ? input->nb[2] : input->nb[1];
 
-                    ggml_backend_synchronize(input_backend);
-
                     // get the ids
                     ggml_tensor * ids_tensor = node->src[2];
                     ggml_backend_t ids_backend = split_backend;
@@ -1541,6 +1722,8 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
                     }
 
                     if (ids_tensor != prev_ids_tensor) {
+                        ggml_backend_synchronize(input_backend);
+
                         ids.resize(ggml_nbytes(ids_tensor) / sizeof(int32_t));
                         ggml_backend_tensor_get_async(ids_backend, ids_tensor, ids.data(), 0, ggml_nbytes(ids_tensor));
                         ggml_backend_synchronize(ids_backend);
@@ -1557,6 +1740,44 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
                         }
 
                         prev_ids_tensor = ids_tensor;
+                    }
+
+                    // If this split was prefetched, the prefetch stream already
+                    // H2D'd the weight bytes into staging[slot] and recorded
+                    // h2d_done[slot]. Issue a main-stream waitEvent + D2D
+                    // staging->input_cpy. This keeps the write to input_cpy on
+                    // the same stream as the subsequent compute (no cross-stream
+                    // alias race) while allowing the H2D itself to overlap with
+                    // the previous split's compute.
+                    //
+                    // n_ranges == 0 means the slot was H2D'd full-tensor; >0
+                    // means selective, and we dispatch the mirror-range D2D so
+                    // only the same expert byte windows are transferred.
+                    //
+                    // NOTE: ids parse above must run FIRST so prev_ids_tensor
+                    // and used_ids are current when the fire block (after
+                    // compute submission below) picks up selective mode.
+                    if (moe_prefetch_hit && moe_prefetch_slot >= 0) {
+                        const int n_ranges = prefetch_n_ranges[moe_prefetch_slot];
+                        bool d2d_ok = false;
+                        const char * mode_str = "full";
+                        if (n_ranges > 0 && fn_staging_d2d_ranges) {
+                            d2d_ok = fn_staging_d2d_ranges((void *)split_backend,
+                                                           moe_prefetch_slot, input_cpy,
+                                                           prefetch_ranges[moe_prefetch_slot],
+                                                           n_ranges);
+                            mode_str = "selective";
+                        } else if (fn_staging_d2d) {
+                            d2d_ok = fn_staging_d2d((void *)split_backend, moe_prefetch_slot, input_cpy);
+                        }
+                        prefetch_n_ranges[moe_prefetch_slot] = 0;  // invalidate cached ranges
+                        if (d2d_ok) {
+                            GGML_LOG_DEBUG("%s: staging D2D split=%d slot=%d mode=%s ranges=%d\n",
+                                           __func__, split_id, moe_prefetch_slot, mode_str, n_ranges);
+                            continue;
+                        }
+                        GGML_LOG_WARN("%s: staging D2D failed split=%d slot=%d — falling back to selective copy\n",
+                                      __func__, split_id, moe_prefetch_slot);
                     }
 
                     // group consecutive experts and copy them together
@@ -1616,6 +1837,10 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
         if (!sched->callback_eval) {
             enum ggml_status ec = ggml_backend_graph_compute_async(split_backend, &split->graph, sched->batch_size);
             if (ec != GGML_STATUS_SUCCESS) {
+                if (prefetch_enabled) {
+                    if (fn_prefetch_stream_sync)    fn_prefetch_stream_sync(prefetch_stream);
+                    if (fn_prefetch_stream_destroy) fn_prefetch_stream_destroy(prefetch_stream);
+                }
                 return ec;
             }
         } else {
@@ -1638,6 +1863,10 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
 
                 enum ggml_status ec = ggml_backend_graph_compute_async(split_backend, &gv, sched->batch_size);
                 if (ec != GGML_STATUS_SUCCESS) {
+                    if (prefetch_enabled) {
+                        if (fn_prefetch_stream_sync)    fn_prefetch_stream_sync(prefetch_stream);
+                        if (fn_prefetch_stream_destroy) fn_prefetch_stream_destroy(prefetch_stream);
+                    }
                     return ec;
                 }
 
@@ -1652,12 +1881,144 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
             }
         }
 
+        // After submitting compute N, fire the next split's H2D on the
+        // INDEPENDENT prefetch stream, writing into the double-buffered
+        // staging[slot].
+        //
+        // Selective mode: when the next split's ids tensor matches the ids
+        // tensor consumed by the current split (same-layer A->B or B->C),
+        // used_ids was just built above. We reuse it to emit one memcpy per
+        // activated expert range (matching the full-weight selective layout).
+        // The consume path (fn_staging_d2d_ranges) mirrors the exact same
+        // ranges.
+        //
+        // Full-tensor fallback is used for:
+        //   - the first MoE split of a layer (cross-layer boundary; previous
+        //     split's ids don't apply)
+        //   - selective dispatch failure
+        //   - _ranges proc addresses not available (old DLL).
+        if (prefetch_enabled && !sched->callback_eval && !prefetch_pending) {
+            int next_id = split_id + 1;
+            if (is_moe_cpu_split(sched, next_id)) {
+                struct ggml_backend_sched_split * next_split = &sched->splits[next_id];
+                struct ggml_tensor * next_node = next_split->graph.nodes[0];
+                if (fn_staging_h2d) {
+                    bool fired = false;
+                    int  slot  = prefetch_counter & 1;
+                    const char * mode_str = "full";
+                    int    n_ranges_used  = 0;
+                    size_t bytes_to_copy  = 0;
+
+                    struct ggml_tensor * next_ids = next_node->src[2];
+                    const bool can_selective =
+                        (fn_staging_h2d_ranges != nullptr) &&
+                        (fn_staging_d2d_ranges != nullptr) &&
+                        (prev_ids_tensor != nullptr) &&
+                        (next_ids == prev_ids_tensor) &&
+                        !used_ids.empty();
+
+                    for (int i = 0; i < next_split->n_inputs; i++) {
+                        struct ggml_tensor * inp     = next_split->inputs[i];
+                        struct ggml_tensor * inp_cpy = tensor_copy(inp, next_split->backend_id, sched->cur_copy);
+                        if (next_node->src[0] == inp_cpy &&
+                            inp->buffer != NULL &&
+                            ggml_backend_buffer_get_usage(inp->buffer) == GGML_BACKEND_BUFFER_USAGE_WEIGHTS &&
+                            ggml_backend_buffer_is_host(inp->buffer) &&
+                            next_node->op == GGML_OP_MUL_MAT_ID) {
+
+                            const int64_t n_expert    = inp->ne[2];
+                            const size_t  expert_size = inp->nb[2];
+
+                            // bound check for the per-slot range cache; if a
+                            // future model ever exceeds this, bump the constant
+                            GGML_ASSERT(n_expert > 0 && n_expert <= MOE_MAX_EXPERTS_PER_LAYER &&
+                                        "n_expert exceeds MOE_MAX_EXPERTS_PER_LAYER");
+
+                            if (can_selective) {
+                                const int n_expert_i = (int)n_expert;
+                                struct moe_expert_range ranges[MOE_MAX_EXPERTS_PER_LAYER];
+                                int n_ranges = 0;
+
+                                int id = 0;
+                                while (id < n_expert_i && !ggml_bitset_get(used_ids.data(), id)) {
+                                    id++;
+                                }
+                                if (id < n_expert_i) {
+                                    int32_t first_id = (int32_t)id;
+                                    int32_t last_id  = first_id;
+                                    for (++id; id < n_expert_i; ++id) {
+                                        if (!ggml_bitset_get(used_ids.data(), id)) continue;
+                                        if (id == last_id + 1) {
+                                            last_id = (int32_t)id;
+                                            continue;
+                                        }
+                                        ranges[n_ranges].first_id = first_id;
+                                        ranges[n_ranges].last_id  = last_id;
+                                        n_ranges++;
+                                        first_id = (int32_t)id;
+                                        last_id  = first_id;
+                                    }
+                                    ranges[n_ranges].first_id = first_id;
+                                    ranges[n_ranges].last_id  = last_id;
+                                    n_ranges++;
+                                }
+
+                                if (n_ranges > 0 &&
+                                    fn_staging_h2d_ranges((void *)moe_cuda_backend, prefetch_stream,
+                                                          slot, inp, ranges, n_ranges)) {
+                                    memcpy(prefetch_ranges[slot], ranges, sizeof(ranges[0]) * n_ranges);
+                                    prefetch_n_ranges[slot] = n_ranges;
+                                    fired = true;
+                                    mode_str = "selective";
+                                    n_ranges_used = n_ranges;
+                                    for (int r = 0; r < n_ranges; r++) {
+                                        bytes_to_copy += (size_t)(ranges[r].last_id - ranges[r].first_id + 1) * expert_size;
+                                    }
+                                }
+                            }
+
+                            if (!fired) {
+                                if (fn_staging_h2d((void *)moe_cuda_backend, prefetch_stream, slot, inp)) {
+                                    prefetch_n_ranges[slot] = 0;  // flag as full-tensor
+                                    fired = true;
+                                    mode_str = "full";
+                                    n_ranges_used = 1;
+                                    bytes_to_copy = ggml_nbytes(inp);
+                                }
+                            }
+
+                            if (fired) {
+                                GGML_LOG_DEBUG("%s: moe prefetch fired: split=%d slot=%d mode=%s ids=%p bytes=%zu ranges=%d\n",
+                                               __func__, next_id, slot, mode_str, (void *)next_ids,
+                                               bytes_to_copy, n_ranges_used);
+                            }
+                            break;
+                        }
+                    }
+                    if (fired) {
+                        prefetch_pending  = true;
+                        prefetch_split_id = next_id;
+                        prefetch_slot     = slot;
+                        prefetch_counter++;
+                    }
+                }
+            }
+        }
+
         // record the event of this copy
         if (split->n_inputs > 0) {
             if (sched->events[split_backend_id][sched->cur_copy] != NULL) {
                 ggml_backend_event_record(sched->events[split_backend_id][sched->cur_copy], split_backend);
             }
         }
+    }
+
+    // Cleanup: drain the prefetch stream and destroy it.
+    // (Staging buffers + per-slot events live on the CUDA backend context and
+    // are torn down in ggml_backend_sched_free / ~ggml_backend_cuda_context.)
+    if (prefetch_enabled) {
+        if (fn_prefetch_stream_sync)    fn_prefetch_stream_sync(prefetch_stream);
+        if (fn_prefetch_stream_destroy) fn_prefetch_stream_destroy(prefetch_stream);
     }
 
     return GGML_STATUS_SUCCESS;
@@ -1751,6 +2112,23 @@ void ggml_backend_sched_free(ggml_backend_sched_t sched) {
     if (sched == NULL) {
         return;
     }
+
+    // Release the MoE staging buffers on the CUDA backend before tearing down
+    // sched internals. Proactive cleanup avoids holding ~2 * max_split_size of
+    // VRAM across sched recreation; the CUDA context destructor remains as a
+    // safety net.
+    if (auto fn_staging_destroy =
+            (moe_staging_destroy_fn_t)moe_get_proc(sched, "ggml_backend_cuda_moe_staging_destroy")) {
+        for (int b = 0; b < sched->n_backends; b++) {
+            ggml_backend_t backend = sched->backends[b];
+            if (!backend) continue;
+            ggml_backend_dev_t dev = ggml_backend_get_device(backend);
+            if (!dev || ggml_backend_dev_type(dev) != GGML_BACKEND_DEVICE_TYPE_GPU) continue;
+            fn_staging_destroy((void *)backend);
+            break;
+        }
+    }
+
     for (int b = 0; b < sched->n_backends; b++) {
         for (int c = 0; c < sched->n_copies; c++) {
             ggml_backend_event_free(sched->events[b][c]);

--- a/ml/backend/ggml/ggml/src/ggml-backend.cpp
+++ b/ml/backend/ggml/ggml/src/ggml-backend.cpp
@@ -14,6 +14,7 @@
 #include "ggml-impl.h"
 
 #include <assert.h>
+#include <ctype.h>
 #include <limits.h>
 #include <stdarg.h>
 #include <stdio.h>
@@ -698,6 +699,36 @@ static bool ggml_is_view_op(enum ggml_op op) {
 #define GGML_SCHED_MAX_COPIES 4
 #endif
 
+typedef void *(*moe_stream_fn_t)(void * backend);
+typedef void  (*moe_stream_synchronize_fn_t)(void *);
+typedef bool  (*moe_staging_init_fn_t)(void * backend, size_t max_size);
+typedef void  (*moe_staging_destroy_fn_t)(void * backend);
+typedef bool  (*moe_staging_h2d_fn_t)(void * backend, void * prefetch_stream, int slot, struct ggml_tensor * input);
+typedef bool  (*moe_staging_d2d_fn_t)(void * backend, int slot, struct ggml_tensor * input_cpy);
+
+struct moe_expert_range {
+    int32_t first_id;
+    int32_t last_id;
+};
+typedef bool  (*moe_staging_h2d_ranges_fn_t)(void * backend, void * prefetch_stream, int slot,
+                                             struct ggml_tensor * input,
+                                             const struct moe_expert_range * ranges, int n_ranges);
+typedef bool  (*moe_staging_d2d_ranges_fn_t)(void * backend, int slot,
+                                             struct ggml_tensor * input_cpy,
+                                             const struct moe_expert_range * ranges, int n_ranges);
+
+struct moe_prefetch_fns {
+    moe_stream_fn_t              stream              = nullptr;
+    moe_stream_synchronize_fn_t  stream_synchronize  = nullptr;
+    moe_staging_init_fn_t        staging_init        = nullptr;
+    moe_staging_destroy_fn_t     staging_destroy     = nullptr;
+    moe_staging_h2d_fn_t         staging_h2d         = nullptr;
+    moe_staging_d2d_fn_t         staging_d2d         = nullptr;
+    moe_staging_h2d_ranges_fn_t  staging_h2d_ranges  = nullptr;
+    moe_staging_d2d_ranges_fn_t  staging_d2d_ranges  = nullptr;
+    bool                         resolved            = false;
+};
+
 struct ggml_backend_sched_split {
     int backend_id;
     int i_start;
@@ -770,6 +801,13 @@ struct ggml_backend_sched {
     // the scheduler needs to be recreated with allocated buffers before it can be used
     // for computation
     bool alloc_buffers;
+
+    bool moe_prefetch_requested;
+    bool moe_prefetch_initialized;
+    void * moe_prefetch_stream;
+    ggml_backend_t moe_cuda_backend;
+    size_t moe_max_split_size;
+    struct moe_prefetch_fns moe_fns;
 };
 
 #define hash_id(tensor) ggml_hash_find_or_insert(&sched->hash_set, tensor)
@@ -1476,38 +1514,9 @@ static bool ggml_backend_sched_alloc_splits(ggml_backend_sched_t sched) {
     return true;
 }
 
-// ---------------------------------------------------------------------------
-// MoE prefetch: function pointer types for CUDA helpers via proc address
-// ---------------------------------------------------------------------------
-
-typedef void *(*moe_stream_create_fn_t)();
-typedef void  (*moe_stream_destroy_fn_t)(void *);
-typedef void  (*moe_stream_synchronize_fn_t)(void *);
-
-// Staging buffer helpers (overlap-safe prefetch)
-typedef bool  (*moe_staging_init_fn_t)(void * backend, size_t max_size);
-typedef void  (*moe_staging_destroy_fn_t)(void * backend);
-typedef bool  (*moe_staging_h2d_fn_t)(void * backend, void * prefetch_stream, int slot, struct ggml_tensor * input);
-typedef bool  (*moe_staging_d2d_fn_t)(void * backend, int slot, struct ggml_tensor * input_cpy);
-
-// Selective variant range descriptor — must match the struct in ggml-cuda.cu.
-struct moe_expert_range {
-    int32_t first_id;
-    int32_t last_id;
-};
-typedef bool  (*moe_staging_h2d_ranges_fn_t)(void * backend, void * prefetch_stream, int slot,
-                                             struct ggml_tensor * input,
-                                             const struct moe_expert_range * ranges, int n_ranges);
-typedef bool  (*moe_staging_d2d_ranges_fn_t)(void * backend, int slot,
-                                             struct ggml_tensor * input_cpy,
-                                             const struct moe_expert_range * ranges, int n_ranges);
-
 // Looks up a MoE prefetch proc address via the ggml backend registry.
 // Iterates sched->backends to find the first GPU backend, then calls
-// ggml_backend_reg_get_proc_address on its reg. This is the correct path
-// for proc addresses registered in ggml-cuda.cu via the proc-address table —
-// static helper functions are not exported from the DLL, so OS-level
-// GetProcAddress / dlsym would fail.
+// ggml_backend_reg_get_proc_address on its reg.
 static void * moe_get_proc(ggml_backend_sched_t sched, const char * name) {
     for (int i = 0; i < sched->n_backends; i++) {
         ggml_backend_t backend = sched->backends[i];
@@ -1521,6 +1530,60 @@ static void * moe_get_proc(ggml_backend_sched_t sched, const char * name) {
         if (fn) return fn;
     }
     return nullptr;
+}
+
+static bool moe_resolve_prefetch_fns(ggml_backend_sched_t sched) {
+    struct moe_prefetch_fns * fns = &sched->moe_fns;
+    if (fns->resolved) {
+        return fns->stream && fns->staging_init && fns->staging_h2d && fns->staging_d2d;
+    }
+
+    fns->stream             = (moe_stream_fn_t)             moe_get_proc(sched, "ggml_backend_cuda_moe_stream");
+    fns->stream_synchronize = (moe_stream_synchronize_fn_t) moe_get_proc(sched, "ggml_backend_cuda_moe_stream_synchronize");
+    fns->staging_init       = (moe_staging_init_fn_t)       moe_get_proc(sched, "ggml_backend_cuda_moe_staging_init");
+    fns->staging_destroy    = (moe_staging_destroy_fn_t)    moe_get_proc(sched, "ggml_backend_cuda_moe_staging_destroy");
+    fns->staging_h2d        = (moe_staging_h2d_fn_t)        moe_get_proc(sched, "ggml_backend_cuda_moe_staging_h2d");
+    fns->staging_d2d        = (moe_staging_d2d_fn_t)        moe_get_proc(sched, "ggml_backend_cuda_moe_staging_d2d");
+    fns->staging_h2d_ranges = (moe_staging_h2d_ranges_fn_t) moe_get_proc(sched, "ggml_backend_cuda_moe_staging_h2d_ranges");
+    fns->staging_d2d_ranges = (moe_staging_d2d_ranges_fn_t) moe_get_proc(sched, "ggml_backend_cuda_moe_staging_d2d_ranges");
+    fns->resolved = true;
+
+    return fns->stream && fns->staging_init && fns->staging_h2d && fns->staging_d2d;
+}
+
+static bool moe_env_enabled(const char * name) {
+    const char * value = getenv(name);
+    if (value == nullptr) {
+        return false;
+    }
+
+    while (isspace((unsigned char) *value)) {
+        value++;
+    }
+
+    const char * end = value + strlen(value);
+    while (end > value && isspace((unsigned char) end[-1])) {
+        end--;
+    }
+
+    const size_t len = end - value;
+    if (len == 0) {
+        return false;
+    }
+    if (len == 1 && value[0] == '0') {
+        return false;
+    }
+    if (len == 5) {
+        const char false_value[] = "false";
+        for (size_t i = 0; i < len; i++) {
+            if (tolower((unsigned char) value[i]) != false_value[i]) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    return true;
 }
 
 // Returns true if split_id refers to a CPU-side MoE expert weight split.
@@ -1558,7 +1621,8 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
     std::vector<ggml_bitset_t> used_ids;
 
     // MoE prefetch (staging path): initialize independent prefetch stream
-    // and double staging buffers if OLLAMA_MOE_PREFETCH is set.
+    // and double staging buffers only when the runner set the internal
+    // OLLAMA_MOE_PREFETCH_ENABLED gate.
     //
     // Architecture:
     //   prefetch stream: H2D pinned_CPU -> staging[slot], record h2d_done[slot]
@@ -1585,29 +1649,11 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
     struct moe_expert_range prefetch_ranges[2][MOE_MAX_EXPERTS_PER_LAYER] = {};
     int    prefetch_n_ranges[2] = {0, 0};
 
-    moe_stream_destroy_fn_t     fn_prefetch_stream_destroy = nullptr;
-    moe_stream_synchronize_fn_t fn_prefetch_stream_sync    = nullptr;
-    moe_staging_init_fn_t       fn_staging_init            = nullptr;
-    moe_staging_destroy_fn_t    fn_staging_destroy         = nullptr;
-    moe_staging_h2d_fn_t        fn_staging_h2d             = nullptr;
-    moe_staging_d2d_fn_t        fn_staging_d2d             = nullptr;
-    moe_staging_h2d_ranges_fn_t fn_staging_h2d_ranges      = nullptr;
-    moe_staging_d2d_ranges_fn_t fn_staging_d2d_ranges      = nullptr;
+    struct moe_prefetch_fns * fns = &sched->moe_fns;
 
-    static bool prefetch_init_logged = false;
-    if (getenv("OLLAMA_MOE_PREFETCH") != nullptr) {
-        auto fn_stream_create = (moe_stream_create_fn_t)moe_get_proc(sched, "ggml_backend_cuda_moe_stream_create");
-        fn_prefetch_stream_destroy = (moe_stream_destroy_fn_t)moe_get_proc(sched, "ggml_backend_cuda_moe_stream_destroy");
-        fn_prefetch_stream_sync    = (moe_stream_synchronize_fn_t)moe_get_proc(sched, "ggml_backend_cuda_moe_stream_synchronize");
-        fn_staging_init        = (moe_staging_init_fn_t)       moe_get_proc(sched, "ggml_backend_cuda_moe_staging_init");
-        fn_staging_destroy     = (moe_staging_destroy_fn_t)    moe_get_proc(sched, "ggml_backend_cuda_moe_staging_destroy");
-        fn_staging_h2d         = (moe_staging_h2d_fn_t)        moe_get_proc(sched, "ggml_backend_cuda_moe_staging_h2d");
-        fn_staging_d2d         = (moe_staging_d2d_fn_t)        moe_get_proc(sched, "ggml_backend_cuda_moe_staging_d2d");
-        fn_staging_h2d_ranges  = (moe_staging_h2d_ranges_fn_t) moe_get_proc(sched, "ggml_backend_cuda_moe_staging_h2d_ranges");
-        fn_staging_d2d_ranges  = (moe_staging_d2d_ranges_fn_t) moe_get_proc(sched, "ggml_backend_cuda_moe_staging_d2d_ranges");
-
-        if (fn_stream_create && fn_staging_init && fn_staging_h2d && fn_staging_d2d) {
-            // Walk splits to find the max MoE weight tensor size and the CUDA backend
+    if (sched->moe_prefetch_requested && moe_resolve_prefetch_fns(sched)) {
+        if (!sched->moe_prefetch_initialized) {
+            // Walk splits once to find the max MoE weight tensor size and CUDA backend.
             size_t max_moe_split_size = 0;
             for (int s = 0; s < sched->n_splits; s++) {
                 if (!is_moe_cpu_split(sched, s)) continue;
@@ -1619,41 +1665,30 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
                         ggml_backend_buffer_get_usage(inp->buffer) == GGML_BACKEND_BUFFER_USAGE_WEIGHTS) {
                         size_t nb = ggml_nbytes(inp);
                         if (nb > max_moe_split_size) max_moe_split_size = nb;
-                        if (!moe_cuda_backend) moe_cuda_backend = sched->backends[sp->backend_id];
+                        if (!sched->moe_cuda_backend) sched->moe_cuda_backend = sched->backends[sp->backend_id];
                     }
                 }
             }
-            if (max_moe_split_size > 0 && moe_cuda_backend) {
-                prefetch_stream = fn_stream_create();
-                if (prefetch_stream && fn_staging_init((void *)moe_cuda_backend, max_moe_split_size)) {
-                    prefetch_enabled = true;
-                    if (!prefetch_init_logged) {
-                        GGML_LOG_INFO("%s: MoE lookahead prefetch enabled (staging 2x%zu MiB)\n",
-                                      __func__, max_moe_split_size / (1024 * 1024));
-                        prefetch_init_logged = true;
-                    }
+            sched->moe_max_split_size = max_moe_split_size;
+            if (max_moe_split_size > 0 && sched->moe_cuda_backend) {
+                sched->moe_prefetch_stream = fns->stream((void *)sched->moe_cuda_backend);
+                if (sched->moe_prefetch_stream && fns->staging_init((void *)sched->moe_cuda_backend, max_moe_split_size)) {
+                    GGML_LOG_DEBUG("%s: MoE lookahead prefetch enabled (staging 2x%zu MiB)\n",
+                                   __func__, max_moe_split_size / (1024 * 1024));
                 } else {
-                    if (fn_prefetch_stream_destroy && prefetch_stream) {
-                        fn_prefetch_stream_destroy(prefetch_stream);
-                    }
-                    prefetch_stream = nullptr;
-                    if (!prefetch_init_logged) {
-                        GGML_LOG_WARN("%s: MoE prefetch disabled — staging allocation failed\n", __func__);
-                        prefetch_init_logged = true;
-                    }
+                    sched->moe_prefetch_stream = nullptr;
+                    GGML_LOG_DEBUG("%s: MoE prefetch disabled - staging allocation failed\n", __func__);
                 }
             } else {
-                if (!prefetch_init_logged) {
-                    GGML_LOG_INFO("%s: MoE prefetch inactive — no CPU-MoE splits in graph\n", __func__);
-                    prefetch_init_logged = true;
-                }
+                GGML_LOG_DEBUG("%s: MoE prefetch inactive - no CPU-MoE splits in graph\n", __func__);
             }
-        } else {
-            if (!prefetch_init_logged) {
-                GGML_LOG_WARN("%s: MoE prefetch disabled — proc lookup failed\n", __func__);
-                prefetch_init_logged = true;
-            }
+            sched->moe_prefetch_initialized = true;
         }
+        prefetch_stream = sched->moe_prefetch_stream;
+        moe_cuda_backend = sched->moe_cuda_backend;
+        prefetch_enabled = prefetch_stream != nullptr && moe_cuda_backend != nullptr && sched->moe_max_split_size > 0;
+    } else if (sched->moe_prefetch_requested && !sched->moe_fns.resolved) {
+        GGML_LOG_DEBUG("%s: MoE prefetch disabled - proc lookup failed\n", __func__);
     }
 
     for (int split_id = 0; split_id < sched->n_splits; split_id++) {
@@ -1761,14 +1796,14 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
                         const int n_ranges = prefetch_n_ranges[moe_prefetch_slot];
                         bool d2d_ok = false;
                         const char * mode_str = "full";
-                        if (n_ranges > 0 && fn_staging_d2d_ranges) {
-                            d2d_ok = fn_staging_d2d_ranges((void *)split_backend,
+                        if (n_ranges > 0 && fns->staging_d2d_ranges) {
+                            d2d_ok = fns->staging_d2d_ranges((void *)split_backend,
                                                            moe_prefetch_slot, input_cpy,
                                                            prefetch_ranges[moe_prefetch_slot],
                                                            n_ranges);
                             mode_str = "selective";
-                        } else if (fn_staging_d2d) {
-                            d2d_ok = fn_staging_d2d((void *)split_backend, moe_prefetch_slot, input_cpy);
+                        } else if (fns->staging_d2d) {
+                            d2d_ok = fns->staging_d2d((void *)split_backend, moe_prefetch_slot, input_cpy);
                         }
                         prefetch_n_ranges[moe_prefetch_slot] = 0;  // invalidate cached ranges
                         if (d2d_ok) {
@@ -1776,7 +1811,7 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
                                            __func__, split_id, moe_prefetch_slot, mode_str, n_ranges);
                             continue;
                         }
-                        GGML_LOG_WARN("%s: staging D2D failed split=%d slot=%d — falling back to selective copy\n",
+                        GGML_LOG_WARN("%s: staging D2D failed split=%d slot=%d - falling back to selective copy\n",
                                       __func__, split_id, moe_prefetch_slot);
                     }
 
@@ -1838,8 +1873,7 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
             enum ggml_status ec = ggml_backend_graph_compute_async(split_backend, &split->graph, sched->batch_size);
             if (ec != GGML_STATUS_SUCCESS) {
                 if (prefetch_enabled) {
-                    if (fn_prefetch_stream_sync)    fn_prefetch_stream_sync(prefetch_stream);
-                    if (fn_prefetch_stream_destroy) fn_prefetch_stream_destroy(prefetch_stream);
+                    if (fns->stream_synchronize) fns->stream_synchronize(prefetch_stream);
                 }
                 return ec;
             }
@@ -1864,8 +1898,7 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
                 enum ggml_status ec = ggml_backend_graph_compute_async(split_backend, &gv, sched->batch_size);
                 if (ec != GGML_STATUS_SUCCESS) {
                     if (prefetch_enabled) {
-                        if (fn_prefetch_stream_sync)    fn_prefetch_stream_sync(prefetch_stream);
-                        if (fn_prefetch_stream_destroy) fn_prefetch_stream_destroy(prefetch_stream);
+                        if (fns->stream_synchronize) fns->stream_synchronize(prefetch_stream);
                     }
                     return ec;
                 }
@@ -1902,7 +1935,7 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
             if (is_moe_cpu_split(sched, next_id)) {
                 struct ggml_backend_sched_split * next_split = &sched->splits[next_id];
                 struct ggml_tensor * next_node = next_split->graph.nodes[0];
-                if (fn_staging_h2d) {
+                if (fns->staging_h2d) {
                     bool fired = false;
                     int  slot  = prefetch_counter & 1;
                     const char * mode_str = "full";
@@ -1911,8 +1944,8 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
 
                     struct ggml_tensor * next_ids = next_node->src[2];
                     const bool can_selective =
-                        (fn_staging_h2d_ranges != nullptr) &&
-                        (fn_staging_d2d_ranges != nullptr) &&
+                        (fns->staging_h2d_ranges != nullptr) &&
+                        (fns->staging_d2d_ranges != nullptr) &&
                         (prev_ids_tensor != nullptr) &&
                         (next_ids == prev_ids_tensor) &&
                         !used_ids.empty();
@@ -1964,7 +1997,7 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
                                 }
 
                                 if (n_ranges > 0 &&
-                                    fn_staging_h2d_ranges((void *)moe_cuda_backend, prefetch_stream,
+                                    fns->staging_h2d_ranges((void *)moe_cuda_backend, prefetch_stream,
                                                           slot, inp, ranges, n_ranges)) {
                                     memcpy(prefetch_ranges[slot], ranges, sizeof(ranges[0]) * n_ranges);
                                     prefetch_n_ranges[slot] = n_ranges;
@@ -1978,7 +2011,7 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
                             }
 
                             if (!fired) {
-                                if (fn_staging_h2d((void *)moe_cuda_backend, prefetch_stream, slot, inp)) {
+                                if (fns->staging_h2d((void *)moe_cuda_backend, prefetch_stream, slot, inp)) {
                                     prefetch_n_ranges[slot] = 0;  // flag as full-tensor
                                     fired = true;
                                     mode_str = "full";
@@ -2011,14 +2044,6 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
                 ggml_backend_event_record(sched->events[split_backend_id][sched->cur_copy], split_backend);
             }
         }
-    }
-
-    // Cleanup: drain the prefetch stream and destroy it.
-    // (Staging buffers + per-slot events live on the CUDA backend context and
-    // are torn down in ggml_backend_sched_free / ~ggml_backend_cuda_context.)
-    if (prefetch_enabled) {
-        if (fn_prefetch_stream_sync)    fn_prefetch_stream_sync(prefetch_stream);
-        if (fn_prefetch_stream_destroy) fn_prefetch_stream_destroy(prefetch_stream);
     }
 
     return GGML_STATUS_SUCCESS;
@@ -2060,6 +2085,7 @@ ggml_backend_sched_t ggml_backend_sched_new_ext(
 
     sched->n_backends = n_backends;
     sched->n_copies = parallel ? GGML_SCHED_MAX_COPIES : 1;
+    sched->moe_prefetch_requested = moe_env_enabled("OLLAMA_MOE_PREFETCH_ENABLED");
 
     // initialize hash table
     // FIXME: needs to be size*2 to account for leafs (do it in graph_split instead)
@@ -2125,7 +2151,6 @@ void ggml_backend_sched_free(ggml_backend_sched_t sched) {
             ggml_backend_dev_t dev = ggml_backend_get_device(backend);
             if (!dev || ggml_backend_dev_type(dev) != GGML_BACKEND_DEVICE_TYPE_GPU) continue;
             fn_staging_destroy((void *)backend);
-            break;
         }
     }
 

--- a/ml/backend/ggml/ggml/src/ggml-cuda/common.cuh
+++ b/ml/backend/ggml/ggml/src/ggml-cuda/common.cuh
@@ -1263,6 +1263,17 @@ struct ggml_backend_cuda_context {
 
     ggml_cuda_stream_context concurrent_stream_context;
 
+    // MoE prefetch: double-buffered staging for overlap-safe H2D.
+    // prefetch stream writes pinned CPU weights -> moe_staging_buffers[slot],
+    // then records moe_staging_h2d_done[slot]; main compute stream waits on the
+    // event and D2D-copies staging -> input_cpy. Prevents the cross-stream race
+    // with ggml-alloc-aliased input_cpy regions.
+    struct {
+        void *       buffers[2]    = {nullptr, nullptr};
+        cudaEvent_t  h2d_done[2]   = {nullptr, nullptr};
+        size_t       capacity      = 0;
+    } moe_staging;
+
     ~ggml_backend_cuda_context();
 
     cudaStream_t stream(int device, int stream) {

--- a/ml/backend/ggml/ggml/src/ggml-cuda/common.cuh
+++ b/ml/backend/ggml/ggml/src/ggml-cuda/common.cuh
@@ -1272,6 +1272,7 @@ struct ggml_backend_cuda_context {
         void *       buffers[2]    = {nullptr, nullptr};
         cudaEvent_t  h2d_done[2]   = {nullptr, nullptr};
         size_t       capacity      = 0;
+        cudaStream_t stream        = nullptr;
     } moe_staging;
 
     ~ggml_backend_cuda_context();

--- a/ml/backend/ggml/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ml/backend/ggml/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -672,6 +672,10 @@ ggml_backend_cuda_context::~ggml_backend_cuda_context() {
         CUDA_CHECK(cudaEventDestroy(copy_event));
     }
     // MoE staging safety-net cleanup (sched normally destroys first)
+    if (moe_staging.stream != nullptr) {
+        CUDA_CHECK(cudaStreamDestroy(moe_staging.stream));
+        moe_staging.stream = nullptr;
+    }
     for (int i = 0; i < 2; i++) {
         if (moe_staging.buffers[i] != nullptr) {
             CUDA_CHECK(cudaFree(moe_staging.buffers[i]));
@@ -5085,21 +5089,22 @@ static ggml_backend_feature * ggml_backend_cuda_get_features(ggml_backend_reg_t 
 }
 
 // ---------------------------------------------------------------------------
-// MoE prefetch CUDA helpers — exposed via proc address as void* handles
+// MoE prefetch CUDA helpers exposed via proc address as void* handles.
 // ---------------------------------------------------------------------------
 
-static void * ggml_backend_cuda_moe_stream_create() {
-    cudaStream_t stream;
-    if (cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking) != cudaSuccess) {
+static void * ggml_backend_cuda_moe_stream(void * backend_handle) {
+    if (!backend_handle) return nullptr;
+    ggml_backend_t backend = (ggml_backend_t)backend_handle;
+    ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *)backend->context;
+    if (cuda_ctx->moe_staging.stream != nullptr) {
+        return (void *)cuda_ctx->moe_staging.stream;
+    }
+    ggml_cuda_set_device(cuda_ctx->device);
+    if (cudaStreamCreateWithFlags(&cuda_ctx->moe_staging.stream, cudaStreamNonBlocking) != cudaSuccess) {
+        cuda_ctx->moe_staging.stream = nullptr;
         return nullptr;
     }
-    return (void *)stream;
-}
-
-static void ggml_backend_cuda_moe_stream_destroy(void * stream_handle) {
-    if (stream_handle) {
-        cudaStreamDestroy((cudaStream_t)stream_handle);
-    }
+    return (void *)cuda_ctx->moe_staging.stream;
 }
 
 static void ggml_backend_cuda_moe_stream_synchronize(void * stream_handle) {
@@ -5109,7 +5114,7 @@ static void ggml_backend_cuda_moe_stream_synchronize(void * stream_handle) {
 }
 
 // ---------------------------------------------------------------------------
-// MoE prefetch — staging buffer path (overlap-safe)
+// MoE prefetch staging buffer path (overlap-safe).
 //
 // Two dedicated VRAM buffers (double-buffered) receive H2D copies on the
 // independent prefetch stream; the main compute stream later D2D-copies from
@@ -5120,7 +5125,7 @@ static void ggml_backend_cuda_moe_stream_synchronize(void * stream_handle) {
 
 // Initialize double staging buffers of `max_size` bytes each on the given
 // backend's device. Returns true on success; leaves staging empty on failure.
-// Safe to call repeatedly — grows (but never shrinks) capacity.
+// Safe to call repeatedly, growing but never shrinking capacity.
 static bool ggml_backend_cuda_moe_staging_init(void * backend_handle, size_t max_size) {
     if (!backend_handle || max_size == 0) return false;
     ggml_backend_t backend = (ggml_backend_t)backend_handle;
@@ -5169,6 +5174,10 @@ static void ggml_backend_cuda_moe_staging_destroy(void * backend_handle) {
     ggml_backend_t backend = (ggml_backend_t)backend_handle;
     ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *)backend->context;
     ggml_cuda_set_device(cuda_ctx->device);
+    if (cuda_ctx->moe_staging.stream != nullptr) {
+        cudaStreamDestroy(cuda_ctx->moe_staging.stream);
+        cuda_ctx->moe_staging.stream = nullptr;
+    }
     for (int i = 0; i < 2; i++) {
         if (cuda_ctx->moe_staging.buffers[i] != nullptr) {
             cudaFree(cuda_ctx->moe_staging.buffers[i]);
@@ -5329,11 +5338,8 @@ static void * ggml_backend_cuda_reg_get_proc_address(ggml_backend_reg_t reg, con
     if (strcmp(name, "ggml_backend_get_features") == 0) {
         return (void *)ggml_backend_cuda_get_features;
     }
-    if (strcmp(name, "ggml_backend_cuda_moe_stream_create") == 0) {
-        return (void *)ggml_backend_cuda_moe_stream_create;
-    }
-    if (strcmp(name, "ggml_backend_cuda_moe_stream_destroy") == 0) {
-        return (void *)ggml_backend_cuda_moe_stream_destroy;
+    if (strcmp(name, "ggml_backend_cuda_moe_stream") == 0) {
+        return (void *)ggml_backend_cuda_moe_stream;
     }
     if (strcmp(name, "ggml_backend_cuda_moe_stream_synchronize") == 0) {
         return (void *)ggml_backend_cuda_moe_stream_synchronize;

--- a/ml/backend/ggml/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ml/backend/ggml/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -5131,22 +5131,31 @@ static bool ggml_backend_cuda_moe_staging_init(void * backend_handle, size_t max
         return true;
     }
     ggml_cuda_set_device(cuda_ctx->device);
-    // free any undersized prior allocation
-    for (int i = 0; i < 2; i++) {
-        if (cuda_ctx->moe_staging.buffers[i] != nullptr) {
-            cudaFree(cuda_ctx->moe_staging.buffers[i]);
-            cuda_ctx->moe_staging.buffers[i] = nullptr;
+    auto cleanup_staging = [&]() {
+        for (int i = 0; i < 2; i++) {
+            if (cuda_ctx->moe_staging.buffers[i] != nullptr) {
+                cudaFree(cuda_ctx->moe_staging.buffers[i]);
+                cuda_ctx->moe_staging.buffers[i] = nullptr;
+            }
+            if (cuda_ctx->moe_staging.h2d_done[i] != nullptr) {
+                cudaEventDestroy(cuda_ctx->moe_staging.h2d_done[i]);
+                cuda_ctx->moe_staging.h2d_done[i] = nullptr;
+            }
         }
-    }
+        cuda_ctx->moe_staging.capacity = 0;
+    };
+    cleanup_staging();
     for (int i = 0; i < 2; i++) {
         if (cudaMalloc(&cuda_ctx->moe_staging.buffers[i], max_size) != cudaSuccess) {
             cuda_ctx->moe_staging.buffers[i] = nullptr;
+            cleanup_staging();
             return false;
         }
         if (cuda_ctx->moe_staging.h2d_done[i] == nullptr) {
             if (cudaEventCreateWithFlags(&cuda_ctx->moe_staging.h2d_done[i],
                                          cudaEventDisableTiming) != cudaSuccess) {
                 cuda_ctx->moe_staging.h2d_done[i] = nullptr;
+                cleanup_staging();
                 return false;
             }
         }

--- a/ml/backend/ggml/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ml/backend/ggml/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -671,6 +671,17 @@ ggml_backend_cuda_context::~ggml_backend_cuda_context() {
     if (copy_event != nullptr) {
         CUDA_CHECK(cudaEventDestroy(copy_event));
     }
+    // MoE staging safety-net cleanup (sched normally destroys first)
+    for (int i = 0; i < 2; i++) {
+        if (moe_staging.buffers[i] != nullptr) {
+            CUDA_CHECK(cudaFree(moe_staging.buffers[i]));
+            moe_staging.buffers[i] = nullptr;
+        }
+        if (moe_staging.h2d_done[i] != nullptr) {
+            CUDA_CHECK(cudaEventDestroy(moe_staging.h2d_done[i]));
+            moe_staging.h2d_done[i] = nullptr;
+        }
+    }
     for (int i = 0; i < GGML_CUDA_MAX_DEVICES; ++i) {
         for (int j = 0; j < GGML_CUDA_MAX_STREAMS; ++j) {
             if (streams[i][j] != nullptr) {
@@ -5073,6 +5084,228 @@ static ggml_backend_feature * ggml_backend_cuda_get_features(ggml_backend_reg_t 
     GGML_UNUSED(reg);
 }
 
+// ---------------------------------------------------------------------------
+// MoE prefetch CUDA helpers — exposed via proc address as void* handles
+// ---------------------------------------------------------------------------
+
+static void * ggml_backend_cuda_moe_stream_create() {
+    cudaStream_t stream;
+    if (cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking) != cudaSuccess) {
+        return nullptr;
+    }
+    return (void *)stream;
+}
+
+static void ggml_backend_cuda_moe_stream_destroy(void * stream_handle) {
+    if (stream_handle) {
+        cudaStreamDestroy((cudaStream_t)stream_handle);
+    }
+}
+
+static void ggml_backend_cuda_moe_stream_synchronize(void * stream_handle) {
+    if (stream_handle) {
+        cudaStreamSynchronize((cudaStream_t)stream_handle);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MoE prefetch — staging buffer path (overlap-safe)
+//
+// Two dedicated VRAM buffers (double-buffered) receive H2D copies on the
+// independent prefetch stream; the main compute stream later D2D-copies from
+// the matching staging slot into input_cpy. The staging VRAM is disjoint from
+// any input_cpy region, so the prefetch H2D cannot race with in-flight compute
+// reading an aliased input_cpy.
+// ---------------------------------------------------------------------------
+
+// Initialize double staging buffers of `max_size` bytes each on the given
+// backend's device. Returns true on success; leaves staging empty on failure.
+// Safe to call repeatedly — grows (but never shrinks) capacity.
+static bool ggml_backend_cuda_moe_staging_init(void * backend_handle, size_t max_size) {
+    if (!backend_handle || max_size == 0) return false;
+    ggml_backend_t backend = (ggml_backend_t)backend_handle;
+    ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *)backend->context;
+    if (cuda_ctx->moe_staging.capacity >= max_size &&
+        cuda_ctx->moe_staging.buffers[0] != nullptr &&
+        cuda_ctx->moe_staging.buffers[1] != nullptr) {
+        return true;
+    }
+    ggml_cuda_set_device(cuda_ctx->device);
+    // free any undersized prior allocation
+    for (int i = 0; i < 2; i++) {
+        if (cuda_ctx->moe_staging.buffers[i] != nullptr) {
+            cudaFree(cuda_ctx->moe_staging.buffers[i]);
+            cuda_ctx->moe_staging.buffers[i] = nullptr;
+        }
+    }
+    for (int i = 0; i < 2; i++) {
+        if (cudaMalloc(&cuda_ctx->moe_staging.buffers[i], max_size) != cudaSuccess) {
+            cuda_ctx->moe_staging.buffers[i] = nullptr;
+            return false;
+        }
+        if (cuda_ctx->moe_staging.h2d_done[i] == nullptr) {
+            if (cudaEventCreateWithFlags(&cuda_ctx->moe_staging.h2d_done[i],
+                                         cudaEventDisableTiming) != cudaSuccess) {
+                cuda_ctx->moe_staging.h2d_done[i] = nullptr;
+                return false;
+            }
+        }
+    }
+    cuda_ctx->moe_staging.capacity = max_size;
+    return true;
+}
+
+static void ggml_backend_cuda_moe_staging_destroy(void * backend_handle) {
+    if (!backend_handle) return;
+    ggml_backend_t backend = (ggml_backend_t)backend_handle;
+    ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *)backend->context;
+    ggml_cuda_set_device(cuda_ctx->device);
+    for (int i = 0; i < 2; i++) {
+        if (cuda_ctx->moe_staging.buffers[i] != nullptr) {
+            cudaFree(cuda_ctx->moe_staging.buffers[i]);
+            cuda_ctx->moe_staging.buffers[i] = nullptr;
+        }
+        if (cuda_ctx->moe_staging.h2d_done[i] != nullptr) {
+            cudaEventDestroy(cuda_ctx->moe_staging.h2d_done[i]);
+            cuda_ctx->moe_staging.h2d_done[i] = nullptr;
+        }
+    }
+    cuda_ctx->moe_staging.capacity = 0;
+}
+
+// H2D on the independent prefetch stream: CPU pinned `input` -> staging[slot],
+// then record h2d_done[slot]. The main-stream D2D must wait on that event.
+static bool ggml_backend_cuda_moe_staging_h2d(
+        void * backend_handle, void * prefetch_stream_handle, int slot,
+        struct ggml_tensor * input) {
+    if (!backend_handle || !prefetch_stream_handle || !input) return false;
+    if (slot < 0 || slot > 1) return false;
+    ggml_backend_t backend = (ggml_backend_t)backend_handle;
+    ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *)backend->context;
+    if (cuda_ctx->moe_staging.buffers[slot] == nullptr ||
+        cuda_ctx->moe_staging.h2d_done[slot] == nullptr) return false;
+    size_t nbytes = ggml_nbytes(input);
+    if (nbytes > cuda_ctx->moe_staging.capacity) return false;
+    cudaStream_t pstream = (cudaStream_t)prefetch_stream_handle;
+    if (cudaMemcpyAsync(cuda_ctx->moe_staging.buffers[slot], input->data, nbytes,
+                        cudaMemcpyHostToDevice, pstream) != cudaSuccess) return false;
+    return cudaEventRecord(cuda_ctx->moe_staging.h2d_done[slot], pstream) == cudaSuccess;
+}
+
+// D2D on the main compute stream: wait on h2d_done[slot], then copy
+// staging[slot] -> input_cpy. Size taken from input_cpy (must equal H2D size).
+static bool ggml_backend_cuda_moe_staging_d2d(
+        void * backend_handle, int slot, struct ggml_tensor * input_cpy) {
+    if (!backend_handle || !input_cpy) return false;
+    if (slot < 0 || slot > 1) return false;
+    ggml_backend_t backend = (ggml_backend_t)backend_handle;
+    ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *)backend->context;
+    if (cuda_ctx->moe_staging.buffers[slot] == nullptr ||
+        cuda_ctx->moe_staging.h2d_done[slot] == nullptr) return false;
+    size_t nbytes = ggml_nbytes(input_cpy);
+    if (nbytes > cuda_ctx->moe_staging.capacity) return false;
+    cudaStream_t main_stream = cuda_ctx->stream();
+    if (cudaStreamWaitEvent(main_stream, cuda_ctx->moe_staging.h2d_done[slot], 0) != cudaSuccess) return false;
+    return cudaMemcpyAsync(input_cpy->data, cuda_ctx->moe_staging.buffers[slot], nbytes,
+                           cudaMemcpyDeviceToDevice, main_stream) == cudaSuccess;
+}
+
+// Range descriptor for selective staging: [first_id, last_id] inclusive, along
+// the expert dimension (input->ne[2]) of a MUL_MAT_ID weight tensor.
+struct moe_expert_range {
+    int32_t first_id;
+    int32_t last_id;
+};
+
+// Selective H2D on the prefetch stream: for each range, copy the corresponding
+// contiguous expert rows from pinned CPU memory to staging[slot] at the SAME
+// byte offset (so the subsequent D2D can mirror the layout). After all ranges
+// are submitted, record h2d_done[slot] once. Mirrors the MMQ padding_end
+// behavior of the full-weight path.
+static bool ggml_backend_cuda_moe_staging_h2d_ranges(
+        void * backend_handle, void * prefetch_stream_handle, int slot,
+        struct ggml_tensor * input,
+        const struct moe_expert_range * ranges, int n_ranges) {
+    if (!backend_handle || !prefetch_stream_handle || !input) return false;
+    if (!ranges || n_ranges <= 0) return false;
+    if (slot < 0 || slot > 1) return false;
+    ggml_backend_t backend = (ggml_backend_t)backend_handle;
+    ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *)backend->context;
+    if (cuda_ctx->moe_staging.buffers[slot] == nullptr ||
+        cuda_ctx->moe_staging.h2d_done[slot] == nullptr) return false;
+    size_t tensor_nbytes = ggml_nbytes(input);
+    if (tensor_nbytes > cuda_ctx->moe_staging.capacity) return false;
+
+    const int32_t n_expert    = (int32_t)input->ne[2];
+    const size_t  expert_size = input->nb[2];
+    const size_t  padding     = expert_size < 512 ? expert_size : 512;
+
+    cudaStream_t pstream = (cudaStream_t)prefetch_stream_handle;
+    uint8_t *    staging = (uint8_t *)cuda_ctx->moe_staging.buffers[slot];
+
+    for (int r = 0; r < n_ranges; r++) {
+        const int32_t first_id = ranges[r].first_id;
+        const int32_t last_id  = ranges[r].last_id;
+        if (first_id < 0 || last_id < first_id || last_id >= n_expert) return false;
+
+        const size_t expert_offset    = (size_t)first_id * expert_size;
+        const size_t expert_size_copy = (size_t)(last_id - first_id + 1) * expert_size;
+        const size_t padding_end      = (n_expert > 1 && last_id < n_expert - 1) ? padding : 0;
+
+        const uint8_t * src = (const uint8_t *)input->data + expert_offset;
+        uint8_t       * dst = staging + expert_offset;
+        if (cudaMemcpyAsync(dst, src, expert_size_copy + padding_end,
+                            cudaMemcpyHostToDevice, pstream) != cudaSuccess) {
+            return false;
+        }
+    }
+    return cudaEventRecord(cuda_ctx->moe_staging.h2d_done[slot], pstream) == cudaSuccess;
+}
+
+// Selective D2D on the main compute stream: wait on h2d_done[slot] once, then
+// issue one cudaMemcpyAsync per range, reading from staging[slot] at the same
+// expert offset that the H2D wrote to.
+static bool ggml_backend_cuda_moe_staging_d2d_ranges(
+        void * backend_handle, int slot, struct ggml_tensor * input_cpy,
+        const struct moe_expert_range * ranges, int n_ranges) {
+    if (!backend_handle || !input_cpy) return false;
+    if (!ranges || n_ranges <= 0) return false;
+    if (slot < 0 || slot > 1) return false;
+    ggml_backend_t backend = (ggml_backend_t)backend_handle;
+    ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *)backend->context;
+    if (cuda_ctx->moe_staging.buffers[slot] == nullptr ||
+        cuda_ctx->moe_staging.h2d_done[slot] == nullptr) return false;
+    size_t tensor_nbytes = ggml_nbytes(input_cpy);
+    if (tensor_nbytes > cuda_ctx->moe_staging.capacity) return false;
+
+    const int32_t n_expert    = (int32_t)input_cpy->ne[2];
+    const size_t  expert_size = input_cpy->nb[2];
+    const size_t  padding     = expert_size < 512 ? expert_size : 512;
+
+    cudaStream_t main_stream = cuda_ctx->stream();
+    if (cudaStreamWaitEvent(main_stream, cuda_ctx->moe_staging.h2d_done[slot], 0) != cudaSuccess) return false;
+
+    const uint8_t * staging = (const uint8_t *)cuda_ctx->moe_staging.buffers[slot];
+    uint8_t *       dst_base = (uint8_t *)input_cpy->data;
+
+    for (int r = 0; r < n_ranges; r++) {
+        const int32_t first_id = ranges[r].first_id;
+        const int32_t last_id  = ranges[r].last_id;
+        if (first_id < 0 || last_id < first_id || last_id >= n_expert) return false;
+
+        const size_t expert_offset    = (size_t)first_id * expert_size;
+        const size_t expert_size_copy = (size_t)(last_id - first_id + 1) * expert_size;
+        const size_t padding_end      = (n_expert > 1 && last_id < n_expert - 1) ? padding : 0;
+
+        if (cudaMemcpyAsync(dst_base + expert_offset, staging + expert_offset,
+                            expert_size_copy + padding_end,
+                            cudaMemcpyDeviceToDevice, main_stream) != cudaSuccess) {
+            return false;
+        }
+    }
+    return true;
+}
+
 static void * ggml_backend_cuda_reg_get_proc_address(ggml_backend_reg_t reg, const char * name) {
     GGML_UNUSED(reg);
     if (strcmp(name, "ggml_backend_split_buffer_type") == 0) {
@@ -5086,6 +5319,33 @@ static void * ggml_backend_cuda_reg_get_proc_address(ggml_backend_reg_t reg, con
     }
     if (strcmp(name, "ggml_backend_get_features") == 0) {
         return (void *)ggml_backend_cuda_get_features;
+    }
+    if (strcmp(name, "ggml_backend_cuda_moe_stream_create") == 0) {
+        return (void *)ggml_backend_cuda_moe_stream_create;
+    }
+    if (strcmp(name, "ggml_backend_cuda_moe_stream_destroy") == 0) {
+        return (void *)ggml_backend_cuda_moe_stream_destroy;
+    }
+    if (strcmp(name, "ggml_backend_cuda_moe_stream_synchronize") == 0) {
+        return (void *)ggml_backend_cuda_moe_stream_synchronize;
+    }
+    if (strcmp(name, "ggml_backend_cuda_moe_staging_init") == 0) {
+        return (void *)ggml_backend_cuda_moe_staging_init;
+    }
+    if (strcmp(name, "ggml_backend_cuda_moe_staging_destroy") == 0) {
+        return (void *)ggml_backend_cuda_moe_staging_destroy;
+    }
+    if (strcmp(name, "ggml_backend_cuda_moe_staging_h2d") == 0) {
+        return (void *)ggml_backend_cuda_moe_staging_h2d;
+    }
+    if (strcmp(name, "ggml_backend_cuda_moe_staging_d2d") == 0) {
+        return (void *)ggml_backend_cuda_moe_staging_d2d;
+    }
+    if (strcmp(name, "ggml_backend_cuda_moe_staging_h2d_ranges") == 0) {
+        return (void *)ggml_backend_cuda_moe_staging_h2d_ranges;
+    }
+    if (strcmp(name, "ggml_backend_cuda_moe_staging_d2d_ranges") == 0) {
+        return (void *)ggml_backend_cuda_moe_staging_d2d_ranges;
     }
     return nullptr;
 }

--- a/ml/backend/ggml/ggml_test.go
+++ b/ml/backend/ggml/ggml_test.go
@@ -1,9 +1,11 @@
 package ggml
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -37,6 +39,63 @@ func setup(tb testing.TB) ml.Context {
 	})
 
 	return ctx
+}
+
+func TestMoEExpertTensorDetection(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{name: "blk.0.ffn_gate_exps.weight", want: true},
+		{name: "blk.0.ffn_up_exps", want: true},
+		{name: "blk.0.ffn_down_exps.bias", want: true},
+		{name: "blk.0.ffn_down_exps.scale", want: true},
+		{name: "blk.0.ffn_gate_up_exps.weight", want: true},
+		{name: "blk.0.ffn_gate_up_exps.bias", want: true},
+		{name: "blk.0.ffn_gate_chexps.weight", want: true},
+		{name: "blk.0.ffn_up_chexps", want: true},
+		{name: "blk.0.ffn_down_ch_exps.weight", want: true},
+		{name: "blk.0.ffn_gate_inp.weight"},
+		{name: "blk.0.ffn_up.weight"},
+		{name: "token_embd.weight"},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isMoEExpertTensor(tt.name); got != tt.want {
+				t.Fatalf("isMoEExpertTensor(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewMoESplitRejectsModelsWithoutDetectedExperts(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "*.gguf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	tensors := []*ggml.Tensor{{
+		Name:     "blk.0.ffn_up.weight",
+		Shape:    []uint64{1},
+		WriterTo: bytes.NewReader(make([]byte, 4)),
+	}}
+	if err := ggml.WriteGGUF(f, ggml.KV{
+		"general.architecture": "test",
+		"block_count":          uint32(1),
+	}, tensors); err != nil {
+		t.Fatal(err)
+	}
+
+	b, err := New(f.Name(), ml.BackendParams{MoESplit: true})
+	if err == nil {
+		b.Close()
+		t.Fatal("New succeeded, want MoE detection error")
+	}
+	if !strings.Contains(err.Error(), "no MoE expert tensors were detected") {
+		t.Fatalf("New error = %v, want missing MoE expert tensor error", err)
+	}
 }
 
 func TestInferShape(t *testing.T) {

--- a/ml/device.go
+++ b/ml/device.go
@@ -153,10 +153,14 @@ type DeviceMemory struct {
 	// Weights is the per-layer memory needed for the model weights.
 	Weights []uint64
 
-	// MoEWeights is the per-layer memory for MoE expert tensors only
-	// (matching \.ffn_(up|down|gate)_(ch_)?exps$). Always a subset of
-	// Weights. Zero for non-MoE models or layers with MoE fully on GPU.
+	// MoEWeights is the per-layer memory for MoE expert tensors only.
+	// Always a subset of Weights. Zero for non-MoE models or layers with
+	// MoE fully on GPU.
 	MoEWeights []uint64
+
+	// MoEMaxTensor is the largest single MoE expert tensor in each layer.
+	// It is accounting metadata only and is not included in Size.
+	MoEMaxTensor []uint64
 
 	// Cache is the per-layer memory needed for the KV cache.
 	Cache []uint64

--- a/ml/device.go
+++ b/ml/device.go
@@ -153,6 +153,11 @@ type DeviceMemory struct {
 	// Weights is the per-layer memory needed for the model weights.
 	Weights []uint64
 
+	// MoEWeights is the per-layer memory for MoE expert tensors only
+	// (matching \.ffn_(up|down|gate)_(ch_)?exps$). Always a subset of
+	// Weights. Zero for non-MoE models or layers with MoE fully on GPU.
+	MoEWeights []uint64
+
 	// Cache is the per-layer memory needed for the KV cache.
 	Cache []uint64
 

--- a/runner/ollamarunner/runner.go
+++ b/runner/ollamarunner/runner.go
@@ -1316,6 +1316,7 @@ func (s *Server) load(w http.ResponseWriter, r *http.Request) {
 			AllocMemory:    req.Operation != llm.LoadOperationFit,
 			NumThreads:     req.NumThreads,
 			GPULayers:      req.GPULayers,
+			MoESplit:       req.MoESplit,
 			MoEGPULayers:   req.MoEGPULayers,
 			FlashAttention: req.FlashAttention,
 		}

--- a/runner/ollamarunner/runner.go
+++ b/runner/ollamarunner/runner.go
@@ -1316,6 +1316,7 @@ func (s *Server) load(w http.ResponseWriter, r *http.Request) {
 			AllocMemory:    req.Operation != llm.LoadOperationFit,
 			NumThreads:     req.NumThreads,
 			GPULayers:      req.GPULayers,
+			MoEGPULayers:   req.MoEGPULayers,
 			FlashAttention: req.FlashAttention,
 		}
 


### PR DESCRIPTION
### Summary

This builds on #15988 and addresses the request in #11772 by adding exact controls for MoE expert placement so dense weights, KV cache, and expert weights can be budgeted separately.

The main user-facing control is `OLLAMA_MOE_CPU_LAYERS`, which keeps the expert weights for the first N model layers on CPU. This mirrors the practical use of `llama.cpp --n-cpu-moe` while keeping the default Ollama behaviour unchanged.

### What changed

- Adds `OLLAMA_MOE_CPU_LAYERS` for exact first-N expert CPU offload.
- Keeps `OLLAMA_MOE_GPU_LAYERS=-1` automatic sizing available for users who want Ollama to choose the GPU expert-layer tail from free VRAM.
- Fails forced MoE split settings clearly when no expert tensors are detected.
- Rejects multi-GPU MoE split for now, because dense placement and staging reserve need per-device accounting before that is safe upstream.
- Tracks the largest single expert tensor for prefetch staging reserve instead of reserving from a whole MoE layer total.
- Routes the runner prefetch gate through an internal `OLLAMA_MOE_PREFETCH_ENABLED` flag so `OLLAMA_MOE_PREFETCH=false` cannot enable prefetch by environment-variable presence.
- Reuses the CUDA prefetch stream across decode steps and caches the scheduler prefetch function lookup.
- Extends expert tensor detection for `gate_up`, `chexps`, `ch_exps`, `.bias`, and `.scale`.
- Adds tests for exact CPU and GPU layer identity, invalid override bounds, no-expert forced splits, multi-GPU rejection, prefetch reserve sizing, tensor detection, and runner prefetch env gating.

### Compatibility

All new environment variables default to off, so existing model loading behaviour is unchanged unless a user explicitly enables MoE expert split controls.

No public API fields are changed. The added load fields are on the internal Ollama to runner boundary.

No new dependencies are added.

### Testing

```bash
/usr/local/go/bin/go test -count=1 ./envconfig ./llm ./runner/ollamarunner ./ml/backend/ggml ./ml
/usr/local/go/bin/go build -o ./ollama .
make -f Makefile.sync clean apply-patches
```

The llama.cpp patch workflow was checked by comparing the generated `llama/vendor` files back to the checked-in Ollama sources after applying the patch series.

### Local benchmark

Environment:

- NVIDIA GeForce RTX 3060, 12288 MiB, driver 596.36
- Exact GGUF: `unsloth/Qwen3.6-35B-A3B-GGUF`, `Qwen3.6-35B-A3B-UD-IQ3_XXS.gguf`, snapshot `a483e9e6cbd595906af30beda3187c2663a1118c`
- Ollama settings: `OLLAMA_FLASH_ATTENTION=1`, `OLLAMA_KV_CACHE_TYPE=q8_0`, `num_ctx` fixed per run, `num_predict=128`
- llama.cpp comparison settings: `--flash-attn on`, `--cache-type-k q8_0`, `--cache-type-v q8_0`, `--n-cpu-moe` set to the same intended split where it fits

The main benchmark claim for this PR is that exact MoE split substantially improves Ollama's current no-split path on this constrained 12 GB card:

| Runtime | Context | Split | Decode throughput |
| --- | ---: | --- | ---: |
| Ollama, no MoE split | 32k | none | 10.80 tok/s |
| Ollama, this PR | 32k | automatic MoE split, pinned and prefetch | 21.99 tok/s |
| Ollama, this PR | 64k | automatic MoE split, pinned and prefetch | 19.79 tok/s |
| Ollama, this PR | 128k | automatic MoE split, pinned and prefetch | 17.31 tok/s |

For comparison, bare llama.cpp with the same GGUF and `--n-cpu-moe` is still faster on this machine:

| Runtime | Context | Split | Decode throughput |
| --- | ---: | --- | ---: |
| llama.cpp | 4k | `--n-cpu-moe 12` | 46.50 tok/s |
| llama.cpp | 32k | `--n-cpu-moe 12` | 46.43 tok/s |
| llama.cpp | 64k | `--n-cpu-moe 12` | 46.82 tok/s |
| llama.cpp | 128k | `--n-cpu-moe 16` | 38.30 tok/s |

The 4k Ollama follow-up is listed separately because the clean PR branch currently fails to load the exact 28 GPU expert layer / 12 CPU expert layer layout on this 12 GB card:

| Runtime | Context | Split | Result |
| --- | ---: | --- | --- |
| Ollama, this PR | 4k | exact 28 GPU / 12 CPU expert split | did not fit, with about 1.6 GiB reported cache reserve |
| Ollama, cache-bounded checkpoint follow-up branch | 4k | exact 28 GPU / 12 CPU expert split | 23.26 tok/s, with about 293.8 MiB reported cache reserve |
| Ollama, no-checkpoint control experiment | 4k | exact 28 GPU / 12 CPU expert split | 23.74 tok/s, with about 105 MiB reported cache reserve |

The cache-bounded checkpoint follow-up is not part of this PR. It isolates why 4k exact split does not currently fit in Ollama while the same split fits in llama.cpp. It is a memory and fit improvement, not a meaningful decode throughput improvement.

A follow-up parity check found two likely separate bottlenecks outside the expert placement controls in this PR:

- Ollama currently reserves much more cache memory for this qwen35moe/Qwen3Next model than llama.cpp. At 4k, the current branch reports about 1.6 GiB of cache and cannot fit the exact 28 GPU expert layer / 12 CPU expert layer layout on this 12 GB card, even though llama.cpp fits it. A follow-up branch that bounds recurrent checkpoint reserve by context capacity brought the Ollama cache estimate down to about 293.8 MiB at 4k and allowed the exact split to load. A no-checkpoint control reduced it further to about 105 MiB.
- Even with the cache reserve reduced enough to fit the exact 4k split, Ollama reached about 23.26 tok/s, not the 46.50 tok/s seen in llama.cpp. The remaining gap appears to be in the qwen35moe/Qwen3Next execution path, not in the MoE layer placement controls alone. In particular, current llama.cpp uses fused Gated Delta Net support for this model, while this Ollama path still builds a larger unfused graph.

Prefetch was neutral in these measurements, so the performance claim is the exact MoE split and memory accounting rather than prefetch alone.

### Known limitation

MoE split is currently single-GPU only. That is deliberate for the first upstreamable version, because multi-GPU dense placement and staging reserve need precise per-device accounting.

This PR does not claim llama.cpp throughput parity for Qwen3.6 35B A3B. It provides the missing exact expert placement controls and makes the Ollama path meaningfully faster than no split, while leaving the recurrent cache reserve and fused Qwen3Next/Gated Delta Net work as separate follow-ups.