### PR TITLE
Don't write word-wrap escape sequences when stdout is not a terminal

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1665,11 +1665,12 @@ type displayResponseState struct {
 }
 
 func displayResponse(content string, wordWrap bool, state *displayResponseState) {
-	termWidth, _, _ := term.GetSize(int(os.Stdout.Fd()))
-	if termWidth == 0 {
-		termWidth = 80
-	}
-	if wordWrap && termWidth >= 10 {
+	termWidth, _, err := term.GetSize(int(os.Stdout.Fd()))
+	// Word-wrapping emits cursor-control escape sequences, which only make sense
+	// on a real terminal. When stdout is redirected to a file or pipe term.GetSize
+	// returns an error; fall through to plain output so the escape sequences don't
+	// leak into the redirected output (issue #16785).
+	if wordWrap && err == nil && termWidth >= 10 {
 		for _, ch := range content {
 			if state.lineLength+1 > termWidth-5 {
 				if runewidth.StringWidth(state.wordBuffer) > termWidth-10 {

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -2390,3 +2390,28 @@ func TestIsLocalhost(t *testing.T) {
 		})
 	}
 }
+
+// Regression for https://github.com/ollama/ollama/issues/16785: when stdout is
+// redirected to a file or pipe (not a terminal), displayResponse must not emit
+// word-wrap cursor-control escape sequences into the output.
+func TestDisplayResponseNoEscapesWhenNotATTY(t *testing.T) {
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	// A long single line that would wrap (and emit escape sequences) on a real
+	// terminal. The pipe is not a terminal, so the output must stay plain.
+	content := strings.Repeat("the quick brown fox jumps over the lazy dog ", 5)
+	displayResponse(content, true, &displayResponseState{})
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	out, _ := io.ReadAll(r)
+	if strings.ContainsRune(string(out), '\x1b') {
+		t.Errorf("output contains an ANSI escape sequence when stdout is not a TTY:\n%q", out)
+	}
+	if string(out) != content {
+		t.Errorf("output = %q, want plain content %q", out, content)
+	}
+}


### PR DESCRIPTION
## What

`ollama run <model> "<prompt>" > out.txt` writes terminal escape sequences into `out.txt`. The file ends up with cursor-control codes (`\x1b[<n>D`, `\x1b[K`) instead of clean text.

Fixes #16785

## Cause

`displayResponse` asks for the terminal width and, when `term.GetSize` fails (which is what happens when stdout is a file or pipe, not a TTY), falls back to an 80-column width:

```go
termWidth, _, _ := term.GetSize(int(os.Stdout.Fd()))
if termWidth == 0 {
    termWidth = 80
}
if wordWrap && termWidth >= 10 {
    // ... emits \x1b[..D / \x1b[K cursor-control sequences for wrapping
```

So even with no real terminal, the word-wrap branch was taken and its cursor-control sequences were written into the redirected output.

## Fix

Word-wrapping only makes sense on a real terminal, so only take that branch when `term.GetSize` succeeds. When stdout is redirected, fall through to the existing plain-text branch — no escape sequences.

```go
termWidth, _, err := term.GetSize(int(os.Stdout.Fd()))
if wordWrap && err == nil && termWidth >= 10 {
```

Interactive terminal behavior is unchanged (`GetSize` succeeds there and returns the real width).

## Test

`TestDisplayResponseNoEscapesWhenNotATTY` redirects stdout to a pipe (not a TTY), renders content that would wrap on a terminal, and asserts the output is the plain text with no escape sequences. It fails before this change and passes after.