### PR TITLE
server: report the same capabilities in /api/tags as /api/show

### DIFF
--- a/server/images.go
+++ b/server/images.go
@@ -298,6 +298,22 @@ func shouldPreferChatTemplate(chatTemplate string, chatTemplateCaps []model.Capa
 	return chatTemplateHasToolRoundTrip(chatTemplate) && !goTemplateHasToolRoundTrip(goTemplate)
 }
 
+// preferGGUFChatTemplate reports whether the GGUF chat_template should take
+// precedence over the model's Go TEMPLATE when rendering chat requests and
+// deriving capabilities.
+func preferGGUFChatTemplate(m *Model, ggufChatTemplate string) bool {
+	if goTemplateEnvSet() || !m.HasGoTemplate || ggufChatTemplate == "" || m.Config.Renderer != "" || m.Config.Parser != "" {
+		return false
+	}
+	if m.Template != nil && shouldUseHarmony(m) {
+		return false
+	}
+
+	ggufCaps := chatTemplateCapabilities(nil, ggufChatTemplate)
+	goCaps := goTemplateCapabilities(m.Template)
+	return shouldPreferChatTemplate(ggufChatTemplate, ggufCaps, m.Template, goCaps)
+}
+
 func goTemplateEnvSet() bool {
 	return envconfig.GoTemplate(true) == envconfig.GoTemplate(false)
 }
@@ -751,13 +767,9 @@ func GetModel(name string) (*Model, error) {
 		}
 	}
 
-	ggufCaps := chatTemplateCapabilities(nil, ggufChatTemplate)
-	goCaps := goTemplateCapabilities(m.Template)
-	usesHarmony := m.Template != nil && shouldUseHarmony(m)
-	if !goTemplateEnvSet() && m.HasGoTemplate && ggufChatTemplate != "" && m.Config.Renderer == "" && m.Config.Parser == "" && !usesHarmony && shouldPreferChatTemplate(ggufChatTemplate, ggufCaps, m.Template, goCaps) {
-		m.PreferChatTemplate = true
-	}
+	m.PreferChatTemplate = preferGGUFChatTemplate(m, ggufChatTemplate)
 
+	usesHarmony := m.Template != nil && shouldUseHarmony(m)
 	if m.ModelPath != "" && m.isGGUF() && !modelHasPooling && !m.HasChatTemplate && (!m.HasGoTemplate || !envconfig.GoTemplate(true)) && m.Config.Renderer == "" && m.Config.Parser == "" && !usesHarmony {
 		slog.Warn("model is missing tokenizer.chat_template and Go TEMPLATE support is unavailable; chat responses may be poorly formatted", "model", m.Name, "env", "OLLAMA_GO_TEMPLATE=1")
 	}

--- a/server/model_list_cache.go
+++ b/server/model_list_cache.go
@@ -18,9 +18,7 @@ import (
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/fs/ggml"
 	"github.com/ollama/ollama/manifest"
-	"github.com/ollama/ollama/model/parsers"
 	ollamatemplate "github.com/ollama/ollama/template"
-	"github.com/ollama/ollama/thinking"
 	"github.com/ollama/ollama/types/model"
 )
 
@@ -337,17 +335,18 @@ func buildModelListSummary(name model.Name, mf *manifest.Manifest) (modelListSum
 		},
 	}
 
-	modelPath, projectorCount, tmpl, err := readModelListLayers(mf, &summary)
+	modelPath, projectorPaths, tmpl, hasGoTemplate, err := readModelListLayers(mf, &summary)
 	if err != nil {
 		return modelListSummary{}, err
 	}
 
