### PR TITLE
fix: flush OpenAI-compatible streaming responsesfix: flush OpenAI-compatible streaming responses

### DIFF
--- a/middleware/openai.go
+++ b/middleware/openai.go
@@ -55,6 +55,17 @@ type EmbedWriter struct {
 	encodingFormat string
 }
 
+func setEventStreamHeaders(h http.Header) {
+	h.Set("Content-Type", "text/event-stream")
+	h.Set("Cache-Control", "no-cache")
+	h.Set("Connection", "keep-alive")
+	h.Set("X-Accel-Buffering", "no")
+}
+
+func flushEventStream(w gin.ResponseWriter) {
+	w.Flush()
+}
+
 func (w *BaseWriter) writeError(data []byte) (int, error) {
 	var serr api.StatusError
 	if err := json.Unmarshal(data, &serr); err != nil {
@@ -81,7 +92,7 @@ func (w *ChatWriter) writeResponse(data []byte) (int, error) {
 	// chat chunk
 	if w.stream {
 		chunks := openai.ToChunks(w.id, chatResponse, w.toolCallSent)
-		w.ResponseWriter.Header().Set("Content-Type", "text/event-stream")
+		setEventStreamHeaders(w.ResponseWriter.Header())
 		for _, c := range chunks {
 			d, err := json.Marshal(c)
 			if err != nil {
@@ -95,6 +106,7 @@ func (w *ChatWriter) writeResponse(data []byte) (int, error) {
 				return 0, err
 			}
 		}
+		flushEventStream(w.ResponseWriter)
 
 		if chatResponse.Done {
 			c := openai.ToChunk(w.id, chatResponse, w.toolCallSent)
@@ -115,11 +127,13 @@ func (w *ChatWriter) writeResponse(data []byte) (int, error) {
 				if err != nil {
 					return 0, err
 				}
+				flushEventStream(w.ResponseWriter)
 			}
 			_, err = w.ResponseWriter.Write([]byte("data: [DONE]\n\n"))
 			if err != nil {
 				return 0, err
 			}
+			flushEventStream(w.ResponseWriter)
 		}
 
 		return len(data), nil
@@ -162,11 +176,12 @@ func (w *CompleteWriter) writeResponse(data []byte) (int, error) {
 			return 0, err
 		}
 
-		w.ResponseWriter.Header().Set("Content-Type", "text/event-stream")
+		setEventStreamHeaders(w.ResponseWriter.Header())
 		_, err = w.ResponseWriter.Write([]byte(fmt.Sprintf("data: %s\n\n", d)))
 		if err != nil {
 			return 0, err
 		}
+		flushEventStream(w.ResponseWriter)
 
 		if generateResponse.Done {
 			if w.streamOptions != nil && w.streamOptions.IncludeUsage {
@@ -181,11 +196,13 @@ func (w *CompleteWriter) writeResponse(data []byte) (int, error) {
 				if err != nil {
 					return 0, err
 				}
+				flushEventStream(w.ResponseWriter)
 			}
 			_, err = w.ResponseWriter.Write([]byte("data: [DONE]\n\n"))
 			if err != nil {
 				return 0, err
 			}
+			flushEventStream(w.ResponseWriter)
 		}
 
 		return len(data), nil

--- a/middleware/openai_test.go
+++ b/middleware/openai_test.go
@@ -89,6 +89,26 @@ func sseDataFrames(body string) []string {
 	return data
 }
 
+func assertEventStreamResponse(t *testing.T, recorder *httptest.ResponseRecorder) {
+	t.Helper()
+
+	if got := recorder.Header().Get("Content-Type"); got != "text/event-stream" {
+		t.Fatalf("expected Content-Type text/event-stream, got %q", got)
+	}
+	if got := recorder.Header().Get("Cache-Control"); got != "no-cache" {
+		t.Fatalf("expected Cache-Control no-cache, got %q", got)
+	}
+	if got := recorder.Header().Get("Connection"); got != "keep-alive" {
+		t.Fatalf("expected Connection keep-alive, got %q", got)
+	}
+	if got := recorder.Header().Get("X-Accel-Buffering"); got != "no" {
+		t.Fatalf("expected X-Accel-Buffering no, got %q", got)
+	}
+	if !recorder.Flushed {
+		t.Fatal("expected stream writer to flush")
+	}
+}
+
 func TestChatWriter_StreamMixedThinkingAndContentEmitsSplitChunks(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	recorder := httptest.NewRecorder()
@@ -124,9 +144,7 @@ func TestChatWriter_StreamMixedThinkingAndContentEmitsSplitChunks(t *testing.T) 
 		t.Fatalf("write response: %v", err)
 	}
 
-	if got := recorder.Header().Get("Content-Type"); got != "text/event-stream" {
-		t.Fatalf("expected Content-Type text/event-stream, got %q", got)
-	}
+	assertEventStreamResponse(t, recorder)
 
 	frames := sseDataFrames(recorder.Body.String())
 	if len(frames) != 4 {
@@ -307,6 +325,49 @@ func TestChatWriter_StreamMixedThinkingAndToolCallsWithoutDoneEmitsChunksOnly(t 
 	}
 	if !writer.toolCallSent {
 		t.Fatal("expected toolCallSent to be tracked after tool-call chunk emission")
+	}
+}
+
+func TestCompleteWriter_StreamFlushesAndSetsEventStreamHeaders(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(recorder)
+
+	writer := &CompleteWriter{
+		stream:        true,
+		streamOptions: &openai.StreamOptions{IncludeUsage: true},
+		id:            "cmpl-test",
+		BaseWriter:    BaseWriter{ResponseWriter: context.Writer},
+	}
+
+	response := api.GenerateResponse{
+		Model:      "test-model",
+		Response:   "done",
+		Done:       true,
+		DoneReason: "stop",
+		Metrics: api.Metrics{
+			PromptEvalCount: 4,
+			EvalCount:       1,
+		},
+	}
+
+	data, err := json.Marshal(response)
+	if err != nil {
+		t.Fatalf("marshal response: %v", err)
+	}
+
+	if _, err = writer.Write(data); err != nil {
+		t.Fatalf("write response: %v", err)
+	}
+
+	assertEventStreamResponse(t, recorder)
+
+	frames := sseDataFrames(recorder.Body.String())
+	if len(frames) != 3 {
+		t.Fatalf("expected 3 SSE data frames (chunk + usage + [DONE]), got %d:\n%s", len(frames), recorder.Body.String())
+	}
+	if frames[2] != "[DONE]" {
+		t.Fatalf("expected final frame [DONE], got %q", frames[2])
 	}
 }
 


### PR DESCRIPTION
## Summary

Improves OpenAI-compatible SSE streaming behavior so UI clients receive chunks promptly and the stream is flushed through completion.

## Problem

Issue #15329 reports that UI clients such as Chatbox and OpenWebUI can appear to hang even though Ollama is performing inference successfully. One possible server-side cause is streamed chunks or terminal SSE frames not being flushed promptly.

## Changes

- Set no-buffering stream headers for OpenAI-compatible streaming responses.
- Flush after emitted streaming chunks.
- Flush after usage chunks.
- Flush after terminal `data: [DONE]`.
- Added focused tests for stream headers, flush behavior, and stream termination.

## Tests

Passed:
- `gofmt -w middleware/openai.go middleware/openai_test.go`
- `git diff --check`
- `go test ./middleware`
- `go test ./openai`

Attempted:
- `go test ./... -run "Stream|Streaming|OpenAI|ChatCompletion|Flush"`

The broader repo-wide test command fails locally on Windows due to unrelated build/setup issues, including missing `app/dist` assets and MLX/imagegen packages that do not build in this environment. The touched middleware package passes.

Related to #15329.