### PR TITLE
docs: fix stale documentation references

### DIFF
--- a/docs/api/anthropic-compatibility.mdx
+++ b/docs/api/anthropic-compatibility.mdx
@@ -339,8 +339,8 @@ claude --model qwen3-coder
 - [x] `content_block_stop`
 - [x] `message_delta`
 - [x] `message_stop`
-- [x] `ping`
-- [x] `error`
+- [ ] `ping`
+- [ ] `error`
 
 ## Models
 

--- a/docs/capabilities/web-search.mdx
+++ b/docs/capabilities/web-search.mdx
@@ -110,7 +110,7 @@ More Ollama [Python example](https://github.com/ollama/ollama-python/blob/main/e
 import { Ollama } from "ollama";
 
 const client = new Ollama();
-const results = await client.webSearch("what is ollama?");
+const results = await client.webSearch({ query: "what is ollama?" });
 console.log(JSON.stringify(results, null, 2));
 ```
 
@@ -213,7 +213,7 @@ models](https://ollama.com/models)\n\nAvailable for macOS, Windows, and Linux',
 import { Ollama } from "ollama";
 
 const client = new Ollama();
-const fetchResult = await client.webFetch("https://ollama.com");
+const fetchResult = await client.webFetch({ url: "https://ollama.com" });
 console.log(JSON.stringify(fetchResult, null, 2));
 ```
 

--- a/docs/integrations/pi.mdx
+++ b/docs/integrations/pi.mdx
@@ -9,7 +9,7 @@ Pi is a minimal and extensible coding agent.
 Install [Pi](https://github.com/badlogic/pi-mono):
 
 ```bash
-npm install -g @mariozechner/pi-coding-agent
+npm install -g @earendil-works/pi-coding-agent
 ```
 
 ## Usage with Ollama

--- a/docs/macos.mdx
+++ b/docs/macos.mdx
@@ -35,8 +35,8 @@ To fully remove Ollama from your system, remove the following files and folders:
 ```
 sudo rm -rf /Applications/Ollama.app
 sudo rm /usr/local/bin/ollama
-rm -rf "~/Library/Application Support/Ollama"
-rm -rf "~/Library/Saved Application State/com.electron.ollama.savedState"
+rm -rf ~/Library/Application\ Support/Ollama
+rm -rf ~/Library/Saved\ Application\ State/com.electron.ollama.savedState
 rm -rf ~/Library/Caches/com.electron.ollama/
 rm -rf ~/Library/Caches/ollama
 rm -rf ~/Library/WebKit/com.electron.ollama


### PR DESCRIPTION
Fixes #16338

Corrects stale documentation items:
1. web-search.mdx - JS SDK examples pass plain strings, should pass request objects
2. macos.mdx - Uninstall commands use quoted tilde paths preventing shell expansion
3. anthropic-compatibility.mdx - ping/error streaming events marked supported but never emitted
4. pi.mdx - npm package scope changed from @mariozechner to @earendil-works