### PR TITLE
windows: use install.ps1 for app upgrades

### DIFF
--- a/.github/workflows/test-install-windows.yaml
+++ b/.github/workflows/test-install-windows.yaml
@@ -1,0 +1,26 @@
+name: test-install-windows
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/install.ps1'
+      - 'scripts/tests/**'
+      - '.github/workflows/test-install-windows.yaml'
+
+jobs:
+  pester:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Pester
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          if (-not (Get-Module -ListAvailable Pester | Where-Object { $_.Version -ge [version]"5.0.0" })) {
+            Install-Module Pester -Scope CurrentUser -Force -MinimumVersion 5.0.0
+          }
+      - name: Run install.ps1 unit tests
+        shell: powershell
+        run: |
+          Import-Module Pester -MinimumVersion 5.0.0
+          Invoke-Pester scripts\tests\install.Tests.ps1 -Tag Unit -CI

--- a/app/README.md
+++ b/app/README.md
@@ -48,6 +48,102 @@ The `-dev` flag enables:
 - CORS headers for cross-origin requests
 - Hot-reload support for UI development
 
+### Upgrade Testing
+
+The local updater endpoint override is compiled only when the app is built with
+the `updater_localtest` tag. Official builds do not include this override.
+The override is shared by the Windows and macOS app; the localhost server below
+serves the current Windows `install.ps1` upgrade flow.
+To intentionally run an unsigned `install.ps1` during local testing, also add
+the `updater_unsigned` tag. Official builds must never use that tag.
+
+These tests install and upgrade Ollama for real. Run them only on a machine
+where it is OK to replace the current Ollama install.
+
+Build a local-test app:
+
+```powershell
+go generate ./...
+go build -tags updater_localtest -trimpath `
+  -ldflags "-H windowsgui -X=github.com/ollama/ollama/app/version.Version=0.0.0-localtest" `
+  -o .\dist\windows-ollama-app-updater-localtest.exe .\app\cmd\app
+```
+
+For the unsigned-script success path only, build with both tags:
+
+```powershell
+go build -tags "updater_localtest updater_unsigned" -trimpath `
+  -ldflags "-H windowsgui -X=github.com/ollama/ollama/app/version.Version=0.0.0-localtest" `
+  -o .\dist\windows-ollama-app-updater-localtest.exe .\app\cmd\app
+```
+
+Start by testing that the app rejects an unsigned `install.ps1`. This serves a
+patched test copy of the script from localhost so the script would download the
+local installer if it were trusted.
+
+```powershell
+python .\scripts\tests\update-server.py `
+  --port 8765 `
+  --version 0.0.1-localtest `
+  --installer .\dist\OllamaSetup.exe `
+  --install-script .\scripts\install.ps1 `
+  --patch-install-script
+```
+
+To exercise the installer-cache fallback for a server that omits installer
+ETags, add `--omit-installer-etag` to the server command.
+
+In another PowerShell window:
+
+```powershell
+Remove-Item "$env:LOCALAPPDATA\Ollama\updates_v2" -Recurse -Force -ErrorAction SilentlyContinue
+Remove-Item "$env:LOCALAPPDATA\Ollama\install_cache" -Recurse -Force -ErrorAction SilentlyContinue
+$env:OLLAMA_DEBUG = "1"
+.\dist\windows-ollama-app-updater-localtest.exe --update-check-url http://127.0.0.1:8765/api/update
+Get-Content "$env:LOCALAPPDATA\Ollama\app.log" -Wait
+```
+
+The log should show `install.ps1 signature verification failed`, and no upgrade
+should be staged.
+
+For the signed success path, generate the patched test script once, sign that
+generated file, then serve it without `--patch-install-script` so its signature
+is preserved.
+
+```powershell
+python .\scripts\tests\update-server.py `
+  --port 8765 `
+  --version 0.0.1-localtest `
+  --installer .\dist\OllamaSetup.exe `
+  --install-script .\scripts\install.ps1 `
+  --patch-install-script `
+  --output-install-script .\.cache\update-server\install.ps1 `
+  --prepare-only
+
+# Sign .\.cache\update-server\install.ps1 using the same Authenticode signing
+# setup used by .\scripts\build_windows.ps1 sign. The installer must also be signed.
+
+python .\scripts\tests\update-server.py `
+  --port 8765 `
+  --version 0.0.1-localtest `
+  --installer .\dist\OllamaSetup.exe `
+  --install-script .\.cache\update-server\install.ps1
+```
+
+Then run the local-test app once to cache the update, quit it after the log
+shows the cache phase completed, and start it hidden to exercise startup
+upgrade:
+
+```powershell
+$env:OLLAMA_DEBUG = "1"
+.\dist\windows-ollama-app-updater-localtest.exe --update-check-url http://127.0.0.1:8765/api/update
+Get-Content "$env:LOCALAPPDATA\Ollama\app.log" -Wait
+
+Get-Process "Ollama app" -ErrorAction SilentlyContinue | Stop-Process
+.\dist\windows-ollama-app-updater-localtest.exe --update-check-url http://127.0.0.1:8765/api/update --hide
+Get-Content "$env:LOCALAPPDATA\Ollama\app.log" -Wait
+```
+
 ## Build
 
 

--- a/app/README.md
+++ b/app/README.md
@@ -48,6 +48,62 @@ The `-dev` flag enables:
 - CORS headers for cross-origin requests
 - Hot-reload support for UI development
 
