### PR TITLE
x/mlxrunner: cap MLX wired/cache memory to fit the host

### DIFF
--- a/x/mlxrunner/mlx/memory.go
+++ b/x/mlxrunner/mlx/memory.go
@@ -87,3 +87,21 @@ type (
 func ClearCache() {
 	C.mlx_clear_cache()
 }
+
+// SetWiredLimit caps how much memory MLX keeps wired (resident and un-evictable).
+// Capping it below free RAM lets a model larger than free memory page from disk
+// instead of being OOM-killed. limit is in bytes; returns the previous limit.
+func SetWiredLimit(limit int) int {
+	var prev C.size_t
+	C.mlx_set_wired_limit(&prev, C.size_t(limit))
+	return int(prev)
+}
+
+// SetCacheLimit caps MLX's buffer reuse pool. A smaller pool trades reuse for a
+// lower resident footprint under memory pressure. limit is in bytes; returns the
+// previous limit.
+func SetCacheLimit(limit int) int {
+	var prev C.size_t
+	C.mlx_set_cache_limit(&prev, C.size_t(limit))
+	return int(prev)
+}

--- a/x/mlxrunner/server.go
+++ b/x/mlxrunner/server.go
@@ -13,12 +13,56 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/ollama/ollama/discover"
 	"github.com/ollama/ollama/envconfig"
+	"github.com/ollama/ollama/format"
 	"github.com/ollama/ollama/logutil"
 	"github.com/ollama/ollama/x/internal/mlxthread"
 	"github.com/ollama/ollama/x/mlxrunner/mlx"
 	"github.com/ollama/ollama/x/mlxrunner/sample"
 )
+
+func planWired(free int) int {
+	return free * 4 / 5
+}
+
+func planCache(modelSize, startupFree int) int {
+	if modelSize > planWired(startupFree) {
+		return startupFree / 5
+	}
+	return 0
+}
+
+func configureMLXMemory() int {
+	mem, err := discover.GetCPUMem()
+	free := int(mem.FreeMemory)
+	if err != nil || free <= 0 {
+		return 0
+	}
+	wired := planWired(free)
+	if wired > 0 {
+		mlx.SetWiredLimit(wired)
+	}
+	slog.Info("capped MLX wired memory",
+		"free", format.HumanBytes2(uint64(free)),
+		"wired", format.HumanBytes2(uint64(wired)))
+	return free
+}
+
+func tuneMLXMemory(startupFree int) {
+	if startupFree <= 0 {
+		return
+	}
+	modelSize := mlx.ActiveMemory()
+	cache := planCache(modelSize, startupFree)
+	if cache > 0 {
+		mlx.SetCacheLimit(cache)
+		slog.Info("tightened MLX cache (model exceeds free RAM)",
+			"model", format.HumanBytes2(uint64(modelSize)),
+			"free", format.HumanBytes2(uint64(startupFree)),
+			"cache", format.HumanBytes2(uint64(cache)))
+	}
+}
 
 func Execute(args []string) error {
 	slog.SetDefault(logutil.NewLogger(os.Stderr, envconfig.LogLevel()))
@@ -34,6 +78,7 @@ func Execute(args []string) error {
 	_ = flagSet.Bool("verbose", false, "Enable debug logging")
 	flagSet.Parse(args)
 
+	var startupFree int
 	worker, err := mlxthread.Start("mlxrunner", func() error {
 		if err := mlx.CheckInit(); err != nil {
 			return fmt.Errorf("MLX not available: %w", err)
@@ -41,6 +86,7 @@ func Execute(args []string) error {
 
 		if mlx.GPUIsAvailable() {
 			mlx.SetDefaultDeviceGPU()
+			startupFree = configureMLXMemory()
 			slog.Info("MLX engine initialized", "MLX version", mlx.Version(), "device", "gpu")
 		} else {
 			slog.Info("MLX engine initialized", "MLX version", mlx.Version(), "device", "cpu")
@@ -64,7 +110,11 @@ func Execute(args []string) error {
 	}
 
 	if err := worker.Do(context.Background(), func() error {
-		return runner.Load(modelName)
+		if err := runner.Load(modelName); err != nil {
+			return err
+		}
+		tuneMLXMemory(startupFree)
+		return nil
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes #16728.

Sizes the MLX runner's memory limits to the host so a model larger than free RAM pages instead of OOM-killing the runner, while leaving roomy hosts untouched.

### Why
The MLX runner doesn't cap MLX's wired/cache footprint, so loading a model larger than free RAM gets the runner OOM-killed (jetsam) instead of paging. That makes large models unrunnable on the common 16-24 GB Mac segment.

### What
- **At startup** (`configureMLXMemory`): read free RAM via `discover.GetCPUMem()` and cap MLX's wired (resident) limit at `free*0.8`, so a model larger than free RAM pages instead of being killed.
- **After the model loads** (`tuneMLXMemory`): compare its size (`mlx.ActiveMemory()`) against startup free RAM and tighten MLX's buffer cache **only if it did not fit and will page**. A model that fits keeps MLX's default pool, so models that already run see no change.
- `planWired` / `planCache` are split out as pure helpers.
- `SetWiredLimit` / `SetCacheLimit` wrap `mlx_set_wired_limit` / `mlx_set_cache_limit`.

### Testing
Validated on a single Apple Silicon host (constrained RAM): a model larger than free RAM that previously OOM-killed the runner now loads and pages. Roomy hosts see no change. **Further testing is welcome** across a wider range of host RAM / model sizes.