### PR TITLE
llm: size-aware mmproj offload instead of blanket 10 GiB VRAM floor

### DIFF
--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -599,7 +599,13 @@ func appendMainGPUArgs(params []string, opts api.Options) []string {
 	return append(params, "--split-mode", "none", "--main-gpu", strconv.Itoa(*opts.MainGPU))
 }
 
-const limitedMMProjOffloadMemory = 10 << 30
+// mmprojOffloadHeadroom is extra free VRAM kept above the raw projector
+// size when deciding whether the multimodal projector fits on the GPU. (#16496)
+const mmprojOffloadHeadroom = 1 << 30 // 1 GiB
+
+// limitedMMProjOffloadFallback is the conservative free-VRAM floor used only
+// when the projector file size is unknown. (#16496)
+const limitedMMProjOffloadFallback = 2 << 30 // 2 GiB
 
 func appendMMProjArgs(params []string, launch llamaServerLaunchConfig) []string {
 	if len(launch.projectors) == 0 {
@@ -619,15 +625,30 @@ func (launch llamaServerLaunchConfig) mmprojOffloadDisabled() (bool, string) {
 	if launch.forceNoMMProjOffload {
 		return true, "startup-oom-retry"
 	}
-	return shouldDisableMMProjOffload(launch.opts, launch.gpus, launch.modelLayers)
+	var mmprojSize uint64
+	if len(launch.projectors) > 0 {
+		if fi, err := os.Stat(launch.projectors[0]); err == nil && fi.Size() > 0 {
+			mmprojSize = uint64(fi.Size())
+		}
+	}
+	return shouldDisableMMProjOffload(launch.opts, launch.gpus, launch.modelLayers, mmprojSize)
 }
 
-func shouldDisableMMProjOffload(opts api.Options, gpus []ml.DeviceInfo, modelLayers uint64) (bool, string) {
+func shouldDisableMMProjOffload(opts api.Options, gpus []ml.DeviceInfo, modelLayers, mmprojSize uint64) (bool, string) {
 	if opts.NumGPU == 0 {
 		return true, "cpu-only"
 	}
 	if opts.NumGPU > 0 && modelLayers > 0 && uint64(opts.NumGPU) < modelLayers {
 		return true, "partial-text-offload"
+	}
+
+	// Required free VRAM to keep the projector on the GPU. Compare against the
+	// actual projector size plus headroom instead of a blanket 10 GiB floor,
+	// which force-disabled offload on small discrete GPUs (e.g. 8 GB W7500) and
+	// regressed multimodal latency from ~3s to 5min+ since 0.24. (#16496)
+	required := uint64(limitedMMProjOffloadFallback)
+	if mmprojSize > 0 {
+		required = mmprojSize + mmprojOffloadHeadroom
 	}
 
 	for _, gpu := range gpus {
@@ -638,7 +659,7 @@ func shouldDisableMMProjOffload(opts api.Options, gpus []ml.DeviceInfo, modelLay
 		if memory == 0 || (gpu.TotalMemory > 0 && gpu.TotalMemory < memory) {
 			memory = gpu.TotalMemory
 		}
-		if memory > 0 && memory <= limitedMMProjOffloadMemory {
+		if memory > 0 && memory < required {
 			return true, "limited-vram"
 		}
 	}

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -1831,10 +1831,22 @@ func TestAppendMMProjArgs(t *testing.T) {
 			want:        []string{"base", "--mmproj", "model.gguf"},
 		},
 		{
-			name:        "small discrete gpu disables projector offload",
+			// #16496: an 8 GB discrete GPU must keep projector offload now that
+			// the decision is size-aware. The projector path here does not exist,
+			// so the size is unknown and the conservative 2 GiB fallback applies;
+			// 8 GiB clears it, so offload stays on.
+			name:        "small discrete gpu keeps projector offload for small projector",
 			projectors:  []string{"model.gguf"},
 			opts:        defaultOpts,
 			gpus:        []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}, TotalMemory: 8 << 30}},
+			modelLayers: 81,
+			want:        []string{"base", "--mmproj", "model.gguf"},
+		},
+		{
+			name:        "tiny discrete gpu disables projector offload",
+			projectors:  []string{"model.gguf"},
+			opts:        defaultOpts,
+			gpus:        []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}, TotalMemory: 1 << 30}},
 			modelLayers: 81,
 			want:        []string{"base", "--mmproj", "model.gguf", "--no-mmproj-offload"},
 		},