+### Upgrade Testing
+
+These commands perform a real app upgrade. Use a test machine or a throwaway
+install.
+
+Build or copy `OllamaSetup.exe` into `dist\`, then build a local-test app:
+
+```powershell
+go generate ./...
+go build -tags updater_localtest -trimpath `
+  -ldflags "-H windowsgui -X=github.com/ollama/ollama/app/version.Version=0.0.0-localtest" `
+  -o .\dist\windows-ollama-app-updater-localtest.exe .\app\cmd\app
+```
+
+For unsigned local `install.ps1` testing:
+
+```powershell
+go build -tags "updater_localtest updater_unsigned" -trimpath `
+  -ldflags "-H windowsgui -X=github.com/ollama/ollama/app/version.Version=0.0.0-localtest" `
+  -o .\dist\windows-ollama-app-updater-localtest.exe .\app\cmd\app
+```
+
+Start the local update server from the repository root:
+
+```powershell
+python .\scripts\tests\update-server.py `
+  --port 8765 `
+  --version 0.0.1-localtest
+```
+
+To test without ETags, add `--omit-etags`.
+
+In another PowerShell window:
+
+```powershell
+Remove-Item "$env:LOCALAPPDATA\Ollama\updates_v2" -Recurse -Force -ErrorAction SilentlyContinue
+Remove-Item "$env:LOCALAPPDATA\Ollama\install_cache" -Recurse -Force -ErrorAction SilentlyContinue
+$env:OLLAMA_DEBUG = "1"
+$env:OLLAMA_TEST_UPDATE_URL = "http://127.0.0.1:8765/api/update"
+.\dist\windows-ollama-app-updater-localtest.exe
+Get-Content "$env:LOCALAPPDATA\Ollama\app.log" -Wait
+```
+
+For the startup upgrade path:
+
+```powershell
+$env:OLLAMA_DEBUG = "1"
+$env:OLLAMA_TEST_UPDATE_URL = "http://127.0.0.1:8765/api/update"
+.\dist\windows-ollama-app-updater-localtest.exe
+Get-Content "$env:LOCALAPPDATA\Ollama\app.log" -Wait
+
+Get-Process "Ollama app" -ErrorAction SilentlyContinue | Stop-Process
+.\dist\windows-ollama-app-updater-localtest.exe --hide
+Get-Content "$env:LOCALAPPDATA\Ollama\app.log" -Wait
+```
+
 ## Build
 
 

--- a/app/cmd/app/app.go
+++ b/app/cmd/app/app.go
@@ -61,7 +61,14 @@ func main() {
 	startHidden := false
 	var urlSchemeRequest string
 	if len(os.Args) > 1 {
-		for _, arg := range os.Args {
+		args := os.Args[1:]
+		for i := 0; i < len(args); i++ {
+			arg := args[i]
+			if handled, consumed := maybeConfigureLocalUpdateCheckURL(args, i); handled {
+				i += consumed
+				continue
+			}
+
 			// Handle URL scheme requests (Windows)
 			if strings.HasPrefix(arg, "ollama://") {
 				urlSchemeRequest = arg

--- a/app/cmd/app/app.go
+++ b/app/cmd/app/app.go
@@ -61,7 +61,10 @@ func main() {
 	startHidden := false
 	var urlSchemeRequest string
 	if len(os.Args) > 1 {
-		for _, arg := range os.Args {
+		args := os.Args[1:]
+		for i := 0; i < len(args); i++ {
+			arg := args[i]
+
 			// Handle URL scheme requests (Windows)
 			if strings.HasPrefix(arg, "ollama://") {
 				urlSchemeRequest = arg

--- a/app/cmd/app/update_check_url_default.go
+++ b/app/cmd/app/update_check_url_default.go
@@ -1,0 +1,7 @@
+//go:build (windows || darwin) && !updater_localtest
+
+package main
+
+func maybeConfigureLocalUpdateCheckURL(args []string, index int) (bool, int) {
+	return false, 0
+}

--- a/app/cmd/app/update_check_url_localtest.go
+++ b/app/cmd/app/update_check_url_localtest.go
@@ -1,0 +1,73 @@
+//go:build (windows || darwin) && updater_localtest
+
+package main
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/ollama/ollama/app/updater"
+)
+
+func maybeConfigureLocalUpdateCheckURL(args []string, index int) (bool, int) {
+	const flag = "--update-check-url"
+
+	arg := args[index]
+	rawURL := ""
+	consumed := 0
+	if arg == flag {
+		if index+1 >= len(args) {
+			fmt.Fprintf(os.Stderr, "%s requires a value\n", flag)
+			os.Exit(2)
+		}
+		rawURL = args[index+1]
+		consumed = 1
+	} else if strings.HasPrefix(arg, flag+"=") {
+		rawURL = strings.TrimPrefix(arg, flag+"=")
+	} else {
+		return false, 0
+	}
+
+	if err := configureLocalUpdateCheckURL(rawURL); err != nil {
+		fmt.Fprintf(os.Stderr, "invalid %s: %v\n", flag, err)
+		os.Exit(2)
+	}
+	fmt.Fprintf(os.Stderr, "using local updater test endpoint: %s\n", updater.UpdateCheckURLBase)
+	return true, consumed
+}
+
+func configureLocalUpdateCheckURL(rawURL string) error {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return err
+	}
+	if parsed.Scheme != "http" {
+		return fmt.Errorf("scheme must be http")
+	}
+	if parsed.User != nil {
+		return fmt.Errorf("userinfo is not allowed")
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return fmt.Errorf("query strings and fragments are not allowed")
+	}
+	if parsed.Path != "/api/update" && parsed.Path != "/update.json" {
+		return fmt.Errorf("path must be /api/update or /update.json")
+	}
+	if !isLoopbackUpdateHost(parsed.Hostname()) {
+		return fmt.Errorf("host must be localhost or a loopback IP")
+	}
+
+	updater.UpdateCheckURLBase = parsed.String()
+	return nil
+}
+
+func isLoopbackUpdateHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}

--- a/app/cmd/app/update_check_url_localtest_test.go
+++ b/app/cmd/app/update_check_url_localtest_test.go
@@ -1,0 +1,43 @@
+//go:build (windows || darwin) && updater_localtest
+
+package main
+
+import (
+	"testing"
+
+	"github.com/ollama/ollama/app/updater"
+)
+
+func TestConfigureLocalUpdateCheckURL(t *testing.T) {
+	old := updater.UpdateCheckURLBase
+	defer func() {
+		updater.UpdateCheckURLBase = old
+	}()
+
+	if err := configureLocalUpdateCheckURL("http://127.0.0.1:8765/api/update"); err != nil {
+		t.Fatalf("configureLocalUpdateCheckURL returned error: %v", err)
+	}
+	if got := updater.UpdateCheckURLBase; got != "http://127.0.0.1:8765/api/update" {
+		t.Fatalf("UpdateCheckURLBase = %q", got)
+	}
+}
+
+func TestConfigureLocalUpdateCheckURLRejectsNonLoopback(t *testing.T) {
+	old := updater.UpdateCheckURLBase
+	defer func() {
+		updater.UpdateCheckURLBase = old
+	}()
+
+	for _, rawURL := range []string{
+		"https://127.0.0.1:8765/api/update",
+		"http://example.com/api/update",
+		"http://127.0.0.1:8765/other",
+		"http://127.0.0.1:8765/api/update?x=1",
+	} {
+		t.Run(rawURL, func(t *testing.T) {
+			if err := configureLocalUpdateCheckURL(rawURL); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}

--- a/app/ui/ui_test.go
+++ b/app/ui/ui_test.go
@@ -1018,9 +1018,7 @@ func TestSettingsToggleAutoUpdateOn_NoPendingUpdate_TriggersCheck(t *testing.T) 
 	updater.UpdateDownloaded = false
 	defer func() { updater.UpdateDownloaded = oldVal }()
 
-	oldStageDir := updater.UpdateStageDir
-	updater.UpdateStageDir = t.TempDir() // empty dir means IsUpdatePending() returns false
-	defer func() { updater.UpdateStageDir = oldStageDir }()
+	isolateNoPendingUpdateState(t)
 
 	upd := &updater.Updater{Store: &store.Store{
 		DBPath: filepath.Join(t.TempDir(), "db2.sqlite"),

--- a/app/ui/update_pending_test.go
+++ b/app/ui/update_pending_test.go
@@ -1,0 +1,19 @@
+//go:build windows || darwin
+
+package ui
+
+import (
+	"testing"
+
+	"github.com/ollama/ollama/app/updater"
+)
+
+func isolateNoPendingUpdateState(t *testing.T) {
+	t.Helper()
+
+	oldStageDir := updater.UpdateStageDir
+	updater.UpdateStageDir = t.TempDir()
+	t.Cleanup(func() {
+		updater.UpdateStageDir = oldStageDir
+	})
+}

--- a/app/updater/update_check_url_default.go
+++ b/app/updater/update_check_url_default.go
@@ -1,0 +1,7 @@
+//go:build (windows || darwin) && !updater_localtest
+
+package updater
+
+func updateCheckURLBase() string {
+	return configuredUpdateCheckURLBase()
+}

--- a/app/updater/update_check_url_localtest.go
+++ b/app/updater/update_check_url_localtest.go
@@ -1,0 +1,19 @@
+//go:build (windows || darwin) && updater_localtest
+
+package updater
+
+import (
+	"os"
+	"strings"
+)
+
+func updateCheckURLBase() string {
+	configuredURL := configuredUpdateCheckURLBase()
+	if configuredURL != defaultUpdateCheckURLBase {
+		return configuredURL
+	}
+	if rawURL := strings.TrimSpace(os.Getenv("OLLAMA_TEST_UPDATE_URL")); rawURL != "" {
+		return rawURL
+	}
+	return configuredURL
+}

--- a/app/updater/update_check_url_localtest_test.go
+++ b/app/updater/update_check_url_localtest_test.go
@@ -1,0 +1,33 @@
+//go:build (windows || darwin) && updater_localtest
+
+package updater
+
+import "testing"
+
+func TestUpdateCheckURLBaseUsesLocalTestEnv(t *testing.T) {
+	t.Setenv("OLLAMA_TEST_UPDATE_URL", "http://127.0.0.1:8765/api/update")
+
+	old := UpdateCheckURLBase
+	UpdateCheckURLBase = defaultUpdateCheckURLBase
+	t.Cleanup(func() {
+		UpdateCheckURLBase = old
+	})
+
+	if got := updateCheckURLBase(); got != "http://127.0.0.1:8765/api/update" {
+		t.Fatalf("updateCheckURLBase() = %q", got)
+	}
+}
+
+func TestUpdateCheckURLBaseUsesExplicitTestOverrideBeforeLocalTestEnv(t *testing.T) {
+	t.Setenv("OLLAMA_TEST_UPDATE_URL", "http://127.0.0.1:8765/api/update")
+
+	old := UpdateCheckURLBase
+	UpdateCheckURLBase = "http://127.0.0.1:8765/update.json"
+	t.Cleanup(func() {
+		UpdateCheckURLBase = old
+	})
+
+	if got := updateCheckURLBase(); got != "http://127.0.0.1:8765/update.json" {
+		t.Fatalf("updateCheckURLBase() = %q", got)
+	}
+}

--- a/app/updater/updater.go
+++ b/app/updater/updater.go
@@ -127,15 +127,12 @@ func (u *Updater) checkForUpdate(ctx context.Context) (bool, UpdateResponse) {
 		slog.Warn(fmt.Sprintf("malformed response checking for update: %s", err))
 		return false, updateResp
 	}
-	// Extract the version string from the URL in the github release artifact path
-	updateResp.UpdateVersion = path.Base(path.Dir(updateResp.UpdateURL))
 
 	slog.Info("New update available at " + updateResp.UpdateURL)
 	return true, updateResp
 }
 
 func (u *Updater) DownloadNewRelease(ctx context.Context, updateResp UpdateResponse) error {
-	// Create a cancellable context for this download
 	downloadCtx, cancel := context.WithCancel(ctx)
 	u.cancelDownloadLock.Lock()
 	u.cancelDownload = cancel
@@ -146,15 +143,19 @@ func (u *Updater) DownloadNewRelease(ctx context.Context, updateResp UpdateRespo
 		u.cancelDownloadLock.Unlock()
 		cancel()
 	}()
+	return u.downloadNewRelease(downloadCtx, updateResp)
+}
 
+// downloadSingleFileRelease downloads a single staged update bundle.
+func (u *Updater) downloadSingleFileRelease(ctx context.Context, updateResp UpdateResponse) error {
 	// Do a head first to check etag info
-	req, err := http.NewRequestWithContext(downloadCtx, http.MethodHead, updateResp.UpdateURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, updateResp.UpdateURL, nil)
 	if err != nil {
 		return err
 	}
 
 	// In case of slow downloads, continue the update check in the background
-	bgctx, bgcancel := context.WithCancel(downloadCtx)
+	bgctx, bgcancel := context.WithCancel(ctx)
 	defer bgcancel()
 	go func() {
 		for {

--- a/app/updater/updater.go
+++ b/app/updater/updater.go
@@ -29,8 +29,10 @@ import (
 	"github.com/ollama/ollama/auth"
 )
 
+const defaultUpdateCheckURLBase = "https://ollama.com/api/update"
+
 var (
-	UpdateCheckURLBase      = "https://ollama.com/api/update"
+	UpdateCheckURLBase      = defaultUpdateCheckURLBase
 	UpdateDownloaded        = false
 	UpdateCheckInterval     = 60 * 60 * time.Second
 	UpdateCheckInitialDelay = 3 * time.Second // 30 * time.Second
@@ -53,7 +55,7 @@ type UpdateResponse struct {
 func (u *Updater) checkForUpdate(ctx context.Context) (bool, UpdateResponse) {
 	var updateResp UpdateResponse
 
-	requestURL, err := url.Parse(UpdateCheckURLBase)
+	requestURL, err := url.Parse(updateCheckURLBase())
 	if err != nil {
 		return false, updateResp
 	}
@@ -127,15 +129,19 @@ func (u *Updater) checkForUpdate(ctx context.Context) (bool, UpdateResponse) {
 		slog.Warn(fmt.Sprintf("malformed response checking for update: %s", err))
 		return false, updateResp
 	}
-	// Extract the version string from the URL in the github release artifact path
-	updateResp.UpdateVersion = path.Base(path.Dir(updateResp.UpdateURL))
 
 	slog.Info("New update available at " + updateResp.UpdateURL)
 	return true, updateResp
 }
 
+func configuredUpdateCheckURLBase() string {
+	if UpdateCheckURLBase == "" {
+		return defaultUpdateCheckURLBase
+	}
+	return UpdateCheckURLBase
+}
+
 func (u *Updater) DownloadNewRelease(ctx context.Context, updateResp UpdateResponse) error {
-	// Create a cancellable context for this download
 	downloadCtx, cancel := context.WithCancel(ctx)
 	u.cancelDownloadLock.Lock()
 	u.cancelDownload = cancel
@@ -146,9 +152,13 @@ func (u *Updater) DownloadNewRelease(ctx context.Context, updateResp UpdateRespo
 		u.cancelDownloadLock.Unlock()
 		cancel()
 	}()
+	return u.downloadNewRelease(downloadCtx, updateResp)
+}
 
+// downloadSingleFileRelease downloads a single staged update bundle.
+func (u *Updater) downloadSingleFileRelease(ctx context.Context, updateResp UpdateResponse) error {
 	// Do a head first to check etag info
-	req, err := http.NewRequestWithContext(downloadCtx, http.MethodHead, updateResp.UpdateURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, updateResp.UpdateURL, nil)
 	if err != nil {
 		return err
 	}
@@ -156,7 +166,7 @@ func (u *Updater) DownloadNewRelease(ctx context.Context, updateResp UpdateRespo
 	// In case of slow downloads, continue the update check in the background.
 	// Drain the goroutine before returning: it reads package-level knobs
 	// (e.g. UpdateCheckInterval), which callers may mutate once we return.
-	bgctx, bgcancel := context.WithCancel(downloadCtx)
+	bgctx, bgcancel := context.WithCancel(ctx)
 	var bgwg sync.WaitGroup
 	bgwg.Go(func() {
 		for {

--- a/app/updater/updater_darwin.go
+++ b/app/updater/updater_darwin.go
@@ -8,6 +8,7 @@ import "C"
 
 import (
 	"archive/zip"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -94,6 +95,10 @@ func init() {
 	UpgradeMarkerFile = filepath.Join(appDataDir, "upgraded")
 	appBackupDir = filepath.Join(appDataDir, "backup")
 	UpdateStageDir = filepath.Join(appDataDir, "updates")
+}
+
+func (u *Updater) downloadNewRelease(ctx context.Context, updateResp UpdateResponse) error {
+	return u.downloadSingleFileRelease(ctx, updateResp)
 }
 
 func DoUpgrade(interactive bool) error {

--- a/app/updater/updater_live_darwin_test.go
+++ b/app/updater/updater_live_darwin_test.go
@@ -1,0 +1,22 @@
+//go:build darwin && updater_live
+
+package updater
+
+func liveExpectedFilename() string {
+	return "Ollama-darwin.zip"
+}
+
+func liveStagedUpdate() string {
+	return getStagedUpdate()
+}
+
+func wrapLiveUpdateVerification(called *bool) func() {
+	oldVerifyDownload := VerifyDownload
+	VerifyDownload = func() error {
+		*called = true
+		return verifyDownload()
+	}
+	return func() {
+		VerifyDownload = oldVerifyDownload
+	}
+}

--- a/app/updater/updater_live_test.go
+++ b/app/updater/updater_live_test.go
@@ -30,35 +30,29 @@ func TestLiveAppUpdate(t *testing.T) {
 
 	oldUpdateStageDir := UpdateStageDir
 	oldUpdateDownloaded := UpdateDownloaded
-	oldVerifyDownload := VerifyDownload
 	oldVersion := version.Version
 	defer func() {
 		UpdateStageDir = oldUpdateStageDir
 		UpdateDownloaded = oldUpdateDownloaded
-		VerifyDownload = oldVerifyDownload
 		version.Version = oldVersion
 	}()
 
 	version.Version = spoofedVersion
 
-	expectedFilename := ""
 	switch runtime.GOOS {
 	case "windows":
 		t.Setenv("LOCALAPPDATA", t.TempDir())
-		expectedFilename = "OllamaSetup.exe"
 	case "darwin":
-		expectedFilename = "Ollama-darwin.zip"
 	default:
 		t.Fatalf("unsupported updater live test OS %q", runtime.GOOS)
 	}
+	expectedFilename := liveExpectedFilename()
 
 	UpdateStageDir = filepath.Join(t.TempDir(), "updates")
 	UpdateDownloaded = false
 	verifyCalled := false
-	VerifyDownload = func() error {
-		verifyCalled = true
-		return verifyDownload()
-	}
+	restoreVerification := wrapLiveUpdateVerification(&verifyCalled)
+	defer restoreVerification()
 
 	updater := &Updater{Store: &store.Store{DBPath: filepath.Join(t.TempDir(), "db.sqlite")}}
 	defer updater.Store.Close()
@@ -73,10 +67,16 @@ func TestLiveAppUpdate(t *testing.T) {
 	t.Logf("production update version=%q url=%q", updateResp.UpdateVersion, updateResp.UpdateURL)
 
 	if err := updater.DownloadNewRelease(ctx, updateResp); err != nil {
+		if runtime.GOOS == "windows" && strings.Contains(err.Error(), "install.ps1 does not support cache-only mode") {
+			if !verifyCalled {
+				t.Fatal("production install.ps1 lacked cache-only support before signature verification ran")
+			}
+			t.Skipf("production install.ps1 has not shipped app cache-only support yet: %v", err)
+		}
 		t.Fatalf("download production update: %v", err)
 	}
 
-	staged := getStagedUpdate()
+	staged := liveStagedUpdate()
 	if staged == "" {
 		t.Fatal("production update was not staged")
 	}
@@ -100,7 +100,7 @@ func TestLiveAppUpdate(t *testing.T) {
 	}
 
 	if !verifyCalled {
-		t.Fatal("DownloadNewRelease did not call VerifyDownload")
+		t.Fatal("DownloadNewRelease did not verify the staged update")
 	}
 	t.Logf("production updater download path verified staged %s update", runtime.GOOS)
 }

--- a/app/updater/updater_live_windows_test.go
+++ b/app/updater/updater_live_windows_test.go
@@ -1,0 +1,22 @@
+//go:build windows && updater_live
+
+package updater
+
+func liveExpectedFilename() string {
+	return installScriptName
+}
+
+func liveStagedUpdate() string {
+	return getStagedInstallScript()
+}
+
+func wrapLiveUpdateVerification(called *bool) func() {
+	oldVerifyInstallScriptSignature := verifyInstallScriptSignature
+	verifyInstallScriptSignature = func(filename string) error {
+		*called = true
+		return oldVerifyInstallScriptSignature(filename)
+	}
+	return func() {
+		verifyInstallScriptSignature = oldVerifyInstallScriptSignature
+	}
+}

--- a/app/updater/updater_test.go
+++ b/app/updater/updater_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -95,7 +96,59 @@ func TestIsNewReleaseAvailable(t *testing.T) {
 	}
 }
 
-func TestDownloadNewReleaseRejectsUnsafeHeaderFilename(t *testing.T) {
+func TestCheckForUpdatePreservesResponseVersion(t *testing.T) {
+	slog.SetLogLoggerLevel(slog.LevelDebug)
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/update.json" {
+			w.Write([]byte(
+				fmt.Sprintf(`{"version": "0.21.0", "url": "%s"}`,
+					server.URL+"/download/install.ps1")))
+			return
+		}
+		t.Errorf("unexpected request path %s", r.URL.Path)
+	}))
+	defer server.Close()
+
+	updater := &Updater{Store: &store.Store{DBPath: filepath.Join(t.TempDir(), "test.db")}}
+	defer updater.Store.Close()
+	UpdateCheckURLBase = server.URL + "/update.json"
+	updatePresent, resp := updater.checkForUpdate(t.Context())
+	if !updatePresent {
+		t.Fatal("expected update to be available")
+	}
+	if resp.UpdateVersion != "0.21.0" {
+		t.Fatalf("version = %q, want response version 0.21.0", resp.UpdateVersion)
+	}
+}
+
+func TestCheckForUpdateDoesNotInferVersionFromURL(t *testing.T) {
+	slog.SetLogLoggerLevel(slog.LevelDebug)
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/update.json" {
+			w.Write([]byte(
+				fmt.Sprintf(`{"url": "%s"}`,
+					server.URL+"/v0.24.0/OllamaSetup.exe")))
+			return
+		}
+		t.Errorf("unexpected request path %s", r.URL.Path)
+	}))
+	defer server.Close()
+
+	updater := &Updater{Store: &store.Store{DBPath: filepath.Join(t.TempDir(), "test.db")}}
+	defer updater.Store.Close()
+	UpdateCheckURLBase = server.URL + "/update.json"
+	updatePresent, resp := updater.checkForUpdate(t.Context())
+	if !updatePresent {
+		t.Fatal("expected update to be available")
+	}
+	if resp.UpdateVersion != "" {
+		t.Fatalf("version = %q, want empty when response omits version", resp.UpdateVersion)
+	}
+}
+
+func TestDownloadSingleFileReleaseRejectsUnsafeHeaderFilename(t *testing.T) {
 	UpdateStageDir = t.TempDir()
 	oldInstaller := Installer
 	oldVerifyDownload := VerifyDownload
@@ -126,7 +179,7 @@ func TestDownloadNewReleaseRejectsUnsafeHeaderFilename(t *testing.T) {
 	defer server.Close()
 
 	updater := &Updater{}
-	err := updater.DownloadNewRelease(t.Context(), UpdateResponse{UpdateURL: server.URL + "/download"})
+	err := updater.downloadSingleFileRelease(t.Context(), UpdateResponse{UpdateURL: server.URL + "/download"})
 	if err == nil || !strings.Contains(err.Error(), "unsafe update filename") {
 		t.Fatalf("expected unsafe filename error, got %v", err)
 	}
@@ -138,7 +191,7 @@ func TestDownloadNewReleaseRejectsUnsafeHeaderFilename(t *testing.T) {
 	}
 }
 
-func TestDownloadNewReleaseDoesNotUseRawETagAsPathComponent(t *testing.T) {
+func TestDownloadSingleFileReleaseDoesNotUseRawETagAsPathComponent(t *testing.T) {
 	UpdateStageDir = t.TempDir()
 	oldInstaller := Installer
 	oldVerifyDownload := VerifyDownload
@@ -165,7 +218,7 @@ func TestDownloadNewReleaseDoesNotUseRawETagAsPathComponent(t *testing.T) {
 	defer server.Close()
 
 	updater := &Updater{}
-	if err := updater.DownloadNewRelease(t.Context(), UpdateResponse{UpdateURL: server.URL + "/download"}); err != nil {
+	if err := updater.downloadSingleFileRelease(t.Context(), UpdateResponse{UpdateURL: server.URL + "/download"}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -191,6 +244,10 @@ func TestDownloadNewReleaseDoesNotUseRawETagAsPathComponent(t *testing.T) {
 }
 
 func TestBackgroundCheckerSkipsAlreadyStagedETagDownload(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows update downloads are staged through install.ps1")
+	}
+
 	UpdateStageDir = t.TempDir()
 	oldInstaller := Installer
 	oldVerifyDownload := VerifyDownload
@@ -313,6 +370,10 @@ func TestBackgroundCheckerSkipsAlreadyStagedETagDownload(t *testing.T) {
 }
 
 func TestBackgoundChecker(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows update downloads are staged through install.ps1")
+	}
+
 	UpdateStageDir = t.TempDir()
 	haveUpdate := false
 	verified := false
@@ -437,6 +498,10 @@ func TestAutoUpdateDisabledSkipsDownload(t *testing.T) {
 }
 
 func TestAutoUpdateReenabledDownloadsUpdate(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows update downloads are staged through install.ps1")
+	}
+
 	UpdateStageDir = t.TempDir()
 	var downloadAttempted atomic.Bool
 	callbackCalled := make(chan struct{}, 1)
@@ -513,7 +578,27 @@ func TestAutoUpdateReenabledDownloadsUpdate(t *testing.T) {
 	}
 }
 
+func TestCancelOngoingDownloadClearsRegisteredCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	updater := &Updater{cancelDownload: cancel}
+
+	updater.CancelOngoingDownload()
+
+	if updater.cancelDownload != nil {
+		t.Fatal("cancelDownload should be cleared after cancellation")
+	}
+	select {
+	case <-ctx.Done():
+	default:
+		t.Fatal("registered download context was not cancelled")
+	}
+}
+
 func TestCancelOngoingDownload(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows update downloads are staged through install.ps1")
+	}
+
 	UpdateStageDir = t.TempDir()
 	downloadStarted := make(chan struct{})
 	downloadCancelled := make(chan struct{})

--- a/app/updater/updater_test.go
+++ b/app/updater/updater_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -95,7 +96,59 @@ func TestIsNewReleaseAvailable(t *testing.T) {
 	}
 }
 
-func TestDownloadNewReleaseRejectsUnsafeHeaderFilename(t *testing.T) {
+func TestCheckForUpdatePreservesResponseVersion(t *testing.T) {
+	slog.SetLogLoggerLevel(slog.LevelDebug)
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/update.json" {
+			w.Write([]byte(
+				fmt.Sprintf(`{"version": "0.21.0", "url": "%s"}`,
+					server.URL+"/download/install.ps1")))
+			return
+		}
+		t.Errorf("unexpected request path %s", r.URL.Path)
+	}))
+	defer server.Close()
+
+	updater := &Updater{Store: &store.Store{DBPath: filepath.Join(t.TempDir(), "test.db")}}
+	defer updater.Store.Close()
+	UpdateCheckURLBase = server.URL + "/update.json"
+	updatePresent, resp := updater.checkForUpdate(t.Context())
+	if !updatePresent {
+		t.Fatal("expected update to be available")
+	}
+	if resp.UpdateVersion != "0.21.0" {
+		t.Fatalf("version = %q, want response version 0.21.0", resp.UpdateVersion)
+	}
+}
+
+func TestCheckForUpdateDoesNotInferVersionFromURL(t *testing.T) {
+	slog.SetLogLoggerLevel(slog.LevelDebug)
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/update.json" {
+			w.Write([]byte(
+				fmt.Sprintf(`{"url": "%s"}`,
+					server.URL+"/v0.24.0/OllamaSetup.exe")))
+			return
+		}
+		t.Errorf("unexpected request path %s", r.URL.Path)
+	}))
+	defer server.Close()
+
+	updater := &Updater{Store: &store.Store{DBPath: filepath.Join(t.TempDir(), "test.db")}}
+	defer updater.Store.Close()
+	UpdateCheckURLBase = server.URL + "/update.json"
+	updatePresent, resp := updater.checkForUpdate(t.Context())
+	if !updatePresent {
+		t.Fatal("expected update to be available")
+	}
+	if resp.UpdateVersion != "" {
+		t.Fatalf("version = %q, want empty when response omits version", resp.UpdateVersion)
+	}
+}
+
+func TestDownloadSingleFileReleaseRejectsUnsafeHeaderFilename(t *testing.T) {
 	UpdateStageDir = t.TempDir()
 	oldInstaller := Installer
 	oldVerifyDownload := VerifyDownload
@@ -126,7 +179,7 @@ func TestDownloadNewReleaseRejectsUnsafeHeaderFilename(t *testing.T) {
 	defer server.Close()
 
 	updater := &Updater{}
-	err := updater.DownloadNewRelease(t.Context(), UpdateResponse{UpdateURL: server.URL + "/download"})
+	err := updater.downloadSingleFileRelease(t.Context(), UpdateResponse{UpdateURL: server.URL + "/download"})
 	if err == nil || !strings.Contains(err.Error(), "unsafe update filename") {
 		t.Fatalf("expected unsafe filename error, got %v", err)
 	}
@@ -138,7 +191,7 @@ func TestDownloadNewReleaseRejectsUnsafeHeaderFilename(t *testing.T) {
 	}
 }
 
-func TestDownloadNewReleaseDoesNotUseRawETagAsPathComponent(t *testing.T) {
+func TestDownloadSingleFileReleaseDoesNotUseRawETagAsPathComponent(t *testing.T) {
 	UpdateStageDir = t.TempDir()
 	oldInstaller := Installer
 	oldVerifyDownload := VerifyDownload
@@ -165,7 +218,7 @@ func TestDownloadNewReleaseDoesNotUseRawETagAsPathComponent(t *testing.T) {
 	defer server.Close()
 
 	updater := &Updater{}
-	if err := updater.DownloadNewRelease(t.Context(), UpdateResponse{UpdateURL: server.URL + "/download"}); err != nil {
+	if err := updater.downloadSingleFileRelease(t.Context(), UpdateResponse{UpdateURL: server.URL + "/download"}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -208,6 +261,10 @@ func (u *Updater) waitDownloadIdle() {
 }
 
 func TestBackgroundCheckerSkipsAlreadyStagedETagDownload(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows update downloads are staged through install.ps1")
+	}
+
 	UpdateStageDir = t.TempDir()
 	oldInstaller := Installer
 	oldVerifyDownload := VerifyDownload
@@ -331,6 +388,10 @@ func TestBackgroundCheckerSkipsAlreadyStagedETagDownload(t *testing.T) {
 }
 
 func TestBackgoundChecker(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows update downloads are staged through install.ps1")
+	}
+
 	UpdateStageDir = t.TempDir()
 	haveUpdate := false
 	verified := false
@@ -457,6 +518,10 @@ func TestAutoUpdateDisabledSkipsDownload(t *testing.T) {
 }
 
 func TestAutoUpdateReenabledDownloadsUpdate(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows update downloads are staged through install.ps1")
+	}
+
 	UpdateStageDir = t.TempDir()
 	var downloadAttempted atomic.Bool
 	callbackCalled := make(chan struct{}, 1)
@@ -534,7 +599,27 @@ func TestAutoUpdateReenabledDownloadsUpdate(t *testing.T) {
 	}
 }
 
+func TestCancelOngoingDownloadClearsRegisteredCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	updater := &Updater{cancelDownload: cancel}
+
+	updater.CancelOngoingDownload()
+
+	if updater.cancelDownload != nil {
+		t.Fatal("cancelDownload should be cleared after cancellation")
+	}
+	select {
+	case <-ctx.Done():
+	default:
+		t.Fatal("registered download context was not cancelled")
+	}
+}
+
 func TestCancelOngoingDownload(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows update downloads are staged through install.ps1")
+	}
+
 	UpdateStageDir = t.TempDir()
 	downloadStarted := make(chan struct{})
 	downloadCancelled := make(chan struct{})

--- a/app/updater/updater_windows.go
+++ b/app/updater/updater_windows.go
@@ -1,10 +1,14 @@
 package updater
 
 import (
-	"crypto/x509"
+	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
+	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path"
@@ -17,30 +21,39 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-var runningInstaller string
-
-var (
-	crypt32              = windows.NewLazySystemDLL("crypt32.dll")
-	procCryptMsgGetParam = crypt32.NewProc("CryptMsgGetParam")
-	procCryptMsgClose    = crypt32.NewProc("CryptMsgClose")
+const (
+	installScriptName              = "install.ps1"
+	stagedCacheReadyFile           = "cache-ready"
+	windowsCreateNoWindow          = 0x08000000
+	installScriptModeCacheOnly     = "cache-only"
+	installScriptModeInstallCached = "install-cached"
 )
 
-const cmsgSignerInfoParam = 6
+var (
+	runningInstaller              string
+	installScriptInstallerLogFile string
+)
 
-type cmsgSignerInfo struct {
-	Version                 uint32
-	Issuer                  windows.CertNameBlob
-	SerialNumber            windows.CryptIntegerBlob
-	HashAlgorithm           windows.CryptAlgorithmIdentifier
-	HashEncryptionAlgorithm windows.CryptAlgorithmIdentifier
-	EncryptedHash           windows.CryptDataBlob
-	AuthAttrs               cryptAttributes
-	UnauthAttrs             cryptAttributes
+var (
+	verifyInstallScriptSignature = verifyPowerShellScriptSignature
+	runInstallScriptCacheOnly    = runInstallScriptCacheOnlyCommand
+	startInstallScriptInstall    = startInstallScriptInstallCommand
+	exitAfterStartingUpgrade     = os.Exit
+)
+
+type installScriptProcess interface {
+	// Release lets the app detach from the launched install.ps1 process before
+	// exiting; the interface keeps DoUpgradeAtStartup testable without starting
+	// a real installer.
+	Release() error
 }
 
-type cryptAttributes struct {
-	Count      uint32
-	Attributes unsafe.Pointer
+type installScriptCommand struct {
+	Program       string
+	Args          []string
+	Env           []string
+	Dir           string
+	CreationFlags uint32
 }
 
 type OSVERSIONINFOEXW struct {
@@ -68,11 +81,223 @@ func init() {
 	UpdateStageDir = filepath.Join(appDataDir, "updates_v2")
 
 	UpgradeLogFile = filepath.Join(appDataDir, "upgrade.log")
+	installScriptInstallerLogFile = filepath.Join(appDataDir, "OllamaSetup.log")
 	Installer = "OllamaSetup.exe"
 	runningInstaller = filepath.Join(appDataDir, Installer)
 	UpgradeMarkerFile = filepath.Join(appDataDir, "upgraded")
 
 	loadOSVersion()
+}
+
+func (u *Updater) downloadNewRelease(ctx context.Context, updateResp UpdateResponse) error {
+	return u.downloadInstallScriptRelease(ctx, updateResp)
+}
+
+func (u *Updater) downloadInstallScriptRelease(ctx context.Context, updateResp UpdateResponse) error {
+	scriptURL, err := installScriptURL(updateResp)
+	if err != nil {
+		return err
+	}
+
+	scriptPath, downloadedScript, err := downloadInstallScript(ctx, scriptURL, updateResp)
+	if err != nil {
+		return err
+	}
+	scriptStageDir := filepath.Dir(scriptPath)
+	version := normalizedUpdateVersion(updateResp)
+
+	if err := verifyInstallScriptSignature(scriptPath); err != nil {
+		_ = os.RemoveAll(scriptStageDir)
+		return fmt.Errorf("install.ps1 signature verification failed: %w", err)
+	}
+	if !installScriptSupportsCacheOnly(scriptPath) {
+		_ = os.RemoveAll(scriptStageDir)
+		return fmt.Errorf("install.ps1 does not support cache-only mode")
+	}
+	if !downloadedScript && isInstallScriptStageReady(scriptStageDir) {
+		slog.Info("update already downloaded", "script", scriptPath)
+		UpdateDownloaded = true
+		return nil
+	}
+
+	// Clear readiness before refreshing the cache so a failed cache-only run
+	// cannot leave startup upgrade stuck retrying stale or partial payloads.
+	_ = removeInstallScriptStageReady(scriptStageDir)
+	if err := runInstallScriptCacheOnly(ctx, scriptPath, scriptStageDir, version); err != nil {
+		_ = os.RemoveAll(scriptStageDir)
+		return err
+	}
+
+	if err := writeInstallScriptStageReady(scriptStageDir); err != nil {
+		_ = os.RemoveAll(scriptStageDir)
+		return err
+	}
+	UpdateDownloaded = true
+	return nil
+}
+
+func downloadInstallScript(ctx context.Context, scriptURL string, updateResp UpdateResponse) (string, bool, error) {
+	slog.Debug("checking install.ps1", "url", scriptURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, scriptURL, nil)
+	if err != nil {
+		return "", false, err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", false, fmt.Errorf("error checking install.ps1: %w", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", false, fmt.Errorf("unexpected status attempting to download install.ps1 %d", resp.StatusCode)
+	}
+
+	stageKey := strings.Join([]string{
+		resp.Header.Get("etag"),
+		normalizedUpdateVersion(updateResp),
+		updateResp.UpdateURL,
+	}, "\n")
+	stageFilename, err := updateStagePath(UpdateStageDir, stageKey, installScriptName)
+	if err != nil {
+		return "", false, err
+	}
+
+	if _, err := os.Stat(stageFilename); err == nil {
+		slog.Info("install.ps1 already downloaded", "script", stageFilename)
+		return stageFilename, false, nil
+	}
+
+	cleanupOldDownloads(UpdateStageDir)
+
+	slog.Debug("downloading install.ps1", "url", scriptURL, "script", stageFilename)
+	req, err = http.NewRequestWithContext(ctx, http.MethodGet, scriptURL, nil)
+	if err != nil {
+		return "", false, err
+	}
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		return "", false, fmt.Errorf("error downloading install.ps1: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", false, fmt.Errorf("unexpected status attempting to download install.ps1 %d", resp.StatusCode)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(stageFilename), 0o755); err != nil {
+		return "", false, fmt.Errorf("create update staging dir %s: %w", filepath.Dir(stageFilename), err)
+	}
+
+	tmpFilename := stageFilename + ".tmp"
+	fp, err := os.OpenFile(tmpFilename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return "", false, fmt.Errorf("write install.ps1 %s: %w", tmpFilename, err)
+	}
+	if _, err := io.Copy(fp, resp.Body); err != nil {
+		_ = fp.Close()
+		_ = os.Remove(tmpFilename)
+		return "", false, fmt.Errorf("write install.ps1 %s: %w", tmpFilename, err)
+	}
+	if err := fp.Close(); err != nil {
+		_ = os.Remove(tmpFilename)
+		return "", false, fmt.Errorf("close install.ps1 %s: %w", tmpFilename, err)
+	}
+	if err := os.Rename(tmpFilename, stageFilename); err != nil {
+		_ = os.Remove(tmpFilename)
+		return "", false, fmt.Errorf("stage install.ps1 %s: %w", stageFilename, err)
+	}
+
+	slog.Info("install.ps1 downloaded", "script", stageFilename)
+	return stageFilename, true, nil
+}
+
+func installScriptURL(updateResp UpdateResponse) (string, error) {
+	parsed, err := url.Parse(updateResp.UpdateURL)
+	if err != nil {
+		return "", fmt.Errorf("parse update URL: %w", err)
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return "", fmt.Errorf("invalid update URL: %s", updateResp.UpdateURL)
+	}
+	parsed.Path = path.Join(path.Dir(parsed.Path), installScriptName)
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed.String(), nil
+}
+
+func normalizedUpdateVersion(updateResp UpdateResponse) string {
+	return strings.TrimPrefix(strings.TrimSpace(updateResp.UpdateVersion), "v")
+}
+
+func windowsPowerShellPath() string {
+	systemDir, err := windows.GetSystemDirectory()
+	if err == nil && systemDir != "" {
+		return filepath.Join(systemDir, "WindowsPowerShell", "v1.0", "powershell.exe")
+	}
+	slog.Warn("unable to resolve Windows system directory for powershell.exe", "error", err)
+
+	systemRoot := os.Getenv("SystemRoot")
+	if systemRoot == "" {
+		systemRoot = os.Getenv("WINDIR")
+	}
+	if systemRoot == "" {
+		systemRoot = `C:\Windows`
+	}
+	return filepath.Join(systemRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe")
+}
+
+func validateWindowsPowerShellPath(powerShellPath string) error {
+	info, err := os.Stat(powerShellPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("Windows PowerShell not found at %s; app upgrades require the system Windows PowerShell component", powerShellPath)
+		}
+		return fmt.Errorf("unable to access Windows PowerShell at %s: %w", powerShellPath, err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("Windows PowerShell path is a directory: %s", powerShellPath)
+	}
+	return nil
+}
+
+func windowsPowerShellModulePath() string {
+	systemDir, err := windows.GetSystemDirectory()
+	if err == nil && systemDir != "" {
+		return filepath.Join(systemDir, "WindowsPowerShell", "v1.0", "Modules")
+	}
+	slog.Warn("unable to resolve Windows system directory for PowerShell module path", "error", err)
+
+	systemRoot := os.Getenv("SystemRoot")
+	if systemRoot == "" {
+		systemRoot = os.Getenv("WINDIR")
+	}
+	if systemRoot == "" {
+		systemRoot = `C:\Windows`
+	}
+	return filepath.Join(systemRoot, "System32", "WindowsPowerShell", "v1.0", "Modules")
+}
+
+func withWindowsPowerShellModulePath(base []string) []string {
+	env := make([]string, 0, len(base)+1)
+	for _, entry := range base {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok && strings.EqualFold(key, "PSModulePath") {
+			continue
+		}
+		env = append(env, entry)
+	}
+	// Force Windows PowerShell to its built-in module path. CI can inherit a
+	// PowerShell 7 PSModulePath that cannot load Windows PowerShell modules, and
+	// user-writable module paths should not participate in signature checks.
+	return append(env, "PSModulePath="+windowsPowerShellModulePath())
+}
+
+func installScriptSupportsCacheOnly(scriptPath string) bool {
+	data, err := os.ReadFile(scriptPath)
+	if err != nil {
+		slog.Warn("unable to read install.ps1 for capability check", "script", scriptPath, "error", err)
+		return false
+	}
+	return strings.Contains(string(data), "OLLAMA_CACHE_ONLY")
 }
 
 func loadOSVersion() {
@@ -99,99 +324,80 @@ func loadOSVersion() {
 	}
 }
 
-func getStagedUpdate() string {
+func getStagedInstallScript() string {
 	// When transitioning from old to new app, cleanup the update from the old staging dir
 	// This can eventually be removed once enough time has passed since the transition
 	cleanupOldDownloads(filepath.Join(os.Getenv("LOCALAPPDATA"), "Ollama", "updates"))
 
-	files, err := filepath.Glob(filepath.Join(UpdateStageDir, "*", "*.exe"))
+	files, err := filepath.Glob(filepath.Join(UpdateStageDir, "*", installScriptName))
 	if err != nil {
 		slog.Debug("failed to lookup downloads", "error", err)
 		return ""
 	}
-	if len(files) == 0 {
-		return ""
-	} else if len(files) > 1 {
-		// Shouldn't happen
-		slog.Warn("multiple update downloads found, using first one", "bundles", files)
+	readyFiles := files[:0]
+	for _, file := range files {
+		if isInstallScriptStageReady(filepath.Dir(file)) {
+			readyFiles = append(readyFiles, file)
+		}
 	}
-	return files[0]
+	if len(readyFiles) == 0 {
+		return ""
+	} else if len(readyFiles) > 1 {
+		// Shouldn't happen
+		slog.Warn("multiple update downloads found, using first one", "bundles", readyFiles)
+	}
+	return readyFiles[0]
 }
 
 func DoUpgrade(interactive bool) error {
-	bundle := getStagedUpdate()
-	if bundle == "" {
+	if script := getStagedInstallScript(); script != "" {
+		return doInstallScriptUpgrade(script, exitAfterStartingUpgrade)
+	}
+	return fmt.Errorf("failed to lookup downloads")
+}
+
+func doInstallScriptUpgrade(script string, exit func(int)) error {
+	if script == "" {
 		return fmt.Errorf("failed to lookup downloads")
 	}
 
 	if err := VerifyDownload(); err != nil {
-		_ = os.Remove(bundle)
-		slog.Warn("verification failure", "bundle", bundle, "error", err)
+		_ = os.RemoveAll(filepath.Dir(script))
+		slog.Warn("verification failure", "script", script, "error", err)
 		return fmt.Errorf("staged update verification failed: %w", err)
 	}
 
-	// We move the installer to ensure we don't race with multiple apps starting in quick succession
-	if err := os.Rename(bundle, runningInstaller); err != nil {
-		return fmt.Errorf("unable to rename %s -> %s : %w", bundle, runningInstaller, err)
-	}
-
-	slog.Info("upgrade log file " + UpgradeLogFile)
-
-	// make the upgrade show progress, but non interactive
-	installArgs := []string{
-		"/CLOSEAPPLICATIONS",                    // Quit the tray app if it's still running
-		"/LOG=" + filepath.Base(UpgradeLogFile), // Only relative seems reliable, so set pwd
-		"/FORCECLOSEAPPLICATIONS",               // Force close the tray app - might be needed
-		"/SP",                                   // Skip the "This will install... Do you wish to continue" prompt
-		"/NOCANCEL",                             // Disable the ability to cancel upgrade mid-flight to avoid partially installed upgrades
-		"/SILENT",
-	}
-
-	if !interactive {
-		// Add flags to make it totally silent without GUI
-		installArgs = append(installArgs, "/VERYSILENT", "/SUPPRESSMSGBOXES")
-	}
-
-	slog.Info("starting upgrade", "installer", runningInstaller, "args", installArgs)
-	os.Chdir(filepath.Dir(UpgradeLogFile)) //nolint:errcheck
-	cmd := exec.Command(runningInstaller, installArgs...)
-
-	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("unable to start ollama app %w", err)
-	}
-
-	if cmd.Process != nil {
-		err := cmd.Process.Release()
-		if err != nil {
-			slog.Error(fmt.Sprintf("failed to release server process: %s", err))
-		}
-	} else {
-		// TODO - some details about why it didn't start, or is this a pedantic error case?
-		return errors.New("installer process did not start")
-	}
-
-	// If the install fails to upgrade the system, and leaves a functional
-	// app, this marker file will cause us to remove the staged upgrade
-	// bundle, which will prevent trying again until we download again.
-	// If this becomes looping a problem, we may need to look for failures
-	// in the upgrade log in DoPostUpgradeCleanup and then not download
-	// the same version again.
-	f, err := os.OpenFile(UpgradeMarkerFile, os.O_RDONLY|os.O_CREATE, 0o666)
-	if err != nil {
+	scriptStageDir := filepath.Dir(script)
+	slog.Info("starting upgrade", "script", script, "stage", scriptStageDir)
+	if err := createUpgradeMarker(); err != nil {
 		slog.Warn("unable to create marker file", "file", UpgradeMarkerFile, "error", err)
 	}
-	f.Close()
 
-	// TODO should we linger for a moment and check to make sure it's actually running by checking the pid?
+	if err := removeInstallScriptStageReady(scriptStageDir); err != nil {
+		_ = os.Remove(UpgradeMarkerFile)
+		return fmt.Errorf("unable to clear staged update readiness: %w", err)
+	}
 
-	slog.Info("Installer started in background, exiting")
+	command := newInstallScriptCommand(script, scriptStageDir, "", installScriptModeInstallCached)
+	process, err := startInstallScriptInstall(command)
+	if err != nil {
+		_ = os.Remove(UpgradeMarkerFile)
+		return fmt.Errorf("unable to start install.ps1 upgrade: %w", err)
+	}
+	if err := process.Release(); err != nil {
+		slog.Error(fmt.Sprintf("failed to release installer process: %s", err))
+	}
 
-	os.Exit(0)
-	// Not reached
+	slog.Info("install.ps1 upgrade started in background, exiting")
+	exit(0)
 	return nil
 }
 
 func DoPostUpgradeCleanup() error {
+	if markerInfo, err := os.Stat(UpgradeMarkerFile); err == nil {
+		logInstallerFailuresSince(markerInfo.ModTime())
+	}
+
 	cleanupOldDownloads(UpdateStageDir)
 	err := os.Remove(UpgradeMarkerFile)
 	if err != nil {
@@ -199,6 +405,9 @@ func DoPostUpgradeCleanup() error {
 	}
 	err = os.Remove(runningInstaller)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
 		slog.Debug("failed to remove running installer on first attempt, backgrounding...", "installer", runningInstaller, "error", err)
 		go func() {
 			for range 10 {
@@ -214,156 +423,237 @@ func DoPostUpgradeCleanup() error {
 	return nil
 }
 
+func logInstallerFailuresSince(start time.Time) {
+	for _, logFile := range []string{installScriptInstallerLogFile} {
+		if logFile == "" {
+			continue
+		}
+		failed, err := windowsInstallerLogIndicatesFailure(logFile, start)
+		if err != nil {
+			slog.Debug("unable to inspect installer log", "log", logFile, "error", err)
+			continue
+		}
+		if failed {
+			slog.Warn("Windows installer reported upgrade failure", "log", logFile)
+		}
+	}
+}
+
+func windowsInstallerLogIndicatesFailure(logFile string, since time.Time) (bool, error) {
+	info, err := os.Stat(logFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	if info.ModTime().Before(since) {
+		return false, nil
+	}
+
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		return false, err
+	}
+	logText := strings.ToLower(string(data))
+	for _, marker := range []string{
+		"installation process failed.",
+		"installation process was aborted.",
+		"user canceled the installation.",
+	} {
+		if strings.Contains(logText, marker) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func verifyDownload() error {
-	bundle := getStagedUpdate()
-	if bundle == "" {
+	script := getStagedInstallScript()
+	if script == "" {
 		return fmt.Errorf("failed to lookup downloads")
 	}
-	slog.Debug("verifying update", "bundle", bundle)
+	slog.Debug("verifying update", "script", script)
 
-	if err := verifyWindowsInstallerSignature(bundle); err != nil {
+	if err := verifyInstallScriptSignature(script); err != nil {
 		return fmt.Errorf("signature verification failed: %w", err)
 	}
+	if !installScriptSupportsCacheOnly(script) {
+		return fmt.Errorf("install.ps1 does not support cache-only mode")
+	}
 	return nil
 }
 
-func verifyWindowsInstallerSignature(filename string) error {
-	filename16, err := windows.UTF16PtrFromString(filename)
+func verifyPowerShellScriptSignature(filename string) error {
+	verificationScript := powerShellSignatureVerificationScript(filename)
+	powerShellPath := windowsPowerShellPath()
+	if err := validateWindowsPowerShellPath(powerShellPath); err != nil {
+		return err
+	}
+	cmd := exec.Command(
+		powerShellPath,
+		"-NoProfile",
+		"-NonInteractive",
+		"-Command",
+		verificationScript,
+	)
+	cmd.Env = withWindowsPowerShellModulePath(os.Environ())
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: windowsCreateNoWindow}
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("Windows PowerShell signature verification failed using %s: %w: %s", powerShellPath, err, strings.TrimSpace(string(output)))
+	}
+	slog.Info("verified install.ps1 signature", "subject", strings.TrimSpace(string(output)))
+	return nil
+}
+
+func powerShellSignatureVerificationScript(filename string) string {
+	encodedFilename := base64.StdEncoding.EncodeToString([]byte(filename))
+	return fmt.Sprintf(`
+$ErrorActionPreference = 'Stop'
+$target = [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('%s'))
+$sig = Get-AuthenticodeSignature -LiteralPath $target
+if ($sig.Status -ne 'Valid') {
+    throw "signature status: $($sig.Status)"
+}
+$subject = $sig.SignerCertificate.Subject
+if ($subject -notmatch '(^|, )O=Ollama Inc\.(,|$)') {
+    throw "unexpected signer: $subject"
+}
+Write-Output $subject
+`, encodedFilename)
+}
+
+func runInstallScriptCacheOnlyCommand(ctx context.Context, scriptPath, scriptStageDir, version string) error {
+	command := newInstallScriptCommand(scriptPath, scriptStageDir, version, installScriptModeCacheOnly)
+	if err := validateWindowsPowerShellPath(command.Program); err != nil {
+		return fmt.Errorf("install.ps1 cache phase failed: %w", err)
+	}
+	cmd := exec.CommandContext(ctx, command.Program, command.Args...)
+	cmd.Env = command.Env
+	cmd.Dir = command.Dir
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: command.CreationFlags}
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("install.ps1 cache phase failed using Windows PowerShell %s: %w: %s", command.Program, err, strings.TrimSpace(string(output)))
+	}
+	if len(output) > 0 {
+		slog.Debug("install.ps1 cache phase completed", "output", strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func startInstallScriptInstallCommand(command installScriptCommand) (installScriptProcess, error) {
+	if err := validateWindowsPowerShellPath(command.Program); err != nil {
+		return nil, err
+	}
+	cmd := exec.Command(command.Program, command.Args...)
+	cmd.Env = command.Env
+	cmd.Dir = command.Dir
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: command.CreationFlags}
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	if cmd.Process == nil {
+		return nil, errors.New("install.ps1 process did not start")
+	}
+	return cmd.Process, nil
+}
+
+func newInstallScriptCommand(scriptPath, workingDir, version, mode string) installScriptCommand {
+	env := installScriptEnv(os.Environ(), version, mode)
+	return installScriptCommand{
+		Program: windowsPowerShellPath(),
+		Args: []string{
+			"-NoProfile",
+			// Execution policy is local machine/user policy, not our trust boundary.
+			// Official builds verify install.ps1 before launch; updater_unsigned
+			// test builds can disable only that verifier for local unsigned scripts.
+			"-ExecutionPolicy",
+			"Bypass",
+			"-File",
+			scriptPath,
+		},
+		Env:           env,
+		Dir:           workingDir,
+		CreationFlags: windowsCreateNoWindow,
+	}
+}
+
+func installScriptEnv(base []string, version, mode string) []string {
+	env := withWindowsPowerShellModulePath(filterInstallScriptEnv(base))
+	switch mode {
+	case installScriptModeCacheOnly:
+		env = append(env, "OLLAMA_CACHE_ONLY=1")
+		if version != "" {
+			env = append(env, "OLLAMA_VERSION="+version)
+		}
+	case installScriptModeInstallCached:
+		env = append(env, "OLLAMA_INSTALL_CACHED=1")
+	}
+	return env
+}
+
+func filterInstallScriptEnv(base []string) []string {
+	blocked := map[string]struct{}{
+		"OLLAMA_CACHE_ONLY":     {},
+		"OLLAMA_DEBUG":          {},
+		"OLLAMA_INSTALL_CACHED": {},
+		"OLLAMA_INSTALL_DIR":    {},
+		"OLLAMA_UNINSTALL":      {},
+		"OLLAMA_VERSION":        {},
+	}
+	env := make([]string, 0, len(base))
+	for _, entry := range base {
+		key, _, ok := strings.Cut(entry, "=")
+		if !ok {
+			env = append(env, entry)
+			continue
+		}
+		if _, found := blocked[strings.ToUpper(key)]; found {
+			continue
+		}
+		env = append(env, entry)
+	}
+	return env
+}
+
+func createUpgradeMarker() error {
+	if err := os.MkdirAll(filepath.Dir(UpgradeMarkerFile), 0o755); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(UpgradeMarkerFile, os.O_RDONLY|os.O_CREATE, 0o666)
 	if err != nil {
 		return err
 	}
+	return f.Close()
+}
 
-	data := &windows.WinTrustData{
-		Size:             uint32(unsafe.Sizeof(windows.WinTrustData{})),
-		UIChoice:         windows.WTD_UI_NONE,
-		RevocationChecks: windows.WTD_REVOKE_WHOLECHAIN,
-		UnionChoice:      windows.WTD_CHOICE_FILE,
-		StateAction:      windows.WTD_STATEACTION_VERIFY,
-		UIContext:        windows.WTD_UICONTEXT_INSTALL,
-		FileOrCatalogOrBlobOrSgnrOrCert: unsafe.Pointer(&windows.WinTrustFileInfo{
-			Size:     uint32(unsafe.Sizeof(windows.WinTrustFileInfo{})),
-			FilePath: filename16,
-		}),
+func isInstallScriptStageReady(scriptStageDir string) bool {
+	if _, err := os.Stat(filepath.Join(scriptStageDir, stagedCacheReadyFile)); err != nil {
+		return false
 	}
+	return true
+}
 
-	verifyErr := windows.WinVerifyTrustEx(windows.InvalidHWND, &windows.WINTRUST_ACTION_GENERIC_VERIFY_V2, data)
-	data.StateAction = windows.WTD_STATEACTION_CLOSE
-	closeErr := windows.WinVerifyTrustEx(windows.InvalidHWND, &windows.WINTRUST_ACTION_GENERIC_VERIFY_V2, data)
-	if verifyErr != nil {
-		return verifyErr
-	}
-	if closeErr != nil {
-		return fmt.Errorf("close WinVerifyTrust state: %w", closeErr)
-	}
-
-	subject, err := windowsInstallerSignerSubject(filename)
-	if err != nil {
+func writeInstallScriptStageReady(scriptStageDir string) error {
+	if err := os.MkdirAll(scriptStageDir, 0o755); err != nil {
 		return err
 	}
-	slog.Debug("verified update signature", "subject", subject)
-	return nil
+	return os.WriteFile(filepath.Join(scriptStageDir, stagedCacheReadyFile), []byte("1\n"), 0o644)
 }
 
-func windowsInstallerSignerSubject(filename string) (string, error) {
-	filename16, err := windows.UTF16PtrFromString(filename)
-	if err != nil {
-		return "", err
+func removeInstallScriptStageReady(scriptStageDir string) error {
+	err := os.Remove(filepath.Join(scriptStageDir, stagedCacheReadyFile))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
 	}
-
-	var certStore windows.Handle
-	var msg windows.Handle
-	if err := windows.CryptQueryObject(
-		windows.CERT_QUERY_OBJECT_FILE,
-		unsafe.Pointer(filename16),
-		windows.CERT_QUERY_CONTENT_FLAG_PKCS7_SIGNED_EMBED,
-		windows.CERT_QUERY_FORMAT_FLAG_BINARY,
-		0,
-		nil,
-		nil,
-		nil,
-		&certStore,
-		&msg,
-		nil,
-	); err != nil {
-		return "", err
-	}
-	defer windows.CertCloseStore(certStore, 0) //nolint:errcheck
-	defer cryptMsgClose(msg)                   //nolint:errcheck
-
-	var signerInfoSize uint32
-	if err := cryptMsgGetParam(msg, cmsgSignerInfoParam, 0, nil, &signerInfoSize); err != nil {
-		return "", err
-	}
-	if signerInfoSize == 0 {
-		return "", fmt.Errorf("missing signer info")
-	}
-
-	signerInfoBuf := make([]byte, signerInfoSize)
-	if err := cryptMsgGetParam(msg, cmsgSignerInfoParam, 0, unsafe.Pointer(&signerInfoBuf[0]), &signerInfoSize); err != nil {
-		return "", err
-	}
-	signerInfo := (*cmsgSignerInfo)(unsafe.Pointer(&signerInfoBuf[0]))
-	certInfo := windows.CertInfo{
-		Issuer:       signerInfo.Issuer,
-		SerialNumber: signerInfo.SerialNumber,
-	}
-
-	cert, err := windows.CertFindCertificateInStore(
-		certStore,
-		windows.X509_ASN_ENCODING|windows.PKCS_7_ASN_ENCODING,
-		0,
-		windows.CERT_FIND_SUBJECT_CERT,
-		unsafe.Pointer(&certInfo),
-		nil,
-	)
-	if err != nil {
-		return "", err
-	}
-	defer windows.CertFreeCertificateContext(cert) //nolint:errcheck
-
-	parsed, err := x509.ParseCertificate(unsafe.Slice(cert.EncodedCert, cert.Length))
-	if err != nil {
-		return "", err
-	}
-
-	for _, org := range parsed.Subject.Organization {
-		if org == "Ollama Inc." {
-			return parsed.Subject.String(), nil
-		}
-	}
-	return "", fmt.Errorf("unexpected signer: %s", parsed.Subject.String())
-}
-
-func cryptMsgGetParam(msg windows.Handle, paramType, index uint32, data unsafe.Pointer, size *uint32) error {
-	r1, _, e1 := procCryptMsgGetParam.Call(
-		uintptr(msg),
-		uintptr(paramType),
-		uintptr(index),
-		uintptr(data),
-		uintptr(unsafe.Pointer(size)),
-	)
-	if r1 == 0 {
-		if e1 != syscall.Errno(0) {
-			return e1
-		}
-		return syscall.EINVAL
-	}
-	return nil
-}
-
-func cryptMsgClose(msg windows.Handle) error {
-	r1, _, e1 := procCryptMsgClose.Call(uintptr(msg))
-	if r1 == 0 {
-		if e1 != syscall.Errno(0) {
-			return e1
-		}
-		return syscall.EINVAL
-	}
-	return nil
+	return err
 }
 
 func IsUpdatePending() bool {
-	return getStagedUpdate() != ""
+	return getStagedInstallScript() != ""
 }
 
 func DoUpgradeAtStartup() error {
@@ -381,7 +671,11 @@ func IsProcRunning(procName string) []uint32 {
 		slog.Debug("failed to check for running installers", "error", err)
 		return nil
 	}
-	pids = pids[:ret]
+	pidCount := ret / uint32(unsafe.Sizeof(pids[0]))
+	if pidCount > uint32(len(pids)) {
+		pidCount = uint32(len(pids))
+	}
+	pids = pids[:pidCount]
 	matches := []uint32{}
 	for _, pid := range pids {
 		if pid == 0 {

--- a/app/updater/updater_windows.go
+++ b/app/updater/updater_windows.go
@@ -1,10 +1,14 @@
 package updater
 
 import (
-	"crypto/x509"
+	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
+	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path"
@@ -17,30 +21,41 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-var runningInstaller string
-
-var (
-	crypt32              = windows.NewLazySystemDLL("crypt32.dll")
-	procCryptMsgGetParam = crypt32.NewProc("CryptMsgGetParam")
-	procCryptMsgClose    = crypt32.NewProc("CryptMsgClose")
+const (
+	installScriptName              = "install.ps1"
+	stagedCacheReadyFile           = "cache-ready"
+	windowsCreateNoWindow          = 0x08000000
+	installScriptModeCacheOnly     = "cache-only"
+	installScriptModeInstallCached = "install-cached"
+	// Signature verification happens before launch; RemoteSigned avoids the
+	// broader Bypass mode while still working on default Windows clients.
+	installScriptExecutionPolicy = "RemoteSigned"
 )
 
-const cmsgSignerInfoParam = 6
+var (
+	runningInstaller              string
+	installScriptInstallerLogFile string
+)
 
-type cmsgSignerInfo struct {
-	Version                 uint32
-	Issuer                  windows.CertNameBlob
-	SerialNumber            windows.CryptIntegerBlob
-	HashAlgorithm           windows.CryptAlgorithmIdentifier
-	HashEncryptionAlgorithm windows.CryptAlgorithmIdentifier
-	EncryptedHash           windows.CryptDataBlob
-	AuthAttrs               cryptAttributes
-	UnauthAttrs             cryptAttributes
+var (
+	verifyInstallScriptSignature = verifyPowerShellScriptSignature
+	runInstallScriptCacheOnly    = runInstallScriptCacheOnlyCommand
+	startInstallScriptInstall    = startInstallScriptInstallCommand
+	exitAfterStartingUpgrade     = os.Exit
+)
+
+// installScriptProcess is the os.Process behavior DoUpgrade needs after
+// launching install.ps1; tests replace it to avoid starting a real installer.
+type installScriptProcess interface {
+	Release() error
 }
 
-type cryptAttributes struct {
-	Count      uint32
-	Attributes unsafe.Pointer
+type installScriptCommand struct {
+	Program       string
+	Args          []string
+	Env           []string
+	Dir           string
+	CreationFlags uint32
 }
 
 type OSVERSIONINFOEXW struct {
@@ -68,11 +83,229 @@ func init() {
 	UpdateStageDir = filepath.Join(appDataDir, "updates_v2")
 
 	UpgradeLogFile = filepath.Join(appDataDir, "upgrade.log")
+	installScriptInstallerLogFile = filepath.Join(appDataDir, "OllamaSetup.log")
 	Installer = "OllamaSetup.exe"
 	runningInstaller = filepath.Join(appDataDir, Installer)
 	UpgradeMarkerFile = filepath.Join(appDataDir, "upgraded")
 
 	loadOSVersion()
+}
+
+func (u *Updater) downloadNewRelease(ctx context.Context, updateResp UpdateResponse) error {
+	return u.downloadInstallScriptRelease(ctx, updateResp)
+}
+
+func (u *Updater) downloadInstallScriptRelease(ctx context.Context, updateResp UpdateResponse) error {
+	scriptURL, err := installScriptURL(updateResp)
+	if err != nil {
+		return err
+	}
+
+	scriptPath, downloadedScript, err := downloadInstallScript(ctx, scriptURL, updateResp)
+	if err != nil {
+		return err
+	}
+	scriptStageDir := filepath.Dir(scriptPath)
+	version := normalizedUpdateVersion(updateResp)
+
+	if err := verifyInstallScriptSignature(scriptPath); err != nil {
+		_ = os.RemoveAll(scriptStageDir)
+		return fmt.Errorf("install.ps1 signature verification failed: %w", err)
+	}
+	if !installScriptSupportsCacheOnly(scriptPath) {
+		_ = os.RemoveAll(scriptStageDir)
+		return fmt.Errorf("install.ps1 does not support cache-only mode")
+	}
+	if !downloadedScript && isInstallScriptStageReady(scriptStageDir) {
+		slog.Info("update already downloaded", "script", scriptPath)
+		UpdateDownloaded = true
+		return nil
+	}
+
+	// Clear readiness before refreshing the cache so a failed cache-only run
+	// cannot leave startup upgrade stuck retrying stale or partial payloads.
+	_ = removeInstallScriptStageReady(scriptStageDir)
+	if err := runInstallScriptCacheOnly(ctx, scriptPath, scriptStageDir, version); err != nil {
+		_ = os.RemoveAll(scriptStageDir)
+		return err
+	}
+
+	if err := writeInstallScriptStageReady(scriptStageDir); err != nil {
+		_ = os.RemoveAll(scriptStageDir)
+		return err
+	}
+	UpdateDownloaded = true
+	return nil
+}
+
+func downloadInstallScript(ctx context.Context, scriptURL string, updateResp UpdateResponse) (string, bool, error) {
+	slog.Debug("checking install.ps1", "url", scriptURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, scriptURL, nil)
+	if err != nil {
+		return "", false, err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", false, fmt.Errorf("error checking install.ps1: %w", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", false, fmt.Errorf("unexpected status attempting to download install.ps1 %d", resp.StatusCode)
+	}
+
+	stageKey := strings.Join([]string{
+		resp.Header.Get("etag"),
+		normalizedUpdateVersion(updateResp),
+		updateResp.UpdateURL,
+	}, "\n")
+	stageFilename, err := updateStagePath(UpdateStageDir, stageKey, installScriptName)
+	if err != nil {
+		return "", false, err
+	}
+
+	if _, err := os.Stat(stageFilename); err == nil {
+		slog.Info("install.ps1 already downloaded", "script", stageFilename)
+		return stageFilename, false, nil
+	}
+
+	cleanupOldDownloads(UpdateStageDir)
+
+	slog.Debug("downloading install.ps1", "url", scriptURL, "script", stageFilename)
+	req, err = http.NewRequestWithContext(ctx, http.MethodGet, scriptURL, nil)
+	if err != nil {
+		return "", false, err
+	}
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		return "", false, fmt.Errorf("error downloading install.ps1: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", false, fmt.Errorf("unexpected status attempting to download install.ps1 %d", resp.StatusCode)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(stageFilename), 0o755); err != nil {
+		return "", false, fmt.Errorf("create update staging dir %s: %w", filepath.Dir(stageFilename), err)
+	}
+
+	tmpFilename := stageFilename + ".tmp"
+	fp, err := os.OpenFile(tmpFilename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return "", false, fmt.Errorf("write install.ps1 %s: %w", tmpFilename, err)
+	}
+	if _, err := io.Copy(fp, resp.Body); err != nil {
+		_ = fp.Close()
+		_ = os.Remove(tmpFilename)
+		return "", false, fmt.Errorf("write install.ps1 %s: %w", tmpFilename, err)
+	}
+	if err := fp.Close(); err != nil {
+		_ = os.Remove(tmpFilename)
+		return "", false, fmt.Errorf("close install.ps1 %s: %w", tmpFilename, err)
+	}
+	if err := os.Rename(tmpFilename, stageFilename); err != nil {
+		_ = os.Remove(tmpFilename)
+		return "", false, fmt.Errorf("stage install.ps1 %s: %w", stageFilename, err)
+	}
+
+	slog.Info("install.ps1 downloaded", "script", stageFilename)
+	return stageFilename, true, nil
+}
+
+func installScriptURL(updateResp UpdateResponse) (string, error) {
+	parsed, err := url.Parse(updateResp.UpdateURL)
+	if err != nil {
+		return "", fmt.Errorf("parse update URL: %w", err)
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return "", fmt.Errorf("invalid update URL: %s", updateResp.UpdateURL)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", fmt.Errorf("unsupported update URL scheme: %s", parsed.Scheme)
+	}
+	if parsed.User != nil {
+		return "", fmt.Errorf("update URL userinfo is not allowed")
+	}
+	parsed.Path = path.Join(path.Dir(parsed.Path), installScriptName)
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed.String(), nil
+}
+
+func normalizedUpdateVersion(updateResp UpdateResponse) string {
+	return strings.TrimPrefix(strings.TrimSpace(updateResp.UpdateVersion), "v")
+}
+
+func windowsPowerShellPath() string {
+	systemDir, err := windows.GetSystemDirectory()
+	if err == nil && systemDir != "" {
+		return filepath.Join(systemDir, "WindowsPowerShell", "v1.0", "powershell.exe")
+	}
+	slog.Warn("unable to resolve Windows system directory for powershell.exe", "error", err)
+
+	systemRoot := os.Getenv("SystemRoot")
+	if systemRoot == "" {
+		systemRoot = os.Getenv("WINDIR")
+	}
+	if systemRoot == "" {
+		systemRoot = `C:\Windows`
+	}
+	return filepath.Join(systemRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe")
+}
+
+func validateWindowsPowerShellPath(powerShellPath string) error {
+	info, err := os.Stat(powerShellPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("Windows PowerShell not found at %s; app upgrades require the system Windows PowerShell component", powerShellPath)
+		}
+		return fmt.Errorf("unable to access Windows PowerShell at %s: %w", powerShellPath, err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("Windows PowerShell path is a directory: %s", powerShellPath)
+	}
+	return nil
+}
+
+func windowsPowerShellModulePath() string {
+	systemDir, err := windows.GetSystemDirectory()
+	if err == nil && systemDir != "" {
+		return filepath.Join(systemDir, "WindowsPowerShell", "v1.0", "Modules")
+	}
+	slog.Warn("unable to resolve Windows system directory for PowerShell module path", "error", err)
+
+	systemRoot := os.Getenv("SystemRoot")
+	if systemRoot == "" {
+		systemRoot = os.Getenv("WINDIR")
+	}
+	if systemRoot == "" {
+		systemRoot = `C:\Windows`
+	}
+	return filepath.Join(systemRoot, "System32", "WindowsPowerShell", "v1.0", "Modules")
+}
+
+func withWindowsPowerShellModulePath(base []string) []string {
+	env := make([]string, 0, len(base)+1)
+	for _, entry := range base {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok && strings.EqualFold(key, "PSModulePath") {
+			continue
+		}
+		env = append(env, entry)
+	}
+	// Force Windows PowerShell to its built-in module path. CI can inherit a
+	// PowerShell 7 PSModulePath that cannot load Windows PowerShell modules, and
+	// user-writable module paths should not participate in signature checks.
+	return append(env, "PSModulePath="+windowsPowerShellModulePath())
+}
+
+func installScriptSupportsCacheOnly(scriptPath string) bool {
+	data, err := os.ReadFile(scriptPath)
+	if err != nil {
+		slog.Warn("unable to read install.ps1 for capability check", "script", scriptPath, "error", err)
+		return false
+	}
+	return strings.Contains(string(data), "OLLAMA_CACHE_ONLY")
 }
 
 func loadOSVersion() {
@@ -99,99 +332,80 @@ func loadOSVersion() {
 	}
 }
 
-func getStagedUpdate() string {
+func getStagedInstallScript() string {
 	// When transitioning from old to new app, cleanup the update from the old staging dir
 	// This can eventually be removed once enough time has passed since the transition
 	cleanupOldDownloads(filepath.Join(os.Getenv("LOCALAPPDATA"), "Ollama", "updates"))
 
-	files, err := filepath.Glob(filepath.Join(UpdateStageDir, "*", "*.exe"))
+	files, err := filepath.Glob(filepath.Join(UpdateStageDir, "*", installScriptName))
 	if err != nil {
 		slog.Debug("failed to lookup downloads", "error", err)
 		return ""
 	}
-	if len(files) == 0 {
-		return ""
-	} else if len(files) > 1 {
-		// Shouldn't happen
-		slog.Warn("multiple update downloads found, using first one", "bundles", files)
+	readyFiles := files[:0]
+	for _, file := range files {
+		if isInstallScriptStageReady(filepath.Dir(file)) {
+			readyFiles = append(readyFiles, file)
+		}
 	}
-	return files[0]
+	if len(readyFiles) == 0 {
+		return ""
+	} else if len(readyFiles) > 1 {
+		// Shouldn't happen
+		slog.Warn("multiple update downloads found, using first one", "bundles", readyFiles)
+	}
+	return readyFiles[0]
 }
 
 func DoUpgrade(interactive bool) error {
-	bundle := getStagedUpdate()
-	if bundle == "" {
+	if script := getStagedInstallScript(); script != "" {
+		return doInstallScriptUpgrade(script, exitAfterStartingUpgrade)
+	}
+	return fmt.Errorf("failed to lookup downloads")
+}
+
+func doInstallScriptUpgrade(script string, exit func(int)) error {
+	if script == "" {
 		return fmt.Errorf("failed to lookup downloads")
 	}
 
 	if err := VerifyDownload(); err != nil {
-		_ = os.Remove(bundle)
-		slog.Warn("verification failure", "bundle", bundle, "error", err)
+		_ = os.RemoveAll(filepath.Dir(script))
+		slog.Warn("verification failure", "script", script, "error", err)
 		return fmt.Errorf("staged update verification failed: %w", err)
 	}
 
-	// We move the installer to ensure we don't race with multiple apps starting in quick succession
-	if err := os.Rename(bundle, runningInstaller); err != nil {
-		return fmt.Errorf("unable to rename %s -> %s : %w", bundle, runningInstaller, err)
-	}
-
-	slog.Info("upgrade log file " + UpgradeLogFile)
-
-	// make the upgrade show progress, but non interactive
-	installArgs := []string{
-		"/CLOSEAPPLICATIONS",                    // Quit the tray app if it's still running
-		"/LOG=" + filepath.Base(UpgradeLogFile), // Only relative seems reliable, so set pwd
-		"/FORCECLOSEAPPLICATIONS",               // Force close the tray app - might be needed
-		"/SP",                                   // Skip the "This will install... Do you wish to continue" prompt
-		"/NOCANCEL",                             // Disable the ability to cancel upgrade mid-flight to avoid partially installed upgrades
-		"/SILENT",
-	}
-
-	if !interactive {
-		// Add flags to make it totally silent without GUI
-		installArgs = append(installArgs, "/VERYSILENT", "/SUPPRESSMSGBOXES")
-	}
-
-	slog.Info("starting upgrade", "installer", runningInstaller, "args", installArgs)
-	os.Chdir(filepath.Dir(UpgradeLogFile)) //nolint:errcheck
-	cmd := exec.Command(runningInstaller, installArgs...)
-
-	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("unable to start ollama app %w", err)
-	}
-
-	if cmd.Process != nil {
-		err := cmd.Process.Release()
-		if err != nil {
-			slog.Error(fmt.Sprintf("failed to release server process: %s", err))
-		}
-	} else {
-		// TODO - some details about why it didn't start, or is this a pedantic error case?
-		return errors.New("installer process did not start")
-	}
-
-	// If the install fails to upgrade the system, and leaves a functional
-	// app, this marker file will cause us to remove the staged upgrade
-	// bundle, which will prevent trying again until we download again.
-	// If this becomes looping a problem, we may need to look for failures
-	// in the upgrade log in DoPostUpgradeCleanup and then not download
-	// the same version again.
-	f, err := os.OpenFile(UpgradeMarkerFile, os.O_RDONLY|os.O_CREATE, 0o666)
-	if err != nil {
+	scriptStageDir := filepath.Dir(script)
+	slog.Info("starting upgrade", "script", script, "stage", scriptStageDir)
+	if err := createUpgradeMarker(); err != nil {
 		slog.Warn("unable to create marker file", "file", UpgradeMarkerFile, "error", err)
 	}
-	f.Close()
 
-	// TODO should we linger for a moment and check to make sure it's actually running by checking the pid?
+	if err := removeInstallScriptStageReady(scriptStageDir); err != nil {
+		_ = os.Remove(UpgradeMarkerFile)
+		return fmt.Errorf("unable to clear staged update readiness: %w", err)
+	}
 
-	slog.Info("Installer started in background, exiting")
+	command := newInstallScriptCommand(script, scriptStageDir, "", installScriptModeInstallCached)
+	process, err := startInstallScriptInstall(command)
+	if err != nil {
+		_ = os.Remove(UpgradeMarkerFile)
+		return fmt.Errorf("unable to start install.ps1 upgrade: %w", err)
+	}
+	if err := process.Release(); err != nil {
+		slog.Error(fmt.Sprintf("failed to release installer process: %s", err))
+	}
 
-	os.Exit(0)
-	// Not reached
+	slog.Info("install.ps1 upgrade started in background, exiting")
+	exit(0)
 	return nil
 }
 
 func DoPostUpgradeCleanup() error {
+	if markerInfo, err := os.Stat(UpgradeMarkerFile); err == nil {
+		logInstallerFailuresSince(markerInfo.ModTime())
+	}
+
 	cleanupOldDownloads(UpdateStageDir)
 	err := os.Remove(UpgradeMarkerFile)
 	if err != nil {
@@ -199,6 +413,9 @@ func DoPostUpgradeCleanup() error {
 	}
 	err = os.Remove(runningInstaller)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
 		slog.Debug("failed to remove running installer on first attempt, backgrounding...", "installer", runningInstaller, "error", err)
 		go func() {
 			for range 10 {
@@ -214,156 +431,243 @@ func DoPostUpgradeCleanup() error {
 	return nil
 }
 
+func logInstallerFailuresSince(start time.Time) {
+	for _, logFile := range installScriptInstallerLogFiles() {
+		if logFile == "" {
+			continue
+		}
+		failed, err := windowsInstallerLogIndicatesFailure(logFile, start)
+		if err != nil {
+			slog.Debug("unable to inspect installer log", "log", logFile, "error", err)
+			continue
+		}
+		if failed {
+			slog.Warn("Windows installer reported upgrade failure", "log", logFile)
+		}
+	}
+}
+
+func installScriptInstallerLogFiles() []string {
+	if installScriptInstallerLogFile == "" {
+		return nil
+	}
+	return []string{installScriptInstallerLogFile}
+}
+
+func windowsInstallerLogIndicatesFailure(logFile string, since time.Time) (bool, error) {
+	info, err := os.Stat(logFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	if info.ModTime().Before(since) {
+		return false, nil
+	}
+
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		return false, err
+	}
+	logText := strings.ToLower(string(data))
+	for _, marker := range []string{
+		"installation process failed.",
+		"installation process was aborted.",
+		"user canceled the installation.",
+		"installation failed",
+		"return value 3",
+	} {
+		if strings.Contains(logText, marker) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func verifyDownload() error {
-	bundle := getStagedUpdate()
-	if bundle == "" {
+	script := getStagedInstallScript()
+	if script == "" {
 		return fmt.Errorf("failed to lookup downloads")
 	}
-	slog.Debug("verifying update", "bundle", bundle)
+	slog.Debug("verifying update", "script", script)
 
-	if err := verifyWindowsInstallerSignature(bundle); err != nil {
+	if err := verifyInstallScriptSignature(script); err != nil {
 		return fmt.Errorf("signature verification failed: %w", err)
 	}
+	if !installScriptSupportsCacheOnly(script) {
+		return fmt.Errorf("install.ps1 does not support cache-only mode")
+	}
 	return nil
 }
 
-func verifyWindowsInstallerSignature(filename string) error {
-	filename16, err := windows.UTF16PtrFromString(filename)
+func verifyPowerShellScriptSignature(filename string) error {
+	verificationScript := powerShellSignatureVerificationScript(filename)
+	powerShellPath := windowsPowerShellPath()
+	if err := validateWindowsPowerShellPath(powerShellPath); err != nil {
+		return err
+	}
+	cmd := exec.Command(
+		powerShellPath,
+		"-NoProfile",
+		"-NonInteractive",
+		"-Command",
+		verificationScript,
+	)
+	cmd.Env = withWindowsPowerShellModulePath(os.Environ())
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: windowsCreateNoWindow}
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("Windows PowerShell signature verification failed using %s: %w: %s", powerShellPath, err, strings.TrimSpace(string(output)))
+	}
+	slog.Info("verified install.ps1 signature", "subject", strings.TrimSpace(string(output)))
+	return nil
+}
+
+func powerShellSignatureVerificationScript(filename string) string {
+	encodedFilename := base64.StdEncoding.EncodeToString([]byte(filename))
+	return fmt.Sprintf(`
+$ErrorActionPreference = 'Stop'
+$target = [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('%s'))
+$sig = Get-AuthenticodeSignature -LiteralPath $target
+if ($sig.Status -ne 'Valid') {
+    throw "signature status: $($sig.Status)"
+}
+$subject = $sig.SignerCertificate.Subject
+if ($subject -notmatch '(^|, )O=Ollama Inc\.(,|$)') {
+    throw "unexpected signer: $subject"
+}
+Write-Output $subject
+`, encodedFilename)
+}
+
+func runInstallScriptCacheOnlyCommand(ctx context.Context, scriptPath, scriptStageDir, version string) error {
+	command := newInstallScriptCommand(scriptPath, scriptStageDir, version, installScriptModeCacheOnly)
+	if err := validateWindowsPowerShellPath(command.Program); err != nil {
+		return fmt.Errorf("install.ps1 cache phase failed: %w", err)
+	}
+	cmd := exec.CommandContext(ctx, command.Program, command.Args...)
+	cmd.Env = command.Env
+	cmd.Dir = command.Dir
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: command.CreationFlags}
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("install.ps1 cache phase failed using Windows PowerShell %s: %w: %s", command.Program, err, strings.TrimSpace(string(output)))
+	}
+	if len(output) > 0 {
+		slog.Debug("install.ps1 cache phase completed", "output", strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func startInstallScriptInstallCommand(command installScriptCommand) (installScriptProcess, error) {
+	if err := validateWindowsPowerShellPath(command.Program); err != nil {
+		return nil, err
+	}
+	cmd := exec.Command(command.Program, command.Args...)
+	cmd.Env = command.Env
+	cmd.Dir = command.Dir
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: command.CreationFlags}
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	if cmd.Process == nil {
+		return nil, errors.New("install.ps1 process did not start")
+	}
+	return cmd.Process, nil
+}
+
+func newInstallScriptCommand(scriptPath, workingDir, version, mode string) installScriptCommand {
+	env := installScriptEnv(os.Environ(), version, mode)
+	return installScriptCommand{
+		Program: windowsPowerShellPath(),
+		Args: []string{
+			"-NoProfile",
+			"-ExecutionPolicy",
+			installScriptExecutionPolicy,
+			"-File",
+			scriptPath,
+		},
+		Env:           env,
+		Dir:           workingDir,
+		CreationFlags: windowsCreateNoWindow,
+	}
+}
+
+func installScriptEnv(base []string, version, mode string) []string {
+	env := withWindowsPowerShellModulePath(filterInstallScriptEnv(base))
+	switch mode {
+	case installScriptModeCacheOnly:
+		env = append(env, "OLLAMA_CACHE_ONLY=1")
+		if version != "" {
+			env = append(env, "OLLAMA_VERSION="+version)
+		}
+	case installScriptModeInstallCached:
+		env = append(env, "OLLAMA_INSTALL_CACHED=1")
+	}
+	return env
+}
+
+func filterInstallScriptEnv(base []string) []string {
+	blocked := map[string]struct{}{
+		"OLLAMA_CACHE_ONLY":     {},
+		"OLLAMA_DEBUG":          {},
+		"OLLAMA_INSTALL_CACHED": {},
+		"OLLAMA_INSTALL_DIR":    {},
+		"OLLAMA_UNINSTALL":      {},
+		"OLLAMA_VERSION":        {},
+	}
+	env := make([]string, 0, len(base))
+	for _, entry := range base {
+		key, _, ok := strings.Cut(entry, "=")
+		if !ok {
+			env = append(env, entry)
+			continue
+		}
+		if _, found := blocked[strings.ToUpper(key)]; found {
+			continue
+		}
+		env = append(env, entry)
+	}
+	return env
+}
+
+func createUpgradeMarker() error {
+	if err := os.MkdirAll(filepath.Dir(UpgradeMarkerFile), 0o755); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(UpgradeMarkerFile, os.O_RDONLY|os.O_CREATE, 0o666)
 	if err != nil {
 		return err
 	}
+	return f.Close()
+}
 
-	data := &windows.WinTrustData{
-		Size:             uint32(unsafe.Sizeof(windows.WinTrustData{})),
-		UIChoice:         windows.WTD_UI_NONE,
-		RevocationChecks: windows.WTD_REVOKE_WHOLECHAIN,
-		UnionChoice:      windows.WTD_CHOICE_FILE,
-		StateAction:      windows.WTD_STATEACTION_VERIFY,
-		UIContext:        windows.WTD_UICONTEXT_INSTALL,
-		FileOrCatalogOrBlobOrSgnrOrCert: unsafe.Pointer(&windows.WinTrustFileInfo{
-			Size:     uint32(unsafe.Sizeof(windows.WinTrustFileInfo{})),
-			FilePath: filename16,
-		}),
+func isInstallScriptStageReady(scriptStageDir string) bool {
+	if _, err := os.Stat(filepath.Join(scriptStageDir, stagedCacheReadyFile)); err != nil {
+		return false
 	}
+	return true
+}
 
-	verifyErr := windows.WinVerifyTrustEx(windows.InvalidHWND, &windows.WINTRUST_ACTION_GENERIC_VERIFY_V2, data)
-	data.StateAction = windows.WTD_STATEACTION_CLOSE
-	closeErr := windows.WinVerifyTrustEx(windows.InvalidHWND, &windows.WINTRUST_ACTION_GENERIC_VERIFY_V2, data)
-	if verifyErr != nil {
-		return verifyErr
-	}
-	if closeErr != nil {
-		return fmt.Errorf("close WinVerifyTrust state: %w", closeErr)
-	}
-
-	subject, err := windowsInstallerSignerSubject(filename)
-	if err != nil {
+func writeInstallScriptStageReady(scriptStageDir string) error {
+	if err := os.MkdirAll(scriptStageDir, 0o755); err != nil {
 		return err
 	}
-	slog.Debug("verified update signature", "subject", subject)
-	return nil
+	return os.WriteFile(filepath.Join(scriptStageDir, stagedCacheReadyFile), []byte("1\n"), 0o644)
 }
 
-func windowsInstallerSignerSubject(filename string) (string, error) {
-	filename16, err := windows.UTF16PtrFromString(filename)
-	if err != nil {
-		return "", err
+func removeInstallScriptStageReady(scriptStageDir string) error {
+	err := os.Remove(filepath.Join(scriptStageDir, stagedCacheReadyFile))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
 	}
-
-	var certStore windows.Handle
-	var msg windows.Handle
-	if err := windows.CryptQueryObject(
-		windows.CERT_QUERY_OBJECT_FILE,
-		unsafe.Pointer(filename16),
-		windows.CERT_QUERY_CONTENT_FLAG_PKCS7_SIGNED_EMBED,
-		windows.CERT_QUERY_FORMAT_FLAG_BINARY,
-		0,
-		nil,
-		nil,
-		nil,
-		&certStore,
-		&msg,
-		nil,
-	); err != nil {
-		return "", err
-	}
-	defer windows.CertCloseStore(certStore, 0) //nolint:errcheck
-	defer cryptMsgClose(msg)                   //nolint:errcheck
-
-	var signerInfoSize uint32
-	if err := cryptMsgGetParam(msg, cmsgSignerInfoParam, 0, nil, &signerInfoSize); err != nil {
-		return "", err
-	}
-	if signerInfoSize == 0 {
-		return "", fmt.Errorf("missing signer info")
-	}
-
-	signerInfoBuf := make([]byte, signerInfoSize)
-	if err := cryptMsgGetParam(msg, cmsgSignerInfoParam, 0, unsafe.Pointer(&signerInfoBuf[0]), &signerInfoSize); err != nil {
-		return "", err
-	}
-	signerInfo := (*cmsgSignerInfo)(unsafe.Pointer(&signerInfoBuf[0]))
-	certInfo := windows.CertInfo{
-		Issuer:       signerInfo.Issuer,
-		SerialNumber: signerInfo.SerialNumber,
-	}
-
-	cert, err := windows.CertFindCertificateInStore(
-		certStore,
-		windows.X509_ASN_ENCODING|windows.PKCS_7_ASN_ENCODING,
-		0,
-		windows.CERT_FIND_SUBJECT_CERT,
-		unsafe.Pointer(&certInfo),
-		nil,
-	)
-	if err != nil {
-		return "", err
-	}
-	defer windows.CertFreeCertificateContext(cert) //nolint:errcheck
-
-	parsed, err := x509.ParseCertificate(unsafe.Slice(cert.EncodedCert, cert.Length))
-	if err != nil {
-		return "", err
-	}
-
-	for _, org := range parsed.Subject.Organization {
-		if org == "Ollama Inc." {
-			return parsed.Subject.String(), nil
-		}
-	}
-	return "", fmt.Errorf("unexpected signer: %s", parsed.Subject.String())
-}
-
-func cryptMsgGetParam(msg windows.Handle, paramType, index uint32, data unsafe.Pointer, size *uint32) error {
-	r1, _, e1 := procCryptMsgGetParam.Call(
-		uintptr(msg),
-		uintptr(paramType),
-		uintptr(index),
-		uintptr(data),
-		uintptr(unsafe.Pointer(size)),
-	)
-	if r1 == 0 {
-		if e1 != syscall.Errno(0) {
-			return e1
-		}
-		return syscall.EINVAL
-	}
-	return nil
-}
-
-func cryptMsgClose(msg windows.Handle) error {
-	r1, _, e1 := procCryptMsgClose.Call(uintptr(msg))
-	if r1 == 0 {
-		if e1 != syscall.Errno(0) {
-			return e1
-		}
-		return syscall.EINVAL
-	}
-	return nil
+	return err
 }
 
 func IsUpdatePending() bool {
-	return getStagedUpdate() != ""
+	return getStagedInstallScript() != ""
 }
 
 func DoUpgradeAtStartup() error {
@@ -381,7 +685,11 @@ func IsProcRunning(procName string) []uint32 {
 		slog.Debug("failed to check for running installers", "error", err)
 		return nil
 	}
-	pids = pids[:ret]
+	pidCount := ret / uint32(unsafe.Sizeof(pids[0]))
+	if pidCount > uint32(len(pids)) {
+		pidCount = uint32(len(pids))
+	}
+	pids = pids[:pidCount]
 	matches := []uint32{}
 	for _, pid := range pids {
 		if pid == 0 {

--- a/app/updater/updater_windows_test.go
+++ b/app/updater/updater_windows_test.go
@@ -3,28 +3,224 @@
 package updater
 
 import (
+	"bytes"
+	"context"
+	"fmt"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
-func TestVerifyDownloadRejectsUnsignedWindowsInstaller(t *testing.T) {
+type fakeInstallScriptProcess struct {
+	released atomic.Bool
+}
+
+func (p *fakeInstallScriptProcess) Release() error {
+	p.released.Store(true)
+	return nil
+}
+
+func resetWindowsUpdaterState(t *testing.T) {
+	t.Helper()
+
 	oldUpdateStageDir := UpdateStageDir
-	defer func() {
+	oldRunningInstaller := runningInstaller
+	oldUpgradeLogFile := UpgradeLogFile
+	oldInstallScriptInstallerLogFile := installScriptInstallerLogFile
+	oldUpgradeMarkerFile := UpgradeMarkerFile
+	oldVerifyDownload := VerifyDownload
+	oldVerifyInstallScriptSignature := verifyInstallScriptSignature
+	oldRunInstallScriptCacheOnly := runInstallScriptCacheOnly
+	oldStartInstallScriptInstall := startInstallScriptInstall
+	oldExitAfterStartingUpgrade := exitAfterStartingUpgrade
+	oldUpdateDownloaded := UpdateDownloaded
+	t.Cleanup(func() {
 		UpdateStageDir = oldUpdateStageDir
-	}()
+		runningInstaller = oldRunningInstaller
+		UpgradeLogFile = oldUpgradeLogFile
+		installScriptInstallerLogFile = oldInstallScriptInstallerLogFile
+		UpgradeMarkerFile = oldUpgradeMarkerFile
+		VerifyDownload = oldVerifyDownload
+		verifyInstallScriptSignature = oldVerifyInstallScriptSignature
+		runInstallScriptCacheOnly = oldRunInstallScriptCacheOnly
+		startInstallScriptInstall = oldStartInstallScriptInstall
+		exitAfterStartingUpgrade = oldExitAfterStartingUpgrade
+		UpdateDownloaded = oldUpdateDownloaded
+	})
+}
+
+func stageInstallScript(t *testing.T, version string) string {
+	t.Helper()
+	return stageInstallScriptBody(t, version, `$CacheOnly = $env:OLLAMA_CACHE_ONLY -eq "1"`)
+}
+
+func stageInstallScriptBody(t *testing.T, _ string, body string) string {
+	t.Helper()
+
+	stageDir := filepath.Join(UpdateStageDir, "etag")
+	if err := os.MkdirAll(stageDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	script := filepath.Join(stageDir, installScriptName)
+	if err := os.WriteFile(script, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return script
+}
+
+func markInstallScriptStageReady(t *testing.T, script string) {
+	t.Helper()
+	if err := writeInstallScriptStageReady(filepath.Dir(script)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func envValue(env []string, key string) (string, bool) {
+	prefix := strings.ToUpper(key) + "="
+	for _, entry := range env {
+		if strings.HasPrefix(strings.ToUpper(entry), prefix) {
+			return entry[len(prefix):], true
+		}
+	}
+	return "", false
+}
+
+func TestWithWindowsPowerShellModulePathReplacesAmbientValue(t *testing.T) {
+	env := withWindowsPowerShellModulePath([]string{
+		"Path=C:\\Windows",
+		"PSModulePath=C:\\user-controlled",
+		"psmodulepath=C:\\also-user-controlled",
+	})
+
+	var count int
+	var modulePath string
+	for _, entry := range env {
+		key, value, ok := strings.Cut(entry, "=")
+		if ok && strings.EqualFold(key, "PSModulePath") {
+			count++
+			modulePath = value
+		}
+	}
+	if count != 1 {
+		t.Fatalf("PSModulePath entries = %d, want 1 in %v", count, env)
+	}
+	if strings.Contains(strings.ToLower(modulePath), "user-controlled") {
+		t.Fatalf("PSModulePath should not preserve ambient user-controlled paths: %s", modulePath)
+	}
+	lowerModulePath := strings.ToLower(modulePath)
+	if !strings.Contains(lowerModulePath, "windowspowershell") || !strings.Contains(lowerModulePath, "modules") {
+		t.Fatalf("PSModulePath = %s, want Windows PowerShell module path", modulePath)
+	}
+}
+
+func TestValidateWindowsPowerShellPathReportsMissingPath(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "powershell.exe")
+	err := validateWindowsPowerShellPath(missing)
+	if err == nil {
+		t.Fatal("expected missing Windows PowerShell path error")
+	}
+	if !strings.Contains(err.Error(), "Windows PowerShell not found") {
+		t.Fatalf("error = %q, want clear Windows PowerShell not found message", err)
+	}
+	if !strings.Contains(err.Error(), missing) {
+		t.Fatalf("error = %q, want missing path", err)
+	}
+}
+
+func TestValidateWindowsPowerShellPathRejectsDirectory(t *testing.T) {
+	dir := t.TempDir()
+	err := validateWindowsPowerShellPath(dir)
+	if err == nil {
+		t.Fatal("expected directory path error")
+	}
+	if !strings.Contains(err.Error(), "Windows PowerShell path is a directory") {
+		t.Fatalf("error = %q, want directory path message", err)
+	}
+}
+
+func TestPowerShellSignatureVerificationScriptEncodesTargetPath(t *testing.T) {
+	filename := `C:\Temp\install'; throw 'oops.ps1`
+	script := powerShellSignatureVerificationScript(filename)
+	if strings.Contains(script, filename) {
+		t.Fatalf("verification script should not contain the raw target path:\n%s", script)
+	}
+	if strings.Contains(script, "$args[0]") {
+		t.Fatalf("verification script should not depend on PowerShell argument binding:\n%s", script)
+	}
+	if !strings.Contains(script, "Get-AuthenticodeSignature -LiteralPath $target") {
+		t.Fatalf("verification script should use LiteralPath:\n%s", script)
+	}
+}
+
+func TestInstallScriptURLUsesUpdateDirectory(t *testing.T) {
+	got, err := installScriptURL(UpdateResponse{
+		UpdateURL: "https://example.com/releases/v0.21.0/OllamaSetup.exe?ignored=1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "https://example.com/releases/v0.21.0/install.ps1" {
+		t.Fatalf("install script URL = %s", got)
+	}
+}
+
+func TestInstallScriptURLAcceptsDirectInstallScriptURL(t *testing.T) {
+	updateResp := UpdateResponse{
+		UpdateURL:     "https://example.com/download/install.ps1",
+		UpdateVersion: "v0.21.0",
+	}
+	got, err := installScriptURL(updateResp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "https://example.com/download/install.ps1" {
+		t.Fatalf("install script URL = %s", got)
+	}
+	if version := normalizedUpdateVersion(updateResp); version != "0.21.0" {
+		t.Fatalf("version = %q, want 0.21.0", version)
+	}
+}
+
+func TestInstallScriptURLRejectsInvalidUpdateURLs(t *testing.T) {
+	for _, rawURL := range []string{
+		"",
+		"not-a-url",
+		"/download/OllamaSetup.exe",
+		"://missing-scheme",
+	} {
+		t.Run(rawURL, func(t *testing.T) {
+			if got, err := installScriptURL(UpdateResponse{UpdateURL: rawURL}); err == nil {
+				t.Fatalf("installScriptURL(%q) = %q, want error", rawURL, got)
+			}
+		})
+	}
+}
+
+func TestNormalizedUpdateVersionDoesNotInferFromURL(t *testing.T) {
+	updateResp := UpdateResponse{
+		UpdateURL: "https://example.com/releases/download/v0.24.0/OllamaSetup.exe",
+	}
+	if version := normalizedUpdateVersion(updateResp); version != "" {
+		t.Fatalf("version = %q, want empty when update response omits version", version)
+	}
+}
+
+func TestVerifyDownloadRejectsUnsignedInstallScript(t *testing.T) {
+	resetWindowsUpdaterState(t)
 
 	t.Setenv("LOCALAPPDATA", t.TempDir())
 	UpdateStageDir = t.TempDir()
-	bundle := filepath.Join(UpdateStageDir, "etag", "OllamaSetup.exe")
-	if err := os.MkdirAll(filepath.Dir(bundle), 0o755); err != nil {
-		t.Fatal(err)
+	verifyInstallScriptSignature = func(filename string) error {
+		return fmt.Errorf("signature verification failed")
 	}
-	if err := os.WriteFile(bundle, []byte("not a signed installer"), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	script := stageInstallScript(t, "")
+	markInstallScriptStageReady(t, script)
 
 	err := verifyDownload()
 	if err == nil || !strings.Contains(err.Error(), "signature verification failed") {
@@ -32,19 +228,8 @@ func TestVerifyDownloadRejectsUnsignedWindowsInstaller(t *testing.T) {
 	}
 }
 
-func TestDoUpgradeAtStartupRejectsUnsignedWindowsInstaller(t *testing.T) {
-	oldUpdateStageDir := UpdateStageDir
-	oldRunningInstaller := runningInstaller
-	oldUpgradeLogFile := UpgradeLogFile
-	oldUpgradeMarkerFile := UpgradeMarkerFile
-	oldVerifyDownload := VerifyDownload
-	defer func() {
-		UpdateStageDir = oldUpdateStageDir
-		runningInstaller = oldRunningInstaller
-		UpgradeLogFile = oldUpgradeLogFile
-		UpgradeMarkerFile = oldUpgradeMarkerFile
-		VerifyDownload = oldVerifyDownload
-	}()
+func TestDoUpgradeAtStartupRejectsUnsignedInstallScript(t *testing.T) {
+	resetWindowsUpdaterState(t)
 
 	t.Setenv("LOCALAPPDATA", t.TempDir())
 	UpdateStageDir = t.TempDir()
@@ -53,28 +238,795 @@ func TestDoUpgradeAtStartupRejectsUnsignedWindowsInstaller(t *testing.T) {
 	UpgradeLogFile = filepath.Join(runDir, "upgrade.log")
 	UpgradeMarkerFile = filepath.Join(runDir, "upgraded")
 	VerifyDownload = verifyDownload
-
-	bundle := filepath.Join(UpdateStageDir, "etag", "OllamaSetup.exe")
-	if err := os.MkdirAll(filepath.Dir(bundle), 0o755); err != nil {
-		t.Fatal(err)
+	verifyInstallScriptSignature = func(filename string) error {
+		return fmt.Errorf("signature verification failed")
 	}
-	if err := os.WriteFile(bundle, []byte("not a signed installer"), 0o755); err != nil {
-		t.Fatal(err)
+
+	script := stageInstallScript(t, "")
+	markInstallScriptStageReady(t, script)
+	startInstallScriptInstall = func(command installScriptCommand) (installScriptProcess, error) {
+		t.Fatal("installer should not start after signature verification fails")
+		return nil, nil
 	}
 
 	err := DoUpgradeAtStartup()
 	if err == nil || !strings.Contains(err.Error(), "signature verification failed") {
 		t.Fatalf("expected signature verification failure, got %v", err)
 	}
-	if _, err := os.Stat(runningInstaller); !os.IsNotExist(err) {
-		t.Fatalf("unsigned installer was moved before verification failed: %v", err)
+	if _, err := os.Stat(script); !os.IsNotExist(err) {
+		t.Fatalf("unsigned staged install script was not removed after verification failure: %v", err)
 	}
-	if _, err := os.Stat(bundle); !os.IsNotExist(err) {
-		t.Fatalf("unsigned staged installer was not removed after verification failure: %v", err)
+}
+
+func TestVerifyDownloadRejectsInstallScriptWithoutCacheOnlySupport(t *testing.T) {
+	resetWindowsUpdaterState(t)
+
+	t.Setenv("LOCALAPPDATA", t.TempDir())
+	UpdateStageDir = t.TempDir()
+	VerifyDownload = verifyDownload
+	verifyInstallScriptSignature = func(filename string) error {
+		return nil
+	}
+	script := stageInstallScriptBody(t, "0.21.0", "# signed old install.ps1")
+	markInstallScriptStageReady(t, script)
+
+	err := VerifyDownload()
+	if err == nil || !strings.Contains(err.Error(), "does not support cache-only mode") {
+		t.Fatalf("expected cache-only support failure, got %v", err)
+	}
+}
+
+func TestDownloadNewReleaseCleansStagedScriptWhenSignatureFails(t *testing.T) {
+	resetWindowsUpdaterState(t)
+
+	UpdateStageDir = t.TempDir()
+	UpdateDownloaded = false
+	t.Setenv("LOCALAPPDATA", t.TempDir())
+
+	verifyInstallScriptSignature = func(filename string) error {
+		if filepath.Base(filename) != installScriptName {
+			t.Fatalf("expected to verify install.ps1, got %s", filename)
+		}
+		return fmt.Errorf("bad signature")
+	}
+	runInstallScriptCacheOnly = func(ctx context.Context, scriptPath, cacheDir, version string) error {
+		t.Fatal("cache-only phase should not run after signature failure")
+		return nil
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v0.21.0/install.ps1" {
+			t.Errorf("unexpected request path %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("ETag", `"script-etag"`)
+		w.WriteHeader(http.StatusOK)
+		if r.Method == http.MethodGet {
+			_, _ = w.Write([]byte(`$CacheOnly = $env:OLLAMA_CACHE_ONLY -eq "1"`))
+		}
+	}))
+	defer server.Close()
+
+	updater := &Updater{}
+	err := updater.DownloadNewRelease(t.Context(), UpdateResponse{
+		UpdateURL:     server.URL + "/v0.21.0/OllamaSetup.exe",
+		UpdateVersion: "v0.21.0",
+	})
+	if err == nil || !strings.Contains(err.Error(), "install.ps1 signature verification failed") {
+		t.Fatalf("expected signature verification failure, got %v", err)
+	}
+	if UpdateDownloaded {
+		t.Fatal("UpdateDownloaded should remain false after signature failure")
+	}
+	entries, err := os.ReadDir(UpdateStageDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("staged script cache was not cleaned up: %v", entries)
+	}
+}
+
+func TestDownloadNewReleaseUsesCompletedCachedInstallScript(t *testing.T) {
+	resetWindowsUpdaterState(t)
+
+	UpdateStageDir = t.TempDir()
+	UpdateDownloaded = false
+	t.Setenv("LOCALAPPDATA", t.TempDir())
+
+	var getRequested atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v0.21.0/install.ps1" {
+			t.Errorf("unexpected request path %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("ETag", `"script-etag"`)
+		switch r.Method {
+		case http.MethodHead:
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			getRequested.Store(true)
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected method %s", r.Method)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer server.Close()
+
+	updateResp := UpdateResponse{
+		UpdateURL:     server.URL + "/v0.21.0/OllamaSetup.exe",
+		UpdateVersion: "v0.21.0",
+	}
+	stageKey := strings.Join([]string{
+		`"script-etag"`,
+		"0.21.0",
+		updateResp.UpdateURL,
+	}, "\n")
+	scriptPath, err := updateStagePath(UpdateStageDir, stageKey, installScriptName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cacheDir := filepath.Dir(scriptPath)
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(scriptPath, []byte(`$CacheOnly = $env:OLLAMA_CACHE_ONLY -eq "1"`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	markInstallScriptStageReady(t, scriptPath)
+
+	verifyInstallScriptSignature = func(filename string) error {
+		if filename != scriptPath {
+			t.Fatalf("verified script = %s, want %s", filename, scriptPath)
+		}
+		return nil
+	}
+	runInstallScriptCacheOnly = func(ctx context.Context, scriptPath, cacheDir, version string) error {
+		t.Fatal("cache-only phase should not rerun for completed cached update")
+		return nil
+	}
+
+	updater := &Updater{}
+	if err := updater.DownloadNewRelease(t.Context(), updateResp); err != nil {
+		t.Fatal(err)
+	}
+	if getRequested.Load() {
+		t.Fatal("completed cached install.ps1 should not be downloaded again")
+	}
+	if !UpdateDownloaded {
+		t.Fatal("UpdateDownloaded should be true for completed cached update")
+	}
+}
+
+func TestDownloadNewReleaseRerunsCacheOnlyForNewVersionWhenInstallScriptETagUnchanged(t *testing.T) {
+	resetWindowsUpdaterState(t)
+
+	UpdateStageDir = t.TempDir()
+	UpdateDownloaded = false
+	t.Setenv("LOCALAPPDATA", t.TempDir())
+	var scriptGetCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v0.22.0/install.ps1" {
+			t.Errorf("unexpected request path %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("ETag", `"same-script-etag"`)
+		switch r.Method {
+		case http.MethodHead:
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			scriptGetCount.Add(1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`$CacheOnly = $env:OLLAMA_CACHE_ONLY -eq "1"`))
+		default:
+			t.Errorf("unexpected method %s", r.Method)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer server.Close()
+
+	oldUpdateResp := UpdateResponse{
+		UpdateURL:     server.URL + "/v0.21.0/OllamaSetup.exe",
+		UpdateVersion: "v0.21.0",
+	}
+	oldStageKey := strings.Join([]string{
+		`"same-script-etag"`,
+		"0.21.0",
+		oldUpdateResp.UpdateURL,
+	}, "\n")
+	oldScriptPath, err := updateStagePath(UpdateStageDir, oldStageKey, installScriptName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(oldScriptPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(oldScriptPath, []byte(`$CacheOnly = $env:OLLAMA_CACHE_ONLY -eq "1"`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	markInstallScriptStageReady(t, oldScriptPath)
+
+	verifyInstallScriptSignature = func(filename string) error {
+		return nil
+	}
+	var cacheOnlyRuns atomic.Int32
+	var recordedVersion string
+	runInstallScriptCacheOnly = func(ctx context.Context, scriptPath, cacheDir, version string) error {
+		cacheOnlyRuns.Add(1)
+		recordedVersion = version
+		if scriptPath == oldScriptPath {
+			t.Fatal("new update should not reuse the old staged script path")
+		}
+		return nil
+	}
+
+	newUpdateResp := UpdateResponse{
+		UpdateURL:     server.URL + "/v0.22.0/OllamaSetup.exe",
+		UpdateVersion: "v0.22.0",
+	}
+	updater := &Updater{}
+	if err := updater.DownloadNewRelease(t.Context(), newUpdateResp); err != nil {
+		t.Fatal(err)
+	}
+
+	if scriptGetCount.Load() != 1 {
+		t.Fatalf("expected install.ps1 to be staged for the new target, got %d GETs", scriptGetCount.Load())
+	}
+	if cacheOnlyRuns.Load() != 1 {
+		t.Fatalf("cache-only should rerun for the new target even with an existing payload, got %d", cacheOnlyRuns.Load())
+	}
+	if recordedVersion != "0.22.0" {
+		t.Fatalf("version = %q, want 0.22.0", recordedVersion)
+	}
+	if !UpdateDownloaded {
+		t.Fatal("UpdateDownloaded should be true after recaching the newer target")
+	}
+	if _, err := os.Stat(oldScriptPath); !os.IsNotExist(err) {
+		t.Fatalf("old staged script should be removed before recaching newer target: %v", err)
+	}
+}
+
+func TestDownloadNewReleaseStagesInstallScriptAndRunsCacheOnly(t *testing.T) {
+	resetWindowsUpdaterState(t)
+
+	UpdateStageDir = t.TempDir()
+	UpdateDownloaded = false
+	t.Setenv("LOCALAPPDATA", t.TempDir())
+	var exeGetRequested atomic.Bool
+	var scriptHeadCount atomic.Int32
+	var scriptGetCount atomic.Int32
+	var recordedScript string
+	var recordedCache string
+	var recordedVersion string
+	verifyInstallScriptSignature = func(filename string) error {
+		if filepath.Base(filename) != installScriptName {
+			t.Fatalf("expected to verify install.ps1, got %s", filename)
+		}
+		return nil
+	}
+	runInstallScriptCacheOnly = func(ctx context.Context, scriptPath, cacheDir, version string) error {
+		recordedScript = scriptPath
+		recordedCache = cacheDir
+		recordedVersion = version
+		return nil
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v0.21.0/install.ps1":
+			w.Header().Set("ETag", `"script-etag"`)
+			switch r.Method {
+			case http.MethodHead:
+				scriptHeadCount.Add(1)
+				w.WriteHeader(http.StatusOK)
+			case http.MethodGet:
+				scriptGetCount.Add(1)
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`$CacheOnly = $env:OLLAMA_CACHE_ONLY -eq "1"`))
+			default:
+				t.Errorf("unexpected method %s", r.Method)
+				w.WriteHeader(http.StatusMethodNotAllowed)
+			}
+		case "/v0.21.0/OllamaSetup.exe":
+			w.Header().Set("ETag", `"exe-etag"`)
+			switch r.Method {
+			case http.MethodHead:
+				t.Errorf("app should let install.ps1 check the installer ETag")
+				w.WriteHeader(http.StatusMethodNotAllowed)
+			case http.MethodGet:
+				exeGetRequested.Store(true)
+				w.WriteHeader(http.StatusOK)
+			default:
+				t.Errorf("unexpected method %s", r.Method)
+				w.WriteHeader(http.StatusMethodNotAllowed)
+			}
+		default:
+			t.Errorf("unexpected request path %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	updater := &Updater{}
+	err := updater.DownloadNewRelease(t.Context(), UpdateResponse{
+		UpdateURL:     server.URL + "/v0.21.0/OllamaSetup.exe",
+		UpdateVersion: "v0.21.0",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if exeGetRequested.Load() {
+		t.Fatal("app cache phase should let install.ps1 download OllamaSetup.exe")
+	}
+	if scriptHeadCount.Load() != 1 || scriptGetCount.Load() != 1 {
+		t.Fatalf("expected one HEAD and one GET for install.ps1, got HEAD=%d GET=%d", scriptHeadCount.Load(), scriptGetCount.Load())
+	}
+	if recordedScript == "" || filepath.Base(recordedScript) != installScriptName {
+		t.Fatalf("cache-only script not recorded correctly: %s", recordedScript)
+	}
+	if recordedCache != filepath.Dir(recordedScript) {
+		t.Fatalf("cache dir = %s, want %s", recordedCache, filepath.Dir(recordedScript))
+	}
+	if recordedVersion != "0.21.0" {
+		t.Fatalf("version = %q, want 0.21.0", recordedVersion)
+	}
+	if _, err := os.Stat(filepath.Join(recordedCache, installScriptName)); err != nil {
+		t.Fatalf("final install.ps1 missing after cache-only success: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(recordedCache, stagedCacheReadyFile)); err != nil {
+		t.Fatalf("cache-ready marker missing after cache-only success: %v", err)
+	}
+	if !UpdateDownloaded {
+		t.Fatal("UpdateDownloaded should be true after staged script download succeeds")
+	}
+}
+
+func TestDownloadNewReleaseRejectsInstallScriptWithoutCacheOnlySupport(t *testing.T) {
+	resetWindowsUpdaterState(t)
+
+	UpdateStageDir = t.TempDir()
+	UpdateDownloaded = false
+
+	var downloadOnlyRan atomic.Bool
+	verifyInstallScriptSignature = func(filename string) error {
+		if filepath.Base(filename) != installScriptName {
+			t.Fatalf("expected to verify install.ps1, got %s", filename)
+		}
+		return nil
+	}
+	runInstallScriptCacheOnly = func(ctx context.Context, scriptPath, cacheDir, version string) error {
+		downloadOnlyRan.Store(true)
+		return nil
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v0.21.0/install.ps1":
+			w.Header().Set("ETag", `"old-script-etag"`)
+			w.WriteHeader(http.StatusOK)
+			if r.Method == http.MethodGet {
+				_, _ = w.Write([]byte("# signed old install.ps1"))
+			}
+		default:
+			t.Errorf("unexpected request path %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	updater := &Updater{}
+	err := updater.DownloadNewRelease(t.Context(), UpdateResponse{
+		UpdateURL:     server.URL + "/v0.21.0/OllamaSetup.exe",
+		UpdateVersion: "v0.21.0",
+	})
+	if err == nil || !strings.Contains(err.Error(), "install.ps1 does not support cache-only mode") {
+		t.Fatalf("expected unsupported install.ps1 error, got %v", err)
+	}
+
+	if downloadOnlyRan.Load() {
+		t.Fatal("install.ps1 cache-only phase should not run without support marker")
+	}
+	if getStagedInstallScript() != "" {
+		t.Fatal("unsupported install.ps1 should not remain staged")
+	}
+	if UpdateDownloaded {
+		t.Fatal("UpdateDownloaded should stay false when install.ps1 lacks cache-only support")
+	}
+}
+
+func TestDownloadNewReleaseDoesNotMarkDownloadedWhenCacheOnlyFails(t *testing.T) {
+	resetWindowsUpdaterState(t)
+
+	UpdateStageDir = t.TempDir()
+	UpdateDownloaded = false
+
+	verifyInstallScriptSignature = func(filename string) error {
+		return nil
+	}
+	runInstallScriptCacheOnly = func(ctx context.Context, scriptPath, cacheDir, version string) error {
+		return fmt.Errorf("download failed")
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v0.21.0/OllamaSetup.exe" && r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if r.URL.Path != "/v0.21.0/install.ps1" {
+			t.Errorf("unexpected request path %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("ETag", `"script-etag"`)
+		w.WriteHeader(http.StatusOK)
+		if r.Method == http.MethodGet {
+			_, _ = w.Write([]byte(`$CacheOnly = $env:OLLAMA_CACHE_ONLY -eq "1"`))
+		}
+	}))
+	defer server.Close()
+
+	updater := &Updater{}
+	err := updater.DownloadNewRelease(t.Context(), UpdateResponse{
+		UpdateURL:     server.URL + "/v0.21.0/OllamaSetup.exe",
+		UpdateVersion: "v0.21.0",
+	})
+	if err == nil || !strings.Contains(err.Error(), "download failed") {
+		t.Fatalf("expected download phase failure, got %v", err)
+	}
+	if UpdateDownloaded {
+		t.Fatal("UpdateDownloaded should remain false when cache-only fails")
+	}
+	if getStagedInstallScript() != "" {
+		t.Fatal("incomplete staged update should not be pending")
+	}
+	entries, err := os.ReadDir(UpdateStageDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("failed cache-only stage was not cleaned up: %v", entries)
+	}
+}
+
+func TestDownloadNewReleaseMarksReadyAfterCacheOnlySucceeds(t *testing.T) {
+	resetWindowsUpdaterState(t)
+
+	UpdateStageDir = t.TempDir()
+	UpdateDownloaded = false
+	t.Setenv("LOCALAPPDATA", t.TempDir())
+
+	verifyInstallScriptSignature = func(filename string) error {
+		return nil
+	}
+	runInstallScriptCacheOnly = func(ctx context.Context, scriptPath, cacheDir, version string) error {
+		return nil
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v0.21.0/install.ps1" {
+			t.Errorf("unexpected request path %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("ETag", `"script-etag"`)
+		w.WriteHeader(http.StatusOK)
+		if r.Method == http.MethodGet {
+			_, _ = w.Write([]byte(`$CacheOnly = $env:OLLAMA_CACHE_ONLY -eq "1"`))
+		}
+	}))
+	defer server.Close()
+
+	updater := &Updater{}
+	err := updater.DownloadNewRelease(t.Context(), UpdateResponse{
+		UpdateURL:     server.URL + "/v0.21.0/OllamaSetup.exe",
+		UpdateVersion: "v0.21.0",
+	})
+	if err != nil {
+		t.Fatalf("cache-only success should be enough for app readiness: %v", err)
+	}
+	if !UpdateDownloaded {
+		t.Fatal("UpdateDownloaded should be true after cache-only succeeds")
+	}
+	if getStagedInstallScript() == "" {
+		t.Fatal("staged install.ps1 should be ready after cache-only succeeds")
+	}
+}
+
+func TestIsUpdatePendingRequiresReadyInstallScript(t *testing.T) {
+	resetWindowsUpdaterState(t)
+
+	UpdateStageDir = t.TempDir()
+	stageDir := filepath.Join(UpdateStageDir, "etag")
+	if err := os.MkdirAll(stageDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	script := filepath.Join(stageDir, installScriptName)
+	if err := os.WriteFile(script, []byte("script"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if IsUpdatePending() {
+		t.Fatal("update should not be pending without a cache-ready marker")
+	}
+	markInstallScriptStageReady(t, script)
+	if !IsUpdatePending() {
+		t.Fatal("update should be pending with a staged script and cache-ready marker")
+	}
+}
+
+func TestDoUpgradeAtStartupRunsInstallScriptInstallCached(t *testing.T) {
+	resetWindowsUpdaterState(t)
+
+	t.Setenv("OLLAMA_CACHE_ONLY", "1")
+	t.Setenv("OLLAMA_DEBUG", "1")
+	t.Setenv("OLLAMA_INSTALL_CACHED", "1")
+	t.Setenv("OLLAMA_INSTALL_DIR", "C:\\bad")
+	t.Setenv("OLLAMA_UNINSTALL", "1")
+	t.Setenv("OLLAMA_VERSION", "bad-version")
+	t.Setenv("PSModulePath", "C:\\user-controlled")
+	t.Setenv("LOCALAPPDATA", t.TempDir())
+
+	UpdateStageDir = t.TempDir()
+	runDir := t.TempDir()
+	UpgradeLogFile = filepath.Join(runDir, "upgrade.log")
+	UpgradeMarkerFile = filepath.Join(runDir, "upgraded")
+	VerifyDownload = verifyDownload
+	verifyInstallScriptSignature = func(filename string) error {
+		return nil
+	}
+
+	script := stageInstallScript(t, "0.21.0")
+	markInstallScriptStageReady(t, script)
+	var recorded installScriptCommand
+	process := &fakeInstallScriptProcess{}
+	startInstallScriptInstall = func(command installScriptCommand) (installScriptProcess, error) {
+		recorded = command
+		return process, nil
+	}
+	var exitCode *int
+	exitAfterStartingUpgrade = func(code int) {
+		exitCode = &code
+	}
+
+	if err := DoUpgradeAtStartup(); err != nil {
+		t.Fatal(err)
+	}
+
+	if exitCode == nil || *exitCode != 0 {
+		t.Fatalf("exit code = %v, want 0", exitCode)
+	}
+	if !process.released.Load() {
+		t.Fatal("install script process was not released")
+	}
+	if recorded.Program != windowsPowerShellPath() {
+		t.Fatalf("program = %s", recorded.Program)
+	}
+	if strings.Join(recorded.Args, " ") != fmt.Sprintf("-NoProfile -ExecutionPolicy Bypass -File %s", script) {
+		t.Fatalf("unexpected args: %v", recorded.Args)
+	}
+	if recorded.Dir != filepath.Dir(script) {
+		t.Fatalf("dir = %s, want %s", recorded.Dir, filepath.Dir(script))
+	}
+	if recorded.CreationFlags&windowsCreateNoWindow == 0 {
+		t.Fatalf("creation flags = %#x, want CREATE_NO_WINDOW", recorded.CreationFlags)
+	}
+	if got, ok := envValue(recorded.Env, "OLLAMA_INSTALL_CACHED"); !ok || got != "1" {
+		t.Fatalf("OLLAMA_INSTALL_CACHED = %q, %v", got, ok)
+	}
+	if _, ok := envValue(recorded.Env, "OLLAMA_CACHE_ONLY"); ok {
+		t.Fatal("OLLAMA_CACHE_ONLY should not be passed to install-cached phase")
+	}
+	if _, ok := envValue(recorded.Env, "OLLAMA_DEBUG"); ok {
+		t.Fatal("OLLAMA_DEBUG should not be passed to install.ps1")
+	}
+	if _, ok := envValue(recorded.Env, "OLLAMA_INSTALL_DIR"); ok {
+		t.Fatal("OLLAMA_INSTALL_DIR should not be passed to install.ps1")
+	}
+	if _, ok := envValue(recorded.Env, "OLLAMA_UNINSTALL"); ok {
+		t.Fatal("OLLAMA_UNINSTALL should not be passed to install.ps1")
+	}
+	if _, ok := envValue(recorded.Env, "OLLAMA_VERSION"); ok {
+		t.Fatal("OLLAMA_VERSION should not be passed to install-cached phase")
+	}
+	modulePath, ok := envValue(recorded.Env, "PSModulePath")
+	if !ok {
+		t.Fatal("PSModulePath should be set for Windows PowerShell")
+	}
+	if strings.Contains(strings.ToLower(modulePath), "user-controlled") {
+		t.Fatalf("PSModulePath should not preserve ambient user-controlled paths: %s", modulePath)
+	}
+	if !strings.Contains(strings.ToLower(modulePath), "windowspowershell") {
+		t.Fatalf("PSModulePath = %s, want Windows PowerShell module path", modulePath)
+	}
+	if _, err := os.Stat(UpgradeMarkerFile); err != nil {
+		t.Fatalf("upgrade marker missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(filepath.Dir(script), stagedCacheReadyFile)); !os.IsNotExist(err) {
+		t.Fatalf("cache-ready marker should be consumed before launching install.ps1: %v", err)
+	}
+}
+
+func TestDoUpgradeAtStartupIgnoresInstallScriptWithoutCacheReady(t *testing.T) {
+	resetWindowsUpdaterState(t)
+
+	UpdateStageDir = t.TempDir()
+	t.Setenv("LOCALAPPDATA", t.TempDir())
+	UpgradeMarkerFile = filepath.Join(t.TempDir(), "upgraded")
+	VerifyDownload = verifyDownload
+	verifyInstallScriptSignature = func(filename string) error {
+		return nil
+	}
+	stageInstallScript(t, "")
+
+	startInstallScriptInstall = func(command installScriptCommand) (installScriptProcess, error) {
+		t.Fatal("installer should not start without cache-ready")
+		return nil, nil
+	}
+	exitAfterStartingUpgrade = func(code int) {
+		t.Fatalf("upgrade should not exit without cache-ready, got %d", code)
+	}
+
+	err := DoUpgradeAtStartup()
+	if err == nil || !strings.Contains(err.Error(), "failed to lookup downloads") {
+		t.Fatalf("expected incomplete staged update to be ignored, got %v", err)
+	}
+}
+
+func TestDoUpgradeAtStartupClearsCacheReadyWhenInstallScriptStartFails(t *testing.T) {
+	resetWindowsUpdaterState(t)
+
+	t.Setenv("LOCALAPPDATA", t.TempDir())
+	UpdateStageDir = t.TempDir()
+	runDir := t.TempDir()
+	UpgradeMarkerFile = filepath.Join(runDir, "upgraded")
+	VerifyDownload = verifyDownload
+	verifyInstallScriptSignature = func(filename string) error {
+		return nil
+	}
+
+	script := stageInstallScript(t, "0.21.0")
+	markInstallScriptStageReady(t, script)
+	startInstallScriptInstall = func(command installScriptCommand) (installScriptProcess, error) {
+		return nil, fmt.Errorf("start failed")
+	}
+	exitAfterStartingUpgrade = func(code int) {
+		t.Fatalf("upgrade should not exit when install.ps1 fails to start, got %d", code)
+	}
+
+	err := DoUpgradeAtStartup()
+	if err == nil || !strings.Contains(err.Error(), "unable to start install.ps1 upgrade") {
+		t.Fatalf("expected install.ps1 start failure, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(filepath.Dir(script), stagedCacheReadyFile)); !os.IsNotExist(err) {
+		t.Fatalf("cache-ready marker should be consumed after start failure: %v", err)
+	}
+	if _, err := os.Stat(UpgradeMarkerFile); !os.IsNotExist(err) {
+		t.Fatalf("upgrade marker should be removed after start failure: %v", err)
+	}
+	if IsUpdatePending() {
+		t.Fatal("failed install.ps1 launch should not stay pending without a refreshed cache")
+	}
+}
+
+func TestDoPostUpgradeCleanupRemovesStagedUpdateAndMarkers(t *testing.T) {
+	resetWindowsUpdaterState(t)
+
+	localAppData := t.TempDir()
+	t.Setenv("LOCALAPPDATA", localAppData)
+	UpdateStageDir = t.TempDir()
+	runDir := t.TempDir()
+	runningInstaller = filepath.Join(runDir, Installer)
+	UpgradeMarkerFile = filepath.Join(runDir, "upgraded")
+
+	script := stageInstallScript(t, "0.21.0")
+	markInstallScriptStageReady(t, script)
+	if err := os.WriteFile(runningInstaller, []byte("running"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(UpgradeMarkerFile), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(UpgradeMarkerFile, []byte("1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := DoPostUpgradeCleanup(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(script); !os.IsNotExist(err) {
+		t.Fatalf("staged install script was not removed: %v", err)
+	}
+	if _, err := os.Stat(UpgradeMarkerFile); !os.IsNotExist(err) {
+		t.Fatalf("upgrade marker was not removed: %v", err)
+	}
+	if _, err := os.Stat(runningInstaller); !os.IsNotExist(err) {
+		t.Fatalf("running installer was not removed: %v", err)
+	}
+}
+
+func TestDoPostUpgradeCleanupLogsInstallerFailure(t *testing.T) {
+	resetWindowsUpdaterState(t)
+
+	localAppData := t.TempDir()
+	t.Setenv("LOCALAPPDATA", localAppData)
+	UpdateStageDir = t.TempDir()
+	runDir := filepath.Join(localAppData, "Ollama")
+	runningInstaller = filepath.Join(runDir, Installer)
+	UpgradeLogFile = filepath.Join(runDir, "upgrade.log")
+	installScriptInstallerLogFile = filepath.Join(runDir, "OllamaSetup.log")
+	UpgradeMarkerFile = filepath.Join(runDir, "upgraded")
+
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(UpgradeMarkerFile, []byte("1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	markerTime := time.Now().Add(-2 * time.Minute)
+	if err := os.Chtimes(UpgradeMarkerFile, markerTime, markerTime); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(installScriptInstallerLogFile, []byte("Installation process failed."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var logs bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() {
+		slog.SetDefault(previousLogger)
+	})
+
+	if err := DoPostUpgradeCleanup(); err != nil {
+		t.Fatal(err)
+	}
+
+	logText := logs.String()
+	if !strings.Contains(logText, "Windows installer reported upgrade failure") {
+		t.Fatalf("expected installer failure warning, got logs:\n%s", logText)
+	}
+	if !strings.Contains(logText, installScriptInstallerLogFile) {
+		t.Fatalf("expected installer log path in warning, got logs:\n%s", logText)
+	}
+}
+
+func TestWindowsInstallerLogIndicatesFailureIgnoresStaleAndSuccessfulLogs(t *testing.T) {
+	resetWindowsUpdaterState(t)
+
+	logFile := filepath.Join(t.TempDir(), "OllamaSetup.log")
+	if err := os.WriteFile(logFile, []byte("Installation process succeeded."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	failed, err := windowsInstallerLogIndicatesFailure(logFile, time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if failed {
+		t.Fatal("successful installer log should not be reported as failure")
+	}
+
+	if err := os.WriteFile(logFile, []byte("Installation process failed."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	staleCutoff := time.Now().Add(2 * time.Minute)
+	failed, err = windowsInstallerLogIndicatesFailure(logFile, staleCutoff)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if failed {
+		t.Fatal("stale installer log should not be reported as failure")
 	}
 }
 
 func TestIsInstallerRunning(t *testing.T) {
+	resetWindowsUpdaterState(t)
+
 	oldInstaller := Installer
 	defer func() {
 		Installer = oldInstaller

--- a/app/updater/updater_windows_test.go
+++ b/app/updater/updater_windows_test.go
@@ -3,28 +3,226 @@
 package updater
 
 import (
+	"bytes"
+	"context"
+	"fmt"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
-func TestVerifyDownloadRejectsUnsignedWindowsInstaller(t *testing.T) {
+type fakeInstallScriptProcess struct {
+	released atomic.Bool
+}
+
+func (p *fakeInstallScriptProcess) Release() error {
+	p.released.Store(true)
+	return nil
+}
+
+func resetWindowsUpdaterState(t *testing.T) {
+	t.Helper()
+
 	oldUpdateStageDir := UpdateStageDir
-	defer func() {
+	oldRunningInstaller := runningInstaller
+	oldUpgradeLogFile := UpgradeLogFile
+	oldInstallScriptInstallerLogFile := installScriptInstallerLogFile
+	oldUpgradeMarkerFile := UpgradeMarkerFile
+	oldVerifyDownload := VerifyDownload
+	oldVerifyInstallScriptSignature := verifyInstallScriptSignature
+	oldRunInstallScriptCacheOnly := runInstallScriptCacheOnly
+	oldStartInstallScriptInstall := startInstallScriptInstall
+	oldExitAfterStartingUpgrade := exitAfterStartingUpgrade
+	oldUpdateDownloaded := UpdateDownloaded
+	t.Cleanup(func() {
 		UpdateStageDir = oldUpdateStageDir
-	}()
+		runningInstaller = oldRunningInstaller
+		UpgradeLogFile = oldUpgradeLogFile
+		installScriptInstallerLogFile = oldInstallScriptInstallerLogFile
+		UpgradeMarkerFile = oldUpgradeMarkerFile
+		VerifyDownload = oldVerifyDownload
+		verifyInstallScriptSignature = oldVerifyInstallScriptSignature
+		runInstallScriptCacheOnly = oldRunInstallScriptCacheOnly
+		startInstallScriptInstall = oldStartInstallScriptInstall
+		exitAfterStartingUpgrade = oldExitAfterStartingUpgrade
+		UpdateDownloaded = oldUpdateDownloaded
+	})
+}
+
+func stageInstallScript(t *testing.T, version string) string {
+	t.Helper()
+	return stageInstallScriptBody(t, version, `$CacheOnly = $env:OLLAMA_CACHE_ONLY -eq "1"`)
+}
+
+func stageInstallScriptBody(t *testing.T, _ string, body string) string {
+	t.Helper()
+
+	stageDir := filepath.Join(UpdateStageDir, "etag")
+	if err := os.MkdirAll(stageDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	script := filepath.Join(stageDir, installScriptName)
+	if err := os.WriteFile(script, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return script
+}
+
+func markInstallScriptStageReady(t *testing.T, script string) {
+	t.Helper()
+	if err := writeInstallScriptStageReady(filepath.Dir(script)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func envValue(env []string, key string) (string, bool) {
+	prefix := strings.ToUpper(key) + "="
+	for _, entry := range env {
+		if strings.HasPrefix(strings.ToUpper(entry), prefix) {
+			return entry[len(prefix):], true
+		}
+	}
+	return "", false
+}
+
+func TestWithWindowsPowerShellModulePathReplacesAmbientValue(t *testing.T) {
+	env := withWindowsPowerShellModulePath([]string{
+		"Path=C:\\Windows",
+		"PSModulePath=C:\\user-controlled",
+		"psmodulepath=C:\\also-user-controlled",
+	})
+
+	var count int
+	var modulePath string
+	for _, entry := range env {
+		key, value, ok := strings.Cut(entry, "=")
+		if ok && strings.EqualFold(key, "PSModulePath") {
+			count++
+			modulePath = value
+		}
+	}
+	if count != 1 {
+		t.Fatalf("PSModulePath entries = %d, want 1 in %v", count, env)
+	}
+	if strings.Contains(strings.ToLower(modulePath), "user-controlled") {
+		t.Fatalf("PSModulePath should not preserve ambient user-controlled paths: %s", modulePath)
+	}
+	lowerModulePath := strings.ToLower(modulePath)
+	if !strings.Contains(lowerModulePath, "windowspowershell") || !strings.Contains(lowerModulePath, "modules") {
+		t.Fatalf("PSModulePath = %s, want Windows PowerShell module path", modulePath)
+	}
+}
+
+func TestValidateWindowsPowerShellPathReportsMissingPath(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "powershell.exe")
+	err := validateWindowsPowerShellPath(missing)
+	if err == nil {
+		t.Fatal("expected missing Windows PowerShell path error")
+	}
+	if !strings.Contains(err.Error(), "Windows PowerShell not found") {
+		t.Fatalf("error = %q, want clear Windows PowerShell not found message", err)
+	}
+	if !strings.Contains(err.Error(), missing) {
+		t.Fatalf("error = %q, want missing path", err)
+	}
+}
+
+func TestValidateWindowsPowerShellPathRejectsDirectory(t *testing.T) {
+	dir := t.TempDir()
+	err := validateWindowsPowerShellPath(dir)
+	if err == nil {
+		t.Fatal("expected directory path error")
+	}
+	if !strings.Contains(err.Error(), "Windows PowerShell path is a directory") {
+		t.Fatalf("error = %q, want directory path message", err)
+	}
+}
+
+func TestPowerShellSignatureVerificationScriptEncodesTargetPath(t *testing.T) {
+	filename := `C:\Temp\install'; throw 'oops.ps1`
+	script := powerShellSignatureVerificationScript(filename)
+	if strings.Contains(script, filename) {
+		t.Fatalf("verification script should not contain the raw target path:\n%s", script)
+	}
+	if strings.Contains(script, "$args[0]") {
+		t.Fatalf("verification script should not depend on PowerShell argument binding:\n%s", script)
+	}
+	if !strings.Contains(script, "Get-AuthenticodeSignature -LiteralPath $target") {
+		t.Fatalf("verification script should use LiteralPath:\n%s", script)
+	}
+}
+
+func TestInstallScriptURLUsesUpdateDirectory(t *testing.T) {
+	got, err := installScriptURL(UpdateResponse{
+		UpdateURL: "https://example.com/releases/v0.21.0/OllamaSetup.exe?ignored=1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "https://example.com/releases/v0.21.0/install.ps1" {
+		t.Fatalf("install script URL = %s", got)
+	}
+}
+
+func TestInstallScriptURLAcceptsDirectInstallScriptURL(t *testing.T) {
+	updateResp := UpdateResponse{
+		UpdateURL:     "https://example.com/download/install.ps1",
+		UpdateVersion: "v0.21.0",
+	}
+	got, err := installScriptURL(updateResp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "https://example.com/download/install.ps1" {
+		t.Fatalf("install script URL = %s", got)
+	}
+	if version := normalizedUpdateVersion(updateResp); version != "0.21.0" {
+		t.Fatalf("version = %q, want 0.21.0", version)
+	}
+}
+
+func TestInstallScriptURLRejectsInvalidUpdateURLs(t *testing.T) {
+	for _, rawURL := range []string{
+		"",
+		"not-a-url",
+		"/download/OllamaSetup.exe",
+		"://missing-scheme",
+		"ftp://example.com/download/OllamaSetup.exe",
+		"https://user@example.com/download/OllamaSetup.exe",
+	} {
+		t.Run(rawURL, func(t *testing.T) {
+			if got, err := installScriptURL(UpdateResponse{UpdateURL: rawURL}); err == nil {
+				t.Fatalf("installScriptURL(%q) = %q, want error", rawURL, got)
+			}
+		})
+	}
+}
+
+func TestNormalizedUpdateVersionDoesNotInferFromURL(t *testing.T) {
+	updateResp := UpdateResponse{
+		UpdateURL: "https://example.com/releases/download/v0.24.0/OllamaSetup.exe",
+	}
+	if version := normalizedUpdateVersion(updateResp); version != "" {
+		t.Fatalf("version = %q, want empty when update response omits version", version)
+	}
+}
+
+func TestVerifyDownloadRejectsUnsignedInstallScript(t *testing.T) {
+	resetWindowsUpdaterState(t)
 
 	t.Setenv("LOCALAPPDATA", t.TempDir())
 	UpdateStageDir = t.TempDir()
-	bundle := filepath.Join(UpdateStageDir, "etag", "OllamaSetup.exe")
-	if err := os.MkdirAll(filepath.Dir(bundle), 0o755); err != nil {
-		t.Fatal(err)
+	verifyInstallScriptSignature = func(filename string) error {
+		return fmt.Errorf("signature verification failed")
 	}
-	if err := os.WriteFile(bundle, []byte("not a signed installer"), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	script := stageInstallScript(t, "")
+	markInstallScriptStageReady(t, script)
 
 	err := verifyDownload()
 	if err == nil || !strings.Contains(err.Error(), "signature verification failed") {
@@ -32,19 +230,8 @@ func TestVerifyDownloadRejectsUnsignedWindowsInstaller(t *testing.T) {
 	}
 }
 
-func TestDoUpgradeAtStartupRejectsUnsignedWindowsInstaller(t *testing.T) {
-	oldUpdateStageDir := UpdateStageDir
-	oldRunningInstaller := runningInstaller
-	oldUpgradeLogFile := UpgradeLogFile
-	oldUpgradeMarkerFile := UpgradeMarkerFile
-	oldVerifyDownload := VerifyDownload
-	defer func() {
-		UpdateStageDir = oldUpdateStageDir
-		runningInstaller = oldRunningInstaller
-		UpgradeLogFile = oldUpgradeLogFile
-		UpgradeMarkerFile = oldUpgradeMarkerFile
-		VerifyDownload = oldVerifyDownload
-	}()
+func TestDoUpgradeAtStartupRejectsUnsignedInstallScript(t *testing.T) {
+	resetWindowsUpdaterState(t)
 
 	t.Setenv("LOCALAPPDATA", t.TempDir())
 	UpdateStageDir = t.TempDir()
@@ -53,28 +240,850 @@ func TestDoUpgradeAtStartupRejectsUnsignedWindowsInstaller(t *testing.T) {
 	UpgradeLogFile = filepath.Join(runDir, "upgrade.log")
 	UpgradeMarkerFile = filepath.Join(runDir, "upgraded")
 	VerifyDownload = verifyDownload
-
-	bundle := filepath.Join(UpdateStageDir, "etag", "OllamaSetup.exe")
-	if err := os.MkdirAll(filepath.Dir(bundle), 0o755); err != nil {
-		t.Fatal(err)
+	verifyInstallScriptSignature = func(filename string) error {
+		return fmt.Errorf("signature verification failed")
 	}
-	if err := os.WriteFile(bundle, []byte("not a signed installer"), 0o755); err != nil {
-		t.Fatal(err)
+
+	script := stageInstallScript(t, "")
+	markInstallScriptStageReady(t, script)
+	startInstallScriptInstall = func(command installScriptCommand) (installScriptProcess, error) {
+		t.Fatal("installer should not start after signature verification fails")
+		return nil, nil
 	}
 
 	err := DoUpgradeAtStartup()
 	if err == nil || !strings.Contains(err.Error(), "signature verification failed") {
 		t.Fatalf("expected signature verification failure, got %v", err)
 	}
-	if _, err := os.Stat(runningInstaller); !os.IsNotExist(err) {
-		t.Fatalf("unsigned installer was moved before verification failed: %v", err)
+	if _, err := os.Stat(script); !os.IsNotExist(err) {
+		t.Fatalf("unsigned staged install script was not removed after verification failure: %v", err)
 	}
-	if _, err := os.Stat(bundle); !os.IsNotExist(err) {
-		t.Fatalf("unsigned staged installer was not removed after verification failure: %v", err)
+}
+
+func TestVerifyDownloadRejectsInstallScriptWithoutCacheOnlySupport(t *testing.T) {
+	resetWindowsUpdaterState(t)
+
+	t.Setenv("LOCALAPPDATA", t.TempDir())
+	UpdateStageDir = t.TempDir()
+	VerifyDownload = verifyDownload
+	verifyInstallScriptSignature = func(filename string) error {
+		return nil
+	}
+	script := stageInstallScriptBody(t, "0.21.0", "# signed old install.ps1")
+	markInstallScriptStageReady(t, script)
+
+	err := VerifyDownload()
+	if err == nil || !strings.Contains(err.Error(), "does not support cache-only mode") {
+		t.Fatalf("expected cache-only support failure, got %v", err)
+	}
+}
+
+func TestDownloadNewReleaseCleansStagedScriptWhenSignatureFails(t *testing.T) {
+	resetWindowsUpdaterState(t)
+
+	UpdateStageDir = t.TempDir()
+	UpdateDownloaded = false
+	t.Setenv("LOCALAPPDATA", t.TempDir())
+
+	verifyInstallScriptSignature = func(filename string) error {
+		if filepath.Base(filename) != installScriptName {
+			t.Fatalf("expected to verify install.ps1, got %s", filename)
+		}
+		return fmt.Errorf("bad signature")
+	}
+	runInstallScriptCacheOnly = func(ctx context.Context, scriptPath, cacheDir, version string) error {
+		t.Fatal("cache-only phase should not run after signature failure")
+		return nil
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v0.21.0/install.ps1" {
+			t.Errorf("unexpected request path %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("ETag", `"script-etag"`)
+		w.WriteHeader(http.StatusOK)
+		if r.Method == http.MethodGet {
+			_, _ = w.Write([]byte(`$CacheOnly = $env:OLLAMA_CACHE_ONLY -eq "1"`))
+		}
+	}))
+	defer server.Close()
+
+	updater := &Updater{}
+	err := updater.DownloadNewRelease(t.Context(), UpdateResponse{
+		UpdateURL:     server.URL + "/v0.21.0/OllamaSetup.exe",
+		UpdateVersion: "v0.21.0",
+	})
+	if err == nil || !strings.Contains(err.Error(), "install.ps1 signature verification failed") {
+		t.Fatalf("expected signature verification failure, got %v", err)
+	}
+	if UpdateDownloaded {
+		t.Fatal("UpdateDownloaded should remain false after signature failure")
+	}
+	entries, err := os.ReadDir(UpdateStageDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("staged script cache was not cleaned up: %v", entries)
+	}
+}
+
+func TestDownloadNewReleaseDoesNotStagePartialInstallScript(t *testing.T) {
+	resetWindowsUpdaterState(t)
+
+	UpdateStageDir = t.TempDir()
+	UpdateDownloaded = false
+
+	verifyInstallScriptSignature = func(filename string) error {
+		t.Fatal("partial install.ps1 should not be verified")
+		return nil
+	}
+	runInstallScriptCacheOnly = func(ctx context.Context, scriptPath, cacheDir, version string) error {
+		t.Fatal("partial install.ps1 should not run")
+		return nil
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v0.21.0/install.ps1" {
+			t.Errorf("unexpected request path %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("ETag", `"script-etag"`)
+		switch r.Method {
+		case http.MethodHead:
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			w.Header().Set("Content-Length", "1024")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`$CacheOnly = $env:OLLAMA_CACHE_ONLY -eq "1"`))
+			if flusher, ok := w.(http.Flusher); ok {
+				flusher.Flush()
+			}
+		default:
+			t.Errorf("unexpected method %s", r.Method)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer server.Close()
+
+	updater := &Updater{}
+	err := updater.DownloadNewRelease(t.Context(), UpdateResponse{
+		UpdateURL:     server.URL + "/v0.21.0/OllamaSetup.exe",
+		UpdateVersion: "v0.21.0",
+	})
+	if err == nil {
+		t.Fatal("expected partial install.ps1 download to fail")
+	}
+	if UpdateDownloaded {
+		t.Fatal("UpdateDownloaded should remain false after a partial install.ps1 download")
+	}
+	if getStagedInstallScript() != "" {
+		t.Fatal("partial install.ps1 should not be considered pending")
+	}
+}
+
+func TestDownloadNewReleaseUsesCompletedCachedInstallScript(t *testing.T) {
+	resetWindowsUpdaterState(t)
+
+	UpdateStageDir = t.TempDir()
+	UpdateDownloaded = false
+	t.Setenv("LOCALAPPDATA", t.TempDir())
+
+	var getRequested atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v0.21.0/install.ps1" {
+			t.Errorf("unexpected request path %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("ETag", `"script-etag"`)
+		switch r.Method {
+		case http.MethodHead:
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			getRequested.Store(true)
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected method %s", r.Method)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer server.Close()
+
+	updateResp := UpdateResponse{
+		UpdateURL:     server.URL + "/v0.21.0/OllamaSetup.exe",
+		UpdateVersion: "v0.21.0",
+	}
+	stageKey := strings.Join([]string{
+		`"script-etag"`,
+		"0.21.0",
+		updateResp.UpdateURL,
+	}, "\n")
+	scriptPath, err := updateStagePath(UpdateStageDir, stageKey, installScriptName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cacheDir := filepath.Dir(scriptPath)
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(scriptPath, []byte(`$CacheOnly = $env:OLLAMA_CACHE_ONLY -eq "1"`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	markInstallScriptStageReady(t, scriptPath)
+
+	verifyInstallScriptSignature = func(filename string) error {
+		if filename != scriptPath {
+			t.Fatalf("verified script = %s, want %s", filename, scriptPath)
+		}
+		return nil
+	}
+	runInstallScriptCacheOnly = func(ctx context.Context, scriptPath, cacheDir, version string) error {
+		t.Fatal("cache-only phase should not rerun for completed cached update")
+		return nil
+	}
+
+	updater := &Updater{}
+	if err := updater.DownloadNewRelease(t.Context(), updateResp); err != nil {
+		t.Fatal(err)
+	}
+	if getRequested.Load() {
+		t.Fatal("completed cached install.ps1 should not be downloaded again")
+	}
+	if !UpdateDownloaded {
+		t.Fatal("UpdateDownloaded should be true for completed cached update")
+	}
+}
+
+func TestDownloadNewReleaseRerunsCacheOnlyForNewVersionWhenInstallScriptETagUnchanged(t *testing.T) {
+	resetWindowsUpdaterState(t)
+
+	UpdateStageDir = t.TempDir()
+	UpdateDownloaded = false
+	t.Setenv("LOCALAPPDATA", t.TempDir())
+	var scriptGetCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v0.22.0/install.ps1" {
+			t.Errorf("unexpected request path %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("ETag", `"same-script-etag"`)
+		switch r.Method {
+		case http.MethodHead:
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			scriptGetCount.Add(1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`$CacheOnly = $env:OLLAMA_CACHE_ONLY -eq "1"`))
+		default:
+			t.Errorf("unexpected method %s", r.Method)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer server.Close()
+
+	oldUpdateResp := UpdateResponse{
+		UpdateURL:     server.URL + "/v0.21.0/OllamaSetup.exe",
+		UpdateVersion: "v0.21.0",
+	}
+	oldStageKey := strings.Join([]string{
+		`"same-script-etag"`,
+		"0.21.0",
+		oldUpdateResp.UpdateURL,
+	}, "\n")
+	oldScriptPath, err := updateStagePath(UpdateStageDir, oldStageKey, installScriptName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(oldScriptPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(oldScriptPath, []byte(`$CacheOnly = $env:OLLAMA_CACHE_ONLY -eq "1"`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	markInstallScriptStageReady(t, oldScriptPath)
+
+	verifyInstallScriptSignature = func(filename string) error {
+		return nil
+	}
+	var cacheOnlyRuns atomic.Int32
+	var recordedVersion string
+	runInstallScriptCacheOnly = func(ctx context.Context, scriptPath, cacheDir, version string) error {
+		cacheOnlyRuns.Add(1)
+		recordedVersion = version
+		if scriptPath == oldScriptPath {
+			t.Fatal("new update should not reuse the old staged script path")
+		}
+		return nil
+	}
+
+	newUpdateResp := UpdateResponse{
+		UpdateURL:     server.URL + "/v0.22.0/OllamaSetup.exe",
+		UpdateVersion: "v0.22.0",
+	}
+	updater := &Updater{}
+	if err := updater.DownloadNewRelease(t.Context(), newUpdateResp); err != nil {
+		t.Fatal(err)
+	}
+
+	if scriptGetCount.Load() != 1 {
+		t.Fatalf("expected install.ps1 to be staged for the new target, got %d GETs", scriptGetCount.Load())
+	}
+	if cacheOnlyRuns.Load() != 1 {
+		t.Fatalf("cache-only should rerun for the new target even with an existing payload, got %d", cacheOnlyRuns.Load())
+	}
+	if recordedVersion != "0.22.0" {
+		t.Fatalf("version = %q, want 0.22.0", recordedVersion)
+	}
+	if !UpdateDownloaded {
+		t.Fatal("UpdateDownloaded should be true after recaching the newer target")
+	}
+	if _, err := os.Stat(oldScriptPath); !os.IsNotExist(err) {
+		t.Fatalf("old staged script should be removed before recaching newer target: %v", err)
+	}
+}
+
+func TestDownloadNewReleaseStagesInstallScriptAndRunsCacheOnly(t *testing.T) {
+	resetWindowsUpdaterState(t)
+
+	UpdateStageDir = t.TempDir()
+	UpdateDownloaded = false
+	t.Setenv("LOCALAPPDATA", t.TempDir())
+	var exeGetRequested atomic.Bool
+	var scriptHeadCount atomic.Int32
+	var scriptGetCount atomic.Int32
+	var recordedScript string
+	var recordedCache string
+	var recordedVersion string
+	verifyInstallScriptSignature = func(filename string) error {
+		if filepath.Base(filename) != installScriptName {
+			t.Fatalf("expected to verify install.ps1, got %s", filename)
+		}
+		return nil
+	}
+	runInstallScriptCacheOnly = func(ctx context.Context, scriptPath, cacheDir, version string) error {
+		recordedScript = scriptPath
+		recordedCache = cacheDir
+		recordedVersion = version
+		return nil
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v0.21.0/install.ps1":
+			w.Header().Set("ETag", `"script-etag"`)
+			switch r.Method {
+			case http.MethodHead:
+				scriptHeadCount.Add(1)
+				w.WriteHeader(http.StatusOK)
+			case http.MethodGet:
+				scriptGetCount.Add(1)
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`$CacheOnly = $env:OLLAMA_CACHE_ONLY -eq "1"`))
+			default:
+				t.Errorf("unexpected method %s", r.Method)
+				w.WriteHeader(http.StatusMethodNotAllowed)
+			}
+		case "/v0.21.0/OllamaSetup.exe":
+			w.Header().Set("ETag", `"exe-etag"`)
+			switch r.Method {
+			case http.MethodHead:
+				t.Errorf("app should let install.ps1 check the installer ETag")
+				w.WriteHeader(http.StatusMethodNotAllowed)
+			case http.MethodGet:
+				exeGetRequested.Store(true)
+				w.WriteHeader(http.StatusOK)
+			default:
+				t.Errorf("unexpected method %s", r.Method)
+				w.WriteHeader(http.StatusMethodNotAllowed)
+			}
+		default:
+			t.Errorf("unexpected request path %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	updater := &Updater{}
+	err := updater.DownloadNewRelease(t.Context(), UpdateResponse{
+		UpdateURL:     server.URL + "/v0.21.0/OllamaSetup.exe",
+		UpdateVersion: "v0.21.0",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if exeGetRequested.Load() {
+		t.Fatal("app cache phase should let install.ps1 download OllamaSetup.exe")
+	}
+	if scriptHeadCount.Load() != 1 || scriptGetCount.Load() != 1 {
+		t.Fatalf("expected one HEAD and one GET for install.ps1, got HEAD=%d GET=%d", scriptHeadCount.Load(), scriptGetCount.Load())
+	}
+	if recordedScript == "" || filepath.Base(recordedScript) != installScriptName {
+		t.Fatalf("cache-only script not recorded correctly: %s", recordedScript)
+	}
+	if recordedCache != filepath.Dir(recordedScript) {
+		t.Fatalf("cache dir = %s, want %s", recordedCache, filepath.Dir(recordedScript))
+	}
+	if recordedVersion != "0.21.0" {
+		t.Fatalf("version = %q, want 0.21.0", recordedVersion)
+	}
+	if _, err := os.Stat(filepath.Join(recordedCache, installScriptName)); err != nil {
+		t.Fatalf("final install.ps1 missing after cache-only success: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(recordedCache, stagedCacheReadyFile)); err != nil {
+		t.Fatalf("cache-ready marker missing after cache-only success: %v", err)
+	}
+	if !UpdateDownloaded {
+		t.Fatal("UpdateDownloaded should be true after staged script download succeeds")
+	}
+}
+
+func TestDownloadNewReleaseRejectsInstallScriptWithoutCacheOnlySupport(t *testing.T) {
+	resetWindowsUpdaterState(t)
+
+	UpdateStageDir = t.TempDir()
+	UpdateDownloaded = false
+
+	var downloadOnlyRan atomic.Bool
+	verifyInstallScriptSignature = func(filename string) error {
+		if filepath.Base(filename) != installScriptName {
+			t.Fatalf("expected to verify install.ps1, got %s", filename)
+		}
+		return nil
+	}
+	runInstallScriptCacheOnly = func(ctx context.Context, scriptPath, cacheDir, version string) error {
+		downloadOnlyRan.Store(true)
+		return nil
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v0.21.0/install.ps1":
+			w.Header().Set("ETag", `"old-script-etag"`)
+			w.WriteHeader(http.StatusOK)
+			if r.Method == http.MethodGet {
+				_, _ = w.Write([]byte("# signed old install.ps1"))
+			}
+		default:
+			t.Errorf("unexpected request path %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	updater := &Updater{}
+	err := updater.DownloadNewRelease(t.Context(), UpdateResponse{
+		UpdateURL:     server.URL + "/v0.21.0/OllamaSetup.exe",
+		UpdateVersion: "v0.21.0",
+	})
+	if err == nil || !strings.Contains(err.Error(), "install.ps1 does not support cache-only mode") {
+		t.Fatalf("expected unsupported install.ps1 error, got %v", err)
+	}
+
+	if downloadOnlyRan.Load() {
+		t.Fatal("install.ps1 cache-only phase should not run without support marker")
+	}
+	if getStagedInstallScript() != "" {
+		t.Fatal("unsupported install.ps1 should not remain staged")
+	}
+	if UpdateDownloaded {
+		t.Fatal("UpdateDownloaded should stay false when install.ps1 lacks cache-only support")
+	}
+}
+
+func TestDownloadNewReleaseDoesNotMarkDownloadedWhenCacheOnlyFails(t *testing.T) {
+	resetWindowsUpdaterState(t)
+
+	UpdateStageDir = t.TempDir()
+	UpdateDownloaded = false
+
+	verifyInstallScriptSignature = func(filename string) error {
+		return nil
+	}
+	runInstallScriptCacheOnly = func(ctx context.Context, scriptPath, cacheDir, version string) error {
+		return fmt.Errorf("download failed")
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v0.21.0/OllamaSetup.exe" && r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if r.URL.Path != "/v0.21.0/install.ps1" {
+			t.Errorf("unexpected request path %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("ETag", `"script-etag"`)
+		w.WriteHeader(http.StatusOK)
+		if r.Method == http.MethodGet {
+			_, _ = w.Write([]byte(`$CacheOnly = $env:OLLAMA_CACHE_ONLY -eq "1"`))
+		}
+	}))
+	defer server.Close()
+
+	updater := &Updater{}
+	err := updater.DownloadNewRelease(t.Context(), UpdateResponse{
+		UpdateURL:     server.URL + "/v0.21.0/OllamaSetup.exe",
+		UpdateVersion: "v0.21.0",
+	})
+	if err == nil || !strings.Contains(err.Error(), "download failed") {
+		t.Fatalf("expected download phase failure, got %v", err)
+	}
+	if UpdateDownloaded {
+		t.Fatal("UpdateDownloaded should remain false when cache-only fails")
+	}
+	if getStagedInstallScript() != "" {
+		t.Fatal("incomplete staged update should not be pending")
+	}
+	entries, err := os.ReadDir(UpdateStageDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("failed cache-only stage was not cleaned up: %v", entries)
+	}
+}
+
+func TestDownloadNewReleaseMarksReadyAfterCacheOnlySucceeds(t *testing.T) {
+	resetWindowsUpdaterState(t)
+
+	UpdateStageDir = t.TempDir()
+	UpdateDownloaded = false
+	t.Setenv("LOCALAPPDATA", t.TempDir())
+
+	verifyInstallScriptSignature = func(filename string) error {
+		return nil
+	}
+	runInstallScriptCacheOnly = func(ctx context.Context, scriptPath, cacheDir, version string) error {
+		return nil
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v0.21.0/install.ps1" {
+			t.Errorf("unexpected request path %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("ETag", `"script-etag"`)
+		w.WriteHeader(http.StatusOK)
+		if r.Method == http.MethodGet {
+			_, _ = w.Write([]byte(`$CacheOnly = $env:OLLAMA_CACHE_ONLY -eq "1"`))
+		}
+	}))
+	defer server.Close()
+
+	updater := &Updater{}
+	err := updater.DownloadNewRelease(t.Context(), UpdateResponse{
+		UpdateURL:     server.URL + "/v0.21.0/OllamaSetup.exe",
+		UpdateVersion: "v0.21.0",
+	})
+	if err != nil {
+		t.Fatalf("cache-only success should be enough for app readiness: %v", err)
+	}
+	if !UpdateDownloaded {
+		t.Fatal("UpdateDownloaded should be true after cache-only succeeds")
+	}
+	if getStagedInstallScript() == "" {
+		t.Fatal("staged install.ps1 should be ready after cache-only succeeds")
+	}
+}
+
+func TestIsUpdatePendingRequiresReadyInstallScript(t *testing.T) {
+	resetWindowsUpdaterState(t)
+
+	UpdateStageDir = t.TempDir()
+	stageDir := filepath.Join(UpdateStageDir, "etag")
+	if err := os.MkdirAll(stageDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	script := filepath.Join(stageDir, installScriptName)
+	if err := os.WriteFile(script, []byte("script"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if IsUpdatePending() {
+		t.Fatal("update should not be pending without a cache-ready marker")
+	}
+	markInstallScriptStageReady(t, script)
+	if !IsUpdatePending() {
+		t.Fatal("update should be pending with a staged script and cache-ready marker")
+	}
+}
+
+func TestDoUpgradeAtStartupRunsInstallScriptInstallCached(t *testing.T) {
+	resetWindowsUpdaterState(t)
+
+	t.Setenv("OLLAMA_CACHE_ONLY", "1")
+	t.Setenv("OLLAMA_DEBUG", "1")
+	t.Setenv("OLLAMA_INSTALL_CACHED", "1")
+	t.Setenv("OLLAMA_INSTALL_DIR", "C:\\bad")
+	t.Setenv("OLLAMA_UNINSTALL", "1")
+	t.Setenv("OLLAMA_VERSION", "bad-version")
+	t.Setenv("PSModulePath", "C:\\user-controlled")
+	t.Setenv("LOCALAPPDATA", t.TempDir())
+
+	UpdateStageDir = t.TempDir()
+	runDir := t.TempDir()
+	UpgradeLogFile = filepath.Join(runDir, "upgrade.log")
+	UpgradeMarkerFile = filepath.Join(runDir, "upgraded")
+	VerifyDownload = verifyDownload
+	verifyInstallScriptSignature = func(filename string) error {
+		return nil
+	}
+
+	script := stageInstallScript(t, "0.21.0")
+	markInstallScriptStageReady(t, script)
+	var recorded installScriptCommand
+	process := &fakeInstallScriptProcess{}
+	startInstallScriptInstall = func(command installScriptCommand) (installScriptProcess, error) {
+		recorded = command
+		return process, nil
+	}
+	var exitCode *int
+	exitAfterStartingUpgrade = func(code int) {
+		exitCode = &code
+	}
+
+	if err := DoUpgradeAtStartup(); err != nil {
+		t.Fatal(err)
+	}
+
+	if exitCode == nil || *exitCode != 0 {
+		t.Fatalf("exit code = %v, want 0", exitCode)
+	}
+	if !process.released.Load() {
+		t.Fatal("install script process was not released")
+	}
+	if recorded.Program != windowsPowerShellPath() {
+		t.Fatalf("program = %s", recorded.Program)
+	}
+	if strings.Join(recorded.Args, " ") != fmt.Sprintf("-NoProfile -ExecutionPolicy %s -File %s", installScriptExecutionPolicy, script) {
+		t.Fatalf("unexpected args: %v", recorded.Args)
+	}
+	if recorded.Dir != filepath.Dir(script) {
+		t.Fatalf("dir = %s, want %s", recorded.Dir, filepath.Dir(script))
+	}
+	if recorded.CreationFlags&windowsCreateNoWindow == 0 {
+		t.Fatalf("creation flags = %#x, want CREATE_NO_WINDOW", recorded.CreationFlags)
+	}
+	if got, ok := envValue(recorded.Env, "OLLAMA_INSTALL_CACHED"); !ok || got != "1" {
+		t.Fatalf("OLLAMA_INSTALL_CACHED = %q, %v", got, ok)
+	}
+	if _, ok := envValue(recorded.Env, "OLLAMA_CACHE_ONLY"); ok {
+		t.Fatal("OLLAMA_CACHE_ONLY should not be passed to install-cached phase")
+	}
+	if _, ok := envValue(recorded.Env, "OLLAMA_DEBUG"); ok {
+		t.Fatal("OLLAMA_DEBUG should not be passed to install.ps1")
+	}
+	if _, ok := envValue(recorded.Env, "OLLAMA_INSTALL_DIR"); ok {
+		t.Fatal("OLLAMA_INSTALL_DIR should not be passed to install.ps1")
+	}
+	if _, ok := envValue(recorded.Env, "OLLAMA_UNINSTALL"); ok {
+		t.Fatal("OLLAMA_UNINSTALL should not be passed to install.ps1")
+	}
+	if _, ok := envValue(recorded.Env, "OLLAMA_VERSION"); ok {
+		t.Fatal("OLLAMA_VERSION should not be passed to install-cached phase")
+	}
+	modulePath, ok := envValue(recorded.Env, "PSModulePath")
+	if !ok {
+		t.Fatal("PSModulePath should be set for Windows PowerShell")
+	}
+	if strings.Contains(strings.ToLower(modulePath), "user-controlled") {
+		t.Fatalf("PSModulePath should not preserve ambient user-controlled paths: %s", modulePath)
+	}
+	if !strings.Contains(strings.ToLower(modulePath), "windowspowershell") {
+		t.Fatalf("PSModulePath = %s, want Windows PowerShell module path", modulePath)
+	}
+	if _, err := os.Stat(UpgradeMarkerFile); err != nil {
+		t.Fatalf("upgrade marker missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(filepath.Dir(script), stagedCacheReadyFile)); !os.IsNotExist(err) {
+		t.Fatalf("cache-ready marker should be consumed before launching install.ps1: %v", err)
+	}
+}
+
+func TestDoUpgradeAtStartupIgnoresInstallScriptWithoutCacheReady(t *testing.T) {
+	resetWindowsUpdaterState(t)
+
+	UpdateStageDir = t.TempDir()
+	t.Setenv("LOCALAPPDATA", t.TempDir())
+	UpgradeMarkerFile = filepath.Join(t.TempDir(), "upgraded")
+	VerifyDownload = verifyDownload
+	verifyInstallScriptSignature = func(filename string) error {
+		return nil
+	}
+	stageInstallScript(t, "")
+
+	startInstallScriptInstall = func(command installScriptCommand) (installScriptProcess, error) {
+		t.Fatal("installer should not start without cache-ready")
+		return nil, nil
+	}
+	exitAfterStartingUpgrade = func(code int) {
+		t.Fatalf("upgrade should not exit without cache-ready, got %d", code)
+	}
+
+	err := DoUpgradeAtStartup()
+	if err == nil || !strings.Contains(err.Error(), "failed to lookup downloads") {
+		t.Fatalf("expected incomplete staged update to be ignored, got %v", err)
+	}
+}
+
+func TestDoUpgradeAtStartupClearsCacheReadyWhenInstallScriptStartFails(t *testing.T) {
+	resetWindowsUpdaterState(t)
+
+	t.Setenv("LOCALAPPDATA", t.TempDir())
+	UpdateStageDir = t.TempDir()
+	runDir := t.TempDir()
+	UpgradeMarkerFile = filepath.Join(runDir, "upgraded")
+	VerifyDownload = verifyDownload
+	verifyInstallScriptSignature = func(filename string) error {
+		return nil
+	}
+
+	script := stageInstallScript(t, "0.21.0")
+	markInstallScriptStageReady(t, script)
+	startInstallScriptInstall = func(command installScriptCommand) (installScriptProcess, error) {
+		return nil, fmt.Errorf("start failed")
+	}
+	exitAfterStartingUpgrade = func(code int) {
+		t.Fatalf("upgrade should not exit when install.ps1 fails to start, got %d", code)
+	}
+
+	err := DoUpgradeAtStartup()
+	if err == nil || !strings.Contains(err.Error(), "unable to start install.ps1 upgrade") {
+		t.Fatalf("expected install.ps1 start failure, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(filepath.Dir(script), stagedCacheReadyFile)); !os.IsNotExist(err) {
+		t.Fatalf("cache-ready marker should be consumed after start failure: %v", err)
+	}
+	if _, err := os.Stat(UpgradeMarkerFile); !os.IsNotExist(err) {
+		t.Fatalf("upgrade marker should be removed after start failure: %v", err)
+	}
+	if IsUpdatePending() {
+		t.Fatal("failed install.ps1 launch should not stay pending without a refreshed cache")
+	}
+}
+
+func TestDoPostUpgradeCleanupRemovesStagedUpdateAndMarkers(t *testing.T) {
+	resetWindowsUpdaterState(t)
+
+	localAppData := t.TempDir()
+	t.Setenv("LOCALAPPDATA", localAppData)
+	UpdateStageDir = t.TempDir()
+	runDir := t.TempDir()
+	runningInstaller = filepath.Join(runDir, Installer)
+	UpgradeMarkerFile = filepath.Join(runDir, "upgraded")
+
+	script := stageInstallScript(t, "0.21.0")
+	markInstallScriptStageReady(t, script)
+	if err := os.WriteFile(runningInstaller, []byte("running"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(UpgradeMarkerFile), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(UpgradeMarkerFile, []byte("1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := DoPostUpgradeCleanup(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(script); !os.IsNotExist(err) {
+		t.Fatalf("staged install script was not removed: %v", err)
+	}
+	if _, err := os.Stat(UpgradeMarkerFile); !os.IsNotExist(err) {
+		t.Fatalf("upgrade marker was not removed: %v", err)
+	}
+	if _, err := os.Stat(runningInstaller); !os.IsNotExist(err) {
+		t.Fatalf("running installer was not removed: %v", err)
+	}
+}
+
+func TestDoPostUpgradeCleanupLogsInstallerFailure(t *testing.T) {
+	resetWindowsUpdaterState(t)
+
+	localAppData := t.TempDir()
+	t.Setenv("LOCALAPPDATA", localAppData)
+	UpdateStageDir = t.TempDir()
+	runDir := filepath.Join(localAppData, "Ollama")
+	runningInstaller = filepath.Join(runDir, Installer)
+	UpgradeLogFile = filepath.Join(runDir, "upgrade.log")
+	installScriptInstallerLogFile = filepath.Join(runDir, "OllamaSetup.log")
+	UpgradeMarkerFile = filepath.Join(runDir, "upgraded")
+
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(UpgradeMarkerFile, []byte("1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	markerTime := time.Now().Add(-2 * time.Minute)
+	if err := os.Chtimes(UpgradeMarkerFile, markerTime, markerTime); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(installScriptInstallerLogFile, []byte("Installation process failed."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var logs bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() {
+		slog.SetDefault(previousLogger)
+	})
+
+	if err := DoPostUpgradeCleanup(); err != nil {
+		t.Fatal(err)
+	}
+
+	logText := logs.String()
+	if !strings.Contains(logText, "Windows installer reported upgrade failure") {
+		t.Fatalf("expected installer failure warning, got logs:\n%s", logText)
+	}
+	if !strings.Contains(logText, installScriptInstallerLogFile) {
+		t.Fatalf("expected installer log path in warning, got logs:\n%s", logText)
+	}
+}
+
+func TestWindowsInstallerLogIndicatesFailureIgnoresStaleAndSuccessfulLogs(t *testing.T) {
+	resetWindowsUpdaterState(t)
+
+	logFile := filepath.Join(t.TempDir(), "OllamaSetup.log")
+	if err := os.WriteFile(logFile, []byte("Installation process succeeded."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	failed, err := windowsInstallerLogIndicatesFailure(logFile, time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if failed {
+		t.Fatal("successful installer log should not be reported as failure")
+	}
+
+	if err := os.WriteFile(logFile, []byte("Installation process failed."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	staleCutoff := time.Now().Add(2 * time.Minute)
+	failed, err = windowsInstallerLogIndicatesFailure(logFile, staleCutoff)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if failed {
+		t.Fatal("stale installer log should not be reported as failure")
 	}
 }
 
 func TestIsInstallerRunning(t *testing.T) {
+	resetWindowsUpdaterState(t)
+
 	oldInstaller := Installer
 	defer func() {
 		Installer = oldInstaller

--- a/app/updater/verify_install_script_unsigned_windows.go
+++ b/app/updater/verify_install_script_unsigned_windows.go
@@ -1,0 +1,12 @@
+//go:build windows && updater_unsigned
+
+package updater
+
+import "log/slog"
+
+func init() {
+	verifyInstallScriptSignature = func(filename string) error {
+		slog.Warn("install.ps1 signature verification disabled by updater_unsigned build tag", "script", filename)
+		return nil
+	}
+}

--- a/app/wintray/menus.go
+++ b/app/wintray/menus.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"unsafe"
 
@@ -76,7 +77,7 @@ func (t *winTray) UpdateAvailable(ver string) error {
 		t.muNID.Lock()
 		defer t.muNID.Unlock()
 		copy(t.nid.InfoTitle[:], windows.StringToUTF16(updateTitle))
-		copy(t.nid.Info[:], windows.StringToUTF16(fmt.Sprintf(updateMessage, ver)))
+		copy(t.nid.Info[:], windows.StringToUTF16(updateNotificationMessage(ver)))
 		t.nid.Flags |= NIF_INFO
 		t.nid.Timeout = 10
 		t.nid.Size = uint32(unsafe.Sizeof(*wt.nid))
@@ -86,6 +87,14 @@ func (t *winTray) UpdateAvailable(ver string) error {
 		}
 	}
 	return nil
+}
+
+func updateNotificationMessage(ver string) string {
+	ver = strings.TrimSpace(ver)
+	if ver == "" {
+		return updateMessageAny
+	}
+	return fmt.Sprintf(updateMessage, ver)
 }
 
 func (t *winTray) showLogs() error {

--- a/app/wintray/messages.go
+++ b/app/wintray/messages.go
@@ -7,6 +7,7 @@ const (
 	firstTimeMessage = "Click here to get started"
 	updateTitle      = "Update available"
 	updateMessage    = "Ollama version %s is ready to install"
+	updateMessageAny = "An Ollama update is ready to install"
 
 	quitMenuTitle            = "Quit Ollama"
 	updateAvailableMenuTitle = "An update is available"

--- a/app/wintray/messages_test.go
+++ b/app/wintray/messages_test.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package wintray
+
+import "testing"
+
+func TestUpdateNotificationMessage(t *testing.T) {
+	for _, tt := range []struct {
+		ver  string
+		want string
+	}{
+		{"0.32.15", "Ollama version 0.32.15 is ready to install"},
+		{"", "An Ollama update is ready to install"},
+		{" \t", "An Ollama update is ready to install"},
+	} {
+		if got := updateNotificationMessage(tt.ver); got != tt.want {
+			t.Fatalf("updateNotificationMessage(%q) = %q, want %q", tt.ver, got, tt.want)
+		}
+	}
+}

--- a/docs/windows.mdx
+++ b/docs/windows.mdx
@@ -24,16 +24,25 @@ Ollama uses unicode characters for progress indication, which may render as unkn
   discrete GPU index.
 </Note>
 
+## Install Ollama
+
+To install Ollama on Windows, run the install script from PowerShell:
+
+```powershell
+irm https://ollama.com/install.ps1 | iex
+```
+
 ## Filesystem Requirements
 
 The Ollama install does not require Administrator, and installs in your home directory by default. You'll need at least 4GB of space for the binary install. Once you've installed Ollama, you'll need additional space for storing the Large Language models, which can be tens to hundreds of GB in size. If your home directory doesn't have enough space, you can change where the binaries are installed, and where the models are stored.
 
 ### Changing Install Location
 
-To install the Ollama application in a location different than your home directory, start the installer with the following flag
+To install the Ollama application in a location different than your home directory, set `OLLAMA_INSTALL_DIR` before running the install script:
 
 ```powershell
