### PR TITLE
fix: Audio only projector without vision capability

### DIFF
--- a/server/images.go
+++ b/server/images.go
@@ -387,33 +387,10 @@ func (m *Model) projectorCapabilities(capabilities []model.Capability) []model.C
 		return capabilities
 	}
 
-	hasAudio := false
-	hasVision := false
 	for _, projectorPath := range m.ProjectorPaths {
-		f, err := gguf.Open(projectorPath)
-		if err != nil {
-			slog.Error("couldn't open projector file", "error", err)
-			continue
+		for _, capability := range projectorCapabilities(projectorPath) {
+			capabilities = appendCapability(capabilities, capability)
 		}
-		projHasAudio := projectorHasAudio(f) && !projectorSuppressesAudioCapability(f)
-		projHasVision := projectorHasVision(f)
-
-		// If the projector has neither explicitly, assume it has vision
-		if projHasVision || !projHasAudio {
-			hasVision = true
-		}
-		if projHasAudio {
-			hasAudio = true
-		}
-
-		f.Close()
-	}
-
-	if hasVision {
-		capabilities = appendCapability(capabilities, model.CapabilityVision)
-	}
-	if hasAudio {
-		capabilities = appendCapability(capabilities, model.CapabilityAudio)
 	}
 
 	return capabilities
@@ -532,6 +509,29 @@ func projectorSuppressesAudioCapability(f *gguf.File) bool {
 	}
 
 	return false
+}
+
+func projectorCapabilities(projectorPath string) []model.Capability {
+	var capabilities []model.Capability
+	f, err := gguf.Open(projectorPath)
+	if err != nil {
+		slog.Error("couldn't open projector file", "error", err)
+		return capabilities
+	}
+	defer f.Close()
+
+	projHasAudio := projectorHasAudio(f) && !projectorSuppressesAudioCapability(f)
+	projHasVision := projectorHasVision(f)
+
+	// If the projector has neither explicitly, assume it has vision
+	if projHasVision || !projHasAudio {
+		capabilities = appendCapability(capabilities, model.CapabilityVision)
+	}
+	if projHasAudio {
+		capabilities = appendCapability(capabilities, model.CapabilityAudio)
+	}
+
+	return capabilities
 }
 
 // CheckCapabilities checks if the model has the specified capabilities returning an error describing

