### PR TITLE
Add otaku to Terminal & CLI community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ console.log(response.message.content);
 - [LLM-X](https://github.com/mrdjohnson/llm-x) - Progressive web app for LLMs
 - [cmdh](https://github.com/pgibler/cmdh) - Natural language to shell commands
 - [VT](https://github.com/vinhnx/vt.ai) - Minimal multimodal AI chat app
+- [otaku](https://github.com/enclavum/otaku) - Terminal chat client with cross-provider model management and encrypted chat history
 
 ### Productivity & Apps
 


### PR DESCRIPTION
Adds [otaku](https://github.com/enclavum/otaku) to the Terminal & CLI list in Community Integrations.

otaku is an MIT-licensed terminal chat client built around Ollama (and other OpenAI-compatible backends): bare model names resolve across providers, `otaku list` / `otaku stop --all` manage loaded models across every configured server, it forwards `keep_alive` on load, supports `reasoning_effort` for thinking models, works as a Unix filter (`git diff | otaku llama3 "write a commit message"`), and stores chat history locally with AES-256-GCM encryption and full-content search. Python 3.11+, installable via `uv tool install otaku` or Homebrew. 30s demo GIF in the README.