### PR TITLE
cmd: extract complete file paths with dotted directories

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -606,10 +606,16 @@ func extractFileNames(input string) []string {
 	// Regex to match file paths starting with optional drive letter, / ./ \ or .\ and include escaped or unescaped spaces (\ or %20)
 	// and followed by more characters and a file extension
 	// This will capture non filename strings, but we'll check for file existence to remove mismatches
-	regexPattern := `(?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp|wav)\b`
+	regexPattern := `((?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp|wav))(?:$|["'\s.,;:!?)\]>` + "`" + `])`
 	re := regexp.MustCompile(regexPattern)
 
-	return re.FindAllString(input, -1)
+	matches := re.FindAllStringSubmatch(input, -1)
+	fileNames := make([]string, 0, len(matches))
+	for _, match := range matches {
+		fileNames = append(fileNames, match[1])
+	}
+
+	return fileNames
 }
 
 func extractFileData(input string) (string, []api.ImageData, error) {

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -606,7 +606,7 @@ func extractFileNames(input string) []string {
 	// Regex to match file paths starting with optional drive letter, / ./ \ or .\ and include escaped or unescaped spaces (\ or %20)
 	// and followed by more characters and a file extension
 	// This will capture non filename strings, but we'll check for file existence to remove mismatches
-	regexPattern := `((?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp|wav))(?:$|["'\s.,;:!?)\]><&|` + "`" + `])`
+	regexPattern := `((?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp|wav))(?:$|["'\s.,;:!?)\]><&|+}` + "`" + `])`
 	re := regexp.MustCompile(regexPattern)
 
 	matches := re.FindAllStringSubmatch(input, -1)

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -606,7 +606,7 @@ func extractFileNames(input string) []string {
 	// Regex to match file paths starting with optional drive letter, / ./ \ or .\ and include escaped or unescaped spaces (\ or %20)
 	// and followed by more characters and a file extension
 	// This will capture non filename strings, but we'll check for file existence to remove mismatches
-	regexPattern := `((?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp|wav))(?:$|["'\s.,;:!?)\]>` + "`" + `])`
+	regexPattern := `((?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp|wav))(?:$|["'\s.,;:!?)\]><&|` + "`" + `])`
 	re := regexp.MustCompile(regexPattern)
 
 	matches := re.FindAllStringSubmatch(input, -1)

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -606,13 +606,18 @@ func extractFileNames(input string) []string {
 	// Regex to match file paths starting with optional drive letter, / ./ \ or .\ and include escaped or unescaped spaces (\ or %20)
 	// and followed by more characters and a file extension
 	// This will capture non filename strings, but we'll check for file existence to remove mismatches
-	regexPattern := `((?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp|wav))(?:$|["'\s.,;:!?)\]><&|+}` + "`" + `])`
+	regexPattern := "((?:[a-zA-Z]:)?(?:\\./|/|\\\\)[\\S\\\\ ]+?\\.(?i:jpg|jpeg|png|webp|wav))(?:$|[\"'\\s.,;:!?)\\]><&|+}`]|[^\\x00-\\x7F])"
 	re := regexp.MustCompile(regexPattern)
 
-	matches := re.FindAllStringSubmatch(input, -1)
-	fileNames := make([]string, 0, len(matches))
-	for _, match := range matches {
-		fileNames = append(fileNames, match[1])
+	var fileNames []string
+	for offset := 0; offset < len(input); {
+		match := re.FindStringSubmatchIndex(input[offset:])
+		if match == nil {
+			break
+		}
+		fileNameEnd := offset + match[3]
+		fileNames = append(fileNames, input[offset+match[2]:fileNameEnd])
+		offset = fileNameEnd
 	}
 
 	return fileNames

--- a/cmd/interactive_test.go
+++ b/cmd/interactive_test.go
@@ -71,6 +71,14 @@ d:\path with\spaces\thirteen.WEBP some ending
 	res = extractFileNames(input)
 	assert.Equal(t, []string{"/tmp/photo.png", "/tmp/wrapped.jpg", "/tmp/a.png", "/tmp/b.png", "/tmp/quoted.webp", "/tmp/single.jpeg", "/tmp/backtick.wav"}, res)
 
+	input = `compare /tmp/a.png&/tmp/b.png | /tmp/c.webp</tmp/d.jpg`
+	res = extractFileNames(input)
+	assert.Equal(t, []string{"/tmp/a.png", "/tmp/b.png", "/tmp/c.webp", "/tmp/d.jpg"}, res)
+
+	input = `compare C:\tmp\a.png&D:\tmp\b.jpg`
+	res = extractFileNames(input)
+	assert.Equal(t, []string{`C:\tmp\a.png`, `D:\tmp\b.jpg`}, res)
+
 	input = `C:\images\dir.png\nested.jpg`
 	res = extractFileNames(input)
 	assert.Equal(t, []string{`C:\images\dir.png\nested.jpg`}, res)

--- a/cmd/interactive_test.go
+++ b/cmd/interactive_test.go
@@ -75,9 +75,17 @@ d:\path with\spaces\thirteen.WEBP some ending
 	res = extractFileNames(input)
 	assert.Equal(t, []string{"/tmp/a.png", "/tmp/b.png", "/tmp/c.webp", "/tmp/d.jpg"}, res)
 
+	input = `compare /tmp/a.png+/tmp/b.png`
+	res = extractFileNames(input)
+	assert.Equal(t, []string{"/tmp/a.png", "/tmp/b.png"}, res)
+
 	input = `compare C:\tmp\a.png&D:\tmp\b.jpg`
 	res = extractFileNames(input)
 	assert.Equal(t, []string{`C:\tmp\a.png`, `D:\tmp\b.jpg`}, res)
+
+	input = `attach {/tmp/photo.png} and {C:\tmp\a.png}`
+	res = extractFileNames(input)
+	assert.Equal(t, []string{"/tmp/photo.png", `C:\tmp\a.png`}, res)
 
 	input = `C:\images\dir.png\nested.jpg`
 	res = extractFileNames(input)

--- a/cmd/interactive_test.go
+++ b/cmd/interactive_test.go
@@ -79,6 +79,14 @@ d:\path with\spaces\thirteen.WEBP some ending
 	res = extractFileNames(input)
 	assert.Equal(t, []string{"/tmp/a.png", "/tmp/b.png"}, res)
 
+	input = `describe /tmp/cat.png请描述 and /tmp/dog.jpg。`
+	res = extractFileNames(input)
+	assert.Equal(t, []string{"/tmp/cat.png", "/tmp/dog.jpg"}, res)
+
+	input = `/tmp/a.png./b.png`
+	res = extractFileNames(input)
+	assert.Equal(t, []string{"/tmp/a.png", "./b.png"}, res)
+
 	input = `compare C:\tmp\a.png&D:\tmp\b.jpg`
 	res = extractFileNames(input)
 	assert.Equal(t, []string{`C:\tmp\a.png`, `D:\tmp\b.jpg`}, res)

--- a/cmd/interactive_test.go
+++ b/cmd/interactive_test.go
@@ -62,6 +62,18 @@ d:\path with\spaces\thirteen.WEBP some ending
 	assert.Contains(t, res[11], "c:")
 	assert.Contains(t, res[12], "thirteen.WEBP")
 	assert.Contains(t, res[12], "d:")
+
+	input = `./directory.png/image.png /tmp/audio.wav/nested.wav`
+	res = extractFileNames(input)
+	assert.Equal(t, []string{"./directory.png/image.png", "/tmp/audio.wav/nested.wav"}, res)
+
+	input = `See /tmp/photo.png. (/tmp/wrapped.jpg) /tmp/a.png,/tmp/b.png "` + `/tmp/quoted.webp"` + `" '` + `/tmp/single.jpeg` + `' ` + "`/tmp/backtick.wav`"
+	res = extractFileNames(input)
+	assert.Equal(t, []string{"/tmp/photo.png", "/tmp/wrapped.jpg", "/tmp/a.png", "/tmp/b.png", "/tmp/quoted.webp", "/tmp/single.jpeg", "/tmp/backtick.wav"}, res)
+
+	input = `C:\images\dir.png\nested.jpg`
+	res = extractFileNames(input)
+	assert.Equal(t, []string{`C:\images\dir.png\nested.jpg`}, res)
 }
 
 // Ensure that file paths wrapped in single quotes are removed with the quotes.

--- a/x/imagegen/cli.go
+++ b/x/imagegen/cli.go
@@ -520,12 +520,17 @@ func displayImageInTerminal(imagePath string) bool {
 // extractFileNames finds image file paths in the input string.
 func extractFileNames(input string) []string {
 	// Regex to match file paths with image extensions
-	regexPattern := `((?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp))(?:$|["'\s.,;:!?)\]><&|+}` + "`" + `])`
+	regexPattern := "((?:[a-zA-Z]:)?(?:\\./|/|\\\\)[\\S\\\\ ]+?\\.(?i:jpg|jpeg|png|webp))(?:$|[\"'\\s.,;:!?)\\]><&|+}`]|[^\\x00-\\x7F])"
 	re := regexp.MustCompile(regexPattern)
-	matches := re.FindAllStringSubmatch(input, -1)
-	fileNames := make([]string, 0, len(matches))
-	for _, match := range matches {
-		fileNames = append(fileNames, match[1])
+	var fileNames []string
+	for offset := 0; offset < len(input); {
+		match := re.FindStringSubmatchIndex(input[offset:])
+		if match == nil {
+			break
+		}
+		fileNameEnd := offset + match[3]
+		fileNames = append(fileNames, input[offset+match[2]:fileNameEnd])
+		offset = fileNameEnd
 	}
 
 	return fileNames

--- a/x/imagegen/cli.go
+++ b/x/imagegen/cli.go
@@ -520,7 +520,7 @@ func displayImageInTerminal(imagePath string) bool {
 // extractFileNames finds image file paths in the input string.
 func extractFileNames(input string) []string {
 	// Regex to match file paths with image extensions
-	regexPattern := `((?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp))(?:$|["'\s.,;:!?)\]>` + "`" + `])`
+	regexPattern := `((?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp))(?:$|["'\s.,;:!?)\]><&|` + "`" + `])`
 	re := regexp.MustCompile(regexPattern)
 	matches := re.FindAllStringSubmatch(input, -1)
 	fileNames := make([]string, 0, len(matches))

--- a/x/imagegen/cli.go
+++ b/x/imagegen/cli.go
@@ -520,7 +520,7 @@ func displayImageInTerminal(imagePath string) bool {
 // extractFileNames finds image file paths in the input string.
 func extractFileNames(input string) []string {
 	// Regex to match file paths with image extensions
-	regexPattern := `((?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp))(?:$|["'\s.,;:!?)\]><&|` + "`" + `])`
+	regexPattern := `((?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp))(?:$|["'\s.,;:!?)\]><&|+}` + "`" + `])`
 	re := regexp.MustCompile(regexPattern)
 	matches := re.FindAllStringSubmatch(input, -1)
 	fileNames := make([]string, 0, len(matches))

--- a/x/imagegen/cli.go
+++ b/x/imagegen/cli.go
@@ -520,9 +520,15 @@ func displayImageInTerminal(imagePath string) bool {
 // extractFileNames finds image file paths in the input string.
 func extractFileNames(input string) []string {
 	// Regex to match file paths with image extensions
-	regexPattern := `(?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp)\b`
+	regexPattern := `((?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp))(?:$|["'\s.,;:!?)\]>` + "`" + `])`
 	re := regexp.MustCompile(regexPattern)
-	return re.FindAllString(input, -1)
+	matches := re.FindAllStringSubmatch(input, -1)
+	fileNames := make([]string, 0, len(matches))
+	for _, match := range matches {
+		fileNames = append(fileNames, match[1])
+	}
+
+	return fileNames
 }
 
 // extractFileData extracts image data from file paths found in the input.

--- a/x/imagegen/cli_test.go
+++ b/x/imagegen/cli_test.go
@@ -15,9 +15,17 @@ func TestExtractFileNames(t *testing.T) {
 	res = extractFileNames(input)
 	assert.Equal(t, []string{"/tmp/a.png", "/tmp/b.png", "/tmp/c.webp", "/tmp/d.jpg"}, res)
 
+	input = `compare /tmp/a.png+/tmp/b.png`
+	res = extractFileNames(input)
+	assert.Equal(t, []string{"/tmp/a.png", "/tmp/b.png"}, res)
+
 	input = `compare C:\tmp\a.png&D:\tmp\b.jpg`
 	res = extractFileNames(input)
 	assert.Equal(t, []string{`C:\tmp\a.png`, `D:\tmp\b.jpg`}, res)
+
+	input = `attach {/tmp/photo.png} and {C:\tmp\a.png}`
+	res = extractFileNames(input)
+	assert.Equal(t, []string{"/tmp/photo.png", `C:\tmp\a.png`}, res)
 
 	input = `C:\images\dir.png\nested.jpg`
 	res = extractFileNames(input)

--- a/x/imagegen/cli_test.go
+++ b/x/imagegen/cli_test.go
@@ -19,6 +19,14 @@ func TestExtractFileNames(t *testing.T) {
 	res = extractFileNames(input)
 	assert.Equal(t, []string{"/tmp/a.png", "/tmp/b.png"}, res)
 
+	input = `describe /tmp/cat.png请描述 and /tmp/dog.jpg。`
+	res = extractFileNames(input)
+	assert.Equal(t, []string{"/tmp/cat.png", "/tmp/dog.jpg"}, res)
+
+	input = `/tmp/a.png./b.png`
+	res = extractFileNames(input)
+	assert.Equal(t, []string{"/tmp/a.png", "./b.png"}, res)
+
 	input = `compare C:\tmp\a.png&D:\tmp\b.jpg`
 	res = extractFileNames(input)
 	assert.Equal(t, []string{`C:\tmp\a.png`, `D:\tmp\b.jpg`}, res)

--- a/x/imagegen/cli_test.go
+++ b/x/imagegen/cli_test.go
@@ -11,6 +11,14 @@ func TestExtractFileNames(t *testing.T) {
 	res := extractFileNames(input)
 	assert.Equal(t, []string{"./directory.png/image.png", "/tmp/photo.png", "/tmp/wrapped.jpg", "/tmp/a.png", "/tmp/b.png", "/tmp/quoted.webp", "/tmp/single.jpeg", "/tmp/backtick.png"}, res)
 
+	input = `compare /tmp/a.png&/tmp/b.png | /tmp/c.webp</tmp/d.jpg`
+	res = extractFileNames(input)
+	assert.Equal(t, []string{"/tmp/a.png", "/tmp/b.png", "/tmp/c.webp", "/tmp/d.jpg"}, res)
+
+	input = `compare C:\tmp\a.png&D:\tmp\b.jpg`
+	res = extractFileNames(input)
+	assert.Equal(t, []string{`C:\tmp\a.png`, `D:\tmp\b.jpg`}, res)
+
 	input = `C:\images\dir.png\nested.jpg`
 	res = extractFileNames(input)
 	assert.Equal(t, []string{`C:\images\dir.png\nested.jpg`}, res)

--- a/x/imagegen/cli_test.go
+++ b/x/imagegen/cli_test.go
@@ -1,0 +1,17 @@
+package imagegen
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractFileNames(t *testing.T) {
+	input := `./directory.png/image.png /tmp/photo.png. (/tmp/wrapped.jpg) /tmp/a.png,/tmp/b.png "` + `/tmp/quoted.webp"` + `" '` + `/tmp/single.jpeg` + `' ` + "`/tmp/backtick.png`"
+	res := extractFileNames(input)
+	assert.Equal(t, []string{"./directory.png/image.png", "/tmp/photo.png", "/tmp/wrapped.jpg", "/tmp/a.png", "/tmp/b.png", "/tmp/quoted.webp", "/tmp/single.jpeg", "/tmp/backtick.png"}, res)
+
+	input = `C:\images\dir.png\nested.jpg`
+	res = extractFileNames(input)
+	assert.Equal(t, []string{`C:\images\dir.png\nested.jpg`}, res)
+}


### PR DESCRIPTION
## Summary

Fixes #16680.

The interactive file path extractor no longer stops at a parent directory whose name happens to end with a supported media extension. For example, `./directory.png/image.png` is now treated as one complete file path instead of being split at `directory.png`.

The same path-boundary handling is applied to the experimental image generation CLI copy of the extractor so both prompt entry points behave consistently for image paths.

## Root cause

The extractor used a non-greedy path match followed by an extension and `\b`. That allowed the match to terminate at the first extension-like directory segment because `/` after `.png` still satisfied the word-boundary check.

## Validation

- `go test ./cmd -run '^TestExtractFilenames$' -count=1 -timeout=5m -v`
- `go test ./x/imagegen -run '^TestExtractFileNames$' -count=1 -timeout=5m -v`
- `go test ./cmd ./x/imagegen -count=1 -timeout=5m`
- `git diff --check`
