### PR TITLE
rocm: remove no longer supported devices

### DIFF
--- a/docs/gpu.mdx
+++ b/docs/gpu.mdx
@@ -68,7 +68,7 @@ using the `amdgpu-install` utility from
 
 | Family         | Cards and accelerators                                                                                                                                         |
 | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| AMD Radeon RX  | `9070 XT` `9070 GRE` `9070` `9060 XT` `9060 XT LP` `9060` `7900 XTX` `7900 XT` `7900 GRE` `7800 XT` `7700 XT` `7700` `7600 XT` `7600` `6950 XT` `6900 XTX` `6900XT` `6800 XT` `6800` `5700 XT` `5700` `5600 XT` `5500 XT` |
+| AMD Radeon RX  | `9070 XT` `9070 GRE` `9070` `9060 XT` `9060 XT LP` `9060` `7900 XTX` `7900 XT` `7900 GRE` `7800 XT` `7700 XT` `7700` `7600 XT` `7600` `6950 XT` `6900 XTX` `6900XT` `6800 XT` `6800` |
 | AMD Radeon AI PRO | `R9700` `R9600D`                                                                                                                                            |
 | AMD Radeon PRO | `W7900` `W7800` `W7700` `W7600` `W7500` `W6900X` `W6800X Duo` `W6800X` `W6800` `V620`                                                                        |
 | AMD Ryzen AI   | `Ryzen AI Max+ 395` `Ryzen AI Max 390` `Ryzen AI Max 385` `Ryzen AI 9 HX 475` `Ryzen AI 9 HX 470` `Ryzen AI 9 465` `Ryzen AI 9 HX 375` `Ryzen AI 9 HX 370` `Ryzen AI 9 365` |
@@ -80,8 +80,8 @@ Ollama requires an AMD ROCm v7 / HIP7-capable driver stack on Windows.
 
 | Family         | Cards and accelerators                                                                                               |
 | -------------- | -------------------------------------------------------------------------------------------------------------------- |
-| AMD Radeon RX  | `7900 XTX` `7900 XT` `7900 GRE` `7800 XT` `7700 XT` `7600 XT` `7600` `6950 XT` `6900 XTX` `6900XT` `6800 XT` `6800`  |
-| AMD Radeon PRO | `W7900` `W7800` `W7700` `W7600` `W7500` `W6900X` `W6800X Duo` `W6800X` `W6800` `V620`                                |
+| AMD Radeon RX  | `7900 XTX` `7900 XT` `7900 GRE` `7800 XT` `7700 XT` `7600 XT` `7600`  |
+| AMD Radeon PRO | `W7900` `W7800` `W7700` `W7600` `W7500`                                |
 
 ### Overrides on Linux
 
@@ -107,13 +107,10 @@ This table shows some example GPUs that map to these LLVM targets:
 | gfx90a | Radeon Instinct MI210/MI250 |
 | gfx942 | Radeon Instinct MI300X/MI300A |
 | gfx950 | Radeon Instinct MI350X |
-| gfx1010 | Radeon RX 5700 XT |
-| gfx1012 | Radeon RX 5500 XT |
 | gfx1030 | Radeon PRO V620 |
 | gfx1100 | Radeon PRO W7900 |
 | gfx1101 | Radeon PRO W7700 |
 | gfx1102 | Radeon RX 7600 |
-| gfx1103 | Radeon 780M |
 | gfx1150 | Ryzen AI 9 HX 375 |
 | gfx1151 | Ryzen AI Max+ 395 |
 | gfx1200 | Radeon RX 9070 |

--- a/llama/server/CMakePresets.json
+++ b/llama/server/CMakePresets.json
@@ -178,7 +178,7 @@
       "inherits": ["rocm_v7_1_base"],
       "binaryDir": "${sourceDir}/../../build/llama-server-rocm_v7_1",
       "cacheVariables": {
-        "AMDGPU_TARGETS": "gfx942;gfx950;gfx1010;gfx1012;gfx1030;gfx1100;gfx1101;gfx1102;gfx1103;gfx1150;gfx1151;gfx1200;gfx1201"
+        "AMDGPU_TARGETS": "gfx1030;gfx1100;gfx1101;gfx1102;gfx1150;gfx1151;gfx1200;gfx1201"
       }
     },
     {
@@ -202,7 +202,7 @@
       "inherits": ["rocm_v7_2_base"],
       "binaryDir": "${sourceDir}/../../build/llama-server-rocm_v7_2",
       "cacheVariables": {
-        "AMDGPU_TARGETS": "gfx908:xnack-;gfx90a:xnack+;gfx90a:xnack-;gfx942;gfx950;gfx1010;gfx1012;gfx1030;gfx1100;gfx1101;gfx1102;gfx1103;gfx1150;gfx1151;gfx1200;gfx1201"
+        "AMDGPU_TARGETS": "gfx908:xnack-;gfx90a:xnack+;gfx90a:xnack-;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1102;gfx1150;gfx1151;gfx1200;gfx1201"
       }
     },
     {


### PR DESCRIPTION
The presets and docs had fallen out of sync with what our current ROCm versions on Linux and Windows actually support.  We rely on Vulkan now to cover these older unsupported devices.

This should also help speed up the official builds as well since we'll no longer be building gfx targets that will be blocked at runtime due to lacking rocblas tensile files.
