### PR TITLE
feat(api): add E.164 phone number validation

### DIFF
--- a/api/phone_validation.go
+++ b/api/phone_validation.go
@@ -1,0 +1,25 @@
+package api
+
+import (
+	"regexp"
+	"strings"
+)
+
+// E.164 international phone number format:
+// + followed by country code (1-3 digits) and subscriber number (up to 14 digits total)
+// This regex validates the structure while being permissive enough for international formats
+var phoneRegex = regexp.MustCompile(`^\+[1-9]\d{1,14}$`)
+
+// ValidatePhoneNumber validates a phone number in E.164 international format.
+// It accepts numbers like +49171234567 (Germany), +14155551234 (US), +972501234567 (Israel), etc.
+// Returns true if the phone number is valid, false otherwise.
+func ValidatePhoneNumber(phone string) bool {
+	// Remove common formatting characters that users might include
+	cleaned := strings.ReplaceAll(phone, " ", "")
+	cleaned = strings.ReplaceAll(cleaned, "-", "")
+	cleaned = strings.ReplaceAll(cleaned, "(", "")
+	cleaned = strings.ReplaceAll(cleaned, ")", "")
+	cleaned = strings.ReplaceAll(cleaned, ".", "")
+	
+	return phoneRegex.MatchString(cleaned)
+}

--- a/api/phone_validation_test.go
+++ b/api/phone_validation_test.go
@@ -1,0 +1,44 @@
+package api
+
+import "testing"
+
+func TestValidatePhoneNumber(t *testing.T) {
+	tests := []struct {
+		name  string
+		phone string
+		want  bool
+	}{
+		// Valid international numbers (E.164 format)
+		{"Germany mobile", "+49171234567", true},
+		{"Germany with spaces", "+49 171 234567", true},
+		{"Germany with hyphens", "+49-171-234567", true},
+		{"US number", "+14155551234", true},
+		{"US formatted", "+1 (415) 555-1234", true},
+		{"Israel mobile", "+972501234567", true},
+		{"UK mobile", "+447700123456", true},
+		{"Spain mobile", "+34612345678", true},
+		{"France mobile", "+33612345678", true},
+		{"China mobile", "+8613912345678", true},
+		{"Short international", "+12345", true},
+		{"Maximum length", "+123456789012345", true},
+		
+		// Invalid numbers
+		{"No plus sign", "14155551234", false},
+		{"Starts with zero", "+01234567890", false},
+		{"Too long", "+1234567890123456", false},
+		{"Empty string", "", false},
+		{"Only plus", "+", false},
+		{"Letters", "+1415ABC1234", false},
+		{"Special chars", "+1-415-555-1234!", false},
+		{"Spaces only", "   ", false},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ValidatePhoneNumber(tt.phone)
+			if got != tt.want {
+				t.Errorf("ValidatePhoneNumber(%q) = %v, want %v", tt.phone, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds validation for international phone numbers in E.164 format to the api package. The ValidatePhoneNumber function accepts phone numbers prefixed with a plus sign followed by country code and subscriber number (up to 15 digits total). The validator is permissive about common formatting characters like spaces, hyphens, parentheses, and dots, stripping them before validation. The regex enforces that numbers start with a non-zero digit after the plus sign and meet E.164 structural requirements. Comprehensive tests cover valid international numbers from multiple countries including Germany, US, Israel, UK, Spain, France, and China, as well as invalid formats. This implementation handles the phone validation requirements for the API layer.

Fixes #16060
