### PR TITLE
Add hidden OMP launcher integration with headless passthrough and tests

### DIFF
--- a/cmd/launch/integrations_test.go
+++ b/cmd/launch/integrations_test.go
@@ -64,6 +64,7 @@ func TestIntegrationLookup(t *testing.T) {
 		{"kimi", "kimi", true, "Kimi Code CLI"},
 		{"droid", "droid", true, "Droid"},
 		{"opencode", "opencode", true, "OpenCode"},
+		{"omp", "omp", true, "OMP"},
 		{"pool", "pool", true, "Pool"},
 		{"unknown integration", "unknown", false, ""},
 		{"empty string", "", false, ""},
@@ -83,7 +84,7 @@ func TestIntegrationLookup(t *testing.T) {
 }
 
 func TestIntegrationRegistry(t *testing.T) {
-	expectedIntegrations := []string{"claude", "claude-desktop", "codex", "codex-app", "kimi", "droid", "opencode", "hermes", "pool"}
+	expectedIntegrations := []string{"claude", "claude-desktop", "codex", "codex-app", "kimi", "droid", "opencode", "omp", "hermes", "pool"}
 	for _, name := range expectedIntegrations {
 		t.Run(name, func(t *testing.T) {
 			r, ok := integrations[name]
@@ -100,7 +101,7 @@ func TestIntegrationRegistry(t *testing.T) {
 func TestHiddenIntegrationsExcludedFromVisibleLists(t *testing.T) {
 	for _, info := range ListIntegrationInfos() {
 		switch info.Name {
-		case "cline", "vscode", "kimi":
+		case "cline", "vscode", "kimi", "omp":
 			t.Fatalf("hidden integration %q should not appear in ListIntegrationInfos", info.Name)
 		}
 	}

--- a/cmd/launch/omp.go
+++ b/cmd/launch/omp.go
@@ -1,0 +1,32 @@
+package launch
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/ollama/ollama/envconfig"
+)
+
+// OMP implements Runner for OMP CLI integration.
+type OMP struct{}
+
+func (o *OMP) String() string { return "OMP" }
+
+func (o *OMP) Run(model string, args []string) error {
+	bin, err := exec.LookPath("omp")
+	if err != nil {
+		return fmt.Errorf("omp is not installed")
+	}
+
+	cmd := exec.Command(bin, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = append(os.Environ(),
+		"OPENAI_BASE_URL="+envconfig.Host().String()+"/v1",
+		"OPENAI_API_KEY=ollama",
+	)
+
+	return cmd.Run()
+}

--- a/cmd/launch/omp.go
+++ b/cmd/launch/omp.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/ollama/ollama/envconfig"
 )
@@ -13,20 +14,36 @@ type OMP struct{}
 
 func (o *OMP) String() string { return "OMP" }
 
+func (o *OMP) args(model string, extra []string) []string {
+	var args []string
+	if model != "" {
+		args = append(args, "--model", ompModelName(model))
+	}
+	args = append(args, extra...)
+	return args
+}
+
 func (o *OMP) Run(model string, args []string) error {
 	bin, err := exec.LookPath("omp")
 	if err != nil {
 		return fmt.Errorf("omp is not installed")
 	}
 
-	cmd := exec.Command(bin, args...)
+	cmd := exec.Command(bin, o.args(model, args)...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Env = append(os.Environ(),
-		"OPENAI_BASE_URL="+envconfig.Host().String()+"/v1",
+		"OPENAI_BASE_URL="+strings.TrimRight(envconfig.ConnectableHost().String(), "/")+"/v1",
 		"OPENAI_API_KEY=ollama",
 	)
 
 	return cmd.Run()
+}
+
+func ompModelName(model string) string {
+	if strings.HasPrefix(model, "ollama/") {
+		return model
+	}
+	return "ollama/" + model
 }

--- a/cmd/launch/omp_test.go
+++ b/cmd/launch/omp_test.go
@@ -1,0 +1,43 @@
+package launch
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestOMPRunSetsOllamaEnv(t *testing.T) {
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "omp.log")
+	ompPath := filepath.Join(tmpDir, "omp")
+	script := "#!/bin/sh\n" +
+		"printf 'base=%s\\nkey=%s\\nargs=%s\\n' \"$OPENAI_BASE_URL\" \"$OPENAI_API_KEY\" \"$*\" > \"" + logPath + "\"\n"
+	if err := os.WriteFile(ompPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("failed to write fake omp binary: %v", err)
+	}
+
+	t.Setenv("PATH", tmpDir)
+	t.Setenv("OLLAMA_HOST", "http://127.0.0.1:11434")
+
+	o := &OMP{}
+	if err := o.Run("", []string{"--headless", "--try"}); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("failed to read omp log: %v", err)
+	}
+
+	got := string(data)
+	if !strings.Contains(got, "base=http://127.0.0.1:11434/v1") {
+		t.Fatalf("expected OPENAI_BASE_URL override in log, got:\n%s", got)
+	}
+	if !strings.Contains(got, "key=ollama") {
+		t.Fatalf("expected OPENAI_API_KEY override in log, got:\n%s", got)
+	}
+	if !strings.Contains(got, "args=--headless --try") {
+		t.Fatalf("expected passthrough args in log, got:\n%s", got)
+	}
+}

--- a/cmd/launch/omp_test.go
+++ b/cmd/launch/omp_test.go
@@ -7,6 +7,31 @@ import (
 	"testing"
 )
 
+func TestOMPArgs(t *testing.T) {
+	o := &OMP{}
+
+	tests := []struct {
+		name  string
+		model string
+		extra []string
+		want  []string
+	}{
+		{"with model", "qwen3.5", nil, []string{"--model", "ollama/qwen3.5"}},
+		{"empty model", "", nil, nil},
+		{"preserves Ollama prefix", "ollama/qwen3.5", []string{"--debug"}, []string{"--model", "ollama/qwen3.5", "--debug"}},
+		{"with extra args", "llama3.2", []string{"--headless", "--try"}, []string{"--model", "ollama/llama3.2", "--headless", "--try"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := o.args(tt.model, tt.extra)
+			if strings.Join(got, "\x00") != strings.Join(tt.want, "\x00") {
+				t.Fatalf("args() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestOMPRunSetsOllamaEnv(t *testing.T) {
 	tmpDir := t.TempDir()
 	logPath := filepath.Join(tmpDir, "omp.log")
@@ -18,10 +43,10 @@ func TestOMPRunSetsOllamaEnv(t *testing.T) {
 	}
 
 	t.Setenv("PATH", tmpDir)
-	t.Setenv("OLLAMA_HOST", "http://127.0.0.1:11434")
+	t.Setenv("OLLAMA_HOST", "http://0.0.0.0:11434")
 
 	o := &OMP{}
-	if err := o.Run("", []string{"--headless", "--try"}); err != nil {
+	if err := o.Run("qwen3.5", []string{"--headless", "--try"}); err != nil {
 		t.Fatalf("Run returned error: %v", err)
 	}
 
@@ -37,7 +62,7 @@ func TestOMPRunSetsOllamaEnv(t *testing.T) {
 	if !strings.Contains(got, "key=ollama") {
 		t.Fatalf("expected OPENAI_API_KEY override in log, got:\n%s", got)
 	}
-	if !strings.Contains(got, "args=--headless --try") {
+	if !strings.Contains(got, "args=--model ollama/qwen3.5 --headless --try") {
 		t.Fatalf("expected passthrough args in log, got:\n%s", got)
 	}
 }

--- a/cmd/launch/registry.go
+++ b/cmd/launch/registry.go
@@ -154,6 +154,19 @@ var integrationSpecs = []*IntegrationSpec{
 		},
 	},
 	{
+		Name:        "omp",
+		Runner:      &OMP{},
+		Description: "OMP's AI coding agent",
+		Hidden:      true,
+		Install: IntegrationInstallSpec{
+			CheckInstalled: func() bool {
+				_, err := exec.LookPath("omp")
+				return err == nil
+			},
+			URL: "https://omp.sh/",
+		},
+	},
+	{
 		Name:        "openclaw",
 		Runner:      &Openclaw{},
 		Aliases:     []string{"clawdbot", "moltbot"},

--- a/cmd/launch/runner_exec_only_test.go
+++ b/cmd/launch/runner_exec_only_test.go
@@ -46,6 +46,14 @@ func TestEditorRunsDoNotRewriteConfig(t *testing.T) {
 			},
 		},
 		{
+			name:   "omp",
+			binary: "omp",
+			runner: &OMP{},
+			checkPath: func(home string) string {
+				return filepath.Join(home, ".omp", "config.json")
+			},
+		},
+		{
 			name:   "pool",
 			binary: "pool",
 			runner: &Poolside{},


### PR DESCRIPTION
### Motivation
- Provide a hidden launcher integration for OMP (`https://omp.sh/`) so it can be invoked via `ollama launch omp` while remaining out of the primary integration list. 
- Ensure `omp` runs in a passthrough mode that supports headless-style flags (e.g. `--headless`, `--try`) and uses the local Ollama server as an OpenAI-compatible endpoint. 

### Description
- Add a new `OMP` runner implemented in `cmd/launch/omp.go` that resolves and execs the `omp` binary, forwards args, and injects `OPENAI_BASE_URL` and `OPENAI_API_KEY` from `envconfig.Host()` and a constant value respectively. 
- Register the integration in `cmd/launch/registry.go` with `Hidden: true`, install detection via `exec.LookPath("omp")`, and `URL: "https://omp.sh/"`. 
- Add `cmd/launch/omp_test.go` which creates a fake `omp` binary and verifies the environment wiring and passthrough args (checks `OPENAI_BASE_URL`, `OPENAI_API_KEY`, and forwarded args such as `--headless --try`). 
- Extend `cmd/launch/runner_exec_only_test.go` to include `omp` in the `TestEditorRunsDoNotRewriteConfig` matrix to assert run-only behavior does not rewrite editor-style configs. 

### Testing
- Ran `gofmt -w cmd/launch/omp.go cmd/launch/omp_test.go cmd/launch/runner_exec_only_test.go cmd/launch/registry.go` (formatting applied). — succeeded. 
- Ran `go test ./cmd/launch -run 'TestOMPRunSetsOllamaEnv|TestEditorRunsDoNotRewriteConfig|TestListIntegrationInfos|TestIntegrationInstallHint|TestLookupIntegration'` and all targeted tests passed (`ok`).

------