### PR TITLE
readme: add ollmcp to community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ console.log(response.message.content);
 - [oterm](https://github.com/ggozad/oterm) - Terminal client for Ollama
 - [gollama](https://github.com/sammcj/gollama) - Go-based model manager for Ollama
 - [tlm](https://github.com/yusufcanb/tlm) - Local shell copilot
+- [ollmcp](https://github.com/jonigl/mcp-client-for-ollama) - Interactive MCP client for Ollama with tools, prompts, and resources
 - [tenere](https://github.com/pythops/tenere) - TUI for LLMs
 - [ParLlama](https://github.com/paulrobello/parllama) - TUI for Ollama
 - [llm-ollama](https://github.com/taketwo/llm-ollama) - Plugin for [Datasette's LLM CLI](https://llm.datasette.io/en/stable/)


### PR DESCRIPTION
Hi Ollama team! I'd love to add `ollmcp` to the Terminal & CLI section of the Community Integrations.

`ollmcp` is an interactive terminal [MCP client for Ollama](https://github.com/jonigl/mcp-client-for-ollama), implementing all three MCP primitives (tools, prompts, resources) plus agent mode, multi-server support, and human-in-the-loop controls. Actively developed since early 2025, now at `v0.29.0`.

Thanks for the great project, **it would be an honor to be listed!**