### PR TITLE
llm: clear parsed buffer sizes when resetting load accounting

### DIFF
--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -1042,6 +1042,14 @@ func (s *llamaServerRunner) resetLoadAccounting() {
 	for k := range s.systemFreeAtLoad {
 		delete(s.systemFreeAtLoad, k)
 	}
+	// The runner memory fields above are recomputed from scratch on every parsed
+	// buffer line by summing s.output.buffers, so the raw map must be cleared too.
+	// Otherwise a retry (e.g. projector CPU offload) merges its buffers with the
+	// previous attempt's; entries whose device moved (GPU->CPU) keep a stale key
+	// and get double-counted, over-reporting VRAM.
+	if s.output != nil {
+		s.output.buffers = nil
+	}
 	if s.status != nil {
 		s.status.SetLastError("")
 	}

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -3211,6 +3211,67 @@ func TestMemoryParsingWriterMemorySizeMmapPartialOffload(t *testing.T) {
 	}
 }
 
+func TestResetLoadAccountingClearsBuffersForMMProjRetry(t *testing.T) {
+	// llama-server's --fit can place text layers on GPU and then OOM while
+	// allocating the multimodal projector on GPU. Ollama retries once with the
+	// projector forced to CPU, calling resetLoadAccounting() before restarting.
+	// The retry's projector buffer moves CUDA0 -> CPU, so its parsed key changes.
+	// If the raw buffer map is not cleared on reset, the stale attempt-1 CUDA0
+	// projector entry is summed alongside the attempt-2 CPU entry and VRAM is
+	// over-reported.
+	runner := &llamaServerRunner{vramByDevice: make(map[string]uint64)}
+	w := &memoryParsingWriter{inner: io.Discard, runner: runner}
+	runner.output = w
+
+	writeAll := func(lines []string) {
+		for _, line := range lines {
+			if _, err := w.Write([]byte(line)); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	// Attempt 1: projector offloaded to GPU (the placement that OOMs).
+	writeAll([]string{
+		"load_tensors:        CUDA0 model buffer size =  2000.00 MiB\n",
+		"clip_model_loader:   CUDA0 model buffer size =   600.00 MiB\n",
+		"llama_kv_cache:      CUDA0 KV buffer size =    400.00 MiB\n",
+		"sched_reserve:       CUDA0 compute buffer size =   200.00 MiB\n",
+	})
+
+	// The OOM retry stops the process and resets accounting before restarting.
+	runner.resetLoadAccounting()
+
+	// Attempt 2: same text placement, projector now on CPU (--no-mmproj-offload).
+	writeAll([]string{
+		"load_tensors:        CUDA0 model buffer size =  2000.00 MiB\n",
+		"clip_model_loader:     CPU model buffer size =   600.00 MiB\n",
+		"llama_kv_cache:      CUDA0 KV buffer size =    400.00 MiB\n",
+		"sched_reserve:       CUDA0 compute buffer size =   200.00 MiB\n",
+	})
+
+	total, vram := runner.MemorySize()
+	// After the retry the projector (600) lives on CPU, so VRAM is only the text
+	// weights + KV + compute. Total counts every buffer once.
+	wantVRAM := uint64((2000 + 400 + 200) * 1024 * 1024)
+	wantTotal := uint64((2000 + 600 + 400 + 200) * 1024 * 1024)
+
+	withinKiB := func(got, want uint64) bool {
+		if got > want {
+			return got-want <= 1024
+		}
+		return want-got <= 1024
+	}
+	if !withinKiB(vram, wantVRAM) {
+		t.Errorf("VRAM = %.2f MiB, want %.2f MiB (stale pre-retry GPU projector was not cleared)",
+			float64(vram)/1024/1024, float64(wantVRAM)/1024/1024)
+	}
+	if !withinKiB(total, wantTotal) {
+		t.Errorf("total = %.2f MiB, want %.2f MiB",
+			float64(total)/1024/1024, float64(wantTotal)/1024/1024)
+	}
+}
+
 func TestVRAMByGPU(t *testing.T) {
 	runner := &llamaServerRunner{
 		vramByDevice: map[string]uint64{


### PR DESCRIPTION
### Summary

`resetLoadAccounting` zeroes the runner's derived memory fields (`memTotal`, `memGPU`, `vramByDevice`, …) but leaves the `memoryParsingWriter`'s raw `buffers` map intact:

```go
func (s *llamaServerRunner) resetLoadAccounting() {
    s.memoryMu.Lock()
    defer s.memoryMu.Unlock()

    s.memTotal = 0
    s.memGPU = 0
    // ... zero the rest, clear vramByDevice / systemFreeAtLoad ...
}
```

But those fields are not authoritative — they are recomputed from scratch by `updateRunnerMemoryLocked()`, which sums the entire `buffers` map, on **every** parsed buffer-size line. The map itself is only ever lazily created and written; it is never cleared. So the first buffer line of the next load immediately rebuilds the fields from the *old* map plus the new entry, silently undoing the reset.

### Impact: multimodal projector CPU-offload retry over-reports VRAM

`--fit` can place text layers on GPU and then OOM while allocating the multimodal projector on GPU. `retryWithMMProjCPUOffload` handles this by stopping llama-server, calling `resetLoadAccounting()`, and restarting with `--no-mmproj-offload` so the projector goes to CPU.

On the retry the projector buffer moves from `CUDA0` to `CPU`, so its parsed key (`{component, backend, kind}`) changes. Because the map was not cleared, the stale attempt-1 `CUDA0` projector entry survives alongside the new `CPU` entry and both are summed. The runner's `memGPU` / `vramByDevice` are inflated by the size of the projector that is no longer on the GPU.

That inflated size is what `ollama ps` reports (`MemorySize()`), and what the scheduler subtracts from free VRAM (`VRAMByGPU` → `updateFreeSpace`), so it can wrongly refuse to co-load or evict another model.

### Fix

Clear `s.output.buffers` in `resetLoadAccounting` so the retry rebuilds its memory picture from scratch. The writer takes the same `memoryMu` the reset already holds, so this is race-safe, and the map is lazily recreated on the next parsed line.

### Testing

Added `TestResetLoadAccountingClearsBuffersForMMProjRetry`: parses an attempt-1 buffer set with the projector on `CUDA0`, calls `resetLoadAccounting()`, then parses an attempt-2 set with the projector on `CPU`, and asserts VRAM reflects only the GPU-resident buffers. Without the fix it reports the stale projector (VRAM 3200 vs 2600 MiB); with it, it is correct.

- `go test ./llm/` — pass
- `go vet ./llm/`, `gofmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
