### PR TITLE
llm: filter noisy llama-server logs

### DIFF
--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -2596,9 +2596,10 @@ func PredictServerVRAM(modelPath string, f *ggml.GGML, numCtx int) uint64 {
 //	MTL0_Mapped model buffer size =  1918.35 MiB
 //	ROCm0 model buffer size =  1918.35 MiB
 type memoryParsingWriter struct {
-	inner   io.Writer
-	runner  *llamaServerRunner
-	buffers map[memoryBufferKey]memoryBuffer
+	inner                   io.Writer
+	runner                  *llamaServerRunner
+	buffers                 map[memoryBufferKey]memoryBuffer
+	suppressLogContinuation bool
 }
 
 type memoryBufferKey struct {
@@ -2625,6 +2626,7 @@ var bufferSizeRegex = regexp.MustCompile(`(?m)(?:^|\n)[^\n:]*?([A-Za-z_][A-Za-z0
 var (
 	offloadedLayersRegex      = regexp.MustCompile(`offloaded\s+(\d+)/(\d+)\s+layers to GPU`)
 	fitOverflowingLayersRegex = regexp.MustCompile(`common_params_fit_impl:\s+-\s+.+:\s+\d+\s+layers\s+\(\s*(\d+)\s+overflowing\)`)
+	successfulGinLogRegex     = regexp.MustCompile(`^\[GIN\].*\|\s+[23]\d\d\s+\|`)
 )
 
 // isGPUBuffer returns true if the backend buffer name represents GPU memory.
@@ -2699,7 +2701,89 @@ func (w *memoryParsingWriter) Write(b []byte) (int, error) {
 			}
 		}()
 	}
-	return w.inner.Write(b)
+
+	if w.inner == nil {
+		return len(b), nil
+	}
+
+	forward := b
+	if !forwardLlamaServerLogOutputUnfiltered() {
+		forward = w.filterLlamaServerLogOutput(b)
+	}
+
+	if len(forward) == 0 {
+		return len(b), nil
+	}
+	_, err := w.inner.Write(forward)
+	return len(b), err
+}
+
+func forwardLlamaServerLogOutputUnfiltered() bool {
+	return envconfig.LogLevel() <= slog.LevelDebug
+}
+
+func (w *memoryParsingWriter) filterLlamaServerLogOutput(b []byte) []byte {
+	filtered := make([]byte, 0, len(b))
+	for len(b) > 0 {
+		lineEnd := bytes.IndexByte(b, '\n')
+		var line []byte
+		if lineEnd < 0 {
+			line = b
+			b = nil
+		} else {
+			line = b[:lineEnd+1]
+			b = b[lineEnd+1:]
+		}
+
+		if w.suppressLlamaServerLogLine(line) {
+			continue
+		}
+		filtered = append(filtered, line...)
+	}
+	return filtered
+}
+
+func (w *memoryParsingWriter) suppressLlamaServerLogLine(lineBytes []byte) bool {
+	line := strings.TrimRight(string(lineBytes), "\r\n")
+	trimmed := strings.TrimLeft(line, " \t")
+
+	if trimmed == "" {
+		return w.suppressLogContinuation
+	}
+
+	if statusErrorLine(trimmed) != "" || isLlamaServerSchedulerAccountingLog(trimmed) {
+		w.suppressLogContinuation = false
+		return false
+	}
+
+	if isIndentedLine(line) && w.suppressLogContinuation {
+		return true
+	}
+	w.suppressLogContinuation = false
+
+	if isNoisyLlamaServerLogLine(trimmed) {
+		w.suppressLogContinuation = strings.Contains(trimmed, "sampler params:")
+		return true
+	}
+
+	return false
+}
+
+func isIndentedLine(line string) bool {
+	return strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t")
+}
+
+func isLlamaServerSchedulerAccountingLog(line string) bool {
+	return deviceFreeRegex.MatchString(line) ||
+		bufferSizeRegex.MatchString(line) ||
+		offloadedLayersRegex.MatchString(line) ||
+		fitOverflowingLayersRegex.MatchString(line)
+}
+
+func isNoisyLlamaServerLogLine(line string) bool {
+	return strings.HasPrefix(line, "slot ") ||
+		strings.HasPrefix(line, "srv ") ||
+		successfulGinLogRegex.MatchString(line)
 }
 
 func (w *memoryParsingWriter) updateRunnerMemoryLocked() {

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -2839,6 +2839,9 @@ func TestMemoryParsingWriterFiltersNoisyRequestLogs(t *testing.T) {
 	input := strings.Join([]string{
 		"slot get_availabl: id  0 | task -1 | selected slot by LRU, t_last = -1",
 		"srv  get_availabl: updating prompt cache",
+		"srv  log_server_r: request: GET /health 127.0.0.1 200",
+		"srv  log_server_r: request: POST /completion 127.0.0.1 500",
+		"srv    operator(): got exception: {\"error\":\"boom\"}",
 		"slot launch_slot_: id  0 | task -1 | sampler params:",
 		"\trepeat_last_n = 64, repeat_penalty = 1.000, frequency_penalty = 0.000",
 		"\ttop_k = 20, top_p = 0.950, min_p = 0.000",
@@ -2860,6 +2863,7 @@ func TestMemoryParsingWriterFiltersNoisyRequestLogs(t *testing.T) {
 	for _, unexpected := range []string{
 		"slot get_availabl",
 		"srv  get_availabl",
+		"GET /health",
 		"sampler params",
 		"repeat_last_n",
 		`| 200 |`,
@@ -2872,6 +2876,8 @@ func TestMemoryParsingWriterFiltersNoisyRequestLogs(t *testing.T) {
 		"CUDA0 model buffer size",
 		"CUDA0 KV buffer size",
 		"offloaded 33/33 layers",
+		"POST /completion",
+		"got exception",
 		`| 500 |`,
 		"error: runner failed",
 	} {

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -2819,6 +2819,94 @@ func TestMemoryParsingWriter(t *testing.T) {
 	}
 }
 
+func TestAppendLlamaServerLogArgsKeepsSchedulerVerbosity(t *testing.T) {
+	params := appendLlamaServerLogArgs(nil)
+	for i, param := range params[:len(params)-1] {
+		if param == "--log-verbosity" && params[i+1] == "4" {
+			return
+		}
+	}
+	t.Fatalf("appendLlamaServerLogArgs() = %v, want --log-verbosity 4", params)
+}
+
+func TestMemoryParsingWriterFiltersNoisyRequestLogs(t *testing.T) {
+	t.Setenv("OLLAMA_DEBUG", "")
+
+	var out bytes.Buffer
+	runner := &llamaServerRunner{vramByDevice: make(map[string]uint64)}
+	w := &memoryParsingWriter{inner: &out, runner: runner}
+
+	input := strings.Join([]string{
+		"slot get_availabl: id  0 | task -1 | selected slot by LRU, t_last = -1",
+		"srv  get_availabl: updating prompt cache",
+		"slot launch_slot_: id  0 | task -1 | sampler params:",
+		"\trepeat_last_n = 64, repeat_penalty = 1.000, frequency_penalty = 0.000",
+		"\ttop_k = 20, top_p = 0.950, min_p = 0.000",
+		"load_tensors:        CUDA0 model buffer size =  1000.00 MiB",
+		"llama_kv_cache:      CUDA0 KV buffer size =  2000.00 MiB",
+		"llm_load_tensors: offloaded 33/33 layers to GPU",
+		"[GIN] 2026/06/25 - 20:47:16 | 200 |         1m28s |       127.0.0.1 | POST     \"/api/chat\"",
+		"[GIN] 2026/06/25 - 20:47:16 | 500 |         1m28s |       127.0.0.1 | POST     \"/api/chat\"",
+		"error: runner failed",
+	}, "\n") + "\n"
+
+	if n, err := w.Write([]byte(input)); err != nil {
+		t.Fatal(err)
+	} else if n != len(input) {
+		t.Fatalf("Write returned %d, want %d", n, len(input))
+	}
+
+	got := out.String()
+	for _, unexpected := range []string{
+		"slot get_availabl",
+		"srv  get_availabl",
+		"sampler params",
+		"repeat_last_n",
+		`| 200 |`,
+	} {
+		if strings.Contains(got, unexpected) {
+			t.Fatalf("filtered output contains %q:\n%s", unexpected, got)
+		}
+	}
+	for _, expected := range []string{
+		"CUDA0 model buffer size",
+		"CUDA0 KV buffer size",
+		"offloaded 33/33 layers",
+		`| 500 |`,
+		"error: runner failed",
+	} {
+		if !strings.Contains(got, expected) {
+			t.Fatalf("filtered output missing %q:\n%s", expected, got)
+		}
+	}
+
+	if runner.memGPU != 3000*1024*1024 {
+		t.Fatalf("memGPU = %d, want %d", runner.memGPU, uint64(3000*1024*1024))
+	}
+	total, vram := runner.MemorySize()
+	if total != vram || total != 3000*1024*1024 {
+		t.Fatalf("MemorySize() = %d/%d, want %d/%d", total, vram, uint64(3000*1024*1024), uint64(3000*1024*1024))
+	}
+}
+
+func TestMemoryParsingWriterKeepsVerboseOutputWhenDebugEnabled(t *testing.T) {
+	t.Setenv("OLLAMA_DEBUG", "1")
+
+	var out bytes.Buffer
+	w := &memoryParsingWriter{inner: &out, runner: &llamaServerRunner{}}
+	input := "slot launch_slot_: id  0 | task -1 | sampler params:\n\trepeat_last_n = 64\n"
+
+	if n, err := w.Write([]byte(input)); err != nil {
+		t.Fatal(err)
+	} else if n != len(input) {
+		t.Fatalf("Write returned %d, want %d", n, len(input))
+	}
+
+	if got := out.String(); got != input {
+		t.Fatalf("output = %q, want %q", got, input)
+	}
+}
+
 func TestMemoryParsingWriterRecordsOutputActivityWithoutNewline(t *testing.T) {
 	runner := &llamaServerRunner{}
 	w := &memoryParsingWriter{inner: io.Discard, runner: runner}

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -2840,6 +2840,7 @@ func TestMemoryParsingWriterFiltersNoisyRequestLogs(t *testing.T) {
 		"slot get_availabl: id  0 | task -1 | selected slot by LRU, t_last = -1",
 		"srv  get_availabl: updating prompt cache",
 		"srv  log_server_r: request: GET /health 127.0.0.1 200",
+		"srv  log_server_r: request: GET /health 127.0.0.1 503",
 		"srv  log_server_r: request: POST /completion 127.0.0.1 500",
 		"srv    operator(): got exception: {\"error\":\"boom\"}",
 		"slot launch_slot_: id  0 | task -1 | sampler params:",

--- a/llm/status.go
+++ b/llm/status.go
@@ -205,12 +205,25 @@ func llamaServerSrvErrorLine(line string) string {
 	if !strings.Contains(trimmed, "log_server_r:") {
 		return ""
 	}
-	for _, field := range strings.Fields(trimmed) {
+	fields := strings.Fields(trimmed)
+	if hasHealthRequestPath(fields) {
+		return ""
+	}
+	for _, field := range fields {
 		if isFailedHTTPStatusField(field) {
 			return strings.TrimRight(trimmed, " \t\r")
 		}
 	}
 	return ""
+}
+
+func hasHealthRequestPath(fields []string) bool {
+	for _, field := range fields {
+		if field == "/health" || strings.HasPrefix(field, "/health?") {
+			return true
+		}
+	}
+	return false
 }
 
 func isFailedHTTPStatusField(field string) bool {

--- a/llm/status.go
+++ b/llm/status.go
@@ -181,9 +181,46 @@ func statusErrorLine(line string) string {
 		return errPrefix + strings.TrimRight(line[errStart+len(errPrefix):], " \t\r")
 	}
 
+	if errMsg := llamaServerSrvErrorLine(line); errMsg != "" {
+		return errMsg
+	}
+
 	if IsOutOfMemoryMessage(line) {
 		return line
 	}
 
 	return ""
+}
+
+func llamaServerSrvErrorLine(line string) string {
+	trimmed := strings.TrimLeft(line, " \t")
+	if !strings.HasPrefix(trimmed, "srv ") {
+		return ""
+	}
+
+	if strings.Contains(trimmed, "got exception:") {
+		return strings.TrimRight(trimmed, " \t\r")
+	}
+
+	if !strings.Contains(trimmed, "log_server_r:") {
+		return ""
+	}
+	for _, field := range strings.Fields(trimmed) {
+		if isFailedHTTPStatusField(field) {
+			return strings.TrimRight(trimmed, " \t\r")
+		}
+	}
+	return ""
+}
+
+func isFailedHTTPStatusField(field string) bool {
+	if len(field) != 3 || (field[0] != '4' && field[0] != '5') {
+		return false
+	}
+	for _, c := range field[1:] {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
 }

--- a/llm/status_test.go
+++ b/llm/status_test.go
@@ -32,6 +32,11 @@ func TestStatusWriterCapturesErrorLine(t *testing.T) {
 			want: "",
 		},
 		{
+			name: "srv health loading",
+			log:  "srv  log_server_r: request: GET /health 127.0.0.1 503\n",
+			want: "",
+		},
+		{
 			name: "srv request failure",
 			log:  "srv  log_server_r: request: POST /completion 127.0.0.1 500\n",
 			want: "srv  log_server_r: request: POST /completion 127.0.0.1 500",

--- a/llm/status_test.go
+++ b/llm/status_test.go
@@ -27,6 +27,21 @@ func TestStatusWriterCapturesErrorLine(t *testing.T) {
 			want: "MLX: there was an error",
 		},
 		{
+			name: "srv request success",
+			log:  "srv  log_server_r: request: GET /health 127.0.0.1 200\n",
+			want: "",
+		},
+		{
+			name: "srv request failure",
+			log:  "srv  log_server_r: request: POST /completion 127.0.0.1 500\n",
+			want: "srv  log_server_r: request: POST /completion 127.0.0.1 500",
+		},
+		{
+			name: "srv exception",
+			log:  "srv    operator(): got exception: {\"error\":\"boom\"}\n",
+			want: "srv    operator(): got exception: {\"error\":\"boom\"}",
+		},
+		{
 			name: "panic header",
 			log: "time=2026-05-01T15:36:45.053Z level=INFO source=pipeline.go:71 msg=\"peak memory\" size=\"8.26 GiB\"\n" +
 				"panic: mlx: Failed to compile kernel: nvrtc: error: invalid value for --gpu-architecture (-arch)\n" +


### PR DESCRIPTION
Fixes #16897.

## Summary
- keep llama-server launched with `--log-verbosity 4` so memory and offload lines remain available for scheduler accounting
- continue parsing every runner log write, then filter default forwarding of noisy per-request `slot`, `srv`, sampler-continuation, and successful Gin access lines
- keep scheduler accounting lines, error lines, non-success Gin access lines, and full raw output when `OLLAMA_DEBUG` enables debug logging

## Validation
- `git diff --check`
- `/usr/bin/env GOPATH=/tmp/ollama-gopath GOMODCACHE=/tmp/ollama-gopath/pkg/mod GOCACHE=/tmp/ollama-gocache go test ./llm -run 'TestMemoryParsingWriter|TestAppendLlamaServerLogArgsKeepsSchedulerVerbosity' -count=1`
- `/usr/bin/env GOPATH=/tmp/ollama-gopath GOMODCACHE=/tmp/ollama-gopath/pkg/mod GOCACHE=/tmp/ollama-gocache go test ./llm -count=1`

## Notes
This intentionally avoids the approach from #16899 and #16910: it does not lower llama-server verbosity. The server still receives the verbosity-4 memory/offload output it needs, and only default log forwarding is filtered.