### PR TITLE
openai: forward num_ctx to options in OpenAI-compatible endpoints

### DIFF
--- a/openai/openai.go
+++ b/openai/openai.go
@@ -113,6 +113,7 @@ type ChatCompletionRequest struct {
 	ReasoningEffort  *string         `json:"reasoning_effort,omitempty"`
 	Logprobs         *bool           `json:"logprobs"`
 	TopLogprobs      int             `json:"top_logprobs"`
+	NumCtx           *int            `json:"num_ctx,omitempty"`
 	DebugRenderOnly  bool            `json:"_debug_render_only"`
 }
 
@@ -152,6 +153,7 @@ type CompletionRequest struct {
 	TopP             float32        `json:"top_p"`
 	Suffix           string         `json:"suffix"`
 	Logprobs         *int           `json:"logprobs"`
+	NumCtx           *int           `json:"num_ctx,omitempty"`
 	DebugRenderOnly  bool           `json:"_debug_render_only"`
 }
 
@@ -614,6 +616,10 @@ func FromChatRequest(r ChatCompletionRequest) (*api.ChatRequest, error) {
 		options["top_p"] = 1.0
 	}
 
+	if r.NumCtx != nil {
+		options["num_ctx"] = *r.NumCtx
+	}
+
 	var format json.RawMessage
 	if r.ResponseFormat != nil {
 		switch strings.ToLower(strings.TrimSpace(r.ResponseFormat.Type)) {
@@ -765,6 +771,10 @@ func FromCompleteRequest(r CompletionRequest) (api.GenerateRequest, error) {
 		options["top_p"] = r.TopP
 	} else {
 		options["top_p"] = 1.0
+	}
+
+	if r.NumCtx != nil {
+		options["num_ctx"] = *r.NumCtx
 	}
 
 	var logprobs bool

--- a/openai/openai_test.go
+++ b/openai/openai_test.go
@@ -907,3 +907,67 @@ func TestFromImageEditRequest_InvalidImage(t *testing.T) {
 		t.Error("expected error for invalid image")
 	}
 }
+
+func TestFromChatRequest_NumCtx(t *testing.T) {
+	numCtx := 16000
+	req := ChatCompletionRequest{
+		Model:  "test-model",
+		Messages: []Message{
+			{Role: "user", Content: "hello"},
+		},
+		NumCtx: &numCtx,
+	}
+
+	result, err := FromChatRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, ok := result.Options["num_ctx"]
+	if !ok {
+		t.Fatal("expected num_ctx in options, but it was not set")
+	}
+	if got != 16000 {
+		t.Errorf("expected num_ctx=16000, got %v", got)
+	}
+}
+
+func TestFromChatRequest_NumCtxNil(t *testing.T) {
+	req := ChatCompletionRequest{
+		Model:  "test-model",
+		Messages: []Message{
+			{Role: "user", Content: "hello"},
+		},
+	}
+
+	result, err := FromChatRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := result.Options["num_ctx"]; ok {
+		t.Error("expected num_ctx to be absent when not set, but it was present")
+	}
+}
+
+func TestFromCompleteRequest_NumCtx(t *testing.T) {
+	numCtx := 8192
+	req := CompletionRequest{
+		Model:  "test-model",
+		Prompt: "hello",
+		NumCtx: &numCtx,
+	}
+
+	result, err := FromCompleteRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, ok := result.Options["num_ctx"]
+	if !ok {
+		t.Fatal("expected num_ctx in options, but it was not set")
+	}
+	if got != 8192 {
+		t.Errorf("expected num_ctx=8192, got %v", got)
+	}
+}


### PR DESCRIPTION
Fixes #16814

## Problem

When using the OpenAI-compatible `/v1/chat/completions` or `/v1/completions` endpoints, the `num_ctx` parameter is silently ignored. This works fine via the native `/api/chat` endpoint (through the `options` map), but the OpenAI-compat layer never forwards it.

Root cause:
- `ChatCompletionRequest` had no `NumCtx` field
- `FromChatRequest()` never wrote `options["num_ctx"]`
- Same issue in `CompletionRequest` / `FromCompleteRequest()`

## Fix

- Added `NumCtx *int `json:"num_ctx,omitempty"`` field to `ChatCompletionRequest` and `CompletionRequest`
- In `FromChatRequest()` and `FromCompleteRequest()`, forward `num_ctx` to the options map when set
- Added tests: `TestFromChatRequest_NumCtx`, `TestFromChatRequest_NumCtxNil`, `TestFromCompleteRequest_NumCtx`

## Reproduction

```bash
curl http://localhost:11434/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"llama3","num_ctx":16000,"messages":[{"role":"user","content":"hi"}]}'
```

Before this fix: `num_ctx` was ignored and the server used the default context window.
After this fix: the requested `num_ctx` is respected.