### PR TITLE
Add Bodega One to Community Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ console.log(response.message.content);
 ### Terminal & CLI
 
 - [aichat](https://github.com/sigoden/aichat) - All-in-one LLM CLI with Shell Assistant, RAG, and AI tools
+- [Bodega One Code](https://bodegaone.ai) - Terminal agentic coding client (TUI + headless) that pulls and runs Ollama models directly (bodega models pull hf.co/{repo}), with air-gap mode and QEL-verified edits
 - [oterm](https://github.com/ggozad/oterm) - Terminal client for Ollama
 - [gollama](https://github.com/sammcj/gollama) - Go-based model manager for Ollama
 - [tlm](https://github.com/yusufcanb/tlm) - Local shell copilot

--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ console.log(response.message.content);
 - [QodeAssist](https://github.com/Palm1r/QodeAssist) - AI coding assistant for Qt Creator
 - [AI Toolkit for VS Code](https://aka.ms/ai-tooklit/ollama-docs) - Microsoft-official VS Code extension
 - [Open Interpreter](https://docs.openinterpreter.com/language-model-setup/local-models/ollama) - Natural language interface for computers
+- [Bodega One](https://bodegaone.ai) - Local-first AI IDE that runs your Ollama models in chat and agentic code modes, with air-gap support and a quality layer that verifies generated code
 
 ### Libraries & SDKs
 


### PR DESCRIPTION
Adds Bodega One (local-first AI IDE, runs Ollama models fully offline) under Code Editors & Development.