### PR TITLE
llama-server: fix gemma4 patch wiring

### DIFF
--- a/llama/compat/README.md
+++ b/llama/compat/README.md
@@ -73,7 +73,7 @@ This table tracks the dispatch surface. Keep it brief; the handler comments in
 | `gemma3` + embedding markers (`embeddinggemma`) | Maps to `gemma-embedding` metadata and fixes embedding dense/norm tensors. | n/a |
 | `bert` + Snowflake markers (`snowflake-arctic-embed2`) | Fixes Snowflake Arctic Embed 2 tokenizer metadata. | n/a |
 | `gemma3n` | Normalizes tokenizer/EOS metadata, truncates vocab-shaped tensors, and hides unused embedded vision/audio/projector tensors. | n/a |
-| `gemma4` | Normalizes tokenizer metadata and hides embedded audio/vision/projector tensors from the text loader. | Gemma 4 projector translation; audio remains disabled. |
+| `gemma4` | Normalizes tokenizer metadata and hides embedded audio/vision/projector tensors from the text loader. | Gemma 4 vision/audio projector translation for GGUF blobs. |
 | `gptoss` | Maps to `gpt-oss`, copies KVs, injects missing expert FFN metadata, and renames tensors. | n/a |
 | `lfm2` | Renames norm tensors and fixes feed-forward metadata. | n/a |
 | `olmo3` | Maps to the OLMo2-compatible loader path. | n/a |

--- a/llama/compat/llama-cpp-hooks.patch
+++ b/llama/compat/llama-cpp-hooks.patch
@@ -87,3 +87,19 @@ index 2e0cfa6..a0f2955 100644
                  fin.seekg(offset, std::ios::beg);
                  if (!fin) {
                      throw std::runtime_error(string_format("%s: failed to seek for tensor %s\n", __func__, t->name));
+@@ -4312,6 +4320,15 @@ int clip_n_mmproj_embd(const struct clip_ctx * ctx) {
++    const auto projector_type = PROJECTOR_TYPE_NAMES.find(ctx->model.proj_type);
++    if (projector_type != PROJECTOR_TYPE_NAMES.end()) {
++        if (int n = llama_ollama_compat::maybe_clip_mmproj_embd(
++                projector_type->second.c_str(),
++                ctx->model.hparams.projection_dim); n > 0) {
++            return n;
++        }
++    }
++
+     switch (ctx->model.proj_type) {
+         case PROJECTOR_TYPE_LDP:
+             return ctx->model.mm_model_block_1_block_2_1_b->ne[0];
+         case PROJECTOR_TYPE_LDPV2:
+             return ctx->model.mm_model_peg_0_b->ne[0];
+         case PROJECTOR_TYPE_MLP:

--- a/llama/compat/llama-ollama-compat.cpp
+++ b/llama/compat/llama-ollama-compat.cpp
@@ -70,6 +70,18 @@ bool compat_disabled() {
     return value && std::strcmp(value, "0") == 0;
 }
 
+bool clip_mmproj_embd_uses_projection_dim(const char * projector_type) {
+    static constexpr const char * kProjectorTypes[] = {
+        "gemma4a",
+    };
+
+    if (!projector_type) return false;
+    for (const char * compat_type : kProjectorTypes) {
+        if (std::strcmp(projector_type, compat_type) == 0) return true;
+    }
+    return false;
+}
+
 // Per-loader file path registry — set by translate_metadata, read by
 // maybe_load_text_tensor so it can pass the path to load ops without a
 // separate patch insertion in the model loader's load_all_data path.
@@ -3385,6 +3397,12 @@ bool maybe_load_text_tensor(const llama_model_loader * ml,
     LoadOp op;
     if (!take_load_op(ggml_get_name(cur), op)) return false;
     return load_tensor_with_op(cur, path.c_str(), buft, op);
+}
+
+int maybe_clip_mmproj_embd(const char * projector_type, int projection_dim) {
+    if (compat_disabled() || projection_dim <= 0) return 0;
+    if (!clip_mmproj_embd_uses_projection_dim(projector_type)) return 0;
+    return projection_dim;
 }
 
 } // namespace llama_ollama_compat

--- a/llama/compat/llama-ollama-compat.h
+++ b/llama/compat/llama-ollama-compat.h
@@ -79,4 +79,10 @@ bool maybe_load_text_tensor(const llama_model_loader * ml,
                             ggml_tensor * cur,
                             size_t file_offset);
 
+// Called from clip_n_mmproj_embd() before the upstream switch. Returns a
+// positive embedding size only for Ollama compatibility cases whose projector
+// metadata already follows upstream naming, but whose legacy projector type
+// is missing from that helper in the pinned llama.cpp version.
+int maybe_clip_mmproj_embd(const char * projector_type, int projection_dim);
+
 } // namespace llama_ollama_compat


### PR DESCRIPTION
This will fix the "clip.cpp:4399: Unknown projector type" crash.