### PR TITLE
[codex] launch: support Codex profile v2

### DIFF
--- a/cmd/launch/codex.go
+++ b/cmd/launch/codex.go
@@ -108,16 +108,100 @@ func codexModelCatalogPathForConfig(configPath string) string {
 	return filepath.Join(filepath.Dir(configPath), "model.json")
 }
 
-// writeCodexProfile ensures ~/.codex/config.toml has the ollama-launch profile
-// and model provider sections with the correct base URL.
+func codexProfileConfigPathForConfig(configPath, profileName string) string {
+	return filepath.Join(filepath.Dir(configPath), profileName+".config.toml")
+}
+
+// writeCodexProfile ensures Codex has an ollama-launch profile using Codex's
+// profile-v2 layout: provider config in ~/.codex/config.toml and profile
+// settings in ~/.codex/ollama-launch.config.toml.
 func writeCodexProfile(configPath string, modelCatalogPath ...string) error {
-	opts := codexLaunchProfileOptions{
-		forceAPIAuth: true,
+	baseURL := codexBaseURL()
+	profileName := codexProfileName
+	profileConfigPath := codexProfileConfigPathForConfig(configPath, profileName)
+
+	content, readErr := os.ReadFile(configPath)
+	text := ""
+	if readErr == nil {
+		text = string(content)
+	} else if !os.IsNotExist(readErr) {
+		return readErr
 	}
-	if len(modelCatalogPath) > 0 {
-		opts.modelCatalogPath = modelCatalogPath[0]
+	parsed, err := codexParseConfig(text)
+	if err != nil {
+		return err
 	}
-	return writeCodexLaunchProfile(configPath, opts)
+
+	profileContent, profileReadErr := os.ReadFile(profileConfigPath)
+	profileText := ""
+	if profileReadErr == nil {
+		profileText = string(profileContent)
+	} else if !os.IsNotExist(profileReadErr) {
+		return profileReadErr
+	}
+	profileParsed, err := codexParseConfig(profileText)
+	if err != nil {
+		return err
+	}
+
+	model := profileParsed.RootString(codexRootModelKey)
+	if model == "" {
+		model = profileParsed.ProfileString(profileName, codexRootModelKey)
+	}
+	if model == "" {
+		model = parsed.ProfileString(profileName, codexRootModelKey)
+	}
+	catalogPath := profileParsed.RootString(codexRootModelCatalogJSONKey)
+	if catalogPath == "" {
+		catalogPath = profileParsed.ProfileString(profileName, codexRootModelCatalogJSONKey)
+	}
+	if catalogPath == "" {
+		catalogPath = parsed.ProfileString(profileName, codexRootModelCatalogJSONKey)
+	}
+	if len(modelCatalogPath) > 0 && strings.TrimSpace(modelCatalogPath[0]) != "" {
+		catalogPath = strings.TrimSpace(modelCatalogPath[0])
+	}
+
+	text = codexRemoveRootValue(text, codexRootProfileKey)
+	text = codexRemoveSection(text, codexProfileHeaderFor(profileName))
+	text = codexUpsertSection(text, codexProviderHeaderFor(profileName), []string{
+		fmt.Sprintf("name = %q", codexProviderName),
+		fmt.Sprintf("base_url = %q", baseURL),
+		`wire_api = "responses"`,
+	})
+
+	profileText = codexRemoveRootValue(profileText, codexRootProfileKey)
+	profileText = codexRemoveSection(profileText, codexProfileHeaderFor(profileName))
+	profileText = codexRemoveSection(profileText, codexProviderHeaderFor(profileName))
+	if model != "" {
+		profileText = codexSetRootStringValue(profileText, codexRootModelKey, model)
+	}
+	profileText = codexSetRootStringValue(profileText, "openai_base_url", baseURL)
+	profileText = codexSetRootStringValue(profileText, codexRootModelProviderKey, profileName)
+	profileText = codexSetRootStringValue(profileText, "forced_login_method", "api")
+	if catalogPath != "" {
+		profileText = codexSetRootStringValue(profileText, codexRootModelCatalogJSONKey, catalogPath)
+	}
+
+	parsed, err = codexParseConfig(text)
+	if err != nil {
+		return err
+	}
+	profileParsed, err = codexParseConfig(profileText)
+	if err != nil {
+		return err
+	}
+	if err := codexValidateProfileV2Text(parsed, profileParsed, profileName, model, catalogPath, baseURL); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		return err
+	}
+	if err := fileutil.WriteWithBackup(configPath, []byte(text)); err != nil {
+		return err
+	}
+	return fileutil.WriteWithBackup(profileConfigPath, []byte(profileText))
 }
 
 type codexLaunchProfileOptions struct {
@@ -300,6 +384,48 @@ func codexValidateLaunchProfileText(config codexParsedConfig, profileName string
 	return nil
 }
 
+func codexValidateProfileV2Text(config, profileConfig codexParsedConfig, profileName, model, modelCatalogPath, baseURL string) error {
+	if config.Exists("profiles", profileName) {
+		return fmt.Errorf("generated Codex config still contains legacy profiles.%s table", profileName)
+	}
+	if got, ok := config.RootStringOK(codexRootProfileKey); ok {
+		return fmt.Errorf("generated Codex config still contains legacy profile = %q", got)
+	}
+	if profileConfig.Exists("profiles", profileName) {
+		return fmt.Errorf("generated Codex profile config still contains legacy profiles.%s table", profileName)
+	}
+	if got, ok := profileConfig.RootStringOK(codexRootProfileKey); ok {
+		return fmt.Errorf("generated Codex profile config still contains legacy profile = %q", got)
+	}
+	for _, check := range []struct {
+		config codexParsedConfig
+		path   []string
+		want   string
+	}{
+		{profileConfig, []string{"openai_base_url"}, baseURL},
+		{profileConfig, []string{codexRootModelProviderKey}, profileName},
+		{profileConfig, []string{"forced_login_method"}, "api"},
+		{config, []string{"model_providers", profileName, "name"}, codexProviderName},
+		{config, []string{"model_providers", profileName, "base_url"}, baseURL},
+		{config, []string{"model_providers", profileName, "wire_api"}, "responses"},
+	} {
+		if got, ok := check.config.String(check.path...); !ok || got != check.want {
+			return fmt.Errorf("generated Codex config missing %s = %q", strings.Join(check.path, "."), check.want)
+		}
+	}
+	if model != "" {
+		if got, ok := profileConfig.String(codexRootModelKey); !ok || got != model {
+			return fmt.Errorf("generated Codex profile config missing model = %q", model)
+		}
+	}
+	if modelCatalogPath != "" {
+		if got, ok := profileConfig.String(codexRootModelCatalogJSONKey); !ok || got != modelCatalogPath {
+			return fmt.Errorf("generated Codex profile config missing model_catalog_json = %q", modelCatalogPath)
+		}
+	}
+	return nil
+}
+
 func codexUpsertSection(text, header string, lines []string) string {
 	block := strings.Join(append([]string{header}, lines...), "\n") + "\n"
 
@@ -354,6 +480,24 @@ func (c codexParsedConfig) String(path ...string) (string, bool) {
 		return "", false
 	}
 	return value, true
+}
+
+func (c codexParsedConfig) Exists(path ...string) bool {
+	if len(path) == 0 {
+		return false
+	}
+	var current any = c.values
+	for _, part := range path {
+		table, ok := current.(map[string]any)
+		if !ok {
+			return false
+		}
+		current, ok = table[part]
+		if !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func (c codexParsedConfig) RootString(key string) string {

--- a/cmd/launch/codex_test.go
+++ b/cmd/launch/codex_test.go
@@ -45,6 +45,7 @@ func TestWriteCodexProfile(t *testing.T) {
 	t.Run("creates new file when none exists", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		configPath := filepath.Join(tmpDir, "config.toml")
+		profilePath := codexProfileConfigPathForConfig(configPath, codexProfileName)
 		catalogPath := filepath.Join(tmpDir, "model.json")
 
 		if err := writeCodexProfile(configPath, catalogPath); err != nil {
@@ -57,22 +58,27 @@ func TestWriteCodexProfile(t *testing.T) {
 		}
 
 		content := string(data)
-		if !strings.Contains(content, "[profiles.ollama-launch]") {
-			t.Error("missing [profiles.ollama-launch] header")
+		profileData, err := os.ReadFile(profilePath)
+		if err != nil {
+			t.Fatal(err)
 		}
-		if !strings.Contains(content, "openai_base_url") {
+		profileContent := string(profileData)
+		if strings.Contains(content, "[profiles.ollama-launch]") {
+			t.Error("main config should not contain legacy [profiles.ollama-launch] header")
+		}
+		if !strings.Contains(profileContent, "openai_base_url") {
 			t.Error("missing openai_base_url key")
 		}
-		if !strings.Contains(content, "/v1/") {
+		if !strings.Contains(profileContent, "/v1/") {
 			t.Error("missing /v1/ suffix in base URL")
 		}
-		if !strings.Contains(content, `forced_login_method = "api"`) {
+		if !strings.Contains(profileContent, `forced_login_method = "api"`) {
 			t.Error("missing forced_login_method key")
 		}
-		if !strings.Contains(content, `model_provider = "ollama-launch"`) {
+		if !strings.Contains(profileContent, `model_provider = "ollama-launch"`) {
 			t.Error("missing model_provider key")
 		}
-		if !strings.Contains(content, fmt.Sprintf("model_catalog_json = %q", catalogPath)) {
+		if !strings.Contains(profileContent, fmt.Sprintf("model_catalog_json = %q", catalogPath)) {
 			t.Error("missing model_catalog_json key")
 		}
 		if !strings.Contains(content, "[model_providers.ollama-launch]") {
@@ -83,6 +89,9 @@ func TestWriteCodexProfile(t *testing.T) {
 		}
 		if err := codexValidateConfigText(content); err != nil {
 			t.Fatalf("generated config should be valid TOML: %v\n%s", err, content)
+		}
+		if err := codexValidateConfigText(profileContent); err != nil {
+			t.Fatalf("generated profile config should be valid TOML: %v\n%s", err, profileContent)
 		}
 	})
 
@@ -103,8 +112,50 @@ func TestWriteCodexProfile(t *testing.T) {
 		if !strings.Contains(content, "[some_other_section]") {
 			t.Error("existing section was removed")
 		}
-		if !strings.Contains(content, "[profiles.ollama-launch]") {
-			t.Error("missing [profiles.ollama-launch] header")
+		if strings.Contains(content, "[profiles.ollama-launch]") {
+			t.Error("main config should not contain legacy [profiles.ollama-launch] header")
+		}
+		profileData, err := os.ReadFile(codexProfileConfigPathForConfig(configPath, codexProfileName))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(profileData), `model_provider = "ollama-launch"`) {
+			t.Error("missing model_provider in profile config")
+		}
+	})
+
+	t.Run("preserves existing profile config settings", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.toml")
+		profilePath := codexProfileConfigPathForConfig(configPath, codexProfileName)
+		profileText := "" +
+			`approval_policy = "on-request"` + "\n\n" +
+			`[profiles.ollama-launch]` + "\n" +
+			`model = "profile-file-legacy"` + "\n\n" +
+			`[model_providers.ollama-launch]` + "\n" +
+			`name = "Old"` + "\n" +
+			`base_url = "http://old:1234/v1/"` + "\n"
+		if err := os.WriteFile(profilePath, []byte(profileText), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := writeCodexProfile(configPath); err != nil {
+			t.Fatal(err)
+		}
+
+		data, err := os.ReadFile(profilePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		content := string(data)
+		if !strings.Contains(content, `approval_policy = "on-request"`) {
+			t.Fatalf("existing profile setting was not preserved, got:\n%s", content)
+		}
+		if !strings.Contains(content, `model = "profile-file-legacy"`) {
+			t.Fatalf("legacy profile file model was not migrated, got:\n%s", content)
+		}
+		if strings.Contains(content, "[profiles.ollama-launch]") || strings.Contains(content, "[model_providers.ollama-launch]") {
+			t.Fatalf("legacy managed sections should be removed from profile config, got:\n%s", content)
 		}
 	})
 
@@ -112,7 +163,7 @@ func TestWriteCodexProfile(t *testing.T) {
 		tmpDir := t.TempDir()
 		configPath := filepath.Join(tmpDir, "config.toml")
 		catalogPath := filepath.Join(tmpDir, "model.json")
-		existing := "[profiles.ollama-launch]\nopenai_base_url = \"http://old:1234/v1/\"\n\n[model_providers.ollama-launch]\nname = \"Ollama\"\nbase_url = \"http://old:1234/v1/\"\n"
+		existing := "profile = \"ollama-launch\"\n\n[profiles.ollama-launch]\nopenai_base_url = \"http://old:1234/v1/\"\nmodel = \"saved-model\"\n\n[model_providers.ollama-launch]\nname = \"Ollama\"\nbase_url = \"http://old:1234/v1/\"\n"
 		os.WriteFile(configPath, []byte(existing), 0o644)
 
 		if err := writeCodexProfile(configPath, catalogPath); err != nil {
@@ -125,14 +176,28 @@ func TestWriteCodexProfile(t *testing.T) {
 		if strings.Contains(content, "old:1234") {
 			t.Error("old URL was not replaced")
 		}
-		if strings.Count(content, "[profiles.ollama-launch]") != 1 {
-			t.Errorf("expected exactly one [profiles.ollama-launch] section, got %d", strings.Count(content, "[profiles.ollama-launch]"))
+		if strings.Contains(content, `profile = "ollama-launch"`) {
+			t.Error("legacy root profile selector was not removed")
+		}
+		if strings.Contains(content, "[profiles.ollama-launch]") {
+			t.Error("legacy [profiles.ollama-launch] section was not removed")
 		}
 		if strings.Count(content, "[model_providers.ollama-launch]") != 1 {
 			t.Errorf("expected exactly one [model_providers.ollama-launch] section, got %d", strings.Count(content, "[model_providers.ollama-launch]"))
 		}
+		profileData, err := os.ReadFile(codexProfileConfigPathForConfig(configPath, codexProfileName))
+		if err != nil {
+			t.Fatal(err)
+		}
+		profileContent := string(profileData)
+		if !strings.Contains(profileContent, `model = "saved-model"`) {
+			t.Fatalf("legacy model should migrate to profile config, got:\n%s", profileContent)
+		}
 		if err := codexValidateConfigText(content); err != nil {
 			t.Fatalf("generated config should be valid TOML: %v\n%s", err, content)
+		}
+		if err := codexValidateConfigText(profileContent); err != nil {
+			t.Fatalf("generated profile config should be valid TOML: %v\n%s", err, profileContent)
 		}
 	})
 
@@ -158,16 +223,23 @@ func TestWriteCodexProfile(t *testing.T) {
 		content := string(data)
 
 		if strings.Contains(content, `profiles."ollama-launch"`) {
-			t.Fatalf("quoted profile table should be replaced, got:\n%s", content)
+			t.Fatalf("quoted profile table should be removed, got:\n%s", content)
 		}
 		if strings.Contains(content, "old:1234") {
 			t.Fatalf("old URL was not replaced, got:\n%s", content)
 		}
-		if got := codexSectionStringValue(content, codexProfileHeader(), "model_provider"); got != codexProfileName {
-			t.Fatalf("profile model_provider = %q, want %q", got, codexProfileName)
+		if got, ok := codexRootStringValueOK(content, "profile"); ok {
+			t.Fatalf("legacy root profile should be removed, got %q", got)
 		}
 		if got := codexSectionStringValue(content, codexProviderHeader(), "base_url"); !strings.Contains(got, "/v1/") {
 			t.Fatalf("provider base_url = %q, want /v1/ URL", got)
+		}
+		profileData, err := os.ReadFile(codexProfileConfigPathForConfig(configPath, codexProfileName))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := codexRootStringValue(string(profileData), "model_provider"); got != codexProfileName {
+			t.Fatalf("profile config model_provider = %q, want %q", got, codexProfileName)
 		}
 		if err := codexValidateConfigText(content); err != nil {
 			t.Fatalf("generated config should be valid TOML: %v\n%s", err, content)
@@ -188,6 +260,34 @@ func TestWriteCodexProfile(t *testing.T) {
 		data, _ := os.ReadFile(configPath)
 		if string(data) != existing {
 			t.Fatalf("invalid config should be left untouched, got:\n%s", data)
+		}
+	})
+
+	t.Run("rejects invalid existing profile config without writing", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.toml")
+		profilePath := codexProfileConfigPathForConfig(configPath, codexProfileName)
+		existingConfig := "[some_other_section]\nkey = \"value\"\n"
+		existingProfile := "model = \n"
+		if err := os.WriteFile(configPath, []byte(existingConfig), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(profilePath, []byte(existingProfile), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		err := writeCodexProfile(configPath)
+		if err == nil || !strings.Contains(err.Error(), "invalid Codex config TOML") {
+			t.Fatalf("writeCodexProfile error = %v, want invalid TOML", err)
+		}
+
+		configData, _ := os.ReadFile(configPath)
+		if string(configData) != existingConfig {
+			t.Fatalf("invalid profile config should leave config untouched, got:\n%s", configData)
+		}
+		profileData, _ := os.ReadFile(profilePath)
+		if string(profileData) != existingProfile {
+			t.Fatalf("invalid profile config should be left untouched, got:\n%s", profileData)
 		}
 	})
 
@@ -294,6 +394,9 @@ func TestWriteCodexProfile(t *testing.T) {
 		if strings.Contains(content, "old:1234") {
 			t.Error("old URL was not replaced")
 		}
+		if strings.Contains(content, "[profiles.ollama-launch]") {
+			t.Error("legacy [profiles.ollama-launch] section was not removed")
+		}
 		if !strings.Contains(content, "[another_section]") {
 			t.Error("following section was removed")
 		}
@@ -316,8 +419,11 @@ func TestWriteCodexProfile(t *testing.T) {
 		data, _ := os.ReadFile(configPath)
 		content := string(data)
 
-		if !strings.Contains(content, "[profiles.ollama-launch]") {
-			t.Error("missing [profiles.ollama-launch] header")
+		if strings.Contains(content, "[profiles.ollama-launch]") {
+			t.Error("main config should not contain legacy [profiles.ollama-launch] header")
+		}
+		if !strings.Contains(content, "[model_providers.ollama-launch]") {
+			t.Error("missing [model_providers.ollama-launch] header")
 		}
 		// Should not have double blank lines from missing trailing newline
 		if strings.Contains(content, "\n\n\n") {
@@ -337,9 +443,16 @@ func TestWriteCodexProfile(t *testing.T) {
 
 		data, _ := os.ReadFile(configPath)
 		content := string(data)
+		profileData, err := os.ReadFile(codexProfileConfigPathForConfig(configPath, codexProfileName))
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		if !strings.Contains(content, "myhost:9999/v1/") {
 			t.Errorf("expected custom host in URL, got:\n%s", content)
+		}
+		if !strings.Contains(string(profileData), "myhost:9999/v1/") {
+			t.Errorf("expected custom host in profile config, got:\n%s", profileData)
 		}
 	})
 
@@ -354,12 +467,16 @@ func TestWriteCodexProfile(t *testing.T) {
 
 		data, _ := os.ReadFile(configPath)
 		content := string(data)
-
-		if strings.Contains(content, "0.0.0.0") {
-			t.Fatalf("config should not write bind-only host, got:\n%s", content)
+		profileData, err := os.ReadFile(codexProfileConfigPathForConfig(configPath, codexProfileName))
+		if err != nil {
+			t.Fatal(err)
 		}
-		if !strings.Contains(content, "127.0.0.1:11434/v1/") {
-			t.Fatalf("expected connectable loopback URL, got:\n%s", content)
+
+		if strings.Contains(content, "0.0.0.0") || strings.Contains(string(profileData), "0.0.0.0") {
+			t.Fatalf("config should not write bind-only host, got:\n%s\n%s", content, profileData)
+		}
+		if !strings.Contains(content, "127.0.0.1:11434/v1/") || !strings.Contains(string(profileData), "127.0.0.1:11434/v1/") {
+			t.Fatalf("expected connectable loopback URL, got:\n%s\n%s", content, profileData)
 		}
 	})
 }
@@ -380,11 +497,19 @@ func TestEnsureCodexConfig(t *testing.T) {
 		}
 
 		content := string(data)
-		if !strings.Contains(content, "[profiles.ollama-launch]") {
-			t.Error("missing [profiles.ollama-launch] header")
+		if strings.Contains(content, "[profiles.ollama-launch]") {
+			t.Error("main config should not contain legacy [profiles.ollama-launch] header")
 		}
-		if !strings.Contains(content, "openai_base_url") {
-			t.Error("missing openai_base_url key")
+		if !strings.Contains(content, "[model_providers.ollama-launch]") {
+			t.Error("missing [model_providers.ollama-launch] header")
+		}
+		profilePath := filepath.Join(tmpDir, ".codex", "ollama-launch.config.toml")
+		profileData, err := os.ReadFile(profilePath)
+		if err != nil {
+			t.Fatalf("profile config not created: %v", err)
+		}
+		if !strings.Contains(string(profileData), "openai_base_url") {
+			t.Error("missing openai_base_url key in profile config")
 		}
 
 		catalogPath := filepath.Join(tmpDir, ".codex", "model.json")
@@ -412,11 +537,19 @@ func TestEnsureCodexConfig(t *testing.T) {
 		data, _ := os.ReadFile(configPath)
 		content := string(data)
 
-		if strings.Count(content, "[profiles.ollama-launch]") != 1 {
-			t.Errorf("expected exactly one [profiles.ollama-launch] section after two calls, got %d", strings.Count(content, "[profiles.ollama-launch]"))
+		if strings.Count(content, "[profiles.ollama-launch]") != 0 {
+			t.Errorf("expected no [profiles.ollama-launch] section after two calls, got %d", strings.Count(content, "[profiles.ollama-launch]"))
 		}
 		if strings.Count(content, "[model_providers.ollama-launch]") != 1 {
 			t.Errorf("expected exactly one [model_providers.ollama-launch] section after two calls, got %d", strings.Count(content, "[model_providers.ollama-launch]"))
+		}
+		profilePath := filepath.Join(tmpDir, ".codex", "ollama-launch.config.toml")
+		profileData, err := os.ReadFile(profilePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Count(string(profileData), `model_provider = "ollama-launch"`) != 1 {
+			t.Fatalf("expected profile config model_provider exactly once, got:\n%s", profileData)
 		}
 	})
 }

--- a/docs/integrations/codex.mdx
+++ b/docs/integrations/codex.mdx
@@ -52,20 +52,31 @@ codex --oss -m gpt-oss:120b-cloud
 
 ### Profile-based setup
 
-For a persistent configuration, add an Ollama provider and profiles to `~/.codex/config.toml`:
+For a persistent configuration, add an Ollama provider to `~/.codex/config.toml`:
 
 ```toml
 [model_providers.ollama-launch]
 name = "Ollama"
-base_url = "http://localhost:11434/v1"
+base_url = "http://localhost:11434/v1/"
+wire_api = "responses"
+```
 
-[profiles.ollama-launch]
+Then create `~/.codex/ollama-launch.config.toml`:
+
+```toml
 model = "gpt-oss:120b"
 model_provider = "ollama-launch"
+openai_base_url = "http://localhost:11434/v1/"
+forced_login_method = "api"
+```
 
-[profiles.ollama-cloud]
+For a cloud model, create `~/.codex/ollama-cloud.config.toml`:
+
+```toml
 model = "gpt-oss:120b-cloud"
 model_provider = "ollama-launch"
+openai_base_url = "http://localhost:11434/v1/"
+forced_login_method = "api"
 ```
 
 Then run:


### PR DESCRIPTION
## Summary

Fixes #16348.

Updates `ollama launch codex` for Codex CLI 0.134+ profile v2 behavior. The launcher now keeps the Ollama model provider in `~/.codex/config.toml` and writes per-profile settings to `~/.codex/ollama-launch.config.toml` instead of recreating the legacy `[profiles.ollama-launch]` table that Codex rejects.

The migration removes legacy root `profile = ...` selectors and the Ollama-managed `[profiles.ollama-launch]` table, preserves unrelated user profile tables, and keeps non-managed settings already present in `ollama-launch.config.toml`.

## Validation

- `go test ./cmd/launch -count=1`
- `git diff --check`
- Built a local Ollama binary with `go build -o /tmp/ollama-codex-profile-v2 .`
- Ran the built binary with a temporary `HOME`, a local test Ollama API, and a fake `codex` executable:
  - `ollama launch codex --model llama3.2 --yes`
  - confirmed it generated `~/.codex/config.toml` with only `[model_providers.ollama-launch]`
  - confirmed it generated `~/.codex/ollama-launch.config.toml` with top-level `openai_base_url`, `model_provider`, `forced_login_method`, and `model_catalog_json`
  - confirmed no `profile = ...` selector or `[profiles.ollama-launch]` table was written
  - confirmed the fake `codex` was invoked with `--profile ollama-launch`, `-c model_catalog_json=...`, `-m llama3.2`, and `OPENAI_API_KEY=ollama`
- Loaded the generated temporary profile with real `codex-cli 0.135.0`; Codex selected `provider: ollama-launch` and did not emit the legacy-profile config error. It later retried the model request as expected because the local test API did not implement `/v1/responses`.
