### PR TITLE
app/tools: time out tool execution

### DIFF
--- a/app/tools/tools.go
+++ b/app/tools/tools.go
@@ -6,7 +6,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 )
+
+const defaultToolTimeout = 60 * time.Second
 
 // Tool defines the interface that all tools must implement
 type Tool interface {
@@ -28,14 +31,16 @@ type Tool interface {
 
 // Registry manages the available tools and their execution
 type Registry struct {
-	tools      map[string]Tool
-	workingDir string // Working directory for all tool operations
+	tools       map[string]Tool
+	workingDir  string // Working directory for all tool operations
+	toolTimeout time.Duration
 }
 
 // NewRegistry creates a new tool registry with no tools
 func NewRegistry() *Registry {
 	return &Registry{
-		tools: make(map[string]Tool),
+		tools:       make(map[string]Tool),
+		toolTimeout: defaultToolTimeout,
 	}
 }
 
@@ -71,11 +76,33 @@ func (r *Registry) Execute(ctx context.Context, name string, args map[string]any
 		return nil, "", fmt.Errorf("unknown tool: %s", name)
 	}
 
-	result, text, err := tool.Execute(ctx, args)
-	if err != nil {
-		return nil, "", err
+	if r.toolTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, r.toolTimeout)
+		defer cancel()
 	}
-	return result, text, nil
+
+	type toolResult struct {
+		result any
+		text   string
+		err    error
+	}
+
+	done := make(chan toolResult, 1)
+	go func() {
+		result, text, err := tool.Execute(ctx, args)
+		done <- toolResult{result: result, text: text, err: err}
+	}()
+
+	select {
+	case result := <-done:
+		if result.err != nil {
+			return nil, "", result.err
+		}
+		return result.result, result.text, nil
+	case <-ctx.Done():
+		return nil, "", ctx.Err()
+	}
 }
 
 // ToolCall represents a request to execute a tool

--- a/app/tools/tools_test.go
+++ b/app/tools/tools_test.go
@@ -1,0 +1,112 @@
+//go:build windows || darwin
+
+package tools
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+var errMissingToolDeadline = errors.New("tool context has no deadline")
+
+type deadlineCapturingTool struct {
+	deadline time.Time
+}
+
+func (d *deadlineCapturingTool) Name() string {
+	return "deadline_capture"
+}
+
+func (d *deadlineCapturingTool) Description() string {
+	return "captures the execution context deadline"
+}
+
+func (d *deadlineCapturingTool) Schema() map[string]any {
+	return map[string]any{}
+}
+
+func (d *deadlineCapturingTool) Execute(ctx context.Context, args map[string]any) (any, string, error) {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return nil, "", errMissingToolDeadline
+	}
+	d.deadline = deadline
+	return nil, "", nil
+}
+
+func (d *deadlineCapturingTool) Prompt() string {
+	return ""
+}
+
+func TestRegistryExecuteAddsDefaultToolDeadline(t *testing.T) {
+	registry := NewRegistry()
+	tool := &deadlineCapturingTool{}
+	registry.Register(tool)
+
+	start := time.Now()
+	if _, _, err := registry.Execute(context.Background(), tool.Name(), nil); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if tool.deadline.IsZero() {
+		t.Fatal("Execute() did not set a tool deadline")
+	}
+
+	if got := tool.deadline.Sub(start); got <= 0 || got > 61*time.Second {
+		t.Fatalf("tool deadline = %v after start, want within default timeout", got)
+	}
+}
+
+type blockingTool struct {
+	release chan struct{}
+}
+
+func (b *blockingTool) Name() string {
+	return "blocking"
+}
+
+func (b *blockingTool) Description() string {
+	return "blocks until released"
+}
+
+func (b *blockingTool) Schema() map[string]any {
+	return map[string]any{}
+}
+
+func (b *blockingTool) Execute(ctx context.Context, args map[string]any) (any, string, error) {
+	<-b.release
+	return nil, "", nil
+}
+
+func (b *blockingTool) Prompt() string {
+	return ""
+}
+
+func TestRegistryExecuteReturnsWhenContextDeadlineExpires(t *testing.T) {
+	registry := NewRegistry()
+	tool := &blockingTool{release: make(chan struct{})}
+	registry.Register(tool)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	errc := make(chan error, 1)
+	go func() {
+		_, _, err := registry.Execute(ctx, tool.Name(), nil)
+		errc <- err
+	}()
+
+	select {
+	case err := <-errc:
+		close(tool.release)
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("Execute() error = %v, want %v", err, context.DeadlineExceeded)
+		}
+	case <-time.After(200 * time.Millisecond):
+		close(tool.release)
+		err := <-errc
+		t.Fatalf("Execute() blocked until the tool returned, err = %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- add a 60s default timeout around app tool registry execution
- return the context deadline/cancel error to the chat loop when a tool call hangs
- cover both default deadline propagation and a blocking tool that ignores context cancellation

Addresses #16813.

## Tests

- `go test ./app/tools -run 'TestRegistryExecute(AddsDefaultToolDeadline|ReturnsWhenContextDeadlineExpires)' -count=1 -v`
- `go test ./app/tools -count=1`
- `(cd app/ui/app && npm ci && npm run build)`
- `go test ./app/ui -count=1`
- `go test ./app/cmd/app ./app/store ./app/server -count=1`
- `go test ./app/... -count=1`
- `go test ./app/updater -run TestAutoUpdateDisabledSkipsDownload -count=1 -v`
- `go test ./app/updater -count=1`

`go test ./... -count=1` was also run; all other packages passed, but the full run failed once in `app/updater` with `TempDir RemoveAll cleanup: ... directory not empty`. The failing updater test and package both passed when rerun separately.
