### PR TITLE
convert: validate safetensors data_offsets before indexing

### DIFF
--- a/convert/reader_safetensors.go
+++ b/convert/reader_safetensors.go
@@ -90,6 +90,9 @@ func parseSafetensors(fsys fs.FS, replacer *strings.Replacer, ps ...string) ([]T
 					return nil, fmt.Errorf("duplicate tensor name '%s' was found for this model", ggufName)
 				}
 				names[ggufName] = struct{}{}
+				if err := validateSafetensorsOffsets(key, value.Offsets); err != nil {
+					return nil, err
+				}
 				ts = append(ts, safetensor{
 					fs:       fsys,
 					path:     p,
@@ -108,6 +111,20 @@ func parseSafetensors(fsys fs.FS, replacer *strings.Replacer, ps ...string) ([]T
 	}
 
 	return ts, nil
+}
+
+// validateSafetensorsOffsets ensures a tensor's data_offsets field is the
+// well-formed [begin, end] pair the rest of the parser assumes. The field is
+// attacker-controlled JSON, so an empty, short, or descending pair must be
+// rejected instead of panicking with an index-out-of-range on Offsets[0:2].
+func validateSafetensorsOffsets(name string, offsets []int64) error {
+	if len(offsets) != 2 {
+		return fmt.Errorf("tensor %q has malformed data_offsets %v (expected [begin, end])", name, offsets)
+	}
+	if offsets[0] < 0 || offsets[1] < offsets[0] {
+		return fmt.Errorf("tensor %q has invalid data_offsets %v", name, offsets)
+	}
+	return nil
 }
 
 // safetensorsPad returns the padded size of the safetensors file given a length n and offset s
@@ -306,6 +323,9 @@ func collectSafetensorsFP8Scales(n int64, headers map[string]safetensorMetadata)
 		}
 		if _, ok := scales.consumed[scaleKey]; ok {
 			return safetensorsFP8Scales{}, fmt.Errorf("fp8 scale companion %q is used by multiple tensors", scaleKey)
+		}
+		if err := validateSafetensorsOffsets(scaleKey, scaleValue.Offsets); err != nil {
+			return safetensorsFP8Scales{}, err
 		}
 
 		scales.byWeight[key] = &safetensorScale{


### PR DESCRIPTION
### Summary

`parseSafetensors` (and `collectSafetensorsFP8Scales`) in
`convert/reader_safetensors.go` index `value.Offsets[0]` and
`value.Offsets[1]` without ever checking the length of the slice:

```go
offset: safetensorsPad(n, value.Offsets[0]),
size:   safetensorsPad(n, value.Offsets[1]) - safetensorsPad(n, value.Offsets[0]),
```

`Offsets` comes straight from the `data_offsets` field of the
attacker-supplied safetensors JSON header. A tensor declaring
`"data_offsets": []` (or omitting it, or giving a single element) makes Go
panic with `index out of range [0] with length 0`.

This is reachable unauthenticated: `/api/create` accepts uploaded blobs,
and `convertFromSafetensors` runs the parser from a goroutine spawned in
`CreateHandler` that has no `recover()`, so the panic takes down the entire
`ollama` server. A small, otherwise-valid `.safetensors` header plus a
minimal `config.json`/`tokenizer.json` is enough.

### Fix

Add `validateSafetensorsOffsets`, which requires `data_offsets` to be a
well-formed `[begin, end]` pair with `begin >= 0` and `end >= begin`, and
call it on both the tensor path and the fp8-scale path before the offsets
are used. Malformed headers now return a descriptive error instead of
crashing the process; valid models are unaffected.

### Test plan

- `gofmt`-clean; `go build ./convert/`
- Crafted header with `"data_offsets": []` now returns
  `tensor "..." has malformed data_offsets [] ...` instead of panicking
- Valid safetensors models continue to convert unchanged