+	var info modelListGGUF
 	if cfg.RemoteHost == "" && cfg.RemoteModel == "" && modelPath != "" {
-		info, err := readModelListGGUF(modelPath)
+		info, err = readModelListGGUF(modelPath)
 		if err != nil {
 			slog.Debug("failed to read gguf model metadata", "model", name.String(), "error", err)
+			info = modelListGGUF{}
 		} else {
-			summary.Capabilities = appendModelListCapabilities(summary.Capabilities, info.Capabilities...)
 			if summary.Details.ContextLength == 0 {
 				summary.Details.ContextLength = info.ContextLength
 			}
@@ -360,41 +359,28 @@ func buildModelListSummary(name model.Name, mf *manifest.Manifest) (modelListSum
 		}
 	}
 
-	for _, c := range cfg.Capabilities {
-		summary.Capabilities = appendModelListCapability(summary.Capabilities, model.Capability(c))
+	// Derive capabilities with the same helpers Model.Capabilities uses so
+	// /api/tags reports the same capabilities as /api/show.
+	m := &Model{
+		Name:            name.String(),
+		Config:          cfg,
+		Template:        tmpl,
+		HasGoTemplate:   hasGoTemplate,
+		HasChatTemplate: info.ChatTemplate != "",
+		ProjectorPaths:  projectorPaths,
 	}
+	m.PreferChatTemplate = preferGGUFChatTemplate(m, info.ChatTemplate)
 
-	builtinParser := parsers.ParserForName(cfg.Parser)
-	if tmpl != nil {
-		vars, err := tmpl.Vars()
-		if err != nil {
-			slog.Warn("model template contains errors", "model", name.String(), "error", err)
-		}
-		if slices.Contains(vars, "tools") || (builtinParser != nil && builtinParser.HasToolSupport()) {
-			summary.Capabilities = appendModelListCapability(summary.Capabilities, model.CapabilityTools)
-		}
-		if slices.Contains(vars, "suffix") {
-			summary.Capabilities = appendModelListCapability(summary.Capabilities, model.CapabilityInsert)
-		}
-
-		openingTag, closingTag := thinking.InferTags(tmpl.Template)
-		hasTags := openingTag != "" && closingTag != ""
-		isGptoss := slices.Contains([]string{"gptoss", "gpt-oss"}, cfg.ModelFamily)
-		if !slices.Contains(summary.Capabilities, model.CapabilityThinking) &&
-			(hasTags || isGptoss || (builtinParser != nil && builtinParser.HasThinkingSupport())) {
-			summary.Capabilities = appendModelListCapability(summary.Capabilities, model.CapabilityThinking)
-		}
+	capabilities := m.configCapabilities(nil)
+	if !usesOllamaRenderedChat(m) {
+		capabilities = chatTemplateCapabilities(capabilities, info.ChatTemplate)
 	}
-
-	if projectorCount > 0 {
-		summary.Capabilities = appendModelListCapability(summary.Capabilities, model.CapabilityVision)
-	}
-
-	if cfg.ModelFormat == "safetensors" && isGemma4Renderer(cfg.Renderer) {
-		summary.Capabilities = slices.DeleteFunc(summary.Capabilities, func(c model.Capability) bool {
-			return c == model.CapabilityVision || c == model.CapabilityAudio
-		})
-	}
+	capabilities = appendModelListCapabilities(capabilities, info.Capabilities...)
+	capabilities = m.projectorCapabilities(capabilities)
+	capabilities = m.templateCapabilities(capabilities, templateCapabilitySelected)
+	capabilities = m.parserCapabilities(capabilities)
+	capabilities = m.modelFamilyCapabilities(capabilities)
+	summary.Capabilities = m.filterUnsupportedCapabilities(capabilities, info.Architecture)
 
 	return summary, nil
 }
@@ -418,9 +404,10 @@ func readModelListConfig(mf *manifest.Manifest) (model.ConfigV2, error) {
 	return cfg, nil
 }
 
-func readModelListLayers(mf *manifest.Manifest, summary *modelListSummary) (string, int, *ollamatemplate.Template, error) {
+func readModelListLayers(mf *manifest.Manifest, summary *modelListSummary) (string, []string, *ollamatemplate.Template, bool, error) {
 	var modelPath string
-	var projectorCount int
+	var projectorPaths []string
+	var hasGoTemplate bool
 	tmpl := ollamatemplate.DefaultTemplate
 
 	for _, layer := range mf.Layers {
@@ -428,35 +415,42 @@ func readModelListLayers(mf *manifest.Manifest, summary *modelListSummary) (stri
 		case "application/vnd.ollama.image.model":
 			filename, err := manifest.BlobsPath(layer.Digest)
 			if err != nil {
-				return "", 0, nil, err
+				return "", nil, nil, false, err
 			}
 			modelPath = filename
 			summary.Details.ParentModel = layer.From
 		case "application/vnd.ollama.image.projector":
-			projectorCount++
+			filename, err := manifest.BlobsPath(layer.Digest)
+			if err != nil {
+				return "", nil, nil, false, err
+			}
+			projectorPaths = append(projectorPaths, filename)
 		case "application/vnd.ollama.image.prompt",
 			"application/vnd.ollama.image.template":
 			filename, err := manifest.BlobsPath(layer.Digest)
 			if err != nil {
-				return "", 0, nil, err
+				return "", nil, nil, false, err
 			}
 			bts, err := os.ReadFile(filename)
 			if err != nil {
-				return "", 0, nil, err
+				return "", nil, nil, false, err
 			}
 
 			tmpl, err = ollamatemplate.Parse(string(bts))
 			if err != nil {
-				return "", 0, nil, err
+				return "", nil, nil, false, err
 			}
+			hasGoTemplate = true
 		}
 	}
 
-	return modelPath, projectorCount, tmpl, nil
+	return modelPath, projectorPaths, tmpl, hasGoTemplate, nil
 }
 
 type modelListGGUF struct {
 	Capabilities    []model.Capability
+	Architecture    string
+	ChatTemplate    string
 	ContextLength   int
 	EmbeddingLength int
 	FileType        string
@@ -483,9 +477,12 @@ const (
 	modelListGGUFTypeFloat64
 )
 
-// readModelListGGUF scans only the small GGUF header values launch needs
-// and stops before tokenizer arrays. Using gguf.File.KeyValue for missing keys
-// can otherwise advance through large arrays just to discover absence.
+// readModelListGGUF scans only the small GGUF header values launch needs.
+// Once tokenizer keys start it skips their values without decoding them,
+// stopping as soon as tokenizer.chat_template is found; capability detection
+// needs the chat template to match what /api/show reports. Using
+// gguf.File.KeyValue for missing keys can otherwise advance through large
+// arrays just to discover absence.
 func readModelListGGUF(path string) (modelListGGUF, error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -537,7 +534,7 @@ func readModelListGGUF(path string) (modelListGGUF, error) {
 
 	info := modelListGGUF{}
 	var architecture string
-	var hasPoolingType bool
+	var hasPoolingType, hasVision, hasAudio bool
 
 	for range numKV {
 		key, err := readModelListGGUFString(r, byteOrder, version)
@@ -556,6 +553,7 @@ func readModelListGGUF(path string) (modelListGGUF, error) {
 				return modelListGGUF{}, err
 			}
 			architecture = value
+			info.Architecture = value
 			continue
 		}
 
@@ -569,7 +567,18 @@ func readModelListGGUF(path string) (modelListGGUF, error) {
 		}
 
 		if architecture != "" && strings.HasPrefix(key, "tokenizer.") {
-			break
+			if key == "tokenizer.chat_template" {
+				value, err := readModelListGGUFStringValue(r, byteOrder, version, valueType)
+				if err != nil {
+					return modelListGGUF{}, err
+				}
+				info.ChatTemplate = value
+				break
+			}
+			if err := skipModelListGGUFValue(r, byteOrder, version, valueType); err != nil {
+				return modelListGGUF{}, err
+			}
+			continue
 		}
 
 		if architecture != "" && strings.HasPrefix(key, architecture+".") {
@@ -577,9 +586,9 @@ func readModelListGGUF(path string) (modelListGGUF, error) {
 			case "pooling_type":
 				hasPoolingType = true
 			case "vision.block_count":
-				info.Capabilities = appendModelListCapability(info.Capabilities, model.CapabilityVision)
+				hasVision = true
 			case "audio.block_count":
-				info.Capabilities = appendModelListCapability(info.Capabilities, model.CapabilityAudio)
+				hasAudio = true
 			case "context_length":
 				value, err := readModelListGGUFIntValue(r, byteOrder, version, valueType)
 				if err != nil {
@@ -606,6 +615,12 @@ func readModelListGGUF(path string) (modelListGGUF, error) {
 		info.Capabilities = appendModelListCapability(info.Capabilities, model.CapabilityEmbedding)
 	} else {
 		info.Capabilities = appendModelListCapability(info.Capabilities, model.CapabilityCompletion)
+	}
+	if hasVision {
+		info.Capabilities = appendModelListCapability(info.Capabilities, model.CapabilityVision)
+	}
+	if hasAudio {
+		info.Capabilities = appendModelListCapability(info.Capabilities, model.CapabilityAudio)
 	}
 
 	return info, nil

--- a/server/model_list_cache_test.go
+++ b/server/model_list_cache_test.go
@@ -65,6 +65,48 @@ func TestModelListCacheHydratesSummary(t *testing.T) {
 	}
 }
 
+func TestModelListCacheUsesGGUFChatTemplateCapabilities(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setTestHome(t, t.TempDir())
+
+	// Mirrors models such as deepseek-r1 where the Go TEMPLATE has no tool
+	// support but the GGUF chat template does; /api/show prefers the chat
+	// template, so /api/tags must report the same capabilities.
+	createListCacheModel(t, "list-chat-template", map[string]any{
+		"tokenizer.chat_template": "{% if tools %}{{ tools }}{% endif %}<think></think>{{ messages[0]['content'] }}",
+	}, "{{ .Prompt }}")
+
+	cache := newModelListCache()
+	if err := cache.hydrate(context.Background()); err != nil {
+		t.Fatalf("hydrate failed: %v", err)
+	}
+
+	summary, ok := cache.Get(model.ParseName("list-chat-template"))
+	if !ok {
+		t.Fatal("list summary missing")
+	}
+
+	for _, capability := range []model.Capability{model.CapabilityCompletion, model.CapabilityTools, model.CapabilityThinking} {
+		if !slices.Contains(summary.Capabilities, capability) {
+			t.Fatalf("capabilities = %v, want %s", summary.Capabilities, capability)
+		}
+	}
+
+	mdl, err := GetModel("list-chat-template")
+	if err != nil {
+		t.Fatalf("get model failed: %v", err)
+	}
+	show := mdl.Capabilities()
+	if len(show) != len(summary.Capabilities) {
+		t.Fatalf("list capabilities = %v, show capabilities = %v", summary.Capabilities, show)
+	}
+	for _, capability := range show {
+		if !slices.Contains(summary.Capabilities, capability) {
+			t.Fatalf("list capabilities = %v, missing %s reported by show", summary.Capabilities, capability)
+		}
+	}
+}
+
 func TestModelListCacheRefreshUpdatesEntry(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	setTestHome(t, t.TempDir())


### PR DESCRIPTION
## Summary
- `/api/tags` derived capabilities from a stripped-down GGUF scanner that
  stopped reading at the first `tokenizer.*` key, so it never saw
  `tokenizer.chat_template`. For models like `deepseek-r1` whose `tools`
  capability comes from the GGUF chat template (not the Go TEMPLATE),
  `/api/tags` reported `[completion, thinking]` while `/api/show` correctly
  reported `[completion, thinking, tools]`.
- The GGUF scanner now reads `tokenizer.chat_template` (skipping other
  tokenizer values without decoding them) and `buildModelListSummary` derives
  capabilities using the same helpers `Model.Capabilities()` uses
  (`configCapabilities`, `chatTemplateCapabilities`, `templateCapabilities`,
  `parserCapabilities`, `modelFamilyCapabilities`,
  `filterUnsupportedCapabilities`), so both endpoints agree.
- Extracted the "prefer GGUF chat template over Go TEMPLATE" decision from
  `GetModel` into a shared `preferGGUFChatTemplate` helper so the list cache
  can reuse the exact same logic `/api/show` uses.
- Added a regression test that mirrors the deepseek-r1 case (Go TEMPLATE
  without tool support, GGUF chat template with tool + thinking support) and
  asserts `/api/tags` and `/api/show` return the same capability set.

Fixes #16969

## Test plan
- [x] `go test ./server -run 'TestModelListCacheUsesGGUFChatTemplateCapabilities' -count=1 -v`
- [x] `go test ./server -run 'TestModelListCache' -count=1 -v`
- [x] `go test ./server -count=1`
- [x] `gofmt -l server/` (clean)
- [x] `git diff --check`