### PR TITLE
parser: quote Modelfile values that begin with a double quote

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -634,7 +634,7 @@ func parseRuneForState(r rune, cs state) (state, rune, error) {
 }
 
 func quote(s string) string {
-	if strings.Contains(s, "\n") || strings.HasPrefix(s, " ") || strings.HasSuffix(s, " ") {
+	if strings.Contains(s, "\n") || strings.HasPrefix(s, " ") || strings.HasSuffix(s, " ") || strings.HasPrefix(s, `"`) {
 		if strings.Contains(s, "\"") {
 			return `"""` + s + `"""`
 		}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -686,6 +686,11 @@ MESSAGE assistant Hello, I want to parse all the things!
 FROM foo
 SYSTEM ""
 `,
+		`
+FROM foo
+SYSTEM """"Always cite your sources" is the first rule."""
+TEMPLATE """"{{ .Prompt }}" goes here."""
+`,
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
A Modelfile doesn't survive a parse → `String()` → parse round-trip when a `SYSTEM`/`TEMPLATE`/`LICENSE`/etc. value *begins* with a double quote. `quote()` only quotes values that contain a newline or have leading/trailing spaces, so a value like `"Always cite your sources" is the first rule.` is written back out unquoted. On the next parse the leading `"` is treated as the start of a quoted string, which then fails with `unexpected EOF` (or silently truncates the value).

This matters wherever a Modelfile is re-serialized and re-read — e.g. `ollama show` followed by recreating the model would corrupt such a value.

The fix: treat a leading double quote as a reason to quote, so the value is wrapped (`"""..."""`, since it contains a quote) and re-parses to the original.

I found this by fuzzing parse → `String()` → parse and minimized it to the leading-quote case. I added the case to the existing `TestParseFileFormatParseFile` round-trip test; it fails before the change (`unexpected EOF`) and passes after. Full `parser` suite, `gofmt`, and `go vet` are clean.
