### PR TITLE
openai: respect explicit top_p=0 in legacy completions

### DIFF
--- a/openai/openai.go
+++ b/openai/openai.go
@@ -149,7 +149,7 @@ type CompletionRequest struct {
 	Stream           bool           `json:"stream"`
 	StreamOptions    *StreamOptions `json:"stream_options"`
 	Temperature      *float32       `json:"temperature"`
-	TopP             float32        `json:"top_p"`
+	TopP             *float32       `json:"top_p"`
 	Suffix           string         `json:"suffix"`
 	Logprobs         *int           `json:"logprobs"`
 	DebugRenderOnly  bool           `json:"_debug_render_only"`
@@ -761,8 +761,8 @@ func FromCompleteRequest(r CompletionRequest) (api.GenerateRequest, error) {
 
 	options["presence_penalty"] = r.PresencePenalty
 
-	if r.TopP != 0.0 {
-		options["top_p"] = r.TopP
+	if r.TopP != nil {
+		options["top_p"] = *r.TopP
 	} else {
 		options["top_p"] = 1.0
 	}

--- a/openai/openai_test.go
+++ b/openai/openai_test.go
@@ -173,6 +173,29 @@ func TestFromCompleteRequest_Basic(t *testing.T) {
 	}
 }
 
+func TestFromCompleteRequest_TopP(t *testing.T) {
+	t.Run("explicit zero is preserved", func(t *testing.T) {
+		topP := float32(0)
+		result, err := FromCompleteRequest(CompletionRequest{Model: "test-model", TopP: &topP})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if v, ok := result.Options["top_p"].(float32); !ok || v != 0 {
+			t.Errorf("expected top_p 0, got %v", result.Options["top_p"])
+		}
+	})
+
+	t.Run("unset defaults to 1", func(t *testing.T) {
+		result, err := FromCompleteRequest(CompletionRequest{Model: "test-model"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if v, ok := result.Options["top_p"].(float64); !ok || v != 1.0 {
+			t.Errorf("expected top_p 1.0, got %v", result.Options["top_p"])
+		}
+	})
+}
+
 func TestToUsage(t *testing.T) {
 	resp := api.ChatResponse{
 		Metrics: api.Metrics{


### PR DESCRIPTION
The legacy `/v1/completions` handler stored `top_p` in a value-typed field (`float32`) and used a `!= 0.0` check, so an explicit `top_p: 0` was treated as unset and silently overridden to `1.0`:

```go
TopP float32 `json:"top_p"`
...
if r.TopP != 0.0 {
    options["top_p"] = r.TopP
} else {
    options["top_p"] = 1.0
}
```

This diverges from the sibling `temperature` field in the same struct, which already uses a pointer (`*float32`) and a `!= nil` check, and from the chat-completions path, which handles `top_p` correctly with a pointer. `top_p: 0` is a valid request (greedy nucleus sampling) and should be passed through rather than replaced with the default.

This makes `CompletionRequest.TopP` a `*float32` and checks `!= nil`, matching `Temperature` in the same struct and the chat path. An unset `top_p` still defaults to `1.0`; behavior is otherwise unchanged.

Tested with `TestFromCompleteRequest_TopP`, which asserts that an explicit `0` is preserved and that an unset value defaults to `1.0`:

```
$ go test ./openai/
ok  	github.com/ollama/ollama/openai
```
