### PR TITLE
fix: use structured logging in updater package

### DIFF
--- a/app/updater/updater.go
+++ b/app/updater/updater.go
@@ -92,7 +92,7 @@ func (u *Updater) checkForUpdate(ctx context.Context) (bool, UpdateResponse) {
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL.String(), nil)
 	if err != nil {
-		slog.Warn(fmt.Sprintf("failed to check for update: %s", err))
+		slog.Warn("failed to check for update", "error", err)
 		return false, updateResp
 	}
 	if signature != "" {
@@ -104,7 +104,7 @@ func (u *Updater) checkForUpdate(ctx context.Context) (bool, UpdateResponse) {
 	slog.Debug("checking for available update", "requestURL", requestURL, "User-Agent", ua)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		slog.Warn(fmt.Sprintf("failed to check for update: %s", err))
+		slog.Warn("failed to check for update", "error", err)
 		return false, updateResp
 	}
 	defer resp.Body.Close()
@@ -115,16 +115,16 @@ func (u *Updater) checkForUpdate(ctx context.Context) (bool, UpdateResponse) {
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		slog.Warn(fmt.Sprintf("failed to read body response: %s", err))
+		slog.Warn("failed to read update check response body", "error", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		slog.Info(fmt.Sprintf("check update error %d - %.96s", resp.StatusCode, string(body)))
+		slog.Info("check update error", "status", resp.StatusCode, "body", string(body[:min(len(body), 96)]))
 		return false, updateResp
 	}
 	err = json.Unmarshal(body, &updateResp)
 	if err != nil {
-		slog.Warn(fmt.Sprintf("malformed response checking for update: %s", err))
+		slog.Warn("malformed response checking for update", "error", err)
 		return false, updateResp
 	}
 	// Extract the version string from the URL in the github release artifact path
@@ -304,15 +304,15 @@ func cleanupOldDownloads(stageDir string) {
 		// Expected behavior on first run
 		return
 	} else if err != nil {
-		slog.Warn(fmt.Sprintf("failed to list stage dir: %s", err))
+		slog.Warn("failed to list stage dir", "error", err)
 		return
 	}
 	for _, file := range files {
 		fullname := filepath.Join(stageDir, file.Name())
-		slog.Debug("cleaning up old download: " + fullname)
+		slog.Debug("cleaning up old download", "path", fullname)
 		err = os.RemoveAll(fullname)
 		if err != nil {
-			slog.Warn(fmt.Sprintf("failed to cleanup stale update download %s", err))
+			slog.Warn("failed to cleanup stale update download", "error", err)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Replace `slog.X(fmt.Sprintf(...))` and string concatenation patterns with proper structured logging using `slog.X(msg, key, value)` in `app/updater/updater.go`.

## Changes

- Replace 5 instances of `slog.Warn(fmt.Sprintf(...))` with `slog.Warn(msg, "error", err)`
- Replace 1 instance of `slog.Info(fmt.Sprintf(...))` with `slog.Info(msg, key, value)`
- Replace string concatenation in `slog.Debug("cleaning up old download: " + fullname)` with `slog.Debug("cleaning up old download", "path", fullname)`

## Why

Using `slog`'s structured key-value arguments instead of `fmt.Sprintf` is more idiomatic and enables:
- Better log parsing and filtering by structured fields
- Consistent log formatting across the codebase
- Potential performance benefits (avoids unnecessary string formatting when log level is disabled)