### PR TITLE
discover: allow gfx1150 (RDNA 3.5) integrated GPU by default

### DIFF
--- a/discover/runner.go
+++ b/discover/runner.go
@@ -29,6 +29,8 @@ var (
 )
 
 var defaultIntegratedROCmGFXTargets = map[string]struct{}{
+	// AMD RDNA 3.5 integrated GPUs (Strix Point / Strix Halo, e.g. Radeon 890M / 8060S).
+	"gfx1150": {},
 	// AMD Radeon 8060S / Ryzen AI Max+ 395.
 	"gfx1151": {},
 }


### PR DESCRIPTION
## Summary

On AMD RDNA 3.5 integrated GPUs that report as `gfx1150` (Strix Point — e.g. Radeon 890M / 880M), Ollama 0.30+ runs models on the **CPU** instead of the GPU. It worked on 0.24. Fixes #16690.

## Root cause

0.30 added a default filter that drops integrated GPUs unless they are explicitly allow-listed (`discover/runner.go`):

```go
var defaultIntegratedROCmGFXTargets = map[string]struct{}{
    // AMD Radeon 8060S / Ryzen AI Max+ 395.
    "gfx1151": {},
}
```

`integratedGPUAllowedByDefault()` only keeps a ROCm iGPU if its `GFXTarget` is in this map. Only `gfx1151` (Strix Halo) was listed, so `gfx1150` (Strix Point) APUs are filtered out and fall back to CPU — the log line is `dropping integrated GPU; to enable, set OLLAMA_IGPU_ENABLE=1`.

`gfx1150` is already a compiled target (it is in the `AMDGPU_TARGETS` of `llama/server/CMakePresets.json`), so the device runs fine once it is no longer filtered — the fix is just to allow it by default, the same way `gfx1151` is.

## Change

Add `gfx1150` to `defaultIntegratedROCmGFXTargets` (2 lines).

## Validation

- `go build ./discover/` and `go vet ./discover/` pass; `gofmt` clean.
- Mechanism reproduced on a `gfx1151` Strix Halo box: the same default-filter path runs; `gfx1151` is admitted by the allowlist while the Vulkan iGPU entry is dropped — confirming the allowlist is the gate. With this change `gfx1150` takes the same admitted path.
- I do not have a `gfx1150` (890M) device on hand, so I have not run end-to-end inference on that exact part; the fix is verified by code path + the existing `gfx1151` precedent + the fact that `gfx1150` is already compiled. A maintainer or the reporter with a 890M can confirm `ollama ps` shows `100% GPU` after this.

> AI usage disclosure: this change was prepared with AI assistance; a human reviewed and verified it and can explain every line. Verified: 2-line allowlist addition, build-validated; root cause confirmed in source.

