### PR TITLE
docs: add missing fields to /api/tags example response

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1420,8 +1420,11 @@ A single JSON object will be returned.
         "family": "qwen2",
         "families": ["qwen2"],
         "parameter_size": "7.6B",
-        "quantization_level": "Q4_K_M"
-      }
+        "quantization_level": "Q4_K_M",
+        "context_length": 131072,
+        "embedding_length": 3584
+      },
+      "capabilities": ["completion", "tools", "thinking", "insert"]
     },
     {
       "name": "llama3.2:latest",
@@ -1435,8 +1438,11 @@ A single JSON object will be returned.
         "family": "llama",
         "families": ["llama"],
         "parameter_size": "3.2B",
-        "quantization_level": "Q4_K_M"
-      }
+        "quantization_level": "Q4_K_M",
+        "context_length": 131072,
+        "embedding_length": 3072
+      },
+      "capabilities": ["completion", "tools", "insert"]
     }
   ]
 }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -635,6 +635,17 @@ components:
             quantization_level:
               type: string
               description: Quantization level used (for example `Q4_0`)
+            context_length:
+              type: integer
+              description: Maximum context length the model supports, when known
+            embedding_length:
+              type: integer
+              description: Embedding dimension of the model, when known
+        capabilities:
+          type: array
+          items:
+            type: string
+          description: Capabilities the model supports (for example `completion`, `tools`, `vision`, `thinking`, `insert`)
     ListResponse:
       type: object
       properties:
@@ -1160,6 +1171,11 @@ paths:
                         - "gemma4"
                       parameter_size: "8.0B"
                       quantization_level: "Q4_K_M"
+                      context_length: 131072
+                      embedding_length: 2560
+                    capabilities:
+                      - "completion"
+                      - "vision"
   /api/ps:
     get:
       summary: List running models

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -618,6 +618,9 @@ components:
           type: object
           description: Additional information about the model's format and family
           properties:
+            parent_model:
+              type: string
+              description: Name of the parent model this model was derived from, when applicable
             format:
               type: string
               description: Model file format (for example `gguf`)
@@ -645,7 +648,16 @@ components:
           type: array
           items:
             type: string
-          description: Capabilities the model supports (for example `completion`, `tools`, `vision`, `thinking`, `insert`)
+            enum:
+              - completion
+              - tools
+              - insert
+              - vision
+              - embedding
+              - thinking
+              - image
+              - audio
+          description: Capabilities the model supports
     ListResponse:
       type: object
       properties:
@@ -1165,6 +1177,7 @@ paths:
                     size: 9608350245
                     digest: "c6eb396dbd5992bbe3f5cdb947e8bbc0ee413d7c17e2beaae69f5d569cf982eb"
                     details:
+                      parent_model: ""
                       format: "gguf"
                       family: "gemma4"
                       families:


### PR DESCRIPTION
## What changed

The documented example response for the List Local Models endpoint (`/api/tags`) now matches what the server actually returns for every model: the `capabilities` list, the `context_length` and `embedding_length` detail fields, and the `parent_model` detail field. This is fixed in two places, the Markdown reference (`docs/api.md`) and the OpenAPI spec (`docs/openapi.yaml`), where both the example and the `ModelSummary` schema were missing those fields.

In the OpenAPI spec the `capabilities` list now also spells out the full set of allowed values instead of being described as a plain list of text. The values a model can report are: `completion`, `tools`, `insert`, `vision`, `embedding`, `thinking`, `image`, and `audio`.

## Why

The server already returns all of these fields, but the docs example never showed them. Anyone comparing a real response from a recent Ollama version against the docs would see extra fields and wonder which one was correct. The docs were stale, the server was right. This brings the docs in line with what the server actually sends, and it tells people who build against the API exactly which capability values they can expect.

## Notes

Documentation only. No code changes.

I am aware the API docs are moving to `docs.ollama.com/api`. That page is generated from `docs/openapi.yaml`, and it was missing the same fields, so this PR fixes it there too. If there is another docs source I have not spotted, point me at it and I will update that as well.