### PR TITLE
server: preserve parser tokens for raw generate

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -437,6 +437,7 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 	}
 
 	var builtinParser parsers.Parser
+	var preservedTokensParser parsers.Parser
 	if shouldUseHarmony(m) {
 		// harmony's Reasoning field only understands low/medium/high; map "max" to "high"
 		if req.Think != nil {
@@ -449,9 +450,10 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 		}
 	}
 
-	if !req.Raw && m.Config.Parser != "" {
-		builtinParser = parsers.ParserForName(m.Config.Parser)
-		if builtinParser != nil {
+	if m.Config.Parser != "" {
+		preservedTokensParser = parsers.ParserForName(m.Config.Parser)
+		if !req.Raw && preservedTokensParser != nil {
+			builtinParser = preservedTokensParser
 			// no tools or last message for generate endpoint
 			builtinParser.Init(nil, nil, req.Think)
 		}
@@ -645,7 +647,7 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 	}
 
 	var thinkingState *thinking.Parser
-	if builtinParser == nil {
+	if !req.Raw && builtinParser == nil {
 		openingTag, closingTag := thinking.InferTags(m.Template.Template)
 		if req.Think != nil && req.Think.Bool() && openingTag != "" && closingTag != "" {
 			thinkingState = &thinking.Parser{
@@ -672,7 +674,7 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 			Truncate:        req.Truncate == nil || *req.Truncate,
 			Logprobs:        req.Logprobs,
 			TopLogprobs:     req.TopLogprobs,
-			PreservedTokens: preservedTokensForCompletion(builtinParser),
+			PreservedTokens: preservedTokensForCompletion(preservedTokensParser),
 			LeadingBOS:      leadingBOS,
 		}, func(cr llm.CompletionResponse) {
 			res := api.GenerateResponse{

--- a/server/routes_generate_test.go
+++ b/server/routes_generate_test.go
@@ -473,6 +473,75 @@ func TestChatHandlerHarmonyPreservesStructuralTokens(t *testing.T) {
 	}
 }
 
+func TestGenerateHandlerRawParserPreservesStructuralTokens(t *testing.T) {
+	t.Setenv("OLLAMA_CONTEXT_LENGTH", "4096")
+	gin.SetMode(gin.TestMode)
+
+	const rawContent = "<|channel>thought\nreason<channel|>answer"
+	mock := mockRunner{
+		CompletionResponse: llm.CompletionResponse{
+			Content:    rawContent,
+			Done:       true,
+			DoneReason: llm.DoneReasonStop,
+		},
+	}
+	s := newServerWithMockRunner(t, &mock)
+
+	_, digest := createBinFile(t, ggml.KV{
+		"general.architecture":          "llama",
+		"llama.block_count":             uint32(1),
+		"llama.context_length":          uint32(8192),
+		"llama.embedding_length":        uint32(4096),
+		"llama.attention.head_count":    uint32(32),
+		"llama.attention.head_count_kv": uint32(8),
+		"tokenizer.ggml.tokens":         []string{""},
+		"tokenizer.ggml.scores":         []float32{0},
+		"tokenizer.ggml.token_type":     []int32{0},
+	}, []*ggml.Tensor{
+		{Name: "token_embd.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+	})
+
+	w := createRequest(t, s.CreateHandler, api.CreateRequest{
+		Model:    "raw-gemma4-parser",
+		Files:    map[string]string{"file.gguf": digest},
+		Parser:   "gemma4",
+		Template: `{{ range .Messages }}<|channel>{{ .Thinking }}<channel|>{{ end }}`,
+		Stream:   &stream,
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("create: expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	streamRequest := false
+	w = createRequest(t, s.GenerateHandler, api.GenerateRequest{
+		Model:  "raw-gemma4-parser",
+		Prompt: "<bos><|turn>model\n",
+		Raw:    true,
+		Think:  &api.ThinkValue{Value: true},
+		Stream: &streamRequest,
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("generate: expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	for _, token := range []string{"<|channel>", "<channel|>"} {
+		if !slices.Contains(mock.CompletionRequest.PreservedTokens, token) {
+			t.Fatalf("expected preserved tokens to contain %q, got %#v", token, mock.CompletionRequest.PreservedTokens)
+		}
+	}
+
+	var res api.GenerateResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &res); err != nil {
+		t.Fatal(err)
+	}
+	if res.Response != rawContent {
+		t.Fatalf("response = %q, want raw content %q", res.Response, rawContent)
+	}
+	if res.Thinking != "" {
+		t.Fatalf("thinking = %q, want empty thinking for raw response", res.Thinking)
+	}
+}
+
 func TestGenerateHandlerChatTemplateRoute(t *testing.T) {
 	t.Setenv("OLLAMA_CONTEXT_LENGTH", "4096")
 	t.Setenv("OLLAMA_GO_TEMPLATE", "")


### PR DESCRIPTION
## Summary

- preserve parser structural tokens for raw generate requests
- keep raw generate responses out of builtin and generic thinking parsers
- add regression coverage for Gemma4 raw generate preserving control tokens

Fixes #16976

## Why

Raw generate skips the builtin response parser, which is correct because callers provide and expect raw text. However, the completion request also derived `PreservedTokens` from that same parser value, so parser-backed models such as Gemma4 did not ask llama-server to preserve structural tokens like `<|channel>` and `<channel|>` in raw mode.

The fix separates the parser used for response parsing from the parser used to declare preserved tokens. Raw mode still returns raw model text, while llama-server receives the parser's structural tokens.

## Validation

- `gofmt -w server/routes.go server/routes_generate_test.go`
- `git diff --check`
- `GOCACHE=/private/tmp/ollama-go-cache go test ./server -run TestGenerateHandlerRawParserPreservesStructuralTokens -count=1`
- `GOCACHE=/private/tmp/ollama-go-cache go test ./server -run 'TestGenerateHandler|TestChatHandlerHarmonyPreservesStructuralTokens|TestPreservedTokensForCompletion' -count=1`
- `GOCACHE=/private/tmp/ollama-go-cache go test ./server -count=1`
