### PR TITLE
launch: Add VS Code extension launch flow

### DIFF
--- a/cmd/launch/integrations_test.go
+++ b/cmd/launch/integrations_test.go
@@ -85,7 +85,7 @@ func TestIntegrationLookup(t *testing.T) {
 }
 
 func TestIntegrationRegistry(t *testing.T) {
-	expectedIntegrations := []string{"claude", "claude-desktop", "cline", "codex", "codex-app", "kimi", "droid", "opencode", "omp", "hermes", "hermes-desktop", "pool", "qwen"}
+	expectedIntegrations := []string{"claude", "claude-desktop", "cline", "codex", "codex-app", "kimi", "droid", "opencode", "omp", "hermes", "hermes-desktop", "pool", "qwen", "vscode"}
 	for _, name := range expectedIntegrations {
 		t.Run(name, func(t *testing.T) {
 			r, ok := integrations[name]
@@ -102,7 +102,7 @@ func TestIntegrationRegistry(t *testing.T) {
 func TestHiddenIntegrationsExcludedFromVisibleLists(t *testing.T) {
 	for _, info := range ListIntegrationInfos() {
 		switch info.Name {
-		case "vscode", "kimi":
+		case "kimi":
 			t.Fatalf("hidden integration %q should not appear in ListIntegrationInfos", info.Name)
 		}
 	}
@@ -1848,9 +1848,9 @@ func TestListIntegrationInfos(t *testing.T) {
 		for _, info := range infos {
 			got = append(got, info.Name)
 		}
-		wantPrefix := []string{"claude", "codex-app", "hermes", "openclaw", "opencode", "hermes-desktop", "codex", "copilot", "omp"}
+		wantPrefix := []string{"claude", "codex-app", "vscode", "hermes", "openclaw", "opencode", "hermes-desktop", "codex", "copilot", "omp"}
 		if codexAppSupported() != nil {
-			wantPrefix = []string{"claude", "hermes", "openclaw", "opencode", "hermes-desktop", "codex", "copilot", "omp"}
+			wantPrefix = []string{"claude", "vscode", "hermes", "openclaw", "opencode", "hermes-desktop", "codex", "copilot", "omp"}
 		}
 		if len(got) < len(wantPrefix) {
 			t.Fatalf("expected at least %d integrations, got %v", len(wantPrefix), got)
@@ -1872,7 +1872,7 @@ func TestListIntegrationInfos(t *testing.T) {
 	})
 
 	t.Run("includes known integrations", func(t *testing.T) {
-		known := map[string]bool{"claude": false, "cline": false, "codex": false, "opencode": false, "omp": false}
+		known := map[string]bool{"claude": false, "cline": false, "codex": false, "opencode": false, "omp": false, "vscode": false}
 		if codexAppSupported() == nil {
 			known["codex-app"] = false
 		}

--- a/cmd/launch/registry.go
+++ b/cmd/launch/registry.go
@@ -33,7 +33,7 @@ type IntegrationInfo struct {
 	Description string
 }
 
-var launcherIntegrationOrder = []string{"claude", "codex-app", "hermes", "openclaw", "opencode", "hermes-desktop", "codex", "copilot", "omp", "cline", "droid", "pi", "pool", "qwen"}
+var launcherIntegrationOrder = []string{"claude", "codex-app", "vscode", "hermes", "openclaw", "opencode", "hermes-desktop", "codex", "copilot", "omp", "cline", "droid", "pi", "pool", "qwen"}
 
 var integrationSpecs = []*IntegrationSpec{
 	{
@@ -259,7 +259,6 @@ var integrationSpecs = []*IntegrationSpec{
 		Runner:      &VSCode{},
 		Aliases:     []string{"code"},
 		Description: "Microsoft's open-source AI code editor",
-		Hidden:      true,
 		Install: IntegrationInstallSpec{
 			CheckInstalled: func() bool {
 				return (&VSCode{}).findBinary() != ""

--- a/cmd/launch/vscode.go
+++ b/cmd/launch/vscode.go
@@ -131,14 +131,42 @@ const (
 	legacyVSCodeOllamaVendor = "ollama-vscode"
 
 	vscodeOllamaExtensionID = "Ollama.ollama"
+
+	legacyCopilotBYOKSetting      = "github.copilot.chat.byok.ollamaEndpoint"
+	legacyLaunchConfiguredSetting = "ollama.launch.configured"
 )
 
 func (v *VSCode) Run(model string, _ []LaunchModel, args []string) error {
 	v.checkVSCodeVersion()
 	v.checkCopilotChatVersion()
-	installedExtension, err := v.ensureOllamaExtensionInstalled()
+	extensionInstalled, err := v.ollamaExtensionInstalled()
 	if err != nil {
 		return err
+	}
+	running := v.IsRunning()
+	hasLegacyBYOK := v.hasLegacyCopilotBYOKSetting()
+
+	setupConfirmed := false
+	if prompt := vscodeSetupPrompt(extensionInstalled, hasLegacyBYOK, running); prompt != "" {
+		ok, err := ConfirmPrompt(prompt)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return nil
+		}
+		setupConfirmed = true
+	}
+
+	if !extensionInstalled {
+		if err := v.installOllamaExtension(); err != nil {
+			return err
+		}
+	}
+	if hasLegacyBYOK {
+		if err := v.removeLegacyVSCodeSettings(); err != nil {
+			return err
+		}
 	}
 
 	// VS Code discovers models from ollama ls. Cloud models that pass Show
@@ -148,14 +176,14 @@ func (v *VSCode) Run(model string, _ []LaunchModel, args []string) error {
 		v.ensureModelsRegistered(context.Background(), client, []string{model})
 	}
 
-	if v.IsRunning() {
-		prompt := "Restart VS Code?"
-		if installedExtension {
-			prompt = "Restart VS Code to finish installing the Ollama extension?"
-		}
-		restart, err := ConfirmPrompt(prompt)
-		if err != nil {
-			restart = false
+	if running {
+		restart := setupConfirmed
+		if !restart {
+			var err error
+			restart, err = ConfirmPrompt("Restart VS Code?")
+			if err != nil {
+				restart = false
+			}
 		}
 		if restart {
 			v.Quit()
@@ -164,11 +192,7 @@ func (v *VSCode) Run(model string, _ []LaunchModel, args []string) error {
 			}
 			v.FocusVSCode()
 		} else {
-			if installedExtension {
-				fmt.Fprintf(os.Stderr, "\nRestart VS Code when you're ready to use the Ollama extension.\n")
-			} else {
-				fmt.Fprintf(os.Stderr, "\nTo get the latest model configuration, restart VS Code when you're ready.\n")
-			}
+			fmt.Fprintf(os.Stderr, "\nTo get the latest model configuration, restart VS Code when you're ready.\n")
 		}
 	} else {
 		if err := v.ShowInModelPicker(model); err != nil {
@@ -292,6 +316,25 @@ func (v *VSCode) writeProviderConfig() error {
 	return v.updateSettings()
 }
 
+func vscodeSetupPrompt(extensionInstalled, hasLegacyBYOK, running bool) string {
+	switch {
+	case !extensionInstalled && hasLegacyBYOK && running:
+		return "Install Ollama VS Code extension, remove old Copilot BYOK setting, and restart VS Code?"
+	case !extensionInstalled && hasLegacyBYOK:
+		return "Install Ollama VS Code extension and remove old Copilot BYOK setting?"
+	case !extensionInstalled && running:
+		return "Install Ollama VS Code extension and restart VS Code?"
+	case !extensionInstalled:
+		return "Install Ollama VS Code extension?"
+	case hasLegacyBYOK && running:
+		return "Remove old Copilot BYOK setting and restart VS Code?"
+	case hasLegacyBYOK:
+		return "Remove old Copilot BYOK setting?"
+	default:
+		return ""
+	}
+}
+
 func (v *VSCode) chatLanguageModelsPath() string {
 	return v.vscodePath("chatLanguageModels.json")
 }
@@ -300,33 +343,81 @@ func (v *VSCode) settingsPath() string {
 	return v.vscodePath("settings.json")
 }
 
-// updateSettings cleans up legacy settings from older Ollama integrations.
+// updateSettings writes settings owned by the Ollama extension. User-facing
+// legacy settings are removed only after an explicit launch prompt.
 func (v *VSCode) updateSettings() error {
 	settingsPath := v.settingsPath()
 	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
 		return err
 	}
 
-	settings := make(map[string]any)
-	data, err := os.ReadFile(settingsPath)
-	if err == nil {
-		if err := json.Unmarshal(data, &settings); err != nil {
-			settings = make(map[string]any)
-		}
+	settings, err := v.readSettings()
+	if err != nil {
+		return err
 	}
 
 	changed := false
-	for _, key := range []string{"github.copilot.chat.byok.ollamaEndpoint", "ollama.launch.configured"} {
-		if _, ok := settings[key]; ok {
-			delete(settings, key)
-			changed = true
-		}
+	if _, ok := settings[legacyLaunchConfiguredSetting]; ok {
+		delete(settings, legacyLaunchConfiguredSetting)
+		changed = true
 	}
 	if current, _ := settings["ollama.endpoint"].(string); current != envconfig.Host().String() {
 		settings["ollama.endpoint"] = envconfig.Host().String()
 		changed = true
 	}
 
+	if !changed {
+		return nil
+	}
+
+	updated, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return err
+	}
+	return fileutil.WriteWithBackup(settingsPath, updated, "vscode")
+}
+
+func (v *VSCode) readSettings() (map[string]any, error) {
+	settings := make(map[string]any)
+	data, err := os.ReadFile(v.settingsPath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return settings, nil
+		}
+		return nil, err
+	}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return make(map[string]any), nil
+	}
+	return settings, nil
+}
+
+func (v *VSCode) hasLegacyCopilotBYOKSetting() bool {
+	settings, err := v.readSettings()
+	if err != nil {
+		return false
+	}
+	_, ok := settings[legacyCopilotBYOKSetting]
+	return ok
+}
+
+func (v *VSCode) removeLegacyVSCodeSettings() error {
+	settingsPath := v.settingsPath()
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		return err
+	}
+	settings, err := v.readSettings()
+	if err != nil {
+		return err
+	}
+
+	changed := false
+	for _, key := range []string{legacyCopilotBYOKSetting, legacyLaunchConfiguredSetting} {
+		if _, ok := settings[key]; ok {
+			delete(settings, key)
+			changed = true
+		}
+	}
 	if !changed {
 		return nil
 	}
@@ -580,7 +671,7 @@ func (v *VSCode) checkCopilotChatVersion() {
 	}
 }
 
-func (v *VSCode) ensureOllamaExtensionInstalled() (bool, error) {
+func (v *VSCode) ollamaExtensionInstalled() (bool, error) {
 	codeCLI := v.findCodeCLI()
 	if codeCLI == "" {
 		return false, fmt.Errorf("could not find VS Code CLI to install the Ollama extension")
@@ -590,19 +681,24 @@ func (v *VSCode) ensureOllamaExtensionInstalled() (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("could not list VS Code extensions: %w", err)
 	}
-	if hasVSCodeExtension(string(out), vscodeOllamaExtensionID) {
-		return false, nil
+	return hasVSCodeExtension(string(out), vscodeOllamaExtensionID), nil
+}
+
+func (v *VSCode) installOllamaExtension() error {
+	codeCLI := v.findCodeCLI()
+	if codeCLI == "" {
+		return fmt.Errorf("could not find VS Code CLI to install the Ollama extension")
 	}
 
 	fmt.Fprintf(os.Stderr, "Installing Ollama VS Code extension...\n")
 	if out, err := exec.Command(codeCLI, "--install-extension", vscodeOllamaExtensionID, "--force").CombinedOutput(); err != nil {
 		detail := strings.TrimSpace(string(out))
 		if detail != "" {
-			return false, fmt.Errorf("could not install Ollama VS Code extension: %w\n%s", err, detail)
+			return fmt.Errorf("could not install Ollama VS Code extension: %w\n%s", err, detail)
 		}
-		return false, fmt.Errorf("could not install Ollama VS Code extension: %w", err)
+		return fmt.Errorf("could not install Ollama VS Code extension: %w", err)
 	}
-	return true, nil
+	return nil
 }
 
 // findCodeCLI returns the path to the VS Code CLI for querying extensions.

--- a/cmd/launch/vscode.go
+++ b/cmd/launch/vscode.go
@@ -126,8 +126,8 @@ const (
 	minCopilotChatVersion = "0.41.0"
 	minVSCodeVersion      = "1.113"
 
-	vscodeOllamaVendor = "ollama-vscode"
-	vscodeOllamaName   = "Ollama"
+	vscodeOllamaVendor       = "ollama-vscode"
+	vscodeOllamaName         = "Ollama"
 	legacyVSCodeOllamaVendor = "ollama"
 
 	vscodeOllamaExtensionID = "Ollama.ollama-vscode"
@@ -303,7 +303,7 @@ func (v *VSCode) updateSettings() error {
 	data, err := os.ReadFile(settingsPath)
 	if err == nil {
 		if err := json.Unmarshal(data, &settings); err != nil {
-			return nil
+			settings = make(map[string]any)
 		}
 	}
 

--- a/cmd/launch/vscode.go
+++ b/cmd/launch/vscode.go
@@ -126,19 +126,19 @@ const (
 	minCopilotChatVersion = "0.41.0"
 	minVSCodeVersion      = "1.113"
 
-	vscodeOllamaVendor    = "ollama"
-	vscodeOllamaDevVendor = "ollama-dev"
-	vscodeOllamaName      = "Ollama"
+	vscodeOllamaVendor = "ollama"
+	vscodeOllamaName   = "Ollama"
 
-	vscodeOllamaExtensionID     = "Ollama.ollama-vscode"
-	vscodeOllamaVSIXEnv         = "OLLAMA_VSCODE_EXTENSION_VSIX"
-	vscodeOllamaDefaultVSIXPath = "/tmp/ollama-vscode-0.0.1.vsix"
+	vscodeOllamaExtensionID = "Ollama.ollama-vscode"
 )
 
 func (v *VSCode) Run(model string, _ []LaunchModel, args []string) error {
 	v.checkVSCodeVersion()
 	v.checkCopilotChatVersion()
-	installedExtension := v.ensureOllamaExtensionInstalled()
+	installedExtension, err := v.ensureOllamaExtensionInstalled()
+	if err != nil {
+		return err
+	}
 
 	// VS Code discovers models from ollama ls. Cloud models that pass Show
 	// (the server knows about them) but aren't in ls need to be pulled to
@@ -265,7 +265,7 @@ func (v *VSCode) writeProviderConfig() error {
 	// Remove any existing Ollama entries, preserve others.
 	filtered := make([]map[string]any, 0, len(entries))
 	for _, entry := range entries {
-		if vendor, _ := entry["vendor"].(string); vendor != vscodeOllamaVendor && vendor != vscodeOllamaDevVendor {
+		if vendor, _ := entry["vendor"].(string); vendor != vscodeOllamaVendor {
 			filtered = append(filtered, entry)
 		}
 	}
@@ -418,7 +418,7 @@ func (v *VSCode) ShowInModelPicker(model string) error {
 	// The extension owns model discovery and picker visibility. Clear launch's
 	// old per-model overrides so previously hidden models can show up again.
 	for id := range prefs {
-		if strings.HasPrefix(id, vscodeOllamaVendor+"/") || strings.HasPrefix(id, vscodeOllamaDevVendor+"/") {
+		if strings.HasPrefix(id, vscodeOllamaVendor+"/") {
 			delete(prefs, id)
 		}
 	}
@@ -552,41 +552,29 @@ func (v *VSCode) checkCopilotChatVersion() {
 	}
 }
 
-func (v *VSCode) ensureOllamaExtensionInstalled() bool {
+func (v *VSCode) ensureOllamaExtensionInstalled() (bool, error) {
 	codeCLI := v.findCodeCLI()
 	if codeCLI == "" {
-		fmt.Fprintf(os.Stderr, "%s  Warning: could not find VS Code CLI to install the Ollama extension%s\n", ansiYellow, ansiReset)
-		return false
+		return false, fmt.Errorf("could not find VS Code CLI to install the Ollama extension")
 	}
 
 	out, err := exec.Command(codeCLI, "--list-extensions", "--show-versions").Output()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%s  Warning: could not list VS Code extensions: %v%s\n", ansiYellow, err, ansiReset)
-		return false
+		return false, fmt.Errorf("could not list VS Code extensions: %w", err)
 	}
 	if hasVSCodeExtension(string(out), vscodeOllamaExtensionID) {
-		return false
-	}
-
-	vsixPath := os.Getenv(vscodeOllamaVSIXEnv)
-	if vsixPath == "" {
-		vsixPath = vscodeOllamaDefaultVSIXPath
-	}
-	if !fileExists(vsixPath) {
-		fmt.Fprintf(os.Stderr, "Installing Ollama VS Code extension...\n")
-		if out, err := exec.Command(codeCLI, "--install-extension", vscodeOllamaExtensionID, "--force").CombinedOutput(); err != nil {
-			fmt.Fprintf(os.Stderr, "%s  Warning: could not install Ollama VS Code extension: %v%s\n%s\n", ansiYellow, err, ansiReset, strings.TrimSpace(string(out)))
-			return false
-		}
-		return true
+		return false, nil
 	}
 
 	fmt.Fprintf(os.Stderr, "Installing Ollama VS Code extension...\n")
-	if out, err := exec.Command(codeCLI, "--install-extension", vsixPath, "--force").CombinedOutput(); err != nil {
-		fmt.Fprintf(os.Stderr, "%s  Warning: could not install Ollama VS Code extension: %v%s\n%s\n", ansiYellow, err, ansiReset, strings.TrimSpace(string(out)))
-		return false
+	if out, err := exec.Command(codeCLI, "--install-extension", vscodeOllamaExtensionID, "--force").CombinedOutput(); err != nil {
+		detail := strings.TrimSpace(string(out))
+		if detail != "" {
+			return false, fmt.Errorf("could not install Ollama VS Code extension: %w\n%s", err, detail)
+		}
+		return false, fmt.Errorf("could not install Ollama VS Code extension: %w", err)
 	}
-	return true
+	return true, nil
 }
 
 // findCodeCLI returns the path to the VS Code CLI for querying extensions.

--- a/cmd/launch/vscode.go
+++ b/cmd/launch/vscode.go
@@ -126,11 +126,11 @@ const (
 	minCopilotChatVersion = "0.41.0"
 	minVSCodeVersion      = "1.113"
 
-	vscodeOllamaVendor       = "ollama-vscode"
+	vscodeOllamaVendor       = "ollama"
 	vscodeOllamaName         = "Ollama"
-	legacyVSCodeOllamaVendor = "ollama"
+	legacyVSCodeOllamaVendor = "ollama-vscode"
 
-	vscodeOllamaExtensionID = "Ollama.ollama-vscode"
+	vscodeOllamaExtensionID = "Ollama.ollama"
 )
 
 func (v *VSCode) Run(model string, _ []LaunchModel, args []string) error {
@@ -258,27 +258,35 @@ func (v *VSCode) Paths() []string {
 
 func (v *VSCode) writeProviderConfig() error {
 	clmPath := v.chatLanguageModelsPath()
-	if fileExists(clmPath) {
-		var entries []map[string]any
-		if data, err := os.ReadFile(clmPath); err == nil {
-			_ = json.Unmarshal(data, &entries)
-		}
+	if err := os.MkdirAll(filepath.Dir(clmPath), 0o755); err != nil {
+		return err
+	}
 
-		filtered := make([]map[string]any, 0, len(entries))
-		for _, entry := range entries {
-			if isManagedOllamaProviderEntry(entry) {
-				continue
-			}
-			filtered = append(filtered, entry)
-		}
+	var entries []map[string]any
+	if data, err := os.ReadFile(clmPath); err == nil {
+		_ = json.Unmarshal(data, &entries)
+	}
 
-		data, err := json.MarshalIndent(filtered, "", "  ")
-		if err != nil {
-			return err
+	filtered := make([]map[string]any, 0, len(entries)+1)
+	for _, entry := range entries {
+		if isManagedOllamaProviderEntry(entry) {
+			continue
 		}
-		if err := fileutil.WriteWithBackup(clmPath, data, "vscode"); err != nil {
-			return err
-		}
+		filtered = append(filtered, entry)
+	}
+
+	filtered = append(filtered, map[string]any{
+		"vendor": vscodeOllamaVendor,
+		"name":   vscodeOllamaName,
+		"url":    envconfig.Host().String(),
+	})
+
+	data, err := json.MarshalIndent(filtered, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := fileutil.WriteWithBackup(clmPath, data, "vscode"); err != nil {
+		return err
 	}
 
 	return v.updateSettings()
@@ -340,6 +348,15 @@ func isManagedOllamaProviderEntry(entry map[string]any) bool {
 	}
 	name, _ := entry["name"].(string)
 	return strings.EqualFold(strings.TrimSpace(name), vscodeOllamaName)
+}
+
+func isManagedOllamaModelID(id string) bool {
+	for _, vendor := range []string{vscodeOllamaVendor, legacyVSCodeOllamaVendor} {
+		if strings.HasPrefix(id, vendor+"/") {
+			return true
+		}
+	}
+	return false
 }
 
 func (v *VSCode) statePath() string {
@@ -421,7 +438,7 @@ func (v *VSCode) ShowInModelPicker(model string) error {
 	// The extension owns model discovery and picker visibility. Clear launch's
 	// old per-model overrides so previously hidden models can show up again.
 	for id := range prefs {
-		if strings.HasPrefix(id, vscodeOllamaVendor+"/") {
+		if isManagedOllamaModelID(id) {
 			delete(prefs, id)
 		}
 	}
@@ -449,11 +466,14 @@ func (v *VSCode) modelVSCodeIDs(model string, nameToID map[string]string) []stri
 			ids = append(ids, id)
 		}
 	}
-	ids = append(ids, vscodeOllamaVendor+"/"+model)
-	ids = append(ids, vscodeOllamaVendor+"/"+vscodeOllamaName+"/"+model)
 	if !strings.Contains(model, ":") {
-		ids = append(ids, vscodeOllamaVendor+"/"+model+":latest")
 		ids = append(ids, vscodeOllamaVendor+"/"+vscodeOllamaName+"/"+model+":latest")
+		ids = append(ids, vscodeOllamaVendor+"/"+vscodeOllamaName+"/"+model)
+		ids = append(ids, vscodeOllamaVendor+"/"+model+":latest")
+		ids = append(ids, vscodeOllamaVendor+"/"+model)
+	} else {
+		ids = append(ids, vscodeOllamaVendor+"/"+vscodeOllamaName+"/"+model)
+		ids = append(ids, vscodeOllamaVendor+"/"+model)
 	}
 	return ids
 }
@@ -464,7 +484,7 @@ func (v *VSCode) primaryModelVSCodeID(model string, nameToID map[string]string) 
 
 func isStaleCachedOllamaModelEntry(entry map[string]any) bool {
 	identifier, _ := entry["identifier"].(string)
-	return strings.HasPrefix(identifier, vscodeOllamaVendor+"/"+vscodeOllamaName+"/")
+	return strings.HasPrefix(identifier, legacyVSCodeOllamaVendor+"/"+vscodeOllamaName+"/")
 }
 
 func (v *VSCode) selectChatModel(db *sql.DB, modelID string) error {

--- a/cmd/launch/vscode.go
+++ b/cmd/launch/vscode.go
@@ -130,7 +130,7 @@ const (
 	vscodeOllamaDevVendor = "ollama-dev"
 	vscodeOllamaName      = "Ollama"
 
-	vscodeOllamaExtensionID     = "ollama.ollama-vscode"
+	vscodeOllamaExtensionID     = "Ollama.ollama-vscode"
 	vscodeOllamaVSIXEnv         = "OLLAMA_VSCODE_EXTENSION_VSIX"
 	vscodeOllamaDefaultVSIXPath = "/tmp/ollama-vscode-0.0.1.vsix"
 )
@@ -138,7 +138,7 @@ const (
 func (v *VSCode) Run(model string, _ []LaunchModel, args []string) error {
 	v.checkVSCodeVersion()
 	v.checkCopilotChatVersion()
-	v.ensureOllamaExtensionInstalled()
+	installedExtension := v.ensureOllamaExtensionInstalled()
 
 	// VS Code discovers models from ollama ls. Cloud models that pass Show
 	// (the server knows about them) but aren't in ls need to be pulled to
@@ -147,26 +147,12 @@ func (v *VSCode) Run(model string, _ []LaunchModel, args []string) error {
 		v.ensureModelsRegistered(context.Background(), client, []string{model})
 	}
 
-	// Warn if the default model doesn't support tool calling
-	if client, err := api.ClientFromEnvironment(); err == nil {
-		if resp, err := client.Show(context.Background(), &api.ShowRequest{Model: model}); err == nil {
-			hasTools := false
-			for _, c := range resp.Capabilities {
-				if c == "tools" {
-					hasTools = true
-					break
-				}
-			}
-			if !hasTools {
-				fmt.Fprintf(os.Stderr, "Note: %s does not support tool calling and may not appear in the Copilot Chat model picker.\n", model)
-			}
-		}
-	}
-
-	v.printModelAccessTip(model)
-
 	if v.IsRunning() {
-		restart, err := ConfirmPrompt("Restart VS Code?")
+		prompt := "Restart VS Code?"
+		if installedExtension {
+			prompt = "Restart VS Code to finish installing the Ollama extension?"
+		}
+		restart, err := ConfirmPrompt(prompt)
 		if err != nil {
 			restart = false
 		}
@@ -177,7 +163,11 @@ func (v *VSCode) Run(model string, _ []LaunchModel, args []string) error {
 			}
 			v.FocusVSCode()
 		} else {
-			fmt.Fprintf(os.Stderr, "\nTo get the latest model configuration, restart VS Code when you're ready.\n")
+			if installedExtension {
+				fmt.Fprintf(os.Stderr, "\nRestart VS Code when you're ready to use the Ollama extension.\n")
+			} else {
+				fmt.Fprintf(os.Stderr, "\nTo get the latest model configuration, restart VS Code when you're ready.\n")
+			}
 		}
 	} else {
 		if err := v.ShowInModelPicker(model); err != nil {
@@ -249,14 +239,6 @@ func (v *VSCode) FocusVSCode() {
 	} else {
 		_ = exec.Command(binary).Start()
 	}
-}
-
-// printModelAccessTip shows instructions for using the configured Ollama model
-// in VS Code's Copilot Chat UI.
-func (v *VSCode) printModelAccessTip(model string) {
-	fmt.Fprintf(os.Stderr, "\nTip: Open Copilot Chat in VS Code.\n")
-	fmt.Fprintf(os.Stderr, "     %s should appear under \"%s\" in the model picker, and it may already be selected.\n", model, vscodeOllamaName)
-	fmt.Fprintf(os.Stderr, "     If it isn't selected, open the model picker and choose it from the \"%s\" section.\n\n", vscodeOllamaName)
 }
 
 func (v *VSCode) Paths() []string {
@@ -570,20 +552,20 @@ func (v *VSCode) checkCopilotChatVersion() {
 	}
 }
 
-func (v *VSCode) ensureOllamaExtensionInstalled() {
+func (v *VSCode) ensureOllamaExtensionInstalled() bool {
 	codeCLI := v.findCodeCLI()
 	if codeCLI == "" {
 		fmt.Fprintf(os.Stderr, "%s  Warning: could not find VS Code CLI to install the Ollama extension%s\n", ansiYellow, ansiReset)
-		return
+		return false
 	}
 
 	out, err := exec.Command(codeCLI, "--list-extensions", "--show-versions").Output()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s  Warning: could not list VS Code extensions: %v%s\n", ansiYellow, err, ansiReset)
-		return
+		return false
 	}
 	if hasVSCodeExtension(string(out), vscodeOllamaExtensionID) {
-		return
+		return false
 	}
 
 	vsixPath := os.Getenv(vscodeOllamaVSIXEnv)
@@ -591,15 +573,20 @@ func (v *VSCode) ensureOllamaExtensionInstalled() {
 		vsixPath = vscodeOllamaDefaultVSIXPath
 	}
 	if !fileExists(vsixPath) {
-		fmt.Fprintf(os.Stderr, "%s  Warning: Ollama VS Code extension is not installed and no VSIX was found at %s%s\n", ansiYellow, vsixPath, ansiReset)
-		fmt.Fprintf(os.Stderr, "     Build the VSIX from ollama/ollama-vscode and set %s, or place it at %s.\n\n", vscodeOllamaVSIXEnv, vscodeOllamaDefaultVSIXPath)
-		return
+		fmt.Fprintf(os.Stderr, "Installing Ollama VS Code extension...\n")
+		if out, err := exec.Command(codeCLI, "--install-extension", vscodeOllamaExtensionID, "--force").CombinedOutput(); err != nil {
+			fmt.Fprintf(os.Stderr, "%s  Warning: could not install Ollama VS Code extension: %v%s\n%s\n", ansiYellow, err, ansiReset, strings.TrimSpace(string(out)))
+			return false
+		}
+		return true
 	}
 
-	fmt.Fprintf(os.Stderr, "Installing Ollama VS Code extension from %s...\n", vsixPath)
+	fmt.Fprintf(os.Stderr, "Installing Ollama VS Code extension...\n")
 	if out, err := exec.Command(codeCLI, "--install-extension", vsixPath, "--force").CombinedOutput(); err != nil {
 		fmt.Fprintf(os.Stderr, "%s  Warning: could not install Ollama VS Code extension: %v%s\n%s\n", ansiYellow, err, ansiReset, strings.TrimSpace(string(out)))
+		return false
 	}
+	return true
 }
 
 // findCodeCLI returns the path to the VS Code CLI for querying extensions.

--- a/cmd/launch/vscode.go
+++ b/cmd/launch/vscode.go
@@ -126,8 +126,9 @@ const (
 	minCopilotChatVersion = "0.41.0"
 	minVSCodeVersion      = "1.113"
 
-	vscodeOllamaVendor = "ollama"
+	vscodeOllamaVendor = "ollama-vscode"
 	vscodeOllamaName   = "Ollama"
+	legacyVSCodeOllamaVendor = "ollama"
 
 	vscodeOllamaExtensionID = "Ollama.ollama-vscode"
 )
@@ -242,73 +243,45 @@ func (v *VSCode) FocusVSCode() {
 }
 
 func (v *VSCode) Paths() []string {
+	var paths []string
 	if p := v.chatLanguageModelsPath(); fileExists(p) {
-		return []string{p}
+		paths = append(paths, p)
 	}
-	return nil
+	if p := v.settingsPath(); fileExists(p) {
+		paths = append(paths, p)
+	}
+	if len(paths) == 0 {
+		return nil
+	}
+	return paths
 }
 
 func (v *VSCode) writeProviderConfig() error {
-	// Write chatLanguageModels.json with an Ollama provider group. The
-	// extension intentionally discovers the full model catalog itself, so the
-	// launcher only persists connection config here.
 	clmPath := v.chatLanguageModelsPath()
-	if err := os.MkdirAll(filepath.Dir(clmPath), 0o755); err != nil {
-		return err
-	}
+	if fileExists(clmPath) {
+		var entries []map[string]any
+		if data, err := os.ReadFile(clmPath); err == nil {
+			_ = json.Unmarshal(data, &entries)
+		}
 
-	var entries []map[string]any
-	if data, err := os.ReadFile(clmPath); err == nil {
-		_ = json.Unmarshal(data, &entries)
-	}
-
-	// Remove any existing Ollama entries, preserve others.
-	filtered := make([]map[string]any, 0, len(entries))
-	for _, entry := range entries {
-		if vendor, _ := entry["vendor"].(string); vendor != vscodeOllamaVendor {
+		filtered := make([]map[string]any, 0, len(entries))
+		for _, entry := range entries {
+			if isManagedOllamaProviderEntry(entry) {
+				continue
+			}
 			filtered = append(filtered, entry)
 		}
-	}
 
-	// Add new Ollama entry
-	filtered = append(filtered, map[string]any{
-		"vendor": vscodeOllamaVendor,
-		"name":   vscodeOllamaName,
-		"url":    envconfig.Host().String(),
-	})
-
-	data, err := json.MarshalIndent(filtered, "", "  ")
-	if err != nil {
-		return err
-	}
-	if err := fileutil.WriteWithBackup(clmPath, data, "vscode"); err != nil {
-		return err
-	}
-
-	// Clean up legacy settings from older Ollama integrations
-	v.updateSettings()
-
-	return nil
-}
-
-// hasOllamaVendor checks if chatLanguageModels.json contains an Ollama vendor entry.
-func (v *VSCode) hasOllamaVendor() bool {
-	data, err := os.ReadFile(v.chatLanguageModelsPath())
-	if err != nil {
-		return false
-	}
-
-	var entries []map[string]any
-	if err := json.Unmarshal(data, &entries); err != nil {
-		return false
-	}
-
-	for _, entry := range entries {
-		if vendor, _ := entry["vendor"].(string); vendor == vscodeOllamaVendor {
-			return true
+		data, err := json.MarshalIndent(filtered, "", "  ")
+		if err != nil {
+			return err
+		}
+		if err := fileutil.WriteWithBackup(clmPath, data, "vscode"); err != nil {
+			return err
 		}
 	}
-	return false
+
+	return v.updateSettings()
 }
 
 func (v *VSCode) chatLanguageModelsPath() string {
@@ -320,16 +293,18 @@ func (v *VSCode) settingsPath() string {
 }
 
 // updateSettings cleans up legacy settings from older Ollama integrations.
-func (v *VSCode) updateSettings() {
+func (v *VSCode) updateSettings() error {
 	settingsPath := v.settingsPath()
-	data, err := os.ReadFile(settingsPath)
-	if err != nil {
-		return
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		return err
 	}
 
-	var settings map[string]any
-	if err := json.Unmarshal(data, &settings); err != nil {
-		return
+	settings := make(map[string]any)
+	data, err := os.ReadFile(settingsPath)
+	if err == nil {
+		if err := json.Unmarshal(data, &settings); err != nil {
+			return nil
+		}
 	}
 
 	changed := false
@@ -339,16 +314,32 @@ func (v *VSCode) updateSettings() {
 			changed = true
 		}
 	}
+	if current, _ := settings["ollama.endpoint"].(string); current != envconfig.Host().String() {
+		settings["ollama.endpoint"] = envconfig.Host().String()
+		changed = true
+	}
 
 	if !changed {
-		return
+		return nil
 	}
 
 	updated, err := json.MarshalIndent(settings, "", "  ")
 	if err != nil {
-		return
+		return err
 	}
-	_ = fileutil.WriteWithBackup(settingsPath, updated, "vscode")
+	return fileutil.WriteWithBackup(settingsPath, updated, "vscode")
+}
+
+func isManagedOllamaProviderEntry(entry map[string]any) bool {
+	vendor, _ := entry["vendor"].(string)
+	if vendor == vscodeOllamaVendor || vendor == legacyVSCodeOllamaVendor {
+		return true
+	}
+	if vendor != "customendpoint" {
+		return false
+	}
+	name, _ := entry["name"].(string)
+	return strings.EqualFold(strings.TrimSpace(name), vscodeOllamaName)
 }
 
 func (v *VSCode) statePath() string {
@@ -399,7 +390,14 @@ func (v *VSCode) ShowInModelPicker(model string) error {
 	if err := db.QueryRow("SELECT value FROM ItemTable WHERE key = 'chat.cachedLanguageModels.v2'").Scan(&cacheJSON); err == nil {
 		var cached []map[string]any
 		if json.Unmarshal([]byte(cacheJSON), &cached) == nil {
+			filtered := cached[:0]
+			cacheChanged := false
 			for _, entry := range cached {
+				if isStaleCachedOllamaModelEntry(entry) {
+					cacheChanged = true
+					continue
+				}
+				filtered = append(filtered, entry)
 				meta, _ := entry["metadata"].(map[string]any)
 				if meta == nil {
 					continue
@@ -410,6 +408,11 @@ func (v *VSCode) ShowInModelPicker(model string) error {
 					if name != "" && id != "" {
 						nameToID[name] = id
 					}
+				}
+			}
+			if cacheChanged {
+				if data, err := json.Marshal(filtered); err == nil {
+					_, _ = db.Exec("INSERT OR REPLACE INTO ItemTable (key, value) VALUES ('chat.cachedLanguageModels.v2', ?)", string(data))
 				}
 			}
 		}
@@ -457,6 +460,11 @@ func (v *VSCode) modelVSCodeIDs(model string, nameToID map[string]string) []stri
 
 func (v *VSCode) primaryModelVSCodeID(model string, nameToID map[string]string) string {
 	return v.modelVSCodeIDs(model, nameToID)[0]
+}
+
+func isStaleCachedOllamaModelEntry(entry map[string]any) bool {
+	identifier, _ := entry["identifier"].(string)
+	return strings.HasPrefix(identifier, vscodeOllamaVendor+"/"+vscodeOllamaName+"/")
 }
 
 func (v *VSCode) selectChatModel(db *sql.DB, modelID string) error {

--- a/cmd/launch/vscode.go
+++ b/cmd/launch/vscode.go
@@ -386,9 +386,7 @@ func (v *VSCode) readSettings() (map[string]any, error) {
 		}
 		return nil, err
 	}
-	if err := json.Unmarshal(data, &settings); err != nil {
-		return make(map[string]any), nil
-	}
+	_ = json.Unmarshal(data, &settings)
 	return settings, nil
 }
 

--- a/cmd/launch/vscode.go
+++ b/cmd/launch/vscode.go
@@ -126,10 +126,9 @@ const (
 	minCopilotChatVersion = "0.41.0"
 	minVSCodeVersion      = "1.113"
 
-	// POC vendor for the local extension branch. Production should use "ollama"
-	// once VS Code has removed or handed off the built-in Ollama provider.
-	vscodeOllamaVendor = "ollama-dev"
-	vscodeOllamaName   = "Ollama"
+	vscodeOllamaVendor    = "ollama"
+	vscodeOllamaDevVendor = "ollama-dev"
+	vscodeOllamaName      = "Ollama"
 
 	vscodeOllamaExtensionID     = "ollama.ollama-vscode"
 	vscodeOllamaVSIXEnv         = "OLLAMA_VSCODE_EXTENSION_VSIX"
@@ -284,7 +283,7 @@ func (v *VSCode) writeProviderConfig() error {
 	// Remove any existing Ollama entries, preserve others.
 	filtered := make([]map[string]any, 0, len(entries))
 	for _, entry := range entries {
-		if vendor, _ := entry["vendor"].(string); vendor != "ollama" && vendor != vscodeOllamaVendor {
+		if vendor, _ := entry["vendor"].(string); vendor != vscodeOllamaVendor && vendor != vscodeOllamaDevVendor {
 			filtered = append(filtered, entry)
 		}
 	}
@@ -437,7 +436,7 @@ func (v *VSCode) ShowInModelPicker(model string) error {
 	// The extension owns model discovery and picker visibility. Clear launch's
 	// old per-model overrides so previously hidden models can show up again.
 	for id := range prefs {
-		if strings.HasPrefix(id, vscodeOllamaVendor+"/") {
+		if strings.HasPrefix(id, vscodeOllamaVendor+"/") || strings.HasPrefix(id, vscodeOllamaDevVendor+"/") {
 			delete(prefs, id)
 		}
 	}
@@ -593,7 +592,7 @@ func (v *VSCode) ensureOllamaExtensionInstalled() {
 	}
 	if !fileExists(vsixPath) {
 		fmt.Fprintf(os.Stderr, "%s  Warning: Ollama VS Code extension is not installed and no VSIX was found at %s%s\n", ansiYellow, vsixPath, ansiReset)
-		fmt.Fprintf(os.Stderr, "     Build it with: cd extensions/vscode && npm run compile && npx --yes @vscode/vsce package --out %s\n\n", vsixPath)
+		fmt.Fprintf(os.Stderr, "     Build the VSIX from ollama/ollama-vscode and set %s, or place it at %s.\n\n", vscodeOllamaVSIXEnv, vscodeOllamaDefaultVSIXPath)
 		return
 	}
 

--- a/cmd/launch/vscode.go
+++ b/cmd/launch/vscode.go
@@ -15,11 +15,12 @@ import (
 
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/cmd/config"
 	"github.com/ollama/ollama/cmd/internal/fileutil"
 	"github.com/ollama/ollama/envconfig"
 )
 
-// VSCode implements Runner and Editor for Visual Studio Code integration.
+// VSCode implements Runner and ManagedSingleModel for Visual Studio Code.
 type VSCode struct{}
 
 func (v *VSCode) String() string { return "Visual Studio Code" }
@@ -124,28 +125,32 @@ func (v *VSCode) Quit() {
 const (
 	minCopilotChatVersion = "0.41.0"
 	minVSCodeVersion      = "1.113"
+
+	// POC vendor for the local extension branch. Production should use "ollama"
+	// once VS Code has removed or handed off the built-in Ollama provider.
+	vscodeOllamaVendor = "ollama-dev"
+	vscodeOllamaName   = "Ollama"
+
+	vscodeOllamaExtensionID     = "ollama.ollama-vscode"
+	vscodeOllamaVSIXEnv         = "OLLAMA_VSCODE_EXTENSION_VSIX"
+	vscodeOllamaDefaultVSIXPath = "/tmp/ollama-vscode-0.0.1.vsix"
 )
 
 func (v *VSCode) Run(model string, _ []LaunchModel, args []string) error {
 	v.checkVSCodeVersion()
 	v.checkCopilotChatVersion()
-
-	// Get all configured models (saved by the launcher framework before Run is called)
-	models := []string{model}
-	if cfg, err := loadStoredIntegrationConfig("vscode"); err == nil && len(cfg.Models) > 0 {
-		models = cfg.Models
-	}
+	v.ensureOllamaExtensionInstalled()
 
 	// VS Code discovers models from ollama ls. Cloud models that pass Show
 	// (the server knows about them) but aren't in ls need to be pulled to
 	// register them so VS Code can find them.
 	if client, err := api.ClientFromEnvironment(); err == nil {
-		v.ensureModelsRegistered(context.Background(), client, models)
+		v.ensureModelsRegistered(context.Background(), client, []string{model})
 	}
 
 	// Warn if the default model doesn't support tool calling
 	if client, err := api.ClientFromEnvironment(); err == nil {
-		if resp, err := client.Show(context.Background(), &api.ShowRequest{Model: models[0]}); err == nil {
+		if resp, err := client.Show(context.Background(), &api.ShowRequest{Model: model}); err == nil {
 			hasTools := false
 			for _, c := range resp.Capabilities {
 				if c == "tools" {
@@ -154,12 +159,12 @@ func (v *VSCode) Run(model string, _ []LaunchModel, args []string) error {
 				}
 			}
 			if !hasTools {
-				fmt.Fprintf(os.Stderr, "Note: %s does not support tool calling and may not appear in the Copilot Chat model picker.\n", models[0])
+				fmt.Fprintf(os.Stderr, "Note: %s does not support tool calling and may not appear in the Copilot Chat model picker.\n", model)
 			}
 		}
 	}
 
-	v.printModelAccessTip()
+	v.printModelAccessTip(model)
 
 	if v.IsRunning() {
 		restart, err := ConfirmPrompt("Restart VS Code?")
@@ -168,7 +173,7 @@ func (v *VSCode) Run(model string, _ []LaunchModel, args []string) error {
 		}
 		if restart {
 			v.Quit()
-			if err := v.ShowInModelPicker(models); err != nil {
+			if err := v.ShowInModelPicker(model); err != nil {
 				fmt.Fprintf(os.Stderr, "%s  Warning: could not update VS Code model picker: %v%s\n", ansiYellow, err, ansiReset)
 			}
 			v.FocusVSCode()
@@ -176,13 +181,35 @@ func (v *VSCode) Run(model string, _ []LaunchModel, args []string) error {
 			fmt.Fprintf(os.Stderr, "\nTo get the latest model configuration, restart VS Code when you're ready.\n")
 		}
 	} else {
-		if err := v.ShowInModelPicker(models); err != nil {
+		if err := v.ShowInModelPicker(model); err != nil {
 			fmt.Fprintf(os.Stderr, "%s  Warning: could not update VS Code model picker: %v%s\n", ansiYellow, err, ansiReset)
 		}
 		v.FocusVSCode()
 	}
 
 	return nil
+}
+
+func (v *VSCode) Configure(model string) error {
+	if model == "" {
+		return nil
+	}
+	return v.writeProviderConfig()
+}
+
+func (v *VSCode) CurrentModel() string {
+	if cfg, err := loadStoredIntegrationConfig("vscode"); err == nil {
+		return primaryModelFromConfig(cfg)
+	}
+	return ""
+}
+
+func (v *VSCode) Onboard() error {
+	return config.MarkIntegrationOnboarded("vscode")
+}
+
+func (v *VSCode) RequiresInteractiveOnboarding() bool {
+	return false
 }
 
 // ensureModelsRegistered pulls models that the server knows about (Show succeeds)
@@ -225,10 +252,12 @@ func (v *VSCode) FocusVSCode() {
 	}
 }
 
-// printModelAccessTip shows instructions for finding Ollama models in VS Code.
-func (v *VSCode) printModelAccessTip() {
-	fmt.Fprintf(os.Stderr, "\nTip: To use Ollama models, open Copilot Chat and click the model picker.\n")
-	fmt.Fprintf(os.Stderr, "     If you don't see your models, click \"Other models\" to find them.\n\n")
+// printModelAccessTip shows instructions for using the configured Ollama model
+// in VS Code's Copilot Chat UI.
+func (v *VSCode) printModelAccessTip(model string) {
+	fmt.Fprintf(os.Stderr, "\nTip: Open Copilot Chat in VS Code.\n")
+	fmt.Fprintf(os.Stderr, "     %s should appear under \"%s\" in the model picker, and it may already be selected.\n", model, vscodeOllamaName)
+	fmt.Fprintf(os.Stderr, "     If it isn't selected, open the model picker and choose it from the \"%s\" section.\n\n", vscodeOllamaName)
 }
 
 func (v *VSCode) Paths() []string {
@@ -238,12 +267,10 @@ func (v *VSCode) Paths() []string {
 	return nil
 }
 
-func (v *VSCode) Edit(models []LaunchModel) error {
-	if len(models) == 0 {
-		return nil
-	}
-
-	// Write chatLanguageModels.json with Ollama vendor entry
+func (v *VSCode) writeProviderConfig() error {
+	// Write chatLanguageModels.json with an Ollama provider group. The
+	// extension intentionally discovers the full model catalog itself, so the
+	// launcher only persists connection config here.
 	clmPath := v.chatLanguageModelsPath()
 	if err := os.MkdirAll(filepath.Dir(clmPath), 0o755); err != nil {
 		return err
@@ -254,18 +281,18 @@ func (v *VSCode) Edit(models []LaunchModel) error {
 		_ = json.Unmarshal(data, &entries)
 	}
 
-	// Remove any existing Ollama entries, preserve others
+	// Remove any existing Ollama entries, preserve others.
 	filtered := make([]map[string]any, 0, len(entries))
 	for _, entry := range entries {
-		if vendor, _ := entry["vendor"].(string); vendor != "ollama" {
+		if vendor, _ := entry["vendor"].(string); vendor != "ollama" && vendor != vscodeOllamaVendor {
 			filtered = append(filtered, entry)
 		}
 	}
 
 	// Add new Ollama entry
 	filtered = append(filtered, map[string]any{
-		"vendor": "ollama",
-		"name":   "Ollama",
+		"vendor": vscodeOllamaVendor,
+		"name":   vscodeOllamaName,
 		"url":    envconfig.Host().String(),
 	})
 
@@ -283,16 +310,6 @@ func (v *VSCode) Edit(models []LaunchModel) error {
 	return nil
 }
 
-func (v *VSCode) Models() []string {
-	if !v.hasOllamaVendor() {
-		return nil
-	}
-	if cfg, err := loadStoredIntegrationConfig("vscode"); err == nil {
-		return cfg.Models
-	}
-	return nil
-}
-
 // hasOllamaVendor checks if chatLanguageModels.json contains an Ollama vendor entry.
 func (v *VSCode) hasOllamaVendor() bool {
 	data, err := os.ReadFile(v.chatLanguageModelsPath())
@@ -306,7 +323,7 @@ func (v *VSCode) hasOllamaVendor() bool {
 	}
 
 	for _, entry := range entries {
-		if vendor, _ := entry["vendor"].(string); vendor == "ollama" {
+		if vendor, _ := entry["vendor"].(string); vendor == vscodeOllamaVendor {
 			return true
 		}
 	}
@@ -357,12 +374,11 @@ func (v *VSCode) statePath() string {
 	return v.vscodePath("globalStorage", "state.vscdb")
 }
 
-// ShowInModelPicker ensures the given models are visible in VS Code's Copilot
-// Chat model picker. It sets the configured models to true in the picker
-// preferences so they appear in the dropdown. Models use the VS Code identifier
-// format "ollama/Ollama/<name>".
-func (v *VSCode) ShowInModelPicker(models []string) error {
-	if len(models) == 0 {
+// ShowInModelPicker selects the requested model in VS Code's Copilot Chat
+// model picker. Model visibility is left to the extension, which discovers the
+// full Ollama catalog.
+func (v *VSCode) ShowInModelPicker(model string) error {
+	if model == "" {
 		return nil
 	}
 
@@ -394,8 +410,9 @@ func (v *VSCode) ShowInModelPicker(models []string) error {
 		_ = json.Unmarshal([]byte(prefsJSON), &prefs)
 	}
 
-	// Build name→ID map from VS Code's cached model list.
-	// VS Code uses numeric IDs like "ollama/Ollama/4", not "ollama/Ollama/kimi-k2.5:cloud".
+	// Build name→ID map from VS Code's cached model list. If VS Code has
+	// already resolved this provider, the cached identifier is the most exact
+	// representation of the model.
 	nameToID := make(map[string]string)
 	var cacheJSON string
 	if err := db.QueryRow("SELECT value FROM ItemTable WHERE key = 'chat.cachedLanguageModels.v2'").Scan(&cacheJSON); err == nil {
@@ -406,7 +423,7 @@ func (v *VSCode) ShowInModelPicker(models []string) error {
 				if meta == nil {
 					continue
 				}
-				if vendor, _ := meta["vendor"].(string); vendor == "ollama" {
+				if vendor, _ := meta["vendor"].(string); vendor == vscodeOllamaVendor {
 					name, _ := meta["name"].(string)
 					id, _ := entry["identifier"].(string)
 					if name != "" && id != "" {
@@ -417,23 +434,21 @@ func (v *VSCode) ShowInModelPicker(models []string) error {
 		}
 	}
 
-	// Ollama config is authoritative: always show configured models,
-	// hide Ollama models that are no longer in the config.
-	configuredIDs := make(map[string]bool)
-	for _, m := range models {
-		for _, id := range v.modelVSCodeIDs(m, nameToID) {
-			prefs[id] = true
-			configuredIDs[id] = true
-		}
-	}
+	// The extension owns model discovery and picker visibility. Clear launch's
+	// old per-model overrides so previously hidden models can show up again.
 	for id := range prefs {
-		if strings.HasPrefix(id, "ollama/") && !configuredIDs[id] {
-			prefs[id] = false
+		if strings.HasPrefix(id, vscodeOllamaVendor+"/") {
+			delete(prefs, id)
 		}
 	}
 
 	data, _ := json.Marshal(prefs)
 	if _, err = db.Exec("INSERT OR REPLACE INTO ItemTable (key, value) VALUES ('chatModelPickerPreferences', ?)", string(data)); err != nil {
+		return err
+	}
+
+	selectedID := v.primaryModelVSCodeID(model, nameToID)
+	if err := v.selectChatModel(db, selectedID); err != nil {
 		return err
 	}
 
@@ -450,11 +465,46 @@ func (v *VSCode) modelVSCodeIDs(model string, nameToID map[string]string) []stri
 			ids = append(ids, id)
 		}
 	}
-	ids = append(ids, "ollama/Ollama/"+model)
+	ids = append(ids, vscodeOllamaVendor+"/"+model)
+	ids = append(ids, vscodeOllamaVendor+"/"+vscodeOllamaName+"/"+model)
 	if !strings.Contains(model, ":") {
-		ids = append(ids, "ollama/Ollama/"+model+":latest")
+		ids = append(ids, vscodeOllamaVendor+"/"+model+":latest")
+		ids = append(ids, vscodeOllamaVendor+"/"+vscodeOllamaName+"/"+model+":latest")
 	}
 	return ids
+}
+
+func (v *VSCode) primaryModelVSCodeID(model string, nameToID map[string]string) string {
+	return v.modelVSCodeIDs(model, nameToID)[0]
+}
+
+func (v *VSCode) selectChatModel(db *sql.DB, modelID string) error {
+	if _, err := db.Exec("INSERT OR REPLACE INTO ItemTable (key, value) VALUES ('chat.currentLanguageModel.panel', ?)", modelID); err != nil {
+		return err
+	}
+	if _, err := db.Exec("INSERT OR REPLACE INTO ItemTable (key, value) VALUES ('chat.currentLanguageModel.panel.isDefault', 'false')"); err != nil {
+		return err
+	}
+
+	recent := []string{}
+	var recentJSON string
+	if err := db.QueryRow("SELECT value FROM ItemTable WHERE key = 'chatModelRecentlyUsed'").Scan(&recentJSON); err == nil {
+		_ = json.Unmarshal([]byte(recentJSON), &recent)
+	}
+
+	updated := []string{modelID}
+	for _, id := range recent {
+		if id != modelID {
+			updated = append(updated, id)
+		}
+	}
+	if len(updated) > 20 {
+		updated = updated[:20]
+	}
+
+	data, _ := json.Marshal(updated)
+	_, err := db.Exec("INSERT OR REPLACE INTO ItemTable (key, value) VALUES ('chatModelRecentlyUsed', ?)", string(data))
+	return err
 }
 
 func (v *VSCode) vscodePath(parts ...string) string {
@@ -496,8 +546,10 @@ func (v *VSCode) checkVSCodeVersion() {
 	}
 }
 
-// checkCopilotChatVersion warns if the GitHub Copilot Chat extension is
-// missing or older than minCopilotChatVersion.
+// checkCopilotChatVersion warns if the explicitly installed GitHub Copilot
+// Chat extension is older than the recommended version. Missing is not treated
+// as an error because newer VS Code builds may provide chat without listing
+// github.copilot-chat in --list-extensions output.
 func (v *VSCode) checkCopilotChatVersion() {
 	codeCLI := v.findCodeCLI()
 	if codeCLI == "" {
@@ -511,13 +563,43 @@ func (v *VSCode) checkCopilotChatVersion() {
 
 	installed, version := parseCopilotChatVersion(string(out))
 	if !installed {
-		fmt.Fprintf(os.Stderr, "\n%sWarning: GitHub Copilot Chat extension is not installed%s\n", ansiYellow, ansiReset)
-		fmt.Fprintf(os.Stderr, "Install it in VS Code: Extensions → search \"GitHub Copilot Chat\" → Install\n\n")
 		return
 	}
 	if compareVersions(version, minCopilotChatVersion) < 0 {
 		fmt.Fprintf(os.Stderr, "\n%sWarning: GitHub Copilot Chat extension version (%s) is older than the recommended version (%s)%s\n", ansiYellow, version, minCopilotChatVersion, ansiReset)
 		fmt.Fprintf(os.Stderr, "Please update it in VS Code: Extensions → search \"GitHub Copilot Chat\" → Update\n\n")
+	}
+}
+
+func (v *VSCode) ensureOllamaExtensionInstalled() {
+	codeCLI := v.findCodeCLI()
+	if codeCLI == "" {
+		fmt.Fprintf(os.Stderr, "%s  Warning: could not find VS Code CLI to install the Ollama extension%s\n", ansiYellow, ansiReset)
+		return
+	}
+
+	out, err := exec.Command(codeCLI, "--list-extensions", "--show-versions").Output()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s  Warning: could not list VS Code extensions: %v%s\n", ansiYellow, err, ansiReset)
+		return
+	}
+	if hasVSCodeExtension(string(out), vscodeOllamaExtensionID) {
+		return
+	}
+
+	vsixPath := os.Getenv(vscodeOllamaVSIXEnv)
+	if vsixPath == "" {
+		vsixPath = vscodeOllamaDefaultVSIXPath
+	}
+	if !fileExists(vsixPath) {
+		fmt.Fprintf(os.Stderr, "%s  Warning: Ollama VS Code extension is not installed and no VSIX was found at %s%s\n", ansiYellow, vsixPath, ansiReset)
+		fmt.Fprintf(os.Stderr, "     Build it with: cd extensions/vscode && npm run compile && npx --yes @vscode/vsce package --out %s\n\n", vsixPath)
+		return
+	}
+
+	fmt.Fprintf(os.Stderr, "Installing Ollama VS Code extension from %s...\n", vsixPath)
+	if out, err := exec.Command(codeCLI, "--install-extension", vsixPath, "--force").CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "%s  Warning: could not install Ollama VS Code extension: %v%s\n%s\n", ansiYellow, err, ansiReset, strings.TrimSpace(string(out)))
 	}
 }
 
@@ -554,6 +636,23 @@ func parseCopilotChatVersion(output string) (installed bool, version string) {
 		return true, strings.TrimSpace(parts[1])
 	}
 	return false, ""
+}
+
+func hasVSCodeExtension(output, extensionID string) bool {
+	extensionID = strings.ToLower(extensionID)
+	for _, line := range strings.Split(output, "\n") {
+		id := strings.TrimSpace(line)
+		if id == "" {
+			continue
+		}
+		if beforeVersion, _, ok := strings.Cut(id, "@"); ok {
+			id = beforeVersion
+		}
+		if strings.ToLower(id) == extensionID {
+			return true
+		}
+	}
+	return false
 }
 
 // compareVersions compares two dot-separated version strings.

--- a/cmd/launch/vscode_test.go
+++ b/cmd/launch/vscode_test.go
@@ -165,14 +165,13 @@ func TestVSCodeConfigure(t *testing.T) {
 	}
 }
 
-func TestVSCodeEditCleansUpOldSettings(t *testing.T) {
+func TestVSCodeConfigurePreservesCopilotBYOKSetting(t *testing.T) {
 	v := &VSCode{}
 	tmpDir := t.TempDir()
 	setTestHome(t, tmpDir)
 	t.Setenv("XDG_CONFIG_HOME", "")
 	settingsPath := testVSCodePath(t, tmpDir, "settings.json")
 
-	// Create settings.json with old byok setting
 	os.MkdirAll(filepath.Dir(settingsPath), 0o755)
 	os.WriteFile(settingsPath, []byte(`{"github.copilot.chat.byok.ollamaEndpoint": "http://old:11434", "ollama.launch.configured": true, "editor.fontSize": 14}`), 0o644)
 
@@ -180,7 +179,45 @@ func TestVSCodeEditCleansUpOldSettings(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Verify old settings were removed
+	// Verify launch-owned settings were updated without removing Copilot BYOK.
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var settings map[string]any
+	json.Unmarshal(data, &settings)
+	if settings["github.copilot.chat.byok.ollamaEndpoint"] != "http://old:11434" {
+		t.Error("github.copilot.chat.byok.ollamaEndpoint should be preserved until launch confirmation")
+	}
+	if _, ok := settings["ollama.launch.configured"]; ok {
+		t.Error("ollama.launch.configured should have been removed")
+	}
+	if settings["ollama.endpoint"] != envconfig.Host().String() {
+		t.Errorf("ollama.endpoint = %v, want %q", settings["ollama.endpoint"], envconfig.Host().String())
+	}
+	if settings["editor.fontSize"] != float64(14) {
+		t.Error("editor.fontSize should have been preserved")
+	}
+}
+
+func TestVSCodeRemoveLegacySettingsCleansUpOldSettings(t *testing.T) {
+	v := &VSCode{}
+	tmpDir := t.TempDir()
+	setTestHome(t, tmpDir)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	settingsPath := testVSCodePath(t, tmpDir, "settings.json")
+
+	os.MkdirAll(filepath.Dir(settingsPath), 0o755)
+	os.WriteFile(settingsPath, []byte(`{"github.copilot.chat.byok.ollamaEndpoint": "http://old:11434", "ollama.launch.configured": true, "editor.fontSize": 14}`), 0o644)
+
+	if !v.hasLegacyCopilotBYOKSetting() {
+		t.Fatal("expected legacy Copilot BYOK setting to be detected")
+	}
+	if err := v.removeLegacyVSCodeSettings(); err != nil {
+		t.Fatal(err)
+	}
+
 	data, err := os.ReadFile(settingsPath)
 	if err != nil {
 		t.Fatal(err)
@@ -194,11 +231,95 @@ func TestVSCodeEditCleansUpOldSettings(t *testing.T) {
 	if _, ok := settings["ollama.launch.configured"]; ok {
 		t.Error("ollama.launch.configured should have been removed")
 	}
-	if settings["ollama.endpoint"] != envconfig.Host().String() {
-		t.Errorf("ollama.endpoint = %v, want %q", settings["ollama.endpoint"], envconfig.Host().String())
-	}
 	if settings["editor.fontSize"] != float64(14) {
 		t.Error("editor.fontSize should have been preserved")
+	}
+}
+
+func TestVSCodeSetupPrompt(t *testing.T) {
+	tests := []struct {
+		name               string
+		extensionInstalled bool
+		hasLegacyBYOK      bool
+		running            bool
+		want               string
+	}{
+		{
+			name:               "install cleanup and restart",
+			extensionInstalled: false,
+			hasLegacyBYOK:      true,
+			running:            true,
+			want:               "Install Ollama VS Code extension, remove old Copilot BYOK setting, and restart VS Code?",
+		},
+		{
+			name:               "install and cleanup",
+			extensionInstalled: false,
+			hasLegacyBYOK:      true,
+			want:               "Install Ollama VS Code extension and remove old Copilot BYOK setting?",
+		},
+		{
+			name:               "install and restart",
+			extensionInstalled: false,
+			running:            true,
+			want:               "Install Ollama VS Code extension and restart VS Code?",
+		},
+		{
+			name:               "install only",
+			extensionInstalled: false,
+			want:               "Install Ollama VS Code extension?",
+		},
+		{
+			name:               "cleanup and restart",
+			extensionInstalled: true,
+			hasLegacyBYOK:      true,
+			running:            true,
+			want:               "Remove old Copilot BYOK setting and restart VS Code?",
+		},
+		{
+			name:               "cleanup only",
+			extensionInstalled: true,
+			hasLegacyBYOK:      true,
+			want:               "Remove old Copilot BYOK setting?",
+		},
+		{
+			name:               "no setup needed",
+			extensionInstalled: true,
+			want:               "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := vscodeSetupPrompt(tt.extensionInstalled, tt.hasLegacyBYOK, tt.running)
+			if got != tt.want {
+				t.Fatalf("vscodeSetupPrompt() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVSCodeLegacyBYOKDetectionAddsCleanupToSetupPrompt(t *testing.T) {
+	v := &VSCode{}
+	tmpDir := t.TempDir()
+	setTestHome(t, tmpDir)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	settingsPath := testVSCodePath(t, tmpDir, "settings.json")
+
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(settingsPath, []byte(`{"github.copilot.chat.byok.ollamaEndpoint":"http://127.0.0.1:11434"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if !v.hasLegacyCopilotBYOKSetting() {
+		t.Fatal("expected legacy Copilot BYOK setting to be detected")
+	}
+
+	got := vscodeSetupPrompt(false, v.hasLegacyCopilotBYOKSetting(), true)
+	want := "Install Ollama VS Code extension, remove old Copilot BYOK setting, and restart VS Code?"
+	if got != want {
+		t.Fatalf("vscodeSetupPrompt() = %q, want %q", got, want)
 	}
 }
 
@@ -335,9 +456,6 @@ func assertSettingsConfigured(t *testing.T, data []byte, extras map[string]any) 
 
 	if settings["ollama.endpoint"] != envconfig.Host().String() {
 		t.Fatalf("ollama.endpoint = %v, want %q", settings["ollama.endpoint"], envconfig.Host().String())
-	}
-	if _, ok := settings["github.copilot.chat.byok.ollamaEndpoint"]; ok {
-		t.Fatal("github.copilot.chat.byok.ollamaEndpoint should have been removed")
 	}
 	if _, ok := settings["ollama.launch.configured"]; ok {
 		t.Fatal("ollama.launch.configured should have been removed")

--- a/cmd/launch/vscode_test.go
+++ b/cmd/launch/vscode_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -25,12 +26,12 @@ func TestVSCodeIntegration(t *testing.T) {
 		var _ Runner = v
 	})
 
-	t.Run("implements Editor", func(t *testing.T) {
-		var _ Editor = v
+	t.Run("implements ManagedSingleModel", func(t *testing.T) {
+		var _ ManagedSingleModel = v
 	})
 }
 
-func TestVSCodeEdit(t *testing.T) {
+func TestVSCodeConfigure(t *testing.T) {
 	v := &VSCode{}
 	tmpDir := t.TempDir()
 	setTestHome(t, tmpDir)
@@ -40,20 +41,20 @@ func TestVSCodeEdit(t *testing.T) {
 	tests := []struct {
 		name     string
 		setup    string // initial chatLanguageModels.json content, empty means no file
-		models   []string
+		model    string
 		validate func(t *testing.T, data []byte)
 	}{
 		{
-			name:   "fresh install",
-			models: []string{"llama3.2"},
+			name:  "fresh install",
+			model: "llama3.2",
 			validate: func(t *testing.T, data []byte) {
 				assertOllamaVendorConfigured(t, data)
 			},
 		},
 		{
-			name:   "preserve other vendor entries",
-			setup:  `[{"vendor": "azure", "name": "Azure", "url": "https://example.com"}]`,
-			models: []string{"llama3.2"},
+			name:  "preserve other vendor entries",
+			setup: `[{"vendor": "azure", "name": "Azure", "url": "https://example.com"}]`,
+			model: "llama3.2",
 			validate: func(t *testing.T, data []byte) {
 				var entries []map[string]any
 				json.Unmarshal(data, &entries)
@@ -74,27 +75,27 @@ func TestVSCodeEdit(t *testing.T) {
 			},
 		},
 		{
-			name:   "update existing ollama entry",
-			setup:  `[{"vendor": "ollama", "name": "Ollama", "url": "http://old:11434"}]`,
-			models: []string{"llama3.2"},
+			name:  "update existing ollama entry",
+			setup: `[{"vendor": "ollama", "name": "Ollama", "url": "http://old:11434"}]`,
+			model: "llama3.2",
 			validate: func(t *testing.T, data []byte) {
 				assertOllamaVendorConfigured(t, data)
 			},
 		},
 		{
-			name:   "empty models is no-op",
-			setup:  `[{"vendor": "azure", "name": "Azure"}]`,
-			models: []string{},
+			name:  "empty model is no-op",
+			setup: `[{"vendor": "azure", "name": "Azure"}]`,
+			model: "",
 			validate: func(t *testing.T, data []byte) {
 				if string(data) != `[{"vendor": "azure", "name": "Azure"}]` {
-					t.Error("empty models should not modify file")
+					t.Error("empty model should not modify file")
 				}
 			},
 		},
 		{
-			name:   "corrupted JSON treated as empty",
-			setup:  `{corrupted json`,
-			models: []string{"llama3.2"},
+			name:  "corrupted JSON treated as empty",
+			setup: `{corrupted json`,
+			model: "llama3.2",
 			validate: func(t *testing.T, data []byte) {
 				var entries []map[string]any
 				if err := json.Unmarshal(data, &entries); err != nil {
@@ -113,7 +114,7 @@ func TestVSCodeEdit(t *testing.T) {
 				os.WriteFile(clmPath, []byte(tt.setup), 0o644)
 			}
 
-			if err := v.Edit(launchModelsFromNames(tt.models)); err != nil {
+			if err := v.Configure(tt.model); err != nil {
 				t.Fatal(err)
 			}
 
@@ -134,7 +135,7 @@ func TestVSCodeEditCleansUpOldSettings(t *testing.T) {
 	os.MkdirAll(filepath.Dir(settingsPath), 0o755)
 	os.WriteFile(settingsPath, []byte(`{"github.copilot.chat.byok.ollamaEndpoint": "http://old:11434", "ollama.launch.configured": true, "editor.fontSize": 14}`), 0o644)
 
-	if err := v.Edit(testLaunchModels("llama3.2")); err != nil {
+	if err := v.Configure("llama3.2"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -180,7 +181,7 @@ func TestVSCodeEdit_CreatesDistinctBackupsForManagedFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := v.Edit(testLaunchModels("llama3.2")); err != nil {
+	if err := v.Configure("llama3.2"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -249,17 +250,20 @@ func assertOllamaVendorConfigured(t *testing.T, data []byte) {
 	}
 
 	for _, entry := range entries {
-		if vendor, _ := entry["vendor"].(string); vendor == "ollama" {
-			if name, _ := entry["name"].(string); name != "Ollama" {
-				t.Errorf("expected name \"Ollama\", got %q", name)
+		if vendor, _ := entry["vendor"].(string); vendor == vscodeOllamaVendor {
+			if name, _ := entry["name"].(string); name != vscodeOllamaName {
+				t.Errorf("expected name %q, got %q", vscodeOllamaName, name)
 			}
 			if url, _ := entry["url"].(string); url == "" {
 				t.Error("url not set")
 			}
+			if _, ok := entry["models"]; ok {
+				t.Fatalf("provider config should not pin models, got %#v", entry["models"])
+			}
 			return
 		}
 	}
-	t.Error("no ollama vendor entry found")
+	t.Errorf("no %s vendor entry found", vscodeOllamaVendor)
 }
 
 func TestShowInModelPicker(t *testing.T) {
@@ -310,7 +314,7 @@ func TestShowInModelPicker(t *testing.T) {
 		return prefs
 	}
 
-	t.Run("fresh DB creates table and shows models", func(t *testing.T) {
+	t.Run("fresh DB creates table and selects model", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		setTestHome(t, tmpDir)
 		t.Setenv("XDG_CONFIG_HOME", "")
@@ -318,67 +322,58 @@ func TestShowInModelPicker(t *testing.T) {
 			t.Setenv("APPDATA", tmpDir)
 		}
 
-		err := v.ShowInModelPicker([]string{"llama3.2"})
+		err := v.ShowInModelPicker("llama3.2")
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		dbPath := testVSCodePath(t, tmpDir, filepath.Join("globalStorage", "state.vscdb"))
 		prefs := readPrefs(t, dbPath)
-		if !prefs["ollama/Ollama/llama3.2"] {
-			t.Error("expected llama3.2 to be shown")
+		if len(prefs) != 0 {
+			t.Fatalf("expected no model picker overrides, got %#v", prefs)
 		}
-		if !prefs["ollama/Ollama/llama3.2:latest"] {
-			t.Error("expected llama3.2:latest to be shown")
-		}
+		assertSelectedChatModel(t, dbPath, vscodeOllamaVendor+"/llama3.2")
 	})
 
-	t.Run("configured models are shown", func(t *testing.T) {
+	t.Run("selected model is stored", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		setTestHome(t, tmpDir)
 		t.Setenv("XDG_CONFIG_HOME", "")
 		dbPath := setupDB(t, testVSCodePath(t, tmpDir, ""), nil, nil)
 
-		err := v.ShowInModelPicker([]string{"llama3.2", "qwen3:8b"})
+		err := v.ShowInModelPicker("llama3.2")
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		prefs := readPrefs(t, dbPath)
-		if !prefs["ollama/Ollama/llama3.2"] {
-			t.Error("expected llama3.2 to be shown")
+		if len(prefs) != 0 {
+			t.Fatalf("expected no model picker overrides, got %#v", prefs)
 		}
-		if !prefs["ollama/Ollama/qwen3:8b"] {
-			t.Error("expected qwen3:8b to be shown")
-		}
+		assertSelectedChatModel(t, dbPath, vscodeOllamaVendor+"/llama3.2")
 	})
 
-	t.Run("removed models are hidden", func(t *testing.T) {
+	t.Run("old launch-managed model visibility overrides are cleared", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		setTestHome(t, tmpDir)
 		t.Setenv("XDG_CONFIG_HOME", "")
 		dbPath := setupDB(t, testVSCodePath(t, tmpDir, ""), map[string]bool{
-			"ollama/Ollama/llama3.2":        true,
-			"ollama/Ollama/llama3.2:latest": true,
-			"ollama/Ollama/mistral":         true,
-			"ollama/Ollama/mistral:latest":  true,
+			vscodeOllamaVendor + "/llama3.2":        true,
+			vscodeOllamaVendor + "/llama3.2:latest": true,
+			vscodeOllamaVendor + "/mistral":         true,
+			vscodeOllamaVendor + "/mistral:latest":  true,
 		}, nil)
 
-		// Only configure llama3.2 — mistral should get hidden
-		err := v.ShowInModelPicker([]string{"llama3.2"})
+		err := v.ShowInModelPicker("llama3.2")
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		prefs := readPrefs(t, dbPath)
-		if !prefs["ollama/Ollama/llama3.2"] {
-			t.Error("expected llama3.2 to stay shown")
-		}
-		if prefs["ollama/Ollama/mistral"] {
-			t.Error("expected mistral to be hidden")
-		}
-		if prefs["ollama/Ollama/mistral:latest"] {
-			t.Error("expected mistral:latest to be hidden")
+		for id := range prefs {
+			if strings.HasPrefix(id, vscodeOllamaVendor+"/") {
+				t.Fatalf("expected %s overrides to be cleared, got %#v", vscodeOllamaVendor, prefs)
+			}
 		}
 	})
 
@@ -390,7 +385,7 @@ func TestShowInModelPicker(t *testing.T) {
 			"copilot/gpt-4o": true,
 		}, nil)
 
-		err := v.ShowInModelPicker([]string{"llama3.2"})
+		err := v.ShowInModelPicker("llama3.2")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -407,54 +402,89 @@ func TestShowInModelPicker(t *testing.T) {
 		t.Setenv("XDG_CONFIG_HOME", "")
 		cache := []map[string]any{
 			{
-				"identifier": "ollama/Ollama/4",
-				"metadata":   map[string]any{"vendor": "ollama", "name": "llama3.2"},
+				"identifier": vscodeOllamaVendor + "/" + vscodeOllamaName + "/4",
+				"metadata":   map[string]any{"vendor": vscodeOllamaVendor, "name": "llama3.2"},
 			},
 		}
 		dbPath := setupDB(t, testVSCodePath(t, tmpDir, ""), nil, cache)
 
-		err := v.ShowInModelPicker([]string{"llama3.2"})
+		err := v.ShowInModelPicker("llama3.2")
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		prefs := readPrefs(t, dbPath)
-		if !prefs["ollama/Ollama/4"] {
-			t.Error("expected numeric ID ollama/Ollama/4 to be shown")
+		if len(prefs) != 0 {
+			t.Fatalf("expected no model picker overrides, got %#v", prefs)
 		}
-		// Name-based fallback should also be set
-		if !prefs["ollama/Ollama/llama3.2"] {
-			t.Error("expected name-based ID to also be shown")
-		}
+		assertSelectedChatModel(t, dbPath, vscodeOllamaVendor+"/"+vscodeOllamaName+"/4")
 	})
 
-	t.Run("empty models is no-op", func(t *testing.T) {
-		err := v.ShowInModelPicker([]string{})
+	t.Run("empty model is no-op", func(t *testing.T) {
+		err := v.ShowInModelPicker("")
 		if err != nil {
 			t.Fatal(err)
 		}
 	})
 
-	t.Run("previously hidden model is re-shown when configured", func(t *testing.T) {
+	t.Run("previously hidden selected model uses extension default visibility", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		setTestHome(t, tmpDir)
 		t.Setenv("XDG_CONFIG_HOME", "")
 		dbPath := setupDB(t, testVSCodePath(t, tmpDir, ""), map[string]bool{
-			"ollama/Ollama/llama3.2":        false,
-			"ollama/Ollama/llama3.2:latest": false,
+			vscodeOllamaVendor + "/llama3.2":        false,
+			vscodeOllamaVendor + "/llama3.2:latest": false,
 		}, nil)
 
-		// Ollama config is authoritative — should override the hidden state
-		err := v.ShowInModelPicker([]string{"llama3.2"})
+		err := v.ShowInModelPicker("llama3.2")
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		prefs := readPrefs(t, dbPath)
-		if !prefs["ollama/Ollama/llama3.2"] {
-			t.Error("expected llama3.2 to be re-shown")
+		for id := range prefs {
+			if strings.HasPrefix(id, vscodeOllamaVendor+"/") {
+				t.Fatalf("expected %s overrides to be cleared, got %#v", vscodeOllamaVendor, prefs)
+			}
 		}
 	})
+}
+
+func assertSelectedChatModel(t *testing.T, dbPath, want string) {
+	t.Helper()
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	var selected string
+	if err := db.QueryRow("SELECT value FROM ItemTable WHERE key = 'chat.currentLanguageModel.panel'").Scan(&selected); err != nil {
+		t.Fatal(err)
+	}
+	if selected != want {
+		t.Fatalf("selected model = %q, want %q", selected, want)
+	}
+
+	var isDefault string
+	if err := db.QueryRow("SELECT value FROM ItemTable WHERE key = 'chat.currentLanguageModel.panel.isDefault'").Scan(&isDefault); err != nil {
+		t.Fatal(err)
+	}
+	if isDefault != "false" {
+		t.Fatalf("selected model default flag = %q, want false", isDefault)
+	}
+
+	var recentJSON string
+	if err := db.QueryRow("SELECT value FROM ItemTable WHERE key = 'chatModelRecentlyUsed'").Scan(&recentJSON); err != nil {
+		t.Fatal(err)
+	}
+	var recent []string
+	if err := json.Unmarshal([]byte(recentJSON), &recent); err != nil {
+		t.Fatal(err)
+	}
+	if len(recent) == 0 || recent[0] != want {
+		t.Fatalf("recent models = %#v, want %q first", recent, want)
+	}
 }
 
 func TestParseCopilotChatVersion(t *testing.T) {
@@ -504,6 +534,23 @@ func TestParseCopilotChatVersion(t *testing.T) {
 				t.Errorf("version = %q, want %q", version, tt.wantVersion)
 			}
 		})
+	}
+}
+
+func TestHasVSCodeExtension(t *testing.T) {
+	output := "github.copilot-chat@0.41.0\nollama.ollama-vscode@0.0.1\nms-python.python\n"
+
+	if !hasVSCodeExtension(output, "ollama.ollama-vscode") {
+		t.Fatal("expected Ollama extension to be detected")
+	}
+	if !hasVSCodeExtension(output, "Ollama.Ollama-VSCode") {
+		t.Fatal("expected extension detection to be case-insensitive")
+	}
+	if hasVSCodeExtension(output, "ollama.missing") {
+		t.Fatal("unexpected missing extension detected")
+	}
+	if !hasVSCodeExtension(output, "ms-python.python") {
+		t.Fatal("expected extension without version to be detected")
 	}
 }
 

--- a/cmd/launch/vscode_test.go
+++ b/cmd/launch/vscode_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -52,9 +51,7 @@ func TestVSCodeConfigure(t *testing.T) {
 			model:        "llama3.2",
 			wantSettings: true,
 			validate: func(t *testing.T, clmData []byte, settingsData []byte) {
-				if len(clmData) != 0 {
-					t.Fatalf("expected no chatLanguageModels.json to be created, got %q", string(clmData))
-				}
+				assertOllamaProviderConfigured(t, clmData)
 				assertSettingsConfigured(t, settingsData, nil)
 			},
 		},
@@ -66,12 +63,19 @@ func TestVSCodeConfigure(t *testing.T) {
 			validate: func(t *testing.T, clmData []byte, settingsData []byte) {
 				var entries []map[string]any
 				json.Unmarshal(clmData, &entries)
-				if len(entries) != 1 {
-					t.Errorf("expected 1 entry, got %d", len(entries))
+				if len(entries) != 2 {
+					t.Errorf("expected 2 entries, got %d", len(entries))
 				}
-				if vendor, _ := entries[0]["vendor"].(string); vendor != "azure" {
-					t.Fatalf("expected azure entry to be preserved, got %#v", entries[0])
+				foundAzure := false
+				for _, entry := range entries {
+					if vendor, _ := entry["vendor"].(string); vendor == "azure" {
+						foundAzure = true
+					}
 				}
+				if !foundAzure {
+					t.Fatalf("expected azure entry to be preserved, got %#v", entries)
+				}
+				assertOllamaProviderConfigured(t, clmData)
 				assertSettingsConfigured(t, settingsData, nil)
 			},
 		},
@@ -81,7 +85,7 @@ func TestVSCodeConfigure(t *testing.T) {
 			model:        "llama3.2",
 			wantSettings: true,
 			validate: func(t *testing.T, clmData []byte, settingsData []byte) {
-				assertChatLanguageModelsCleaned(t, clmData)
+				assertOllamaProviderConfigured(t, clmData)
 				assertSettingsConfigured(t, settingsData, nil)
 			},
 		},
@@ -96,14 +100,19 @@ func TestVSCodeConfigure(t *testing.T) {
 					t.Fatalf("invalid JSON: %v", err)
 				}
 
-				if len(entries) != 1 {
-					t.Fatalf("expected only the non-Ollama entry to remain, got %#v", entries)
+				if len(entries) != 2 {
+					t.Fatalf("expected non-Ollama entry plus one configured provider, got %#v", entries)
 				}
+				managed := 0
 				for _, entry := range entries {
 					if isManagedOllamaProviderEntry(entry) {
-						t.Fatalf("expected managed Ollama provider entries to be removed, got %#v", entries)
+						managed++
 					}
 				}
+				if managed != 1 {
+					t.Fatalf("expected exactly one managed Ollama provider entry, got %#v", entries)
+				}
+				assertOllamaProviderConfigured(t, clmData)
 				assertSettingsConfigured(t, settingsData, nil)
 			},
 		},
@@ -127,7 +136,7 @@ func TestVSCodeConfigure(t *testing.T) {
 			model:        "llama3.2",
 			wantSettings: true,
 			validate: func(t *testing.T, clmData []byte, settingsData []byte) {
-				assertChatLanguageModelsCleaned(t, clmData)
+				assertOllamaProviderConfigured(t, clmData)
 				assertSettingsConfigured(t, settingsData, nil)
 			},
 		},
@@ -303,6 +312,34 @@ func assertChatLanguageModelsCleaned(t *testing.T, data []byte) {
 	}
 }
 
+func assertOllamaProviderConfigured(t *testing.T, data []byte) {
+	t.Helper()
+	var entries []map[string]any
+	if err := json.Unmarshal(data, &entries); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	var managed []map[string]any
+	for _, entry := range entries {
+		if isManagedOllamaProviderEntry(entry) {
+			managed = append(managed, entry)
+		}
+	}
+	if len(managed) != 1 {
+		t.Fatalf("expected exactly one managed Ollama provider, got %#v", entries)
+	}
+	entry := managed[0]
+	if vendor, _ := entry["vendor"].(string); vendor != vscodeOllamaVendor {
+		t.Fatalf("vendor = %q, want %q", vendor, vscodeOllamaVendor)
+	}
+	if name, _ := entry["name"].(string); name != vscodeOllamaName {
+		t.Fatalf("name = %q, want %q", name, vscodeOllamaName)
+	}
+	if url, _ := entry["url"].(string); url != envconfig.Host().String() {
+		t.Fatalf("url = %q, want %q", url, envconfig.Host().String())
+	}
+}
+
 func assertSettingsConfigured(t *testing.T, data []byte, extras map[string]any) {
 	t.Helper()
 	var settings map[string]any
@@ -392,7 +429,7 @@ func TestShowInModelPicker(t *testing.T) {
 		if len(prefs) != 0 {
 			t.Fatalf("expected no model picker overrides, got %#v", prefs)
 		}
-		assertSelectedChatModel(t, dbPath, vscodeOllamaVendor+"/llama3.2")
+		assertSelectedChatModel(t, dbPath, vscodeOllamaVendor+"/"+vscodeOllamaName+"/llama3.2:latest")
 	})
 
 	t.Run("selected model is stored", func(t *testing.T) {
@@ -410,7 +447,7 @@ func TestShowInModelPicker(t *testing.T) {
 		if len(prefs) != 0 {
 			t.Fatalf("expected no model picker overrides, got %#v", prefs)
 		}
-		assertSelectedChatModel(t, dbPath, vscodeOllamaVendor+"/llama3.2")
+		assertSelectedChatModel(t, dbPath, vscodeOllamaVendor+"/"+vscodeOllamaName+"/llama3.2:latest")
 	})
 
 	t.Run("old launch-managed model visibility overrides are cleared", func(t *testing.T) {
@@ -422,6 +459,7 @@ func TestShowInModelPicker(t *testing.T) {
 			vscodeOllamaVendor + "/llama3.2:latest": true,
 			vscodeOllamaVendor + "/mistral":         true,
 			vscodeOllamaVendor + "/mistral:latest":  true,
+			legacyVSCodeOllamaVendor + "/llama3.2":  true,
 		}, nil)
 
 		err := v.ShowInModelPicker("llama3.2")
@@ -431,8 +469,8 @@ func TestShowInModelPicker(t *testing.T) {
 
 		prefs := readPrefs(t, dbPath)
 		for id := range prefs {
-			if strings.HasPrefix(id, vscodeOllamaVendor+"/") {
-				t.Fatalf("expected %s overrides to be cleared, got %#v", vscodeOllamaVendor, prefs)
+			if isManagedOllamaModelID(id) {
+				t.Fatalf("expected managed Ollama overrides to be cleared, got %#v", prefs)
 			}
 		}
 	})
@@ -480,7 +518,7 @@ func TestShowInModelPicker(t *testing.T) {
 		assertSelectedChatModel(t, dbPath, vscodeOllamaVendor+"/4")
 	})
 
-	t.Run("removes stale named ollama cache entries", func(t *testing.T) {
+	t.Run("keeps current named cache entries and removes legacy named entries", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		setTestHome(t, tmpDir)
 		t.Setenv("XDG_CONFIG_HOME", "")
@@ -493,6 +531,10 @@ func TestShowInModelPicker(t *testing.T) {
 				"identifier": vscodeOllamaVendor + "/" + vscodeOllamaName + "/qwen3.6-latest-8e5d0015",
 				"metadata":   map[string]any{"vendor": vscodeOllamaVendor, "name": "qwen3.6:latest", "detail": vscodeOllamaName},
 			},
+			{
+				"identifier": legacyVSCodeOllamaVendor + "/" + vscodeOllamaName + "/qwen3.6-latest-8e5d0015",
+				"metadata":   map[string]any{"vendor": legacyVSCodeOllamaVendor, "name": "qwen3.6:latest", "detail": vscodeOllamaName},
+			},
 		}
 		dbPath := setupDB(t, testVSCodePath(t, tmpDir, ""), nil, cache)
 
@@ -501,8 +543,9 @@ func TestShowInModelPicker(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		assertSelectedChatModel(t, dbPath, vscodeOllamaVendor+"/qwen3.6-latest-8e5d0015")
+		assertSelectedChatModel(t, dbPath, vscodeOllamaVendor+"/"+vscodeOllamaName+"/qwen3.6-latest-8e5d0015")
 		assertNoStaleCachedOllamaEntries(t, dbPath)
+		assertCachedLanguageModelPresent(t, dbPath, vscodeOllamaVendor+"/"+vscodeOllamaName+"/qwen3.6-latest-8e5d0015")
 	})
 
 	t.Run("empty model is no-op", func(t *testing.T) {
@@ -528,8 +571,8 @@ func TestShowInModelPicker(t *testing.T) {
 
 		prefs := readPrefs(t, dbPath)
 		for id := range prefs {
-			if strings.HasPrefix(id, vscodeOllamaVendor+"/") {
-				t.Fatalf("expected %s overrides to be cleared, got %#v", vscodeOllamaVendor, prefs)
+			if isManagedOllamaModelID(id) {
+				t.Fatalf("expected managed Ollama overrides to be cleared, got %#v", prefs)
 			}
 		}
 	})
@@ -597,6 +640,32 @@ func assertNoStaleCachedOllamaEntries(t *testing.T, dbPath string) {
 	}
 }
 
+func assertCachedLanguageModelPresent(t *testing.T, dbPath, want string) {
+	t.Helper()
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	var cacheJSON string
+	if err := db.QueryRow("SELECT value FROM ItemTable WHERE key = 'chat.cachedLanguageModels.v2'").Scan(&cacheJSON); err != nil {
+		t.Fatal(err)
+	}
+
+	var cached []map[string]any
+	if err := json.Unmarshal([]byte(cacheJSON), &cached); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, entry := range cached {
+		if id, _ := entry["identifier"].(string); id == want {
+			return
+		}
+	}
+	t.Fatalf("cached language model %q not found in %#v", want, cached)
+}
+
 func TestParseCopilotChatVersion(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -648,12 +717,12 @@ func TestParseCopilotChatVersion(t *testing.T) {
 }
 
 func TestHasVSCodeExtension(t *testing.T) {
-	output := "github.copilot-chat@0.41.0\nollama.ollama-vscode@0.0.1\nms-python.python\n"
+	output := "github.copilot-chat@0.41.0\nollama.ollama@0.0.1\nms-python.python\n"
 
-	if !hasVSCodeExtension(output, "ollama.ollama-vscode") {
+	if !hasVSCodeExtension(output, "ollama.ollama") {
 		t.Fatal("expected Ollama extension to be detected")
 	}
-	if !hasVSCodeExtension(output, "Ollama.Ollama-VSCode") {
+	if !hasVSCodeExtension(output, "Ollama.Ollama") {
 		t.Fatal("expected extension detection to be case-insensitive")
 	}
 	if hasVSCodeExtension(output, "ollama.missing") {

--- a/cmd/launch/vscode_test.go
+++ b/cmd/launch/vscode_test.go
@@ -11,6 +11,7 @@ import (
 
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/ollama/ollama/cmd/internal/fileutil"
+	"github.com/ollama/ollama/envconfig"
 )
 
 func TestVSCodeIntegration(t *testing.T) {
@@ -37,58 +38,86 @@ func TestVSCodeConfigure(t *testing.T) {
 	setTestHome(t, tmpDir)
 	t.Setenv("XDG_CONFIG_HOME", "")
 	clmPath := testVSCodePath(t, tmpDir, "chatLanguageModels.json")
+	settingsPath := testVSCodePath(t, tmpDir, "settings.json")
 
 	tests := []struct {
-		name     string
-		setup    string // initial chatLanguageModels.json content, empty means no file
-		model    string
-		validate func(t *testing.T, data []byte)
+		name          string
+		setup         string // initial chatLanguageModels.json content, empty means no file
+		model         string
+		validate      func(t *testing.T, clmData []byte, settingsData []byte)
+		wantSettings  bool
 	}{
 		{
 			name:  "fresh install",
 			model: "llama3.2",
-			validate: func(t *testing.T, data []byte) {
-				assertOllamaVendorConfigured(t, data)
+			wantSettings: true,
+			validate: func(t *testing.T, clmData []byte, settingsData []byte) {
+				if len(clmData) != 0 {
+					t.Fatalf("expected no chatLanguageModels.json to be created, got %q", string(clmData))
+				}
+				assertSettingsConfigured(t, settingsData, nil)
 			},
 		},
 		{
 			name:  "preserve other vendor entries",
 			setup: `[{"vendor": "azure", "name": "Azure", "url": "https://example.com"}]`,
 			model: "llama3.2",
-			validate: func(t *testing.T, data []byte) {
+			wantSettings: true,
+			validate: func(t *testing.T, clmData []byte, settingsData []byte) {
 				var entries []map[string]any
-				json.Unmarshal(data, &entries)
-				if len(entries) != 2 {
-					t.Errorf("expected 2 entries, got %d", len(entries))
+				json.Unmarshal(clmData, &entries)
+				if len(entries) != 1 {
+					t.Errorf("expected 1 entry, got %d", len(entries))
 				}
-				// Check Azure entry preserved
-				found := false
-				for _, e := range entries {
-					if v, _ := e["vendor"].(string); v == "azure" {
-						found = true
-					}
+				if vendor, _ := entries[0]["vendor"].(string); vendor != "azure" {
+					t.Fatalf("expected azure entry to be preserved, got %#v", entries[0])
 				}
-				if !found {
-					t.Error("azure vendor entry was not preserved")
-				}
-				assertOllamaVendorConfigured(t, data)
+				assertSettingsConfigured(t, settingsData, nil)
 			},
 		},
 		{
 			name:  "update existing ollama entry",
 			setup: `[{"vendor": "ollama", "name": "Ollama", "url": "http://old:11434"}]`,
 			model: "llama3.2",
-			validate: func(t *testing.T, data []byte) {
-				assertOllamaVendorConfigured(t, data)
+			wantSettings: true,
+			validate: func(t *testing.T, clmData []byte, settingsData []byte) {
+				assertChatLanguageModelsCleaned(t, clmData)
+				assertSettingsConfigured(t, settingsData, nil)
+			},
+		},
+		{
+			name:  "remove legacy, current, and old custom endpoint ollama entries",
+			setup: `[{"vendor": "ollama", "name": "Ollama", "url": "http://old:11434"},{"vendor": "ollama-vscode", "name": "Ollama", "url": "http://older:11434"},{"vendor": "customendpoint", "name": "Ollama", "url": "http://127.0.0.1:11434"},{"vendor": "azure", "name": "Azure"}]`,
+			model: "llama3.2",
+			wantSettings: true,
+			validate: func(t *testing.T, clmData []byte, settingsData []byte) {
+				var entries []map[string]any
+				if err := json.Unmarshal(clmData, &entries); err != nil {
+					t.Fatalf("invalid JSON: %v", err)
+				}
+
+				if len(entries) != 1 {
+					t.Fatalf("expected only the non-Ollama entry to remain, got %#v", entries)
+				}
+				for _, entry := range entries {
+					if isManagedOllamaProviderEntry(entry) {
+						t.Fatalf("expected managed Ollama provider entries to be removed, got %#v", entries)
+					}
+				}
+				assertSettingsConfigured(t, settingsData, nil)
 			},
 		},
 		{
 			name:  "empty model is no-op",
 			setup: `[{"vendor": "azure", "name": "Azure"}]`,
 			model: "",
-			validate: func(t *testing.T, data []byte) {
-				if string(data) != `[{"vendor": "azure", "name": "Azure"}]` {
+			wantSettings: false,
+			validate: func(t *testing.T, clmData []byte, settingsData []byte) {
+				if string(clmData) != `[{"vendor": "azure", "name": "Azure"}]` {
 					t.Error("empty model should not modify file")
+				}
+				if len(settingsData) != 0 {
+					t.Fatalf("empty model should not create settings, got %q", string(settingsData))
 				}
 			},
 		},
@@ -96,11 +125,10 @@ func TestVSCodeConfigure(t *testing.T) {
 			name:  "corrupted JSON treated as empty",
 			setup: `{corrupted json`,
 			model: "llama3.2",
-			validate: func(t *testing.T, data []byte) {
-				var entries []map[string]any
-				if err := json.Unmarshal(data, &entries); err != nil {
-					t.Errorf("result is not valid JSON: %v", err)
-				}
+			wantSettings: true,
+			validate: func(t *testing.T, clmData []byte, settingsData []byte) {
+				assertChatLanguageModelsCleaned(t, clmData)
+				assertSettingsConfigured(t, settingsData, nil)
 			},
 		},
 	}
@@ -118,8 +146,12 @@ func TestVSCodeConfigure(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			data, _ := os.ReadFile(clmPath)
-			tt.validate(t, data)
+			clmData, _ := os.ReadFile(clmPath)
+			settingsData, _ := os.ReadFile(settingsPath)
+			if tt.wantSettings && len(settingsData) == 0 {
+				t.Fatalf("expected settings.json to be written")
+			}
+			tt.validate(t, clmData, settingsData)
 		})
 	}
 }
@@ -152,6 +184,9 @@ func TestVSCodeEditCleansUpOldSettings(t *testing.T) {
 	}
 	if _, ok := settings["ollama.launch.configured"]; ok {
 		t.Error("ollama.launch.configured should have been removed")
+	}
+	if settings["ollama.endpoint"] != envconfig.Host().String() {
+		t.Errorf("ollama.endpoint = %v, want %q", settings["ollama.endpoint"], envconfig.Host().String())
 	}
 	if settings["editor.fontSize"] != float64(14) {
 		t.Error("editor.fontSize should have been preserved")
@@ -210,9 +245,11 @@ func TestVSCodePaths(t *testing.T) {
 	setTestHome(t, tmpDir)
 	t.Setenv("XDG_CONFIG_HOME", "")
 	clmPath := testVSCodePath(t, tmpDir, "chatLanguageModels.json")
+	settingsPath := testVSCodePath(t, tmpDir, "settings.json")
 
 	t.Run("no file returns nil", func(t *testing.T) {
 		os.Remove(clmPath)
+		os.Remove(settingsPath)
 		if paths := v.Paths(); paths != nil {
 			t.Errorf("expected nil, got %v", paths)
 		}
@@ -224,6 +261,16 @@ func TestVSCodePaths(t *testing.T) {
 
 		if paths := v.Paths(); len(paths) != 1 {
 			t.Errorf("expected 1 path, got %d", len(paths))
+		}
+	})
+
+	t.Run("settings file is included", func(t *testing.T) {
+		os.Remove(clmPath)
+		os.MkdirAll(filepath.Dir(settingsPath), 0o755)
+		os.WriteFile(settingsPath, []byte(`{}`), 0o644)
+
+		if paths := v.Paths(); len(paths) != 1 || paths[0] != settingsPath {
+			t.Errorf("expected settings path, got %v", paths)
 		}
 	})
 }
@@ -242,7 +289,7 @@ func testVSCodePath(t *testing.T, tmpDir, filename string) string {
 	}
 }
 
-func assertOllamaVendorConfigured(t *testing.T, data []byte) {
+func assertChatLanguageModelsCleaned(t *testing.T, data []byte) {
 	t.Helper()
 	var entries []map[string]any
 	if err := json.Unmarshal(data, &entries); err != nil {
@@ -250,20 +297,33 @@ func assertOllamaVendorConfigured(t *testing.T, data []byte) {
 	}
 
 	for _, entry := range entries {
-		if vendor, _ := entry["vendor"].(string); vendor == vscodeOllamaVendor {
-			if name, _ := entry["name"].(string); name != vscodeOllamaName {
-				t.Errorf("expected name %q, got %q", vscodeOllamaName, name)
-			}
-			if url, _ := entry["url"].(string); url == "" {
-				t.Error("url not set")
-			}
-			if _, ok := entry["models"]; ok {
-				t.Fatalf("provider config should not pin models, got %#v", entry["models"])
-			}
-			return
+		if isManagedOllamaProviderEntry(entry) {
+			t.Fatalf("expected managed Ollama provider entries to be removed, got %#v", entries)
 		}
 	}
-	t.Errorf("no %s vendor entry found", vscodeOllamaVendor)
+}
+
+func assertSettingsConfigured(t *testing.T, data []byte, extras map[string]any) {
+	t.Helper()
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("invalid settings JSON: %v", err)
+	}
+
+	if settings["ollama.endpoint"] != envconfig.Host().String() {
+		t.Fatalf("ollama.endpoint = %v, want %q", settings["ollama.endpoint"], envconfig.Host().String())
+	}
+	if _, ok := settings["github.copilot.chat.byok.ollamaEndpoint"]; ok {
+		t.Fatal("github.copilot.chat.byok.ollamaEndpoint should have been removed")
+	}
+	if _, ok := settings["ollama.launch.configured"]; ok {
+		t.Fatal("ollama.launch.configured should have been removed")
+	}
+	for key, want := range extras {
+		if settings[key] != want {
+			t.Fatalf("%s = %v, want %v", key, settings[key], want)
+		}
+	}
 }
 
 func TestShowInModelPicker(t *testing.T) {
@@ -396,13 +456,13 @@ func TestShowInModelPicker(t *testing.T) {
 		}
 	})
 
-	t.Run("uses cached numeric IDs when available", func(t *testing.T) {
+	t.Run("uses cached IDs when available", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		setTestHome(t, tmpDir)
 		t.Setenv("XDG_CONFIG_HOME", "")
 		cache := []map[string]any{
 			{
-				"identifier": vscodeOllamaVendor + "/" + vscodeOllamaName + "/4",
+				"identifier": vscodeOllamaVendor + "/4",
 				"metadata":   map[string]any{"vendor": vscodeOllamaVendor, "name": "llama3.2"},
 			},
 		}
@@ -417,7 +477,32 @@ func TestShowInModelPicker(t *testing.T) {
 		if len(prefs) != 0 {
 			t.Fatalf("expected no model picker overrides, got %#v", prefs)
 		}
-		assertSelectedChatModel(t, dbPath, vscodeOllamaVendor+"/"+vscodeOllamaName+"/4")
+		assertSelectedChatModel(t, dbPath, vscodeOllamaVendor+"/4")
+	})
+
+	t.Run("removes stale named ollama cache entries", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setTestHome(t, tmpDir)
+		t.Setenv("XDG_CONFIG_HOME", "")
+		cache := []map[string]any{
+			{
+				"identifier": vscodeOllamaVendor + "/qwen3.6-latest-8e5d0015",
+				"metadata":   map[string]any{"vendor": vscodeOllamaVendor, "name": "qwen3.6:latest"},
+			},
+			{
+				"identifier": vscodeOllamaVendor + "/" + vscodeOllamaName + "/qwen3.6-latest-8e5d0015",
+				"metadata":   map[string]any{"vendor": vscodeOllamaVendor, "name": "qwen3.6:latest", "detail": vscodeOllamaName},
+			},
+		}
+		dbPath := setupDB(t, testVSCodePath(t, tmpDir, ""), nil, cache)
+
+		err := v.ShowInModelPicker("qwen3.6:latest")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assertSelectedChatModel(t, dbPath, vscodeOllamaVendor+"/qwen3.6-latest-8e5d0015")
+		assertNoStaleCachedOllamaEntries(t, dbPath)
 	})
 
 	t.Run("empty model is no-op", func(t *testing.T) {
@@ -484,6 +569,31 @@ func assertSelectedChatModel(t *testing.T, dbPath, want string) {
 	}
 	if len(recent) == 0 || recent[0] != want {
 		t.Fatalf("recent models = %#v, want %q first", recent, want)
+	}
+}
+
+func assertNoStaleCachedOllamaEntries(t *testing.T, dbPath string) {
+	t.Helper()
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	var cacheJSON string
+	if err := db.QueryRow("SELECT value FROM ItemTable WHERE key = 'chat.cachedLanguageModels.v2'").Scan(&cacheJSON); err != nil {
+		t.Fatal(err)
+	}
+
+	var cached []map[string]any
+	if err := json.Unmarshal([]byte(cacheJSON), &cached); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, entry := range cached {
+		if isStaleCachedOllamaModelEntry(entry) {
+			t.Fatalf("stale cached Ollama entry still present: %#v", entry)
+		}
 	}
 }
 

--- a/cmd/launch/vscode_test.go
+++ b/cmd/launch/vscode_test.go
@@ -41,15 +41,15 @@ func TestVSCodeConfigure(t *testing.T) {
 	settingsPath := testVSCodePath(t, tmpDir, "settings.json")
 
 	tests := []struct {
-		name          string
-		setup         string // initial chatLanguageModels.json content, empty means no file
-		model         string
-		validate      func(t *testing.T, clmData []byte, settingsData []byte)
-		wantSettings  bool
+		name         string
+		setup        string // initial chatLanguageModels.json content, empty means no file
+		model        string
+		validate     func(t *testing.T, clmData []byte, settingsData []byte)
+		wantSettings bool
 	}{
 		{
-			name:  "fresh install",
-			model: "llama3.2",
+			name:         "fresh install",
+			model:        "llama3.2",
 			wantSettings: true,
 			validate: func(t *testing.T, clmData []byte, settingsData []byte) {
 				if len(clmData) != 0 {
@@ -59,9 +59,9 @@ func TestVSCodeConfigure(t *testing.T) {
 			},
 		},
 		{
-			name:  "preserve other vendor entries",
-			setup: `[{"vendor": "azure", "name": "Azure", "url": "https://example.com"}]`,
-			model: "llama3.2",
+			name:         "preserve other vendor entries",
+			setup:        `[{"vendor": "azure", "name": "Azure", "url": "https://example.com"}]`,
+			model:        "llama3.2",
 			wantSettings: true,
 			validate: func(t *testing.T, clmData []byte, settingsData []byte) {
 				var entries []map[string]any
@@ -76,9 +76,9 @@ func TestVSCodeConfigure(t *testing.T) {
 			},
 		},
 		{
-			name:  "update existing ollama entry",
-			setup: `[{"vendor": "ollama", "name": "Ollama", "url": "http://old:11434"}]`,
-			model: "llama3.2",
+			name:         "update existing ollama entry",
+			setup:        `[{"vendor": "ollama", "name": "Ollama", "url": "http://old:11434"}]`,
+			model:        "llama3.2",
 			wantSettings: true,
 			validate: func(t *testing.T, clmData []byte, settingsData []byte) {
 				assertChatLanguageModelsCleaned(t, clmData)
@@ -86,9 +86,9 @@ func TestVSCodeConfigure(t *testing.T) {
 			},
 		},
 		{
-			name:  "remove legacy, current, and old custom endpoint ollama entries",
-			setup: `[{"vendor": "ollama", "name": "Ollama", "url": "http://old:11434"},{"vendor": "ollama-vscode", "name": "Ollama", "url": "http://older:11434"},{"vendor": "customendpoint", "name": "Ollama", "url": "http://127.0.0.1:11434"},{"vendor": "azure", "name": "Azure"}]`,
-			model: "llama3.2",
+			name:         "remove legacy, current, and old custom endpoint ollama entries",
+			setup:        `[{"vendor": "ollama", "name": "Ollama", "url": "http://old:11434"},{"vendor": "ollama-vscode", "name": "Ollama", "url": "http://older:11434"},{"vendor": "customendpoint", "name": "Ollama", "url": "http://127.0.0.1:11434"},{"vendor": "azure", "name": "Azure"}]`,
+			model:        "llama3.2",
 			wantSettings: true,
 			validate: func(t *testing.T, clmData []byte, settingsData []byte) {
 				var entries []map[string]any
@@ -108,9 +108,9 @@ func TestVSCodeConfigure(t *testing.T) {
 			},
 		},
 		{
-			name:  "empty model is no-op",
-			setup: `[{"vendor": "azure", "name": "Azure"}]`,
-			model: "",
+			name:         "empty model is no-op",
+			setup:        `[{"vendor": "azure", "name": "Azure"}]`,
+			model:        "",
 			wantSettings: false,
 			validate: func(t *testing.T, clmData []byte, settingsData []byte) {
 				if string(clmData) != `[{"vendor": "azure", "name": "Azure"}]` {
@@ -122,9 +122,9 @@ func TestVSCodeConfigure(t *testing.T) {
 			},
 		},
 		{
-			name:  "corrupted JSON treated as empty",
-			setup: `{corrupted json`,
-			model: "llama3.2",
+			name:         "corrupted JSON treated as empty",
+			setup:        `{corrupted json`,
+			model:        "llama3.2",
 			wantSettings: true,
 			validate: func(t *testing.T, clmData []byte, settingsData []byte) {
 				assertChatLanguageModelsCleaned(t, clmData)

--- a/cmd/launch/vscode_test.go
+++ b/cmd/launch/vscode_test.go
@@ -298,20 +298,6 @@ func testVSCodePath(t *testing.T, tmpDir, filename string) string {
 	}
 }
 
-func assertChatLanguageModelsCleaned(t *testing.T, data []byte) {
-	t.Helper()
-	var entries []map[string]any
-	if err := json.Unmarshal(data, &entries); err != nil {
-		t.Fatalf("invalid JSON: %v", err)
-	}
-
-	for _, entry := range entries {
-		if isManagedOllamaProviderEntry(entry) {
-			t.Fatalf("expected managed Ollama provider entries to be removed, got %#v", entries)
-		}
-	}
-}
-
 func assertOllamaProviderConfigured(t *testing.T, data []byte) {
 	t.Helper()
 	var entries []map[string]any


### PR DESCRIPTION
## Summary
- Update VS Code launch integration to use the published `Ollama.ollama` extension and `ollama` provider vendor.
- Write the Ollama provider entry to `chatLanguageModels.json` so VS Code shows the Ollama model group.
- Select models using VS Code’s current `ollama/Ollama/...` language model IDs, including `:latest` fallback for untagged local models.
- Preserve current Ollama cache entries while removing legacy `ollama-vscode/Ollama/...` cache entries.

## Testing
- `go test ./cmd/launch`
- `go test ./cmd`
- Smoke tested `go run . launch vscode --model llama3.2 --yes`
- Smoke tested `go run . launch vscode --model qwen3.5:cloud --yes`