### PR TITLE
server: grow embedding batch for long inputs

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -200,9 +200,40 @@ func usesAutomaticNumBatch(model *Model, requestOpts map[string]any) bool {
 	return true
 }
 
+func numBatchPolicyForRequest(model *Model, requestOpts map[string]any, embeddingBatchGrowable bool) numBatchPolicy {
+	if !usesAutomaticNumBatch(model, requestOpts) {
+		return numBatchFixed
+	}
+
+	if shouldApplyEmbeddingBatchDefault(model, requestOpts) {
+		if embeddingBatchGrowable {
+			return numBatchAutoGrowable
+		}
+		return numBatchFixed
+	}
+
+	return numBatchAuto
+}
+
+func (s *Server) validateEmbeddingBatchTokenCount(model *Model, requestOpts map[string]any, opts api.Options, tokenCount int) error {
+	return s.sched.validateEmbeddingBatchTokenCount(opts, numBatchPolicyForRequest(model, requestOpts, true), tokenCount)
+}
+
+type scheduleRunnerOptions struct {
+	embeddingTokenCount *int
+}
+
 // scheduleRunner schedules a runner after validating inputs such as capabilities and model options.
 // It returns the allocated runner, model instance, and consolidated options if successful and error otherwise.
-func (s *Server) scheduleRunner(ctx context.Context, name string, caps []model.Capability, requestOpts map[string]any, keepAlive *api.Duration, shift *bool, embeddingTokenCount ...int) (llm.LlamaServer, *Model, *api.Options, error) {
+func (s *Server) scheduleRunner(ctx context.Context, name string, caps []model.Capability, requestOpts map[string]any, keepAlive *api.Duration, shift *bool) (llm.LlamaServer, *Model, *api.Options, error) {
+	return s.scheduleRunnerWithOptions(ctx, name, caps, requestOpts, keepAlive, shift, scheduleRunnerOptions{})
+}
+
+func (s *Server) scheduleEmbeddingRunner(ctx context.Context, name string, requestOpts map[string]any, keepAlive *api.Duration, tokenCount int) (llm.LlamaServer, *Model, *api.Options, error) {
+	return s.scheduleRunnerWithOptions(ctx, name, []model.Capability{}, requestOpts, keepAlive, nil, scheduleRunnerOptions{embeddingTokenCount: &tokenCount})
+}
+
+func (s *Server) scheduleRunnerWithOptions(ctx context.Context, name string, caps []model.Capability, requestOpts map[string]any, keepAlive *api.Duration, shift *bool, loadOptions scheduleRunnerOptions) (llm.LlamaServer, *Model, *api.Options, error) {
 	if name == "" {
 		return nil, nil, nil, fmt.Errorf("model %w", errRequired)
 	}
@@ -225,23 +256,19 @@ func (s *Server) scheduleRunner(ctx context.Context, name string, caps []model.C
 
 	numCtxAuto := usesAutomaticNumCtx(model, requestOpts)
 	embeddingBatchDefault := shouldApplyEmbeddingBatchDefault(model, requestOpts)
-	numBatchAuto := usesAutomaticNumBatch(model, requestOpts)
-	embBatchAuto := embeddingBatchDefault && embeddingTokenCount != nil
-	if embeddingBatchDefault && !embBatchAuto {
-		numBatchAuto = false
-	}
+	numBatchPolicy := numBatchPolicyForRequest(model, requestOpts, loadOptions.embeddingTokenCount != nil)
 	opts, err := s.modelOptionsWithEmbeddingBatchDefault(model, requestOpts, embeddingBatchDefault)
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	if embeddingTokenCount != nil {
-		opts, err = s.sched.embeddingBatchOptionsForTokenCount(opts, embBatchAuto, embeddingTokenCount[0])
+	if loadOptions.embeddingTokenCount != nil {
+		opts, err = s.sched.embeddingBatchOptionsForTokenCount(opts, numBatchPolicy, *loadOptions.embeddingTokenCount)
 		if err != nil {
 			return nil, nil, nil, err
 		}
 	}
 
-	runnerCh, errCh := s.sched.getRunner(ctx, model, opts, keepAlive, numCtxAuto, numBatchAuto, embBatchAuto, shift)
+	runnerCh, errCh := s.sched.getRunner(ctx, model, opts, keepAlive, numCtxAuto, numBatchPolicy, shift)
 	var runner *runnerRef
 	select {
 	case runner = <-runnerCh:
@@ -817,7 +844,7 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 	runnerCtx, releaseRunner := context.WithCancel(c.Request.Context())
 	defer releaseRunner()
 
-	r, m, opts, err := s.scheduleRunner(runnerCtx, name.String(), []model.Capability{}, req.Options, req.KeepAlive, nil, 0)
+	r, m, opts, err := s.scheduleEmbeddingRunner(runnerCtx, name.String(), req.Options, req.KeepAlive, 0)
 	if err != nil {
 		handleScheduleError(c, req.Model, err)
 		return
@@ -851,6 +878,20 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 	embeddingTokenCount := func(tokens []int) int {
 		return 2*len(tokens) - adjustTokenLimit(tokens, len(tokens))
 	}
+
+	embeddingTokenLimit := func(tokens []int, limit int) int {
+		if limit <= 0 {
+			return 0
+		}
+
+		tokenLimit := min(len(tokens), limit)
+		for tokenLimit > 0 && embeddingTokenCount(tokens[:tokenLimit]) > limit {
+			tokenLimit--
+		}
+		return tokenLimit
+	}
+
+	embeddingBatchPolicy := numBatchPolicyForRequest(m, req.Options, true)
 
 	inputTokensAndContext := func(text string) ([]int, int, error) {
 		tokens, err := r.Tokenize(ctx, text)
@@ -886,11 +927,16 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 			return text, embeddingTokenCount(tokens), nil
 		}
 
-		if len(tokens) <= ctxLen {
+		tokenLimit := ctxLen
+		if embeddingBatchPolicy != numBatchAutoGrowable {
+			tokenLimit = min(tokenLimit, embeddingTokenLimit(tokens, opts.NumBatch))
+		}
+
+		if len(tokens) <= tokenLimit {
 			return text, embeddingTokenCount(tokens), nil
 		}
 
-		truncatedTokens := tokens[:ctxLen]
+		truncatedTokens := tokens[:tokenLimit]
 		truncated, err := r.Detokenize(ctx, truncatedTokens)
 		if err != nil {
 			return "", 0, err
@@ -920,29 +966,29 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 	}
 
 	if maxTokenCount > opts.NumBatch {
-		nextOpts, err := s.sched.embeddingBatchOptionsForTokenCount(*opts, shouldApplyEmbeddingBatchDefault(m, req.Options), maxTokenCount)
-		if err != nil {
+		if err := s.validateEmbeddingBatchTokenCount(m, req.Options, *opts, maxTokenCount); err != nil {
 			handleScheduleError(c, req.Model, err)
 			return
 		}
 
-		slog.Info(
-			"reloading runner for larger embedding batch",
-			"model", req.Model,
-			"current_num_batch", opts.NumBatch,
-			"next_num_batch", nextOpts.NumBatch,
-			"required_tokens", maxTokenCount,
-		)
+		currentNumBatch := opts.NumBatch
 		releaseRunner()
 		runnerCtx, releaseRunner = context.WithCancel(c.Request.Context())
 		defer releaseRunner()
 		ctx = runnerCtx
 
-		r, _, opts, err = s.scheduleRunner(runnerCtx, name.String(), []model.Capability{}, req.Options, req.KeepAlive, nil, maxTokenCount)
+		r, _, opts, err = s.scheduleEmbeddingRunner(runnerCtx, name.String(), req.Options, req.KeepAlive, maxTokenCount)
 		if err != nil {
 			handleScheduleError(c, req.Model, err)
 			return
 		}
+		slog.Info(
+			"reloaded runner for larger embedding batch",
+			"model", req.Model,
+			"current_num_batch", currentNumBatch,
+			"next_num_batch", opts.NumBatch,
+			"required_tokens", maxTokenCount,
+		)
 		checkpointLoaded = time.Now()
 	}
 
@@ -950,7 +996,6 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 	embeddings := make([][]float32, len(input))
 	var totalTokens uint64
 	for i, text := range input {
-		i, text := i, text
 		g.Go(func() error {
 			embedding, tokenCount, err := r.Embedding(ctx, text)
 			if err != nil {

--- a/server/routes.go
+++ b/server/routes.go
@@ -202,7 +202,7 @@ func usesAutomaticNumBatch(model *Model, requestOpts map[string]any) bool {
 
 // scheduleRunner schedules a runner after validating inputs such as capabilities and model options.
 // It returns the allocated runner, model instance, and consolidated options if successful and error otherwise.
-func (s *Server) scheduleRunner(ctx context.Context, name string, caps []model.Capability, requestOpts map[string]any, keepAlive *api.Duration, shift *bool) (llm.LlamaServer, *Model, *api.Options, error) {
+func (s *Server) scheduleRunner(ctx context.Context, name string, caps []model.Capability, requestOpts map[string]any, keepAlive *api.Duration, shift *bool, embeddingTokenCount ...int) (llm.LlamaServer, *Model, *api.Options, error) {
 	if name == "" {
 		return nil, nil, nil, fmt.Errorf("model %w", errRequired)
 	}
@@ -225,13 +225,23 @@ func (s *Server) scheduleRunner(ctx context.Context, name string, caps []model.C
 
 	numCtxAuto := usesAutomaticNumCtx(model, requestOpts)
 	embeddingBatchDefault := shouldApplyEmbeddingBatchDefault(model, requestOpts)
-	numBatchAuto := usesAutomaticNumBatch(model, requestOpts) && !embeddingBatchDefault
+	numBatchAuto := usesAutomaticNumBatch(model, requestOpts)
+	embBatchAuto := embeddingBatchDefault && embeddingTokenCount != nil
+	if embeddingBatchDefault && !embBatchAuto {
+		numBatchAuto = false
+	}
 	opts, err := s.modelOptionsWithEmbeddingBatchDefault(model, requestOpts, embeddingBatchDefault)
 	if err != nil {
 		return nil, nil, nil, err
 	}
+	if embeddingTokenCount != nil {
+		opts, err = s.sched.embeddingBatchOptionsForTokenCount(opts, embBatchAuto, embeddingTokenCount[0])
+		if err != nil {
+			return nil, nil, nil, err
+		}
+	}
 
-	runnerCh, errCh := s.sched.getRunner(ctx, model, opts, keepAlive, numCtxAuto, numBatchAuto, shift)
+	runnerCh, errCh := s.sched.getRunner(ctx, model, opts, keepAlive, numCtxAuto, numBatchAuto, embBatchAuto, shift)
 	var runner *runnerRef
 	select {
 	case runner = <-runnerCh:
@@ -804,7 +814,10 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 		return
 	}
 
-	r, m, opts, err := s.scheduleRunner(c.Request.Context(), name.String(), []model.Capability{}, req.Options, req.KeepAlive, nil)
+	runnerCtx, releaseRunner := context.WithCancel(c.Request.Context())
+	defer releaseRunner()
+
+	r, m, opts, err := s.scheduleRunner(runnerCtx, name.String(), []model.Capability{}, req.Options, req.KeepAlive, nil, 0)
 	if err != nil {
 		handleScheduleError(c, req.Model, err)
 		return
@@ -823,7 +836,7 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 		return
 	}
 
-	ctx := c.Request.Context()
+	ctx := runnerCtx
 
 	adjustTokenLimit := func(tokens []int, limit int) int {
 		if bos := kvData.Uint("tokenizer.ggml.bos_token_id"); len(tokens) > 0 && tokens[0] != int(bos) && kvData.Bool("add_bos_token", true) {
@@ -833,6 +846,10 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 			limit--
 		}
 		return limit
+	}
+
+	embeddingTokenCount := func(tokens []int) int {
+		return 2*len(tokens) - adjustTokenLimit(tokens, len(tokens))
 	}
 
 	inputTokensAndContext := func(text string) ([]int, int, error) {
@@ -850,86 +867,92 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 		return tokens, adjustTokenLimit(tokens, ctxLen), nil
 	}
 
-	truncateInputToLimit := func(text string, limit int) (string, bool, error) {
+	prepareInput := func(text string) (string, int, error) {
 		tokens, ctxLen, err := inputTokensAndContext(text)
 		if err != nil {
-			return "", false, err
-		}
-		if limit > 0 {
-			ctxLen = min(ctxLen, adjustTokenLimit(tokens, limit))
+			return "", 0, err
 		}
 
 		if ctxLen <= 0 {
-			return "", false, fmt.Errorf("input after truncation exceeds maximum context length")
+			return "", 0, fmt.Errorf("input after truncation exceeds maximum context length")
 		}
-		if len(tokens) <= ctxLen {
-			return text, false, nil
-		}
-
-		truncated, err := r.Detokenize(ctx, tokens[:ctxLen])
-		if err != nil {
-			return "", false, err
-		}
-		return truncated, true, nil
-	}
-
-	truncateInput := func(text string) (string, bool, error) {
-		return truncateInputToLimit(text, 0)
-	}
-
-	embedWithRetry := func(text string) ([]float32, int, error) {
 		if req.Truncate != nil && !*req.Truncate {
-			tokens, ctxLen, err := inputTokensAndContext(text)
-			if err != nil {
-				return nil, 0, err
-			}
-			if ctxLen <= 0 {
-				return nil, 0, fmt.Errorf("input after truncation exceeds maximum context length")
-			}
 			if len(tokens) > ctxLen {
-				return nil, 0, api.StatusError{
+				return "", 0, api.StatusError{
 					StatusCode:   http.StatusBadRequest,
 					ErrorMessage: "the input length exceeds the context length",
 				}
 			}
-		} else {
-			var err error
-			text, _, err = truncateInput(text)
-			if err != nil {
-				return nil, 0, err
-			}
+			return text, embeddingTokenCount(tokens), nil
 		}
 
-		emb, tokCount, err := r.Embedding(ctx, text)
-		if err == nil {
-			return emb, tokCount, nil
+		if len(tokens) <= ctxLen {
+			return text, embeddingTokenCount(tokens), nil
 		}
 
-		var serr api.StatusError
-		if !errors.As(err, &serr) || serr.StatusCode != http.StatusBadRequest {
-			return nil, 0, err
-		}
-		if req.Truncate != nil && !*req.Truncate {
-			return nil, 0, err
-		}
-
-		truncated, ok, err := truncateInputToLimit(text, opts.NumBatch)
+		truncatedTokens := tokens[:ctxLen]
+		truncated, err := r.Detokenize(ctx, truncatedTokens)
 		if err != nil {
-			return nil, 0, err
+			return "", 0, err
 		}
-		if !ok {
-			return nil, 0, fmt.Errorf("input exceeds maximum context length and cannot be truncated further")
+		return truncated, embeddingTokenCount(truncatedTokens), nil
+	}
+
+	maxTokenCount := 0
+	for i, text := range input {
+		prepared, tokenCount, err := prepareInput(text)
+		if err != nil {
+			var serr api.StatusError
+			if errors.As(err, &serr) {
+				c.AbortWithStatusJSON(serr.StatusCode, gin.H{
+					"error": strings.TrimSpace(serr.ErrorMessage),
+				})
+				return
+			}
+
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
+				"error": strings.TrimSpace(err.Error()),
+			})
+			return
+		}
+		input[i] = prepared
+		maxTokenCount = max(maxTokenCount, tokenCount)
+	}
+
+	if maxTokenCount > opts.NumBatch {
+		nextOpts, err := s.sched.embeddingBatchOptionsForTokenCount(*opts, shouldApplyEmbeddingBatchDefault(m, req.Options), maxTokenCount)
+		if err != nil {
+			handleScheduleError(c, req.Model, err)
+			return
 		}
 
-		return r.Embedding(ctx, truncated)
+		slog.Info(
+			"reloading runner for larger embedding batch",
+			"model", req.Model,
+			"current_num_batch", opts.NumBatch,
+			"next_num_batch", nextOpts.NumBatch,
+			"required_tokens", maxTokenCount,
+		)
+		releaseRunner()
+		runnerCtx, releaseRunner = context.WithCancel(c.Request.Context())
+		defer releaseRunner()
+		ctx = runnerCtx
+
+		r, _, opts, err = s.scheduleRunner(runnerCtx, name.String(), []model.Capability{}, req.Options, req.KeepAlive, nil, maxTokenCount)
+		if err != nil {
+			handleScheduleError(c, req.Model, err)
+			return
+		}
+		checkpointLoaded = time.Now()
 	}
 
 	var g errgroup.Group
 	embeddings := make([][]float32, len(input))
 	var totalTokens uint64
 	for i, text := range input {
+		i, text := i, text
 		g.Go(func() error {
-			embedding, tokenCount, err := embedWithRetry(text)
+			embedding, tokenCount, err := r.Embedding(ctx, text)
 			if err != nil {
 				return err
 			}
@@ -3078,7 +3101,10 @@ func countChatImages(msgs []api.Message) int {
 }
 
 func handleScheduleError(c *gin.Context, name string, err error) {
+	var serr api.StatusError
 	switch {
+	case errors.As(err, &serr):
+		c.JSON(serr.StatusCode, gin.H{"error": strings.TrimSpace(serr.ErrorMessage)})
 	case errors.Is(err, errCapabilities), errors.Is(err, errRequired):
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 	case errors.Is(err, context.Canceled):

--- a/server/routes_embed_test.go
+++ b/server/routes_embed_test.go
@@ -1,0 +1,85 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/fs/ggml"
+)
+
+func createEmbedTestModel(t *testing.T, s *Server, name string) {
+	t.Helper()
+
+	createMinimalGGUFModel(t, s, name, ggml.KV{
+		"add_bos_token": false,
+		"add_eos_token": false,
+	}, "", map[string]any{
+		"capabilities": []string{"embedding"},
+	})
+}
+
+func TestEmbedHandlerExplicitNumBatchTruncatesInput(t *testing.T) {
+	t.Setenv("OLLAMA_CONTEXT_LENGTH", "8192")
+	gin.SetMode(gin.TestMode)
+
+	mock := mockRunner{}
+	s := newServerWithMockRunner(t, &mock)
+	createEmbedTestModel(t, s, "embed-batch-truncate")
+
+	truncate := true
+	w := createRequest(t, s.EmbedHandler, api.EmbedRequest{
+		Model:    "embed-batch-truncate",
+		Input:    "one two three four five",
+		Truncate: &truncate,
+		Options: map[string]any{
+			"num_batch": float64(3),
+		},
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp api.EmbedResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Embeddings) != 1 {
+		t.Fatalf("expected one embedding, got %#v", resp.Embeddings)
+	}
+	if got := mock.EmbeddingInputs; len(got) != 1 || got[0] != "x x x" {
+		t.Fatalf("embedding inputs = %#v, want one truncated input", got)
+	}
+}
+
+func TestEmbedHandlerExplicitNumBatchNoTruncateErrors(t *testing.T) {
+	t.Setenv("OLLAMA_CONTEXT_LENGTH", "8192")
+	gin.SetMode(gin.TestMode)
+
+	mock := mockRunner{}
+	s := newServerWithMockRunner(t, &mock)
+	createEmbedTestModel(t, s, "embed-batch-no-truncate")
+
+	truncate := false
+	w := createRequest(t, s.EmbedHandler, api.EmbedRequest{
+		Model:    "embed-batch-no-truncate",
+		Input:    "one two three four five",
+		Truncate: &truncate,
+		Options: map[string]any{
+			"num_batch": float64(3),
+		},
+	})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := mock.EmbeddingInputs; len(got) != 0 {
+		t.Fatalf("embedding inputs = %#v, want none", got)
+	}
+	if !strings.Contains(w.Body.String(), "exceeds configured num_batch") {
+		t.Fatalf("expected num_batch error, got %s", w.Body.String())
+	}
+}

--- a/server/routes_generate_test.go
+++ b/server/routes_generate_test.go
@@ -56,13 +56,16 @@ type mockRunner struct {
 	// CompletionRequest is only valid until the next call to Completion
 	llm.CompletionRequest
 	llm.CompletionResponse
-	CompletionFn  func(context.Context, llm.CompletionRequest, func(llm.CompletionResponse)) error
-	ChatRequest   llm.ChatRequest
-	ChatResponse  llm.ChatResponse
-	ChatFn        func(context.Context, llm.ChatRequest, func(llm.ChatResponse)) error
-	Template      string
-	TemplateFn    func(context.Context, llm.ChatRequest) (string, error)
-	contextLength int
+	CompletionFn    func(context.Context, llm.CompletionRequest, func(llm.CompletionResponse)) error
+	ChatRequest     llm.ChatRequest
+	ChatResponse    llm.ChatResponse
+	ChatFn          func(context.Context, llm.ChatRequest, func(llm.ChatResponse)) error
+	Template        string
+	TemplateFn      func(context.Context, llm.ChatRequest) (string, error)
+	contextLength   int
+	mu              sync.Mutex
+	EmbeddingFn     func(context.Context, string) ([]float32, int, error)
+	EmbeddingInputs []string
 }
 
 func (m *mockRunner) Completion(ctx context.Context, r llm.CompletionRequest, fn func(r llm.CompletionResponse)) error {
@@ -97,6 +100,26 @@ func (mockRunner) Tokenize(_ context.Context, s string) (tokens []int, err error
 	}
 
 	return
+}
+
+func (mockRunner) Detokenize(_ context.Context, tokens []int) (string, error) {
+	fields := make([]string, len(tokens))
+	for i := range fields {
+		fields[i] = "x"
+	}
+	return strings.Join(fields, " "), nil
+}
+
+func (m *mockRunner) Embedding(ctx context.Context, input string) ([]float32, int, error) {
+	m.mu.Lock()
+	m.EmbeddingInputs = append(m.EmbeddingInputs, input)
+	m.mu.Unlock()
+
+	if m.EmbeddingFn != nil {
+		return m.EmbeddingFn(ctx, input)
+	}
+
+	return []float32{1, 0}, len(strings.Fields(input)), nil
 }
 
 func (mockRunner) Ping(_ context.Context) error { return nil }

--- a/server/routes_options_test.go
+++ b/server/routes_options_test.go
@@ -273,3 +273,62 @@ func TestUsesAutomaticNumBatch(t *testing.T) {
 		})
 	}
 }
+
+func TestNumBatchPolicyForRequest(t *testing.T) {
+	embeddingModel := func(modelOpts map[string]any) *Model {
+		m := &Model{Options: modelOpts}
+		m.Config.Capabilities = []string{string(model.CapabilityEmbedding)}
+		return m
+	}
+	completionModel := func(modelOpts map[string]any) *Model {
+		m := &Model{Options: modelOpts}
+		m.Config.Capabilities = []string{string(model.CapabilityCompletion)}
+		return m
+	}
+
+	tests := []struct {
+		name                   string
+		model                  *Model
+		requestOpts            map[string]any
+		embeddingBatchGrowable bool
+		want                   numBatchPolicy
+	}{
+		{
+			name:  "completion default is automatic",
+			model: completionModel(nil),
+			want:  numBatchAuto,
+		},
+		{
+			name:  "embedding default without token count is fixed",
+			model: embeddingModel(nil),
+			want:  numBatchFixed,
+		},
+		{
+			name:                   "embedding default can grow",
+			model:                  embeddingModel(nil),
+			embeddingBatchGrowable: true,
+			want:                   numBatchAutoGrowable,
+		},
+		{
+			name:                   "request num_batch is fixed",
+			model:                  embeddingModel(nil),
+			requestOpts:            map[string]any{"num_batch": float64(1024)},
+			embeddingBatchGrowable: true,
+			want:                   numBatchFixed,
+		},
+		{
+			name:                   "model num_batch is fixed",
+			model:                  embeddingModel(map[string]any{"num_batch": float64(1024)}),
+			embeddingBatchGrowable: true,
+			want:                   numBatchFixed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := numBatchPolicyForRequest(tt.model, tt.requestOpts, tt.embeddingBatchGrowable); got != tt.want {
+				t.Fatalf("numBatchPolicyForRequest = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/server/sched.go
+++ b/server/sched.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
 	"reflect"
 	"runtime"
@@ -47,6 +48,10 @@ type LlmRequest struct {
 	// numBatchAuto is true when NumBatch came from Ollama's default options
 	// rather than an explicit request or model option.
 	numBatchAuto bool
+
+	// embBatchAuto is true when NumBatch is an automatic embedding batch
+	// capacity that may grow to fit larger embedding inputs.
+	embBatchAuto bool
 
 	// useMMapAuto is true when UseMMap was derived by the scheduler rather than
 	// explicitly requested.
@@ -129,7 +134,29 @@ func schedulerModelKey(m *Model) string {
 
 // context must be canceled to decrement ref count and release the runner
 func (s *Scheduler) GetRunner(c context.Context, m *Model, opts api.Options, sessionDuration *api.Duration) (chan *runnerRef, chan error) {
-	return s.getRunner(c, m, opts, sessionDuration, false, false, nil)
+	return s.getRunner(c, m, opts, sessionDuration, false, false, false, nil)
+}
+
+const embeddingBatchQuantum = 1024
+
+func (s *Scheduler) embeddingBatchOptionsForTokenCount(opts api.Options, embBatchAuto bool, tokenCount int) (api.Options, error) {
+	if tokenCount <= opts.NumBatch {
+		return opts, nil
+	}
+
+	if !embBatchAuto {
+		return opts, api.StatusError{
+			StatusCode:   http.StatusBadRequest,
+			ErrorMessage: fmt.Sprintf("input length (%d tokens) exceeds configured num_batch (%d tokens)", tokenCount, opts.NumBatch),
+		}
+	}
+
+	opts.NumBatch = max(tokenCount, llm.DefaultEmbeddingNumBatch)
+	opts.NumBatch = ((opts.NumBatch + embeddingBatchQuantum - 1) / embeddingBatchQuantum) * embeddingBatchQuantum
+	if opts.NumCtx > 0 {
+		opts.NumBatch = min(opts.NumBatch, opts.NumCtx)
+	}
+	return opts, nil
 }
 
 func resolveContextShift(shift *bool, m *Model) bool {
@@ -172,7 +199,7 @@ func effectiveContext(numCtx, trainCtx int) int {
 	return numCtx
 }
 
-func (s *Scheduler) getRunner(c context.Context, m *Model, opts api.Options, sessionDuration *api.Duration, numCtxAuto bool, numBatchAuto bool, shift *bool) (chan *runnerRef, chan error) {
+func (s *Scheduler) getRunner(c context.Context, m *Model, opts api.Options, sessionDuration *api.Duration, numCtxAuto bool, numBatchAuto bool, embBatchAuto bool, shift *bool) (chan *runnerRef, chan error) {
 	if opts.NumCtx < 4 {
 		opts.NumCtx = 4
 	}
@@ -196,6 +223,7 @@ func (s *Scheduler) getRunner(c context.Context, m *Model, opts api.Options, ses
 		errCh:           make(chan error, 1),
 		numCtxAuto:      numCtxAuto,
 		numBatchAuto:    numBatchAuto,
+		embBatchAuto:    embBatchAuto,
 		contextShift:    contextShift,
 		shift:           shift,
 	}
@@ -719,6 +747,7 @@ iGPUScan:
 		pid:             llama.Pid(),
 		numCtxAuto:      req.numCtxAuto,
 		numBatchAuto:    req.numBatchAuto,
+		embBatchAuto:    req.embBatchAuto,
 		useMMapAuto:     req.useMMapAuto,
 		contextShift:    req.contextShift,
 		trainContext:    trainContext,
@@ -1369,6 +1398,7 @@ type runnerRef struct {
 	numParallel  int
 	numCtxAuto   bool
 	numBatchAuto bool
+	embBatchAuto bool
 	useMMapAuto  bool
 	contextShift bool
 	trainContext int
@@ -1418,7 +1448,13 @@ func (runner *runnerRef) needsReload(ctx context.Context, req *LlmRequest) bool 
 		optsNew.NumCtx = optsExisting.NumCtx
 	}
 	if runner.numBatchAuto && req.numBatchAuto {
-		optsNew.NumBatch = optsExisting.NumBatch
+		if runner.embBatchAuto && req.embBatchAuto {
+			if optsExisting.NumBatch >= optsNew.NumBatch {
+				optsNew.NumBatch = optsExisting.NumBatch
+			}
+		} else {
+			optsNew.NumBatch = optsExisting.NumBatch
+		}
 	}
 	if runner.useMMapAuto && optsNew.UseMMap == nil {
 		optsNew.UseMMap = optsExisting.UseMMap

--- a/server/sched.go
+++ b/server/sched.go
@@ -28,6 +28,20 @@ import (
 	"github.com/ollama/ollama/x/mlxrunner"
 )
 
+type numBatchPolicy int
+
+const (
+	// numBatchFixed requires the requested NumBatch to match the loaded runner.
+	numBatchFixed numBatchPolicy = iota
+
+	// numBatchAuto can reuse a loaded runner's automatically selected NumBatch.
+	numBatchAuto
+
+	// numBatchAutoGrowable can reuse a loaded runner if its automatically
+	// selected embedding NumBatch is at least as large as the requested one.
+	numBatchAutoGrowable
+)
+
 type LlmRequest struct {
 	ctx             context.Context //nolint:containedctx
 	model           *Model
@@ -45,13 +59,9 @@ type LlmRequest struct {
 	// default rather than explicit request, model, or environment config.
 	numCtxAuto bool
 
-	// numBatchAuto is true when NumBatch came from Ollama's default options
-	// rather than an explicit request or model option.
-	numBatchAuto bool
-
-	// embBatchAuto is true when NumBatch is an automatic embedding batch
-	// capacity that may grow to fit larger embedding inputs.
-	embBatchAuto bool
+	// numBatchPolicy records how NumBatch was derived so an already-loaded
+	// runner can decide whether a different requested batch size requires reload.
+	numBatchPolicy numBatchPolicy
 
 	// useMMapAuto is true when UseMMap was derived by the scheduler rather than
 	// explicitly requested.
@@ -134,21 +144,29 @@ func schedulerModelKey(m *Model) string {
 
 // context must be canceled to decrement ref count and release the runner
 func (s *Scheduler) GetRunner(c context.Context, m *Model, opts api.Options, sessionDuration *api.Duration) (chan *runnerRef, chan error) {
-	return s.getRunner(c, m, opts, sessionDuration, false, false, false, nil)
+	return s.getRunner(c, m, opts, sessionDuration, false, numBatchFixed, nil)
 }
 
 const embeddingBatchQuantum = 1024
 
-func (s *Scheduler) embeddingBatchOptionsForTokenCount(opts api.Options, embBatchAuto bool, tokenCount int) (api.Options, error) {
+func (s *Scheduler) validateEmbeddingBatchTokenCount(opts api.Options, policy numBatchPolicy, tokenCount int) error {
+	if tokenCount <= opts.NumBatch || policy == numBatchAutoGrowable {
+		return nil
+	}
+
+	return api.StatusError{
+		StatusCode:   http.StatusBadRequest,
+		ErrorMessage: fmt.Sprintf("input length (%d tokens) exceeds configured num_batch (%d tokens)", tokenCount, opts.NumBatch),
+	}
+}
+
+func (s *Scheduler) embeddingBatchOptionsForTokenCount(opts api.Options, policy numBatchPolicy, tokenCount int) (api.Options, error) {
 	if tokenCount <= opts.NumBatch {
 		return opts, nil
 	}
 
-	if !embBatchAuto {
-		return opts, api.StatusError{
-			StatusCode:   http.StatusBadRequest,
-			ErrorMessage: fmt.Sprintf("input length (%d tokens) exceeds configured num_batch (%d tokens)", tokenCount, opts.NumBatch),
-		}
+	if err := s.validateEmbeddingBatchTokenCount(opts, policy, tokenCount); err != nil {
+		return opts, err
 	}
 
 	opts.NumBatch = max(tokenCount, llm.DefaultEmbeddingNumBatch)
@@ -199,7 +217,7 @@ func effectiveContext(numCtx, trainCtx int) int {
 	return numCtx
 }
 
-func (s *Scheduler) getRunner(c context.Context, m *Model, opts api.Options, sessionDuration *api.Duration, numCtxAuto bool, numBatchAuto bool, embBatchAuto bool, shift *bool) (chan *runnerRef, chan error) {
+func (s *Scheduler) getRunner(c context.Context, m *Model, opts api.Options, sessionDuration *api.Duration, numCtxAuto bool, numBatchPolicy numBatchPolicy, shift *bool) (chan *runnerRef, chan error) {
 	if opts.NumCtx < 4 {
 		opts.NumCtx = 4
 	}
@@ -222,8 +240,7 @@ func (s *Scheduler) getRunner(c context.Context, m *Model, opts api.Options, ses
 		successCh:       make(chan *runnerRef, 1),
 		errCh:           make(chan error, 1),
 		numCtxAuto:      numCtxAuto,
-		numBatchAuto:    numBatchAuto,
-		embBatchAuto:    embBatchAuto,
+		numBatchPolicy:  numBatchPolicy,
 		contextShift:    contextShift,
 		shift:           shift,
 	}
@@ -746,8 +763,7 @@ iGPUScan:
 		loading:         true,
 		pid:             llama.Pid(),
 		numCtxAuto:      req.numCtxAuto,
-		numBatchAuto:    req.numBatchAuto,
-		embBatchAuto:    req.embBatchAuto,
+		numBatchPolicy:  req.numBatchPolicy,
 		useMMapAuto:     req.useMMapAuto,
 		contextShift:    req.contextShift,
 		trainContext:    trainContext,
@@ -845,7 +861,7 @@ const (
 )
 
 func (req *LlmRequest) applyAutomaticGenerationBatch(completion bool, effectiveCtx int, predictedVRAM, availableMemory uint64, flashAttention ml.FlashAttentionType, gpus []ml.DeviceInfo) {
-	if !completion || !req.numBatchAuto {
+	if !completion || req.numBatchPolicy != numBatchAuto {
 		return
 	}
 
@@ -1392,16 +1408,15 @@ type runnerRef struct {
 	expireTimer     *time.Timer
 	expiresAt       time.Time
 
-	model        *Model
-	modelPath    string
-	modelKey     string
-	numParallel  int
-	numCtxAuto   bool
-	numBatchAuto bool
-	embBatchAuto bool
-	useMMapAuto  bool
-	contextShift bool
-	trainContext int
+	model          *Model
+	modelPath      string
+	modelKey       string
+	numParallel    int
+	numCtxAuto     bool
+	numBatchPolicy numBatchPolicy
+	useMMapAuto    bool
+	contextShift   bool
+	trainContext   int
 	*api.Options
 }
 
@@ -1447,13 +1462,14 @@ func (runner *runnerRef) needsReload(ctx context.Context, req *LlmRequest) bool 
 	if runner.numCtxAuto && req.numCtxAuto {
 		optsNew.NumCtx = optsExisting.NumCtx
 	}
-	if runner.numBatchAuto && req.numBatchAuto {
-		if runner.embBatchAuto && req.embBatchAuto {
+	if runner.numBatchPolicy == req.numBatchPolicy {
+		switch req.numBatchPolicy {
+		case numBatchAuto:
+			optsNew.NumBatch = optsExisting.NumBatch
+		case numBatchAutoGrowable:
 			if optsExisting.NumBatch >= optsNew.NumBatch {
 				optsNew.NumBatch = optsExisting.NumBatch
 			}
-		} else {
-			optsNew.NumBatch = optsExisting.NumBatch
 		}
 	}
 	if runner.useMMapAuto && optsNew.UseMMap == nil {

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -187,7 +187,7 @@ func TestSchedVisionContextFloor(t *testing.T) {
 		opts := api.DefaultOptions()
 		opts.NumCtx = 128
 
-		s.getRunner(ctx, visionModel, opts, nil, true, false, false, nil)
+		s.getRunner(ctx, visionModel, opts, nil, true, numBatchFixed, nil)
 
 		req := <-s.pendingReqCh
 		require.Equal(t, 2048, req.opts.NumCtx)
@@ -199,7 +199,7 @@ func TestSchedVisionContextFloor(t *testing.T) {
 		opts := api.DefaultOptions()
 		opts.NumCtx = 128
 
-		s.getRunner(ctx, visionModel, opts, nil, false, false, false, nil)
+		s.getRunner(ctx, visionModel, opts, nil, false, numBatchFixed, nil)
 
 		req := <-s.pendingReqCh
 		require.Equal(t, 2048, req.opts.NumCtx)
@@ -1020,22 +1020,22 @@ func TestSchedNeedsReloadIgnoresAutomaticNumBatchDerivation(t *testing.T) {
 	opts.NumBatch = 1024
 	model := &Model{}
 	runner := &runnerRef{
-		model:        model,
-		Options:      &opts,
-		llama:        llm,
-		numParallel:  1,
-		numBatchAuto: true,
+		model:          model,
+		Options:        &opts,
+		llama:          llm,
+		numParallel:    1,
+		numBatchPolicy: numBatchAuto,
 	}
 	req := &LlmRequest{
-		model:        model,
-		opts:         api.DefaultOptions(),
-		numBatchAuto: true,
+		model:          model,
+		opts:           api.DefaultOptions(),
+		numBatchPolicy: numBatchAuto,
 	}
 	req.opts.NumBatch = 512
 
 	require.False(t, runner.needsReload(ctx, req))
 
-	req.numBatchAuto = false
+	req.numBatchPolicy = numBatchFixed
 	require.True(t, runner.needsReload(ctx, req))
 }
 
@@ -1044,16 +1044,16 @@ func TestSchedEmbeddingBatchOptionsForTokenCount(t *testing.T) {
 	opts.NumCtx = 8192
 	opts.NumBatch = llm.DefaultEmbeddingNumBatch
 
-	nextOpts, err := (&Scheduler{}).embeddingBatchOptionsForTokenCount(opts, true, 3602)
+	nextOpts, err := (&Scheduler{}).embeddingBatchOptionsForTokenCount(opts, numBatchAutoGrowable, 3602)
 	require.NoError(t, err)
 	require.Equal(t, 4096, nextOpts.NumBatch)
 
 	opts.NumCtx = 3602
-	nextOpts, err = (&Scheduler{}).embeddingBatchOptionsForTokenCount(opts, true, 3602)
+	nextOpts, err = (&Scheduler{}).embeddingBatchOptionsForTokenCount(opts, numBatchAutoGrowable, 3602)
 	require.NoError(t, err)
 	require.Equal(t, 3602, nextOpts.NumBatch)
 
-	_, err = (&Scheduler{}).embeddingBatchOptionsForTokenCount(opts, false, 3602)
+	_, err = (&Scheduler{}).embeddingBatchOptionsForTokenCount(opts, numBatchFixed, 3602)
 	require.Error(t, err)
 	var statusErr api.StatusError
 	require.ErrorAs(t, err, &statusErr)
@@ -1065,18 +1065,16 @@ func TestSchedNeedsReloadAutomaticEmbeddingNumBatchCanGrow(t *testing.T) {
 	opts := api.DefaultOptions()
 	opts.NumBatch = 4096
 	runner := &runnerRef{
-		model:        model,
-		Options:      &opts,
-		llama:        &mockLlm{vramByGPU: map[ml.DeviceID]uint64{}},
-		numParallel:  1,
-		numBatchAuto: true,
-		embBatchAuto: true,
+		model:          model,
+		Options:        &opts,
+		llama:          &mockLlm{vramByGPU: map[ml.DeviceID]uint64{}},
+		numParallel:    1,
+		numBatchPolicy: numBatchAutoGrowable,
 	}
 	req := &LlmRequest{
-		model:        model,
-		opts:         api.DefaultOptions(),
-		numBatchAuto: true,
-		embBatchAuto: true,
+		model:          model,
+		opts:           api.DefaultOptions(),
+		numBatchPolicy: numBatchAutoGrowable,
 	}
 
 	req.opts.NumBatch = 2048
@@ -1879,7 +1877,7 @@ func TestSchedLoadOOMReducesAutomaticContextBeforeRetry(t *testing.T) {
 	scenario := newScenarioRequestWithContext(t, ctx, "crashing-model", 1*format.GigaByte, nil, nil, 131072)
 	scenario.req.opts.NumCtx = 262144
 	scenario.req.numCtxAuto = true
-	scenario.req.numBatchAuto = true
+	scenario.req.numBatchPolicy = numBatchAuto
 	systemInfo := getSystemInfoFn()
 	gpus := s.getGpuFn(ctx, nil)
 

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -187,7 +187,7 @@ func TestSchedVisionContextFloor(t *testing.T) {
 		opts := api.DefaultOptions()
 		opts.NumCtx = 128
 
-		s.getRunner(ctx, visionModel, opts, nil, true, false, nil)
+		s.getRunner(ctx, visionModel, opts, nil, true, false, false, nil)
 
 		req := <-s.pendingReqCh
 		require.Equal(t, 2048, req.opts.NumCtx)
@@ -199,7 +199,7 @@ func TestSchedVisionContextFloor(t *testing.T) {
 		opts := api.DefaultOptions()
 		opts.NumCtx = 128
 
-		s.getRunner(ctx, visionModel, opts, nil, false, false, nil)
+		s.getRunner(ctx, visionModel, opts, nil, false, false, false, nil)
 
 		req := <-s.pendingReqCh
 		require.Equal(t, 2048, req.opts.NumCtx)
@@ -1037,6 +1037,56 @@ func TestSchedNeedsReloadIgnoresAutomaticNumBatchDerivation(t *testing.T) {
 
 	req.numBatchAuto = false
 	require.True(t, runner.needsReload(ctx, req))
+}
+
+func TestSchedEmbeddingBatchOptionsForTokenCount(t *testing.T) {
+	opts := api.DefaultOptions()
+	opts.NumCtx = 8192
+	opts.NumBatch = llm.DefaultEmbeddingNumBatch
+
+	nextOpts, err := (&Scheduler{}).embeddingBatchOptionsForTokenCount(opts, true, 3602)
+	require.NoError(t, err)
+	require.Equal(t, 4096, nextOpts.NumBatch)
+
+	opts.NumCtx = 3602
+	nextOpts, err = (&Scheduler{}).embeddingBatchOptionsForTokenCount(opts, true, 3602)
+	require.NoError(t, err)
+	require.Equal(t, 3602, nextOpts.NumBatch)
+
+	_, err = (&Scheduler{}).embeddingBatchOptionsForTokenCount(opts, false, 3602)
+	require.Error(t, err)
+	var statusErr api.StatusError
+	require.ErrorAs(t, err, &statusErr)
+	require.Equal(t, 400, statusErr.StatusCode)
+}
+
+func TestSchedNeedsReloadAutomaticEmbeddingNumBatchCanGrow(t *testing.T) {
+	model := &Model{}
+	opts := api.DefaultOptions()
+	opts.NumBatch = 4096
+	runner := &runnerRef{
+		model:        model,
+		Options:      &opts,
+		llama:        &mockLlm{vramByGPU: map[ml.DeviceID]uint64{}},
+		numParallel:  1,
+		numBatchAuto: true,
+		embBatchAuto: true,
+	}
+	req := &LlmRequest{
+		model:        model,
+		opts:         api.DefaultOptions(),
+		numBatchAuto: true,
+		embBatchAuto: true,
+	}
+
+	req.opts.NumBatch = 2048
+	require.False(t, runner.needsReload(t.Context(), req))
+
+	req.opts.NumBatch = 4096
+	require.False(t, runner.needsReload(t.Context(), req))
+
+	req.opts.NumBatch = 5120
+	require.True(t, runner.needsReload(t.Context(), req))
 }
 
 func TestSchedNeedsReloadIgnoresAutomaticUseMMapDefault(t *testing.T) {


### PR DESCRIPTION
Embedding requests must fit in llama-server's physical batch. When an automatic embedding runner is already loaded with too small of a batch, pre-tokenize the request, log the reason, and reload with a larger batch before calling /embedding.

Keep explicit num_batch requests bounded by returning 400 instead of silently growing the runner.

Fixes #16582