### PR TITLE
Recover qwen tool calls when the tool-call xml is malformed

### DIFF
--- a/model/parsers/qwen3coder.go
+++ b/model/parsers/qwen3coder.go
@@ -232,9 +232,17 @@ func parseToolCall(raw qwenEventRawToolCall, tools []api.Tool) (api.ToolCall, er
 	xmlString := transformToXML(raw.raw)
 
 	var functionCall XMLFunctionCall
-	err := xml.Unmarshal([]byte(xmlString), &functionCall)
-	if err != nil {
-		return api.ToolCall{}, err
+	if err := xml.Unmarshal([]byte(xmlString), &functionCall); err != nil {
+		// Models occasionally emit malformed tool-call xml — for example a stray
+		// or unbalanced </parameter> tag. Strict parsing rejects the entire call,
+		// which previously surfaced as an error and aborted the whole response.
+		// Fall back to a lenient recovery that salvages the function name and any
+		// well-formed parameters; only surface the error if even that fails.
+		recovered, ok := recoverFunctionCall(raw.raw)
+		if !ok {
+			return api.ToolCall{}, err
+		}
+		functionCall = recovered
 	}
 
 	toolCall.Function = api.ToolCallFunction{
@@ -271,6 +279,28 @@ func parseToolCall(raw qwenEventRawToolCall, tools []api.Tool) (api.ToolCall, er
 	}
 
 	return toolCall, nil
+}
+
+// recoverFunctionCall makes a best-effort attempt to reconstruct a function call
+// from raw qwen tool-call output whose xml is malformed (for example a stray or
+// unbalanced </parameter> tag) and therefore rejected by strict parsing. It
+// scans the raw string for the function name and any well-formed
+// <parameter=...>...</parameter> pairs, so a single malformed tag no longer
+// discards the entire call. Because it reads the same raw form the strict path
+// transforms, recovered values flow through parseValue identically to parsed
+// ones. It reports false only when no function name is present, in which case
+// the caller keeps the original parse error.
+func recoverFunctionCall(raw string) (XMLFunctionCall, bool) {
+	nameMatch := qwenRecoverFunctionRegex.FindStringSubmatch(raw)
+	if nameMatch == nil {
+		return XMLFunctionCall{}, false
+	}
+
+	functionCall := XMLFunctionCall{Name: nameMatch[1]}
+	for _, m := range qwenRecoverParameterRegex.FindAllStringSubmatch(raw, -1) {
+		functionCall.Parameters = append(functionCall.Parameters, XMLParameter{Name: m[1], Value: m[2]})
+	}
+	return functionCall, true
 }
 
 // parseValue converts a raw string value to the appropriate type based on the parameter type specification.
@@ -401,6 +431,11 @@ func parseValue(raw string, paramType api.PropertyType) any {
 var (
 	qwenTagRegex    = regexp.MustCompile(`<(\w+)=([^>]+)>`)
 	qwenXMLTagRegex = regexp.MustCompile(`</?(?:function|parameter)(?:\s+name="[^"]*")?>`)
+
+	// Used by recoverFunctionCall to salvage a tool call from raw qwen output
+	// whose xml is malformed and rejected by strict parsing.
+	qwenRecoverFunctionRegex  = regexp.MustCompile(`<function=([^>]+)>`)
+	qwenRecoverParameterRegex = regexp.MustCompile(`(?s)<parameter=([^>]+)>(.*?)</parameter>`)
 )
 
 // transformToXML transforms a raw qwen tool call with xml-like tags into valid

--- a/model/parsers/qwen3coder_test.go
+++ b/model/parsers/qwen3coder_test.go
@@ -1240,3 +1240,55 @@ func TestOverlapFunction(t *testing.T) {
 		})
 	}
 }
