### PR TITLE
fix: honor Codex App num_ctx metadata

### DIFF
--- a/cmd/launch/codex_app.go
+++ b/cmd/launch/codex_app.go
@@ -240,6 +240,10 @@ func (c *CodexApp) RequiresInteractiveOnboarding() bool {
 	return false
 }
 
+func (c *CodexApp) EnrichModelMetadataFromShow() bool {
+	return true
+}
+
 func (c *CodexApp) RestoreHint() string {
 	return codexAppRestoreHint
 }
@@ -446,13 +450,30 @@ func codexAppDefaultModelMetadata() codexAppModelMetadata {
 
 func codexAppModelMetadataFromLaunchModel(model LaunchModel) codexAppModelMetadata {
 	metadata := codexAppDefaultModelMetadata()
-	if model.ContextLength > 0 {
+	if numCtx, ok := modelfileNumCtx(model.Parameters); ok {
+		metadata.contextWindow = numCtx
+	} else if model.ContextLength > 0 {
 		metadata.contextWindow = model.ContextLength
 	}
 	if model.HasCapability("vision") {
 		metadata.inputModalities = []string{"text", "image"}
 	}
 	return metadata
+}
+
+func modelfileNumCtx(parameters string) (int, bool) {
+	for _, line := range strings.Split(parameters, "\n") {
+		fields := strings.Fields(strings.TrimSpace(line))
+		if len(fields) < 2 || strings.ToLower(fields[0]) != "num_ctx" {
+			continue
+		}
+		value := strings.Trim(fields[1], `"'`)
+		numCtx, err := strconv.Atoi(value)
+		if err == nil && numCtx > 0 {
+			return numCtx, true
+		}
+	}
+	return 0, false
 }
 
 func codexAppCatalogEntry(model string, metadata codexAppModelMetadata, priority int, baseInstructions string) map[string]any {

--- a/cmd/launch/codex_app_test.go
+++ b/cmd/launch/codex_app_test.go
@@ -631,7 +631,7 @@ func TestCodexAppConfigurePopulatesCatalogFromEnrichedModels(t *testing.T) {
 	setTestHome(t, tmpDir)
 
 	models := []LaunchModel{
-		{Name: "gemma4", ContextLength: 65536 + len("gemma4"), Capabilities: []model.Capability{model.CapabilityVision}},
+		{Name: "gemma4", Parameters: "num_ctx 32768\n", ContextLength: 65536 + len("gemma4"), Capabilities: []model.Capability{model.CapabilityVision}},
 		{Name: "qwen3:8b"},
 		{Name: "llama3.2"},
 	}
@@ -675,7 +675,7 @@ func TestCodexAppConfigurePopulatesCatalogFromEnrichedModels(t *testing.T) {
 		wantContext := float64(128000)
 		wantModalities := []string{"text"}
 		if slug == "gemma4" {
-			wantContext = float64(65536 + len(slug))
+			wantContext = float64(32768)
 			wantModalities = []string{"text", "image"}
 		}
 		if model["context_window"] != wantContext {
@@ -730,6 +730,28 @@ func TestCodexAppConfigureCatalogIncludesExactSelectedModel(t *testing.T) {
 	}
 	if got := catalog.Models[0]["context_window"]; got != float64(65_536) {
 		t.Fatalf("selected model context_window = %v, want 65536", got)
+	}
+}
+
+func TestModelfileNumCtx(t *testing.T) {
+	tests := []struct {
+		name       string
+		parameters string
+		want       int
+		wantOK     bool
+	}{
+		{name: "plain", parameters: "temperature 0.3\nnum_ctx 32768\n", want: 32768, wantOK: true},
+		{name: "quoted", parameters: "num_ctx \"16384\"\n", want: 16384, wantOK: true},
+		{name: "invalid", parameters: "num_ctx nope\n", wantOK: false},
+		{name: "missing", parameters: "temperature 0.3\n", wantOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := modelfileNumCtx(tt.parameters)
+			if ok != tt.wantOK || got != tt.want {
+				t.Fatalf("modelfileNumCtx() = %d, %v; want %d, %v", got, ok, tt.want, tt.wantOK)
+			}
+		})
 	}
 }
 

--- a/cmd/launch/launch.go
+++ b/cmd/launch/launch.go
@@ -170,6 +170,12 @@ type ManagedModelListConfigurer interface {
 	ConfigureWithModels(primary string, models []LaunchModel) error
 }
 
+// ManagedShowMetadataConfigurer marks managed integrations that need /api/show
+// metadata for their generated model catalog.
+type ManagedShowMetadataConfigurer interface {
+	EnrichModelMetadataFromShow() bool
+}
+
 // ManagedAutodiscoveryIntegration is for managed integrations that do not need
 // a launcher-selected model because the app discovers available models itself.
 type ManagedAutodiscoveryIntegration interface {
@@ -799,7 +805,11 @@ func (c *launcherClient) launchManagedSingleIntegration(ctx context.Context, nam
 		if err != nil {
 			return err
 		}
-		if err := prepareManagedSingleIntegration(name, managed, target, c.modelInventory().Resolve(ctx, configureModels)); err != nil {
+		launchModels := c.modelInventory().Resolve(ctx, configureModels)
+		if showMetadata, ok := managed.(ManagedShowMetadataConfigurer); ok && showMetadata.EnrichModelMetadataFromShow() {
+			launchModels = c.modelInventory().withShowMetadata(ctx, launchModels)
+		}
+		if err := prepareManagedSingleIntegration(name, managed, target, launchModels); err != nil {
 			return err
 		}
 		if refresher, ok := managed.(ManagedRuntimeRefresher); ok {

--- a/cmd/launch/model_inventory.go
+++ b/cmd/launch/model_inventory.go
@@ -17,6 +17,7 @@ type LaunchModel struct {
 	Remote          bool
 	ToolCapable     bool
 	Capabilities    []modelpkg.Capability
+	Parameters      string
 	ContextLength   int
 	MaxOutputTokens int
 	EmbeddingLength int
@@ -114,6 +115,29 @@ func (i *modelInventory) Resolve(ctx context.Context, names []string) []LaunchMo
 		}
 	}
 	return resolved
+}
+
+func (i *modelInventory) ResolveWithShowMetadata(ctx context.Context, names []string) []LaunchModel {
+	return i.withShowMetadata(ctx, i.Resolve(ctx, names))
+}
+
+func (i *modelInventory) withShowMetadata(ctx context.Context, models []LaunchModel) []LaunchModel {
+	if i == nil || i.client == nil {
+		return models
+	}
+	for idx := range models {
+		model := models[idx]
+		if model.Name == "" || model.Remote || isCloudModelName(model.Name) {
+			continue
+		}
+		resp, err := i.client.Show(ctx, &api.ShowRequest{Model: model.Name})
+		if err != nil {
+			continue
+		}
+		model.Parameters = resp.Parameters
+		models[idx] = model
+	}
+	return models
 }
 
 func resolveLaunchModels(names []string, models []LaunchModel) ([]LaunchModel, bool) {

--- a/cmd/launch/model_inventory_test.go
+++ b/cmd/launch/model_inventory_test.go
@@ -49,6 +49,31 @@ func TestModelInventoryResolveRefreshesLocalMiss(t *testing.T) {
 	}
 }
 
+func TestModelInventoryResolveKeepsShowParameters(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/tags":
+			fmt.Fprint(w, `{"models":[{"name":"gemma4-fast","size":123,"details":{"context_length":262144}}]}`)
+		case "/api/show":
+			fmt.Fprint(w, `{"parameters":"num_ctx 32768\n","model_info":{"general.context_length":262144}}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	u, _ := url.Parse(srv.URL)
+	inventory := newModelInventory(api.NewClient(u, srv.Client()))
+
+	got := inventory.ResolveWithShowMetadata(context.Background(), []string{"gemma4-fast"})
+	if len(got) != 1 {
+		t.Fatalf("Resolve returned %d models, want 1", len(got))
+	}
+	if got[0].Parameters != "num_ctx 32768\n" {
+		t.Fatalf("Parameters = %q, want num_ctx line", got[0].Parameters)
+	}
+}
+
 func TestModelInventoryResolveDoesNotRefreshCloudMiss(t *testing.T) {
 	calls := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
﻿## Summary
- fetch `/api/show` parameters for Codex App catalog generation
- prefer a Modelfile-level `num_ctx` over the base model context length when writing `context_window`
- keep the extra show metadata scoped to managed integrations that opt in, so normal editor launch validation still only checks the primary model

Fixes #16188.

## To verify
- `go test ./cmd/launch -run "TestCodexAppConfigurePopulatesCatalogFromEnrichedModels|TestModelfileNumCtx|TestModelInventoryResolveKeepsShowParameters|TestLaunchIntegration_ConfiguredEditorLaunchValidatesPrimaryOnly" -count=1`
- `go test ./cmd/launch -count=1`
- `git diff --check`
