### PR TITLE
cuda: add CC 10.0 for linux in CUDA v12

### DIFF
--- a/llama/server/CMakePresets.json
+++ b/llama/server/CMakePresets.json
@@ -68,7 +68,7 @@
       "inherits": ["llama_cuda_v12_base"],
       "binaryDir": "${sourceDir}/../../build/llama-server-cuda_v12",
       "cacheVariables": {
-        "CMAKE_CUDA_ARCHITECTURES": "50-virtual;52-virtual;60;61;70;75;80;86;89;90;90a;120"
+        "CMAKE_CUDA_ARCHITECTURES": "50-virtual;52-virtual;60;61;70;75;80;86;89;90;90a;100;120"
       }
     },
     {


### PR DESCRIPTION
Add compute capability 10.0 to the Linux CUDA v12 preset so B200-class devices can use the cuda_v12 backend with drivers that do not meet the CUDA v13 minimum.

Fixes #12583