### PR TITLE
llm: preserve generation headroom for shifted prompts

### DIFF
--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -273,8 +273,8 @@ func (s *llamaServerRunner) completionPromptForRequest(ctx context.Context, req 
 		return nil, err
 	}
 
-	limit := s.options.NumCtx - 1
-	if len(tokens) <= limit {
+	fullPromptLimit := s.options.NumCtx - 1
+	if len(tokens) <= fullPromptLimit {
 		return prompt, nil
 	}
 
@@ -289,8 +289,12 @@ func (s *llamaServerRunner) completionPromptForRequest(ctx context.Context, req 
 	if nKeep < 0 {
 		nKeep = len(tokens)
 	}
-	nKeep = min(nKeep, limit)
+	if s.tokenizerAddsBOS() {
+		nKeep++
+	}
+	nKeep = min(nKeep, fullPromptLimit)
 
+	limit := contextShiftPromptLimit(s.options.NumCtx, nKeep)
 	discard := len(tokens) - limit
 	truncated := make([]int, 0, limit)
 	truncated = append(truncated, tokens[:nKeep]...)
@@ -298,6 +302,18 @@ func (s *llamaServerRunner) completionPromptForRequest(ctx context.Context, req 
 
 	slog.Warn("truncating input prompt", "limit", limit, "prompt", len(tokens), "keep", nKeep, "new", len(truncated))
 	return truncated, nil
+}
+
+func contextShiftPromptLimit(numCtx, numKeep int) int {
+	if numCtx <= 1 {
+		return 0
+	}
+
+	numKeep = max(0, min(numKeep, numCtx-1))
+
+	// Match the old runners' first context shift: preserve num_keep, then free
+	// roughly half of the remaining context before generation needs the slot.
+	return numCtx - max((numCtx-numKeep)/2, 1)
 }
 
 func (s *llamaServerRunner) ContextLength() int {

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -126,6 +126,30 @@ func TestBoundedNumPredict(t *testing.T) {
 	}
 }
 
+func TestContextShiftPromptLimit(t *testing.T) {
+	tests := []struct {
+		name    string
+		numCtx  int
+		numKeep int
+		want    int
+	}{
+		{name: "small context reserves half after keep", numCtx: 8, numKeep: 3, want: 6},
+		{name: "issue 16618 context preserves generation headroom", numCtx: 4096, numKeep: 4, want: 2050},
+		{name: "issue 16618 with implicit BOS keep", numCtx: 4096, numKeep: 5, want: 2051},
+		{name: "keep is clamped below context", numCtx: 8, numKeep: 99, want: 7},
+		{name: "negative keep is treated as zero", numCtx: 8, numKeep: -1, want: 4},
+		{name: "invalid context has no prompt budget", numCtx: 1, numKeep: 0, want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := contextShiftPromptLimit(tt.numCtx, tt.numKeep); got != tt.want {
+				t.Fatalf("contextShiftPromptLimit(%d, %d) = %d, want %d", tt.numCtx, tt.numKeep, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestLlamaServerCompletionSSEParsing(t *testing.T) {
 	// Simulate llama-server SSE streaming response
 	sseLines := []string{
@@ -653,7 +677,7 @@ func TestLlamaServerCompletionContextShiftTruncatesPromptOverContext(t *testing.
 				return
 			}
 			w.Header().Set("Content-Type", "text/event-stream")
-			fmt.Fprintln(w, `data: {"content":"ok","stop":true,"timings":{"prompt_n":7,"prompt_ms":1,"predicted_n":1,"predicted_ms":1}}`)
+			fmt.Fprintln(w, `data: {"content":"ok","stop":true,"timings":{"prompt_n":6,"prompt_ms":1,"predicted_n":1,"predicted_ms":1}}`)
 		default:
 			t.Errorf("unexpected path: %s", r.URL.Path)
 		}
@@ -697,7 +721,7 @@ func TestLlamaServerCompletionContextShiftTruncatesPromptOverContext(t *testing.
 	if !ok {
 		t.Fatalf("completion prompt = %T, want token array", capturedReq.Prompt)
 	}
-	want := []int{0, 1, 2, 6, 7, 8, 9}
+	want := []int{0, 1, 2, 7, 8, 9}
 	if len(got) != len(want) {
 		t.Fatalf("token prompt len = %d, want %d: %#v", len(got), len(want), got)
 	}
@@ -709,6 +733,90 @@ func TestLlamaServerCompletionContextShiftTruncatesPromptOverContext(t *testing.
 	}
 	if capturedReq.NKeep != opts.NumKeep {
 		t.Fatalf("n_keep = %d, want %d", capturedReq.NKeep, opts.NumKeep)
+	}
+}
+
+func TestLlamaServerCompletionContextShiftAvoidsOneTokenHeadroomRegression(t *testing.T) {
+	var capturedReq llamaServerCompletionRequest
+	tokens := make([]int, 5000)
+	for i := range tokens {
+		tokens[i] = i
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health":
+			fmt.Fprint(w, `{"status":"ok"}`)
+		case "/tokenize":
+			if err := json.NewEncoder(w).Encode(map[string][]int{"tokens": tokens}); err != nil {
+				t.Errorf("failed to encode tokenize response: %v", err)
+			}
+		case "/completion":
+			if err := json.NewDecoder(r.Body).Decode(&capturedReq); err != nil {
+				t.Errorf("invalid completion request body: %v", err)
+				return
+			}
+			w.Header().Set("Content-Type", "text/event-stream")
+			fmt.Fprintln(w, `data: {"content":"ok","stop":true,"timings":{"prompt_n":2051,"prompt_ms":1,"predicted_n":32,"predicted_ms":1}}`)
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	parts := strings.Split(srv.URL, ":")
+	var portInt int
+	fmt.Sscanf(parts[len(parts)-1], "%d", &portInt)
+
+	runner := &llamaServerRunner{
+		port:    portInt,
+		cmd:     fakeRunningCmd(),
+		sem:     semaphore.NewWeighted(1),
+		options: api.Options{Runner: api.Runner{NumCtx: 4096}},
+		ggml: loadTestGGML(t, ggml.KV{
+			"general.architecture":         "gemma3",
+			"tokenizer.ggml.add_bos_token": true,
+		}),
+		launch: llamaServerLaunchConfig{
+			config: LlamaServerConfig{ContextShift: true},
+		},
+	}
+
+	opts := api.DefaultOptions()
+	opts.NumKeep = 4
+	err := runner.Completion(t.Context(), CompletionRequest{
+		Prompt:   strings.Repeat("long prompt ", 500),
+		Options:  &opts,
+		Truncate: true,
+	}, func(cr CompletionResponse) {})
+	if err != nil {
+		t.Fatalf("Completion error: %v", err)
+	}
+
+	got, ok := capturedReq.Prompt.([]any)
+	if !ok {
+		t.Fatalf("completion prompt = %T, want token array", capturedReq.Prompt)
+	}
+
+	if len(got) != 2051 {
+		t.Fatalf("token prompt len = %d, want 2051", len(got))
+	}
+	if len(got) == 4095 {
+		t.Fatal("token prompt preserved old one-token headroom behavior")
+	}
+
+	effectiveKeep := opts.NumKeep + 1
+	for i := 0; i < effectiveKeep; i++ {
+		gotToken, ok := got[i].(float64)
+		if !ok || int(gotToken) != i {
+			t.Fatalf("token prompt[%d] = %#v, want %d", i, got[i], i)
+		}
+	}
+
+	const wantSuffixStart = 2954
+	gotToken, ok := got[effectiveKeep].(float64)
+	if !ok || int(gotToken) != wantSuffixStart {
+		t.Fatalf("first shifted token = %#v, want %d", got[effectiveKeep], wantSuffixStart)
 	}
 }
 

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -738,6 +738,11 @@ func TestLlamaServerCompletionContextShiftTruncatesPromptOverContext(t *testing.
 
 func TestLlamaServerCompletionContextShiftAvoidsOneTokenHeadroomRegression(t *testing.T) {
 	var capturedReq llamaServerCompletionRequest
+	var tokenizeReq struct {
+		Content      string `json:"content"`
+		AddSpecial   bool   `json:"add_special"`
+		ParseSpecial *bool  `json:"parse_special"`
+	}
 	tokens := make([]int, 5000)
 	for i := range tokens {
 		tokens[i] = i
@@ -748,6 +753,10 @@ func TestLlamaServerCompletionContextShiftAvoidsOneTokenHeadroomRegression(t *te
 		case "/health":
 			fmt.Fprint(w, `{"status":"ok"}`)
 		case "/tokenize":
+			if err := json.NewDecoder(r.Body).Decode(&tokenizeReq); err != nil {
+				t.Errorf("invalid tokenize request body: %v", err)
+				return
+			}
 			if err := json.NewEncoder(w).Encode(map[string][]int{"tokens": tokens}); err != nil {
 				t.Errorf("failed to encode tokenize response: %v", err)
 			}
@@ -806,7 +815,7 @@ func TestLlamaServerCompletionContextShiftAvoidsOneTokenHeadroomRegression(t *te
 	}
 
 	effectiveKeep := opts.NumKeep + 1
-	for i := 0; i < effectiveKeep; i++ {
+	for i := range effectiveKeep {
 		gotToken, ok := got[i].(float64)
 		if !ok || int(gotToken) != i {
 			t.Fatalf("token prompt[%d] = %#v, want %d", i, got[i], i)


### PR DESCRIPTION
## Summary

This addresses the prompt/context regression discussed in #16618 for Go-rendered `/completion` prompts on the llama-server path.

| Area | Current v0.30.x behavior | Why it is an issue | Patched behavior |
|---|---|---|---|
| Over-context rendered `/completion` prompt with context shift enabled | Ollama truncates to `num_ctx - 1` tokens before calling llama-server. For `num_ctx=4096`, that is `4095` prompt tokens. | llama-server has only one token of room left, so generation can immediately stop with `limit`/`length`. Through Anthropic compatibility, that surfaces as a misleading `max_tokens`/output-token failure in clients like Claude Code. | Ollama pre-applies the old runner's first context-shift window: keep `num_keep` plus implicit BOS when applicable, then retain roughly half the remaining context. For `num_ctx=4096`, `num_keep=4`, tokenizer-owned BOS, this forwards `2051` prompt tokens. |
| Relation to pre-v0.30 | Old runners accepted the oversized prompt, truncated to context, then shifted away about half of the non-kept window before generation needed room. | v0.30 moved to llama-server, which rejects prompts that fill/exceed the slot, so Ollama added a `num_ctx - 1` pre-truncation that preserved legality but lost generation headroom. | The patch emulates the old runner's post-shift prompt state before calling llama-server, without requiring llama-server to ingest an illegal prompt. |
| Expected user-visible change | Large Claude Code/Hermes/OpenCode prompts can fail immediately with "max output tokens" even though almost no output was generated. | This looks like an output budget problem but is actually context-window saturation caused by prompt packing. | Oversized prompts still lose context, but they have meaningful generation headroom and should no longer immediately fail as fake output-token exhaustion. |
| Non-shift / fitting prompts | Fitting prompts pass through unchanged. Oversized prompts with context shift disabled return the existing context-length error. | Good behavior; should stay stable. | Unchanged. The patch only affects oversized, truncatable, text `/completion` prompts when context shift is enabled. |

## What changed

- Replaces `num_ctx - 1` context-shift prompt truncation with the old runner's first-shift retention math.
- Accounts for tokenizer-owned BOS when computing the effective keep prefix, matching old runner behavior.
- Adds focused tests for the helper math and the #16618-shaped regression case.

## Validation

- `go test ./llm -run 'TestContextShiftPromptLimit|TestLlamaServerCompletionContextShift|TestLlamaServerCompletionRejectsPromptOverContext|TestLlamaServerCompletionLengthStop' -count=1`
- `go test ./llm ./server ./anthropic ./middleware -count=1`
- `git diff --check`

Note: `go test ./server` emitted the existing linker warning `ld: warning: ignoring duplicate libraries: '-lc++'`, but passed.