### PR TITLE
llm: clarify the error when llama-server is not bundled

### DIFF
--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -303,7 +303,11 @@ func (s *llamaServerRunner) ContextLength() int {
 func FindLlamaServer() (string, error) {
 	path, candidates, err := findLlamaCppBinary("llama-server", defaultLlamaCppBinarySearch())
 	if err != nil {
-		return "", fmt.Errorf("llama-server binary not found (checked: %s). Run 'cmake -S llama/server --preset cpu && cmake --build --preset cpu' first", strings.Join(candidates, ", "))
+		return "", fmt.Errorf("llama-server binary not found. Ollama needs llama-server to run GGUF models (MLX models do not require it). "+
+			"If you installed Ollama from a package (Homebrew, a distro package, etc.) that does not include it, the package must ship the llama-server built from the Ollama tree using Ollama's cmake wiring — "+
+			"Ollama patches llama.cpp and pins it to a specific GGML version, so an unrelated llama-server will not work. Please report this to the package maintainer. "+
+			"To build it from source, run 'cmake -S llama/server --preset cpu && cmake --build --preset cpu'. "+
+			"(checked: %s)", strings.Join(candidates, ", "))
 	}
 	return path, nil
 }


### PR DESCRIPTION
## Problem

As of 0.30, GGUF models run via a separate `llama-server` binary (MLX models do not need it). When it's missing — e.g. a package that doesn't ship it (#16417) — the error tells the user to run a `cmake` dev command, which is unhelpful to anyone who installed Ollama from a package.

## Change

Reword the not-found error to:
- explain that `llama-server` is needed for GGUF models (and that MLX models are unaffected),
- state that a package without it must ship the `llama-server` built from the Ollama tree — Ollama patches llama.cpp and pins it to a specific GGML version, so an unrelated `llama-server` will not work,
- point users to report it to their package maintainer.

## Scope note

This started as a `$PATH` fallback for `llama-server`, but per @dhiltgen that's unsafe: the bundled binary carries model-compatibility patches and is version-locked to GGML for GPU discovery, so a stray `llama-server` can't be substituted. I've dropped the fallback and kept only the clearer error message, which aligns with the guidance that downstream packagers must include Ollama's own `llama-server` build.

Refs #16417