### PR TITLE
convert: guard rope dimension division against zero head count

### DIFF
--- a/convert/convert_lfm2.go
+++ b/convert/convert_lfm2.go
@@ -141,8 +141,13 @@ func (p *lfm2Model) KV(t *Tokenizer) KV {
 
 	kv["attention.head_count"] = p.NumAttentionHeads
 	kv["attention.head_count_kv"] = kvHeadCounts
-	kv["attention.key_length"] = p.HiddenSize / p.NumAttentionHeads
-	kv["attention.value_length"] = p.HiddenSize / p.NumAttentionHeads
+	if p.NumAttentionHeads > 0 {
+		// NumAttentionHeads comes from the attacker-controlled config.json;
+		// guard the division so num_attention_heads:0 does not panic the
+		// (unrecovered) conversion goroutine with an integer divide by zero.
+		kv["attention.key_length"] = p.HiddenSize / p.NumAttentionHeads
+		kv["attention.value_length"] = p.HiddenSize / p.NumAttentionHeads
+	}
 	kv["attention.layer_norm_rms_epsilon"] = p.NormEps
 	kv["shortconv.l_cache"] = p.ConvLCache
 

--- a/convert/convert_llama.go
+++ b/convert/convert_llama.go
@@ -83,7 +83,10 @@ func (p *llamaModel) KV(t *Tokenizer) KV {
 	if p.RopeScaling.Type == "linear" {
 		kv["llama.rope.scaling.type"] = p.RopeScaling.Type
 		kv["llama.rope.scaling.factor"] = p.RopeScaling.Factor
-	} else if p.RopeScaling.RopeType == "llama3" {
+	} else if p.RopeScaling.RopeType == "llama3" && p.NumAttentionHeads > 0 {
+		// NumAttentionHeads comes from the attacker-controlled config.json;
+		// guard the division so num_attention_heads:0 does not panic the
+		// (unrecovered) conversion goroutine with an integer divide by zero.
 		dim := p.HiddenSize / p.NumAttentionHeads
 		for i := uint32(0); i < dim; i += 2 {
 			factor := cmp.Or(p.RopeScaling.Factor, 8.0)

--- a/convert/convert_mistral_causal.go
+++ b/convert/convert_mistral_causal.go
@@ -54,7 +54,15 @@ func (p *mistral3CausalModel) KV(t *Tokenizer) KV {
 	kv["mistral3.attention.layer_norm_rms_epsilon"] = p.RMSNormEPS
 	kv["mistral3.attention.key_length"] = p.HeadDim
 	kv["mistral3.attention.value_length"] = p.HeadDim
-	kv["mistral3.rope.dimension_count"] = cmp.Or(p.HeadDim, p.HiddenSize/p.NumAttentionHeads)
+	// cmp.Or evaluates both operands, so the division runs even when
+	// HeadDim != 0. NumAttentionHeads comes from the attacker-controlled
+	// config.json; guard the division so num_attention_heads:0 does not
+	// panic the (unrecovered) conversion goroutine with a divide by zero.
+	var ropeDimensionCount uint32
+	if p.NumAttentionHeads > 0 {
+		ropeDimensionCount = p.HiddenSize / p.NumAttentionHeads
+	}
+	kv["mistral3.rope.dimension_count"] = cmp.Or(p.HeadDim, ropeDimensionCount)
 	kv["mistral3.rope.freq_base"] = cmp.Or(p.RopeTheta, p.RopeParameters.RopeTheta)
 	kv["mistral3.rope.scaling.factor"] = p.RopeParameters.Factor
 	kv["mistral3.rope.scaling.type"] = p.RopeParameters.RopeType

--- a/convert/convert_phi3.go
+++ b/convert/convert_phi3.go
@@ -47,7 +47,14 @@ func (p *phi3Model) KV(t *Tokenizer) KV {
 	kv["phi3.attention.head_count"] = cmp.Or(p.NumAttentionHeads, p.NHead)
 	kv["phi3.attention.head_count_kv"] = cmp.Or(p.NumKeyValueHeads, p.NHeadKV)
 	kv["phi3.attention.layer_norm_rms_epsilon"] = p.RMSNormEPS
-	kv["phi3.rope.dimension_count"] = p.HiddenSize / cmp.Or(p.NumAttentionHeads, p.NHead)
+	// NumAttentionHeads / NHead come from the attacker-controlled
+	// config.json; guard the division so both being 0 does not panic the
+	// (unrecovered) conversion goroutine with an integer divide by zero.
+	var ropeDimensionCount uint32
+	if headCount := cmp.Or(p.NumAttentionHeads, p.NHead); headCount > 0 {
+		ropeDimensionCount = p.HiddenSize / headCount
+	}
+	kv["phi3.rope.dimension_count"] = ropeDimensionCount
 	kv["phi3.rope.freq_base"] = p.RopeTheta
 	kv["phi3.rope.scaling.original_context_length"] = p.OriginalMaxPositionEmbeddings
 	kv["phi3.attention.sliding_window"] = p.SlidingWindow


### PR DESCRIPTION
### Summary

Several `KV()` converters divide `HiddenSize` by the attention head count
read directly from the attacker-controlled `config.json`, with no `> 0`
guard:

| File | Division |
|------|----------|
| `convert/convert_llama.go` | `p.HiddenSize / p.NumAttentionHeads` (llama3 rope branch) |
| `convert/convert_lfm2.go` | `p.HiddenSize / p.NumAttentionHeads` (key/value length) |
| `convert/convert_mistral_causal.go` | `cmp.Or(p.HeadDim, p.HiddenSize/p.NumAttentionHeads)` |
| `convert/convert_phi3.go` | `p.HiddenSize / cmp.Or(p.NumAttentionHeads, p.NHead)` |

`num_attention_heads` is an ordinary integer; setting it to `0` (and `0`
for `n_head` too in the phi3 case) yields
`runtime error: integer divide by zero`. Note `cmp.Or` evaluates **both**
operands, so the mistral case panics even when `HeadDim != 0`.

`KV()` runs in an unrecovered goroutine spawned by `CreateHandler`, so an
unauthenticated `POST /api/create` with a crafted `config.json` crashes the
entire `ollama` process. The `llama3` variant is verified end-to-end in the
report.

### Fix

Guard each division with a head-count `> 0` check. For the `cmp.Or` cases
the division is hoisted into a guarded local so `cmp.Or` semantics are
preserved exactly (a `0` fallback when the head count is `0`, identical to
the previous behavior for any non-crashing input). Models with a valid
head count are unaffected.

### Test plan

- `gofmt`-clean; `go build ./convert/`
- `config.json` with `num_attention_heads:0` for Llama (`rope_type:llama3`)
  / LFM2 / Mistral3 / Phi3 now converts instead of crashing the server
- Models with a normal head count produce identical KV output
