### PR TITLE
convert: don't over-quantize the mtp.fc.weight tensor

### DIFF
--- a/server/quantization.go
+++ b/server/quantization.go
@@ -68,6 +68,9 @@ func useMoreBits(iLayer, nLayers int) bool {
 
 func qwen3LinearAttnQuantType(name string) (fsggml.TensorType, bool) {
 	switch {
+	case name == "mtp.fc.weight" || strings.HasSuffix(name, ".mtp.fc.weight"):
+		return fsggml.TensorTypeQ8_0, true
+
 	// Full attention
 	case strings.HasSuffix(name, ".attn_q.weight"):
 		return fsggml.TensorTypeQ4_K, true

--- a/server/quantization_test.go
+++ b/server/quantization_test.go
@@ -196,6 +196,27 @@ func TestQwen3LinearAttentionQuantOverride(t *testing.T) {
 			expected: fsggml.TensorTypeQ4_K,
 		},
 		{
+			name:     "qwen3next_mtp_fc_q4_k_m",
+			arch:     "qwen3next",
+			tensor:   "mtp.fc.weight",
+			fileType: fsggml.FileTypeQ4_K_M,
+			expected: fsggml.TensorTypeQ8_0,
+		},
+		{
+			name:     "qwen35_mtp_fc_q4_k_m",
+			arch:     "qwen35",
+			tensor:   "mtp.fc.weight",
+			fileType: fsggml.FileTypeQ4_K_M,
+			expected: fsggml.TensorTypeQ8_0,
+		},
+		{
+			name:     "qwen35_mtp_fc_q4_k_s",
+			arch:     "qwen35",
+			tensor:   "mtp.fc.weight",
+			fileType: fsggml.FileTypeQ4_K_S,
+			expected: fsggml.TensorTypeQ8_0,
+		},
+		{
 			name:     "non_qwen35_falls_back",
 			arch:     "foo",
 			tensor:   "blk.0.attn_qkv.weight",


### PR DESCRIPTION
This change is specifically for Qwen 3.6 MTP and not over-quantizing the mtp.fc.weight tensor which was previously being quantized to q4_K_M if you quantized it to 4bit.

You can test it out with these models:
* pdevine/qwen3.6:27b-mtp-oldstyle-q4_K_M
* pdevine/qwen3.6:27b-mtp-oldstyle-q8_0
* pdevine/qwen3.6:27b-mtp-oldstyle-bf16
* pdevine/qwen3.6:35b-a3b-mtp-oldstyle-q4_K_M
* pdevine/qwen3.6:35b-a3b-mtp-oldstyle-q8_0
* pdevine/qwen3.6:35b-a3b-mtp-oldstyle-bf16
