### PR TITLE
server: reject zero-size tensors in quantizer to avoid panic

### DIFF
--- a/server/quantization.go
+++ b/server/quantization.go
@@ -23,6 +23,15 @@ type quantizer struct {
 }
 
 func (q quantizer) WriteTo(w io.Writer) (int64, error) {
+	// Size() and Elements() multiply the (attacker-controlled) tensor shape
+	// without overflow checks, so a crafted GGUF with a shape like
+	// [2^32, 2^32] wraps the uint64 product to 0. That makes the
+	// len(data) < Size() guard below vacuous (0 < 0) and then panics on
+	// &data[0] over the empty slice. A legitimate weight tensor is never
+	// empty, so reject a zero element count or size up front.
+	if q.from.Elements() == 0 || q.from.Size() == 0 {
+		return 0, fmt.Errorf("tensor %s has invalid shape %v", q.from.Name, q.from.Shape)
+	}
 	quantize := q.from.Kind != q.to.Kind
 	sr := io.NewSectionReader(q, int64(q.offset), int64(q.from.Size()))
 	if !quantize {


### PR DESCRIPTION
### Summary

`Tensor.Size()` and `Tensor.Elements()` in `fs/ggml/ggml.go` multiply the
tensor shape with unchecked `uint64` arithmetic:

```go
func (t Tensor) Elements() uint64 {
    var count uint64 = 1
    for _, n := range t.Shape {
        count *= n // wraps mod 2^64
    }
    return count
}
```

A crafted GGUF whose tensor shape is e.g. `[2^32, 2^32]` wraps the product
to `0`, so `Size() == 0`. In `quantizer.WriteTo` the section reader then
yields an empty `data`, the existing CVE-2026-7482 guard
`len(data) < Size()` becomes vacuous (`0 < 0` is false), and the next line
panics:

```go
f32s = unsafe.Slice((*float32)(unsafe.Pointer(&data[0])), q.from.Elements())
//                                        ^ &data[0] on empty slice → panic
```

`quantizer.WriteTo` runs in an unrecovered errgroup goroutine launched by
`WriteGGUF`, so an unauthenticated `/api/create … "quantize":"Q4_K_M"`
request with such a file crashes the whole `ollama` process. This is an
availability-only bypass of the CVE-2026-7482 size hardening (no heap leak —
the bounds check fires before any C-level read).

### Fix

Reject a zero element count or zero size at the top of `quantizer.WriteTo`.
A legitimate weight tensor being quantized is never empty, so this has no
effect on valid models while turning the crash into a clean error. Kept to
`server/quantization.go` to avoid churning the `Elements()` signature, which
has ~27 call sites across the repo.

### Test plan

- `gofmt`-clean; `go build ./server/`
- Crafted GGUF with shape `[2^32, 2^32]` now returns
  `tensor ... has invalid shape [...]` instead of panicking
- Valid models continue to quantize unchanged
