### PR TITLE
docs: clarify Claude Code context limits

### DIFF
--- a/docs/integrations/claude-code.mdx
+++ b/docs/integrations/claude-code.mdx
@@ -103,12 +103,14 @@ Choose a model with enough context for your repository.
   </Card>
 
   <Card title="Local models" icon="hard-drive" href="https://ollama.com/search?c=tools">
-    Choose a model and set a 100k+ context window.
+    Choose a model and set a 64k+ context window.
   </Card>
 </CardGroup>
 
+<Note>For larger repositories, set the [context length](/context-length) to 64k or higher.</Note>
+
 <Note>
-  Set the [context length](/context-length) to 100k or higher. Claude Code currently uses up to 200k context through Ollama.
+  Claude Code supports up to a 200k token limit through Ollama.
 </Note>
 
 ## More features

--- a/docs/integrations/claude-code.mdx
+++ b/docs/integrations/claude-code.mdx
@@ -103,11 +103,13 @@ Choose a model with enough context for your repository.
   </Card>
 
   <Card title="Local models" icon="hard-drive" href="https://ollama.com/search?c=tools">
-    Choose a model and set a 64k+ context window.
+    Choose a model and set a 100k+ context window.
   </Card>
 </CardGroup>
 
-<Note>For larger repositories, set the [context length](/context-length) to 64k or higher.</Note>
+<Note>
+  Set the [context length](/context-length) to 100k or higher. Claude Code currently uses up to 200k context through Ollama.
+</Note>
 
 ## More features
 


### PR DESCRIPTION
## Summary

- Update Claude Code local model guidance from 64k+ to 100k+ context
- Add a short note that Claude Code currently uses up to 200k context through Ollama

## Testing

Docs-only change. I reviewed the rendered MDX source/diff locally; no docs validation config was present in this repo root.