### PR TITLE
codex: omit patch tool type

### DIFF
--- a/cmd/launch/codex.go
+++ b/cmd/launch/codex.go
@@ -638,7 +638,6 @@ func buildCodexModelEntry(modelName string) map[string]any {
 		"slug":                         modelName,
 		"display_name":                 modelName,
 		"context_window":               contextWindow,
-		"apply_patch_tool_type":        "function",
 		"shell_type":                   "default",
 		"visibility":                   "list",
 		"supported_in_api":             true,

--- a/cmd/launch/codex_test.go
+++ b/cmd/launch/codex_test.go
@@ -639,11 +639,14 @@ func TestBuildCodexModelEntryContextWindow(t *testing.T) {
 				}
 			}
 
-			requiredKeys := []string{"slug", "display_name", "apply_patch_tool_type", "shell_type"}
+			requiredKeys := []string{"slug", "display_name", "shell_type"}
 			for _, key := range requiredKeys {
 				if _, ok := entry[key]; !ok {
 					t.Errorf("missing required key %q", key)
 				}
+			}
+			if _, ok := entry["apply_patch_tool_type"]; ok {
+				t.Error("apply_patch_tool_type should be omitted so Codex CLI defaults can handle schema changes")
 			}
 
 			if _, err := json.Marshal(entry); err != nil {


### PR DESCRIPTION
Including this value can cause schema compatibility issues. It was removed from codex in a new version.