### PR TITLE
fix(cli): abort interactive mode with error when stdout is redirected without prompt

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -577,6 +577,9 @@ func RunHandler(cmd *cobra.Command, args []string) error {
 	// Be quiet if we're redirecting to a pipe or file
 	if !term.IsTerminal(int(os.Stdout.Fd())) {
 		interactive = false
+		if opts.Prompt == "" {
+			return fmt.Errorf("interactive mode requires a terminal. To redirect output, pass the prompt directly: ollama run %s \"your prompt\" > output.txt", args[0])
+		}
 	}
 
 	nowrap, err := cmd.Flags().GetBool("nowordwrap")


### PR DESCRIPTION
## Description
This PR fixes the issue where running `ollama run <model> > output.txt` without providing a direct prompt argument corrupts the output file. 

Previously, the CLI blindly initiated the interactive chat mode (REPL) even when `stdout` was redirected. As a result, terminal ANSI escape sequences, colors, and spinner formatting characters were written directly into the text file, corrupting its content.

## Changes
- Injected a TTY guard check inside `cmd/cmd.go` using the `"golang.org/x/term"` package.
- If the command is executed with no prompt arguments and `os.Stdout` is detected as a non-TTY (redirected to a file or pipe), the CLI now gracefully aborts execution.
- It prints a clear, descriptive error message guiding the user to pass the prompt directly, and exits with code `1`.
- It outputs the error specifically to `os.Stderr` to avoid polluting the redirected stdout file.

## Verifications & Testing
Verified all 3 core scenarios:
1. `ollama run model > output.txt` -> Aborts safely with a clean error on stderr. (Fixed)
2. `ollama run model "hello" > output.txt` -> Non-interactive mode triggers properly, writing clean text output to the file. (Works as expected)
3. `echo "hello" | ollama run model > output.txt` -> Stdin pipe reads the prompt, executes normally, and outputs clean text to the file. (Works as expected)

Fixes #16787