### PR TITLE
README: add CrustAI to community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ console.log(response.message.content);
 - [Discord-Ollama Chat Bot](https://github.com/kevinthedang/discord-ollama) - TypeScript Discord bot
 - [Ollama Telegram Bot](https://github.com/ruecat/ollama-telegram) - Telegram bot
 - [LLM Telegram Bot](https://github.com/innightwolfsleep/llm_telegram_bot) - Telegram bot for roleplay
+- [CrustAI](https://github.com/DaveSimoes/CrustAI) - Self-hosted private AI assistant for Telegram, WhatsApp, Discord and Slack via Ollama, zero cloud
 
 ### Terminal & CLI
 


### PR DESCRIPTION
Adds CrustAI to the Bots & Messaging section of community integrations.

CrustAI is a self-hosted, privacy-first AI assistant that connects 
Telegram, WhatsApp, Discord and Slack to a local Ollama instance — 
zero cloud, zero data sharing.

https://github.com/DaveSimoes/CrustAI

Note: the commit history has two commits due to a commit message 
correction — the content itself is unchanged.