### PR TITLE
x/imagegen: wire --negative flag through to Z-Image CFG path

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -141,6 +141,10 @@ type GenerateRequest struct {
 	// Steps is the number of diffusion steps for image generation.
 	// Only used for image generation models.
 	Steps int32 `json:"steps,omitempty"`
+
+	// Negative is the negative prompt for image generation.
+	// Only used for image generation models that support classifier-free guidance (e.g. Z-Image).
+	Negative string `json:"negative,omitempty"`
 }
 
 // ChatRequest describes a request sent by [Client.Chat].

--- a/llm/server.go
+++ b/llm/server.go
@@ -223,10 +223,11 @@ type CompletionRequest struct {
 	TopLogprobs int
 
 	// Image generation fields
-	Width  int32 `json:"width,omitempty"`
-	Height int32 `json:"height,omitempty"`
-	Steps  int32 `json:"steps,omitempty"`
-	Seed   int64 `json:"seed,omitempty"`
+	Width    int32  `json:"width,omitempty"`
+	Height   int32  `json:"height,omitempty"`
+	Steps    int32  `json:"steps,omitempty"`
+	Seed     int64  `json:"seed,omitempty"`
+	Negative string `json:"negative,omitempty"`
 }
 
 type ChatRequest struct {

--- a/server/routes.go
+++ b/server/routes.go
@@ -3181,12 +3181,13 @@ func (s *Server) handleImageGenerate(c *gin.Context, req api.GenerateRequest, mo
 	var finalResponse api.GenerateResponse
 
 	if err := runner.Completion(c.Request.Context(), llm.CompletionRequest{
-		Prompt: req.Prompt,
-		Width:  req.Width,
-		Height: req.Height,
-		Steps:  req.Steps,
-		Seed:   seed,
-		Media:  media,
+		Prompt:   req.Prompt,
+		Width:    req.Width,
+		Height:   req.Height,
+		Steps:    req.Steps,
+		Seed:     seed,
+		Negative: req.Negative,
+		Media:    media,
 	}, func(cr llm.CompletionResponse) {
 		streamStarted = true
 		res := api.GenerateResponse{

--- a/x/imagegen/cli.go
+++ b/x/imagegen/cli.go
@@ -59,7 +59,6 @@ func RegisterFlags(cmd *cobra.Command) {
 	cmd.Flags().MarkHidden("height")
 	cmd.Flags().MarkHidden("steps")
 	cmd.Flags().MarkHidden("seed")
-	cmd.Flags().MarkHidden("negative")
 }
 
 // AppendFlagsDocs appends image generation flags documentation to the command's usage template.
@@ -122,12 +121,13 @@ func generateImageWithOptions(cmd *cobra.Command, modelName, prompt string, keep
 	}
 
 	req := &api.GenerateRequest{
-		Model:  modelName,
-		Prompt: prompt,
-		Images: images,
-		Width:  int32(opts.Width),
-		Height: int32(opts.Height),
-		Steps:  int32(opts.Steps),
+		Model:    modelName,
+		Prompt:   prompt,
+		Images:   images,
+		Width:    int32(opts.Width),
+		Height:   int32(opts.Height),
+		Steps:    int32(opts.Steps),
+		Negative: opts.NegativePrompt,
 	}
 	if opts.Seed != 0 {
 		req.Options = map[string]any{"seed": opts.Seed}
@@ -289,12 +289,13 @@ func runInteractive(cmd *cobra.Command, modelName string, keepAlive *api.Duratio
 
 		// Generate image with current options
 		req := &api.GenerateRequest{
-			Model:  modelName,
-			Prompt: prompt,
-			Images: images,
-			Width:  int32(opts.Width),
-			Height: int32(opts.Height),
-			Steps:  int32(opts.Steps),
+			Model:    modelName,
+			Prompt:   prompt,
+			Images:   images,
+			Width:    int32(opts.Width),
+			Height:   int32(opts.Height),
+			Steps:    int32(opts.Steps),
+			Negative: opts.NegativePrompt,
 		}
 		if opts.Seed != 0 {
 			req.Options = map[string]any{"seed": opts.Seed}

--- a/x/imagegen/imagegen.go
+++ b/x/imagegen/imagegen.go
@@ -18,6 +18,9 @@ import (
 // ImageModel is the interface for image generation models.
 type ImageModel interface {
 	GenerateImage(ctx context.Context, prompt string, width, height int32, steps int, seed int64, progress func(step, total int)) (*mlx.Array, error)
+	// GenerateWithCFG generates an image using classifier-free guidance.
+	// Models that do not support CFG should return an error.
+	GenerateWithCFG(prompt, negativePrompt string, width, height int32, steps int, seed int64, cfgScale float32, progress func(step, total int)) (*mlx.Array, error)
 }
 
 var imageGenMu sync.Mutex
@@ -91,8 +94,14 @@ func (s *server) handleImageCompletion(w http.ResponseWriter, r *http.Request, r
 		flusher.Flush()
 	}
 
-	// Generate image
-	img, err := s.imageModel.GenerateImage(ctx, req.Prompt, req.Width, req.Height, req.Steps, req.Seed, progress)
+	// Generate image, using CFG path when a negative prompt is provided
+	var img *mlx.Array
+	var err error
+	if req.Negative != "" {
+		img, err = s.imageModel.GenerateWithCFG(req.Prompt, req.Negative, req.Width, req.Height, req.Steps, req.Seed, 0, progress)
+	} else {
+		img, err = s.imageModel.GenerateImage(ctx, req.Prompt, req.Width, req.Height, req.Steps, req.Seed, progress)
+	}
 	if err != nil {
 		// Don't send error for cancellation
 		if ctx.Err() != nil {

--- a/x/imagegen/models/flux2/flux2.go
+++ b/x/imagegen/models/flux2/flux2.go
@@ -175,6 +175,11 @@ func (m *Model) GenerateImage(ctx context.Context, prompt string, width, height 
 	})
 }
 
+// GenerateWithCFG is not supported by the Flux2 model.
+func (m *Model) GenerateWithCFG(prompt, negativePrompt string, width, height int32, steps int, seed int64, cfgScale float32, progress func(step, total int)) (*mlx.Array, error) {
+	return nil, fmt.Errorf("negative prompt is not supported by this model")
+}
+
 // GenerateImageWithInputs implements runner.ImageEditModel interface.
 // It generates an image conditioned on the provided input images for image editing.
 func (m *Model) GenerateImageWithInputs(ctx context.Context, prompt string, width, height int32, steps int, seed int64, inputImages []image.Image, progress func(step, total int)) (*mlx.Array, error) {

--- a/x/imagegen/server.go
+++ b/x/imagegen/server.go
@@ -269,12 +269,13 @@ func (s *Server) Completion(ctx context.Context, req llm.CompletionRequest, fn f
 
 	// Build request for subprocess
 	creq := Request{
-		Prompt: req.Prompt,
-		Width:  req.Width,
-		Height: req.Height,
-		Steps:  int(req.Steps),
-		Seed:   seed,
-		Images: images,
+		Prompt:   req.Prompt,
+		Negative: req.Negative,
+		Width:    req.Width,
+		Height:   req.Height,
+		Steps:    int(req.Steps),
+		Seed:     seed,
+		Images:   images,
 	}
 
 	// Pass LLM options if present

--- a/x/imagegen/types.go
+++ b/x/imagegen/types.go
@@ -9,6 +9,10 @@ package imagegen
 type Request struct {
 	Prompt string `json:"prompt"`
 
+	// Negative is the negative prompt for classifier-free guidance.
+	// Only used by models that support CFG (e.g. Z-Image). Empty means no CFG.
+	Negative string `json:"negative,omitempty"`
+
 	// LLM-specific fields
 	Options *RequestOptions `json:"options,omitempty"`
 


### PR DESCRIPTION
NegativePrompt was collected by the CLI but silently dropped before
reaching the runner — Request had no field for it, the server never
passed it through the stack, and the handler always called
GenerateImage (which hard-codes NegativePrompt=""). With a fixed seed
the output PNG was byte-identical with and without the flag.

Changes:
- api/types.go: add Negative field to GenerateRequest
- llm/server.go: add Negative field to CompletionRequest
- server/routes.go: pass Negative into CompletionRequest
- x/imagegen/types.go: add Negative field to runner Request
- x/imagegen/server.go: pass Negative into subprocess Request
- x/imagegen/imagegen.go: extend ImageModel interface with
  GenerateWithCFG; route through it when req.Negative is non-empty
- x/imagegen/cli.go: populate Negative in api.GenerateRequest
  (one-shot and interactive); remove MarkHidden on --negative
- x/imagegen/models/flux2: add GenerateWithCFG returning a clear
  "not supported" error

Fixes #16068