### PR TITLE
cmake: ease Windows clang and custom ROCm builds from source

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,27 @@ if(CMAKE_OSX_ARCHITECTURES AND NOT CMAKE_OSX_ARCHITECTURES MATCHES ";")
     endif()
 endif()
 
+# When building on Windows with clang as the C/C++ compiler (instead of MSVC),
+# CMake cannot locate the Windows Resource Compiler (rc.exe) on its own, forcing
+# a manual -DCMAKE_RC_COMPILER pointing at a version-specific Windows SDK path.
+# Search the installed Windows SDKs and pick the newest rc.exe so the build
+# works without that manual flag. Only runs on Windows when it isn't already set.
+if(WIN32 AND NOT CMAKE_RC_COMPILER)
+    set(_winsdk_bin "$ENV{ProgramFiles\(x86\)}/Windows Kits/10/bin")
+    if(NOT EXISTS "${_winsdk_bin}")
+        set(_winsdk_bin "C:/Program Files (x86)/Windows Kits/10/bin")
+    endif()
+    file(GLOB _winsdk_versions "${_winsdk_bin}/10.*")
+    list(SORT _winsdk_versions ORDER DESCENDING)
+    foreach(_ver IN LISTS _winsdk_versions)
+        if(EXISTS "${_ver}/x64/rc.exe")
+            set(CMAKE_RC_COMPILER "${_ver}/x64/rc.exe" CACHE FILEPATH "Windows Resource Compiler" FORCE)
+            message(STATUS "Auto-detected Windows Resource Compiler: ${CMAKE_RC_COMPILER}")
+            break()
+        endif()
+    endforeach()
+endif()
+
 include(CheckLanguage)
 include(GNUInstallDirs)
 

--- a/llama/server/CMakeLists.txt
+++ b/llama/server/CMakeLists.txt
@@ -95,6 +95,24 @@ endif()
 if(GGML_HIP AND OLLAMA_RUNNER_DIR MATCHES "^rocm_v")
     ollama_set_cache_default(CMAKE_HIP_FLAGS STRING
         "-parallel-jobs=4" "HIP compiler flags")
+    # Custom ROCm toolchains (TheRock, self-built, nightly) may keep the device
+    # bitcode at a non-standard layout, e.g. <rocm>/lib/llvm/amdgcn/bitcode
+    # instead of <rocm>/amdgcn/bitcode, which requires passing
+    # --rocm-device-lib-path to the HIP compiler. Expose it as a cache variable
+    # so users don't have to patch the vendored ggml-hip CMake.
+    set(OLLAMA_HIP_DEVICE_LIB_PATH "" CACHE STRING
+        "ROCm device library bitcode directory (--rocm-device-lib-path); only needed for non-standard ROCm layouts")
+    if(OLLAMA_HIP_DEVICE_LIB_PATH)
+        if(WIN32)
+            # ggml-hip builds with CXX_IS_HIPCC on Windows, so CMAKE_HIP_FLAGS is
+            # not consulted; route the flag through the C++ flags instead.
+            ollama_append_cache_flags(CMAKE_CXX_FLAGS
+                "--rocm-device-lib-path=${OLLAMA_HIP_DEVICE_LIB_PATH}")
+        else()
+            ollama_append_cache_flags(CMAKE_HIP_FLAGS
+                "--rocm-device-lib-path=${OLLAMA_HIP_DEVICE_LIB_PATH}")
+        endif()
+    endif()
     if(WIN32)
         # Windows ROCm split-load needs peer copies disabled for correctness.
         ollama_set_cache_default(GGML_CUDA_NO_PEER_COPY BOOL ON


### PR DESCRIPTION
Fixes #16889

Two build-from-source friction points reported on Windows + clang / custom ROCm toolchains, both fixed with gated, opt-in CMake changes.

**1. Auto-detect the Windows Resource Compiler.** With clang as the C/C++ compiler (instead of MSVC), CMake can't find `rc.exe` on its own, so the build fails unless you pass a version-specific `-DCMAKE_RC_COMPILER=".../Windows Kits/10/bin/10.0.xxxxx.0/x64/rc.exe"`. The top-level CMake now globs the installed Windows SDKs and picks the newest `rc.exe` automatically. Runs only on Windows, only when `CMAKE_RC_COMPILER` isn't already set — globbing avoids hardcoding SDK versions.

**2. `OLLAMA_HIP_DEVICE_LIB_PATH` cache variable.** Custom ROCm layouts (TheRock, self-built, nightly) keep the device bitcode at e.g. `<rocm>/lib/llvm/amdgcn/bitcode` instead of `<rocm>/amdgcn/bitcode`, requiring `--rocm-device-lib-path`. Today that means patching the vendored `ggml-hip` CMake. The new opt-in cache var injects the flag into the existing `rocm_v*` HIP block, routed through CXX flags on Windows (where ggml-hip builds with `CXX_IS_HIPCC`, so `CMAKE_HIP_FLAGS` is ignored) and HIP flags elsewhere.

Both default to no-ops and are gated on `WIN32` / the cache var being set, so non-Windows and standard ROCm builds are unchanged.

Verification: I don't have a Windows/ROCm box, so I validated the CMake logic in isolation rather than a full Windows build — the SDK glob+sort picks the newest `rc.exe` from a fake SDK tree, the `$ENV{ProgramFiles(x86)}` escaping parses, and the device-lib-path flag routes to CXX flags on Windows. A configure on macOS executes the new top-level block cleanly. Would appreciate a maintainer with a Windows + clang / custom-ROCm setup confirming the end-to-end build.