### PR TITLE
Add CapyBro to Community Integrations (Productivity & Apps)

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ console.log(response.message.content);
 - [Serene Pub](https://github.com/doolijb/serene-pub) - AI roleplaying app
 - [Mayan EDMS](https://gitlab.com/mayan-edms/mayan-edms) - Document management with Ollama workflows
 - [TagSpaces](https://www.tagspaces.org) - File management with [AI tagging](https://docs.tagspaces.org/ai/)
+- [CapyBro](https://github.com/phantasmat2018/capy-bro) - Rewrite, fix, and translate selected text in any Windows app via a hotkey, using a local Ollama model
 
 ### Observability & Monitoring
 


### PR DESCRIPTION
Adds **CapyBro** under Community Integrations → Productivity & Apps.

CapyBro is a free, open-source (MIT) Windows tray app. You select text in any application, press a hotkey, and it rewrites / fixes grammar / translates the selection in place. **Ollama is one of its two backends** — in Ollama mode everything runs fully locally and the selected text never leaves the machine. Native .NET 8 / WPF (not Electron), ~48 MB, per-user install, no admin.

Repo: https://github.com/phantasmat2018/capy-bro

I appended the entry to the end of the Productivity & Apps list, following the existing one-line format.
