### PR TITLE
llm: set --ctx-checkpoints 0 for Gemma 4 models to prevent OOM

### DIFF
--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -342,6 +342,9 @@ func startLlamaServer(launch llamaServerLaunchConfig, out io.Writer) (cmd *exec.
 		"-c", strconv.Itoa(launch.opts.NumCtx * launch.numParallel),
 		"-np", strconv.Itoa(launch.numParallel),
 	}
+	if launch.modelArch == "gemma4" {	
+		params = append(params, "--ctx-checkpoints", "0")
+	}
 	params = appendLlamaServerLogArgs(params)
 	params = appendJinjaArgs(params, launch.config)
 


### PR DESCRIPTION
Gemma 4 models consume abnormally large amounts of system RAM due to ctx-checkpoints, to the point of triggering the OOM killer during normal use. This appears to be an architectural characteristic of Gemma 4 rather than a bug in llama.cpp (see ggml-org/llama.cpp#21690).

With Gemma 4 models, llama-server's default ctx-checkpoint behaviour causes ~900MB of system RAM to be allocated on first request, with continued growth of ~200MB per subsequent message, eventually triggering the OOM killer. This PR sets --ctx-checkpoints 0 when the model architecture is gemma4, matching the community-confirmed workaround. Setting --ctx-checkpoints 1 reduced but did not eliminate RAM growth. Setting --ctx-checkpoints 0 fully stabilised RSS.

**Tested with:** gemma4:26b-a4b-it-qat on Ollama 0.30.8, RTX 3090, Linux. RSS stabilised at ~1.5GB vs unbounded growth previously.