### PR TITLE
convert: validate safetensors header length to prevent unbounded allocation

### DIFF
--- a/convert/reader_safetensors.go
+++ b/convert/reader_safetensors.go
@@ -43,6 +43,14 @@ func parseSafetensors(fsys fs.FS, replacer *strings.Replacer, ps ...string) ([]T
 			return nil, err
 		}
 
+		// Bound the header length to prevent unbounded allocation from a
+		// crafted file. Real safetensors headers are JSON metadata and the
+		// reference safetensors implementation caps them at 100MB.
+		const maxSafetensorsHeaderSize = 100 * 1024 * 1024
+		if n <= 0 || n > maxSafetensorsHeaderSize {
+			return nil, fmt.Errorf("invalid safetensors header length %d in %q (must be between 1 and %d bytes)", n, p, maxSafetensorsHeaderSize)
+		}
+
 		b := bytes.NewBuffer(make([]byte, 0, n))
 		if _, err = io.CopyN(b, f, n); err != nil {
 			return nil, err

--- a/convert/reader_test.go
+++ b/convert/reader_test.go
@@ -521,3 +521,42 @@ func TestSafetensorKind(t *testing.T) {
 		})
 	}
 }
+
+func TestParseSafetensorsRejectsCorruptHeaderLength(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		headerLen  int64
+		wantSubstr string
+	}{
+		{"max int64 would overflow allocator", 0x7FFFFFFFFFFFFFFF, "invalid safetensors header length"},
+		{"negative length is rejected", -1, "invalid safetensors header length"},
+		{"zero length is rejected", 0, "invalid safetensors header length"},
+		{"above the 100MB cap is rejected", 100*1024*1024 + 1, "invalid safetensors header length"},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tempDir := t.TempDir()
+
+			var buf bytes.Buffer
+			if err := binary.Write(&buf, binary.LittleEndian, tt.headerLen); err != nil {
+				t.Fatalf("write header length: %v", err)
+			}
+			path := filepath.Join(tempDir, "model-00001-of-00001.safetensors")
+			if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+				t.Fatalf("write file: %v", err)
+			}
+
+			_, err := parseSafetensors(os.DirFS(tempDir), strings.NewReplacer(), "model-00001-of-00001.safetensors")
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantSubstr)
+			}
+			if !strings.Contains(err.Error(), tt.wantSubstr) {
+				t.Fatalf("expected error containing %q, got %v", tt.wantSubstr, err)
+			}
+		})
+	}
+}

--- a/server/create.go
+++ b/server/create.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime/debug"
 	"slices"
 	"strings"
 	"sync/atomic"
@@ -98,6 +99,15 @@ func (s *Server) CreateHandler(c *gin.Context) {
 	ch := make(chan any)
 	go func() {
 		defer close(ch)
+		defer func() {
+			// Gin's recovery middleware only wraps the request goroutine, not
+			// the ones it spawns. Catch panics from convert / model loading
+			// so a crafted upload cannot take down the server.
+			if r := recover(); r != nil {
+				slog.Error("create panicked", "panic", r, "stack", string(debug.Stack()))
+				ch <- gin.H{"error": fmt.Sprintf("internal error: %v", r), "status": http.StatusInternalServerError}
+			}
+		}()
 		fn := func(resp api.ProgressResponse) {
 			ch <- resp
 		}


### PR DESCRIPTION
## Summary

- `parseSafetensors` reads the 8-byte header length from the file and passes it straight to `make([]byte, 0, n)` with no validation (convert/reader_safetensors.go:41-46). A crafted `.safetensors` with `n = MaxInt64` makes `make` panic with `makeslice: cap out of range`; a large positive `n` requests gigabytes and OOMs the process. Both paths are reachable through an unauthenticated `/api/create` upload, since the conversion runs in a goroutine spawned by `CreateHandler` that has no `recover()` and Gin's recovery middleware only wraps the request goroutine.
- Validates the header length against a 100MB cap (matching the [reference safetensors implementation](https://github.com/huggingface/safetensors/blob/main/safetensors/src/tensor.rs)) before allocating. Rejects values that are non-positive or above the cap with a descriptive error.
- Adds `defer recover()` to the `CreateHandler` goroutine as defense in depth, so a future panic anywhere in the convert / model-loading path returns an internal-error response instead of taking down the server. Panics are logged at `Error` level with the stack.

Fixes #16190

## Test plan

- [x] `go test ./convert/ ./server/` passes; `TestParseSafetensorsRejectsCorruptHeaderLength` covers MaxInt64, -1, 0, and 100MB+1 cases
- [x] `go vet`, `gofumpt`, `golangci-lint run --new-from-rev=upstream/main` all clean
- [x] Reproduced the issue's PoC against unpatched main and against the patched build:
  - **Unpatched**: daemon panics with `runtime error: makeslice: cap out of range` at `reader_safetensors.go:46`, full stack ends at `CreateHandler.func1` in goroutine 149, daemon PID gone, post-attack `/api/version` connection refused.
  - **Patched**: `/api/create` returns HTTP 200 with a streaming response carrying `"invalid safetensors header length 9223372036854775807 in \"model.safetensors\" (must be between 1 and 104857600 bytes)"`, daemon stays up, post-attack `/api/version` answers normally.