### PR TITLE
convert: bound safetensors header length before allocation

### DIFF
--- a/convert/reader_safetensors.go
+++ b/convert/reader_safetensors.go
@@ -24,6 +24,10 @@ type safetensorMetadata struct {
 	Offsets []int64  `json:"data_offsets"`
 }
 
+// maxSafetensorsHeader is the largest safetensors header length we will
+// allocate for. The safetensors format specifies a 100MB header limit.
+const maxSafetensorsHeader = 100 << 20
+
 func parseSafetensors(fsys fs.FS, replacer *strings.Replacer, ps ...string) ([]Tensor, error) {
 	fp8Block, err := safetensorsFP8BlockSize(fsys)
 	if err != nil {
@@ -41,6 +45,15 @@ func parseSafetensors(fsys fs.FS, replacer *strings.Replacer, ps ...string) ([]T
 		var n int64
 		if err := binary.Read(f, binary.LittleEndian, &n); err != nil {
 			return nil, err
+		}
+
+		// n is the safetensors header length, read directly from the
+		// (attacker-controlled) file. Validate it before using it as an
+		// allocation size: a negative value panics make() with
+		// "makeslice: cap out of range" and a huge value exhausts memory.
+		// The safetensors format caps the header at 100MB.
+		if n < 0 || n > maxSafetensorsHeader {
+			return nil, fmt.Errorf("invalid safetensors header length %d (must be between 0 and %d bytes)", n, maxSafetensorsHeader)
 		}
 
 		b := bytes.NewBuffer(make([]byte, 0, n))


### PR DESCRIPTION
### Summary

`parseSafetensors` in `convert/reader_safetensors.go` reads the 8-byte
little-endian safetensors header length straight from the input file and
passes it directly to `make([]byte, 0, n)` with no validation:

```go
var n int64
if err := binary.Read(f, binary.LittleEndian, &n); err != nil {
    return nil, err
}

b := bytes.NewBuffer(make([]byte, 0, n)) // n is fully attacker-controlled
```

`n` is `int64`. A value with the high bit set (e.g. `0xFFFF...`) becomes
negative and makes `make()` panic with `makeslice: cap out of range`; a
large positive value requests gigabytes and OOMs the process.

This input is reachable unauthenticated: `/api/create` accepts uploaded
blobs, and `convertFromSafetensors` runs `parseSafetensors` from a
goroutine spawned in `CreateHandler` that has no `recover()`, so the panic
takes down the entire `ollama` server. An 8-byte crafted `.safetensors`
file plus a minimal `config.json`/`tokenizer.json` is enough.

### Fix

Reject header lengths that are negative or exceed the 100MB cap defined by
the safetensors format before using `n` as an allocation size. This is a
small, contained input-validation change with no behavioral impact on
valid models (real headers are JSON metadata, well under 100MB).

### Test plan

- `gofmt`-clean; `go build ./convert/`
- Crafted file with header length `0x7FFFFFFFFFFFFFFF` now returns
  `invalid safetensors header length ...` instead of panicking
- Valid safetensors models continue to convert unchanged
