### PR TITLE
Kill llama-server during Windows cleanup

### DIFF
--- a/app/ollama.iss
+++ b/app/ollama.iss
@@ -14,6 +14,7 @@
 #define MyAppPublisher "Ollama"
 #define MyAppURL "https://ollama.com/"
 #define MyAppExeName "ollama app.exe"
+#define LlamaServerExeName "llama-server.exe"
 #define MyIcon ".\assets\app.ico"
 
 [Setup]
@@ -126,6 +127,7 @@ Filename: "{cmd}"; Parameters: "/C set PATH={app};%PATH% & ""{app}\{#MyAppExeNam
 ; Filename: "{cmd}"; Parameters: "/C ""taskkill /im ollama.exe /f /t"; Flags: runhidden
 Filename: "taskkill"; Parameters: "/im ""{#MyAppExeName}"" /f /t"; Flags: runhidden
 Filename: "taskkill"; Parameters: "/im ""ollama.exe"" /f /t"; Flags: runhidden
+Filename: "taskkill"; Parameters: "/im ""{#LlamaServerExeName}"" /f /t"; Flags: runhidden
 ; HACK!  need to give the server and app enough time to exit
 ; TODO - convert this to a Pascal code script so it waits until they're no longer running, then completes
 Filename: "{cmd}"; Parameters: "/c timeout 5"; Flags: runhidden
@@ -325,5 +327,8 @@ procedure TaskKill(FileName: String);
 var
   ResultCode: Integer;
 begin
-    Exec('taskkill.exe', '/f /im ' + '"' + FileName + '"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+    Exec('taskkill.exe', '/f /t /im ' + '"' + FileName + '"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+    if FileName <> '{#LlamaServerExeName}' then begin
+      Exec('taskkill.exe', '/f /t /im "{#LlamaServerExeName}"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+    end;
 end;

--- a/app/server/server_windows.go
+++ b/app/server/server_windows.go
@@ -164,7 +164,7 @@ func reapServers() error {
 			continue
 		}
 
-		cmd := exec.Command("taskkill", "/F", "/PID", pidStr)
+		cmd := exec.Command("taskkill", "/F", "/T", "/PID", pidStr)
 		if err := cmd.Run(); err != nil {
 			slog.Warn("failed to kill ollama process", "pid", pid, "err", err)
 		}


### PR DESCRIPTION
Windows installer and app cleanup could leave llama-server.exe running when ollama.exe was killed directly, so cleanup now includes llama-server.exe and taskkill /T.