### PR TITLE
server: default mistral3 models to ministral parser

### DIFF
--- a/model/parsers/ministral_test.go
+++ b/model/parsers/ministral_test.go
@@ -444,6 +444,38 @@ func TestMinistralParserAssignsSequentialToolCallIndices(t *testing.T) {
 	}
 }
 
+func TestMinistralParserAllowsNameArgument(t *testing.T) {
+	parser := &MinistralParser{}
+	parser.Init([]api.Tool{{Function: api.ToolFunction{Name: "foo"}}}, nil, nil)
+
+	content, thinking, calls, err := parser.Add(`[TOOL_CALLS]foo[ARGS]{"name":"bar"}`, true)
+	if err != nil {
+		t.Fatalf("Add() error = %v", err)
+	}
+	if content != "" {
+		t.Fatalf("expected no content, got %q", content)
+	}
+	if thinking != "" {
+		t.Fatalf("expected no thinking, got %q", thinking)
+	}
+
+	expected := []api.ToolCall{
+		{
+			Function: api.ToolCallFunction{
+				Index: 0,
+				Name:  "foo",
+				Arguments: testArgs(map[string]any{
+					"name": "bar",
+				}),
+			},
+		},
+	}
+
+	if diff := cmp.Diff(expected, calls, argsComparer); diff != "" {
+		t.Fatalf("tool calls mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestMinistralParser_Errors(t *testing.T) {
 	t.Run("unknown tool returns error", func(t *testing.T) {
 		p := &MinistralParser{}

--- a/model/parsers/parsers.go
+++ b/model/parsers/parsers.go
@@ -62,7 +62,7 @@ func ParserForName(name string) Parser {
 		p = &Qwen3VLParser{hasThinkingSupport: false}
 	case "qwen3-vl-thinking":
 		p = &Qwen3VLParser{hasThinkingSupport: true}
-	case "ministral":
+	case "ministral", "mistral3":
 		p = &MinistralParser{hasThinkingSupport: false}
 	case "passthrough":
 		return &PassthroughParser{}

--- a/model/parsers/parsers_test.go
+++ b/model/parsers/parsers_test.go
@@ -62,6 +62,7 @@ func TestBuiltInParsersStillWork(t *testing.T) {
 		{"qwen3"},
 		{"qwen3-thinking"},
 		{"qwen3-coder"},
+		{"mistral3"},
 		{"lfm2"},
 		{"lfm2-thinking"},
 		{"qwen3.5"},

--- a/server/create.go
+++ b/server/create.go
@@ -778,7 +778,9 @@ func createModel(r api.CreateRequest, name model.Name, baseLayers []*layerGGML, 
 						config.Renderer = cmp.Or(config.Renderer, "laguna")
 						config.Parser = cmp.Or(config.Parser, "laguna")
 					case "mistral3":
-						config.Parser = cmp.Or(config.Parser, "ministral")
+						if layer.GGML.KV().String("tokenizer.chat_template") == "" {
+							config.Parser = cmp.Or(config.Parser, "ministral")
+						}
 					case "nemotron_h", "nemotron_h_moe", "nemotron_h_omni":
 						config.Renderer = cmp.Or(config.Renderer, "nemotron-3-nano")
 						config.Parser = cmp.Or(config.Parser, "nemotron-3-nano")

--- a/server/create.go
+++ b/server/create.go
@@ -777,6 +777,8 @@ func createModel(r api.CreateRequest, name model.Name, baseLayers []*layerGGML, 
 					case "laguna":
 						config.Renderer = cmp.Or(config.Renderer, "laguna")
 						config.Parser = cmp.Or(config.Parser, "laguna")
+					case "mistral3":
+						config.Parser = cmp.Or(config.Parser, "ministral")
 					case "nemotron_h", "nemotron_h_moe", "nemotron_h_omni":
 						config.Renderer = cmp.Or(config.Renderer, "nemotron-3-nano")
 						config.Parser = cmp.Or(config.Parser, "nemotron-3-nano")

--- a/server/create.go
+++ b/server/create.go
@@ -811,7 +811,9 @@ func createModel(r api.CreateRequest, name model.Name, baseLayers []*layerGGML, 
 						config.Renderer = cmp.Or(config.Renderer, "laguna")
 						config.Parser = cmp.Or(config.Parser, "laguna")
 					case "mistral3":
-						config.Parser = cmp.Or(config.Parser, "ministral")
+						if layer.GGML.KV().String("tokenizer.chat_template") == "" {
+							config.Parser = cmp.Or(config.Parser, "ministral")
+						}
 					case "nemotron_h", "nemotron_h_moe", "nemotron_h_omni":
 						config.Renderer = cmp.Or(config.Renderer, "nemotron-3-nano")
 						config.Parser = cmp.Or(config.Parser, "nemotron-3-nano")

--- a/server/create.go
+++ b/server/create.go
@@ -810,6 +810,8 @@ func createModel(r api.CreateRequest, name model.Name, baseLayers []*layerGGML, 
 					case "laguna":
 						config.Renderer = cmp.Or(config.Renderer, "laguna")
 						config.Parser = cmp.Or(config.Parser, "laguna")
+					case "mistral3":
+						config.Parser = cmp.Or(config.Parser, "ministral")
 					case "nemotron_h", "nemotron_h_moe", "nemotron_h_omni":
 						config.Renderer = cmp.Or(config.Renderer, "nemotron-3-nano")
 						config.Parser = cmp.Or(config.Parser, "nemotron-3-nano")

--- a/server/routes.go
+++ b/server/routes.go
@@ -97,11 +97,25 @@ func defaultParserForModel(m *Model) string {
 	switch {
 	case shouldUseHarmony(m):
 		return "harmony"
-	case m.Config.ModelFamily == "mistral3", slices.Contains(m.Config.ModelFamilies, "mistral3"):
+	case isMistral3Model(m) && !usesNativeChatTemplate(m):
 		return "ministral"
 	default:
 		return ""
 	}
+}
+
+func isMistral3Model(m *Model) bool {
+	return m != nil && (m.Config.ModelFamily == "mistral3" || slices.Contains(m.Config.ModelFamilies, "mistral3"))
+}
+
+func usesNativeChatTemplate(m *Model) bool {
+	return m != nil &&
+		!m.IsMLX() &&
+		m.HasChatTemplate &&
+		m.Config.Renderer == "" &&
+		m.Config.Parser == "" &&
+		!shouldUseHarmony(m) &&
+		!shouldUseGoTemplate(m)
 }
 
 func setDefaultParser(m *Model) {

--- a/server/routes.go
+++ b/server/routes.go
@@ -89,6 +89,27 @@ func shouldUseHarmony(model *Model) bool {
 	return false
 }
 
+func defaultParserForModel(m *Model) string {
+	if m == nil {
+		return ""
+	}
+
+	switch {
+	case shouldUseHarmony(m):
+		return "harmony"
+	case m.Config.ModelFamily == "mistral3", slices.Contains(m.Config.ModelFamilies, "mistral3"):
+		return "ministral"
+	default:
+		return ""
+	}
+}
+
+func setDefaultParser(m *Model) {
+	if m != nil && m.Config.Parser == "" {
+		m.Config.Parser = defaultParserForModel(m)
+	}
+}
+
 func experimentEnabled(name string) bool {
 	return slices.Contains(strings.Split(os.Getenv("OLLAMA_EXPERIMENT"), ","), name)
 }
@@ -211,6 +232,7 @@ func (s *Server) scheduleRunner(ctx context.Context, name string, caps []model.C
 	if err != nil {
 		return nil, nil, nil, err
 	}
+	setDefaultParser(model)
 
 	if slices.Contains(model.Config.ModelFamilies, "mllama") && len(model.ProjectorPaths) > 0 {
 		return nil, nil, nil, fmt.Errorf("'llama3.2-vision' is no longer compatible with your version of Ollama and has been replaced by a newer version. To re-download, run 'ollama pull llama3.2-vision'")
@@ -444,10 +466,8 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 				req.Think.Value = "high"
 			}
 		}
-		if m.Config.Parser == "" {
-			m.Config.Parser = "harmony"
-		}
 	}
+	setDefaultParser(m)
 
 	if !req.Raw && m.Config.Parser != "" {
 		builtinParser = parsers.ParserForName(m.Config.Parser)
@@ -2632,6 +2652,16 @@ func (s *Server) ChatHandler(c *gin.Context) {
 	}
 
 	caps := []model.Capability{model.CapabilityCompletion}
+	if shouldUseHarmony(m) {
+		// harmony's Reasoning field only understands low/medium/high; map "max" to "high"
+		if req.Think != nil {
+			if s, ok := req.Think.Value.(string); ok && s == "max" {
+				req.Think.Value = "high"
+			}
+		}
+	}
+	setDefaultParser(m)
+
 	if len(req.Tools) > 0 {
 		caps = append(caps, model.CapabilityTools)
 	}
@@ -2663,6 +2693,7 @@ func (s *Server) ChatHandler(c *gin.Context) {
 		handleScheduleError(c, req.Model, err)
 		return
 	}
+	setDefaultParser(m)
 
 	checkpointLoaded := time.Now()
 
@@ -2682,18 +2713,6 @@ func (s *Server) ChatHandler(c *gin.Context) {
 		msgs = append([]api.Message{{Role: "system", Content: m.System}}, msgs...)
 	}
 	msgs = filterThinkTags(msgs, m)
-
-	if shouldUseHarmony(m) {
-		// harmony's Reasoning field only understands low/medium/high; map "max" to "high"
-		if req.Think != nil {
-			if s, ok := req.Think.Value.(string); ok && s == "max" {
-				req.Think.Value = "high"
-			}
-		}
-		if m.Config.Parser == "" {
-			m.Config.Parser = "harmony"
-		}
-	}
 
 	if chatModeForModel(m) == chatExecutionModeNative {
 		s.handleNativeChat(c, req, m, r, opts, msgs, checkpointStart, checkpointLoaded)

--- a/server/routes.go
+++ b/server/routes.go
@@ -94,11 +94,25 @@ func defaultParserForModel(m *Model) string {
 	switch {
 	case shouldUseHarmony(m):
 		return "harmony"
-	case m.Config.ModelFamily == "mistral3", slices.Contains(m.Config.ModelFamilies, "mistral3"):
+	case isMistral3Model(m) && !usesNativeChatTemplate(m):
 		return "ministral"
 	default:
 		return ""
 	}
+}
+
+func isMistral3Model(m *Model) bool {
+	return m != nil && (m.Config.ModelFamily == "mistral3" || slices.Contains(m.Config.ModelFamilies, "mistral3"))
+}
+
+func usesNativeChatTemplate(m *Model) bool {
+	return m != nil &&
+		!m.IsMLX() &&
+		m.HasChatTemplate &&
+		m.Config.Renderer == "" &&
+		m.Config.Parser == "" &&
+		!shouldUseHarmony(m) &&
+		!shouldUseGoTemplate(m)
 }
 
 func setDefaultParser(m *Model) {

--- a/server/routes.go
+++ b/server/routes.go
@@ -116,8 +116,20 @@ func usesNativeChatTemplate(m *Model) bool {
 }
 
 func setDefaultParser(m *Model) {
-	if m != nil && m.Config.Parser == "" {
-		m.Config.Parser = defaultParserForModel(m)
+	if m == nil || m.Config.Parser != "" {
+		return
+	}
+
+	parser := defaultParserForModel(m)
+	if parser == "" {
+		return
+	}
+
+	m.Config.Parser = parser
+	if m.capabilitiesCached {
+		m.capabilitiesCached = false
+		m.capabilities = m.Capabilities()
+		m.capabilitiesCached = true
 	}
 }
 

--- a/server/routes.go
+++ b/server/routes.go
@@ -86,6 +86,27 @@ func shouldUseHarmony(model *Model) bool {
 	return false
 }
 
+func defaultParserForModel(m *Model) string {
+	if m == nil {
+		return ""
+	}
+
+	switch {
+	case shouldUseHarmony(m):
+		return "harmony"
+	case m.Config.ModelFamily == "mistral3", slices.Contains(m.Config.ModelFamilies, "mistral3"):
+		return "ministral"
+	default:
+		return ""
+	}
+}
+
+func setDefaultParser(m *Model) {
+	if m != nil && m.Config.Parser == "" {
+		m.Config.Parser = defaultParserForModel(m)
+	}
+}
+
 func experimentEnabled(name string) bool {
 	return slices.Contains(strings.Split(os.Getenv("OLLAMA_EXPERIMENT"), ","), name)
 }
@@ -203,6 +224,7 @@ func (s *Server) scheduleRunner(ctx context.Context, model *Model, caps []model.
 	if model == nil || model.Name == "" {
 		return nil, nil, nil, fmt.Errorf("model %w", errRequired)
 	}
+	setDefaultParser(model)
 
 	if slices.Contains(model.Config.ModelFamilies, "mllama") && len(model.ProjectorPaths) > 0 {
 		return nil, nil, nil, fmt.Errorf("'llama3.2-vision' is no longer compatible with your version of Ollama and has been replaced by a newer version. To re-download, run 'ollama pull llama3.2-vision'")
@@ -432,10 +454,8 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 				req.Think.Value = "high"
 			}
 		}
-		if m.Config.Parser == "" {
-			m.Config.Parser = "harmony"
-		}
 	}
+	setDefaultParser(m)
 
 	if !req.Raw && m.Config.Parser != "" {
 		builtinParser = parsers.ParserForName(m.Config.Parser)
@@ -2608,6 +2628,16 @@ func (s *Server) ChatHandler(c *gin.Context) {
 	}
 
 	caps := []model.Capability{model.CapabilityCompletion}
+	if shouldUseHarmony(m) {
+		// harmony's Reasoning field only understands low/medium/high; map "max" to "high"
+		if req.Think != nil {
+			if s, ok := req.Think.Value.(string); ok && s == "max" {
+				req.Think.Value = "high"
+			}
+		}
+	}
+	setDefaultParser(m)
+
 	if len(req.Tools) > 0 {
 		caps = append(caps, model.CapabilityTools)
 	}
@@ -2639,6 +2669,7 @@ func (s *Server) ChatHandler(c *gin.Context) {
 		handleScheduleError(c, req.Model, err)
 		return
 	}
+	setDefaultParser(m)
 
 	checkpointLoaded := time.Now()
 
@@ -2658,18 +2689,6 @@ func (s *Server) ChatHandler(c *gin.Context) {
 		msgs = append([]api.Message{{Role: "system", Content: m.System}}, msgs...)
 	}
 	msgs = filterThinkTags(msgs, m)
-
-	if shouldUseHarmony(m) {
-		// harmony's Reasoning field only understands low/medium/high; map "max" to "high"
-		if req.Think != nil {
-			if s, ok := req.Think.Value.(string); ok && s == "max" {
-				req.Think.Value = "high"
-			}
-		}
-		if m.Config.Parser == "" {
-			m.Config.Parser = "harmony"
-		}
-	}
 
 	if chatModeForModel(m) == chatExecutionModeNative {
 		s.handleNativeChat(c, req, m, r, opts, msgs, checkpointStart, checkpointLoaded)

--- a/server/routes_create_test.go
+++ b/server/routes_create_test.go
@@ -132,6 +132,37 @@ func readCreatedModelConfig(t *testing.T, name string) model.ConfigV2 {
 	return cfg
 }
 
+func TestCreateMistral3DefaultsParser(t *testing.T) {
+	t.Setenv("OLLAMA_MODELS", t.TempDir())
+
+	_, digest := createBinFile(t, map[string]any{
+		"general.architecture":          "mistral3",
+		"mistral3.block_count":          uint32(1),
+		"mistral3.context_length":       uint32(8192),
+		"mistral3.embedding_length":     uint32(4096),
+		"mistral3.attention.head_count": uint32(32),
+		"tokenizer.ggml.tokens":         []string{""},
+		"tokenizer.ggml.scores":         []float32{0},
+		"tokenizer.ggml.token_type":     []int32{0},
+	}, []*ggml.Tensor{
+		{Name: "token_embd.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+	})
+
+	w := createRequest(t, (&Server{}).CreateHandler, api.CreateRequest{
+		Model:  "test-mistral3-parser",
+		Files:  map[string]string{"model.gguf": digest},
+		Stream: &stream,
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	cfg := readCreatedModelConfig(t, "test-mistral3-parser:latest")
+	if cfg.Parser != "ministral" {
+		t.Fatalf("Parser = %q, want ministral", cfg.Parser)
+	}
+}
+
 func TestCreateModelPreservesEmbeddedCompatibilityGGUFWithoutQuantization(t *testing.T) {
 	t.Setenv("OLLAMA_MODELS", t.TempDir())
 	oldRun := runLlamaQuantize

--- a/server/routes_create_test.go
+++ b/server/routes_create_test.go
@@ -135,6 +135,65 @@ func readCreatedModelConfig(t *testing.T, name string) model.ConfigV2 {
 func TestCreateMistral3DefaultsParser(t *testing.T) {
 	t.Setenv("OLLAMA_MODELS", t.TempDir())
 
+	tests := []struct {
+		name       string
+		kv         map[string]any
+		wantParser string
+	}{
+		{
+			name:       "without chat template",
+			wantParser: "ministral",
+		},
+		{
+			name: "with chat template",
+			kv: map[string]any{
+				"tokenizer.chat_template": "{% if tools %}{{ tools }}{% endif %}{{ messages[0]['content'] }}",
+			},
+			wantParser: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kv := map[string]any{
+				"general.architecture":          "mistral3",
+				"mistral3.block_count":          uint32(1),
+				"mistral3.context_length":       uint32(8192),
+				"mistral3.embedding_length":     uint32(4096),
+				"mistral3.attention.head_count": uint32(32),
+				"tokenizer.ggml.tokens":         []string{""},
+				"tokenizer.ggml.scores":         []float32{0},
+				"tokenizer.ggml.token_type":     []int32{0},
+			}
+			for k, v := range tt.kv {
+				kv[k] = v
+			}
+
+			_, digest := createBinFile(t, kv, []*ggml.Tensor{
+				{Name: "token_embd.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+			})
+
+			modelName := "test-mistral3-parser-" + strings.ReplaceAll(tt.name, " ", "-")
+			w := createRequest(t, (&Server{}).CreateHandler, api.CreateRequest{
+				Model:  modelName,
+				Files:  map[string]string{"model.gguf": digest},
+				Stream: &stream,
+			})
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+			}
+
+			cfg := readCreatedModelConfig(t, modelName+":latest")
+			if cfg.Parser != tt.wantParser {
+				t.Fatalf("Parser = %q, want %q", cfg.Parser, tt.wantParser)
+			}
+		})
+	}
+}
+
+func TestCreateMistral3DefaultsParserExplicitRequest(t *testing.T) {
+	t.Setenv("OLLAMA_MODELS", t.TempDir())
+
 	_, digest := createBinFile(t, map[string]any{
 		"general.architecture":          "mistral3",
 		"mistral3.block_count":          uint32(1),
@@ -149,17 +208,18 @@ func TestCreateMistral3DefaultsParser(t *testing.T) {
 	})
 
 	w := createRequest(t, (&Server{}).CreateHandler, api.CreateRequest{
-		Model:  "test-mistral3-parser",
+		Model:  "test-mistral3-explicit-parser",
 		Files:  map[string]string{"model.gguf": digest},
+		Parser: "custom-parser",
 		Stream: &stream,
 	})
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	cfg := readCreatedModelConfig(t, "test-mistral3-parser:latest")
-	if cfg.Parser != "ministral" {
-		t.Fatalf("Parser = %q, want ministral", cfg.Parser)
+	cfg := readCreatedModelConfig(t, "test-mistral3-explicit-parser:latest")
+	if cfg.Parser != "custom-parser" {
+		t.Fatalf("Parser = %q, want custom-parser", cfg.Parser)
 	}
 }
 

--- a/server/routes_create_test.go
+++ b/server/routes_create_test.go
@@ -184,6 +184,37 @@ func readCreatedModelConfig(t *testing.T, name string) model.ConfigV2 {
 	return cfg
 }
 
+func TestCreateMistral3DefaultsParser(t *testing.T) {
+	t.Setenv("OLLAMA_MODELS", t.TempDir())
+
+	_, digest := createBinFile(t, map[string]any{
+		"general.architecture":          "mistral3",
+		"mistral3.block_count":          uint32(1),
+		"mistral3.context_length":       uint32(8192),
+		"mistral3.embedding_length":     uint32(4096),
+		"mistral3.attention.head_count": uint32(32),
+		"tokenizer.ggml.tokens":         []string{""},
+		"tokenizer.ggml.scores":         []float32{0},
+		"tokenizer.ggml.token_type":     []int32{0},
+	}, []*ggml.Tensor{
+		{Name: "token_embd.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+	})
+
+	w := createRequest(t, (&Server{}).CreateHandler, api.CreateRequest{
+		Model:  "test-mistral3-parser",
+		Files:  map[string]string{"model.gguf": digest},
+		Stream: &stream,
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	cfg := readCreatedModelConfig(t, "test-mistral3-parser:latest")
+	if cfg.Parser != "ministral" {
+		t.Fatalf("Parser = %q, want ministral", cfg.Parser)
+	}
+}
+
 func TestCreateModelPreservesEmbeddedCompatibilityGGUFWithoutQuantization(t *testing.T) {
 	t.Setenv("OLLAMA_MODELS", t.TempDir())
 	oldRun := runLlamaQuantize

--- a/server/routes_create_test.go
+++ b/server/routes_create_test.go
@@ -187,6 +187,65 @@ func readCreatedModelConfig(t *testing.T, name string) model.ConfigV2 {
 func TestCreateMistral3DefaultsParser(t *testing.T) {
 	t.Setenv("OLLAMA_MODELS", t.TempDir())
 
+	tests := []struct {
+		name       string
+		kv         map[string]any
+		wantParser string
+	}{
+		{
+			name:       "without chat template",
+			wantParser: "ministral",
+		},
+		{
+			name: "with chat template",
+			kv: map[string]any{
+				"tokenizer.chat_template": "{% if tools %}{{ tools }}{% endif %}{{ messages[0]['content'] }}",
+			},
+			wantParser: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kv := map[string]any{
+				"general.architecture":          "mistral3",
+				"mistral3.block_count":          uint32(1),
+				"mistral3.context_length":       uint32(8192),
+				"mistral3.embedding_length":     uint32(4096),
+				"mistral3.attention.head_count": uint32(32),
+				"tokenizer.ggml.tokens":         []string{""},
+				"tokenizer.ggml.scores":         []float32{0},
+				"tokenizer.ggml.token_type":     []int32{0},
+			}
+			for k, v := range tt.kv {
+				kv[k] = v
+			}
+
+			_, digest := createBinFile(t, kv, []*ggml.Tensor{
+				{Name: "token_embd.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+			})
+
+			modelName := "test-mistral3-parser-" + strings.ReplaceAll(tt.name, " ", "-")
+			w := createRequest(t, (&Server{}).CreateHandler, api.CreateRequest{
+				Model:  modelName,
+				Files:  map[string]string{"model.gguf": digest},
+				Stream: &stream,
+			})
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+			}
+
+			cfg := readCreatedModelConfig(t, modelName+":latest")
+			if cfg.Parser != tt.wantParser {
+				t.Fatalf("Parser = %q, want %q", cfg.Parser, tt.wantParser)
+			}
+		})
+	}
+}
+
+func TestCreateMistral3DefaultsParserExplicitRequest(t *testing.T) {
+	t.Setenv("OLLAMA_MODELS", t.TempDir())
+
 	_, digest := createBinFile(t, map[string]any{
 		"general.architecture":          "mistral3",
 		"mistral3.block_count":          uint32(1),
@@ -201,17 +260,18 @@ func TestCreateMistral3DefaultsParser(t *testing.T) {
 	})
 
 	w := createRequest(t, (&Server{}).CreateHandler, api.CreateRequest{
-		Model:  "test-mistral3-parser",
+		Model:  "test-mistral3-explicit-parser",
 		Files:  map[string]string{"model.gguf": digest},
+		Parser: "custom-parser",
 		Stream: &stream,
 	})
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	cfg := readCreatedModelConfig(t, "test-mistral3-parser:latest")
-	if cfg.Parser != "ministral" {
-		t.Fatalf("Parser = %q, want ministral", cfg.Parser)
+	cfg := readCreatedModelConfig(t, "test-mistral3-explicit-parser:latest")
+	if cfg.Parser != "custom-parser" {
+		t.Fatalf("Parser = %q, want custom-parser", cfg.Parser)
 	}
 }
 

--- a/server/routes_generate_test.go
+++ b/server/routes_generate_test.go
@@ -274,9 +274,11 @@ func TestChatModeForModel(t *testing.T) {
 
 func TestSetDefaultParser(t *testing.T) {
 	tests := []struct {
-		name string
-		m    *Model
-		want string
+		name             string
+		m                *Model
+		goTemplateEnv    string
+		setGoTemplateEnv bool
+		want             string
 	}{
 		{
 			name: "mistral3 family",
@@ -289,6 +291,23 @@ func TestSetDefaultParser(t *testing.T) {
 			want: "ministral",
 		},
 		{
+			name: "mistral3 native chat template",
+			m:    &Model{Config: model.ConfigV2{ModelFamily: "mistral3"}, HasChatTemplate: true},
+			want: "",
+		},
+		{
+			name: "mistral3 mlx chat template",
+			m:    &Model{Config: model.ConfigV2{ModelFamily: "mistral3", ModelFormat: "safetensors"}, HasChatTemplate: true},
+			want: "ministral",
+		},
+		{
+			name:             "mistral3 forced go template",
+			m:                &Model{Config: model.ConfigV2{ModelFamily: "mistral3"}, HasChatTemplate: true, HasGoTemplate: true},
+			goTemplateEnv:    "1",
+			setGoTemplateEnv: true,
+			want:             "ministral",
+		},
+		{
 			name: "explicit parser",
 			m:    &Model{Config: model.ConfigV2{ModelFamily: "mistral3", Parser: "custom"}},
 			want: "custom",
@@ -297,6 +316,9 @@ func TestSetDefaultParser(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.setGoTemplateEnv {
+				t.Setenv("OLLAMA_GO_TEMPLATE", tt.goTemplateEnv)
+			}
 			setDefaultParser(tt.m)
 			if tt.m.Config.Parser != tt.want {
 				t.Fatalf("Parser = %q, want %q", tt.m.Config.Parser, tt.want)
@@ -382,6 +404,89 @@ func TestChatMistral3ParserHandlesNameArgument(t *testing.T) {
 
 	if diff := cmp.Diff(gotToolCall, expectedToolCall, argsComparer); diff != "" {
 		t.Fatalf("tool call mismatch (-got +want):\n%s", diff)
+	}
+}
+
+func TestChatMistral3ChatTemplateKeepsNativeRenderPath(t *testing.T) {
+	t.Setenv("OLLAMA_CONTEXT_LENGTH", "4096")
+	t.Setenv("OLLAMA_GO_TEMPLATE", "0")
+	gin.SetMode(gin.TestMode)
+
+	chatCalled := false
+	mock := mockRunner{
+		CompletionFn: func(context.Context, llm.CompletionRequest, func(llm.CompletionResponse)) error {
+			t.Fatal("expected Mistral3 model with GGUF chat_template to use native chat")
+			return nil
+		},
+		ChatFn: func(_ context.Context, req llm.ChatRequest, fn func(llm.ChatResponse)) error {
+			chatCalled = true
+			if len(req.Tools) != 1 || req.Tools[0].Function.Name != "foo" {
+				t.Fatalf("native chat tools = %#v", req.Tools)
+			}
+			fn(llm.ChatResponse{
+				Message: api.Message{
+					Role: "assistant",
+					ToolCalls: []api.ToolCall{
+						{
+							ID: "call_native",
+							Function: api.ToolCallFunction{
+								Name: "foo",
+								Arguments: testArgs(map[string]any{
+									"name": "bar",
+								}),
+							},
+						},
+					},
+				},
+				Done:       true,
+				DoneReason: llm.DoneReasonStop,
+			})
+			return nil
+		},
+	}
+	s := newServerWithMockRunner(t, &mock)
+
+	createMinimalGGUFModel(t, s, "mistral3-native-chat-template", ggml.KV{
+		"general.architecture":    "mistral3",
+		"tokenizer.chat_template": "{% if tools %}{{ tools }}{% endif %}{{ messages[0]['content'] }}",
+	}, "", nil)
+
+	stream := false
+	w := createRequest(t, s.ChatHandler, api.ChatRequest{
+		Model: "mistral3-native-chat-template",
+		Messages: []api.Message{
+			{Role: "user", Content: "Call foo with name=bar"},
+		},
+		Tools: []api.Tool{
+			{
+				Type: "function",
+				Function: api.ToolFunction{
+					Name: "foo",
+					Parameters: api.ToolFunctionParameters{
+						Type:     "object",
+						Required: []string{"name"},
+						Properties: testPropsMap(map[string]api.ToolProperty{
+							"name": {Type: api.PropertyType{"string"}},
+						}),
+					},
+				},
+			},
+		},
+		Stream: &stream,
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !chatCalled {
+		t.Fatal("expected native chat path to run")
+	}
+
+	var resp api.ChatResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(resp.Message.ToolCalls); got != 1 {
+		t.Fatalf("expected 1 native tool call, got %d: %#v", got, resp.Message.ToolCalls)
 	}
 }
 

--- a/server/routes_generate_test.go
+++ b/server/routes_generate_test.go
@@ -272,6 +272,119 @@ func TestChatModeForModel(t *testing.T) {
 	}
 }
 
+func TestSetDefaultParser(t *testing.T) {
+	tests := []struct {
+		name string
+		m    *Model
+		want string
+	}{
+		{
+			name: "mistral3 family",
+			m:    &Model{Config: model.ConfigV2{ModelFamily: "mistral3"}},
+			want: "ministral",
+		},
+		{
+			name: "mistral3 families",
+			m:    &Model{Config: model.ConfigV2{ModelFamilies: []string{"llama", "mistral3"}}},
+			want: "ministral",
+		},
+		{
+			name: "explicit parser",
+			m:    &Model{Config: model.ConfigV2{ModelFamily: "mistral3", Parser: "custom"}},
+			want: "custom",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setDefaultParser(tt.m)
+			if tt.m.Config.Parser != tt.want {
+				t.Fatalf("Parser = %q, want %q", tt.m.Config.Parser, tt.want)
+			}
+		})
+	}
+}
+
+func TestChatMistral3ParserHandlesNameArgument(t *testing.T) {
+	t.Setenv("OLLAMA_CONTEXT_LENGTH", "4096")
+	t.Setenv("OLLAMA_GO_TEMPLATE", "1")
+	gin.SetMode(gin.TestMode)
+
+	mock := mockRunner{
+		CompletionResponse: llm.CompletionResponse{
+			Content:            `[TOOL_CALLS]foo[ARGS]{"name":"bar"}`,
+			Done:               true,
+			DoneReason:         llm.DoneReasonStop,
+			PromptEvalCount:    1,
+			PromptEvalDuration: 1,
+			EvalCount:          1,
+			EvalDuration:       1,
+		},
+	}
+	s := newServerWithMockRunner(t, &mock)
+
+	createMinimalGGUFModel(t, s, "mistral3-runtime", nil, "{{ range .Messages }}{{ .Role }}: {{ .Content }}{{ end }}", map[string]any{
+		"model_family": "mistral3",
+	})
+
+	stream := false
+	w := createRequest(t, s.ChatHandler, api.ChatRequest{
+		Model: "mistral3-runtime",
+		Messages: []api.Message{
+			{Role: "user", Content: "Call foo with name=bar"},
+		},
+		Tools: []api.Tool{
+			{
+				Type: "function",
+				Function: api.ToolFunction{
+					Name: "foo",
+					Parameters: api.ToolFunctionParameters{
+						Type:     "object",
+						Required: []string{"name"},
+						Properties: testPropsMap(map[string]api.ToolProperty{
+							"name": {Type: api.PropertyType{"string"}},
+						}),
+					},
+				},
+			},
+		},
+		Stream: &stream,
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp api.ChatResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(resp.Message.ToolCalls); got != 1 {
+		t.Fatalf("expected 1 tool call, got %d: %#v", got, resp.Message.ToolCalls)
+	}
+
+	gotToolCall := resp.Message.ToolCalls[0]
+	if gotToolCall.ID == "" {
+		t.Fatal("expected tool call ID to be populated")
+	}
+	if !strings.HasPrefix(gotToolCall.ID, "call_") {
+		t.Fatalf("expected tool call ID to have call_ prefix, got %q", gotToolCall.ID)
+	}
+
+	expectedToolCall := api.ToolCall{
+		ID: gotToolCall.ID,
+		Function: api.ToolCallFunction{
+			Name: "foo",
+			Arguments: testArgs(map[string]any{
+				"name": "bar",
+			}),
+		},
+	}
+
+	if diff := cmp.Diff(gotToolCall, expectedToolCall, argsComparer); diff != "" {
+		t.Fatalf("tool call mismatch (-got +want):\n%s", diff)
+	}
+}
+
 func TestChatHandlerChatTemplateRoute(t *testing.T) {
 	t.Setenv("OLLAMA_CONTEXT_LENGTH", "4096")
 	t.Setenv("OLLAMA_GO_TEMPLATE", "")

--- a/server/routes_generate_test.go
+++ b/server/routes_generate_test.go
@@ -271,6 +271,119 @@ func TestChatModeForModel(t *testing.T) {
 	}
 }
 
+func TestSetDefaultParser(t *testing.T) {
+	tests := []struct {
+		name string
+		m    *Model
+		want string
+	}{
+		{
+			name: "mistral3 family",
+			m:    &Model{Config: model.ConfigV2{ModelFamily: "mistral3"}},
+			want: "ministral",
+		},
+		{
+			name: "mistral3 families",
+			m:    &Model{Config: model.ConfigV2{ModelFamilies: []string{"llama", "mistral3"}}},
+			want: "ministral",
+		},
+		{
+			name: "explicit parser",
+			m:    &Model{Config: model.ConfigV2{ModelFamily: "mistral3", Parser: "custom"}},
+			want: "custom",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setDefaultParser(tt.m)
+			if tt.m.Config.Parser != tt.want {
+				t.Fatalf("Parser = %q, want %q", tt.m.Config.Parser, tt.want)
+			}
+		})
+	}
+}
+
+func TestChatMistral3ParserHandlesNameArgument(t *testing.T) {
+	t.Setenv("OLLAMA_CONTEXT_LENGTH", "4096")
+	t.Setenv("OLLAMA_GO_TEMPLATE", "1")
+	gin.SetMode(gin.TestMode)
+
+	mock := mockRunner{
+		CompletionResponse: llm.CompletionResponse{
+			Content:            `[TOOL_CALLS]foo[ARGS]{"name":"bar"}`,
+			Done:               true,
+			DoneReason:         llm.DoneReasonStop,
+			PromptEvalCount:    1,
+			PromptEvalDuration: 1,
+			EvalCount:          1,
+			EvalDuration:       1,
+		},
+	}
+	s := newServerWithMockRunner(t, &mock)
+
+	createMinimalGGUFModel(t, s, "mistral3-runtime", nil, "{{ range .Messages }}{{ .Role }}: {{ .Content }}{{ end }}", map[string]any{
+		"model_family": "mistral3",
+	})
+
+	stream := false
+	w := createRequest(t, s.ChatHandler, api.ChatRequest{
+		Model: "mistral3-runtime",
+		Messages: []api.Message{
+			{Role: "user", Content: "Call foo with name=bar"},
+		},
+		Tools: []api.Tool{
+			{
+				Type: "function",
+				Function: api.ToolFunction{
+					Name: "foo",
+					Parameters: api.ToolFunctionParameters{
+						Type:     "object",
+						Required: []string{"name"},
+						Properties: testPropsMap(map[string]api.ToolProperty{
+							"name": {Type: api.PropertyType{"string"}},
+						}),
+					},
+				},
+			},
+		},
+		Stream: &stream,
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp api.ChatResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(resp.Message.ToolCalls); got != 1 {
+		t.Fatalf("expected 1 tool call, got %d: %#v", got, resp.Message.ToolCalls)
+	}
+
+	gotToolCall := resp.Message.ToolCalls[0]
+	if gotToolCall.ID == "" {
+		t.Fatal("expected tool call ID to be populated")
+	}
+	if !strings.HasPrefix(gotToolCall.ID, "call_") {
+		t.Fatalf("expected tool call ID to have call_ prefix, got %q", gotToolCall.ID)
+	}
+
+	expectedToolCall := api.ToolCall{
+		ID: gotToolCall.ID,
+		Function: api.ToolCallFunction{
+			Name: "foo",
+			Arguments: testArgs(map[string]any{
+				"name": "bar",
+			}),
+		},
+	}
+
+	if diff := cmp.Diff(gotToolCall, expectedToolCall, argsComparer); diff != "" {
+		t.Fatalf("tool call mismatch (-got +want):\n%s", diff)
+	}
+}
+
 func TestChatHandlerChatTemplateRoute(t *testing.T) {
 	t.Setenv("OLLAMA_CONTEXT_LENGTH", "4096")
 	t.Setenv("OLLAMA_GO_TEMPLATE", "")

--- a/server/routes_generate_test.go
+++ b/server/routes_generate_test.go
@@ -326,6 +326,23 @@ func TestSetDefaultParser(t *testing.T) {
 	}
 }
 
+func TestSetDefaultParserRefreshesCachedCapabilities(t *testing.T) {
+	m := &Model{
+		Config:             model.ConfigV2{ModelFamily: "mistral3"},
+		capabilities:       []model.Capability{model.CapabilityCompletion},
+		capabilitiesCached: true,
+	}
+
+	setDefaultParser(m)
+
+	if !m.capabilitiesCached {
+		t.Fatal("expected capabilities to remain cached")
+	}
+	if err := m.CheckCapabilities(model.CapabilityTools); err != nil {
+		t.Fatalf("expected default parser to refresh tool capability: %v", err)
+	}
+}
+
 func TestChatMistral3ParserHandlesNameArgument(t *testing.T) {
 	t.Setenv("OLLAMA_CONTEXT_LENGTH", "4096")
 	t.Setenv("OLLAMA_GO_TEMPLATE", "1")

--- a/server/routes_generate_test.go
+++ b/server/routes_generate_test.go
@@ -273,9 +273,11 @@ func TestChatModeForModel(t *testing.T) {
 
 func TestSetDefaultParser(t *testing.T) {
 	tests := []struct {
-		name string
-		m    *Model
-		want string
+		name             string
+		m                *Model
+		goTemplateEnv    string
+		setGoTemplateEnv bool
+		want             string
 	}{
 		{
 			name: "mistral3 family",
@@ -288,6 +290,23 @@ func TestSetDefaultParser(t *testing.T) {
 			want: "ministral",
 		},
 		{
+			name: "mistral3 native chat template",
+			m:    &Model{Config: model.ConfigV2{ModelFamily: "mistral3"}, HasChatTemplate: true},
+			want: "",
+		},
+		{
+			name: "mistral3 mlx chat template",
+			m:    &Model{Config: model.ConfigV2{ModelFamily: "mistral3", ModelFormat: "safetensors"}, HasChatTemplate: true},
+			want: "ministral",
+		},
+		{
+			name:             "mistral3 forced go template",
+			m:                &Model{Config: model.ConfigV2{ModelFamily: "mistral3"}, HasChatTemplate: true, HasGoTemplate: true},
+			goTemplateEnv:    "1",
+			setGoTemplateEnv: true,
+			want:             "ministral",
+		},
+		{
 			name: "explicit parser",
 			m:    &Model{Config: model.ConfigV2{ModelFamily: "mistral3", Parser: "custom"}},
 			want: "custom",
@@ -296,6 +315,9 @@ func TestSetDefaultParser(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.setGoTemplateEnv {
+				t.Setenv("OLLAMA_GO_TEMPLATE", tt.goTemplateEnv)
+			}
 			setDefaultParser(tt.m)
 			if tt.m.Config.Parser != tt.want {
 				t.Fatalf("Parser = %q, want %q", tt.m.Config.Parser, tt.want)
@@ -381,6 +403,89 @@ func TestChatMistral3ParserHandlesNameArgument(t *testing.T) {
 
 	if diff := cmp.Diff(gotToolCall, expectedToolCall, argsComparer); diff != "" {
 		t.Fatalf("tool call mismatch (-got +want):\n%s", diff)
+	}
+}
+
+func TestChatMistral3ChatTemplateKeepsNativeRenderPath(t *testing.T) {
+	t.Setenv("OLLAMA_CONTEXT_LENGTH", "4096")
+	t.Setenv("OLLAMA_GO_TEMPLATE", "0")
+	gin.SetMode(gin.TestMode)
+
+	chatCalled := false
+	mock := mockRunner{
+		CompletionFn: func(context.Context, llm.CompletionRequest, func(llm.CompletionResponse)) error {
+			t.Fatal("expected Mistral3 model with GGUF chat_template to use native chat")
+			return nil
+		},
+		ChatFn: func(_ context.Context, req llm.ChatRequest, fn func(llm.ChatResponse)) error {
+			chatCalled = true
+			if len(req.Tools) != 1 || req.Tools[0].Function.Name != "foo" {
+				t.Fatalf("native chat tools = %#v", req.Tools)
+			}
+			fn(llm.ChatResponse{
+				Message: api.Message{
+					Role: "assistant",
+					ToolCalls: []api.ToolCall{
+						{
+							ID: "call_native",
+							Function: api.ToolCallFunction{
+								Name: "foo",
+								Arguments: testArgs(map[string]any{
+									"name": "bar",
+								}),
+							},
+						},
+					},
+				},
+				Done:       true,
+				DoneReason: llm.DoneReasonStop,
+			})
+			return nil
+		},
+	}
+	s := newServerWithMockRunner(t, &mock)
+
+	createMinimalGGUFModel(t, s, "mistral3-native-chat-template", ggml.KV{
+		"general.architecture":    "mistral3",
+		"tokenizer.chat_template": "{% if tools %}{{ tools }}{% endif %}{{ messages[0]['content'] }}",
+	}, "", nil)
+
+	stream := false
+	w := createRequest(t, s.ChatHandler, api.ChatRequest{
+		Model: "mistral3-native-chat-template",
+		Messages: []api.Message{
+			{Role: "user", Content: "Call foo with name=bar"},
+		},
+		Tools: []api.Tool{
+			{
+				Type: "function",
+				Function: api.ToolFunction{
+					Name: "foo",
+					Parameters: api.ToolFunctionParameters{
+						Type:     "object",
+						Required: []string{"name"},
+						Properties: testPropsMap(map[string]api.ToolProperty{
+							"name": {Type: api.PropertyType{"string"}},
+						}),
+					},
+				},
+			},
+		},
+		Stream: &stream,
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !chatCalled {
+		t.Fatal("expected native chat path to run")
+	}
+
+	var resp api.ChatResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(resp.Message.ToolCalls); got != 1 {
+		t.Fatalf("expected 1 native tool call, got %d: %#v", got, resp.Message.ToolCalls)
 	}
 }
 


### PR DESCRIPTION
Fixes #16932.

## Summary

- default `mistral3` GGUF models to the existing Ministral parser during create
- apply the same default at runtime before capability checks so existing pulled model configs with `model_family: mistral3` can use tools
- add `mistral3` as a parser alias for robustness
- add regressions for top-level tool arguments named `name`

## Root cause

Mistral-format models emit tool calls as `[TOOL_CALLS]<function_name>[ARGS]{<arguments_json>}`. Without the dedicated parser, the generic parser can treat a top-level argument key named `name` as a tool-call wrapper field and fail to return the tool call.

## Testing

- `git diff --check`
- `env GOCACHE=/tmp/ollama-gocache GOMODCACHE=/tmp/ollama-gomodcache GOTMPDIR=/tmp go test ./model/parsers ./tools -count=1`
- `env GOCACHE=/tmp/ollama-gocache GOMODCACHE=/tmp/ollama-gomodcache GOTMPDIR=/tmp go test ./server -run 'Test(ChatMistral3ParserHandlesNameArgument|CreateMistral3DefaultsParser|SetDefaultParser|ChatHandlerHarmonyPreservesStructuralTokens)' -count=1`
- `env GOCACHE=/tmp/ollama-gocache GOMODCACHE=/tmp/ollama-gomodcache GOTMPDIR=/tmp go test ./server -count=1`
