### PR TITLE
app: prevent sidebar animation on initial load

### DIFF
--- a/app/ui/app/src/components/layout/layout.tsx
+++ b/app/ui/app/src/components/layout/layout.tsx
@@ -1,5 +1,6 @@
 import { Link } from "@tanstack/react-router";
 import { useSettings } from "@/hooks/useSettings";
+import { useEffect, useState } from "react";
 
 export function SidebarLayout({
   sidebar,
@@ -9,13 +10,37 @@ export function SidebarLayout({
   collapsible?: boolean;
   chatId?: string;
 }>) {
-  const { settings, setSettings } = useSettings();
+  const { settings, settingsData, setSettings } = useSettings();
+  const [transitionsReady, setTransitionsReady] = useState(false);
   const isWindows = navigator.platform.toLowerCase().includes("win");
 
+  useEffect(() => {
+    if (!settingsData || transitionsReady) {
+      return;
+    }
+
+    const frame = requestAnimationFrame(() => {
+      setTransitionsReady(true);
+    });
+
+    return () => cancelAnimationFrame(frame);
+  }, [settingsData, transitionsReady]);
+
+  const widthTransition = transitionsReady
+    ? "transition-[width] duration-300"
+    : "";
+  const leftTransition = transitionsReady
+    ? "transition-[left] duration-375"
+    : "";
+  const opacityTransition = transitionsReady
+    ? "transition-opacity duration-375"
+    : "";
+  const mainTransition = transitionsReady ? "transition-all duration-300" : "";
+
   return (
-    <div className={`flex transition-[width] duration-300 dark:bg-neutral-900`}>
+    <div className={`flex ${widthTransition} dark:bg-neutral-900`}>
       <div
-        className={`absolute flex mx-2 py-2 z-20 items-center transition-[left] duration-375 text-neutral-500 dark:text-neutral-400 ${settings.sidebarOpen ? (isWindows ? "left-2" : "left-[204px]") : isWindows ? "left-2" : "left-20"}`}
+        className={`absolute flex mx-2 py-2 z-20 items-center ${leftTransition} text-neutral-500 dark:text-neutral-400 ${settings.sidebarOpen ? (isWindows ? "left-2" : "left-[204px]") : isWindows ? "left-2" : "left-20"}`}
       >
         <button
           onClick={() => setSettings({ SidebarOpen: !settings.sidebarOpen })}
@@ -39,7 +64,7 @@ export function SidebarLayout({
           to="/c/$chatId"
           params={{ chatId: "new" }}
           title="New chat"
-          className={`flex ml-1 items-center justify-center rounded-full transition-opacity duration-375 h-9 w-9 hover:bg-neutral-100 dark:hover:bg-neutral-700 ${
+          className={`flex ml-1 items-center justify-center rounded-full ${opacityTransition} h-9 w-9 hover:bg-neutral-100 dark:hover:bg-neutral-700 ${
             settings.sidebarOpen
               ? "opacity-0 pointer-events-none"
               : "opacity-100"
@@ -57,7 +82,7 @@ export function SidebarLayout({
         </Link>
       </div>
       <div
-        className={`flex flex-col transition-[width] duration-300 max-h-screen ${settings.sidebarOpen ? "w-64" : "w-0"}`}
+        className={`flex flex-col ${widthTransition} max-h-screen ${settings.sidebarOpen ? "w-64" : "w-0"}`}
       >
         <div
           onDoubleClick={() => window.doubleClick && window.doubleClick()}
@@ -66,9 +91,7 @@ export function SidebarLayout({
         ></div>
         {settings.sidebarOpen && sidebar}
       </div>
-      <main
-        className={`flex flex-1 flex-col min-w-0 transition-all duration-300`}
-      >
+      <main className={`flex flex-1 flex-col min-w-0 ${mainTransition}`}>
         <div
           className={`h-13 flex-none w-full z-10 flex items-center bg-white dark:bg-neutral-900 ${isWindows ? "xl:hidden" : "xl:fixed xl:bg-transparent xl:dark:bg-transparent"}`}
           onDoubleClick={() => window.doubleClick && window.doubleClick()}


### PR DESCRIPTION
Fixes #12954

Summary:
- Avoid applying sidebar layout transitions during the first frame after settings load.
- Keep the existing sidebar transition for user-triggered open and close actions.

Testing:
- npm run build
- npx eslint src/components/layout/layout.tsx