### PR TITLE
server: default gemma4 thinking to off

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -89,6 +89,14 @@ func shouldUseHarmony(model *Model) bool {
 	return false
 }
 
+func defaultThinkValue(model *Model) *api.ThinkValue {
+	if model != nil && model.Config.Parser == "gemma4" {
+		return &api.ThinkValue{Value: false}
+	}
+
+	return &api.ThinkValue{Value: true}
+}
+
 func experimentEnabled(name string) bool {
 	return slices.Contains(strings.Split(os.Getenv("OLLAMA_EXPERIMENT"), ","), name)
 }
@@ -466,7 +474,7 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 	if slices.Contains(modelCaps, model.CapabilityThinking) {
 		caps = append(caps, model.CapabilityThinking)
 		if req.Think == nil {
-			req.Think = &api.ThinkValue{Value: true}
+			req.Think = defaultThinkValue(m)
 		}
 	} else {
 		if req.Think != nil && req.Think.Bool() {
@@ -2598,7 +2606,7 @@ func (s *Server) ChatHandler(c *gin.Context) {
 	if slices.Contains(modelCaps, model.CapabilityThinking) {
 		caps = append(caps, model.CapabilityThinking)
 		if req.Think == nil {
-			req.Think = &api.ThinkValue{Value: true}
+			req.Think = defaultThinkValue(m)
 		}
 	} else {
 		if req.Think != nil && req.Think.Bool() {

--- a/server/routes_generate_test.go
+++ b/server/routes_generate_test.go
@@ -50,6 +50,34 @@ var argsComparer = cmp.Comparer(func(a, b api.ToolCallFunctionArguments) bool {
 	return cmp.Equal(a.ToMap(), b.ToMap())
 })
 
+func TestDefaultThinkValue(t *testing.T) {
+	tests := []struct {
+		name string
+		m    *Model
+		want bool
+	}{
+		{
+			name: "gemma4 parser defaults to disabled thinking",
+			m:    &Model{Config: model.ConfigV2{Parser: "gemma4"}},
+			want: false,
+		},
+		{
+			name: "other thinking models default to enabled thinking",
+			m:    &Model{},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := defaultThinkValue(tt.m)
+			if got.Bool() != tt.want {
+				t.Fatalf("defaultThinkValue().Bool() = %v, want %v", got.Bool(), tt.want)
+			}
+		})
+	}
+}
+
 type mockRunner struct {
 	llm.LlamaServer
 


### PR DESCRIPTION
## Summary
- Default omitted `think` to `false` for models using the Gemma 4 parser
- Keep the existing default of `think: true` for other thinking-capable models
- Add a focused regression test for the model-specific default

## Why
Issue #16562 reports that `gemma4:12b` often spends too much work in thinking mode for ordinary writing prompts, leading to very slow generations and sometimes empty visible responses. The reporter found that explicitly setting `think:false` made both `/api/generate` and `/api/chat` much more usable.

This preserves explicit user control: `think:true` still enables thinking, and `think:false` still disables it. The change only affects the default when the request omits `think`.

## Test plan
- `go test ./server -run TestDefaultThinkValue -count=1`
- `go test ./server -run 'Test(DefaultThinkValue|ChatWithPromptEndingInThinkTag|Generate.*Think|Chat.*Think)' -count=1`
- `go test ./server -count=1`

Addresses #16562
