### PR TITLE
cmd: guard empty editor before indexing fields

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -653,9 +653,12 @@ func editInExternalEditor(content string) (string, error) {
 	}
 
 	// Check that the editor binary exists
-	name := strings.Fields(editor)[0]
-	if _, err := exec.LookPath(name); err != nil {
-		return "", fmt.Errorf("editor %q not found, set OLLAMA_EDITOR to the path of your preferred editor", name)
+	args := strings.Fields(editor)
+	if len(args) == 0 {
+		return "", fmt.Errorf("no editor configured, set OLLAMA_EDITOR to the path of your preferred editor")
+	}
+	if _, err := exec.LookPath(args[0]); err != nil {
+		return "", fmt.Errorf("editor %q not found, set OLLAMA_EDITOR to the path of your preferred editor", args[0])
 	}
 
 	tmpFile, err := os.CreateTemp("", "ollama-prompt-*.txt")
@@ -672,7 +675,6 @@ func editInExternalEditor(content string) (string, error) {
 	}
 	tmpFile.Close()
 
-	args := strings.Fields(editor)
 	args = append(args, tmpFile.Name())
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.Stdin = os.Stdin

--- a/cmd/interactive_test.go
+++ b/cmd/interactive_test.go
@@ -85,6 +85,39 @@ func TestExtractFileDataRemovesQuotedFilepath(t *testing.T) {
 	assert.Equal(t, cleaned, "before  after")
 }
 
+func TestEditInExternalEditorWhitespaceOnly(t *testing.T) {
+	// A whitespace-only VISUAL or EDITOR is non-empty, so it bypasses the
+	// editor == "" fallbacks, but strings.Fields collapses it to an empty
+	// slice. Indexing that slice must not panic; it must return an error.
+	cases := []struct {
+		name   string
+		visual string
+		editor string
+	}{
+		{name: "VISUAL whitespace", visual: "\t "},
+		{name: "EDITOR whitespace", editor: "\t "},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("OLLAMA_EDITOR", "")
+			t.Setenv("VISUAL", tt.visual)
+			t.Setenv("EDITOR", tt.editor)
+			_, err := editInExternalEditor("content")
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestEditInExternalEditorParsesEditorWithArgs(t *testing.T) {
+	// A well-formed editor command with arguments must still be parsed so
+	// its binary is looked up (guards the normal path from regressing).
+	t.Setenv("OLLAMA_EDITOR", "definitely-not-a-real-editor arg1")
+	t.Setenv("VISUAL", "")
+	t.Setenv("EDITOR", "")
+	_, err := editInExternalEditor("content")
+	assert.ErrorContains(t, err, "definitely-not-a-real-editor")
+}
+
 func TestExtractFileDataWAV(t *testing.T) {
 	dir := t.TempDir()
 	fp := filepath.Join(dir, "sample.wav")


### PR DESCRIPTION
Pressing Ctrl+G in the `ollama run` REPL opens the current prompt in an external
editor. If `OLLAMA_EDITOR` is unset and `VISUAL` (or `EDITOR`) is set to a
non-empty but whitespace-only value, the client panics and the whole `ollama run`
session crashes:

```
panic: runtime error: index out of range [0] with length 0
```

### Cause

`editInExternalEditor` (`cmd/interactive.go`) resolves the editor through three
`editor == ""` fallbacks (`OLLAMA_EDITOR` -> `VISUAL` -> `EDITOR` -> the default),
then takes the binary name with `strings.Fields(editor)[0]`.

`OLLAMA_EDITOR` is read through `envconfig.Editor()`, which trims the value, so a
whitespace-only `OLLAMA_EDITOR` collapses to `""` and safely falls through to the
default. But `VISUAL` and `EDITOR` are read with raw `os.Getenv`, so a value like
`"\t "` is non-empty and skips all three `== ""` guards. `strings.Fields` on an
all-whitespace string returns an empty slice, and indexing `[0]` panics. There is
no `recover` around the caller, so the panic takes down the client.

### Fix

Split the resolved editor into fields once and guard the result before indexing:

```go
args := strings.Fields(editor)
if len(args) == 0 {
    return "", fmt.Errorf("no editor configured, set OLLAMA_EDITOR to the path of your preferred editor")
}
```

The caller already prints a returned error to stderr and continues the REPL, so
instead of crashing, the user now sees a clear message and the session keeps
running. The same `args` slice is reused for the later `exec.Command`, which also
removes a redundant second `strings.Fields(editor)` call. The valid-editor path
and its `editor %q not found` message are unchanged.

### Tests

`cmd/interactive_test.go`:

- `TestEditInExternalEditorWhitespaceOnly` (table-driven: `VISUAL` and `EDITOR`
  each whitespace-only) asserts an error and no panic. Without the guard this test
  panics with the exact `index out of range [0] with length 0`; with the guard it
  passes.
- `TestEditInExternalEditorParsesEditorWithArgs` asserts a well-formed editor
  command with arguments is still parsed and its binary looked up, guarding the
  normal path from regressing.

`go test ./cmd/`, `gofmt -l`, and `go vet ./cmd/` are clean.
