### PR TITLE
support multiple bind addresses in OLLAMA_HOST

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1998,12 +1998,21 @@ func RunServer(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	ln, err := net.Listen("tcp", envconfig.Host().Host)
-	if err != nil {
-		return err
+	hosts := envconfig.Hosts()
+	listeners := make([]net.Listener, 0, len(hosts))
+	for _, h := range hosts {
+		ln, err := net.Listen("tcp", h.Host)
+		if err != nil {
+			// Close any listeners we already opened
+			for _, l := range listeners {
+				l.Close()
+			}
+			return err
+		}
+		listeners = append(listeners, ln)
 	}
 
-	err = server.Serve(ln)
+	err := server.Serve(listeners)
 	if errors.Is(err, http.ErrServerClosed) {
 		return nil
 	}

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -19,10 +19,19 @@ import (
 
 // Host returns the scheme and host. Host can be configured via the OLLAMA_HOST environment variable.
 // Default is scheme "http" and host "127.0.0.1:11434"
+// When OLLAMA_HOST contains multiple comma-separated values, Host returns the first one.
 func Host() *url.URL {
+	s := strings.TrimSpace(Var("OLLAMA_HOST"))
+	// If multiple hosts are specified, return the first one
+	if i := strings.Index(s, ","); i >= 0 {
+		s = strings.TrimSpace(s[:i])
+	}
+	return parseHost(s)
+}
+
+func parseHost(s string) *url.URL {
 	defaultPort := "11434"
 
-	s := strings.TrimSpace(Var("OLLAMA_HOST"))
 	scheme, hostport, ok := strings.Cut(s, "://")
 	switch {
 	case !ok:
@@ -57,6 +66,30 @@ func Host() *url.URL {
 		Host:   net.JoinHostPort(host, port),
 		Path:   path,
 	}
+}
+
+// Hosts returns all configured host URLs. If OLLAMA_HOST contains comma-separated
+// values, each is parsed as a separate host. This allows binding to multiple
+// addresses (e.g., "127.0.0.1,172.28.48.1:11434").
+func Hosts() []*url.URL {
+	s := strings.TrimSpace(Var("OLLAMA_HOST"))
+	if s == "" || !strings.Contains(s, ",") {
+		return []*url.URL{Host()}
+	}
+
+	var hosts []*url.URL
+	for _, part := range strings.Split(s, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		hosts = append(hosts, parseHost(part))
+	}
+
+	if len(hosts) == 0 {
+		return []*url.URL{Host()}
+	}
+	return hosts
 }
 
 // ConnectableHost returns Host() with unspecified bind addresses (0.0.0.0, ::)
@@ -319,7 +352,7 @@ func AsMap() map[string]EnvVar {
 		"OLLAMA_IGPU_ENABLE":          {"OLLAMA_IGPU_ENABLE", String("OLLAMA_IGPU_ENABLE")(), "Enable integrated GPUs"},
 		"LLAMA_ARG_FIT":               {"LLAMA_ARG_FIT", String("LLAMA_ARG_FIT")(), "Enable llama.cpp automatic fit of unset memory options (default \"on\")"},
 		"LLAMA_ARG_FIT_TARGET":        {"LLAMA_ARG_FIT_TARGET", String("LLAMA_ARG_FIT_TARGET")(), "Target free VRAM margin per device for llama.cpp fit (MiB)"},
-		"OLLAMA_HOST":                 {"OLLAMA_HOST", Host(), "IP Address for the ollama server (default 127.0.0.1:11434)"},
+		"OLLAMA_HOST":                 {"OLLAMA_HOST", Host(), "IP Address for the ollama server (default 127.0.0.1:11434). Comma-separated for multiple addresses"},
 		"OLLAMA_KEEP_ALIVE":           {"OLLAMA_KEEP_ALIVE", KeepAlive(), "The duration that models stay loaded in memory (default \"5m\")"},
 		"OLLAMA_LLM_LIBRARY":          {"OLLAMA_LLM_LIBRARY", LLMLibrary(), "Set LLM library to bypass autodetection"},
 		"OLLAMA_LOAD_TIMEOUT":         {"OLLAMA_LOAD_TIMEOUT", LoadTimeout(), "How long to allow model loads to stall before giving up (default \"5m\")"},

--- a/envconfig/config_test.go
+++ b/envconfig/config_test.go
@@ -83,6 +83,43 @@ func TestConnectableHost(t *testing.T) {
 	}
 }
 
+func TestHosts(t *testing.T) {
+	cases := map[string]struct {
+		value  string
+		expect []string
+	}{
+		"empty":            {"", []string{"http://127.0.0.1:11434"}},
+		"single":           {"192.168.1.5:8080", []string{"http://192.168.1.5:8080"}},
+		"multiple":         {"127.0.0.1,172.28.48.1", []string{"http://127.0.0.1:11434", "http://172.28.48.1:11434"}},
+		"multiple + ports": {"127.0.0.1:11434,172.28.48.1:11435", []string{"http://127.0.0.1:11434", "http://172.28.48.1:11435"}},
+		"with spaces":      {" 127.0.0.1 , 172.28.48.1:9999 ", []string{"http://127.0.0.1:11434", "http://172.28.48.1:9999"}},
+		"trailing comma":   {"127.0.0.1,", []string{"http://127.0.0.1:11434"}},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("OLLAMA_HOST", tt.value)
+			hosts := Hosts()
+			if len(hosts) != len(tt.expect) {
+				t.Fatalf("%s: expected %d hosts, got %d", name, len(tt.expect), len(hosts))
+			}
+			for i, h := range hosts {
+				if h.String() != tt.expect[i] {
+					t.Errorf("%s[%d]: expected %s, got %s", name, i, tt.expect[i], h.String())
+				}
+			}
+		})
+	}
+}
+
+func TestHostMultipleReturnsFirst(t *testing.T) {
+	t.Setenv("OLLAMA_HOST", "192.168.1.5:8080,172.28.48.1:9999")
+	host := Host()
+	if host.String() != "http://192.168.1.5:8080" {
+		t.Errorf("expected first host, got %s", host.String())
+	}
+}
+
 func TestOrigins(t *testing.T) {
 	cases := []struct {
 		value  string

--- a/server/routes.go
+++ b/server/routes.go
@@ -1914,7 +1914,12 @@ func (s *Server) ModelRecommendationsExperimentalHandler(c *gin.Context) {
 	})
 }
 
-func Serve(ln net.Listener) error {
+func Serve(listeners []net.Listener) error {
+	if len(listeners) == 0 {
+		return fmt.Errorf("at least one listener is required")
+	}
+
+	ln := listeners[0]
 	slog.SetDefault(logutil.NewLogger(os.Stderr, envconfig.LogLevel()))
 	slog.Info("server config", "env", envconfig.Values())
 	cloudDisabled, _ := internalcloud.Status()
@@ -1978,7 +1983,9 @@ func Serve(ln net.Listener) error {
 	s.sched = sched
 	s.modelCaches.Start(ctx)
 
-	slog.Info(fmt.Sprintf("Listening on %s (version %s)", ln.Addr(), version.Version))
+	for _, l := range listeners {
+		slog.Info(fmt.Sprintf("Listening on %s (version %s)", l.Addr(), version.Version))
+	}
 	srvr := &http.Server{
 		// Use http.DefaultServeMux so we get net/http/pprof for
 		// free.
@@ -2029,6 +2036,11 @@ func Serve(ln net.Listener) error {
 		s.defaultNumCtx = 4096
 	}
 	slog.Info("vram-based default context", "total_vram", format.HumanBytes2(totalVRAM), "default_num_ctx", s.defaultNumCtx)
+
+	// Serve additional listeners in goroutines
+	for _, l := range listeners[1:] {
+		go srvr.Serve(l)
+	}
 
 	err = srvr.Serve(ln)
 	// If server is closed from the signal handler, wait for the ctx to be done


### PR DESCRIPTION
## Summary

Allow comma-separated addresses in `OLLAMA_HOST` to bind the server to multiple network interfaces simultaneously.

## Motivation

Currently `OLLAMA_HOST` only accepts a single address, forcing users who need access from multiple interfaces (e.g., localhost + WSL bridge) to bind to `0.0.0.0` and rely on firewall rules. This change enables targeted multi-interface binding without full network exposure.

## Usage

```bash
# Bind to both localhost and WSL bridge interface
OLLAMA_HOST=127.0.0.1,172.28.48.1 ollama serve

# Different ports per interface
OLLAMA_HOST=127.0.0.1:11434,172.28.48.1:11435 ollama serve
```

## Changes

- **envconfig/config.go** - Added `Hosts()` function that parses comma-separated values; refactored `Host()` to use shared `parseHost()` helper (returns first host for backward compatibility)
- **cmd/cmd.go** - `RunServer` creates a listener per host
- **server/routes.go** - `Serve` accepts `[]net.Listener`, serves additional listeners in goroutines
- **envconfig/config_test.go** - Tests for `Hosts()` and multi-host `Host()` behavior

## Backward Compatibility

Single-value `OLLAMA_HOST` works exactly as before. The comma separator is the opt-in for multiple addresses.

Fixes #12456