### PR TITLE
server: default Think before parser init in GenerateHandler

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -388,14 +388,6 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 		}
 	}
 
-	if !req.Raw && m.Config.Parser != "" {
-		builtinParser = parsers.ParserForName(m.Config.Parser)
-		if builtinParser != nil {
-			// no tools or last message for generate endpoint
-			builtinParser.Init(nil, nil, req.Think)
-		}
-	}
-
 	caps := []model.Capability{model.CapabilityCompletion}
 	if req.Suffix != "" {
 		caps = append(caps, model.CapabilityInsert)
@@ -411,6 +403,19 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 		if req.Think != nil && req.Think.Bool() {
 			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("%q does not support thinking", req.Model)})
 			return
+		}
+	}
+
+	// Parser init must run after the CapabilityThinking auto-default above
+	// so that thinking-aware parsers (e.g. gemma4, deepseek3, glm46, cogito)
+	// receive a non-nil req.Think. Otherwise channel-formatted thinking output
+	// is silently discarded and short-num_predict requests can return empty
+	// responses.
+	if !req.Raw && m.Config.Parser != "" {
+		builtinParser = parsers.ParserForName(m.Config.Parser)
+		if builtinParser != nil {
+			// no tools or last message for generate endpoint
+			builtinParser.Init(nil, nil, req.Think)
 		}
 	}
 

