### PR TITLE
docs: fix formatting, capitalization, and wording inconsistencies

### DIFF
--- a/docs/context-length.mdx
+++ b/docs/context-length.mdx
@@ -6,9 +6,10 @@ Context length is the maximum number of tokens that the model has access to in m
 
 <Note>
   Ollama defaults to the following context lengths based on VRAM:
+
     - < 24 GiB VRAM: 4k context
     - 24-48 GiB VRAM: 32k context
-    - &gt;= 48 GiB VRAM: 256k context
+    - >= 48 GiB VRAM: 256k context
 </Note>
 
 Tasks which require large context like web search, agents, and coding tools should be set to at least 64000 tokens.

--- a/docs/development.md
+++ b/docs/development.md
@@ -173,7 +173,7 @@ export OLLAMA_MLX_SOURCE=/path/to/mlx
 export OLLAMA_MLX_C_SOURCE=/path/to/mlx-c
 ```
 
-For example, using the helper scripts with local mlx and mlx-c repos:
+For example, using the helper scripts with local MLX and MLX-C repos:
 ```shell
 OLLAMA_MLX_SOURCE=../mlx OLLAMA_MLX_C_SOURCE=../mlx-c ./scripts/build_linux.sh
 
@@ -183,7 +183,7 @@ OLLAMA_MLX_SOURCE=../mlx OLLAMA_MLX_C_SOURCE=../mlx-c ./scripts/build_darwin.sh
 ```powershell
 $env:OLLAMA_MLX_SOURCE="../mlx"
 $env:OLLAMA_MLX_C_SOURCE="../mlx-c"
-./scripts/build_darwin.ps1
+./scripts/build_windows.ps1
 ```
 
 ## Docker

--- a/docs/docker.mdx
+++ b/docs/docker.mdx
@@ -4,7 +4,7 @@
 docker run -d -v ollama:/root/.ollama -p 11434:11434 --name ollama ollama/ollama
 ```
 
-## Nvidia GPU
+## NVIDIA GPU
 
 Install the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html#installation).
 
@@ -42,7 +42,7 @@ Install the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-
     sudo yum install -y nvidia-container-toolkit
     ```
 
-### Configure Docker to use Nvidia driver
+### Configure Docker to use NVIDIA driver
 
 ```shell
 sudo nvidia-ctk runtime configure --runtime=docker

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -11,4 +11,4 @@ Ollama JavaScript examples at [ollama-js/examples](https://github.com/ollama/oll
 
 
 ## OpenAI compatibility examples
-Ollama OpenAI compatibility examples at [ollama/examples/openai](../docs/openai.md)
+Ollama OpenAI compatibility examples at [ollama/examples/openai](../openai)

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -72,11 +72,11 @@ The `Processor` column will show which memory the model was loaded into:
 - `100% CPU` means the model was loaded entirely in system memory
 - `48%/52% CPU/GPU` means the model was loaded partially onto both the GPU and into system memory
 
-## How do I configure Ollama server?
+## How do I configure Ollama Server?
 
 Ollama server can be configured with environment variables.
 
-### Setting environment variables on Mac
+### Setting environment variables on macOS
 
 If Ollama is run as a macOS application, environment variables should be set using `launchctl`:
 

--- a/docs/gpu.mdx
+++ b/docs/gpu.mdx
@@ -46,7 +46,7 @@ ignore the GPUs and force CPU usage, use an invalid GPU ID (e.g., "-1")
 
 ### Linux Suspend Resume
 
-On linux, after a suspend/resume cycle, sometimes Ollama will fail to discover
+On Linux, after a suspend/resume cycle, sometimes Ollama will fail to discover
 your NVIDIA GPU, and fallback to running on the CPU. You can workaround this
 driver bug by reloading the NVIDIA UVM driver with `sudo rmmod nvidia_uvm &&
 sudo modprobe nvidia_uvm`
@@ -98,7 +98,7 @@ If you have multiple GPUs with different GFX versions, append the numeric device
 number to the environment variable to set them individually. For example,
 `HSA_OVERRIDE_GFX_VERSION_0=10.3.0` and `HSA_OVERRIDE_GFX_VERSION_1=11.0.0`
 
-At this time, the known supported GPU types on linux are the following LLVM Targets.
+At this time, the known supported GPU types on Linux are the following LLVM Targets.
 This table shows some example GPUs that map to these LLVM targets:
 | **LLVM Target** | **An Example GPU** |
 |-----------------|---------------------|

--- a/docs/import.mdx
+++ b/docs/import.mdx
@@ -9,9 +9,9 @@ title: Importing a Model
 - [Importing a GGUF file](#Importing-a-GGUF-based-model-or-adapter)
 - [Sharing models on ollama.com](#Sharing-your-model-on-ollamacom)
 
-## Importing a fine tuned adapter from Safetensors weights
+## Importing a fine-tuned adapter from Safetensors weights
 
-First, create a `Modelfile` with a `FROM` command pointing at the base model you used for fine tuning, and an `ADAPTER` command which points to the directory with your Safetensors adapter:
+First, create a `Modelfile` with a `FROM` command pointing at the base model you used for fine-tuning, and an `ADAPTER` command which points to the directory with your Safetensors adapter:
 
 ```dockerfile
 FROM <base model name>
