### PR TITLE
launch: set copilot token length defaults

### DIFF
--- a/cmd/launch/copilot.go
+++ b/cmd/launch/copilot.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 
 	"github.com/ollama/ollama/envconfig"
 )
@@ -14,6 +15,11 @@ import (
 type Copilot struct{}
 
 func (c *Copilot) String() string { return "Copilot CLI" }
+
+const (
+	copilotFallbackPromptTokens = 4_096
+	copilotDefaultOutputTokens  = 64_000
+)
 
 func (c *Copilot) args(model string, extra []string) []string {
 	var args []string
@@ -43,7 +49,7 @@ func (c *Copilot) findPath() (string, error) {
 	return fallback, nil
 }
 
-func (c *Copilot) Run(model string, _ []LaunchModel, args []string) error {
+func (c *Copilot) Run(model string, models []LaunchModel, args []string) error {
 	copilotPath, err := c.findPath()
 	if err != nil {
 		return fmt.Errorf("copilot is not installed, install from https://docs.github.com/en/copilot/how-tos/set-up/install-copilot-cli")
@@ -54,18 +60,21 @@ func (c *Copilot) Run(model string, _ []LaunchModel, args []string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	cmd.Env = append(os.Environ(), c.envVars(model)...)
+	cmd.Env = append(os.Environ(), c.envVars(model, models)...)
 
 	return cmd.Run()
 }
 
 // envVars returns the environment variables that configure Copilot CLI
 // to use Ollama as its model provider.
-func (c *Copilot) envVars(model string) []string {
+func (c *Copilot) envVars(model string, models []LaunchModel) []string {
+	promptTokens, outputTokens := copilotTokenLimits(model, models)
 	env := []string{
 		"COPILOT_PROVIDER_BASE_URL=" + envconfig.Host().String() + "/v1",
 		"COPILOT_PROVIDER_API_KEY=",
 		"COPILOT_PROVIDER_WIRE_API=responses",
+		"COPILOT_PROVIDER_MAX_PROMPT_TOKENS=" + strconv.Itoa(promptTokens),
+		"COPILOT_PROVIDER_MAX_OUTPUT_TOKENS=" + strconv.Itoa(outputTokens),
 	}
 
 	if model != "" {
@@ -73,4 +82,41 @@ func (c *Copilot) envVars(model string) []string {
 	}
 
 	return env
+}
+
+func copilotTokenLimits(model string, models []LaunchModel) (int, int) {
+	launchModel := copilotLaunchModel(model, models)
+
+	promptTokens := launchModel.ContextLength
+	if promptTokens <= 0 {
+		promptTokens = launchModel.Details.ContextLength
+	}
+	if !isCloudModelName(launchModel.Name) && launchModel.Details.Format != "safetensors" {
+		if ctxLen := envconfig.ContextLength(); ctxLen > 0 {
+			promptTokens = int(ctxLen)
+		}
+	}
+	if promptTokens <= 0 {
+		promptTokens = copilotFallbackPromptTokens
+	}
+
+	outputTokens := launchModel.MaxOutputTokens
+	if outputTokens <= 0 {
+		outputTokens = copilotDefaultOutputTokens
+	}
+
+	return promptTokens, outputTokens
+}
+
+func copilotLaunchModel(model string, models []LaunchModel) LaunchModel {
+	if model != "" {
+		if launchModel, ok := findLaunchModel(models, model); ok {
+			return launchModel.WithCloudLimits()
+		}
+		return fallbackLaunchModel(model)
+	}
+	if len(models) > 0 {
+		return models[0].WithCloudLimits()
+	}
+	return LaunchModel{}
 }

--- a/cmd/launch/copilot_test.go
+++ b/cmd/launch/copilot_test.go
@@ -7,6 +7,8 @@ import (
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/ollama/ollama/api"
 )
 
 func TestCopilotIntegration(t *testing.T) {
@@ -113,6 +115,54 @@ func TestCopilotArgs(t *testing.T) {
 	}
 }
 
+func TestCopilotRunPassesTokenEnvVars(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell stub uses /bin/sh")
+	}
+
+	tmpDir := t.TempDir()
+	capturePath := filepath.Join(tmpDir, "capture")
+	fakeBin := filepath.Join(tmpDir, "copilot")
+	script := `#!/bin/sh
+{
+  echo "ARGS:$*"
+  echo "COPILOT_MODEL=$COPILOT_MODEL"
+  echo "COPILOT_PROVIDER_MAX_PROMPT_TOKENS=$COPILOT_PROVIDER_MAX_PROMPT_TOKENS"
+  echo "COPILOT_PROVIDER_MAX_OUTPUT_TOKENS=$COPILOT_PROVIDER_MAX_OUTPUT_TOKENS"
+} > "$COPILOT_CAPTURE"
+`
+	if err := os.WriteFile(fakeBin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", tmpDir)
+	t.Setenv("COPILOT_CAPTURE", capturePath)
+	t.Setenv("OLLAMA_CONTEXT_LENGTH", "")
+
+	c := &Copilot{}
+	err := c.Run("gemma4:31b-nvfp4", []LaunchModel{
+		{Name: "gemma4:31b-nvfp4", ContextLength: 262_144},
+	}, []string{"-p", "hello"})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	data, err := os.ReadFile(capturePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+	for _, want := range []string{
+		"ARGS:--model gemma4:31b-nvfp4 -p hello",
+		"COPILOT_MODEL=gemma4:31b-nvfp4",
+		"COPILOT_PROVIDER_MAX_PROMPT_TOKENS=262144",
+		"COPILOT_PROVIDER_MAX_OUTPUT_TOKENS=64000",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("captured output missing %q:\n%s", want, got)
+		}
+	}
+}
+
 func TestCopilotEnvVars(t *testing.T) {
 	c := &Copilot{}
 
@@ -126,7 +176,10 @@ func TestCopilotEnvVars(t *testing.T) {
 	}
 
 	t.Run("sets required provider env vars with model", func(t *testing.T) {
-		got := envMap(c.envVars("llama3.2"))
+		t.Setenv("OLLAMA_CONTEXT_LENGTH", "")
+		got := envMap(c.envVars("llama3.2", []LaunchModel{
+			{Name: "llama3.2:latest", ContextLength: 65_536, MaxOutputTokens: 4_096},
+		}))
 		if got["COPILOT_PROVIDER_BASE_URL"] == "" {
 			t.Error("COPILOT_PROVIDER_BASE_URL should be set")
 		}
@@ -139,13 +192,20 @@ func TestCopilotEnvVars(t *testing.T) {
 		if got["COPILOT_PROVIDER_WIRE_API"] != "responses" {
 			t.Errorf("COPILOT_PROVIDER_WIRE_API = %q, want %q", got["COPILOT_PROVIDER_WIRE_API"], "responses")
 		}
+		if got["COPILOT_PROVIDER_MAX_PROMPT_TOKENS"] != "65536" {
+			t.Errorf("COPILOT_PROVIDER_MAX_PROMPT_TOKENS = %q, want %q", got["COPILOT_PROVIDER_MAX_PROMPT_TOKENS"], "65536")
+		}
+		if got["COPILOT_PROVIDER_MAX_OUTPUT_TOKENS"] != "4096" {
+			t.Errorf("COPILOT_PROVIDER_MAX_OUTPUT_TOKENS = %q, want %q", got["COPILOT_PROVIDER_MAX_OUTPUT_TOKENS"], "4096")
+		}
 		if got["COPILOT_MODEL"] != "llama3.2" {
 			t.Errorf("COPILOT_MODEL = %q, want %q", got["COPILOT_MODEL"], "llama3.2")
 		}
 	})
 
 	t.Run("omits COPILOT_MODEL when model is empty", func(t *testing.T) {
-		got := envMap(c.envVars(""))
+		t.Setenv("OLLAMA_CONTEXT_LENGTH", "")
+		got := envMap(c.envVars("", nil))
 		if _, ok := got["COPILOT_MODEL"]; ok {
 			t.Errorf("COPILOT_MODEL should not be set for empty model, got %q", got["COPILOT_MODEL"])
 		}
@@ -153,9 +213,68 @@ func TestCopilotEnvVars(t *testing.T) {
 
 	t.Run("uses custom OLLAMA_HOST", func(t *testing.T) {
 		t.Setenv("OLLAMA_HOST", "http://myhost:9999")
-		got := envMap(c.envVars("test"))
+		t.Setenv("OLLAMA_CONTEXT_LENGTH", "")
+		got := envMap(c.envVars("test", nil))
 		if !strings.Contains(got["COPILOT_PROVIDER_BASE_URL"], "myhost:9999") {
 			t.Errorf("COPILOT_PROVIDER_BASE_URL = %q, want custom host", got["COPILOT_PROVIDER_BASE_URL"])
+		}
+	})
+
+	t.Run("uses details context length when direct context is absent", func(t *testing.T) {
+		t.Setenv("OLLAMA_CONTEXT_LENGTH", "")
+		got := envMap(c.envVars("llama3.2", []LaunchModel{
+			{Name: "llama3.2", Details: api.ModelDetails{ContextLength: 32_768}},
+		}))
+		if got["COPILOT_PROVIDER_MAX_PROMPT_TOKENS"] != "32768" {
+			t.Errorf("COPILOT_PROVIDER_MAX_PROMPT_TOKENS = %q, want %q", got["COPILOT_PROVIDER_MAX_PROMPT_TOKENS"], "32768")
+		}
+		if got["COPILOT_PROVIDER_MAX_OUTPUT_TOKENS"] != "64000" {
+			t.Errorf("COPILOT_PROVIDER_MAX_OUTPUT_TOKENS = %q, want %q", got["COPILOT_PROVIDER_MAX_OUTPUT_TOKENS"], "64000")
+		}
+	})
+
+	t.Run("uses default output tokens for custom model metadata", func(t *testing.T) {
+		t.Setenv("OLLAMA_CONTEXT_LENGTH", "")
+		got := envMap(c.envVars("gemma4:31b-nvfp4", []LaunchModel{
+			{Name: "gemma4:31b-nvfp4", ContextLength: 262_144},
+		}))
+		if got["COPILOT_PROVIDER_MAX_PROMPT_TOKENS"] != "262144" {
+			t.Errorf("COPILOT_PROVIDER_MAX_PROMPT_TOKENS = %q, want %q", got["COPILOT_PROVIDER_MAX_PROMPT_TOKENS"], "262144")
+		}
+		if got["COPILOT_PROVIDER_MAX_OUTPUT_TOKENS"] != "64000" {
+			t.Errorf("COPILOT_PROVIDER_MAX_OUTPUT_TOKENS = %q, want %q", got["COPILOT_PROVIDER_MAX_OUTPUT_TOKENS"], "64000")
+		}
+	})
+
+	t.Run("uses known cloud limits when inventory metadata is absent", func(t *testing.T) {
+		t.Setenv("OLLAMA_CONTEXT_LENGTH", "64000")
+		got := envMap(c.envVars("qwen3.5:cloud", nil))
+		if got["COPILOT_PROVIDER_MAX_PROMPT_TOKENS"] != "262144" {
+			t.Errorf("COPILOT_PROVIDER_MAX_PROMPT_TOKENS = %q, want %q", got["COPILOT_PROVIDER_MAX_PROMPT_TOKENS"], "262144")
+		}
+		if got["COPILOT_PROVIDER_MAX_OUTPUT_TOKENS"] != "32768" {
+			t.Errorf("COPILOT_PROVIDER_MAX_OUTPUT_TOKENS = %q, want %q", got["COPILOT_PROVIDER_MAX_OUTPUT_TOKENS"], "32768")
+		}
+	})
+
+	t.Run("uses fallback limits when metadata is absent", func(t *testing.T) {
+		t.Setenv("OLLAMA_CONTEXT_LENGTH", "")
+		got := envMap(c.envVars("custom-model", nil))
+		if got["COPILOT_PROVIDER_MAX_PROMPT_TOKENS"] != "4096" {
+			t.Errorf("COPILOT_PROVIDER_MAX_PROMPT_TOKENS = %q, want %q", got["COPILOT_PROVIDER_MAX_PROMPT_TOKENS"], "4096")
+		}
+		if got["COPILOT_PROVIDER_MAX_OUTPUT_TOKENS"] != "64000" {
+			t.Errorf("COPILOT_PROVIDER_MAX_OUTPUT_TOKENS = %q, want %q", got["COPILOT_PROVIDER_MAX_OUTPUT_TOKENS"], "64000")
+		}
+	})
+
+	t.Run("uses explicit local context override", func(t *testing.T) {
+		t.Setenv("OLLAMA_CONTEXT_LENGTH", "64000")
+		got := envMap(c.envVars("llama3.2", []LaunchModel{
+			{Name: "llama3.2", ContextLength: 131_072, Details: api.ModelDetails{Format: "gguf"}},
+		}))
+		if got["COPILOT_PROVIDER_MAX_PROMPT_TOKENS"] != "64000" {
+			t.Errorf("COPILOT_PROVIDER_MAX_PROMPT_TOKENS = %q, want %q", got["COPILOT_PROVIDER_MAX_PROMPT_TOKENS"], "64000")
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- Set Copilot provider prompt/output token env vars from launch metadata so custom Ollama model names avoid Copilot's built-in catalog warning.
- Use resolved launch context length when available, known cloud output limits when available, and the same 64k output-token default Droid uses when output metadata is absent.
- Add focused Copilot env var and runner tests.

## Tests
- `go test ./cmd/launch -run 'TestCopilot'`
- `go test ./cmd/launch`
- `git diff --check`
- `go build -o /tmp/ollama-launch-copilot-test .`
- Stubbed `ollama launch copilot --model gemma4:31b-nvfp4 --yes -- -p hello` captured `COPILOT_PROVIDER_MAX_PROMPT_TOKENS=262144` and `COPILOT_PROVIDER_MAX_OUTPUT_TOKENS=64000`.