### PR TITLE
fix laguna patch build breakage

### DIFF
--- a/llama/compat/models/llama-cpp-laguna.patch
+++ b/llama/compat/models/llama-cpp-laguna.patch
@@ -39,6 +39,14 @@ index 914fc423b..b135cff88 100644
          case LLM_ARCH_TALKIE:
 +        case LLM_ARCH_LAGUNA:
              return LLAMA_ROPE_TYPE_NEOX;
+diff --git a/src/llama-model-loader.cpp b/src/llama-model-loader.cpp
+index 1afeb766c..7d297565e 100644
+--- a/src/llama-model-loader.cpp
++++ b/src/llama-model-loader.cpp
+@@ -505,2 +505,3 @@ namespace GGUFMeta {
+     template bool llama_model_loader::get_key_or_arr<std::array<uint32_t, 512>>(enum llm_kv kid, std::array<uint32_t, 512> & result, uint32_t n, bool required);
++    template bool llama_model_loader::get_key_or_arr<uint32_t, 512>(const std::string & key, std::array<uint32_t, 512> & result, uint32_t n, bool required);
+     template bool llama_model_loader::get_key_or_arr<std::array<float, 512>>(enum llm_kv kid, std::array<float, 512> & result, uint32_t n, bool required);
 diff --git a/src/llama-vocab.cpp b/src/llama-vocab.cpp
 index b61397311..cbdc32eef 100644
 --- a/src/llama-vocab.cpp


### PR DESCRIPTION
Follow up to #16396

Fix kernel template instantiation so the symbols are exported in the library.