### PR TITLE
lfm2: support ColBERT embedding models

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -216,10 +216,6 @@ type moreParser interface {
 	parseMore(fs.FS) error
 }
 
-type extraTensorParser interface {
-	extraTensors(fs.FS) ([]Tensor, error)
-}
-
 type tokenizerAdjuster interface {
 	adjustTokenizer(*Tokenizer)
 }
@@ -346,7 +342,7 @@ func LoadModelMetadata(fsys fs.FS) (ModelKV, *Tokenizer, error) {
 		conv = &lagunaModel{}
 	case "GlmOcrForConditionalGeneration":
 		conv = &glmOcrModel{}
-	case "Lfm2ForCausalLM", "Lfm2MoeForCausalLM":
+	case "Lfm2Model", "Lfm2ForCausalLM", "Lfm2MoeForCausalLM":
 		conv = &lfm2Model{}
 	case "Lfm2VlForConditionalGeneration":
 		conv = &lfm2VLTextModel{}
@@ -414,14 +410,6 @@ func ConvertModel(fsys fs.FS, f *os.File, projectorFiles ...*os.File) error {
 	ts, err := parseTensors(fsys, strings.NewReplacer(conv.Replacements()...))
 	if err != nil {
 		return err
-	}
-
-	if tp, ok := conv.(extraTensorParser); ok {
-		extra, err := tp.extraTensors(fsys)
-		if err != nil {
-			return err
-		}
-		ts = append(ts, extra...)
 	}
 
 	if err := ensureUniqueTensorNames(ts); err != nil {

--- a/convert/convert_embeddinggemma.go
+++ b/convert/convert_embeddinggemma.go
@@ -32,7 +32,6 @@ type embeddingGemmaDenseModule struct {
 var (
 	_ ModelConverter    = (*embeddingGemmaModel)(nil)
 	_ moreParser        = (*embeddingGemmaModel)(nil)
-	_ extraTensorParser = (*embeddingGemmaModel)(nil)
 	_ tokenizerAdjuster = (*embeddingGemmaModel)(nil)
 )
 
@@ -214,29 +213,6 @@ func embeddingGemmaDenseTensorName(modulePath string) (string, bool) {
 	}
 }
 
-func (m *embeddingGemmaModel) extraTensors(fsys fs.FS) ([]Tensor, error) {
-	var extra []Tensor
-	for _, dense := range m.denseModules {
-		ts, err := parseSafetensors(fsys, strings.NewReplacer("linear.", dense.tensorName+"."), dense.path)
-		if err != nil {
-			return nil, err
-		}
-
-		foundWeight := false
-		for _, t := range ts {
-			if t.Name() == dense.tensorName+".weight" {
-				extra = append(extra, t)
-				foundWeight = true
-			}
-		}
-		if !foundWeight {
-			return nil, fmt.Errorf("embeddinggemma dense module %s missing linear.weight", dense.path)
-		}
-	}
-
-	return extra, nil
-}
-
 func (m *embeddingGemmaModel) Tensors(ts []Tensor) []*ggml.Tensor {
 	out := make([]*ggml.Tensor, 0, len(ts))
 	for _, t := range ts {
@@ -261,6 +237,8 @@ func (m *embeddingGemmaModel) Tensors(ts []Tensor) []*ggml.Tensor {
 
 func (m *embeddingGemmaModel) Replacements() []string {
 	return []string{
+		"2_Dense.linear", "dense_2",
+		"3_Dense.linear", "dense_3",
 		"embed_tokens.", "token_embd.",
 		"layers.", "blk.",
 		"input_layernorm", "attn_norm",

--- a/convert/convert_embeddinggemma_test.go
+++ b/convert/convert_embeddinggemma_test.go
@@ -120,6 +120,14 @@ func TestConvertEmbeddingGemmaSentenceTransformers(t *testing.T) {
 			t.Errorf("missing tensor %s", name)
 		}
 	}
+	for _, name := range []string{
+		"2_Dense.linear.weight",
+		"3_Dense.linear.weight",
+	} {
+		if slices.Contains(names, name) {
+			t.Errorf("unexpected raw nested tensor %s", name)
+		}
+	}
 
 	assertF32TensorValues(t, f, tensors, "output_norm.weight", 1)
 	assertF32TensorValues(t, f, tensors, "blk.0.attn_norm.weight", 1)

--- a/convert/convert_lfm2.go
+++ b/convert/convert_lfm2.go
@@ -2,7 +2,11 @@ package convert
 
 import (
 	"cmp"
+	"encoding/json"
+	"errors"
 	"fmt"
+	iofs "io/fs"
+	"path"
 	"slices"
 	"strings"
 
@@ -32,12 +36,19 @@ type lfm2Model struct {
 	RoutedScalingFactor   float32  `json:"routed_scaling_factor"`
 	LayerTypes            []string `json:"layer_types"`
 	TieEmbedding          bool     `json:"tie_embedding"`
+	PoolingType           uint32
+	normalizeEmbeddings   bool
+	dense2FeatIn          uint32
+	dense2FeatOut         uint32
 	RopeParameters        struct {
 		RopeTheta float32 `json:"rope_theta"`
 	} `json:"rope_parameters"`
 }
 
-var _ ModelConverter = (*lfm2Model)(nil)
+var (
+	_ ModelConverter = (*lfm2Model)(nil)
+	_ moreParser     = (*lfm2Model)(nil)
+)
 
 const (
 	defaultMaxPositionEmbeddings = uint32(128_000)
@@ -106,6 +117,72 @@ func (p *lfm2Model) contextLength() uint32 {
 	return p.MaxPositionEmbeddings
 }
 
+func (p *lfm2Model) parseMore(fsys iofs.FS) error {
+	bts, err := iofs.ReadFile(fsys, "modules.json")
+	if errors.Is(err, iofs.ErrNotExist) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	var modules []struct {
+		Type string `json:"type"`
+		Path string `json:"path"`
+	}
+	if err := json.Unmarshal(bts, &modules); err != nil {
+		return err
+	}
+
+	var hasDense bool
+	for _, m := range modules {
+		switch {
+		case strings.HasSuffix(m.Type, ".Pooling"):
+			bts, err := iofs.ReadFile(fsys, path.Join(m.Path, "config.json"))
+			if err != nil {
+				return err
+			}
+
+			var pc struct {
+				PoolingModeMeanTokens bool `json:"pooling_mode_mean_tokens"`
+				PoolingModeCLSToken   bool `json:"pooling_mode_cls_token"`
+			}
+			if err := json.Unmarshal(bts, &pc); err != nil {
+				return err
+			}
+
+			if pc.PoolingModeMeanTokens {
+				p.PoolingType = 1
+			} else if pc.PoolingModeCLSToken {
+				p.PoolingType = 2
+			}
+		case strings.HasSuffix(m.Type, ".Normalize"):
+			p.normalizeEmbeddings = true
+		case strings.HasSuffix(m.Type, ".Dense"):
+			hasDense = true
+			bts, err := iofs.ReadFile(fsys, path.Join(m.Path, "config.json"))
+			if err != nil {
+				return err
+			}
+
+			var dc struct {
+				InFeatures  uint32 `json:"in_features"`
+				OutFeatures uint32 `json:"out_features"`
+			}
+			if err := json.Unmarshal(bts, &dc); err != nil {
+				return err
+			}
+			p.dense2FeatIn = dc.InFeatures
+			p.dense2FeatOut = dc.OutFeatures
+		}
+	}
+
+	if hasDense && p.PoolingType == 0 {
+		p.PoolingType = 1
+	}
+
+	return nil
+}
+
 func (p *lfm2Model) KV(t *Tokenizer) KV {
 	architecture := "lfm2"
 	if p.isMoE() {
@@ -148,6 +225,17 @@ func (p *lfm2Model) KV(t *Tokenizer) KV {
 
 	if ropeFreqBase := p.ropeFreqBase(); ropeFreqBase != 0 {
 		kv["rope.freq_base"] = ropeFreqBase
+	}
+
+	if p.PoolingType != 0 {
+		kv["pooling_type"] = p.PoolingType
+		kv["normalize_embeddings"] = p.normalizeEmbeddings
+	}
+	if p.dense2FeatIn != 0 {
+		kv["dense_2_feat_in"] = p.dense2FeatIn
+	}
+	if p.dense2FeatOut != 0 {
+		kv["dense_2_feat_out"] = p.dense2FeatOut
 	}
 
 	if p.isMoE() {
@@ -213,8 +301,13 @@ func (p *lfm2Model) Tensors(ts []Tensor) []*ggml.Tensor {
 func (p *lfm2Model) Replacements() []string {
 	return []string{
 		"model.embed_tokens", "token_embd",
+		"embed_tokens", "token_embd",
 		"model.embedding_norm", "token_embd_norm",
+		"embedding_norm", "token_embd_norm",
+		"2_Dense.linear", "dense_2",
+		"1_Dense.linear", "dense_2",
 		"model.layers", "blk",
+		"layers", "blk",
 		"operator_norm", "attn_norm",
 		"self_attn.q_proj", "attn_q",
 		"self_attn.k_proj", "attn_k",

--- a/convert/convert_lfm2_test.go
+++ b/convert/convert_lfm2_test.go
@@ -2,9 +2,12 @@ package convert
 
 import (
 	"io"
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
+	"testing/fstest"
 )
 
 type lfm2StubTensor struct {
@@ -125,6 +128,90 @@ func TestLFM2DenseKV(t *testing.T) {
 	}
 }
 
+func TestLFM2ColBERTSentenceTransformersMetadata(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite := func(name, content string) {
+		t.Helper()
+		path := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	mustWrite("modules.json", `[
+		{"idx": 0, "name": "0", "path": "0_Transformer", "type": "sentence_transformers.models.Transformer"},
+		{"idx": 1, "name": "1", "path": "1_Dense", "type": "sentence_transformers.models.Dense"},
+		{"idx": 2, "name": "2", "path": "2_Normalize", "type": "sentence_transformers.models.Normalize"}
+	]`)
+	mustWrite("1_Dense/config.json", `{"in_features": 1024, "out_features": 128, "bias": false}`)
+
+	p := lfm2Model{
+		ModelParameters:       ModelParameters{Architectures: []string{"Lfm2Model"}, ModelType: "lfm2", VocabSize: 65536},
+		HiddenSize:            1024,
+		NumHiddenLayers:       16,
+		MaxPositionEmbeddings: 32768,
+		IntermediateSize:      4096,
+		NumAttentionHeads:     16,
+		NumKeyValueHeads:      8,
+		LayerTypes:            []string{"conv", "full_attention"},
+		NormEps:               1e-5,
+		ConvLCache:            3,
+	}
+
+	if err := p.parseMore(os.DirFS(dir)); err != nil {
+		t.Fatal(err)
+	}
+
+	kv := p.KV(&Tokenizer{Vocabulary: &Vocabulary{Model: "gpt2"}})
+	if got, want := kv["pooling_type"], uint32(1); got != want {
+		t.Fatalf("pooling_type = %v, want %v", got, want)
+	}
+	if got, want := kv["normalize_embeddings"], true; got != want {
+		t.Fatalf("normalize_embeddings = %v, want %v", got, want)
+	}
+	if got, want := kv["dense_2_feat_in"], uint32(1024); got != want {
+		t.Fatalf("dense_2_feat_in = %v, want %v", got, want)
+	}
+	if got, want := kv["dense_2_feat_out"], uint32(128); got != want {
+		t.Fatalf("dense_2_feat_out = %v, want %v", got, want)
+	}
+}
+
+func TestLFM2ParseMoreMissingModulesIsOptional(t *testing.T) {
+	var p lfm2Model
+	if err := p.parseMore(os.DirFS(t.TempDir())); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLFM2ParseMoreUsesFSPaths(t *testing.T) {
+	fsys := fstest.MapFS{
+		"modules.json": &fstest.MapFile{Data: []byte(`[
+			{"path": "1_Pooling", "type": "sentence_transformers.models.Pooling"},
+			{"path": "2_Dense", "type": "sentence_transformers.models.Dense"}
+		]`)},
+		"1_Pooling/config.json": &fstest.MapFile{Data: []byte(`{"pooling_mode_mean_tokens": true}`)},
+		"2_Dense/config.json":   &fstest.MapFile{Data: []byte(`{"in_features": 1024, "out_features": 128}`)},
+	}
+
+	var p lfm2Model
+	if err := p.parseMore(fsys); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := p.PoolingType, uint32(1); got != want {
+		t.Fatalf("pooling type = %v, want %v", got, want)
+	}
+	if got, want := p.dense2FeatIn, uint32(1024); got != want {
+		t.Fatalf("dense2FeatIn = %v, want %v", got, want)
+	}
+	if got, want := p.dense2FeatOut, uint32(128); got != want {
+		t.Fatalf("dense2FeatOut = %v, want %v", got, want)
+	}
+}
+
 func TestLFM2MoETensors(t *testing.T) {
 	p := lfm2Model{
 		ModelParameters: ModelParameters{ModelType: "lfm2_moe"},
@@ -188,6 +275,22 @@ func TestLFM2MoEReplacements(t *testing.T) {
 
 	if got, want := replacer.Replace("model.layers.2.feed_forward.gate.weight"), "blk.2.ffn_gate_inp.weight"; got != want {
 		t.Fatalf("gate replacement = %q, want %q", got, want)
+	}
+
+	if got, want := replacer.Replace("1_Dense.linear.weight"), "dense_2.weight"; got != want {
+		t.Fatalf("dense replacement = %q, want %q", got, want)
+	}
+
+	if got, want := replacer.Replace("embed_tokens.weight"), "token_embd.weight"; got != want {
+		t.Fatalf("root token embedding replacement = %q, want %q", got, want)
+	}
+
+	if got, want := replacer.Replace("embedding_norm.weight"), "token_embd_norm.weight"; got != want {
+		t.Fatalf("root embedding norm replacement = %q, want %q", got, want)
+	}
+
+	if got, want := replacer.Replace("layers.0.operator_norm.weight"), "blk.0.attn_norm.weight"; got != want {
+		t.Fatalf("root layer replacement = %q, want %q", got, want)
 	}
 }
 

--- a/convert/reader.go
+++ b/convert/reader.go
@@ -76,11 +76,23 @@ func (t *tensorBase) SetRepacker(fn Repacker) {
 type Repacker func(string, []float32, []uint64) ([]float32, error)
 
 func parseTensors(fsys fs.FS, replacer *strings.Replacer) ([]Tensor, error) {
+	matches, err := fs.Glob(fsys, "*.safetensors")
+	if err != nil {
+		return nil, err
+	}
+	nestedMatches, err := fs.Glob(fsys, "*/*.safetensors")
+	if err != nil {
+		return nil, err
+	}
+	matches = append(matches, nestedMatches...)
+	if len(matches) > 0 {
+		return parseSafetensors(fsys, replacer, matches...)
+	}
+
 	patterns := []struct {
 		Pattern string
 		Func    func(fs.FS, *strings.Replacer, ...string) ([]Tensor, error)
 	}{
-		{"*.safetensors", parseSafetensors},
 		{"pytorch_model-*-of-*.bin", parseTorch},
 		{"pytorch_model.bin", parseTorch},
 		{"consolidated.*.pth", parseTorch},

--- a/convert/reader_safetensors.go
+++ b/convert/reader_safetensors.go
@@ -11,6 +11,7 @@ import (
 	"io/fs"
 	"maps"
 	"math"
+	"path"
 	"slices"
 	"strings"
 
@@ -31,6 +32,7 @@ func parseSafetensors(fsys fs.FS, replacer *strings.Replacer, ps ...string) ([]T
 	}
 
 	var ts []Tensor
+	names := make(map[string]struct{})
 	for _, p := range ps {
 		f, err := fsys.Open(p)
 		if err != nil {
@@ -54,8 +56,6 @@ func parseSafetensors(fsys fs.FS, replacer *strings.Replacer, ps ...string) ([]T
 		}
 
 		keys := slices.Sorted(maps.Keys(headers))
-
-		names := make(map[string]struct{}, len(keys))
 
 		fp8Scales, err := collectSafetensorsFP8Scales(n, headers)
 		if err != nil {
@@ -85,7 +85,12 @@ func parseSafetensors(fsys fs.FS, replacer *strings.Replacer, ps ...string) ([]T
 					}
 				}
 
-				ggufName := replacer.Replace(key)
+				sourceKey := key
+				if dir := path.Dir(p); dir != "." {
+					sourceKey = dir + "." + sourceKey
+				}
+
+				ggufName := replacer.Replace(sourceKey)
 				if _, ok := names[ggufName]; ok {
 					return nil, fmt.Errorf("duplicate tensor name '%s' was found for this model", ggufName)
 				}

--- a/convert/reader_test.go
+++ b/convert/reader_test.go
@@ -377,6 +377,60 @@ func TestParseSafetensorsConsumesFP8ScaleCompanion(t *testing.T) {
 	}
 }
 
+func TestParseSafetensorsPrefixesNestedModulePath(t *testing.T) {
+	tempDir := t.TempDir()
+	moduleDir := filepath.Join(tempDir, "1_Dense")
+	if err := os.MkdirAll(moduleDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	generateSafetensorTestData(t, moduleDir, map[string]*tensorData{
+		"linear.weight": {
+			Offsets: []int{0, 4},
+			Type:    "F32",
+			Shape:   []int{1, 1},
+		},
+	})
+
+	tensors, err := parseTensors(os.DirFS(tempDir), strings.NewReplacer("1_Dense.linear", "dense_2"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tensors) != 1 {
+		t.Fatalf("expected one tensor, got %d", len(tensors))
+	}
+	if got, want := tensors[0].Name(), "dense_2.weight"; got != want {
+		t.Fatalf("tensor name = %q, want %q", got, want)
+	}
+}
+
+func TestParseSafetensorsRejectsDuplicateNamesAcrossFiles(t *testing.T) {
+	tempDir := t.TempDir()
+	generateSafetensorTestData(t, tempDir, map[string]*tensorData{
+		"dense_2.weight": {
+			Offsets: []int{0, 4},
+			Type:    "F32",
+			Shape:   []int{1, 1},
+		},
+	})
+
+	moduleDir := filepath.Join(tempDir, "1_Dense")
+	if err := os.MkdirAll(moduleDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	generateSafetensorTestData(t, moduleDir, map[string]*tensorData{
+		"linear.weight": {
+			Offsets: []int{0, 4},
+			Type:    "F32",
+			Shape:   []int{1, 1},
+		},
+	})
+
+	_, err := parseTensors(os.DirFS(tempDir), strings.NewReplacer("1_Dense.linear", "dense_2"))
+	if err == nil || !strings.Contains(err.Error(), "duplicate tensor name 'dense_2.weight'") {
+		t.Fatalf("expected duplicate tensor name error, got %v", err)
+	}
+}
+
 func TestParseSafetensorsRejectsFP8WithoutBlockMetadata(t *testing.T) {
 	tempDir := t.TempDir()
 	generateSafetensorTestData(t, tempDir, map[string]*tensorData{

--- a/docs/capabilities/embeddings.mdx
+++ b/docs/capabilities/embeddings.mdx
@@ -68,6 +68,12 @@ Embeddings turn text into numeric vectors you can store in a vector database, se
   The `/api/embed` endpoint returns L2‑normalized (unit‑length) vectors.
 </Note>
 
+### LFM2-ColBERT models
+
+Ollama can load LFM2-based ColBERT checkpoints that are converted from a SentenceTransformers layout with a dense projection head. During conversion, the LFM2 backbone is exposed as an embedding model when the checkpoint includes SentenceTransformers embedding metadata, and dense projection metadata is preserved in the converted model.
+
+For ColBERT checkpoints that are trained for late-interaction retrieval, `/api/embed` returns one pooled vector per input so it can be used with standard vector databases. Applications that need token-level MaxSim scoring should use a retrieval stack that exposes token-level embeddings from the same checkpoint.
+
 ## Generate a batch of embeddings
 
 Pass an array of strings to `input`.
@@ -123,5 +129,3 @@ Pass an array of strings to `input`.
 
 - Use cosine similarity for most semantic search use cases.
 - Use the same embedding model for both indexing and querying.
-
-


### PR DESCRIPTION
## Summary

This PR adds conversion support for LFM2-based ColBERT embedding checkpoints that use SentenceTransformers-style layouts.

It includes:

- LFM2 conversion registration for `Lfm2Model` checkpoints
- SentenceTransformers `modules.json` parsing for pooling, normalization, and dense projection metadata
- nested safetensors discovery for module subdirectories such as `1_Dense/model.safetensors`
- tensor-name prefixing for nested safetensors so dense module weights convert to the expected GGUF tensor names
- duplicate tensor-name detection across root and nested safetensors files after replacement
- EmbeddingGemma compatibility with the generic nested safetensors prefixing behavior, without emitting raw nested module tensor names
- removal of the now-unused extra tensor parser hook that was superseded by generic nested safetensors parsing
- documentation for LFM2-ColBERT embedding behavior

## Context

The branch was refreshed on June 14 against current `ollama/ollama:main` (`12e04379c`). Earlier low-level vendored `llama/llama.cpp` runtime file patches were dropped during the refresh because current `main` no longer tracks those vendored files in the same path. The current PR is intentionally focused on conversion and documentation.

Current validated head: `8d61f89f80b33a95e5669af3a8b7126b9c5df4ab`.

## Verification

Focused tests:

```bash
go test -count=1 ./cmd ./convert ./parser
```

Broader non-app sweep:

```bash
find . -name '*.go' -not -path './app/*' -not -path './integration/*' -not -path './.git/*' -exec dirname {} \; | sort -u | sed 's#^\./#./#' | xargs go test -count=1
```

Notes:

- `app/*` is excluded locally because `app/dist` is not present in this checkout.
- `integration/*` is excluded because its files are build-tagged and a blind package sweep reports `build constraints exclude all Go files`.
- One earlier broad sweep hit a timing timeout in `TestLlamaServerWaitUntilRunningExtendsTimeoutOnOutputActivity`; `go test -count=1 ./llm` passed on rerun, and later full broad non-app sweeps passed.
- Companion artifact/provenance docs are published at https://huggingface.co/edithatogo/ollama-colbert-local-artifacts. No weights, GGUF files, binaries, or third-party artifacts are uploaded there.
