### PR TITLE
launch: preserve opencode context limits

### DIFF
--- a/cmd/launch/opencode.go
+++ b/cmd/launch/opencode.go
@@ -20,6 +20,8 @@ type OpenCode struct {
 	configContent string // JSON config built by Edit, passed to Run via env var
 }
 
+const openCodeDefaultOutputLimit = 32_768
+
 func (o *OpenCode) String() string { return "OpenCode" }
 
 // findOpenCode returns the opencode binary path, checking PATH first then the
@@ -278,12 +280,16 @@ func buildModelEntries(modelList []LaunchModel) map[string]any {
 				"output": []string{"text"},
 			}
 		}
-		if model.MaxOutputTokens > 0 {
+		if model.ContextLength > 0 || model.MaxOutputTokens > 0 {
 			limit := make(map[string]any)
 			if model.ContextLength > 0 {
 				limit["context"] = model.ContextLength
 			}
-			limit["output"] = model.MaxOutputTokens
+			if model.MaxOutputTokens > 0 {
+				limit["output"] = model.MaxOutputTokens
+			} else {
+				limit["output"] = openCodeDefaultOutputLimit
+			}
 			entry["limit"] = limit
 		}
 		models[model.Name] = entry

--- a/cmd/launch/opencode_test.go
+++ b/cmd/launch/opencode_test.go
@@ -197,11 +197,12 @@ func TestBuildModelEntries(t *testing.T) {
 		}
 	})
 
-	t.Run("omits context-only limits", func(t *testing.T) {
+	t.Run("uses default output for context-only limits", func(t *testing.T) {
 		models := buildModelEntries([]LaunchModel{{Name: "qwen2.5:0.5b", ContextLength: 32768}})
 		entry, _ := models["qwen2.5:0.5b"].(map[string]any)
-		if _, ok := entry["limit"]; ok {
-			t.Fatalf("limit should be omitted when output limit is unknown, got %v", entry["limit"])
+		limit, _ := entry["limit"].(map[string]any)
+		if limit["context"] != 32768 || limit["output"] != openCodeDefaultOutputLimit {
+			t.Fatalf("limit = %v, want context/default output", limit)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- preserve local model context metadata in generated OpenCode configs
- add a conservative default output limit when Ollama knows the context length but not the model output limit
- cover context-only model metadata in `buildModelEntries` tests

Fixes #16442

## Testing

- `go test ./cmd/launch`