-OllamaSetup.exe /DIR="d:\some\location"
+$env:OLLAMA_INSTALL_DIR = "D:\some\location"
+irm https://ollama.com/install.ps1 | iex
 ```
 
 ### Changing Model Location
@@ -80,11 +89,6 @@ The Ollama Windows installer registers an Uninstaller application. Under `Add or
 </Note>
 
 ## Standalone CLI
-
-The easiest way to install Ollama on Windows is to use the `OllamaSetup.exe`
-installer. It installs in your account without requiring Administrator rights.
-We update Ollama regularly to support the latest models, and this installer will
-help you keep up to date.
 
 If you'd like to install or integrate Ollama as a service, a standalone
 `ollama-windows-amd64.zip` zip file is available containing only the Ollama CLI

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -23,10 +23,12 @@
 
     Environment variables:
 
-        OLLAMA_VERSION       Target version (default: latest stable)
-        OLLAMA_INSTALL_DIR   Custom install directory
-        OLLAMA_UNINSTALL     Set to 1 to uninstall Ollama
-        OLLAMA_DEBUG         Enable verbose output
+        OLLAMA_VERSION         Target version (default: latest stable)
+        OLLAMA_INSTALL_DIR     Custom install directory
+        OLLAMA_UNINSTALL       Set to 1 to uninstall Ollama
+        OLLAMA_CACHE_ONLY      Set to 1 to download installer payloads without installing
+        OLLAMA_INSTALL_CACHED  Set to 1 to install from the Ollama installer cache without downloading
+        OLLAMA_DEBUG           Enable verbose output
 
 .EXAMPLE
     irm https://ollama.com/install.ps1 | iex
