### PR TITLE
llm: size mmproj offload by projector memory

### DIFF
--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -160,6 +160,7 @@ type llamaServerLaunchConfig struct {
 	modelPath            string
 	modelArch            string
 	projectors           []string
+	mmprojMemory         uint64
 	modelLayers          uint64
 	adapters             []string
 	opts                 api.Options
@@ -602,7 +603,12 @@ func appendMainGPUArgs(params []string, opts api.Options) []string {
 	return append(params, "--split-mode", "none", "--main-gpu", strconv.Itoa(*opts.MainGPU))
 }
 
-const limitedMMProjOffloadMemory = 10 << 30
+const (
+	// mmprojOffloadHeadroom leaves room for backend buffers beyond projector weights.
+	mmprojOffloadHeadroom = 1 << 30
+	// unknownMMProjOffloadMemory is the fallback projector size when GGUF metadata is unavailable.
+	unknownMMProjOffloadMemory = 2 << 30
+)
 
 func appendMMProjArgs(params []string, launch llamaServerLaunchConfig) []string {
 	if len(launch.projectors) == 0 {
@@ -622,16 +628,22 @@ func (launch llamaServerLaunchConfig) mmprojOffloadDisabled() (bool, string) {
 	if launch.forceNoMMProjOffload {
 		return true, "startup-oom-retry"
 	}
-	return shouldDisableMMProjOffload(launch.opts, launch.gpus, launch.modelLayers)
+	return shouldDisableMMProjOffload(launch.opts, launch.gpus, launch.modelLayers, launch.mmprojMemory)
 }
 
-func shouldDisableMMProjOffload(opts api.Options, gpus []ml.DeviceInfo, modelLayers uint64) (bool, string) {
+func shouldDisableMMProjOffload(opts api.Options, gpus []ml.DeviceInfo, modelLayers, mmprojMemory uint64) (bool, string) {
 	if opts.NumGPU == 0 {
 		return true, "cpu-only"
 	}
 	if opts.NumGPU > 0 && modelLayers > 0 && uint64(opts.NumGPU) < modelLayers {
 		return true, "partial-text-offload"
 	}
+
+	requiredMemory := mmprojMemory
+	if requiredMemory == 0 {
+		requiredMemory = unknownMMProjOffloadMemory
+	}
+	requiredMemory += mmprojOffloadHeadroom
 
 	for _, gpu := range gpus {
 		if gpu.Integrated && gpu.Library != "Metal" {
@@ -641,12 +653,46 @@ func shouldDisableMMProjOffload(opts api.Options, gpus []ml.DeviceInfo, modelLay
 		if memory == 0 || (gpu.TotalMemory > 0 && gpu.TotalMemory < memory) {
 			memory = gpu.TotalMemory
 		}
-		if memory > 0 && memory <= limitedMMProjOffloadMemory {
+		if memory > 0 && memory < requiredMemory {
 			return true, "limited-vram"
 		}
 	}
 
 	return false, ""
+}
+
+// mmprojMemoryRequirement is a stopgap until fit accounts for mmproj memory directly.
+func mmprojMemoryRequirement(modelPath string, f *ggml.GGML, projectors []string) (size uint64) {
+	if len(projectors) == 0 {
+		return 0
+	}
+
+	if projectors[0] == modelPath {
+		if f == nil {
+			return 0
+		}
+		for _, prefix := range []string{"v.", "mm.", "a."} {
+			for _, tensor := range f.Tensors().Items(prefix) {
+				size += tensor.Size()
+			}
+		}
+		return size
+	}
+
+	file, err := os.Open(projectors[0])
+	if err != nil {
+		return 0
+	}
+	defer file.Close()
+
+	projector, err := ggml.Decode(file, 1024)
+	if err != nil {
+		return 0
+	}
+	for _, tensor := range projector.Tensors().Items() {
+		size += tensor.Size()
+	}
+	return size
 }
 
 func appendJinjaArgs(params []string, config LlamaServerConfig) []string {
@@ -752,6 +798,7 @@ func NewLlamaServerRunner(
 		compatClipArches[arch] {
 		projectors = []string{modelPath}
 	}
+	mmprojMemory := mmprojMemoryRequirement(modelPath, f, projectors)
 	if config.DraftModelPath == "" && hasMTPDraft(f) {
 		config.EnableMTP = true
 	}
@@ -771,19 +818,20 @@ func NewLlamaServerRunner(
 	serverEnvs["LLAMA_MEDIA_MARKER"] = mediaMarker
 
 	launch := llamaServerLaunchConfig{
-		modelPath:   modelPath,
-		modelArch:   arch,
-		projectors:  slices.Clone(projectors),
-		modelLayers: f.KV().BlockCount() + 1,
-		adapters:    slices.Clone(adapters),
-		opts:        opts,
-		numParallel: numParallel,
-		kvCacheType: kvCacheType,
-		embedding:   isEmbedding,
-		config:      config,
-		gpus:        slices.Clone(gpus),
-		gpuLibs:     slices.Clone(gpuLibs),
-		extraEnvs:   cloneStringMap(serverEnvs),
+		modelPath:    modelPath,
+		modelArch:    arch,
+		projectors:   slices.Clone(projectors),
+		mmprojMemory: mmprojMemory,
+		modelLayers:  f.KV().BlockCount() + 1,
+		adapters:     slices.Clone(adapters),
+		opts:         opts,
+		numParallel:  numParallel,
+		kvCacheType:  kvCacheType,
+		embedding:    isEmbedding,
+		config:       config,
+		gpus:         slices.Clone(gpus),
+		gpuLibs:      slices.Clone(gpuLibs),
+		extraEnvs:    cloneStringMap(serverEnvs),
 	}
 
 	s := &llamaServerRunner{

--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -604,10 +604,8 @@ func appendMainGPUArgs(params []string, opts api.Options) []string {
 }
 
 const (
-	// mmprojOffloadHeadroom leaves room for backend buffers beyond projector weights.
+	// mmprojOffloadHeadroom leaves 1 GiB for backend buffers beyond projector weights.
 	mmprojOffloadHeadroom = 1 << 30
-	// unknownMMProjOffloadMemory is the fallback projector size when GGUF metadata is unavailable.
-	unknownMMProjOffloadMemory = 2 << 30
 )
 
 func appendMMProjArgs(params []string, launch llamaServerLaunchConfig) []string {
@@ -639,11 +637,7 @@ func shouldDisableMMProjOffload(opts api.Options, gpus []ml.DeviceInfo, modelLay
 		return true, "partial-text-offload"
 	}
 
-	requiredMemory := mmprojMemory
-	if requiredMemory == 0 {
-		requiredMemory = unknownMMProjOffloadMemory
-	}
-	requiredMemory += mmprojOffloadHeadroom
+	requiredMemory := mmprojMemory + mmprojOffloadHeadroom
 
 	for _, gpu := range gpus {
 		if gpu.Integrated && gpu.Library != "Metal" {
@@ -662,37 +656,45 @@ func shouldDisableMMProjOffload(opts api.Options, gpus []ml.DeviceInfo, modelLay
 }
 
 // mmprojMemoryRequirement is a stopgap until fit accounts for mmproj memory directly.
-func mmprojMemoryRequirement(modelPath string, f *ggml.GGML, projectors []string) (size uint64) {
+func mmprojMemoryRequirement(modelPath string, f *ggml.GGML, projectors []string) (uint64, error) {
 	if len(projectors) == 0 {
-		return 0
+		return 0, nil
 	}
 
 	if projectors[0] == modelPath {
 		if f == nil {
-			return 0
+			return 0, errors.New("read inline mmproj metadata: missing model metadata")
 		}
+		var size uint64
 		for _, prefix := range []string{"v.", "mm.", "a."} {
 			for _, tensor := range f.Tensors().Items(prefix) {
 				size += tensor.Size()
 			}
 		}
-		return size
+		if size == 0 {
+			return 0, errors.New("read inline mmproj metadata: no projector tensors found")
+		}
+		return size, nil
 	}
 
 	file, err := os.Open(projectors[0])
 	if err != nil {
-		return 0
+		return 0, fmt.Errorf("read mmproj metadata %q: %w", projectors[0], err)
 	}
 	defer file.Close()
 
 	projector, err := ggml.Decode(file, 1024)
 	if err != nil {
-		return 0
+		return 0, fmt.Errorf("read mmproj metadata %q: %w", projectors[0], err)
 	}
+	var size uint64
 	for _, tensor := range projector.Tensors().Items() {
 		size += tensor.Size()
 	}
-	return size
+	if size == 0 {
+		return 0, fmt.Errorf("read mmproj metadata %q: no projector tensors found", projectors[0])
+	}
+	return size, nil
 }
 
 func appendJinjaArgs(params []string, config LlamaServerConfig) []string {
@@ -798,7 +800,10 @@ func NewLlamaServerRunner(
 		compatClipArches[arch] {
 		projectors = []string{modelPath}
 	}
-	mmprojMemory := mmprojMemoryRequirement(modelPath, f, projectors)
+	mmprojMemory, err := mmprojMemoryRequirement(modelPath, f, projectors)
+	if err != nil {
+		return nil, err
+	}
 	if config.DraftModelPath == "" && hasMTPDraft(f) {
 		config.EnableMTP = true
 	}

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -1,6 +1,7 @@
 package llm
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -1961,13 +1962,14 @@ func TestAppendMMProjArgs(t *testing.T) {
 	cpuOpts.NumGPU = 0
 
 	tests := []struct {
-		name        string
-		projectors  []string
-		opts        api.Options
-		gpus        []ml.DeviceInfo
-		modelLayers uint64
-		retry       bool
-		want        []string
+		name         string
+		projectors   []string
+		opts         api.Options
+		gpus         []ml.DeviceInfo
+		mmprojMemory uint64
+		modelLayers  uint64
+		retry        bool
+		want         []string
 	}{
 		{
 			name: "no projector leaves args unchanged",
@@ -1983,12 +1985,22 @@ func TestAppendMMProjArgs(t *testing.T) {
 			want:        []string{"base", "--mmproj", "model.gguf"},
 		},
 		{
-			name:        "small discrete gpu disables projector offload",
-			projectors:  []string{"model.gguf"},
-			opts:        defaultOpts,
-			gpus:        []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}, TotalMemory: 8 << 30}},
-			modelLayers: 81,
-			want:        []string{"base", "--mmproj", "model.gguf", "--no-mmproj-offload"},
+			name:         "small discrete gpu keeps projector offload when projector fits",
+			projectors:   []string{"model.gguf"},
+			opts:         defaultOpts,
+			gpus:         []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "ROCm"}, FreeMemory: 7900 << 20, TotalMemory: 8 << 30}},
+			mmprojMemory: 933 << 20,
+			modelLayers:  81,
+			want:         []string{"base", "--mmproj", "model.gguf"},
+		},
+		{
+			name:         "tight discrete gpu disables projector offload",
+			projectors:   []string{"model.gguf"},
+			opts:         defaultOpts,
+			gpus:         []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}, FreeMemory: 1500 << 20, TotalMemory: 8 << 30}},
+			mmprojMemory: 933 << 20,
+			modelLayers:  81,
+			want:         []string{"base", "--mmproj", "model.gguf", "--no-mmproj-offload"},
 		},
 		{
 			name:        "integrated rocm gpu disables projector offload",
@@ -2046,6 +2058,7 @@ func TestAppendMMProjArgs(t *testing.T) {
 			got := appendMMProjArgs([]string{"base"}, llamaServerLaunchConfig{
 				modelPath:            "model.gguf",
 				projectors:           tt.projectors,
+				mmprojMemory:         tt.mmprojMemory,
 				opts:                 tt.opts,
 				gpus:                 tt.gpus,
 				modelLayers:          tt.modelLayers,
@@ -2055,6 +2068,29 @@ func TestAppendMMProjArgs(t *testing.T) {
 				t.Fatalf("appendMMProjArgs = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestMMProjMemoryRequirement(t *testing.T) {
+	modelPath, model := writeTestGGML(t, ggml.KV{"general.architecture": "gemma3"}, []*ggml.Tensor{
+		testGGMLTensor("blk.0.attn_q.weight", ggml.TensorTypeF32, []uint64{4}),
+		testGGMLTensor("v.patch_embd.weight", ggml.TensorTypeF16, []uint64{16}),
+		testGGMLTensor("mm.0.weight", ggml.TensorTypeF32, []uint64{8}),
+		testGGMLTensor("a.encoder.weight", ggml.TensorTypeF32, []uint64{2}),
+	})
+
+	wantInline := uint64(16*2 + 8*4 + 2*4)
+	if got := mmprojMemoryRequirement(modelPath, model, []string{modelPath}); got != wantInline {
+		t.Fatalf("inline mmproj memory = %d, want %d", got, wantInline)
+	}
+
+	projectorPath, _ := writeTestGGML(t, ggml.KV{"general.architecture": "clip"}, []*ggml.Tensor{
+		testGGMLTensor("vision.weight", ggml.TensorTypeF16, []uint64{32}),
+		testGGMLTensor("audio.weight", ggml.TensorTypeF32, []uint64{4}),
+	})
+	wantProjector := uint64(32*2 + 4*4)
+	if got := mmprojMemoryRequirement(modelPath, model, []string{projectorPath}); got != wantProjector {
+		t.Fatalf("projector file memory = %d, want %d", got, wantProjector)
 	}
 }
 
@@ -3145,11 +3181,18 @@ func TestFindLlamaServer(t *testing.T) {
 func loadTestGGML(t *testing.T, kv ggml.KV) *ggml.GGML {
 	t.Helper()
 
+	_, model := writeTestGGML(t, kv, nil)
+	return model
+}
+
+func writeTestGGML(t *testing.T, kv ggml.KV, tensors []*ggml.Tensor) (string, *ggml.GGML) {
+	t.Helper()
+
 	f, err := os.CreateTemp(t.TempDir(), "*.gguf")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := ggml.WriteGGUF(f, kv, nil); err != nil {
+	if err := ggml.WriteGGUF(f, kv, tensors); err != nil {
 		t.Fatal(err)
 	}
 	if err := f.Close(); err != nil {
@@ -3160,7 +3203,17 @@ func loadTestGGML(t *testing.T, kv ggml.KV) *ggml.GGML {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return model
+	return f.Name(), model
+}
+
+func testGGMLTensor(name string, kind ggml.TensorType, shape []uint64) *ggml.Tensor {
+	tensor := &ggml.Tensor{
+		Name:  name,
+		Kind:  uint32(kind),
+		Shape: shape,
+	}
+	tensor.WriterTo = bytes.NewReader(make([]byte, tensor.Size()))
+	return tensor
 }
 
 // fakeRunningCmd returns an exec.Cmd that looks like it's still running

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -1977,12 +1977,13 @@ func TestAppendMMProjArgs(t *testing.T) {
 			want: []string{"base"},
 		},
 		{
-			name:        "large discrete gpu keeps projector offload",
-			projectors:  []string{"model.gguf"},
-			opts:        defaultOpts,
-			gpus:        []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}, FreeMemory: 24 << 30}},
-			modelLayers: 81,
-			want:        []string{"base", "--mmproj", "model.gguf"},
+			name:         "large discrete gpu keeps projector offload",
+			projectors:   []string{"model.gguf"},
+			opts:         defaultOpts,
+			gpus:         []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}, FreeMemory: 24 << 30}},
+			mmprojMemory: 933 << 20,
+			modelLayers:  81,
+			want:         []string{"base", "--mmproj", "model.gguf"},
 		},
 		{
 			name:         "small discrete gpu keeps projector offload when projector fits",
@@ -2003,53 +2004,59 @@ func TestAppendMMProjArgs(t *testing.T) {
 			want:         []string{"base", "--mmproj", "model.gguf", "--no-mmproj-offload"},
 		},
 		{
-			name:        "integrated rocm gpu disables projector offload",
-			projectors:  []string{"model.gguf"},
-			opts:        defaultOpts,
-			gpus:        []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "ROCm"}, Integrated: true, FreeMemory: 32 << 30}},
-			modelLayers: 81,
-			want:        []string{"base", "--mmproj", "model.gguf", "--no-mmproj-offload"},
+			name:         "integrated rocm gpu disables projector offload",
+			projectors:   []string{"model.gguf"},
+			opts:         defaultOpts,
+			gpus:         []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "ROCm"}, Integrated: true, FreeMemory: 32 << 30}},
+			mmprojMemory: 933 << 20,
+			modelLayers:  81,
+			want:         []string{"base", "--mmproj", "model.gguf", "--no-mmproj-offload"},
 		},
 		{
-			name:        "integrated metal gpu keeps projector offload",
-			projectors:  []string{"model.gguf"},
-			opts:        defaultOpts,
-			gpus:        []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "Metal"}, Integrated: true, FreeMemory: 32 << 30}},
-			modelLayers: 81,
-			want:        []string{"base", "--mmproj", "model.gguf"},
+			name:         "integrated metal gpu keeps projector offload",
+			projectors:   []string{"model.gguf"},
+			opts:         defaultOpts,
+			gpus:         []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "Metal"}, Integrated: true, FreeMemory: 32 << 30}},
+			mmprojMemory: 933 << 20,
+			modelLayers:  81,
+			want:         []string{"base", "--mmproj", "model.gguf"},
 		},
 		{
-			name:        "cpu only request disables projector offload",
-			projectors:  []string{"model.gguf"},
-			opts:        cpuOpts,
-			gpus:        []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}, FreeMemory: 24 << 30}},
-			modelLayers: 81,
-			want:        []string{"base", "--mmproj", "model.gguf", "--no-mmproj-offload"},
+			name:         "cpu only request disables projector offload",
+			projectors:   []string{"model.gguf"},
+			opts:         cpuOpts,
+			gpus:         []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}, FreeMemory: 24 << 30}},
+			mmprojMemory: 933 << 20,
+			modelLayers:  81,
+			want:         []string{"base", "--mmproj", "model.gguf", "--no-mmproj-offload"},
 		},
 		{
-			name:        "partial text offload disables projector offload",
-			projectors:  []string{"model.gguf"},
-			opts:        partialOpts,
-			gpus:        []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}, FreeMemory: 24 << 30}},
-			modelLayers: 81,
-			want:        []string{"base", "--mmproj", "model.gguf", "--no-mmproj-offload"},
+			name:         "partial text offload disables projector offload",
+			projectors:   []string{"model.gguf"},
+			opts:         partialOpts,
+			gpus:         []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}, FreeMemory: 24 << 30}},
+			mmprojMemory: 933 << 20,
+			modelLayers:  81,
+			want:         []string{"base", "--mmproj", "model.gguf", "--no-mmproj-offload"},
 		},
 		{
-			name:        "explicit full text offload keeps projector offload",
-			projectors:  []string{"model.gguf"},
-			opts:        fullOpts,
-			gpus:        []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}, FreeMemory: 24 << 30}},
-			modelLayers: 81,
-			want:        []string{"base", "--mmproj", "model.gguf"},
+			name:         "explicit full text offload keeps projector offload",
+			projectors:   []string{"model.gguf"},
+			opts:         fullOpts,
+			gpus:         []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}, FreeMemory: 24 << 30}},
+			mmprojMemory: 933 << 20,
+			modelLayers:  81,
+			want:         []string{"base", "--mmproj", "model.gguf"},
 		},
 		{
-			name:        "startup oom retry disables projector offload",
-			projectors:  []string{"model.gguf"},
-			opts:        defaultOpts,
-			gpus:        []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}, FreeMemory: 24 << 30}},
-			modelLayers: 81,
-			retry:       true,
-			want:        []string{"base", "--mmproj", "model.gguf", "--no-mmproj-offload"},
+			name:         "startup oom retry disables projector offload",
+			projectors:   []string{"model.gguf"},
+			opts:         defaultOpts,
+			gpus:         []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}, FreeMemory: 24 << 30}},
+			mmprojMemory: 933 << 20,
+			modelLayers:  81,
+			retry:        true,
+			want:         []string{"base", "--mmproj", "model.gguf", "--no-mmproj-offload"},
 		},
 	}
 
