### PR TITLE
docs: added tz-ollama-utils a desktop Ollama model manager utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ console.log(response.message.content);
 - [Kerlig AI](https://www.kerlig.com/) - AI writing assistant for macOS
 - [Hillnote](https://hillnote.com) - Markdown-first AI workspace
 - [Perfect Memory AI](https://www.perfectmemory.ai/) - Productivity AI personalized by screen and meeting history
+- [tz-ollama-utils](https://github.com/taggedzi/tz-ollama-utils) - Utility for managing, updating, testing, and searching local Ollama models
 
 #### Mobile
 


### PR DESCRIPTION
Adds a community utility to the Desktop section of the public README.md

The tool helps users manage, update, test, and search local Ollama models.