### PR TITLE
cmd: keep nested image paths with dotted directories intact

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -606,7 +606,12 @@ func extractFileNames(input string) []string {
 	// Regex to match file paths starting with optional drive letter, / ./ \ or .\ and include escaped or unescaped spaces (\ or %20)
 	// and followed by more characters and a file extension
 	// This will capture non filename strings, but we'll check for file existence to remove mismatches
-	regexPattern := `(?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp|wav)\b`
+	//
+	// The optional leading group consumes intermediate path segments that
+	// themselves end in an image extension followed by a path separator (e.g. a
+	// parent directory named "image.png/"). Without it, the lazy match would
+	// stop at the first extension and fracture a single path into pieces.
+	regexPattern := `(?:[a-zA-Z]:)?(?:\./|/|\\)(?:[\S\\ ]+?\.(?i:jpg|jpeg|png|webp|wav)[/\\])*[\S\\ ]+?\.(?i:jpg|jpeg|png|webp|wav)\b`
 	re := regexp.MustCompile(regexPattern)
 
 	return re.FindAllString(input, -1)

--- a/cmd/interactive_test.go
+++ b/cmd/interactive_test.go
@@ -64,6 +64,22 @@ d:\path with\spaces\thirteen.WEBP some ending
 	assert.Contains(t, res[12], "d:")
 }
 
+// A path whose parent directory name ends in a valid image extension must be
+// captured as a single path, not fractured at the intermediate extension.
+func TestExtractFilenamesNestedExtensions(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected []string
+	}{
+		{"./image.png/image.png", []string{"./image.png/image.png"}},
+		{"/a/photo.png/real.jpg", []string{"/a/photo.png/real.jpg"}},
+		{`c:\dir.webp\sub.jpeg\final.png`, []string{`c:\dir.webp\sub.jpeg\final.png`}},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.expected, extractFileNames(tc.input), "input %q", tc.input)
+	}
+}
+
 // Ensure that file paths wrapped in single quotes are removed with the quotes.
 func TestExtractFileDataRemovesQuotedFilepath(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
extractFileNames used a lazy quantifier that stopped at the first valid image extension, so a path whose parent directory ends in an image extension (e.g. ./image.png/image.png) was fractured into two fragments. Allow the match to consume intermediate segment.ext/ directory components so the full path is captured as one token, and add a regression test covering nested extensions on both Unix and Windows style paths.

Fixes #16680