### PR TITLE
server: return runner status code from EmbeddingsHandler

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -1073,6 +1073,14 @@ func (s *Server) EmbeddingsHandler(c *gin.Context) {
 	embedding, _, err := r.Embedding(c.Request.Context(), req.Prompt)
 	if err != nil {
 		s.sched.expireRunnersForRuntimeOOM(m, err)
+		// Preserve client-error status codes from the runner (e.g. an input
+		// longer than the context length is a 400, not a server error) instead
+		// of reporting every failure as 500, matching EmbedHandler.
+		var serr api.StatusError
+		if errors.As(err, &serr) {
+			c.AbortWithStatusJSON(serr.StatusCode, gin.H{"error": strings.TrimSpace(serr.ErrorMessage)})
+			return
+		}
 		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": strings.TrimSpace(err.Error())})
 		return
 	}


### PR DESCRIPTION
## Problem

The legacy `/api/embeddings` endpoint returns **HTTP 500** when the input is longer than the model's context length — but that's a client error, not a server fault. `/api/embed` already returns **400** for the same input.

Reproduced with `nomic-embed-text` (context 2048) and an ~8000-token input:

| endpoint | status before |
| --- | --- |
| `/api/embed` | 400 ✓ |
| `/api/embeddings` | **500** ✗ |

## Root cause

`EmbeddingsHandler` (server/routes.go) wraps every `r.Embedding` error as `http.StatusInternalServerError`. The runner already returns an `api.StatusError{StatusCode: 400}` for over-length input (via `normalizeEmbeddingError`), but the handler discards that code. `EmbedHandler` handles this correctly with `errors.As`.

## Fix

Mirror `EmbedHandler`: if the error is an `api.StatusError`, propagate its status code and message; otherwise keep the 500 fallback.

## Verification

Built the patched binary and re-ran against a local server:

| request | status after |
| --- | --- |
| `/api/embeddings`, ~8000-token input | **400** — "the input length exceeds the context length" |
| `/api/embed`, same input (control) | 200 (truncates) |
| `/api/embeddings`, normal input (sanity) | 200, 768-dim — unchanged |

No handler-level test currently covers these embedding endpoints, so this was verified end-to-end; happy to add a test harness if that's preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
