### PR TITLE
launch: fix opencode local model limits

### DIFF
--- a/cmd/launch/opencode.go
+++ b/cmd/launch/opencode.go
@@ -278,14 +278,12 @@ func buildModelEntries(modelList []LaunchModel) map[string]any {
 				"output": []string{"text"},
 			}
 		}
-		if model.ContextLength > 0 || model.MaxOutputTokens > 0 {
+		if model.MaxOutputTokens > 0 {
 			limit := make(map[string]any)
 			if model.ContextLength > 0 {
 				limit["context"] = model.ContextLength
 			}
-			if model.MaxOutputTokens > 0 {
-				limit["output"] = model.MaxOutputTokens
-			}
+			limit["output"] = model.MaxOutputTokens
 			entry["limit"] = limit
 		}
 		models[model.Name] = entry

--- a/cmd/launch/opencode_test.go
+++ b/cmd/launch/opencode_test.go
@@ -196,6 +196,14 @@ func TestBuildModelEntries(t *testing.T) {
 			t.Fatalf("limit = %v, want context/output", limit)
 		}
 	})
+
+	t.Run("omits context-only limits", func(t *testing.T) {
+		models := buildModelEntries([]LaunchModel{{Name: "qwen2.5:0.5b", ContextLength: 32768}})
+		entry, _ := models["qwen2.5:0.5b"].(map[string]any)
+		if _, ok := entry["limit"]; ok {
+			t.Fatalf("limit should be omitted when output limit is unknown, got %v", entry["limit"])
+		}
+	})
 }
 
 func TestOpenCodeModels_ReturnsNil(t *testing.T) {


### PR DESCRIPTION
Local model metadata from /api/tags can include a context length without a max output limit, so omit OpenCode limit stanzas unless an output limit is known.

This preserves the pre-0.30 OpenCode behavior: local models did not receive a limit stanza because /api/tags did not expose context length, while cloud models still emit complete context/output limits.

Fixes #16424