### PR TITLE
discover: fix inverted iGPU/dGPU Vulkan classification on Windows hybrid graphics

### DIFF
--- a/discover/llama_server.go
+++ b/discover/llama_server.go
@@ -160,8 +160,8 @@ func llamaServerDiscoverDevices(ctx context.Context, libDirs []string, extraEnvs
 		logNativeProbeFailure(nativeErr, nativeStderr, libDirs)
 	}
 
-	combined := string(listOutput) + "\n" + strings.Join(stderrLines, "\n") + "\n" + nativeStderr
-	return parseLlamaServerDevicesWithNative(combined, libDirs, nativeDevices), status, nil
+	llamaOutput := string(listOutput) + "\n" + strings.Join(stderrLines, "\n")
+	return parseLlamaServerDevicesWithNative(llamaOutput, nativeStderr, libDirs, nativeDevices), status, nil
 }
 
 func llamaServerDiscoveryOutput(ctx context.Context) io.Writer {
@@ -203,13 +203,20 @@ var (
 // It extracts device info, ROCm gfx targets, CUDA compute capabilities, and
 // CUDA compiled architecture lists.
 func parseLlamaServerDevices(output string, libDirs []string) []ml.DeviceInfo {
-	return parseLlamaServerDevicesWithNative(output, libDirs, nil)
+	return parseLlamaServerDevicesWithNative(output, "", libDirs, nil)
 }
 
-func parseLlamaServerDevicesWithNative(output string, libDirs []string, nativeDevices []nativeProbeDevice) []ml.DeviceInfo {
+func parseLlamaServerDevicesWithNative(output, nativeOutput string, libDirs []string, nativeDevices []nativeProbeDevice) []ml.DeviceInfo {
+	combined := output
+	if nativeOutput != "" {
+		combined += "\n" + nativeOutput
+	}
 	// Extract per-device metadata from stderr
-	gfxByIndex := parseROCmGFXTargets(output)
+	gfxByIndex := parseROCmGFXTargets(combined)
 	rocmGFXOverride := hsaOverrideGFXTarget()
+	// The native probe enumerates Vulkan devices in its own order, which can
+	// differ from llama-server's, so its ggml_vulkan uma lines must not key
+	// into llama-server's device indexes.
 	integratedByIndex := parseVulkanUMA(output)
 	ccByIndex := make(map[int]cudaComputeCapability)
 	var cudaArchs []string // compiled architectures for this variant
@@ -222,7 +229,7 @@ func parseLlamaServerDevicesWithNative(output string, libDirs []string, nativeDe
 		}
 	}
 
-	scanner := bufio.NewScanner(strings.NewReader(output))
+	scanner := bufio.NewScanner(strings.NewReader(combined))
 	for scanner.Scan() {
 		line := scanner.Text()
 		if matches := cudaCCRegex.FindStringSubmatch(line); matches != nil {

--- a/discover/llama_server_test.go
+++ b/discover/llama_server_test.go
@@ -399,7 +399,7 @@ Available devices:
 			TotalMemory:         16107 * 1024 * 1024,
 		}}
 
-		devices := parseLlamaServerDevicesWithNative(output, []string{"/lib/ollama", "/lib/ollama/vulkan"}, nativeDevices)
+		devices := parseLlamaServerDevicesWithNative(output, "", []string{"/lib/ollama", "/lib/ollama/vulkan"}, nativeDevices)
 		if len(devices) != 1 {
 			t.Fatalf("got %d devices, want 1", len(devices))
 		}
@@ -408,6 +408,33 @@ Available devices:
 		}
 		if devices[0].Integrated {
 			t.Fatal("Integrated = true, want false")
+		}
+	})
+
+	t.Run("native probe uma lines do not key into llama-server device order", func(t *testing.T) {
+		// llama-server enumerates [Intel iGPU, NVIDIA dGPU]; the native probe
+		// enumerates the same devices in the opposite order. Its ggml_vulkan
+		// uma lines must not overwrite llama-server's index-keyed UMA map,
+		// otherwise the classification inverts (#16667).
+		output := `ggml_vulkan: 0 = Intel(R) RaptorLake-S Mobile Graphics Controller (Intel Corporation) | uma: 1 | fp16: 1 | bf16: 0 | warp size: 32 | shared memory: 65536 | int dot: 1 | matrix cores: none
+ggml_vulkan: 1 = NVIDIA GeForce RTX 4080 Laptop GPU (NVIDIA) | uma: 0 | fp16: 1 | bf16: 0 | warp size: 32 | shared memory: 49152 | int dot: 1 | matrix cores: KHR_coopmat
+Available devices:
+  Vulkan0: Intel(R) RaptorLake-S Mobile Graphics Controller (32550 MiB, 31800 MiB free)
+  Vulkan1: NVIDIA GeForce RTX 4080 Laptop GPU (12282 MiB, 11000 MiB free)
+`
+		nativeOutput := `ggml_vulkan: 0 = NVIDIA GeForce RTX 4080 Laptop GPU (NVIDIA) | uma: 0 | fp16: 1 | bf16: 0 | warp size: 32 | shared memory: 49152 | int dot: 1 | matrix cores: KHR_coopmat
+ggml_vulkan: 1 = Intel(R) RaptorLake-S Mobile Graphics Controller (Intel Corporation) | uma: 1 | fp16: 1 | bf16: 0 | warp size: 32 | shared memory: 65536 | int dot: 1 | matrix cores: none
+`
+
+		devices := parseLlamaServerDevicesWithNative(output, nativeOutput, []string{"/lib/ollama", "/lib/ollama/vulkan"}, nil)
+		if len(devices) != 2 {
+			t.Fatalf("got %d devices, want 2", len(devices))
+		}
+		if !devices[0].Integrated {
+			t.Fatal("device 0 (Intel iGPU) Integrated = false, want true")
+		}
+		if devices[1].Integrated {
+			t.Fatal("device 1 (NVIDIA dGPU) Integrated = true, want false")
 		}
 	})
 
