### PR TITLE
mlx: disable unsafe prompt cache restore

### DIFF
--- a/x/mlxrunner/cache.go
+++ b/x/mlxrunner/cache.go
@@ -92,6 +92,13 @@ func (c *kvCache) begin(m base.Model, inputs []int32) *cacheSession {
 
 	matchPath, matched := findBestMatch(c.root, inputs)
 	originalMatched := matched
+	// MLX cache restore currently changes deterministic outputs for supported
+	// models, even on exact prompt reuse. Keep trie bookkeeping for diagnostics
+	// and future fixes, but re-evaluate prompt input instead of restoring it.
+	if matched > 0 {
+		matchPath = []*trieNode{c.root}
+		matched = 0
+	}
 
 	// Always keep at least one token to re-evaluate so the
 	// pipeline can seed token generation from it.
@@ -113,8 +120,8 @@ func (c *kvCache) begin(m base.Model, inputs []int32) *cacheSession {
 		remaining: remaining,
 	}
 
-	// Schedule a snapshot at the branch point during prefill so future
-	// requests diverging here can restore instead of re-evaluating.
+	// Keep the branch-point snapshot path intact for a future safe restore
+	// policy. With restore disabled above, this is intentionally inactive.
 	if prefix < matched {
 		session.pendingSnapshots = append(session.pendingSnapshots, pendingSnapshot{offset: matched, user: false})
 	}
@@ -123,7 +130,7 @@ func (c *kvCache) begin(m base.Model, inputs []int32) *cacheSession {
 	if prefix == 0 {
 		msg = "cache miss"
 	}
-	slog.Info(msg, "total", len(inputs), "matched", originalMatched, "cached", prefix, "left", len(remaining))
+	slog.Info(msg, "total", len(inputs), "matchable", originalMatched, "restored", prefix, "left", len(remaining), "restore_disabled", originalMatched > matched)
 
 	return session
 }
@@ -428,13 +435,42 @@ func (c *kvCache) advancePath(frontier *trieNode, tokens []int32, endOffset int)
 		if len(dest.children) == 0 && !dest.user {
 			dest.setSnapshots(nil, &c.pagedOutBytes)
 		}
-		newDest := dest.appendTokens(c.root, remaining, endOffset)
+		newDest := dest.appendTokens(c.root, remaining, endOffset, false, c.caches, &c.pagedOutBytes)
 		if newDest != dest {
 			c.activePath = append(c.activePath, newDest)
 		}
 		dest = newDest
 	}
 	return dest
+}
+
+// capturePromptBoundary stores a restorable trie boundary at the end of the
+// input prompt before the first generated token mutates the live cache.
+func (s *cacheSession) capturePromptBoundary() {
+	c := s.cache
+	offset := c.minCacheOffset()
+	if offset != len(s.inputs) || len(c.activePath) == 0 {
+		return
+	}
+
+	frontier := c.activePath[len(c.activePath)-1]
+	if offset > frontier.endOffset {
+		frontier = c.advancePath(frontier, s.inputs[frontier.endOffset:offset], offset)
+	}
+	if frontier.hasAllSnapshots() {
+		return
+	}
+
+	snaps := make([]cache.Snapshot, len(c.caches))
+	for j, kv := range c.caches {
+		if kv == nil {
+			continue
+		}
+		snaps[j] = kv.Snapshot(frontier.startOffset())
+	}
+	frontier.setSnapshots(snaps, &c.pagedOutBytes)
+	frontier.lastUsed = time.Now()
+	c.enforceEvictionPolicy()
 }
 
 // freeAll releases all cache layers.
