### PR TITLE
cmd: fix nil pointer panic in PushHandler success path

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1068,7 +1068,9 @@ func PushHandler(cmd *cobra.Command, args []string) error {
 	}
 
 	p.Stop()
-	spinner.Stop()
+	if spinner != nil {
+		spinner.Stop()
+	}
 
 	destination := n.String()
 	if strings.HasSuffix(n.Host, ".ollama.ai") || strings.HasSuffix(n.Host, ".ollama.com") {


### PR DESCRIPTION
## Summary

Fixes #16202 — nil pointer dereference panic in `PushHandler` when the server sends only blob-digest responses.

The error path already has a nil guard for `spinner.Stop()`. This adds the same guard to the success path.

## Test Plan

- [x] `go build ./cmd/...` passes
- [x] Push scenario without status responses no longer panics