### PR TITLE
imagegen/mlx: skip initialization on non-darwin platforms

### DIFF
--- a/x/imagegen/mlx/mlx.go
+++ b/x/imagegen/mlx/mlx.go
@@ -1829,6 +1829,13 @@ func GetMLXInitError() error {
 }
 
 func init() {
+	// MLX is only available on macOS
+	if runtime.GOOS != "darwin" {
+		mlxInitError = fmt.Errorf("MLX is only supported on macOS")
+		mlxInitialized = false
+		return
+	}
+
 	// Initialize MLX dynamic library first
 	if err := InitMLX(); err != nil {
 		// Don't panic in init - let the caller handle the error


### PR DESCRIPTION
The MLX image generation module was attempting to initialize on Windows and Linux platforms, causing an immediate crash on startup due to access violations when calling cgo functions that depend on Apple-specific Metal framework APIs. The crash occurred in `x/imagegen/mlx/mlx.go` during package initialization, specifically when `init()` called `RandomKey()` which invokes `_Cfunc_mlx_random_key`.

This fix adds a runtime platform check at the beginning of `init()` to skip all MLX initialization on non-darwin platforms. The module now gracefully sets an error state and returns early, preventing any cgo calls into Apple-specific code. This ensures Ollama starts successfully on Windows and Linux while preserving full MLX functionality on macOS.

The crash was particularly problematic on Windows systems with integrated GPUs (such as AMD Radeon 780M), where it prevented any Ollama commands from running. With this change, the module remains available on macOS while safely disabled on other platforms.

Fixes #15481
