### PR TITLE
fix: reduce llama-server default logging verbosity (#16897)

### DIFF
--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -562,9 +562,19 @@ func embeddingBatchSize(opts api.Options, numParallel int) int {
 }
 
 func appendLlamaServerLogArgs(params []string) []string {
-	// Keep startup memory/offload lines visible for scheduler accounting.
+	// Default to warnings-only to avoid flooding logs with per-request
+	// slot diagnostics (launch, update, timing, idle). When OLLAMA_DEBUG
+	// is set, bump verbosity so those lines remain visible for debugging.
+	verbosity := 2 // warnings only
+	if s := envconfig.Var("OLLAMA_DEBUG"); s != "" {
+		if b, _ := strconv.ParseBool(s); b {
+			verbosity = 5 // debug
+		} else if i, _ := strconv.ParseInt(s, 10, 64); i > 0 {
+			verbosity = int(i) + 3
+		}
+	}
 	return append(params,
-		"--log-verbosity", "4",
+		"--log-verbosity", strconv.Itoa(verbosity),
 		"--no-log-prefix",
 		"--no-log-timestamps",
 	)


### PR DESCRIPTION
Fixes #16897

## Problem

The `llama-server` subprocess logs at verbosity level 4 (DEBUG) by default, flooding journald and other log aggregators with per-request slot diagnostics:

- `slot launch_slot_:` — sampler chain and params for every request
- `slot update_slots:` — prompt/continuation processing
- `slot print_timing:` — per-request timing stats
- `srv update_slots: all slots are idle` — idle transitions

## Fix

Change the default `--log-verbosity` from `4` to `2` (warnings only), hiding per-request noise. Honor the existing `OLLAMA_DEBUG` environment variable so users can opt back in:

| `OLLAMA_DEBUG` | llama-server verbosity |
|---|---|
| unset (default) | 2 — warnings only |
| `1` / `true` | 5 — debug |
| numeric N | N + 3 |

This matches the pattern used by Ollama's Go-side logging (via `envconfig.LogLevel()`).

## Prior art

PR #16899 attempted the same fix (4 → 2) but was reverted. This version additionally ties verbosity to `OLLAMA_DEBUG` so production users get clean logs while developers retain full visibility.