### PR TITLE
docs: fix grammar in logrotate package comment

### DIFF
--- a/app/logrotate/logrotate.go
+++ b/app/logrotate/logrotate.go
@@ -1,7 +1,7 @@
 //go:build windows || darwin
 
 // package logrotate provides utilities for rotating logs
-// TODO (jmorgan): this most likely doesn't need it's own
+// TODO (jmorgan): this most likely doesn't need its own
 // package and can be moved to app where log files are created
 package logrotate
 


### PR DESCRIPTION
## Summary

Fix a grammar error in the `app/logrotate/logrotate.go` package comment.

## Change

- Fix `"it's own"` to `"its own"` in the TODO comment on line 4

## Why

"Its" is the possessive form (belonging to it), while "it's" is a contraction of "it is". The comment is saying the package doesn't need its own separate existence, so the possessive form is correct.