### PR TITLE
Add Ollama API Gateway with Docker Compose stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,26 @@
+HTTP_PORT=8080
+
+# Low-end / CPU: official image + lower memory use (do not use :rocm on Windows Docker)
+OLLAMA_IMAGE=ollama/ollama:latest
+OLLAMA_KEEP_ALIVE=5m
+OLLAMA_NUM_PARALLEL=1
+OLLAMA_MAX_LOADED_MODELS=1
+
+# Session storage TTL in seconds (default 7 days)
+SESSION_TTL_SECONDS=604800
+
+# Higher-end: use 24h keep-alive and more parallel loads if you have RAM/GPU headroom
+# OLLAMA_KEEP_ALIVE=24h
+# OLLAMA_NUM_PARALLEL=2
+# OLLAMA_MAX_LOADED_MODELS=3
+
+# Bootstrap super admin credentials (used to create initial admin account)
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD=change-this-secure-password
+
+# JWT secret for admin tokens (generate with: python -c "import secrets; print(secrets.token_urlsafe(32))")
+JWT_SECRET_KEY=generate-a-secure-random-key-here
+
+# Legacy: Comma-separated API keys for migration to Redis
+# After initial setup, use the admin UI to manage keys instead of .env
+API_KEYS=your-long-secret-key-here

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ llama/build
 llama/vendor
 /ollama
 integration/testdata/models/
