### PR TITLE
cmd: avoid terminal wrapping when stdout is redirected

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1665,11 +1665,19 @@ type displayResponseState struct {
 }
 
 func displayResponse(content string, wordWrap bool, state *displayResponseState) {
-	termWidth, _, _ := term.GetSize(int(os.Stdout.Fd()))
-	if termWidth == 0 {
-		termWidth = 80
-	}
-	if wordWrap && termWidth >= 10 {
+	if wordWrap && term.IsTerminal(int(os.Stdout.Fd())) {
+		termWidth, _, _ := term.GetSize(int(os.Stdout.Fd()))
+		if termWidth == 0 {
+			termWidth = 80
+		}
+		if termWidth < 10 {
+			fmt.Printf("%s%s", state.wordBuffer, content)
+			if len(state.wordBuffer) > 0 {
+				state.wordBuffer = ""
+			}
+			return
+		}
+
 		for _, ch := range content {
 			if state.lineLength+1 > termWidth-5 {
 				if runewidth.StringWidth(state.wordBuffer) > termWidth-10 {

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -389,6 +389,39 @@ func TestDeleteHandler(t *testing.T) {
 	}
 }
 
+func TestDisplayResponseSkipsTerminalSequencesForRedirectedStdout(t *testing.T) {
+	oldStdout := os.Stdout
+	stdoutR, stdoutW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = stdoutW
+	defer func() {
+		os.Stdout = oldStdout
+	}()
+
+	content := strings.Repeat("hello ", 20)
+	displayResponse(content, true, &displayResponseState{})
+
+	if err := stdoutW.Close(); err != nil {
+		t.Fatal(err)
+	}
+	out, err := io.ReadAll(stdoutR)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := stdoutR.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.Contains(string(out), "\x1b[") {
+		t.Fatalf("redirected stdout contains ANSI escape sequence: %q", out)
+	}
+	if diff := cmp.Diff(content, string(out)); diff != "" {
+		t.Fatalf("unexpected redirected output (-want +got):\n%s", diff)
+	}
+}
+
 func TestRunEmbeddingModel(t *testing.T) {
 	reqCh := make(chan api.EmbedRequest, 1)
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

- skip terminal-width word wrapping unless stdout is a TTY
- preserve plain output when `ollama run ... > file` uses word wrap mode
- add regression coverage for redirected stdout not containing ANSI escape sequences

Fixes #16785

## Validation

- `gofmt -w cmd/cmd.go cmd/cmd_test.go`
- `git diff --check`
- `go test ./cmd -run 'TestDisplayResponseSkipsTerminalSequencesForRedirectedStdout' -count=1`
- `go test ./cmd -count=1`
