### PR TITLE
fix: add verbose flag to launch command

### DIFF
--- a/cmd/launch/command_test.go
+++ b/cmd/launch/command_test.go
@@ -79,6 +79,9 @@ func TestLaunchCmd(t *testing.T) {
 		if cmd.Flags().Lookup("yes") == nil {
 			t.Error("--yes flag should exist")
 		}
+		if cmd.Flags().Lookup("verbose") == nil {
+			t.Error("--verbose flag should exist")
+		}
 	})
 
 	t.Run("PreRunE is set", func(t *testing.T) {
@@ -105,6 +108,27 @@ func TestLaunchCmdTUICallback(t *testing.T) {
 
 		if !tuiCalled {
 			t.Error("TUI callback should be called when no args provided")
+		}
+	})
+
+	t.Run("verbose flag is available to TUI", func(t *testing.T) {
+		var gotVerbose bool
+		mockTUI := func(cmd *cobra.Command) {
+			var err error
+			gotVerbose, err = cmd.Flags().GetBool("verbose")
+			if err != nil {
+				t.Fatalf("verbose flag should be readable: %v", err)
+			}
+		}
+
+		cmd := LaunchCmd(mockCheck, mockTUI)
+		cmd.SetArgs([]string{"--verbose"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("launch command failed: %v", err)
+		}
+
+		if !gotVerbose {
+			t.Fatal("expected TUI callback to see verbose=true")
 		}
 	})
 

--- a/cmd/launch/launch.go
+++ b/cmd/launch/launch.go
@@ -398,6 +398,7 @@ Examples:
 	cmd.Flags().BoolVar(&configFlag, "config", false, "Configure without launching")
 	cmd.Flags().BoolVar(&restoreFlag, "restore", false, "Restore an integration to its default profile")
 	cmd.Flags().BoolVarP(&yesFlag, "yes", "y", false, "Automatically answer yes to confirmation prompts")
+	cmd.Flags().Bool("verbose", false, "Show timings for response")
 	return cmd
 }
 


### PR DESCRIPTION
## Summary

Fixes #16885.

`ollama launch` can enter the model runner path via the launch TUI. That path reuses the interactive generation code, which reads and updates the `verbose` flag on the command. The launch subcommand did not register `--verbose`, so selecting verbose mode from that path could fail with `flag accessed but not defined: verbose`.

This adds the same `--verbose` flag to `LaunchCmd` and covers that the TUI callback can read it when `ollama launch --verbose` is used.

## Tests

- `git diff --check`

I could not run the Go unit test locally because this environment does not have `go`/`gofmt` on PATH or in the bundled Codex runtime.
