### PR TITLE
server: prevent system sleep during inference on Windows

### DIFF
--- a/server/power.go
+++ b/server/power.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package server
+
+// preventSleep is a no-op on non-Windows platforms.
+// On Windows, it prevents the OS from sleeping during inference.
+func preventSleep() func() {
+	return func() {}
+}

--- a/server/power_test.go
+++ b/server/power_test.go
@@ -1,0 +1,23 @@
+package server
+
+import (
+	"testing"
+)
+
+func TestPreventSleep(t *testing.T) {
+	restore := preventSleep()
+	if restore == nil {
+		t.Fatal("preventSleep returned nil restore function")
+	}
+	// Calling restore should not panic
+	restore()
+}
+
+func TestPreventSleepMultipleCalls(t *testing.T) {
+	// Multiple concurrent inference requests should each be able
+	// to call preventSleep without panicking
+	for range 5 {
+		restore := preventSleep()
+		defer restore()
+	}
+}

--- a/server/power_windows.go
+++ b/server/power_windows.go
@@ -1,0 +1,68 @@
+//go:build windows
+
+package server
+
+import (
+	"log/slog"
+	"runtime"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+var (
+	kernel32                 = windows.NewLazySystemDLL("kernel32.dll")
+	pSetThreadExecutionState = kernel32.NewProc("SetThreadExecutionState")
+)
+
+const (
+	esSystemRequired = 0x00000001
+	esContinuous     = 0x80000000
+
+	// refreshInterval resets the idle timer well before Windows' minimum
+	// sleep timeout (typically 60s), keeping the system awake continuously.
+	refreshInterval = 30 * time.Second
+)
+
+func setExecutionState(flags uintptr) bool {
+	ret, _, err := pSetThreadExecutionState.Call(flags)
+	if ret == 0 {
+		slog.Warn("SetThreadExecutionState failed", "error", err)
+		return false
+	}
+	return true
+}
+
+// preventSleep prevents the OS from sleeping during inference.
+// It periodically resets the system idle timer so the computer
+// stays awake for the full duration of the request.
+// Returns a function that restores normal sleep behavior when called.
+func preventSleep() func() {
+	stop := make(chan struct{})
+
+	go func() {
+		// Lock this goroutine to its OS thread so SetThreadExecutionState
+		// remains effective — the API is per-thread on Windows.
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
+
+		setExecutionState(uintptr(esContinuous | esSystemRequired))
+
+		ticker := time.NewTicker(refreshInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-stop:
+				setExecutionState(uintptr(esContinuous))
+				return
+			case <-ticker.C:
+				setExecutionState(uintptr(esContinuous | esSystemRequired))
+			}
+		}
+	}()
+
+	return func() {
+		close(stop)
+	}
+}

--- a/server/routes.go
+++ b/server/routes.go
@@ -254,6 +254,9 @@ func signinURL() (string, error) {
 }
 
 func (s *Server) GenerateHandler(c *gin.Context) {
+	restoreSleep := preventSleep()
+	defer restoreSleep()
+
 	checkpointStart := time.Now()
 	var req api.GenerateRequest
 	if err := c.ShouldBindJSON(&req); errors.Is(err, io.EOF) {
@@ -2420,6 +2423,9 @@ func writeChatResponse(c *gin.Context, req api.ChatRequest, ch chan any) {
 }
 
 func (s *Server) ChatHandler(c *gin.Context) {
+	restoreSleep := preventSleep()
+	defer restoreSleep()
+
 	checkpointStart := time.Now()
 
 	var req api.ChatRequest


### PR DESCRIPTION
Fixes #4072

On Windows, the system could go to sleep during long inference
requests, interrupting generation.

Added `preventSleep()` which calls `SetThreadExecutionState` with
`ES_CONTINUOUS | ES_SYSTEM_REQUIRED` to keep the system awake.
A background goroutine periodically refreshes the idle timer every
30 seconds. When inference completes, sleep is automatically
restored via defer.

Verified with `powercfg /requests` — the process appears under
SYSTEM while inference is active and disappears when done.