--- a/server/images.go
+++ b/server/images.go
@@ -506,6 +506,12 @@ func projectorHasAudio(f *gguf.File) bool {
 }
 
 func projectorHasVision(f *gguf.File) bool {
+	// Handle explicit bool before checking for implicit vision KVs
+	for _, kv := range f.KeyValues() {
+		if strings.Contains(kv.Key, "has_vision_encoder") {
+			return kv.Bool()
+		}
+	}
 	for _, kv := range f.KeyValues() {
 		if strings.Contains(kv.Key, "vision") {
 			return true

--- a/server/images.go
+++ b/server/images.go
@@ -387,7 +387,8 @@ func (m *Model) projectorCapabilities(capabilities []model.Capability) []model.C
 		return capabilities
 	}
 
-	capabilities = appendCapability(capabilities, model.CapabilityVision)
+	hasAudio := false
+	hasVision := false
 	for _, projectorPath := range m.ProjectorPaths {
 		f, err := gguf.Open(projectorPath)
 		if err != nil {
@@ -395,9 +396,20 @@ func (m *Model) projectorCapabilities(capabilities []model.Capability) []model.C
 			continue
 		}
 		if projectorHasAudio(f) && !projectorSuppressesAudioCapability(f) {
-			capabilities = appendCapability(capabilities, model.CapabilityAudio)
+			hasAudio = true
+		}
+		if projectorHasVision(f) {
+			hasVision = true
 		}
 		f.Close()
+	}
+
+	// If the projectors have neither explicitly, assume they have vision
+	if hasVision || !hasAudio {
+		capabilities = appendCapability(capabilities, model.CapabilityVision)
+	}
+	if hasAudio {
+		capabilities = appendCapability(capabilities, model.CapabilityAudio)
 	}
 
 	return capabilities
@@ -486,6 +498,16 @@ func projectorHasAudio(f *gguf.File) bool {
 
 	for _, kv := range f.KeyValues() {
 		if strings.HasSuffix(kv.Key, ".has_audio_encoder") && kv.Bool() {
+			return true
+		}
+	}
+
+	return false
+}
+
+func projectorHasVision(f *gguf.File) bool {
+	for _, kv := range f.KeyValues() {
+		if strings.Contains(kv.Key, "vision") {
 			return true
 		}
 	}

--- a/server/images.go
+++ b/server/images.go
@@ -395,17 +395,21 @@ func (m *Model) projectorCapabilities(capabilities []model.Capability) []model.C
 			slog.Error("couldn't open projector file", "error", err)
 			continue
 		}
-		if projectorHasAudio(f) && !projectorSuppressesAudioCapability(f) {
-			hasAudio = true
-		}
-		if projectorHasVision(f) {
+		projHasAudio := projectorHasAudio(f) && !projectorSuppressesAudioCapability(f)
+		projHasVision := projectorHasVision(f)
+
+		// If the projector has neither explicitly, assume it has vision
+		if projHasVision || !projHasAudio {
 			hasVision = true
 		}
+		if projHasAudio {
+			hasAudio = true
+		}
+
 		f.Close()
 	}
 
-	// If the projectors have neither explicitly, assume they have vision
-	if hasVision || !hasAudio {
+	if hasVision {
 		capabilities = appendCapability(capabilities, model.CapabilityVision)
 	}
 	if hasAudio {

--- a/server/images_test.go
+++ b/server/images_test.go
@@ -317,9 +317,9 @@ func TestModelCapabilities(t *testing.T) {
 	}, []*ggml.Tensor{})
 
 	visionImplicitProjectorPath, _ := createBinFile(t, ggml.KV{
-		"general.architecture":   "clip",
-		"clip.projector_type":    "some_implicit_vision_projector",
-		"clip.block_count": uint32(1),
+		"general.architecture": "clip",
+		"clip.projector_type":  "some_implicit_vision_projector",
+		"clip.block_count":     uint32(1),
 	}, []*ggml.Tensor{})
 
 	audioProjectorPath, _ := createBinFile(t, ggml.KV{
@@ -330,10 +330,10 @@ func TestModelCapabilities(t *testing.T) {
 	}, []*ggml.Tensor{})
 
 	audioOnlyExplicitProjectorPath, _ := createBinFile(t, ggml.KV{
-		"general.architecture":   "clip",
-		"clip.has_audio_encoder": true,
-		"clip.projector_type":    "granite_speech",
-		"clip.audio.block_count": uint32(1),
+		"general.architecture":    "clip",
+		"clip.has_audio_encoder":  true,
+		"clip.projector_type":     "granite_speech",
+		"clip.audio.block_count":  uint32(1),
 		"clip.has_vision_encoder": false,
 	}, []*ggml.Tensor{})
 

--- a/server/images_test.go
+++ b/server/images_test.go
@@ -316,6 +316,12 @@ func TestModelCapabilities(t *testing.T) {
 		"bert.pooling_type":    uint32(1),
 	}, []*ggml.Tensor{})
 
+	visionImplicitProjectorPath, _ := createBinFile(t, ggml.KV{
+		"general.architecture":   "clip",
+		"clip.projector_type":    "some_implicit_vision_projector",
+		"clip.block_count": uint32(1),
+	}, []*ggml.Tensor{})
+
 	audioProjectorPath, _ := createBinFile(t, ggml.KV{
 		"general.architecture":   "clip",
 		"clip.has_audio_encoder": true,
@@ -485,6 +491,15 @@ func TestModelCapabilities(t *testing.T) {
 				Template:       chatTemplate,
 			},
 			expectedCaps: []model.Capability{model.CapabilityCompletion, model.CapabilityAudio},
+		},
+		{
+			name: "model with audio projector and implicit vision capability",
+			model: Model{
+				ModelPath:      completionModelPath,
+				ProjectorPaths: []string{audioProjectorPath, visionImplicitProjectorPath},
+				Template:       chatTemplate,
+			},
+			expectedCaps: []model.Capability{model.CapabilityCompletion, model.CapabilityAudio, model.CapabilityVision},
 		},
 		{
 			name: "model with audio and vision projector capability",

--- a/server/images_test.go
+++ b/server/images_test.go
@@ -317,6 +317,13 @@ func TestModelCapabilities(t *testing.T) {
 	}, []*ggml.Tensor{})
 
 	audioProjectorPath, _ := createBinFile(t, ggml.KV{
+		"general.architecture":   "clip",
+		"clip.has_audio_encoder": true,
+		"clip.projector_type":    "granite_speech",
+		"clip.audio.block_count": uint32(1),
+	}, []*ggml.Tensor{})
+
+	audioAndVisionProjectorPath, _ := createBinFile(t, ggml.KV{
 		"general.architecture":    "clip",
 		"clip.has_audio_encoder":  true,
 		"vision.projector_type":   "pixtral",
@@ -454,13 +461,22 @@ func TestModelCapabilities(t *testing.T) {
 			expectedCaps: []model.Capability{model.CapabilityEmbedding},
 		},
 		{
-			name: "model with audio projector capability",
+			name: "model with audio projector only capability",
 			model: Model{
 				ModelPath:      completionModelPath,
 				ProjectorPaths: []string{audioProjectorPath},
 				Template:       chatTemplate,
 			},
-			expectedCaps: []model.Capability{model.CapabilityCompletion, model.CapabilityVision, model.CapabilityAudio},
+			expectedCaps: []model.Capability{model.CapabilityCompletion, model.CapabilityAudio},
+		},
+		{
+			name: "model with audio and vision projector capability",
+			model: Model{
+				ModelPath:      completionModelPath,
+				ProjectorPaths: []string{audioAndVisionProjectorPath},
+				Template:       chatTemplate,
+			},
+			expectedCaps: []model.Capability{model.CapabilityCompletion, model.CapabilityAudio, model.CapabilityVision},
 		},
 		{
 			name: "model with parser and projector capabilities without template",
@@ -471,7 +487,7 @@ func TestModelCapabilities(t *testing.T) {
 					Parser: "functiongemma",
 				},
 			},
-			expectedCaps: []model.Capability{model.CapabilityCompletion, model.CapabilityVision, model.CapabilityAudio, model.CapabilityTools},
+			expectedCaps: []model.Capability{model.CapabilityCompletion, model.CapabilityAudio, model.CapabilityTools},
 		},
 		{
 			name: "gemma4 projector exposes audio capability",
@@ -486,7 +502,7 @@ func TestModelCapabilities(t *testing.T) {
 			name: "gemma4 gguf exposes audio capability",
 			model: Model{
 				ModelPath:      completionModelPath,
-				ProjectorPaths: []string{audioProjectorPath},
+				ProjectorPaths: []string{audioAndVisionProjectorPath},
 				Config: model.ConfigV2{
 					Renderer:     gemma4RendererSmall,
 					Capabilities: []string{"audio"},
@@ -507,7 +523,7 @@ func TestModelCapabilities(t *testing.T) {
 			name: "nemotron3 projector suppresses audio capability",
 			model: Model{
 				ModelPath:      completionModelPath,
-				ProjectorPaths: []string{audioProjectorPath},
+				ProjectorPaths: []string{audioAndVisionProjectorPath},
 				Config: model.ConfigV2{
 					ModelFamily: "nemotron_h_omni",
 				},

--- a/server/images_test.go
+++ b/server/images_test.go
@@ -323,6 +323,14 @@ func TestModelCapabilities(t *testing.T) {
 		"clip.audio.block_count": uint32(1),
 	}, []*ggml.Tensor{})
 
+	audioOnlyExplicitProjectorPath, _ := createBinFile(t, ggml.KV{
+		"general.architecture":   "clip",
+		"clip.has_audio_encoder": true,
+		"clip.projector_type":    "granite_speech",
+		"clip.audio.block_count": uint32(1),
+		"clip.has_vision_encoder": false,
+	}, []*ggml.Tensor{})
+
 	audioAndVisionProjectorPath, _ := createBinFile(t, ggml.KV{
 		"general.architecture":    "clip",
 		"clip.has_audio_encoder":  true,
@@ -465,6 +473,15 @@ func TestModelCapabilities(t *testing.T) {
 			model: Model{
 				ModelPath:      completionModelPath,
 				ProjectorPaths: []string{audioProjectorPath},
+				Template:       chatTemplate,
+			},
+			expectedCaps: []model.Capability{model.CapabilityCompletion, model.CapabilityAudio},
+		},
+		{
+			name: "model with audio projector and vision false only capability",
+			model: Model{
+				ModelPath:      completionModelPath,
+				ProjectorPaths: []string{audioOnlyExplicitProjectorPath},
 				Template:       chatTemplate,
 			},
 			expectedCaps: []model.Capability{model.CapabilityCompletion, model.CapabilityAudio},

--- a/server/model_list_cache.go
+++ b/server/model_list_cache.go
@@ -338,7 +338,7 @@ func buildModelListSummary(name model.Name, mf *manifest.Manifest) (modelListSum
 		},
 	}
 
-	modelPath, projectorCount, tmpl, err := readModelListLayers(mf, &summary)
+	modelPath, projectorCaps, tmpl, err := readModelListLayers(mf, &summary)
 	if err != nil {
 		return modelListSummary{}, err
 	}
@@ -387,8 +387,8 @@ func buildModelListSummary(name model.Name, mf *manifest.Manifest) (modelListSum
 		}
 	}
 
-	if projectorCount > 0 {
-		summary.Capabilities = appendModelListCapability(summary.Capabilities, model.CapabilityVision)
+	for _, projectorCapability := range projectorCaps {
+		summary.Capabilities = appendModelListCapability(summary.Capabilities, projectorCapability)
 	}
 
 	if cfg.ModelFormat == "safetensors" && isGemma4Renderer(cfg.Renderer) {
@@ -419,9 +419,9 @@ func readModelListConfig(mf *manifest.Manifest) (model.ConfigV2, error) {
 	return cfg, nil
 }
 
-func readModelListLayers(mf *manifest.Manifest, summary *modelListSummary) (string, int, *ollamatemplate.Template, error) {
+func readModelListLayers(mf *manifest.Manifest, summary *modelListSummary) (string, []model.Capability, *ollamatemplate.Template, error) {
 	var modelPath string
-	var projectorCount int
+	var projectorCaps []model.Capability
 	tmpl := ollamatemplate.DefaultTemplate
 
 	for _, layer := range mf.Layers {
@@ -429,31 +429,37 @@ func readModelListLayers(mf *manifest.Manifest, summary *modelListSummary) (stri
 		case "application/vnd.ollama.image.model":
 			filename, err := manifest.BlobsPath(layer.Digest)
 			if err != nil {
-				return "", 0, nil, err
+				return "", []model.Capability{}, nil, err
 			}
 			modelPath = filename
 			summary.Details.ParentModel = layer.From
 		case "application/vnd.ollama.image.projector":
-			projectorCount++
+			filename, err := manifest.BlobsPath(layer.Digest)
+			if err != nil {
+				return "", []model.Capability{}, nil, err
+			}
+			for _, projectorCapability := range projectorCapabilities(filename) {
+				projectorCaps = appendCapability(projectorCaps, projectorCapability)
+			}
 		case "application/vnd.ollama.image.prompt",
 			"application/vnd.ollama.image.template":
 			filename, err := manifest.BlobsPath(layer.Digest)
 			if err != nil {
-				return "", 0, nil, err
+				return "", []model.Capability{}, nil, err
 			}
 			bts, err := os.ReadFile(filename)
 			if err != nil {
-				return "", 0, nil, err
+				return "", []model.Capability{}, nil, err
 			}
 
 			tmpl, err = ollamatemplate.Parse(string(bts))
 			if err != nil {
-				return "", 0, nil, err
+				return "", []model.Capability{}, nil, err
 			}
 		}
 	}
 
-	return modelPath, projectorCount, tmpl, nil
+	return modelPath, projectorCaps, tmpl, nil
 }
 
 type modelListGGUF struct {

--- a/server/model_list_cache_test.go
+++ b/server/model_list_cache_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/ollama/ollama/fs/ggml"
 
 	"github.com/ollama/ollama/api"
 	fsgguf "github.com/ollama/ollama/fs/gguf"
@@ -337,5 +338,112 @@ func writeModelListGGUFUint64(t *testing.T, b *bytes.Buffer, v uint64) {
 	t.Helper()
 	if err := binary.Write(b, binary.LittleEndian, v); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestModelListCacheExtractsProjectorCapabilities(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	modelsDir := t.TempDir()
+	t.Setenv("OLLAMA_MODELS", modelsDir)
+
+	visionOnlyKV := ggml.KV{
+		"general.architecture":    "clip",
+		"clip.projector_type":     "pixtral",
+		"clip.vision.block_count": uint32(1),
+	}
+	_, visionOnlyDigest := createBinFile(t, visionOnlyKV, nil)
+
+	audioOnlyKV := ggml.KV{
+		"general.architecture":    "clip",
+		"clip.has_audio_encoder":  true,
+		"clip.projector_type":     "granite_speech",
+		"clip.audio.block_count":  uint32(1),
+		"clip.has_vision_encoder": false,
+	}
+	_, audioOnlyDigest := createBinFile(t, audioOnlyKV, nil)
+
+	visionAndAudioKV := ggml.KV{
+		"general.architecture":    "clip",
+		"clip.has_audio_encoder":  true,
+		"vision.projector_type":   "gemma3",
+		"clip.vision.block_count": uint32(1),
+		"clip.audio.block_count":  uint32(1),
+	}
+	_, visionAndAudioDigest := createBinFile(t, visionAndAudioKV, nil)
+
+	baseKV := map[string]any{"general.architecture": "llama"}
+	_, baseModelDigest := createBinFile(t, baseKV, nil)
+
+	testCases := []struct {
+		name         string
+		modelName    string
+		modelFiles   map[string]string
+		expectedCaps []model.Capability
+	}{
+		{
+			name:      "vision-only projector",
+			modelName: "proj-vision",
+			modelFiles: map[string]string{
+				"model.gguf":     baseModelDigest,
+				"projector.gguf": visionOnlyDigest,
+			},
+			expectedCaps: []model.Capability{model.CapabilityCompletion, model.CapabilityVision},
+		},
+		{
+			name:      "audio-only projector",
+			modelName: "proj-audio",
+			modelFiles: map[string]string{
+				"model.gguf":     baseModelDigest,
+				"projector.gguf": audioOnlyDigest,
+			},
+			expectedCaps: []model.Capability{model.CapabilityCompletion, model.CapabilityAudio},
+		},
+		{
+			name:      "vision and audio projector",
+			modelName: "proj-vision-audio",
+			modelFiles: map[string]string{
+				"model.gguf":     baseModelDigest,
+				"projector.gguf": visionAndAudioDigest,
+			},
+			expectedCaps: []model.Capability{model.CapabilityCompletion, model.CapabilityVision, model.CapabilityAudio},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := api.CreateRequest{
+				Model:  tc.modelName,
+				Files:  tc.modelFiles,
+				Stream: &stream,
+			}
+
+			var s Server
+			w := createRequest(t, s.CreateHandler, req)
+			if w.Code != http.StatusOK {
+				t.Fatalf("create model status = %d, want 200: %s", w.Code, w.Body.String())
+			}
+
+			cache := newModelListCache()
+			if err := cache.hydrate(context.Background()); err != nil {
+				t.Fatalf("hydrate failed: %v", err)
+			}
+
+			summary, ok := cache.Get(model.ParseName(tc.modelName))
+			if !ok {
+				t.Fatal("model summary missing from cache")
+			}
+
+			for _, cap := range tc.expectedCaps {
+				if !slices.Contains(summary.Capabilities, cap) {
+					t.Fatalf("capabilities = %v, want %s", summary.Capabilities, cap)
+				}
+			}
+
+			for _, cap := range summary.Capabilities {
+				if !slices.Contains(tc.expectedCaps, cap) {
+					t.Fatalf("capabilities = %v, unexpected %s", summary.Capabilities, cap)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Description

Currently, the logic for deducing multimodal capabilities from a GGUF projector will _always_ add `vision` and then optionally add `audio` if set. This leads audio-only models to appear as supporting both audio and vision (eg https://ollama.com/gabegoodhart/granite4.1-speech).

## Changes

- In `projectorCapabilities`, look for both explicit audio and vision support
- If no support set explicitly, default to `vision` (matching existing behavior)
- If audio found without vision, only set `audio`
- If vision set, set vision (regardless of `audio`)

## Testing

I updated the unit tests in `images_test.go` that target model capabilities (`go test ./server -c && ./server.test -test.run TestModelCapabilities`). My understanding of these tests is that the sample binaries are supposed to be representative of real GGUF binaries for models on the registry. I couldn't find examples on the hub for several of the model/projector combos (eg, I couldn't find `nemotron 3` with a projector), so I made an educated guess that these are models that are supposed to have both audio and vision in their projector KVs.

Many of the other tests fail for me locally, so I'm not easily able to see whether there are other impacted tests that will need updating.

## AI Usage

~~This was simple enough that all the changes are AI-free.~~

AI was used to generate new tests for the cache list functionality.

<details>
<summary>git-ai-stats</summary>

```
╔══════════════════════════════════════════════════════════╗
║           GIT AI USAGE ANALYSIS                          ║
╚══════════════════════════════════════════════════════════╝

📊 COMMITS BY AGENT

--- Aggregate ---
Commits                        |      Count
---------------------------------------------
none                           |          8
OpenCode + Qwen3.6-35b         |          1
---------------------------------------------
TOTAL                          |          9

📊 COMMITS BY USAGE TYPE

--- Aggregate ---
Commits                        |      Count
---------------------------------------------
none                           |          8
draft                          |          0
full                           |          1
---------------------------------------------
TOTAL                          |          9

📈 LINES OF CODE BY AGENT

--- Aggregate ---
Agent                     |    Commits |  Additions |  Deletions
------------------------------------------------------------
none                      |          8 |        142 |         56
OpenCode + Qwen3.6-35b    |          1 |        108 |          0
------------------------------------------------------------
TOTAL                     |          9 |        250 |         56

📈 LINES OF CODE BY USAGE TYPE

--- Aggregate ---
Usage Type           |    Commits |  Additions |  Deletions
-------------------------------------------------------
none                 |          8 |        142 |         56
draft                |          0 |          0 |          0
full                 |          1 |        108 |          0
-------------------------------------------------------
TOTAL                |          9 |        250 |         56
```

</details>