### PR TITLE
server/sched: trust GPU free memory on unified-memory APUs

### DIFF
--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -2404,7 +2404,8 @@ func (s *llamaServerRunner) stopProcess() error {
 //   - System-reported: free VRAM from llama-server at load time minus our allocations
 //
 // The min-of-two approach handles both our own usage (accurate) and external
-// consumers (system-reported, may be optimistic on some platforms).
+// consumers (system-reported, may be optimistic on some platforms). Unified-memory
+// APUs are an exception and use our accounting directly; see the loop below.
 func (s *llamaServerRunner) GetDeviceInfos(ctx context.Context) []ml.DeviceInfo {
 	if len(s.gpus) == 0 {
 		return nil
@@ -2435,8 +2436,18 @@ func (s *llamaServerRunner) GetDeviceInfos(ctx context.Context) []ml.DeviceInfo 
 			}
 		}
 
-		// Take the minimum — never optimistic
-		infos[i].FreeMemory = min(accountedFree, systemFree)
+		// Take the minimum — never optimistic.
+		//
+		// Exception: on unified-memory APUs the VRAM is carved out of system RAM
+		// and the driver reports GPU free memory accurately. The system-reported
+		// value (systemFreeAtLoad - used) underestimates the real GPU free memory
+		// once the runner is loaded, because host page cache and other consumers
+		// shrink the captured baseline. Trust our own accounting instead.
+		if gpu.IsUnifiedMemoryAPU() {
+			infos[i].FreeMemory = accountedFree
+		} else {
+			infos[i].FreeMemory = min(accountedFree, systemFree)
+		}
 	}
 	return infos
 }

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -2836,6 +2836,65 @@ func TestGetDeviceInfosSystemOptimistic(t *testing.T) {
 	}
 }
 
