### PR TITLE
 server: inherit context_length and base name from parent model on create 

### DIFF
--- a/server/create.go
+++ b/server/create.go
@@ -159,33 +159,54 @@ func (s *Server) CreateHandler(c *gin.Context) {
 				if err != nil {
 					ch <- gin.H{"error": err.Error()}
 				}
+			}
 
-				if err == nil && !remote {
-					mf, mErr := manifest.ParseNamedManifest(fromName)
-					if mErr == nil && mf.Config.Digest != "" {
-						configPath, pErr := manifest.BlobsPath(mf.Config.Digest)
-						if pErr == nil {
-							if cfgFile, fErr := os.Open(configPath); fErr == nil {
-								var baseConfig model.ConfigV2
-								if decErr := json.NewDecoder(cfgFile).Decode(&baseConfig); decErr == nil {
-									if config.Renderer == "" {
-										config.Renderer = baseConfig.Renderer
-									}
-									if config.Parser == "" {
-										config.Parser = baseConfig.Parser
-									}
-									if config.Requires == "" {
-										config.Requires = baseConfig.Requires
-									}
-									if config.ModelFormat == "" {
-										config.ModelFormat = baseConfig.ModelFormat
-									}
-									if len(config.Capabilities) == 0 {
-										config.Capabilities = baseConfig.Capabilities
-									}
+			if err == nil {
+				mf, mErr := manifest.ParseNamedManifest(fromName)
+				if mErr == nil && mf.Config.Digest != "" {
+					configPath, pErr := manifest.BlobsPath(mf.Config.Digest)
+					if pErr == nil {
+						if cfgFile, fErr := os.Open(configPath); fErr == nil {
+							var baseConfig model.ConfigV2
+							if decErr := json.NewDecoder(cfgFile).Decode(&baseConfig); decErr == nil {
+								if config.Renderer == "" {
+									config.Renderer = baseConfig.Renderer
 								}
-								cfgFile.Close()
+								if config.Parser == "" {
+									config.Parser = baseConfig.Parser
+								}
+								if config.Requires == "" {
+									config.Requires = baseConfig.Requires
+								}
+								if config.ModelFormat == "" {
+									config.ModelFormat = baseConfig.ModelFormat
+								}
+								if len(config.Capabilities) == 0 {
+									config.Capabilities = baseConfig.Capabilities
+								}
+								if config.ModelFamily == "" {
+									config.ModelFamily = baseConfig.ModelFamily
+								}
+								if len(config.ModelFamilies) == 0 {
+									config.ModelFamilies = baseConfig.ModelFamilies
+								}
+								if config.ModelType == "" {
+									config.ModelType = baseConfig.ModelType
+								}
+								if config.FileType == "" {
+									config.FileType = baseConfig.FileType
+								}
+								if config.ContextLen == 0 {
+									config.ContextLen = baseConfig.ContextLen
+								}
+								if config.EmbedLen == 0 {
+									config.EmbedLen = baseConfig.EmbedLen
+								}
+								if config.BaseName == "" {
+									config.BaseName = baseConfig.BaseName
+								}
 							}
+							cfgFile.Close()
 						}
 					}
 				}
@@ -757,7 +778,10 @@ func createModel(r api.CreateRequest, name model.Name, baseLayers []*layerGGML, 
 				config.ModelFamily = cmp.Or(config.ModelFamily, layer.GGML.KV().Architecture())
 				config.ModelType = cmp.Or(config.ModelType, format.HumanNumber(layer.GGML.KV().ParameterCount()))
 				config.FileType = cmp.Or(config.FileType, layer.GGML.KV().FileType().String())
-				config.ModelFamilies = append(config.ModelFamilies, layer.GGML.KV().Architecture())
+				arch := layer.GGML.KV().Architecture()
+				if !slices.Contains(config.ModelFamilies, arch) {
+					config.ModelFamilies = append(config.ModelFamilies, arch)
+				}
 
 				// Auto-detect renderer, parser, and stop tokens from GGUF architecture.
 				// TODO: abstract this into a registry/lookup table when multiple models

--- a/server/routes_create_test.go
+++ b/server/routes_create_test.go
@@ -1346,6 +1346,88 @@ func TestCreateAndShowRemoteModel(t *testing.T) {
 	fmt.Printf("resp = %#v\n", resp)
 }
 
+func TestCreateRemoteModelInheritsFromBase(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	t.Setenv("OLLAMA_MODELS", t.TempDir())
+
+	// Write a mock base remote model manifest
+	cfgData, err := json.Marshal(model.ConfigV2{
+		ModelFormat:   "gguf",
+		ModelFamily:   "gptoss",
+		ModelFamilies: []string{"gptoss"},
+		ContextLen:    131072,
+		EmbedLen:      2880,
+		BaseName:      "bob-base",
+		Capabilities:  []string{"completion", "tools"},
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal base config: %v", err)
+	}
+
+	configLayer, err := manifest.NewLayer(bytes.NewReader(cfgData), "application/vnd.docker.container.image.v1+json")
+	if err != nil {
+		t.Fatalf("failed to create config layer: %v", err)
+	}
+
+	name := model.ParseName("bob")
+	if err := manifest.WriteManifest(name, configLayer, nil); err != nil {
+		t.Fatalf("failed to write manifest: %v", err)
+	}
+
+	var s Server
+	w := createRequest(t, s.CreateHandler, api.CreateRequest{
+		Model:      "test-custom",
+		From:       "bob",
+		RemoteHost: "https://ollama.com",
+		Stream:     &stream,
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status code 200, actual %d", w.Code)
+	}
+
+	w = createRequest(t, s.ShowHandler, api.ShowRequest{Model: "test-custom"})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status code 200, actual %d", w.Code)
+	}
+
+	var resp api.ShowResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.Details.Family != "gptoss" {
+		t.Errorf("expected family to be %q, got %q", "gptoss", resp.Details.Family)
+	}
+
+	v, ok := resp.ModelInfo["gptoss.context_length"]
+	if !ok {
+		t.Fatalf("missing context length in ModelInfo: %#v", resp.ModelInfo)
+	}
+	ctxlen := v.(float64)
+	if int(ctxlen) != 131072 {
+		t.Errorf("context len: expected %d, actual %d", 131072, int(ctxlen))
+	}
+
+	v, ok = resp.ModelInfo["gptoss.embedding_length"]
+	if !ok {
+		t.Fatalf("missing embedding length in ModelInfo")
+	}
+	embedlen := v.(float64)
+	if int(embedlen) != 2880 {
+		t.Errorf("embed len: expected %d, actual %d", 2880, int(embedlen))
+	}
+
+	v, ok = resp.ModelInfo["general.basename"]
+	if !ok {
+		t.Fatalf("missing general.basename in ModelInfo")
+	}
+	basename := v.(string)
+	if basename != "bob-base" {
+		t.Errorf("basename: expected %q, actual %q", "bob-base", basename)
+	}
+}
+
 func TestCreateRemoteModelRejectsDraftFiles(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 


### PR DESCRIPTION
 PR Description                                                                                   
                                                                                                   
    ### Problem                                                                                    
    When creating a custom model using a Modelfile (e.g. `FROM glm-5.2:cloud` with parameter       
  overrides), Ollama creates a new manifest but does not inherit the parent model's `model_info`   
  configuration (such as `context_length`, `embedding_length`, and `base_name`).                   
                                                                                                   
    As a result, IDE integrations (such as VSCode Copilot or Cursor) query `/api/show` for the new 
  custom model name, find an empty `model_info` object, and default to a small context window (e.g.,
  32K tokens), breaking long-context capabilities for customized local/remote models.              
                                                                                                   
    Fixes #16891                                                                                   
                                                                                                   
    ### Solution                                                                                   
    - Moved the parent configuration parsing/inheritance logic out of the `!remote` branch in      
  `CreateHandler` so that it runs for both local and remote/cloud base models if their manifests   
  are present locally.                                                                             
    - Extended the inheritance block in `server/create.go` to copy missing fields (`ModelFamily`,  
  `ModelFamilies`, `ModelType`, `FileType`, `ContextLen`, `EmbedLen`, `BaseName`) from the base    
  config into the new model's config.                                                              
    - Guarded `config.ModelFamilies` appending with a `slices.Contains` check in `createModel` to  
  avoid double-appending architectures when config fields are inherited.                           
    - Added a full unit test `TestCreateRemoteModelInheritsFromBase` in `server/routes_create_test.
  go` to verify that creation from a base model correctly inherits and reports `context_length`,   
  `embedding_length`, and `general.basename`.