### PR TITLE
llm: include cached prompt tokens in llama-server counts

### DIFF
--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -1223,15 +1223,10 @@ type llamaServerMultimodalPrompt struct {
 
 // llamaServerCompletionResponse is the response format from llama-server's /completion endpoint.
 type llamaServerCompletionResponse struct {
-	Content  string `json:"content"`
-	Stop     bool   `json:"stop"`
-	StopType string `json:"stop_type"`
-	Timings  struct {
-		PromptN   int     `json:"prompt_n"`
-		PromptMS  float64 `json:"prompt_ms"`
-		PredictN  int     `json:"predicted_n"`
-		PredictMS float64 `json:"predicted_ms"`
-	} `json:"timings"`
+	Content                 string                 `json:"content"`
+	Stop                    bool                   `json:"stop"`
+	StopType                string                 `json:"stop_type"`
+	Timings                 llamaServerTimings     `json:"timings"`
 	CompletionProbabilities []llamaServerTokenProb `json:"completion_probabilities"`
 }
 
@@ -1257,13 +1252,20 @@ type llamaServerChatChoice struct {
 
 type llamaServerChatResponse struct {
 	Choices []llamaServerChatChoice `json:"choices"`
-	Timings struct {
-		PromptN   int     `json:"prompt_n"`
-		PromptMS  float64 `json:"prompt_ms"`
-		PredictN  int     `json:"predicted_n"`
-		PredictMS float64 `json:"predicted_ms"`
-	} `json:"timings"`
-	Error any `json:"error"`
+	Timings llamaServerTimings      `json:"timings"`
+	Error   any                     `json:"error"`
+}
+
+type llamaServerTimings struct {
+	CacheN    int     `json:"cache_n"`
+	PromptN   int     `json:"prompt_n"`
+	PromptMS  float64 `json:"prompt_ms"`
+	PredictN  int     `json:"predicted_n"`
+	PredictMS float64 `json:"predicted_ms"`
+}
+
+func (t llamaServerTimings) promptEvalCount() int {
+	return t.CacheN + t.PromptN
 }
 
 type llamaServerApplyTemplateResponse struct {
@@ -1467,7 +1469,7 @@ func (s *llamaServerRunner) Completion(ctx context.Context, req CompletionReques
 					Content:            lsResp.Content,
 					Done:               true,
 					DoneReason:         doneReason,
-					PromptEvalCount:    lsResp.Timings.PromptN,
+					PromptEvalCount:    lsResp.Timings.promptEvalCount(),
 					PromptEvalDuration: time.Duration(lsResp.Timings.PromptMS * float64(time.Millisecond)),
 					EvalCount:          lsResp.Timings.PredictN,
 					EvalDuration:       time.Duration(lsResp.Timings.PredictMS * float64(time.Millisecond)),
@@ -1763,7 +1765,7 @@ func (s *llamaServerRunner) Chat(ctx context.Context, req ChatRequest, fn func(C
 
 				resp.Done = true
 				resp.DoneReason = doneReason
-				resp.PromptEvalCount = lsResp.Timings.PromptN
+				resp.PromptEvalCount = lsResp.Timings.promptEvalCount()
 				resp.PromptEvalDuration = time.Duration(lsResp.Timings.PromptMS * float64(time.Millisecond))
 				resp.EvalCount = lsResp.Timings.PredictN
 				resp.EvalDuration = time.Duration(lsResp.Timings.PredictMS * float64(time.Millisecond))

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -216,6 +216,102 @@ func TestLlamaServerCompletionSSEParsing(t *testing.T) {
 	}
 }
 
+func TestLlamaServerCompletionPromptEvalCountIncludesCache(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health":
+			fmt.Fprint(w, `{"status":"ok"}`)
+		case "/completion":
+			w.Header().Set("Content-Type", "text/event-stream")
+			fmt.Fprintln(w, `data: {"content":"","stop":true,"stop_type":"eos","timings":{"cache_n":12,"prompt_n":5,"prompt_ms":10,"predicted_n":2,"predicted_ms":20}}`)
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	parts := strings.Split(srv.URL, ":")
+	var portInt int
+	fmt.Sscanf(parts[len(parts)-1], "%d", &portInt)
+
+	runner := &llamaServerRunner{
+		port:    portInt,
+		cmd:     fakeRunningCmd(),
+		sem:     semaphore.NewWeighted(1),
+		options: api.Options{Runner: api.Runner{NumCtx: 2048}},
+	}
+
+	var responses []CompletionResponse
+	opts := api.DefaultOptions()
+	err := runner.Completion(t.Context(), CompletionRequest{
+		Prompt:  "test prompt",
+		Options: &opts,
+	}, func(cr CompletionResponse) {
+		responses = append(responses, cr)
+	})
+	if err != nil {
+		t.Fatalf("Completion error: %v", err)
+	}
+	if len(responses) != 1 {
+		t.Fatalf("got %d responses, want 1", len(responses))
+	}
+	if responses[0].PromptEvalCount != 17 {
+		t.Errorf("PromptEvalCount = %d, want 17", responses[0].PromptEvalCount)
+	}
+	if responses[0].PromptEvalDuration != 10*time.Millisecond {
+		t.Errorf("PromptEvalDuration = %s, want 10ms", responses[0].PromptEvalDuration)
+	}
+}
+
+func TestLlamaServerChatPromptEvalCountIncludesCache(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health":
+			fmt.Fprint(w, `{"status":"ok"}`)
+		case "/v1/chat/completions":
+			w.Header().Set("Content-Type", "text/event-stream")
+			fmt.Fprintln(w, `data: {"choices":[{"delta":{"content":"Hello"}}]}`)
+			fmt.Fprintln(w, `data: {"choices":[{"delta":{},"finish_reason":"stop"}],"timings":{"cache_n":12,"prompt_n":5,"prompt_ms":10,"predicted_n":2,"predicted_ms":20}}`)
+			fmt.Fprintln(w, `data: [DONE]`)
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	parts := strings.Split(srv.URL, ":")
+	var portInt int
+	fmt.Sscanf(parts[len(parts)-1], "%d", &portInt)
+
+	runner := &llamaServerRunner{
+		port:    portInt,
+		cmd:     fakeRunningCmd(),
+		sem:     semaphore.NewWeighted(1),
+		options: api.Options{Runner: api.Runner{NumCtx: 2048}},
+	}
+
+	var responses []ChatResponse
+	opts := api.DefaultOptions()
+	err := runner.Chat(t.Context(), ChatRequest{
+		Messages: []api.Message{{Role: "user", Content: "test prompt"}},
+		Options:  &opts,
+	}, func(cr ChatResponse) {
+		responses = append(responses, cr)
+	})
+	if err != nil {
+		t.Fatalf("Chat error: %v", err)
+	}
+	if len(responses) != 2 {
+		t.Fatalf("got %d responses, want 2", len(responses))
+	}
+	if responses[1].PromptEvalCount != 17 {
+		t.Errorf("PromptEvalCount = %d, want 17", responses[1].PromptEvalCount)
+	}
+	if responses[1].PromptEvalDuration != 10*time.Millisecond {
+		t.Errorf("PromptEvalDuration = %s, want 10ms", responses[1].PromptEvalDuration)
+	}
+}
+
 func TestLlamaServerStreamsHandleLargeSSELines(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
llama-server reports newly processed prompt tokens separately from cached prompt tokens, so add cache_n to prompt_n to preserve Ollama's pre-0.30 full-context prompt_eval_count semantics.

Fixes #16414