### PR TITLE
fix(server): don't force thinking on for chat requests with tools (#10976)

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -2419,6 +2419,17 @@ func writeChatResponse(c *gin.Context, req api.ChatRequest, ch chan any) {
 	streamResponse(c, ch)
 }
 
+// defaultChatThink resolves the default thinking setting for a thinking-capable
+// model on the chat path when the client expressed no preference. Thinking
+// defaults on, except when tools are also requested: some thinking models (e.g.
+// Qwen3) then express their tool-call intent only inside the reasoning block and
+// never emit tool-call tokens, yielding empty content and no tool calls. The
+// caller still honors an explicit client preference (req.Think != nil).
+// See https://github.com/ollama/ollama/issues/10976.
+func defaultChatThink(hasTools bool) *api.ThinkValue {
+	return &api.ThinkValue{Value: !hasTools}
+}
+
 func (s *Server) ChatHandler(c *gin.Context) {
 	checkpointStart := time.Now()
 
@@ -2598,7 +2609,7 @@ func (s *Server) ChatHandler(c *gin.Context) {
 	if slices.Contains(modelCaps, model.CapabilityThinking) {
 		caps = append(caps, model.CapabilityThinking)
 		if req.Think == nil {
-			req.Think = &api.ThinkValue{Value: true}
+			req.Think = defaultChatThink(len(req.Tools) > 0)
 		}
 	} else {
 		if req.Think != nil && req.Think.Bool() {

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -1137,6 +1137,18 @@ func TestFilterThinkTags(t *testing.T) {
 	}
 }
 
+func TestDefaultChatThink(t *testing.T) {
+	// Thinking-capable model, no tools, no client preference -> thinking on.
+	if v := defaultChatThink(false); v == nil || !v.Bool() {
+		t.Errorf("defaultChatThink(false) = %v, want think on", v)
+	}
+	// Tools requested with no client preference -> thinking off, so the model
+	// emits tool-call tokens instead of burying intent in <think> (#10976).
+	if v := defaultChatThink(true); v == nil || v.Bool() {
+		t.Errorf("defaultChatThink(true) = %v, want think off", v)
+	}
+}
+
 func TestWaitForStream(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/server/routes_think_tools_test.go
+++ b/server/routes_think_tools_test.go
@@ -1,0 +1,123 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/llm"
+)
+
+// TestChatHandlerDefaultThinkWithTools is the end-to-end regression for #10976:
+// a thinking-capable model used with tools and no explicit thinking preference
+// must default thinking OFF, so the model can emit tool tokens instead of
+// burying its decision inside the reasoning block. The mock emits a fixed
+// "<think>deciding</think>hello"; whether ChatHandler engages the thinking
+// parser is observable on the response — Message.Thinking is populated when
+// thinking is on, and the raw <think> text stays in Message.Content when off.
+func TestChatHandlerDefaultThinkWithTools(t *testing.T) {
+	t.Setenv("OLLAMA_GO_TEMPLATE", "1")
+	gin.SetMode(gin.TestMode)
+
+	mock := mockRunner{
+		CompletionResponse: llm.CompletionResponse{
+			Content:            "<think>deciding</think>hello",
+			Done:               true,
+			DoneReason:         llm.DoneReasonStop,
+			PromptEvalCount:    1,
+			PromptEvalDuration: 1,
+			EvalCount:          1,
+			EvalDuration:       1,
+		},
+	}
+	s := newServerWithMockRunner(t, &mock)
+	// Template is both thinking-capable (<think> tags) and tool-capable ({{ .Tools }}).
+	createMinimalGGUFModel(t, s, "thinky", nil,
+		`{{- if .Tools }}{{ .Tools }}{{ end }}{{ range .Messages }}{{ if .Thinking }}<think>{{ .Thinking }}</think>{{ end }}{{ .Content }}{{ end }}`,
+		nil)
+
+	weather := []api.Tool{{Type: "function", Function: api.ToolFunction{Name: "get_weather"}}}
+
+	chat := func(t *testing.T, tools []api.Tool, think *api.ThinkValue) api.ChatResponse {
+		t.Helper()
+		w := createRequest(t, s.ChatHandler, api.ChatRequest{
+			Model:    "thinky",
+			Messages: []api.Message{{Role: "user", Content: "what is the weather?"}},
+			Tools:    tools,
+			Think:    think,
+		})
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		var resp api.ChatResponse
+		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+			t.Fatal(err)
+		}
+		return resp
+	}
+
+	// First request loads the runner (DoneReason "load"); ignore it so the cases
+	// below exercise real completions against a warm runner.
+	_ = chat(t, nil, nil)
+
+	cases := []struct {
+		name      string
+		tools     []api.Tool
+		think     *api.ThinkValue
+		wantThink bool
+	}{
+		{"tools + no preference defaults thinking off", weather, nil, false},
+		{"no tools + no preference keeps thinking on", nil, nil, true},
+		{"explicit think true is honored even with tools", weather, &api.ThinkValue{Value: true}, true},
+		{"explicit think false is honored", nil, &api.ThinkValue{Value: false}, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := chat(t, tc.tools, tc.think)
+			if tc.wantThink {
+				if resp.Message.Thinking != "deciding" {
+					t.Errorf("thinking should be engaged: got Thinking=%q Content=%q", resp.Message.Thinking, resp.Message.Content)
+				}
+			} else {
+				if resp.Message.Thinking != "" {
+					t.Errorf("thinking should be off: got Thinking=%q", resp.Message.Thinking)
+				}
+				if !strings.Contains(resp.Message.Content, "<think>") {
+					t.Errorf("thinking off should leave raw <think> in content: got Content=%q", resp.Message.Content)
+				}
+			}
+		})
+	}
+
+	// A multi-turn conversation carrying a prior assistant tool call with empty
+	// content, with tools and no thinking preference, still defaults thinking off.
+	t.Run("multi-turn tool loop defaults thinking off", func(t *testing.T) {
+		w := createRequest(t, s.ChatHandler, api.ChatRequest{
+			Model: "thinky",
+			Messages: []api.Message{
+				{Role: "user", Content: "weather in Paris?"},
+				{Role: "assistant", Content: "", ToolCalls: []api.ToolCall{
+					{Function: api.ToolCallFunction{Name: "get_weather", Arguments: api.NewToolCallFunctionArguments()}},
+				}},
+				{Role: "tool", Content: "18C"},
+				{Role: "user", Content: "and tomorrow?"},
+			},
+			Tools: weather,
+		})
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		var resp api.ChatResponse
+		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+			t.Fatal(err)
+		}
+		if resp.Message.Thinking != "" {
+			t.Errorf("multi-turn with tools should default thinking off: got Thinking=%q", resp.Message.Thinking)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Fixes #10976. On the chat path, a thinking-capable model (e.g. Qwen3) returns empty content and no tool calls when tools are requested through an OpenAI-compatible client (VS Code Copilot, agent frameworks) that sends no thinking preference.

## Root cause

`ChatHandler` promotes `req.Think` from `nil` to `true` for any model with `CapabilityThinking`. When the client sent no thinking preference (so `req.Think == nil`) **and** tools are present, thinking is forced on — and some thinking models then express their tool-call intent only inside the `<think>` block and never emit the tool-call tokens the parser looks for. The thinking parser strips the reasoning, the tool parser receives an empty string, and the client gets `content: ""` with no `tool_calls`.

(Full code-level trace by @darkmatter2222 in #10976; independently reproduced on Apple Silicon / Metal, Ollama 0.30.6, with a different Qwen3 model.)

## Fix

When a thinking-capable model is used with tools and the client expressed **no** thinking preference, default thinking **off** so the model emits tool-call tokens directly. Explicit client preferences (`req.Think != nil`) are still honored, and behavior is unchanged for requests without tools and for non-thinking models. The policy is in a small `defaultChatThink(hasTools)` helper with a unit test.

This is the server-side version of a mitigation several clients have adopted independently (sending `reasoning_effort: "none"` / `think: false` for thinking models with tools) — fixing it in `ChatHandler` un-breaks every OpenAI-compatible client at once instead of each one special-casing Ollama.

## Test plan

- `gofmt` clean; `go test ./server/` passes, including the new `TestDefaultChatThink` (think on without tools, off with tools).
- End-to-end behavior (empty response → correct tool call) is reproduced in #10976 and independently confirmed on Apple Silicon with a Qwen3 model; this change has not been run against a live model in CI here.

Credit to @darkmatter2222 for the root-cause analysis.
