### PR TITLE
Show the full command in the experimental agent tool-call display

### DIFF
--- a/x/cmd/run.go
+++ b/x/cmd/run.go
@@ -376,7 +376,7 @@ func Chat(ctx context.Context, opts RunOptions) (*api.Message, error) {
 				if cmd, ok := args["command"].(string); ok {
 					// Check if command is denied (dangerous pattern)
 					if denied, pattern := agent.IsDenied(cmd); denied {
-						fmt.Fprintf(os.Stderr, "\033[1mblocked:\033[0m %s\n", formatToolShort(toolName, args))
+						fmt.Fprintf(os.Stderr, "\033[1mblocked:\033[0m %s\n", formatToolCall(toolName, args))
 						fmt.Fprintf(os.Stderr, "  matches dangerous pattern: %s\n", pattern)
 						toolResults = append(toolResults, api.Message{
 							Role:       "tool",
@@ -389,7 +389,7 @@ func Chat(ctx context.Context, opts RunOptions) (*api.Message, error) {
 					// Check if command is auto-allowed (safe command)
 					// TODO(parthsareen): re-enable with tighter scoped allowlist
 					// if agent.IsAutoAllowed(cmd) {
-					// 	fmt.Fprintf(os.Stderr, "\033[1mauto-allowed:\033[0m %s\n", formatToolShort(toolName, args))
+					// 	fmt.Fprintf(os.Stderr, "\033[1mauto-allowed:\033[0m %s\n", formatToolCall(toolName, args))
 					// 	skipApproval = true
 					// }
 				}
@@ -399,7 +399,7 @@ func Chat(ctx context.Context, opts RunOptions) (*api.Message, error) {
 			// In yolo mode, skip all approval prompts
 			if opts.YoloMode {
 				if !skipApproval {
-					fmt.Fprintf(os.Stderr, "\033[1mrunning:\033[0m %s\n", formatToolShort(toolName, args))
+					fmt.Fprintf(os.Stderr, "\033[1mrunning:\033[0m %s\n", formatToolCall(toolName, args))
 				}
 			} else if !skipApproval && !approval.IsAllowed(toolName, args) {
 				result, err := approval.RequestApproval(toolName, args)
@@ -429,7 +429,7 @@ func Chat(ctx context.Context, opts RunOptions) (*api.Message, error) {
 				}
 			} else if !skipApproval {
 				// Already allowed - show running indicator
-				fmt.Fprintf(os.Stderr, "\033[1mrunning:\033[0m %s\n", formatToolShort(toolName, args))
+				fmt.Fprintf(os.Stderr, "\033[1mrunning:\033[0m %s\n", formatToolCall(toolName, args))
 			}
 
 			// Execute the tool
@@ -513,29 +513,20 @@ func Chat(ctx context.Context, opts RunOptions) (*api.Message, error) {
 	return &api.Message{Role: role, Thinking: thinkingContent.String(), Content: fullResponse.String()}, nil
 }
 
-// truncateUTF8 safely truncates a string to at most limit runes, adding "..." if truncated.
-func truncateUTF8(s string, limit int) string {
-	runes := []rune(s)
-	if len(runes) <= limit {
-		return s
-	}
-	if limit <= 3 {
-		return string(runes[:limit])
-	}
-	return string(runes[:limit-3]) + "..."
-}
-
-// formatToolShort returns a short description of a tool call.
-func formatToolShort(toolName string, args map[string]any) string {
+// formatToolCall returns a description of a tool call for display. It shows the
+// full command or query, untruncated, so the user can see exactly what is about
+// to run. This matters most in yolo mode, where there is no approval prompt to
+// inspect the call before it executes.
+func formatToolCall(toolName string, args map[string]any) string {
 	displayName := agent.ToolDisplayName(toolName)
 	if toolName == "bash" {
 		if cmd, ok := args["command"].(string); ok {
-			return fmt.Sprintf("%s: %s", displayName, truncateUTF8(cmd, 50))
+			return fmt.Sprintf("%s: %s", displayName, cmd)
 		}
 	}
 	if toolName == "web_search" {
 		if query, ok := args["query"].(string); ok {
-			return fmt.Sprintf("%s: %s", displayName, truncateUTF8(query, 50))
+			return fmt.Sprintf("%s: %s", displayName, query)
 		}
 	}
 	return displayName

--- a/x/cmd/run_test.go
+++ b/x/cmd/run_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -184,6 +185,53 @@ func TestTruncateToolOutput(t *testing.T) {
 				if result != tt.output {
 					t.Error("expected output to not be truncated")
 				}
+			}
+		})
+	}
+}
+
+// Regression for https://github.com/ollama/ollama/issues/16648: the tool-call
+// display must show the full command/query so the user can see exactly what is
+// about to run. This is the only place a call is surfaced in yolo mode, where
+// there is no approval prompt to inspect it first, so it must not be truncated.
+func TestFormatToolCall(t *testing.T) {
+	longCmd := "curl -sS -X POST https://api.example.com/v1/very/long/endpoint?token=abcdef0123456789 -H 'Content-Type: application/json' -d '{\"hello\":\"world\"}'"
+	longQuery := strings.Repeat("how to write a very long search query that exceeds fifty characters ", 3)
+
+	tests := []struct {
+		name     string
+		toolName string
+		args     map[string]any
+		want     string
+	}{
+		{
+			name:     "bash command shown in full",
+			toolName: "bash",
+			args:     map[string]any{"command": longCmd},
+			want:     longCmd,
+		},
+		{
+			name:     "web_search query shown in full",
+			toolName: "web_search",
+			args:     map[string]any{"query": longQuery},
+			want:     longQuery,
+		},
+		{
+			name:     "unknown tool falls back to display name",
+			toolName: "some_tool",
+			args:     map[string]any{},
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatToolCall(tt.toolName, tt.args)
+			if tt.want != "" && !strings.Contains(got, tt.want) {
+				t.Errorf("formatToolCall(%q) = %q, want it to contain the full value %q", tt.toolName, got, tt.want)
+			}
+			if strings.Contains(got, "...") {
+				t.Errorf("formatToolCall(%q) = %q, want no truncation ellipsis", tt.toolName, got)
 			}
 		})
 	}


### PR DESCRIPTION
## What

In the experimental agent (`ollama run --experimental`), the tool-call display truncated the command to 50 characters:

```go
return fmt.Sprintf("%s: %s", displayName, truncateUTF8(cmd, 50))
```

In yolo mode there is no approval prompt, so the `running:` line is the **only** place a tool call is shown before it executes. With the 50-char cap, a command like a `curl` call was cut off — you couldn't see the URL it was hitting or the payload it was sending.

Fixes #16648

## Fix

Show the full command/query, untruncated, in the call display (renamed `formatToolShort` → `formatToolCall`). The now-unused `truncateUTF8` helper is removed.

This only affects the *display* of the call. `truncateToolOutput`, which caps tool **results** fed back into the model's context, is intentionally left as-is.

## Tests

Added `TestFormatToolCall`, asserting a long bash command and a long `web_search` query are surfaced in full with no truncation ellipsis.