### PR TITLE
server: validate safetensors architecture before copying blobs

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -276,6 +276,67 @@ func ConvertAdapter(fsys fs.FS, f *os.File, baseKV ofs.Config) error {
 	return writeFile(f, conv.KV(baseKV), conv.Tensors(ts))
 }
 
+// CheckArchitecture reads the config.json at configPath and returns an error if
+// the model architecture is not supported by ConvertModel. It returns nil when
+// config.json is missing, unreadable, or unparseable — those errors surface
+// with full context inside ConvertModel. The intent is to fail fast before any
+// large safetensors blobs are copied into the staging directory.
+func CheckArchitecture(configPath string) error {
+	bts, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil
+	}
+	bts = sanitizeNonFiniteJSON(bts)
+	var p ModelParameters
+	if err := json.Unmarshal(bts, &p); err != nil || len(p.Architectures) == 0 {
+		return nil
+	}
+	switch p.Architectures[0] {
+	case "LlamaForCausalLM",
+		"MllamaForConditionalGeneration",
+		"Llama4ForConditionalGeneration",
+		"Mistral3ForConditionalGeneration",
+		"Ministral3ForCausalLM",
+		"MixtralForCausalLM",
+		"GemmaForCausalLM",
+		"Gemma2ForCausalLM",
+		"Gemma3ForCausalLM",
+		"Gemma3ForConditionalGeneration",
+		"Gemma3TextModel",
+		"Gemma3nForConditionalGeneration",
+		"Gemma4ForCausalLM",
+		"Gemma4ForConditionalGeneration",
+		"Phi3ForCausalLM",
+		"Qwen2ForCausalLM",
+		"Qwen2_5_VLForConditionalGeneration",
+		"Qwen3VLForConditionalGeneration",
+		"Qwen3VLMoeForConditionalGeneration",
+		"Olmo3ForCausalLM",
+		"BertModel",
+		"NomicBertModel",
+		"NomicBertMoEModel",
+		"CohereForCausalLM",
+		"GptOssForCausalLM",
+		"DeepseekOCRForCausalLM",
+		"DeepseekV3ForCausalLM",
+		"Glm4MoeLiteForCausalLM",
+		"LagunaForCausalLM",
+		"GlmOcrForConditionalGeneration",
+		"Lfm2ForCausalLM",
+		"Lfm2MoeForCausalLM",
+		"Lfm2VlForConditionalGeneration",
+		"Qwen3NextForCausalLM",
+		"Qwen3_5ForConditionalGeneration",
+		"Qwen3_5MoeForConditionalGeneration",
+		"NemotronH_Nano_VL_V2",
+		"NemotronH_Nano_Omni_Reasoning_V3",
+		"NemotronHForCausalLM":
+		return nil
+	default:
+		return fmt.Errorf("unsupported architecture %q", p.Architectures[0])
+	}
+}
+
 func LoadModelMetadata(fsys fs.FS) (ModelKV, *Tokenizer, error) {
 	bts, err := fs.ReadFile(fsys, "config.json")
 	if err != nil {

--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -349,6 +349,66 @@ func TestConvertAdapter(t *testing.T) {
 	}
 }
 
+func TestCheckArchitecture(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     string // empty string = file should not exist
+		wantErr bool
+	}{
+		{
+			name:    "supported LlamaForCausalLM",
+			cfg:     `{"architectures":["LlamaForCausalLM"]}`,
+			wantErr: false,
+		},
+		{
+			name:    "supported Gemma3ForCausalLM",
+			cfg:     `{"architectures":["Gemma3ForCausalLM"]}`,
+			wantErr: false,
+		},
+		{
+			name:    "unsupported MistralForCausalLM",
+			cfg:     `{"architectures":["MistralForCausalLM"]}`,
+			wantErr: true,
+		},
+		{
+			name:    "unsupported unknown architecture",
+			cfg:     `{"architectures":["SomeNewModel"]}`,
+			wantErr: true,
+		},
+		{
+			name:    "empty architectures returns nil",
+			cfg:     `{"architectures":[]}`,
+			wantErr: false,
+		},
+		{
+			name:    "missing config.json returns nil",
+			cfg:     "",
+			wantErr: false,
+		},
+		{
+			name:    "invalid JSON returns nil",
+			cfg:     `not json at all`,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "config.json")
+			if tt.cfg != "" {
+				if err := os.WriteFile(path, []byte(tt.cfg), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			err := CheckArchitecture(path)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CheckArchitecture(%q) error = %v, wantErr %v", tt.cfg, err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func generateLoraTestData(t *testing.T, tempDir string) {
 	offset := 4096 * 8 * 4
 

--- a/server/create.go
+++ b/server/create.go
@@ -479,6 +479,18 @@ func detectModelTypeFromFiles(files map[string]string) string {
 }
 
 func convertFromSafetensors(files map[string]string, baseLayers []*layerGGML, isAdapter bool, mediaType string, detectTemplate bool, fn func(resp api.ProgressResponse)) ([]*layerGGML, error) {
+	// Validate architecture before copying any blobs to avoid wasting time and
+	// disk space when the model is not supported (issue #15949).
+	if !isAdapter {
+		if configDigest, ok := files["config.json"]; ok {
+			if blobPath, err := manifest.BlobsPath(configDigest); err == nil {
+				if err := convert.CheckArchitecture(blobPath); err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+
 	tmpDir, err := os.MkdirTemp(envconfig.Models(), "ollama-safetensors")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes #15949.

## Problem

When importing a safetensors model with an unsupported architecture, Ollama copies all blobs into a staging directory first and only then attempts conversion — surfacing the `unsupported architecture` error after potentially many gigabytes of unnecessary I/O:

```
converting model
Error: unsupported architecture "MistralForCausalLM"
```

A user reporting this issue had already copied 77 GB of safetensors files before getting the error.

## Fix

`convert.CheckArchitecture(configPath string) error` reads `config.json` from the given path, parses `ModelParameters.Architectures`, and returns a descriptive error for any architecture that is not handled by `LoadModelMetadata`'s switch statement.

`convertFromSafetensors` in `server/create.go` calls this before `os.MkdirTemp` and before any blob links are created. If config.json is missing, unreadable, or has no architectures field, `CheckArchitecture` returns `nil` so that `ConvertModel` can surface those errors with full context as before.

## Tests

`TestCheckArchitecture` in `convert/convert_test.go` covers:
- Supported architectures (`LlamaForCausalLM`, `Gemma3ForCausalLM`) → no error
- Known-unsupported architecture (`MistralForCausalLM`) → error with architecture name
- Unknown/future architecture → error
- Empty architectures list → nil (let ConvertModel handle)
- Missing config.json → nil (let ConvertModel handle)
- Invalid JSON → nil (let ConvertModel handle)