### PR TITLE
model/parsers: honor think value when initializing the qwen3-vl parser

### DIFF
--- a/model/parsers/qwen3vl.go
+++ b/model/parsers/qwen3vl.go
@@ -48,14 +48,18 @@ func (p *Qwen3VLParser) PreservedTokens() []string {
 	}
 }
 
-func (p *Qwen3VLParser) setInitialState(lastMessage *api.Message) {
-	prefill := lastMessage != nil && lastMessage.Role == "assistant"
+func (p *Qwen3VLParser) setInitialState(lastMessage *api.Message, thinkValue *api.ThinkValue) {
 	if !p.HasThinkingSupport() {
 		p.state = CollectingContent
 		return
 	}
 
-	if prefill && lastMessage.Content != "" {
+	// Thinking is enabled by default when the caller doesn't specify a value,
+	// otherwise honor the requested think value (think=false disables it).
+	thinkingEnabled := thinkValue == nil || thinkValue.Bool()
+
+	prefill := lastMessage != nil && lastMessage.Role == "assistant" && lastMessage.Content != ""
+	if !thinkingEnabled || prefill {
 		p.state = CollectingContent
 		return
 	}
@@ -66,7 +70,7 @@ func (p *Qwen3VLParser) setInitialState(lastMessage *api.Message) {
 func (p *Qwen3VLParser) Init(tools []api.Tool, lastMessage *api.Message, thinkValue *api.ThinkValue) []api.Tool {
 	p.tools = tools
 	p.callIndex = 0
-	p.setInitialState(lastMessage)
+	p.setInitialState(lastMessage, thinkValue)
 	return tools
 }
 

--- a/model/parsers/qwen3vl_thinking_test.go
+++ b/model/parsers/qwen3vl_thinking_test.go
@@ -353,6 +353,7 @@ func TestQwen3VLParserState(t *testing.T) {
 		desc        string
 		hasThinking bool
 		last        *api.Message
+		think       *api.ThinkValue
 		wantState   qwenParserState
 	}{
 		{
@@ -360,6 +361,27 @@ func TestQwen3VLParserState(t *testing.T) {
 			hasThinking: false,
 			last:        nil,
 			wantState:   CollectingContent,
+		},
+		{
+			desc:        "thinking support, think=false => CollectingContent",
+			hasThinking: true,
+			last:        nil,
+			think:       &api.ThinkValue{Value: false},
+			wantState:   CollectingContent,
+		},
+		{
+			desc:        "thinking support, think=true => CollectingThinkingContent",
+			hasThinking: true,
+			last:        nil,
+			think:       &api.ThinkValue{Value: true},
+			wantState:   CollectingThinkingContent,
+		},
+		{
+			desc:        "thinking support, think=high => CollectingThinkingContent",
+			hasThinking: true,
+			last:        nil,
+			think:       &api.ThinkValue{Value: "high"},
+			wantState:   CollectingThinkingContent,
 		},
 		{
 			desc:        "thinking support, no last message => CollectingThinkingContent",
@@ -389,7 +411,7 @@ func TestQwen3VLParserState(t *testing.T) {
 
 	for _, tc := range cases {
 		parser := Qwen3VLParser{hasThinkingSupport: tc.hasThinking}
-		parser.Init(nil, tc.last, nil)
+		parser.Init(nil, tc.last, tc.think)
 		if parser.state != tc.wantState {
 			t.Errorf("%s: got state %v, want %v", tc.desc, parser.state, tc.wantState)
 		}


### PR DESCRIPTION
Fixes #16945

The qwen3-vl parser always started in the thinking-collection state whenever the model supported thinking, ignoring the request's `think` value. With `think: false` the model emits an answer directly without a `</think>` tag, so the parser kept treating every token as reasoning, never emitted content, and the stream ended with `finish_reason: length`.

`setInitialState` now receives the `think` value and starts in the content state when thinking is disabled, matching how the qwen3.5 and deepseek3 parsers already behave. Thinking stays on by default when no value is passed, so existing behavior is unchanged.

Added cases to `TestQwen3VLParserState` covering `think=false`, `think=true`, and `think="high"`.