### PR TITLE
cmake: add zendnn backend for AMD EPYC CPUs

### DIFF
--- a/cmake/local.cmake
+++ b/cmake/local.cmake
@@ -7,7 +7,7 @@
 include(ExternalProject)
 
 set(OLLAMA_LLAMA_BACKENDS "" CACHE STRING
-    "Semicolon-separated llama-server GPU backends to build: cuda_v12;cuda_v13;rocm_v7_1;rocm_v7_2;vulkan;cuda_jetpack5;cuda_jetpack6")
+    "Semicolon-separated llama-server GPU backends to build: cuda_v12;cuda_v13;rocm_v7_1;rocm_v7_2;vulkan;zendnn;cuda_jetpack5;cuda_jetpack6")
 set(_ollama_mlx_backends_doc "Semicolon-separated MLX backends to build: cuda_v13;metal_v3;metal_v4")
 set(OLLAMA_VERSION "0.0.0" CACHE STRING "Ollama version embedded in the local Go binary")
 set(OLLAMA_PAYLOAD_INSTALL_PREFIX "${CMAKE_BINARY_DIR}" CACHE PATH
@@ -522,6 +522,17 @@ if(OLLAMA_HAVE_LLAMA_SERVER)
         endif()
     endif()
 
+    if("zendnn" IN_LIST OLLAMA_LLAMA_BACKENDS)
+        if(WIN32)
+            message(FATAL_ERROR "OLLAMA_LLAMA_BACKENDS=zendnn is only supported on Linux")
+        endif()
+        list(APPEND _cpu_args
+            -DGGML_ZENDNN=ON
+            -DGGML_OPENMP=ON)
+        ollama_append_cache_arg_if_set(_cpu_args ZENDNN_ROOT)
+        list(APPEND _cpu_targets ggml-zendnn)
+    endif()
+
     ollama_add_llama_server_build(local
         RUNNER_DIR ""
         TARGETS llama-server llama-quantize
@@ -593,6 +604,8 @@ if(OLLAMA_HAVE_LLAMA_SERVER)
                     -DGGML_VULKAN=ON
                     -DOLLAMA_GPU_BACKEND=vulkan)
             list(APPEND _backend_targets ollama-llama-server-vulkan)
+        elseif(_backend STREQUAL "zendnn")
+            # CPU accelerator; handled above as part of the local CPU build.
         elseif(_backend STREQUAL "cuda_jetpack5")
             if(CMAKE_CUDA_ARCHITECTURES)
                 set(_cuda_preset llama_cuda_jetpack5_user_arch)

--- a/docs/development.md
+++ b/docs/development.md
@@ -39,7 +39,23 @@ cmake -B build . -DOLLAMA_LLAMA_BACKENDS="cuda_v13;vulkan"
 cmake --build build --parallel 8
 ```
 
-Supported backend values are `cuda_v12`, `cuda_v13`, `rocm_v7_1`, `rocm_v7_2`, `vulkan`, `cuda_jetpack5`, and `cuda_jetpack6`.
+Supported backend values are `cuda_v12`, `cuda_v13`, `rocm_v7_1`, `rocm_v7_2`, `vulkan`, `zendnn`, `cuda_jetpack5`, and `cuda_jetpack6`.
+
+On Linux, `zendnn` accelerates CPU inference on AMD CPUs via [ZenDNN](https://github.com/amd/ZenDNN). It is built into the CPU payload rather than a separate runner. Set `ZENDNN_ROOT` to an existing ZenDNN install to skip the automatic download and build:
+
+```shell
+# ZenDNN
+cmake -B build . -DOLLAMA_LLAMA_BACKENDS=zendnn
+cmake --build build --parallel 8
+
+# llama/server preset only 
+cmake -S llama/server --preset zendnn
+cmake --build build/llama-server-zendnn --parallel 8 --target llama-server llama-quantize
+
+# with an existing ZenDNN install
+cmake -B build . -DOLLAMA_LLAMA_BACKENDS=zendnn -DZENDNN_ROOT=/path/to/zendnn/install
+cmake --build build --parallel 8
+```
 
 Use standard CMake architecture overrides to narrow GPU builds for local hardware:
 

--- a/llama/server/CMakeLists.txt
+++ b/llama/server/CMakeLists.txt
@@ -548,6 +548,20 @@ else()
     # do not depend on host-global redistributables.
     ollama_install_windows_runtime_dlls("${_base_dest}")
 
+    # ZenDNN accelerates CPU inference, so its backend module and runtime
+    # dependencies live next to llama-server where ggml auto-loads them.
+    if(GGML_ZENDNN AND TARGET ggml-zendnn)
+        install(TARGETS ggml-zendnn
+            RUNTIME_DEPENDENCY_SET zendnn_deps
+            RUNTIME DESTINATION "${_base_dest}" COMPONENT llama-server
+            LIBRARY DESTINATION "${_base_dest}" COMPONENT llama-server)
+        install(RUNTIME_DEPENDENCY_SET zendnn_deps
+            PRE_INCLUDE_REGEXES zendnnl aoclutils aocl-dlp dnnl xsmm
+            PRE_EXCLUDE_REGEXES ".*"
+            RUNTIME DESTINATION "${_base_dest}" COMPONENT llama-server
+            LIBRARY DESTINATION "${_base_dest}" COMPONENT llama-server)
+    endif()
+
     # CPU backend modules (multiple variants from GGML_CPU_ALL_VARIANTS).
     # install(CODE) runs at install time so CMAKE_INSTALL_CONFIG_NAME is
     # available for multi-config generators. llama.cpp creates variant module

--- a/llama/server/CMakePresets.json
+++ b/llama/server/CMakePresets.json
@@ -219,6 +219,17 @@
         "OLLAMA_RUNNER_DIR": "vulkan",
         "OLLAMA_GPU_BACKEND": "vulkan"
       }
+    },
+    {
+      "name": "zendnn",
+      "inherits": ["default"],
+      "binaryDir": "${sourceDir}/../../build/llama-server-zendnn",
+      "cacheVariables": {
+        "GGML_ZENDNN": "ON",
+        "GGML_OPENMP": "ON",
+        "GGML_CPU_ALL_VARIANTS": "ON",
+        "OLLAMA_RUNNER_DIR": ""
+      }
     }
   ],
   "buildPresets": [
@@ -316,6 +327,11 @@
       "name": "vulkan",
       "configurePreset": "vulkan",
       "targets": ["ggml-vulkan"]
+    },
+    {
+      "name": "zendnn",
+      "configurePreset": "zendnn",
+      "targets": ["ggml-zendnn"]
     }
   ]
 }


### PR DESCRIPTION
## Summary
  - Adds `zendnn` as a new `OLLAMA_LLAMA_BACKENDS` value that accelerates CPU inference on AMD EPYC and Ryzen CPUs via
  [AMD ZenDNN](https://github.com/amd/ZenDNN) (BF16/AVX-512)
  - `libggml-zendnn.so` is folded into the local CPU build and auto-loaded by llama-server's `GGML_BACKEND_DL` — no
  Go-side changes required
  - ZenDNN and runtime libs are auto-downloaded at configure time; apply `-DZENDNN_ROOT` to use a pre-built install
  - Linux only; supported dtypes: F32, BF16, Q8_0

  Upstream llama.cpp PRs (both merged):
  - ggml-org/llama.cpp#17690 — adds the `ggml-zendnn` backend
  - ggml-org/llama.cpp#23414 — fixes and stabilizes ZenDNN integration

  ## Test plan

  ```shell
  cmake -B build . -DOLLAMA_LLAMA_BACKENDS=zendnn
  cmake --build build --parallel $(nproc)

  # with a pre-built ZenDNN install
  cmake -B build . -DOLLAMA_LLAMA_BACKENDS=zendnn -DZENDNN_ROOT=/path/to/zendnn/install
  cmake --build build --parallel $(nproc)

  # standalone llama/server preset
  cmake -S llama/server --preset zendnn
  cmake --build build/llama-server-zendnn -j$(nproc) --target llama-server llama-quantize
