### PR TITLE
cmd/launch: fix opencode state path on Windows

### DIFF
--- a/cmd/launch/opencode.go
+++ b/cmd/launch/opencode.go
@@ -125,10 +125,10 @@ func (o *OpenCode) Paths() []string {
 	return nil
 }
 
-// openCodeStatePath returns the path to opencode's model state file.
-// TODO: this hardcodes the Linux/macOS XDG path. On Windows, opencode stores
-// state under %LOCALAPPDATA% (or similar) — verify and branch on runtime.GOOS.
 func openCodeStatePath() (string, error) {
+	if runtime.GOOS == "windows" {
+		return filepath.Join(os.Getenv("LOCALAPPDATA"), "opencode", "model.json"), nil
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
On Windows, opencode stores its model state under %LOCALAPPDATA% instead of ~/.local/state/opencode/. Adds a untime.GOOS check so the correct path is used.