### PR TITLE
fix(server): implement configurable download timeouts and resilient chunking

### DIFF
--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -163,6 +163,28 @@ func LoadTimeout() (loadTimeout time.Duration) {
 	return loadTimeout
 }
 
+// DownloadTimeout returns the duration for stall detection during model downloads.
+// If no data is received for this duration, the download part is considered stalled
+// and will be retried. DownloadTimeout can be configured via the OLLAMA_DOWNLOAD_TIMEOUT
+// environment variable. Zero or Negative values are treated as infinite.
+// Default is 30 seconds.
+func DownloadTimeout() (downloadTimeout time.Duration) {
+	downloadTimeout = 30 * time.Second
+	if s := Var("OLLAMA_DOWNLOAD_TIMEOUT"); s != "" {
+		if d, err := time.ParseDuration(s); err == nil {
+			downloadTimeout = d
+		} else if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+			downloadTimeout = time.Duration(n) * time.Second
+		}
+	}
+
+	if downloadTimeout <= 0 {
+		return time.Duration(math.MaxInt64)
+	}
+
+	return downloadTimeout
+}
+
 func Remotes() []string {
 	var r []string
 	raw := strings.TrimSpace(Var("OLLAMA_REMOTES"))
@@ -323,6 +345,7 @@ func AsMap() map[string]EnvVar {
 		"OLLAMA_KEEP_ALIVE":           {"OLLAMA_KEEP_ALIVE", KeepAlive(), "The duration that models stay loaded in memory (default \"5m\")"},
 		"OLLAMA_LLM_LIBRARY":          {"OLLAMA_LLM_LIBRARY", LLMLibrary(), "Set LLM library to bypass autodetection"},
 		"OLLAMA_LOAD_TIMEOUT":         {"OLLAMA_LOAD_TIMEOUT", LoadTimeout(), "How long to allow model loads to stall before giving up (default \"5m\")"},
+		"OLLAMA_DOWNLOAD_TIMEOUT":     {"OLLAMA_DOWNLOAD_TIMEOUT", DownloadTimeout(), "How long to wait with no download progress before retrying a stalled part (default \"30s\")"},
 		"OLLAMA_MAX_LOADED_MODELS":    {"OLLAMA_MAX_LOADED_MODELS", MaxRunners(), "Maximum number of loaded models per GPU"},
 		"OLLAMA_MAX_TRANSFER_STREAMS": {"OLLAMA_MAX_TRANSFER_STREAMS", MaxTransferStreams(), "Maximum parallel transfer streams for safetensors model pulls/pushes (default 4)"},
 		"OLLAMA_MAX_QUEUE":            {"OLLAMA_MAX_QUEUE", MaxQueue(), "Maximum number of queued requests"},

--- a/server/download.go
+++ b/server/download.go
@@ -23,6 +23,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/envconfig"
 	"github.com/ollama/ollama/format"
 	"github.com/ollama/ollama/manifest"
 	"github.com/ollama/ollama/types/model"
@@ -343,8 +344,14 @@ func (b *blobDownload) downloadChunk(ctx context.Context, requestURL *url.URL, w
 		defer resp.Body.Close()
 
 		n, err := io.CopyN(w, io.TeeReader(resp.Body, part), part.Size-part.Completed.Load())
-		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, io.ErrUnexpectedEOF) {
-			// rollback progress
+		switch {
+		case err == nil,
+			errors.Is(err, context.Canceled),
+			errors.Is(err, io.ErrUnexpectedEOF),
+			errors.Is(err, io.EOF):
+			// success or resumable: persist the progress
+		default:
+			// non-resumable error: rollback progress
 			b.Completed.Add(-n)
 			return err
 		}
@@ -371,7 +378,7 @@ func (b *blobDownload) downloadChunk(ctx context.Context, requestURL *url.URL, w
 				lastUpdated := part.lastUpdated
 				part.lastUpdatedMu.Unlock()
 
-				if !lastUpdated.IsZero() && time.Since(lastUpdated) > 30*time.Second {
+				if !lastUpdated.IsZero() && time.Since(lastUpdated) > envconfig.DownloadTimeout() {
 					const msg = "%s part %d stalled; retrying. If this persists, press ctrl-c to exit, then 'ollama pull' to find a faster connection."
 					slog.Info(fmt.Sprintf(msg, b.Digest[7:19], part.N))
 					// reset last updated


### PR DESCRIPTION
### Description

This Pull Request resolves issue #8484, where the model pull process drops connections and reverts download progress.

### Changes Included:
1. **Configurable Download Timeout**: Replaced the hardcoded `30 * time.Second` read deadline in `server/download.go` with a configurable `OLLAMA_DOWNLOAD_TIMEOUT` environment variable (mapped via `envconfig.DownloadTimeout()`, defaulting to 30 seconds).
2. **Resilient Chunk Resuming**: Fixed the progress rollback bug where `io.EOF` errors from connection drops were treated as fatal failures, causing download progress to revert. Added `io.EOF` to the list of gracefully-handled errors, allowing progress to resume robustly from the last successfully written byte.

Fixes #8484.