### PR TITLE
app/store: overwrite deleted chat data in SQLite Fixes #16544

### DIFF
--- a/app/store/database.go
+++ b/app/store/database.go
@@ -28,7 +28,7 @@ type database struct {
 
 func newDatabase(dbPath string) (*database, error) {
 	// Open database connection
-	conn, err := sql.Open("sqlite3", dbPath+"?_foreign_keys=on&_journal_mode=WAL&_busy_timeout=5000&_txlock=immediate")
+	conn, err := sql.Open("sqlite3", dbPath+"?_foreign_keys=on&_journal_mode=WAL&_busy_timeout=5000&_txlock=immediate&_secure_delete=on")
 	if err != nil {
 		return nil, fmt.Errorf("open database: %w", err)
 	}
@@ -764,7 +764,13 @@ func (db *database) deleteChat(id string) error {
 		return fmt.Errorf("delete chat: %w", err)
 	}
 
+	// Checkpoint the WAL so deleted pages are moved back into the main database
+	// file, then VACUUM to reclaim and zero-fill those freed pages. Together with
+	// the _secure_delete=on connection option (which overwrites deleted content
+	// with zeros at the SQLite level), this ensures that chat data is not
+	// recoverable from the database file after deletion. See: #16544
 	_, _ = db.conn.Exec("PRAGMA wal_checkpoint(TRUNCATE);")
+	_, _ = db.conn.Exec("VACUUM;")
 
 	return nil
 }


### PR DESCRIPTION
Deleted chats were recoverable by opening the SQLite database file with any DB browser because SQLite's default behavior only marks pages free rather than zeroing them. 
Fix by:1. Enabling _secure_delete=on in the connection DSN so every DELETE overwrites content with zeros before freeing pages. 2. Running VACUUM after deleteChat() so freed pages are reclaimed and the database file is compacted, leaving no ghost rows.