### PR TITLE
discover: recognize the SYCL ggml backend

### DIFF
--- a/discover/native_probe_platform.go
+++ b/discover/native_probe_platform.go
@@ -32,6 +32,8 @@ func ggmlProbeLibraryName(name string) string {
 		return "Vulkan"
 	case "metal":
 		return "Metal"
+	case "sycl":
+		return "SYCL"
 	default:
 		return name
 	}
@@ -78,6 +80,7 @@ func nativeProbeBackendPatterns(dir string) []string {
 			filepath.Join(dir, "ggml-cuda.dll"),
 			filepath.Join(dir, "ggml-hip.dll"),
 			filepath.Join(dir, "ggml-vulkan.dll"),
+			filepath.Join(dir, "ggml-sycl.dll"),
 		}
 	}
 
@@ -85,6 +88,7 @@ func nativeProbeBackendPatterns(dir string) []string {
 		filepath.Join(dir, "libggml-cuda.so"),
 		filepath.Join(dir, "libggml-hip.so"),
 		filepath.Join(dir, "libggml-vulkan.so"),
+		filepath.Join(dir, "libggml-sycl.so"),
 	}
 }
 

--- a/discover/native_probe_platform_test.go
+++ b/discover/native_probe_platform_test.go
@@ -1,0 +1,66 @@
+//go:build (linux && cgo) || windows
+
+package discover
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// TestGGMLProbeLibraryNamePreservesIdentity verifies that each backend keeps its
+// own identity: the library label is derived from the ggml backend registration
+// name, so CUDA stays CUDA, ROCm stays ROCm, Vulkan stays Vulkan, and SYCL stays
+// SYCL. Unknown names pass through unchanged.
+func TestGGMLProbeLibraryNamePreservesIdentity(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"cuda", "cuda", "CUDA"},
+		{"cuda mixed case", "CUDA", "CUDA"},
+		{"hip", "hip", "ROCm"},
+		{"rocm", "rocm", "ROCm"},
+		{"vulkan", "vulkan", "Vulkan"},
+		{"vulkan mixed case", "Vulkan", "Vulkan"},
+		{"metal", "metal", "Metal"},
+		{"sycl", "sycl", "SYCL"},
+		{"sycl mixed case", "SYCL", "SYCL"},
+		{"unknown passthrough", "madeupbackend", "madeupbackend"},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ggmlProbeLibraryName(tt.in); got != tt.want {
+				t.Fatalf("ggmlProbeLibraryName(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestNativeProbeBackendPatterns verifies that the SYCL backend module is probed
+// in addition to the existing CUDA, HIP, and Vulkan modules. Without a matching
+// pattern here a discovered libggml-sycl module would never be loaded.
+func TestNativeProbeBackendPatterns(t *testing.T) {
+	dir := filepath.Join("opt", "ollama", "lib")
+	patterns := nativeProbeBackendPatterns(dir)
+
+	got := make(map[string]bool, len(patterns))
+	for _, p := range patterns {
+		got[p] = true
+	}
+
+	var wantNames []string
+	if runtime.GOOS == "windows" {
+		wantNames = []string{"ggml-cuda.dll", "ggml-hip.dll", "ggml-vulkan.dll", "ggml-sycl.dll"}
+	} else {
+		wantNames = []string{"libggml-cuda.so", "libggml-hip.so", "libggml-vulkan.so", "libggml-sycl.so"}
+	}
+
+	for _, name := range wantNames {
+		want := filepath.Join(dir, name)
+		if !got[want] {
+			t.Errorf("nativeProbeBackendPatterns(%q) missing %q; got %v", dir, want, patterns)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

This PR teaches Ollama's native GPU discovery to recognize an Intel `ggml-sycl` backend module when it is present, and to label the resulting device as `SYCL`.

It is the first step toward adding opt-in Intel Arc / Battlemage GPU support through oneAPI/SYCL. By itself, this PR does not change any defaults and does not ship a SYCL backend. It only makes discovery aware of a SYCL module if one is included in the runtime payload.

## Context

Part of #16930, which tracks a small PR series for Intel SYCL support:

1. discovery
2. build support
3. runtime scheduling
4. packaging

The full local series has been tested end to end on an Intel Arc Pro B50 with oneAPI 2026 on Linux. It builds `libggml-sycl.so`, discovers the Intel GPU, and offloads inference successfully.

In local testing with a 35B-A3B MoE model, generation improved from roughly 11 tok/s with Vulkan to roughly 35 tok/s with SYCL.

This PR is the discovery-only piece. It has no oneAPI dependency, does not require Intel hardware, and is covered by normal Go tests.

## What's in this PR

* Add `sycl -> SYCL` handling in `ggmlProbeLibraryName`, so the ggml backend registration name normalizes to a stable `SYCL` device label.
* Add `libggml-sycl.so` on Linux and `ggml-sycl.dll` on Windows to `nativeProbeBackendPatterns`, alongside the existing CUDA, HIP, and Vulkan probe patterns.
* Add `discover/native_probe_platform_test.go` with table-driven tests for backend identity:

  * CUDA -> CUDA
  * ROCm -> ROCm
  * Vulkan -> Vulkan
  * SYCL -> SYCL
* Add a platform-specific test that checks the SYCL backend module is included in the probe pattern list.

## Design notes

Device identity is based on the ggml backend registration name, not the file path.

That means a backend is labeled according to what the loaded ggml backend registers itself as. The directory it was loaded from does not matter. The tests lock this in for the existing backends and for SYCL, so adding a SYCL payload cannot accidentally relabel CUDA, ROCm, Vulkan, or another backend.

This PR is intentionally inert without the rest of the series. If no `libggml-sycl.so` or `ggml-sycl.dll` is present, the new probe pattern simply does not match anything.

## Testing

Tested with:

`go test ./discover/...`

`go build ./...`

`go vet ./...`

No Intel hardware or oneAPI installation is required for this PR.

## Risk and compatibility

This PR adds no new environment variable, changes no default build behavior, and does not affect existing GPU backends.

For users without a SYCL backend module, the only practical change is one extra glob pattern per probe directory that will not match anything.
