### PR TITLE
fix: update goose docs to reflect latest version

### DIFF
--- a/docs/integrations/goose.mdx
+++ b/docs/integrations/goose.mdx
@@ -1,33 +1,34 @@
 ---
-title: Goose
+title: goose
 ---
 
-## Goose Desktop
+## goose Desktop
 
-Install [Goose](https://block.github.io/goose/docs/getting-started/installation/) Desktop.
+Install [goose](https://goose-docs.ai/docs/getting-started/installation/) Desktop.
 
 ### Usage with Ollama
-1. In Goose, open **Settings** → **Configure Provider**.  
+1. In goose, open **Settings** → **Models**.
+2. In the **Models** panel, click the **Configure providers** button.
 <div style={{ display: 'flex', justifyContent: 'center' }}>
   <img 
     src="/images/goose-settings.png" 
-    alt="Goose settings Panel"
+    alt="goose settings Panel"
     width="75%"
   />
 </div>
-2. Find **Ollama**, click **Configure** 
-3. Confirm **API Host** is `http://localhost:11434` and click Submit
+3. Find **Ollama**, click **Configure**
+4. Confirm **API Host** is set to `localhost` and click Submit
 
 
 ### Connecting to ollama.com
 
 1. Create an [API key](https://ollama.com/settings/keys) on ollama.com and save it in your `.env` 
-2. In Goose, set **API Host** to `https://ollama.com`
+2. In goose, set **API Host** to `https://ollama.com`
 
 
-## Goose CLI
+## goose CLI
 
-Install [Goose](https://block.github.io/goose/docs/getting-started/installation/) CLI
+Install [goose](https://goose-docs.ai/docs/getting-started/installation/) CLI
 
 ### Usage with Ollama
 1. Run `goose configure`
@@ -35,7 +36,7 @@ Install [Goose](https://block.github.io/goose/docs/getting-started/installation/
 <div style={{ display: 'flex', justifyContent: 'center' }}>
   <img 
     src="/images/goose-cli.png" 
-    alt="Goose CLI"
+    alt="goose CLI"
     width="50%"
   />
 </div>


### PR DESCRIPTION
I updated the docs for goose to reflect 3 things:

1. goose has [moved](https://goose-docs.ai/blog/2026/04/07/goose-moves-to-aaif/) to the Agentic AI Foundation, so the documentation URLs need updated
2. goose is branded as `goose`, with a lowercase `g`, not `Goose`
3. Some changes in the goose desktop UI changed the way Ollama is configured as a provider