### PR TITLE
docs: fix GPU docs FAQ link

### DIFF
--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -18,7 +18,7 @@ Review the [Troubleshooting](./troubleshooting.mdx) docs for more about using lo
 
 ## Is my GPU compatible with Ollama?
 
-Please refer to the [GPU docs](./gpu.mdx).
+Please refer to the [GPU docs](./gpu).
 
 ## How can I specify the context window size?
 


### PR DESCRIPTION
## Summary
- update the FAQ GPU docs link to use the docs route instead of the source .mdx path

Fixes #14243

## Tests
- git diff --check