### PR TITLE
progress: stop leaking the render goroutine

### DIFF
--- a/progress/progress.go
+++ b/progress/progress.go
@@ -27,12 +27,16 @@ type Progress struct {
 
 	pos int
 
-	ticker *time.Ticker
-	states []State
+	// done signals the background render goroutine to exit. It is created in
+	// NewProgress (before the goroutine starts) and closed exactly once by
+	// stopOnce, so stop is idempotent and free of a start/stop race.
+	done     chan struct{}
+	stopOnce sync.Once
+	states   []State
 }
 
 func NewProgress(w io.Writer) *Progress {
-	p := &Progress{w: bufio.NewWriter(w)}
+	p := &Progress{w: bufio.NewWriter(w), done: make(chan struct{})}
 	go p.start()
 	return p
 }
@@ -44,14 +48,19 @@ func (p *Progress) stop() bool {
 		}
 	}
 
-	if p.ticker != nil {
-		p.ticker.Stop()
-		p.ticker = nil
+	stopped := false
+	p.stopOnce.Do(func() {
+		// Closing done makes the start goroutine return; time.Ticker.Stop
+		// alone would not, because it does not close the ticker channel.
+		close(p.done)
+		stopped = true
+	})
+
+	if stopped {
 		p.render()
-		return true
 	}
 
-	return false
+	return stopped
 }
 
 func (p *Progress) Stop() bool {
@@ -127,8 +136,17 @@ func (p *Progress) render() {
 }
 
 func (p *Progress) start() {
-	p.ticker = time.NewTicker(100 * time.Millisecond)
-	for range p.ticker.C {
-		p.render()
+	// The ticker is owned solely by this goroutine, so there is no shared
+	// mutable state to race on. defer Stop releases the ticker on exit.
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			p.render()
+		case <-p.done:
+			return
+		}
 	}
 }

--- a/progress/progress_test.go
+++ b/progress/progress_test.go
@@ -1,0 +1,66 @@
+package progress
+
+import (
+	"io"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// waitForGoroutines polls the live goroutine count until it drops to at most
+// want, or the deadline passes. It returns the last observed count. We poll
+// (rather than sampling once) because goroutine teardown is asynchronous.
+func waitForGoroutines(want int, timeout time.Duration) int {
+	deadline := time.Now().Add(timeout)
+	var n int
+	for {
+		runtime.GC()
+		n = runtime.NumGoroutine()
+		if n <= want || time.Now().After(deadline) {
+			return n
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestProgressStopReleasesGoroutine verifies that Stop terminates the
+// background render goroutine started by NewProgress. Before the fix the
+// goroutine blocked forever on `for range p.ticker.C` (Ticker.Stop does not
+// close the channel), leaking one goroutine per Progress instance.
+func TestProgressStopReleasesGoroutine(t *testing.T) {
+	// Let any goroutines from earlier tests settle first.
+	baseline := waitForGoroutines(runtime.NumGoroutine(), 100*time.Millisecond)
+
+	const n = 50
+	for range n {
+		p := NewProgress(io.Discard)
+		if !p.Stop() {
+			t.Fatal("Stop() returned false on a running Progress")
+		}
+	}
+
+	// After stopping, the goroutine count must return to ~baseline. Allow a
+	// tiny slack for unrelated runtime goroutines, but n (=50) leaked
+	// goroutines is far above any noise.
+	const slack = 5
+	if got := waitForGoroutines(baseline+slack, 2*time.Second); got > baseline+slack {
+		t.Errorf("goroutine leak: started %d Progress instances, %d goroutines still live (baseline %d)", n, got, baseline)
+	}
+}
+
+// TestProgressStopIsIdempotent verifies the bool contract of Stop: the first
+// call stops the Progress (true), later calls are no-ops (false), and calling
+// it repeatedly does not panic (e.g. closing a channel twice).
+func TestProgressStopIsIdempotent(t *testing.T) {
+	p := NewProgress(io.Discard)
+
+	if !p.Stop() {
+		t.Fatal("first Stop() = false, want true")
+	}
+	if p.Stop() {
+		t.Error("second Stop() = true, want false")
+	}
+	if p.StopAndClear() {
+		t.Error("StopAndClear() after Stop() = true, want false")
+	}
+}


### PR DESCRIPTION
What

progress.Progress starts a background goroutine in NewProgress that renders on a ticker. The goroutine was never released when the progress bar stopped, leaking one goroutine per Progress instance.

Why

start() ran the render loop with "for range p.ticker.C". stop() called p.ticker.Stop(), but time.Ticker.Stop does not close the channel, so the range never terminates and the goroutine blocks forever. Every command that shows progress (pull, push, create, run, and so on) leaked a goroutine after the bar was stopped.

There was also a start/stop race: p.ticker is assigned inside the goroutine, so if Stop() ran before that assignment, stop() observed a nil ticker, returned false, and the goroutine still leaked once it set the ticker.

How

Signal shutdown over a done channel selected against the ticker, instead of relying on Ticker.Stop. The ticker is now a local owned solely by the start goroutine, which removes the shared field and its data race. The done channel is closed exactly once via sync.Once, so stop stays idempotent (Stop and StopAndClear both call it) and the start/stop race is gone because done is created in NewProgress before the goroutine starts.


Tests

Added progress/progress_test.go

TestProgressStopReleasesGoroutine creates 50 Progress instances, stops each, and asserts the live goroutine count returns to baseline. It fails before the change (50 leaked goroutines) and passes after.

TestProgressStopIsIdempotent verifies the stop bool contract and that repeated stops do not panic.

go test ./progress/ -race passes