### PR TITLE
create: drop Qwen MTP tensors during MLX import

### DIFF
--- a/x/create/create_test.go
+++ b/x/create/create_test.go
@@ -1570,8 +1570,8 @@ func TestCreateSafetensorsModel_Qwen35Transforms(t *testing.T) {
 		t.Fatalf("CreateSafetensorsModel failed: %v", err)
 	}
 
-	if _, ok := calls["mtp.layers.0.foo.weight"]; !ok {
-		t.Fatal("mtp tensor should have been preserved")
+	if _, ok := calls["mtp.layers.0.foo.weight"]; ok {
+		t.Fatal("mtp tensor should have been dropped")
 	}
 
 	layerNorm := calls["language_model.model.layers.0.input_layernorm.weight"]

--- a/x/create/qwen35.go
+++ b/x/create/qwen35.go
@@ -83,7 +83,7 @@ func qwen35InspectSource(modelDir string) (qwen35SourceInfo, error) {
 }
 
 func (t qwen35ImportTransform) skipTensor(name string) bool {
-	return false
+	return strings.Contains(name, "mtp.")
 }
 
 func qwen35ShouldKeepBF16ForDirectNonAffine(name string) bool {
@@ -253,8 +253,6 @@ func (t qwen35ImportTransform) canonicalTensorName(name string) string {
 		return "vision_tower." + strings.TrimPrefix(name, "model.visual.")
 	case strings.HasPrefix(name, "vision_tower."):
 		return name
-	case strings.HasPrefix(name, "mtp."):
-		return name
 	}
 
 	// Language model tensors: normalize to language_model.model.* prefix
@@ -275,8 +273,6 @@ func qwen35ShouldShiftNormKey(key string) bool {
 	for _, suffix := range []string{
 		".input_layernorm.weight",
 		".post_attention_layernorm.weight",
-		"mtp.pre_fc_norm_embedding.weight",
-		"mtp.pre_fc_norm_hidden.weight",
 		"model.norm.weight",
 		".q_norm.weight",
 		".k_norm.weight",


### PR DESCRIPTION
### Summary

Drop `mtp.*` tensors during Qwen3.5/Qwen3.6 MLX safetensors create.

Qwen3.5 create already detects MTP source tensors and applies the compatibility
norm shift during import. Keeping `mtp.*` tensors in the artifact manifest makes
the runtime detect MTP again and apply the same norm shift a second time. The
created model loads, but Qwen3.5/Qwen3.6 generation becomes corrupted.

This restores the earlier behavior of skipping `mtp.*` tensors during create
until the runtime has real MTP support that does not use tensor presence as a
compatibility signal.

Fixes https://github.com/ollama/ollama/issues/17019

### Validation

```text
go test ./x/create ./x/models/qwen3_5
./scripts/mlx_build.sh
MCP macOS ./scripts/mlx_build.sh
```

Manual MLX create+infer check:

```text
model: qwen3.6:27b-nvfp4
source: Qwen3.6-27B-6a9e13b
family: qwen3_5
parameters: 27.4B
quantization: nvfp4
layers: 1194
MTP layers: 0
artifact bytes: 19763221673
result: pass
done reasons: stop,stop
```

Smoke prompt:

```text
Write one short sentence about release testing.
```

Both `think=false` and `think=true` produced coherent final responses.
