### PR TITLE
fs/ggml: add GraphSize estimates for gemma4 and qwen3/qwen3moe

### DIFF
--- a/fs/ggml/ggml.go
+++ b/fs/ggml/ggml.go
@@ -763,6 +763,70 @@ func (f GGML) GraphSize(context, batch uint64, numParallel int, kvCacheType stri
 				}
 			}
 		}
+	case "gemma4":
+		fullOffload = max(
+			4*batch*(embedding+vocab),
+			4*batch*(2+context+context*heads+2*embedding+2*embeddingHeadsK*heads),
+		)
+
+		partialOffload = max(
+			4*embedding*batch+embedding*vocab*105/128+4*vocab*batch,
+			4*batch*(2*embedding+1+2*embeddingHeadsK*heads+context+context*heads)+
+				4*embeddingHeadsK*context*8+
+				embedding*embeddingHeadsK*heads*9/16,
+		)
+
+		slidingWindow := (uint64(numParallel) * uint64(f.KV().Uint("attention.sliding_window"))) + batch
+		headKSWA := uint64(f.KV().Uint("attention.key_length_swa", uint32(f.KV().Uint("attention.key_length"))))
+		headVSWA := uint64(f.KV().Uint("attention.value_length_swa", uint32(headKSWA)))
+		pattern := f.KV().Bools("attention.sliding_window_pattern")
+		sharedKV := int(f.KV().Uint("attention.shared_kv_layers"))
+		nLayers := len(kv)
+		for i := range kv {
+			if sharedKV > 0 && i >= nLayers-sharedKV {
+				kv[i] = 0
+				continue
+			}
+
+			isSliding := true
+			if i < len(pattern) {
+				isSliding = pattern[i]
+			}
+
+			headsKVL := headsKVArr[i]
+			if headsKVL == 0 {
+				headsKVL = headsKV
+			}
+
+			if isSliding {
+				kv[i] = uint64(float64(slidingWindow*(headKSWA+headVSWA)*headsKVL) * bytesPerElement)
+			}
+		}
+
+		if useFlashAttention == ml.FlashAttentionEnabled && context > 32*1024 {
+			// Large-context prefill graph overhead (aligned with gpt-oss estimate).
+			partialOffload = max(
+				partialOffload,
+				(4*uint64(numParallel)+context>>10+110)*format.MebiByte,
+			)
+		}
+	case "qwen3", "qwen3moe":
+		fullOffload = max(
+			4*batch*(embedding+vocab),
+			4*batch*(1+2*embedding+context+context*heads),
+		)
+
+		partialOffload = max(
+			4*batch*(embedding+vocab)+embedding*vocab*105/128,
+			4*(batch*(1+2*embedding+context*(1+heads))+embedding*(1+context)),
+		)
+
+		if useFlashAttention == ml.FlashAttentionEnabled && context > 32*1024 {
+			partialOffload = max(
+				partialOffload,
+				(4*uint64(numParallel)+context>>10+110)*format.MebiByte,
+			)
+		}
 	case "command-r":
 		fullOffload = max(
 			4*batch*(embedding+vocab),

--- a/fs/ggml/ggml_test.go
+++ b/fs/ggml/ggml_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
+	"github.com/ollama/ollama/ml"
 )
 
 func TestTensorLayers(t *testing.T) {
@@ -299,3 +301,71 @@ func TestHeadCount(t *testing.T) {
 		}
 	}
 }
