### PR TITLE
tools: ignore braces inside JSON strings when detecting tool call end

### DIFF
--- a/tools/tools.go
+++ b/tools/tools.go
@@ -358,7 +358,23 @@ func (p *Parser) done() bool {
 	}
 
 	var count int
+	var inString, escaped bool
 	for _, c := range p.buffer {
+		if escaped {
+			escaped = false
+			continue
+		}
+		if c == '\\' {
+			escaped = true
+			continue
+		}
+		if c == '"' {
+			inString = !inString
+			continue
+		}
+		if inString {
+			continue
+		}
 		if c == byte(open) {
 			count++
 		} else if c == byte(close) {

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -842,6 +842,24 @@ func TestDone(t *testing.T) {
 			buffer: []byte("[]"),
 			want:   true,
 		},
+		{
+			name:   "json close brace inside string",
+			tag:    "{",
+			buffer: []byte("{\"note\": \"a}b\""),
+			want:   false,
+		},
+		{
+			name:   "json complete with brace inside string",
+			tag:    "{",
+			buffer: []byte("{\"note\": \"a}b\"}"),
+			want:   true,
+		},
+		{
+			name:   "list close bracket inside string",
+			tag:    "[",
+			buffer: []byte("[{\"note\": \"x]y\"}"),
+			want:   false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What

`tools.Parser.done()` counts the tag's open/close characters (`{`/`}` or `[`/`]`) to decide when a streamed tool call is complete, but it does not track JSON string context. So a tool call whose **string argument value** contains a closing brace or bracket — e.g. `{"code": "if (x) { return y }"}` or `{"note": "a]b"}` — is detected as complete at the character **inside the string**, before the object/array actually closes. `Parser.Add` then transitions to done and flushes the buffer as plain content, so the tool call is silently dropped and leaked to the user as text instead of being parsed.

`findArguments()` in the same file already tracks string context (`inString` / `escaped`); this applies the same handling in `done()` so open/close characters inside string values are ignored.

## Testing

Extended `TestDone` with cases for a closing brace/bracket inside a string value:

- `{"note": "a}b"` (unterminated) → not done
- `{"note": "a}b"}` (complete) → done
- `[{"note": "x]y"}` (unterminated list) → not done

The two "inside string" cases fail before this change (`done()` returns `true` prematurely) and pass after. `go test ./tools/...` and `go vet ./tools/...` pass.
