### PR TITLE
llm: ignore llama-server SSE ping comments

### DIFF
--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -1507,6 +1507,9 @@ func (s *llamaServerRunner) Completion(ctx context.Context, req CompletionReques
 			if len(line) == 0 {
 				continue
 			}
+			if bytes.HasPrefix(line, []byte(":")) {
+				continue
+			}
 
 			evt, ok := bytes.CutPrefix(line, []byte("data: "))
 			if !ok {
@@ -1792,6 +1795,9 @@ func (s *llamaServerRunner) Chat(ctx context.Context, req ChatRequest, fn func(C
 		default:
 			line := scanner.Bytes()
 			if len(line) == 0 {
+				continue
+			}
+			if bytes.HasPrefix(line, []byte(":")) {
 				continue
 			}
 

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -131,8 +131,10 @@ func TestLlamaServerCompletionSSEParsing(t *testing.T) {
 	sseLines := []string{
 		`data: {"content":"Hello","stop":false}`,
 		``,
+		`:`,
 		`data: {"content":" world","stop":false}`,
 		``,
+		`:`,
 		`data: {"content":"","stop":true,"stop_type":"eos","timings":{"prompt_n":5,"prompt_ms":10.5,"predicted_n":2,"predicted_ms":20.3}}`,
 		``,
 	}
@@ -277,6 +279,7 @@ func TestLlamaServerChatPromptEvalCountIncludesCache(t *testing.T) {
 		case "/v1/chat/completions":
 			w.Header().Set("Content-Type", "text/event-stream")
 			fmt.Fprintln(w, `data: {"choices":[{"delta":{"content":"Hello"}}]}`)
+			fmt.Fprintln(w, `:`)
 			fmt.Fprintln(w, `data: {"choices":[{"delta":{},"finish_reason":"stop"}],"timings":{"cache_n":12,"prompt_n":5,"prompt_ms":10,"predicted_n":2,"predicted_ms":20}}`)
 			fmt.Fprintln(w, `data: [DONE]`)
 		default:


### PR DESCRIPTION
llama.cpp b9478 added a default 30s SSE ping that emits colon-only comment frames (":\n\n") while streamed requests are idle; Ollama treated non-data SSE lines as JSON, so skip SSE comments in completion and chat streams.