### PR TITLE
Make runner host configurable via OLLAMA_RUNNER_HOST

### DIFF
--- a/discover/runner.go
+++ b/discover/runner.go
@@ -412,7 +412,12 @@ func filterOverlapByLibrary(supported map[string]map[string]map[string]int, need
 
 type bootstrapRunner struct {
 	port int
+	host string
 	cmd  *exec.Cmd
+}
+
+func (r *bootstrapRunner) GetHost() string {
+	return r.host
 }
 
 func (r *bootstrapRunner) GetPort() int {
@@ -494,7 +499,7 @@ func bootstrapDevicesWithStatus(ctx context.Context, ollamaLibDirs []string, ext
 	}
 
 	status := llm.NewStatusWriter(baseOut)
-	cmd, port, err := llm.StartRunner(
+	cmd, port, host, err := llm.StartRunner(
 		true, // ollama engine
 		"",   // no model
 		ollamaLibDirs,
@@ -512,7 +517,7 @@ func bootstrapDevicesWithStatus(ctx context.Context, ollamaLibDirs []string, ext
 
 	defer cmd.Process.Kill()
 
-	devices, err := ml.GetDevicesFromRunner(ctx, &bootstrapRunner{port: port, cmd: cmd})
+	devices, err := ml.GetDevicesFromRunner(ctx, &bootstrapRunner{port: port, host: host, cmd: cmd})
 	exitCode := -1
 	if cmd.ProcessState != nil {
 		exitCode = cmd.ProcessState.ExitCode()

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -17,6 +17,20 @@ import (
 	"time"
 )
 
+// RunnerHost returns the IP address that model runner subprocesses will bind to for
+// their internal HTTP IPC server. RunnerHost can be configured via the
+// OLLAMA_RUNNER_HOST environment variable. Default is "127.0.0.1".
+func RunnerHost() string {
+	if h := strings.TrimSpace(Var("OLLAMA_RUNNER_HOST")); h != "" {
+		// Strip brackets for bare IPv6 literals like "[::1]".
+		if ip := net.ParseIP(strings.Trim(h, "[]")); ip != nil {
+			return ip.String()
+		}
+		return h
+	}
+	return "127.0.0.1"
+}
+
 // Host returns the scheme and host. Host can be configured via the OLLAMA_HOST environment variable.
 // Default is scheme "http" and host "127.0.0.1:11434"
 func Host() *url.URL {
@@ -316,6 +330,7 @@ func AsMap() map[string]EnvVar {
 		"OLLAMA_KV_CACHE_TYPE":        {"OLLAMA_KV_CACHE_TYPE", KvCacheType(), "Quantization type for the K/V cache (default: f16)"},
 		"OLLAMA_GPU_OVERHEAD":         {"OLLAMA_GPU_OVERHEAD", GpuOverhead(), "Reserve a portion of VRAM per GPU (bytes)"},
 		"OLLAMA_HOST":                 {"OLLAMA_HOST", Host(), "IP Address for the ollama server (default 127.0.0.1:11434)"},
+		"OLLAMA_RUNNER_HOST":          {"OLLAMA_RUNNER_HOST", RunnerHost(), "IP address runner subprocesses bind to for internal IPC (default 127.0.0.1)"},
 		"OLLAMA_KEEP_ALIVE":           {"OLLAMA_KEEP_ALIVE", KeepAlive(), "The duration that models stay loaded in memory (default \"5m\")"},
 		"OLLAMA_LLM_LIBRARY":          {"OLLAMA_LLM_LIBRARY", LLMLibrary(), "Set LLM library to bypass autodetection"},
 		"OLLAMA_LOAD_TIMEOUT":         {"OLLAMA_LOAD_TIMEOUT", LoadTimeout(), "How long to allow model loads to stall before giving up (default \"5m\")"},

--- a/llm/server.go
+++ b/llm/server.go
@@ -78,6 +78,7 @@ type LlamaServer interface {
 	VRAMByGPU(id ml.DeviceID) uint64
 	Pid() int
 	GetPort() int
+	GetHost() string
 	GetDeviceInfos(ctx context.Context) []ml.DeviceInfo
 	HasExited() bool
 	ContextLength() int
@@ -86,6 +87,7 @@ type LlamaServer interface {
 // llmServer is an instance of a runner hosting a single model
 type llmServer struct {
 	port      int
+	host      string // IP address the runner subprocess is bound to
 	cmd       *exec.Cmd
 	done      chan struct{} // closed when the process exits
 	doneErr   error         // valid after done is closed
@@ -273,7 +275,7 @@ func NewLlamaServer(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, modelPath st
 
 	gpuLibs := ml.LibraryPaths(gpus)
 	status := NewStatusWriter(os.Stderr)
-	cmd, port, err := StartRunner(
+	cmd, port, host, err := StartRunner(
 		tok != nil,
 		modelPath,
 		gpuLibs,
@@ -283,6 +285,7 @@ func NewLlamaServer(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, modelPath st
 
 	s := llmServer{
 		port:           port,
+		host:           host,
 		cmd:            cmd,
 		status:         status,
 		options:        opts,
@@ -331,19 +334,21 @@ func NewLlamaServer(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, modelPath st
 	}
 }
 
-func StartRunner(ollamaEngine bool, modelPath string, gpuLibs []string, out io.Writer, extraEnvs map[string]string) (cmd *exec.Cmd, port int, err error) {
+func StartRunner(ollamaEngine bool, modelPath string, gpuLibs []string, out io.Writer, extraEnvs map[string]string) (cmd *exec.Cmd, port int, host string, err error) {
 	var exe string
 	exe, err = os.Executable()
 	if err != nil {
-		return nil, 0, fmt.Errorf("unable to lookup executable path: %w", err)
+		return nil, 0, "", fmt.Errorf("unable to lookup executable path: %w", err)
 	}
 
 	if eval, err := filepath.EvalSymlinks(exe); err == nil {
 		exe = eval
 	}
 
+	host = envconfig.RunnerHost()
+
 	port = 0
-	if a, err := net.ResolveTCPAddr("tcp", "localhost:0"); err == nil {
+	if a, err := net.ResolveTCPAddr("tcp", net.JoinHostPort(host, "0")); err == nil {
 		var l *net.TCPListener
 		if l, err = net.ListenTCP("tcp", a); err == nil {
 			port = l.Addr().(*net.TCPAddr).Port
@@ -361,6 +366,7 @@ func StartRunner(ollamaEngine bool, modelPath string, gpuLibs []string, out io.W
 	if modelPath != "" {
 		params = append(params, "--model", modelPath)
 	}
+	params = append(params, "--host", host)
 	params = append(params, "--port", strconv.Itoa(port))
 
 	var pathEnv string
@@ -434,7 +440,7 @@ func StartRunner(ollamaEngine bool, modelPath string, gpuLibs []string, out io.W
 	slog.Debug("subprocess", "", filteredEnv(cmd.Env))
 
 	if err = cmd.Start(); err != nil {
-		return nil, 0, err
+		return nil, 0, "", err
 	}
 	err = nil
 	return
@@ -1229,7 +1235,7 @@ func (s *llmServer) initModel(ctx context.Context, req LoadRequest, operation Lo
 		return nil, fmt.Errorf("error marshaling load data: %w", err)
 	}
 
-	r, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("http://127.0.0.1:%d/load", s.port), bytes.NewBuffer(data))
+	r, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("http://%s/load", net.JoinHostPort(s.host, strconv.Itoa(s.port))), bytes.NewBuffer(data))
 	if err != nil {
 		return nil, fmt.Errorf("error creating load request: %w", err)
 	}
@@ -1307,7 +1313,7 @@ func (s *llmServer) getServerStatus(ctx context.Context) (ServerStatus, error) {
 		return ServerStatusError, fmt.Errorf("llama runner process no longer running: %d %s", s.cmd.ProcessState.ExitCode(), msg)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d/health", s.port), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://%s/health", net.JoinHostPort(s.host, strconv.Itoa(s.port))), nil)
 	if err != nil {
 		return ServerStatusError, fmt.Errorf("error creating GET request: %v", err)
 	}
@@ -1453,6 +1459,10 @@ func (s *llmServer) Pid() int {
 		return s.cmd.Process.Pid
 	}
 	return -1
+}
+
+func (s *llmServer) GetHost() string {
+	return s.host
 }
 
 func (s *llmServer) GetPort() int {
@@ -1639,7 +1649,7 @@ func (s *llmServer) Completion(ctx context.Context, req CompletionRequest, fn fu
 		return fmt.Errorf("failed to marshal data: %v", err)
 	}
 
-	endpoint := fmt.Sprintf("http://127.0.0.1:%d/completion", s.port)
+	endpoint := fmt.Sprintf("http://%s/completion", net.JoinHostPort(s.host, strconv.Itoa(s.port)))
 	serverReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, buffer)
 	if err != nil {
 		return fmt.Errorf("error creating POST request: %v", err)
@@ -1774,7 +1784,7 @@ func (s *llmServer) Embedding(ctx context.Context, input string) ([]float32, int
 		return nil, 0, fmt.Errorf("error marshaling embed data: %w", err)
 	}
 
-	r, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("http://127.0.0.1:%d/embedding", s.port), bytes.NewBuffer(data))
+	r, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("http://%s/embedding", net.JoinHostPort(s.host, strconv.Itoa(s.port))), bytes.NewBuffer(data))
 	if err != nil {
 		return nil, 0, fmt.Errorf("error creating embed request: %w", err)
 	}

--- a/ml/device.go
+++ b/ml/device.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"math"
+	"net"
 	"net/http"
 	"runtime"
 	"slices"
@@ -605,6 +606,9 @@ func (d DeviceInfo) updateVisibleDevicesEnv(env map[string]string, mustFilter bo
 }
 
 type BaseRunner interface {
+	// GetHost returns the hos the runner is running on, usually localhost
+	GetHost() string
+
 	// GetPort returns the localhost port number the runner is running on
 	GetPort() int
 
@@ -635,13 +639,14 @@ type FilteredRunnerDiscovery interface {
 func GetDevicesFromRunner(ctx context.Context, runner BaseRunner) ([]DeviceInfo, error) {
 	var moreDevices []DeviceInfo
 	port := runner.GetPort()
+	host := runner.GetHost()
 	tick := time.Tick(10 * time.Millisecond)
 	for {
 		select {
 		case <-ctx.Done():
 			return nil, fmt.Errorf("failed to finish discovery before timeout")
 		case <-tick:
-			r, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d/info", port), nil)
+			r, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://%s/info", net.JoinHostPort(host, strconv.Itoa(port))), nil)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create request: %w", err)
 			}

--- a/runner/llamarunner/runner.go
+++ b/runner/llamarunner/runner.go
@@ -951,6 +951,7 @@ func (s *Server) load(w http.ResponseWriter, r *http.Request) {
 func Execute(args []string) error {
 	fs := flag.NewFlagSet("runner", flag.ExitOnError)
 	mpath := fs.String("model", "", "Path to model binary file")
+	host := fs.String("host", "127.0.0.1", "IP address to bind the runner HTTP server to")
 	port := fs.Int("port", 8080, "Port to expose the server on")
 	_ = fs.Bool("verbose", false, "verbose output (default: disabled)")
 
@@ -980,7 +981,7 @@ func Execute(args []string) error {
 
 	go server.run(ctx)
 
-	addr := "127.0.0.1:" + strconv.Itoa(*port)
+	addr := net.JoinHostPort(*host, strconv.Itoa(*port))
 	listener, err := net.Listen("tcp", addr)
 	if err != nil {
 		fmt.Println("Listen error:", err)

--- a/runner/ollamarunner/runner.go
+++ b/runner/ollamarunner/runner.go
@@ -1436,6 +1436,7 @@ func (s *Server) infoModelLocked() (model.Model, error) {
 func Execute(args []string) error {
 	fs := flag.NewFlagSet("runner", flag.ExitOnError)
 	mpath := fs.String("model", "", "Path to model binary file")
+	host := fs.String("host", "127.0.0.1", "IP address to bind the runner HTTP server to")
 	port := fs.Int("port", 8080, "Port to expose the server on")
 	_ = fs.Bool("verbose", false, "verbose output (default: disabled)")
 
@@ -1462,7 +1463,7 @@ func Execute(args []string) error {
 
 	go server.run(ctx)
 
-	addr := "127.0.0.1:" + strconv.Itoa(*port)
+	addr := net.JoinHostPort(*host, strconv.Itoa(*port))
 	listener, err := net.Listen("tcp", addr)
 	if err != nil {
 		fmt.Println("Listen error:", err)

--- a/server/sched.go
+++ b/server/sched.go
@@ -814,6 +814,13 @@ func (runner *runnerRef) GetPort() int {
 	return -1
 }
 
+func (runner *runnerRef) GetHost() string {
+	if runner.llama != nil {
+		return runner.llama.GetHost()
+	}
+	return ""
+}
+
 func (runner *runnerRef) GetDeviceInfos(ctx context.Context) []ml.DeviceInfo {
 	if runner.llama != nil {
 		return runner.llama.GetDeviceInfos(ctx)

--- a/x/imagegen/server.go
+++ b/x/imagegen/server.go
@@ -36,6 +36,7 @@ type Server struct {
 	mu          sync.Mutex
 	cmd         *exec.Cmd
 	port        int
+	host        string
 	modelName   string
 	vramSize    uint64
 	done        chan error
@@ -442,6 +443,11 @@ func (s *Server) Pid() int {
 // GetPort returns the port the subprocess is listening on.
 func (s *Server) GetPort() int {
 	return s.port
+}
+
+// GetHost returns the host the subprocess is listening on.
+func (s *Server) GetHost() string {
+	return s.host
 }
 
 // GetDeviceInfos returns device information.

--- a/x/mlxrunner/client.go
+++ b/x/mlxrunner/client.go
@@ -33,6 +33,7 @@ import (
 // Client wraps an MLX runner subprocess to implement llm.LlamaServer for LLM models.
 type Client struct {
 	port          int
+	host          string
 	modelName     string
 	contextLength atomic.Int64
 	memory        atomic.Uint64
@@ -233,6 +234,11 @@ func (c *Client) GetDeviceInfos(ctx context.Context) []ml.DeviceInfo {
 // GetPort implements llm.LlamaServer.
 func (c *Client) GetPort() int {
 	return c.port
+}
+
+// GetPort implements llm.LlamaServer.
+func (c *Client) GetHost() string {
+	return c.host
 }
 
 // HasExited implements llm.LlamaServer.


### PR DESCRIPTION
It's useful in environments (for example in containers) where there is no IPv4 or loopback interface or user is not allowed to bind to 127.0.0.1.