### PR TITLE
env: expose user-visible OLLAMA_NUM_THREADS override

### DIFF
--- a/discover/gpu.go
+++ b/discover/gpu.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ollama/ollama/envconfig"
 	"github.com/ollama/ollama/logutil"
 	"github.com/ollama/ollama/ml"
 )
@@ -38,6 +39,11 @@ func GetSystemInfo() ml.SystemInfo {
 	if threadCount == 0 {
 		// Fall back to Go's num CPU
 		threadCount = runtime.NumCPU()
+	}
+
+        if userThreadCount := envconfig.NumThreads(); userThreadCount > 0 {
+		slog.Info("user override thread count", "override", userThreadCount, "default", threadCount)
+		threadCount = int(userThreadCount)
 	}
 
 	return ml.SystemInfo{

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -222,6 +222,8 @@ var (
 	NoHistory = Bool("OLLAMA_NOHISTORY")
 	// NoPrune disables pruning of model blobs on startup.
 	NoPrune = Bool("OLLAMA_NOPRUNE")
+	// NumThreads overrides the default inference thread count.
+	NumThreads = Uint("OLLMA_NUM_THREADS", 0)
 	// SchedSpread allows scheduling models across all GPUs.
 	SchedSpread = Bool("OLLAMA_SCHED_SPREAD")
 	// MultiUserCache optimizes prompt caching for multi-user scenarios
@@ -327,6 +329,7 @@ func AsMap() map[string]EnvVar {
 		"OLLAMA_NOHISTORY":            {"OLLAMA_NOHISTORY", NoHistory(), "Do not preserve readline history"},
 		"OLLAMA_NOPRUNE":              {"OLLAMA_NOPRUNE", NoPrune(), "Do not prune model blobs on startup"},
 		"OLLAMA_NUM_PARALLEL":         {"OLLAMA_NUM_PARALLEL", NumParallel(), "Maximum number of parallel requests"},
+		"OLLAMA_NUM_THREADS":          {"OLLAMA_NUM_THREADS", NumThreads(), "Override the default cpu inference thread count"},
 		"OLLAMA_ORIGINS":              {"OLLAMA_ORIGINS", AllowedOrigins(), "A comma separated list of allowed origins"},
 		"OLLAMA_SCHED_SPREAD":         {"OLLAMA_SCHED_SPREAD", SchedSpread(), "Always schedule model across all GPUs"},
 		"OLLAMA_MULTIUSER_CACHE":      {"OLLAMA_MULTIUSER_CACHE", MultiUserCache(), "Optimize prompt caching for multi-user scenarios"},


### PR DESCRIPTION
This commit introduces the OLLAMA_NUM_THREADS environment variable to allow users to manually override the default inference thread count. This is particularly useful for performance tuning on architectures where automatic CPU detection may not be optimal.

This PR resolves merge conflicts from the original patch in #13122.