### PR TITLE
parsers: track nesting depth when closing qwen3-coder tool calls

### DIFF
--- a/model/parsers/qwen3coder.go
+++ b/model/parsers/qwen3coder.go
@@ -179,28 +179,69 @@ func eat(p *Qwen3CoderParser) ([]qwenEvent, bool) {
 			return events, false
 		}
 	case qwenParserState_CollectingToolContent:
-		if strings.Contains(p.acc.String(), toolCloseTag) {
-			split := strings.SplitN(p.acc.String(), toolCloseTag, 2)
-			before := split[0]
-			if len(before) == 0 {
-				slog.Warn("qwen tool call closing tag found but no content before it")
-			}
-			// remove any whitespace between the tool call and any content after it
-			after := strings.TrimLeftFunc(split[1], unicode.IsSpace)
-			p.acc.Reset()
-			p.acc.WriteString(after)
-			events = append(events, qwenEventRawToolCall{raw: before})
-			p.state = qwenParserState_LookingForToolStart
-			return events, true
-		} else {
+		acc := p.acc.String()
+		end := matchingToolCloseIndex(acc)
+		if end == -1 {
 			// note that we don't need to check the overlap here because we only plan
 			// on parsing the tool call once we see the full closing tag. We don't
 			// stream back the unparsed tool content, so there's no need to be eager
 			// here
 			return events, false
 		}
+
+		before := acc[:end]
+		if len(before) == 0 {
+			slog.Warn("qwen tool call closing tag found but no content before it")
+		}
+		// remove any whitespace between the tool call and any content after it
+		after := strings.TrimLeftFunc(acc[end+len(toolCloseTag):], unicode.IsSpace)
+		p.acc.Reset()
+		p.acc.WriteString(after)
+		events = append(events, qwenEventRawToolCall{raw: before})
+		p.state = qwenParserState_LookingForToolStart
+		return events, true
 	default:
 		panic("unreachable")
+	}
+}
+
+// matchingToolCloseIndex returns the byte offset in s of the toolCloseTag
+// that matches the single toolOpenTag already consumed to enter
+// qwenParserState_CollectingToolContent (depth starts at 1). A
+// toolOpenTag/toolCloseTag pair fully contained in s is treated as nested
+// and skipped over, so a tool call's own content (e.g. a parameter value)
+// can contain a complete, well-formed nested <tool_call>...</tool_call>
+// without truncating the outer call early. Returns -1 if the matching
+// close tag hasn't fully arrived yet.
+//
+// Note: this only resolves genuinely nested, fully-paired <tool_call>
+// blocks. A bare, unpaired toolCloseTag-shaped substring (e.g. literal
+// text "</tool_call>" inside a parameter value with no matching open) is
+// indistinguishable from a real terminator by depth counting alone, and
+// will still close the call early. Fixing that would require parameter-
+// boundary awareness, which eat() deliberately doesn't have.
+func matchingToolCloseIndex(s string) int {
+	depth := 1
+	pos := 0
+	for {
+		closeIdx := strings.Index(s[pos:], toolCloseTag)
+		if closeIdx == -1 {
+			return -1
+		}
+
+		openIdx := strings.Index(s[pos:], toolOpenTag)
+		if openIdx != -1 && openIdx < closeIdx {
+			depth++
+			pos += openIdx + len(toolOpenTag)
+			continue
+		}
+
+		depth--
+		closePos := pos + closeIdx
+		if depth == 0 {
+			return closePos
+		}
+		pos = closePos + len(toolCloseTag)
 	}
 }
 

--- a/model/parsers/qwen3coder_test.go
+++ b/model/parsers/qwen3coder_test.go
@@ -21,6 +21,10 @@ func TestQwenParserStreaming(t *testing.T) {
 		wantEvents []qwenEvent
 	}
 
