### PR TITLE
fix: auto-disable thinking for audio inputs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -335,6 +335,24 @@ curl http://localhost:11434/api/generate -d '{
 }
 ```
 
+#### Request (Audio Input)
+
+For models with audio support (e.g. `gemma4:e4b`, `gemma4:12b`), audio files can be passed via the `images` field as base64-encoded WAV or MP3 data. The audio format is auto-detected from file headers.
+
+> **Note:** Thinking mode is automatically disabled for audio inputs, since internal reasoning can consume the token budget and produce empty responses.
+
+```shell
+# Base64-encode a WAV file:
+# AUDIO_BASE64=$(base64 -w0 audio.wav)
+
+curl http://localhost:11434/api/generate -d '{
+  "model": "gemma4:12b",
+  "prompt": "Transcribe this audio exactly.",
+  "stream": false,
+  "images": ["<base64-encoded-wav>"]
+}'
+```
+
 #### Request (Raw Mode)
 
 In some cases, you may wish to bypass the templating system and provide a full prompt. In this case, you can use the `raw` parameter to disable templating. Also note that raw mode will not return a context.
@@ -1003,6 +1021,27 @@ curl http://localhost:11434/api/chat -d '{
   "eval_count": 83,
   "eval_duration": 1303285000
 }
+```
+
+#### Chat request (with audio)
+
+##### Request
+
+Send a chat message with audio input. For models with audio support (e.g. `gemma4:e4b`, `gemma4:12b`), audio files can be passed via the `images` field as base64-encoded WAV or MP3 data. The audio format is auto-detected from file headers.
+
+> **Note:** Thinking mode is automatically disabled for audio inputs, since internal reasoning can consume the token budget and produce empty responses. To override this, explicitly set `"think": true`.
+
+```shell
+curl http://localhost:11434/api/chat -d '{
+  "model": "gemma4:12b",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Transcribe this audio exactly.",
+      "images": ["<base64-encoded-wav>"]
+    }
+  ]
+}'
 ```
 
 #### Chat request (Reproducible outputs)

