### PR TITLE
Fix symlink path for ollama in install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -172,7 +172,7 @@ download_and_extract "https://ollama.com/download" "$OLLAMA_INSTALL_DIR" "ollama
 
 if [ "$OLLAMA_INSTALL_DIR/bin/ollama" != "$BINDIR/ollama" ] ; then
     status "Making ollama accessible in the PATH in $BINDIR"
-    $SUDO ln -sf "$OLLAMA_INSTALL_DIR/ollama" "$BINDIR/ollama"
+    $SUDO ln -sf "$OLLAMA_INSTALL_DIR/bin/ollama" "$BINDIR/ollama"
 fi
 
 # Check for NVIDIA JetPack systems with additional downloads


### PR DESCRIPTION
The install script has a typo for symlinking path for ollama binary if I understand correctly. I tried to fix it
`Before:`
``` bash
- $SUDO ln -sf "$OLLAMA_INSTALL_DIR/ollama" "$BINDIR/ollama"
```
`After:`
```bash
+ $SUDO ln -sf "$OLLAMA_INSTALL_DIR/bin/ollama" "$BINDIR/ollama"
```