### PR TITLE
x/mlxrunner: support gemma-4 MLX models (mixed-precision quant, KV-sharing, BOS)

### DIFF
--- a/x/mlxrunner/model/quant.go
+++ b/x/mlxrunner/model/quant.go
@@ -66,7 +66,13 @@ func ResolveLinearQuantParams(
 
 	if mode == "affine" {
 		if inferredGroupSize, inferredBits, ok := InferAffineQuantParamsFromShapes(weight, scales, bits); ok {
-			if !fromTensor || groupSize == 0 || bits == 0 {
+			// Prefer shape inference when we have no trustworthy metadata, or when
+			// the metadata contradicts the packed weight/scale shapes. The latter
+			// happens with mixed-precision checkpoints whose container declares a
+			// single global quant type even though some layers (e.g. the MLP) are
+			// packed at a different bit width. The packed shapes are ground truth.
+			if !fromTensor || groupSize == 0 || bits == 0 ||
+				!affineShapeConsistent(weight, scales, groupSize, bits) {
 				groupSize = inferredGroupSize
 				bits = inferredBits
 			}
@@ -74,6 +80,29 @@ func ResolveLinearQuantParams(
 	}
 
 	return groupSize, bits, mode
+}
+
+// affineShapeConsistent reports whether (groupSize, bits) is compatible with the
+// packed weight and scale shapes of an affine quantized tensor. MLX packs the
+// last weight axis as uint32 words, so packed_cols*32 == scale_cols*groupSize*bits.
+func affineShapeConsistent(weight, scales *mlx.Array, groupSize, bits int) bool {
+	if weight == nil || scales == nil || groupSize <= 0 || bits <= 0 {
+		return false
+	}
+
+	weightShape := weight.Dims()
+	scaleShape := scales.Dims()
+	if len(weightShape) == 0 || len(scaleShape) == 0 {
+		return false
+	}
+
+	weightCols := weightShape[len(weightShape)-1]
+	scalesCols := scaleShape[len(scaleShape)-1]
+	if weightCols <= 0 || scalesCols <= 0 {
+		return false
+	}
+
+	return weightCols*32 == scalesCols*groupSize*bits
 }
 
 // InferAffineQuantParamsFromShapes infers (groupSize,bits) for affine quantized

--- a/x/mlxrunner/model/quant_test.go
+++ b/x/mlxrunner/model/quant_test.go
@@ -1,0 +1,76 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+)
+
+func shapedArray(t *testing.T, dims ...int) *mlx.Array {
+	t.Helper()
+	n := 1
+	for _, d := range dims {
+		n *= d
+	}
+	return mlx.FromValues(make([]float32, n), dims...)
+}
+
+// affineShapeConsistent uses packed_cols*32 == scale_cols*groupSize*bits, so the
+// last-axis sizes are all that matter. Small proportional shapes exercise the
+// same arithmetic as full-size weights.
+func TestAffineShapeConsistent(t *testing.T) {
+	skipIfNoMLX(t)
+
+	tests := []struct {
+		name                  string
+		weightCols, scaleCols int
+		groupSize, bits       int
+		want                  bool
+	}{
+		{"4bit matches shapes", 16, 2, 64, 4, true}, // 16*32 == 2*64*4
+		{"8bit matches shapes", 32, 2, 64, 8, true}, // 32*32 == 2*64*8
+		{"4bit metadata on 8bit weight", 32, 2, 64, 4, false},
+		{"8bit metadata on 4bit weight", 16, 2, 64, 8, false},
+		{"zero group size", 16, 2, 0, 4, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := shapedArray(t, 4, tc.weightCols)
+			s := shapedArray(t, 4, tc.scaleCols)
+			if got := affineShapeConsistent(w, s, tc.groupSize, tc.bits); got != tc.want {
+				t.Fatalf("affineShapeConsistent(wCols=%d,sCols=%d,g=%d,b=%d) = %v, want %v",
+					tc.weightCols, tc.scaleCols, tc.groupSize, tc.bits, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResolveLinearQuantParamsMixedPrecision mirrors a checkpoint whose container
+// declares a single global 4-bit quant type even though some layers are packed at
+// 8 bits (e.g. gemma-4 QAT: 4-bit attention, 8-bit MLP). The packed shapes are
+// ground truth, so the 8-bit layers must be detected as 8-bit despite the
+// metadata, while genuinely 4-bit layers keep their metadata params.
+func TestResolveLinearQuantParamsMixedPrecision(t *testing.T) {
+	skipIfNoMLX(t)
+
+	q4 := map[string]*TensorQuantInfo{
+		"attn.weight": {QuantType: "Q4", GroupSize: 64},
+		"mlp.weight":  {QuantType: "Q4", GroupSize: 64},
+	}
+
+	// 4-bit attention weight: 16*32 == 2*64*4, consistent with the metadata.
+	attnW := shapedArray(t, 4, 16)
+	attnS := shapedArray(t, 4, 2)
+	if g, b, mode := ResolveLinearQuantParams(64, 4, "affine", q4, "attn.weight", attnW, attnS); g != 64 || b != 4 || mode != "affine" {
+		t.Fatalf("attention resolved to g=%d b=%d mode=%q, want 64/4/affine", g, b, mode)
+	}
+
+	// 8-bit MLP weight: same scale groups, twice the packed columns (32*32 ==
+	// 2*64*8). Metadata still claims 4-bit; shape inference must override it.
+	mlpW := shapedArray(t, 4, 32)
+	mlpS := shapedArray(t, 4, 2)
+	if g, b, mode := ResolveLinearQuantParams(64, 4, "affine", q4, "mlp.weight", mlpW, mlpS); g != 64 || b != 8 || mode != "affine" {
+		t.Fatalf("MLP resolved to g=%d b=%d mode=%q, want 64/8/affine", g, b, mode)
+	}
+}

--- a/x/models/gemma4/gemma4.go
+++ b/x/models/gemma4/gemma4.go
@@ -1011,16 +1011,25 @@ func (m *Model) LoadWeights(tensors map[string]*mlx.Array) error {
 		if layer.Attention.QProj == nil || layer.Attention.OProj == nil {
 			return fmt.Errorf("layer %d: missing attention q/o projections", i)
 		}
-		if layer.Attention.KProj == nil {
-			return fmt.Errorf("layer %d: missing attention k projection", i)
+		if layer.Attention.QNorm == nil {
+			return fmt.Errorf("layer %d: missing attention q norm", i)
 		}
-		// VProj is nil for K=V full-attention layers (value_states = key_states).
-		useAltAttn := m.AttentionKEqV && !isSliding
-		if layer.Attention.VProj == nil && !useAltAttn {
-			return fmt.Errorf("layer %d: missing attention v projection", i)
-		}
-		if layer.Attention.QNorm == nil || layer.Attention.KNorm == nil {
-			return fmt.Errorf("layer %d: missing attention q/k norms", i)
+		// KV-shared layers reuse a donor layer's K/V, so they carry no k_proj,
+		// v_proj, or k_norm of their own (only q_proj/q_norm/o_proj). The forward
+		// pass sources K/V from the donor (see KVShareDonor), so skip the K/V
+		// validation for them.
+		if !isShared {
+			if layer.Attention.KProj == nil {
+				return fmt.Errorf("layer %d: missing attention k projection", i)
+			}
+			// VProj is nil for K=V full-attention layers (value_states = key_states).
+			useAltAttn := m.AttentionKEqV && !isSliding
+			if layer.Attention.VProj == nil && !useAltAttn {
+				return fmt.Errorf("layer %d: missing attention v projection", i)
+			}
+			if layer.Attention.KNorm == nil {
+				return fmt.Errorf("layer %d: missing attention k norm", i)
+			}
 		}
 		if layer.MLP.GateProj == nil || layer.MLP.UpProj == nil || layer.MLP.DownProj == nil {
 			return fmt.Errorf("layer %d: missing mlp projections", i)

--- a/x/tokenizer/tokenizer.go
+++ b/x/tokenizer/tokenizer.go
@@ -29,6 +29,14 @@ type Vocabulary struct {
 	AddBOS bool
 	AddEOS bool
 
+	// ppLeadingSpecial is the token id the tokenizer.json post-processor prepends
+	// to every single sequence, or -1 if it doesn't begin with a special token.
+	// finalizeBOS turns this into AddBOS only when it matches the configured BOS.
+	ppLeadingSpecial int32
+	// addBOSExplicit records that add_bos_token was set in tokenizer_config.json,
+	// which then takes precedence over the post-processor default.
+	addBOSExplicit bool
+
 	// Precomputed byte token IDs for <0xNN> fallback (256 entries, -1 if not found)
 	byteTokens [256]int32
 }

--- a/x/tokenizer/tokenizer_bos_test.go
+++ b/x/tokenizer/tokenizer_bos_test.go
@@ -1,0 +1,110 @@
+package tokenizer
+
+import "testing"
+
+// A minimal BPE tokenizer whose tokenizer.json post-processor prepends <bos>,
+// matching the Gemma family (where add_bos_token is absent from
+// tokenizer_config.json but the post-processor specifies BOS).
+const bosPostProcessorJSON = `{
+	"model": {"type":"BPE","vocab":{"a":0,"b":1,"<bos>":2},"merges":[]},
+	"added_tokens":[{"id":2,"content":"<bos>","special":true}],
+	"post_processor":{
+		"type":"TemplateProcessing",
+		"single":[{"SpecialToken":{"id":"<bos>","type_id":0}},{"Sequence":{"id":"A","type_id":0}}],
+		"special_tokens":{"<bos>":{"id":"<bos>","ids":[2],"tokens":["<bos>"]}}
+	}
+}`
+
+func TestPostProcessorEnablesAddBOS(t *testing.T) {
+	tok, err := LoadFromBytes([]byte(bosPostProcessorJSON))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !tok.AddBOS() {
+		t.Fatal("AddBOS() = false, want true (post-processor prepends <bos>)")
+	}
+	if tok.BOS() != 2 {
+		t.Fatalf("BOS() = %d, want 2 (resolved from post-processor special_tokens)", tok.BOS())
+	}
+
+	// BOS prepended when requested.
+	if ids := tok.Encode("ab", true); len(ids) == 0 || ids[0] != 2 {
+		t.Fatalf("Encode(addBOS=true) = %v, want a leading 2", ids)
+	}
+	// No BOS when not requested.
+	if ids := tok.Encode("ab", false); len(ids) > 0 && ids[0] == 2 {
+		t.Fatalf("Encode(addBOS=false) = %v, want no leading BOS", ids)
+	}
+	// Dedup: text already starting with <bos> must not get a second BOS — this
+	// is what keeps the renderer path (which emits a literal <bos>) from
+	// double-prepending once AddBOS() is true.
+	ids := tok.Encode("<bos>ab", true)
+	if len(ids) < 1 || ids[0] != 2 {
+		t.Fatalf("Encode(\"<bos>ab\") = %v, want leading 2", ids)
+	}
+	if len(ids) >= 2 && ids[1] == 2 {
+		t.Fatalf("Encode(\"<bos>ab\") = %v, double BOS was not deduped", ids)
+	}
+}
+
+// An explicit add_bos_token in tokenizer_config.json takes precedence over the
+// post-processor default.
+func TestAddBOSTokenConfigOverridesPostProcessor(t *testing.T) {
+	cfg := &TokenizerConfig{TokenizerConfigJSON: []byte(`{"add_bos_token": false}`)}
+	tok, err := LoadFromBytesWithConfig([]byte(bosPostProcessorJSON), cfg)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if tok.AddBOS() {
+		t.Fatal("AddBOS() = true, want false (explicit add_bos_token=false should win)")
+	}
+}
+
+// A post-processor whose leading special token is NOT the configured bos_token
+// must not be treated as BOS: encoding should not prepend it, and BOS should
+// remain the configured token.
+const nonBOSPostProcessorJSON = `{
+	"model": {"type":"BPE","vocab":{"a":0,"b":1,"<bos>":2,"<other>":3},"merges":[]},
+	"added_tokens":[
+		{"id":2,"content":"<bos>","special":true},
+		{"id":3,"content":"<other>","special":true}
+	],
+	"post_processor":{
+		"type":"TemplateProcessing",
+		"single":[{"SpecialToken":{"id":"<other>","type_id":0}},{"Sequence":{"id":"A","type_id":0}}],
+		"special_tokens":{"<other>":{"id":"<other>","ids":[3],"tokens":["<other>"]}}
+	}
+}`
+
+// The real Gemma case: companion config names <bos> as bos_token and the
+// post-processor's leading special token is also <bos> -> AddBOS is enabled.
+func TestPostProcessorMatchesConfiguredBOS(t *testing.T) {
+	cfg := &TokenizerConfig{TokenizerConfigJSON: []byte(`{"bos_token": "<bos>"}`)}
+	tok, err := LoadFromBytesWithConfig([]byte(bosPostProcessorJSON), cfg)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !tok.AddBOS() {
+		t.Fatal("AddBOS() = false, want true (post-processor prepends the configured BOS)")
+	}
+	if tok.BOS() != 2 {
+		t.Fatalf("BOS() = %d, want 2", tok.BOS())
+	}
+}
+
+func TestPostProcessorLeadingNonBOSNotPrepended(t *testing.T) {
+	cfg := &TokenizerConfig{TokenizerConfigJSON: []byte(`{"bos_token": "<bos>"}`)}
+	tok, err := LoadFromBytesWithConfig([]byte(nonBOSPostProcessorJSON), cfg)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if tok.AddBOS() {
+		t.Fatal("AddBOS() = true, want false (the post-processor's leading token is not the configured BOS)")
+	}
+	if tok.BOS() != 2 {
+		t.Fatalf("BOS() = %d, want 2 (the configured bos_token, not the post-processor's leading token)", tok.BOS())
+	}
+	if ids := tok.Encode("ab", true); len(ids) > 0 && ids[0] == 3 {
+		t.Fatalf("Encode prepended the non-BOS leading token: %v", ids)
+	}
+}

--- a/x/tokenizer/tokenizer_encode.go
+++ b/x/tokenizer/tokenizer_encode.go
@@ -188,7 +188,7 @@ func (t *Tokenizer) Encode(s string, addBOS bool) []int32 {
 			})
 		}
 
-		if addBOS && t.vocab.BOS >= 0 {
+		if addBOS && t.vocab.BOS >= 0 && (len(ids) == 0 || ids[0] != t.vocab.BOS) {
 			ids = append([]int32{t.vocab.BOS}, ids...)
 		}
 		return ids
@@ -250,7 +250,7 @@ func (t *Tokenizer) Encode(s string, addBOS bool) []int32 {
 		}
 	}
 
-	if addBOS && t.vocab.BOS >= 0 {
+	if addBOS && t.vocab.BOS >= 0 && (len(ids) == 0 || ids[0] != t.vocab.BOS) {
 		ids = append([]int32{t.vocab.BOS}, ids...)
 	}
 	return ids

--- a/x/tokenizer/tokenizer_load.go
+++ b/x/tokenizer/tokenizer_load.go
@@ -21,7 +21,12 @@ type TokenizerConfig struct {
 // Note: This won't load special token config from companion files. Use LoadFromBytesWithConfig
 // to provide tokenizer_config.json data for proper PAD/EOS token loading.
 func LoadFromBytes(data []byte) (*Tokenizer, error) {
-	return loadFromTokenizerJSON(data)
+	t, err := loadFromTokenizerJSON(data)
+	if err != nil {
+		return nil, err
+	}
+	finalizeBOS(t)
+	return t, nil
 }
 
 // LoadFromBytesWithConfig loads a tokenizer from tokenizer.json bytes with additional config files.
@@ -32,12 +37,14 @@ func LoadFromBytesWithConfig(data []byte, config *TokenizerConfig) (*Tokenizer, 
 		return nil, err
 	}
 
-	if config == nil {
-		return t, nil
+	// Apply special token configs from provided data
+	if config != nil {
+		loadSpecialTokenConfigFromBytes(t, config)
 	}
 
-	// Apply special token configs from provided data
-	loadSpecialTokenConfigFromBytes(t, config)
+	// Decide BOS prepending once any companion config (bos_token, add_bos_token)
+	// has been parsed.
+	finalizeBOS(t)
 
 	return t, nil
 }
@@ -50,9 +57,10 @@ func loadFromTokenizerJSON(data []byte) (*Tokenizer, error) {
 			Vocab  map[string]int32 `json:"vocab"`
 			Merges json.RawMessage  `json:"merges"` // Can be []string or [][]string (BPE only)
 		} `json:"model"`
-		PreTokenizer json.RawMessage `json:"pre_tokenizer"`
-		Decoder      json.RawMessage `json:"decoder"`
-		AddedTokens  []struct {
+		PreTokenizer  json.RawMessage `json:"pre_tokenizer"`
+		Decoder       json.RawMessage `json:"decoder"`
+		PostProcessor json.RawMessage `json:"post_processor"`
+		AddedTokens   []struct {
 			ID      int32  `json:"id"`
 			Content string `json:"content"`
 			Special bool   `json:"special"`
@@ -91,11 +99,12 @@ func loadFromTokenizerJSON(data []byte) (*Tokenizer, error) {
 	// Build tokenizer
 	t := &Tokenizer{
 		vocab: &Vocabulary{
-			Values:  make([]string, len(raw.Model.Vocab)),
-			Reverse: raw.Model.Vocab,
-			Merges:  make(map[string]int, len(mergesStrings)),
-			BOS:     -1,
-			PAD:     -1,
+			Values:           make([]string, len(raw.Model.Vocab)),
+			Reverse:          raw.Model.Vocab,
+			Merges:           make(map[string]int, len(mergesStrings)),
+			BOS:              -1,
+			PAD:              -1,
+			ppLeadingSpecial: -1,
 		},
 		specialTokens: make(map[string]int32),
 	}
@@ -156,7 +165,93 @@ func loadFromTokenizerJSON(data []byte) (*Tokenizer, error) {
 
 	cacheSortedSpecialTokens(t)
 
+	// Record the special token (if any) that the tokenizer.json post-processor
+	// prepends to every single sequence. Whether that token is the BOS - and so
+	// whether to prepend it during encoding - is decided by finalizeBOS once any
+	// companion config has been parsed.
+	t.vocab.ppLeadingSpecial = postProcessorLeadingSpecial(t, raw.PostProcessor)
+
 	return t, nil
+}
+
+// postProcessorLeadingSpecial returns the token id of the special token that a
+// tokenizer.json post-processor prepends to every single sequence (e.g. Gemma's
+// <bos>), or -1 if the post-processor does not begin with a resolvable special
+// token. Handles a top-level TemplateProcessing and a Sequence wrapping one.
+func postProcessorLeadingSpecial(t *Tokenizer, ppRaw json.RawMessage) int32 {
+	if len(ppRaw) == 0 {
+		return -1
+	}
+
+	var pp struct {
+		Type          string                       `json:"type"`
+		Single        []map[string]json.RawMessage `json:"single"`
+		SpecialTokens map[string]struct {
+			IDs []int32 `json:"ids"`
+		} `json:"special_tokens"`
+		Processors []json.RawMessage `json:"processors"`
+	}
+	if err := json.Unmarshal(ppRaw, &pp); err != nil {
+		return -1
+	}
+
+	if pp.Type == "Sequence" {
+		for _, p := range pp.Processors {
+			if id := postProcessorLeadingSpecial(t, p); id >= 0 {
+				return id
+			}
+		}
+		return -1
+	}
+
+	if pp.Type != "TemplateProcessing" || len(pp.Single) == 0 {
+		return -1
+	}
+
+	st, ok := pp.Single[0]["SpecialToken"]
+	if !ok {
+		return -1
+	}
+	var tok struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(st, &tok); err != nil || tok.ID == "" {
+		return -1
+	}
+
+	// Resolve the token string to an id: prefer the processor's own table, then
+	// fall back to the tokenizer's special tokens / vocabulary.
+	if info, ok := pp.SpecialTokens[tok.ID]; ok && len(info.IDs) > 0 {
+		return info.IDs[0]
+	}
+	if id, ok := t.specialTokens[tok.ID]; ok {
+		return id
+	}
+	if id, ok := t.vocab.Reverse[tok.ID]; ok {
+		return id
+	}
+	return -1
+}
+
+// finalizeBOS decides whether encoding should prepend a BOS, based on the
+// tokenizer.json post-processor and any companion config. An explicit
+// add_bos_token in tokenizer_config.json takes precedence. Otherwise the
+// post-processor's leading special token enables BOS only when it matches the
+// configured BOS (or, when no BOS is configured, is adopted as the BOS) - so a
+// post-processor that prepends some other special token is not mistaken for BOS.
+func finalizeBOS(t *Tokenizer) {
+	if t.vocab.addBOSExplicit || t.vocab.ppLeadingSpecial < 0 {
+		return
+	}
+	switch {
+	case t.vocab.BOS < 0:
+		// No configured BOS; adopt the post-processor's leading special token.
+		t.vocab.BOS = t.vocab.ppLeadingSpecial
+		t.vocab.AddBOS = true
+	case t.vocab.ppLeadingSpecial == t.vocab.BOS:
+		// The post-processor prepends the configured BOS.
+		t.vocab.AddBOS = true
+	}
 }
 
 func cacheSortedSpecialTokens(t *Tokenizer) {
@@ -268,6 +363,7 @@ func applySpecialTokenConfig(t *Tokenizer, config specialTokenConfigData) {
 			}
 			if tokConfig.AddBOSToken != nil {
 				t.vocab.AddBOS = *tokConfig.AddBOSToken
+				t.vocab.addBOSExplicit = true
 			}
 			if tokConfig.AddEOSToken != nil {
 				t.vocab.AddEOS = *tokConfig.AddEOSToken


### PR DESCRIPTION
Closes #16740.

Enables running the gemma-4 family (e4b / 12B, instruct + base) from mlx-community safetensors on the MLX runner. Three independent fixes, one per commit:

### 1. Mixed-precision affine quant — `x/mlxrunner/model`
QAT checkpoints pack attention at 4-bit and the MLP at 8-bit, but declare a single global affine quant type in their container metadata. The loader read the 8-bit MLP as 4-bit and `QuantizedMatmul` produced an invalid result. Fall back to shape inference when the metadata-derived `(group, bits)` is inconsistent with the packed shapes — MLX packs the last weight axis as uint32 words, so `packed_cols*32 == scale_cols*group*bits` must hold; when it doesn't, the packed shapes win.

### 2. KV-shared layers — `x/models/gemma4`
Checkpoints with `num_kv_shared_layers` reuse a donor layer's K/V in their later layers, so those layers carry only `q_proj`/`q_norm`/`o_proj`. The forward already sources K/V from the donor (`KVShareDonor`), but `LoadWeights` unconditionally required the k/v projections and rejected such checkpoints. Skip the k/v/k_norm validation for KV-shared layers.

### 3. BOS from the tokenizer post-processor — `x/tokenizer`
When `tokenizer_config.json` omits `add_bos_token`, the loader left `AddBOS` false, so completion/raw requests were tokenized without a BOS — and gemma is highly BOS-sensitive (the same weights run coherently in `mlx_lm` with BOS, degenerate without). Honor the `tokenizer.json` post-processor (a `TemplateProcessing` that prepends `<bos>`), which is what HF/transformers use; an explicit `add_bos_token` still wins. Encode also dedups so callers that emit a literal `<bos>` (chat renderers) don't double-prepend.

### Testing
Validated on a single Apple Silicon host (constrained RAM/disk), using `mlx_lm` as a reference oracle on identical weights:

| Model | Mode | Result |
|---|---|---|
| [`gemma4:e4b-mlx`](https://ollama.com/library/gemma4) (official, nvfp4) | chat | coherent |
| [`mlx-community/gemma-4-E4B-it-qat-4bit`](https://huggingface.co/mlx-community/gemma-4-E4B-it-qat-4bit) (mixed 4/8-bit) | chat | coherent |
| [`mlx-community/gemma-4-e4b-4bit`](https://huggingface.co/mlx-community/gemma-4-e4b-4bit) (base) | completion | coherent (matches `mlx_lm` on the same weights) |
| [`mlx-community/gemma-4-12B-it-qat-4bit`](https://huggingface.co/mlx-community/gemma-4-12B-it-qat-4bit) (`gemma4_unified`) | chat | coherent |

**Further testing is welcome** — hardware limits here constrained coverage of longer contexts, additional quantization schemes, and non-Mac MLX hosts.

### Related
Part of the MLX gemma-4 / diffusion-gemma effort; see #16722 (diffusion-gemma) and #16728 (MLX memory cap).
