### PR TITLE
cmake: build llama UI embedder for host arch

### DIFF
--- a/llama/compat/llama-cpp-ui-host-tool.patch
+++ b/llama/compat/llama-cpp-ui-host-tool.patch
@@ -1,0 +1,23 @@
+diff --git a/tools/ui/CMakeLists.txt b/tools/ui/CMakeLists.txt
+--- a/tools/ui/CMakeLists.txt
++++ b/tools/ui/CMakeLists.txt
+@@ -36,6 +36,18 @@
+ set(UI_H   "${CMAKE_CURRENT_BINARY_DIR}/ui.h")
+ 
+-if(CMAKE_CROSSCOMPILING)
++set(LLAMA_UI_EMBED_USE_HOST_COMPILER ${CMAKE_CROSSCOMPILING})
++
++# CMake does not set CMAKE_CROSSCOMPILING when macOS builds a non-native
++# architecture slice via CMAKE_OSX_ARCHITECTURES. llama-ui-embed is executed
++# during the build, so it must match the host architecture rather than the
++# target slice.
++if(APPLE AND CMAKE_OSX_ARCHITECTURES AND NOT CMAKE_OSX_ARCHITECTURES MATCHES ";")
++    if(NOT CMAKE_OSX_ARCHITECTURES STREQUAL CMAKE_HOST_SYSTEM_PROCESSOR)
++        set(LLAMA_UI_EMBED_USE_HOST_COMPILER ON)
++    endif()
++endif()
++
++if(LLAMA_UI_EMBED_USE_HOST_COMPILER)
+     find_program(HOST_CXX_COMPILER NAMES g++ clang++ NO_CMAKE_FIND_ROOT_PATH)
+     if(NOT HOST_CXX_COMPILER)
+         message(FATAL_ERROR "UI: no host C++ compiler (g++/clang++) found to build llama-ui-embed; set -DHOST_CXX_COMPILER=<path>")


### PR DESCRIPTION
## Summary

- patch the pinned llama.cpp UI CMake to treat single-arch macOS builds targeting a non-host architecture as a host-tool case for `llama-ui-embed`
- keep the generated `llama-ui` library and llama-server objects on the requested `CMAKE_OSX_ARCHITECTURES` slice
- allow Darwin `amd64` builds on Apple Silicon hosts without requiring Rosetta just to run the build-time UI embedder

Fixes #16500.

## Testing

- `cmake -DPATCH_DIR=/tmp/ollama-16500/llama/compat -P /tmp/ollama-16500/llama/compat/apply-patch.cmake`
- `cmake -S llama/server -B build/test-llama-server-amd64-ui-host ... -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0`
- `cmake --build build/test-llama-server-amd64-ui-host --target llama-ui-assets --parallel 4`
- `file build/test-llama-server-amd64-ui-host/_deps/llama_cpp-build/tools/ui/llama-ui-embed-host`

The generated rules build `llama-ui-embed-host` without `-arch x86_64`, while `llama-ui` still compiles with `-arch x86_64`. The helper was reported as `Mach-O 64-bit executable arm64` and `llama-ui-assets` completed.
