### PR TITLE
convert: guard special token type assertion against non-objects

### DIFF
--- a/convert/tokenizer_spm.go
+++ b/convert/tokenizer_spm.go
@@ -146,8 +146,13 @@ func parseAdditionalSpecialTokens(fsys fs.FS) ([]specialToken, error) {
 		}
 	case []any:
 		for _, s := range st {
-			// marshal and unmarshal the object to get the special token
-			tMap := s.(map[string]any)
+			// marshal and unmarshal the object to get the special token.
+			// s comes from attacker-controlled JSON: a non-object entry
+			// (e.g. [1,2,3]) would panic an unchecked type assertion.
+			tMap, ok := s.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("invalid additional_special_tokens entry %v: expected object", s)
+			}
 			data, err := json.Marshal(tMap)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
### Summary

`parseAdditionalSpecialTokens` in `convert/tokenizer_spm.go` performs an
unchecked type assertion on every element of the
`additional_special_tokens` array read from `special_tokens_map.json`:

```go
case []any:
    for _, s := range st {
        tMap := s.(map[string]any) // panics if s is not an object
        ...
    }
```

That JSON file is attacker-controlled. An array of non-objects such as
`{"additional_special_tokens":[1,2,3]}` decodes to `[]any{float64, ...}`,
takes the `[]any` branch, and panics with
`interface conversion: interface {} is float64, not map[string]interface {}`.

The parser runs in an unrecovered goroutine spawned by `CreateHandler`, so
an unauthenticated `/api/create` request with a crafted
`special_tokens_map.json` crashes the entire `ollama` process.

### Fix

Use a comma-ok assertion and return a descriptive error for non-object
entries instead of panicking. Valid tokenizer files (string or object
entries) are unaffected.

### Test plan

- `gofmt`-clean; `go build ./convert/`
- `{"additional_special_tokens":[1,2,3]}` now returns
  `invalid additional_special_tokens entry 1: expected object` instead of
  panicking
- Tokenizers with valid string/object special tokens convert unchanged
