### PR TITLE
fix(parsers/qwen3coder): recover bare <function=...> tool call when opening <tool_call> tag is omitted

### DIFF
--- a/model/parsers/qwen3coder.go
+++ b/model/parsers/qwen3coder.go
@@ -21,11 +21,18 @@ type qwenParserState int
 const (
 	toolOpenTag  = "<tool_call>"
 	toolCloseTag = "</tool_call>"
+	// functionOpenTag/functionCloseTag delimit the inner function block. Normally
+	// they are wrapped by toolOpenTag/toolCloseTag, but qwen3-coder occasionally
+	// emits the function block while omitting the opening <tool_call> tag, so we
+	// also accept a bare <function=...> block as a tool call (see eat).
+	functionOpenTag  = "<function="
+	functionCloseTag = "</function>"
 )
 
 const (
 	qwenParserState_LookingForToolStart qwenParserState = iota
 	qwenParserState_CollectingToolContent
+	qwenParserState_CollectingBareFunction
 )
 
 type Qwen3CoderParser struct {
@@ -135,29 +142,48 @@ func eat(p *Qwen3CoderParser) ([]qwenEvent, bool) {
 
 	switch p.state {
 	case qwenParserState_LookingForToolStart:
-		if strings.Contains(p.acc.String(), toolOpenTag) {
+		acc := p.acc.String()
+		toolIdx := strings.Index(acc, toolOpenTag)
+		fnIdx := strings.Index(acc, functionOpenTag)
+		if toolIdx >= 0 && (fnIdx < 0 || toolIdx <= fnIdx) {
 			// we found a full tool open tag, so we can emit the content before the
 			// tag, being sure to trim any trailing whitespace
-			split := strings.SplitN(p.acc.String(), toolOpenTag, 2)
-			before := split[0]
+			before := acc[:toolIdx]
 			before = strings.TrimRightFunc(before, unicode.IsSpace)
 			if len(before) > 0 {
 				events = append(events, qwenEventContent{content: before})
 			}
-			after := split[1]
+			after := acc[toolIdx+len(toolOpenTag):]
 			p.acc.Reset()
 			p.acc.WriteString(after)
 			p.state = qwenParserState_CollectingToolContent
 			return events, true
-		} else if overlap := overlap(p.acc.String(), toolOpenTag); overlap > 0 {
-			// we found a partial tool open tag, so we can emit the unambiguous part,
-			// which is the (trailing-whitespace trimmed) content before the partial
-			// tool open tag
-			beforePartialTag := p.acc.String()[:len(p.acc.String())-overlap]
+		} else if fnIdx >= 0 {
+			// we found a bare <function=...> block with no preceding <tool_call>.
+			// qwen3-coder sometimes omits the opening <tool_call> (while still
+			// emitting the function block and a stray closing </tool_call>), which
+			// would otherwise leak the entire tool call into content. Recover it by
+			// treating the function block itself as the tool call. We keep the
+			// <function= marker in the buffer so the collected raw matches the
+			// normal <tool_call>-wrapped form.
+			before := acc[:fnIdx]
+			before = strings.TrimRightFunc(before, unicode.IsSpace)
+			if len(before) > 0 {
+				events = append(events, qwenEventContent{content: before})
+			}
+			p.acc.Reset()
+			p.acc.WriteString(acc[fnIdx:])
+			p.state = qwenParserState_CollectingBareFunction
+			return events, true
+		} else if overlap := maxOverlap(acc, toolOpenTag, functionOpenTag); overlap > 0 {
+			// we found a partial open tag (either form), so we can emit the
+			// unambiguous part, which is the (trailing-whitespace trimmed) content
+			// before the partial open tag
+			beforePartialTag := acc[:len(acc)-overlap]
 			trailingWhitespaceLen := trailingWhitespaceLen(beforePartialTag)
 			ambiguousStart := len(beforePartialTag) - trailingWhitespaceLen
-			unambiguous := p.acc.String()[:ambiguousStart]
-			ambiguous := p.acc.String()[ambiguousStart:]
+			unambiguous := acc[:ambiguousStart]
+			ambiguous := acc[ambiguousStart:]
 			p.acc.Reset()
 			p.acc.WriteString(ambiguous)
 			if len(unambiguous) > 0 {
@@ -167,10 +193,10 @@ func eat(p *Qwen3CoderParser) ([]qwenEvent, bool) {
 		} else {
 			// we found content that is entirely not a tool call. We should withhold
 			// any trailing whitespace in case this is the end of the content
-			whitespaceLen := trailingWhitespaceLen(p.acc.String())
-			ambiguousStart := len(p.acc.String()) - whitespaceLen
-			unambiguous := p.acc.String()[:ambiguousStart]
-			ambiguous := p.acc.String()[ambiguousStart:]
+			whitespaceLen := trailingWhitespaceLen(acc)
+			ambiguousStart := len(acc) - whitespaceLen
+			unambiguous := acc[:ambiguousStart]
+			ambiguous := acc[ambiguousStart:]
 			p.acc.Reset()
 			p.acc.WriteString(ambiguous)
 			if len(unambiguous) > 0 {
@@ -178,6 +204,27 @@ func eat(p *Qwen3CoderParser) ([]qwenEvent, bool) {
 			}
 			return events, false
 		}
+	case qwenParserState_CollectingBareFunction:
+		// like CollectingToolContent, but entered via a bare <function=...> with no
+		// wrapping <tool_call>. We close on </function> and then swallow an optional
+		// trailing </tool_call> (with surrounding whitespace) that the model emits
+		// even though it omitted the opener.
+		if idx := strings.Index(p.acc.String(), functionCloseTag); idx >= 0 {
+			raw := p.acc.String()[:idx+len(functionCloseTag)]
+			rest := p.acc.String()[idx+len(functionCloseTag):]
+			rest = strings.TrimLeftFunc(rest, unicode.IsSpace)
+			rest = strings.TrimPrefix(rest, toolCloseTag)
+			rest = strings.TrimLeftFunc(rest, unicode.IsSpace)
+			p.acc.Reset()
+			p.acc.WriteString(rest)
+			events = append(events, qwenEventRawToolCall{raw: raw})
+			p.state = qwenParserState_LookingForToolStart
+			return events, true
+		}
+		// we haven't seen the full closing tag yet, so we keep collecting. As with
+		// CollectingToolContent we don't stream back the unparsed tool content, so
+		// there's no need to check for a partial tag here.
+		return events, false
 	case qwenParserState_CollectingToolContent:
 		if strings.Contains(p.acc.String(), toolCloseTag) {
 			split := strings.SplitN(p.acc.String(), toolCloseTag, 2)
@@ -202,6 +249,19 @@ func eat(p *Qwen3CoderParser) ([]qwenEvent, bool) {
 	default:
 		panic("unreachable")
 	}
+}
+
+// maxOverlap returns the largest suffix-of-s that is a prefix of any of the
+// given delimiters. It lets the parser withhold a trailing partial open tag
+// when more than one open tag (<tool_call> or <function=) is possible.
+func maxOverlap(s string, delims ...string) int {
+	best := 0
+	for _, delim := range delims {
+		if o := overlap(s, delim); o > best {
+			best = o
+		}
+	}
+	return best
 }
 
 type XMLFunctionCall struct {

--- a/model/parsers/qwen3coder_test.go
+++ b/model/parsers/qwen3coder_test.go
@@ -49,6 +49,41 @@ func TestQwenParserStreaming(t *testing.T) {
 			},
 		},
 		{
+			// qwen3-coder sometimes omits the opening <tool_call> tag while still
+			// emitting the function block and a stray closing </tool_call>. The bare
+			// <function=...> block should still be recovered as a tool call instead
+			// of leaking into content.
+			desc: "bare function block without opening tool_call tag",
+			steps: []step{
+				{
+					input: "I'll use the tool.\n\n<function=Glob>\n<parameter=pattern>\n*.md\n</parameter>\n</function>\n</tool_call>",
+					wantEvents: []qwenEvent{
+						qwenEventContent{content: "I'll use the tool."},
+						qwenEventRawToolCall{raw: "<function=Glob>\n<parameter=pattern>\n*.md\n</parameter>\n</function>"},
+					},
+				},
+			},
+		},
+		{
+			desc: "bare function streamed across chunks withholds partial open tag",
+			steps: []step{
+				{
+					input:      "text <func",
+					wantEvents: []qwenEvent{qwenEventContent{content: "text"}},
+				},
+				{
+					input:      "tion=Glob><parameter=p>x</parameter>",
+					wantEvents: []qwenEvent{},
+				},
+				{
+					input: "</function></tool_call>",
+					wantEvents: []qwenEvent{
+						qwenEventRawToolCall{raw: "<function=Glob><parameter=p>x</parameter></function>"},
+					},
+				},
+			},
+		},
+		{
 			desc: "multiple tool calls in one message",
 			steps: []step{
 				{
@@ -1112,6 +1147,36 @@ func TestQwen3CoderParserToolCallIndexResetOnInit(t *testing.T) {
 
 	want := api.ToolCall{
 		Function: api.ToolCallFunction{Name: "second", Arguments: testArgs(map[string]any{"b": "2"}), Index: 0},
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(calls))
+	}
+	if !toolCallEqual(calls[0], want) {
+		t.Fatalf("got %#v, want %#v", calls[0], want)
+	}
+}
+
+func TestQwen3CoderParserBareFunctionWithoutToolCallTag(t *testing.T) {
+	parser := Qwen3CoderParser{}
+	parser.Init([]api.Tool{
+		tool("get_weather", map[string]api.ToolProperty{
+			"city": {Type: api.PropertyType{"string"}},
+		}),
+	}, nil, nil)
+
+	// The model omits the opening <tool_call> but still emits the function block
+	// and a trailing </tool_call>. The whole call should be recovered, the leading
+	// content preserved, and the orphan </tool_call> not leaked into content.
+	content, _, calls, err := parser.Add("Let me check.\n\n<function=get_weather>\n<parameter=city>\nParis\n</parameter>\n</function>\n</tool_call>", true)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if content != "Let me check." {
+		t.Fatalf("got content %q, want %q", content, "Let me check.")
+	}
+
+	want := api.ToolCall{
+		Function: api.ToolCallFunction{Name: "get_weather", Arguments: testArgs(map[string]any{"city": "Paris"}), Index: 0},
 	}
 	if len(calls) != 1 {
 		t.Fatalf("expected 1 call, got %d", len(calls))


### PR DESCRIPTION
Fixes #16686

### Problem

When `qwen3-coder` emits a tool call but omits the opening `<tool_call>` tag (a known flub of this model — it emits everything *except* the opening trigger, often including a trailing `</tool_call>`), `Qwen3CoderParser` stays in `LookingForToolStart` and the entire tool call leaks into message `content` as plain text. Agent clients (Claude Code via the Anthropic-compatible endpoint in the report) therefore never execute the tool — to the user it looks like the model "lost" all its tools.

Example payload returned as a single `text` block instead of a `tool_use`:

```
I'll fetch the example.com webpage...

<function=WebFetch>
<parameter=url>
https://example.com
</parameter>
</function>
</tool_call>
```

Note the trailing `</tool_call>` with no opening tag. The payload is unambiguous and fully recoverable; the parser just never engages.

### Fix

Treat a bare `<function=...>` block as a tool-call start when it appears with no preceding `<tool_call>` opener:

- In `LookingForToolStart`, detect the earliest of `<tool_call>` / `<function=`. The well-formed `<tool_call>`-wrapped path is preferred whenever both openers are present, so existing behavior is unchanged.
- A new `CollectingBareFunction` state collects until `</function>`, then swallows an optional orphan `</tool_call>` (with surrounding whitespace) so it doesn't leak into content.
- Trailing partial-open-tag withholding now covers both tag forms (`maxOverlap`), keeping streaming correct (the `<function=...` prefix is never emitted as content prematurely).

This is the same bug class as the qwen3.5 unclosed-`think` fix in #15022, and matches fallbacks already shipped downstream for the same qwen3-coder malformation (goose `block/goose#6883`, vllm `vllm-project/vllm#35615`).

### Tests

Added to `qwen3coder_test.go`:
- streaming event case: bare `<function=...>` block without an opening `<tool_call>` → content + recovered tool call
- streaming-across-chunks case: partial `<func`…`tion=` open tag is withheld, not leaked
- end-to-end `Add` case: verifies the recovered `api.ToolCall` (name + parsed args), preserved leading content, and that the orphan `</tool_call>` is not leaked

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
