### PR TITLE
fix(progress): truncate rendered lines to terminal width to prevent ANSI drift

### DIFF
--- a/progress/bar.go
+++ b/progress/bar.go
@@ -132,6 +132,9 @@ func (b *Bar) String() string {
 	var mid strings.Builder
 	// add 5 extra spaces: 2 boundary characters and 1 space at each end
 	f := termWidth - pre.Len() - suf.Len() - 5
+	if f < 0 {
+		f = 0
+	}
 	n := int(float64(f) * b.percent() / 100)
 
 	mid.WriteString(" ▕")

--- a/progress/progress.go
+++ b/progress/progress.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"golang.org/x/term"
 )
@@ -91,8 +92,9 @@ func (p *Progress) Add(key string, state State) {
 }
 
 func (p *Progress) render() {
-	_, termHeight, err := term.GetSize(int(os.Stderr.Fd()))
+	termWidth, termHeight, err := term.GetSize(int(os.Stderr.Fd()))
 	if err != nil {
+		termWidth = defaultTermWidth
 		termHeight = defaultTermHeight
 	}
 
@@ -117,7 +119,13 @@ func (p *Progress) render() {
 	// render progress lines
 	maxHeight := min(len(p.states), termHeight)
 	for i := len(p.states) - maxHeight; i < len(p.states); i++ {
-		fmt.Fprint(p.w, p.states[i].String(), "\033[K")
+		line := p.states[i].String()
+		// truncate to terminal width to prevent line wrapping, which breaks
+		// ANSI cursor-up positioning and causes duplicate lines
+		if w := utf8.RuneCountInString(line); w > termWidth {
+			line = string([]rune(line)[:termWidth])
+		}
+		fmt.Fprint(p.w, line, "\033[K")
 		if i < len(p.states)-1 {
 			fmt.Fprint(p.w, "\n")
 		}

--- a/progress/spinner.go
+++ b/progress/spinner.go
@@ -2,9 +2,13 @@ package progress
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"sync/atomic"
 	"time"
+	"unicode/utf8"
+
+	"golang.org/x/term"
 )
 
 type Spinner struct {
@@ -57,6 +61,16 @@ func (s *Spinner) String() string {
 		spinner := s.parts[s.value]
 		sb.WriteString(spinner)
 		sb.WriteString(" ")
+	}
+
+	// truncate to terminal width to prevent line wrapping
+	if line := sb.String(); len(line) > 0 {
+		if termWidth, _, err := term.GetSize(int(os.Stderr.Fd())); err == nil {
+			if w := utf8.RuneCountInString(line); w > termWidth {
+				line = string([]rune(line)[:termWidth])
+			}
+		}
+		return line
 	}
 
 	return sb.String()


### PR DESCRIPTION
## Fixes #13900

### Root cause
The `render()` function in `progress/progress.go` only retrieves terminal **height**, not **width**. When rendered lines exceed terminal width, they wrap to the next visual line. The `\033[A` (cursor up) ANSI escape moves up by **logical** lines (`len(states)`), not visual lines, so it cannot correctly reposition after wrapping. Each subsequent render drifts further down, causing "pulling manifest" to appear on a new line every 100ms.

### Changes

**progress/progress.go** — `render()` now gets `termWidth` alongside `termHeight`. Each state string is truncated to `termWidth` runes (UTF-8-safe) before being written, preventing line wrapping entirely.

**progress/bar.go** — Guard against negative bar-fill width `f` when terminal is too narrow for the fixed text (message + transfer rate + ETA).

**progress/spinner.go** — Defense-in-depth: terminal-width truncation in `Spinner.String()` for callers that invoke it directly.

### Verification
- `go build ./progress/` ✅
- `go build ./cmd/ollama/` ✅
- `go vet ./progress/` ✅

### Notes
- Truncation uses `utf8.RuneCountInString` + `[]rune` slicing to avoid splitting multi-byte characters.
- On terminals wide enough to fit all output, truncation is a no-op — behavior is identical to before.
- This is a pragmatic fix for the reported issue. A follow-up could replace rune-count truncation with display-width measurement (e.g., `go-runewidth`) for full Unicode correctness, or implement visual-line counting to preserve all progress info even on narrow terminals.