### PR TITLE
discover: work around ROCm iGPU free memory overreport

### DIFF
--- a/discover/amd.go
+++ b/discover/amd.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/ollama/ollama/llm"
 	"github.com/ollama/ollama/ml"
 )
 
@@ -134,7 +135,15 @@ type rocmLinuxSysfsDevice struct {
 	gfxTarget  string
 	integrated bool
 	known      bool
+	gttTotal   uint64
+	gttUsed    uint64
+	gttKnown   bool
 }
+
+const (
+	rocmLinuxFitTargetEnv            = "LLAMA_ARG_FIT_TARGET"
+	rocmLinuxIntegratedFitTargetUnit = uint64(1024 * 1024)
+)
 
 func refineLinuxROCmDevices(devices []ml.DeviceInfo) []ml.DeviceInfo {
 	if runtime.GOOS != "linux" {
@@ -248,6 +257,65 @@ func applyROCmLinuxSysfsDevice(device *ml.DeviceInfo, sysfsDevice rocmLinuxSysfs
 	if sysfsDevice.known {
 		device.Integrated = sysfsDevice.integrated
 	}
+	if sysfsDevice.known && sysfsDevice.integrated && sysfsDevice.gttKnown {
+		workaroundROCmLinuxIntegratedMemory(device, sysfsDevice)
+	}
+}
+
+// workaroundROCmLinuxIntegratedMemory handles a llama.cpp/ROCm UMA reporting bug
+// where free memory can exceed the real GTT budget. Remove this once bundled
+// llama.cpp reports sane free memory for Linux ROCm integrated devices.
+func workaroundROCmLinuxIntegratedMemory(device *ml.DeviceInfo, sysfsDevice rocmLinuxSysfsDevice) {
+	if sysfsDevice.gttTotal == 0 {
+		return
+	}
+
+	reportedFree := device.FreeMemory
+	gttFree := sysfsDevice.gttTotal
+	if sysfsDevice.gttUsed < sysfsDevice.gttTotal {
+		gttFree -= sysfsDevice.gttUsed
+	} else {
+		gttFree = 0
+	}
+
+	if device.TotalMemory == 0 {
+		device.TotalMemory = sysfsDevice.gttTotal
+	}
+	if device.FreeMemory > sysfsDevice.gttTotal || (device.TotalMemory > 0 && device.FreeMemory > device.TotalMemory) {
+		device.FreeMemory = gttFree
+		setROCmLinuxIntegratedFitTarget(device, reportedFree, gttFree)
+	}
+	if device.TotalMemory > 0 && device.FreeMemory > device.TotalMemory {
+		device.FreeMemory = device.TotalMemory
+	}
+}
+
+func setROCmLinuxIntegratedFitTarget(device *ml.DeviceInfo, reportedFree, gttFree uint64) {
+	if reportedFree <= gttFree {
+		return
+	}
+	overreportedFreeMiB := (reportedFree - gttFree + rocmLinuxIntegratedFitTargetUnit - 1) / rocmLinuxIntegratedFitTargetUnit
+	targetMiB := overreportedFreeMiB + llm.LlamaServerDefaultFitTargetMiB
+
+	if _, ok := os.LookupEnv(rocmLinuxFitTargetEnv); ok {
+		slog.Warn("skipping ROCm iGPU fit target correction because user already set environment override",
+			"env", rocmLinuxFitTargetEnv,
+			"computed_fit_target_mib", targetMiB,
+			"overreported_free_mib", overreportedFreeMiB,
+			"fit_target_pad_mib", llm.LlamaServerDefaultFitTargetMiB,
+			"reported_free", reportedFree,
+			"gtt_free", gttFree)
+		return
+	}
+	if device.RunnerEnvOverrides != nil {
+		if _, ok := device.RunnerEnvOverrides[rocmLinuxFitTargetEnv]; ok {
+			return
+		}
+	} else {
+		device.RunnerEnvOverrides = map[string]string{}
+	}
+
+	device.RunnerEnvOverrides[rocmLinuxFitTargetEnv] = strconv.FormatUint(targetMiB, 10)
 }
 
 func readROCmLinuxSysfsDevices(sysfsRoot string) ([]rocmLinuxSysfsDevice, error) {
@@ -366,6 +434,10 @@ func readROCmDRMDevice(sysfsRoot string, renderMinor int) (rocmLinuxSysfsDevice,
 	if !ok {
 		return device, nil
 	}
+	gttUsed, _ := readROCmLinuxMemoryInfo(resolvedDevicePath, "mem_info_gtt_used")
+	device.gttTotal = gttTotal
+	device.gttUsed = gttUsed
+	device.gttKnown = true
 
 	const (
 		maxIntegratedVRAM = 4 << 30

--- a/discover/amd_test.go
+++ b/discover/amd_test.go
@@ -1,10 +1,13 @@
 package discover
 
 import (
+	"bytes"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/ollama/ollama/ml"
@@ -22,6 +25,9 @@ func TestApplyLinuxROCmRefinement(t *testing.T) {
 		applied        bool
 		wantIntegrated []bool
 		wantPCIIDs     []string
+		wantTotal      []uint64
+		wantFree       []uint64
+		wantEnv        []map[string]string
 	}{
 		{
 			name: "apu is integrated",
@@ -39,6 +45,54 @@ func TestApplyLinuxROCmRefinement(t *testing.T) {
 			}},
 			applied:        true,
 			wantIntegrated: []bool{true},
+		},
+		{
+			name: "apu corrects impossible backend free memory to gtt free",
+			nodes: []fakeROCmNode{{
+				node:        1,
+				renderMinor: 128,
+				gfxVersion:  "110501",
+				vramTotal:   512 << 20,
+				gttTotal:    64 << 30,
+				gttUsed:     3 << 30,
+			}},
+			devices: []ml.DeviceInfo{{
+				DeviceID:    ml.DeviceID{ID: "0", Library: "ROCm"},
+				Name:        "ROCm0",
+				GFXTarget:   "gfx1151",
+				TotalMemory: 64 << 30,
+				FreeMemory:  120 << 30,
+			}},
+			applied:        true,
+			wantIntegrated: []bool{true},
+			wantTotal:      []uint64{64 << 30},
+			wantFree:       []uint64{61 << 30},
+			wantEnv: []map[string]string{{
+				rocmLinuxFitTargetEnv: "61440",
+			}},
+		},
+		{
+			name: "apu preserves sane backend free memory",
+			nodes: []fakeROCmNode{{
+				node:        1,
+				renderMinor: 128,
+				gfxVersion:  "110501",
+				vramTotal:   512 << 20,
+				gttTotal:    64 << 30,
+				gttUsed:     3 << 30,
+			}},
+			devices: []ml.DeviceInfo{{
+				DeviceID:    ml.DeviceID{ID: "0", Library: "ROCm"},
+				Name:        "ROCm0",
+				GFXTarget:   "gfx1151",
+				TotalMemory: 64 << 30,
+				FreeMemory:  60 << 30,
+			}},
+			applied:        true,
+			wantIntegrated: []bool{true},
+			wantTotal:      []uint64{64 << 30},
+			wantFree:       []uint64{60 << 30},
+			wantEnv:        []map[string]string{{}},
 		},
 		{
 			name: "low vram dgpu is not integrated",
@@ -179,7 +233,63 @@ func TestApplyLinuxROCmRefinement(t *testing.T) {
 					t.Fatalf("device %d PCIID = %q, want %q", i, devices[i].PCIID, want)
 				}
 			}
+			for i, want := range tt.wantTotal {
+				if devices[i].TotalMemory != want {
+					t.Fatalf("device %d TotalMemory = %d, want %d", i, devices[i].TotalMemory, want)
+				}
+			}
+			for i, want := range tt.wantFree {
+				if devices[i].FreeMemory != want {
+					t.Fatalf("device %d FreeMemory = %d, want %d", i, devices[i].FreeMemory, want)
+				}
+			}
+			for i, want := range tt.wantEnv {
+				for key, value := range want {
+					if devices[i].RunnerEnvOverrides[key] != value {
+						t.Fatalf("device %d RunnerEnvOverrides[%q] = %q, want %q", i, key, devices[i].RunnerEnvOverrides[key], value)
+					}
+				}
+				if len(want) == 0 && len(devices[i].RunnerEnvOverrides) != 0 {
+					t.Fatalf("device %d RunnerEnvOverrides = %#v, want empty", i, devices[i].RunnerEnvOverrides)
+				}
+			}
 		})
+	}
+}
+
+func TestROCmLinuxIntegratedFitTargetPreservesUserEnv(t *testing.T) {
+	t.Setenv(rocmLinuxFitTargetEnv, "2048")
+
+	var logs bytes.Buffer
+	handler := slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn})
+	oldLogger := slog.Default()
+	slog.SetDefault(slog.New(handler))
+	t.Cleanup(func() {
+		slog.SetDefault(oldLogger)
+	})
+
+	device := ml.DeviceInfo{
+		DeviceID:    ml.DeviceID{ID: "0", Library: "ROCm"},
+		Name:        "ROCm0",
+		GFXTarget:   "gfx1151",
+		TotalMemory: 64 << 30,
+		FreeMemory:  120 << 30,
+	}
+	sysfsDevice := rocmLinuxSysfsDevice{
+		known:      true,
+		integrated: true,
+		gttTotal:   64 << 30,
+		gttUsed:    3 << 30,
+		gttKnown:   true,
+	}
+
+	applyROCmLinuxSysfsDevice(&device, sysfsDevice)
+
+	if device.RunnerEnvOverrides != nil {
+		t.Fatalf("RunnerEnvOverrides = %#v, want nil", device.RunnerEnvOverrides)
+	}
+	if !strings.Contains(logs.String(), "user already set environment override") {
+		t.Fatalf("warning log = %q, want user override warning", logs.String())
 	}
 }
 
