### PR TITLE
llm: sum sliding-window KV caches in VRAM accounting

### DIFF
--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -2685,15 +2685,52 @@ func (w *memoryParsingWriter) Write(b []byte) (int, error) {
 			}
 			for _, match := range bufferSizeRegex.FindAllSubmatch(b, -1) {
 				backendName := string(match[2])
+				kind := string(match[3])
 				if mib, err := strconv.ParseFloat(string(match[4]), 64); err == nil {
 					if w.buffers == nil {
 						w.buffers = make(map[memoryBufferKey]memoryBuffer)
 					}
-					w.buffers[memoryBufferKey{
+					// llama-server logs buffer sizes twice: a fit probe and then
+					// the final load. A model buffer line arriving after compute
+					// buffers were recorded marks the start of that second pass.
+					// Non-KV buffers are keyed so the final value simply overwrites
+					// the probe's, but KV buffers accumulate (see below), so the
+					// probe's KV entries must be dropped first — otherwise the final
+					// KV sizes would be added on top of the probe's. Buffers that
+					// only appear in the probe (e.g. output) are left untouched.
+					if kind == "model" {
+						hasCompute := false
+						for existing := range w.buffers {
+							if existing.kind == "compute" {
+								hasCompute = true
+								break
+							}
+						}
+						if hasCompute {
+							for existing := range w.buffers {
+								if existing.kind == "KV" {
+									delete(w.buffers, existing)
+								}
+							}
+						}
+					}
+					key := memoryBufferKey{
 						component: string(match[1]),
 						backend:   backendName,
-						kind:      string(match[3]),
-					}] = memoryBuffer{bytes: uint64(mib * 1024 * 1024)}
+						kind:      kind,
+					}
+					bytes := uint64(mib * 1024 * 1024)
+					// Sliding-window-attention models (e.g. gemma2/gemma3) allocate
+					// two KV caches on the same device within one pass — a
+					// full-attention cache and a smaller sliding-window cache — each
+					// logged with an identical "<src>: <dev> KV buffer size" prefix,
+					// so they share this key. They are distinct allocations, so sum
+					// them instead of letting the second overwrite the first (which
+					// undercounts VRAM by a whole KV cache at long contexts).
+					if kind == "KV" {
+						bytes += w.buffers[key].bytes
+					}
+					w.buffers[key] = memoryBuffer{bytes: bytes}
 					w.updateRunnerMemoryLocked()
 				}
 			}

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -3161,6 +3161,26 @@ func TestMemoryParsingWriterMemorySizeMmapPartialOffload(t *testing.T) {
 			wantTotalMiB: 6500 + 7000,
 			wantVRAMMiB:  6500,
 		},
+		{
+			// Sliding-window-attention models (gemma2/gemma3) allocate two KV
+			// caches on one GPU — a full-attention cache and a smaller
+			// sliding-window cache — both logged as "CUDA0 KV buffer size".
+			// They are distinct allocations and must be summed; before the fix
+			// the 174 line overwrote the 2560 line, undercounting VRAM by a whole
+			// KV cache. Captured from gemma3:4b @ 128K ctx on an RTX 5080.
+			name:          "sliding window attention sums both KV caches",
+			fileSizeBytes: 0,
+			lines: []string{
+				"load_tensors: offloaded 35/35 layers to GPU\n",
+				"load_tensors:        CUDA0 model buffer size =  2367.54 MiB\n",
+				"llama_kv_cache:      CUDA0 KV buffer size =  2560.00 MiB\n",
+				"llama_kv_cache:      CUDA0 KV buffer size =   174.00 MiB\n",
+				"sched_reserve:       CUDA0 compute buffer size =   203.52 MiB\n",
+			},
+			// full offload => total == vram; both KV caches counted.
+			wantTotalMiB: 2367.54 + 2560.00 + 174.00 + 203.52,
+			wantVRAMMiB:  2367.54 + 2560.00 + 174.00 + 203.52,
+		},
 	}
 
 	withinKiB := func(got, want uint64) bool {


### PR DESCRIPTION
## Problem

`ollama ps` — and the scheduler's internal VRAM bookkeeping (`runner.vramSize`) — under-reports GPU memory for **sliding-window-attention models** (the gemma2 / gemma3 family) by a whole KV cache once the context is non-trivial.

Reproduced on an RTX 5080 (16 GB) with `gemma3:4b`:

| context | `ollama ps` SIZE | actual device memory (llama-server's own breakdown) |
| --- | --- | --- |
| 4K   | 2.9 GB | ~2.7 GiB |
| 128K | 3.0 GB | **5.2 GiB** (`5305 MiB = 2367 model + 2734 kv + 203 compute`) |

The reported size barely moves (2.9 → 3.0 GB) while the KV cache grows ~2.5 GiB, so at 128K it under-reports by ~2.4 GiB.

## Root cause

`memoryParsingWriter` keys each parsed buffer by `{component, backend, kind}`. Sliding-window-attention models allocate **two** KV caches on the same device — a full-attention cache and a smaller sliding-window cache — and llama-server logs both with an identical prefix:

```
llama_kv_cache:   CUDA0 KV buffer size =  2560.00 MiB
llama_kv_cache:   CUDA0 KV buffer size =   174.00 MiB
```

They share the same map key, so the second silently overwrites the first and the larger cache is dropped from the VRAM total.

## Fix

Sum KV buffers that share a key within a single load pass instead of overwriting. Because llama-server logs buffer sizes twice (a fit probe, then the final load) and KV now accumulates, the probe pass's KV entries are dropped when the final load's model buffers reappear — so the final KV sizes replace the probe's rather than stacking on top. Non-KV buffers keep their existing last-writer-wins behavior, and buffers that only appear in the probe (e.g. `output`) are preserved.

## Tests

Added a `TestMemoryParsingWriterMemorySizeMmapPartialOffload` case built from the real `gemma3:4b` @ 128K log output, asserting the two KV caches are summed (5305 MiB, not 2745 MiB). It fails without the fix and passes with it; the existing probe/final-replace and mmap-trimming cases continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
