### PR TITLE
server: add NaN/Inf safety check to EmbeddingsHandler

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -1035,6 +1035,13 @@ func (s *Server) EmbeddingsHandler(c *gin.Context) {
 		return
 	}
 
+	for _, v := range embedding {
+		if math.IsNaN(float64(v)) || math.IsInf(float64(v), 0) {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "model returned invalid embedding"})
+			return
+		}
+	}
+
 	var e []float64
 	for _, v := range embedding {
 		e = append(e, float64(v))


### PR DESCRIPTION
The legacy /api/embeddings endpoint was missing NaN/Inf validation that the newer /v1/embeddings endpoint already has via the normalize() function. An embedding vector containing NaN or Inf values could cause Go's json.Encoder to fail with 'json: unsupported value: NaN'.

This adds an explicit check so the API returns a proper error instead of an unparseable response, preventing issues like #15987.