### PR TITLE
launch: Fix launch provider drift

### DIFF
--- a/cmd/launch/launch.go
+++ b/cmd/launch/launch.go
@@ -765,7 +765,7 @@ func (c *launcherClient) launchEditorIntegration(ctx context.Context, name strin
 
 	var launchModels []LaunchModel
 	liveConfigMatches := editorLiveConfigMatchesModels(editor, models)
-	if (needsConfigure || req.ModelOverride != "") && (!savedMatchesModels(saved, models) || !liveConfigMatches) {
+	if !savedMatchesModels(saved, models) || !liveConfigMatches {
 		launchModels = c.modelInventory().Resolve(ctx, models)
 		if err := prepareEditorIntegration(name, editor, launchModels); err != nil {
 			return err

--- a/cmd/launch/launch.go
+++ b/cmd/launch/launch.go
@@ -765,7 +765,7 @@ func (c *launcherClient) launchEditorIntegration(ctx context.Context, name strin
 
 	var launchModels []LaunchModel
 	liveConfigMatches := slices.Equal(editor.Models(), models)
-	if ((needsConfigure || req.ModelOverride != "") && !savedMatchesModels(saved, models)) || !liveConfigMatches {
+	if needsConfigure || req.ModelOverride != "" || !savedMatchesModels(saved, models) || !liveConfigMatches {
 		launchModels = c.modelInventory().Resolve(ctx, models)
 		if err := prepareEditorIntegration(name, editor, launchModels); err != nil {
 			return err

--- a/cmd/launch/launch.go
+++ b/cmd/launch/launch.go
@@ -764,7 +764,7 @@ func (c *launcherClient) launchEditorIntegration(ctx context.Context, name strin
 	}
 
 	var launchModels []LaunchModel
-	liveConfigMatches := editorLiveConfigMatchesModels(editor, models)
+	liveConfigMatches := slices.Equal(editor.Models(), models)
 	if ((needsConfigure || req.ModelOverride != "") && !savedMatchesModels(saved, models)) || !liveConfigMatches {
 		launchModels = c.modelInventory().Resolve(ctx, models)
 		if err := prepareEditorIntegration(name, editor, launchModels); err != nil {
@@ -1481,10 +1481,6 @@ func savedMatchesModels(saved *config.IntegrationConfig, models []string) bool {
 		return false
 	}
 	return slices.Equal(saved.Models, models)
-}
-
-func editorLiveConfigMatchesModels(editor Editor, models []string) bool {
-	return slices.Equal(editor.Models(), models)
 }
 
 func editorPreCheckedModels(saved *config.IntegrationConfig, override string) []string {

--- a/cmd/launch/launch.go
+++ b/cmd/launch/launch.go
@@ -764,7 +764,8 @@ func (c *launcherClient) launchEditorIntegration(ctx context.Context, name strin
 	}
 
 	var launchModels []LaunchModel
-	if (needsConfigure || req.ModelOverride != "") && !savedMatchesModels(saved, models) {
+	liveConfigMatches := editorLiveConfigMatchesModels(editor, models)
+	if (needsConfigure || req.ModelOverride != "") && (!savedMatchesModels(saved, models) || !liveConfigMatches) {
 		launchModels = c.modelInventory().Resolve(ctx, models)
 		if err := prepareEditorIntegration(name, editor, launchModels); err != nil {
 			return err
@@ -1480,6 +1481,10 @@ func savedMatchesModels(saved *config.IntegrationConfig, models []string) bool {
 		return false
 	}
 	return slices.Equal(saved.Models, models)
+}
+
+func editorLiveConfigMatchesModels(editor Editor, models []string) bool {
+	return slices.Equal(editor.Models(), models)
 }
 
 func editorPreCheckedModels(saved *config.IntegrationConfig, override string) []string {

--- a/cmd/launch/launch.go
+++ b/cmd/launch/launch.go
@@ -765,7 +765,7 @@ func (c *launcherClient) launchEditorIntegration(ctx context.Context, name strin
 
 	var launchModels []LaunchModel
 	liveConfigMatches := editorLiveConfigMatchesModels(editor, models)
-	if !savedMatchesModels(saved, models) || !liveConfigMatches {
+	if ((needsConfigure || req.ModelOverride != "") && !savedMatchesModels(saved, models)) || !liveConfigMatches {
 		launchModels = c.modelInventory().Resolve(ctx, models)
 		if err := prepareEditorIntegration(name, editor, launchModels); err != nil {
 			return err

--- a/cmd/launch/launch_test.go
+++ b/cmd/launch/launch_test.go
@@ -23,6 +23,7 @@ import (
 type launcherEditorRunner struct {
 	paths    []string
 	edited   [][]string
+	models   []string
 	ranModel string
 }
 
@@ -36,11 +37,15 @@ func (r *launcherEditorRunner) String() string { return "LauncherEditor" }
 func (r *launcherEditorRunner) Paths() []string { return r.paths }
 
 func (r *launcherEditorRunner) Edit(models []LaunchModel) error {
-	r.edited = append(r.edited, launchModelNames(models))
+	names := launchModelNames(models)
+	r.edited = append(r.edited, names)
+	r.models = append([]string(nil), names...)
 	return nil
 }
 
-func (r *launcherEditorRunner) Models() []string { return nil }
+func (r *launcherEditorRunner) Models() []string {
+	return append([]string(nil), r.models...)
+}
 
 type launcherSingleRunner struct {
 	ranModel string
@@ -2260,8 +2265,7 @@ func TestLaunchIntegration_ClineRewritesWhenLiveProviderDrifted(t *testing.T) {
 	t.Setenv("OLLAMA_HOST", srv.URL)
 
 	if err := LaunchIntegration(context.Background(), IntegrationLaunchRequest{
-		Name:          "cline",
-		ModelOverride: "llama3.2",
+		Name: "cline",
 	}); err != nil {
 		t.Fatalf("LaunchIntegration returned error: %v", err)
 	}
@@ -2874,7 +2878,7 @@ func TestLaunchIntegration_ConfiguredEditorLaunchValidatesPrimaryOnly(t *testing
 	writeFakeBinary(t, binDir, "droid")
 	t.Setenv("PATH", binDir)
 
-	editor := &launcherEditorRunner{}
+	editor := &launcherEditorRunner{models: []string{"llama3.2", "missing-local"}}
 	withIntegrationOverride(t, "droid", editor)
 
 	if err := config.SaveIntegration("droid", []string{"llama3.2", "missing-local"}); err != nil {
@@ -2943,7 +2947,7 @@ func TestLaunchIntegration_ConfiguredEditorLaunchSkipsReconfigure(t *testing.T) 
 	if err := os.WriteFile(settingsPath, []byte("{}"), 0o644); err != nil {
 		t.Fatalf("failed to seed editor settings: %v", err)
 	}
-	editor := &launcherEditorRunner{paths: []string{settingsPath}}
+	editor := &launcherEditorRunner{paths: []string{settingsPath}, models: []string{"llama3.2", "qwen3:8b"}}
 	withIntegrationOverride(t, "droid", editor)
 
 	if err := config.SaveIntegration("droid", []string{"llama3.2", "qwen3:8b"}); err != nil {
@@ -2995,7 +2999,7 @@ func TestLaunchIntegration_OpenclawPreservesExistingModelList(t *testing.T) {
 	writeFakeBinary(t, binDir, "openclaw")
 	t.Setenv("PATH", binDir)
 
-	editor := &launcherEditorRunner{}
+	editor := &launcherEditorRunner{models: []string{"llama3.2", "mistral"}}
 	withIntegrationOverride(t, "openclaw", editor)
 
 	if err := config.SaveIntegration("openclaw", []string{"llama3.2", "mistral"}); err != nil {

--- a/cmd/launch/launch_test.go
+++ b/cmd/launch/launch_test.go
@@ -2990,6 +2990,53 @@ func TestLaunchIntegration_ConfiguredEditorLaunchSkipsReconfigure(t *testing.T) 
 	}
 }
 
+func TestLaunchIntegration_ConfiguredEditorLaunchRepairsLiveDrift(t *testing.T) {
+	tmpDir := t.TempDir()
+	setLaunchTestHome(t, tmpDir)
+	withLauncherHooks(t)
+
+	binDir := t.TempDir()
+	writeFakeBinary(t, binDir, "droid")
+	t.Setenv("PATH", binDir)
+
+	editor := &launcherEditorRunner{models: []string{"old-model"}}
+	withIntegrationOverride(t, "droid", editor)
+
+	if err := config.SaveIntegration("droid", []string{"llama3.2", "qwen3:8b"}); err != nil {
+		t.Fatalf("failed to seed config: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/show" {
+			var req apiShowRequest
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			fmt.Fprintf(w, `{"model":%q}`, req.Model)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+	t.Setenv("OLLAMA_HOST", srv.URL)
+
+	if err := LaunchIntegration(context.Background(), IntegrationLaunchRequest{Name: "droid"}); err != nil {
+		t.Fatalf("LaunchIntegration returned error: %v", err)
+	}
+	if diff := compareStringSlices(editor.edited, [][]string{{"llama3.2", "qwen3:8b"}}); diff != "" {
+		t.Fatalf("unexpected editor rewrites (-want +got):\n%s", diff)
+	}
+	if editor.ranModel != "llama3.2" {
+		t.Fatalf("expected launch to use saved primary model, got %q", editor.ranModel)
+	}
+
+	saved, err := config.LoadIntegration("droid")
+	if err != nil {
+		t.Fatalf("failed to reload saved config: %v", err)
+	}
+	if diff := compareStrings(saved.Models, []string{"llama3.2", "qwen3:8b"}); diff != "" {
+		t.Fatalf("unexpected saved models (-want +got):\n%s", diff)
+	}
+}
+
 func TestLaunchIntegration_OpenclawPreservesExistingModelList(t *testing.T) {
 	tmpDir := t.TempDir()
 	setLaunchTestHome(t, tmpDir)

--- a/cmd/launch/launch_test.go
+++ b/cmd/launch/launch_test.go
@@ -22,8 +22,8 @@ import (
 
 type launcherEditorRunner struct {
 	paths    []string
-	edited   [][]string
 	models   []string
+	edited   [][]string
 	ranModel string
 }
 
@@ -39,7 +39,6 @@ func (r *launcherEditorRunner) Paths() []string { return r.paths }
 func (r *launcherEditorRunner) Edit(models []LaunchModel) error {
 	names := launchModelNames(models)
 	r.edited = append(r.edited, names)
-	r.models = append([]string(nil), names...)
 	return nil
 }
 
@@ -2303,7 +2302,7 @@ func TestLaunchIntegration_EditorForceConfigure_FloatsCheckedModelsInPicker(t *t
 	writeFakeBinary(t, binDir, "droid")
 	t.Setenv("PATH", binDir)
 
-	editor := &launcherEditorRunner{}
+	editor := &launcherEditorRunner{models: []string{"llama3.2", "missing-local"}}
 	withIntegrationOverride(t, "droid", editor)
 
 	if err := config.SaveIntegration("droid", []string{"qwen3.5:cloud", "qwen3.5"}); err != nil {
@@ -2990,7 +2989,7 @@ func TestLaunchIntegration_ConfiguredEditorLaunchSkipsReconfigure(t *testing.T) 
 	}
 }
 
-func TestLaunchIntegration_ConfiguredEditorLaunchRepairsLiveDrift(t *testing.T) {
+func TestLaunchIntegration_ConfiguredEditorLaunchRewritesDriftedLiveConfig(t *testing.T) {
 	tmpDir := t.TempDir()
 	setLaunchTestHome(t, tmpDir)
 	withLauncherHooks(t)
@@ -2999,11 +2998,16 @@ func TestLaunchIntegration_ConfiguredEditorLaunchRepairsLiveDrift(t *testing.T) 
 	writeFakeBinary(t, binDir, "droid")
 	t.Setenv("PATH", binDir)
 
-	editor := &launcherEditorRunner{models: []string{"old-model"}}
+	editor := &launcherEditorRunner{models: []string{"qwen3:8b"}}
 	withIntegrationOverride(t, "droid", editor)
 
-	if err := config.SaveIntegration("droid", []string{"llama3.2", "qwen3:8b"}); err != nil {
+	if err := config.SaveIntegration("droid", []string{"llama3.2", "mistral"}); err != nil {
 		t.Fatalf("failed to seed config: %v", err)
+	}
+
+	DefaultConfirmPrompt = func(prompt string, options ConfirmOptions) (bool, error) {
+		t.Fatalf("did not expect prompt during a normal editor launch: %s", prompt)
+		return false, nil
 	}
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3021,8 +3025,8 @@ func TestLaunchIntegration_ConfiguredEditorLaunchRepairsLiveDrift(t *testing.T) 
 	if err := LaunchIntegration(context.Background(), IntegrationLaunchRequest{Name: "droid"}); err != nil {
 		t.Fatalf("LaunchIntegration returned error: %v", err)
 	}
-	if diff := compareStringSlices(editor.edited, [][]string{{"llama3.2", "qwen3:8b"}}); diff != "" {
-		t.Fatalf("unexpected editor rewrites (-want +got):\n%s", diff)
+	if diff := cmp.Diff([][]string{{"llama3.2", "mistral"}}, editor.edited); diff != "" {
+		t.Fatalf("expected editor config rewrite when live config drifts (-want +got):\n%s", diff)
 	}
 	if editor.ranModel != "llama3.2" {
 		t.Fatalf("expected launch to use saved primary model, got %q", editor.ranModel)
@@ -3032,7 +3036,7 @@ func TestLaunchIntegration_ConfiguredEditorLaunchRepairsLiveDrift(t *testing.T) 
 	if err != nil {
 		t.Fatalf("failed to reload saved config: %v", err)
 	}
-	if diff := compareStrings(saved.Models, []string{"llama3.2", "qwen3:8b"}); diff != "" {
+	if diff := compareStrings(saved.Models, []string{"llama3.2", "mistral"}); diff != "" {
 		t.Fatalf("unexpected saved models (-want +got):\n%s", diff)
 	}
 }

--- a/cmd/launch/launch_test.go
+++ b/cmd/launch/launch_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/ollama/ollama/cmd/config"
+	"github.com/ollama/ollama/cmd/internal/fileutil"
 )
 
 type launcherEditorRunner struct {
@@ -2205,6 +2206,87 @@ func TestLaunchIntegration_EditorForceConfigure(t *testing.T) {
 	}
 	if diff := compareStrings(saved.Models, []string{"llama3.2", "qwen3:8b"}); diff != "" {
 		t.Fatalf("unexpected saved models (-want +got):\n%s", diff)
+	}
+}
+
+func TestLaunchIntegration_ClineRewritesWhenLiveProviderDrifted(t *testing.T) {
+	tmpDir := t.TempDir()
+	setLaunchTestHome(t, tmpDir)
+	withLauncherHooks(t)
+
+	binDir := t.TempDir()
+	writeFakeBinary(t, binDir, "cline")
+	t.Setenv("PATH", binDir)
+
+	if err := config.SaveIntegration("cline", []string{"llama3.2"}); err != nil {
+		t.Fatalf("failed to seed saved config: %v", err)
+	}
+
+	providersPath := clineProvidersPath(tmpDir)
+	if err := os.MkdirAll(filepath.Dir(providersPath), 0o755); err != nil {
+		t.Fatalf("failed to create providers dir: %v", err)
+	}
+	existingProviders := map[string]any{
+		"version":          float64(1),
+		"lastUsedProvider": "openai-codex-cli",
+		"providers": map[string]any{
+			"openai-codex-cli": map[string]any{
+				"settings": map[string]any{
+					"provider":  "openai-codex-cli",
+					"model":     "gpt-5.5",
+					"reasoning": "medium",
+				},
+				"updatedAt":   "2026-06-01T12:00:00Z",
+				"tokenSource": "manual",
+			},
+		},
+	}
+	data, _ := json.Marshal(existingProviders)
+	if err := os.WriteFile(providersPath, data, 0o644); err != nil {
+		t.Fatalf("failed to seed providers config: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/show":
+			var req apiShowRequest
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			fmt.Fprintf(w, `{"model":%q}`, req.Model)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	t.Setenv("OLLAMA_HOST", srv.URL)
+
+	if err := LaunchIntegration(context.Background(), IntegrationLaunchRequest{
+		Name:          "cline",
+		ModelOverride: "llama3.2",
+	}); err != nil {
+		t.Fatalf("LaunchIntegration returned error: %v", err)
+	}
+
+	providersConfig, err := fileutil.ReadJSON(providersPath)
+	if err != nil {
+		t.Fatalf("failed to read providers config: %v", err)
+	}
+	if providersConfig["lastUsedProvider"] != clineLaunchProvider {
+		t.Fatalf("lastUsedProvider = %v, want %s", providersConfig["lastUsedProvider"], clineLaunchProvider)
+	}
+	providers, _ := providersConfig["providers"].(map[string]any)
+	if _, ok := providers["openai-codex-cli"]; !ok {
+		t.Fatal("expected existing openai-codex-cli provider to be preserved")
+	}
+	ollamaProvider, _ := providers[clineLaunchProvider].(map[string]any)
+	settings, _ := ollamaProvider["settings"].(map[string]any)
+	if settings["provider"] != clineLaunchProvider {
+		t.Fatalf("ollama settings.provider = %v, want %s", settings["provider"], clineLaunchProvider)
+	}
+	if settings["model"] != "llama3.2" {
+		t.Fatalf("ollama settings.model = %v, want llama3.2", settings["model"])
+	}
+	if settings["baseUrl"] != srv.URL+"/v1" {
+		t.Fatalf("ollama settings.baseUrl = %v, want %s/v1", settings["baseUrl"], srv.URL)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fix `ollama launch cline` and other editor integrations so launch repairs editor config whenever setup is requested, saved launch state differs, or live editor config has drifted from Ollama's saved integration model list.

## Root cause

Cline is handled through the generic editor launch path. The PR initially computed whether the editor's live config matched the target models, but only acted on that mismatch during forced configure or `--model` flows. That still left a hole for normal saved launches: if Ollama had `cline` saved with `llama3.2`, but Cline's own `providers.json` had drifted to another active provider such as `openai-codex-cli`, launch could start Cline without rewriting the provider back to Ollama.

## What changed

- Compare the editor's live model list from `Editor.Models()` before skipping setup.
- Run editor setup when `needsConfigure`, `--model`, saved launch-state mismatch, or live editor drift is present.
- Add a shared editor regression where a normal saved launch rewrites stale live editor models before running.
- Add a Cline regression where Cline starts with `openai-codex-cli` active, then a normal saved `LaunchIntegration{Name: "cline"}` switches `lastUsedProvider` to `ollama` while preserving the existing Codex provider entry.
- Update test editor fixtures so no-drift normal launches explicitly report matching live models.

## Validation

- `go test ./cmd/launch`
- Slack #integrations context reviewed; Bruce's diff attachment is still blocked by missing Slack file-read scope, but the pasted/quoted diagnosis and GitHub suggestions are reflected in this patch.
- Safe temp-home checks around a Cline config active on `openai-codex-cli`; verified launch writes `lastUsedProvider: ollama` and preserves the Codex provider entry.