### PR TITLE
docs: add Sieve to community integrations (RAG & Knowledge Bases)

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ console.log(response.message.content);
 - [Archyve](https://github.com/nickthecook/archyve) - RAG-enabling document library
 - [Casibase](https://casibase.org) - AI knowledge base with RAG and SSO
 - [BrainSoup](https://www.nurgo-software.com/products/brainsoup) - Native client with RAG and multi-agent automation
+- [Sieve](https://github.com/llmsieve/llm-sieve) - Transparent context-reduction proxy with an encrypted local memory store
 
 ### Bots & Messaging
 


### PR DESCRIPTION
Adds [Sieve](https://github.com/llmsieve/llm-sieve) to the RAG & Knowledge Bases section.

Sieve is a transparent proxy for Ollama's `/api/chat` (and the OpenAI-compatible endpoint): it strips repeated instructions, tool schemas, and stale history from each outbound turn and backs retrieval with an encrypted local memory store. Local-first, zero telemetry, Apache 2.0, installable via `pipx install llm-sieve`.

One line added, matching the existing entry format.