### PR TITLE
x/mlxrunner: cap MLX wired/cache memory to fit the host

### DIFF
--- a/x/mlxrunner/memory_test.go
+++ b/x/mlxrunner/memory_test.go
@@ -1,0 +1,32 @@
+package mlxrunner
+
+import "testing"
+
+const gib = 1 << 30
+
+func TestPlanWired(t *testing.T) {
+	if got, want := planWired(64*gib), 64*gib*4/5; got != want {
+		t.Errorf("planWired(64 GiB) = %d, want %d", got, want)
+	}
+}
+
+func TestPlanCache(t *testing.T) {
+	cases := []struct {
+		name            string
+		modelSize, free int
+		want            int
+	}{
+		// free=16 GiB -> wired cap 12.8 GiB.
+		{"model fits leaves default", 10 * gib, 16 * gib, 0},
+		{"model at cap leaves default", 12 * gib, 16 * gib, 0},
+		{"model overflows tightens", 14 * gib, 16 * gib, 16 * gib / 5},
+		{"unknown free leaves default", 14 * gib, 0, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := planCache(tc.modelSize, tc.free); got != tc.want {
+				t.Errorf("planCache(%d, %d) = %d, want %d", tc.modelSize, tc.free, got, tc.want)
+			}
+		})
+	}
+}

--- a/x/mlxrunner/mlx/memory.go
+++ b/x/mlxrunner/mlx/memory.go
@@ -87,3 +87,21 @@ type (
 func ClearCache() {
 	C.mlx_clear_cache()
 }
+
+// SetWiredLimit caps how much memory MLX keeps wired (resident and un-evictable).
+// Capping it below free RAM lets a model larger than free memory page from disk
+// instead of being OOM-killed. limit is in bytes; returns the previous limit.
+func SetWiredLimit(limit int) int {
+	var prev C.size_t
+	C.mlx_set_wired_limit(&prev, C.size_t(limit))
+	return int(prev)
+}
+
+// SetCacheLimit caps MLX's buffer reuse pool. A smaller pool trades reuse for a
+// lower resident footprint under memory pressure. limit is in bytes; returns the
+// previous limit.
+func SetCacheLimit(limit int) int {
+	var prev C.size_t
+	C.mlx_set_cache_limit(&prev, C.size_t(limit))
+	return int(prev)
+}

--- a/x/mlxrunner/server.go
+++ b/x/mlxrunner/server.go
@@ -13,12 +13,72 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/ollama/ollama/discover"
 	"github.com/ollama/ollama/envconfig"
+	"github.com/ollama/ollama/format"
 	"github.com/ollama/ollama/logutil"
 	"github.com/ollama/ollama/x/internal/mlxthread"
 	"github.com/ollama/ollama/x/mlxrunner/mlx"
 	"github.com/ollama/ollama/x/mlxrunner/sample"
 )
