### PR TITLE
docs: document max think level

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -46,7 +46,7 @@ Generate a response for a given prompt with a provided model. This is a streamin
 - `prompt`: the prompt to generate a response for
 - `suffix`: the text after the model response
 - `images`: (optional) a list of base64-encoded images (for multimodal models such as `llava`)
-- `think`: (for thinking models) should the model think before responding?
+- `think`: (for thinking models) should the model think before responding? Can be a boolean or a thinking level (`"low"`, `"medium"`, `"high"`, or `"max"`).
 
 Advanced parameters (optional):
 
@@ -504,7 +504,7 @@ Generate the next message in a chat with a provided model. This is a streaming e
 - `model`: (required) the [model name](#model-names)
 - `messages`: the messages of the chat, this can be used to keep a chat memory
 - `tools`: list of tools in JSON for the model to use if supported
-- `think`: (for thinking models) should the model think before responding?
+- `think`: (for thinking models) should the model think before responding? Can be a boolean or a thinking level (`"low"`, `"medium"`, `"high"`, or `"max"`).
 
 The `message` object has the following fields:
 

--- a/docs/api/openai-compatibility.mdx
+++ b/docs/api/openai-compatibility.mdx
@@ -208,9 +208,9 @@ curl -X POST http://localhost:11434/v1/chat/completions \
 - [x] `top_p`
 - [x] `max_tokens`
 - [x] `tools`
-- [x] `reasoning_effort` (`"high"`, `"medium"`, `"low"`, `"none"`)
+- [x] `reasoning_effort` (`"high"`, `"medium"`, `"low"`, `"max"`, `"none"`)
 - [x] `reasoning`
-  - [x] `effort` (`"high"`, `"medium"`, `"low"`, `"none"`)
+  - [x] `effort` (`"high"`, `"medium"`, `"low"`, `"max"`, `"none"`)
 - [ ] `tool_choice`
 - [ ] `logit_bias`
 - [ ] `user`

--- a/docs/capabilities/thinking.mdx
+++ b/docs/capabilities/thinking.mdx
@@ -16,9 +16,9 @@ Use this capability to audit model steps, animate the model *thinking* in a UI, 
 
 ## Enable thinking in API calls
 
-Set the `think` field on chat or generate requests. Most models accept booleans (`true`/`false`).
+Set the `think` field on chat or generate requests. Most models accept booleans (`true`/`false`) or levels (`low`, `medium`, `high`, `max`), where `max` requests the highest thinking level.
 
-GPT-OSS instead expects one of `low`, `medium`, or `high` to tune the trace length. 
+GPT-OSS instead expects one of `low`, `medium`, or `high` to tune the trace length.
 
 The `message.thinking` (chat endpoint) or `thinking` (generate endpoint) field contains the reasoning trace while `message.content` / `response` holds the final answer.
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -99,8 +99,8 @@ components:
           oneOf:
             - type: boolean
             - type: string
-              enum: [high, medium, low]
-          description: When true, returns separate thinking output in addition to content. Can be a boolean (true/false) or a string ("high", "medium", "low") for supported models.
+              enum: [high, medium, low, max]
+          description: When true, returns separate thinking output in addition to content. Can be a boolean (true/false) or a string ("high", "medium", "low", "max") for supported models, with "max" requesting the highest thinking level.
         raw:
           type: boolean
           description: When true, returns the raw response from the model without any prompt templating
@@ -291,8 +291,8 @@ components:
           oneOf:
             - type: boolean
             - type: string
-              enum: [high, medium, low]
-          description: When true, returns separate thinking output in addition to content. Can be a boolean (true/false) or a string ("high", "medium", "low") for supported models.
+              enum: [high, medium, low, max]
+          description: When true, returns separate thinking output in addition to content. Can be a boolean (true/false) or a string ("high", "medium", "low", "max") for supported models, with "max" requesting the highest thinking level.
         keep_alive:
           oneOf:
             - type: string


### PR DESCRIPTION
## Summary

- Document `think: "max"` as an accepted native API value for generate and chat requests.
- Update the OpenAPI schema for generate/chat `think` enums and descriptions.
- Update OpenAI-compatible reasoning effort docs to include `"max"`.
- Keep GPT-OSS-specific guidance limited to `low`, `medium`, and `high`.

## Validation

- `go test ./api ./openai ./anthropic`
- `ruby -e "require 'yaml'; YAML.load_file('docs/openapi.yaml'); puts 'docs/openapi.yaml OK'"`
- `rg` scan for GPT-OSS-specific `max` mentions
