### PR TITLE
Add OLLAMA_NUM_THREAD default capped at 85% of CPU cores

### DIFF
--- a/discover/gpu.go
+++ b/discover/gpu.go
@@ -29,22 +29,27 @@ func GetSystemInfo() ml.SystemInfo {
 	if err != nil {
 		slog.Warn("error looking up system memory", "error", err)
 	}
-	var threadCount int
+	var threadCount, totalCoreCount int
 	cpus := GetCPUDetails()
 	for _, c := range cpus {
 		threadCount += c.CoreCount - c.EfficiencyCoreCount
+		totalCoreCount += c.CoreCount
 	}
 
 	if threadCount == 0 {
 		// Fall back to Go's num CPU
 		threadCount = runtime.NumCPU()
 	}
+	if totalCoreCount == 0 {
+		totalCoreCount = runtime.NumCPU()
+	}
 
 	return ml.SystemInfo{
-		ThreadCount: threadCount,
-		TotalMemory: memInfo.TotalMemory,
-		FreeMemory:  memInfo.FreeMemory,
-		FreeSwap:    memInfo.FreeSwap,
+		ThreadCount:    threadCount,
+		TotalCoreCount: totalCoreCount,
+		TotalMemory:    memInfo.TotalMemory,
+		FreeMemory:     memInfo.FreeMemory,
+		FreeSwap:       memInfo.FreeSwap,
 	}
 }
 

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -271,6 +271,11 @@ func Uint(key string, defaultValue uint) func() uint {
 }
 
 var (
+	// NumThread sets the default CPU thread count for model inference when the
+	// client does not pass num_thread. Zero means use hardware discovery.
+	// When set, the value is capped at 85% of the sum of physical CoreCount from CPU discovery.
+	// NumThread can be configured via the OLLAMA_NUM_THREAD environment variable.
+	NumThread = Uint("OLLAMA_NUM_THREAD", 0)
 	// NumParallel sets the number of parallel model requests. NumParallel can be configured via the OLLAMA_NUM_PARALLEL environment variable.
 	NumParallel = Uint("OLLAMA_NUM_PARALLEL", 1)
 	// MaxRunners sets the maximum number of loaded models. MaxRunners can be configured via the OLLAMA_MAX_LOADED_MODELS environment variable.
@@ -327,6 +332,7 @@ func AsMap() map[string]EnvVar {
 		"OLLAMA_NOHISTORY":            {"OLLAMA_NOHISTORY", NoHistory(), "Do not preserve readline history"},
 		"OLLAMA_NOPRUNE":              {"OLLAMA_NOPRUNE", NoPrune(), "Do not prune model blobs on startup"},
 		"OLLAMA_NUM_PARALLEL":         {"OLLAMA_NUM_PARALLEL", NumParallel(), "Maximum number of parallel requests"},
+		"OLLAMA_NUM_THREAD":           {"OLLAMA_NUM_THREAD", NumThread(), "Default CPU threads for inference when not set per request (0 = use hardware discovery; capped at 85% of discovered physical core count)"},
 		"OLLAMA_ORIGINS":              {"OLLAMA_ORIGINS", AllowedOrigins(), "A comma separated list of allowed origins"},
 		"OLLAMA_SCHED_SPREAD":         {"OLLAMA_SCHED_SPREAD", SchedSpread(), "Always schedule model across all GPUs"},
 		"OLLAMA_MULTIUSER_CACHE":      {"OLLAMA_MULTIUSER_CACHE", MultiUserCache(), "Optimize prompt caching for multi-user scenarios"},

--- a/llm/server.go
+++ b/llm/server.go
@@ -175,6 +175,24 @@ func NewLlamaServer(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, modelPath st
 	loadRequest := LoadRequest{LoraPath: adapters, KvSize: opts.NumCtx * numParallel, BatchSize: opts.NumBatch, Parallel: numParallel, MultiUserCache: envconfig.MultiUserCache()}
 
 	defaultThreads := systemInfo.ThreadCount
+	if n := envconfig.NumThread(); n > 0 {
+		requested := int(n)
+		if systemInfo.TotalCoreCount > 0 {
+			maxAllowed := (systemInfo.TotalCoreCount * 85) / 100
+			switch {
+			case requested > maxAllowed && maxAllowed > 0:
+				slog.Warn("OLLAMA_NUM_THREAD exceeds 85% of physical core count, clamping", "requested", requested, "max", maxAllowed, "total_cores", systemInfo.TotalCoreCount)
+				defaultThreads = maxAllowed
+			case requested > maxAllowed && maxAllowed == 0:
+				slog.Warn("OLLAMA_NUM_THREAD exceeds 85% of physical core count (limit rounds down to zero for this system), ignoring OLLAMA_NUM_THREAD", "requested", requested, "total_cores", systemInfo.TotalCoreCount)
+				// defaultThreads remains systemInfo.ThreadCount
+			default:
+				defaultThreads = requested
+			}
+		} else {
+			defaultThreads = requested
+		}
+	}
 	if opts.NumThread > 0 {
 		loadRequest.NumThreads = opts.NumThread
 	} else if defaultThreads > 0 {

--- a/ml/device.go
+++ b/ml/device.go
@@ -325,6 +325,10 @@ type SystemInfo struct {
 	// ThreadCount is the optimal number of threads to use for inference
 	ThreadCount int `json:"threads,omitempty"`
 
+	// TotalCoreCount is the sum of physical CoreCount across all CPU packages
+	// (performance plus efficiency cores). Used for limits such as OLLAMA_NUM_THREAD.
+	TotalCoreCount int `json:"total_cores,omitempty"`
+
 	// TotalMemory is the total amount of system memory
 	TotalMemory uint64 `json:"total_memory,omitempty"`
 


### PR DESCRIPTION
Introduce OLLAMA_NUM_THREAD in envconfig for a server-wide default when
clients omit num_thread.
Populate SystemInfo.TotalCoreCount from summed CPU CoreCount (with
fallback) and clamp the env value to floor(85% of that total), logging
when clamped or ignored.
Per-request num_thread and Modelfile overrides are unchanged.
