### PR TITLE
readme: add Local Deep Research to Community Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ console.log(response.message.content);
 - [Archyve](https://github.com/nickthecook/archyve) - RAG-enabling document library
 - [Casibase](https://casibase.org) - AI knowledge base with RAG and SSO
 - [BrainSoup](https://www.nurgo-software.com/products/brainsoup) - Native client with RAG and multi-agent automation
+- [Local Deep Research](https://github.com/LearningCircuit/local-deep-research) - Local-first deep agentic research across web, arXiv, PubMed, and private documents
 
 ### Bots & Messaging
 


### PR DESCRIPTION
Adding [Local Deep Research](https://github.com/LearningCircuit/local-deep-research) to the **RAG & Knowledge Bases** subsection, alongside ARGO and the other deep-research entries.

LDR is an open-source deep agentic research assistant that uses Ollama as its default (and recommended) LLM backend — the Docker Compose stack ships with Ollama pre-wired, and the Quick Start instructions tell users to `docker exec ollama ollama pull gpt-oss:20b` before running LDR.

- Multi-step agentic research across web (SearXNG, Brave), arXiv, PubMed, Semantic Scholar, and private documents
- 20+ research strategies including a LangGraph agent mode
- ~95% on SimpleQA (n=500) on a single RTX 3090 with Qwen3-27B ([benchmark dataset](https://huggingface.co/datasets/local-deep-research/ldr-benchmarks))
- 7.8k stars, MIT licensed, actively maintained

Happy to revise the one-liner if you'd prefer different wording.