### PR TITLE
llm: load models from non-ASCII paths on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -26,3 +26,4 @@ ml/backend/ggml/ggml/src/ggml-metal/ggml-metal-embed.s linguist-generated
 
 * text=auto
 *.go text eol=lf
+llama/compat/**/*.patch text eol=lf

--- a/llama/compat/004-windows-utf8-paths.patch
+++ b/llama/compat/004-windows-utf8-paths.patch
@@ -1,0 +1,124 @@
+diff --git a/tools/mtmd/clip.cpp b/tools/mtmd/clip.cpp
+index 28be9b4..a12f4a3 100644
+--- a/tools/mtmd/clip.cpp
++++ b/tools/mtmd/clip.cpp
+@@ -18,6 +18,13 @@
+ #include <cstdlib>
+ #include <cstring>
+ #include <fstream>
++#if defined(_WIN32)
++#ifndef NOMINMAX
++#define NOMINMAX
++#endif
++#include <filesystem>
++#include <windows.h>
++#endif
+ #include <map>
+ #include <stdexcept>
+ #include <unordered_set>
+@@ -30,6 +37,25 @@
+ 
+ struct clip_logger_state g_logger_state = {clip_log_callback_default, NULL};
+ 
++static std::ifstream clip_open_ifstream(const std::string & fname) {
++#if defined(_WIN32)
++    // std::ifstream interprets a narrow path with the active code page,
++    // so non-ASCII UTF-8 paths fail to open on Windows. Build a wide
++    // std::filesystem::path from the UTF-8 name instead.
++    if (!fname.empty()) {
++        const int wide_len = MultiByteToWideChar(CP_UTF8, 0, fname.c_str(), -1, nullptr, 0);
++        if (wide_len > 0) {
++            std::wstring wide(static_cast<size_t>(wide_len), wchar_t{});
++            if (MultiByteToWideChar(CP_UTF8, 0, fname.c_str(), -1, wide.data(), wide_len) > 0) {
++                wide.resize(static_cast<size_t>(wide_len - 1));
++                return std::ifstream(std::filesystem::path(wide), std::ios::binary);
++            }
++        }
++    }
++#endif
++    return std::ifstream(fname, std::ios::binary);
++}
++
+ //#define CLIP_DEBUG_FUNCTIONS
+ 
+ #ifdef CLIP_DEBUG_FUNCTIONS
+@@ -1743,7 +1769,7 @@ struct clip_model_loader {
+         std::map<std::string, size_t> tensor_offset;
+         std::vector<ggml_tensor *> tensors_to_load;
+ 
+-        auto fin = std::ifstream(fname, std::ios::binary);
++        auto fin = clip_open_ifstream(fname);
+         if (!fin) {
+             throw std::runtime_error(string_format("%s: failed to open %s\n", __func__, fname.c_str()));
+         }
+diff --git a/tools/server/main.cpp b/tools/server/main.cpp
+index 7f17c56..bf3a69b 100644
+--- a/tools/server/main.cpp
++++ b/tools/server/main.cpp
+@@ -1,5 +1,66 @@
++#if defined(_WIN32)
++#include <windows.h>
++#include <shellapi.h>
++
++#include <string>
++#include <vector>
++#endif
++
+ int llama_server(int argc, char ** argv);
+ 
++#if defined(_WIN32)
++// On Windows the C runtime hands main() its arguments in the active (ANSI)
++// code page, which mangles non-ASCII model paths such as
++// C:\Users\Maëlys\.ollama\models\... before llama-server can open
++// them. Rebuild argv from the wide command line and re-encode it as UTF-8 so
++// the path survives down to the UTF-8 aware file opens (ggml_fopen and the
++// std::filesystem based clip loader).
++static std::string wide_to_utf8(const wchar_t * value) {
++    if (value == nullptr) {
++        return {};
++    }
++
++    const int size = WideCharToMultiByte(CP_UTF8, 0, value, -1, nullptr, 0, nullptr, nullptr);
++    if (size <= 0) {
++        return {};
++    }
++
++    std::string out(static_cast<size_t>(size), char{});
++    if (WideCharToMultiByte(CP_UTF8, 0, value, -1, out.data(), size, nullptr, nullptr) <= 0) {
++        return {};
++    }
++    out.resize(static_cast<size_t>(size - 1));
++    return out;
++}
++
++int main(int argc, char ** argv) {
++    int wide_argc = 0;
++    LPWSTR * wide_argv = CommandLineToArgvW(GetCommandLineW(), &wide_argc);
++    if (wide_argv == nullptr || wide_argc <= 0) {
++        if (wide_argv != nullptr) {
++            LocalFree(wide_argv);
++        }
++        return llama_server(argc, argv);
++    }
++
++    std::vector<std::string> utf8_args;
++    utf8_args.reserve(static_cast<size_t>(wide_argc));
++    for (int i = 0; i < wide_argc; ++i) {
++        utf8_args.emplace_back(wide_to_utf8(wide_argv[i]));
++    }
++    LocalFree(wide_argv);
++
++    std::vector<char *> utf8_argv;
++    utf8_argv.reserve(utf8_args.size() + 1);
++    for (auto & arg : utf8_args) {
++        utf8_argv.push_back(arg.data());
++    }
++    utf8_argv.push_back(nullptr);
++
++    return llama_server(wide_argc, utf8_argv.data());
++}
++#else
+ int main(int argc, char ** argv) {
+     return llama_server(argc, argv);
+ }
++#endif

--- a/llama/compat/README.md
+++ b/llama/compat/README.md
@@ -27,6 +27,10 @@ intentionally skipped so a developer can iterate on a local llama.cpp tree.
   It currently touches `src/llama-model-loader.cpp` and `tools/mtmd/clip.cpp`.
 - `002-llama-cpp-ui-empty-assets.patch` - lets the llama.cpp UI embed helper
   generate an empty asset table when no UI assets are present.
+- `004-windows-utf8-paths.patch` - Windows-only UTF-8 path handling so models
+  under non-ASCII home directories load. It rebuilds `argv` from the wide
+  command line in `tools/server/main.cpp` and opens the CLIP/mmproj file
+  through a wide `std::filesystem::path` in `tools/mtmd/clip.cpp`.
 - `compat.cmake`, `apply-patch.cmake` - CMake glue and an idempotent applier
   (used by `llama/server/CMakeLists.txt`) that applies every `*.patch` under
   this directory by numeric filename order — the hooks patch plus each
@@ -109,7 +113,7 @@ dispatching them from `translate_metadata` / `translate_clip_metadata`. For
 monolithic vision models, also update the `compatClipArches` allowlist in
 `llm/llama_server.go` so Ollama passes the main GGUF as `--mmproj`.
 
-## Regenerating the Patch File
+## Regenerating the Patch Files
 
 After a llama.cpp bump moves the insertion points, re-apply the edits to a
 fresh checkout and run:
@@ -120,6 +124,16 @@ git diff -- \
     src/llama-model-loader.cpp \
     tools/mtmd/clip.cpp \
     > /path/to/ollama/llama/compat/001-llama-cpp-hooks.patch
+```
+
+The Windows UTF-8 path edits live in their own patch. Regenerate it on top of
+`001-llama-cpp-hooks.patch` (which also touches `clip.cpp`) with:
+
+```sh
+git diff -- \
+    tools/mtmd/clip.cpp \
+    tools/server/main.cpp \
+    > /path/to/ollama/llama/compat/004-windows-utf8-paths.patch
 ```
 
 ## Implementation Notes

--- a/llama/compat/llama-ollama-compat-util.cpp
+++ b/llama/compat/llama-ollama-compat-util.cpp
@@ -275,7 +275,7 @@ bool take_load_op(const char * dest_name, LoadOp & out) {
 }
 
 bool read_at(const char * path, size_t offset, void * dst, size_t size) {
-    FILE * f = std::fopen(path, "rb");
+    FILE * f = ggml_fopen(path, "rb");
     if (!f) {
         std::fprintf(stderr, "%s: open failed path=%s offset=%zu size=%zu errno=%d (%s)\n",
                      __func__, path, offset, size, errno, std::strerror(errno));

--- a/llama/server/CMakeLists.txt
+++ b/llama/server/CMakeLists.txt
@@ -186,6 +186,13 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(llama_cpp)
 
+# The Windows UTF-8 argv shim in tools/server/main.cpp (applied via
+# llama/compat/004-windows-utf8-paths.patch) calls CommandLineToArgvW, which
+# lives in shell32.
+if(WIN32 AND TARGET llama-server)
+    target_link_libraries(llama-server PRIVATE shell32)
+endif()
+
 # Link the Ollama-compat source files into the fetched llama target.
 # Kept separate from the hook patch so our .cpp/.h stay
 # on-disk in llama/compat/ rather than being copied into _deps/.

--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -333,6 +333,33 @@ func startLlamaServer(launch llamaServerLaunchConfig, out io.Writer) (cmd *exec.
 	}
 
 	// Build CLI flags — minimal set, let llama-server auto-detect the rest
+	params := llamaServerParams(port, launch)
+
+	// Set up library paths for GPU backend discovery
+	cmd = exec.Command(exe, params...)
+
+	if out != nil {
+		// os/exec serializes Write calls when stdout and stderr share a writer.
+		cmd.Stdout = out
+		cmd.Stderr = out
+	}
+	cmd.SysProcAttr = LlamaServerSysProcAttr
+	SetupLlamaServerCommandEnv(cmd, exe, launch.gpuLibs, launch.extraEnvs)
+
+	slog.Info("starting llama-server", "cmd", cmd)
+	slog.Debug("subprocess", "", filteredEnv(cmd.Env))
+
+	if err = cmd.Start(); err != nil {
+		return nil, 0, err
+	}
+	return cmd, port, nil
+}
+
+// llamaServerParams builds the llama-server CLI flags. It is split out from
+// startLlamaServer so the argument list can be unit tested without spawning a
+// process — in particular to guard that paths (e.g. non-ASCII model and
+// projector paths on Windows) are passed through verbatim.
+func llamaServerParams(port int, launch llamaServerLaunchConfig) []string {
 	params := []string{
 		"--model", launch.modelPath,
 		"--port", strconv.Itoa(port),
@@ -389,24 +416,7 @@ func startLlamaServer(launch llamaServerLaunchConfig, out io.Writer) (cmd *exec.
 
 	params = appendContextShiftArgs(params, launch.opts, launch.config.ContextShift)
 
-	// Set up library paths for GPU backend discovery
-	cmd = exec.Command(exe, params...)
-
-	if out != nil {
-		// os/exec serializes Write calls when stdout and stderr share a writer.
-		cmd.Stdout = out
-		cmd.Stderr = out
-	}
-	cmd.SysProcAttr = LlamaServerSysProcAttr
-	SetupLlamaServerCommandEnv(cmd, exe, launch.gpuLibs, launch.extraEnvs)
-
-	slog.Info("starting llama-server", "cmd", cmd)
-	slog.Debug("subprocess", "", filteredEnv(cmd.Env))
-
-	if err = cmd.Start(); err != nil {
-		return nil, 0, err
-	}
-	return cmd, port, nil
+	return params
 }
 
 // SetupLlamaServerCommandEnv configures the environment for a llama-server

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -1906,6 +1906,42 @@ func TestAppendMMProjArgs(t *testing.T) {
 	}
 }
 
+func TestLlamaServerParamsPreserveNonASCIIPaths(t *testing.T) {
+	opts := api.DefaultOptions()
+	opts.NumGPU = 0
+	opts.NumCtx = 4096
+
+	// A non-ASCII Windows home directory, e.g. a user named "Maëlys".
+	modelPath := `C:\Users\Maëlys\.ollama\models\blobs\sha256-0000000000000000000000000000000000000000000000000000000000000000`
+
+	got := llamaServerParams(49152, llamaServerLaunchConfig{
+		modelPath:   modelPath,
+		projectors:  []string{modelPath},
+		opts:        opts,
+		numParallel: 1,
+		config:      LlamaServerConfig{},
+	})
+
+	argValue := func(flag string) (string, bool) {
+		for i := 0; i+1 < len(got); i++ {
+			if got[i] == flag {
+				return got[i+1], true
+			}
+		}
+		return "", false
+	}
+
+	for _, flag := range []string{"--model", "--mmproj"} {
+		v, ok := argValue(flag)
+		if !ok {
+			t.Fatalf("missing %s in args %v", flag, got)
+		}
+		if v != modelPath {
+			t.Errorf("%s = %q, want %q", flag, v, modelPath)
+		}
+	}
+}
+
 func TestAppendJinjaArgs(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
On Windows the C runtime hands llama-server's main() its arguments in the active (ANSI) code page, so a model path under a non-ASCII home directory (e.g. C:\Users\Maëlys\.ollama\models\...) is corrupted before any file is opened, and the model fails to load with a 500 error.

Rebuild argv from the wide command line (CommandLineToArgvW) and re-encode it as UTF-8 in tools/server/main.cpp so the path reaches the loader intact, then open the remaining native file sites in a UTF-8 aware way: the CLIP/mmproj file via a wide std::filesystem::path in tools/mtmd/clip.cpp, and the compat tensor reload via ggml_fopen instead of std::fopen. Link shell32 for CommandLineToArgvW and keep the compat *.patch files LF-only so git apply works on Windows.

llamaServerParams is split out of startLlamaServer so the argument list can be unit tested.

This change was developed with the help of an AI assistant.

Fixes #16493