### PR TITLE
docs: Add ContextWardenKit to community tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ console.log(response.message.content);
 - [Langfuse](https://langfuse.com/docs/integrations/ollama) - Open source LLM observability
 - [HoneyHive](https://docs.honeyhive.ai/integrations/ollama) - AI observability and evaluation for agents
 - [MLflow Tracing](https://mlflow.org/docs/latest/llms/tracing/index.html#automatic-tracing) - Open source LLM observability
+- [ContextWardenKit](https://github.com/noushadkabeer/ContextWardenKit) - Native Apple Silicon memory monitoring framework for Swift
 
 ### Database & Embeddings
 


### PR DESCRIPTION
Adds ContextWardenKit, an open-source macOS native monitoring framework for accurately profiling Ollama unified memory footprints on Apple Silicon, to the community integrations list.