### PR TITLE
docs: clarify OpenAI-compatible request fields

### DIFF
--- a/docs/api/openai-compatibility.mdx
+++ b/docs/api/openai-compatibility.mdx
@@ -405,6 +405,10 @@ curl http://localhost:11434/v1/chat/completions \
     }'
 ```
 
+### Ollama-native request fields
+
+OpenAI-compatible endpoints accept OpenAI request fields only. Ollama-native fields such as `keep_alive` and `options` are not supported by `/v1/chat/completions` or `/v1/completions`. Use the native `/api/chat` or `/api/generate` endpoints when those fields are required.
+
 ### Setting the context size
 
 The OpenAI API does not have a way of setting the context size for a model. If you need to change the context size, create a `Modelfile` which looks like:


### PR DESCRIPTION
## Summary

- clarify that `/v1/chat/completions` and `/v1/completions` accept OpenAI request fields only
- point users to `/api/chat` or `/api/generate` when they need Ollama-native fields such as `keep_alive` or `options`

This follows the clarification in #16707 that `keep_alive` is not supported by the OpenAI compatibility endpoint.

## Tests

- `git diff --check`