### PR TITLE
x/mlxrunner: support the diffusion-gemma architecture (MLX/safetensors only)

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -586,6 +586,7 @@ type Options struct {
 	NumKeep          int      `json:"num_keep,omitempty"`
 	Seed             int      `json:"seed,omitempty"`
 	NumPredict       int      `json:"num_predict,omitempty"`
+	DiffusionSteps   int      `json:"diffusion_steps,omitempty"`
 	TopK             int      `json:"top_k,omitempty"`
 	TopP             float32  `json:"top_p,omitempty"`
 	MinP             float32  `json:"min_p,omitempty"`

--- a/api/types.go
+++ b/api/types.go
@@ -586,7 +586,6 @@ type Options struct {
 	NumKeep          int      `json:"num_keep,omitempty"`
 	Seed             int      `json:"seed,omitempty"`
 	NumPredict       int      `json:"num_predict,omitempty"`
-	DiffusionSteps   int      `json:"diffusion_steps,omitempty"`
 	TopK             int      `json:"top_k,omitempty"`
 	TopP             float32  `json:"top_p,omitempty"`
 	MinP             float32  `json:"min_p,omitempty"`

--- a/x/create/client/create.go
+++ b/x/create/client/create.go
@@ -751,6 +751,9 @@ func getParserName(modelDir string) string {
 		if strings.Contains(archLower, "deepseek") {
 			return "deepseek3"
 		}
+		if strings.Contains(archLower, "diffusion") && strings.Contains(archLower, "gemma") {
+			return "gemma4"
+		}
 		if strings.Contains(archLower, "gemma4") {
 			return "gemma4"
 		}
@@ -770,6 +773,9 @@ func getParserName(modelDir string) string {
 		}
 		if strings.Contains(typeLower, "deepseek") {
 			return "deepseek3"
+		}
+		if strings.Contains(typeLower, "diffusion") && strings.Contains(typeLower, "gemma") {
+			return "gemma4"
 		}
 		if strings.Contains(typeLower, "gemma4") {
 			return "gemma4"
@@ -805,6 +811,9 @@ func getRendererName(modelDir string) string {
 		if strings.Contains(archLower, "laguna") {
 			return "laguna"
 		}
+		if strings.Contains(archLower, "diffusion") && strings.Contains(archLower, "gemma") {
+			return "gemma4"
+		}
 		if strings.Contains(archLower, "gemma4") {
 			return "gemma4"
 		}
@@ -824,6 +833,9 @@ func getRendererName(modelDir string) string {
 		typeLower := strings.ToLower(cfg.ModelType)
 		if strings.Contains(typeLower, "laguna") {
 			return "laguna"
+		}
+		if strings.Contains(typeLower, "diffusion") && strings.Contains(typeLower, "gemma") {
+			return "gemma4"
 		}
 		if strings.Contains(typeLower, "gemma4") {
 			return "gemma4"

--- a/x/create/create.go
+++ b/x/create/create.go
@@ -824,6 +824,8 @@ var tensorImportTransformRegistry = map[string]tensorImportTransformFactory{
 	"Gemma4AssistantForCausalLM":            newGemma4ImportTransform,
 	"Gemma4UnifiedAssistantForCausalLM":     newGemma4ImportTransform,
 	"gemma4_unified_assistant":              newGemma4ImportTransform,
+	"DiffusionGemmaForBlockDiffusion":       newDiffusionGemmaImportTransform,
+	"DiffusionGemma4ModelForBlockDiffusion": newDiffusionGemmaImportTransform,
 }
 
 func newTensorImportTransform(modelDir string, cfg sourceModelConfig) (tensorImportTransform, error) {

--- a/x/create/diffusiongemma.go
+++ b/x/create/diffusiongemma.go
@@ -1,0 +1,107 @@
+package create
+
+import (
+	"strings"
+
+	"github.com/ollama/ollama/x/safetensors"
+)
+
+// diffusionGemmaImportTransform adapts a DiffusionGemma checkpoint to the
+// canonical Gemma 4 tensor layout the MLX loader expects, then defers to the
+// Gemma 4 transform for MoE expert splitting and per-tensor quantization.
+//
+// DiffusionGemma checkpoints carry two transformer stacks that share weights
+// (an "encoder" used for the causal prompt prefill and a "decoder" used for the
+// bidirectional canvas denoising) plus a small self-conditioning MLP and a
+// vision tower. Mirroring the reference converter (conversion/diffusion_gemma.py
+// in llama.cpp PR #24427), we keep the decoder stack as the canonical model.*
+// tensors, drop the duplicate encoder stack (keeping only its per-layer output
+// scale), map the self-conditioning MLP to self_cond_* names, and drop vision.
+type diffusionGemmaImportTransform struct {
+	gemma4ImportTransform
+}
+
+func newDiffusionGemmaImportTransform(modelDir string, cfg sourceModelConfig) (tensorImportTransform, error) {
+	g, err := newGemma4ImportTransform(modelDir, cfg)
+	if err != nil {
+		return nil, err
+	}
+	return diffusionGemmaImportTransform{gemma4ImportTransform: g.(gemma4ImportTransform)}, nil
+}
+
+func (t diffusionGemmaImportTransform) skipTensor(name string) bool {
+	// Drop the entire encoder stack: the vision tower and the encoder per-layer
+	// output scale (model.encoder.language_model.layers.N.layer_scalar), which the
+	// reference loads but never applies. The decoder stack carries the canonical
+	// text weights (including its own layer_scalar) and the self-conditioning MLP.
+	if isDiffusionGemmaVisionTensor(name) || strings.Contains(name, "model.encoder.") {
+		return true
+	}
+	return t.gemma4ImportTransform.skipTensor(name)
+}
+
+func (t diffusionGemmaImportTransform) transformTensor(td *safetensors.TensorData) ([]*safetensors.TensorData, error) {
+	if td == nil {
+		return nil, nil
+	}
+
+	mapped := remapDiffusionGemmaName(td.Name)
+	if mapped == "" {
+		return nil, nil
+	}
+	td.Name = mapped
+
+	// Keep the MoE experts STACKED. DiffusionGemma ships pre-quantized experts as
+	// one tensor per projection spanning all experts (experts.gate_up_proj /
+	// experts.down_proj, plus companion .scales/.biases). gemma4's transform splits
+	// the .weight per-expert but leaves the 3-D .scales/.biases stacked, orphaning
+	// them — the loader would then find a per-expert weight with no matching scale
+	// and treat the 4-bit weight as float (garbage MoE). The MLX loader reads the
+	// stacked quantized experts directly via GatherQMM, so don't split them.
+	if strings.Contains(mapped, ".experts.") {
+		return []*safetensors.TensorData{td}, nil
+	}
+
+	// Defer to the Gemma 4 transform for any other stacked-MoE handling on the
+	// now-canonical names.
+	return t.gemma4ImportTransform.transformTensor(td)
+}
+
+func isDiffusionGemmaVisionTensor(name string) bool {
+	return strings.Contains(name, "vision") || strings.Contains(name, "embed_vision")
+}
+
+// remapDiffusionGemmaName rewrites a DiffusionGemma decoder tensor name to the
+// canonical Gemma 4 name the MLX loader resolves, or returns "" to drop it. The
+// encoder stack is dropped earlier by skipTensor.
+func remapDiffusionGemmaName(name string) string {
+	// Self-conditioning MLP: model.decoder.self_conditioning.<part>.<suffix> ->
+	// self_cond_<name>.<suffix>. The <suffix> (.weight / .scales / .biases) MUST
+	// be preserved — the MLP is quantized, so the scale/bias companions ride along.
+	if i := strings.Index(name, "decoder.self_conditioning."); i >= 0 {
+		sub := name[i+len("decoder.self_conditioning."):] // e.g. "gate_proj.scales"
+		dot := strings.IndexByte(sub, '.')
+		if dot < 0 {
+			return ""
+		}
+		part, suffix := sub[:dot], sub[dot:] // "gate_proj", ".scales"
+		switch part {
+		case "pre_norm":
+			return "self_cond_pre_norm" + suffix
+		case "gate_proj":
+			return "self_cond_gate" + suffix
+		case "up_proj":
+			return "self_cond_up" + suffix
+		case "down_proj":
+			return "self_cond_down" + suffix
+		}
+		return "" // unknown self-conditioning tensor
+	}
+
+	// Decoder stack -> canonical model.* (strip the "decoder." segment).
+	if i := strings.Index(name, "model.decoder."); i >= 0 {
+		return name[:i] + "model." + name[i+len("model.decoder."):]
+	}
+
+	return name
+}

--- a/x/create/diffusiongemma_test.go
+++ b/x/create/diffusiongemma_test.go
@@ -1,0 +1,56 @@
+package create
+
+import "testing"
+
+func TestRemapDiffusionGemmaName(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		// Decoder stack -> canonical model.*
+		{"model.decoder.embed_tokens.weight", "model.embed_tokens.weight"},
+		{"model.decoder.embed_tokens.scales", "model.embed_tokens.scales"},
+		{"model.decoder.norm.weight", "model.norm.weight"},
+		{"model.decoder.layers.0.self_attn.q_proj.weight", "model.layers.0.self_attn.q_proj.weight"},
+		{"model.decoder.layers.0.self_attn.q_proj.biases", "model.layers.0.self_attn.q_proj.biases"},
+		{"model.decoder.layers.3.layer_scalar", "model.layers.3.layer_scalar"},
+		{"model.decoder.layers.5.experts.gate_up_proj.weight", "model.layers.5.experts.gate_up_proj.weight"},
+		// Self-conditioning MLP -> self_cond_*, preserving the quant companion suffix.
+		{"model.decoder.self_conditioning.pre_norm.weight", "self_cond_pre_norm.weight"},
+		{"model.decoder.self_conditioning.gate_proj.weight", "self_cond_gate.weight"},
+		{"model.decoder.self_conditioning.gate_proj.scales", "self_cond_gate.scales"},
+		{"model.decoder.self_conditioning.gate_proj.biases", "self_cond_gate.biases"},
+		{"model.decoder.self_conditioning.up_proj.scales", "self_cond_up.scales"},
+		{"model.decoder.self_conditioning.down_proj.biases", "self_cond_down.biases"},
+		// Already-canonical names pass through unchanged.
+		{"model.norm.weight", "model.norm.weight"},
+	}
+	for _, c := range cases {
+		if got := remapDiffusionGemmaName(c.in); got != c.want {
+			t.Errorf("remapDiffusionGemmaName(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestDiffusionGemmaSkipTensor(t *testing.T) {
+	tr := diffusionGemmaImportTransform{gemma4ImportTransform{numLayers: 30, numExperts: 128}}
+	cases := []struct {
+		name string
+		want bool
+	}{
+		// Entire encoder stack (vision tower + encoder per-layer scale) is dropped.
+		{"model.encoder.vision_tower.encoder.layers.0.self_attn.q_proj.linear.weight", true},
+		{"model.encoder.embed_vision.embedding_projection.weight", true},
+		{"model.encoder.language_model.layers.0.layer_scalar", true},
+		// Decoder stack and self-conditioning are kept.
+		{"model.decoder.layers.0.self_attn.q_proj.weight", false},
+		{"model.decoder.layers.0.layer_scalar", false},
+		{"model.decoder.self_conditioning.gate_proj.scales", false},
+		{"model.decoder.embed_tokens.weight", false},
+	}
+	for _, c := range cases {
+		if got := tr.skipTensor(c.name); got != c.want {
+			t.Errorf("skipTensor(%q) = %v, want %v", c.name, got, c.want)
+		}
+	}
+}

--- a/x/mlxrunner/diffusion.go
+++ b/x/mlxrunner/diffusion.go
@@ -32,6 +32,11 @@ func fitDiffusionCanvases(maxCanvases, canvas, promptLen, contextLength int) (in
 // streams the emitted tokens (buffering partial UTF-8), and sends the final
 // summary response. It is selected over TextGenerationPipeline when the loaded
 // model implements base.DiffusionModel.
+//
+// Unsupported vs the autoregressive pipeline: stop strings (generation is
+// canvas-based and EOS-terminated) and logprobs (argmax is committed per canvas).
+// num_predict is a canvas budget: rounded up to whole canvases by ResolveDiffuse,
+// then capped by fitDiffusionCanvases to fit the context window.
 func (r *Runner) DiffusionGenerationPipeline(ctx context.Context, request Request) error {
 	dm, ok := r.Model.(base.DiffusionModel)
 	if !ok {

--- a/x/mlxrunner/diffusion.go
+++ b/x/mlxrunner/diffusion.go
@@ -4,10 +4,28 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/ollama/ollama/x/mlxrunner/model/base"
 )
+
+// fitDiffusionCanvases bounds the number of canvases so the prompt plus every
+// processed canvas fits the model's context window. Block diffusion processes
+// each canvas at positions [nPast, nPast+canvas) and commits whole canvases, so
+// the context budget is promptLen + n*canvas - not just the emitted tokens that
+// Prepare accounts for. Returns the reduced canvas count, or an error when not
+// even a single canvas fits.
+func fitDiffusionCanvases(maxCanvases, canvas, promptLen, contextLength int) (int, error) {
+	if canvas <= 0 {
+		return maxCanvases, nil
+	}
+	fit := (contextLength - promptLen) / canvas
+	if fit < 1 {
+		return 0, fmt.Errorf("prompt (%d tokens) leaves no room for a diffusion canvas (%d tokens) within the context window (%d tokens)", promptLen, canvas, contextLength)
+	}
+	return min(maxCanvases, fit), nil
+}
 
 // DiffusionGenerationPipeline drives a block-diffusion model. The denoising loop
 // itself lives on the model (Diffuse); this pipeline resolves the runtime config,
@@ -25,7 +43,19 @@ func (r *Runner) DiffusionGenerationPipeline(ctx context.Context, request Reques
 	if request.SamplerOpts.UseSeed {
 		seed = int64(request.SamplerOpts.Seed)
 	}
-	cfg := dm.ResolveDiffuse(request.Options.NumPredict, request.Options.DiffusionSteps, seed)
+	// The denoising step count uses the model's configured default. A per-request
+	// override is intentionally not exposed as a global API option yet (pending
+	// maintainer agreement on how diffusion-specific knobs should be surfaced).
+	cfg := dm.ResolveDiffuse(request.Options.NumPredict, 0, seed)
+
+	// Prepare caps NumPredict as if tokens were emitted autoregressively, but the
+	// denoiser commits whole canvases to the KV cache. Reduce the canvas count so
+	// the prompt plus every canvas stays within the context window.
+	fitted, err := fitDiffusionCanvases(cfg.MaxCanvases, cfg.Canvas, len(request.Tokens), r.contextLength)
+	if err != nil {
+		return err
+	}
+	cfg.MaxCanvases = fitted
 
 	now := time.Now()
 	var buf bytes.Buffer

--- a/x/mlxrunner/diffusion.go
+++ b/x/mlxrunner/diffusion.go
@@ -1,0 +1,74 @@
+package mlxrunner
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"time"
+
+	"github.com/ollama/ollama/x/mlxrunner/model/base"
+)
+
+// DiffusionGenerationPipeline drives a block-diffusion model. The denoising loop
+// itself lives on the model (Diffuse); this pipeline resolves the runtime config,
+// streams the emitted tokens (buffering partial UTF-8), and sends the final
+// summary response. It is selected over TextGenerationPipeline when the loaded
+// model implements base.DiffusionModel.
+func (r *Runner) DiffusionGenerationPipeline(ctx context.Context, request Request) error {
+	dm, ok := r.Model.(base.DiffusionModel)
+	if !ok {
+		return errors.New("model does not support diffusion generation")
+	}
+
+	// Seed 0 lets the model apply the reference default (1234).
+	var seed int64
+	if request.SamplerOpts.UseSeed {
+		seed = int64(request.SamplerOpts.Seed)
+	}
+	cfg := dm.ResolveDiffuse(request.Options.NumPredict, request.Options.DiffusionSteps, seed)
+
+	now := time.Now()
+	var buf bytes.Buffer
+	var emitted int
+	emit := func(tok int32) error {
+		emitted++
+		buf.WriteString(r.Tokenizer.Decode([]int32{tok}))
+		content := flushValidUTF8Prefix(&buf)
+		if content == "" {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case request.Responses <- CompletionResponse{Content: content}:
+			return nil
+		}
+	}
+
+	if err := dm.Diffuse(ctx, request.Tokens, cfg, emit); err != nil {
+		return err
+	}
+
+	// Flush any bytes still buffered (e.g. a trailing incomplete rune).
+	if tail := buf.String(); tail != "" {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case request.Responses <- CompletionResponse{Content: tail}:
+		}
+	}
+
+	final := CompletionResponse{
+		Done:            true,
+		DoneReason:      1,
+		PromptEvalCount: len(request.Tokens),
+		EvalCount:       emitted,
+		EvalDuration:    time.Since(now),
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case request.Responses <- final:
+		return nil
+	}
+}

--- a/x/mlxrunner/diffusion_test.go
+++ b/x/mlxrunner/diffusion_test.go
@@ -1,0 +1,38 @@
+package mlxrunner
+
+import "testing"
+
+func TestFitDiffusionCanvases(t *testing.T) {
+	tests := []struct {
+		name                             string
+		maxCanvases, canvas, prompt, ctx int
+		want                             int
+		wantErr                          bool
+	}{
+		{"fits unchanged", 4, 32, 10, 1024, 4, false},
+		{"reduced to fit context", 10, 256, 100, 1024, 3, false},                // (1024-100)/256 = 3
+		{"exact multiple", 8, 256, 0, 1024, 4, false},                           // 1024/256 = 4
+		{"prompt near boundary leaves one canvas", 5, 256, 768, 1024, 1, false}, // (1024-768)/256 = 1
+		{"prompt leaves no room for a canvas", 5, 256, 800, 1024, 0, true},      // (1024-800)/256 = 0
+		{"canvas unset is a no-op", 4, 0, 10, 1024, 4, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := fitDiffusionCanvases(tc.maxCanvases, tc.canvas, tc.prompt, tc.ctx)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("fitDiffusionCanvases err = %v, wantErr %v", err, tc.wantErr)
+			}
+			if tc.wantErr {
+				return
+			}
+			if got != tc.want {
+				t.Fatalf("fitDiffusionCanvases = %d, want %d", got, tc.want)
+			}
+			// Invariant: the prompt plus every fitted canvas fits the context window.
+			if tc.canvas > 0 && tc.prompt+got*tc.canvas > tc.ctx {
+				t.Fatalf("prompt(%d)+%d*canvas(%d) = %d exceeds context %d", tc.prompt, got, tc.canvas, tc.prompt+got*tc.canvas, tc.ctx)
+			}
+		})
+	}
+}

--- a/x/mlxrunner/imports.go
+++ b/x/mlxrunner/imports.go
@@ -1,6 +1,7 @@
 package mlxrunner
 
 import (
+	_ "github.com/ollama/ollama/x/models/diffusiongemma"
 	_ "github.com/ollama/ollama/x/models/gemma3"
 	_ "github.com/ollama/ollama/x/models/gemma4"
 	_ "github.com/ollama/ollama/x/models/glm4_moe_lite"

--- a/x/mlxrunner/model/base/base.go
+++ b/x/mlxrunner/model/base/base.go
@@ -1,6 +1,7 @@
 package base
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -55,6 +56,37 @@ type MTPDraftModel interface {
 // MTPEmbeddingModel exposes the target token embedding path used by MTP drafts.
 type MTPEmbeddingModel interface {
 	TokenEmbeddings(inputIDs *mlx.Array) *mlx.Array
+}
+
+// DiffuseConfig holds the resolved runtime settings for one block-diffusion
+// generation. The runner obtains it from the model via ResolveDiffuse and passes
+// it back to Diffuse.
+type DiffuseConfig struct {
+	Canvas              int // canvas (block) width in tokens
+	Steps               int // max denoising steps per canvas
+	PredictTokens       int // requested generated tokens, capped by the runner
+	MaxCanvases         int // number of autoregressive canvases to generate
+	SelfCondK           int // self-conditioning top-k gather width
+	StabilityThreshold  int // consecutive-stable steps before early stop (0 = always stable)
+	TMin                float32
+	TMax                float32
+	EntropyBound        float32
+	ConfidenceThreshold float32
+	Seed                int64
+}
+
+// DiffusionModel is implemented by block-diffusion models (e.g. diffusion-gemma).
+// The runner routes such models to its diffusion pipeline instead of the
+// autoregressive one.
+type DiffusionModel interface {
+	Model
+	// ResolveDiffuse derives the runtime config from the model's parsed defaults,
+	// the requested predict length (which sets the number of canvases), an
+	// optional step override (<= 0 means use the model default), and a seed.
+	ResolveDiffuse(nPredict, steps int, seed int64) DiffuseConfig
+	// Diffuse runs the denoising loop over prompt, invoking emit for each
+	// generated token id in order. emit returning a non-nil error stops generation.
+	Diffuse(ctx context.Context, prompt []int32, cfg DiffuseConfig, emit func(token int32) error) error
 }
 
 var (

--- a/x/mlxrunner/server.go
+++ b/x/mlxrunner/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ollama/ollama/logutil"
 	"github.com/ollama/ollama/x/internal/mlxthread"
 	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/mlxrunner/model/base"
 	"github.com/ollama/ollama/x/mlxrunner/sample"
 )
 
@@ -127,6 +128,11 @@ func Execute(args []string) error {
 		}
 
 		request.Pipeline = runner.TextGenerationPipeline
+		if _, ok := runner.Model.(base.DiffusionModel); ok {
+			// Block-diffusion models use a denoising pipeline, not the
+			// autoregressive one.
+			request.Pipeline = runner.DiffusionGenerationPipeline
+		}
 		request.SamplerOpts = sample.Options{
 			Temperature:      request.Options.Temperature,
 			TopP:             request.Options.TopP,

--- a/x/models/diffusiongemma/diffuse.go
+++ b/x/models/diffusiongemma/diffuse.go
@@ -1,0 +1,236 @@
+package diffusiongemma
+
+import (
+	"context"
+	"math/rand"
+
+	"github.com/ollama/ollama/x/mlxrunner/batch"
+	"github.com/ollama/ollama/x/mlxrunner/cache"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/mlxrunner/model/base"
+)
+
+// Compile-time check that the model is a diffusion model the runner can drive.
+var _ base.DiffusionModel = (*Model)(nil)
+
+// Reference defaults (llama.cpp PR #24427, diffusion-gemma-cli.cpp) applied when
+// the checkpoint's generation_config omits a value. The reference hardcodes these
+// at runtime; we prefer the model's parsed values and fall back to these.
+const (
+	defCanvasLength = 256
+	defMaxSteps     = 48
+	// Self-conditioning gather width. The reference uses the full softmax; we
+	// approximate with a top-k probability-weighted embedding. High-probability
+	// mass dominates, so 32 keeps converging positions intact while bounding the
+	// per-step embedding gather.
+	defSelfCondK       = 32
+	defStabilityThresh = 1
+	defSeed            = 1234
+)
+
+const (
+	defTMin       float32 = 0.4
+	defTMax       float32 = 0.8
+	defEntropy    float32 = 0.1
+	defConfidence float32 = 0.005
+)
+
+// ResolveDiffuse derives the runtime block-diffusion config from the model's
+// parsed defaults, the requested predict length (number of canvases), an optional
+// step override, and a seed.
+func (m *Model) ResolveDiffuse(nPredict, steps int, seed int64) base.DiffuseConfig {
+	canvas := int(m.Diffusion.CanvasLength)
+	if canvas <= 0 {
+		canvas = defCanvasLength
+	}
+	st := steps
+	if st <= 0 {
+		st = int(m.Diffusion.MaxDenoisingSteps)
+	}
+	if st <= 0 {
+		st = defMaxSteps
+	}
+	tMin := m.Diffusion.TMin
+	if tMin <= 0 {
+		tMin = defTMin
+	}
+	tMax := m.Diffusion.TMax
+	if tMax <= 0 {
+		tMax = defTMax
+	}
+	eb := m.Diffusion.EntropyBound
+	if eb <= 0 {
+		eb = defEntropy
+	}
+	conf := m.Diffusion.ConfidenceThreshold
+	if conf <= 0 {
+		conf = defConfidence
+	}
+	stab := int(m.Diffusion.StabilityThreshold)
+	if stab <= 0 {
+		stab = defStabilityThresh
+	}
+	if seed == 0 {
+		seed = defSeed
+	}
+	return base.DiffuseConfig{
+		Canvas:              canvas,
+		Steps:               st,
+		PredictTokens:       nPredict,
+		MaxCanvases:         numCanvases(nPredict, canvas),
+		SelfCondK:           defSelfCondK,
+		StabilityThreshold:  stab,
+		TMin:                tMin,
+		TMax:                tMax,
+		EntropyBound:        eb,
+		ConfidenceThreshold: conf,
+		Seed:                seed,
+	}
+}
+
+// Diffuse runs the block-diffusion denoising loop: prefill the prompt (causal),
+// then for each canvas iterate the bidirectional self-conditioned denoiser to
+// convergence, emit the canvas's greedy (argmax) tokens, and commit the canvas as
+// a causal prefix. emit is called for each generated token id in order.
+func (m *Model) Diffuse(ctx context.Context, prompt []int32, cfg base.DiffuseConfig, emit func(token int32) error) error {
+	caches := m.NewCaches()
+	vocab := int(m.VocabSize)
+	rng := rand.New(rand.NewSource(cfg.Seed))
+
+	// Causal prefill of the prompt — the read-only prefix every canvas attends to.
+	m.prefillPrompt(prompt, caches)
+	nPast := len(prompt)
+	emitted := 0
+
+	for block := 0; block < cfg.MaxCanvases; block++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		canvas := randomCanvas(rng, cfg.Canvas, vocab)
+		checkpoint := CheckpointPrefix(caches)
+
+		var prevArgmax, argmaxCanvas []int32
+		var selfCond *SelfCond
+		for step := cfg.Steps; step >= 1; step-- {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+
+			temp := tempAt(step, cfg.Steps, cfg.TMin, cfg.TMax)
+			logits := m.decodeCanvasHostLogits(canvas, int32(nPast), selfCond, caches)
+			s := sampleCanvas(logits, cfg.Canvas, vocab, temp, cfg.SelfCondK, rng)
+			checkpoint.Rollback(caches) // discard this step's canvas K/V
+			argmaxCanvas = s.argmax
+
+			if stableAndConfident(s.argmax, prevArgmax, s.entropy, cfg.ConfidenceThreshold, cfg.StabilityThreshold) {
+				break
+			}
+			prevArgmax = s.argmax
+			accept := entropyBoundAccept(s.entropy, cfg.EntropyBound)
+			selfCond = &SelfCond{IDs: s.scIDs, Probs: s.scProbs, K: cfg.SelfCondK}
+			canvas = renoise(s.sampled, accept, rng, vocab)
+			logits = nil // release the [canvas*vocab] host buffer before the next step
+			mlx.Sweep()
+			mlx.ClearCache() // release MLX's per-step buffers
+		}
+
+		// Emit the settled canvas's greedy (argmax) tokens.
+		remaining := len(argmaxCanvas)
+		if cfg.PredictTokens > 0 {
+			remaining = min(remaining, cfg.PredictTokens-emitted)
+		}
+		stop := false
+		for _, tok := range argmaxCanvas[:remaining] {
+			if m.tok != nil && m.tok.IsEOS(tok) {
+				stop = true
+				break
+			}
+			if err := emit(tok); err != nil {
+				return err
+			}
+			emitted++
+		}
+		if stop || (cfg.PredictTokens > 0 && emitted >= cfg.PredictTokens) {
+			break
+		}
+
+		if block+1 < cfg.MaxCanvases {
+			m.commitCanvas(argmaxCanvas, int32(nPast), caches)
+			nPast += cfg.Canvas
+		}
+	}
+	return nil
+}
+
+// computeSelfCond builds the decoder self-conditioning addend:
+//
+//	soft = (Σ_k probs · embed[ids]) · sqrt(n_embd)
+//	sc   = sc_down( gelu(sc_gate(rms_norm(soft))) · sc_up(rms_norm(soft)) )
+func (m *Model) computeSelfCond(sc *SelfCond, B, L int32) *mlx.Array {
+	k := int32(sc.K)
+	ids := mlx.FromValues(sc.IDs, int(B), int(L*k))
+	emb := m.EmbedTokens.Forward(ids)             // [B, L*k, n_embd] (raw gather)
+	emb = mlx.Reshape(emb, B, L, k, m.HiddenSize) // [B, L, k, n_embd]
+	probs := mlx.FromValues(sc.Probs, int(B), int(L), int(k), 1)
+	soft := mlx.Sum(mlx.Mul(emb, probs), 2, false) // [B, L, n_embd]
+	soft = mlx.MulScalar(soft, m.EmbedScale)       // · sqrt(n_embd)
+
+	scn := mlx.RMSNormFn(soft, m.SelfCond.PreNormScaled, m.RMSNormEps)
+	gated := mlx.GeGLU(m.SelfCond.Gate.Forward(scn), m.SelfCond.Up.Forward(scn))
+	return m.SelfCond.Down.Forward(gated)
+}
+
+func (m *Model) prefillPrompt(tokens []int32, caches []cache.Cache) {
+	const chunk = 2048
+	for off := 0; off < len(tokens); off += chunk {
+		end := min(off+chunk, len(tokens))
+		m.forward(&batch.Batch{
+			InputIDs:     mlx.FromValues(tokens[off:end], 1, end-off),
+			SeqOffsets:   []int32{int32(off)},
+			SeqQueryLens: []int32{int32(end - off)},
+		}, caches, nil)
+	}
+	evalCaches(caches)
+}
+
+// decodeCanvasHostLogits runs one bidirectional, self-conditioned denoising pass
+// and returns the canvas logits materialized on the host, row-major
+// [canvasLen*vocab]. (Pulling logits to host mirrors the reference host sampler;
+// moving the per-position math on-device is a future optimization.)
+func (m *Model) decodeCanvasHostLogits(canvas []int32, nPast int32, selfCond *SelfCond, caches []cache.Cache) []float32 {
+	hidden := m.forward(&batch.Batch{
+		InputIDs:     mlx.FromValues(canvas, 1, len(canvas)),
+		SeqOffsets:   []int32{nPast},
+		SeqQueryLens: []int32{int32(len(canvas))},
+	}, caches, &forwardOpts{
+		decoderPhase: true,
+		canvasStart:  nPast,
+		canvasLen:    int32(len(canvas)),
+		selfCond:     selfCond,
+	})
+	logits := m.Unembed(hidden).AsType(mlx.DTypeFloat32)
+	mlx.Eval(logits) // MLX is lazy; materialize before reading the host buffer.
+	return logits.Floats()
+}
+
+func (m *Model) commitCanvas(tokens []int32, nPast int32, caches []cache.Cache) {
+	m.forward(&batch.Batch{
+		InputIDs:     mlx.FromValues(tokens, 1, len(tokens)),
+		SeqOffsets:   []int32{nPast},
+		SeqQueryLens: []int32{int32(len(tokens))},
+	}, caches, nil)
+	evalCaches(caches)
+}
+
+func evalCaches(caches []cache.Cache) {
+	var state []*mlx.Array
+	for _, c := range caches {
+		if c != nil {
+			state = append(state, c.State()...)
+		}
+	}
+	if len(state) > 0 {
+		mlx.Eval(state...)
+	}
+}

--- a/x/models/diffusiongemma/diffuse.go
+++ b/x/models/diffusiongemma/diffuse.go
@@ -96,6 +96,7 @@ func (m *Model) Diffuse(ctx context.Context, prompt []int32, cfg base.DiffuseCon
 	caches := m.NewCaches()
 	vocab := int(m.VocabSize)
 	rng := rand.New(rand.NewSource(cfg.Seed))
+	var keyCounter uint64 // distinct MLX RNG key per denoising step
 
 	// Causal prefill of the prompt — the read-only prefix every canvas attends to.
 	m.prefillPrompt(prompt, caches)
@@ -118,8 +119,9 @@ func (m *Model) Diffuse(ctx context.Context, prompt []int32, cfg base.DiffuseCon
 			}
 
 			temp := tempAt(step, cfg.Steps, cfg.TMin, cfg.TMax)
-			logits := m.decodeCanvasHostLogits(canvas, int32(nPast), selfCond, caches)
-			s := sampleCanvas(logits, cfg.Canvas, vocab, temp, cfg.SelfCondK, rng)
+			key := mlx.RandomKey(uint64(cfg.Seed) + keyCounter)
+			keyCounter++
+			s := m.decodeCanvasSample(canvas, int32(nPast), selfCond, caches, temp, cfg.SelfCondK, key)
 			checkpoint.Rollback(caches) // discard this step's canvas K/V
 			argmaxCanvas = s.argmax
 
@@ -130,7 +132,6 @@ func (m *Model) Diffuse(ctx context.Context, prompt []int32, cfg base.DiffuseCon
 			accept := entropyBoundAccept(s.entropy, cfg.EntropyBound)
 			selfCond = &SelfCond{IDs: s.scIDs, Probs: s.scProbs, K: cfg.SelfCondK}
 			canvas = renoise(s.sampled, accept, rng, vocab)
-			logits = nil // release the [canvas*vocab] host buffer before the next step
 			mlx.Sweep()
 			mlx.ClearCache() // release MLX's per-step buffers
 		}
@@ -192,26 +193,6 @@ func (m *Model) prefillPrompt(tokens []int32, caches []cache.Cache) {
 		}, caches, nil)
 	}
 	evalCaches(caches)
-}
-
-// decodeCanvasHostLogits runs one bidirectional, self-conditioned denoising pass
-// and returns the canvas logits materialized on the host, row-major
-// [canvasLen*vocab]. (Pulling logits to host mirrors the reference host sampler;
-// moving the per-position math on-device is a future optimization.)
-func (m *Model) decodeCanvasHostLogits(canvas []int32, nPast int32, selfCond *SelfCond, caches []cache.Cache) []float32 {
-	hidden := m.forward(&batch.Batch{
-		InputIDs:     mlx.FromValues(canvas, 1, len(canvas)),
-		SeqOffsets:   []int32{nPast},
-		SeqQueryLens: []int32{int32(len(canvas))},
-	}, caches, &forwardOpts{
-		decoderPhase: true,
-		canvasStart:  nPast,
-		canvasLen:    int32(len(canvas)),
-		selfCond:     selfCond,
-	})
-	logits := m.Unembed(hidden).AsType(mlx.DTypeFloat32)
-	mlx.Eval(logits) // MLX is lazy; materialize before reading the host buffer.
-	return logits.Floats()
 }
 
 func (m *Model) commitCanvas(tokens []int32, nPast int32, caches []cache.Cache) {

--- a/x/models/diffusiongemma/diffuse.go
+++ b/x/models/diffusiongemma/diffuse.go
@@ -168,6 +168,11 @@ func (m *Model) Diffuse(ctx context.Context, prompt []int32, cfg base.DiffuseCon
 //
 //	soft = (Σ_k probs · embed[ids]) · sqrt(n_embd)
 //	sc   = sc_down( gelu(sc_gate(rms_norm(soft))) · sc_up(rms_norm(soft)) )
+//
+// soft sums only the top-k terms (k = SelfCondK) instead of the reference's full
+// softmax. The top-k probs are the normalized softmax probs, so this is the exact
+// truncation of the full sum; the error is the dropped tail mass, negligible once
+// the canvas converges. See TestSelfCondTopKApproximatesFullSoftmax.
 func (m *Model) computeSelfCond(sc *SelfCond, B, L int32) *mlx.Array {
 	k := int32(sc.K)
 	ids := mlx.FromValues(sc.IDs, int(B), int(L*k))

--- a/x/models/diffusiongemma/diffusiongemma.go
+++ b/x/models/diffusiongemma/diffusiongemma.go
@@ -1,0 +1,1897 @@
+// Package diffusiongemma provides the DiffusionGemma block-diffusion model
+// implementation for MLX.
+//
+// DiffusionGemma reuses the Gemma 4 26B-A4B decoder block (attention + dual
+// dense/MoE FFN + PLE + KV sharing) but generates text by iteratively denoising
+// a fixed-size block of tokens (a "canvas") with bidirectional attention and
+// self-conditioning, instead of autoregressive left-to-right decoding. This file
+// is intentionally a close fork of x/models/gemma4 so the shared transformer body
+// stays diffable against it; the diffusion-specific additions are the
+// self-conditioning MLP, the per-layer encoder output scale, the diffusion
+// hyper-parameters, and (in later phases) the bidirectional canvas attention and
+// the denoising loop.
+package diffusiongemma
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/ollama/ollama/x/mlxrunner/batch"
+	"github.com/ollama/ollama/x/mlxrunner/cache"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/mlxrunner/model"
+	"github.com/ollama/ollama/x/mlxrunner/model/base"
+	"github.com/ollama/ollama/x/models/nn"
+	"github.com/ollama/ollama/x/tokenizer"
+)
+
+func init() {
+	// HF architecture class names emitted by the DiffusionGemma checkpoints
+	// (config.json "architectures"). base.New looks up architectures[0].
+	base.Register("DiffusionGemmaForBlockDiffusion", newModel)
+	base.Register("DiffusionGemma4ModelForBlockDiffusion", newModel)
+}
+
+// Compile-time interface checks.
+var (
+	_ base.Model               = (*Model)(nil)
+	_ base.MTPDefaultsProvider = (*Model)(nil)
+)
+
+// RopeParams holds per-layer-type RoPE settings.
+type RopeParams struct {
+	PartialRotaryFactor float32 `json:"partial_rotary_factor"`
+	RopeTheta           float32 `json:"rope_theta"`
+	RopeType            string  `json:"rope_type"`
+}
+
+// TextConfig holds configuration for the Gemma 4 text model.
+type TextConfig struct {
+	HiddenSize             int32                  `json:"hidden_size"`
+	NumHiddenLayers        int32                  `json:"num_hidden_layers"`
+	IntermediateSize       int32                  `json:"intermediate_size"`
+	NumAttentionHeads      int32                  `json:"num_attention_heads"`
+	NumKeyValueHeads       int32                  `json:"num_key_value_heads"`
+	HeadDim                int32                  `json:"head_dim"`
+	GlobalHeadDim          int32                  `json:"global_head_dim"`
+	VocabSize              int32                  `json:"vocab_size"`
+	RMSNormEps             float32                `json:"rms_norm_eps"`
+	MaxPositionEmbeddings  int32                  `json:"max_position_embeddings"`
+	SlidingWindow          int32                  `json:"sliding_window"`
+	SlidingWindowPattern   int32                  `json:"sliding_window_pattern"`
+	LayerTypes             []string               `json:"layer_types"`
+	TieWordEmbeddings      bool                   `json:"tie_word_embeddings"`
+	FinalLogitSoftcapping  float32                `json:"final_logit_softcapping"`
+	UseDoubleWideMLP       bool                   `json:"use_double_wide_mlp"`
+	NumKVSharedLayers      int32                  `json:"num_kv_shared_layers"`
+	HiddenSizePerLayer     int32                  `json:"hidden_size_per_layer_input"`
+	VocabSizePerLayer      int32                  `json:"vocab_size_per_layer_input"`
+	AttentionKEqV          bool                   `json:"attention_k_eq_v"`
+	NumGlobalKeyValueHeads int32                  `json:"num_global_key_value_heads"`
+	EnableMoeBlock         bool                   `json:"enable_moe_block"`
+	NumExperts             int32                  `json:"num_experts"`
+	TopKExperts            int32                  `json:"top_k_experts"`
+	ExpertIntermediateSize int32                  `json:"moe_intermediate_size"`
+	RopeParameters         map[string]*RopeParams `json:"rope_parameters"`
+	ImageTokenIDValue      int32                  `json:"image_token_id"`
+
+	// Quantization parameters.
+	QuantGroupSize int                               `json:"-"`
+	QuantBits      int                               `json:"-"`
+	QuantMode      string                            `json:"-"`
+	TensorQuant    map[string]*model.TensorQuantInfo `json:"-"`
+
+	// Computed fields.
+	SlidingScale    float32    `json:"-"` // 1/sqrt(HeadDim) for sliding layers
+	FullScale       float32    `json:"-"` // 1/sqrt(GlobalHeadDim) for full layers
+	SlidingRopeDims int        `json:"-"` // HeadDim (full rotation for sliding)
+	FullRopeDims    int        `json:"-"` // GlobalHeadDim (partial rotation via custom freqs)
+	SlidingRopeBase float32    `json:"-"`
+	FullRopeBase    float32    `json:"-"`
+	FullRopeFreqs   *mlx.Array `json:"-"` // Precomputed proportional RoPE frequencies
+
+	// Precomputed scale factors (avoid per-forward math.Sqrt/Pow).
+	EmbedScale      float32 `json:"-"` // sqrt(hidden_size)
+	PLEScale        float32 `json:"-"` // sqrt(hidden_size_per_layer_input)
+	PLEProjScale    float32 `json:"-"` // 1/sqrt(hidden_size)
+	PLECombineScale float32 `json:"-"` // 2^(-0.5) = 0.7071...
+	RouterScale     float32 `json:"-"` // 1/sqrt(hidden_size)
+
+	// KV sharing: maps shared layer index -> donor layer index.
+	KVShareMap map[int32]int32 `json:"-"`
+	// Set of donor layer indices that need to store their KV.
+	KVDonors map[int32]bool `json:"-"`
+}
+
+type generationConfig struct {
+	SuppressTokens []int32 `json:"suppress_tokens"`
+}
+
+// DiffusionParams holds the block-diffusion sampler defaults. canvas_length comes
+// from the root of config.json; the entropy-bound ("eb") sampler settings come
+// from generation_config.json. They are parsed here so the runner/loop
+// can read model-provided defaults; a request may override them.
+type DiffusionParams struct {
+	CanvasLength        int32   // root config.json "canvas_length" (e.g. 256)
+	MaxDenoisingSteps   int32   // generation_config.json "max_denoising_steps" (e.g. 48)
+	TMin                float32 // sampler temperature floor (e.g. 0.4)
+	TMax                float32 // sampler temperature ceiling (e.g. 0.8)
+	EntropyBound        float32 // early-stop entropy bound (e.g. 0.1)
+	StabilityThreshold  int32   // consecutive-stable steps before commit
+	ConfidenceThreshold float32 // per-token unmask confidence floor (e.g. 0.005)
+}
+
+// SelfConditioning is the gated-GELU MLP DiffusionGemma applies to the previous
+// denoising step's soft (probability-weighted) token embedding, added to the
+// scaled input embedding in the decoder phase. Dimensions: hidden -> n_ff -> hidden.
+type SelfConditioning struct {
+	PreNorm *nn.RMSNorm
+	Gate    nn.LinearLayer
+	Up      nn.LinearLayer
+	Down    nn.LinearLayer
+
+	// Precomputed raw norm weight (Gemma uses scale_shift=0.0).
+	PreNormScaled *mlx.Array
+}
+
+// sharedHistory carries a donor layer's K/V to donees that share
+// it. Exactly one of history or (k, v) is populated: history when
+// the donor had a cache (donees feed it to SDPA via WithKVHistory;
+// (k, v) when the donor had no cache (donees feed them via WithKV).
+// mask carries any storage-side mask the (k, v) path needs (e.g.
+// sliding window) — unused on the history path, where the cache's
+// applier supplies the equivalent restriction.
+type sharedHistory struct {
+	history *nn.KVHistory
+	k, v    *mlx.Array
+	mask    nn.AttentionMask
+}
+
+// Attention implements Gemma 4 attention with Q/K normalization and v-norm.
+type Attention struct {
+	QProj nn.LinearLayer
+	KProj nn.LinearLayer
+	VProj nn.LinearLayer
+	OProj nn.LinearLayer
+
+	QNorm *nn.RMSNorm
+	KNorm *nn.RMSNorm
+
+	// Norm weight for Q/K RMSNorm.
+	QNormScaled *mlx.Array
+	KNormScaled *mlx.Array
+}
+
+// MLP is the feed-forward network with GELU activation.
+type MLP struct {
+	GateProj nn.LinearLayer
+	UpProj   nn.LinearLayer
+	DownProj nn.LinearLayer
+}
+
+// stackedExpertResult holds the result of collecting and stacking per-expert weights.
+type stackedExpertResult struct {
+	Weight    *mlx.Array
+	Scales    *mlx.Array
+	Biases    *mlx.Array
+	Bits      int
+	GroupSize int
+	Mode      string
+}
+
+// firstNonNil returns the first non-nil tensor found under any of the given keys.
+func firstNonNil(tensors map[string]*mlx.Array, keys ...string) *mlx.Array {
+	for _, k := range keys {
+		if t := tensors[k]; t != nil {
+			return t
+		}
+	}
+	return nil
+}
+
+func aliasTensor(tensors map[string]*mlx.Array, name string, arr *mlx.Array) {
+	if arr == nil || name == "" || tensors[name] != nil {
+		return
+	}
+	tensors[name] = arr
+}
+
+func aliasQuantCompanion(tensors map[string]*mlx.Array, name string, arr *mlx.Array) {
+	switch {
+	case strings.HasSuffix(name, ".scales"):
+		aliasTensor(tensors, strings.TrimSuffix(name, ".scales")+".weight_scale", arr)
+	case strings.HasSuffix(name, ".biases"):
+		aliasTensor(tensors, strings.TrimSuffix(name, ".biases")+".weight_qbias", arr)
+	}
+}
+
+func remapNativeSelfConditioningName(name string) string {
+	i := strings.Index(name, "model.decoder.self_conditioning.")
+	if i < 0 {
+		return ""
+	}
+
+	sub := name[i+len("model.decoder.self_conditioning."):]
+	dot := strings.IndexByte(sub, '.')
+	if dot < 0 {
+		return ""
+	}
+
+	var base string
+	switch sub[:dot] {
+	case "pre_norm":
+		base = "self_cond_pre_norm"
+	case "gate_proj":
+		base = "self_cond_gate"
+	case "up_proj":
+		base = "self_cond_up"
+	case "down_proj":
+		base = "self_cond_down"
+	default:
+		return ""
+	}
+
+	switch suffix := sub[dot:]; suffix {
+	case ".scales":
+		return base + ".weight_scale"
+	case ".biases":
+		return base + ".weight_qbias"
+	default:
+		return base + suffix
+	}
+}
+
+func normalizeNativeDiffusionGemmaTensors(tensors map[string]*mlx.Array) {
+	for name, arr := range tensors {
+		aliasQuantCompanion(tensors, name, arr)
+
+		if mapped := remapNativeSelfConditioningName(name); mapped != "" {
+			aliasTensor(tensors, mapped, arr)
+			continue
+		}
+
+		if strings.Contains(name, "model.decoder.") {
+			mapped := strings.Replace(name, "model.decoder.", "model.", 1)
+			aliasTensor(tensors, mapped, arr)
+			aliasQuantCompanion(tensors, mapped, arr)
+		}
+	}
+}
+
+// sliceAxis1 slices a tensor along axis 1: a[:, start:stop, ...].
+func sliceAxis1(a *mlx.Array, start, stop int32) *mlx.Array {
+	dims := a.Dims()
+	beg := make([]int32, len(dims))
+	end := make([]int32, len(dims))
+	for i, d := range dims {
+		end[i] = int32(d)
+	}
+	beg[1] = start
+	end[1] = stop
+	return mlx.SliceStartStop(a, beg, end)
+}
+
+// transposeForGatherMM transposes stacked expert weights from [experts, out, in]
+// to [experts, in, out] for use with GatherMM (which computes a @ b[group]).
+func transposeForGatherMM(w *mlx.Array) *mlx.Array {
+	if w == nil || !w.Valid() || w.NumDims() != 3 {
+		return w
+	}
+	t := mlx.Transpose(w, 0, 2, 1).Clone()
+	mlx.Eval(t)
+	return t
+}
+
+// collectExpertProjection collects per-expert tensors, stacks them, and
+// optionally keeps quantized weight/scale/bias for GatherQMM.
+// prefix: e.g. "model.language_model.layers.0.moe.experts"
+// proj: e.g. "gate_proj"
+func collectExpertProjection(tensors map[string]*mlx.Array, cfg *TextConfig, prefix, proj string, numExperts int32) *stackedExpertResult {
+	weights := make([]*mlx.Array, 0, numExperts)
+	scales := make([]*mlx.Array, 0, numExperts)
+	biases := make([]*mlx.Array, 0, numExperts)
+	bits, groupSize := 0, 0
+	mode := cfg.QuantMode
+
+	for e := range numExperts {
+		// Try "prefix.E.proj.weight" then "prefix.E.proj"
+		base := fmt.Sprintf("%s.%d.%s", prefix, e, proj)
+		w := tensors[base+".weight"]
+		key := base + ".weight"
+		if w == nil {
+			w = tensors[base]
+			key = base
+		}
+		if w == nil {
+			return nil
+		}
+
+		s := tensors[key+"_scale"]
+		if s == nil {
+			weights = append(weights, w)
+			continue
+		}
+		qb := tensors[key+"_qbias"]
+		gs, b, m := model.ResolveLinearQuantParams(
+			cfg.QuantGroupSize, cfg.QuantBits, cfg.QuantMode,
+			cfg.TensorQuant, key, w, s,
+		)
+		if bits == 0 {
+			bits = b
+			groupSize = gs
+			mode = m
+		}
+		// Keep quantized weights for GatherQMM (supports affine, nvfp4, mxfp8).
+		weights = append(weights, w)
+		scales = append(scales, s)
+		if qb != nil {
+			biases = append(biases, qb)
+		}
+	}
+
+	if len(weights) == 0 {
+		return nil
+	}
+
+	stacked := mlx.Stack(weights, 0).Clone()
+	mlx.Eval(stacked)
+	out := &stackedExpertResult{Weight: stacked, Bits: bits, GroupSize: groupSize, Mode: mode}
+	if len(scales) == len(weights) {
+		out.Scales = mlx.Stack(scales, 0).Clone()
+		mlx.Eval(out.Scales)
+	}
+	if len(biases) == len(weights) {
+		out.Biases = mlx.Stack(biases, 0).Clone()
+		mlx.Eval(out.Biases)
+	}
+	return out
+}
+
+// loadStackedQuantizedExperts loads DiffusionGemma's pre-quantized STACKED MoE
+// experts: one quantized tensor per projection spanning all experts
+// (experts.gate_up_proj / experts.down_proj, each a 3-D .weight plus companion
+// .weight_scale/.weight_qbias produced by normalizeNativeDiffusionGemmaTensors).
+// They go straight into the fused GatherQMM path. Returns false when the stacked
+// quantized tensors are absent, so the caller falls back to the gemma4
+// unquantized / per-expert paths.
+//
+// This is required because splitting the experts per-expert (as gemma4 does for
+// unquantized stacks) would orphan the 3-D stacked scales/biases, and the
+// per-expert collector would then load the 4-bit weight as float (garbage MoE).
+func loadStackedQuantizedExperts(moe *MoEBlock, tensors map[string]*mlx.Array, layerPrefix string, m *Model) bool {
+	gateUp := tensors[layerPrefix+".experts.gate_up_proj.weight"]
+	gateUpScale := tensors[layerPrefix+".experts.gate_up_proj.weight_scale"]
+	down := tensors[layerPrefix+".experts.down_proj.weight"]
+	downScale := tensors[layerPrefix+".experts.down_proj.weight_scale"]
+	if gateUp == nil || gateUpScale == nil || down == nil || downScale == nil {
+		return false
+	}
+
+	moe.GateUpWeightQ = gateUp
+	moe.GateUpScales = gateUpScale
+	moe.GateUpBiases = tensors[layerPrefix+".experts.gate_up_proj.weight_qbias"]
+	moe.DownWeightQ = down
+	moe.DownScales = downScale
+	moe.DownBiases = tensors[layerPrefix+".experts.down_proj.weight_qbias"]
+	moe.UseQuantized = true
+	moe.UseFusedGateUp = true
+
+	moe.GateUpGroupSize, moe.GateUpBits, moe.QuantMode = model.ResolveLinearQuantParams(
+		m.QuantGroupSize, m.QuantBits, m.QuantMode, m.TensorQuant,
+		layerPrefix+".experts.gate_up_proj.weight", gateUp, gateUpScale,
+	)
+	moe.DownGroupSize, moe.DownBits, moe.DownQuantMode = model.ResolveLinearQuantParams(
+		m.QuantGroupSize, m.QuantBits, m.QuantMode, m.TensorQuant,
+		layerPrefix+".experts.down_proj.weight", down, downScale,
+	)
+	return true
+}
+
+// Router implements Gemma 4's expert routing mechanism.
+type Router struct {
+	Proj  nn.LinearLayer // [hidden_size -> num_experts]
+	Scale *mlx.Array     // learnable scale [hidden_size]
+}
+
+// MoEBlock implements the Gemma 4 mixture-of-experts block.
+// Uses GatherQMM for quantized weights, GatherMM for dense.
+type MoEBlock struct {
+	// Dense expert weights for GatherMM (used when not quantized).
+	GateUpWeight *mlx.Array // [num_experts, 2*intermediate, hidden] (fused gate+up)
+	GateWeight   *mlx.Array // [num_experts, hidden_size, expert_intermediate_size]
+	UpWeight     *mlx.Array // [num_experts, hidden_size, expert_intermediate_size]
+	DownWeight   *mlx.Array // [num_experts, expert_intermediate_size, hidden_size]
+
+	// Quantized expert weights for GatherQMM.
+	GateUpWeightQ, GateUpScales, GateUpBiases *mlx.Array // fused gate+up
+	GateWeightQ, GateScales, GateBiases       *mlx.Array
+	UpWeightQ, UpScales, UpBiases             *mlx.Array
+	DownWeightQ, DownScales, DownBiases       *mlx.Array
+
+	PerExpertScale *mlx.Array // [num_experts]
+	UseQuantized   bool
+	UseFusedGateUp bool // true when gate+up are stored as single tensor
+
+	// Per-projection quant params (may differ due to mixed-precision).
+	GateUpGroupSize, GateUpBits int
+	GateGroupSize, UpGroupSize  int
+	DownGroupSize               int
+	GateBits, UpBits, DownBits  int
+	QuantMode                   string // gate/up mode
+	DownQuantMode               string // down mode (may differ for mixed mxfp4/mxfp8)
+}
+
+// PLELayer holds per-layer PLE weights for a single decoder layer.
+type PLELayer struct {
+	InputGate  nn.LinearLayer // [hidden_size -> ple_dim]
+	Projection nn.LinearLayer // [ple_dim -> hidden_size]
+	PostNorm   *nn.RMSNorm
+
+	// Norm weight for post-norm.
+	PostNormScaled *mlx.Array
+}
+
+// DecoderLayer is a single transformer block.
+type DecoderLayer struct {
+	InputNorm    *nn.RMSNorm
+	Attention    *Attention
+	PostAttnNorm *nn.RMSNorm
+	PreFFNorm    *nn.RMSNorm
+	MLP          *MLP
+	PostFFNorm   *nn.RMSNorm
+
+	// PLE per-layer components (nil if no PLE).
+	PLE *PLELayer
+
+	// MoE components (nil if no MoE).
+	Router *Router
+	MoE    *MoEBlock
+
+	// Additional norms for MoE dual-path (nil if no MoE).
+	PostFFNorm1 *nn.RMSNorm // post-norm for dense MLP path
+	PostFFNorm2 *nn.RMSNorm // post-norm for MoE path
+	PreFFNorm2  *nn.RMSNorm // pre-norm for MoE input
+
+	// Norm weight for RMSNorm.
+	InputNormScaled    *mlx.Array
+	PostAttnNormScaled *mlx.Array
+	PreFFNormScaled    *mlx.Array
+	PostFFNormScaled   *mlx.Array
+
+	// Norm weight for MoE norms.
+	PostFFNorm1Scaled *mlx.Array
+	PostFFNorm2Scaled *mlx.Array
+	PreFFNorm2Scaled  *mlx.Array
+
+	// Layer scalar for full-attention layers (nil for sliding).
+	LayerScalar *mlx.Array
+
+	// Layer metadata.
+	IsSliding    bool
+	LayerIdx     int32
+	KVShareDonor int32 // -1 if not shared, else index of donor layer
+	IsDonor      bool  // true if this layer's KV is shared by later layers
+}
+
+// Model is the Gemma 4 model (text + optional vision).
+type Model struct {
+	EmbedTokens nn.EmbeddingLayer
+	Layers      []*DecoderLayer
+	Norm        *nn.RMSNorm
+	LMHead      nn.LinearLayer
+
+	// PLE model-level components (nil if no PLE).
+	EmbedTokensPerLayer nn.EmbeddingLayer
+	PerLayerModelProj   nn.LinearLayer
+	PerLayerProjNorm    *nn.RMSNorm
+
+	// Precomputed scaled weights.
+	NormScaled             *mlx.Array
+	PerLayerProjNormWeight *mlx.Array
+
+	// SelfCond is the self-conditioning MLP used in the decoder (denoising)
+	// phase. nil if the checkpoint omits it.
+	SelfCond *SelfConditioning
+
+	// Diffusion holds block-diffusion sampler defaults parsed from config.
+	Diffusion DiffusionParams
+
+	tok *tokenizer.Tokenizer
+	*TextConfig
+
+	SuppressLogitBias *mlx.Array
+	weightPrefix      string
+}
+
+func parseTextConfig(configData []byte) (TextConfig, error) {
+	var cfg TextConfig
+	if err := json.Unmarshal(configData, &cfg); err != nil {
+		return TextConfig{}, fmt.Errorf("parse config: %w", err)
+	}
+
+	var wrapped struct {
+		TextConfig *TextConfig `json:"text_config"`
+	}
+	if err := json.Unmarshal(configData, &wrapped); err != nil {
+		return TextConfig{}, fmt.Errorf("parse nested text config: %w", err)
+	}
+
+	if wrapped.TextConfig != nil {
+		cfg = *wrapped.TextConfig
+	}
+
+	// Apply defaults.
+	if cfg.HeadDim == 0 {
+		cfg.HeadDim = 256
+	}
+	if cfg.GlobalHeadDim == 0 {
+		cfg.GlobalHeadDim = cfg.HeadDim
+	}
+	if cfg.NumAttentionHeads == 0 {
+		cfg.NumAttentionHeads = 8
+	}
+	if cfg.NumKeyValueHeads == 0 {
+		cfg.NumKeyValueHeads = 1
+	}
+	if cfg.NumGlobalKeyValueHeads > 0 {
+		cfg.AttentionKEqV = true
+	}
+	if cfg.RMSNormEps == 0 {
+		cfg.RMSNormEps = 1e-6
+	}
+	if cfg.VocabSize == 0 {
+		cfg.VocabSize = 262144
+	}
+	// DiffusionGemma always uses the MoE block (router + 128 experts). Unlike
+	// Gemma 4, the checkpoint config omits "enable_moe_block", so derive it from
+	// the presence of experts — otherwise the whole MoE is skipped and only the
+	// dense MLP runs (garbled output).
+	if cfg.NumExperts > 0 {
+		cfg.EnableMoeBlock = true
+	}
+	if cfg.SlidingWindowPattern <= 0 && len(cfg.LayerTypes) == 0 {
+		cfg.SlidingWindowPattern = 5
+	}
+	if cfg.MaxPositionEmbeddings == 0 {
+		cfg.MaxPositionEmbeddings = 131072
+	}
+
+	// Gemma 4 uses scaling=1.0 (no 1/sqrt(head_dim) scaling); the Q/K norms
+	// handle magnitude control. This differs from Gemma 3 which uses
+	// query_pre_attn_scalar^(-0.5).
+	cfg.SlidingScale = 1.0
+	cfg.FullScale = 1.0
+
+	// Compute RoPE settings from rope_parameters.
+	cfg.SlidingRopeDims = int(cfg.HeadDim) // full rotation for sliding
+	cfg.SlidingRopeBase = 10000
+	cfg.FullRopeDims = int(cfg.HeadDim) // default: full rotation
+	cfg.FullRopeBase = 1000000
+
+	if rp := cfg.RopeParameters; rp != nil {
+		if sp := rp["sliding_attention"]; sp != nil && sp.RopeTheta > 0 {
+			cfg.SlidingRopeBase = sp.RopeTheta
+		}
+		if fp := rp["full_attention"]; fp != nil {
+			if fp.RopeTheta > 0 {
+				cfg.FullRopeBase = fp.RopeTheta
+			}
+			if fp.PartialRotaryFactor > 0 {
+				// Proportional RoPE: the reference computes inv_freq with divisor
+				// global_head_dim, then applies rotate_half which splits at head_dim/2.
+				// MLX fast_rope splits at dims/2, so we use dims=global_head_dim
+				// and pass custom frequencies that match the reference formula.
+				// Non-rotated dims use 1e10 so MLX reciprocals to ~0 (identity).
+				ghd := int(cfg.GlobalHeadDim)
+				cfg.FullRopeDims = ghd
+				halfDim := ghd / 2
+				ropeAngles := int(fp.PartialRotaryFactor * float32(ghd) / 2)
+				freqs := make([]float32, halfDim)
+				for i := range ropeAngles {
+					freqs[i] = float32(math.Pow(float64(cfg.FullRopeBase), float64(2*i)/float64(ghd)))
+				}
+				for i := ropeAngles; i < halfDim; i++ {
+					freqs[i] = 1e10
+				}
+				cfg.FullRopeFreqs = mlx.FromValues(freqs, halfDim)
+				mlx.Eval(cfg.FullRopeFreqs)
+			}
+		}
+	}
+
+	// Precompute constant scale factors used in forward pass.
+	cfg.EmbedScale = float32(math.Sqrt(float64(cfg.HiddenSize)))
+	if cfg.HiddenSizePerLayer > 0 {
+		cfg.PLEScale = float32(math.Sqrt(float64(cfg.HiddenSizePerLayer)))
+		cfg.PLEProjScale = float32(1.0 / math.Sqrt(float64(cfg.HiddenSize)))
+		cfg.PLECombineScale = float32(math.Pow(2.0, -0.5))
+	}
+	cfg.RouterScale = float32(1.0 / math.Sqrt(float64(cfg.HiddenSize)))
+
+	// Compute KV sharing map.
+	cfg.KVShareMap = make(map[int32]int32)
+	cfg.KVDonors = make(map[int32]bool)
+	if cfg.NumKVSharedLayers > 0 && len(cfg.LayerTypes) > 0 {
+		firstShared := cfg.NumHiddenLayers - cfg.NumKVSharedLayers
+		prevLayers := cfg.LayerTypes[:firstShared]
+
+		for i := firstShared; i < cfg.NumHiddenLayers; i++ {
+			layerType := cfg.LayerTypes[i]
+			// Find the last non-shared layer of the same type.
+			donor := int32(-1)
+			for j := len(prevLayers) - 1; j >= 0; j-- {
+				if prevLayers[j] == layerType {
+					donor = int32(j)
+					break
+				}
+			}
+			if donor >= 0 {
+				cfg.KVShareMap[i] = donor
+				cfg.KVDonors[donor] = true
+			}
+		}
+	}
+
+	return cfg, nil
+}
+
+func parseSuppressTokens(configData []byte) []int32 {
+	var cfg generationConfig
+	if err := json.Unmarshal(configData, &cfg); err != nil {
+		return nil
+	}
+	return cfg.SuppressTokens
+}
+
+// parseDiffusionParams reads the block-diffusion defaults. canvas_length lives at
+// the root of config.json; the sampler defaults live in generation_config.json
+// (mirroring the reference converter's diffusion.* GGUF metadata). Both inputs are
+// optional — missing values leave the zero value, which the runner treats as
+// "use built-in default". genConfigData may be nil.
+func parseDiffusionParams(configData, genConfigData []byte) DiffusionParams {
+	var p DiffusionParams
+
+	var root struct {
+		CanvasLength int32 `json:"canvas_length"`
+	}
+	if err := json.Unmarshal(configData, &root); err == nil {
+		p.CanvasLength = root.CanvasLength
+	}
+
+	if len(genConfigData) > 0 {
+		var gen struct {
+			MaxDenoisingSteps   int32   `json:"max_denoising_steps"`
+			TMin                float32 `json:"t_min"`
+			TMax                float32 `json:"t_max"`
+			StabilityThreshold  int32   `json:"stability_threshold"`
+			ConfidenceThreshold float32 `json:"confidence_threshold"`
+			SamplerConfig       struct {
+				EntropyBound float32 `json:"entropy_bound"`
+			} `json:"sampler_config"`
+		}
+		if err := json.Unmarshal(genConfigData, &gen); err == nil {
+			p.MaxDenoisingSteps = gen.MaxDenoisingSteps
+			p.TMin = gen.TMin
+			p.TMax = gen.TMax
+			p.StabilityThreshold = gen.StabilityThreshold
+			p.ConfidenceThreshold = gen.ConfidenceThreshold
+			p.EntropyBound = gen.SamplerConfig.EntropyBound
+		}
+	}
+
+	return p
+}
+
+func (m *Model) EnableCompile() bool {
+	return true
+}
+
+func (m *Model) MTPDraftDefaults(_ bool) base.MTPDefaults {
+	defaults := base.MTPDefaults{
+		InitialDraftTokens: 4,
+		MaxDraftTokens:     16,
+		Enabled:            true,
+	}
+	if m == nil || m.TextConfig == nil {
+		return defaults
+	}
+	switch {
+	case !m.EnableMoeBlock && m.HiddenSize == 5376 && m.NumHiddenLayers == 60:
+		defaults.InitialDraftTokens = 14
+	case m.EnableMoeBlock && m.HiddenSize == 2816 && m.NumHiddenLayers == 30:
+		defaults.InitialDraftTokens = 8
+	}
+	return defaults
+}
+
+func resolveWeightPrefix(tensors map[string]*mlx.Array) string {
+	for _, prefix := range []string{"", "language_model.", "model.language_model."} {
+		if tensors[prefix+"embed_tokens.weight"] != nil {
+			return prefix
+		}
+	}
+	// Also try with "model." before the layer path.
+	for _, prefix := range []string{"", "language_model.", "model.language_model."} {
+		if tensors[prefix+"model.embed_tokens.weight"] != nil {
+			return prefix + "model."
+		}
+	}
+	return ""
+}
+
+func isLayerSliding(layerIdx int32, cfg *TextConfig) bool {
+	if len(cfg.LayerTypes) > 0 && int(layerIdx) < len(cfg.LayerTypes) {
+		return cfg.LayerTypes[layerIdx] == "sliding_attention"
+	}
+	if cfg.SlidingWindowPattern <= 0 {
+		return false
+	}
+	return (layerIdx+1)%cfg.SlidingWindowPattern != 0
+}
+
+// precomputeGemmaScaledWeights assigns raw norm weights to the *Scaled fields.
+// Gemma 4 uses scale_shift=0.0 for all norms (no +1.0 adjustment), so the
+// precomputed weights are just the raw weights from the model.
+func precomputeGemmaScaledWeights(m *Model) {
+	if m.Norm != nil {
+		m.NormScaled = m.Norm.Weight
+	}
+
+	if m.PerLayerProjNorm != nil {
+		m.PerLayerProjNormWeight = m.PerLayerProjNorm.Weight
+	}
+
+	if m.SelfCond != nil && m.SelfCond.PreNorm != nil {
+		m.SelfCond.PreNormScaled = m.SelfCond.PreNorm.Weight
+	}
+
+	for _, layer := range m.Layers {
+		if layer == nil || layer.Attention == nil {
+			continue
+		}
+
+		if layer.InputNorm != nil {
+			layer.InputNormScaled = layer.InputNorm.Weight
+		}
+		if layer.PostAttnNorm != nil {
+			layer.PostAttnNormScaled = layer.PostAttnNorm.Weight
+		}
+		if layer.PreFFNorm != nil {
+			layer.PreFFNormScaled = layer.PreFFNorm.Weight
+		}
+		if layer.PostFFNorm != nil {
+			layer.PostFFNormScaled = layer.PostFFNorm.Weight
+		}
+		if layer.Attention.QNorm != nil {
+			layer.Attention.QNormScaled = layer.Attention.QNorm.Weight
+		}
+		if layer.Attention.KNorm != nil {
+			layer.Attention.KNormScaled = layer.Attention.KNorm.Weight
+		}
+		if layer.PLE != nil && layer.PLE.PostNorm != nil {
+			layer.PLE.PostNormScaled = layer.PLE.PostNorm.Weight
+		}
+		if layer.PostFFNorm1 != nil {
+			layer.PostFFNorm1Scaled = layer.PostFFNorm1.Weight
+		}
+		if layer.PostFFNorm2 != nil {
+			layer.PostFFNorm2Scaled = layer.PostFFNorm2.Weight
+		}
+		if layer.PreFFNorm2 != nil {
+			layer.PreFFNorm2Scaled = layer.PreFFNorm2.Weight
+		}
+	}
+}
+
+func newModel(root *model.Root) (base.Model, error) {
+	configData, err := root.Manifest.ReadConfig("config.json")
+	if err != nil {
+		return nil, fmt.Errorf("load config: %w", err)
+	}
+
+	cfg, err := parseTextConfig(configData)
+	if err != nil {
+		return nil, err
+	}
+
+	if qt := root.QuantType(); qt != "" {
+		cfg.QuantGroupSize, cfg.QuantBits, cfg.QuantMode = model.QuantizationParams(qt)
+		if gs := root.GroupSize(); gs > 0 {
+			cfg.QuantGroupSize = gs
+		}
+	} else {
+		cfg.QuantGroupSize, cfg.QuantBits, cfg.QuantMode = model.QuantizationParams("")
+	}
+	cfg.TensorQuant = root.AllTensorQuant()
+
+	tokData, err := root.Manifest.ReadConfig("tokenizer.json")
+	if err != nil {
+		return nil, fmt.Errorf("load tokenizer config: %w", err)
+	}
+
+	tokConfig := &tokenizer.TokenizerConfig{ConfigJSON: configData}
+	var suppressTokens []int32
+	var genConfigData []byte
+	if data, err := root.Manifest.ReadConfig("generation_config.json"); err == nil {
+		genConfigData = data
+		tokConfig.GenerationConfigJSON = genConfigData
+		suppressTokens = parseSuppressTokens(genConfigData)
+	}
+	if tokConfigData, err := root.Manifest.ReadConfig("tokenizer_config.json"); err == nil {
+		tokConfig.TokenizerConfigJSON = tokConfigData
+	}
+
+	tok, err := tokenizer.LoadFromBytesWithConfig(tokData, tokConfig)
+	if err != nil {
+		return nil, fmt.Errorf("parse tokenizer: %w", err)
+	}
+
+	m := &Model{
+		Layers:            make([]*DecoderLayer, cfg.NumHiddenLayers),
+		TextConfig:        &cfg,
+		tok:               tok,
+		SuppressLogitBias: makeSuppressLogitBias(suppressTokens, cfg.VocabSize),
+		Diffusion:         parseDiffusionParams(configData, genConfigData),
+	}
+
+	for i := range m.Layers {
+		donor, isShared := cfg.KVShareMap[int32(i)]
+		if !isShared {
+			donor = -1
+		}
+		m.Layers[i] = &DecoderLayer{
+			LayerIdx:     int32(i),
+			IsSliding:    isLayerSliding(int32(i), m.TextConfig),
+			KVShareDonor: donor,
+			IsDonor:      cfg.KVDonors[int32(i)],
+		}
+	}
+
+	return m, nil
+}
+
+// LoadWeights receives all tensors loaded from the manifest and assigns them
+// to model fields.
+func (m *Model) LoadWeights(tensors map[string]*mlx.Array) error {
+	normalizeNativeDiffusionGemmaTensors(tensors)
+	m.weightPrefix = resolveWeightPrefix(tensors)
+	prefix := m.weightPrefix
+	linears := model.NewLinearFactory(tensors, m.QuantGroupSize, m.QuantBits, m.QuantMode, m.TensorQuant)
+
+	// Embeddings.
+	embedTokens := model.MakeEmbeddingLayer(tensors, prefix+"embed_tokens", m.QuantGroupSize, m.QuantBits, m.QuantMode, m.TensorQuant)
+	if embedTokens == nil {
+		return fmt.Errorf("missing embedding weight: %sembed_tokens.weight", prefix)
+	}
+	m.EmbedTokens = embedTokens
+
+	// Final norm.
+	normWeight := tensors[prefix+"norm.weight"]
+	if normWeight == nil {
+		return fmt.Errorf("missing final norm weight: %snorm.weight", prefix)
+	}
+	m.Norm = nn.NewRMSNorm(normWeight, m.RMSNormEps)
+
+	// LM head.
+	if lmHead := linears.Make(prefix + "lm_head"); lmHead != nil {
+		m.LMHead = lmHead
+	} else if lmHead := linears.Make("lm_head"); lmHead != nil {
+		m.LMHead = lmHead
+	} else {
+		// Gemma 4 ties output projection to embeddings.
+		m.LMHead = m.EmbedTokens.AsLinear()
+	}
+
+	// PLE model-level weights.
+	if m.HiddenSizePerLayer > 0 {
+		pleEmbed := model.MakeEmbeddingLayer(tensors, prefix+"embed_tokens_per_layer", m.QuantGroupSize, m.QuantBits, m.QuantMode, m.TensorQuant)
+		if pleEmbed == nil {
+			return fmt.Errorf("missing PLE embedding weight")
+		}
+		m.EmbedTokensPerLayer = pleEmbed
+
+		m.PerLayerModelProj = linears.Make(prefix + "per_layer_model_projection")
+		if m.PerLayerModelProj == nil {
+			return fmt.Errorf("missing per_layer_model_projection weight")
+		}
+
+		pleProjNormWeight := tensors[prefix+"per_layer_projection_norm.weight"]
+		if pleProjNormWeight == nil {
+			return fmt.Errorf("missing per_layer_projection_norm weight")
+		}
+		m.PerLayerProjNorm = nn.NewRMSNorm(pleProjNormWeight, m.RMSNormEps)
+	}
+
+	// Decoder layers.
+	for i := range m.NumHiddenLayers {
+		layerPrefix := fmt.Sprintf("%slayers.%d", prefix, i)
+		isSliding := isLayerSliding(i, m.TextConfig)
+
+		donor, isShared := m.KVShareMap[i]
+		if !isShared {
+			donor = -1
+		}
+
+		layer := &DecoderLayer{
+			LayerIdx:     i,
+			IsSliding:    isSliding,
+			KVShareDonor: donor,
+			IsDonor:      m.KVDonors[i],
+			Attention:    &Attention{},
+			MLP:          &MLP{},
+		}
+
+		// Norms.
+		if w := tensors[layerPrefix+".input_layernorm.weight"]; w != nil {
+			layer.InputNorm = nn.NewRMSNorm(w, m.RMSNormEps)
+		}
+		if w := tensors[layerPrefix+".post_attention_layernorm.weight"]; w != nil {
+			layer.PostAttnNorm = nn.NewRMSNorm(w, m.RMSNormEps)
+		}
+		if w := tensors[layerPrefix+".pre_feedforward_layernorm.weight"]; w != nil {
+			layer.PreFFNorm = nn.NewRMSNorm(w, m.RMSNormEps)
+		}
+		if w := tensors[layerPrefix+".post_feedforward_layernorm.weight"]; w != nil {
+			layer.PostFFNorm = nn.NewRMSNorm(w, m.RMSNormEps)
+		}
+
+		// Attention projections.
+		layer.Attention.QProj = linears.Make(layerPrefix + ".self_attn.q_proj")
+		layer.Attention.KProj = linears.Make(layerPrefix + ".self_attn.k_proj")
+		layer.Attention.VProj = linears.Make(layerPrefix + ".self_attn.v_proj")
+		layer.Attention.OProj = linears.Make(layerPrefix + ".self_attn.o_proj")
+
+		if w := tensors[layerPrefix+".self_attn.q_norm.weight"]; w != nil {
+			layer.Attention.QNorm = nn.NewRMSNorm(w, m.RMSNormEps)
+		}
+		if w := tensors[layerPrefix+".self_attn.k_norm.weight"]; w != nil {
+			layer.Attention.KNorm = nn.NewRMSNorm(w, m.RMSNormEps)
+		}
+
+		// MLP.
+		layer.MLP.GateProj = linears.Make(layerPrefix + ".mlp.gate_proj")
+		layer.MLP.UpProj = linears.Make(layerPrefix + ".mlp.up_proj")
+		layer.MLP.DownProj = linears.Make(layerPrefix + ".mlp.down_proj")
+
+		// Layer scalar (all layers in new weights, was full-attention only in earlier releases).
+		if w := tensors[layerPrefix+".layer_scalar"]; w != nil {
+			layer.LayerScalar = w
+		}
+
+		// MoE components.
+		if m.EnableMoeBlock {
+			// Router.
+			routerProj := linears.Make(layerPrefix + ".router.proj")
+			// Raw safetensors uses ".router.scale"; runner.go remaps to "_scale".
+			routerScale := tensors[layerPrefix+".router.scale"]
+			if routerScale == nil {
+				routerScale = tensors[layerPrefix+".router_scale"]
+			}
+			if routerProj == nil || routerScale == nil {
+				return fmt.Errorf("layer %d: missing router weights", i)
+			}
+			layer.Router = &Router{
+				Proj:  routerProj,
+				Scale: routerScale,
+			}
+
+			// MoE expert weights. Try pre-stacked (BF16 from HF) first,
+			// then per-expert (from quantized create path).
+			perExpertScale := tensors[layerPrefix+".router.per_expert_scale"]
+			if perExpertScale == nil {
+				perExpertScale = tensors[layerPrefix+".moe.per_expert_scale"]
+			}
+			if perExpertScale == nil {
+				return fmt.Errorf("layer %d: missing MoE per_expert_scale", i)
+			}
+
+			moe := &MoEBlock{PerExpertScale: perExpertScale}
+
+			// Check for pre-stacked tensors (unquantized HF format).
+			// Try .experts. first (new weight drop), fall back to .moe. (old format).
+			gateUpW := tensors[layerPrefix+".experts.gate_up_proj"]
+			if gateUpW == nil {
+				gateUpW = tensors[layerPrefix+".moe.gate_up_proj"]
+			}
+			gateW := tensors[layerPrefix+".experts.gate_proj"]
+			if gateW == nil {
+				gateW = tensors[layerPrefix+".moe.gate_proj"]
+			}
+			if loadStackedQuantizedExperts(moe, tensors, layerPrefix, m) {
+				// DiffusionGemma ships pre-quantized STACKED experts; loaded
+				// directly into the fused GatherQMM path by the helper above.
+			} else if gateUpW != nil {
+				// Fused gate+up: split along dim 1, transpose for GatherMM.
+				dims := gateUpW.Dims()
+				half := int32(dims[1] / 2)
+				gateSlice := sliceAxis1(gateUpW, 0, half)
+				upSlice := sliceAxis1(gateUpW, half, int32(dims[1]))
+				moe.GateWeight = transposeForGatherMM(gateSlice)
+				moe.UpWeight = transposeForGatherMM(upSlice)
+				downW := tensors[layerPrefix+".experts.down_proj"]
+				if downW == nil {
+					downW = tensors[layerPrefix+".moe.down_proj"]
+				}
+				if downW == nil {
+					return fmt.Errorf("layer %d: missing MoE down_proj with fused gate_up_proj", i)
+				}
+				moe.DownWeight = transposeForGatherMM(downW)
+			} else if gateW != nil {
+				// Separate gate_proj and up_proj (older format). Transpose for GatherMM.
+				moe.GateWeight = transposeForGatherMM(gateW)
+				upW := tensors[layerPrefix+".experts.up_proj"]
+				if upW == nil {
+					upW = tensors[layerPrefix+".moe.up_proj"]
+				}
+				downW := tensors[layerPrefix+".experts.down_proj"]
+				if downW == nil {
+					downW = tensors[layerPrefix+".moe.down_proj"]
+				}
+				moe.UpWeight = transposeForGatherMM(upW)
+				moe.DownWeight = transposeForGatherMM(downW)
+				if moe.UpWeight == nil || moe.DownWeight == nil {
+					return fmt.Errorf("layer %d: incomplete pre-stacked MoE weights", i)
+				}
+			} else if switchGateUp := firstNonNil(tensors,
+				layerPrefix+".moe.switch_mlp.gate_up_proj.weight",
+				layerPrefix+".moe.switch_mlp.gate_up_proj"); switchGateUp != nil {
+				// Stacked switch_mlp format (from create pipeline with expert packing).
+				switchDown := firstNonNil(tensors,
+					layerPrefix+".moe.switch_mlp.down_proj.weight",
+					layerPrefix+".moe.switch_mlp.down_proj")
+				if switchDown == nil {
+					return fmt.Errorf("layer %d: missing switch_mlp down_proj", i)
+				}
+
+				// Check for quantized weights (scales present).
+				// The scale key depends on whether the tensor has .weight suffix.
+				gateUpKey := layerPrefix + ".moe.switch_mlp.gate_up_proj.weight"
+				if tensors[gateUpKey] == nil {
+					gateUpKey = layerPrefix + ".moe.switch_mlp.gate_up_proj"
+				}
+				downKey := layerPrefix + ".moe.switch_mlp.down_proj.weight"
+				if tensors[downKey] == nil {
+					downKey = layerPrefix + ".moe.switch_mlp.down_proj"
+				}
+				gateUpScales := firstNonNil(tensors, gateUpKey+"_scale", gateUpKey+".scale")
+				downScales := firstNonNil(tensors, downKey+"_scale", downKey+".scale")
+
+				if gateUpScales != nil && downScales != nil {
+					// Quantized: keep fused gate_up as single tensor for GatherQMM.
+					// One fused call instead of two separate gate+up calls.
+					gateUpBiases := firstNonNil(tensors, gateUpKey+"_qbias", gateUpKey+".bias")
+					downBiases := firstNonNil(tensors, downKey+"_qbias", downKey+".bias")
+
+					moe.GateUpWeightQ = switchGateUp
+					moe.GateUpScales = gateUpScales
+					moe.GateUpBiases = gateUpBiases
+					moe.DownWeightQ = switchDown
+					moe.DownScales = downScales
+					if downBiases != nil {
+						moe.DownBiases = downBiases
+					}
+
+					groupSize, bits, mode := model.ResolveLinearQuantParams(
+						m.QuantGroupSize, m.QuantBits, m.QuantMode,
+						m.TensorQuant, gateUpKey, switchGateUp, gateUpScales,
+					)
+					moe.UseQuantized = true
+					moe.UseFusedGateUp = true
+					moe.GateUpGroupSize = groupSize
+					moe.GateUpBits = bits
+					moe.QuantMode = mode
+
+					dGroupSize, dBits, dMode := model.ResolveLinearQuantParams(
+						m.QuantGroupSize, m.QuantBits, m.QuantMode,
+						m.TensorQuant, downKey, switchDown, downScales,
+					)
+					moe.DownGroupSize = dGroupSize
+					moe.DownBits = dBits
+					moe.DownQuantMode = dMode
+				} else {
+					// Unquantized switch_mlp: keep fused and transpose for GatherMM.
+					moe.GateUpWeight = transposeForGatherMM(switchGateUp)
+					moe.UseFusedGateUp = true
+					moe.DownWeight = transposeForGatherMM(switchDown)
+				}
+			} else {
+				// Per-expert tensors (from create path).
+				// Try separate gate_proj/up_proj first, then fused gate_up_proj.
+				gateStacked := collectExpertProjection(tensors, m.TextConfig,
+					layerPrefix+".moe.experts", "gate_proj", m.NumExperts)
+				upStacked := collectExpertProjection(tensors, m.TextConfig,
+					layerPrefix+".moe.experts", "up_proj", m.NumExperts)
+				downStacked := collectExpertProjection(tensors, m.TextConfig,
+					layerPrefix+".moe.experts", "down_proj", m.NumExperts)
+
+				if gateStacked == nil && upStacked == nil {
+					// Try fused gate_up_proj format — split along axis 1 (out-dim).
+					// For quantized weights, also split scales and biases.
+					gateUpStacked := collectExpertProjection(tensors, m.TextConfig,
+						layerPrefix+".moe.experts", "gate_up_proj", m.NumExperts)
+					if gateUpStacked != nil {
+						dims := gateUpStacked.Weight.Dims()
+						if len(dims) >= 2 {
+							mid := int32(dims[1] / 2)
+							gateStacked = &stackedExpertResult{
+								Weight:    sliceAxis1(gateUpStacked.Weight, 0, mid),
+								Bits:      gateUpStacked.Bits,
+								GroupSize: gateUpStacked.GroupSize,
+								Mode:      gateUpStacked.Mode,
+							}
+							upStacked = &stackedExpertResult{
+								Weight:    sliceAxis1(gateUpStacked.Weight, mid, int32(dims[1])),
+								Bits:      gateUpStacked.Bits,
+								GroupSize: gateUpStacked.GroupSize,
+								Mode:      gateUpStacked.Mode,
+							}
+							if gateUpStacked.Scales != nil {
+								sDims := gateUpStacked.Scales.Dims()
+								sMid := int32(sDims[1] / 2)
+								gateStacked.Scales = sliceAxis1(gateUpStacked.Scales, 0, sMid)
+								upStacked.Scales = sliceAxis1(gateUpStacked.Scales, sMid, int32(sDims[1]))
+							}
+							if gateUpStacked.Biases != nil {
+								bDims := gateUpStacked.Biases.Dims()
+								bMid := int32(bDims[1] / 2)
+								gateStacked.Biases = sliceAxis1(gateUpStacked.Biases, 0, bMid)
+								upStacked.Biases = sliceAxis1(gateUpStacked.Biases, bMid, int32(bDims[1]))
+							}
+						}
+					}
+				}
+
+				if gateStacked == nil || upStacked == nil || downStacked == nil {
+					return fmt.Errorf("layer %d: missing MoE expert weights", i)
+				}
+				// Use GatherQMM if all projections have quantized weights.
+				if gateStacked.Scales != nil && upStacked.Scales != nil && downStacked.Scales != nil {
+					moe.GateWeightQ = gateStacked.Weight
+					moe.GateScales = gateStacked.Scales
+					moe.GateBiases = gateStacked.Biases
+					moe.UpWeightQ = upStacked.Weight
+					moe.UpScales = upStacked.Scales
+					moe.UpBiases = upStacked.Biases
+					moe.DownWeightQ = downStacked.Weight
+					moe.DownScales = downStacked.Scales
+					moe.DownBiases = downStacked.Biases
+					moe.UseQuantized = true
+					moe.GateGroupSize = gateStacked.GroupSize
+					moe.GateBits = gateStacked.Bits
+					moe.UpGroupSize = upStacked.GroupSize
+					moe.UpBits = upStacked.Bits
+					moe.DownGroupSize = downStacked.GroupSize
+					moe.DownBits = downStacked.Bits
+					moe.QuantMode = gateStacked.Mode
+					moe.DownQuantMode = downStacked.Mode
+				} else {
+					// Unquantized: transpose for GatherMM (expects [experts, in, out]).
+					moe.GateWeight = transposeForGatherMM(gateStacked.Weight)
+					moe.UpWeight = transposeForGatherMM(upStacked.Weight)
+					moe.DownWeight = transposeForGatherMM(downStacked.Weight)
+				}
+			}
+			layer.MoE = moe
+
+			// Additional norms for MoE dual-path.
+			if w := tensors[layerPrefix+".post_feedforward_layernorm_1.weight"]; w != nil {
+				layer.PostFFNorm1 = nn.NewRMSNorm(w, m.RMSNormEps)
+			}
+			if w := tensors[layerPrefix+".post_feedforward_layernorm_2.weight"]; w != nil {
+				layer.PostFFNorm2 = nn.NewRMSNorm(w, m.RMSNormEps)
+			}
+			if w := tensors[layerPrefix+".pre_feedforward_layernorm_2.weight"]; w != nil {
+				layer.PreFFNorm2 = nn.NewRMSNorm(w, m.RMSNormEps)
+			}
+
+			if layer.PostFFNorm1 == nil || layer.PostFFNorm2 == nil || layer.PreFFNorm2 == nil {
+				return fmt.Errorf("layer %d: missing MoE norm weights", i)
+			}
+		}
+
+		// PLE per-layer weights.
+		if m.HiddenSizePerLayer > 0 {
+			layer.PLE = &PLELayer{}
+			layer.PLE.InputGate = linears.Make(layerPrefix + ".per_layer_input_gate")
+			layer.PLE.Projection = linears.Make(layerPrefix + ".per_layer_projection")
+			if w := tensors[layerPrefix+".post_per_layer_input_norm.weight"]; w != nil {
+				layer.PLE.PostNorm = nn.NewRMSNorm(w, m.RMSNormEps)
+			}
+
+			if layer.PLE.InputGate == nil || layer.PLE.Projection == nil || layer.PLE.PostNorm == nil {
+				return fmt.Errorf("layer %d: missing PLE weights", i)
+			}
+		}
+
+		// Validation.
+		if layer.InputNorm == nil {
+			return fmt.Errorf("layer %d: missing input_layernorm", i)
+		}
+		if layer.PostAttnNorm == nil {
+			return fmt.Errorf("layer %d: missing post_attention_layernorm", i)
+		}
+		if layer.PreFFNorm == nil {
+			return fmt.Errorf("layer %d: missing pre_feedforward_layernorm", i)
+		}
+		if layer.PostFFNorm == nil {
+			return fmt.Errorf("layer %d: missing post_feedforward_layernorm", i)
+		}
+		if layer.Attention.QProj == nil || layer.Attention.OProj == nil {
+			return fmt.Errorf("layer %d: missing attention q/o projections", i)
+		}
+		if layer.Attention.KProj == nil {
+			return fmt.Errorf("layer %d: missing attention k projection", i)
+		}
+		// VProj is nil for K=V full-attention layers (value_states = key_states).
+		useAltAttn := m.AttentionKEqV && !isSliding
+		if layer.Attention.VProj == nil && !useAltAttn {
+			return fmt.Errorf("layer %d: missing attention v projection", i)
+		}
+		if layer.Attention.QNorm == nil || layer.Attention.KNorm == nil {
+			return fmt.Errorf("layer %d: missing attention q/k norms", i)
+		}
+		if layer.MLP.GateProj == nil || layer.MLP.UpProj == nil || layer.MLP.DownProj == nil {
+			return fmt.Errorf("layer %d: missing mlp projections", i)
+		}
+
+		m.Layers[i] = layer
+	}
+
+	// Self-conditioning MLP (DiffusionGemma decoder phase). Tolerant of absence
+	// so the model still loads + runs an encoder-mode forward without it; the
+	// diffusion forward requires it. Try prefixed then bare names.
+	if pn := firstNonNil(tensors, prefix+"self_cond_pre_norm.weight", "self_cond_pre_norm.weight"); pn != nil {
+		sc := &SelfConditioning{PreNorm: nn.NewRMSNorm(pn, m.RMSNormEps)}
+		sc.Gate = firstLinear(linears, prefix+"self_cond_gate", "self_cond_gate")
+		sc.Up = firstLinear(linears, prefix+"self_cond_up", "self_cond_up")
+		sc.Down = firstLinear(linears, prefix+"self_cond_down", "self_cond_down")
+		if sc.Gate != nil && sc.Up != nil && sc.Down != nil {
+			m.SelfCond = sc
+		}
+	}
+
+	precomputeGemmaScaledWeights(m)
+	if m.NormScaled == nil {
+		return fmt.Errorf("missing precomputed final norm weight")
+	}
+
+	return nil
+}
+
+// firstLinear returns the first linear layer that resolves from the given base
+// names (each tried without the ".weight" suffix, matching LinearFactory.Make).
+func firstLinear(linears model.LinearFactory, names ...string) nn.LinearLayer {
+	for _, n := range names {
+		if l := linears.Make(n); l != nil {
+			return l
+		}
+	}
+	return nil
+}
+
+// forwardOpts selects the diffusion forward mode. A nil opts (or decoderPhase
+// false) runs the causal "encoder" pass used to prefill the prompt and to
+// commit a finalized canvas into the KV cache. decoderPhase runs the
+// bidirectional "decoder" pass over the canvas: canvas tokens attend
+// bidirectionally to one another and causally to the read-only cached prefix.
+type forwardOpts struct {
+	decoderPhase bool
+	// canvasStart is the absolute position of the first canvas token, i.e. the
+	// number of committed prefix tokens; canvasLen is the canvas width. Both
+	// position the bidirectional relaxation rectangle over the canvas.
+	canvasStart int32
+	canvasLen   int32
+	// selfCond is the previous denoising step's self-conditioning payload (nil on
+	// the first step). Only used in the decoder phase.
+	selfCond *SelfCond
+}
+
+// SelfCond is the previous denoising step's top-k self-conditioning payload, laid
+// out per canvas position: IDs[pos*K + j] / Probs[pos*K + j] for j in [0,K). It
+// feeds the decoder input transform (the soft probability-weighted embedding).
+type SelfCond struct {
+	IDs   []int32
+	Probs []float32
+	K     int
+}
+
+// Forward runs the causal pass (prompt prefill / canvas commit) and satisfies
+// base.Model. The denoising loop uses DecodeCanvas for the
+// bidirectional decoder pass.
+func (m *Model) Forward(b *batch.Batch, caches []cache.Cache) *mlx.Array {
+	return m.forward(b, caches, nil)
+}
+
+// DecodeCanvas runs one bidirectional denoising pass over a canvas of canvasLen
+// tokens whose first token sits at absolute position canvasStart. The canvas
+// attends bidirectionally to itself and causally to the cached prefix.
+func (m *Model) DecodeCanvas(b *batch.Batch, caches []cache.Cache, canvasStart, canvasLen int32) *mlx.Array {
+	return m.forward(b, caches, &forwardOpts{decoderPhase: true, canvasStart: canvasStart, canvasLen: canvasLen})
+}
+
+// CanvasCheckpoint records the committed-prefix state of every layer KV cache so
+// that the canvas K/V written during a denoising step can be discarded
+// afterwards, leaving the prefix (prompt + previously committed canvases)
+// intact. This mirrors the reference design: the decoder denoising pass rolls
+// back its own K/V each step, while the encoder pass commits a finalized canvas.
+//
+// It is part of the diffusion model API the denoising loop (in the runner)
+// drives: after the prefix is in the caches, call CheckpointPrefix once; for each
+// non-committing denoising step, append the canvas via DecodeCanvas then call
+// Rollback.
+type CanvasCheckpoint struct {
+	prefixLen int
+	snaps     []cache.Snapshot
+}
+
+// CheckpointPrefix snapshots the current (prefix) state of each cache. Call once,
+// after the prefix is written and before the first denoising step of a canvas.
+func CheckpointPrefix(caches []cache.Cache) *CanvasCheckpoint {
+	cp := &CanvasCheckpoint{snaps: make([]cache.Snapshot, len(caches))}
+	for i, c := range caches {
+		if c == nil {
+			continue
+		}
+		cp.prefixLen = c.Offset()
+		cp.snaps[i] = c.Snapshot(0)
+	}
+	return cp
+}
+
+// Rollback restores every cache to the checkpointed prefix, discarding canvas
+// K/V appended since. Returns false if any cache could not be rewound.
+func (cp *CanvasCheckpoint) Rollback(caches []cache.Cache) bool {
+	ok := true
+	for i, c := range caches {
+		if c == nil || i >= len(cp.snaps) {
+			continue
+		}
+		if !c.Restore(cp.snaps[i], cp.prefixLen) {
+			ok = false
+		}
+	}
+	return ok
+}
+
+// canvasMask builds the logical attention mask for a forward pass. The
+// encoder/causal pass uses a plain causal mask. The decoder pass relaxes
+// attention within the canvas [canvasStart, canvasStart+canvasLen) to be
+// bidirectional (every canvas token sees every other) while remaining causal to
+// the cached prefix. Construction is allocation-light (a causal flag plus a
+// relaxation rectangle); the additive bias tensor is materialized lazily by SDPA.
+func canvasMask(decoderPhase bool, canvasStart, canvasLen int32) nn.AttentionMask {
+	mask := nn.CausalMask()
+	if decoderPhase && canvasLen > 0 {
+		lo := int(canvasStart)
+		hi := int(canvasStart + canvasLen)
+		mask = mask.Relax(0, lo, hi, lo, hi)
+	}
+	return mask
+}
+
+func (m *Model) forward(b *batch.Batch, caches []cache.Cache, opts *forwardOpts) *mlx.Array {
+	dims := b.InputIDs.Dims()
+	B, L := int32(dims[0]), int32(dims[1])
+	positions := mlx.FromValues(b.SeqOffsets, len(b.SeqOffsets))
+	h := m.EmbedTokens.Forward(b.InputIDs)
+	h = mlx.MulScalar(h, m.EmbedScale)
+
+	decoderPhase := opts != nil && opts.decoderPhase
+
+	// Decoder (denoising) input transform: self-conditioning. The decoder always
+	// applies a scale-less input RMSNorm; when a previous step's self-cond payload
+	// is present it first adds the gated-MLP transform of the soft (probability-
+	// weighted) token embedding:
+	//   soft = (Σ_k probs · embed[ids]) · sqrt(n_embd)
+	//   h    = rms_norm( scaled_embed + sc_mlp( rms_norm(soft) ) )
+	// On the first step (no self-cond) this reduces to h = rms_norm(scaled_embed),
+	// matching the reference (step-1 soft is zero, so sc_mlp(...) is zero).
+	if decoderPhase {
+		var sc *mlx.Array
+		if opts.selfCond != nil && m.SelfCond != nil {
+			sc = m.computeSelfCond(opts.selfCond, B, L)
+		}
+		if sc != nil {
+			h = mlx.RMSNormFn(mlx.Add(h, sc), nil, m.RMSNormEps)
+		} else {
+			h = mlx.RMSNormFn(h, nil, m.RMSNormEps)
+		}
+	}
+
+	// Attention mask: causal by default. In the decoder phase the canvas
+	// attends bidirectionally to itself — a relaxation rectangle over the canvas
+	// positions — while staying causal to the cached prefix. Each cache's mask
+	// applier layers the per-layer sliding-window restriction on top.
+	var mask nn.AttentionMask
+	if decoderPhase {
+		mask = canvasMask(true, opts.canvasStart, opts.canvasLen)
+	} else {
+		mask = canvasMask(false, 0, 0)
+	}
+
+	// Compute PLE inputs if configured.
+	var perLayerInputs *mlx.Array
+	if m.HiddenSizePerLayer > 0 && m.EmbedTokensPerLayer != nil {
+		perLayerInputs = m.computePLEInputs(b.InputIDs, h)
+	}
+
+	// KV sharing: each donor layer stores its KVHistory here so later
+	// shared layers can reuse it in lieu of their own cache update.
+	var sharedKV map[int32]sharedHistory
+	if len(m.KVShareMap) > 0 {
+		sharedKV = make(map[int32]sharedHistory)
+	}
+
+	for i, layer := range m.Layers {
+		var c cache.Cache
+		if caches != nil && i < len(caches) {
+			c = caches[i]
+		}
+
+		// Extract per-layer PLE input for this layer.
+		var pleInput *mlx.Array
+		if perLayerInputs != nil {
+			pleInput = sliceLayerDim(perLayerInputs, int32(i), B, L, m.HiddenSizePerLayer)
+		}
+
+		// Get shared KV for this layer if it's a shared layer.
+		var donor *sharedHistory
+		if layer.KVShareDonor >= 0 {
+			if d, ok := sharedKV[layer.KVShareDonor]; ok {
+				donor = &d
+			}
+		}
+
+		var donorKV *sharedHistory
+		h, donorKV = layer.Forward(h, b, c, positions, B, L, m.TextConfig, pleInput, donor, mask)
+
+		// If this layer is a donor, store its cached KV for later shared layers.
+		if layer.IsDonor && donorKV != nil {
+			sharedKV[layer.LayerIdx] = *donorKV
+		}
+	}
+
+	return mlx.RMSNormFn(h, m.NormScaled, m.RMSNormEps)
+}
+
+func (m *Model) Unembed(x *mlx.Array) *mlx.Array {
+	logits := m.LMHead.Forward(x)
+
+	if m.FinalLogitSoftcapping > 0 {
+		cap := mlx.FromValue(m.FinalLogitSoftcapping).AsType(logits.DType())
+		logits = mlx.LogitSoftcap(logits, cap)
+	}
+
+	return suppressTokenLogits(logits, m.SuppressLogitBias)
+}
+
+func makeSuppressLogitBias(tokenIDs []int32, vocabSize int32) *mlx.Array {
+	if len(tokenIDs) == 0 || vocabSize <= 0 {
+		return nil
+	}
+
+	bias := make([]float32, int(vocabSize))
+	any := false
+	for _, tokenID := range tokenIDs {
+		if tokenID >= 0 && tokenID < vocabSize {
+			bias[tokenID] = float32(math.Inf(-1))
+			any = true
+		}
+	}
+	if !any {
+		return nil
+	}
+
+	return mlx.FromValues(bias, 1, 1, int(vocabSize))
+}
+
+func suppressTokenLogits(logits, bias *mlx.Array) *mlx.Array {
+	if bias == nil {
+		return logits
+	}
+
+	dims := logits.Dims()
+	if len(dims) != 3 {
+		return logits
+	}
+
+	return logits.Add(bias.AsType(logits.DType()))
+}
+
+func (m *Model) NumLayers() int {
+	return len(m.Layers)
+}
+
+func (m *Model) MaxContextLength() int {
+	return int(m.MaxPositionEmbeddings)
+}
+
+func (m *Model) Tokenizer() *tokenizer.Tokenizer {
+	return m.tok
+}
+
+// TokenEmbeddings returns the target model's scaled token embeddings for MTP.
+func (m *Model) TokenEmbeddings(inputIDs *mlx.Array) *mlx.Array {
+	return mlx.MulScalar(m.EmbedTokens.Forward(inputIDs), m.EmbedScale)
+}
+
+// NewCaches creates cache objects for layers that own KV state.
+func (m *Model) NewCaches() []cache.Cache {
+	cacheLayers := len(m.Layers)
+	for i, layer := range m.Layers {
+		if layer.KVShareDonor >= 0 {
+			cacheLayers = i
+			break
+		}
+	}
+
+	caches := make([]cache.Cache, cacheLayers)
+	for i, layer := range m.Layers[:cacheLayers] {
+		if m.SlidingWindow > 0 && layer.IsSliding {
+			caches[i] = cache.NewRotatingKVCache(int(m.SlidingWindow))
+		} else {
+			caches[i] = cache.NewKVCache()
+		}
+	}
+	return caches
+}
+
+// computePLEInputs computes per-layer embeddings and projections.
+// Returns shape [B, L, NumHiddenLayers, HiddenSizePerLayer].
+func (m *Model) computePLEInputs(tokens, h *mlx.Array) *mlx.Array {
+	dims := tokens.Dims()
+	B, L := int32(dims[0]), int32(dims[1])
+	pleScale := m.PLEScale
+	projScale := m.PLEProjScale
+
+	// Token-based per-layer embeddings: [B, L, NumLayers*PLEDim]
+	pleEmb := m.EmbedTokensPerLayer.Forward(tokens)
+	pleEmb = mlx.MulScalar(pleEmb, pleScale)
+	// Reshape to [B, L, NumLayers, PLEDim]
+	pleEmb = mlx.Reshape(pleEmb, B, L, m.NumHiddenLayers, m.HiddenSizePerLayer)
+
+	// Hidden-state projection: [B, L, NumLayers*PLEDim]
+	pleProj := m.PerLayerModelProj.Forward(h)
+	pleProj = mlx.MulScalar(pleProj, projScale)
+	// Reshape to [B, L, NumLayers, PLEDim]
+	pleProj = mlx.Reshape(pleProj, B, L, m.NumHiddenLayers, m.HiddenSizePerLayer)
+
+	// Apply per-layer projection norm (scale_shift=0.0, uses raw weight).
+	pleProj = mlx.RMSNormFn(pleProj, m.PerLayerProjNormWeight, m.RMSNormEps)
+
+	// Combine: (proj + emb) * 2^(-0.5)
+	combined := mlx.Add(pleProj, pleEmb)
+	combined = mlx.MulScalar(combined, m.PLECombineScale)
+
+	return combined
+}
+
+// sliceLayerDim extracts a single layer's PLE input from the combined tensor.
+// Input shape: [B, L, NumLayers, PLEDim], output shape: [B, L, PLEDim].
+func sliceLayerDim(combined *mlx.Array, layerIdx, B, L, pleDim int32) *mlx.Array {
+	sliced := mlx.SliceStartStop(
+		combined,
+		[]int32{0, 0, layerIdx, 0},
+		[]int32{B, L, layerIdx + 1, pleDim},
+	)
+	return mlx.Squeeze(sliced, 2)
+}
+
+func (l *DecoderLayer) Forward(x *mlx.Array, b *batch.Batch, c cache.Cache, positions *mlx.Array, B, L int32, cfg *TextConfig, pleInput *mlx.Array, donor *sharedHistory, mask nn.AttentionMask) (*mlx.Array, *sharedHistory) {
+	normed := mlx.RMSNormFn(x, l.InputNormScaled, cfg.RMSNormEps)
+	attnOut, kv := l.Attention.Forward(normed, b, c, positions, B, L, l.IsSliding, cfg, donor, mask)
+	attnOut = mlx.RMSNormFn(attnOut, l.PostAttnNormScaled, cfg.RMSNormEps)
+	h := mlx.Add(x, attnOut)
+
+	if l.Router != nil && l.MoE != nil {
+		// Dual-path: dense MLP + MoE, both normed separately, then combined.
+		residual := h
+
+		// Path 1: Dense MLP.
+		normed = mlx.RMSNormFn(h, l.PreFFNormScaled, cfg.RMSNormEps)
+		mlpOut := l.MLP.Forward(normed)
+		mlpOut = mlx.RMSNormFn(mlpOut, l.PostFFNorm1Scaled, cfg.RMSNormEps)
+
+		// Path 2: MoE.
+		scores, inds := l.Router.Forward(h, cfg)
+		normed2 := mlx.RMSNormFn(h, l.PreFFNorm2Scaled, cfg.RMSNormEps)
+		moeOut := l.MoE.Forward(normed2, scores, inds, cfg)
+		moeOut = mlx.RMSNormFn(moeOut, l.PostFFNorm2Scaled, cfg.RMSNormEps)
+
+		// Combine and apply outer post-norm.
+		combined := mlx.Add(mlpOut, moeOut)
+		combined = mlx.RMSNormFn(combined, l.PostFFNormScaled, cfg.RMSNormEps)
+		h = mlx.Add(residual, combined)
+	} else {
+		// Standard single MLP path.
+		normed = mlx.RMSNormFn(h, l.PreFFNormScaled, cfg.RMSNormEps)
+		mlpOut := l.MLP.Forward(normed)
+		mlpOut = mlx.RMSNormFn(mlpOut, l.PostFFNormScaled, cfg.RMSNormEps)
+		h = mlx.Add(h, mlpOut)
+	}
+
+	// PLE injection (after MLP residual).
+	if l.PLE != nil && pleInput != nil {
+		residual := h
+		gated := mlx.GeGLU(l.PLE.InputGate.Forward(h), pleInput)
+		projected := l.PLE.Projection.Forward(gated)
+		projected = mlx.RMSNormFn(projected, l.PLE.PostNormScaled, cfg.RMSNormEps)
+		h = mlx.Add(residual, projected)
+	}
+
+	// Per-layer output scale (full-attention layers). Both diffusion phases apply
+	// the decoder layer_scalar here: the reference's transformer body is identical
+	// across phases — only the input embedding (self-conditioning) and the
+	// attention mask differ.
+	if l.LayerScalar != nil {
+		h = mlx.Mul(h, l.LayerScalar)
+	}
+
+	return h, kv
+}
+
+func (a *Attention) Forward(x *mlx.Array, b *batch.Batch, c cache.Cache, positions *mlx.Array, B, L int32, isSliding bool, cfg *TextConfig, donor *sharedHistory, attnMask nn.AttentionMask) (*mlx.Array, *sharedHistory) {
+	// Determine head dim and scale based on layer type.
+	headDim := cfg.HeadDim
+	scale := cfg.SlidingScale
+	ropeDims := cfg.SlidingRopeDims
+	ropeBase := cfg.SlidingRopeBase
+	if !isSliding {
+		headDim = cfg.GlobalHeadDim
+		scale = cfg.FullScale
+		ropeDims = cfg.FullRopeDims
+		ropeBase = cfg.FullRopeBase
+	}
+
+	q := a.QProj.Forward(x)
+	q = mlx.Reshape(q, B, L, cfg.NumAttentionHeads, headDim)
+	q = mlx.Transpose(q, 0, 2, 1, 3)
+
+	// Apply Q norm.
+	q = mlx.RMSNormFn(q, a.QNormScaled, cfg.RMSNormEps)
+
+	var ropeFreqs *mlx.Array
+	if !isSliding {
+		ropeFreqs = cfg.FullRopeFreqs
+	}
+	q = mlx.RoPEWithFreqs(q, ropeDims, false, ropeBase, 1.0, positions, ropeFreqs)
+
+	kv := donor
+	if kv == nil {
+		// Determine KV head count: K=V full-attention layers use NumGlobalKeyValueHeads.
+		kvHeads := cfg.NumKeyValueHeads
+		if a.VProj == nil && !isSliding && cfg.NumGlobalKeyValueHeads > 0 {
+			kvHeads = cfg.NumGlobalKeyValueHeads
+		}
+
+		k := a.KProj.Forward(x)
+		k = mlx.Reshape(k, B, L, kvHeads, headDim)
+		k = mlx.Transpose(k, 0, 2, 1, 3)
+
+		var v *mlx.Array
+		if a.VProj != nil {
+			v = a.VProj.Forward(x)
+			v = mlx.Reshape(v, B, L, kvHeads, headDim)
+			v = mlx.Transpose(v, 0, 2, 1, 3)
+		} else {
+			// K=V: value_states = key_states (raw, before k_norm/rope).
+			v = k
+		}
+
+		// Apply K norm.
+		k = mlx.RMSNormFn(k, a.KNormScaled, cfg.RMSNormEps)
+
+		// Apply RoPE to K.
+		k = mlx.RoPEWithFreqs(k, ropeDims, false, ropeBase, 1.0, positions, ropeFreqs)
+
+		// Apply V norm (no learnable weight, pure RMS normalization).
+		v = mlx.RMSNormFn(v, nil, cfg.RMSNormEps)
+
+		// Update cache.
+		kv = &sharedHistory{}
+		if c != nil {
+			kv.history = c.(cache.Attention).Update(b, k, v)
+		} else {
+			kv.k, kv.v = k, v
+			if isSliding {
+				kv.mask = nn.SlidingWindowMask(b, k.Dim(2), int(cfg.SlidingWindow), q.DType())
+			}
+		}
+	}
+
+	var out *mlx.Array
+	if headDim > 128 && L > 1 && !mlx.MetalIsAvailable() {
+		// Manual attention for CUDA prefill with head_dim > 128.
+		// cuDNN SDPA requires head_dim <= 128, and the MLX CUDA SDPA vector
+		// kernel only handles L < 4 (generation). For prefill, we fall back
+		// to explicit matmul+softmax+matmul on CUDA.
+		var k, v *mlx.Array
+		mask := attnMask.Intersect(nn.QPaddingMask(b, q.DType()))
+		if kv.history != nil {
+			k, v = kv.history.K(), kv.history.V()
+			mask = kv.history.Mask(mask)
+		} else {
+			k, v = kv.k, kv.v
+			mask = mask.Intersect(nn.KPaddingMask(b, k.Dim(2), b.SeqQueryLens, q.DType()))
+			mask = mask.Intersect(kv.mask)
+		}
+		kvHeads := int32(k.Dim(1))
+		nRepeats := cfg.NumAttentionHeads / kvHeads
+		kLen := int32(k.Dim(2))
+		// AsArray returns [B, 1, L, K]; reshape to rank 5 so that
+		// right-to-left broadcast against scores [B, kvHeads,
+		// nRepeats, L, K] aligns the batch dim correctly.
+		maskArr := mlx.Reshape(mask.AsArray(b, int(kLen), q.DType()), B, 1, 1, L, kLen)
+
+		q = mlx.MulScalar(q, scale)
+		q = mlx.Reshape(q, B, kvHeads, nRepeats, L, headDim)
+		k = mlx.Reshape(k, B, kvHeads, 1, kLen, headDim)
+		v = mlx.Reshape(v, B, kvHeads, 1, kLen, headDim)
+
+		kT := mlx.Transpose(k, 0, 1, 2, 4, 3)
+		scores := mlx.Matmul(q, kT)
+		scores = mlx.Add(scores, maskArr)
+		scores = mlx.SoftmaxAxis(scores, -1, true)
+		out = mlx.Matmul(scores, v)
+		out = mlx.Reshape(out, B, cfg.NumAttentionHeads, L, headDim)
+	} else {
+		var opt nn.SDPAOption
+		mask := attnMask
+		if kv.history != nil {
+			opt = nn.WithKVHistory(kv.history)
+		} else {
+			opt = nn.WithKV(kv.k, kv.v, b.SeqQueryLens)
+			mask = mask.Intersect(kv.mask)
+		}
+		out = nn.ScaledDotProductAttention(b, q, scale, opt, nn.WithMask(mask))
+	}
+	out = mlx.Reshape(mlx.Transpose(out, 0, 2, 1, 3), B, L, cfg.NumAttentionHeads*headDim)
+	if !mlx.MetalIsAvailable() {
+		// Force contiguous layout before OProj on CUDA where matmul handles
+		// strided views differently. Metal handles them natively.
+		out = mlx.Contiguous(out, false)
+	}
+	return a.OProj.Forward(out), kv
+}
+
+func (m *MLP) Forward(x *mlx.Array) *mlx.Array {
+	gate := m.GateProj.Forward(x)
+	up := m.UpProj.Forward(x)
+	return m.DownProj.Forward(mlx.GeGLU(gate, up))
+}
+
+// Forward runs the router to select top-k experts per token.
+// Returns (scores [B*L, topK], indices [B*L, topK]).
+func (r *Router) Forward(x *mlx.Array, cfg *TextConfig) (*mlx.Array, *mlx.Array) {
+	dims := x.Dims()
+	BL := int32(dims[0]) * int32(dims[1])
+
+	// Flatten to [B*L, hidden].
+	xFlat := mlx.Reshape(x, BL, cfg.HiddenSize)
+
+	// Norm (no weight) -> scale by 1/sqrt(hidden_size) -> multiply by learnable scale.
+	normed := mlx.RMSNormFn(xFlat, nil, cfg.RMSNormEps)
+	normed = mlx.MulScalar(normed, cfg.RouterScale)
+	normed = mlx.Mul(normed, r.Scale)
+
+	// Project to expert scores: [B*L, num_experts].
+	expertScores := r.Proj.Forward(normed)
+
+	// Top-k selection via argpartition on negated scores.
+	neg := mlx.Neg(expertScores)
+	inds := mlx.Argpartition(neg, int(cfg.TopKExperts)-1, -1)
+	inds = mlx.SliceStartStop(
+		inds,
+		[]int32{0, 0},
+		[]int32{BL, cfg.TopKExperts},
+	)
+
+	// Softmax only over selected logits. This is equivalent to full softmax +
+	// gather + renormalize, but avoids normalizing over every expert.
+	scores := mlx.TakeAlongAxis(expertScores, inds, -1)
+	scores = mlx.SoftmaxAxis(scores, -1, true) // [B*L, topK]
+
+	return scores, inds
+}
+
+// Forward runs the MoE block using GatherQMM (quantized) or GatherMM (dense).
+// scores: [B*L, topK], inds: [B*L, topK], x: [B, L, hidden].
+func (m *MoEBlock) Forward(x *mlx.Array, scores, inds *mlx.Array, cfg *TextConfig) *mlx.Array {
+	dims := x.Dims()
+	B, L := int32(dims[0]), int32(dims[1])
+	topK := cfg.TopKExperts
+
+	// Flatten and prepare for expert dispatch.
+	xFlat := mlx.Reshape(x, B*L, 1, 1, cfg.HiddenSize)
+	idxFlat := mlx.Reshape(inds, B*L, topK)
+
+	// Sort indices for efficiency when batch is large enough.
+	// The sorted_indices flag tells GatherQMM the indices are pre-sorted,
+	// enabling coalesced memory access. Testing confirmed the sort is
+	// beneficial for prefill (2x faster with sort at 2048 tokens).
+	doSort := B*L >= 64
+	var invOrder *mlx.Array
+	n := B * L * topK
+
+	if doSort {
+		idxAll := mlx.Flatten(idxFlat)
+		order := mlx.Argsort(idxAll, 0)
+		invOrder = mlx.Argsort(order, 0)
+		xFlat = mlx.ExpandDims(mlx.Take(mlx.Squeeze(xFlat, 1), mlx.FloorDivideScalar(order, topK), 0), 1)
+		idxFlat = mlx.Reshape(mlx.Take(idxAll, order, 0), n, 1)
+	}
+
+	// Expert computation: gate+up followed by GELU and down.
+	// When gate+up are fused, we do 2 GatherQMM calls instead of 3.
+	var hidden, down *mlx.Array
+	if m.UseQuantized {
+		if m.UseFusedGateUp {
+			// Fused gate+up: single GatherQMM produces [B*L*topK, 1, 1, 2*intermediate]
+			gateUp := mlx.GatherQMM(xFlat, m.GateUpWeightQ, m.GateUpScales, m.GateUpBiases,
+				nil, idxFlat, true, m.GateUpGroupSize, m.GateUpBits, m.QuantMode, doSort)
+			// Split along last dim into gate and up
+			guDims := gateUp.Dims()
+			mid := int32(guDims[len(guDims)-1] / 2)
+			gate := mlx.SliceStartStop(gateUp,
+				[]int32{0, 0, 0, 0},
+				[]int32{int32(guDims[0]), int32(guDims[1]), int32(guDims[2]), mid})
+			up := mlx.SliceStartStop(gateUp,
+				[]int32{0, 0, 0, mid},
+				[]int32{int32(guDims[0]), int32(guDims[1]), int32(guDims[2]), int32(guDims[len(guDims)-1])})
+			hidden = mlx.GeGLU(gate, up)
+		} else {
+			gate := mlx.GatherQMM(xFlat, m.GateWeightQ, m.GateScales, m.GateBiases,
+				nil, idxFlat, true, m.GateGroupSize, m.GateBits, m.QuantMode, doSort)
+			up := mlx.GatherQMM(xFlat, m.UpWeightQ, m.UpScales, m.UpBiases,
+				nil, idxFlat, true, m.UpGroupSize, m.UpBits, m.QuantMode, doSort)
+			hidden = mlx.GeGLU(gate, up)
+		}
+		downMode := m.DownQuantMode
+		if downMode == "" {
+			downMode = m.QuantMode
+		}
+		down = mlx.GatherQMM(hidden, m.DownWeightQ, m.DownScales, m.DownBiases,
+			nil, idxFlat, true, m.DownGroupSize, m.DownBits, downMode, doSort)
+	} else {
+		if m.UseFusedGateUp && m.GateUpWeight != nil {
+			gateUp := mlx.GatherMM(xFlat, m.GateUpWeight, nil, idxFlat, doSort)
+			guDims := gateUp.Dims()
+			mid := int32(guDims[len(guDims)-1] / 2)
+			gate := mlx.SliceStartStop(gateUp,
+				[]int32{0, 0, 0, 0},
+				[]int32{int32(guDims[0]), int32(guDims[1]), int32(guDims[2]), mid})
+			up := mlx.SliceStartStop(gateUp,
+				[]int32{0, 0, 0, mid},
+				[]int32{int32(guDims[0]), int32(guDims[1]), int32(guDims[2]), int32(guDims[len(guDims)-1])})
+			hidden = mlx.GeGLU(gate, up)
+		} else {
+			gate := mlx.GatherMM(xFlat, m.GateWeight, nil, idxFlat, doSort)
+			up := mlx.GatherMM(xFlat, m.UpWeight, nil, idxFlat, doSort)
+			hidden = mlx.GeGLU(gate, up)
+		}
+		down = mlx.GatherMM(hidden, m.DownWeight, nil, idxFlat, doSort)
+	}
+
+	// Unsort if needed.
+	if doSort {
+		down = mlx.Reshape(mlx.Take(mlx.Squeeze(mlx.Squeeze(down, 2), 1), invOrder, 0), B*L, topK, cfg.HiddenSize)
+	} else {
+		down = mlx.Squeeze(down, 2)
+	}
+
+	// Reshape to [B*L, topK, hidden_size].
+	down = mlx.Reshape(down, B*L, topK, cfg.HiddenSize)
+
+	// Gather per-expert scales at selected indices: flatten inds, take, reshape back.
+	indsFlat := mlx.Reshape(inds, B*L*topK)
+	expertScales := mlx.Take(m.PerExpertScale, indsFlat, 0) // [B*L*topK]
+	expertScales = mlx.Reshape(expertScales, B*L, topK)     // [B*L, topK]
+	down = mlx.Mul(down, mlx.ExpandDims(expertScales, -1))
+
+	// Weight by dispatch scores and sum across experts (axis 1 = topK dim).
+	y := mlx.Sum(mlx.Mul(down, mlx.ExpandDims(scores, -1)), 1, false) // [B*L, hidden_size]
+
+	return mlx.Reshape(y, B, L, cfg.HiddenSize)
+}

--- a/x/models/diffusiongemma/diffusiongemma.go
+++ b/x/models/diffusiongemma/diffusiongemma.go
@@ -10,6 +10,13 @@
 // self-conditioning MLP, the per-layer encoder output scale, the diffusion
 // hyper-parameters, and (in later phases) the bidirectional canvas attention and
 // the denoising loop.
+//
+// This package copies the gemma4 transformer body rather than importing it, so
+// fixes to the gemma4 decoder must be mirrored here. Keep in sync: attention
+// (sliding/full heads, k==v on full layers, KV sharing), the dense/MoE FFN, the
+// RMSNorms, RoPE, PLE, and the logit softcap. Diffusion-only (no gemma4 twin):
+// computeSelfCond, the bidirectional canvas attention, and the denoising loop. A
+// shared package could replace the fork if maintainers prefer.
 package diffusiongemma
 
 import (

--- a/x/models/diffusiongemma/diffusiongemma_test.go
+++ b/x/models/diffusiongemma/diffusiongemma_test.go
@@ -1,0 +1,157 @@
+package diffusiongemma
+
+import (
+	"math"
+	"slices"
+	"testing"
+
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+)
+
+func TestCanvasMask(t *testing.T) {
+	// Encoder/causal pass: a plain causal mask.
+	if got := canvasMask(false, 0, 0); !got.IsCausal() {
+		t.Errorf("encoder mask: IsCausal() = false, want true")
+	}
+	// decoderPhase with a zero-width canvas degrades to causal (no relaxation).
+	if got := canvasMask(true, 10, 0); !got.IsCausal() {
+		t.Errorf("decoder mask, canvasLen=0: IsCausal() = false, want true (degrades to causal)")
+	}
+	// Decoder pass over a real canvas: relaxed (bidirectional within the canvas),
+	// so not pure-causal, but still a restrictive (non-zero) mask vs the prefix.
+	dec := canvasMask(true, 34, 256)
+	if dec.IsCausal() {
+		t.Errorf("decoder canvas mask: IsCausal() = true, want false (relaxed/bidirectional)")
+	}
+	if dec.IsZero() {
+		t.Errorf("decoder canvas mask: IsZero() = true, want false (prefix stays causal)")
+	}
+}
+
+func TestParseSuppressTokens(t *testing.T) {
+	got := parseSuppressTokens([]byte(`{"suppress_tokens":[258883,258882]}`))
+	want := []int32{258883, 258882}
+	if !slices.Equal(got, want) {
+		t.Fatalf("parseSuppressTokens() = %v, want %v", got, want)
+	}
+
+	if got := parseSuppressTokens([]byte(`{"eos_token_id":[1,106,50]}`)); got != nil {
+		t.Fatalf("parseSuppressTokens() without suppress_tokens = %v, want nil", got)
+	}
+}
+
+func TestParseDiffusionParams(t *testing.T) {
+	config := []byte(`{
+		"architectures": ["DiffusionGemmaForBlockDiffusion"],
+		"model_type": "diffusion_gemma",
+		"canvas_length": 256,
+		"text_config": {"hidden_size": 2816, "num_hidden_layers": 30}
+	}`)
+	genConfig := []byte(`{
+		"max_denoising_steps": 48,
+		"t_min": 0.4,
+		"t_max": 0.8,
+		"stability_threshold": 2,
+		"confidence_threshold": 0.005,
+		"sampler_config": {"entropy_bound": 0.1}
+	}`)
+
+	p := parseDiffusionParams(config, genConfig)
+
+	if p.CanvasLength != 256 {
+		t.Errorf("CanvasLength = %d, want 256", p.CanvasLength)
+	}
+	if p.MaxDenoisingSteps != 48 {
+		t.Errorf("MaxDenoisingSteps = %d, want 48", p.MaxDenoisingSteps)
+	}
+	if p.StabilityThreshold != 2 {
+		t.Errorf("StabilityThreshold = %d, want 2", p.StabilityThreshold)
+	}
+	for _, tc := range []struct {
+		name string
+		got  float32
+		want float32
+	}{
+		{"TMin", p.TMin, 0.4},
+		{"TMax", p.TMax, 0.8},
+		{"EntropyBound", p.EntropyBound, 0.1},
+		{"ConfidenceThreshold", p.ConfidenceThreshold, 0.005},
+	} {
+		if math.Abs(float64(tc.got-tc.want)) > 1e-6 {
+			t.Errorf("%s = %v, want %v", tc.name, tc.got, tc.want)
+		}
+	}
+}
+
+func TestParseDiffusionParamsMissingGenConfig(t *testing.T) {
+	// canvas_length still parses from root config; gen-config fields stay zero
+	// (the runner treats zero as "use built-in default").
+	p := parseDiffusionParams([]byte(`{"canvas_length": 128}`), nil)
+	if p.CanvasLength != 128 {
+		t.Errorf("CanvasLength = %d, want 128", p.CanvasLength)
+	}
+	if p.MaxDenoisingSteps != 0 || p.EntropyBound != 0 {
+		t.Errorf("expected zero gen-config defaults, got steps=%d entropy=%v", p.MaxDenoisingSteps, p.EntropyBound)
+	}
+}
+
+func TestParseTextConfigInfersAttentionKEqV(t *testing.T) {
+	cfg, err := parseTextConfig([]byte(`{
+		"architectures": ["DiffusionGemmaForBlockDiffusion"],
+		"text_config": {
+			"num_global_key_value_heads": 2,
+			"layer_types": ["sliding_attention", "full_attention"]
+		}
+	}`))
+	if err != nil {
+		t.Fatalf("parseTextConfig: %v", err)
+	}
+	if !cfg.AttentionKEqV {
+		t.Fatal("AttentionKEqV = false, want true when global KV heads are configured")
+	}
+}
+
+func TestNormalizeNativeDiffusionGemmaTensors(t *testing.T) {
+	embed := mlx.New("embed")
+	embedScales := mlx.New("embed_scales")
+	embedBiases := mlx.New("embed_biases")
+	norm := mlx.New("norm")
+	qProj := mlx.New("q_proj")
+	selfCondGate := mlx.New("self_cond_gate")
+	selfCondScales := mlx.New("self_cond_scales")
+	selfCondBiases := mlx.New("self_cond_biases")
+
+	tensors := map[string]*mlx.Array{
+		"model.decoder.embed_tokens.weight":                embed,
+		"model.decoder.embed_tokens.scales":                embedScales,
+		"model.decoder.embed_tokens.biases":                embedBiases,
+		"model.decoder.norm.weight":                        norm,
+		"model.decoder.layers.0.self_attn.q_proj.weight":   qProj,
+		"model.decoder.self_conditioning.gate_proj.weight": selfCondGate,
+		"model.decoder.self_conditioning.gate_proj.scales": selfCondScales,
+		"model.decoder.self_conditioning.gate_proj.biases": selfCondBiases,
+	}
+
+	normalizeNativeDiffusionGemmaTensors(tensors)
+
+	cases := map[string]*mlx.Array{
+		"model.embed_tokens.weight":              embed,
+		"model.embed_tokens.weight_scale":        embedScales,
+		"model.embed_tokens.weight_qbias":        embedBiases,
+		"model.norm.weight":                      norm,
+		"model.layers.0.self_attn.q_proj.weight": qProj,
+		"self_cond_gate.weight":                  selfCondGate,
+		"self_cond_gate.weight_scale":            selfCondScales,
+		"self_cond_gate.weight_qbias":            selfCondBiases,
+	}
+
+	for name, want := range cases {
+		if got := tensors[name]; got != want {
+			t.Fatalf("tensors[%q] = %p, want %p", name, got, want)
+		}
+	}
+
+	if got := resolveWeightPrefix(tensors); got != "model." {
+		t.Fatalf("resolveWeightPrefix() = %q, want %q", got, "model.")
+	}
+}

--- a/x/models/diffusiongemma/forward_metal_test.go
+++ b/x/models/diffusiongemma/forward_metal_test.go
@@ -1,0 +1,185 @@
+package diffusiongemma
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	xmodel "github.com/ollama/ollama/x/mlxrunner/model"
+	"github.com/ollama/ollama/x/mlxrunner/model/base"
+)
+
+func skipIfNoMLX(t *testing.T) {
+	t.Helper()
+	if err := mlx.CheckInit(); err != nil {
+		t.Skipf("MLX not available: %v", err)
+	}
+}
+
+// tinyArr builds a small deterministic weight of the given shape.
+func tinyArr(shape ...int) *mlx.Array {
+	n := 1
+	for _, d := range shape {
+		n *= d
+	}
+	data := make([]float32, n)
+	for i := range data {
+		data[i] = float32(math.Sin(float64(i)*0.1)) * 0.05
+	}
+	return mlx.FromValues(data, shape...)
+}
+
+// tiny model dims (MoE disabled to keep the synthetic weight set small; the MoE
+// path is inherited unchanged from gemma4).
+const (
+	tHidden  = 8
+	tLayers  = 2
+	tHeads   = 2
+	tKVHeads = 1
+	tHeadDim = 4
+	tVocab   = 16
+	tInterm  = 8
+	tCanvas  = 4
+)
+
+// newTinyModel builds and loads a tiny DiffusionGemma model with random weights.
+func newTinyModel(t *testing.T) *Model {
+	t.Helper()
+	cfgJSON := []byte(`{
+		"architectures": ["DiffusionGemmaForBlockDiffusion"],
+		"canvas_length": 4,
+		"text_config": {
+			"hidden_size": 8, "num_hidden_layers": 2, "intermediate_size": 8,
+			"num_attention_heads": 2, "num_key_value_heads": 1,
+			"head_dim": 4, "global_head_dim": 4, "vocab_size": 16,
+			"rms_norm_eps": 1e-6, "max_position_embeddings": 64,
+			"sliding_window": 0, "enable_moe_block": false,
+			"layer_types": ["full_attention","full_attention"],
+			"rope_parameters": {"full_attention": {"rope_theta": 10000.0}}
+		}
+	}`)
+	cfg, err := parseTextConfig(cfgJSON)
+	if err != nil {
+		t.Fatalf("parseTextConfig: %v", err)
+	}
+	cfg.QuantGroupSize, cfg.QuantBits, cfg.QuantMode = xmodel.QuantizationParams("")
+
+	tensors := map[string]*mlx.Array{
+		"embed_tokens.weight":       tinyArr(tVocab, tHidden),
+		"norm.weight":               tinyArr(tHidden),
+		"self_cond_pre_norm.weight": tinyArr(tHidden),
+		"self_cond_gate.weight":     tinyArr(tInterm, tHidden),
+		"self_cond_up.weight":       tinyArr(tInterm, tHidden),
+		"self_cond_down.weight":     tinyArr(tHidden, tInterm),
+	}
+	for i := range tLayers {
+		p := "layers." + itoa(i)
+		tensors[p+".input_layernorm.weight"] = tinyArr(tHidden)
+		tensors[p+".post_attention_layernorm.weight"] = tinyArr(tHidden)
+		tensors[p+".pre_feedforward_layernorm.weight"] = tinyArr(tHidden)
+		tensors[p+".post_feedforward_layernorm.weight"] = tinyArr(tHidden)
+		tensors[p+".self_attn.q_proj.weight"] = tinyArr(tHeads*tHeadDim, tHidden)
+		tensors[p+".self_attn.k_proj.weight"] = tinyArr(tKVHeads*tHeadDim, tHidden)
+		tensors[p+".self_attn.v_proj.weight"] = tinyArr(tKVHeads*tHeadDim, tHidden)
+		tensors[p+".self_attn.o_proj.weight"] = tinyArr(tHidden, tHeads*tHeadDim)
+		tensors[p+".self_attn.q_norm.weight"] = tinyArr(tHeadDim)
+		tensors[p+".self_attn.k_norm.weight"] = tinyArr(tHeadDim)
+		tensors[p+".mlp.gate_proj.weight"] = tinyArr(tInterm, tHidden)
+		tensors[p+".mlp.up_proj.weight"] = tinyArr(tInterm, tHidden)
+		tensors[p+".mlp.down_proj.weight"] = tinyArr(tHidden, tInterm)
+	}
+
+	m := &Model{Layers: make([]*DecoderLayer, tLayers), TextConfig: &cfg}
+	if err := m.LoadWeights(tensors); err != nil {
+		t.Fatalf("LoadWeights: %v", err)
+	}
+	if m.SelfCond == nil {
+		t.Fatal("self-conditioning MLP did not load")
+	}
+	// Mirror base.Weights: pin the model weights so the Diffuse loop's Sweep
+	// doesn't free them (production loads via base.Weights, which does this).
+	collected := mlx.Collect(m)
+	for _, arr := range collected {
+		mlx.Pin(arr)
+	}
+	mlx.Eval(collected...)
+	return m
+}
+
+// TestForwardMetal validates LoadWeights, both forward phases, the canvas mask,
+// the self-conditioning MLP, and Unembed end to end (shapes + finiteness).
+func TestForwardMetal(t *testing.T) {
+	skipIfNoMLX(t)
+	m := newTinyModel(t)
+	caches := m.NewCaches()
+
+	m.prefillPrompt([]int32{1, 2, 3}, caches)
+	nPast := 3
+
+	logits1 := m.decodeCanvasHostLogits([]int32{0, 0, 0, 0}, int32(nPast), nil, caches)
+	if len(logits1) != tCanvas*tVocab {
+		t.Fatalf("logits len = %d, want %d", len(logits1), tCanvas*tVocab)
+	}
+	assertFinite(t, "no-selfcond", logits1)
+
+	const k = 2
+	sc := &SelfCond{K: k, IDs: make([]int32, tCanvas*k), Probs: make([]float32, tCanvas*k)}
+	for j := range tCanvas {
+		sc.IDs[j*k], sc.IDs[j*k+1] = int32(j%tVocab), int32((j+1)%tVocab)
+		sc.Probs[j*k], sc.Probs[j*k+1] = 0.7, 0.3
+	}
+	logits2 := m.decodeCanvasHostLogits([]int32{0, 1, 2, 3}, int32(nPast), sc, caches)
+	assertFinite(t, "selfcond", logits2)
+	t.Logf("OK: prefill + 2 decoder passes (with self-cond) ran on Metal")
+}
+
+// TestDiffuseMetal validates the full denoising loop on Metal — in particular the
+// per-step cache checkpoint/rollback and multi-canvas commit (nil tokenizer => no
+// EOS, so it runs all canvases).
+func TestDiffuseMetal(t *testing.T) {
+	skipIfNoMLX(t)
+	m := newTinyModel(t)
+	cfg := base.DiffuseConfig{
+		Canvas: tCanvas, Steps: 3, MaxCanvases: 2, SelfCondK: 2,
+		StabilityThreshold: 1, TMin: 0.4, TMax: 0.8,
+		EntropyBound: 0.1, ConfidenceThreshold: 0.005, Seed: 7,
+	}
+	var got []int32
+	if err := m.Diffuse(context.Background(), []int32{1, 2, 3}, cfg, func(tok int32) error {
+		got = append(got, tok)
+		return nil
+	}); err != nil {
+		t.Fatalf("Diffuse: %v", err)
+	}
+	if len(got) != cfg.MaxCanvases*cfg.Canvas {
+		t.Fatalf("emitted %d tokens, want %d: %v", len(got), cfg.MaxCanvases*cfg.Canvas, got)
+	}
+	for _, tk := range got {
+		if tk < 0 || tk >= tVocab {
+			t.Errorf("token out of vocab: %d", tk)
+		}
+	}
+	t.Logf("OK: Diffuse loop (checkpoint/rollback + commit) ran on Metal, emitted %v", got)
+}
+
+func assertFinite(t *testing.T, label string, xs []float32) {
+	t.Helper()
+	for i, v := range xs {
+		if math.IsNaN(float64(v)) || math.IsInf(float64(v), 0) {
+			t.Fatalf("%s: non-finite at %d: %v", label, i, v)
+		}
+	}
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b []byte
+	for i > 0 {
+		b = append([]byte{byte('0' + i%10)}, b...)
+		i /= 10
+	}
+	return string(b)
+}

--- a/x/models/diffusiongemma/forward_metal_test.go
+++ b/x/models/diffusiongemma/forward_metal_test.go
@@ -117,20 +117,26 @@ func TestForwardMetal(t *testing.T) {
 	m.prefillPrompt([]int32{1, 2, 3}, caches)
 	nPast := 3
 
-	logits1 := m.decodeCanvasHostLogits([]int32{0, 0, 0, 0}, int32(nPast), nil, caches)
-	if len(logits1) != tCanvas*tVocab {
-		t.Fatalf("logits len = %d, want %d", len(logits1), tCanvas*tVocab)
-	}
-	assertFinite(t, "no-selfcond", logits1)
-
 	const k = 2
+	s1 := m.decodeCanvasSample([]int32{0, 0, 0, 0}, int32(nPast), nil, caches, 0.8, k, mlx.RandomKey(1))
+	if len(s1.argmax) != tCanvas || len(s1.entropy) != tCanvas || len(s1.scIDs) != tCanvas*k {
+		t.Fatalf("sample shapes: argmax=%d entropy=%d scIDs=%d", len(s1.argmax), len(s1.entropy), len(s1.scIDs))
+	}
+	assertFinite(t, "entropy-no-selfcond", s1.entropy)
+	assertFinite(t, "scProbs-no-selfcond", s1.scProbs)
+	for _, a := range s1.argmax {
+		if a < 0 || int(a) >= tVocab {
+			t.Fatalf("argmax out of vocab: %d", a)
+		}
+	}
+
 	sc := &SelfCond{K: k, IDs: make([]int32, tCanvas*k), Probs: make([]float32, tCanvas*k)}
 	for j := range tCanvas {
 		sc.IDs[j*k], sc.IDs[j*k+1] = int32(j%tVocab), int32((j+1)%tVocab)
 		sc.Probs[j*k], sc.Probs[j*k+1] = 0.7, 0.3
 	}
-	logits2 := m.decodeCanvasHostLogits([]int32{0, 1, 2, 3}, int32(nPast), sc, caches)
-	assertFinite(t, "selfcond", logits2)
+	s2 := m.decodeCanvasSample([]int32{0, 1, 2, 3}, int32(nPast), sc, caches, 0.8, k, mlx.RandomKey(2))
+	assertFinite(t, "entropy-selfcond", s2.entropy)
 	t.Logf("OK: prefill + 2 decoder passes (with self-cond) ran on Metal")
 }
 

--- a/x/models/diffusiongemma/sample_device.go
+++ b/x/models/diffusiongemma/sample_device.go
@@ -1,0 +1,94 @@
+package diffusiongemma
+
+import (
+	"github.com/ollama/ollama/x/mlxrunner/batch"
+	"github.com/ollama/ollama/x/mlxrunner/cache"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+)
+
+// decodeCanvasSample runs one bidirectional denoising forward, unembeds, and
+// computes the per-position reductions (argmax, entropy, self-cond top-k, and
+// the multinomial draw) ON-DEVICE, returning only the small host arrays: the
+// [canvasLen*vocab] logits never cross to the host and the per-vocab math runs on
+// the GPU instead of a single-threaded Go loop over a host-materialized copy.
+// key seeds the multinomial draw.
+func (m *Model) decodeCanvasSample(canvas []int32, nPast int32, selfCond *SelfCond, caches []cache.Cache, temp float32, scK int, key *mlx.Array) canvasSample {
+	hidden := m.forward(&batch.Batch{
+		InputIDs:     mlx.FromValues(canvas, 1, len(canvas)),
+		SeqOffsets:   []int32{nPast},
+		SeqQueryLens: []int32{int32(len(canvas))},
+	}, caches, &forwardOpts{
+		decoderPhase: true,
+		canvasStart:  nPast,
+		canvasLen:    int32(len(canvas)),
+		selfCond:     selfCond,
+	})
+
+	vocab := int(m.VocabSize)
+	logits := mlx.Reshape(m.Unembed(hidden).AsType(mlx.DTypeFloat32), int32(len(canvas)), int32(vocab))
+	return sampleCanvasDevice(logits, len(canvas), vocab, temp, scK, key)
+}
+
+// sampleCanvasDevice computes the per-position step results from on-device,
+// already-softcapped logits ([canvasLen, vocab]). It mirrors sampleCanvas (the
+// host reference) exactly for the deterministic outputs (argmax, entropy,
+// self-cond top-k); the multinomial draw uses MLX's key-based RNG, so it differs
+// from the host inverse-CDF draw but samples from the same temperature softmax.
+func sampleCanvasDevice(logits *mlx.Array, canvasLen, vocab int, temp float32, scK int, key *mlx.Array) canvasSample {
+	if temp <= 0 {
+		temp = 1
+	}
+	if scK < 1 {
+		scK = 1
+	}
+	if scK > vocab {
+		scK = vocab
+	}
+
+	scaled := logits
+	if temp != 1 {
+		scaled = mlx.DivScalar(logits, temp)
+	}
+
+	// Entropy H = -Σ p·ln p with p = softmax(scaled). Using the log-sum-exp,
+	// ln p = scaled - lse, so H = lse - Σ p·scaled (a numerically stable form).
+	lse := scaled.LogsumexpAxis(-1, true)            // [L,1]
+	p := mlx.Exp(mlx.Sub(scaled, lse))               // [L,V] softmax
+	pScaled := mlx.Sum(mlx.Mul(p, scaled), -1, true) // [L,1]
+	entropy := mlx.Reshape(mlx.Sub(lse, pScaled), int32(canvasLen))
+
+	// Argmax (committed token) and the unordered top-k self-cond ids, both via
+	// argpartition on the negated logits (smallest-of-negated == largest).
+	neg := scaled.Negative()
+	argmax := neg.ArgpartitionAxis(0, -1).Slice(mlx.Slice(), mlx.Slice(0, 1)).AsType(mlx.DTypeInt32) // [L,1]
+	topkU := neg.ArgpartitionAxis(scK-1, -1).Slice(mlx.Slice(), mlx.Slice(0, scK))                   // [L,scK] (U32)
+	topkProbs := p.TakeAlongAxis(topkU, -1)                                                          // [L,scK]
+	topkIDs := topkU.AsType(mlx.DTypeInt32)
+
+	// Multinomial draw per position (used to renoise accepted positions).
+	sampled := scaled.CategoricalWithKey(-1, key).AsType(mlx.DTypeInt32) // [L]
+
+	mlx.Eval(entropy, argmax, topkIDs, topkProbs, sampled)
+
+	ent := entropy.Floats()
+	for i, e := range ent {
+		if e < 0 {
+			ent[i] = 0 // guard tiny negative from fp error, matching the host path
+		}
+	}
+	return canvasSample{
+		entropy: ent,
+		argmax:  intsToInt32(argmax.Ints()),
+		sampled: intsToInt32(sampled.Ints()),
+		scIDs:   intsToInt32(topkIDs.Ints()),
+		scProbs: topkProbs.Floats(),
+	}
+}
+
+func intsToInt32(in []int) []int32 {
+	out := make([]int32, len(in))
+	for i, v := range in {
+		out[i] = int32(v)
+	}
+	return out
+}

--- a/x/models/diffusiongemma/sample_device_test.go
+++ b/x/models/diffusiongemma/sample_device_test.go
@@ -1,0 +1,56 @@
+package diffusiongemma
+
+import (
+	"math"
+	"math/rand"
+	"sort"
+	"testing"
+
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+)
+
+// TestSampleCanvasDeviceMatchesHost checks the on-device sampler reproduces the
+// host reference for the deterministic outputs (argmax, entropy, self-cond
+// top-k). The multinomial draw uses MLX's RNG, so it is only range-checked.
+func TestSampleCanvasDeviceMatchesHost(t *testing.T) {
+	skipIfNoMLX(t)
+
+	const (
+		L     = 5
+		vocab = 64
+		scK   = 4
+		temp  = float32(0.8)
+	)
+
+	// Distinct, varied logits so argmax / top-k ordering is unambiguous.
+	data := make([]float32, L*vocab)
+	for i := range data {
+		data[i] = float32(math.Sin(float64(i)*0.37))*3 + float32(math.Cos(float64(i)*0.131))*2
+	}
+
+	host := sampleCanvas(data, L, vocab, temp, scK, rand.New(rand.NewSource(1)))
+	dev := sampleCanvasDevice(mlx.FromValues(data, L, vocab), L, vocab, temp, scK, mlx.RandomKey(42))
+
+	for j := range L {
+		if dev.argmax[j] != host.argmax[j] {
+			t.Errorf("argmax[%d]: device=%d host=%d", j, dev.argmax[j], host.argmax[j])
+		}
+		if d := math.Abs(float64(dev.entropy[j] - host.entropy[j])); d > 0.02 {
+			t.Errorf("entropy[%d]: device=%g host=%g (|d|=%g)", j, dev.entropy[j], host.entropy[j], d)
+		}
+		if dev.sampled[j] < 0 || int(dev.sampled[j]) >= vocab {
+			t.Errorf("sampled[%d]=%d out of range", j, dev.sampled[j])
+		}
+
+		// Top-k probs as sorted-descending sets (device top-k is unordered).
+		dp := append([]float32(nil), dev.scProbs[j*scK:(j+1)*scK]...)
+		hp := append([]float32(nil), host.scProbs[j*scK:(j+1)*scK]...)
+		sort.Slice(dp, func(a, b int) bool { return dp[a] > dp[b] })
+		sort.Slice(hp, func(a, b int) bool { return hp[a] > hp[b] })
+		for k := range scK {
+			if d := math.Abs(float64(dp[k] - hp[k])); d > 1e-3 {
+				t.Errorf("scProbs[%d] rank %d: device=%g host=%g", j, k, dp[k], hp[k])
+			}
+		}
+	}
+}

--- a/x/models/diffusiongemma/sampling.go
+++ b/x/models/diffusiongemma/sampling.go
@@ -1,0 +1,226 @@
+package diffusiongemma
+
+import (
+	"math"
+	"math/rand"
+	"sort"
+)
+
+// This file implements the host-side block-diffusion sampling kernels, ported
+// from the llama.cpp reference (PR #24427, diffusion-gemma-cli.cpp full-softmax
+// host path). They operate on plain Go slices of host-materialized logits so the
+// algorithm — the tricky part — is unit-testable without a Metal device. The MLX
+// forward passes that produce the logits live in the model forward.
+//
+// Key facts that drive this design (verified against the reference):
+//   - There is NO mask token. A canvas is initialized to uniformly random token
+//     ids; "remasking" means renoising rejected positions with fresh random ids.
+//   - Position acceptance is ENTROPY-BOUND prefix selection (sort positions by
+//     entropy ascending, accept a prefix while the running entropy sum stays
+//     <= entropy_bound), NOT confidence/top-k unmasking.
+//   - The committed/emitted tokens are the per-position ARGMAX of the final
+//     settled step, not the multinomially sampled canvas.
+//   - Logits handed in here are already final-softcapped by the model's Unembed.
+
+// tempAt returns the linear temperature for a denoising step. curStep counts
+// DOWN from nSteps to 1, so step nSteps yields tMax and step 1 yields
+// tMin + (tMax-tMin)/nSteps (the tMin floor is the asymptote, never reached —
+// matching the reference exactly).
+func tempAt(curStep, nSteps int, tMin, tMax float32) float32 {
+	if nSteps <= 0 {
+		return tMax
+	}
+	return tMin + (tMax-tMin)*float32(curStep)/float32(nSteps)
+}
+
+// numCanvases returns how many autoregressive canvases (blocks) to generate for
+// the requested number of predicted tokens. Defaults to 1 when nPredict <= 0.
+func numCanvases(nPredict, canvasLen int) int {
+	if canvasLen <= 0 {
+		return 1
+	}
+	if nPredict <= 0 {
+		return 1
+	}
+	return max((nPredict+canvasLen-1)/canvasLen, 1)
+}
+
+// randomCanvas fills a fresh canvas with uniformly random token ids in
+// [0, vocab).
+func randomCanvas(rng *rand.Rand, canvasLen, vocab int) []int32 {
+	c := make([]int32, canvasLen)
+	for i := range c {
+		c[i] = int32(rng.Intn(vocab))
+	}
+	return c
+}
+
+// canvasSample holds the per-position results of one denoising step.
+type canvasSample struct {
+	entropy []float32 // per-position Shannon entropy of the temperature softmax
+	sampled []int32   // per-position multinomial draw
+	argmax  []int32   // per-position argmax (the committed/emitted candidate)
+	scIDs   []int32   // self-cond top-k token ids, laid out [pos*k + j]
+	scProbs []float32 // self-cond top-k probs, same layout
+}
+
+// sampleCanvas computes, per canvas position, the temperature-softmax entropy, a
+// multinomial sample, the argmax, and the top-k (id, prob) self-conditioning
+// payload. logits is row-major [canvasLen*vocab] and already softcapped. This is
+// the full-softmax host path; it is O(canvasLen*vocab) and intentionally simple
+// (perf — moving this on-device — is a later concern).
+func sampleCanvas(logits []float32, canvasLen, vocab int, temp float32, scK int, rng *rand.Rand) canvasSample {
+	if temp <= 0 {
+		temp = 1
+	}
+	if scK < 1 {
+		scK = 1
+	}
+	if scK > vocab {
+		scK = vocab
+	}
+	out := canvasSample{
+		entropy: make([]float32, canvasLen),
+		sampled: make([]int32, canvasLen),
+		argmax:  make([]int32, canvasLen),
+		scIDs:   make([]int32, canvasLen*scK),
+		scProbs: make([]float32, canvasLen*scK),
+	}
+
+	for j := range canvasLen {
+		row := logits[j*vocab : (j+1)*vocab]
+
+		// max(logit/temp) for numerical stability, and the argmax token.
+		amax := 0
+		maxScaled := float32(math.Inf(-1))
+		for v, lg := range row {
+			s := lg / temp
+			if s > maxScaled {
+				maxScaled = s
+				amax = v
+			}
+		}
+
+		// Unnormalized softmax p[v] = exp(logit/temp - maxScaled), and its sum.
+		// Accumulate entropy via sum(p) and sum(p*log p), normalized at the end:
+		//   H = ln(sum) - (1/sum) * sum(p * ln p_unnorm)   ... computed directly below.
+		var sum float64
+		var plogp float64 // sum p*ln(p) over unnormalized p
+		for _, lg := range row {
+			p := math.Exp(float64(lg/temp - maxScaled))
+			sum += p
+			if p > 0 {
+				plogp += p * math.Log(p)
+			}
+		}
+		// Normalized entropy: H = -sum (p/Z) ln(p/Z) = ln Z - (1/Z) sum p ln p.
+		entropy := math.Log(sum) - plogp/sum
+		if entropy < 0 {
+			entropy = 0 // guard tiny negative from fp error
+		}
+		out.entropy[j] = float32(entropy)
+		out.argmax[j] = int32(amax)
+
+		// Multinomial draw via inverse CDF over unnormalized p; fall back to amax.
+		r := rng.Float64() * sum
+		acc := 0.0
+		sampled := amax
+		for v, lg := range row {
+			acc += math.Exp(float64(lg/temp - maxScaled))
+			if acc >= r {
+				sampled = v
+				break
+			}
+		}
+		out.sampled[j] = int32(sampled)
+
+		// Top-k by scaled logit, with full-normalized softmax probs, for self-cond.
+		fillTopK(row, temp, maxScaled, float32(sum), scK, out.scIDs[j*scK:(j+1)*scK], out.scProbs[j*scK:(j+1)*scK])
+	}
+	return out
+}
+
+// fillTopK writes the top-k token ids (by logit) and their normalized softmax
+// probabilities into ids/probs. Naive (sorts all vocab indices); fine for tests
+// and the reference host path, optimized later.
+func fillTopK(row []float32, temp, maxScaled, sum float32, k int, ids []int32, probs []float32) {
+	idx := make([]int, len(row))
+	for i := range idx {
+		idx[i] = i
+	}
+	sort.Slice(idx, func(a, b int) bool { return row[idx[a]] > row[idx[b]] })
+	for t := range k {
+		v := idx[t]
+		ids[t] = int32(v)
+		probs[t] = float32(math.Exp(float64(row[v]/temp-maxScaled))) / sum
+	}
+}
+
+// entropyBoundAccept selects which positions to commit this step: positions
+// sorted by entropy ascending are accepted while the running entropy sum stays
+// <= bound. The bound is tested BEFORE adding the current position's entropy
+// (matching the reference's off-by-one), so the last accepted position may push
+// the sum past the bound.
+func entropyBoundAccept(entropy []float32, bound float32) []bool {
+	n := len(entropy)
+	order := make([]int, n)
+	for i := range order {
+		order[i] = i
+	}
+	sort.Slice(order, func(a, b int) bool { return entropy[order[a]] < entropy[order[b]] })
+
+	accept := make([]bool, n)
+	var prefix float32
+	for _, idx := range order {
+		if prefix <= bound {
+			accept[idx] = true
+			prefix += entropy[idx]
+		} else {
+			break
+		}
+	}
+	return accept
+}
+
+// stableAndConfident is the per-canvas early-stop test. stable means the
+// full-canvas argmax is unchanged from the previous step (for stabThresh==1; a
+// stabThresh of 0 means always-stable). confident means the mean per-position
+// entropy is below confThresh. prevArgmax is nil on the first step (never stable).
+func stableAndConfident(argmax, prevArgmax []int32, entropy []float32, confThresh float32, stabThresh int) bool {
+	stable := stabThresh == 0 || int32sEqual(argmax, prevArgmax)
+	if !stable {
+		return false
+	}
+	var sum float32
+	for _, e := range entropy {
+		sum += e
+	}
+	mean := sum / float32(max(len(entropy), 1))
+	return mean < confThresh
+}
+
+// renoise produces the next-step canvas: accepted positions keep their sampled
+// token, the rest are overwritten with fresh uniformly random tokens.
+func renoise(sampled []int32, accept []bool, rng *rand.Rand, vocab int) []int32 {
+	next := make([]int32, len(sampled))
+	for i := range sampled {
+		if accept[i] {
+			next[i] = sampled[i]
+		} else {
+			next[i] = int32(rng.Intn(vocab))
+		}
+	}
+	return next
+}
+
+func int32sEqual(a, b []int32) bool {
+	if len(a) != len(b) || b == nil {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/x/models/diffusiongemma/sampling_test.go
+++ b/x/models/diffusiongemma/sampling_test.go
@@ -1,0 +1,140 @@
+package diffusiongemma
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+func TestTempAt(t *testing.T) {
+	const nSteps = 48
+	tMin, tMax := float32(0.4), float32(0.8)
+	if got := tempAt(nSteps, nSteps, tMin, tMax); math.Abs(float64(got-tMax)) > 1e-6 {
+		t.Errorf("tempAt(nSteps) = %v, want tMax=%v", got, tMax)
+	}
+	// Step 1 is the tMin floor + one increment, NOT tMin exactly (matches reference).
+	want1 := tMin + (tMax-tMin)/float32(nSteps)
+	if got := tempAt(1, nSteps, tMin, tMax); math.Abs(float64(got-want1)) > 1e-6 {
+		t.Errorf("tempAt(1) = %v, want %v", got, want1)
+	}
+	if got := tempAt(nSteps/2, nSteps, tMin, tMax); got <= tMin || got >= tMax {
+		t.Errorf("tempAt(mid) = %v, want in (%v,%v)", got, tMin, tMax)
+	}
+}
+
+func TestNumCanvases(t *testing.T) {
+	cases := []struct{ nPredict, canvas, want int }{
+		{0, 256, 1},
+		{-5, 256, 1},
+		{1, 256, 1},
+		{256, 256, 1},
+		{257, 256, 2},
+		{1024, 256, 4},
+	}
+	for _, c := range cases {
+		if got := numCanvases(c.nPredict, c.canvas); got != c.want {
+			t.Errorf("numCanvases(%d,%d) = %d, want %d", c.nPredict, c.canvas, got, c.want)
+		}
+	}
+}
+
+func TestEntropyBoundAccept(t *testing.T) {
+	// Distinct entropies: accept the ascending prefix while the running sum is
+	// <= bound when tested (so the last accepted may exceed it).
+	// [0.0, 0.15, 0.3], bound 0.1: accept 0.0 (sum->0), accept 0.15 (0<=0.1, sum->0.15),
+	// reject 0.3 (0.15>0.1). -> [true, true, false].
+	got := entropyBoundAccept([]float32{0.0, 0.15, 0.3}, 0.1)
+	want := []bool{true, true, false}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("entropyBoundAccept = %v, want %v", got, want)
+		}
+	}
+
+	// All-zero entropy: every position accepted regardless of bound.
+	for _, b := range entropyBoundAccept([]float32{0, 0, 0, 0}, 0.1) {
+		if !b {
+			t.Fatalf("all-zero entropy should accept everything")
+		}
+	}
+
+	// The off-by-one: a single high-entropy position with bound 0 is still
+	// accepted (bound tested before adding), but the next is not.
+	got = entropyBoundAccept([]float32{0.5, 0.5}, 0.0)
+	if !got[0] && !got[1] {
+		t.Fatalf("expected exactly one accepted with bound 0, got %v", got)
+	}
+	if got[0] && got[1] {
+		t.Fatalf("expected exactly one accepted with bound 0, got %v", got)
+	}
+}
+
+func TestStableAndConfident(t *testing.T) {
+	lowEnt := []float32{0.001, 0.001}
+	highEnt := []float32{0.5, 0.5}
+	am := []int32{3, 7}
+
+	if stableAndConfident(am, nil, lowEnt, 0.005, 1) {
+		t.Error("first step (prevArgmax nil) must not be stable")
+	}
+	if !stableAndConfident(am, []int32{3, 7}, lowEnt, 0.005, 1) {
+		t.Error("equal argmax + low entropy should be stable&confident")
+	}
+	if stableAndConfident(am, []int32{3, 9}, lowEnt, 0.005, 1) {
+		t.Error("changed argmax should not be stable")
+	}
+	if stableAndConfident(am, []int32{3, 7}, highEnt, 0.005, 1) {
+		t.Error("high entropy should not be confident")
+	}
+	if !stableAndConfident(am, nil, lowEnt, 0.005, 0) {
+		t.Error("stabThresh=0 should be always-stable (confident still required)")
+	}
+}
+
+func TestRenoise(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+	sampled := []int32{5, 6, 7, 8}
+	accept := []bool{true, false, true, false}
+	next := renoise(sampled, accept, rng, 100)
+	if next[0] != 5 || next[2] != 7 {
+		t.Errorf("accepted positions must keep their token, got %v", next)
+	}
+	for _, i := range []int{1, 3} {
+		if next[i] < 0 || next[i] >= 100 {
+			t.Errorf("renoised token %d out of range: %d", i, next[i])
+		}
+	}
+}
+
+func TestSampleCanvas(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	canvasLen, vocab := 2, 3
+	// pos0 peaked on token 0 (low entropy); pos1 uniform (max entropy ~ln3).
+	logits := []float32{
+		10, 0, 0,
+		0, 0, 0,
+	}
+	s := sampleCanvas(logits, canvasLen, vocab, 1.0, 2, rng)
+
+	if s.argmax[0] != 0 {
+		t.Errorf("argmax[0] = %d, want 0", s.argmax[0])
+	}
+	if s.entropy[0] >= s.entropy[1] {
+		t.Errorf("peaked position should have lower entropy: %v vs %v", s.entropy[0], s.entropy[1])
+	}
+	if math.Abs(float64(s.entropy[1])-math.Log(3)) > 1e-3 {
+		t.Errorf("uniform entropy = %v, want ~ln3=%v", s.entropy[1], math.Log(3))
+	}
+	// Top-1 self-cond prob at the peaked position should be ~1.
+	if s.scProbs[0] < 0.99 {
+		t.Errorf("peaked top-1 prob = %v, want ~1", s.scProbs[0])
+	}
+	if s.scIDs[0] != 0 {
+		t.Errorf("peaked top-1 id = %d, want 0", s.scIDs[0])
+	}
+	for j := range canvasLen {
+		if s.sampled[j] < 0 || s.sampled[j] >= int32(vocab) {
+			t.Errorf("sampled[%d] out of range: %d", j, s.sampled[j])
+		}
+	}
+}

--- a/x/models/diffusiongemma/selfcond_approx_test.go
+++ b/x/models/diffusiongemma/selfcond_approx_test.go
@@ -1,0 +1,148 @@
+package diffusiongemma
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+// fullSoftmaxSelfCondSoft is the REFERENCE self-conditioning "soft" vector that
+// the top-k path in computeSelfCond approximates. It matches the llama.cpp
+// reference (PR #24427): soft[j] = Σ_v softmax(logits[j]/temp)[v] · embed[v],
+// summed over the WHOLE vocabulary. Returned row-major [canvasLen*dim]. The
+// EmbedScale and the self-cond MLP that computeSelfCond applies afterwards are
+// identical for both paths, so they are omitted here — only `soft` differs.
+func fullSoftmaxSelfCondSoft(logits, embed []float32, canvasLen, vocab, dim int, temp float32) []float32 {
+	soft := make([]float32, canvasLen*dim)
+	for j := range canvasLen {
+		row := logits[j*vocab : (j+1)*vocab]
+		maxScaled := float32(math.Inf(-1))
+		for _, lg := range row {
+			if s := lg / temp; s > maxScaled {
+				maxScaled = s
+			}
+		}
+		var sum float64
+		for _, lg := range row {
+			sum += math.Exp(float64(lg/temp - maxScaled))
+		}
+		for v, lg := range row {
+			p := float32(math.Exp(float64(lg/temp-maxScaled)) / sum)
+			for d := range dim {
+				soft[j*dim+d] += p * embed[v*dim+d]
+			}
+		}
+	}
+	return soft
+}
+
+// topKSelfCondSoft is what computeSelfCond actually sums: only the top-k terms,
+// with the SAME normalized softmax probs (fillTopK / sample_device both divide by
+// the full softmax sum). It is therefore the exact truncation of
+// fullSoftmaxSelfCondSoft. Also returns the per-position captured probability mass.
+func topKSelfCondSoft(scIDs []int32, scProbs, embed []float32, canvasLen, scK, dim int) (soft, captured []float32) {
+	soft = make([]float32, canvasLen*dim)
+	captured = make([]float32, canvasLen)
+	for j := range canvasLen {
+		for t := range scK {
+			id := int(scIDs[j*scK+t])
+			pr := scProbs[j*scK+t]
+			captured[j] += pr
+			for d := range dim {
+				soft[j*dim+d] += pr * embed[id*dim+d]
+			}
+		}
+	}
+	return soft, captured
+}
+
+// TestSelfCondTopKApproximatesFullSoftmax documents and bounds the deliberate
+// top-k self-conditioning approximation in computeSelfCond. Because the top-k
+// probs are the normalized full-softmax probs (not renormalized), soft_topk is
+// the EXACT truncation of soft_full, so the error is exactly the dropped tail:
+//
+//	||soft_full - soft_topk|| = ||Σ_tail p·embed|| <= (1 - capturedMass) · maxEmbedNorm
+//
+// This bound holds for ANY distribution — proving the approximation is intentional
+// and bounded — and is TIGHT for the peaked distributions that converging
+// denoising settles into, where top-k (SelfCondK=32) captures ~all the mass.
+func TestSelfCondTopKApproximatesFullSoftmax(t *testing.T) {
+	const (
+		L     = 4
+		vocab = 512
+		dim   = 16
+		scK   = 32
+		temp  = float32(0.8)
+	)
+	rng := rand.New(rand.NewSource(7))
+
+	// Synthetic embedding table [vocab, dim] and its max row L2 norm.
+	embed := make([]float32, vocab*dim)
+	for i := range embed {
+		embed[i] = float32(rng.NormFloat64())
+	}
+	maxNorm := 0.0
+	for v := range vocab {
+		var n float64
+		for d := range dim {
+			e := float64(embed[v*dim+d])
+			n += e * e
+		}
+		maxNorm = math.Max(maxNorm, math.Sqrt(n))
+	}
+
+	mkLogits := func(peaked bool) []float32 {
+		lg := make([]float32, L*vocab)
+		for i := range lg {
+			lg[i] = float32(rng.NormFloat64())
+		}
+		if peaked {
+			for j := range L {
+				for range 3 { // a few sharply dominant tokens per position
+					lg[j*vocab+rng.Intn(vocab)] += 12
+				}
+			}
+		}
+		return lg
+	}
+
+	cases := []struct {
+		name        string
+		peaked      bool
+		minCaptured float32
+	}{
+		{"peaked (converging-denoising regime)", true, 0.99},
+		{"flat (worst case — only the general bound must hold)", false, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			logits := mkLogits(tc.peaked)
+			host := sampleCanvas(logits, L, vocab, temp, scK, rng)
+
+			full := fullSoftmaxSelfCondSoft(logits, embed, L, vocab, dim, temp)
+			topk, captured := topKSelfCondSoft(host.scIDs, host.scProbs, embed, L, scK, dim)
+
+			for j := range L {
+				var errNorm float64
+				for d := range dim {
+					e := float64(full[j*dim+d] - topk[j*dim+d])
+					errNorm += e * e
+				}
+				errNorm = math.Sqrt(errNorm)
+
+				// General bound: the truncation error never exceeds the dropped
+				// tail mass times the largest embedding norm.
+				bound := float64(1-captured[j])*maxNorm + 1e-3 // fp slack
+				if errNorm > bound {
+					t.Errorf("pos %d: error %.6g exceeds tail-mass bound %.6g (captured=%.4f)",
+						j, errNorm, bound, captured[j])
+				}
+				// Tightness: in the peaked regime top-k captures ~all the mass.
+				if captured[j] < tc.minCaptured {
+					t.Errorf("pos %d: top-%d captured only %.4f of mass (want >= %.2f)",
+						j, scK, captured[j], tc.minCaptured)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
MLX-only support for the diffusion-gemma block-diffusion architecture ([`google/diffusiongemma-26B-A4B-it`](https://huggingface.co/google/diffusiongemma-26B-A4B-it)). **Experimental / draft** for maintainer feedback per CONTRIBUTING (issue-first) — refs #16664.

### Scope
MLX runner / safetensors only (e.g. [`mlx-community/diffusiongemma-26B-A4B-it-4bit`](https://huggingface.co/mlx-community/diffusiongemma-26B-A4B-it-4bit)); GGUF + llama.cpp not covered (cf. llama.cpp #24427).

### What
The gemma4 26B-A4B MoE backbone run as a bidirectional block-diffusion denoiser over a fixed-size canvas (entropy-bound acceptance, prob-weighted self-conditioning, early stop, argmax committed per canvas). Adds `x/models/diffusiongemma`, a `base.DiffusionModel` + `DiffusionGenerationPipeline` in `x/mlxrunner`, and a `DiffusionGemmaForBlockDiffusion` import transform in `x/create`. Denoising steps come from the model default — the previously-proposed global `diffusion_steps` `api.Options` field was **dropped** (no public API change here).

### Notes for review
- **Context accounting:** the denoiser commits whole canvases, so the real budget is `len(prompt) + MaxCanvases*Canvas`, not the autoregressive `num_predict` that `Prepare` caps. `fitDiffusionCanvases` shrinks `MaxCanvases` to fit the context window (`TestFitDiffusionCanvases`).
- **Fork sync:** `x/models/diffusiongemma` is a literal source fork of `x/models/gemma4` (not an import), so gemma4 transformer changes (attention/KV-sharing, MoE FFN, RMSNorms, RoPE, PLE, softcap) must be re-synced by hand. Happy to extract a shared package instead if preferred.
- **Self-conditioning:** top-k (`SelfCondK`=32) is the exact truncation of the reference's full softmax, so the error is the dropped tail mass — bounded by `(1−captured)·max_embed_norm`, negligible once a canvas converges. Reference path + `TestSelfCondTopKApproximatesFullSoftmax` prove it; not bit-exact.
- **API semantics:** stop strings and logprobs are unsupported (canvas-based, argmax-committed); `num_predict` is a whole-canvas budget.

### Testing
`go test ./x/models/diffusiongemma ./x/create ./x/mlxrunner` green + Metal tiny-model forward. e2e on [`mlx-community/diffusiongemma-26B-A4B-it-4bit`](https://huggingface.co/mlx-community/diffusiongemma-26B-A4B-it-4bit) (`/api/generate`, `raw=false`, `num_predict=256`): *"capital of France"* → "The capital of France is Paris."; *"why is the sky blue"* → "The sky is blue because the Earth's atmosphere scatters blue light more than other colors."

Validated on one constrained Apple Silicon host (~14 GB model on 16 GB RAM, heavy paging); non-Mac MLX hosts, longer contexts, and other quantizations untested. The checkpoint emits a harmony reasoning format, so `num_predict` must reach the final channel or `response` comes back empty (truncated mid-thought).

### Related
#16741 (gemma-4 MLX support), #16728 (MLX memory cap — diffusion on constrained Macs relies on it to page instead of OOM).
