### PR TITLE
Middleware fix content length

### DIFF
--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -143,6 +143,20 @@ func KeepAlive() (keepAlive time.Duration) {
 	return keepAlive
 }
 
+// MLXPingTimeout returns the timeout for pinging the MLX runner to check if it
+// is still alive. During large-context prefill the runner is busy and may not
+// respond within the default window; raise via OLLAMA_MLX_PING_TIMEOUT (e.g.
+// "60s"). Default is 10 seconds.
+func MLXPingTimeout() time.Duration {
+	d := 10 * time.Second
+	if s := Var("OLLAMA_MLX_PING_TIMEOUT"); s != "" {
+		if parsed, err := time.ParseDuration(s); err == nil && parsed > 0 {
+			d = parsed
+		}
+	}
+	return d
+}
+
 // LoadTimeout returns the duration for stall detection during model loads. LoadTimeout can be configured via the OLLAMA_LOAD_TIMEOUT environment variable.
 // Zero or Negative values are treated as infinite.
 // Default is 5 minutes.
@@ -323,6 +337,7 @@ func AsMap() map[string]EnvVar {
 		"OLLAMA_KEEP_ALIVE":           {"OLLAMA_KEEP_ALIVE", KeepAlive(), "The duration that models stay loaded in memory (default \"5m\")"},
 		"OLLAMA_LLM_LIBRARY":          {"OLLAMA_LLM_LIBRARY", LLMLibrary(), "Set LLM library to bypass autodetection"},
 		"OLLAMA_LOAD_TIMEOUT":         {"OLLAMA_LOAD_TIMEOUT", LoadTimeout(), "How long to allow model loads to stall before giving up (default \"5m\")"},
+		"OLLAMA_MLX_PING_TIMEOUT":     {"OLLAMA_MLX_PING_TIMEOUT", MLXPingTimeout(), "Timeout for MLX runner health ping during large-context prefill (default \"10s\")"},
 		"OLLAMA_MAX_LOADED_MODELS":    {"OLLAMA_MAX_LOADED_MODELS", MaxRunners(), "Maximum number of loaded models per GPU"},
 		"OLLAMA_MAX_TRANSFER_STREAMS": {"OLLAMA_MAX_TRANSFER_STREAMS", MaxTransferStreams(), "Maximum parallel transfer streams for safetensors model pulls/pushes (default 4)"},
 		"OLLAMA_MAX_QUEUE":            {"OLLAMA_MAX_QUEUE", MaxQueue(), "Maximum number of queued requests"},

--- a/middleware/openai.go
+++ b/middleware/openai.go
@@ -307,6 +307,7 @@ func RetrieveMiddleware() gin.HandlerFunc {
 		}
 
 		c.Request.Body = io.NopCloser(&b)
+		c.Request.ContentLength = int64(b.Len())
 
 		w := &RetrieveWriter{
 			BaseWriter: BaseWriter{ResponseWriter: c.Writer},
@@ -341,6 +342,7 @@ func CompletionsMiddleware() gin.HandlerFunc {
 		}
 
 		c.Request.Body = io.NopCloser(&b)
+		c.Request.ContentLength = int64(b.Len())
 
 		w := &CompleteWriter{
 			BaseWriter:    BaseWriter{ResponseWriter: c.Writer},
@@ -392,6 +394,7 @@ func EmbeddingsMiddleware() gin.HandlerFunc {
 		}
 
 		c.Request.Body = io.NopCloser(&b)
+		c.Request.ContentLength = int64(b.Len())
 
 		w := &EmbedWriter{
 			BaseWriter:     BaseWriter{ResponseWriter: c.Writer},
@@ -433,6 +436,7 @@ func ChatMiddleware() gin.HandlerFunc {
 		}
 
 		c.Request.Body = io.NopCloser(&b)
+		c.Request.ContentLength = int64(b.Len())
 
 		w := &ChatWriter{
 			BaseWriter:    BaseWriter{ResponseWriter: c.Writer},
@@ -544,6 +548,7 @@ func ResponsesMiddleware() gin.HandlerFunc {
 		}
 
 		c.Request.Body = io.NopCloser(&b)
+		c.Request.ContentLength = int64(b.Len())
 
 		responseID := fmt.Sprintf("resp_%d", rand.Intn(999999))
 		itemID := fmt.Sprintf("msg_%d", rand.Intn(999999))
@@ -623,6 +628,7 @@ func ImageGenerationsMiddleware() gin.HandlerFunc {
 		}
 
 		c.Request.Body = io.NopCloser(&b)
+		c.Request.ContentLength = int64(b.Len())
 
 		w := &ImageWriter{
 			BaseWriter: BaseWriter{ResponseWriter: c.Writer},
@@ -669,6 +675,7 @@ func ImageEditsMiddleware() gin.HandlerFunc {
 		}
 
 		c.Request.Body = io.NopCloser(&b)
+		c.Request.ContentLength = int64(b.Len())
 
 		w := &ImageWriter{
 			BaseWriter: BaseWriter{ResponseWriter: c.Writer},

--- a/server/sched.go
+++ b/server/sched.go
@@ -1391,7 +1391,7 @@ func (runner *runnerRef) needsReload(ctx context.Context, req *LlmRequest) bool 
 		return true
 	}
 
-	timeout := 10 * time.Second
+	timeout := envconfig.MLXPingTimeout()
 	if runner.loading {
 		timeout = 2 * time.Minute // Initial load can take a long time for big models on slow systems...
 	}


### PR DESCRIPTION
When each OpenAI-compat middleware rewrites c.Request.Body with a new
bytes.Buffer, the original Content-Length header still reflects the
incoming request size. If the re-encoded body differs in size, gin's
JSON binder reads fewer bytes than Content-Length advertises and returns
an unexpected EOF or "cannot parse request body" error.

TranscriptionMiddleware already sets c.Request.ContentLength after the
body rewrite; apply the same fix to the remaining seven middlewares.

Fixes #16082