### PR TITLE
fix: include GGUF chat template tools capability in /api/tags

### DIFF
--- a/server/model_list_cache.go
+++ b/server/model_list_cache.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/fs/ggml"
+	"github.com/ollama/ollama/fs/gguf"
 	"github.com/ollama/ollama/manifest"
 	"github.com/ollama/ollama/model/parsers"
 	ollamatemplate "github.com/ollama/ollama/template"
@@ -370,7 +371,15 @@ func buildModelListSummary(name model.Name, mf *manifest.Manifest) (modelListSum
 		if err != nil {
 			slog.Warn("model template contains errors", "model", name.String(), "error", err)
 		}
-		if slices.Contains(vars, "tools") || (builtinParser != nil && builtinParser.HasToolSupport()) {
+		hasToolsVar := slices.Contains(vars, "tools")
+		if !hasToolsVar && modelPath != "" {
+			if f, err := gguf.Open(modelPath); err == nil {
+				chatTmpl := f.KeyValue("tokenizer.chat_template").String()
+				f.Close()
+				hasToolsVar = strings.Contains(chatTmpl, "tools") || strings.Contains(chatTmpl, "tool_call")
+			}
+		}
+		if hasToolsVar || (builtinParser != nil && builtinParser.HasToolSupport()) {
 			summary.Capabilities = appendModelListCapability(summary.Capabilities, model.CapabilityTools)
 		}
 		if slices.Contains(vars, "suffix") {

--- a/server/model_list_cache.go
+++ b/server/model_list_cache.go
@@ -371,7 +371,15 @@ func buildModelListSummary(name model.Name, mf *manifest.Manifest) (modelListSum
 		if err != nil {
 			slog.Warn("model template contains errors", "model", name.String(), "error", err)
 		}
-		if slices.Contains(vars, "tools") || (builtinParser != nil && builtinParser.HasToolSupport()) {
+		hasToolsVar := slices.Contains(vars, "tools")
+		if !hasToolsVar && modelPath != "" {
+			if f, err := fsgguf.Open(modelPath); err == nil {
+				chatTmpl := f.KeyValue("tokenizer.chat_template").String()
+				f.Close()
+				hasToolsVar = strings.Contains(chatTmpl, "tools") || strings.Contains(chatTmpl, "tool_call")
+			}
+		}
+		if hasToolsVar || (builtinParser != nil && builtinParser.HasToolSupport()) {
 			summary.Capabilities = appendModelListCapability(summary.Capabilities, model.CapabilityTools)
 		}
 		if slices.Contains(vars, "suffix") {
@@ -498,7 +506,7 @@ const (
 )
 
 // readModelListGGUF scans only the small GGUF header values launch needs
-// and stops before tokenizer arrays. Using gguf.File.KeyValue for missing keys
+// and stops before tokenizer arrays. Using fsgguf.File.KeyValue for missing keys
 // can otherwise advance through large arrays just to discover absence.
 func readModelListGGUF(path string) (modelListGGUF, error) {
 	f, err := os.Open(path)

--- a/server/model_list_cache_test.go
+++ b/server/model_list_cache_test.go
@@ -237,3 +237,53 @@ func createListCacheModel(t *testing.T, name string, kv map[string]any, tmpl str
 		t.Fatalf("create model status = %d, want 200: %s", w.Code, w.Body.String())
 	}
 }
+
+// TestBuildModelListSummaryGGUFChatTemplateTools verifies that /api/tags includes
+// the "tools" capability when it is present only in the GGUF tokenizer.chat_template
+// but not in the Ollama Go template (reproduces issue #16969).
+func TestBuildModelListSummaryGGUFChatTemplateTools(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setTestHome(t, t.TempDir())
+	// Go template has no .Tools reference; tools support lives in the GGUF chat template.
+	createListCacheModelWithKV(t, "list-gguf-tools",
+		map[string]any{
+			"test.context_length":       uint32(4096),
+			"tokenizer.chat_template":   "{% for tool in tools %} {{ tool.name }} {% endfor %}{{ prompt }}",
+		},
+		"{{ .prompt }}",
+	)
+
+	cache := newModelListCache()
+	if err := cache.hydrate(context.Background()); err != nil {
+		t.Fatalf("hydrate failed: %v", err)
+	}
+
+	summary, ok := cache.Get(model.ParseName("list-gguf-tools"))
+	if !ok {
+		t.Fatal("list summary missing")
+	}
+
+	if !slices.Contains(summary.Capabilities, model.CapabilityTools) {
+		t.Fatalf("capabilities = %v, want to contain %s (tools in GGUF chat template)", summary.Capabilities, model.CapabilityTools)
+	}
+}
+
+func createListCacheModelWithKV(t *testing.T, name string, kv map[string]any, tmpl string) {
+	t.Helper()
+	_, digest := createBinFile(t, kv, nil)
+
+	req := api.CreateRequest{
+		Model:  name,
+		Files:  map[string]string{"model.gguf": digest},
+		Stream: &stream,
+	}
+	if tmpl != "" {
+		req.Template = tmpl
+	}
+
+	var s Server
+	w := createRequest(t, s.CreateHandler, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("create model status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+}

--- a/server/model_list_cache_test.go
+++ b/server/model_list_cache_test.go
@@ -369,3 +369,52 @@ func writeModelListGGUFUint64(t *testing.T, b *bytes.Buffer, v uint64) {
 		t.Fatal(err)
 	}
 }
+
+// TestBuildModelListSummaryGGUFChatTemplateTools verifies that /api/tags includes
+// the "tools" capability when it is present only in the GGUF tokenizer.chat_template
+// but not in the Ollama Go template (reproduces issue #16969).
+func TestBuildModelListSummaryGGUFChatTemplateTools(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setTestHome(t, t.TempDir())
+	createListCacheModelWithKV(t, "list-gguf-tools",
+		map[string]any{
+			"test.context_length":       uint32(4096),
+			"tokenizer.chat_template":   "{% for tool in tools %} {{ tool.name }} {% endfor %}{{ prompt }}",
+		},
+		"{{ .prompt }}",
+	)
+
+	cache := newModelListCache()
+	if err := cache.hydrate(context.Background()); err != nil {
+		t.Fatalf("hydrate failed: %v", err)
+	}
+
+	summary, ok := cache.Get(model.ParseName("list-gguf-tools"))
+	if !ok {
+		t.Fatal("list summary missing")
+	}
+
+	if !slices.Contains(summary.Capabilities, model.CapabilityTools) {
+		t.Fatalf("capabilities = %v, want to contain %s (tools in GGUF chat template)", summary.Capabilities, model.CapabilityTools)
+	}
+}
+
+func createListCacheModelWithKV(t *testing.T, name string, kv map[string]any, tmpl string) {
+	t.Helper()
+	_, digest := createBinFile(t, kv, nil)
+
+	req := api.CreateRequest{
+		Model:  name,
+		Files:  map[string]string{"model.gguf": digest},
+		Stream: &stream,
+	}
+	if tmpl != "" {
+		req.Template = tmpl
+	}
+
+	var s Server
+	w := createRequest(t, s.CreateHandler, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("create model status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #16969 — `/api/tags` omits the `tools` capability for models like `deepseek-r1` even though `/api/show` correctly reports it.

### Root cause

`buildModelListSummary` (which powers `/api/tags`) detects tool support by checking the Ollama Go template's variable list via `tmpl.Vars()`:

```go
if slices.Contains(vars, "tools") || (builtinParser != nil && builtinParser.HasToolSupport()) {
    summary.Capabilities = appendModelListCapability(summary.Capabilities, model.CapabilityTools)
}
```

This only finds `.Tools` in the **Ollama Go template** layer. Models like `deepseek-r1` ship with a Jinja2 chat template stored in `tokenizer.chat_template` (GGUF key) that references `tools`, but their Ollama Go template wrapper does not — so the capability is silently dropped.

`/api/show` uses `Model.Capabilities()` → `capabilitiesForTemplate` → `ggufCapabilities` which reads `tokenizer.chat_template` directly via `f.KeyValue("tokenizer.chat_template").String()` and runs `chatTemplateHasToolSupport` on it. That path correctly finds `tools`.

### Fix

When `tmpl.Vars()` doesn't find `"tools"`, fall back to opening the GGUF file and checking `tokenizer.chat_template` for `"tools"` or `"tool_call"` — exactly what `chatTemplateHasToolSupport` does in `images.go`:

```go
hasToolsVar := slices.Contains(vars, "tools")
if !hasToolsVar && modelPath != "" {
    if f, err := gguf.Open(modelPath); err == nil {
        chatTmpl := f.KeyValue("tokenizer.chat_template").String()
        f.Close()
        hasToolsVar = strings.Contains(chatTmpl, "tools") || strings.Contains(chatTmpl, "tool_call")
    }
}
```

### Test

Added `TestBuildModelListSummaryGGUFChatTemplateTools`: creates a model whose Ollama Go template is plain `{{ .prompt }}` (no `.Tools`) but whose GGUF `tokenizer.chat_template` contains `tools`, then asserts that `CapabilityTools` appears in the hydrated cache entry.

## Test plan

- [x] `go test ./server/ -run TestBuildModelListSummaryGGUFChatTemplateTools` — new regression test passes
- [x] `go test ./server/ -run TestModelListCacheHydratesSummary` — existing coverage test still passes
- [x] `go build ./server/...` — compiles cleanly