### PR TITLE
server: validate manifest digest format at parse time

### DIFF
--- a/server/images.go
+++ b/server/images.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"slices"
 	"strconv"
@@ -873,7 +874,32 @@ func pullModelManifest(ctx context.Context, n model.Name, regOpts *registryOptio
 		return nil, nil, err
 	}
 
+	if err := validateManifestDigests(&m); err != nil {
+		return nil, nil, err
+	}
+
 	return &m, data, err
+}
+
+var manifestDigestPattern = regexp.MustCompile(`^sha256[:-][0-9a-fA-F]{64}$`)
+
+// validateManifestDigests rejects manifests whose config or layer digests do
+// not match the same regex applied at filesystem-write time in
+// manifest.BlobsPath. Hoisting the check to the parse boundary means a
+// malformed digest cannot reach downstream code paths.
+func validateManifestDigests(m *manifest.Manifest) error {
+	if m.Config.Digest != "" && !manifestDigestPattern.MatchString(m.Config.Digest) {
+		return fmt.Errorf("invalid config digest format: %q", m.Config.Digest)
+	}
+	for i, layer := range m.Layers {
+		if layer.Digest == "" {
+			return fmt.Errorf("layer %d missing digest", i)
+		}
+		if !manifestDigestPattern.MatchString(layer.Digest) {
+			return fmt.Errorf("invalid layer %d digest format: %q", i, layer.Digest)
+		}
+	}
+	return nil
 }
 
 // GetSHA256Digest returns the SHA256 hash of a given buffer and returns it, and the size of buffer

--- a/server/images_test.go
+++ b/server/images_test.go
@@ -430,3 +430,61 @@ func TestPullModelManifest(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateManifestDigests(t *testing.T) {
+	validDigest := "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	cases := []struct {
+		name    string
+		m       manifest.Manifest
+		wantErr bool
+	}{
+		{
+			name: "valid config and layers",
+			m: manifest.Manifest{
+				Config: manifest.Layer{Digest: validDigest},
+				Layers: []manifest.Layer{{Digest: validDigest}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty config digest tolerated",
+			m: manifest.Manifest{
+				Config: manifest.Layer{Digest: ""},
+				Layers: []manifest.Layer{{Digest: validDigest}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing layer digest rejected",
+			m: manifest.Manifest{
+				Config: manifest.Layer{Digest: validDigest},
+				Layers: []manifest.Layer{{Digest: ""}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "malformed digest rejected",
+			m: manifest.Manifest{
+				Config: manifest.Layer{Digest: "sha256:notahex"},
+				Layers: []manifest.Layer{{Digest: validDigest}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "path-traversal attempt rejected",
+			m: manifest.Manifest{
+				Config: manifest.Layer{Digest: "sha256:../etc/passwd"},
+				Layers: []manifest.Layer{{Digest: validDigest}},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateManifestDigests(&tc.m)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("validateManifestDigests err = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why

Digest format is currently validated only when \`manifest.BlobsPath\` runs at filesystem-write time via the regex \`^sha256[:-][0-9a-fA-F]{64}\$\`. Validation lives deep in the call stack instead of at the parse boundary. A future change that moves the disk write or routes the digest through a new code path would bypass the check.

containerd, Docker engine, and podman / c/image all validate digests at manifest-parse, not at filesystem-write. Bringing ollama in line removes a class of latent regression.

## What

Adds \`validateManifestDigests(m *manifest.Manifest) error\` and calls it immediately after \`json.Unmarshal\` in \`pullModelManifest\`. The helper checks \`Config.Digest\` (when non-empty) and every \`Layers[i].Digest\` against the same regex \`manifest.BlobsPath\` uses.

Defense-in-depth on CVE-2024-37032. No behavior change for valid manifests.

Adds 5 table-driven test cases: valid, empty-config-tolerated, missing-layer-digest, malformed-hex, path-traversal-attempt.

## Testing

\`\`\`
go test ./server -run TestValidateManifestDigests -v
\`\`\`

## References

- CVE-2024-37032 (origin of the filesystem-side regex check).
- containerd \`digest.Parse\` precedent.