### PR TITLE
fix(cmd): improve file path detection for macOS drag-drop paths

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -583,33 +583,80 @@ func NewCreateRequest(name string, opts runOptions) *api.CreateRequest {
 }
 
 func normalizeFilePath(fp string) string {
-	return strings.NewReplacer(
-		"\\ ", " ", // Escaped space
-		"\\(", "(", // Escaped left parenthesis
-		"\\)", ")", // Escaped right parenthesis
-		"\\[", "[", // Escaped left square bracket
-		"\\]", "]", // Escaped right square bracket
-		"\\{", "{", // Escaped left curly brace
-		"\\}", "}", // Escaped right curly brace
-		"\\$", "$", // Escaped dollar sign
-		"\\&", "&", // Escaped ampersand
-		"\\;", ";", // Escaped semicolon
-		"\\'", "'", // Escaped single quote
+	// Remove macOS drag-drop URL prefix
+	fp = strings.TrimPrefix(fp, "file://")
+
+	// Replace common shell escape sequences
+	replacer := strings.NewReplacer(
+		"\\ ", " ",   // Escaped space
+		"\\(", "(",   // Escaped left parenthesis
+		"\\)", ")",   // Escaped right parenthesis
+		"\\[", "[",   // Escaped left square bracket
+		"\\]", "]",   // Escaped right square bracket
+		"\\{", "{",   // Escaped left curly brace
+		"\\}", "}",   // Escaped right curly brace
+		"\\$", "$",   // Escaped dollar sign
+		"\\&", "&",   // Escaped ampersand
+		"\\;", ";",   // Escaped semicolon
+		"\\'", "'",   // Escaped single quote
 		"\\\\", "\\", // Escaped backslash
-		"\\*", "*", // Escaped asterisk
-		"\\?", "?", // Escaped question mark
-		"\\~", "~", // Escaped tilde
-	).Replace(fp)
+		"\\*", "*",   // Escaped asterisk
+		"\\?", "?",   // Escaped question mark
+		"\\~", "~",   // Escaped tilde
+		"\\!", "!",   // Escaped exclamation mark
+		"\\#", "#",   // Escaped hash
+		"\\@", "@",   // Escaped at sign
+	)
+	return replacer.Replace(fp)
 }
 
 func extractFileNames(input string) []string {
-	// Regex to match file paths starting with optional drive letter, / ./ \ or .\ and include escaped or unescaped spaces (\ or %20)
-	// and followed by more characters and a file extension
-	// This will capture non filename strings, but we'll check for file existence to remove mismatches
-	regexPattern := `(?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp|wav)\b`
-	re := regexp.MustCompile(regexPattern)
+	// Match file paths with supported image/audio extensions.
+	// Handles absolute paths (/...), relative paths (./...), Windows paths (C:\...),
+	// and paths with escaped spaces from macOS drag-drop.
+	//
+	// Uses a two-pass approach:
+	// 1. Regex matching for well-formed paths
+	// 2. Token-based fallback for quoted or unescaped paths
+	var matches []string
 
-	return re.FindAllString(input, -1)
+	// Pass 1: Regex for well-formed paths with typical separators
+	regexPattern := `(?:[a-zA-Z]:)?(?:\./|/|\\)\S+\.(?i:jpg|jpeg|png|webp|wav)\b`
+	re := regexp.MustCompile(regexPattern)
+	matches = re.FindAllString(input, -1)
+
+	// Pass 2: Token-based check for paths that didn't match the regex
+	// (e.g., paths with escaped spaces from macOS drag-drop, or quoted paths)
+	fields := strings.Fields(input)
+	for _, f := range fields {
+		// Skip empty fields
+		if f == "" {
+			continue
+		}
+
+		// Strip surrounding quotes if present
+		clean := strings.Trim(f, "\"'")
+
+		// Check if it has a supported extension
+		ext := strings.ToLower(filepath.Ext(clean))
+		if ext != ".jpg" && ext != ".jpeg" && ext != ".png" && ext != ".webp" && ext != ".wav" {
+			continue
+		}
+
+		// Avoid duplicates
+		duplicate := false
+		for _, m := range matches {
+			if m == clean {
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate {
+			matches = append(matches, clean)
+		}
+	}
+
+	return matches
 }
 
 func extractFileData(input string) (string, []api.ImageData, error) {

--- a/cmd/interactive_test.go
+++ b/cmd/interactive_test.go
@@ -64,6 +64,55 @@ d:\path with\spaces\thirteen.WEBP some ending
 	assert.Contains(t, res[12], "d:")
 }
 
+func TestExtractFilenamesWithMacOSPaths(t *testing.T) {
+	// macOS drag-drop paths with escaped spaces (backslash-space)
+	input := `describe /Users/jdoe/My\ Project/image.png and also /Users/jdoe/file.webp`
+	res := extractFileNames(input)
+	assert.Contains(t, res[0], "image.png", "should find macOS path with escaped space")
+	assert.Contains(t, res[1], "file.webp", "should find normal macOS path")
+
+	// macOS drag-drop with file:// URL prefix
+	input = `what's in file:///Users/jdoe/photo.jpeg?`
+	res = extractFileNames(input)
+	assert.Contains(t, res[0], "photo.jpeg", "should find file:// path")
+
+	// macOS drag-drop combining file:// with escaped spaces
+	input = `analyze file:///Users/jdoe/My\ Project/screenshot.png`
+	res = extractFileNames(input)
+	assert.NotEmpty(t, res, "should find file:// path with escaped space")
+	assert.Contains(t, res[0], "screenshot.png")
+
+	// Quoted paths (single and double quotes)
+	input = `look at '/path/to/my file.jpg' and "/another/file with spaces.png"`
+	res = extractFileNames(input)
+	assert.Contains(t, res[0], "my file.jpg", "should find single-quoted path")
+	assert.Contains(t, res[1], "file with spaces.png", "should find double-quoted path")
+
+	// Mixed content with macOS drag-drop path
+	input = `describe the image file:///Users/jdoe/Desktop/sample.JPEG and /tmp/normal.webp`
+	res = extractFileNames(input)
+	assert.Len(t, res, 2, "should find both macOS drag-drop and normal paths")
+}
+
+func TestNormalizeFilePath(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"file:///Users/jdoe/image.png", "/Users/jdoe/image.png"},
+		{"/Users/jdoe/My\\ Project/image.png", "/Users/jdoe/My Project/image.png"},
+		{"file:///Users/jdoe/My\\ Project/image.png", "/Users/jdoe/My Project/image.png"},
+		{"/path/with (parens)/file.png", "/path/with (parens)/file.png"},
+		{"/path/with/file?.png", "/path/with/file?.png"},
+	}
+	for _, tt := range tests {
+		got := normalizeFilePath(tt.input)
+		if got != tt.expected {
+			t.Errorf("normalizeFilePath(%q) = %q, want %q", tt.input, got, tt.expected)
+		}
+	}
+}
+
 // Ensure that file paths wrapped in single quotes are removed with the quotes.
 func TestExtractFileDataRemovesQuotedFilepath(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
Fixes #10333

Improves the file path detection logic in extractFileNames to handle:
- macOS drag-drop paths with escaped spaces (\\ )
- Quoted paths (single and double quotes)
- macOS file:// URL prefix
- More escape sequences in normalizeFilePath

Uses a two-pass approach: regex for well-formed paths, then token-based fallback for paths that didn't match the regex.