### PR TITLE
llm: allow forcing projector offload on integrated GPUs

### DIFF
--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -220,6 +220,8 @@ var (
 	DebugLogRequests = Bool("OLLAMA_DEBUG_LOG_REQUESTS")
 	// KvCacheType is the quantization type for the K/V cache.
 	KvCacheType = String("OLLAMA_KV_CACHE_TYPE")
+	// MmProjOffload controls multimodal projector GPU offload heuristics.
+	MmProjOffload = String("OLLAMA_MMPROJ_OFFLOAD")
 	// NoHistory disables readline history.
 	NoHistory = Bool("OLLAMA_NOHISTORY")
 	// NoPrune disables pruning of model blobs on startup.
@@ -317,6 +319,7 @@ func AsMap() map[string]EnvVar {
 		"OLLAMA_KV_CACHE_TYPE":        {"OLLAMA_KV_CACHE_TYPE", KvCacheType(), "Quantization type for the K/V cache (default: f16)"},
 		"OLLAMA_GPU_OVERHEAD":         {"OLLAMA_GPU_OVERHEAD", GpuOverhead(), "Reserve a portion of VRAM per GPU (bytes)"},
 		"OLLAMA_IGPU_ENABLE":          {"OLLAMA_IGPU_ENABLE", String("OLLAMA_IGPU_ENABLE")(), "Enable integrated GPUs"},
+		"OLLAMA_MMPROJ_OFFLOAD":       {"OLLAMA_MMPROJ_OFFLOAD", MmProjOffload(), "Set to \"force\" to keep multimodal projector GPU offload enabled on integrated GPUs"},
 		"LLAMA_ARG_FIT":               {"LLAMA_ARG_FIT", String("LLAMA_ARG_FIT")(), "Enable llama.cpp automatic fit of unset memory options (default \"on\")"},
 		"LLAMA_ARG_FIT_TARGET":        {"LLAMA_ARG_FIT_TARGET", String("LLAMA_ARG_FIT_TARGET")(), "Target free VRAM margin per device for llama.cpp fit (MiB)"},
 		"OLLAMA_HOST":                 {"OLLAMA_HOST", Host(), "IP Address for the ollama server (default 127.0.0.1:11434)"},

--- a/envconfig/config_test.go
+++ b/envconfig/config_test.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -435,5 +436,20 @@ func TestNoCloud(t *testing.T) {
 				t.Errorf("NoCloudSource() = %q, want %q", got, tt.wantSource)
 			}
 		})
+	}
+}
+
+func TestAsMapIncludesMmProjOffload(t *testing.T) {
+	t.Setenv("OLLAMA_MMPROJ_OFFLOAD", "force")
+
+	envVar, ok := AsMap()["OLLAMA_MMPROJ_OFFLOAD"]
+	if !ok {
+		t.Fatal("AsMap() missing OLLAMA_MMPROJ_OFFLOAD")
+	}
+	if got := envVar.Value; got != "force" {
+		t.Fatalf("OLLAMA_MMPROJ_OFFLOAD value = %v, want force", got)
+	}
+	if !strings.Contains(envVar.Description, "integrated GPUs") {
+		t.Fatalf("OLLAMA_MMPROJ_OFFLOAD description = %q, want integrated GPU scope", envVar.Description)
 	}
 }

--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -630,8 +630,13 @@ func shouldDisableMMProjOffload(opts api.Options, gpus []ml.DeviceInfo, modelLay
 		return true, "partial-text-offload"
 	}
 
