### PR TITLE
Support automatic installation for Pool

### DIFF
--- a/cmd/launch/integrations_test.go
+++ b/cmd/launch/integrations_test.go
@@ -1819,15 +1819,6 @@ func TestListIntegrationInfos(t *testing.T) {
 		}
 
 		want := append([]string(nil), integrationOrder...)
-		if poolsideGOOS == "windows" {
-			filtered := make([]string, 0, len(want))
-			for _, name := range want {
-				if name != "pool" {
-					filtered = append(filtered, name)
-				}
-			}
-			want = filtered
-		}
 		if codexAppSupported() != nil {
 			filtered := make([]string, 0, len(want))
 			for _, name := range want {
@@ -1872,12 +1863,9 @@ func TestListIntegrationInfos(t *testing.T) {
 	})
 
 	t.Run("includes known integrations", func(t *testing.T) {
-		known := map[string]bool{"claude": false, "cline": false, "codex": false, "opencode": false, "omp": false}
+		known := map[string]bool{"claude": false, "cline": false, "codex": false, "opencode": false, "omp": false, "pool": false}
 		if codexAppSupported() == nil {
 			known["codex-app"] = false
-		}
-		if poolsideGOOS != "windows" {
-			known["pool"] = false
 		}
 		for _, info := range infos {
 			if _, ok := known[info.Name]; ok {
@@ -1921,18 +1909,6 @@ func TestListIntegrationInfos(t *testing.T) {
 			t.Fatal("expected hermes integration runner to be present")
 		}
 	})
-}
-
-func TestListIntegrationInfos_HidesPoolsideOnWindows(t *testing.T) {
-	prev := poolsideGOOS
-	poolsideGOOS = "windows"
-	t.Cleanup(func() { poolsideGOOS = prev })
-
-	for _, info := range ListIntegrationInfos() {
-		if info.Name == "pool" {
-			t.Fatal("expected pool to be hidden on Windows")
-		}
-	}
 }
 
 func TestListIntegrationInfos_HidesClaudeDesktop(t *testing.T) {
@@ -2031,6 +2007,7 @@ func TestIntegration_AutoInstallable(t *testing.T) {
 	}{
 		{"openclaw", true},
 		{"pi", true},
+		{"pool", true},
 		{"hermes", true},
 		{"hermes-desktop", true},
 		{"cline", true},
@@ -2052,20 +2029,6 @@ func TestIntegration_AutoInstallable(t *testing.T) {
 				t.Errorf("integrationFor(%q).autoInstallable = %v, want %v", tt.name, got, tt.want)
 			}
 		})
-	}
-}
-
-func TestEnsureIntegrationInstalled_PoolsideUnsupportedOnWindows(t *testing.T) {
-	prev := poolsideGOOS
-	poolsideGOOS = "windows"
-	t.Cleanup(func() { poolsideGOOS = prev })
-
-	err := EnsureIntegrationInstalled("pool", &Poolside{})
-	if err == nil {
-		t.Fatal("expected Windows unsupported error")
-	}
-	if !strings.Contains(err.Error(), "not currently supported on Windows") {
-		t.Fatalf("expected Windows warning, got %v", err)
 	}
 }
 

