### PR TITLE
server: support importing split GGUF models with multiple FROM lines

### DIFF
--- a/discover/runner.go
+++ b/discover/runner.go
@@ -149,7 +149,8 @@ func GPUDevices(ctx context.Context, runners []ml.FilteredRunnerDiscovery) []ml.
 				extraEnvs := ml.GetDevicesEnv(devices[i:i+1], true)
 				devices[i].AddInitValidation(extraEnvs)
 				if len(bootstrapDevicesWithMetalRetry(ctx2ndPass, ctx, 30*time.Second, devices[i].LibraryPath, extraEnvs)) == 0 {
-					slog.Debug("filtering device which didn't fully initialize",
+					slog.Debug(
+						"filtering device which didn't fully initialize",
 						"id", devices[i].ID,
 						"libdir", devices[i].LibraryPath[len(devices[i].LibraryPath)-1],
 						"pci_id", devices[i].PCIID,
@@ -223,7 +224,8 @@ func GPUDevices(ctx context.Context, runners []ml.FilteredRunnerDiscovery) []ml.
 					if droppedDevice.Integrated {
 						typeStr = "iGPU"
 					}
-					slog.Debug("dropping duplicate device",
+					slog.Debug(
+						"dropping duplicate device",
 						"id", droppedDevice.ID,
 						"library", droppedDevice.Library,
 						"compute", droppedDevice.Compute(),
@@ -397,7 +399,8 @@ func filterOverlapByLibrary(supported map[string]map[string]map[string]int, need
 			}
 			for dev, i := range byLibDirs[libDir] {
 				if _, found := byLibDirs[newest][dev]; found {
-					slog.Debug("filtering device with overlapping libraries",
+					slog.Debug(
+						"filtering device with overlapping libraries",
 						"id", dev,
 						"library", libDir,
 						"delete_index", i,
@@ -496,7 +499,7 @@ func bootstrapDevicesWithStatus(ctx context.Context, ollamaLibDirs []string, ext
 	status := llm.NewStatusWriter(baseOut)
 	cmd, port, err := llm.StartRunner(
 		true, // ollama engine
-		"",   // no model
+		nil,  // no model
 		ollamaLibDirs,
 		status,
 		extraEnvs,

--- a/docs/import.mdx
+++ b/docs/import.mdx
@@ -89,6 +89,16 @@ To import a GGUF model, create a `Modelfile` containing:
 FROM /path/to/file.gguf
 ```
 
+### Importing a split GGUF model
+
+Large models are often distributed as multiple GGUF shard files (e.g. `model-00001-of-00003.gguf`). Add one `FROM` line per shard in any order — Ollama will sort them automatically by their `split.no` metadata before loading:
+
+```dockerfile
+FROM /path/to/model-00001-of-00003.gguf
+FROM /path/to/model-00002-of-00003.gguf
+FROM /path/to/model-00003-of-00003.gguf
+```
+
 For a GGUF adapter, create the `Modelfile` with:
 
 ```dockerfile

--- a/fs/ggml/decode_shards_test.go
+++ b/fs/ggml/decode_shards_test.go
@@ -1,0 +1,258 @@
+package ggml
+
+// Tests for DecodeShards, the multi-file GGUF merge path.
+//
+// Issue #5245: users import split GGUF models with multiple FROM lines.
+// The server sorts shards by split.no, then DecodeShards merges them into
+// a single *GGML whose tensors carry ShardIdx so the backend knows which
+// file to read each tensor from.
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// f32Data returns n*4 bytes of zero-valued F32 tensor data.
+func f32Data(n int) *bytes.Reader {
+	return bytes.NewReader(make([]byte, n*4))
+}
+
+// writeShard creates a temporary GGUF file for one shard and returns its path.
+// no / count are the split.no / split.count values; total is split.tensors.count.
+// extraKV is merged into the KV block (useful for adding arch metadata to shard 0).
+func writeShard(t *testing.T, no, count, total int, extraKV KV, tensors []*Tensor) string {
+	t.Helper()
+
+	kv := KV{
+		"general.architecture": "test",
+		"split.no":             uint16(no),
+		"split.count":          uint16(count),
+		"split.tensors.count":  int32(total),
+	}
+	for k, v := range extraKV {
+		kv[k] = v
+	}
+
+	f, err := os.CreateTemp(t.TempDir(), "shard*.gguf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	if err := WriteGGUF(f, kv, tensors); err != nil {
+		t.Fatal("WriteGGUF:", err)
+	}
+	return f.Name()
+}
+
+func TestDecodeShards_EmptyPaths(t *testing.T) {
+	_, err := DecodeShards(nil, -1)
+	if err == nil {
+		t.Fatal("expected error for nil paths, got nil")
+	}
+
+	_, err = DecodeShards([]string{}, -1)
+	if err == nil {
+		t.Fatal("expected error for empty paths, got nil")
+	}
+}
+
+func TestDecodeShards_SinglePath(t *testing.T) {
+	// Single path delegates to Decode; result must not have ShardOffsets.
+	path := writeShard(t, 0, 1, 2, KV{"general.name": "solo"}, []*Tensor{
+		{Name: "token_embd.weight", Shape: []uint64{2, 3}, WriterTo: f32Data(6)},
+		{Name: "output.weight", Shape: []uint64{3, 2}, WriterTo: f32Data(6)},
+	})
+
+	g, err := DecodeShards([]string{path}, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tensors := g.Tensors()
+	if tensors.ShardOffsets != nil {
+		t.Errorf("single-path: ShardOffsets should be nil, got %v", tensors.ShardOffsets)
+	}
+	if n := len(tensors.Items()); n != 2 {
+		t.Errorf("single-path: want 2 tensors, got %d", n)
+	}
+	// split keys must still be present (not stripped) for single-path (caller's concern)
+	if g.KV()["split.no"] == nil {
+		// single-path passes through Decode unchanged, split keys are whatever the file has
+	}
+}
+
+func TestDecodeShards_MissingFile(t *testing.T) {
+	path0 := writeShard(t, 0, 2, 4, nil, []*Tensor{
+		{Name: "token_embd.weight", Shape: []uint64{2, 3}, WriterTo: f32Data(6)},
+	})
+
+	_, err := DecodeShards([]string{path0, "/nonexistent/shard-00002-of-00002.gguf"}, -1)
+	if err == nil {
+		t.Fatal("expected error for missing shard file, got nil")
+	}
+}
+
+func TestDecodeShards_TwoShards(t *testing.T) {
+	// Core invariant from issue #5245:
+	// All tensors from all shards are merged into one *GGML.
+	// Tensors from shard 0 keep ShardIdx=0 (zero value), tensors from shard 1 get ShardIdx=1.
+	// ShardOffsets has one entry per shard.
+	// KV metadata comes from shard 0; split.* keys are removed.
+
+	path0 := writeShard(t, 0, 2, 4, KV{"general.name": "split-model"}, []*Tensor{
+		{Name: "blk.0.attn_k.weight", Shape: []uint64{2, 3}, WriterTo: f32Data(6)},
+		{Name: "blk.0.attn_q.weight", Shape: []uint64{2, 3}, WriterTo: f32Data(6)},
+	})
+	path1 := writeShard(t, 1, 2, 4, nil, []*Tensor{
+		{Name: "blk.1.attn_k.weight", Shape: []uint64{2, 3}, WriterTo: f32Data(6)},
+		{Name: "blk.1.attn_q.weight", Shape: []uint64{2, 3}, WriterTo: f32Data(6)},
+	})
+
+	g, err := DecodeShards([]string{path0, path1}, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// ── tensor count ──────────────────────────────────────────────────────────
+	tensors := g.Tensors()
+	if n := len(tensors.Items()); n != 4 {
+		t.Errorf("want 4 tensors total, got %d", n)
+	}
+
+	// ── ShardIdx assignment ───────────────────────────────────────────────────
+	shardOf := make(map[string]int)
+	for _, t2 := range tensors.Items() {
+		shardOf[t2.Name] = t2.ShardIdx
+	}
+	wantShardOf := map[string]int{
+		"blk.0.attn_k.weight": 0,
+		"blk.0.attn_q.weight": 0,
+		"blk.1.attn_k.weight": 1,
+		"blk.1.attn_q.weight": 1,
+	}
+	if diff := cmp.Diff(wantShardOf, shardOf); diff != "" {
+		t.Errorf("ShardIdx mismatch (-want +got):\n%s", diff)
+	}
+
+	// ── ShardOffsets ──────────────────────────────────────────────────────────
+	if got := len(tensors.ShardOffsets); got != 2 {
+		t.Errorf("want ShardOffsets len=2, got %d", got)
+	}
+	// Both offsets must be nonzero (they're after the GGUF header+KV block).
+	for i, off := range tensors.ShardOffsets {
+		if off == 0 {
+			t.Errorf("ShardOffsets[%d] is 0, expected positive offset", i)
+		}
+	}
+
+	// ── KV merge ─────────────────────────────────────────────────────────────
+	kv := g.KV()
+	// split.* keys must be stripped
+	for _, k := range []string{"split.no", "split.count", "split.tensors.count"} {
+		if kv[k] != nil {
+			t.Errorf("KV key %q should have been removed after merge, still present", k)
+		}
+	}
+	// arch and model metadata from shard 0 must survive
+	if kv["general.architecture"] == nil {
+		t.Error("general.architecture missing from merged KV")
+	}
+	if kv["general.name"] == nil {
+		t.Error("general.name from shard 0 missing from merged KV")
+	}
+	// SplitNo / SplitCount helpers must return zero after strip
+	if v := kv.SplitNo(); v != 0 {
+		t.Errorf("SplitNo() after merge: want 0, got %d", v)
+	}
+	if v := kv.SplitCount(); v != 0 {
+		t.Errorf("SplitCount() after merge: want 0, got %d", v)
+	}
+}
+
+func TestDecodeShards_OrderIsCallerResponsibility(t *testing.T) {
+	// DecodeShards trusts the caller to pass paths in split.no order.
+	// The server sorts by split.no in create.go before storing to the manifest,
+	// so by the time paths reach DecodeShards the order is always correct.
+	//
+	// This test documents what happens when paths are reversed: tensors get
+	// wrong ShardIdx, so the backend would read weight data from the wrong file.
+	// It is a contract test, not a correctness test for DecodeShards itself.
+
+	path0 := writeShard(t, 0, 2, 4, KV{"general.name": "original"}, []*Tensor{
+		{Name: "blk.0.attn_k.weight", Shape: []uint64{2, 3}, WriterTo: f32Data(6)},
+		{Name: "blk.0.attn_q.weight", Shape: []uint64{2, 3}, WriterTo: f32Data(6)},
+	})
+	path1 := writeShard(t, 1, 2, 4, nil, []*Tensor{
+		{Name: "blk.1.attn_k.weight", Shape: []uint64{2, 3}, WriterTo: f32Data(6)},
+		{Name: "blk.1.attn_q.weight", Shape: []uint64{2, 3}, WriterTo: f32Data(6)},
+	})
+
+	// correct order: [shard0, shard1]
+	correct, err := DecodeShards([]string{path0, path1}, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// reversed order: [shard1, shard0] — what happens if sort in create.go is bypassed
+	reversed, err := DecodeShards([]string{path1, path0}, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// In correct order, shard 0 tensors have ShardIdx 0, shard 1 tensors have ShardIdx 1.
+	correctIdx := make(map[string]int)
+	for _, tt := range correct.Tensors().Items() {
+		correctIdx[tt.Name] = tt.ShardIdx
+	}
+	if correctIdx["blk.0.attn_k.weight"] != 0 || correctIdx["blk.1.attn_k.weight"] != 1 {
+		t.Errorf("correct order: unexpected ShardIdx map %v", correctIdx)
+	}
+
+	// In reversed order, the same tensors get the opposite ShardIdx,
+	// proving that DecodeShards does not auto-correct the order.
+	reversedIdx := make(map[string]int)
+	for _, tt := range reversed.Tensors().Items() {
+		reversedIdx[tt.Name] = tt.ShardIdx
+	}
+	if reversedIdx["blk.0.attn_k.weight"] != 1 || reversedIdx["blk.1.attn_k.weight"] != 0 {
+		t.Errorf("reversed order: expected ShardIdx to be swapped, got %v", reversedIdx)
+	}
+}
+
+func TestDecodeShards_ShardOffsetsDiffer(t *testing.T) {
+	// Shard 0 has more KV than shard 1, so its header is larger and its
+	// tensor-data region starts at a higher offset. ShardOffsets must reflect
+	// each shard's individual tensorOffset, not a shared value.
+	path0 := writeShard(
+		t, 0, 2, 2,
+		KV{
+			"general.name":       "big-metadata",
+			"tokenizer.ggml.bos": uint32(1),
+			"tokenizer.ggml.eos": uint32(2),
+		},
+		[]*Tensor{
+			{Name: "token_embd.weight", Shape: []uint64{2, 3}, WriterTo: f32Data(6)},
+		},
+	)
+	path1 := writeShard(t, 1, 2, 2, nil, []*Tensor{
+		{Name: "output.weight", Shape: []uint64{3, 2}, WriterTo: f32Data(6)},
+	})
+
+	g, err := DecodeShards([]string{path0, path1}, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	so := g.Tensors().ShardOffsets
+	if len(so) != 2 {
+		t.Fatalf("want 2 ShardOffsets, got %d", len(so))
+	}
+	// Shard 0 has more KV bytes so its tensor region starts later.
+	if so[0] <= so[1] {
+		t.Errorf("shard 0 has larger header, its offset (%d) should exceed shard 1's (%d)", so[0], so[1])
+	}
+}

--- a/fs/ggml/ggml.go
+++ b/fs/ggml/ggml.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"maps"
 	"math"
+	"os"
 	"slices"
 	"strings"
 
@@ -141,6 +142,18 @@ func (kv KV) ContextLength() uint64 {
 
 func (kv KV) ChatTemplate() string {
 	return kv.String("tokenizer.chat_template")
+}
+
+// split GGUF metadata
+
+func (kv KV) SplitNo() uint16 {
+	v, _ := kv["split.no"].(uint16)
+	return v
+}
+
+func (kv KV) SplitCount() uint16 {
+	v, _ := kv["split.count"].(uint16)
+	return v
 }
 
 // ssm architecture parameters
@@ -316,7 +329,7 @@ type arrayValueTypes interface {
 }
 
 func keyValue[T valueTypes | arrayValueTypes](kv KV, key string, defaultValue ...T) (T, bool) {
-	if !strings.HasPrefix(key, "tokenizer.") && !strings.HasPrefix(key, "general.") {
+	if !strings.HasPrefix(key, "tokenizer.") && !strings.HasPrefix(key, "general.") && !strings.HasPrefix(key, "split.") {
 		key = kv.Architecture() + "." + key
 	}
 
@@ -329,8 +342,9 @@ func keyValue[T valueTypes | arrayValueTypes](kv KV, key string, defaultValue ..
 }
 
 type Tensors struct {
-	items  []*Tensor
-	Offset uint64
+	items        []*Tensor
+	Offset       uint64
+	ShardOffsets []uint64 // nil for single-file; len == shard count for split GGUF
 }
 
 func (s Tensors) Items(prefix ...string) []*Tensor {
@@ -357,7 +371,8 @@ func (ts Tensors) GroupLayers() map[string]Layer {
 				// blk and mm should have a number after them, join it
 				parts = append(
 					[]string{strings.Join(parts[:index+2], ".")},
-					parts[index+2:]...)
+					parts[index+2:]...,
+				)
 			}
 		}
 
@@ -382,9 +397,10 @@ func (l Layer) Size() (size uint64) {
 }
 
 type Tensor struct {
-	Name   string `json:"name"`
-	Kind   uint32 `json:"kind"`
-	Offset uint64 `json:"-"`
+	Name     string `json:"name"`
+	Kind     uint32 `json:"kind"`
+	Offset   uint64 `json:"-"`
+	ShardIdx int    `json:"-"`
 
 	// Shape is the number of elements in each dimension
 	Shape []uint64 `json:"shape"`
@@ -596,6 +612,59 @@ func Decode(rs io.ReadSeeker, maxArraySize int) (*GGML, error) {
 		model:     model,
 		Length:    offset,
 	}, nil
+}
+
+// DecodeShards opens each path, decodes the GGUF header, and merges the
+// results into a single GGML. KV metadata is taken from shard 0; tensors are
+// collected from all shards with ShardIdx set to their source file index.
+// Paths must be ordered by split.no (0-indexed).
+func DecodeShards(paths []string, maxArraySize int) (*GGML, error) {
+	if len(paths) == 0 {
+		return nil, fmt.Errorf("no paths provided")
+	}
+	if len(paths) == 1 {
+		f, err := os.Open(paths[0])
+		if err != nil {
+			return nil, err
+		}
+		defer f.Close()
+		return Decode(f, maxArraySize)
+	}
+
+	shards := make([]*GGML, len(paths))
+	for i, p := range paths {
+		f, err := os.Open(p)
+		if err != nil {
+			return nil, fmt.Errorf("shard %d: %w", i, err)
+		}
+		defer f.Close()
+		shards[i], err = Decode(f, maxArraySize)
+		if err != nil {
+			return nil, fmt.Errorf("shard %d: %w", i, err)
+		}
+	}
+
+	base := shards[0]
+	kv := base.KV()
+	delete(kv, "split.no")
+	delete(kv, "split.count")
+	delete(kv, "split.tensors.count")
+
+	g := base.model.(*gguf)
+	g.shardOffsets = make([]uint64, len(shards))
+	g.shardOffsets[0] = g.tensorOffset
+
+	for i, shard := range shards[1:] {
+		idx := i + 1
+		sg := shard.model.(*gguf)
+		g.shardOffsets[idx] = sg.tensorOffset
+		for _, t := range sg.tensors {
+			t.ShardIdx = idx
+			g.tensors = append(g.tensors, t)
+		}
+	}
+
+	return base, nil
 }
 
 func (f GGML) GraphSize(context, batch uint64, numParallel int, kvCacheType string, useFlashAttention ml.FlashAttentionType) (kv []uint64, partialOffload, fullOffload uint64) {

--- a/fs/ggml/gguf.go
+++ b/fs/ggml/gguf.go
@@ -94,6 +94,7 @@ type gguf struct {
 
 	parameters   uint64
 	tensorOffset uint64
+	shardOffsets []uint64 // nil for single-file models
 
 	scratch [16 << 10]byte
 }
@@ -111,8 +112,9 @@ func (llm *gguf) KV() KV {
 
 func (llm *gguf) Tensors() Tensors {
 	return Tensors{
-		items:  llm.tensors,
-		Offset: llm.tensorOffset,
+		items:        llm.tensors,
+		Offset:       llm.tensorOffset,
+		ShardOffsets: llm.shardOffsets,
 	}
 }
 
@@ -597,7 +599,8 @@ func ggufWriteKV(ws io.WriteSeeker, arch, k string, v any) error {
 	if !strings.HasPrefix(k, arch+".") &&
 		!strings.HasPrefix(k, "general.") &&
 		!strings.HasPrefix(k, "adapter.") &&
-		!strings.HasPrefix(k, "tokenizer.") {
+		!strings.HasPrefix(k, "tokenizer.") &&
+		!strings.HasPrefix(k, "split.") {
 		k = arch + "." + k
 	}
 
@@ -612,6 +615,8 @@ func ggufWriteKV(ws io.WriteSeeker, arch, k string, v any) error {
 
 	var err error
 	switch v := v.(type) {
+	case uint16:
+		err = writeGGUF(ws, ggufTypeUint16, v)
 	case int32:
 		err = writeGGUF(ws, ggufTypeInt32, v)
 	case int64:

--- a/integration/create_test.go
+++ b/integration/create_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -301,6 +302,140 @@ func TestCreateGGUF(t *testing.T) {
 	deleteReq := &api.DeleteRequest{Model: modelName}
 	if err := client.Delete(ctx, deleteReq); err != nil {
 		t.Logf("Warning: failed to delete test model: %v", err)
+	}
+}
+
+// TestCreateSplitGGUF verifies that a Modelfile with multiple FROM lines
+// (one per shard) imports correctly regardless of the order the shards are
+// listed. It also checks that an incomplete shard set is rejected.
+//
+// Requirements: huggingface-cli (to download the base model) and
+// llama-gguf-split (from llama.cpp) must be on PATH. The test is skipped
+// automatically if either tool is missing.
+func TestCreateSplitGGUF(t *testing.T) {
+	if testModel != "" {
+		t.Skip("exercises create pipeline with a fixed source model, not applicable with model override")
+	}
+	skipIfRemote(t)
+
+	// Require llama-gguf-split; skip if absent.
+	splitBin, err := exec.LookPath("llama-gguf-split")
+	if err != nil {
+		t.Skip("llama-gguf-split not found in PATH; install from llama.cpp to enable this test")
+	}
+
+	// Download SmolLM2-135M Q8_0 (~90 MB, fast even on slow connections).
+	modelDir := filepath.Join(testdataModelsDir, "SmolLM2-135M-GGUF")
+	downloadHFModel(t, "hugging-quants/SmolLM2-135M-Instruct-Q8_0-GGUF", modelDir,
+		"--include", "smollm2-135m-instruct-q8_0.gguf")
+
+	var basePath string
+	entries, _ := os.ReadDir(modelDir)
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".gguf" {
+			basePath = filepath.Join(modelDir, e.Name())
+			break
+		}
+	}
+	if basePath == "" {
+		t.Skip("No GGUF file found in model directory")
+	}
+
+	// Split into 3 shards so the incomplete-shard error case is testable
+	// (needs at least 2 paths for the mismatch check to fire).
+	splitDir := t.TempDir()
+	splitBase := filepath.Join(splitDir, "smollm")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	splitCmd := exec.CommandContext(ctx, splitBin, "--split-max-tensors", "100", basePath, splitBase)
+	splitCmd.Stdout = os.Stdout
+	splitCmd.Stderr = os.Stderr
+	if err := splitCmd.Run(); err != nil {
+		t.Fatalf("llama-gguf-split failed: %v", err)
+	}
+
+	shardFiles, err := filepath.Glob(filepath.Join(splitDir, "smollm-*.gguf"))
+	if err != nil || len(shardFiles) < 2 {
+		t.Fatalf("expected ≥2 shard files after split, got %v", shardFiles)
+	}
+
+	// ── case 1: reversed FROM order must still produce a working model ────────
+
+	// Sort shards in reverse filename order so FROM lines are intentionally wrong.
+	sort.Sort(sort.Reverse(sort.StringSlice(shardFiles)))
+
+	var lines []string
+	for _, s := range shardFiles {
+		abs, _ := filepath.Abs(s)
+		lines = append(lines, "FROM "+abs)
+	}
+	mfContent := strings.Join(lines, "\n") + "\n"
+
+	mfPath := filepath.Join(t.TempDir(), "Modelfile")
+	if err := os.WriteFile(mfPath, []byte(mfContent), 0o644); err != nil {
+		t.Fatalf("Failed to write Modelfile: %v", err)
+	}
+
+	client, _, cleanup := InitServerConnection(ctx, t)
+	defer cleanup()
+
+	const modelName = "test-split-gguf"
+
+	createCmd := exec.CommandContext(ctx, ollamaBin(), "create", modelName, "-f", mfPath)
+	createCmd.Stdout = os.Stdout
+	createCmd.Stderr = os.Stderr
+	if err := createCmd.Run(); err != nil {
+		t.Fatalf("ollama create failed with reversed shard order: %v", err)
+	}
+
+	if _, err := client.Show(ctx, &api.ShowRequest{Name: modelName}); err != nil {
+		t.Fatalf("Model show failed after create: %v", err)
+	}
+
+	var output strings.Builder
+	if err := client.Generate(ctx, &api.GenerateRequest{
+		Model:  modelName,
+		Prompt: "Write a short sentence about the weather.",
+		Options: map[string]interface{}{
+			"num_predict": 20,
+			"temperature": 0.0,
+		},
+	}, func(r api.GenerateResponse) error {
+		output.WriteString(r.Response)
+		return nil
+	}); err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+	t.Logf("Generated output: %q", output.String())
+	assertCoherentOutput(t, output.String())
+
+	if err := client.Delete(ctx, &api.DeleteRequest{Model: modelName}); err != nil {
+		t.Logf("Warning: failed to delete test model: %v", err)
+	}
+
+	// ── case 2: supplying fewer shards than split.count must be rejected ──────
+
+	// Use the first two shards of a 3-shard model (sorted order, not reversed).
+	sort.Strings(shardFiles)
+	var incompleteLines []string
+	for _, s := range shardFiles[:2] {
+		abs, _ := filepath.Abs(s)
+		incompleteLines = append(incompleteLines, "FROM "+abs)
+	}
+	incompleteMF := filepath.Join(t.TempDir(), "Modelfile.incomplete")
+	if err := os.WriteFile(incompleteMF, []byte(strings.Join(incompleteLines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("Failed to write incomplete Modelfile: %v", err)
+	}
+
+	incompleteCreate := exec.CommandContext(ctx, ollamaBin(), "create", "test-split-gguf-incomplete", "-f", incompleteMF)
+	var incompleteStderr strings.Builder
+	incompleteCreate.Stderr = io.MultiWriter(os.Stderr, &incompleteStderr)
+	if err := incompleteCreate.Run(); err == nil {
+		t.Error("expected ollama create to fail with incomplete shard set, but it succeeded")
+	} else if !strings.Contains(incompleteStderr.String(), "declares") {
+		t.Errorf("expected 'declares N shards but M were provided' in stderr, got: %s", incompleteStderr.String())
 	}
 }
 

--- a/llama/llama.go
+++ b/llama/llama.go
@@ -313,6 +313,66 @@ func LoadModelFromFile(modelPath string, params ModelParams) (*Model, error) {
 	return &m, nil
 }
 
+// LoadModelFromSplits loads a split GGUF model from multiple shard paths.
+// paths must be ordered by split.no (0-indexed). For single-file models prefer LoadModelFromFile.
+func LoadModelFromSplits(paths []string, params ModelParams) (*Model, error) {
+	cparams := C.llama_model_default_params()
+	cparams.n_gpu_layers = C.int(params.NumGpuLayers)
+	cparams.main_gpu = C.int32_t(params.MainGpu)
+	cparams.use_mmap = C.bool(params.UseMmap)
+	cparams.vocab_only = C.bool(params.VocabOnly)
+
+	var devices []C.ggml_backend_dev_t
+	for _, llamaID := range params.Devices {
+		devices = append(devices, C.ggml_backend_dev_get(C.size_t(llamaID)))
+	}
+	if len(devices) > 0 {
+		devices = append(devices, C.ggml_backend_dev_t(C.NULL))
+		devicesData := &devices[0]
+
+		var devicesPin runtime.Pinner
+		devicesPin.Pin(devicesData)
+		defer devicesPin.Unpin()
+
+		cparams.devices = devicesData
+	}
+
+	if len(params.TensorSplit) > 0 {
+		tensorSplitData := &params.TensorSplit[0]
+
+		var tensorSplitPin runtime.Pinner
+		tensorSplitPin.Pin(tensorSplitData)
+		defer tensorSplitPin.Unpin()
+
+		cparams.tensor_split = (*C.float)(unsafe.Pointer(tensorSplitData))
+	}
+
+	if params.Progress != nil {
+		handle := cgo.NewHandle(params.Progress)
+		defer handle.Delete()
+
+		var handlePin runtime.Pinner
+		handlePin.Pin(&handle)
+		defer handlePin.Unpin()
+
+		cparams.progress_callback = C.llama_progress_callback(C.llamaProgressCallback)
+		cparams.progress_callback_user_data = unsafe.Pointer(&handle)
+	}
+
+	cpaths := make([]*C.char, len(paths))
+	for i, p := range paths {
+		cpaths[i] = C.CString(p)
+		defer C.free(unsafe.Pointer(cpaths[i]))
+	}
+
+	m := Model{c: C.llama_model_load_from_splits(&cpaths[0], C.size_t(len(paths)), cparams)}
+	if m.c == nil {
+		return nil, fmt.Errorf("unable to load split model: %v", paths)
+	}
+
+	return &m, nil
+}
+
 func FreeModel(model *Model) {
 	C.llama_model_free(model.c)
 }
@@ -426,7 +486,7 @@ func (b *Batch) Add(token int, embed []float32, pos int, logits bool, seqIds ...
 	unsafe.Slice(b.c.n_seq_id, b.allocSize())[b.c.n_tokens] = C.int(len(seqIds))
 
 	for i, s := range seqIds {
-		unsafe.Slice((unsafe.Slice(b.c.seq_id, b.allocSize())[b.c.n_tokens]), C.int(len(seqIds)))[i] = C.int32_t(s)
+		unsafe.Slice(unsafe.Slice(b.c.seq_id, b.allocSize())[b.c.n_tokens], C.int(len(seqIds)))[i] = C.int32_t(s)
 	}
 
 	if logits {

--- a/llm/server.go
+++ b/llm/server.go
@@ -85,13 +85,13 @@ type LlamaServer interface {
 
 // llmServer is an instance of a runner hosting a single model
 type llmServer struct {
-	port      int
-	cmd       *exec.Cmd
-	done      chan struct{} // closed when the process exits
-	doneErr   error         // valid after done is closed
-	status    *StatusWriter
-	options   api.Options
-	modelPath string
+	port       int
+	cmd        *exec.Cmd
+	done       chan struct{} // closed when the process exits
+	doneErr    error         // valid after done is closed
+	status     *StatusWriter
+	options    api.Options
+	modelPaths []string
 
 	loadRequest LoadRequest       // Parameters used to initialize the runner
 	mem         *ml.BackendMemory // Memory allocations for this model
@@ -141,23 +141,28 @@ func LoadModel(model string, maxArraySize int) (*ggml.GGML, error) {
 }
 
 // NewLlamaServer will run a server for the given GPUs
-func NewLlamaServer(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, modelPath string, f *ggml.GGML, adapters, projectors []string, opts api.Options, numParallel int) (LlamaServer, error) {
+func NewLlamaServer(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, modelPaths []string, f *ggml.GGML, adapters, projectors []string, opts api.Options, numParallel int) (LlamaServer, error) {
 	var llamaModel *llama.Model
 	var tok tokenizer.Tokenizer
 	var err error
 	if envconfig.NewEngine() || f.KV().OllamaEngineRequired() {
 		if len(projectors) == 0 {
-			tok, err = model.NewTextProcessor(modelPath)
+			tok, err = model.NewTextProcessor(modelPaths[0])
 		} else {
 			err = errors.New("split vision models aren't supported")
 		}
 		if err != nil {
 			// To prepare for opt-out mode, instead of treating this as an error, we fallback to the old runner
-			slog.Debug("model not yet supported by Ollama engine, switching to compatibility mode", "model", modelPath, "error", err)
+			slog.Debug("model not yet supported by Ollama engine, switching to compatibility mode", "model", modelPaths[0], "error", err)
 		}
 	}
 	if tok == nil {
-		llamaModel, err = llama.LoadModelFromFile(modelPath, llama.ModelParams{VocabOnly: true})
+		vocabParams := llama.ModelParams{VocabOnly: true}
+		if len(modelPaths) > 1 {
+			llamaModel, err = llama.LoadModelFromSplits(modelPaths, vocabParams)
+		} else {
+			llamaModel, err = llama.LoadModelFromFile(modelPaths[0], vocabParams)
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -275,7 +280,7 @@ func NewLlamaServer(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, modelPath st
 	status := NewStatusWriter(os.Stderr)
 	cmd, port, err := StartRunner(
 		tok != nil,
-		modelPath,
+		modelPaths,
 		gpuLibs,
 		status,
 		ml.GetDevicesEnv(gpus, false),
@@ -286,7 +291,7 @@ func NewLlamaServer(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, modelPath st
 		cmd:            cmd,
 		status:         status,
 		options:        opts,
-		modelPath:      modelPath,
+		modelPaths:     modelPaths,
 		loadRequest:    loadRequest,
 		llamaModel:     llamaModel,
 		llamaModelLock: &sync.Mutex{},
@@ -331,7 +336,7 @@ func NewLlamaServer(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, modelPath st
 	}
 }
 
-func StartRunner(ollamaEngine bool, modelPath string, gpuLibs []string, out io.Writer, extraEnvs map[string]string) (cmd *exec.Cmd, port int, err error) {
+func StartRunner(ollamaEngine bool, modelPaths []string, gpuLibs []string, out io.Writer, extraEnvs map[string]string) (cmd *exec.Cmd, port int, err error) {
 	var exe string
 	exe, err = os.Executable()
 	if err != nil {
@@ -358,8 +363,8 @@ func StartRunner(ollamaEngine bool, modelPath string, gpuLibs []string, out io.W
 	if ollamaEngine {
 		params = append(params, "--ollama-engine")
 	}
-	if modelPath != "" {
-		params = append(params, "--model", modelPath)
+	for _, p := range modelPaths {
+		params = append(params, "--model", p)
 	}
 	params = append(params, "--port", strconv.Itoa(port))
 
@@ -473,7 +478,10 @@ func ShouldRetryWithMetalTensorDisabled(err error, status *StatusWriter) bool {
 }
 
 func (s *llmServer) ModelPath() string {
-	return s.modelPath
+	if len(s.modelPaths) > 0 {
+		return s.modelPaths[0]
+	}
+	return ""
 }
 
 type LoadOperation int

--- a/ml/backend.go
+++ b/ml/backend.go
@@ -73,9 +73,9 @@ type BackendParams struct {
 	FlashAttention FlashAttentionType
 }
 
-var backends = make(map[string]func(string, BackendParams) (Backend, error))
+var backends = make(map[string]func([]string, BackendParams) (Backend, error))
 
-func RegisterBackend(name string, f func(string, BackendParams) (Backend, error)) {
+func RegisterBackend(name string, f func([]string, BackendParams) (Backend, error)) {
 	if _, ok := backends[name]; ok {
 		panic("backend: backend already registered")
 	}
@@ -83,9 +83,9 @@ func RegisterBackend(name string, f func(string, BackendParams) (Backend, error)
 	backends[name] = f
 }
 
-func NewBackend(modelPath string, params BackendParams) (Backend, error) {
+func NewBackend(modelPaths []string, params BackendParams) (Backend, error) {
 	if backend, ok := backends["ggml"]; ok {
-		return backend(modelPath, params)
+		return backend(modelPaths, params)
 	}
 
 	return nil, fmt.Errorf("unsupported backend")

--- a/ml/backend/ggml/ggml.go
+++ b/ml/backend/ggml/ggml.go
@@ -82,8 +82,8 @@ type layerDevice struct {
 }
 
 type Backend struct {
-	// modelPath is the location of the model data
-	modelPath string
+	// modelPaths are the shard file paths; single-element for non-split models
+	modelPaths []string
 
 	meta *fsggml.GGML
 
@@ -128,14 +128,24 @@ type Backend struct {
 
 var once sync.Once
 
-func New(modelPath string, params ml.BackendParams) (ml.Backend, error) {
-	r, err := os.Open(modelPath)
-	if err != nil {
-		return nil, err
+func New(modelPaths []string, params ml.BackendParams) (ml.Backend, error) {
+	if len(modelPaths) == 0 {
+		return nil, fmt.Errorf("no model paths provided")
 	}
-	defer r.Close()
 
-	meta, err := fsggml.Decode(r, -1)
+	var meta *fsggml.GGML
+	var err error
+	if len(modelPaths) == 1 {
+		var r *os.File
+		r, err = os.Open(modelPaths[0])
+		if err != nil {
+			return nil, err
+		}
+		defer r.Close()
+		meta, err = fsggml.Decode(r, -1)
+	} else {
+		meta, err = fsggml.DecodeShards(modelPaths, -1)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -428,7 +438,7 @@ func New(modelPath string, params ml.BackendParams) (ml.Backend, error) {
 	}
 
 	return &Backend{
-		modelPath:         modelPath,
+		modelPaths:        modelPaths,
 		allocMemory:       params.AllocMemory,
 		flashAttention:    params.FlashAttention,
 		meta:              meta,
@@ -473,6 +483,16 @@ func (b *Backend) Close() {
 	C.ggml_backend_sched_free(b.sched)
 }
 
+// tensorLocation returns the file path and the base byte offset for the tensor
+// data region in that file. For split GGUF models the shard index on the tensor
+// selects the correct file; for single-file models it always returns modelPaths[0].
+func (b *Backend) tensorLocation(t *fsggml.Tensor) (path string, baseOffset int64) {
+	if so := b.meta.Tensors().ShardOffsets; len(so) > 0 {
+		return b.modelPaths[t.ShardIdx], int64(so[t.ShardIdx])
+	}
+	return b.modelPaths[0], int64(b.meta.Tensors().Offset)
+}
+
 func (b *Backend) Load(ctx context.Context, progress func(float32)) error {
 	if !b.allocMemory {
 		return errors.New("cannot load model without memory allocation")
@@ -502,7 +522,10 @@ func (b *Backend) Load(ctx context.Context, progress func(float32)) error {
 	slog.Info(fmt.Sprintf("offloaded %d/%d layers to GPU", gpuLayers, len(b.layers)+1))
 
 	var doneBytes atomic.Uint64
-	totalBytes := uint64(b.meta.Length) - b.meta.Tensors().Offset
+	var totalBytes uint64
+	for _, t := range b.meta.Tensors().Items() {
+		totalBytes += t.Size()
+	}
 
 	g, ctx := errgroup.WithContext(ctx)
 	g.SetLimit(runtime.GOMAXPROCS(0))
@@ -525,13 +548,14 @@ func (b *Backend) Load(ctx context.Context, progress func(float32)) error {
 
 			// Create a new FD for each goroutine so that each FD is read sequentially, rather than
 			// seeking around within an FD shared between all goroutines.
-			file, err := os.Open(b.modelPath)
+			filePath, baseOffset := b.tensorLocation(t)
+			file, err := os.Open(filePath)
 			if err != nil {
-				slog.Warn("file open error", "file", b.modelPath, "error", err)
+				slog.Warn("file open error", "file", filePath, "error", err)
 				return err
 			}
 			defer file.Close()
-			sr := io.NewSectionReader(file, int64(b.meta.Tensors().Offset+t.Offset), int64(t.Size()))
+			sr := io.NewSectionReader(file, baseOffset+int64(t.Offset), int64(t.Size()))
 
 			if t.Kind == 4 && tts[0]._type == 39 {
 				// source is mxfp4, target is ggml mxfp4
@@ -547,7 +571,7 @@ func (b *Backend) Load(ctx context.Context, progress func(float32)) error {
 					}
 					n, err := io.ReadFull(sr, bts[:min(len(bts), int(t.Size()-s))])
 					if err != nil {
-						slog.Warn("file read error", "file", b.modelPath, "error", err)
+						slog.Warn("file read error", "file", filePath, "error", err)
 						return err
 					}
 					for j := range n / BS {
@@ -585,7 +609,7 @@ func (b *Backend) Load(ctx context.Context, progress func(float32)) error {
 					}
 					n, err := io.ReadFull(sr, bts[:min(len(bts), int(t.Elements()-e)*2)])
 					if err != nil {
-						slog.Warn("file read error", "file", b.modelPath, "error", err)
+						slog.Warn("file read error", "file", filePath, "error", err)
 						return err
 					}
 					fp32 := ConvertToF32(bts, uint32(fsggml.TensorTypeBF16), uint64(n/2))
@@ -613,7 +637,7 @@ func (b *Backend) Load(ctx context.Context, progress func(float32)) error {
 
 				n, err := io.ReadFull(sr, bts[:min(len(bts), int(t.Size()-s))])
 				if err != nil {
-					slog.Warn("file read error", "file", b.modelPath, "error", err)
+					slog.Warn("file read error", "file", filePath, "error", err)
 					return err
 				}
 
@@ -725,10 +749,10 @@ func (b *Backend) BackendDevices() []ml.DeviceInfo {
 		info.Description = C.GoString(props.description)
 		info.ID = C.GoString(props.id)
 		info.Library = C.GoString(props.library)
-		info.ComputeMajor = (int)(props.compute_major)
-		info.ComputeMinor = (int)(props.compute_minor)
-		info.DriverMajor = (int)(props.driver_major)
-		info.DriverMinor = (int)(props.driver_minor)
+		info.ComputeMajor = int(props.compute_major)
+		info.ComputeMinor = int(props.compute_minor)
+		info.DriverMajor = int(props.driver_major)
+		info.DriverMinor = int(props.driver_minor)
 		info.Integrated = props.integrated != 0
 		if props.library != nil {
 			info.Library = C.GoString(props.library)
@@ -738,8 +762,8 @@ func (b *Backend) BackendDevices() []ml.DeviceInfo {
 		}
 		info.LibraryPath = ggml.LibPaths()
 		C.ggml_backend_dev_memory(dev, &props.memory_free, &props.memory_total)
-		info.TotalMemory = (uint64)(props.memory_total)
-		info.FreeMemory = (uint64)(props.memory_free)
+		info.TotalMemory = uint64(props.memory_total)
+		info.FreeMemory = uint64(props.memory_free)
 
 		deviceInfos = append(deviceInfos, info)
 	}
@@ -1467,7 +1491,7 @@ func (t *Tensor) Reshape(ctx ml.Context, shape ...int) ml.Tensor {
 func (t *Tensor) Scale(ctx ml.Context, s float64) ml.Tensor {
 	return &Tensor{
 		b: t.b,
-		t: C.ggml_scale(ctx.(*Context).ctx, t.t, (C.float)(s)),
+		t: C.ggml_scale(ctx.(*Context).ctx, t.t, C.float(s)),
 	}
 }
 
@@ -1944,7 +1968,8 @@ func (t *Tensor) Slice(ctx ml.Context, dim int, low, high, step int) ml.Tensor {
 
 	if dim == 0 && step > 1 {
 		// dim=0,step>1 is a special case so handle it here first
-		return t.View(ctx,
+		return t.View(
+			ctx,
 			low*t.Stride(0), 1,
 			step*t.Stride(0), (high-low+1)/step,
 			t.Stride(1), t.Dim(1),

--- a/ml/backend/ggml/ggml_test.go
+++ b/ml/backend/ggml/ggml_test.go
@@ -24,7 +24,7 @@ func setup(tb testing.TB) ml.Context {
 		tb.Fatal(err)
 	}
 
-	b, err := ml.NewBackend(f.Name(), ml.BackendParams{AllocMemory: true})
+	b, err := ml.NewBackend([]string{f.Name()}, ml.BackendParams{AllocMemory: true})
 	if err != nil {
 		tb.Fatal(err)
 	}

--- a/ml/backend/ggml/quantization.go
+++ b/ml/backend/ggml/quantization.go
@@ -71,11 +71,12 @@ func Quantize(newType fsggml.TensorType, f32s []float32, shape []uint64) []byte 
 		newSize += C.ggml_quantize_chunk(
 			uint32(newType),
 			(*C.float)(&f32s[f32s_03]),
-			unsafe.Pointer((uintptr)(unsafe.Pointer(&buf[0]))+uintptr(buf_03)),
+			unsafe.Pointer(uintptr(unsafe.Pointer(&buf[0]))+uintptr(buf_03)),
 			0,
 			nrows,
 			nPerRow,
-			nil)
+			nil,
+		)
 	}
 	return buf[:newSize]
 }

--- a/ml/nn/pooling/pooling_test.go
+++ b/ml/nn/pooling/pooling_test.go
@@ -30,7 +30,7 @@ func setup(tb testing.TB, n int) ml.Backend {
 		tb.Fatal(err)
 	}
 
-	b, err := ggml.New(f.Name(), ml.BackendParams{AllocMemory: true})
+	b, err := ggml.New([]string{f.Name()}, ml.BackendParams{AllocMemory: true})
 	if err != nil {
 		tb.Fatal(err)
 	}

--- a/model/model.go
+++ b/model/model.go
@@ -115,9 +115,9 @@ func Register(name string, f func(fs.Config) (Model, error)) {
 	models[name] = f
 }
 
-// New initializes a new model instance with the provided configuration based on the metadata in the model file
-func New(modelPath string, params ml.BackendParams) (Model, error) {
-	b, err := ml.NewBackend(modelPath, params)
+// New initializes a new model instance with the provided configuration based on the metadata in the model file.
+func New(modelPaths []string, params ml.BackendParams) (Model, error) {
+	b, err := ml.NewBackend(modelPaths, params)
 	if err != nil {
 		return nil, err
 	}

--- a/model/models/gemma4/tokenizer_compare_test.go
+++ b/model/models/gemma4/tokenizer_compare_test.go
@@ -16,7 +16,7 @@ func TestTokenizerMatchesHF(t *testing.T) {
 		t.Skip("set GEMMA4_MODEL_PATH to a gemma4 GGUF file")
 	}
 
-	m, err := model.New(modelPath, ml.BackendParams{AllocMemory: true})
+	m, err := model.New([]string{modelPath}, ml.BackendParams{AllocMemory: true})
 	if err != nil {
 		t.Fatalf("Failed to load model: %v", err)
 	}

--- a/model/models/nemotronh/model_omni_test.go
+++ b/model/models/nemotronh/model_omni_test.go
@@ -42,7 +42,7 @@ func setupTestContext(t *testing.T) ml.Context {
 		t.Fatal(err)
 	}
 
-	b, err := ml.NewBackend(f.Name(), ml.BackendParams{AllocMemory: true})
+	b, err := ml.NewBackend([]string{f.Name()}, ml.BackendParams{AllocMemory: true})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/runner/llamarunner/runner.go
+++ b/runner/llamarunner/runner.go
@@ -254,8 +254,8 @@ func (s *Server) inputs(prompt string, images []llm.ImageData) ([]input, error) 
 }
 
 type Server struct {
-	// modelPath is the location of the model to be loaded
-	modelPath string
+	// modelPaths are the shard file paths; single-element for non-split models
+	modelPaths []string
 
 	// loadMu prevents more than one load attempt from occurring at a time
 	loadMu sync.Mutex
@@ -828,7 +828,7 @@ func (s *Server) health(w http.ResponseWriter, r *http.Request) {
 // memory allocated is worst case for text models but not for vision.
 func (s *Server) loadModel(
 	params llama.ModelParams,
-	mpath string,
+	mpaths []string,
 	lpath []string,
 	ppath string,
 	kvSize int,
@@ -838,7 +838,11 @@ func (s *Server) loadModel(
 	multiUserCache bool,
 ) {
 	var err error
-	s.model, err = llama.LoadModelFromFile(mpath, params)
+	if len(mpaths) == 1 {
+		s.model, err = llama.LoadModelFromFile(mpaths[0], params)
+	} else {
+		s.model, err = llama.LoadModelFromSplits(mpaths, params)
+	}
 	if err != nil {
 		panic(err)
 	}
@@ -931,7 +935,7 @@ func (s *Server) load(w http.ResponseWriter, r *http.Request) {
 		}
 
 		s.status = llm.ServerStatusLoadingModel
-		go s.loadModel(params, s.modelPath, req.LoraPath, req.ProjectorPath, req.KvSize, req.KvCacheType, req.FlashAttention, req.NumThreads, req.MultiUserCache)
+		go s.loadModel(params, s.modelPaths, req.LoraPath, req.ProjectorPath, req.KvSize, req.KvCacheType, req.FlashAttention, req.NumThreads, req.MultiUserCache)
 
 	case llm.LoadOperationClose:
 		// No-op for us
@@ -950,7 +954,11 @@ func (s *Server) load(w http.ResponseWriter, r *http.Request) {
 
 func Execute(args []string) error {
 	fs := flag.NewFlagSet("runner", flag.ExitOnError)
-	mpath := fs.String("model", "", "Path to model binary file")
+	var mpaths []string
+	fs.Func("model", "path to model shard file (may be repeated for split GGUF)", func(v string) error {
+		mpaths = append(mpaths, v)
+		return nil
+	})
 	port := fs.Int("port", 8080, "Port to expose the server on")
 	_ = fs.Bool("verbose", false, "verbose output (default: disabled)")
 
@@ -967,8 +975,8 @@ func Execute(args []string) error {
 	llama.BackendInit()
 
 	server := &Server{
-		modelPath: *mpath,
-		status:    llm.ServerStatusLaunched,
+		modelPaths: mpaths,
+		status:     llm.ServerStatusLaunched,
 	}
 
 	server.ready.Add(1)

--- a/runner/ollamarunner/runner.go
+++ b/runner/ollamarunner/runner.go
@@ -329,8 +329,8 @@ type batchState struct {
 }
 
 type Server struct {
-	// modelPath is the location of the model to be loaded
-	modelPath string
+	// modelPaths are the shard file paths; single-element for non-split models
+	modelPaths []string
 
 	// loadMu prevents more than one load attempt from occurring at a time
 	loadMu sync.Mutex
@@ -725,7 +725,8 @@ func (s *Server) computeBatch(activeBatch batchState) {
 			logutil.Trace("computeBatch: signaling computeStartedCh", "batchID", activeBatch.id)
 			activeBatch.computeStartedCh <- struct{}{}
 		},
-		activeBatch.modelOutput)
+		activeBatch.modelOutput,
+	)
 
 	outputs := activeBatch.modelOutput.Floats()
 	t := time.Now()
@@ -1181,7 +1182,7 @@ func (s *Server) reserveWorstCaseGraph(prompt bool) error {
 // allocModel pre-allocates the maximum needed memory for a model
 // based on the given parameters
 func (s *Server) allocModel(
-	mpath string,
+	mpaths []string,
 	params ml.BackendParams,
 	loraPath []string,
 	parallel int,
@@ -1206,7 +1207,7 @@ func (s *Server) allocModel(
 	}()
 
 	var err error
-	s.model, err = model.New(mpath, params)
+	s.model, err = model.New(mpaths, params)
 	if err != nil {
 		return err
 	}
@@ -1321,7 +1322,7 @@ func (s *Server) load(w http.ResponseWriter, r *http.Request) {
 
 		s.batchSize = req.BatchSize
 
-		err := s.allocModel(s.modelPath, params, req.LoraPath, req.Parallel, req.KvCacheType, req.KvSize, req.MultiUserCache)
+		err := s.allocModel(s.modelPaths, params, req.LoraPath, req.Parallel, req.KvCacheType, req.KvSize, req.MultiUserCache)
 		if err != nil {
 			s.closeModel()
 
@@ -1416,7 +1417,7 @@ func (s *Server) infoModelLocked() (model.Model, error) {
 				return
 			}
 
-			s.infoModel, s.infoErr = model.New(f.Name(), ml.BackendParams{NumThreads: runtime.NumCPU(), AllocMemory: false, GPULayers: ml.GPULayersList{{}}})
+			s.infoModel, s.infoErr = model.New([]string{f.Name()}, ml.BackendParams{NumThreads: runtime.NumCPU(), AllocMemory: false, GPULayers: ml.GPULayersList{{}}})
 			if s.infoErr == nil {
 				slog.Debug("dummy model load took", "duration", time.Since(startLoad))
 			}
@@ -1435,7 +1436,11 @@ func (s *Server) infoModelLocked() (model.Model, error) {
 
 func Execute(args []string) error {
 	fs := flag.NewFlagSet("runner", flag.ExitOnError)
-	mpath := fs.String("model", "", "Path to model binary file")
+	var mpaths []string
+	fs.Func("model", "path to model shard file (may be repeated for split GGUF)", func(v string) error {
+		mpaths = append(mpaths, v)
+		return nil
+	})
 	port := fs.Int("port", 8080, "Port to expose the server on")
 	_ = fs.Bool("verbose", false, "verbose output (default: disabled)")
 
@@ -1453,8 +1458,8 @@ func Execute(args []string) error {
 	defer cancel()
 
 	server := &Server{
-		modelPath: *mpath,
-		status:    llm.ServerStatusLaunched,
+		modelPaths: mpaths,
+		status:     llm.ServerStatusLaunched,
 	}
 
 	server.cond = sync.NewCond(&server.mu)

--- a/server/create.go
+++ b/server/create.go
@@ -343,16 +343,40 @@ func convertModelFromFiles(files map[string]string, baseLayers []*layerGGML, isA
 			return nil, errOnlyOneAdapterSupported
 		}
 
-		var digest string
 		var allLayers []*layerGGML
-		for _, v := range files {
-			digest = v
+		for _, digest := range files {
 			layers, err := ggufLayers(digest, fn)
 			if err != nil {
 				return nil, err
 			}
 			allLayers = append(allLayers, layers...)
 		}
+
+		// Sort model shards by split.no so manifest layers are in the right order.
+		// Non-split files all have split.no == 0 and sort stably among themselves.
+		slices.SortStableFunc(allLayers, func(a, b *layerGGML) int {
+			if a.MediaType != "application/vnd.ollama.image.model" || b.MediaType != "application/vnd.ollama.image.model" {
+				return 0
+			}
+			return cmp.Compare(a.KV().SplitNo(), b.KV().SplitNo())
+		})
+
+		// Verify shard count matches declared split.count (0 means not a split model).
+		if len(allLayers) > 1 {
+			var modelLayers []*layerGGML
+			for _, l := range allLayers {
+				if l.MediaType == "application/vnd.ollama.image.model" {
+					modelLayers = append(modelLayers, l)
+				}
+			}
+			if n := len(modelLayers); n > 1 {
+				declared := int(modelLayers[0].KV().SplitCount())
+				if declared != 0 && declared != n {
+					return nil, fmt.Errorf("split GGUF declares %d shards but %d were provided", declared, n)
+				}
+			}
+		}
+
 		return allLayers, nil
 	default:
 		return nil, errUnknownType

--- a/server/images.go
+++ b/server/images.go
@@ -64,7 +64,8 @@ type Model struct {
 	Name           string `json:"name"`
 	Config         model.ConfigV2
 	ShortName      string
-	ModelPath      string
+	ModelPath      string   // first shard path; used for logging and keying
+	ModelPaths     []string // all shard paths ordered by split.no
 	ParentModel    string
 	AdapterPaths   []string
 	ProjectorPaths []string
@@ -338,7 +339,10 @@ func GetModel(name string) (*Model, error) {
 
 		switch layer.MediaType {
 		case "application/vnd.ollama.image.model":
-			m.ModelPath = filename
+			m.ModelPaths = append(m.ModelPaths, filename)
+			if m.ModelPath == "" {
+				m.ModelPath = filename
+			}
 			m.ParentModel = layer.From
 		case "application/vnd.ollama.image.embed":
 			// Deprecated in versions  > 0.1.2

--- a/server/routes_generate_test.go
+++ b/server/routes_generate_test.go
@@ -76,8 +76,8 @@ func (mockRunner) Tokenize(_ context.Context, s string) (tokens []int, err error
 
 func (mockRunner) Ping(_ context.Context) error { return nil }
 
-func newMockServer(mock *mockRunner) func(ml.SystemInfo, []ml.DeviceInfo, string, *ggml.GGML, []string, []string, api.Options, int) (llm.LlamaServer, error) {
-	return func(_ ml.SystemInfo, _ []ml.DeviceInfo, _ string, _ *ggml.GGML, _, _ []string, _ api.Options, _ int) (llm.LlamaServer, error) {
+func newMockServer(mock *mockRunner) func(ml.SystemInfo, []ml.DeviceInfo, []string, *ggml.GGML, []string, []string, api.Options, int) (llm.LlamaServer, error) {
+	return func(_ ml.SystemInfo, _ []ml.DeviceInfo, _ []string, _ *ggml.GGML, _, _ []string, _ api.Options, _ int) (llm.LlamaServer, error) {
 		return mock, nil
 	}
 }

--- a/server/sched.go
+++ b/server/sched.go
@@ -52,7 +52,7 @@ type Scheduler struct {
 	loaded        map[string]*runnerRef
 
 	loadFn          func(req *LlmRequest, systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, requireFull bool) bool
-	newServerFn     func(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, model string, f *ggml.GGML, adapters []string, projectors []string, opts api.Options, numParallel int) (llm.LlamaServer, error)
+	newServerFn     func(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, modelPaths []string, f *ggml.GGML, adapters []string, projectors []string, opts api.Options, numParallel int) (llm.LlamaServer, error)
 	getGpuFn        func(ctx context.Context, runners []ml.FilteredRunnerDiscovery) []ml.DeviceInfo
 	getSystemInfoFn func() ml.SystemInfo
 	waitForRecovery time.Duration
@@ -441,7 +441,11 @@ func (s *Scheduler) load(req *LlmRequest, systemInfo ml.SystemInfo, gpus []ml.De
 				s.loadedMu.Unlock()
 				return false
 			}
-			llama, err = s.newServerFn(systemInfo, gpus, req.model.ModelPath, f, req.model.AdapterPaths, req.model.ProjectorPaths, req.opts, numParallel)
+			modelPaths := req.model.ModelPaths
+			if len(modelPaths) == 0 && req.model.ModelPath != "" {
+				modelPaths = []string{req.model.ModelPath}
+			}
+			llama, err = s.newServerFn(systemInfo, gpus, modelPaths, f, req.model.AdapterPaths, req.model.ProjectorPaths, req.opts, numParallel)
 			if err != nil {
 				// some older models are not compatible with newer versions of llama.cpp
 				// show a generalized compatibility error until there is a better way to
@@ -789,11 +793,13 @@ func (runner *runnerRef) LogValue() slog.Value {
 		attrs = append(attrs, slog.String("name", runner.model.Name))
 	}
 	if len(runner.gpus) > 0 {
-		attrs = append(attrs,
+		attrs = append(
+			attrs,
 			slog.Any("inference", runner.gpus),
 		)
 	}
-	attrs = append(attrs,
+	attrs = append(
+		attrs,
 		slog.String("size", format.HumanBytes2(runner.totalSize)),
 		slog.String("vram", format.HumanBytes2(runner.vramSize)),
 		slog.Int("parallel", runner.numParallel),

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -64,7 +64,7 @@ func TestSchedLoad(t *testing.T) {
 		sessionDuration: &api.Duration{Duration: 2 * time.Second},
 	}
 	// Fail to load model first
-	s.newServerFn = func(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, model string, f *ggml.GGML, adapters []string, projectors []string, opts api.Options, numParallel int) (llm.LlamaServer, error) {
+	s.newServerFn = func(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, modelPaths []string, f *ggml.GGML, adapters []string, projectors []string, opts api.Options, numParallel int) (llm.LlamaServer, error) {
 		return nil, errors.New("something failed to load model blah")
 	}
 	gpus := []ml.DeviceInfo{}
@@ -79,8 +79,8 @@ func TestSchedLoad(t *testing.T) {
 	require.Contains(t, err.Error(), "this model may be incompatible")
 
 	server := &mockLlm{vramSize: 10, vramByGPU: map[ml.DeviceID]uint64{}}
-	s.newServerFn = func(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, model string, f *ggml.GGML, adapters []string, projectors []string, opts api.Options, numParallel int) (llm.LlamaServer, error) {
-		server.modelPath = model
+	s.newServerFn = func(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, modelPaths []string, f *ggml.GGML, adapters []string, projectors []string, opts api.Options, numParallel int) (llm.LlamaServer, error) {
+		server.modelPath = modelPaths[0]
 		return server, nil
 	}
 	s.load(req, systemInfo, gpus, false)
@@ -135,8 +135,10 @@ type reqBundle struct {
 	req     *LlmRequest
 }
 
-func (scenario *reqBundle) newServer(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, model string, f *ggml.GGML, adapters []string, projectors []string, opts api.Options, numParallel int) (llm.LlamaServer, error) {
-	scenario.srv.modelPath = model
+func (scenario *reqBundle) newServer(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, modelPaths []string, f *ggml.GGML, adapters []string, projectors []string, opts api.Options, numParallel int) (llm.LlamaServer, error) {
+	if len(modelPaths) > 0 {
+		scenario.srv.modelPath = modelPaths[0]
+	}
 	return scenario.srv, nil
 }
 
@@ -568,8 +570,8 @@ func TestSchedExpireRunner(t *testing.T) {
 	gpus := []ml.DeviceInfo{}
 	systemInfo := ml.SystemInfo{}
 	server := &mockLlm{vramSize: 10, vramByGPU: map[ml.DeviceID]uint64{}}
-	s.newServerFn = func(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, model string, f *ggml.GGML, adapters []string, projectors []string, opts api.Options, numParallel int) (llm.LlamaServer, error) {
-		server.modelPath = model
+	s.newServerFn = func(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, modelPaths []string, f *ggml.GGML, adapters []string, projectors []string, opts api.Options, numParallel int) (llm.LlamaServer, error) {
+		server.modelPath = modelPaths[0]
 		return server, nil
 	}
 	s.load(req, systemInfo, gpus, false)
@@ -898,6 +900,7 @@ func (s *mockLlm) Close() error {
 	s.closeCalled = true
 	return s.closeResp
 }
+
 func (s *mockLlm) MemorySize() (uint64, uint64)                       { return s.totalSize, s.vramSize }
 func (s *mockLlm) VRAMByGPU(id ml.DeviceID) uint64                    { return s.vramByGPU[id] }
 func (s *mockLlm) Pid() int                                           { return -1 }


### PR DESCRIPTION
## Problem

Large models are often distributed as split GGUF files (e.g. `model-00001-of-00003.gguf`). Previously, `ollama create` only accepted a single `FROM` line pointing at a GGUF file, so users had no way to import these models.

Closes #5245

## Changes

**Modelfile / create**
- `server/create.go`: accept multiple `FROM` lines that resolve to GGUF files; sort the resulting model layers by `split.no` metadata (via `slices.SortStableFunc`) so the manifest always stores shards in the correct order regardless of the order the user listed them.
- `server/images.go`: `ModelPaths()` returns the ordered list of model-layer blob paths from the manifest.

**GGUF parsing**
- `fs/ggml/ggml.go`: add `DecodeShards(paths []string, maxArraySize int) (*GGML, error)` — merges N shard files into a single `*GGML`; each tensor carries a `ShardIdx` pointing back to its source file; `split.*` KV keys are removed from the merged result.
- `fs/ggml/gguf.go`: fix `ggufWriteKV` to handle `uint16` values and not prefix `split.*` keys with the architecture name (needed by the test helper and for correct shard writes).

**llama.cpp bridge**
- `llama/llama.go`: expose `LoadModelFromSplits(paths []string, params ModelParams) (*Model, error)` wrapping `llama_model_load_from_splits`.
- `llm/server.go`: when multiple model paths are present, use `LoadModelFromSplits` for both the VocabOnly preflight and the main runner, instead of `LoadModelFromFile`. `LoadModelFromFile` on a split shard triggers llama.cpp's filename-pattern auto-discovery, which fails on content-addressed blob names.

**Runner paths**
- `runner/llamarunner/runner.go`, `runner/ollamarunner/runner.go`: propagate the model-paths slice through to the load call.

**API surface**
- `ml/backend.go`, `ml/backend/ggml/ggml.go`, `model/model.go`: change `NewBackend` / `New` from a single `modelPath string` to `modelPaths []string`; all existing single-file callers pass a one-element slice.

**Docs**
- `docs/import.mdx`: add "Importing a split GGUF model" subsection explaining the multi-`FROM` syntax and that order does not matter.

**Tests**
- `fs/ggml/decode_shards_test.go`: six test cases covering empty paths, single-path delegation, missing-file error, two-shard merge (tensor count, `ShardIdx` assignment, `ShardOffsets`, KV strip), caller-ordering contract, and per-shard offset correctness.

## Validation

End-to-end tested on Apple Silicon (Metal) with:

1. **2-shard model** created with `llama-gguf-split --split-max-size 50M` from SmolLM 135M — `ollama create` + `ollama run` produce valid output; Metal logs show two separate buffer allocations (`47.66 MiB` + `38.12 MiB`).

2. **3-shard model** created with `llama-gguf-split --split-max-tensors 91` (91/91/90 tensors, 3 shards). Modelfile listed shards in **reversed order** (`shard3 → shard1 → shard2`); the manifest was verified to store them in correct `split.no` order (`shard1 → shard2 → shard3`). Inference ran successfully.

3. **Incomplete shard set** (2 paths for a 3-shard model) → `Error: split GGUF declares 3 shards but 2 were provided`.

4. All unit tests pass: `go test -count=1 ./fs/ggml/... ./server/...`