### PR TITLE
mlxrunner: unify and tune speculative decoding

### DIFF
--- a/x/mlxrunner/batch/batch.go
+++ b/x/mlxrunner/batch/batch.go
@@ -17,6 +17,10 @@ type Batch struct {
 	// Length equals the batch dimension of InputIDs.
 	SeqQueryLens []int32
 
+	// Hidden is the target hidden state a draft model fuses with its input
+	// embedding for this step. It is nil for ordinary forward passes.
+	Hidden *mlx.Array
+
 	// Memo is per-forward memoization used to cache results, such as masks,
 	// which are often the same across layers.
 	Memo Memo

--- a/x/mlxrunner/model/base/base.go
+++ b/x/mlxrunner/model/base/base.go
@@ -27,8 +27,21 @@ type Model interface {
 	LoadWeights(tensors map[string]*mlx.Array) error
 }
 
-// DraftModel is an auxiliary model stored alongside a target model.
+// DraftModel is an auxiliary model alongside a target that proposes speculative
+// tokens.
 type DraftModel interface {
+	// Draft fuses b.Hidden (the target hidden state) into its own forward and
+	// returns the head's hidden plus the projected hidden seeding the next step.
+	Draft(b *batch.Batch, caches []cache.Cache) (hidden, projected *mlx.Array)
+
+	// Unembed projects a hidden state to vocabulary logits.
+	Unembed(x *mlx.Array) *mlx.Array
+
+	// DraftCaches selects the draft model's own KV caches from the full
+	// per-request slice — any subset, or nil when the draft keeps no KV.
+	DraftCaches(caches []cache.Cache) []cache.Cache
+
+	// LoadWeights assigns manifest tensors to the draft head's fields.
 	LoadWeights(tensors map[string]*mlx.Array) error
 }
 
@@ -46,15 +59,10 @@ type MTPDefaultsProvider interface {
 	MTPDraftDefaults(sample bool) MTPDefaults
 }
 
-// MTPDraftModel is a draft model capable of Gemma-style multi-token
-// prediction from target token embeddings, target hidden states, and target KV.
-type MTPDraftModel interface {
-	Draft(inputEmbeds *mlx.Array, position int32, caches []cache.Cache) (logits, hidden *mlx.Array)
-}
-
-// MTPEmbeddingModel exposes the target token embedding path used by MTP drafts.
-type MTPEmbeddingModel interface {
-	TokenEmbeddings(inputIDs *mlx.Array) *mlx.Array
+// SelfDraft is implemented by models whose draft head ships inline with the
+// target weights; it returns the head, or nil when the checkpoint shipped none.
+type SelfDraft interface {
+	SelfDraft() DraftModel
 }
 
 var (

--- a/x/mlxrunner/model/base/base.go
+++ b/x/mlxrunner/model/base/base.go
@@ -45,20 +45,6 @@ type DraftModel interface {
 	LoadWeights(tensors map[string]*mlx.Array) error
 }
 
-// MTPDefaults holds model-provided draft-token defaults for speculative
-// decoding. Environment settings in the runner may override these values.
-type MTPDefaults struct {
-	InitialDraftTokens int
-	MaxDraftTokens     int
-	Enabled            bool
-}
-
-// MTPDefaultsProvider lets a model provide MTP policy defaults from its own
-// config without teaching the runner model-specific shape heuristics.
-type MTPDefaultsProvider interface {
-	MTPDraftDefaults(sample bool) MTPDefaults
-}
-
 // SelfDraft is implemented by models whose draft head ships inline with the
 // target weights; it returns the head, or nil when the checkpoint shipped none.
 type SelfDraft interface {

--- a/x/mlxrunner/mtp.go
+++ b/x/mlxrunner/mtp.go
@@ -5,37 +5,13 @@ import (
 
 	"github.com/ollama/ollama/x/mlxrunner/batch"
 	"github.com/ollama/ollama/x/mlxrunner/mlx"
-	"github.com/ollama/ollama/x/mlxrunner/model/base"
 	sampler "github.com/ollama/ollama/x/mlxrunner/sample"
-)
-
-const (
-	mtpDefaultInitialDraftTokens = 4
-	mtpDefaultMaxDraftTokens     = 16
 )
 
 // mtpPendingFlushTokens caps how many committed look-ahead tokens wait in the
 // pending buffer before a batched flush, bounding the pinned hidden states
 // regardless of what else triggers a flush.
 const mtpPendingFlushTokens = 32
-
-func (r *Runner) mtpDefaults(sample bool) base.MTPDefaults {
-	defaults := base.MTPDefaults{
-		InitialDraftTokens: mtpDefaultInitialDraftTokens,
-		MaxDraftTokens:     mtpDefaultMaxDraftTokens,
-		Enabled:            true,
-	}
-	if p, ok := r.Model.(base.MTPDefaultsProvider); ok {
-		defaults = p.MTPDraftDefaults(sample)
-	}
-	if defaults.InitialDraftTokens <= 0 {
-		defaults.InitialDraftTokens = mtpDefaultInitialDraftTokens
-	}
-	if defaults.MaxDraftTokens <= 0 {
-		defaults.MaxDraftTokens = mtpDefaultMaxDraftTokens
-	}
-	return defaults
-}
 
 // mtpDrafter drafts with a model's multi-token-prediction head, fed through
 // the committed-stream reports. The draft KV pairs each slot S with the

--- a/x/mlxrunner/mtp.go
+++ b/x/mlxrunner/mtp.go
@@ -1,7 +1,9 @@
 package mlxrunner
 
 import (
-	"github.com/ollama/ollama/x/mlxrunner/cache"
+	"fmt"
+
+	"github.com/ollama/ollama/x/mlxrunner/batch"
 	"github.com/ollama/ollama/x/mlxrunner/mlx"
 	"github.com/ollama/ollama/x/mlxrunner/model/base"
 	sampler "github.com/ollama/ollama/x/mlxrunner/sample"
@@ -11,6 +13,11 @@ const (
 	mtpDefaultInitialDraftTokens = 4
 	mtpDefaultMaxDraftTokens     = 16
 )
+
+// mtpPendingFlushTokens caps how many committed look-ahead tokens wait in the
+// pending buffer before a batched flush, bounding the pinned hidden states
+// regardless of what else triggers a flush.
+const mtpPendingFlushTokens = 32
 
 func (r *Runner) mtpDefaults(sample bool) base.MTPDefaults {
 	defaults := base.MTPDefaults{
@@ -30,85 +37,231 @@ func (r *Runner) mtpDefaults(sample bool) base.MTPDefaults {
 	return defaults
 }
 
-// mtpDrafter drafts with a model's multi-token-prediction head: a small
-// head trained to continue the target's hidden states, fed through the
-// committed-stream reports. It retains the hidden at the last committed
-// slot and tracks the committed frontier, which anchors its drafting.
+// mtpDrafter drafts with a model's multi-token-prediction head, fed through
+// the committed-stream reports. The draft KV pairs each slot S with the
+// look-ahead token at S+1 fused with the target hidden at S, so a pair
+// completes only when the next token arrives.
 type mtpDrafter struct {
-	spec   *speculation
-	draft  base.MTPDraftModel
-	target base.MTPEmbeddingModel
-	caches []cache.Cache
+	spec *speculation
 
-	// frontier is the slot after the last committed token; the hidden
-	// reported for slot frontier-1 is retained (pinned) as the fusion
-	// input for the next proposal chain.
+	// frontier is the slot after the last reported token; frontierHidden is
+	// the pinned target hidden at frontier-1, fused into the next pair.
 	frontier       int
 	frontierHidden *mlx.Array
+
+	// committedDraftOffset is the slot after the last pair written to the
+	// draft caches; later pairs wait pinned in the pending lists until
+	// flushed. pendingCount is the look-ahead tokens those lists hold, summed
+	// across the buffered runs.
+	committedDraftOffset int
+	pendingTokens        []*mlx.Array
+	pendingHiddens       []*mlx.Array
+	pendingCount         int
+
+	// heldHidden is the frontier row's pre-unembed hidden and heldProjected
+	// its fusion hidden, carried from the last flush so the first proposal
+	// reuses them without a head call.
+	heldHidden    *mlx.Array
+	heldProjected *mlx.Array
 }
 
-// newMTPDrafter returns the MTP drafter for this request's caches, or nil
-// when the model carries no MTP head.
-func newMTPDrafter(s *speculation, caches []cache.Cache) *mtpDrafter {
-	draft, ok := s.draft.(base.MTPDraftModel)
-	if !ok {
-		return nil
+// newMTPDrafter returns the MTP drafter cursor for this request, syncing its
+// pairing frontier to the draft caches' restored offset.
+func newMTPDrafter(s *speculation) *mtpDrafter {
+	d := &mtpDrafter{spec: s}
+	if len(s.draftKV) > 0 {
+		// A restored prefix arrives with the draft caches already written;
+		// pairing resumes from their absolute offset.
+		d.committedDraftOffset = s.draftKV[0].Offset()
+		d.frontier = d.committedDraftOffset
 	}
-	target, ok := s.r.Model.(base.MTPEmbeddingModel)
-	if !ok {
-		return nil
-	}
-	return &mtpDrafter{spec: s, draft: draft, target: target, caches: caches}
+	return d
 }
 
 func (d *mtpDrafter) committed(tokens, hiddens *mlx.Array, position int) {
-	d.frontier = position + tokens.Dim(1)
-	h := lastHiddenRow(hiddens)
-	mlx.Pin(h)
-	if d.frontierHidden != nil {
-		mlx.Unpin(d.frontierHidden)
+	n := tokens.Dim(1)
+	if len(d.spec.draftKV) > 0 {
+		// The pair at slot S fuses token[S+1] with hidden[S], so a run pairs its
+		// tokens with its own hiddens shifted one slot back: the first writable
+		// token takes the carried frontier hidden, each later token the row
+		// before it. Leading tokens whose slot is already buffered or written
+		// through (a proposal consumed the run's first token, or a restored
+		// prefix sits at the run start) are skipped; a slot below the frontier
+		// is a gap bug.
+		start := d.committedDraftOffset + d.pendingCount - position + 1
+		if start < 0 {
+			panic(fmt.Sprintf("mtp: committed run at %d leaves a pair gap at %d", position, d.committedDraftOffset+d.pendingCount))
+		}
+		if start < n {
+			ids := tokens.Slice(mlx.Slice(), mlx.Slice(start, n))
+			var h *mlx.Array
+			if start == 0 {
+				h = mlx.Concatenate([]*mlx.Array{d.frontierHidden, hiddens.Slice(mlx.Slice(), mlx.Slice(0, n-1), mlx.Slice())}, 1)
+			} else {
+				h = hiddens.Slice(mlx.Slice(), mlx.Slice(start-1, n-1), mlx.Slice())
+			}
+			d.queueCacheWrites(ids, h)
+		}
 	}
-	d.frontierHidden = h
+
+	d.frontier = position + n
+	d.setFrontierHidden(lastHiddenRow(hiddens))
+}
+
+// finish settles the drafter when generation ends: current completes the
+// frontier pair, leveling the draft caches with the target's resting offset.
+//
+// TODO: leveling the draft to the target writes a boundary entry whose
+// look-ahead token is outside the stored prefix (here, the never-committed
+// current). When a later request restores this prefix and diverges at the
+// boundary, that entry is stale and lowers draft acceptance. EAGLE keeps the
+// draft one slot behind the target so the unconfirmed boundary entry is never
+// written (its bigram partner token[S+1] does not exist yet); we should do the
+// same rather than level here. Regenerating hidden[S] to re-pair the boundary
+// on the next request is a separate, re-prefill-bound concern for recurrent
+// targets.
+func (d *mtpDrafter) finish(current *mlx.Array) {
+	if len(d.spec.draftKV) == 0 {
+		return
+	}
+	d.settle(current)
+}
+
+// settle completes any open frontier pair with current, then flushes.
+func (d *mtpDrafter) settle(current *mlx.Array) {
+	if d.frontierHidden != nil && d.frontier-1 == d.committedDraftOffset+d.pendingCount {
+		d.queueCacheWrites(current.ExpandDims(-1), d.frontierHidden)
+	}
+	d.flush()
 }
 
 func (d *mtpDrafter) close() {
-	if d.frontierHidden != nil {
-		mlx.Unpin(d.frontierHidden)
-		d.frontierHidden = nil
+	d.flush()
+	d.setFrontierHidden(nil)
+	d.setHeld(nil, nil)
+}
+
+// queueCacheWrites buffers completed draft-cache writes — look-ahead tokens
+// fused with their target hiddens — flushing once the buffer reaches the token
+// cap so the pinned hiddens stay bounded. flush coalesces the buffered writes
+// into one head forward, so a contiguous run lands in a single draft-cache extend.
+func (d *mtpDrafter) queueCacheWrites(tokens, hiddens *mlx.Array) {
+	mlx.Pin(tokens, hiddens)
+	d.pendingTokens = append(d.pendingTokens, tokens)
+	d.pendingHiddens = append(d.pendingHiddens, hiddens)
+	d.pendingCount += tokens.Dim(1)
+	if d.pendingCount >= mtpPendingFlushTokens {
+		d.flush()
 	}
 }
 
-// propose drafts a token chain Gemma-style ("single-position"): the head is
-// trained to draft every speculative token as if it sat at the last
-// committed slot, re-attending the target caches read-only. Each step fuses
-// the previous token's target embedding with the hidden chain — the
-// reported hidden first, then the head's own projections — and the
-// RoPE/cache anchor stays at the last committed slot while the proposed
-// tokens advance.
+// flush writes the pending pairs to the draft caches in one head forward,
+// dropping speculative entries past the committed range first and holding
+// the last row's logits and projected hidden for the next proposal chain.
+func (d *mtpDrafter) flush() {
+	if len(d.pendingTokens) == 0 {
+		return
+	}
+	for _, c := range d.spec.draftKV {
+		if c.Offset() > d.committedDraftOffset {
+			if !c.Restore(nil, d.committedDraftOffset) {
+				panic(fmt.Sprintf("mtp: draft cache rewind to %d failed", d.committedDraftOffset))
+			}
+		}
+	}
+
+	ids := mlx.Concatenate(d.pendingTokens, 1)
+	hiddens := mlx.Concatenate(d.pendingHiddens, 1)
+	hidden, projected := d.spec.draft.Draft(&batch.Batch{
+		InputIDs:     ids,
+		SeqOffsets:   []int32{int32(d.committedDraftOffset)},
+		SeqQueryLens: []int32{int32(ids.Dim(1))},
+		Hidden:       hiddens,
+	}, d.spec.caches)
+	d.setHeld(lastHiddenRow(hidden), lastHiddenRow(projected))
+	d.committedDraftOffset += ids.Dim(1)
+
+	// Force the draft writes: a session that never drafts would otherwise
+	// leave the flush chain unevaluated, pinning every hidden until close.
+	state := make([]*mlx.Array, 0, 2*len(d.spec.draftKV))
+	for _, c := range d.spec.draftKV {
+		state = append(state, c.State()...)
+	}
+	mlx.AsyncEval(state...)
+
+	mlx.Unpin(d.pendingTokens...)
+	mlx.Unpin(d.pendingHiddens...)
+	d.pendingTokens, d.pendingHiddens = nil, nil
+	d.pendingCount = 0
+}
+
+func (d *mtpDrafter) setFrontierHidden(h *mlx.Array) {
+	mlx.Pin(h)
+	mlx.Unpin(d.frontierHidden)
+	d.frontierHidden = h
+}
+
+// setHeld replaces the held flush outputs, pinned until the next flush or close.
+func (d *mtpDrafter) setHeld(hidden, projected *mlx.Array) {
+	mlx.Pin(hidden, projected)
+	mlx.Unpin(d.heldHidden, d.heldProjected)
+	d.heldHidden, d.heldProjected = hidden, projected
+}
+
+// propose drafts a token chain after the not-yet-validated current token.
+// A head with draft caches settles the frontier pair first, so its first step
+// reuses the held frontier row with no head call; a cacheless head re-attends
+// the target caches read-only, anchored at the last committed slot.
 func (d *mtpDrafter) propose(current *mlx.Array, maxTokens int) *draftCandidates {
 	if maxTokens <= 0 || d.frontierHidden == nil {
 		return nil
 	}
 	r := d.spec.r
 
-	anchor := int32(d.frontier - 1)
+	if len(d.spec.draftKV) > 0 {
+		d.settle(current)
+		if d.heldHidden == nil {
+			return nil
+		}
+	}
+
 	lastToken := current.ExpandDims(-1)
 	lastHidden := d.frontierHidden
-	draftTokens := make([]*mlx.Array, 0, maxTokens)
 	draftDists := make([]sampler.Distribution, 0, maxTokens)
 	var prefix *mlx.Array
 
-	for range maxTokens {
-		tokenEmbedding := d.target.TokenEmbeddings(lastToken)
-		inputs := tokenEmbedding.Concatenate(-1, lastHidden)
-		logits, projected := d.draft.Draft(inputs, anchor, d.caches)
-		stepLogits := lastLogits(logits)
+	for i := range maxTokens {
+		var hidden, projected *mlx.Array
+		if i == 0 && len(d.spec.draftKV) > 0 {
+			// The settle flush already produced the frontier row; reuse it
+			// instead of re-running the head.
+			hidden, projected = d.heldHidden, d.heldProjected
+		} else {
+			// A head with draft caches writes each draft token to the next
+			// draft-cache slot, advancing one per step from the last committed
+			// slot (the held i==0 step stands in for that slot). A cacheless
+			// head stays at the last committed slot every step, re-attending
+			// the committed prefix read-only ("single-position").
+			pos := d.frontier - 1
+			if len(d.spec.draftKV) > 0 {
+				pos = d.frontier - 1 + i
+			}
+			hidden, projected = d.spec.draft.Draft(&batch.Batch{
+				InputIDs:     lastToken,
+				SeqOffsets:   []int32{int32(pos)},
+				SeqQueryLens: []int32{1},
+				Hidden:       lastHidden,
+			}, d.spec.caches)
+		}
+		// Unembed only the row being sampled, never the batch.
+		stepLogits := d.spec.draft.Unembed(hidden).Squeeze(1)
+		lastHidden = projected
+		// The chain's earlier drafts ride along as the row's history, so
+		// penalties shape proposals the same way they shape validation.
 		dist := r.Sampler.Distribution(pipelineSlot, stepLogits, prefix)
 		nextToken := r.Sampler.SampleDistribution(pipelineSlot, dist)
 
 		lastToken = nextToken.ExpandDims(-1)
-		lastHidden = projected
-		draftTokens = append(draftTokens, lastToken)
 		draftDists = append(draftDists, dist)
 		if prefix == nil {
 			prefix = lastToken
@@ -117,7 +270,7 @@ func (d *mtpDrafter) propose(current *mlx.Array, maxTokens int) *draftCandidates
 		}
 	}
 	return &draftCandidates{
-		tokens: mlx.Concatenate(draftTokens, 1),
+		tokens: prefix,
 		dist:   sampler.ConcatenateDistributions(draftDists),
 	}
 }

--- a/x/mlxrunner/mtp.go
+++ b/x/mlxrunner/mtp.go
@@ -1,15 +1,6 @@
 package mlxrunner
 
 import (
-	"context"
-	"fmt"
-	"log/slog"
-	"os"
-	"strconv"
-	"strings"
-	"time"
-
-	"github.com/ollama/ollama/x/mlxrunner/batch"
 	"github.com/ollama/ollama/x/mlxrunner/cache"
 	"github.com/ollama/ollama/x/mlxrunner/mlx"
 	"github.com/ollama/ollama/x/mlxrunner/model/base"
@@ -20,31 +11,6 @@ const (
 	mtpDefaultInitialDraftTokens = 4
 	mtpDefaultMaxDraftTokens     = 16
 )
-
-type mtpDraftSchedule string
-
-const (
-	mtpDraftScheduleHeuristic mtpDraftSchedule = "heuristic"
-	mtpDraftScheduleConstant  mtpDraftSchedule = "constant"
-)
-
-type mtpStats struct {
-	iterations       int
-	drafted          int
-	accepted         int
-	mismatches       int
-	allAccepted      int
-	maxDraft         int
-	targetDuration   time.Duration
-	draftDuration    time.Duration
-	validateDuration time.Duration
-}
-
-type mtpOptions struct {
-	initialDraftTokens int
-	maxDraftTokens     int
-	draftSchedule      mtpDraftSchedule
-}
 
 func (r *Runner) mtpDefaults(sample bool) base.MTPDefaults {
 	defaults := base.MTPDefaults{
@@ -64,245 +30,83 @@ func (r *Runner) mtpDefaults(sample bool) base.MTPDefaults {
 	return defaults
 }
 
-func (r *Runner) loadMTPOptions(sample bool) mtpOptions {
-	defaults := r.mtpDefaults(sample)
+// mtpDrafter drafts with a model's multi-token-prediction head: a small
+// head trained to continue the target's hidden states, fed through the
+// committed-stream reports. It retains the hidden at the last committed
+// slot and tracks the committed frontier, which anchors its drafting.
+type mtpDrafter struct {
+	spec   *speculation
+	draft  base.MTPDraftModel
+	target base.MTPEmbeddingModel
+	caches []cache.Cache
 
-	opts := mtpOptions{
-		initialDraftTokens: defaults.InitialDraftTokens,
-		maxDraftTokens:     defaults.MaxDraftTokens,
-		draftSchedule:      mtpDraftScheduleConstant,
-	}
-	if v := positiveEnvInt("OLLAMA_MLX_MTP_MAX_DRAFT_TOKENS"); v > 0 {
-		opts.maxDraftTokens = v
-	}
-	if v := positiveEnvInt("OLLAMA_MLX_MTP_INITIAL_DRAFT_TOKENS"); v > 0 {
-		opts.initialDraftTokens = v
-	}
-	if opts.initialDraftTokens > opts.maxDraftTokens {
-		opts.initialDraftTokens = opts.maxDraftTokens
-	}
-	switch schedule := strings.ToLower(strings.TrimSpace(os.Getenv("OLLAMA_MLX_MTP_DRAFT_SCHEDULE"))); schedule {
-	case "", string(mtpDraftScheduleConstant):
-		opts.draftSchedule = mtpDraftScheduleConstant
-	case string(mtpDraftScheduleHeuristic):
-		opts.draftSchedule = mtpDraftScheduleHeuristic
-	default:
-		slog.Warn("invalid MTP env setting", "key", "OLLAMA_MLX_MTP_DRAFT_SCHEDULE", "value", schedule)
-	}
-	return opts
+	// frontier is the slot after the last committed token; the hidden
+	// reported for slot frontier-1 is retained (pinned) as the fusion
+	// input for the next proposal chain.
+	frontier       int
+	frontierHidden *mlx.Array
 }
 
-func positiveEnvInt(key string) int {
-	raw := os.Getenv(key)
-	if raw == "" {
-		return 0
-	}
-	v, err := strconv.Atoi(raw)
-	if err != nil || v <= 0 {
-		slog.Warn("invalid MTP env setting", "key", key, "value", raw)
-		return 0
-	}
-	return v
-}
-
-// useMTP reports whether the request can run through the MTP speculative
-// decode path. Logprobs are not yet supported.
-func (r *Runner) useMTP(opts sampler.Options) bool {
-	if r.Draft == nil {
-		return false
-	}
-	if _, ok := r.Draft.(base.MTPDraftModel); !ok {
-		return false
-	}
-	if _, ok := r.Model.(base.MTPEmbeddingModel); !ok {
-		return false
-	}
-	if !r.mtpDefaults(opts.Temperature != 0).Enabled {
-		return false
-	}
-	if opts.Logprobs || opts.TopLogprobs > 0 {
-		return false
-	}
-	return true
-}
-
-func (r *Runner) runMTPDecode(ctx context.Context, request Request, session *cacheSession, caches []cache.Cache, seed []int32, position *int, started time.Time) error {
-	targetEmbeddings := r.Model.(base.MTPEmbeddingModel)
-	draft := r.Draft.(base.MTPDraftModel)
-	mtpOpts := r.loadMTPOptions(request.SamplerOpts.Temperature != 0)
-	stats := mtpStats{maxDraft: mtpOpts.initialDraftTokens}
-	draftLimit := mtpOpts.initialDraftTokens
-	slog.Info("MTP decode enabled", "initial_draft_tokens", mtpOpts.initialDraftTokens, "max_draft_tokens", mtpOpts.maxDraftTokens, "draft_schedule", mtpOpts.draftSchedule)
-
-	targetForward := func(token *mlx.Array) *mlx.Array {
-		fwd := r.Model.Forward(&batch.Batch{
-			InputIDs:     token,
-			SeqOffsets:   []int32{int32(*position)},
-			SeqQueryLens: []int32{int32(token.Dim(1))},
-		}, caches)
-		*position += token.Dim(1)
-		return fwd
-	}
-
-	hidden := targetForward(mlx.FromValues(seed, 1, len(seed)))
-	current := r.Sampler.Sample([]int{pipelineSlot}, r.lastLogits(hidden))
-	mlx.Pin(current.Arrays()...)
-	mlx.Sweep()
-	mlx.AsyncEval(current.Arrays()...)
-	defer func() {
-		mlx.Unpin(current.Arrays()...)
-	}()
-
-	dec := decoder{tokenizer: r.Tokenizer}
-	final := CompletionResponse{Done: true, PromptEvalCount: len(request.Tokens), DoneReason: 1}
-	now := started
-
-	generated := 0
-	for generated < request.Options.NumPredict {
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-
-		t0 := time.Now()
-		hidden = targetForward(mtpTokenInput(current.Token))
-		baseLogits := r.lastLogits(hidden)
-		stats.targetDuration += time.Since(t0)
-
-		if generated == 0 {
-			mlx.Eval(current.Arrays()...)
-			final.PromptEvalDuration = time.Since(now)
-			now = time.Now()
-		}
-
-		done, err := r.emitTokens(ctx, request, session, &dec, []sampler.Result{current}, &final, &generated)
-		if err != nil {
-			return err
-		}
-		if done {
-			break
-		}
-
-		stats.iterations++
-		maxDraft := min(draftLimit, request.Options.NumPredict-generated)
-		t0 = time.Now()
-		candidates := r.generateMTPDraftCandidates(draft, targetEmbeddings, current.Token, hidden, caches, int32(*position-1), maxDraft)
-		draftCount := 0
-		var candidateArrays []*mlx.Array
-		if candidates != nil {
-			draftCount = candidates.tokens.Dim(1)
-			candidateArrays = append([]*mlx.Array{baseLogits}, candidates.Arrays()...)
-			mlx.Pin(candidateArrays...)
-			mlx.Sweep()
-		}
-		stats.draftDuration += time.Since(t0)
-		stats.drafted += draftCount
-		var next sampler.Result
-		if draftCount == 0 {
-			next = r.Sampler.Sample([]int{pipelineSlot}, baseLogits)
-		} else {
-			var accepted int
-			t0 = time.Now()
-			next, accepted, done, err = r.acceptMTPDrafts(ctx, request, session, &dec, caches, position, baseLogits, candidates, &final, &generated)
-			stats.validateDuration += time.Since(t0)
-			mlx.Unpin(candidateArrays...)
-			if err != nil {
-				return err
-			}
-			stats.accepted += accepted
-			switch {
-			case mtpOpts.draftSchedule == mtpDraftScheduleConstant:
-			case accepted == draftCount:
-				stats.allAccepted++
-				draftLimit = min(mtpOpts.maxDraftTokens, draftLimit+2)
-			default:
-				stats.mismatches++
-				draftLimit = max(1, draftLimit-1)
-			}
-			if mtpOpts.draftSchedule == mtpDraftScheduleConstant {
-				if accepted == draftCount {
-					stats.allAccepted++
-				} else {
-					stats.mismatches++
-				}
-			}
-			stats.maxDraft = max(stats.maxDraft, draftLimit)
-			if next.Token == nil {
-				mlx.Sweep()
-			}
-			if done || generated >= request.Options.NumPredict {
-				break
-			}
-		}
-
-		mlx.Pin(next.Arrays()...)
-		old := current
-		current = next
-		mlx.Unpin(old.Arrays()...)
-		mlx.Sweep()
-		mlx.AsyncEval(current.Arrays()...)
-
-		if generated%256 == 0 {
-			mlx.ClearCache()
-		}
-	}
-
-	final.EvalCount = generated
-	final.EvalDuration = time.Since(now)
-	acceptance := 0.0
-	if stats.drafted > 0 {
-		acceptance = float64(stats.accepted) / float64(stats.drafted)
-	}
-	avgDraft := 0.0
-	avgAccepted := 0.0
-	if stats.iterations > 0 {
-		avgDraft = float64(stats.drafted) / float64(stats.iterations)
-		avgAccepted = float64(stats.accepted) / float64(stats.iterations)
-	}
-	slog.Info("MTP decode stats", "generated", generated, "drafted", stats.drafted, "accepted", stats.accepted, "acceptance", acceptance, "iterations", stats.iterations, "avg_draft", avgDraft, "avg_accepted", avgAccepted, "mismatches", stats.mismatches, "all_accepted", stats.allAccepted, "max_draft", stats.maxDraft, "draft_schedule", mtpOpts.draftSchedule, "target_duration", stats.targetDuration, "draft_duration", stats.draftDuration, "validate_duration", stats.validateDuration)
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case request.Responses <- final:
+// newMTPDrafter returns the MTP drafter for this request's caches, or nil
+// when the model carries no MTP head.
+func newMTPDrafter(s *speculation, caches []cache.Cache) *mtpDrafter {
+	draft, ok := s.draft.(base.MTPDraftModel)
+	if !ok {
 		return nil
 	}
-}
-
-type mtpDraftCandidates struct {
-	tokens *mlx.Array
-	// dist is the proposal distribution used to sample each drafted token.
-	dist sampler.Distribution
-}
-
-func (c *mtpDraftCandidates) Arrays() []*mlx.Array {
-	if c == nil {
+	target, ok := s.r.Model.(base.MTPEmbeddingModel)
+	if !ok {
 		return nil
 	}
-	return append([]*mlx.Array{c.tokens}, c.dist.Arrays()...)
+	return &mtpDrafter{spec: s, draft: draft, target: target, caches: caches}
 }
 
-func (r *Runner) generateMTPDraftCandidates(draft base.MTPDraftModel, target base.MTPEmbeddingModel, token *mlx.Array, hidden *mlx.Array, caches []cache.Cache, position int32, maxDraft int) *mtpDraftCandidates {
-	if maxDraft <= 0 {
+func (d *mtpDrafter) committed(tokens, hiddens *mlx.Array, position int) {
+	d.frontier = position + tokens.Dim(1)
+	h := lastHiddenRow(hiddens)
+	mlx.Pin(h)
+	if d.frontierHidden != nil {
+		mlx.Unpin(d.frontierHidden)
+	}
+	d.frontierHidden = h
+}
+
+func (d *mtpDrafter) close() {
+	if d.frontierHidden != nil {
+		mlx.Unpin(d.frontierHidden)
+		d.frontierHidden = nil
+	}
+}
+
+// propose drafts a token chain Gemma-style ("single-position"): the head is
+// trained to draft every speculative token as if it sat at the last
+// committed slot, re-attending the target caches read-only. Each step fuses
+// the previous token's target embedding with the hidden chain — the
+// reported hidden first, then the head's own projections — and the
+// RoPE/cache anchor stays at the last committed slot while the proposed
+// tokens advance.
+func (d *mtpDrafter) propose(current *mlx.Array, maxTokens int) *draftCandidates {
+	if maxTokens <= 0 || d.frontierHidden == nil {
 		return nil
 	}
+	r := d.spec.r
 
-	lastToken := mtpTokenInput(token)
-	lastHidden := hidden
-	draftTokens := make([]*mlx.Array, 0, maxDraft)
-	draftDists := make([]sampler.Distribution, 0, maxDraft)
+	anchor := int32(d.frontier - 1)
+	lastToken := current.ExpandDims(-1)
+	lastHidden := d.frontierHidden
+	draftTokens := make([]*mlx.Array, 0, maxTokens)
+	draftDists := make([]sampler.Distribution, 0, maxTokens)
 	var prefix *mlx.Array
 
-	// Gemma4 assistant MTP is trained as "single-position" drafting:
-	// keep the RoPE/cache position anchored at the last target-seen token
-	// while the proposed token and projected hidden state advance.
-	for range maxDraft {
-		tokenEmbedding := target.TokenEmbeddings(lastToken)
+	for range maxTokens {
+		tokenEmbedding := d.target.TokenEmbeddings(lastToken)
 		inputs := tokenEmbedding.Concatenate(-1, lastHidden)
-		logits, projected := draft.Draft(inputs, position, caches)
-		stepLogits := r.lastLogitsFromLogits(logits)
+		logits, projected := d.draft.Draft(inputs, anchor, d.caches)
+		stepLogits := lastLogits(logits)
 		dist := r.Sampler.Distribution(pipelineSlot, stepLogits, prefix)
 		nextToken := r.Sampler.SampleDistribution(pipelineSlot, dist)
 
-		lastToken = mtpTokenInput(nextToken)
+		lastToken = nextToken.ExpandDims(-1)
 		lastHidden = projected
 		draftTokens = append(draftTokens, lastToken)
 		draftDists = append(draftDists, dist)
@@ -312,248 +116,12 @@ func (r *Runner) generateMTPDraftCandidates(draft base.MTPDraftModel, target bas
 			prefix = prefix.Concatenate(1, lastToken)
 		}
 	}
-	if len(draftTokens) == 0 {
-		return nil
-	}
-	return &mtpDraftCandidates{
+	return &draftCandidates{
 		tokens: mlx.Concatenate(draftTokens, 1),
 		dist:   sampler.ConcatenateDistributions(draftDists),
 	}
 }
 
-// scheduleSpeculation schedules per-token snapshots at offsets
-// [before, before+draftCount) on every cache, so the speculative forward
-// captures a rollback point before each draft token's write.
-func scheduleSpeculation(caches []cache.Cache, before, draftCount int) {
-	offsets := make([]int, draftCount)
-	for i := range offsets {
-		offsets[i] = before + i
-	}
-	for _, c := range caches {
-		if c != nil {
-			c.PrepareSnapshots(offsets)
-		}
-	}
-}
-
-// commitSpeculation collects the captured snapshots and rolls every cache
-// back to before+accepted, keeping only the accepted prefix of the
-// speculative forward. The bonus token (at before+draftCount) is never
-// committed. On full acceptance no restore is needed.
-//
-// Rollback tries a live rewind first (Restore(nil)) and falls back to the
-// captured snapshot when the live state can't be rewound in place.
-func commitSpeculation(caches []cache.Cache, accepted, draftCount, before int) {
-	target := before + accepted
-	for _, c := range caches {
-		if c == nil {
-			continue
-		}
-		snaps := c.TakeSnapshots()
-		if accepted < draftCount {
-			// Close the snapshots we won't restore from before restoring: a
-			// snapshot restore on a wrapped RotatingKVCache copies out every
-			// outstanding lazy snapshot before it rebuilds the buffer, so
-			// dropping the unused ones first stops that copy-out from
-			// materializing snapshots we are about to discard anyway.
-			for i, s := range snaps {
-				if s != nil && i != accepted {
-					s.Close()
-					snaps[i] = nil
-				}
-			}
-			if !c.Restore(nil, target) && !c.Restore(snaps[accepted], target) {
-				panic(fmt.Sprintf("mtp: cache restore to %d failed", target))
-			}
-		}
-		for _, s := range snaps {
-			if s != nil {
-				s.Close()
-			}
-		}
-	}
-}
-
-// acceptMTPDrafts accepts the longest draft prefix that survives rejection
-// sampling against the target model. At temperature 0 the distributions are
-// point masses, so acceptance reduces to argmax-match.
-func (r *Runner) acceptMTPDrafts(ctx context.Context, request Request, session *cacheSession, dec *decoder, caches []cache.Cache, position *int, baseLogits *mlx.Array, candidates *mtpDraftCandidates, final *CompletionResponse, generated *int) (sampler.Result, int, bool, error) {
-	before := *position
-	draftCount := candidates.tokens.Dim(1)
-	scheduleSpeculation(caches, before, draftCount)
-	hiddenSeq := r.Model.Forward(&batch.Batch{
-		InputIDs:     candidates.tokens,
-		SeqOffsets:   []int32{int32(before)},
-		SeqQueryLens: []int32{int32(draftCount)},
-	}, caches)
-
-	targetDist := r.Sampler.Distribution(pipelineSlot, r.mtpValidationLogits(baseLogits, hiddenSeq), candidates.tokens)
-	draftDist := candidates.dist
-	acceptedMask := r.mtpSampleAcceptedMask(targetDist.SliceRows(0, draftCount), draftDist, candidates.tokens)
-	mlx.Eval(candidates.tokens, acceptedMask)
-
-	draftIDs := candidates.tokens.Ints()
-	acceptedFlags := acceptedMask.Ints()
-	accepted := 0
-	for _, ok := range acceptedFlags {
-		if ok == 0 {
-			break
-		}
-		accepted++
-	}
-	if accepted > draftCount {
-		// Drain the scheduled snapshots and roll the speculative forward back
-		// out of the live caches before bailing, so the abandoned drafts don't
-		// reach the trie via session.close().
-		commitSpeculation(caches, 0, draftCount, before)
-		return sampler.Result{}, 0, false, fmt.Errorf("mtp sample validation accepted %d tokens for %d draft tokens", accepted, draftCount)
-	}
-
-	commitIDs := make([]int32, 0, accepted+1)
-	done := false
-	for i, id := range draftIDs[:accepted] {
-		commitIDs = append(commitIDs, int32(id))
-		if r.Tokenizer.IsEOS(int32(id)) {
-			done = true
-			accepted = i + 1
-			commitIDs = commitIDs[:accepted]
-			break
-		}
-	}
-
-	commitSpeculation(caches, accepted, draftCount, before)
-	*position = before + accepted
-
-	emitted, err := r.emitTokens(ctx, request, session, dec, draftResults(draftIDs[:accepted]), final, generated)
-	if err != nil {
-		return sampler.Result{}, accepted, emitted || done, err
-	}
-	if emitted || done {
-		r.Sampler.Commit(pipelineSlot, commitIDs)
-		return sampler.Result{}, accepted, true, nil
-	}
-
-	var nextToken *mlx.Array
-	if accepted == draftCount {
-		nextToken = r.mtpSampleTokenAt(targetDist, draftCount)
-	} else {
-		nextToken = r.mtpSampleResidualToken(targetDist, draftDist, accepted)
-	}
-	mlx.Eval(nextToken)
-	nextID := int32(tokenID(nextToken))
-	commitIDs = append(commitIDs, nextID)
-	r.Sampler.Commit(pipelineSlot, commitIDs)
-
-	return sampler.Result{Token: nextToken}, accepted, false, nil
-}
-
-func (r *Runner) mtpSampleAcceptedMask(targetDist, draftDist sampler.Distribution, draftTokens *mlx.Array) *mlx.Array {
-	p := targetDist.Prob(draftTokens)
-	q := draftDist.Prob(draftTokens)
-	acceptP := mlx.Minimum(p.Divide(q), mlx.FromValue(float32(1)))
-	return r.Sampler.Bernoulli(pipelineSlot, acceptP).AsType(mlx.DTypeInt32)
-}
-
-func (r *Runner) mtpSampleTokenAt(dist sampler.Distribution, index int) *mlx.Array {
-	return mtpTokenVector(r.Sampler.SampleDistribution(pipelineSlot, dist.SliceRows(index, index+1)))
-}
-
-func (r *Runner) mtpSampleResidualToken(targetDist, draftDist sampler.Distribution, index int) *mlx.Array {
-	residual := targetDist.SliceRows(index, index+1).ResidualAgainst(draftDist.SliceRows(index, index+1))
-	return mtpTokenVector(r.Sampler.SampleDistribution(pipelineSlot, residual))
-}
-
-func mtpTokenInput(token *mlx.Array) *mlx.Array {
-	switch token.NumDims() {
-	case 0:
-		return token.Reshape(1, 1)
-	case 1:
-		return token.ExpandDims(-1)
-	case 2:
-		return token
-	default:
-		panic(fmt.Sprintf("mtp token must be rank 0, 1, or 2, got rank %d", token.NumDims()))
-	}
-}
-
-func mtpTokenVector(token *mlx.Array) *mlx.Array {
-	switch token.NumDims() {
-	case 0:
-		return token.Reshape(1)
-	case 1:
-		return token
-	default:
-		panic(fmt.Sprintf("mtp sampled token must be rank 0 or 1, got rank %d", token.NumDims()))
-	}
-}
-
-// emitTokens records a run of generated tokens to session.outputs, then streams
-// them. A trailing EOS stops generation and is recorded but not streamed.
-// Returns whether to stop and any cancellation error.
-func (r *Runner) emitTokens(ctx context.Context, request Request, session *cacheSession, dec *decoder, results []sampler.Result, final *CompletionResponse, generated *int) (done bool, err error) {
-	stream := len(results)
-	for i, res := range results {
-		id := int32(tokenID(res.Token))
-		session.outputs = append(session.outputs, id)
-		if r.Tokenizer.IsEOS(id) {
-			final.DoneReason = 0
-			done = true
-			stream = i
-			break
-		}
-		(*generated)++
-	}
-	if *generated >= request.Options.NumPredict {
-		done = true
-	}
-
-	// Record the whole run before streaming any of it: streaming returns early on
-	// a cancelled context, and a partial stream must not leave the cache ahead of
-	// session.outputs.
-	for _, res := range results[:stream] {
-		resp, ok := dec.decode(res)
-		if !ok {
-			continue
-		}
-		select {
-		case <-ctx.Done():
-			return done, ctx.Err()
-		case request.Responses <- resp:
-		}
-	}
-	return done, nil
-}
-
-// draftResults wraps accepted draft token ids as sampler results for emitTokens.
-// Accepted drafts carry no logprobs, so only the token id is set.
-func draftResults(ids []int) []sampler.Result {
-	results := make([]sampler.Result, len(ids))
-	for i, id := range ids {
-		results[i] = sampler.Result{Token: mlx.FromValues([]int32{int32(id)}, 1)}
-	}
-	return results
-}
-
-func (r *Runner) lastLogits(hidden *mlx.Array) *mlx.Array {
-	logits := r.Model.Unembed(hidden)
-	return r.lastLogitsFromLogits(logits)
-}
-
-func (r *Runner) mtpValidationLogits(baseLogits, hiddenSeq *mlx.Array) *mlx.Array {
-	seqLogits := r.Model.Unembed(hiddenSeq)
-	return baseLogits.ExpandDims(1).Concatenate(1, seqLogits)
-}
-
-func (r *Runner) lastLogitsFromLogits(logits *mlx.Array) *mlx.Array {
-	return logits.Slice(mlx.Slice(), mlx.Slice(logits.Dim(1)-1), mlx.Slice()).Squeeze(1)
-}
-
-// tokenID reads a single-token array as its host id. It goes through the
-// item accessor, which evaluates the array first: raw data reads on a lazy
-// array race its evaluation and return garbage.
-func tokenID(token *mlx.Array) int {
-	if token == nil {
-		return -1
-	}
-	return token.Int()
+func lastHiddenRow(hidden *mlx.Array) *mlx.Array {
+	return hidden.Slice(mlx.Slice(), mlx.Slice(hidden.Dim(1)-1), mlx.Slice())
 }

--- a/x/mlxrunner/mtp.go
+++ b/x/mlxrunner/mtp.go
@@ -34,8 +34,6 @@ type mtpStats struct {
 	accepted         int
 	mismatches       int
 	allAccepted      int
-	batched          int
-	serial           int
 	maxDraft         int
 	targetDuration   time.Duration
 	draftDuration    time.Duration
@@ -46,7 +44,6 @@ type mtpOptions struct {
 	initialDraftTokens int
 	maxDraftTokens     int
 	draftSchedule      mtpDraftSchedule
-	serialValidate     bool
 }
 
 func (r *Runner) mtpDefaults(sample bool) base.MTPDefaults {
@@ -84,9 +81,6 @@ func (r *Runner) loadMTPOptions(sample bool) mtpOptions {
 	if opts.initialDraftTokens > opts.maxDraftTokens {
 		opts.initialDraftTokens = opts.maxDraftTokens
 	}
-	if b, err := strconv.ParseBool(os.Getenv("OLLAMA_MLX_MTP_SERIAL_VALIDATE")); err == nil {
-		opts.serialValidate = b
-	}
 	switch schedule := strings.ToLower(strings.TrimSpace(os.Getenv("OLLAMA_MLX_MTP_DRAFT_SCHEDULE"))); schedule {
 	case "", string(mtpDraftScheduleConstant):
 		opts.draftSchedule = mtpDraftScheduleConstant
@@ -111,7 +105,9 @@ func positiveEnvInt(key string) int {
 	return v
 }
 
-func (r *Runner) useGreedyMTP(opts sampler.Options) bool {
+// useMTP reports whether the request can run through the MTP speculative
+// decode path. Logprobs are not yet supported.
+func (r *Runner) useMTP(opts sampler.Options) bool {
 	if r.Draft == nil {
 		return false
 	}
@@ -121,190 +117,22 @@ func (r *Runner) useGreedyMTP(opts sampler.Options) bool {
 	if _, ok := r.Model.(base.MTPEmbeddingModel); !ok {
 		return false
 	}
-	if !r.mtpDefaults(false).Enabled {
+	if !r.mtpDefaults(opts.Temperature != 0).Enabled {
 		return false
 	}
 	if opts.Logprobs || opts.TopLogprobs > 0 {
 		return false
 	}
-	if opts.Temperature != 0 {
-		return false
-	}
-	repeatPenaltyNeutral := opts.RepeatPenalty <= 0 || opts.RepeatPenalty == 1
-	topPNeutral := opts.TopP <= 0 || opts.TopP >= 1
-	topKNeutral := opts.TopK <= 0
-	return repeatPenaltyNeutral && opts.PresencePenalty == 0 && opts.FrequencyPenalty == 0 && topPNeutral && topKNeutral && opts.MinP == 0
+	return true
 }
 
-func (r *Runner) useSampleMTP(opts sampler.Options) bool {
-	if serial, err := strconv.ParseBool(os.Getenv("OLLAMA_MLX_MTP_SERIAL_VALIDATE")); err == nil && serial {
-		return false
-	}
-	if r.Draft == nil {
-		return false
-	}
-	if _, ok := r.Draft.(base.MTPDraftModel); !ok {
-		return false
-	}
-	if _, ok := r.Model.(base.MTPEmbeddingModel); !ok {
-		return false
-	}
-	if !r.mtpDefaults(true).Enabled {
-		return false
-	}
-	if opts.Logprobs || opts.TopLogprobs > 0 {
-		return false
-	}
-	return opts.Temperature != 0
-}
-
-func (r *Runner) runGreedyMTPDecode(ctx context.Context, request Request, session *cacheSession, caches []cache.Cache, seed []int32, position *int, started time.Time) error {
+func (r *Runner) runMTPDecode(ctx context.Context, request Request, session *cacheSession, caches []cache.Cache, seed []int32, position *int, started time.Time) error {
 	targetEmbeddings := r.Model.(base.MTPEmbeddingModel)
 	draft := r.Draft.(base.MTPDraftModel)
-	mtpOpts := r.loadMTPOptions(false)
+	mtpOpts := r.loadMTPOptions(request.SamplerOpts.Temperature != 0)
 	stats := mtpStats{maxDraft: mtpOpts.initialDraftTokens}
 	draftLimit := mtpOpts.initialDraftTokens
-	slog.Info("MTP greedy decode enabled", "initial_draft_tokens", mtpOpts.initialDraftTokens, "max_draft_tokens", mtpOpts.maxDraftTokens, "draft_schedule", mtpOpts.draftSchedule, "serial_validate", mtpOpts.serialValidate)
-
-	targetForward := func(token *mlx.Array) *mlx.Array {
-		fwd := r.Model.Forward(&batch.Batch{
-			InputIDs:     token,
-			SeqOffsets:   []int32{int32(*position)},
-			SeqQueryLens: []int32{int32(token.Dim(1))},
-		}, caches)
-		*position += token.Dim(1)
-		return fwd
-	}
-
-	hidden := targetForward(mlx.FromValues(seed, 1, len(seed)))
-	current := sampler.Result{Token: greedyTokenFromLogits(r.lastLogits(hidden))}
-	mlx.Pin(current.Arrays()...)
-	mlx.Sweep()
-	mlx.AsyncEval(current.Arrays()...)
-	defer func() {
-		mlx.Unpin(current.Arrays()...)
-	}()
-
-	dec := decoder{tokenizer: r.Tokenizer}
-	final := CompletionResponse{Done: true, PromptEvalCount: len(request.Tokens), DoneReason: 1}
-	now := started
-
-	generated := 0
-	for generated < request.Options.NumPredict {
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-
-		t0 := time.Now()
-		hidden = targetForward(current.Token.ExpandDims(-1))
-		baseLogits := r.lastLogits(hidden)
-		stats.targetDuration += time.Since(t0)
-
-		if generated == 0 {
-			mlx.Eval(current.Arrays()...)
-			final.PromptEvalDuration = time.Since(now)
-			now = time.Now()
-		}
-
-		done, err := r.emitTokens(ctx, request, session, &dec, []sampler.Result{current}, &final, &generated)
-		if err != nil {
-			return err
-		}
-		if done {
-			break
-		}
-
-		stats.iterations++
-		maxDraft := min(draftLimit, request.Options.NumPredict-generated)
-		t0 = time.Now()
-		draftTokens := r.generateMTPDrafts(draft, targetEmbeddings, current.Token, hidden, caches, int32(*position-1), maxDraft)
-		draftCount := 0
-		if draftTokens != nil {
-			draftCount = draftTokens.Dim(1)
-			mlx.Pin(baseLogits, draftTokens)
-			mlx.Eval(draftTokens)
-			mlx.Sweep()
-		}
-		stats.draftDuration += time.Since(t0)
-		stats.drafted += draftCount
-		var next sampler.Result
-		if draftCount == 0 {
-			next = sampler.Result{Token: greedyTokenFromLogits(baseLogits)}
-		} else {
-			var accepted int
-			t0 = time.Now()
-			next, accepted, done, err = r.acceptMTPDrafts(ctx, request, session, &dec, caches, position, baseLogits, draftTokens, &final, &generated, &stats, mtpOpts)
-			stats.validateDuration += time.Since(t0)
-			mlx.Unpin(baseLogits, draftTokens)
-			if err != nil {
-				return err
-			}
-			stats.accepted += accepted
-			switch {
-			case mtpOpts.draftSchedule == mtpDraftScheduleConstant:
-			case accepted == draftCount:
-				stats.allAccepted++
-				draftLimit = min(mtpOpts.maxDraftTokens, draftLimit+2)
-			default:
-				stats.mismatches++
-				draftLimit = max(1, draftLimit-1)
-			}
-			if mtpOpts.draftSchedule == mtpDraftScheduleConstant {
-				if accepted == draftCount {
-					stats.allAccepted++
-				} else {
-					stats.mismatches++
-				}
-			}
-			stats.maxDraft = max(stats.maxDraft, draftLimit)
-			if next.Token == nil {
-				mlx.Sweep()
-			}
-			if done || generated >= request.Options.NumPredict {
-				break
-			}
-		}
-
-		mlx.Pin(next.Arrays()...)
-		old := current
-		current = next
-		mlx.Unpin(old.Arrays()...)
-		mlx.Sweep()
-		mlx.AsyncEval(current.Arrays()...)
-
-		if generated%256 == 0 {
-			mlx.ClearCache()
-		}
-	}
-
-	final.EvalCount = generated
-	final.EvalDuration = time.Since(now)
-	acceptance := 0.0
-	if stats.drafted > 0 {
-		acceptance = float64(stats.accepted) / float64(stats.drafted)
-	}
-	avgDraft := 0.0
-	avgAccepted := 0.0
-	if stats.iterations > 0 {
-		avgDraft = float64(stats.drafted) / float64(stats.iterations)
-		avgAccepted = float64(stats.accepted) / float64(stats.iterations)
-	}
-	slog.Info("MTP decode stats", "generated", generated, "drafted", stats.drafted, "accepted", stats.accepted, "acceptance", acceptance, "iterations", stats.iterations, "avg_draft", avgDraft, "avg_accepted", avgAccepted, "batched", stats.batched, "serial", stats.serial, "mismatches", stats.mismatches, "all_accepted", stats.allAccepted, "max_draft", stats.maxDraft, "draft_schedule", mtpOpts.draftSchedule, "target_duration", stats.targetDuration, "draft_duration", stats.draftDuration, "validate_duration", stats.validateDuration)
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case request.Responses <- final:
-		return nil
-	}
-}
-
-func (r *Runner) runSampleMTPDecode(ctx context.Context, request Request, session *cacheSession, caches []cache.Cache, seed []int32, position *int, started time.Time) error {
-	targetEmbeddings := r.Model.(base.MTPEmbeddingModel)
-	draft := r.Draft.(base.MTPDraftModel)
-	mtpOpts := r.loadMTPOptions(true)
-	stats := mtpStats{maxDraft: mtpOpts.initialDraftTokens}
-	draftLimit := mtpOpts.initialDraftTokens
-	slog.Info("MTP sample decode enabled", "initial_draft_tokens", mtpOpts.initialDraftTokens, "max_draft_tokens", mtpOpts.maxDraftTokens, "draft_schedule", mtpOpts.draftSchedule, "serial_validate", mtpOpts.serialValidate)
+	slog.Info("MTP decode enabled", "initial_draft_tokens", mtpOpts.initialDraftTokens, "max_draft_tokens", mtpOpts.maxDraftTokens, "draft_schedule", mtpOpts.draftSchedule)
 
 	targetForward := func(token *mlx.Array) *mlx.Array {
 		fwd := r.Model.Forward(&batch.Batch{
@@ -368,14 +196,13 @@ func (r *Runner) runSampleMTPDecode(ctx context.Context, request Request, sessio
 		}
 		stats.draftDuration += time.Since(t0)
 		stats.drafted += draftCount
-
 		var next sampler.Result
 		if draftCount == 0 {
 			next = r.Sampler.Sample([]int{pipelineSlot}, baseLogits)
 		} else {
 			var accepted int
 			t0 = time.Now()
-			next, accepted, done, err = r.acceptSampleMTPDrafts(ctx, request, session, &dec, caches, position, baseLogits, candidates, &final, &generated, &stats)
+			next, accepted, done, err = r.acceptMTPDrafts(ctx, request, session, &dec, caches, position, baseLogits, candidates, &final, &generated)
 			stats.validateDuration += time.Since(t0)
 			mlx.Unpin(candidateArrays...)
 			if err != nil {
@@ -431,7 +258,7 @@ func (r *Runner) runSampleMTPDecode(ctx context.Context, request Request, sessio
 		avgDraft = float64(stats.drafted) / float64(stats.iterations)
 		avgAccepted = float64(stats.accepted) / float64(stats.iterations)
 	}
-	slog.Info("MTP decode stats", "mode", "sample", "generated", generated, "drafted", stats.drafted, "accepted", stats.accepted, "acceptance", acceptance, "iterations", stats.iterations, "avg_draft", avgDraft, "avg_accepted", avgAccepted, "batched", stats.batched, "serial", stats.serial, "mismatches", stats.mismatches, "all_accepted", stats.allAccepted, "max_draft", stats.maxDraft, "draft_schedule", mtpOpts.draftSchedule, "target_duration", stats.targetDuration, "draft_duration", stats.draftDuration, "validate_duration", stats.validateDuration)
+	slog.Info("MTP decode stats", "generated", generated, "drafted", stats.drafted, "accepted", stats.accepted, "acceptance", acceptance, "iterations", stats.iterations, "avg_draft", avgDraft, "avg_accepted", avgAccepted, "mismatches", stats.mismatches, "all_accepted", stats.allAccepted, "max_draft", stats.maxDraft, "draft_schedule", mtpOpts.draftSchedule, "target_duration", stats.targetDuration, "draft_duration", stats.draftDuration, "validate_duration", stats.validateDuration)
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -451,35 +278,6 @@ func (c *mtpDraftCandidates) Arrays() []*mlx.Array {
 		return nil
 	}
 	return append([]*mlx.Array{c.tokens}, c.dist.Arrays()...)
-}
-
-func (r *Runner) generateMTPDrafts(draft base.MTPDraftModel, target base.MTPEmbeddingModel, token *mlx.Array, hidden *mlx.Array, caches []cache.Cache, position int32, maxDraft int) *mlx.Array {
-	if maxDraft <= 0 {
-		return nil
-	}
-
-	lastToken := token.ExpandDims(-1)
-	lastHidden := hidden
-	draftTokens := make([]*mlx.Array, 0, maxDraft)
-
-	// Gemma4 assistant MTP is trained as "single-position" drafting:
-	// keep the RoPE/cache position anchored at the last target-seen token
-	// while the proposed token and projected hidden state advance.
-	for range maxDraft {
-		tokenEmbedding := target.TokenEmbeddings(lastToken)
-		inputs := tokenEmbedding.Concatenate(-1, lastHidden)
-		logits, projected := draft.Draft(inputs, position, caches)
-		stepLogits := r.lastLogitsFromLogits(logits)
-		nextToken := greedyTokenFromLogits(stepLogits)
-
-		lastToken = nextToken.ExpandDims(-1)
-		lastHidden = projected
-		draftTokens = append(draftTokens, lastToken)
-	}
-	if len(draftTokens) == 0 {
-		return nil
-	}
-	return mlx.Concatenate(draftTokens, 1)
 }
 
 func (r *Runner) generateMTPDraftCandidates(draft base.MTPDraftModel, target base.MTPEmbeddingModel, token *mlx.Array, hidden *mlx.Array, caches []cache.Cache, position int32, maxDraft int) *mtpDraftCandidates {
@@ -521,16 +319,6 @@ func (r *Runner) generateMTPDraftCandidates(draft base.MTPDraftModel, target bas
 		tokens: mlx.Concatenate(draftTokens, 1),
 		dist:   sampler.ConcatenateDistributions(draftDists),
 	}
-}
-
-func (r *Runner) acceptMTPDrafts(ctx context.Context, request Request, session *cacheSession, dec *decoder, caches []cache.Cache, position *int, baseLogits *mlx.Array, draftTokens *mlx.Array, final *CompletionResponse, generated *int, stats *mtpStats, opts mtpOptions) (sampler.Result, int, bool, error) {
-	if opts.serialValidate {
-		stats.serial++
-		return r.acceptMTPDraftsSerial(ctx, request, session, dec, caches, position, baseLogits, draftTokens, final, generated)
-	}
-
-	stats.batched++
-	return r.acceptMTPDraftsBatched(ctx, request, session, dec, caches, position, baseLogits, draftTokens, final, generated)
 }
 
 // scheduleSpeculation schedules per-token snapshots at offsets
@@ -586,64 +374,10 @@ func commitSpeculation(caches []cache.Cache, accepted, draftCount, before int) {
 	}
 }
 
-func (r *Runner) acceptMTPDraftsBatched(ctx context.Context, request Request, session *cacheSession, dec *decoder, caches []cache.Cache, position *int, baseLogits *mlx.Array, draftTokens *mlx.Array, final *CompletionResponse, generated *int) (sampler.Result, int, bool, error) {
-	before := *position
-	draftCount := draftTokens.Dim(1)
-
-	scheduleSpeculation(caches, before, draftCount)
-	hiddenSeq := r.Model.Forward(&batch.Batch{
-		InputIDs:     draftTokens,
-		SeqOffsets:   []int32{int32(before)},
-		SeqQueryLens: []int32{int32(draftCount)},
-	}, caches)
-
-	accepted := 0
-	var next sampler.Result
-	done := false
-
-	selectedTokens := r.mtpValidationTokens(baseLogits, hiddenSeq)
-	mlx.Eval(draftTokens, selectedTokens)
-	draftIDs := draftTokens.Ints()
-	selectedIDs := selectedTokens.Ints()
-	if len(selectedIDs) < draftCount+1 {
-		// Drain the scheduled snapshots and roll the speculative forward back
-		// out of the live caches before bailing, so the abandoned drafts don't
-		// reach the trie via session.close().
-		commitSpeculation(caches, 0, draftCount, before)
-		return sampler.Result{}, accepted, false, fmt.Errorf("mtp validation produced %d tokens for %d draft tokens", len(selectedIDs), draftCount)
-	}
-
-	for i, id := range draftIDs {
-		if selectedIDs[i] != id {
-			next = sampler.Result{Token: mtpTokenAt(selectedTokens, i)}
-			break
-		}
-		accepted++
-		if r.Tokenizer.IsEOS(int32(id)) {
-			done = true
-			break
-		}
-	}
-
-	commitSpeculation(caches, accepted, draftCount, before)
-	*position = before + accepted
-
-	emitted, err := r.emitTokens(ctx, request, session, dec, draftResults(draftIDs[:accepted]), final, generated)
-	if err != nil {
-		return sampler.Result{}, accepted, emitted || done, err
-	}
-	if emitted || done {
-		return sampler.Result{}, accepted, true, nil
-	}
-	if next.Token == nil {
-		next = sampler.Result{Token: mtpTokenAt(selectedTokens, draftCount)}
-	}
-	return next, accepted, false, nil
-}
-
-func (r *Runner) acceptSampleMTPDrafts(ctx context.Context, request Request, session *cacheSession, dec *decoder, caches []cache.Cache, position *int, baseLogits *mlx.Array, candidates *mtpDraftCandidates, final *CompletionResponse, generated *int, stats *mtpStats) (sampler.Result, int, bool, error) {
-	stats.batched++
-
+// acceptMTPDrafts accepts the longest draft prefix that survives rejection
+// sampling against the target model. At temperature 0 the distributions are
+// point masses, so acceptance reduces to argmax-match.
+func (r *Runner) acceptMTPDrafts(ctx context.Context, request Request, session *cacheSession, dec *decoder, caches []cache.Cache, position *int, baseLogits *mlx.Array, candidates *mtpDraftCandidates, final *CompletionResponse, generated *int) (sampler.Result, int, bool, error) {
 	before := *position
 	draftCount := candidates.tokens.Dim(1)
 	scheduleSpeculation(caches, before, draftCount)
@@ -753,42 +487,6 @@ func mtpTokenVector(token *mlx.Array) *mlx.Array {
 	}
 }
 
-func (r *Runner) acceptMTPDraftsSerial(ctx context.Context, request Request, session *cacheSession, dec *decoder, caches []cache.Cache, position *int, baseLogits *mlx.Array, draftTokens *mlx.Array, final *CompletionResponse, generated *int) (sampler.Result, int, bool, error) {
-	logits := baseLogits
-	accepted := 0
-	draftIDs := draftTokens.Ints()
-
-	for _, id := range draftIDs {
-		selected := greedyTokenFromLogits(logits)
-		mlx.Eval(selected)
-		selectedID := tokenID(selected)
-		if selectedID != id {
-			return sampler.Result{Token: mlx.FromValues([]int32{int32(selectedID)}, 1)}, accepted, false, nil
-		}
-
-		hidden := r.Model.Forward(&batch.Batch{
-			InputIDs:     mlx.FromValues([]int32{int32(id)}, 1, 1),
-			SeqOffsets:   []int32{int32(*position)},
-			SeqQueryLens: []int32{1},
-		}, caches)
-		(*position)++
-		accepted++
-
-		res := sampler.Result{Token: mlx.FromValues([]int32{int32(id)}, 1)}
-		done, err := r.emitTokens(ctx, request, session, dec, []sampler.Result{res}, final, generated)
-		if err != nil {
-			return sampler.Result{}, accepted, done, err
-		}
-		if done {
-			return sampler.Result{}, accepted, true, nil
-		}
-
-		logits = r.lastLogits(hidden)
-	}
-
-	return sampler.Result{Token: greedyTokenFromLogits(logits)}, accepted, false, nil
-}
-
 // emitTokens records a run of generated tokens to session.outputs, then streams
 // them. A trailing EOS stops generation and is recorded but not streamed.
 // Returns whether to stop and any cancellation error.
@@ -841,36 +539,21 @@ func (r *Runner) lastLogits(hidden *mlx.Array) *mlx.Array {
 	return r.lastLogitsFromLogits(logits)
 }
 
-func (r *Runner) mtpValidationTokens(baseLogits, hiddenSeq *mlx.Array) *mlx.Array {
-	return greedyTokenFromLogits(r.mtpValidationLogits(baseLogits, hiddenSeq))
-}
-
 func (r *Runner) mtpValidationLogits(baseLogits, hiddenSeq *mlx.Array) *mlx.Array {
 	seqLogits := r.Model.Unembed(hiddenSeq)
 	return baseLogits.ExpandDims(1).Concatenate(1, seqLogits)
-}
-
-func mtpTokenAt(tokens *mlx.Array, index int) *mlx.Array {
-	return tokens.Slice(mlx.Slice(), mlx.Slice(index)).Squeeze(0)
 }
 
 func (r *Runner) lastLogitsFromLogits(logits *mlx.Array) *mlx.Array {
 	return logits.Slice(mlx.Slice(), mlx.Slice(logits.Dim(1)-1), mlx.Slice()).Squeeze(1)
 }
 
-func greedyTokenFromLogits(logits *mlx.Array) *mlx.Array {
-	return logits.Argmax(-1, false).AsType(mlx.DTypeInt32)
-}
-
+// tokenID reads a single-token array as its host id. It goes through the
+// item accessor, which evaluates the array first: raw data reads on a lazy
+// array race its evaluation and return garbage.
 func tokenID(token *mlx.Array) int {
 	if token == nil {
 		return -1
-	}
-	if token.DType() == mlx.DTypeInt32 {
-		ids := token.Ints()
-		if len(ids) > 0 {
-			return ids[0]
-		}
 	}
 	return token.Int()
 }

--- a/x/mlxrunner/mtp_test.go
+++ b/x/mlxrunner/mtp_test.go
@@ -263,13 +263,12 @@ func TestAcceptMTPDraftsGreedyAcceptAll(t *testing.T) {
 
 	caches, _ := newMTPTestCaches(1)
 	candidates := scriptedCandidates(r, []int32{2, 3, 4})
-	baseLogits := oneHotLogits([]int32{2}).Squeeze(1) // target prediction after the seed token 1
 
 	position := caches[0].Offset()
 
 	spec := testSpeculationSession(r, caches)
 	current := sampler.Result{Token: mlx.FromValues([]int32{1}, 1)}
-	results, accepted, err := spec.accept(&position, current, oneHotLogits([]int32{1}), baseLogits, candidates)
+	results, accepted, err := spec.accept(&position, current, candidates)
 	if err != nil {
 		t.Fatalf("accept: %v", err)
 	}
@@ -280,11 +279,11 @@ func TestAcceptMTPDraftsGreedyAcceptAll(t *testing.T) {
 	if got := resultIDs(results); !slices.Equal(got, []int{2, 3, 4, 5}) {
 		t.Fatalf("results = %v, want [2 3 4 5]", got)
 	}
-	if position != 3 {
-		t.Fatalf("position = %d, want 3", position)
+	if position != 4 {
+		t.Fatalf("position = %d, want 4 (current + accepted)", position)
 	}
-	if got := caches[0].Offset(); got != 3 {
-		t.Fatalf("cache offset = %d, want 3 (all drafts kept)", got)
+	if got := caches[0].Offset(); got != 4 {
+		t.Fatalf("cache offset = %d, want 4 (current + all drafts kept)", got)
 	}
 }
 
@@ -298,13 +297,12 @@ func TestAcceptMTPDraftsGreedyMismatch(t *testing.T) {
 
 	caches, _ := newMTPTestCaches(1)
 	candidates := scriptedCandidates(r, []int32{2, 7})
-	baseLogits := oneHotLogits([]int32{2}).Squeeze(1)
 
 	position := caches[0].Offset()
 
 	spec := testSpeculationSession(r, caches)
 	current := sampler.Result{Token: mlx.FromValues([]int32{1}, 1)}
-	results, accepted, err := spec.accept(&position, current, oneHotLogits([]int32{1}), baseLogits, candidates)
+	results, accepted, err := spec.accept(&position, current, candidates)
 	if err != nil {
 		t.Fatalf("accept: %v", err)
 	}
@@ -316,11 +314,11 @@ func TestAcceptMTPDraftsGreedyMismatch(t *testing.T) {
 	if got := resultIDs(results); !slices.Equal(got, []int{2, 3}) {
 		t.Fatalf("results = %v, want [2 3]", got)
 	}
-	if position != 1 {
-		t.Fatalf("position = %d, want 1", position)
+	if position != 2 {
+		t.Fatalf("position = %d, want 2 (current + accepted)", position)
 	}
-	if got := caches[0].Offset(); got != 1 {
-		t.Fatalf("cache offset = %d, want 1 (rolled back to accepted)", got)
+	if got := caches[0].Offset(); got != 2 {
+		t.Fatalf("cache offset = %d, want 2 (rolled back to accepted)", got)
 	}
 }
 
@@ -335,13 +333,12 @@ func TestAcceptMTPDraftsGreedyEOS(t *testing.T) {
 
 	caches, _ := newMTPTestCaches(1)
 	candidates := scriptedCandidates(r, []int32{2, eos})
-	baseLogits := oneHotLogits([]int32{2}).Squeeze(1)
 
 	position := caches[0].Offset()
 
 	spec := testSpeculationSession(r, caches)
 	current := sampler.Result{Token: mlx.FromValues([]int32{1}, 1)}
-	results, accepted, err := spec.accept(&position, current, oneHotLogits([]int32{1}), baseLogits, candidates)
+	results, accepted, err := spec.accept(&position, current, candidates)
 	if err != nil {
 		t.Fatalf("accept: %v", err)
 	}
@@ -356,11 +353,11 @@ func TestAcceptMTPDraftsGreedyEOS(t *testing.T) {
 	if len(results) != accepted {
 		t.Fatalf("results has %d tokens, want exactly the %d accepted with no bonus after EOS", len(results), accepted)
 	}
-	if position != 1 {
-		t.Fatalf("position = %d, want 1 (kept draft committed, EOS dropped)", position)
+	if position != 2 {
+		t.Fatalf("position = %d, want 2 (current + kept draft, EOS dropped)", position)
 	}
-	if got := caches[0].Offset(); got != 1 {
-		t.Fatalf("cache offset = %d, want 1 (one behind the recorded outputs, EOS dropped)", got)
+	if got := caches[0].Offset(); got != 2 {
+		t.Fatalf("cache offset = %d, want 2 (one behind the recorded outputs, EOS dropped)", got)
 	}
 }
 
@@ -407,9 +404,9 @@ func TestRunMTPDecodeGreedy(t *testing.T) {
 	}
 
 	// The target writes the caches contiguously: the seed token at offset 1,
-	// the round's current token at offset 2, then the 4-token validation
-	// forward at offset 3.
-	wantForwards := []forwardCall{{offset: 1, n: 1}, {offset: 2, n: 1}, {offset: 3, n: 4}}
+	// then one fused forward validating the current token and the 4 drafts
+	// together at offset 2.
+	wantForwards := []forwardCall{{offset: 1, n: 1}, {offset: 2, n: 5}}
 	model := r.Model.(*fakeMTPModel)
 	if !slices.Equal(model.forwards, wantForwards) {
 		t.Fatalf("target forwards = %v, want %v", model.forwards, wantForwards)
@@ -465,6 +462,65 @@ func TestRunMTPDecodeSampled(t *testing.T) {
 	}
 	if got := []int32{2, 3, 4, eos}; !slices.Equal(session.outputs, got) {
 		t.Fatalf("session outputs = %v, want %v", session.outputs, got)
+	}
+}
+
+func TestRunMTPDecodeWarmDrafter(t *testing.T) {
+	skipIfNoMLX(t)
+	// A drafter warmed by a prefill report proposes in the very first round:
+	// the last prompt token seeds the decode loop and is forwarded fused
+	// with the drafts, so generation runs no plain forward at all.
+	const eos int32 = 7
+	predict := map[int32]int32{1: 2, 2: 3, 3: 4, 4: eos, eos: 0}
+	r := mtpTestRunner(t, predict, []int32{eos}, sampler.Options{})
+	draft := &fakeMTPDraft{predict: predict}
+	r.spec = newSpeculation(r, draft)
+
+	caches, _ := newMTPTestCaches(1)
+	session, ch := newMTPTestSession(caches)
+	position := 1 // one prefill token already processed
+
+	req := Request{
+		Responses:         ch,
+		Tokens:            []int32{0},
+		CompletionRequest: CompletionRequest{Options: api.Options{Runner: api.Runner{DraftNumPredict: 4}, NumPredict: 20}},
+		SamplerOpts:       sampler.Options{},
+	}
+	spec := r.spec.open(req, caches)
+	// The prefill chunk's committed report: token 0 at slot 0 with its
+	// hidden row, leaving the drafter ready to propose from slot 1.
+	spec.committed(mlx.FromValues([]int32{0}, 1, 1), oneHotLogits([]int32{1}), 0)
+
+	d := spec.decoder([]int32{1}, position)
+	if err := r.decode(context.Background(), req, session, d, 0); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	d.close()
+
+	content, final := collectResponses(ch)
+	if content != "234" {
+		t.Fatalf("content = %q, want %q", content, "234")
+	}
+	if final.DoneReason != 0 {
+		t.Fatalf("DoneReason = %d, want 0 (EOS)", final.DoneReason)
+	}
+	if got := []int32{2, 3, 4, eos}; !slices.Equal(session.outputs, got) {
+		t.Fatalf("session outputs = %v, want %v", session.outputs, got)
+	}
+
+	// One fused forward validates the seed token and all 4 proposals
+	// together at the seed token's slot.
+	wantForwards := []forwardCall{{offset: 1, n: 5}}
+	model := r.Model.(*fakeMTPModel)
+	if !slices.Equal(model.forwards, wantForwards) {
+		t.Fatalf("target forwards = %v, want %v", model.forwards, wantForwards)
+	}
+
+	// Warm drafting anchors at the last reported slot (0) and extends the
+	// seed token through the proposal chain.
+	wantDraft := []draftCall{{0, 1}, {0, 2}, {0, 3}, {0, 4}}
+	if !slices.Equal(draft.calls, wantDraft) {
+		t.Fatalf("draft calls = %v, want %v", draft.calls, wantDraft)
 	}
 }
 

--- a/x/mlxrunner/mtp_test.go
+++ b/x/mlxrunner/mtp_test.go
@@ -1,0 +1,446 @@
+package mlxrunner
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/x/mlxrunner/batch"
+	"github.com/ollama/ollama/x/mlxrunner/cache"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/mlxrunner/model/base"
+	sampler "github.com/ollama/ollama/x/mlxrunner/sample"
+	"github.com/ollama/ollama/x/tokenizer"
+)
+
+// skipIfNoMLX skips a test that exercises native MLX when the dynamic library
+// is unavailable, as on CI runners without an MLX build.
+func skipIfNoMLX(t *testing.T) {
+	t.Helper()
+	if err := mlx.CheckInit(); err != nil {
+		t.Skipf("MLX not available: %v", err)
+	}
+}
+
+// The MTP fakes make hidden state and logits the same tensor (Forward returns
+// one-hot logits, Unembed is the identity), so tests fully script target and
+// draft predictions.
+
+const mtpTestVocab = 8
+
+// oneHotLogits builds logits with a large value on each listed token id.
+func oneHotLogits(tokens []int32) *mlx.Array {
+	data := make([]float32, len(tokens)*mtpTestVocab)
+	for i, tok := range tokens {
+		data[i*mtpTestVocab+int(tok)] = 30
+	}
+	return mlx.FromValues(data, 1, len(tokens), mtpTestVocab)
+}
+
+// fakeMTPModel is a target whose next-token prediction is a fixed function of
+// the input token; Forward also feeds ids to the caches so offsets advance.
+type fakeMTPModel struct {
+	predict map[int32]int32
+	tok     *tokenizer.Tokenizer
+	// forwards records each Forward call so tests can assert contiguous writes.
+	forwards []forwardCall
+}
+
+type forwardCall struct {
+	offset int32
+	n      int32
+}
+
+func (m *fakeMTPModel) Forward(b *batch.Batch, caches []cache.Cache) *mlx.Array {
+	mlx.Eval(b.InputIDs)
+	ids := b.InputIDs.Ints()
+	m.forwards = append(m.forwards, forwardCall{offset: b.SeqOffsets[0], n: int32(len(ids))})
+	for _, c := range caches {
+		if rc, ok := c.(*fakeRewindableCache); ok {
+			seg := make([]int32, len(ids))
+			for i, id := range ids {
+				seg[i] = int32(id)
+			}
+			rc.feed(seg)
+		}
+	}
+
+	preds := make([]int32, len(ids))
+	for i, id := range ids {
+		preds[i] = m.predict[int32(id)]
+	}
+	return oneHotLogits(preds)
+}
+
+func (m *fakeMTPModel) Unembed(x *mlx.Array) *mlx.Array { return x }
+func (m *fakeMTPModel) NumLayers() int                  { return 1 }
+func (m *fakeMTPModel) Tokenizer() *tokenizer.Tokenizer { return m.tok }
+func (m *fakeMTPModel) MaxContextLength() int           { return 4096 }
+func (m *fakeMTPModel) LoadWeights(map[string]*mlx.Array) error {
+	return nil
+}
+
+// TokenEmbeddings returns a width-1 embedding holding the token id as a float,
+// so a draft can recover which token it is extending from inputs[...,0].
+func (m *fakeMTPModel) TokenEmbeddings(inputIDs *mlx.Array) *mlx.Array {
+	mlx.Eval(inputIDs)
+	ids := inputIDs.Ints()
+	data := make([]float32, len(ids))
+	for i, id := range ids {
+		data[i] = float32(id)
+	}
+	return mlx.FromValues(data, inputIDs.Dim(0), inputIDs.Dim(1), 1)
+}
+
+var (
+	_ base.Model             = (*fakeMTPModel)(nil)
+	_ base.MTPEmbeddingModel = (*fakeMTPModel)(nil)
+)
+
+// fakeMTPDraft extends the token in inputEmbeds through predict; a map (not a
+// step counter) keeps drafting consistent regardless of batching.
+type fakeMTPDraft struct {
+	predict map[int32]int32
+	// calls records each Draft call so tests can assert the position convention.
+	calls []draftCall
+}
+
+type draftCall struct {
+	position int32
+	from     int32
+}
+
+func (d *fakeMTPDraft) LoadWeights(map[string]*mlx.Array) error { return nil }
+
+func (d *fakeMTPDraft) Draft(inputEmbeds *mlx.Array, position int32, caches []cache.Cache) (logits, hidden *mlx.Array) {
+	mlx.Eval(inputEmbeds)
+	prev := int32(inputEmbeds.Floats()[0])
+	d.calls = append(d.calls, draftCall{position: position, from: prev})
+	return oneHotLogits([]int32{d.predict[prev]}), mlx.Zeros(mlx.DTypeFloat32, 1, 1, mtpTestVocab)
+}
+
+var (
+	_ base.DraftModel    = (*fakeMTPDraft)(nil)
+	_ base.MTPDraftModel = (*fakeMTPDraft)(nil)
+)
+
+// newTestTokenizer builds a byte-level BPE tokenizer over single-character
+// tokens "0".."7" with the given EOS ids, so Decode(id) yields that digit and
+// IsEOS reports membership.
+func newTestTokenizer(t *testing.T, eos []int32) *tokenizer.Tokenizer {
+	t.Helper()
+	vocab := make(map[string]int32, mtpTestVocab)
+	for i := range mtpTestVocab {
+		vocab[fmt.Sprintf("%d", i)] = int32(i)
+	}
+	model := map[string]any{
+		"type":   "BPE",
+		"vocab":  vocab,
+		"merges": []string{},
+	}
+	data, err := json.Marshal(map[string]any{"model": model})
+	if err != nil {
+		t.Fatalf("marshal tokenizer: %v", err)
+	}
+	genConfig, err := json.Marshal(map[string]any{"eos_token_id": eos})
+	if err != nil {
+		t.Fatalf("marshal generation config: %v", err)
+	}
+	tok, err := tokenizer.LoadFromBytesWithConfig(data, &tokenizer.TokenizerConfig{GenerationConfigJSON: genConfig})
+	if err != nil {
+		t.Fatalf("load tokenizer: %v", err)
+	}
+	return tok
+}
+
+// mtpTestRunner wires a Runner with the MTP fakes and a real sampler
+// registered with opts.
+func mtpTestRunner(t *testing.T, predict map[int32]int32, eos []int32, opts sampler.Options) *Runner {
+	t.Helper()
+	tok := newTestTokenizer(t, eos)
+	r := &Runner{
+		Model:     &fakeMTPModel{predict: predict, tok: tok},
+		Tokenizer: tok,
+		Sampler:   sampler.New(4096),
+	}
+	r.Sampler.Add(pipelineSlot, opts, nil)
+	t.Cleanup(func() { r.Sampler.Remove(pipelineSlot) })
+	return r
+}
+
+// collectResponses drains a buffered response channel into the concatenated
+// streamed content and the captured terminal response.
+func collectResponses(ch chan CompletionResponse) (content string, final CompletionResponse) {
+	var b strings.Builder
+	for {
+		select {
+		case resp := <-ch:
+			if resp.Done {
+				return b.String(), resp
+			}
+			b.WriteString(resp.Content)
+		default:
+			return b.String(), final
+		}
+	}
+}
+
+func TestAcceptMTPDraftsGreedyAcceptAll(t *testing.T) {
+	skipIfNoMLX(t)
+	// Target predicts 1->2->3->4 along the accepted chain; the draft proposed
+	// exactly that, so every draft token is accepted and the bonus token is the
+	// target's prediction after the last accepted token.
+	predict := map[int32]int32{1: 2, 2: 3, 3: 4, 4: 5}
+	r := mtpTestRunner(t, predict, nil, sampler.Options{})
+
+	caches, _ := newMTPTestCaches(1)
+	candidates := scriptedCandidates(r, []int32{2, 3, 4})
+	baseLogits := oneHotLogits([]int32{2}).Squeeze(1) // target prediction after the seed token 1
+
+	session, ch := newMTPTestSession(caches)
+	position := caches[0].Offset()
+	final := CompletionResponse{Done: true}
+	generated := 0
+
+	req := Request{Responses: ch, CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 100}}}
+	next, accepted, done, err := r.acceptMTPDrafts(context.Background(), req, session, &decoder{tokenizer: r.Tokenizer}, caches, &position, baseLogits, candidates, &final, &generated)
+	if err != nil {
+		t.Fatalf("acceptMTPDrafts: %v", err)
+	}
+	if accepted != 3 {
+		t.Fatalf("accepted = %d, want 3", accepted)
+	}
+	if done {
+		t.Fatalf("done = true, want false")
+	}
+	if got := tokenID(next.Token); got != 5 {
+		t.Fatalf("bonus token = %d, want 5", got)
+	}
+	if position != 3 {
+		t.Fatalf("position = %d, want 3", position)
+	}
+	if got := caches[0].Offset(); got != 3 {
+		t.Fatalf("cache offset = %d, want 3 (all drafts kept)", got)
+	}
+	if generated != 3 {
+		t.Fatalf("generated = %d, want 3", generated)
+	}
+}
+
+func TestAcceptMTPDraftsGreedyMismatch(t *testing.T) {
+	skipIfNoMLX(t)
+	// Target predicts 1->2->9 but the draft proposed 2 then 7: the second draft
+	// token mismatches, so only the first is accepted and the bonus is the
+	// target's own prediction (3) at the rejection point.
+	predict := map[int32]int32{1: 2, 2: 3, 7: 0}
+	r := mtpTestRunner(t, predict, nil, sampler.Options{})
+
+	caches, _ := newMTPTestCaches(1)
+	candidates := scriptedCandidates(r, []int32{2, 7})
+	baseLogits := oneHotLogits([]int32{2}).Squeeze(1)
+
+	session, ch := newMTPTestSession(caches)
+	position := caches[0].Offset()
+	final := CompletionResponse{Done: true}
+	generated := 0
+
+	req := Request{Responses: ch, CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 100}}}
+	next, accepted, done, err := r.acceptMTPDrafts(context.Background(), req, session, &decoder{tokenizer: r.Tokenizer}, caches, &position, baseLogits, candidates, &final, &generated)
+	if err != nil {
+		t.Fatalf("acceptMTPDrafts: %v", err)
+	}
+	if accepted != 1 {
+		t.Fatalf("accepted = %d, want 1", accepted)
+	}
+	if done {
+		t.Fatalf("done = true, want false")
+	}
+	if got := tokenID(next.Token); got != 3 {
+		t.Fatalf("bonus token = %d, want 3 (target prediction at rejection)", got)
+	}
+	if position != 1 {
+		t.Fatalf("position = %d, want 1", position)
+	}
+	if got := caches[0].Offset(); got != 1 {
+		t.Fatalf("cache offset = %d, want 1 (rolled back to accepted)", got)
+	}
+}
+
+func TestAcceptMTPDraftsGreedyEOS(t *testing.T) {
+	skipIfNoMLX(t)
+	// The second accepted draft token is EOS: it is recorded but stops
+	// generation, no bonus token is produced, and the cache keeps both tokens.
+	const eos int32 = 6
+	predict := map[int32]int32{1: 2, 2: eos, eos: 0}
+	r := mtpTestRunner(t, predict, []int32{eos}, sampler.Options{})
+
+	caches, _ := newMTPTestCaches(1)
+	candidates := scriptedCandidates(r, []int32{2, eos})
+	baseLogits := oneHotLogits([]int32{2}).Squeeze(1)
+
+	session, ch := newMTPTestSession(caches)
+	position := caches[0].Offset()
+	final := CompletionResponse{Done: true, DoneReason: 1}
+	generated := 0
+
+	req := Request{Responses: ch, CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 100}}}
+	next, accepted, done, err := r.acceptMTPDrafts(context.Background(), req, session, &decoder{tokenizer: r.Tokenizer}, caches, &position, baseLogits, candidates, &final, &generated)
+	if err != nil {
+		t.Fatalf("acceptMTPDrafts: %v", err)
+	}
+	if accepted != 2 {
+		t.Fatalf("accepted = %d, want 2 (token + EOS)", accepted)
+	}
+	if !done {
+		t.Fatalf("done = false, want true")
+	}
+	if next.Token != nil {
+		t.Fatalf("bonus token = %d, want none after EOS", tokenID(next.Token))
+	}
+	if final.DoneReason != 0 {
+		t.Fatalf("DoneReason = %d, want 0 (EOS)", final.DoneReason)
+	}
+	if position != 2 {
+		t.Fatalf("position = %d, want 2", position)
+	}
+}
+
+func TestRunMTPDecodeGreedy(t *testing.T) {
+	skipIfNoMLX(t)
+	// The seed token 1 is the last prefill token; its prediction (2) is the
+	// first generated token. The decode then walks 2->3->4->EOS. The draft
+	// proposes the correct chain so steps are accepted in a single forward.
+	const eos int32 = 7
+	predict := map[int32]int32{1: 2, 2: 3, 3: 4, 4: eos, eos: 0}
+	r := mtpTestRunner(t, predict, []int32{eos}, sampler.Options{})
+	// The draft mirrors the target chain, so every drafted token is accepted.
+	draft := &fakeMTPDraft{predict: predict}
+	r.Draft = draft
+
+	caches, _ := newMTPTestCaches(1)
+	session, ch := newMTPTestSession(caches)
+	position := 1 // one prefill token already processed
+
+	req := Request{
+		Responses:         ch,
+		Tokens:            []int32{0},
+		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
+		SamplerOpts:       sampler.Options{},
+	}
+	if err := r.runMTPDecode(context.Background(), req, session, caches, []int32{1}, &position, time.Now()); err != nil {
+		t.Fatalf("runMTPDecode: %v", err)
+	}
+
+	content, final := collectResponses(ch)
+	if content != "234" {
+		t.Fatalf("content = %q, want %q", content, "234")
+	}
+	if !final.Done {
+		t.Fatalf("final response not marked Done")
+	}
+	if final.DoneReason != 0 {
+		t.Fatalf("DoneReason = %d, want 0 (EOS)", final.DoneReason)
+	}
+	if got := []int32{2, 3, 4, eos}; !slices.Equal(session.outputs, got) {
+		t.Fatalf("session outputs = %v, want %v", session.outputs, got)
+	}
+
+	// The target writes the caches contiguously: the seed token at offset 1,
+	// the round's current token at offset 2, then the 4-token validation
+	// forward at offset 3.
+	wantForwards := []forwardCall{{offset: 1, n: 1}, {offset: 2, n: 1}, {offset: 3, n: 4}}
+	model := r.Model.(*fakeMTPModel)
+	if !slices.Equal(model.forwards, wantForwards) {
+		t.Fatalf("target forwards = %v, want %v", model.forwards, wantForwards)
+	}
+
+	// Single-position drafting anchors every Draft call in a round at the
+	// last target-seen position (the current token, offset 2), while the
+	// extended token advances along the proposed chain.
+	wantDraft := []draftCall{{2, 2}, {2, 3}, {2, 4}, {2, eos}}
+	if !slices.Equal(draft.calls, wantDraft) {
+		t.Fatalf("draft calls = %v, want %v", draft.calls, wantDraft)
+	}
+}
+
+func TestRunMTPDecodeSampled(t *testing.T) {
+	skipIfNoMLX(t)
+	// The same chain at temperature 1: because oneHotLogits uses a large gap,
+	// the proposal and target distributions are effectively point masses, so the
+	// rejection-sampling accept path that the sampled and greedy paths now share
+	// accepts the mirrored draft chain deterministically.
+	const eos int32 = 7
+	predict := map[int32]int32{1: 2, 2: 3, 3: 4, 4: eos, eos: 0}
+	r := mtpTestRunner(t, predict, []int32{eos}, sampler.Options{Temperature: 1, Seed: 42, UseSeed: true})
+	r.Draft = &fakeMTPDraft{predict: predict}
+
+	if !r.useMTP(sampler.Options{Temperature: 1}) {
+		t.Fatalf("useMTP rejected a sampled request")
+	}
+
+	caches, _ := newMTPTestCaches(1)
+	session, ch := newMTPTestSession(caches)
+	position := 1
+
+	req := Request{
+		Responses:         ch,
+		Tokens:            []int32{0},
+		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
+		SamplerOpts:       sampler.Options{Temperature: 1, Seed: 42, UseSeed: true},
+	}
+	if err := r.runMTPDecode(context.Background(), req, session, caches, []int32{1}, &position, time.Now()); err != nil {
+		t.Fatalf("runMTPDecode: %v", err)
+	}
+
+	content, final := collectResponses(ch)
+	if content != "234" {
+		t.Fatalf("content = %q, want %q", content, "234")
+	}
+	if final.DoneReason != 0 {
+		t.Fatalf("DoneReason = %d, want 0 (EOS)", final.DoneReason)
+	}
+	if got := []int32{2, 3, 4, eos}; !slices.Equal(session.outputs, got) {
+		t.Fatalf("session outputs = %v, want %v", session.outputs, got)
+	}
+}
+
+// newMTPTestCaches returns n rewindable fake caches sharing one snapshot
+// tracker, matching the cache.Cache the speculation helpers drive.
+func newMTPTestCaches(n int) ([]cache.Cache, *snapshotTracker) {
+	tr := &snapshotTracker{}
+	caches := make([]cache.Cache, n)
+	for i := range caches {
+		caches[i] = &fakeRewindableCache{tracker: tr}
+	}
+	return caches, tr
+}
+
+// newMTPTestSession wraps caches in a cacheSession with a buffered response
+// channel large enough to hold a short decode run without a reader.
+func newMTPTestSession(caches []cache.Cache) (*cacheSession, chan CompletionResponse) {
+	ch := make(chan CompletionResponse, 256)
+	return &cacheSession{caches: caches}, ch
+}
+
+// scriptedCandidates builds draft candidates by running the real generator
+// against a draft whose prediction chain, starting from seed token 0, yields
+// exactly the requested tokens. Using the real generator means the proposal
+// distributions match what acceptMTPDrafts expects.
+func scriptedCandidates(r *Runner, tokens []int32) *mtpDraftCandidates {
+	chain := map[int32]int32{}
+	prev := int32(0)
+	for _, tok := range tokens {
+		chain[prev] = tok
+		prev = tok
+	}
+	draft := &fakeMTPDraft{predict: chain}
+	target := r.Model.(base.MTPEmbeddingModel)
+	seed := mlx.FromValues([]int32{0}, 1, 1)
+	hidden := mlx.Zeros(mlx.DTypeFloat32, 1, 1, mtpTestVocab)
+	return r.generateMTPDraftCandidates(draft, target, seed, hidden, nil, 0, len(tokens))
+}

--- a/x/mlxrunner/mtp_test.go
+++ b/x/mlxrunner/mtp_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"slices"
 	"strings"
 	"testing"
@@ -60,7 +61,10 @@ func (m *fakeMTPModel) Forward(b *batch.Batch, caches []cache.Cache) *mlx.Array 
 	mlx.Eval(b.InputIDs)
 	ids := b.InputIDs.Ints()
 	m.forwards = append(m.forwards, forwardCall{offset: b.SeqOffsets[0], n: int32(len(ids))})
-	for _, c := range caches {
+	for i, c := range caches {
+		if i >= m.NumLayers() {
+			break
+		}
 		if rc, ok := c.(*fakeRewindableCache); ok {
 			seg := make([]int32, len(ids))
 			for i, id := range ids {
@@ -85,25 +89,10 @@ func (m *fakeMTPModel) LoadWeights(map[string]*mlx.Array) error {
 	return nil
 }
 
-// TokenEmbeddings returns a width-1 embedding holding the token id as a float,
-// so a draft can recover which token it is extending from inputs[...,0].
-func (m *fakeMTPModel) TokenEmbeddings(inputIDs *mlx.Array) *mlx.Array {
-	mlx.Eval(inputIDs)
-	ids := inputIDs.Ints()
-	data := make([]float32, len(ids))
-	for i, id := range ids {
-		data[i] = float32(id)
-	}
-	return mlx.FromValues(data, inputIDs.Dim(0), inputIDs.Dim(1), 1)
-}
+var _ base.Model = (*fakeMTPModel)(nil)
 
-var (
-	_ base.Model             = (*fakeMTPModel)(nil)
-	_ base.MTPEmbeddingModel = (*fakeMTPModel)(nil)
-)
-
-// fakeMTPDraft extends the token in inputEmbeds through predict; a map (not a
-// step counter) keeps drafting consistent regardless of batching.
+// fakeMTPDraft is a cacheless draft that extends b.InputIDs through predict;
+// a map (not a step counter) keeps drafting consistent regardless of batching.
 type fakeMTPDraft struct {
 	predict map[int32]int32
 	// calls records each Draft call so tests can assert the position convention.
@@ -117,17 +106,82 @@ type draftCall struct {
 
 func (d *fakeMTPDraft) LoadWeights(map[string]*mlx.Array) error { return nil }
 
-func (d *fakeMTPDraft) Draft(inputEmbeds *mlx.Array, position int32, caches []cache.Cache) (logits, hidden *mlx.Array) {
-	mlx.Eval(inputEmbeds)
-	prev := int32(inputEmbeds.Floats()[0])
-	d.calls = append(d.calls, draftCall{position: position, from: prev})
+func (d *fakeMTPDraft) DraftCaches([]cache.Cache) []cache.Cache { return nil }
+
+func (d *fakeMTPDraft) Draft(b *batch.Batch, caches []cache.Cache) (hidden, projected *mlx.Array) {
+	mlx.Eval(b.InputIDs)
+	prev := int32(b.InputIDs.Ints()[0])
+	d.calls = append(d.calls, draftCall{position: b.SeqOffsets[0], from: prev})
 	return oneHotLogits([]int32{d.predict[prev]}), mlx.Zeros(mlx.DTypeFloat32, 1, 1, mtpTestVocab)
 }
 
-var (
-	_ base.DraftModel    = (*fakeMTPDraft)(nil)
-	_ base.MTPDraftModel = (*fakeMTPDraft)(nil)
-)
+// Unembed is the identity: the fake's hidden already is its one-hot logits.
+func (d *fakeMTPDraft) Unembed(x *mlx.Array) *mlx.Array { return x }
+
+var _ base.DraftModel = (*fakeMTPDraft)(nil)
+
+// fakeKVDraft is a draft head with its own KV cache: it claims the trailing
+// cache slot, writes its input ids there on every Draft call (advancing the
+// offset like a real KV write), and records each call's offset, ids, and
+// the identity of every fused hidden row. A target hidden row is one-hot
+// (its hot index identifies which position it came from); the head's own
+// projected hidden is all-zero and records as -1.
+type fakeKVDraft struct {
+	predict map[int32]int32
+	extends []extendCall
+}
+
+// extendCall is one recorded Draft call: the absolute slot of the first
+// entry written, the look-ahead token ids, and the hot index of each fused
+// hidden row (-1 for the head's own projected hidden).
+type extendCall struct {
+	offset  int32
+	ids     []int32
+	hiddens []int32
+}
+
+func (d *fakeKVDraft) LoadWeights(map[string]*mlx.Array) error { return nil }
+
+func (d *fakeKVDraft) DraftCaches(caches []cache.Cache) []cache.Cache {
+	return caches[len(caches)-1:]
+}
+
+func (d *fakeKVDraft) Draft(b *batch.Batch, caches []cache.Cache) (hidden, projected *mlx.Array) {
+	mlx.Eval(b.InputIDs, b.Hidden)
+	rawIDs := b.InputIDs.Ints()
+	ids := make([]int32, len(rawIDs))
+	for i, id := range rawIDs {
+		ids[i] = int32(id)
+	}
+
+	hot := make([]int32, b.Hidden.Dim(1))
+	flat := b.Hidden.Floats()
+	for r := range hot {
+		hot[r] = -1
+		for v := range mtpTestVocab {
+			if flat[r*mtpTestVocab+v] != 0 {
+				hot[r] = int32(v)
+				break
+			}
+		}
+	}
+	d.extends = append(d.extends, extendCall{offset: b.SeqOffsets[0], ids: ids, hiddens: hot})
+
+	if rc, ok := d.DraftCaches(caches)[0].(*fakeRewindableCache); ok {
+		rc.feed(ids)
+	}
+
+	preds := make([]int32, len(ids))
+	for i, id := range ids {
+		preds[i] = d.predict[id]
+	}
+	return oneHotLogits(preds), mlx.Zeros(mlx.DTypeFloat32, 1, 1, mtpTestVocab)
+}
+
+// Unembed is the identity: the fake's hidden already is its one-hot logits.
+func (d *fakeKVDraft) Unembed(x *mlx.Array) *mlx.Array { return x }
+
+var _ base.DraftModel = (*fakeKVDraft)(nil)
 
 // newTestTokenizer builds a byte-level BPE tokenizer over single-character
 // tokens "0".."7" with the given EOS ids, so Decode(id) yields that digit and
@@ -215,7 +269,7 @@ func TestAcceptMTPDraftsGreedyAcceptAll(t *testing.T) {
 
 	spec := testSpeculationSession(r, caches)
 	current := sampler.Result{Token: mlx.FromValues([]int32{1}, 1)}
-	results, accepted, err := spec.accept(&position, current, oneHotLogits([]int32{2}), baseLogits, candidates)
+	results, accepted, err := spec.accept(&position, current, oneHotLogits([]int32{1}), baseLogits, candidates)
 	if err != nil {
 		t.Fatalf("accept: %v", err)
 	}
@@ -250,7 +304,7 @@ func TestAcceptMTPDraftsGreedyMismatch(t *testing.T) {
 
 	spec := testSpeculationSession(r, caches)
 	current := sampler.Result{Token: mlx.FromValues([]int32{1}, 1)}
-	results, accepted, err := spec.accept(&position, current, oneHotLogits([]int32{2}), baseLogits, candidates)
+	results, accepted, err := spec.accept(&position, current, oneHotLogits([]int32{1}), baseLogits, candidates)
 	if err != nil {
 		t.Fatalf("accept: %v", err)
 	}
@@ -273,8 +327,8 @@ func TestAcceptMTPDraftsGreedyMismatch(t *testing.T) {
 func TestAcceptMTPDraftsGreedyEOS(t *testing.T) {
 	skipIfNoMLX(t)
 	// The second accepted draft token is EOS: it is recorded but stops
-	// generation and no bonus token is produced. Both accepted tokens are
-	// committed, so the caches hold the EOS's KV.
+	// generation and no bonus token is produced. The EOS's own KV is rolled
+	// back so the caches rest one token behind the recorded outputs.
 	const eos int32 = 6
 	predict := map[int32]int32{1: 2, 2: eos, eos: 0}
 	r := mtpTestRunner(t, predict, []int32{eos}, sampler.Options{})
@@ -287,7 +341,7 @@ func TestAcceptMTPDraftsGreedyEOS(t *testing.T) {
 
 	spec := testSpeculationSession(r, caches)
 	current := sampler.Result{Token: mlx.FromValues([]int32{1}, 1)}
-	results, accepted, err := spec.accept(&position, current, oneHotLogits([]int32{2}), baseLogits, candidates)
+	results, accepted, err := spec.accept(&position, current, oneHotLogits([]int32{1}), baseLogits, candidates)
 	if err != nil {
 		t.Fatalf("accept: %v", err)
 	}
@@ -302,11 +356,11 @@ func TestAcceptMTPDraftsGreedyEOS(t *testing.T) {
 	if len(results) != accepted {
 		t.Fatalf("results has %d tokens, want exactly the %d accepted with no bonus after EOS", len(results), accepted)
 	}
-	if position != 2 {
-		t.Fatalf("position = %d, want 2 (both accepted tokens committed)", position)
+	if position != 1 {
+		t.Fatalf("position = %d, want 1 (kept draft committed, EOS dropped)", position)
 	}
-	if got := caches[0].Offset(); got != 2 {
-		t.Fatalf("cache offset = %d, want 2 (both accepted tokens committed)", got)
+	if got := caches[0].Offset(); got != 1 {
+		t.Fatalf("cache offset = %d, want 1 (one behind the recorded outputs, EOS dropped)", got)
 	}
 }
 
@@ -392,7 +446,11 @@ func TestRunMTPDecodeSampled(t *testing.T) {
 		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
 		SamplerOpts:       sampler.Options{Temperature: 1, Seed: 42, UseSeed: true},
 	}
-	d := testDecoder(r, req, caches, []int32{1}, position)
+	spec := r.spec.open(req, caches)
+	if spec == nil || !spec.enabled {
+		t.Fatalf("newSpeculationSession rejected a sampled request")
+	}
+	d := spec.decoder([]int32{1}, position)
 	if err := r.decode(context.Background(), req, session, d, 0); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
@@ -518,7 +576,299 @@ func testDecoder(r *Runner, req Request, caches []cache.Cache, seed []int32, pos
 	if spec := r.spec.open(req, caches); spec != nil {
 		return spec.decoder(seed, position)
 	}
-	return r.pipelinedDecoder(caches, seed, position)
+	return r.pipelinedDecoder(nil, caches, seed, position)
+}
+
+func TestDecodeKVDraft(t *testing.T) {
+	skipIfNoMLX(t)
+	// A draft with its own KV cache mirroring the target chain
+	// 1->2->3->4->5->6->EOS.
+	// The decode seed catch-up writes the draft pair for the prompt token,
+	// the first proposal comes from the catch-up's held logits (no draft
+	// call), speculative entries are written at advancing slots, and the
+	// post-accept rebuild rewrites the committed range from target hiddens.
+	const eos int32 = 7
+	predict := map[int32]int32{1: 2, 2: 3, 3: 4, 4: 5, 5: 6, 6: eos, eos: 0}
+	r := mtpTestRunner(t, predict, []int32{eos}, sampler.Options{})
+	draft := &fakeKVDraft{predict: predict}
+	r.spec = newSpeculation(r, draft)
+
+	caches, _ := newMTPTestCaches(2) // caches[0] target, caches[1] draft KV
+	session, ch := newMTPTestSession(caches)
+	position := 0
+
+	req := Request{
+		Responses:         ch,
+		Tokens:            []int32{1},
+		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
+		SamplerOpts:       sampler.Options{},
+	}
+	spec := r.spec.open(req, caches)
+	if spec == nil || !spec.enabled || len(spec.spec.targets) != 1 {
+		t.Fatalf("speculation engine not built around the draft caches")
+	}
+	defer spec.close()
+	d := spec.decoder([]int32{1}, position)
+	if err := r.decode(context.Background(), req, session, d, 0); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	d.close()
+
+	content, final := collectResponses(ch)
+	if content != "23456" {
+		t.Fatalf("content = %q, want %q", content, "23456")
+	}
+	if final.EvalCount != 5 || final.DoneReason != 0 {
+		t.Fatalf("EvalCount = %d, DoneReason = %d, want 5 and 0", final.EvalCount, final.DoneReason)
+	}
+	if got := []int32{2, 3, 4, 5, 6, eos}; !slices.Equal(session.outputs, got) {
+		t.Fatalf("session outputs = %v, want %v", session.outputs, got)
+	}
+
+	// All caches rest together at the trie frontier: the prompt token plus
+	// five generated tokens; the EOS's KV is never committed.
+	if got := caches[0].Offset(); got != 6 {
+		t.Fatalf("target offset = %d, want 6", got)
+	}
+	if got := caches[1].Offset(); got != 6 {
+		t.Fatalf("draft cache offset = %d, want 6 (lockstep with target)", got)
+	}
+
+	// Every committed draft slot S fuses look-ahead token x_{S+1} with the
+	// target hidden at S (whose hot index equals the look-ahead id on this
+	// mirrored chain); speculative steps fuse the head's own projections
+	// (-1), seeded by the catch-up flush's held projection. The first
+	// proposal of the round consumes the catch-up's held logits, so the
+	// four-token draft makes only three head calls before the rebuild.
+	wantExtends := []extendCall{
+		{offset: 0, ids: []int32{2}, hiddens: []int32{2}},                             // frontier pair flushed at the first proposal
+		{offset: 1, ids: []int32{3}, hiddens: []int32{-1}},                            // speculative step 2 (held projection)
+		{offset: 2, ids: []int32{4}, hiddens: []int32{-1}},                            // speculative step 3 (projection)
+		{offset: 3, ids: []int32{5}, hiddens: []int32{-1}},                            // speculative step 4 (projection)
+		{offset: 1, ids: []int32{3, 4, 5, 6, eos}, hiddens: []int32{3, 4, 5, 6, eos}}, // committed pairs from the validated run + finish
+	}
+	if !reflect.DeepEqual(draft.extends, wantExtends) {
+		t.Fatalf("draft extends = %+v, want %+v", draft.extends, wantExtends)
+	}
+
+	// The committed draft KV holds the look-ahead tokens, one per slot.
+	if got, want := caches[1].(*fakeRewindableCache).tokens, []int32{2, 3, 4, 5, 6, eos}; !slices.Equal(got, want) {
+		t.Fatalf("draft cache = %v, want %v", got, want)
+	}
+}
+
+func TestDecodeKVDraftRejectionRebuildsFromTarget(t *testing.T) {
+	skipIfNoMLX(t)
+	// The draft mispredicts mid-chain: it proposes 6 where the target's own
+	// next token is 4, so the round is accepted only up to the rejection and the
+	// loop re-proposes from the target's correction. The speculative draft KV
+	// written for the rejected proposals is rolled back and rewritten from the
+	// validated run's target hiddens, so the committed draft cache holds the
+	// target chain with no trace of the rejected tokens.
+	const eos int32 = 7
+	target := map[int32]int32{1: 2, 2: 3, 3: 4, 4: 5, 5: eos, eos: 0}
+	r := mtpTestRunner(t, target, []int32{eos}, sampler.Options{})
+	// The draft mirrors the target except at 3, where it proposes 6 (absent from
+	// the target chain); once the target corrects 3->4 the next proposal
+	// re-aligns on the shared chain.
+	draft := &fakeKVDraft{predict: map[int32]int32{1: 2, 2: 3, 3: 6, 6: 0, 4: 5, 5: eos, eos: 0}}
+	r.spec = newSpeculation(r, draft)
+
+	caches, _ := newMTPTestCaches(2) // caches[0] target, caches[1] draft KV
+	session, ch := newMTPTestSession(caches)
+	position := 0
+
+	req := Request{
+		Responses:         ch,
+		Tokens:            []int32{1},
+		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
+		SamplerOpts:       sampler.Options{},
+	}
+	spec := r.spec.open(req, caches)
+	spec.limit = 4
+	defer spec.close()
+	d := spec.decoder([]int32{1}, position)
+	if err := r.decode(context.Background(), req, session, d, 0); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	d.close()
+
+	content, final := collectResponses(ch)
+	if content != "2345" {
+		t.Fatalf("content = %q, want %q", content, "2345")
+	}
+	if final.DoneReason != 0 {
+		t.Fatalf("DoneReason = %d, want 0 (EOS)", final.DoneReason)
+	}
+	if got := []int32{2, 3, 4, 5, eos}; !slices.Equal(session.outputs, got) {
+		t.Fatalf("session outputs = %v, want %v", session.outputs, got)
+	}
+
+	// The divergent token was drafted into the speculative KV...
+	drafted := false
+	for _, e := range draft.extends {
+		if slices.Contains(e.ids, 6) {
+			drafted = true
+		}
+	}
+	if !drafted {
+		t.Fatalf("draft never proposed the divergent token 6; extends = %+v", draft.extends)
+	}
+	// ...but the rejection rolled it back: both caches rest in lockstep at the
+	// target chain, and the committed draft KV holds only the validated
+	// look-ahead tokens.
+	if got := caches[0].Offset(); got != 5 {
+		t.Fatalf("target offset = %d, want 5", got)
+	}
+	if got := caches[1].Offset(); got != 5 {
+		t.Fatalf("draft cache offset = %d, want 5 (lockstep with target)", got)
+	}
+	if got, want := caches[1].(*fakeRewindableCache).tokens, []int32{2, 3, 4, 5, eos}; !slices.Equal(got, want) {
+		t.Fatalf("draft cache = %v, want %v (rejected proposals rolled back)", got, want)
+	}
+}
+
+func TestDecodeMaintainsDraftCacheWithoutDrafting(t *testing.T) {
+	skipIfNoMLX(t)
+	// A request that cannot speculate (logprobs) on a model whose draft has
+	// its own KV cache still maintains it: the pipelined decoder
+	// reports each forwarded token, the pairs wait in the pending list, and
+	// one batched extend at close — its final pair completed by the decoder's
+	// discarded in-flight sample — leaves the draft level with the target.
+	const eos int32 = 7
+	predict := map[int32]int32{1: 2, 2: 3, 3: 4, 4: 5, 5: 6, 6: eos, eos: 0}
+	opts := sampler.Options{Logprobs: true}
+	r := mtpTestRunner(t, predict, []int32{eos}, opts)
+	draft := &fakeKVDraft{predict: predict}
+	r.spec = newSpeculation(r, draft)
+
+	caches, _ := newMTPTestCaches(2)
+	session, ch := newMTPTestSession(caches)
+	position := 0
+
+	req := Request{
+		Responses:         ch,
+		Tokens:            []int32{1},
+		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
+		SamplerOpts:       opts,
+	}
+	spec := r.spec.open(req, caches)
+	if spec == nil || spec.enabled {
+		t.Fatalf("want a maintain-only speculationSession, got %+v", spec)
+	}
+	d := spec.decoder([]int32{1}, position)
+	if err := r.decode(context.Background(), req, session, d, 0); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	d.close()
+	spec.close() // the pipeline defers this before session close
+
+	content, _ := collectResponses(ch)
+	if content != "23456" {
+		t.Fatalf("content = %q, want %q", content, "23456")
+	}
+
+	// The pipelined decoder forwards every emitted token, including the
+	// ending EOS, so both caches rest at the full recorded path.
+	if got := caches[0].Offset(); got != 7 {
+		t.Fatalf("target offset = %d, want 7", got)
+	}
+	if got := caches[1].Offset(); got != 7 {
+		t.Fatalf("draft cache offset = %d, want 7 (lockstep with target)", got)
+	}
+
+	// A session that never drafts defers every committed pair: the whole
+	// generation arrives in one batched flush at finish, with the EOS slot's
+	// pair completed by the in-flight sample (predict[eos] = 0) that decoding
+	// discarded.
+	wantExtends := []extendCall{
+		{offset: 0, ids: []int32{2, 3, 4, 5, 6, eos, 0}, hiddens: []int32{2, 3, 4, 5, 6, eos, 0}},
+	}
+	if !reflect.DeepEqual(draft.extends, wantExtends) {
+		t.Fatalf("draft extends = %+v, want %+v", draft.extends, wantExtends)
+	}
+	if got, want := caches[1].(*fakeRewindableCache).tokens, []int32{2, 3, 4, 5, 6, eos, 0}; !slices.Equal(got, want) {
+		t.Fatalf("draft cache = %v, want %v", got, want)
+	}
+}
+
+func TestFlushLevelsDraftCacheWithPrefill(t *testing.T) {
+	skipIfNoMLX(t)
+	// Prefill attaches its scheduled snapshots only at offsets every cache
+	// has crossed, so the pipeline flushes the drafter's buffered pairs
+	// first: after a prefill-sized committed report and a flush, the
+	// draft cache covers every completed pair, one slot behind the target
+	// (the frontier pair still awaits its look-ahead token).
+	const eos int32 = 7
+	predict := map[int32]int32{2: 3, 3: 4, 4: 5}
+	r := mtpTestRunner(t, predict, []int32{eos}, sampler.Options{})
+	draft := &fakeKVDraft{predict: predict}
+	r.spec = newSpeculation(r, draft)
+
+	caches, _ := newMTPTestCaches(2)
+	req := Request{
+		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
+		SamplerOpts:       sampler.Options{},
+	}
+	spec := r.spec.open(req, caches)
+	defer spec.close()
+
+	// The prompt's only chunk: tokens 1..4 at slots 0..3 with their hiddens.
+	spec.committed(mlx.FromValues([]int32{1, 2, 3, 4}, 1, 4), oneHotLogits([]int32{1, 2, 3, 4}), 0)
+	spec.flush()
+
+	if got := caches[1].Offset(); got != 3 {
+		t.Fatalf("draft cache offset after flush = %d, want 3 (all completed pairs)", got)
+	}
+	wantExtends := []extendCall{
+		{offset: 0, ids: []int32{2, 3, 4}, hiddens: []int32{1, 2, 3}},
+	}
+	if !reflect.DeepEqual(draft.extends, wantExtends) {
+		t.Fatalf("draft extends = %+v, want %+v", draft.extends, wantExtends)
+	}
+}
+
+func TestCommittedRunBatchesPastFlushCap(t *testing.T) {
+	skipIfNoMLX(t)
+	// A committed run longer than the pending-flush cap still writes the draft
+	// caches in a single head forward: the run's completed pairs coalesce into
+	// one batched extend at the run's start, rather than splitting at the cap.
+	const n = mtpPendingFlushTokens + 8
+	predict := map[int32]int32{}
+	tokens := make([]int32, n)
+	for i := range tokens {
+		tokens[i] = int32(i%7 + 1)
+		predict[tokens[i]] = int32((i+1)%7 + 1)
+	}
+
+	r := mtpTestRunner(t, predict, []int32{0}, sampler.Options{})
+	draft := &fakeKVDraft{predict: predict}
+	r.spec = newSpeculation(r, draft)
+
+	caches, _ := newMTPTestCaches(2)
+	req := Request{
+		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
+		SamplerOpts:       sampler.Options{},
+	}
+	spec := r.spec.open(req, caches)
+	defer spec.close()
+
+	// One prefill-sized chunk: n tokens at slots 0..n-1 with their hiddens.
+	spec.committed(mlx.FromValues(tokens, 1, n), oneHotLogits(tokens), 0)
+	spec.flush()
+
+	if got := len(draft.extends); got != 1 {
+		t.Fatalf("draft extends = %d calls, want 1 batched extend", got)
+	}
+	if got, want := len(draft.extends[0].ids), n-1; got != want {
+		t.Fatalf("batched extend ids = %d, want %d (every completed pair)", got, want)
+	}
+	if got := draft.extends[0].offset; got != 0 {
+		t.Fatalf("batched extend offset = %d, want 0", got)
+	}
+	if got := caches[1].Offset(); got != n-1 {
+		t.Fatalf("draft cache offset = %d, want %d (all completed pairs)", got, n-1)
+	}
 }
 
 // newMTPTestCaches returns n rewindable fake caches sharing one snapshot
@@ -539,19 +889,16 @@ func newMTPTestSession(caches []cache.Cache) (*cacheSession, chan CompletionResp
 	return &cacheSession{caches: caches}, ch
 }
 
-// testSpeculationSession wires a speculation engine around the runner's drafter and
-// caches for tests that drive accept directly. A runner without a draft
-// model gets a no-op drafter, since the engine requires one.
+// testSpeculationSession wires a speculation engine around a drafter and caches for
+// tests that drive accept directly. A runner without a draft model gets a
+// no-op drafter, since the engine requires one.
 func testSpeculationSession(r *Runner, caches []cache.Cache) *speculationSession {
-	s := r.spec
-	if s == nil {
-		s = &speculation{r: r}
+	if r.spec != nil {
+		r.spec.bind(caches)
+		return &speculationSession{spec: r.spec, drafter: newMTPDrafter(r.spec)}
 	}
-	var d drafter = nopDrafter{}
-	if md := newMTPDrafter(s, caches); md != nil {
-		d = md
-	}
-	return &speculationSession{spec: s, drafter: d, caches: caches}
+	s := &speculation{r: r, caches: caches, targets: caches}
+	return &speculationSession{spec: s, drafter: nopDrafter{}}
 }
 
 // nopDrafter satisfies drafter for engine tests that supply candidates
@@ -560,6 +907,8 @@ type nopDrafter struct{}
 
 func (nopDrafter) propose(*mlx.Array, int) *draftCandidates { return nil }
 func (nopDrafter) committed(_, _ *mlx.Array, _ int)         {}
+func (nopDrafter) finish(*mlx.Array)                        {}
+func (nopDrafter) flush()                                   {}
 func (nopDrafter) close()                                   {}
 
 // scriptedCandidates builds draft candidates by running the real drafter
@@ -573,7 +922,8 @@ func scriptedCandidates(r *Runner, tokens []int32) *draftCandidates {
 		chain[prev] = tok
 		prev = tok
 	}
-	d := &mtpDrafter{spec: &speculation{r: r}, draft: &fakeMTPDraft{predict: chain}, target: r.Model.(base.MTPEmbeddingModel)}
+	s := &speculation{r: r, draft: &fakeMTPDraft{predict: chain}}
+	d := &mtpDrafter{spec: s}
 	d.committed(mlx.FromValues([]int32{0}, 1, 1), mlx.Zeros(mlx.DTypeFloat32, 1, 1, mtpTestVocab), 0)
 	return d.propose(mlx.FromValues([]int32{0}, 1), len(tokens))
 }

--- a/x/mlxrunner/mtp_test.go
+++ b/x/mlxrunner/mtp_test.go
@@ -3,11 +3,11 @@ package mlxrunner
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/x/mlxrunner/batch"
@@ -190,6 +190,15 @@ func collectResponses(ch chan CompletionResponse) (content string, final Complet
 	}
 }
 
+// resultIDs reads the token id of each result.
+func resultIDs(results []sampler.Result) []int {
+	ids := make([]int, 0, len(results))
+	for _, res := range results {
+		ids = append(ids, res.Token.Int())
+	}
+	return ids
+}
+
 func TestAcceptMTPDraftsGreedyAcceptAll(t *testing.T) {
 	skipIfNoMLX(t)
 	// Target predicts 1->2->3->4 along the accepted chain; the draft proposed
@@ -202,33 +211,26 @@ func TestAcceptMTPDraftsGreedyAcceptAll(t *testing.T) {
 	candidates := scriptedCandidates(r, []int32{2, 3, 4})
 	baseLogits := oneHotLogits([]int32{2}).Squeeze(1) // target prediction after the seed token 1
 
-	session, ch := newMTPTestSession(caches)
 	position := caches[0].Offset()
-	final := CompletionResponse{Done: true}
-	generated := 0
 
-	req := Request{Responses: ch, CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 100}}}
-	next, accepted, done, err := r.acceptMTPDrafts(context.Background(), req, session, &decoder{tokenizer: r.Tokenizer}, caches, &position, baseLogits, candidates, &final, &generated)
+	spec := testSpeculationSession(r, caches)
+	current := sampler.Result{Token: mlx.FromValues([]int32{1}, 1)}
+	results, accepted, err := spec.accept(&position, current, oneHotLogits([]int32{2}), baseLogits, candidates)
 	if err != nil {
-		t.Fatalf("acceptMTPDrafts: %v", err)
+		t.Fatalf("accept: %v", err)
 	}
 	if accepted != 3 {
 		t.Fatalf("accepted = %d, want 3", accepted)
 	}
-	if done {
-		t.Fatalf("done = true, want false")
-	}
-	if got := tokenID(next.Token); got != 5 {
-		t.Fatalf("bonus token = %d, want 5", got)
+	// The run is the accepted drafts followed by the bonus token (5).
+	if got := resultIDs(results); !slices.Equal(got, []int{2, 3, 4, 5}) {
+		t.Fatalf("results = %v, want [2 3 4 5]", got)
 	}
 	if position != 3 {
 		t.Fatalf("position = %d, want 3", position)
 	}
 	if got := caches[0].Offset(); got != 3 {
 		t.Fatalf("cache offset = %d, want 3 (all drafts kept)", got)
-	}
-	if generated != 3 {
-		t.Fatalf("generated = %d, want 3", generated)
 	}
 }
 
@@ -244,24 +246,21 @@ func TestAcceptMTPDraftsGreedyMismatch(t *testing.T) {
 	candidates := scriptedCandidates(r, []int32{2, 7})
 	baseLogits := oneHotLogits([]int32{2}).Squeeze(1)
 
-	session, ch := newMTPTestSession(caches)
 	position := caches[0].Offset()
-	final := CompletionResponse{Done: true}
-	generated := 0
 
-	req := Request{Responses: ch, CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 100}}}
-	next, accepted, done, err := r.acceptMTPDrafts(context.Background(), req, session, &decoder{tokenizer: r.Tokenizer}, caches, &position, baseLogits, candidates, &final, &generated)
+	spec := testSpeculationSession(r, caches)
+	current := sampler.Result{Token: mlx.FromValues([]int32{1}, 1)}
+	results, accepted, err := spec.accept(&position, current, oneHotLogits([]int32{2}), baseLogits, candidates)
 	if err != nil {
-		t.Fatalf("acceptMTPDrafts: %v", err)
+		t.Fatalf("accept: %v", err)
 	}
 	if accepted != 1 {
 		t.Fatalf("accepted = %d, want 1", accepted)
 	}
-	if done {
-		t.Fatalf("done = true, want false")
-	}
-	if got := tokenID(next.Token); got != 3 {
-		t.Fatalf("bonus token = %d, want 3 (target prediction at rejection)", got)
+	// The run is the one accepted draft (2) followed by the target's own
+	// prediction at the rejection point (3).
+	if got := resultIDs(results); !slices.Equal(got, []int{2, 3}) {
+		t.Fatalf("results = %v, want [2 3]", got)
 	}
 	if position != 1 {
 		t.Fatalf("position = %d, want 1", position)
@@ -274,7 +273,8 @@ func TestAcceptMTPDraftsGreedyMismatch(t *testing.T) {
 func TestAcceptMTPDraftsGreedyEOS(t *testing.T) {
 	skipIfNoMLX(t)
 	// The second accepted draft token is EOS: it is recorded but stops
-	// generation, no bonus token is produced, and the cache keeps both tokens.
+	// generation and no bonus token is produced. Both accepted tokens are
+	// committed, so the caches hold the EOS's KV.
 	const eos int32 = 6
 	predict := map[int32]int32{1: 2, 2: eos, eos: 0}
 	r := mtpTestRunner(t, predict, []int32{eos}, sampler.Options{})
@@ -283,30 +283,30 @@ func TestAcceptMTPDraftsGreedyEOS(t *testing.T) {
 	candidates := scriptedCandidates(r, []int32{2, eos})
 	baseLogits := oneHotLogits([]int32{2}).Squeeze(1)
 
-	session, ch := newMTPTestSession(caches)
 	position := caches[0].Offset()
-	final := CompletionResponse{Done: true, DoneReason: 1}
-	generated := 0
 
-	req := Request{Responses: ch, CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 100}}}
-	next, accepted, done, err := r.acceptMTPDrafts(context.Background(), req, session, &decoder{tokenizer: r.Tokenizer}, caches, &position, baseLogits, candidates, &final, &generated)
+	spec := testSpeculationSession(r, caches)
+	current := sampler.Result{Token: mlx.FromValues([]int32{1}, 1)}
+	results, accepted, err := spec.accept(&position, current, oneHotLogits([]int32{2}), baseLogits, candidates)
 	if err != nil {
-		t.Fatalf("acceptMTPDrafts: %v", err)
+		t.Fatalf("accept: %v", err)
 	}
 	if accepted != 2 {
 		t.Fatalf("accepted = %d, want 2 (token + EOS)", accepted)
 	}
-	if !done {
-		t.Fatalf("done = false, want true")
+	// The EOS ends generation, so the run is exactly the accepted tokens
+	// with no bonus appended.
+	if got := resultIDs(results); !slices.Equal(got, []int{2, int(eos)}) {
+		t.Fatalf("results = %v, want [2 %d]", got, eos)
 	}
-	if next.Token != nil {
-		t.Fatalf("bonus token = %d, want none after EOS", tokenID(next.Token))
-	}
-	if final.DoneReason != 0 {
-		t.Fatalf("DoneReason = %d, want 0 (EOS)", final.DoneReason)
+	if len(results) != accepted {
+		t.Fatalf("results has %d tokens, want exactly the %d accepted with no bonus after EOS", len(results), accepted)
 	}
 	if position != 2 {
-		t.Fatalf("position = %d, want 2", position)
+		t.Fatalf("position = %d, want 2 (both accepted tokens committed)", position)
+	}
+	if got := caches[0].Offset(); got != 2 {
+		t.Fatalf("cache offset = %d, want 2 (both accepted tokens committed)", got)
 	}
 }
 
@@ -320,7 +320,7 @@ func TestRunMTPDecodeGreedy(t *testing.T) {
 	r := mtpTestRunner(t, predict, []int32{eos}, sampler.Options{})
 	// The draft mirrors the target chain, so every drafted token is accepted.
 	draft := &fakeMTPDraft{predict: predict}
-	r.Draft = draft
+	r.spec = newSpeculation(r, draft)
 
 	caches, _ := newMTPTestCaches(1)
 	session, ch := newMTPTestSession(caches)
@@ -332,9 +332,11 @@ func TestRunMTPDecodeGreedy(t *testing.T) {
 		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
 		SamplerOpts:       sampler.Options{},
 	}
-	if err := r.runMTPDecode(context.Background(), req, session, caches, []int32{1}, &position, time.Now()); err != nil {
-		t.Fatalf("runMTPDecode: %v", err)
+	d := testDecoder(r, req, caches, []int32{1}, position)
+	if err := r.decode(context.Background(), req, session, d, 0); err != nil {
+		t.Fatalf("decode: %v", err)
 	}
+	d.close()
 
 	content, final := collectResponses(ch)
 	if content != "234" {
@@ -360,9 +362,10 @@ func TestRunMTPDecodeGreedy(t *testing.T) {
 	}
 
 	// Single-position drafting anchors every Draft call in a round at the
-	// last target-seen position (the current token, offset 2), while the
-	// extended token advances along the proposed chain.
-	wantDraft := []draftCall{{2, 2}, {2, 3}, {2, 4}, {2, eos}}
+	// last committed position (offset 1 — the current token at offset 2 is
+	// not yet validated), while the extended token advances along the
+	// proposed chain.
+	wantDraft := []draftCall{{1, 2}, {1, 3}, {1, 4}, {1, eos}}
 	if !slices.Equal(draft.calls, wantDraft) {
 		t.Fatalf("draft calls = %v, want %v", draft.calls, wantDraft)
 	}
@@ -377,11 +380,7 @@ func TestRunMTPDecodeSampled(t *testing.T) {
 	const eos int32 = 7
 	predict := map[int32]int32{1: 2, 2: 3, 3: 4, 4: eos, eos: 0}
 	r := mtpTestRunner(t, predict, []int32{eos}, sampler.Options{Temperature: 1, Seed: 42, UseSeed: true})
-	r.Draft = &fakeMTPDraft{predict: predict}
-
-	if !r.useMTP(sampler.Options{Temperature: 1}) {
-		t.Fatalf("useMTP rejected a sampled request")
-	}
+	r.spec = newSpeculation(r, &fakeMTPDraft{predict: predict})
 
 	caches, _ := newMTPTestCaches(1)
 	session, ch := newMTPTestSession(caches)
@@ -393,9 +392,11 @@ func TestRunMTPDecodeSampled(t *testing.T) {
 		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
 		SamplerOpts:       sampler.Options{Temperature: 1, Seed: 42, UseSeed: true},
 	}
-	if err := r.runMTPDecode(context.Background(), req, session, caches, []int32{1}, &position, time.Now()); err != nil {
-		t.Fatalf("runMTPDecode: %v", err)
+	d := testDecoder(r, req, caches, []int32{1}, position)
+	if err := r.decode(context.Background(), req, session, d, 0); err != nil {
+		t.Fatalf("decode: %v", err)
 	}
+	d.close()
 
 	content, final := collectResponses(ch)
 	if content != "234" {
@@ -407,6 +408,117 @@ func TestRunMTPDecodeSampled(t *testing.T) {
 	if got := []int32{2, 3, 4, eos}; !slices.Equal(session.outputs, got) {
 		t.Fatalf("session outputs = %v, want %v", session.outputs, got)
 	}
+}
+
+func TestDecodePlain(t *testing.T) {
+	skipIfNoMLX(t)
+	// The same chain with no speculationSession: decode's pipelined loop runs,
+	// dispatching the forward that produces the next token before the
+	// current one is emitted.
+	const eos int32 = 7
+	predict := map[int32]int32{1: 2, 2: 3, 3: 4, 4: eos, eos: 0}
+	r := mtpTestRunner(t, predict, []int32{eos}, sampler.Options{})
+
+	caches, _ := newMTPTestCaches(1)
+	session, ch := newMTPTestSession(caches)
+	position := 1
+
+	req := Request{
+		Responses:         ch,
+		Tokens:            []int32{0},
+		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
+		SamplerOpts:       sampler.Options{},
+	}
+	d := testDecoder(r, req, caches, []int32{1}, position)
+	if err := r.decode(context.Background(), req, session, d, 0); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	d.close()
+
+	content, final := collectResponses(ch)
+	if content != "234" {
+		t.Fatalf("content = %q, want %q", content, "234")
+	}
+	if final.DoneReason != 0 || final.EvalCount != 3 {
+		t.Fatalf("final DoneReason = %d, EvalCount = %d, want 0 (EOS) and 3", final.DoneReason, final.EvalCount)
+	}
+	if got := []int32{2, 3, 4, eos}; !slices.Equal(session.outputs, got) {
+		t.Fatalf("session outputs = %v, want %v", session.outputs, got)
+	}
+
+	// One forward per token: the seed at offset 1, then each sampled token
+	// in turn — including the ending EOS, whose forward is already in
+	// flight when the token is checked. Every forwarded token is recorded,
+	// so the caches rest exactly at the recorded path.
+	wantForwards := []forwardCall{{1, 1}, {2, 1}, {3, 1}, {4, 1}, {5, 1}}
+	model := r.Model.(*fakeMTPModel)
+	if !slices.Equal(model.forwards, wantForwards) {
+		t.Fatalf("target forwards = %v, want %v", model.forwards, wantForwards)
+	}
+}
+
+func TestDecodeCancelledMidStream(t *testing.T) {
+	skipIfNoMLX(t)
+	// Cancelling while accepted drafts stream must leave the session
+	// consistent: every token committed to the caches is recorded in
+	// session.outputs, no speculation snapshot schedule is left pending on
+	// the shared caches, and every captured snapshot is closed.
+	const eos int32 = 7
+	predict := map[int32]int32{1: 2, 2: 3, 3: 4, 4: 5, 5: 6, 6: eos}
+	r := mtpTestRunner(t, predict, []int32{eos}, sampler.Options{})
+	r.spec = newSpeculation(r, &fakeMTPDraft{predict: predict})
+
+	caches, tr := newMTPTestCaches(1)
+	session := &cacheSession{caches: caches}
+	ch := make(chan CompletionResponse) // unbuffered: every send must rendezvous
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-ch // the first streamed token
+		cancel()
+		// Stop reading: the next send blocks until the emit select sees
+		// the cancelled context.
+	}()
+
+	position := 0
+	req := Request{
+		Responses:         ch,
+		Tokens:            []int32{1},
+		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
+		SamplerOpts:       sampler.Options{},
+	}
+	d := testDecoder(r, req, caches, []int32{1}, position)
+	err := r.decode(ctx, req, session, d, 0)
+	d.close()
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("decode error = %v, want context.Canceled", err)
+	}
+
+	// Every committed token is recorded, and the caches never run ahead of
+	// the record: the final recorded output is the round's next token,
+	// emitted before it is ever forwarded, so the caches rest one short.
+	rc := caches[0].(*fakeRewindableCache)
+	if want := 1 + len(session.outputs) - 1; rc.Offset() != want {
+		t.Fatalf("cache offset = %d, want %d (seed + recorded outputs %v minus the unforwarded final)", rc.Offset(), want, session.outputs)
+	}
+	if rc.pending.offsets != nil {
+		t.Fatalf("speculation snapshot schedule left pending: %v", rc.pending.offsets)
+	}
+	for i, s := range tr.all {
+		if s.closeCount == 0 {
+			t.Fatalf("snapshot #%d [%d,%d) leaked: never closed", i, s.from, s.to)
+		}
+	}
+}
+
+// testDecoder builds the decoder TextGenerationPipeline would construct for
+// this request; tests close it explicitly so close-time effects are visible
+// to assertions.
+func testDecoder(r *Runner, req Request, caches []cache.Cache, seed []int32, position int) decoder {
+	if spec := r.spec.open(req, caches); spec != nil {
+		return spec.decoder(seed, position)
+	}
+	return r.pipelinedDecoder(caches, seed, position)
 }
 
 // newMTPTestCaches returns n rewindable fake caches sharing one snapshot
@@ -427,20 +539,41 @@ func newMTPTestSession(caches []cache.Cache) (*cacheSession, chan CompletionResp
 	return &cacheSession{caches: caches}, ch
 }
 
-// scriptedCandidates builds draft candidates by running the real generator
-// against a draft whose prediction chain, starting from seed token 0, yields
-// exactly the requested tokens. Using the real generator means the proposal
-// distributions match what acceptMTPDrafts expects.
-func scriptedCandidates(r *Runner, tokens []int32) *mtpDraftCandidates {
+// testSpeculationSession wires a speculation engine around the runner's drafter and
+// caches for tests that drive accept directly. A runner without a draft
+// model gets a no-op drafter, since the engine requires one.
+func testSpeculationSession(r *Runner, caches []cache.Cache) *speculationSession {
+	s := r.spec
+	if s == nil {
+		s = &speculation{r: r}
+	}
+	var d drafter = nopDrafter{}
+	if md := newMTPDrafter(s, caches); md != nil {
+		d = md
+	}
+	return &speculationSession{spec: s, drafter: d, caches: caches}
+}
+
+// nopDrafter satisfies drafter for engine tests that supply candidates
+// directly and never propose.
+type nopDrafter struct{}
+
+func (nopDrafter) propose(*mlx.Array, int) *draftCandidates { return nil }
+func (nopDrafter) committed(_, _ *mlx.Array, _ int)         {}
+func (nopDrafter) close()                                   {}
+
+// scriptedCandidates builds draft candidates by running the real drafter
+// against a fake whose prediction chain, starting from seed token 0, yields
+// exactly the requested tokens. Using the real drafter means the proposal
+// distributions match what the engine's acceptance expects.
+func scriptedCandidates(r *Runner, tokens []int32) *draftCandidates {
 	chain := map[int32]int32{}
 	prev := int32(0)
 	for _, tok := range tokens {
 		chain[prev] = tok
 		prev = tok
 	}
-	draft := &fakeMTPDraft{predict: chain}
-	target := r.Model.(base.MTPEmbeddingModel)
-	seed := mlx.FromValues([]int32{0}, 1, 1)
-	hidden := mlx.Zeros(mlx.DTypeFloat32, 1, 1, mtpTestVocab)
-	return r.generateMTPDraftCandidates(draft, target, seed, hidden, nil, 0, len(tokens))
+	d := &mtpDrafter{spec: &speculation{r: r}, draft: &fakeMTPDraft{predict: chain}, target: r.Model.(base.MTPEmbeddingModel)}
+	d.committed(mlx.FromValues([]int32{0}, 1, 1), mlx.Zeros(mlx.DTypeFloat32, 1, 1, mtpTestVocab), 0)
+	return d.propose(mlx.FromValues([]int32{0}, 1), len(tokens))
 }

--- a/x/mlxrunner/mtp_test.go
+++ b/x/mlxrunner/mtp_test.go
@@ -268,12 +268,14 @@ func TestAcceptMTPDraftsGreedyAcceptAll(t *testing.T) {
 
 	spec := testSpeculationSession(r, caches)
 	current := sampler.Result{Token: mlx.FromValues([]int32{1}, 1)}
-	results, accepted, err := spec.accept(&position, current, candidates)
+	unpin := pinAcceptInputs(current, candidates)
+	defer unpin()
+	results, accepted, observed, err := spec.accept(&position, current, candidates)
 	if err != nil {
 		t.Fatalf("accept: %v", err)
 	}
-	if accepted != 3 {
-		t.Fatalf("accepted = %d, want 3", accepted)
+	if accepted != 3 || observed != 3 {
+		t.Fatalf("accepted = %d, observed = %d, want 3 and 3", accepted, observed)
 	}
 	// The run is the accepted drafts followed by the bonus token (5).
 	if got := resultIDs(results); !slices.Equal(got, []int{2, 3, 4, 5}) {
@@ -302,12 +304,14 @@ func TestAcceptMTPDraftsGreedyMismatch(t *testing.T) {
 
 	spec := testSpeculationSession(r, caches)
 	current := sampler.Result{Token: mlx.FromValues([]int32{1}, 1)}
-	results, accepted, err := spec.accept(&position, current, candidates)
+	unpin := pinAcceptInputs(current, candidates)
+	defer unpin()
+	results, accepted, observed, err := spec.accept(&position, current, candidates)
 	if err != nil {
 		t.Fatalf("accept: %v", err)
 	}
-	if accepted != 1 {
-		t.Fatalf("accepted = %d, want 1", accepted)
+	if accepted != 1 || observed != 2 {
+		t.Fatalf("accepted = %d, observed = %d, want 1 and 2 (a rejection judges the full round)", accepted, observed)
 	}
 	// The run is the one accepted draft (2) followed by the target's own
 	// prediction at the rejection point (3).
@@ -338,12 +342,14 @@ func TestAcceptMTPDraftsGreedyEOS(t *testing.T) {
 
 	spec := testSpeculationSession(r, caches)
 	current := sampler.Result{Token: mlx.FromValues([]int32{1}, 1)}
-	results, accepted, err := spec.accept(&position, current, candidates)
+	unpin := pinAcceptInputs(current, candidates)
+	defer unpin()
+	results, accepted, observed, err := spec.accept(&position, current, candidates)
 	if err != nil {
 		t.Fatalf("accept: %v", err)
 	}
-	if accepted != 2 {
-		t.Fatalf("accepted = %d, want 2 (token + EOS)", accepted)
+	if accepted != 2 || observed != 2 {
+		t.Fatalf("accepted = %d, observed = %d, want 2 and 2 (token + EOS)", accepted, observed)
 	}
 	// The EOS ends generation, so the run is exactly the accepted tokens
 	// with no bonus appended.
@@ -403,20 +409,21 @@ func TestRunMTPDecodeGreedy(t *testing.T) {
 		t.Fatalf("session outputs = %v, want %v", session.outputs, got)
 	}
 
-	// The target writes the caches contiguously: the seed token at offset 1,
-	// then one fused forward validating the current token and the 4 drafts
-	// together at offset 2.
-	wantForwards := []forwardCall{{offset: 1, n: 1}, {offset: 2, n: 5}}
+	// The unprimed drafter parks the first call, so the seed token and the
+	// stretch's in-flight successor decode as pipelined plain forwards; the
+	// resumed round then validates the current token and the 4 drafts in one
+	// fused forward at offset 3.
+	wantForwards := []forwardCall{{offset: 1, n: 1}, {offset: 2, n: 1}, {offset: 3, n: 5}}
 	model := r.Model.(*fakeMTPModel)
 	if !slices.Equal(model.forwards, wantForwards) {
 		t.Fatalf("target forwards = %v, want %v", model.forwards, wantForwards)
 	}
 
 	// Single-position drafting anchors every Draft call in a round at the
-	// last committed position (offset 1 — the current token at offset 2 is
-	// not yet validated), while the extended token advances along the
-	// proposed chain.
-	wantDraft := []draftCall{{1, 2}, {1, 3}, {1, 4}, {1, eos}}
+	// last committed position (offset 2 — the current token at offset 3 is
+	// not yet validated), while the input token advances along the proposed
+	// chain.
+	wantDraft := []draftCall{{2, 3}, {2, 4}, {2, eos}, {2, 0}}
 	if !slices.Equal(draft.calls, wantDraft) {
 		t.Fatalf("draft calls = %v, want %v", draft.calls, wantDraft)
 	}
@@ -445,8 +452,9 @@ func TestRunMTPDecodeSampled(t *testing.T) {
 	}
 	spec := r.spec.open(req, caches)
 	if spec == nil || !spec.enabled {
-		t.Fatalf("newSpeculationSession rejected a sampled request")
+		t.Fatalf("open rejected a sampled request")
 	}
+	pinDraftLimit(spec, 4)
 	d := spec.decoder([]int32{1}, position)
 	if err := r.decode(context.Background(), req, session, d, 0); err != nil {
 		t.Fatalf("decode: %v", err)
@@ -483,10 +491,11 @@ func TestRunMTPDecodeWarmDrafter(t *testing.T) {
 	req := Request{
 		Responses:         ch,
 		Tokens:            []int32{0},
-		CompletionRequest: CompletionRequest{Options: api.Options{Runner: api.Runner{DraftNumPredict: 4}, NumPredict: 20}},
+		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
 		SamplerOpts:       sampler.Options{},
 	}
 	spec := r.spec.open(req, caches)
+	pinDraftLimit(spec, 4)
 	// The prefill chunk's committed report: token 0 at slot 0 with its
 	// hidden row, leaving the drafter ready to propose from slot 1.
 	spec.committed(mlx.FromValues([]int32{0}, 1, 1), oneHotLogits([]int32{1}), 0)
@@ -521,6 +530,65 @@ func TestRunMTPDecodeWarmDrafter(t *testing.T) {
 	wantDraft := []draftCall{{0, 1}, {0, 2}, {0, 3}, {0, 4}}
 	if !slices.Equal(draft.calls, wantDraft) {
 		t.Fatalf("draft calls = %v, want %v", draft.calls, wantDraft)
+	}
+}
+
+func TestRunMTPDecodeEOSCutLeavesPositionsUnjudged(t *testing.T) {
+	skipIfNoMLX(t)
+	// An accepted EOS inside the draft ends the round at a terminator, not a
+	// target rejection. The persisted acceptance model records outcomes only
+	// up to the EOS: the positions past it lie beyond where the round stopped,
+	// and folding them in as rejections would bias the depth controller
+	// shallow.
+	const eos int32 = 7
+	predict := map[int32]int32{1: 2, 2: 3, 3: eos, eos: 0}
+	r := mtpTestRunner(t, predict, []int32{eos}, sampler.Options{})
+	r.spec = newSpeculation(r, &fakeMTPDraft{predict: predict})
+
+	caches, _ := newMTPTestCaches(1)
+	session, ch := newMTPTestSession(caches)
+	position := 1
+
+	req := Request{
+		Responses:         ch,
+		Tokens:            []int32{0},
+		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
+		SamplerOpts:       sampler.Options{},
+	}
+	spec := r.spec.open(req, caches)
+	if spec == nil || !spec.enabled {
+		t.Fatalf("want an enabled speculationSession with a depth controller, got %+v", spec)
+	}
+	// Force a four-token first round so the EOS (third draft) is interior;
+	// the controller still records the round's outcomes.
+	spec.limit = 4
+	spec.committed(mlx.FromValues([]int32{0}, 1, 1), oneHotLogits([]int32{1}), 0)
+
+	d := spec.decoder([]int32{1}, position)
+	if err := r.decode(context.Background(), req, session, d, 0); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	d.close()
+
+	content, _ := collectResponses(ch)
+	if content != "23" {
+		t.Fatalf("content = %q, want %q", content, "23")
+	}
+	if got := []int32{2, 3, eos}; !slices.Equal(session.outputs, got) {
+		t.Fatalf("session outputs = %v, want %v", session.outputs, got)
+	}
+
+	// The round drafted {2, 3, eos, 0} and the target accepted through the
+	// EOS at position 3; the fourth draft was cut, not judged. Positions
+	// 1..3 record accepts and position 4 is never grown.
+	acc := r.spec.depth.acc
+	if len(acc.seen) != 4 {
+		t.Fatalf("acceptance model grew to %d positions, want 4 (the cut position stays unjudged)", len(acc.seen))
+	}
+	for i := 1; i <= 3; i++ {
+		if acc.seen[i] != 1 || acc.rate[i] != 1 {
+			t.Fatalf("position %d: seen = %d, rate = %v, want 1 and 1", i, acc.seen[i], acc.rate[i])
+		}
 	}
 }
 
@@ -625,24 +693,36 @@ func TestDecodeCancelledMidStream(t *testing.T) {
 	}
 }
 
+// pinDraftLimit fixes an engine's draft length for the whole run: decode
+// tests assert engine mechanics at known widths, so they disable adaptive
+// depth rather than steer what it learns.
+func pinDraftLimit(spec *speculationSession, limit int) {
+	spec.enabled = false
+	spec.limit = limit
+}
+
 // testDecoder builds the decoder TextGenerationPipeline would construct for
-// this request; tests close it explicitly so close-time effects are visible
-// to assertions.
+// this request, with the draft length pinned to a fixed width; tests close it
+// explicitly so close-time effects are visible to assertions.
 func testDecoder(r *Runner, req Request, caches []cache.Cache, seed []int32, position int) decoder {
 	if spec := r.spec.open(req, caches); spec != nil {
+		if spec.enabled {
+			pinDraftLimit(spec, 4)
+		}
 		return spec.decoder(seed, position)
 	}
-	return r.pipelinedDecoder(nil, caches, seed, position)
+	return r.pipelinedDecoder(nil, caches, mlx.FromValues(seed, 1, len(seed)), position)
 }
 
 func TestDecodeKVDraft(t *testing.T) {
 	skipIfNoMLX(t)
 	// A draft with its own KV cache mirroring the target chain
 	// 1->2->3->4->5->6->EOS.
-	// The decode seed catch-up writes the draft pair for the prompt token,
-	// the first proposal comes from the catch-up's held logits (no draft
-	// call), speculative entries are written at advancing slots, and the
-	// post-accept rebuild rewrites the committed range from target hiddens.
+	// The unprimed drafter parks the first call, whose pipelined tokens pair
+	// the prompt token and the first generated token; the first proposal
+	// comes from the catch-up's held logits (no draft call), speculative
+	// entries are written at advancing slots, and the post-accept rebuild
+	// rewrites the committed range from target hiddens.
 	const eos int32 = 7
 	predict := map[int32]int32{1: 2, 2: 3, 3: 4, 4: 5, 5: 6, 6: eos, eos: 0}
 	r := mtpTestRunner(t, predict, []int32{eos}, sampler.Options{})
@@ -663,6 +743,7 @@ func TestDecodeKVDraft(t *testing.T) {
 	if spec == nil || !spec.enabled || len(spec.spec.targets) != 1 {
 		t.Fatalf("speculation engine not built around the draft caches")
 	}
+	pinDraftLimit(spec, 4)
 	defer spec.close()
 	d := spec.decoder([]int32{1}, position)
 	if err := r.decode(context.Background(), req, session, d, 0); err != nil {
@@ -693,15 +774,17 @@ func TestDecodeKVDraft(t *testing.T) {
 	// Every committed draft slot S fuses look-ahead token x_{S+1} with the
 	// target hidden at S (whose hot index equals the look-ahead id on this
 	// mirrored chain); speculative steps fuse the head's own projections
-	// (-1), seeded by the catch-up flush's held projection. The first
-	// proposal of the round consumes the catch-up's held logits, so the
-	// four-token draft makes only three head calls before the rebuild.
+	// (-1), seeded by the catch-up flush's held projection. The unprimed
+	// drafter parks the first call, so two pipelined tokens precede the
+	// round and their pairs flush together at the first proposal, which
+	// consumes the catch-up's held logits — the four-token draft makes only
+	// three head calls before the rebuild.
 	wantExtends := []extendCall{
-		{offset: 0, ids: []int32{2}, hiddens: []int32{2}},                             // frontier pair flushed at the first proposal
-		{offset: 1, ids: []int32{3}, hiddens: []int32{-1}},                            // speculative step 2 (held projection)
-		{offset: 2, ids: []int32{4}, hiddens: []int32{-1}},                            // speculative step 3 (projection)
-		{offset: 3, ids: []int32{5}, hiddens: []int32{-1}},                            // speculative step 4 (projection)
-		{offset: 1, ids: []int32{3, 4, 5, 6, eos}, hiddens: []int32{3, 4, 5, 6, eos}}, // committed pairs from the validated run + finish
+		{offset: 0, ids: []int32{2, 3}, hiddens: []int32{2, 3}},                 // parked pairs flushed at the first proposal
+		{offset: 2, ids: []int32{4}, hiddens: []int32{-1}},                      // speculative step 2 (held projection)
+		{offset: 3, ids: []int32{5}, hiddens: []int32{-1}},                      // speculative step 3 (projection)
+		{offset: 4, ids: []int32{6}, hiddens: []int32{-1}},                      // speculative step 4 (projection)
+		{offset: 2, ids: []int32{4, 5, 6, eos}, hiddens: []int32{4, 5, 6, eos}}, // committed pairs from the validated run + finish
 	}
 	if !reflect.DeepEqual(draft.extends, wantExtends) {
 		t.Fatalf("draft extends = %+v, want %+v", draft.extends, wantExtends)
@@ -741,7 +824,7 @@ func TestDecodeKVDraftRejectionRebuildsFromTarget(t *testing.T) {
 		SamplerOpts:       sampler.Options{},
 	}
 	spec := r.spec.open(req, caches)
-	spec.limit = 4
+	pinDraftLimit(spec, 4)
 	defer spec.close()
 	d := spec.decoder([]int32{1}, position)
 	if err := r.decode(context.Background(), req, session, d, 0); err != nil {
@@ -787,10 +870,11 @@ func TestDecodeKVDraftRejectionRebuildsFromTarget(t *testing.T) {
 func TestDecodeMaintainsDraftCacheWithoutDrafting(t *testing.T) {
 	skipIfNoMLX(t)
 	// A request that cannot speculate (logprobs) on a model whose draft has
-	// its own KV cache still maintains it: the pipelined decoder
-	// reports each forwarded token, the pairs wait in the pending list, and
-	// one batched extend at close — its final pair completed by the decoder's
-	// discarded in-flight sample — leaves the draft level with the target.
+	// its own KV cache still maintains it: the speculationSession permanently parks,
+	// so the inner pipelined decoder reports each forwarded token, the pairs
+	// wait in the pending list, and one batched extend at close — its final
+	// pair completed by the decoder's discarded in-flight sample — leaves the
+	// draft level with the target.
 	const eos int32 = 7
 	predict := map[int32]int32{1: 2, 2: 3, 3: 4, 4: 5, 5: 6, 6: eos, eos: 0}
 	opts := sampler.Options{Logprobs: true}
@@ -810,7 +894,7 @@ func TestDecodeMaintainsDraftCacheWithoutDrafting(t *testing.T) {
 	}
 	spec := r.spec.open(req, caches)
 	if spec == nil || spec.enabled {
-		t.Fatalf("want a maintain-only speculationSession, got %+v", spec)
+		t.Fatalf("want a permanent-park speculationSession, got %+v", spec)
 	}
 	d := spec.decoder([]int32{1}, position)
 	if err := r.decode(context.Background(), req, session, d, 0); err != nil {
@@ -927,6 +1011,94 @@ func TestCommittedRunBatchesPastFlushCap(t *testing.T) {
 	}
 }
 
+func TestDecodeParkedDraftResume(t *testing.T) {
+	skipIfNoMLX(t)
+	// Leaving a parked stretch: the inner decoder's in-flight sample is
+	// emitted without any new forward, becomes the round's current, and the
+	// next call drafts from it — with the draft pairs contiguous across the
+	// boundary.
+	const eos int32 = 7
+	predict := map[int32]int32{1: 2, 2: 3, 3: 4, 4: 5, 5: 6, 6: eos, eos: 0}
+	r := mtpTestRunner(t, predict, []int32{eos}, sampler.Options{})
+	draft := &fakeKVDraft{predict: predict}
+	r.spec = newSpeculation(r, draft)
+
+	caches, _ := newMTPTestCaches(2)
+	req := Request{
+		Tokens:            []int32{1},
+		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
+		SamplerOpts:       sampler.Options{},
+	}
+	spec := r.spec.open(req, caches)
+	if spec == nil || !spec.enabled {
+		t.Fatalf("want a drafting speculationSession, got %+v", spec)
+	}
+	pinDraftLimit(spec, 0)
+	d := spec.decoder([]int32{1}, 0).(*speculativeDecoder)
+
+	// Two parked calls arrive pipelined, one token each.
+	for _, want := range []int{2, 3} {
+		results, err := d.next(20)
+		if err != nil {
+			t.Fatalf("parked next: %v", err)
+		}
+		if got := resultIDs(results); !slices.Equal(got, []int{want}) {
+			t.Fatalf("parked results = %v, want [%d]", got, want)
+		}
+	}
+
+	// The controller picks a positive depth: the next call hands back the
+	// in-flight sample without dispatching another forward.
+	model := r.Model.(*fakeMTPModel)
+	forwards := len(model.forwards)
+	spec.limit = 2
+	results, err := d.next(20)
+	if err != nil {
+		t.Fatalf("resume next: %v", err)
+	}
+	if got := resultIDs(results); !slices.Equal(got, []int{4}) {
+		t.Fatalf("resume results = %v, want [4]", got)
+	}
+	if len(model.forwards) != forwards {
+		t.Fatalf("resume dispatched a forward: %v", model.forwards[forwards:])
+	}
+
+	// The following call runs a fused round drafting from the resumed
+	// current token.
+	results, err = d.next(20)
+	if err != nil {
+		t.Fatalf("round next: %v", err)
+	}
+	if got := resultIDs(results); !slices.Equal(got, []int{5, 6, int(eos)}) {
+		t.Fatalf("round results = %v, want [5 6 %d]", got, eos)
+	}
+	wantForwards := []forwardCall{{0, 1}, {1, 1}, {2, 1}, {3, 3}}
+	if !slices.Equal(model.forwards, wantForwards) {
+		t.Fatalf("target forwards = %v, want %v", model.forwards, wantForwards)
+	}
+
+	// The stretch's reports, the resume pair, and the round's validated run
+	// extend the draft cache contiguously: the catch-up flush at the round's
+	// propose, its speculative entry, and the rebuild from target hiddens at
+	// close.
+	d.close()
+	spec.close()
+	wantExtends := []extendCall{
+		{offset: 0, ids: []int32{2, 3, 4}, hiddens: []int32{2, 3, 4}},
+		{offset: 3, ids: []int32{5}, hiddens: []int32{-1}},
+		{offset: 3, ids: []int32{5, 6, eos}, hiddens: []int32{5, 6, eos}},
+	}
+	if !reflect.DeepEqual(draft.extends, wantExtends) {
+		t.Fatalf("draft extends = %+v, want %+v", draft.extends, wantExtends)
+	}
+	if got, want := caches[0].Offset(), 6; got != want {
+		t.Fatalf("target offset = %d, want %d (EOS never forwarded)", got, want)
+	}
+	if got, want := caches[1].Offset(), 6; got != want {
+		t.Fatalf("draft cache offset = %d, want %d (lockstep with target)", got, want)
+	}
+}
+
 // newMTPTestCaches returns n rewindable fake caches sharing one snapshot
 // tracker, matching the cache.Cache the speculation helpers drive.
 func newMTPTestCaches(n int) ([]cache.Cache, *snapshotTracker) {
@@ -982,4 +1154,13 @@ func scriptedCandidates(r *Runner, tokens []int32) *draftCandidates {
 	d := &mtpDrafter{spec: s}
 	d.committed(mlx.FromValues([]int32{0}, 1, 1), mlx.Zeros(mlx.DTypeFloat32, 1, 1, mtpTestVocab), 0)
 	return d.propose(mlx.FromValues([]int32{0}, 1), len(tokens))
+}
+
+// pinAcceptInputs pins the arrays accept's caller must keep alive across
+// accept's internal sweep — current and the candidate tokens — as the decoder
+// and next do in the live engine. It returns the matching unpin.
+func pinAcceptInputs(current sampler.Result, candidates *draftCandidates) func() {
+	arrays := append(current.Arrays(), candidates.tokens)
+	mlx.Pin(arrays...)
+	return func() { mlx.Unpin(arrays...) }
 }

--- a/x/mlxrunner/pipeline.go
+++ b/x/mlxrunner/pipeline.go
@@ -137,11 +137,8 @@ func (r *Runner) TextGenerationPipeline(ctx context.Context, request Request) er
 
 	// Register the sampler after prefill completes.
 	r.Sampler.Add(pipelineSlot, request.SamplerOpts, inputs)
-	if r.useGreedyMTP(request.SamplerOpts) {
-		return r.runGreedyMTPDecode(ctx, request, session, caches, tokens[processed:], &position, now)
-	}
-	if r.useSampleMTP(request.SamplerOpts) {
-		return r.runSampleMTPDecode(ctx, request, session, caches, tokens[processed:], &position, now)
+	if r.useMTP(request.SamplerOpts) {
+		return r.runMTPDecode(ctx, request, session, caches, tokens[processed:], &position, now)
 	}
 
 	step := func(token *mlx.Array) sampler.Result {

--- a/x/mlxrunner/pipeline.go
+++ b/x/mlxrunner/pipeline.go
@@ -92,16 +92,15 @@ func (r *Runner) TextGenerationPipeline(ctx context.Context, request Request) er
 	if spec != nil {
 		d = spec.decoder(seed, position)
 	} else {
-		d = r.pipelinedDecoder(nil, caches, seed, position)
+		d = r.pipelinedDecoder(nil, caches, mlx.FromValues(seed, 1, len(seed)), position)
 	}
 	defer d.close()
 	return r.decode(ctx, request, session, d, promptEval)
 }
 
-// prefill evaluates the prompt's unprocessed tokens in chunks, leaving
-// one token for decode to seed from, and schedules the prompt's periodic
-// snapshots. It returns the seed tokens, the resume position, and the
-// prompt-evaluation duration.
+// prefill evaluates the prompt in chunks, leaving one token for decode to
+// seed from, and schedules the prompt's periodic snapshots. It returns the
+// seed tokens, the resume position, and the prompt-evaluation duration.
 func (r *Runner) prefill(ctx context.Context, session *cacheSession, spec *speculationSession) ([]int32, int, time.Duration, error) {
 	start := time.Now()
 	inputs := session.inputs
@@ -280,9 +279,9 @@ type pipelinedDecoder struct {
 	emitted  sampler.Result // last call's result, pinned until the next call
 }
 
-func (r *Runner) pipelinedDecoder(spec *speculationSession, caches []cache.Cache, seed []int32, position int) *pipelinedDecoder {
+func (r *Runner) pipelinedDecoder(spec *speculationSession, caches []cache.Cache, seed *mlx.Array, position int) *pipelinedDecoder {
 	t := &pipelinedDecoder{r: r, spec: spec, caches: caches, position: position}
-	t.sample = t.dispatch(mlx.FromValues(seed, 1, len(seed)))
+	t.sample = t.dispatch(seed)
 	return t
 }
 
@@ -311,16 +310,21 @@ func (t *pipelinedDecoder) next(int) ([]sampler.Result, error) {
 	return []sampler.Result{t.emitted}, nil
 }
 
+// detach ends a parked stretch: it hands the in-flight sample (sampled but
+// never forwarded) and the resume position to the caller, releasing the
+// decoder's emitted pin but not settling the drafter. The caller drafts from
+// the sample next, and that round completes the still-open frontier pair.
+func (t *pipelinedDecoder) detach() (sampler.Result, int) {
+	mlx.Unpin(t.emitted.Arrays()...)
+	return t.sample, t.position
+}
+
 func (t *pipelinedDecoder) close() {
-	// The in-flight sample's forward was never dispatched; its report lets
-	// the drafter settle level with the caches' resting offset.
+	// The in-flight sample's forward was never dispatched; its report settles
+	// the drafter level with the caches' resting offset.
 	t.spec.finish(t.sample.Token)
 	mlx.Unpin(t.emitted.Arrays()...)
 	mlx.Unpin(t.sample.Arrays()...)
-}
-
-func lastLogits(logits *mlx.Array) *mlx.Array {
-	return logits.Slice(mlx.Slice(), mlx.Slice(logits.Dim(1)-1), mlx.Slice()).Squeeze(1)
 }
 
 // detokenizer serializes sampled tokens into response chunks, holding bytes

--- a/x/mlxrunner/pipeline.go
+++ b/x/mlxrunner/pipeline.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ollama/ollama/llm"
 	"github.com/ollama/ollama/logutil"
 	"github.com/ollama/ollama/x/mlxrunner/batch"
+	"github.com/ollama/ollama/x/mlxrunner/cache"
 	"github.com/ollama/ollama/x/mlxrunner/mlx"
 	sampler "github.com/ollama/ollama/x/mlxrunner/sample"
 	"github.com/ollama/ollama/x/tokenizer"
@@ -55,12 +56,9 @@ const pipelineSlot = 0
 
 func (r *Runner) TextGenerationPipeline(ctx context.Context, request Request) error {
 	mlx.ResetPeakMemory()
-	var sample, nextSample sampler.Result
 
 	defer func() {
 		r.Sampler.Remove(pipelineSlot)
-		mlx.Unpin(sample.Arrays()...)
-		mlx.Unpin(nextSample.Arrays()...)
 		mlx.Sweep()
 		mlx.ClearCache()
 
@@ -75,9 +73,38 @@ func (r *Runner) TextGenerationPipeline(ctx context.Context, request Request) er
 
 	session := r.cache.begin(r.Model, inputs)
 	defer session.close()
-
 	caches := session.caches
+
+	seed, position, promptEval, err := r.prefill(ctx, session)
+	if err != nil {
+		return err
+	}
+
+	// Register the sampler after prefill completes.
+	r.Sampler.Add(pipelineSlot, request.SamplerOpts, inputs)
+
+	spec := r.spec.open(request, caches)
+	defer spec.close()
+
+	var d decoder
+	if spec != nil {
+		d = spec.decoder(seed, position)
+	} else {
+		d = r.pipelinedDecoder(caches, seed, position)
+	}
+	defer d.close()
+	return r.decode(ctx, request, session, d, promptEval)
+}
+
+// prefill evaluates the prompt's unprocessed tokens in chunks, leaving
+// one token for decode to seed from, and schedules the prompt's periodic
+// snapshots. It returns the seed tokens, the resume position, and the
+// prompt-evaluation duration.
+func (r *Runner) prefill(ctx context.Context, session *cacheSession) ([]int32, int, time.Duration, error) {
+	start := time.Now()
+	inputs := session.inputs
 	tokens := session.remaining
+	caches := session.caches
 	prefillChunk := prefillChunkSize()
 
 	// Request periodic snapshots during prefill and near the end of the
@@ -107,12 +134,11 @@ func (r *Runner) TextGenerationPipeline(ctx context.Context, request Request) er
 
 	session.schedulePrefillSnapshots(snapshotOffsets)
 
-	now := time.Now()
 	total, processed := len(tokens), 0
 	position := len(inputs) - len(tokens)
 	for total-processed > 1 {
 		if err := ctx.Err(); err != nil {
-			return err
+			return nil, 0, 0, err
 		}
 
 		n := min(prefillChunk, total-processed-1)
@@ -135,65 +161,78 @@ func (r *Runner) TextGenerationPipeline(ctx context.Context, request Request) er
 	// Attach the snapshots captured during prefill to the trie.
 	session.attachPrefillSnapshots()
 
-	// Register the sampler after prefill completes.
-	r.Sampler.Add(pipelineSlot, request.SamplerOpts, inputs)
-	if r.useMTP(request.SamplerOpts) {
-		return r.runMTPDecode(ctx, request, session, caches, tokens[processed:], &position, now)
-	}
+	return tokens[processed:], position, time.Since(start), nil
+}
 
-	step := func(token *mlx.Array) sampler.Result {
-		fwd := r.Model.Forward(&batch.Batch{
-			InputIDs:     token,
-			SeqOffsets:   []int32{int32(position)},
-			SeqQueryLens: []int32{int32(token.Dim(1))},
-		}, caches)
-		position += token.Dim(1)
-		logits := r.Model.Unembed(fwd)
-		logits = logits.Slice(mlx.Slice(), mlx.Slice(logits.Dim(1)-1), mlx.Slice()).Squeeze(1)
+// A decoder produces each run of tokens to emit, owning its own dispatch and
+// synchronization; the decode loop owns the budget, emission, and
+// cancellation. next may return none while its first tokens are in flight.
+type decoder interface {
+	next(remaining int) ([]sampler.Result, error)
+	close()
+}
 
-		sample := r.Sampler.Sample([]int{pipelineSlot}, logits)
-		mlx.Pin(sample.Arrays()...)
-		mlx.Sweep()
-		mlx.AsyncEval(sample.Arrays()...)
-		return sample
-	}
-
-	sample = step(mlx.FromValues(tokens[processed:], 1, total-processed))
-	logutil.TraceContext(ctx, "mlx decode seed", "tokens", total-processed, "memory", mlx.Memory{})
-
-	dec := decoder{
+// decode drives either decoder and owns where generation stops — at an EOS
+// or the NumPredict budget. Every produced token is recorded so the caches
+// never rest ahead of session.outputs; tokens past the stop are recorded but
+// not streamed or counted.
+func (r *Runner) decode(ctx context.Context, request Request, session *cacheSession, d decoder, promptEval time.Duration) error {
+	detok := detokenizer{
 		tokenizer:       r.Tokenizer,
 		wantLogprobs:    request.SamplerOpts.Logprobs,
 		wantTopLogprobs: request.SamplerOpts.TopLogprobs,
 	}
 
-	final := CompletionResponse{Done: true, PromptEvalCount: len(inputs), EvalCount: request.Options.NumPredict, DoneReason: 1}
-	for i := range request.Options.NumPredict {
+	final := CompletionResponse{Done: true, PromptEvalCount: len(request.Tokens), DoneReason: 1}
+	final.PromptEvalDuration = promptEval
+	now := time.Now()
+
+	// Release MLX's cached free buffers every clearCacheInterval tokens so the
+	// allocator's pool does not grow unbounded over a long generation.
+	const clearCacheInterval = 256
+
+	generated := 0
+	for generated < request.Options.NumPredict {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
 
-		nextSample = step(sample.Token.ExpandDims(-1))
-
-		if i == 0 {
-			mlx.Eval(sample.Arrays()...)
-			final.PromptEvalDuration = time.Since(now)
-			now = time.Now()
+		results, err := d.next(request.Options.NumPredict - generated)
+		if err != nil {
+			return err
 		}
 
-		output := int32(sample.Token.Int())
-		session.outputs = append(session.outputs, output)
-		if i == 0 {
-			logutil.TraceContext(ctx, "mlx decode first token", "memory", mlx.Memory{})
+		// Record the whole run before streaming any of it: a cancelled
+		// stream returns early and must not leave the caches ahead of
+		// session.outputs.
+		done := false
+		stream := len(results)
+		for i, res := range results {
+			// Int evaluates the array before reading it; a raw data read
+			// on a lazy array races its evaluation and returns garbage.
+			id := int32(res.Token.Int())
+			session.outputs = append(session.outputs, id)
+			if done {
+				continue
+			}
+			if r.Tokenizer.IsEOS(id) {
+				final.DoneReason = 0
+				done = true
+				stream = i
+				continue
+			}
+			generated++
+			if generated >= request.Options.NumPredict {
+				done = true
+				stream = i + 1
+			}
 		}
 
-		if r.Tokenizer.IsEOS(output) {
-			final.DoneReason = 0
-			final.EvalCount = i
-			break
-		}
-
-		if resp, ok := dec.decode(sample); ok {
+		for _, res := range results[:stream] {
+			resp, ok := detok.detokenize(res)
+			if !ok {
+				continue
+			}
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
@@ -201,14 +240,16 @@ func (r *Runner) TextGenerationPipeline(ctx context.Context, request Request) er
 			}
 		}
 
-		mlx.Unpin(sample.Arrays()...)
-		sample, nextSample = nextSample, sampler.Result{}
+		if done {
+			break
+		}
 
-		if i%256 == 0 {
+		if generated%clearCacheInterval == 0 {
 			mlx.ClearCache()
 		}
 	}
 
+	final.EvalCount = generated
 	final.EvalDuration = time.Since(now)
 	select {
 	case <-ctx.Done():
@@ -218,11 +259,60 @@ func (r *Runner) TextGenerationPipeline(ctx context.Context, request Request) er
 	}
 }
 
-// decoder serializes sampled tokens into response chunks, holding bytes
+// pipelinedDecoder decodes one token per call, one call ahead of emission:
+// the next token's chain is dispatched before the returned one is
+// synchronized, so the device runs ahead of host emission.
+type pipelinedDecoder struct {
+	r        *Runner
+	caches   []cache.Cache
+	position int
+	sample   sampler.Result // in flight: sampled, not yet forwarded
+	emitted  sampler.Result // last call's result, pinned until the next call
+}
+
+func (r *Runner) pipelinedDecoder(caches []cache.Cache, seed []int32, position int) *pipelinedDecoder {
+	t := &pipelinedDecoder{r: r, caches: caches, position: position}
+	t.sample = t.dispatch(mlx.FromValues(seed, 1, len(seed)))
+	return t
+}
+
+// dispatch builds one forward-and-sample chain without reading the token's
+// value, so it is in flight before the previous token is synchronized.
+func (t *pipelinedDecoder) dispatch(token *mlx.Array) sampler.Result {
+	r := t.r
+	hidden := r.Model.Forward(&batch.Batch{
+		InputIDs:     token,
+		SeqOffsets:   []int32{int32(t.position)},
+		SeqQueryLens: []int32{int32(token.Dim(1))},
+	}, t.caches)
+	t.position += token.Dim(1)
+	next := r.Sampler.Sample([]int{pipelineSlot}, lastLogits(r.Model.Unembed(hidden)))
+	mlx.Pin(next.Arrays()...)
+	mlx.Sweep()
+	mlx.AsyncEval(next.Arrays()...)
+	return next
+}
+
+func (t *pipelinedDecoder) next(int) ([]sampler.Result, error) {
+	mlx.Unpin(t.emitted.Arrays()...)
+	t.emitted, t.sample = t.sample, t.dispatch(t.sample.Token.ExpandDims(-1))
+	return []sampler.Result{t.emitted}, nil
+}
+
+func (t *pipelinedDecoder) close() {
+	mlx.Unpin(t.emitted.Arrays()...)
+	mlx.Unpin(t.sample.Arrays()...)
+}
+
+func lastLogits(logits *mlx.Array) *mlx.Array {
+	return logits.Slice(mlx.Slice(), mlx.Slice(logits.Dim(1)-1), mlx.Slice()).Squeeze(1)
+}
+
+// detokenizer serializes sampled tokens into response chunks, holding bytes
 // whose UTF-8 sequence hasn't completed yet and the logprobs that belong
 // with those bytes so Content and Logprobs stay aligned when a chunk does
 // flush.
-type decoder struct {
+type detokenizer struct {
 	tokenizer       *tokenizer.Tokenizer
 	buf             bytes.Buffer
 	logprobs        []llm.Logprob
@@ -230,7 +320,7 @@ type decoder struct {
 	wantTopLogprobs int
 }
 
-func (d *decoder) decode(res sampler.Result) (CompletionResponse, bool) {
+func (d *detokenizer) detokenize(res sampler.Result) (CompletionResponse, bool) {
 	output := int32(res.Token.Int())
 	d.buf.WriteString(d.tokenizer.Decode([]int32{output}))
 	d.logprobs = append(d.logprobs, buildLogprob(res, d.wantLogprobs, d.wantTopLogprobs, d.tokenizer.Decode)...)

--- a/x/mlxrunner/pipeline.go
+++ b/x/mlxrunner/pipeline.go
@@ -75,7 +75,12 @@ func (r *Runner) TextGenerationPipeline(ctx context.Context, request Request) er
 	defer session.close()
 	caches := session.caches
 
-	seed, position, promptEval, err := r.prefill(ctx, session)
+	// Built before prefill so a drafter with draft caches follows the prompt
+	// through prefill alongside the target.
+	spec := r.spec.open(request, caches)
+	defer spec.close()
+
+	seed, position, promptEval, err := r.prefill(ctx, session, spec)
 	if err != nil {
 		return err
 	}
@@ -83,14 +88,11 @@ func (r *Runner) TextGenerationPipeline(ctx context.Context, request Request) er
 	// Register the sampler after prefill completes.
 	r.Sampler.Add(pipelineSlot, request.SamplerOpts, inputs)
 
-	spec := r.spec.open(request, caches)
-	defer spec.close()
-
 	var d decoder
 	if spec != nil {
 		d = spec.decoder(seed, position)
 	} else {
-		d = r.pipelinedDecoder(caches, seed, position)
+		d = r.pipelinedDecoder(nil, caches, seed, position)
 	}
 	defer d.close()
 	return r.decode(ctx, request, session, d, promptEval)
@@ -100,7 +102,7 @@ func (r *Runner) TextGenerationPipeline(ctx context.Context, request Request) er
 // one token for decode to seed from, and schedules the prompt's periodic
 // snapshots. It returns the seed tokens, the resume position, and the
 // prompt-evaluation duration.
-func (r *Runner) prefill(ctx context.Context, session *cacheSession) ([]int32, int, time.Duration, error) {
+func (r *Runner) prefill(ctx context.Context, session *cacheSession, spec *speculationSession) ([]int32, int, time.Duration, error) {
 	start := time.Now()
 	inputs := session.inputs
 	tokens := session.remaining
@@ -143,11 +145,13 @@ func (r *Runner) prefill(ctx context.Context, session *cacheSession) ([]int32, i
 
 		n := min(prefillChunk, total-processed-1)
 
-		r.Model.Forward(&batch.Batch{
-			InputIDs:     mlx.FromValues(tokens[processed:processed+n], 1, n),
+		chunkIDs := mlx.FromValues(tokens[processed:processed+n], 1, n)
+		hidden := r.Model.Forward(&batch.Batch{
+			InputIDs:     chunkIDs,
 			SeqOffsets:   []int32{int32(position)},
 			SeqQueryLens: []int32{int32(n)},
 		}, caches)
+		spec.committed(chunkIDs, hidden, position)
 		mlx.Sweep()
 		materializeCaches()
 		processed += n
@@ -158,7 +162,10 @@ func (r *Runner) prefill(ctx context.Context, session *cacheSession) ([]int32, i
 		mlx.ClearCache()
 	}
 
-	// Attach the snapshots captured during prefill to the trie.
+	// Flush before attaching: snapshots attach only at offsets every cache
+	// has crossed, and a drafter with draft caches keeps buffered pairs that
+	// would otherwise hold those caches short of the scheduled offsets.
+	spec.flush()
 	session.attachPrefillSnapshots()
 
 	return tokens[processed:], position, time.Since(start), nil
@@ -263,15 +270,18 @@ func (r *Runner) decode(ctx context.Context, request Request, session *cacheSess
 // the next token's chain is dispatched before the returned one is
 // synchronized, so the device runs ahead of host emission.
 type pipelinedDecoder struct {
-	r        *Runner
+	r *Runner
+	// spec, when non-nil, receives every forwarded token and settles its
+	// drafter at close, keeping a non-drafting session's draft KV level.
+	spec     *speculationSession
 	caches   []cache.Cache
 	position int
 	sample   sampler.Result // in flight: sampled, not yet forwarded
 	emitted  sampler.Result // last call's result, pinned until the next call
 }
 
-func (r *Runner) pipelinedDecoder(caches []cache.Cache, seed []int32, position int) *pipelinedDecoder {
-	t := &pipelinedDecoder{r: r, caches: caches, position: position}
+func (r *Runner) pipelinedDecoder(spec *speculationSession, caches []cache.Cache, seed []int32, position int) *pipelinedDecoder {
+	t := &pipelinedDecoder{r: r, spec: spec, caches: caches, position: position}
 	t.sample = t.dispatch(mlx.FromValues(seed, 1, len(seed)))
 	return t
 }
@@ -285,8 +295,10 @@ func (t *pipelinedDecoder) dispatch(token *mlx.Array) sampler.Result {
 		SeqOffsets:   []int32{int32(t.position)},
 		SeqQueryLens: []int32{int32(token.Dim(1))},
 	}, t.caches)
+	t.spec.committed(token, hidden, t.position)
 	t.position += token.Dim(1)
-	next := r.Sampler.Sample([]int{pipelineSlot}, lastLogits(r.Model.Unembed(hidden)))
+	logits := r.Model.Unembed(hidden)
+	next := r.Sampler.Sample([]int{pipelineSlot}, logits.Slice(mlx.Slice(), mlx.Slice(logits.Dim(1)-1), mlx.Slice()).Squeeze(1))
 	mlx.Pin(next.Arrays()...)
 	mlx.Sweep()
 	mlx.AsyncEval(next.Arrays()...)
@@ -300,6 +312,9 @@ func (t *pipelinedDecoder) next(int) ([]sampler.Result, error) {
 }
 
 func (t *pipelinedDecoder) close() {
+	// The in-flight sample's forward was never dispatched; its report lets
+	// the drafter settle level with the caches' resting offset.
+	t.spec.finish(t.sample.Token)
 	mlx.Unpin(t.emitted.Arrays()...)
 	mlx.Unpin(t.sample.Arrays()...)
 }

--- a/x/mlxrunner/runner.go
+++ b/x/mlxrunner/runner.go
@@ -81,6 +81,9 @@ func (r *Runner) Load(modelName string) error {
 			return err
 		}
 		draftModel = draft
+	} else if sd, ok := m.(base.SelfDraft); ok {
+		// Inline draft head: already loaded with the target; nil if none shipped.
+		draftModel = sd.SelfDraft()
 	}
 
 	collected := mlx.Collect(m)

--- a/x/mlxrunner/runner.go
+++ b/x/mlxrunner/runner.go
@@ -35,13 +35,15 @@ type Request struct {
 
 type Runner struct {
 	Model         base.Model
-	Draft         base.DraftModel
 	Tokenizer     *tokenizer.Tokenizer
 	Requests      chan Request
 	Sampler       *sample.Sampler
 	cache         kvCache
 	contextLength int
 	mlxThread     *mlxthread.Thread
+	// spec is the speculative-decoding subsystem. Nil when the model ships no
+	// draft head.
+	spec *speculation
 }
 
 func (r *Runner) Load(modelName string) error {
@@ -69,7 +71,7 @@ func (r *Runner) Load(modelName string) error {
 		return err
 	}
 
-	r.Draft = nil
+	var draftModel base.DraftModel
 	draft, err := base.NewDraft(root, m)
 	if err != nil {
 		return err
@@ -78,7 +80,7 @@ func (r *Runner) Load(modelName string) error {
 		if err := draft.LoadWeights(tensors); err != nil {
 			return err
 		}
-		r.Draft = draft
+		draftModel = draft
 	}
 
 	collected := mlx.Collect(m)
@@ -101,8 +103,10 @@ func (r *Runner) Load(modelName string) error {
 	r.Tokenizer = m.Tokenizer()
 	r.contextLength = m.MaxContextLength()
 	r.Sampler = sample.New(r.contextLength)
+	r.spec = newSpeculation(r, draftModel)
 
 	mlx.EnableCompile()
+
 	return nil
 }
 

--- a/x/mlxrunner/sample/sample.go
+++ b/x/mlxrunner/sample/sample.go
@@ -443,8 +443,12 @@ func (s *Sampler) Sample(seqIDs []int, logits *mlx.Array) Result {
 }
 
 // Distribution applies this slot's sampling transforms to logits without
-// mutating sampler state. Row i is built as if draftTokens[:i] had already
-// been appended to the slot history. logits must be [R,V] or [1,R,V].
+// mutating sampler state. Rows align with the end of the draft chain: the
+// final row is built as if every draft token had already been appended to
+// the slot history, each earlier row with one fewer. Validation passes
+// len(draftTokens)+1 rows, so row i sees draftTokens[:i]; a proposal step
+// passes a single row, which sees the whole chain so far. logits must be
+// [R,V] or [1,R,V].
 func (s *Sampler) Distribution(seqID int, logits *mlx.Array, draftTokens *mlx.Array) Distribution {
 	slot, logits, draftTokens := s.speculativeInputs("Distribution", seqID, logits, draftTokens)
 	rows := logits.Dim(0)
@@ -465,7 +469,8 @@ func (s *Sampler) Distribution(seqID int, logits *mlx.Array, draftTokens *mlx.Ar
 
 // SpeculativeScores applies this slot's sampling transforms to logits without
 // mutating sampler state and returns dense log-probability scores for sampled
-// decoding. Greedy decoding returns the penalty-adjusted logits.
+// decoding. Greedy decoding returns the penalty-adjusted logits. Rows align
+// with the end of the draft chain as in Distribution.
 func (s *Sampler) SpeculativeScores(seqID int, logits *mlx.Array, draftTokens *mlx.Array) *mlx.Array {
 	slot, logits, draftTokens := s.speculativeInputs("SpeculativeScores", seqID, logits, draftTokens)
 	rows := logits.Dim(0)
@@ -521,6 +526,17 @@ func (s *Sampler) speculativeInputs(caller string, seqID int, logits *mlx.Array,
 
 	if draftTokens != nil && draftTokens.NumDims() == 1 {
 		draftTokens = draftTokens.ExpandDims(0)
+	}
+
+	// Rows align with the end of the draft chain, so the earliest row sees
+	// draftCount-rows+1 prior drafts. More rows than draftCount+1 would make
+	// that count negative and silently drop the prefix; reject it loudly.
+	draftCount := 0
+	if draftTokens != nil {
+		draftCount = draftTokens.Dim(1)
+	}
+	if logits.Dim(0) > draftCount+1 {
+		panic(fmt.Sprintf("sample.Sampler.%s: %d logit rows exceed the %d-token draft chain", caller, logits.Dim(0), draftCount))
 	}
 	return slot, logits, draftTokens
 }
@@ -578,7 +594,7 @@ func (s *Sampler) speculativeDistributionSerial(slot *slotState, logits *mlx.Arr
 	for i := range rows {
 		rowLogits := logits.Slice(mlx.Slice(i, i+1), mlx.Slice())
 		hist := base
-		prefixLen := min(i, draftCount)
+		prefixLen := draftCount - rows + 1 + i
 		if prefixLen > 0 {
 			prefix := draftTokens.Slice(mlx.Slice(), mlx.Slice(0, prefixLen))
 			if hist == nil {
@@ -616,7 +632,9 @@ func (s *Sampler) speculativeHistory(slot *slotState, draftTokens *mlx.Array, ro
 	sourceIdx := make([]int32, rows*width)
 	writeMask := make([]bool, rows*width)
 	for i := range rows {
-		prefixLen := min(i, draftCount)
+		// Non-positive lengths run no iterations: rows beyond the draft
+		// chain's start carry the base history unchanged.
+		prefixLen := draftCount - rows + 1 + i
 		for j := range prefixLen {
 			pos := (next + j) % width
 			sourceIdx[i*width+pos] = int32(j)

--- a/x/mlxrunner/sample/sample_test.go
+++ b/x/mlxrunner/sample/sample_test.go
@@ -336,6 +336,34 @@ func TestSpeculativeScoresUsesDraftHistoryWithoutCommit(t *testing.T) {
 	}
 }
 
+func TestDistributionSingleRowAppliesDraftPrefix(t *testing.T) {
+	skipIfNoMLX(t)
+
+	s := New(128)
+	t.Cleanup(func() {
+		s.Free()
+		mlx.Sweep()
+	})
+
+	// A proposal step passes one logits row with the chain's earlier drafts:
+	// the single row is the chain's final step, so every draft belongs to
+	// its history. Slot 0 exercises the batched history path (full ring),
+	// slot 1 the serial path (ring not yet full).
+	s.Add(0, Options{RepeatLastN: 2, RepeatPenalty: 10}, []int32{0, 1})
+	s.Add(1, Options{RepeatLastN: 8, RepeatPenalty: 10}, []int32{0, 1})
+	prefix := mlx.NewArrayInt32([]int32{3, 4}, []int32{1, 2})
+
+	for _, seqID := range []int{0, 1} {
+		// Drafts 3 and 4 are penalized, so token 2 wins over the higher raw
+		// scores; with the drafts absent from the history, token 3 would.
+		dist := s.Distribution(seqID, batchLogits([]float32{0, 0, 9, 9, 8}), prefix)
+		mlx.Eval(dist.IDs)
+		if got := dist.IDs.Ints()[0]; got != 2 {
+			t.Fatalf("seq %d token = %d, want 2 (drafts 3 and 4 penalized)", seqID, got)
+		}
+	}
+}
+
 func TestCommitBatchesRingWrites(t *testing.T) {
 	skipIfNoMLX(t)
 

--- a/x/mlxrunner/speculate.go
+++ b/x/mlxrunner/speculate.go
@@ -1,0 +1,513 @@
+package mlxrunner
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/ollama/ollama/x/mlxrunner/batch"
+	"github.com/ollama/ollama/x/mlxrunner/cache"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/mlxrunner/model/base"
+	sampler "github.com/ollama/ollama/x/mlxrunner/sample"
+)
+
+// drafter proposes speculative tokens for the engine to validate, learning
+// the conversation through the committed-stream reports.
+type drafter interface {
+	// propose returns up to maxTokens draft tokens with their proposal
+	// distributions, or nil to decode this round plainly.
+	propose(current *mlx.Array, maxTokens int) *draftCandidates
+
+	// committed reports a run of tokens committed to the target caches:
+	// tokens[i] sits at slot position+i and hiddens row i is the target
+	// hidden state at that slot. Runs arrive in slot order — the decode
+	// seed, then each round's validated tokens.
+	committed(tokens, hiddens *mlx.Array, position int)
+
+	close()
+}
+
+type draftSchedule string
+
+const (
+	draftScheduleHeuristic draftSchedule = "heuristic"
+	draftScheduleConstant  draftSchedule = "constant"
+)
+
+type specStats struct {
+	iterations  int
+	drafted     int
+	accepted    int
+	mismatches  int
+	allAccepted int
+	maxDraft    int
+}
+
+type specOptions struct {
+	initialDraftTokens int
+	maxDraftTokens     int
+	draftSchedule      draftSchedule
+}
+
+func (r *Runner) loadSpecOptions(sample bool) specOptions {
+	defaults := r.mtpDefaults(sample)
+
+	opts := specOptions{
+		initialDraftTokens: defaults.InitialDraftTokens,
+		maxDraftTokens:     defaults.MaxDraftTokens,
+		draftSchedule:      draftScheduleConstant,
+	}
+	if v := positiveEnvInt("OLLAMA_MLX_MTP_MAX_DRAFT_TOKENS"); v > 0 {
+		opts.maxDraftTokens = v
+	}
+	if v := positiveEnvInt("OLLAMA_MLX_MTP_INITIAL_DRAFT_TOKENS"); v > 0 {
+		opts.initialDraftTokens = v
+	}
+	if opts.initialDraftTokens > opts.maxDraftTokens {
+		opts.initialDraftTokens = opts.maxDraftTokens
+	}
+	switch schedule := strings.ToLower(strings.TrimSpace(os.Getenv("OLLAMA_MLX_MTP_DRAFT_SCHEDULE"))); schedule {
+	case "", string(draftScheduleConstant):
+		opts.draftSchedule = draftScheduleConstant
+	case string(draftScheduleHeuristic):
+		opts.draftSchedule = draftScheduleHeuristic
+	default:
+		slog.Warn("invalid MTP env setting", "key", "OLLAMA_MLX_MTP_DRAFT_SCHEDULE", "value", schedule)
+	}
+	return opts
+}
+
+func positiveEnvInt(key string) int {
+	raw := os.Getenv(key)
+	if raw == "" {
+		return 0
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil || v <= 0 {
+		slog.Warn("invalid MTP env setting", "key", key, "value", raw)
+		return 0
+	}
+	return v
+}
+
+// speculation is the persistent speculative-decoding subsystem of a Runner,
+// one per loaded model. It holds the draft model; as the feature grows it
+// also holds the cache partition and the depth state learned across requests.
+// A nil *speculation means the checkpoint ships no draft head.
+type speculation struct {
+	r     *Runner
+	draft base.DraftModel
+}
+
+// newSpeculation builds the speculative-decoding subsystem for a loaded model,
+// or nil when the checkpoint ships no draft head.
+func newSpeculation(r *Runner, draft base.DraftModel) *speculation {
+	if draft == nil {
+		return nil
+	}
+	return &speculation{r: r, draft: draft}
+}
+
+// speculationSession is the speculation cursor for one request over a speculation. A
+// nil speculationSession is a plain decode.
+type speculationSession struct {
+	spec    *speculation
+	drafter drafter
+	caches  []cache.Cache
+	opts    specOptions
+	limit   int // current draft length
+	stats   specStats
+}
+
+// open returns the speculation cursor for this request, or nil when the model
+// carries no draft head or the request cannot speculate. Logprobs are not yet
+// supported. A nil receiver (no draft head) decodes plainly.
+func (s *speculation) open(request Request, caches []cache.Cache) *speculationSession {
+	if s == nil {
+		return nil
+	}
+	d := newMTPDrafter(s, caches)
+	if d == nil {
+		return nil
+	}
+	opts := request.SamplerOpts
+	if !s.r.mtpDefaults(opts.Temperature != 0).Enabled {
+		return nil
+	}
+	if opts.Logprobs || opts.TopLogprobs > 0 {
+		return nil
+	}
+
+	specOpts := s.r.loadSpecOptions(opts.Temperature != 0)
+	return &speculationSession{
+		spec:    s,
+		drafter: d,
+		caches:  caches,
+		opts:    specOpts,
+		limit:   specOpts.initialDraftTokens,
+		stats:   specStats{maxDraft: specOpts.initialDraftTokens},
+	}
+}
+
+func (s *speculationSession) committed(tokens, hiddens *mlx.Array, position int) {
+	if s == nil {
+		return
+	}
+	s.drafter.committed(tokens, hiddens, position)
+}
+
+func (s *speculationSession) close() {
+	if s == nil {
+		return
+	}
+	s.drafter.close()
+}
+
+// speculativeDecoder decodes one speculative round per call: it forwards
+// the current token — emitted by the previous call, so a token that ends
+// generation is never forwarded — has the engine draft and validate ahead
+// of it, and returns the round's accepted tokens followed by the engine's
+// next token. The last returned token becomes the next call's current; the
+// seed token primes current and is never returned.
+type speculativeDecoder struct {
+	s        *speculationSession
+	position int
+	current  sampler.Result // emitted (or the seed), not yet forwarded
+}
+
+func (s *speculationSession) decoder(seed []int32, position int) *speculativeDecoder {
+	current := sampler.Result{Token: mlx.FromValues(seed, len(seed))}
+	mlx.Pin(current.Arrays()...)
+	return &speculativeDecoder{s: s, position: position, current: current}
+}
+
+func (st *speculativeDecoder) next(remaining int) ([]sampler.Result, error) {
+	s := st.s
+	r := s.spec.r
+
+	hidden := r.Model.Forward(&batch.Batch{
+		InputIDs:     tokenInput(st.current.Token),
+		SeqOffsets:   []int32{int32(st.position)},
+		SeqQueryLens: []int32{1},
+	}, s.caches)
+	st.position++
+
+	results, next, err := s.round(&st.position, st.current, hidden, remaining)
+	if err != nil {
+		return nil, err
+	}
+	if next.Token != nil {
+		results = append(results, next)
+	}
+
+	last := results[len(results)-1]
+	mlx.Pin(last.Arrays()...)
+	mlx.Unpin(st.current.Arrays()...)
+	st.current = last
+	mlx.AsyncEval(st.current.Arrays()...)
+	return results, nil
+}
+
+func (st *speculativeDecoder) close() {
+	mlx.Unpin(st.current.Arrays()...)
+	st.s.logStats()
+}
+
+// round runs one speculative decode round for the just-forwarded current
+// token and its hidden state: draft candidates after it, validate them
+// against the target, and return the accepted run and the bonus or
+// resampled next token.
+func (s *speculationSession) round(position *int, current sampler.Result, hidden *mlx.Array, remaining int) (results []sampler.Result, next sampler.Result, err error) {
+	r := s.spec.r
+	s.stats.iterations++
+
+	// A round emits the accepted drafts plus one more token (the bonus or
+	// residual), so cap the draft one below the remaining budget to land that
+	// extra token within it rather than overshooting. At remaining 1 the cap is
+	// 0 and the last token decodes plainly.
+	maxDraft := min(s.limit, remaining-1)
+	candidates := s.drafter.propose(current.Token, maxDraft)
+	baseLogits := lastLogits(r.Model.Unembed(hidden))
+	if candidates == nil {
+		s.drafter.committed(tokenInput(current.Token), lastHiddenRow(hidden), *position-1)
+		return nil, r.Sampler.Sample([]int{pipelineSlot}, baseLogits), nil
+	}
+
+	draftCount := candidates.tokens.Dim(1)
+	// hidden survives the sweep alongside the candidates: the post-accept
+	// report fuses it into the committed stream.
+	candidateArrays := append([]*mlx.Array{baseLogits, hidden}, candidates.Arrays()...)
+	mlx.Pin(candidateArrays...)
+	mlx.Sweep()
+	defer mlx.Unpin(candidateArrays...)
+	s.stats.drafted += draftCount
+
+	results, accepted, err := s.accept(position, current, hidden, baseLogits, candidates)
+	if err != nil {
+		return nil, sampler.Result{}, err
+	}
+	// accept folds the bonus token into its results; surface it back out as
+	// the next step's current.
+	if len(results) > accepted {
+		next = results[len(results)-1]
+		results = results[:accepted]
+	}
+
+	s.stats.accepted += accepted
+	if accepted == draftCount {
+		s.stats.allAccepted++
+	} else {
+		s.stats.mismatches++
+	}
+	if s.opts.draftSchedule == draftScheduleHeuristic {
+		if accepted == draftCount {
+			s.limit = min(s.opts.maxDraftTokens, s.limit+2)
+		} else {
+			s.limit = max(1, s.limit-1)
+		}
+		s.stats.maxDraft = max(s.stats.maxDraft, s.limit)
+	}
+	return results, next, nil
+}
+
+// logStats reports the per-request speculation summary.
+func (s *speculationSession) logStats() {
+	acceptance := 0.0
+	if s.stats.drafted > 0 {
+		acceptance = float64(s.stats.accepted) / float64(s.stats.drafted)
+	}
+	avgDraft := 0.0
+	avgAccepted := 0.0
+	if s.stats.iterations > 0 {
+		avgDraft = float64(s.stats.drafted) / float64(s.stats.iterations)
+		avgAccepted = float64(s.stats.accepted) / float64(s.stats.iterations)
+	}
+	slog.Info("speculative decode stats", "drafted", s.stats.drafted, "accepted", s.stats.accepted, "acceptance", acceptance, "iterations", s.stats.iterations, "avg_draft", avgDraft, "avg_accepted", avgAccepted, "mismatches", s.stats.mismatches, "all_accepted", s.stats.allAccepted, "max_draft", s.stats.maxDraft, "draft_schedule", s.opts.draftSchedule)
+}
+
+// draftCandidates is one round's draft tokens and the proposal distribution
+// each was sampled from, weighed against the target during acceptance.
+type draftCandidates struct {
+	tokens *mlx.Array
+	dist   sampler.Distribution
+}
+
+func (c *draftCandidates) Arrays() []*mlx.Array {
+	if c == nil {
+		return nil
+	}
+	return append([]*mlx.Array{c.tokens}, c.dist.Arrays()...)
+}
+
+// scheduleSpeculation schedules per-token snapshots at offsets
+// [before, before+draftCount) on every cache, so the speculative forward
+// captures a rollback point before each draft token's write.
+func scheduleSpeculation(caches []cache.Cache, before, draftCount int) {
+	offsets := make([]int, draftCount)
+	for i := range offsets {
+		offsets[i] = before + i
+	}
+	for _, c := range caches {
+		if c != nil {
+			c.PrepareSnapshots(offsets)
+		}
+	}
+}
+
+// commitSpeculation rolls every cache back to before+accepted, keeping only
+// the accepted prefix; full acceptance needs no restore. Rollback tries a
+// live rewind first (Restore(nil)) and falls back to the captured snapshot.
+func commitSpeculation(caches []cache.Cache, accepted, draftCount, before int) {
+	target := before + accepted
+	for _, c := range caches {
+		if c == nil {
+			continue
+		}
+		snaps := c.TakeSnapshots()
+		if accepted < draftCount {
+			// Close the snapshots we won't restore from before restoring: a
+			// snapshot restore on a wrapped RotatingKVCache copies out every
+			// outstanding lazy snapshot before it rebuilds the buffer, so
+			// dropping the unused ones first stops that copy-out from
+			// materializing snapshots we are about to discard anyway.
+			for i, s := range snaps {
+				if s != nil && i != accepted {
+					s.Close()
+					snaps[i] = nil
+				}
+			}
+			if !c.Restore(nil, target) && !c.Restore(snaps[accepted], target) {
+				panic(fmt.Sprintf("speculation: cache restore to %d failed", target))
+			}
+		}
+		for _, s := range snaps {
+			if s != nil {
+				s.Close()
+			}
+		}
+	}
+}
+
+// accept accepts the longest draft prefix that survives rejection sampling
+// against the target model. At temperature 0 the distributions are point
+// masses, so acceptance reduces to argmax-match. It returns the accepted
+// drafts followed by the target's own next token — the residual at the
+// rejection point, or the bonus past a fully accepted run — so a round
+// yields accepted+1 tokens, except when an accepted EOS ends generation,
+// where the run stops at the EOS with no continuation. The accepted run is
+// reported back to the drafter with its hidden states.
+//
+// The NumPredict budget is the decode loop's to enforce; the drafter is
+// already capped to the remaining budget, so an accepted run never
+// overshoots, and a legitimate token past the budget is left for decode to
+// drop rather than cut here.
+func (s *speculationSession) accept(position *int, current sampler.Result, hidden, baseLogits *mlx.Array, candidates *draftCandidates) (results []sampler.Result, accepted int, err error) {
+	r := s.spec.r
+	before := *position
+	draftCount := candidates.tokens.Dim(1)
+	scheduleSpeculation(s.caches, before, draftCount)
+
+	// Every exit between schedule and commit must drain the snapshot
+	// schedule and roll the speculative writes back out of the live caches:
+	// an undrained schedule panics the next PrepareSnapshots, and
+	// uncommitted speculative tokens reach the trie through session.close.
+	committed := false
+	commit := func(keep int) {
+		if committed {
+			return
+		}
+		committed = true
+		commitSpeculation(s.caches, keep, draftCount, before)
+	}
+	defer commit(0)
+
+	hiddenSeq := r.Model.Forward(&batch.Batch{
+		InputIDs:     candidates.tokens,
+		SeqOffsets:   []int32{int32(before)},
+		SeqQueryLens: []int32{int32(draftCount)},
+	}, s.caches)
+
+	targetDist := r.Sampler.Distribution(pipelineSlot, validationLogits(r, baseLogits, hiddenSeq), candidates.tokens)
+	draftDist := candidates.dist
+	acceptedMask := r.sampleAcceptedMask(targetDist.SliceRows(0, draftCount), draftDist, candidates.tokens)
+	mlx.Eval(candidates.tokens, acceptedMask)
+
+	draftIDs := candidates.tokens.Ints()
+	acceptedFlags := acceptedMask.Ints()
+	for _, ok := range acceptedFlags {
+		if ok == 0 {
+			break
+		}
+		accepted++
+	}
+	if accepted > draftCount {
+		return nil, 0, fmt.Errorf("speculation validation accepted %d tokens for %d draft tokens", accepted, draftCount)
+	}
+
+	// Find where an accepted EOS ends the run, before committing, so the cut
+	// is known while the per-token rollback snapshots still exist.
+	commitIDs := make([]int32, 0, accepted+1)
+	done := false
+	for i, id := range draftIDs[:accepted] {
+		commitIDs = append(commitIDs, int32(id))
+		if r.Tokenizer.IsEOS(int32(id)) {
+			done = true
+			accepted = i + 1
+			break
+		}
+	}
+
+	commit(accepted)
+	*position = before + accepted
+
+	// Report the validated run — current plus the accepted drafts, with the
+	// hidden state at each token's own slot — to the drafter before
+	// returning, so even a cancelled emission leaves the drafter's state
+	// describing exactly what the target caches hold.
+	runIDs := append([]int32{int32(current.Token.Int())}, commitIDs...)
+	runHiddens := lastHiddenRow(hidden)
+	if accepted > 0 {
+		runHiddens = runHiddens.Concatenate(1, hiddenSeq.Slice(mlx.Slice(), mlx.Slice(0, accepted), mlx.Slice()))
+	}
+	s.drafter.committed(mlx.FromValues(runIDs, 1, len(runIDs)), runHiddens, before-1)
+
+	results = draftResults(draftIDs[:accepted])
+	if done {
+		r.Sampler.Commit(pipelineSlot, commitIDs)
+		return results, accepted, nil
+	}
+
+	var nextToken *mlx.Array
+	if accepted == draftCount {
+		nextToken = r.sampleTokenAt(targetDist, draftCount)
+	} else {
+		nextToken = r.sampleResidualToken(targetDist, draftDist, accepted)
+	}
+	mlx.Eval(nextToken)
+	nextID := int32(nextToken.Int())
+	commitIDs = append(commitIDs, nextID)
+	r.Sampler.Commit(pipelineSlot, commitIDs)
+
+	results = append(results, sampler.Result{Token: nextToken})
+	return results, accepted, nil
+}
+
+// validationLogits stacks the current token's logits ahead of the draft
+// positions' logits so row i scores draft i.
+func validationLogits(r *Runner, baseLogits, hiddenSeq *mlx.Array) *mlx.Array {
+	seqLogits := r.Model.Unembed(hiddenSeq)
+	return baseLogits.ExpandDims(1).Concatenate(1, seqLogits)
+}
+
+func (r *Runner) sampleAcceptedMask(targetDist, draftDist sampler.Distribution, draftTokens *mlx.Array) *mlx.Array {
+	p := targetDist.Prob(draftTokens)
+	q := draftDist.Prob(draftTokens)
+	acceptP := mlx.Minimum(p.Divide(q), mlx.FromValue(float32(1)))
+	return r.Sampler.Bernoulli(pipelineSlot, acceptP).AsType(mlx.DTypeInt32)
+}
+
+func (r *Runner) sampleTokenAt(dist sampler.Distribution, index int) *mlx.Array {
+	return r.Sampler.SampleDistribution(pipelineSlot, dist.SliceRows(index, index+1))
+}
+
+func (r *Runner) sampleResidualToken(targetDist, draftDist sampler.Distribution, index int) *mlx.Array {
+	residual := targetDist.SliceRows(index, index+1).ResidualAgainst(draftDist.SliceRows(index, index+1))
+	return tokenVector(r.Sampler.SampleDistribution(pipelineSlot, residual))
+}
+
+// draftResults wraps accepted draft ids as sampler results; drafts carry no
+// logprobs, so only the token id is set.
+func draftResults(ids []int) []sampler.Result {
+	results := make([]sampler.Result, len(ids))
+	for i, id := range ids {
+		results[i] = sampler.Result{Token: mlx.FromValues([]int32{int32(id)}, 1)}
+	}
+	return results
+}
+
+func tokenInput(token *mlx.Array) *mlx.Array {
+	switch token.NumDims() {
+	case 0:
+		return token.Reshape(1, 1)
+	case 1:
+		return token.ExpandDims(-1)
+	case 2:
+		return token
+	default:
+		panic(fmt.Sprintf("token must be rank 0, 1, or 2, got rank %d", token.NumDims()))
+	}
+}
+
+func tokenVector(token *mlx.Array) *mlx.Array {
+	switch token.NumDims() {
+	case 0:
+		return token.Reshape(1)
+	case 1:
+		return token
+	default:
+		panic(fmt.Sprintf("sampled token must be rank 0 or 1, got rank %d", token.NumDims()))
+	}
+}

--- a/x/mlxrunner/speculate.go
+++ b/x/mlxrunner/speculate.go
@@ -463,7 +463,15 @@ func (s *speculationSession) accept(position *int, current sampler.Result, candi
 	targetDist := r.Sampler.Distribution(pipelineSlot, r.Model.Unembed(hiddenSeq), candidates.tokens)
 	draftDist := candidates.dist
 	acceptedMask := r.sampleAcceptedMask(targetDist.SliceRows(0, draftCount), draftDist, candidates.tokens)
-	mlx.Eval(candidates.tokens, acceptedMask)
+
+	// The next token is sampled for every possible outcome before anything
+	// is evaluated — the residual at each rejection point in one batched
+	// draw, plus the bonus row — so a single Eval covers acceptance and the
+	// next token instead of a second host round trip after the rejection
+	// point is known.
+	residualTokens := r.Sampler.SampleDistribution(pipelineSlot, targetDist.SliceRows(0, draftCount).ResidualAgainst(draftDist))
+	bonusToken := r.sampleTokenAt(targetDist, draftCount)
+	mlx.Eval(candidates.tokens, acceptedMask, residualTokens, bonusToken)
 
 	draftIDs := candidates.tokens.Ints()
 	acceptedFlags := acceptedMask.Ints()
@@ -516,18 +524,16 @@ func (s *speculationSession) accept(position *int, current sampler.Result, candi
 		return results, accepted, nil
 	}
 
-	var nextToken *mlx.Array
-	if accepted == draftCount {
-		nextToken = r.sampleTokenAt(targetDist, draftCount)
+	var nextID int32
+	if accepted < draftCount {
+		nextID = int32(residualTokens.Ints()[accepted])
 	} else {
-		nextToken = r.sampleResidualToken(targetDist, draftDist, accepted)
+		nextID = int32(bonusToken.Int())
 	}
-	mlx.Eval(nextToken)
-	nextID := int32(nextToken.Int())
 	commitIDs = append(commitIDs, nextID)
 	r.Sampler.Commit(pipelineSlot, commitIDs)
 
-	results = append(results, sampler.Result{Token: nextToken})
+	results = append(results, sampler.Result{Token: mlx.FromValues([]int32{nextID}, 1)})
 	return results, accepted, nil
 }
 
@@ -540,11 +546,6 @@ func (r *Runner) sampleAcceptedMask(targetDist, draftDist sampler.Distribution, 
 
 func (r *Runner) sampleTokenAt(dist sampler.Distribution, index int) *mlx.Array {
 	return r.Sampler.SampleDistribution(pipelineSlot, dist.SliceRows(index, index+1))
-}
-
-func (r *Runner) sampleResidualToken(targetDist, draftDist sampler.Distribution, index int) *mlx.Array {
-	residual := targetDist.SliceRows(index, index+1).ResidualAgainst(draftDist.SliceRows(index, index+1))
-	return tokenVector(r.Sampler.SampleDistribution(pipelineSlot, residual))
 }
 
 // draftResults wraps accepted draft ids as sampler results; drafts carry no
@@ -567,16 +568,5 @@ func tokenInput(token *mlx.Array) *mlx.Array {
 		return token
 	default:
 		panic(fmt.Sprintf("token must be rank 0, 1, or 2, got rank %d", token.NumDims()))
-	}
-}
-
-func tokenVector(token *mlx.Array) *mlx.Array {
-	switch token.NumDims() {
-	case 0:
-		return token.Reshape(1)
-	case 1:
-		return token
-	default:
-		panic(fmt.Sprintf("sampled token must be rank 0 or 1, got rank %d", token.NumDims()))
 	}
 }

--- a/x/mlxrunner/speculate.go
+++ b/x/mlxrunner/speculate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -23,9 +24,17 @@ type drafter interface {
 
 	// committed reports a run of tokens committed to the target caches:
 	// tokens[i] sits at slot position+i and hiddens row i is the target
-	// hidden state at that slot. Runs arrive in slot order — the decode
-	// seed, then each round's validated tokens.
+	// hidden state at that slot. Runs arrive in slot order — prefill
+	// chunks, the decode seed, then each round's validated tokens.
 	committed(tokens, hiddens *mlx.Array, position int)
+
+	// finish reports generation ended with current sampled but never
+	// committed, so the drafter can settle state tracking the target caches.
+	finish(current *mlx.Array)
+
+	// flush writes any buffered committed reports through to the draft
+	// caches. A drafter without draft caches has nothing to write.
+	flush()
 
 	close()
 }
@@ -100,6 +109,15 @@ func positiveEnvInt(key string) int {
 type speculation struct {
 	r     *Runner
 	draft base.DraftModel
+
+	// caches is the whole persistent slice, passed to every forward; draftKV
+	// are the draft head's own caches and targets are the rest — the caches the
+	// target forward writes, which speculation snapshots and rollback cover.
+	// Bound the first time the caches exist (the Runner reuses one cache slice
+	// for its life) and stable thereafter.
+	caches  []cache.Cache
+	draftKV []cache.Cache
+	targets []cache.Cache
 }
 
 // newSpeculation builds the speculative-decoding subsystem for a loaded model,
@@ -111,41 +129,68 @@ func newSpeculation(r *Runner, draft base.DraftModel) *speculation {
 	return &speculation{r: r, draft: draft}
 }
 
+// bind computes the draft/target cache partition the first time the persistent
+// caches exist; later requests reuse the same slice, so it runs once.
+func (s *speculation) bind(caches []cache.Cache) {
+	if s.caches != nil {
+		if !slices.Equal(s.caches, caches) {
+			panic("speculation: cache slice changed between requests")
+		}
+		return
+	}
+	draftKV := s.draft.DraftCaches(caches)
+
+	// Partition caches into target slots (everything not in draftKV) in one
+	// pass. The count check rejects a draft slot that isn't a member of caches.
+	targets := make([]cache.Cache, 0, len(caches))
+	for _, c := range caches {
+		if !slices.Contains(draftKV, c) {
+			targets = append(targets, c)
+		}
+	}
+	if len(caches)-len(targets) != len(draftKV) {
+		panic("speculation: DraftCaches must select slots of the cache slice")
+	}
+
+	s.caches = caches
+	s.draftKV = draftKV
+	s.targets = targets
+}
+
 // speculationSession is the speculation cursor for one request over a speculation. A
 // nil speculationSession is a plain decode.
 type speculationSession struct {
 	spec    *speculation
 	drafter drafter
-	caches  []cache.Cache
+	// enabled selects speculative rounds; a maintain-only engine decodes
+	// plainly while streaming committed runs to keep draft KV prefix-cached.
+	enabled bool
 	opts    specOptions
 	limit   int // current draft length
 	stats   specStats
 }
 
-// open returns the speculation cursor for this request, or nil when the model
-// carries no draft head or the request cannot speculate. Logprobs are not yet
-// supported. A nil receiver (no draft head) decodes plainly.
+// open returns the speculation cursor for this request or nil when the model ships
+// no draft head (a nil receiver), which decodes plainly.
 func (s *speculation) open(request Request, caches []cache.Cache) *speculationSession {
 	if s == nil {
 		return nil
 	}
-	d := newMTPDrafter(s, caches)
+	s.bind(caches)
+	d := newMTPDrafter(s)
 	if d == nil {
 		return nil
 	}
+
 	opts := request.SamplerOpts
-	if !s.r.mtpDefaults(opts.Temperature != 0).Enabled {
-		return nil
-	}
-	if opts.Logprobs || opts.TopLogprobs > 0 {
-		return nil
-	}
+	enabled := s.r.mtpDefaults(opts.Temperature != 0).Enabled &&
+		!opts.Logprobs && opts.TopLogprobs == 0
 
 	specOpts := s.r.loadSpecOptions(opts.Temperature != 0)
 	return &speculationSession{
 		spec:    s,
 		drafter: d,
-		caches:  caches,
+		enabled: enabled,
 		opts:    specOpts,
 		limit:   specOpts.initialDraftTokens,
 		stats:   specStats{maxDraft: specOpts.initialDraftTokens},
@@ -157,6 +202,23 @@ func (s *speculationSession) committed(tokens, hiddens *mlx.Array, position int)
 		return
 	}
 	s.drafter.committed(tokens, hiddens, position)
+}
+
+// finish reports the end of generation to the drafter: current was sampled
+// after the last committed slot and will never be committed.
+func (s *speculationSession) finish(current *mlx.Array) {
+	if s == nil {
+		return
+	}
+	s.drafter.finish(current)
+}
+
+// flush writes the drafter's buffered committed reports to the draft caches.
+func (s *speculationSession) flush() {
+	if s == nil {
+		return
+	}
+	s.drafter.flush()
 }
 
 func (s *speculationSession) close() {
@@ -178,7 +240,13 @@ type speculativeDecoder struct {
 	current  sampler.Result // emitted (or the seed), not yet forwarded
 }
 
-func (s *speculationSession) decoder(seed []int32, position int) *speculativeDecoder {
+// decoder returns the decoder for this engine's session. A maintain-only
+// engine decodes plainly via the pipelined decoder, which reports every
+// forwarded token to keep draft KV level with the target.
+func (s *speculationSession) decoder(seed []int32, position int) decoder {
+	if !s.enabled {
+		return s.spec.r.pipelinedDecoder(s, s.spec.caches, seed, position)
+	}
 	current := sampler.Result{Token: mlx.FromValues(seed, len(seed))}
 	mlx.Pin(current.Arrays()...)
 	return &speculativeDecoder{s: s, position: position, current: current}
@@ -192,7 +260,7 @@ func (st *speculativeDecoder) next(remaining int) ([]sampler.Result, error) {
 		InputIDs:     tokenInput(st.current.Token),
 		SeqOffsets:   []int32{int32(st.position)},
 		SeqQueryLens: []int32{1},
-	}, s.caches)
+	}, s.spec.caches)
 	st.position++
 
 	results, next, err := s.round(&st.position, st.current, hidden, remaining)
@@ -212,6 +280,10 @@ func (st *speculativeDecoder) next(remaining int) ([]sampler.Result, error) {
 }
 
 func (st *speculativeDecoder) close() {
+	// Generation always ends with a final token that was emitted but never
+	// forwarded; its report lets the drafter settle level with the caches'
+	// resting offset.
+	st.s.finish(st.current.Token)
 	mlx.Unpin(st.current.Arrays()...)
 	st.s.logStats()
 }
@@ -368,7 +440,7 @@ func (s *speculationSession) accept(position *int, current sampler.Result, hidde
 	r := s.spec.r
 	before := *position
 	draftCount := candidates.tokens.Dim(1)
-	scheduleSpeculation(s.caches, before, draftCount)
+	scheduleSpeculation(s.spec.targets, before, draftCount)
 
 	// Every exit between schedule and commit must drain the snapshot
 	// schedule and roll the speculative writes back out of the live caches:
@@ -380,7 +452,7 @@ func (s *speculationSession) accept(position *int, current sampler.Result, hidde
 			return
 		}
 		committed = true
-		commitSpeculation(s.caches, keep, draftCount, before)
+		commitSpeculation(s.spec.targets, keep, draftCount, before)
 	}
 	defer commit(0)
 
@@ -388,7 +460,7 @@ func (s *speculationSession) accept(position *int, current sampler.Result, hidde
 		InputIDs:     candidates.tokens,
 		SeqOffsets:   []int32{int32(before)},
 		SeqQueryLens: []int32{int32(draftCount)},
-	}, s.caches)
+	}, s.spec.caches)
 
 	targetDist := r.Sampler.Distribution(pipelineSlot, validationLogits(r, baseLogits, hiddenSeq), candidates.tokens)
 	draftDist := candidates.dist
@@ -419,18 +491,24 @@ func (s *speculationSession) accept(position *int, current sampler.Result, hidde
 			break
 		}
 	}
+	// The final token of a generation is recorded and streamed but its KV
+	// is never committed: the caches rest at the trie frontier.
+	keep := accepted
+	if done {
+		keep--
+	}
+	commit(keep)
+	*position = before + keep
 
-	commit(accepted)
-	*position = before + accepted
-
-	// Report the validated run — current plus the accepted drafts, with the
+	// Report the validated run — current plus the kept drafts, with the
 	// hidden state at each token's own slot — to the drafter before
 	// returning, so even a cancelled emission leaves the drafter's state
-	// describing exactly what the target caches hold.
-	runIDs := append([]int32{int32(current.Token.Int())}, commitIDs...)
+	// describing exactly what the target caches hold. A done generation's
+	// final token is never committed; it reaches the drafter through finish.
+	runIDs := append([]int32{int32(current.Token.Int())}, commitIDs[:keep]...)
 	runHiddens := lastHiddenRow(hidden)
-	if accepted > 0 {
-		runHiddens = runHiddens.Concatenate(1, hiddenSeq.Slice(mlx.Slice(), mlx.Slice(0, accepted), mlx.Slice()))
+	if keep > 0 {
+		runHiddens = runHiddens.Concatenate(1, hiddenSeq.Slice(mlx.Slice(), mlx.Slice(0, keep), mlx.Slice()))
 	}
 	s.drafter.committed(mlx.FromValues(runIDs, 1, len(runIDs)), runHiddens, before-1)
 

--- a/x/mlxrunner/speculate.go
+++ b/x/mlxrunner/speculate.go
@@ -2,11 +2,8 @@ package mlxrunner
 
 import (
 	"fmt"
-	"log/slog"
-	"os"
 	"slices"
-	"strconv"
-	"strings"
+	"time"
 
 	"github.com/ollama/ollama/x/mlxrunner/batch"
 	"github.com/ollama/ollama/x/mlxrunner/cache"
@@ -39,73 +36,13 @@ type drafter interface {
 	close()
 }
 
-type draftSchedule string
-
-const (
-	draftScheduleHeuristic draftSchedule = "heuristic"
-	draftScheduleConstant  draftSchedule = "constant"
-)
-
-type specStats struct {
-	iterations  int
-	drafted     int
-	accepted    int
-	mismatches  int
-	allAccepted int
-	maxDraft    int
-}
-
-type specOptions struct {
-	initialDraftTokens int
-	maxDraftTokens     int
-	draftSchedule      draftSchedule
-}
-
-func (r *Runner) loadSpecOptions(sample bool) specOptions {
-	defaults := r.mtpDefaults(sample)
-
-	opts := specOptions{
-		initialDraftTokens: defaults.InitialDraftTokens,
-		maxDraftTokens:     defaults.MaxDraftTokens,
-		draftSchedule:      draftScheduleConstant,
-	}
-	if v := positiveEnvInt("OLLAMA_MLX_MTP_MAX_DRAFT_TOKENS"); v > 0 {
-		opts.maxDraftTokens = v
-	}
-	if v := positiveEnvInt("OLLAMA_MLX_MTP_INITIAL_DRAFT_TOKENS"); v > 0 {
-		opts.initialDraftTokens = v
-	}
-	if opts.initialDraftTokens > opts.maxDraftTokens {
-		opts.initialDraftTokens = opts.maxDraftTokens
-	}
-	switch schedule := strings.ToLower(strings.TrimSpace(os.Getenv("OLLAMA_MLX_MTP_DRAFT_SCHEDULE"))); schedule {
-	case "", string(draftScheduleConstant):
-		opts.draftSchedule = draftScheduleConstant
-	case string(draftScheduleHeuristic):
-		opts.draftSchedule = draftScheduleHeuristic
-	default:
-		slog.Warn("invalid MTP env setting", "key", "OLLAMA_MLX_MTP_DRAFT_SCHEDULE", "value", schedule)
-	}
-	return opts
-}
-
-func positiveEnvInt(key string) int {
-	raw := os.Getenv(key)
-	if raw == "" {
-		return 0
-	}
-	v, err := strconv.Atoi(raw)
-	if err != nil || v <= 0 {
-		slog.Warn("invalid MTP env setting", "key", key, "value", raw)
-		return 0
-	}
-	return v
-}
-
-// speculation is the persistent speculative-decoding subsystem of a Runner,
-// one per loaded model. It holds the draft model; as the feature grows it
-// also holds the cache partition and the depth state learned across requests.
-// A nil *speculation means the checkpoint ships no draft head.
+// speculation is the persistent speculative-decoding subsystem of a Runner —
+// one per loaded model, holding everything that outlives a request: the draft
+// model, the target-cache partition, and the depth state learned across
+// requests so each request starts at the proven-out depth. Each request opens a
+// short-lived speculationSession cursor over it; nothing here is rebuilt per request. A
+// nil *speculation means the checkpoint ships no draft head, so every request
+// decodes plainly.
 type speculation struct {
 	r     *Runner
 	draft base.DraftModel
@@ -118,6 +55,10 @@ type speculation struct {
 	caches  []cache.Cache
 	draftKV []cache.Cache
 	targets []cache.Cache
+
+	// depth selects each request's draft length and owns the cost/acceptance
+	// models and probe cadence it learns across requests.
+	depth *depthController
 }
 
 // newSpeculation builds the speculative-decoding subsystem for a loaded model,
@@ -126,7 +67,7 @@ func newSpeculation(r *Runner, draft base.DraftModel) *speculation {
 	if draft == nil {
 		return nil
 	}
-	return &speculation{r: r, draft: draft}
+	return &speculation{r: r, draft: draft, depth: newDepthController()}
 }
 
 // bind computes the draft/target cache partition the first time the persistent
@@ -157,17 +98,22 @@ func (s *speculation) bind(caches []cache.Cache) {
 	s.targets = targets
 }
 
-// speculationSession is the speculation cursor for one request over a speculation. A
-// nil speculationSession is a plain decode.
+// speculationSession is the per-request cursor over the persistent speculation:
+// it owns the drafter and runs the validate rounds. A nil session is a plain
+// decode.
 type speculationSession struct {
 	spec    *speculation
 	drafter drafter
-	// enabled selects speculative rounds; a maintain-only engine decodes
-	// plainly while streaming committed runs to keep draft KV prefix-cached.
-	enabled bool
-	opts    specOptions
-	limit   int // current draft length
+	enabled bool // whether this request drafts; false parks (maintain-only)
+	limit   int  // current draft length
 	stats   specStats
+
+	// Cost sampling: each round's wall time (start to next start, spanning the
+	// next emit's sync) is attributed to its draft depth only when the depth
+	// matches the previous round's, since batch-shape transitions inflate it.
+	lastRoundStart time.Time
+	prevDrafts     int
+	roundDrafts    int
 }
 
 // open returns the speculation cursor for this request or nil when the model ships
@@ -178,22 +124,49 @@ func (s *speculation) open(request Request, caches []cache.Cache) *speculationSe
 	}
 	s.bind(caches)
 	d := newMTPDrafter(s)
-	if d == nil {
-		return nil
-	}
 
+	// Logprobs are not yet supported, so a logprobs request keeps a speculationSession
+	// only to maintain a draft cache in lockstep (permanently parked).
 	opts := request.SamplerOpts
-	enabled := s.r.mtpDefaults(opts.Temperature != 0).Enabled &&
-		!opts.Logprobs && opts.TopLogprobs == 0
+	enabled := !opts.Logprobs && opts.TopLogprobs == 0
 
-	specOpts := s.r.loadSpecOptions(opts.Temperature != 0)
-	return &speculationSession{
-		spec:    s,
-		drafter: d,
-		enabled: enabled,
-		opts:    specOpts,
-		limit:   specOpts.initialDraftTokens,
-		stats:   specStats{maxDraft: specOpts.initialDraftTokens},
+	spec := &speculationSession{spec: s, drafter: d, enabled: enabled, prevDrafts: -1, roundDrafts: -1}
+	if enabled {
+		spec.limit = s.depth.scheduled
+		spec.stats.maxDraft = spec.limit
+	}
+	return spec
+}
+
+// beginRound records the previous round's cost sample (its wall time runs to
+// this round's start) and starts timing the new one.
+func (s *speculationSession) beginRound() {
+	now := time.Now()
+	if !s.lastRoundStart.IsZero() && s.roundDrafts >= 0 {
+		s.stats.recordRound(s.roundDrafts)
+		if s.roundDrafts == s.prevDrafts {
+			s.spec.depth.cost.observe(s.roundDrafts, now.Sub(s.lastRoundStart))
+		}
+		s.prevDrafts = s.roundDrafts
+	}
+	s.lastRoundStart = now
+}
+
+// endRound records a completed round's draft depth, proposal outcome, and the
+// controller's next draft length. observed is the leading draft positions the
+// acceptance model learns from: the full round, except an accepted EOS holds out
+// positions past it (a terminator, not a target rejection).
+func (s *speculationSession) endRound(drafted, accepted, observed int) {
+	s.roundDrafts = drafted
+	s.stats.iterations++
+	s.stats.drafted += drafted
+	s.stats.accepted += accepted
+	if s.enabled {
+		if observed > 0 {
+			s.spec.depth.acc.observe(observed, accepted)
+		}
+		s.limit = s.spec.depth.next()
+		s.stats.maxDraft = max(s.stats.maxDraft, s.limit)
 	}
 }
 
@@ -229,129 +202,114 @@ func (s *speculationSession) close() {
 }
 
 // speculativeDecoder decodes one speculative round per call: the engine
-// forwards the current token — emitted by the previous call, so a token
-// that ends generation is never forwarded — fused with the drafter's
-// proposals, and the call returns the round's accepted tokens followed by
-// the engine's next token. The last returned token becomes the next call's
-// current; the seed token primes current and is never returned.
+// forwards the current token (emitted by the previous call, so a token that
+// ends generation is never forwarded) fused with the drafter's proposals,
+// returning the round's accepted tokens followed by the next token. The seed
+// primes current and is never returned. While the engine cannot draft (parked
+// at depth zero, or nothing committed to propose from) calls delegate to an
+// inner pipelined decoder at plain decode speed.
 type speculativeDecoder struct {
 	s        *speculationSession
 	position int
-	current  sampler.Result // emitted (or the seed), not yet forwarded
+	current  sampler.Result    // emitted (or the seed), not yet forwarded
+	inner    *pipelinedDecoder // pipelines plain tokens while parked; nil while drafting
 }
 
-// decoder returns the decoder for this engine's session. A maintain-only
-// engine decodes plainly via the pipelined decoder, which reports every
-// forwarded token to keep draft KV level with the target.
+// decoder returns the decoder for this engine's session. A speculationSession that
+// cannot draft (logprobs) has no depth controller and permanently parks,
+// running the inner pipelined decoder whose reports keep the draft KV level.
 func (s *speculationSession) decoder(seed []int32, position int) decoder {
-	if !s.enabled {
-		return s.spec.r.pipelinedDecoder(s, s.spec.caches, seed, position)
-	}
 	current := sampler.Result{Token: mlx.FromValues(seed, len(seed))}
 	mlx.Pin(current.Arrays()...)
 	return &speculativeDecoder{s: s, position: position, current: current}
 }
 
 func (st *speculativeDecoder) next(remaining int) ([]sampler.Result, error) {
-	results, next, err := st.s.round(&st.position, st.current, remaining)
-	if err != nil {
-		return nil, err
-	}
-	if next.Token != nil {
-		results = append(results, next)
+	// Route: end a parked stretch by emitting the inner sample, draft on a
+	// positive length and a primed drafter, else decode parked.
+	var results []sampler.Result
+	if s := st.s; st.inner != nil && s.limit > 0 {
+		results = st.resume()
+	} else {
+		s.beginRound()
+		var candidates *draftCandidates
+		if s.limit > 0 {
+			// A round emits the accepted drafts plus one more token (the bonus
+			// or residual), so cap the draft one below the remaining budget to
+			// land that extra token within it rather than overshooting. At
+			// remaining 1 the cap is 0 and the last token decodes plainly.
+			candidates = s.drafter.propose(st.current.Token, min(s.limit, remaining-1))
+		}
+		var accepted, observed int
+		var err error
+		if candidates == nil {
+			results, err = st.park(remaining)
+		} else {
+			// candidates stays pinned across accept's internal sweep and the
+			// draft-count read below; accept pins only its own intermediates.
+			mlx.Pin(candidates.tokens)
+			defer mlx.Unpin(candidates.tokens)
+			results, accepted, observed, err = st.s.accept(&st.position, st.current, candidates)
+		}
+		if err != nil {
+			return nil, err
+		}
+		drafted := 0
+		if candidates != nil {
+			drafted = candidates.tokens.Dim(1)
+		}
+		s.endRound(drafted, accepted, observed)
 	}
 
-	last := results[len(results)-1]
-	mlx.Pin(last.Arrays()...)
-	mlx.Unpin(st.current.Arrays()...)
-	st.current = last
-	mlx.AsyncEval(st.current.Arrays()...)
+	st.advance(results[len(results)-1])
 	return results, nil
 }
 
+// advance retires the last returned token as the next call's current, pinned
+// across the sweeps the next call runs before reading it. Nothing is forced here.
+func (st *speculativeDecoder) advance(next sampler.Result) {
+	mlx.Pin(next.Arrays()...)
+	mlx.Unpin(st.current.Arrays()...)
+	st.current = next
+}
+
+// resume ends a parked stretch: the inner decoder's in-flight sample (sampled
+// but never forwarded) is exactly the current token a drafting round expects,
+// so emit it and let the next call draft from it.
+func (st *speculativeDecoder) resume() []sampler.Result {
+	next, position := st.inner.detach()
+	st.position = position
+	st.inner = nil
+	// No round spans this call, so the next beginRound attributes no cost.
+	st.s.roundDrafts = -1
+	// detach handed over the pin; advance re-pins, no sweep in between.
+	mlx.Unpin(next.Arrays()...)
+	return []sampler.Result{next}
+}
+
+// park decodes one pipelined plain token while the engine cannot draft. Each
+// is a depth-0 round in the controller's accounting, and the inner decoder's
+// reports keep the drafter primed and maintained.
+func (st *speculativeDecoder) park(remaining int) ([]sampler.Result, error) {
+	s := st.s
+	if st.inner == nil {
+		st.inner = s.spec.r.pipelinedDecoder(s, s.spec.caches, st.current.Token.ExpandDims(-1), st.position)
+	}
+	return st.inner.next(remaining)
+}
+
 func (st *speculativeDecoder) close() {
-	// Generation always ends with a final token that was emitted but never
-	// forwarded; its report lets the drafter settle level with the caches'
-	// resting offset.
-	st.s.finish(st.current.Token)
+	if st.inner != nil {
+		// Ended while parked: the inner decoder's close settles the drafter
+		// with its in-flight sample.
+		st.inner.close()
+	} else {
+		// The final token was emitted but never forwarded; its report settles
+		// the drafter level with the caches' resting offset.
+		st.s.finish(st.current.Token)
+	}
 	mlx.Unpin(st.current.Arrays()...)
 	st.s.logStats()
-}
-
-// round runs one speculative decode round: fuse the current token with the
-// drafter's proposals in one target forward, validate the proposals, and
-// return the accepted run and the bonus or resampled next token.
-func (s *speculationSession) round(position *int, current sampler.Result, remaining int) (results []sampler.Result, next sampler.Result, err error) {
-	r := s.spec.r
-	s.stats.iterations++
-
-	// A round emits the accepted drafts plus one more token (the bonus or
-	// residual), so cap the draft one below the remaining budget to land that
-	// extra token within it rather than overshooting. At remaining 1 the cap is
-	// 0 and the last token decodes plainly.
-	maxDraft := min(s.limit, remaining-1)
-	candidates := s.drafter.propose(current.Token, maxDraft)
-	if candidates == nil {
-		// Nothing to validate: a plain single-token round.
-		tok := tokenInput(current.Token)
-		hidden := r.Model.Forward(&batch.Batch{
-			InputIDs:     tok,
-			SeqOffsets:   []int32{int32(*position)},
-			SeqQueryLens: []int32{1},
-		}, s.spec.caches)
-		*position++
-		s.drafter.committed(tok, hidden, *position-1)
-		return nil, r.Sampler.Sample([]int{pipelineSlot}, lastLogits(r.Model.Unembed(hidden))), nil
-	}
-
-	draftCount := candidates.tokens.Dim(1)
-	candidateArrays := candidates.Arrays()
-	mlx.Pin(candidateArrays...)
-	mlx.Sweep()
-	defer mlx.Unpin(candidateArrays...)
-	s.stats.drafted += draftCount
-
-	results, accepted, err := s.accept(position, current, candidates)
-	if err != nil {
-		return nil, sampler.Result{}, err
-	}
-	// accept folds the bonus token into its results; surface it back out as
-	// the next step's current.
-	if len(results) > accepted {
-		next = results[len(results)-1]
-		results = results[:accepted]
-	}
-
-	s.stats.accepted += accepted
-	if accepted == draftCount {
-		s.stats.allAccepted++
-	} else {
-		s.stats.mismatches++
-	}
-	if s.opts.draftSchedule == draftScheduleHeuristic {
-		if accepted == draftCount {
-			s.limit = min(s.opts.maxDraftTokens, s.limit+2)
-		} else {
-			s.limit = max(1, s.limit-1)
-		}
-		s.stats.maxDraft = max(s.stats.maxDraft, s.limit)
-	}
-	return results, next, nil
-}
-
-// logStats reports the per-request speculation summary.
-func (s *speculationSession) logStats() {
-	acceptance := 0.0
-	if s.stats.drafted > 0 {
-		acceptance = float64(s.stats.accepted) / float64(s.stats.drafted)
-	}
-	avgDraft := 0.0
-	avgAccepted := 0.0
-	if s.stats.iterations > 0 {
-		avgDraft = float64(s.stats.drafted) / float64(s.stats.iterations)
-		avgAccepted = float64(s.stats.accepted) / float64(s.stats.iterations)
-	}
-	slog.Info("speculative decode stats", "drafted", s.stats.drafted, "accepted", s.stats.accepted, "acceptance", acceptance, "iterations", s.stats.iterations, "avg_draft", avgDraft, "avg_accepted", avgAccepted, "mismatches", s.stats.mismatches, "all_accepted", s.stats.allAccepted, "max_draft", s.stats.maxDraft, "draft_schedule", s.opts.draftSchedule)
 }
 
 // draftCandidates is one round's draft tokens and the proposal distribution
@@ -417,20 +375,18 @@ func commitSpeculation(caches []cache.Cache, accepted, draftCount, before int) {
 	}
 }
 
-// accept accepts the longest draft prefix that survives rejection sampling
-// against the target model. At temperature 0 the distributions are point
-// masses, so acceptance reduces to argmax-match. It returns the accepted
-// drafts followed by the target's own next token — the residual at the
-// rejection point, or the bonus past a fully accepted run — so a round
-// yields accepted+1 tokens, except when an accepted EOS ends generation,
-// where the run stops at the EOS with no continuation. The accepted run is
-// reported back to the drafter with its hidden states.
+// accept accepts the longest draft prefix that survives rejection sampling,
+// returning the accepted drafts followed by the target's own next token
+// (residual at a rejection, bonus past a full run), except an accepted EOS
+// ends the run with no continuation. observed is the leading positions the
+// acceptance model learns from, capped at the EOS (a terminator, not a target
+// rejection). NumPredict is the decode loop's to enforce, so a token past the
+// budget is left for decode to drop, not cut here.
 //
-// The NumPredict budget is the decode loop's to enforce; the drafter is
-// already capped to the remaining budget, so an accepted run never
-// overshoots, and a legitimate token past the budget is left for decode to
-// drop rather than cut here.
-func (s *speculationSession) accept(position *int, current sampler.Result, candidates *draftCandidates) (results []sampler.Result, accepted int, err error) {
+// The caller keeps current and the candidate tokens pinned across the call,
+// since accept sweeps before its eval and reads both afterward; accept pins
+// only the intermediates it produces.
+func (s *speculationSession) accept(position *int, current sampler.Result, candidates *draftCandidates) (results []sampler.Result, accepted, observed int, err error) {
 	r := s.spec.r
 	before := *position
 	draftCount := candidates.tokens.Dim(1)
@@ -471,6 +427,15 @@ func (s *speculationSession) accept(position *int, current sampler.Result, candi
 	// point is known.
 	residualTokens := r.Sampler.SampleDistribution(pipelineSlot, targetDist.SliceRows(0, draftCount).ResidualAgainst(draftDist))
 	bonusToken := r.sampleTokenAt(targetDist, draftCount)
+
+	// Pin the arrays read after the eval, then sweep so the draft proposal
+	// chain and this validation forward's intermediates are freed as the eval
+	// consumes them, the way the plain decode dispatch sweeps before its eval.
+	// current and the candidate tokens stay pinned by the caller across the call.
+	live := []*mlx.Array{hiddenSeq, acceptedMask, residualTokens, bonusToken}
+	mlx.Pin(live...)
+	defer mlx.Unpin(live...)
+	mlx.Sweep()
 	mlx.Eval(candidates.tokens, acceptedMask, residualTokens, bonusToken)
 
 	draftIDs := candidates.tokens.Ints()
@@ -482,11 +447,13 @@ func (s *speculationSession) accept(position *int, current sampler.Result, candi
 		accepted++
 	}
 	if accepted > draftCount {
-		return nil, 0, fmt.Errorf("speculation validation accepted %d tokens for %d draft tokens", accepted, draftCount)
+		return nil, 0, 0, fmt.Errorf("speculation validation accepted %d tokens for %d draft tokens", accepted, draftCount)
 	}
+	observed = draftCount
 
 	// Find where an accepted EOS ends the run, before committing, so the cut
-	// is known while the per-token rollback snapshots still exist.
+	// is known while the per-token rollback snapshots still exist. The EOS also
+	// caps observed: positions past it are held out, not logged as rejections.
 	commitIDs := make([]int32, 0, accepted+1)
 	keep := accepted
 	done := false
@@ -495,6 +462,7 @@ func (s *speculationSession) accept(position *int, current sampler.Result, candi
 		if r.Tokenizer.IsEOS(int32(id)) {
 			done = true
 			accepted = i + 1
+			observed = accepted
 			// Leave the EOS's own state uncommitted: the next sequence won't
 			// contain this EOS, and recurrent state can't drop a folded-in
 			// token, so committing it would carry the caches past the
@@ -507,11 +475,9 @@ func (s *speculationSession) accept(position *int, current sampler.Result, candi
 	commit(keep)
 	*position = before + 1 + keep
 
-	// Report the validated run — current plus the kept drafts, with the
-	// fused hidden state at each token's own slot — to the drafter before
-	// returning, so even a cancelled emission leaves the drafter's state
-	// describing exactly what the target caches hold. A done generation's
-	// final token is never committed; it reaches the drafter through finish.
+	// Report the validated run (current plus kept drafts) to the drafter before
+	// returning, so a cancelled emission still leaves it matching the caches. A
+	// done generation's final token is uncommitted; it reaches finish instead.
 	runIDs := append([]int32{int32(current.Token.Int())}, commitIDs[:keep]...)
 	s.drafter.committed(
 		mlx.FromValues(runIDs, 1, len(runIDs)),
@@ -521,7 +487,7 @@ func (s *speculationSession) accept(position *int, current sampler.Result, candi
 	results = draftResults(draftIDs[:accepted])
 	if done {
 		r.Sampler.Commit(pipelineSlot, commitIDs)
-		return results, accepted, nil
+		return results, accepted, observed, nil
 	}
 
 	var nextID int32
@@ -534,7 +500,7 @@ func (s *speculationSession) accept(position *int, current sampler.Result, candi
 	r.Sampler.Commit(pipelineSlot, commitIDs)
 
 	results = append(results, sampler.Result{Token: mlx.FromValues([]int32{nextID}, 1)})
-	return results, accepted, nil
+	return results, accepted, observed, nil
 }
 
 func (r *Runner) sampleAcceptedMask(targetDist, draftDist sampler.Distribution, draftTokens *mlx.Array) *mlx.Array {
@@ -556,17 +522,4 @@ func draftResults(ids []int) []sampler.Result {
 		results[i] = sampler.Result{Token: mlx.FromValues([]int32{int32(id)}, 1)}
 	}
 	return results
-}
-
-func tokenInput(token *mlx.Array) *mlx.Array {
-	switch token.NumDims() {
-	case 0:
-		return token.Reshape(1, 1)
-	case 1:
-		return token.ExpandDims(-1)
-	case 2:
-		return token
-	default:
-		panic(fmt.Sprintf("token must be rank 0, 1, or 2, got rank %d", token.NumDims()))
-	}
 }

--- a/x/mlxrunner/speculate.go
+++ b/x/mlxrunner/speculate.go
@@ -228,12 +228,12 @@ func (s *speculationSession) close() {
 	s.drafter.close()
 }
 
-// speculativeDecoder decodes one speculative round per call: it forwards
-// the current token — emitted by the previous call, so a token that ends
-// generation is never forwarded — has the engine draft and validate ahead
-// of it, and returns the round's accepted tokens followed by the engine's
-// next token. The last returned token becomes the next call's current; the
-// seed token primes current and is never returned.
+// speculativeDecoder decodes one speculative round per call: the engine
+// forwards the current token — emitted by the previous call, so a token
+// that ends generation is never forwarded — fused with the drafter's
+// proposals, and the call returns the round's accepted tokens followed by
+// the engine's next token. The last returned token becomes the next call's
+// current; the seed token primes current and is never returned.
 type speculativeDecoder struct {
 	s        *speculationSession
 	position int
@@ -253,17 +253,7 @@ func (s *speculationSession) decoder(seed []int32, position int) decoder {
 }
 
 func (st *speculativeDecoder) next(remaining int) ([]sampler.Result, error) {
-	s := st.s
-	r := s.spec.r
-
-	hidden := r.Model.Forward(&batch.Batch{
-		InputIDs:     tokenInput(st.current.Token),
-		SeqOffsets:   []int32{int32(st.position)},
-		SeqQueryLens: []int32{1},
-	}, s.spec.caches)
-	st.position++
-
-	results, next, err := s.round(&st.position, st.current, hidden, remaining)
+	results, next, err := st.s.round(&st.position, st.current, remaining)
 	if err != nil {
 		return nil, err
 	}
@@ -288,11 +278,10 @@ func (st *speculativeDecoder) close() {
 	st.s.logStats()
 }
 
-// round runs one speculative decode round for the just-forwarded current
-// token and its hidden state: draft candidates after it, validate them
-// against the target, and return the accepted run and the bonus or
-// resampled next token.
-func (s *speculationSession) round(position *int, current sampler.Result, hidden *mlx.Array, remaining int) (results []sampler.Result, next sampler.Result, err error) {
+// round runs one speculative decode round: fuse the current token with the
+// drafter's proposals in one target forward, validate the proposals, and
+// return the accepted run and the bonus or resampled next token.
+func (s *speculationSession) round(position *int, current sampler.Result, remaining int) (results []sampler.Result, next sampler.Result, err error) {
 	r := s.spec.r
 	s.stats.iterations++
 
@@ -302,22 +291,27 @@ func (s *speculationSession) round(position *int, current sampler.Result, hidden
 	// 0 and the last token decodes plainly.
 	maxDraft := min(s.limit, remaining-1)
 	candidates := s.drafter.propose(current.Token, maxDraft)
-	baseLogits := lastLogits(r.Model.Unembed(hidden))
 	if candidates == nil {
-		s.drafter.committed(tokenInput(current.Token), lastHiddenRow(hidden), *position-1)
-		return nil, r.Sampler.Sample([]int{pipelineSlot}, baseLogits), nil
+		// Nothing to validate: a plain single-token round.
+		tok := tokenInput(current.Token)
+		hidden := r.Model.Forward(&batch.Batch{
+			InputIDs:     tok,
+			SeqOffsets:   []int32{int32(*position)},
+			SeqQueryLens: []int32{1},
+		}, s.spec.caches)
+		*position++
+		s.drafter.committed(tok, hidden, *position-1)
+		return nil, r.Sampler.Sample([]int{pipelineSlot}, lastLogits(r.Model.Unembed(hidden))), nil
 	}
 
 	draftCount := candidates.tokens.Dim(1)
-	// hidden survives the sweep alongside the candidates: the post-accept
-	// report fuses it into the committed stream.
-	candidateArrays := append([]*mlx.Array{baseLogits, hidden}, candidates.Arrays()...)
+	candidateArrays := candidates.Arrays()
 	mlx.Pin(candidateArrays...)
 	mlx.Sweep()
 	defer mlx.Unpin(candidateArrays...)
 	s.stats.drafted += draftCount
 
-	results, accepted, err := s.accept(position, current, hidden, baseLogits, candidates)
+	results, accepted, err := s.accept(position, current, candidates)
 	if err != nil {
 		return nil, sampler.Result{}, err
 	}
@@ -436,11 +430,11 @@ func commitSpeculation(caches []cache.Cache, accepted, draftCount, before int) {
 // already capped to the remaining budget, so an accepted run never
 // overshoots, and a legitimate token past the budget is left for decode to
 // drop rather than cut here.
-func (s *speculationSession) accept(position *int, current sampler.Result, hidden, baseLogits *mlx.Array, candidates *draftCandidates) (results []sampler.Result, accepted int, err error) {
+func (s *speculationSession) accept(position *int, current sampler.Result, candidates *draftCandidates) (results []sampler.Result, accepted int, err error) {
 	r := s.spec.r
 	before := *position
 	draftCount := candidates.tokens.Dim(1)
-	scheduleSpeculation(s.spec.targets, before, draftCount)
+	scheduleSpeculation(s.spec.targets, before+1, draftCount)
 
 	// Every exit between schedule and commit must drain the snapshot
 	// schedule and roll the speculative writes back out of the live caches:
@@ -452,17 +446,21 @@ func (s *speculationSession) accept(position *int, current sampler.Result, hidde
 			return
 		}
 		committed = true
-		commitSpeculation(s.spec.targets, keep, draftCount, before)
+		commitSpeculation(s.spec.targets, keep, draftCount, before+1)
 	}
 	defer commit(0)
 
 	hiddenSeq := r.Model.Forward(&batch.Batch{
-		InputIDs:     candidates.tokens,
+		InputIDs:     current.Token.ExpandDims(-1).Concatenate(1, candidates.tokens),
 		SeqOffsets:   []int32{int32(before)},
-		SeqQueryLens: []int32{int32(draftCount)},
+		SeqQueryLens: []int32{int32(draftCount + 1)},
 	}, s.spec.caches)
 
-	targetDist := r.Sampler.Distribution(pipelineSlot, validationLogits(r, baseLogits, hiddenSeq), candidates.tokens)
+	// Row i of the fused hidden is the state after the token at before+i, so
+	// the rows already line up with the drafts: row 0 (current's state)
+	// predicts draft 0, and the row after the last accepted draft is the
+	// bonus row. No separate base-logits forward exists on this path.
+	targetDist := r.Sampler.Distribution(pipelineSlot, r.Model.Unembed(hiddenSeq), candidates.tokens)
 	draftDist := candidates.dist
 	acceptedMask := r.sampleAcceptedMask(targetDist.SliceRows(0, draftCount), draftDist, candidates.tokens)
 	mlx.Eval(candidates.tokens, acceptedMask)
@@ -482,35 +480,35 @@ func (s *speculationSession) accept(position *int, current sampler.Result, hidde
 	// Find where an accepted EOS ends the run, before committing, so the cut
 	// is known while the per-token rollback snapshots still exist.
 	commitIDs := make([]int32, 0, accepted+1)
+	keep := accepted
 	done := false
 	for i, id := range draftIDs[:accepted] {
 		commitIDs = append(commitIDs, int32(id))
 		if r.Tokenizer.IsEOS(int32(id)) {
 			done = true
 			accepted = i + 1
+			// Leave the EOS's own state uncommitted: the next sequence won't
+			// contain this EOS, and recurrent state can't drop a folded-in
+			// token, so committing it would carry the caches past the
+			// reusable prefix and force the next sequence to recompute.
+			keep = i
 			break
 		}
 	}
-	// The final token of a generation is recorded and streamed but its KV
-	// is never committed: the caches rest at the trie frontier.
-	keep := accepted
-	if done {
-		keep--
-	}
+
 	commit(keep)
-	*position = before + keep
+	*position = before + 1 + keep
 
 	// Report the validated run — current plus the kept drafts, with the
-	// hidden state at each token's own slot — to the drafter before
+	// fused hidden state at each token's own slot — to the drafter before
 	// returning, so even a cancelled emission leaves the drafter's state
 	// describing exactly what the target caches hold. A done generation's
 	// final token is never committed; it reaches the drafter through finish.
 	runIDs := append([]int32{int32(current.Token.Int())}, commitIDs[:keep]...)
-	runHiddens := lastHiddenRow(hidden)
-	if keep > 0 {
-		runHiddens = runHiddens.Concatenate(1, hiddenSeq.Slice(mlx.Slice(), mlx.Slice(0, keep), mlx.Slice()))
-	}
-	s.drafter.committed(mlx.FromValues(runIDs, 1, len(runIDs)), runHiddens, before-1)
+	s.drafter.committed(
+		mlx.FromValues(runIDs, 1, len(runIDs)),
+		hiddenSeq.Slice(mlx.Slice(), mlx.Slice(0, len(runIDs)), mlx.Slice()),
+		before)
 
 	results = draftResults(draftIDs[:accepted])
 	if done {
@@ -531,13 +529,6 @@ func (s *speculationSession) accept(position *int, current sampler.Result, hidde
 
 	results = append(results, sampler.Result{Token: nextToken})
 	return results, accepted, nil
-}
-
-// validationLogits stacks the current token's logits ahead of the draft
-// positions' logits so row i scores draft i.
-func validationLogits(r *Runner, baseLogits, hiddenSeq *mlx.Array) *mlx.Array {
-	seqLogits := r.Model.Unembed(hiddenSeq)
-	return baseLogits.ExpandDims(1).Concatenate(1, seqLogits)
 }
 
 func (r *Runner) sampleAcceptedMask(targetDist, draftDist sampler.Distribution, draftTokens *mlx.Array) *mlx.Array {

--- a/x/mlxrunner/speculate_depth.go
+++ b/x/mlxrunner/speculate_depth.go
@@ -1,0 +1,302 @@
+package mlxrunner
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+)
+
+// depthProbeInterval is the base cadence at which the controller drafts one past its
+// selection to refresh the next position up; without it a shallow controller never
+// notices a deeper draft becoming worthwhile.
+const depthProbeInterval = 4
+
+// depthProbeIntervalMax caps the probe backoff. Probes that keep changing nothing
+// double the interval up to this cap, trading slower re-engagement — worst case
+// plain decode speed, never below — for fewer probes.
+const depthProbeIntervalMax = 512
+
+// depthController drafts argmax_N EV(N) where EV(N) = committed(N) / cost(N), over
+// depths from 0 (plain decode) up to one past the frontier. The depth-0 floor lets
+// it stop speculating when no draft pays; the frontier ceiling keeps it from scoring
+// a depth on the optimistic inherited rate, so it climbs outward one position at a
+// time as acceptance is measured rather than leaping deep.
+//
+// It holds the depth-selection state learned across requests — the target forward's
+// per-depth cost curve, the drafts' per-position acceptance rates, the probe cadence,
+// and the depth scheduled for the next round — persisted on the speculation so a fresh
+// request starts at the proven-out depth instead of re-ramping from shallow.
+type depthController struct {
+	cost   *costModel
+	acc    *acceptanceModel
+	probed bool // the previous round drafted a probe
+
+	// scheduled is the draft depth next() chose for the upcoming round, carried
+	// across requests so a new request's first round consumes it instead of
+	// recomputing at the boundary. Its zero value is the depth-0 warmup start.
+	scheduled int
+
+	// Probe cadence, persisted so a backed-off request need not restart at the base.
+	probeInterval int // rounds between probes; backs off while probes change nothing
+	probeSince    int // rounds since the cadence was last calibrated
+	lastSelected  int // the selection the cadence was calibrated against
+}
+
+func newDepthController() *depthController {
+	return &depthController{cost: newCostModel(), acc: newAcceptanceModel(), probeInterval: depthProbeInterval}
+}
+
+func (c *depthController) frontier() int { return c.acc.frontier() }
+
+// next returns the draft depth for the upcoming step: the EV-optimal depth (capped
+// at frontier+1), except periodically it probes one past the selection to refresh
+// the next position up. The probe stays within the frontier window. The cadence
+// doubles toward its cap while probes change nothing and resets on any selection
+// change, giving the new selection a full interval to settle. The chosen depth is
+// recorded in c.scheduled for the next request's open to consume.
+func (c *depthController) next() (depth int) {
+	defer func() { c.scheduled = depth }()
+	sel := c.selected()
+	if sel != c.lastSelected {
+		c.probeInterval = depthProbeInterval
+		c.probeSince = 0
+		c.lastSelected = sel
+	} else if c.probed {
+		c.probeInterval = min(c.probeInterval*2, depthProbeIntervalMax)
+	}
+	c.probed = false
+
+	c.probeSince++
+	if c.probeSince >= c.probeInterval {
+		c.probeSince = 0
+		if probe := min(sel+1, c.frontier()+1); probe != sel {
+			c.probed = true
+			return probe
+		}
+	}
+	// Seed a clean cost sample for every depth in [0, frontier+1] before judging by
+	// EV. Cost is only recorded when a round's draft depth matches the prior round's
+	// (the same-depth gate dropping batch-shape transitions), so a depth never dwelt
+	// at has no clean sample; draft the shallowest such depth to dwell there. Without
+	// this the controller stays at the one depth it can sit at without a transition
+	// (depth 0) and never learns that drafting pays on a deep-optimum model.
+	if seed := c.costSeedDepth(); seed >= 0 {
+		return seed
+	}
+	return sel
+}
+
+// costSeedDepth is the shallowest depth in [0, frontier+1] with no clean
+// cost sample, or -1 if all are sampled; bounding to frontier+1 keeps cost-seeding
+// from outrunning the acceptance frontier.
+func (c *depthController) costSeedDepth() int {
+	limit := c.frontier() + 1
+	for n := 0; n <= limit; n++ {
+		if !c.cost.sampled(n) {
+			return n
+		}
+	}
+	return -1
+}
+
+// selected returns the EV-optimal draft depth without mutating probe state, the
+// argmax over [0, frontier+1]. The frontier bound keeps the inherited optimistic
+// rate from making ever-deeper depths look best; the depth-0 floor lets it stop
+// speculating. Returns 0 until the cost model can compare depths.
+func (c *depthController) selected() int {
+	if !c.cost.ready() {
+		return 0
+	}
+	limit := c.frontier() + 1
+	best, bestEV := 0, c.acc.expectedCommitted(0)/c.cost.cost(0)
+	for n := 1; n <= limit; n++ {
+		if ev := c.acc.expectedCommitted(n) / c.cost.cost(n); ev > bestEV {
+			best, bestEV = n, ev
+		}
+	}
+	return best
+}
+
+// costEWMAAlpha weights the newest cost sample. Fixed-depth cost is low-variance,
+// so a responsive alpha converges in a few visits while smoothing scheduler jitter.
+const costEWMAAlpha = 0.3
+
+// costModel is the target-forward cost for validating N drafts — a fused batch of
+// 1 current token plus N drafts — as an EWMA per visited draft depth read by
+// piecewise-linear interpolation between samples (flat beyond the extremes).
+// Interpolation assumes no curve shape, so a steep compute-bound or flat
+// bandwidth-bound forward is represented as measured. Cost is static within a run,
+// learned from decode steps that already sync the forward, so there is no startup
+// probe.
+type costModel struct {
+	ewma   map[int]float64 // EWMA of measured ms by draft depth
+	depths []int           // sampled draft depths, sorted; updated as new depths arrive
+}
+
+func newCostModel() *costModel {
+	return &costModel{ewma: map[int]float64{}}
+}
+
+// costClampFraction bounds one sample's EWMA innovation. A host stall (cache trim,
+// backpressure) can inflate a sample severalfold; unclamped it can flip the EV
+// comparison against plain decode, and once the controller stops parking it stops
+// resampling depth 0, so the error never heals. A genuine cost change still
+// converges because every sample keeps pushing toward it.
+const costClampFraction = 0.25
+
+// observe folds one forward's wall time into the draft depth's EWMA, clamping the
+// innovation so one stall-inflated sample cannot move it far.
+func (m *costModel) observe(drafts int, dt time.Duration) {
+	if drafts < 0 || dt <= 0 {
+		return
+	}
+	ms := float64(dt) / float64(time.Millisecond)
+	if v, ok := m.ewma[drafts]; ok {
+		limit := costClampFraction * v
+		m.ewma[drafts] = v + costEWMAAlpha*max(-limit, min(limit, ms-v))
+	} else {
+		m.ewma[drafts] = ms
+		i, _ := slices.BinarySearch(m.depths, drafts)
+		m.depths = slices.Insert(m.depths, i, drafts)
+	}
+}
+
+// ready reports whether two distinct depths have been sampled, so a slope exists.
+func (m *costModel) ready() bool { return len(m.ewma) >= 2 }
+
+func (m *costModel) sampled(drafts int) bool {
+	_, ok := m.ewma[drafts]
+	return ok
+}
+
+// cost returns the estimated forward wall time (ms) for validating drafts tokens:
+// a piecewise-linear interpolation of the per-depth EWMAs, clamping to the nearest
+// sample outside the sampled range (the curve beyond is unknown).
+func (m *costModel) cost(drafts int) float64 {
+	ds := m.depths
+	if len(ds) == 0 {
+		return 0
+	}
+	if drafts <= ds[0] {
+		return m.ewma[ds[0]]
+	}
+	if drafts >= ds[len(ds)-1] {
+		return m.ewma[ds[len(ds)-1]]
+	}
+	for i := 1; i < len(ds); i++ {
+		if drafts <= ds[i] {
+			lo, hi := ds[i-1], ds[i]
+			t := float64(drafts-lo) / float64(hi-lo)
+			return m.ewma[lo] + t*(m.ewma[hi]-m.ewma[lo])
+		}
+	}
+	return m.ewma[ds[len(ds)-1]]
+}
+
+// sampleString reports the EWMA ms per visited draft depth for diagnostics.
+func (m *costModel) sampleString() string {
+	ds := m.depths
+	parts := make([]string, 0, len(ds))
+	for _, d := range ds {
+		parts = append(parts, fmt.Sprintf("%d:%.0fms", d, m.ewma[d]))
+	}
+	return strings.Join(parts, " ")
+}
+
+// acceptanceEWMAAlpha weights the newest acceptance outcome. Acceptance drifts with
+// content, so an EWMA follows the drift instead of being anchored by early tokens.
+const acceptanceEWMAAlpha = 0.1
+
+// acceptanceMinSamples is how many reaches a position needs before its rate is
+// trusted; since the search reaches one past the frontier, it also gates how fast
+// the frontier advances. Set near the EWMA's memory (~1/alpha); larger only slows
+// the ramp, since each depth is re-measured as it is drafted.
+const acceptanceMinSamples = 10
+
+// acceptanceModel learns the per-position conditional acceptance rate — the chance
+// position i is accepted given every draft before it already was — as an EWMA, shared
+// across requests so a fresh request keeps the proven-out frontier. Drift is handled
+// by the EWMA forgetting, not by discarding the estimate.
+type acceptanceModel struct {
+	rate []float64 // EWMA acceptance rate given the prefix survived; index i is position i
+	seen []int     // times position i was reached (warmup gate for rate)
+}
+
+func newAcceptanceModel() *acceptanceModel {
+	return &acceptanceModel{rate: []float64{0}, seen: []int{0}}
+}
+
+func (a *acceptanceModel) grow(i int) {
+	for len(a.seen) <= i {
+		a.rate = append(a.rate, 0)
+		a.seen = append(a.seen, 0)
+	}
+}
+
+// observe folds a step's outcome into each reached position's EWMA. A position is
+// reached only when the prefix before it survived (accepted >= i-1), and is accepted
+// iff accepted >= i; updating only the surviving prefix avoids diluting deeper
+// positions the step never reached.
+func (a *acceptanceModel) observe(drafted, accepted int) {
+	for i := 1; i <= drafted; i++ {
+		if accepted < i-1 {
+			break // prefix did not survive to position i; deeper positions unreached
+		}
+		a.grow(i)
+		outcome := 0.0
+		if accepted >= i {
+			outcome = 1.0
+		}
+		if a.seen[i] == 0 {
+			a.rate[i] = outcome
+		} else {
+			a.rate[i] += acceptanceEWMAAlpha * (outcome - a.rate[i])
+		}
+		a.seen[i]++
+	}
+}
+
+// acceptance returns the rate position i is accepted given its prefix survived. An under-sampled
+// position inherits the deepest trusted rate rather than zero, so the controller
+// keeps exploring deeper instead of locking shallow on noise.
+func (a *acceptanceModel) acceptance(i int) float64 {
+	if i >= 1 && i < len(a.seen) && a.seen[i] >= acceptanceMinSamples {
+		return a.rate[i]
+	}
+	// Inherit the deepest trusted rate; fall back to optimistic 1 if none yet.
+	for j := i - 1; j >= 1; j-- {
+		if j < len(a.seen) && a.seen[j] >= acceptanceMinSamples {
+			return a.rate[j]
+		}
+	}
+	return 1
+}
+
+// expectedCommitted returns expected committed tokens at depth N: the current token,
+// which always commits, plus the expected number of accepted drafts — each draft
+// position contributes the probability its whole prefix was accepted, the running
+// product of the per-position acceptance rates summed over positions.
+func (a *acceptanceModel) expectedCommitted(n int) float64 {
+	total, prod := 1.0, 1.0
+	for k := 1; k <= n; k++ {
+		prod *= a.acceptance(k)
+		total += prod
+	}
+	return total
+}
+
+// frontier is the deepest position with a trusted acceptance rate. The controller
+// never selects beyond frontier+1, so the selection grows outward one position at a
+// time instead of jumping deep on the inherited optimistic rate.
+func (a *acceptanceModel) frontier() int {
+	f := 0
+	for i := 1; i < len(a.seen); i++ {
+		if a.seen[i] >= acceptanceMinSamples {
+			f = i
+		} else {
+			break
+		}
+	}
+	return f
+}

--- a/x/mlxrunner/speculate_depth_test.go
+++ b/x/mlxrunner/speculate_depth_test.go
@@ -1,0 +1,298 @@
+package mlxrunner
+
+import (
+	"testing"
+	"time"
+)
+
+// driveDepthController runs the controller for n steps against a regime mirroring
+// the real loop: next() picks a draft depth D; the regime reports the forward time
+// at fused width D+1, fed to the cost model keyed by draft depth D, and how many of
+// the D drafts are accepted as a prefix (fed to the controller's acceptance
+// estimator). It returns the depth the controller selects after the run. draw(pos,
+// step) is the per-position acceptance outcome; a draft of length D accepts the
+// leading run of positions whose draws succeed.
+func driveDepthController(c *depthController, n int, fwdMS func(width int) float64, draw func(pos, step int) bool) int {
+	for step := range n {
+		d := c.next()
+		c.cost.observe(d, time.Duration(fwdMS(d+1)*float64(time.Millisecond)))
+		accepted := 0
+		for i := 1; i <= d; i++ {
+			if draw(i, step) {
+				accepted++
+			} else {
+				break
+			}
+		}
+		c.acc.observe(d, accepted)
+	}
+	return c.selected()
+}
+
+// deterministicDraw turns a per-position acceptance rate into a reproducible,
+// independent Bernoulli accept/reject per (pos, step). It uses a splitmix64-style
+// avalanche so adjacent positions and steps decorrelate — a plain linear hash leaves
+// the prefix acceptance correlated across positions and biases the recovered rates.
+func deterministicDraw(acceptance func(pos int) float64) func(pos, step int) bool {
+	return func(pos, step int) bool {
+		x := uint64(step)*0x9E3779B97F4A7C15 + uint64(pos)*0xD1B54A32D192ED03
+		x ^= x >> 30
+		x *= 0xBF58476D1CE4E5B9
+		x ^= x >> 27
+		x *= 0x94D049BB133111EB
+		x ^= x >> 31
+		frac := float64(x%1_000_000) / 1_000_000.0
+		return frac < acceptance(pos)
+	}
+}
+
+// Per-position acceptance rates (probability draft position i is accepted given the
+// prefix survived), defined directly as valid probabilities that decay with depth —
+// the model property both quants share. bf16 and nvfp4 use the same acceptance curve;
+// only their cost curves differ, which is what shifts the optimum. The expected
+// accepted prefix at depth N is Σ_{k<=N} ∏_{i<=k} a_i, which decays as the product
+// shrinks, matching the measured diminishing returns.
+func decayAcceptance(pos int) float64 {
+	rates := []float64{0, 0.90, 0.82, 0.72, 0.60, 0.48, 0.40, 0.34, 0.30, 0.27, 0.25, 0.23, 0.22, 0.21, 0.20, 0.20, 0.20}
+	if pos < 1 || pos >= len(rates) {
+		return 0.18
+	}
+	return rates[pos]
+}
+
+func bf16Acceptance(pos int) float64  { return decayAcceptance(pos) }
+func nvfp4Acceptance(pos int) float64 { return decayAcceptance(pos) }
+
+// bandwidthBoundCost models a near-flat forward (deep optimum); computeBoundCost a
+// steep one (shallow optimum). width = 1 + drafts.
+func bandwidthBoundCost(width int) float64 { return 210.0 + 2.6*float64(width) }
+func computeBoundCost(width int) float64   { return 30.0 + 19.0*float64(width) }
+
+func TestDepthControllerSelectsDeepWhenForwardFlat(t *testing.T) {
+	c := newDepthController()
+	selected := driveDepthController(c, 600, bandwidthBoundCost, deterministicDraw(bf16Acceptance))
+	// A near-flat forward makes extra width nearly free, so committed/cost keeps
+	// rising until acceptance saturates: the EV peak sits deep (~6 for this curve).
+	if selected < 5 {
+		t.Errorf("expected a deep selection on a near-flat-cost forward, got %d", selected)
+	}
+}
+
+func TestDepthControllerSelectsShallowWhenForwardSteep(t *testing.T) {
+	c := newDepthController()
+	selected := driveDepthController(c, 600, computeBoundCost, deterministicDraw(nvfp4Acceptance))
+	// A steep forward makes each extra validated token expensive, so committed/cost
+	// peaks shallow.
+	if selected > 4 {
+		t.Errorf("expected a shallow selection on a steep-cost forward, got %d", selected)
+	}
+}
+
+func TestDepthControllerSelectsZeroWhenDraftNotWorthIt(t *testing.T) {
+	c := newDepthController()
+	cost := c.cost
+	// A steep forward (each extra column ~19ms over a 30ms base) paired with poor
+	// acceptance: even the first draft is accepted under half the time. One draft
+	// costs cost(1)/cost(0) = 49/30 = 1.63x the plain step but commits only
+	// 1 + 0.4 = 1.4 tokens, so plain decode (depth 0) wins. The controller must be able
+	// to stop speculating, not be floored at drafting one token.
+	poor := func(int) float64 { return 0.4 }
+	selected := driveDepthController(c, 600, computeBoundCost, deterministicDraw(poor))
+	if selected != 0 {
+		t.Errorf("expected depth 0 (plain decode) when no draft pays for itself, got %d", selected)
+	}
+	// The depth-0 (plain-decode) cost must actually have been measured, or depth 0 was
+	// chosen on a phantom cost rather than a real comparison.
+	if !cost.sampled(0) {
+		t.Error("depth-0 cost was never sampled, so depth 0 was not a real EV comparison")
+	}
+}
+
+func TestDepthControllerExploresBeforeCostReady(t *testing.T) {
+	c := newDepthController()
+	cost := c.cost
+	// Before any cost data, warmup walks the floor upward from depth 0 to seed depths
+	// from the shallowest end — never jumping deep. The first draft is 0 (depth-0,
+	// plain-decode cost); once that depth is recorded the next is 1. Those are the two
+	// depths the controller first compares at.
+	first := c.next()
+	if cost.ready() {
+		t.Fatal("cost model should not be ready before any observation")
+	}
+	if first != 0 {
+		t.Errorf("first warmup draft = %d, want 0 (depth-0 cost first, never deep)", first)
+	}
+	cost.observe(first, 24*time.Millisecond)
+	second := c.next()
+	if second != 1 {
+		t.Errorf("second warmup draft = %d, want 1 (depth-1 cost next)", second)
+	}
+	// After two distinct depths are observed the model becomes usable.
+	cost.observe(second, 31*time.Millisecond)
+	if !cost.ready() {
+		t.Error("cost model should be ready after two distinct depths")
+	}
+}
+
+func TestDepthControllerClimbsOutwardWithinFrontier(t *testing.T) {
+	// The bug this guards: on a near-flat-cost forward the inherited optimistic
+	// acceptance (1 for unmeasured positions) makes deep depths look best, so an
+	// unbounded argmax jumps straight to a deep depth and drafts a dozen tokens that are
+	// almost all rejected. The frontier bound forbids drafting beyond one past the
+	// deepest position with trusted data, so the depth can only climb outward as
+	// fast as acceptance is actually measured. Assert that invariant holds at every
+	// step, even with always-accept (the most deep-favoring case) and flat cost.
+	c := newDepthController()
+	cost := c.cost
+	always := func(int) float64 { return 1.0 }
+	draw := deterministicDraw(always)
+	for step := range 400 {
+		d := c.next()
+		if d > c.frontier()+1 {
+			t.Fatalf("step %d drafted depth %d, want <= frontier+1 = %d", step, d, c.frontier()+1)
+		}
+		cost.observe(d, time.Duration(bandwidthBoundCost(d+1)*float64(time.Millisecond)))
+		accepted := 0
+		for i := 1; i <= d; i++ {
+			if draw(i, step) {
+				accepted++
+			} else {
+				break
+			}
+		}
+		c.acc.observe(d, accepted)
+	}
+}
+
+func TestCostModelBoundsSingleSampleInfluence(t *testing.T) {
+	m := newCostModel()
+	for range 20 {
+		m.observe(0, 16*time.Millisecond)
+	}
+	base := m.cost(0)
+	// One stall-inflated sample may move the estimate by at most alpha times
+	// the clamp fraction.
+	m.observe(0, 49*time.Millisecond)
+	if bound := base * (1 + costEWMAAlpha*costClampFraction) * 1.001; m.cost(0) > bound {
+		t.Errorf("one outlier moved cost(0) from %.2fms to %.2fms, beyond the clamp bound %.2fms", base, m.cost(0), bound)
+	}
+	// A genuine cost change is rate-limited, not rejected: repeated samples at
+	// the new level must converge to it.
+	for range 60 {
+		m.observe(0, 32*time.Millisecond)
+	}
+	if got := m.cost(0); got < 31 || got > 33 {
+		t.Errorf("estimate did not converge to a persistent cost change: got %.2fms, want ~32ms", got)
+	}
+}
+
+func TestDepthControllerStaysParkedThroughHostStall(t *testing.T) {
+	c := newDepthController()
+	cost := c.cost
+	// A regime where plain decode wins (steep width cost, mediocre acceptance):
+	// the controller settles parked at depth 0.
+	steep := func(width int) float64 { return 16.0 + 15.0*float64(width-1) }
+	mediocre := func(int) float64 { return 0.6 }
+	if selected := driveDepthController(c, 600, steep, deterministicDraw(mediocre)); selected != 0 {
+		t.Fatalf("expected the controller to park at depth 0, got %d", selected)
+	}
+	// A host stall between two parked rounds lands in a single depth-0 cost
+	// sample at ~3x the real round time. Its influence must stay bounded so the
+	// parked baseline remains credible and the controller does not start
+	// drafting against a phantom plain-decode cost.
+	cost.observe(0, 49*time.Millisecond)
+	if selected := c.selected(); selected != 0 {
+		t.Errorf("a single stall-inflated depth-0 sample un-parked the controller: selected %d with cost(0)=%.1fms", selected, cost.cost(0))
+	}
+}
+
+// driveCountingProbes is driveDepthController with a count of the rounds that
+// drafted (the parked regime's probes).
+func driveCountingProbes(c *depthController, n int, fwdMS func(width int) float64, draw func(pos, step int) bool) int {
+	probes := 0
+	for step := range n {
+		d := c.next()
+		if d > 0 {
+			probes++
+		}
+		c.cost.observe(d, time.Duration(fwdMS(d+1)*float64(time.Millisecond)))
+		accepted := 0
+		for i := 1; i <= d; i++ {
+			if draw(i, step) {
+				accepted++
+			} else {
+				break
+			}
+		}
+		c.acc.observe(d, accepted)
+	}
+	return probes
+}
+
+func TestDepthControllerProbeBackoff(t *testing.T) {
+	c := newDepthController()
+	// A regime where plain decode wins: the controller parks and its probes
+	// keep changing nothing, so the cadence must back off to the cap and the
+	// probe count over a long stretch must follow the doubling series, not the
+	// base cadence.
+	steep := func(width int) float64 { return 16.0 + 15.0*float64(width-1) }
+	mediocre := deterministicDraw(func(int) float64 { return 0.6 })
+	driveDepthController(c, 600, steep, mediocre)
+	if c.selected() != 0 {
+		t.Fatalf("expected the controller to park at depth 0, got %d", c.selected())
+	}
+	probes := driveCountingProbes(c, 4096, steep, mediocre)
+	if c.probeInterval != depthProbeIntervalMax {
+		t.Errorf("probe interval = %d, want backed off to %d", c.probeInterval, depthProbeIntervalMax)
+	}
+	if probes > 10 {
+		t.Errorf("%d probes in 4096 parked rounds, want the backed-off handful", probes)
+	}
+
+	// The cadence is the controller's own persistent state, so a fresh stretch
+	// starts at the backed-off interval: a stretch shorter than it never probes.
+	c.probeSince = 0
+	if probes := driveCountingProbes(c, 400, steep, mediocre); probes != 0 {
+		t.Errorf("%d probes within the first backed-off interval, want 0", probes)
+	}
+
+	// When drafting turns worthwhile — cheap wide forwards and high acceptance —
+	// the probes eventually pay off, and the selection change must snap the
+	// cadence back to the base interval.
+	flat := func(width int) float64 { return 16.0 + 0.5*float64(width-1) }
+	good := deterministicDraw(func(int) float64 { return 0.95 })
+	if selected := driveDepthController(c, 8192, flat, good); selected == 0 {
+		t.Fatal("controller never re-engaged after the regime turned draft-favorable")
+	}
+	if c.probeInterval != depthProbeInterval {
+		t.Errorf("probe interval = %d after the selection changed, want reset to %d", c.probeInterval, depthProbeInterval)
+	}
+}
+
+func TestDepthControllerTracksAcceptanceDrift(t *testing.T) {
+	c := newDepthController()
+	// Flat cost throughout, so depth is governed by acceptance alone. First phase:
+	// deep acceptance is poor, so the optimum is shallow. Second phase: acceptance
+	// stays high deep, so the optimum moves deeper. The EWMA acceptance rate must follow the
+	// shift — a cumulative all-time mean would stay anchored to the first phase.
+	shallowFavoring := func(pos int) float64 {
+		if pos <= 2 {
+			return 0.9
+		}
+		return 0.2 // deep rarely accepted
+	}
+	deepFavoring := func(int) float64 { return 0.95 } // deep readily accepted
+	driveDepthController(c, 400, bandwidthBoundCost, deterministicDraw(shallowFavoring))
+	shallow := c.selected()
+	if shallow > 4 {
+		t.Fatalf("expected shallow selection while deep acceptance is poor, got %d", shallow)
+	}
+	// The probe cadence backed off while phase-one probes changed nothing, so
+	// recovery runs at backed-off probe spacing until the first selection
+	// change snaps it back — the drive must span several backed-off intervals.
+	driveDepthController(c, 4096, bandwidthBoundCost, deterministicDraw(deepFavoring))
+	deep := c.selected()
+	if deep <= shallow {
+		t.Errorf("expected selection to deepen after acceptance rose (was %d, now %d)", shallow, deep)
+	}
+}

--- a/x/mlxrunner/speculate_stats.go
+++ b/x/mlxrunner/speculate_stats.go
@@ -1,0 +1,84 @@
+package mlxrunner
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+)
+
+type specStats struct {
+	iterations int
+	drafted    int
+	accepted   int
+	maxDraft   int
+	// chosen is the draft depth picked each round, in order; split into time
+	// buckets it distinguishes a ramp that holds from one that thrashes shallow.
+	chosen []int
+}
+
+func (s *specStats) recordRound(depth int) {
+	if !slog.Default().Enabled(context.TODO(), slog.LevelDebug) {
+		return
+	}
+	s.chosen = append(s.chosen, depth)
+}
+
+// depthBuckets is how many equal time slices depthOverTime splits a run into.
+const depthBuckets = 8
+
+// depthOverTime reports per-bucket mean/max chosen depth across up to depthBuckets
+// equal time buckets, e.g. "0.3/1 2.1/3 4.8/5 5.0/6".
+func (s *specStats) depthOverTime() string {
+	if len(s.chosen) == 0 {
+		return ""
+	}
+	buckets := min(depthBuckets, len(s.chosen))
+	parts := make([]string, 0, buckets)
+	for b := range buckets {
+		lo := b * len(s.chosen) / buckets
+		hi := (b + 1) * len(s.chosen) / buckets
+		sum, mx := 0, 0
+		for _, d := range s.chosen[lo:hi] {
+			sum += d
+			mx = max(mx, d)
+		}
+		parts = append(parts, fmt.Sprintf("%.1f/%d", float64(sum)/float64(hi-lo), mx))
+	}
+	return strings.Join(parts, " ")
+}
+
+func (s *speculationSession) logStats() {
+	if !s.enabled || !slog.Default().Enabled(context.TODO(), slog.LevelDebug) {
+		return
+	}
+	acceptance := 0.0
+	if s.stats.drafted > 0 {
+		acceptance = float64(s.stats.accepted) / float64(s.stats.drafted)
+	}
+	avgDraft := 0.0
+	avgAccepted := 0.0
+	if s.stats.iterations > 0 {
+		avgDraft = float64(s.stats.drafted) / float64(s.stats.iterations)
+		avgAccepted = float64(s.stats.accepted) / float64(s.stats.iterations)
+	}
+	slog.Debug("speculative decode stats", "iterations", s.stats.iterations, "drafted", s.stats.drafted, "accepted", s.stats.accepted, "acceptance", fmt.Sprintf("%.2f", acceptance), "avg_draft", fmt.Sprintf("%.2f", avgDraft), "max_draft", s.stats.maxDraft, "avg_accepted", fmt.Sprintf("%.2f", avgAccepted), "depth_over_time", s.stats.depthOverTime())
+
+	// Log learned acceptance over the trusted positions [1, frontier] and
+	// expected throughput over the searched window [0, frontier+1]; deeper
+	// depths have no data of their own.
+	d := s.spec.depth
+	frontier := d.frontier()
+	rates := make([]string, 0, frontier)
+	for n := 1; n <= frontier; n++ {
+		rates = append(rates, fmt.Sprintf("%d:%.2f", n, d.acc.acceptance(n)))
+	}
+	limit := frontier + 1
+	tps := make([]string, 0, limit+1)
+	if d.cost.ready() {
+		for n := 0; n <= limit; n++ {
+			tps = append(tps, fmt.Sprintf("%d:%.1f", n, 1000*d.acc.expectedCommitted(n)/d.cost.cost(n)))
+		}
+	}
+	slog.Debug("speculation depth controller", "cost", d.cost.sampleString(), "acceptance", strings.Join(rates, " "), "expected_tps", strings.Join(tps, " "), "probe_interval", d.probeInterval)
+}

--- a/x/models/gemma4/assistant.go
+++ b/x/models/gemma4/assistant.go
@@ -12,10 +12,7 @@ import (
 	"github.com/ollama/ollama/x/models/nn"
 )
 
-var (
-	_ base.DraftModel    = (*AssistantModel)(nil)
-	_ base.MTPDraftModel = (*AssistantModel)(nil)
-)
+var _ base.DraftModel = (*AssistantModel)(nil)
 
 type AssistantConfig struct {
 	TextConfig               TextConfig `json:"text_config"`
@@ -36,6 +33,10 @@ type AssistantModel struct {
 	Norm           *nn.RMSNorm
 
 	NormScaled *mlx.Array
+
+	// target supplies the scaled token embeddings the MTP head fuses with
+	// the target hidden state.
+	target *Model
 
 	*AssistantConfig
 	tensorPrefix string
@@ -145,6 +146,7 @@ func newAssistantModel(root *model.Root, target base.Model) (base.DraftModel, er
 	m := &AssistantModel{
 		AssistantConfig: &cfg,
 		tensorPrefix:    tensorPrefix,
+		target:          targetGemma,
 		Layers:          make([]*AssistantLayer, cfg.TextConfig.NumHiddenLayers),
 		TensorQuant:     root.AllTensorQuant(),
 	}
@@ -267,26 +269,42 @@ func (m *AssistantModel) precomputeScaledWeights() {
 	}
 }
 
-func (m *AssistantModel) Draft(inputsEmbeds *mlx.Array, position int32, caches []cache.Cache) (logits, hidden *mlx.Array) {
+// DraftCaches returns nil: the assistant keeps no KV and re-attends the
+// target's caches read-only each step.
+func (m *AssistantModel) DraftCaches([]cache.Cache) []cache.Cache { return nil }
+
+// Draft is single-position: the head drafts every token as if it sat at the
+// last target-seen position, so it anchors RoPE and the mask there — from the
+// non-moving target full-attention cache — regardless of the advancing offset
+// in b. The input fuses the target's scaled token embedding with b.Hidden.
+func (m *AssistantModel) Draft(b *batch.Batch, caches []cache.Cache) (hidden, projected *mlx.Array) {
+	inputsEmbeds := m.target.TokenEmbeddings(b.InputIDs).Concatenate(-1, b.Hidden)
 	dims := inputsEmbeds.Dims()
 	B, L := int32(dims[0]), int32(dims[1])
-	b := &batch.Batch{
+
+	anchor := int32(0)
+	if len(caches) > 0 {
+		if full := caches[len(caches)-1]; full != nil {
+			anchor = int32(full.Offset() - 1)
+		}
+	}
+	ab := &batch.Batch{
 		InputIDs:     mlx.Zeros(mlx.DTypeInt32, int(B), int(L)),
-		SeqOffsets:   []int32{position},
+		SeqOffsets:   []int32{anchor},
 		SeqQueryLens: []int32{L},
 	}
 
-	sliding, full := m.sharedHistories(b, caches)
+	sliding, full := m.sharedHistories(ab, caches)
 	h := m.PreProjection.Forward(inputsEmbeds)
 
-	positions := mlx.FromValues([]int32{position}, 1)
+	positions := mlx.FromValues([]int32{anchor}, 1)
 	for _, layer := range m.Layers {
-		h = layer.Forward(h, b, positions, B, L, &m.TextConfig, sliding, full)
+		h = layer.Forward(h, ab, positions, B, L, &m.TextConfig, sliding, full)
 	}
 
 	hidden = mlx.RMSNormFn(h, m.NormScaled, m.TextConfig.RMSNormEps)
-	projected := m.PostProjection.Forward(hidden)
-	return m.unembed(hidden), projected
+	projected = m.PostProjection.Forward(hidden)
+	return hidden, projected
 }
 
 func (m *AssistantModel) sharedHistories(b *batch.Batch, caches []cache.Cache) (sliding, full *nn.KVHistory) {
@@ -302,7 +320,7 @@ func (m *AssistantModel) sharedHistories(b *batch.Batch, caches []cache.Cache) (
 	return sliding, full
 }
 
-func (m *AssistantModel) unembed(hidden *mlx.Array) *mlx.Array {
+func (m *AssistantModel) Unembed(hidden *mlx.Array) *mlx.Array {
 	if m.UseOrderedEmbeddings {
 		return m.applyCentroidMasking(hidden)
 	}

--- a/x/models/gemma4/gemma4.go
+++ b/x/models/gemma4/gemma4.go
@@ -28,10 +28,7 @@ func init() {
 }
 
 // Compile-time interface checks.
-var (
-	_ base.Model               = (*Model)(nil)
-	_ base.MTPDefaultsProvider = (*Model)(nil)
-)
+var _ base.Model = (*Model)(nil)
 
 // RopeParams holds per-layer-type RoPE settings.
 type RopeParams struct {
@@ -487,24 +484,6 @@ func parseSuppressTokens(configData []byte) []int32 {
 
 func (m *Model) EnableCompile() bool {
 	return true
-}
-
-func (m *Model) MTPDraftDefaults(_ bool) base.MTPDefaults {
-	defaults := base.MTPDefaults{
-		InitialDraftTokens: 4,
-		MaxDraftTokens:     16,
-		Enabled:            true,
-	}
-	if m == nil || m.TextConfig == nil {
-		return defaults
-	}
-	switch {
-	case !m.EnableMoeBlock && m.HiddenSize == 5376 && m.NumHiddenLayers == 60:
-		defaults.InitialDraftTokens = 14
-	case m.EnableMoeBlock && m.HiddenSize == 2816 && m.NumHiddenLayers == 30:
-		defaults.InitialDraftTokens = 8
-	}
-	return defaults
 }
 
 func resolveWeightPrefix(tensors map[string]*mlx.Array) string {

--- a/x/models/gemma4/gemma4_test.go
+++ b/x/models/gemma4/gemma4_test.go
@@ -561,54 +561,6 @@ func TestLayerTypeDetection(t *testing.T) {
 	}
 }
 
-func TestMTPDraftDefaults(t *testing.T) {
-	tests := []struct {
-		name        string
-		cfg         *TextConfig
-		wantInitial int
-		wantMax     int
-	}{
-		{
-			name:        "nil config",
-			wantInitial: 4,
-			wantMax:     16,
-		},
-		{
-			name:        "31b bf16",
-			cfg:         &TextConfig{HiddenSize: 5376, NumHiddenLayers: 60},
-			wantInitial: 14,
-			wantMax:     16,
-		},
-		{
-			name:        "31b quantized",
-			cfg:         &TextConfig{HiddenSize: 5376, NumHiddenLayers: 60, QuantBits: 4},
-			wantInitial: 14,
-			wantMax:     16,
-		},
-		{
-			name:        "26b-a4b moe",
-			cfg:         &TextConfig{HiddenSize: 2816, NumHiddenLayers: 30, EnableMoeBlock: true},
-			wantInitial: 8,
-			wantMax:     16,
-		},
-		{
-			name:        "generic default",
-			cfg:         &TextConfig{HiddenSize: 2560, NumHiddenLayers: 42, HiddenSizePerLayer: 256},
-			wantInitial: 4,
-			wantMax:     16,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := (&Model{TextConfig: tt.cfg}).MTPDraftDefaults(false)
-			if got.InitialDraftTokens != tt.wantInitial || got.MaxDraftTokens != tt.wantMax || !got.Enabled {
-				t.Fatalf("MTPDraftDefaults() = %+v, want initial=%d max=%d enabled=true", got, tt.wantInitial, tt.wantMax)
-			}
-		})
-	}
-}
-
 func TestNewCachesOmitsSharedKVLayers(t *testing.T) {
 	m := &Model{
 		Layers: []*DecoderLayer{


### PR DESCRIPTION
MTP previously drafted a fixed number of tokens per round — a constant by default, or an opt-in heuristic that grew toward a cap on acceptance. Neither targeted throughput: a constant depth couldn't adapt to the target, and the heuristic maximized accepted tokens per step, so on a steep forward curve it kept drafting deeper while tokens per second fell, ending up slower than plain decode.

This replaces both with a controller that picks the draft length to maximize committed tokens per second, from measured per-position acceptance and forward cost. It backs off to plain decode when no draft pays and persists across requests, so each one starts at the proven-out depth instead of re-ramping from shallow.

This change also:

- **Unifies the decode paths.** Greedy, sampled, and serial paths and per-model draft branches collapse into one engine and a single drafter interface that every draft head implements.
- **Cuts per-step overhead.** Two costs that capped speculation's benefit go away: the current token and its draft validation share one target forward, and each round resolves in one host sync instead of two.
- **Adds draft-cache infrastructure for Qwen3.6 MTP.** A draft head can maintain its own KV caches, prefix-cached across requests, instead of reusing the target's.

The `OLLAMA_MLX_MTP_*` environment variables are removed along with the old schedule.