### PR TITLE
Fix/mmproj gpu offload dgx spark

### DIFF
--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -631,7 +631,7 @@ func shouldDisableMMProjOffload(opts api.Options, gpus []ml.DeviceInfo, modelLay
 	}
 
 	for _, gpu := range gpus {
-		if gpu.Integrated && gpu.Library != "Metal" {
+		if gpu.Integrated && gpu.Library != "Metal" && gpu.Library != "CUDA" {
 			return true, "shared-memory-gpu"
 		}
 		memory := gpu.FreeMemory

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -1855,6 +1855,14 @@ func TestAppendMMProjArgs(t *testing.T) {
 			want:        []string{"base", "--mmproj", "model.gguf"},
 		},
 		{
+			name:        "integrated cuda gpu with large memory keeps projector offload (dgx spark)",
+			projectors:  []string{"model.gguf"},
+			opts:        defaultOpts,
+			gpus:        []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}, Integrated: true, FreeMemory: 128 << 30}},
+			modelLayers: 81,
+			want:        []string{"base", "--mmproj", "model.gguf"},
+		},
+		{
 			name:        "cpu only request disables projector offload",
 			projectors:  []string{"model.gguf"},
 			opts:        cpuOpts,


### PR DESCRIPTION
### Summary

Fixes an issue where `MMProj` offloading was incorrectly disabled for integrated GPUs when using CUDA.

### Changes

* Updated `shouldDisableMMProjOffload` in `llm/llama_server.go` to explicitly allow CUDA devices, ensuring they are not treated as shared-memory GPUs that require disabling offload.
* Added a new unit test case in `llm/llama_server_test.go` to verify that integrated CUDA GPUs with sufficient memory keep the projector offload enabled.