+	// shared content for the "well-formed nested pair" case below, so the
+	// input and the expected raw event can't drift out of sync
+	nestedInner := "<function=outer><parameter=note><tool_call><function=inner><parameter=x>1</parameter></function></tool_call></parameter></function>"
+
 	cases := []struct {
 		desc  string
 		steps []step
@@ -120,6 +124,77 @@ func TestQwenParserStreaming(t *testing.T) {
 				{input: "l", wantEvents: []qwenEvent{}},
 				{input: "l", wantEvents: []qwenEvent{}},
 				{input: ">", wantEvents: []qwenEvent{qwenEventRawToolCall{raw: "abc"}}},
+			},
+		},
+		{
+			// this documents a known, intentionally scoped-out limitation: a bare
+			// </tool_call>-shaped substring with no matching <tool_call> open can't
+			// be distinguished from a real terminator by depth counting alone, so
+			// it still closes the call early. This is not a regression from the
+			// nesting fix below, and behavior here is unchanged from before it.
+			desc: "unpaired </tool_call>-like substring in a parameter value still closes early (known limitation, not a regression)",
+			steps: []step{
+				{
+					input: "<tool_call><function=outer><parameter=note>value with </tool_call> inside</parameter></function></tool_call>",
+					wantEvents: []qwenEvent{
+						qwenEventRawToolCall{raw: "<function=outer><parameter=note>value with "},
+						qwenEventContent{content: "inside</parameter></function></tool_call>"},
+					},
+				},
+			},
+		},
+		{
+			desc: "well-formed nested <tool_call> pair closes on the outer tag, not the inner one",
+			steps: []step{
+				{
+					input: "<tool_call>" + nestedInner + "</tool_call>",
+					wantEvents: []qwenEvent{
+						qwenEventRawToolCall{raw: nestedInner},
+					},
+				},
+			},
+		},
+		{
+			desc: "regression: multiple sequential (non-nested) tool calls still parsed independently",
+			steps: []step{
+				{
+					input: "before1<tool_call>call one</tool_call>between<tool_call>call two</tool_call>between2<tool_call>call three</tool_call>after",
+					wantEvents: []qwenEvent{
+						qwenEventContent{content: "before1"},
+						qwenEventRawToolCall{raw: "call one"},
+						qwenEventContent{content: "between"},
+						qwenEventRawToolCall{raw: "call two"},
+						qwenEventContent{content: "between2"},
+						qwenEventRawToolCall{raw: "call three"},
+						qwenEventContent{content: "after"},
+					},
+				},
+			},
+		},
+		{
+			desc: "regression: nested tool call streamed across chunks with partial tag boundaries",
+			steps: []step{
+				{
+					// ends mid partial open tag ("<tool_c") while already inside
+					// CollectingToolContent, exercising the depth scan's "not found
+					// yet, wait for more" path
+					input:      "<tool_call>outer-start<tool_c",
+					wantEvents: []qwenEvent{},
+				},
+				{
+					// completes a full, well-formed nested pair, but the outer close
+					// still hasn't arrived - depth must not drop to 0 here
+					input:      "all>inner</tool_call>outer-e",
+					wantEvents: []qwenEvent{},
+				},
+				{
+					// the real outer close arrives; the whole nested span should be
+					// emitted as a single raw tool call
+					input: "nd</tool_call>",
+					wantEvents: []qwenEvent{
+						qwenEventRawToolCall{raw: "outer-start<tool_call>inner</tool_call>outer-end"},
+					},
+				},
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

`qwenParserState_CollectingToolContent` was finding the tool-call close tag using a naive first-match `strings.Contains`/`SplitN`, with no nesting depth tracking. This meant a well-formed nested `<tool_call>...</tool_call>` pair inside a tool call's own content (e.g. embedded in a parameter value) would close on the inner tag instead of the outer one — corrupting the parsed call and causing the true outer close (and anything after it) to get misprocessed as top-level content.

This PR adds `matchingToolCloseIndex`, which walks the buffer counting `toolOpenTag`/`toolCloseTag` occurrences and only resolves once depth returns to zero, correctly skipping fully-paired nested blocks. This mirrors the approach used in #16937, which fixed the same class of bug (naive delimiter counting getting fooled by delimiter-like content inside an argument value) in the sibling generic tool-call parser.

Note: this does **not** attempt to resolve a bare, unpaired `</tool_call>`-shaped substring with no matching open (e.g. literal text inside a parameter value) — that's indistinguishable from a real terminator by depth counting alone, so I've left it out of scope here. This is documented and covered by a test asserting the existing (unchanged) behavior.

Related to #16992 (I found this while investigating that issue), but it doesn't resolve it — the failure reported there stems from the model emitting a different tool-call vocabulary entirely, not from nested `<tool_call>` tags.

## Test plan

- [x] Added table-driven cases to `TestQwenParserStreaming` in `model/parsers/qwen3coder_test.go`: well-formed nested pair closes on the outer tag with full nested content preserved; unpaired-substring case documented as unchanged; multiple sequential (non-nested) tool calls still parse independently; nested tool call streamed across chunks with partial tag boundaries.
- [x] `go test ./model/parsers/... -v -count=1` — all tests pass, including all pre-existing cases unchanged.
- [x] `gofmt -l` and `go vet ./model/parsers/...` clean.