### PR TITLE
server: "PARAMETER env" for setting environment variables from the Modelfile.

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -600,13 +600,14 @@ type Options struct {
 
 // Runner options which must be set when the model is loaded into memory
 type Runner struct {
-	NumCtx          int   `json:"num_ctx,omitempty"`
-	NumBatch        int   `json:"num_batch,omitempty"`
-	NumGPU          int   `json:"num_gpu,omitempty"`
-	MainGPU         *int  `json:"main_gpu,omitempty"`
-	UseMMap         *bool `json:"use_mmap,omitempty"`
-	NumThread       int   `json:"num_thread,omitempty"`
-	DraftNumPredict int   `json:"draft_num_predict,omitempty"`
+	NumCtx          int      `json:"num_ctx,omitempty"`
+	NumBatch        int      `json:"num_batch,omitempty"`
+	NumGPU          int      `json:"num_gpu,omitempty"`
+	MainGPU         *int     `json:"main_gpu,omitempty"`
+	UseMMap         *bool    `json:"use_mmap,omitempty"`
+	NumThread       int      `json:"num_thread,omitempty"`
+	DraftNumPredict int      `json:"draft_num_predict,omitempty"`
+	Env             []string `json:"env,omitempty"`
 }
 
 // EmbedRequest is the request passed to [Client.Embed].

--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -761,11 +761,16 @@ func NewLlamaServerRunner(
 
 	mediaMarker := newLlamaServerMediaMarker()
 	extraEnvs := ml.GetDevicesEnv(gpus)
-	serverEnvs := make(map[string]string, len(extraEnvs)+1)
+	serverEnvs := make(map[string]string, len(extraEnvs)+1+len(opts.Env))
 	for k, v := range extraEnvs {
 		serverEnvs[k] = v
 	}
 	serverEnvs["LLAMA_MEDIA_MARKER"] = mediaMarker
+	for _, e := range opts.Env {
+		if k, v, ok := strings.Cut(e, "="); ok {
+			serverEnvs[k] = v
+		}
+	}
 
 	launch := llamaServerLaunchConfig{
 		modelPath:   modelPath,


### PR DESCRIPTION
The llama-server can use environment variables for controlling some functions.  These can be set in the environment of the server and are passed to the runner when a model is loaded.  However, these are server-wide and there's no way to set them on a per-model basis.

This PR adds `PARAMETER env` to the Modelfile to allow per-model setting of these variables.

```dockerfile
FROM qwen3.5:2b

PARAMETER env GGML_CUDA_ENABLE_UNIFIED_MEMORY=1
PARAMETER env LLAMA_ARG_OVERRIDE_TENSOR=blk\.[12][0-9].*=CPU
```