### PR TITLE
Add Fedora to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,3 +354,4 @@ console.log(response.message.content);
 - [Gentoo](https://github.com/gentoo/guru/tree/master/app-misc/ollama)
 - [Flox](https://flox.dev/blog/ollama-part-one)
 - [Guix channel](https://codeberg.org/tusharhero/ollama-guix)
+- [Fedora](https://packages.fedoraproject.org/pkgs/ollama/ollama/)


### PR DESCRIPTION
I maintain the ollama package in Fedora and want to share its location.