### PR TITLE
Fix macOS installer app launch path

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -85,7 +85,7 @@ if [ "$OS" = "Darwin" ]; then
 
     if [ -z "${OLLAMA_NO_START:-}" ]; then
         status "Starting Ollama..."
-        open -a Ollama --args hidden
+        open "/Applications/Ollama.app" --args hidden
     fi
 
     status "Install complete. You can now run 'ollama'."


### PR DESCRIPTION
Fixes #16638

## Problem

The macOS install script installs `/Applications/Ollama.app` and then starts it with:

```sh
open -a Ollama --args hidden
```

On some systems, Launch Services cannot resolve the application by name immediately after the script removes and replaces the app bundle, which causes the installer to finish with:

```text
Unable to find application named 'Ollama'
```

## Change

Open the app bundle that the installer just moved into `/Applications` by absolute path:

```sh
open "/Applications/Ollama.app" --args hidden
```

This avoids relying on Launch Services name lookup while preserving the existing hidden startup behavior.

## Tests

- `sh -n scripts/install.sh`
- `git diff --check`