### PR TITLE
openai: pass through chat truncate option

### DIFF
--- a/docs/api/openai-compatibility.mdx
+++ b/docs/api/openai-compatibility.mdx
@@ -208,6 +208,7 @@ curl -X POST http://localhost:11434/v1/chat/completions \
 - [x] `top_p`
 - [x] `max_tokens`
 - [x] `tools`
+- [x] `truncate` (Ollama extension)
 - [x] `reasoning_effort` (`"high"`, `"medium"`, `"low"`, `"none"`)
 - [x] `reasoning`
   - [x] `effort` (`"high"`, `"medium"`, `"low"`, `"none"`)

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -113,6 +113,7 @@ type ChatCompletionRequest struct {
 	ReasoningEffort  *string         `json:"reasoning_effort,omitempty"`
 	Logprobs         *bool           `json:"logprobs"`
 	TopLogprobs      int             `json:"top_logprobs"`
+	Truncate         *bool           `json:"truncate,omitempty"`
 	DebugRenderOnly  bool            `json:"_debug_render_only"`
 }
 
@@ -658,6 +659,7 @@ func FromChatRequest(r ChatCompletionRequest) (*api.ChatRequest, error) {
 		Think:           think,
 		Logprobs:        r.Logprobs != nil && *r.Logprobs,
 		TopLogprobs:     r.TopLogprobs,
+		Truncate:        r.Truncate,
 		DebugRenderOnly: r.DebugRenderOnly,
 	}, nil
 }

--- a/openai/openai_test.go
+++ b/openai/openai_test.go
@@ -55,6 +55,47 @@ func TestFromChatRequest_Basic(t *testing.T) {
 	}
 }
 
+func TestFromChatRequest_Truncate(t *testing.T) {
+	tests := []struct {
+		name     string
+		truncate *bool
+	}{
+		{name: "unset", truncate: nil},
+		{name: "true", truncate: func() *bool { v := true; return &v }()},
+		{name: "false", truncate: func() *bool { v := false; return &v }()},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := ChatCompletionRequest{
+				Model: "test-model",
+				Messages: []Message{
+					{Role: "user", Content: "Hello"},
+				},
+				Truncate: tt.truncate,
+			}
+
+			result, err := FromChatRequest(req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tt.truncate == nil {
+				if result.Truncate != nil {
+					t.Fatalf("expected truncate to stay unset, got %v", *result.Truncate)
+				}
+				return
+			}
+			if result.Truncate == nil {
+				t.Fatalf("expected truncate to be set")
+			}
+			if *result.Truncate != *tt.truncate {
+				t.Fatalf("expected truncate %v, got %v", *tt.truncate, *result.Truncate)
+			}
+		})
+	}
+}
+
 func TestFromChatRequest_ReasoningEffort(t *testing.T) {
 	effort := func(s string) *string { return &s }
 


### PR DESCRIPTION
## Summary

- accept the Ollama-specific `truncate` field on OpenAI chat completion requests
- pass the value through to the native `api.ChatRequest` conversion instead of dropping it
- document `truncate` as an Ollama extension for `/v1/chat/completions`

This addresses the OpenAI compatibility endpoint gap discussed in #16800. The native `/api/chat` endpoint already supports `truncate`; this keeps the compatibility adapter aligned with that behavior without changing the default when the field is omitted.

## Tests

- `go test ./openai`
- `git diff --check`