### PR TITLE
install.sh: detect AMD ROCm on WSL2 (ROCDXG) and enable it out of the box

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -290,7 +290,20 @@ if [ "$IS_WSL2" = true ]; then
         status "Nvidia GPU detected."
     elif [ "$ROCDXG" = true ]; then
         download_and_extract "https://ollama.com/download" "$OLLAMA_INSTALL_DIR" "ollama-linux-${ARCH}-rocm"
-        status "AMD GPU (WSL2 / ROCDXG) ready."
+        # The systemd unit only covers the service; a manual `ollama serve` needs
+        # HSA_ENABLE_DXG_DETECTION too, and profile.d reaches login shells even
+        # when systemd is disabled (common on WSL2). /etc/environment would not:
+        # without systemd there is no PAM login to apply it.
+        echo 'export HSA_ENABLE_DXG_DETECTION=1' | $SUDO tee /etc/profile.d/ollama-rocdxg.sh >/dev/null
+        case "${SYSTEMCTL_RUNNING:-}" in
+            running|degraded)
+                status "AMD GPU (WSL2 / ROCDXG) ready."
+                ;;
+            *)
+                status "AMD GPU (WSL2 / ROCDXG) detected, but the ollama service is not running."
+                status "Run 'export HSA_ENABLE_DXG_DETECTION=1' before 'ollama serve' (new login shells set this automatically)."
+                ;;
+        esac
     fi
     install_success
     exit 0

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -211,6 +211,15 @@ configure_systemd() {
     status "Adding current user to ollama group..."
     $SUDO usermod -a -G ollama $(whoami)
 
+    # WSL2 ROCDXG needs HSA_ENABLE_DXG_DETECTION=1 for the runtime to reach the
+    # GPU through /dev/dxg; add it to the service env only in that case (ROCDXG is
+    # detected below, before this function is called).
+    ROCDXG_ENV=""
+    if [ "$ROCDXG" = true ]; then
+        ROCDXG_ENV='
+Environment="HSA_ENABLE_DXG_DETECTION=1"'
+    fi
+
     status "Creating ollama systemd service..."
     cat <<EOF | $SUDO tee /etc/systemd/system/ollama.service >/dev/null
 [Unit]
@@ -223,7 +232,7 @@ User=ollama
 Group=ollama
 Restart=always
 RestartSec=3
-Environment="PATH=$PATH"
+Environment="PATH=$PATH"${ROCDXG_ENV}
 
 [Install]
 WantedBy=default.target
@@ -247,15 +256,41 @@ EOF
     esac
 }
 
+# rocminfo ships with ROCm (which ROCDXG requires) but isn't always on PATH — it
+# commonly lives in /opt/rocm/bin — so probe both. HSA_ENABLE_DXG_DETECTION=1 is
+# set here too, in case the runtime needs it to enumerate the device.
+rocdxg_rocminfo() {
+    if available rocminfo; then
+        HSA_ENABLE_DXG_DETECTION=1 rocminfo 2>/dev/null
+    elif [ -x /opt/rocm/bin/rocminfo ]; then
+        HSA_ENABLE_DXG_DETECTION=1 /opt/rocm/bin/rocminfo 2>/dev/null
+    else
+        return 1
+    fi
+}
+
+# WSL2 hides the GPU from the PCI bus, exposing it through DXCore at /dev/dxg
+# instead, so the lspci/lshw checks below miss it. AMD's ROCm-on-WSL (ROCDXG)
+# drives the GPU through /dev/dxg; rocminfo confirms an AMD GPU is reachable there
+# (a positive check, so it won't fire on an NVIDIA WSL2 box).
+ROCDXG=false
+if [ "$IS_WSL2" = true ] && [ -e /dev/dxg ] && rocdxg_rocminfo | grep -qE 'gfx[0-9]'; then
+    ROCDXG=true
+fi
+
 if available systemctl; then
     configure_systemd
 fi
 
