### PR TITLE
cmd: keep image paths with dotted parent dirs intact

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -609,7 +609,20 @@ func extractFileNames(input string) []string {
 	regexPattern := `(?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp|wav)\b`
 	re := regexp.MustCompile(regexPattern)
 
-	return re.FindAllString(input, -1)
+	matches := re.FindAllStringIndex(input, -1)
+	paths := make([]string, 0, len(matches))
+	lastEnd := -1
+	for _, match := range matches {
+		start, end := match[0], match[1]
+		if len(paths) > 0 && start == lastEnd && (input[start] == '/' || input[start] == '\\') {
+			paths[len(paths)-1] += input[start:end]
+		} else {
+			paths = append(paths, input[start:end])
+		}
+		lastEnd = end
+	}
+
+	return paths
 }
 
 func extractFileData(input string) (string, []api.ImageData, error) {

--- a/cmd/interactive_test.go
+++ b/cmd/interactive_test.go
@@ -64,6 +64,13 @@ d:\path with\spaces\thirteen.WEBP some ending
 	assert.Contains(t, res[12], "d:")
 }
 
+func TestExtractFilenamesParentDirectoryWithImageExtension(t *testing.T) {
+	input := `/tmp/directory.png/image.png`
+
+	res := extractFileNames(input)
+	assert.Equal(t, []string{input}, res)
+}
+
 // Ensure that file paths wrapped in single quotes are removed with the quotes.
 func TestExtractFileDataRemovesQuotedFilepath(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary
- keep adjacent path fragments together when an image extension appears in a parent directory name
- add regression coverage for paths like /tmp/directory.png/image.png

## Reproduction
Fixes #16680. Before this change, extractFileNames split /tmp/directory.png/image.png into /tmp/directory.png and /image.png, causing the CLI to try reading the parent directory as an image.

## Tests
- go test ./cmd -run TestExtractFilenamesParentDirectoryWithImageExtension -count=1
- go test ./cmd -run "TestExtractFilenames|TestExtractFilenamesParentDirectoryWithImageExtension" -count=1
- go test ./cmd
- git diff --check