### PR TITLE
fix(ui): re-encode clipboard/pasted images to PNG via canvas before sending

### DIFF
--- a/app/ui/app/src/utils/fileValidation.ts
+++ b/app/ui/app/src/utils/fileValidation.ts
@@ -103,6 +103,41 @@ export function readFileAsBytes(file: File): Promise<Uint8Array> {
   });
 }
 
+// Re-encode image bytes through canvas to guarantee a format llama.cpp can decode.
+// macOS clipboard provides images as TIFF bytes mislabeled with type "image/png";
+// stb_image (used by llama.cpp) does not support TIFF. Re-encoding via
+// createImageBitmap + canvas.toBlob("image/png") strips any problematic container
+// and always produces valid PNG data.
+async function ensureValidImageBytes(
+  data: Uint8Array,
+  mimeType: string,
+): Promise<Uint8Array> {
+  if (!mimeType?.startsWith("image/")) return data;
+
+  try {
+    const blob = new Blob([data], { type: mimeType });
+    const imageBitmap = await createImageBitmap(blob);
+
+    const canvas = document.createElement("canvas");
+    canvas.width = imageBitmap.width;
+    canvas.height = imageBitmap.height;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return data;
+    ctx.drawImage(imageBitmap, 0, 0);
+    imageBitmap.close();
+
+    const pngBlob = await new Promise<Blob>((resolve) => {
+      canvas.toBlob((b) => resolve(b!), "image/png");
+    });
+
+    const arrayBuffer = await pngBlob.arrayBuffer();
+    return new Uint8Array(arrayBuffer);
+  } catch (e) {
+    console.warn("Failed to re-encode image, sending original bytes:", e);
+    return data;
+  }
+}
+
 // Process multiple files with validation
 export async function processFiles(
   files: File[],
@@ -131,9 +166,10 @@ export async function processFiles(
 
     try {
       const fileBytes = await readFileAsBytes(file);
+      const normalizedBytes = await ensureValidImageBytes(fileBytes, file.type);
       validFiles.push({
         filename: file.name,
-        data: fileBytes,
+        data: normalizedBytes,
         type: file.type || undefined,
       });
     } catch (error) {


### PR DESCRIPTION
## Problem

Pasting or uploading images through the Ollama Desktop app (GUI) always returns `400 Bad Request` with `mtmd_helper_bitmap_init_from_buf: failed to decode image bytes`.

On macOS, the clipboard provides images in TIFF format. The Electron webview wraps these TIFF bytes into a `File` object with `.type = "image/png"`, but the underlying bytes remain TIFF. llama.cpp's image decoder (stb_image) does not support TIFF, causing decode failure.

`ollama run llava:latest /tmp/test.jpg "describe"` works fine from CLI — proving the Ollama server, llama.cpp, and models are all functional. The bug is exclusively in the desktop app's data pipeline.

## Solution

Re-encode all image data through `createImageBitmap()` + `<canvas>.toBlob('image/png')` before base64-encoding and sending. This:
- Strips any unsupported container format (TIFF, BMP, etc.)
- Always produces valid PNG that stb_image can decode
- Falls back to original bytes if re-encoding fails (no regression)
- Only processes image MIME types; passes non-images through unchanged

## Testing

- `vitest`: 27/27 tests pass (including 8 `fileValidation` tests)
- `tsc --noEmit`: no errors
- `eslint`: no errors