### PR TITLE
docs: add Lynkr to Community Integrations (Libraries & SDKs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ console.log(response.message.content);
 ### Libraries & SDKs
 
 - [LiteLLM](https://github.com/BerriAI/litellm) - Unified API for 100+ LLM providers
+- [Lynkr](https://github.com/Fast-Editor/Lynkr) - Self-hosted gateway that routes AI coding tools (Claude Code, Cursor, Codex CLI) to Ollama by request complexity
 - [Semantic Kernel](https://github.com/microsoft/semantic-kernel/tree/main/python/semantic_kernel/connectors/ai/ollama) - Microsoft AI orchestration SDK
 - [LangChain4j](https://github.com/langchain4j/langchain4j) - Java LangChain ([example](https://github.com/langchain4j/langchain4j-examples/tree/main/ollama-examples/src/main/java))
 - [LangChainGo](https://github.com/tmc/langchaingo/) - Go LangChain ([example](https://github.com/tmc/langchaingo/tree/main/examples/ollama-completion-example))


### PR DESCRIPTION
Adds Lynkr to the Libraries & SDKs list.

Lynkr is an Apache-2.0 self-hosted gateway that uses Ollama as a first-class routing tier: it scores each request from AI coding tools (Claude Code, Cursor, Codex CLI, Cline, Continue) by complexity and routes simple/medium requests to local Ollama models, escalating only complex ones to cloud providers. It also compresses JSON tool outputs and adds semantic caching in front of Ollama.

- Repo: https://github.com/Fast-Editor/Lynkr (Apache-2.0)
- Quick start with Ollama: https://github.com/Fast-Editor/Lynkr#quick-start-2-minutes

Follows the existing entry format; placed after LiteLLM in Libraries & SDKs.