### PR TITLE
feat: add performance command for memory optimization

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -2561,6 +2561,7 @@ func NewCLI() *cobra.Command {
 		copyCmd,
 		deleteCmd,
 		serveCmd,
+		performanceCmd,
 	} {
 		switch cmd {
 		case runCmd:
@@ -2613,6 +2614,7 @@ func NewCLI() *cobra.Command {
 		deleteCmd,
 		runnerCmd,
 		gpuDiscoverCmd,
+		performanceCmd,
 		launch.LaunchCmd(checkServerHeartbeat, runInteractiveTUI),
 	)
 

--- a/cmd/cmd_performance.go
+++ b/cmd/cmd_performance.go
@@ -1,0 +1,138 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/format"
+	"github.com/ollama/ollama/internal/performance"
+)
+
+func init() {
+	performanceCmd.Flags().Bool("force", false, "Terminate high memory consuming processes (>40% RAM)")
+	performanceCmd.Flags().Bool("optimize", false, "Perform automated memory optimizations (unload idle models) and show recommendations")
+}
+
+var performanceCmd = &cobra.Command{
+	Use:     "performance",
+	Aliases: []string{"/performance"},
+	Short:   "Analyze and optimize system memory for Ollama",
+	RunE:    PerformanceHandler,
+}
+
+func PerformanceHandler(cmd *cobra.Command, args []string) error {
+	force, _ := cmd.Flags().GetBool("force")
+	optimize, _ := cmd.Flags().GetBool("optimize")
+
+	// 1. Get memory stats
+	stats, err := performance.GetMemoryStats()
+	if err != nil {
+		return fmt.Errorf("failed to retrieve memory stats: %w", err)
+	}
+
+	// Print basic memory info
+	totalStr := format.HumanBytes(int64(stats.Total))
+	requiredStr := format.HumanBytes(int64(float64(stats.Total) * 0.6))
+
+	fmt.Printf("System Memory: %s\n", totalStr)
+	fmt.Printf("Required for Ollama: %s (60%%)\n\n", requiredStr)
+
+	// 2. Detect high memory consumers (>40% RAM)
+	highMemProcs, err := performance.GetHighMemoryProcesses(40.0, stats.Total)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: Failed to retrieve process list: %v\n", err)
+	} else if len(highMemProcs) > 0 {
+		fmt.Println("Detected High Memory Consumers:")
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 4, ' ', 0)
+		fmt.Fprintln(w, "PID\tProcess\tMemory")
+		for _, p := range highMemProcs {
+			fmt.Fprintf(w, "%d\t%s\t%.1f%%\n", p.PID, p.Name, p.MemoryPercent)
+		}
+		w.Flush()
+		fmt.Println()
+
+		// If --force is specified, ask to terminate
+		if force {
+			if promptYesNo("Terminate these processes? (y/N): ") {
+				fmt.Println("Terminating processes...")
+				for _, p := range highMemProcs {
+					if err := performance.KillProcess(p); err != nil {
+						fmt.Printf("Error terminating process %s (PID %d): %v\n", p.Name, p.PID, err)
+					} else {
+						fmt.Printf("✓ Terminated %s (PID %d)\n", p.Name, p.PID)
+					}
+				}
+				fmt.Println()
+			} else {
+				fmt.Println("Termination cancelled.\n")
+			}
+		}
+	} else {
+		fmt.Println("No high memory processes (>40% RAM) detected.\n")
+	}
+
+	// 3. Optimize mode
+	if optimize {
+		fmt.Println("Running optimizations...")
+		client, clientErr := api.ClientFromEnvironment()
+		if clientErr != nil {
+			fmt.Printf("Warning: Could not connect to Ollama server: %v\n\n", clientErr)
+		} else {
+			optResult, optErr := performance.Optimize(cmd.Context(), client, stats)
+			if optErr != nil {
+				fmt.Printf("Error running optimizations: %v\n\n", optErr)
+			} else {
+				if len(optResult.UnloadedModels) > 0 {
+					fmt.Println("Unloaded running models:")
+					for _, m := range optResult.UnloadedModels {
+						fmt.Printf("✓ Model '%s' unloaded\n", m)
+					}
+					fmt.Println()
+				} else {
+					fmt.Println("✓ No running models needed to be unloaded.\n")
+				}
+
+				fmt.Println("Recommended:")
+				for _, rec := range optResult.Recommendations {
+					fmt.Printf("✓ %s\n", rec)
+				}
+				fmt.Println()
+			}
+		}
+	} else {
+		// Just show recommendations by default
+		totalGB := float64(stats.Total) / (1024 * 1024 * 1024)
+		fmt.Println("Memory Optimization Recommendations:")
+		if totalGB < 16.0 {
+			fmt.Println("- Reduce context window to 2048 or 4096 (e.g. num_ctx=4096)")
+			fmt.Println("- Use highly quantized models (e.g., q4_K_M or q3_K_L)")
+			fmt.Println("- Enable aggressive model swapping (OLLAMA_NUM_PARALLEL=1)")
+		} else if totalGB < 32.0 {
+			fmt.Println("- Reduce context window from 32768 to 8192 (e.g. num_ctx=8192)")
+			fmt.Println("- Use q4_K_M or q5_K_M quantized models")
+			fmt.Println("- Set keep-alive to a lower duration (e.g., --keepalive 5m)")
+		} else {
+			fmt.Println("- Keep context window at or below 16384 for large models")
+			fmt.Println("- Use q4_K_M or q8_0 quantized models for optimal performance")
+		}
+		fmt.Println("\nRun 'ollama performance --optimize' to unload running models and apply recommendations.")
+	}
+
+	return nil
+}
+
+func promptYesNo(prompt string) bool {
+	fmt.Print(prompt)
+	var response string
+	_, err := fmt.Scanln(&response)
+	if err != nil {
+		return false
+	}
+	response = strings.TrimSpace(strings.ToLower(response))
+	return response == "y" || response == "yes"
+}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/x448/float16 v0.8.4
 	golang.org/x/sync v0.17.0
 	golang.org/x/sys v0.37.0
