### PR TITLE
ui: add local-only model filter

### DIFF
--- a/app/ui/app/src/components/ModelPicker.tsx
+++ b/app/ui/app/src/components/ModelPicker.tsx
@@ -30,9 +30,11 @@ export const ModelPicker = forwardRef<
 ): JSX.Element {
   const [isOpen, setIsOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
+  const [localOnly, setLocalOnly] = useState(false);
   const { selectedModel, setSettings, models, loading } = useSelectedModel(
     chatId,
     searchQuery,
+    localOnly,
   );
   const { cloudDisabled } = useCloudStatus();
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -162,6 +164,16 @@ export const ModelPicker = forwardRef<
         onDoubleClick={(e) => e.stopPropagation()}
         className="flex items-center select-none gap-1.5 rounded-full px-3.5 py-1.5 bg-white dark:bg-neutral-700 text-neutral-800 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:text-neutral-100 cursor-pointer"
       >
+      <div className="px-3 py-2 border-b border-neutral-100 dark:border-neutral-700">
+        <label className="flex items-center gap-2 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={localOnly}
+            onChange={(e) => setLocalOnly(e.target.checked)}
+          />
+          <span>Local models only</span>
+        </label>
+      </div>
         <div className="flex items-center gap-2">
           <span>
             {isDisabled

--- a/app/ui/app/src/components/ModelPicker.tsx
+++ b/app/ui/app/src/components/ModelPicker.tsx
@@ -103,6 +103,11 @@ export const ModelPicker = forwardRef<
       modelListRef.current?.scrollToSelectedModel();
     } else {
       setSearchQuery("");
+
+      // Reset localOnly when closed
+      // confusing if user opens, checks localOnly, then
+      // closes and opens again and sees only local models
+      setLocalOnly(false);
     }
   }, [isOpen]);
 
@@ -164,16 +169,6 @@ export const ModelPicker = forwardRef<
         onDoubleClick={(e) => e.stopPropagation()}
         className="flex items-center select-none gap-1.5 rounded-full px-3.5 py-1.5 bg-white dark:bg-neutral-700 text-neutral-800 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:text-neutral-100 cursor-pointer"
       >
-      <div className="px-3 py-2 border-b border-neutral-100 dark:border-neutral-700">
-        <label className="flex items-center gap-2 cursor-pointer">
-          <input
-            type="checkbox"
-            checked={localOnly}
-            onChange={(e) => setLocalOnly(e.target.checked)}
-          />
-          <span>Local models only</span>
-        </label>
-      </div>
         <div className="flex items-center gap-2">
           <span>
             {isDisabled
@@ -207,6 +202,17 @@ export const ModelPicker = forwardRef<
               autoCorrect="off"
               className="w-full px-2 py-0.5 bg-transparent border-none border-neutral-200 rounded-md outline-none focus:border-neutral-400 dark:border-neutral-600 dark:focus:border-neutral-400"
             />
+          </div>
+
+          <div className="px-3 py-2 border-b border-neutral-100 dark:border-neutral-700">
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={localOnly}
+                onChange={(e) => setLocalOnly(e.target.checked)}
+              />
+              <span>Local models only</span>
+            </label>
           </div>
 
           <ModelList

--- a/app/ui/app/src/hooks/useModels.ts
+++ b/app/ui/app/src/hooks/useModels.ts
@@ -5,7 +5,7 @@ import { useMemo } from "react";
 import { useCloudStatus } from "./useCloudStatus";
 import { useFeaturedModels } from "./useFeaturedModels";
 
-export function useModels(searchQuery = "") {
+export function useModels(searchQuery = "", localOnly = false) {
   const { cloudDisabled } = useCloudStatus();
   const { data: recommendations, isLoading: recommendationsLoading } =
     useFeaturedModels();
@@ -34,11 +34,9 @@ export function useModels(searchQuery = "") {
     const rest = local.filter((m) => !featuredSet.has(m.model));
     const merged = [...recommended, ...rest];
 
-    const visible = cloudDisabled
-      ? merged.filter((m) => !m.isCloud())
-      : merged;
+    const visible = cloudDisabled || localOnly ? merged.filter((m) => !m.isCloud()) : merged;
     return filterBySearch(visible, searchQuery);
-  }, [localQuery.data, searchQuery, cloudDisabled, recommendations]);
+  }, [localQuery.data, searchQuery, cloudDisabled, recommendations, localOnly]);
 
   return {
     ...localQuery,

--- a/app/ui/app/src/hooks/useSelectedModel.ts
+++ b/app/ui/app/src/hooks/useSelectedModel.ts
@@ -19,9 +19,9 @@ export function recommendDefaultModel(totalVRAM: number): string {
   return "gpt-oss:20b";
 }
 
-export function useSelectedModel(currentChatId?: string, searchQuery?: string) {
+export function useSelectedModel(currentChatId?: string, searchQuery?: string, localOnly: boolean = false) {
   const { settings, setSettings } = useSettings();
-  const { data: models = [], isLoading } = useModels(searchQuery || "");
+  const { data: models = [], isLoading } = useModels(searchQuery || "", localOnly);
   const { cloudDisabled } = useCloudStatus();
   const { data: chatData, isLoading: isChatLoading } = useChat(
     currentChatId && currentChatId !== "new" ? currentChatId : "",
@@ -50,6 +50,16 @@ export function useSelectedModel(currentChatId?: string, searchQuery?: string) {
 
   const selectedModel: Model | null = useMemo(() => {
     // If cloud is disabled and selected model ends with cloud, switch to a local default.
+    
+    // if you need to prevent using cloud models. "Local models only" filter usually means: hide cloud models from the picker
+    // ----------------------------------------------------------------------------------------------------------------------
+    // if (localOnly && settings.selectedModel?.endsWith("cloud")) {
+    //   return (
+    //     models.find((m) => !m.isCloud()) ||
+    //     null
+    //   );
+    // }
+
     if (cloudDisabled && settings.selectedModel?.endsWith("cloud")) {
       return (
         models.find((m) => m.model === recommendedModel) ||


### PR DESCRIPTION
## Summary

Adds a "Local models only" filter option to the model picker UI, allowing users to hide cloud models and browse only local Ollama models.

## Changes

### UI changes (`ModelPicker.tsx`)
- Added a "Local models only" checkbox inside the model picker dropdown.
- Added local-only filter state handling in the model picker component.
- Passed the filter state through the existing model selection flow.
- Kept the selected model behavior unchanged while allowing users to control which models are displayed.

### Model selection logic changes (`useSelectedModel.ts`)
- Extended `useSelectedModel` to accept a local-only filtering option.
- Forwarded the filter option to the model fetching layer.
- Preserved existing selected model restoration, chat model loading, and default model selection behavior.

### Model filtering changes (`useModels.ts`)
- Updated `useModels` to support filtering cloud models when local-only mode is enabled.
- Applied the filter after model merging/recommendation handling so recommended and locally available models continue to behave correctly.
- Kept existing cloud-disabled behavior unchanged.

## Reasoning for fix

The model picker currently displays both local and cloud models together. Users who prefer to run models locally need an easier way to hide cloud options and focus only on local Ollama models.

This change adds an explicit filter while keeping the default model picker behavior unchanged.

## Testing

Verified:
- `go test ./...`
- `cd app/ui/app && npm run build`

Manual testing:
- Opened the model picker dropdown.
- Enabled "Local models only".
- Confirmed cloud models are hidden.
- Disabled the filter and confirmed cloud models are shown again.
- Confirmed selecting models and existing model restoration behavior still work correctly.