### PR TITLE
jetson: add CC 87 for CUDA v13

### DIFF
--- a/llama/server/CMakePresets.json
+++ b/llama/server/CMakePresets.json
@@ -100,7 +100,7 @@
       "inherits": ["llama_cuda_v13_base"],
       "binaryDir": "${sourceDir}/../../build/llama-server-cuda_v13",
       "cacheVariables": {
-        "CMAKE_CUDA_ARCHITECTURES": "75-virtual;80-virtual;86-virtual;89-virtual;90-virtual;90a-virtual;100-virtual;103-virtual;110-virtual;120-virtual;121-virtual"
+        "CMAKE_CUDA_ARCHITECTURES": "75-virtual;80-virtual;86-virtual;87-virtual;89-virtual;90-virtual;90a-virtual;100-virtual;103-virtual;110-virtual;120-virtual;121-virtual"
       }
     },
     {


### PR DESCRIPTION
The new Jetpack 7.2 supports SBSA based CUDA, so we can add the architecture now.