### PR TITLE
cmd/interactive.go: convert "true"/"false" strings to bools in /set think

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -315,10 +315,14 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 						maybeLevel = args[2]
 					}
 					if maybeLevel != "" {
-						// TODO(drifkin): validate the level, could be model dependent
-						// though... It will also be validated on the server once a call is
-						// made.
-						thinkValue.Value = maybeLevel
+						switch maybeLevel {
+						case "true":
+							thinkValue.Value = true
+						case "false":
+							thinkValue.Value = false
+						default:
+							thinkValue.Value = maybeLevel
+						}
 					}
 					opts.Think = &thinkValue
 					thinkExplicitlySet = true


### PR DESCRIPTION
## Problem

Running `/set think false` in interactive mode produces an error:

```
invalid think value: "false" (must be "high", "medium", "low", "max", true, or false)
```

The argument `"false"` is stored as a Go string instead of a Go bool, so when it is JSON-marshaled it becomes `{"Value":"false"}` (a JSON string). The server-side `UnmarshalJSON` fails to parse it as a boolean (since it is a JSON string) and then rejects the string value because `"false"` is not one of the allowed string levels.

## Fix

In `cmd/interactive.go`, convert the string arguments `"true"` and `"false"` to their corresponding boolean values before storing them in `ThinkValue.Value`. All other string values (e.g. `"high"`, `"medium"`, `"low"`, `"max"`) continue to be stored as strings as before.

## Verification

- `/set think` → `Value: true` (bool) — thinking enabled at default level
- `/set think true` → `Value: true` (bool) — thinking enabled
- `/set think false` → `Value: false` (bool) — thinking disabled
- `/set think high` → `Value: "high"` (string) — thinking enabled at high effort