### PR TITLE
ggml: increase model load chunk size

### DIFF
--- a/ml/backend/ggml/ggml.go
+++ b/ml/backend/ggml/ggml.go
@@ -44,6 +44,8 @@ var (
 	backends           map[C.ggml_backend_dev_t]C.ggml_backend_t
 )
 
+const modelLoadChunkSize = 4 * format.MebiByte
+
 var initDevices = sync.OnceFunc(func() {
 	ggml.OnceLoad()
 
@@ -602,7 +604,7 @@ func (b *Backend) Load(ctx context.Context, progress func(float32)) error {
 				return nil
 			}
 
-			bts := make([]byte, 128*format.KibiByte)
+			bts := make([]byte, modelLoadChunkSize)
 
 			var s uint64
 			for s < t.Size() {


### PR DESCRIPTION
## Summary

Increase the normal ggml model tensor load buffer from 128 KiB to 4 MiB.

This is intentionally a small change: it keeps the current file-backed loading path and only changes the copy chunk used by the common tensor load loop.

## Why

On Windows, loading a full local GGUF blob into memory was fastest with file-backed reads and ~4 MiB copies. Larger chunks were close but did not improve the result enough to justify a bigger default allocation.

Local benchmark setup:
- OS: Windows
- Model blob: 23,938,321,664 bytes
- Path: `%USERPROFILE%\.ollama\models\blobs\sha256-f5ee307a2982106a6eb82b62b2c00b575c9072145a759ae4660378acda8dcf2d`
- Measurement: full file materialization into memory, one iteration per chunk size

Representative warm results:

| Path | Chunk | Time |
| --- | ---: | ---: |
| file-backed read | 512 KiB | 4.29s |
| file-backed read | 1 MiB | 4.24s |
| file-backed read | 4 MiB | 4.08s |
| file-backed read | 16 MiB | 4.17s |

I also tested mmap and DirectStorage-to-system-memory paths locally and did not include either in this PR:
- mmap full-copy was much slower than file-backed reads on this workload.
- DirectStorage to system memory was also slower; it may be more relevant for a future D3D12 GPU-resource path, but not for the current ggml loader flow.

## Validation

```powershell
$env:Path = 'C:\Program Files\Go\bin;C:\msys64\ucrt64\bin;' + $env:Path
$env:CGO_ENABLED='1'
go test ./ml/backend/ggml
go build ./runner/ollamarunner
```