@@ -3021,4 +3033,35 @@ func fakeRunningCmd() *exec.Cmd {
 	// pass *testing.T here without changing all call sites. The OS will
 	// SIGKILL children when the test process exits.
 	return cmd
+}
+
+func TestShouldDisableMMProjOffload16496(t *testing.T) {
+	const gib = uint64(1) << 30
+	opts := api.DefaultOptions() // NumGPU = -1 (auto)
+	w7500 := []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "ROCm"}, FreeMemory: 7900 << 20, TotalMemory: 8 * gib}}
+	gemmaMMProj := uint64(933) << 20 // ~933 MiB Gemma3 mmproj
+
+	// Regression (#16496): the ~933 MiB projector fits in 7.9 GiB free VRAM on an
+	// 8 GB discrete W7500, so GPU offload must NOT be disabled. The pre-fix 10 GiB
+	// floor wrongly returned "limited-vram" here.
+	if disable, reason := shouldDisableMMProjOffload(opts, w7500, 0, gemmaMMProj); disable {
+		t.Fatalf("W7500 + 933MiB projector should keep GPU offload, got disabled (%q)", reason)
+	}
+
+	// Safety: a projector larger than free VRAM must still be CPU-offloaded.
+	if disable, reason := shouldDisableMMProjOffload(opts, w7500, 0, 9*gib); !disable || reason != "limited-vram" {
+		t.Fatalf("oversized projector must disable offload, got disable=%v reason=%q", disable, reason)
+	}
+
+	// Integrated/shared-memory GPU stays disabled regardless of projector size.
+	igpu := []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "ROCm"}, Integrated: true, FreeMemory: 32 * gib}}
+	if disable, reason := shouldDisableMMProjOffload(opts, igpu, 0, gemmaMMProj); !disable || reason != "shared-memory-gpu" {
+		t.Fatalf("integrated gpu must disable offload, got disable=%v reason=%q", disable, reason)
+	}
+
+	// Unknown projector size on tiny VRAM falls back to the conservative floor.
+	tiny := []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "ROCm"}, FreeMemory: 1 * gib, TotalMemory: 2 * gib}}
+	if disable, _ := shouldDisableMMProjOffload(opts, tiny, 0, 0); !disable {
+		t.Fatalf("tiny VRAM with unknown projector size should disable via fallback")
+	}
 }


### PR DESCRIPTION

### Summary
Make the multimodal-projector GPU-offload decision size-aware instead of using a
blanket 10 GiB VRAM floor, so small projectors keep running on the GPU on cards
with limited but sufficient VRAM.

### Problem
Fixes https://github.com/ollama/ollama/issues/16496 (regression since 0.30).
`shouldDisableMMProjOffload()` disables projector offload whenever a GPU reports
`<= 10 GiB` of memory, ignoring the projector's actual size. On an 8 GB discrete
GPU (Radeon Pro W7500, ~7.9 GiB free) the ~933 MiB Gemma3 CLIP projector fits
easily, but the flat floor appends `--no-mmproj-offload`, moving it to the CPU
and pushing multimodal inference from ~3-4 s to 5 min+. 0.24 had no such floor.

### Change
- Thread the projector's on-disk size (via `os.Stat`) into the decision.
- Disable offload only when free VRAM is below `mmprojSize + 1 GiB` headroom;
  when the size is unknown, fall back to a conservative 2 GiB floor.
- Integrated/UMA GPUs and genuinely-too-small cards still disable offload.
- Adds `TestShouldDisableMMProjOffload16496` and realigns the existing
  `TestAppendMMProjArgs` small-GPU expectation to the size-aware rule.

### Validation
Reproduced and verified on real AMD ROCm hardware:
- Hardware: Radeon RX 7900 XTX, gfx1100 (RDNA3, same family as the reporter's
  W7500) - ROCm 7.2 - source ollama v0.30.3
- `go test ./llm/` PASS - incl. `TestShouldDisableMMProjOffload16496`
  (8 GB / ~933 MiB projector keeps offload; oversized / integrated / tiny GPUs
  still disable) and the updated `TestAppendMMProjArgs`.
- `gofmt` clean, `go vet ./llm/` clean (go1.26.4).
- Before->after: stock logic returns `disable=true reason="limited-vram"` for the
  8 GB-free / 933 MiB-projector case; patched logic keeps the projector on GPU.

### Provenance
AI usage disclosure: this change was prepared with AI assistance; a human reviewed and verified it and can explain every line. (Reviewed by AMD engineers before submission.)
before submission.

