### PR TITLE
ml/ggml: add OLLAMA_PINNED_HOST_BUFFER opt-in for faster prefill on partial-offload models

### DIFF
--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -234,6 +234,11 @@ var (
 	UseAuth = Bool("OLLAMA_AUTH")
 	// Enable Vulkan backend
 	EnableVulkan = Bool("OLLAMA_VULKAN")
+	// PinnedHostBuffer routes CPU-resident tensors through CUDA pinned host
+	// memory (cudaMallocHost) for faster host-to-device transfers.
+	// Default: disabled (opt-in). Set OLLAMA_PINNED_HOST_BUFFER=1 to enable.
+	// EXPERIMENTAL.
+	PinnedHostBuffer = Bool("OLLAMA_PINNED_HOST_BUFFER")
 	// NoCloudEnv checks the OLLAMA_NO_CLOUD environment variable.
 	NoCloudEnv = Bool("OLLAMA_NO_CLOUD")
 )
@@ -333,6 +338,7 @@ func AsMap() map[string]EnvVar {
 		"OLLAMA_CONTEXT_LENGTH":       {"OLLAMA_CONTEXT_LENGTH", ContextLength(), "Context length to use unless otherwise specified (default: 4k/32k/256k based on VRAM)"},
 		"OLLAMA_EDITOR":               {"OLLAMA_EDITOR", Editor(), "Path to editor for interactive prompt editing (Ctrl+G)"},
 		"OLLAMA_NEW_ENGINE":           {"OLLAMA_NEW_ENGINE", NewEngine(), "Enable the new Ollama engine"},
+		"OLLAMA_PINNED_HOST_BUFFER":   {"OLLAMA_PINNED_HOST_BUFFER", PinnedHostBuffer(), "Route CPU-resident tensors through CUDA pinned host memory for faster H2D (experimental)"},
 		"OLLAMA_REMOTES":              {"OLLAMA_REMOTES", Remotes(), "Allowed hosts for remote models (default \"ollama.com\")"},
 
 		// Informational

--- a/ml/backend/ggml/ggml.go
+++ b/ml/backend/ggml/ggml.go
@@ -29,6 +29,7 @@ import (
 	"unicode"
 	"unsafe"
 
+	"github.com/ollama/ollama/envconfig"
 	"github.com/ollama/ollama/format"
 	"github.com/ollama/ollama/fs"
 	fsggml "github.com/ollama/ollama/fs/ggml"
@@ -164,17 +165,45 @@ func New(modelPath string, params ml.BackendParams) (ml.Backend, error) {
 
 	blocks := int(meta.KV().BlockCount())
 
-	// create list of buffer types for the cpu
+	// create list of buffer types for the cpu in order: ACCEL → GPU host → CPU
 	cpuDeviceBufferType := deviceBufferType{d: C.ggml_backend_dev_by_type(C.GGML_BACKEND_DEVICE_TYPE_CPU)}
-	for _, d := range append(accels, append(gpus, cpus...)...) {
-		switch C.ggml_backend_dev_type(d) {
-		case C.GGML_BACKEND_DEVICE_TYPE_CPU,
-			C.GGML_BACKEND_DEVICE_TYPE_ACCEL:
-			bt := C.ggml_backend_dev_buffer_type(d)
-			cpuDeviceBufferType.bts = append(cpuDeviceBufferType.bts, bt)
+	for _, d := range accels {
+		bt := C.ggml_backend_dev_buffer_type(d)
+		cpuDeviceBufferType.bts = append(cpuDeviceBufferType.bts, bt)
+		btDeviceMemory[bt] = &requiredMemory.CPU
+	}
 
-			btDeviceMemory[C.ggml_backend_dev_buffer_type(d)] = &requiredMemory.CPU
+	// EXPERIMENTAL: when OLLAMA_PINNED_HOST_BUFFER=1, insert the GPU's host
+	// buffer type (cudaMallocHost-backed pinned memory) after ACCEL bufts and
+	// before the plain CPU buffer, matching llama.cpp's make_cpu_buft_list order.
+	//
+	// Allocation safety: createTensor walks bts in order; if cudaMallocHost
+	// fails, the next fallback is the plain CPU buffer, so behavior is at worst
+	// equivalent to the disabled path.
+	//
+	// Only the first GPU's host buft is added. On systems with no CUDA GPU
+	// this loop is a no-op. The pinned buffer's memory still counts against
+	// system RAM, so we map it to CPU memory accounting.
+	if envconfig.PinnedHostBuffer() {
+		for _, d := range gpus {
+			hostBuft := C.ggml_backend_dev_host_buffer_type(d)
+			if hostBuft == nil {
+				continue
+			}
+			cpuDeviceBufferType.bts = append(cpuDeviceBufferType.bts, hostBuft)
+			btDeviceMemory[hostBuft] = &requiredMemory.CPU
+			slog.Info("OLLAMA_PINNED_HOST_BUFFER enabled: prefer cuda_host pinned for CPU-resident tensors",
+				"buft", C.GoString(C.ggml_backend_buft_name(hostBuft)),
+				"device", C.GoString(C.ggml_backend_dev_name(d)),
+			)
+			break
 		}
+	}
+
+	for _, d := range cpus {
+		bt := C.ggml_backend_dev_buffer_type(d)
+		cpuDeviceBufferType.bts = append(cpuDeviceBufferType.bts, bt)
+		btDeviceMemory[bt] = &requiredMemory.CPU
 	}
 
 	requiredMemory.CPU.Name = C.GoString(C.ggml_backend_dev_name(cpuDeviceBufferType.d))


### PR DESCRIPTION
## Summary

Adds `OLLAMA_PINNED_HOST_BUFFER=1` opt-in to route CPU-resident model weights through CUDA pinned host memory (`cudaMallocHost`) instead of plain pageable memory, closing the prefill gap described in issue #16221 .

## Motivation

On partial-offload setups (model size > VRAM), ollama runner's CPU buffer type list is built from `ggml_backend_dev_buffer_type()` only — plain `malloc`-backed pageable memory. GPU devices are skipped entirely in that loop, so the pinned host buffer type exposed via `ggml_backend_dev_host_buffer_type()` is never used for weight allocation.

llama runner's `make_cpu_buft_list` explicitly prepends the first GPU's host buffer type to the list for exactly this reason (see comment in [`llama-model.cpp:336-350`](https://github.com/ollama/ollama/blob/56b319f457d6c47a5a69c893110dcfb8290f93bd/llama/llama.cpp/src/llama-model.cpp#L336-L350)). This means CPU-resident weights in llama runner land in `cudaMallocHost`-backed pinned memory, while ollama runner's go through pageable memory with a driver staging copy on every H2D transfer. With ~28 GiB of CPU-resident weights per prefill batch, this is a meaningful per-batch cost.

## Implementation

`Backend.New()` builds the CPU buft list in three explicit passes, matching
llama.cpp's `make_cpu_buft_list` order (`ACCEL → GPU host → CPU`):

```go
// ACCEL pass (unchanged)
for _, d := range accels {
    bt := C.ggml_backend_dev_buffer_type(d)
    cpuDeviceBufferType.bts = append(cpuDeviceBufferType.bts, bt)
    btDeviceMemory[bt] = &requiredMemory.CPU
}

// GPU host pass (opt-in)
if envconfig.PinnedHostBuffer() {
    for _, d := range gpus {
        hostBuft := C.ggml_backend_dev_host_buffer_type(d)
        if hostBuft == nil {
            continue
        }
        cpuDeviceBufferType.bts = append(cpuDeviceBufferType.bts, hostBuft)
        btDeviceMemory[hostBuft] = &requiredMemory.CPU
        break
    }
}

// CPU pass (unchanged)
for _, d := range cpus {
    bt := C.ggml_backend_dev_buffer_type(d)
    cpuDeviceBufferType.bts = append(cpuDeviceBufferType.bts, bt)
    btDeviceMemory[bt] = &requiredMemory.CPU
}
```

`createTensor` already walks `bts` in order, so CPU-resident weights automatically land in pinned memory when the opt-in is set. No changes to op scheduling, decode path, or KV cache placement.

## Results

**Test platform:**

| Configuration | |
|---|---|
| CPU | Intel Core Ultra 9 265K (Arrow Lake) |
| RAM | 128 GB DDR5 6400 MT/s |
| GPU | NVIDIA RTX 3090 (24 GB VRAM) |
| OS | Windows 11 |
| Model | qwen3-coder-next 80B Q4_K_M (~52 GB GGUF, 49 layers) |
| Workload | batch_size=1024, prompt=1024, max_tokens=16 |

| Config | prefill_ms | prefill_tps |
|---|---:|---:|
| ollama runner (default) | 2061 ms | 475 t/s |
| ollama runner + `OLLAMA_PINNED_HOST_BUFFER=1` | **1469 ms** | **666 t/s** |

- **-29% prefill latency / +40% prefill tps** vs default ollama runner

## Note

**Allocation failure fallback**: if `cudaMallocHost` fails, `createTensor` advances to the next buft in the list — plain CPU buffer. Worst case is identical to the disabled path.

**No-op cases:**
- `OLLAMA_PINNED_HOST_BUFFER` unset (default)
- No CUDA GPU present (`gpus` slice is empty)
- Models that fully fit in VRAM (no CPU-resident weights to transfer)