### PR TITLE
docs: add Prompter to Terminal & CLI community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ console.log(response.message.content);
 - [tlm](https://github.com/yusufcanb/tlm) - Local shell copilot
 - [tenere](https://github.com/pythops/tenere) - TUI for LLMs
 - [ParLlama](https://github.com/paulrobello/parllama) - TUI for Ollama
+- [Prompter](https://github.com/whonixnetworks/prompter) - Multi-model comparison, benchmarking, and evaluation TUI for Ollama
 - [llm-ollama](https://github.com/taketwo/llm-ollama) - Plugin for [Datasette's LLM CLI](https://llm.datasette.io/en/stable/)
 - [ShellOracle](https://github.com/djcopley/ShellOracle) - Shell command suggestions
 - [LLM-X](https://github.com/mrdjohnson/llm-x) - Progressive web app for LLMs


### PR DESCRIPTION
Adds [Prompter](https://github.com/whonixnetworks/prompter) to the Terminal & CLI section of community integrations.

Prompter is a terminal-based multi-model comparison, benchmarking, and evaluation tool for Ollama.

- Single Python file, zero dependencies (stdlib only)
- Side-by-side streaming comparison of multiple models
- Council mode: multi-persona debate with synthesis verdict
- Tribunal mode: adversarial cross-examination with arbiter rulings
- RALPH mode: self-review loop with convergence detection
- Benchmark mode: 20 standardised capability tests per model
- Optional tool orchestration (web search, shell, Python, file read, etc.)

Closes #16312