+func TestGetDeviceInfosUnifiedMemoryAPU(t *testing.T) {
+	// On a unified-memory APU the system-reported free memory at load time
+	// underestimates the real GPU free once the runner is loaded, so
+	// GetDeviceInfos must trust our own accounting (TotalMemory - used) rather
+	// than the min-of-two. The VRAM carveout is BIOS-configurable, so the result
+	// is a function of the device's reported TotalMemory and must hold for any
+	// size — no carveout size is assumed. In each case the min-of-two would
+	// instead yield the much smaller systemFreeAtLoad-based value (the bug).
+	const mib = 1024 * 1024
+	tests := []struct {
+		name          string
+		device        ml.DeviceInfo
+		totalMiB      uint64
+		usedMiB       uint64
+		systemFreeMiB uint64
+	}{
+		{
+			name:          "rocm small carveout",
+			device:        ml.DeviceInfo{DeviceID: ml.DeviceID{ID: "0", Library: "ROCm"}, Name: "ROCm0", Integrated: true, GFXTarget: "gfx1151"},
+			totalMiB:      48000,
+			usedMiB:       20000,
+			systemFreeMiB: 8000,
+		},
+		{
+			name:          "rocm large carveout",
+			device:        ml.DeviceInfo{DeviceID: ml.DeviceID{ID: "0", Library: "ROCm"}, Name: "ROCm0", Integrated: true, GFXTarget: "gfx1151"},
+			totalMiB:      96000,
+			usedMiB:       24000,
+			systemFreeMiB: 26000,
+		},
+		{
+			name:          "vulkan large carveout",
+			device:        ml.DeviceInfo{DeviceID: ml.DeviceID{ID: "0", Library: "Vulkan"}, Name: "Vulkan0", Description: "Radeon 8060S Graphics (RADV GFX1151)", Integrated: true},
+			totalMiB:      110000,
+			usedMiB:       24000,
+			systemFreeMiB: 20000,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dev := tt.device
+			dev.TotalMemory = tt.totalMiB * mib
+			runner := &llamaServerRunner{
+				vramByDevice:     map[string]uint64{dev.Name: tt.usedMiB * mib},
+				systemFreeAtLoad: map[string]uint64{dev.Name: tt.systemFreeMiB * mib},
+				gpus:             []ml.DeviceInfo{dev},
+			}
+
+			infos := runner.GetDeviceInfos(context.Background())
+			want := (tt.totalMiB - tt.usedMiB) * mib
+			if infos[0].FreeMemory != want {
+				t.Errorf("FreeMemory = %d MiB, want %d MiB (unified-memory APU should use accounting, not system free)",
+					infos[0].FreeMemory/mib, want/mib)
+			}
+		})
+	}
+}
+
 func TestIsGPUBuffer(t *testing.T) {
 	gpu := []string{
 		"Metal", "Metal_Private", "CUDA0", "CUDA1", "ROCm0", "Vulkan0", "MUSA0",

--- a/ml/device.go
+++ b/ml/device.go
@@ -353,6 +353,46 @@ func (d DeviceInfo) Driver() string {
 	return strconv.Itoa(d.DriverMajor) + "." + strconv.Itoa(d.DriverMinor)
 }
 
+// IsUnifiedMemoryAPU reports whether the device is an integrated GPU whose VRAM
+// is carved out of system RAM (a unified-memory APU). On these devices the GPU
+// reports its own free memory against a large carveout that is sized
+// independently of host free memory, so host free memory must not be used to
+// bound the GPU memory budget.
+//
+// This currently covers AMD Strix Halo (gfx1151, e.g. Ryzen AI Max+ 395 /
+// Radeon 8060S/8050S), which may run on either the ROCm or Vulkan backend. ROCm
+// exposes a structured GFXTarget; the Vulkan backend does not, so the Vulkan
+// device is matched on the name it reports (the only place the gfx target / SKU
+// is surfaced). Extend as additional unified-memory APUs are validated.
+func (d DeviceInfo) IsUnifiedMemoryAPU() bool {
+	if !d.Integrated {
+		return false
+	}
+	switch {
+	case strings.EqualFold(d.Library, "ROCm"):
+		return d.GFXTarget == "gfx1151"
+	case strings.EqualFold(d.Library, "Vulkan"):
+		return isStrixHaloName(d.Name) || isStrixHaloName(d.Description)
+	default:
+		return false
+	}
+}
+
+// isStrixHaloName reports whether a backend-provided device name identifies an
+// AMD Strix Halo iGPU (gfx1151). The Vulkan backend exposes no structured gfx
+// target, so the chip is identified by the markers that appear in its reported
+// name: the gfx target, the "Strix Halo" codename, or the Radeon 8060S/8050S
+// marketing SKUs.
+func isStrixHaloName(name string) bool {
+	name = strings.ToLower(name)
+	for _, marker := range []string{"gfx1151", "strix halo", "strix_halo", "radeon 8060s", "radeon 8050s"} {
+		if strings.Contains(name, marker) {
+			return true
+		}
+	}
+	return false
+}
+
 // MinimumMemory reports the amount of memory that should be set aside
 // on the device for overhead (e.g. VRAM consumed by context structures independent
 // of model allocations)

--- a/ml/device_test.go
+++ b/ml/device_test.go
@@ -7,6 +7,67 @@ import (
 	"testing"
 )
 
+func TestIsUnifiedMemoryAPU(t *testing.T) {
+	cases := []struct {
+		name string
+		dev  DeviceInfo
+		want bool
+	}{
+		{
+			name: "strix halo rocm",
+			dev:  DeviceInfo{DeviceID: DeviceID{Library: "ROCm"}, Integrated: true, GFXTarget: "gfx1151"},
+			want: true,
+		},
+		{
+			name: "strix halo rocm lowercase library",
+			dev:  DeviceInfo{DeviceID: DeviceID{Library: "rocm"}, Integrated: true, GFXTarget: "gfx1151"},
+			want: true,
+		},
+		{
+			name: "strix halo vulkan gfx target in name",
+			dev:  DeviceInfo{DeviceID: DeviceID{Library: "Vulkan"}, Integrated: true, Description: "Radeon 8060S Graphics (RADV GFX1151)"},
+			want: true,
+		},
+		{
+			name: "strix halo vulkan codename in name",
+			dev:  DeviceInfo{DeviceID: DeviceID{Library: "Vulkan"}, Integrated: true, Description: "AMD Radeon 8060S Graphics (RADV STRIX_HALO)"},
+			want: true,
+		},
+		{
+			name: "discrete rocm gfx1100",
+			dev:  DeviceInfo{DeviceID: DeviceID{Library: "ROCm"}, Integrated: false, GFXTarget: "gfx1100"},
+			want: false,
+		},
+		{
+			name: "integrated rocm other gfx",
+			dev:  DeviceInfo{DeviceID: DeviceID{Library: "ROCm"}, Integrated: true, GFXTarget: "gfx1103"},
+			want: false,
+		},
+		{
+			name: "integrated vulkan non-amd",
+			dev:  DeviceInfo{DeviceID: DeviceID{Library: "Vulkan"}, Integrated: true, Description: "Intel(R) Arc(TM) Graphics"},
+			want: false,
+		},
+		{
+			name: "discrete vulkan with strix name",
+			dev:  DeviceInfo{DeviceID: DeviceID{Library: "Vulkan"}, Integrated: false, Description: "Radeon 8060S Graphics (RADV GFX1151)"},
+			want: false,
+		},
+		{
+			name: "cuda",
+			dev:  DeviceInfo{DeviceID: DeviceID{Library: "CUDA"}, Integrated: false},
+			want: false,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.dev.IsUnifiedMemoryAPU(); got != tt.want {
+				t.Errorf("IsUnifiedMemoryAPU() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestMergeEnvWithRunnerEnvOverrides(t *testing.T) {
 	devices := []DeviceInfo{
 		{

--- a/server/sched.go
+++ b/server/sched.go
@@ -944,10 +944,31 @@ func availableMemoryForLoad(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo) (ava
 	// live measurement that already includes those loaded runners, so use the
 	// smaller value for shared-memory GPUs without discounting discrete VRAM.
 	if systemInfo.FreeMemory > 0 && sharedGPUFree > 0 && systemInfo.FreeMemory < sharedGPUFree {
+		// Unified-memory APUs (e.g. AMD Strix Halo) carve their VRAM out of
+		// system RAM and report GPU free memory accurately, so host free memory
+		// is not a meaningful bound on the GPU budget. Trust the GPU's own free
+		// memory rather than clamping to system free.
+		if allUnifiedMemoryAPUs(gpus) {
+			return gpuFree, gpuFree, false
+		}
 		return discreteGPUFree + systemInfo.FreeMemory, gpuFree, true
 	}
 
 	return gpuFree, gpuFree, false
+}
+
+// allUnifiedMemoryAPUs reports whether every GPU in the list is a unified-memory
+// APU (see ml.DeviceInfo.IsUnifiedMemoryAPU). Returns false for an empty list.
+func allUnifiedMemoryAPUs(gpus []ml.DeviceInfo) bool {
+	if len(gpus) == 0 {
+		return false
+	}
+	for _, gpu := range gpus {
+		if !gpu.IsUnifiedMemoryAPU() {
+			return false
+		}
+	}
+	return true
 }
 
 func availableMemoryForPlacement(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, opts api.Options) (available, gpuFree uint64, systemLimited bool) {
@@ -1119,6 +1140,11 @@ func hasDiscreteGPU(gpus []ml.DeviceInfo) bool {
 
 func availableMemoryForGPU(systemInfo ml.SystemInfo, gpu ml.DeviceInfo) uint64 {
 	if gpu.Integrated && systemInfo.FreeMemory > 0 && systemInfo.FreeMemory < gpu.FreeMemory {
+		// Unified-memory APUs report GPU free memory accurately and their VRAM is
+		// not bounded by host free memory, so don't clamp to system free.
+		if gpu.IsUnifiedMemoryAPU() {
+			return gpu.FreeMemory
+		}
 		return systemInfo.FreeMemory
 	}
 

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -1403,6 +1403,19 @@ func TestAvailableMemoryForLoadUsesWorstSharedMemoryMeasurement(t *testing.T) {
 			wantSystemLimited: true,
 		},
 		{
+			name:       "unified-memory APU trusts gpu free over lower system free",
+			systemFree: 6 * format.GigaByte,
+			gpus: []ml.DeviceInfo{{
+				DeviceID:   ml.DeviceID{Library: "ROCm"},
+				Integrated: true,
+				GFXTarget:  "gfx1151",
+				FreeMemory: 72 * format.GigaByte,
+			}},
+			wantAvailable:     72 * format.GigaByte,
+			wantGPUFree:       72 * format.GigaByte,
+			wantSystemLimited: false,
+		},
+		{
 			name:       "discrete metal ignores lower system free",
 			systemFree: 6 * format.GigaByte,
 			gpus: []ml.DeviceInfo{{
@@ -1459,6 +1472,46 @@ func TestAvailableMemoryForLoadUsesWorstSharedMemoryMeasurement(t *testing.T) {
 			require.Equal(t, tt.wantAvailable, available)
 			require.Equal(t, tt.wantGPUFree, gpuFree)
 			require.Equal(t, tt.wantSystemLimited, systemLimited)
+		})
+	}
+}
+
+func TestAvailableMemoryForGPU(t *testing.T) {
+	tests := []struct {
+		name       string
+		systemFree uint64
+		gpu        ml.DeviceInfo
+		want       uint64
+	}{
+		{
+			name:       "integrated gpu clamps to lower system free",
+			systemFree: 6 * format.GigaByte,
+			gpu:        ml.DeviceInfo{DeviceID: ml.DeviceID{Library: "Vulkan"}, Integrated: true, FreeMemory: 12 * format.GigaByte},
+			want:       6 * format.GigaByte,
+		},
+		{
+			name:       "unified-memory APU (ROCm) trusts gpu free",
+			systemFree: 6 * format.GigaByte,
+			gpu:        ml.DeviceInfo{DeviceID: ml.DeviceID{Library: "ROCm"}, Integrated: true, GFXTarget: "gfx1151", FreeMemory: 72 * format.GigaByte},
+			want:       72 * format.GigaByte,
+		},
+		{
+			name:       "unified-memory APU (Vulkan) trusts gpu free",
+			systemFree: 6 * format.GigaByte,
+			gpu:        ml.DeviceInfo{DeviceID: ml.DeviceID{Library: "Vulkan"}, Integrated: true, Description: "Radeon 8060S Graphics (RADV GFX1151)", FreeMemory: 88 * format.GigaByte},
+			want:       88 * format.GigaByte,
+		},
+		{
+			name:       "discrete gpu ignores system free",
+			systemFree: 6 * format.GigaByte,
+			gpu:        ml.DeviceInfo{DeviceID: ml.DeviceID{Library: "CUDA"}, FreeMemory: 12 * format.GigaByte},
+			want:       12 * format.GigaByte,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, availableMemoryForGPU(ml.SystemInfo{FreeMemory: tt.systemFree}, tt.gpu))
 		})
 	}
 }


### PR DESCRIPTION
## Problem

On unified-memory APUs (AMD Strix Halo / Ryzen AI Max+ 395 / Radeon 8060S/8050S,
`gfx1151`) the GPU's VRAM is carved out of system RAM, and the GPU reports its
free memory against the full carveout. The scheduler, however, treats **host**
free memory as an upper bound on the GPU budget in three spots —
`GetDeviceInfos`, `availableMemoryForLoad`, and `availableMemoryForGPU` all clamp
GPU free down to system free.

On these APUs the host pool (e.g. 32 GiB, mostly page cache once a model is
resident) is far smaller than the GPU carveout (e.g. 96 GiB), so the clamp
collapses reported "available" VRAM. With `OLLAMA_MAX_LOADED_MODELS=2`, loading a
second model trips the pre-flight eviction check and unloads the first even
though both fit easily — even when the GPU itself reports tens of GiB free
(`gpu_free="88.5 GiB"` while `available` is clamped to `system_free`).

## Why it matters

Multi-model usage (and any keep-alive workflow) is broken on Strix Halo despite
ample VRAM — the GPU is most of the way idle but the second load evicts the
first. This affects both backends the APU can run on (ROCm and Vulkan).

## Change

Add `ml.DeviceInfo.IsUnifiedMemoryAPU()` and use it in the three places that
clamp GPU memory to host free, returning the GPU's own free memory for these
devices. Detection covers both backends:

- **ROCm** — via the structured `GFXTarget` (`gfx1151`).
- **Vulkan** — matched on the reported device name (`Radeon 8060S Graphics (RADV
  GFX1151)` / `RADV STRIX_HALO`), since the Vulkan backend exposes no structured
  gfx target.

All other integrated GPUs keep the existing system-free clamp, so no other
configuration changes behavior. No new API fields, env vars, or dependencies.

## How it's tested

- Unit tests: `ml.TestIsUnifiedMemoryAPU` (ROCm + Vulkan + negative cases), a
  unified-APU case in `availableMemoryForLoad`'s table, `TestAvailableMemoryForGPU`
  (ROCm + Vulkan), and `TestGetDeviceInfosUnifiedMemoryAPU`.
- Hardware: Radeon 8060S (`gfx1151`, 96 GiB), both backends, `qwen3.5:35b` +
  `qwen3.6:latest` (~24 GiB each), `OLLAMA_MAX_LOADED_MODELS=2`:
  - **Before:** the second model evicts the first (`ollama ps` shows one model).
  - **After:** both stay resident (`ollama ps` shows both; `rocm-smi` ~49 GiB
    used). On Vulkan the scheduler reports `available="88.5 GiB"` after the first
    model (full 111 GiB carveout); on ROCm it reports `available="73.4 GiB"`
    instead of `4.2 GiB`.

No docs changes are needed (no new user-facing surface area).

## Scope and related issues

Fixes #16719.

This fixes the multi-model case: each model fits within the GPU's free memory,
but the second load is wrongly refused (and evicts the first) because the
scheduler clamps the GPU budget to host free memory.

Note a separate, discovery-time problem on the **ROCm** backend (#16462 /
#16529): there `available` is reported as ≈ system RAM at discovery, because
`ggml_backend_cuda_get_available_uma_memory()` returns `/proc/meminfo`
`MemAvailable`. That cap is applied before the scheduler runs, so this PR does
**not** fix those reports. The upstream fix for that is in progress at
ggml-org/llama.cpp#20472 (`max(hipMemGetInfo, MemAvailable)`), which I confirmed
on a gfx1151 box restores full-carveout reporting on the ROCm backend; those
reports are corrected once it lands and ollama's pinned llama.cpp includes it.
The Vulkan backend already reads the full carveout. (With this PR, the Vulkan
backend handles both the full-carveout single-model case and multi-model
coexistence.) This PR should therefore not be linked as fixing #16462 / #16529.

Related design discussion: #14953 (iGPU memory management / RAM-pressure guard);
this change is deliberately scoped to unified-memory APUs (gfx1151) so it does
not loosen memory budgets on small shared iGPUs.
