### PR TITLE
fix: prevent sidebar animation on initial app load

### DIFF
--- a/app/ui/app/src/components/layout/layout.tsx
+++ b/app/ui/app/src/components/layout/layout.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from "react";
 import { Link } from "@tanstack/react-router";
 import { useSettings } from "@/hooks/useSettings";
 
@@ -11,9 +12,11 @@ export function SidebarLayout({
 }>) {
   const { settings, setSettings } = useSettings();
   const isWindows = navigator.platform.toLowerCase().includes("win");
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => { setMounted(true); }, []);
 
   return (
-    <div className={`flex transition-[width] duration-300 dark:bg-neutral-900`}>
+    <div className={`flex ${mounted ? "transition-[width] duration-300" : ""} dark:bg-neutral-900`}>
       <div
         className={`absolute flex mx-2 py-2 z-20 items-center transition-[left] duration-375 text-neutral-500 dark:text-neutral-400 ${settings.sidebarOpen ? (isWindows ? "left-2" : "left-[204px]") : isWindows ? "left-2" : "left-20"}`}
       >
@@ -57,7 +60,7 @@ export function SidebarLayout({
         </Link>
       </div>
       <div
-        className={`flex flex-col transition-[width] duration-300 max-h-screen ${settings.sidebarOpen ? "w-64" : "w-0"}`}
+        className={`flex flex-col max-h-screen ${mounted ? "transition-[width] duration-300" : ""} ${settings.sidebarOpen ? "w-64" : "w-0"}`}
       >
         <div
           onDoubleClick={() => window.doubleClick && window.doubleClick()}


### PR DESCRIPTION
## Problem

The sidebar animates open on first load instead of appearing already expanded. This is caused by 	ransition-[width] duration-300 classes being active during the initial render.

## Fix

Track component mount state with useState/useEffect and only apply transition classes after the component has mounted.

- 	ransition-[width] on the outer container is now conditional on mounted`n- 	ransition-[width] on the sidebar div is now conditional on mounted`n
Closes #12954