### PR TITLE
llm: raise the completion scanner buffer to 8MB

### DIFF
--- a/llm/server.go
+++ b/llm/server.go
@@ -1489,7 +1489,7 @@ number ::= ("-"? ([0-9] | [1-9] [0-9]*)) ("." [0-9]+)? ([eE] [-+]? [0-9]+)?
 ws ::= ([ \t\n] ws)?
 `
 
-const maxBufferSize = 512 * format.KiloByte
+const maxBufferSize = 8 * format.MegaByte
 
 type ImageData struct {
 	Data []byte `json:"data"`


### PR DESCRIPTION
Fixes #16243.

The `bufio.Scanner` that reads the llama-server completion stream in `llm/server.go` caps a single SSE line at `maxBufferSize`, currently 512KB. A large response, e.g. a long-context run or a big tool-call payload, can emit a line past that, and `bufio.Scanner` then aborts the whole stream with `bufio.Scanner: token too long` (which surfaces to the user as the error in #16243).

`api/client.go` already sizes its equivalent streaming scanner at `8 * format.MegaByte`. So a response that the outer API layer streams fine can still be rejected one layer down by the 512KB cap. This bumps `llm/server.go` to the same 8MB so the two layers are consistent.

A fixed buffer is still a ceiling rather than a real fix for unbounded lines, but 8MB matches what the project already considers acceptable for this kind of stream and resolves the reported case.