### PR TITLE
model/renderers: fix Qwen tool-call prefill rendering

### DIFF
--- a/model/renderers/qwen35.go
+++ b/model/renderers/qwen35.go
@@ -131,7 +131,7 @@ func (r *Qwen35Renderer) Render(messages []api.Message, tools []api.Tool, think 
 		content = strings.TrimSpace(content)
 
 		lastMessage := i == len(messages)-1
-		prefill := lastMessage && message.Role == "assistant"
+		prefill := lastMessage && message.Role == "assistant" && len(message.ToolCalls) == 0
 
 		if message.Role == "user" || (message.Role == "system" && i != 0) {
 			sb.WriteString(imStartTag + message.Role + "\n" + content + imEndTag + "\n")

--- a/model/renderers/qwen35_test.go
+++ b/model/renderers/qwen35_test.go
@@ -90,6 +90,44 @@ func TestQwen35RendererNoThinkPrefill(t *testing.T) {
 	}
 }
 
+func TestQwen35RendererTrailingToolCallStartsNextAssistantTurn(t *testing.T) {
+	renderer := &Qwen35Renderer{isThinking: true}
+	msgs := []api.Message{
+		{Role: "user", Content: "What's the weather in Paris?"},
+		{
+			Role:     "assistant",
+			Thinking: "Need the weather before answering.",
+			ToolCalls: []api.ToolCall{
+				{Function: api.ToolCallFunction{
+					Name: "get_weather",
+					Arguments: testArgsOrdered([]orderedArg{
+						{Key: "location", Value: "Paris"},
+					}),
+				}},
+			},
+		},
+	}
+
+	got, err := renderer.Render(msgs, qwen35WeatherUVTools()[:1], nil)
+	if err != nil {
+		t.Fatalf("render failed: %v", err)
+	}
+
+	wantSuffix := `<tool_call>
+<function=get_weather>
+<parameter=location>
+Paris
+</parameter>
+</function>
+</tool_call><|im_end|>
+<|im_start|>assistant
+<think>
+`
+	if !strings.HasSuffix(got, wantSuffix) {
+		t.Fatalf("expected trailing tool call to close and start a new assistant turn, got:\n%s", got)
+	}
+}
+
 func TestQwen35RendererBackToBackToolCallsAndResponses(t *testing.T) {
 	renderer := &Qwen35Renderer{isThinking: true}
 

--- a/model/renderers/qwen3coder.go
+++ b/model/renderers/qwen3coder.go
@@ -137,7 +137,7 @@ func (r *Qwen3CoderRenderer) Render(messages []api.Message, tools []api.Tool, _ 
 
 	for i, message := range filteredMessages {
 		lastMessage := i == len(filteredMessages)-1
-		prefill := lastMessage && message.Role == "assistant"
+		prefill := lastMessage && message.Role == "assistant" && len(message.ToolCalls) == 0
 		switch message.Role {
 		case "assistant":
 			if len(message.ToolCalls) > 0 {

--- a/model/renderers/qwen3coder_test.go
+++ b/model/renderers/qwen3coder_test.go
@@ -252,6 +252,33 @@ Tell me something interesting.<|im_end|>
 I'll tell you something interesting about cats`,
 		},
 		{
+			name: "last assistant tool call starts next assistant turn",
+			msgs: []api.Message{
+				{Role: "user", Content: "call tool"},
+				{Role: "assistant", ToolCalls: []api.ToolCall{
+					{Function: api.ToolCallFunction{
+						Name: "echo",
+						Arguments: testArgs(map[string]any{
+							"payload": "ok",
+						}),
+					}},
+				}},
+			},
+			expected: `<|im_start|>user
+call tool<|im_end|>
+<|im_start|>assistant
+
+<tool_call>
+<function=echo>
+<parameter=payload>
+ok
+</parameter>
+</function>
+</tool_call><|im_end|>
+<|im_start|>assistant
+`,
+		},
+		{
 			name: "complex tool call arguments should remain json encoded",
 			msgs: []api.Message{
 				{Role: "user", Content: "call tool"},

--- a/model/renderers/qwen3vl.go
+++ b/model/renderers/qwen3vl.go
@@ -77,7 +77,7 @@ func (r *Qwen3VLRenderer) Render(messages []api.Message, tools []api.Tool, think
 		imageOffset = nextImageOffset
 
 		lastMessage := i == len(messages)-1
-		prefill := lastMessage && message.Role == "assistant"
+		prefill := lastMessage && message.Role == "assistant" && len(message.ToolCalls) == 0
 
 		if message.Role == "user" || message.Role == "system" && i != 0 {
 			sb.WriteString("<|im_start|>" + message.Role + "\n" + content + "<|im_end|>\n")

--- a/model/renderers/qwen3vl_nonthinking_test.go
+++ b/model/renderers/qwen3vl_nonthinking_test.go
@@ -381,7 +381,9 @@ before
 </tool_call>
 <tool_call>
 {"name": "mul", "arguments": {"x": 4, "y": 5}}
-</tool_call>`,
+</tool_call><|im_end|>
+<|im_start|>assistant
+`,
 		},
 		{
 			name: "consecutive tool responses grouped",


### PR DESCRIPTION
## Summary
- Treat trailing Qwen assistant messages as prefill only when they do not contain tool calls
- Close completed trailing tool-call turns and emit the next assistant generation prompt
- Add regression coverage for qwen3.5, qwen3-coder, and qwen3-vl rendering

Refs #14493

## Tests
- `go test ./model/renderers ./model/parsers`