### PR TITLE
fix qwen3vl image embedding width in llama runner

### DIFF
--- a/llama/llama.go
+++ b/llama/llama.go
@@ -524,6 +524,10 @@ func (m *Model) NEmbd() int {
 	return int(C.llama_model_n_embd(m.c))
 }
 
+func (m *Model) NEmbdInput() int {
+	return int(C.llama_model_n_embd_inp(m.c))
+}
+
 // vision processing
 type MtmdContext struct {
 	c *C.struct_mtmd_context
@@ -571,7 +575,7 @@ func (c *MtmdContext) MultimodalTokenize(llamaContext *Context, data []byte) ([]
 		return nil, errors.New("unable to tokenize mtmd embedding from image")
 	}
 	nChunks := C.mtmd_input_chunks_size(ic)
-	numEmbed := llamaContext.Model().NEmbd()
+	numEmbed := llamaContext.Model().NEmbdInput()
 	outChunks := make([]MtmdChunk, 0)
 	for i := range int(nChunks) {
 		chunk := C.mtmd_input_chunks_get(ic, C.size_t(i))

--- a/runner/llamarunner/image.go
+++ b/runner/llamarunner/image.go
@@ -97,7 +97,7 @@ func (c *ImageContext) BatchSize(configuredBatchSize int) int {
 }
 
 func (c *ImageContext) EmbedSize(llamaContext *llama.Context) int {
-	return llamaContext.Model().NEmbd()
+	return llamaContext.Model().NEmbdInput()
 }
 
 type imageCache struct {


### PR DESCRIPTION
Fixes #16264.

Qwen3-VL image requests can require the model input embedding width (`llama_model_n_embd_inp`) because deepstack visual features are appended to the base text embedding.

The 0llama runner was using `llama_model_n_embd` when copying mtmd image embeddings and allocating image embedding batches.
This switches the multimodal image path to use `llama_model_n_embd_inp`.

Tests:
- `env GOCACHE=/tmp/go-build go test ./llama`
- `env GOCACHE=/tmp/go-build GOPATH=/tmp/go go test ./runner/llamarunner`