### PR TITLE
Include parser capabilities in model list

### DIFF
--- a/server/model_list_cache.go
+++ b/server/model_list_cache.go
@@ -365,6 +365,14 @@ func buildModelListSummary(name model.Name, mf *manifest.Manifest) (modelListSum
 	}
 
 	builtinParser := parsers.ParserForName(cfg.Parser)
+	if builtinParser != nil {
+		if builtinParser.HasToolSupport() {
+			summary.Capabilities = appendModelListCapability(summary.Capabilities, model.CapabilityTools)
+		}
+		if builtinParser.HasThinkingSupport() {
+			summary.Capabilities = appendModelListCapability(summary.Capabilities, model.CapabilityThinking)
+		}
+	}
 	if tmpl != nil {
 		vars, err := tmpl.Vars()
 		if err != nil {

--- a/server/model_list_cache_test.go
+++ b/server/model_list_cache_test.go
@@ -65,6 +65,39 @@ func TestModelListCacheHydratesSummary(t *testing.T) {
 	}
 }
 
+func TestModelListCacheIncludesParserCapabilitiesWithoutTemplate(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setTestHome(t, t.TempDir())
+	_, digest := createBinFile(t, nil, nil)
+
+	var s Server
+	w := createRequest(t, s.CreateHandler, api.CreateRequest{
+		Model:  "list-parser-caps",
+		Files:  map[string]string{"model.gguf": digest},
+		Parser: "deepseek3",
+		Stream: &stream,
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("create model status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+
+	cache := newModelListCache()
+	if err := cache.hydrate(context.Background()); err != nil {
+		t.Fatalf("hydrate failed: %v", err)
+	}
+
+	summary, ok := cache.Get(model.ParseName("list-parser-caps"))
+	if !ok {
+		t.Fatal("list summary missing")
+	}
+
+	for _, capability := range []model.Capability{model.CapabilityCompletion, model.CapabilityTools, model.CapabilityThinking} {
+		if !slices.Contains(summary.Capabilities, capability) {
+			t.Fatalf("capabilities = %v, want %s", summary.Capabilities, capability)
+		}
+	}
+}
+
 func TestModelListCacheRefreshUpdatesEntry(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	setTestHome(t, t.TempDir())


### PR DESCRIPTION
## Summary
- Include built-in parser capabilities when building `/api/tags` model summaries, even when a model has no template layer.
- Align `/api/tags` capability discovery with `/api/show`, which already reports parser-provided `tools` and `thinking` capabilities.
- Add a regression test for a parser-backed model without a template returning `completion`, `tools`, and `thinking` in the model list cache.

Fixes #16969

## Tests
- `go test ./server -run 'TestModelListCacheIncludesParserCapabilitiesWithoutTemplate|TestModelListCacheHydratesSummary|TestList' -count=1`
- `go test ./server -run 'TestModelListCache' -count=1`
- `go test ./server -count=1`
- `git diff --check`