### PR TITLE
readme: add ModelStatus to community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ console.log(response.message.content);
 - [Kerlig AI](https://www.kerlig.com/) - AI writing assistant for macOS
 - [Hillnote](https://hillnote.com) - Markdown-first AI workspace
 - [Perfect Memory AI](https://www.perfectmemory.ai/) - Productivity AI personalized by screen and meeting history
+- [ModelStatus](https://github.com/lucasmullikin/ModelStatus) - macOS menu bar app that monitors Ollama (and other local model servers) at a glance
 
 #### Mobile
 


### PR DESCRIPTION
Adds ModelStatus to the Desktop subsection of Community Integrations.

ModelStatus is a free, open-source (MIT) macOS menu bar app that monitors Ollama (and other local LLM servers — LM Studio, vLLM, llama.cpp, MLX, anything OpenAI-compatible) at a glance. It auto-detects the backend type from the URL, supports eject/load from the menu, includes LAN + Tailscale-peer discovery, no telemetry, no account.

- Source: https://github.com/lucasmullikin/ModelStatus
- Install: `brew tap lucasmullikin/tap && brew install --cask modelstatus`

No code change to ollama itself — single README line addition.