### PR TITLE
Fix Turbo migration cloud model names

### DIFF
--- a/app/ui/app/src/hooks/useSelectedModel.ts
+++ b/app/ui/app/src/hooks/useSelectedModel.ts
@@ -7,6 +7,7 @@ import { Model } from "@/gotypes";
 import { getTotalVRAM } from "@/utils/vram.ts";
 import { getInferenceCompute } from "@/api";
 import { useCloudStatus } from "./useCloudStatus";
+import { getTurboMigrationCloudModel } from "@/utils/turboMigration";
 
 export function recommendDefaultModel(totalVRAM: number): string {
   const vram = Math.max(0, Number(totalVRAM) || 0);
@@ -33,7 +34,10 @@ export function useSelectedModel(currentChatId?: string, searchQuery?: string) {
     enabled: !settings.selectedModel, // Only fetch if no model is selected
   });
 
-  const inferenceComputes = inferenceComputeResponse?.inferenceComputes || [];
+  const inferenceComputes = useMemo(
+    () => inferenceComputeResponse?.inferenceComputes || [],
+    [inferenceComputeResponse?.inferenceComputes],
+  );
 
   const totalVRAM = useMemo(
     () => getTotalVRAM(inferenceComputes),
@@ -60,30 +64,18 @@ export function useSelectedModel(currentChatId?: string, searchQuery?: string) {
       );
     }
 
-    // Migration logic: if turboEnabled is true and selectedModel is a base model,
-    // migrate to the cloud version and disable turboEnabled permanently
-    // TODO: remove this logic in a future release
-    const baseModelsToMigrate = [
-      "gpt-oss:20b",
-      "gpt-oss:120b",
-      "deepseek-v3.1:671b",
-      "qwen3-coder:480b",
-    ];
-    const shouldMigrate =
-      !cloudDisabled &&
-      settings.turboEnabled &&
-      baseModelsToMigrate.includes(settings.selectedModel);
-
-    if (shouldMigrate) {
-      const cloudModel = `${settings.selectedModel}cloud`;
-      return (
-        models.find((m) => m.model === cloudModel) ||
-        new Model({
-          model: cloudModel,
-          cloud: true,
-          ollama_host: false,
-        })
-      );
+    if (!cloudDisabled && settings.turboEnabled) {
+      const cloudModel = getTurboMigrationCloudModel(settings.selectedModel);
+      if (cloudModel) {
+        return (
+          models.find((m) => m.model === cloudModel) ||
+          new Model({
+            model: cloudModel,
+            cloud: true,
+            ollama_host: false,
+          })
+        );
+      }
     }
 
     return (
@@ -99,6 +91,7 @@ export function useSelectedModel(currentChatId?: string, searchQuery?: string) {
   }, [
     models,
     settings.selectedModel,
+    settings.turboEnabled,
     cloudDisabled,
     recommendedModel,
   ]);
@@ -125,6 +118,8 @@ export function useSelectedModel(currentChatId?: string, searchQuery?: string) {
     selectedModel,
     cloudDisabled,
     settings.selectedModel,
+    settings.turboEnabled,
+    setSettings,
   ]);
 
   // Set model from chat history when chat data loads
@@ -190,9 +185,11 @@ export function useSelectedModel(currentChatId?: string, searchQuery?: string) {
   }, [
     isLoading,
     inferenceComputes.length,
-    models.length,
+    models,
+    recommendedModel,
     settings.selectedModel,
     cloudDisabled,
+    setSettings,
   ]);
 
   // Add the selected model to the models list if it's not already there

--- a/app/ui/app/src/utils/turboMigration.test.ts
+++ b/app/ui/app/src/utils/turboMigration.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { getTurboMigrationCloudModel } from "./turboMigration";
+
+describe("getTurboMigrationCloudModel", () => {
+  it("should append explicit cloud source if model needs Turbo migration", () => {
+    expect(getTurboMigrationCloudModel("gpt-oss:20b")).toBe(
+      "gpt-oss:20b:cloud",
+    );
+    expect(getTurboMigrationCloudModel("gpt-oss:120b")).toBe(
+      "gpt-oss:120b:cloud",
+    );
+    expect(getTurboMigrationCloudModel("deepseek-v3.1:671b")).toBe(
+      "deepseek-v3.1:671b:cloud",
+    );
+    expect(getTurboMigrationCloudModel("qwen3-coder:480b")).toBe(
+      "qwen3-coder:480b:cloud",
+    );
+  });
+
+  it("should return null if model does not need Turbo migration", () => {
+    expect(getTurboMigrationCloudModel("gemma3:4b")).toBeNull();
+  });
+});

--- a/app/ui/app/src/utils/turboMigration.ts
+++ b/app/ui/app/src/utils/turboMigration.ts
@@ -1,0 +1,14 @@
+const TURBO_MIGRATION_BASE_MODELS = [
+  "gpt-oss:20b",
+  "gpt-oss:120b",
+  "deepseek-v3.1:671b",
+  "qwen3-coder:480b",
+];
+
+export function getTurboMigrationCloudModel(model: string): string | null {
+  if (!TURBO_MIGRATION_BASE_MODELS.includes(model)) {
+    return null;
+  }
+
+  return `${model}:cloud`;
+}


### PR DESCRIPTION
Fixes #16266.

## Summary

- preserve explicit cloud source syntax when migrating legacy Turbo settings
- move the legacy Turbo migration model list into a focused helper
- add a regression test for the migrated cloud model names

## Root cause

The app migration appended `cloud` directly to the selected base model, producing names like `gpt-oss:20bcloud`. The frontend treated those strings as cloud models because it checks `endsWith("cloud")`, but the backend parser only recognizes explicit `:cloud` source tags or legacy `-cloud` tag suffixes.

## Validation

- `npm test -- --run src/utils/turboMigration.test.ts`
- `npm run build`
- `npx eslint src/hooks/useSelectedModel.ts src/utils/turboMigration.ts src/utils/turboMigration.test.ts`

Note: `npm run lint` still fails on existing repo-wide `no-explicit-any` errors in generated and component files outside this change.
