### PR TITLE
launch: disable claude code telemetry

### DIFF
--- a/cmd/launch/claude.go
+++ b/cmd/launch/claude.go
@@ -60,17 +60,25 @@ func (c *Claude) Run(model string, _ []LaunchModel, args []string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	env := append(os.Environ(),
-		"ANTHROPIC_BASE_URL="+envconfig.Host().String(),
+	cmd.Env = append(os.Environ(), c.envVars(model)...)
+	return cmd.Run()
+}
+
+func (c *Claude) envVars(model string) []string {
+	env := []string{
+		"ANTHROPIC_BASE_URL=" + envconfig.Host().String(),
 		"ANTHROPIC_API_KEY=",
 		"ANTHROPIC_AUTH_TOKEN=ollama",
 		"CLAUDE_CODE_ATTRIBUTION_HEADER=0",
-	)
+		"DISABLE_TELEMETRY=1",
+		"DISABLE_ERROR_REPORTING=1",
+		"DISABLE_FEEDBACK_COMMAND=1",
+		"CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY=1",
+		"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1",
+	}
 
 	env = append(env, c.modelEnvVars(model)...)
-
-	cmd.Env = env
-	return cmd.Run()
+	return env
 }
 
 func ensureClaudeInstalled() (string, error) {

--- a/cmd/launch/claude_test.go
+++ b/cmd/launch/claude_test.go
@@ -8,6 +8,8 @@ import (
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/ollama/ollama/envconfig"
 )
 
 func TestClaudeIntegration(t *testing.T) {
@@ -329,6 +331,40 @@ func TestClaudeArgs(t *testing.T) {
 				t.Errorf("args(%q, %v) = %v, want %v", tt.model, tt.args, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestClaudeEnvVars(t *testing.T) {
+	c := &Claude{}
+
+	envMap := func(envs []string) map[string]string {
+		m := make(map[string]string)
+		for _, e := range envs {
+			k, v, _ := strings.Cut(e, "=")
+			m[k] = v
+		}
+		return m
+	}
+
+	got := envMap(c.envVars("llama3.2"))
+	for key, want := range map[string]string{
+		"ANTHROPIC_BASE_URL":                       envconfig.Host().String(),
+		"ANTHROPIC_API_KEY":                        "",
+		"ANTHROPIC_AUTH_TOKEN":                     "ollama",
+		"CLAUDE_CODE_ATTRIBUTION_HEADER":           "0",
+		"DISABLE_TELEMETRY":                        "1",
+		"DISABLE_ERROR_REPORTING":                  "1",
+		"DISABLE_FEEDBACK_COMMAND":                 "1",
+		"CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY":      "1",
+		"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+		"ANTHROPIC_DEFAULT_OPUS_MODEL":             "llama3.2",
+		"ANTHROPIC_DEFAULT_SONNET_MODEL":           "llama3.2",
+		"ANTHROPIC_DEFAULT_HAIKU_MODEL":            "llama3.2",
+		"CLAUDE_CODE_SUBAGENT_MODEL":               "llama3.2",
+	} {
+		if got[key] != want {
+			t.Errorf("%s = %q, want %q", key, got[key], want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- set Claude Code telemetry, error reporting, feedback, and nonessential traffic opt-out env vars when launched through `ollama launch claude`
- group Claude launch environment construction in a helper and cover the default env in tests

## Validation

- `go test ./cmd/launch`
- `env GOCACHE=/private/tmp/ollama-go-cache go build .`