--- a/server/routes_generate_gemma4_think_default_test.go
+++ b/server/routes_generate_gemma4_think_default_test.go
@@ -1,0 +1,170 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/fs/ggml"
+	"github.com/ollama/ollama/llm"
+	"github.com/ollama/ollama/ml"
+)
+
+// TestGenerateGemma4ParserThinkingDefaultsOn pins the /api/generate handler's
+// ordering invariant: when a model has CapabilityThinking, the handler must
+// auto-default req.Think to true BEFORE initialising the builtin parser so
+// thinking-aware parsers see thinkValue.Bool()==true and surface channel
+// content through the Thinking field instead of silently dropping it.
+//
+// Before the fix, the parser was initialised with req.Think still nil, so
+// Gemma4Parser.thinkingEnabled stayed false. Channel content was discarded
+// and short-num_predict requests came back with an empty response and no
+// thinking — see the empty-response repro on gemma4:31b that motivated the
+// fix.
+func TestGenerateGemma4ParserThinkingDefaultsOn(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	mock := &mockRunner{}
+	s := &Server{
+		sched: &Scheduler{
+			pendingReqCh:    make(chan *LlmRequest, 1),
+			finishedReqCh:   make(chan *LlmRequest, 1),
+			expiredCh:       make(chan *runnerRef, 1),
+			unloadedCh:      make(chan any, 1),
+			loaded:          make(map[string]*runnerRef),
+			newServerFn:     newMockServer(mock),
+			getGpuFn:        getGpuFn,
+			getSystemInfoFn: getSystemInfoFn,
+			waitForRecovery: 250 * time.Millisecond,
+			loadFn: func(req *LlmRequest, _ ml.SystemInfo, _ []ml.DeviceInfo, _ bool) bool {
+				time.Sleep(time.Millisecond)
+				req.successCh <- &runnerRef{llama: mock}
+				return false
+			},
+		},
+	}
+	go s.sched.Run(t.Context())
+
+	_, digest := createBinFile(t, ggml.KV{
+		"general.architecture":          "llama",
+		"llama.block_count":             uint32(1),
+		"llama.context_length":          uint32(8192),
+		"llama.embedding_length":        uint32(4096),
+		"llama.attention.head_count":    uint32(32),
+		"llama.attention.head_count_kv": uint32(8),
+		"tokenizer.ggml.tokens":         []string{""},
+		"tokenizer.ggml.scores":         []float32{0},
+		"tokenizer.ggml.token_type":     []int32{0},
+	}, []*ggml.Tensor{
+		{Name: "token_embd.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.attn_norm.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.ffn_down.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.ffn_gate.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.ffn_up.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.ffn_norm.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.attn_k.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.attn_output.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.attn_q.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.attn_v.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "output.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+	})
+
+	streamCreate := false
+	if w := createRequest(t, s.CreateHandler, api.CreateRequest{
+		Model:    "test-gemma4-think-default",
+		Files:    map[string]string{"file.gguf": digest},
+		Parser:   "gemma4",
+		Template: `{{ .Prompt }}`,
+		Stream:   &streamCreate,
+	}); w.Code != http.StatusOK {
+		t.Fatalf("create: expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Mock the runner to emit the gemma4 channel-thinking format the real
+	// model produces — opening <|channel>, a "thought\n" channel-name prefix
+	// the parser strips, the thinking body, the <channel|> close tag, and
+	// finally the user-visible content.
+	mock.CompletionFn = func(ctx context.Context, _ llm.CompletionRequest, fn func(r llm.CompletionResponse)) error {
+		chunks := []llm.CompletionResponse{
+			{Content: "<|channel>thought\nReasoning about the question."},
+			{
+				Content:            "<channel|>Paris.",
+				Done:               true,
+				DoneReason:         llm.DoneReasonStop,
+				PromptEvalCount:    1,
+				PromptEvalDuration: 1,
+				EvalCount:          1,
+				EvalDuration:       1,
+			},
+		}
+		for _, c := range chunks {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+				fn(c)
+			}
+		}
+		return nil
+	}
+
+	noStream := false
+
+	// Case 1 — no Think param set; the handler must auto-default it to true
+	// before Init so the parser surfaces thinking content.
+	t.Run("default_think_surfaces_thinking", func(t *testing.T) {
+		w := createRequest(t, s.GenerateHandler, api.GenerateRequest{
+			Model:  "test-gemma4-think-default",
+			Prompt: "The capital of France is",
+			Stream: &noStream,
+		})
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+		}
+
+		var resp api.GenerateResponse
+		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+
+		if resp.Thinking != "Reasoning about the question." {
+			t.Errorf("Thinking = %q, want %q", resp.Thinking, "Reasoning about the question.")
+		}
+		if resp.Response != "Paris." {
+			t.Errorf("Response = %q, want %q", resp.Response, "Paris.")
+		}
+	})
+
+	// Case 2 — explicit think=false; the parser should silently drop channel
+	// thinking content but still surface user-visible content after <channel|>.
+	t.Run("explicit_think_false_hides_thinking", func(t *testing.T) {
+		think := false
+		w := createRequest(t, s.GenerateHandler, api.GenerateRequest{
+			Model:  "test-gemma4-think-default",
+			Prompt: "The capital of France is",
+			Think:  &api.ThinkValue{Value: think},
+			Stream: &noStream,
+		})
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+		}
+
+		var resp api.GenerateResponse
+		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+
+		if resp.Thinking != "" {
+			t.Errorf("Thinking = %q, want empty (think=false hides reasoning)", resp.Thinking)
+		}
+		if resp.Response != "Paris." {
+			t.Errorf("Response = %q, want %q", resp.Response, "Paris.")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

`/api/generate` against a thinking-capable model with no `think` parameter silently dropped the model's reasoning output, producing an empty `response` whenever the model didn't finish its `<|channel>…<channel|>` thinking block before `num_predict` (or context) ran out. Most visible on `gemma4:31b`, which unconditionally opens its output with `<|channel>thought\n…`.

The cause is a sequencing bug in `GenerateHandler`. The builtin parser was initialised with `req.Think == nil` before the `CapabilityThinking` block ran the auto-default that sets `req.Think = &api.ThinkValue{Value: true}`. By the time the default kicked in, the parser had already locked in `thinkingEnabled=false`. The parser still recognised `<|channel>` in the stream and transitioned to its thinking-collection state, but `Add` then dropped that content because thinking was "disabled".

`ChatHandler` already runs caps-check before parser init and was unaffected. This PR reorders `GenerateHandler` to mirror it. No logic change beyond sequencing.

## Repro (before fix)

```
$ curl -sS http://127.0.0.1:11434/api/generate -d '{"model":"gemma4:31b","prompt":"The capital of France is","stream":false,"options":{"temperature":0,"num_predict":20}}'
{"model":"gemma4:31b","response":"","done":true,"done_reason":"length",
 "context":[2,105,9731,107,98,107,106,107,105,2364,107,818,5279,529,7001,563,106,107,105,4368,107,
              100,45518,107,818,2430,563,6655,496,13315,16975,236787,623,818,5279,529,7001,563,3056,107,818],
 "eval_count":20,…}
```

Decoding the 20 sampled tokens with the gemma4 tokenizer:

> `<|channel>thought\nThe user is providing a sentence fragment: "The capital of France is".\nThe`

So the model is producing coherent text — the runner-side `Gemma4Parser` is swallowing it because `thinkingEnabled=false` despite the model being thinking-capable and `req.Think` being intended to default to true.

`gemma3:27b` on the same daemon/prompt produces `"The capital of France is **Paris**. 🇫🇷"` correctly — confirming the bug is scoped to models with a thinking-aware builtin parser, not a model/hardware/quant issue.

## Repro (after fix)

```
$ curl -sS http://127.0.0.1:11434/api/generate -d '{"model":"gemma4:31b","prompt":"The capital of France is","stream":false,"options":{"temperature":0,"num_predict":200}}'
{"model":"gemma4:31b",
 "response":"Paris.",
 "thinking":"The user is providing a sentence fragment: \"The capital of France is\".\nThe user wants me to complete the sentence with the correct information.\nThe capital of France is Paris.",
 "done_reason":"stop",…}
```

With `num_predict:20` after the fix, `response` is still empty (the model genuinely didn't reach `<channel|>` in 20 tokens), but the `thinking` field now correctly surfaces the in-progress reasoning instead of dropping it silently.

A more realistic scenario — 2000-char system prompt, `num_predict:200`, no `think` param — would, before the fix, return a totally empty body. After the fix, the `thinking` field carries the model's reasoning chain so the caller can see what the model is doing even when it doesn't reach a final answer within the token budget.

## Scope

Other thinking-capable parsers (`deepseek3`, `glm46`, `cogito`) share the `thinkValue.Bool()` check at `Init` and benefit from the same reorder. They were unlikely to hit the exact failure mode `gemma4` does because their parsers don't unconditionally enter thinking-collection state on a marker; `gemma4`'s does, which is why this surfaced there first.

This PR fixes only the `GenerateHandler` ordering. `/api/chat` was already correct. The fix does **not** address:
- Empty responses on `/api/chat` (different code path, already correctly ordered)
- MoE-specific behaviour (e.g. `gemma4:26b` early-stop on long system prompts is a separate symptom not exercised by this fix)
- Any model-side or quantisation issues

## Test plan

- [x] `go test ./server/` — full server package suite passes
- [x] `go test ./model/parsers/` — parser tests pass
- [x] `go test ./model/models/gemma4/` — gemma4 tests pass
- [x] New `TestGenerateGemma4ParserThinkingDefaultsOn` in `server/routes_generate_gemma4_think_default_test.go` covers default-Think and explicit `think:false` cases; verified failing on unfixed code and passing on fixed code
- [x] End-to-end against `gemma4:31b` on a clean mainline build: `response` and `thinking` populated as expected; `gemma3:27b` control unchanged