@@ -48,14 +50,145 @@ $ProgressPreference = "SilentlyContinue"
 $Version      = if ($env:OLLAMA_VERSION) { $env:OLLAMA_VERSION } else { "" }
 $InstallDir   = if ($env:OLLAMA_INSTALL_DIR) { $env:OLLAMA_INSTALL_DIR } else { "" }
 $Uninstall    = $env:OLLAMA_UNINSTALL -eq "1"
+$CacheOnly    = $env:OLLAMA_CACHE_ONLY -eq "1"
+$InstallCached = $env:OLLAMA_INSTALL_CACHED -eq "1"
 $DebugInstall = [bool]$env:OLLAMA_DEBUG
+
+if ($CacheOnly -and $InstallCached) {
+    throw "OLLAMA_CACHE_ONLY and OLLAMA_INSTALL_CACHED cannot both be set"
+}
+if ($Uninstall -and ($CacheOnly -or $InstallCached)) {
+    throw "OLLAMA_UNINSTALL cannot be combined with OLLAMA_CACHE_ONLY or OLLAMA_INSTALL_CACHED"
+}
+
+<#
+Returns a stable filesystem-safe cache key for an installer ETag.
+#>
+function Get-InstallerCacheKey {
+    param([string]$ETag)
+
+    $normalizedETag = $ETag.Trim().Trim('"')
+    if (-not $normalizedETag) {
+        throw "Installer ETag is required for installer cache"
+    }
+
+    $sha256 = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        $bytes = [System.Text.Encoding]::UTF8.GetBytes($normalizedETag)
+        $hash = $sha256.ComputeHash($bytes)
+        return -join ($hash | ForEach-Object { $_.ToString("x2") })
+    } finally {
+        $sha256.Dispose()
+    }
+}
+
+function Get-InstallerCacheRoot {
+    return Join-Path $env:LOCALAPPDATA "Ollama\install_cache"
+}
+
+function Get-TemporaryInstallerCacheRoot {
+    return Join-Path $env:TEMP "Ollama\install_cache"
+}
+
+function New-InstallerTarget {
+    param(
+        [string]$CacheRoot,
+        [string]$CacheDir,
+        [string]$ETag = "",
+        [bool]$ReplaceCacheRoot = $false
+    )
+
+    return [PSCustomObject]@{
+        Path             = (Join-Path $CacheDir "OllamaSetup.exe")
+        StagingPath      = (Join-Path "${CacheDir}.download" "OllamaSetup.exe")
+        CacheDir         = $CacheDir
+        StagingCacheDir  = "${CacheDir}.download"
+        CacheRoot        = $CacheRoot
+        ETag             = $ETag
+        ReplaceCacheRoot = $ReplaceCacheRoot
+    }
+}
+
+<#
+Removes a resolved installer cache entry after signature, ETag, or install failure.
+#>
+function Remove-InstallerCacheEntry {
+    param($Installer)
+
+    Remove-Item -LiteralPath $Installer.CacheDir -Recurse -Force -ErrorAction SilentlyContinue
+    if ($Installer.StagingCacheDir) {
+        Remove-Item -LiteralPath $Installer.StagingCacheDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+<#
+Resolves the installer URL into the exact local path this run should use.
+Cache-only mode uses the persistent cache. If ETags are unavailable, it refreshes the cache with a one-shot GUID entry.
+Normal installs fall back to a throwaway temp directory when ETags are unavailable.
+#>
+function Get-InstallerTarget {
+    param(
+        [string]$InstallerUrl,
+        [bool]$CacheOnlyMode = $false
+    )
+
+    $installerETag = Get-RemoteETag -Url $InstallerUrl
+    if ($installerETag) {
+        $cacheRoot = Get-InstallerCacheRoot
+        $cacheDir = Join-Path $cacheRoot (Get-InstallerCacheKey -ETag $installerETag)
+        $replaceCacheRoot = $true
+    } elseif ($CacheOnlyMode) {
+        Write-Status "  Installer ETag unavailable; refreshing installer cache without cache reuse."
+        $cacheRoot = Get-InstallerCacheRoot
+        $cacheDir = Join-Path $cacheRoot ([guid]::NewGuid().ToString("N"))
+        $replaceCacheRoot = $true
+    } else {
+        $cacheRoot = Get-TemporaryInstallerCacheRoot
+        $cacheDir = Join-Path $cacheRoot ([guid]::NewGuid().ToString("N"))
+        $replaceCacheRoot = $false
+    }
+
+    return New-InstallerTarget -CacheRoot $cacheRoot -CacheDir $cacheDir -ETag $installerETag -ReplaceCacheRoot $replaceCacheRoot
+}
+
+<#
+Finds the single completed installer cache entry for install-cached mode.
+#>
+function Get-CachedInstallerTarget {
+    $cacheRoot = Get-InstallerCacheRoot
+    if (-not (Test-Path -LiteralPath $cacheRoot)) {
+        throw "Cached installer not found in $cacheRoot"
+    }
+
+    $installers = @()
+    foreach ($entry in @(Get-ChildItem -LiteralPath $cacheRoot -Directory -ErrorAction SilentlyContinue)) {
+        if ($entry.Name.EndsWith(".download", [System.StringComparison]::OrdinalIgnoreCase)) {
+            continue
+        }
+        $candidate = Join-Path $entry.FullName "OllamaSetup.exe"
+        if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+            $installers += $candidate
+        }
+    }
+
+    if ($installers.Count -eq 0) {
+        throw "Cached installer not found in $cacheRoot"
+    }
+    if ($installers.Count -gt 1) {
+        # Cache-only replaces the cache root before staging a new installer, so
+        # multiple completed installers means the cache is stale or corrupt.
+        throw "Multiple cached installers found in $cacheRoot"
+    }
+
+    $cacheDir = Split-Path -Parent $installers[0]
+    return New-InstallerTarget -CacheRoot $cacheRoot -CacheDir $cacheDir
+}
 
 # --------------------------------------------------------------------------
 # Constants
 # --------------------------------------------------------------------------
 
-# OLLAMA_DOWNLOAD_URL for developer testing only
-$DownloadBaseURL = if ($env:OLLAMA_DOWNLOAD_URL) { $env:OLLAMA_DOWNLOAD_URL.TrimEnd('/') } else { "https://ollama.com/download" }
+$DownloadBaseURL = "https://ollama.com/download"
 $InnoSetupUninstallGuid = "{44E83376-CE68-45EB-8FC1-393500EB558C}_is1"
 
 # --------------------------------------------------------------------------
@@ -70,6 +203,51 @@ function Write-Status {
 function Write-Step {
     param([string]$Message)
     if ($DebugInstall) { Write-Host ">>> $Message" -ForegroundColor Cyan }
+}
+
+function Quote-ProcessArgument {
+    param([string]$Argument)
+
+    if ($null -eq $Argument -or $Argument.Length -eq 0) {
+        return '""'
+    }
+
+    # Quote args containing whitespace or a double quote: space, tab, LF, VT, FF, CR, or ".
+    $charsRequiringQuotes = @([char]32, [char]9, [char]10, [char]11, [char]12, [char]13, [char]34)
+    if ($Argument.IndexOfAny($charsRequiringQuotes) -lt 0) {
+        return $Argument
+    }
+
+    $quoted = [System.Text.StringBuilder]::new()
+    [void]$quoted.Append('"')
+    $backslashes = 0
+    foreach ($char in $Argument.ToCharArray()) {
+        if ($char -eq [char]92) {
+            $backslashes++
+            continue
+        }
+
+        if ($char -eq [char]34) {
+            if ($backslashes -gt 0) {
+                [void]$quoted.Append(('\' * ($backslashes * 2)))
+                $backslashes = 0
+            }
+            [void]$quoted.Append('\"')
+            continue
+        }
+
+        if ($backslashes -gt 0) {
+            [void]$quoted.Append(('\' * $backslashes))
+            $backslashes = 0
+        }
+        [void]$quoted.Append($char)
+    }
+
+    if ($backslashes -gt 0) {
+        [void]$quoted.Append(('\' * ($backslashes * 2)))
+    }
+    [void]$quoted.Append('"')
+    return $quoted.ToString()
 }
 
 function Test-Signature {
@@ -139,6 +317,7 @@ function Invoke-Download {
         $request = [System.Net.HttpWebRequest]::Create($Url)
         $request.AllowAutoRedirect = $true
         $response = $request.GetResponse()
+        $responseETag = $response.Headers["ETag"]
         $totalBytes = $response.ContentLength
         $stream = $response.GetResponseStream()
         $fileStream = [System.IO.FileStream]::new($OutFile, [System.IO.FileMode]::Create)
@@ -182,6 +361,7 @@ function Invoke-Download {
             $stream.Close()
             $response.Close()
         }
+        return $responseETag
     } catch {
         if ($_.Exception -is [System.Net.WebException]) {
             $webEx = [System.Net.WebException]$_.Exception
@@ -196,6 +376,25 @@ function Invoke-Download {
             }
         }
         throw "Download failed for ${Url}: $($_.Exception.Message)"
+    }
+}
+
+function Get-RemoteETag {
+    param([string]$Url)
+
+    try {
+        $request = [System.Net.HttpWebRequest]::Create($Url)
+        $request.AllowAutoRedirect = $true
+        $request.Method = "HEAD"
+        $response = $request.GetResponse()
+        try {
+            return $response.Headers["ETag"]
+        } finally {
+            $response.Close()
+        }
+    } catch {
+        Write-Status "  Unable to read remote ETag for ${Url}: $($_.Exception.Message)"
+        return ""
     }
 }
 
@@ -243,36 +442,157 @@ function Invoke-Uninstall {
 # Install
 # --------------------------------------------------------------------------
 
+<#
+Entry point for install behavior.
+Resolves the target, optionally populates the cache, then either returns for cache-only mode or runs the installer.
+#>
 function Invoke-Install {
-    # Determine installer URL
-    if ($Version) {
-        $installerUrl = "$DownloadBaseURL/OllamaSetup.exe?version=$Version"
+    $downloadedInstaller = $false
+    if ($InstallCached) {
+        $installer = Get-CachedInstallerTarget
     } else {
-        $installerUrl = "$DownloadBaseURL/OllamaSetup.exe"
+        # Determine installer URL
+        if ($Version) {
+            $installerUrl = "$DownloadBaseURL/OllamaSetup.exe?version=$Version"
+        } else {
+            $installerUrl = "$DownloadBaseURL/OllamaSetup.exe"
+        }
+
+        $installer = Get-InstallerTarget -InstallerUrl $installerUrl -CacheOnlyMode $CacheOnly
+        $downloadedInstaller = Prepare-InstallerPayload -Installer $installer -InstallerUrl $installerUrl
     }
 
-    # Download installer
-    Write-Step "Downloading Ollama"
-    if (-not $DebugInstall) {
+    if ($CacheOnly) {
+        if (-not $downloadedInstaller) {
+            Write-Step "Verifying signature"
+            if (-not $DebugInstall) {
+                Write-Host ">>> Verifying signature..."
+            }
+            if (-not (Test-Signature -FilePath $installer.Path)) {
+                Remove-InstallerCacheEntry -Installer $installer
+                throw "Installer signature verification failed"
+            }
+        }
+
+        if ($downloadedInstaller) {
+            Write-Host ""
+            if ($DebugInstall) {
+                Write-Host "Downloads complete. Installer cached in $($installer.CacheDir)"
+            } else {
+                Write-Host "Downloads complete."
+            }
+        } else {
+            if ($DebugInstall) {
+                Write-Host "Installer cache is current: $($installer.CacheDir)"
+            } else {
+                Write-Host "Installer cache is current."
+            }
+        }
+        return
+    }
+
+    Start-Installer -Installer $installer -SignatureVerifiedThisRun $downloadedInstaller
+}
+
+<#
+Ensures the resolved installer payload exists and is trusted.
+This may download the installer, reuse a warm cache, and validates the ETag/signature for new downloads before promotion.
+#>
+function Prepare-InstallerPayload {
+    param(
+        $Installer,
+        [string]$InstallerUrl
+    )
+
+    $cacheHasInstaller = Test-Path -LiteralPath $Installer.Path
+    $downloadedInstaller = $false
+    $downloadedInstallerETag = ""
+    $needsDownload = -not $cacheHasInstaller
+    if (-not $DebugInstall -and $needsDownload) {
         Write-Host ">>> Downloading Ollama for Windows..."
     }
+    if ($needsDownload) {
+        if ($Installer.ReplaceCacheRoot) {
+            Remove-Item -LiteralPath $Installer.CacheRoot -Recurse -Force -ErrorAction SilentlyContinue
+        } else {
+            Remove-InstallerCacheEntry -Installer $Installer
+        }
+        if (-not (Test-Path -LiteralPath $Installer.StagingCacheDir)) {
+            [System.IO.Directory]::CreateDirectory($Installer.StagingCacheDir) | Out-Null
+        }
 
-    $tempInstaller = Join-Path $env:TEMP "OllamaSetup.exe"
-    Invoke-Download -Url $installerUrl -OutFile $tempInstaller
-
-    # Verify signature
-    Write-Step "Verifying signature"
-    if (-not (Test-Signature -FilePath $tempInstaller)) {
-        Remove-Item $tempInstaller -Force -ErrorAction SilentlyContinue
-        throw "Installer signature verification failed"
+        Write-Step "Downloading Ollama"
+        try {
+            $downloadedInstallerETag = Invoke-Download -Url $InstallerUrl -OutFile $Installer.StagingPath
+        } catch {
+            Remove-InstallerCacheEntry -Installer $Installer
+            throw
+        }
+        $downloadedInstallerETag = if ($downloadedInstallerETag) { $downloadedInstallerETag.Trim() } else { "" }
+        $downloadedInstaller = $true
+    } else {
+        Write-Status "  Using cached installer: $($Installer.Path)"
     }
+
+    if ($downloadedInstaller) {
+        if ($Installer.ETag -and $downloadedInstallerETag -and ($downloadedInstallerETag -ne $Installer.ETag)) {
+            Remove-InstallerCacheEntry -Installer $Installer
+            throw "Downloaded installer ETag mismatch: expected $($Installer.ETag), found $downloadedInstallerETag"
+        }
+        Write-Step "Verifying signature"
+        if (-not $DebugInstall) {
+            Write-Host ">>> Verifying signature..."
+        }
+        if (-not (Test-Signature -FilePath $Installer.StagingPath)) {
+            Remove-InstallerCacheEntry -Installer $Installer
+            throw "Installer signature verification failed"
+        }
+        try {
+            Move-Item -LiteralPath $Installer.StagingCacheDir -Destination $Installer.CacheDir -ErrorAction Stop
+        } catch {
+            Remove-InstallerCacheEntry -Installer $Installer
+            throw "Failed to stage installer cache: $($_.Exception.Message)"
+        }
+    }
+    return $downloadedInstaller
+}
+
+<#
+Runs an already resolved installer payload.
+Cached installs recheck the signature immediately before launch; freshly downloaded installers verified by this same run do not need a second Authenticode pass.
+#>
+function Start-Installer {
+    param(
+        $Installer,
+        [bool]$SignatureVerifiedThisRun = $false
+    )
+
+    if (-not (Test-Path -LiteralPath $Installer.Path)) {
+        throw "Cached installer not found: $($Installer.Path)"
+    }
+
+    $markerDir = Join-Path $env:LOCALAPPDATA "Ollama"
+    $installerLog = Join-Path $markerDir "OllamaSetup.log"
 
     # Build installer arguments
-    $installerArgs = "/VERYSILENT /NORESTART /SUPPRESSMSGBOXES"
+    $installerArgs = @("/VERYSILENT", "/NORESTART", "/SUPPRESSMSGBOXES", "/LOG=$installerLog")
     if ($InstallDir) {
-        $installerArgs += " /DIR=`"$InstallDir`""
+        $installerArgs += "/DIR=$InstallDir"
     }
-    Write-Status "  Installer args: $installerArgs"
+    $installerArgumentList = (($installerArgs | ForEach-Object { Quote-ProcessArgument $_ }) -join " ")
+    Write-Status "  Installer args: $installerArgumentList"
+    Write-Status "  Installer log: $installerLog"
+
+    if (-not $SignatureVerifiedThisRun) {
+        Write-Step "Verifying signature"
+        if (-not $DebugInstall) {
+            Write-Host ">>> Verifying signature..."
+        }
+        if (-not (Test-Signature -FilePath $Installer.Path)) {
+            Remove-InstallerCacheEntry -Installer $Installer
+            throw "Installer signature verification failed before launch"
+        }
+    }
 
     # Run installer
     Write-Step "Installing Ollama"
@@ -282,7 +602,6 @@ function Invoke-Install {
 
     # Create upgrade marker so the app starts hidden
     # The app checks for this file on startup and removes it after
-    $markerDir = Join-Path $env:LOCALAPPDATA "Ollama"
     $markerFile = Join-Path $markerDir "upgraded"
     if (-not (Test-Path $markerDir)) {
         New-Item -ItemType Directory -Path $markerDir -Force | Out-Null
@@ -292,18 +611,18 @@ function Invoke-Install {
 
     # Start installer and wait for just the installer process (not children)
     # Using -Wait would wait for Ollama to exit too, which we don't want
-    $proc = Start-Process -FilePath $tempInstaller `
-        -ArgumentList $installerArgs `
+    $proc = Start-Process -FilePath $Installer.Path `
+        -ArgumentList $installerArgumentList `
         -PassThru
     $proc.WaitForExit()
 
     if ($proc.ExitCode -ne 0) {
-        Remove-Item $tempInstaller -Force -ErrorAction SilentlyContinue
-        throw "Installation failed with exit code $($proc.ExitCode)"
+        Remove-InstallerCacheEntry -Installer $Installer
+        throw "Installation failed with exit code $($proc.ExitCode). Installer log: $installerLog"
     }
 
     # Cleanup
-    Remove-Item $tempInstaller -Force -ErrorAction SilentlyContinue
+    Remove-InstallerCacheEntry -Installer $Installer
 
     # Update PATH in current session so 'ollama' works immediately
     Write-Step "Updating session PATH"
@@ -316,8 +635,10 @@ function Invoke-Install {
 # Main
 # --------------------------------------------------------------------------
 
-if ($Uninstall) {
-    Invoke-Uninstall
-} else {
-    Invoke-Install
+if ($MyInvocation.InvocationName -ne ".") {
+    if ($Uninstall) {
+        Invoke-Uninstall
+    } else {
+        Invoke-Install
+    }
 }

--- a/scripts/tests/install.Tests.ps1
+++ b/scripts/tests/install.Tests.ps1
@@ -1,0 +1,1196 @@
+<#
+.SYNOPSIS
+    Pester tests for the Windows install.ps1 script.
+
+.DESCRIPTION
+    IMPORTANT: Integration tests (Tag: Integration) install and uninstall
+    Ollama for real. Run them only on a machine where Ollama is not currently
+    installed; the tests abort if they detect an existing install.
+
+    Unit tests (Tag: Unit) are fast, mock downloads/signatures/process launch,
+    and do not touch the real install state.
+
+    Integration tests (Tag: Integration) use a signed dist\OllamaSetup.exe
+    when present. Otherwise, they download and cache the latest shipped
+    OllamaSetup.exe. They install Ollama for real, verify the installed state,
+    run a pinned-version upgrade from 0.21.0, and then run the real uninstaller.
+
+.EXAMPLE
+    Import-Module Pester -MinimumVersion 5.0
+    Invoke-Pester scripts\tests\install.Tests.ps1 -Tag Unit -Output Detailed
+
+.EXAMPLE
+    # Compatibility check: run unit tests under Windows PowerShell.
+    powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "Import-Module Pester -MinimumVersion 5.0; Invoke-Pester scripts\tests\install.Tests.ps1 -Tag Unit -Output Detailed"
+
+.EXAMPLE
+    # Destructive: requires no existing Ollama install.
+    Invoke-Pester scripts\tests\install.Tests.ps1 -Tag Integration -Output Detailed
+#>
+
+BeforeAll {
+    $script:RepoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+    $script:InstallScript = Join-Path $script:RepoRoot "scripts\install.ps1"
+    $script:UpdateServerScript = Join-Path $script:RepoRoot "scripts\tests\update-server.py"
+    $script:InstallerDownloadCacheDir = Join-Path $script:RepoRoot ".cache\install-tests"
+    $script:DistInstaller = Join-Path $script:RepoRoot "dist\OllamaSetup.exe"
+    $script:OriginalLocalAppData = [Environment]::GetEnvironmentVariable("LOCALAPPDATA", "Process")
+    $script:LatestInstallerUrl = "https://ollama.com/download/OllamaSetup.exe"
+    $script:PinnedUpgradeVersion = "0.21.0"
+    $script:PinnedUpgradeInstallerUrl = "https://github.com/ollama/ollama/releases/download/v$($script:PinnedUpgradeVersion)/OllamaSetup.exe"
+    $script:InnoSetupUninstallGuid = "{44E83376-CE68-45EB-8FC1-393500EB558C}_is1"
+    $script:EnvNames = @(
+        "OLLAMA_VERSION",
+        "OLLAMA_INSTALL_DIR",
+        "OLLAMA_UNINSTALL",
+        "OLLAMA_CACHE_ONLY",
+        "OLLAMA_INSTALL_CACHED",
+        "OLLAMA_DEBUG",
+        "LOCALAPPDATA",
+        "TEMP"
+    )
+
+    function Save-TestEnvironment {
+        $script:SavedEnv = @{}
+        foreach ($name in $script:EnvNames) {
+            $script:SavedEnv[$name] = [Environment]::GetEnvironmentVariable($name, "Process")
+            Remove-Item "Env:$name" -ErrorAction SilentlyContinue
+        }
+    }
+
+    function Restore-TestEnvironment {
+        foreach ($name in $script:EnvNames) {
+            Remove-Item "Env:$name" -ErrorAction SilentlyContinue
+            if ($null -ne $script:SavedEnv[$name]) {
+                Set-Item "Env:$name" $script:SavedEnv[$name]
+            }
+        }
+    }
+
+    function Set-TestProcessEnvironment {
+        $pathValue = [Environment]::GetEnvironmentVariable("Path", "Process")
+        if (-not $pathValue) {
+            $pathValue = [Environment]::GetEnvironmentVariable("PATH", "Process")
+        }
+
+        [Environment]::SetEnvironmentVariable("PATH", $null, "Process")
+        if ($pathValue) {
+            [Environment]::SetEnvironmentVariable("Path", $pathValue, "Process")
+        }
+    }
+
+    function Get-WindowsPowerShellModulePath {
+        $paths = @()
+        $documents = [Environment]::GetFolderPath("MyDocuments")
+        if ($documents) {
+            $paths += Join-Path $documents "WindowsPowerShell\Modules"
+        }
+        if ($env:ProgramFiles) {
+            $paths += Join-Path $env:ProgramFiles "WindowsPowerShell\Modules"
+        }
+        if ($env:SystemRoot) {
+            $paths += Join-Path $env:SystemRoot "system32\WindowsPowerShell\v1.0\Modules"
+        }
+        return ($paths -join ";")
+    }
+
+    function Set-TestEnvironment {
+        param(
+            [hashtable]$Values = @{}
+        )
+
+        $testRoot = Join-Path $TestDrive ([guid]::NewGuid().ToString("N"))
+        $localAppData = Join-Path $testRoot "LocalAppData"
+        $tempDir = Join-Path $testRoot "Temp"
+        New-Item -ItemType Directory -Path $localAppData, $tempDir -Force | Out-Null
+        Set-Item Env:LOCALAPPDATA $localAppData
+        Set-Item Env:TEMP $tempDir
+
+        foreach ($name in $Values.Keys) {
+            Set-Item "Env:$name" $Values[$name]
+        }
+    }
+
+    function New-FakeProcess {
+        $process = [PSCustomObject]@{ ExitCode = 0 }
+        $process | Add-Member -MemberType ScriptMethod -Name WaitForExit -Value { }
+        return $process
+    }
+
+    function Get-TestInstallerCacheDir {
+        param([string]$ETag)
+
+        $normalizedETag = $ETag.Trim().Trim('"')
+        $sha256 = [System.Security.Cryptography.SHA256]::Create()
+        try {
+            $bytes = [System.Text.Encoding]::UTF8.GetBytes($normalizedETag)
+            $hash = $sha256.ComputeHash($bytes)
+            $cacheKey = -join ($hash | ForEach-Object { $_.ToString("x2") })
+            return Join-Path $env:LOCALAPPDATA "Ollama\install_cache\$cacheKey"
+        } finally {
+            $sha256.Dispose()
+        }
+    }
+
+    function Get-TestInstallerStagingCacheDir {
+        param([string]$ETag)
+
+        return "$(Get-TestInstallerCacheDir $ETag).download"
+    }
+
+    function Get-TestInstallerStagingPath {
+        param([string]$ETag)
+
+        return Join-Path (Get-TestInstallerStagingCacheDir $ETag) "OllamaSetup.exe"
+    }
+
+    function New-TestInstallScript {
+        param([string]$DownloadBaseUrl)
+
+        $scriptPath = Join-Path $TestDrive ("install-" + [guid]::NewGuid().ToString("N") + ".ps1")
+        $content = Get-Content -LiteralPath $script:InstallScript -Raw
+        $replacement = '$DownloadBaseURL = "' + $DownloadBaseUrl.TrimEnd('/') + '"'
+        $content = $content.Replace('$DownloadBaseURL = "https://ollama.com/download"', $replacement)
+        Set-Content -LiteralPath $scriptPath -Value $content -Encoding UTF8
+        return $scriptPath
+    }
+
+    function Get-IntegrationInstaller {
+        if (Test-Path -LiteralPath $script:DistInstaller) {
+            $installer = (Resolve-Path -LiteralPath $script:DistInstaller).Path
+            try {
+                Assert-TestInstallerSignature -FilePath $installer
+                Write-Host "    Using signed dist installer: $installer" -ForegroundColor DarkGray
+                return $installer
+            } catch {
+                Write-Host "    Ignoring unsigned dist installer: $installer ($($_.Exception.Message))" -ForegroundColor DarkYellow
+            }
+        }
+
+        return Save-TestInstallerDownload -Url $script:LatestInstallerUrl -FileName "OllamaSetup-latest.exe"
+    }
+
+    function Get-PinnedUpgradeInstaller {
+        return Save-TestInstallerDownload -Url $script:PinnedUpgradeInstallerUrl -FileName "OllamaSetup-$($script:PinnedUpgradeVersion).exe"
+    }
+
+    function Save-TestInstallerDownload {
+        param(
+            [string]$Url,
+            [string]$FileName
+        )
+
+        New-Item -ItemType Directory -Path $script:InstallerDownloadCacheDir -Force | Out-Null
+        $installerPath = Join-Path $script:InstallerDownloadCacheDir $FileName
+        if (-not (Test-Path -LiteralPath $installerPath)) {
+            Write-Host "    Downloading $Url" -ForegroundColor DarkGray
+            $oldProgressPreference = $ProgressPreference
+            $ProgressPreference = "SilentlyContinue"
+            try {
+                Invoke-WebRequest -Uri $Url -OutFile $installerPath -UseBasicParsing
+            } finally {
+                $ProgressPreference = $oldProgressPreference
+            }
+        } else {
+            Write-Host "    Using cached installer: $installerPath" -ForegroundColor DarkGray
+        }
+        Assert-TestInstallerSignature -FilePath $installerPath
+        return $installerPath
+    }
+
+    function Assert-TestInstallerSignature {
+        param([string]$FilePath)
+
+        $sig = Get-AuthenticodeSignature -FilePath $FilePath
+        if ($sig.Status -ne "Valid") {
+            throw "Installer signature is not valid: $FilePath ($($sig.Status))"
+        }
+        $subject = $sig.SignerCertificate.Subject
+        if ($subject -notmatch "(^|, )O=Ollama Inc\.(,|$)") {
+            throw "Installer is not signed by Ollama Inc.: $subject"
+        }
+    }
+
+    function Get-TestPython {
+        foreach ($candidate in @("python.exe", "python")) {
+            $command = Get-Command $candidate -ErrorAction SilentlyContinue | Select-Object -First 1
+            if ($command) {
+                return $command.Source
+            }
+        }
+        return $null
+    }
+
+    function Get-FreeTcpPort {
+        $listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Parse("127.0.0.1"), 0)
+        try {
+            $listener.Start()
+            return $listener.LocalEndpoint.Port
+        } finally {
+            $listener.Stop()
+        }
+    }
+
+    function Wait-TestHttpServer {
+        param($Server)
+
+        $url = "$($Server.BaseUrl)/download/OllamaSetup.exe"
+        for ($i = 0; $i -lt 50; $i++) {
+            try {
+                Invoke-WebRequest -Uri $url -Method Head -UseBasicParsing -TimeoutSec 2 | Out-Null
+                return
+            } catch {
+                Start-Sleep -Milliseconds 100
+            }
+        }
+
+        $stderr = if ($Server.Process.HasExited) { $Server.Process.StandardError.ReadToEnd() } else { "" }
+        throw "Local HTTP server did not start. $stderr"
+    }
+
+    function Join-TestProcessArguments {
+        param([string[]]$Arguments)
+
+        return (($Arguments | ForEach-Object {
+            if ($null -eq $_ -or $_.Length -eq 0) {
+                '""'
+            } elseif ($_.IndexOfAny(@([char]32, [char]9, [char]34)) -lt 0) {
+                $_
+            } else {
+                '"' + ($_.Replace('\', '\\').Replace('"', '\"')) + '"'
+            }
+        }) -join " ")
+    }
+
+    function Start-LocalHttpServer {
+        param(
+            [string]$InstallerPath,
+            [string]$ETag = ""
+        )
+
+        $python = Get-TestPython
+        if (-not $python) {
+            Set-ItResult -Skipped -Because "Python is required to run local HTTP integration tests"
+            return $null
+        }
+
+        $port = Get-FreeTcpPort
+        $args = @(
+            $script:UpdateServerScript,
+            "--host", "127.0.0.1",
+            "--port", [string]$port,
+            "--installer", $InstallerPath,
+            "--install-script", $script:InstallScript
+        )
+        if ($ETag) {
+            $args += @("--installer-etag", $ETag)
+        }
+
+        $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+        $startInfo.FileName = $python
+        $startInfo.Arguments = Join-TestProcessArguments $args
+        $startInfo.WorkingDirectory = $script:RepoRoot
+        $startInfo.UseShellExecute = $false
+        $startInfo.CreateNoWindow = $true
+        $startInfo.RedirectStandardOutput = $true
+        $startInfo.RedirectStandardError = $true
+
+        $proc = [System.Diagnostics.Process]::new()
+        $proc.StartInfo = $startInfo
+        [void]$proc.Start()
+
+        $server = [PSCustomObject]@{
+            Process = $proc
+            BaseUrl = "http://127.0.0.1:$port"
+            DownloadBaseUrl = "http://127.0.0.1:$port/download"
+        }
+        Wait-TestHttpServer -Server $server
+        return $server
+    }
+
+    function Stop-LocalHttpServer {
+        param($Server)
+
+        if ($Server -and $Server.Process -and -not $Server.Process.HasExited) {
+            Stop-Process -Id $Server.Process.Id -Force -ErrorAction SilentlyContinue
+        }
+        if ($Server -and $Server.Process) {
+            $Server.Process.Dispose()
+        }
+    }
+
+    function Get-TestOllamaInstallDir {
+        param([switch]$UseOriginalLocalAppData)
+
+        if (-not $UseOriginalLocalAppData -and $env:OLLAMA_INSTALL_DIR) {
+            return $env:OLLAMA_INSTALL_DIR
+        }
+        $localAppData = if ($UseOriginalLocalAppData -or -not $env:LOCALAPPDATA) {
+            $script:OriginalLocalAppData
+        } else {
+            $env:LOCALAPPDATA
+        }
+        return Join-Path $localAppData "Programs\Ollama"
+    }
+
+    function Get-TestOllamaRegistryKey {
+        $possibleKeys = @(
+            "HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\$script:InnoSetupUninstallGuid",
+            "HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\$script:InnoSetupUninstallGuid",
+            "HKLM:\Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\$script:InnoSetupUninstallGuid"
+        )
+
+        foreach ($key in $possibleKeys) {
+            if (Test-Path $key) {
+                return $key
+            }
+        }
+        return $null
+    }
+
+    function Get-TestOllamaInstalledVersion {
+        param([string]$InstallDir)
+
+        $regKey = Get-TestOllamaRegistryKey
+        if ($regKey) {
+            $displayVersion = (Get-ItemProperty -Path $regKey).DisplayVersion
+            if ($displayVersion) {
+                return $displayVersion
+            }
+        }
+
+        $ollamaExe = Join-Path $InstallDir "ollama.exe"
+        if (Test-Path -LiteralPath $ollamaExe) {
+            try {
+                $output = & $ollamaExe --version 2>$null
+                $text = if ($output -is [array]) { $output -join "`n" } else { [string]$output }
+                if ($text -match "(\d+\.\d+\.\d+)") {
+                    return $matches[1]
+                }
+            } catch { }
+        }
+
+        return $null
+    }
+
+    function Test-OllamaRealInstallPresent {
+        $installDir = Get-TestOllamaInstallDir -UseOriginalLocalAppData
+        return [bool]((Get-TestOllamaRegistryKey) -or (Test-Path -LiteralPath (Join-Path $installDir "Ollama app.exe")))
+    }
+
+    function Stop-TestOllamaProcesses {
+        Get-Process -Name "ollama", "Ollama app" -ErrorAction SilentlyContinue |
+            Stop-Process -Force -ErrorAction SilentlyContinue
+    }
+
+    function Split-TestCommandLine {
+        param([string]$CommandLine)
+
+        if ($CommandLine -match '^\s*"([^"]+)"\s*(.*)$') {
+            return [PSCustomObject]@{ FilePath = $matches[1]; Arguments = $matches[2] }
+        }
+        $parts = $CommandLine -split '\s+', 2
+        return [PSCustomObject]@{
+            FilePath = $parts[0]
+            Arguments = if ($parts.Count -gt 1) { $parts[1] } else { "" }
+        }
+    }
+
+    function Start-TestProcessAndWait {
+        param(
+            [string]$FilePath,
+            [string]$Arguments = "",
+            [int]$TimeoutSeconds = 180
+        )
+
+        $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+        $startInfo.FileName = $FilePath
+        $startInfo.Arguments = $Arguments
+        $startInfo.UseShellExecute = $false
+        $startInfo.CreateNoWindow = $true
+
+        $proc = [System.Diagnostics.Process]::new()
+        $proc.StartInfo = $startInfo
+        [void]$proc.Start()
+        try {
+            if (-not $proc.WaitForExit($TimeoutSeconds * 1000)) {
+                $proc.Kill()
+                throw "Process did not exit within $TimeoutSeconds seconds: $FilePath"
+            }
+            return $proc.ExitCode
+        } finally {
+            $proc.Dispose()
+        }
+    }
+
+    function Invoke-InstallScript {
+        param(
+            [string]$InstallScriptPath = $script:InstallScript,
+            [hashtable]$EnvVars = @{},
+            [int]$TimeoutSeconds = 600
+        )
+
+        $flagSummary = ($EnvVars.Keys | Sort-Object | ForEach-Object { "$_=$($EnvVars[$_])" }) -join ", "
+        if ($flagSummary) {
+            Write-Host "    Running install.ps1 ($flagSummary)" -ForegroundColor DarkGray
+        } else {
+            Write-Host "    Running install.ps1 (defaults)" -ForegroundColor DarkGray
+        }
+
+        $sw = [System.Diagnostics.Stopwatch]::StartNew()
+        $exitCode = 0
+        $stdout = ""
+        $stderr = ""
+        $proc = $null
+        try {
+            Set-TestProcessEnvironment
+
+            foreach ($key in $EnvVars.Keys) {
+                Set-Item -Path "Env:\$key" -Value $EnvVars[$key]
+            }
+
+            $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+            $startInfo.FileName = "powershell.exe"
+            $startInfo.Arguments = Join-TestProcessArguments @("-NoProfile", "-ExecutionPolicy", "Bypass", "-File", $InstallScriptPath)
+            $startInfo.WorkingDirectory = $script:RepoRoot
+            $startInfo.UseShellExecute = $false
+            $startInfo.CreateNoWindow = $true
+            $startInfo.RedirectStandardOutput = $true
+            $startInfo.RedirectStandardError = $true
+            $startInfo.EnvironmentVariables["PSModulePath"] = Get-WindowsPowerShellModulePath
+
+            $proc = [System.Diagnostics.Process]::new()
+            $proc.StartInfo = $startInfo
+
+            [void]$proc.Start()
+            $stdoutTask = $proc.StandardOutput.ReadToEndAsync()
+            $stderrTask = $proc.StandardError.ReadToEndAsync()
+
+            if (-not $proc.WaitForExit($TimeoutSeconds * 1000)) {
+                try {
+                    $proc.Kill()
+                } catch { }
+                throw "install.ps1 did not exit within $TimeoutSeconds seconds"
+            }
+            $proc.WaitForExit()
+            $exitCode = $proc.ExitCode
+            $stdout = $stdoutTask.GetAwaiter().GetResult()
+            $stderr = $stderrTask.GetAwaiter().GetResult()
+        } finally {
+            foreach ($key in $EnvVars.Keys) {
+                Remove-Item "Env:\$key" -ErrorAction SilentlyContinue
+            }
+            if ($proc) {
+                $proc.Dispose()
+            }
+        }
+        $sw.Stop()
+        Write-Host "    Install completed in $($sw.Elapsed.ToString('mm\:ss'))" -ForegroundColor DarkGray
+        if ($exitCode -ne 0) {
+            if ($stdout) {
+                Write-Host "    install.ps1 stdout:" -ForegroundColor DarkGray
+                Write-Host $stdout
+            }
+            if ($stderr) {
+                Write-Host "    install.ps1 stderr:" -ForegroundColor DarkGray
+                Write-Host $stderr
+            }
+        }
+
+        return @{
+            ExitCode = $exitCode
+            Output   = $stdout
+            Error    = $stderr
+            Duration = $sw.Elapsed
+        }
+    }
+
+    function Invoke-TestInnoInstall {
+        param(
+            [string]$InstallerPath,
+            [string]$InstallDir
+        )
+
+        Assert-TestInstallerSignature -FilePath $InstallerPath
+        $args = Join-TestProcessArguments @(
+            "/VERYSILENT",
+            "/SUPPRESSMSGBOXES",
+            "/NORESTART",
+            "/DIR=$InstallDir"
+        )
+        Write-Host "    Installing pinned base installer..." -ForegroundColor DarkGray
+        $exitCode = Start-TestProcessAndWait -FilePath $InstallerPath -Arguments $args -TimeoutSeconds 600
+        if ($exitCode -ne 0) {
+            throw "Ollama install failed with exit code $exitCode"
+        }
+        Write-Host "    Pinned base installer completed" -ForegroundColor DarkGray
+        Stop-TestOllamaProcesses
+    }
+
+    function Invoke-TestOllamaUninstall {
+        Stop-TestOllamaProcesses
+
+        $regKey = Get-TestOllamaRegistryKey
+        if (-not $regKey) {
+            return
+        }
+
+        $props = Get-ItemProperty -Path $regKey
+        $commandLine = if ($props.QuietUninstallString) { $props.QuietUninstallString } else { $props.UninstallString }
+        if (-not $commandLine) {
+            throw "No uninstall command found in $regKey"
+        }
+
+        $command = Split-TestCommandLine -CommandLine $commandLine
+        $args = "$($command.Arguments) /VERYSILENT /SUPPRESSMSGBOXES /NORESTART".Trim()
+
+        Write-Host "    Running uninstall cleanup..." -ForegroundColor DarkGray
+        $exitCode = Start-TestProcessAndWait -FilePath $command.FilePath -Arguments $args -TimeoutSeconds 300
+        if ($exitCode -ne 0) {
+            throw "Ollama uninstall failed with exit code $exitCode"
+        }
+        Stop-TestOllamaProcesses
+    }
+
+    function Require-RealInstallIntegration {
+        if (Test-OllamaRealInstallPresent) {
+            throw @"
+INTEGRATION TEST SAFETY ABORT:
+An existing Ollama installation was detected. Real integration tests install and
+uninstall Ollama and would interfere with your install.
+
+Uninstall Ollama first, then rerun the integration tests.
+"@
+        }
+        $signedInstaller = Get-IntegrationInstaller
+        if (-not $signedInstaller) {
+            return $null
+        }
+        return $signedInstaller
+    }
+}
+
+Describe "Windows install.ps1" -Tag Unit {
+    BeforeEach {
+        Save-TestEnvironment
+    }
+
+    AfterEach {
+        Restore-TestEnvironment
+    }
+
+    Context "syntax" {
+    It "parses without errors" {
+        $errors = $null
+        $null = [System.Management.Automation.Language.Parser]::ParseFile(
+            $script:InstallScript, [ref]$null, [ref]$errors
+        )
+        $errors.Count | Should -Be 0
+    }
+
+    It "documents the two-phase cache surface without exposing a cache path knob" {
+        $content = Get-Content $script:InstallScript -Raw
+        $content | Should -Match 'OLLAMA_CACHE_ONLY'
+        $content | Should -Match 'OLLAMA_INSTALL_CACHED'
+        $content | Should -Not -Match 'OLLAMA_DOWNLOAD_ONLY'
+    }
+
+    It "rejects invalid cache mode combinations" {
+        Set-TestEnvironment @{
+            OLLAMA_CACHE_ONLY = "1"
+            OLLAMA_INSTALL_CACHED = "1"
+        }
+
+        { . $script:InstallScript } | Should -Throw "*OLLAMA_CACHE_ONLY and OLLAMA_INSTALL_CACHED cannot both be set*"
+    }
+
+    It "rejects uninstall combined with cache modes" {
+        Set-TestEnvironment @{
+            OLLAMA_UNINSTALL = "1"
+            OLLAMA_CACHE_ONLY = "1"
+        }
+
+        { . $script:InstallScript } | Should -Throw "*OLLAMA_UNINSTALL cannot be combined*"
+    }
+    }
+
+    Context "signature verification" {
+    It "rejects unsigned files" {
+        Set-TestEnvironment
+        . $script:InstallScript
+
+        $unsignedFile = Join-Path $env:TEMP "unsigned.exe"
+        Set-Content -Path $unsignedFile -Value "unsigned payload" -Encoding ASCII
+
+        Test-Signature -FilePath $unsignedFile | Should -Be $false
+    }
+
+    It "accepts valid Ollama signatures" {
+        . $script:InstallScript
+
+        Mock Get-AuthenticodeSignature {
+            [PSCustomObject]@{
+                Status = "Valid"
+                SignerCertificate = [PSCustomObject]@{
+                    Subject = "CN=Ollama Inc., O=Ollama Inc., L=San Francisco, S=California, C=US"
+                }
+            }
+        }
+
+        Test-Signature -FilePath "OllamaSetup.exe" | Should -Be $true
+    }
+
+    It "rejects valid signatures from other organizations" {
+        . $script:InstallScript
+
+        Mock Get-AuthenticodeSignature {
+            [PSCustomObject]@{
+                Status = "Valid"
+                SignerCertificate = [PSCustomObject]@{
+                    Subject = "CN=Example Corp, O=Example Corp, C=US"
+                }
+            }
+        }
+
+        Test-Signature -FilePath "OllamaSetup.exe" | Should -Be $false
+    }
+
+    It "rejects organization-name lookalikes" {
+        . $script:InstallScript
+
+        Mock Get-AuthenticodeSignature {
+            [PSCustomObject]@{
+                Status = "Valid"
+                SignerCertificate = [PSCustomObject]@{
+                    Subject = "CN=Example, O=Not Ollama Inc., C=US"
+                }
+            }
+        }
+
+        Test-Signature -FilePath "OllamaSetup.exe" | Should -Be $false
+    }
+    }
+
+    Context "argument quoting" {
+    It "quotes installer arguments without allowing install dir switch injection" {
+        . $script:InstallScript
+
+        $args = @(
+            "/VERYSILENT",
+            "/DIR=C:\Apps\Ollama `"Preview`"\"
+        )
+
+        (($args | ForEach-Object { Quote-ProcessArgument $_ }) -join " ") | Should -Be '/VERYSILENT "/DIR=C:\Apps\Ollama \"Preview\"\\"'
+    }
+    }
+
+    Context "cache modes" {
+    It "cache-only without a version caches latest using the installer ETag" {
+        Set-TestEnvironment @{ OLLAMA_CACHE_ONLY = "1" }
+        . $script:InstallScript
+
+        Mock Get-RemoteETag { '"latest-etag"' }
+        Mock Invoke-Download {
+            Set-Content -Path $OutFile -Value "payload" -Encoding ASCII
+            return '"latest-etag"'
+        }
+        Mock Test-Signature { $true }
+        Mock Start-Process { throw "installer should not start in cache-only mode" }
+
+        Invoke-Install
+
+        $cacheDir = Get-TestInstallerCacheDir '"latest-etag"'
+        $stagingInstaller = Get-TestInstallerStagingPath '"latest-etag"'
+        Test-Path (Join-Path $cacheDir "OllamaSetup.exe") | Should -Be $true
+        Test-Path (Split-Path $stagingInstaller -Parent) | Should -Be $false
+        Should -Invoke Get-RemoteETag -Times 1 -Exactly -ParameterFilter {
+            $Url -eq "https://ollama.com/download/OllamaSetup.exe"
+        }
+        Should -Invoke Invoke-Download -Times 1 -Exactly -ParameterFilter {
+            $Url -eq "https://ollama.com/download/OllamaSetup.exe" -and
+            $OutFile -eq $stagingInstaller
+        }
+        Should -Invoke Test-Signature -Times 1 -Exactly -ParameterFilter {
+            $FilePath -eq $stagingInstaller
+        }
+        Should -Invoke Start-Process -Times 0 -Exactly
+    }
+
+    It "downloads the requested version into the prescribed cache" {
+        Set-TestEnvironment @{
+            OLLAMA_CACHE_ONLY = "1"
+            OLLAMA_VERSION = "v0.21.0"
+        }
+        . $script:InstallScript
+
+        Mock Get-RemoteETag { '"version-etag"' }
+        Mock Invoke-Download {
+            Set-Content -Path $OutFile -Value "payload" -Encoding ASCII
+            return '"version-etag"'
+        }
+        Mock Test-Signature { $true }
+        Mock Start-Process { throw "installer should not start in cache-only mode" }
+
+        Invoke-Install
+
+        $cacheDir = Get-TestInstallerCacheDir '"version-etag"'
+        $stagingInstaller = Get-TestInstallerStagingPath '"version-etag"'
+        Test-Path (Join-Path $cacheDir "OllamaSetup.exe") | Should -Be $true
+        Test-Path (Split-Path $stagingInstaller -Parent) | Should -Be $false
+        Should -Invoke Invoke-Download -Times 1 -Exactly -ParameterFilter {
+            $Url -eq "https://ollama.com/download/OllamaSetup.exe?version=v0.21.0" -and
+            $OutFile -eq $stagingInstaller
+        }
+        Should -Invoke Test-Signature -Times 1 -Exactly -ParameterFilter {
+            $FilePath -eq $stagingInstaller
+        }
+        Should -Invoke Start-Process -Times 0 -Exactly
+    }
+
+    It "cache-only replaces a stale cached ETag directory instead of accumulating cache entries" {
+        Set-TestEnvironment @{
+            OLLAMA_CACHE_ONLY = "1"
+            OLLAMA_VERSION = "0.21.0"
+        }
+        $cacheRoot = Join-Path $env:LOCALAPPDATA "Ollama\install_cache"
+        $oldCacheDir = Get-TestInstallerCacheDir '"old-etag"'
+        $newCacheDir = Get-TestInstallerCacheDir '"new-etag"'
+        $installer = Join-Path $newCacheDir "OllamaSetup.exe"
+        $stagingCacheDir = Get-TestInstallerStagingCacheDir '"new-etag"'
+        New-Item -ItemType Directory -Path $oldCacheDir -Force | Out-Null
+        Set-Content -Path (Join-Path $oldCacheDir "OllamaSetup.exe") -Value "old payload" -Encoding ASCII
+        . $script:InstallScript
+
+        Mock Get-RemoteETag { '"new-etag"' }
+        Mock Invoke-Download {
+            Test-Path $OutFile | Should -Be $false
+            Test-Path $oldCacheDir | Should -Be $false
+            Set-Content -Path $OutFile -Value "new payload" -Encoding ASCII
+            return '"new-etag"'
+        }
+        Mock Test-Signature { $true }
+        Mock Start-Process { throw "installer should not start in cache-only mode" }
+
+        Invoke-Install
+
+        (Get-Content $installer -Raw).Trim() | Should -Be "new payload"
+        Test-Path $stagingCacheDir | Should -Be $false
+        Get-ChildItem -Path $cacheRoot -Directory | Should -HaveCount 1
+        Should -Invoke Invoke-Download -Times 1 -Exactly
+        Should -Invoke Start-Process -Times 0 -Exactly
+    }
+
+    It "cache-only removes stale cache before a failed newer download" {
+        Set-TestEnvironment @{
+            OLLAMA_CACHE_ONLY = "1"
+            OLLAMA_VERSION = "0.21.0"
+        }
+        $oldCacheDir = Get-TestInstallerCacheDir '"old-etag"'
+        $newCacheDir = Get-TestInstallerCacheDir '"new-etag"'
+        $stagingCacheDir = Get-TestInstallerStagingCacheDir '"new-etag"'
+        New-Item -ItemType Directory -Path $oldCacheDir -Force | Out-Null
+        Set-Content -Path (Join-Path $oldCacheDir "OllamaSetup.exe") -Value "old payload" -Encoding ASCII
+        . $script:InstallScript
+
+        Mock Get-RemoteETag { '"new-etag"' }
+        Mock Invoke-Download {
+            Test-Path $oldCacheDir | Should -Be $false
+            Set-Content -Path $OutFile -Value "partial payload" -Encoding ASCII
+            throw "download failed"
+        }
+        Mock Test-Signature { throw "signature verification should not run after download failure" }
+        Mock Start-Process { throw "installer should not start after download failure" }
+
+        { Invoke-Install } | Should -Throw "*download failed*"
+        Test-Path $oldCacheDir | Should -Be $false
+        Test-Path $newCacheDir | Should -Be $false
+        Test-Path $stagingCacheDir | Should -Be $false
+        Should -Invoke Invoke-Download -Times 1 -Exactly
+        Should -Invoke Test-Signature -Times 0 -Exactly
+        Should -Invoke Start-Process -Times 0 -Exactly
+    }
+
+    It "cache-only refreshes the persistent cache when ETags are unavailable" {
+        Set-TestEnvironment @{ OLLAMA_CACHE_ONLY = "1" }
+        $cacheRoot = Join-Path $env:LOCALAPPDATA "Ollama\install_cache"
+        $oldCacheDir = Get-TestInstallerCacheDir '"old-etag"'
+        New-Item -ItemType Directory -Path $oldCacheDir -Force | Out-Null
+        Set-Content -Path (Join-Path $oldCacheDir "OllamaSetup.exe") -Value "old payload" -Encoding ASCII
+        . $script:InstallScript
+
+        Mock Get-RemoteETag { "" }
+        Mock Invoke-Download {
+            Test-Path $oldCacheDir | Should -Be $false
+            Set-Content -Path $OutFile -Value "payload" -Encoding ASCII
+            return ""
+        }
+        Mock Test-Signature { $true }
+        Mock Start-Process { throw "installer should not start in cache-only mode" }
+
+        Invoke-Install
+
+        $cacheEntries = @(Get-ChildItem -Path $cacheRoot -Directory | Where-Object { -not $_.Name.EndsWith(".download") })
+        $cacheEntries | Should -HaveCount 1
+        Test-Path (Join-Path $cacheEntries[0].FullName "OllamaSetup.exe") | Should -Be $true
+        Test-Path $oldCacheDir | Should -Be $false
+        Should -Invoke Invoke-Download -Times 1 -Exactly
+        Should -Invoke Test-Signature -Times 1 -Exactly
+        Should -Invoke Start-Process -Times 0 -Exactly
+    }
+
+    It "cache-only tolerates a missing GET ETag after HEAD identified the cache" {
+        Set-TestEnvironment @{ OLLAMA_CACHE_ONLY = "1" }
+        $cacheDir = Get-TestInstallerCacheDir '"head-etag"'
+        $stagingInstaller = Get-TestInstallerStagingPath '"head-etag"'
+        . $script:InstallScript
+
+        Mock Get-RemoteETag { '"head-etag"' }
+        Mock Invoke-Download {
+            Set-Content -Path $OutFile -Value "payload" -Encoding ASCII
+            return ""
+        }
+        Mock Test-Signature { $true }
+        Mock Start-Process { throw "installer should not start in cache-only mode" }
+
+        Invoke-Install
+
+        Test-Path (Join-Path $cacheDir "OllamaSetup.exe") | Should -Be $true
+        Test-Path (Split-Path $stagingInstaller -Parent) | Should -Be $false
+        Should -Invoke Invoke-Download -Times 1 -Exactly -ParameterFilter {
+            $OutFile -eq $stagingInstaller
+        }
+        Should -Invoke Test-Signature -Times 1 -Exactly -ParameterFilter {
+            $FilePath -eq $stagingInstaller
+        }
+    }
+
+    It "cache-only rejects downloads that return a different ETag" {
+        Set-TestEnvironment @{ OLLAMA_CACHE_ONLY = "1" }
+        $cacheDir = Get-TestInstallerCacheDir '"head-etag"'
+        $stagingInstaller = Get-TestInstallerStagingPath '"head-etag"'
+        . $script:InstallScript
+
+        Mock Get-RemoteETag { '"head-etag"' }
+        Mock Invoke-Download {
+            Set-Content -Path $OutFile -Value "payload" -Encoding ASCII
+            return '"other-etag"'
+        }
+        Mock Test-Signature { throw "signature verification should not run after ETag mismatch" }
+
+        { Invoke-Install } | Should -Throw "*Downloaded installer ETag mismatch*"
+        Test-Path $cacheDir | Should -Be $false
+        Test-Path (Split-Path $stagingInstaller -Parent) | Should -Be $false
+        Should -Invoke Invoke-Download -Times 1 -Exactly -ParameterFilter {
+            $OutFile -eq $stagingInstaller
+        }
+        Should -Invoke Test-Signature -Times 0 -Exactly
+    }
+
+    It "install-cached ignores partial staging downloads when the cache is missing" {
+        Set-TestEnvironment @{ OLLAMA_INSTALL_CACHED = "1" }
+        $stagingCacheDir = Get-TestInstallerStagingCacheDir '"missing-etag"'
+        New-Item -ItemType Directory -Path $stagingCacheDir -Force | Out-Null
+        Set-Content -Path (Join-Path $stagingCacheDir "OllamaSetup.exe") -Value "partial payload" -Encoding ASCII
+        . $script:InstallScript
+
+        Mock Get-RemoteETag { throw "install-cached should not resolve remote ETags" }
+        Mock Invoke-Download { throw "download should not run in install-cached mode" }
+        Mock Test-Signature { throw "signature verification should not run without a complete cached installer" }
+        Mock Start-Process { throw "installer should not start without a complete cached installer" }
+
+        { Invoke-Install } | Should -Throw "*Cached installer not found*"
+        Should -Invoke Get-RemoteETag -Times 0 -Exactly
+        Should -Invoke Invoke-Download -Times 0 -Exactly
+        Should -Invoke Test-Signature -Times 0 -Exactly
+        Should -Invoke Start-Process -Times 0 -Exactly
+    }
+
+    It "install-cached installs the existing cached installer without network resolution" {
+        Set-TestEnvironment @{ OLLAMA_INSTALL_CACHED = "1" }
+        $cacheDir = Get-TestInstallerCacheDir '"cached-etag"'
+        $installer = Join-Path $cacheDir "OllamaSetup.exe"
+        New-Item -ItemType Directory -Path $cacheDir -Force | Out-Null
+        Set-Content -Path $installer -Value "payload" -Encoding ASCII
+        . $script:InstallScript
+
+        Mock Get-RemoteETag { throw "install-cached should not resolve remote ETags" }
+        Mock Invoke-Download { throw "download should not run in install-cached mode" }
+        Mock Test-Signature { $true }
+        Mock Start-Process { return New-FakeProcess }
+        Mock Update-SessionPath { }
+
+        Invoke-Install
+
+        Should -Invoke Invoke-Download -Times 0 -Exactly
+        Should -Invoke Get-RemoteETag -Times 0 -Exactly
+        Should -Invoke Start-Process -Times 1 -Exactly -ParameterFilter {
+            $FilePath -eq $installer
+        }
+        Test-Path $cacheDir | Should -Be $false
+    }
+
+    It "install-cached ignores OLLAMA_VERSION and uses the final cached installer" {
+        Set-TestEnvironment @{
+            OLLAMA_INSTALL_CACHED = "1"
+            OLLAMA_VERSION = "0.21.0"
+        }
+        $cacheDir = Get-TestInstallerCacheDir '"cached-etag"'
+        $installer = Join-Path $cacheDir "OllamaSetup.exe"
+        New-Item -ItemType Directory -Path $cacheDir -Force | Out-Null
+        Set-Content -Path $installer -Value "payload" -Encoding ASCII
+        . $script:InstallScript
+
+        Mock Get-RemoteETag { throw "install-cached should not resolve remote ETags" }
+        Mock Test-Signature { $true }
+        Mock Start-Process { return New-FakeProcess }
+        Mock Update-SessionPath { }
+
+        Invoke-Install
+
+        Should -Invoke Get-RemoteETag -Times 0 -Exactly
+        Should -Invoke Start-Process -Times 1 -Exactly -ParameterFilter {
+            $FilePath -eq $installer
+        }
+    }
+
+    It "install-cached verifies the cached installer immediately before launch" {
+        Set-TestEnvironment @{
+            OLLAMA_INSTALL_CACHED = "1"
+            OLLAMA_VERSION = "0.21.0"
+        }
+        $cacheDir = Get-TestInstallerCacheDir '"cached-etag"'
+        $installer = Join-Path $cacheDir "OllamaSetup.exe"
+        New-Item -ItemType Directory -Path $cacheDir -Force | Out-Null
+        Set-Content -Path $installer -Value "payload" -Encoding ASCII
+        . $script:InstallScript
+
+        Mock Get-RemoteETag { throw "install-cached should not resolve remote ETags" }
+        $script:SignatureChecks = 0
+        $script:StartedInstaller = $null
+        Mock Test-Signature {
+            $script:SignatureChecks++
+            return $true
+        }
+        Mock Start-Process {
+            $script:StartedInstaller = @{
+                FilePath = $FilePath
+                ArgumentList = $ArgumentList
+            }
+            return New-FakeProcess
+        }
+        Mock Update-SessionPath { }
+
+        Invoke-Install
+
+        Should -Invoke Get-RemoteETag -Times 0 -Exactly
+        $script:SignatureChecks | Should -Be 1
+        $script:StartedInstaller.FilePath | Should -Be $installer
+        $script:StartedInstaller.ArgumentList | Should -Match "/VERYSILENT"
+        $script:StartedInstaller.ArgumentList | Should -Match "/LOG="
+        $script:StartedInstaller.ArgumentList | Should -Match "OllamaSetup\.log"
+        Test-Path $cacheDir | Should -Be $false
+    }
+
+    It "install-cached deletes the persistent cache when signature verification fails" {
+        Set-TestEnvironment @{
+            OLLAMA_INSTALL_CACHED = "1"
+            OLLAMA_VERSION = "0.21.0"
+        }
+        $cacheDir = Get-TestInstallerCacheDir '"cached-etag"'
+        $installer = Join-Path $cacheDir "OllamaSetup.exe"
+        New-Item -ItemType Directory -Path $cacheDir -Force | Out-Null
+        Set-Content -Path $installer -Value "payload" -Encoding ASCII
+        . $script:InstallScript
+
+        Mock Get-RemoteETag { throw "install-cached should not resolve remote ETags" }
+        Mock Test-Signature { $false }
+        Mock Start-Process { throw "installer should not start after signature failure" }
+
+        { Invoke-Install } | Should -Throw "*Installer signature verification failed*"
+        Should -Invoke Get-RemoteETag -Times 0 -Exactly
+        Test-Path $cacheDir | Should -Be $false
+        Should -Invoke Start-Process -Times 0 -Exactly
+    }
+    }
+
+    Context "normal install path" {
+    It "downloads default installs through the installer cache" {
+        Set-TestEnvironment
+        $cacheDir = Get-TestInstallerCacheDir '"default-etag"'
+        $installer = Join-Path $cacheDir "OllamaSetup.exe"
+        $stagingInstaller = Get-TestInstallerStagingPath '"default-etag"'
+        . $script:InstallScript
+
+        $script:DownloadedTo = $null
+        $script:StartedInstaller = $null
+        Mock Get-RemoteETag { '"default-etag"' }
+        Mock Invoke-Download {
+            $script:DownloadedTo = $OutFile
+            Set-Content -Path $OutFile -Value "payload" -Encoding ASCII
+        }
+        Mock Test-Signature { $true }
+        Mock Start-Process {
+            $script:StartedInstaller = $FilePath
+            return New-FakeProcess
+        }
+        Mock Update-SessionPath { }
+
+        Invoke-Install
+
+        $script:DownloadedTo | Should -Be $stagingInstaller
+        $script:StartedInstaller | Should -Be $installer
+        Test-Path $cacheDir | Should -Be $false
+    }
+
+    It "reuses a warm cache for normal installs and cleans it up after success" {
+        Set-TestEnvironment
+        $cacheDir = Get-TestInstallerCacheDir '"warm-etag"'
+        $installer = Join-Path $cacheDir "OllamaSetup.exe"
+        New-Item -ItemType Directory -Path $cacheDir -Force | Out-Null
+        Set-Content -Path $installer -Value "payload" -Encoding ASCII
+        . $script:InstallScript
+
+        Mock Get-RemoteETag { '"warm-etag"' }
+        Mock Invoke-Download { throw "download should not run with warm cache" }
+        Mock Test-Signature { $true }
+        Mock Start-Process { return New-FakeProcess }
+        Mock Update-SessionPath { }
+
+        Invoke-Install
+
+        Should -Invoke Invoke-Download -Times 0 -Exactly
+        Should -Invoke Start-Process -Times 1 -Exactly -ParameterFilter {
+            $FilePath -eq $installer
+        }
+        Test-Path $cacheDir | Should -Be $false
+    }
+
+    It "falls back to a throwaway temp cache for normal installs when ETags are unavailable" {
+        Set-TestEnvironment
+        . $script:InstallScript
+
+        $script:DownloadedTo = $null
+        $script:StartedInstaller = $null
+        Mock Get-RemoteETag { "" }
+        Mock Invoke-Download {
+            $script:DownloadedTo = $OutFile
+            Set-Content -Path $OutFile -Value "payload" -Encoding ASCII
+        }
+        Mock Test-Signature { $true }
+        Mock Start-Process {
+            $script:StartedInstaller = $FilePath
+            return New-FakeProcess
+        }
+        Mock Update-SessionPath { }
+
+        Invoke-Install
+
+        $script:StartedInstaller | Should -Not -BeNullOrEmpty
+        $script:DownloadedTo | Should -Be (Join-Path ("$(Split-Path $script:StartedInstaller -Parent).download") "OllamaSetup.exe")
+        $script:StartedInstaller | Should -Match ([regex]::Escape((Join-Path $env:TEMP "Ollama\install_cache")))
+        Test-Path (Split-Path $script:StartedInstaller -Parent) | Should -Be $false
+        Test-Path (Split-Path $script:DownloadedTo -Parent) | Should -Be $false
+    }
+
+    It "deletes a newly downloaded cache entry when signature verification fails" {
+        Set-TestEnvironment
+        $cacheDir = Get-TestInstallerCacheDir '"bad-signature-etag"'
+        $stagingCacheDir = Get-TestInstallerStagingCacheDir '"bad-signature-etag"'
+        . $script:InstallScript
+
+        Mock Get-RemoteETag { '"bad-signature-etag"' }
+        Mock Invoke-Download {
+            Set-Content -Path $OutFile -Value "payload" -Encoding ASCII
+        }
+        Mock Test-Signature { $false }
+        Mock Start-Process { throw "installer should not start after signature failure" }
+
+        { Invoke-Install } | Should -Throw "*Installer signature verification failed*"
+        Test-Path $cacheDir | Should -Be $false
+        Test-Path $stagingCacheDir | Should -Be $false
+        Should -Invoke Start-Process -Times 0 -Exactly
+    }
+    }
+}
+
+Describe "Windows install.ps1 integration" -Tag Integration {
+    BeforeEach {
+        Save-TestEnvironment
+        $script:RealInstallTestStarted = $false
+    }
+
+    AfterEach {
+        if ($script:RealInstallTestStarted) {
+            Invoke-TestOllamaUninstall
+            Remove-Item -LiteralPath (Join-Path $env:LOCALAPPDATA "Ollama\install_cache") -Recurse -Force -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath (Join-Path $env:LOCALAPPDATA "Ollama\upgraded") -Force -ErrorAction SilentlyContinue
+        }
+        Restore-TestEnvironment
+    }
+
+    It "installs from a local signed installer" {
+        $signedInstaller = Require-RealInstallIntegration
+        if (-not $signedInstaller) { return }
+
+        $server = $null
+        try {
+            $installDir = Join-Path $TestDrive ("OllamaInstall-" + [guid]::NewGuid().ToString("N"))
+            Set-TestEnvironment @{ OLLAMA_INSTALL_DIR = $installDir }
+            $script:RealInstallTestStarted = $true
+            $server = Start-LocalHttpServer -InstallerPath $signedInstaller
+            if (-not $server) { return }
+            $installScript = New-TestInstallScript -DownloadBaseUrl $server.DownloadBaseUrl
+
+            $result = Invoke-InstallScript -InstallScriptPath $installScript
+            $result.ExitCode | Should -Be 0
+
+            Test-Path -LiteralPath (Join-Path $installDir "Ollama app.exe") | Should -Be $true
+            Test-Path -LiteralPath (Join-Path $installDir "ollama.exe") | Should -Be $true
+            Get-TestOllamaRegistryKey | Should -Not -BeNullOrEmpty
+        } finally {
+            Stop-LocalHttpServer $server
+        }
+    }
+
+    It "upgrades from pinned 0.21.0 through the two-phase app cache flow" {
+        $signedInstaller = Require-RealInstallIntegration
+        if (-not $signedInstaller) { return }
+        $oldInstaller = Get-PinnedUpgradeInstaller
+
+        $server = $null
+        try {
+            $installDir = Join-Path $TestDrive ("OllamaInstall-" + [guid]::NewGuid().ToString("N"))
+            Set-TestEnvironment @{ OLLAMA_INSTALL_DIR = $installDir }
+            $script:RealInstallTestStarted = $true
+
+            Invoke-TestInnoInstall -InstallerPath $oldInstaller -InstallDir $installDir
+            Test-Path -LiteralPath (Join-Path $installDir "Ollama app.exe") | Should -Be $true
+            $oldVersion = Get-TestOllamaInstalledVersion -InstallDir $installDir
+            $oldVersion | Should -Not -BeNullOrEmpty
+
+            $etag = "real-install-cache-etag"
+            $cacheDir = Get-TestInstallerCacheDir $etag
+            $server = Start-LocalHttpServer -InstallerPath $signedInstaller -ETag $etag
+            if (-not $server) { return }
+            $installScript = New-TestInstallScript -DownloadBaseUrl $server.DownloadBaseUrl
+
+            $result = Invoke-InstallScript -InstallScriptPath $installScript -EnvVars @{ OLLAMA_CACHE_ONLY = "1" }
+            $result.ExitCode | Should -Be 0
+
+            $installer = Join-Path $cacheDir "OllamaSetup.exe"
+            Test-Path -LiteralPath $installer | Should -Be $true
+
+            $result = Invoke-InstallScript -InstallScriptPath $installScript -EnvVars @{ OLLAMA_INSTALL_CACHED = "1" }
+            $result.ExitCode | Should -Be 0
+
+            Test-Path -LiteralPath (Join-Path $installDir "Ollama app.exe") | Should -Be $true
+            Get-TestOllamaRegistryKey | Should -Not -BeNullOrEmpty
+            Test-Path -LiteralPath $cacheDir | Should -Be $false
+            $newVersion = Get-TestOllamaInstalledVersion -InstallDir $installDir
+            $newVersion | Should -Not -BeNullOrEmpty
+            $newVersion | Should -Not -Be $oldVersion
+        } finally {
+            Stop-LocalHttpServer $server
+        }
+    }
+}

--- a/scripts/tests/install.Tests.ps1
+++ b/scripts/tests/install.Tests.ps1
@@ -1,0 +1,1200 @@
+<#
+.SYNOPSIS
+    Pester tests for the Windows install.ps1 script.
+
+.DESCRIPTION
+    IMPORTANT: Integration tests (Tag: Integration) install and uninstall
+    Ollama for real. Run them only on a machine where Ollama is not currently
+    installed; the tests abort if they detect an existing install.
+
+    Unit tests (Tag: Unit) are fast, mock downloads/signatures/process launch,
+    and do not touch the real install state.
+
+    Integration tests (Tag: Integration) use a signed dist\OllamaSetup.exe
+    when present. Otherwise, they download and cache the latest shipped
+    OllamaSetup.exe. They install Ollama for real, verify the installed state,
+    run a pinned-version upgrade from 0.21.0, and then run the real uninstaller.
+
+.EXAMPLE
+    Import-Module Pester -MinimumVersion 5.0
+    Invoke-Pester scripts\tests\install.Tests.ps1 -Tag Unit -Output Detailed
+
+.EXAMPLE
+    # Compatibility check: run unit tests under Windows PowerShell.
+    powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "Import-Module Pester -MinimumVersion 5.0; Invoke-Pester scripts\tests\install.Tests.ps1 -Tag Unit -Output Detailed"
+
+.EXAMPLE
+    # Destructive: requires no existing Ollama install.
+    Invoke-Pester scripts\tests\install.Tests.ps1 -Tag Integration -Output Detailed
+#>
+
+BeforeAll {
+    $script:RepoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+    $script:InstallScript = Join-Path $script:RepoRoot "scripts\install.ps1"
+    $script:UpdateServerScript = Join-Path $script:RepoRoot "scripts\tests\update-server.py"
+    $script:InstallerDownloadCacheDir = Join-Path $script:RepoRoot ".cache\install-tests"
+    $script:DistInstaller = Join-Path $script:RepoRoot "dist\OllamaSetup.exe"
+    $script:OriginalLocalAppData = [Environment]::GetEnvironmentVariable("LOCALAPPDATA", "Process")
+    $script:LatestInstallerUrl = "https://ollama.com/download/OllamaSetup.exe"
+    $script:PinnedUpgradeVersion = "0.21.0"
+    $script:PinnedUpgradeInstallerUrl = "https://github.com/ollama/ollama/releases/download/v$($script:PinnedUpgradeVersion)/OllamaSetup.exe"
+    $script:InnoSetupUninstallGuid = "{44E83376-CE68-45EB-8FC1-393500EB558C}_is1"
+    $script:EnvNames = @(
+        "OLLAMA_VERSION",
+        "OLLAMA_INSTALL_DIR",
+        "OLLAMA_UNINSTALL",
+        "OLLAMA_CACHE_ONLY",
+        "OLLAMA_INSTALL_CACHED",
+        "OLLAMA_DEBUG",
+        "LOCALAPPDATA",
+        "TEMP"
+    )
+
+    function Save-TestEnvironment {
+        $script:SavedEnv = @{}
+        foreach ($name in $script:EnvNames) {
+            $script:SavedEnv[$name] = [Environment]::GetEnvironmentVariable($name, "Process")
+            Remove-Item "Env:$name" -ErrorAction SilentlyContinue
+        }
+    }
+
+    function Restore-TestEnvironment {
+        foreach ($name in $script:EnvNames) {
+            Remove-Item "Env:$name" -ErrorAction SilentlyContinue
+            if ($null -ne $script:SavedEnv[$name]) {
+                Set-Item "Env:$name" $script:SavedEnv[$name]
+            }
+        }
+    }
+
+    function Set-TestProcessEnvironment {
+        $pathValue = [Environment]::GetEnvironmentVariable("Path", "Process")
+        if (-not $pathValue) {
+            $pathValue = [Environment]::GetEnvironmentVariable("PATH", "Process")
+        }
+
+        [Environment]::SetEnvironmentVariable("PATH", $null, "Process")
+        if ($pathValue) {
+            [Environment]::SetEnvironmentVariable("Path", $pathValue, "Process")
+        }
+    }
+
+    function Get-WindowsPowerShellModulePath {
+        $paths = @()
+        $documents = [Environment]::GetFolderPath("MyDocuments")
+        if ($documents) {
+            $paths += Join-Path $documents "WindowsPowerShell\Modules"
+        }
+        if ($env:ProgramFiles) {
+            $paths += Join-Path $env:ProgramFiles "WindowsPowerShell\Modules"
+        }
+        if ($env:SystemRoot) {
+            $paths += Join-Path $env:SystemRoot "system32\WindowsPowerShell\v1.0\Modules"
+        }
+        return ($paths -join ";")
+    }
+
+    function Set-TestEnvironment {
+        param(
+            [hashtable]$Values = @{}
+        )
+
+        $testRoot = Join-Path $TestDrive ([guid]::NewGuid().ToString("N"))
+        $localAppData = Join-Path $testRoot "LocalAppData"
+        $tempDir = Join-Path $testRoot "Temp"
+        New-Item -ItemType Directory -Path $localAppData, $tempDir -Force | Out-Null
+        Set-Item Env:LOCALAPPDATA $localAppData
+        Set-Item Env:TEMP $tempDir
+
+        foreach ($name in $Values.Keys) {
+            Set-Item "Env:$name" $Values[$name]
+        }
+    }
+
+    function New-FakeProcess {
+        $process = [PSCustomObject]@{ ExitCode = 0 }
+        $process | Add-Member -MemberType ScriptMethod -Name WaitForExit -Value { }
+        return $process
+    }
+
+    function Get-TestInstallerCacheDir {
+        param([string]$ETag)
+
+        $normalizedETag = $ETag.Trim().Trim('"')
+        $sha256 = [System.Security.Cryptography.SHA256]::Create()
+        try {
+            $bytes = [System.Text.Encoding]::UTF8.GetBytes($normalizedETag)
+            $hash = $sha256.ComputeHash($bytes)
+            $cacheKey = -join ($hash | ForEach-Object { $_.ToString("x2") })
+            return Join-Path $env:LOCALAPPDATA "Ollama\install_cache\$cacheKey"
+        } finally {
+            $sha256.Dispose()
+        }
+    }
+
+    function Get-TestInstallerStagingCacheDir {
+        param([string]$ETag)
+
+        return "$(Get-TestInstallerCacheDir $ETag).download"
+    }
+
+    function Get-TestInstallerStagingPath {
+        param([string]$ETag)
+
+        return Join-Path (Get-TestInstallerStagingCacheDir $ETag) "OllamaSetup.exe"
+    }
+
+    function New-TestInstallScript {
+        param([string]$DownloadBaseUrl)
+
+        $scriptPath = Join-Path $TestDrive ("install-" + [guid]::NewGuid().ToString("N") + ".ps1")
+        $content = Get-Content -LiteralPath $script:InstallScript -Raw
+        $replacement = '$DownloadBaseURL = "' + $DownloadBaseUrl.TrimEnd('/') + '"'
+        $content = $content.Replace('$DownloadBaseURL = "https://ollama.com/download"', $replacement)
+        Set-Content -LiteralPath $scriptPath -Value $content -Encoding UTF8
+        return $scriptPath
+    }
+
+    function Get-IntegrationInstaller {
+        if (Test-Path -LiteralPath $script:DistInstaller) {
+            $installer = (Resolve-Path -LiteralPath $script:DistInstaller).Path
+            try {
+                Assert-TestInstallerSignature -FilePath $installer
+                Write-Host "    Using signed dist installer: $installer" -ForegroundColor DarkGray
+                return $installer
+            } catch {
+                Write-Host "    Ignoring unsigned dist installer: $installer ($($_.Exception.Message))" -ForegroundColor DarkYellow
+            }
+        }
+
+        return Save-TestInstallerDownload -Url $script:LatestInstallerUrl -FileName "OllamaSetup-latest.exe"
+    }
+
+    function Get-PinnedUpgradeInstaller {
+        return Save-TestInstallerDownload -Url $script:PinnedUpgradeInstallerUrl -FileName "OllamaSetup-$($script:PinnedUpgradeVersion).exe"
+    }
+
+    function Save-TestInstallerDownload {
+        param(
+            [string]$Url,
+            [string]$FileName
+        )
+
+        New-Item -ItemType Directory -Path $script:InstallerDownloadCacheDir -Force | Out-Null
+        $installerPath = Join-Path $script:InstallerDownloadCacheDir $FileName
+        if (-not (Test-Path -LiteralPath $installerPath)) {
+            Write-Host "    Downloading $Url" -ForegroundColor DarkGray
+            $oldProgressPreference = $ProgressPreference
+            $ProgressPreference = "SilentlyContinue"
+            try {
+                Invoke-WebRequest -Uri $Url -OutFile $installerPath -UseBasicParsing
+            } finally {
+                $ProgressPreference = $oldProgressPreference
+            }
+        } else {
+            Write-Host "    Using cached installer: $installerPath" -ForegroundColor DarkGray
+        }
+        Assert-TestInstallerSignature -FilePath $installerPath
+        return $installerPath
+    }
+
+    function Assert-TestInstallerSignature {
+        param([string]$FilePath)
+
+        $sig = Get-AuthenticodeSignature -FilePath $FilePath
+        if ($sig.Status -ne "Valid") {
+            throw "Installer signature is not valid: $FilePath ($($sig.Status))"
+        }
+        $subject = $sig.SignerCertificate.Subject
+        if ($subject -notmatch "(^|, )O=Ollama Inc\.(,|$)") {
+            throw "Installer is not signed by Ollama Inc.: $subject"
+        }
+    }
+
+    function Get-TestPython {
+        foreach ($candidate in @("python.exe", "python")) {
+            $command = Get-Command $candidate -ErrorAction SilentlyContinue | Select-Object -First 1
+            if ($command) {
+                return $command.Source
+            }
+        }
+        return $null
+    }
+
+    function Get-FreeTcpPort {
+        $listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Parse("127.0.0.1"), 0)
+        try {
+            $listener.Start()
+            return $listener.LocalEndpoint.Port
+        } finally {
+            $listener.Stop()
+        }
+    }
+
+    function Wait-TestHttpServer {
+        param($Server)
+
+        $url = "$($Server.BaseUrl)/download/OllamaSetup.exe"
+        for ($i = 0; $i -lt 50; $i++) {
+            try {
+                Invoke-WebRequest -Uri $url -Method Head -UseBasicParsing -TimeoutSec 2 | Out-Null
+                return
+            } catch {
+                Start-Sleep -Milliseconds 100
+            }
+        }
+
+        $stderr = if ($Server.Process.HasExited) { $Server.Process.StandardError.ReadToEnd() } else { "" }
+        throw "Local HTTP server did not start. $stderr"
+    }
+
+    function Join-TestProcessArguments {
+        param([string[]]$Arguments)
+
+        return (($Arguments | ForEach-Object {
+            if ($null -eq $_ -or $_.Length -eq 0) {
+                '""'
+            } elseif ($_.IndexOfAny(@([char]32, [char]9, [char]34)) -lt 0) {
+                $_
+            } else {
+                '"' + ($_.Replace('\', '\\').Replace('"', '\"')) + '"'
+            }
+        }) -join " ")
+    }
+
+    function Start-LocalHttpServer {
+        param(
+            [string]$InstallerPath,
+            [string]$ETag = ""
+        )
+
+        $python = Get-TestPython
+        if (-not $python) {
+            Set-ItResult -Skipped -Because "Python is required to run local HTTP integration tests"
+            return $null
+        }
+
+        $port = Get-FreeTcpPort
+        $serverDist = Join-Path $TestDrive ("update-dist-" + [guid]::NewGuid().ToString("N"))
+        New-Item -ItemType Directory -Path $serverDist -Force | Out-Null
+        Copy-Item -LiteralPath $InstallerPath -Destination (Join-Path $serverDist "OllamaSetup.exe")
+        Copy-Item -LiteralPath $script:InstallScript -Destination (Join-Path $serverDist "install.ps1")
+        if ($ETag) {
+            Set-Content -LiteralPath (Join-Path $serverDist "OllamaSetup.exe.etag") -Value $ETag -Encoding ASCII
+        }
+
+        $args = @(
+            $script:UpdateServerScript,
+            "--host", "127.0.0.1",
+            "--port", [string]$port,
+            "--dist", $serverDist
+        )
+
+        $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+        $startInfo.FileName = $python
+        $startInfo.Arguments = Join-TestProcessArguments $args
+        $startInfo.WorkingDirectory = $script:RepoRoot
+        $startInfo.UseShellExecute = $false
+        $startInfo.CreateNoWindow = $true
+        $startInfo.RedirectStandardOutput = $true
+        $startInfo.RedirectStandardError = $true
+
+        $proc = [System.Diagnostics.Process]::new()
+        $proc.StartInfo = $startInfo
+        [void]$proc.Start()
+
+        $server = [PSCustomObject]@{
+            Process = $proc
+            BaseUrl = "http://127.0.0.1:$port"
+            DownloadBaseUrl = "http://127.0.0.1:$port/download"
+        }
+        Wait-TestHttpServer -Server $server
+        return $server
+    }
+
+    function Stop-LocalHttpServer {
+        param($Server)
+
+        if ($Server -and $Server.Process -and -not $Server.Process.HasExited) {
+            Stop-Process -Id $Server.Process.Id -Force -ErrorAction SilentlyContinue
+        }
+        if ($Server -and $Server.Process) {
+            $Server.Process.Dispose()
+        }
+    }
+
+    function Get-TestOllamaInstallDir {
+        param([switch]$UseOriginalLocalAppData)
+
+        if (-not $UseOriginalLocalAppData -and $env:OLLAMA_INSTALL_DIR) {
+            return $env:OLLAMA_INSTALL_DIR
+        }
+        $localAppData = if ($UseOriginalLocalAppData -or -not $env:LOCALAPPDATA) {
+            $script:OriginalLocalAppData
+        } else {
+            $env:LOCALAPPDATA
+        }
+        return Join-Path $localAppData "Programs\Ollama"
+    }
+
+    function Get-TestOllamaRegistryKey {
+        $possibleKeys = @(
+            "HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\$script:InnoSetupUninstallGuid",
+            "HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\$script:InnoSetupUninstallGuid",
+            "HKLM:\Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\$script:InnoSetupUninstallGuid"
+        )
+
+        foreach ($key in $possibleKeys) {
+            if (Test-Path $key) {
+                return $key
+            }
+        }
+        return $null
+    }
+
+    function Get-TestOllamaInstalledVersion {
+        param([string]$InstallDir)
+
+        $regKey = Get-TestOllamaRegistryKey
+        if ($regKey) {
+            $displayVersion = (Get-ItemProperty -Path $regKey).DisplayVersion
+            if ($displayVersion) {
+                return $displayVersion
+            }
+        }
+
+        $ollamaExe = Join-Path $InstallDir "ollama.exe"
+        if (Test-Path -LiteralPath $ollamaExe) {
+            try {
+                $output = & $ollamaExe --version 2>$null
+                $text = if ($output -is [array]) { $output -join "`n" } else { [string]$output }
+                if ($text -match "(\d+\.\d+\.\d+)") {
+                    return $matches[1]
+                }
+            } catch { }
+        }
+
+        return $null
+    }
+
+    function Test-OllamaRealInstallPresent {
+        $installDir = Get-TestOllamaInstallDir -UseOriginalLocalAppData
+        return [bool]((Get-TestOllamaRegistryKey) -or (Test-Path -LiteralPath (Join-Path $installDir "Ollama app.exe")))
+    }
+
+    function Stop-TestOllamaProcesses {
+        Get-Process -Name "ollama", "Ollama app" -ErrorAction SilentlyContinue |
+            Stop-Process -Force -ErrorAction SilentlyContinue
+    }
+
+    function Split-TestCommandLine {
+        param([string]$CommandLine)
+
+        if ($CommandLine -match '^\s*"([^"]+)"\s*(.*)$') {
+            return [PSCustomObject]@{ FilePath = $matches[1]; Arguments = $matches[2] }
+        }
+        $parts = $CommandLine -split '\s+', 2
+        return [PSCustomObject]@{
+            FilePath = $parts[0]
+            Arguments = if ($parts.Count -gt 1) { $parts[1] } else { "" }
+        }
+    }
+
+    function Start-TestProcessAndWait {
+        param(
+            [string]$FilePath,
+            [string]$Arguments = "",
+            [int]$TimeoutSeconds = 180
+        )
+
+        $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+        $startInfo.FileName = $FilePath
+        $startInfo.Arguments = $Arguments
+        $startInfo.UseShellExecute = $false
+        $startInfo.CreateNoWindow = $true
+
+        $proc = [System.Diagnostics.Process]::new()
+        $proc.StartInfo = $startInfo
+        [void]$proc.Start()
+        try {
+            if (-not $proc.WaitForExit($TimeoutSeconds * 1000)) {
+                $proc.Kill()
+                throw "Process did not exit within $TimeoutSeconds seconds: $FilePath"
+            }
+            return $proc.ExitCode
+        } finally {
+            $proc.Dispose()
+        }
+    }
+
+    function Invoke-InstallScript {
+        param(
+            [string]$InstallScriptPath = $script:InstallScript,
+            [hashtable]$EnvVars = @{},
+            [int]$TimeoutSeconds = 600
+        )
+
+        $flagSummary = ($EnvVars.Keys | Sort-Object | ForEach-Object { "$_=$($EnvVars[$_])" }) -join ", "
+        if ($flagSummary) {
+            Write-Host "    Running install.ps1 ($flagSummary)" -ForegroundColor DarkGray
+        } else {
+            Write-Host "    Running install.ps1 (defaults)" -ForegroundColor DarkGray
+        }
+
+        $sw = [System.Diagnostics.Stopwatch]::StartNew()
+        $exitCode = 0
+        $stdout = ""
+        $stderr = ""
+        $proc = $null
+        try {
+            Set-TestProcessEnvironment
+
+            foreach ($key in $EnvVars.Keys) {
+                Set-Item -Path "Env:\$key" -Value $EnvVars[$key]
+            }
+
+            $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+            $startInfo.FileName = "powershell.exe"
+            $startInfo.Arguments = Join-TestProcessArguments @("-NoProfile", "-ExecutionPolicy", "Bypass", "-File", $InstallScriptPath)
+            $startInfo.WorkingDirectory = $script:RepoRoot
+            $startInfo.UseShellExecute = $false
+            $startInfo.CreateNoWindow = $true
+            $startInfo.RedirectStandardOutput = $true
+            $startInfo.RedirectStandardError = $true
+            $startInfo.EnvironmentVariables["PSModulePath"] = Get-WindowsPowerShellModulePath
+
+            $proc = [System.Diagnostics.Process]::new()
+            $proc.StartInfo = $startInfo
+
+            [void]$proc.Start()
+            $stdoutTask = $proc.StandardOutput.ReadToEndAsync()
+            $stderrTask = $proc.StandardError.ReadToEndAsync()
+
+            if (-not $proc.WaitForExit($TimeoutSeconds * 1000)) {
+                try {
+                    $proc.Kill()
+                } catch { }
+                throw "install.ps1 did not exit within $TimeoutSeconds seconds"
+            }
+            $proc.WaitForExit()
+            $exitCode = $proc.ExitCode
+            $stdout = $stdoutTask.GetAwaiter().GetResult()
+            $stderr = $stderrTask.GetAwaiter().GetResult()
+        } finally {
+            foreach ($key in $EnvVars.Keys) {
+                Remove-Item "Env:\$key" -ErrorAction SilentlyContinue
+            }
+            if ($proc) {
+                $proc.Dispose()
+            }
+        }
+        $sw.Stop()
+        Write-Host "    Install completed in $($sw.Elapsed.ToString('mm\:ss'))" -ForegroundColor DarkGray
+        if ($exitCode -ne 0) {
+            if ($stdout) {
+                Write-Host "    install.ps1 stdout:" -ForegroundColor DarkGray
+                Write-Host $stdout
+            }
+            if ($stderr) {
+                Write-Host "    install.ps1 stderr:" -ForegroundColor DarkGray
+                Write-Host $stderr
+            }
+        }
+
+        return @{
+            ExitCode = $exitCode
+            Output   = $stdout
+            Error    = $stderr
+            Duration = $sw.Elapsed
+        }
+    }
+
+    function Invoke-TestInnoInstall {
+        param(
+            [string]$InstallerPath,
+            [string]$InstallDir
+        )
+
+        Assert-TestInstallerSignature -FilePath $InstallerPath
+        $args = Join-TestProcessArguments @(
+            "/VERYSILENT",
+            "/SUPPRESSMSGBOXES",
+            "/NORESTART",
+            "/DIR=$InstallDir"
+        )
+        Write-Host "    Installing pinned base installer..." -ForegroundColor DarkGray
+        $exitCode = Start-TestProcessAndWait -FilePath $InstallerPath -Arguments $args -TimeoutSeconds 600
+        if ($exitCode -ne 0) {
+            throw "Ollama install failed with exit code $exitCode"
+        }
+        Write-Host "    Pinned base installer completed" -ForegroundColor DarkGray
+        Stop-TestOllamaProcesses
+    }
+
+    function Invoke-TestOllamaUninstall {
+        Stop-TestOllamaProcesses
+
+        $regKey = Get-TestOllamaRegistryKey
+        if (-not $regKey) {
+            return
+        }
+
+        $props = Get-ItemProperty -Path $regKey
+        $commandLine = if ($props.QuietUninstallString) { $props.QuietUninstallString } else { $props.UninstallString }
+        if (-not $commandLine) {
+            throw "No uninstall command found in $regKey"
+        }
+
+        $command = Split-TestCommandLine -CommandLine $commandLine
+        $args = "$($command.Arguments) /VERYSILENT /SUPPRESSMSGBOXES /NORESTART".Trim()
+
+        Write-Host "    Running uninstall cleanup..." -ForegroundColor DarkGray
+        $exitCode = Start-TestProcessAndWait -FilePath $command.FilePath -Arguments $args -TimeoutSeconds 300
+        if ($exitCode -ne 0) {
+            throw "Ollama uninstall failed with exit code $exitCode"
+        }
+        Stop-TestOllamaProcesses
+    }
+
+    function Require-RealInstallIntegration {
+        if (Test-OllamaRealInstallPresent) {
+            throw @"
+INTEGRATION TEST SAFETY ABORT:
+An existing Ollama installation was detected. Real integration tests install and
+uninstall Ollama and would interfere with your install.
+
+Uninstall Ollama first, then rerun the integration tests.
+"@
+        }
+        $signedInstaller = Get-IntegrationInstaller
+        if (-not $signedInstaller) {
+            return $null
+        }
+        return $signedInstaller
+    }
+}
+
+Describe "Windows install.ps1" -Tag Unit {
+    BeforeEach {
+        Save-TestEnvironment
+    }
+
+    AfterEach {
+        Restore-TestEnvironment
+    }
+
+    Context "syntax" {
+    It "parses without errors" {
+        $errors = $null
+        $null = [System.Management.Automation.Language.Parser]::ParseFile(
+            $script:InstallScript, [ref]$null, [ref]$errors
+        )
+        $errors.Count | Should -Be 0
+    }
+
+    It "documents the two-phase cache surface without exposing a cache path knob" {
+        $content = Get-Content $script:InstallScript -Raw
+        $content | Should -Match 'OLLAMA_CACHE_ONLY'
+        $content | Should -Match 'OLLAMA_INSTALL_CACHED'
+        $content | Should -Not -Match 'OLLAMA_DOWNLOAD_ONLY'
+    }
+
+    It "rejects invalid cache mode combinations" {
+        Set-TestEnvironment @{
+            OLLAMA_CACHE_ONLY = "1"
+            OLLAMA_INSTALL_CACHED = "1"
+        }
+
+        { . $script:InstallScript } | Should -Throw "*OLLAMA_CACHE_ONLY and OLLAMA_INSTALL_CACHED cannot both be set*"
+    }
+
+    It "rejects uninstall combined with cache modes" {
+        Set-TestEnvironment @{
+            OLLAMA_UNINSTALL = "1"
+            OLLAMA_CACHE_ONLY = "1"
+        }
+
+        { . $script:InstallScript } | Should -Throw "*OLLAMA_UNINSTALL cannot be combined*"
+    }
+    }
+
+    Context "signature verification" {
+    It "rejects unsigned files" {
+        Set-TestEnvironment
+        . $script:InstallScript
+
+        $unsignedFile = Join-Path $env:TEMP "unsigned.exe"
+        Set-Content -Path $unsignedFile -Value "unsigned payload" -Encoding ASCII
+
+        Test-Signature -FilePath $unsignedFile | Should -Be $false
+    }
+
+    It "accepts valid Ollama signatures" {
+        . $script:InstallScript
+
+        Mock Get-AuthenticodeSignature {
+            [PSCustomObject]@{
+                Status = "Valid"
+                SignerCertificate = [PSCustomObject]@{
+                    Subject = "CN=Ollama Inc., O=Ollama Inc., L=San Francisco, S=California, C=US"
+                }
+            }
+        }
+
+        Test-Signature -FilePath "OllamaSetup.exe" | Should -Be $true
+    }
+
+    It "rejects valid signatures from other organizations" {
+        . $script:InstallScript
+
+        Mock Get-AuthenticodeSignature {
+            [PSCustomObject]@{
+                Status = "Valid"
+                SignerCertificate = [PSCustomObject]@{
+                    Subject = "CN=Example Corp, O=Example Corp, C=US"
+                }
+            }
+        }
+
+        Test-Signature -FilePath "OllamaSetup.exe" | Should -Be $false
+    }
+
+    It "rejects organization-name lookalikes" {
+        . $script:InstallScript
+
+        Mock Get-AuthenticodeSignature {
+            [PSCustomObject]@{
+                Status = "Valid"
+                SignerCertificate = [PSCustomObject]@{
+                    Subject = "CN=Example, O=Not Ollama Inc., C=US"
+                }
+            }
+        }
+
+        Test-Signature -FilePath "OllamaSetup.exe" | Should -Be $false
+    }
+    }
+
+    Context "argument quoting" {
+    It "quotes installer arguments without allowing install dir switch injection" {
+        . $script:InstallScript
+
+        $args = @(
+            "/VERYSILENT",
+            "/DIR=C:\Apps\Ollama `"Preview`"\"
+        )
+
+        (($args | ForEach-Object { Quote-ProcessArgument $_ }) -join " ") | Should -Be '/VERYSILENT "/DIR=C:\Apps\Ollama \"Preview\"\\"'
+    }
+    }
+
+    Context "cache modes" {
+    It "cache-only without a version caches latest using the installer ETag" {
+        Set-TestEnvironment @{ OLLAMA_CACHE_ONLY = "1" }
+        . $script:InstallScript
+
+        Mock Get-RemoteETag { '"latest-etag"' }
+        Mock Invoke-Download {
+            Set-Content -Path $OutFile -Value "payload" -Encoding ASCII
+            return '"latest-etag"'
+        }
+        Mock Test-Signature { $true }
+        Mock Start-Process { throw "installer should not start in cache-only mode" }
+
+        Invoke-Install
+
+        $cacheDir = Get-TestInstallerCacheDir '"latest-etag"'
+        $stagingInstaller = Get-TestInstallerStagingPath '"latest-etag"'
+        Test-Path (Join-Path $cacheDir "OllamaSetup.exe") | Should -Be $true
+        Test-Path (Split-Path $stagingInstaller -Parent) | Should -Be $false
+        Should -Invoke Get-RemoteETag -Times 1 -Exactly -ParameterFilter {
+            $Url -eq "https://ollama.com/download/OllamaSetup.exe"
+        }
+        Should -Invoke Invoke-Download -Times 1 -Exactly -ParameterFilter {
+            $Url -eq "https://ollama.com/download/OllamaSetup.exe" -and
+            $OutFile -eq $stagingInstaller
+        }
+        Should -Invoke Test-Signature -Times 1 -Exactly -ParameterFilter {
+            $FilePath -eq $stagingInstaller
+        }
+        Should -Invoke Start-Process -Times 0 -Exactly
+    }
+
+    It "downloads the requested version into the prescribed cache" {
+        Set-TestEnvironment @{
+            OLLAMA_CACHE_ONLY = "1"
+            OLLAMA_VERSION = "v0.21.0"
+        }
+        . $script:InstallScript
+
+        Mock Get-RemoteETag { '"version-etag"' }
+        Mock Invoke-Download {
+            Set-Content -Path $OutFile -Value "payload" -Encoding ASCII
+            return '"version-etag"'
+        }
+        Mock Test-Signature { $true }
+        Mock Start-Process { throw "installer should not start in cache-only mode" }
+
+        Invoke-Install
+
+        $cacheDir = Get-TestInstallerCacheDir '"version-etag"'
+        $stagingInstaller = Get-TestInstallerStagingPath '"version-etag"'
+        Test-Path (Join-Path $cacheDir "OllamaSetup.exe") | Should -Be $true
+        Test-Path (Split-Path $stagingInstaller -Parent) | Should -Be $false
+        Should -Invoke Invoke-Download -Times 1 -Exactly -ParameterFilter {
+            $Url -eq "https://ollama.com/download/OllamaSetup.exe?version=v0.21.0" -and
+            $OutFile -eq $stagingInstaller
+        }
+        Should -Invoke Test-Signature -Times 1 -Exactly -ParameterFilter {
+            $FilePath -eq $stagingInstaller
+        }
+        Should -Invoke Start-Process -Times 0 -Exactly
+    }
+
+    It "cache-only replaces a stale cached ETag directory instead of accumulating cache entries" {
+        Set-TestEnvironment @{
+            OLLAMA_CACHE_ONLY = "1"
+            OLLAMA_VERSION = "0.21.0"
+        }
+        $cacheRoot = Join-Path $env:LOCALAPPDATA "Ollama\install_cache"
+        $oldCacheDir = Get-TestInstallerCacheDir '"old-etag"'
+        $newCacheDir = Get-TestInstallerCacheDir '"new-etag"'
+        $installer = Join-Path $newCacheDir "OllamaSetup.exe"
+        $stagingCacheDir = Get-TestInstallerStagingCacheDir '"new-etag"'
+        New-Item -ItemType Directory -Path $oldCacheDir -Force | Out-Null
+        Set-Content -Path (Join-Path $oldCacheDir "OllamaSetup.exe") -Value "old payload" -Encoding ASCII
+        . $script:InstallScript
+
+        Mock Get-RemoteETag { '"new-etag"' }
+        Mock Invoke-Download {
+            Test-Path $OutFile | Should -Be $false
+            Test-Path $oldCacheDir | Should -Be $false
+            Set-Content -Path $OutFile -Value "new payload" -Encoding ASCII
+            return '"new-etag"'
+        }
+        Mock Test-Signature { $true }
+        Mock Start-Process { throw "installer should not start in cache-only mode" }
+
+        Invoke-Install
+
+        (Get-Content $installer -Raw).Trim() | Should -Be "new payload"
+        Test-Path $stagingCacheDir | Should -Be $false
+        Get-ChildItem -Path $cacheRoot -Directory | Should -HaveCount 1
+        Should -Invoke Invoke-Download -Times 1 -Exactly
+        Should -Invoke Start-Process -Times 0 -Exactly
+    }
+
+    It "cache-only removes stale cache before a failed newer download" {
+        Set-TestEnvironment @{
+            OLLAMA_CACHE_ONLY = "1"
+            OLLAMA_VERSION = "0.21.0"
+        }
+        $oldCacheDir = Get-TestInstallerCacheDir '"old-etag"'
+        $newCacheDir = Get-TestInstallerCacheDir '"new-etag"'
+        $stagingCacheDir = Get-TestInstallerStagingCacheDir '"new-etag"'
+        New-Item -ItemType Directory -Path $oldCacheDir -Force | Out-Null
+        Set-Content -Path (Join-Path $oldCacheDir "OllamaSetup.exe") -Value "old payload" -Encoding ASCII
+        . $script:InstallScript
+
+        Mock Get-RemoteETag { '"new-etag"' }
+        Mock Invoke-Download {
+            Test-Path $oldCacheDir | Should -Be $false
+            Set-Content -Path $OutFile -Value "partial payload" -Encoding ASCII
+            throw "download failed"
+        }
+        Mock Test-Signature { throw "signature verification should not run after download failure" }
+        Mock Start-Process { throw "installer should not start after download failure" }
+
+        { Invoke-Install } | Should -Throw "*download failed*"
+        Test-Path $oldCacheDir | Should -Be $false
+        Test-Path $newCacheDir | Should -Be $false
+        Test-Path $stagingCacheDir | Should -Be $false
+        Should -Invoke Invoke-Download -Times 1 -Exactly
+        Should -Invoke Test-Signature -Times 0 -Exactly
+        Should -Invoke Start-Process -Times 0 -Exactly
+    }
+
+    It "cache-only refreshes the persistent cache when ETags are unavailable" {
+        Set-TestEnvironment @{ OLLAMA_CACHE_ONLY = "1" }
+        $cacheRoot = Join-Path $env:LOCALAPPDATA "Ollama\install_cache"
+        $oldCacheDir = Get-TestInstallerCacheDir '"old-etag"'
+        New-Item -ItemType Directory -Path $oldCacheDir -Force | Out-Null
+        Set-Content -Path (Join-Path $oldCacheDir "OllamaSetup.exe") -Value "old payload" -Encoding ASCII
+        . $script:InstallScript
+
+        Mock Get-RemoteETag { "" }
+        Mock Invoke-Download {
+            Test-Path $oldCacheDir | Should -Be $false
+            Set-Content -Path $OutFile -Value "payload" -Encoding ASCII
+            return ""
+        }
+        Mock Test-Signature { $true }
+        Mock Start-Process { throw "installer should not start in cache-only mode" }
+
+        Invoke-Install
+
+        $cacheEntries = @(Get-ChildItem -Path $cacheRoot -Directory | Where-Object { -not $_.Name.EndsWith(".download") })
+        $cacheEntries | Should -HaveCount 1
+        Test-Path (Join-Path $cacheEntries[0].FullName "OllamaSetup.exe") | Should -Be $true
+        Test-Path $oldCacheDir | Should -Be $false
+        Should -Invoke Invoke-Download -Times 1 -Exactly
+        Should -Invoke Test-Signature -Times 1 -Exactly
+        Should -Invoke Start-Process -Times 0 -Exactly
+    }
+
+    It "cache-only tolerates a missing GET ETag after HEAD identified the cache" {
+        Set-TestEnvironment @{ OLLAMA_CACHE_ONLY = "1" }
+        $cacheDir = Get-TestInstallerCacheDir '"head-etag"'
+        $stagingInstaller = Get-TestInstallerStagingPath '"head-etag"'
+        . $script:InstallScript
+
+        Mock Get-RemoteETag { '"head-etag"' }
+        Mock Invoke-Download {
+            Set-Content -Path $OutFile -Value "payload" -Encoding ASCII
+            return ""
+        }
+        Mock Test-Signature { $true }
+        Mock Start-Process { throw "installer should not start in cache-only mode" }
+
+        Invoke-Install
+
+        Test-Path (Join-Path $cacheDir "OllamaSetup.exe") | Should -Be $true
+        Test-Path (Split-Path $stagingInstaller -Parent) | Should -Be $false
+        Should -Invoke Invoke-Download -Times 1 -Exactly -ParameterFilter {
+            $OutFile -eq $stagingInstaller
+        }
+        Should -Invoke Test-Signature -Times 1 -Exactly -ParameterFilter {
+            $FilePath -eq $stagingInstaller
+        }
+    }
+
+    It "cache-only rejects downloads that return a different ETag" {
+        Set-TestEnvironment @{ OLLAMA_CACHE_ONLY = "1" }
+        $cacheDir = Get-TestInstallerCacheDir '"head-etag"'
+        $stagingInstaller = Get-TestInstallerStagingPath '"head-etag"'
+        . $script:InstallScript
+
+        Mock Get-RemoteETag { '"head-etag"' }
+        Mock Invoke-Download {
+            Set-Content -Path $OutFile -Value "payload" -Encoding ASCII
+            return '"other-etag"'
+        }
+        Mock Test-Signature { throw "signature verification should not run after ETag mismatch" }
+
+        { Invoke-Install } | Should -Throw "*Downloaded installer ETag mismatch*"
+        Test-Path $cacheDir | Should -Be $false
+        Test-Path (Split-Path $stagingInstaller -Parent) | Should -Be $false
+        Should -Invoke Invoke-Download -Times 1 -Exactly -ParameterFilter {
+            $OutFile -eq $stagingInstaller
+        }
+        Should -Invoke Test-Signature -Times 0 -Exactly
+    }
+
+    It "install-cached ignores partial staging downloads when the cache is missing" {
+        Set-TestEnvironment @{ OLLAMA_INSTALL_CACHED = "1" }
+        $stagingCacheDir = Get-TestInstallerStagingCacheDir '"missing-etag"'
+        New-Item -ItemType Directory -Path $stagingCacheDir -Force | Out-Null
+        Set-Content -Path (Join-Path $stagingCacheDir "OllamaSetup.exe") -Value "partial payload" -Encoding ASCII
+        . $script:InstallScript
+
+        Mock Get-RemoteETag { throw "install-cached should not resolve remote ETags" }
+        Mock Invoke-Download { throw "download should not run in install-cached mode" }
+        Mock Test-Signature { throw "signature verification should not run without a complete cached installer" }
+        Mock Start-Process { throw "installer should not start without a complete cached installer" }
+
+        { Invoke-Install } | Should -Throw "*Cached installer not found*"
+        Should -Invoke Get-RemoteETag -Times 0 -Exactly
+        Should -Invoke Invoke-Download -Times 0 -Exactly
+        Should -Invoke Test-Signature -Times 0 -Exactly
+        Should -Invoke Start-Process -Times 0 -Exactly
+    }
+
+    It "install-cached installs the existing cached installer without network resolution" {
+        Set-TestEnvironment @{ OLLAMA_INSTALL_CACHED = "1" }
+        $cacheDir = Get-TestInstallerCacheDir '"cached-etag"'
+        $installer = Join-Path $cacheDir "OllamaSetup.exe"
+        New-Item -ItemType Directory -Path $cacheDir -Force | Out-Null
+        Set-Content -Path $installer -Value "payload" -Encoding ASCII
+        . $script:InstallScript
+
+        Mock Get-RemoteETag { throw "install-cached should not resolve remote ETags" }
+        Mock Invoke-Download { throw "download should not run in install-cached mode" }
+        Mock Test-Signature { $true }
+        Mock Start-Process { return New-FakeProcess }
+        Mock Update-SessionPath { }
+
+        Invoke-Install
+
+        Should -Invoke Invoke-Download -Times 0 -Exactly
+        Should -Invoke Get-RemoteETag -Times 0 -Exactly
+        Should -Invoke Start-Process -Times 1 -Exactly -ParameterFilter {
+            $FilePath -eq $installer
+        }
+        Test-Path $cacheDir | Should -Be $false
+    }
+
+    It "install-cached ignores OLLAMA_VERSION and uses the final cached installer" {
+        Set-TestEnvironment @{
+            OLLAMA_INSTALL_CACHED = "1"
+            OLLAMA_VERSION = "0.21.0"
+        }
+        $cacheDir = Get-TestInstallerCacheDir '"cached-etag"'
+        $installer = Join-Path $cacheDir "OllamaSetup.exe"
+        New-Item -ItemType Directory -Path $cacheDir -Force | Out-Null
+        Set-Content -Path $installer -Value "payload" -Encoding ASCII
+        . $script:InstallScript
+
+        Mock Get-RemoteETag { throw "install-cached should not resolve remote ETags" }
+        Mock Test-Signature { $true }
+        Mock Start-Process { return New-FakeProcess }
+        Mock Update-SessionPath { }
+
+        Invoke-Install
+
+        Should -Invoke Get-RemoteETag -Times 0 -Exactly
+        Should -Invoke Start-Process -Times 1 -Exactly -ParameterFilter {
+            $FilePath -eq $installer
+        }
+    }
+
+    It "install-cached verifies the cached installer immediately before launch" {
+        Set-TestEnvironment @{
+            OLLAMA_INSTALL_CACHED = "1"
+            OLLAMA_VERSION = "0.21.0"
+        }
+        $cacheDir = Get-TestInstallerCacheDir '"cached-etag"'
+        $installer = Join-Path $cacheDir "OllamaSetup.exe"
+        New-Item -ItemType Directory -Path $cacheDir -Force | Out-Null
+        Set-Content -Path $installer -Value "payload" -Encoding ASCII
+        . $script:InstallScript
+
+        Mock Get-RemoteETag { throw "install-cached should not resolve remote ETags" }
+        $script:SignatureChecks = 0
+        $script:StartedInstaller = $null
+        Mock Test-Signature {
+            $script:SignatureChecks++
+            return $true
+        }
+        Mock Start-Process {
+            $script:StartedInstaller = @{
+                FilePath = $FilePath
+                ArgumentList = $ArgumentList
+            }
+            return New-FakeProcess
+        }
+        Mock Update-SessionPath { }
+
+        Invoke-Install
+
+        Should -Invoke Get-RemoteETag -Times 0 -Exactly
+        $script:SignatureChecks | Should -Be 1
+        $script:StartedInstaller.FilePath | Should -Be $installer
+        $script:StartedInstaller.ArgumentList | Should -Match "/VERYSILENT"
+        $script:StartedInstaller.ArgumentList | Should -Match "/LOG="
+        $script:StartedInstaller.ArgumentList | Should -Match "OllamaSetup\.log"
+        Test-Path $cacheDir | Should -Be $false
+    }
+
+    It "install-cached deletes the persistent cache when signature verification fails" {
+        Set-TestEnvironment @{
+            OLLAMA_INSTALL_CACHED = "1"
+            OLLAMA_VERSION = "0.21.0"
+        }
+        $cacheDir = Get-TestInstallerCacheDir '"cached-etag"'
+        $installer = Join-Path $cacheDir "OllamaSetup.exe"
+        New-Item -ItemType Directory -Path $cacheDir -Force | Out-Null
+        Set-Content -Path $installer -Value "payload" -Encoding ASCII
+        . $script:InstallScript
+
+        Mock Get-RemoteETag { throw "install-cached should not resolve remote ETags" }
+        Mock Test-Signature { $false }
+        Mock Start-Process { throw "installer should not start after signature failure" }
+
+        { Invoke-Install } | Should -Throw "*Installer signature verification failed*"
+        Should -Invoke Get-RemoteETag -Times 0 -Exactly
+        Test-Path $cacheDir | Should -Be $false
+        Should -Invoke Start-Process -Times 0 -Exactly
+    }
+    }
+
+    Context "normal install path" {
+    It "downloads default installs through the installer cache" {
+        Set-TestEnvironment
+        $cacheDir = Get-TestInstallerCacheDir '"default-etag"'
+        $installer = Join-Path $cacheDir "OllamaSetup.exe"
+        $stagingInstaller = Get-TestInstallerStagingPath '"default-etag"'
+        . $script:InstallScript
+
+        $script:DownloadedTo = $null
+        $script:StartedInstaller = $null
+        Mock Get-RemoteETag { '"default-etag"' }
+        Mock Invoke-Download {
+            $script:DownloadedTo = $OutFile
+            Set-Content -Path $OutFile -Value "payload" -Encoding ASCII
+        }
+        Mock Test-Signature { $true }
+        Mock Start-Process {
+            $script:StartedInstaller = $FilePath
+            return New-FakeProcess
+        }
+        Mock Update-SessionPath { }
+
+        Invoke-Install
+
+        $script:DownloadedTo | Should -Be $stagingInstaller
+        $script:StartedInstaller | Should -Be $installer
+        Test-Path $cacheDir | Should -Be $false
+    }
+
+    It "reuses a warm cache for normal installs and cleans it up after success" {
+        Set-TestEnvironment
+        $cacheDir = Get-TestInstallerCacheDir '"warm-etag"'
+        $installer = Join-Path $cacheDir "OllamaSetup.exe"
+        New-Item -ItemType Directory -Path $cacheDir -Force | Out-Null
+        Set-Content -Path $installer -Value "payload" -Encoding ASCII
+        . $script:InstallScript
+
+        Mock Get-RemoteETag { '"warm-etag"' }
+        Mock Invoke-Download { throw "download should not run with warm cache" }
+        Mock Test-Signature { $true }
+        Mock Start-Process { return New-FakeProcess }
+        Mock Update-SessionPath { }
+
+        Invoke-Install
+
+        Should -Invoke Invoke-Download -Times 0 -Exactly
+        Should -Invoke Start-Process -Times 1 -Exactly -ParameterFilter {
+            $FilePath -eq $installer
+        }
+        Test-Path $cacheDir | Should -Be $false
+    }
+
+    It "falls back to a throwaway temp cache for normal installs when ETags are unavailable" {
+        Set-TestEnvironment
+        . $script:InstallScript
+
+        $script:DownloadedTo = $null
+        $script:StartedInstaller = $null
+        Mock Get-RemoteETag { "" }
+        Mock Invoke-Download {
+            $script:DownloadedTo = $OutFile
+            Set-Content -Path $OutFile -Value "payload" -Encoding ASCII
+        }
+        Mock Test-Signature { $true }
+        Mock Start-Process {
+            $script:StartedInstaller = $FilePath
+            return New-FakeProcess
+        }
+        Mock Update-SessionPath { }
+
+        Invoke-Install
+
+        $script:StartedInstaller | Should -Not -BeNullOrEmpty
+        $script:DownloadedTo | Should -Be (Join-Path ("$(Split-Path $script:StartedInstaller -Parent).download") "OllamaSetup.exe")
+        $script:StartedInstaller | Should -Match ([regex]::Escape((Join-Path $env:TEMP "Ollama\install_cache")))
+        Test-Path (Split-Path $script:StartedInstaller -Parent) | Should -Be $false
+        Test-Path (Split-Path $script:DownloadedTo -Parent) | Should -Be $false
+    }
+
+    It "deletes a newly downloaded cache entry when signature verification fails" {
+        Set-TestEnvironment
+        $cacheDir = Get-TestInstallerCacheDir '"bad-signature-etag"'
+        $stagingCacheDir = Get-TestInstallerStagingCacheDir '"bad-signature-etag"'
+        . $script:InstallScript
+
+        Mock Get-RemoteETag { '"bad-signature-etag"' }
+        Mock Invoke-Download {
+            Set-Content -Path $OutFile -Value "payload" -Encoding ASCII
+        }
+        Mock Test-Signature { $false }
+        Mock Start-Process { throw "installer should not start after signature failure" }
+
+        { Invoke-Install } | Should -Throw "*Installer signature verification failed*"
+        Test-Path $cacheDir | Should -Be $false
+        Test-Path $stagingCacheDir | Should -Be $false
+        Should -Invoke Start-Process -Times 0 -Exactly
+    }
+    }
+}
+
+Describe "Windows install.ps1 integration" -Tag Integration {
+    BeforeEach {
+        Save-TestEnvironment
+        $script:RealInstallTestStarted = $false
+    }
+
+    AfterEach {
+        if ($script:RealInstallTestStarted) {
+            Invoke-TestOllamaUninstall
+            Remove-Item -LiteralPath (Join-Path $env:LOCALAPPDATA "Ollama\install_cache") -Recurse -Force -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath (Join-Path $env:LOCALAPPDATA "Ollama\upgraded") -Force -ErrorAction SilentlyContinue
+        }
+        Restore-TestEnvironment
+    }
+
+    It "installs from a local signed installer" {
+        $signedInstaller = Require-RealInstallIntegration
+        if (-not $signedInstaller) { return }
+
+        $server = $null
+        try {
+            $installDir = Join-Path $TestDrive ("OllamaInstall-" + [guid]::NewGuid().ToString("N"))
+            Set-TestEnvironment @{ OLLAMA_INSTALL_DIR = $installDir }
+            $script:RealInstallTestStarted = $true
+            $server = Start-LocalHttpServer -InstallerPath $signedInstaller
+            if (-not $server) { return }
+            $installScript = New-TestInstallScript -DownloadBaseUrl $server.DownloadBaseUrl
+
+            $result = Invoke-InstallScript -InstallScriptPath $installScript
+            $result.ExitCode | Should -Be 0
+
+            Test-Path -LiteralPath (Join-Path $installDir "Ollama app.exe") | Should -Be $true
+            Test-Path -LiteralPath (Join-Path $installDir "ollama.exe") | Should -Be $true
+            Get-TestOllamaRegistryKey | Should -Not -BeNullOrEmpty
+        } finally {
+            Stop-LocalHttpServer $server
+        }
+    }
+
+    It "upgrades from pinned 0.21.0 through the two-phase app cache flow" {
+        $signedInstaller = Require-RealInstallIntegration
+        if (-not $signedInstaller) { return }
+        $oldInstaller = Get-PinnedUpgradeInstaller
+
+        $server = $null
+        try {
+            $installDir = Join-Path $TestDrive ("OllamaInstall-" + [guid]::NewGuid().ToString("N"))
+            Set-TestEnvironment @{ OLLAMA_INSTALL_DIR = $installDir }
+            $script:RealInstallTestStarted = $true
+
+            Invoke-TestInnoInstall -InstallerPath $oldInstaller -InstallDir $installDir
+            Test-Path -LiteralPath (Join-Path $installDir "Ollama app.exe") | Should -Be $true
+            $oldVersion = Get-TestOllamaInstalledVersion -InstallDir $installDir
+            $oldVersion | Should -Not -BeNullOrEmpty
+
+            $etag = "real-install-cache-etag"
+            $cacheDir = Get-TestInstallerCacheDir $etag
+            $server = Start-LocalHttpServer -InstallerPath $signedInstaller -ETag $etag
+            if (-not $server) { return }
+            $installScript = New-TestInstallScript -DownloadBaseUrl $server.DownloadBaseUrl
+
+            $result = Invoke-InstallScript -InstallScriptPath $installScript -EnvVars @{ OLLAMA_CACHE_ONLY = "1" }
+            $result.ExitCode | Should -Be 0
+
+            $installer = Join-Path $cacheDir "OllamaSetup.exe"
+            Test-Path -LiteralPath $installer | Should -Be $true
+
+            $result = Invoke-InstallScript -InstallScriptPath $installScript -EnvVars @{ OLLAMA_INSTALL_CACHED = "1" }
+            $result.ExitCode | Should -Be 0
+
+            Test-Path -LiteralPath (Join-Path $installDir "Ollama app.exe") | Should -Be $true
+            Get-TestOllamaRegistryKey | Should -Not -BeNullOrEmpty
+            Test-Path -LiteralPath $cacheDir | Should -Be $false
+            $newVersion = Get-TestOllamaInstalledVersion -InstallDir $installDir
+            $newVersion | Should -Not -BeNullOrEmpty
+            $newVersion | Should -Not -Be $oldVersion
+        } finally {
+            Stop-LocalHttpServer $server
+        }
+    }
+}

--- a/scripts/tests/update-server.py
+++ b/scripts/tests/update-server.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Serve a loopback Ollama app update endpoint for manual upgrade testing."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import http.server
+import json
+import mimetypes
+import sys
+from pathlib import Path
+from typing import Optional
+from urllib.parse import urlparse
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def default_install_script(root: Path) -> Path:
+    dist_script = root / "dist" / "install.ps1"
+    if dist_script.exists():
+        return dist_script
+    return root / "scripts" / "install.ps1"
+
+
+def file_etag(path: Path) -> str:
+    stat = path.stat()
+    payload = f"{path.resolve()}:{stat.st_size}:{stat.st_mtime_ns}".encode("utf-8")
+    return '"' + hashlib.sha256(payload).hexdigest()[:32] + '"'
+
+
+def patch_install_script(source: Path, output: Path, download_base_url: str) -> Path:
+    content = source.read_text(encoding="utf-8-sig")
+    old = '$DownloadBaseURL = "https://ollama.com/download"'
+    new = f'$DownloadBaseURL = "{download_base_url.rstrip("/")}"'
+    if old not in content:
+        raise SystemExit(f"{source} does not contain expected DownloadBaseURL assignment")
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(content.replace(old, new), encoding="utf-8")
+    return output
+
+
+class UpdateHandler(http.server.BaseHTTPRequestHandler):
+    server_version = "OllamaUpdateTest/1.0"
+
+    def do_HEAD(self) -> None:
+        self.handle_request(send_body=False)
+
+    def do_GET(self) -> None:
+        self.handle_request(send_body=True)
+
+    def handle_request(self, send_body: bool) -> None:
+        parsed = urlparse(self.path)
+        path = parsed.path
+        if path in {"/api/update", "/update.json"}:
+            self.serve_update_json(send_body)
+            return
+        if path == "/download/install.ps1":
+            self.serve_file(self.server.install_script, self.server.script_etag, send_body)
+            return
+        if path == "/download/OllamaSetup.exe":
+            self.serve_file(self.server.installer, self.server.installer_etag, send_body)
+            return
+
+        self.send_error(404, "not found")
+
+    def serve_update_json(self, send_body: bool) -> None:
+        body = {
+            "url": f"{self.server.base_url}/download/OllamaSetup.exe",
+        }
+        if self.server.version:
+            body["version"] = self.server.version
+
+        data = json.dumps(body, separators=(",", ":")).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        if send_body:
+            self.wfile.write(data)
+
+    def serve_file(self, path: Path, etag: Optional[str], send_body: bool) -> None:
+        if not path.exists():
+            self.send_error(404, f"missing {path}")
+            return
+
+        content_type = mimetypes.guess_type(str(path))[0] or "application/octet-stream"
+        self.send_response(200)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(path.stat().st_size))
+        if etag is not None:
+            self.send_header("ETag", etag)
+        self.end_headers()
+
+        if send_body:
+            with path.open("rb") as fp:
+                while True:
+                    chunk = fp.read(1024 * 1024)
+                    if not chunk:
+                        break
+                    self.wfile.write(chunk)
+
+    def log_message(self, fmt: str, *args: object) -> None:
+        sys.stderr.write("%s - %s\n" % (self.log_date_time_string(), fmt % args))
+
+
+class UpdateServer(http.server.ThreadingHTTPServer):
+    def __init__(
+        self,
+        address: tuple[str, int],
+        handler,
+        *,
+        base_url: str,
+        installer: Path,
+        install_script: Path,
+        version: str,
+        installer_etag: Optional[str],
+        script_etag: Optional[str],
+    ):
+        super().__init__(address, handler)
+        self.base_url = base_url
+        self.installer = installer
+        self.install_script = install_script
+        self.version = version
+        self.installer_etag = installer_etag
+        self.script_etag = script_etag
+
+
+def parse_args() -> argparse.Namespace:
+    root = repo_root()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="127.0.0.1", help="Loopback bind host")
+    parser.add_argument("--port", type=int, default=8765, help="Bind port")
+    parser.add_argument("--version", default="", help="Optional update response version")
+    parser.add_argument("--installer-etag", default="", help="Override the installer ETag")
+    parser.add_argument("--script-etag", default="", help="Override the install.ps1 ETag")
+    parser.add_argument("--omit-installer-etag", action="store_true", help="Serve OllamaSetup.exe without an ETag")
+    parser.add_argument("--omit-script-etag", action="store_true", help="Serve install.ps1 without an ETag")
+    parser.add_argument("--installer", type=Path, default=root / "dist" / "OllamaSetup.exe", help="OllamaSetup.exe to serve")
+    parser.add_argument("--install-script", type=Path, default=default_install_script(root), help="install.ps1 to serve")
+    parser.add_argument(
+        "--patch-install-script",
+        action="store_true",
+        help="Generate a test install.ps1 with DownloadBaseURL pointed at this server",
+    )
+    parser.add_argument(
+        "--output-install-script",
+        type=Path,
+        default=root / ".cache" / "update-server" / "install.ps1",
+        help="Path for the generated patched install.ps1",
+    )
+    parser.add_argument(
+        "--prepare-only",
+        action="store_true",
+        help="Generate files and print paths without starting the server",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    installer = args.installer.resolve()
+    install_script = args.install_script.resolve()
+    base_url = f"http://{args.host}:{args.port}"
+
+    if not installer.exists():
+        raise SystemExit(f"installer not found: {installer}")
+    if not install_script.exists():
+        raise SystemExit(f"install script not found: {install_script}")
+
+    if args.patch_install_script:
+        install_script = patch_install_script(
+            install_script,
+            args.output_install_script.resolve(),
+            f"{base_url}/download",
+        )
+
+    installer_etag = None if args.omit_installer_etag else (args.installer_etag or file_etag(installer))
+    script_etag = None if args.omit_script_etag else (args.script_etag or file_etag(install_script))
+
+    print(f"Update endpoint: {base_url}/api/update")
+    print(f"Installer URL:   {base_url}/download/OllamaSetup.exe")
+    print(f"install.ps1:     {install_script}")
+    print(f"Installer:       {installer}")
+    print(f"Version field:   {args.version or '(omitted)'}")
+    print(f"Installer ETag:  {installer_etag or '(omitted)'}")
+    print(f"install.ps1 ETag:{script_etag or '(omitted)'}")
+
+    if args.prepare_only:
+        return
+
+    server = UpdateServer(
+        (args.host, args.port),
+        UpdateHandler,
+        base_url=base_url,
+        installer=installer,
+        install_script=install_script,
+        version=args.version,
+        installer_etag=installer_etag,
+        script_etag=script_etag,
+    )
+    print("Serving until interrupted.")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/update-server.py
+++ b/scripts/tests/update-server.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Serve a loopback Ollama app update endpoint for manual upgrade testing.
+
+The server only models the public update surface: an update JSON response with
+an artifact URL and optional version, plus files available under /download/.
+It does not model ollama.com rollout, account, or policy logic.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import http.server
+import json
+import mimetypes
+import sys
+from pathlib import Path
+from typing import Optional
+from urllib.parse import parse_qs, quote, unquote, urlparse
+
+
+APP_ARTIFACTS = {
+    "windows": "OllamaSetup.exe",
+    "darwin": "Ollama-darwin.zip",
+}
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def file_etag(path: Path) -> str:
+    stat = path.stat()
+    payload = f"{path.resolve()}:{stat.st_size}:{stat.st_mtime_ns}".encode("utf-8")
+    return '"' + hashlib.sha256(payload).hexdigest()[:32] + '"'
+
+
+def content_etag(data: bytes) -> str:
+    return '"' + hashlib.sha256(data).hexdigest()[:32] + '"'
+
+
+def sidecar_etag(path: Path) -> Optional[str]:
+    sidecar = path.with_name(path.name + ".etag")
+    if not sidecar.exists():
+        return None
+    etag = sidecar.read_text(encoding="utf-8").strip()
+    return etag or None
+
+
+class ServedFile:
+    def __init__(self, path: Path, etag: Optional[str], content: Optional[bytes] = None):
+        self.path = path
+        self.etag = etag
+        self.content = content
+
+
+class UpdateHandler(http.server.BaseHTTPRequestHandler):
+    server_version = "OllamaUpdateTest/1.0"
+
+    def do_HEAD(self) -> None:
+        self.handle_request(send_body=False)
+
+    def do_GET(self) -> None:
+        self.handle_request(send_body=True)
+
+    def handle_request(self, send_body: bool) -> None:
+        parsed = urlparse(self.path)
+        path = parsed.path
+        if path in {"/api/update", "/update.json"}:
+            self.serve_update_json(parsed.query, send_body)
+            return
+
+        if path.startswith("/download/"):
+            name = unquote(path.removeprefix("/download/"))
+            if "/" not in name and "\\" not in name and name in self.server.files:
+                self.serve_file(self.server.files[name], send_body)
+                return
+
+        self.send_error(404, "not found")
+
+    def serve_update_json(self, query: str, send_body: bool) -> None:
+        artifact_name = self.server.update_artifact_name(query)
+        if not artifact_name:
+            self.send_response(204)
+            self.end_headers()
+            return
+
+        body = {
+            "url": f"{self.server.base_url}/download/{quote(artifact_name)}",
+        }
+        if self.server.version:
+            body["version"] = self.server.version
+
+        data = json.dumps(body, separators=(",", ":")).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        if send_body:
+            self.wfile.write(data)
+
+    def serve_file(self, served: ServedFile, send_body: bool) -> None:
+        if not served.path.exists():
+            self.send_error(404, f"missing {served.path}")
+            return
+
+        content_type = mimetypes.guess_type(str(served.path))[0] or "application/octet-stream"
+        content_length = len(served.content) if served.content is not None else served.path.stat().st_size
+        self.send_response(200)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(content_length))
+        if served.etag is not None:
+            self.send_header("ETag", served.etag)
+        self.end_headers()
+
+        if send_body:
+            if served.content is not None:
+                self.wfile.write(served.content)
+            else:
+                with served.path.open("rb") as fp:
+                    while True:
+                        chunk = fp.read(1024 * 1024)
+                        if not chunk:
+                            break
+                        self.wfile.write(chunk)
+
+    def log_message(self, fmt: str, *args: object) -> None:
+        sys.stderr.write("%s - %s\n" % (self.log_date_time_string(), fmt % args))
+
+
+class UpdateServer(http.server.ThreadingHTTPServer):
+    def __init__(
+        self,
+        address: tuple[str, int],
+        handler,
+        *,
+        base_url: str,
+        files: dict[str, ServedFile],
+        version: str,
+    ):
+        super().__init__(address, handler)
+        self.base_url = base_url
+        self.files = files
+        self.version = version
+
+    def update_artifact_name(self, query: str) -> str:
+        os_name = parse_qs(query).get("os", [""])[0].lower()
+        if os_name in APP_ARTIFACTS:
+            name = APP_ARTIFACTS[os_name]
+            return name if name in self.files else ""
+
+        for name in APP_ARTIFACTS.values():
+            if name in self.files:
+                return name
+        return ""
+
+
+def patched_install_script(path: Path, download_base_url: str) -> bytes:
+    content = path.read_text(encoding="utf-8-sig")
+    old = '$DownloadBaseURL = "https://ollama.com/download"'
+    new = f'$DownloadBaseURL = "{download_base_url.rstrip("/")}"'
+    if content.count(old) != 1:
+        raise ValueError(
+            f"{path} does not contain the expected DownloadBaseURL assignment; "
+            "refusing to serve an install.ps1 that may download from production"
+        )
+    return content.replace(old, new, 1).encode("utf-8")
+
+
+def discover_files(root: Path, dist: Path, omit_etags: bool, download_base_url: str) -> dict[str, ServedFile]:
+    files: dict[str, ServedFile] = {}
+    for path in dist.iterdir() if dist.exists() else []:
+        if not path.is_file():
+            continue
+        if path.name.endswith(".etag"):
+            continue
+        if path.name == "install.ps1":
+            content = patched_install_script(path, download_base_url)
+            etag = None if omit_etags else (sidecar_etag(path) or content_etag(content))
+            files[path.name] = ServedFile(path, etag, content)
+            continue
+        etag = None if omit_etags else (sidecar_etag(path) or file_etag(path))
+        files[path.name] = ServedFile(path, etag)
+
+    install_script = root / "scripts" / "install.ps1"
+    if "install.ps1" not in files and install_script.exists():
+        content = patched_install_script(install_script, download_base_url)
+        etag = None if omit_etags else content_etag(content)
+        files["install.ps1"] = ServedFile(install_script, etag, content)
+    return files
+
+
+def parse_args() -> argparse.Namespace:
+    root = repo_root()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="127.0.0.1", help="Loopback bind host")
+    parser.add_argument("--port", type=int, default=8765, help="Bind port")
+    parser.add_argument("--dist", type=Path, default=root / "dist", help="Directory of artifacts to serve")
+    parser.add_argument("--version", default="", help="Optional update response version")
+    parser.add_argument("--omit-etags", action="store_true", help="Serve files without ETag headers")
+    parser.add_argument("--prepare-only", action="store_true", help="Print resolved files without starting the server")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    root = repo_root()
+    dist = args.dist.resolve()
+    base_url = f"http://{args.host}:{args.port}"
+    try:
+        files = discover_files(root, dist, args.omit_etags, f"{base_url}/download")
+    except ValueError as err:
+        raise SystemExit(str(err)) from err
+
+    if not files:
+        raise SystemExit(f"no files found in dist directory: {dist}")
+
+    print(f"Update endpoint: {base_url}/api/update")
+    print(f"Dist:            {dist}")
+    print(f"Version field:   {args.version or '(omitted)'}")
+    for name, served in sorted(files.items()):
+        print(f"/download/{quote(name)}")
+        print(f"  file: {served.path}")
+        print(f"  etag: {served.etag or '(omitted)'}")
+
+    if args.prepare_only:
+        return
+
+    server = UpdateServer(
+        (args.host, args.port),
+        UpdateHandler,
+        base_url=base_url,
+        files=files,
+        version=args.version,
+    )
+    print("Serving until interrupted.")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Teach the Windows app updater to stage signed install.ps1 updates and let the script cache payloads before startup upgrade. Add local loopback test hooks and warn on explicit Inno Setup failure logs so detached upgrade failures point developers/users to the log directory.

Depends on #16909 merging and shipping in a release before this can merge.