### PR TITLE
server: inherit model_info when creating from a remote model

### DIFF
--- a/server/create.go
+++ b/server/create.go
@@ -151,6 +151,37 @@ func (s *Server) CreateHandler(c *gin.Context) {
 				config.RemoteModel = fromRef.Base
 				config.RemoteHost = ru
 				remote = true
+
+				// Inherit model_info fields (architecture, context/embedding
+				// length, basename) from the parent's stored config so /api/show
+				// and /api/tags report them for the derived model. Without this,
+				// model_info comes back empty and integrations fall back to a
+				// short default context window.
+				if mf, mErr := manifest.ParseNamedManifest(fromName); mErr == nil && mf.Config.Digest != "" {
+					if configPath, pErr := manifest.BlobsPath(mf.Config.Digest); pErr == nil {
+						if cfgFile, fErr := os.Open(configPath); fErr == nil {
+							var baseConfig model.ConfigV2
+							if decErr := json.NewDecoder(cfgFile).Decode(&baseConfig); decErr == nil {
+								if config.ModelFamily == "" {
+									config.ModelFamily = baseConfig.ModelFamily
+								}
+								if len(config.ModelFamilies) == 0 {
+									config.ModelFamilies = baseConfig.ModelFamilies
+								}
+								if config.BaseName == "" {
+									config.BaseName = baseConfig.BaseName
+								}
+								if config.ContextLen == 0 {
+									config.ContextLen = baseConfig.ContextLen
+								}
+								if config.EmbedLen == 0 {
+									config.EmbedLen = baseConfig.EmbedLen
+								}
+							}
+							cfgFile.Close()
+						}
+					}
+				}
 			} else {
 				ctx, cancel := context.WithCancel(c.Request.Context())
 				defer cancel()

--- a/server/routes_create_test.go
+++ b/server/routes_create_test.go
@@ -1346,6 +1346,70 @@ func TestCreateAndShowRemoteModel(t *testing.T) {
 	fmt.Printf("resp = %#v\n", resp)
 }
 
+func TestCreateFromRemoteModelInheritsModelInfo(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	p := t.TempDir()
+	t.Setenv("OLLAMA_MODELS", p)
+
+	var s Server
+
+	// Create the parent remote model with its model_info populated via Info.
+	w := createRequest(t, s.CreateHandler, api.CreateRequest{
+		Model:      "parent",
+		From:       "bob",
+		RemoteHost: "https://ollama.com",
+		Info: map[string]any{
+			"capabilities":     []string{"completion"},
+			"model_family":     "gptoss",
+			"context_length":   131072,
+			"embedding_length": 2880,
+		},
+		Stream: &stream,
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("create parent: expected status 200, got %d", w.Code)
+	}
+
+	// Derive a child from the parent without re-supplying Info, mirroring an
+	// `ollama create child -f Modelfile` with only `FROM parent`.
+	w = createRequest(t, s.CreateHandler, api.CreateRequest{
+		Model:      "child",
+		From:       "parent",
+		RemoteHost: "https://ollama.com",
+		Stream:     &stream,
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("create child: expected status 200, got %d", w.Code)
+	}
+
+	w = createRequest(t, s.ShowHandler, api.ShowRequest{Model: "child"})
+	if w.Code != http.StatusOK {
+		t.Fatalf("show child: expected status 200, got %d", w.Code)
+	}
+
+	var resp api.ShowResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+
+	v, ok := resp.ModelInfo["gptoss.context_length"]
+	if !ok {
+		t.Fatalf("context_length missing from inherited model_info: %#v", resp.ModelInfo)
+	}
+	if ctxlen := v.(float64); int(ctxlen) != 131072 {
+		t.Errorf("context len: expected %d, actual %d", 131072, int(ctxlen))
+	}
+
+	v, ok = resp.ModelInfo["gptoss.embedding_length"]
+	if !ok {
+		t.Fatalf("embedding_length missing from inherited model_info: %#v", resp.ModelInfo)
+	}
+	if embedlen := v.(float64); int(embedlen) != 2880 {
+		t.Errorf("embed len: expected %d, actual %d", 2880, int(embedlen))
+	}
+}
+
 func TestCreateRemoteModelRejectsDraftFiles(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 


### PR DESCRIPTION
Fixes #16891

Creating a model from a remote parent (e.g. `FROM glm-5.2:cloud`) only carried `RemoteModel` and `RemoteHost` into the new config. The parent's architecture, context length and embedding length were dropped, so `/api/show` and `/api/tags` returned an empty `model_info` for the derived model.

Integrations that read the context window from `model_info` (e.g. VSCode Copilot) then fall back to a short default (~32K), which breaks long-context use of any model created this way. Since `ollama create` is the only config path for those integrations, there's no workaround.

The remote branch in `CreateHandler` now loads the parent's stored config and inherits `model_family`, `context_length` and `embedding_length`, mirroring the inheritance already done for local parents. Explicit `Info` overrides still win.

Added `TestCreateFromRemoteModelInheritsModelInfo`, which fails on `main` (empty `model_info`) and passes with the change.