### PR TITLE
cmd: add load command to preload a model into memory

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -536,6 +536,11 @@ func LoadHandler(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
+		// A zero duration would unload the model immediately, contradicting
+		// the load intent. Send users to `ollama stop` instead.
+		if d == 0 {
+			return fmt.Errorf("--keepalive 0 would immediately unload the model; use \"ollama stop %s\" to unload, or pass a positive duration (e.g. 5m) or negative duration (e.g. -1s for indefinite)", args[0])
+		}
 		opts.KeepAlive = &api.Duration{Duration: d}
 	}
 	if err := loadOrUnloadModel(cmd, opts); err != nil {
@@ -2365,7 +2370,7 @@ func NewCLI() *cobra.Command {
 		RunE:    LoadHandler,
 	}
 
-	loadCmd.Flags().String("keepalive", "", "Duration to keep the model loaded (e.g. 5m)")
+	loadCmd.Flags().String("keepalive", "", "Duration to keep the model loaded (e.g. 5m, -1s to keep indefinitely)")
 
 	stopCmd := &cobra.Command{
 		Use:     "stop MODEL",

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -523,6 +523,30 @@ func loadOrUnloadModel(cmd *cobra.Command, opts *runOptions) error {
 	})
 }
 
+func LoadHandler(cmd *cobra.Command, args []string) error {
+	opts := &runOptions{
+		Model: args[0],
+	}
+	keepAlive, err := cmd.Flags().GetString("keepalive")
+	if err != nil {
+		return err
+	}
+	if keepAlive != "" {
+		d, err := time.ParseDuration(keepAlive)
+		if err != nil {
+			return err
+		}
+		opts.KeepAlive = &api.Duration{Duration: d}
+	}
+	if err := loadOrUnloadModel(cmd, opts); err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return fmt.Errorf("couldn't find model %q to load", args[0])
+		}
+		return err
+	}
+	return nil
+}
+
 func StopHandler(cmd *cobra.Command, args []string) error {
 	opts := &runOptions{
 		Model:     args[0],
@@ -2333,6 +2357,16 @@ func NewCLI() *cobra.Command {
 	runCmd.Flags().Bool("imagegen", false, "Use the imagegen runner for LLM inference")
 	runCmd.Flags().MarkHidden("imagegen")
 
+	loadCmd := &cobra.Command{
+		Use:     "load MODEL",
+		Short:   "Load a model into memory",
+		Args:    cobra.ExactArgs(1),
+		PreRunE: checkServerHeartbeat,
+		RunE:    LoadHandler,
+	}
+
+	loadCmd.Flags().String("keepalive", "", "Duration to keep the model loaded (e.g. 5m)")
+
 	stopCmd := &cobra.Command{
 		Use:     "stop MODEL",
 		Short:   "Stop a running model",
@@ -2453,6 +2487,7 @@ func NewCLI() *cobra.Command {
 		createCmd,
 		showCmd,
 		runCmd,
+		loadCmd,
 		stopCmd,
 		pullCmd,
 		pushCmd,
@@ -2497,6 +2532,7 @@ func NewCLI() *cobra.Command {
 		createCmd,
 		showCmd,
 		runCmd,
+		loadCmd,
 		stopCmd,
 		pullCmd,
 		pushCmd,

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -2359,3 +2359,118 @@ func TestIsLocalhost(t *testing.T) {
 		})
 	}
 }
+
+func TestLoadHandler(t *testing.T) {
+	tests := []struct {
+		name            string
+		model           string
+		keepaliveFlag   string
+		showStatus      int
+		remoteHost      string
+		expectError     string
+		expectGenerate  bool
+		expectKeepAlive *api.Duration
+	}{
+		{
+			name:           "local model with default keepalive sends nil so server default applies",
+			model:          "test-model",
+			expectGenerate: true,
+		},
+		{
+			name:            "local model with explicit keepalive is forwarded to generate",
+			model:           "test-model",
+			keepaliveFlag:   "10m",
+			expectGenerate:  true,
+			expectKeepAlive: &api.Duration{Duration: 10 * time.Minute},
+		},
+		{
+			name:          "invalid keepalive returns parse error before contacting server",
+			model:         "test-model",
+			keepaliveFlag: "garbage",
+			expectError:   "invalid duration",
+		},
+		{
+			name:        "missing model surfaces helpful error message",
+			model:       "missing-model",
+			showStatus:  http.StatusNotFound,
+			expectError: "couldn't find model",
+		},
+		{
+			name:           "non-ollama.com remote model skips generate",
+			model:          "remote-model",
+			remoteHost:     "https://other-remote.com",
+			expectGenerate: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			generateCalled := false
+			var sentKeepAlive *api.Duration
+
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/show":
+					if tt.showStatus != 0 && tt.showStatus != http.StatusOK {
+						w.WriteHeader(tt.showStatus)
+						_ = json.NewEncoder(w).Encode(map[string]string{"error": "not found"})
+						return
+					}
+					w.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(w).Encode(api.ShowResponse{RemoteHost: tt.remoteHost})
+				case "/api/generate":
+					generateCalled = true
+					var req api.GenerateRequest
+					if err := json.NewDecoder(r.Body).Decode(&req); err == nil {
+						sentKeepAlive = req.KeepAlive
+					}
+					w.WriteHeader(http.StatusOK)
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer mockServer.Close()
+
+			t.Setenv("OLLAMA_HOST", mockServer.URL)
+
+			cmd := &cobra.Command{}
+			cmd.Flags().String("keepalive", "", "")
+			cmd.SetContext(t.Context())
+			if tt.keepaliveFlag != "" {
+				if err := cmd.Flags().Set("keepalive", tt.keepaliveFlag); err != nil {
+					t.Fatalf("set keepalive flag: %v", err)
+				}
+			}
+
+			err := LoadHandler(cmd, []string{tt.model})
+
+			if tt.expectError != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.expectError)
+				}
+				if !strings.Contains(err.Error(), tt.expectError) {
+					t.Fatalf("expected error containing %q, got %v", tt.expectError, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if generateCalled != tt.expectGenerate {
+				t.Errorf("generate called = %v, want %v", generateCalled, tt.expectGenerate)
+			}
+			switch {
+			case tt.expectKeepAlive != nil:
+				if sentKeepAlive == nil {
+					t.Errorf("expected keepalive %v, got nil", tt.expectKeepAlive)
+				} else if sentKeepAlive.Duration != tt.expectKeepAlive.Duration {
+					t.Errorf("expected keepalive %v, got %v", tt.expectKeepAlive, sentKeepAlive)
+				}
+			case tt.expectGenerate:
+				if sentKeepAlive != nil {
+					t.Errorf("expected nil keepalive (server default), got %v", sentKeepAlive)
+				}
+			}
+		})
+	}
+}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -2388,6 +2389,22 @@ func TestLoadHandler(t *testing.T) {
 			model:         "test-model",
 			keepaliveFlag: "garbage",
 			expectError:   "invalid duration",
+		},
+		{
+			name:          "zero keepalive is rejected to avoid silently unloading",
+			model:         "test-model",
+			keepaliveFlag: "0",
+			expectError:   "would immediately unload",
+		},
+		{
+			// api.Duration.MarshalJSON encodes any negative Duration as the
+			// literal -1, and the server's UnmarshalJSON maps that to
+			// math.MaxInt64 (the "keep loaded indefinitely" sentinel).
+			name:            "negative keepalive is forwarded as indefinite",
+			model:           "test-model",
+			keepaliveFlag:   "-1s",
+			expectGenerate:  true,
+			expectKeepAlive: &api.Duration{Duration: time.Duration(math.MaxInt64)},
 		},
 		{
 			name:        "missing model surfaces helpful error message",

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -130,6 +130,14 @@ ollama create -f Modelfile
 ollama ps
 ```
 
+### Load a model
+
+```
+ollama load gemma3
+```
+
+Preloads a model into memory without starting an interactive session, useful for warming up models at server startup or from scripts. Use `--keepalive` to control how long the model stays loaded (e.g. `--keepalive 1h`, `--keepalive -1s` to keep indefinitely).
+
 ### Stop a running model
 
 ```


### PR DESCRIPTION
## Summary

- Adds `ollama load MODEL` to preload a model into memory without starting an interactive session. Reuses the existing `loadOrUnloadModel` helper (cmd/cmd.go:469) that already backs `ollama stop`, so the new command is a thin CLI wrapper over an internal function that `RunHandler` and `StopHandler` already exercise in production.
- Adds a `--keepalive` flag that mirrors `ollama run`'s parsing via `time.ParseDuration`, including negative durations like `-1s` to keep the model loaded indefinitely.
- Rejects `--keepalive 0` with a helpful error pointing users to `ollama stop`, because a zero duration would route through the unload branch inside `loadOrUnloadModel` and silently unload the model.

Fixes #16084

## Test plan

- [x] `go test ./cmd/...` passes; 7 new subtests cover default keepalive, explicit duration, invalid duration, zero rejection, negative duration forwarded as indefinite, missing model, and cloud model
- [x] `go vet ./cmd/...` clean, `gofumpt -l` clean, `golangci-lint run --new-from-rev=upstream/main ./cmd/...` reports 0 issues
- [x] Manual against a real daemon with `smollm:135m`:
  - `ollama load smollm:135m` loads, `ollama ps` shows the default keepalive
  - `ollama load smollm:135m --keepalive 1m` updates keepalive, `ps` shows 59 seconds
  - `ollama load smollm:135m --keepalive 0` exits 1 with a helpful error, model stays loaded
  - `ollama load smollm:135m --keepalive garbage` exits 1 with `time: invalid duration`
  - `ollama load nonexistent:abc` exits 1 with `couldn't find model`
  - `ollama load smollm:135m --keepalive -1s` loads, `ps` shows `Forever`
- [x] Docs entry added in `docs/cli.mdx` next to `ollama stop`