### PR TITLE
progress: render plain output when stderr is not a TTY

### DIFF
--- a/progress/bar.go
+++ b/progress/bar.go
@@ -149,6 +149,10 @@ func (b *Bar) String() string {
 	return pre.String() + mid.String() + suf.String()
 }
 
+func (b *Bar) PlainString() string {
+	return fmt.Sprintf("%s %.0f%%", strings.TrimSpace(b.message), b.percent())
+}
+
 func (b *Bar) Set(value int64) {
 	if value >= b.maxValue {
 		value = b.maxValue

--- a/progress/bar.go
+++ b/progress/bar.go
@@ -156,6 +156,10 @@ func (b *Bar) String() string {
 	return pre.String() + mid.String() + suf.String()
 }
 
+func (b *Bar) PlainString() string {
+	return fmt.Sprintf("%s %.0f%%", strings.TrimSpace(b.message), b.percent())
+}
+
 func (b *Bar) Set(value int64) {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/progress/progress.go
+++ b/progress/progress.go
@@ -11,6 +11,12 @@ import (
 	"golang.org/x/term"
 )
 
+// PlainStringer is an optional interface for States that can render
+// without ANSI animation sequences, used when output is not a TTY.
+type PlainStringer interface {
+	PlainString() string
+}
+
 const (
 	defaultTermWidth  = 80
 	defaultTermHeight = 24
@@ -27,12 +33,18 @@ type Progress struct {
 
 	pos int
 
-	ticker *time.Ticker
-	states []State
+	ticker  *time.Ticker
+	states  []State
+	tty     bool // true when w is a terminal that supports ANSI codes
+	printed int  // number of states already printed in non-TTY mode
 }
 
 func NewProgress(w io.Writer) *Progress {
-	p := &Progress{w: bufio.NewWriter(w)}
+	tty := false
+	if f, ok := w.(*os.File); ok {
+		tty = term.IsTerminal(int(f.Fd()))
+	}
+	p := &Progress{w: bufio.NewWriter(w), tty: tty}
 	go p.start()
 	return p
 }
@@ -56,7 +68,7 @@ func (p *Progress) stop() bool {
 
 func (p *Progress) Stop() bool {
 	stopped := p.stop()
-	if stopped {
+	if stopped && p.tty {
 		fmt.Fprint(p.w, "\n")
 		p.w.Flush()
 	}
@@ -100,6 +112,22 @@ func (p *Progress) render() {
 	defer p.mu.Unlock()
 
 	defer p.w.Flush()
+
+	if !p.tty {
+		for i := p.printed; i < len(p.states); i++ {
+			var msg string
+			if ps, ok := p.states[i].(PlainStringer); ok {
+				msg = ps.PlainString()
+			} else {
+				msg = p.states[i].String()
+			}
+			if msg != "" {
+				fmt.Fprintln(p.w, msg)
+			}
+		}
+		p.printed = len(p.states)
+		return
+	}
 
 	// eliminate flickering on terminals that support synchronized output
 	fmt.Fprint(p.w, "\033[?2026h")

--- a/progress/progress.go
+++ b/progress/progress.go
@@ -11,6 +11,12 @@ import (
 	"golang.org/x/term"
 )
 
+// PlainStringer is an optional interface for States that can render
+// without ANSI animation sequences, used when output is not a TTY.
+type PlainStringer interface {
+	PlainString() string
+}
+
 const (
 	defaultTermWidth  = 80
 	defaultTermHeight = 24
@@ -29,13 +35,20 @@ type Progress struct {
 
 	states []State
 
+	tty     bool // true when w is a terminal that supports ANSI codes
+	printed int  // number of states already printed in non-TTY mode
+
 	stopOnce sync.Once
 	// done is closed to tell the render loop to exit.
 	done chan struct{}
 }
 
 func NewProgress(w io.Writer) *Progress {
-	p := &Progress{w: bufio.NewWriter(w), done: make(chan struct{})}
+	tty := false
+	if f, ok := w.(*os.File); ok {
+		tty = term.IsTerminal(int(f.Fd()))
+	}
+	p := &Progress{w: bufio.NewWriter(w), tty: tty, done: make(chan struct{})}
 	go p.start()
 	return p
 }
@@ -66,7 +79,7 @@ func (p *Progress) stop() (bool, int) {
 
 func (p *Progress) Stop() bool {
 	stopped, _ := p.stop()
-	if stopped {
+	if stopped && p.tty {
 		fmt.Fprint(p.w, "\n")
 		p.w.Flush()
 	}
@@ -115,6 +128,22 @@ func (p *Progress) renderLocked() {
 	}
 
 	defer p.w.Flush()
+
+	if !p.tty {
+		for i := p.printed; i < len(p.states); i++ {
+			var msg string
+			if ps, ok := p.states[i].(PlainStringer); ok {
+				msg = ps.PlainString()
+			} else {
+				msg = p.states[i].String()
+			}
+			if msg != "" {
+				fmt.Fprintln(p.w, msg)
+			}
+		}
+		p.printed = len(p.states)
+		return
+	}
 
 	// eliminate flickering on terminals that support synchronized output
 	fmt.Fprint(p.w, "\033[?2026h")

--- a/progress/progress_test.go
+++ b/progress/progress_test.go
@@ -1,0 +1,84 @@
+package progress
+
+import (
+	"bufio"
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestNonTTYNoDuplicateLines verifies that in non-TTY mode a spinner
+// message is printed exactly once regardless of how many render ticks fire.
+func TestNonTTYNoDuplicateLines(t *testing.T) {
+	var buf bytes.Buffer
+	p := &Progress{w: bufio.NewWriter(&buf), tty: false}
+	go p.start()
+
+	p.Add("status", NewSpinner("pulling manifest"))
+
+	// Wait for several render ticks (ticker fires every 100ms)
+	time.Sleep(350 * time.Millisecond)
+
+	p.Stop()
+	p.w.Flush()
+
+	got := strings.TrimSpace(buf.String())
+	lines := strings.Split(got, "\n")
+	count := 0
+	for _, l := range lines {
+		if strings.Contains(l, "pulling manifest") {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 line containing %q, got %d:\n%s", "pulling manifest", count, buf.String())
+	}
+}
+
+// TestNonTTYMultipleStates verifies each distinct status prints once in non-TTY mode.
+func TestNonTTYMultipleStates(t *testing.T) {
+	var buf bytes.Buffer
+	p := &Progress{w: bufio.NewWriter(&buf), tty: false}
+	go p.start()
+
+	s1 := NewSpinner("pulling manifest")
+	p.Add("s1", s1)
+	time.Sleep(150 * time.Millisecond)
+
+	s1.Stop()
+	s2 := NewSpinner("verifying sha256 digest")
+	p.Add("s2", s2)
+	time.Sleep(150 * time.Millisecond)
+
+	p.Stop()
+	p.w.Flush()
+
+	out := buf.String()
+	if strings.Count(out, "pulling manifest") != 1 {
+		t.Errorf("expected 1 occurrence of %q:\n%s", "pulling manifest", out)
+	}
+	if strings.Count(out, "verifying sha256 digest") != 1 {
+		t.Errorf("expected 1 occurrence of %q:\n%s", "verifying sha256 digest", out)
+	}
+}
+
+// TestPlainStringerSpinner checks that Spinner.PlainString returns just the message.
+func TestPlainStringerSpinner(t *testing.T) {
+	s := NewSpinner("pulling manifest")
+	got := s.PlainString()
+	if got != "pulling manifest" {
+		t.Errorf("PlainString() = %q, want %q", got, "pulling manifest")
+	}
+	s.Stop()
+}
+
+// TestPlainStringerBar checks that Bar.PlainString returns message + percentage.
+func TestPlainStringerBar(t *testing.T) {
+	b := NewBar("pulling abc123:", 100, 0)
+	b.Set(50)
+	got := b.PlainString()
+	if !strings.Contains(got, "pulling abc123:") || !strings.Contains(got, "50%") {
+		t.Errorf("PlainString() = %q, want message and percentage", got)
+	}
+}

--- a/progress/progress_test.go
+++ b/progress/progress_test.go
@@ -3,6 +3,7 @@ package progress
 import (
 	"bytes"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 )
@@ -88,5 +89,76 @@ func TestSpinnerStopStopsAnimating(t *testing.T) {
 	defer s.mu.Unlock()
 	if s.value != settled {
 		t.Fatalf("spinner still animating after Stop: %d -> %d", settled, s.value)
+	}
+}
+
+// TestNonTTYNoDuplicateLines verifies that in non-TTY mode a spinner
+// message is printed exactly once regardless of how many render ticks fire.
+func TestNonTTYNoDuplicateLines(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewProgress(&buf)
+
+	p.Add("status", NewSpinner("pulling manifest"))
+
+	// Wait for several render ticks (ticker fires every 100ms)
+	time.Sleep(350 * time.Millisecond)
+
+	p.Stop()
+
+	got := strings.TrimSpace(buf.String())
+	lines := strings.Split(got, "\n")
+	count := 0
+	for _, l := range lines {
+		if strings.Contains(l, "pulling manifest") {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 line containing %q, got %d:\n%s", "pulling manifest", count, buf.String())
+	}
+}
+
+// TestNonTTYMultipleStates verifies each distinct status prints once in non-TTY mode.
+func TestNonTTYMultipleStates(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewProgress(&buf)
+
+	s1 := NewSpinner("pulling manifest")
+	p.Add("s1", s1)
+	time.Sleep(150 * time.Millisecond)
+
+	s1.Stop()
+	s2 := NewSpinner("verifying sha256 digest")
+	p.Add("s2", s2)
+	time.Sleep(150 * time.Millisecond)
+
+	p.Stop()
+
+	out := buf.String()
+	if strings.Count(out, "pulling manifest") != 1 {
+		t.Errorf("expected 1 occurrence of %q:\n%s", "pulling manifest", out)
+	}
+	if strings.Count(out, "verifying sha256 digest") != 1 {
+		t.Errorf("expected 1 occurrence of %q:\n%s", "verifying sha256 digest", out)
+	}
+}
+
+// TestPlainStringerSpinner checks that Spinner.PlainString returns just the message.
+func TestPlainStringerSpinner(t *testing.T) {
+	s := NewSpinner("pulling manifest")
+	got := s.PlainString()
+	if got != "pulling manifest" {
+		t.Errorf("PlainString() = %q, want %q", got, "pulling manifest")
+	}
+	s.Stop()
+}
+
+// TestPlainStringerBar checks that Bar.PlainString returns message + percentage.
+func TestPlainStringerBar(t *testing.T) {
+	b := NewBar("pulling abc123:", 100, 0)
+	b.Set(50)
+	got := b.PlainString()
+	if !strings.Contains(got, "pulling abc123:") || !strings.Contains(got, "50%") {
+		t.Errorf("PlainString() = %q, want message and percentage", got)
 	}
 }

--- a/progress/spinner.go
+++ b/progress/spinner.go
@@ -77,3 +77,10 @@ func (s *Spinner) Stop() {
 		s.stopped = time.Now()
 	}
 }
+
+func (s *Spinner) PlainString() string {
+	if m, ok := s.message.Load().(string); ok {
+		return strings.TrimSpace(m)
+	}
+	return ""
+}

--- a/progress/spinner.go
+++ b/progress/spinner.go
@@ -97,3 +97,10 @@ func (s *Spinner) Stop() {
 
 	s.stopOnce.Do(func() { close(s.done) })
 }
+
+func (s *Spinner) PlainString() string {
+	if m, ok := s.message.Load().(string); ok {
+		return strings.TrimSpace(m)
+	}
+	return ""
+}

--- a/progress/stepbar.go
+++ b/progress/stepbar.go
@@ -20,6 +20,10 @@ func (s *StepBar) Set(current int) {
 	s.current = current
 }
 
+func (s *StepBar) PlainString() string {
+	return fmt.Sprintf("%s %d/%d", s.message, s.current, s.total)
+}
+
 func (s *StepBar) String() string {
 	percent := float64(s.current) / float64(s.total) * 100
 	barWidth := s.total


### PR DESCRIPTION
The progress renderer always emitted ANSI escape sequences (cursor moves, line clears, synchronized output) to animate spinners and bars in place. When stderr is not a terminal — output redirected to a file, a pipe, or CI logs — these codes are not interpreted, and since the render ticker fires every 100ms the same line was reprinted on every tick, flooding the output with duplicate lines and raw escape codes.

Detect whether the writer is a terminal in NewProgress and, when it is not, print each state once as plain text instead of animating. A new optional PlainStringer interface lets Spinner, Bar and StepBar provide an ANSI-free representation; a printed counter tracks which states have already been emitted so they are not repeated on later ticks. The trailing newline in Stop is only written in TTY mode.

Fixes #13900