### PR TITLE
app: notify the user when the server can't start due to a port conflict

### DIFF
--- a/app/cmd/app/app.go
+++ b/app/cmd/app/app.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/ollama/ollama/app/auth"
+	"github.com/ollama/ollama/app/dialog"
 	"github.com/ollama/ollama/app/logrotate"
 	"github.com/ollama/ollama/app/server"
 	"github.com/ollama/ollama/app/store"
@@ -246,6 +247,13 @@ func main() {
 	wv.Store = st
 	done := make(chan error, 1)
 	osrv := server.New(st, devMode)
+	osrv.NotifyPortConflict = func(addr string) {
+		dialog.Message(
+			"Ollama can't start because the address %s is already in use by another "+
+				"application.\n\nQuit the other application (or change OLLAMA_HOST) and Ollama "+
+				"will start automatically.", addr,
+		).Title("Ollama").Error()
+	}
 	go func() {
 		slog.Info("starting ollama server")
 		done <- osrv.Run(octx)

--- a/app/server/server.go
+++ b/app/server/server.go
@@ -235,6 +235,9 @@ func (s *Server) Run(ctx context.Context) error {
 // returns false so the caller can log it normally.
 func (s *Server) handlePortConflict(err error, reaped, notified *bool) bool {
 	var exitErr *exec.ExitError
+	// Skip anything that isn't an exit-1 (bind) failure. Also skip in dev mode:
+	// the developer typically runs their own ollama server (see app/README.md),
+	// so reaping it or showing a conflict dialog would be disruptive.
 	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 || s.dev {
 		return false
 	}
@@ -254,12 +257,13 @@ func (s *Server) handlePortConflict(err error, reaped, notified *bool) bool {
 	}
 
 	// First time: a stale ollama process may hold the port. Reap it and retry
-	// before bothering the user.
+	// before bothering the user. Only mark it reaped on success so a failed
+	// reap is retried on the next restart attempt rather than silently skipped.
 	if !*reaped {
-		*reaped = true
 		if reapErr := reapServers(); reapErr != nil {
-			slog.Warn("failed to stop existing ollama server", "err", reapErr)
+			slog.Warn("failed to stop existing ollama server, will retry", "err", reapErr)
 		} else {
+			*reaped = true
 			slog.Debug("conflicting server stopped, waiting for port to be released")
 			return true
 		}

--- a/app/server/server.go
+++ b/app/server/server.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -20,6 +21,7 @@ import (
 
 	"github.com/ollama/ollama/app/logrotate"
 	"github.com/ollama/ollama/app/store"
+	"github.com/ollama/ollama/envconfig"
 )
 
 const restartDelay = time.Second
@@ -30,6 +32,11 @@ type Server struct {
 	bin   string // resolved path to `ollama`
 	log   io.WriteCloser
 	dev   bool // true if running with the dev flag
+
+	// NotifyPortConflict, if set, is called when ollama cannot start because
+	// addr is already in use by another process. It is invoked once per
+	// conflict so the app can surface the problem to the user.
+	NotifyPortConflict func(addr string)
 }
 
 type InferenceCompute struct {
@@ -188,6 +195,7 @@ func (s *Server) Run(ctx context.Context) error {
 	}
 
 	reaped := false
+	notified := false
 	for ctx.Err() == nil {
 		select {
 		case <-ctx.Done():
@@ -210,21 +218,68 @@ func (s *Server) Run(ctx context.Context) error {
 		}
 
 		if err = cmd.Wait(); err != nil && !errors.Is(err, context.Canceled) {
-			var exitErr *exec.ExitError
-			if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 && !s.dev && !reaped {
-				reaped = true
-				// This could be a port conflict, try to kill any existing ollama processes
-				if err := reapServers(); err != nil {
-					slog.Warn("failed to stop existing ollama server", "err", err)
-				} else {
-					slog.Debug("conflicting server stopped, waiting for port to be released")
-					continue
-				}
+			if s.handlePortConflict(err, &reaped, &notified) {
+				continue
 			}
 			slog.Error("ollama exited", "err", err)
 		}
 	}
 	return ctx.Err()
+}
+
+// handlePortConflict inspects a non-canceled cmd.Wait error and, when it is
+// caused by the configured address already being in use, handles it and
+// reports true (the caller should retry). The first conflict reaps a stale
+// ollama process; a persisting conflict means a foreign process holds the port,
+// so the user is notified once via NotifyPortConflict. Any other failure
+// returns false so the caller can log it normally.
+func (s *Server) handlePortConflict(err error, reaped, notified *bool) bool {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 || s.dev {
+		return false
+	}
+
+	// Our child has already exited, so a failed bind proves a foreign process
+	// holds the address rather than our own (just-exited) server.
+	addr, inUse := addrInUse()
+	if !inUse {
+		return false
+	}
+
+	// First time: a stale ollama process may hold the port. Reap it and retry
+	// before bothering the user.
+	if !*reaped {
+		*reaped = true
+		if reapErr := reapServers(); reapErr != nil {
+			slog.Warn("failed to stop existing ollama server", "err", reapErr)
+		} else {
+			slog.Debug("conflicting server stopped, waiting for port to be released")
+			return true
+		}
+	}
+
+	// Still in use after reaping → a foreign process holds the port. Tell the
+	// user once, then keep retrying quietly so we recover automatically once the
+	// port is freed.
+	slog.Error("ollama cannot start: address already in use", "addr", addr)
+	if !*notified && s.NotifyPortConflict != nil {
+		*notified = true
+		s.NotifyPortConflict(addr)
+	}
+	return true
+}
+
+// addrInUse reports the configured ollama address and whether it is already
+// bound by another process. It returns true only when a bind attempt fails
+// specifically because the address is in use — not for other errors.
+func addrInUse() (string, bool) {
+	addr := envconfig.Host().Host
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return addr, isAddrInUse(err)
+	}
+	_ = ln.Close()
+	return addr, false
 }
 
 func (s *Server) cmd(ctx context.Context) (*exec.Cmd, error) {

--- a/app/server/server.go
+++ b/app/server/server.go
@@ -239,9 +239,16 @@ func (s *Server) handlePortConflict(err error, reaped, notified *bool) bool {
 		return false
 	}
 
-	// Our child has already exited, so a failed bind proves a foreign process
-	// holds the address rather than our own (just-exited) server.
-	addr, inUse := addrInUse()
+	// Probe the address the child actually binds, which depends on the Expose
+	// setting (see cmd). Our child has already exited, so a failed bind proves a
+	// foreign process holds the address rather than our own (just-exited) server.
+	expose := false
+	if settings, err := s.store.Settings(); err != nil {
+		slog.Warn("failed to load settings for port conflict check", "err", err)
+	} else {
+		expose = settings.Expose
+	}
+	addr, inUse := addrInUse(expose)
 	if !inUse {
 		return false
 	}
@@ -269,11 +276,18 @@ func (s *Server) handlePortConflict(err error, reaped, notified *bool) bool {
 	return true
 }
 
-// addrInUse reports the configured ollama address and whether it is already
-// bound by another process. It returns true only when a bind attempt fails
-// specifically because the address is in use — not for other errors.
-func addrInUse() (string, bool) {
+// addrInUse reports the address the child server binds and whether it is
+// already bound by another process. When expose is set the child binds all
+// interfaces (0.0.0.0), matching cmd, so we probe that instead of the
+// configured host. It returns true only when a bind attempt fails specifically
+// because the address is in use — not for other errors.
+func addrInUse(expose bool) (string, bool) {
 	addr := envconfig.Host().Host
+	if expose {
+		if _, port, err := net.SplitHostPort(addr); err == nil {
+			addr = net.JoinHostPort("0.0.0.0", port)
+		}
+	}
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
 		return addr, isAddrInUse(err)

--- a/app/server/server_test.go
+++ b/app/server/server_test.go
@@ -4,6 +4,7 @@ package server
 
 import (
 	"context"
+	"net"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -13,6 +14,42 @@ import (
 
 	"github.com/ollama/ollama/app/store"
 )
+
+func TestAddrInUse(t *testing.T) {
+	// Occupy a port so we can assert addrInUse detects the conflict.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	defer ln.Close()
+	busy := ln.Addr().String()
+
+	t.Run("in use", func(t *testing.T) {
+		t.Setenv("OLLAMA_HOST", busy)
+		addr, inUse := addrInUse()
+		if !inUse {
+			t.Errorf("expected addr %s to be reported in use", busy)
+		}
+		if addr != busy {
+			t.Errorf("addr = %q, want %q", addr, busy)
+		}
+	})
+
+	t.Run("free", func(t *testing.T) {
+		// Grab a port then release it so it is free when we probe.
+		free, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("failed to listen: %v", err)
+		}
+		addr := free.Addr().String()
+		free.Close()
+
+		t.Setenv("OLLAMA_HOST", addr)
+		if _, inUse := addrInUse(); inUse {
+			t.Errorf("expected addr %s to be free", addr)
+		}
+	})
+}
 
 func TestNew(t *testing.T) {
 	tmpDir := t.TempDir()

--- a/app/server/server_test.go
+++ b/app/server/server_test.go
@@ -26,12 +26,25 @@ func TestAddrInUse(t *testing.T) {
 
 	t.Run("in use", func(t *testing.T) {
 		t.Setenv("OLLAMA_HOST", busy)
-		addr, inUse := addrInUse()
+		addr, inUse := addrInUse(false)
 		if !inUse {
 			t.Errorf("expected addr %s to be reported in use", busy)
 		}
 		if addr != busy {
 			t.Errorf("addr = %q, want %q", addr, busy)
+		}
+	})
+
+	t.Run("expose probes all interfaces", func(t *testing.T) {
+		// With expose the child binds 0.0.0.0, so addrInUse must probe the
+		// wildcard address rather than the configured host.
+		_, port, err := net.SplitHostPort(busy)
+		if err != nil {
+			t.Fatalf("split host port: %v", err)
+		}
+		t.Setenv("OLLAMA_HOST", net.JoinHostPort("127.0.0.1", port))
+		if addr, _ := addrInUse(true); addr != net.JoinHostPort("0.0.0.0", port) {
+			t.Errorf("addr = %q, want %q", addr, net.JoinHostPort("0.0.0.0", port))
 		}
 	})
 
@@ -45,7 +58,7 @@ func TestAddrInUse(t *testing.T) {
 		free.Close()
 
 		t.Setenv("OLLAMA_HOST", addr)
-		if _, inUse := addrInUse(); inUse {
+		if _, inUse := addrInUse(false); inUse {
 			t.Errorf("expected addr %s to be free", addr)
 		}
 	})

--- a/app/server/server_unix.go
+++ b/app/server/server_unix.go
@@ -24,6 +24,12 @@ func commandContext(ctx context.Context, name string, arg ...string) *exec.Cmd {
 	return exec.CommandContext(ctx, name, arg...)
 }
 
+// isAddrInUse reports whether err is the "address already in use" error
+// returned by net.Listen when the port is held by another process.
+func isAddrInUse(err error) bool {
+	return errors.Is(err, syscall.EADDRINUSE)
+}
+
 func terminate(proc *os.Process) error {
 	return proc.Signal(os.Interrupt)
 }

--- a/app/server/server_windows.go
+++ b/app/server/server_windows.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -27,6 +28,13 @@ func commandContext(ctx context.Context, name string, arg ...string) *exec.Cmd {
 	}
 
 	return cmd
+}
+
+// isAddrInUse reports whether err is the "address already in use" error
+// returned by net.Listen when the port is held by another process. On Windows
+// the socket error is WSAEADDRINUSE.
+func isAddrInUse(err error) bool {
+	return errors.Is(err, syscall.WSAEADDRINUSE) || errors.Is(err, syscall.EADDRINUSE)
 }
 
 func terminate(proc *os.Process) error {


### PR DESCRIPTION
## Problem

Fixes #13923.

On macOS the desktop app gets stuck on **"Loading…"** indefinitely when another process is already bound to the ollama address (default `127.0.0.1:11434`). The CLI/API keep working, but the app gives no indication of why it's stuck — users have to manually tail `~/.ollama/logs/server.log` to discover the port conflict.

The app supervises `ollama serve` in a restart loop and already reaps a *stale ollama* process on exit code 1. But when a **non-ollama** process holds the port, `reapServers()` finds nothing to kill, so the loop silently restarts forever and the UI never leaves "Loading…".

## Fix

Detect a port conflict and tell the user, while leaving every other startup failure untouched:

- After the supervised server exits with code 1, probe the configured address with `net.Listen`. Because our own child has already exited, a bind that fails with `EADDRINUSE` proves a **foreign** process holds the port (`addrInUse()` + platform-specific `isAddrInUse`).
- On a confirmed conflict: reap a stale ollama once (existing behavior), and if the port is still held, surface a **native error dialog** once via a new `Server.NotifyPortConflict` callback, then keep retrying quietly so the server **recovers automatically** when the port is freed.
- Any other exit-1 cause falls through to the existing `ollama exited` log path — **no dialog**.

The supervisor stays UI-agnostic (exposes a callback; the dialog is wired in `app/cmd/app/app.go`), which keeps the restart logic unit-testable.

## Testing

- `go test ./app/server/` — added `TestAddrInUse` covering the in-use and free cases.
- Manual (macOS): occupied `11434` with a non-ollama listener, launched the app → native dialog named the in-use address and the log showed `address already in use`; freeing the port let the server recover with no further popups.
- Negative case: forced a non-port exit-1 (bind to an unassigned address) → no dialog, only the normal `ollama exited` log.