-# WSL2 only supports GPUs via nvidia passthrough
-# so check for nvidia-smi to determine if GPU is available
+# WSL2 exposes the GPU through DXCore, not the PCI bus, so the lspci/lshw checks
+# below can't see it. NVIDIA works via nvidia-smi + the base bundle's CUDA
+# backend; AMD (ROCDXG) is reached through /dev/dxg, so install the ROCm backend.
 if [ "$IS_WSL2" = true ]; then
     if available nvidia-smi && [ -n "$(nvidia-smi | grep -o "CUDA Version: [0-9]*\.[0-9]*")" ]; then
         status "Nvidia GPU detected."
+    elif [ "$ROCDXG" = true ]; then
+        download_and_extract "https://ollama.com/download" "$OLLAMA_INSTALL_DIR" "ollama-linux-${ARCH}-rocm"
+        status "AMD GPU (WSL2 / ROCDXG) ready."
     fi
     install_success
     exit 0


### PR DESCRIPTION
Closes #16551

## Problem

On WSL2, AMD GPUs are exposed through Microsoft DXCore (`/dev/dxg`), not the PCI
bus, and `/dev/kfd` doesn't exist. The installer's AMD detection relies on
`lspci`/`lshw` (PCI vendor `1002`), which can't see the GPU in WSL2 — so AMD
users on WSL2 fall through to a **CPU-only install**, even though Ollama's ROCm
backend works there through AMD's ROCm-on-WSL (ROCDXG) path. Today the only way
to get GPU acceleration is to manually install the `-rocm` bundle and set
`HSA_ENABLE_DXG_DETECTION=1` on the service.

## Why it matters

[ROCDXG](https://github.com/ROCm/librocdxg) is [AMD's supported way to run ROCm inside WSL2](https://rocm.docs.amd.com/projects/radeon-ryzen/en/latest/docs/install/installrad/wsl/howto_wsl.html), and the hardware is
capable (e.g. an RX 7900 XTX runs models at full GPU offload). Right now
`install.sh` silently leaves that GPU unused for WSL2 AMD users — the same class
of gap that `scripts: add macOS support` (#14060) and Jetson support (#7632)
filled for their platforms.

## What this changes

When `IS_WSL2` is true and `/dev/dxg` exists, probe `rocminfo` (on `PATH`, or
`/opt/rocm/bin`) for an AMD `gfx` device — a *positive* AMD signal, so it won't
fire on an NVIDIA WSL2 box. When found:

- download the `ollama-linux-<arch>-rocm` bundle (same as the bare-metal AMD
  path), and
- add `Environment="HSA_ENABLE_DXG_DETECTION=1"` to the systemd unit (only in
  this case) [so the HSA runtime enumerates the GPU](https://github.com/ROCm/librocdxg#4-load-the-amd-rocdxg-libary) through `/dev/dxg`.

`rocminfo` ships with ROCm, which ROCDXG already requires, so it's a safe
prerequisite to lean on. The env var is added to the service only when ROCDXG is
detected; all other installs are unchanged.

## How it's tested

Validated on a Radeon RX 7900 XTX under WSL2 (Ubuntu, ROCm 7.2.x):

- **Before:** installer reports "No NVIDIA/AMD GPU detected" → CPU-only; the
  loaded model shows `100% CPU`.
- **After:** installer reports "AMD GPU (WSL2 / ROCDXG) ready", installs the rocm
  bundle, writes both `Environment=` lines, and Ollama loads at
  `library=ROCm compute=gfx1100`, `100% GPU`.

`sh -n` is clean, and the change is safe under the script's `set -eu` (the
`ROCDXG` flag is always initialized to `false`, and the `rocminfo` probe runs
inside an `if` condition).

## Draft documentation

A line in the Linux/GPU docs would help: "On WSL2 with an AMD GPU, install AMD's
ROCm-on-WSL (ROCDXG) runtime first; `install.sh` then detects it and installs
the ROCm backend automatically."

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


