### PR TITLE
llm: skip quantized kv cache for models that don't support it

### DIFF
--- a/fs/ggml/ggml.go
+++ b/fs/ggml/ggml.go
@@ -857,9 +857,15 @@ func (f GGML) GraphSize(context, batch uint64, numParallel int, kvCacheType stri
 }
 
 // SupportsKVCacheType checks if the requested cache type is supported
-func (f GGML) SupportsKVCacheType(cacheType string) bool {
+func (kv KV) SupportsKVCacheType(cacheType string) bool {
 	if cacheType == "" || cacheType == "f16" {
 		return true
+	}
+
+	if arch := kv.Architecture(); slices.Contains([]string{"gptoss", "gpt-oss"}, arch) {
+		// gpt-oss uses attention with sinks which does not support quantized cache types
+		slog.Warn("model only supports non-quantized cache types", "model", arch)
+		return false
 	}
 
 	return slices.Contains([]string{"q8_0", "q4_0"}, cacheType)

--- a/fs/ggml/ggml_test.go
+++ b/fs/ggml/ggml_test.go
@@ -270,6 +270,34 @@ func TestKeyValue(t *testing.T) {
 	}
 }
 
+func TestSupportsKVCacheType(t *testing.T) {
+	cases := []struct {
+		arch      string
+		cacheType string
+		want      bool
+	}{
+		// gpt-oss uses attention with sinks and only supports non-quantized cache
+		{"gptoss", "q8_0", false},
+		{"gpt-oss", "q8_0", false},
+		{"gptoss", "q4_0", false},
+		{"gptoss", "f16", true},
+		{"gptoss", "", true},
+		// other architectures support the usual quantized cache types
+		{"llama", "q8_0", true},
+		{"llama", "q4_0", true},
+		{"llama", "f16", true},
+		{"llama", "", true},
+		{"llama", "q4_1", false},
+	}
+
+	for _, tt := range cases {
+		kv := KV{"general.architecture": tt.arch}
+		if got := kv.SupportsKVCacheType(tt.cacheType); got != tt.want {
+			t.Errorf("SupportsKVCacheType(%q) for %q = %v, want %v", tt.cacheType, tt.arch, got, tt.want)
+		}
+	}
+}
+
 func TestHeadCount(t *testing.T) {
 	valuesArray := []int32{1, 5, 3, 4}
 	cases := []struct {

--- a/llm/server.go
+++ b/llm/server.go
@@ -116,6 +116,13 @@ func NewLlamaServer(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, modelPath st
 	}
 
 	kvct := strings.ToLower(envconfig.KvCacheType())
+	if !f.KV().SupportsKVCacheType(kvct) {
+		// Some architectures (e.g. gpt-oss, which uses attention with sinks)
+		// crash llama-server when served with a quantized KV cache. Fall back
+		// to the default rather than passing an unsupported cache type.
+		slog.Warn("model does not support the requested kv cache type, using the default", "model", f.KV().Architecture(), "type", kvct)
+		kvct = ""
+	}
 	return NewLlamaServerRunner(gpus, modelPath, f, adapters, projectors, opts, numParallel, kvct, config)
 }
 


### PR DESCRIPTION
Fixes #16946

Serving gpt-oss with `OLLAMA_KV_CACHE_TYPE=q8_0` core dumps llama-server. gpt-oss uses attention with sinks, which does not support a quantized KV cache.

A guard for this used to live in `GGML.SupportsKVCacheType`, but that function lost all of its callers and the gpt-oss branch was removed in 19e6796 (assuming a GGML update made it safe). The requested cache type now flows straight to llama-server as `--cache-type-k`/`--cache-type-v` unchecked, so it crashes. This is a regression — the reporter confirms it works on 0.24.0 and fails on 0.30.x.

This restores the gpt-oss guard, moves `SupportsKVCacheType` onto `KV`, and consults it when building the llama-server command: if the model doesn't support the requested cache type, fall back to the default instead of passing an unsupported one.

Added a unit test covering gpt-oss (quantized rejected, f16/unset allowed) and other architectures (q8_0/q4_0 allowed).