### PR TITLE
feat: opt-in slot KV save/restore via OLLAMA_SLOT_SAVE_PATH

### DIFF
--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -247,6 +247,12 @@ func String(s string) func() string {
 var (
 	LLMLibrary = String("OLLAMA_LLM_LIBRARY")
 	Editor     = String("OLLAMA_EDITOR")
+	// SlotSavePath, when set, is passed to llama-server as --slot-save-path so
+	// that per-slot KV state can be saved to / restored from disk. This unlocks
+	// the prefill-cache persistence the upstream llama.cpp server supports but
+	// Ollama otherwise hides; it is consumed by the /api/kv/{save,restore}
+	// passthrough routes. Opt-in: empty means the feature stays disabled.
+	SlotSavePath = String("OLLAMA_SLOT_SAVE_PATH")
 
 	CudaVisibleDevices    = String("CUDA_VISIBLE_DEVICES")
 	HipVisibleDevices     = String("HIP_VISIBLE_DEVICES")
@@ -331,6 +337,7 @@ func AsMap() map[string]EnvVar {
 		"OLLAMA_NOHISTORY":            {"OLLAMA_NOHISTORY", NoHistory(), "Do not preserve readline history"},
 		"OLLAMA_NOPRUNE":              {"OLLAMA_NOPRUNE", NoPrune(), "Do not prune model blobs on startup"},
 		"OLLAMA_NUM_PARALLEL":         {"OLLAMA_NUM_PARALLEL", NumParallel(), "Maximum number of parallel requests"},
+		"OLLAMA_SLOT_SAVE_PATH":       {"OLLAMA_SLOT_SAVE_PATH", SlotSavePath(), "Directory for llama-server slot KV save/restore; enables /api/kv/{save,restore} (experimental)"},
 		"OLLAMA_ORIGINS":              {"OLLAMA_ORIGINS", AllowedOrigins(), "A comma separated list of allowed origins"},
 		"OLLAMA_SCHED_SPREAD":         {"OLLAMA_SCHED_SPREAD", SchedSpread(), "Always schedule model across all GPUs"},
 		"OLLAMA_CONTEXT_LENGTH":       {"OLLAMA_CONTEXT_LENGTH", ContextLength(), "Context length to use unless otherwise specified (default: 4k/32k/256k based on VRAM)"},

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -250,8 +250,9 @@ var (
 	// SlotSavePath, when set, is passed to llama-server as --slot-save-path so
 	// that per-slot KV state can be saved to / restored from disk. This unlocks
 	// the prefill-cache persistence the upstream llama.cpp server supports but
-	// Ollama otherwise hides; it is consumed by the /api/kv/{save,restore}
-	// passthrough routes. Opt-in: empty means the feature stays disabled.
+	// Ollama otherwise hides; it is consumed by the
+	// /api/experimental/kv/{save,restore} routes. Opt-in: empty means the
+	// feature stays disabled.
 	SlotSavePath = String("OLLAMA_SLOT_SAVE_PATH")
 
 	CudaVisibleDevices    = String("CUDA_VISIBLE_DEVICES")
@@ -337,7 +338,7 @@ func AsMap() map[string]EnvVar {
 		"OLLAMA_NOHISTORY":            {"OLLAMA_NOHISTORY", NoHistory(), "Do not preserve readline history"},
 		"OLLAMA_NOPRUNE":              {"OLLAMA_NOPRUNE", NoPrune(), "Do not prune model blobs on startup"},
 		"OLLAMA_NUM_PARALLEL":         {"OLLAMA_NUM_PARALLEL", NumParallel(), "Maximum number of parallel requests"},
-		"OLLAMA_SLOT_SAVE_PATH":       {"OLLAMA_SLOT_SAVE_PATH", SlotSavePath(), "Directory for llama-server slot KV save/restore; enables /api/kv/{save,restore} (experimental)"},
+		"OLLAMA_SLOT_SAVE_PATH":       {"OLLAMA_SLOT_SAVE_PATH", SlotSavePath(), "Directory for llama-server slot KV save/restore; enables /api/experimental/kv/{save,restore}. Files are large (tens of MB each) and never auto-removed; enable on a trusted local host only (experimental)"},
 		"OLLAMA_ORIGINS":              {"OLLAMA_ORIGINS", AllowedOrigins(), "A comma separated list of allowed origins"},
 		"OLLAMA_SCHED_SPREAD":         {"OLLAMA_SCHED_SPREAD", SchedSpread(), "Always schedule model across all GPUs"},
 		"OLLAMA_CONTEXT_LENGTH":       {"OLLAMA_CONTEXT_LENGTH", ContextLength(), "Context length to use unless otherwise specified (default: 4k/32k/256k based on VRAM)"},

--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -392,6 +392,13 @@ func startLlamaServer(launch llamaServerLaunchConfig, out io.Writer) (cmd *exec.
 
 	params = appendContextShiftArgs(params, launch.opts, launch.config.ContextShift)
 
+	// Opt-in KV slot persistence (fork): when OLLAMA_SLOT_SAVE_PATH is set,
+	// expose llama-server's slot save/restore so the same system prompt's
+	// prefill KV can be reused across requests (see /api/kv/{save,restore}).
+	if dir := envconfig.SlotSavePath(); dir != "" {
+		params = append(params, "--slot-save-path", dir)
+	}
+
 	// Set up library paths for GPU backend discovery
 	cmd = exec.Command(exe, params...)
 
@@ -606,6 +613,16 @@ const limitedMMProjOffloadMemory = 10 << 30
 
 func appendMMProjArgs(params []string, launch llamaServerLaunchConfig) []string {
 	if len(launch.projectors) == 0 {
+		return params
+	}
+
+	// KV slot persistence (fork) is mutually exclusive with multimodal: llama-server
+	// returns 501 on /slots save/restore when an mmproj context is loaded. When the
+	// user opts into OLLAMA_SLOT_SAVE_PATH, run the text-only path so the prefill
+	// cache can be persisted (these qwen3.5 GGUFs embed a projector but the cache
+	// optimization targets the text prompt).
+	if envconfig.SlotSavePath() != "" {
+		slog.Info("OLLAMA_SLOT_SAVE_PATH set: skipping multimodal projector to enable slot save/restore", "model", launch.modelPath)
 		return params
 	}
 

--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -210,6 +210,61 @@ func (s *llamaServerRunner) HasExited() bool {
 	return s.cmd != nil && s.cmd.ProcessState != nil && s.cmd.ProcessState.ExitCode() >= 0
 }
 
+// SaveSlot persists the runner's KV cache to <slot-save-path>/<filename>.
+func (s *llamaServerRunner) SaveSlot(ctx context.Context, filename string) (*SlotKVResult, error) {
+	return s.slotAction(ctx, "save", filename)
+}
+
+// RestoreSlot restores the runner's KV cache from <slot-save-path>/<filename>.
+func (s *llamaServerRunner) RestoreSlot(ctx context.Context, filename string) (*SlotKVResult, error) {
+	return s.slotAction(ctx, "restore", filename)
+}
+
+// slotAction proxies a slot KV save/restore to the llama-server subprocess. It
+// acquires the same semaphore inference uses, so a save/restore never races a
+// generation in flight on the slot. Restricted to single-slot runners: with
+// more than one parallel slot the scheduler — not the caller — owns slot
+// assignment, so a fixed slot index would be unsafe.
+func (s *llamaServerRunner) slotAction(ctx context.Context, action, filename string) (*SlotKVResult, error) {
+	if s.launch.numParallel != 1 {
+		return nil, fmt.Errorf("slot KV %s requires OLLAMA_NUM_PARALLEL=1 (runner has %d parallel slots)", action, s.launch.numParallel)
+	}
+
+	if err := s.sem.Acquire(ctx, 1); err != nil {
+		return nil, err
+	}
+	defer s.sem.Release(1)
+
+	body, err := json.Marshal(map[string]string{"filename": filename})
+	if err != nil {
+		return nil, err
+	}
+
+	endpoint := fmt.Sprintf("http://127.0.0.1:%d/slots/0?action=%s", s.port, action)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.httpClient().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("slot %s request failed: %w", action, err)
+	}
+	defer resp.Body.Close()
+
+	out, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading slot %s response: %w", action, err)
+	}
+
+	return &SlotKVResult{
+		Status:      resp.StatusCode,
+		ContentType: resp.Header.Get("Content-Type"),
+		Body:        out,
+	}, nil
+}
+
 func (s *llamaServerRunner) llamaServerMediaMarker() string {
 	if s.mediaMarker != "" {
 		return s.mediaMarker
@@ -394,7 +449,8 @@ func startLlamaServer(launch llamaServerLaunchConfig, out io.Writer) (cmd *exec.
 
 	// Opt-in KV slot persistence (fork): when OLLAMA_SLOT_SAVE_PATH is set,
 	// expose llama-server's slot save/restore so the same system prompt's
-	// prefill KV can be reused across requests (see /api/kv/{save,restore}).
+	// prefill KV can be reused across requests (see
+	// /api/experimental/kv/{save,restore}).
 	if dir := envconfig.SlotSavePath(); dir != "" {
 		params = append(params, "--slot-save-path", dir)
 	}
@@ -613,16 +669,6 @@ const limitedMMProjOffloadMemory = 10 << 30
 
 func appendMMProjArgs(params []string, launch llamaServerLaunchConfig) []string {
 	if len(launch.projectors) == 0 {
-		return params
-	}
-
-	// KV slot persistence (fork) is mutually exclusive with multimodal: llama-server
-	// returns 501 on /slots save/restore when an mmproj context is loaded. When the
-	// user opts into OLLAMA_SLOT_SAVE_PATH, run the text-only path so the prefill
-	// cache can be persisted (these qwen3.5 GGUFs embed a projector but the cache
-	// optimization targets the text prompt).
-	if envconfig.SlotSavePath() != "" {
-		slog.Info("OLLAMA_SLOT_SAVE_PATH set: skipping multimodal projector to enable slot save/restore", "model", launch.modelPath)
 		return params
 	}
 

--- a/llm/server.go
+++ b/llm/server.go
@@ -77,6 +77,27 @@ type LlamaServer interface {
 	ContextLength() int
 }
 
+// SlotKVResult is the outcome of a slot KV save/restore proxied to the runner's
+// subprocess. Status/ContentType/Body mirror the underlying llama-server HTTP
+// response so the caller can relay it verbatim (including a 501 on multimodal
+// runners). A non-nil error means the proxy itself failed (transport,
+// precondition), not that the runner returned a non-2xx status.
+type SlotKVResult struct {
+	Status      int
+	ContentType string
+	Body        []byte
+}
+
+// SlotKVSaver is an optional capability: runners that launch with
+// --slot-save-path (i.e. OLLAMA_SLOT_SAVE_PATH is set) implement it to persist
+// and restore slot KV state. The save/restore is serialized against inference
+// on the same runner. Callers type-assert and return a clear error when the
+// active runner does not implement it (e.g. mlx / imagegen runners).
+type SlotKVSaver interface {
+	SaveSlot(ctx context.Context, filename string) (*SlotKVResult, error)
+	RestoreSlot(ctx context.Context, filename string) (*SlotKVResult, error)
+}
+
 type LlamaServerConfig struct {
 	DisableJinja   bool
 	ContextShift   bool

--- a/server/routes.go
+++ b/server/routes.go
@@ -20,6 +20,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"slices"
 	"strings"
 	"sync/atomic"
@@ -251,6 +252,84 @@ func signinURL() (string, error) {
 	encKey := base64.RawURLEncoding.EncodeToString([]byte(pubKey))
 	h, _ := os.Hostname()
 	return fmt.Sprintf(signinURLStr, url.PathEscape(h), encKey), nil
+}
+
+// KVSlotRequest is the body for /api/kv/save and /api/kv/restore.
+type KVSlotRequest struct {
+	Model     string         `json:"model"`
+	Slot      int            `json:"slot"`
+	Filename  string         `json:"filename"`
+	KeepAlive *api.Duration  `json:"keep_alive,omitempty"`
+	Options   map[string]any `json:"options,omitempty"`
+}
+
+// KVSlotHandler proxies llama-server's per-slot KV save/restore to the
+// currently loaded runner. This is the Ollama-side surface of the fork's
+// prefill-cache persistence: persist the KV of a fixed system prompt once,
+// then restore it before each request to collapse TTFT. Requires
+// OLLAMA_SLOT_SAVE_PATH (which makes the runner launch llama-server with
+// --slot-save-path). action is "save" or "restore".
+func (s *Server) KVSlotHandler(action string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if envconfig.SlotSavePath() == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "KV slot persistence disabled; set OLLAMA_SLOT_SAVE_PATH and restart ollama"})
+			return
+		}
+
+		var req KVSlotRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		if req.Model == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "model is required"})
+			return
+		}
+		if req.Filename == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "filename is required"})
+			return
+		}
+		// Restrict to a basename so the path cannot escape OLLAMA_SLOT_SAVE_PATH
+		// (the directory llama-server resolves the filename against). Rejects
+		// path separators, "..", and absolute paths.
+		if name := filepath.Base(req.Filename); name != req.Filename || name == "." || name == ".." {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "filename must be a basename (no path separators)"})
+			return
+		}
+
+		// Ensure the model is loaded and obtain its runner (and subprocess port).
+		runner, _, _, err := s.scheduleRunner(c.Request.Context(), req.Model, []model.Capability{model.CapabilityCompletion}, req.Options, req.KeepAlive, nil)
+		if err != nil {
+			handleScheduleError(c, req.Model, err)
+			return
+		}
+		port := runner.GetPort()
+		if port == 0 {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "runner has no local port (KV slots require a local llama-server)"})
+			return
+		}
+
+		body, err := json.Marshal(map[string]string{"filename": req.Filename})
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		endpoint := fmt.Sprintf("http://127.0.0.1:%d/slots/%d?action=%s", port, req.Slot, action)
+		preq, err := http.NewRequestWithContext(c.Request.Context(), http.MethodPost, endpoint, bytes.NewReader(body))
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		preq.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(preq)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("slot %s failed: %v", action, err)})
+			return
+		}
+		defer resp.Body.Close()
+		out, _ := io.ReadAll(resp.Body)
+		c.Data(resp.StatusCode, "application/json", out)
+	}
 }
 
 func (s *Server) GenerateHandler(c *gin.Context) {
@@ -1862,6 +1941,11 @@ func (s *Server) GenerateRoutes(rc *ollama.Registry) (http.Handler, error) {
 	r.POST("/api/chat", s.withInferenceRequestLogging("/api/chat", s.ChatHandler)...)
 	r.POST("/api/embed", s.EmbedHandler)
 	r.POST("/api/embeddings", s.EmbeddingsHandler)
+
+	// KV slot persistence (fork): save/restore a model's prefill cache to disk.
+	// No-op unless OLLAMA_SLOT_SAVE_PATH is set.
+	r.POST("/api/kv/save", s.KVSlotHandler("save"))
+	r.POST("/api/kv/restore", s.KVSlotHandler("restore"))
 
 	// Inference (OpenAI compatibility)
 	// TODO(cloud-stage-a): apply Modelfile overlay deltas for local models with cloud

--- a/server/routes.go
+++ b/server/routes.go
@@ -20,7 +20,6 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"slices"
 	"strings"
 	"sync/atomic"
@@ -290,10 +289,16 @@ func (s *Server) KVSlotHandler(action string) gin.HandlerFunc {
 			return
 		}
 		// Restrict to a basename so the path cannot escape OLLAMA_SLOT_SAVE_PATH
-		// (the directory llama-server resolves the filename against). Rejects
-		// path separators, "..", and absolute paths.
-		if name := filepath.Base(req.Filename); name != req.Filename || name == "." || name == ".." {
+		// (the directory llama-server resolves the filename against). Reject path
+		// separators for both Unix and Windows ("/" and "\"), plus "." and ".."
+		// — checked explicitly rather than via filepath.Base, which is OS-dependent
+		// and would let "sub\\x" through on a Unix host.
+		if strings.ContainsAny(req.Filename, `/\`) || req.Filename == "." || req.Filename == ".." {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "filename must be a basename (no path separators)"})
+			return
+		}
+		if req.Slot < 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "slot must be non-negative"})
 			return
 		}
 

--- a/server/routes.go
+++ b/server/routes.go
@@ -253,10 +253,15 @@ func signinURL() (string, error) {
 	return fmt.Sprintf(signinURLStr, url.PathEscape(h), encKey), nil
 }
 
-// KVSlotRequest is the body for /api/kv/save and /api/kv/restore.
+// KVSlotRequest is the body for /api/experimental/kv/save and .../restore.
+//
+// The runner's slot index is intentionally not exposed: this feature targets
+// single-slot (OLLAMA_NUM_PARALLEL=1) runners and the runner picks the slot
+// internally. Options, if set, must match the options used for inference on
+// this model — otherwise scheduling may load a different runner and the saved
+// KV would not correspond to it.
 type KVSlotRequest struct {
 	Model     string         `json:"model"`
-	Slot      int            `json:"slot"`
 	Filename  string         `json:"filename"`
 	KeepAlive *api.Duration  `json:"keep_alive,omitempty"`
 	Options   map[string]any `json:"options,omitempty"`
@@ -288,52 +293,50 @@ func (s *Server) KVSlotHandler(action string) gin.HandlerFunc {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "filename is required"})
 			return
 		}
-		// Restrict to a basename so the path cannot escape OLLAMA_SLOT_SAVE_PATH
-		// (the directory llama-server resolves the filename against). Reject path
-		// separators for both Unix and Windows ("/" and "\"), plus "." and ".."
-		// — checked explicitly rather than via filepath.Base, which is OS-dependent
-		// and would let "sub\\x" through on a Unix host.
-		if strings.ContainsAny(req.Filename, `/\`) || req.Filename == "." || req.Filename == ".." {
+		// Constrain the filename to a basename so it cannot escape the
+		// OLLAMA_SLOT_SAVE_PATH directory llama-server resolves it against.
+		// Reject, explicitly (not via filepath.Base, which is OS-dependent and
+		// would let "sub\\x" through on a Unix host): both separators ("/", "\"),
+		// the Windows drive-relative ":", a NUL byte, and the "."/".." refs. This
+		// is the first line of defense — llama-server independently re-validates
+		// the name (fs_validate_filename) and would also reject an escape.
+		if strings.ContainsAny(req.Filename, "/\\:\x00") || req.Filename == "." || req.Filename == ".." {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "filename must be a basename (no path separators)"})
 			return
 		}
-		if req.Slot < 0 {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "slot must be non-negative"})
-			return
-		}
-
-		// Ensure the model is loaded and obtain its runner (and subprocess port).
+		// Ensure the model is loaded and obtain its runner.
 		runner, _, _, err := s.scheduleRunner(c.Request.Context(), req.Model, []model.Capability{model.CapabilityCompletion}, req.Options, req.KeepAlive, nil)
 		if err != nil {
 			handleScheduleError(c, req.Model, err)
 			return
 		}
-		port := runner.GetPort()
-		if port == 0 {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "runner has no local port (KV slots require a local llama-server)"})
+
+		// Slot save/restore is an optional runner capability (only llama-server
+		// runners launched with --slot-save-path implement it). Go through the
+		// runner so the call is serialized against inference via the same
+		// semaphore, rather than reaching past the interface to the subprocess.
+		saver, ok := runner.(llm.SlotKVSaver)
+		if !ok {
+			c.JSON(http.StatusNotImplemented, gin.H{"error": "the active runner does not support slot KV save/restore"})
 			return
 		}
 
-		body, err := json.Marshal(map[string]string{"filename": req.Filename})
+		var res *llm.SlotKVResult
+		if action == "save" {
+			res, err = saver.SaveSlot(c.Request.Context(), req.Filename)
+		} else {
+			res, err = saver.RestoreSlot(c.Request.Context(), req.Filename)
+		}
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}
-		endpoint := fmt.Sprintf("http://127.0.0.1:%d/slots/%d?action=%s", port, req.Slot, action)
-		preq, err := http.NewRequestWithContext(c.Request.Context(), http.MethodPost, endpoint, bytes.NewReader(body))
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-			return
+
+		contentType := res.ContentType
+		if contentType == "" {
+			contentType = "application/json"
 		}
-		preq.Header.Set("Content-Type", "application/json")
-		resp, err := http.DefaultClient.Do(preq)
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("slot %s failed: %v", action, err)})
-			return
-		}
-		defer resp.Body.Close()
-		out, _ := io.ReadAll(resp.Body)
-		c.Data(resp.StatusCode, "application/json", out)
+		c.Data(res.Status, contentType, res.Body)
 	}
 }
 
@@ -1948,9 +1951,9 @@ func (s *Server) GenerateRoutes(rc *ollama.Registry) (http.Handler, error) {
 	r.POST("/api/embeddings", s.EmbeddingsHandler)
 
 	// KV slot persistence (fork): save/restore a model's prefill cache to disk.
-	// No-op unless OLLAMA_SLOT_SAVE_PATH is set.
-	r.POST("/api/kv/save", s.KVSlotHandler("save"))
-	r.POST("/api/kv/restore", s.KVSlotHandler("restore"))
+	// Experimental and disabled unless OLLAMA_SLOT_SAVE_PATH is set.
+	r.POST("/api/experimental/kv/save", s.KVSlotHandler("save"))
+	r.POST("/api/experimental/kv/restore", s.KVSlotHandler("restore"))
 
 	// Inference (OpenAI compatibility)
 	// TODO(cloud-stage-a): apply Modelfile overlay deltas for local models with cloud

--- a/server/routes_kv_test.go
+++ b/server/routes_kv_test.go
@@ -16,8 +16,8 @@ func kvEngine() *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	s := &Server{}
 	r := gin.New()
-	r.POST("/api/kv/save", s.KVSlotHandler("save"))
-	r.POST("/api/kv/restore", s.KVSlotHandler("restore"))
+	r.POST("/api/experimental/kv/save", s.KVSlotHandler("save"))
+	r.POST("/api/experimental/kv/restore", s.KVSlotHandler("restore"))
 	return r
 }
 
@@ -65,15 +65,15 @@ func TestKVSlotHandlerRejects(t *testing.T) {
 			wantStatus:  http.StatusBadRequest,
 		},
 		{
-			name:        "negative slot",
+			name:        "filename with leading slash",
 			slotSaveEnv: t.TempDir(),
-			body:        `{"model":"m","filename":"sys.bin","slot":-1}`,
+			body:        `{"model":"m","filename":"/etc/passwd"}`,
 			wantStatus:  http.StatusBadRequest,
 		},
 		{
-			name:        "absolute filename",
+			name:        "filename with windows drive colon",
 			slotSaveEnv: t.TempDir(),
-			body:        `{"model":"m","filename":"/etc/passwd"}`,
+			body:        `{"model":"m","filename":"C:sys.bin"}`,
 			wantStatus:  http.StatusBadRequest,
 		},
 		{
@@ -91,7 +91,7 @@ func TestKVSlotHandlerRejects(t *testing.T) {
 				r := kvEngine()
 
 				w := httptest.NewRecorder()
-				req := httptest.NewRequest(http.MethodPost, "/api/kv/"+action, strings.NewReader(tt.body))
+				req := httptest.NewRequest(http.MethodPost, "/api/experimental/kv/"+action, strings.NewReader(tt.body))
 				req.Header.Set("Content-Type", "application/json")
 				r.ServeHTTP(w, req)
 

--- a/server/routes_kv_test.go
+++ b/server/routes_kv_test.go
@@ -59,6 +59,18 @@ func TestKVSlotHandlerRejects(t *testing.T) {
 			wantStatus:  http.StatusBadRequest,
 		},
 		{
+			name:        "filename with backslash subdir",
+			slotSaveEnv: t.TempDir(),
+			body:        `{"model":"m","filename":"sub\\sys.bin"}`,
+			wantStatus:  http.StatusBadRequest,
+		},
+		{
+			name:        "negative slot",
+			slotSaveEnv: t.TempDir(),
+			body:        `{"model":"m","filename":"sys.bin","slot":-1}`,
+			wantStatus:  http.StatusBadRequest,
+		},
+		{
 			name:        "absolute filename",
 			slotSaveEnv: t.TempDir(),
 			body:        `{"model":"m","filename":"/etc/passwd"}`,

--- a/server/routes_kv_test.go
+++ b/server/routes_kv_test.go
@@ -1,0 +1,92 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// kvEngine builds a minimal gin engine with only the KV slot routes wired to a
+// zero-value Server. All the cases tested here return before scheduleRunner is
+// reached, so no real runner is required.
+func kvEngine() *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	s := &Server{}
+	r := gin.New()
+	r.POST("/api/kv/save", s.KVSlotHandler("save"))
+	r.POST("/api/kv/restore", s.KVSlotHandler("restore"))
+	return r
+}
+
+func TestKVSlotHandlerRejects(t *testing.T) {
+	tests := []struct {
+		name        string
+		slotSaveEnv string // value for OLLAMA_SLOT_SAVE_PATH ("" = feature disabled)
+		body        string
+		wantStatus  int
+	}{
+		{
+			name:        "disabled when env unset",
+			slotSaveEnv: "",
+			body:        `{"model":"m","filename":"sys.bin"}`,
+			wantStatus:  http.StatusBadRequest,
+		},
+		{
+			name:        "missing model",
+			slotSaveEnv: t.TempDir(),
+			body:        `{"filename":"sys.bin"}`,
+			wantStatus:  http.StatusBadRequest,
+		},
+		{
+			name:        "missing filename",
+			slotSaveEnv: t.TempDir(),
+			body:        `{"model":"m"}`,
+			wantStatus:  http.StatusBadRequest,
+		},
+		{
+			name:        "filename with parent traversal",
+			slotSaveEnv: t.TempDir(),
+			body:        `{"model":"m","filename":"../escape.bin"}`,
+			wantStatus:  http.StatusBadRequest,
+		},
+		{
+			name:        "filename with subdir",
+			slotSaveEnv: t.TempDir(),
+			body:        `{"model":"m","filename":"sub/sys.bin"}`,
+			wantStatus:  http.StatusBadRequest,
+		},
+		{
+			name:        "absolute filename",
+			slotSaveEnv: t.TempDir(),
+			body:        `{"model":"m","filename":"/etc/passwd"}`,
+			wantStatus:  http.StatusBadRequest,
+		},
+		{
+			name:        "malformed json",
+			slotSaveEnv: t.TempDir(),
+			body:        `{`,
+			wantStatus:  http.StatusBadRequest,
+		},
+	}
+
+	for _, action := range []string{"save", "restore"} {
+		for _, tt := range tests {
+			t.Run(action+"/"+tt.name, func(t *testing.T) {
+				t.Setenv("OLLAMA_SLOT_SAVE_PATH", tt.slotSaveEnv)
+				r := kvEngine()
+
+				w := httptest.NewRecorder()
+				req := httptest.NewRequest(http.MethodPost, "/api/kv/"+action, strings.NewReader(tt.body))
+				req.Header.Set("Content-Type", "application/json")
+				r.ServeHTTP(w, req)
+
+				if w.Code != tt.wantStatus {
+					t.Fatalf("status = %d, want %d (body: %s)", w.Code, tt.wantStatus, w.Body.String())
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
### What

Adds an opt-in path to persist and restore a slot's KV cache through Ollama,
exposing the llama-server slot endpoints that are otherwise unreachable. No
behavior change unless `OLLAMA_SLOT_SAVE_PATH` is set.

When set, Ollama launches llama-server with `--slot-save-path <dir>` and enables:

- `POST /api/experimental/kv/save`
- `POST /api/experimental/kv/restore`

This lets single-user workflows persist the KV of a fixed long prefix (e.g. a
system prompt) once and restore it before later requests, collapsing repeated
prefill cost.

### Measured benefit

`llama3.2:3b`, RTX 4070, flash attention on. TTFT (prefill time) read from
llama.cpp `/completion` timings; mean of 3 runs after a forced cache eviction,
cold-start iteration discarded. "Recompute" = evicted then re-sent (full prefill);
"Restore" = evicted then `/api/experimental/kv/restore` then re-sent (only the
short tail computed). Reproducible with `OLLAMA_SLOT_SAVE_PATH` alone — no extra flags.

| System prompt (tok) | Recompute TTFT | Restore TTFT | Speedup |
|---:|---:|---:|---:|
| 264 | 30.2 ms | 9.1 ms | 3.3× |
| 516 | 53.9 ms | 8.9 ms | 6.0× |
| 1,020 | 108.5 ms | 9.1 ms | 11.9× |
| 4,107 | 476.7 ms | 10.4 ms | 45.9× |
| 8,223 | 1,067 ms | 11.4 ms | 93.6× |
| 16,455 | 2,692 ms | 13.9 ms | 193× |
| 33,486 | 8,110 ms | 19.4 ms | **417×** |

<img width="1800" height="690" alt="kv_sweep" src="https://github.com/user-attachments/assets/ee81d712-e8b5-484a-9fce-909282eb3f5e" />


Restore cost is roughly flat (~9–19 ms) while recompute is ~linear in tokens, so
the win grows with prefix length — 3.3× at 256 tok up to 417× at ~33K. Decode
throughput is unchanged (this is purely a prefill win).

### Changes (4 files + tests)

- **`envconfig/config.go`** — add `OLLAMA_SLOT_SAVE_PATH` (String) + AsMap entry.
- **`llm/llama_server.go`** — inject `--slot-save-path <dir>` when set; add the
  `SaveSlot`/`RestoreSlot` runner methods (acquire the inference semaphore, POST
  to the subprocess slot endpoint, refuse unless `OLLAMA_NUM_PARALLEL=1`).
- **`llm/server.go`** — add an optional `SlotKVSaver` capability interface
  (`SaveSlot`/`RestoreSlot`) + `SlotKVResult`. The base `LlamaServer` interface is
  unchanged, so mlx / imagegen runners need no no-op stubs.
- **`server/routes.go`** — add `KVSlotHandler` + register
  `/api/experimental/kv/save` and `.../restore`. The handler schedules the runner,
  type-asserts `SlotKVSaver`, and relays the result. It does **not** reach past the
  interface to the subprocess port; the runner method owns the HTTP call.

### Safety / scope

- Disabled by default; the handler returns 400 when `OLLAMA_SLOT_SAVE_PATH` is unset,
  and 501 if the active runner doesn't implement the capability.
- Save/restore is serialized against inference via the **same semaphore** the
  Completion/Embedding paths use, so it can't race a generation in flight.
- The runner's slot index is **not** exposed on the API; the runner uses its single
  slot internally and refuses to save/restore unless `OLLAMA_NUM_PARALLEL=1` (with
  more slots the scheduler, not the caller, owns slot assignment).
- Requires explicit `model` and `filename`; `filename` is restricted to a basename
  (rejects `/`, `\`, the Windows drive-relative `:`, a NUL byte, and `.`/`..` —
  cross-platform) so saves can't escape the configured dir. This is the first line
  of defense; llama-server independently re-validates the name.
- Single-user, serial-request use case — not the multi-tenant path.
- Improves prefill / TTFT only; decode throughput unchanged.
- Does not manage save-file naming, eviction, or cleanup; files are large (tens of
  MB each). Enable on a trusted local host only — do not expose the save dir on a
  network-bound instance.
- Mounted under `/api/experimental/` — not a stable public API.

### Multimodal note (known limitation)

Models whose GGUF embeds a projector (e.g. qwen3.5) make Ollama launch
llama-server with `--mmproj`, which puts it in multimodal mode — and the server
then rejects slot save/restore with `501 "not supported by multimodal"`. Such
models are therefore unsupported here; the 501 is surfaced unchanged. A text-only
launch escape hatch is possible as a follow-up if there's appetite (flagged as an
open question in #16835), but it's deliberately kept out of this PR so that
`OLLAMA_SLOT_SAVE_PATH` never changes model launch behavior on its own.

### Testing

- Handler tests (`server/routes_kv_test.go`, 9 cases × {save, restore} = 18 subtests,
  all guard paths that return before scheduling): `OLLAMA_SLOT_SAVE_PATH` unset → 400;
  missing model → 400; missing filename → 400; filename with `..` / `/` subdir /
  `\` subdir / leading slash / Windows drive `:` → 400; malformed JSON → 400.
- Manual E2E (`llama3.2:3b`, RTX 4070): the prefix-length sweep shown under
  **Measured benefit** above — save persists the prefix KV, restore replays it after
  a forced cache eviction, and only the short tail is recomputed. Run with
  `OLLAMA_SLOT_SAVE_PATH` set and `OLLAMA_NUM_PARALLEL=1`.

### Checklist

- [x] Drop unrelated `OLLAMA_UNSAFE_PARALLEL` (separate experiment).
- [x] `filename` basename validation (cross-platform).
- [x] No raw slot index on the API; runner serializes via its semaphore and
  refuses `OLLAMA_NUM_PARALLEL>1`.
- [x] `OLLAMA_SLOT_SAVE_PATH` never changes model launch on its own; multimodal
  models surface llama-server's 501 (text-only escape hatch left as a follow-up).
- [x] Re-measure the headline TTFT on a pure text model (`llama3.2:3b`, PATH-only, reproducible) — prefix sweep 256→33K tok, 3.3×→417×, plot attached.
- [x] Mounted under `/api/experimental/`.
- [x] Handler tests (400 paths).
- [x] `gofmt` / `go vet` clean.
- [ ] Rebase onto current `main` if it has moved (fork based on v0.30.10, 4 days old).
- [ ] Sign the CLA if required.
