### PR TITLE
fix: use structured logging in auth package

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -27,7 +27,7 @@ func GetPublicKey() (string, error) {
 	keyPath := filepath.Join(home, ".ollama", defaultPrivateKey)
 	privateKeyFile, err := os.ReadFile(keyPath)
 	if err != nil {
-		slog.Info(fmt.Sprintf("Failed to load private key: %v", err))
+		slog.Info("failed to load private key", "error", err)
 		return "", err
 	}
 
@@ -59,7 +59,7 @@ func Sign(ctx context.Context, bts []byte) (string, error) {
 	keyPath := filepath.Join(home, ".ollama", defaultPrivateKey)
 	privateKeyFile, err := os.ReadFile(keyPath)
 	if err != nil {
-		slog.Info(fmt.Sprintf("Failed to load private key: %v", err))
+		slog.Info("failed to load private key", "error", err)
 		return "", err
 	}
 


### PR DESCRIPTION
## Summary

Replace `slog.Info(fmt.Sprintf(...))` with proper structured logging using `slog.Info(msg, key, value)` pattern in `auth/auth.go`.

## Changes

- Replace two instances of `slog.Info(fmt.Sprintf("Failed to load private key: %v", err))` with `slog.Info("failed to load private key", "error", err)`
- Normalize log message casing to lowercase for consistency with Go conventions

## Why

Using `slog`'s structured key-value arguments instead of `fmt.Sprintf` is more idiomatic and enables:
- Better log parsing and filtering by structured fields
- Consistent log formatting across the codebase
- Potential performance benefits (avoids unnecessary string formatting when log level is disabled)