### PR TITLE
app: add first-run terminal onboarding

### DIFF
--- a/app/cmd/app/app.go
+++ b/app/cmd/app/app.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ollama/ollama/app/ui"
 	"github.com/ollama/ollama/app/updater"
 	"github.com/ollama/ollama/app/version"
+	ollamaConfig "github.com/ollama/ollama/cmd/config"
 )
 
 var (
@@ -303,17 +304,7 @@ func main() {
 		}
 	}
 
-	hasCompletedFirstRun, err := st.HasCompletedFirstRun()
-	if err != nil {
-		slog.Error("failed to load has completed first run", "error", err)
-	}
-
-	if !hasCompletedFirstRun {
-		err = st.SetHasCompletedFirstRun(true)
-		if err != nil {
-			slog.Error("failed to set has completed first run", "error", err)
-		}
-	}
+	hasCompletedFirstRun := hasCompletedAppTerminalPrompt(st)
 
 	// capture SIGINT and SIGTERM signals and gracefully shutdown the app
 	signals := make(chan os.Signal, 1)
@@ -353,6 +344,33 @@ func main() {
 	slog.Info("shutting down ollama server")
 	cancel()
 	<-done
+}
+
+func hasCompletedAppTerminalPrompt(st *store.Store) bool {
+	completed, ok, err := ollamaConfig.LookupOnboardingCompleted(ollamaConfig.OnboardingSectionApp, ollamaConfig.OnboardingKeyTerminalPrompt)
+	if err != nil {
+		slog.Error("failed to load onboarding status", "error", err)
+		return false
+	}
+	if ok {
+		return completed
+	}
+
+	// Bridge the legacy SQLite first-run flag into the shared JSON config so
+	// existing app users do not see onboarding again after this migration.
+	hasCompletedLegacyFirstRun, err := st.HasCompletedFirstRun()
+	if err != nil {
+		slog.Error("failed to load legacy first run status", "error", err)
+		return false
+	}
+	if !hasCompletedLegacyFirstRun {
+		return false
+	}
+
+	if err := ollamaConfig.MarkOnboardingCompleted(ollamaConfig.OnboardingSectionApp, ollamaConfig.OnboardingKeyTerminalPrompt); err != nil {
+		slog.Warn("failed to migrate first run status to config", "error", err)
+	}
+	return true
 }
 
 func startHiddenTasks() {

--- a/app/ui/app/codegen/gotypes.gen.ts
+++ b/app/ui/app/codegen/gotypes.gen.ts
@@ -439,10 +439,12 @@ export class Settings {
 }
 export class SettingsResponse {
     settings: Settings;
+    hasCompletedFirstRun: boolean;
 
     constructor(source: any = {}) {
         if ('string' === typeof source) source = JSON.parse(source);
         this.settings = this.convertValues(source["settings"], Settings);
+        this.hasCompletedFirstRun = source["hasCompletedFirstRun"];
     }
 
 	convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/app/ui/app/src/api.ts
+++ b/app/ui/app/src/api.ts
@@ -32,6 +32,10 @@ export interface CloudStatusResponse {
   disabled: boolean;
   source: CloudStatusSource;
 }
+export interface SettingsResponse {
+  settings: Settings;
+  hasCompletedFirstRun: boolean;
+}
 // Helper function to convert Uint8Array to base64
 function uint8ArrayToBase64(uint8Array: Uint8Array): string {
   const chunkSize = 0x8000; // 32KB chunks to avoid stack overflow
@@ -257,9 +261,7 @@ export async function* sendMessage(
   }
 }
 
-export async function getSettings(): Promise<{
-  settings: Settings;
-}> {
+export async function getSettings(): Promise<SettingsResponse> {
   const response = await fetch(`${API_BASE}/api/v1/settings`);
   if (!response.ok) {
     throw new Error("Failed to fetch settings");
@@ -267,12 +269,13 @@ export async function getSettings(): Promise<{
   const data = await response.json();
   return {
     settings: new Settings(data.settings),
+    hasCompletedFirstRun: Boolean(data.hasCompletedFirstRun),
   };
 }
 
-export async function updateSettings(settings: Settings): Promise<{
-  settings: Settings;
-}> {
+export async function updateSettings(
+  settings: Settings,
+): Promise<SettingsResponse> {
   const response = await fetch(`${API_BASE}/api/v1/settings`, {
     method: "POST",
     headers: {
@@ -287,7 +290,28 @@ export async function updateSettings(settings: Settings): Promise<{
   const data = await response.json();
   return {
     settings: new Settings(data.settings),
+    hasCompletedFirstRun: Boolean(data.hasCompletedFirstRun),
   };
+}
+
+export async function skipFirstRun(): Promise<void> {
+  const response = await fetch(`${API_BASE}/api/v1/first-run/skip`, {
+    method: "POST",
+  });
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(error || "Failed to skip first run");
+  }
+}
+
+export async function runOllamaInTerminal(): Promise<void> {
+  const response = await fetch(`${API_BASE}/api/v1/first-run/terminal`, {
+    method: "POST",
+  });
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(error || "Failed to open terminal");
+  }
 }
 
 export async function updateCloudSetting(
@@ -418,7 +442,9 @@ export interface ModelRecommendationsResponse {
   recommendations: ModelRecommendation[];
 }
 
-export async function getModelRecommendations(): Promise<ModelRecommendation[]> {
+export async function getModelRecommendations(): Promise<
+  ModelRecommendation[]
+> {
   const response = await fetch(
     `${API_BASE}/api/experimental/model-recommendations`,
   );

--- a/app/ui/app/src/components/FirstRunPrompt.tsx
+++ b/app/ui/app/src/components/FirstRunPrompt.tsx
@@ -3,7 +3,6 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { runOllamaInTerminal, skipFirstRun } from "@/api";
 import type { SettingsResponse } from "@/api";
 import CopyButton from "@/components/CopyButton";
-import { Button } from "@/components/ui/button";
 
 interface FirstRunPromptProps {
   open: boolean;
@@ -45,7 +44,7 @@ export function FirstRunPrompt({ open }: FirstRunPromptProps) {
         aria-modal="true"
         aria-label="Run Ollama in terminal"
         aria-describedby="first-run-description"
-        className="w-full max-w-[620px] text-neutral-950 dark:text-white"
+        className="flex min-h-[620px] w-full max-w-[500px] flex-col justify-center text-neutral-950 dark:text-white"
       >
         <div>
           <div className="flex items-center justify-center gap-4">
@@ -91,25 +90,23 @@ export function FirstRunPrompt({ open }: FirstRunPromptProps) {
           ) : null}
         </div>
 
-        <div className="mt-8 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-          <Button
-            plain
+        <div className="mt-8 flex flex-col-reverse items-stretch justify-center gap-3 sm:flex-row sm:items-center">
+          <button
             type="button"
             onClick={() => skipMutation.mutate()}
             disabled={pending}
-            className="w-full sm:w-auto"
+            className="inline-flex h-12 items-center justify-center rounded-full bg-neutral-100 px-8 text-lg font-normal text-neutral-950 transition hover:bg-neutral-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-300 disabled:pointer-events-none disabled:opacity-50 dark:bg-neutral-800 dark:text-neutral-50 dark:hover:bg-neutral-700 dark:focus-visible:ring-neutral-600"
           >
             Skip
-          </Button>
-          <Button
+          </button>
+          <button
             type="button"
             onClick={() => runMutation.mutate()}
             disabled={pending}
-            className="w-full sm:w-auto"
+            className="inline-flex h-12 items-center justify-center gap-3 rounded-full bg-black px-8 text-lg font-normal text-white shadow-sm transition hover:bg-neutral-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-400 disabled:pointer-events-none disabled:opacity-50 dark:bg-white dark:text-black dark:hover:bg-neutral-200 dark:focus-visible:ring-neutral-500"
           >
-            <CommandLineIcon data-slot="icon" aria-hidden="true" />
-            Run Ollama in terminal
-          </Button>
+            Open in terminal
+          </button>
         </div>
       </div>
     </div>

--- a/app/ui/app/src/components/FirstRunPrompt.tsx
+++ b/app/ui/app/src/components/FirstRunPrompt.tsx
@@ -1,0 +1,117 @@
+import { CommandLineIcon } from "@heroicons/react/24/outline";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { runOllamaInTerminal, skipFirstRun } from "@/api";
+import type { SettingsResponse } from "@/api";
+import CopyButton from "@/components/CopyButton";
+import { Button } from "@/components/ui/button";
+
+interface FirstRunPromptProps {
+  open: boolean;
+}
+
+export function FirstRunPrompt({ open }: FirstRunPromptProps) {
+  const queryClient = useQueryClient();
+
+  const dismiss = () => {
+    queryClient.setQueryData<SettingsResponse | undefined>(
+      ["settings"],
+      (current) => {
+        if (!current) return current;
+        return { ...current, hasCompletedFirstRun: true };
+      },
+    );
+    queryClient.invalidateQueries({ queryKey: ["settings"] });
+  };
+
+  const runMutation = useMutation({
+    mutationFn: runOllamaInTerminal,
+    onSuccess: dismiss,
+  });
+
+  const skipMutation = useMutation({
+    mutationFn: skipFirstRun,
+    onSuccess: dismiss,
+  });
+
+  if (!open) return null;
+
+  const pending = runMutation.isPending || skipMutation.isPending;
+  const error = runMutation.error ?? skipMutation.error;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-white px-5 py-10 dark:bg-neutral-900">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Run Ollama in terminal"
+        aria-describedby="first-run-description"
+        className="w-full max-w-[620px] text-neutral-950 dark:text-white"
+      >
+        <div>
+          <div className="flex items-center justify-center gap-4">
+            <img
+              src="/hello.png"
+              alt=""
+              draggable={false}
+              className="h-100 w-100 select-none dark:invert"
+            />
+            <span className="-mt-40 font-rounded text-4xl font-semibold text-neutral-950 dark:text-neutral-50">
+              hi!
+            </span>
+          </div>
+
+          <div className="-mt-5 flex min-h-15 items-center gap-4 max-w-s rounded-[28px] bg-neutral-100 py-4 pr-4 pl-6 dark:bg-neutral-800">
+            <CommandLineIcon
+              aria-hidden="true"
+              className="h-5 w-5 shrink-0 text-neutral-400 dark:text-neutral-500"
+            />
+            <code className="min-w-0 truncate font-mono text-xl font-normal tracking-normal text-neutral-700 dark:text-neutral-200">
+              ollama
+            </code>
+            <CopyButton
+              content="ollama"
+              size="md"
+              title="Copy command to clipboard"
+              className="ml-auto text-neutral-500 hover:bg-neutral-200/60 hover:text-neutral-700 dark:text-neutral-400 dark:hover:bg-neutral-700/70 dark:hover:text-neutral-200"
+            />
+          </div>
+
+          <p
+            id="first-run-description"
+            className="mt-5 text-center text-sm/6 text-neutral-500 dark:text-neutral-400"
+          >
+            Run Ollama in your terminal to get started.
+          </p>
+
+          {error ? (
+            <p className="mt-6 rounded-xl border border-red-200 bg-red-50 px-3 py-2 text-center text-sm/6 text-red-700 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-200">
+              Could not open a terminal. Run{" "}
+              <span className="font-mono">ollama</span>.
+            </p>
+          ) : null}
+        </div>
+
+        <div className="mt-8 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <Button
+            plain
+            type="button"
+            onClick={() => skipMutation.mutate()}
+            disabled={pending}
+            className="w-full sm:w-auto"
+          >
+            Skip
+          </Button>
+          <Button
+            type="button"
+            onClick={() => runMutation.mutate()}
+            disabled={pending}
+            className="w-full sm:w-auto"
+          >
+            <CommandLineIcon data-slot="icon" aria-hidden="true" />
+            Run Ollama in terminal
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/ui/app/src/hooks/useSettings.ts
+++ b/app/ui/app/src/hooks/useSettings.ts
@@ -5,6 +5,7 @@ import { useMemo, useCallback } from "react";
 
 // TODO(hoyyeva): remove turboEnabled when we remove Migration logic in useSelectedModel.ts
 interface SettingsState {
+  hasCompletedFirstRun: boolean;
   turboEnabled: boolean;
   webSearchEnabled: boolean;
   selectedModel: string;
@@ -46,6 +47,7 @@ export function useSettings() {
   // Extract settings with defaults
   const settings: SettingsState = useMemo(
     () => ({
+      hasCompletedFirstRun: settingsData?.hasCompletedFirstRun ?? true,
       turboEnabled: settingsData?.settings?.TurboEnabled ?? false,
       webSearchEnabled: settingsData?.settings?.WebSearchEnabled ?? false,
       thinkEnabled: settingsData?.settings?.ThinkEnabled ?? false,
@@ -54,7 +56,7 @@ export function useSettings() {
       sidebarOpen: settingsData?.settings?.SidebarOpen ?? false,
       lastHomeView: settingsData?.settings?.LastHomeView ?? "launch",
     }),
-    [settingsData?.settings],
+    [settingsData?.hasCompletedFirstRun, settingsData?.settings],
   );
 
   // Single function to update most settings

--- a/app/ui/app/src/routes/__root.tsx
+++ b/app/ui/app/src/routes/__root.tsx
@@ -3,21 +3,26 @@ import { createRootRouteWithContext, Outlet } from "@tanstack/react-router";
 import { getSettings } from "@/api";
 import { useQuery } from "@tanstack/react-query";
 import { useCloudStatus } from "@/hooks/useCloudStatus";
+import { FirstRunPrompt } from "@/components/FirstRunPrompt";
 
 function RootComponent() {
   // This hook ensures settings are fetched on app startup
-  useQuery({
+  const { data: settingsData, isLoading } = useQuery({
     queryKey: ["settings"],
     queryFn: getSettings,
   });
   // Fetch cloud status on startup (best-effort)
   useCloudStatus();
 
-  return (
-    <div>
-      <Outlet />
-    </div>
-  );
+  if (isLoading) {
+    return <div className="min-h-screen bg-white dark:bg-neutral-900" />;
+  }
+
+  if (settingsData?.hasCompletedFirstRun === false) {
+    return <FirstRunPrompt open />;
+  }
+
+  return <Outlet />;
 }
 
 export const Route = createRootRouteWithContext<{

--- a/app/ui/responses/types.go
+++ b/app/ui/responses/types.go
@@ -94,7 +94,8 @@ type ErrorEvent struct {
 }
 
 type SettingsResponse struct {
-	Settings store.Settings `json:"settings"`
+	Settings             store.Settings `json:"settings"`
+	HasCompletedFirstRun bool           `json:"hasCompletedFirstRun"`
 }
 
 type HealthResponse struct {

--- a/app/ui/ui.go
+++ b/app/ui/ui.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"os"
+	"os/exec"
 	"runtime"
 	"runtime/debug"
 	"slices"
@@ -31,6 +32,7 @@ import (
 	"github.com/ollama/ollama/app/updater"
 	"github.com/ollama/ollama/app/version"
 	ollamaAuth "github.com/ollama/ollama/auth"
+	ollamaConfig "github.com/ollama/ollama/cmd/config"
 	"github.com/ollama/ollama/envconfig"
 	"github.com/ollama/ollama/manifest"
 	"github.com/ollama/ollama/types/model"
@@ -290,6 +292,8 @@ func (s *Server) Handler() http.Handler {
 	mux.Handle("POST /api/v1/model/upstream", handle(s.modelUpstream))
 	mux.Handle("GET /api/v1/settings", handle(s.getSettings))
 	mux.Handle("POST /api/v1/settings", handle(s.settings))
+	mux.Handle("POST /api/v1/first-run/skip", handle(s.skipFirstRun))
+	mux.Handle("POST /api/v1/first-run/terminal", handle(s.runOllamaInTerminal))
 	mux.Handle("GET /api/v1/cloud", handle(s.getCloudSetting))
 	mux.Handle("POST /api/v1/cloud", handle(s.cloudSetting))
 
@@ -1454,7 +1458,8 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) error {
 
 	w.Header().Set("Content-Type", "application/json")
 	return json.NewEncoder(w).Encode(responses.SettingsResponse{
-		Settings: settings,
+		Settings:             settings,
+		HasCompletedFirstRun: s.hasCompletedAppTerminalPrompt(),
 	})
 }
 
@@ -1499,8 +1504,73 @@ func (s *Server) settings(w http.ResponseWriter, r *http.Request) error {
 
 	w.Header().Set("Content-Type", "application/json")
 	return json.NewEncoder(w).Encode(responses.SettingsResponse{
-		Settings: settings,
+		Settings:             settings,
+		HasCompletedFirstRun: s.hasCompletedAppTerminalPrompt(),
 	})
+}
+
+func (s *Server) skipFirstRun(w http.ResponseWriter, r *http.Request) error {
+	if err := ollamaConfig.MarkOnboardingCompleted(ollamaConfig.OnboardingSectionApp, ollamaConfig.OnboardingKeyTerminalPrompt); err != nil {
+		return fmt.Errorf("failed to save first run status: %w", err)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	return json.NewEncoder(w).Encode(map[string]bool{"ok": true})
+}
+
+func (s *Server) runOllamaInTerminal(w http.ResponseWriter, r *http.Request) error {
+	if err := ollamaConfig.MarkOnboardingCompleted(ollamaConfig.OnboardingSectionApp, ollamaConfig.OnboardingKeyTerminalPrompt); err != nil {
+		return fmt.Errorf("failed to save first run status: %w", err)
+	}
+
+	if err := openTerminalWithOllama(); err != nil {
+		return fmt.Errorf("open terminal: %w", err)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	return json.NewEncoder(w).Encode(map[string]bool{"ok": true})
+}
+
+var openTerminalWithOllama = defaultOpenTerminalWithOllama
+
+func defaultOpenTerminalWithOllama() error {
+	switch runtime.GOOS {
+	case "darwin":
+		script := `tell application "Terminal"
+	activate
+	do script "ollama"
+end tell`
+		return exec.Command("osascript", "-e", script).Run()
+	case "windows":
+		return exec.Command("cmd", "/C", "start", "", "cmd", "/K", "ollama").Run()
+	default:
+		return fmt.Errorf("unsupported platform %s", runtime.GOOS)
+	}
+}
+
+func (s *Server) hasCompletedAppTerminalPrompt() bool {
+	completed, ok, err := ollamaConfig.LookupOnboardingCompleted(ollamaConfig.OnboardingSectionApp, ollamaConfig.OnboardingKeyTerminalPrompt)
+	if err != nil {
+		s.log().Warn("failed to load onboarding status", "error", err)
+		return false
+	}
+	if ok {
+		return completed
+	}
+
+	hasCompletedLegacyFirstRun, err := s.Store.HasCompletedFirstRun()
+	if err != nil {
+		s.log().Warn("failed to load legacy first run status", "error", err)
+		return false
+	}
+	if !hasCompletedLegacyFirstRun {
+		return false
+	}
+
+	if err := ollamaConfig.MarkOnboardingCompleted(ollamaConfig.OnboardingSectionApp, ollamaConfig.OnboardingKeyTerminalPrompt); err != nil {
+		s.log().Warn("failed to migrate first run status to config", "error", err)
+	}
+	return true
 }
 
 func (s *Server) cloudSetting(w http.ResponseWriter, r *http.Request) error {

--- a/app/ui/ui_test.go
+++ b/app/ui/ui_test.go
@@ -18,7 +18,15 @@ import (
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/app/store"
 	"github.com/ollama/ollama/app/updater"
+	ollamaConfig "github.com/ollama/ollama/cmd/config"
 )
+
+func setUITestHome(t *testing.T, home string) {
+	t.Helper()
+	t.Setenv("HOME", home)
+	t.Setenv("TMPDIR", home)
+	t.Setenv("USERPROFILE", home)
+}
 
 func TestHandlePostApiSettings(t *testing.T) {
 	tests := []struct {
@@ -217,6 +225,197 @@ func TestHandleGetApiCloudSetting(t *testing.T) {
 	}
 	if got["source"] != "config" {
 		t.Fatalf("response source = %v, want config", got["source"])
+	}
+}
+
+func TestHandleGetApiSettingsIncludesFirstRunStatus(t *testing.T) {
+	tmpHome := t.TempDir()
+	setUITestHome(t, tmpHome)
+
+	testStore := &store.Store{
+		DBPath: filepath.Join(tmpHome, "db.sqlite"),
+	}
+	defer testStore.Close()
+
+	server := &Server{
+		Store: testStore,
+	}
+
+	if err := testStore.SetHasCompletedFirstRun(false); err != nil {
+		t.Fatalf("SetHasCompletedFirstRun(false) error = %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/api/v1/settings", nil)
+	rr := httptest.NewRecorder()
+	if err := server.getSettings(rr, req); err != nil {
+		t.Fatalf("getSettings() error = %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("getSettings() invalid response JSON: %v", err)
+	}
+	if got["hasCompletedFirstRun"] != false {
+		t.Fatalf("hasCompletedFirstRun = %v, want false", got["hasCompletedFirstRun"])
+	}
+
+	if err := ollamaConfig.MarkOnboardingCompleted(ollamaConfig.OnboardingSectionApp, ollamaConfig.OnboardingKeyTerminalPrompt); err != nil {
+		t.Fatalf("MarkOnboardingCompleted() error = %v", err)
+	}
+
+	rr = httptest.NewRecorder()
+	if err := server.getSettings(rr, req); err != nil {
+		t.Fatalf("getSettings() after completion error = %v", err)
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("getSettings() after completion invalid response JSON: %v", err)
+	}
+	if got["hasCompletedFirstRun"] != true {
+		t.Fatalf("hasCompletedFirstRun = %v, want true", got["hasCompletedFirstRun"])
+	}
+}
+
+func TestHandleGetApiSettingsMigratesLegacyFirstRunStatus(t *testing.T) {
+	tmpHome := t.TempDir()
+	setUITestHome(t, tmpHome)
+
+	testStore := &store.Store{
+		DBPath: filepath.Join(tmpHome, "db.sqlite"),
+	}
+	defer testStore.Close()
+
+	if err := testStore.SetHasCompletedFirstRun(true); err != nil {
+		t.Fatalf("SetHasCompletedFirstRun(true) error = %v", err)
+	}
+
+	server := &Server{
+		Store: testStore,
+	}
+
+	req := httptest.NewRequest("GET", "/api/v1/settings", nil)
+	rr := httptest.NewRecorder()
+	if err := server.getSettings(rr, req); err != nil {
+		t.Fatalf("getSettings() error = %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("getSettings() invalid response JSON: %v", err)
+	}
+	if got["hasCompletedFirstRun"] != true {
+		t.Fatalf("hasCompletedFirstRun = %v, want true", got["hasCompletedFirstRun"])
+	}
+	if !ollamaConfig.OnboardingCompleted(ollamaConfig.OnboardingSectionApp, ollamaConfig.OnboardingKeyTerminalPrompt) {
+		t.Fatal("expected legacy first-run status to migrate into onboarding config")
+	}
+}
+
+func TestHandleGetApiSettingsRespectsExplicitOnboardingFalse(t *testing.T) {
+	tmpHome := t.TempDir()
+	setUITestHome(t, tmpHome)
+
+	testStore := &store.Store{
+		DBPath: filepath.Join(tmpHome, "db.sqlite"),
+	}
+	defer testStore.Close()
+
+	if err := testStore.SetHasCompletedFirstRun(true); err != nil {
+		t.Fatalf("SetHasCompletedFirstRun(true) error = %v", err)
+	}
+	if err := ollamaConfig.SetOnboardingCompleted(ollamaConfig.OnboardingSectionApp, ollamaConfig.OnboardingKeyTerminalPrompt, false); err != nil {
+		t.Fatalf("SetOnboardingCompleted(false) error = %v", err)
+	}
+
+	server := &Server{
+		Store: testStore,
+	}
+
+	req := httptest.NewRequest("GET", "/api/v1/settings", nil)
+	rr := httptest.NewRecorder()
+	if err := server.getSettings(rr, req); err != nil {
+		t.Fatalf("getSettings() error = %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("getSettings() invalid response JSON: %v", err)
+	}
+	if got["hasCompletedFirstRun"] != false {
+		t.Fatalf("hasCompletedFirstRun = %v, want false", got["hasCompletedFirstRun"])
+	}
+	completed, ok, err := ollamaConfig.LookupOnboardingCompleted(ollamaConfig.OnboardingSectionApp, ollamaConfig.OnboardingKeyTerminalPrompt)
+	if err != nil {
+		t.Fatalf("LookupOnboardingCompleted() error = %v", err)
+	}
+	if !ok || completed {
+		t.Fatalf("onboarding lookup = %v, %v, want false, true", completed, ok)
+	}
+}
+
+func TestHandleFirstRunSkipMarksCompleted(t *testing.T) {
+	tmpHome := t.TempDir()
+	setUITestHome(t, tmpHome)
+
+	testStore := &store.Store{
+		DBPath: filepath.Join(tmpHome, "db.sqlite"),
+	}
+	defer testStore.Close()
+
+	server := &Server{
+		Store: testStore,
+	}
+
+	req := httptest.NewRequest("POST", "/api/v1/first-run/skip", nil)
+	rr := httptest.NewRecorder()
+	if err := server.skipFirstRun(rr, req); err != nil {
+		t.Fatalf("skipFirstRun() error = %v", err)
+	}
+	if rr.Code != http.StatusOK {
+		t.Fatalf("skipFirstRun() status = %d, want %d", rr.Code, http.StatusOK)
+	}
+
+	if !ollamaConfig.OnboardingCompleted(ollamaConfig.OnboardingSectionApp, ollamaConfig.OnboardingKeyTerminalPrompt) {
+		t.Fatal("OnboardingCompleted(app terminal prompt) = false, want true")
+	}
+}
+
+func TestHandleFirstRunTerminalMarksCompletedAndOpensTerminal(t *testing.T) {
+	tmpHome := t.TempDir()
+	setUITestHome(t, tmpHome)
+
+	testStore := &store.Store{
+		DBPath: filepath.Join(tmpHome, "db.sqlite"),
+	}
+	defer testStore.Close()
+
+	called := false
+	originalOpenTerminal := openTerminalWithOllama
+	openTerminalWithOllama = func() error {
+		called = true
+		return nil
+	}
+	defer func() {
+		openTerminalWithOllama = originalOpenTerminal
+	}()
+
+	server := &Server{
+		Store: testStore,
+	}
+
+	req := httptest.NewRequest("POST", "/api/v1/first-run/terminal", nil)
+	rr := httptest.NewRecorder()
+	if err := server.runOllamaInTerminal(rr, req); err != nil {
+		t.Fatalf("runOllamaInTerminal() error = %v", err)
+	}
+	if rr.Code != http.StatusOK {
+		t.Fatalf("runOllamaInTerminal() status = %d, want %d", rr.Code, http.StatusOK)
+	}
+	if !called {
+		t.Fatal("openTerminalWithOllama was not called")
+	}
+
+	if !ollamaConfig.OnboardingCompleted(ollamaConfig.OnboardingSectionApp, ollamaConfig.OnboardingKeyTerminalPrompt) {
+		t.Fatal("OnboardingCompleted(app terminal prompt) = false, want true")
 	}
 }
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -2341,7 +2341,7 @@ func NewCLI() *cobra.Command {
 
 	rootCmd := &cobra.Command{
 		Use:           "ollama",
-		Short:         "Large language model runner",
+		Short:         "Run the Ollama interactive menu",
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		CompletionOptions: cobra.CompletionOptions{

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -1,8 +1,9 @@
-// Package config provides integration configuration for external coding tools
-// (Claude Code, Codex, Droid, OpenCode) to use Ollama models.
+// Package config provides shared Ollama CLI configuration, including launch
+// integration settings and scoped onboarding state.
 package config
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -23,10 +24,16 @@ type integration struct {
 type IntegrationConfig = integration
 
 type config struct {
-	Integrations  map[string]*integration `json:"integrations"`
-	LastModel     string                  `json:"last_model,omitempty"`
-	LastSelection string                  `json:"last_selection,omitempty"` // "run" or integration name
+	Integrations  map[string]*integration    `json:"integrations"`
+	Onboarding    map[string]map[string]bool `json:"onboarding,omitempty"`
+	LastModel     string                     `json:"last_model,omitempty"`
+	LastSelection string                     `json:"last_selection,omitempty"` // "run" or integration name
 }
+
+const (
+	OnboardingSectionApp        = "app"
+	OnboardingKeyTerminalPrompt = "terminal_prompt"
+)
 
 func configPath() (string, error) {
 	home, err := os.UserHomeDir()
@@ -101,12 +108,26 @@ func load() (*config, error) {
 		return nil, err
 	}
 
-	var cfg config
-	if err := json.Unmarshal(data, &cfg); err != nil {
+	var raw struct {
+		Integrations  map[string]*integration `json:"integrations"`
+		Onboarding    json.RawMessage         `json:"onboarding,omitempty"`
+		LastModel     string                  `json:"last_model,omitempty"`
+		LastSelection string                  `json:"last_selection,omitempty"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
 		return nil, fmt.Errorf("failed to parse config: %w, at: %s", err, path)
+	}
+	cfg := config{
+		Integrations:  raw.Integrations,
+		Onboarding:    parseOnboarding(raw.Onboarding),
+		LastModel:     raw.LastModel,
+		LastSelection: raw.LastSelection,
 	}
 	if cfg.Integrations == nil {
 		cfg.Integrations = make(map[string]*integration)
+	}
+	if cfg.Onboarding == nil {
+		cfg.Onboarding = make(map[string]map[string]bool)
 	}
 	return &cfg, nil
 }
@@ -228,6 +249,138 @@ func SetLastSelection(selection string) error {
 	}
 	cfg.LastSelection = selection
 	return save(cfg)
+}
+
+// OnboardingCompleted returns true when the named onboarding item has been completed.
+func OnboardingCompleted(section string, key string) bool {
+	completed, err := GetOnboardingCompleted(section, key)
+	return err == nil && completed
+}
+
+// GetOnboardingCompleted returns whether the named onboarding item has been completed.
+func GetOnboardingCompleted(section string, key string) (bool, error) {
+	completed, _, err := LookupOnboardingCompleted(section, key)
+	return completed, err
+}
+
+// LookupOnboardingCompleted returns whether the named onboarding item exists
+// and, if so, whether it has been completed.
+func LookupOnboardingCompleted(section string, key string) (bool, bool, error) {
+	section, key, err := normalizeOnboardingPath(section, key)
+	if err != nil {
+		return false, false, err
+	}
+
+	cfg, err := load()
+	if err != nil {
+		return false, false, err
+	}
+
+	values, ok := cfg.Onboarding[section]
+	if !ok {
+		return false, false, nil
+	}
+	completed, ok := values[key]
+	return completed, ok, nil
+}
+
+// MarkOnboardingCompleted marks the named onboarding item as completed.
+func MarkOnboardingCompleted(section string, key string) error {
+	return SetOnboardingCompleted(section, key, true)
+}
+
+// SetOnboardingCompleted records whether the named onboarding item has been completed.
+func SetOnboardingCompleted(section string, key string, completed bool) error {
+	section, key, err := normalizeOnboardingPath(section, key)
+	if err != nil {
+		return err
+	}
+
+	cfg, err := load()
+	if err != nil {
+		return err
+	}
+	if cfg.Onboarding == nil {
+		cfg.Onboarding = make(map[string]map[string]bool)
+	}
+	if cfg.Onboarding[section] == nil {
+		cfg.Onboarding[section] = make(map[string]bool)
+	}
+
+	cfg.Onboarding[section][key] = completed
+	return save(cfg)
+}
+
+func normalizeOnboardingPath(section string, key string) (string, string, error) {
+	section = strings.ToLower(strings.TrimSpace(section))
+	key = strings.ToLower(strings.TrimSpace(key))
+	if section == "" {
+		return "", "", errors.New("onboarding section cannot be empty")
+	}
+	if key == "" {
+		return "", "", errors.New("onboarding key cannot be empty")
+	}
+	return section, key, nil
+}
+
+func parseOnboarding(raw json.RawMessage) map[string]map[string]bool {
+	onboarding := make(map[string]map[string]bool)
+	if len(bytes.TrimSpace(raw)) == 0 || bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return onboarding
+	}
+
+	var nested map[string]map[string]bool
+	if err := json.Unmarshal(raw, &nested); err == nil {
+		for section, values := range nested {
+			section = strings.ToLower(strings.TrimSpace(section))
+			if section == "" {
+				continue
+			}
+			if onboarding[section] == nil {
+				onboarding[section] = make(map[string]bool)
+			}
+			for key, completed := range values {
+				key = strings.ToLower(strings.TrimSpace(key))
+				if key == "" {
+					continue
+				}
+				onboarding[section][key] = completed
+			}
+		}
+		return onboarding
+	}
+
+	var flat map[string]bool
+	if err := json.Unmarshal(raw, &flat); err == nil {
+		for scope, completed := range flat {
+			section, key := splitLegacyOnboardingScope(scope)
+			if section == "" || key == "" {
+				continue
+			}
+			if onboarding[section] == nil {
+				onboarding[section] = make(map[string]bool)
+			}
+			onboarding[section][key] = completed
+		}
+	}
+
+	return onboarding
+}
+
+func splitLegacyOnboardingScope(scope string) (string, string) {
+	scope = strings.ToLower(strings.TrimSpace(scope))
+	if scope == "" {
+		return "", ""
+	}
+	if scope == "app_terminal_prompt" {
+		return OnboardingSectionApp, OnboardingKeyTerminalPrompt
+	}
+	if section, key, ok := strings.Cut(scope, "."); ok {
+		section = strings.TrimSpace(section)
+		key = strings.TrimSpace(key)
+		return section, key
+	}
+	return "legacy", scope
 }
 
 // LoadIntegration returns the saved config for one integration.

--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -222,6 +223,123 @@ func TestSaveIntegration_EmptyAppName(t *testing.T) {
 	}
 	if err != nil && !strings.Contains(err.Error(), "app name cannot be empty") {
 		t.Errorf("expected 'app name cannot be empty' error, got: %v", err)
+	}
+}
+
+func TestOnboardingConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	setTestHome(t, tmpDir)
+
+	completed, err := GetOnboardingCompleted(OnboardingSectionApp, OnboardingKeyTerminalPrompt)
+	if err != nil {
+		t.Fatalf("GetOnboardingCompleted() error = %v", err)
+	}
+	if completed {
+		t.Fatal("GetOnboardingCompleted() = true, want false for missing item")
+	}
+	if OnboardingCompleted(OnboardingSectionApp, OnboardingKeyTerminalPrompt) {
+		t.Fatal("OnboardingCompleted() = true, want false for missing item")
+	}
+	if completed, ok, err := LookupOnboardingCompleted(OnboardingSectionApp, OnboardingKeyTerminalPrompt); err != nil {
+		t.Fatalf("LookupOnboardingCompleted() error = %v", err)
+	} else if completed || ok {
+		t.Fatalf("LookupOnboardingCompleted() = %v, %v, want false, false", completed, ok)
+	}
+
+	if err := MarkOnboardingCompleted("App", "Terminal_Prompt"); err != nil {
+		t.Fatalf("MarkOnboardingCompleted() error = %v", err)
+	}
+	if !OnboardingCompleted(OnboardingSectionApp, OnboardingKeyTerminalPrompt) {
+		t.Fatal("OnboardingCompleted() = false, want true")
+	}
+	if completed, ok, err := LookupOnboardingCompleted(OnboardingSectionApp, OnboardingKeyTerminalPrompt); err != nil {
+		t.Fatalf("LookupOnboardingCompleted() after mark error = %v", err)
+	} else if !completed || !ok {
+		t.Fatalf("LookupOnboardingCompleted() = %v, %v, want true, true", completed, ok)
+	}
+
+	loaded, err := load()
+	if err != nil {
+		t.Fatalf("load() error = %v", err)
+	}
+	if !loaded.Onboarding["app"]["terminal_prompt"] {
+		t.Fatalf("stored onboarding = %v, want true", loaded.Onboarding)
+	}
+
+	path, err := configPath()
+	if err != nil {
+		t.Fatalf("configPath() error = %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unmarshal config: %v", err)
+	}
+	onboarding, ok := raw["onboarding"].(map[string]any)
+	if !ok {
+		t.Fatalf("onboarding = %#v, want object", raw["onboarding"])
+	}
+	app, ok := onboarding["app"].(map[string]any)
+	if !ok {
+		t.Fatalf("onboarding.app = %#v, want object", onboarding["app"])
+	}
+	if app["terminal_prompt"] != true {
+		t.Fatalf("onboarding.app.terminal_prompt = %#v, want true", app["terminal_prompt"])
+	}
+}
+
+func TestSetOnboardingCompletedPreservesIntegrations(t *testing.T) {
+	tmpDir := t.TempDir()
+	setTestHome(t, tmpDir)
+
+	if err := SaveIntegration("claude", []string{"llama3.2"}); err != nil {
+		t.Fatalf("SaveIntegration() error = %v", err)
+	}
+	if err := SetOnboardingCompleted("cli", "launcher", true); err != nil {
+		t.Fatalf("SetOnboardingCompleted() error = %v", err)
+	}
+
+	integrationConfig, err := LoadIntegration("claude")
+	if err != nil {
+		t.Fatalf("LoadIntegration() error = %v", err)
+	}
+	if len(integrationConfig.Models) != 1 || integrationConfig.Models[0] != "llama3.2" {
+		t.Fatalf("models = %v, want [llama3.2]", integrationConfig.Models)
+	}
+	if !OnboardingCompleted("cli", "launcher") {
+		t.Fatal("OnboardingCompleted(cli launcher) = false, want true")
+	}
+}
+
+func TestOnboardingConfigEmptyPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	setTestHome(t, tmpDir)
+
+	if err := MarkOnboardingCompleted(" ", "terminal_prompt"); err == nil {
+		t.Fatal("MarkOnboardingCompleted(empty section) error = nil, want error")
+	}
+	if err := MarkOnboardingCompleted("app", " "); err == nil {
+		t.Fatal("MarkOnboardingCompleted(empty key) error = nil, want error")
+	}
+}
+
+func TestOnboardingConfigMigratesFlatScope(t *testing.T) {
+	tmpDir := t.TempDir()
+	setTestHome(t, tmpDir)
+
+	configPath := filepath.Join(tmpDir, ".ollama", "config.json")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte(`{"integrations":{},"onboarding":{"app_terminal_prompt":true}}`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if !OnboardingCompleted(OnboardingSectionApp, OnboardingKeyTerminalPrompt) {
+		t.Fatal("OnboardingCompleted(app terminal_prompt) = false, want true")
 	}
 }
 


### PR DESCRIPTION
## Summary
- add shared JSON config state for scoped onboarding under `onboarding.app.terminal_prompt`
- show a focused first-run app prompt with `ollama`, copy support, Skip, and Run Ollama in terminal actions
- bridge the legacy app first-run SQLite flag into JSON config for existing users
- add app API handlers for first-run skip/terminal actions and a small CLI copy update

## Behavior
New app users see the first-run terminal prompt until they choose Skip or Run Ollama in terminal. Both actions mark the onboarding item complete in `~/.ollama/config.json`. Existing app users with the legacy first-run flag are migrated so they are not prompted again.

On macOS, Run Ollama in terminal activates Terminal.app and runs `ollama`. On Windows, it opens `cmd` and runs `ollama`. Other platforms return an unsupported-platform error for now.

## Validation
- `go test ./cmd/config ./app/ui ./app/cmd/app`
- `npm exec eslint -- src/components/FirstRunPrompt.tsx src/routes/__root.tsx`
- `npm run build`