### PR TITLE
x/agent: detect sibling cwd escapes

### DIFF
--- a/x/agent/approval.go
+++ b/x/agent/approval.go
@@ -344,7 +344,7 @@ func isCommandOutsideCwd(command string) bool {
 			// Check for absolute paths outside cwd
 			if filepath.IsAbs(arg) {
 				absPath := filepath.Clean(arg)
-				if !strings.HasPrefix(absPath, cwd) {
+				if !isPathWithin(absPath, cwd) {
 					return true
 				}
 				continue
@@ -355,7 +355,7 @@ func isCommandOutsideCwd(command string) bool {
 				// Resolve the path relative to cwd
 				absPath := filepath.Join(cwd, arg)
 				absPath = filepath.Clean(absPath)
-				if !strings.HasPrefix(absPath, cwd) {
+				if !isPathWithin(absPath, cwd) {
 					return true
 				}
 			}
@@ -363,7 +363,7 @@ func isCommandOutsideCwd(command string) bool {
 			// Check for home directory expansion
 			if strings.HasPrefix(arg, "~") {
 				home, err := os.UserHomeDir()
-				if err == nil && !strings.HasPrefix(home, cwd) {
+				if err == nil && !isPathWithin(home, cwd) {
 					return true
 				}
 			}
@@ -371,6 +371,15 @@ func isCommandOutsideCwd(command string) bool {
 	}
 
 	return false
+}
+
+func isPathWithin(path, root string) bool {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
 }
 
 // AllowlistKey generates the key for exact allowlist lookup.

--- a/x/agent/approval_test.go
+++ b/x/agent/approval_test.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -286,6 +288,19 @@ func TestApprovalManager_HierarchicalPrefixAllowlist_CrossPlatform(t *testing.T)
 	// Mixed slashes should also work
 	if !am.IsAllowed("bash", map[string]any{"command": "cat tools\\a/b\\c/deep.go"}) {
 		t.Error("expected mixed slash path to be allowed via hierarchical prefix")
+	}
+}
+
+func TestIsCommandOutsideCwdDetectsSiblingDirectory(t *testing.T) {
+	tmp := t.TempDir()
+	cwd := filepath.Join(tmp, "workspace")
+	if err := os.Mkdir(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+
+	if !isCommandOutsideCwd("cat ../workspace2/secret.txt") {
+		t.Fatal("expected sibling directory path to be detected as outside cwd")
 	}
 }
 


### PR DESCRIPTION
## Summary
- replace string-prefix cwd containment checks with filepath.Rel boundary checks
- apply the boundary check to relative parent paths, absolute paths, and home expansion warnings
- add regression coverage for ../workspace2 paths escaping a workspace named workspace

## Reproduction
The approval warning path previously treated a cleaned path such as /tmp/.../workspace2/secret.txt as inside /tmp/.../workspace because it used strings.HasPrefix. That misses sibling directories whose names share the cwd prefix.

## Tests
- go test ./x/agent -run TestIsCommandOutsideCwdDetectsSiblingDirectory -count=1
- go test ./x/agent
- git diff --check