+
+// Regression for https://github.com/ollama/ollama/issues/16810: qwen models
+// (including qwen3.5, which delegates tool parsing here) sometimes emit
+// malformed tool-call xml. The stray second </parameter> below makes Go's
+// strict xml decoder fail with "element <function> closed by </parameter>",
+// which previously propagated out of Add and aborted the entire response. The
+// parser now recovers the function name and any well-formed parameters instead.
+func TestQwen3CoderParserRecoversMalformedToolCall(t *testing.T) {
+	parser := Qwen3CoderParser{}
+	parser.Init(nil, nil, nil)
+
+	input := "<tool_call>\n<function=web_search>\n<parameter=query>\nlunch menu Trnava\n</parameter>\n</parameter>\n</function>\n</tool_call>"
+	_, _, calls, err := parser.Add(input, true)
+	if err != nil {
+		t.Fatalf("expected lenient recovery, got error: %v", err)
+	}
+
+	want := []api.ToolCall{
+		{Function: api.ToolCallFunction{Name: "web_search", Arguments: testArgs(map[string]any{"query": "lunch menu Trnava"}), Index: 0}},
+	}
+	if len(calls) != len(want) {
+		t.Fatalf("expected %d calls, got %d: %#v", len(want), len(calls), calls)
+	}
+	if !toolCallEqual(calls[0], want[0]) {
+		t.Fatalf("call mismatch:\n got %#v\nwant %#v", calls[0], want[0])
+	}
+}
+
+func TestRecoverFunctionCall(t *testing.T) {
+	t.Run("no function name returns false", func(t *testing.T) {
+		if _, ok := recoverFunctionCall("<parameter=query>oops</parameter>"); ok {
+			t.Fatal("expected ok=false when no function name is present")
+		}
+	})
+
+	t.Run("salvages name and well-formed params around a stray tag", func(t *testing.T) {
+		raw := "<function=web_search>\n<parameter=query>\nlunch menu\n</parameter>\n<parameter=count>\n3\n</parameter>\n</parameter>\n"
+		fc, ok := recoverFunctionCall(raw)
+		if !ok {
+			t.Fatal("expected ok=true")
+		}
+		if fc.Name != "web_search" {
+			t.Fatalf("name = %q, want %q", fc.Name, "web_search")
+		}
+		if len(fc.Parameters) != 2 {
+			t.Fatalf("got %d parameters, want 2: %#v", len(fc.Parameters), fc.Parameters)
+		}
+		if fc.Parameters[0].Name != "query" || fc.Parameters[1].Name != "count" {
+			t.Fatalf("parameter names = [%q, %q], want [query, count]", fc.Parameters[0].Name, fc.Parameters[1].Name)
+		}
+	})
+}


### PR DESCRIPTION
## What

When a qwen model emits a tool call whose xml is malformed, the whole response is aborted with an error like:

```
XML syntax error on line 8: element <function> closed by </parameter>
```

A user hit this with qwen3.5 calling web search (#16810). Because `Qwen35Parser` delegates tool parsing to `Qwen3CoderParser`, both parsers report the failure for a single root cause.

Fixes #16810

## Cause

`parseToolCall` parses the transformed tool call with a strict xml decoder:

```go
err := xml.Unmarshal([]byte(xmlString), &functionCall)
if err != nil {
    return api.ToolCall{}, err
}
```

Any malformed or unbalanced tag (here a stray `</parameter>`) makes `xml.Unmarshal` fail, and that error propagates out of `Add`, aborting the entire chat stream — the user gets nothing back.

## Fix

Keep strict parsing as the primary path, but when it fails, fall back to a lenient recovery that scans the raw output for the function name and any well-formed `<parameter=...>...</parameter>` pairs. A single bad tag no longer discards the whole call. The recovery reads the same raw form the strict path transforms, so recovered values flow through the existing `parseValue` conversion identically to parsed ones. If no function name can be found, the original parse error is returned unchanged.

## Tests

- `TestQwen3CoderParserRecoversMalformedToolCall` — drives the full parser with the reporter's failure shape (a stray `</parameter>`) and asserts the call is recovered (function name + the well-formed parameter) instead of erroring. Confirmed this input fails strict parsing with the exact reported message before the change.
- `TestRecoverFunctionCall` — unit coverage: returns false when no function name is present (so the caller keeps the original error), and salvages multiple well-formed parameters around a stray tag.