### PR TITLE
server: remove duplicate template parsing

### DIFF
--- a/server/create.go
+++ b/server/create.go
@@ -743,9 +743,6 @@ func setTemplate(layers []manifest.Layer, t string) ([]manifest.Layer, error) {
 	if _, err := template.Parse(t); err != nil {
 		return nil, fmt.Errorf("%w: %s", errBadTemplate, err)
 	}
-	if _, err := template.Parse(t); err != nil {
-		return nil, fmt.Errorf("%w: %s", errBadTemplate, err)
-	}
 
 	blob := strings.NewReader(t)
 	layer, err := manifest.NewLayer(blob, "application/vnd.ollama.image.template")

--- a/server/create_test.go
+++ b/server/create_test.go
@@ -256,3 +256,33 @@ func TestRemoteURL_Idempotent(t *testing.T) {
 		})
 	}
 }
+
+func TestSetTemplate(t *testing.T) {
+	t.Setenv("OLLAMA_MODELS", t.TempDir())
+
+	t.Run("valid template", func(t *testing.T) {
+		layers, err := setTemplate(nil, "{{ .Prompt }}")
+		if err != nil {
+			t.Fatalf("setTemplate returned error for valid template: %v", err)
+		}
+
+		if len(layers) != 1 {
+			t.Fatalf("expected 1 layer, got %d", len(layers))
+		}
+
+		if got, want := layers[0].MediaType, "application/vnd.ollama.image.template"; got != want {
+			t.Fatalf("unexpected media type: got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("invalid template", func(t *testing.T) {
+		_, err := setTemplate(nil, "{{ if .Prompt }}")
+		if err == nil {
+			t.Fatal("expected error for invalid template, got nil")
+		}
+
+		if !errors.Is(err, errBadTemplate) {
+			t.Fatalf("expected errBadTemplate, got %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Removes a duplicate `template.Parse` call in `setTemplate`.

## Changes

* removed redundant template parsing
* preserved existing behavior
* added focused unit tests for valid and invalid templates

## Testing

* `go test ./server
* `go test ./server -run TestSetTemplate
