### PR TITLE
docs: fix non-expanding quoted ~ in macOS uninstall and stale Pi npm package (#16338)

### DIFF
--- a/docs/macos.mdx
+++ b/docs/macos.mdx
@@ -35,8 +35,8 @@ To fully remove Ollama from your system, remove the following files and folders:
 ```
 sudo rm -rf /Applications/Ollama.app
 sudo rm /usr/local/bin/ollama
-rm -rf "~/Library/Application Support/Ollama"
-rm -rf "~/Library/Saved Application State/com.electron.ollama.savedState"
+rm -rf "$HOME/Library/Application Support/Ollama"
+rm -rf "$HOME/Library/Saved Application State/com.electron.ollama.savedState"
 rm -rf ~/Library/Caches/com.electron.ollama/
 rm -rf ~/Library/Caches/ollama
 rm -rf ~/Library/WebKit/com.electron.ollama


### PR DESCRIPTION
## What

Fixes two of the documentation issues reported in #16338:

### 1. macOS uninstall commands — quoted `~` does not expand (`docs/macos.mdx`)

The first two `rm -rf` lines wrapped the path in double quotes:

```sh
rm -rf "~/Library/Application Support/Ollama"
rm -rf "~/Library/Saved Application State/com.electron.ollama.savedState"
```

In bash/zsh, `~` is **not** expanded inside quotes, so these commands target a
literal `./~/Library/...` directory in the current working directory rather than
the user's home — the actual files are never removed. (The other lines in the
same block are unquoted and work correctly.)

Switched the quoted paths to `"$HOME/..."`, which expands inside double quotes
while still tolerating the spaces in `Application Support` / `Saved Application State`.

### 2. Pi integration — stale npm package scope (`docs/integrations/pi.mdx`)

`@mariozechner/pi-coding-agent` is deprecated. Its npm registry entry now reads:

> please use @earendil-works/pi-coding-agent instead going forward

Updated the install command to the maintained `@earendil-works/pi-coding-agent` package.

## Scope note

#16338 lists five items. This PR intentionally covers only the two
unambiguous, independently-verifiable doc fixes (#4 and #5 in the issue).
The others are left for maintainer judgement:
- the `ggerganov` → `ggml-org` link updates (#1) — `llama/README.md` no longer exists on `main`;
- the web-search JS examples (#2) — appears intentional and is under active discussion in the issue;
- the Anthropic ping/error stream events (#3) — depends on runtime behavior of `StreamConverter` and is better confirmed by a maintainer.

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
