### PR TITLE
server: raise automatic context floor for vision models

### DIFF
--- a/server/sched.go
+++ b/server/sched.go
@@ -179,7 +179,18 @@ func (s *Scheduler) getRunner(c context.Context, m *Model, opts api.Options, ses
 
 	if m.CheckCapabilities(model.CapabilityVision) == nil {
 		// multimodal models require at least 2048 context
-		opts.NumCtx = max(opts.NumCtx, 2048)
+		minCtx := 2048
+		if numCtxAuto {
+			// High-resolution vision models (notably OCR) emit many image
+			// tokens per image. The automatic low-VRAM default (4096) can be
+			// smaller than a single image's token span, which trips a runtime
+			// assert mid-decode (#16696). Raise the automatic floor so the
+			// default context can hold at least one image's worth of tokens.
+			// When the model can't be loaded at this size the scheduler reduces
+			// the automatic context on OOM, so this stays a floor, not a force.
+			minCtx = 8192
+		}
+		opts.NumCtx = max(opts.NumCtx, minCtx)
 	}
 
 	contextShift := false

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -182,19 +182,31 @@ func TestSchedVisionContextFloor(t *testing.T) {
 		},
 	}
 
-	t.Run("automatic num_ctx is floored", func(t *testing.T) {
+	t.Run("automatic num_ctx is floored for vision tokens", func(t *testing.T) {
 		s := InitScheduler(ctx)
 		opts := api.DefaultOptions()
-		opts.NumCtx = 128
+		opts.NumCtx = 4096
 
 		s.getRunner(ctx, visionModel, opts, nil, true, false, nil)
 
 		req := <-s.pendingReqCh
-		require.Equal(t, 2048, req.opts.NumCtx)
+		require.Equal(t, 8192, req.opts.NumCtx)
 		require.True(t, req.numCtxAuto)
 	})
 
-	t.Run("explicit num_ctx is floored", func(t *testing.T) {
+	t.Run("automatic num_ctx above floor is kept", func(t *testing.T) {
+		s := InitScheduler(ctx)
+		opts := api.DefaultOptions()
+		opts.NumCtx = 32768
+
+		s.getRunner(ctx, visionModel, opts, nil, true, false, nil)
+
+		req := <-s.pendingReqCh
+		require.Equal(t, 32768, req.opts.NumCtx)
+		require.True(t, req.numCtxAuto)
+	})
+
+	t.Run("explicit num_ctx keeps the base floor", func(t *testing.T) {
 		s := InitScheduler(ctx)
 		opts := api.DefaultOptions()
 		opts.NumCtx = 128


### PR DESCRIPTION
Fixes #16696

High-resolution vision models — OCR models like `glm-ocr` in particular — can emit more image tokens for a single image than the automatic low-VRAM default context (4096) holds. When the context is too small, the runner aborts mid-decode with `GGML_ASSERT(a->ne[2]*4==b->ne[0])` and the request returns a 500. Same image and request succeed at `num_ctx>=8192`, which the reporter isolated as the root cause (also behind #14171 / #14401).

This raises the automatic multimodal context floor from 2048 to 8192 in `getRunner`, so the default context can hold at least one image's worth of tokens.

Scope is deliberately narrow:
- Only applies when `num_ctx` is automatic. An explicit `num_ctx` is still honored down to the existing 2048 multimodal minimum.
- The scheduler already reduces the automatic context on load OOM (`reduceAutoNumCtxForLoadOOM`), so on small VRAM this stays a floor rather than a forced size.

`TestSchedVisionContextFloor` covers the automatic floor, an automatic value already above the floor (left untouched), and the explicit-minimum case.

Note: I don't have the hardware to reproduce the GGML assert end-to-end; verification here is the scheduler-level context selection plus the reporter's num_ctx findings. Happy to adjust the floor value if maintainers prefer a different threshold or a projector-derived size.