### PR TITLE
docs: update Screenpipe URL (repo renamed from mediar-ai to screenpipe)

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ console.log(response.message.content);
 ### Productivity & Apps
 
 - [AppFlowy](https://github.com/AppFlowy-IO/AppFlowy) - AI collaborative workspace, self-hostable Notion alternative
-- [Screenpipe](https://github.com/mediar-ai/screenpipe) - 24/7 screen and mic recording with AI-powered search
+- [Screenpipe](https://github.com/screenpipe/screenpipe) - 24/7 screen and mic recording with AI-powered search
 - [Vibe](https://github.com/thewh1teagle/vibe) - Transcribe and analyze meetings
 - [Page Assist](https://github.com/n4ze3m/page-assist) - Chrome extension for AI-powered browsing
 - [NativeMind](https://github.com/NativeMindBrowser/NativeMindExtension) - Private, on-device browser AI assistant


### PR DESCRIPTION
The screenpipe GitHub org was renamed from `mediar-ai` to `screenpipe`. The old URL still resolves via GitHub's redirect, but the canonical URL is now https://github.com/screenpipe/screenpipe. This PR updates the link in the Community Integrations → Productivity & Apps entry so it points directly to the canonical URL.

Description, position, and surrounding entries are unchanged.

Disclosure: this update was prepared by screenpipe's automated contribution agent; I'm the maintainer of screenpipe (louis@screenpi.pe) — happy to adjust or close if it isn't a fit.