### PR TITLE
[codex] request authorization for macOS app updates

### DIFF
--- a/app/updater/updater_darwin.go
+++ b/app/updater/updater_darwin.go
@@ -32,8 +32,10 @@ const (
 )
 
 var (
-	appBackupDir   string
-	SystemWidePath = "/Applications/Ollama.app"
+	appBackupDir                   string
+	SystemWidePath                 = "/Applications/Ollama.app"
+	renameBundle                   = os.Rename
+	replaceBundleWithAuthorization = replaceBundleWithAuthorizationNative
 )
 
 var BundlePath = func() string {
@@ -130,23 +132,21 @@ func DoUpgrade(interactive bool) error {
 	defer r.Close()
 
 	slog.Debug("temporarily staging old version", "staging", appBackup)
-	if err := os.Rename(BundlePath, appBackup); err != nil {
+	if err := renameBundle(BundlePath, appBackup); err != nil {
 		if !interactive {
 			// We don't want to prompt for permission if we're attempting to upgrade at startup
 			return fmt.Errorf("unable to upgrade in non-interactive mode with permission problems: %w", err)
 		}
-		// TODO actually inspect the error and look for permission problems before trying chown
-		slog.Warn("unable to backup old version due to permission problems, changing ownership", "error", err)
-		u, err := user.Current()
-		if err != nil {
-			return err
-		}
-		if !chownWithAuthorization(u.Username) {
-			return fmt.Errorf("unable to change permissions to complete upgrade")
-		}
-		if err := os.Rename(BundlePath, appBackup); err != nil {
+		if !isPermissionProblem(err) {
 			return fmt.Errorf("unable to perform upgrade - failed to stage old version: %w", err)
 		}
+
+		slog.Warn("unable to backup old version due to permission problems, requesting authorization", "error", err)
+		if err := doUpgradeWithAuthorization(r.File, appBackup); err != nil {
+			return err
+		}
+		completeUpgrade()
+		return nil
 	}
 
 	// Get ready to try to unwind a partial upgade failure during unzip
@@ -160,100 +160,30 @@ func DoUpgrade(interactive bool) error {
 				// At this point, we're basically hosed and the user will need to re-install
 				return
 			}
-			if err := os.Rename(appBackup, BundlePath); err != nil {
+			if err := renameBundle(appBackup, BundlePath); err != nil {
 				slog.Error("failed to revert to prior version", "path", contentsName, "error", err)
 			}
 		}
 	}()
 
-	// Bundle contents Ollama.app/Contents/...
-	links := []*zip.File{}
-	for _, f := range r.File {
-		s := strings.SplitN(f.Name, "/", 2)
-		if len(s) < 2 || s[1] == "" {
-			slog.Debug("skipping", "file", f.Name)
-			continue
-		}
-		name := s[1]
-		if strings.HasSuffix(name, "/") {
-			d, err := bundleEntryPath(BundlePath, name, bundleEntryRelative)
-			if err != nil {
-				anyFailures = true
-				return err
-			}
-			err = os.MkdirAll(d, 0o755)
-			if err != nil {
-				anyFailures = true
-				return fmt.Errorf("failed to mkdir %s: %w", d, err)
-			}
-			continue
-		}
-		if f.Mode()&os.ModeSymlink != 0 {
-			// Defer links to the end
-			links = append(links, f)
-			continue
-		}
-
-		destName, err := bundleEntryPath(BundlePath, name, bundleEntryRelative)
-		if err != nil {
-			anyFailures = true
-			return err
-		}
-		if err := extractBundleFile(f, destName, name); err != nil {
-			anyFailures = true
-			return err
-		}
-	}
-	for _, f := range links {
-		s := strings.SplitN(f.Name, "/", 2) // Strip off Ollama.app/
-		if len(s) < 2 || s[1] == "" {
-			slog.Debug("skipping link", "file", f.Name)
-			continue
-		}
-		name := s[1]
-		src, err := f.Open()
-		if err != nil {
-			anyFailures = true
-			return err
-		}
-		buf, err := io.ReadAll(src)
-		if err != nil {
-			anyFailures = true
-			return err
-		}
-		link := string(buf)
-		if link == "" {
-			anyFailures = true
-			return fmt.Errorf("bundle contains empty symlink %s", f.Name)
-		}
-		if filepath.IsAbs(link) {
-			anyFailures = true
-			return fmt.Errorf("bundle contains absolute symlink %s -> %s", f.Name, link)
-		}
-		if !validBundleLinkTarget(name, link, bundleEntryRelative) {
-			anyFailures = true
-			return fmt.Errorf("bundle contains invalid symlink %s -> %s", f.Name, link)
-		}
-		destName, err := bundleEntryPath(BundlePath, name, bundleEntryRelative)
-		if err != nil {
-			anyFailures = true
-			return err
-		}
-		if err = os.Symlink(link, destName); err != nil {
-			anyFailures = true
-			return err
-		}
+	if err := extractUpdateBundle(r.File, BundlePath, bundleEntryRelative); err != nil {
+		anyFailures = true
+		return err
 	}
 
+	completeUpgrade()
+	return nil
+}
+
+func completeUpgrade() {
 	f, err := os.OpenFile(UpgradeMarkerFile, os.O_RDONLY|os.O_CREATE, 0o666)
 	if err != nil {
 		slog.Warn("unable to create marker file", "file", UpgradeMarkerFile, "error", err)
+	} else if err := f.Close(); err != nil {
+		slog.Warn("unable to close marker file", "file", UpgradeMarkerFile, "error", err)
 	}
-	f.Close()
 	// Make sure to remove the staged download now that we succeeded so we don't inadvertently try again.
 	cleanupOldDownloads(UpdateStageDir)
-
-	return nil
 }
 
 func DoPostUpgradeCleanup() error {
@@ -284,10 +214,55 @@ func verifyDownload() error {
 		return fmt.Errorf("unable to open upgrade bundle %s: %w", bundle, err)
 	}
 	defer r.Close()
+	if err := extractUpdateBundle(r.File, dir, bundleEntryWithArchiveRoot); err != nil {
+		return err
+	}
+
+	if err := verifyExtractedBundle(filepath.Join(dir, "Ollama.app")); err != nil {
+		return fmt.Errorf("signature verification failed: %s", err)
+	}
+	return nil
+}
+
+func doUpgradeWithAuthorization(files []*zip.File, appBackup string) error {
+	u, err := user.Current()
+	if err != nil {
+		return err
+	}
+	owner := u.Uid
+	if owner == "" {
+		owner = u.Username
+	}
+
+	stagingDir, err := os.MkdirTemp(appBackupDir, "authorized-update-")
+	if err != nil {
+		return fmt.Errorf("unable to create authorized update staging dir: %w", err)
+	}
+	defer os.RemoveAll(stagingDir)
+
+	if err := extractUpdateBundle(files, stagingDir, bundleEntryWithArchiveRoot); err != nil {
+		return err
+	}
+	stagedApp := filepath.Join(stagingDir, updateArchiveRoot)
+	if _, err := os.Stat(stagedApp); err != nil {
+		return fmt.Errorf("staged update is missing app bundle: %w", err)
+	}
+	if !replaceBundleWithAuthorization(stagedApp, appBackup, BundlePath, owner) {
+		return fmt.Errorf("unable to replace app bundle with authorization")
+	}
+	return nil
+}
+
+func extractUpdateBundle(files []*zip.File, root string, scope bundleEntryScope) error {
 	links := []*zip.File{}
-	for _, f := range r.File {
-		if strings.HasSuffix(f.Name, "/") {
-			d, err := bundleEntryPath(dir, f.Name, bundleEntryWithArchiveRoot)
+	for _, f := range files {
+		name, ok := bundleArchiveName(f.Name, scope)
+		if !ok {
+			slog.Debug("skipping", "file", f.Name)
+			continue
+		}
+		if strings.HasSuffix(name, "/") {
+			d, err := bundleEntryPath(root, name, scope)
 			if err != nil {
 				return err
 			}
@@ -298,24 +273,33 @@ func verifyDownload() error {
 			continue
 		}
 		if f.Mode()&os.ModeSymlink != 0 {
-			// Defer links to the end
+			// Defer links until their target files have been extracted.
 			links = append(links, f)
 			continue
 		}
-		destName, err := bundleEntryPath(dir, f.Name, bundleEntryWithArchiveRoot)
+
+		destName, err := bundleEntryPath(root, name, scope)
 		if err != nil {
 			return err
 		}
-		if err := extractBundleFile(f, destName, f.Name); err != nil {
+		if err := extractBundleFile(f, destName, name); err != nil {
 			return err
 		}
 	}
 	for _, f := range links {
+		name, ok := bundleArchiveName(f.Name, scope)
+		if !ok {
+			slog.Debug("skipping link", "file", f.Name)
+			continue
+		}
 		src, err := f.Open()
 		if err != nil {
 			return err
 		}
 		buf, err := io.ReadAll(src)
+		if closeErr := src.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
 		if err != nil {
 			return err
 		}
@@ -326,10 +310,10 @@ func verifyDownload() error {
 		if filepath.IsAbs(link) {
 			return fmt.Errorf("bundle contains absolute symlink %s -> %s", f.Name, link)
 		}
-		if !validBundleLinkTarget(f.Name, link, bundleEntryWithArchiveRoot) {
+		if !validBundleLinkTarget(name, link, scope) {
 			return fmt.Errorf("bundle contains invalid symlink %s -> %s", f.Name, link)
 		}
-		destName, err := bundleEntryPath(dir, f.Name, bundleEntryWithArchiveRoot)
+		destName, err := bundleEntryPath(root, name, scope)
 		if err != nil {
 			return err
 		}
@@ -337,11 +321,19 @@ func verifyDownload() error {
 			return err
 		}
 	}
-
-	if err := verifyExtractedBundle(filepath.Join(dir, "Ollama.app")); err != nil {
-		return fmt.Errorf("signature verification failed: %s", err)
-	}
 	return nil
+}
+
+func bundleArchiveName(name string, scope bundleEntryScope) (string, bool) {
+	if scope == bundleEntryWithArchiveRoot {
+		return name, true
+	}
+
+	parts := strings.SplitN(name, "/", 2)
+	if len(parts) < 2 || parts[1] == "" {
+		return "", false
+	}
+	return parts[1], true
 }
 
 func bundleEntryPath(root, name string, scope bundleEntryScope) (string, error) {
@@ -391,6 +383,12 @@ func validBundleLinkTarget(name, link string, scope bundleEntryScope) bool {
 		strings.HasPrefix(cleanTarget, updateArchiveRoot+string(os.PathSeparator))
 }
 
+func isPermissionProblem(err error) bool {
+	return errors.Is(err, os.ErrPermission) ||
+		errors.Is(err, syscall.EACCES) ||
+		errors.Is(err, syscall.EPERM)
+}
+
 // If we detect an upgrade bundle, attempt to upgrade at startup
 func DoUpgradeAtStartup() error {
 	bundle := getStagedUpdate()
@@ -435,6 +433,18 @@ func chownWithAuthorization(user string) bool {
 	u := C.CString(user)
 	defer C.free(unsafe.Pointer(u))
 	return (bool)(C.chownWithAuthorization(u))
+}
+
+func replaceBundleWithAuthorizationNative(stagedApp, backupApp, destApp, owner string) bool {
+	staged := C.CString(stagedApp)
+	defer C.free(unsafe.Pointer(staged))
+	backup := C.CString(backupApp)
+	defer C.free(unsafe.Pointer(backup))
+	dest := C.CString(destApp)
+	defer C.free(unsafe.Pointer(dest))
+	ownerName := C.CString(owner)
+	defer C.free(unsafe.Pointer(ownerName))
+	return (bool)(C.replaceBundleWithAuthorization(staged, backup, dest, ownerName))
 }
 
 func verifyExtractedBundle(path string) error {

--- a/app/updater/updater_darwin.h
+++ b/app/updater/updater_darwin.h
@@ -1,4 +1,5 @@
 #import <Cocoa/Cocoa.h>
+#import <Security/Security.h>
 
 // TODO make these macros so we can extract line numbers from the native code
 void appLogInfo(NSString *msg);
@@ -14,3 +15,5 @@ AuthorizationRef getAppInstallAuthorization();
 
 const char* verifyExtractedBundle(char *path);
 bool chownWithAuthorization(const char *user);
+bool replaceBundleWithAuthorization(const char *stagedApp, const char *backupApp,
+                                    const char *destApp, const char *owner);

--- a/app/updater/updater_darwin.m
+++ b/app/updater/updater_darwin.m
@@ -4,7 +4,7 @@
 #import <CoreServices/CoreServices.h>
 #import <Security/Security.h>
 #import <ServiceManagement/ServiceManagement.h>
-#import <sys/wait.h>
+#import <string.h>
 
 void appLogInfo(NSString *msg) {
     NSLog(@"%@", msg);
@@ -140,12 +140,15 @@ bool replaceBundleWithAuthorization(const char *stagedApp, const char *backupApp
         return NO;
     }
 
+    static const char *successMarker = "__OLLAMA_AUTHORIZED_UPDATE_SUCCESS__";
     static const char *script =
         "set -u\n"
+        "exec 2>&1\n"
         "staged=$1\n"
         "backup=$2\n"
         "dest=$3\n"
         "owner=$4\n"
+        "success_marker=$5\n"
         "if [ -e \"$backup\" ]; then\n"
         "  echo \"backup already exists: $backup\" >&2\n"
         "  exit 73\n"
@@ -154,6 +157,7 @@ bool replaceBundleWithAuthorization(const char *stagedApp, const char *backupApp
         "mv \"$dest\" \"$backup\" || exit 1\n"
         "if cp -pR \"$staged\" \"$dest\"; then\n"
         "  chown -R \"$owner\" \"$backup\" >/dev/null 2>&1 || true\n"
+        "  printf '%s\\n' \"$success_marker\"\n"
         "  exit 0\n"
         "fi\n"
         "status=$?\n"
@@ -163,16 +167,18 @@ bool replaceBundleWithAuthorization(const char *stagedApp, const char *backupApp
 
     const char *shellTool = "/bin/sh";
     const char *shellArgs[] = {"-c", script, "ollama-authorized-update",
-                               stagedApp, backupApp, destApp, owner, NULL};
+                               stagedApp, backupApp, destApp, owner,
+                               successMarker, NULL};
     appLogInfo([NSString
         stringWithFormat:@"requesting authorization to replace %@ from %@",
                          @(destApp), @(stagedApp)]);
 
+    FILE *pipe = NULL;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     OSStatus err = AuthorizationExecuteWithPrivileges(
         authRef, shellTool, kAuthorizationFlagDefaults,
-        (char *const *)shellArgs, NULL);
+        (char *const *)shellArgs, &pipe);
 #pragma clang diagnostic pop
 
     if (err != errAuthorizationSuccess) {
@@ -183,14 +189,29 @@ bool replaceBundleWithAuthorization(const char *stagedApp, const char *backupApp
         return NO;
     }
 
-    int status = 0;
-    pid_t pid = wait(&status);
+    BOOL succeeded = NO;
+    if (pipe != NULL) {
+        char line[4096];
+        while (fgets(line, sizeof(line), pipe) != NULL) {
+            line[strcspn(line, "\r\n")] = '\0';
+            appLogDebug([NSString
+                stringWithFormat:@"authorized update output: %s", line]);
+            if (strcmp(line, successMarker) == 0) {
+                succeeded = YES;
+            }
+        }
+        if (ferror(pipe)) {
+            appLogInfo(@"failed to read authorized update output");
+            succeeded = NO;
+        }
+        fclose(pipe);
+    } else {
+        appLogInfo(@"authorized update did not provide a completion pipe");
+    }
     AuthorizationFree(authRef, kAuthorizationFlagDestroyRights);
 
-    if (pid == -1 || !WIFEXITED(status) || WEXITSTATUS(status) != 0) {
-        appLogInfo([NSString
-            stringWithFormat:@"authorized update failed pid=%d exit=%d",
-                             pid, WIFEXITED(status) ? WEXITSTATUS(status) : -1]);
+    if (!succeeded) {
+        appLogInfo(@"authorized update failed or did not report success");
         return NO;
     }
 

--- a/app/updater/updater_darwin.m
+++ b/app/updater/updater_darwin.m
@@ -4,6 +4,7 @@
 #import <CoreServices/CoreServices.h>
 #import <Security/Security.h>
 #import <ServiceManagement/ServiceManagement.h>
+#import <sys/wait.h>
 
 void appLogInfo(NSString *msg) {
     NSLog(@"%@", msg);
@@ -130,6 +131,73 @@ bool chownWithAuthorization(const char *user) {
     appLogDebug([NSString stringWithFormat:@"XXX finished chown"]);
     AuthorizationFree(authRef, kAuthorizationFlagDestroyRights);
     return true;
+}
+
+bool replaceBundleWithAuthorization(const char *stagedApp, const char *backupApp,
+                                    const char *destApp, const char *owner) {
+    AuthorizationRef authRef = getAppInstallAuthorization();
+    if (authRef == NULL) {
+        return NO;
+    }
+
+    static const char *script =
+        "set -u\n"
+        "staged=$1\n"
+        "backup=$2\n"
+        "dest=$3\n"
+        "owner=$4\n"
+        "if [ -e \"$backup\" ]; then\n"
+        "  echo \"backup already exists: $backup\" >&2\n"
+        "  exit 73\n"
+        "fi\n"
+        "mkdir -p \"$(dirname \"$backup\")\" || exit 1\n"
+        "mv \"$dest\" \"$backup\" || exit 1\n"
+        "if cp -pR \"$staged\" \"$dest\"; then\n"
+        "  chown -R \"$owner\" \"$backup\" >/dev/null 2>&1 || true\n"
+        "  exit 0\n"
+        "fi\n"
+        "status=$?\n"
+        "rm -rf \"$dest\" >/dev/null 2>&1 || true\n"
+        "mv \"$backup\" \"$dest\" >/dev/null 2>&1 || true\n"
+        "exit \"$status\"\n";
+
+    const char *shellTool = "/bin/sh";
+    const char *shellArgs[] = {"-c", script, "ollama-authorized-update",
+                               stagedApp, backupApp, destApp, owner, NULL};
+    appLogInfo([NSString
+        stringWithFormat:@"requesting authorization to replace %@ from %@",
+                         @(destApp), @(stagedApp)]);
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    OSStatus err = AuthorizationExecuteWithPrivileges(
+        authRef, shellTool, kAuthorizationFlagDefaults,
+        (char *const *)shellArgs, NULL);
+#pragma clang diagnostic pop
+
+    if (err != errAuthorizationSuccess) {
+        appLogInfo([NSString
+            stringWithFormat:@"Failed to start authorized update. Status = %d",
+                             err]);
+        AuthorizationFree(authRef, kAuthorizationFlagDestroyRights);
+        return NO;
+    }
+
+    int status = 0;
+    pid_t pid = wait(&status);
+    AuthorizationFree(authRef, kAuthorizationFlagDestroyRights);
+
+    if (pid == -1 || !WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        appLogInfo([NSString
+            stringWithFormat:@"authorized update failed pid=%d exit=%d",
+                             pid, WIFEXITED(status) ? WEXITSTATUS(status) : -1]);
+        return NO;
+    }
+
+    appLogInfo([NSString
+        stringWithFormat:@"authorized update replaced %@ successfully",
+                         @(destApp)]);
+    return YES;
 }
 
 // nil if bundle is good, error string otherwise

--- a/app/updater/updater_darwin_test.go
+++ b/app/updater/updater_darwin_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 )
 
@@ -184,6 +185,134 @@ func TestDoUpgradeRejectsInvalidBundlePath(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(BundlePath, "Contents", "MacOS", "Ollama")); err != nil {
 		t.Fatalf("old app was not restored: %s", err)
+	}
+}
+
+func TestDoUpgradeInteractiveUsesAuthorizationOnPermissionFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+	BundlePath = filepath.Join(tmpDir, "Ollama.app")
+	appBackupDir = filepath.Join(tmpDir, "backup")
+	UpdateStageDir = filepath.Join(tmpDir, "updates")
+	UpgradeMarkerFile = filepath.Join(tmpDir, "upgraded")
+	bundle := filepath.Join(UpdateStageDir, "foo", "ollama-darwin.zip")
+
+	if err := os.MkdirAll(filepath.Join(BundlePath, "Contents", "MacOS"), 0o755); err != nil {
+		t.Fatal("failed to create app bundle")
+	}
+	if err := os.WriteFile(filepath.Join(BundlePath, "Contents", "MacOS", "Ollama"), []byte("old app"), 0o755); err != nil {
+		t.Fatal("failed to write old app")
+	}
+	if err := os.MkdirAll(filepath.Dir(bundle), 0o755); err != nil {
+		t.Fatal("failed to create update dir")
+	}
+	if err := zipCreationHelper(bundle, []testPayload{
+		{
+			Name: "Ollama.app/Contents/MacOS/Ollama",
+			Body: []byte("new app"),
+		},
+		{
+			Name: "Ollama.app/Contents/Resources/ollama",
+			Body: []byte("new cli"),
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	oldRenameBundle := renameBundle
+	oldReplaceBundleWithAuthorization := replaceBundleWithAuthorization
+	t.Cleanup(func() {
+		renameBundle = oldRenameBundle
+		replaceBundleWithAuthorization = oldReplaceBundleWithAuthorization
+	})
+
+	renameBundle = func(oldpath, newpath string) error {
+		if oldpath == BundlePath {
+			return &os.PathError{Op: "rename", Path: oldpath, Err: syscall.EACCES}
+		}
+		return os.Rename(oldpath, newpath)
+	}
+
+	authorized := false
+	replaceBundleWithAuthorization = func(stagedApp, backupApp, destApp, owner string) bool {
+		authorized = true
+		if owner == "" {
+			t.Fatal("expected owner for authorized backup handoff")
+		}
+		if backupApp != filepath.Join(appBackupDir, "Ollama.app") {
+			t.Fatalf("backup path = %s, want %s", backupApp, filepath.Join(appBackupDir, "Ollama.app"))
+		}
+		if destApp != BundlePath {
+			t.Fatalf("dest path = %s, want %s", destApp, BundlePath)
+		}
+		if got, err := os.ReadFile(filepath.Join(stagedApp, "Contents", "MacOS", "Ollama")); err != nil || string(got) != "new app" {
+			t.Fatalf("staged app binary = %q, %v", got, err)
+		}
+		if err := os.Rename(destApp, backupApp); err != nil {
+			t.Fatalf("failed to simulate authorized backup: %s", err)
+		}
+		if err := os.Rename(stagedApp, destApp); err != nil {
+			t.Fatalf("failed to simulate authorized install: %s", err)
+		}
+		return true
+	}
+
+	if err := DoUpgrade(true); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if !authorized {
+		t.Fatal("expected authorized replacement")
+	}
+	if got, err := os.ReadFile(filepath.Join(BundlePath, "Contents", "MacOS", "Ollama")); err != nil || string(got) != "new app" {
+		t.Fatalf("new app binary = %q, %v", got, err)
+	}
+	if got, err := os.ReadFile(filepath.Join(appBackupDir, "Ollama.app", "Contents", "MacOS", "Ollama")); err != nil || string(got) != "old app" {
+		t.Fatalf("backup app binary = %q, %v", got, err)
+	}
+	if _, err := os.Stat(UpgradeMarkerFile); err != nil {
+		t.Fatalf("missing marker %s", UpgradeMarkerFile)
+	}
+}
+
+func TestDoUpgradeInteractiveDoesNotAuthorizeNonPermissionFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+	BundlePath = filepath.Join(tmpDir, "Ollama.app")
+	appBackupDir = filepath.Join(tmpDir, "backup")
+	UpdateStageDir = filepath.Join(tmpDir, "updates")
+	UpgradeMarkerFile = filepath.Join(tmpDir, "upgraded")
+	bundle := filepath.Join(UpdateStageDir, "foo", "ollama-darwin.zip")
+
+	if err := os.MkdirAll(filepath.Join(BundlePath, "Contents", "MacOS"), 0o755); err != nil {
+		t.Fatal("failed to create app bundle")
+	}
+	if err := os.MkdirAll(filepath.Dir(bundle), 0o755); err != nil {
+		t.Fatal("failed to create update dir")
+	}
+	if err := zipCreationHelper(bundle, []testPayload{{
+		Name: "Ollama.app/Contents/MacOS/Ollama",
+		Body: []byte("new app"),
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	oldRenameBundle := renameBundle
+	oldReplaceBundleWithAuthorization := replaceBundleWithAuthorization
+	t.Cleanup(func() {
+		renameBundle = oldRenameBundle
+		replaceBundleWithAuthorization = oldReplaceBundleWithAuthorization
+	})
+
+	renameBundle = func(oldpath, newpath string) error {
+		return &os.LinkError{Op: "rename", Old: oldpath, New: newpath, Err: syscall.EXDEV}
+	}
+	replaceBundleWithAuthorization = func(stagedApp, backupApp, destApp, owner string) bool {
+		t.Fatal("authorization should not be requested for non-permission rename failures")
+		return false
+	}
+
+	if err := DoUpgrade(true); err == nil {
+		t.Fatal("expected rename failure")
+	} else if !strings.Contains(err.Error(), "failed to stage old version") {
+		t.Fatalf("unexpected error: %s", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fall back to a macOS authorization flow when an interactive app update cannot rename a system-wide `/Applications/Ollama.app` installation due to permissions.
- Stage the replacement bundle in the user cache, then perform the privileged app swap with rollback behavior in the authorized helper path.
- Reuse the existing bundle path and symlink validation logic for normal install, verification, and authorized staging paths.
- Add regression coverage for permission failures that should request authorization and non-permission rename failures that should not.

## Why this matters
System-wide macOS installs can be owned by root or another administrator account, so a standard user can download an update but fail when the updater tries to replace the app bundle. That leaves auto-update effectively broken for users who run Ollama day to day without admin ownership of `/Applications/Ollama.app`.

This change keeps the update flow self-service: the app only asks for macOS authorization when an interactive update hits a real permission boundary, while startup updates remain non-interactive and avoid unexpected prompts. It also keeps the security-sensitive archive extraction and path validation in Go before any privileged file operation happens.

## Validation
- `go test ./app/updater`
- `git diff --check`
- `git diff --staged --check`

## Notes
- I did not run a manual end-to-end update as a macOS standard user, so the OS authorization dialog still needs real-device validation.