### PR TITLE
launch: hermes desktop in the background

### DIFF
--- a/cmd/launch/hermes.go
+++ b/cmd/launch/hermes.go
@@ -94,7 +94,14 @@ func (h *HermesDesktop) Run(_ string, _ []LaunchModel, args []string) error {
 	if err != nil {
 		return err
 	}
-	return hermesAttachedCommand(bin, h.launchArgs(args)...).Run()
+	desktopArgs := h.launchArgs(args)
+	if h.shouldRunForeground(args) {
+		return hermesAttachedCommand(bin, desktopArgs...).Run()
+	}
+	if err := hermesDetachedCommand(bin, desktopArgs...).Start(); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (h *HermesDesktop) Onboard() error {
@@ -125,6 +132,14 @@ func (h *HermesDesktop) packagedAppExists() bool {
 		}
 	}
 	return false
+}
+
+// shouldRunForeground reports whether Hermes Desktop should stay attached to
+// the launcher terminal instead of detaching into the background. Help and
+// build-only invocations produce terminal output, and --foreground lets users
+// opt into the attached behavior explicitly.
+func (h *HermesDesktop) shouldRunForeground(args []string) bool {
+	return hermesDesktopHasFlag(args, "--foreground", "--help", "-h", "--build-only")
 }
 
 // These roots mirror Hermes' own install layout:
@@ -868,5 +883,14 @@ func hermesAttachedCommand(name string, args ...string) *exec.Cmd {
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	return cmd
+}
+
+// hermesDetachedCommand builds a command whose stdio is detached from the
+// launcher terminal and that runs in its own process group, so the desktop app
+// keeps running after the launcher exits without holding the launcher's tty.
+func hermesDetachedCommand(name string, args ...string) *exec.Cmd {
+	cmd := hermesCommand(name, args...)
+	cmd.SysProcAttr = hermesDesktopBackgroundSysProcAttr()
 	return cmd
 }

--- a/cmd/launch/hermes.go
+++ b/cmd/launch/hermes.go
@@ -136,10 +136,9 @@ func (h *HermesDesktop) packagedAppExists() bool {
 
 // shouldRunForeground reports whether Hermes Desktop should stay attached to
 // the launcher terminal instead of detaching into the background. Help and
-// build-only invocations produce terminal output, and --foreground lets users
-// opt into the attached behavior explicitly.
+// build-only invocations produce terminal output.
 func (h *HermesDesktop) shouldRunForeground(args []string) bool {
-	return hermesDesktopHasFlag(args, "--foreground", "--help", "-h", "--build-only")
+	return hermesDesktopHasFlag(args, "--help", "-h", "--build-only")
 }
 
 // These roots mirror Hermes' own install layout:

--- a/cmd/launch/hermes_desktop_bg_unix.go
+++ b/cmd/launch/hermes_desktop_bg_unix.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+package launch
+
+import "syscall"
+
+// hermesDesktopBackgroundSysProcAttr returns SysProcAttr for running Hermes
+// Desktop in the background on Unix. Setpgid detaches the desktop process from
+// the launcher's process group so it survives the launcher exiting and does not
+// receive signals sent to the launcher terminal.
+func hermesDesktopBackgroundSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{
+		Setpgid: true,
+	}
+}

--- a/cmd/launch/hermes_desktop_bg_windows.go
+++ b/cmd/launch/hermes_desktop_bg_windows.go
@@ -1,0 +1,14 @@
+package launch
+
+import "syscall"
+
+// hermesDesktopBackgroundSysProcAttr returns SysProcAttr for running Hermes
+// Desktop in the background on Windows. CREATE_NO_WINDOW (0x08000000) keeps a
+// console window from flashing for the launcher-spawned process while the
+// desktop app's own window opens normally.
+func hermesDesktopBackgroundSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{
+		CreationFlags: 0x08000000,
+		HideWindow:    true,
+	}
+}

--- a/cmd/launch/hermes_test.go
+++ b/cmd/launch/hermes_test.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"gopkg.in/yaml.v3"
 
@@ -635,13 +636,20 @@ func writeHermesDesktopTestBinary(t *testing.T, dir string) {
 	}
 }
 
-func readHermesDesktopInvocations(t *testing.T, home string) string {
+func waitForHermesDesktopInvocations(t *testing.T, home, want string) {
 	t.Helper()
-	data, err := os.ReadFile(filepath.Join(home, "hermes-invocations.log"))
-	if err != nil {
-		t.Fatal(err)
+	path := filepath.Join(home, "hermes-invocations.log")
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		data, err := os.ReadFile(path)
+		if err == nil && strings.TrimSpace(string(data)) == want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected hermes invocations %q, got %q", want, strings.TrimSpace(string(data)))
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
-	return strings.TrimSpace(string(data))
 }
 
 func TestHermesDesktopRun(t *testing.T) {
@@ -726,11 +734,39 @@ func TestHermesDesktopRun(t *testing.T) {
 			if err := (&HermesDesktop{}).Run("", nil, tt.args); err != nil {
 				t.Fatalf("Run returned error: %v", err)
 			}
-			if got := readHermesDesktopInvocations(t, tmpDir); got != tt.want {
-				t.Fatalf("expected %q, got %q", tt.want, got)
-			}
+			waitForHermesDesktopInvocations(t, tmpDir, tt.want)
 		})
 	}
+}
+
+func TestHermesDesktopRunBackgroundNonBlocking(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses a POSIX shell test binary")
+	}
+	tmpDir := t.TempDir()
+	setTestHome(t, tmpDir)
+	withHermesPlatform(t, runtime.GOOS)
+	t.Setenv("PATH", tmpDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	// The fake hermes binary sleeps before recording its invocation, so a
+	// blocking (foreground) Run would not return until the sleep finishes.
+	// A detached background launch returns immediately and the invocation
+	// appears later.
+	bin := filepath.Join(tmpDir, "hermes")
+	script := "#!/bin/sh\nsleep 1\nprintf '[%s]\\n' \"$*\" >> \"$HOME/hermes-invocations.log\"\n"
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Now()
+	if err := (&HermesDesktop{}).Run("", nil, nil); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	elapsed := time.Since(start)
+	if elapsed >= time.Second {
+		t.Fatalf("Run blocked for %v; expected a detached background launch to return immediately", elapsed)
+	}
+	waitForHermesDesktopInvocations(t, tmpDir, "[desktop]")
 }
 
 func TestHermesDesktopRunUsesWindowsLocalAppDataPackage(t *testing.T) {

--- a/cmd/launch/hermes_test.go
+++ b/cmd/launch/hermes_test.go
@@ -668,9 +668,8 @@ func TestHermesDesktopRun(t *testing.T) {
 		{
 			name:        "desktop subcommand",
 			goos:        "darwin",
-			args:        []string{"--foreground"},
 			clearPkgEnv: true,
-			want:        "[desktop --foreground]",
+			want:        "[desktop]",
 		},
 		{
 			name:       "skip build when packaged app exists",


### PR DESCRIPTION
`ollama launch hermes-desktop` used to block the terminal. The desktop process stayed attached to the launcher's stdin/stdout/stderr until it exited. I changed it to detach the process and return immediately, so the terminal is free while the app keeps running.

I used `Start()` with `Setpgid` on Unix and `CREATE_NO_WINDOW` on Windows, mirroring how the ollama server itself is backgrounded. Help, build-only, and the `--foreground` flag still run attached, since those produce terminal output.