+
+func TestGraphSizeGemma4AndQwen3GraphOverhead(t *testing.T) {
+	const (
+		nLayers = 12
+		context = 262144
+		batch   = 512
+	)
+
+	mkKV := func(arch string) KV {
+		pattern := make([]bool, nLayers)
+		for i := range pattern {
+			pattern[i] = (i+1)%6 != 0
+		}
+		return KV{
+			"general.architecture":                     arch,
+			arch + ".block_count":                      uint32(nLayers),
+			arch + ".context_length":                   uint32(context),
+			arch + ".embedding_length":                 uint32(3840),
+			arch + ".attention.head_count":             uint32(16),
+			arch + ".attention.head_count_kv":          uint32(4),
+			arch + ".attention.key_length":             uint32(512),
+			arch + ".attention.key_length_swa":         uint32(256),
+			arch + ".attention.value_length":           uint32(512),
+			arch + ".attention.sliding_window":         uint32(1024),
+			arch + ".attention.sliding_window_pattern": &array[bool]{size: len(pattern), values: pattern},
+			"tokenizer.ggml.tokens":                    &array[string]{size: 1, values: []string{"a"}},
+		}
+	}
+
+	ts := []*Tensor{{Name: "blk.0.attn_k.weight", Shape: []uint64{1, 1}}}
+	fGemma := GGML{model: modelGGUF{kv: mkKV("gemma4"), tensors: Tensors{items: ts}}}
+	fQwen := GGML{model: modelGGUF{kv: mkKV("qwen3"), tensors: Tensors{items: ts}}}
+	fUnknown := GGML{model: modelGGUF{kv: mkKV("somearch"), tensors: Tensors{items: ts}}}
+
+	_, partialGemma, _ := fGemma.GraphSize(context, batch, 1, "", ml.FlashAttentionEnabled)
+	_, partialQwen, _ := fQwen.GraphSize(context, batch, 1, "", ml.FlashAttentionEnabled)
+	fQwenMoe := GGML{model: modelGGUF{kv: mkKV("qwen3moe"), tensors: Tensors{items: ts}}}
+
+	_, partialUnknown, _ := fUnknown.GraphSize(context, batch, 1, "", ml.FlashAttentionEnabled)
+	_, partialQwenMoe, _ := fQwenMoe.GraphSize(context, batch, 1, "", ml.FlashAttentionEnabled)
+
+	_, smallGemma, _ := fGemma.GraphSize(8192, batch, 1, "", ml.FlashAttentionEnabled)
+	_, smallQwen, _ := fQwen.GraphSize(8192, batch, 1, "", ml.FlashAttentionEnabled)
+
+	if partialGemma <= partialUnknown {
+		t.Fatalf("gemma4 partialOffload=%d should exceed default fallback %d", partialGemma, partialUnknown)
+	}
+	if partialQwen <= partialUnknown {
+		t.Fatalf("qwen3 partialOffload=%d should exceed default fallback %d", partialQwen, partialUnknown)
+	}
+	if partialQwenMoe <= partialUnknown {
+		t.Fatalf("qwen3moe partialOffload=%d should exceed default fallback %d", partialQwenMoe, partialUnknown)
+	}
+	if partialGemma <= smallGemma {
+		t.Fatalf("gemma4 partialOffload must grow with context: 256K=%d <= 8K=%d", partialGemma, smallGemma)
+	}
+	if partialQwen <= smallQwen {
+		t.Fatalf("qwen3 partialOffload must grow with context: 256K=%d <= 8K=%d", partialQwen, smallQwen)
+	}
+}
+
+type modelGGUF struct {
+	kv      KV
+	tensors Tensors
+}
+
+func (m modelGGUF) KV() KV           { return m.kv }
+func (m modelGGUF) Tensors() Tensors { return m.tensors }


### PR DESCRIPTION

`GraphSize` had no arch-specific case for `gemma4` or `qwen3`/`qwen3moe`, so they
fell back to the default estimate and under-counted graph overhead on long-context
(RAG) workloads — which can over-estimate free VRAM, offload too aggressively, and
OOM. This adds dedicated `fullOffload`/`partialOffload` estimates for these
architectures: gemma4 gets sliding-window KV accounting, and both get a
large-context (>32K, flash-attention) prefill-overhead floor aligned with the
existing gpt-oss estimate.

Adds a `fs/ggml` unit test asserting each arch's partialOffload exceeds the default
fallback and that the 256K-context estimate strictly exceeds the 8K-context one.

Validated on AMD ROCm (gfx1201, ROCm 7.2.1): `go test ./fs/ggml/` PASS, `gofmt`
and `go vet` clean.

Fixes #16310

---

*This is an experimental, AI-generated code change, reviewed by AMD engineers before submission.*
