### PR TITLE
openai: skip empty stream chunks

### DIFF
--- a/openai/openai.go
+++ b/openai/openai.go
@@ -322,11 +322,28 @@ func toChunk(id string, r api.ChatResponse, toolCallSent bool) ChatCompletionChu
 	}
 }
 
+func hasChunkSignal(c ChatCompletionChunk) bool {
+	if len(c.Choices) == 0 {
+		return false
+	}
+
+	choice := c.Choices[0]
+	return choice.Delta.Content != "" ||
+		choice.Delta.Reasoning != "" ||
+		len(choice.Delta.ToolCalls) > 0 ||
+		choice.FinishReason != nil ||
+		choice.Logprobs != nil
+}
+
 // ToChunks converts an api.ChatResponse to one or more ChatCompletionChunk values.
 func ToChunks(id string, r api.ChatResponse, toolCallSent bool) []ChatCompletionChunk {
 	hasMixedResponse := r.Message.Thinking != "" && (r.Message.Content != "" || len(r.Message.ToolCalls) > 0)
 	if !hasMixedResponse {
-		return []ChatCompletionChunk{toChunk(id, r, toolCallSent)}
+		chunk := toChunk(id, r, toolCallSent)
+		if !hasChunkSignal(chunk) {
+			return nil
+		}
+		return []ChatCompletionChunk{chunk}
 	}
 
 	reasoningChunk := toChunk(id, r, toolCallSent)

--- a/openai/openai_test.go
+++ b/openai/openai_test.go
@@ -559,6 +559,39 @@ func TestToChunks_SplitsThinkingAndToolCalls(t *testing.T) {
 	}
 }
 
+func TestToChunks_SkipsEmptyDeltasWithoutFinishReason(t *testing.T) {
+	resp := api.ChatResponse{
+		Model: "test-model",
+		Message: api.Message{
+			Role: "assistant",
+		},
+	}
+
+	chunks := ToChunks("test-id", resp, false)
+	if len(chunks) != 0 {
+		t.Fatalf("expected empty response to produce no stream chunks, got %d", len(chunks))
+	}
+}
+
+func TestToChunks_KeepsEmptyDeltasWithFinishReason(t *testing.T) {
+	resp := api.ChatResponse{
+		Model: "test-model",
+		Message: api.Message{
+			Role: "assistant",
+		},
+		Done:       true,
+		DoneReason: "stop",
+	}
+
+	chunks := ToChunks("test-id", resp, false)
+	if len(chunks) != 1 {
+		t.Fatalf("expected finish response to produce one stream chunk, got %d", len(chunks))
+	}
+	if chunks[0].Choices[0].FinishReason == nil || *chunks[0].Choices[0].FinishReason != "stop" {
+		t.Fatalf("expected finish reason %q, got %v", "stop", chunks[0].Choices[0].FinishReason)
+	}
+}
+
 func TestToChunks_SingleChunkForNonMixedResponses(t *testing.T) {
 	toolCalls := []api.ToolCall{
 		{


### PR DESCRIPTION
## Summary
- Skips OpenAI-compatible stream chunks that have no content, reasoning, tool calls, logprobs, or finish reason.
- Keeps terminal chunks that carry a finish reason so clients still receive stop/tool-call completion state.
- Adds regression coverage for empty deltas and finish-only deltas.

Fixes #12420

## Tests
- `go test ./openai ./middleware -count=1`
- `git diff --check`
