### PR TITLE
convert: do not panic on unknown rope scaling type

### DIFF
--- a/convert/convert_phi3.go
+++ b/convert/convert_phi3.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"encoding/binary"
 	"io"
+	"log/slog"
 	"math"
 	"strings"
 	"sync"
@@ -62,7 +63,11 @@ func (p *phi3Model) KV(t *Tokenizer) KV {
 	case "yarn":
 		kv["phi3.rope.scaling.attn_factor"] = float32(max(0.1*math.Log(scale)+1.0, 1.0))
 	default:
-		panic("unknown rope scaling type")
+		// RopeScaling.Type comes from attacker-controlled config.json.
+		// An unrecognized value is unknown metadata, not a security
+		// boundary, so skip it instead of panicking and crashing the
+		// (unrecovered) conversion goroutine.
+		slog.Warn("unknown rope scaling type, ignoring", "type", p.RopeScaling.Type)
 	}
 
 	return kv

--- a/convert/convert_qwen2.go
+++ b/convert/convert_qwen2.go
@@ -1,6 +1,10 @@
 package convert
 
-import "github.com/ollama/ollama/fs/ggml"
+import (
+	"log/slog"
+
+	"github.com/ollama/ollama/fs/ggml"
+)
 
 type qwen2Model struct {
 	ModelParameters
@@ -43,7 +47,11 @@ func (q *qwen2Model) KV(t *Tokenizer) KV {
 	case "mrope", "default":
 		kv["qwen2.rope.mrope_section"] = q.RopeScaling.MropeSection
 	default:
-		panic("unknown rope scaling type")
+		// RopeScaling.Type comes from attacker-controlled config.json.
+		// An unrecognized value is unknown metadata, not a security
+		// boundary, so skip it instead of panicking and crashing the
+		// (unrecovered) conversion goroutine.
+		slog.Warn("unknown rope scaling type, ignoring", "type", q.RopeScaling.Type)
 	}
 	return kv
 }

--- a/convert/convert_qwen3.go
+++ b/convert/convert_qwen3.go
@@ -1,6 +1,7 @@
 package convert
 
 import (
+	"log/slog"
 	"slices"
 	"strings"
 
@@ -67,7 +68,11 @@ func (q *qwen3Model) KV(t *Tokenizer) KV {
 	case "mrope", "default":
 		kv["rope.mrope_section"] = q.RopeScaling.MropeSection
 	default:
-		panic("unknown rope scaling type")
+		// RopeScaling.Type comes from attacker-controlled config.json.
+		// An unrecognized value is unknown metadata, not a security
+		// boundary, so skip it instead of panicking and crashing the
+		// (unrecovered) conversion goroutine.
+		slog.Warn("unknown rope scaling type, ignoring", "type", q.RopeScaling.Type)
 	}
 	return kv
 }


### PR DESCRIPTION
### Summary

The `KV()` converters for `Phi3ForCausalLM`, `Qwen2ForCausalLM`, and the
Qwen3/Qwen3VL families end their `rope_scaling` switch with a bare panic on
the default arm:

```go
switch p.RopeScaling.Type {
case "":
case "su", "longrope": ...
case "yarn": ...
default:
    panic("unknown rope scaling type")
}
```

`RopeScaling.Type` is read straight from the attacker-controlled
`config.json`. Setting `"rope_scaling":{"type":"anything"}` triggers the
panic. `KV()` is invoked from an **unrecovered goroutine** spawned by
`CreateHandler`, so an unauthenticated `POST /api/create` referencing a
crafted `config.json` crashes the entire `ollama` process (Gin's recovery
middleware only covers the request goroutine, not the ones it launches).

Confirmed in `convert/convert_phi3.go`, `convert/convert_qwen2.go`, and
`convert/convert_qwen3.go` (the latter also reachable via `qwen3VLModel`).

### Fix

An unrecognized rope scaling type is unknown metadata, not a security
boundary, and nothing downstream depends on the skipped
`*.rope.scaling.*` KV entries. Replace the `panic` with `slog.Warn` and
ignore the value. This is a contained drop-in that keeps the
`ModelConverter.KV` interface (`KV(*Tokenizer) KV`) unchanged — turning it
into `(KV, error)` would churn every converter and is better left to a
separate refactor.

### Test plan

- `gofmt`-clean; `go build ./convert/`
- `config.json` with `"rope_scaling":{"type":"haha-bomb"}` for Phi3 / Qwen2
  / Qwen3(VL) now logs a warning and converts instead of crashing the server
- Known rope scaling types (`su`/`longrope`/`yarn`/`mrope`/`default`)
  behave exactly as before