@@ -2072,6 +2079,10 @@ func TestAppendMMProjArgs(t *testing.T) {
 }
 
 func TestMMProjMemoryRequirement(t *testing.T) {
+	if got, err := mmprojMemoryRequirement("model.gguf", nil, nil); err != nil || got != 0 {
+		t.Fatalf("no projector memory = %d, %v; want 0, nil", got, err)
+	}
+
 	modelPath, model := writeTestGGML(t, ggml.KV{"general.architecture": "gemma3"}, []*ggml.Tensor{
 		testGGMLTensor("blk.0.attn_q.weight", ggml.TensorTypeF32, []uint64{4}),
 		testGGMLTensor("v.patch_embd.weight", ggml.TensorTypeF16, []uint64{16}),
@@ -2080,8 +2091,8 @@ func TestMMProjMemoryRequirement(t *testing.T) {
 	})
 
 	wantInline := uint64(16*2 + 8*4 + 2*4)
-	if got := mmprojMemoryRequirement(modelPath, model, []string{modelPath}); got != wantInline {
-		t.Fatalf("inline mmproj memory = %d, want %d", got, wantInline)
+	if got, err := mmprojMemoryRequirement(modelPath, model, []string{modelPath}); err != nil || got != wantInline {
+		t.Fatalf("inline mmproj memory = %d, %v; want %d, nil", got, err, wantInline)
 	}
 
 	projectorPath, _ := writeTestGGML(t, ggml.KV{"general.architecture": "clip"}, []*ggml.Tensor{
@@ -2089,8 +2100,20 @@ func TestMMProjMemoryRequirement(t *testing.T) {
 		testGGMLTensor("audio.weight", ggml.TensorTypeF32, []uint64{4}),
 	})
 	wantProjector := uint64(32*2 + 4*4)
-	if got := mmprojMemoryRequirement(modelPath, model, []string{projectorPath}); got != wantProjector {
-		t.Fatalf("projector file memory = %d, want %d", got, wantProjector)
+	if got, err := mmprojMemoryRequirement(modelPath, model, []string{projectorPath}); err != nil || got != wantProjector {
+		t.Fatalf("projector file memory = %d, %v; want %d, nil", got, err, wantProjector)
+	}
+
+	if _, err := mmprojMemoryRequirement(modelPath, nil, []string{modelPath}); err == nil {
+		t.Fatal("inline mmproj with nil model error = nil, want error")
+	}
+	if _, err := mmprojMemoryRequirement(modelPath, model, []string{filepath.Join(t.TempDir(), "missing.gguf")}); err == nil {
+		t.Fatal("missing projector error = nil, want error")
+	}
+
+	emptyProjectorPath, _ := writeTestGGML(t, ggml.KV{"general.architecture": "clip"}, nil)
+	if _, err := mmprojMemoryRequirement(modelPath, model, []string{emptyProjectorPath}); err == nil {
+		t.Fatal("empty projector error = nil, want error")
 	}
 }
 


### PR DESCRIPTION
Replace the blanket 10 GiB VRAM cutoff with a projector tensor-size estimate plus backend headroom, while preserving the existing CPU-only, partial text offload, shared-memory GPU, and startup OOM retry gates.

This is a stopgap until fit accounts for mmproj memory directly.

The same limited-vram path appears in the qwen3.5 vision hang report: the logs show --no-mmproj-offload on a 7.5 GiB RTX 5050 with about 6.4 GiB free while llama-server estimates the inline mmproj at about 962 MiB.

Fixes #16496

Fixes #16570