### PR TITLE
docs: document Linux context length service config

### DIFF
--- a/docs/context-length.mdx
+++ b/docs/context-length.mdx
@@ -30,6 +30,28 @@ If editing the context length for Ollama is not possible, the context length can
 OLLAMA_CONTEXT_LENGTH=64000 ollama serve
 ```
 
+### Linux service
+
+If Ollama is running as a systemd service, set `OLLAMA_CONTEXT_LENGTH` in the service environment:
+
+```shell
+sudo systemctl edit ollama
+```
+
+Add the context length under the `[Service]` section:
+
+```ini
+[Service]
+Environment="OLLAMA_CONTEXT_LENGTH=64000"
+```
+
+Then reload systemd and restart Ollama:
+
+```shell
+sudo systemctl daemon-reload
+sudo systemctl restart ollama
+```
+
 ### Check allocated context length and model offloading
 For best performance, use the maximum context length for a model, and avoid offloading the model to CPU. Verify the split under `PROCESSOR` using `ollama ps`.
 ```


### PR DESCRIPTION
## Summary
- add Linux systemd service instructions for setting OLLAMA_CONTEXT_LENGTH
- include daemon reload and service restart commands

Fixes #15848

## Tests
- git diff --check