### PR TITLE
llama/compat: fix GLM-OCR tokenizer metadata

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -84,7 +84,7 @@ jobs:
           - preset: CPU
             superbuild_target: ollama-local
             superbuild_dir: build/local-superbuild
-            superbuild_args: ''
+            superbuild_args: '-DOLLAMA_LLAMA_CPP_BUILD_COMPAT_TESTS=ON'
             expected_payload: lib/ollama/llama-server
             install-go: true
           - preset: CUDA
@@ -169,6 +169,10 @@ jobs:
           "$RUNNER_TEMP/ollama-local/bin/ollama" --version
           "$RUNNER_TEMP/ollama-local/lib/ollama/llama-server" --version
           test -x "$RUNNER_TEMP/ollama-local/lib/ollama/llama-quantize"
+      - name: Run llama.cpp compatibility tests
+        if: matrix.superbuild_target == 'ollama-local'
+        run: |
+          ctest --test-dir "${{ matrix.superbuild_dir }}/llama-server-local" --output-on-failure -R ollama-compat-test
   windows:
     needs: [changes]
     if: needs.changes.outputs.changed == 'True'

--- a/cmake/local.cmake
+++ b/cmake/local.cmake
@@ -12,6 +12,7 @@ set(_ollama_mlx_backends_doc "Semicolon-separated MLX backends to build: cuda_v1
 set(OLLAMA_VERSION "0.0.0" CACHE STRING "Ollama version embedded in the local Go binary")
 set(OLLAMA_PAYLOAD_INSTALL_PREFIX "${CMAKE_BINARY_DIR}" CACHE PATH
     "Build-time staging prefix for nested Ollama native payloads")
+option(OLLAMA_LLAMA_CPP_BUILD_COMPAT_TESTS "Build llama.cpp compatibility tests for the local payload" OFF)
 
 string(REGEX REPLACE "^v" "" OLLAMA_VERSION "${OLLAMA_VERSION}")
 
@@ -607,9 +608,15 @@ if(OLLAMA_HAVE_LLAMA_SERVER)
         endif()
     endif()
 
+    set(_cpu_targets llama-server llama-quantize)
+    if(OLLAMA_LLAMA_CPP_BUILD_COMPAT_TESTS)
+        list(APPEND _cpu_args -DOLLAMA_LLAMA_CPP_BUILD_COMPAT_TESTS=ON)
+        list(APPEND _cpu_targets ollama-compat-test)
+    endif()
+
     ollama_add_llama_server_build(local
         RUNNER_DIR ""
-        TARGETS llama-server llama-quantize
+        TARGETS ${_cpu_targets}
         CMAKE_ARGS ${_cpu_args})
 
     add_custom_target(ollama-local ALL

--- a/llama/compat/llama-ollama-compat-test.cpp
+++ b/llama/compat/llama-ollama-compat-test.cpp
@@ -1,0 +1,184 @@
+#include "llama-ollama-compat.h"
+
+#include "ggml.h"
+#include "gguf.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <string>
+
+namespace {
+
+int fail(const char * msg) {
+    std::fprintf(stderr, "%s\n", msg);
+    return 1;
+}
+
+bool expect_u32(const gguf_context * meta, const char * key, uint32_t want) {
+    const int64_t kid = gguf_find_key(meta, key);
+    if (kid < 0) {
+        std::fprintf(stderr, "missing key: %s\n", key);
+        return false;
+    }
+    if (gguf_get_kv_type(meta, kid) != GGUF_TYPE_UINT32) {
+        std::fprintf(stderr, "%s has type %d, want %d\n", key, gguf_get_kv_type(meta, kid), GGUF_TYPE_UINT32);
+        return false;
+    }
+    const uint32_t got = gguf_get_val_u32(meta, kid);
+    if (got != want) {
+        std::fprintf(stderr, "%s = %u, want %u\n", key, got, want);
+        return false;
+    }
+    return true;
+}
+
+bool expect_str(const gguf_context * meta, const char * key, const char * want) {
+    const int64_t kid = gguf_find_key(meta, key);
+    if (kid < 0 || gguf_get_kv_type(meta, kid) != GGUF_TYPE_STRING) {
+        std::fprintf(stderr, "missing string key: %s\n", key);
+        return false;
+    }
+    const char * got = gguf_get_val_str(meta, kid);
+    if (!got || std::string(got) != want) {
+        std::fprintf(stderr, "%s = %s, want %s\n", key, got ? got : "<null>", want);
+        return false;
+    }
+    return true;
+}
+
+bool expect_missing(const gguf_context * meta, const char * key) {
+    if (gguf_find_key(meta, key) >= 0) {
+        std::fprintf(stderr, "unexpected key: %s\n", key);
+        return false;
+    }
+    return true;
+}
+
+void set_minimal_glmocr_kvs(gguf_context * meta) {
+    const int32_t mrope_section[] = { 16, 24, 24 };
+
+    gguf_set_val_str(meta, "general.architecture", "glmocr");
+    gguf_set_val_u32(meta, "glmocr.attention.key_length", 128);
+    gguf_set_val_u32(meta, "glmocr.block_count", 0);
+    gguf_set_arr_data(meta, "glmocr.rope.mrope_section", GGUF_TYPE_INT32, mrope_section, 3);
+    gguf_set_val_str(meta, "tokenizer.ggml.pre", "llama-bpe");
+}
+
+ggml_context * init_ggml_context() {
+    ggml_init_params params = { 16 * 1024, nullptr, false };
+    return ggml_init(params);
+}
+
+} // namespace
+
+int main() {
+    bool ok = true;
+
+    {
+        gguf_context * meta = gguf_init_empty();
+        if (!meta) return fail("gguf_init_empty failed");
+        ggml_context * ctx = init_ggml_context();
+        if (!ctx) {
+            gguf_free(meta);
+            return fail("ggml_init failed");
+        }
+
+        const char * tokens[] = {
+            "<|endoftext|>",
+            "x",
+            "<|user|>",
+        };
+
+        set_minimal_glmocr_kvs(meta);
+        gguf_set_arr_str(meta, "tokenizer.ggml.tokens", tokens, 3);
+
+        // Same numeric value but wrong GGUF type: must be rewritten as UINT32.
+        gguf_set_val_i32(meta, "tokenizer.ggml.bos_token_id", 0);
+        // Wrong value: must be rewritten to <|endoftext|>.
+        gguf_set_val_u32(meta, "tokenizer.ggml.unknown_token_id", 99);
+        // Wrong type and value: must be rewritten to <|user|>.
+        gguf_set_val_i32(meta, "tokenizer.ggml.eot_token_id", -1);
+
+        std::string arch = "glmocr";
+        llama_ollama_compat::translate_metadata(nullptr, meta, ctx, arch, "test.gguf");
+
+        ok = expect_str(meta, "general.architecture", "glm4") && ok;
+        ok = arch == "glm4" && ok;
+        ok = expect_str(meta, "tokenizer.ggml.pre", "chatglm-bpe") && ok;
+        ok = expect_u32(meta, "tokenizer.ggml.bos_token_id", 0) && ok;
+        ok = expect_u32(meta, "tokenizer.ggml.unknown_token_id", 0) && ok;
+        ok = expect_u32(meta, "tokenizer.ggml.eot_token_id", 2) && ok;
+        ok = expect_u32(meta, "glm4.rope.dimension_count", 128) && ok;
+
+        const int64_t mrope_kid = gguf_find_key(meta, "glm4.rope.dimension_sections");
+        if (mrope_kid < 0 || gguf_get_arr_n(meta, mrope_kid) != 4) {
+            std::fprintf(stderr, "glm4.rope.dimension_sections was not padded to 4 entries\n");
+            ok = false;
+        }
+
+        ggml_free(ctx);
+        gguf_free(meta);
+    }
+
+    {
+        gguf_context * meta = gguf_init_empty();
+        if (!meta) return fail("gguf_init_empty failed");
+        ggml_context * ctx = init_ggml_context();
+        if (!ctx) {
+            gguf_free(meta);
+            return fail("ggml_init failed");
+        }
+
+        const char * tokens[] = {
+            "<|endoftext|>",
+            "x",
+        };
+
+        set_minimal_glmocr_kvs(meta);
+        gguf_set_arr_str(meta, "tokenizer.ggml.tokens", tokens, 2);
+
+        std::string arch = "glmocr";
+        llama_ollama_compat::translate_metadata(nullptr, meta, ctx, arch, "test-missing-user.gguf");
+
+        ok = expect_u32(meta, "tokenizer.ggml.bos_token_id", 0) && ok;
+        ok = expect_u32(meta, "tokenizer.ggml.unknown_token_id", 0) && ok;
+        ok = expect_missing(meta, "tokenizer.ggml.eot_token_id") && ok;
+
+        ggml_free(ctx);
+        gguf_free(meta);
+    }
+
+    {
+        gguf_context * meta = gguf_init_empty();
+        if (!meta) return fail("gguf_init_empty failed");
+        ggml_context * ctx = init_ggml_context();
+        if (!ctx) {
+            gguf_free(meta);
+            return fail("ggml_init failed");
+        }
+
+        const char * tokens[] = {
+            "<|endoftext|>",
+            "<|user|>",
+        };
+
+        gguf_set_val_str(meta, "general.architecture", "glm4");
+        gguf_set_val_str(meta, "tokenizer.ggml.pre", "llama-bpe");
+        gguf_set_arr_str(meta, "tokenizer.ggml.tokens", tokens, 2);
+
+        std::string arch = "glm4";
+        llama_ollama_compat::translate_metadata(nullptr, meta, ctx, arch, "test-native-glm4.gguf");
+
+        ok = expect_str(meta, "general.architecture", "glm4") && ok;
+        ok = arch == "glm4" && ok;
+        ok = expect_str(meta, "tokenizer.ggml.pre", "llama-bpe") && ok;
+        ok = expect_missing(meta, "tokenizer.ggml.bos_token_id") && ok;
+        ok = expect_missing(meta, "tokenizer.ggml.unknown_token_id") && ok;
+        ok = expect_missing(meta, "tokenizer.ggml.eot_token_id") && ok;
+
+        ggml_free(ctx);
+        gguf_free(meta);
+    }
+
+    return ok ? 0 : 1;
+}

--- a/llama/compat/llama-ollama-compat.cpp
+++ b/llama/compat/llama-ollama-compat.cpp
@@ -147,6 +147,30 @@ bool token_at_equals(const gguf_context * meta, size_t idx, const char * want) {
     return tok && std::strcmp(tok, want) == 0;
 }
 
+bool find_token_id(const gguf_context * meta, const char * want, uint32_t & out) {
+    const int64_t kid = gguf_find_key(meta, "tokenizer.ggml.tokens");
+    if (kid < 0 || gguf_get_kv_type(meta, kid) != GGUF_TYPE_ARRAY) return false;
+    if (gguf_get_arr_type(meta, kid) != GGUF_TYPE_STRING) return false;
+
+    const size_t n = gguf_get_arr_n(meta, kid);
+    for (size_t i = 0; i < n; ++i) {
+        const char * tok = gguf_get_arr_str(meta, kid, i);
+        if (tok && std::strcmp(tok, want) == 0) {
+            out = (uint32_t) i;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void set_u32_kv(gguf_context * meta, const char * key, uint32_t value) {
+    const int64_t kid = gguf_find_key(meta, key);
+    if (kid < 0 || gguf_get_kv_type(meta, kid) != GGUF_TYPE_UINT32 || gguf_get_val_u32(meta, kid) != value) {
+        gguf_set_val_u32(meta, key, value);
+    }
+}
+
 bool string_kv_equals(const gguf_context * meta, const char * key, const char * want) {
     const int64_t kid = gguf_find_key(meta, key);
     if (kid < 0 || gguf_get_kv_type(meta, kid) != GGUF_TYPE_STRING) return false;
@@ -1427,6 +1451,20 @@ void handle_glmocr(const llama_model_loader * ml, gguf_context * meta,
             if (cur && std::strcmp(cur, "chatglm-bpe") != 0) {
                 gguf_set_val_str(meta, "tokenizer.ggml.pre", "chatglm-bpe");
             }
+        }
+    }
+    // Mirror convert_glmocr.go for already-published Ollama-format GGUFs.
+    // New conversions write these fields, but older published files can lack
+    // them or use the wrong GGUF type/value, causing llama.cpp to miss
+    // GLM-OCR's turn-ending token.
+    {
+        uint32_t token_id = 0;
+        if (find_token_id(meta, "<|endoftext|>", token_id)) {
+            set_u32_kv(meta, "tokenizer.ggml.bos_token_id", token_id);
+            set_u32_kv(meta, "tokenizer.ggml.unknown_token_id", token_id);
+        }
+        if (find_token_id(meta, "<|user|>", token_id)) {
+            set_u32_kv(meta, "tokenizer.ggml.eot_token_id", token_id);
         }
     }
     // Tensor renames (substring): each leaf appears once per block and

--- a/llama/server/CMakeLists.txt
+++ b/llama/server/CMakeLists.txt
@@ -192,6 +192,7 @@ FetchContent_MakeAvailable(llama_cpp)
 if(_ollama_link_compat_sources AND DEFINED OLLAMA_LLAMA_CPP_COMPAT_DIR)
     file(GLOB _compat_sources CONFIGURE_DEPENDS
         ${OLLAMA_LLAMA_CPP_COMPAT_DIR}/*.cpp)
+    list(FILTER _compat_sources EXCLUDE REGEX "-test\\.cpp$")
     foreach(_compat_target IN ITEMS llama mtmd)
         if(TARGET ${_compat_target})
             target_sources(${_compat_target} PRIVATE ${_compat_sources})
@@ -216,6 +217,33 @@ if(_ollama_link_compat_sources AND DEFINED OLLAMA_LLAMA_CPP_COMPAT_DIR)
             ${OLLAMA_LLAMA_CPP_COMPAT_DIR}/models
             ${llama_cpp_SOURCE_DIR}/src)
     endif()
+endif()
+
+option(OLLAMA_LLAMA_CPP_BUILD_COMPAT_TESTS
+    "Build Ollama llama.cpp compatibility tests"
+    OFF)
+if(OLLAMA_LLAMA_CPP_BUILD_COMPAT_TESTS AND _ollama_link_compat_sources AND TARGET llama)
+    enable_testing()
+    add_executable(ollama-compat-test
+        ${OLLAMA_LLAMA_CPP_COMPAT_DIR}/llama-ollama-compat-test.cpp
+        ${_compat_sources})
+    target_link_libraries(ollama-compat-test PRIVATE ggml)
+    target_compile_definitions(ollama-compat-test PRIVATE OLLAMA_COMPAT_MTMD_BUILD)
+    target_compile_features(ollama-compat-test PRIVATE cxx_std_17)
+    target_include_directories(ollama-compat-test PRIVATE
+        ${OLLAMA_LLAMA_CPP_COMPAT_DIR}
+        ${OLLAMA_LLAMA_CPP_COMPAT_DIR}/models
+        ${llama_cpp_SOURCE_DIR}/include
+        ${llama_cpp_SOURCE_DIR}/ggml/include
+        ${llama_cpp_SOURCE_DIR}/src)
+    set_target_properties(ollama-compat-test PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+        RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}/bin/Debug"
+        RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/bin/Release")
+    if(MSVC)
+        target_compile_options(ollama-compat-test PRIVATE /utf-8)
+    endif()
+    add_test(NAME ollama-compat-test COMMAND ollama-compat-test)
 endif()
 
 # Find GPU toolkits for runtime dependency bundling.


### PR DESCRIPTION
## Summary
- Mirror `convert/convert_glmocr.go` tokenizer metadata for already-published Ollama-format GLM-OCR GGUFs handled by the temporary `llama/compat` layer.
- Normalize missing, wrong-typed, or wrong-valued tokenizer IDs on legacy `general.architecture=glmocr` files:
  - `tokenizer.ggml.bos_token_id` and `tokenizer.ggml.unknown_token_id` -> `<|endoftext|>`
  - `tokenizer.ggml.eot_token_id` -> `<|user|>`
- Keep the change scoped to the legacy `glmocr` compatibility path; native `glm4` metadata is left untouched.
- Build and run the new C++ compat regression test in the Linux CPU CI path.

Fixes #16892

## Why this belongs in compat
`llama/compat/README.md` describes this layer as a temporary bridge for existing published model blobs whose metadata no longer matches current llama.cpp loaders. This is the same case: new conversions already write the GLM-OCR tokenizer IDs, but published Ollama-format GLM-OCR GGUFs can be missing or carry malformed values, so llama.cpp can miss the turn-ending token and continue until the length limit.

## Verification
- `go test ./model/renderers ./llm`
- `cmake --build build/local-superbuild --target ollama-llama-server-local --parallel 8`
- `ctest --test-dir build/local-superbuild/llama-server-local --output-on-failure -R ollama-compat-test`
- Manual runtime smoke with prompt `hi`:
  - v0.30.10: `done_reason=length`, `eval_count=4089`
  - patched: `done_reason=stop`, `eval_count=40`

## Dependencies
- No new runtime dependencies.
