### PR TITLE
docs: update stale README and documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ console.log(response.message.content);
 
 - [AutoGPT](https://github.com/Significant-Gravitas/AutoGPT/blob/master/docs/content/platform/ollama.md) - Autonomous AI agent platform
 - [crewAI](https://github.com/crewAIInc/crewAI) - Multi-agent orchestration framework
-- [Strands Agents](https://github.com/strands-agents/sdk-python) - Model-driven agent building by AWS
+- [Strands Agents](https://github.com/strands-agents/harness-sdk) - Model-driven agent building by AWS
 - [Cheshire Cat](https://github.com/cheshire-cat-ai/core) - AI assistant framework
 - [any-agent](https://github.com/mozilla-ai/any-agent) - Unified agent framework interface by Mozilla
 - [Stakpak](https://github.com/stakpak/agent) - Open source DevOps agent
@@ -310,7 +310,7 @@ console.log(response.message.content);
 - [Vibe](https://github.com/thewh1teagle/vibe) - Transcribe and analyze meetings
 - [Page Assist](https://github.com/n4ze3m/page-assist) - Chrome extension for AI-powered browsing
 - [NativeMind](https://github.com/NativeMindBrowser/NativeMindExtension) - Private, on-device browser AI assistant
-- [Ollama Fortress](https://github.com/ParisNeo/ollama_proxy_server) - Security proxy for Ollama
+- [LoLLMs Hub](https://github.com/ParisNeo/lollms_hub) - Security proxy for Ollama
 - [1Panel](https://github.com/1Panel-dev/1Panel/) - Web-based Linux server management
 - [Writeopia](https://github.com/Writeopia/Writeopia) - Text editor with Ollama integration
 - [QA-Pilot](https://github.com/reid41/QA-Pilot) - GitHub code repository understanding

--- a/docs/integrations/droid.mdx
+++ b/docs/integrations/droid.mdx
@@ -29,7 +29,7 @@ ollama launch droid --config
 
 ### Manual setup
 
-Add a local configuration block to `~/.factory/config.json`:
+Add a local configuration block to `~/.factory/settings.json`:
 
 ```json
 {
@@ -40,7 +40,7 @@ Add a local configuration block to `~/.factory/config.json`:
       "base_url": "http://localhost:11434/v1/",
       "api_key": "not-needed",
       "provider": "generic-chat-completion-api",
-      "max_tokens": 32000 
+      "max_tokens": 64000
     }
   ]
 }
@@ -50,7 +50,7 @@ Add a local configuration block to `~/.factory/config.json`:
 ## Cloud Models
 `qwen3-coder:480b-cloud` is the recommended model for use with Droid.
 
-Add the cloud configuration block to `~/.factory/config.json`:
+Add the cloud configuration block to `~/.factory/settings.json`:
 
 ```json
 {
@@ -70,7 +70,7 @@ Add the cloud configuration block to `~/.factory/config.json`:
 ## Connecting to ollama.com
 
 1. Create an [API key](https://ollama.com/settings/keys) from ollama.com and export it as `OLLAMA_API_KEY`.
-2. Add the cloud configuration block to `~/.factory/config.json`:
+2. Add the cloud configuration block to `~/.factory/settings.json`:
 
    ```json
    {

--- a/docs/integrations/marimo.mdx
+++ b/docs/integrations/marimo.mdx
@@ -55,7 +55,7 @@ would typically point the base url to `http://localhost:11434/v1`.
   />
 </div>
 
-4. Alternatively, you can now use Ollama for **inline code completion** in marimo. This can be configured in the "AI Features" tab. 
+5. Alternatively, you can now use Ollama for **inline code completion** in marimo. This can be configured in the "AI Features" tab.
 
 <div style={{ display: 'flex', justifyContent: 'center' }}>
   <img 


### PR DESCRIPTION
This PR fixes documentation inconsistencies in the Ollama README and integration docs.

## Commits

https://github.com/ollama/ollama/commit/3013660df9e9af6a63b89abc9bbf6cdd45abc947

Updates root `README.md` community integration links to use current canonical targets:
- Strands Agents now points to `strands-agents/harness-sdk`.
- LoLLMs Hub now points to `ParisNeo/lollms_hub` and uses the current project name.

https://github.com/ollama/ollama/commit/d63dc9c052d26eae6f53e36c0b77dc51354565e9

Updates Droid integration docs to match `cmd/launch/droid.go`:
- Uses `~/.factory/settings.json` instead of stale `~/.factory/config.json`. (source: https://docs.factory.ai/cli/configuration/settings)
- Updates the local example `max_tokens` from `32000` to `64000`, matching the documented 64k context recommendation.

https://github.com/ollama/ollama/commit/4ef236394c185e7b5c5cdabecacbff9e83b49339

Fixes duplicate numbered steps in `docs/integrations/marimo.mdx` by changing the second `4.` item to `5.`.