### PR TITLE
cmd: show optional prefix in list help

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -2404,9 +2404,10 @@ func NewCLI() *cobra.Command {
 	}
 
 	listCmd := &cobra.Command{
-		Use:     "list",
+		Use:     "list [MODEL_PREFIX]",
 		Aliases: []string{"ls"},
 		Short:   "List models",
+		Args:    cobra.MaximumNArgs(1),
 		PreRunE: checkServerHeartbeat,
 		RunE:    ListHandler,
 	}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1398,6 +1398,41 @@ func TestListHandler(t *testing.T) {
 	}
 }
 
+func TestListCommandHelpShowsOptionalPrefix(t *testing.T) {
+	cmd := NewCLI()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"list", "--help"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	got := out.String()
+	for _, want := range []string{
+		"ollama list [MODEL_PREFIX]",
+		"Aliases:",
+		"list, ls",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected help output to contain %q, got:\n%s", want, got)
+		}
+	}
+}
+
+func TestListCommandRejectsExtraArgs(t *testing.T) {
+	cmd := NewCLI()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"list", "llama", "mistral"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "accepts at most 1 arg") {
+		t.Fatalf("expected max args error, got %v", err)
+	}
+}
+
 func TestCreateHandler(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION
## Summary
- show the optional MODEL_PREFIX argument in ollama list help
- reject extra positional arguments for ollama list
- add CLI tests for list help and argument validation

## Testing
- git diff --check
- go test ./cmd -run 'TestListCommand|TestListHandler' -count=1 (does not complete locally on Windows; package compilation fails before tests due to existing MLX/imagegen build constraints such as undefined mlx.Array)