### PR TITLE
add OLLAMA_NO_FILE_FRAGMENTATION

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -2486,6 +2486,7 @@ func NewCLI() *cobra.Command {
 				envVars["OLLAMA_LLM_LIBRARY"],
 				envVars["OLLAMA_GPU_OVERHEAD"],
 				envVars["OLLAMA_LOAD_TIMEOUT"],
+				envVars["OLLAMA_NO_FILE_FRAGMENTATION"],
 			})
 		default:
 			appendEnvDocs(cmd, envs)

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -236,6 +236,9 @@ var (
 	EnableVulkan = Bool("OLLAMA_VULKAN")
 	// NoCloudEnv checks the OLLAMA_NO_CLOUD environment variable.
 	NoCloudEnv = Bool("OLLAMA_NO_CLOUD")
+	// NoFileFragmentation prevents severe NTFS file fragmentation on Windows
+	// by forcing single-threaded sequential downloads and disabling sparse files.
+	NoFileFragmentation = Bool("OLLAMA_NO_FILE_FRAGMENTATION")
 )
 
 func String(s string) func() string {
@@ -334,6 +337,7 @@ func AsMap() map[string]EnvVar {
 		"OLLAMA_EDITOR":               {"OLLAMA_EDITOR", Editor(), "Path to editor for interactive prompt editing (Ctrl+G)"},
 		"OLLAMA_NEW_ENGINE":           {"OLLAMA_NEW_ENGINE", NewEngine(), "Enable the new Ollama engine"},
 		"OLLAMA_REMOTES":              {"OLLAMA_REMOTES", Remotes(), "Allowed hosts for remote models (default \"ollama.com\")"},
+		"OLLAMA_NO_FILE_FRAGMENTATION": {"OLLAMA_NO_FILE_FRAGMENTATION", NoFileFragmentation(), "Prevent on-disk file fragmentation by forcing each download to be 1 single stream"},
 
 		// Informational
 		"HTTP_PROXY":  {"HTTP_PROXY", String("HTTP_PROXY")(), "HTTP proxy"},

--- a/server/download.go
+++ b/server/download.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ollama/ollama/format"
 	"github.com/ollama/ollama/manifest"
 	"github.com/ollama/ollama/types/model"
+	"github.com/ollama/ollama/envconfig"
 )
 
 const maxRetries = 6
@@ -97,10 +98,18 @@ func (p *blobDownloadPart) UnmarshalJSON(b []byte) error {
 }
 
 const (
-	numDownloadParts          = 16
 	minDownloadPartSize int64 = 100 * format.MegaByte
 	maxDownloadPartSize int64 = 1000 * format.MegaByte
 )
+
+func getNumDownloadParts() int {
+	if envconfig.NoFileFragmentation() {
+		return 1
+	}
+
+	const numDownloadParts = 16 // inside the func to avoid accidental use outside
+	return numDownloadParts
+}
 
 func (p *blobDownloadPart) Name() string {
 	return strings.Join([]string{
@@ -153,7 +162,7 @@ func (b *blobDownload) Prepare(ctx context.Context, requestURL *url.URL, opts *r
 
 		b.Total, _ = strconv.ParseInt(resp.Header.Get("Content-Length"), 10, 64)
 
-		size := b.Total / numDownloadParts
+		size := b.Total / int64(getNumDownloadParts())
 		switch {
 		case size < minDownloadPartSize:
 			size = minDownloadPartSize
@@ -273,7 +282,7 @@ func (b *blobDownload) run(ctx context.Context, requestURL *url.URL, opts *regis
 	}
 
 	g, inner := errgroup.WithContext(ctx)
-	g.SetLimit(numDownloadParts)
+	g.SetLimit(getNumDownloadParts())
 	for i := range b.Parts {
 		part := b.Parts[i]
 		if part.Completed.Load() == part.Size {

--- a/server/sparse_windows.go
+++ b/server/sparse_windows.go
@@ -4,9 +4,13 @@ import (
 	"os"
 
 	"golang.org/x/sys/windows"
+	"github.com/ollama/ollama/envconfig"
 )
 
 func setSparse(file *os.File) {
+	if envconfig.NoFileFragmentation() {
+		return
+	}
 	// exFat (and other FS types) don't support sparse files, so ignore errors
 	windows.DeviceIoControl( //nolint:errcheck
 		windows.Handle(file.Fd()), windows.FSCTL_SET_SPARSE,


### PR DESCRIPTION
reduces file fragmentation due to `ollama pull`
thus `ollama run` will load model 10x time faster on HDDs

affects only Windows though

fixes https://github.com/ollama/ollama/issues/16220

`OLLAMA_NO_FILE_FRAGMENTATION` defaults to false, so behavior is unchanged unless `OLLAMA_NO_FILE_FRAGMENTATION` is set to `1` or `true` by user.

Let me know what you want me to change or close it if v0.30.0+ obsoletes v0.24.0+ anyway soon.
EDIT: I see `version 0.30.8`(and `v0.30.10`) still uses this code (not the one from `x/`) and thus the reads from SSD(NVMe not tested) are slowed by 100MB/sec as seen here: https://github.com/ollama/ollama/issues/16220#issuecomment-4701939205 thus this PR would improve things even on SSD