### PR TITLE
launch: make --config truly config-only and refresh MiniMax M3 cloud defaults

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -2255,7 +2255,7 @@ func TestLoadOrUnloadModel_CloudModelAuth(t *testing.T) {
 		},
 		{
 			name:            "explicit :cloud model without local stub returns not found by default",
-			model:           "minimax-m2.7:cloud",
+			model:           "minimax-m3:cloud",
 			showStatus:      http.StatusNotFound,
 			whoamiStatus:    http.StatusOK,
 			whoamiResp:      api.UserResponse{Name: "testuser"},

--- a/cmd/launch/integrations_test.go
+++ b/cmd/launch/integrations_test.go
@@ -472,7 +472,7 @@ func TestBuildModelList_ExistingRecommendedMarked(t *testing.T) {
 			if !strings.HasSuffix(item.Description, "(not downloaded)") {
 				t.Errorf("non-installed recommended %q should have '(not downloaded)' suffix, got %q", item.Name, item.Description)
 			}
-		case "minimax-m2.7:cloud", "kimi-k2.6:cloud", "qwen3.5:cloud":
+		case "minimax-m3:cloud", "kimi-k2.6:cloud", "qwen3.5:cloud":
 			if strings.HasSuffix(item.Description, "(not downloaded)") {
 				t.Errorf("cloud model %q should not have '(not downloaded)' suffix, got %q", item.Name, item.Description)
 			}
@@ -685,7 +685,7 @@ func TestBuildModelList_RecsAboveNonRecs(t *testing.T) {
 	lastRecIdx := -1
 	firstNonRecIdx := len(got)
 	for i, name := range got {
-		isRec := name == "gemma4" || name == "qwen3.5" || name == "minimax-m2.7:cloud" || name == "glm-5.1:cloud" || name == "kimi-k2.6:cloud" || name == "qwen3.5:cloud"
+		isRec := name == "gemma4" || name == "qwen3.5" || name == "minimax-m3:cloud" || name == "glm-5.1:cloud" || name == "kimi-k2.6:cloud" || name == "qwen3.5:cloud"
 		if isRec && i > lastRecIdx {
 			lastRecIdx = i
 		}
@@ -718,7 +718,7 @@ func TestBuildModelList_StaleSavedKimiK25DoesNotReshuffleRecommendedOrder(t *tes
 		{Name: "kimi-k2.5:cloud", Remote: true},
 	}
 
-	items, _, _, _ := buildModelList(existing, []string{"kimi-k2.5:cloud", "qwen3.5:cloud", "glm-5.1:cloud", "minimax-m2.7:cloud"}, "kimi-k2.5:cloud")
+	items, _, _, _ := buildModelList(existing, []string{"kimi-k2.5:cloud", "qwen3.5:cloud", "glm-5.1:cloud", "minimax-m3:cloud"}, "kimi-k2.5:cloud")
 	got := names(items)
 
 	want := recommendedNames("kimi-k2.5:cloud")
@@ -1522,7 +1522,7 @@ func TestRecommendedModelsDoNotIncludeRequiredPlanStubs(t *testing.T) {
 	if item := byName["kimi-k2.6:cloud"]; item.RequiredPlan != "" {
 		t.Fatalf("kimi fallback required plan should not be stubbed: %#v", item)
 	}
-	if item := byName["minimax-m2.7:cloud"]; item.RequiredPlan != "" {
+	if item := byName["minimax-m3:cloud"]; item.RequiredPlan != "" {
 		t.Fatalf("minimax fallback required plan should not be stubbed: %#v", item)
 	}
 	if item := byName["qwen3.5:cloud"]; item.RequiredPlan != "" {

--- a/cmd/launch/launch.go
+++ b/cmd/launch/launch.go
@@ -1390,13 +1390,7 @@ func runIntegration(runner Runner, modelName string, models []LaunchModel, args 
 
 func launchAfterConfiguration(name string, runner Runner, model string, models []LaunchModel, req IntegrationLaunchRequest) error {
 	if req.ConfigureOnly {
-		launch, err := ConfirmPrompt(fmt.Sprintf("Launch %s now?", runner))
-		if err != nil {
-			return err
-		}
-		if !launch {
-			return nil
-		}
+		return nil
 	}
 	if err := EnsureIntegrationInstalled(name, runner); err != nil {
 		return err

--- a/cmd/launch/launch_test.go
+++ b/cmd/launch/launch_test.go
@@ -970,7 +970,7 @@ func TestLaunchIntegration_ManagedSingleIntegrationCanConfigureWithModelList(t *
 		t.Fatalf("LaunchIntegration returned error: %v", err)
 	}
 
-	if diff := compareStringSlices(runner.configuredModelLists, [][]string{{"gemma4", "kimi-k2.6:cloud", "qwen3.5:cloud", "glm-5.1:cloud", "minimax-m2.7:cloud", "qwen3.5", "qwen3:8b"}}); diff != "" {
+	if diff := compareStringSlices(runner.configuredModelLists, [][]string{{"gemma4", "kimi-k2.6:cloud", "qwen3.5:cloud", "glm-5.1:cloud", "minimax-m3:cloud", "qwen3.5", "qwen3:8b"}}); diff != "" {
 		t.Fatalf("configured model list mismatch (-want +got):\n%s", diff)
 	}
 	if diff := compareStrings(runner.configured, []string{"gemma4"}); diff != "" {
@@ -3032,15 +3032,6 @@ func TestLaunchIntegration_ConfigureOnlyDoesNotRequireInstalledBinary(t *testing
 		return []string{"llama3.2"}, nil
 	}
 
-	var prompts []string
-	DefaultConfirmPrompt = func(prompt string, options ConfirmOptions) (bool, error) {
-		prompts = append(prompts, prompt)
-		if strings.Contains(prompt, "Launch LauncherEditor now?") {
-			return false, nil
-		}
-		return true, nil
-	}
-
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/experimental/model-recommendations":
@@ -3068,9 +3059,6 @@ func TestLaunchIntegration_ConfigureOnlyDoesNotRequireInstalledBinary(t *testing
 	}
 	if editor.ranModel != "" {
 		t.Fatalf("expected configure-only flow to skip launch, got %q", editor.ranModel)
-	}
-	if !slices.Contains(prompts, "Launch LauncherEditor now?") {
-		t.Fatalf("expected configure-only launch prompt, got %v", prompts)
 	}
 }
 
@@ -3310,7 +3298,7 @@ func TestLaunchIntegration_ClaudeModelOverrideSkipsSelector(t *testing.T) {
 	}
 }
 
-func TestLaunchIntegration_ConfigureOnlyPrompt(t *testing.T) {
+func TestLaunchIntegration_ConfigureOnlyDoesNotPromptOrLaunch(t *testing.T) {
 	tmpDir := t.TempDir()
 	setLaunchTestHome(t, tmpDir)
 	withLauncherHooks(t)
@@ -3322,12 +3310,9 @@ func TestLaunchIntegration_ConfigureOnlyPrompt(t *testing.T) {
 		return "llama3.2", nil
 	}
 
-	var prompts []string
+	confirmCalled := false
 	DefaultConfirmPrompt = func(prompt string, options ConfirmOptions) (bool, error) {
-		prompts = append(prompts, prompt)
-		if strings.Contains(prompt, "Launch StubSingle now?") {
-			return false, nil
-		}
+		confirmCalled = true
 		return true, nil
 	}
 
@@ -3354,10 +3339,10 @@ func TestLaunchIntegration_ConfigureOnlyPrompt(t *testing.T) {
 		t.Fatalf("LaunchIntegration returned error: %v", err)
 	}
 	if runner.ranModel != "" {
-		t.Fatalf("expected configure-only flow to skip launch when prompt is declined, got %q", runner.ranModel)
+		t.Fatalf("expected configure-only flow to skip launch, got %q", runner.ranModel)
 	}
-	if !slices.Contains(prompts, "Launch StubSingle now?") {
-		t.Fatalf("expected launch confirmation prompt, got %v", prompts)
+	if confirmCalled {
+		t.Fatal("expected configure-only flow not to prompt for launch")
 	}
 }
 

--- a/cmd/launch/models.go
+++ b/cmd/launch/models.go
@@ -26,7 +26,7 @@ var recommendedModels = []ModelItem{
 	{Name: "kimi-k2.6:cloud", Description: "State-of-the-art coding, long-horizon execution, and multimodal agent swarm capability", Recommended: true, Details: api.ModelDetails{ContextLength: 262_144}, MaxOutputTokens: 262_144},
 	{Name: "qwen3.5:cloud", Description: "Reasoning, coding, and agentic tool use with vision", Recommended: true, Details: api.ModelDetails{ContextLength: 262_144}, MaxOutputTokens: 32_768},
 	{Name: "glm-5.1:cloud", Description: "Reasoning and code generation", Recommended: true, Details: api.ModelDetails{ContextLength: 202_752}, MaxOutputTokens: 131_072},
-	{Name: "minimax-m2.7:cloud", Description: "Fast, efficient coding and real-world productivity", Recommended: true, Details: api.ModelDetails{ContextLength: 204_800}, MaxOutputTokens: 128_000},
+	{Name: "minimax-m3:cloud", Description: "State-of-the-art coding & agent capabilities with multimodal reasoning and support for up to 1M context", Recommended: true, Details: api.ModelDetails{ContextLength: 524_288}, MaxOutputTokens: 131_072},
 	{Name: "gemma4", Description: "Reasoning and code generation locally", Recommended: true, VRAMBytes: 12 * format.GigaByte},
 	{Name: "qwen3.5", Description: "Reasoning, coding, and visual understanding locally", Recommended: true, VRAMBytes: 14 * format.GigaByte},
 }

--- a/cmd/launch/openclaw_test.go
+++ b/cmd/launch/openclaw_test.go
@@ -2349,7 +2349,7 @@ func TestOpenclawModelConfig(t *testing.T) {
 	})
 
 	t.Run("cloud model uses hardcoded limits", func(t *testing.T) {
-		cfg, isCloud := openclawModelConfig(fallbackLaunchModel("minimax-m2.7:cloud"))
+		cfg, isCloud := openclawModelConfig(fallbackLaunchModel("minimax-m3:cloud"))
 
 		if !isCloud {
 			t.Error("expected isCloud = true for cloud model")

--- a/docs/integrations/claude-code.mdx
+++ b/docs/integrations/claude-code.mdx
@@ -4,7 +4,7 @@ title: Claude Code
 
 Claude Code is Anthropic's agentic coding tool that can read, modify, and execute code in your working directory. 
 
-Open models can be used with Claude Code through Ollama's Anthropic-compatible API, enabling you to use models such as `qwen3.5`, `glm-5:cloud`, `kimi-k2.5:cloud`.
+Open models can be used with Claude Code through Ollama's Anthropic-compatible API, enabling you to use models such as `qwen3.5`, `glm-5.1:cloud`, `kimi-k2.6:cloud`, `minimax-m3:cloud`.
 
 ![Claude Code with Ollama](https://files.ollama.com/claude-code.png)
 
@@ -34,14 +34,14 @@ ollama launch claude
 
 ### Run directly with a model
 ```shell
-ollama launch claude --model kimi-k2.5:cloud
+ollama launch claude --model minimax-m3:cloud
 ```
 
 ## Recommended Models
 
-- `kimi-k2.5:cloud`
-- `glm-5:cloud`
-- `minimax-m2.7:cloud`
+- `kimi-k2.6:cloud`
+- `glm-5.1:cloud`
+- `minimax-m3:cloud`
 - `qwen3.5:cloud`
 - `glm-4.7-flash`
 - `qwen3.5`
@@ -133,4 +133,3 @@ ANTHROPIC_AUTH_TOKEN=ollama ANTHROPIC_BASE_URL=http://localhost:11434 ANTHROPIC_
 ```
 
 **Note:** Claude Code requires a large context window. We recommend at least 64k tokens. See the [context length documentation](/context-length) for how to adjust context length in Ollama.
-

--- a/docs/integrations/copilot-cli.mdx
+++ b/docs/integrations/copilot-cli.mdx
@@ -48,7 +48,7 @@ ollama launch copilot --model kimi-k2.5:cloud
 
 - `kimi-k2.5:cloud`
 - `glm-5:cloud`
-- `minimax-m2.7:cloud`
+- `minimax-m3:cloud`
 - `qwen3.5:cloud`
 - `glm-4.7-flash`
 - `qwen3.5`

--- a/docs/integrations/hermes.mdx
+++ b/docs/integrations/hermes.mdx
@@ -26,7 +26,7 @@ Ollama handles everything automatically:
 - `kimi-k2.5:cloud` — Multimodal reasoning with subagents
 - `glm-5.1:cloud` — Reasoning and code generation
 - `qwen3.5:cloud` — Reasoning, coding, and agentic tool use with vision
-- `minimax-m2.7:cloud` — Fast, efficient coding and real-world productivity
+- `minimax-m3:cloud` — State-of-the-art coding & agent capabilities with multimodal reasoning and support for up to 1M context
 
 **Local models:**
 

--- a/docs/integrations/openclaw.mdx
+++ b/docs/integrations/openclaw.mdx
@@ -61,7 +61,7 @@ If the gateway is already running, it restarts automatically to pick up the new 
 - `kimi-k2.5:cloud` — Multimodal reasoning with subagents
 - `qwen3.5:cloud` — Reasoning, coding, and agentic tool use with vision
 - `glm-5.1:cloud` — Reasoning and code generation
-- `minimax-m2.7:cloud` — Fast, efficient coding and real-world productivity
+- `minimax-m3:cloud` — State-of-the-art coding & agent capabilities with multimodal reasoning and support for up to 1M context
 
 **Local models:**
 

--- a/server/model_recommendations.go
+++ b/server/model_recommendations.go
@@ -384,10 +384,11 @@ var defaultModelRecommendations = []api.ModelRecommendation{
 		MaxOutputTokens: 32_768,
 	},
 	{
-		Model:           "minimax-m2.7:cloud",
-		Description:     "Fast, efficient coding and real-world productivity",
-		ContextLength:   204_800,
-		MaxOutputTokens: 128_000,
+		Model:           "minimax-m3:cloud",
+		Description:     "State-of-the-art coding & agent capabilities with multimodal reasoning and support for up to 1M context",
+		ContextLength:   524_288,
+		MaxOutputTokens: 131_072,
+		RequiredPlan:    "free",
 	},
 	{
 		Model:       "gemma4",

--- a/server/model_recommendations_test.go
+++ b/server/model_recommendations_test.go
@@ -27,7 +27,7 @@ func TestModelRecommendationsDefaultOrder(t *testing.T) {
 		"kimi-k2.6:cloud",
 		"glm-5.1:cloud",
 		"qwen3.5:cloud",
-		"minimax-m2.7:cloud",
+		"minimax-m3:cloud",
 		"gemma4",
 		"qwen3.5",
 	}
@@ -279,7 +279,7 @@ func TestValidateModelRecommendationsDoesNotSynthesizeRequiredPlans(t *testing.T
 		{Model: "kimi-k2.6:cloud", Description: "coding", ContextLength: 262_144, MaxOutputTokens: 262_144},
 		{Model: "qwen3.5:cloud", Description: "reasoning", ContextLength: 262_144, MaxOutputTokens: 32_768},
 		{Model: "custom:cloud", Description: "custom", ContextLength: 4096, MaxOutputTokens: 1024},
-		{Model: "minimax-m2.7:cloud", Description: "custom", ContextLength: 204_800, MaxOutputTokens: 128_000, RequiredPlan: "team"},
+		{Model: "minimax-m3:cloud", Description: "custom", ContextLength: 524_288, MaxOutputTokens: 131_072, RequiredPlan: "free"},
 	}
 
 	got, err := validateModelRecommendations(input)
@@ -301,7 +301,7 @@ func TestValidateModelRecommendationsDoesNotSynthesizeRequiredPlans(t *testing.T
 	if rec := byName["custom:cloud"]; rec.RequiredPlan != "" {
 		t.Fatalf("custom required plan should not be synthesized: %#v", rec)
 	}
-	if rec := byName["minimax-m2.7:cloud"]; rec.RequiredPlan != "team" {
+	if rec := byName["minimax-m3:cloud"]; rec.RequiredPlan != "free" {
 		t.Fatalf("explicit required plan should not be overwritten: %#v", rec)
 	}
 }


### PR DESCRIPTION
## Summary
- stop `ollama launch ... --config` from prompting to launch and then executing the integration
- refresh Claude/OpenClaw/Hermes/Copilot/launcher cloud defaults from `minimax-m2.7:cloud` to `minimax-m3:cloud`
- use the current `minimax-m3:cloud` recommendation metadata (`context_length=524288`, `max_output_tokens=131072`, `required_plan=free`)

## Why
`ollama launch claude --config --model ... --yes` currently reaches the launch path after configuration. In non-interactive contexts this still executes `claude`, which breaks the documented expectation that `--config` configures without launching.

Separately, Ollama Cloud now advertises `minimax-m3:cloud` as the Claude Code / Codex / OpenClaw / Hermes integration target, while the launcher defaults and integration docs still point to `minimax-m2.7:cloud`.

## Validation
- `go test ./cmd/launch -run 'TestLaunchIntegration_(ConfigureOnlyDoesNotRequireInstalledBinary|ConfigureOnlyDoesNotPromptOrLaunch|ClaudeSavesPrimaryModel|ClaudeForceConfigureReprompts)'`
- `go test ./cmd/launch ./server ./cmd -run 'Test(LaunchIntegration_(ConfigureOnlyDoesNotRequireInstalledBinary|ConfigureOnlyDoesNotPromptOrLaunch)|ValidateModelRecommendationsDoesNotSynthesizeRequiredPlans|RecommendedModelsDoNotIncludeRequiredPlanStubs|LaunchIntegration_ModelOverrideHeadlessMissingFailsWithoutPrompt|RunHandlerCloudModelAuthBehavior)'`

## Source of truth for MiniMax M3 values
Validated from a live Ollama server and the Ollama model page for `minimax-m3:cloud`, which currently reports:
- `context_length=524288`
- `max_output_tokens=131072`
- `required_plan=free`
