### PR TITLE
fix: add ~/  path support in CLI image path regex

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -606,7 +606,7 @@ func extractFileNames(input string) []string {
 	// Regex to match file paths starting with optional drive letter, / ./ \ or .\ and include escaped or unescaped spaces (\ or %20)
 	// and followed by more characters and a file extension
 	// This will capture non filename strings, but we'll check for file existence to remove mismatches
-	regexPattern := `(?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp|wav)\b`
+	regexPattern := `(?:[a-zA-Z]:)?(?:~/|\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp|wav)\b`
 	re := regexp.MustCompile(regexPattern)
 
 	return re.FindAllString(input, -1)


### PR DESCRIPTION
## Problem
When dragging an image from the home directory (~/) in the CLI, 
the file path was not recognized because the regex pattern 
did not include ~/ as a valid path prefix.

## Fix
Added ~/ to the regex pattern in extractFileNames() to correctly 
match home directory paths.

## Testing
Verified the fix compiles successfully.