### PR TITLE
sched: align placement reserve with llama fit target

### DIFF
--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -774,8 +774,8 @@ func hasLegacyQwenMTPDraft(arch string, tensors []*ggml.Tensor) bool {
 	}
 }
 
-// llamaServerDefaultFitTargetMiB mirrors llama.cpp's default per-device fit margin.
-const llamaServerDefaultFitTargetMiB = 1024
+// LlamaServerDefaultFitTargetMiB mirrors llama.cpp's default per-device fit margin.
+const LlamaServerDefaultFitTargetMiB = 1024
 
 func applyGPUOverheadFitTargetEnv(env map[string]string) {
 	if envconfig.Var("LLAMA_ARG_FIT_TARGET") != "" {
@@ -783,7 +783,7 @@ func applyGPUOverheadFitTargetEnv(env map[string]string) {
 	}
 
 	const bytesPerMiB = uint64(1024 * 1024)
-	if overhead := envconfig.GpuOverhead(); overhead > llamaServerDefaultFitTargetMiB*bytesPerMiB {
+	if overhead := envconfig.GpuOverhead(); overhead > LlamaServerDefaultFitTargetMiB*bytesPerMiB {
 		env["LLAMA_ARG_FIT_TARGET"] = strconv.FormatUint((overhead+bytesPerMiB-1)/bytesPerMiB, 10)
 	}
 }

--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -774,6 +774,20 @@ func hasLegacyQwenMTPDraft(arch string, tensors []*ggml.Tensor) bool {
 	}
 }
 
+// llamaServerDefaultFitTargetMiB mirrors llama.cpp's default per-device fit margin.
+const llamaServerDefaultFitTargetMiB = 1024
+
+func applyGPUOverheadFitTargetEnv(env map[string]string) {
+	if envconfig.Var("LLAMA_ARG_FIT_TARGET") != "" {
+		return
+	}
+
+	const bytesPerMiB = uint64(1024 * 1024)
+	if overhead := envconfig.GpuOverhead(); overhead > llamaServerDefaultFitTargetMiB*bytesPerMiB {
+		env["LLAMA_ARG_FIT_TARGET"] = strconv.FormatUint((overhead+bytesPerMiB-1)/bytesPerMiB, 10)
+	}
+}
+
 // NewLlamaServerRunner creates a new llama-server runner that wraps the upstream llama-server binary.
 func NewLlamaServerRunner(
 	gpus []ml.DeviceInfo,
@@ -839,6 +853,7 @@ func NewLlamaServerRunner(
 		serverEnvs[k] = v
 	}
 	serverEnvs["LLAMA_MEDIA_MARKER"] = mediaMarker
+	applyGPUOverheadFitTargetEnv(serverEnvs)
 
 	launch := llamaServerLaunchConfig{
 		modelPath:    modelPath,

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -2036,6 +2036,26 @@ func TestAppendFlashAttentionArgs(t *testing.T) {
 	}
 }
 
+func TestApplyGPUOverheadFitTargetEnv(t *testing.T) {
+	check := func(name, overhead, fitTarget, want string, wantSet bool) {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("OLLAMA_GPU_OVERHEAD", overhead)
+			t.Setenv("LLAMA_ARG_FIT_TARGET", fitTarget)
+			env := map[string]string{}
+			applyGPUOverheadFitTargetEnv(env)
+			got, ok := env["LLAMA_ARG_FIT_TARGET"]
+			if ok != wantSet || got != want {
+				t.Fatalf("LLAMA_ARG_FIT_TARGET = %q, set %v; want %q, set %v", got, ok, want, wantSet)
+			}
+		})
+	}
+
+	check("below default", "536870912", "", "", false)
+	check("above default", "2147483648", "", "2048", true)
+	check("rounds up", "1073741825", "", "1025", true)
+	check("explicit fit target wins", "2147483648", "512", "", false)
+}
+
 func TestAppendMainGPUArgs(t *testing.T) {
 	tests := []struct {
 		name string

--- a/llm/server.go
+++ b/llm/server.go
@@ -41,6 +41,7 @@ func filteredEnvLogKey(key string) bool {
 		strings.HasPrefix(key, "HSA_") ||
 		strings.HasPrefix(key, "GGML_") ||
 		slices.Contains([]string{
+			"LLAMA_ARG_FIT_TARGET",
 			"PATH",
 			"LD_LIBRARY_PATH",
 			"DYLD_LIBRARY_PATH",

--- a/server/sched.go
+++ b/server/sched.go
@@ -933,9 +933,6 @@ func nextLowerAutoNumCtx(numCtx int) (int, bool) {
 	}
 }
 
-// llamaServerDefaultFitTargetMiB mirrors llama.cpp's default per-device fit margin.
-const llamaServerDefaultFitTargetMiB = 1024
-
 func availableMemoryForLoad(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo) (available, gpuFree uint64, systemLimited bool) {
 	var sharedGPUFree uint64
 	var discreteGPUFree uint64
@@ -1046,6 +1043,8 @@ func selectLlamaServerPlacement(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, 
 }
 
 func singleLlamaServerGPUPlacement(gpu ml.DeviceInfo, opts api.Options) ([]ml.DeviceInfo, api.Options) {
+	// llama-server sees only the selected GPU after compaction, so the selected
+	// device is index 0 for both main_gpu and per-device fit-target values.
 	mainGPU := 0
 	opts.MainGPU = &mainGPU
 	return []ml.DeviceInfo{gpu}, opts
@@ -1131,34 +1130,34 @@ func hasDiscreteGPU(gpus []ml.DeviceInfo) bool {
 	return false
 }
 
-func availableMemoryForGPU(systemInfo ml.SystemInfo, gpu ml.DeviceInfo, index int) uint64 {
+func availableMemoryForGPU(systemInfo ml.SystemInfo, gpu ml.DeviceInfo, visibleIndex int) uint64 {
 	available := gpu.FreeMemory
 	if gpu.Integrated && systemInfo.FreeMemory > 0 && systemInfo.FreeMemory < gpu.FreeMemory {
 		available = systemInfo.FreeMemory
 	}
 
-	return saturatingSubtract(available, llamaServerDeviceReserve(gpu, index))
+	return saturatingSubtract(available, llamaServerDeviceReserve(gpu, visibleIndex))
 }
 
-func llamaServerDeviceReserve(gpu ml.DeviceInfo, index int) uint64 {
-	return gpu.MinimumMemory() + max(envconfig.GpuOverhead(), llamaServerFitTargetBytes(index))
+func llamaServerDeviceReserve(gpu ml.DeviceInfo, visibleIndex int) uint64 {
+	return gpu.MinimumMemory() + max(envconfig.GpuOverhead(), llamaServerFitTargetBytes(visibleIndex))
 }
 
-func llamaServerFitTargetBytes(index int) uint64 {
+func llamaServerFitTargetBytes(visibleIndex int) uint64 {
 	value := envconfig.Var("LLAMA_ARG_FIT_TARGET")
 	if value != "" {
 		targets := strings.Split(value, ",")
 		if len(targets) == 1 {
-			index = 0
+			visibleIndex = 0
 		}
-		if index < len(targets) {
-			if target, err := strconv.ParseUint(strings.TrimSpace(targets[index]), 10, 64); err == nil {
+		if visibleIndex < len(targets) {
+			if target, err := strconv.ParseUint(strings.TrimSpace(targets[visibleIndex]), 10, 64); err == nil {
 				return target * format.MebiByte
 			}
 		}
 	}
 
-	return llamaServerDefaultFitTargetMiB * format.MebiByte
+	return llm.LlamaServerDefaultFitTargetMiB * format.MebiByte
 }
 
 func saturatingSubtract(value, reserve uint64) uint64 {

--- a/server/sched.go
+++ b/server/sched.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -552,8 +553,7 @@ func (s *Scheduler) load(req *LlmRequest, systemInfo ml.SystemInfo, gpus []ml.De
 			// we predict it won't fit, evict before spawning.
 			if requireFull && !explicitPartialGPUOffload(launchOpts, f) && len(s.loaded) > 0 && len(loadGpus) > 0 {
 				freeMemory, gpuFreeMemory, systemLimited := availableMemoryForPlacement(systemInfo, loadGpus, launchOpts)
-				// Use 80% of free memory as threshold to leave headroom.
-				if predictedForLoad > freeMemory*80/100 {
+				if predictedForLoad > freeMemory {
 					slog.Info("llama-server model predicted to exceed available memory, evicting",
 						"predicted", format.HumanBytes2(predictedForLoad),
 						"predicted_num_ctx", predictedCtx,
@@ -622,11 +622,8 @@ func (s *Scheduler) load(req *LlmRequest, systemInfo ml.SystemInfo, gpus []ml.De
 	systemSwapFreeMemory := systemInfo.FreeSwap
 	slog.Info("system memory", "total", format.HumanBytes2(systemTotalMemory), "free", format.HumanBytes2(systemFreeMemory), "free_swap", format.HumanBytes2(systemSwapFreeMemory))
 
-	for _, gpu := range loadGpus {
-		available := gpu.FreeMemory - envconfig.GpuOverhead() - gpu.MinimumMemory()
-		if gpu.FreeMemory < envconfig.GpuOverhead()+gpu.MinimumMemory() {
-			available = 0
-		}
+	for i, gpu := range loadGpus {
+		available := availableMemoryForGPU(systemInfo, gpu, i)
 		slog.Info("gpu memory", "id", gpu.ID, "library", gpu.Library,
 			"available", format.HumanBytes2(available),
 			"free", format.HumanBytes2(gpu.FreeMemory),
@@ -936,11 +933,16 @@ func nextLowerAutoNumCtx(numCtx int) (int, bool) {
 	}
 }
 
+// llamaServerDefaultFitTargetMiB mirrors llama.cpp's default per-device fit margin.
+const llamaServerDefaultFitTargetMiB = 1024
+
 func availableMemoryForLoad(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo) (available, gpuFree uint64, systemLimited bool) {
 	var sharedGPUFree uint64
 	var discreteGPUFree uint64
-	for _, gpu := range gpus {
+	var reserve uint64
+	for i, gpu := range gpus {
 		gpuFree += gpu.FreeMemory
+		reserve += llamaServerDeviceReserve(gpu, i)
 		if gpu.Integrated {
 			sharedGPUFree += gpu.FreeMemory
 		} else {
@@ -948,24 +950,26 @@ func availableMemoryForLoad(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo) (ava
 		}
 	}
 
+	available = gpuFree
 	// On iGPUs, GPU free memory can be a static or slowly refreshed device
 	// baseline. updateFreeSpace has already subtracted known Ollama runner
 	// allocations from that baseline. Current system free memory is a separate
 	// live measurement that already includes those loaded runners, so use the
 	// smaller value for shared-memory GPUs without discounting discrete VRAM.
 	if systemInfo.FreeMemory > 0 && sharedGPUFree > 0 && systemInfo.FreeMemory < sharedGPUFree {
-		return discreteGPUFree + systemInfo.FreeMemory, gpuFree, true
+		available, systemLimited = discreteGPUFree+systemInfo.FreeMemory, true
 	}
 
-	return gpuFree, gpuFree, false
+	return saturatingSubtract(available, reserve), gpuFree, systemLimited
 }
 
 func availableMemoryForPlacement(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, opts api.Options) (available, gpuFree uint64, systemLimited bool) {
 	placementGpus := gpusForPlacement(gpus, opts)
 	if len(placementGpus) == 1 && opts.MainGPU != nil {
-		gpuFree = placementGpus[0].FreeMemory
-		available = availableMemoryForGPU(systemInfo, placementGpus[0])
-		systemLimited = available < gpuFree
+		gpu := placementGpus[0]
+		gpuFree = gpu.FreeMemory
+		available = availableMemoryForGPU(systemInfo, gpu, 0)
+		systemLimited = gpu.Integrated && systemInfo.FreeMemory > 0 && systemInfo.FreeMemory < gpu.FreeMemory
 		return available, gpuFree, systemLimited
 	}
 
@@ -1057,7 +1061,7 @@ func bestExplicitMainGPU(systemInfo ml.SystemInfo, groups [][]ml.DeviceInfo, mai
 			continue
 		}
 		candidate := group[mainGPU]
-		candidateAvailable := availableMemoryForGPU(systemInfo, candidate)
+		candidateAvailable := availableMemoryForGPU(systemInfo, candidate, 0)
 		if !ok || betterPlacementGPU(candidate, candidateAvailable, gpu, available) {
 			gpu = candidate
 			available = candidateAvailable
@@ -1071,8 +1075,8 @@ func bestExplicitMainGPU(systemInfo ml.SystemInfo, groups [][]ml.DeviceInfo, mai
 func bestSingleGPUFit(systemInfo ml.SystemInfo, groups [][]ml.DeviceInfo, predictedVRAM uint64) (gpu ml.DeviceInfo, available uint64, ok bool) {
 	for _, group := range groups {
 		for _, candidate := range group {
-			candidateAvailable := availableMemoryForGPU(systemInfo, candidate)
-			if predictedVRAM > candidateAvailable*80/100 {
+			candidateAvailable := availableMemoryForGPU(systemInfo, candidate, 0)
+			if predictedVRAM > candidateAvailable {
 				continue
 			}
 			if !ok || betterPlacementGPU(candidate, candidateAvailable, gpu, available) {
@@ -1127,12 +1131,41 @@ func hasDiscreteGPU(gpus []ml.DeviceInfo) bool {
 	return false
 }
 
-func availableMemoryForGPU(systemInfo ml.SystemInfo, gpu ml.DeviceInfo) uint64 {
+func availableMemoryForGPU(systemInfo ml.SystemInfo, gpu ml.DeviceInfo, index int) uint64 {
+	available := gpu.FreeMemory
 	if gpu.Integrated && systemInfo.FreeMemory > 0 && systemInfo.FreeMemory < gpu.FreeMemory {
-		return systemInfo.FreeMemory
+		available = systemInfo.FreeMemory
 	}
 
-	return gpu.FreeMemory
+	return saturatingSubtract(available, llamaServerDeviceReserve(gpu, index))
+}
+
+func llamaServerDeviceReserve(gpu ml.DeviceInfo, index int) uint64 {
+	return gpu.MinimumMemory() + max(envconfig.GpuOverhead(), llamaServerFitTargetBytes(index))
+}
+
+func llamaServerFitTargetBytes(index int) uint64 {
+	value := envconfig.Var("LLAMA_ARG_FIT_TARGET")
+	if value != "" {
+		targets := strings.Split(value, ",")
+		if len(targets) == 1 {
+			index = 0
+		}
+		if index < len(targets) {
+			if target, err := strconv.ParseUint(strings.TrimSpace(targets[index]), 10, 64); err == nil {
+				return target * format.MebiByte
+			}
+		}
+	}
+
+	return llamaServerDefaultFitTargetMiB * format.MebiByte
+}
+
+func saturatingSubtract(value, reserve uint64) uint64 {
+	if value <= reserve {
+		return 0
+	}
+	return value - reserve
 }
 
 func logSelectedGPUGroup(all, selected []ml.DeviceInfo) {

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -405,7 +405,7 @@ func TestSchedRequestsMultipleLoadedModels(t *testing.T) {
 	b.req.sessionDuration = &api.Duration{Duration: 5 * time.Millisecond}
 	c := newScenarioRequest(t, ctx, "model-c-10g-cpu", 10*format.GigaByte, nil, nil /* No GPU load */)
 	c.req.opts.NumGPU = 0                                                                                                                         // CPU load, will be allowed
-	b.req.sessionDuration = &api.Duration{Duration: 10 * time.Millisecond}                                                                        // longer than b to cause the scheduler to favor unloading b over c
+	c.req.sessionDuration = &api.Duration{Duration: 10 * time.Millisecond}                                                                        // longer than b to cause the scheduler to favor unloading b over c
 	d := newScenarioRequest(t, ctx, "model-d-10g-gpu", 13*format.GigaByte, nil, map[ml.DeviceID]uint64{{Library: "Metal"}: 13 * format.GigaByte}) // Needs prior unloaded
 
 	s.newServerFn = a.newServer
@@ -470,25 +470,25 @@ func TestSchedRequestsMultipleLoadedModels(t *testing.T) {
 	require.Len(t, s.loaded, 3)
 	s.loadedMu.Unlock()
 	a.ctxDone() // Won't help since this one isn't big enough to make room
-	time.Sleep(2 * time.Millisecond)
 	s.pendingReqCh <- d.req
-	// finish prior request, so new model can load
-	time.Sleep(6 * time.Millisecond)
-	s.loadedMu.Lock()
-	require.Len(t, s.loaded, 2)
-	s.loadedMu.Unlock()
-	// Mark b done so it can unload
-	b.ctxDone()
-	// Report recovered VRAM usage so scheduler will finish waiting and unload
-	time.Sleep(1 * time.Millisecond)
+	require.Eventually(t, func() bool {
+		s.loadedMu.Lock()
+		defer s.loadedMu.Unlock()
+		return len(s.loaded) == 2
+	}, 500*time.Millisecond, 10*time.Millisecond)
+
+	// Report recovered VRAM usage before releasing b so the next fit check sees it.
 	gMu.Lock()
 	g.FreeMemory = 24 * format.GigaByte
 	gMu.Unlock()
+	b.ctxDone()
 	select {
 	case resp := <-d.req.successCh:
 		require.Equal(t, resp.llama, d.srv)
 		require.Empty(t, s.pendingReqCh)
 		require.Empty(t, d.req.errCh)
+	case err := <-d.req.errCh:
+		t.Fatal(err.Error())
 	case <-ctx.Done():
 		t.Fatal("timeout")
 	}
@@ -744,14 +744,15 @@ func TestSchedPrematureExpired(t *testing.T) {
 		t.Fatal("timeout")
 	}
 	time.Sleep(scenario1a.req.sessionDuration.Duration)
-	scenario1a.ctxDone()
-	time.Sleep(20 * time.Millisecond)
-	require.LessOrEqual(t, len(s.finishedReqCh), 1)
-	time.Sleep(10 * time.Millisecond)
-	require.Empty(t, s.finishedReqCh)
 	s.loadedMu.Lock()
-	require.Empty(t, s.loaded)
+	require.Len(t, s.loaded, 1)
 	s.loadedMu.Unlock()
+	scenario1a.ctxDone()
+	require.Eventually(t, func() bool {
+		s.loadedMu.Lock()
+		defer s.loadedMu.Unlock()
+		return len(s.loaded) == 0
+	}, 500*time.Millisecond, 10*time.Millisecond)
 
 	// also shouldn't happen in real life
 	s.finishedReqCh <- scenario1a.req

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -1472,7 +1472,7 @@ func TestAvailableMemoryForLoadUsesWorstSharedMemoryMeasurement(t *testing.T) {
 
 func schedulerReserveForTest(library string) uint64 {
 	gpu := ml.DeviceInfo{DeviceID: ml.DeviceID{Library: library}}
-	return gpu.MinimumMemory() + llamaServerDefaultFitTargetMiB*format.MebiByte
+	return gpu.MinimumMemory() + llm.LlamaServerDefaultFitTargetMiB*format.MebiByte
 }
 
 func TestSelectLlamaServerPlacement(t *testing.T) {
@@ -1592,8 +1592,8 @@ func TestSelectLlamaServerPlacement(t *testing.T) {
 
 func TestSelectLlamaServerPlacementReserveEnv(t *testing.T) {
 	gpus := []ml.DeviceInfo{
-		{DeviceID: ml.DeviceID{ID: "0", Library: "CUDA"}, FreeMemory: 23336 * format.MebiByte},
-		{DeviceID: ml.DeviceID{ID: "1", Library: "CUDA"}, FreeMemory: 7106 * format.MebiByte},
+		{DeviceID: ml.DeviceID{ID: "0", Library: "CUDA"}, FreeMemory: 7106 * format.MebiByte},
+		{DeviceID: ml.DeviceID{ID: "1", Library: "CUDA"}, FreeMemory: 23336 * format.MebiByte},
 	}
 	check := func(name, overhead, fitTarget string, want int) {
 		t.Run(name, func(t *testing.T) {
@@ -1607,6 +1607,7 @@ func TestSelectLlamaServerPlacementReserveEnv(t *testing.T) {
 	check("default reserve compacts", "", "", 1)
 	check("gpu overhead prevents compaction", "3221225472", "", 2)
 	check("fit target prevents compaction", "", "4096", 2)
+	check("comma fit target uses compacted visible gpu index", "", "1024,4096", 1)
 }
 
 func testIntPtr(v int) *int {

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -1372,6 +1372,10 @@ func TestSchedLlamaServerPredictionUsesTotalParallelContext(t *testing.T) {
 }
 
 func TestAvailableMemoryForLoadUsesWorstSharedMemoryMeasurement(t *testing.T) {
+	metalReserve := schedulerReserveForTest("Metal")
+	vulkanReserve := schedulerReserveForTest("Vulkan")
+	cudaReserve := schedulerReserveForTest("CUDA")
+
 	tests := []struct {
 		name              string
 		systemFree        uint64
@@ -1388,7 +1392,7 @@ func TestAvailableMemoryForLoadUsesWorstSharedMemoryMeasurement(t *testing.T) {
 				Integrated: true,
 				FreeMemory: 300 * format.GigaByte,
 			}},
-			wantAvailable:     80 * format.GigaByte,
+			wantAvailable:     80*format.GigaByte - metalReserve,
 			wantGPUFree:       300 * format.GigaByte,
 			wantSystemLimited: true,
 		},
@@ -1400,7 +1404,7 @@ func TestAvailableMemoryForLoadUsesWorstSharedMemoryMeasurement(t *testing.T) {
 				Integrated: true,
 				FreeMemory: 12 * format.GigaByte,
 			}},
-			wantAvailable:     6 * format.GigaByte,
+			wantAvailable:     6*format.GigaByte - vulkanReserve,
 			wantGPUFree:       12 * format.GigaByte,
 			wantSystemLimited: true,
 		},
@@ -1411,7 +1415,7 @@ func TestAvailableMemoryForLoadUsesWorstSharedMemoryMeasurement(t *testing.T) {
 				DeviceID:   ml.DeviceID{Library: "Metal"},
 				FreeMemory: 12 * format.GigaByte,
 			}},
-			wantAvailable: 12 * format.GigaByte,
+			wantAvailable: 12*format.GigaByte - metalReserve,
 			wantGPUFree:   12 * format.GigaByte,
 		},
 		{
@@ -1421,7 +1425,7 @@ func TestAvailableMemoryForLoadUsesWorstSharedMemoryMeasurement(t *testing.T) {
 				DeviceID:   ml.DeviceID{Library: "CUDA"},
 				FreeMemory: 12 * format.GigaByte,
 			}},
-			wantAvailable: 12 * format.GigaByte,
+			wantAvailable: 12*format.GigaByte - cudaReserve,
 			wantGPUFree:   12 * format.GigaByte,
 		},
 		{
@@ -1438,7 +1442,7 @@ func TestAvailableMemoryForLoadUsesWorstSharedMemoryMeasurement(t *testing.T) {
 					FreeMemory: 10 * format.GigaByte,
 				},
 			},
-			wantAvailable:     18 * format.GigaByte,
+			wantAvailable:     18*format.GigaByte - cudaReserve - vulkanReserve,
 			wantGPUFree:       22 * format.GigaByte,
 			wantSystemLimited: true,
 		},
@@ -1450,7 +1454,7 @@ func TestAvailableMemoryForLoadUsesWorstSharedMemoryMeasurement(t *testing.T) {
 				Integrated: true,
 				FreeMemory: 12 * format.GigaByte,
 			}},
-			wantAvailable: 12 * format.GigaByte,
+			wantAvailable: 12*format.GigaByte - metalReserve,
 			wantGPUFree:   12 * format.GigaByte,
 		},
 	}
@@ -1463,6 +1467,11 @@ func TestAvailableMemoryForLoadUsesWorstSharedMemoryMeasurement(t *testing.T) {
 			require.Equal(t, tt.wantSystemLimited, systemLimited)
 		})
 	}
+}
+
+func schedulerReserveForTest(library string) uint64 {
+	gpu := ml.DeviceInfo{DeviceID: ml.DeviceID{Library: library}}
+	return gpu.MinimumMemory() + llamaServerDefaultFitTargetMiB*format.MebiByte
 }
 
 func TestSelectLlamaServerPlacement(t *testing.T) {
@@ -1578,6 +1587,25 @@ func TestSelectLlamaServerPlacement(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSelectLlamaServerPlacementReserveEnv(t *testing.T) {
+	gpus := []ml.DeviceInfo{
+		{DeviceID: ml.DeviceID{ID: "0", Library: "CUDA"}, FreeMemory: 23336 * format.MebiByte},
+		{DeviceID: ml.DeviceID{ID: "1", Library: "CUDA"}, FreeMemory: 7106 * format.MebiByte},
+	}
+	check := func(name, overhead, fitTarget string, want int) {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("OLLAMA_GPU_OVERHEAD", overhead)
+			t.Setenv("LLAMA_ARG_FIT_TARGET", fitTarget)
+			selected, _ := selectLlamaServerPlacement(ml.SystemInfo{}, gpus, 20307*format.MebiByte, api.DefaultOptions())
+			require.Len(t, selected, want)
+		})
+	}
+
+	check("default reserve compacts", "", "", 1)
+	check("gpu overhead prevents compaction", "3221225472", "", 2)
+	check("fit target prevents compaction", "", "4096", 2)
 }
 
 func testIntPtr(v int) *int {


### PR DESCRIPTION
Replace the hidden 80% single-GPU placement threshold with an explicit per-device reserve based on Ollama's minimum GPU memory plus the larger of OLLAMA_GPU_OVERHEAD and llama.cpp's fit target.

When LLAMA_ARG_FIT_TARGET is unset and OLLAMA_GPU_OVERHEAD is larger than llama.cpp's default 1 GiB fit target, pass that overhead through to llama-server as LLAMA_ARG_FIT_TARGET so scheduling and fit use the same reserve.

This makes default placement less wasteful on larger GPUs while preserving user controls for more conservative scheduling via OLLAMA_GPU_OVERHEAD and LLAMA_ARG_FIT_TARGET.

Fixes #16599.
