### PR TITLE
Fix image path detection when a parent directory ends in an image extension

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -604,12 +604,26 @@ func normalizeFilePath(fp string) string {
 
 func extractFileNames(input string) []string {
 	// Regex to match file paths starting with optional drive letter, / ./ \ or .\ and include escaped or unescaped spaces (\ or %20)
-	// and followed by more characters and a file extension
-	// This will capture non filename strings, but we'll check for file existence to remove mismatches
-	regexPattern := `(?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp|wav)\b`
+	// and followed by more characters and a file extension.
+	//
+	// The extension must be path-terminal: a parent directory whose name ends in
+	// an image extension (e.g. "/photos.png/cat.jpg") must not cut the match
+	// short at the directory. We require the extension to be followed by a true
+	// delimiter — anything but '.', a path separator, or a word character — or
+	// end of input, capturing the path in group 1 so the delimiter isn't
+	// included. Go's RE2 has no lookahead, so a trailing capture group stands in
+	// for a negative lookahead.
+	//
+	// This will capture non filename strings, but we'll check for file existence to remove mismatches.
+	regexPattern := `((?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp|wav))(?:[^./\\\w]|$)`
 	re := regexp.MustCompile(regexPattern)
 
-	return re.FindAllString(input, -1)
+	matches := re.FindAllStringSubmatch(input, -1)
+	names := make([]string, 0, len(matches))
+	for _, m := range matches {
+		names = append(names, m[1])
+	}
+	return names
 }
 
 func extractFileData(input string) (string, []api.ImageData, error) {

--- a/cmd/interactive_test.go
+++ b/cmd/interactive_test.go
@@ -64,6 +64,34 @@ d:\path with\spaces\thirteen.WEBP some ending
 	assert.Contains(t, res[12], "d:")
 }
 
+// Regression for https://github.com/ollama/ollama/issues/16680: a parent
+// directory whose name ends in an image extension (e.g. "photos.png/cat.jpg")
+// must not fracture the path — the whole path should be returned as one match,
+// not cut short at the directory.
+func TestExtractFilenamesNestedExtension(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"parent dir ends in .png (absolute)", "open /photos.png/cat.jpg now", "/photos.png/cat.jpg"},
+		{"parent dir ends in extension (relative)", "./album.png/sunset.jpeg", "./album.png/sunset.jpeg"},
+		{"parent dir ends in extension (windows)", `c:\photos.png\cat.jpg`, `c:\photos.png\cat.jpg`},
+		{"multiple extension-named dirs", "/a.jpg/b.png/c.webp", "/a.jpg/b.png/c.webp"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := extractFileNames(tc.input)
+			if len(res) != 1 {
+				t.Fatalf("got %d matches %v, want 1", len(res), res)
+			}
+			if res[0] != tc.want {
+				t.Errorf("got %q, want %q", res[0], tc.want)
+			}
+		})
+	}
+}
+
 // Ensure that file paths wrapped in single quotes are removed with the quotes.
 func TestExtractFileDataRemovesQuotedFilepath(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
## What

`extractFileNames` (used to attach images/audio referenced in a prompt) ended its regex on a word boundary (`\b`) right after the extension. When a **parent directory** name ends in an image extension, the match stopped at the directory instead of the actual file.

For example, the path `/photos.png/cat.jpg` matched only `/photos.png` — so Ollama tried to attach the directory as an image, and the real file (`cat.jpg`) was never picked up.

Fixes #16680

## Fix

Require the extension to be **path-terminal**: it must be followed by a real delimiter (anything that isn't `.`, a path separator, or a word character) or the end of input. The full path is captured in group 1 so the delimiter isn't included in the result.

```
((?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp|wav))(?:[^./\\\w]|$)
```

Go's RE2 engine has no lookahead, so the trailing throwaway group stands in for a negative lookahead.

## Tests

Added `TestExtractFilenamesNestedExtension` covering absolute, relative, Windows, and multiple extension-named directories. The existing `TestExtractFilenames` cases (7 Unix + 13 Windows) still pass unchanged.