### PR TITLE
launch: clean legacy codex profile before launch

### DIFF
--- a/cmd/launch/codex.go
+++ b/cmd/launch/codex.go
@@ -215,6 +215,9 @@ func ensureCodexConfig(modelName string, models []LaunchModel) error {
 	if err := os.MkdirAll(codexDir, 0o755); err != nil {
 		return err
 	}
+	if err := cleanupCodexLegacyProfileConfig(configPath); err != nil {
+		return err
+	}
 
 	catalogPath := codexModelCatalogPathForConfig(configPath)
 	if err := writeCodexModelCatalog(catalogPath, codexCatalogModel(modelName, models)); err != nil {
@@ -259,6 +262,36 @@ func codexProfileConfigPathForConfig(configPath string) string {
 
 func codexNamedProfileConfigPathForConfig(configPath, profileName string) string {
 	return filepath.Join(filepath.Dir(configPath), profileName+".config.toml")
+}
+
+func cleanupCodexLegacyProfileConfig(configPath string) error {
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	text := string(content)
+	parsed, err := codexParseConfig(text)
+	if err != nil {
+		return err
+	}
+
+	updated := text
+	if profile, ok := parsed.RootStringOK(codexRootProfileKey); ok && profile == codexProfileName {
+		updated = codexRemoveRootValue(updated, codexRootProfileKey)
+	}
+	if parsed.Exists("profiles", codexProfileName) {
+		updated = codexRemoveSection(updated, codexProfileHeader())
+	}
+	if updated == text {
+		return nil
+	}
+	if err := codexValidateConfigText(updated); err != nil {
+		return err
+	}
+	return fileutil.WriteWithBackup(configPath, []byte(updated), "")
 }
 
 // writeCodexProfileConfig ensures ~/.codex/ollama-launch.config.toml selects

--- a/cmd/launch/codex_test.go
+++ b/cmd/launch/codex_test.go
@@ -312,6 +312,63 @@ func TestEnsureCodexConfig(t *testing.T) {
 			t.Errorf("expected exactly one [model_providers.ollama-launch] section after two calls, got %d", strings.Count(content, "[model_providers.ollama-launch]"))
 		}
 	})
+
+	t.Run("cleans legacy root profile that conflicts with --profile", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setTestHome(t, tmpDir)
+
+		configPath := filepath.Join(tmpDir, ".codex", "config.toml")
+		if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		existing := "" +
+			`profile = "ollama-launch"` + "\n" +
+			`model = "gpt-5.5"` + "\n" +
+			`model_provider = "openai"` + "\n\n" +
+			"[profiles.ollama-launch]\n" +
+			`model = "old-local"` + "\n" +
+			`model_provider = "ollama-launch"` + "\n\n" +
+			"[profiles.default]\n" +
+			`model = "gpt-5.5"` + "\n"
+		if err := os.WriteFile(configPath, []byte(existing), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := ensureCodexConfig("llama3.2", launchModelsFromNames([]string{"llama3.2"})); err != nil {
+			t.Fatal(err)
+		}
+
+		data, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		content := string(data)
+		if got, ok := codexRootStringValueOK(content, codexRootProfileKey); ok {
+			t.Fatalf("legacy root profile should be removed, got %q in:\n%s", got, content)
+		}
+		if strings.Contains(content, codexProfileHeader()) {
+			t.Fatalf("legacy profile table should be removed, got:\n%s", content)
+		}
+		for _, want := range []string{
+			`model = "gpt-5.5"`,
+			`model_provider = "openai"`,
+			"[profiles.default]",
+		} {
+			if !strings.Contains(content, want) {
+				t.Fatalf("expected %q to be preserved in:\n%s", want, content)
+			}
+		}
+
+		profilePath := filepath.Join(tmpDir, ".codex", "ollama-launch.config.toml")
+		profileData, err := os.ReadFile(profilePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(profileData), `model = "llama3.2"`) {
+			t.Fatalf("managed profile was not written with selected model:\n%s", profileData)
+		}
+		assertBackupContains(t, filepath.Join(fileutil.BackupDir(), "config.toml.*"), `profile = "ollama-launch"`)
+	})
 }
 
 func TestCodexRestoreRemovesCLIProfileAndCatalogWithoutChangingUserRootConfig(t *testing.T) {


### PR DESCRIPTION
## Summary

- Clean up legacy Codex CLI profile config before launching Codex
- Remove stale `profile = "ollama-launch"` and `[profiles.ollama-launch]` entries from `~/.codex/config.toml`
- Preserve unrelated user root config while continuing to write the managed `~/.codex/ollama-launch.config.toml`
- Add a regression test for the Codex CLI error caused by legacy profile config conflicting with `--profile ollama-launch`

## Motivation

Recent Codex profile changes require named profile settings to live in `~/.codex/ollama-launch.config.toml`. If an older Ollama launch setup left `profile = "ollama-launch"` or `[profiles.ollama-launch]` in `~/.codex/config.toml`, Codex refuses to start with:

```text
--profile `ollama-launch` cannot be used while ... config.toml contains legacy `profile = "ollama-launch"` or `[profiles.ollama-launch]`

```

This migration cleanup lets ollama launch codex recover automatically from that stale config state.