### PR TITLE
parser: quote Modelfile values that start or end with a double quote

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -634,7 +634,7 @@ func parseRuneForState(r rune, cs state) (state, rune, error) {
 }
 
 func quote(s string) string {
-	if strings.Contains(s, "\n") || strings.HasPrefix(s, " ") || strings.HasSuffix(s, " ") {
+	if strings.Contains(s, "\n") || strings.HasPrefix(s, " ") || strings.HasSuffix(s, " ") || strings.HasPrefix(s, `"`) || strings.HasSuffix(s, `"`) {
 		if strings.Contains(s, "\"") {
 			return `"""` + s + `"""`
 		}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -701,6 +701,33 @@ SYSTEM ""
 	}
 }
 
+func TestParseFileQuoteRoundtrip(t *testing.T) {
+	// A value whose content starts or ends with a double quote must survive a
+	// String() -> ParseFile round-trip. quote() previously only wrapped values
+	// containing newlines or leading/trailing spaces, so an edge-quote value was
+	// emitted verbatim and its surrounding quotes were stripped when re-parsed.
+	cases := []string{
+		`"quoted"`,
+		`"leading`,
+		`trailing"`,
+		`a "middle" quote`,
+	}
+
+	for _, args := range cases {
+		t.Run("", func(t *testing.T) {
+			modelfile := &Modelfile{Commands: []Command{
+				{Name: "model", Args: "foo"},
+				{Name: "system", Args: args},
+			}}
+
+			modelfile2, err := ParseFile(strings.NewReader(modelfile.String()))
+			require.NoError(t, err)
+
+			assert.Equal(t, modelfile, modelfile2)
+		})
+	}
+}
+
 func TestParseFileUTF16ParseFile(t *testing.T) {
 	data := `FROM bob
 PARAMETER param1 1


### PR DESCRIPTION
## Description

`Command.String()` serializes a Modelfile back to text using `quote()`, which only wraps a value in quotes when it contains a newline or has leading/trailing spaces. A single-line value that itself **starts or ends with a double quote** is emitted verbatim, so the `String()` → `ParseFile` round-trip corrupts it:

```
SYSTEM value  "quoted"   -> serialized as:  SYSTEM "quoted"   -> re-parses to:  quoted     (quotes lost)
SYSTEM value  "leading   -> serialized as:  SYSTEM "leading    -> re-parses to:  unexpected EOF
```

This affects SYSTEM, TEMPLATE, LICENSE, PARAMETER and MESSAGE values, and breaks the round-trip that `ollama show --modelfile` and copy/edit/recreate workflows depend on.

## Fix

A value beginning or ending with a double quote is parser-significant (`unquote()` will consume it), so include that in `quote()`'s predicate. Such a value always contains a quote and therefore takes the existing `"""..."""` triple-quote branch, which `unquote()` strips back correctly.

```go
if strings.Contains(s, "\n") || strings.HasPrefix(s, " ") || strings.HasSuffix(s, " ") ||
    strings.HasPrefix(s, `"`) || strings.HasSuffix(s, `"`) {
```

## How tested

Added `TestParseFileQuoteRoundtrip` (parse-free: builds a Modelfile, round-trips through `String()` → `ParseFile`) covering edge-quoted values. It **fails on current `main`** (`"quoted"` loses its quotes; `"leading` errors with unexpected EOF) and **passes** with this change.

```
go test ./parser/    # ok, full package green; gofmt + go vet clean
```

No change to the already-correct paths (newline / leading-trailing space / mid-string quotes).

_Disclosure: authored with the assistance of an AI tool; fully reviewed and verified by me._