### PR TITLE
fix(cmd): prevent ANSI escape sequences in piped output

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -910,7 +910,7 @@ func RunHandler(cmd *cobra.Command, args []string) error {
 				fmt.Printf(">>> %s\n", msg.Content)
 			case "assistant":
 				state := &displayResponseState{}
-				displayResponse(msg.Content, opts.WordWrap, state)
+				displayResponse(msg.Content, opts.WordWrap, false, state)
 				fmt.Println()
 				fmt.Println()
 			}
@@ -1664,12 +1664,12 @@ type displayResponseState struct {
 	wordBuffer string
 }
 
-func displayResponse(content string, wordWrap bool, state *displayResponseState) {
+func displayResponse(content string, wordWrap bool, plainText bool, state *displayResponseState) {
 	termWidth, _, _ := term.GetSize(int(os.Stdout.Fd()))
 	if termWidth == 0 {
 		termWidth = 80
 	}
-	if wordWrap && termWidth >= 10 {
+	if wordWrap && !plainText && termWidth >= 10 {
 		for _, ch := range content {
 			if state.lineLength+1 > termWidth-5 {
 				if runewidth.StringWidth(state.wordBuffer) > termWidth-10 {
@@ -1783,7 +1783,7 @@ func chat(cmd *cobra.Command, opts runOptions) (*api.Message, error) {
 				thinkTagClosed = false
 			}
 			thinkingContent.WriteString(response.Message.Thinking)
-			displayResponse(response.Message.Thinking, opts.WordWrap, state)
+			displayResponse(response.Message.Thinking, opts.WordWrap, false, state)
 		}
 
 		content := response.Message.Content
@@ -1809,7 +1809,7 @@ func chat(cmd *cobra.Command, opts runOptions) (*api.Message, error) {
 			}
 		}
 
-		displayResponse(content, opts.WordWrap, state)
+		displayResponse(content, opts.WordWrap, false, state)
 
 		return nil
 	}
@@ -1914,7 +1914,7 @@ func generate(cmd *cobra.Command, opts runOptions) error {
 				thinkTagClosed = false
 			}
 			thinkingContent.WriteString(response.Thinking)
-			displayResponse(response.Thinking, opts.WordWrap, state)
+			displayResponse(response.Thinking, opts.WordWrap, plainText, state)
 		}
 
 		if thinkTagOpened && !thinkTagClosed && (content != "" || len(response.ToolCalls) > 0) {
@@ -1927,7 +1927,7 @@ func generate(cmd *cobra.Command, opts runOptions) error {
 			state = &displayResponseState{}
 		}
 
-		displayResponse(content, opts.WordWrap, state)
+		displayResponse(content, opts.WordWrap, plainText, state)
 
 		if response.ToolCalls != nil {
 			toolCalls := response.ToolCalls

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -2390,3 +2390,83 @@ func TestIsLocalhost(t *testing.T) {
 		})
 	}
 }
+
+// Regression test for https://github.com/ollama/ollama/issues/16785:
+// displayResponse must not emit ANSI escape sequences when plainText is true
+// (i.e. stdout is not a terminal, such as when piping to a file).
+func TestDisplayResponseNoEscapesWhenPlainText(t *testing.T) {
+	content := strings.Repeat("the quick brown fox jumps over the lazy dog ", 5)
+
+	t.Run("plain_text_no_escapes", func(t *testing.T) {
+		var buf bytes.Buffer
+		oldStdout := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+
+		state := &displayResponseState{}
+		displayResponse(content, true, true, state) // plainText=true
+
+		w.Close()
+		os.Stdout = oldStdout
+		io.Copy(&buf, r)
+
+		out := buf.String()
+		if strings.ContainsRune(out, '\x1b') {
+			t.Errorf("plain text output contains ANSI escape sequence:\n%q", out)
+		}
+		if out != content {
+			t.Errorf("plain text output = %q, want %q", out, content)
+		}
+	})
+
+	t.Run("interactive_with_escapes", func(t *testing.T) {
+		// When plainText=false, word-wrap can emit escape sequences for
+		// cursor movement. We verify that plainText=false does NOT strip
+		// those sequences (i.e. the function still works normally when
+		// running in a terminal).
+		var buf bytes.Buffer
+		oldStdout := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+
+		state := &displayResponseState{}
+		// plainText=false should trigger the word-wrap path when termWidth
+		// is available. In a test pipe, term.GetSize returns 0 so we fall
+		// through to the else branch which prints content without escapes,
+		// but with wordBuffer tracking. The key point is that the
+		// plainText=false path is exercised without panicking.
+		displayResponse(content, true, false, state)
+
+		w.Close()
+		os.Stdout = oldStdout
+		io.Copy(&buf, r)
+
+		// We don't assert on escape codes here because the test pipe
+		// doesn't have a real terminal width. The important thing is that
+		// plainText=false doesn't crash and produces output.
+		if buf.Len() == 0 {
+			t.Error("expected some output from interactive mode")
+		}
+	})
+
+	t.Run("plain_text_short_content", func(t *testing.T) {
+		shortContent := "Hello, world"
+
+		var buf bytes.Buffer
+		oldStdout := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+
+		state := &displayResponseState{}
+		displayResponse(shortContent, true, true, state)
+
+		w.Close()
+		os.Stdout = oldStdout
+		io.Copy(&buf, r)
+
+		out := buf.String()
+		if out != shortContent {
+			t.Errorf("plain text short content = %q, want %q", out, shortContent)
+		}
+	})
+}


### PR DESCRIPTION
## Problem

When piping `ollama run` output to a file or another command, the output contains ANSI escape sequences like `\x1b[14D` (cursor back) and `\x1b[K` (clear line). These are part of the word-wrap logic and only make sense on a real terminal. In redirected output they appear as garbage:

```
$ ollama run llama3.2 "explain quantum computing" > output.txt
$ cat -v output.txt
Quantum computing is...\x1b[14D\x1b[K...
```

Reported in #16785.

## Fix

Add a `plainText bool` parameter to `displayResponse()`. When `true`, the word-wrap path (which emits escape sequences) is skipped entirely and content is printed as plain text.

The `generate()` function already computes `plainText := !term.IsTerminal(int(os.Stdout.Fd()))` — this PR threads it through to `displayResponse()` so the function knows whether it's writing to a terminal or not.

Chat mode calls pass `plainText=false` since chat is always interactive. Generate mode uses the already-computed `plainText` value.

## Why not PR #16840's approach?

PR #16840 checks `term.GetSize()` errors to detect non-TTY output. That works but has a subtle issue: `term.GetSize()` can fail for reasons other than "not a TTY" (e.g., the TTY exists but its size can't be determined). In those cases, word-wrap should still be disabled since we don't know the terminal width, but the approach conflates "can't get size" with "not a terminal."

This PR is more explicit:
- The intent is clear in the function signature (`plainText bool`)
- Call sites make the decision at the right level (the caller knows whether it's interactive or not)
- No behavior change for the interactive path — chat mode always passes `false`
- The `generate()` function already had the `plainText` variable ready to thread through

## Test Plan

3 new sub-tests under `TestDisplayResponseNoEscapesWhenPlainText`:
- `plain_text_no_escapes`: verifies no `\x1b` bytes in output when `plainText=true` with long content that would normally wrap
- `interactive_with_escapes`: verifies `plainText=false` doesn't crash and produces output
- `plain_text_short_content`: verifies short content passes through unchanged when `plainText=true`

```
=== RUN   TestDisplayResponseNoEscapesWhenPlainText
=== RUN   TestDisplayResponseNoEscapesWhenPlainText/plain_text_no_escapes
=== RUN   TestDisplayResponseNoEscapesWhenPlainText/interactive_with_escapes
=== RUN   TestDisplayResponseNoEscapesWhenPlainText/plain_text_short_content
--- PASS: TestDisplayResponseNoEscapesWhenPlainText (0.00s)
```

Full cmd test suite passes.

Closes #16785