### PR TITLE
fix(cmd): don't write terminal escape sequences when stdout is redirected (#16785)

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -795,7 +795,10 @@ func RunHandler(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	opts.WordWrap = !nowrap
+	// Word wrapping emits ANSI cursor-movement escape sequences, so only enable
+	// it when stdout is an interactive terminal. When stdout is redirected to a
+	// file or pipe the escapes would otherwise be written verbatim into the output.
+	opts.WordWrap = !nowrap && term.IsTerminal(int(os.Stdout.Fd()))
 
 	// Fill out the rest of the options based on information about the
 	// model.


### PR DESCRIPTION
## Summary

Fixes #16785.

When running `ollama run <model> "prompt" > file` (stdout redirected to a file or pipe), the output file contained raw ANSI terminal escape sequences instead of clean text.

Root cause is in the word-wrap path. `displayResponse` emits cursor-movement escapes (`\x1b[<n>D` to backtrack and `\x1b[K` to clear to end of line) while wrapping:

```go
a := runewidth.StringWidth(state.wordBuffer)
if a > 0 {
    fmt.Printf("\x1b[%dD", a)
}
fmt.Printf("\x1b[K\n")
```

In `RunHandler`, when stdout is **not** a terminal we only set `interactive = false`, but the following line unconditionally re-enables word wrap:

```go
opts.WordWrap = !nowrap
```

(The `opts.WordWrap = false` set when stdin is not a terminal is also clobbered by this line.) When stdout is redirected, `term.GetSize` fails and `displayResponse` falls back to `termWidth = 80`, so word wrap stays on and the escape sequences land in the output file.

## Fix

Gate word wrap on stdout being an interactive terminal, mirroring the existing intent of disabling it for non-terminal output:

```go
opts.WordWrap = !nowrap && term.IsTerminal(int(os.Stdout.Fd()))
```

Word wrapping is purely a visual convenience for an interactive terminal, so suppressing it (and its escapes) when stdout is a file/pipe yields clean redirected output without changing terminal behavior.

## Test plan

- [ ] `ollama run <model> "say hi" > out.txt` → `out.txt` contains plain UTF-8 text with no `\x1b[` sequences
- [ ] `ollama run <model> "say hi" | cat` → clean piped output
- [ ] Interactive terminal run still word-wraps as before
- [ ] `--nowordwrap` still disables wrapping in a terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)
