### PR TITLE
test: cover llama-server physical batch args

### DIFF
--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -1142,6 +1142,12 @@ func TestAppendBatchArgs(t *testing.T) {
 			want:        []string{"-b", "1024", "-ub", "1024"},
 		},
 		{
+			name:        "generation sets physical batch for default options",
+			opts:        api.DefaultOptions(),
+			numParallel: 1,
+			want:        []string{"-b", "512", "-ub", "512"},
+		},
+		{
 			name:        "generation omits unset batch",
 			opts:        api.Options{},
 			numParallel: 1,


### PR DESCRIPTION
## Summary
- Adds a regression test that default llama-server generation requests set both logical (`-b`) and physical (`-ub`) batch size flags.
- Covers the prompt-eval regression path from #16148 where leaving llama-server's physical batch at its default reduced prefill throughput for small models.

## Test Plan
- `PATH=/home/ubuntu/.local/go/bin:$PATH go test ./llm -run 'TestAppendBatchArgs|TestEmbeddingBatchSize' -count=1`
- `PATH=/home/ubuntu/.local/go/bin:$PATH go test ./llm -count=1`

Refs #16148
