### PR TITLE
llama: add sm_86 architecture to cuda_v13_windows preset

### DIFF
--- a/llama/server/CMakePresets.json
+++ b/llama/server/CMakePresets.json
@@ -108,7 +108,7 @@
       "inherits": ["llama_cuda_v13_base"],
       "binaryDir": "${sourceDir}/../../build/llama-server-cuda_v13",
       "cacheVariables": {
-        "CMAKE_CUDA_ARCHITECTURES": "75-virtual;89-virtual;100-virtual;120-virtual"
+        "CMAKE_CUDA_ARCHITECTURES": "75-virtual;80-virtual;86-virtual;89-virtual;100-virtual;120-virtual"
       }
     },
     {


### PR DESCRIPTION
The llama_cuda_v13_windows preset in llama/server/CMakePresets.json was missing sm_86 and sm_80 architectures, causing RTX 3060 laptop and similar mobile RTX 30-series GPUs to be skipped during runtime GPU detection on Windows with CUDA 13. The Linux preset (llama_cuda_v13_linux) included these architectures as "86-virtual" and "80-virtual", but the Windows preset only had "75-virtual;89-virtual;100-virtual;120-virtual", excluding Ampere mobile GPUs.

Added sm_80-virtual and sm_86-virtual to the CMAKE_CUDA_ARCHITECTURES list in the llama_cuda_v13_windows preset to match the Linux configuration and ensure compatibility with RTX 30-series mobile GPUs (RTX 3060, 3050 Ti, etc.) on Windows.

Fixes #16620
