### PR TITLE
llm: warn when model silently falls back to CPU despite GPU being available

### DIFF
--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -908,6 +908,32 @@ func (s *llamaServerRunner) Load(ctx context.Context, systemInfo ml.SystemInfo, 
 			"model", s.modelPath, "gpus", len(s.gpus))
 	}
 
+	// Warn when the user has a GPU (or requested one) but llama-server loaded
+	// the model entirely on CPU. This happens when the GPU driver is
+	// incompatible (e.g. after a driver update that leaves the old kernel
+	// module loaded until reboot — CUDA "forward compatibility" error). Without
+	// this warning the server appears healthy while running at CPU speed with
+	// high RAM usage, often causing 100 % CPU, thermal throttling, and
+	// downstream timeouts — all with no visible error.
+	s.memoryMu.RLock()
+	gpuLayers := s.gpuLayers
+	totalLayers := s.totalLayers
+	s.memoryMu.RUnlock()
+	if s.options.NumGPU != 0 && totalLayers > 0 && gpuLayers == 0 {
+		for _, g := range s.gpus {
+			if !strings.EqualFold(g.Library, "cpu") {
+				slog.Warn("model loaded entirely on CPU despite GPU being available — "+
+					"GPU initialization likely failed (check for driver or CUDA errors above). "+
+					"Inference will be much slower than expected and may cause high CPU/RAM usage.",
+					"model", s.modelPath,
+					"total_layers", totalLayers,
+					"gpu", g.Name,
+					"library", g.Library)
+				break
+			}
+		}
+	}
+
 	if s.options.MainGPU != nil && *s.options.MainGPU >= 0 && *s.options.MainGPU < len(gpus) {
 		return []ml.DeviceID{gpus[*s.options.MainGPU].DeviceID}, nil
 	}

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -1,12 +1,14 @@
 package llm
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -3021,4 +3023,84 @@ func fakeRunningCmd() *exec.Cmd {
 	// pass *testing.T here without changing all call sites. The OS will
 	// SIGKILL children when the test process exits.
 	return cmd
+}
+
+func TestLlamaServerLoadWarnsSilentCPUFallback(t *testing.T) {
+	var logs bytes.Buffer
+	oldLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(oldLogger) })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			return
+		}
+		fmt.Fprint(w, `{"status":"ok"}`)
+	}))
+	defer srv.Close()
+
+	parts := strings.Split(srv.URL, ":")
+	var portInt int
+	fmt.Sscanf(parts[len(parts)-1], "%d", &portInt)
+
+	gpus := []ml.DeviceInfo{
+		{DeviceID: ml.DeviceID{Library: "cuda", ID: "0"}, Name: "NVIDIA RTX 3080"},
+	}
+	runner := &llamaServerRunner{
+		port:        portInt,
+		cmd:         fakeRunningCmd(),
+		gpus:        gpus,
+		totalLayers: 33,
+		// gpuLayers defaults to 0: the silent CPU-fallback scenario
+		options: api.Options{NumGPU: -1},
+	}
+
+	if _, err := runner.Load(t.Context(), ml.SystemInfo{}, gpus, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := logs.String(); !strings.Contains(got, "model loaded entirely on CPU despite GPU being available") {
+		t.Errorf("expected silent CPU fallback warning, got logs:\n%s", got)
+	}
+}
+
+func TestLlamaServerLoadNoWarnWhenGPULayersLoaded(t *testing.T) {
+	var logs bytes.Buffer
+	oldLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(oldLogger) })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			return
+		}
+		fmt.Fprint(w, `{"status":"ok"}`)
+	}))
+	defer srv.Close()
+
+	parts := strings.Split(srv.URL, ":")
+	var portInt int
+	fmt.Sscanf(parts[len(parts)-1], "%d", &portInt)
+
+	gpus := []ml.DeviceInfo{
+		{DeviceID: ml.DeviceID{Library: "cuda", ID: "0"}, Name: "NVIDIA RTX 3080"},
+	}
+	runner := &llamaServerRunner{
+		port:        portInt,
+		cmd:         fakeRunningCmd(),
+		gpus:        gpus,
+		totalLayers: 33,
+		gpuLayers:   33, // fully loaded on GPU — warning must not fire
+		options:     api.Options{NumGPU: -1},
+	}
+
+	if _, err := runner.Load(t.Context(), ml.SystemInfo{}, gpus, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := logs.String(); strings.Contains(got, "model loaded entirely on CPU") {
+		t.Errorf("unexpected CPU fallback warning when GPU layers are loaded:\n%s", got)
+	}
 }


### PR DESCRIPTION
## Problem

When a GPU driver update leaves the old kernel module loaded (the CUDA "forward compatibility" scenario), `llama-server` initializes successfully but loads all model layers on CPU. The server reports healthy and inference appears to work — but at CPU speed, with 100% CPU usage, high RAM consumption, and downstream timeouts — with no visible error in the UI or logs.

Issue: #15918

## Solution

Add a warning in `Load()` that fires after `WaitUntilRunning()` succeeds when:
- `totalLayers > 0` (we know the model has offloadable layers)
- `gpuLayers == 0` (none were actually loaded on GPU)
- at least one non-CPU device is in `s.gpus` (a GPU was selected or `NumGPU != 0`)

The warning includes the model path, total layer count, GPU name, and library so users and support staff can immediately identify the root cause.

## Tests

- `TestLlamaServerLoadWarnsSilentCPUFallback`: verifies the warning is emitted when `gpuLayers == 0` with a non-CPU GPU device present.
- `TestLlamaServerLoadNoWarnWhenGPULayersLoaded`: verifies no spurious warning when GPU layers are correctly populated.

Both tests follow the existing `httptest.NewServer` + `fakeRunningCmd()` pattern used throughout `llm/llama_server_test.go`.