--- a/cmd/launch/poolside.go
+++ b/cmd/launch/poolside.go
@@ -12,13 +12,14 @@ import (
 // Poolside implements Runner for Poolside's CLI.
 type Poolside struct{}
 
+const (
+	poolsideUnixInstallScript    = "curl -fsSL https://downloads.poolside.ai/pool/install.sh | sh"
+	poolsideWindowsInstallScript = "irm https://downloads.poolside.ai/pool/install.ps1 | iex"
+)
+
 var poolsideGOOS = runtime.GOOS
 
 func (p *Poolside) String() string { return "Pool" }
-
-func poolsideUnsupportedError() error {
-	return fmt.Errorf("Warning: Poolside is not currently supported on Windows")
-}
 
 func (p *Poolside) args(model string, extra []string) []string {
 	var args []string
@@ -30,13 +31,9 @@ func (p *Poolside) args(model string, extra []string) []string {
 }
 
 func (p *Poolside) Run(model string, _ []LaunchModel, args []string) error {
-	if poolsideGOOS == "windows" {
-		return poolsideUnsupportedError()
-	}
-
-	bin, err := exec.LookPath("pool")
+	bin, err := ensurePoolsideInstalled()
 	if err != nil {
-		return fmt.Errorf("pool is not installed")
+		return err
 	}
 
 	cmd := exec.Command(bin, p.args(model, args)...)
@@ -48,4 +45,80 @@ func (p *Poolside) Run(model string, _ []LaunchModel, args []string) error {
 		"POOLSIDE_API_KEY=ollama",
 	)
 	return cmd.Run()
+}
+
+func ensurePoolsideInstalled() (string, error) {
+	if path, err := exec.LookPath("pool"); err == nil {
+		return path, nil
+	}
+
+	if poolsideGOOS == "windows" {
+		return ensurePoolsideInstalledWindows()
+	}
+	return ensurePoolsideInstalledUnix()
+}
+
+func ensurePoolsideInstalledUnix() (string, error) {
+	if _, err := exec.LookPath("curl"); err != nil {
+		return "", fmt.Errorf("pool is not installed and curl is required to install it\n\nInstall curl, then re-run:\n  ollama launch pool")
+	}
+	if _, err := exec.LookPath("sh"); err != nil {
+		return "", fmt.Errorf("pool is not installed and sh is required to install it\n\nInstall a POSIX shell, then re-run:\n  ollama launch pool")
+	}
+
+	ok, err := ConfirmPrompt("Pool is not installed. Install now?")
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		return "", fmt.Errorf("pool installation cancelled")
+	}
+
+	fmt.Fprintf(os.Stderr, "\nInstalling Pool...\n")
+	cmd := exec.Command("sh", "-c", poolsideUnixInstallScript)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("failed to install pool: %w", err)
+	}
+
+	path, err := exec.LookPath("pool")
+	if err != nil {
+		return "", fmt.Errorf("pool was installed but the binary was not found on PATH\n\nYou may need to restart your shell")
+	}
+
+	fmt.Fprintf(os.Stderr, "%sPool installed successfully%s\n\n", ansiGreen, ansiReset)
+	return path, nil
+}
+
+func ensurePoolsideInstalledWindows() (string, error) {
+	if _, err := exec.LookPath("powershell"); err != nil {
+		return "", fmt.Errorf("pool is not installed and PowerShell is required to install it\n\nInstall PowerShell, then re-run:\n  ollama launch pool")
+	}
+
+	ok, err := ConfirmPrompt("Pool is not installed. Install now?")
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		return "", fmt.Errorf("pool installation cancelled")
+	}
+
+	fmt.Fprintf(os.Stderr, "\nInstalling Pool...\n")
+	cmd := exec.Command("powershell", "-NoProfile", "-Command", poolsideWindowsInstallScript)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("failed to install pool: %w", err)
+	}
+
+	path, err := exec.LookPath("pool")
+	if err != nil {
+		return "", fmt.Errorf("pool was installed but the binary was not found on PATH\n\nYou may need to restart your shell")
+	}
+
+	fmt.Fprintf(os.Stderr, "%sPool installed successfully%s\n\n", ansiGreen, ansiReset)
+	return path, nil
 }

--- a/cmd/launch/poolside_test.go
+++ b/cmd/launch/poolside_test.go
@@ -71,18 +71,3 @@ func TestPoolsideRunSetsOllamaEnv(t *testing.T) {
 		t.Fatalf("expected model and extra args in log, got:\n%s", got)
 	}
 }
-
-func TestPoolsideRunWindowsUnsupported(t *testing.T) {
-	prev := poolsideGOOS
-	poolsideGOOS = "windows"
-	t.Cleanup(func() { poolsideGOOS = prev })
-
-	p := &Poolside{}
-	err := p.Run("kimi-k2.6:cloud", nil, nil)
-	if err == nil {
-		t.Fatal("expected Windows unsupported error")
-	}
-	if !strings.Contains(err.Error(), "not currently supported on Windows") {
-		t.Fatalf("expected Windows warning, got %v", err)
-	}
-}

