### PR TITLE
cmd: preserve UNC image path prefixes

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -583,7 +583,13 @@ func NewCreateRequest(name string, opts runOptions) *api.CreateRequest {
 }
 
 func normalizeFilePath(fp string) string {
-	return strings.NewReplacer(
+	prefix := ""
+	if strings.HasPrefix(fp, `\\`) {
+		prefix = `\\`
+		fp = strings.TrimPrefix(fp, prefix)
+	}
+
+	return prefix + strings.NewReplacer(
 		"\\ ", " ", // Escaped space
 		"\\(", "(", // Escaped left parenthesis
 		"\\)", ")", // Escaped right parenthesis

--- a/cmd/interactive_test.go
+++ b/cmd/interactive_test.go
@@ -64,6 +64,12 @@ d:\path with\spaces\thirteen.WEBP some ending
 	assert.Contains(t, res[12], "d:")
 }
 
+func TestNormalizeFilePathPreservesUNCPathPrefix(t *testing.T) {
+	input := `\\Network\folder\photo.jpg`
+
+	assert.Equal(t, input, normalizeFilePath(input))
+}
+
 // Ensure that file paths wrapped in single quotes are removed with the quotes.
 func TestExtractFileDataRemovesQuotedFilepath(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary
- preserve leading UNC path prefixes when normalizing CLI image/audio file paths
- keep existing shell-escape normalization for the rest of the path
- add regression coverage for \\Network\folder\photo.jpg

## Reproduction
Fixes #7553.

Before this change, normalizeFilePath("\\\\Network\\folder\\photo.jpg") collapsed the UNC prefix to "\\Network\\folder\\photo.jpg", causing network share paths to be read as invalid local-style paths.

## Tests
- go test ./cmd -run TestNormalizeFilePathPreservesUNCPathPrefix -count=1
- go test ./cmd
- git diff --check