### PR TITLE
runner: apply temperature scaling before computing logprobs

### DIFF
--- a/runner/common/logprob.go
+++ b/runner/common/logprob.go
@@ -12,27 +12,39 @@ type TokenDecoderFunc func(tokenID int) string
 
 // CalculateLogprobs converts raw logits to log probabilities and finds top K tokens.
 // It uses numerically stable softmax to compute log probabilities.
-func CalculateLogprobs(logits []float32, selectedToken int, topK int, decoder TokenDecoderFunc) []llm.Logprob {
+// If temperature > 0, logits are scaled by temperature before computing probabilities,
+// matching the distribution used during sampling.
+func CalculateLogprobs(logits []float32, selectedToken int, topK int, temperature float32, decoder TokenDecoderFunc) []llm.Logprob {
 	if len(logits) == 0 {
 		return nil
 	}
 
+	// Apply temperature scaling to match the sampling distribution
+	scaledLogits := make([]float32, len(logits))
+	copy(scaledLogits, logits)
+	if temperature > 0 {
+		temp := max(temperature, 1e-7)
+		for i := range scaledLogits {
+			scaledLogits[i] = scaledLogits[i] / temp
+		}
+	}
+
 	// Step 1: Convert logits to log probabilities using numerically stable softmax
-	maxLogit := logits[0]
-	for _, logit := range logits[1:] {
+	maxLogit := scaledLogits[0]
+	for _, logit := range scaledLogits[1:] {
 		if logit > maxLogit {
 			maxLogit = logit
 		}
 	}
 
 	var sumExp float64
-	for _, logit := range logits {
+	for _, logit := range scaledLogits {
 		sumExp += math.Exp(float64(logit - maxLogit))
 	}
 	logSumExp := float32(math.Log(sumExp))
 
-	logProbs := make([]float32, len(logits))
-	for i, logit := range logits {
+	logProbs := make([]float32, len(scaledLogits))
+	for i, logit := range scaledLogits {
 		logProbs[i] = (logit - maxLogit) - logSumExp
 	}
 

--- a/runner/common/logprob_test.go
+++ b/runner/common/logprob_test.go
@@ -56,7 +56,7 @@ func TestCalculateLogprobs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := CalculateLogprobs(tt.logits, tt.selectedToken, tt.topK, decoder)
+			result := CalculateLogprobs(tt.logits, tt.selectedToken, tt.topK, 1.0, decoder)
 			if len(result) != tt.wantLen {
 				t.Errorf("CalculateLogprobs() returned %d results, want %d", len(result), tt.wantLen)
 			}
@@ -87,7 +87,7 @@ func TestCalculateLogprobsNumericalStability(t *testing.T) {
 
 	// Test with very large logits to ensure numerical stability
 	logits := []float32{1000.0, 999.0, 998.0}
-	result := CalculateLogprobs(logits, 0, 3, decoder)
+	result := CalculateLogprobs(logits, 0, 3, 1.0, decoder)
 
 	if len(result) != 1 {
 		t.Fatalf("Expected 1 result, got %d", len(result))
@@ -161,7 +161,7 @@ func TestCalculateLogprobsProbabilityCorrectness(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := CalculateLogprobs(tt.logits, tt.selectedToken, tt.topK, decoder)
+			result := CalculateLogprobs(tt.logits, tt.selectedToken, tt.topK, 1.0, decoder)
 
 			if len(result) != 1 {
 				t.Fatalf("Expected 1 result, got %d", len(result))
@@ -262,7 +262,7 @@ func TestCalculateLogprobsSoftmaxCorrectness(t *testing.T) {
 			// Calculate logprobs for all tokens
 			var totalProb float64
 			for i := range tt.logits {
-				result := CalculateLogprobs(tt.logits, i, 0, decoder)
+				result := CalculateLogprobs(tt.logits, i, 0, 1.0, decoder)
 				if len(result) != 1 {
 					t.Fatalf("Expected 1 result, got %d", len(result))
 				}
@@ -305,7 +305,7 @@ func TestCalculateLogprobsSelectedTokenCorrectness(t *testing.T) {
 	var maxProbIndex int
 
 	for i := range logits {
-		result := CalculateLogprobs(logits, i, 0, decoder)
+		result := CalculateLogprobs(logits, i, 0, 1.0, decoder)
 		prob := math.Exp(result[0].Logprob)
 
 		if prob > maxProb {
@@ -344,7 +344,7 @@ func TestCalculateLogprobsTopKOrdering(t *testing.T) {
 	// Expected order by probability: 1 (5.0), 3 (4.0), 4 (3.0), 0 (2.0), 2 (1.0)
 	expectedOrder := []string{"second", "fourth", "fifth", "first", "third"}
 
-	result := CalculateLogprobs(logits, 0, 5, decoder)
+	result := CalculateLogprobs(logits, 0, 5, 1.0, decoder)
 
 	if len(result) != 1 {
 		t.Fatalf("Expected 1 result, got %d", len(result))

--- a/runner/llamarunner/runner.go
+++ b/runner/llamarunner/runner.go
@@ -99,6 +99,9 @@ type Sequence struct {
 	logprobs    bool
 	topLogprobs int
 
+	// temperature used for sampling, needed for correct logprob scaling
+	temperature float32
+
 	// Metrics
 	processingDuration time.Duration
 	generationDuration time.Duration
@@ -167,6 +170,11 @@ func (s *Server) NewSequence(prompt string, images []llm.ImageData, params NewSe
 		}
 	}
 
+	var temp float32
+	if params.samplingParams != nil {
+		temp = params.samplingParams.Temp
+	}
+
 	return &Sequence{
 		inputs:           inputs,
 		numPromptInputs:  len(inputs),
@@ -182,12 +190,13 @@ func (s *Server) NewSequence(prompt string, images []llm.ImageData, params NewSe
 		shift:            params.shift,
 		logprobs:         params.logprobs,
 		topLogprobs:      params.topLogprobs,
+		temperature:      temp,
 	}, nil
 }
 
 // calculateLogprobsLlama converts raw logits to log probabilities and finds top K tokens
-func calculateLogprobsLlama(logits []float32, selectedToken int, topK int, model *llama.Model) []llm.Logprob {
-	return common.CalculateLogprobs(logits, selectedToken, topK, model.TokenToPiece)
+func calculateLogprobsLlama(logits []float32, selectedToken int, topK int, temperature float32, model *llama.Model) []llm.Logprob {
+	return common.CalculateLogprobs(logits, selectedToken, topK, temperature, model.TokenToPiece)
 }
 
 // inputs processes the prompt and images into a list of inputs
@@ -556,7 +565,7 @@ func (s *Server) processBatch(tokenBatch *llama.Batch, embedBatch *llama.Batch) 
 		if seq.logprobs {
 			logits := s.lc.GetLogitsIth(seq.iBatch)
 			if logits != nil {
-				logprobs := calculateLogprobsLlama(logits, token, seq.topLogprobs, s.model)
+				logprobs := calculateLogprobsLlama(logits, token, seq.topLogprobs, seq.temperature, s.model)
 				seq.pendingLogprobs = append(seq.pendingLogprobs, logprobs...)
 			}
 		}

--- a/runner/ollamarunner/runner.go
+++ b/runner/ollamarunner/runner.go
@@ -211,12 +211,12 @@ func (s *Server) NewSequence(prompt string, images []llm.ImageData, params NewSe
 }
 
 // calculateLogprobs converts raw logits to log probabilities and finds top K tokens
-func calculateLogprobs(logits []float32, selectedToken int32, topK int, tok tokenizer.Tokenizer) []llm.Logprob {
+func calculateLogprobs(logits []float32, selectedToken int32, topK int, temperature float32, tok tokenizer.Tokenizer) []llm.Logprob {
 	decoder := func(tokenID int) string {
 		text, _ := tok.Decode([]int32{int32(tokenID)})
 		return text
 	}
-	return common.CalculateLogprobs(logits, int(selectedToken), topK, decoder)
+	return common.CalculateLogprobs(logits, int(selectedToken), topK, temperature, decoder)
 }
 
 // inputs processes the prompt and images into a list of inputs
@@ -788,7 +788,7 @@ func (s *Server) computeBatch(activeBatch batchState) {
 
 		// Calculate logprobs if requested (after EOS check to avoid logprobs for EOS tokens)
 		if seq.logprobs {
-			logprobs := calculateLogprobs(logits, token, seq.topLogprobs, s.model.(tokenizer.Tokenizer))
+			logprobs := calculateLogprobs(logits, token, seq.topLogprobs, seq.sampler.Temperature(), s.model.(tokenizer.Tokenizer))
 			seq.pendingLogprobs = append(seq.pendingLogprobs, logprobs...)
 		}
 

--- a/sample/samplers.go
+++ b/sample/samplers.go
@@ -204,3 +204,8 @@ func (g *GrammarSampler) Accept(token int32) {
 func (g *GrammarSampler) Free() {
 	g.grammar.Free()
 }
+
+// Temperature returns the temperature used by this sampler
+func (s *Sampler) Temperature() float32 {
+	return s.temperature
+}


### PR DESCRIPTION
## Related Issue
Closes #16196

## Summary
Logprobs were computed from raw logits without temperature scaling, which meant the returned logprobs did not reflect the actual sampling distribution used to select tokens. This caused logprob values to be identical regardless of the 	emperature setting.

## Changes
- Add Temperature() getter to sample.Sampler
- Modify CalculateLogprobs to accept a 	emperature parameter and apply temperature scaling before computing softmax
- Pass temperature from both ollamarunner and llamarunner to CalculateLogprobs
- Update tests to pass default temperature of 1.0

## Verification
- Code reviewed for correctness
- Tests updated to match new signature
- Go build not available in environment; CI will validate builds
