### PR TITLE
launch: add NanoClaw integration

### DIFF
--- a/cmd/launch/integrations_test.go
+++ b/cmd/launch/integrations_test.go
@@ -2035,6 +2035,7 @@ func TestIntegration_AutoInstallable(t *testing.T) {
 		{"hermes-desktop", true},
 		{"cline", true},
 		{"qwen", true},
+		{"nanoclaw", true},
 		{"claude", false},
 		{"claude-desktop", false},
 		{"codex", false},

--- a/cmd/launch/launch.go
+++ b/cmd/launch/launch.go
@@ -301,6 +301,7 @@ Supported integrations:
   pool            Pool
   cline           Cline
   qwen            Qwen Code
+  nanoclaw        NanoClaw
   vscode          VS Code (aliases: code)
 
 Examples:
@@ -311,6 +312,7 @@ Examples:
   ollama launch codex-app --restore
   ollama launch hermes
   ollama launch hermes-desktop
+  ollama launch nanoclaw
   ollama launch droid --config (does not auto-launch)
   ollama launch codex --restore
   ollama launch codex -- --sandbox workspace-write`,

--- a/cmd/launch/nanoclaw.go
+++ b/cmd/launch/nanoclaw.go
@@ -1,0 +1,302 @@
+package launch
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/ollama/ollama/envconfig"
+)
+
+const (
+	nanoclawRepoURL     = "https://github.com/nanocoai/nanoclaw"
+	nanoclawPackageName = "nanoclaw"
+	// nanoclawAgentName is the assistant name launch sets for the initial chat
+	// agent NanoClaw creates on first run.
+	nanoclawAgentName = "Ollama"
+)
+
+// nanoclawGOOS is a seam over runtime.GOOS so the platform-specific Docker
+// install hints and the Windows WSL2 guidance can be unit-tested off the target
+// OS.
+var nanoclawGOOS = runtime.GOOS
+
+// Nanoclaw implements Runner for NanoClaw, a self-hosted assistant that
+// orchestrates containerized agents. launch installs it into a fixed,
+// launch-owned checkout and hands off to one entrypoint script that owns all
+// per-group setup against the local Ollama endpoint (the frozen seam contract).
+type Nanoclaw struct{}
+
+func (n *Nanoclaw) String() string { return "NanoClaw" }
+
+// nanoclawDir returns the fixed, launch-owned NanoClaw checkout location under
+// the ~/.ollama/launch/ state directory.
+func nanoclawDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".ollama", "launch", "nanoclaw"), nil
+}
+
+// nanoclawScriptPath returns the seam-contract entrypoint inside a checkout.
+func nanoclawScriptPath(dir string) string {
+	return filepath.Join(dir, "scripts", "ollama-launch.sh")
+}
+
+// nanoclawCheckoutValid reports whether dir looks like a real NanoClaw checkout
+// (a directory whose package.json declares the nanoclaw package). This only
+// confirms the repository is present; first-run setup state is tracked
+// separately by the entrypoint script via its idempotency marker.
+func nanoclawCheckoutValid(dir string) bool {
+	info, err := os.Stat(dir)
+	if err != nil || !info.IsDir() {
+		return false
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "package.json"))
+	if err != nil {
+		return false
+	}
+	var pkg struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return false
+	}
+	return pkg.Name == nanoclawPackageName
+}
+
+// nanoclawInstalled is the registry CheckInstalled probe: is the launch-owned
+// NanoClaw checkout present and valid?
+func nanoclawInstalled() bool {
+	dir, err := nanoclawDir()
+	if err != nil {
+		return false
+	}
+	return nanoclawCheckoutValid(dir)
+}
+
+// nanoclawOnboarded reports whether NanoClaw has completed first-run setup in
+// the given checkout. The setup `service` step writes data/upgrade-state.json;
+// its presence is the idempotency marker the entrypoint script also checks, and
+// it gates whether launch passes a first-run --display-name.
+func nanoclawOnboarded(dir string) bool {
+	_, err := os.Stat(filepath.Join(dir, "data", "upgrade-state.json"))
+	return err == nil
+}
+
+// nanoclawCloneArgs builds the `git clone` arguments for fetching NanoClaw into
+// tmp: a shallow clone of the canonical repo's default branch.
+//
+// It is a package variable, not a plain function, so the local-development file
+// nanoclaw_localdev.go can swap in an override that honors the
+// NANOCLAW_LAUNCH_REPO / NANOCLAW_LAUNCH_REF environment variables for local
+// testing. That file is the ONLY local-dev seam in this package: deleting it
+// (and nanoclaw_localdev_test.go) before the production push to ollama/ollama
+// restores this canonical behavior with no other change required here.
+var nanoclawCloneArgs = func(tmp string) []string {
+	return []string{"clone", "--depth", "1", nanoclawRepoURL, tmp}
+}
+
+// ensureNanoclawInstalled is the registry EnsureInstalled action: clone NanoClaw
+// into the launch-owned directory after explicit consent. It is idempotent — an
+// existing valid checkout is a no-op.
+func ensureNanoclawInstalled() error {
+	dir, err := nanoclawDir()
+	if err != nil {
+		return err
+	}
+	if nanoclawCheckoutValid(dir) {
+		return nil
+	}
+
+	// Installing here is heavyweight and partly irreversible (clones a repo,
+	// builds a container image, installs a background service). Require a real
+	// terminal so a non-interactive or piped session can never silently kick it
+	// off — this is the hard guard against the unattended data-loss path.
+	if !isInteractiveSession() {
+		return fmt.Errorf("NanoClaw is not installed; run 'ollama launch nanoclaw' in an interactive terminal to install it")
+	}
+
+	// Validate every hard prerequisite before asking for consent, and report all
+	// missing ones at once, so a user lacking more than one tool isn't made to
+	// answer the prompts (or fix tools) one at a time.
+	if err := nanoclawCheckPrerequisites(); err != nil {
+		return err
+	}
+
+	ok, err := ConfirmPrompt("Install NanoClaw? This clones the NanoClaw repo, builds a Docker image (~3-10 min), and installs a background service. NanoClaw runs agent-issued actions inside sandboxed containers.")
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("nanoclaw installation cancelled")
+	}
+
+	fmt.Fprintf(os.Stderr, "\nInstalling NanoClaw into %s...\n", dir)
+	if err := os.MkdirAll(filepath.Dir(dir), 0o755); err != nil {
+		return fmt.Errorf("failed to prepare NanoClaw install directory: %w", err)
+	}
+
+	// Clone into a temp sibling and move it into place only after it validates.
+	// This keeps the fixed install dir wedge-proof: an interrupted or invalid
+	// clone leaves only the temp dir behind (cleaned here), so a later run never
+	// hits "git clone" refusing a non-empty destination, and a stale/invalid
+	// pre-existing checkout is replaced rather than blocking the install.
+	tmp := dir + ".tmp"
+	if err := os.RemoveAll(tmp); err != nil {
+		return fmt.Errorf("failed to clear stale NanoClaw download: %w", err)
+	}
+
+	clone := exec.Command("git", nanoclawCloneArgs(tmp)...)
+	clone.Stdin = os.Stdin
+	clone.Stdout = os.Stdout
+	clone.Stderr = os.Stderr
+	if err := clone.Run(); err != nil {
+		_ = os.RemoveAll(tmp)
+		return fmt.Errorf("failed to clone NanoClaw: %w", err)
+	}
+	if !nanoclawCheckoutValid(tmp) {
+		_ = os.RemoveAll(tmp)
+		return fmt.Errorf("cloned NanoClaw from %s does not look like a valid checkout", nanoclawRepoURL)
+	}
+
+	if err := os.RemoveAll(dir); err != nil {
+		_ = os.RemoveAll(tmp)
+		return fmt.Errorf("failed to replace existing NanoClaw directory: %w", err)
+	}
+	if err := os.Rename(tmp, dir); err != nil {
+		_ = os.RemoveAll(tmp)
+		return fmt.Errorf("failed to finalize NanoClaw install: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "%sNanoClaw downloaded%s\n\n", ansiGreen, ansiReset)
+	return nil
+}
+
+// nanoclawCheckPrerequisites verifies git (to clone) and Docker (to build the
+// image and run containers), returning one error listing every missing tool
+// with install guidance. Prerequisites are never auto-installed: heavyweight,
+// OS-specific, and usually need elevated privileges.
+func nanoclawCheckPrerequisites() error {
+	var missing []string
+	if _, err := exec.LookPath("git"); err != nil {
+		missing = append(missing, "git: https://git-scm.com/")
+	}
+	if _, err := exec.LookPath("docker"); err != nil {
+		missing = append(missing, "Docker: "+nanoclawDockerInstallURL())
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	return fmt.Errorf("NanoClaw is not installed and required dependencies are missing\n\nInstall the following first:\n  %s\n\nThen re-run:\n  ollama launch nanoclaw", strings.Join(missing, "\n  "))
+}
+
+// nanoclawDockerInstallURL returns the Docker install page for the current OS.
+func nanoclawDockerInstallURL() string {
+	switch nanoclawGOOS {
+	case "darwin":
+		return "https://docs.docker.com/desktop/install/mac-install/"
+	case "windows":
+		return "https://docs.docker.com/desktop/install/windows-install/"
+	default:
+		return "https://docs.docker.com/engine/install/"
+	}
+}
+
+// nanoclawEnv returns the parent environment with cloud LLM provider API keys
+// stripped before handing off to the entrypoint script. NanoClaw talks to the
+// local Ollama endpoint (passed via --base-url) and runs agent-issued actions
+// inside containers, so ambient provider credentials from the user's shell must
+// not leak into the script, the Docker build, or those agents.
+func nanoclawEnv() []string {
+	clear := map[string]bool{
+		"ANTHROPIC_API_KEY":     true,
+		"ANTHROPIC_OAUTH_TOKEN": true,
+		"OPENAI_API_KEY":        true,
+		"GEMINI_API_KEY":        true,
+		"MISTRAL_API_KEY":       true,
+		"GROQ_API_KEY":          true,
+		"XAI_API_KEY":           true,
+		"OPENROUTER_API_KEY":    true,
+	}
+	env := make([]string, 0, len(os.Environ()))
+	for _, e := range os.Environ() {
+		key, _, _ := strings.Cut(e, "=")
+		if !clear[key] {
+			env = append(env, e)
+		}
+	}
+	return env
+}
+
+// nanoclawDisplayName derives the operator display name for the initial chat
+// agent created on first run, falling back to a stable default when the OS user
+// is unavailable. The entrypoint script normalizes it into the agent folder.
+func nanoclawDisplayName() string {
+	if u, err := user.Current(); err == nil {
+		if name := strings.TrimSpace(u.Username); name != "" {
+			return name
+		}
+	}
+	return "operator"
+}
+
+func (n *Nanoclaw) Run(model string, _ []LaunchModel, args []string) error {
+	// Ensure the checkout exists before handing off. This is idempotent and
+	// returns immediately when NanoClaw is already installed.
+	if err := ensureNanoclawInstalled(); err != nil {
+		return err
+	}
+
+	dir, err := nanoclawDir()
+	if err != nil {
+		return err
+	}
+
+	script := nanoclawScriptPath(dir)
+	if _, err := os.Stat(script); err != nil {
+		return fmt.Errorf("NanoClaw entrypoint not found at %s\n\nUpdate the checkout (git -C %q pull) or reinstall.", script, dir)
+	}
+
+	if _, err := exec.LookPath("bash"); err != nil {
+		msg := "NanoClaw's launch script requires bash, which was not found on PATH"
+		if nanoclawGOOS == "windows" {
+			msg += "\n\nNanoClaw runs best under WSL2 on Windows (wsl --install)."
+		}
+		return fmt.Errorf("%s", msg)
+	}
+
+	// The frozen seam contract: launch passes the model id and host view of the
+	// Ollama endpoint; the script rewrites the host to host.docker.internal and
+	// owns per-group setup. Use ConnectableHost (not Host) so an OLLAMA_HOST on
+	// 0.0.0.0/:: normalizes to a loopback the container can reach. --display-name
+	// and --agent-name matter only on first run, so omit them once onboarded.
+	scriptArgs := []string{
+		script,
+		"--model", model,
+		"--base-url", envconfig.ConnectableHost().String(),
+	}
+	if !nanoclawOnboarded(dir) {
+		scriptArgs = append(scriptArgs,
+			"--display-name", nanoclawDisplayName(),
+			"--agent-name", nanoclawAgentName,
+		)
+	}
+	scriptArgs = append(scriptArgs, args...)
+
+	// stdio is inherited so the script's consent-free prompts, progress, and the
+	// final CHAT: line reach the user directly; exit codes propagate verbatim.
+	cmd := exec.Command("bash", scriptArgs...)
+	cmd.Dir = dir
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = nanoclawEnv()
+	return cmd.Run()
+}

--- a/cmd/launch/nanoclaw_test.go
+++ b/cmd/launch/nanoclaw_test.go
@@ -1,0 +1,493 @@
+package launch
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/ollama/ollama/envconfig"
+)
+
+func TestNanoclawIntegration(t *testing.T) {
+	n := &Nanoclaw{}
+
+	t.Run("String", func(t *testing.T) {
+		if got := n.String(); got != "NanoClaw" {
+			t.Errorf("String() = %q, want %q", got, "NanoClaw")
+		}
+	})
+
+	t.Run("implements Runner", func(t *testing.T) {
+		var _ Runner = n
+	})
+}
+
+func TestNanoclawRegistered(t *testing.T) {
+	spec, err := LookupIntegrationSpec("nanoclaw")
+	if err != nil {
+		t.Fatalf("LookupIntegrationSpec(nanoclaw): %v", err)
+	}
+	if spec.Hidden {
+		t.Error("nanoclaw should be visible (in launcher order), not hidden")
+	}
+	if spec.Install.CheckInstalled == nil {
+		t.Error("nanoclaw should wire CheckInstalled")
+	}
+	if spec.Install.EnsureInstalled == nil {
+		t.Error("nanoclaw should wire EnsureInstalled (install-if-missing)")
+	}
+	if !slices.Contains(launcherIntegrationOrder, "nanoclaw") {
+		t.Error("nanoclaw should appear in launcherIntegrationOrder")
+	}
+}
+
+func TestNanoclawInstalled(t *testing.T) {
+	t.Run("false on a fresh home", func(t *testing.T) {
+		setTestHome(t, t.TempDir())
+		if nanoclawInstalled() {
+			t.Error("nanoclawInstalled() = true, want false with no checkout")
+		}
+	})
+
+	t.Run("true for a valid checkout", func(t *testing.T) {
+		setTestHome(t, t.TempDir())
+		writeNanoclawCheckout(t, nanoclawPackageName)
+		if !nanoclawInstalled() {
+			t.Error("nanoclawInstalled() = false, want true for a valid checkout")
+		}
+	})
+
+	t.Run("false when package name mismatches", func(t *testing.T) {
+		setTestHome(t, t.TempDir())
+		writeNanoclawCheckout(t, "some-other-package")
+		if nanoclawInstalled() {
+			t.Error("nanoclawInstalled() = true, want false when package.json name differs")
+		}
+	})
+}
+
+func TestNanoclawDisplayName(t *testing.T) {
+	// Whatever the OS reports, a display name must never be empty — the script
+	// uses it to name the first chat agent's folder.
+	if got := nanoclawDisplayName(); strings.TrimSpace(got) == "" {
+		t.Errorf("nanoclawDisplayName() = %q, want non-empty", got)
+	}
+}
+
+func TestNanoclawRun(t *testing.T) {
+	t.Run("execs entrypoint with contract flags on first run", func(t *testing.T) {
+		setTestHome(t, t.TempDir())
+		guardNanoclawAgainstInstall(t)
+		dir := writeNanoclawCheckout(t, nanoclawPackageName)
+
+		if err := (&Nanoclaw{}).Run("qwen3-coder:30b", nil, nil); err != nil {
+			t.Fatalf("Run returned error: %v", err)
+		}
+
+		got := readNanoclawInvocation(t, dir)
+		assertFlagValue(t, got, "--model", "qwen3-coder:30b")
+		assertFlagValue(t, got, "--base-url", envconfig.ConnectableHost().String())
+		assertFlagValue(t, got, "--display-name", nanoclawDisplayName())
+		assertFlagValue(t, got, "--agent-name", nanoclawAgentName)
+	})
+
+	t.Run("omits first-run flags once onboarded", func(t *testing.T) {
+		setTestHome(t, t.TempDir())
+		guardNanoclawAgainstInstall(t)
+		dir := writeNanoclawCheckout(t, nanoclawPackageName)
+		markNanoclawOnboarded(t, dir)
+
+		if err := (&Nanoclaw{}).Run("gemma4:latest", nil, nil); err != nil {
+			t.Fatalf("Run returned error: %v", err)
+		}
+
+		got := readNanoclawInvocation(t, dir)
+		assertFlagValue(t, got, "--model", "gemma4:latest")
+		if slices.Contains(got, "--display-name") {
+			t.Errorf("did not expect --display-name on re-launch, got %v", got)
+		}
+		if slices.Contains(got, "--agent-name") {
+			t.Errorf("did not expect --agent-name on re-launch, got %v", got)
+		}
+	})
+
+	t.Run("forwards extra args as a contiguous suffix after contract flags", func(t *testing.T) {
+		setTestHome(t, t.TempDir())
+		guardNanoclawAgainstInstall(t)
+		dir := writeNanoclawCheckout(t, nanoclawPackageName)
+		markNanoclawOnboarded(t, dir) // keep the suffix free of --display-name
+
+		extra := []string{"--mode", "local"}
+		if err := (&Nanoclaw{}).Run("gemma4:latest", nil, slices.Clone(extra)); err != nil {
+			t.Fatalf("Run returned error: %v", err)
+		}
+
+		got := readNanoclawInvocation(t, dir)
+		if len(got) < len(extra) || !slices.Equal(got[len(got)-len(extra):], extra) {
+			t.Errorf("extra args should be a contiguous suffix; got %v, want suffix %v", got, extra)
+		}
+	})
+
+	t.Run("normalizes a 0.0.0.0 OLLAMA_HOST to a connectable loopback", func(t *testing.T) {
+		setTestHome(t, t.TempDir())
+		t.Setenv("OLLAMA_HOST", "0.0.0.0:11434")
+		guardNanoclawAgainstInstall(t)
+		dir := writeNanoclawCheckout(t, nanoclawPackageName)
+		markNanoclawOnboarded(t, dir)
+
+		if err := (&Nanoclaw{}).Run("gemma4:latest", nil, nil); err != nil {
+			t.Fatalf("Run returned error: %v", err)
+		}
+
+		got := readNanoclawInvocation(t, dir)
+		assertFlagValue(t, got, "--base-url", envconfig.ConnectableHost().String())
+		for i, a := range got {
+			if a == "--base-url" && i+1 < len(got) && strings.Contains(got[i+1], "0.0.0.0") {
+				t.Errorf("--base-url must not be an unconnectable 0.0.0.0 address, got %q", got[i+1])
+			}
+		}
+	})
+}
+
+func TestNanoclawRunErrors(t *testing.T) {
+	t.Run("errors when the entrypoint script is missing", func(t *testing.T) {
+		setTestHome(t, t.TempDir())
+		guardNanoclawAgainstInstall(t)
+		dir := writeNanoclawCheckout(t, nanoclawPackageName)
+		if err := os.Remove(nanoclawScriptPath(dir)); err != nil {
+			t.Fatal(err)
+		}
+
+		err := (&Nanoclaw{}).Run("gemma4:latest", nil, nil)
+		if err == nil || !strings.Contains(err.Error(), "entrypoint not found") {
+			t.Fatalf("Run error = %v, want one mentioning the missing entrypoint", err)
+		}
+		if _, statErr := os.Stat(filepath.Join(dir, "invocation.txt")); statErr == nil {
+			t.Error("entrypoint should not have been invoked when the script is missing")
+		}
+	})
+
+	t.Run("errors when bash is unavailable", func(t *testing.T) {
+		setTestHome(t, t.TempDir())
+		guardNanoclawAgainstInstall(t)
+		writeNanoclawCheckout(t, nanoclawPackageName)
+		// An empty PATH hides bash from exec.LookPath.
+		t.Setenv("PATH", t.TempDir())
+
+		err := (&Nanoclaw{}).Run("gemma4:latest", nil, nil)
+		if err == nil || !strings.Contains(err.Error(), "bash") {
+			t.Fatalf("Run error = %v, want one mentioning bash", err)
+		}
+	})
+
+	t.Run("bash-missing error includes a WSL2 hint on Windows", func(t *testing.T) {
+		setTestHome(t, t.TempDir())
+		guardNanoclawAgainstInstall(t)
+		setNanoclawGOOS(t, "windows")
+		writeNanoclawCheckout(t, nanoclawPackageName)
+		t.Setenv("PATH", t.TempDir()) // hide bash from exec.LookPath
+
+		err := (&Nanoclaw{}).Run("gemma4:latest", nil, nil)
+		if err == nil || !strings.Contains(err.Error(), "WSL2") {
+			t.Fatalf("Run error = %v, want a WSL2 hint on Windows", err)
+		}
+	})
+}
+
+func TestNanoclawDockerInstallURL(t *testing.T) {
+	cases := map[string]string{
+		"darwin":  "docker.com/desktop",
+		"windows": "docker.com/desktop",
+		"linux":   "docker.com/engine",
+	}
+	for goos, want := range cases {
+		t.Run(goos, func(t *testing.T) {
+			setNanoclawGOOS(t, goos)
+			if got := nanoclawDockerInstallURL(); !strings.Contains(got, want) {
+				t.Errorf("nanoclawDockerInstallURL() for %s = %q, want one containing %q", goos, got, want)
+			}
+		})
+	}
+}
+
+func TestNanoclawEnv(t *testing.T) {
+	// Cloud provider credentials from the user's shell must not flow into the
+	// entrypoint script or the containers it spawns.
+	t.Setenv("ANTHROPIC_API_KEY", "secret")
+	t.Setenv("OPENAI_API_KEY", "secret")
+	t.Setenv("NANOCLAW_TEST_KEEP", "keep")
+
+	env := nanoclawEnv()
+	for _, e := range env {
+		if strings.HasPrefix(e, "ANTHROPIC_API_KEY=") || strings.HasPrefix(e, "OPENAI_API_KEY=") {
+			t.Errorf("provider credential leaked into handoff env: %q", e)
+		}
+	}
+	if !slices.Contains(env, "NANOCLAW_TEST_KEEP=keep") {
+		t.Error("non-provider environment variables should be preserved")
+	}
+}
+
+func TestNanoclawEnsureInstalled(t *testing.T) {
+	t.Run("refuses to install without a real terminal", func(t *testing.T) {
+		setTestHome(t, t.TempDir())
+		withInteractiveSession(t, false)
+		forbidNanoclawConfirm(t) // a non-TTY refusal must never reach a prompt
+
+		err := ensureNanoclawInstalled()
+		if err == nil || !strings.Contains(err.Error(), "interactive terminal") {
+			t.Fatalf("ensureNanoclawInstalled error = %v, want an interactive-terminal refusal", err)
+		}
+		if nanoclawInstalled() {
+			t.Error("a refused install must not produce a checkout")
+		}
+	})
+
+	t.Run("aggregates every missing prerequisite before prompting", func(t *testing.T) {
+		setTestHome(t, t.TempDir())
+		withInteractiveSession(t, true)
+		forbidNanoclawConfirm(t)
+		t.Setenv("PATH", t.TempDir()) // neither git nor docker on PATH
+
+		err := ensureNanoclawInstalled()
+		if err == nil {
+			t.Fatal("ensureNanoclawInstalled error = nil, want a missing-dependencies error")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "required dependencies are missing") {
+			t.Errorf("error should use the aggregated missing-deps wording, got %q", msg)
+		}
+		if !strings.Contains(msg, "git:") || !strings.Contains(msg, "Docker:") {
+			t.Errorf("error should list both git and Docker in one message, got %q", msg)
+		}
+	})
+
+	t.Run("reports only git when Docker is present", func(t *testing.T) {
+		setTestHome(t, t.TempDir())
+		withInteractiveSession(t, true)
+		forbidNanoclawConfirm(t)
+		bin := t.TempDir()
+		writeFakeBinary(t, bin, "docker") // docker present, git absent
+		t.Setenv("PATH", bin)
+
+		err := ensureNanoclawInstalled()
+		if err == nil || !strings.Contains(err.Error(), "git:") {
+			t.Fatalf("ensureNanoclawInstalled error = %v, want a missing-git error", err)
+		}
+		if strings.Contains(err.Error(), "Docker:") {
+			t.Errorf("should not list Docker when it is present, got %q", err.Error())
+		}
+	})
+
+	t.Run("reports only Docker when git is present", func(t *testing.T) {
+		setTestHome(t, t.TempDir())
+		withInteractiveSession(t, true)
+		forbidNanoclawConfirm(t)
+		bin := t.TempDir()
+		writeFakeBinary(t, bin, "git") // git present, docker absent
+		t.Setenv("PATH", bin)
+
+		err := ensureNanoclawInstalled()
+		if err == nil || !strings.Contains(err.Error(), "Docker:") {
+			t.Fatalf("ensureNanoclawInstalled error = %v, want a missing-Docker error", err)
+		}
+		if strings.Contains(err.Error(), "git:") {
+			t.Errorf("should not list git when it is present, got %q", err.Error())
+		}
+	})
+
+	t.Run("aborts when the first consent is declined", func(t *testing.T) {
+		setTestHome(t, t.TempDir())
+		withInteractiveSession(t, true)
+		bin := t.TempDir()
+		writeFakeBinary(t, bin, "git")
+		writeFakeBinary(t, bin, "docker")
+		t.Setenv("PATH", bin)
+		stubNanoclawConfirm(t, false)
+
+		err := ensureNanoclawInstalled()
+		if err == nil || !strings.Contains(err.Error(), "cancelled") {
+			t.Fatalf("ensureNanoclawInstalled error = %v, want a cancellation error", err)
+		}
+		if nanoclawInstalled() {
+			t.Error("a cancelled install must not produce a checkout")
+		}
+	})
+
+	t.Run("is a no-op when already installed", func(t *testing.T) {
+		setTestHome(t, t.TempDir())
+		withInteractiveSession(t, false) // would refuse if it didn't short-circuit
+		forbidNanoclawConfirm(t)
+		writeNanoclawCheckout(t, nanoclawPackageName)
+
+		if err := ensureNanoclawInstalled(); err != nil {
+			t.Fatalf("ensureNanoclawInstalled on an existing checkout = %v, want nil", err)
+		}
+	})
+
+	t.Run("clones, validates, and replaces a stale invalid dir", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("fake git clone shim is a POSIX shell script")
+		}
+		setTestHome(t, t.TempDir())
+		withInteractiveSession(t, true)
+		bin := t.TempDir()
+		writeFakeGitCloneShim(t, bin)
+		writeFakeBinary(t, bin, "docker")
+		// Prepend bin so the fake git/docker shadow the real ones, while the
+		// shim can still find coreutils (mkdir/printf) on the inherited PATH.
+		t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+		stubNanoclawConfirm(t, true)
+
+		// A pre-existing non-empty invalid checkout must not wedge the install.
+		dir, err := nanoclawDir()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "stale.txt"), []byte("leftover"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := ensureNanoclawInstalled(); err != nil {
+			t.Fatalf("ensureNanoclawInstalled = %v, want success", err)
+		}
+		if !nanoclawInstalled() {
+			t.Error("expected a valid checkout after a successful install")
+		}
+		if _, statErr := os.Stat(filepath.Join(dir, "stale.txt")); statErr == nil {
+			t.Error("the stale leftover should have been replaced")
+		}
+		if _, statErr := os.Stat(dir + ".tmp"); statErr == nil {
+			t.Error("the temp clone dir should have been moved/cleaned, not left behind")
+		}
+	})
+}
+
+// writeNanoclawCheckout creates a minimal fake NanoClaw checkout under the test
+// HOME with a recording entrypoint script, and returns the checkout dir. The
+// script writes its arguments (one per line) to invocation.txt in its working
+// directory so tests can assert the exact seam-contract flags launch passed.
+func writeNanoclawCheckout(t *testing.T, packageName string) string {
+	t.Helper()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("UserHomeDir: %v", err)
+	}
+	dir := filepath.Join(home, ".ollama", "launch", "nanoclaw")
+	if err := os.MkdirAll(filepath.Join(dir, "scripts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	pkg := `{"name":"` + packageName + `"}`
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(pkg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	script := "#!/usr/bin/env bash\nprintf '%s\\n' \"$@\" > invocation.txt\n"
+	if err := os.WriteFile(nanoclawScriptPath(dir), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func markNanoclawOnboarded(t *testing.T, dir string) {
+	t.Helper()
+	dataDir := filepath.Join(dir, "data")
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dataDir, "upgrade-state.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// writeFakeGitCloneShim installs a fake `git` that emulates
+// `git clone --depth 1 <url> <dest>` by materializing a minimal valid NanoClaw
+// checkout at the destination (the last argument), so the install path can be
+// exercised hermetically without any network access.
+func writeFakeGitCloneShim(t *testing.T, dir string) {
+	t.Helper()
+	script := "#!/bin/sh\n" +
+		"for a in \"$@\"; do dest=\"$a\"; done\n" +
+		"mkdir -p \"$dest/scripts\"\n" +
+		"printf '%s' '{\"name\":\"nanoclaw\"}' > \"$dest/package.json\"\n" +
+		"printf '#!/usr/bin/env bash\\n' > \"$dest/scripts/ollama-launch.sh\"\n" +
+		"exit 0\n"
+	if err := os.WriteFile(filepath.Join(dir, "git"), []byte(script), 0o755); err != nil {
+		t.Fatalf("failed to write fake git: %v", err)
+	}
+}
+
+// guardNanoclawAgainstInstall makes Run happy-path tests defensively hermetic:
+// the checkout already exists so ensureNanoclawInstalled short-circuits, but if
+// a regression ever let it fall through, this fails loudly instead of cloning
+// the real repository.
+func guardNanoclawAgainstInstall(t *testing.T) {
+	t.Helper()
+	withInteractiveSession(t, true)
+	forbidNanoclawConfirm(t)
+}
+
+// setNanoclawGOOS overrides the runtime.GOOS seam for the duration of a test so
+// the OS-specific Docker hints and Windows WSL2 guidance can be exercised off
+// the target platform.
+func setNanoclawGOOS(t *testing.T, goos string) {
+	t.Helper()
+	old := nanoclawGOOS
+	nanoclawGOOS = goos
+	t.Cleanup(func() { nanoclawGOOS = old })
+}
+
+func forbidNanoclawConfirm(t *testing.T) {
+	t.Helper()
+	old := DefaultConfirmPrompt
+	DefaultConfirmPrompt = func(string, ConfirmOptions) (bool, error) {
+		t.Fatalf("did not expect a confirmation prompt")
+		return false, nil
+	}
+	t.Cleanup(func() { DefaultConfirmPrompt = old })
+}
+
+func stubNanoclawConfirm(t *testing.T, answer bool) {
+	t.Helper()
+	old := DefaultConfirmPrompt
+	DefaultConfirmPrompt = func(string, ConfirmOptions) (bool, error) {
+		return answer, nil
+	}
+	t.Cleanup(func() { DefaultConfirmPrompt = old })
+}
+
+func readNanoclawInvocation(t *testing.T, dir string) []string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, "invocation.txt"))
+	if err != nil {
+		t.Fatalf("entrypoint was not invoked (no invocation.txt): %v", err)
+	}
+	var args []string
+	for _, line := range strings.Split(strings.TrimRight(string(data), "\n"), "\n") {
+		if line != "" {
+			args = append(args, line)
+		}
+	}
+	return args
+}
+
+func assertFlagValue(t *testing.T, args []string, flag, want string) {
+	t.Helper()
+	for i, a := range args {
+		if a == flag {
+			if i+1 >= len(args) {
+				t.Fatalf("flag %q has no value in %v", flag, args)
+			}
+			if args[i+1] != want {
+				t.Errorf("%s = %q, want %q", flag, args[i+1], want)
+			}
+			return
+		}
+	}
+	t.Errorf("flag %q not found in %v", flag, args)
+}

--- a/cmd/launch/registry.go
+++ b/cmd/launch/registry.go
@@ -33,7 +33,7 @@ type IntegrationInfo struct {
 	Description string
 }
 
-var launcherIntegrationOrder = []string{"claude", "codex-app", "hermes", "openclaw", "opencode", "hermes-desktop", "codex", "copilot", "omp", "cline", "droid", "pi", "pool", "qwen"}
+var launcherIntegrationOrder = []string{"claude", "codex-app", "hermes", "openclaw", "opencode", "hermes-desktop", "codex", "copilot", "omp", "cline", "droid", "pi", "pool", "qwen", "nanoclaw"}
 
 var integrationSpecs = []*IntegrationSpec{
 	{
@@ -273,6 +273,20 @@ var integrationSpecs = []*IntegrationSpec{
 				return err
 			},
 			URL: "https://qwen.ai/qwencode",
+		},
+	},
+	{
+		Name:        "nanoclaw",
+		Runner:      &Nanoclaw{},
+		Description: "Personal AI assistant orchestrating container agents",
+		Install: IntegrationInstallSpec{
+			CheckInstalled: func() bool {
+				return nanoclawInstalled()
+			},
+			EnsureInstalled: func() error {
+				return ensureNanoclawInstalled()
+			},
+			URL: "https://github.com/nanocoai/nanoclaw",
 		},
 	},
 }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -116,7 +116,8 @@
                 "pages": [
                   "/integrations/openclaw",
                   "/integrations/hermes",
-                  "/integrations/hermes-desktop"
+                  "/integrations/hermes-desktop",
+                  "/integrations/nanoclaw"
                 ]
               },
               {

--- a/docs/integrations/index.mdx
+++ b/docs/integrations/index.mdx
@@ -27,6 +27,7 @@ AI assistants that help with everyday tasks.
 - [OpenClaw](/integrations/openclaw)
 - [Hermes Agent](/integrations/hermes)
 - [Hermes Desktop](/integrations/hermes-desktop)
+- [NanoClaw](/integrations/nanoclaw)
 
 ## IDEs & Editors
 

--- a/docs/integrations/nanoclaw.mdx
+++ b/docs/integrations/nanoclaw.mdx
@@ -1,0 +1,71 @@
+---
+title: NanoClaw
+---
+
+NanoClaw is a personal AI assistant that orchestrates containerized agents on your own machine. Ollama installs it into a self-managed checkout and hands off to NanoClaw's own setup, pointing it at your local Ollama endpoint.
+
+## Quick start
+
+```bash
+ollama launch nanoclaw
+```
+
+The first run walks through setup:
+
+1. **Prerequisites** — NanoClaw needs `git` and `Docker` (it builds a container image and runs each agent in a sandbox). If either is missing, Ollama lists what to install rather than installing it for you.
+2. **Consent** — Because installing clones a repository, builds a Docker image, and starts a background service — and because NanoClaw runs agent-issued actions inside sandboxed containers — Ollama asks you to confirm once before proceeding.
+3. **Install** — Ollama clones NanoClaw into `~/.ollama/launch/nanoclaw`.
+4. **Model** — Pick a model from the selector (local or cloud).
+5. **Launch** — Ollama hands off to NanoClaw's entrypoint, which configures it against your local Ollama host and starts the assistant.
+
+<Note>Installing NanoClaw must be done from an interactive terminal, not a non-interactive or piped session.</Note>
+
+## Prerequisites
+
+- **git** — to fetch NanoClaw
+- **Docker** — to build the image and run sandboxed agents (Docker Desktop on macOS and Windows, Docker Engine on Linux); make sure it is running
+- **bash** — NanoClaw's launch script is POSIX `bash`. On Windows, run it inside WSL2 (`wsl --install`).
+
+## Use a specific model
+
+```bash
+ollama launch nanoclaw --model qwen3-coder:30b
+```
+
+To pick a model without launching:
+
+```bash
+ollama launch nanoclaw --config
+```
+
+## Pass extra arguments
+
+Anything after `--` is forwarded verbatim to NanoClaw's launch script, after the model and Ollama host Ollama already injects:
+
+```bash
+ollama launch nanoclaw -- --some-flag
+```
+
+## Recommended models
+
+NanoClaw drives tools and subagents, so prefer tool-capable models with a generous context window.
+
+**Cloud models**:
+
+- `kimi-k2.5:cloud` — Multimodal reasoning with subagents
+- `qwen3.5:cloud` — Reasoning, coding, and agentic tool use with vision
+- `glm-5.1:cloud` — Reasoning and code generation
+- `minimax-m2.7:cloud` — Fast, efficient coding and real-world productivity
+
+**Local models:**
+
+- `gemma4` — Reasoning and code generation locally (~16 GB VRAM)
+- `qwen3.5` — Reasoning, coding, and visual understanding locally (~11 GB VRAM)
+
+More models at [ollama.com/search](https://ollama.com/search?c=cloud).
+
+<Note>NanoClaw orchestrates multiple agents and tools, so a larger context window helps. See [Context length](/context-length) for more information.</Note>
+
+## Where NanoClaw is installed
+
+Ollama keeps a launch-owned checkout at `~/.ollama/launch/nanoclaw`. To update it, pull the latest there (`git -C ~/.ollama/launch/nanoclaw pull`) or remove the directory and re-run `ollama launch nanoclaw`.


### PR DESCRIPTION
Add `ollama launch nanoclaw`, which installs NanoClaw into a launch-owned checkout (~/.ollama/launch/nanoclaw) and hands off to its entrypoint script configured against the local Ollama endpoint.

- Install is gated behind an interactive-TTY refusal, an aggregated git+Docker prerequisite check, and a single consent prompt; clone-to-temp-then-rename keeps the fixed checkout dir wedge-proof on a partial or invalid clone.
- Hand off via `bash scripts/ollama-launch.sh --model <m> --base-url <host> [--display-name <op> --agent-name "Ollama"]` (the trailing pair first-run only), passing ConnectableHost for --base-url so an OLLAMA_HOST bound to 0.0.0.0/:: is normalized to a loopback the container can reach, and scrubbing cloud provider API keys from the child environment.
- Register non-hidden with CheckInstalled/EnsureInstalled wiring and help text, and add a docs/integrations/nanoclaw.mdx page.