### PR TITLE
fix(install): honor OLLAMA_INSTALL_DIR/OLLAMA_BIN_DIR env vars

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -156,10 +156,26 @@ download_and_extract() {
         $SUDO tar -xzf - -C "${dest_dir}"
 }
 
-for BINDIR in /usr/local/bin /usr/bin /bin; do
-    echo $PATH | grep -q $BINDIR && break || continue
-done
-OLLAMA_INSTALL_DIR=$(dirname ${BINDIR})
+# Allow overriding the install location via OLLAMA_INSTALL_DIR
+# (which sets the lib path) and OLLAMA_BIN_DIR (which sets the
+# symlink target). This lets users on systems where they lack
+# write access to /usr/local/bin or /usr/bin install ollama into
+# a user-owned prefix (e.g. ~/.local) without having to patch the
+# install script. SUDO is set below based on the effective uid,
+# not based on the destination directory, so this also fixes
+# installs on corporate machines without sudo (issue #16783).
+if [ -n "${OLLAMA_INSTALL_DIR:-}" ]; then
+    OLLAMA_INSTALL_DIR="${OLLAMA_INSTALL_DIR%/}"
+    BINDIR="${OLLAMA_BIN_DIR:-$OLLAMA_INSTALL_DIR/bin}"
+elif [ -n "${OLLAMA_BIN_DIR:-}" ]; then
+    BINDIR="${OLLAMA_BIN_DIR%/}"
+    OLLAMA_INSTALL_DIR=$(dirname "${BINDIR}")
+else
+    for BINDIR in /usr/local/bin /usr/bin /bin; do
+        echo $PATH | grep -q $BINDIR && break || continue
+    done
+    OLLAMA_INSTALL_DIR=$(dirname ${BINDIR})
+fi
 
 if [ -d "$OLLAMA_INSTALL_DIR/lib/ollama" ] ; then
     status "Cleaning up old version at $OLLAMA_INSTALL_DIR/lib/ollama"


### PR DESCRIPTION
The `install.sh` script hard-codes `/usr/local/bin` and `/usr/bin` as the binary destination. Users on systems where they lack write access to either (corporate machines, locked-down CI runners, shared hosts, etc.) cannot install ollama without manually patching the script. Even after replacing `/usr/local` with the desired prefix, the script still tried to write to `/usr/bin` in some code paths.

Allow overriding the install location via two new env vars:

- `OLLAMA_INSTALL_DIR` sets the lib path (where the ollama binary and its bundled libraries are unpacked).
- `OLLAMA_BIN_DIR` sets the symlink target. Defaults to `$OLLAMA_INSTALL_DIR/bin` if only `OLLAMA_INSTALL_DIR` is set.

When neither env var is set, the existing PATH-based discovery is preserved, so this is fully backwards compatible.

Example:
```
OLLAMA_INSTALL_DIR=$HOME/.local sh install.sh
```

Fixes #16783