+	github.com/shirou/gopsutil/v3 v3.24.5
 )
 
 require (

--- a/internal/performance/memory.go
+++ b/internal/performance/memory.go
@@ -1,0 +1,24 @@
+package performance
+
+import (
+	"github.com/shirou/gopsutil/v3/mem"
+)
+
+type MemoryStats struct {
+	Total     uint64 // in bytes
+	Used      uint64 // in bytes
+	Available uint64 // in bytes
+}
+
+// GetMemoryStats retrieves virtual memory statistics of the system
+func GetMemoryStats() (*MemoryStats, error) {
+	vm, err := mem.VirtualMemory()
+	if err != nil {
+		return nil, err
+	}
+	return &MemoryStats{
+		Total:     vm.Total,
+		Used:      vm.Used,
+		Available: vm.Available,
+	}, nil
+}

--- a/internal/performance/optimizer.go
+++ b/internal/performance/optimizer.go
@@ -1,0 +1,63 @@
+package performance
+
+import (
+	"context"
+	"time"
+
+	"github.com/ollama/ollama/api"
+)
+
+type OptimizationResult struct {
+	UnloadedModels  []string
+	Recommendations []string
+}
+
+// Optimize unloads any running models and computes memory optimization recommendations
+func Optimize(ctx context.Context, client *api.Client, stats *MemoryStats) (*OptimizationResult, error) {
+	result := &OptimizationResult{}
+
+	// 1. Evict idle models / Stop unused runners
+	running, err := client.ListRunning(ctx)
+	if err == nil && running != nil {
+		for _, m := range running.Models {
+			// Unload the model by sending a generate request with keep_alive = 0
+			req := &api.GenerateRequest{
+				Model:     m.Model,
+				KeepAlive: &api.Duration{Duration: 0},
+			}
+			// Use a short timeout context to avoid hanging
+			unloadCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+			_ = client.Generate(unloadCtx, req, func(api.GenerateResponse) error {
+				return nil
+			})
+			cancel()
+			result.UnloadedModels = append(result.UnloadedModels, m.Model)
+		}
+	}
+
+	// 2. Generate recommendations based on memory size
+	totalGB := float64(stats.Total) / (1024 * 1024 * 1024)
+
+	if totalGB < 16.0 {
+		result.Recommendations = append(result.Recommendations,
+			"Reduce context window to 2048 or 4096 (e.g. num_ctx=4096)",
+			"Use highly quantized models (e.g., q4_K_M or q3_K_L)",
+			"Enable aggressive model swapping by setting OLLAMA_NUM_PARALLEL=1",
+			"Avoid running multiple heavy applications alongside Ollama",
+		)
+	} else if totalGB < 32.0 {
+		result.Recommendations = append(result.Recommendations,
+			"Reduce context window from 32768 to 8192 (e.g. num_ctx=8192)",
+			"Use q4_K_M or q5_K_M quantized models",
+			"Set model keep-alive timeout to a shorter duration (e.g. keepalive=5m)",
+		)
+	} else {
+		result.Recommendations = append(result.Recommendations,
+			"Keep context window at or below 16384 for large models",
+			"Use q4_K_M or q8_0 quantized models for optimal performance/accuracy ratio",
+			"Ensure GPU hardware acceleration is properly configured",
+		)
+	}
+
+	return result, nil
+}

--- a/internal/performance/process.go
+++ b/internal/performance/process.go
@@ -1,0 +1,107 @@
+package performance
+
+import (
+	"strings"
+
+	"github.com/shirou/gopsutil/v3/process"
+)
+
+type ProcessInfo struct {
+	PID           int32
+	Name          string
+	MemoryPercent float32 // percentage of total RAM (0-100)
+	MemoryBytes   uint64
+	proc          *process.Process
+}
+
+// GetHighMemoryProcesses returns processes consuming more than a threshold percentage of total memory (threshold in 0-100)
+func GetHighMemoryProcesses(thresholdPercent float32, totalRAM uint64) ([]ProcessInfo, error) {
+	procs, err := process.Processes()
+	if err != nil {
+		return nil, err
+	}
+
+	var results []ProcessInfo
+	for _, p := range procs {
+		if p.Pid <= 4 {
+			continue
+		}
+
+		name, err := p.Name()
+		if err != nil {
+			continue
+		}
+
+		if IsWhitelisted(name) {
+			continue
+		}
+
+		percent, err := p.MemoryPercent()
+		if err != nil {
+			continue
+		}
+
+		if percent > thresholdPercent {
+			var memBytes uint64
+			memInfo, err := p.MemoryInfo()
+			if err == nil && memInfo != nil {
+				memBytes = memInfo.RSS
+			} else {
+				memBytes = uint64(float64(totalRAM) * float64(percent) / 100.0)
+			}
+
+			results = append(results, ProcessInfo{
+				PID:           p.Pid,
+				Name:          name,
+				MemoryPercent: percent,
+				MemoryBytes:   memBytes,
+				proc:          p,
+			})
+		}
+	}
+
+	return results, nil
+}
+
+// IsWhitelisted returns true if the process should never be killed
+func IsWhitelisted(name string) bool {
+	lowerName := strings.ToLower(name)
+	lowerName = strings.TrimSuffix(lowerName, ".exe")
+
+	whitelist := []string{
+		"ollama",
+		"systemd",
+		"launchd",
+		"explorer",
+		"system idle process",
+		"system",
+		"registry",
+		"smss",
+		"csrss",
+		"wininit",
+		"services",
+		"lsass",
+		"svchost",
+		"winlogon",
+	}
+
+	for _, item := range whitelist {
+		if lowerName == item {
+			return true
+		}
+	}
+	return false
+}
+
+// KillProcess terminates a high-memory process
+func KillProcess(p ProcessInfo) error {
+	if p.proc == nil {
+		// Try to find the process if nil
+		proc, err := process.NewProcess(p.PID)
+		if err != nil {
+			return err
+		}
+		p.proc = proc
+	}
+	return p.proc.Kill()
+}

--- a/tests/performance_test.go
+++ b/tests/performance_test.go
@@ -1,0 +1,64 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/ollama/ollama/internal/performance"
+)
+
+func TestIsWhitelisted(t *testing.T) {
+	cases := []struct {
+		name     string
+		expected bool
+	}{
+		{"ollama", true},
+		{"OLLAMA", true},
+		{"ollama.exe", true},
+		{"explorer", true},
+		{"explorer.exe", true},
+		{"systemd", true},
+		{"chrome", false},
+		{"chrome.exe", false},
+		{"my-app", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := performance.IsWhitelisted(tc.name)
+			if got != tc.expected {
+				t.Errorf("IsWhitelisted(%q) = %v; want %v", tc.name, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestGetMemoryStats(t *testing.T) {
+	stats, err := performance.GetMemoryStats()
+	if err != nil {
+		t.Fatalf("GetMemoryStats failed: %v", err)
+	}
+	if stats.Total == 0 {
+		t.Errorf("Expected Total memory to be > 0, got 0")
+	}
+}
+
+func TestRecommendations(t *testing.T) {
+	// Mock stats for low memory (<16GB)
+	lowMemStats := &performance.MemoryStats{
+		Total: 8 * 1024 * 1024 * 1024, // 8GB
+	}
+	res, err := performance.Optimize(t.Context(), nil, lowMemStats)
+	if err != nil {
+		t.Fatalf("Optimize failed: %v", err)
+	}
+
+	foundReducedCtx := false
+	for _, rec := range res.Recommendations {
+		if rec == "Reduce context window to 2048 or 4096 (e.g. num_ctx=4096)" {
+			foundReducedCtx = true
+		}
+	}
+	if !foundReducedCtx {
+		t.Errorf("Expected recommendation for context window reduction for low memory, got recommendations: %v", res.Recommendations)
+	}
+}


### PR DESCRIPTION
# Pull Request: Add `ollama performance` Memory Optimization Command

## Description
This PR introduces the `ollama performance` CLI command, designed to optimize system memory usage on local machines. Running local LLMs demands substantial RAM, and memory pressure is a frequent cause of execution failure. This feature analyzes system memory, identifies high-memory processes, safely allows terminating them, and provides recommendations for memory footprint reduction (like quantization levels and context window tuning).

---

## Changes Made

### 1. CLI registration
- Registered `performanceCmd` in `cmd/cmd.go` and integrated it into the root CLI configuration.
- Added `/performance` as a command alias, so both `ollama performance` and `ollama /performance` will invoke the command.
- Flags added:
  - `--force`: Triggers identification of high-memory consumers (>40% total RAM) and safely prompts the user to terminate them.
  - `--optimize`: Unloads any running models in the local Ollama instance and prints automated system-tailored memory recommendations.

### 2. Implementation files
- **`internal/performance/memory.go`**: Gets system-wide virtual memory statistics.
- **`internal/performance/process.go`**: Detects processes consuming more than 40% memory and terminates selected processes safely. Includes a hardcoded whitelist to prevent terminating critical system services or Ollama itself.
- **`internal/performance/optimizer.go`**: Lists currently loaded models on the server and unloads them by sending a `keep_alive` eviction request. Generates memory limit recommendations based on total RAM size.
- **`cmd/cmd_performance.go`**: Handles terminal output and CLI flag parsing, formatting memory values and high-memory lists in a clean table.

### 3. Safety Controls & Exclusions
Processes with a PID ≤ 4 and critical services are automatically whitelisted and will never be terminated. The safety whitelist contains:
- `ollama`
- `systemd` (Linux init)
- `launchd` (macOS init)
- `explorer` (Windows Desktop environment)
- Windows services: `system idle process`, `system`, `registry`, `smss`, `csrss`, `wininit`, `services`, `lsass`, `svchost`, `winlogon`

### 4. Tests
- Created **`tests/performance_test.go`** verifying the whitelisting mechanism, memory statistics collection, and recommendations generator.

---

## File Structure Reference

cmd/
 ├── cmd.go (modified)
 └── cmd_performance.go (new)

internal/
 └── performance/
      ├── memory.go (new)
      ├── process.go (new)
      └── optimizer.go (new)

tests/
 └── performance_test.go (new)

go.mod (modified to add gopsutil)
```

```
