### PR TITLE
docs: add Dakera to Community Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ console.log(response.message.content);
 - [Ollama-rs for Rust](https://github.com/pepperoni21/ollama-rs) - Rust SDK
 - [LangChain for .NET](https://github.com/tryAGI/LangChain) - .NET LangChain ([example](https://github.com/tryAGI/LangChain/blob/main/examples/LangChain.Samples.OpenAI/Program.cs))
 - [chromem-go](https://github.com/philippgille/chromem-go) - Go vector database with Ollama embeddings ([example](https://github.com/philippgille/chromem-go/tree/v0.5.0/examples/rag-wikipedia-ollama))
+- [Dakera](https://github.com/dakera-ai/dakera-deploy) - Self-hosted persistent memory server adding decay-weighted vector recall across sessions for Ollama apps
 - [LangChainDart](https://github.com/davidmigloz/langchain_dart) - Dart LangChain
 - [LlmTornado](https://github.com/lofcz/llmtornado) - Unified C# interface for multiple inference APIs
 - [Ollama4j for Java](https://github.com/ollama4j/ollama4j) - Java SDK

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ console.log(response.message.content);
 - [Ollama-rs for Rust](https://github.com/pepperoni21/ollama-rs) - Rust SDK
 - [LangChain for .NET](https://github.com/tryAGI/LangChain) - .NET LangChain ([example](https://github.com/tryAGI/LangChain/blob/main/examples/LangChain.Samples.OpenAI/Program.cs))
 - [chromem-go](https://github.com/philippgille/chromem-go) - Go vector database with Ollama embeddings ([example](https://github.com/philippgille/chromem-go/tree/v0.5.0/examples/rag-wikipedia-ollama))
-- [Dakera](https://github.com/dakera-ai/dakera-deploy) - Self-hosted persistent memory server adding decay-weighted vector recall across sessions for Ollama apps
+- [Dakera](https://github.com/dakera-ai/dakera-py) - Self-hosted persistent memory with decay-weighted vector recall across sessions for Ollama apps ([example](https://github.com/dakera-ai/dakera-py/blob/main/examples/ollama_memory_chat.py))
 - [LangChainDart](https://github.com/davidmigloz/langchain_dart) - Dart LangChain
 - [LlmTornado](https://github.com/lofcz/llmtornado) - Unified C# interface for multiple inference APIs
 - [Ollama4j for Java](https://github.com/ollama4j/ollama4j) - Java SDK
@@ -335,6 +335,7 @@ console.log(response.message.content);
 - [pgai](https://github.com/timescale/pgai) - PostgreSQL as a vector database ([guide](https://github.com/timescale/pgai/blob/main/docs/vectorizer-quick-start.md))
 - [MindsDB](https://github.com/mindsdb/mindsdb/blob/staging/mindsdb/integrations/handlers/ollama_handler/README.md) - Connect Ollama with 200+ data platforms
 - [chromem-go](https://github.com/philippgille/chromem-go/blob/v0.5.0/embed_ollama.go) - Embeddable vector database for Go ([example](https://github.com/philippgille/chromem-go/tree/v0.5.0/examples/rag-wikipedia-ollama))
+- [Dakera](https://github.com/dakera-ai/dakera-py) - Self-hosted vector memory server with decay-weighted recall ([example](https://github.com/dakera-ai/dakera-py/blob/main/examples/ollama_memory_proxy.py))
 - [Kangaroo](https://github.com/dbkangaroo/kangaroo) - AI-powered SQL client
 
 ### Infrastructure & Deployment


### PR DESCRIPTION
### What
Adds **Dakera** to Community Integrations → *Libraries & SDKs*, next to the existing vector-store entries (e.g. `chromem-go`).

Follow-up to #16987, where @rick-github asked for a PR.

### Why it fits Ollama
Ollama's `/api/chat` and `/api/generate` are stateless — every call starts fresh. Dakera is a self-hosted memory server that adds **persistent, decay-weighted vector recall** across sessions, so an Ollama app can transparently store what happened and retrieve relevant context on the next turn. Memories are importance-scored and decay over time, so stale context stops competing with fresh, relevant facts. No Ollama code changes are required — it sits beside the model server, like the other data/memory libraries already listed.

### Concrete usage (self-hosted, no external services)
Run the server (image + object store) via the public [`dakera-deploy`](https://github.com/dakera-ai/dakera-deploy) compose, then use the Python SDK around your Ollama calls:

```python
import ollama
from dakera import DakeraClient  # pip install dakera

mem = DakeraClient(base_url="http://localhost:3000", api_key="dk-local")
AGENT = "my-ollama-app"

def chat(user_msg: str) -> str:
    # 1. recall relevant long-term context
    ctx = mem.recall(agent_id=AGENT, query=user_msg, top_k=5)
    system = "Relevant memory:\n" + "\n".join(m.content for m in ctx.memories)

    # 2. normal stateless Ollama call, now grounded in memory
    resp = ollama.chat(model="llama3.2", messages=[
        {"role": "system", "content": system},
        {"role": "user", "content": user_msg},
    ])
    answer = resp["message"]["content"]

    # 3. persist the turn with importance weighting
    mem.store_memory(agent_id=AGENT, content=f"User: {user_msg}\nAssistant: {answer}", importance=0.6)
    return answer
```

### Runnable examples
Two complete, runnable recipes ship in the Dakera Python SDK's [`examples/`](https://github.com/dakera-ai/dakera-py/tree/main/examples) directory:

- **`ollama_memory_chat.py`** — embeds recall→chat→store around `ollama.chat` using the SDK's `ChatMemorySession` helper.
- **`ollama_memory_proxy.py`** — a transparent proxy: point any Ollama client at `:8080` instead of `:11434` and `/api/chat` gains memory with no app changes (the middleware requested in #16987).

Docs: https://dakera.ai/docs/python-sdk · Self-host: https://github.com/dakera-ai/dakera-deploy

### Change
Single-line README addition to an existing curated list; no code changes to Ollama itself. Verified the link and category placement against the current README.
