### PR TITLE
docs: add NULLA under Community Integrations (Frameworks & Agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ console.log(response.message.content);
 - [Stakpak](https://github.com/stakpak/agent) - Open source DevOps agent
 - [Hexabot](https://github.com/hexastack/hexabot) - Conversational AI builder
 - [Neuro SAN](https://github.com/cognizant-ai-lab/neuro-san-studio) - Multi-agent orchestration ([docs](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/user_guide.md#ollama))
+- [NULLA](https://github.com/Parad0x-Labs/nulla-local) - Local-first, private agent with offline-verifiable action receipts
 
 ### RAG & Knowledge Bases
 


### PR DESCRIPTION
Adds NULLA under Community Integrations -> Frameworks & Agents.

NULLA is a local-first AI agent built on Ollama. It runs fully on the user's machine and signs an offline-verifiable receipt of each action (what it claimed vs. what actually ran). MIT-licensed, Alpha.

Repo: https://github.com/Parad0x-Labs/nulla-local
