### PR TITLE
server: notify the caller when the scheduler drops a cancelled request

### DIFF
--- a/server/sched.go
+++ b/server/sched.go
@@ -242,6 +242,9 @@ func (s *Scheduler) processPending(ctx context.Context) {
 
 			if pending.ctx.Err() != nil {
 				slog.Debug("pending request cancelled or timed out, skipping scheduling")
+				// The caller blocks on successCh/errCh with no context arm, so it
+				// must be notified here or its goroutine leaks forever.
+				pending.errCh <- pending.ctx.Err()
 				continue
 			}
 			logutil.Trace("processing incoming request", "model", pending.model.ModelPath)

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -1202,8 +1202,15 @@ func TestSchedAlreadyCanceled(t *testing.T) {
 	s.Run(ctx)
 	time.Sleep(5 * time.Millisecond)
 	require.Empty(t, s.pendingReqCh)
-	require.Empty(t, scenario1a.req.errCh)
 	require.Empty(t, scenario1a.req.successCh)
+	// The scheduler must report the cancellation on errCh; otherwise the caller
+	// (scheduleRunner) blocks on errCh/successCh forever and leaks its goroutine.
+	select {
+	case err := <-scenario1a.req.errCh:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-ctx.Done():
+		t.Fatal("timeout: cancelled request was dropped without notifying the caller")
+	}
 }
 
 // hasLoadedRunner is a test helper that checks if any runner is loaded.


### PR DESCRIPTION
### Summary

When `processPending` dequeues a request whose context is already cancelled, it logs and skips scheduling but writes to **neither** `successCh` nor `errCh`:

```go
if pending.ctx.Err() != nil {
    slog.Debug("pending request cancelled or timed out, skipping scheduling")
    continue
}
```

The only consumer of those channels, `scheduleRunner`, blocks on a `select` over them with no context arm:

```go
runnerCh, errCh := s.sched.getRunner(ctx, model, opts, keepAlive, numCtxAuto, numBatchAuto, shift)
var runner *runnerRef
select {
case runner = <-runnerCh:
case err = <-errCh:
    return nil, nil, nil, err
}
```

So when the scheduler silently drops the request, the caller's goroutine — the HTTP request handler — blocks **forever**, pinning the `LlmRequest`, `Model`, and context. This leaks one goroutine (plus its request state) for **every** request that is cancelled while queued behind an in-progress model load, e.g. a client that times out or disconnects while a large model is loading. Under real traffic with client timeouts/retries this is unbounded goroutine and memory growth.

`net/http` never tears down handler goroutines on client disconnect — it only cancels the request context — so nothing else unblocks the stuck send/receive.

### Fix

Report the cancellation on the request's buffered `errCh` before dropping it, mirroring the existing `req.errCh <- ErrMaxQueue` path a few lines above. The caller then unblocks with the context error and returns normally.

The fix is intentionally on the scheduler side rather than adding a `ctx.Done()` arm to `scheduleRunner`: the `successCh` send paths (`useLoadedRunner`, and the load-success path) do not re-check the request context, so a caller-side context arm would race with a runner that finishes loading in the cancellation window and leak a fully-loaded runner (worse than a goroutine). Notifying on `errCh` in the drop branch is race-free and covers every caller of `getRunner`.

### Testing

`TestSchedAlreadyCanceled` previously asserted the request was dropped with nothing sent on either channel — i.e. it codified the leaking behavior. Updated it to assert the caller is now notified with `context.Canceled` on `errCh`. Without the fix this select times out (demonstrating the stuck caller); with it, it passes.

- `go test ./server/ -run TestSched` — pass
- `go test ./server/` — pass
- `go vet ./server/`, `gofmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
