### PR TITLE
llama: add laguna (poolside) arch via a llama.cpp patch under llama/c…

### DIFF
--- a/llama/compat/README.md
+++ b/llama/compat/README.md
@@ -25,8 +25,13 @@ intentionally skipped so a developer can iterate on a local llama.cpp tree.
   small tensor repacking primitives.
 - `llama-cpp-hooks.patch` - small additive call-site edits in llama.cpp files.
   It currently touches `src/llama-model-loader.cpp` and `tools/mtmd/clip.cpp`.
-- `compat.cmake`, `apply-patch.cmake` - CMake glue and an idempotent patch
-  applier used by `llama/server/CMakeLists.txt`.
+- `compat.cmake`, `apply-patch.cmake` - CMake glue and an idempotent applier
+  (used by `llama/server/CMakeLists.txt`) that applies every `*.patch` under
+  this directory — the hooks patch plus each `models/` architecture patch.
+- `models/` - the sibling **new-architecture** layer: implementations of
+  architectures llama.cpp doesn't support yet, each added via a small
+  registration patch. (Those files *add* archs; the files above *translate*
+  existing GGUFs onto archs llama.cpp already has.)
 
 The compatibility source files stay in this directory and are linked into the
 fetched llama.cpp targets. The patch file only adds call sites.

--- a/llama/compat/apply-patch.cmake
+++ b/llama/compat/apply-patch.cmake
@@ -1,18 +1,15 @@
 # Idempotent patch applier used by compat.cmake.
 #
 # Invocation (from a CMake PATCH_COMMAND):
-#   cmake -DPATCH_FILE=<abs path> -P apply-patch.cmake
+#   cmake -DPATCH_DIR=<dir of *.patch> -P apply-patch.cmake
 #
-# The patch is applied in the current working directory (which ExternalProject
-# / FetchContent sets to the fetched source's SOURCE_DIR). If the patch is
-# already applied — detected via `git apply --reverse --check` — this script
-# is a no-op. This makes re-configuring and re-building the project safe.
+# Every *.patch under PATCH_DIR is applied in the current working directory
+# (which ExternalProject / FetchContent sets to the fetched source's
+# SOURCE_DIR). A patch already applied — detected via `git apply --reverse
+# --check` — is skipped. This makes re-configuring and re-building safe.
 
-if(NOT DEFINED PATCH_FILE)
-    message(FATAL_ERROR "apply-patch.cmake: PATCH_FILE not set")
-endif()
-if(NOT EXISTS "${PATCH_FILE}")
-    message(FATAL_ERROR "apply-patch.cmake: PATCH_FILE does not exist: ${PATCH_FILE}")
+if(NOT DEFINED PATCH_DIR)
+    message(FATAL_ERROR "apply-patch.cmake: PATCH_DIR not set")
 endif()
 
 find_package(Git QUIET REQUIRED)
@@ -21,30 +18,33 @@ get_filename_component(_patch_workdir "." ABSOLUTE)
 get_filename_component(_git_ceiling "${_patch_workdir}" DIRECTORY)
 set(_git_apply_env GIT_CEILING_DIRECTORIES=${_git_ceiling})
 
-# If the patch can be REVERSED cleanly, it's already applied. Skip.
-execute_process(
-    COMMAND ${CMAKE_COMMAND} -E env ${_git_apply_env}
-        ${GIT_EXECUTABLE} apply --reverse --check "${PATCH_FILE}"
-    RESULT_VARIABLE _reverse_check
-    OUTPUT_QUIET ERROR_QUIET
-)
-if(_reverse_check EQUAL 0)
-    message(STATUS "llama/compat: patch already applied, skipping")
-    return()
-endif()
+file(GLOB_RECURSE _patches "${PATCH_DIR}/*.patch")
+list(SORT _patches)
+foreach(PATCH_FILE IN LISTS _patches)
+    # If the patch can be REVERSED cleanly, it's already applied. Skip.
+    execute_process(
+        COMMAND ${CMAKE_COMMAND} -E env ${_git_apply_env}
+            ${GIT_EXECUTABLE} apply --reverse --check "${PATCH_FILE}"
+        RESULT_VARIABLE _reverse_check
+        OUTPUT_QUIET ERROR_QUIET
+    )
+    if(_reverse_check EQUAL 0)
+        message(STATUS "llama/compat: patch already applied, skipping")
+        continue()
+    endif()
 
-# Otherwise, apply forward.
-execute_process(
-    COMMAND ${CMAKE_COMMAND} -E env ${_git_apply_env}
-        ${GIT_EXECUTABLE} apply --whitespace=nowarn "${PATCH_FILE}"
-    RESULT_VARIABLE _apply_result
-)
-if(NOT _apply_result EQUAL 0)
-    message(FATAL_ERROR
-        "llama/compat: failed to apply ${PATCH_FILE}\n"
-        "This usually means the pinned llama.cpp source has changed. "
-        "Regenerate the patch (see llama/compat/README.md) against the "
-        "pinned LLAMA_CPP_VERSION and retry.")
-endif()
+    # Otherwise, apply forward.
+    execute_process(
+        COMMAND ${CMAKE_COMMAND} -E env ${_git_apply_env}
+            ${GIT_EXECUTABLE} apply --whitespace=nowarn "${PATCH_FILE}"
+        RESULT_VARIABLE _apply_result
+    )
+    if(NOT _apply_result EQUAL 0)
+        message(FATAL_ERROR
+            "llama/compat: failed to apply ${PATCH_FILE}\n"
+            "This usually means the pinned llama.cpp source has changed. "
+            "Regenerate the patch against the pinned LLAMA_CPP_VERSION and retry.")
+    endif()
 
