### PR TITLE
fix: allow image paths with spaces in CLI drag and drop

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -606,10 +606,7 @@ func extractFileNames(input string) []string {
 	// Regex to match file paths starting with optional drive letter, / ./ \ or .\ and include escaped or unescaped spaces (\ or %20)
 	// and followed by more characters and a file extension
 	// This will capture non filename strings, but we'll check for file existence to remove mismatches
-	regexPattern := `(?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp|wav)\b`
-	re := regexp.MustCompile(regexPattern)
-
-	return re.FindAllString(input, -1)
+	`regexPattern := `(?:[a-zA-Z]:)?(?:\\.\\/|/|\\\\)[^\\r\\n]+?\\.(?i:jpg|jpeg|png|webp|wav)\\b`\n	return re.FindAllString(input, -1)
 }
 
 func extractFileData(input string) (string, []api.ImageData, error) {


### PR DESCRIPTION
Fixes #10333

- Changed the regex pattern in extractFileNames to match any character except newline
  (using [^\r\n]+) instead of [\\S\\ ]+? which was too restrictive and caused
  paths with spaces to be split incorrectly.
- This fixes the issue where dragging an image with spaces in the path would result
  in the path being truncated at the first space.