### PR TITLE
mlx: route fast quantized matmul on CUDA

### DIFF
--- a/x/mlxrunner/mlx/mlx.go
+++ b/x/mlxrunner/mlx/mlx.go
@@ -105,3 +105,10 @@ func MetalIsAvailable() bool {
 	C.mlx_metal_is_available(&available)
 	return bool(available)
 }
+
+// CUDAIsAvailable returns true if a CUDA GPU is available.
+func CUDAIsAvailable() bool {
+	var available C._Bool
+	C.mlx_cuda_is_available(&available)
+	return bool(available)
+}

--- a/x/mlxrunner/mlx/ops_extra.go
+++ b/x/mlxrunner/mlx/ops_extra.go
@@ -5,10 +5,14 @@ import "C"
 
 import (
 	"reflect"
+	"strings"
+	"sync/atomic"
 	"unsafe"
 )
 
 // Quantization operations
+
+var fastQuantizedMatmulBackendState atomic.Int32 // 0 unknown, 1 unsupported, 2 supported
 
 func Quantize(w *Array, groupSize, bits int, mode string) (weights, scales, biases *Array) {
 	cMode := C.CString(mode)
@@ -77,6 +81,86 @@ func QuantizedMatmul(x, w, scales, biases *Array, transpose bool, groupSize, bit
 	out := New("QUANTIZED_MATMUL")
 	C.mlx_quantized_matmul(&out.ctx, x.ctx, w.ctx, scales.ctx, b, C.bool(transpose), optGroupSize, optBits, cMode, DefaultStream().ctx)
 	return out
+}
+
+func FastQuantizedMatmul(x, w, scales, biases *Array, transpose bool, groupSize, bits int, mode string) *Array {
+	if transpose && biases == nil && supportsQQMatmul(x, mode) {
+		return qqMatmul(x, w, scales, nil, nil, groupSize, bits, mode)
+	}
+	return QuantizedMatmul(x, w, scales, biases, transpose, groupSize, bits, mode)
+}
+
+func SupportsFastQuantizedMatmulMode(mode string) bool {
+	switch strings.ToLower(mode) {
+	case "nvfp4", "mxfp8":
+		return supportsFastQuantizedMatmulBackend()
+	default:
+		return false
+	}
+}
+
+func supportsFastQuantizedMatmulBackend() bool {
+	switch fastQuantizedMatmulBackendState.Load() {
+	case 1:
+		return false
+	case 2:
+		return true
+	}
+	if CheckInit() != nil {
+		fastQuantizedMatmulBackendState.Store(1)
+		return false
+	}
+
+	supported := !MetalIsAvailable() && CUDAIsAvailable() && cudaComputeCapabilityAtLeast(10, 0)
+	if supported {
+		fastQuantizedMatmulBackendState.Store(2)
+	} else {
+		fastQuantizedMatmulBackendState.Store(1)
+	}
+	return supported
+}
+
+func resetFastQuantizedMatmulBackendCache() {
+	fastQuantizedMatmulBackendState.Store(0)
+}
+
+func qqMatmul(x, w, scales, globalScaleX, globalScaleW *Array, groupSize, bits int, mode string) *Array {
+	cMode := C.CString(mode)
+	defer C.free(unsafe.Pointer(cMode))
+	optGroupSize := C.mlx_optional_int{value: C.int(groupSize), has_value: true}
+	optBits := C.mlx_optional_int{value: C.int(bits), has_value: true}
+
+	var s, gsX, gsW C.mlx_array
+	if scales != nil {
+		s = scales.ctx
+	}
+	if globalScaleX != nil {
+		gsX = globalScaleX.ctx
+	}
+	if globalScaleW != nil {
+		gsW = globalScaleW.ctx
+	}
+
+	out := New("QQMM")
+	C.mlx_qqmm(&out.ctx, x.ctx, w.ctx, s, optGroupSize, optBits, cMode, gsX, gsW, DefaultStream().ctx)
+	return out
+}
+
+func supportsQQMatmul(x *Array, mode string) bool {
+	if x == nil || !x.Valid() || x.NumDims() == 0 {
+		return false
+	}
+	if !SupportsFastQuantizedMatmulMode(mode) {
+		return false
+	}
+	lastDim := x.Dim(x.NumDims() - 1)
+	if lastDim <= 0 {
+		return false
+	}
+	// MLX CUDA routes QQMM vector inputs back through a qmv-shaped path. Keep
+	// decode and small prompts on QuantizedMatmul so this fast path targets
+	// large prompt/prefill batches where block-scaled matmul can amortize setup.
+	return x.Size()/lastDim >= 128
 }
 
 func GatherQMM(x, w, scales *Array, biases, lhsIndices, rhsIndices *Array, transpose bool, groupSize, bits int, mode string, sortedIndices bool) *Array {

--- a/x/mlxrunner/mlx/ops_extra_test.go
+++ b/x/mlxrunner/mlx/ops_extra_test.go
@@ -1,0 +1,17 @@
+package mlx
+
+import "testing"
+
+func TestSupportsFastQuantizedMatmulModeDisabledOnMetal(t *testing.T) {
+	withMLXThread(t, func() {
+		if !MetalIsAvailable() {
+			t.Skip("Metal is not available")
+		}
+
+		for _, mode := range []string{"nvfp4", "mxfp8"} {
+			if SupportsFastQuantizedMatmulMode(mode) {
+				t.Fatalf("SupportsFastQuantizedMatmulMode(%q) = true on Metal", mode)
+			}
+		}
+	})
+}

--- a/x/mlxrunner/mlx/stream.go
+++ b/x/mlxrunner/mlx/stream.go
@@ -1,9 +1,14 @@
 package mlx
 
 // #include "generated.h"
+// #include <stdlib.h>
 import "C"
 
-import "log/slog"
+import (
+	"log/slog"
+	"sync"
+	"unsafe"
+)
 
 type Device struct {
 	ctx C.mlx_device
@@ -21,11 +26,24 @@ var (
 	defaultDeviceSet bool
 	defaultStream    Stream
 	defaultStreamSet bool
+
+	cudaCapabilityMu    sync.Mutex
+	cudaCapabilityValid bool
+	cudaCapabilityMajor int
+	cudaCapabilityMinor int
 )
 
 func resetDefaultStreamCache() {
 	defaultDeviceSet = false
 	defaultStreamSet = false
+
+	cudaCapabilityMu.Lock()
+	cudaCapabilityValid = false
+	cudaCapabilityMajor = 0
+	cudaCapabilityMinor = 0
+	cudaCapabilityMu.Unlock()
+
+	resetFastQuantizedMatmulBackendCache()
 }
 
 func DefaultDevice() Device {
@@ -54,6 +72,65 @@ func SetDefaultDeviceGPU() {
 	C.mlx_set_default_device(dev)
 	C.mlx_device_free(dev)
 	resetDefaultStreamCache()
+}
+
+func cudaComputeCapability() (major, minor int, ok bool) {
+	cudaCapabilityMu.Lock()
+	defer cudaCapabilityMu.Unlock()
+
+	if cudaCapabilityValid {
+		return cudaCapabilityMajor, cudaCapabilityMinor, true
+	}
+
+	dev := C.mlx_device_new_type(C.MLX_GPU, 0)
+	defer C.mlx_device_free(dev)
+
+	var avail C.bool
+	if C.mlx_device_is_available(&avail, dev) != 0 || !bool(avail) {
+		return 0, 0, false
+	}
+
+	info := C.mlx_device_info_new()
+	defer C.mlx_device_info_free(info)
+	if C.mlx_device_info_get(&info, dev) != 0 {
+		return 0, 0, false
+	}
+
+	major, ok = deviceInfoSize(info, "compute_capability_major")
+	if !ok {
+		return 0, 0, false
+	}
+	minor, ok = deviceInfoSize(info, "compute_capability_minor")
+	if !ok {
+		return 0, 0, false
+	}
+
+	cudaCapabilityMajor = major
+	cudaCapabilityMinor = minor
+	cudaCapabilityValid = true
+	return major, minor, true
+}
+
+func cudaComputeCapabilityAtLeast(major, minor int) bool {
+	actualMajor, actualMinor, ok := cudaComputeCapability()
+	if !ok {
+		return false
+	}
+	if actualMajor != major {
+		return actualMajor > major
+	}
+	return actualMinor >= minor
+}
+
+func deviceInfoSize(info C.mlx_device_info, key string) (int, bool) {
+	cKey := C.CString(key)
+	defer C.free(unsafe.Pointer(cKey))
+
+	var value C.size_t
+	if C.mlx_device_info_get_size(&value, info, cKey) != 0 {
+		return 0, false
+	}
+	return int(value), true
 }
 
 type Stream struct {

--- a/x/mlxrunner/model/linear.go
+++ b/x/mlxrunner/model/linear.go
@@ -91,6 +91,7 @@ func MakeLinearLayer(
 			GroupSize:   groupSize,
 			Bits:        bits,
 			Mode:        mode,
+			FastMatmul:  mlx.SupportsFastQuantizedMatmulMode(mode),
 		}
 	}
 

--- a/x/models/nn/nn.go
+++ b/x/models/nn/nn.go
@@ -89,6 +89,7 @@ type QuantizedLinear struct {
 	GroupSize   int
 	Bits        int
 	Mode        string
+	FastMatmul  bool
 }
 
 func NewQuantizedLinear(weight *mlx.Array, bias *mlx.Array, groupSize, bits int, mode string) *QuantizedLinear {
@@ -102,18 +103,24 @@ func NewQuantizedLinear(weight *mlx.Array, bias *mlx.Array, groupSize, bits int,
 		bias = bias.AsType(weight.DType())
 	}
 	return &QuantizedLinear{
-		Weight:    qw,
-		Scales:    scales,
-		QBiases:   qbiases,
-		Bias:      bias,
-		GroupSize: groupSize,
-		Bits:      bits,
-		Mode:      mode,
+		Weight:     qw,
+		Scales:     scales,
+		QBiases:    qbiases,
+		Bias:       bias,
+		GroupSize:  groupSize,
+		Bits:       bits,
+		Mode:       mode,
+		FastMatmul: mlx.SupportsFastQuantizedMatmulMode(mode),
 	}
 }
 
 func (ql *QuantizedLinear) Forward(x *mlx.Array) *mlx.Array {
-	out := mlx.QuantizedMatmul(x, ql.Weight, ql.Scales, ql.QBiases, true, ql.GroupSize, ql.Bits, ql.Mode)
+	var out *mlx.Array
+	if ql.FastMatmul {
+		out = mlx.FastQuantizedMatmul(x, ql.Weight, ql.Scales, ql.QBiases, true, ql.GroupSize, ql.Bits, ql.Mode)
+	} else {
+		out = mlx.QuantizedMatmul(x, ql.Weight, ql.Scales, ql.QBiases, true, ql.GroupSize, ql.Bits, ql.Mode)
+	}
 	if ql.GlobalScale != nil {
 		// Double-scale nvfp4 (e.g., NVIDIA ModelOpt): standard quantized_matmul
 		// followed by global_scale multiply. The global_scale is a per-tensor
@@ -207,6 +214,7 @@ func (qe *QuantizedEmbedding) AsLinear() LinearLayer {
 		GroupSize:   qe.GroupSize,
 		Bits:        qe.Bits,
 		Mode:        qe.Mode,
+		FastMatmul:  mlx.SupportsFastQuantizedMatmulMode(qe.Mode),
 	}
 }
 


### PR DESCRIPTION
Use MLX QQMM for prompt-sized nvfp4 and mxfp8 quantized linears when the active backend is CUDA on compute capability 10.0 or newer. Keep Metal, non-CUDA, biased, and decode-sized cases on the existing quantized_matmul path.