### PR TITLE
app/tools: keep web search snippets from splitting UTF-8 characters

### DIFF
--- a/app/tools/browser.go
+++ b/app/tools/browser.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/ollama/ollama/app/ui/responses"
 )
@@ -176,6 +177,18 @@ func (b *BrowserSearch) Execute(ctx context.Context, args map[string]any) (any, 
 	return b.state.Data, pageText, nil
 }
 
+// truncateUTF8 returns at most maxBytes bytes of s, cut back to the nearest
+// UTF-8 rune boundary so a multi-byte character is never split in half.
+func truncateUTF8(s string, maxBytes int) string {
+	if len(s) <= maxBytes {
+		return s
+	}
+	for maxBytes > 0 && !utf8.RuneStart(s[maxBytes]) {
+		maxBytes--
+	}
+	return s[:maxBytes]
+}
+
 func (b *Browser) buildSearchResultsPageCollection(query string, results *WebSearchResponse) *responses.Page {
 	page := &responses.Page{
 		URL:       "search_results_" + query,
@@ -204,8 +217,7 @@ func (b *Browser) buildSearchResultsPageCollection(query string, results *WebSea
 			linkFormat := fmt.Sprintf("* 【%d†%s†%s】", linkIdx, result.Title, domain)
 			textBuilder.WriteString(linkFormat)
 
-			numChars := min(len(result.Content.FullText), 400)
-			snippet := strings.TrimSpace(result.Content.FullText[:numChars])
+			snippet := strings.TrimSpace(truncateUTF8(result.Content.FullText, 400))
 			textBuilder.WriteString(snippet)
 			textBuilder.WriteString("\n")
 
@@ -235,8 +247,7 @@ func (b *Browser) buildSearchResultsPage(result *WebSearchResult, linkIdx int) *
 	textBuilder.WriteString(linkFormat)
 	textBuilder.WriteString("\n")
 	textBuilder.WriteString(fmt.Sprintf("URL: %s\n", result.URL))
-	numChars := min(len(result.Content.FullText), 300)
-	textBuilder.WriteString(result.Content.FullText[:numChars])
+	textBuilder.WriteString(truncateUTF8(result.Content.FullText, 300))
 	textBuilder.WriteString("\n\n")
 
 	// Only store link and snippet if we won't be processing full text later

--- a/app/tools/browser_test.go
+++ b/app/tools/browser_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/ollama/ollama/app/ui/responses"
 )
@@ -164,5 +165,22 @@ func TestDisplayPage_FormatHeaderAndLines(t *testing.T) {
 	}
 	if !strings.Contains(out, "L1: URL: https://example.com/x\n") || !strings.Contains(out, "L2: A\n") {
 		t.Fatalf("missing expected line numbers/content: %q", out)
+	}
+}
+
+func TestTruncateUTF8(t *testing.T) {
+	// Shorter than the limit is returned unchanged.
+	if got := truncateUTF8("hello", 400); got != "hello" {
+		t.Fatalf("got %q, want %q", got, "hello")
+	}
+	// A byte limit landing inside a multi-byte rune must back up to a rune
+	// boundary and keep the result valid UTF-8.
+	s := strings.Repeat("世界", 200) // 1200 bytes; 400 is not a rune boundary
+	got := truncateUTF8(s, 400)
+	if len(got) > 400 {
+		t.Fatalf("len=%d, want <= 400", len(got))
+	}
+	if !utf8.ValidString(got) {
+		t.Fatalf("result not valid UTF-8: %q", got)
 	}
 }


### PR DESCRIPTION
### What

The browser tool builds web-search result snippets by slicing the fetched page text with a byte limit:

```go
numChars := min(len(result.Content.FullText), 400)
snippet := strings.TrimSpace(result.Content.FullText[:numChars])
```

`FullText[:numChars]` cuts at a byte offset. Web pages are frequently non-ASCII (CJK, emoji, accented text), so the cut can land in the middle of a multi-byte rune, leaving a broken/invalid-UTF-8 character at the end of the snippet that then gets fed to the model.

### Change

Add a small `truncateUTF8` helper that backs the cut up to the nearest rune boundary (via `utf8.RuneStart`), and use it for both the 400-byte and 300-byte snippet truncations in `browser.go`. Added `TestTruncateUTF8`.

### Tested

`go test ./app/tools/`, `go vet ./app/tools/`, and `gofmt` all pass locally.