### PR TITLE
middleware: omit empty usage on intermediate completion stream chunks

### DIFF
--- a/middleware/openai.go
+++ b/middleware/openai.go
@@ -154,9 +154,6 @@ func (w *CompleteWriter) writeResponse(data []byte) (int, error) {
 	// completion chunk
 	if w.stream {
 		c := openai.ToCompleteChunk(w.id, generateResponse)
-		if w.streamOptions != nil && w.streamOptions.IncludeUsage {
-			c.Usage = &openai.Usage{}
-		}
 		d, err := json.Marshal(c)
 		if err != nil {
 			return 0, err

--- a/middleware/openai_test.go
+++ b/middleware/openai_test.go
@@ -369,6 +369,82 @@ func TestChatWriter_StreamMixedThinkingAndContentWithoutDoneEmitsChunksOnly(t *t
 	}
 }
 
+func TestCompleteWriter_StreamUsageOnlyOnFinalChunk(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(recorder)
+
+	writer := &CompleteWriter{
+		stream:        true,
+		streamOptions: &openai.StreamOptions{IncludeUsage: true},
+		id:            "cmpl-test",
+		BaseWriter:    BaseWriter{ResponseWriter: context.Writer},
+	}
+
+	// an intermediate (non-final) streaming chunk
+	intermediate, err := json.Marshal(api.GenerateResponse{
+		Model:    "test-model",
+		Response: "partial",
+		Done:     false,
+	})
+	if err != nil {
+		t.Fatalf("marshal intermediate response: %v", err)
+	}
+	if _, err = writer.Write(intermediate); err != nil {
+		t.Fatalf("write intermediate response: %v", err)
+	}
+
+	// the final streaming chunk carrying token counts
+	final, err := json.Marshal(api.GenerateResponse{
+		Model:      "test-model",
+		Response:   "",
+		Done:       true,
+		DoneReason: "stop",
+		Metrics: api.Metrics{
+			PromptEvalCount: 3,
+			EvalCount:       2,
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal final response: %v", err)
+	}
+	if _, err = writer.Write(final); err != nil {
+		t.Fatalf("write final response: %v", err)
+	}
+
+	frames := sseDataFrames(recorder.Body.String())
+	// intermediate chunk, final content chunk, usage chunk, [DONE]
+	if len(frames) != 4 {
+		t.Fatalf("expected 4 SSE data frames, got %d:\n%s", len(frames), recorder.Body.String())
+	}
+	if frames[3] != "[DONE]" {
+		t.Fatalf("expected final frame [DONE], got %q", frames[3])
+	}
+
+	// the OpenAI streaming contract requires usage to be null on every chunk
+	// except the dedicated final usage chunk. Inspect the raw JSON so a
+	// zero-valued (but non-nil) usage object is not silently accepted.
+	for i := 0; i < 2; i++ {
+		if strings.Contains(frames[i], "\"usage\"") {
+			t.Fatalf("chunk %d should not contain a usage field, got %s", i, frames[i])
+		}
+	}
+
+	var usageChunk openai.CompletionChunk
+	if err := json.Unmarshal([]byte(frames[2]), &usageChunk); err != nil {
+		t.Fatalf("unmarshal usage chunk: %v", err)
+	}
+	if usageChunk.Usage == nil {
+		t.Fatal("expected usage chunk to include usage")
+	}
+	if usageChunk.Usage.TotalTokens != 5 {
+		t.Fatalf("expected usage total tokens 5, got %d", usageChunk.Usage.TotalTokens)
+	}
+	if len(usageChunk.Choices) != 0 {
+		t.Fatalf("expected usage chunk choices to be empty, got %d", len(usageChunk.Choices))
+	}
+}
+
 func TestChatMiddleware(t *testing.T) {
 	type testCase struct {
 		name string


### PR DESCRIPTION
When streaming `/v1/completions` with `stream_options.include_usage: true`, every intermediate chunk came back with `"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}` instead of `null`.

The cause is in `CompleteWriter.writeResponse`: it set `c.Usage = &openai.Usage{}` on each intermediate chunk. `CompletionChunk.Usage` is a `*Usage` tagged `omitempty`, but omitempty only drops nil pointers — a non-nil pointer to a zero struct is still serialized. So clients that read per-chunk usage saw bogus all-zero counts on every chunk.

The OpenAI streaming contract is that usage is `null` on all chunks except the final dedicated usage chunk. The `/v1/chat/completions` path already does the right thing by leaving usage untouched on intermediate chunks; this just brings the completions path in line by dropping the erroneous assignment. The final usage chunk (built separately when `Done`) is unchanged and still carries the real token counts.

Tested with a new `CompleteWriter` streaming test that sends an intermediate and a final response and asserts, against the raw SSE JSON, that intermediate chunks have no `usage` field while only the final usage chunk carries the totals (and has empty choices). The test fails before the change and passes after; existing middleware and openai tests still pass.
