### PR TITLE
fix: use structured logging in app startup

### DIFF
--- a/app/cmd/app/app.go
+++ b/app/cmd/app/app.go
@@ -109,7 +109,7 @@ func main() {
 	logrotate.Rotate(appLogPath)
 	if _, err := os.Stat(filepath.Dir(appLogPath)); errors.Is(err, os.ErrNotExist) {
 		if err := os.MkdirAll(filepath.Dir(appLogPath), 0o755); err != nil {
-			slog.Error(fmt.Sprintf("failed to create server log dir %v", err))
+			slog.Error("failed to create server log dir", "error", err)
 			return
 		}
 	}
@@ -118,7 +118,7 @@ func main() {
 	var err error
 	logFile, err = os.OpenFile(appLogPath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0o755)
 	if err != nil {
-		slog.Error(fmt.Sprintf("failed to create server log %v", err))
+		slog.Error("failed to create server log", "error", err)
 		return
 	}
 	// Detect if we're a GUI app on windows, and if not, send logs to console as well


### PR DESCRIPTION
## Summary

Replace `slog.Error(fmt.Sprintf(...))` with proper structured logging using `slog.Error(msg, key, value)` in `app/cmd/app/app.go`.

## Changes

- Replace `slog.Error(fmt.Sprintf("failed to create server log dir %v", err))` with `slog.Error("failed to create server log dir", "error", err)`
- Replace `slog.Error(fmt.Sprintf("failed to create server log %v", err))` with `slog.Error("failed to create server log", "error", err)`

## Why

Using `slog`'s structured key-value arguments instead of `fmt.Sprintf` is more idiomatic and enables:
- Better log parsing and filtering by structured fields
- Consistent log formatting across the codebase
- Potential performance benefits (avoids unnecessary string formatting when log level is disabled)