### PR TITLE
fix: resolve Gemma4 QAT vision hang and Jetson projector offload regr…

### DIFF
--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -658,7 +658,7 @@ func shouldDisableMMProjOffload(opts api.Options, gpus []ml.DeviceInfo, modelLay
 	requiredMemory := mmprojMemory + mmprojOffloadHeadroom
 
 	for _, gpu := range gpus {
-		if gpu.Integrated && gpu.Library != "Metal" {
+		if gpu.Integrated && gpu.Library != "Metal" && gpu.Library != "CUDA" {
 			return true, "shared-memory-gpu"
 		}
 		memory := gpu.FreeMemory

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -2139,6 +2139,15 @@ func TestAppendMMProjArgs(t *testing.T) {
 			want:         []string{"base", "--mmproj", "model.gguf"},
 		},
 		{
+			name:         "integrated cuda gpu keeps projector offload",
+			projectors:   []string{"model.gguf"},
+			opts:         defaultOpts,
+			gpus:         []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}, Integrated: true, FreeMemory: 32 << 30}},
+			mmprojMemory: 933 << 20,
+			modelLayers:  81,
+			want:         []string{"base", "--mmproj", "model.gguf"},
+		},
+		{
 			name:         "cpu only request disables projector offload",
 			projectors:   []string{"model.gguf"},
 			opts:         cpuOpts,

--- a/model/model.go
+++ b/model/model.go
@@ -136,6 +136,12 @@ func New(modelPath string, params ml.BackendParams) (Model, error) {
 		}
 	}
 
+	if postLoader, ok := m.(PostLoader); ok {
+		if err := postLoader.PostLoad(); err != nil {
+			return nil, err
+		}
+	}
+
 	return m, nil
 }
 


### PR DESCRIPTION
…ession

Two critical fixes for Gemma4 vision processing on Jetson ORIN AGX:

1. model/model.go: Call PostLoad() during model initialization PostLoad() was never invoked despite being defined on the Gemma4 Model. This meant InitClamp() was never called, so the vision encoder's ClippableLinear layers never received their clamp values (input_min/max, output_min/max). Without clamping, attention scores overflow to NaN, causing the softmax to hang indefinitely — explaining the QAT model hang.

2. llm/llama_server.go: Allow CUDA integrated GPU projector offload The integrated GPU check in shouldDisableMMProjOffload only exempted Metal, leaving Jetson ORIN AGX (integrated CUDA GPU with unified memory) forced to run the projector on CPU via llama.cpp. This caused 2-10x slowdown vs GPU projection on v0.24.0.

Fixes #16950