### PR TITLE
anthropic: include empty input for parameterless tool calls in non-streaming responses

### DIFF
--- a/anthropic/anthropic.go
+++ b/anthropic/anthropic.go
@@ -671,11 +671,15 @@ func ToMessagesResponse(id string, r api.ChatResponse) MessagesResponse {
 	}
 
 	for _, tc := range r.Message.ToolCalls {
+		input := tc.Function.Arguments
+		if input.Len() == 0 {
+			input = api.NewToolCallFunctionArguments()
+		}
 		content = append(content, ContentBlock{
 			Type:  "tool_use",
 			ID:    tc.ID,
 			Name:  tc.Function.Name,
-			Input: tc.Function.Arguments,
+			Input: input,
 		})
 	}
 

--- a/anthropic/anthropic_test.go
+++ b/anthropic/anthropic_test.go
@@ -816,6 +816,43 @@ func TestToMessagesResponse_WithToolCalls(t *testing.T) {
 	}
 }
 
+func TestToMessagesResponse_ParameterlessToolCall(t *testing.T) {
+	resp := api.ChatResponse{
+		Model: "test-model",
+		Message: api.Message{
+			Role: "assistant",
+			ToolCalls: []api.ToolCall{
+				{
+					ID:       "call_123",
+					Function: api.ToolCallFunction{Name: "get_time"},
+				},
+			},
+		},
+		Done:       true,
+		DoneReason: "stop",
+	}
+
+	result := ToMessagesResponse("msg_123", resp)
+
+	data, err := json.Marshal(result.Content[0])
+	if err != nil {
+		t.Fatalf("failed to marshal content block: %v", err)
+	}
+
+	var block map[string]any
+	if err := json.Unmarshal(data, &block); err != nil {
+		t.Fatalf("failed to unmarshal content block: %v", err)
+	}
+
+	input, ok := block["input"]
+	if !ok {
+		t.Fatalf("tool_use block missing required 'input' field: %s", data)
+	}
+	if m, ok := input.(map[string]any); !ok || len(m) != 0 {
+		t.Errorf("expected input to be an empty object, got %v", input)
+	}
+}
+
 func TestToMessagesResponse_WithThinking(t *testing.T) {
 	resp := api.ChatResponse{
 		Model: "test-model",


### PR DESCRIPTION
The Anthropic-compatible `/v1/messages` endpoint can return a `tool_use` content block with no `input` field for a parameterless tool call.

`ContentBlock.Input` is tagged `json:"input,omitzero"`, and `api.ToolCallFunctionArguments` has no `IsZero()` method, so `omitzero` falls back to the struct-zero check and drops the field whenever a tool call has no arguments. The Anthropic Messages API expects every `tool_use` block to carry an `input` object (empty as `{}`).

The streaming path already guarantees this: #15105 made `StreamConverter` emit `api.NewToolCallFunctionArguments()` so streamed `tool_use` blocks always include `"input":{}`. The non-streaming `ToMessagesResponse` was missed and still copies the raw zero value, so a parameterless tool call serializes as `{"type":"tool_use","id":"...","name":"get_time"}` with no `input` at all.

This mirrors the streaming fix in `ToMessagesResponse`: when a tool call has no arguments, substitute an empty arguments object so the block serializes as `"input":{}`.

Tested with `TestToMessagesResponse_ParameterlessToolCall`, which marshals the block and asserts `input` is present and empty; it fails before the change (no `input` field) and passes after.

```
go test ./anthropic/
ok  	github.com/ollama/ollama/anthropic
```
