### PR TITLE
Add DeepSeek-OCR-2 model support

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -338,6 +338,8 @@ func LoadModelMetadata(fsys fs.FS) (ModelKV, *Tokenizer, error) {
 		conv = &gptossModel{}
 	case "DeepseekOCRForCausalLM":
 		conv = &deepseekocr{}
+	case "DeepseekOCR2ForCausalLM":
+		conv = &deepseekocr2{}
 	case "DeepseekV3ForCausalLM":
 		conv = &deepseek2Model{}
 	case "Glm4MoeLiteForCausalLM":

--- a/convert/convert_deepseekocr2.go
+++ b/convert/convert_deepseekocr2.go
@@ -1,0 +1,142 @@
+package convert
+
+import (
+	"fmt"
+
+	"github.com/ollama/ollama/fs/ggml"
+)
+
+type deepseekocr2 struct {
+	ModelParameters
+	LanguageConfig struct {
+		MaxPositionEmbeddings uint32 `json:"max_position_embeddings"`
+		HiddenSize            uint32 `json:"hidden_size"`
+		HiddenLayers          uint32 `json:"num_hidden_layers"`
+		IntermediateSize      uint32 `json:"intermediate_size"`
+		NumAttentionHeads     uint32 `json:"num_attention_heads"`
+		NumKeyValueHeads      uint32 `json:"num_key_value_heads"`
+		NumRoutedExperts      uint32 `json:"n_routed_experts"`
+		NumSharedExperts      uint32 `json:"n_shared_experts"`
+		NumExpertsPerToken    uint32 `json:"num_experts_per_tok"`
+		FirstKDenseReplace    uint32 `json:"first_k_dense_replace"`
+	} `json:"language_config"`
+
+	VisionConfig struct {
+		ImageSize uint32 `json:"image_size"`
+		Width     struct {
+			Qwen2 struct {
+				Dim uint32 `json:"dim"`
+			} `json:"qwen2-0-5b"`
+			Sam struct {
+				GlobalAttentionIndexes []int32 `json:"global_attn_indexes"`
+				Heads                  uint32  `json:"heads"`
+				Layers                 uint32  `json:"layers"`
+				Width                  uint32  `json:"width"`
+			} `json:"sam_vit_b"`
+		}
+	} `json:"vision_config"`
+}
+
+func (m *deepseekocr2) KV(t *Tokenizer) KV {
+	kv := m.ModelParameters.KV(t)
+	kv["general.architecture"] = "deepseekocr2"
+	kv["block_count"] = m.LanguageConfig.HiddenLayers
+	kv["context_length"] = m.LanguageConfig.MaxPositionEmbeddings
+	kv["embedding_length"] = m.LanguageConfig.HiddenSize
+	kv["feed_forward_length"] = m.LanguageConfig.IntermediateSize
+	kv["attention.head_count"] = m.LanguageConfig.NumAttentionHeads
+	kv["attention.head_count_kv"] = m.LanguageConfig.NumKeyValueHeads
+	kv["expert_count"] = m.LanguageConfig.NumRoutedExperts
+	kv["expert_used_count"] = m.LanguageConfig.NumExpertsPerToken
+	kv["leading_dense_block_count"] = m.LanguageConfig.FirstKDenseReplace
+
+	// Vision capability marker (enables CLI image support)
+	kv["vision.block_count"] = uint32(24)
+
+	// Qwen2 vision encoder config
+	kv["qwen2.embedding_length"] = m.VisionConfig.Width.Qwen2.Dim
+	// Qwen2 has fixed architecture: 24 layers, 14 heads, 2 KV heads, 4864 intermediate
+	kv["qwen2.block_count"] = uint32(24)
+	kv["qwen2.head_count"] = uint32(14)
+	kv["qwen2.head_count_kv"] = uint32(2)
+	kv["qwen2.intermediate_size"] = uint32(4864)
+
+	// SAM config (same as v1)
+	kv["sam.block_count"] = m.VisionConfig.Width.Sam.Layers
+	kv["sam.embedding_length"] = m.VisionConfig.Width.Sam.Width
+	kv["sam.head_count"] = m.VisionConfig.Width.Sam.Heads
+	kv["sam.global_attention_indexes"] = m.VisionConfig.Width.Sam.GlobalAttentionIndexes
+	return kv
+}
+
+func (m *deepseekocr2) Tensors(s []Tensor) (out []*ggml.Tensor) {
+	merges := make([]merge, m.LanguageConfig.HiddenLayers*3)
+	for i := range m.LanguageConfig.HiddenLayers {
+		merges[i*3+0] = merge{
+			fmt.Sprintf("blk.%d.mlp.experts.*.gate_proj.weight", i),
+			fmt.Sprintf("blk.%d.ffn_gate_exps.weight", i),
+		}
+		merges[i*3+1] = merge{
+			fmt.Sprintf("blk.%d.mlp.experts.*.up_proj.weight", i),
+			fmt.Sprintf("blk.%d.ffn_up_exps.weight", i),
+		}
+		merges[i*3+2] = merge{
+			fmt.Sprintf("blk.%d.mlp.experts.*.down_proj.weight", i),
+			fmt.Sprintf("blk.%d.ffn_down_exps.weight", i),
+		}
+	}
+
+	out, s = mergeTensors(s, merges...)
+	for _, t := range s {
+		out = append(out, &ggml.Tensor{
+			Name:     t.Name(),
+			Kind:     t.Kind(),
+			Shape:    t.Shape(),
+			WriterTo: t,
+		})
+	}
+	return out
+}
+
+func (m *deepseekocr2) Replacements() []string {
+	return []string{
+		// Text model (LLM)
+		"model.embed_tokens", "token_embd",
+		"model.layers", "blk",
+		"input_layernorm", "attn_norm",
+		"self_attn.q_proj", "attn_q",
+		"self_attn.k_proj", "attn_k",
+		"self_attn.v_proj", "attn_v",
+		"self_attn.o_proj", "attn_output",
+		"post_attention_layernorm", "ffn_norm",
+		"mlp.gate_proj", "ffn_gate",
+		"mlp.up_proj", "ffn_up",
+		"mlp.down_proj", "ffn_down",
+		"mlp.gate", "ffn_gate_inp",
+		"mlp.shared_experts.gate_proj", "ffn_gate_shexp",
+		"mlp.shared_experts.up_proj", "ffn_up_shexp",
+		"mlp.shared_experts.down_proj", "ffn_down_shexp",
+		"model.norm", "output_norm",
+		"lm_head", "output",
+
+		// Qwen2 vision encoder (replaces CLIP in v1)
+		// IMPORTANT: "model.qwen2_model.model.model.norm" must come BEFORE "model.norm"
+		// to prevent "model.norm" from matching inside the Qwen2 path
+		"model.qwen2_model.model.model.norm", "q.output_norm",
+		"model.qwen2_model.model.model.layers", "q.blk",
+		"model.qwen2_model.query_768", "q.query_768",
+		"model.qwen2_model.query_1024", "q.query_1024",
+
+		// Projector
+		"model.projector", "mm",
+		//nolint:misspell // this misspelling is upstream. fixing it breaks the model
+		"model.view_seperator", "mm.view_seperator",
+
+		// SAM (same as v1)
+		"model.sam_model.patch_embed.proj", "s.patch_embd",
+		"model.sam_model.pos_embed", "s.position_embd",
+		"model.sam_model.blocks", "s.blk",
+		"model.sam_model.neck", "s.neck",
+		"model.sam_model.net_", "s.net_",
+	}
+}

--- a/convert/convert_deepseekocr2_test.go
+++ b/convert/convert_deepseekocr2_test.go
@@ -1,0 +1,90 @@
+package convert
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDeepseekOCR2CreatesCorrectMetadataAndNames(t *testing.T) {
+	m := &deepseekocr2{}
+	m.LanguageConfig.MaxPositionEmbeddings = 8192
+	m.LanguageConfig.HiddenSize = 1280
+	m.LanguageConfig.HiddenLayers = 12
+	m.LanguageConfig.IntermediateSize = 6848
+	m.LanguageConfig.NumAttentionHeads = 10
+	m.LanguageConfig.NumKeyValueHeads = 10
+	m.LanguageConfig.NumRoutedExperts = 64
+	m.LanguageConfig.NumSharedExperts = 2
+	m.LanguageConfig.NumExpertsPerToken = 6
+	m.LanguageConfig.FirstKDenseReplace = 1
+	m.VisionConfig.Width.Qwen2.Dim = 896
+	m.VisionConfig.Width.Sam.Layers = 12
+	m.VisionConfig.Width.Sam.Width = 768
+	m.VisionConfig.Width.Sam.Heads = 12
+
+	kv := m.KV(&Tokenizer{Vocabulary: &Vocabulary{Model: "gpt2"}, Pre: "default"})
+
+	for k, want := range map[string]any{
+		"general.architecture":              "deepseekocr2",
+		"block_count":                       uint32(12),
+		"context_length":                    uint32(8192),
+		"embedding_length":                  uint32(1280),
+		"feed_forward_length":               uint32(6848),
+		"attention.head_count":              uint32(10),
+		"attention.head_count_kv":           uint32(10),
+		"expert_count":                      uint32(64),
+		"expert_used_count":                 uint32(6),
+		"leading_dense_block_count":         uint32(1),
+		"vision.block_count":                uint32(24),
+		"qwen2.embedding_length":            uint32(896),
+		"qwen2.block_count":                 uint32(24),
+		"qwen2.head_count":                  uint32(14),
+		"qwen2.head_count_kv":               uint32(2),
+		"qwen2.intermediate_size":           uint32(4864),
+		"sam.block_count":                   uint32(12),
+		"sam.embedding_length":              uint32(768),
+		"sam.head_count":                    uint32(12),
+	} {
+		if got := kv[k]; got != want {
+			t.Fatalf("%s = %v (%T), want %v (%T)", k, got, got, want, want)
+		}
+	}
+
+	replacer := strings.NewReplacer(m.Replacements()...)
+
+	for name, want := range map[string]string{
+		// Text model
+		"model.embed_tokens.weight":                                    "token_embd.weight",
+		"model.layers.0.input_layernorm.weight":                        "blk.0.attn_norm.weight",
+		"model.layers.0.self_attn.q_proj.weight":                       "blk.0.attn_q.weight",
+		"model.layers.0.self_attn.k_proj.weight":                       "blk.0.attn_k.weight",
+		"model.layers.0.self_attn.v_proj.weight":                       "blk.0.attn_v.weight",
+		"model.layers.0.self_attn.o_proj.weight":                       "blk.0.attn_output.weight",
+		"model.layers.0.post_attention_layernorm.weight":               "blk.0.ffn_norm.weight",
+		"model.layers.0.mlp.gate_proj.weight":                          "blk.0.ffn_gate.weight",
+		"model.layers.0.mlp.up_proj.weight":                            "blk.0.ffn_up.weight",
+		"model.layers.0.mlp.down_proj.weight":                          "blk.0.ffn_down.weight",
+		"model.norm.weight":                                            "output_norm.weight",
+		"lm_head.weight":                                               "output.weight",
+
+		// Qwen2 vision encoder
+		"model.qwen2_model.model.model.norm.weight":                    "q.output_norm.weight",
+		"model.qwen2_model.model.model.layers.0.self_attn.q_proj.weight": "q.blk.0.attn_q.weight",
+		"model.qwen2_model.query_768":                                  "q.query_768",
+		"model.qwen2_model.query_1024":                                 "q.query_1024",
+
+		// Projector
+		"model.projector.weight":                                       "mm.weight",
+		"model.view_seperator":                                         "mm.view_seperator",
+
+		// SAM
+		"model.sam_model.patch_embed.proj.weight":                      "s.patch_embd.weight",
+		"model.sam_model.pos_embed":                                    "s.position_embd",
+		"model.sam_model.blocks.0.attn.qkv.weight":                    "s.blk.0.attn.qkv.weight",
+		"model.sam_model.neck.conv1.weight":                            "s.neck.conv1.weight",
+	} {
+		if got := replacer.Replace(name); got != want {
+			t.Fatalf("Replace(%q) = %q, want %q", name, got, want)
+		}
+	}
+}

--- a/llama/compat/llama-ollama-compat.cpp
+++ b/llama/compat/llama-ollama-compat.cpp
@@ -1133,6 +1133,63 @@ void handle_deepseekocr(const llama_model_loader * ml, gguf_context * meta,
 }
 
 // =========================================================================
+// deepseekocr2 (text side)
+// =========================================================================
+//
+// Same pattern as deepseekocr.  Ollama uses "deepseekocr2" / KV prefix
+// "deepseekocr2.*", llama.cpp uses "deepseek2-ocr" / "deepseek2-ocr.*".
+
+bool detect_ollama_deepseekocr2(const gguf_context * meta) {
+    const int64_t arch_kid = gguf_find_key(meta, "general.architecture");
+    if (arch_kid < 0) return false;
+    return std::strcmp(gguf_get_val_str(meta, arch_kid), "deepseekocr2") == 0;
+}
+
+void handle_deepseekocr2(const llama_model_loader * ml, gguf_context * meta,
+                         ggml_context * ctx, std::string & arch_name) {
+    if (!detect_ollama_deepseekocr2(meta)) return;
+
+    OLLAMA_COMPAT_LOG_INFO("%s: detected Ollama-format deepseekocr2 GGUF; applying compatibility fixes\n", __func__);
+
+    gguf_set_val_str(meta, "general.architecture", "deepseek2-ocr");
+    rename_kv_prefix(meta, "deepseekocr2.", "deepseek2-ocr.");
+    arch_name = "deepseek2-ocr";
+
+    // Inject defaults needed by the llama.cpp loader.
+    inject_f32_if_missing(meta, "deepseek2-ocr.attention.layer_norm_rms_epsilon",
+                          1e-6f);
+
+    // Recover expert_feed_forward_length from blk.1 (first MoE block; blk.0
+    // is dense). ne[0] of ffn_down_exps is the per-expert inner dim.
+    if (!has_key(meta, "deepseek2-ocr.expert_feed_forward_length")) {
+        if (ggml_tensor * t = ggml_get_tensor(ctx, "blk.1.ffn_down_exps.weight")) {
+            gguf_set_val_u32(meta, "deepseek2-ocr.expert_feed_forward_length",
+                             (uint32_t) t->ne[0]);
+        }
+    }
+
+    // Recover expert_shared_count from blk.1.ffn_down_shexp shape.
+    if (!has_key(meta, "deepseek2-ocr.expert_shared_count")) {
+        ggml_tensor * shexp = ggml_get_tensor(ctx, "blk.1.ffn_down_shexp.weight");
+        const int64_t fflen_kid = gguf_find_key(meta, "deepseek2-ocr.expert_feed_forward_length");
+        if (shexp && fflen_kid >= 0) {
+            const uint32_t fflen = gguf_get_val_u32(meta, fflen_kid);
+            if (fflen > 0) {
+                gguf_set_val_u32(meta, "deepseek2-ocr.expert_shared_count",
+                                 (uint32_t)(shexp->ne[0] / fflen));
+            }
+        }
+    }
+
+    // Hide embedded SAM (`s.*`), vision (`v.*`), projector (`mm.*`),
+    // and Qwen2 encoder (`q.*`) tensors from the text loader.
+    add_skip_prefix(ml, "s.");
+    add_skip_prefix(ml, "v.");
+    add_skip_prefix(ml, "mm.");
+    add_skip_prefix(ml, "q.");
+}
+
+// =========================================================================
 // nemotron_h_moe (text only)
 // =========================================================================
 //
@@ -2225,6 +2282,100 @@ void handle_deepseekocr_clip(gguf_context * meta, ggml_context * ctx) {
 }
 
 // =========================================================================
+// deepseekocr2 (clip side — deepseekocr2 projector)
+// =========================================================================
+//
+// Same pattern as deepseekocr clip, but with "deepseekocr2" prefix and
+// additional Qwen2 encoder tensors (q.*).
+
+void handle_deepseekocr2_clip(gguf_context * meta, ggml_context * ctx) {
+    OLLAMA_COMPAT_LOG_INFO("%s: detected Ollama-format deepseekocr2 GGUF used as mmproj; translating\n", __func__);
+
+    // CLIP encoder hparams.
+    copy_u32_kv(meta, "deepseekocr2.vision.block_count",      "clip.vision.block_count");
+    copy_u32_kv(meta, "deepseekocr2.vision.embedding_length", "clip.vision.embedding_length");
+    copy_u32_kv(meta, "deepseekocr2.vision.head_count",       "clip.vision.attention.head_count");
+    copy_u32_kv(meta, "deepseekocr2.vision.image_size",       "clip.vision.image_size");
+    copy_u32_kv(meta, "deepseekocr2.vision.patch_size",       "clip.vision.patch_size");
+
+    // SAM encoder hparams.
+    copy_u32_kv(meta, "deepseekocr2.sam.block_count",         "clip.vision.sam.block_count");
+    copy_u32_kv(meta, "deepseekocr2.sam.embedding_length",    "clip.vision.sam.embedding_length");
+    copy_u32_kv(meta, "deepseekocr2.sam.head_count",          "clip.vision.sam.head_count");
+
+    // Qwen2 encoder hparams.
+    copy_u32_kv(meta, "deepseekocr2.qwen2.block_count",       "clip.vision.qwen2.block_count");
+    copy_u32_kv(meta, "deepseekocr2.qwen2.embedding_length",  "clip.vision.qwen2.embedding_length");
+    copy_u32_kv(meta, "deepseekocr2.qwen2.head_count",        "clip.vision.qwen2.head_count");
+    copy_u32_kv(meta, "deepseekocr2.qwen2.head_count_kv",     "clip.vision.qwen2.head_count_kv");
+    copy_u32_kv(meta, "deepseekocr2.qwen2.intermediate_size", "clip.vision.qwen2.intermediate_size");
+
+    // Defaults.
+    inject_u32_if_missing(meta, "clip.vision.feed_forward_length",          64);
+    inject_u32_if_missing(meta, "clip.vision.projection_dim",               1280);
+    inject_u32_if_missing(meta, "clip.vision.projector.scale_factor",       1);
+    inject_u32_if_missing(meta, "clip.vision.window_size",                  14);
+    inject_f32_if_missing(meta, "clip.vision.attention.layer_norm_epsilon", 1e-6f);
+
+    static const float kHalfHalfHalf[3] = {0.5f, 0.5f, 0.5f};
+    inject_f32_arr_if_missing(meta, "clip.vision.image_mean", kHalfHalfHalf, 3);
+    inject_f32_arr_if_missing(meta, "clip.vision.image_std",  kHalfHalfHalf, 3);
+
+    inject_bool_if_missing(meta, "clip.has_vision_encoder", true);
+    inject_bool_if_missing(meta, "clip.use_gelu",           true);
+    gguf_set_val_str(meta, "clip.projector_type",  "deepseekocr2");
+    gguf_set_val_str(meta, "general.architecture", "clip");
+
+    // Step 1: rename SAM prefix `s.` -> `v.sam.` only at the start of names.
+    {
+        std::vector<std::string> sam_names;
+        const int64_t n = gguf_get_n_tensors(meta);
+        for (int64_t i = 0; i < n; ++i) {
+            std::string name(gguf_get_tensor_name(meta, i));
+            if (name.size() >= 2 && name[0] == 's' && name[1] == '.') {
+                sam_names.push_back(std::move(name));
+            }
+        }
+        for (const auto & old_name : sam_names) {
+            rename_tensor(meta, ctx, old_name.c_str(),
+                          ("v.sam." + old_name.substr(2)).c_str());
+        }
+    }
+
+    // Step 2: rename Qwen2 prefix `q.` -> `v.qwen2.` only at the start of names.
+    {
+        std::vector<std::string> qwen2_names;
+        const int64_t n = gguf_get_n_tensors(meta);
+        for (int64_t i = 0; i < n; ++i) {
+            std::string name(gguf_get_tensor_name(meta, i));
+            if (name.size() >= 2 && name[0] == 'q' && name[1] == '.') {
+                qwen2_names.push_back(std::move(name));
+            }
+        }
+        for (const auto & old_name : qwen2_names) {
+            rename_tensor(meta, ctx, old_name.c_str(),
+                          ("v.qwen2." + old_name.substr(2)).c_str());
+        }
+    }
+
+    // Step 3: SAM `s.position_embd` (no `.weight` suffix).
+    rename_tensor(meta, ctx, "v.sam.position_embd", "v.sam.pos_embd.weight");
+
+    // Step 4: substring renames for CLIP, SAM block leaves, and projector.
+    for (const auto & [from, to] : kDeepseekocrClipRenames) {
+        rename_tensors_containing(meta, ctx, from, to);
+    }
+
+    // Metal IM2COL needs F32 patch_embd.
+    promote_tensor_to_f32(meta, ctx, "v.patch_embd.weight");
+    promote_tensor_to_f32(meta, ctx, "v.sam.patch_embd.weight");
+    promote_tensor_to_f32(meta, ctx, "v.position_embd.weight");
+
+    // Qwen2 encoder tensors need F32 for some ops.
+    promote_tensor_to_f32(meta, ctx, "v.qwen2.query_embed.weight");
+}
+
+// =========================================================================
 // nemotron_h_omni (clip side — nemotron_v2_vl projector)
 // =========================================================================
 
@@ -3220,6 +3371,7 @@ bool translate_metadata(const llama_model_loader * ml,
     // glm4moelite switches arch_name to "deepseek2" — same pattern.
     if (arch_name == "glm4moelite")   handle_glm4moelite   (ml, meta, ctx, arch_name);
     if (arch_name == "deepseekocr")   handle_deepseekocr   (ml, meta, ctx, arch_name);
+    if (arch_name == "deepseekocr2")  handle_deepseekocr2  (ml, meta, ctx, arch_name);
     if (arch_name == "nemotron_h_omni") handle_nemotron_h_omni(ml, meta, ctx, arch_name);
     if (arch_name == "nemotron_h_moe")  handle_nemotron_h_moe (ml, meta, ctx);
     if (arch_name == "llama")         handle_llama3_metadata(meta);
@@ -3261,6 +3413,10 @@ void translate_clip_metadata(gguf_context * meta, ggml_context * ctx) {
     }
     if (detect_ollama_deepseekocr(meta)) {
         handle_deepseekocr_clip(meta, ctx);
+        return;
+    }
+    if (detect_ollama_deepseekocr2(meta)) {
+        handle_deepseekocr2_clip(meta, ctx);
         return;
     }
     if (detect_ollama_nemotron_h_omni(meta, ctx)) {


### PR DESCRIPTION
## Summary
- Add GGUF converter for DeepSeek-OCR-2 (DeepseekOCR2ForCausalLM)
- Add compatibility layer handlers for llama-server to load Ollama-format deepseekocr2 GGUF files
- The model uses a 3-stage vision encoder (SAM ViT-B + Qwen2-0.5B + projector) and DeepSeek MoE text decoder

## Changes
- `convert/convert_deepseekocr2.go`: New GGUF converter for HuggingFace to GGUF conversion
- `convert/convert.go`: Register DeepseekOCR2ForCausalLM case
- `llama/compat/llama-ollama-compat.cpp`: Add text-side and clip-side compat handlers for deepseekocr2

## Test plan
- [x] Build from source with `go build .`
- [x] Build llama-server with cmake
- [x] Create model from GGUF with `ollama create`
- [x] Run OCR with `ollama run deepseek-ocr2`
- [ ] Test with various images for OCR quality
- [ ] Verify no regressions with existing deepseekocr models

## References
- Issue: https://github.com/ollama/ollama/issues/13974
- llama.cpp PR: https://github.com/ggml-org/llama.cpp/pull/20975
- Reference implementation: https://github.com/larryteal/Mac-M5-Deepseek-OCR-2