--- a/server/routes.go
+++ b/server/routes.go
@@ -466,7 +466,12 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 	if slices.Contains(modelCaps, model.CapabilityThinking) {
 		caps = append(caps, model.CapabilityThinking)
 		if req.Think == nil {
-			req.Think = &api.ThinkValue{Value: true}
+			// Auto-disable thinking for audio inputs (see ChatHandler).
+			if imagesContainAudio(req.Images) {
+				req.Think = &api.ThinkValue{Value: false}
+			} else {
+				req.Think = &api.ThinkValue{Value: true}
+			}
 		}
 	} else {
 		if req.Think != nil && req.Think.Bool() {
@@ -2598,7 +2603,16 @@ func (s *Server) ChatHandler(c *gin.Context) {
 	if slices.Contains(modelCaps, model.CapabilityThinking) {
 		caps = append(caps, model.CapabilityThinking)
 		if req.Think == nil {
-			req.Think = &api.ThinkValue{Value: true}
+			// Auto-disable thinking when the request contains audio data.
+			// Thinking mode consumes the num_predict token budget with
+			// internal reasoning, often leaving no tokens for the actual
+			// response. Audio inputs (speech transcription, voice commands)
+			// need direct answers rather than chain-of-thought reasoning.
+			if messagesContainAudio(req.Messages) {
+				req.Think = &api.ThinkValue{Value: false}
+			} else {
+				req.Think = &api.ThinkValue{Value: true}
+			}
 		}
 	} else {
 		if req.Think != nil && req.Think.Bool() {
@@ -3235,4 +3249,26 @@ func (s *Server) handleImageGenerate(c *gin.Context, req api.GenerateRequest, mo
 	if !isStreaming {
 		c.JSON(http.StatusOK, finalResponse)
 	}
+}
+
+// messagesContainAudio reports whether any message in msgs carries audio data
+// (e.g. a WAV file) in its Images field. Audio files are detected by checking
+// for WAV/MP3 magic bytes using [llm.AudioFormat].
+func messagesContainAudio(msgs []api.Message) bool {
+	for _, msg := range msgs {
+		if imagesContainAudio(msg.Images) {
+			return true
+		}
+	}
+	return false
+}
+
+// imagesContainAudio reports whether any entry in images is an audio file.
+func imagesContainAudio(images []api.ImageData) bool {
+	for _, img := range images {
+		if _, ok := llm.AudioFormat(img); ok {
+			return true
+		}
+	}
+	return false
 }

--- a/server/routes_audio_test.go
+++ b/server/routes_audio_test.go
@@ -1,0 +1,131 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/ollama/ollama/api"
+)
+
+func TestMessagesContainAudio(t *testing.T) {
+	// Valid WAV header: "RIFF" + 4 bytes size + "WAVE"
+	wavData := append([]byte("RIFF"), 0, 0, 0, 0)
+	wavData = append(wavData, []byte("WAVE")...)
+	wavData = append(wavData, make([]byte, 20)...) // padding
+
+	// Valid MP3 header (ID3 tag)
+	mp3Data := append([]byte("ID3"), make([]byte, 20)...)
+
+	// PNG image data (not audio)
+	pngData := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
+	pngData = append(pngData, make([]byte, 20)...)
+
+	tests := []struct {
+		name     string
+		messages []api.Message
+		want     bool
+	}{
+		{
+			name:     "no messages",
+			messages: nil,
+			want:     false,
+		},
+		{
+			name: "text only",
+			messages: []api.Message{
+				{Role: "user", Content: "Hello"},
+			},
+			want: false,
+		},
+		{
+			name: "image only",
+			messages: []api.Message{
+				{Role: "user", Content: "Describe this.", Images: []api.ImageData{pngData}},
+			},
+			want: false,
+		},
+		{
+			name: "wav audio",
+			messages: []api.Message{
+				{Role: "user", Content: "Transcribe this.", Images: []api.ImageData{wavData}},
+			},
+			want: true,
+		},
+		{
+			name: "mp3 audio",
+			messages: []api.Message{
+				{Role: "user", Content: "Transcribe this.", Images: []api.ImageData{mp3Data}},
+			},
+			want: true,
+		},
+		{
+			name: "mixed image and audio",
+			messages: []api.Message{
+				{Role: "user", Content: "Describe this.", Images: []api.ImageData{pngData, wavData}},
+			},
+			want: true,
+		},
+		{
+			name: "audio in earlier message",
+			messages: []api.Message{
+				{Role: "system", Content: "You are a transcription assistant."},
+				{Role: "user", Content: "First clip.", Images: []api.ImageData{wavData}},
+				{Role: "user", Content: "Now explain it."},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := messagesContainAudio(tt.messages)
+			if got != tt.want {
+				t.Errorf("messagesContainAudio() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestImagesContainAudio(t *testing.T) {
+	wavData := append([]byte("RIFF"), 0, 0, 0, 0)
+	wavData = append(wavData, []byte("WAVE")...)
+	wavData = append(wavData, make([]byte, 20)...)
+
+	pngData := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
+	pngData = append(pngData, make([]byte, 20)...)
+
+	tests := []struct {
+		name   string
+		images []api.ImageData
+		want   bool
+	}{
+		{
+			name:   "nil images",
+			images: nil,
+			want:   false,
+		},
+		{
+			name:   "empty images",
+			images: []api.ImageData{},
+			want:   false,
+		},
+		{
+			name:   "only images",
+			images: []api.ImageData{pngData},
+			want:   false,
+		},
+		{
+			name:   "wav file",
+			images: []api.ImageData{wavData},
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := imagesContainAudio(tt.images)
+			if got != tt.want {
+				t.Errorf("imagesContainAudio() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Auto-disable thinking mode when a chat or generate request contains audio data (WAV/MP3 detected via magic bytes in the `images` field)
- Add audio input documentation to the API docs, since audio support via the `images` field is currently undocumented

## Problem

When using Gemma 4 models (E4B, 12B) with audio input, thinking mode consumes the entire `num_predict` token budget with internal chain-of-thought reasoning, leaving zero tokens for the actual response. Users get empty `content` fields with all tokens spent in `thinking`.

This affects all thinking-capable models that also support audio, since Ollama defaults `think: true` when the user doesn't specify it (lines 468-469 and 2600-2601 in `routes.go`).

## Fix

In both `GenerateHandler` and `ChatHandler`, when `req.Think == nil` (user didn't specify), check if the request contains audio data. If so, default to `think: false` instead of `think: true`. Users can still explicitly set `"think": true` to override.

Audio detection reuses the existing `llm.AudioFormat()` function which checks WAV/MP3 magic bytes.

## Test plan

- [x] `go vet -tags nometal ./server/` passes
- [x] Unit tests for `messagesContainAudio` and `imagesContainAudio` helpers
- [x] Manual testing: `gemma4:12b` with WAV audio input produces correct transcriptions without needing to set `think: false`
- [x] Manual testing: `gemma4:e4b` audio input no longer produces empty responses
- [ ] CI tests (pending — `go test ./server/` fails on Windows due to unrelated MLX/imagegen deps)

Fixes #16583
Related: #16584

🤖 Generated with [Claude Code](https://claude.com/claude-code)