+	forceIntegratedMMProjOffload := strings.EqualFold(envconfig.MmProjOffload(), "force")
+
 	for _, gpu := range gpus {
-		if gpu.Integrated && gpu.Library != "Metal" {
+		// Users with high-memory integrated GPUs can opt into projector GPU
+		// offload while keeping the CPU-only, partial-text-offload, and
+		// limited-VRAM safety checks active.
+		if gpu.Integrated && gpu.Library != "Metal" && !forceIntegratedMMProjOffload {
 			return true, "shared-memory-gpu"
 		}
 		memory := gpu.FreeMemory

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -1815,6 +1815,7 @@ func TestAppendMMProjArgs(t *testing.T) {
 		gpus        []ml.DeviceInfo
 		modelLayers uint64
 		retry       bool
+		env         string
 		want        []string
 	}{
 		{
@@ -1887,10 +1888,67 @@ func TestAppendMMProjArgs(t *testing.T) {
 			retry:       true,
 			want:        []string{"base", "--mmproj", "model.gguf", "--no-mmproj-offload"},
 		},
+		{
+			name:        "force override keeps projector offload on integrated non-Metal gpu",
+			projectors:  []string{"model.gguf"},
+			opts:        defaultOpts,
+			gpus:        []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "ROCm"}, Integrated: true, FreeMemory: 32 << 30}},
+			modelLayers: 81,
+			env:         "force",
+			want:        []string{"base", "--mmproj", "model.gguf"},
+		},
+		{
+			name:        "force override does not override limited vram",
+			projectors:  []string{"model.gguf"},
+			opts:        defaultOpts,
+			gpus:        []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}, FreeMemory: 8 << 30, TotalMemory: 8 << 30}},
+			modelLayers: 81,
+			env:         "Force",
+			want:        []string{"base", "--mmproj", "model.gguf", "--no-mmproj-offload"},
+		},
+		{
+			name:        "force override does not override cpu only",
+			projectors:  []string{"model.gguf"},
+			opts:        cpuOpts,
+			gpus:        []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}, FreeMemory: 24 << 30}},
+			modelLayers: 81,
+			env:         "force",
+			want:        []string{"base", "--mmproj", "model.gguf", "--no-mmproj-offload"},
+		},
+		{
+			name:        "force override does not override partial text offload",
+			projectors:  []string{"model.gguf"},
+			opts:        partialOpts,
+			gpus:        []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}, FreeMemory: 24 << 30}},
+			modelLayers: 81,
+			env:         "force",
+			want:        []string{"base", "--mmproj", "model.gguf", "--no-mmproj-offload"},
+		},
+		{
+			name:        "unknown override preserves heuristic",
+			projectors:  []string{"model.gguf"},
+			opts:        defaultOpts,
+			gpus:        []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "ROCm"}, Integrated: true, FreeMemory: 32 << 30}},
+			modelLayers: 81,
+			env:         "true",
+			want:        []string{"base", "--mmproj", "model.gguf", "--no-mmproj-offload"},
+		},
+		{
+			name:        "force override does not affect startup oom retry path",
+			projectors:  []string{"model.gguf"},
+			opts:        defaultOpts,
+			gpus:        []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}, FreeMemory: 24 << 30}},
+			modelLayers: 81,
+			retry:       true,
+			env:         "force",
+			want:        []string{"base", "--mmproj", "model.gguf", "--no-mmproj-offload"},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("OLLAMA_MMPROJ_OFFLOAD", tt.env)
+
 			got := appendMMProjArgs([]string{"base"}, llamaServerLaunchConfig{
 				modelPath:            "model.gguf",
 				projectors:           tt.projectors,


### PR DESCRIPTION
### What

Adds an opt-in `OLLAMA_MMPROJ_OFFLOAD=force` override for multimodal projector GPU offload on non-Metal integrated GPUs. The default behavior stays unchanged.

The override only bypasses the `shared-memory-gpu` heuristic. The existing `cpu-only`, partial text offload, limited-VRAM, and startup OOM retry safeguards still keep projector CPU offload enabled.

### Why

Fixes #16419. Users with high-memory shared-memory GPUs reported that the default projector CPU fallback can make multimodal prompt evaluation dramatically slower, while direct `llama-server` runs without `--no-mmproj-offload` work on the same hardware.

This keeps the default conservative path and gives affected users a narrow opt-in escape hatch.

### Tests

- `go test ./llm -run TestAppendMMProjArgs -count=1`
- `go test ./envconfig -count=1`
- `git diff --check`