### PR TITLE
server: allow hf.co realm to redirect to huggingface.co (#15661)

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -50,14 +50,30 @@ func (r registryChallenge) URL() (*url.URL, error) {
 	return redirectURL, nil
 }
 
+// realmHostAllowed reports whether the auth realm host is permitted to
+// differ from the original request host. The default behavior is strict
+// equality; this helper allows a small set of known registry aliases that
+// legitimately redirect to a canonical host.
+func realmHostAllowed(originalHost, realmHost string) bool {
+	if originalHost == realmHost {
+		return true
+	}
+	aliases := map[string]string{
+		"hf.co": "huggingface.co",
+	}
+	canonical, ok := aliases[originalHost]
+	return ok && canonical == realmHost
+}
+
 func getAuthorizationToken(ctx context.Context, challenge registryChallenge, originalHost string) (string, error) {
 	redirectURL, err := challenge.URL()
 	if err != nil {
 		return "", err
 	}
 
-	// Validate that the realm host matches the original request host to prevent sending tokens cross-origin.
-	if redirectURL.Host != originalHost {
+	// Validate that the realm host matches the original request host (or a
+	// known safe alias) to prevent sending tokens cross-origin.
+	if !realmHostAllowed(originalHost, redirectURL.Host) {
 		return "", fmt.Errorf("realm host %q does not match original host %q", redirectURL.Host, originalHost)
 	}
 

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -111,3 +111,26 @@ func TestRegistryChallengeURLInvalid(t *testing.T) {
 		t.Error("expected error for invalid URL")
 	}
 }
+
+func TestRealmHostAllowed(t *testing.T) {
+	cases := []struct {
+		name         string
+		originalHost string
+		realmHost    string
+		wantAllowed  bool
+	}{
+		{"same host", "registry.example.com", "registry.example.com", true},
+		{"hf.co alias to huggingface.co", "hf.co", "huggingface.co", true},
+		{"reverse alias rejected", "huggingface.co", "hf.co", false},
+		{"different host rejected", "registry.example.com", "evil.example.com", false},
+		{"empty original rejected", "", "huggingface.co", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := realmHostAllowed(tc.originalHost, tc.realmHost)
+			if got != tc.wantAllowed {
+				t.Errorf("realmHostAllowed(%q, %q) = %v, want %v", tc.originalHost, tc.realmHost, got, tc.wantAllowed)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why

Issue #15661 (open since 2026-04-18) reports that \`ollama pull hf.co/...\` fails with:

\`\`\`
pull model manifest: realm host "huggingface.co" does not match original host "hf.co"
\`\`\`

The mechanics: \`hf.co\` is the HuggingFace short URL that returns HTTP 401 with \`Www-Authenticate: Bearer realm="https://huggingface.co/v2/token"\`. The realm host (\`huggingface.co\`) is the canonical hostname for the same registry. The strict equality check added in 7601f0e9 (PR #13738, additional hardening following the CVE-2025-51471 fix in #10750) rejects this legitimate aliasing.

## What

Adds a \`realmHostAllowed(originalHost, realmHost string) bool\` helper to \`server/auth.go\` and replaces the strict equality with a call to it. The helper consults a hardcoded map of known registry-alias pairs:

\`\`\`go
aliases := map[string]string{
    "hf.co": "huggingface.co",
}
\`\`\`

Default-deny remains for any host pair not in the map. Same pattern Docker, Podman, and containerd use for their known registry-realm aliases. The CVE-2025-51471 protection is preserved: the Authorization token still only goes to a host the maintainers have explicitly blessed.

Adds 5 table-driven cases in \`server/auth_test.go\` covering same-host, alias, reverse-alias, different-host, and empty-host scenarios.

## Impact

- \`ollama pull hf.co/...\` works again.
- All other hosts continue to require strict equality.
- The map is the only structure to update when a future registry-alias pair surfaces.

## Testing

\`\`\`
go test ./server -run TestRealmHostAllowed -v
\`\`\`

Plus manual smoke test: \`ollama pull hf.co/ggerganov/whisper.cpp-large-v3:q8_0\` succeeds after patch.

## References

- Fixes #15661.
- CVE-2025-51471 (originally fixed in #10750).
- PR #13738 (subsequent hardening that introduced the strict realm-host equality check this PR relaxes for known aliases).