+
+// planWired returns the MLX wired (resident) cap in bytes for the given free RAM,
+// held below free memory so a model larger than free RAM pages from disk instead
+// of OOM-killing the runner.
+func planWired(free int) int {
+	return free * 4 / 5
+}
+
+// planCache returns the MLX cache limit in bytes for a model of modelSize against
+// the free RAM the host had at startup. The pool is tightened only when the model
+// did not fit under the wired cap (so it pages); a return of 0 leaves MLX's
+// default, so a resident model keeps full buffer reuse.
+func planCache(modelSize, startupFree int) int {
+	if modelSize > planWired(startupFree) {
+		return startupFree / 5
+	}
+	return 0
+}
+
+// configureMLXMemory caps MLX's wired footprint to the host's free RAM at startup
+// so that a model the scheduler has already admitted pages instead of MLX wiring
+// its whole resident set and OOM-killing the runner. This is a post-admission
+// safeguard only; it does not change the Client.Load fit check that governs
+// whether an oversized model is loaded at all. It returns the free RAM read
+// (0 if unavailable) for the post-load cache decision. Must run on the MLX thread.
+func configureMLXMemory() int {
+	mem, err := discover.GetCPUMem()
+	free := int(mem.FreeMemory)
+	if err != nil || free <= 0 {
+		return 0 // without a free-memory reading, keep MLX's defaults
+	}
+	wired := planWired(free)
+	if wired > 0 {
+		mlx.SetWiredLimit(wired)
+	}
+	slog.Info("capped MLX wired memory",
+		"free", format.HumanBytes2(uint64(free)),
+		"wired", format.HumanBytes2(uint64(wired)))
+	return free
+}
+
+// tuneMLXMemory tightens MLX's buffer cache once the model is loaded and its size
+// is known — but only when the model did not fit in the startup free RAM (so it
+// pages). A model that fit keeps MLX's default pool. Must run on the MLX thread.
+func tuneMLXMemory(startupFree int) {
+	if startupFree <= 0 {
+		return
+	}
+	modelSize := mlx.ActiveMemory()
+	cache := planCache(modelSize, startupFree)
+	if cache > 0 {
+		mlx.SetCacheLimit(cache)
+		slog.Info("tightened MLX cache (model exceeds free RAM)",
+			"model", format.HumanBytes2(uint64(modelSize)),
+			"free", format.HumanBytes2(uint64(startupFree)),
+			"cache", format.HumanBytes2(uint64(cache)))
+	}
+}
 
 func Execute(args []string) error {
 	slog.SetDefault(logutil.NewLogger(os.Stderr, envconfig.LogLevel()))
@@ -34,6 +94,7 @@ func Execute(args []string) error {
 	_ = flagSet.Bool("verbose", false, "Enable debug logging")
 	flagSet.Parse(args)
 
+	var startupFree int // free RAM at engine init, for the post-load cache decision
 	worker, err := mlxthread.Start("mlxrunner", func() error {
 		if err := mlx.CheckInit(); err != nil {
 			return fmt.Errorf("MLX not available: %w", err)
@@ -41,6 +102,7 @@ func Execute(args []string) error {
 
 		if mlx.GPUIsAvailable() {
 			mlx.SetDefaultDeviceGPU()
+			startupFree = configureMLXMemory()
 			slog.Info("MLX engine initialized", "MLX version", mlx.Version(), "device", "gpu")
 		} else {
 			slog.Info("MLX engine initialized", "MLX version", mlx.Version(), "device", "cpu")
@@ -64,7 +126,11 @@ func Execute(args []string) error {
 	}
 
 	if err := worker.Do(context.Background(), func() error {
-		return runner.Load(modelName)
+		if err := runner.Load(modelName); err != nil {
+			return err
+		}
+		tuneMLXMemory(startupFree)
+		return nil
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
Bounds the MLX runner's wired/cache footprint to the host's free memory so MLX's otherwise-unbounded pool doesn't push the runner into jetsam during inference.

### Why
The MLX runner doesn't cap MLX's wired/cache footprint. For a model the scheduler admits, MLX's runtime allocations (buffer cache, KV cache, intermediates) can grow the resident set past free memory and get the runner OOM-killed (jetsam) on memory-constrained Macs.

### What
- **At startup** (`configureMLXMemory`): read free RAM via `discover.GetCPUMem()` and cap MLX's wired (resident) limit at `free*0.8`.
- **After the model loads** (`tuneMLXMemory`): if the loaded model already uses most of free RAM, tighten MLX's buffer cache so runtime allocations stay within the host budget. A model that comfortably fits keeps MLX's default pool — no change for models that already run.
- `planWired` / `planCache` are pure helpers; `SetWiredLimit` / `SetCacheLimit` wrap `mlx_set_wired_limit` / `mlx_set_cache_limit`.

### Scope — post-admission only (by design)
This PR is intentionally scoped to **post-admission memory safety**: it reduces jetsam for a model that has already been admitted and reached the runner. It does **not** modify the admission path (`x/mlxrunner/client.go` `Client.Load` / the scheduler fit check) — that is a deliberate decision, not an oversight.

In practice on the Apple Silicon hosts this runner targets, the scheduler already admits a model larger than free RAM, so it reaches the runner; the cap is what then keeps MLX from jetsam-killing it mid-run. Making oversized admission *explicit and portable* — e.g. gating a relaxed fit check to unified/integrated memory, since paging doesn't apply to discrete GPUs — is a separate follow-up that needs validation across host types, and is out of scope here.

### Testing
Validated on a single Apple Silicon host (16 GiB): a 14.3 GiB model ([`mlx-community/diffusiongemma-26B-A4B-it-4bit`](https://huggingface.co/mlx-community/diffusiongemma-26B-A4B-it-4bit)) — which MLX's default unbounded pool would otherwise push into jetsam — was admitted, loaded under the cap (`capped MLX wired memory`, then `tightened MLX cache` once the loaded model size was known), and **ran inference to completion**. A model that comfortably fits is unaffected (keeps MLX's default pool). Further testing is welcome across host RAM / model sizes / quantizations.

### Related
This came out of the MLX-runner work behind #16740 (gemma-4 MLX) and #16664 (diffusion-gemma): the large checkpoints those efforts add are what surface the jetsam this caps. Sibling PRs: #16741 (gemma-4 MLX support) and #16722 (diffusion-gemma, which relies on this cap to page on memory-constrained Macs). Happy to split this into its own tracking issue if maintainers prefer.

