### PR TITLE
chore: modernize ThinkValue Value type and wrap auth body-read error

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -1098,7 +1098,7 @@ func DefaultOptions() Options {
 // ThinkValue represents a value that can be a boolean or a string ("high", "medium", "low", "max")
 type ThinkValue struct {
 	// Value can be a bool or string
-	Value interface{}
+	Value any
 }
 
 // IsValid checks if the ThinkValue is valid

--- a/server/auth.go
+++ b/server/auth.go
@@ -80,7 +80,7 @@ func getAuthorizationToken(ctx context.Context, challenge registryChallenge, ori
 
 	body, err := io.ReadAll(response.Body)
 	if err != nil {
-		return "", fmt.Errorf("%d: %v", response.StatusCode, err)
+		return "", fmt.Errorf("%d: %w", response.StatusCode, err)
 	}
 
 	if response.StatusCode >= http.StatusBadRequest {


### PR DESCRIPTION
Two small maintenance touch-ups:

- api: change `ThinkValue.Value` from `interface{}` to `any` for consistency with the rest of the codebase.
- server/auth: wrap the body-read error with `%w` so callers can `errors.Is`/`errors.As` the underlying cause.

No behavior change, no public API change.