@@ -38,9 +38,9 @@ Ollama supports importing adapters based on several different model architecture
 - Mistral (including Mistral 1, Mistral 2, and Mixtral); and
 - Gemma (including Gemma 1 and Gemma 2)
 
-You can create the adapter using a fine tuning framework or tool which can output adapters in the Safetensors format, such as:
+You can create the adapter using a fine-tuning framework or tool which can output adapters in the Safetensors format, such as:
 
-- Hugging Face [fine tuning framework](https://huggingface.co/docs/transformers/en/training)
+- Hugging Face [fine-tuning framework](https://huggingface.co/docs/transformers/en/training)
 - [Unsloth](https://github.com/unslothai/unsloth)
 - [MLX](https://github.com/ml-explore/mlx)
 
@@ -73,7 +73,7 @@ Ollama supports importing models for several different architectures including:
 - Gemma (including Gemma 1 and Gemma 2); and
 - Phi3
 
-This includes importing foundation models as well as any fine tuned models which have been _fused_ with a foundation model.
+This includes importing foundation models as well as any fine-tuned models which have been _fused_ with a foundation model.
 
 ## Importing a GGUF based model or adapter
 
@@ -81,7 +81,7 @@ If you have a GGUF based model or adapter it is possible to import it into Ollam
 
 - converting a Safetensors model with the `convert_hf_to_gguf.py` from Llama.cpp;
 - converting a Safetensors adapter with the `convert_lora_to_gguf.py` from Llama.cpp; or
-- downloading a model or adapter from a place such as HuggingFace
+- downloading a model or adapter from a place such as Hugging Face
 
 To import a GGUF model, create a `Modelfile` containing:
 
@@ -151,7 +151,7 @@ First, use your browser to go to the [Ollama Sign-Up](https://ollama.com/signup)
 
 The `Username` field will be used as part of your model's name (e.g. `jmorganca/mymodel`), so make sure you are comfortable with the username that you have selected.
 
-Now that you have created an account and are signed-in, go to the [Ollama Keys Settings](https://ollama.com/settings/keys) page.
+Now that you have created an account and are signed in, go to the [Ollama Keys Settings](https://ollama.com/settings/keys) page.
 
 Follow the directions on the page to determine where your Ollama Public Key is located.
 

--- a/docs/linux.mdx
+++ b/docs/linux.mdx
@@ -113,7 +113,7 @@ sudo systemctl status ollama
 ```
 
 <Note>
-  While AMD has contributed the `amdgpu` driver upstream to the official linux
+  While AMD has contributed the `amdgpu` driver upstream to the official Linux
   kernel source, the version is older and may not support all ROCm features. We
   recommend you install the latest driver from
   https://www.amd.com/en/support/linux-drivers for best support of your Radeon

--- a/docs/macos.mdx
+++ b/docs/macos.mdx
@@ -4,7 +4,7 @@ title: macOS
 
 ## System Requirements
 
-* MacOS Sonoma (v14) or newer
+* macOS Sonoma (v14) or newer
 * Apple M series (CPU and GPU support) or x86 (CPU only)
 
 
@@ -21,7 +21,7 @@ To install the Ollama application somewhere other than `Applications`, place the
 
 ## Troubleshooting
 
-Ollama on MacOS stores files in a few different locations.
+Ollama on macOS stores files in a few different locations.
 - `~/.ollama` contains models and configuration
 - `~/.ollama/logs` contains logs
     - *app.log* contains most recent logs from the GUI application

--- a/docs/modelfile.mdx
+++ b/docs/modelfile.mdx
@@ -242,11 +242,11 @@ MESSAGE <role> <message>
 
 ```
 MESSAGE user Is Toronto in Canada?
-MESSAGE assistant yes
+MESSAGE assistant Yes
 MESSAGE user Is Sacramento in Canada?
-MESSAGE assistant no
+MESSAGE assistant No
 MESSAGE user Is Ontario in Canada?
-MESSAGE assistant yes
+MESSAGE assistant Yes
 ```
 
 ### REQUIRES

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -7,20 +7,19 @@ Ollama is available on macOS, Windows, and Linux.
 <a
   href="https://ollama.com/download"
   target="_blank"
-  className="inline-block px-6 py-2 bg-black rounded-full dark:bg-neutral-700 text-white font-normal border-none"
->
+  className="inline-block px-6 py-2 bg-black rounded-full dark:bg-neutral-700 text-white font-normal border-none">
   Download Ollama
 </a>
 
 ## Get Started
 
-Run `ollama` in your terminal to open the interactive menu:
+Run `Ollama` in your terminal to open the interactive menu:
 
 ```sh
 ollama
 ```
 
-Navigate with `↑/↓`, press `enter` to launch, `→` to change model, and `esc` to quit.
+Navigate with `↑/↓`, press `Enter` to launch, `→` to change model, and `Esc` to quit.
 
 The menu provides quick access to:
 - **Run a model** - Start an interactive chat
@@ -60,7 +59,12 @@ Use the [API](/api) to integrate Ollama into your applications:
 ```sh
 curl http://localhost:11434/api/chat -d '{
   "model": "gemma3",
-  "messages": [{ "role": "user", "content": "Hello!" }]
+  "messages": [
+    { 
+      "role": "user", 
+      "content": "Hello!" 
+    }
+  ]
 }'
 ```
 

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -43,7 +43,7 @@ Join the [Discord](https://discord.gg/ollama) for help interpreting the logs.
 
 ## LLM libraries
 
-Ollama includes multiple LLM libraries compiled for different GPUs and CPU vector features. Ollama tries to pick the best one based on the capabilities of your system. If this autodetection has problems, or you run into other problems (e.g. crashes in your GPU) you can workaround this by forcing a specific LLM library. `cpu_avx2` will perform the best, followed by `cpu_avx` an the slowest but most compatible is `cpu`. Rosetta emulation under MacOS will work with the `cpu` library.
+Ollama includes multiple LLM libraries compiled for different GPUs and CPU vector features. Ollama tries to pick the best one based on the capabilities of your system. If this autodetection has problems, or you run into other problems (e.g. crashes in your GPU) you can workaround this by forcing a specific LLM library. `cpu_avx2` will perform the best, followed by `cpu_avx` and the slowest but most compatible is `cpu`. Rosetta emulation under MacOS will work with the `cpu` library.
 
 In the server log, you will see a message that looks something like this (varies from release to release):
 
@@ -141,4 +141,4 @@ If you experience gibberish responses when models load across multiple AMD GPUs 
 
 ## Windows Terminal Errors
 
-Older versions of Windows 10 (e.g., 21H1) are known to have a bug where the standard terminal program does not display control characters correctly. This can result in a long string of strings like `←[?25h←[?25l` being displayed, sometimes erroring with `The parameter is incorrect` To resolve this problem, please update to Win 10 22H1 or newer.
+Older versions of Windows 10 (e.g., 21H1) are known to have a bug where the standard terminal program does not display control characters correctly. This can result in a long string of strings like `←[?25h←[?25l` being displayed, sometimes erroring with `The parameter is incorrect` To resolve this problem, please update to Windows 10 22H1 or newer.

--- a/docs/windows.mdx
+++ b/docs/windows.mdx
@@ -56,7 +56,7 @@ Ollama on Windows stores files in a few different locations. You can view them i
 the explorer window by hitting `<Ctrl>+R` and type in:
 
 - `explorer %LOCALAPPDATA%\Ollama` contains logs, and downloaded updates
-  - _app.log_ contains most resent logs from the GUI application
+  - _app.log_ contains most recent logs from the GUI application
   - _server.log_ contains the most recent server logs
   - _upgrade.log_ contains log output for upgrades
 - `explorer %LOCALAPPDATA%\Programs\Ollama` contains the binaries (The installer adds this to your user PATH)
@@ -80,7 +80,7 @@ help you keep up to date.
 
 If you'd like to install or integrate Ollama as a service, a standalone
 `ollama-windows-amd64.zip` zip file is available containing only the Ollama CLI
-and GPU library dependencies for Nvidia. Depending on your hardware, you may also
+and GPU library dependencies for NVIDIA. Depending on your hardware, you may also
 need to download and extract additional packages into the same directory:
 
 - **AMD GPU**: `ollama-windows-amd64-rocm.zip`


### PR DESCRIPTION
### Summary
This PR fixes minor documentation inconsistencies across multiple docs pages, including:

- Capitalization and branding consistency
- Formatting and wording improvements
- Typo fixes
- Heading consistency
- Broken relative path fix in examples.md
- MLX/MLX-C naming consistency in development.md

These changes are documentation-only and do not affect functionality.