### PR TITLE
readme: add nolock to Code Editors & Development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ console.log(response.message.content);
 - [Copilot for Obsidian](https://github.com/logancyang/obsidian-copilot) - AI assistant for Obsidian
 - [twinny](https://github.com/rjmacarthy/twinny) - Copilot and Copilot chat alternative
 - [gptel Emacs client](https://github.com/karthink/gptel) - LLM client for Emacs
+- [nolock](https://github.com/impacte-tech/nolock) - Privacy-first, AI-native desktop IDE with local Ollama support
 - [Ollama Copilot](https://github.com/bernardo-bruning/ollama-copilot) - Use Ollama as GitHub Copilot
 - [Obsidian Local GPT](https://github.com/pfrankov/obsidian-local-gpt) - Local AI for Obsidian
 - [Ellama Emacs client](https://github.com/s-kostyaev/ellama) - LLM tool for Emacs


### PR DESCRIPTION
nolock is a privacy-first, AI-native desktop IDE built for developers who want AI assistance without losing control of their codebase. It belongs in the Community Integrations list because it's core values are:

Air-gapped & private: Zero telemetry, no accounts, no cloud dependency. Everything runs locally on your machine with full offline support.

Community-built for students, by students: Developed by a community of STEM, Computer Science, and AI students who believe AI should augment human judgment, not replace it. nolock is designed to keep the developer firmly in the driver's seat.

Free and accessible: Open source (GPL-3.0) and free forever. No vendor lock-in, no paid tiers, no API costs. AI-assisted coding should be available to everyone, regardless of budget.

The editor integrates with Ollama (and other backends like llama.cpp and OpenRouter) for inline code completions and agentic chat with tool-calling — all running locally.