### PR TITLE
fix tool_result image content unmarshaling

### DIFF
--- a/anthropic/anthropic.go
+++ b/anthropic/anthropic.go
@@ -140,6 +140,60 @@ type ContentBlock struct {
 	Signature string  `json:"signature,omitempty"`
 }
 
+func (cb *ContentBlock) UnmarshalJSON(data []byte) error {
+	// Create an alias type to avoid infinite recursion
+	type Alias ContentBlock
+	aux := &struct {
+		Content json.RawMessage `json:"content,omitempty"`
+		*Alias
+	}{
+		Alias: (*Alias)(cb),
+	}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+
+	// Handle Content field based on block type
+	if len(aux.Content) > 0 {
+		// For tool_result blocks, Content can be a string or an array of nested ContentBlocks
+		if cb.Type == "tool_result" {
+			// Try unmarshaling as string first
+			var s string
+			if err := json.Unmarshal(aux.Content, &s); err == nil {
+				cb.Content = s
+				return nil
+			}
+
+			// Try unmarshaling as array of content blocks (for nested images/text)
+			var blocks []ContentBlock
+			if err := json.Unmarshal(aux.Content, &blocks); err == nil {
+				// Store as []any for compatibility with convertToolResultContent
+				cb.Content = rawToAny(aux.Content)
+				return nil
+			}
+
+			// If neither works, store raw to preserve original behavior
+			cb.Content = rawToAny(aux.Content)
+			return nil
+		}
+
+		// For other block types, use standard unmarshaling
+		cb.Content = rawToAny(aux.Content)
+	}
+
+	return nil
+}
+
+// rawToAny unmarshals json.RawMessage into any for generic handling
+func rawToAny(raw json.RawMessage) any {
+	var result any
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return string(raw)
+	}
+	return result
+}
+
 // Citation represents a citation in a text block
 type Citation struct {
 	Type           string `json:"type"` // "web_search_result_location"

--- a/anthropic/anthropic_test.go
+++ b/anthropic/anthropic_test.go
@@ -328,6 +328,67 @@ func TestFromMessagesRequest_WithToolResultImage(t *testing.T) {
 	}
 }
 
+func TestFromMessagesRequest_WithToolResultImageFromJSON(t *testing.T) {
+	// This test simulates the exact scenario from issue #16298:
+	// Claude Code's Read tool returning a PNG image wrapped in a tool_result
+	// when unmarshaled from JSON (as happens in real API requests)
+	requestJSON := `{
+		"model": "test-model",
+		"max_tokens": 1024,
+		"messages": [
+			{
+				"role": "user",
+				"content": [
+					{
+						"type": "tool_result",
+						"tool_use_id": "toolu_01PNG123",
+						"content": [
+							{
+								"type": "image",
+								"source": {
+									"type": "base64",
+									"media_type": "image/png",
+									"data": "` + testImage + `"
+								}
+							}
+						]
+					}
+				]
+			}
+		]
+	}`
+
+	var req MessagesRequest
+	if err := json.Unmarshal([]byte(requestJSON), &req); err != nil {
+		t.Fatalf("failed to unmarshal request: %v", err)
+	}
+
+	result, err := FromMessagesRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(result.Messages))
+	}
+
+	msg := result.Messages[0]
+	if msg.Role != "tool" {
+		t.Errorf("expected role 'tool', got %q", msg.Role)
+	}
+	if msg.ToolCallID != "toolu_01PNG123" {
+		t.Errorf("expected tool_call_id 'toolu_01PNG123', got %q", msg.ToolCallID)
+	}
+	if len(msg.Images) != 1 {
+		t.Fatalf("expected 1 image, got %d", len(msg.Images))
+	}
+
+	expectedImgData, _ := base64.StdEncoding.DecodeString(testImage)
+	if string(msg.Images[0]) != string(expectedImgData) {
+		t.Error("image data mismatch")
+	}
+}
+
 func TestFromMessagesRequest_WithToolResultFollowedByUserText(t *testing.T) {
 	req := MessagesRequest{
 		Model:     "test-model",


### PR DESCRIPTION
The /v1/messages endpoint failed with "API Error: 400 Input should be a valid string" when the Read tool returned PNG images wrapped in tool_result blocks. The issue occurred during JSON unmarshaling of nested image content within tool_result content arrays.

Added a custom UnmarshalJSON method to ContentBlock in the codebase that properly handles the Content field when it contains nested content blocks with images. The method preserves compatibility with existing string-based tool results while correctly parsing complex nested structures like image sources with base64 data.

Added regression test TestFromMessagesRequest_WithToolResultImageFromJSON that unmarshals a real JSON request matching the issue scenario.

Fixes #16298