### PR TITLE
Add path for machine scope Visual Studio Code

### DIFF
--- a/cmd/launch/vscode.go
+++ b/cmd/launch/vscode.go
@@ -34,9 +34,11 @@ func (v *VSCode) findBinary() string {
 			"/Applications/Visual Studio Code.app",
 		}
 	case "windows":
-		candidates = []string{
-			"C:\\Program Files\\Microsoft VS Code\\bin\\code.cmd",
-			"C:\\Program Files (x86)\\Microsoft VS Code\\bin\\code.cmd",
+		if programFiles := os.Getenv("ProgramFiles"); programFiles != "" {
+			candidates = append(candidates, filepath.Join(programFiles, "Microsoft VS Code", "bin", "code.cmd"))
+		}
+		if programFilesX86 := os.Getenv("ProgramFiles(x86)"); programFilesX86 != "" {
+			candidates = append(candidates, filepath.Join(programFilesX86, "Microsoft VS Code", "bin", "code.cmd"))
 		}
 		if localAppData := os.Getenv("LOCALAPPDATA"); localAppData != "" {
 			candidates = append(candidates, filepath.Join(localAppData, "Programs", "Microsoft VS Code", "bin", "code.cmd"))

--- a/cmd/launch/vscode.go
+++ b/cmd/launch/vscode.go
@@ -34,6 +34,10 @@ func (v *VSCode) findBinary() string {
 			"/Applications/Visual Studio Code.app",
 		}
 	case "windows":
+		candidates = []string{
+			"C:\\Program Files\\Microsoft VS Code\\bin\\code.cmd",
+			"C:\\Program Files (x86)\\Microsoft VS Code\\bin\\code.cmd",
+		}
 		if localAppData := os.Getenv("LOCALAPPDATA"); localAppData != "" {
 			candidates = append(candidates, filepath.Join(localAppData, "Programs", "Microsoft VS Code", "bin", "code.cmd"))
 		}


### PR DESCRIPTION
Added `C:\Program Files\Microsoft VS Code` & `C:\Program Files (x86)\Microsoft VS Code` path to properly handle VS Code installed in machine scope (or system install, or whatever you wanna call it)


Just a simple change... I'd consider doing it in some other way like checking the `PATH` variable and invoking it from there (for everything in `ollama launch`)...

I'll probably create a better one (the one with using `PATH` for custom install paths, etc.), but RN I need this to work.

