### PR TITLE
convert: read top-level text fields for text-only gemma4 configs

### DIFF
--- a/convert/convert_gemma4.go
+++ b/convert/convert_gemma4.go
@@ -3,6 +3,7 @@ package convert
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"math"
 	"slices"
@@ -64,6 +65,30 @@ type gemma4Model struct {
 		ConvKernelSize    uint32  `json:"conv_kernel_size"`
 		RMSNormEps        float32 `json:"rms_norm_eps"`
 	} `json:"audio_config"`
+}
+
+// UnmarshalJSON handles both Gemma4 config.json layouts: multimodal
+// Gemma4ForConditionalGeneration checkpoints nest the text fields under
+// "text_config", while text-only Gemma4ForCausalLM checkpoints keep them at
+// the top level. Without the fallback, text-only imports produce all-zero
+// gemma4.* metadata.
+func (p *gemma4Model) UnmarshalJSON(data []byte) error {
+	type gemma4ModelNoCustomUnmarshal gemma4Model
+	if err := json.Unmarshal(data, (*gemma4ModelNoCustomUnmarshal)(p)); err != nil {
+		return err
+	}
+
+	var layout struct {
+		TextConfig json.RawMessage `json:"text_config"`
+	}
+	if err := json.Unmarshal(data, &layout); err != nil {
+		return err
+	}
+	if len(layout.TextConfig) == 0 {
+		// text-only checkpoint: text fields live at the top level
+		return json.Unmarshal(data, &p.TextModel)
+	}
+	return nil
 }
 
 func (p *gemma4Model) KV(t *Tokenizer) KV {

--- a/convert/convert_gemma4_test.go
+++ b/convert/convert_gemma4_test.go
@@ -1,6 +1,9 @@
 package convert
 
 import (
+	"encoding/json"
+	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -312,6 +315,79 @@ func TestGemma4AudioReplacements(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := r.Replace(tt.in); got != tt.want {
 				t.Errorf("Replace(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGemma4ConfigLayouts(t *testing.T) {
+	// Text fields as found in a Gemma4ForCausalLM (text-only) config.json,
+	// where they live at the top level rather than under "text_config".
+	textFields := `
+		"hidden_size": 3840,
+		"intermediate_size": 15360,
+		"num_hidden_layers": 48,
+		"num_attention_heads": 16,
+		"num_key_value_heads": 8,
+		"head_dim": 256,
+		"global_head_dim": 512,
+		"max_position_embeddings": 131072,
+		"vocab_size": 262144,
+		"rms_norm_eps": 1e-6,
+		"sliding_window": 1024,
+		"layer_types": ["sliding_attention", "full_attention"],
+		"final_logit_softcapping": 30.0,
+		"rope_parameters": {
+			"full_attention": {"rope_theta": 1000000},
+			"sliding_attention": {"rope_theta": 10000}
+		}`
+
+	configs := map[string]string{
+		"text-only top-level": fmt.Sprintf(`{
+			"architectures": ["Gemma4ForCausalLM"],
+			%s
+		}`, textFields),
+		"nested text_config": fmt.Sprintf(`{
+			"architectures": ["Gemma4ForConditionalGeneration"],
+			"text_config": {%s}
+		}`, textFields),
+	}
+
+	want := map[string]any{
+		"gemma4.block_count":                      uint32(48),
+		"gemma4.embedding_length":                 uint32(3840),
+		"gemma4.feed_forward_length":              uint32(15360),
+		"gemma4.context_length":                   uint32(131072),
+		"gemma4.attention.head_count":             uint32(16),
+		"gemma4.attention.head_count_kv":          uint32(8),
+		"gemma4.attention.key_length":             uint32(512),
+		"gemma4.attention.value_length":           uint32(512),
+		"gemma4.attention.key_length_swa":         uint32(256),
+		"gemma4.attention.value_length_swa":       uint32(256),
+		"gemma4.attention.layer_norm_rms_epsilon": float32(1e-6),
+		"gemma4.attention.sliding_window":         uint32(1024),
+		"gemma4.attention.sliding_window_pattern": []bool{true, false},
+		"gemma4.rope.freq_base":                   float32(1000000),
+		"gemma4.rope.dimension_count":             uint32(512),
+		"gemma4.rope.freq_base_swa":               float32(10000),
+		"gemma4.rope.dimension_count_swa":         uint32(256),
+		"gemma4.final_logit_softcapping":          float32(30),
+	}
+
+	for name, config := range configs {
+		t.Run(name, func(t *testing.T) {
+			p := &gemma4Model{}
+			if err := json.Unmarshal([]byte(config), p); err != nil {
+				t.Fatal(err)
+			}
+
+			kv := p.KV(&Tokenizer{Vocabulary: &Vocabulary{}})
+			for key, w := range want {
+				if got, ok := kv[key]; !ok {
+					t.Errorf("missing %s", key)
+				} else if !reflect.DeepEqual(got, w) {
+					t.Errorf("%s = %v (%T), want %v (%T)", key, got, got, w, w)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Importing a text-only `Gemma4ForCausalLM` safetensors checkpoint with `ollama create --experimental` produces a model whose `gemma4.*` metadata is all zero ("embedding length 0" in `ollama show`); the model loads but returns EOS on the first token (#16557).

**Root cause:** `gemma4Model` in `convert/convert_gemma4.go` only parses text fields nested under `text_config` (the `Gemma4ForConditionalGeneration` layout). Text-only `Gemma4ForCausalLM` checkpoints keep `hidden_size`, `num_hidden_layers`, `rope_parameters`, etc. at the top level of `config.json`, so every `TextModel` field stayed at its zero value and `KV()` emitted zeros (and dropped the conditional rope/softcapping keys). The gemma3 converter already handles both layouts; gemma4 did not.

**Change:** add a `gemma4Model.UnmarshalJSON` that, when `config.json` has no `text_config` key, parses the top-level object into `TextModel`. Configs with `text_config` are unaffected (same code path as before, then early return). This mirrors the existing whole-model `UnmarshalJSON` pattern in `convert_laguna.go`.

**Testing:**
- `TestGemma4ConfigLayouts` (new): the same synthetic text fields — values taken from the 12B config in #16557 — are parsed once at the top level (`Gemma4ForCausalLM`) and once under `text_config` (`Gemma4ForConditionalGeneration`); both must yield identical, non-zero `gemma4.*` KV, including the per-layout-conditional keys (`rope.freq_base{,_swa}`, `rope.dimension_count{,_swa}`, `final_logit_softcapping`, `sliding_window_pattern`).
- `go test ./convert/ -count=1` passes; `go vet ./convert/` clean.

Fixes #16557

🤖 Generated with [Claude Code](https://claude.com/claude-code)