@@ -488,15 +524,26 @@ func (s *cacheSession) close() {
 	// that we also actually have the data.
 	mlx.AsyncEval(arrays...)
 
-	// Advance the trie frontier with any newly generated tokens.
+	// Advance the trie frontier with prompt tokens first, then keep generated
+	// output on a separate branch. Future prompt matching deliberately ignores
+	// generated branches; multi-turn prompts can still re-evaluate assistant
+	// output as input instead of restoring from post-generation state.
 	c := s.cache
 	if len(c.activePath) > 0 {
 		frontier := c.activePath[len(c.activePath)-1]
 		stored := append(s.inputs, s.outputs...)
 
-		if offset > frontier.endOffset {
+		promptEnd := min(offset, len(s.inputs))
+		if promptEnd > frontier.endOffset {
+			c.advancePath(frontier, s.inputs[frontier.endOffset:promptEnd], promptEnd)
+		}
+		if offset > promptEnd {
+			frontier = c.activePath[len(c.activePath)-1]
 			newTokens := stored[frontier.endOffset:offset]
-			c.advancePath(frontier, newTokens, offset)
+			newDest := frontier.appendTokens(c.root, newTokens, offset, true, c.caches, &c.pagedOutBytes)
+			if newDest != frontier {
+				c.activePath = append(c.activePath, newDest)
+			}
 		}
 		c.activePath[len(c.activePath)-1].lastUsed = time.Now()
 	}
@@ -517,6 +564,9 @@ func (c *kvCache) enforceEvictionPolicy() {
 		var best *trieNode
 		walkNodes(c.root, func(n *trieNode) bool {
 			if n == c.root || activeSet[n] || len(n.children) > 1 {
+				return true
+			}
+			if len(n.children) == 1 && n.generated != n.children[0].generated {
 				return true
 			}
 			// Evict: oldest, then deepest, then largest.
@@ -543,6 +593,10 @@ func (c *kvCache) evictNode(node *trieNode) {
 		slog.Debug("evicting leaf", "offset", node.startOffset(), "tokens", len(node.tokens), "freed", mlx.PrettyBytes(int(node.snapshotBytes())))
 		removeNode(node, &c.pagedOutBytes)
 	} else if len(node.children) == 1 {
+		if node.generated != node.children[0].generated {
+			slog.Debug("skipping cross-boundary eviction merge", "offset", node.startOffset(), "tokens", len(node.tokens))
+			return
+		}
 		// Interior node with one child: merge with child.
 		before := c.pagedOutBytes
 		tokens := len(node.tokens)
@@ -611,6 +665,9 @@ func (c *kvCache) dumpTree() {
 		if n.hasAllSnapshots() {
 			snapshotCount++
 			flags = append(flags, "snap")
+		}
+		if n.generated {
+			flags = append(flags, "generated")
 		}
 		if active[n] {
 			flags = append(flags, "active")

--- a/x/mlxrunner/cache_test.go
+++ b/x/mlxrunner/cache_test.go
@@ -505,6 +505,7 @@ func simulateRequest(t *testing.T, kvc *kvCache, inputs, generated []int32, user
 		feedAll(kvc.caches, remaining)
 	}
 	session.attachPrefillSnapshots()
+	session.capturePromptBoundary()
 
 	assertCacheOffsetAlignment(t, kvc, "after prefill")
 
@@ -585,16 +586,21 @@ func checkTrieInvariants(t *testing.T, root *trieNode) {
 				t.Errorf("child [%d,%d) parent mismatch", c.startOffset(), c.endOffset)
 			}
 		}
-		// No two siblings should start with the same token.
-		seen := make(map[int32]bool)
+		// No two siblings of the same branch kind should start with the same
+		// token. Prompt matching ignores generated branches.
+		type siblingKey struct {
+			token     int32
+			generated bool
+		}
+		seen := make(map[siblingKey]bool)
 		for _, c := range n.children {
 			if len(c.tokens) > 0 {
-				first := c.tokens[0]
-				if seen[first] {
-					t.Errorf("node [%d,%d): duplicate sibling first token %d",
-						n.startOffset(), n.endOffset, first)
+				key := siblingKey{token: c.tokens[0], generated: c.generated}
+				if seen[key] {
+					t.Errorf("node [%d,%d): duplicate sibling first token %d generated=%t",
+						n.startOffset(), n.endOffset, key.token, key.generated)
 				}
-				seen[first] = true
+				seen[key] = true
 			}
 		}
 		return true
@@ -658,64 +664,54 @@ func forEachEnv(t *testing.T, fn func(t *testing.T, env *testEnv)) {
 	t.Run("Recurrent", func(t *testing.T) { run(t, newRecurrentEnv()) })
 }
 
-// TestBranchCreationAndReuse exercises the core multi-conversation lifecycle:
+// TestBranchCreationWithoutPromptRestore exercises the core multi-conversation lifecycle:
 // two conversations share a prefix and diverge, creating a branch point.
-// A third conversation extends the first. Verifies trie structure, cache
-// hit lengths, and that semantic caches contain the correct token sequences.
-func TestBranchCreationAndReuse(t *testing.T) {
+// Divergent prompts are re-evaluated from the beginning so output does not
+// depend on partial-prefix cache reuse.
+func TestBranchCreationWithoutPromptRestore(t *testing.T) {
 	forEachEnv(t, func(t *testing.T, env *testEnv) {
 		kvc := env.kvc
 
-		// Request A: [1,2,3,4,5,6,7,8] + generate [20,21] — full miss.
+		// Request A: [1,2,3,4,5,6,7,8] + generate [20,21] - full miss.
 		resA := simulateRequest(t, kvc, []int32{1, 2, 3, 4, 5, 6, 7, 8}, []int32{20, 21})
 		if len(resA.remaining) != 8 {
 			t.Fatalf("A: remaining = %d, want 8 (full miss)", len(resA.remaining))
 		}
 		env.assertAllTokens(t, "after A", []int32{1, 2, 3, 4, 5, 6, 7, 8, 20, 21})
 
-		// Verify trie was populated by close().
+		// Verify only prompt tokens are matchable as future prompt input.
 		_, mA := findBestMatch(kvc.root, []int32{1, 2, 3, 4, 5, 6, 7, 8, 20, 21})
-		if mA != 10 {
-			t.Fatalf("A findable: expected 10 matched, got %d", mA)
+		if mA != 8 {
+			t.Fatalf("A findable: expected 8 matched, got %d", mA)
 		}
 
-		// Request B: [1,2,3,4,5,10,11,12] — shares 5-token prefix with A.
-		// For rewindable caches, switchToPath rewinds to the match point
-		// so only the non-matching suffix needs evaluation. For non-rewindable
-		// caches (RecurrentCache), the rewind fails and freeAll fires.
+		// Request B: [1,2,3,4,5,10,11,12] shares a 5-token prefix with A,
+		// but partial prompt matches are not reused.
 		resB := simulateRequest(t, kvc, []int32{1, 2, 3, 4, 5, 10, 11, 12}, []int32{30, 31})
-		if env.rewindable {
-			if resB.pendingSnapshots != 0 {
-				t.Fatalf("B: pendingSnapshots = %d, want 0 (rewind succeeded)", resB.pendingSnapshots)
-			}
-			if len(resB.remaining) != 3 {
-				t.Fatalf("B: remaining = %d, want 3 (rewind to match point)", len(resB.remaining))
-			}
-		} else {
-			if resB.pendingSnapshots != 1 {
-				t.Fatalf("B: pendingSnapshots = %d, want 1", resB.pendingSnapshots)
-			}
-			if len(resB.remaining) != 8 {
-				t.Fatalf("B: remaining = %d, want 8 (freeAll fallback)", len(resB.remaining))
-			}
+		if resB.pendingSnapshots != 0 {
+			t.Fatalf("B: pendingSnapshots = %d, want 0", resB.pendingSnapshots)
+		}
+		if len(resB.remaining) != 8 {
+			t.Fatalf("B: remaining = %d, want 8 (partial prompt match disabled)", len(resB.remaining))
 		}
 		env.assertAllTokens(t, "after B", []int32{1, 2, 3, 4, 5, 10, 11, 12, 30, 31})
 
-		// Both A and B should be findable in the trie.
+		// Both prompt branches should be fully matchable in the trie, but
+		// generated suffixes are not matchable as prompt input.
 		_, mA2 := findBestMatch(kvc.root, []int32{1, 2, 3, 4, 5, 6, 7, 8, 20, 21})
-		if mA2 < 5 {
-			t.Fatalf("A still findable: expected >= 5 matched, got %d", mA2)
+		if mA2 != 8 {
+			t.Fatalf("A still findable: expected 8 matched, got %d", mA2)
 		}
 		_, mB := findBestMatch(kvc.root, []int32{1, 2, 3, 4, 5, 10, 11, 12, 30, 31})
-		if mB < 5 {
-			t.Fatalf("B findable: expected >= 5 matched, got %d", mB)
+		if mB != 8 {
+			t.Fatalf("B findable: expected 8 matched, got %d", mB)
 		}
 
-		// Request C: [1,2,3,4,5,6,7,8,40,41] — extends A's prefix.
-		// Should get a cache hit for the shared prefix.
+		// Request C: [1,2,3,4,5,6,7,8,40,41] extends A's prefix, but is
+		// not an exact prompt match and must be fully re-evaluated.
 		resC := simulateRequest(t, kvc, []int32{1, 2, 3, 4, 5, 6, 7, 8, 40, 41}, nil)
-		if len(resC.remaining) >= 10 {
-			t.Fatalf("C: remaining = %d, want < 10 (should get cache hit)", len(resC.remaining))
+		if len(resC.remaining) != 10 {
+			t.Fatalf("C: remaining = %d, want 10 (partial prompt match disabled)", len(resC.remaining))
 		}
 		env.assertAllTokens(t, "after C", []int32{1, 2, 3, 4, 5, 6, 7, 8, 40, 41})
 
@@ -723,9 +719,10 @@ func TestBranchCreationAndReuse(t *testing.T) {
 	})
 }
 
-// TestExactMatchSeedBehavior verifies the holdback mechanism: when the exact
-// same prompt is requested twice, the cache does not overclaim cached work.
-// The last token must be re-evaluated to seed generation.
+// TestExactMatchSeedBehavior verifies the deterministic-safe cache policy:
+// even exact repeated prompts are re-evaluated instead of restored from MLX
+// cache state, because supported MLX models can otherwise produce
+// order-dependent outputs.
 func TestExactMatchSeedBehavior(t *testing.T) {
 	forEachEnv(t, func(t *testing.T, env *testEnv) {
 		kvc := env.kvc
@@ -733,25 +730,14 @@ func TestExactMatchSeedBehavior(t *testing.T) {
 		// Request A: first time.
 		simulateRequest(t, kvc, []int32{1, 2, 3, 4, 5}, []int32{10, 11})
 
-		// Request B: identical prompt. Holdback means matched=4, partial in
-		// the 5-token edge. For rewindable caches, switchToPath rewinds to
-		// offset 4, so only the held-back token needs re-evaluation. For
-		// non-rewindable caches, the rewind fails and freeAll fires.
+		// Request B: identical prompt. Matching cache state exists, but the
+		// deterministic-safe policy disables restoring it.
 		resB := simulateRequest(t, kvc, []int32{1, 2, 3, 4, 5}, []int32{20, 21})
-		if env.rewindable {
-			if len(resB.remaining) != 1 {
-				t.Fatalf("B: remaining = %d, want 1 (rewind to holdback point)", len(resB.remaining))
-			}
-			if resB.pendingSnapshots != 0 {
-				t.Fatalf("B: pendingSnapshots = %d, want 0 (rewind succeeded)", resB.pendingSnapshots)
-			}
-		} else {
-			if len(resB.remaining) != 5 {
-				t.Fatalf("B: remaining = %d, want 5 (freeAll fallback)", len(resB.remaining))
-			}
-			if resB.pendingSnapshots != 1 {
-				t.Fatalf("B: pendingSnapshots = %d, want 1", resB.pendingSnapshots)
-			}
+		if len(resB.remaining) != 5 {
+			t.Fatalf("B: remaining = %d, want 5 (prompt cache restore disabled)", len(resB.remaining))
+		}
+		if resB.pendingSnapshots != 0 {
+			t.Fatalf("B: pendingSnapshots = %d, want 0", resB.pendingSnapshots)
 		}
 		env.assertAllTokens(t, "after B", []int32{1, 2, 3, 4, 5, 20, 21})
 
@@ -759,9 +745,84 @@ func TestExactMatchSeedBehavior(t *testing.T) {
 	})
 }
 
+func TestGeneratedBranchIsNotMatchedAsPromptInput(t *testing.T) {
+	forEachEnv(t, func(t *testing.T, env *testEnv) {
+		kvc := env.kvc
+
+		simulateRequest(t, kvc, []int32{1, 2, 3}, []int32{4, 5})
+
+		res := simulateRequest(t, kvc, []int32{1, 2, 3, 4, 9}, nil)
+		if len(res.remaining) != 5 {
+			t.Fatalf("remaining = %d, want 5; generated or partial prompt branch was reused", len(res.remaining))
+		}
+
+		checkTrieInvariants(t, kvc.root)
+	})
+}
+
+func TestRepeatedGeneratedBranchesDoNotDuplicateSiblings(t *testing.T) {
+	forEachEnv(t, func(t *testing.T, env *testEnv) {
+		kvc := env.kvc
+
+		simulateRequest(t, kvc, []int32{1, 2, 3}, []int32{4, 5})
+		simulateRequest(t, kvc, []int32{1, 2, 3}, []int32{4, 5})
+		simulateRequest(t, kvc, []int32{1, 2, 3}, []int32{4, 6})
+
+		_, promptMatched := findBestMatch(kvc.root, []int32{1, 2, 3, 4, 5})
+		if promptMatched != 3 {
+			t.Fatalf("prompt match = %d, want 3; generated output became prompt-matchable", promptMatched)
+		}
+
+		promptPath, matched := findBestMatch(kvc.root, []int32{1, 2, 3})
+		if matched != 3 {
+			t.Fatalf("prompt matched = %d, want 3", matched)
+		}
+		promptNode := promptPath[len(promptPath)-1]
+		if _, generatedMatched := findBestMatchKind(promptNode, []int32{4, 5}, true); generatedMatched != 2 {
+			t.Fatalf("generated [4,5] matched = %d, want 2", generatedMatched)
+		}
+		if _, generatedMatched := findBestMatchKind(promptNode, []int32{4, 6}, true); generatedMatched != 2 {
+			t.Fatalf("generated [4,6] matched = %d, want 2", generatedMatched)
+		}
+
+		checkTrieInvariants(t, kvc.root)
+	})
+}
+
+func TestEvictionDoesNotMergeGeneratedBranchIntoPromptBranch(t *testing.T) {
+	forEachEnv(t, func(t *testing.T, env *testEnv) {
+		kvc := env.kvc
+
+		simulateRequest(t, kvc, []int32{1, 2, 3}, []int32{4, 5})
+		kvc.activePath = []*trieNode{kvc.root}
+
+		walkNodes(kvc.root, func(n *trieNode) bool {
+			if !n.hasSnapshots() {
+				return true
+			}
+			snaps := make([]cache.Snapshot, len(n.snapshots))
+			for i, s := range n.snapshots {
+				if s != nil {
+					snaps[i] = &fakeSnapshot{byteSize: 5 * 1024 * 1024 * 1024}
+				}
+			}
+			n.setSnapshots(snaps, &kvc.pagedOutBytes)
+			return true
+		})
+		kvc.enforceEvictionPolicy()
+
+		_, matched := findBestMatch(kvc.root, []int32{1, 2, 3, 4, 5})
+		if matched > 3 {
+			t.Fatalf("matched = %d, want at most 3; eviction merged generated tokens into prompt path", matched)
+		}
+
+		checkTrieInvariants(t, kvc.root)
+	})
+}
+
 // TestConversationResumption tests the most common pattern: user sends a message,
-// gets a response, then sends a follow-up. The follow-up should reuse the cached
-// prefix (system prompt + first turn + assistant response).
+// gets a response, then sends a follow-up. Generated output branches and partial
+// prompt prefixes are not reused as prompt input, so follow-ups are re-evaluated.
 func TestConversationResumption(t *testing.T) {
 	forEachEnv(t, func(t *testing.T, env *testEnv) {
 		kvc := env.kvc
@@ -770,18 +831,18 @@ func TestConversationResumption(t *testing.T) {
 		simulateRequest(t, kvc, []int32{1, 2, 3, 4, 5}, []int32{10, 11, 12})
 		env.assertAllTokens(t, "turn 1", []int32{1, 2, 3, 4, 5, 10, 11, 12})
 
-		// Turn 2: full history + new user message. Should get a cache hit on
-		// the prefix [1,2,3,4,5,10,11,12] and only need to evaluate [20,21].
+		// Turn 2: full history + new user message is not an exact prompt
+		// match and must not reuse cached partial-prefix state.
 		resB := simulateRequest(t, kvc, []int32{1, 2, 3, 4, 5, 10, 11, 12, 20, 21}, []int32{30})
-		if len(resB.remaining) > 5 {
-			t.Fatalf("turn 2: remaining = %d, want <= 5 (should reuse most of history)", len(resB.remaining))
+		if len(resB.remaining) != 10 {
+			t.Fatalf("turn 2: remaining = %d, want 10 (partial prompt match disabled)", len(resB.remaining))
 		}
 		env.assertAllTokens(t, "turn 2", []int32{1, 2, 3, 4, 5, 10, 11, 12, 20, 21, 30})
 
 		// Turn 3: even longer history.
 		resC := simulateRequest(t, kvc, []int32{1, 2, 3, 4, 5, 10, 11, 12, 20, 21, 30, 40, 41}, nil)
-		if len(resC.remaining) > 5 {
-			t.Fatalf("turn 3: remaining = %d, want <= 5", len(resC.remaining))
+		if len(resC.remaining) != 13 {
+			t.Fatalf("turn 3: remaining = %d, want 13 (partial prompt match disabled)", len(resC.remaining))
 		}
 		env.assertAllTokens(t, "turn 3", []int32{1, 2, 3, 4, 5, 10, 11, 12, 20, 21, 30, 40, 41})
 
@@ -1080,9 +1141,16 @@ func TestLRUOnlyUpdatesUsedNodes(t *testing.T) {
 				frontier.lastUsed, beforeRequest)
 		}
 
-		// Every non-frontier node on the active path (including root)
-		// should retain its old lastUsed — only the frontier gets refreshed.
+		// Every node before the prompt-boundary match should retain its old
+		// lastUsed. The prompt boundary may be refreshed because generated
+		// output is re-evaluated as prompt input from there.
 		for i, node := range kvc.activePath[:len(kvc.activePath)-1] {
+			if node == kvc.root {
+				continue
+			}
+			if node.endOffset == 5 {
+				continue
+			}
 			if !node.lastUsed.Before(beforeRequest) {
 				t.Errorf("activePath[%d] (endOffset=%d) lastUsed was refreshed: got %v, want < %v",
 					i, node.endOffset, node.lastUsed, beforeRequest)

--- a/x/mlxrunner/cache_trie.go
+++ b/x/mlxrunner/cache_trie.go
@@ -19,6 +19,7 @@ type trieNode struct {
 	lastUsed  time.Time        // for LRU eviction
 	snapshots []cache.Snapshot // per-layer paged-out snapshot data (nil if not paged out)
 	user      bool             // true = explicit restore point (resist auto-merge)
+	generated bool             // true when this edge contains generated output tokens
 }
 
 // startOffset returns the cumulative token offset at the start of this node's edge.
@@ -89,6 +90,10 @@ func (n *trieNode) hasAllSnapshots() bool {
 // findBestMatch walks the trie matching input tokens, returning the path of
 // nodes traversed and the total number of tokens matched.
 func findBestMatch(root *trieNode, tokens []int32) (path []*trieNode, matched int) {
+	return findBestMatchKind(root, tokens, false)
+}
+
+func findBestMatchKind(root *trieNode, tokens []int32, generated bool) (path []*trieNode, matched int) {
 	if root == nil {
 		return nil, 0
 	}
@@ -107,7 +112,7 @@ func findBestMatch(root *trieNode, tokens []int32) (path []*trieNode, matched in
 		bestFull := false
 		for _, child := range node.children {
 			edge := child.tokens
-			if len(edge) == 0 {
+			if child.generated != generated || len(edge) == 0 {
 				continue
 			}
 			if edge[0] != tokens[pos] {
@@ -145,13 +150,28 @@ func findBestMatch(root *trieNode, tokens []int32) (path []*trieNode, matched in
 
 // appendTokens either creates a new child node or extends the leaf in place,
 // returning the node that now holds the tokens.
-func (n *trieNode) appendTokens(root *trieNode, tokens []int32, endOffset int) *trieNode {
-	if n == root || len(n.children) > 0 || n.hasSnapshots() {
+func (n *trieNode) appendTokens(root *trieNode, tokens []int32, endOffset int, generated bool, caches []cache.Cache, counter *int64) *trieNode {
+	matchPath, matched := findBestMatchKind(n, tokens, generated)
+	if len(matchPath) > 1 {
+		lastNode := matchPath[len(matchPath)-1]
+		matchedInEdge := n.endOffset + matched - lastNode.startOffset()
+		if matchedInEdge > 0 && matchedInEdge < len(lastNode.tokens) {
+			lastNode = splitNode(lastNode, matchedInEdge, caches, counter)
+		}
+		if matched == len(tokens) {
+			return lastNode
+		}
+		n = lastNode
+		tokens = tokens[matched:]
+	}
+
+	if n == root || n.generated != generated || len(n.children) > 0 || n.hasSnapshots() {
 		child := &trieNode{
 			tokens:    make([]int32, len(tokens)),
 			endOffset: endOffset,
 			parent:    n,
 			lastUsed:  n.lastUsed,
+			generated: generated,
 		}
 		copy(child.tokens, tokens)
 		n.children = append(n.children, child)
@@ -198,6 +218,7 @@ func splitNode(node *trieNode, at int, caches []cache.Cache, counter *int64) *tr
 		parent:    node.parent,
 		children:  []*trieNode{node},
 		lastUsed:  node.lastUsed,
+		generated: node.generated,
 	}
 	copy(newParent.tokens, node.tokens[:at])
 
@@ -243,6 +264,9 @@ func mergeWithChild(node *trieNode, caches []cache.Cache, counter *int64) {
 	}
 
 	child := node.children[0]
+	if node.generated != child.generated {
+		panic("mergeWithChild called across prompt/generated boundary")
+	}
 
 	// Concatenate tokens.
 	node.tokens = append(node.tokens, child.tokens...)

--- a/x/mlxrunner/cache_trie_test.go
+++ b/x/mlxrunner/cache_trie_test.go
@@ -170,7 +170,7 @@ func TestFindSplitAppendSequence(t *testing.T) {
 	matchedInEdge := matched - lastNode.startOffset()
 	split := splitNode(lastNode, matchedInEdge, nil, nil)
 
-	split.appendTokens(root, []int32{6, 7}, 5)
+	split.appendTokens(root, []int32{6, 7}, 5, false, nil, nil)
 
 	if len(root.children) != 1 {
 		t.Fatalf("root should have 1 child, got %d", len(root.children))
@@ -200,7 +200,7 @@ func TestFindSplitAppendSequence(t *testing.T) {
 func TestRepeatedBranching(t *testing.T) {
 	root := &trieNode{lastUsed: time.Now()}
 
-	root.appendTokens(root, []int32{1, 2, 3, 4, 5}, 5)
+	root.appendTokens(root, []int32{1, 2, 3, 4, 5}, 5, false, nil, nil)
 
 	_, matchedB := findBestMatch(root, []int32{1, 2, 3, 6, 7})
 	if matchedB != 3 {
@@ -208,14 +208,14 @@ func TestRepeatedBranching(t *testing.T) {
 	}
 	nodeA := root.children[0]
 	split1 := splitNode(nodeA, 3, nil, nil)
-	split1.appendTokens(root, []int32{6, 7}, 5)
+	split1.appendTokens(root, []int32{6, 7}, 5, false, nil, nil)
 
 	_, matchedC := findBestMatch(root, []int32{1, 2, 8, 9})
 	if matchedC != 2 {
 		t.Fatalf("C: expected 2 matched, got %d", matchedC)
 	}
 	split2 := splitNode(split1, 2, nil, nil)
-	split2.appendTokens(root, []int32{8, 9}, 4)
+	split2.appendTokens(root, []int32{8, 9}, 4, false, nil, nil)
 
 	_, mA := findBestMatch(root, []int32{1, 2, 3, 4, 5})
 	if mA != 5 {

--- a/x/mlxrunner/mtp.go
+++ b/x/mlxrunner/mtp.go
@@ -177,6 +177,7 @@ func (r *Runner) runGreedyMTPDecode(ctx context.Context, request Request, sessio
 	}
 
 	hidden := targetForward(mlx.FromValues(seed, 1, len(seed)))
+	session.capturePromptBoundary()
 	current := sampler.Result{Token: greedyTokenFromLogits(r.lastLogits(hidden))}
 	mlx.Pin(current.Arrays()...)
 	mlx.Sweep()
@@ -317,6 +318,7 @@ func (r *Runner) runSampleMTPDecode(ctx context.Context, request Request, sessio
 	}
 
 	hidden := targetForward(mlx.FromValues(seed, 1, len(seed)))
+	session.capturePromptBoundary()
 	current := r.Sampler.Sample([]int{pipelineSlot}, r.lastLogits(hidden))
 	mlx.Pin(current.Arrays()...)
 	mlx.Sweep()

--- a/x/mlxrunner/pipeline.go
+++ b/x/mlxrunner/pipeline.go
@@ -80,9 +80,9 @@ func (r *Runner) TextGenerationPipeline(ctx context.Context, request Request) er
 	tokens := session.remaining
 	prefillChunk := prefillChunkSize()
 
-	// Request periodic snapshots during prefill and near the end of the
-	// prompt so that long prompts can be partially restored and
-	// thinking/generation can be retried without full reprocessing.
+	// Request periodic snapshots during prefill and near the end of the prompt.
+	// Prompt restore is currently disabled for deterministic correctness, but
+	// these snapshots keep the path available for a future safe restore policy.
 	const snapshotInterval = 8192
 	var snapshotOffsets []int
 	for offset := snapshotInterval; offset < len(inputs); offset += snapshotInterval {
@@ -162,6 +162,7 @@ func (r *Runner) TextGenerationPipeline(ctx context.Context, request Request) er
 	}
 
 	sample = step(mlx.FromValues(tokens[processed:], 1, total-processed))
+	session.capturePromptBoundary()
 	logutil.TraceContext(ctx, "mlx decode seed", "tokens", total-processed, "memory", mlx.Memory{})
 
 	dec := decoder{


### PR DESCRIPTION
# mlx: disable unsafe prompt cache restore

## Summary

Fixes https://github.com/ollama/ollama/issues/16860.

This PR disables MLX prompt-cache restore for now because the current restore path can change deterministic model output. The cache trie bookkeeping remains in place for diagnostics and for a future safe restore policy, but prompt input is re-evaluated instead of restoring a cached MLX state.

The change is intentionally correctness-first: it may reduce prompt-reuse performance for MLX models, but it removes an observable output correctness issue in supported Ollama models.

## Problem

With deterministic generation (`temperature=0`, fixed seed), MLX models could produce a different response depending on prior prompts in the same loaded runner session. This was reproducible with official GGUF/MLX model pairs where the GGUF model stayed stable and the MLX variant did not.

Observed failures before this change:

| Model | Phase | Result |
| --- | --- | --- |
| `gemma4:e4b-mlx` | `cached_order_C` after A/B/C prompts | Response length changed from `477` cold to `447`; `response_matches_cold=False` |
| `qwen3.6:27b-mlx` | warm exact prompt reuse | Response length changed from `698` cold to `672`; `response_matches_cold=False` |

The corresponding GGUF baselines stayed stable:

| Model | Phase | Result |
| --- | --- | --- |
| `gemma4:latest` | cold, warm, cached order, unloaded order | all matched cold |
| `qwen3.6:27b-q4_K_M` | cold, warm, cached order, unloaded order | all matched cold |

This shows an MLX prompt-cache restore correctness problem observed across multiple supported GGUF/MLX model pairs.

The issue was reproduced on both Apple M5 Max and Apple M1 Max systems. The same smaller official pairs, `gemma4:e2b-it-q4_K_M` vs `gemma4:e2b-mlx` and `qwen3.5:4b-q4_K_M` vs `qwen3.5:4b-mlx`, reproduce the same pattern on both machines: GGUF stays stable while MLX diverges under cache reuse. The fix was reverified on M1 and the divergences disappeared.

## Fix

- Do not restore cached prompt state in `cacheSession.begin`.
- Continue tracking prompt/generated cache trie state so the structure remains available for diagnostics and future safe restore work.
- Keep generated output on separate trie branches that are not matchable as prompt input.
- Capture prompt-boundary snapshots before generation mutates the live cache.
- Coalesce and split repeated generated branches with snapshot-aware trie updates, avoiding duplicate generated siblings on repeated deterministic prompts.
- Update mlxrunner cache tests to cover:
  - no prompt restore on exact prompt reuse
  - no generated-branch reuse as prompt input
  - no prompt/generated cross-boundary merge during eviction
  - repeated generated branches do not duplicate siblings

Although restore is disabled, this PR keeps cache bookkeeping correct so later restore work has tested prompt/generated boundaries.

## Probe Phases

Each probe compares later responses for prompt C against a cold baseline response for the same model. Prompts A, B, and C are fixed deterministic prompts used only to exercise runner cache state across prompt orderings.

- `cold_C`: prompt C after loading a fresh runner; this is the expected baseline.
- `warm_C`: prompt C repeated immediately in the same loaded runner.
- `cached_order_C`: prompt C after prompts A and B have already populated cache state in the same loaded runner.
- `unloaded_order_C`: prompt C after unloading/reloading around the ordered probe, used to distinguish persistent model behavior from loaded-runner cache state.

`Matches Cold` means exact response text equality with `cold_C`. Response length is included only as a compact symptom.

## Before / After

### Gemma4

Before:

| Model | Phase | Done | Response Length | Matches Cold |
| --- | --- | --- | ---: | --- |
| `gemma4:latest` | `cold_C` | `stop` | 502 | true |
| `gemma4:latest` | `warm_C` | `stop` | 502 | true |
| `gemma4:latest` | `cached_order_C` | `stop` | 502 | true |
| `gemma4:latest` | `unloaded_order_C` | `stop` | 502 | true |
| `gemma4:e4b-mlx` | `cold_C` | `stop` | 477 | true |
| `gemma4:e4b-mlx` | `warm_C` | `stop` | 477 | true |
| `gemma4:e4b-mlx` | `cached_order_C` | `stop` | 447 | false |
| `gemma4:e4b-mlx` | `unloaded_order_C` | `stop` | 477 | true |

After:

| Model | Phase | Done | Response Length | Matches Cold |
| --- | --- | --- | ---: | --- |
| `gemma4:latest` | `cold_C` | `stop` | 502 | true |
| `gemma4:latest` | `warm_C` | `stop` | 502 | true |
| `gemma4:latest` | `cached_order_C` | `stop` | 502 | true |
| `gemma4:latest` | `unloaded_order_C` | `stop` | 502 | true |
| `gemma4:e4b-mlx` | `cold_C` | `stop` | 477 | true |
| `gemma4:e4b-mlx` | `warm_C` | `stop` | 477 | true |
| `gemma4:e4b-mlx` | `cached_order_C` | `stop` | 477 | true |
| `gemma4:e4b-mlx` | `unloaded_order_C` | `stop` | 477 | true |

Artifacts:

- Before: `tmp/cache-order-gemma4-official-20260622T093435Z`
- After: `tmp/cache-order-gemma4-pr1-final-20260622T133613Z`

### Qwen3.6

Before:

| Model | Phase | Done | Response Length | Matches Cold |
| --- | --- | --- | ---: | --- |
| `qwen3.6:27b-q4_K_M` | `cold_C` | `stop` | 512 | true |
| `qwen3.6:27b-q4_K_M` | `warm_C` | `stop` | 512 | true |
| `qwen3.6:27b-q4_K_M` | `cached_order_C` | `stop` | 512 | true |
| `qwen3.6:27b-q4_K_M` | `unloaded_order_C` | `stop` | 512 | true |
| `qwen3.6:27b-mlx` | `cold_C` | `stop` | 698 | true |
| `qwen3.6:27b-mlx` | `warm_C` | `stop` | 672 | false |
| `qwen3.6:27b-mlx` | `cached_order_C` | `stop` | 698 | true |
| `qwen3.6:27b-mlx` | `unloaded_order_C` | `stop` | 698 | true |

After:

| Model | Phase | Done | Response Length | Matches Cold |
| --- | --- | --- | ---: | --- |
| `qwen3.6:27b-q4_K_M` | `cold_C` | `stop` | 512 | true |
| `qwen3.6:27b-q4_K_M` | `warm_C` | `stop` | 512 | true |
| `qwen3.6:27b-q4_K_M` | `cached_order_C` | `stop` | 512 | true |
| `qwen3.6:27b-q4_K_M` | `unloaded_order_C` | `stop` | 512 | true |
| `qwen3.6:27b-mlx` | `cold_C` | `stop` | 698 | true |
| `qwen3.6:27b-mlx` | `warm_C` | `stop` | 698 | true |
| `qwen3.6:27b-mlx` | `cached_order_C` | `stop` | 698 | true |
| `qwen3.6:27b-mlx` | `unloaded_order_C` | `stop` | 698 | true |

Artifacts:

- Before: `tmp/cache-order-qwen36-official-fixed-20260622T094255Z`
- After: `tmp/cache-order-qwen36-pr1-final-20260622T133613Z`

## Validation

- `go test ./x/mlxrunner -run Test -count=1`
- `./scripts/mlx_build.sh`
- macOS MCP `mlx_build.sh`
- Cache-order probe: `gemma4:latest` vs `gemma4:e4b-mlx`
- Cache-order probe: `qwen3.6:27b-q4_K_M` vs `qwen3.6:27b-mlx`

## Tradeoff

This disables prompt-cache restore for MLX models only, so repeated prompt evaluation can be slower than a correct restore implementation would be. That is deliberate for this PR: deterministic correctness should be restored first, and prompt-cache restore can be re-enabled later behind tests that prove it is bit-stable across the supported MLX paths.
