### PR TITLE
fix: use structured logging with 'error' key in slog calls

### DIFF
--- a/app/cmd/app/app.go
+++ b/app/cmd/app/app.go
@@ -109,7 +109,7 @@ func main() {
 	logrotate.Rotate(appLogPath)
 	if _, err := os.Stat(filepath.Dir(appLogPath)); errors.Is(err, os.ErrNotExist) {
 		if err := os.MkdirAll(filepath.Dir(appLogPath), 0o755); err != nil {
-			slog.Error(fmt.Sprintf("failed to create server log dir %v", err))
+			slog.Error("failed to create server log dir", "error", err)
 			return
 		}
 	}
@@ -118,7 +118,7 @@ func main() {
 	var err error
 	logFile, err = os.OpenFile(appLogPath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0o755)
 	if err != nil {
-		slog.Error(fmt.Sprintf("failed to create server log %v", err))
+		slog.Error("failed to create server log", "error", err)
 		return
 	}
 	// Detect if we're a GUI app on windows, and if not, send logs to console as well

--- a/app/cmd/app/app_windows.go
+++ b/app/cmd/app/app_windows.go
@@ -127,7 +127,7 @@ func (app *appCallbacks) DoUpdate() {
 	app.shutdown()
 
 	if err := updater.DoUpgrade(true); err != nil {
-		slog.Warn(fmt.Sprintf("upgrade attempt failed: %s", err))
+		slog.Warn("upgrade attempt failed", "error", err)
 	}
 }
 

--- a/app/server/server.go
+++ b/app/server/server.go
@@ -130,7 +130,7 @@ func cleanup() error {
 
 	ok, err := terminated(pid)
 	if err != nil {
-		slog.Debug("cleanup: error checking if terminated", "pid", pid, "err", err)
+		slog.Debug("cleanup: error checking if terminated", "pid", pid, "error", err)
 	}
 	if ok {
 		return nil
@@ -149,7 +149,7 @@ func stop(proc *os.Process) error {
 	}
 
 	if err := terminate(proc); err != nil {
-		slog.Warn("graceful terminate failed, killing", "err", err)
+		slog.Warn("graceful terminate failed, killing", "error", err)
 		return proc.Kill()
 	}
 
@@ -164,7 +164,7 @@ func stop(proc *os.Process) error {
 		default:
 			ok, err := terminated(proc.Pid)
 			if err != nil {
-				slog.Error("error checking if ollama process is terminated", "err", err)
+				slog.Error("error checking if ollama process is terminated", "error", err)
 				return err
 			}
 			if ok {
@@ -184,7 +184,7 @@ func (s *Server) Run(ctx context.Context) error {
 	defer s.log.Close()
 
 	if err := cleanup(); err != nil {
-		slog.Warn("failed to cleanup previous ollama process", "err", err)
+		slog.Warn("failed to cleanup previous ollama process", "error", err)
 	}
 
 	reaped := false
@@ -206,7 +206,7 @@ func (s *Server) Run(ctx context.Context) error {
 
 		err = os.WriteFile(pidFile, []byte(strconv.Itoa(cmd.Process.Pid)), 0o644)
 		if err != nil {
-			slog.Warn("failed to write pid file", "file", pidFile, "err", err)
+			slog.Warn("failed to write pid file", "file", pidFile, "error", err)
 		}
 
 		if err = cmd.Wait(); err != nil && !errors.Is(err, context.Canceled) {
@@ -215,13 +215,13 @@ func (s *Server) Run(ctx context.Context) error {
 				reaped = true
 				// This could be a port conflict, try to kill any existing ollama processes
 				if err := reapServers(); err != nil {
-					slog.Warn("failed to stop existing ollama server", "err", err)
+					slog.Warn("failed to stop existing ollama server", "error", err)
 				} else {
 					slog.Debug("conflicting server stopped, waiting for port to be released")
 					continue
 				}
 			}
-			slog.Error("ollama exited", "err", err)
+			slog.Error("ollama exited", "error", err)
 		}
 	}
 	return ctx.Err()
@@ -257,7 +257,7 @@ func (s *Server) cmd(ctx context.Context) (*exec.Cmd, error) {
 		if _, err := os.Stat(settings.Models); err == nil {
 			env["OLLAMA_MODELS"] = settings.Models
 		} else {
-			slog.Warn("models path not accessible, using default", "path", settings.Models, "err", err)
+			slog.Warn("models path not accessible, using default", "path", settings.Models, "error", err)
 		}
 	}
 	if settings.ContextLength > 0 {

--- a/app/updater/updater.go
+++ b/app/updater/updater.go
@@ -92,7 +92,7 @@ func (u *Updater) checkForUpdate(ctx context.Context) (bool, UpdateResponse) {
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL.String(), nil)
 	if err != nil {
-		slog.Warn(fmt.Sprintf("failed to check for update: %s", err))
+		slog.Warn("failed to check for update", "error", err)
 		return false, updateResp
 	}
 	if signature != "" {
@@ -104,7 +104,7 @@ func (u *Updater) checkForUpdate(ctx context.Context) (bool, UpdateResponse) {
 	slog.Debug("checking for available update", "requestURL", requestURL, "User-Agent", ua)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		slog.Warn(fmt.Sprintf("failed to check for update: %s", err))
+		slog.Warn("failed to check for update", "error", err)
 		return false, updateResp
 	}
 	defer resp.Body.Close()
@@ -115,16 +115,16 @@ func (u *Updater) checkForUpdate(ctx context.Context) (bool, UpdateResponse) {
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		slog.Warn(fmt.Sprintf("failed to read body response: %s", err))
+		slog.Warn("failed to read body response", "error", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		slog.Info(fmt.Sprintf("check update error %d - %.96s", resp.StatusCode, string(body)))
+		slog.Info("check update error", "statusCode", resp.StatusCode, "body", string(body))
 		return false, updateResp
 	}
 	err = json.Unmarshal(body, &updateResp)
 	if err != nil {
-		slog.Warn(fmt.Sprintf("malformed response checking for update: %s", err))
+		slog.Warn("malformed response checking for update", "error", err)
 		return false, updateResp
 	}
 	// Extract the version string from the URL in the github release artifact path
@@ -304,7 +304,7 @@ func cleanupOldDownloads(stageDir string) {
 		// Expected behavior on first run
 		return
 	} else if err != nil {
-		slog.Warn(fmt.Sprintf("failed to list stage dir: %s", err))
+		slog.Warn("failed to list stage dir", "error", err)
 		return
 	}
 	for _, file := range files {
@@ -312,7 +312,7 @@ func cleanupOldDownloads(stageDir string) {
 		slog.Debug("cleaning up old download: " + fullname)
 		err = os.RemoveAll(fullname)
 		if err != nil {
-			slog.Warn(fmt.Sprintf("failed to cleanup stale update download %s", err))
+			slog.Warn("failed to cleanup stale update download", "error", err)
 		}
 	}
 }

--- a/app/updater/updater_windows.go
+++ b/app/updater/updater_windows.go
@@ -163,7 +163,7 @@ func DoUpgrade(interactive bool) error {
 	if cmd.Process != nil {
 		err := cmd.Process.Release()
 		if err != nil {
-			slog.Error(fmt.Sprintf("failed to release server process: %s", err))
+			slog.Error("failed to release server process", "error", err)
 		}
 	} else {
 		// TODO - some details about why it didn't start, or is this a pedantic error case?

--- a/app/wintray/eventloop.go
+++ b/app/wintray/eventloop.go
@@ -53,7 +53,7 @@ func (t *winTray) TrayRun() {
 		// https://msdn.microsoft.com/en-us/library/windows/desktop/ms644936(v=vs.85).aspx
 		switch int32(ret) {
 		case -1:
-			slog.Error(fmt.Sprintf("get message failure: %v", err))
+			slog.Error("get message failure", "error", err)
 			return
 		case 0:
 			// slog.Debug("XXX tray run loop exiting from handling", "message", fmt.Sprintf("0x%x", m.Message), "wParam", fmt.Sprintf("0x%x", m.Wparam), "lParam", fmt.Sprintf("0x%x", m.Lparam))
@@ -100,11 +100,11 @@ func (t *winTray) wndProc(hWnd windows.Handle, message uint32, wParam, lParam ui
 		// slog.Debug("XXX WM_CLOSE triggered")
 		boolRet, _, err := pDestroyWindow.Call(uintptr(t.window))
 		if boolRet == 0 {
-			slog.Error(fmt.Sprintf("failed to destroy window: %s", err))
+			slog.Error("failed to destroy window", "error", err)
 		}
 		err = t.wcex.unregister()
 		if err != nil {
-			slog.Error(fmt.Sprintf("failed to uregister windo %s", err))
+			slog.Error("failed to unregister window", "error", err)
 		}
 	case WM_DESTROY:
 		// slog.Debug("XXX WM_DESTROY triggered")
@@ -118,7 +118,7 @@ func (t *winTray) wndProc(hWnd windows.Handle, message uint32, wParam, lParam ui
 		if t.nid != nil {
 			err := t.nid.delete()
 			if err != nil {
-				slog.Error(fmt.Sprintf("failed to delete nid: %s", err))
+				slog.Error("failed to delete nid", "error", err)
 			}
 		}
 		t.muNID.Unlock()
@@ -129,7 +129,7 @@ func (t *winTray) wndProc(hWnd windows.Handle, message uint32, wParam, lParam ui
 		case WM_RBUTTONUP, WM_LBUTTONUP:
 			err := t.showMenu()
 			if err != nil {
-				slog.Error(fmt.Sprintf("failed to show menu: %s", err))
+				slog.Error("failed to show menu", "error", err)
 			}
 		case 0x405: // TODO - how is this magic value derived for the notification left click
 			if t.pendingUpdate {
@@ -152,7 +152,7 @@ func (t *winTray) wndProc(hWnd windows.Handle, message uint32, wParam, lParam ui
 		t.muNID.Lock()
 		err := t.nid.add()
 		if err != nil {
-			slog.Error(fmt.Sprintf("failed to refresh the taskbar on explorer restart: %s", err))
+			slog.Error("failed to refresh the taskbar on explorer restart", "error", err)
 		}
 		t.muNID.Unlock()
 	case uint32(UI_REQUEST_MSG_ID):
@@ -211,7 +211,7 @@ func SendUIRequestMessage(path string) {
 		uintptr(unsafe.Pointer(unsafe.StringData(path))),
 	)
 	if boolRet == 0 {
-		slog.Error(fmt.Sprintf("failed to post UI request message %s", err))
+		slog.Error("failed to post UI request message", "error", err)
 	}
 }
 
@@ -223,7 +223,7 @@ func quit() {
 		0,
 	)
 	if boolRet == 0 {
-		slog.Error(fmt.Sprintf("failed to post close message on shutdown %s", err))
+		slog.Error("failed to post close message on shutdown", "error", err)
 	}
 }
 

--- a/app/wintray/menus.go
+++ b/app/wintray/menus.go
@@ -97,7 +97,7 @@ func (t *winTray) showLogs() error {
 	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: false, CreationFlags: 0x08000000}
 	err := cmd.Start()
 	if err != nil {
-		slog.Error(fmt.Sprintf("Failed to open log dir: %s", err))
+		slog.Error("failed to open log dir", "error", err)
 	}
 	return nil
 }

--- a/app/wintray/tray.go
+++ b/app/wintray/tray.go
@@ -222,7 +222,7 @@ func (t *winTray) initInstance() error {
 
 	boolRet, _, err := pUpdateWindow.Call(uintptr(t.window))
 	if boolRet == 0 {
-		slog.Error(fmt.Sprintf("failed to update window: %s", err))
+		slog.Error("failed to update window", "error", err)
 	}
 
 	t.muNID.Lock()
@@ -377,7 +377,7 @@ func (t *winTray) showMenu() error {
 	}
 	boolRet, _, err = pSetForegroundWindow.Call(uintptr(t.window))
 	if boolRet == 0 {
-		slog.Warn(fmt.Sprintf("failed to bring menu to foreground: %s", err))
+		slog.Warn("failed to bring menu to foreground", "error", err)
 	}
 
 	boolRet, _, err = pTrackPopupMenu.Call(

--- a/server/create.go
+++ b/server/create.go
@@ -1030,7 +1030,7 @@ func rewriteLayerWithLlamaQuantize(layer *layerGGML, typeName string, fn func(re
 
 	f, err := ggml.Decode(temp, 1024)
 	if err != nil {
-		slog.Error(fmt.Sprintf("error decoding ggml: %s\n", err))
+		slog.Error("error decoding ggml", "error", err)
 		return nil, err
 	}
 	return &layerGGML{Layer: newLayer, GGML: f}, nil
@@ -1219,7 +1219,7 @@ func ggufLayersWithMediaType(digest, sourceName, mediaType string, fn func(resp 
 	}
 
 	if contentType != "gguf" {
-		slog.Error(fmt.Sprintf("unsupported content type: %s", contentType))
+		slog.Error("unsupported content type", "contentType", contentType)
 		return nil, errOnlyGGUFSupported
 	}
 

--- a/server/images.go
+++ b/server/images.go
@@ -864,7 +864,7 @@ func PruneLayers() error {
 	slog.Info(fmt.Sprintf("total blobs: %d", len(deleteMap)))
 
 	if err := deleteUnusedLayers(deleteMap); err != nil {
-		slog.Error(fmt.Sprintf("couldn't remove unused layers: %v", err))
+		slog.Error("couldn't remove unused layers", "error", err)
 		return nil
 	}
 

--- a/server/routes.go
+++ b/server/routes.go
@@ -391,7 +391,7 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 			if errors.As(err, &authError) {
 				sURL, sErr := signinURL()
 				if sErr != nil {
-					slog.Error(sErr.Error())
+					slog.Error("failed to get signin URL", "error", sErr)
 					c.JSON(http.StatusInternalServerError, gin.H{"error": "error getting authorization details"})
 					return
 				}
@@ -2153,7 +2153,7 @@ func (s *Server) WhoamiHandler(c *gin.Context) {
 	// todo allow other hosts
 	u, err := url.Parse("https://ollama.com")
 	if err != nil {
-		slog.Error(err.Error())
+		slog.Error("failed to parse ollama.com URL", "error", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "URL parse error"})
 		return
 	}
@@ -2170,7 +2170,7 @@ func (s *Server) WhoamiHandler(c *gin.Context) {
 				var sErr error
 				sURL, sErr = signinURL()
 				if sErr != nil {
-					slog.Error(sErr.Error())
+					slog.Error("failed to get signin URL", "error", sErr)
 					c.JSON(http.StatusInternalServerError, gin.H{"error": "error getting authorization details"})
 					return
 				}
@@ -2179,7 +2179,7 @@ func (s *Server) WhoamiHandler(c *gin.Context) {
 			return
 		}
 
-		slog.Error(err.Error())
+		slog.Error("account unavailable", "error", err)
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "account unavailable"})
 		return
 	}
@@ -2187,7 +2187,7 @@ func (s *Server) WhoamiHandler(c *gin.Context) {
 	if user == nil || user.Name == "" {
 		sURL, sErr := signinURL()
 		if sErr != nil {
-			slog.Error(sErr.Error())
+			slog.Error("failed to get signin URL", "error", sErr)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "error getting authorization details"})
 			return
 		}
@@ -2216,7 +2216,7 @@ func (s *Server) SignoutHandler(c *gin.Context) {
 	// todo allow other hosts
 	u, err := url.Parse("https://ollama.com")
 	if err != nil {
-		slog.Error(err.Error())
+		slog.Error("failed to parse ollama.com URL", "error", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "URL parse error"})
 		return
 	}
@@ -2569,7 +2569,7 @@ func (s *Server) ChatHandler(c *gin.Context) {
 			if errors.As(err, &authError) {
 				sURL, sErr := signinURL()
 				if sErr != nil {
-					slog.Error(sErr.Error())
+					slog.Error("failed to get signin URL", "error", sErr)
 					c.JSON(http.StatusInternalServerError, gin.H{"error": "error getting authorization details"})
 					return
 				}


### PR DESCRIPTION
Replaces unstructured slog.Error(fmt.Sprintf(...)) and slog.Error(err.Error()) patterns with proper key-value pairs, ensuring errors are logged as structured data compatible with JSON loggers and log parsing tools. Also fixes 'err' vs 'error' key inconsistency.

Changes across 11 files, 40 insertions, 40 deletions.