### PR TITLE
docs: fix stale compatibility examples

### DIFF
--- a/docs/api/anthropic-compatibility.mdx
+++ b/docs/api/anthropic-compatibility.mdx
@@ -339,8 +339,8 @@ claude --model qwen3-coder
 - [x] `content_block_stop`
 - [x] `message_delta`
 - [x] `message_stop`
-- [x] `ping`
-- [x] `error`
+- [ ] `ping`
+- [ ] `error`
 
 ## Models
 

--- a/docs/capabilities/web-search.mdx
+++ b/docs/capabilities/web-search.mdx
@@ -110,7 +110,7 @@ More Ollama [Python example](https://github.com/ollama/ollama-python/blob/main/e
 import { Ollama } from "ollama";
 
 const client = new Ollama();
-const results = await client.webSearch("what is ollama?");
+const results = await client.webSearch({ query: "what is ollama?" });
 console.log(JSON.stringify(results, null, 2));
 ```
 
@@ -213,7 +213,7 @@ models](https://ollama.com/models)\n\nAvailable for macOS, Windows, and Linux',
 import { Ollama } from "ollama";
 
 const client = new Ollama();
-const fetchResult = await client.webFetch("https://ollama.com");
+const fetchResult = await client.webFetch({ url: "https://ollama.com" });
 console.log(JSON.stringify(fetchResult, null, 2));
 ```
 


### PR DESCRIPTION
## Summary

- update the web search JavaScript examples to pass request objects, matching the current `ollama-js` `webSearch` and `webFetch` signatures
- mark Anthropic `ping` and streaming `error` events as unsupported so the streaming-event checklist matches the converter implementation and the unsupported-features table

Addresses part of #16338.

## Tests

- `git diff --check`