### PR TITLE
fix(parser): ensure robust tool name matching for parameter named name (#16932)

### DIFF
--- a/model/parsers/ministral.go
+++ b/model/parsers/ministral.go
@@ -89,6 +89,7 @@ func (p *MinistralParser) Init(tools []api.Tool, lastMessage *api.Message, think
 }
 
 func toolByName(tools []api.Tool, n string) (*api.Tool, error) {
+	n = strings.TrimSpace(n)
 	for i := range tools {
 		if tools[i].Function.Name == n {
 			return &tools[i], nil
@@ -215,7 +216,7 @@ func (p *MinistralParser) eat() ([]ministralEvent, bool) {
 
 		if strings.Contains(bufStr, ministralArgsTag) {
 			split := strings.SplitN(bufStr, ministralArgsTag, 2)
-			toolName := split[0]
+			toolName := strings.TrimSpace(split[0])
 			after := split[1]
 			p.pendingToolName = toolName
 			p.buffer.Reset()

--- a/model/parsers/ministral_test.go
+++ b/model/parsers/ministral_test.go
@@ -49,6 +49,15 @@ func TestMinistralParserStreaming(t *testing.T) {
 			},
 		},
 		{
+			desc:  "tool call with parameter named name and whitespace",
+			tools: []api.Tool{{Function: api.ToolFunction{Name: "foo"}}},
+			steps: []step{
+				{input: `[TOOL_CALLS] foo [ARGS]{"name": "bar"}`, wantEvents: []ministralEvent{
+					ministralEventToolCall{name: "foo", args: `{"name": "bar"}`},
+				}},
+			},
+		},
+		{
 			desc:  "tool call with nested object",
 			tools: []api.Tool{{Function: api.ToolFunction{Name: "create_entities"}}},
 			steps: []step{

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -147,6 +147,22 @@ func TestParser(t *testing.T) {
 				},
 			},
 		},
+		{
+			Type: "function",
+			Function: api.ToolFunction{
+				Name:        "foo",
+				Description: "Foo tool with parameter named name",
+				Parameters: api.ToolFunctionParameters{
+					Type: "object",
+					Properties: testPropsMap(map[string]api.ToolProperty{
+						"name": {
+							Type:        api.PropertyType{"string"},
+							Description: "Name parameter",
+						},
+					}),
+				},
+			},
+		},
 	}
 
 	tests := []struct {
@@ -248,6 +264,40 @@ func TestParser(t *testing.T) {
 						Name:  "get_conditions",
 						Arguments: testArgs(map[string]any{
 							"location": "Tokyo",
+						}),
+					},
+				},
+			},
+		},
+		{
+			name:    "tool call with parameter named name",
+			inputs:  []string{`[TOOL_CALLS] [{"name": "foo", "arguments": {"name": "bar"}}][/TOOL_CALLS]`},
+			content: "",
+			tmpl:    mistral,
+			calls: []api.ToolCall{
+				{
+					Function: api.ToolCallFunction{
+						Index: 0,
+						Name:  "foo",
+						Arguments: testArgs(map[string]any{
+							"name": "bar",
+						}),
+					},
+				},
+			},
+		},
+		{
+			name:    "json tool call with parameter named name",
+			inputs:  []string{`{"name": "foo", "parameters": {"name": "bar"}}`},
+			content: "",
+			tmpl:    json,
+			calls: []api.ToolCall{
+				{
+					Function: api.ToolCallFunction{
+						Index: 0,
+						Name:  "foo",
+						Arguments: testArgs(map[string]any{
+							"name": "bar",
 						}),
 					},
 				},


### PR DESCRIPTION
### Summary
Fixes #16932 by ensuring robust tool name matching and whitespace normalization during streaming tool call parsing.

### Key Changes
1. **Tool Name Whitespace Trimming:** Updated `MinistralParser` (`model/parsers/ministral.go`) to trim leading/trailing whitespace around extracted tool names (`split[0]`) and inside `toolByName()`.
2. **Regression Testing:** Added test cases in `model/parsers/ministral_test.go` and `tools/tools_test.go` explicitly verifying tool calls containing parameters named `name`.