-message(STATUS "llama/compat: applied patch")
+    message(STATUS "llama/compat: applied patch")
+endforeach()

--- a/llama/compat/compat.cmake
+++ b/llama/compat/compat.cmake
@@ -33,7 +33,7 @@ set(_compat_dir ${CMAKE_CURRENT_LIST_DIR})
 # Ollama's tree and makes the patch pure call-site insertions.
 set(OLLAMA_LLAMA_CPP_COMPAT_PATCH_COMMAND
     ${CMAKE_COMMAND}
-        -DPATCH_FILE=${_compat_dir}/llama-cpp-hooks.patch
+        -DPATCH_DIR=${_compat_dir}
         -P ${_compat_dir}/apply-patch.cmake
     CACHE INTERNAL "llama.cpp compat patch command for FetchContent")
 

--- a/llama/compat/models/laguna.cpp
+++ b/llama/compat/models/laguna.cpp
@@ -1,0 +1,232 @@
+#include "models/models.h"
+
+void llama_model_laguna::load_arch_hparams(llama_model_loader & ml) {
+    ml.get_key(LLM_KV_ATTENTION_LAYERNORM_RMS_EPS, hparams.f_norm_rms_eps);
+
+    // MoE
+    ml.get_key(LLM_KV_LEADING_DENSE_BLOCK_COUNT,         hparams.n_layer_dense_lead, false);
+    ml.get_key(LLM_KV_EXPERT_FEED_FORWARD_LENGTH,        hparams.n_ff_exp);
+    ml.get_key(LLM_KV_EXPERT_SHARED_FEED_FORWARD_LENGTH, hparams.n_ff_shexp,        false);
+    ml.get_key(LLM_KV_EXPERT_SHARED_COUNT,               hparams.n_expert_shared,   false);
+    ml.get_key(LLM_KV_EXPERT_WEIGHTS_SCALE,              hparams.expert_weights_scale, false);
+    ml.get_key(LLM_KV_EXPERT_WEIGHTS_NORM,               hparams.expert_weights_norm,  false);
+    ml.get_key(LLM_KV_EXPERT_GATING_FUNC,                hparams.expert_gating_func,   false);
+
+    ml.get_key(LLM_KV_ATTENTION_SLIDING_WINDOW, hparams.n_swa, false);
+    hparams.swa_type = LLAMA_SWA_TYPE_STANDARD;
+    ml.get_key_or_arr("laguna.attention.layer_types", hparams.swa_layers, hparams.n_layer, false);
+
+    ml.get_key("laguna.rope.swa.dimension_count", hparams.n_rot_swa,                false);
+    ml.get_key("laguna.rope.swa.freq_base",       hparams.rope_freq_base_train_swa, false);
+    ml.get_key("laguna.rope.scaling.beta_fast",   hparams.yarn_beta_fast,           false);
+    ml.get_key("laguna.rope.scaling.beta_slow",   hparams.yarn_beta_slow,           false);
+
+    type = LLM_TYPE_UNKNOWN;
+}
+
+void llama_model_laguna::load_arch_tensors(llama_model_loader &) {
+    LLAMA_LOAD_LOCALS;
+
+    const int64_t n_ff_exp        = hparams.n_ff_exp;
+    const int64_t n_ff_shexp      = hparams.n_ff_shexp;
+
+    tok_embd = create_tensor(tn(LLM_TENSOR_TOKEN_EMBD, "weight"), {n_embd, n_vocab}, 0);
+
+    output_norm = create_tensor(tn(LLM_TENSOR_OUTPUT_NORM, "weight"), {n_embd}, 0);
+    output      = create_tensor(tn(LLM_TENSOR_OUTPUT,      "weight"), {n_embd, n_vocab}, TENSOR_NOT_REQUIRED);
+    if (output == NULL) {
+        output = create_tensor(tn(LLM_TENSOR_TOKEN_EMBD, "weight"), {n_embd, n_vocab}, TENSOR_DUPLICATED);
+    }
+
+    for (int i = 0; i < n_layer; ++i) {
+        auto & layer = layers[i];
+
+        const int64_t n_head_i    = hparams.n_head(i);
+        const int64_t n_head_kv_i = hparams.n_head_kv(i);
+        const int64_t n_embd_q    = n_embd_head_k * n_head_i;
+        const int64_t n_embd_kv   = n_embd_head_k * n_head_kv_i;
+
+        layer.attn_norm = create_tensor(tn(LLM_TENSOR_ATTN_NORM, "weight", i), {n_embd}, 0);
+
+        layer.wq = create_tensor(tn(LLM_TENSOR_ATTN_Q,   "weight", i), {n_embd, n_embd_q},  0);
+        layer.wk = create_tensor(tn(LLM_TENSOR_ATTN_K,   "weight", i), {n_embd, n_embd_kv}, 0);
+        layer.wv = create_tensor(tn(LLM_TENSOR_ATTN_V,   "weight", i), {n_embd, n_embd_kv}, 0);
+        layer.wo = create_tensor(tn(LLM_TENSOR_ATTN_OUT, "weight", i), {n_embd_q, n_embd},  0);
+
+        layer.wqkv_gate = create_tensor(tn(LLM_TENSOR_ATTN_GATE_LAGUNA, "weight", i), {n_embd, n_head_i}, 0);
+
+        layer.attn_q_norm = create_tensor(tn(LLM_TENSOR_ATTN_Q_NORM, "weight", i), {n_embd_head_k}, 0);
+        layer.attn_k_norm = create_tensor(tn(LLM_TENSOR_ATTN_K_NORM, "weight", i), {n_embd_head_k}, 0);
+
+        layer.ffn_norm = create_tensor(tn(LLM_TENSOR_FFN_NORM, "weight", i), {n_embd}, 0);
+
+        if (i < (int) hparams.n_layer_dense_lead) {
+            layer.ffn_gate = create_tensor(tn(LLM_TENSOR_FFN_GATE, "weight", i), {n_embd,   n_ff}, 0);
+            layer.ffn_down = create_tensor(tn(LLM_TENSOR_FFN_DOWN, "weight", i), {  n_ff, n_embd}, 0);
+            layer.ffn_up   = create_tensor(tn(LLM_TENSOR_FFN_UP,   "weight", i), {n_embd,   n_ff}, 0);
+        } else {
+            layer.ffn_gate_inp    = create_tensor(tn(LLM_TENSOR_FFN_GATE_INP,    "weight", i), {n_embd, n_expert}, 0);
+            layer.ffn_exp_probs_b = create_tensor(tn(LLM_TENSOR_FFN_EXP_PROBS_B, "bias",   i), {n_expert}, TENSOR_NOT_REQUIRED);
+
+            layer.ffn_gate_exps = create_tensor(tn(LLM_TENSOR_FFN_GATE_EXPS, "weight", i), {  n_embd, n_ff_exp, n_expert}, 0);
+            layer.ffn_down_exps = create_tensor(tn(LLM_TENSOR_FFN_DOWN_EXPS, "weight", i), {n_ff_exp,   n_embd, n_expert}, 0);
+            layer.ffn_up_exps   = create_tensor(tn(LLM_TENSOR_FFN_UP_EXPS,   "weight", i), {  n_embd, n_ff_exp, n_expert}, 0);
+
+            layer.ffn_gate_shexp = create_tensor(tn(LLM_TENSOR_FFN_GATE_SHEXP, "weight", i), {n_embd, n_ff_shexp}, 0);
+            layer.ffn_down_shexp = create_tensor(tn(LLM_TENSOR_FFN_DOWN_SHEXP, "weight", i), {n_ff_shexp, n_embd}, 0);
+            layer.ffn_up_shexp   = create_tensor(tn(LLM_TENSOR_FFN_UP_SHEXP,   "weight", i), {n_embd, n_ff_shexp}, 0);
+        }
+    }
+}
+
+std::unique_ptr<llm_graph_context> llama_model_laguna::build_arch_graph(const llm_graph_params & params) const {
+    return std::make_unique<graph>(*this, params);
+}
+
+llama_model_laguna::graph::graph(const llama_model & model, const llm_graph_params & params) :
+        llm_graph_context(params) {
+    const int64_t n_embd_head = hparams.n_embd_head_v();
+    GGML_ASSERT(n_embd_head == hparams.n_embd_head_k());
+
+    const float kq_scale = 1.0f / sqrtf(float(n_embd_head));
+
+    ggml_tensor * cur;
+    ggml_tensor * inpL;
+
+    inpL = build_inp_embd(model.tok_embd);
+
+    ggml_tensor * inp_pos = build_inp_pos();
+
+    auto * inp_attn = build_attn_inp_kv_iswa();
+
+    ggml_tensor * inp_out_ids = build_inp_out_ids();
+
+    for (int il = 0; il < n_layer; ++il) {
+        ggml_tensor * inpSA = inpL;
+
+        const int64_t n_head_il    = hparams.n_head(il);
+        const int64_t n_head_kv_il = hparams.n_head_kv(il);
+        const bool    is_swa       = hparams.is_swa(il);
+
+        const int   rope_n_dims = hparams.n_rot(il);
+        const float rope_base   = is_swa ? hparams.rope_freq_base_train_swa  : hparams.rope_freq_base_train;
+        const float rope_scale  = is_swa ? hparams.rope_freq_scale_train_swa : hparams.rope_freq_scale_train;
+        const float rope_ext    = is_swa ? 0.0f : 1.0f;
+        const float rope_bfast  = hparams.yarn_beta_fast;
+        const float rope_bslow  = hparams.yarn_beta_slow;
+
+        cur = build_norm(inpL, model.layers[il].attn_norm, NULL, LLM_NORM_RMS, il);
+        cb(cur, "attn_norm", il);
+
+        // self-attention
+        {
+            ggml_tensor * Qcur = build_lora_mm(model.layers[il].wq, cur);
+            cb(Qcur, "Qcur", il);
+            ggml_tensor * Kcur = build_lora_mm(model.layers[il].wk, cur);
+            cb(Kcur, "Kcur", il);
+            ggml_tensor * Vcur = build_lora_mm(model.layers[il].wv, cur);
+            cb(Vcur, "Vcur", il);
+
+            ggml_tensor * gate = build_lora_mm(model.layers[il].wqkv_gate, cur);
+            cb(gate, "gate", il);
+
+            Qcur = ggml_reshape_3d(ctx0, Qcur, n_embd_head, n_head_il,    n_tokens);
+            Kcur = ggml_reshape_3d(ctx0, Kcur, n_embd_head, n_head_kv_il, n_tokens);
+            Vcur = ggml_reshape_3d(ctx0, Vcur, n_embd_head, n_head_kv_il, n_tokens);
+
+            Qcur = build_norm(Qcur, model.layers[il].attn_q_norm, NULL, LLM_NORM_RMS, il);
+            cb(Qcur, "Qcur_normed", il);
+            Kcur = build_norm(Kcur, model.layers[il].attn_k_norm, NULL, LLM_NORM_RMS, il);
+            cb(Kcur, "Kcur_normed", il);
+
+            Qcur = ggml_rope_ext(ctx0, Qcur, inp_pos, nullptr,
+                    rope_n_dims, rope_type, hparams.n_ctx_orig_yarn, rope_base, rope_scale,
+                    rope_ext, hparams.rope_attn_factor, rope_bfast, rope_bslow);
+            Kcur = ggml_rope_ext(ctx0, Kcur, inp_pos, nullptr,
+                    rope_n_dims, rope_type, hparams.n_ctx_orig_yarn, rope_base, rope_scale,
+                    rope_ext, hparams.rope_attn_factor, rope_bfast, rope_bslow);
+
+            cb(Qcur, "Qcur", il);
+            cb(Kcur, "Kcur", il);
+            cb(Vcur, "Vcur", il);
+
+            cur = build_attn(inp_attn,
+                    nullptr, nullptr, nullptr,
+                    Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, kq_scale, il);
+            cb(cur, "attn_pregate", il);
+
+            gate = ggml_softplus(ctx0, gate);
+            cur  = ggml_reshape_3d(ctx0, cur, n_embd_head, n_head_il, n_tokens);
+            gate = ggml_reshape_3d(ctx0, gate, 1, n_head_il, n_tokens);
+            cur  = ggml_mul(ctx0, cur, gate);
+            cur  = ggml_reshape_2d(ctx0, cur, n_embd_head * n_head_il, n_tokens);
+            cb(cur, "attn_gated", il);
+
+            cur = build_lora_mm(model.layers[il].wo, cur, model.layers[il].wo_s);
+            cb(cur, "attn_out", il);
+        }
+
+        if (il == n_layer - 1 && inp_out_ids) {
+            cur   = ggml_get_rows(ctx0, cur,   inp_out_ids);
+            inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
+        }
+
+        ggml_tensor * ffn_inp = ggml_add(ctx0, cur, inpSA);
+        cb(ffn_inp, "ffn_inp", il);
+
+        // feed-forward
+        cur = build_norm(ffn_inp, model.layers[il].ffn_norm, NULL, LLM_NORM_RMS, il);
+        cb(cur, "ffn_norm", il);
+
+        if ((uint32_t) il < hparams.n_layer_dense_lead) {
+            cur = build_ffn(cur,
+                    model.layers[il].ffn_up,   NULL, NULL,
+                    model.layers[il].ffn_gate, NULL, NULL,
+                    model.layers[il].ffn_down, NULL, NULL,
+                    NULL, LLM_FFN_SILU, LLM_FFN_PAR, il);
+            cb(cur, "ffn_out", il);
+        } else {
+            ggml_tensor * moe_out = build_moe_ffn(cur,
+                    model.layers[il].ffn_gate_inp,
+                    model.layers[il].ffn_up_exps,
+                    model.layers[il].ffn_gate_exps,
+                    model.layers[il].ffn_down_exps,
+                    model.layers[il].ffn_exp_probs_b,
+                    n_expert, n_expert_used,
+                    LLM_FFN_SILU, hparams.expert_weights_norm,
+                    hparams.expert_weights_scale,
+                    (llama_expert_gating_func_type) hparams.expert_gating_func,
+                    il);
+            cb(moe_out, "ffn_moe_out", il);
+
+            ggml_tensor * ffn_shexp = build_ffn(cur,
+                    model.layers[il].ffn_up_shexp,   NULL, NULL,
+                    model.layers[il].ffn_gate_shexp, NULL, NULL,
+                    model.layers[il].ffn_down_shexp, NULL, NULL,
+                    NULL, LLM_FFN_SILU, LLM_FFN_PAR, il);
+            cb(ffn_shexp, "ffn_shexp", il);
+
+            cur = ggml_add(ctx0, moe_out, ffn_shexp);
+            cb(cur, "ffn_out", il);
+        }
+
+        cur = ggml_add(ctx0, cur, ffn_inp);
+
+        cur = build_cvec(cur, il);
+        cb(cur, "l_out", il);
+
+        inpL = cur;
+    }
+
+    cur = inpL;
+
+    cur = build_norm(cur, model.output_norm, NULL, LLM_NORM_RMS, -1);
+    cb(cur, "result_norm", -1);
+    res->t_embd = cur;
+
+    cur = build_lora_mm(model.output, cur, model.output_s);
+    cb(cur, "result_output", -1);
+    res->t_logits = cur;
+
+    ggml_build_forward_expand(gf, cur);
+}