@@ -234,6 +344,7 @@ type fakeROCmNode struct {
 	gfxVersion  string
 	vramTotal   uint64
 	gttTotal    uint64
+	gttUsed     uint64
 	vramVendor  bool
 	boardInfo   bool
 }
@@ -273,6 +384,7 @@ func writeFakeROCmNode(t *testing.T, sysfsRoot string, node fakeROCmNode) {
 	writeFakeSysfsFile(t, deviceDir, "driver", "amdgpu\n")
 	writeFakeSysfsFile(t, deviceDir, "mem_info_vram_total", strconv.FormatUint(node.vramTotal, 10)+"\n")
 	writeFakeSysfsFile(t, deviceDir, "mem_info_gtt_total", strconv.FormatUint(node.gttTotal, 10)+"\n")
+	writeFakeSysfsFile(t, deviceDir, "mem_info_gtt_used", strconv.FormatUint(node.gttUsed, 10)+"\n")
 	if node.vramVendor {
 		writeFakeSysfsFile(t, deviceDir, "mem_info_vram_vendor", "samsung\n")
 	}

--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -74,6 +74,7 @@ ws ::= ([ \t\n] ws)?
 // when neither the model nor the request specifies num_batch.
 const (
 	DefaultEmbeddingNumBatch             = 2048
+	LlamaServerDefaultFitTargetMiB       = 1024
 	openEndedGenerationContextMultiplier = 10
 )
 


### PR DESCRIPTION
Work around a llama.cpp/ROCm UMA reporting bug where Linux ROCm integrated devices can report more free memory than the real GTT budget. Use sysfs GTT accounting to clamp impossible discovery results, and set a per-device llama-server fit target to the overreported delta plus llama-server's default pad so --fit uses the same effective budget.

This is a temporary workaround; remove it once the free memory reported for these devices is accurate.

Fixes #16416
Fixes #16480
