### PR TITLE
launch: map codex xhigh reasoning effort

### DIFF
--- a/cmd/launch/codex.go
+++ b/cmd/launch/codex.go
@@ -29,6 +29,7 @@ const (
 	codexRootModelKey            = "model"
 	codexRootModelProviderKey    = "model_provider"
 	codexRootModelCatalogJSONKey = "model_catalog_json"
+	codexRootReasoningEffortKey  = "model_reasoning_effort"
 )
 
 func (c *Codex) args(model, modelCatalogPath string, extra []string) []string {
@@ -160,6 +161,9 @@ func writeCodexLaunchProfile(configPath string, opts codexLaunchProfileOptions) 
 	profileLines := []string{}
 	if model != "" {
 		profileLines = append(profileLines, fmt.Sprintf("%s = %q", codexRootModelKey, model))
+	}
+	if reasoningEffort := codexLaunchReasoningEffort(parsed, profileName); reasoningEffort != "" {
+		profileLines = append(profileLines, fmt.Sprintf("%s = %q", codexRootReasoningEffortKey, reasoningEffort))
 	}
 	profileLines = append(profileLines,
 		fmt.Sprintf("openai_base_url = %q", baseURL),
@@ -298,6 +302,28 @@ func codexValidateLaunchProfileText(config codexParsedConfig, profileName string
 		}
 	}
 	return nil
+}
+
+func codexLaunchReasoningEffort(config codexParsedConfig, profileName string) string {
+	if effort := config.ProfileString(profileName, codexRootReasoningEffortKey); effort != "" {
+		return codexOllamaReasoningEffort(effort)
+	}
+	if effort := config.RootString(codexRootReasoningEffortKey); effort != "" {
+		return codexOllamaReasoningEffort(effort)
+	}
+	return ""
+}
+
+func codexOllamaReasoningEffort(effort string) string {
+	effort = strings.ToLower(strings.TrimSpace(effort))
+	switch effort {
+	case "low", "medium", "high", "max", "none":
+		return effort
+	case "xhigh":
+		return "high"
+	default:
+		return "none"
+	}
 }
 
 func codexUpsertSection(text, header string, lines []string) string {

--- a/cmd/launch/codex_test.go
+++ b/cmd/launch/codex_test.go
@@ -362,6 +362,51 @@ func TestWriteCodexProfile(t *testing.T) {
 			t.Fatalf("expected connectable loopback URL, got:\n%s", content)
 		}
 	})
+
+	t.Run("maps inherited xhigh reasoning effort to Ollama value", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.toml")
+		existing := "" +
+			`model_reasoning_effort = "xhigh"` + "\n\n" +
+			"[profiles.default]\n" +
+			`model = "gpt-5.5"` + "\n"
+		os.WriteFile(configPath, []byte(existing), 0o644)
+
+		if err := writeCodexProfile(configPath); err != nil {
+			t.Fatal(err)
+		}
+
+		data, _ := os.ReadFile(configPath)
+		content := string(data)
+
+		if got := codexRootStringValue(content, "model_reasoning_effort"); got != "xhigh" {
+			t.Fatalf("root model_reasoning_effort = %q, want original xhigh in:\n%s", got, content)
+		}
+		if got := codexSectionStringValue(content, codexProfileHeader(), "model_reasoning_effort"); got != "high" {
+			t.Fatalf("profile model_reasoning_effort = %q, want high in:\n%s", got, content)
+		}
+	})
+
+	t.Run("preserves valid profile reasoning effort", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.toml")
+		existing := "" +
+			`model_reasoning_effort = "xhigh"` + "\n\n" +
+			codexProfileHeader() + "\n" +
+			`model_reasoning_effort = "medium"` + "\n"
+		os.WriteFile(configPath, []byte(existing), 0o644)
+
+		if err := writeCodexProfile(configPath); err != nil {
+			t.Fatal(err)
+		}
+
+		data, _ := os.ReadFile(configPath)
+		content := string(data)
+
+		if got := codexSectionStringValue(content, codexProfileHeader(), "model_reasoning_effort"); got != "medium" {
+			t.Fatalf("profile model_reasoning_effort = %q, want medium in:\n%s", got, content)
+		}
+	})
 }
 
 func TestEnsureCodexConfig(t *testing.T) {


### PR DESCRIPTION
Maps Codex's `xhigh` reasoning effort to `high` for the `ollama-launch` profile.

Codex allows `xhigh`, but Ollama's Responses API does not. If a user has `model_reasoning_effort = "xhigh"` in their global Codex config, `ollama launch codex` can pass that through and fail on the first request.

This keeps the user's global config unchanged, writes the Ollama profile with a supported value, and preserves already-supported profile values like `medium`.

Fixes #16214

Tests:
- `go test ./cmd/launch`