+docker-compose.yml
+docke-compose.gpu.yml
+.env.example

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,0 +1,252 @@
+# Ollama Gateway — Quickstart
+
+Run Ollama behind a small API gateway with a web chat UI. Ollama stays private on the Docker network; only nginx is exposed on the host.
+
+## What you get
+
+| Service | Role |
+|---------|------|
+| **ollama** | Local LLM inference |
+| **redis** | Session and chat history storage |
+| **api** | FastAPI gateway (API key auth, sessions) |
+| **frontend** | React chat UI |
+| **nginx** | Public entrypoint at `http://localhost:8080` |
+
+## Prerequisites
+
+- **Docker Desktop** (Windows/macOS) or **Docker Engine + Compose** (Linux)
+- **8 GB+ RAM** recommended for small models on CPU
+- **NVIDIA GPU** (optional) — drivers + [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html)
+
+On Windows, use Docker Desktop with **WSL 2** backend.
+
+---
+
+## 1. Configure environment
+
+From the repository root:
+
+```powershell
+Copy-Item .env.example .env
+```
+
+Edit `.env` and set at least one API key:
+
+```dotenv
+HTTP_PORT=8080
+OLLAMA_IMAGE=ollama/ollama:latest
+OLLAMA_KEEP_ALIVE=5m
+OLLAMA_NUM_PARALLEL=1
+OLLAMA_MAX_LOADED_MODELS=1
+SESSION_TTL_SECONDS=604800
+
+# Required — comma-separated keys for users
+API_KEYS=your-secret-key-here
+```
+
+You can add multiple keys (one per user or team):
+
+```dotenv
+API_KEYS=alice-key,bob-key,team-key
+```
+
+Each key maps to a stable `user_id`; chat sessions are isolated per key.
+
+---
+
+## 2. Start the stack
+
+```powershell
+docker compose up -d --build
+```
+
+First run builds the API gateway and frontend images. Wait until all containers are up:
+
+```powershell
+docker compose ps
+```
+
+Check health:
+
+```powershell
+curl.exe http://localhost:8080/api/health
+```
+
+Expected response includes `"status": "ok"` and `"redis_connected": true`.
+
+---
+
+## 3. Pull a model
+
+Pull a small model suitable for CPU (recommended on low-end machines):
+
+```powershell
+docker exec -it ollama ollama pull llama3.2:1b
+```
+
+Other small options: `phi3:mini`, `qwen2.5:0.5b`.
+
+---
+
+## 4. Use the web UI
+
+1. Open **http://localhost:8080**
+2. Enter an API key from `.env` (e.g. `your-secret-key-here`)
+3. Click **Sign In**
+4. Click **+ New Chat**
+5. Type a message and press **Send**
+
+The UI stores your API key in the browser and loads session history from the gateway.
+
+---
+
+## 5. Optional — NVIDIA GPU
+
+Verify Docker sees the GPU:
+
+```powershell
+docker run --rm --gpus all nvidia/cuda:12.6.0-base-ubuntu24.04 nvidia-smi
+```
+
+Start with the GPU override:
+
+```powershell
+docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d --build
+```
+
+---
+
+## API usage (curl / PowerShell)
+
+All requests require:
+
+```
+Authorization: Bearer <your-api-key>
+```
+
+### List models
+
+```powershell
+curl.exe http://localhost:8080/api/v1/models `
+  -H "Authorization: Bearer your-secret-key-here"
+```
+
+### Create a session
+
+```powershell
+$headers = @{
+  Authorization  = "Bearer your-secret-key-here"
+  "Content-Type" = "application/json"
+}
+
+$body = @{ title = "My chat"; model = "llama3.2:1b" } | ConvertTo-Json
+
+Invoke-RestMethod `
+  -Uri "http://localhost:8080/api/sessions" `
+  -Method Post `
+  -Headers $headers `
+  -Body $body
+```
+
+### Send a message (server keeps context)
+
+```powershell
+$sessionId = "<session_id from create response>"
+
+$body = @{ message = "What is Docker?" } | ConvertTo-Json
+
+Invoke-RestMethod `
+  -Uri "http://localhost:8080/api/sessions/$sessionId/chat" `
+  -Method Post `
+  -Headers $headers `
+  -Body $body
+```
+
+Interactive API docs (when the gateway is running): **http://localhost:8080/api/docs**
+
+---
+
+## Useful commands
+
+| Task | Command |
+|------|---------|
+| View logs | `docker compose logs -f` |
+| API logs only | `docker compose logs -f api` |
+| Restart after `.env` change | `docker compose up -d --build` |
+| Stop stack | `docker compose down` |
+| Stop and remove volumes (models + Redis) | `docker compose down -v` |
+
+---
+
+## Troubleshooting
+
+### `Set API_KEYS in your .env file`
+
+`API_KEYS` is required. Add it to `.env` and restart:
+
+```powershell
+docker compose up -d --build
+```
+
+### 502 Bad Gateway on login or `/api/health`
+
+The API container may not be running:
+
+```powershell
+docker compose ps
+docker compose logs api --tail 50
+```
+
+Restart the API:
+
+```powershell
+docker compose restart api
+```
+
+### Invalid API key
+
+- Key must match one entry in `API_KEYS` in `.env` (no extra spaces)
+- Restart API after changing `.env`: `docker compose restart api`
+
+### Chat returns errors / no model
+
+Pull the model inside the Ollama container:
+
+```powershell
+docker exec -it ollama ollama list
+docker exec -it ollama ollama pull llama3.2:1b
+```
+
+### Slow responses on CPU
+
+Use a smaller model and keep defaults in `.env`:
+
+```dotenv
+OLLAMA_KEEP_ALIVE=5m
+OLLAMA_NUM_PARALLEL=1
+OLLAMA_MAX_LOADED_MODELS=1
+```
+
+---
+
+## Security notes
+
+- Do not expose Ollama port `11434` directly to the internet.
+- Replace example API keys before any non-local use.
+- Put HTTPS in front of nginx (Cloudflare, Caddy, Traefik, etc.) before public deployment.
+- Sessions expire after `SESSION_TTL_SECONDS` (default 7 days).
+
+---
+
+## Project layout
+
+```
+.
+├── api-gateway/      # FastAPI gateway
+├── frontend/         # React UI
+├── nginx/            # Reverse proxy config
+├── docker-compose.yml
+├── docker-compose.gpu.yml
+├── .env.example
+└── QUICKSTART.md     # This file
+```

--- a/api-gateway/Dockerfile
+++ b/api-gateway/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/api-gateway/main.py
+++ b/api-gateway/main.py
@@ -1,0 +1,503 @@
+import json
+import os
+import secrets
+import uuid
+from collections.abc import AsyncIterator
+from datetime import datetime
+from typing import Any
+
+import httpx
+import redis.asyncio as redis
+from fastapi import FastAPI, HTTPException, Header, Request, status
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse, StreamingResponse
+from pydantic import BaseModel
+from starlette.background import BackgroundTask
+from starlette.middleware.base import BaseHTTPMiddleware
+
+
+OLLAMA_URL = os.getenv("OLLAMA_URL", "http://ollama:11434").rstrip("/")
+REDIS_URL = os.getenv("REDIS_URL", "redis://redis:6379")
+REQUEST_TIMEOUT_SECONDS = float(os.getenv("REQUEST_TIMEOUT_SECONDS", "300"))
+SESSION_TTL_SECONDS = int(os.getenv("SESSION_TTL_SECONDS", "604800"))  # 7 days
+
+FORMAT_SYSTEM_PROMPT = os.getenv(
+    "FORMAT_SYSTEM_PROMPT",
+    (
+        "You are a helpful assistant. Format all answers in Markdown.\n"
+        "- Use headings and bullet points when helpful.\n"
+        "- Preserve indentation and line breaks.\n"
+        "- For code, use fenced code blocks with the correct language tag.\n"
+        "- When rewriting text, output only the rewritten text.\n"
+    ),
+)
+
+HOP_BY_HOP_HEADERS = {
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+}
+
+app = FastAPI(title="Ollama API Gateway", docs_url="/docs", redoc_url=None)
+
+# Configure CORS
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],  # In production, specify exact origins
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# Global Redis client (initialized on startup)
+redis_client: redis.Redis | None = None
+
+
+class Message(BaseModel):
+    role: str
+    content: str
+
+
+class SessionCreate(BaseModel):
+    title: str | None = None
+    model: str = "llama3.2:1b"
+
+
+class SessionChatRequest(BaseModel):
+    message: str
+    model: str | None = None
+    stream: bool = False
+
+
+class SessionResponse(BaseModel):
+    session_id: str
+    user_id: str
+    title: str
+    model: str
+    message_count: int
+    created_at: str
+    updated_at: str
+
+
+@app.on_event("startup")
+async def startup():
+    global redis_client
+    redis_client = redis.from_url(REDIS_URL, decode_responses=True)
+
+
+@app.on_event("shutdown")
+async def shutdown():
+    if redis_client:
+        await redis_client.close()
+
+
+def configured_api_keys() -> dict[str, str]:
+    """Returns {api_key: user_id} mapping from .env."""
+    raw_keys = os.getenv("API_KEYS", "")
+    keys = [k.strip() for k in raw_keys.split(",") if k.strip()]
+    # Simple mapping: hash the key to get a stable user_id
+    return {key: f"user_{abs(hash(key)) % 10000:04d}" for key in keys}
+
+
+async def require_api_key(authorization: str | None) -> str:
+    """Validate Bearer token and return user_id."""
+    if not authorization:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing API key",
+        )
+
+    scheme, _, token = authorization.partition(" ")
+    if scheme.lower() != "bearer" or not token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Use Authorization: Bearer <api-key>",
+        )
+
+    # Use constant-time comparison
+    key_map = configured_api_keys()
+    if not key_map:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Gateway API keys are not configured",
+        )
+
+    for key, user_id in key_map.items():
+        if secrets.compare_digest(token, key):
+            return user_id
+
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Invalid API key",
+    )
+
+
+def forward_request_headers(request: Request) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    for name, value in request.headers.items():
+        lower_name = name.lower()
+        if lower_name in HOP_BY_HOP_HEADERS:
+            continue
+        if lower_name in {"authorization", "host", "content-length", "x-session-id"}:
+            continue
+        headers[name] = value
+    return headers
+
+
+def forward_response_headers(response: httpx.Response) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    for name, value in response.headers.items():
+        lower_name = name.lower()
+        if lower_name in HOP_BY_HOP_HEADERS:
+            continue
+        if lower_name == "content-length":
+            continue
+        headers[name] = value
+    return headers
+
+
+async def close_upstream(response: httpx.Response, client: httpx.AsyncClient) -> None:
+    await response.aclose()
+    await client.aclose()
+
+
+async def stream_response(response: httpx.Response) -> AsyncIterator[bytes]:
+    async for chunk in response.aiter_raw():
+        yield chunk
+
+
+def session_key(user_id: str, session_id: str) -> str:
+    """Redis key for session data."""
+    return f"session:{user_id}:{session_id}"
+
+
+def session_index_key(user_id: str) -> str:
+    """Redis key for user's session list."""
+    return f"sessions:{user_id}"
+
+
+async def create_session(user_id: str, title: str | None, model: str) -> str:
+    """Create a new session and return session_id."""
+    session_id = str(uuid.uuid4())
+    now = datetime.utcnow().isoformat()
+
+    session_data = {
+        "session_id": session_id,
+        "user_id": user_id,
+        "title": title or "New chat",
+        "model": model,
+        "messages": json.dumps([]),
+        "created_at": now,
+        "updated_at": now,
+    }
+
+    # Store session
+    key = session_key(user_id, session_id)
+    await redis_client.hset(key, mapping=session_data)
+    await redis_client.expire(key, SESSION_TTL_SECONDS)
+
+    # Add to user's session index
+    await redis_client.sadd(session_index_key(user_id), session_id)
+
+    return session_id
+
+
+async def get_session(user_id: str, session_id: str) -> dict[str, Any] | None:
+    """Load session data."""
+    key = session_key(user_id, session_id)
+    data = await redis_client.hgetall(key)
+    if not data:
+        return None
+
+    # Parse messages JSON
+    data["messages"] = json.loads(data.get("messages", "[]"))
+    return data
+
+
+async def update_session(user_id: str, session_id: str, messages: list[dict], model: str | None = None):
+    """Update session messages and refresh TTL."""
+    key = session_key(user_id, session_id)
+    updates = {
+        "messages": json.dumps(messages),
+        "updated_at": datetime.utcnow().isoformat(),
+    }
+    if model:
+        updates["model"] = model
+
+    await redis_client.hset(key, mapping=updates)
+    await redis_client.expire(key, SESSION_TTL_SECONDS)
+
+
+async def list_sessions(user_id: str) -> list[SessionResponse]:
+    """List all sessions for a user."""
+    session_ids = await redis_client.smembers(session_index_key(user_id))
+    sessions = []
+
+    for sid in session_ids:
+        data = await get_session(user_id, sid)
+        if data:
+            sessions.append(
+                SessionResponse(
+                    session_id=data["session_id"],
+                    user_id=data["user_id"],
+                    title=data["title"],
+                    model=data["model"],
+                    message_count=len(data["messages"]),
+                    created_at=data["created_at"],
+                    updated_at=data["updated_at"],
+                )
+            )
+
+    return sorted(sessions, key=lambda s: s.updated_at, reverse=True)
+
+
+async def delete_session(user_id: str, session_id: str):
+    """Delete a session."""
+    await redis_client.delete(session_key(user_id, session_id))
+    await redis_client.srem(session_index_key(user_id), session_id)
+
+
+# ============================================================================
+# Session management endpoints
+# ============================================================================
+
+
+@app.get("/health")
+async def health() -> dict[str, str | bool]:
+    redis_ok = False
+    if redis_client:
+        try:
+            await redis_client.ping()
+            redis_ok = True
+        except Exception:
+            pass
+
+    return {
+        "status": "ok",
+        "ollama_url": OLLAMA_URL,
+        "redis_connected": redis_ok,
+        "api_keys_configured": bool(configured_api_keys()),
+    }
+
+
+@app.post("/sessions", response_model=SessionResponse, status_code=201)
+async def create_session_endpoint(
+    body: SessionCreate,
+    authorization: str | None = Header(default=None),
+):
+    """Create a new chat session."""
+    user_id = await require_api_key(authorization)
+    session_id = await create_session(user_id, body.title, body.model)
+    session = await get_session(user_id, session_id)
+
+    return SessionResponse(
+        session_id=session["session_id"],
+        user_id=session["user_id"],
+        title=session["title"],
+        model=session["model"],
+        message_count=0,
+        created_at=session["created_at"],
+        updated_at=session["updated_at"],
+    )
+
+
+@app.get("/sessions", response_model=list[SessionResponse])
+async def list_sessions_endpoint(authorization: str | None = Header(default=None)):
+    """List all sessions for the authenticated user."""
+    user_id = await require_api_key(authorization)
+    return await list_sessions(user_id)
+
+
+@app.get("/sessions/{session_id}/messages")
+async def get_session_messages(
+    session_id: str,
+    authorization: str | None = Header(default=None),
+):
+    """Get message history for a session."""
+    user_id = await require_api_key(authorization)
+    session = await get_session(user_id, session_id)
+
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    return {"session_id": session_id, "messages": session["messages"]}
+
+
+@app.delete("/sessions/{session_id}", status_code=204)
+async def delete_session_endpoint(
+    session_id: str,
+    authorization: str | None = Header(default=None),
+):
+    """Delete a session."""
+    user_id = await require_api_key(authorization)
+    await delete_session(user_id, session_id)
+
+
+@app.post("/sessions/{session_id}/chat")
+async def session_chat(
+    session_id: str,
+    body: SessionChatRequest,
+    authorization: str | None = Header(default=None),
+):
+    """Send a message in a session (server manages context)."""
+    user_id = await require_api_key(authorization)
+    session = await get_session(user_id, session_id)
+
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    # Build messages with session history
+    messages = session["messages"]
+    # Ensure a consistent formatting/system prompt at the start of the session.
+    if not messages or messages[0].get("role") != "system":
+        messages.insert(0, {"role": "system", "content": FORMAT_SYSTEM_PROMPT})
+    elif messages[0].get("content") != FORMAT_SYSTEM_PROMPT:
+        # Keep the session stable even if the prompt changes across deployments.
+        messages[0]["content"] = FORMAT_SYSTEM_PROMPT
+    messages.append({"role": "user", "content": body.message})
+
+    model = body.model or session["model"]
+
+    # Call Ollama
+    ollama_body = {
+        "model": model,
+        "messages": messages,
+        "stream": body.stream,
+    }
+
+    client = httpx.AsyncClient(timeout=httpx.Timeout(REQUEST_TIMEOUT_SECONDS, connect=10.0))
+
+    try:
+        response = await client.post(
+            f"{OLLAMA_URL}/v1/chat/completions",
+            json=ollama_body,
+            headers={"Content-Type": "application/json"},
+        )
+        response.raise_for_status()
+        result = response.json()
+    except httpx.HTTPError as exc:
+        await client.aclose()
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"Ollama request failed: {exc}",
+        )
+    finally:
+        await client.aclose()
+
+    # Extract assistant reply
+    assistant_message = result["choices"][0]["message"]["content"]
+    messages.append({"role": "assistant", "content": assistant_message})
+
+    # Update session
+    await update_session(user_id, session_id, messages, model)
+
+    return result
+
+
+# ============================================================================
+# OpenAI-compatible proxy (optional X-Session-Id)
+# ============================================================================
+
+
+class OllamaProxyMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        if not request.url.path.startswith("/v1/"):
+            return await call_next(request)
+
+        authorization = request.headers.get("authorization")
+        session_id_header = request.headers.get("x-session-id")
+
+        try:
+            user_id = await require_api_key(authorization)
+        except HTTPException as exc:
+            return JSONResponse(
+                status_code=exc.status_code,
+                content={"error": exc.detail},
+            )
+
+        # Optional: load session context if X-Session-Id provided
+        if session_id_header:
+            session = await get_session(user_id, session_id_header)
+            if session:
+                # Inject session messages into request body
+                body_bytes = await request.body()
+                try:
+                    body = json.loads(body_bytes)
+                    # Merge session history with incoming messages
+                    session_messages = session["messages"]
+                    if "messages" in body:
+                        # Append new user message to session history
+                        session_messages.extend(body["messages"])
+                        body["messages"] = session_messages
+                        body_bytes = json.dumps(body).encode()
+                except json.JSONDecodeError:
+                    pass
+
+                # Rebuild request with merged context
+                request._body = body_bytes
+
+        path = request.url.path.removeprefix("/v1/")
+        target_url = f"{OLLAMA_URL}/v1/{path}"
+        if request.url.query:
+            target_url = f"{target_url}?{request.url.query}"
+
+        body = await request.body()
+        client = httpx.AsyncClient(
+            timeout=httpx.Timeout(REQUEST_TIMEOUT_SECONDS, connect=10.0)
+        )
+        upstream_request = client.build_request(
+            request.method,
+            target_url,
+            headers=forward_request_headers(request),
+            content=body,
+        )
+
+        try:
+            upstream_response = await client.send(upstream_request, stream=True)
+        except httpx.HTTPError as exc:
+            await client.aclose()
+            return JSONResponse(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                content={"error": f"Ollama upstream request failed: {exc}"},
+            )
+
+        # Optionally save response to session
+        if session_id_header and request.method == "POST" and "/chat/completions" in request.url.path:
+            # Read response to extract assistant message
+            response_bytes = b""
+            async for chunk in upstream_response.aiter_raw():
+                response_bytes += chunk
+
+            try:
+                response_data = json.loads(response_bytes)
+                if "choices" in response_data and len(response_data["choices"]) > 0:
+                    assistant_content = response_data["choices"][0]["message"]["content"]
+                    session = await get_session(user_id, session_id_header)
+                    if session:
+                        messages = session["messages"]
+                        messages.append({"role": "assistant", "content": assistant_content})
+                        await update_session(user_id, session_id_header, messages)
+
+                # Return buffered response
+                return JSONResponse(
+                    status_code=upstream_response.status_code,
+                    content=response_data,
+                    headers=dict(forward_response_headers(upstream_response)),
+                )
+            except Exception:
+                pass
+
+        return StreamingResponse(
+            stream_response(upstream_response),
+            status_code=upstream_response.status_code,
+            headers=forward_response_headers(upstream_response),
+            background=BackgroundTask(close_upstream, upstream_response, client),
+        )
+
+
+app.add_middleware(OllamaProxyMiddleware)

--- a/api-gateway/requirements.txt
+++ b/api-gateway/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.115.6
+httpx==0.28.1
+uvicorn[standard]==0.34.0
+redis==5.2.1

--- a/docker-compose.gpu.yml
+++ b/docker-compose.gpu.yml
@@ -1,0 +1,9 @@
+services:
+  ollama:
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,64 @@
+services:
+  ollama:
+    image: ${OLLAMA_IMAGE:-ollama/ollama:latest}
+    container_name: ollama
+    restart: unless-stopped
+    expose:
+      - "11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    environment:
+      OLLAMA_HOST: 0.0.0.0:11434
+      OLLAMA_KEEP_ALIVE: ${OLLAMA_KEEP_ALIVE:-5m}
+      OLLAMA_NUM_PARALLEL: ${OLLAMA_NUM_PARALLEL:-1}
+      OLLAMA_MAX_LOADED_MODELS: ${OLLAMA_MAX_LOADED_MODELS:-1}
+
+  redis:
+    image: redis:7-alpine
+    container_name: ollama-redis
+    restart: unless-stopped
+    expose:
+      - "6379"
+    volumes:
+      - redis_data:/data
+    command: redis-server --appendonly yes
+
+  api:
+    build:
+      context: ./api-gateway
+    container_name: ollama-api-gateway
+    restart: unless-stopped
+    depends_on:
+      - ollama
+      - redis
+    expose:
+      - "8000"
+    environment:
+      OLLAMA_URL: http://ollama:11434
+      REDIS_URL: redis://redis:6379
+      API_KEYS: ${API_KEYS:?Set API_KEYS in your .env file}
+      SESSION_TTL_SECONDS: ${SESSION_TTL_SECONDS:-604800}
+
+  frontend:
+    build:
+      context: ./frontend
+    container_name: ollama-frontend
+    restart: unless-stopped
+    expose:
+      - "80"
+
+  nginx:
+    image: nginx:1.27-alpine
+    container_name: ollama-nginx
+    restart: unless-stopped
+    depends_on:
+      - api
+      - frontend
+    ports:
+      - "${HTTP_PORT:-8080}:80"
+    volumes:
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+
+volumes:
+  ollama_data:
+  redis_data:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.env
+.env.local

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json* ./
+RUN npm install
+
+COPY . .
+RUN npm run build
+
+FROM nginx:1.27-alpine
+COPY --from=builder /app/dist /usr/share/nginx/html
+EXPOSE 80

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,136 @@
+# Ollama Gateway Frontend
+
+Modern React + TypeScript chat interface for the Ollama Gateway API.
+
+## Features
+
+- **User Authentication** - API key-based login with persistent session storage
+- **Multi-Session Management** - Create, switch, and delete chat sessions
+- **Real-time Chat** - Send messages and receive AI responses
+- **Session Isolation** - Each user's chats are completely isolated via Redis
+- **Responsive Design** - Works on desktop and mobile
+- **Dark Theme** - Easy on the eyes
+
+## Technology Stack
+
+- **React 18** - UI framework
+- **TypeScript** - Type safety
+- **Vite** - Fast build tool and dev server
+- **CSS Modules** - Scoped styling
+
+## Development
+
+### Prerequisites
+
+- Node.js 20+
+- npm or yarn
+
+### Local Development
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+The app will be available at `http://localhost:3000` with API proxy to the gateway.
+
+### Build for Production
+
+```bash
+npm run build
+```
+
+Outputs to `dist/` directory, served by nginx in Docker.
+
+## Docker Deployment
+
+The frontend is automatically built and deployed via `docker-compose.yml`:
+
+```yaml
+frontend:
+  build:
+    context: ./frontend
+  container_name: ollama-frontend
+```
+
+Access at `http://localhost:8080` (same port as the gateway, nginx routes traffic).
+
+## Usage
+
+### First Time
+
+1. Open `http://localhost:8080`
+2. Enter your API key (e.g., `user1-key` from `.env`)
+3. Click "Sign In"
+
+### Creating Chats
+
+1. Click "+ New Chat" in sidebar
+2. Type a message and press Send
+3. AI responds with full conversation context
+
+### Managing Sessions
+
+- **Switch Chat**: Click any chat in the sidebar
+- **Delete Chat**: Hover over chat, click × button
+- **Logout**: Click Logout button at bottom of sidebar
+
+## API Integration
+
+The frontend calls these gateway endpoints:
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/api/health` | GET | Health check |
+| `/api/sessions` | POST | Create session |
+| `/api/sessions` | GET | List sessions |
+| `/api/sessions/{id}/messages` | GET | Get history |
+| `/api/sessions/{id}/chat` | POST | Send message |
+| `/api/sessions/{id}` | DELETE | Delete session |
+
+All requests (except health) require `Authorization: Bearer <api-key>`.
+
+## File Structure
+
+```
+frontend/
+├── src/
+│   ├── components/
+│   │   ├── Login.tsx        # API key login
+│   │   ├── Sidebar.tsx      # Session list
+│   │   └── Chat.tsx         # Message display + input
+│   ├── api.ts               # API client
+│   ├── App.tsx              # Main component
+│   └── main.tsx             # Entry point
+├── Dockerfile               # Multi-stage build
+├── vite.config.ts           # Vite config
+└── package.json
+```
+
+## Security Notes
+
+- API keys are stored in `localStorage` (browser-only, not sent to server except in headers)
+- HTTPS recommended for production
+- CORS enabled on gateway for dev mode
+- In production, specify exact `allow_origins` in gateway CORS config
+
+## Troubleshooting
+
+**Login fails:**
+- Check API key is correct (matches `.env` `API_KEYS`)
+- Verify gateway is running: `docker compose ps`
+- Check gateway health: `http://localhost:8080/api/health`
+
+**Messages not sending:**
+- Ensure session was created successfully
+- Check browser console for errors
+- Verify model is pulled: `docker exec -it ollama ollama list`
+
+**Sessions not loading:**
+- Check Redis is running: `docker compose ps`
+- Verify `redis_connected: true` in health endpoint
+
+## License
+
+Same as parent Ollama project (MIT).

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ollama Gateway</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "ollama-gateway-ui",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.43",
+    "@types/react-dom": "^18.2.17",
+    "@vitejs/plugin-react": "^4.2.1",
+    "typescript": "^5.2.2",
+    "vite": "^5.0.8"
+  }
+}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,61 @@
+.app {
+  display: flex;
+  height: 100vh;
+  width: 100%;
+  overflow: hidden;
+}
+
+.main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  gap: 1rem;
+  color: #666;
+}
+
+.empty-state button {
+  padding: 0.75rem 1.5rem;
+  background: #1a73e8;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.empty-state button:hover {
+  background: #1557b0;
+}
+
+.loading-screen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  gap: 1rem;
+}
+
+.spinner {
+  width: 50px;
+  height: 50px;
+  border: 4px solid #333;
+  border-top-color: #1a73e8;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,112 @@
+import { useState, useEffect } from 'react';
+import Login from './components/Login';
+import Chat from './components/Chat';
+import Sidebar from './components/Sidebar';
+import { api, Session } from './api';
+import './App.css';
+
+function App() {
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [sessions, setSessions] = useState<Session[]>([]);
+  const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const apiKey = api.getApiKey();
+    if (apiKey) {
+      setIsAuthenticated(true);
+      loadSessions();
+    } else {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const loadSessions = async () => {
+    try {
+      const sessionList = await api.listSessions();
+      setSessions(sessionList);
+      if (sessionList.length > 0 && !activeSessionId) {
+        setActiveSessionId(sessionList[0].session_id);
+      }
+    } catch (error) {
+      console.error('Failed to load sessions:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleLogin = async (apiKey: string) => {
+    api.setApiKey(apiKey);
+    setIsAuthenticated(true);
+    await loadSessions();
+  };
+
+  const handleLogout = () => {
+    api.clearApiKey();
+    setIsAuthenticated(false);
+    setSessions([]);
+    setActiveSessionId(null);
+  };
+
+  const handleNewChat = async () => {
+    try {
+      const session = await api.createSession('New chat');
+      setSessions([session, ...sessions]);
+      setActiveSessionId(session.session_id);
+    } catch (error) {
+      console.error('Failed to create session:', error);
+      alert('Failed to create new chat. Please check your API key.');
+    }
+  };
+
+  const handleDeleteSession = async (sessionId: string) => {
+    try {
+      await api.deleteSession(sessionId);
+      setSessions(sessions.filter((s) => s.session_id !== sessionId));
+      if (activeSessionId === sessionId) {
+        setActiveSessionId(sessions[0]?.session_id || null);
+      }
+    } catch (error) {
+      console.error('Failed to delete session:', error);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="loading-screen">
+        <div className="spinner"></div>
+        <p>Loading...</p>
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return <Login onLogin={handleLogin} />;
+  }
+
+  return (
+    <div className="app">
+      <Sidebar
+        sessions={sessions}
+        activeSessionId={activeSessionId}
+        onSelectSession={setActiveSessionId}
+        onNewChat={handleNewChat}
+        onDeleteSession={handleDeleteSession}
+        onLogout={handleLogout}
+      />
+      <div className="main">
+        {activeSessionId ? (
+          <Chat sessionId={activeSessionId} />
+        ) : (
+          <div className="empty-state">
+            <h2>No active chat</h2>
+            <p>Create a new chat to get started</p>
+            <button onClick={handleNewChat}>New Chat</button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,0 +1,122 @@
+export interface Message {
+  role: string;
+  content: string;
+}
+
+export interface Session {
+  session_id: string;
+  user_id: string;
+  title: string;
+  model: string;
+  message_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ChatResponse {
+  id: string;
+  object: string;
+  created: number;
+  model: string;
+  choices: Array<{
+    index: number;
+    message: Message;
+    finish_reason: string;
+  }>;
+  usage: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+  };
+}
+
+class ApiClient {
+  private apiKey: string | null = null;
+  private baseUrl: string;
+
+  constructor(baseUrl: string = '/api') {
+    this.baseUrl = baseUrl;
+  }
+
+  setApiKey(key: string) {
+    this.apiKey = key;
+    localStorage.setItem('ollama_api_key', key);
+  }
+
+  getApiKey(): string | null {
+    if (!this.apiKey) {
+      this.apiKey = localStorage.getItem('ollama_api_key');
+    }
+    return this.apiKey;
+  }
+
+  clearApiKey() {
+    this.apiKey = null;
+    localStorage.removeItem('ollama_api_key');
+  }
+
+  private async request<T>(
+    endpoint: string,
+    options: RequestInit = {}
+  ): Promise<T> {
+    const apiKey = this.getApiKey();
+    if (!apiKey) {
+      throw new Error('API key not set');
+    }
+
+    const response = await fetch(`${this.baseUrl}${endpoint}`, {
+      ...options,
+      headers: {
+        'Authorization': `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+        ...options.headers,
+      },
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`API error: ${response.status} - ${error}`);
+    }
+
+    return response.json();
+  }
+
+  async health() {
+    const response = await fetch(`${this.baseUrl}/health`);
+    return response.json();
+  }
+
+  async createSession(title?: string, model: string = 'llama3.2:1b'): Promise<Session> {
+    return this.request<Session>('/sessions', {
+      method: 'POST',
+      body: JSON.stringify({ title, model }),
+    });
+  }
+
+  async listSessions(): Promise<Session[]> {
+    return this.request<Session[]>('/sessions');
+  }
+
+  async getSessionMessages(sessionId: string): Promise<{ session_id: string; messages: Message[] }> {
+    return this.request(`/sessions/${sessionId}/messages`);
+  }
+
+  async sendMessage(
+    sessionId: string,
+    message: string,
+    model?: string
+  ): Promise<ChatResponse> {
+    return this.request<ChatResponse>(`/sessions/${sessionId}/chat`, {
+      method: 'POST',
+      body: JSON.stringify({ message, model, stream: false }),
+    });
+  }
+
+  async deleteSession(sessionId: string): Promise<void> {
+    await this.request(`/sessions/${sessionId}`, {
+      method: 'DELETE',
+    });
+  }
+}
+
+export const api = new ApiClient();

--- a/frontend/src/components/Chat.css
+++ b/frontend/src/components/Chat.css
@@ -1,0 +1,82 @@
+.chat-container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: #1a1a1a;
+}
+
+.messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.message {
+  padding: 1rem;
+  border-radius: 8px;
+  max-width: 80%;
+}
+
+.message.user {
+  align-self: flex-end;
+  background: #1a73e8;
+  color: white;
+}
+
+.message.assistant {
+  align-self: flex-start;
+  background: #2a2a2a;
+  color: #e0e0e0;
+}
+
+.message-content {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  line-height: 1.5;
+}
+
+.message.loading {
+  opacity: 0.7;
+  font-style: italic;
+}
+
+.input-area {
+  display: flex;
+  gap: 1rem;
+  padding: 1rem 2rem;
+  background: #0f0f0f;
+  border-top: 1px solid #333;
+}
+
+.input-area input {
+  flex: 1;
+  padding: 0.75rem;
+  background: #2a2a2a;
+  border: 1px solid #444;
+  border-radius: 6px;
+  color: #e0e0e0;
+  font-size: 1rem;
+}
+
+.input-area input:focus {
+  outline: none;
+  border-color: #1a73e8;
+}
+
+.input-area button {
+  padding: 0.75rem 1.5rem;
+  background: #1a73e8;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.input-area button:disabled {
+  background: #555;
+  cursor: not-allowed;
+}

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -1,0 +1,72 @@
+import { useState, useEffect } from 'react';
+import { api, Message } from '../api';
+import './Chat.css';
+
+interface ChatProps {
+  sessionId: string;
+}
+
+function Chat({ sessionId }: ChatProps) {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    loadMessages();
+  }, [sessionId]);
+
+  const loadMessages = async () => {
+    try {
+      const data = await api.getSessionMessages(sessionId);
+      setMessages(data.messages);
+    } catch (error) {
+      console.error('Failed to load messages:', error);
+    }
+  };
+
+  const handleSend = async () => {
+    if (!input.trim() || isLoading) return;
+
+    const userMessage = input;
+    setInput('');
+    setIsLoading(true);
+
+    try {
+      await api.sendMessage(sessionId, userMessage);
+      await loadMessages();
+    } catch (error) {
+      console.error('Failed to send message:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="chat-container">
+      <div className="messages">
+        {messages.map((msg, idx) => (
+          <div key={idx} className={`message ${msg.role}`}>
+            <div className="message-content">{msg.content}</div>
+          </div>
+        ))}
+        {isLoading && <div className="message assistant loading">Thinking...</div>}
+      </div>
+
+      <div className="input-area">
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyPress={(e) => e.key === 'Enter' && handleSend()}
+          placeholder="Type a message..."
+          disabled={isLoading}
+        />
+        <button onClick={handleSend} disabled={isLoading || !input.trim()}>
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default Chat;

--- a/frontend/src/components/Login.css
+++ b/frontend/src/components/Login.css
@@ -1,0 +1,116 @@
+.login-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  width: 100%;
+  background: linear-gradient(135deg, #1a1a1a 0%, #0f0f0f 100%);
+}
+
+.login-box {
+  background: #1a1a1a;
+  border: 1px solid #333;
+  border-radius: 12px;
+  padding: 3rem;
+  width: 100%;
+  max-width: 400px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+}
+
+.login-box h1 {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
+  background: linear-gradient(135deg, #1a73e8 0%, #34a853 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.subtitle {
+  color: #999;
+  margin-bottom: 2rem;
+}
+
+.form-group {
+  margin-bottom: 1.5rem;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 0.5rem;
+  color: #ccc;
+  font-size: 0.9rem;
+}
+
+.form-group input {
+  width: 100%;
+  padding: 0.75rem;
+  background: #0f0f0f;
+  border: 1px solid #333;
+  border-radius: 6px;
+  color: #e0e0e0;
+  font-size: 1rem;
+}
+
+.form-group input:focus {
+  outline: none;
+  border-color: #1a73e8;
+}
+
+.error {
+  background: #3d1f1f;
+  border: 1px solid #ff4444;
+  color: #ff6666;
+  padding: 0.75rem;
+  border-radius: 6px;
+  margin-bottom: 1rem;
+  font-size: 0.9rem;
+}
+
+.login-button {
+  width: 100%;
+  padding: 0.875rem;
+  background: #1a73e8;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-size: 1rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.login-button:hover {
+  background: #1557b0;
+}
+
+.login-button:disabled {
+  background: #555;
+  cursor: not-allowed;
+}
+
+.info {
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid #333;
+  text-align: center;
+}
+
+.info p {
+  color: #666;
+  font-size: 0.85rem;
+}
+
+.link-button {
+  background: none;
+  border: none;
+  color: #1a73e8;
+  cursor: pointer;
+  text-decoration: underline;
+  font-size: 0.85rem;
+  padding: 0;
+}
+
+.link-button:hover {
+  color: #1557b0;
+}

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -1,0 +1,55 @@
+import { useState, FormEvent } from 'react';
+import './Login.css';
+
+interface LoginProps {
+  onLogin: (apiKey: string) => void;
+}
+
+function Login({ onLogin }: LoginProps) {
+  const [apiKey, setApiKey] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    if (!apiKey.trim()) {
+      setError('Please enter an API key');
+      return;
+    }
+    onLogin(apiKey);
+  };
+
+  return (
+    <div className="login-container">
+      <div className="login-box">
+        <h1>Ollama Gateway</h1>
+        <p className="subtitle">Enter your API key to continue</p>
+
+        <form onSubmit={handleSubmit}>
+          <div className="form-group">
+            <label htmlFor="apiKey">API Key</label>
+            <input
+              type="password"
+              id="apiKey"
+              value={apiKey}
+              onChange={(e) => setApiKey(e.target.value)}
+              placeholder="Enter your API key"
+              autoFocus
+            />
+          </div>
+
+          {error && <div className="error">{error}</div>}
+
+          <button type="submit" className="login-button">
+            Sign In
+          </button>
+        </form>
+
+        <div className="info">
+          <p>Don't have an API key? Contact your administrator.</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default Login;

--- a/frontend/src/components/Sidebar.css
+++ b/frontend/src/components/Sidebar.css
@@ -1,0 +1,107 @@
+.sidebar {
+  width: 260px;
+  background: #0f0f0f;
+  border-right: 1px solid #333;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.sidebar-header {
+  padding: 1.5rem 1rem;
+  border-bottom: 1px solid #333;
+}
+
+.sidebar-header h2 {
+  margin: 0 0 1rem 0;
+  font-size: 1.25rem;
+  color: #e0e0e0;
+}
+
+.new-chat-button {
+  width: 100%;
+  padding: 0.75rem;
+  background: #1a73e8;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.new-chat-button:hover {
+  background: #1557b0;
+}
+
+.sessions-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.5rem;
+}
+
+.session-item {
+  padding: 0.75rem;
+  margin-bottom: 0.25rem;
+  background: #1a1a1a;
+  border-radius: 6px;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  transition: background 0.2s;
+}
+
+.session-item:hover {
+  background: #2a2a2a;
+}
+
+.session-item.active {
+  background: #2a2a2a;
+  border-left: 3px solid #1a73e8;
+}
+
+.session-title {
+  flex: 1;
+  color: #e0e0e0;
+  font-size: 0.9rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.delete-button {
+  background: none;
+  border: none;
+  color: #666;
+  cursor: pointer;
+  font-size: 1.5rem;
+  padding: 0;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.delete-button:hover {
+  color: #ff4444;
+}
+
+.sidebar-footer {
+  padding: 1rem;
+  border-top: 1px solid #333;
+}
+
+.sidebar-footer .logout-button {
+  width: 100%;
+  padding: 0.75rem;
+  background: #444;
+  color: #e0e0e0;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.sidebar-footer .logout-button:hover {
+  background: #555;
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,0 +1,62 @@
+import { Session } from '../api';
+import './Sidebar.css';
+
+interface SidebarProps {
+  sessions: Session[];
+  activeSessionId: string | null;
+  onSelectSession: (sessionId: string) => void;
+  onNewChat: () => void;
+  onDeleteSession: (sessionId: string) => void;
+  onLogout: () => void;
+}
+
+function Sidebar({
+  sessions,
+  activeSessionId,
+  onSelectSession,
+  onNewChat,
+  onDeleteSession,
+  onLogout,
+}: SidebarProps) {
+  return (
+    <div className="sidebar">
+      <div className="sidebar-header">
+        <h2>Ollama Gateway</h2>
+        <button onClick={onNewChat} className="new-chat-button">
+          + New Chat
+        </button>
+      </div>
+
+      <div className="sessions-list">
+        {sessions.map((session) => (
+          <div
+            key={session.session_id}
+            className={`session-item ${
+              session.session_id === activeSessionId ? 'active' : ''
+            }`}
+            onClick={() => onSelectSession(session.session_id)}
+          >
+            <div className="session-title">{session.title}</div>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onDeleteSession(session.session_id);
+              }}
+              className="delete-button"
+            >
+              ×
+            </button>
+          </div>
+        ))}
+      </div>
+
+      <div className="sidebar-footer">
+        <button onClick={onLogout} className="logout-button">
+          Logout
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default Sidebar;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,20 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  background: #0f0f0f;
+  color: #e0e0e0;
+}
+
+code {
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+    monospace;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App.tsx'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+)

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: true,
+    port: 5173,
+  },
+})

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,40 @@
+upstream api_backend {
+    server api:8000;
+}
+
+upstream frontend {
+    server frontend:80;
+}
+
+server {
+    listen 80;
+    server_name _;
+
+    client_max_body_size 100m;
+
+    # Serve frontend
+    location / {
+        proxy_pass http://frontend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Proxy API requests
+    location /api/ {
+        rewrite ^/api/(.*)$ /$1 break;
+        proxy_pass http://api_backend;
+        proxy_http_version 1.1;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_buffering off;
+        proxy_read_timeout 300s;
+        proxy_send_timeout 300s;
+    }
+}


### PR DESCRIPTION
Implements a complete hosted AI API service on top of Ollama with:
- FastAPI gateway with API key authentication and OpenAI-compatible endpoints
- Redis-backed server-side session management for multi-user chat contexts
- React/TypeScript frontend UI for chat interactions
- Nginx reverse proxy for routing
- Docker Compose orchestration with CPU optimization settings
- Support for GPU deployment via docker-compose.gpu.yml
- Session CRUD endpoints and context injection middleware
- Format system prompt for better response formatting

Default model: qwen2.5:0.5b
Authentication: .env based API keys
Frontend: http://localhost:8080
API docs: http://localhost:8080/api/docs