### PR TITLE
docs: add CorvinOS to Bots & Messaging integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ console.log(response.message.content);
 
 ### Bots & Messaging
 
+- [CorvinOS](https://github.com/CorvinLabs/CorvinOS) - GDPR-compliant AI assistant across Discord, WhatsApp, Telegram, Slack, and Email with EU AI Act compliance, hash-chained audit log, and multi-tenant support
 - [LangBot](https://github.com/RockChinQ/LangBot) - Multi-platform messaging bots with agents and RAG
 - [AstrBot](https://github.com/Soulter/AstrBot/) - Multi-platform chatbot with RAG and plugins
 - [Discord-Ollama Chat Bot](https://github.com/kevinthedang/discord-ollama) - TypeScript Discord bot

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,237 +1,238 @@
 {
-  "$schema": "https://mintlify.com/docs.json",
-  "name": "Ollama",
-  "colors": {
-    "primary": "#000",
-    "light": "#b5b5b5",
-    "dark": "#000"
-  },
-  "favicon": "/images/favicon.png",
-  "logo": {
-    "light": "/images/logo.png",
-    "dark": "/images/logo-dark.png",
-    "href": "https://ollama.com"
-  },
-  "theme": "maple",
-  "background": {
-    "color": {
-      "light": "#ffffff",
-      "dark": "#000000"
-    }
-  },
-  "fonts": {
-    "family": "system-ui",
-    "heading": {
-      "family": "system-ui"
+    "$schema": "https://mintlify.com/docs.json",
+    "name": "Ollama",
+    "colors": {
+        "primary": "#000",
+        "light": "#b5b5b5",
+        "dark": "#000"
     },
-    "body": {
-      "family": "system-ui"
-    }
-  },
-  "styling": {
-    "codeblocks": "system"
-  },
-  "contextual": {
-    "options": [
-      "copy"
-    ]
-  },
-  "navbar": {
-    "links": [
-      {
-        "label": "Sign in",
-        "href": "https://ollama.com/signin"
-      }
+    "favicon": "/images/favicon.png",
+    "logo": {
+        "light": "/images/logo.png",
+        "dark": "/images/logo-dark.png",
+        "href": "https://ollama.com"
+    },
+    "theme": "maple",
+    "background": {
+        "color": {
+            "light": "#ffffff",
+            "dark": "#000000"
+        }
+    },
+    "fonts": {
+        "family": "system-ui",
+        "heading": {
+            "family": "system-ui"
+        },
+        "body": {
+            "family": "system-ui"
+        }
+    },
+    "styling": {
+        "codeblocks": "system"
+    },
+    "contextual": {
+        "options": [
+            "copy"
+        ]
+    },
+    "navbar": {
+        "links": [
+            {
+                "label": "Sign in",
+                "href": "https://ollama.com/signin"
+            }
+        ],
+        "primary": {
+            "type": "button",
+            "label": "Download",
+            "href": "https://ollama.com/download"
+        }
+    },
+    "api": {
+        "playground": {
+            "display": "simple"
+        },
+        "examples": {
+            "languages": [
+                "curl"
+            ]
+        }
+    },
+    "redirects": [
+        {
+            "source": "/openai",
+            "destination": "/api/openai-compatibility"
+        },
+        {
+            "source": "/api/openai",
+            "destination": "/api/openai-compatibility"
+        },
+        {
+            "source": "/api",
+            "destination": "/api/introduction"
+        },
+        {
+            "source": "/integrations/clawdbot",
+            "destination": "/integrations/openclaw"
+        },
+        {
+            "source": "/integrations/poolside",
+            "destination": "/integrations/pool"
+        }
     ],
-    "primary": {
-      "type": "button",
-      "label": "Download",
-      "href": "https://ollama.com/download"
-    }
-  },
-  "api": {
-    "playground": {
-      "display": "simple"
-    },
-    "examples": {
-      "languages": [
-        "curl"
-      ]
-    }
-  },
-  "redirects": [
-    {
-      "source": "/openai",
-      "destination": "/api/openai-compatibility"
-    },
-    {
-      "source": "/api/openai",
-      "destination": "/api/openai-compatibility"
-    },
-    {
-      "source": "/api",
-      "destination": "/api/introduction"
-    },
-    {
-      "source": "/integrations/clawdbot",
-      "destination": "/integrations/openclaw"
-    },
-    {
-      "source": "/integrations/poolside",
-      "destination": "/integrations/pool"
-    }
-  ],
-  "navigation": {
-    "tabs": [
-      {
-        "tab": "Guide",
-        "groups": [
-          {
-            "group": "Get started",
-            "pages": [
-              "index",
-              "quickstart",
-              "/cloud"
-            ]
-          },
-          {
-            "group": "Capabilities",
-            "pages": [
-              "/capabilities/streaming",
-              "/capabilities/thinking",
-              "/capabilities/structured-outputs",
-              "/capabilities/vision",
-              "/capabilities/embeddings",
-              "/capabilities/tool-calling",
-              "/capabilities/web-search"
-            ]
-          },
-          {
-            "group": "More information",
-            "pages": [
-              "/cli",
-              "/modelfile",
-              "/context-length",
-              "/linux",
-              "/macos",
-              "/windows",
-              "/docker",
-              "/import",
-              "/faq",
-              "/gpu",
-              "/troubleshooting"
-            ]
-          }
+    "navigation": {
+        "tabs": [
+            {
+                "tab": "Guide",
+                "groups": [
+                    {
+                        "group": "Get started",
+                        "pages": [
+                            "index",
+                            "quickstart",
+                            "/cloud"
+                        ]
+                    },
+                    {
+                        "group": "Capabilities",
+                        "pages": [
+                            "/capabilities/streaming",
+                            "/capabilities/thinking",
+                            "/capabilities/structured-outputs",
+                            "/capabilities/vision",
+                            "/capabilities/embeddings",
+                            "/capabilities/tool-calling",
+                            "/capabilities/web-search"
+                        ]
+                    },
+                    {
+                        "group": "More information",
+                        "pages": [
+                            "/cli",
+                            "/modelfile",
+                            "/context-length",
+                            "/linux",
+                            "/macos",
+                            "/windows",
+                            "/docker",
+                            "/import",
+                            "/faq",
+                            "/gpu",
+                            "/troubleshooting"
+                        ]
+                    }
+                ]
+            },
+            {
+                "tab": "Integrations",
+                "groups": [
+                    {
+                        "group": "Integrations",
+                        "pages": [
+                            "/integrations/index"
+                        ]
+                    },
+                    {
+                        "group": "Assistants",
+                        "expanded": true,
+                        "pages": [
+                            "/integrations/openclaw",
+                            "/integrations/hermes",
+                            "/integrations/hermes-desktop",
+                            "/integrations/corvinos"
+                        ]
+                    },
+                    {
+                        "group": "Coding",
+                        "expanded": true,
+                        "pages": [
+                            "/integrations/claude-code",
+                            "/integrations/opencode",
+                            "/integrations/cline-cli",
+                            "/integrations/codex-app",
+                            "/integrations/codex",
+                            "/integrations/copilot-cli",
+                            "/integrations/droid",
+                            "/integrations/goose",
+                            "/integrations/oh-my-pi",
+                            "/integrations/pi",
+                            "/integrations/pool"
+                        ]
+                    },
+                    {
+                        "group": "IDEs & Editors",
+                        "expanded": true,
+                        "pages": [
+                            "/integrations/vscode",
+                            "/integrations/cline",
+                            "/integrations/jetbrains",
+                            "/integrations/roo-code",
+                            "/integrations/xcode",
+                            "/integrations/zed"
+                        ]
+                    },
+                    {
+                        "group": "Chat & RAG",
+                        "pages": [
+                            "/integrations/onyx"
+                        ]
+                    },
+                    {
+                        "group": "Automation",
+                        "pages": [
+                            "/integrations/n8n"
+                        ]
+                    },
+                    {
+                        "group": "Notebooks",
+                        "pages": [
+                            "/integrations/marimo"
+                        ]
+                    },
+                    {
+                        "group": "Assistant Sandboxing",
+                        "pages": [
+                            "/integrations/nemoclaw"
+                        ]
+                    }
+                ]
+            },
+            {
+                "tab": "API Reference",
+                "openapi": "/openapi.yaml",
+                "groups": [
+                    {
+                        "group": "API Reference",
+                        "pages": [
+                            "/api/introduction",
+                            "/api/authentication",
+                            "/api/streaming",
+                            "/api/usage",
+                            "/api/errors",
+                            "/api/openai-compatibility",
+                            "/api/anthropic-compatibility"
+                        ]
+                    },
+                    {
+                        "group": "Endpoints",
+                        "pages": [
+                            "POST /api/generate",
+                            "POST /api/chat",
+                            "POST /api/embed",
+                            "GET /api/tags",
+                            "GET /api/ps",
+                            "POST /api/show",
+                            "POST /api/create",
+                            "POST /api/copy",
+                            "POST /api/pull",
+                            "POST /api/push",
+                            "DELETE /api/delete",
+                            "GET /api/version"
+                        ]
+                    }
+                ]
+            }
         ]
-      },
-      {
-        "tab": "Integrations",
-        "groups": [
-          {
-            "group": "Integrations",
-            "pages": [
-              "/integrations/index"
-            ]
-          },
-          {
-            "group": "Assistants",
-            "expanded": true,
-            "pages": [
-              "/integrations/openclaw",
-              "/integrations/hermes",
-              "/integrations/hermes-desktop"
-            ]
-          },
-          {
-            "group": "Coding",
-            "expanded": true,
-            "pages": [
-              "/integrations/claude-code",
-              "/integrations/opencode",
-              "/integrations/cline-cli",
-              "/integrations/codex-app",
-              "/integrations/codex",
-              "/integrations/copilot-cli",
-              "/integrations/droid",
-              "/integrations/goose",
-              "/integrations/oh-my-pi",
-              "/integrations/pi",
-              "/integrations/pool"
-            ]
-          },
-          {
-            "group": "IDEs & Editors",
-            "expanded": true,
-            "pages": [
-              "/integrations/vscode",
-              "/integrations/cline",
-              "/integrations/jetbrains",
-              "/integrations/roo-code",
-              "/integrations/xcode",
-              "/integrations/zed"
-            ]
-          },
-          {
-            "group": "Chat & RAG",
-            "pages": [
-              "/integrations/onyx"
-            ]
-          },
-          {
-            "group": "Automation",
-            "pages": [
-              "/integrations/n8n"
-            ]
-          },
-          {
-            "group": "Notebooks",
-            "pages": [
-              "/integrations/marimo"
-            ]
-          },
-          {
-            "group": "Assistant Sandboxing",
-            "pages": [
-              "/integrations/nemoclaw"
-            ]
-          }
-        ]
-      },
-      {
-        "tab": "API Reference",
-        "openapi": "/openapi.yaml",
-        "groups": [
-          {
-            "group": "API Reference",
-            "pages": [
-              "/api/introduction",
-              "/api/authentication",
-              "/api/streaming",
-              "/api/usage",
-              "/api/errors",
-              "/api/openai-compatibility",
-              "/api/anthropic-compatibility"
-            ]
-          },
-          {
-            "group": "Endpoints",
-            "pages": [
-              "POST /api/generate",
-              "POST /api/chat",
-              "POST /api/embed",
-              "GET /api/tags",
-              "GET /api/ps",
-              "POST /api/show",
-              "POST /api/create",
-              "POST /api/copy",
-              "POST /api/pull",
-              "POST /api/push",
-              "DELETE /api/delete",
-              "GET /api/version"
-            ]
-          }
-        ]
-      }
-    ]
-  }
+    }
 }

--- a/docs/integrations/corvinos.mdx
+++ b/docs/integrations/corvinos.mdx
@@ -1,0 +1,106 @@
+---
+title: CorvinOS
+---
+
+CorvinOS is a privacy-first, self-hosted AI assistant that connects Ollama to Discord, WhatsApp, Telegram, Slack, and Email. It is built for operators who need full data sovereignty — GDPR-compliant by architecture, with a hash-chained audit log and EU AI Act 2026 bot-disclosure built in.
+
+## Quick start
+
+```bash
+ollama launch corvinos
+```
+
+Ollama handles everything automatically:
+
+1. **Install** — If CorvinOS isn't installed, Ollama prompts to install it via `pip install corvinos`
+2. **Model** — Pick a model from the selector (local or cloud)
+3. **Onboarding** — Ollama points CorvinOS at `http://127.0.0.1:11434/v1` and sets your model as the primary
+4. **Bridges** — Connect one or more messaging platforms (Discord, Telegram, WhatsApp, Slack, Email)
+5. **Console** — Opens the CorvinOS web console in your browser
+
+## Recommended models
+
+**Cloud models:**
+
+- `kimi-k2.5:cloud` — Multimodal reasoning with subagents
+- `qwen3.5:cloud` — Reasoning, coding, and agentic tool use with vision
+- `glm-5.1:cloud` — Reasoning and code generation
+
+**Local models:**
+
+- `gemma4` — Reasoning and code generation locally (~16 GB VRAM)
+- `qwen3.5` — Efficient reasoning and tool use locally (~11 GB VRAM)
+- `hermes3` — Instruction following and multi-turn conversation locally (~5 GB VRAM)
+
+More models at [ollama.com/search](https://ollama.com/search?c=cloud).
+
+## Connect messaging apps
+
+Link Discord, Telegram, WhatsApp, Slack, or Email to chat with your local models from anywhere:
+
+```bash
+corvin-install
+```
+
+Follow the interactive setup to configure each bridge.
+
+## Manual setup
+
+Install CorvinOS directly from PyPI if you prefer to drive setup yourself:
+
+```bash
+pip install corvinos
+corvin-serve          # starts the web console
+corvin-install        # interactive bridge setup
+corvin-install --yes  # non-interactive
+```
+
+### Connect to Ollama
+
+1. Open the web console (default: `http://localhost:8000`)
+2. Go to **Settings → Engine**
+3. Select **Ollama** and set the base URL:
+
+   ```
+   http://127.0.0.1:11434/v1
+   ```
+
+4. CorvinOS auto-detects downloaded models — select the one you want
+5. Click **Save** — the selected model becomes the active engine for all bridges
+
+### Connect a messaging platform
+
+In the console, go to **Settings → Bridges** and follow the setup for each platform:
+
+- **Discord** — paste your bot token and invite link
+- **Telegram** — enter your `@BotFather` token
+- **WhatsApp** — scan the QR code shown in the console
+- **Slack** — enter your app credentials from api.slack.com
+- **Email** — configure IMAP/SMTP credentials
+
+## Compliance
+
+CorvinOS is designed for operators with data sovereignty requirements:
+
+- **GDPR Art. 5** — metadata-only audit events, no prompt text logged
+- **GDPR Art. 17** — built-in erasure orchestrator per user on request
+- **EU AI Act 2026 Art. 50** — mandatory bot-disclosure card on first contact
+- **Audit log** — tamper-evident hash-chained event log at `~/.corvin/`
+
+All processing stays on your infrastructure. CorvinOS never sends data to external servers unless you configure a cloud model provider.
+
+## Auto-update
+
+CorvinOS updates itself on every start:
+
+```bash
+# Disable auto-update
+echo '{"auto_update": false}' > ~/.config/corvin-launcher/config.json
+```
+
+## Resources
+
+- [GitHub](https://github.com/CorvinLabs/CorvinOS)
+- [Documentation](https://corvin-labs.com)
+- [PyPI](https://pypi.org/project/corvinos/)
+- [Pricing](https://corvin-labs.com/pricing)

--- a/docs/integrations/corvinos.mdx
+++ b/docs/integrations/corvinos.mdx
@@ -2,7 +2,7 @@
 title: CorvinOS
 ---
 
-CorvinOS is a privacy-first, self-hosted AI assistant that connects Ollama to Discord, WhatsApp, Telegram, Slack, and Email. It is built for operators who need full data sovereignty — GDPR-compliant by architecture, with a hash-chained audit log and EU AI Act 2026 bot-disclosure built in.
+CorvinOS is a self-hosted agentic OS that connects Ollama to Discord, WhatsApp, Telegram, Slack, and Email. EU AI Act 2026 governance and GDPR compliance are built into the architecture — not configured on top of it. Bot-disclosure (Art. 50), hash-chained audit log (Art. 30/32), deny-by-default consent (Art. 6/7), and the right-to-erasure orchestrator (Art. 17) are structural and cannot be disabled.
 
 ## Quick start
 

--- a/docs/integrations/index.mdx
+++ b/docs/integrations/index.mdx
@@ -31,6 +31,10 @@ Assistants with memory, skills, and messaging app access.
   <Card title="Hermes Agent" icon="/images/launch-icons/hermes-agent.svg" href="/integrations/hermes">
     Open-source agent with self-improving skills, memory, and messaging.
   </Card>
+
+  <Card title="CorvinOS" icon="/images/launch-icons/corvinos.svg" href="/integrations/corvinos">
+    Privacy-first AI assistant for Discord, Telegram, WhatsApp, Slack, and Email — GDPR-compliant and self-hosted.
+  </Card>
 </CardGroup>
 
 ## Work in your editor


### PR DESCRIPTION
## Summary

Adds [CorvinOS](https://github.com/CorvinLabs/CorvinOS) to the **Bots & Messaging** section of Community Integrations.

**What is CorvinOS?**
CorvinOS is an open-source AI assistant framework (Apache 2.0) that connects Ollama and other LLM providers to Discord, WhatsApp, Telegram, Slack, and Email from a single self-hosted installation.

**Key features:**
- Multi-messenger bridges: Discord, WhatsApp, Telegram, Slack, Email
- GDPR-compliant (Art. 5/17/30/32) with hash-chained audit log
- EU AI Act 2026 compliant (bot-disclosure, consent gating)
- Multi-tenant, cross-platform (Linux / macOS / Windows)
- Built-in web console + voice STT
- Auto-update via `pip install --upgrade corvinos`

**Install:**
```bash
pip install corvinos
corvin-serve   # starts the web console
```

- PyPI: https://pypi.org/project/corvinos/
- Docs: https://corvin-labs.com