### PR TITLE
x/imagegen: allow long image generations

### DIFF
--- a/x/imagegen/server.go
+++ b/x/imagegen/server.go
@@ -28,6 +28,8 @@ import (
 	"github.com/ollama/ollama/x/imagegen/manifest"
 )
 
+const imagegenHealthCheckTimeout = 200 * time.Millisecond
+
 // Server wraps an MLX runner subprocess to implement llm.LlamaServer.
 //
 // This implementation is compatible with Ollama's scheduler and can be loaded/unloaded
@@ -55,7 +57,7 @@ func NewServer(modelName string) (*Server, error) {
 	return &Server{
 		modelName: modelName,
 		done:      make(chan error, 1),
-		client:    &http.Client{Timeout: 10 * time.Minute},
+		client:    &http.Client{},
 	}, nil
 }
 
@@ -246,7 +248,10 @@ func (s *Server) WaitUntilRunning(ctx context.Context) error {
 			}
 			return errors.New("timeout waiting for mlx runner to start")
 		case <-ticker.C:
-			if err := s.Ping(ctx); err == nil {
+			pingCtx, cancel := context.WithTimeout(ctx, imagegenHealthCheckTimeout)
+			err := s.Ping(pingCtx)
+			cancel()
+			if err == nil {
 				slog.Info("mlx runner is ready", "port", s.port)
 				return nil
 			}

--- a/x/imagegen/server_test.go
+++ b/x/imagegen/server_test.go
@@ -4,9 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"net"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ollama/ollama/llm"
 )
@@ -15,6 +20,60 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return fn(req)
+}
+
+func TestNewServerDoesNotSetFixedClientTimeout(t *testing.T) {
+	if err := CheckPlatformSupport(); err != nil {
+		t.Skip(err)
+	}
+
+	s, err := NewServer("test-model")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.client.Timeout != 0 {
+		t.Fatalf("client timeout = %s, want no fixed timeout", s.client.Timeout)
+	}
+}
+
+func TestWaitUntilRunningHonorsLoadTimeoutWhenHealthHangs(t *testing.T) {
+	t.Setenv("OLLAMA_LOAD_TIMEOUT", "250ms")
+
+	healthServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer healthServer.Close()
+
+	u, err := url.Parse(healthServer.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, portString, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.Atoi(portString)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := &Server{
+		port:   port,
+		done:   make(chan error, 1),
+		client: &http.Client{},
+	}
+
+	start := time.Now()
+	err = s.WaitUntilRunning(context.Background())
+	if err == nil {
+		t.Fatal("expected timeout")
+	}
+	if !strings.Contains(err.Error(), "timeout waiting for mlx runner") {
+		t.Fatalf("error = %v, want timeout waiting for mlx runner", err)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("WaitUntilRunning took %s, want bounded by load timeout", elapsed)
+	}
 }
 
 func newCompletionTestServer(handler func(*http.Request) string) *Server {


### PR DESCRIPTION
Fixes #15107

## Summary
- remove the fixed 10-minute timeout from the imagegen runner HTTP client so long CPU image generations can continue under the caller request context
- keep startup health checks bounded with a short per-ping context so `OLLAMA_LOAD_TIMEOUT` still limits hung runner startup
- add regression coverage for both behaviors

## Issue freshness
- Issue #15107 is open and labeled `bug`.
- Reviewed issue comments; there is no maintainer comment marking it duplicate, invalid, wontfix, fixed, or unreproducible.
- Current `origin/main` (`11be8f6ac87479bbb0cb3370de9f46c678681b53`) still had `client: &http.Client{Timeout: 10 * time.Minute}` in `x/imagegen/server.go`.
- Searched open PRs by issue number and key terms: `15107`, `10 minutes http client timeout image generation CPU`, `x/imagegen timeout`, `image generation timeout CPU`, and `http.Client Timeout imagegen`. I did not find an active PR that changes the local `x/imagegen` runner timeout.

## Verification
- `go test ./x/imagegen`
- `git diff --check`
- Codex review-mode loop completed clean after addressing two review findings about unsupported-platform test behavior and bounded startup health checks.
