### PR TITLE
fix(cli): resolve CLI image path parsing drag-and-drop failures (issue #10333)

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"slices"
 	"strings"
 
@@ -591,6 +592,13 @@ func normalizeFilePath(fp string) string {
 		if err == nil {
 			fp = filepath.Join(home, fp[2:])
 		}
+	}
+
+	if runtime.GOOS == "windows" {
+		// On Windows, backslashes are path separators, but spaces might still be escaped in bash-like environments.
+		// So we only replace backslash-escaped spaces with a space.
+		fp = strings.ReplaceAll(fp, `\ `, ` `)
+		return fp
 	}
 
 	// Generic shell unescaper: replace backslash followed by any character with that character

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -583,30 +583,26 @@ func NewCreateRequest(name string, opts runOptions) *api.CreateRequest {
 }
 
 func normalizeFilePath(fp string) string {
-	return strings.NewReplacer(
-		"\\ ", " ", // Escaped space
-		"\\(", "(", // Escaped left parenthesis
-		"\\)", ")", // Escaped right parenthesis
-		"\\[", "[", // Escaped left square bracket
-		"\\]", "]", // Escaped right square bracket
-		"\\{", "{", // Escaped left curly brace
-		"\\}", "}", // Escaped right curly brace
-		"\\$", "$", // Escaped dollar sign
-		"\\&", "&", // Escaped ampersand
-		"\\;", ";", // Escaped semicolon
-		"\\'", "'", // Escaped single quote
-		"\\\\", "\\", // Escaped backslash
-		"\\*", "*", // Escaped asterisk
-		"\\?", "?", // Escaped question mark
-		"\\~", "~", // Escaped tilde
-	).Replace(fp)
+	fp = strings.TrimSpace(fp)
+	fp = strings.Trim(fp, "\"'")
+
+	if strings.HasPrefix(fp, "~/") {
+		home, err := os.UserHomeDir()
+		if err == nil {
+			fp = filepath.Join(home, fp[2:])
+		}
+	}
+
+	// Generic shell unescaper: replace backslash followed by any character with that character
+	re := regexp.MustCompile(`\\(.)`)
+	return re.ReplaceAllString(fp, "$1")
 }
 
 func extractFileNames(input string) []string {
-	// Regex to match file paths starting with optional drive letter, / ./ \ or .\ and include escaped or unescaped spaces (\ or %20)
+	// Regex to match file paths starting with optional drive letter, / ./ ~/ \ or .\ and include escaped or unescaped spaces (\ or %20)
 	// and followed by more characters and a file extension
 	// This will capture non filename strings, but we'll check for file existence to remove mismatches
-	regexPattern := `(?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp|wav)\b`
+	regexPattern := `(?:[a-zA-Z]:)?(?:\./|~/|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp|wav)\b`
 	re := regexp.MustCompile(regexPattern)
 
 	return re.FindAllString(input, -1)

--- a/cmd/interactive_test.go
+++ b/cmd/interactive_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -139,5 +140,16 @@ func TestNormalizeFilePath(t *testing.T) {
 	fp = `/tmp/test_\!_\"image\".jpg`
 	normalized = normalizeFilePath(fp)
 	assert.Equal(t, `/tmp/test_!_"image".jpg`, filepath.ToSlash(normalized))
+
+	// Windows path normalization
+	if runtime.GOOS == "windows" {
+		fp = `c:\users\jdoe\eight.png`
+		normalized = normalizeFilePath(fp)
+		assert.Equal(t, `c:\users\jdoe\eight.png`, normalized)
+
+		fp = `c:\users\jdoe\my\ image.png`
+		normalized = normalizeFilePath(fp)
+		assert.Equal(t, `c:\users\jdoe\my image.png`, normalized)
+	}
 }
 

--- a/cmd/interactive_test.go
+++ b/cmd/interactive_test.go
@@ -62,6 +62,12 @@ d:\path with\spaces\thirteen.WEBP some ending
 	assert.Contains(t, res[11], "c:")
 	assert.Contains(t, res[12], "thirteen.WEBP")
 	assert.Contains(t, res[12], "d:")
+
+	// Tilde style paths
+	input = ` some preamble ~/Library/Mobile\ Documents/com\~apple\~CloudDocs/screenshots/CleanShot\ 2025-04-17\ at\ 21.26.40@2x.png `
+	res = extractFileNames(input)
+	assert.Len(t, res, 1)
+	assert.Contains(t, res[0], "CleanShot")
 }
 
 // Ensure that file paths wrapped in single quotes are removed with the quotes.
@@ -114,3 +120,24 @@ func TestExtractFileDataWAV(t *testing.T) {
 	assert.Len(t, imgs, 1)
 	assert.Equal(t, "before  after", cleaned)
 }
+
+func TestNormalizeFilePath(t *testing.T) {
+	// Standard home dir mock for test validation
+	t.Setenv("HOME", "/Users/ollama")
+
+	// Escaped path
+	fp := `~/Library/Mobile\ Documents/com\~apple\~CloudDocs/screenshots/CleanShot\ 2025-04-17\ at\ 21.26.40@2x.png`
+	normalized := normalizeFilePath(fp)
+	assert.Equal(t, "/Users/ollama/Library/Mobile Documents/com~apple~CloudDocs/screenshots/CleanShot 2025-04-17 at 21.26.40@2x.png", filepath.ToSlash(normalized))
+
+	// Quoted path
+	fp = `"/Users/ollama/Library/Mobile Documents/CleanShot.png"`
+	normalized = normalizeFilePath(fp)
+	assert.Equal(t, "/Users/ollama/Library/Mobile Documents/CleanShot.png", filepath.ToSlash(normalized))
+
+	// Escaped exclamation mark and double quotes
+	fp = `/tmp/test_\!_\"image\".jpg`
+	normalized = normalizeFilePath(fp)
+	assert.Equal(t, `/tmp/test_!_"image".jpg`, filepath.ToSlash(normalized))
+}
+


### PR DESCRIPTION
### Description
This Pull Request resolves a long-standing CLI path parsing issue ([#10333](https://github.com/ollama/ollama/issues/10333)) where dragging and dropping image files with embedded tildes, single quotes, double quotes, or mixed shell-escaped characters (like `\ `, `\~`, `\!`, `\"`) silently fails in the CLI because of a rigid, hardcoded unescaped replacement list inside the path normalizer.

### Root Cause
The previous implementation of `normalizeFilePath` relied on a static `strings.NewReplacer` which replaced only a handful of hardcoded character sequences like `\ `, `\~`, `\!`, `\"`. However, different shells (bash, zsh, fish) and OS drag-and-drop mechanisms escape characters differently, often resulting in unhandled escape combinations (e.g., double-backslashes `\\~` matching `\\` first, leaving `\~` instead of expanding to `~`). Furthermore, dragging-and-dropping folders/files containing spaces can wrap the entire path in single or double quotes, which were not stripped.

### Solution
1. **Generic Backslash Unescaping:** Replaced the static, fragile replacement list with a robust, generic regex-based backslash unescaper: any backslash followed by a character is replaced with that character (`\\(.)` -> `$1`). This matches native shell behavior.
2. **Quote Stripping:** Automatically trims leading/trailing single (`'`) and double (`"`) quotes from the file path.
3. **Tilde expansion:** Automatically expands `~/` Unix home directory shortcuts to the user's home directory.
4. **Added Unit Tests:** Added regression tests in `interactive_test.go` verifying tilde matching in `extractFileNames` and comprehensive normalization behaviors in `normalizeFilePath` (escaped spaces, quotes, tildes, special symbols).

This provides a premium, robust experience for CLI users across macOS, Linux, and Windows who drag-and-drop multi-modal inputs (like images) into their local terminal.