### PR TITLE
model: fuse qwen3next gated delta net decode

### DIFF
--- a/llama/patches/0037-ggml-backport-gated-delta-net-op.patch
+++ b/llama/patches/0037-ggml-backport-gated-delta-net-op.patch
@@ -1,0 +1,702 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jayson Espley <jayson@yorkshire3d.co.uk>
+Date: Thu, 14 May 2026 15:47:52 +0100
+Subject: [PATCH] ggml: backport gated delta net op
+
+---
+ ggml/include/ggml.h                    |  10 +
+ ggml/src/ggml-cpu/ggml-cpu.c           |  10 +
+ ggml/src/ggml-cpu/ops.cpp              | 169 +++++++++++++++
+ ggml/src/ggml-cpu/ops.h                |   1 +
+ ggml/src/ggml-cuda/gated_delta_net.cu  | 273 +++++++++++++++++++++++++
+ ggml/src/ggml-cuda/gated_delta_net.cuh |   4 +
+ ggml/src/ggml-cuda/ggml-cuda.cu        |  12 ++
+ ggml/src/ggml.c                        |  64 +++++-
+ 8 files changed, 541 insertions(+), 2 deletions(-)
+ create mode 100644 ggml/src/ggml-cuda/gated_delta_net.cu
+ create mode 100644 ggml/src/ggml-cuda/gated_delta_net.cuh
+
+diff --git a/ggml/include/ggml.h b/ggml/include/ggml.h
+index 20c912d0e..a46734c05 100644
+--- a/ggml/include/ggml.h
++++ b/ggml/include/ggml.h
+@@ -551,6 +551,7 @@ extern "C" {
+         GGML_OP_GATED_LINEAR_ATTN,
+         GGML_OP_RWKV_WKV7,
+         GGML_OP_SOLVE_TRI,
++        GGML_OP_GATED_DELTA_NET,
+
+         GGML_OP_UNARY,
+
+@@ -2460,6 +2461,15 @@ extern "C" {
+         bool                  lower,
+         bool                  uni);
+
++    GGML_API struct ggml_tensor * ggml_gated_delta_net(
++            struct ggml_context * ctx,
++            struct ggml_tensor  * q,
++            struct ggml_tensor  * k,
++            struct ggml_tensor  * v,
++            struct ggml_tensor  * g,
++            struct ggml_tensor  * beta,
++            struct ggml_tensor  * state);
++
+     // custom operators
+
+     typedef void (*ggml_custom1_op_t)(struct ggml_tensor * dst , const struct ggml_tensor * a, int ith, int nth, void * userdata);
+diff --git a/ggml/src/ggml-cpu/ggml-cpu.c b/ggml/src/ggml-cpu/ggml-cpu.c
+index 8d4851312..b539ae448 100644
+--- a/ggml/src/ggml-cpu/ggml-cpu.c
++++ b/ggml/src/ggml-cpu/ggml-cpu.c
+@@ -2020,6 +2020,10 @@ static void ggml_compute_forward(struct ggml_compute_params * params, struct ggm
+             {
+                 ggml_compute_forward_solve_tri(params, tensor);
+             } break;
++        case GGML_OP_GATED_DELTA_NET:
++            {
++                ggml_compute_forward_gated_delta_net(params, tensor);
++            } break;
+         case GGML_OP_MAP_CUSTOM1:
+             {
+                 ggml_compute_forward_map_custom1(params, tensor);
+@@ -2199,6 +2203,7 @@ static int ggml_get_n_tasks(struct ggml_tensor * node, int n_threads) {
+             } break;
+         case GGML_OP_COUNT_EQUAL:
+         case GGML_OP_SOLVE_TRI:
++        case GGML_OP_GATED_DELTA_NET:
+             {
+                 n_tasks = n_threads;
+             } break;
+@@ -2894,6 +2899,11 @@ struct ggml_cplan ggml_graph_plan(
+                     {
+                         cur = ggml_type_size(node->type)*(n_tasks + node->src[0]->ne[0]*n_tasks);
+                     } break;
++                case GGML_OP_GATED_DELTA_NET:
++                    {
++                        const int64_t S_v = node->src[2]->ne[0];
++                        cur = S_v * sizeof(float) * n_tasks;
++                    } break;
+                 case GGML_OP_COUNT:
+                     {
+                         GGML_ABORT("fatal error");
+diff --git a/ggml/src/ggml-cpu/ops.cpp b/ggml/src/ggml-cpu/ops.cpp
+index f4aae5332..dec18edad 100644
+--- a/ggml/src/ggml-cpu/ops.cpp
++++ b/ggml/src/ggml-cpu/ops.cpp
+@@ -9913,6 +9913,175 @@ void ggml_compute_forward_solve_tri(const struct ggml_compute_params * params, s
+     }
+ }
+
++// ggml_compute_forward_gated_delta_net
++static void ggml_compute_forward_gated_delta_net_one_chunk(
++    const ggml_compute_params * params,
++    ggml_tensor * dst,
++    int64_t ir0,
++    int64_t ir1) {
++
++    ggml_tensor * src_q     = dst->src[0];
++    ggml_tensor * src_k     = dst->src[1];
++    ggml_tensor * src_v     = dst->src[2];
++    ggml_tensor * src_g     = dst->src[3];
++    ggml_tensor * src_beta  = dst->src[4];
++    ggml_tensor * src_state = dst->src[5];
++
++    const int64_t S_v      = src_v->ne[0];
++    const int64_t H        = src_v->ne[1];
++    const int64_t n_tokens = src_v->ne[2];
++    const int64_t n_seqs   = src_v->ne[3];
++
++    GGML_ASSERT(ggml_is_contiguous_rows(src_q));
++    GGML_ASSERT(ggml_is_contiguous_rows(src_k));
++    GGML_ASSERT(ggml_is_contiguous_rows(src_v));
++    GGML_ASSERT(ggml_is_contiguous(src_g));
++    GGML_ASSERT(ggml_is_contiguous(src_beta));
++    GGML_ASSERT(ggml_is_contiguous(src_state));
++
++    GGML_ASSERT(src_g->ne[0] == 1 || src_g->ne[0] == S_v);
++    GGML_ASSERT(src_beta->ne[0] == 1);
++
++    GGML_TENSOR_LOCALS(int64_t, neq, src_q, ne);
++    GGML_TENSOR_LOCALS(size_t,  nbq, src_q, nb);
++    GGML_TENSOR_LOCALS(int64_t, nek, src_k, ne);
++    GGML_TENSOR_LOCALS(size_t,  nbk, src_k, nb);
++    GGML_TENSOR_LOCALS(size_t,  nbv, src_v, nb);
++    GGML_TENSOR_LOCALS(int64_t, neg, src_g, ne);
++    GGML_TENSOR_LOCALS(size_t,  nbg, src_g, nb);
++    GGML_TENSOR_LOCALS(size_t,  nbb, src_beta, nb);
++
++    const bool kda = (neg0 == S_v);
++
++    const int64_t scratch_per_thread = S_v;
++    const int ith = params->ith;
++
++    float * delta = (float *) params->wdata + ith * scratch_per_thread + CACHE_LINE_SIZE_F32;
++
++    const int64_t attn_score_elems = S_v * H * n_tokens * n_seqs;
++    float * attn_out_base  = (float *) dst->data;
++    float * state_out_base = (float *) dst->data + attn_score_elems;
++
++    const float * state_in_base = (const float *) src_state->data;
++
++    const int64_t rq3 = src_v->ne[3] / neq3;
++    const int64_t rk3 = src_v->ne[3] / nek3;
++
++    const float scale = 1.0f / sqrtf((float) S_v);
++
++    for (int64_t ir = ir0; ir < ir1; ++ir) {
++        const int64_t iv1 = ir % H;
++        const int64_t iv3 = ir / H;
++
++        const int64_t iq1 = iv1 % neq1;
++        const int64_t ik1 = iv1 % nek1;
++
++        const int64_t iq3 = iv3 / rq3;
++        const int64_t ik3 = iv3 / rk3;
++
++        float * s_out = state_out_base + (iv3 * H + iv1) * S_v * S_v;
++
++        const float * s_in = state_in_base + (iv3 * H + iv1) * S_v * S_v;
++        memcpy(s_out, s_in, S_v * S_v * sizeof(float));
++
++        float * attn_data = attn_out_base + (iv3 * n_tokens * H + iv1) * S_v;
++
++        for (int64_t t = 0; t < n_tokens; t++) {
++            const float * q_d = (const float *)((const char *) src_q->data + iq3 * nbq3 + t * nbq2 + iq1 * nbq1);
++            const float * k_d = (const float *)((const char *) src_k->data + ik3 * nbk3 + t * nbk2 + ik1 * nbk1);
++            const float * v_d = (const float *)((const char *) src_v->data + iv3 * nbv3 + t * nbv2 + iv1 * nbv1);
++
++            const float beta_val = *(const float *)((const char *) src_beta->data + iv3 * nbb3 + t * nbb2 + iv1 * nbb1);
++            const float * g_d    =  (const float *)((const char *) src_g->data    + iv3 * nbg3 + t * nbg2 + iv1 * nbg1);
++
++            if (kda) {
++                for (int64_t i = 0; i < S_v; ++i) {
++                    delta[i] = expf(g_d[i]);
++                }
++                for (int64_t j = 0; j < S_v; ++j) {
++                    ggml_vec_mul_f32(S_v, &s_out[j * S_v], &s_out[j * S_v], delta);
++                }
++            } else {
++                ggml_vec_scale_f32(S_v * S_v, s_out, expf(g_d[0]));
++            }
++
++            for (int64_t j = 0; j < S_v; ++j) {
++                float sum = 0.0f;
++                ggml_vec_dot_f32(S_v, &sum, 0, &s_out[j * S_v], 0, k_d, 0, 1);
++                delta[j] = (v_d[j] - sum) * beta_val;
++            }
++
++            for (int64_t j = 0; j < S_v; ++j) {
++                ggml_vec_mad_f32(S_v, &s_out[j * S_v], k_d, delta[j]);
++            }
++
++            for (int64_t j = 0; j < S_v; ++j) {
++                float sum = 0.0f;
++                ggml_vec_dot_f32(S_v, &sum, 0, &s_out[j * S_v], 0, q_d, 0, 1);
++                attn_data[j] = sum * scale;
++            }
++
++            attn_data += S_v * H;
++        }
++    }
++}
++
++static void ggml_compute_forward_gated_delta_net_f32(
++        const ggml_compute_params * params,
++        ggml_tensor * dst) {
++
++    ggml_tensor * v = dst->src[2];
++    int64_t nr = v->ne[1] * v->ne[3];
++
++    const bool disable_chunking = ggml_is_numa();
++
++    int nth = params->nth;
++    int ith = params->ith;
++
++    int nth_scaled = nth * 4;
++    int64_t chunk_size = (nr + nth_scaled - 1) / nth_scaled;
++    int64_t nchunk     = (nr + chunk_size - 1) / chunk_size;
++
++    if (nth == 1 || nchunk < nth || disable_chunking) {
++        nchunk = nth;
++    }
++
++    if (ith == 0) {
++        ggml_threadpool_chunk_set(params->threadpool, nth);
++    }
++
++    ggml_barrier(params->threadpool);
++
++    const int64_t dr = (nr + nchunk - 1) / nchunk;
++
++    int current_chunk = ith;
++
++    while (current_chunk < nchunk) {
++        const int64_t ir0 = dr * current_chunk;
++        const int64_t ir1 = MIN(ir0 + dr, nr);
++
++        ggml_compute_forward_gated_delta_net_one_chunk(params, dst, ir0, ir1);
++        current_chunk = ggml_threadpool_chunk_add(params->threadpool, 1);
++    }
++}
++
++void ggml_compute_forward_gated_delta_net(
++        const ggml_compute_params * params,
++        ggml_tensor * dst) {
++    const ggml_tensor * src0 = dst->src[0];
++
++    switch (src0->type) {
++        case GGML_TYPE_F32:
++            {
++                ggml_compute_forward_gated_delta_net_f32(params, dst);
++            } break;
++        default:
++            {
++                GGML_ABORT("fatal error");
++            }
++    }
++}
++
+ // ggml_compute_forward_rwkv_wkv7
+
+ static void ggml_compute_forward_rwkv_wkv7_f32(
+diff --git a/ggml/src/ggml-cpu/ops.h b/ggml/src/ggml-cpu/ops.h
+index 0fdfee797..2e374aa07 100644
+--- a/ggml/src/ggml-cpu/ops.h
++++ b/ggml/src/ggml-cpu/ops.h
+@@ -101,6 +101,7 @@ void ggml_compute_forward_add_rel_pos(const struct ggml_compute_params * params,
+ void ggml_compute_forward_rwkv_wkv6(const struct ggml_compute_params * params, struct ggml_tensor * dst);
+ void ggml_compute_forward_rwkv_wkv7(const struct ggml_compute_params * params, struct ggml_tensor * dst);
+ void ggml_compute_forward_solve_tri(const struct ggml_compute_params * params, struct ggml_tensor * dst);
++void ggml_compute_forward_gated_delta_net(const struct ggml_compute_params * params, struct ggml_tensor * dst);
+ void ggml_compute_forward_gla(const struct ggml_compute_params * params, struct ggml_tensor * dst);
+ void ggml_compute_forward_map_custom1(const struct ggml_compute_params * params, struct ggml_tensor * dst);
+ void ggml_compute_forward_map_custom2(const struct ggml_compute_params * params, struct ggml_tensor * dst);
+diff --git a/ggml/src/ggml-cuda/gated_delta_net.cu b/ggml/src/ggml-cuda/gated_delta_net.cu
+new file mode 100644
+index 000000000..6b44bec73
+--- /dev/null
++++ b/ggml/src/ggml-cuda/gated_delta_net.cu
+@@ -0,0 +1,273 @@
++#include "gated_delta_net.cuh"
++
++template <int S_v, bool KDA>
++__global__ void __launch_bounds__((ggml_cuda_get_physical_warp_size() < S_v ? ggml_cuda_get_physical_warp_size() : S_v) * 4, 2)
++gated_delta_net_cuda(const float * q,
++                                     const float * k,
++                                     const float * v,
++                                     const float * g,
++                                     const float * beta,
++                                     const float * curr_state,
++                                     float *       dst,
++                                     int64_t       H,
++                                     int64_t       n_tokens,
++                                     int64_t       n_seqs,
++                                     int64_t       sq1,
++                                     int64_t       sq2,
++                                     int64_t       sq3,
++                                     int64_t       sv1,
++                                     int64_t       sv2,
++                                     int64_t       sv3,
++                                     int64_t       sb1,
++                                     int64_t       sb2,
++                                     int64_t       sb3,
++                                     const uint3   neqk1_magic,
++                                     const uint3   rq3_magic,
++                                     float         scale) {
++    const uint32_t h_idx    = blockIdx.x;
++    const uint32_t sequence = blockIdx.y;
++    // each warp owns one column, using warp-level primitives to reduce across rows
++    const int      lane     = threadIdx.x;
++    const int      col      = blockIdx.z * blockDim.y + threadIdx.y;
++
++    const uint32_t iq1 = fastmodulo(h_idx, neqk1_magic);
++    const uint32_t iq3 = fastdiv(sequence, rq3_magic);
++
++    const int64_t attn_score_elems = S_v * H * n_tokens * n_seqs;
++    float *       attn_data        = dst;
++    float *       state            = dst + attn_score_elems;
++
++    const int64_t state_offset = (sequence * H + h_idx) * S_v * S_v;
++    state += state_offset;
++    curr_state += state_offset + col * S_v;
++    attn_data += (sequence * n_tokens * H + h_idx) * S_v;
++
++    constexpr int warp_size = ggml_cuda_get_physical_warp_size() < S_v ? ggml_cuda_get_physical_warp_size() : S_v;
++    static_assert(S_v % warp_size == 0, "S_v must be a multiple of warp_size");
++    constexpr int rows_per_lane = (S_v + warp_size - 1) / warp_size;
++    float         s_shard[rows_per_lane];
++    // state is stored transposed: M[col][i] = S[i][col], row col is contiguous
++
++#pragma unroll
++    for (int r = 0; r < rows_per_lane; r++) {
++        const int i = r * warp_size + lane;
++        s_shard[r]  = curr_state[i];
++    }
++
++    for (int t = 0; t < n_tokens; t++) {
++        const float * q_t = q + iq3 * sq3 + t * sq2 + iq1 * sq1;
++        const float * k_t = k + iq3 * sq3 + t * sq2 + iq1 * sq1;
++        const float * v_t = v + sequence * sv3 + t * sv2 + h_idx * sv1;
++
++        const int64_t gb_offset = sequence * sb3 + t * sb2 + h_idx * sb1;
++        const float * beta_t = beta + gb_offset;
++        const float * g_t    = g    + gb_offset * (KDA ? S_v : 1);
++
++        const float beta_val = *beta_t;
++
++        // Cache k and q in registers
++        float k_reg[rows_per_lane];
++        float q_reg[rows_per_lane];
++#pragma unroll
++        for (int r = 0; r < rows_per_lane; r++) {
++            const int i = r * warp_size + lane;
++            k_reg[r] = k_t[i];
++            q_reg[r] = q_t[i];
++        }
++
++        if constexpr (!KDA) {
++            const float g_val = expf(*g_t);
++
++            // kv[col] = (S^T @ k)[col] = sum_i S[i][col] * k[i]
++            float kv_shard = 0.0f;
++#pragma unroll
++            for (int r = 0; r < rows_per_lane; r++) {
++                kv_shard += s_shard[r] * k_reg[r];
++            }
++            float kv_col = warp_reduce_sum<warp_size>(kv_shard);
++
++            // delta[col] = (v[col] - g * kv[col]) * beta
++            float delta_col = (v_t[col] - g_val * kv_col) * beta_val;
++
++            // fused: S[i][col] = g * S[i][col] + k[i] * delta[col]
++            // attn[col] = (S^T @ q)[col] = sum_i S[i][col] * q[i]
++            float attn_partial = 0.0f;
++#pragma unroll
++            for (int r = 0; r < rows_per_lane; r++) {
++                s_shard[r]  = g_val * s_shard[r] + k_reg[r] * delta_col;
++                attn_partial += s_shard[r] * q_reg[r];
++            }
++
++            float attn_col = warp_reduce_sum<warp_size>(attn_partial);
++
++            if (lane == 0) {
++                attn_data[col] = attn_col * scale;
++            }
++        } else {
++            // kv[col] = sum_i g[i] * S[i][col] * k[i]
++            float kv_shard = 0.0f;
++#pragma unroll
++            for (int r = 0; r < rows_per_lane; r++) {
++                const int i = r * warp_size + lane;
++                kv_shard += expf(g_t[i]) * s_shard[r] * k_reg[r];
++            }
++
++            float kv_col = warp_reduce_sum<warp_size>(kv_shard);
++
++            // delta[col] = (v[col] - kv[col]) * beta
++            float delta_col = (v_t[col] - kv_col) * beta_val;
++
++            // fused: S[i][col] = g[i] * S[i][col] + k[i] * delta[col]
++            // attn[col] = (S^T @ q)[col] = sum_i S[i][col] * q[i]
++            float attn_partial = 0.0f;
++#pragma unroll
++            for (int r = 0; r < rows_per_lane; r++) {
++                const int i = r * warp_size + lane;
++                s_shard[r]  = expf(g_t[i]) * s_shard[r] + k_reg[r] * delta_col;
++                attn_partial += s_shard[r] * q_reg[r];
++            }
++
++            float attn_col = warp_reduce_sum<warp_size>(attn_partial);
++
++            if (lane == 0) {
++                attn_data[col] = attn_col * scale;
++            }
++        }
++
++        attn_data += S_v * H;
++    }
++
++    // Write state back to global memory (transposed layout)
++#pragma unroll
++    for (int r = 0; r < rows_per_lane; r++) {
++        const int i          = r * warp_size + lane;
++        state[col * S_v + i] = s_shard[r];
++    }
++}
++
++template <bool KDA>
++static void launch_gated_delta_net(
++        const float * q_d, const float * k_d, const float * v_d,
++        const float * g_d, const float * b_d, const float * s_d,
++        float * dst_d,
++        int64_t S_v,   int64_t H, int64_t n_tokens, int64_t n_seqs,
++        int64_t sq1,   int64_t sq2, int64_t sq3,
++        int64_t sv1,   int64_t sv2, int64_t sv3,
++        int64_t sb1,   int64_t sb2, int64_t sb3,
++        int64_t neqk1, int64_t rq3,
++        float scale, cudaStream_t stream) {
++    //TODO: Add chunked kernel for even faster pre-fill
++    const int warp_size = ggml_cuda_info().devices[ggml_cuda_get_device()].warp_size;
++    const int num_warps = 4;
++    dim3      grid_dims(H, n_seqs, (S_v + num_warps - 1) / num_warps);
++    dim3      block_dims(warp_size <= S_v ? warp_size : S_v, num_warps, 1);
++
++    const uint3 neqk1_magic = init_fastdiv_values(neqk1);
++    const uint3 rq3_magic   = init_fastdiv_values(rq3);
++
++    int cc = ggml_cuda_info().devices[ggml_cuda_get_device()].cc;
++
++    switch (S_v) {
++        case 16:
++            gated_delta_net_cuda<16, KDA><<<grid_dims, block_dims, 0, stream>>>(
++                q_d, k_d, v_d, g_d, b_d, s_d, dst_d, H,
++                n_tokens, n_seqs, sq1, sq2, sq3, sv1, sv2, sv3,
++                sb1, sb2, sb3, neqk1_magic, rq3_magic, scale);
++            break;
++        case 32:
++            gated_delta_net_cuda<32, KDA><<<grid_dims, block_dims, 0, stream>>>(
++                q_d, k_d, v_d, g_d, b_d, s_d, dst_d, H,
++                n_tokens, n_seqs, sq1, sq2, sq3, sv1, sv2, sv3,
++                sb1, sb2, sb3, neqk1_magic, rq3_magic, scale);
++            break;
++        case 64: {
++            gated_delta_net_cuda<64, KDA><<<grid_dims, block_dims, 0, stream>>>(
++                q_d, k_d, v_d, g_d, b_d, s_d, dst_d, H,
++                n_tokens, n_seqs, sq1, sq2, sq3, sv1, sv2, sv3,
++                sb1, sb2, sb3, neqk1_magic, rq3_magic, scale);
++            break;
++        }
++        case 128: {
++            gated_delta_net_cuda<128, KDA><<<grid_dims, block_dims, 0, stream>>>(
++                q_d, k_d, v_d, g_d, b_d, s_d, dst_d, H,
++                n_tokens, n_seqs, sq1, sq2, sq3, sv1, sv2, sv3,
++                sb1, sb2, sb3, neqk1_magic, rq3_magic, scale);
++            break;
++        }
++        default:
++            GGML_ABORT("fatal error");
++            break;
++    }
++}
++
++void ggml_cuda_op_gated_delta_net(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
++    ggml_tensor * src_q     = dst->src[0];
++    ggml_tensor * src_k     = dst->src[1];
++    ggml_tensor * src_v     = dst->src[2];
++    ggml_tensor * src_g     = dst->src[3];
++    ggml_tensor * src_beta  = dst->src[4];
++    ggml_tensor * src_state = dst->src[5];
++
++    GGML_TENSOR_LOCALS(int64_t, neq, src_q, ne);
++    GGML_TENSOR_LOCALS(size_t , nbq, src_q, nb);
++    GGML_TENSOR_LOCALS(int64_t, nek, src_k, ne);
++    GGML_TENSOR_LOCALS(size_t , nbk, src_k, nb);
++    GGML_TENSOR_LOCALS(int64_t, nev, src_v, ne);
++    GGML_TENSOR_LOCALS(size_t,  nbv, src_v, nb);
++    GGML_TENSOR_LOCALS(size_t,  nbb, src_beta, nb);
++
++    const int64_t S_v      = nev0;
++    const int64_t H        = nev1;
++    const int64_t n_tokens = nev2;
++    const int64_t n_seqs   = nev3;
++
++    const bool kda = (src_g->ne[0] == S_v);
++
++    GGML_ASSERT(neq1 == nek1);
++    const int64_t neqk1 = neq1;
++
++    const int64_t rq3 = nev3 / neq3;
++
++    const float * q_d = (const float *) src_q->data;
++    const float * k_d = (const float *) src_k->data;
++    const float * v_d = (const float *) src_v->data;
++    const float * g_d = (const float *) src_g->data;
++    const float * b_d = (const float *) src_beta->data;
++
++    const float * s_d   = (const float *) src_state->data;
++    float *       dst_d = (float *) dst->data;
++
++    GGML_ASSERT(ggml_is_contiguous_rows(src_q));
++    GGML_ASSERT(ggml_is_contiguous_rows(src_k));
++    GGML_ASSERT(ggml_is_contiguous_rows(src_v));
++    GGML_ASSERT(ggml_are_same_stride(src_q, src_k));
++    GGML_ASSERT(src_g->ne[0] == 1 || kda);
++    GGML_ASSERT(ggml_is_contiguous(src_g));
++    GGML_ASSERT(ggml_is_contiguous(src_beta));
++    GGML_ASSERT(ggml_is_contiguous(src_state));
++
++    // strides in floats (beta strides used for both g and beta offset computation)
++    const int64_t sq1 = nbq1 / sizeof(float);
++    const int64_t sq2 = nbq2 / sizeof(float);
++    const int64_t sq3 = nbq3 / sizeof(float);
++    const int64_t sv1 = nbv1 / sizeof(float);
++    const int64_t sv2 = nbv2 / sizeof(float);
++    const int64_t sv3 = nbv3 / sizeof(float);
++    const int64_t sb1 = nbb1 / sizeof(float);
++    const int64_t sb2 = nbb2 / sizeof(float);
++    const int64_t sb3 = nbb3 / sizeof(float);
++
++    const float scale = 1.0f / sqrtf((float) S_v);
++
++    cudaStream_t stream = ctx.stream();
++
++    if (kda) {
++        launch_gated_delta_net<true>(q_d, k_d, v_d, g_d, b_d, s_d, dst_d,
++            S_v, H, n_tokens, n_seqs, sq1, sq2, sq3, sv1, sv2, sv3,
++            sb1, sb2, sb3, neqk1, rq3, scale, stream);
++    } else {
++        launch_gated_delta_net<false>(q_d, k_d, v_d, g_d, b_d, s_d, dst_d,
++            S_v, H, n_tokens, n_seqs, sq1, sq2, sq3, sv1, sv2, sv3,
++            sb1, sb2, sb3, neqk1, rq3, scale, stream);
++    }
++}
+diff --git a/ggml/src/ggml-cuda/gated_delta_net.cuh b/ggml/src/ggml-cuda/gated_delta_net.cuh
+new file mode 100644
+index 000000000..7375e81c0
+--- /dev/null
++++ b/ggml/src/ggml-cuda/gated_delta_net.cuh
+@@ -0,0 +1,4 @@
++#include "common.cuh"
++#include "ggml.h"
++
++void ggml_cuda_op_gated_delta_net(ggml_backend_cuda_context & ctx, ggml_tensor * dst);
+diff --git a/ggml/src/ggml-cuda/ggml-cuda.cu b/ggml/src/ggml-cuda/ggml-cuda.cu
+index d2bf5d0dc..ebce0b77d 100644
+--- a/ggml/src/ggml-cuda/ggml-cuda.cu
++++ b/ggml/src/ggml-cuda/ggml-cuda.cu
+@@ -58,6 +58,7 @@
+ #include "ggml-cuda/tri.cuh"
+ #include "ggml-cuda/cumsum.cuh"
+ #include "ggml-cuda/fill.cuh"
++#include "ggml-cuda/gated_delta_net.cuh"
+ #include "ggml.h"
+
+ #include <algorithm>
+@@ -2869,6 +2870,9 @@ static bool ggml_cuda_compute_forward(ggml_backend_cuda_context & ctx, struct gg
+         case GGML_OP_GATED_LINEAR_ATTN:
+             ggml_cuda_op_gated_linear_attn(ctx, dst);
+             break;
++        case GGML_OP_GATED_DELTA_NET:
++            ggml_cuda_op_gated_delta_net(ctx, dst);
++            break;
+         case GGML_OP_RWKV_WKV7:
+             ggml_cuda_op_rwkv_wkv7(ctx, dst);
+             break;
+@@ -4914,6 +4918,14 @@ static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const g
+         case GGML_OP_GATED_LINEAR_ATTN:
+         case GGML_OP_RWKV_WKV7:
+             return true;
++        case GGML_OP_GATED_DELTA_NET: {
++#ifdef GGML_USE_MUSA
++            return false;
++#else
++            const int64_t S_v = op->src[2]->ne[0];
++            return S_v == 16 || S_v == 32 || S_v == 64 || S_v == 128;
++#endif // GGML_USE_MUSA
++        }
+         case GGML_OP_FLASH_ATTN_EXT:
+             return ggml_cuda_flash_attn_ext_supported(dev_ctx->device, op);
+         case GGML_OP_CROSS_ENTROPY_LOSS:
+diff --git a/ggml/src/ggml.c b/ggml/src/ggml.c
+index c9242a15a..62ce119a0 100644
+--- a/ggml/src/ggml.c
++++ b/ggml/src/ggml.c
+@@ -1033,6 +1033,7 @@ static const char * GGML_OP_NAME[GGML_OP_COUNT] = {
+     "GATED_LINEAR_ATTN",
+     "RWKV_WKV7",
+     "SOLVE_TRI",
++    "GATED_DELTA_NET",
+
+     "UNARY",
+
+@@ -1050,7 +1051,7 @@ static const char * GGML_OP_NAME[GGML_OP_COUNT] = {
+     "GLU",
+ };
+
+-static_assert(GGML_OP_COUNT == 95, "GGML_OP_COUNT != 95");
++static_assert(GGML_OP_COUNT == 96, "GGML_OP_COUNT != 96");
+
+ static const char * GGML_OP_SYMBOL[GGML_OP_COUNT] = {
+     "none",
+@@ -1142,6 +1143,7 @@ static const char * GGML_OP_SYMBOL[GGML_OP_COUNT] = {
+     "gated_linear_attn(k, v, q, gate, s)",
+     "rwkv_wkv7(r, w, k, v, a, b, s)",
+     "A X = B, A triangular, solve X",
++    "gated_delta_net(q, k, v, g, beta, s)",
+
+     "unary(x)",
+
+@@ -1159,7 +1161,7 @@ static const char * GGML_OP_SYMBOL[GGML_OP_COUNT] = {
+     "glu(x)",
+ };
+
+-static_assert(GGML_OP_COUNT == 95, "GGML_OP_COUNT != 95");
++static_assert(GGML_OP_COUNT == 96, "GGML_OP_COUNT != 96");
+
+ static_assert(GGML_OP_POOL_COUNT == 2, "GGML_OP_POOL_COUNT != 2");
+
+@@ -6098,6 +6100,64 @@ struct ggml_tensor * ggml_solve_tri(
+     return result;
+ }
+
++// ggml_gated_delta_net
++
++struct ggml_tensor * ggml_gated_delta_net(
++        struct ggml_context * ctx,
++        struct ggml_tensor  * q,
++        struct ggml_tensor  * k,
++        struct ggml_tensor  * v,
++        struct ggml_tensor  * g,
++        struct ggml_tensor  * beta,
++        struct ggml_tensor  * state) {
++    GGML_ASSERT(ggml_is_contiguous_rows(q));
++    GGML_ASSERT(ggml_is_contiguous_rows(k));
++    GGML_ASSERT(ggml_is_contiguous_rows(v));
++    GGML_ASSERT(ggml_is_contiguous(g));
++    GGML_ASSERT(ggml_is_contiguous(beta));
++    GGML_ASSERT(ggml_is_contiguous(state));
++
++    GGML_ASSERT(q->type == GGML_TYPE_F32);
++    GGML_ASSERT(k->type == GGML_TYPE_F32);
++    GGML_ASSERT(v->type == GGML_TYPE_F32);
++    GGML_ASSERT(g->type == GGML_TYPE_F32);
++    GGML_ASSERT(beta->type == GGML_TYPE_F32);
++    GGML_ASSERT(state->type == GGML_TYPE_F32);
++
++    const int64_t S_k      = q->ne[0];
++    const int64_t H_k      = q->ne[1];
++    const int64_t n_tokens = q->ne[2];
++    const int64_t n_seqs   = q->ne[3];
++
++    const int64_t S_v = v->ne[0];
++    const int64_t H_v = v->ne[1];
++
++    GGML_ASSERT(S_k == S_v);
++    GGML_ASSERT(H_v % H_k == 0);
++
++    GGML_ASSERT(q->ne[0] == S_k && q->ne[1] == H_k && q->ne[2] == n_tokens && q->ne[3] == n_seqs);
++    GGML_ASSERT(k->ne[0] == S_k && k->ne[1] == H_k && k->ne[2] == n_tokens && k->ne[3] == n_seqs);
++    GGML_ASSERT(v->ne[0] == S_v && v->ne[1] == H_v && v->ne[2] == n_tokens && v->ne[3] == n_seqs);
++
++    GGML_ASSERT(g->ne[0] == 1 || g->ne[0] == S_v);
++    GGML_ASSERT(                 g->ne[1] == H_v && g->ne[2] == n_tokens && g->ne[3] == n_seqs);
++    GGML_ASSERT(beta->ne[0] == 1 && beta->ne[1] == H_v && beta->ne[2] == n_tokens && beta->ne[3] == n_seqs);
++    GGML_ASSERT(state->ne[0] == S_v && state->ne[1] == S_v && state->ne[2] == H_v && state->ne[3] == n_seqs);
++
++    const int64_t ne[4] = { S_v * H_v, n_tokens * n_seqs + S_v * n_seqs, 1, 1 };
++    struct ggml_tensor * result = ggml_new_tensor(ctx, GGML_TYPE_F32, 4, ne);
++
++    result->op     = GGML_OP_GATED_DELTA_NET;
++    result->src[0] = q;
++    result->src[1] = k;
++    result->src[2] = v;
++    result->src[3] = g;
++    result->src[4] = beta;
++    result->src[5] = state;
++
++    return result;
++}
++
+ ////////////////////////////////////////////////////////////////////////////////
+
+ struct ggml_hash_set ggml_hash_set_new(size_t size) {

--- a/ml/backend.go
+++ b/ml/backend.go
@@ -166,6 +166,7 @@ type Tensor interface {
 	Conv1DDW(ctx Context, weight Tensor, s, p, d int) Tensor
 	SSMConv(ctx Context, kernel Tensor) Tensor
 	SSMScan(ctx Context, x, dt, A, B, C, ids Tensor) Tensor
+	GatedDeltaNet(ctx Context, k, v, gate, beta, state Tensor) Tensor
 
 	IM2Col(ctx Context, weight Tensor, s0, s1, p0, p1, d0, d1 int) Tensor
 

--- a/ml/backend/ggml/gated_delta_net_test.go
+++ b/ml/backend/ggml/gated_delta_net_test.go
@@ -1,0 +1,305 @@
+package ggml
+
+import (
+	"bytes"
+	"math"
+	"os"
+	"strconv"
+	"testing"
+
+	fsggml "github.com/ollama/ollama/fs/ggml"
+	"github.com/ollama/ollama/ml"
+)
+
+func TestGatedDeltaNetReferenceScalarGate(t *testing.T) {
+	ctx := setup(t)
+
+	q := ctx.FromFloats([]float32{
+		0.3, -0.4,
+		0.6, 0.2,
+	}, 2, 1, 2, 1)
+	k := ctx.FromFloats([]float32{
+		0.2, 0.7,
+		-0.5, 0.4,
+	}, 2, 1, 2, 1)
+	v := ctx.FromFloats([]float32{
+		1.0, -0.5,
+		0.25, 0.8,
+	}, 2, 1, 2, 1)
+	gate := ctx.FromFloats([]float32{-0.2, 0.1}, 1, 1, 2, 1)
+	beta := ctx.FromFloats([]float32{0.3, 0.6}, 1, 1, 2, 1)
+	state := ctx.FromFloats([]float32{
+		0.1, -0.2,
+		0.05, 0.3,
+	}, 2, 2, 1, 1)
+
+	fused := q.GatedDeltaNet(ctx, k, v, gate, beta, state)
+	fusedOut := gatedDeltaNetOutput(ctx, fused, 2, 1, 2, 1)
+	fusedState := gatedDeltaNetState(ctx, fused, 2, 1, 2, 1)
+	refOut, refState := referenceGatedDeltaNet(ctx, q, k, v, gate, beta, state)
+
+	ctx.Forward(fusedOut, fusedState, refOut, refState).Compute(fusedOut, fusedState, refOut, refState)
+
+	assertCloseFloats(t, "output", refOut.Floats(), fusedOut.Floats(), 1e-5)
+	assertCloseFloats(t, "state", refState.Floats(), fusedState.Floats(), 1e-5)
+}
+
+func TestGatedDeltaNetReferenceMultiHeadBroadcast(t *testing.T) {
+	ctx := setup(t)
+
+	q := ctx.FromFloats([]float32{0.25, -0.6}, 2, 1, 1, 1)
+	k := ctx.FromFloats([]float32{0.4, 0.1}, 2, 1, 1, 1)
+	v := ctx.FromFloats([]float32{
+		0.7, -0.3,
+		-0.2, 0.9,
+	}, 2, 2, 1, 1)
+	gate := ctx.FromFloats([]float32{
+		0.0, -0.4,
+		0.2, -0.1,
+	}, 2, 2, 1, 1)
+	beta := ctx.FromFloats([]float32{0.5, 0.8}, 1, 2, 1, 1)
+	state := ctx.FromFloats([]float32{
+		0.2, -0.1,
+		0.05, 0.3,
+
+		-0.2, 0.4,
+		0.1, -0.05,
+	}, 2, 2, 2, 1)
+
+	fused := q.GatedDeltaNet(ctx, k, v, gate, beta, state)
+	fusedOut := gatedDeltaNetOutput(ctx, fused, 2, 2, 1, 1)
+	fusedState := gatedDeltaNetState(ctx, fused, 2, 2, 1, 1)
+	refOut, refState := referenceGatedDeltaNet(ctx, q, k, v, gate, beta, state)
+
+	ctx.Forward(fusedOut, fusedState, refOut, refState).Compute(fusedOut, fusedState, refOut, refState)
+
+	assertCloseFloats(t, "output", refOut.Floats(), fusedOut.Floats(), 1e-5)
+	assertCloseFloats(t, "state", refState.Floats(), fusedState.Floats(), 1e-5)
+}
+
+func TestGatedDeltaNetCUDAParity(t *testing.T) {
+	device, ok := firstCUDATestDevice(t)
+	if !ok {
+		t.Skip("CUDA device not available")
+	}
+
+	cpuBackend := newGatedDeltaNetTestBackend(t, nil)
+	defer cpuBackend.Close()
+
+	cudaBackend := newGatedDeltaNetTestBackend(t, &device)
+	defer cudaBackend.Close()
+
+	for _, headDim := range []int{16, 32, 64, 128} {
+		t.Run("headDim="+strconv.Itoa(headDim), func(t *testing.T) {
+			cpuOut, cpuState := runGatedDeltaNetOp(t, cpuBackend, headDim)
+			cudaOut, cudaState := runGatedDeltaNetOp(t, cudaBackend, headDim)
+
+			assertCloseFloats(t, "output", cpuOut, cudaOut, 2e-4)
+			assertCloseFloats(t, "state", cpuState, cudaState, 2e-4)
+		})
+	}
+}
+
+func referenceGatedDeltaNet(ctx ml.Context, q, k, v, gate, beta, state ml.Tensor) (ml.Tensor, ml.Tensor) {
+	headDim := v.Dim(0)
+	numHeads := v.Dim(1)
+	numTokens := v.Dim(2)
+	numSeqs := v.Dim(3)
+
+	state = state.Permute(ctx, 1, 0, 2, 3).Contiguous(ctx, headDim, headDim, numHeads, numSeqs)
+
+	var outputs []ml.Tensor
+	for i := 0; i < numTokens; i++ {
+		qi := q.Slice(ctx, 2, i, i+1, 1)
+		ki := k.Slice(ctx, 2, i, i+1, 1)
+		vi := v.Slice(ctx, 2, i, i+1, 1)
+		gatei := gate.Slice(ctx, 2, i, i+1, 1)
+		betai := beta.Slice(ctx, 2, i, i+1, 1)
+
+		var out ml.Tensor
+		state, out = referenceGatedDeltaNetStep(ctx, qi, ki, vi, gatei, betai, state)
+		outputs = append(outputs, out)
+	}
+
+	output := outputs[0]
+	for _, out := range outputs[1:] {
+		output = output.Concat(ctx, out, 2)
+	}
+
+	state = state.Permute(ctx, 1, 0, 2, 3).Contiguous(ctx, headDim, headDim, numHeads, numSeqs)
+	return output.Contiguous(ctx), state
+}
+
+func firstCUDATestDevice(tb testing.TB) (ml.DeviceID, bool) {
+	tb.Helper()
+
+	backend := newGatedDeltaNetTestBackend(tb, nil)
+	defer backend.Close()
+
+	for _, gpu := range backend.BackendMemory().GPUs {
+		if gpu.Library == "CUDA" {
+			return gpu.DeviceID, true
+		}
+	}
+
+	return ml.DeviceID{}, false
+}
+
+func newGatedDeltaNetTestBackend(tb testing.TB, device *ml.DeviceID) ml.Backend {
+	tb.Helper()
+
+	f, err := os.CreateTemp(tb.TempDir(), "*.bin")
+	if err != nil {
+		tb.Fatal(err)
+	}
+	defer f.Close()
+
+	tensors := []*fsggml.Tensor{
+		{
+			Name:     "blk.0.dummy.weight",
+			Kind:     uint32(fsggml.TensorTypeF32),
+			Shape:    []uint64{1},
+			WriterTo: bytes.NewReader(make([]byte, 4)),
+		},
+	}
+
+	if err := fsggml.WriteGGUF(f, fsggml.KV{
+		"general.architecture": "test",
+		"block_count":          uint32(1),
+	}, tensors); err != nil {
+		tb.Fatal(err)
+	}
+
+	params := ml.BackendParams{AllocMemory: true}
+	if device != nil {
+		params.GPULayers = ml.GPULayersList{{
+			DeviceID: *device,
+			Layers:   []int{0},
+		}}
+	}
+
+	backend, err := ml.NewBackend(f.Name(), params)
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	return backend
+}
+
+func runGatedDeltaNetOp(tb testing.TB, backend ml.Backend, headDim int) ([]float32, []float32) {
+	tb.Helper()
+
+	const (
+		numQHeads = 1
+		numVHeads = 2
+		numTokens = 2
+		numSeqs   = 2
+	)
+
+	ctx := backend.NewContext().Layer(0)
+	defer ctx.Close()
+
+	q := ctx.FromFloats(gatedDeltaNetFloats(headDim*numQHeads*numTokens*numSeqs, 0.10), headDim, numQHeads, numTokens, numSeqs)
+	k := ctx.FromFloats(gatedDeltaNetFloats(headDim*numQHeads*numTokens*numSeqs, 0.20), headDim, numQHeads, numTokens, numSeqs)
+	v := ctx.FromFloats(gatedDeltaNetFloats(headDim*numVHeads*numTokens*numSeqs, 0.30), headDim, numVHeads, numTokens, numSeqs)
+	gate := ctx.FromFloats(gatedDeltaNetFloats(headDim*numVHeads*numTokens*numSeqs, 0.40), headDim, numVHeads, numTokens, numSeqs)
+	beta := ctx.FromFloats(gatedDeltaNetFloats(numVHeads*numTokens*numSeqs, 0.50), 1, numVHeads, numTokens, numSeqs)
+	state := ctx.FromFloats(gatedDeltaNetFloats(headDim*headDim*numVHeads*numSeqs, 0.60), headDim, headDim, numVHeads, numSeqs)
+
+	fused := q.GatedDeltaNet(ctx, k, v, gate, beta, state)
+	fusedOut := gatedDeltaNetOutput(ctx, fused, headDim, numVHeads, numTokens, numSeqs)
+	fusedState := gatedDeltaNetState(ctx, fused, headDim, numVHeads, numTokens, numSeqs)
+
+	ctx.Forward(fusedOut, fusedState).Compute(fusedOut, fusedState)
+
+	return fusedOut.Floats(), fusedState.Floats()
+}
+
+func gatedDeltaNetFloats(n int, seed float64) []float32 {
+	values := make([]float32, n)
+	for i := range values {
+		values[i] = float32(math.Sin(seed+float64(i+1)*0.071) * 0.2)
+	}
+	return values
+}
+
+func referenceGatedDeltaNetStep(ctx ml.Context, q, k, v, gate, beta, state ml.Tensor) (ml.Tensor, ml.Tensor) {
+	headDim := v.Dim(0)
+	numHeads := v.Dim(1)
+	numSeqs := v.Dim(3)
+
+	gateExp := gate.Exp(ctx)
+	if gate.Dim(0) == headDim {
+		gateExp = gateExp.Reshape(ctx, 1, headDim, gate.Dim(1), numSeqs)
+	} else {
+		gateExp = gateExp.Reshape(ctx, 1, 1, gate.Dim(1), numSeqs)
+	}
+	state = state.Mul(ctx, gateExp)
+
+	kKey := k.Reshape(ctx, 1, headDim, k.Dim(1), numSeqs)
+	kvMem := state.Mul(ctx, kKey)
+	kvMem = kvMem.Permute(ctx, 1, 0, 2, 3).Contiguous(ctx).SumRows(ctx)
+	kvMem = kvMem.Permute(ctx, 1, 0, 2, 3)
+
+	vValue := v.Reshape(ctx, headDim, 1, numHeads, numSeqs)
+	betaScale := beta.Reshape(ctx, 1, 1, beta.Dim(1), numSeqs)
+	delta := vValue.Sub(ctx, kvMem).Mul(ctx, betaScale)
+
+	kUpdate := kKey.Repeat4D(ctx, headDim, headDim, numHeads, numSeqs).Mul(ctx, delta)
+	state = state.Add(ctx, kUpdate)
+
+	qKey := q.Reshape(ctx, 1, headDim, q.Dim(1), numSeqs)
+	output := state.Mul(ctx, qKey)
+	output = output.Permute(ctx, 1, 0, 2, 3).Contiguous(ctx).SumRows(ctx)
+	output = output.Permute(ctx, 1, 0, 2, 3).Reshape(ctx, headDim, numHeads, 1, numSeqs)
+	output = output.Mul(ctx, ctx.FromFloats([]float32{float32(1.0 / math.Sqrt(float64(headDim)))}, 1, 1, 1, 1))
+
+	return state, output
+}
+
+func gatedDeltaNetOutput(ctx ml.Context, result ml.Tensor, headDim, numHeads, numTokens, numSeqs int) ml.Tensor {
+	elemSize := result.Stride(0)
+	stride1 := elemSize * headDim
+	stride2 := stride1 * numHeads
+	stride3 := stride2 * numTokens
+
+	return result.View(ctx,
+		0,
+		headDim, stride1,
+		numHeads, stride2,
+		numTokens, stride3,
+		numSeqs,
+	).Contiguous(ctx)
+}
+
+func gatedDeltaNetState(ctx ml.Context, result ml.Tensor, headDim, numHeads, numTokens, numSeqs int) ml.Tensor {
+	elemSize := result.Stride(0)
+	offset := elemSize * headDim * numHeads * numTokens * numSeqs
+	stride1 := elemSize * headDim
+	stride2 := stride1 * headDim
+	stride3 := stride2 * numHeads
+
+	return result.View(ctx,
+		offset,
+		headDim, stride1,
+		headDim, stride2,
+		numHeads, stride3,
+		numSeqs,
+	).Contiguous(ctx)
+}
+
+func assertCloseFloats(t *testing.T, name string, want, got []float32, tol float64) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("%s length = %d, want %d", name, len(got), len(want))
+	}
+
+	for i := range want {
+		diff := math.Abs(float64(got[i] - want[i]))
+		if diff > tol {
+			t.Fatalf("%s[%d] = %.8f, want %.8f (diff %.8f > %.8f)\nall got:  %v\nall want: %v",
+				name, i, got[i], want[i], diff, tol, got, want)
+		}
+	}
+}

--- a/ml/backend/ggml/ggml.go
+++ b/ml/backend/ggml/ggml.go
@@ -799,6 +799,35 @@ func (c *Context) Layer(i int) ml.Context {
 	return c
 }
 
+func (c *Context) SupportsGatedDeltaNet(layer, headDim int) bool {
+	layerDevice, ok := c.b.layers[layer]
+	if !ok {
+		return false
+	}
+
+	dev := layerDevice.d
+	switch C.ggml_backend_dev_type(dev) {
+	case C.GGML_BACKEND_DEVICE_TYPE_CPU:
+		return true
+	case C.GGML_BACKEND_DEVICE_TYPE_GPU,
+		C.GGML_BACKEND_DEVICE_TYPE_IGPU:
+		var props C.struct_ggml_backend_dev_props
+		C.ggml_backend_dev_get_props(dev, &props)
+		if C.GoString(props.library) != "CUDA" {
+			return false
+		}
+
+		switch headDim {
+		case 16, 32, 64, 128:
+			return true
+		default:
+			return false
+		}
+	default:
+		return false
+	}
+}
+
 func (c *Context) Forward(tensors ...ml.Tensor) ml.Context {
 	if c.graph == nil {
 		c.graph = C.ggml_new_graph_custom(c.ctx, C.size_t(c.maxGraphNodes), false)
@@ -1718,6 +1747,13 @@ func (t *Tensor) SSMScan(ctx ml.Context, x, dt, A, B, C, ids ml.Tensor) ml.Tenso
 	return &Tensor{
 		b: t.b,
 		t: C.ggml_ssm_scan(ctx.(*Context).ctx, t.t, x.(*Tensor).t, dt.(*Tensor).t, A.(*Tensor).t, B.(*Tensor).t, C.(*Tensor).t, ids.(*Tensor).t),
+	}
+}
+
+func (t *Tensor) GatedDeltaNet(ctx ml.Context, k, v, gate, beta, state ml.Tensor) ml.Tensor {
+	return &Tensor{
+		b: t.b,
+		t: C.ggml_gated_delta_net(ctx.(*Context).ctx, t.t, k.(*Tensor).t, v.(*Tensor).t, gate.(*Tensor).t, beta.(*Tensor).t, state.(*Tensor).t),
 	}
 }
 

--- a/ml/backend/ggml/ggml/include/ggml.h
+++ b/ml/backend/ggml/ggml/include/ggml.h
@@ -551,6 +551,7 @@ extern "C" {
         GGML_OP_GATED_LINEAR_ATTN,
         GGML_OP_RWKV_WKV7,
         GGML_OP_SOLVE_TRI,
+        GGML_OP_GATED_DELTA_NET,
 
         GGML_OP_UNARY,
 
@@ -2459,6 +2460,15 @@ extern "C" {
         bool                  left,
         bool                  lower,
         bool                  uni);
+
+    GGML_API struct ggml_tensor * ggml_gated_delta_net(
+            struct ggml_context * ctx,
+            struct ggml_tensor  * q,
+            struct ggml_tensor  * k,
+            struct ggml_tensor  * v,
+            struct ggml_tensor  * g,
+            struct ggml_tensor  * beta,
+            struct ggml_tensor  * state);
 
     // custom operators
 

--- a/ml/backend/ggml/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ml/backend/ggml/ggml/src/ggml-cpu/ggml-cpu.c
@@ -2020,6 +2020,10 @@ static void ggml_compute_forward(struct ggml_compute_params * params, struct ggm
             {
                 ggml_compute_forward_solve_tri(params, tensor);
             } break;
+        case GGML_OP_GATED_DELTA_NET:
+            {
+                ggml_compute_forward_gated_delta_net(params, tensor);
+            } break;
         case GGML_OP_MAP_CUSTOM1:
             {
                 ggml_compute_forward_map_custom1(params, tensor);
@@ -2199,6 +2203,7 @@ static int ggml_get_n_tasks(struct ggml_tensor * node, int n_threads) {
             } break;
         case GGML_OP_COUNT_EQUAL:
         case GGML_OP_SOLVE_TRI:
+        case GGML_OP_GATED_DELTA_NET:
             {
                 n_tasks = n_threads;
             } break;
@@ -2893,6 +2898,11 @@ struct ggml_cplan ggml_graph_plan(
                 case GGML_OP_CROSS_ENTROPY_LOSS:
                     {
                         cur = ggml_type_size(node->type)*(n_tasks + node->src[0]->ne[0]*n_tasks);
+                    } break;
+                case GGML_OP_GATED_DELTA_NET:
+                    {
+                        const int64_t S_v = node->src[2]->ne[0];
+                        cur = S_v * sizeof(float) * n_tasks;
                     } break;
                 case GGML_OP_COUNT:
                     {

--- a/ml/backend/ggml/ggml/src/ggml-cpu/ops.cpp
+++ b/ml/backend/ggml/ggml/src/ggml-cpu/ops.cpp
@@ -9913,6 +9913,175 @@ void ggml_compute_forward_solve_tri(const struct ggml_compute_params * params, s
     }
 }
 
+// ggml_compute_forward_gated_delta_net
+static void ggml_compute_forward_gated_delta_net_one_chunk(
+    const ggml_compute_params * params,
+    ggml_tensor * dst,
+    int64_t ir0,
+    int64_t ir1) {
+
+    ggml_tensor * src_q     = dst->src[0];
+    ggml_tensor * src_k     = dst->src[1];
+    ggml_tensor * src_v     = dst->src[2];
+    ggml_tensor * src_g     = dst->src[3];
+    ggml_tensor * src_beta  = dst->src[4];
+    ggml_tensor * src_state = dst->src[5];
+
+    const int64_t S_v      = src_v->ne[0];
+    const int64_t H        = src_v->ne[1];
+    const int64_t n_tokens = src_v->ne[2];
+    const int64_t n_seqs   = src_v->ne[3];
+
+    GGML_ASSERT(ggml_is_contiguous_rows(src_q));
+    GGML_ASSERT(ggml_is_contiguous_rows(src_k));
+    GGML_ASSERT(ggml_is_contiguous_rows(src_v));
+    GGML_ASSERT(ggml_is_contiguous(src_g));
+    GGML_ASSERT(ggml_is_contiguous(src_beta));
+    GGML_ASSERT(ggml_is_contiguous(src_state));
+
+    GGML_ASSERT(src_g->ne[0] == 1 || src_g->ne[0] == S_v);
+    GGML_ASSERT(src_beta->ne[0] == 1);
+
+    GGML_TENSOR_LOCALS(int64_t, neq, src_q, ne);
+    GGML_TENSOR_LOCALS(size_t,  nbq, src_q, nb);
+    GGML_TENSOR_LOCALS(int64_t, nek, src_k, ne);
+    GGML_TENSOR_LOCALS(size_t,  nbk, src_k, nb);
+    GGML_TENSOR_LOCALS(size_t,  nbv, src_v, nb);
+    GGML_TENSOR_LOCALS(int64_t, neg, src_g, ne);
+    GGML_TENSOR_LOCALS(size_t,  nbg, src_g, nb);
+    GGML_TENSOR_LOCALS(size_t,  nbb, src_beta, nb);
+
+    const bool kda = (neg0 == S_v);
+
+    const int64_t scratch_per_thread = S_v;
+    const int ith = params->ith;
+
+    float * delta = (float *) params->wdata + ith * scratch_per_thread + CACHE_LINE_SIZE_F32;
+
+    const int64_t attn_score_elems = S_v * H * n_tokens * n_seqs;
+    float * attn_out_base  = (float *) dst->data;
+    float * state_out_base = (float *) dst->data + attn_score_elems;
+
+    const float * state_in_base = (const float *) src_state->data;
+
+    const int64_t rq3 = src_v->ne[3] / neq3;
+    const int64_t rk3 = src_v->ne[3] / nek3;
+
+    const float scale = 1.0f / sqrtf((float) S_v);
+
+    for (int64_t ir = ir0; ir < ir1; ++ir) {
+        const int64_t iv1 = ir % H;
+        const int64_t iv3 = ir / H;
+
+        const int64_t iq1 = iv1 % neq1;
+        const int64_t ik1 = iv1 % nek1;
+
+        const int64_t iq3 = iv3 / rq3;
+        const int64_t ik3 = iv3 / rk3;
+
+        float * s_out = state_out_base + (iv3 * H + iv1) * S_v * S_v;
+
+        const float * s_in = state_in_base + (iv3 * H + iv1) * S_v * S_v;
+        memcpy(s_out, s_in, S_v * S_v * sizeof(float));
+
+        float * attn_data = attn_out_base + (iv3 * n_tokens * H + iv1) * S_v;
+
+        for (int64_t t = 0; t < n_tokens; t++) {
+            const float * q_d = (const float *)((const char *) src_q->data + iq3 * nbq3 + t * nbq2 + iq1 * nbq1);
+            const float * k_d = (const float *)((const char *) src_k->data + ik3 * nbk3 + t * nbk2 + ik1 * nbk1);
+            const float * v_d = (const float *)((const char *) src_v->data + iv3 * nbv3 + t * nbv2 + iv1 * nbv1);
+
+            const float beta_val = *(const float *)((const char *) src_beta->data + iv3 * nbb3 + t * nbb2 + iv1 * nbb1);
+            const float * g_d    =  (const float *)((const char *) src_g->data    + iv3 * nbg3 + t * nbg2 + iv1 * nbg1);
+
+            if (kda) {
+                for (int64_t i = 0; i < S_v; ++i) {
+                    delta[i] = expf(g_d[i]);
+                }
+                for (int64_t j = 0; j < S_v; ++j) {
+                    ggml_vec_mul_f32(S_v, &s_out[j * S_v], &s_out[j * S_v], delta);
+                }
+            } else {
+                ggml_vec_scale_f32(S_v * S_v, s_out, expf(g_d[0]));
+            }
+
+            for (int64_t j = 0; j < S_v; ++j) {
+                float sum = 0.0f;
+                ggml_vec_dot_f32(S_v, &sum, 0, &s_out[j * S_v], 0, k_d, 0, 1);
+                delta[j] = (v_d[j] - sum) * beta_val;
+            }
+
+            for (int64_t j = 0; j < S_v; ++j) {
+                ggml_vec_mad_f32(S_v, &s_out[j * S_v], k_d, delta[j]);
+            }
+
+            for (int64_t j = 0; j < S_v; ++j) {
+                float sum = 0.0f;
+                ggml_vec_dot_f32(S_v, &sum, 0, &s_out[j * S_v], 0, q_d, 0, 1);
+                attn_data[j] = sum * scale;
+            }
+
+            attn_data += S_v * H;
+        }
+    }
+}
+
+static void ggml_compute_forward_gated_delta_net_f32(
+        const ggml_compute_params * params,
+        ggml_tensor * dst) {
+
+    ggml_tensor * v = dst->src[2];
+    int64_t nr = v->ne[1] * v->ne[3];
+
+    const bool disable_chunking = ggml_is_numa();
+
+    int nth = params->nth;
+    int ith = params->ith;
+
+    int nth_scaled = nth * 4;
+    int64_t chunk_size = (nr + nth_scaled - 1) / nth_scaled;
+    int64_t nchunk     = (nr + chunk_size - 1) / chunk_size;
+
+    if (nth == 1 || nchunk < nth || disable_chunking) {
+        nchunk = nth;
+    }
+
+    if (ith == 0) {
+        ggml_threadpool_chunk_set(params->threadpool, nth);
+    }
+
+    ggml_barrier(params->threadpool);
+
+    const int64_t dr = (nr + nchunk - 1) / nchunk;
+
+    int current_chunk = ith;
+
+    while (current_chunk < nchunk) {
+        const int64_t ir0 = dr * current_chunk;
+        const int64_t ir1 = MIN(ir0 + dr, nr);
+
+        ggml_compute_forward_gated_delta_net_one_chunk(params, dst, ir0, ir1);
+        current_chunk = ggml_threadpool_chunk_add(params->threadpool, 1);
+    }
+}
+
+void ggml_compute_forward_gated_delta_net(
+        const ggml_compute_params * params,
+        ggml_tensor * dst) {
+    const ggml_tensor * src0 = dst->src[0];
+
+    switch (src0->type) {
+        case GGML_TYPE_F32:
+            {
+                ggml_compute_forward_gated_delta_net_f32(params, dst);
+            } break;
+        default:
+            {
+                GGML_ABORT("fatal error");
+            }
+    }
+}
+
 // ggml_compute_forward_rwkv_wkv7
 
 static void ggml_compute_forward_rwkv_wkv7_f32(

--- a/ml/backend/ggml/ggml/src/ggml-cpu/ops.h
+++ b/ml/backend/ggml/ggml/src/ggml-cpu/ops.h
@@ -101,6 +101,7 @@ void ggml_compute_forward_add_rel_pos(const struct ggml_compute_params * params,
 void ggml_compute_forward_rwkv_wkv6(const struct ggml_compute_params * params, struct ggml_tensor * dst);
 void ggml_compute_forward_rwkv_wkv7(const struct ggml_compute_params * params, struct ggml_tensor * dst);
 void ggml_compute_forward_solve_tri(const struct ggml_compute_params * params, struct ggml_tensor * dst);
+void ggml_compute_forward_gated_delta_net(const struct ggml_compute_params * params, struct ggml_tensor * dst);
 void ggml_compute_forward_gla(const struct ggml_compute_params * params, struct ggml_tensor * dst);
 void ggml_compute_forward_map_custom1(const struct ggml_compute_params * params, struct ggml_tensor * dst);
 void ggml_compute_forward_map_custom2(const struct ggml_compute_params * params, struct ggml_tensor * dst);

--- a/ml/backend/ggml/ggml/src/ggml-cuda/gated_delta_net.cu
+++ b/ml/backend/ggml/ggml/src/ggml-cuda/gated_delta_net.cu
@@ -1,0 +1,273 @@
+#include "gated_delta_net.cuh"
+
+template <int S_v, bool KDA>
+__global__ void __launch_bounds__((ggml_cuda_get_physical_warp_size() < S_v ? ggml_cuda_get_physical_warp_size() : S_v) * 4, 2)
+gated_delta_net_cuda(const float * q,
+                                     const float * k,
+                                     const float * v,
+                                     const float * g,
+                                     const float * beta,
+                                     const float * curr_state,
+                                     float *       dst,
+                                     int64_t       H,
+                                     int64_t       n_tokens,
+                                     int64_t       n_seqs,
+                                     int64_t       sq1,
+                                     int64_t       sq2,
+                                     int64_t       sq3,
+                                     int64_t       sv1,
+                                     int64_t       sv2,
+                                     int64_t       sv3,
+                                     int64_t       sb1,
+                                     int64_t       sb2,
+                                     int64_t       sb3,
+                                     const uint3   neqk1_magic,
+                                     const uint3   rq3_magic,
+                                     float         scale) {
+    const uint32_t h_idx    = blockIdx.x;
+    const uint32_t sequence = blockIdx.y;
+    // each warp owns one column, using warp-level primitives to reduce across rows
+    const int      lane     = threadIdx.x;
+    const int      col      = blockIdx.z * blockDim.y + threadIdx.y;
+
+    const uint32_t iq1 = fastmodulo(h_idx, neqk1_magic);
+    const uint32_t iq3 = fastdiv(sequence, rq3_magic);
+
+    const int64_t attn_score_elems = S_v * H * n_tokens * n_seqs;
+    float *       attn_data        = dst;
+    float *       state            = dst + attn_score_elems;
+
+    const int64_t state_offset = (sequence * H + h_idx) * S_v * S_v;
+    state += state_offset;
+    curr_state += state_offset + col * S_v;
+    attn_data += (sequence * n_tokens * H + h_idx) * S_v;
+
+    constexpr int warp_size = ggml_cuda_get_physical_warp_size() < S_v ? ggml_cuda_get_physical_warp_size() : S_v;
+    static_assert(S_v % warp_size == 0, "S_v must be a multiple of warp_size");
+    constexpr int rows_per_lane = (S_v + warp_size - 1) / warp_size;
+    float         s_shard[rows_per_lane];
+    // state is stored transposed: M[col][i] = S[i][col], row col is contiguous
+
+#pragma unroll
+    for (int r = 0; r < rows_per_lane; r++) {
+        const int i = r * warp_size + lane;
+        s_shard[r]  = curr_state[i];
+    }
+
+    for (int t = 0; t < n_tokens; t++) {
+        const float * q_t = q + iq3 * sq3 + t * sq2 + iq1 * sq1;
+        const float * k_t = k + iq3 * sq3 + t * sq2 + iq1 * sq1;
+        const float * v_t = v + sequence * sv3 + t * sv2 + h_idx * sv1;
+
+        const int64_t gb_offset = sequence * sb3 + t * sb2 + h_idx * sb1;
+        const float * beta_t = beta + gb_offset;
+        const float * g_t    = g    + gb_offset * (KDA ? S_v : 1);
+
+        const float beta_val = *beta_t;
+
+        // Cache k and q in registers
+        float k_reg[rows_per_lane];
+        float q_reg[rows_per_lane];
+#pragma unroll
+        for (int r = 0; r < rows_per_lane; r++) {
+            const int i = r * warp_size + lane;
+            k_reg[r] = k_t[i];
+            q_reg[r] = q_t[i];
+        }
+
+        if constexpr (!KDA) {
+            const float g_val = expf(*g_t);
+
+            // kv[col] = (S^T @ k)[col] = sum_i S[i][col] * k[i]
+            float kv_shard = 0.0f;
+#pragma unroll
+            for (int r = 0; r < rows_per_lane; r++) {
+                kv_shard += s_shard[r] * k_reg[r];
+            }
+            float kv_col = warp_reduce_sum<warp_size>(kv_shard);
+
+            // delta[col] = (v[col] - g * kv[col]) * beta
+            float delta_col = (v_t[col] - g_val * kv_col) * beta_val;
+
+            // fused: S[i][col] = g * S[i][col] + k[i] * delta[col]
+            // attn[col] = (S^T @ q)[col] = sum_i S[i][col] * q[i]
+            float attn_partial = 0.0f;
+#pragma unroll
+            for (int r = 0; r < rows_per_lane; r++) {
+                s_shard[r]  = g_val * s_shard[r] + k_reg[r] * delta_col;
+                attn_partial += s_shard[r] * q_reg[r];
+            }
+
+            float attn_col = warp_reduce_sum<warp_size>(attn_partial);
+
+            if (lane == 0) {
+                attn_data[col] = attn_col * scale;
+            }
+        } else {
+            // kv[col] = sum_i g[i] * S[i][col] * k[i]
+            float kv_shard = 0.0f;
+#pragma unroll
+            for (int r = 0; r < rows_per_lane; r++) {
+                const int i = r * warp_size + lane;
+                kv_shard += expf(g_t[i]) * s_shard[r] * k_reg[r];
+            }
+
+            float kv_col = warp_reduce_sum<warp_size>(kv_shard);
+
+            // delta[col] = (v[col] - kv[col]) * beta
+            float delta_col = (v_t[col] - kv_col) * beta_val;
+
+            // fused: S[i][col] = g[i] * S[i][col] + k[i] * delta[col]
+            // attn[col] = (S^T @ q)[col] = sum_i S[i][col] * q[i]
+            float attn_partial = 0.0f;
+#pragma unroll
+            for (int r = 0; r < rows_per_lane; r++) {
+                const int i = r * warp_size + lane;
+                s_shard[r]  = expf(g_t[i]) * s_shard[r] + k_reg[r] * delta_col;
+                attn_partial += s_shard[r] * q_reg[r];
+            }
+
+            float attn_col = warp_reduce_sum<warp_size>(attn_partial);
+
+            if (lane == 0) {
+                attn_data[col] = attn_col * scale;
+            }
+        }
+
+        attn_data += S_v * H;
+    }
+
+    // Write state back to global memory (transposed layout)
+#pragma unroll
+    for (int r = 0; r < rows_per_lane; r++) {
+        const int i          = r * warp_size + lane;
+        state[col * S_v + i] = s_shard[r];
+    }
+}
+
+template <bool KDA>
+static void launch_gated_delta_net(
+        const float * q_d, const float * k_d, const float * v_d,
+        const float * g_d, const float * b_d, const float * s_d,
+        float * dst_d,
+        int64_t S_v,   int64_t H, int64_t n_tokens, int64_t n_seqs,
+        int64_t sq1,   int64_t sq2, int64_t sq3,
+        int64_t sv1,   int64_t sv2, int64_t sv3,
+        int64_t sb1,   int64_t sb2, int64_t sb3,
+        int64_t neqk1, int64_t rq3,
+        float scale, cudaStream_t stream) {
+    //TODO: Add chunked kernel for even faster pre-fill
+    const int warp_size = ggml_cuda_info().devices[ggml_cuda_get_device()].warp_size;
+    const int num_warps = 4;
+    dim3      grid_dims(H, n_seqs, (S_v + num_warps - 1) / num_warps);
+    dim3      block_dims(warp_size <= S_v ? warp_size : S_v, num_warps, 1);
+
+    const uint3 neqk1_magic = init_fastdiv_values(neqk1);
+    const uint3 rq3_magic   = init_fastdiv_values(rq3);
+
+    int cc = ggml_cuda_info().devices[ggml_cuda_get_device()].cc;
+
+    switch (S_v) {
+        case 16:
+            gated_delta_net_cuda<16, KDA><<<grid_dims, block_dims, 0, stream>>>(
+                q_d, k_d, v_d, g_d, b_d, s_d, dst_d, H,
+                n_tokens, n_seqs, sq1, sq2, sq3, sv1, sv2, sv3,
+                sb1, sb2, sb3, neqk1_magic, rq3_magic, scale);
+            break;
+        case 32:
+            gated_delta_net_cuda<32, KDA><<<grid_dims, block_dims, 0, stream>>>(
+                q_d, k_d, v_d, g_d, b_d, s_d, dst_d, H,
+                n_tokens, n_seqs, sq1, sq2, sq3, sv1, sv2, sv3,
+                sb1, sb2, sb3, neqk1_magic, rq3_magic, scale);
+            break;
+        case 64: {
+            gated_delta_net_cuda<64, KDA><<<grid_dims, block_dims, 0, stream>>>(
+                q_d, k_d, v_d, g_d, b_d, s_d, dst_d, H,
+                n_tokens, n_seqs, sq1, sq2, sq3, sv1, sv2, sv3,
+                sb1, sb2, sb3, neqk1_magic, rq3_magic, scale);
+            break;
+        }
+        case 128: {
+            gated_delta_net_cuda<128, KDA><<<grid_dims, block_dims, 0, stream>>>(
+                q_d, k_d, v_d, g_d, b_d, s_d, dst_d, H,
+                n_tokens, n_seqs, sq1, sq2, sq3, sv1, sv2, sv3,
+                sb1, sb2, sb3, neqk1_magic, rq3_magic, scale);
+            break;
+        }
+        default:
+            GGML_ABORT("fatal error");
+            break;
+    }
+}
+
+void ggml_cuda_op_gated_delta_net(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
+    ggml_tensor * src_q     = dst->src[0];
+    ggml_tensor * src_k     = dst->src[1];
+    ggml_tensor * src_v     = dst->src[2];
+    ggml_tensor * src_g     = dst->src[3];
+    ggml_tensor * src_beta  = dst->src[4];
+    ggml_tensor * src_state = dst->src[5];
+
+    GGML_TENSOR_LOCALS(int64_t, neq, src_q, ne);
+    GGML_TENSOR_LOCALS(size_t , nbq, src_q, nb);
+    GGML_TENSOR_LOCALS(int64_t, nek, src_k, ne);
+    GGML_TENSOR_LOCALS(size_t , nbk, src_k, nb);
+    GGML_TENSOR_LOCALS(int64_t, nev, src_v, ne);
+    GGML_TENSOR_LOCALS(size_t,  nbv, src_v, nb);
+    GGML_TENSOR_LOCALS(size_t,  nbb, src_beta, nb);
+
+    const int64_t S_v      = nev0;
+    const int64_t H        = nev1;
+    const int64_t n_tokens = nev2;
+    const int64_t n_seqs   = nev3;
+
+    const bool kda = (src_g->ne[0] == S_v);
+
+    GGML_ASSERT(neq1 == nek1);
+    const int64_t neqk1 = neq1;
+
+    const int64_t rq3 = nev3 / neq3;
+
+    const float * q_d = (const float *) src_q->data;
+    const float * k_d = (const float *) src_k->data;
+    const float * v_d = (const float *) src_v->data;
+    const float * g_d = (const float *) src_g->data;
+    const float * b_d = (const float *) src_beta->data;
+
+    const float * s_d   = (const float *) src_state->data;
+    float *       dst_d = (float *) dst->data;
+
+    GGML_ASSERT(ggml_is_contiguous_rows(src_q));
+    GGML_ASSERT(ggml_is_contiguous_rows(src_k));
+    GGML_ASSERT(ggml_is_contiguous_rows(src_v));
+    GGML_ASSERT(ggml_are_same_stride(src_q, src_k));
+    GGML_ASSERT(src_g->ne[0] == 1 || kda);
+    GGML_ASSERT(ggml_is_contiguous(src_g));
+    GGML_ASSERT(ggml_is_contiguous(src_beta));
+    GGML_ASSERT(ggml_is_contiguous(src_state));
+
+    // strides in floats (beta strides used for both g and beta offset computation)
+    const int64_t sq1 = nbq1 / sizeof(float);
+    const int64_t sq2 = nbq2 / sizeof(float);
+    const int64_t sq3 = nbq3 / sizeof(float);
+    const int64_t sv1 = nbv1 / sizeof(float);
+    const int64_t sv2 = nbv2 / sizeof(float);
+    const int64_t sv3 = nbv3 / sizeof(float);
+    const int64_t sb1 = nbb1 / sizeof(float);
+    const int64_t sb2 = nbb2 / sizeof(float);
+    const int64_t sb3 = nbb3 / sizeof(float);
+
+    const float scale = 1.0f / sqrtf((float) S_v);
+
+    cudaStream_t stream = ctx.stream();
+
+    if (kda) {
+        launch_gated_delta_net<true>(q_d, k_d, v_d, g_d, b_d, s_d, dst_d,
+            S_v, H, n_tokens, n_seqs, sq1, sq2, sq3, sv1, sv2, sv3,
+            sb1, sb2, sb3, neqk1, rq3, scale, stream);
+    } else {
+        launch_gated_delta_net<false>(q_d, k_d, v_d, g_d, b_d, s_d, dst_d,
+            S_v, H, n_tokens, n_seqs, sq1, sq2, sq3, sv1, sv2, sv3,
+            sb1, sb2, sb3, neqk1, rq3, scale, stream);
+    }
+}

--- a/ml/backend/ggml/ggml/src/ggml-cuda/gated_delta_net.cuh
+++ b/ml/backend/ggml/ggml/src/ggml-cuda/gated_delta_net.cuh
@@ -1,0 +1,4 @@
+#include "common.cuh"
+#include "ggml.h"
+
+void ggml_cuda_op_gated_delta_net(ggml_backend_cuda_context & ctx, ggml_tensor * dst);

--- a/ml/backend/ggml/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ml/backend/ggml/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -58,6 +58,7 @@
 #include "ggml-cuda/tri.cuh"
 #include "ggml-cuda/cumsum.cuh"
 #include "ggml-cuda/fill.cuh"
+#include "ggml-cuda/gated_delta_net.cuh"
 #include "ggml.h"
 
 #include <algorithm>
@@ -2854,6 +2855,9 @@ static bool ggml_cuda_compute_forward(ggml_backend_cuda_context & ctx, struct gg
         case GGML_OP_GATED_LINEAR_ATTN:
             ggml_cuda_op_gated_linear_attn(ctx, dst);
             break;
+        case GGML_OP_GATED_DELTA_NET:
+            ggml_cuda_op_gated_delta_net(ctx, dst);
+            break;
         case GGML_OP_RWKV_WKV7:
             ggml_cuda_op_rwkv_wkv7(ctx, dst);
             break;
@@ -4899,6 +4903,14 @@ static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const g
         case GGML_OP_GATED_LINEAR_ATTN:
         case GGML_OP_RWKV_WKV7:
             return true;
+        case GGML_OP_GATED_DELTA_NET: {
+#ifdef GGML_USE_MUSA
+            return false;
+#else
+            const int64_t S_v = op->src[2]->ne[0];
+            return S_v == 16 || S_v == 32 || S_v == 64 || S_v == 128;
+#endif // GGML_USE_MUSA
+        }
         case GGML_OP_FLASH_ATTN_EXT:
             return ggml_cuda_flash_attn_ext_supported(dev_ctx->device, op);
         case GGML_OP_CROSS_ENTROPY_LOSS:

--- a/ml/backend/ggml/ggml/src/ggml.c
+++ b/ml/backend/ggml/ggml/src/ggml.c
@@ -1033,6 +1033,7 @@ static const char * GGML_OP_NAME[GGML_OP_COUNT] = {
     "GATED_LINEAR_ATTN",
     "RWKV_WKV7",
     "SOLVE_TRI",
+    "GATED_DELTA_NET",
 
     "UNARY",
 
@@ -1050,7 +1051,7 @@ static const char * GGML_OP_NAME[GGML_OP_COUNT] = {
     "GLU",
 };
 
-static_assert(GGML_OP_COUNT == 95, "GGML_OP_COUNT != 95");
+static_assert(GGML_OP_COUNT == 96, "GGML_OP_COUNT != 96");
 
 static const char * GGML_OP_SYMBOL[GGML_OP_COUNT] = {
     "none",
@@ -1142,6 +1143,7 @@ static const char * GGML_OP_SYMBOL[GGML_OP_COUNT] = {
     "gated_linear_attn(k, v, q, gate, s)",
     "rwkv_wkv7(r, w, k, v, a, b, s)",
     "A X = B, A triangular, solve X",
+    "gated_delta_net(q, k, v, g, beta, s)",
 
     "unary(x)",
 
@@ -1159,7 +1161,7 @@ static const char * GGML_OP_SYMBOL[GGML_OP_COUNT] = {
     "glu(x)",
 };
 
-static_assert(GGML_OP_COUNT == 95, "GGML_OP_COUNT != 95");
+static_assert(GGML_OP_COUNT == 96, "GGML_OP_COUNT != 96");
 
 static_assert(GGML_OP_POOL_COUNT == 2, "GGML_OP_POOL_COUNT != 2");
 
@@ -6094,6 +6096,64 @@ struct ggml_tensor * ggml_solve_tri(
     result->op     = GGML_OP_SOLVE_TRI;
     result->src[0] = a;
     result->src[1] = b;
+
+    return result;
+}
+
+// ggml_gated_delta_net
+
+struct ggml_tensor * ggml_gated_delta_net(
+        struct ggml_context * ctx,
+        struct ggml_tensor  * q,
+        struct ggml_tensor  * k,
+        struct ggml_tensor  * v,
+        struct ggml_tensor  * g,
+        struct ggml_tensor  * beta,
+        struct ggml_tensor  * state) {
+    GGML_ASSERT(ggml_is_contiguous_rows(q));
+    GGML_ASSERT(ggml_is_contiguous_rows(k));
+    GGML_ASSERT(ggml_is_contiguous_rows(v));
+    GGML_ASSERT(ggml_is_contiguous(g));
+    GGML_ASSERT(ggml_is_contiguous(beta));
+    GGML_ASSERT(ggml_is_contiguous(state));
+
+    GGML_ASSERT(q->type == GGML_TYPE_F32);
+    GGML_ASSERT(k->type == GGML_TYPE_F32);
+    GGML_ASSERT(v->type == GGML_TYPE_F32);
+    GGML_ASSERT(g->type == GGML_TYPE_F32);
+    GGML_ASSERT(beta->type == GGML_TYPE_F32);
+    GGML_ASSERT(state->type == GGML_TYPE_F32);
+
+    const int64_t S_k      = q->ne[0];
+    const int64_t H_k      = q->ne[1];
+    const int64_t n_tokens = q->ne[2];
+    const int64_t n_seqs   = q->ne[3];
+
+    const int64_t S_v = v->ne[0];
+    const int64_t H_v = v->ne[1];
+
+    GGML_ASSERT(S_k == S_v);
+    GGML_ASSERT(H_v % H_k == 0);
+
+    GGML_ASSERT(q->ne[0] == S_k && q->ne[1] == H_k && q->ne[2] == n_tokens && q->ne[3] == n_seqs);
+    GGML_ASSERT(k->ne[0] == S_k && k->ne[1] == H_k && k->ne[2] == n_tokens && k->ne[3] == n_seqs);
+    GGML_ASSERT(v->ne[0] == S_v && v->ne[1] == H_v && v->ne[2] == n_tokens && v->ne[3] == n_seqs);
+
+    GGML_ASSERT(g->ne[0] == 1 || g->ne[0] == S_v);
+    GGML_ASSERT(                 g->ne[1] == H_v && g->ne[2] == n_tokens && g->ne[3] == n_seqs);
+    GGML_ASSERT(beta->ne[0] == 1 && beta->ne[1] == H_v && beta->ne[2] == n_tokens && beta->ne[3] == n_seqs);
+    GGML_ASSERT(state->ne[0] == S_v && state->ne[1] == S_v && state->ne[2] == H_v && state->ne[3] == n_seqs);
+
+    const int64_t ne[4] = { S_v * H_v, n_tokens * n_seqs + S_v * n_seqs, 1, 1 };
+    struct ggml_tensor * result = ggml_new_tensor(ctx, GGML_TYPE_F32, 4, ne);
+
+    result->op     = GGML_OP_GATED_DELTA_NET;
+    result->src[0] = q;
+    result->src[1] = k;
+    result->src[2] = v;
+    result->src[3] = g;
+    result->src[4] = beta;
+    result->src[5] = state;
 
     return result;
 }

--- a/model/models/qwen3next/deltanet.go
+++ b/model/models/qwen3next/deltanet.go
@@ -214,33 +214,27 @@ func (gdn *GatedDeltaNet) Forward(ctx ml.Context, hiddenStates, _ ml.Tensor, cac
 	}
 	state = state.Reshape(ctx, headVDim, headVDim*numVHeads, 1, nSeqs)
 
-	// Repeat interleave Q and K if numKHeads != numVHeads
-	if numKHeads != numVHeads {
-		if opts.vHeadReordered {
-			qConv = qConv.Repeat4D(ctx, headKDim, numVHeads, nSeqTokens, nSeqs)
-			kConv = kConv.Repeat4D(ctx, headKDim, numVHeads, nSeqTokens, nSeqs)
-		} else {
-			repeatFactor := numVHeads / numKHeads
-			qReshaped := qConv.Reshape(ctx, headKDim, 1, numKHeads*nSeqTokens*nSeqs)
-			kReshaped := kConv.Reshape(ctx, headKDim, 1, numKHeads*nSeqTokens*nSeqs)
-
-			qRepeated := qReshaped.Repeat4D(ctx, headKDim, repeatFactor, numKHeads*nSeqTokens*nSeqs, 1)
-			kRepeated := kReshaped.Repeat4D(ctx, headKDim, repeatFactor, numKHeads*nSeqTokens*nSeqs, 1)
-
-			qConv = qRepeated.Reshape(ctx, headKDim, numKHeads*repeatFactor, nSeqTokens, nSeqs)
-			kConv = kRepeated.Reshape(ctx, headKDim, numKHeads*repeatFactor, nSeqTokens, nSeqs)
-		}
+	if numVHeads%numKHeads != 0 {
+		return nil, errors.New("qwen3next: value heads must be divisible by key heads")
 	}
 
-	// Choose computation mode based on sequence length
 	var attnOut ml.Tensor
-	if nSeqTokens == 1 {
-		attnOut = gdn.deltaNetAutoregressive(ctx, qConv, kConv, vConv, gate, beta, state, opts, layer, cache)
+
+	if useFusedDeltaNet(supportsFusedDeltaNet(ctx, layer, headVDim), nSeqTokens, numKHeads, numVHeads, opts.vHeadReordered) {
+		attnOut = gdn.deltaNetAutoregressiveFused(ctx, qConv, kConv, vConv, gate, beta, state, opts, layer, cache)
 	} else {
-		if opts.masks == nil {
-			opts.masks = createMasks(ctx)
+		if numKHeads != numVHeads {
+			qConv, kConv = repeatQKToVHeads(ctx, qConv, kConv, headKDim, numKHeads, numVHeads, nSeqTokens, nSeqs, opts.vHeadReordered)
 		}
-		attnOut = gdn.deltaNetChunked(ctx, qConv, kConv, vConv, gate, beta, state, opts.masks, opts, layer, cache)
+
+		if nSeqTokens == 1 {
+			attnOut = gdn.deltaNetAutoregressive(ctx, qConv, kConv, vConv, gate, beta, state, opts, layer, cache)
+		} else {
+			if opts.masks == nil {
+				opts.masks = createMasks(ctx)
+			}
+			attnOut = gdn.deltaNetChunked(ctx, qConv, kConv, vConv, gate, beta, state, opts.masks, opts, layer, cache)
+		}
 	}
 
 	// Apply gated normalization
@@ -257,6 +251,88 @@ func (gdn *GatedDeltaNet) Forward(ctx ml.Context, hiddenStates, _ ml.Tensor, cac
 
 	out := gdn.SSMOut.Forward(ctx, finalOutput)
 	return out.Reshape(ctx, out.Dim(0), nSeqTokens*nSeqs), nil
+}
+
+type gatedDeltaNetSupport interface {
+	SupportsGatedDeltaNet(layer, headDim int) bool
+}
+
+func supportsFusedDeltaNet(ctx ml.Context, layer, headDim int) bool {
+	support, ok := ctx.(gatedDeltaNetSupport)
+	return ok && support.SupportsGatedDeltaNet(layer, headDim)
+}
+
+func useFusedDeltaNet(supported bool, nSeqTokens, numKHeads, numVHeads int, vHeadReordered bool) bool {
+	return supported && nSeqTokens == 1 && (numKHeads == numVHeads || vHeadReordered)
+}
+
+func repeatQKToVHeads(ctx ml.Context, q, k ml.Tensor, headKDim, numKHeads, numVHeads, nSeqTokens, nSeqs int, vHeadReordered bool) (ml.Tensor, ml.Tensor) {
+	if vHeadReordered {
+		q = q.Repeat4D(ctx, headKDim, numVHeads, nSeqTokens, nSeqs)
+		k = k.Repeat4D(ctx, headKDim, numVHeads, nSeqTokens, nSeqs)
+		return q, k
+	}
+
+	repeatFactor := numVHeads / numKHeads
+	qReshaped := q.Reshape(ctx, headKDim, 1, numKHeads*nSeqTokens*nSeqs)
+	kReshaped := k.Reshape(ctx, headKDim, 1, numKHeads*nSeqTokens*nSeqs)
+
+	qRepeated := qReshaped.Repeat4D(ctx, headKDim, repeatFactor, numKHeads*nSeqTokens*nSeqs, 1)
+	kRepeated := kReshaped.Repeat4D(ctx, headKDim, repeatFactor, numKHeads*nSeqTokens*nSeqs, 1)
+
+	q = qRepeated.Reshape(ctx, headKDim, numKHeads*repeatFactor, nSeqTokens, nSeqs)
+	k = kRepeated.Reshape(ctx, headKDim, numKHeads*repeatFactor, nSeqTokens, nSeqs)
+	return q, k
+}
+
+func (gdn *GatedDeltaNet) deltaNetAutoregressiveFused(
+	ctx ml.Context,
+	q, k, v, gate, beta, state ml.Tensor,
+	opts *Options,
+	layer int,
+	cache *HybridCache,
+) ml.Tensor {
+	numVHeads := v.Dim(1)
+	headVDim := v.Dim(0)
+	nSeqTokens := q.Dim(2)
+	nSeqs := q.Dim(3)
+
+	q = q.L2Norm(ctx, opts.eps)
+	k = k.L2Norm(ctx, opts.eps)
+	beta = beta.Sigmoid(ctx)
+	state = state.Reshape(ctx, headVDim, headVDim, numVHeads, nSeqs)
+	state = state.Permute(ctx, 1, 0, 2, 3).Contiguous(ctx, headVDim, headVDim, numVHeads, nSeqs)
+
+	result := q.GatedDeltaNet(ctx, k, v, gate, beta, state)
+
+	elemSize := result.Stride(0)
+	outputStride1 := elemSize * headVDim
+	outputStride2 := outputStride1 * numVHeads
+	outputStride3 := outputStride2 * nSeqTokens
+	output := result.View(ctx,
+		0,
+		headVDim, outputStride1,
+		numVHeads, outputStride2,
+		nSeqTokens, outputStride3,
+		nSeqs,
+	)
+
+	stateOffset := elemSize * headVDim * numVHeads * nSeqTokens * nSeqs
+	stateStride1 := elemSize * headVDim
+	stateStride2 := stateStride1 * headVDim
+	stateStride3 := stateStride2 * numVHeads
+	newState := result.View(ctx,
+		stateOffset,
+		headVDim, stateStride1,
+		headVDim, stateStride2,
+		numVHeads, stateStride3,
+		nSeqs,
+	)
+
+	newState = newState.Permute(ctx, 1, 0, 2, 3).Contiguous(ctx, headVDim, headVDim, numVHeads, nSeqs)
+	cache.UpdateDeltaState(ctx, layer, newState.Reshape(ctx, headVDim, headVDim*numVHeads, nSeqs))
+
+	return output
 }
 
 // deltaNetAutoregressive implements single-token state update.

--- a/model/models/qwen3next/deltanet_test.go
+++ b/model/models/qwen3next/deltanet_test.go
@@ -1,0 +1,369 @@
+package qwen3next
+
+import (
+	"math"
+	"os"
+	"testing"
+
+	"github.com/ollama/ollama/fs/ggml"
+	"github.com/ollama/ollama/ml"
+	"github.com/ollama/ollama/model/input"
+)
+
+func TestDeltaNetAutoregressiveFusedMatchesExplicit(t *testing.T) {
+	fusedOut, fusedState := runDeltaNetAutoregressiveCase(t, true)
+	explicitOut, explicitState := runDeltaNetAutoregressiveCase(t, false)
+
+	assertCloseFloat32s(t, "output", explicitOut, fusedOut, 1e-5)
+	assertCloseFloat32s(t, "state", explicitState, fusedState, 1e-5)
+}
+
+func TestDeltaNetAutoregressiveFusedMaintainsStateAcrossSteps(t *testing.T) {
+	cases := []struct {
+		name      string
+		headDim   int
+		numKHeads int
+		numVHeads int
+	}{
+		{
+			name:      "production grouped heads",
+			headDim:   128,
+			numKHeads: 2,
+			numVHeads: 16,
+		},
+		{
+			name:      "single key head",
+			headDim:   16,
+			numKHeads: 1,
+			numVHeads: 4,
+		},
+		{
+			name:      "equal heads",
+			headDim:   16,
+			numKHeads: 4,
+			numVHeads: 4,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			fusedOut, fusedState := runDeltaNetAutoregressiveSequenceCase(t, true, tt.headDim, tt.numKHeads, tt.numVHeads)
+			explicitOut, explicitState := runDeltaNetAutoregressiveSequenceCase(t, false, tt.headDim, tt.numKHeads, tt.numVHeads)
+
+			assertCloseFloat32s(t, "output", explicitOut, fusedOut, 2e-4)
+			assertCloseFloat32s(t, "state", explicitState, fusedState, 2e-4)
+		})
+	}
+}
+
+func runDeltaNetAutoregressiveCase(t *testing.T, fused bool) ([]float32, []float32) {
+	t.Helper()
+
+	backend := setupDeltaNetBackend(t)
+	defer backend.Close()
+
+	const (
+		headDim     = 2
+		numKHeads   = 2
+		numVHeads   = 4
+		nSeqTokens  = 1
+		nSeqs       = 1
+		deltaSize   = headDim * headDim * numVHeads
+		recurrentIx = 0
+	)
+
+	opts := &Options{
+		eps:            1e-6,
+		vHeadReordered: true,
+	}
+
+	seqBatch := input.Batch{
+		Positions: []int32{0},
+		Sequences: []int{0},
+	}
+
+	ctx := backend.NewContext().Input()
+	defer ctx.Close()
+
+	fusedCache := NewHybridCache(nil, 0, 0, deltaSize)
+	fusedCache.Init(backend, ml.DTypeF32, 1, 8, 1)
+	defer fusedCache.Close()
+	if err := fusedCache.StartForward(ctx, seqBatch, false); err != nil {
+		t.Fatal(err)
+	}
+
+	explicitCache := NewHybridCache(nil, 0, 0, deltaSize)
+	explicitCache.Init(backend, ml.DTypeF32, 1, 8, 1)
+	defer explicitCache.Close()
+	if err := explicitCache.StartForward(ctx, seqBatch, false); err != nil {
+		t.Fatal(err)
+	}
+
+	q := ctx.FromFloats([]float32{
+		0.3, -0.4,
+		0.6, 0.2,
+	}, headDim, numKHeads, nSeqTokens, nSeqs)
+	k := ctx.FromFloats([]float32{
+		0.2, 0.7,
+		-0.5, 0.4,
+	}, headDim, numKHeads, nSeqTokens, nSeqs)
+	v := ctx.FromFloats([]float32{
+		1.0, -0.5,
+		0.25, 0.8,
+		-0.1, 0.9,
+		0.7, -0.3,
+	}, headDim, numVHeads, nSeqTokens, nSeqs)
+	gate := ctx.FromFloats([]float32{
+		-0.2, 0.1,
+		0.0, -0.4,
+	}, 1, numVHeads, nSeqTokens, nSeqs)
+	beta := ctx.FromFloats([]float32{
+		0.3, 0.6, -0.2, 0.1,
+	}, 1, numVHeads, nSeqTokens, nSeqs)
+	state := ctx.Zeros(ml.DTypeF32, headDim, headDim*numVHeads, nSeqTokens, nSeqs)
+
+	explicitQ, explicitK := repeatQKToVHeads(ctx, q, k, headDim, numKHeads, numVHeads, nSeqTokens, nSeqs, opts.vHeadReordered)
+
+	var gdn GatedDeltaNet
+	var out ml.Tensor
+	cache := explicitCache
+	if fused {
+		out = gdn.deltaNetAutoregressiveFused(ctx, q, k, v, gate, beta, state, opts, recurrentIx, fusedCache)
+		cache = fusedCache
+	} else {
+		out = gdn.deltaNetAutoregressive(ctx, explicitQ, explicitK, v, gate, beta, state, opts, recurrentIx, explicitCache)
+	}
+
+	ctx.Forward(out).Compute(out)
+	output := out.Floats()
+
+	checkCtx := backend.NewContext().Input()
+	defer checkCtx.Close()
+	if err := cache.StartForward(checkCtx, seqBatch, false); err != nil {
+		t.Fatal(err)
+	}
+	stateOut, err := cache.DeltaState(checkCtx, recurrentIx, headDim, numVHeads)
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkCtx.Forward(stateOut).Compute(stateOut)
+	return output, stateOut.Floats()
+}
+
+func runDeltaNetAutoregressiveSequenceCase(t *testing.T, fused bool, headDim, numKHeads, numVHeads int) ([]float32, []float32) {
+	t.Helper()
+
+	backend := setupDeltaNetBackend(t)
+	defer backend.Close()
+
+	const (
+		nSeqTokens  = 1
+		nSeqs       = 2
+		steps       = 4
+		recurrentIx = 0
+	)
+
+	deltaSize := headDim * headDim * numVHeads
+	opts := &Options{
+		eps:            1e-6,
+		vHeadReordered: true,
+	}
+
+	cache := NewHybridCache(nil, 0, 0, deltaSize)
+	cache.Init(backend, ml.DTypeF32, nSeqs, 16, nSeqs)
+	defer cache.Close()
+
+	seqBatch := input.Batch{
+		Positions: []int32{0, 0},
+		Sequences: []int{0, 1},
+	}
+
+	seedCtx := backend.NewContext().Input()
+	if err := cache.StartForward(seedCtx, seqBatch, false); err != nil {
+		t.Fatal(err)
+	}
+	initialState := seedCtx.FromFloats(deterministicFloats(deltaSize*nSeqs, 0.05), headDim, headDim*numVHeads, nSeqs)
+	cache.UpdateDeltaState(seedCtx, recurrentIx, initialState)
+	seedCtx.Compute()
+	seedCtx.Close()
+
+	var outputs []float32
+	var gdn GatedDeltaNet
+	for step := range steps {
+		ctx := backend.NewContext().Input()
+		seqBatch.Positions = []int32{int32(step + 1), int32(step + 1)}
+		if err := cache.StartForward(ctx, seqBatch, false); err != nil {
+			t.Fatal(err)
+		}
+
+		state, err := cache.DeltaState(ctx, recurrentIx, headDim, numVHeads)
+		if err != nil {
+			t.Fatal(err)
+		}
+		state = state.Reshape(ctx, headDim, headDim*numVHeads, nSeqTokens, nSeqs)
+
+		q := ctx.FromFloats(deterministicFloats(headDim*numKHeads*nSeqs, float32(step)+0.10), headDim, numKHeads, nSeqTokens, nSeqs)
+		k := ctx.FromFloats(deterministicFloats(headDim*numKHeads*nSeqs, float32(step)+0.20), headDim, numKHeads, nSeqTokens, nSeqs)
+		v := ctx.FromFloats(deterministicFloats(headDim*numVHeads*nSeqs, float32(step)+0.30), headDim, numVHeads, nSeqTokens, nSeqs)
+		gate := ctx.FromFloats(deterministicFloats(numVHeads*nSeqs, float32(step)+0.40), 1, numVHeads, nSeqTokens, nSeqs)
+		beta := ctx.FromFloats(deterministicFloats(numVHeads*nSeqs, float32(step)+0.50), 1, numVHeads, nSeqTokens, nSeqs)
+
+		var out ml.Tensor
+		if fused {
+			out = gdn.deltaNetAutoregressiveFused(ctx, q, k, v, gate, beta, state, opts, recurrentIx, cache)
+		} else {
+			q, k = repeatQKToVHeads(ctx, q, k, headDim, numKHeads, numVHeads, nSeqTokens, nSeqs, opts.vHeadReordered)
+			out = gdn.deltaNetAutoregressive(ctx, q, k, v, gate, beta, state, opts, recurrentIx, cache)
+		}
+
+		ctx.Forward(out).Compute(out)
+		outputs = append(outputs, out.Floats()...)
+		ctx.Close()
+	}
+
+	checkCtx := backend.NewContext().Input()
+	seqBatch.Positions = []int32{steps + 1, steps + 1}
+	if err := cache.StartForward(checkCtx, seqBatch, false); err != nil {
+		t.Fatal(err)
+	}
+	stateOut, err := cache.DeltaState(checkCtx, recurrentIx, headDim, numVHeads)
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkCtx.Forward(stateOut).Compute(stateOut)
+	state := stateOut.Floats()
+	checkCtx.Close()
+
+	return outputs, state
+}
+
+func TestUseFusedDeltaNetGuard(t *testing.T) {
+	cases := []struct {
+		name           string
+		supported      bool
+		nSeqTokens     int
+		numKHeads      int
+		numVHeads      int
+		vHeadReordered bool
+		want           bool
+	}{
+		{
+			name:       "unsupported backend",
+			supported:  false,
+			nSeqTokens: 1,
+			numKHeads:  4,
+			numVHeads:  4,
+			want:       false,
+		},
+		{
+			name:       "equal heads",
+			supported:  true,
+			nSeqTokens: 1,
+			numKHeads:  4,
+			numVHeads:  4,
+			want:       true,
+		},
+		{
+			name:           "single key head reordered",
+			supported:      true,
+			nSeqTokens:     1,
+			numKHeads:      1,
+			numVHeads:      4,
+			vHeadReordered: true,
+			want:           true,
+		},
+		{
+			name:           "grouped key heads reordered",
+			supported:      true,
+			nSeqTokens:     1,
+			numKHeads:      2,
+			numVHeads:      4,
+			vHeadReordered: true,
+			want:           true,
+		},
+		{
+			name:           "chunked path",
+			supported:      true,
+			nSeqTokens:     2,
+			numKHeads:      1,
+			numVHeads:      4,
+			vHeadReordered: true,
+			want:           false,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := useFusedDeltaNet(tt.supported, tt.nSeqTokens, tt.numKHeads, tt.numVHeads, tt.vHeadReordered)
+			if got != tt.want {
+				t.Fatalf("useFusedDeltaNet() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRepeatQKToVHeadsReordered(t *testing.T) {
+	backend := setupDeltaNetBackend(t)
+	defer backend.Close()
+
+	ctx := backend.NewContext().Input()
+	defer ctx.Close()
+
+	q := ctx.FromFloats([]float32{0.3, -0.4}, 2, 1, 1, 1)
+	k := ctx.FromFloats([]float32{0.2, 0.7}, 2, 1, 1, 1)
+	q, k = repeatQKToVHeads(ctx, q, k, 2, 1, 4, 1, 1, true)
+
+	ctx.Forward(q, k).Compute(q, k)
+
+	assertCloseFloat32s(t, "q", []float32{0.3, -0.4, 0.3, -0.4, 0.3, -0.4, 0.3, -0.4}, q.Floats(), 1e-6)
+	assertCloseFloat32s(t, "k", []float32{0.2, 0.7, 0.2, 0.7, 0.2, 0.7, 0.2, 0.7}, k.Floats(), 1e-6)
+}
+
+func setupDeltaNetBackend(tb testing.TB) ml.Backend {
+	tb.Helper()
+
+	f, err := os.CreateTemp(tb.TempDir(), "*.bin")
+	if err != nil {
+		tb.Fatal(err)
+	}
+	defer f.Close()
+
+	if err := ggml.WriteGGUF(f, ggml.KV{
+		"general.architecture": "test",
+		"block_count":          uint32(1),
+	}, nil); err != nil {
+		tb.Fatal(err)
+	}
+
+	backend, err := ml.NewBackend(f.Name(), ml.BackendParams{AllocMemory: true})
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	return backend
+}
+
+func deterministicFloats(n int, seed float32) []float32 {
+	values := make([]float32, n)
+	for i := range values {
+		x := math.Sin(float64(seed)+float64(i+1)*0.113) * 0.25
+		values[i] = float32(x)
+	}
+	return values
+}
+
+func assertCloseFloat32s(t *testing.T, name string, want, got []float32, tol float64) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("%s length = %d, want %d", name, len(got), len(want))
+	}
+
+	for i := range want {
+		diff := math.Abs(float64(got[i] - want[i]))
+		if diff > tol {
+			t.Fatalf("%s[%d] = %.8f, want %.8f (diff %.8f > %.8f)\nall got:  %v\nall want: %v",
+				name, i, got[i], want[i], diff, tol, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Refs #16149

This changes Ollama to use a fused ggml Gated Delta Net op for Qwen3Next and Qwen35 autoregressive decode when the active backend can execute it directly.

## What changed

- Backports `ggml_gated_delta_net` from llama.cpp commit `c5a778891`.
- Adds CPU and CUDA implementations for the fused op.
- Adds Go bindings through `ml.Tensor.GatedDeltaNet`.
- Uses the fused op in Qwen3Next and Qwen35 decode only when:
  - the current step is autoregressive decode,
  - the Q/K and V head layout is compatible,
  - the active layer backend can execute the op directly.
- Keeps chunked prefill on the existing explicit graph.
- Leaves unsupported backends on the existing unfused path.

## Why

Qwen3Next and Qwen35 use recurrent Gated Delta Net layers. During decode, the recurrent update can be represented as one fused operation instead of a larger graph of smaller tensor operations. llama.cpp already has this fused op, but Ollama currently pins llama.cpp at `ec98e2002`, which predates the upstream GDN implementation. This patch is therefore needed until Ollama's llama.cpp pin moves past `c5a778891`.

When the pin is advanced past that upstream commit, this backport patch should be removed with the pin bump.

## Backend behaviour

The fused path is currently enabled for CPU and CUDA only. CUDA support is limited to the upstream-specialised `S_v` values:

- 16
- 32
- 64
- 128

Metal, Vulkan, unknown backends and unsupported CUDA head sizes continue to use the existing explicit graph.

## Validation

Ran locally on the clean branch:

```text
cmake --build build --target ggml ggml-cpu ggml-cuda -j$(nproc)
```

```text
OLLAMA_LIBRARY_PATH=/home/jayson/ollama-gdn-pr-clean/build/lib/ollama \
LD_LIBRARY_PATH=/home/jayson/ollama-gdn-pr-clean/build/lib/ollama:/usr/local/cuda-13.2/lib64:$LD_LIBRARY_PATH \
/usr/local/go/bin/go test ./ml/backend/ggml -run 'TestGatedDeltaNetCUDAParity' -count=1 -v
```

```text
OLLAMA_LIBRARY_PATH=/home/jayson/ollama-gdn-pr-clean/build/lib/ollama \
LD_LIBRARY_PATH=/home/jayson/ollama-gdn-pr-clean/build/lib/ollama:/usr/local/cuda-13.2/lib64:$LD_LIBRARY_PATH \
/usr/local/go/bin/go test ./model/models/qwen3next ./ml/backend/ggml ./kvcache ./llm \
  -run 'TestDeltaNet|TestUseFusedDeltaNet|TestRepeatQK|TestGatedDeltaNet|TestMoEExpertTensorDetection|TestNewMoESplitRejectsModelsWithoutDetectedExperts|TestLLMServerMoE|TestLLMServerVerifyLayoutMoE|TestRecurrent' \
  -count=1
```

```text
PATH=/usr/local/cuda-13.2/bin:$PATH /usr/local/go/bin/go build -o ./ollama .
git diff --check
git show --check -1
```

The CUDA parity test was run against an RTX 3060 and covers `S_v` values 16, 32, 64 and 128.

## Local performance notes

On a local exact Qwen3.6/Qwen3Next GGUF setup, measured on the companion MoE-offload fit branch where this model can be loaded with the same local constraints:

```text
context   before    after     change
4k        24.15     27.01     +11.9%
32k       19.22     20.16     +4.9%
64k       16.62     18.48     +11.2%
128k      15.05     15.26     +1.4%
```

These numbers are included as local evidence that the fused decode path is active and beneficial. They are not intended to claim that this PR alone resolves all Qwen3Next performance differences versus llama.cpp.
