### PR TITLE
refactor: extract shared file/path utilities into internal/fileutil

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -5,13 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"slices"
 	"strings"
+
+	"github.com/ollama/ollama/internal/fileutil"
 
 	"github.com/spf13/cobra"
 
@@ -582,43 +582,13 @@ func NewCreateRequest(name string, opts runOptions) *api.CreateRequest {
 	return req
 }
 
-func normalizeFilePath(fp string) string {
-	return strings.NewReplacer(
-		"\\ ", " ", // Escaped space
-		"\\(", "(", // Escaped left parenthesis
-		"\\)", ")", // Escaped right parenthesis
-		"\\[", "[", // Escaped left square bracket
-		"\\]", "]", // Escaped right square bracket
-		"\\{", "{", // Escaped left curly brace
-		"\\}", "}", // Escaped right curly brace
-		"\\$", "$", // Escaped dollar sign
-		"\\&", "&", // Escaped ampersand
-		"\\;", ";", // Escaped semicolon
-		"\\'", "'", // Escaped single quote
-		"\\\\", "\\", // Escaped backslash
-		"\\*", "*", // Escaped asterisk
-		"\\?", "?", // Escaped question mark
-		"\\~", "~", // Escaped tilde
-	).Replace(fp)
-}
-
-func extractFileNames(input string) []string {
-	// Regex to match file paths starting with optional drive letter, / ./ \ or .\ and include escaped or unescaped spaces (\ or %20)
-	// and followed by more characters and a file extension
-	// This will capture non filename strings, but we'll check for file existence to remove mismatches
-	regexPattern := `(?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp|wav)\b`
-	re := regexp.MustCompile(regexPattern)
-
-	return re.FindAllString(input, -1)
-}
-
 func extractFileData(input string) (string, []api.ImageData, error) {
-	filePaths := extractFileNames(input)
+	filePaths := fileutil.ExtractFileNames(input)
 	var imgs []api.ImageData
 
 	for _, fp := range filePaths {
-		nfp := normalizeFilePath(fp)
-		data, err := getImageData(nfp)
+		nfp := fileutil.NormalizeFilePath(fp)
+		data, err := fileutil.GetImageData(nfp)
 		if errors.Is(err, os.ErrNotExist) {
 			continue
 		} else if err != nil {
@@ -626,12 +596,8 @@ func extractFileData(input string) (string, []api.ImageData, error) {
 			return "", imgs, err
 		}
 		ext := strings.ToLower(filepath.Ext(nfp))
-		switch ext {
-		case ".wav":
-			fmt.Fprintf(os.Stderr, "Added audio '%s'\n", nfp)
-		default:
-			fmt.Fprintf(os.Stderr, "Added image '%s'\n", nfp)
-		}
+		mediaType := fileutil.GetMediaType(ext)
+		fmt.Fprintf(os.Stderr, "Added %s '%s'\n", mediaType, nfp)
 		input = strings.ReplaceAll(input, "'"+nfp+"'", "")
 		input = strings.ReplaceAll(input, "'"+fp+"'", "")
 		input = strings.ReplaceAll(input, fp, "")
@@ -691,45 +657,4 @@ func editInExternalEditor(content string) (string, error) {
 	return strings.TrimRight(string(data), "\n"), nil
 }
 
-func getImageData(filePath string) ([]byte, error) {
-	file, err := os.Open(filePath)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
 
-	buf := make([]byte, 512)
-	_, err = file.Read(buf)
-	if err != nil {
-		return nil, err
-	}
-
-	contentType := http.DetectContentType(buf)
-	allowedTypes := []string{"image/jpeg", "image/jpg", "image/png", "image/webp", "audio/wave"}
-	if !slices.Contains(allowedTypes, contentType) {
-		return nil, fmt.Errorf("invalid file type: %s", contentType)
-	}
-
-	info, err := file.Stat()
-	if err != nil {
-		return nil, err
-	}
-
-	var maxSize int64 = 100 * 1024 * 1024 // 100MB
-	if info.Size() > maxSize {
-		return nil, errors.New("file size exceeds maximum limit (100MB)")
-	}
-
-	buf = make([]byte, info.Size())
-	_, err = file.Seek(0, 0)
-	if err != nil {
-		return nil, err
-	}
-
-	_, err = io.ReadFull(file, buf)
-	if err != nil {
-		return nil, err
-	}
-
-	return buf, nil
-}

--- a/internal/fileutil/fileutil.go
+++ b/internal/fileutil/fileutil.go
@@ -1,0 +1,96 @@
+package fileutil
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+)
+
+// NormalizeFilePath unescapes shell escape sequences and URL-encoded spaces.
+func NormalizeFilePath(fp string) string {
+	return strings.NewReplacer(
+		"\\ ", " ",
+		"\\(", "(",
+		"\\)", ")",
+		"\\[", "[",
+		"\\]", "]",
+		"\\{", "{",
+		"\\}", "}",
+		"\\$", "$",
+		"\\&", "&",
+		"\\;", ";",
+		"\\'", "'",
+		"\\\\", "\\",
+		"\\*", "*",
+		"\\?", "?",
+		"\\~", "~",
+		"%20", " ",
+	).Replace(fp)
+}
+
+// ExtractFileNames extracts file paths from input string using a regex pattern.
+func ExtractFileNames(input string) []string {
+	regexPattern := `(?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp|wav)\b`
+	re := regexp.MustCompile(regexPattern)
+	return re.FindAllString(input, -1)
+}
+
+// GetImageData reads and validates image/audio data from a file.
+func GetImageData(filePath string) ([]byte, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	buf := make([]byte, 512)
+	_, err = file.Read(buf)
+	if err != nil {
+		return nil, err
+	}
+
+	contentType := http.DetectContentType(buf)
+	allowedTypes := []string{"image/jpeg", "image/jpg", "image/png", "image/webp", "audio/wave"}
+	if !slices.Contains(allowedTypes, contentType) {
+		return nil, fmt.Errorf("invalid file type: %s", contentType)
+	}
+
+	info, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	var maxSize int64 = 100 * 1024 * 1024
+	if info.Size() > maxSize {
+		return nil, errors.New("file size exceeds maximum limit (100MB)")
+	}
+
+	buf = make([]byte, info.Size())
+	_, err = file.Seek(0, io.SeekStart)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = io.ReadFull(file, buf)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf, nil
+}
+
+// GetMediaType returns the media type label for display purposes.
+func GetMediaType(ext string) string {
+	switch strings.ToLower(ext) {
+	case ".wav":
+		return "audio"
+	default:
+		return "image"
+	}
+}

--- a/x/imagegen/cli.go
+++ b/x/imagegen/cli.go
@@ -10,13 +10,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
-	"regexp"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/ollama/ollama/internal/fileutil"
 
 	"github.com/spf13/cobra"
 
@@ -517,28 +516,15 @@ func displayImageInTerminal(imagePath string) bool {
 	}
 }
 
-// extractFileNames finds image file paths in the input string.
-func extractFileNames(input string) []string {
-	// Regex to match file paths with image extensions
-	regexPattern := `(?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp)\b`
-	re := regexp.MustCompile(regexPattern)
-	return re.FindAllString(input, -1)
-}
-
 // extractFileData extracts image data from file paths found in the input.
 // Returns the cleaned prompt (with file paths removed) and the image data.
 func extractFileData(input string) (string, []api.ImageData, error) {
-	filePaths := extractFileNames(input)
+	filePaths := fileutil.ExtractFileNames(input)
 	var imgs []api.ImageData
 
 	for _, fp := range filePaths {
-		// Normalize shell escapes
-		nfp := strings.ReplaceAll(fp, "\\ ", " ")
-		nfp = strings.ReplaceAll(nfp, "\\(", "(")
-		nfp = strings.ReplaceAll(nfp, "\\)", ")")
-		nfp = strings.ReplaceAll(nfp, "%20", " ")
-
-		data, err := getImageData(nfp)
+		nfp := fileutil.NormalizeFilePath(fp)
+		data, err := fileutil.GetImageData(nfp)
 		if errors.Is(err, os.ErrNotExist) {
 			continue
 		} else if err != nil {
@@ -549,28 +535,4 @@ func extractFileData(input string) (string, []api.ImageData, error) {
 		imgs = append(imgs, data)
 	}
 	return strings.TrimSpace(input), imgs, nil
-}
-
-// getImageData reads and validates image data from a file.
-func getImageData(filePath string) ([]byte, error) {
-	file, err := os.Open(filePath)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-
-	buf := make([]byte, 512)
-	_, err = file.Read(buf)
-	if err != nil {
-		return nil, err
-	}
-
-	contentType := http.DetectContentType(buf)
-	allowedTypes := []string{"image/jpeg", "image/jpg", "image/png", "image/webp"}
-	if !slices.Contains(allowedTypes, contentType) {
-		return nil, fmt.Errorf("invalid image type: %s", contentType)
-	}
-
-	// Re-read the full file
-	return os.ReadFile(filePath)
 }


### PR DESCRIPTION
Extract , , , and the media-type display logic from  and  into a shared  package.

**Changes**
- New  with four exported functions: , , , 
- : removed ~60 lines of duplicate functions, now calls  instead
- : removed ~65 lines of duplicate functions, now calls  instead; also gains the  tilde escape not previously handled in this file

**Behavior preserved**
-  handles the same shell escape sequences (, , , , , , , , , , , , , , ) plus 
- File type validation and 100MB size limit unchanged
- Audio file detection () and display messaging preserved via 