### PR TITLE
Reject impossible GGUF metadata lengths

### DIFF
--- a/fs/gguf/gguf.go
+++ b/fs/gguf/gguf.go
@@ -101,7 +101,11 @@ func (f *File) readTensor() (TensorInfo, error) {
 		return TensorInfo{}, err
 	}
 
-	shape := make([]uint64, dims)
+	if err := checkLengthFitsFile(f, uint64(dims), 8, "tensor dimensions"); err != nil {
+		return TensorInfo{}, err
+	}
+
+	shape := make([]uint64, int(dims))
 	for i := range dims {
 		shape[i], err = read[uint64](f)
 		if err != nil {
@@ -191,11 +195,16 @@ func readString(f *File) (string, error) {
 		return "", err
 	}
 
-	if int(n) > len(f.bts) {
-		f.bts = make([]byte, n)
+	length, err := checkedLength(f, n, 1, "string")
+	if err != nil {
+		return "", err
 	}
 
-	bts := f.bts[:n]
+	if length > len(f.bts) {
+		f.bts = make([]byte, length)
+	}
+
+	bts := f.bts[:length]
 	if _, err := io.ReadFull(f.reader, bts); err != nil {
 		return "", err
 	}
@@ -246,8 +255,19 @@ func readArray(f *File) (any, error) {
 }
 
 func readArrayData[T any](f *File, n uint64) (s []T, err error) {
-	s = make([]T, n)
-	for i := range n {
+	var zero T
+	size := binary.Size(zero)
+	if size <= 0 {
+		return nil, fmt.Errorf("%w array element size %d", ErrUnsupported, size)
+	}
+
+	length, err := checkedLength(f, n, uint64(size), "array")
+	if err != nil {
+		return nil, err
+	}
+
+	s = make([]T, length)
+	for i := range length {
 		e, err := read[T](f)
 		if err != nil {
 			return nil, err
@@ -260,8 +280,13 @@ func readArrayData[T any](f *File, n uint64) (s []T, err error) {
 }
 
 func readArrayString(f *File, n uint64) (s []string, err error) {
-	s = make([]string, n)
-	for i := range n {
+	length, err := checkedLength(f, n, 8, "string array")
+	if err != nil {
+		return nil, err
+	}
+
+	s = make([]string, length)
+	for i := range length {
 		e, err := readString(f)
 		if err != nil {
 			return nil, err
@@ -271,6 +296,36 @@ func readArrayString(f *File, n uint64) (s []string, err error) {
 	}
 
 	return s, nil
+}
+
+func checkedLength(f *File, n, unit uint64, what string) (int, error) {
+	if uint64(int(n)) != n {
+		return 0, fmt.Errorf("%s length %d overflows platform int", what, n)
+	}
+
+	if err := checkLengthFitsFile(f, n, unit, what); err != nil {
+		return 0, err
+	}
+
+	return int(n), nil
+}
+
+func checkLengthFitsFile(f *File, n, unit uint64, what string) error {
+	if unit == 0 {
+		return fmt.Errorf("%s length has zero unit size", what)
+	}
+
+	info, err := f.file.Stat()
+	if err != nil {
+		return err
+	}
+
+	remaining := info.Size() - f.reader.offset
+	if remaining < 0 || n > uint64(remaining)/unit {
+		return io.ErrUnexpectedEOF
+	}
+
+	return nil
 }
 
 func (f *File) Close() error {

--- a/fs/gguf/gguf_test.go
+++ b/fs/gguf/gguf_test.go
@@ -2,6 +2,8 @@ package gguf_test
 
 import (
 	"bytes"
+	"encoding/binary"
+	"math"
 	"os"
 	"strconv"
 	"strings"
@@ -12,6 +14,47 @@ import (
 	"github.com/ollama/ollama/fs/ggml"
 	"github.com/ollama/ollama/fs/gguf"
 )
+
+func createMalformedGGUFFile(tb testing.TB, writeBody func(*os.File)) string {
+	tb.Helper()
+	f, err := os.CreateTemp(tb.TempDir(), "")
+	if err != nil {
+		tb.Fatal(err)
+	}
+	defer f.Close()
+
+	for _, value := range []any{
+		[]byte("GGUF"),
+		uint32(3),
+		uint64(0),
+		uint64(1),
+	} {
+		if err := binary.Write(f, binary.LittleEndian, value); err != nil {
+			tb.Fatal(err)
+		}
+	}
+
+	writeBody(f)
+	return f.Name()
+}
+
+func assertGGUFLazyParseDoesNotPanic(tb testing.TB, path string) {
+	tb.Helper()
+	defer func() {
+		if r := recover(); r != nil {
+			tb.Fatalf("GGUF lazy parse panicked: %v", r)
+		}
+	}()
+
+	f, err := gguf.Open(path)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	defer f.Close()
+
+	for range f.KeyValues() {
+	}
+}
 
 func createBinFile(tb testing.TB) string {
 	tb.Helper()
@@ -82,6 +125,34 @@ func createBinFile(tb testing.TB) string {
 	}
 
 	return f.Name()
+}
+
+func TestMalformedStringLengthDoesNotPanic(t *testing.T) {
+	path := createMalformedGGUFFile(t, func(f *os.File) {
+		if err := binary.Write(f, binary.LittleEndian, uint64(math.MaxUint64)); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	assertGGUFLazyParseDoesNotPanic(t, path)
+}
+
+func TestMalformedArrayLengthDoesNotPanic(t *testing.T) {
+	path := createMalformedGGUFFile(t, func(f *os.File) {
+		for _, value := range []any{
+			uint64(1),
+			[]byte("x"),
+			uint32(9),
+			uint32(0),
+			uint64(math.MaxUint64),
+		} {
+			if err := binary.Write(f, binary.LittleEndian, value); err != nil {
+				t.Fatal(err)
+			}
+		}
+	})
+
+	assertGGUFLazyParseDoesNotPanic(t, path)
 }
 
 func TestRead(t *testing.T) {


### PR DESCRIPTION
### Summary

This bounds GGUF metadata allocations against the remaining file size before allocating slices for strings, arrays, and tensor dimensions.

The GGUF parser reads length fields from the file and currently allocates based on those values before proving that the declared bytes can exist in the file. A malformed header can therefore drive very large allocation attempts or panic during lazy metadata parsing instead of being rejected as malformed input.

### Changes

- Check string lengths before growing the reusable string buffer.
- Check scalar and string-array lengths before allocating result slices.
- Check tensor dimension counts before allocating the shape slice.
- Add malformed GGUF regression coverage for oversized string and array lengths.

### Validation

```text
go test ./fs/gguf
# ok github.com/ollama/ollama/fs/gguf

git diff --check
```