### PR TITLE
docs: mark Logprobs as supported in OpenAI compatibility

### DIFF
--- a/docs/api/openai-compatibility.mdx
+++ b/docs/api/openai-compatibility.mdx
@@ -185,7 +185,7 @@ curl -X POST http://localhost:11434/v1/chat/completions \
 - [x] Vision
 - [x] Tools
 - [x] Reasoning/thinking control (for thinking models)
-- [ ] Logprobs
+- [x] Logprobs
 
 #### Supported request fields
 
@@ -224,7 +224,7 @@ curl -X POST http://localhost:11434/v1/chat/completions \
 - [x] Streaming
 - [x] JSON mode
 - [x] Reproducible outputs
-- [ ] Logprobs
+- [x] Logprobs
 
 #### Supported request fields
 


### PR DESCRIPTION
The OpenAI-compatibility doc lists `Logprobs` as unsupported (`- [ ] Logprobs`) in both the chat and completions sections, but it is fully implemented:

- request fields `Logprobs`/`TopLogprobs` in `openai/openai.go`
- response population into `ChoiceLogprobs` in `openai/openai.go`
- covered by `TestFromChatRequest_WithLogprobs` in `openai/openai_test.go`

This flips both checkboxes to `- [x] Logprobs` to match the implementation.