### PR TITLE
fix: sidebar renders open on initial load without animation

### DIFF
--- a/app/ui/app/src/hooks/useSettings.ts
+++ b/app/ui/app/src/hooks/useSettings.ts
@@ -51,7 +51,7 @@ export function useSettings() {
       thinkEnabled: settingsData?.settings?.ThinkEnabled ?? false,
       thinkLevel: settingsData?.settings?.ThinkLevel ?? "none",
       selectedModel: settingsData?.settings?.SelectedModel ?? "",
-      sidebarOpen: settingsData?.settings?.SidebarOpen ?? false,
+      sidebarOpen: settingsData?.settings?.SidebarOpen ?? true,
       lastHomeView: settingsData?.settings?.LastHomeView ?? "launch",
     }),
     [settingsData?.settings],


### PR DESCRIPTION
fixes #12954

- Changed default sidebarOpen state to true in useSettings hook.
- This ensures that on first load (no saved setting) the sidebar is open without animating from closed to open.
- If a user has previously closed the sidebar, it will start open and then animate closed when the saved setting loads (this is a known limitation to be improved in a future PR).