### PR TITLE
perf: improve profiling support

### DIFF
--- a/cmd/bench/bench.go
+++ b/cmd/bench/bench.go
@@ -3,6 +3,7 @@ package main
 import (
 	"cmp"
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -33,6 +34,20 @@ type flagOptions struct {
 	warmup       *int
 	promptTokens *int
 	numCtx       *int
+
+	// Target selection. When -runner is empty and -spawn is false, bench drives
+	// the full ollama server via the public API (legacy default). When -runner
+	// is set, bench probes it and auto-detects whether it is an MLX runner or a
+	// llama-server.
+	runner *string // host:port of a runner (MLX or llama-server) to drive directly
+
+	// MLX-runner spawn options (only when -runner is empty).
+	spawn     *bool
+	ollamaBin *string
+
+	// Profiling controls.
+	mode      *string // prefill | decode | both
+	ignoreEOS *bool   // disable stop tokens so generation runs exactly maxTokens
 }
 
 type Metrics struct {
@@ -50,6 +65,55 @@ type ModelInfo struct {
 	SizeBytes         int64
 	VRAMBytes         int64
 	NumCtx            int64
+}
+
+// Benchmark modes. prefill and decode produce single-phase workloads for clean
+// profiler capture windows; both is the legacy mixed run.
+const (
+	modePrefill = "prefill"
+	modeDecode  = "decode"
+	modeBoth    = "both"
+)
+
+// completionParams is the backend-agnostic description of one completion call.
+type completionParams struct {
+	prompt      string
+	numPredict  int // 0 = prefill-only
+	temperature float64
+	seed        int
+	numCtx      int
+	ignoreEOS   bool
+	image       api.ImageData
+	debug       bool
+}
+
+// completionResult carries the timing data every backend reports. Fields a
+// backend cannot supply are left zero.
+type completionResult struct {
+	promptEvalCount    int
+	promptEvalDuration time.Duration
+	evalCount          int
+	evalDuration       time.Duration
+	ttft               time.Duration
+	loadDuration       time.Duration
+	totalDuration      time.Duration
+}
+
+// errNoMetrics signals that a completion finished without delivering a final
+// (Done) metrics record, so its timings are unusable.
+var errNoMetrics = errors.New("no metrics received")
+
+// benchBackend abstracts the thing under test: the full ollama server, an MLX
+// runner driven directly, or a llama-server driven directly.
+type benchBackend interface {
+	// Name identifies the backend for logging.
+	Name() string
+	// ModelInfo returns best-effort display metadata.
+	ModelInfo(ctx context.Context, fOpt flagOptions) ModelInfo
+	// Complete runs one completion and returns its timing metrics.
+	Complete(ctx context.Context, p completionParams) (completionResult, error)
+	// Cleanup tears the backend down (unload model, kill spawned subprocess).
+	Cleanup(timeout int)
 }
 
 const DefaultPrompt = `Please write a descriptive story about a llama named Alonso who grows up to be President of the Land of Llamas. Include details about Alonso's childhood, adolescent years, and how he grew up to be a political mover and shaker. Write the story with a sense of whimsy.`
@@ -97,46 +161,61 @@ func calibratePromptTokens(targetTokens, actualTokens, wordCount int) {
 		tokensPerWord, targetTokens, actualTokens, wordCount, newWords)
 }
 
-func buildGenerateRequest(model string, fOpt flagOptions, imgData api.ImageData, epoch int) *api.GenerateRequest {
-	options := make(map[string]interface{})
-	if *fOpt.maxTokens > 0 {
-		options["num_predict"] = *fOpt.maxTokens
-	}
-	options["temperature"] = *fOpt.temperature
-	if fOpt.seed != nil && *fOpt.seed > 0 {
-		options["seed"] = *fOpt.seed
-	}
-	if fOpt.numCtx != nil && *fOpt.numCtx > 0 {
-		options["num_ctx"] = *fOpt.numCtx
+// buildParams derives the completion parameters for one epoch, shaping the
+// prompt, num_predict, and ignore_eos according to the benchmark mode:
+//
+//   - prefill: vary the prompt per epoch (force a cache miss) and request
+//     num_predict 0 so only the prompt is processed.
+//   - decode: hold the prompt fixed across epochs so the runner's prefix cache
+//     hits and the measured window is pure decode.
+//   - both: legacy mixed run, prompt varied per epoch.
+//
+// numPredict convention: -1 = generate to the context limit, 0 = prefill-only,
+// N>0 = exactly N tokens.
+func buildParams(fOpt flagOptions, mode string, imgData api.ImageData, epoch int) completionParams {
+	// decode mode keeps the prompt identical so the KV prefix cache hits;
+	// prefill/both vary it per epoch to defeat the cache.
+	promptEpoch := epoch
+	if mode == modeDecode {
+		promptEpoch = 0
 	}
 
-	var keepAliveDuration *api.Duration
-	if *fOpt.keepAlive > 0 {
-		duration := api.Duration{Duration: time.Duration(*fOpt.keepAlive * float64(time.Second))}
-		keepAliveDuration = &duration
-	}
-
-	prompt := *fOpt.prompt
+	var prompt string
 	if *fOpt.promptTokens > 0 {
-		prompt = generatePromptForTokenCount(*fOpt.promptTokens, epoch)
+		prompt = generatePromptForTokenCount(*fOpt.promptTokens, promptEpoch)
+	} else if mode == modeDecode {
+		prompt = *fOpt.prompt
 	} else {
-		// Vary the prompt per epoch to defeat KV cache prefix matching
-		prompt = fmt.Sprintf("[%d] %s", epoch, prompt)
+		prompt = fmt.Sprintf("[%d] %s", epoch, *fOpt.prompt)
 	}
 
-	req := &api.GenerateRequest{
-		Model:     model,
-		Prompt:    prompt,
-		Raw:       true,
-		Options:   options,
-		KeepAlive: keepAliveDuration,
+	numPredict := -1
+	if *fOpt.maxTokens > 0 {
+		numPredict = *fOpt.maxTokens
+	}
+	if mode == modePrefill {
+		numPredict = 0
 	}
 
-	if imgData != nil {
-		req.Images = []api.ImageData{imgData}
+	seed := 0
+	if fOpt.seed != nil {
+		seed = *fOpt.seed
+	}
+	numCtx := 0
+	if fOpt.numCtx != nil {
+		numCtx = *fOpt.numCtx
 	}
 
-	return req
+	return completionParams{
+		prompt:      prompt,
+		numPredict:  numPredict,
+		temperature: *fOpt.temperature,
+		seed:        seed,
+		numCtx:      numCtx,
+		ignoreEOS:   *fOpt.ignoreEOS && mode != modePrefill,
+		image:       imgData,
+		debug:       *fOpt.debug,
+	}
 }
 
 func fetchModelInfo(ctx context.Context, client *api.Client, model string) ModelInfo {
@@ -258,7 +337,10 @@ func OutputMetrics(w io.Writer, format string, metrics []Metrics, verbose bool) 
 }
 
 func BenchmarkModel(fOpt flagOptions) error {
-	models := strings.Split(*fOpt.models, ",")
+	mode := *fOpt.mode
+	if mode != modePrefill && mode != modeDecode && mode != modeBoth {
+		return fmt.Errorf("unknown -mode %q (want prefill|decode|both)", mode)
+	}
 
 	var imgData api.ImageData
 	var err error
@@ -268,16 +350,9 @@ func BenchmarkModel(fOpt flagOptions) error {
 			fmt.Fprintf(os.Stderr, "ERROR: Couldn't read image '%s': %v\n", *fOpt.imageFile, err)
 			return err
 		}
-	}
-
-	if *fOpt.debug && imgData != nil {
-		fmt.Fprintf(os.Stderr, "Read file '%s'\n", *fOpt.imageFile)
-	}
-
-	client, err := api.ClientFromEnvironment()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "ERROR: Couldn't create ollama client: %v\n", err)
-		return err
+		if *fOpt.debug {
+			fmt.Fprintf(os.Stderr, "Read file '%s'\n", *fOpt.imageFile)
+		}
 	}
 
 	var out io.Writer = os.Stdout
@@ -293,208 +368,227 @@ func BenchmarkModel(fOpt flagOptions) error {
 
 	outputFormatHeader(out, *fOpt.format, *fOpt.verbose)
 
-	// Log prompt-tokens info in debug mode
 	if *fOpt.debug && *fOpt.promptTokens > 0 {
 		prompt := generatePromptForTokenCount(*fOpt.promptTokens, 0)
-		wordCount := len(strings.Fields(prompt))
-		fmt.Fprintf(os.Stderr, "Generated prompt targeting ~%d tokens (%d words, varied per epoch)\n", *fOpt.promptTokens, wordCount)
+		fmt.Fprintf(os.Stderr, "Generated prompt targeting ~%d tokens (%d words)\n", *fOpt.promptTokens, len(strings.Fields(prompt)))
 	}
 
-	for _, model := range models {
-		// Fetch model info
-		infoCtx, infoCancel := context.WithTimeout(context.Background(), 10*time.Second)
-		info := fetchModelInfo(infoCtx, client, model)
-		infoCancel()
-
-		// Warmup phase (uses negative epoch numbers to avoid colliding with timed epochs)
-		for i := range *fOpt.warmup {
-			req := buildGenerateRequest(model, fOpt, imgData, -(i + 1))
-			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(*fOpt.timeout)*time.Second)
-
-			var warmupMetrics *api.Metrics
-			err = client.Generate(ctx, req, func(resp api.GenerateResponse) error {
-				if resp.Done {
-					warmupMetrics = &resp.Metrics
-				}
-				return nil
-			})
-			cancel()
-
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "WARNING: Warmup %d/%d for %s failed: %v\n", i+1, *fOpt.warmup, model, err)
-			} else {
-				if *fOpt.debug {
-					fmt.Fprintf(os.Stderr, "Warmup %d/%d for %s complete\n", i+1, *fOpt.warmup, model)
-				}
-				// Calibrate prompt token count on last warmup run
-				if i == *fOpt.warmup-1 && *fOpt.promptTokens > 0 && warmupMetrics != nil {
-					prompt := generatePromptForTokenCount(*fOpt.promptTokens, -(i + 1))
-					wordCount := len(strings.Fields(prompt))
-					calibratePromptTokens(*fOpt.promptTokens, warmupMetrics.PromptEvalCount, wordCount)
-				}
-			}
+	// Direct backends serve a single, already-loaded model; the -model value is
+	// just a label. With -runner set, bench probes the endpoint and auto-detects
+	// MLX runner vs llama-server. The serve path iterates the comma-separated
+	// model list as before.
+	switch {
+	case *fOpt.runner != "" || *fOpt.spawn:
+		backend, err := newDirectBackend(fOpt)
+		if err != nil {
+			return err
 		}
-
-		// Fetch memory/context info once after warmup (model is loaded and stable)
-		memCtx, memCancel := context.WithTimeout(context.Background(), 5*time.Second)
-		info.SizeBytes, info.VRAMBytes = fetchMemoryUsage(memCtx, client, model)
-		if fOpt.numCtx != nil && *fOpt.numCtx > 0 {
-			info.NumCtx = int64(*fOpt.numCtx)
-		} else {
-			info.NumCtx = fetchContextLength(memCtx, client, model)
+		defer backend.Cleanup(*fOpt.timeout)
+		runBenchmark(out, backend, fOpt, mode, imgData, *fOpt.models)
+	default:
+		client, err := api.ClientFromEnvironment()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: Couldn't create ollama client: %v\n", err)
+			return err
 		}
-		memCancel()
-
-		outputModelInfo(out, *fOpt.format, info)
-
-		// Timed epoch loop
-		shortCount := 0
-		for epoch := range *fOpt.epochs {
-			var responseMetrics *api.Metrics
-			var ttft time.Duration
-			short := false
-
-			// Retry loop: if the model hits a stop token before max-tokens,
-			// retry with a different prompt (up to maxRetries times).
-			const maxRetries = 3
-			for attempt := range maxRetries + 1 {
-				responseMetrics = nil
-				ttft = 0
-				var ttftOnce sync.Once
-
-				req := buildGenerateRequest(model, fOpt, imgData, epoch+attempt*1000)
-				requestStart := time.Now()
-
-				ctx, cancel := context.WithTimeout(context.Background(), time.Duration(*fOpt.timeout)*time.Second)
-
-				err = client.Generate(ctx, req, func(resp api.GenerateResponse) error {
-					if *fOpt.debug {
-						fmt.Fprintf(os.Stderr, "%s", cmp.Or(resp.Thinking, resp.Response))
-					}
-
-					// Capture TTFT on first content
-					ttftOnce.Do(func() {
-						if resp.Response != "" || resp.Thinking != "" {
-							ttft = time.Since(requestStart)
-						}
-					})
-
-					if resp.Done {
-						responseMetrics = &resp.Metrics
-					}
-					return nil
-				})
-				cancel()
-
-				if *fOpt.debug {
-					fmt.Fprintln(os.Stderr)
-				}
-
-				if err != nil {
-					if ctx.Err() == context.DeadlineExceeded {
-						fmt.Fprintf(os.Stderr, "ERROR: Request timed out with model '%s' after %vs\n", model, *fOpt.timeout)
-					} else {
-						fmt.Fprintf(os.Stderr, "ERROR: Couldn't generate with model '%s': %v\n", model, err)
-					}
-					break
-				}
-
-				if responseMetrics == nil {
-					fmt.Fprintf(os.Stderr, "ERROR: No metrics received for model '%s'\n", model)
-					break
-				}
-
-				// Check if the response was shorter than requested
-				short = *fOpt.maxTokens > 0 && responseMetrics.EvalCount < *fOpt.maxTokens
-				if !short || attempt == maxRetries {
-					break
-				}
-
-				if *fOpt.debug {
-					fmt.Fprintf(os.Stderr, "Short response (%d/%d tokens), retrying with different prompt (attempt %d/%d)\n",
-						responseMetrics.EvalCount, *fOpt.maxTokens, attempt+1, maxRetries)
-				}
-			}
-
-			if err != nil || responseMetrics == nil {
-				continue
-			}
-
-			if short {
-				shortCount++
-				if *fOpt.debug {
-					fmt.Fprintf(os.Stderr, "WARNING: Short response (%d/%d tokens) after %d retries for epoch %d\n",
-						responseMetrics.EvalCount, *fOpt.maxTokens, maxRetries, epoch+1)
-				}
-			}
-
-			metrics := []Metrics{
-				{
-					Model:    model,
-					Step:     "prefill",
-					Count:    responseMetrics.PromptEvalCount,
-					Duration: responseMetrics.PromptEvalDuration,
-				},
-				{
-					Model:    model,
-					Step:     "generate",
-					Count:    responseMetrics.EvalCount,
-					Duration: responseMetrics.EvalDuration,
-				},
-				{
-					Model:    model,
-					Step:     "ttft",
-					Count:    1,
-					Duration: ttft,
-				},
-				{
-					Model:    model,
-					Step:     "load",
-					Count:    1,
-					Duration: responseMetrics.LoadDuration,
-				},
-				{
-					Model:    model,
-					Step:     "total",
-					Count:    1,
-					Duration: responseMetrics.TotalDuration,
-				},
-			}
-
-			OutputMetrics(out, *fOpt.format, metrics, *fOpt.verbose)
-
-			if *fOpt.debug && *fOpt.promptTokens > 0 {
-				fmt.Fprintf(os.Stderr, "Generated prompt targeting ~%d tokens (actual: %d)\n",
-					*fOpt.promptTokens, responseMetrics.PromptEvalCount)
-			}
-
-			if *fOpt.keepAlive > 0 {
-				time.Sleep(time.Duration(*fOpt.keepAlive*float64(time.Second)) + 200*time.Millisecond)
-			}
+		for _, model := range strings.Split(*fOpt.models, ",") {
+			backend := &serveBackend{client: client, model: model}
+			runBenchmark(out, backend, fOpt, mode, imgData, model)
+			backend.Cleanup(*fOpt.timeout)
 		}
-
-		if shortCount > 0 {
-			fmt.Fprintf(os.Stderr, "WARNING: %d/%d epochs for '%s' had short responses (<%d tokens). Generation metrics may be unreliable.\n",
-				shortCount, *fOpt.epochs, model, *fOpt.maxTokens)
-		}
-
-		// Unload model before moving to the next one
-		unloadModel(client, model, *fOpt.timeout)
 	}
 
 	return nil
 }
 
-func unloadModel(client *api.Client, model string, timeout int) {
+// runBenchmark drives one backend: warmup (+ calibration and decode-cache
+// priming), then the timed epoch loop, emitting metrics through OutputMetrics.
+func runBenchmark(out io.Writer, backend benchBackend, fOpt flagOptions, mode string, imgData api.ImageData, model string) {
+	timeout := time.Duration(*fOpt.timeout) * time.Second
+
+	// Warmup. In decode mode the prompt is fixed, so warmup also primes the
+	// runner's prefix cache for the timed epochs.
+	for i := range *fOpt.warmup {
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		res, err := backend.Complete(ctx, buildParams(fOpt, mode, imgData, -(i+1)))
+		cancel()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "WARNING: Warmup %d/%d for %s failed: %v\n", i+1, *fOpt.warmup, model, err)
+			continue
+		}
+		if *fOpt.debug {
+			fmt.Fprintf(os.Stderr, "Warmup %d/%d for %s complete\n", i+1, *fOpt.warmup, model)
+		}
+		if i == *fOpt.warmup-1 && *fOpt.promptTokens > 0 && res.promptEvalCount > 0 {
+			prompt := generatePromptForTokenCount(*fOpt.promptTokens, -(i + 1))
+			calibratePromptTokens(*fOpt.promptTokens, res.promptEvalCount, len(strings.Fields(prompt)))
+		}
+	}
+
+	// Decode mode needs a primed cache; if the user disabled warmup, prime once.
+	if mode == modeDecode && *fOpt.warmup == 0 {
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		if _, err := backend.Complete(ctx, buildParams(fOpt, mode, imgData, 0)); err != nil {
+			fmt.Fprintf(os.Stderr, "WARNING: decode prime for %s failed: %v\n", model, err)
+		}
+		cancel()
+	}
+
+	info := backend.ModelInfo(context.Background(), fOpt)
+	outputModelInfo(out, *fOpt.format, info)
+
+	shortCount := 0
+	for epoch := range *fOpt.epochs {
+		var res completionResult
+		var err error
+		short := false
+
+		// Retry only matters when stop tokens can truncate generation: not in
+		// prefill mode and not when ignore_eos guarantees the full count.
+		const maxRetries = 3
+		for attempt := range maxRetries + 1 {
+			p := buildParams(fOpt, mode, imgData, epoch+attempt*1000)
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			res, err = backend.Complete(ctx, p)
+			timedOut := ctx.Err() == context.DeadlineExceeded
+			cancel()
+
+			if err != nil {
+				switch {
+				case errors.Is(err, errNoMetrics):
+					fmt.Fprintf(os.Stderr, "ERROR: No metrics received for model '%s'\n", model)
+				case timedOut:
+					fmt.Fprintf(os.Stderr, "ERROR: Request timed out with model '%s' after %vs\n", model, *fOpt.timeout)
+				default:
+					fmt.Fprintf(os.Stderr, "ERROR: Couldn't generate with model '%s': %v\n", model, err)
+				}
+				break
+			}
+
+			canRetry := !p.ignoreEOS && p.numPredict > 0
+			short = canRetry && res.evalCount < p.numPredict
+			if !short || attempt == maxRetries {
+				break
+			}
+			if *fOpt.debug {
+				fmt.Fprintf(os.Stderr, "Short response (%d/%d tokens), retrying (attempt %d/%d)\n",
+					res.evalCount, p.numPredict, attempt+1, maxRetries)
+			}
+		}
+
+		if err != nil {
+			continue
+		}
+		if short {
+			shortCount++
+		}
+
+		metrics := []Metrics{
+			{Model: model, Step: "prefill", Count: res.promptEvalCount, Duration: res.promptEvalDuration},
+			{Model: model, Step: "generate", Count: res.evalCount, Duration: res.evalDuration},
+			{Model: model, Step: "ttft", Count: 1, Duration: res.ttft},
+			{Model: model, Step: "load", Count: 1, Duration: res.loadDuration},
+			{Model: model, Step: "total", Count: 1, Duration: res.totalDuration},
+		}
+		OutputMetrics(out, *fOpt.format, metrics, *fOpt.verbose)
+
+		if *fOpt.debug && *fOpt.promptTokens > 0 {
+			fmt.Fprintf(os.Stderr, "Prompt targeting ~%d tokens (actual: %d)\n", *fOpt.promptTokens, res.promptEvalCount)
+		}
+
+		if *fOpt.keepAlive > 0 {
+			time.Sleep(time.Duration(*fOpt.keepAlive*float64(time.Second)) + 200*time.Millisecond)
+		}
+	}
+
+	if shortCount > 0 {
+		fmt.Fprintf(os.Stderr, "WARNING: %d/%d epochs for '%s' had short responses (<%d tokens). Use -ignore-eos for exact counts.\n",
+			shortCount, *fOpt.epochs, model, *fOpt.maxTokens)
+	}
+}
+
+// serveBackend drives the full ollama server through the public API (the legacy
+// default target).
+type serveBackend struct {
+	client *api.Client
+	model  string
+}
+
+func (b *serveBackend) Name() string { return "ollama-serve" }
+
+func (b *serveBackend) Complete(ctx context.Context, p completionParams) (completionResult, error) {
+	options := map[string]any{"temperature": p.temperature}
+	// num_predict convention: 0 = prefill-only, N>0 = exact; negative means
+	// "unlimited", which we express by leaving the option unset.
+	if p.numPredict >= 0 {
+		options["num_predict"] = p.numPredict
+	}
+	if p.seed > 0 {
+		options["seed"] = p.seed
+	}
+	if p.numCtx > 0 {
+		options["num_ctx"] = p.numCtx
+	}
+
+	req := &api.GenerateRequest{
+		Model:   b.model,
+		Prompt:  p.prompt,
+		Raw:     true,
+		Options: options,
+	}
+	if p.image != nil {
+		req.Images = []api.ImageData{p.image}
+	}
+
+	requestStart := time.Now()
+	var res completionResult
+	var ttftOnce sync.Once
+	gotDone := false
+	err := b.client.Generate(ctx, req, func(resp api.GenerateResponse) error {
+		if p.debug {
+			fmt.Fprintf(os.Stderr, "%s", cmp.Or(resp.Thinking, resp.Response))
+		}
+		ttftOnce.Do(func() {
+			if resp.Response != "" || resp.Thinking != "" {
+				res.ttft = time.Since(requestStart)
+			}
+		})
+		if resp.Done {
+			gotDone = true
+			res.promptEvalCount = resp.Metrics.PromptEvalCount
+			res.promptEvalDuration = resp.Metrics.PromptEvalDuration
+			res.evalCount = resp.Metrics.EvalCount
+			res.evalDuration = resp.Metrics.EvalDuration
+			res.loadDuration = resp.Metrics.LoadDuration
+			res.totalDuration = resp.Metrics.TotalDuration
+		}
+		return nil
+	})
+	if p.debug {
+		fmt.Fprintln(os.Stderr)
+	}
+	if err == nil && !gotDone {
+		return res, errNoMetrics
+	}
+	return res, err
+}
+
+func (b *serveBackend) ModelInfo(ctx context.Context, fOpt flagOptions) ModelInfo {
+	info := fetchModelInfo(ctx, b.client, b.model)
+	info.SizeBytes, info.VRAMBytes = fetchMemoryUsage(ctx, b.client, b.model)
+	if fOpt.numCtx != nil && *fOpt.numCtx > 0 {
+		info.NumCtx = int64(*fOpt.numCtx)
+	} else {
+		info.NumCtx = fetchContextLength(ctx, b.client, b.model)
+	}
+	return info
+}
+
+func (b *serveBackend) Cleanup(timeout int) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
 	defer cancel()
-
 	zero := api.Duration{Duration: 0}
-	req := &api.GenerateRequest{
-		Model:     model,
-		KeepAlive: &zero,
-	}
-	_ = client.Generate(ctx, req, func(resp api.GenerateResponse) error {
+	_ = b.client.Generate(ctx, &api.GenerateRequest{Model: b.model, KeepAlive: &zero}, func(api.GenerateResponse) error {
 		return nil
 	})
 }
@@ -532,6 +626,12 @@ func main() {
 		warmup:       flag.Int("warmup", 1, "Number of warmup requests before timing"),
 		promptTokens: flag.Int("prompt-tokens", 0, "Generate prompt targeting ~N tokens (0 = use -p prompt)"),
 		numCtx:       flag.Int("num-ctx", 0, "Context size (0 = server default)"),
+
+		runner:    flag.String("runner", "", "Drive a runner directly at host:port, bypassing ollama serve (auto-detects MLX runner vs llama-server)"),
+		spawn:     flag.Bool("spawn", false, "Spawn the runner subprocess: MLX runner for an MLX model, or llama-server for a GGUF model/path"),
+		ollamaBin: flag.String("ollama", "", "Path to the ollama binary for -spawn (default: PATH or this executable)"),
+		mode:      flag.String("mode", "both", "Benchmark mode [prefill|decode|both]"),
+		ignoreEOS: flag.Bool("ignore-eos", false, "Disable stop tokens so generation runs exactly -max-tokens (direct backends only)"),
 	}
 
 	flag.Usage = func() {
@@ -541,8 +641,18 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Options:\n")
 		flag.PrintDefaults()
 		fmt.Fprintf(os.Stderr, "\nExamples:\n")
+		fmt.Fprintf(os.Stderr, "  # Benchmark via ollama serve (default)\n")
 		fmt.Fprintf(os.Stderr, "  bench -model gemma3,llama3 -epochs 6\n")
-		fmt.Fprintf(os.Stderr, "  bench -model gemma3 -epochs 6 -prompt-tokens 512 -format csv\n")
+		fmt.Fprintf(os.Stderr, "  bench -model gemma3 -epochs 6 -prompt-tokens 512 -format csv\n\n")
+		fmt.Fprintf(os.Stderr, "  # Profile an MLX runner directly. Start it under a profiler first, e.g.\n")
+		fmt.Fprintf(os.Stderr, "  #   ollama runner --mlx-engine --model gemma3 --port 8081 --profile\n")
+		fmt.Fprintf(os.Stderr, "  bench -model gemma3 -runner 127.0.0.1:8081 -mode prefill -prompt-tokens 2048\n")
+		fmt.Fprintf(os.Stderr, "  bench -model gemma3 -runner 127.0.0.1:8081 -mode decode  -prompt-tokens 2048 -max-tokens 128 -ignore-eos\n\n")
+		fmt.Fprintf(os.Stderr, "  # Spawn the runner for a quick (unprofiled) direct benchmark\n")
+		fmt.Fprintf(os.Stderr, "  bench -model gemma3 -spawn -mode decode -ignore-eos               # MLX model -> MLX runner\n")
+		fmt.Fprintf(os.Stderr, "  bench -model llama3.2:latest -spawn -mode decode -ignore-eos      # GGUF model -> llama-server\n\n")
+		fmt.Fprintf(os.Stderr, "  # Compare against an already-running llama-server (same -runner flag; auto-detected)\n")
+		fmt.Fprintf(os.Stderr, "  bench -model llama3.2 -runner 127.0.0.1:8091 -mode decode -ignore-eos\n")
 	}
 	flag.Parse()
 

--- a/cmd/bench/bench_test.go
+++ b/cmd/bench/bench_test.go
@@ -30,6 +30,12 @@ func createTestFlagOptions() flagOptions {
 	debug := false
 	warmup := 0
 	promptTokens := 0
+	numCtx := 0
+	runner := ""
+	spawn := false
+	ollamaBin := ""
+	mode := modeBoth
+	ignoreEOS := false
 
 	return flagOptions{
 		models:       &models,
@@ -46,6 +52,12 @@ func createTestFlagOptions() flagOptions {
 		debug:        &debug,
 		warmup:       &warmup,
 		promptTokens: &promptTokens,
+		numCtx:       &numCtx,
+		runner:       &runner,
+		spawn:        &spawn,
+		ollamaBin:    &ollamaBin,
+		mode:         &mode,
+		ignoreEOS:    &ignoreEOS,
 	}
 }
 
@@ -1132,55 +1144,69 @@ func TestGeneratePromptForTokenCount_VariesByEpoch(t *testing.T) {
 	}
 }
 
-func TestBuildGenerateRequest(t *testing.T) {
+func TestBuildParams(t *testing.T) {
 	fOpt := createTestFlagOptions()
-	req := buildGenerateRequest("test-model", fOpt, nil, 0)
+	p := buildParams(fOpt, modeBoth, nil, 0)
 
-	if req.Model != "test-model" {
-		t.Errorf("Expected model 'test-model', got '%s'", req.Model)
+	if !strings.Contains(p.prompt, "test prompt") {
+		t.Errorf("Expected prompt to contain 'test prompt', got '%s'", p.prompt)
 	}
-	if !req.Raw {
-		t.Error("Expected raw mode to be true")
-	}
-	if !strings.Contains(req.Prompt, "test prompt") {
-		t.Errorf("Expected prompt to contain 'test prompt', got '%s'", req.Prompt)
+	if p.numPredict != 50 {
+		t.Errorf("Expected numPredict 50, got %d", p.numPredict)
 	}
 }
 
-func TestBuildGenerateRequest_WithPromptTokens(t *testing.T) {
+func TestBuildParams_PrefillMode(t *testing.T) {
+	fOpt := createTestFlagOptions()
+	p := buildParams(fOpt, modePrefill, nil, 0)
+	if p.numPredict != 0 {
+		t.Errorf("Expected prefill mode numPredict 0, got %d", p.numPredict)
+	}
+}
+
+func TestBuildParams_DecodeModeFixedPrompt(t *testing.T) {
+	fOpt := createTestFlagOptions()
+	// Decode mode holds the prompt fixed across epochs for cache hits.
+	p0 := buildParams(fOpt, modeDecode, nil, 0)
+	p1 := buildParams(fOpt, modeDecode, nil, 1)
+	if p0.prompt != p1.prompt {
+		t.Errorf("Expected identical decode-mode prompts across epochs")
+	}
+}
+
+func TestBuildParams_WithPromptTokens(t *testing.T) {
 	fOpt := createTestFlagOptions()
 	promptTokens := 200
 	fOpt.promptTokens = &promptTokens
 
-	req := buildGenerateRequest("test-model", fOpt, nil, 0)
-	// Should not contain the original prompt
-	if strings.Contains(req.Prompt, "test prompt") {
+	p := buildParams(fOpt, modeBoth, nil, 0)
+	if strings.Contains(p.prompt, "test prompt") {
 		t.Error("Expected generated prompt when promptTokens is set")
 	}
 
-	wordCount := len(strings.Fields(req.Prompt))
+	wordCount := len(strings.Fields(p.prompt))
 	if wordCount < 100 || wordCount > 200 {
 		t.Errorf("Expected ~153 words for 200 tokens, got %d", wordCount)
 	}
 }
 
-func TestBuildGenerateRequest_WithImage(t *testing.T) {
+func TestBuildParams_WithImage(t *testing.T) {
 	fOpt := createTestFlagOptions()
 	imgData := api.ImageData([]byte("fake image"))
 
-	req := buildGenerateRequest("test-model", fOpt, imgData, 0)
-	if len(req.Images) != 1 {
-		t.Errorf("Expected 1 image, got %d", len(req.Images))
+	p := buildParams(fOpt, modeBoth, imgData, 0)
+	if p.image == nil {
+		t.Error("Expected image to be carried in params")
 	}
 }
 
-func TestBuildGenerateRequest_VariesByEpoch(t *testing.T) {
+func TestBuildParams_VariesByEpoch(t *testing.T) {
 	fOpt := createTestFlagOptions()
 
-	req0 := buildGenerateRequest("test-model", fOpt, nil, 0)
-	req1 := buildGenerateRequest("test-model", fOpt, nil, 1)
+	p0 := buildParams(fOpt, modeBoth, nil, 0)
+	p1 := buildParams(fOpt, modeBoth, nil, 1)
 
-	if req0.Prompt == req1.Prompt {
+	if p0.prompt == p1.prompt {
 		t.Error("Expected different prompts for different epochs")
 	}
 }

--- a/cmd/bench/llamaserver.go
+++ b/cmd/bench/llamaserver.go
@@ -1,0 +1,263 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// llamaServerBackend drives a llama-server directly over its native /completion
+type llamaServerBackend struct {
+	addr   string
+	model  string
+	mode   string
+	client *http.Client
+	debug  bool
+
+	cmd *exec.Cmd // non-nil when bench spawned the llama-server
+}
+
+// llamaServerReq is the subset of llama-server's /completion request bench uses.
+// This mirrors llama.cpp's stable native protocol (not the ollama MLX runner
+// wire types), so it is intentionally defined locally.
+type llamaServerReq struct {
+	Prompt      string  `json:"prompt"`
+	NPredict    int     `json:"n_predict"`
+	Stream      bool    `json:"stream"`
+	CachePrompt bool    `json:"cache_prompt"`
+	IgnoreEOS   bool    `json:"ignore_eos"`
+	Temperature float64 `json:"temperature"`
+	Seed        int     `json:"seed"`
+}
+
+type llamaServerTimings struct {
+	CacheN      int     `json:"cache_n"`
+	PromptN     int     `json:"prompt_n"`
+	PromptMS    float64 `json:"prompt_ms"`
+	PredictedN  int     `json:"predicted_n"`
+	PredictedMS float64 `json:"predicted_ms"`
+}
+
+// llamaServerChunk is one streamed SSE event. timings is present on the final
+// (stop) chunk.
+type llamaServerChunk struct {
+	Content string             `json:"content"`
+	Stop    bool               `json:"stop"`
+	Timings llamaServerTimings `json:"timings"`
+}
+
+func newLlamaServerBackend(fOpt flagOptions) *llamaServerBackend {
+	return &llamaServerBackend{
+		addr:   *fOpt.runner,
+		model:  *fOpt.models,
+		mode:   *fOpt.mode,
+		client: &http.Client{},
+		debug:  *fOpt.debug,
+	}
+}
+
+// newLlamaServerSpawn launches a llama-server on a free port serving ggufPath,
+// captures its stderr, and waits for it to become ready.
+func newLlamaServerSpawn(fOpt flagOptions, ggufPath string) (*llamaServerBackend, error) {
+	bin, err := resolveLlamaServer()
+	if err != nil {
+		return nil, err
+	}
+	port, err := freePort()
+	if err != nil {
+		return nil, fmt.Errorf("could not find a free port: %w", err)
+	}
+
+	args := []string{"-m", ggufPath, "--port", strconv.Itoa(port), "-ngl", "99"}
+	if *fOpt.numCtx > 0 {
+		args = append(args, "-c", strconv.Itoa(*fOpt.numCtx))
+	}
+	cmd := exec.Command(bin, args...)
+	cmd.Env = os.Environ()
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("failed to spawn llama-server: %w", err)
+	}
+
+	b := &llamaServerBackend{
+		addr:   fmt.Sprintf("127.0.0.1:%d", port),
+		model:  *fOpt.models,
+		mode:   *fOpt.mode,
+		client: &http.Client{},
+		debug:  *fOpt.debug,
+		cmd:    cmd,
+	}
+	fmt.Fprintf(os.Stderr, "bench: spawned llama-server (pid %d) on %s for %s\n", cmd.Process.Pid, b.addr, ggufPath)
+
+	if err := b.waitReady(time.Duration(*fOpt.timeout) * time.Second); err != nil {
+		b.Cleanup(*fOpt.timeout)
+		return nil, fmt.Errorf("llama-server not ready: %w", err)
+	}
+	return b, nil
+}
+
+// resolveLlamaServer locates the llama-server binary: the -ollama flag's sibling
+// payload dir, a dev build/ tree, or PATH.
+func resolveLlamaServer() (string, error) {
+	var candidates []string
+	if cwd, err := os.Getwd(); err == nil {
+		for dir := cwd; ; {
+			candidates = append(candidates, filepath.Join(dir, "build", "lib", "ollama", "llama-server"))
+			candidates = append(candidates, filepath.Join(dir, "dist", "lib", "ollama", "llama-server"))
+			parent := filepath.Dir(dir)
+			if parent == dir {
+				break
+			}
+			dir = parent
+		}
+	}
+	for _, c := range candidates {
+		if _, err := os.Stat(c); err == nil {
+			return c, nil
+		}
+	}
+	if p, err := exec.LookPath("llama-server"); err == nil {
+		return p, nil
+	}
+	return "", fmt.Errorf("could not locate the llama-server binary; build it (cmake --build build) or put it on PATH")
+}
+
+func (b *llamaServerBackend) waitReady(timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		if httpOK(b.client, "http://"+b.addr+"/health") {
+			return nil
+		}
+		if b.cmd != nil && b.cmd.ProcessState != nil && b.cmd.ProcessState.Exited() {
+			return fmt.Errorf("llama-server exited before becoming ready")
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for %s", b.addr)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+func (b *llamaServerBackend) Name() string { return "llama-server" }
+
+func (b *llamaServerBackend) ModelInfo(ctx context.Context, fOpt flagOptions) ModelInfo {
+	// llama-server exposes /props with model metadata; for now we report just
+	// the label and let the values fall back to "unknown".
+	return ModelInfo{Name: b.model}
+}
+
+func (b *llamaServerBackend) Complete(ctx context.Context, p completionParams) (completionResult, error) {
+	lreq := llamaServerReq{
+		Prompt:      p.prompt,
+		NPredict:    p.numPredict,
+		Stream:      true,
+		CachePrompt: b.mode == modeDecode,
+		IgnoreEOS:   p.ignoreEOS,
+		Temperature: p.temperature,
+		Seed:        p.seed,
+	}
+
+	body, err := json.Marshal(lreq)
+	if err != nil {
+		return completionResult{}, err
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", "http://"+b.addr+"/completion", bytes.NewReader(body))
+	if err != nil {
+		return completionResult{}, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	requestStart := time.Now()
+	resp, err := b.client.Do(httpReq)
+	if err != nil {
+		return completionResult{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return completionResult{}, fmt.Errorf("llama-server status %d", resp.StatusCode)
+	}
+
+	var res completionResult
+	ttftSet := false
+	gotTimings := false
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		// llama-server emits SSE: "data: {json}" lines separated by blanks.
+		line, ok := strings.CutPrefix(line, "data:")
+		if !ok {
+			continue
+		}
+		line = strings.TrimSpace(line)
+		if line == "" || line == "[DONE]" {
+			continue
+		}
+
+		var chunk llamaServerChunk
+		if err := json.Unmarshal([]byte(line), &chunk); err != nil {
+			continue
+		}
+		if !ttftSet && chunk.Content != "" {
+			res.ttft = time.Since(requestStart)
+			ttftSet = true
+		}
+		if b.debug && chunk.Content != "" {
+			fmt.Fprint(os.Stderr, chunk.Content)
+		}
+		if chunk.Stop {
+			res.promptEvalCount = chunk.Timings.CacheN + chunk.Timings.PromptN
+			res.promptEvalDuration = msToDuration(chunk.Timings.PromptMS)
+			res.evalCount = chunk.Timings.PredictedN
+			res.evalDuration = msToDuration(chunk.Timings.PredictedMS)
+			gotTimings = true
+		}
+	}
+	if b.debug {
+		fmt.Fprintln(os.Stderr)
+	}
+	if err := scanner.Err(); err != nil {
+		return res, err
+	}
+	if !gotTimings {
+		return res, errNoMetrics
+	}
+	res.totalDuration = time.Since(requestStart)
+	return res, nil
+}
+
+// Cleanup terminates the llama-server only if bench spawned it; an
+// operator-managed server (reached via -runner) is left running.
+func (b *llamaServerBackend) Cleanup(int) {
+	if b.cmd == nil || b.cmd.Process == nil {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "bench: stopping spawned llama-server (pid %d)\n", b.cmd.Process.Pid)
+	_ = b.cmd.Process.Signal(os.Interrupt)
+	done := make(chan struct{})
+	go func() {
+		_ = b.cmd.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		_ = b.cmd.Process.Kill()
+	}
+	b.cmd = nil
+}
+
+func msToDuration(ms float64) time.Duration {
+	return time.Duration(ms * float64(time.Millisecond))
+}

--- a/cmd/bench/resolve.go
+++ b/cmd/bench/resolve.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ollama/ollama/envconfig"
+	"github.com/ollama/ollama/fs/gguf"
+	"github.com/ollama/ollama/types/model"
+)
+
+// resolveGGUF decides whether target names a GGUF model and, if so, returns the
+// path to its GGUF file. target may be a direct path to a GGUF file or an
+// ollama model name (e.g. "llama3.2:latest") whose manifest points at a GGUF
+// blob. MLX model names — whose manifests carry safetensors tensor layers —
+// return ("", false) so the caller falls back to the MLX runner.
+func resolveGGUF(target string) (string, bool) {
+	if isGGUFFile(target) {
+		return target, true
+	}
+	return ggufBlobForModel(target)
+}
+
+// isGGUFFile reports whether path is a readable GGUF file. It checks the file's
+// header magic via fs/gguf (not the extension), so unsuffixed blob paths work.
+func isGGUFFile(path string) bool {
+	f, err := gguf.Open(path)
+	if err != nil {
+		return false
+	}
+	f.Close()
+	return true
+}
+
+// ollamaManifest is the subset of an ollama image manifest needed to locate the
+// model blob.
+type ollamaManifest struct {
+	Layers []struct {
+		MediaType string `json:"mediaType"`
+		Digest    string `json:"digest"`
+	} `json:"layers"`
+}
+
+// ggufBlobForModel resolves an ollama model name to its GGUF blob path when the
+// model is GGUF-based. A model is GGUF-based when its manifest carries a model
+// layer (application/vnd.ollama.image.model) whose blob has the GGUF magic;
+// MLX models instead carry image.tensor layers and yield ("", false).
+func ggufBlobForModel(name string) (string, bool) {
+	n := model.ParseName(name)
+	if !n.IsValid() {
+		return "", false
+	}
+	models := envconfig.Models()
+	data, err := os.ReadFile(filepath.Join(models, "manifests", n.Filepath()))
+	if err != nil {
+		return "", false
+	}
+	var m ollamaManifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return "", false
+	}
+	for _, l := range m.Layers {
+		if l.MediaType != "application/vnd.ollama.image.model" {
+			continue
+		}
+		blob := filepath.Join(models, "blobs", strings.ReplaceAll(l.Digest, ":", "-"))
+		if isGGUFFile(blob) {
+			return blob, true
+		}
+	}
+	return "", false
+}

--- a/cmd/bench/runner.go
+++ b/cmd/bench/runner.go
@@ -1,0 +1,349 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/x/mlxrunner/wire"
+)
+
+const (
+	backendMLX   = "mlx"
+	backendLlama = "llama"
+)
+
+// newDirectBackend builds the right direct backend for -runner/-spawn. -spawn
+// always launches an MLX runner. For -runner host:port it probes the endpoint
+// and auto-detects MLX runner vs llama-server.
+func newDirectBackend(fOpt flagOptions) (benchBackend, error) {
+	if *fOpt.spawn {
+		// The spawn target is chosen from -model: a GGUF (a .gguf file path, or
+		// an ollama model name that resolves to a GGUF model) launches a
+		// llama-server; anything else is treated as an MLX model name and
+		// launches the MLX runner.
+		if ggufPath, ok := resolveGGUF(*fOpt.models); ok {
+			return newLlamaServerSpawn(fOpt, ggufPath)
+		}
+		return newRunnerBackend(fOpt)
+	}
+
+	client := &http.Client{}
+	kind, err := detectRunnerKind(*fOpt.runner, client, time.Duration(*fOpt.timeout)*time.Second, *fOpt.debug)
+	if err != nil {
+		return nil, err
+	}
+	switch kind {
+	case backendMLX:
+		return newRunnerBackend(fOpt)
+	case backendLlama:
+		return newLlamaServerBackend(fOpt), nil
+	default:
+		return nil, fmt.Errorf("could not determine backend at %s", *fOpt.runner)
+	}
+}
+
+// detectRunnerKind probes addr until it identifies an MLX runner (GET
+// /v1/status returns 200) or a llama-server (GET /props returns 200), or the
+// timeout elapses. This also serves as the readiness wait when the operator
+// started the runner under a profiler just before launching bench.
+func detectRunnerKind(addr string, client *http.Client, timeout time.Duration, debug bool) (string, error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		if httpOK(client, "http://"+addr+"/v1/status") {
+			if debug {
+				fmt.Fprintf(os.Stderr, "bench: detected MLX runner at %s\n", addr)
+			}
+			return backendMLX, nil
+		}
+		if httpOK(client, "http://"+addr+"/props") {
+			if debug {
+				fmt.Fprintf(os.Stderr, "bench: detected llama-server at %s\n", addr)
+			}
+			return backendLlama, nil
+		}
+		if time.Now().After(deadline) {
+			return "", fmt.Errorf("no MLX runner (/v1/status) or llama-server (/props) responded at %s", addr)
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+}
+
+// httpOK reports whether a GET to url returns 200.
+func httpOK(client *http.Client, url string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return false
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
+}
+
+// runnerBackend drives an MLX runner subprocess directly over its HTTP API,
+// bypassing ollama serve. The runner is either already running (started under a
+// profiler by the operator) and reached via -runner host:port, or spawned by
+// bench when -spawn is set.
+type runnerBackend struct {
+	addr   string // host:port
+	model  string
+	client *http.Client
+	debug  bool
+
+	cmd *exec.Cmd // non-nil when bench spawned the runner
+}
+
+// runnerStatus mirrors the MLX runner's GET /v1/status response.
+type runnerStatus struct {
+	Status        int
+	Progress      int
+	ContextLength int
+	Memory        uint64
+}
+
+func newRunnerBackend(fOpt flagOptions) (*runnerBackend, error) {
+	model := *fOpt.models
+	if strings.Contains(model, ",") {
+		fmt.Fprintf(os.Stderr, "WARNING: direct runner mode serves a single model; using %q\n", model)
+	}
+	if *fOpt.imageFile != "" {
+		fmt.Fprintf(os.Stderr, "WARNING: images are not supported in direct runner mode; ignoring -image\n")
+	}
+
+	b := &runnerBackend{
+		model:  model,
+		client: &http.Client{},
+		debug:  *fOpt.debug,
+	}
+
+	if *fOpt.runner != "" {
+		b.addr = *fOpt.runner
+	} else {
+		if err := b.spawn(fOpt); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := b.waitReady(time.Duration(*fOpt.timeout) * time.Second); err != nil {
+		b.Cleanup(*fOpt.timeout)
+		return nil, fmt.Errorf("mlx runner not ready: %w", err)
+	}
+	return b, nil
+}
+
+// spawn launches `ollama runner --mlx-engine` on a free port and captures its
+// stderr. It relies on the runner self-configuring its MLX libraries (dev
+// builds resolve them relative to the executable); for non-dev installs the
+// library path may need to be set in the environment.
+func (b *runnerBackend) spawn(fOpt flagOptions) error {
+	port, err := freePort()
+	if err != nil {
+		return fmt.Errorf("could not find a free port: %w", err)
+	}
+	exe, err := resolveOllama(fOpt)
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.Command(exe, "runner", "--mlx-engine", "--model", b.model, "--port", strconv.Itoa(port))
+	cmd.Env = os.Environ()
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to spawn mlx runner: %w", err)
+	}
+	b.cmd = cmd
+	b.addr = fmt.Sprintf("127.0.0.1:%d", port)
+	fmt.Fprintf(os.Stderr, "bench: spawned mlx runner (pid %d) on %s\n", cmd.Process.Pid, b.addr)
+	return nil
+}
+
+func (b *runnerBackend) Name() string { return "mlx-runner" }
+
+func (b *runnerBackend) status(ctx context.Context) (runnerStatus, error) {
+	var st runnerStatus
+	req, err := http.NewRequestWithContext(ctx, "GET", "http://"+b.addr+"/v1/status", nil)
+	if err != nil {
+		return st, err
+	}
+	resp, err := b.client.Do(req)
+	if err != nil {
+		return st, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return st, fmt.Errorf("status %d", resp.StatusCode)
+	}
+	err = json.NewDecoder(resp.Body).Decode(&st)
+	return st, err
+}
+
+func (b *runnerBackend) waitReady(timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		_, err := b.status(ctx)
+		cancel()
+		if err == nil {
+			return nil
+		}
+		if b.cmd != nil && b.cmd.ProcessState != nil && b.cmd.ProcessState.Exited() {
+			return fmt.Errorf("runner exited before becoming ready")
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for %s", b.addr)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+func (b *runnerBackend) ModelInfo(ctx context.Context, fOpt flagOptions) ModelInfo {
+	info := ModelInfo{Name: b.model}
+	if *fOpt.numCtx > 0 {
+		fmt.Fprintf(os.Stderr, "WARNING: -num-ctx is ignored in direct runner mode (context is fixed at model load)\n")
+	}
+	st, err := b.status(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "WARNING: could not fetch runner status: %v\n", err)
+		return info
+	}
+	info.SizeBytes = int64(st.Memory)
+	info.VRAMBytes = int64(st.Memory)
+	info.NumCtx = int64(st.ContextLength)
+	return info
+}
+
+func (b *runnerBackend) Complete(ctx context.Context, p completionParams) (completionResult, error) {
+	creq := wire.CompletionRequest{
+		Prompt:    p.prompt,
+		IgnoreEOS: p.ignoreEOS,
+		Options: api.Options{
+			Runner:     api.Runner{NumCtx: p.numCtx},
+			Seed:       p.seed,
+			NumPredict: p.numPredict,
+		},
+	}
+	creq.Options.Temperature = float32(p.temperature)
+
+	body, err := json.Marshal(creq)
+	if err != nil {
+		return completionResult{}, err
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", "http://"+b.addr+"/v1/completions", strings.NewReader(string(body)))
+	if err != nil {
+		return completionResult{}, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	requestStart := time.Now()
+	resp, err := b.client.Do(httpReq)
+	if err != nil {
+		return completionResult{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return completionResult{}, fmt.Errorf("runner returned status %d", resp.StatusCode)
+	}
+
+	var res completionResult
+	ttftSet := false
+	gotDone := false
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		var cr wire.CompletionResponse
+		if err := json.Unmarshal(scanner.Bytes(), &cr); err != nil {
+			continue
+		}
+		if cr.Error != nil {
+			return res, fmt.Errorf("runner error: %s", cr.Error.ErrorMessage)
+		}
+		if !ttftSet && cr.Content != "" {
+			res.ttft = time.Since(requestStart)
+			ttftSet = true
+		}
+		if b.debug && cr.Content != "" {
+			fmt.Fprint(os.Stderr, cr.Content)
+		}
+		if cr.Done {
+			gotDone = true
+			res.promptEvalCount = cr.PromptEvalCount
+			res.promptEvalDuration = cr.PromptEvalDuration
+			res.evalCount = cr.EvalCount
+			res.evalDuration = cr.EvalDuration
+		}
+	}
+	if b.debug {
+		fmt.Fprintln(os.Stderr)
+	}
+	if err := scanner.Err(); err != nil {
+		return res, err
+	}
+	if !gotDone {
+		return res, errNoMetrics
+	}
+	res.totalDuration = time.Since(requestStart)
+	return res, nil
+}
+
+// Cleanup terminates the runner only if bench spawned it; an operator-managed
+// runner (reached via -runner) is left running.
+func (b *runnerBackend) Cleanup(timeout int) {
+	if b.cmd == nil || b.cmd.Process == nil {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "bench: stopping spawned mlx runner (pid %d)\n", b.cmd.Process.Pid)
+	_ = b.cmd.Process.Signal(os.Interrupt)
+	done := make(chan struct{})
+	go func() {
+		_ = b.cmd.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		_ = b.cmd.Process.Kill()
+	}
+	b.cmd = nil
+}
+
+func freePort() (int, error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port, nil
+}
+
+func resolveOllama(fOpt flagOptions) (string, error) {
+	if *fOpt.ollamaBin != "" {
+		return *fOpt.ollamaBin, nil
+	}
+	if p, err := exec.LookPath("ollama"); err == nil {
+		return p, nil
+	}
+	if exe, err := os.Executable(); err == nil {
+		cand := filepath.Join(filepath.Dir(exe), "ollama")
+		if _, err := os.Stat(cand); err == nil {
+			return cand, nil
+		}
+	}
+	return "", fmt.Errorf("could not locate the ollama binary; pass -ollama <path>")
+}

--- a/x/mlxrunner/PROFILING.md
+++ b/x/mlxrunner/PROFILING.md
@@ -1,0 +1,89 @@
+# Profiling the MLX runner
+
+Pointers for getting clean, repeatable performance data out of the MLX runner on
+Metal and CUDA. The `cmd/bench` tool drives a runner directly (bypassing
+`ollama serve`) so the process under a profiler is the runner itself — no
+serve→runner fork to confuse `nsys`/`rocprofv3`/`xctrace`.
+
+## The bench driver (both platforms)
+
+Point `bench` at a runner you started yourself, or let it spawn one:
+
+```bash
+# Connect to a runner you started (e.g. under a profiler). Auto-detects whether
+# the endpoint is an MLX runner or a llama-server.
+go run ./cmd/bench -model <model> -runner 127.0.0.1:8081 -mode decode -ignore-eos
+
+# Let bench spawn the runner. An MLX model launches the MLX runner; a GGUF model
+# (a .gguf path, or an ollama name like llama3.2:latest) launches a llama-server.
+go run ./cmd/bench -model <model> -spawn -mode decode -ignore-eos
+```
+
+Key flags:
+
+- `-mode prefill|decode|both` — isolate a single phase so a capture window
+  contains one workload. `prefill` varies the prompt per epoch (cache miss) and
+  generates 0 tokens; `decode` holds the prompt fixed so the prefix cache hits
+  and the window is pure decode; `both` is a normal mixed run.
+- `-ignore-eos` — disable stop tokens so generation runs exactly `-max-tokens`,
+  making a capture attributable to a known number of decode passes.
+- `-prompt-tokens N` / `-max-tokens N` — shape the prompt/generation.
+
+**Prefer two separate captures (`-mode prefill` and `-mode decode`) over one
+mixed run** — prefill (compute-bound GEMMs) and decode (bandwidth-bound batch-1
+matvecs) have different bottlenecks and aggregate counters average across them.
+
+## Metal (Apple Silicon)
+
+Throughput numbers: just run `bench` as above; it reports per-phase tok/s.
+
+Per-kernel timeline — `xctrace` Metal System Trace, attached to the runner:
+
+```bash
+RUNNER_PID=$(lsof -ti :8081)
+xctrace record --template 'Metal System Trace' --attach $RUNNER_PID \
+  --time-limit 10s --output /tmp/decode.trace
+# ...drive load with `bench -mode decode` during the window...
+xctrace export --input /tmp/decode.trace --toc          # list tables
+```
+
+- **Named kernels:** by default MLX dispatches show as generic "Compute
+  Command". Build with `cmake -B build -DMLX_METAL_DEBUG=on .` (the `MLX_`
+  prefix is forwarded to the MLX sub-build) and rebuild; dispatches then carry
+  the real op graph (`QuantizedMatmul`, `ScaledDotProductAttention`, `RMSNorm`,
+  `RoPE`, …). The debug metallib is larger and can cost performance — turn it
+  back off (`-DMLX_METAL_DEBUG=off`) for timing runs.
+- **Phase markers (optional):** start the runner with `--profile` to emit
+  `os_signpost` intervals (`com.ollama.mlx`, points-of-interest) around prefill
+  and decode. The `Metal System Trace` template does **not** capture these — use
+  a template that includes the os_signpost instrument (e.g. `Logging` or
+  `System Trace`) if you want phase intervals. For most work the `-mode`
+  isolation above is simpler.
+
+## CUDA (Linux)
+
+Start the runner under Nsight Systems (or attach), with `--profile` so it emits
+NVTX ranges; `nsys` captures these natively in the same trace:
+
+```bash
+nsys profile --trace=nvtx,cuda,osrt --output /tmp/decode \
+  ollama runner --mlx-engine --model <model> --port 8081 --profile
+# ...drive load with `bench -runner 127.0.0.1:8081 -mode decode -ignore-eos`...
+nsys stats /tmp/decode.nsys-rep --report cuda_gpu_kern_sum
+```
+
+The `prefill` / `decode` NVTX ranges show up on the timeline and bound the right
+kernels with no extra setup — this is the primary phase-attribution mechanism on
+CUDA. Use `ncu` only when you need per-kernel hardware counters.
+
+System-wide capture is an alternative when attaching is awkward; it requires
+`perf_event_paranoid=0` and `--cuda-trace-scope=system-wide`.
+
+## Notes
+
+- The runner serves one model and fixes context length at load; `-num-ctx` is
+  ignored in direct mode.
+- Markers default off and are a near-no-op unless `--profile` is set, so they do
+  not affect normal benchmarking.
+- ROCm is not a shipping target yet; the Linux marker path leaves a stub for a
+  future `roctx` (rocprofv3) backend.

--- a/x/mlxrunner/client.go
+++ b/x/mlxrunner/client.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ollama/ollama/ml"
 	"github.com/ollama/ollama/x/imagegen"
 	"github.com/ollama/ollama/x/imagegen/manifest"
+	"github.com/ollama/ollama/x/mlxrunner/wire"
 )
 
 // Client wraps an MLX runner subprocess to implement llm.LlamaServer for LLM models.
@@ -95,27 +96,14 @@ func (c *Client) WaitUntilRunning(ctx context.Context) error {
 	}
 }
 
-type CompletionRequest struct {
-	Prompt      string
-	Options     api.Options
-	Logprobs    bool
-	TopLogprobs int
-}
-
-type CompletionResponse struct {
-	Content    string
-	Done       bool
-	DoneReason int
-
-	PromptEvalCount    int
-	PromptEvalDuration time.Duration
-	EvalCount          int
-	EvalDuration       time.Duration
-
-	Logprobs []llm.Logprob
-
-	Error *api.StatusError
-}
+// CompletionRequest and CompletionResponse are the runner's HTTP wire types.
+// They live in the cgo-free wire package so tools like cmd/bench can import
+// them without pulling in the MLX runtime; these aliases keep the existing
+// runner call sites unqualified.
+type (
+	CompletionRequest  = wire.CompletionRequest
+	CompletionResponse = wire.CompletionResponse
+)
 
 // Close terminates the subprocess.
 func (c *Client) Close() error {

--- a/x/mlxrunner/mlx/profile.go
+++ b/x/mlxrunner/mlx/profile.go
@@ -1,0 +1,34 @@
+package mlx
+
+import "sync/atomic"
+
+// profilingEnabled gates emission of GPU profiler phase markers. It is off by
+// default; the runner turns it on via the --profile CLI flag. Markers are
+// os_signpost intervals on macOS (captured by Instruments / xctrace) and NVTX
+// ranges on CUDA/Linux (captured by Nsight Systems). When disabled, the push
+// and pop calls are a single atomic load and return, off the hot path.
+var profilingEnabled atomic.Bool
+
+// SetProfilingEnabled toggles phase-marker emission. Safe to call from any
+// goroutine.
+func SetProfilingEnabled(on bool) { profilingEnabled.Store(on) }
+
+// ProfilingEnabled reports whether phase markers are being emitted.
+func ProfilingEnabled() bool { return profilingEnabled.Load() }
+
+// ProfileRangePush opens a named profiler range. Ranges nest and must be
+// balanced with ProfileRangePop. No-op unless profiling is enabled.
+func ProfileRangePush(name string) {
+	if !profilingEnabled.Load() {
+		return
+	}
+	profileRangePush(name)
+}
+
+// ProfileRangePop closes the most recently opened range. No-op unless enabled.
+func ProfileRangePop() {
+	if !profilingEnabled.Load() {
+		return
+	}
+	profileRangePop()
+}

--- a/x/mlxrunner/mlx/profile_darwin.go
+++ b/x/mlxrunner/mlx/profile_darwin.go
@@ -1,0 +1,57 @@
+//go:build darwin
+
+// os_signpost intervals land in Instruments / xctrace's "Points of Interest"
+// track, letting a Metal System Trace be split by inference phase. We use a
+// single static signpost name ("phase") and pass the actual phase name as the
+// interval message so prefill/decode show up as labeled sub-intervals. Begin
+// returns a generated signpost id which end must match, so we keep a small
+// stack; pushes/pops run on the serialized MLX worker thread.
+
+package mlx
+
+// #include <os/log.h>
+// #include <os/signpost.h>
+// #include <stdlib.h>
+//
+// static os_log_t _ollama_signpost_log(void) {
+//     // Initialized on first use from the single MLX worker thread.
+//     static os_log_t log = NULL;
+//     if (log == NULL) {
+//         log = os_log_create("com.ollama.mlx", OS_LOG_CATEGORY_POINTS_OF_INTEREST);
+//     }
+//     return log;
+// }
+//
+// static os_signpost_id_t _sp_stack[32];
+// static int _sp_top = 0;
+//
+// static void ollama_signpost_begin(const char *name) {
+//     os_log_t log = _ollama_signpost_log();
+//     os_signpost_id_t sid = os_signpost_id_generate(log);
+//     if (_sp_top < (int)(sizeof(_sp_stack) / sizeof(_sp_stack[0]))) {
+//         _sp_stack[_sp_top++] = sid;
+//     }
+//     os_signpost_interval_begin(log, sid, "phase", "%s", name);
+// }
+//
+// static void ollama_signpost_end(void) {
+//     if (_sp_top <= 0) {
+//         return;
+//     }
+//     os_log_t log = _ollama_signpost_log();
+//     os_signpost_id_t sid = _sp_stack[--_sp_top];
+//     os_signpost_interval_end(log, sid, "phase");
+// }
+import "C"
+
+import "unsafe"
+
+func profileRangePush(name string) {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	C.ollama_signpost_begin(cName)
+}
+
+func profileRangePop() {
+	C.ollama_signpost_end()
+}

--- a/x/mlxrunner/mlx/profile_linux.go
+++ b/x/mlxrunner/mlx/profile_linux.go
@@ -1,0 +1,74 @@
+//go:build linux
+
+// On Linux the shipping GPU backend is CUDA, so we emit NVTX ranges that Nsight
+// Systems captures. We dlopen libnvToolsExt at first use rather than linking it,
+// so the runner has no hard dependency on the CUDA toolkit when profiling is
+// off. Backend selection is funneled through load_markers() so a future ROCm
+// (roctx) path drops into the marked slot without restructuring.
+
+package mlx
+
+// #cgo LDFLAGS: -ldl
+// #include <dlfcn.h>
+// #include <stdlib.h>
+//
+// typedef int (*range_push_t)(const char *);
+// typedef int (*range_pop_t)(void);
+//
+// static range_push_t _range_push = NULL;
+// static range_pop_t  _range_pop  = NULL;
+// static int          _markers_tried = 0;
+//
+// // load_markers resolves a push/pop marker pair the first time it is called.
+// // Returns 1 if markers are available, 0 otherwise.
+// static int load_markers(void) {
+//     if (_markers_tried) {
+//         return _range_push != NULL && _range_pop != NULL;
+//     }
+//     _markers_tried = 1;
+//
+//     // CUDA: NVTX (captured by Nsight Systems).
+//     void *h = dlopen("libnvToolsExt.so.1", RTLD_NOW | RTLD_GLOBAL);
+//     if (h == NULL) {
+//         h = dlopen("libnvToolsExt.so", RTLD_NOW | RTLD_GLOBAL);
+//     }
+//     if (h != NULL) {
+//         _range_push = (range_push_t)dlsym(h, "nvtxRangePushA");
+//         _range_pop  = (range_pop_t)dlsym(h, "nvtxRangePop");
+//         if (_range_push != NULL && _range_pop != NULL) {
+//             return 1;
+//         }
+//     }
+//
+//     // Future ROCm slot: dlopen("libroctx64.so") + roctxRangePushA/roctxRangePop
+//     // (captured by rocprofv3). Not implemented yet.
+//
+//     _range_push = NULL;
+//     _range_pop  = NULL;
+//     return 0;
+// }
+//
+// static void marker_push(const char *msg) {
+//     if (load_markers()) {
+//         _range_push(msg);
+//     }
+// }
+//
+// static void marker_pop(void) {
+//     if (load_markers()) {
+//         _range_pop();
+//     }
+// }
+import "C"
+
+import "unsafe"
+
+func profileRangePush(name string) {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	C.marker_push(cName)
+}
+
+func profileRangePop() {
+	C.marker_pop()
+}

--- a/x/mlxrunner/mlx/profile_other.go
+++ b/x/mlxrunner/mlx/profile_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin && !linux
+
+package mlx
+
+func profileRangePush(string) {}
+
+func profileRangePop() {}

--- a/x/mlxrunner/mtp.go
+++ b/x/mlxrunner/mtp.go
@@ -581,7 +581,7 @@ func (r *Runner) acceptMTPDraftsBatched(ctx context.Context, request Request, se
 			break
 		}
 		accepted++
-		if r.Tokenizer.IsEOS(int32(id)) {
+		if !request.IgnoreEOS && r.Tokenizer.IsEOS(int32(id)) {
 			done = true
 			break
 		}
@@ -660,7 +660,7 @@ func (r *Runner) acceptSampleMTPDrafts(ctx context.Context, request Request, ses
 	done := false
 	for i, id := range draftIDs[:accepted] {
 		commitIDs = append(commitIDs, int32(id))
-		if r.Tokenizer.IsEOS(int32(id)) {
+		if !request.IgnoreEOS && r.Tokenizer.IsEOS(int32(id)) {
 			done = true
 			accepted = i + 1
 			commitIDs = commitIDs[:accepted]
@@ -892,7 +892,7 @@ func (r *Runner) emitMTPToken(ctx context.Context, request Request, session *cac
 	output := int32(tokenID(res.Token))
 	session.outputs = append(session.outputs, output)
 
-	if r.Tokenizer.IsEOS(output) {
+	if !request.IgnoreEOS && r.Tokenizer.IsEOS(output) {
 		final.DoneReason = 0
 		return true, nil
 	}

--- a/x/mlxrunner/pipeline.go
+++ b/x/mlxrunner/pipeline.go
@@ -38,9 +38,11 @@ func (r *Runner) Prepare(request *Request) error {
 		return fmt.Errorf("input length (%d tokens) exceeds the model's maximum context length (%d tokens)", len(tokens), r.contextLength)
 	}
 
-	// Cap generation to stay within the model's context length
+	// Cap generation to stay within the model's context length. A negative
+	// num_predict (the default is -1) means "generate to the context limit";
+	// zero is preserved and means prefill-only (no decode) for profiling.
 	maxGenerate := r.contextLength - len(tokens)
-	if request.Options.NumPredict <= 0 {
+	if request.Options.NumPredict < 0 {
 		request.Options.NumPredict = maxGenerate
 	} else {
 		request.Options.NumPredict = min(request.Options.NumPredict, maxGenerate)
@@ -107,6 +109,7 @@ func (r *Runner) TextGenerationPipeline(ctx context.Context, request Request) er
 	now := time.Now()
 	total, processed := len(tokens), 0
 	position := len(inputs) - len(tokens)
+	mlx.ProfileRangePush("prefill")
 	for total-processed > 1 {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -144,6 +147,27 @@ func (r *Runner) TextGenerationPipeline(ctx context.Context, request Request) er
 
 		mlx.ClearCache()
 	}
+	mlx.ProfileRangePop() // prefill
+
+	// Prefill-only (num_predict==0): materialize the prompt's KV state so the
+	// prefill compute actually executes under a profiler, then stop before any
+	// decode or sampling. This yields a clean, single-phase prefill capture.
+	if request.Options.NumPredict == 0 {
+		materializeCaches()
+		final := CompletionResponse{
+			Done:               true,
+			DoneReason:         1,
+			PromptEvalCount:    len(inputs),
+			PromptEvalDuration: time.Since(now),
+			EvalCount:          0,
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case request.Responses <- final:
+			return nil
+		}
+	}
 
 	// Register the sampler after prefill completes.
 	r.Sampler.Add(pipelineSlot, request.SamplerOpts, inputs)
@@ -171,6 +195,7 @@ func (r *Runner) TextGenerationPipeline(ctx context.Context, request Request) er
 		return sample
 	}
 
+	mlx.ProfileRangePush("decode")
 	sample = step(mlx.FromValues(tokens[processed:], 1, total-processed))
 	logutil.TraceContext(ctx, "mlx decode seed", "tokens", total-processed, "memory", mlx.Memory{})
 
@@ -200,7 +225,7 @@ func (r *Runner) TextGenerationPipeline(ctx context.Context, request Request) er
 			logutil.TraceContext(ctx, "mlx decode first token", "memory", mlx.Memory{})
 		}
 
-		if r.Tokenizer.IsEOS(output) {
+		if !request.IgnoreEOS && r.Tokenizer.IsEOS(output) {
 			final.DoneReason = 0
 			final.EvalCount = i
 			break
@@ -221,6 +246,7 @@ func (r *Runner) TextGenerationPipeline(ctx context.Context, request Request) er
 			mlx.ClearCache()
 		}
 	}
+	mlx.ProfileRangePop() // decode
 
 	final.EvalDuration = time.Since(now)
 	select {

--- a/x/mlxrunner/server.go
+++ b/x/mlxrunner/server.go
@@ -26,13 +26,17 @@ func Execute(args []string) error {
 	var (
 		modelName string
 		port      int
+		profile   bool
 	)
 
 	flagSet := flag.NewFlagSet("mlxrunner", flag.ExitOnError)
 	flagSet.StringVar(&modelName, "model", "", "Model name")
 	flagSet.IntVar(&port, "port", 0, "Port to listen on")
+	flagSet.BoolVar(&profile, "profile", false, "Emit GPU profiler phase markers (os_signpost/NVTX) around prefill and decode")
 	_ = flagSet.Bool("verbose", false, "Enable debug logging")
 	flagSet.Parse(args)
+
+	mlx.SetProfilingEnabled(profile)
 
 	worker, err := mlxthread.Start("mlxrunner", func() error {
 		if err := mlx.CheckInit(); err != nil {

--- a/x/mlxrunner/wire/wire.go
+++ b/x/mlxrunner/wire/wire.go
@@ -1,0 +1,45 @@
+// Package wire defines the HTTP wire types exchanged between the MLX runner
+// subprocess and its callers (the ollama server's mlxrunner.Client, and the
+// cmd/bench profiling driver). It is deliberately free of any cgo/MLX
+// dependency so lightweight tools can import the request/response shapes
+// without pulling in the MLX runtime. The runner package re-exports these as
+// type aliases, so this package is the single source of truth.
+package wire
+
+import (
+	"time"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/llm"
+)
+
+// CompletionRequest is the JSON body for POST /v1/completions. Fields use Go
+// names on the wire (the runner decodes with stdlib JSON and no struct tags).
+type CompletionRequest struct {
+	Prompt      string
+	Options     api.Options
+	Logprobs    bool
+	TopLogprobs int
+
+	// IgnoreEOS disables stop-token handling so generation runs for the full
+	// requested num_predict. Used by profiling/benchmark drivers to get an
+	// exact, attributable number of decode passes. The ollama server never
+	// sets it, so production behavior is unchanged.
+	IgnoreEOS bool
+}
+
+// CompletionResponse is one JSONL record streamed from /v1/completions.
+type CompletionResponse struct {
+	Content    string
+	Done       bool
+	DoneReason int
+
+	PromptEvalCount    int
+	PromptEvalDuration time.Duration
+	EvalCount          int
+	EvalDuration       time.Duration
+
+	Logprobs []llm.Logprob
+
+	Error *api.StatusError
+}


### PR DESCRIPTION
This enhances the bench.go tool to support running against the underlying runners directly (mlx runner or llama-server) to make it easier to gather profiling data from backend GPU tooling.  You can now start the runner manually (under a profiler) and then specify  -runner host:port, or use -spawn to start the runner directly from the bench.go process.

The MLX runner is refined to support num_predict=0 to make it easier to separate prompt profiling from generate.  (-1 still indicates unlimited generation tokens.) A new -profile flag is added to the runner to enable additional profiling logic to avoid slowing sown normal hot-path.