### PR TITLE
README: add Ollama Monitor to community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,8 @@ console.log(response.message.content);
 - [Langfuse](https://langfuse.com/docs/integrations/ollama) - Open source LLM observability
 - [HoneyHive](https://docs.honeyhive.ai/integrations/ollama) - AI observability and evaluation for agents
 - [MLflow Tracing](https://mlflow.org/docs/latest/llms/tracing/index.html#automatic-tracing) - Open source LLM observability
+- [Ollama Monitor](https://github.com/Jamalianpour/ollama-monitor) - Real-time dashboard for running models, requests, GPU, system metrics, and logs
+
 
 ### Database & Embeddings
 


### PR DESCRIPTION
Adds Ollama Monitor to the Observability & Monitoring section. It's a real-time web dashboard (Flutter + FastAPI) that shows running models, per-request metrics, GPU/CPU/RAM gauges, and a live log viewer. Supports multiple Ollama servers simultaneously.

Repo: https://github.com/Jamalianpour/ollama-monitor

<img width="2880" height="1906" alt="sc_dashboard_1" src="https://github.com/user-attachments/assets/a037a55c-a3f8-4db7-81a0-1f0daa2f88f1" />
