### PR TITLE
model/parsers: tolerate qwen tool-call format drift (qwen3.6 + qwen3-coder)

### DIFF
--- a/model/parsers/qwen3coder.go
+++ b/model/parsers/qwen3coder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"log/slog"
 	"math"
@@ -15,6 +16,14 @@ import (
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/logutil"
 )
+
+// errEmptyToolCall is returned by parseToolCall when the model emitted a
+// <tool_call>…</tool_call> envelope that contains no parseable function
+// block. qwen3.6 occasionally does this when it changes its mind mid-stream
+// or drifts to an older training format whose tags don't match. Callers
+// should treat the envelope as a no-op and let the agent loop decide
+// whether to retry or finalize, rather than returning 500 from /api/chat.
+var errEmptyToolCall = errors.New("qwen tool call envelope contained no function block")
 
 type qwenParserState int
 
@@ -67,6 +76,13 @@ func (p *Qwen3CoderParser) Add(s string, done bool) (content string, thinking st
 		switch event := event.(type) {
 		case qwenEventRawToolCall:
 			toolCall, err := parseToolCall(event, p.tools)
+			if errors.Is(err, errEmptyToolCall) {
+				// Model emitted an empty or non-tool <tool_call> envelope.
+				// Skip silently — returning an error here would 500 the chat
+				// request even though the rest of the turn is fine.
+				slog.Warn("qwen tool call envelope was empty; skipping", "raw", event.raw)
+				continue
+			}
 			if err != nil {
 				slog.Warn("qwen tool call parsing failed", "error", err)
 				return "", "", nil, err
@@ -223,14 +239,14 @@ type XMLParameter struct {
 // Anchoring on the function block lets the XML unmarshaler handle the
 // well-formed portion and discard the noise.
 //
-// If no <function= opening tag exists, the input is returned unchanged so
-// the unmarshaler still surfaces the same error it would have before — the
-// helper only tightens the input when it can find an anchor, it never
-// invents one.
-func extractFunctionBlock(raw string) string {
+// Returns the extracted slice and ok=true on success. Returns ("", false)
+// when the envelope is empty, whitespace-only, or contains no usable
+// <function=...>...</function> pair — callers should treat that as a
+// silent no-op rather than an unmarshaler error.
+func extractFunctionBlock(raw string) (string, bool) {
 	open := strings.Index(raw, "<function=")
 	if open < 0 {
-		return raw
+		return "", false
 	}
 	// The first </function> after the opener is the matching close tag.
 	// Using LastIndex would accidentally absorb stray duplicates (e.g.
@@ -238,9 +254,9 @@ func extractFunctionBlock(raw string) string {
 	// xml.Unmarshal error this helper is meant to prevent.
 	end := strings.Index(raw[open:], "</function>")
 	if end < 0 {
-		return raw
+		return "", false
 	}
-	return raw[open : open+end+len("</function>")]
+	return raw[open : open+end+len("</function>")], true
 }
 
 // parseToolCall parses a raw tool call string into an api.ToolCall.
@@ -257,7 +273,13 @@ func extractFunctionBlock(raw string) string {
 func parseToolCall(raw qwenEventRawToolCall, tools []api.Tool) (api.ToolCall, error) {
 	toolCall := api.ToolCall{}
 
-	xmlString := transformToXML(extractFunctionBlock(raw.raw))
+	extracted, ok := extractFunctionBlock(raw.raw)
+	if !ok {
+		// Empty / non-tool envelope. Surface as a sentinel so the streaming
+		// caller can skip silently instead of failing the whole request.
+		return api.ToolCall{}, errEmptyToolCall
+	}
+	xmlString := transformToXML(extracted)
 
 	var functionCall XMLFunctionCall
 	err := xml.Unmarshal([]byte(xmlString), &functionCall)

--- a/model/parsers/qwen3coder.go
+++ b/model/parsers/qwen3coder.go
@@ -30,11 +30,21 @@ type qwenParserState int
 const (
 	toolOpenTag  = "<tool_call>"
 	toolCloseTag = "</tool_call>"
+	// funcOpenTag / funcCloseTag are the inner function-block tags. qwen3-coder
+	// (and qwen3.6) sometimes emit a bare <function=…></function> block with no
+	// enclosing <tool_call> opening tag — often leaving a stray </tool_call>
+	// behind. We treat <function= as an alternate tool-call trigger so the call
+	// isn't dropped into content. See https://github.com/ollama/ollama/issues/16686.
+	funcOpenTag  = "<function="
+	funcCloseTag = "</function>"
 )
 
 const (
 	qwenParserState_LookingForToolStart qwenParserState = iota
 	qwenParserState_CollectingToolContent
+	// CollectingBareFunction handles a <function=…> block that appeared without
+	// an opening <tool_call>; it collects up to and including </function>.
+	qwenParserState_CollectingBareFunction
 )
 
 type Qwen3CoderParser struct {
@@ -151,49 +161,75 @@ func eat(p *Qwen3CoderParser) ([]qwenEvent, bool) {
 
 	switch p.state {
 	case qwenParserState_LookingForToolStart:
-		if strings.Contains(p.acc.String(), toolOpenTag) {
-			// we found a full tool open tag, so we can emit the content before the
-			// tag, being sure to trim any trailing whitespace
-			split := strings.SplitN(p.acc.String(), toolOpenTag, 2)
-			before := split[0]
-			before = strings.TrimRightFunc(before, unicode.IsSpace)
+		acc := p.acc.String()
+		// Dispatch on the earliest of three triggers:
+		//   <tool_call>   — normal envelope open
+		//   <function=    — a bare function block with no opening <tool_call> (#16686)
+		//   </tool_call>  — a stray close tag with no opener (the same malformation
+		//                   leaves one behind); drop it so it doesn't leak as content
+		best, kind := -1, 0
+		for _, t := range []struct {
+			idx, kind int
+		}{
+			{strings.Index(acc, toolOpenTag), 1},
+			{strings.Index(acc, funcOpenTag), 2},
+			{strings.Index(acc, toolCloseTag), 3},
+		} {
+			if t.idx >= 0 && (best < 0 || t.idx < best) {
+				best, kind = t.idx, t.kind
+			}
+		}
+
+		switch kind {
+		case 1: // <tool_call>: emit content before it, drop the tag, collect the envelope
+			before := strings.TrimRightFunc(acc[:best], unicode.IsSpace)
 			if len(before) > 0 {
 				events = append(events, qwenEventContent{content: before})
 			}
-			after := split[1]
 			p.acc.Reset()
-			p.acc.WriteString(after)
+			p.acc.WriteString(acc[best+len(toolOpenTag):])
 			p.state = qwenParserState_CollectingToolContent
 			return events, true
-		} else if overlap := overlap(p.acc.String(), toolOpenTag); overlap > 0 {
-			// we found a partial tool open tag, so we can emit the unambiguous part,
-			// which is the (trailing-whitespace trimmed) content before the partial
-			// tool open tag
-			beforePartialTag := p.acc.String()[:len(p.acc.String())-overlap]
-			trailingWhitespaceLen := trailingWhitespaceLen(beforePartialTag)
-			ambiguousStart := len(beforePartialTag) - trailingWhitespaceLen
-			unambiguous := p.acc.String()[:ambiguousStart]
-			ambiguous := p.acc.String()[ambiguousStart:]
-			p.acc.Reset()
-			p.acc.WriteString(ambiguous)
-			if len(unambiguous) > 0 {
-				events = append(events, qwenEventContent{content: unambiguous})
+		case 2: // bare <function=>: emit content before it, KEEP the tag, collect to </function>
+			before := strings.TrimRightFunc(acc[:best], unicode.IsSpace)
+			if len(before) > 0 {
+				events = append(events, qwenEventContent{content: before})
 			}
-			return events, false
-		} else {
-			// we found content that is entirely not a tool call. We should withhold
-			// any trailing whitespace in case this is the end of the content
-			whitespaceLen := trailingWhitespaceLen(p.acc.String())
-			ambiguousStart := len(p.acc.String()) - whitespaceLen
-			unambiguous := p.acc.String()[:ambiguousStart]
-			ambiguous := p.acc.String()[ambiguousStart:]
 			p.acc.Reset()
-			p.acc.WriteString(ambiguous)
-			if len(unambiguous) > 0 {
-				events = append(events, qwenEventContent{content: unambiguous})
+			p.acc.WriteString(acc[best:])
+			p.state = qwenParserState_CollectingBareFunction
+			return events, true
+		case 3: // stray </tool_call>: emit content before it, drop the tag + trailing space
+			before := strings.TrimRightFunc(acc[:best], unicode.IsSpace)
+			if len(before) > 0 {
+				events = append(events, qwenEventContent{content: before})
 			}
-			return events, false
+			rest := strings.TrimLeftFunc(acc[best+len(toolCloseTag):], unicode.IsSpace)
+			p.acc.Reset()
+			p.acc.WriteString(rest)
+			return events, true
 		}
+
+		// No complete trigger. Withhold a trailing partial of any of the three
+		// tags (and the whitespace before it, which a real tag would trim), so we
+		// never stream out part of a tag or whitespace that may precede one.
+		o := overlap(acc, toolOpenTag)
+		if of := overlap(acc, funcOpenTag); of > o {
+			o = of
+		}
+		if oc := overlap(acc, toolCloseTag); oc > o {
+			o = oc
+		}
+		beforePartial := acc[:len(acc)-o]
+		ambiguousStart := len(beforePartial) - trailingWhitespaceLen(beforePartial)
+		unambiguous := acc[:ambiguousStart]
+		ambiguous := acc[ambiguousStart:]
+		p.acc.Reset()
+		p.acc.WriteString(ambiguous)
+		if len(unambiguous) > 0 {
+			events = append(events, qwenEventContent{content: unambiguous})
+		}
+		return events, false
 	case qwenParserState_CollectingToolContent:
 		if strings.Contains(p.acc.String(), toolCloseTag) {
 			split := strings.SplitN(p.acc.String(), toolCloseTag, 2)
@@ -215,6 +251,24 @@ func eat(p *Qwen3CoderParser) ([]qwenEvent, bool) {
 			// here
 			return events, false
 		}
+	case qwenParserState_CollectingBareFunction:
+		// We're inside a bare <function=…> block (no enclosing <tool_call>).
+		// Collect up to and including </function>, then emit it as a raw tool
+		// call. We don't stream partial tool content, so we just wait for the
+		// closing tag.
+		acc := p.acc.String()
+		if idx := strings.Index(acc, funcCloseTag); idx >= 0 {
+			raw := acc[:idx+len(funcCloseTag)]
+			// Hand the remainder back to LookingForToolStart. A stray </tool_call>
+			// the model often leaves after the bare block (the #16686 malformation)
+			// is dropped there along with any other trailing tags.
+			p.acc.Reset()
+			p.acc.WriteString(acc[idx+len(funcCloseTag):])
+			events = append(events, qwenEventRawToolCall{raw: raw})
+			p.state = qwenParserState_LookingForToolStart
+			return events, true
+		}
+		return events, false
 	default:
 		panic("unreachable")
 	}

--- a/model/parsers/qwen3coder.go
+++ b/model/parsers/qwen3coder.go
@@ -215,6 +215,34 @@ type XMLParameter struct {
 	Value string `xml:",chardata"`
 }
 
+// extractFunctionBlock narrows the tool-call payload to the first
+// <function=...>...</function> block in the input. Some models occasionally
+// drift from the documented chat_template format (e.g. qwen3.6, which is
+// trained on a wrapper from an earlier generation) and emit stray closing
+// tags or unrelated elements alongside an otherwise valid function block.
+// Anchoring on the function block lets the XML unmarshaler handle the
+// well-formed portion and discard the noise.
+//
+// If no <function= opening tag exists, the input is returned unchanged so
+// the unmarshaler still surfaces the same error it would have before — the
+// helper only tightens the input when it can find an anchor, it never
+// invents one.
+func extractFunctionBlock(raw string) string {
+	open := strings.Index(raw, "<function=")
+	if open < 0 {
+		return raw
+	}
+	// The first </function> after the opener is the matching close tag.
+	// Using LastIndex would accidentally absorb stray duplicates (e.g.
+	// `</function></function>`) into the slice and re-introduce the same
+	// xml.Unmarshal error this helper is meant to prevent.
+	end := strings.Index(raw[open:], "</function>")
+	if end < 0 {
+		return raw
+	}
+	return raw[open : open+end+len("</function>")]
+}
+
 // parseToolCall parses a raw tool call string into an api.ToolCall.
 // The raw string follows an xml-like format, here's an example:
 //
@@ -229,7 +257,7 @@ type XMLParameter struct {
 func parseToolCall(raw qwenEventRawToolCall, tools []api.Tool) (api.ToolCall, error) {
 	toolCall := api.ToolCall{}
 
-	xmlString := transformToXML(raw.raw)
+	xmlString := transformToXML(extractFunctionBlock(raw.raw))
 
 	var functionCall XMLFunctionCall
 	err := xml.Unmarshal([]byte(xmlString), &functionCall)

--- a/model/parsers/qwen3coder.go
+++ b/model/parsers/qwen3coder.go
@@ -80,6 +80,23 @@ func (p *Qwen3CoderParser) Add(s string, done bool) (content string, thinking st
 
 	events := p.parseEvents()
 
+	// If the stream ended while we were still inside a bare <function=…>
+	// block that never closed, flush what we accumulated as content
+	// rather than dropping it silently. The block is not a valid tool
+	// call — we don't have </function> — so surfacing it as content is
+	// the closest thing to what the model actually tried to say. The
+	// tool-envelope case (CollectingToolContent) intentionally still
+	// drops on unterminated close, since <tool_call> is an unambiguous
+	// invocation attempt and emitting the raw envelope as content would
+	// be more confusing than helpful.
+	if done && p.state == qwenParserState_CollectingBareFunction {
+		if remaining := p.acc.String(); remaining != "" {
+			events = append(events, qwenEventContent{content: remaining})
+		}
+		p.acc.Reset()
+		p.state = qwenParserState_LookingForToolStart
+	}
+
 	var toolCalls []api.ToolCall
 	var sb strings.Builder
 	for _, event := range events {
@@ -190,8 +207,26 @@ func eat(p *Qwen3CoderParser) ([]qwenEvent, bool) {
 			p.acc.WriteString(acc[best+len(toolOpenTag):])
 			p.state = qwenParserState_CollectingToolContent
 			return events, true
-		case 2: // bare <function=>: emit content before it, KEEP the tag, collect to </function>
-			before := strings.TrimRightFunc(acc[:best], unicode.IsSpace)
+		case 2: // bare <function=>: only trigger when the tag stands alone
+			// Reject the trigger if the block appears mid-prose. Models asked
+			// to explain their own tool-call syntax happily emit inline
+			// examples like "you use <function=get_weather> to call it",
+			// and we don't want to consume those as real tool calls. A real
+			// drift-mode call is separated by a newline (or is at the start
+			// of the stream) — we treat anything mid-line as prose and let
+			// it pass through as content.
+			leading := acc[:best]
+			trimmedRight := strings.TrimRight(leading, " \t")
+			atCallBoundary := trimmedRight == "" || strings.HasSuffix(trimmedRight, "\n") || strings.HasSuffix(trimmedRight, ">")
+			if !atCallBoundary {
+				// Emit everything up to and including the tag as content,
+				// then keep scanning the remainder for a legitimate trigger.
+				events = append(events, qwenEventContent{content: acc[:best+len(funcOpenTag)]})
+				p.acc.Reset()
+				p.acc.WriteString(acc[best+len(funcOpenTag):])
+				return events, true
+			}
+			before := strings.TrimRightFunc(leading, unicode.IsSpace)
 			if len(before) > 0 {
 				events = append(events, qwenEventContent{content: before})
 			}
@@ -336,9 +371,15 @@ func parseToolCall(raw qwenEventRawToolCall, tools []api.Tool) (api.ToolCall, er
 	xmlString := transformToXML(extracted)
 
 	var functionCall XMLFunctionCall
-	err := xml.Unmarshal([]byte(xmlString), &functionCall)
-	if err != nil {
-		return api.ToolCall{}, err
+	if err := xml.Unmarshal([]byte(xmlString), &functionCall); err != nil {
+		// A malformed bare block (e.g. unterminated <parameter=…>) reaches
+		// us as a well-delimited slice but invalid XML. The old behavior
+		// propagated the error, which 500'd the whole chat request. Prefer
+		// the sentinel so the streaming caller skips this call silently,
+		// matching the empty-envelope behavior. The raw slice is logged so
+		// the drift is still traceable.
+		slog.Warn("qwen bare function block failed to parse; skipping", "error", err, "raw", raw.raw)
+		return api.ToolCall{}, errEmptyToolCall
 	}
 
 	toolCall.Function = api.ToolCallFunction{

--- a/model/parsers/qwen3coder.go
+++ b/model/parsers/qwen3coder.go
@@ -52,6 +52,14 @@ type Qwen3CoderParser struct {
 	acc       strings.Builder
 	tools     []api.Tool
 	callIndex int
+	// lineHasContent tracks whether the current output line has emitted
+	// any non-whitespace content yet. It persists across Add() calls so
+	// the bare-<function=> and stray-</tool_call> prose guards work
+	// under streaming input, where preceding prose is emitted in earlier
+	// calls and by the time the trigger arrives the local buffer only
+	// holds the withheld partial tag. Reset by a newline in emitted
+	// content, set by any non-whitespace rune.
+	lineHasContent bool
 }
 
 func (p *Qwen3CoderParser) HasToolSupport() bool {
@@ -72,7 +80,40 @@ func (p *Qwen3CoderParser) PreservedTokens() []string {
 func (p *Qwen3CoderParser) Init(tools []api.Tool, lastMessage *api.Message, thinkValue *api.ThinkValue) []api.Tool {
 	p.tools = tools
 	p.callIndex = 0
+	p.lineHasContent = false
 	return tools // Qwen doesn't modify tools
+}
+
+// recordEmitted updates lineHasContent to reflect the position we'd be at
+// after streaming s to the caller. A newline resets to false (fresh line);
+// any other non-whitespace rune sets to true.
+func (p *Qwen3CoderParser) recordEmitted(s string) {
+	for _, r := range s {
+		if r == '\n' {
+			p.lineHasContent = false
+		} else if !unicode.IsSpace(r) {
+			p.lineHasContent = true
+		}
+	}
+}
+
+// atCallBoundary reports whether appending leading to the already-emitted
+// stream would leave us at a call boundary — the start of a line (either
+// the stream start or after a newline) with no non-whitespace content
+// since. Used by the bare-<function=> and stray-</tool_call> guards to
+// distinguish real drift-mode calls (own-line) from prose mentions
+// (mid-line). Chained tool calls work via p.lineHasContent being reset
+// to false whenever Add() processes a tool-call event.
+func (p *Qwen3CoderParser) atCallBoundary(leading string) bool {
+	hasContent := p.lineHasContent
+	for _, r := range leading {
+		if r == '\n' {
+			hasContent = false
+		} else if !unicode.IsSpace(r) {
+			hasContent = true
+		}
+	}
+	return !hasContent
 }
 
 func (p *Qwen3CoderParser) Add(s string, done bool) (content string, thinking string, calls []api.ToolCall, err error) {
@@ -102,6 +143,12 @@ func (p *Qwen3CoderParser) Add(s string, done bool) (content string, thinking st
 	for _, event := range events {
 		switch event := event.(type) {
 		case qwenEventRawToolCall:
+			// A tool call — real or empty — is a semantic line break: the
+			// model is done with prose and won't be building on the same
+			// line. Reset so a follow-on bare <function=…> in a later
+			// Add() is recognized as at a call boundary even if there was
+			// non-whitespace content earlier in the turn.
+			p.lineHasContent = false
 			toolCall, err := parseToolCall(event, p.tools)
 			if errors.Is(err, errEmptyToolCall) {
 				// Model emitted an empty or non-tool <tool_call> envelope.
@@ -122,6 +169,7 @@ func (p *Qwen3CoderParser) Add(s string, done bool) (content string, thinking st
 			// events, we naively append them together here. See the note below about
 			// `qwenEvent`s for more details
 			sb.WriteString(event.content)
+			p.recordEmitted(event.content)
 		}
 	}
 
@@ -215,10 +263,13 @@ func eat(p *Qwen3CoderParser) ([]qwenEvent, bool) {
 			// drift-mode call is separated by a newline (or is at the start
 			// of the stream) — we treat anything mid-line as prose and let
 			// it pass through as content.
+			//
+			// The check must combine per-call `leading` with cross-call
+			// `p.lineHasContent`, since under streaming input the preceding
+			// prose was already emitted in earlier Add() calls and `leading`
+			// alone would be empty.
 			leading := acc[:best]
-			trimmedRight := strings.TrimRight(leading, " \t")
-			atCallBoundary := trimmedRight == "" || strings.HasSuffix(trimmedRight, "\n") || strings.HasSuffix(trimmedRight, ">")
-			if !atCallBoundary {
+			if !p.atCallBoundary(leading) {
 				// Emit everything up to and including the tag as content,
 				// then keep scanning the remainder for a legitimate trigger.
 				events = append(events, qwenEventContent{content: acc[:best+len(funcOpenTag)]})
@@ -234,14 +285,28 @@ func eat(p *Qwen3CoderParser) ([]qwenEvent, bool) {
 			p.acc.WriteString(acc[best:])
 			p.state = qwenParserState_CollectingBareFunction
 			return events, true
-		case 3: // stray </tool_call>: emit content before it, drop the tag + trailing space
-			before := strings.TrimRightFunc(acc[:best], unicode.IsSpace)
-			if len(before) > 0 {
-				events = append(events, qwenEventContent{content: before})
+		case 3: // stray </tool_call>
+			// If we're at a call boundary (the tag is trailing a completed
+			// drift-mode tool call — the #16686 malformation always leaves
+			// one behind), drop it silently along with framing whitespace.
+			// Otherwise it's a prose mention of the tag: preserve it as
+			// content so words don't collide ("the </tool_call> tag" must
+			// not become "thetag"). This matches main's behavior of
+			// leaking unrecognized tags through as content.
+			leading := acc[:best]
+			if p.atCallBoundary(leading) {
+				before := strings.TrimRightFunc(leading, unicode.IsSpace)
+				if len(before) > 0 {
+					events = append(events, qwenEventContent{content: before})
+				}
+				rest := strings.TrimLeftFunc(acc[best+len(toolCloseTag):], unicode.IsSpace)
+				p.acc.Reset()
+				p.acc.WriteString(rest)
+				return events, true
 			}
-			rest := strings.TrimLeftFunc(acc[best+len(toolCloseTag):], unicode.IsSpace)
+			events = append(events, qwenEventContent{content: acc[:best+len(toolCloseTag)]})
 			p.acc.Reset()
-			p.acc.WriteString(rest)
+			p.acc.WriteString(acc[best+len(toolCloseTag):])
 			return events, true
 		}
 

--- a/model/parsers/qwen3coder_test.go
+++ b/model/parsers/qwen3coder_test.go
@@ -545,6 +545,70 @@ Hello! 你好! 🌟 مرحبا
 				},
 			},
 		},
+		// Regression: qwen3.6 occasionally emits a spurious extra </function> close
+		// tag after an otherwise valid block (drift from the documented
+		// chat_template format). The parser anchors on the function block and
+		// discards the stray tag.
+		{
+			name:  "trailing stray </function> close tag",
+			tools: []api.Tool{},
+			rawToolCall: `<function=get_weather>
+<parameter=location>
+Paris
+</parameter>
+</function>
+</function>`,
+			wantToolCall: api.ToolCall{
+				Function: api.ToolCallFunction{
+					Name: "get_weather",
+					Arguments: testArgs(map[string]any{
+						"location": "Paris",
+					}),
+				},
+			},
+		},
+		// Regression: qwen3.6 was trained on a <function_invocation>...</function_invocation>
+		// wrapper from an earlier generation and intermittently leaks the close
+		// tag through even when the renderer specifies <tool_call>...</tool_call>.
+		{
+			name:  "stray </function_invocation> close tag from older wrapper format",
+			tools: []api.Tool{},
+			rawToolCall: `<function=get_weather>
+<parameter=location>
+Paris
+</parameter>
+</function>
+</function_invocation>`,
+			wantToolCall: api.ToolCall{
+				Function: api.ToolCallFunction{
+					Name: "get_weather",
+					Arguments: testArgs(map[string]any{
+						"location": "Paris",
+					}),
+				},
+			},
+		},
+		// Regression: stray opening wrapper before the function block — handles
+		// the case where the model emits an unrelated container around the call.
+		{
+			name:  "stray <function_invocation> wrapper around function block",
+			tools: []api.Tool{},
+			rawToolCall: `<function_invocation>
+<function=get_weather>
+<parameter=location>
+Paris
+</parameter>
+</function>
+</function_invocation>`,
+			wantToolCall: api.ToolCall{
+				Function: api.ToolCallFunction{
+					Name: "get_weather",
+					Arguments: testArgs(map[string]any{
+						"location": "Paris",
+					}),
+				},
+			},
+		},
 	}
 
 	for i, step := range steps {
@@ -555,6 +619,53 @@ Hello! 你好! 🌟 مرحبا
 		if !toolCallEqual(gotToolCall, step.wantToolCall) {
 			t.Errorf("step %d (%s): got tool call %#v, want %#v", i, step.name, gotToolCall, step.wantToolCall)
 		}
+	}
+}
+
+func TestExtractFunctionBlock(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "passthrough — input is already a clean function block",
+			in:   `<function=foo><parameter=x>1</parameter></function>`,
+			want: `<function=foo><parameter=x>1</parameter></function>`,
+		},
+		{
+			name: "trims trailing stray closing tags",
+			in:   `<function=foo><parameter=x>1</parameter></function></function></function_invocation>`,
+			want: `<function=foo><parameter=x>1</parameter></function>`,
+		},
+		{
+			name: "trims leading wrapper",
+			in:   `<function_invocation><function=foo><parameter=x>1</parameter></function></function_invocation>`,
+			want: `<function=foo><parameter=x>1</parameter></function>`,
+		},
+		{
+			name: "no <function= anchor — returns input unchanged so existing error path fires",
+			in:   `<parameter=x>1</parameter></function>`,
+			want: `<parameter=x>1</parameter></function>`,
+		},
+		{
+			name: "no </function> close — returns input unchanged",
+			in:   `<function=foo><parameter=x>1</parameter>`,
+			want: `<function=foo><parameter=x>1</parameter>`,
+		},
+		{
+			name: "empty input",
+			in:   ``,
+			want: ``,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := extractFunctionBlock(tc.in); got != tc.want {
+				t.Errorf("extractFunctionBlock(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/model/parsers/qwen3coder_test.go
+++ b/model/parsers/qwen3coder_test.go
@@ -624,48 +624,146 @@ Paris
 
 func TestExtractFunctionBlock(t *testing.T) {
 	cases := []struct {
-		name string
-		in   string
-		want string
+		name   string
+		in     string
+		want   string
+		wantOk bool
 	}{
 		{
-			name: "passthrough — input is already a clean function block",
-			in:   `<function=foo><parameter=x>1</parameter></function>`,
-			want: `<function=foo><parameter=x>1</parameter></function>`,
+			name:   "passthrough — input is already a clean function block",
+			in:     `<function=foo><parameter=x>1</parameter></function>`,
+			want:   `<function=foo><parameter=x>1</parameter></function>`,
+			wantOk: true,
 		},
 		{
-			name: "trims trailing stray closing tags",
-			in:   `<function=foo><parameter=x>1</parameter></function></function></function_invocation>`,
-			want: `<function=foo><parameter=x>1</parameter></function>`,
+			name:   "trims trailing stray closing tags",
+			in:     `<function=foo><parameter=x>1</parameter></function></function></function_invocation>`,
+			want:   `<function=foo><parameter=x>1</parameter></function>`,
+			wantOk: true,
 		},
 		{
-			name: "trims leading wrapper",
-			in:   `<function_invocation><function=foo><parameter=x>1</parameter></function></function_invocation>`,
-			want: `<function=foo><parameter=x>1</parameter></function>`,
+			name:   "trims leading wrapper",
+			in:     `<function_invocation><function=foo><parameter=x>1</parameter></function></function_invocation>`,
+			want:   `<function=foo><parameter=x>1</parameter></function>`,
+			wantOk: true,
 		},
 		{
-			name: "no <function= anchor — returns input unchanged so existing error path fires",
-			in:   `<parameter=x>1</parameter></function>`,
-			want: `<parameter=x>1</parameter></function>`,
+			name:   "no <function= anchor — empty envelope drift",
+			in:     `<parameter=x>1</parameter></function>`,
+			want:   ``,
+			wantOk: false,
 		},
 		{
-			name: "no </function> close — returns input unchanged",
-			in:   `<function=foo><parameter=x>1</parameter>`,
-			want: `<function=foo><parameter=x>1</parameter>`,
+			name:   "no </function> close — partial / truncated envelope",
+			in:     `<function=foo><parameter=x>1</parameter>`,
+			want:   ``,
+			wantOk: false,
 		},
 		{
-			name: "empty input",
-			in:   ``,
-			want: ``,
+			name:   "empty input — empty envelope (model emitted <tool_call></tool_call>)",
+			in:     ``,
+			want:   ``,
+			wantOk: false,
+		},
+		{
+			name:   "whitespace only — empty envelope",
+			in:     "\n   \t \n",
+			want:   ``,
+			wantOk: false,
+		},
+		{
+			name:   "non-XML prose — empty envelope (model put narration in <tool_call> tags)",
+			in:     `let me check the files`,
+			want:   ``,
+			wantOk: false,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := extractFunctionBlock(tc.in); got != tc.want {
-				t.Errorf("extractFunctionBlock(%q) = %q, want %q", tc.in, got, tc.want)
+			got, ok := extractFunctionBlock(tc.in)
+			if got != tc.want || ok != tc.wantOk {
+				t.Errorf("extractFunctionBlock(%q) = (%q, %v), want (%q, %v)", tc.in, got, ok, tc.want, tc.wantOk)
 			}
 		})
+	}
+}
+
+// TestQwenParserEmptyToolCallEnvelope covers the streaming behavior when
+// qwen3.6 emits a <tool_call>...</tool_call> envelope with no parseable
+// function block inside. These shapes used to return an error from
+// parseToolCall (EOF, "expected element type <function> but have
+// <parameter>", etc) which the runner surfaced as HTTP 500 — taking down
+// the entire chat request even though the rest of the stream was healthy.
+// The parser now treats these as silent no-ops so the agent loop can
+// retry or finalize on its own.
+func TestQwenParserEmptyToolCallEnvelope(t *testing.T) {
+	cases := []struct {
+		name        string
+		envelope    string
+		wantContent string
+	}{
+		{
+			name:        "completely empty envelope",
+			envelope:    `<tool_call></tool_call>`,
+			wantContent: "",
+		},
+		{
+			name:        "whitespace-only envelope",
+			envelope:    "<tool_call>\n   \n</tool_call>",
+			wantContent: "",
+		},
+		{
+			name:        "prose-only envelope (model put narration in tool_call tags)",
+			envelope:    `<tool_call>let me check the files</tool_call>`,
+			wantContent: "",
+		},
+		{
+			name:        "parameter-only drift (no <function= anchor)",
+			envelope:    `<tool_call><parameter=x>1</parameter></tool_call>`,
+			wantContent: "",
+		},
+		{
+			name:        "partial function block (missing </function> close)",
+			envelope:    `<tool_call><function=foo><parameter=x>1</parameter></tool_call>`,
+			wantContent: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := Qwen3CoderParser{}
+			p.Init(nil, nil, nil)
+			content, _, calls, err := p.Add(tc.envelope, true)
+			if err != nil {
+				t.Fatalf("Add returned error for empty envelope %q: %v", tc.envelope, err)
+			}
+			if len(calls) != 0 {
+				t.Errorf("expected 0 tool calls for empty envelope, got %d", len(calls))
+			}
+			if content != tc.wantContent {
+				t.Errorf("content = %q, want %q", content, tc.wantContent)
+			}
+		})
+	}
+}
+
+// TestQwenParserEmptyEnvelopeMixedWithRealCalls verifies that a stray
+// empty envelope doesn't poison the rest of the stream — adjacent real
+// tool calls in the same Add() invocation still get parsed.
+func TestQwenParserEmptyEnvelopeMixedWithRealCalls(t *testing.T) {
+	p := Qwen3CoderParser{}
+	p.Init(nil, nil, nil)
+	input := `<tool_call></tool_call><tool_call><function=get_weather><parameter=location>Paris</parameter></function></tool_call>`
+	_, _, calls, err := p.Add(input, true)
+	if err != nil {
+		t.Fatalf("Add returned error: %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 tool call after skipping empty envelope, got %d", len(calls))
+	}
+	if calls[0].Function.Name != "get_weather" {
+		t.Errorf("got call name %q, want %q", calls[0].Function.Name, "get_weather")
 	}
 }
 

--- a/model/parsers/qwen3coder_test.go
+++ b/model/parsers/qwen3coder_test.go
@@ -1,7 +1,9 @@
 package parsers
 
 import (
+	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/ollama/ollama/api"
@@ -764,6 +766,101 @@ func TestQwenParserEmptyEnvelopeMixedWithRealCalls(t *testing.T) {
 	}
 	if calls[0].Function.Name != "get_weather" {
 		t.Errorf("got call name %q, want %q", calls[0].Function.Name, "get_weather")
+	}
+}
+
+// TestQwenParserBareFunctionNoOpenTag covers
+// https://github.com/ollama/ollama/issues/16686: qwen3-coder / qwen3.6
+// sometimes emit a <function=…> block with no opening <tool_call> tag
+// (frequently leaving a stray </tool_call> behind). The parser must recognize
+// the call instead of leaking the whole block into content.
+func TestQwenParserBareFunctionNoOpenTag(t *testing.T) {
+	cases := []struct {
+		name        string
+		input       string
+		wantContent string
+		wantName    string
+		wantArg     string // expected value of the "pattern" argument
+	}{
+		{
+			name:        "bare function with stray closing tag (the #16686 case)",
+			input:       "<function=Glob>\n<parameter=pattern>\n*.md\n</parameter>\n</function>\n</tool_call>",
+			wantContent: "",
+			wantName:    "Glob",
+			wantArg:     "*.md",
+		},
+		{
+			name:        "bare function with no closing tool tag at all",
+			input:       "<function=Glob><parameter=pattern>*.md</parameter></function>",
+			wantContent: "",
+			wantName:    "Glob",
+			wantArg:     "*.md",
+		},
+		{
+			name:        "narration before a bare function block",
+			input:       "I'll list the markdown files.\n\n<function=Glob><parameter=pattern>*.md</parameter></function></tool_call>",
+			wantContent: "I'll list the markdown files.",
+			wantName:    "Glob",
+			wantArg:     "*.md",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := Qwen3CoderParser{}
+			p.Init(nil, nil, nil)
+			content, _, calls, err := p.Add(tc.input, true)
+			if err != nil {
+				t.Fatalf("Add returned error: %v", err)
+			}
+			if content != tc.wantContent {
+				t.Errorf("content = %q, want %q", content, tc.wantContent)
+			}
+			if len(calls) != 1 {
+				t.Fatalf("expected 1 tool call, got %d", len(calls))
+			}
+			if calls[0].Function.Name != tc.wantName {
+				t.Errorf("call name = %q, want %q", calls[0].Function.Name, tc.wantName)
+			}
+			got, ok := calls[0].Function.Arguments.Get("pattern")
+			if !ok {
+				t.Fatalf("missing 'pattern' argument")
+			}
+			if fmt.Sprint(got) != tc.wantArg {
+				t.Errorf("pattern arg = %v, want %q", got, tc.wantArg)
+			}
+		})
+	}
+}
+
+// TestQwenParserBareFunctionStreaming feeds the #16686 malformation one rune at
+// a time, exercising the partial-tag withholding for the <function= trigger so
+// the block is never streamed out as content before it's recognized.
+func TestQwenParserBareFunctionStreaming(t *testing.T) {
+	input := "Here you go.\n\n<function=Glob><parameter=pattern>*.md</parameter></function></tool_call>"
+	p := Qwen3CoderParser{}
+	p.Init(nil, nil, nil)
+
+	var content strings.Builder
+	var calls []api.ToolCall
+	runes := []rune(input)
+	for i, r := range runes {
+		c, _, cl, err := p.Add(string(r), i == len(runes)-1)
+		if err != nil {
+			t.Fatalf("Add returned error at rune %d: %v", i, err)
+		}
+		content.WriteString(c)
+		calls = append(calls, cl...)
+	}
+
+	if got := content.String(); got != "Here you go." {
+		t.Errorf("content = %q, want %q", got, "Here you go.")
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(calls))
+	}
+	if calls[0].Function.Name != "Glob" {
+		t.Errorf("call name = %q, want %q", calls[0].Function.Name, "Glob")
 	}
 }
 

--- a/model/parsers/qwen3coder_test.go
+++ b/model/parsers/qwen3coder_test.go
@@ -864,6 +864,113 @@ func TestQwenParserBareFunctionStreaming(t *testing.T) {
 	}
 }
 
+// TestQwenParserBareFunctionInProse covers reviewer feedback on #16398:
+// when the model writes documentation or code-in-prose examples containing
+// "<function=…>" fragments, the parser must not consume them as real tool
+// calls. Only blocks that appear at a call boundary (start of stream or
+// after a newline / closing tag) should trigger tool-call collection.
+func TestQwenParserBareFunctionInProse(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		wantCalls int
+	}{
+		{
+			name:      "single inline example after a colon",
+			input:     "You would call it like this: <function=get_weather><parameter=location>Tokyo</parameter></function> and get a result.",
+			wantCalls: 0,
+		},
+		{
+			name: "reviewer's reproducer - three inline examples",
+			input: `Here are some examples:
+- Weather lookup: <function=get_weather><parameter=location>Tokyo</parameter></function>
+- Generic form: <function=function_name><parameter=arg>value</parameter></function>
+- File glob: <function=Glob><parameter=pattern>*.pdf</parameter></function>
+Those show the syntax.`,
+			wantCalls: 0,
+		},
+		{
+			name:      "inline mention with no complete block after",
+			input:     "The <function= tag opens a call, and </function> closes it.",
+			wantCalls: 0,
+		},
+		{
+			name:      "legitimate bare call after narration and newline still fires",
+			input:     "I'll check the weather now.\n<function=get_weather><parameter=location>Tokyo</parameter></function>",
+			wantCalls: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := Qwen3CoderParser{}
+			p.Init(nil, nil, nil)
+			_, _, calls, err := p.Add(tc.input, true)
+			if err != nil {
+				t.Fatalf("Add returned error: %v", err)
+			}
+			if len(calls) != tc.wantCalls {
+				t.Errorf("got %d tool calls, want %d (calls=%+v)", len(calls), tc.wantCalls, calls)
+			}
+		})
+	}
+}
+
+// TestQwenParserMalformedBareBlockNoError covers reviewer feedback on #16398:
+// a bare <function=…></function> pair whose contents fail xml.Unmarshal must
+// not propagate the error (which would 500 the chat request). It should be
+// treated like an empty envelope — skipped silently with the streaming
+// caller returning cleanly.
+func TestQwenParserMalformedBareBlockNoError(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "unterminated parameter tag",
+			input: "<function=broken><parameter=arg>value oops</function>",
+		},
+		{
+			name:  "mismatched inner tag",
+			input: "<function=broken><parameter=arg>value</different></function>",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := Qwen3CoderParser{}
+			p.Init(nil, nil, nil)
+			_, _, calls, err := p.Add(tc.input, true)
+			if err != nil {
+				t.Fatalf("Add returned error for malformed bare block: %v", err)
+			}
+			if len(calls) != 0 {
+				t.Errorf("expected 0 tool calls for malformed block, got %d", len(calls))
+			}
+		})
+	}
+}
+
+// TestQwenParserIncompleteBareBlockFlushesAsContent covers reviewer feedback
+// on #16398: if the model opens a bare <function=…> block and the stream
+// ends before </function> arrives, the accumulated bytes must reach the
+// caller as content rather than being silently dropped.
+func TestQwenParserIncompleteBareBlockFlushesAsContent(t *testing.T) {
+	p := Qwen3CoderParser{}
+	p.Init(nil, nil, nil)
+	input := "<function=Glob><parameter=pattern>*.md</parameter>"
+	content, _, calls, err := p.Add(input, true)
+	if err != nil {
+		t.Fatalf("Add returned error: %v", err)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("expected 0 tool calls (block never closed), got %d", len(calls))
+	}
+	if !strings.Contains(content, "<function=Glob>") || !strings.Contains(content, "*.md") {
+		t.Errorf("content = %q, expected it to preserve the unterminated block", content)
+	}
+}
+
 func TestTrailingWhitespaceLenUnicode(t *testing.T) {
 	cases := []struct {
 		name  string

--- a/model/parsers/qwen3coder_test.go
+++ b/model/parsers/qwen3coder_test.go
@@ -916,6 +916,118 @@ Those show the syntax.`,
 	}
 }
 
+// TestQwenParserBareFunctionInProseStreaming covers @ParthSareen's second-round
+// review on #16398: the single-call prose guard passes when input arrives
+// rune-by-rune because the preceding prose is emitted in earlier Add() calls
+// and by the time <function= is recognized the local buffer only has the
+// withheld partial tag. The guard has to remember line state across calls.
+func TestQwenParserBareFunctionInProseStreaming(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		wantCalls int
+	}{
+		{
+			name:      "reviewer's exact streaming reproducer",
+			input:     "Use <function=get_weather><parameter=location>Tokyo</parameter></function> to get weather.",
+			wantCalls: 0,
+		},
+		{
+			name:      "prose across multiple sentences before an inline example",
+			input:     "Here is how it works. You call it like <function=Glob><parameter=pattern>*.md</parameter></function> and get files back.",
+			wantCalls: 0,
+		},
+		{
+			name:      "narration then newline then real bare call still fires",
+			input:     "I'll check the weather now.\n<function=get_weather><parameter=location>Tokyo</parameter></function>",
+			wantCalls: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := Qwen3CoderParser{}
+			p.Init(nil, nil, nil)
+			var calls []api.ToolCall
+			runes := []rune(tc.input)
+			for i, r := range runes {
+				_, _, cl, err := p.Add(string(r), i == len(runes)-1)
+				if err != nil {
+					t.Fatalf("Add returned error at rune %d (%q): %v", i, string(r), err)
+				}
+				calls = append(calls, cl...)
+			}
+			if len(calls) != tc.wantCalls {
+				t.Errorf("streaming got %d tool calls, want %d (calls=%+v)", len(calls), tc.wantCalls, calls)
+			}
+		})
+	}
+}
+
+// TestQwenParserStrayCloseTagInProse covers @ParthSareen's second-round
+// review on #16398: a stray </tool_call> that appears in prose must not
+// collide adjacent words. The bare-function feature added stray-tag
+// dropping (needed for the #16686 malformation where a real drift-mode
+// call is trailed by a stray </tool_call>), but the drop trimmed
+// whitespace from both sides, turning "the </tool_call> tag" into
+// "thetag". The tag is only dropped when it appears at a call boundary
+// (trailing a completed tool call); prose mentions are preserved.
+func TestQwenParserStrayCloseTagInProse(t *testing.T) {
+	cases := []struct {
+		name          string
+		input         string
+		wantSubstring string // must appear verbatim in emitted content
+	}{
+		{
+			name:          "single-call: stray tag in prose preserves word boundaries",
+			input:         "The closing tag is </tool_call> and that's fine.",
+			wantSubstring: "tag is </tool_call> and",
+		},
+		{
+			name:          "single-call: no adjacent word collision",
+			input:         "You end with </tool_call> after a call.",
+			wantSubstring: "with </tool_call> after",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := Qwen3CoderParser{}
+			p.Init(nil, nil, nil)
+			content, _, calls, err := p.Add(tc.input, true)
+			if err != nil {
+				t.Fatalf("Add returned error: %v", err)
+			}
+			if len(calls) != 0 {
+				t.Errorf("expected 0 tool calls for prose mention, got %d", len(calls))
+			}
+			if !strings.Contains(content, tc.wantSubstring) {
+				t.Errorf("content = %q\n  did not contain %q", content, tc.wantSubstring)
+			}
+		})
+	}
+}
+
+// TestQwenParserStrayCloseTagAfterBareCall keeps the #16686 behavior alive:
+// when a bare drift-mode call leaves a trailing </tool_call>, it must still
+// be dropped rather than surface as content. Guards against regressing the
+// original malformation fix while adding the prose-preservation carve-out.
+func TestQwenParserStrayCloseTagAfterBareCall(t *testing.T) {
+	p := Qwen3CoderParser{}
+	p.Init(nil, nil, nil)
+	input := "<function=Glob><parameter=pattern>*.md</parameter></function></tool_call>"
+	content, _, calls, err := p.Add(input, true)
+	if err != nil {
+		t.Fatalf("Add returned error: %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(calls))
+	}
+	if content != "" {
+		t.Errorf("expected empty content, got %q (stray </tool_call> leaked)", content)
+	}
+}
+
 // TestQwenParserMalformedBareBlockNoError covers reviewer feedback on #16398:
 // a bare <function=…></function> pair whose contents fail xml.Unmarshal must
 // not propagate the error (which would 500 the chat request). It should be


### PR DESCRIPTION
## Summary

Fixes #16383 — `qwen3.6:27b` (and the other qwen3.6 tags) is registered with `PARSER qwen3.5` / `RENDERER qwen3.5` and is documented to emit tool calls in the format the qwen3.5 parser expects. In practice the model intermittently drifts to a wrapper from an earlier training generation and emits stray closing tags (`</function>` duplicates, leaked `</function_invocation>` from an older `<function_invocation>...</function_invocation>` wrapper) around an otherwise valid function block. `xml.Unmarshal` rejects the drifted input and `/api/chat` returns 500.

## Approach

Narrow the raw tool-call payload to the first `<function=...>...</function>` block before transforming to XML. The unmarshaler then sees a well-formed fragment and the surrounding noise is discarded.

The helper is deliberately minimal:

- Anchors on the **first** `<function=` and the **first** matching `</function>` after it — using `LastIndex` would have absorbed duplicate close tags into the slice and re-introduced the same `xml.Unmarshal` error.
- If no `<function=` anchor exists, the input is returned unchanged. The existing error path still fires for genuinely malformed inputs — the helper only **tightens**, never invents.
- Healthy `<function=foo>...</function>` payloads pass through unchanged, so `qwen3.5` and `qwen3-coder` happy paths are unaffected.

## Evidence — what qwen3.6 actually emits

From #16383, this is the raw model output when given a tool-use prompt without a `tools[]` field (so the qwen3.5 parser doesn't run and we can see the model's untouched emission):

```
<function=get_weather>
<parameter=location>Paris</parameter>
</function>
</function>
</function_invocation>
```

The valid function block is followed by a spurious extra `</function>` and a `</function_invocation>` close tag with no matching open — strongly suggestive of leakage from a wrapper format the model was trained on alongside `<tool_call>`. With this PR, that input parses successfully; the legitimate `<function=get_weather>...</function>` block is extracted and the trailing noise is discarded.

## Tests

- **`TestQwenToolParser`** — three new regression cases pin the drift shapes:
  - trailing stray `</function>` close tag
  - stray `</function_invocation>` close tag from older wrapper format
  - leading `<function_invocation>` wrapper around the function block

- **`TestExtractFunctionBlock`** — table-driven coverage of the helper itself:
  - passthrough on clean function block
  - trims trailing stray closing tags
  - trims leading wrapper
  - no `<function=` anchor (returns input unchanged so existing error path fires)
  - no `</function>` close (returns input unchanged)
  - empty input

All existing tests in `./model/parsers/...` pass unchanged.

```
$ go test ./model/parsers/...
ok  	github.com/ollama/ollama/model/parsers	0.189s
```


## Also handles #16686 — missing opening `<tool_call>` tag

A third drift shape, reported separately in #16686: `qwen3-coder:30b` frequently emits a complete `<function=…>…</function>` block but omits the opening `<tool_call>` (leaving a stray `</tool_call>` behind):

```
<function=Glob>
<parameter=pattern>
*.md
</parameter>
</function>
</tool_call>
```

The parser only engaged on `<tool_call>`, so the entire block was returned as plain content and agent clients (Claude Code, in the report) never executed the tool. `LookingForToolStart` now treats `<function=` as an alternate trigger (collecting to `</function>`) and drops a stray `</tool_call>` with no opener. Same fallback precedent as goose (block/goose#6883) and vLLM.

**Tests:** `TestQwenParserBareFunctionNoOpenTag` (the malformation + a no-closing-tag variant + narration-before-block) and `TestQwenParserBareFunctionStreaming` (byte-by-byte, which exercises the partial-tag withholding). Full `./model/parsers/...` suite green.
