### PR TITLE
docs: fix web-search JS examples and unsupported Anthropic stream events

### DIFF
--- a/docs/api/anthropic-compatibility.mdx
+++ b/docs/api/anthropic-compatibility.mdx
@@ -339,8 +339,8 @@ claude --model qwen3-coder
 - [x] `content_block_stop`
 - [x] `message_delta`
 - [x] `message_stop`
-- [x] `ping`
-- [x] `error`
+- [ ] `ping`
+- [ ] `error`
 
 ## Models
 

--- a/docs/capabilities/web-search.mdx
+++ b/docs/capabilities/web-search.mdx
@@ -110,7 +110,7 @@ More Ollama [Python example](https://github.com/ollama/ollama-python/blob/main/e
 import { Ollama } from "ollama";
 
 const client = new Ollama();
-const results = await client.webSearch("what is ollama?");
+const results = await client.webSearch({ query: "what is ollama?" });
 console.log(JSON.stringify(results, null, 2));
 ```
 
@@ -213,7 +213,7 @@ models](https://ollama.com/models)\n\nAvailable for macOS, Windows, and Linux',
 import { Ollama } from "ollama";
 
 const client = new Ollama();
-const fetchResult = await client.webFetch("https://ollama.com");
+const fetchResult = await client.webFetch({ url: "https://ollama.com" });
 console.log(JSON.stringify(fetchResult, null, 2));
 ```
 


### PR DESCRIPTION
Two of the five doc gaps from #16338 (parts #2 and #3); #16357 covers the others.

The JS examples on the web-search page passed a plain string to \`webSearch\`/\`webFetch\`, but [ollama-js](https://github.com/ollama/ollama-js/blob/9c92b18d4026/src/browser.ts#L348-L369) expects a request object (\`{ query }\` or \`{ url }\`). Running the snippets as written errors out.

The Anthropic compatibility page also listed \`ping\` and \`error\` stream events as supported, but \`StreamConverter.Process\` in \`anthropic/anthropic.go\` never emits either type. Marked both as unsupported.

For #16338