### PR TITLE
x/mlxrunner: validate affine quant params against packed tensor shapes

### DIFF
--- a/x/mlxrunner/model/quant.go
+++ b/x/mlxrunner/model/quant.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"log/slog"
 	"strings"
 
 	"github.com/ollama/ollama/x/mlxrunner/mlx"
@@ -48,7 +49,10 @@ func TensorQuantParams(
 
 // ResolveLinearQuantParams resolves quantization params for a quantized linear
 // tensor, preferring per-tensor metadata and falling back to shape-based
-// inference for affine packed tensors.
+// inference for affine packed tensors. Metadata that is inconsistent with the
+// packed shapes (e.g. mixed-precision MLX checkpoints that quantize individual
+// tensors at a different width than the model-level default) is overridden by
+// shape-based inference.
 func ResolveLinearQuantParams(
 	defaultGroupSize, defaultBits int,
 	defaultMode string,
@@ -64,21 +68,47 @@ func ResolveLinearQuantParams(
 		tensorName,
 	)
 
-	if mode == "affine" {
-		if inferredGroupSize, inferredBits, ok := InferAffineQuantParamsFromShapes(weight, scales, bits); ok {
-			if !fromTensor || groupSize == 0 || bits == 0 {
-				groupSize = inferredGroupSize
-				bits = inferredBits
+	if mode == "affine" && !affineParamsMatchShapes(weight, scales, groupSize, bits) {
+		inferredGroupSize, inferredBits, ok := 0, 0, false
+
+		// Per-tensor metadata that fails shape validation typically has the
+		// right group size and a stale bit width (mlx-lm mixed-precision
+		// overrides usually change bits only), so resolve the bit width from
+		// the recorded group size before falling back to generic heuristics.
+		// Overrides that change the group size as well can still be
+		// mis-inferred here; any (groupSize,bits) pair with the same packed
+		// ratio is indistinguishable by shape alone.
+		if fromTensor {
+			if weightCols, scalesCols, colsOK := affinePackedCols(weight, scales); colsOK {
+				if b, bOK := affineBitsForGroupSize(weightCols, scalesCols, groupSize); bOK {
+					inferredGroupSize, inferredBits, ok = groupSize, b, true
+				}
 			}
+		}
+		if !ok {
+			inferredGroupSize, inferredBits, ok = InferAffineQuantParamsFromShapes(weight, scales, groupSize, bits)
+		}
+
+		switch {
+		case ok && groupSize > 0 && bits > 0:
+			slog.Warn("recorded quantization params are inconsistent with packed shapes; re-inferred",
+				"tensor", tensorName,
+				"recorded_group_size", groupSize, "recorded_bits", bits,
+				"group_size", inferredGroupSize, "bits", inferredBits)
+		case !ok:
+			slog.Warn("quantization params are inconsistent with packed shapes and could not be re-inferred; keeping recorded params",
+				"tensor", tensorName, "group_size", groupSize, "bits", bits)
+		}
+		if ok {
+			groupSize = inferredGroupSize
+			bits = inferredBits
 		}
 	}
 
 	return groupSize, bits, mode
 }
 
-// InferAffineQuantParamsFromShapes infers (groupSize,bits) for affine quantized
-// tensors from packed weight and scale shapes.
-func InferAffineQuantParamsFromShapes(weight, scales *mlx.Array, hintBits int) (groupSize, bits int, ok bool) {
+func affinePackedCols(weight, scales *mlx.Array) (weightCols, scalesCols int, ok bool) {
 	if weight == nil || scales == nil {
 		return 0, 0, false
 	}
@@ -89,12 +119,69 @@ func InferAffineQuantParamsFromShapes(weight, scales *mlx.Array, hintBits int) (
 		return 0, 0, false
 	}
 
-	weightCols := weightShape[len(weightShape)-1]
-	scalesCols := scaleShape[len(scaleShape)-1]
+	weightCols = weightShape[len(weightShape)-1]
+	scalesCols = scaleShape[len(scaleShape)-1]
 	if weightCols <= 0 || scalesCols <= 0 {
 		return 0, 0, false
 	}
+	return weightCols, scalesCols, true
+}
 
+// affineParamsMatchShapes reports whether (groupSize,bits) is consistent with
+// the packed weight and scale shapes.
+func affineParamsMatchShapes(weight, scales *mlx.Array, groupSize, bits int) bool {
+	weightCols, scalesCols, ok := affinePackedCols(weight, scales)
+	if !ok {
+		return false
+	}
+	return affineParamsMatchCols(weightCols, scalesCols, groupSize, bits)
+}
+
+// affineParamsMatchCols reports whether (groupSize,bits) is consistent with
+// the packed weight and scale column counts: a uint32-packed affine weight
+// holds 32/bits values per element, so weightCols*32 == scalesCols*groupSize*bits.
+func affineParamsMatchCols(weightCols, scalesCols, groupSize, bits int) bool {
+	if weightCols <= 0 || scalesCols <= 0 || groupSize <= 0 || bits <= 0 {
+		return false
+	}
+	return weightCols*32 == scalesCols*groupSize*bits
+}
+
+// affineBitsForGroupSize returns the bit width implied by the packed column
+// counts for a known group size. The packed ratio weightCols*32/scalesCols
+// equals bits*groupSize, so a known group size uniquely determines the bit
+// width.
+func affineBitsForGroupSize(weightCols, scalesCols, groupSize int) (bits int, ok bool) {
+	if weightCols <= 0 || scalesCols <= 0 || groupSize <= 0 {
+		return 0, false
+	}
+	if (weightCols*32)%scalesCols != 0 {
+		return 0, false
+	}
+	ratio := weightCols * 32 / scalesCols
+	if ratio%groupSize != 0 {
+		return 0, false
+	}
+	bits = ratio / groupSize
+	if !isSupportedAffineBits(bits) {
+		return 0, false
+	}
+	return bits, true
+}
+
+// InferAffineQuantParamsFromShapes infers (groupSize,bits) for affine quantized
+// tensors from packed weight and scale shapes.
+func InferAffineQuantParamsFromShapes(weight, scales *mlx.Array, hintGroupSize, hintBits int) (groupSize, bits int, ok bool) {
+	weightCols, scalesCols, ok := affinePackedCols(weight, scales)
+	if !ok {
+		return 0, 0, false
+	}
+	return inferAffineQuantParamsFromCols(weightCols, scalesCols, hintGroupSize, hintBits)
+}
+
+// inferAffineQuantParamsFromCols infers (groupSize,bits) from packed weight
+// and scale column counts.
+func inferAffineQuantParamsFromCols(weightCols, scalesCols, hintGroupSize, hintBits int) (groupSize, bits int, ok bool) {
 	groupSize4 := weightCols * 8 / scalesCols
 	groupSize8 := weightCols * 4 / scalesCols
 
@@ -119,7 +206,45 @@ func InferAffineQuantParamsFromShapes(weight, scales *mlx.Array, hintBits int) (
 		return groupSize8, 8, true
 	}
 
+	// Mixed-precision checkpoints may quantize individual tensors at widths
+	// the heuristics above do not cover (e.g. 6-bit experts in a 4-bit model).
+	if hintGroupSize > 0 {
+		if b, ok := affineBitsForGroupSize(weightCols, scalesCols, hintGroupSize); ok {
+			return hintGroupSize, b, true
+		}
+	}
+
 	return 0, 0, false
+}
+
+// SupportsGatherQMM reports whether the bundled MLX Metal kernels implement
+// gather_qmm for the given quantization mode and bit width. MLX v0.31.2
+// instantiates affine gather_qmm kernels for bits {2,3,4,5,6,8} and group
+// sizes {32,64,128} (mlx/backend/metal/kernels/quantized.metal,
+// instantiate_quantized_all); mxfp8 is 8-bit only, nvfp4 and mxfp4 are 4-bit
+// only.
+func SupportsGatherQMM(mode string, bits int) bool {
+	switch mode {
+	case "affine":
+		return isSupportedAffineBits(bits)
+	case "mxfp8":
+		return bits == 8
+	case "nvfp4", "mxfp4":
+		return bits == 4
+	default:
+		return false
+	}
+}
+
+// isSupportedAffineBits reports whether the bundled MLX kernels are
+// instantiated for an affine bit width (see SupportsGatherQMM).
+func isSupportedAffineBits(bits int) bool {
+	switch bits {
+	case 2, 3, 4, 5, 6, 8:
+		return true
+	default:
+		return false
+	}
 }
 
 func isCommonGroupSize(v int) bool {

--- a/x/mlxrunner/model/quant_test.go
+++ b/x/mlxrunner/model/quant_test.go
@@ -1,0 +1,257 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+)
+
+// Pure shape-math tests below run everywhere, including CI runners without
+// the MLX library.
+
+func TestAffineParamsMatchCols(t *testing.T) {
+	tests := []struct {
+		name                   string
+		weightCols, scalesCols int
+		groupSize, bits        int
+		want                   bool
+	}{
+		// inDim=128: weightCols = inDim*bits/32, scalesCols = inDim/groupSize.
+		{name: "4bit gs64", weightCols: 16, scalesCols: 2, groupSize: 64, bits: 4, want: true},
+		{name: "8bit gs32", weightCols: 32, scalesCols: 4, groupSize: 32, bits: 8, want: true},
+		{name: "6bit gs64", weightCols: 24, scalesCols: 2, groupSize: 64, bits: 6, want: true},
+		{name: "2bit gs64", weightCols: 8, scalesCols: 2, groupSize: 64, bits: 2, want: true},
+		{name: "ambiguous ratio matches gs64/4bit", weightCols: 16, scalesCols: 2, groupSize: 64, bits: 4, want: true},
+		{name: "ambiguous ratio matches gs32/8bit", weightCols: 16, scalesCols: 2, groupSize: 32, bits: 8, want: true},
+		{name: "6bit tensor against 4bit params", weightCols: 24, scalesCols: 2, groupSize: 64, bits: 4, want: false},
+		{name: "zero group size", weightCols: 16, scalesCols: 2, groupSize: 0, bits: 4, want: false},
+		{name: "zero bits", weightCols: 16, scalesCols: 2, groupSize: 64, bits: 0, want: false},
+		{name: "zero weight cols", weightCols: 0, scalesCols: 2, groupSize: 64, bits: 4, want: false},
+		{name: "zero scales cols", weightCols: 16, scalesCols: 0, groupSize: 64, bits: 4, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := affineParamsMatchCols(tt.weightCols, tt.scalesCols, tt.groupSize, tt.bits); got != tt.want {
+				t.Fatalf("affineParamsMatchCols(%d, %d, %d, %d) = %v, want %v",
+					tt.weightCols, tt.scalesCols, tt.groupSize, tt.bits, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAffineBitsForGroupSize(t *testing.T) {
+	tests := []struct {
+		name                   string
+		weightCols, scalesCols int
+		groupSize              int
+		wantBits               int
+		wantOK                 bool
+	}{
+		// inDim=128 throughout.
+		{name: "6bit gs64", weightCols: 24, scalesCols: 2, groupSize: 64, wantBits: 6, wantOK: true},
+		{name: "3bit gs64", weightCols: 12, scalesCols: 2, groupSize: 64, wantBits: 3, wantOK: true},
+		{name: "5bit gs64", weightCols: 20, scalesCols: 2, groupSize: 64, wantBits: 5, wantOK: true},
+		{name: "2bit gs64", weightCols: 8, scalesCols: 2, groupSize: 64, wantBits: 2, wantOK: true},
+		{name: "ratio not divisible by group size", weightCols: 24, scalesCols: 2, groupSize: 80, wantOK: false},
+		{name: "unsupported bit width", weightCols: 28, scalesCols: 2, groupSize: 64, wantOK: false}, // ratio 448 -> 7 bits
+		{name: "zero group size", weightCols: 24, scalesCols: 2, groupSize: 0, wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bits, ok := affineBitsForGroupSize(tt.weightCols, tt.scalesCols, tt.groupSize)
+			if ok != tt.wantOK || (ok && bits != tt.wantBits) {
+				t.Fatalf("affineBitsForGroupSize(%d, %d, %d) = (%d, %v), want (%d, %v)",
+					tt.weightCols, tt.scalesCols, tt.groupSize, bits, ok, tt.wantBits, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestInferAffineQuantParamsFromCols(t *testing.T) {
+	tests := []struct {
+		name                    string
+		weightCols, scalesCols  int
+		hintGroupSize, hintBits int
+		wantGroupSize, wantBits int
+		wantOK                  bool
+	}{
+		// inDim=128 throughout.
+		{name: "4bit gs32", weightCols: 16, scalesCols: 4, wantGroupSize: 32, wantBits: 4, wantOK: true},
+		{name: "8bit gs64", weightCols: 32, scalesCols: 2, wantGroupSize: 64, wantBits: 8, wantOK: true},
+		{name: "ambiguous ratio, 4bit hint", weightCols: 16, scalesCols: 2, hintBits: 4, wantGroupSize: 64, wantBits: 4, wantOK: true},
+		{name: "ambiguous ratio, 8bit hint", weightCols: 16, scalesCols: 2, hintBits: 8, wantGroupSize: 32, wantBits: 8, wantOK: true},
+		{name: "6bit via group size hint", weightCols: 24, scalesCols: 2, hintGroupSize: 64, hintBits: 4, wantGroupSize: 64, wantBits: 6, wantOK: true},
+		{name: "no hints, uninferable ratio", weightCols: 24, scalesCols: 2, wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			groupSize, bits, ok := inferAffineQuantParamsFromCols(tt.weightCols, tt.scalesCols, tt.hintGroupSize, tt.hintBits)
+			if ok != tt.wantOK || groupSize != tt.wantGroupSize || bits != tt.wantBits {
+				t.Fatalf("inferAffineQuantParamsFromCols(%d, %d, %d, %d) = (%d, %d, %v), want (%d, %d, %v)",
+					tt.weightCols, tt.scalesCols, tt.hintGroupSize, tt.hintBits,
+					groupSize, bits, ok, tt.wantGroupSize, tt.wantBits, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestSupportsGatherQMM(t *testing.T) {
+	tests := []struct {
+		mode string
+		bits int
+		want bool
+	}{
+		{mode: "affine", bits: 1, want: false},
+		{mode: "affine", bits: 2, want: true},
+		{mode: "affine", bits: 3, want: true},
+		{mode: "affine", bits: 4, want: true},
+		{mode: "affine", bits: 5, want: true},
+		{mode: "affine", bits: 6, want: true},
+		{mode: "affine", bits: 7, want: false},
+		{mode: "affine", bits: 8, want: true},
+		{mode: "mxfp8", bits: 8, want: true},
+		{mode: "mxfp8", bits: 4, want: false},
+		{mode: "nvfp4", bits: 4, want: true},
+		{mode: "nvfp4", bits: 8, want: false},
+		{mode: "mxfp4", bits: 4, want: true},
+		{mode: "mxfp4", bits: 8, want: false},
+		{mode: "", bits: 4, want: false},
+		{mode: "unknown", bits: 4, want: false},
+	}
+
+	for _, tt := range tests {
+		if got := SupportsGatherQMM(tt.mode, tt.bits); got != tt.want {
+			t.Fatalf("SupportsGatherQMM(%q, %d) = %v, want %v", tt.mode, tt.bits, got, tt.want)
+		}
+	}
+}
+
+func TestResolveLinearQuantParamsNonAffinePassthrough(t *testing.T) {
+	// Shape validation only applies to affine mode; other modes must pass
+	// through untouched (no MLX needed: the arrays are never inspected).
+	tests := []struct {
+		mode      string
+		groupSize int
+		bits      int
+	}{
+		{mode: "nvfp4", groupSize: 16, bits: 4},
+		{mode: "mxfp4", groupSize: 32, bits: 4},
+		{mode: "mxfp8", groupSize: 32, bits: 8},
+	}
+
+	for _, tt := range tests {
+		groupSize, bits, mode := ResolveLinearQuantParams(
+			tt.groupSize, tt.bits, tt.mode,
+			nil,
+			"w", nil, nil,
+		)
+		if groupSize != tt.groupSize || bits != tt.bits || mode != tt.mode {
+			t.Fatalf("resolved (gs=%d, bits=%d, mode=%q), want (%d, %d, %q)",
+				groupSize, bits, mode, tt.groupSize, tt.bits, tt.mode)
+		}
+	}
+}
+
+// MLX-backed tests below quantize real tensors and skip when the MLX library
+// is not available.
+
+func quantizeTestWeight(t *testing.T, rows, cols, groupSize, bits int) (qw, scales *mlx.Array) {
+	t.Helper()
+
+	vals := make([]float32, rows*cols)
+	for i := range vals {
+		vals[i] = float32(i%19)/7 - 1
+	}
+	dense := mlx.FromValues(vals, rows, cols).AsType(mlx.DTypeBFloat16)
+	qw, scales, qbiases := mlx.Quantize(dense, groupSize, bits, "affine")
+	mlx.Eval(qw, scales, qbiases)
+	return qw, scales
+}
+
+func TestResolveLinearQuantParamsConsistentMetadata(t *testing.T) {
+	skipIfNoMLX(t)
+
+	qw, scales := quantizeTestWeight(t, 8, 128, 64, 4)
+
+	groupSize, bits, mode := ResolveLinearQuantParams(
+		64, 4, "affine",
+		map[string]*TensorQuantInfo{"w": {QuantType: "INT4", GroupSize: 64}},
+		"w", qw, scales,
+	)
+	if groupSize != 64 || bits != 4 || mode != "affine" {
+		t.Fatalf("resolved (gs=%d, bits=%d, mode=%q), want (64, 4, affine)", groupSize, bits, mode)
+	}
+}
+
+func TestResolveLinearQuantParamsMismatchedMetadataBits(t *testing.T) {
+	skipIfNoMLX(t)
+
+	// Mixed-precision checkpoint: tensor quantized at 6 bits, but metadata
+	// carries the model-level 4-bit params.
+	qw, scales := quantizeTestWeight(t, 8, 128, 64, 6)
+
+	groupSize, bits, mode := ResolveLinearQuantParams(
+		64, 4, "affine",
+		map[string]*TensorQuantInfo{"w": {QuantType: "INT4", GroupSize: 64}},
+		"w", qw, scales,
+	)
+	if groupSize != 64 || bits != 6 || mode != "affine" {
+		t.Fatalf("resolved (gs=%d, bits=%d, mode=%q), want (64, 6, affine)", groupSize, bits, mode)
+	}
+}
+
+func TestResolveLinearQuantParamsMismatchedMetadataBits2(t *testing.T) {
+	skipIfNoMLX(t)
+
+	// A 2-bit packed ratio collides with common 4/8-bit pairs, so the legacy
+	// heuristics alone would mis-infer it; the recorded per-tensor group size
+	// must be consulted first.
+	qw, scales := quantizeTestWeight(t, 8, 128, 64, 2)
+
+	groupSize, bits, mode := ResolveLinearQuantParams(
+		64, 4, "affine",
+		map[string]*TensorQuantInfo{"w": {QuantType: "INT4", GroupSize: 64}},
+		"w", qw, scales,
+	)
+	if groupSize != 64 || bits != 2 || mode != "affine" {
+		t.Fatalf("resolved (gs=%d, bits=%d, mode=%q), want (64, 2, affine)", groupSize, bits, mode)
+	}
+}
+
+func TestResolveLinearQuantParamsAmbiguousRatioKeepsMetadata(t *testing.T) {
+	skipIfNoMLX(t)
+
+	// gs=32/8-bit and gs=64/4-bit have the same packed ratio, so recorded
+	// metadata that is shape-consistent is trusted even when it is wrong.
+	// This pins the documented limitation: shape validation cannot
+	// distinguish parameter pairs with identical packed ratios, and it must
+	// never override metadata that passes the shape check.
+	qw, scales := quantizeTestWeight(t, 8, 128, 32, 8)
+
+	groupSize, bits, mode := ResolveLinearQuantParams(
+		64, 4, "affine",
+		map[string]*TensorQuantInfo{"w": {QuantType: "INT4", GroupSize: 64}},
+		"w", qw, scales,
+	)
+	if groupSize != 64 || bits != 4 || mode != "affine" {
+		t.Fatalf("resolved (gs=%d, bits=%d, mode=%q), want (64, 4, affine): ambiguous ratios must keep recorded metadata", groupSize, bits, mode)
+	}
+}
+
+func TestResolveLinearQuantParamsNoMetadataFallsBackToShapes(t *testing.T) {
+	skipIfNoMLX(t)
+
+	qw, scales := quantizeTestWeight(t, 8, 128, 32, 4)
+
+	groupSize, bits, mode := ResolveLinearQuantParams(
+		64, 8, "affine",
+		nil,
+		"w", qw, scales,
+	)
+	if groupSize != 32 || bits != 4 || mode != "affine" {
+		t.Fatalf("resolved (gs=%d, bits=%d, mode=%q), want (32, 4, affine)", groupSize, bits, mode)
+	}
+}

--- a/x/models/glm4_moe_lite/glm4_moe_lite.go
+++ b/x/models/glm4_moe_lite/glm4_moe_lite.go
@@ -364,11 +364,6 @@ func computeScale(cfg *Config) float32 {
 	return scale
 }
 
-// supportsGatherQMM returns true if the quantization mode has GatherQMM kernel support.
-func supportsGatherQMM(mode string, bits int) bool {
-	return mode == "affine" && (bits == 4 || bits == 8)
-}
-
 // ExpertWeight holds a single expert's weight with optional quantization components.
 type ExpertWeight struct {
 	Weight    *mlx.Array
@@ -399,7 +394,7 @@ func loadExpertWeight(tensors map[string]*mlx.Array, path string, useQuantized b
 			scales,
 		)
 
-		if useQuantized && supportsGatherQMM(mode, bits) {
+		if useQuantized && model.SupportsGatherQMM(mode, bits) {
 			return &ExpertWeight{Weight: w, Scales: scales, Biases: qbiases, Bits: bits, GroupSize: groupSize}
 		}
 
@@ -570,14 +565,14 @@ func newModel(root *model.Root) (base.Model, error) {
 func (m *Model) LoadWeights(tensors map[string]*mlx.Array) error {
 	cfg := m.Config
 	linears := model.NewLinearFactory(tensors, cfg.QuantGroupSize, cfg.QuantBits, cfg.QuantMode, cfg.TensorQuant)
-	useQuantized := supportsGatherQMM(cfg.QuantMode, cfg.QuantBits)
+	useQuantized := model.SupportsGatherQMM(cfg.QuantMode, cfg.QuantBits)
 	if !useQuantized && cfg.TensorQuant != nil {
 		for _, tq := range cfg.TensorQuant {
 			if tq == nil {
 				continue
 			}
 			_, bits, mode := model.QuantizationParams(tq.QuantType)
-			if supportsGatherQMM(mode, bits) {
+			if model.SupportsGatherQMM(mode, bits) {
 				useQuantized = true
 				break
 			}

--- a/x/models/laguna/laguna.go
+++ b/x/models/laguna/laguna.go
@@ -546,19 +546,6 @@ func tensorAny(tensors map[string]*mlx.Array, keys ...string) (*mlx.Array, strin
 	return nil, ""
 }
 
-func supportsGatherQMM(mode string, bits int) bool {
-	switch mode {
-	case "affine":
-		return bits == 4 || bits == 8
-	case "mxfp8":
-		return bits == 8
-	case "nvfp4", "mxfp4":
-		return bits == 4
-	default:
-		return false
-	}
-}
-
 func freeTensorKeys(tensors map[string]*mlx.Array, keys ...string) {
 	for _, k := range keys {
 		if k == "" {
@@ -676,7 +663,7 @@ func collectPerExpertProjection(tensors map[string]*mlx.Array, cfg *Config, useQ
 			groupSize = gs
 			mode = m
 		}
-		if useQuantized && supportsGatherQMM(m, b) {
+		if useQuantized && model.SupportsGatherQMM(m, b) {
 			weights = append(weights, w)
 			scales = append(scales, s)
 			if globalScale != nil {
@@ -728,7 +715,7 @@ func loadStackedProjection(tensors map[string]*mlx.Array, cfg *Config, useQuanti
 		}
 		globalScale, _ := combinedTensorGlobalScale(tensors, key)
 		gs, b, m := model.ResolveLinearQuantParams(cfg.QuantGroupSize, cfg.QuantBits, cfg.QuantMode, cfg.TensorQuant, key, w, s)
-		if useQuantized && supportsGatherQMM(m, b) {
+		if useQuantized && model.SupportsGatherQMM(m, b) {
 			return &stackedExpertWeights{Weight: w, Scales: s, Biases: qb, GlobalScales: globalScale, Bits: b, GroupSize: gs, Mode: m}
 		}
 		deq := mlx.Dequantize(w, s, qb, gs, b, m)
@@ -764,14 +751,14 @@ func (m *Model) LoadWeights(tensors map[string]*mlx.Array) error {
 		return fmt.Errorf("missing lm_head.weight")
 	}
 
-	useQuantizedExperts := supportsGatherQMM(cfg.QuantMode, cfg.QuantBits)
+	useQuantizedExperts := model.SupportsGatherQMM(cfg.QuantMode, cfg.QuantBits)
 	if !useQuantizedExperts && cfg.TensorQuant != nil {
 		for _, tq := range cfg.TensorQuant {
 			if tq == nil {
 				continue
 			}
 			_, bits, mode := model.QuantizationParams(tq.QuantType)
-			if supportsGatherQMM(mode, bits) {
+			if model.SupportsGatherQMM(mode, bits) {
 				useQuantizedExperts = true
 				break
 			}

--- a/x/models/qwen3_5/qwen3_5.go
+++ b/x/models/qwen3_5/qwen3_5.go
@@ -421,19 +421,6 @@ func tensorByBase(tensors map[string]*mlx.Array, base string) (*mlx.Array, strin
 	return tensorAny(tensors, base+".weight", base)
 }
 
-func supportsGatherQMM(mode string, bits int) bool {
-	switch mode {
-	case "affine":
-		return bits == 4 || bits == 8
-	case "mxfp8":
-		return bits == 8
-	case "nvfp4", "mxfp4":
-		return bits == 4
-	default:
-		return false
-	}
-}
-
 func freeTensorKeys(tensors map[string]*mlx.Array, keys ...string) {
 	for _, k := range keys {
 		if k == "" {
@@ -474,7 +461,7 @@ func describeMoEProjection(prefix string, w *stackedExpertWeights) string {
 	}
 	if w.Bits > 0 || w.Mode != "" {
 		reason := "dequantized"
-		if !supportsGatherQMM(w.Mode, w.Bits) {
+		if !model.SupportsGatherQMM(w.Mode, w.Bits) {
 			reason = "unsupported_gather_qmm"
 		}
 		return fmt.Sprintf("%s=%s(mode=%s,bits=%d,gs=%d)", prefix, reason, w.Mode, w.Bits, w.GroupSize)
@@ -491,7 +478,7 @@ func summarizeMoEFallbackReason(gateW, upW, downW *stackedExpertWeights) string 
 			continue
 		}
 		if w.Bits > 0 || w.Mode != "" {
-			if !supportsGatherQMM(w.Mode, w.Bits) {
+			if !model.SupportsGatherQMM(w.Mode, w.Bits) {
 				return fmt.Sprintf("unsupported_gather_qmm(mode=%s,bits=%d)", w.Mode, w.Bits)
 			}
 			return "dequantized_quant_weights"
@@ -540,7 +527,7 @@ func loadStackedProjection(tensors map[string]*mlx.Array, cfg *Config, useQuanti
 			w,
 			scales,
 		)
-		if useQuantized && supportsGatherQMM(mode, bits) {
+		if useQuantized && model.SupportsGatherQMM(mode, bits) {
 			return &stackedExpertWeights{
 				Weight:    w,
 				Scales:    scales,
@@ -603,7 +590,7 @@ func collectPerExpertProjection(tensors map[string]*mlx.Array, cfg *Config, useQ
 			groupSize = gs
 			mode = m
 		}
-		if useQuantized && supportsGatherQMM(m, b) {
+		if useQuantized && model.SupportsGatherQMM(m, b) {
 			weights = append(weights, w)
 			scales = append(scales, s)
 			if qb != nil {
@@ -650,7 +637,7 @@ func splitGateUpProjection(tensors map[string]*mlx.Array, cfg *Config, useQuanti
 			gateUp,
 			scales,
 		)
-		if useQuantized && supportsGatherQMM(mode, bits) {
+		if useQuantized && model.SupportsGatherQMM(mode, bits) {
 			gate = &stackedExpertWeights{
 				Bits:      bits,
 				GroupSize: groupSize,
@@ -726,7 +713,7 @@ func splitGateUpProjection(tensors map[string]*mlx.Array, cfg *Config, useQuanti
 			downW,
 			scales,
 		)
-		if useQuantized && supportsGatherQMM(mode, bits) {
+		if useQuantized && model.SupportsGatherQMM(mode, bits) {
 			down = &stackedExpertWeights{
 				Weight:    downW,
 				Scales:    scales,
@@ -858,14 +845,14 @@ func (m *Model) LoadWeights(tensors map[string]*mlx.Array) error {
 		m.LMHead = m.EmbedTokens.AsLinear()
 	}
 
-	useQuantizedExperts := supportsGatherQMM(cfg.QuantMode, cfg.QuantBits)
+	useQuantizedExperts := model.SupportsGatherQMM(cfg.QuantMode, cfg.QuantBits)
 	if !useQuantizedExperts && cfg.TensorQuant != nil {
 		for _, tq := range cfg.TensorQuant {
 			if tq == nil {
 				continue
 			}
 			_, bits, mode := model.QuantizationParams(tq.QuantType)
-			if supportsGatherQMM(mode, bits) {
+			if model.SupportsGatherQMM(mode, bits) {
 				useQuantizedExperts = true
 				break
 			}

--- a/x/models/qwen3_5/qwen3_5_test.go
+++ b/x/models/qwen3_5/qwen3_5_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ollama/ollama/x/mlxrunner/cache"
 	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/mlxrunner/model"
 )
 
 func skipIfNoMLX(t *testing.T) {
@@ -83,25 +84,45 @@ func TestLayerSelectionHelpers(t *testing.T) {
 	}
 }
 
-func TestSupportsGatherQMM(t *testing.T) {
-	tests := []struct {
-		mode string
-		bits int
-		want bool
-	}{
-		{mode: "affine", bits: 4, want: true},
-		{mode: "affine", bits: 8, want: true},
-		{mode: "mxfp8", bits: 8, want: true},
-		{mode: "nvfp4", bits: 4, want: true},
-		{mode: "mxfp4", bits: 4, want: true},
-		{mode: "mxfp8", bits: 4, want: false},
-		{mode: "affine", bits: 3, want: false},
+func TestLoadStackedProjectionMixedPrecisionBits(t *testing.T) {
+	skipIfNoMLX(t)
+
+	// Simulate an imported mixed-precision MLX checkpoint: experts quantized
+	// at 6 bits while per-tensor metadata carries the model-level 4-bit
+	// params (the import pipeline only records the global quantization).
+	const experts, outDim, inDim = 2, 8, 64
+	vals := make([]float32, experts*outDim*inDim)
+	for i := range vals {
+		vals[i] = float32(i%23)/11 - 1
+	}
+	dense := mlx.FromValues(vals, experts, outDim, inDim).AsType(mlx.DTypeBFloat16)
+	qw, scales, qbiases := mlx.Quantize(dense, 64, 6, "affine")
+	mlx.Eval(qw, scales, qbiases)
+
+	key := "model.layers.0.mlp.switch_mlp.gate_proj.weight"
+	tensors := map[string]*mlx.Array{
+		key:            qw,
+		key + "_scale": scales,
+		key + "_qbias": qbiases,
+	}
+	cfg := &Config{
+		QuantGroupSize: 64,
+		QuantBits:      4,
+		QuantMode:      "affine",
+		TensorQuant: map[string]*model.TensorQuantInfo{
+			key: {QuantType: "INT4", GroupSize: 64},
+		},
 	}
 
-	for _, tt := range tests {
-		if got := supportsGatherQMM(tt.mode, tt.bits); got != tt.want {
-			t.Fatalf("supportsGatherQMM(%q, %d) = %v, want %v", tt.mode, tt.bits, got, tt.want)
-		}
+	w := loadStackedProjection(tensors, cfg, true, "model.layers.0.mlp.switch_mlp.gate_proj")
+	if w == nil {
+		t.Fatal("loadStackedProjection returned nil")
+	}
+	if w.Bits != 6 || w.GroupSize != 64 {
+		t.Fatalf("resolved (bits=%d, groupSize=%d), want (6, 64)", w.Bits, w.GroupSize)
+	}
+	if w.Scales == nil {
+		t.Fatal("expected quantized gather path (scales retained) for 6-bit affine experts")
 	}
 }
 


### PR DESCRIPTION
## Problem

Importing an mlx-lm **mixed-precision** quantized checkpoint with `ollama create --experimental` succeeds, but the first request panics the MLX runner:

```
panic: runtime error: index out of range [0] with length 0
  x/models/qwen3_5.(*SparseMoE).Forward  qwen3_5.go (x.Dims() is empty)
```

Reproduced with `Youssofal/Qwen3.6-35B-A3B-Abliterated-Heretic-MLX-4bit` (Apple M4 Pro 48GB): `config.json` declares global `{bits: 4, group_size: 64}`, but 147 tensors (all `switch_mlp.{gate,up,down}_proj` experts, `shared_expert.*`, some `out_proj`/`lm_head`) are quantized at **6 bits** via per-tensor overrides in the `quantization` block.

This fixes the **affine bit-width variant** of the panic class reported in #15746: tensors quantized at a different affine bit width than the recorded model-level params decode with wrong shapes, the C layer surfaces a null array, and the null propagates until `Dims()` is empty in `SparseMoE.Forward`. The NVFP4-mode scenario described in the issue body (a tensor stored as affine while the recorded mode is `nvfp4`) requires re-inferring the quantization **mode**, which shape validation alone cannot do, and is not covered here — that side needs import-time per-tensor overrides (the approach of #15760, to which this PR is complementary: it fixes blobs that are **already imported**, no re-import needed).

## Change

- `ResolveLinearQuantParams` cross-checks recorded affine params against the packed weight/scales shapes (`weightCols*32 == scalesCols*groupSize*bits`) and re-infers the bit width on mismatch, preferring the recorded group size when per-tensor metadata is present. Every override is logged via `slog.Warn` with the tensor name and recorded vs. inferred params (the repro logs exactly 147 warnings — one per overridden tensor).
- `SupportsGatherQMM` moves to the `model` package with the full set of affine bit widths the bundled MLX Metal kernels implement, replacing three diverging local copies: `qwen3_5`, `laguna`, and `glm4_moe_lite` (the latter two still rejected 6-bit and would have dequantized re-inferred experts to bf16, ~+32GB for a 35B MoE).

The bundled MLX (mlx-c pin `fba4470` = MLX **v0.31.2**) instantiates affine `gather_qmm` kernels for **bits {2,3,4,5,6,8}** × group sizes {32,64,128} via `instantiate_quantized_all()` in [`mlx/backend/metal/kernels/quantized.metal` (L144-158)](https://github.com/ml-explore/mlx/blob/v0.31.2/mlx/backend/metal/kernels/quantized.metal#L144-L158).

## Regression safety

Re-inference triggers **only** when the recorded affine params contradict the packed-shape identity `weightCols*32 == scalesCols*groupSize*bits`, which holds for every correctly imported affine tensor (MLX packs affine weights into uint32 along the last axis). For all shape-consistent blobs — including registry models — resolved params are bit-for-bit identical to current behavior; `TestResolveLinearQuantParamsAmbiguousRatioKeepsMetadata` pins this. Non-affine modes (`nvfp4`, `mxfp4`, `mxfp8`) are never touched (`TestResolveLinearQuantParamsNonAffinePassthrough`).

**Known limitations:** parameter pairs with identical packed ratios (e.g. `gs=64/bits=4` vs `gs=32/bits=8`) are indistinguishable, so shape-consistent metadata is always trusted; per-tensor overrides that change the group size (not just bits) can be mis-inferred — every re-inference leaves a `slog.Warn` trace for diagnosis.

## Testing

- Pure integer-math helpers (`affineParamsMatchCols`, `affineBitsForGroupSize`, `inferAffineQuantParamsFromCols`) are covered by table tests that run without MLX libraries, so CI exercises the core logic on all platforms; MLX-dependent cases (mixed-precision expert loading, ambiguous-ratio, 2-bit override) skip cleanly when MLX is unavailable.
- `go test ./x/mlxrunner/model/ ./x/models/qwen3_5/ ./x/models/laguna/ ./x/models/glm4_moe_lite/` — all pass with MLX libraries present (none skipped locally).
- End-to-end on a binary built from this branch with the checkpoint above: import → `/api/generate` returns correct output (temperature-0 sanity checks pass) at ~78 tok/s decode on M4 Pro, no panic, 147 re-inference warnings logged as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)