--- a/llama/compat/models/llama-cpp-laguna.patch
+++ b/llama/compat/models/llama-cpp-laguna.patch
@@ -1,0 +1,140 @@
+diff --git a/src/llama-arch.cpp b/src/llama-arch.cpp
+index e95ba6daa..daff484e3 100644
+--- a/src/llama-arch.cpp
++++ b/src/llama-arch.cpp
+@@ -134,6 +134,7 @@ static const std::map<llm_arch, const char *> LLM_ARCH_NAMES = {
+     { LLM_ARCH_MAINCODER,        "maincoder"        },
+     { LLM_ARCH_KIMI_LINEAR,      "kimi-linear"      },
+     { LLM_ARCH_TALKIE,           "talkie"           },
++    { LLM_ARCH_LAGUNA,           "laguna"           },
+     { LLM_ARCH_UNKNOWN,          "(unknown)"        },
+ };
+
+@@ -370,6 +371,7 @@ static const std::map<llm_tensor, const char *> LLM_TENSOR_NAMES = {
+     { LLM_TENSOR_ATTN_Q_NORM,                            "blk.%d.attn_q_norm" },
+     { LLM_TENSOR_ATTN_K_NORM,                            "blk.%d.attn_k_norm" },
+     { LLM_TENSOR_ATTN_GATE,                              "blk.%d.attn_gate" },
++    { LLM_TENSOR_ATTN_GATE_LAGUNA,                       "blk.%d.attn_g" },
+     { LLM_TENSOR_FFN_POST_NORM,                          "blk.%d.post_ffw_norm" },
+     { LLM_TENSOR_FFN_POST_NORM_1,                        "blk.%d.post_ffw_norm_1" },
+     { LLM_TENSOR_FFN_POST_NORM_2,                        "blk.%d.post_ffw_norm_2" },
+@@ -585,6 +587,7 @@ static const std::map<llm_tensor, llm_tensor_info> LLM_TENSOR_INFOS = {
+     {LLM_TENSOR_ATTN_QKV,                   {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
+     {LLM_TENSOR_ATTN_OUT,                   {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
+     {LLM_TENSOR_ATTN_GATE,                  {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
++    {LLM_TENSOR_ATTN_GATE_LAGUNA,           {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
+     {LLM_TENSOR_FFN_GATE,                   {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
+     {LLM_TENSOR_FFN_DOWN,                   {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
+     {LLM_TENSOR_FFN_UP,                     {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
+diff --git a/src/llama-arch.h b/src/llama-arch.h
+index 7c1dcc4d6..c726452f8 100644
+--- a/src/llama-arch.h
++++ b/src/llama-arch.h
+@@ -138,6 +138,7 @@ enum llm_arch {
+     LLM_ARCH_MAINCODER,
+     LLM_ARCH_KIMI_LINEAR,
+     LLM_ARCH_TALKIE,
++    LLM_ARCH_LAGUNA,
+     LLM_ARCH_UNKNOWN,
+ };
+
+@@ -372,6 +373,7 @@ enum llm_tensor {
+     LLM_TENSOR_ATTN_ROT_EMBD,
+     LLM_TENSOR_ATTN_SINKS,
+     LLM_TENSOR_ATTN_GATE,
++    LLM_TENSOR_ATTN_GATE_LAGUNA,
+     LLM_TENSOR_FFN_GATE_INP,
+     LLM_TENSOR_FFN_GATE_INP_SHEXP,
+     LLM_TENSOR_FFN_NORM,
+diff --git a/src/llama-model.cpp b/src/llama-model.cpp
+index 0c3e03a61..366d82730 100644
+--- a/src/llama-model.cpp
++++ b/src/llama-model.cpp
+@@ -286,6 +286,8 @@ static llama_model * llama_model_mapping(llm_arch arch, const llama_model_params
+             return new llama_model_kimi_linear(params);
+         case LLM_ARCH_STEP35:
+             return new llama_model_step35(params);
++        case LLM_ARCH_LAGUNA:
++            return new llama_model_laguna(params);
+         default:
+             throw std::runtime_error(std::string("unsupported model architecture: '") + llm_arch_name(arch) + "'");
+     }
+@@ -2356,6 +2358,7 @@ llama_rope_type llama_model_rope_type(const llama_model * model) {
+         case LLM_ARCH_MIMO2:
+         case LLM_ARCH_STEP35:
+         case LLM_ARCH_TALKIE:
++        case LLM_ARCH_LAGUNA:
+             return LLAMA_ROPE_TYPE_NEOX;
+
+         case LLM_ARCH_QWEN2VL:
+diff --git a/src/llama-vocab.cpp b/src/llama-vocab.cpp
+index 473becade..898f6e080 100644
+--- a/src/llama-vocab.cpp
++++ b/src/llama-vocab.cpp
+@@ -358,6 +358,12 @@ struct llm_tokenizer_bpe : llm_tokenizer {
+                     "'s|'t|'re|'ve|'m|'ll|'d| ?\\p{L}+| ?\\p{N}+| ?[^\\s\\p{L}\\p{N}]+|\\s+(?!\\S)",
+                 };
+                 break;
++            case LLAMA_VOCAB_PRE_TYPE_LAGUNA:
++                regex_exprs = {
++                    "(?:\\r?\\n)+(?!\\r?\\n)",
++                    "(?:'[sS]|'[tT]|'[rR][eE]|'[vV][eE]|'[mM]|'[lL][lL]|'[dD])|[^\\r\\n\\p{L}\\p{N}]?\\p{L}+|\\p{N}| ?[^\\s\\p{L}\\p{N}]+[\\r\\n]*|\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+",
++                };
++                break;
+             case LLAMA_VOCAB_PRE_TYPE_GPT2:
+             case LLAMA_VOCAB_PRE_TYPE_MPT:
+             case LLAMA_VOCAB_PRE_TYPE_OLMO:
+@@ -2050,6 +2056,8 @@ void llama_vocab::impl::load(llama_model_loader & ml, const LLM_KV & kv) {
+             } else if (tokenizer_pre == "minicpm5") {
+                 pre_type = LLAMA_VOCAB_PRE_TYPE_MINICPM5;
+                 ignore_merges = true;
++            } else if (tokenizer_pre == "laguna") {
++                pre_type = LLAMA_VOCAB_PRE_TYPE_LAGUNA;
+             } else if (
+                     tokenizer_pre == "llama3"   ||
+                     tokenizer_pre == "llama-v3" ||
+@@ -2697,6 +2705,7 @@ void llama_vocab::impl::load(llama_model_loader & ml, const LLM_KV & kv) {
+                     || t.first == "<turn|>"          // gemma4
+                     || t.first == "<|tool_response>" // gemma4
+                     || t.first == "<｜end▁of▁sentence｜>" // deepseek-ocr
++                    || t.first == "</assistant>"     // poolside Laguna (eos_token_ids)
+                ) {
+                 special_eog_ids.insert(t.second);
+                 if ((attr & LLAMA_TOKEN_ATTR_CONTROL) == 0) {
+diff --git a/src/llama-vocab.h b/src/llama-vocab.h
+index 8ab775942..b69be9154 100644
+--- a/src/llama-vocab.h
++++ b/src/llama-vocab.h
+@@ -61,7 +61,8 @@ enum llama_vocab_pre_type {
+     LLAMA_VOCAB_PRE_TYPE_GEMMA4          = 50,
+     LLAMA_VOCAB_PRE_TYPE_SARVAM_MOE      = 51,
+     LLAMA_VOCAB_PRE_TYPE_MINICPM5        = 52,
+     LLAMA_VOCAB_PRE_TYPE_WHITESPACE      = 53,
++    LLAMA_VOCAB_PRE_TYPE_LAGUNA          = 54,
+ };
+
+ struct LLM_KV;
+diff --git a/src/models/models.h b/src/models/models.h
+index db228865d..dab40e4f8 100644
+--- a/src/models/models.h
++++ b/src/models/models.h
+@@ -1453,6 +1453,19 @@ struct llama_model_dots1 : public llama_model_base {
+ };
+
+
++struct llama_model_laguna : public llama_model_base {
++    llama_model_laguna(const struct llama_model_params & params) : llama_model_base(params) {}
++    void load_arch_hparams(llama_model_loader & ml) override;
++    void load_arch_tensors(llama_model_loader & ml) override;
++
++    struct graph : public llm_graph_context {
++        graph(const llama_model & model, const llm_graph_params & params);
++    };
++
++    std::unique_ptr<llm_graph_context> build_arch_graph(const llm_graph_params & params) const override;
++};
++
++
+ struct llama_model_arcee : public llama_model_base {
+     llama_model_arcee(const struct llama_model_params & params) : llama_model_base(params) {}
+     void load_arch_hparams(llama_model_loader & ml) override;

--- a/llama/compat/models/llama-cpp-laguna.patch
+++ b/llama/compat/models/llama-cpp-laguna.patch
@@ -1,79 +1,49 @@
 diff --git a/src/llama-arch.cpp b/src/llama-arch.cpp
-index e95ba6daa..daff484e3 100644
+index be8f73cc1..70a268566 100644
 --- a/src/llama-arch.cpp
 +++ b/src/llama-arch.cpp
-@@ -134,6 +134,7 @@ static const std::map<llm_arch, const char *> LLM_ARCH_NAMES = {
-     { LLM_ARCH_MAINCODER,        "maincoder"        },
-     { LLM_ARCH_KIMI_LINEAR,      "kimi-linear"      },
+@@ -137,2 +137,3 @@ static const std::map<llm_arch, const char *> LLM_ARCH_NAMES = {
      { LLM_ARCH_TALKIE,           "talkie"           },
 +    { LLM_ARCH_LAGUNA,           "laguna"           },
      { LLM_ARCH_UNKNOWN,          "(unknown)"        },
- };
-
-@@ -370,6 +371,7 @@ static const std::map<llm_tensor, const char *> LLM_TENSOR_NAMES = {
-     { LLM_TENSOR_ATTN_Q_NORM,                            "blk.%d.attn_q_norm" },
-     { LLM_TENSOR_ATTN_K_NORM,                            "blk.%d.attn_k_norm" },
+@@ -374,2 +375,3 @@ static const std::map<llm_tensor, const char *> LLM_TENSOR_NAMES = {
      { LLM_TENSOR_ATTN_GATE,                              "blk.%d.attn_gate" },
 +    { LLM_TENSOR_ATTN_GATE_LAGUNA,                       "blk.%d.attn_g" },
      { LLM_TENSOR_FFN_POST_NORM,                          "blk.%d.post_ffw_norm" },
-     { LLM_TENSOR_FFN_POST_NORM_1,                        "blk.%d.post_ffw_norm_1" },
-     { LLM_TENSOR_FFN_POST_NORM_2,                        "blk.%d.post_ffw_norm_2" },
-@@ -585,6 +587,7 @@ static const std::map<llm_tensor, llm_tensor_info> LLM_TENSOR_INFOS = {
-     {LLM_TENSOR_ATTN_QKV,                   {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
-     {LLM_TENSOR_ATTN_OUT,                   {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
+@@ -589,2 +591,3 @@ static const std::map<llm_tensor, llm_tensor_info> LLM_TENSOR_INFOS = {
      {LLM_TENSOR_ATTN_GATE,                  {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
 +    {LLM_TENSOR_ATTN_GATE_LAGUNA,           {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
      {LLM_TENSOR_FFN_GATE,                   {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
-     {LLM_TENSOR_FFN_DOWN,                   {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
-     {LLM_TENSOR_FFN_UP,                     {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
 diff --git a/src/llama-arch.h b/src/llama-arch.h
-index 7c1dcc4d6..c726452f8 100644
+index 2c71bbe81..1e0e059fc 100644
 --- a/src/llama-arch.h
 +++ b/src/llama-arch.h
-@@ -138,6 +138,7 @@ enum llm_arch {
-     LLM_ARCH_MAINCODER,
-     LLM_ARCH_KIMI_LINEAR,
+@@ -141,2 +141,3 @@ enum llm_arch {
      LLM_ARCH_TALKIE,
 +    LLM_ARCH_LAGUNA,
      LLM_ARCH_UNKNOWN,
- };
-
-@@ -372,6 +373,7 @@ enum llm_tensor {
-     LLM_TENSOR_ATTN_ROT_EMBD,
-     LLM_TENSOR_ATTN_SINKS,
+@@ -376,2 +377,3 @@ enum llm_tensor {
      LLM_TENSOR_ATTN_GATE,
 +    LLM_TENSOR_ATTN_GATE_LAGUNA,
      LLM_TENSOR_FFN_GATE_INP,
-     LLM_TENSOR_FFN_GATE_INP_SHEXP,
-     LLM_TENSOR_FFN_NORM,
 diff --git a/src/llama-model.cpp b/src/llama-model.cpp
-index 0c3e03a61..366d82730 100644
+index 914fc423b..b135cff88 100644
 --- a/src/llama-model.cpp
 +++ b/src/llama-model.cpp
-@@ -286,6 +286,8 @@ static llama_model * llama_model_mapping(llm_arch arch, const llama_model_params
-             return new llama_model_kimi_linear(params);
-         case LLM_ARCH_STEP35:
+@@ -291,2 +291,4 @@ static llama_model * llama_model_mapping(llm_arch arch, const llama_model_params
              return new llama_model_step35(params);
 +        case LLM_ARCH_LAGUNA:
 +            return new llama_model_laguna(params);
          default:
-             throw std::runtime_error(std::string("unsupported model architecture: '") + llm_arch_name(arch) + "'");
-     }
-@@ -2356,6 +2358,7 @@ llama_rope_type llama_model_rope_type(const llama_model * model) {
-         case LLM_ARCH_MIMO2:
-         case LLM_ARCH_STEP35:
+@@ -2381,2 +2383,3 @@ llama_rope_type llama_model_rope_type(const llama_model * model) {
          case LLM_ARCH_TALKIE:
 +        case LLM_ARCH_LAGUNA:
              return LLAMA_ROPE_TYPE_NEOX;
-
-         case LLM_ARCH_QWEN2VL:
 diff --git a/src/llama-vocab.cpp b/src/llama-vocab.cpp
-index 473becade..898f6e080 100644
+index b61397311..cbdc32eef 100644
 --- a/src/llama-vocab.cpp
 +++ b/src/llama-vocab.cpp
-@@ -358,6 +358,12 @@ struct llm_tokenizer_bpe : llm_tokenizer {
-                     "'s|'t|'re|'ve|'m|'ll|'d| ?\\p{L}+| ?\\p{N}+| ?[^\\s\\p{L}\\p{N}]+|\\s+(?!\\S)",
-                 };
+@@ -360,2 +360,8 @@ struct llm_tokenizer_bpe : llm_tokenizer {
                  break;
 +            case LLAMA_VOCAB_PRE_TYPE_LAGUNA:
 +                regex_exprs = {
@@ -82,46 +52,30 @@ index 473becade..898f6e080 100644
 +                };
 +                break;
              case LLAMA_VOCAB_PRE_TYPE_GPT2:
-             case LLAMA_VOCAB_PRE_TYPE_MPT:
-             case LLAMA_VOCAB_PRE_TYPE_OLMO:
-@@ -2050,6 +2056,8 @@ void llama_vocab::impl::load(llama_model_loader & ml, const LLM_KV & kv) {
-             } else if (tokenizer_pre == "minicpm5") {
-                 pre_type = LLAMA_VOCAB_PRE_TYPE_MINICPM5;
+@@ -2089,2 +2095,4 @@ void llama_vocab::impl::load(llama_model_loader & ml, const LLM_KV & kv) {
                  ignore_merges = true;
 +            } else if (tokenizer_pre == "laguna") {
 +                pre_type = LLAMA_VOCAB_PRE_TYPE_LAGUNA;
              } else if (
-                     tokenizer_pre == "llama3"   ||
-                     tokenizer_pre == "llama-v3" ||
-@@ -2697,6 +2705,7 @@ void llama_vocab::impl::load(llama_model_loader & ml, const LLM_KV & kv) {
-                     || t.first == "<turn|>"          // gemma4
-                     || t.first == "<|tool_response>" // gemma4
+@@ -2740,2 +2748,3 @@ void llama_vocab::impl::load(llama_model_loader & ml, const LLM_KV & kv) {
                      || t.first == "<｜end▁of▁sentence｜>" // deepseek-ocr
 +                    || t.first == "</assistant>"     // poolside Laguna (eos_token_ids)
                 ) {
-                 special_eog_ids.insert(t.second);
-                 if ((attr & LLAMA_TOKEN_ATTR_CONTROL) == 0) {
 diff --git a/src/llama-vocab.h b/src/llama-vocab.h
-index 8ab775942..b69be9154 100644
+index 093e5d02c..04156676c 100644
 --- a/src/llama-vocab.h
 +++ b/src/llama-vocab.h
-@@ -61,7 +61,8 @@ enum llama_vocab_pre_type {
-     LLAMA_VOCAB_PRE_TYPE_GEMMA4          = 50,
-     LLAMA_VOCAB_PRE_TYPE_SARVAM_MOE      = 51,
-     LLAMA_VOCAB_PRE_TYPE_MINICPM5        = 52,
+@@ -64,2 +64,3 @@ enum llama_vocab_pre_type {
      LLAMA_VOCAB_PRE_TYPE_WHITESPACE      = 53,
 +    LLAMA_VOCAB_PRE_TYPE_LAGUNA          = 54,
  };
-
- struct LLM_KV;
 diff --git a/src/models/models.h b/src/models/models.h
-index db228865d..dab40e4f8 100644
+index 5251e2d82..067230045 100644
 --- a/src/models/models.h
 +++ b/src/models/models.h
-@@ -1453,6 +1453,19 @@ struct llama_model_dots1 : public llama_model_base {
- };
-
-
+@@ -1468,2 +1468,15 @@ struct llama_model_dots1 : public llama_model_base {
+-
++
 +struct llama_model_laguna : public llama_model_base {
 +    llama_model_laguna(const struct llama_model_params & params) : llama_model_base(params) {}
 +    void load_arch_hparams(llama_model_loader & ml) override;
@@ -136,5 +90,3 @@ index db228865d..dab40e4f8 100644
 +
 +
  struct llama_model_arcee : public llama_model_base {
-     llama_model_arcee(const struct llama_model_params & params) : llama_model_base(params) {}
-     void load_arch_hparams(llama_model_loader & ml) override;

--- a/llama/server/CMakeLists.txt
+++ b/llama/server/CMakeLists.txt
@@ -205,6 +205,19 @@ if(_ollama_link_compat_sources AND DEFINED OLLAMA_LLAMA_CPP_COMPAT_DIR)
     endif()
 endif()
 
+# Link temporary architecture sources (llama/compat/models/*.cpp) into the
+# llama target only (not the mtmd projector lib).
+if(_ollama_link_compat_sources AND DEFINED OLLAMA_LLAMA_CPP_COMPAT_DIR)
+    file(GLOB _ollama_model_sources CONFIGURE_DEPENDS
+        ${OLLAMA_LLAMA_CPP_COMPAT_DIR}/models/*.cpp)
+    if(_ollama_model_sources AND TARGET llama)
+        target_sources(llama PRIVATE ${_ollama_model_sources})
+        target_include_directories(llama PRIVATE
+            ${OLLAMA_LLAMA_CPP_COMPAT_DIR}/models
+            ${llama_cpp_SOURCE_DIR}/src)
+    endif()
+endif()
+
 # Find GPU toolkits for runtime dependency bundling.
 # The llama.cpp build finds these internally, but we need the
 # variables (CUDAToolkit_LIBRARY_DIR, etc.) in our install scope.


### PR DESCRIPTION
…ompat/models

The pinned llama.cpp does not include poolside Laguna yet. Add it as an Ollama-owned source file plus a small registration patch under llama/compat/models/. apply-patch.cmake now applies every *.patch under llama/compat/ (the hooks patch plus each arch patch), so adding an architecture only adds files under llama/compat/models/ and needs no new cmake.

Once Laguna support lands upstream this change can be reverted.