### PR TITLE
llm: warn on large CUDA host model buffers

### DIFF
--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -2596,9 +2596,10 @@ func PredictServerVRAM(modelPath string, f *ggml.GGML, numCtx int) uint64 {
 //	MTL0_Mapped model buffer size =  1918.35 MiB
 //	ROCm0 model buffer size =  1918.35 MiB
 type memoryParsingWriter struct {
-	inner   io.Writer
-	runner  *llamaServerRunner
-	buffers map[memoryBufferKey]memoryBuffer
+	inner               io.Writer
+	runner              *llamaServerRunner
+	buffers             map[memoryBufferKey]memoryBuffer
+	cudaHostModelWarned bool
 }
 
 type memoryBufferKey struct {
@@ -2610,6 +2611,8 @@ type memoryBufferKey struct {
 type memoryBuffer struct {
 	bytes uint64
 }
+
+const largeCUDAHostModelBufferBytes = 1024 * 1024 * 1024
 
 // deviceFreeRegex matches per-device free VRAM reported at model load time:
 //
@@ -2686,6 +2689,7 @@ func (w *memoryParsingWriter) Write(b []byte) (int, error) {
 			for _, match := range bufferSizeRegex.FindAllSubmatch(b, -1) {
 				backendName := string(match[2])
 				if mib, err := strconv.ParseFloat(string(match[4]), 64); err == nil {
+					bytes := uint64(mib * 1024 * 1024)
 					if w.buffers == nil {
 						w.buffers = make(map[memoryBufferKey]memoryBuffer)
 					}
@@ -2693,7 +2697,8 @@ func (w *memoryParsingWriter) Write(b []byte) (int, error) {
 						component: string(match[1]),
 						backend:   backendName,
 						kind:      string(match[3]),
-					}] = memoryBuffer{bytes: uint64(mib * 1024 * 1024)}
+					}] = memoryBuffer{bytes: bytes}
+					w.warnLargeCUDAHostModelBufferLocked(backendName, string(match[3]), bytes)
 					w.updateRunnerMemoryLocked()
 				}
 			}
@@ -2733,6 +2738,18 @@ func (w *memoryParsingWriter) updateRunnerMemoryLocked() {
 	w.runner.memModelFileBacked = modelFileBacked
 	w.runner.memCPUMappedModel = cpuMappedModel
 	w.runner.vramByDevice = byDevice
+}
+
+func (w *memoryParsingWriter) warnLargeCUDAHostModelBufferLocked(backendName, kind string, bytes uint64) {
+	if w.cudaHostModelWarned || backendName != "CUDA_Host" || kind != "model" || bytes < largeCUDAHostModelBufferBytes {
+		return
+	}
+	w.cudaHostModelWarned = true
+	slog.Warn("model using CUDA host memory", "size", humanGiB(bytes), "detail", "large CUDA_Host model buffers can reduce throughput because model weights are read through system memory; use a smaller model or quantization, or disable NVIDIA system memory fallback on Windows")
+}
+
+func humanGiB(bytes uint64) string {
+	return fmt.Sprintf("%.2f GiB", float64(bytes)/(1024*1024*1024))
 }
 
 // VRAMByGPU returns the VRAM used by this runner on the specified device.

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -2817,6 +2818,81 @@ func TestMemoryParsingWriter(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMemoryParsingWriterWarnsOnLargeCUDAHostModelBuffer(t *testing.T) {
+	logs := captureSlog(t)
+
+	runner := &llamaServerRunner{vramByDevice: make(map[string]uint64)}
+	w := &memoryParsingWriter{inner: io.Discard, runner: runner}
+	if _, err := w.Write([]byte("load_tensors:    CUDA_Host model buffer size = 12849.61 MiB\n")); err != nil {
+		t.Fatal(err)
+	}
+
+	got := logs.String()
+	for _, want := range []string{"model using CUDA host memory", "size=\"12.55 GiB\""} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("logs = %q, want substring %q", got, want)
+		}
+	}
+}
+
+func TestMemoryParsingWriterSkipsSmallOrNonModelCUDAHostBuffers(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+	}{
+		{
+			name: "small model buffer",
+			line: "load_tensors:    CUDA_Host model buffer size =   512.00 MiB\n",
+		},
+		{
+			name: "large compute buffer",
+			line: "sched_reserve:  CUDA_Host compute buffer size =  2048.00 MiB\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logs := captureSlog(t)
+
+			runner := &llamaServerRunner{vramByDevice: make(map[string]uint64)}
+			w := &memoryParsingWriter{inner: io.Discard, runner: runner}
+			if _, err := w.Write([]byte(tt.line)); err != nil {
+				t.Fatal(err)
+			}
+
+			if got := logs.String(); strings.Contains(got, "model using CUDA host memory") {
+				t.Fatalf("logs = %q, want no CUDA host memory warning", got)
+			}
+		})
+	}
+}
+
+func TestMemoryParsingWriterWarnsOnceForLargeCUDAHostModelBuffers(t *testing.T) {
+	logs := captureSlog(t)
+
+	runner := &llamaServerRunner{vramByDevice: make(map[string]uint64)}
+	w := &memoryParsingWriter{inner: io.Discard, runner: runner}
+	for range 2 {
+		if _, err := w.Write([]byte("load_tensors:    CUDA_Host model buffer size = 2048.00 MiB\n")); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if got := strings.Count(logs.String(), "model using CUDA host memory"); got != 1 {
+		t.Fatalf("warning count = %d, want 1; logs = %q", got, logs.String())
+	}
+}
+
+func captureSlog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+
+	var logs bytes.Buffer
+	oldLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(oldLogger) })
+	return &logs
 }
 
 func TestMemoryParsingWriterRecordsOutputActivityWithoutNewline(t *testing.T) {


### PR DESCRIPTION
## Summary

- warn when llama-server reports a large `CUDA_Host` model buffer
- include the parsed host-buffer size in GiB so the warning matches the user-visible server logs
- cover the warning, threshold, non-model buffer, and once-only behavior with focused tests

## Context

Refs #16873.

In #16873, the server logs showed most of the model in `CUDA_Host` memory:

```text
load_tensors:          CPU model buffer size =   577.50 MiB
load_tensors:        CUDA0 model buffer size =  3151.86 MiB
load_tensors:    CUDA_Host model buffer size = 12849.61 MiB
```

A collaborator explained that large `CUDA_Host` model buffers can make the GPU wait on system-memory transfers, which appears as low GPU utilization and poor throughput. This change does not alter tensor placement. It makes that condition visible in the default logs with the specific mitigation already discussed in the issue: use a smaller model/quantization or disable NVIDIA system memory fallback on Windows.

## Test plan

- [x] `go test ./llm -run 'TestMemoryParsingWriter(WarnsOnLargeCUDAHostModelBuffer|SkipsSmallOrNonModelCUDAHostBuffers|WarnsOnceForLargeCUDAHostModelBuffers|$)' -count=1`
- [x] `go test ./llm -count=1`
- [x] `go vet ./llm`
- [x] `git diff --check`
- [x] `go test ./...` attempted; failed only because this checkout has no generated `app/dist` files for `app/cmd/app` and `app/ui` embeds. Other packages that ran before that setup failure passed, including `github.com/ollama/ollama/llm`.

## Second-agent review

- Preferred reviewer: `claude -p`
- Result: unavailable, exited 401 authentication error
- Fallback reviewer: `hermes chat -Q`
- Result: CLEAN

The fallback review checked correctness, regressions, tests, security, duplicate/superseded work, and maintainer fit. No blocking findings were reported after the added edge-case test coverage.
