### PR TITLE
discover: allow Radeon 8060S iGPU by default

### DIFF
--- a/discover/runner.go
+++ b/discover/runner.go
@@ -28,6 +28,11 @@ var (
 	bootstrapped bool
 )
 
+var defaultIntegratedROCmGFXTargets = map[string]struct{}{
+	// AMD Radeon 8060S / Ryzen AI Max+ 395.
+	"gfx1151": {},
+}
+
 func GPUDevices(ctx context.Context, runners []ml.FilteredRunnerDiscovery) []ml.DeviceInfo {
 	deviceMu.Lock()
 	defer deviceMu.Unlock()
@@ -410,7 +415,15 @@ func integratedGPUAdmission() (allow, explicit bool) {
 }
 
 func integratedGPUAllowedByDefault(device ml.DeviceInfo) bool {
-	return device.Library == "CUDA"
+	switch device.Library {
+	case "CUDA":
+		return true
+	case "ROCm":
+		_, ok := defaultIntegratedROCmGFXTargets[device.GFXTarget]
+		return ok
+	default:
+		return false
+	}
 }
 
 func filterOverlapByLibrary(supported map[string]map[string]map[string]int, needsDelete []bool) {

--- a/discover/runner_test.go
+++ b/discover/runner_test.go
@@ -137,7 +137,8 @@ func TestFilterIntegratedGPUs(t *testing.T) {
 		{DeviceID: ml.DeviceID{Library: "CUDA", ID: "0"}, Description: "NVIDIA integrated", Integrated: true},
 		{DeviceID: ml.DeviceID{Library: "Metal", ID: "0"}, Description: "Apple GPU", Integrated: true},
 		{DeviceID: ml.DeviceID{Library: "Vulkan", ID: "0"}, Description: "AMD Radeon(TM) Graphics", Integrated: true},
-		{DeviceID: ml.DeviceID{Library: "ROCm", ID: "0"}, Description: "AMD Radeon(TM) Graphics", Integrated: true},
+		{DeviceID: ml.DeviceID{Library: "ROCm", ID: "0"}, Description: "AMD Radeon 780M", Integrated: true, GFXTarget: "gfx1103"},
+		{DeviceID: ml.DeviceID{Library: "ROCm", ID: "1"}, Description: "AMD Radeon 8060S Graphics", Integrated: true, GFXTarget: "gfx1151"},
 		{DeviceID: ml.DeviceID{Library: "Vulkan", ID: "1"}, Description: "AMD Radeon RX 6800"},
 	}
 
@@ -149,6 +150,7 @@ func TestFilterIntegratedGPUs(t *testing.T) {
 			{Library: "Metal", ID: "0"},
 			{Library: "Vulkan", ID: "0"},
 			{Library: "ROCm", ID: "0"},
+			{Library: "ROCm", ID: "1"},
 			{Library: "Vulkan", ID: "1"},
 		}
 		assertDeviceIDs(t, got, want)
@@ -159,6 +161,7 @@ func TestFilterIntegratedGPUs(t *testing.T) {
 		got := filterIntegratedGPUs(append([]ml.DeviceInfo{}, devices...))
 		want := []ml.DeviceID{
 			{Library: "CUDA", ID: "0"},
+			{Library: "ROCm", ID: "1"},
 			{Library: "Vulkan", ID: "1"},
 		}
 		assertDeviceIDs(t, got, want)
@@ -172,6 +175,7 @@ func TestFilterIntegratedGPUs(t *testing.T) {
 			{Library: "Metal", ID: "0"},
 			{Library: "Vulkan", ID: "0"},
 			{Library: "ROCm", ID: "0"},
+			{Library: "ROCm", ID: "1"},
 			{Library: "Vulkan", ID: "1"},
 		}
 		assertDeviceIDs(t, got, want)


### PR DESCRIPTION
Default integrated GPU filtering dropped the supported ROCm gfx1151 Radeon 8060S unless OLLAMA_IGPU_ENABLE was set, so add a ROCm gfx-target allowlist with gfx1151 as the first admitted target.  This iGPU is a known-good iGPU.

Fixes #16423