@@ -471,9 +498,49 @@ Available devices:
 				want: []bool{false, false, false},
 			},
 			{
-				name:   "skips when counts do not line up",
+				name:   "skips when probe finds fewer devices",
 				probed: []vulkanPhysicalDevice{{Name: "AMD Radeon(TM) Graphics", Integrated: true}},
 				want:   []bool{false, false, false},
+			},
+			{
+				name: "matches subset when probe enumerates extra devices",
+				devices: []ml.DeviceInfo{
+					{DeviceID: ml.DeviceID{ID: "0", Library: "Vulkan"}, Description: "Intel(R) RaptorLake-S Mobile Graphics Controller"},
+					{DeviceID: ml.DeviceID{ID: "1", Library: "Vulkan"}, Description: "NVIDIA GeForce RTX 4080 Laptop GPU"},
+				},
+				probed: []vulkanPhysicalDevice{
+					{Name: "NVIDIA GeForce RTX 4080 Laptop GPU", Integrated: false},
+					{Name: "Intel(R) RaptorLake-S Mobile Graphics Controller", Integrated: true},
+					{Name: "Microsoft Direct3D12 (NVIDIA GeForce RTX 4080 Laptop GPU)", Integrated: false},
+					{Name: "Microsoft Direct3D12 (Intel(R) RaptorLake-S Mobile Graphics Controller)", Integrated: true},
+					{Name: "llvmpipe (LLVM 17.0.6, 256 bits)", Integrated: false},
+				},
+				want:    []bool{true, false},
+				applied: true,
+			},
+			{
+				name: "skips ambiguous duplicate names with conflicting types",
+				devices: []ml.DeviceInfo{
+					{DeviceID: ml.DeviceID{ID: "0", Library: "Vulkan"}, Description: "AMD Radeon Graphics"},
+				},
+				probed: []vulkanPhysicalDevice{
+					{Name: "AMD Radeon Graphics", Integrated: true},
+					{Name: "AMD Radeon Graphics", Integrated: false},
+				},
+				want: []bool{false},
+			},
+			{
+				name: "matches duplicate names with agreeing types",
+				devices: []ml.DeviceInfo{
+					{DeviceID: ml.DeviceID{ID: "0", Library: "Vulkan"}, Description: "AMD Radeon RX 7900 XTX"},
+					{DeviceID: ml.DeviceID{ID: "1", Library: "Vulkan"}, Description: "AMD Radeon RX 7900 XTX"},
+				},
+				probed: []vulkanPhysicalDevice{
+					{Name: "AMD Radeon RX 7900 XTX", Integrated: false},
+					{Name: "AMD Radeon RX 7900 XTX", Integrated: false},
+				},
+				want:    []bool{false, false},
+				applied: true,
 			},
 			{
 				name: "overwrites stale classification",

--- a/discover/native_probe_test.go
+++ b/discover/native_probe_test.go
@@ -46,7 +46,7 @@ func TestParseLlamaServerDevicesUsesNativeCUDAComputeCapability(t *testing.T) {
 Available devices:
   CUDA0: NVIDIA GeForce GTX 1060 6GB (6063 MiB, 5900 MiB free)
 `
-	devices := parseLlamaServerDevicesWithNative(output, []string{"/lib/ollama", "/lib/ollama/cuda_v13"}, []nativeProbeDevice{{
+	devices := parseLlamaServerDevicesWithNative(output, "", []string{"/lib/ollama", "/lib/ollama/cuda_v13"}, []nativeProbeDevice{{
 		Library:             "CUDA",
 		Index:               0,
 		IndexMatchesBackend: true,
@@ -64,7 +64,7 @@ Available devices:
 Available devices:
   CUDA0: NVIDIA GeForce GTX 1060 6GB (6063 MiB, 5900 MiB free)
 `
-	devices = parseLlamaServerDevicesWithNative(output, []string{"/lib/ollama", "/lib/ollama/cuda_v12"}, []nativeProbeDevice{{
+	devices = parseLlamaServerDevicesWithNative(output, "", []string{"/lib/ollama", "/lib/ollama/cuda_v12"}, []nativeProbeDevice{{
 		Library:             "CUDA",
 		Index:               0,
 		IndexMatchesBackend: true,
@@ -97,7 +97,7 @@ func TestParseLlamaServerDevicesUsesNativeROCmMetadata(t *testing.T) {
 Available devices:
   ROCm0: AMD Radeon RX 7600 (8176 MiB, 7900 MiB free)
 `
-	devices := parseLlamaServerDevicesWithNative(output, []string{"/lib/ollama", "/lib/ollama/rocm_v7_2"}, []nativeProbeDevice{{
+	devices := parseLlamaServerDevicesWithNative(output, "", []string{"/lib/ollama", "/lib/ollama/rocm_v7_2"}, []nativeProbeDevice{{
 		Library:             "ROCm",
 		Index:               0,
 		IndexMatchesBackend: true,

--- a/discover/vulkan.go
+++ b/discover/vulkan.go
@@ -95,32 +95,40 @@ func applyWindowsVulkanRefinement(devices []ml.DeviceInfo, probed []vulkanPhysic
 		}
 	}
 
-	if len(probed) != len(vulkanIndexes) {
-		slog.Debug("windows vulkan device refinement skipped: device count mismatch",
+	if len(probed) < len(vulkanIndexes) {
+		slog.Debug("windows vulkan device refinement skipped: fewer probed devices than llama-server devices",
 			"llama_server_count", len(vulkanIndexes), "vulkan_count", len(probed))
 		return false
 	}
 
+	// Raw Vulkan enumeration can be a superset of llama-server's device list
+	// (extra ICDs, D3D12 mapping-layer devices) and the two orders can differ,
+	// so match by name rather than requiring equal counts or matching indexes.
 	matches := make([]int, len(vulkanIndexes))
-	for i := range matches {
-		matches[i] = -1
-	}
 	used := make([]bool, len(probed))
 	for i, deviceIndex := range vulkanIndexes {
+		matches[i] = -1
 		description := devices[deviceIndex].Description
 		for j, probedDevice := range probed {
 			if used[j] || !sameVulkanDeviceName(description, probedDevice.Name) {
 				continue
 			}
+			if matches[i] >= 0 {
+				if probed[matches[i]].Integrated != probedDevice.Integrated {
+					slog.Debug("windows vulkan device refinement skipped: ambiguous device name match",
+						"index", i, "llama_server_name", description)
+					return false
+				}
+				continue
+			}
 			matches[i] = j
-			used[j] = true
-			break
 		}
 		if matches[i] < 0 {
 			slog.Debug("windows vulkan device refinement skipped: device name mismatch",
 				"index", i, "llama_server_name", description)
 			return false
 		}
+		used[matches[i]] = true
 	}
 
 	for i, probedIndex := range matches {


### PR DESCRIPTION
Fixes #16667

## Problem

On Windows hybrid-graphics systems (Intel iGPU + NVIDIA dGPU), discovery can invert the integrated/discrete classification: the Intel iGPU is kept as `type=discrete` with its shared system RAM reported as 31.8 GiB of "VRAM", while the NVIDIA dGPU's Vulkan device is dropped as integrated. The scheduler then places models on the iGPU out of system RAM — ~9x slower than CUDA on the same machine.

Two index-keyed correlations between independently-ordered device enumerations cause this:

1. **Native-probe stderr contaminates the UMA map.** `llamaServerDiscoverDevices` concatenates the native probe's stderr into the output passed to `parseVulkanUMA`. The probe enumerates Vulkan devices in its own order (on the repro machine, NVIDIA first; llama-server lists Intel first), so its `ggml_vulkan: N = ... uma:` lines overwrite llama-server's index-keyed UMA map with inverted values.

2. **Windows Vulkan refinement bails on count mismatch.** `applyWindowsVulkanRefinement` required the raw `vkEnumeratePhysicalDevices` count to equal llama-server's Vulkan device count. The raw enumeration is a superset on real systems — on the repro machine it returns 5 devices:

   ```
   probed[0] "Intel(R) RaptorLake-S Mobile Graphics Controller"            integrated=true
   probed[1] "Microsoft Direct3D12 (Intel(R) UHD Graphics)"                integrated=true
   probed[2] "NVIDIA GeForce RTX 4080 Laptop GPU"                          integrated=false
   probed[3] "Microsoft Direct3D12 (NVIDIA GeForce RTX 4080 Laptop GPU)"   integrated=false
   probed[4] "Microsoft Direct3D12 (Microsoft Basic Render Driver)"        integrated=false
   ```

   vs llama-server's 2, so the one component that reads the authoritative `VkPhysicalDeviceType` was skipped exactly on the systems that need it.

## Fix

- Parse Vulkan UMA metadata only from llama-server's own output, not the native probe's stderr (the probe's structured results are still merged as before).
- Match llama-server Vulkan devices against the probed superset by name instead of requiring equal counts, skipping refinement only when a device has no match or duplicate names disagree on device type.

## Testing

- New regression tests for both bugs (crossed-order UMA lines; superset/duplicate-name matching), plus existing `discover`, `ml`, and `llm` suites pass.
- Verified end-to-end on the hardware from #16667 (Intel RaptorLake-S + RTX 4080 Laptop, Windows 11), default configuration with no environment overrides:

  | | before (default) | after (default) |
  |---|---|---|
  | discovery | Intel Vulkan "31.8 GiB" discrete + CUDA0 | CUDA0 only (iGPU dropped as integrated, Vulkan dGPU deduped against CUDA) |
  | placement of llama-guard3:8b | Intel iGPU, system RAM (~0.5 GB on `nvidia-smi`) | `using device CUDA0 ... 0000:01:00.0`, 33/33 layers, 4403.49 MiB buffer, 5.5 GB on `nvidia-smi` |
  | short request | ~3.8 s | ~0.8 s |

  The after-fix CUDA0 model buffer is byte-identical to the `OLLAMA_LLM_LIBRARY=cuda_v13` workaround path from the issue.
