### PR TITLE
server: don't clamp a dedicated GPU carveout to host RAM

### DIFF
--- a/server/sched.go
+++ b/server/sched.go
@@ -925,7 +925,11 @@ func availableMemoryForLoad(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo) (ava
 	var discreteGPUFree uint64
 	for _, gpu := range gpus {
 		gpuFree += gpu.FreeMemory
-		if gpu.Integrated {
+		// A dedicated BIOS carveout larger than host RAM (e.g. Strix Halo) is not
+		// host-shared for budgeting; treat it like discrete VRAM so the host-free
+		// bound below does not collapse its budget.
+		dedicatedCarveout := systemInfo.TotalMemory > 0 && gpu.TotalMemory > systemInfo.TotalMemory
+		if gpu.Integrated && !dedicatedCarveout {
 			sharedGPUFree += gpu.FreeMemory
 		} else {
 			discreteGPUFree += gpu.FreeMemory
@@ -1112,7 +1116,11 @@ func hasDiscreteGPU(gpus []ml.DeviceInfo) bool {
 }
 
 func availableMemoryForGPU(systemInfo ml.SystemInfo, gpu ml.DeviceInfo) uint64 {
-	if gpu.Integrated && systemInfo.FreeMemory > 0 && systemInfo.FreeMemory < gpu.FreeMemory {
+	// The host-free bound applies only to an integrated GPU whose pool is carved live
+	// from host RAM. A dedicated BIOS carveout larger than host RAM (e.g. Strix Halo)
+	// is not bounded by host free memory, so trust the device's own free figure there.
+	dedicatedCarveout := systemInfo.TotalMemory > 0 && gpu.TotalMemory > systemInfo.TotalMemory
+	if gpu.Integrated && !dedicatedCarveout && systemInfo.FreeMemory > 0 && systemInfo.FreeMemory < gpu.FreeMemory {
 		return systemInfo.FreeMemory
 	}
 

--- a/server/sched_carveout_test.go
+++ b/server/sched_carveout_test.go
@@ -1,0 +1,64 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/ollama/ollama/format"
+	"github.com/ollama/ollama/ml"
+)
+
+// availableMemoryForGPU must not clamp a dedicated BIOS carveout (e.g. Strix Halo,
+// where the GPU carveout is larger than host RAM) down to host free memory, while
+// still clamping a genuine host-shared iGPU whose pool is carved from host RAM.
+func TestAvailableMemoryForGPUCarveout(t *testing.T) {
+	cases := []struct {
+		name string
+		sys  ml.SystemInfo
+		gpu  ml.DeviceInfo
+		want uint64
+	}{
+		{
+			name: "large carveout APU not clamped to host RAM",
+			sys:  ml.SystemInfo{TotalMemory: 32 * format.GigaByte, FreeMemory: 4 * format.GigaByte},
+			gpu:  ml.DeviceInfo{Integrated: true, TotalMemory: 96 * format.GigaByte, FreeMemory: 72 * format.GigaByte},
+			want: 72 * format.GigaByte,
+		},
+		{
+			name: "small UMA iGPU still clamped to host free",
+			sys:  ml.SystemInfo{TotalMemory: 16 * format.GigaByte, FreeMemory: 6 * format.GigaByte},
+			gpu:  ml.DeviceInfo{Integrated: true, TotalMemory: 16 * format.GigaByte, FreeMemory: 12 * format.GigaByte},
+			want: 6 * format.GigaByte,
+		},
+		{
+			name: "discrete GPU ignores host free",
+			sys:  ml.SystemInfo{TotalMemory: 16 * format.GigaByte, FreeMemory: 2 * format.GigaByte},
+			gpu:  ml.DeviceInfo{Integrated: false, TotalMemory: 24 * format.GigaByte, FreeMemory: 20 * format.GigaByte},
+			want: 20 * format.GigaByte,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := availableMemoryForGPU(tt.sys, tt.gpu); got != tt.want {
+				t.Fatalf("availableMemoryForGPU = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+// availableMemoryForLoad must treat a dedicated carveout APU like discrete VRAM so
+// the shared-memory host-free bound does not collapse its budget.
+func TestAvailableMemoryForLoadCarveout(t *testing.T) {
+	sys := ml.SystemInfo{TotalMemory: 32 * format.GigaByte, FreeMemory: 4 * format.GigaByte}
+	gpus := []ml.DeviceInfo{{Integrated: true, TotalMemory: 96 * format.GigaByte, FreeMemory: 72 * format.GigaByte}}
+
+	available, gpuFree, systemLimited := availableMemoryForLoad(sys, gpus)
+	if available != 72*format.GigaByte {
+		t.Fatalf("available = %d, want %d", available, 72*format.GigaByte)
+	}
+	if gpuFree != 72*format.GigaByte {
+		t.Fatalf("gpuFree = %d, want %d", gpuFree, 72*format.GigaByte)
+	}
+	if systemLimited {
+		t.Fatalf("systemLimited = true, want false for a dedicated carveout")
+	}
+}


### PR DESCRIPTION
## What

`free`/available GPU memory is clamped to **host free RAM** for integrated GPUs in
`server/sched.go`. On a large BIOS-carveout APU (e.g. Strix Halo, 96 GiB VRAM carveout with 32 GiB host
RAM) that collapses the GPU budget: after the first ~24 GiB model loads, the scheduler believes only a
few GiB are available and evicts the first model when a second is requested, even though both fit in the
96 GiB carveout.

Fixes #16719.

## Why

The host-free clamp is correct for a small-UMA iGPU whose pool is carved live from host RAM (the device
free figure can lag; host free is the live measure). It is wrong when the GPU carveout is *dedicated* and
*larger* than host RAM, because host free can no longer bound it. The same misclassification is in
`availableMemoryForLoad`'s shared/discrete accounting.

## Change

Apply the host-free bound only when the carveout could plausibly come from host RAM, i.e. when the GPU
total does not exceed system total:

```go
dedicatedCarveout := systemInfo.TotalMemory > 0 && gpu.TotalMemory > systemInfo.TotalMemory
if gpu.Integrated && !dedicatedCarveout && systemInfo.FreeMemory > 0 && systemInfo.FreeMemory < gpu.FreeMemory {
    return systemInfo.FreeMemory
}
```

A dedicated carveout is then budgeted like discrete VRAM. When `systemInfo.TotalMemory` is unknown (0),
behavior is unchanged.

## Tests

`server/sched_carveout_test.go`:
- `TestAvailableMemoryForGPUCarveout` — large-carveout APU returns the carveout free (not host free); a
  genuine small-UMA iGPU still clamps to host free; discrete ignores host free.
- `TestAvailableMemoryForLoadCarveout` — the multi-GPU path returns the carveout free with
  `systemLimited=false`.

Existing `TestAvailableMemoryForLoadUsesWorstSharedMemoryMeasurement` (6 subcases) is unchanged and still
passes; `go test ./server/` is green; gofmt/vet/build clean.
