### PR TITLE
docs: remove amd-only /dev/kfd from vulkan docker command

### DIFF
--- a/docs/docker.mdx
+++ b/docs/docker.mdx
@@ -73,8 +73,11 @@ docker run -d --device /dev/kfd --device /dev/dri -v ollama:/root/.ollama -p 114
 Vulkan is bundled into the `ollama/ollama` image and is enabled by default when
 the container can access the GPU devices.
 
+Vulkan needs the GPU render nodes at `/dev/dri`. Unlike the AMD ROCm command
+above, it does not need `/dev/kfd`, which is not present for Intel GPUs.
+
 ```shell
-docker run -d --device /dev/kfd --device /dev/dri -v ollama:/root/.ollama -p 11434:11434 --name ollama ollama/ollama
+docker run -d --device /dev/dri -v ollama:/root/.ollama -p 11434:11434 --name ollama ollama/ollama
 ```
 
 Use `OLLAMA_VULKAN=0` to disable Vulkan, or `GGML_VK_VISIBLE_DEVICES=<ids>` to


### PR DESCRIPTION
The `## Vulkan Support` example in `docs/docker.mdx` passes `--device /dev/kfd`, which is the AMD ROCm device node. It does not exist on Intel GPUs, so the documented command fails on exactly the Intel iGPU + Vulkan setup the section is meant to cover (reported in #13130).

Vulkan accesses the GPU through the DRM render nodes at `/dev/dri`; `/dev/kfd` is only needed by the ROCm backend documented in the AMD GPU section above. This drops the AMD-only device from the Vulkan command and adds a one-line note clarifying the device requirement.

Closes #13130

🤖 Generated with [Claude Code](https://claude.com/claude-code)
