### PR TITLE
docs: add missing fields to ChatStreamEvent in openapi.yaml

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -401,6 +401,27 @@ components:
         done:
           type: boolean
           description: True for the final event in the stream
+        done_reason:
+          type: string
+          description: Reason the stream ended (e.g. "stop", "length")
+        total_duration:
+          type: integer
+          description: Time spent generating the response in nanoseconds
+        load_duration:
+          type: integer
+          description: Time spent loading the model in nanoseconds
+        prompt_eval_count:
+          type: integer
+          description: Number of input tokens in the prompt
+        prompt_eval_duration:
+          type: integer
+          description: Time spent evaluating the prompt in nanoseconds
+        eval_count:
+          type: integer
+          description: Number of output tokens generated in the response
+        eval_duration:
+          type: integer
+          description: Time spent generating tokens in nanoseconds
     StatusEvent:
       type: object
       properties:


### PR DESCRIPTION
## Problem

`ChatStreamEvent` in `docs/openapi.yaml` was missing 7 fields that the API
actually returns on the **final stream chunk** (when `done: true`):

- `done_reason`
- `total_duration`
- `load_duration`
- `prompt_eval_count`
- `prompt_eval_duration`
- `eval_count`
- `eval_duration`

These fields are already present on `GenerateStreamEvent` (the generate endpoint
shares the same final-chunk pattern). SDK generators and OpenAPI consumers that
read this spec silently drop timing and token-count metadata because the schema
says those fields don't exist.

## Fix

Add the same 7 fields to `ChatStreamEvent`, matching the descriptions already
used for `GenerateStreamEvent`.

## Before / After

```yaml
# Before — ChatStreamEvent ends at:
done:
  type: boolean

# After — ChatStreamEvent now includes:
done:
  type: boolean
done_reason:
  type: string
  description: Reason the stream ended (e.g. "stop", "length")
total_duration:
  type: integer
  description: Time spent generating the response in nanoseconds
load_duration:
  type: integer
  description: Time spent loading the model in nanoseconds
prompt_eval_count:
  type: integer
  description: Number of input tokens in the prompt
prompt_eval_duration:
  type: integer
  description: Time spent evaluating the prompt in nanoseconds
eval_count:
  type: integer
  description: Number of output tokens generated in the response
eval_duration:
  type: integer
  description: Time spent generating tokens in nanoseconds
```

Closes #14680