--- a/cmd/launch/registry.go
+++ b/cmd/launch/registry.go
@@ -215,6 +215,10 @@ var integrationSpecs = []*IntegrationSpec{
 				_, err := exec.LookPath("pool")
 				return err == nil
 			},
+			EnsureInstalled: func() error {
+				_, err := ensurePoolsideInstalled()
+				return err
+			},
 			URL: "https://github.com/poolsideai/pool",
 		},
 	},
@@ -370,9 +374,6 @@ func ListVisibleIntegrationSpecs() []IntegrationSpec {
 		if supported, ok := spec.Runner.(SupportedIntegration); ok && supported.Supported() != nil {
 			continue
 		}
-		if spec.Name == "pool" && poolsideGOOS == "windows" {
-			continue
-		}
 		visible = append(visible, *spec)
 	}
 
@@ -491,10 +492,6 @@ func EnsureIntegrationInstalled(name string, runner Runner) error {
 		if err := supported.Supported(); err != nil {
 			return err
 		}
-	}
-
-	if integration.spec.Name == "pool" && poolsideGOOS == "windows" {
-		return poolsideUnsupportedError()
 	}
 
 	if integration.installed {

--- a/cmd/launch/runner_exec_only_test.go
+++ b/cmd/launch/runner_exec_only_test.go
@@ -73,10 +73,6 @@ func TestEditorRunsDoNotRewriteConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.name == "pool" && poolsideGOOS == "windows" {
-				t.Skip("Poolside is intentionally unsupported on Windows")
-			}
-
 			home := t.TempDir()
 			setTestHome(t, home)
 

--- a/docs/integrations/pool.mdx
+++ b/docs/integrations/pool.mdx
@@ -31,7 +31,7 @@ ollama launch pool
 ### Run directly with a model
 
 ```shell
-ollama launch pool --model kimi-k2.6:cloud
+ollama launch pool --model laguna-xs.2
 ```
 
 ### Pass arguments through to Pool
@@ -56,11 +56,11 @@ export POOLSIDE_API_KEY=ollama
 2. Run Pool with an Ollama model:
 
 ```shell
-pool -m kimi-k2.6:cloud
+pool -m laguna-xs.2
 ```
 
 Or run with environment variables inline:
 
 ```shell
-POOLSIDE_STANDALONE_BASE_URL=http://localhost:11434/v1 POOLSIDE_API_KEY=ollama pool -m kimi-k2.6:cloud
+POOLSIDE_STANDALONE_BASE_URL=http://localhost:11434/v1 POOLSIDE_API_KEY=ollama pool -m laguna-xs.2
 ```

--- a/docs/integrations/pool.mdx
+++ b/docs/integrations/pool.mdx
@@ -6,7 +6,19 @@ Pool is Poolside's software agent for the terminal, built for enterprise develop
 
 ## Install
 
-Install [Pool](https://github.com/poolsideai/pool):
+`ollama launch pool` will install [Pool](https://github.com/poolsideai/pool) on first run, or you can install it ahead of time:
+
+**macOS / Linux**
+
+```shell
+curl -fsSL https://downloads.poolside.ai/pool/install.sh | sh
+```
+
+**Windows**
+
+```powershell
+irm https://downloads.poolside.ai/pool/install.ps1 | iex
+```
 
 ## Usage with Ollama
 


### PR DESCRIPTION
Adding support for auto-installing [Pool](https://github.com/poolsideai/pool). We also support Windows now, so I removed previous checks.

Tested manually by removing installed `pool` with `command -v pool >/dev/null && rm -- "$(command -v pool)"` and then trying:

1. Default UI selection flow: `go run .`
2. Direct launch flow: `go run . launch pool --model laguna-xs.2`