### PR TITLE
mlxrunner: MTP follow-up fixes and tuning

### DIFF
--- a/x/mlxrunner/cache/recurrent.go
+++ b/x/mlxrunner/cache/recurrent.go
@@ -40,7 +40,7 @@ type RecurrentCache struct {
 func (c *RecurrentCache) PrepareSnapshots(offsets []int) {
 	c.snapshots.prepare(c.offset, offsets)
 	// The current offset is a valid boundary right now, so capture it.
-	c.captureBoundary(c.offset)
+	c.captureBoundary(c.offset, c.convState, c.deltaState)
 }
 
 func (c *RecurrentCache) TakeSnapshots() []Snapshot { return c.snapshots.take() }
@@ -62,32 +62,23 @@ func (c *RecurrentCache) SnapshotSplits(forwardLen int) []int {
 	return splits
 }
 
-func (c *RecurrentCache) captureBoundary(reached int) {
-	c.snapshots.captureReached(reached, func(int) Snapshot { return c.Snapshot(reached) })
-}
-
-// captureBoundaryState captures a scheduled interior offset from the
-// per-boundary conv/delta states the kernel wrappers produced while segmenting,
-// rather than from the cache's current (end-of-forward) state.
-func (c *RecurrentCache) captureBoundaryState(reached int, conv, delta *mlx.Array) {
+// captureBoundary snapshots the boundary state (conv, delta) at reached if
+// reached is a scheduled offset — the live state at a forward boundary, or a
+// kernel segment state at an interior split.
+func (c *RecurrentCache) captureBoundary(reached int, conv, delta *mlx.Array) {
 	c.snapshots.captureReached(reached, func(int) Snapshot {
+		// Nothing exists to page out yet; a zero-width capture is a nil entry.
+		if conv == nil && delta == nil {
+			return nil
+		}
 		return newRecurrentSnapshot(conv, delta, reached)
 	})
 }
 
-func (c *RecurrentCache) setState(old, v *mlx.Array, contiguous bool) *mlx.Array {
-	if v == nil || !v.Valid() {
-		return old
-	}
-
-	if contiguous {
-		v = mlx.Contiguous(v, false)
-	}
+func (c *RecurrentCache) setState(old, v *mlx.Array) *mlx.Array {
 	v = v.Clone()
-
 	mlx.Pin(v)
 	mlx.Unpin(old)
-
 	return v
 }
 
@@ -123,8 +114,8 @@ func (c *RecurrentCache) Get(b *batch.Batch, dtype mlx.DType) *nn.RecurrentHisto
 		return nn.NewRecurrentHistory(c.convState, c.deltaState)
 	}
 
-	c.convState = c.setState(nil, mlx.Zeros(dtype, batch, c.convTail, c.convDim), false)
-	c.deltaState = c.setState(nil, mlx.Zeros(mlx.DTypeFloat32, batch, c.numVHeads, c.headVDim, c.headKDim), false)
+	c.convState = c.setState(nil, mlx.Zeros(dtype, batch, c.convTail, c.convDim))
+	c.deltaState = c.setState(nil, mlx.Zeros(mlx.DTypeFloat32, batch, c.numVHeads, c.headVDim, c.headKDim))
 	return nn.NewRecurrentHistory(c.convState, c.deltaState)
 }
 
@@ -154,19 +145,29 @@ func (c *RecurrentCache) Put(b *batch.Batch, convStates, deltaStates []*mlx.Arra
 	// Leading entries are the interior split boundaries; capture each as a
 	// snapshot at its scheduled offset.
 	for i, s := range splits {
-		c.captureBoundaryState(start+s, convStates[i], deltaStates[i])
+		c.captureBoundary(start+s, convStates[i], deltaStates[i])
 	}
 
 	// The final entry is the forward-end state — the committed live state.
 	last := len(convStates) - 1
-	c.convState = c.setState(c.convState, convStates[last], true)
-	c.deltaState = c.setState(c.deltaState, deltaStates[last], false)
+	c.convState = c.setState(c.convState, convStates[last])
+	c.deltaState = c.setState(c.deltaState, deltaStates[last])
 	c.offset += int(b.SeqQueryLens[0])
-	c.captureBoundary(c.offset)
+	c.captureBoundary(c.offset, c.convState, c.deltaState)
 }
 
 func (c *RecurrentCache) State() []*mlx.Array {
-	return []*mlx.Array{c.convState, c.deltaState}
+	state := []*mlx.Array{c.convState, c.deltaState}
+	// Captured snapshots own compact copies still needing eval; fold them into
+	// the caller's batched State eval instead of an async eval per snapshot per
+	// layer. They drain at TakeSnapshots.
+	for _, s := range c.snapshots.captured {
+		if s != nil {
+			rs := s.(*recurrentSnapshot)
+			state = append(state, rs.convState, rs.deltaState)
+		}
+	}
+	return state
 }
 
 // recurrentSnapshot holds paged-out recurrent state. Self-contained —
@@ -179,13 +180,13 @@ type recurrentSnapshot struct {
 func (s *recurrentSnapshot) Size() int { return s.convState.NumBytes() + s.deltaState.NumBytes() }
 func (s *recurrentSnapshot) Close()    { mlx.Unpin(s.convState, s.deltaState) }
 
-// SetMaterializeHook is a no-op: recurrent snapshots are always materialized
-// at construction.
+// SetMaterializeHook is a no-op: recurrent snapshots own their compact copy from
+// construction.
 func (s *recurrentSnapshot) SetMaterializeHook(func(int)) {}
 
 // newRecurrentSnapshot clones and pins conv/delta into an owned snapshot at
-// offset. Recurrent state is not position-sliceable, so a snapshot always owns
-// a full copy.
+// offset. It does not schedule the eval — capture-path snapshots ride the
+// cache's State into the caller's batched eval.
 func newRecurrentSnapshot(conv, delta *mlx.Array, offset int) *recurrentSnapshot {
 	snap := &recurrentSnapshot{
 		convState:  conv.Clone(),
@@ -202,7 +203,11 @@ func (c *RecurrentCache) Snapshot(fromOffset int) Snapshot {
 		return nil
 	}
 
-	return newRecurrentSnapshot(c.convState, c.deltaState, c.offset)
+	// Page-out snapshots go straight to the trie and never ride State, so
+	// schedule the eval here instead of through the batched State eval.
+	snap := newRecurrentSnapshot(c.convState, c.deltaState, c.offset)
+	mlx.AsyncEval(snap.convState, snap.deltaState)
+	return snap
 }
 
 func (c *RecurrentCache) Restore(snapshot Snapshot, target int) bool {
@@ -221,8 +226,8 @@ func (c *RecurrentCache) Restore(snapshot Snapshot, target int) bool {
 		return false
 	}
 
-	c.convState = c.setState(c.convState, snap.convState, false)
-	c.deltaState = c.setState(c.deltaState, snap.deltaState, false)
+	c.convState = c.setState(c.convState, snap.convState)
+	c.deltaState = c.setState(c.deltaState, snap.deltaState)
 	c.offset = snap.offset
 
 	return true

--- a/x/mlxrunner/cache/recurrent_test.go
+++ b/x/mlxrunner/cache/recurrent_test.go
@@ -152,6 +152,9 @@ func TestRecurrentCachePaddedRoundTrip(t *testing.T) {
 		return mlx.FromValues(vals, convDim, convTail+1)
 	}
 	weight := mkWeight(0.2)
+	// Build the depthwise causal Conv1d as the model does at load time: the
+	// [C, K] kernel becomes [C, K, 1] and the conv is grouped per channel.
+	conv := nn.NewConv1d(mlx.ExpandDims(weight, 2), nil, 1, 0, 1, convDim)
 
 	runForward := func(c *RecurrentCache, b *batch.Batch, T int) (*mlx.Array, *mlx.Array) {
 		var convInput *mlx.Array
@@ -164,7 +167,7 @@ func TestRecurrentCachePaddedRoundTrip(t *testing.T) {
 		}
 
 		history := c.Get(b, mlx.DTypeFloat32)
-		_, convStates := nn.CausalConv1D(b, convInput, nil, weight, convTail,
+		_, convStates := nn.CausalConv1D(b, convInput, conv, convTail,
 			nn.WithRecurrentHistory(history))
 
 		var q, k, v, g, beta *mlx.Array

--- a/x/mlxrunner/cache_trie.go
+++ b/x/mlxrunner/cache_trie.go
@@ -8,12 +8,15 @@ import (
 	"github.com/ollama/ollama/x/mlxrunner/cache"
 )
 
+// trieKey encodes a token for trie matching (see prefixCache.key).
+type trieKey int64
+
 // trieNode represents a node in the compressed prefix trie for cache branching.
 // Each node stores a compressed edge (multiple tokens) and optional paged-out
 // snapshot data per cache layer.
 type trieNode struct {
-	tokens    []int32 // compressed edge — multiple tokens per node
-	endOffset int     // cumulative tokens from root to end of this node
+	tokens    []trieKey // compressed edge — multiple tokens per node
+	endOffset int       // cumulative tokens from root to end of this node
 	parent    *trieNode
 	children  []*trieNode
 	lastUsed  time.Time        // for LRU eviction
@@ -88,7 +91,7 @@ func (n *trieNode) hasAllSnapshots() bool {
 
 // findBestMatch walks the trie matching input tokens, returning the path of
 // nodes traversed and the total number of tokens matched.
-func findBestMatch(root *trieNode, tokens []int32) (path []*trieNode, matched int) {
+func findBestMatch(root *trieNode, tokens []trieKey) (path []*trieNode, matched int) {
 	if root == nil {
 		return nil, 0
 	}
@@ -145,10 +148,10 @@ func findBestMatch(root *trieNode, tokens []int32) (path []*trieNode, matched in
 
 // appendTokens either creates a new child node or extends the leaf in place,
 // returning the node that now holds the tokens.
-func (n *trieNode) appendTokens(root *trieNode, tokens []int32, endOffset int) *trieNode {
+func (n *trieNode) appendTokens(root *trieNode, tokens []trieKey, endOffset int) *trieNode {
 	if n == root || len(n.children) > 0 || n.hasSnapshots() {
 		child := &trieNode{
-			tokens:    make([]int32, len(tokens)),
+			tokens:    make([]trieKey, len(tokens)),
 			endOffset: endOffset,
 			parent:    n,
 			lastUsed:  n.lastUsed,
@@ -193,7 +196,7 @@ func splitNode(node *trieNode, at int, caches []cache.Cache, counter *int64) *tr
 
 	// Create new parent with the prefix of the edge.
 	newParent := &trieNode{
-		tokens:    make([]int32, at),
+		tokens:    make([]trieKey, at),
 		endOffset: node.startOffset() + at,
 		parent:    node.parent,
 		children:  []*trieNode{node},

--- a/x/mlxrunner/cache_trie.go
+++ b/x/mlxrunner/cache_trie.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ollama/ollama/x/mlxrunner/cache"
 )
 
-// trieNode represents a node in the compressed prefix trie for KV cache branching.
+// trieNode represents a node in the compressed prefix trie for cache branching.
 // Each node stores a compressed edge (multiple tokens) and optional paged-out
 // snapshot data per cache layer.
 type trieNode struct {

--- a/x/mlxrunner/cache_trie_test.go
+++ b/x/mlxrunner/cache_trie_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ollama/ollama/x/mlxrunner/cache"
 )
 
-func newTestTrie(tokens []int32) *trieNode {
+func newTestTrie(tokens []trieKey) *trieNode {
 	root := &trieNode{lastUsed: time.Now()}
 	if len(tokens) > 0 {
 		child := &trieNode{
@@ -26,13 +26,13 @@ func TestFindBestMatchMultipleBranches(t *testing.T) {
 	root := &trieNode{lastUsed: time.Now()}
 
 	branch1 := &trieNode{
-		tokens:    []int32{1, 2, 3},
+		tokens:    []trieKey{1, 2, 3},
 		endOffset: 3,
 		parent:    root,
 		lastUsed:  time.Now(),
 	}
 	branch2 := &trieNode{
-		tokens:    []int32{4, 5, 6},
+		tokens:    []trieKey{4, 5, 6},
 		endOffset: 3,
 		parent:    root,
 		lastUsed:  time.Now(),
@@ -40,7 +40,7 @@ func TestFindBestMatchMultipleBranches(t *testing.T) {
 	root.children = []*trieNode{branch1, branch2}
 
 	// Match branch 1.
-	path, matched := findBestMatch(root, []int32{1, 2, 3, 7})
+	path, matched := findBestMatch(root, []trieKey{1, 2, 3, 7})
 	if matched != 3 {
 		t.Fatalf("expected 3 matched, got %d", matched)
 	}
@@ -49,7 +49,7 @@ func TestFindBestMatchMultipleBranches(t *testing.T) {
 	}
 
 	// Match branch 2.
-	path, matched = findBestMatch(root, []int32{4, 5, 6, 8})
+	path, matched = findBestMatch(root, []trieKey{4, 5, 6, 8})
 	if matched != 3 {
 		t.Fatalf("expected 3 matched, got %d", matched)
 	}
@@ -58,7 +58,7 @@ func TestFindBestMatchMultipleBranches(t *testing.T) {
 	}
 
 	// Match neither.
-	_, matched = findBestMatch(root, []int32{7, 8, 9})
+	_, matched = findBestMatch(root, []trieKey{7, 8, 9})
 	if matched != 0 {
 		t.Fatalf("expected 0 matched, got %d", matched)
 	}
@@ -68,7 +68,7 @@ func TestFindBestMatchPrefersFullEdge(t *testing.T) {
 	root := &trieNode{lastUsed: time.Now()}
 
 	shared := &trieNode{
-		tokens:    []int32{1, 2, 3},
+		tokens:    []trieKey{1, 2, 3},
 		endOffset: 3,
 		parent:    root,
 		lastUsed:  time.Now(),
@@ -76,13 +76,13 @@ func TestFindBestMatchPrefersFullEdge(t *testing.T) {
 	root.children = []*trieNode{shared}
 
 	longer := &trieNode{
-		tokens:    []int32{10, 11, 12, 13, 14},
+		tokens:    []trieKey{10, 11, 12, 13, 14},
 		endOffset: 8,
 		parent:    shared,
 		lastUsed:  time.Now(),
 	}
 	shorter := &trieNode{
-		tokens:    []int32{10, 11, 12},
+		tokens:    []trieKey{10, 11, 12},
 		endOffset: 6,
 		parent:    shared,
 		lastUsed:  time.Now(),
@@ -90,7 +90,7 @@ func TestFindBestMatchPrefersFullEdge(t *testing.T) {
 	// Put longer first so naive first-match would pick it.
 	shared.children = []*trieNode{longer, shorter}
 
-	input := []int32{1, 2, 3, 10, 11, 12, 99, 100}
+	input := []trieKey{1, 2, 3, 10, 11, 12, 99, 100}
 	path, matched := findBestMatch(root, input)
 
 	if matched != 6 {
@@ -108,20 +108,20 @@ func TestFindBestMatchPrefersLongerPartial(t *testing.T) {
 	root := &trieNode{lastUsed: time.Now()}
 
 	child1 := &trieNode{
-		tokens:    []int32{1, 2, 3, 4, 5},
+		tokens:    []trieKey{1, 2, 3, 4, 5},
 		endOffset: 5,
 		parent:    root,
 		lastUsed:  time.Now(),
 	}
 	child2 := &trieNode{
-		tokens:    []int32{1, 2, 9},
+		tokens:    []trieKey{1, 2, 9},
 		endOffset: 3,
 		parent:    root,
 		lastUsed:  time.Now(),
 	}
 	root.children = []*trieNode{child2, child1}
 
-	input := []int32{1, 2, 3, 7, 8}
+	input := []trieKey{1, 2, 3, 7, 8}
 	path, matched := findBestMatch(root, input)
 
 	if matched != 3 {
@@ -133,7 +133,7 @@ func TestFindBestMatchPrefersLongerPartial(t *testing.T) {
 }
 
 func TestSplitNodeWithSnapshots(t *testing.T) {
-	root := newTestTrie([]int32{1, 2, 3, 4, 5})
+	root := newTestTrie([]trieKey{1, 2, 3, 4, 5})
 	child := root.children[0]
 
 	rc := &fakeRewindableCache{tracker: &snapshotTracker{}, tokens: []int32{1, 2, 3, 4, 5}}
@@ -159,9 +159,9 @@ func TestSplitNodeWithSnapshots(t *testing.T) {
 }
 
 func TestFindSplitAppendSequence(t *testing.T) {
-	root := newTestTrie([]int32{1, 2, 3, 4, 5})
+	root := newTestTrie([]trieKey{1, 2, 3, 4, 5})
 
-	path, matched := findBestMatch(root, []int32{1, 2, 3, 6, 7})
+	path, matched := findBestMatch(root, []trieKey{1, 2, 3, 6, 7})
 	if matched != 3 {
 		t.Fatalf("expected 3 matched, got %d", matched)
 	}
@@ -170,28 +170,28 @@ func TestFindSplitAppendSequence(t *testing.T) {
 	matchedInEdge := matched - lastNode.startOffset()
 	split := splitNode(lastNode, matchedInEdge, nil, nil)
 
-	split.appendTokens(root, []int32{6, 7}, 5)
+	split.appendTokens(root, []trieKey{6, 7}, 5)
 
 	if len(root.children) != 1 {
 		t.Fatalf("root should have 1 child, got %d", len(root.children))
 	}
 	shared := root.children[0]
-	if !slices.Equal(shared.tokens, []int32{1, 2, 3}) {
+	if !slices.Equal(shared.tokens, []trieKey{1, 2, 3}) {
 		t.Fatalf("shared tokens = %v, want [1,2,3]", shared.tokens)
 	}
 	if len(shared.children) != 2 {
 		t.Fatalf("shared should have 2 children, got %d", len(shared.children))
 	}
 
-	_, m1 := findBestMatch(root, []int32{1, 2, 3, 4, 5})
+	_, m1 := findBestMatch(root, []trieKey{1, 2, 3, 4, 5})
 	if m1 != 5 {
 		t.Fatalf("original branch: expected 5 matched, got %d", m1)
 	}
-	_, m2 := findBestMatch(root, []int32{1, 2, 3, 6, 7})
+	_, m2 := findBestMatch(root, []trieKey{1, 2, 3, 6, 7})
 	if m2 != 5 {
 		t.Fatalf("new branch: expected 5 matched, got %d", m2)
 	}
-	_, m3 := findBestMatch(root, []int32{1, 2, 3, 9, 9})
+	_, m3 := findBestMatch(root, []trieKey{1, 2, 3, 9, 9})
 	if m3 != 3 {
 		t.Fatalf("unrelated input: expected 3 matched, got %d", m3)
 	}
@@ -200,32 +200,32 @@ func TestFindSplitAppendSequence(t *testing.T) {
 func TestRepeatedBranching(t *testing.T) {
 	root := &trieNode{lastUsed: time.Now()}
 
-	root.appendTokens(root, []int32{1, 2, 3, 4, 5}, 5)
+	root.appendTokens(root, []trieKey{1, 2, 3, 4, 5}, 5)
 
-	_, matchedB := findBestMatch(root, []int32{1, 2, 3, 6, 7})
+	_, matchedB := findBestMatch(root, []trieKey{1, 2, 3, 6, 7})
 	if matchedB != 3 {
 		t.Fatalf("B: expected 3 matched, got %d", matchedB)
 	}
 	nodeA := root.children[0]
 	split1 := splitNode(nodeA, 3, nil, nil)
-	split1.appendTokens(root, []int32{6, 7}, 5)
+	split1.appendTokens(root, []trieKey{6, 7}, 5)
 
-	_, matchedC := findBestMatch(root, []int32{1, 2, 8, 9})
+	_, matchedC := findBestMatch(root, []trieKey{1, 2, 8, 9})
 	if matchedC != 2 {
 		t.Fatalf("C: expected 2 matched, got %d", matchedC)
 	}
 	split2 := splitNode(split1, 2, nil, nil)
-	split2.appendTokens(root, []int32{8, 9}, 4)
+	split2.appendTokens(root, []trieKey{8, 9}, 4)
 
-	_, mA := findBestMatch(root, []int32{1, 2, 3, 4, 5})
+	_, mA := findBestMatch(root, []trieKey{1, 2, 3, 4, 5})
 	if mA != 5 {
 		t.Fatalf("A: expected 5 matched, got %d", mA)
 	}
-	_, mB := findBestMatch(root, []int32{1, 2, 3, 6, 7})
+	_, mB := findBestMatch(root, []trieKey{1, 2, 3, 6, 7})
 	if mB != 5 {
 		t.Fatalf("B: expected 5 matched, got %d", mB)
 	}
-	_, mC := findBestMatch(root, []int32{1, 2, 8, 9})
+	_, mC := findBestMatch(root, []trieKey{1, 2, 8, 9})
 	if mC != 4 {
 		t.Fatalf("C: expected 4 matched, got %d", mC)
 	}
@@ -239,21 +239,21 @@ func TestMergeWithChild(t *testing.T) {
 		now := time.Now()
 		root := &trieNode{lastUsed: now}
 		a := &trieNode{
-			tokens:    []int32{1, 2, 3},
+			tokens:    []trieKey{1, 2, 3},
 			endOffset: 3,
 			parent:    root,
 			lastUsed:  now,
 			snapshots: []cache.Snapshot{&fakeSnapshot{tokens: []int32{1, 2, 3}, from: 0, to: 3}},
 		}
 		b := &trieNode{
-			tokens:    []int32{4, 5},
+			tokens:    []trieKey{4, 5},
 			endOffset: 5,
 			parent:    a,
 			lastUsed:  now,
 			snapshots: []cache.Snapshot{&fakeSnapshot{tokens: []int32{4, 5}, from: 3, to: 5}},
 		}
-		c := &trieNode{tokens: []int32{6}, endOffset: 6, parent: b, lastUsed: now}
-		d := &trieNode{tokens: []int32{7}, endOffset: 6, parent: b, lastUsed: now}
+		c := &trieNode{tokens: []trieKey{6}, endOffset: 6, parent: b, lastUsed: now}
+		d := &trieNode{tokens: []trieKey{7}, endOffset: 6, parent: b, lastUsed: now}
 		root.children = []*trieNode{a}
 		a.children = []*trieNode{b}
 		b.children = []*trieNode{c, d}
@@ -262,7 +262,7 @@ func TestMergeWithChild(t *testing.T) {
 		mergeWithChild(a, []cache.Cache{mc}, nil)
 
 		// Tokens concatenated.
-		if !slices.Equal(a.tokens, []int32{1, 2, 3, 4, 5}) {
+		if !slices.Equal(a.tokens, []trieKey{1, 2, 3, 4, 5}) {
 			t.Fatalf("merged tokens = %v, want [1,2,3,4,5]", a.tokens)
 		}
 		if a.endOffset != 5 {
@@ -294,11 +294,11 @@ func TestMergeWithChild(t *testing.T) {
 	t.Run("UserFlag", func(t *testing.T) {
 		root := &trieNode{lastUsed: time.Now()}
 		parent := &trieNode{
-			tokens: []int32{1, 2}, endOffset: 2, parent: root,
+			tokens: []trieKey{1, 2}, endOffset: 2, parent: root,
 			lastUsed: time.Now(), user: false,
 		}
 		child := &trieNode{
-			tokens: []int32{3, 4}, endOffset: 4, parent: parent,
+			tokens: []trieKey{3, 4}, endOffset: 4, parent: parent,
 			lastUsed: time.Now(), user: true,
 		}
 		root.children = []*trieNode{parent}
@@ -315,11 +315,11 @@ func TestMergeWithChild(t *testing.T) {
 		now := time.Now()
 		root := &trieNode{lastUsed: now}
 		parent := &trieNode{
-			tokens: []int32{1}, endOffset: 1, parent: root,
+			tokens: []trieKey{1}, endOffset: 1, parent: root,
 			lastUsed: now.Add(-1 * time.Hour),
 		}
 		child := &trieNode{
-			tokens: []int32{2}, endOffset: 2, parent: parent,
+			tokens: []trieKey{2}, endOffset: 2, parent: parent,
 			lastUsed: now.Add(1 * time.Hour),
 		}
 		root.children = []*trieNode{parent}
@@ -340,10 +340,10 @@ func TestMergeWithChild(t *testing.T) {
 		}()
 		root := &trieNode{lastUsed: time.Now()}
 		node := &trieNode{
-			tokens: []int32{1}, endOffset: 1, parent: root, lastUsed: time.Now(),
+			tokens: []trieKey{1}, endOffset: 1, parent: root, lastUsed: time.Now(),
 			children: []*trieNode{
-				{tokens: []int32{2}, endOffset: 2, lastUsed: time.Now()},
-				{tokens: []int32{3}, endOffset: 2, lastUsed: time.Now()},
+				{tokens: []trieKey{2}, endOffset: 2, lastUsed: time.Now()},
+				{tokens: []trieKey{3}, endOffset: 2, lastUsed: time.Now()},
 			},
 		}
 		root.children = []*trieNode{node}
@@ -354,7 +354,7 @@ func TestMergeWithChild(t *testing.T) {
 func TestSplitMergeRoundTrip(t *testing.T) {
 	root := &trieNode{lastUsed: time.Now()}
 	leaf := &trieNode{
-		tokens:    []int32{1, 2, 3, 4, 5},
+		tokens:    []trieKey{1, 2, 3, 4, 5},
 		endOffset: 5,
 		parent:    root,
 		lastUsed:  time.Now(),
@@ -367,17 +367,17 @@ func TestSplitMergeRoundTrip(t *testing.T) {
 
 	// Split at 3: [1,2,3] -> [4,5]
 	newParent := splitNode(leaf, 3, caches, nil)
-	if !slices.Equal(newParent.tokens, []int32{1, 2, 3}) {
+	if !slices.Equal(newParent.tokens, []trieKey{1, 2, 3}) {
 		t.Fatalf("after split: parent tokens = %v, want [1,2,3]", newParent.tokens)
 	}
-	if !slices.Equal(leaf.tokens, []int32{4, 5}) {
+	if !slices.Equal(leaf.tokens, []trieKey{4, 5}) {
 		t.Fatalf("after split: child tokens = %v, want [4,5]", leaf.tokens)
 	}
 	checkTrieInvariants(t, root)
 
 	// Merge back: should restore [1,2,3,4,5]
 	mergeWithChild(newParent, caches, nil)
-	if !slices.Equal(newParent.tokens, []int32{1, 2, 3, 4, 5}) {
+	if !slices.Equal(newParent.tokens, []trieKey{1, 2, 3, 4, 5}) {
 		t.Fatalf("after merge: tokens = %v, want [1,2,3,4,5]", newParent.tokens)
 	}
 	if newParent.endOffset != 5 {
@@ -402,14 +402,14 @@ func TestRemoveNode(t *testing.T) {
 	t.Run("Leaf", func(t *testing.T) {
 		root := &trieNode{lastUsed: time.Now()}
 		shared := &trieNode{
-			tokens: []int32{1, 2, 3}, endOffset: 3, parent: root, lastUsed: time.Now(),
+			tokens: []trieKey{1, 2, 3}, endOffset: 3, parent: root, lastUsed: time.Now(),
 		}
 		leafA := &trieNode{
-			tokens: []int32{4, 5}, endOffset: 5, parent: shared, lastUsed: time.Now(),
+			tokens: []trieKey{4, 5}, endOffset: 5, parent: shared, lastUsed: time.Now(),
 			snapshots: []cache.Snapshot{&fakeSnapshot{from: 3, to: 5}},
 		}
 		leafB := &trieNode{
-			tokens: []int32{6, 7}, endOffset: 5, parent: shared, lastUsed: time.Now(),
+			tokens: []trieKey{6, 7}, endOffset: 5, parent: shared, lastUsed: time.Now(),
 			snapshots: []cache.Snapshot{&fakeSnapshot{from: 3, to: 5}},
 		}
 		root.children = []*trieNode{shared}

--- a/x/mlxrunner/mtp.go
+++ b/x/mlxrunner/mtp.go
@@ -13,12 +13,35 @@ import (
 // regardless of what else triggers a flush.
 const mtpPendingFlushTokens = 32
 
-// mtpDrafter drafts with a model's multi-token-prediction head, fed through
-// the committed-stream reports. The draft KV pairs each slot S with the
-// look-ahead token at S+1 fused with the target hidden at S, so a pair
-// completes only when the next token arrives.
+// mtpDrafter drafts with a model's multi-token-prediction head. Constructed
+// at load, it opens each request's drafting session.
 type mtpDrafter struct {
 	spec *speculation
+}
+
+func newMTPDrafter(s *speculation) *mtpDrafter {
+	return &mtpDrafter{spec: s}
+}
+
+// open returns the drafting session for one request, its pairing frontier
+// synced to the draft caches' restored offset.
+func (d *mtpDrafter) open() *mtpDraftSession {
+	s := &mtpDraftSession{drafter: d}
+	if kv := d.spec.draftKV; len(kv) > 0 {
+		// A restored prefix arrives with the draft caches already written;
+		// pairing resumes from their absolute offset.
+		s.committedDraftOffset = kv[0].Offset()
+		s.frontier = s.committedDraftOffset
+	}
+	return s
+}
+
+// mtpDraftSession runs one request's drafting, fed through the
+// committed-stream reports. The draft KV pairs each slot S with the
+// look-ahead token at S+1 fused with the target hidden at S, so a pair
+// completes only when the next token arrives.
+type mtpDraftSession struct {
+	drafter *mtpDrafter
 
 	// frontier is the slot after the last reported token; frontierHidden is
 	// the pinned target hidden at frontier-1, fused into the next pair.
@@ -41,22 +64,9 @@ type mtpDrafter struct {
 	heldProjected *mlx.Array
 }
 
-// newMTPDrafter returns the MTP drafter cursor for this request, syncing its
-// pairing frontier to the draft caches' restored offset.
-func newMTPDrafter(s *speculation) *mtpDrafter {
-	d := &mtpDrafter{spec: s}
-	if len(s.draftKV) > 0 {
-		// A restored prefix arrives with the draft caches already written;
-		// pairing resumes from their absolute offset.
-		d.committedDraftOffset = s.draftKV[0].Offset()
-		d.frontier = d.committedDraftOffset
-	}
-	return d
-}
-
-func (d *mtpDrafter) committed(tokens, hiddens *mlx.Array, position int) {
+func (d *mtpDraftSession) committed(tokens, hiddens *mlx.Array, position int) {
 	n := tokens.Dim(1)
-	if len(d.spec.draftKV) > 0 {
+	if len(d.drafter.spec.draftKV) > 0 {
 		// The pair at slot S fuses token[S+1] with hidden[S], so a run pairs its
 		// tokens with its own hiddens shifted one slot back: the first writable
 		// token takes the carried frontier hidden, each later token the row
@@ -96,22 +106,22 @@ func (d *mtpDrafter) committed(tokens, hiddens *mlx.Array, position int) {
 // same rather than level here. Regenerating hidden[S] to re-pair the boundary
 // on the next request is a separate, re-prefill-bound concern for recurrent
 // targets.
-func (d *mtpDrafter) finish(current *mlx.Array) {
-	if len(d.spec.draftKV) == 0 {
+func (d *mtpDraftSession) finish(current *mlx.Array) {
+	if len(d.drafter.spec.draftKV) == 0 {
 		return
 	}
 	d.settle(current)
 }
 
 // settle completes any open frontier pair with current, then flushes.
-func (d *mtpDrafter) settle(current *mlx.Array) {
+func (d *mtpDraftSession) settle(current *mlx.Array) {
 	if d.frontierHidden != nil && d.frontier-1 == d.committedDraftOffset+d.pendingCount {
 		d.queueCacheWrites(current.ExpandDims(-1), d.frontierHidden)
 	}
 	d.flush()
 }
 
-func (d *mtpDrafter) close() {
+func (d *mtpDraftSession) close() {
 	d.flush()
 	d.setFrontierHidden(nil)
 	d.setHeld(nil, nil)
@@ -121,7 +131,7 @@ func (d *mtpDrafter) close() {
 // fused with their target hiddens — flushing once the buffer reaches the token
 // cap so the pinned hiddens stay bounded. flush coalesces the buffered writes
 // into one head forward, so a contiguous run lands in a single draft-cache extend.
-func (d *mtpDrafter) queueCacheWrites(tokens, hiddens *mlx.Array) {
+func (d *mtpDraftSession) queueCacheWrites(tokens, hiddens *mlx.Array) {
 	mlx.Pin(tokens, hiddens)
 	d.pendingTokens = append(d.pendingTokens, tokens)
 	d.pendingHiddens = append(d.pendingHiddens, hiddens)
@@ -134,11 +144,12 @@ func (d *mtpDrafter) queueCacheWrites(tokens, hiddens *mlx.Array) {
 // flush writes the pending pairs to the draft caches in one head forward,
 // dropping speculative entries past the committed range first and holding
 // the last row's logits and projected hidden for the next proposal chain.
-func (d *mtpDrafter) flush() {
+func (d *mtpDraftSession) flush() {
 	if len(d.pendingTokens) == 0 {
 		return
 	}
-	for _, c := range d.spec.draftKV {
+	spec := d.drafter.spec
+	for _, c := range spec.draftKV {
 		if c.Offset() > d.committedDraftOffset {
 			if !c.Restore(nil, d.committedDraftOffset) {
 				panic(fmt.Sprintf("mtp: draft cache rewind to %d failed", d.committedDraftOffset))
@@ -148,19 +159,19 @@ func (d *mtpDrafter) flush() {
 
 	ids := mlx.Concatenate(d.pendingTokens, 1)
 	hiddens := mlx.Concatenate(d.pendingHiddens, 1)
-	hidden, projected := d.spec.draft.Draft(&batch.Batch{
+	hidden, projected := spec.draft.Draft(&batch.Batch{
 		InputIDs:     ids,
 		SeqOffsets:   []int32{int32(d.committedDraftOffset)},
 		SeqQueryLens: []int32{int32(ids.Dim(1))},
 		Hidden:       hiddens,
-	}, d.spec.caches)
+	}, spec.caches)
 	d.setHeld(lastHiddenRow(hidden), lastHiddenRow(projected))
 	d.committedDraftOffset += ids.Dim(1)
 
 	// Force the draft writes: a session that never drafts would otherwise
 	// leave the flush chain unevaluated, pinning every hidden until close.
-	state := make([]*mlx.Array, 0, 2*len(d.spec.draftKV))
-	for _, c := range d.spec.draftKV {
+	state := make([]*mlx.Array, 0, 2*len(spec.draftKV))
+	for _, c := range spec.draftKV {
 		state = append(state, c.State()...)
 	}
 	mlx.AsyncEval(state...)
@@ -171,14 +182,14 @@ func (d *mtpDrafter) flush() {
 	d.pendingCount = 0
 }
 
-func (d *mtpDrafter) setFrontierHidden(h *mlx.Array) {
+func (d *mtpDraftSession) setFrontierHidden(h *mlx.Array) {
 	mlx.Pin(h)
 	mlx.Unpin(d.frontierHidden)
 	d.frontierHidden = h
 }
 
 // setHeld replaces the held flush outputs, pinned until the next flush or close.
-func (d *mtpDrafter) setHeld(hidden, projected *mlx.Array) {
+func (d *mtpDraftSession) setHeld(hidden, projected *mlx.Array) {
 	mlx.Pin(hidden, projected)
 	mlx.Unpin(d.heldHidden, d.heldProjected)
 	d.heldHidden, d.heldProjected = hidden, projected
@@ -188,13 +199,14 @@ func (d *mtpDrafter) setHeld(hidden, projected *mlx.Array) {
 // A head with draft caches settles the frontier pair first, so its first step
 // reuses the held frontier row with no head call; a cacheless head re-attends
 // the target caches read-only, anchored at the last committed slot.
-func (d *mtpDrafter) propose(current *mlx.Array, maxTokens int) *draftCandidates {
+func (d *mtpDraftSession) propose(current *mlx.Array, maxTokens int) *draftCandidates {
 	if maxTokens <= 0 || d.frontierHidden == nil {
 		return nil
 	}
-	r := d.spec.r
+	spec := d.drafter.spec
+	r := spec.r
 
-	if len(d.spec.draftKV) > 0 {
+	if len(spec.draftKV) > 0 {
 		d.settle(current)
 		if d.heldHidden == nil {
 			return nil
@@ -208,7 +220,7 @@ func (d *mtpDrafter) propose(current *mlx.Array, maxTokens int) *draftCandidates
 
 	for i := range maxTokens {
 		var hidden, projected *mlx.Array
-		if i == 0 && len(d.spec.draftKV) > 0 {
+		if i == 0 && len(spec.draftKV) > 0 {
 			// The settle flush already produced the frontier row; reuse it
 			// instead of re-running the head.
 			hidden, projected = d.heldHidden, d.heldProjected
@@ -219,18 +231,18 @@ func (d *mtpDrafter) propose(current *mlx.Array, maxTokens int) *draftCandidates
 			// head stays at the last committed slot every step, re-attending
 			// the committed prefix read-only ("single-position").
 			pos := d.frontier - 1
-			if len(d.spec.draftKV) > 0 {
+			if len(spec.draftKV) > 0 {
 				pos = d.frontier - 1 + i
 			}
-			hidden, projected = d.spec.draft.Draft(&batch.Batch{
+			hidden, projected = spec.draft.Draft(&batch.Batch{
 				InputIDs:     lastToken,
 				SeqOffsets:   []int32{int32(pos)},
 				SeqQueryLens: []int32{1},
 				Hidden:       lastHidden,
-			}, d.spec.caches)
+			}, spec.caches)
 		}
 		// Unembed only the row being sampled, never the batch.
-		stepLogits := d.spec.draft.Unembed(hidden).Squeeze(1)
+		stepLogits := spec.draft.Unembed(hidden).Squeeze(1)
 		lastHidden = projected
 		// The chain's earlier drafts ride along as the row's history, so
 		// penalties shape proposals the same way they shape validation.

--- a/x/mlxrunner/mtp.go
+++ b/x/mlxrunner/mtp.go
@@ -14,12 +14,18 @@ import (
 const mtpPendingFlushTokens = 32
 
 // mtpDrafter drafts with a model's multi-token-prediction head. Constructed
-// at load, it opens each request's drafting session.
+// at load, it fixes the trie keys' draft look-ahead for the model's lifetime
+// and opens each request's drafting session.
 type mtpDrafter struct {
 	spec *speculation
 }
 
 func newMTPDrafter(s *speculation) *mtpDrafter {
+	if len(s.draftKV) > 0 {
+		// The pairing references one token past each slot; trie keys carry
+		// that look-ahead so a match verifies it (see prefixCache.draftLookahead).
+		s.r.cache.draftLookahead = 1
+	}
 	return &mtpDrafter{spec: s}
 }
 
@@ -94,29 +100,15 @@ func (d *mtpDraftSession) committed(tokens, hiddens *mlx.Array, position int) {
 	d.setFrontierHidden(lastHiddenRow(hiddens))
 }
 
-// finish settles the drafter when generation ends: current completes the
-// frontier pair, leveling the draft caches with the target's resting offset.
-//
-// TODO: leveling the draft to the target writes a boundary entry whose
-// look-ahead token is outside the stored prefix (here, the never-committed
-// current). When a later request restores this prefix and diverges at the
-// boundary, that entry is stale and lowers draft acceptance. EAGLE keeps the
-// draft one slot behind the target so the unconfirmed boundary entry is never
-// written (its bigram partner token[S+1] does not exist yet); we should do the
-// same rather than level here. Regenerating hidden[S] to re-pair the boundary
-// on the next request is a separate, re-prefill-bound concern for recurrent
-// targets.
-func (d *mtpDraftSession) finish(current *mlx.Array) {
+// settle completes any open frontier pair with next — the token after the
+// last committed slot — and flushes, leveling the draft caches with the
+// target.
+func (d *mtpDraftSession) settle(next *mlx.Array) {
 	if len(d.drafter.spec.draftKV) == 0 {
 		return
 	}
-	d.settle(current)
-}
-
-// settle completes any open frontier pair with current, then flushes.
-func (d *mtpDraftSession) settle(current *mlx.Array) {
 	if d.frontierHidden != nil && d.frontier-1 == d.committedDraftOffset+d.pendingCount {
-		d.queueCacheWrites(current.ExpandDims(-1), d.frontierHidden)
+		d.queueCacheWrites(next.ExpandDims(-1), d.frontierHidden)
 	}
 	d.flush()
 }

--- a/x/mlxrunner/mtp.go
+++ b/x/mlxrunner/mtp.go
@@ -11,7 +11,7 @@ import (
 // mtpPendingFlushTokens caps how many committed look-ahead tokens wait in the
 // pending buffer before a batched flush, bounding the pinned hidden states
 // regardless of what else triggers a flush.
-const mtpPendingFlushTokens = 32
+const mtpPendingFlushTokens = 256
 
 // mtpDrafter drafts with a model's multi-token-prediction head. Constructed
 // at load, it fixes the trie keys' draft look-ahead for the model's lifetime

--- a/x/mlxrunner/mtp_test.go
+++ b/x/mlxrunner/mtp_test.go
@@ -221,6 +221,7 @@ func mtpTestRunner(t *testing.T, predict map[int32]int32, eos []int32, opts samp
 		Model:     &fakeMTPModel{predict: predict, tok: tok},
 		Tokenizer: tok,
 		Sampler:   sampler.New(4096),
+		cache:     &prefixCache{},
 	}
 	r.Sampler.Add(pipelineSlot, opts, nil)
 	t.Cleanup(func() { r.Sampler.Remove(pipelineSlot) })
@@ -377,9 +378,9 @@ func TestRunMTPDecodeGreedy(t *testing.T) {
 	r := mtpTestRunner(t, predict, []int32{eos}, sampler.Options{})
 	// The draft mirrors the target chain, so every drafted token is accepted.
 	draft := &fakeMTPDraft{predict: predict}
-	r.spec = newSpeculation(r, draft)
-
 	caches, _ := newMTPTestCaches(1)
+	r.cache.caches = caches
+	r.spec = newSpeculation(r, draft)
 	session, ch := newMTPTestSession(caches)
 	position := 1 // one prefill token already processed
 
@@ -438,9 +439,9 @@ func TestRunMTPDecodeSampled(t *testing.T) {
 	const eos int32 = 7
 	predict := map[int32]int32{1: 2, 2: 3, 3: 4, 4: eos, eos: 0}
 	r := mtpTestRunner(t, predict, []int32{eos}, sampler.Options{Temperature: 1, Seed: 42, UseSeed: true})
-	r.spec = newSpeculation(r, &fakeMTPDraft{predict: predict})
-
 	caches, _ := newMTPTestCaches(1)
+	r.cache.caches = caches
+	r.spec = newSpeculation(r, &fakeMTPDraft{predict: predict})
 	session, ch := newMTPTestSession(caches)
 	position := 1
 
@@ -482,9 +483,9 @@ func TestRunMTPDecodeWarmDrafter(t *testing.T) {
 	predict := map[int32]int32{1: 2, 2: 3, 3: 4, 4: eos, eos: 0}
 	r := mtpTestRunner(t, predict, []int32{eos}, sampler.Options{})
 	draft := &fakeMTPDraft{predict: predict}
-	r.spec = newSpeculation(r, draft)
-
 	caches, _ := newMTPTestCaches(1)
+	r.cache.caches = caches
+	r.spec = newSpeculation(r, draft)
 	session, ch := newMTPTestSession(caches)
 	position := 1 // one prefill token already processed
 
@@ -543,9 +544,9 @@ func TestRunMTPDecodeEOSCutLeavesPositionsUnjudged(t *testing.T) {
 	const eos int32 = 7
 	predict := map[int32]int32{1: 2, 2: 3, 3: eos, eos: 0}
 	r := mtpTestRunner(t, predict, []int32{eos}, sampler.Options{})
-	r.spec = newSpeculation(r, &fakeMTPDraft{predict: predict})
-
 	caches, _ := newMTPTestCaches(1)
+	r.cache.caches = caches
+	r.spec = newSpeculation(r, &fakeMTPDraft{predict: predict})
 	session, ch := newMTPTestSession(caches)
 	position := 1
 
@@ -648,9 +649,9 @@ func TestDecodeCancelledMidStream(t *testing.T) {
 	const eos int32 = 7
 	predict := map[int32]int32{1: 2, 2: 3, 3: 4, 4: 5, 5: 6, 6: eos}
 	r := mtpTestRunner(t, predict, []int32{eos}, sampler.Options{})
-	r.spec = newSpeculation(r, &fakeMTPDraft{predict: predict})
-
 	caches, tr := newMTPTestCaches(1)
+	r.cache.caches = caches
+	r.spec = newSpeculation(r, &fakeMTPDraft{predict: predict})
 	session := &cacheSession{caches: caches}
 	ch := make(chan CompletionResponse) // unbuffered: every send must rendezvous
 
@@ -727,9 +728,9 @@ func TestDecodeKVDraft(t *testing.T) {
 	predict := map[int32]int32{1: 2, 2: 3, 3: 4, 4: 5, 5: 6, 6: eos, eos: 0}
 	r := mtpTestRunner(t, predict, []int32{eos}, sampler.Options{})
 	draft := &fakeKVDraft{predict: predict}
-	r.spec = newSpeculation(r, draft)
-
 	caches, _ := newMTPTestCaches(2) // caches[0] target, caches[1] draft KV
+	r.cache.caches = caches
+	r.spec = newSpeculation(r, draft)
 	session, ch := newMTPTestSession(caches)
 	position := 0
 
@@ -811,9 +812,9 @@ func TestDecodeKVDraftRejectionRebuildsFromTarget(t *testing.T) {
 	// the target chain); once the target corrects 3->4 the next proposal
 	// re-aligns on the shared chain.
 	draft := &fakeKVDraft{predict: map[int32]int32{1: 2, 2: 3, 3: 6, 6: 0, 4: 5, 5: eos, eos: 0}}
-	r.spec = newSpeculation(r, draft)
-
 	caches, _ := newMTPTestCaches(2) // caches[0] target, caches[1] draft KV
+	r.cache.caches = caches
+	r.spec = newSpeculation(r, draft)
 	session, ch := newMTPTestSession(caches)
 	position := 0
 
@@ -880,9 +881,9 @@ func TestDecodeMaintainsDraftCacheWithoutDrafting(t *testing.T) {
 	opts := sampler.Options{Logprobs: true}
 	r := mtpTestRunner(t, predict, []int32{eos}, opts)
 	draft := &fakeKVDraft{predict: predict}
-	r.spec = newSpeculation(r, draft)
-
 	caches, _ := newMTPTestCaches(2)
+	r.cache.caches = caches
+	r.spec = newSpeculation(r, draft)
 	session, ch := newMTPTestSession(caches)
 	position := 0
 
@@ -943,9 +944,9 @@ func TestFlushLevelsDraftCacheWithPrefill(t *testing.T) {
 	predict := map[int32]int32{2: 3, 3: 4, 4: 5}
 	r := mtpTestRunner(t, predict, []int32{eos}, sampler.Options{})
 	draft := &fakeKVDraft{predict: predict}
-	r.spec = newSpeculation(r, draft)
-
 	caches, _ := newMTPTestCaches(2)
+	r.cache.caches = caches
+	r.spec = newSpeculation(r, draft)
 	req := Request{
 		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
 		SamplerOpts:       sampler.Options{},
@@ -983,9 +984,9 @@ func TestCommittedRunBatchesPastFlushCap(t *testing.T) {
 
 	r := mtpTestRunner(t, predict, []int32{0}, sampler.Options{})
 	draft := &fakeKVDraft{predict: predict}
-	r.spec = newSpeculation(r, draft)
-
 	caches, _ := newMTPTestCaches(2)
+	r.cache.caches = caches
+	r.spec = newSpeculation(r, draft)
 	req := Request{
 		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
 		SamplerOpts:       sampler.Options{},
@@ -1021,9 +1022,9 @@ func TestDecodeParkedDraftResume(t *testing.T) {
 	predict := map[int32]int32{1: 2, 2: 3, 3: 4, 4: 5, 5: 6, 6: eos, eos: 0}
 	r := mtpTestRunner(t, predict, []int32{eos}, sampler.Options{})
 	draft := &fakeKVDraft{predict: predict}
-	r.spec = newSpeculation(r, draft)
-
 	caches, _ := newMTPTestCaches(2)
+	r.cache.caches = caches
+	r.spec = newSpeculation(r, draft)
 	req := Request{
 		Tokens:            []int32{1},
 		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
@@ -1123,7 +1124,7 @@ func newMTPTestSession(caches []cache.Cache) (*cacheSession, chan CompletionResp
 func testSpeculationSession(r *Runner, caches []cache.Cache) *speculationSession {
 	if r.spec != nil {
 		r.spec.bind(caches)
-		return &speculationSession{spec: r.spec, drafter: newMTPDrafter(r.spec)}
+		return &speculationSession{spec: r.spec, drafter: r.spec.drafter.open()}
 	}
 	s := &speculation{r: r, caches: caches, targets: caches}
 	return &speculationSession{spec: s, drafter: nopDrafter{}}
@@ -1151,7 +1152,7 @@ func scriptedCandidates(r *Runner, tokens []int32) *draftCandidates {
 		prev = tok
 	}
 	s := &speculation{r: r, draft: &fakeMTPDraft{predict: chain}}
-	d := &mtpDrafter{spec: s}
+	d := (&mtpDrafter{spec: s}).open()
 	d.committed(mlx.FromValues([]int32{0}, 1, 1), mlx.Zeros(mlx.DTypeFloat32, 1, 1, mtpTestVocab), 0)
 	return d.propose(mlx.FromValues([]int32{0}, 1), len(tokens))
 }

--- a/x/mlxrunner/mtp_test.go
+++ b/x/mlxrunner/mtp_test.go
@@ -456,7 +456,7 @@ func TestRunMTPDecodeSampled(t *testing.T) {
 		t.Fatalf("open rejected a sampled request")
 	}
 	pinDraftLimit(spec, 4)
-	d := spec.decoder([]int32{1}, position)
+	d := spec.decoder(mlx.FromValues([]int32{1}, 1), position)
 	if err := r.decode(context.Background(), req, session, d, 0); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
@@ -501,7 +501,7 @@ func TestRunMTPDecodeWarmDrafter(t *testing.T) {
 	// hidden row, leaving the drafter ready to propose from slot 1.
 	spec.committed(mlx.FromValues([]int32{0}, 1, 1), oneHotLogits([]int32{1}), 0)
 
-	d := spec.decoder([]int32{1}, position)
+	d := spec.decoder(mlx.FromValues([]int32{1}, 1), position)
 	if err := r.decode(context.Background(), req, session, d, 0); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
@@ -565,7 +565,7 @@ func TestRunMTPDecodeEOSCutLeavesPositionsUnjudged(t *testing.T) {
 	spec.limit = 4
 	spec.committed(mlx.FromValues([]int32{0}, 1, 1), oneHotLogits([]int32{1}), 0)
 
-	d := spec.decoder([]int32{1}, position)
+	d := spec.decoder(mlx.FromValues([]int32{1}, 1), position)
 	if err := r.decode(context.Background(), req, session, d, 0); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
@@ -625,14 +625,14 @@ func TestDecodePlain(t *testing.T) {
 	if final.DoneReason != 0 || final.EvalCount != 3 {
 		t.Fatalf("final DoneReason = %d, EvalCount = %d, want 0 (EOS) and 3", final.DoneReason, final.EvalCount)
 	}
-	if got := []int32{2, 3, 4, eos}; !slices.Equal(session.outputs, got) {
+	if got := []int32{2, 3, 4, eos, 0}; !slices.Equal(session.outputs, got) {
 		t.Fatalf("session outputs = %v, want %v", session.outputs, got)
 	}
 
 	// One forward per token: the seed at offset 1, then each sampled token
 	// in turn — including the ending EOS, whose forward is already in
 	// flight when the token is checked. Every forwarded token is recorded,
-	// so the caches rest exactly at the recorded path.
+	// and the EOS's sampled successor is recorded without being forwarded.
 	wantForwards := []forwardCall{{1, 1}, {2, 1}, {3, 1}, {4, 1}, {5, 1}}
 	model := r.Model.(*fakeMTPModel)
 	if !slices.Equal(model.forwards, wantForwards) {
@@ -710,7 +710,7 @@ func testDecoder(r *Runner, req Request, caches []cache.Cache, seed []int32, pos
 		if spec.enabled {
 			pinDraftLimit(spec, 4)
 		}
-		return spec.decoder(seed, position)
+		return spec.decoder(mlx.FromValues(seed, len(seed)), position)
 	}
 	return r.pipelinedDecoder(nil, caches, mlx.FromValues(seed, 1, len(seed)), position)
 }
@@ -746,7 +746,7 @@ func TestDecodeKVDraft(t *testing.T) {
 	}
 	pinDraftLimit(spec, 4)
 	defer spec.close()
-	d := spec.decoder([]int32{1}, position)
+	d := spec.decoder(mlx.FromValues([]int32{1}, 1), position)
 	if err := r.decode(context.Background(), req, session, d, 0); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
@@ -827,7 +827,7 @@ func TestDecodeKVDraftRejectionRebuildsFromTarget(t *testing.T) {
 	spec := r.spec.open(req, caches)
 	pinDraftLimit(spec, 4)
 	defer spec.close()
-	d := spec.decoder([]int32{1}, position)
+	d := spec.decoder(mlx.FromValues([]int32{1}, 1), position)
 	if err := r.decode(context.Background(), req, session, d, 0); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
@@ -897,7 +897,7 @@ func TestDecodeMaintainsDraftCacheWithoutDrafting(t *testing.T) {
 	if spec == nil || spec.enabled {
 		t.Fatalf("want a permanent-park speculationSession, got %+v", spec)
 	}
-	d := spec.decoder([]int32{1}, position)
+	d := spec.decoder(mlx.FromValues([]int32{1}, 1), position)
 	if err := r.decode(context.Background(), req, session, d, 0); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
@@ -933,13 +933,12 @@ func TestDecodeMaintainsDraftCacheWithoutDrafting(t *testing.T) {
 	}
 }
 
-func TestFlushLevelsDraftCacheWithPrefill(t *testing.T) {
+func TestSettleLevelsDraftCacheWithPrefill(t *testing.T) {
 	skipIfNoMLX(t)
 	// Prefill attaches its scheduled snapshots only at offsets every cache
-	// has crossed, so the pipeline flushes the drafter's buffered pairs
-	// first: after a prefill-sized committed report and a flush, the
-	// draft cache covers every completed pair, one slot behind the target
-	// (the frontier pair still awaits its look-ahead token).
+	// has crossed, so the pipeline settles the drafter with the seed first:
+	// the completed frontier pair brings the draft cache level with the
+	// target, in one batched extend with the buffered pairs.
 	const eos int32 = 7
 	predict := map[int32]int32{2: 3, 3: 4, 4: 5}
 	r := mtpTestRunner(t, predict, []int32{eos}, sampler.Options{})
@@ -954,15 +953,16 @@ func TestFlushLevelsDraftCacheWithPrefill(t *testing.T) {
 	spec := r.spec.open(req, caches)
 	defer spec.close()
 
-	// The prompt's only chunk: tokens 1..4 at slots 0..3 with their hiddens.
+	// The prompt's only chunk: tokens 1..4 at slots 0..3 with their hiddens;
+	// token 5 is the seed.
 	spec.committed(mlx.FromValues([]int32{1, 2, 3, 4}, 1, 4), oneHotLogits([]int32{1, 2, 3, 4}), 0)
-	spec.flush()
+	spec.settle(mlx.FromValues([]int32{5}, 1))
 
-	if got := caches[1].Offset(); got != 3 {
-		t.Fatalf("draft cache offset after flush = %d, want 3 (all completed pairs)", got)
+	if got := caches[1].Offset(); got != 4 {
+		t.Fatalf("draft cache offset after settle = %d, want 4 (level with target)", got)
 	}
 	wantExtends := []extendCall{
-		{offset: 0, ids: []int32{2, 3, 4}, hiddens: []int32{1, 2, 3}},
+		{offset: 0, ids: []int32{2, 3, 4, 5}, hiddens: []int32{1, 2, 3, 4}},
 	}
 	if !reflect.DeepEqual(draft.extends, wantExtends) {
 		t.Fatalf("draft extends = %+v, want %+v", draft.extends, wantExtends)
@@ -995,8 +995,8 @@ func TestCommittedRunBatchesPastFlushCap(t *testing.T) {
 	defer spec.close()
 
 	// One prefill-sized chunk: n tokens at slots 0..n-1 with their hiddens.
+	// The run crosses the flush cap, so the write happens inside committed.
 	spec.committed(mlx.FromValues(tokens, 1, n), oneHotLogits(tokens), 0)
-	spec.flush()
 
 	if got := len(draft.extends); got != 1 {
 		t.Fatalf("draft extends = %d calls, want 1 batched extend", got)
@@ -1009,6 +1009,61 @@ func TestCommittedRunBatchesPastFlushCap(t *testing.T) {
 	}
 	if got := caches[1].Offset(); got != n-1 {
 		t.Fatalf("draft cache offset = %d, want %d (all completed pairs)", got, n-1)
+	}
+}
+
+func TestRestoredPrefixRewritesBoundaryPair(t *testing.T) {
+	skipIfNoMLX(t)
+	// A finished generation levels the draft with the target, its boundary
+	// pair naming the never-committed EOS. The next request restores one
+	// token below the match (the draft look-ahead), so the re-evaluated
+	// boundary token's report rewrites that pair with the token that follows.
+	const eos int32 = 7
+	predict := map[int32]int32{1: 2, 2: 3, 3: 4, 4: 5, 5: 6, 6: eos, eos: 0}
+	r := mtpTestRunner(t, predict, []int32{eos}, sampler.Options{})
+	draft := &fakeKVDraft{predict: predict}
+	caches, _ := newMTPTestCaches(2)
+	r.cache.caches = caches
+	r.spec = newSpeculation(r, draft)
+	session, ch := newMTPTestSession(caches)
+	req := Request{
+		Responses:         ch,
+		Tokens:            []int32{1},
+		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
+		SamplerOpts:       sampler.Options{},
+	}
+	spec := r.spec.open(req, caches)
+	pinDraftLimit(spec, 4)
+	d := spec.decoder(mlx.FromValues([]int32{1}, 1), 0)
+	if err := r.decode(context.Background(), req, session, d, 0); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	d.close()
+	spec.close()
+
+	// The leveled rest: the draft's last pair names the EOS.
+	if got, want := caches[1].(*fakeRewindableCache).tokens, []int32{2, 3, 4, 5, 6, eos}; !slices.Equal(got, want) {
+		t.Fatalf("draft cache = %v, want %v", got, want)
+	}
+
+	// The next request matches the six stored tokens and restores at 5, as
+	// begin does for the draft look-ahead; its prefill re-evaluates token 6,
+	// and the token that follows is 1, not the EOS.
+	for _, c := range caches {
+		if !c.Restore(nil, 5) {
+			t.Fatal("restore to 5 failed")
+		}
+	}
+	spec = r.spec.open(req, caches)
+	spec.committed(mlx.FromValues([]int32{6, 1}, 1, 2), oneHotLogits([]int32{eos, 2}), 5)
+	spec.close()
+
+	last := draft.extends[len(draft.extends)-1]
+	if want := (extendCall{offset: 5, ids: []int32{1}, hiddens: []int32{eos}}); !reflect.DeepEqual(last, want) {
+		t.Fatalf("boundary rewrite = %+v, want %+v", last, want)
+	}
+	if got, want := caches[1].(*fakeRewindableCache).tokens, []int32{2, 3, 4, 5, 6, 1}; !slices.Equal(got, want) {
+		t.Fatalf("draft cache = %v, want %v (stale EOS pair rewritten)", got, want)
 	}
 }
 
@@ -1035,7 +1090,7 @@ func TestDecodeParkedDraftResume(t *testing.T) {
 		t.Fatalf("want a drafting speculationSession, got %+v", spec)
 	}
 	pinDraftLimit(spec, 0)
-	d := spec.decoder([]int32{1}, 0).(*speculativeDecoder)
+	d := spec.decoder(mlx.FromValues([]int32{1}, 1), 0).(*speculativeDecoder)
 
 	// Two parked calls arrive pipelined, one token each.
 	for _, want := range []int{2, 3} {
@@ -1136,8 +1191,7 @@ type nopDrafter struct{}
 
 func (nopDrafter) propose(*mlx.Array, int) *draftCandidates { return nil }
 func (nopDrafter) committed(_, _ *mlx.Array, _ int)         {}
-func (nopDrafter) finish(*mlx.Array)                        {}
-func (nopDrafter) flush()                                   {}
+func (nopDrafter) settle(*mlx.Array)                        {}
 func (nopDrafter) close()                                   {}
 
 // scriptedCandidates builds draft candidates by running the real drafter

--- a/x/mlxrunner/pipeline.go
+++ b/x/mlxrunner/pipeline.go
@@ -71,7 +71,7 @@ func (r *Runner) TextGenerationPipeline(ctx context.Context, request Request) er
 
 	inputs := request.Tokens
 
-	session := r.cache.begin(r.Model, inputs)
+	session := r.cache.begin(inputs)
 	defer session.close()
 	caches := session.caches
 

--- a/x/mlxrunner/pipeline.go
+++ b/x/mlxrunner/pipeline.go
@@ -92,7 +92,7 @@ func (r *Runner) TextGenerationPipeline(ctx context.Context, request Request) er
 	if spec != nil {
 		d = spec.decoder(seed, position)
 	} else {
-		d = r.pipelinedDecoder(nil, caches, mlx.FromValues(seed, 1, len(seed)), position)
+		d = r.pipelinedDecoder(nil, caches, seed.ExpandDims(-1), position)
 	}
 	defer d.close()
 	return r.decode(ctx, request, session, d, promptEval)
@@ -100,8 +100,8 @@ func (r *Runner) TextGenerationPipeline(ctx context.Context, request Request) er
 
 // prefill evaluates the prompt in chunks, leaving one token for decode to
 // seed from, and schedules the prompt's periodic snapshots. It returns the
-// seed tokens, the resume position, and the prompt-evaluation duration.
-func (r *Runner) prefill(ctx context.Context, session *cacheSession, spec *speculationSession) ([]int32, int, time.Duration, error) {
+// seed token, the resume position, and the prompt-evaluation duration.
+func (r *Runner) prefill(ctx context.Context, session *cacheSession, spec *speculationSession) (*mlx.Array, int, time.Duration, error) {
 	start := time.Now()
 	inputs := session.inputs
 	tokens := session.remaining
@@ -161,13 +161,14 @@ func (r *Runner) prefill(ctx context.Context, session *cacheSession, spec *specu
 		mlx.ClearCache()
 	}
 
-	// Flush before attaching: snapshots attach only at offsets every cache
-	// has crossed, and a drafter with draft caches keeps buffered pairs that
-	// would otherwise hold those caches short of the scheduled offsets.
-	spec.flush()
+	// Settle before attaching: snapshots attach only at offsets every cache
+	// has crossed, and the draft caches stay a pair short of the target
+	// until the seed completes the frontier pair.
+	seed := mlx.FromValues(tokens[processed:], 1)
+	spec.settle(seed)
 	session.attachPrefillSnapshots()
 
-	return tokens[processed:], position, time.Since(start), nil
+	return seed, position, time.Since(start), nil
 }
 
 // A decoder produces each run of tokens to emit, owning its own dispatch and
@@ -175,6 +176,12 @@ func (r *Runner) prefill(ctx context.Context, session *cacheSession, spec *specu
 // cancellation. next may return none while its first tokens are in flight.
 type decoder interface {
 	next(remaining int) ([]sampler.Result, error)
+
+	// drain ends production, returning any results sampled but never
+	// delivered through next and the position the next forward would have
+	// taken; the decoder remains closeable.
+	drain() ([]sampler.Result, int)
+
 	close()
 }
 
@@ -183,6 +190,14 @@ type decoder interface {
 // never rest ahead of session.outputs; tokens past the stop are recorded but
 // not streamed or counted.
 func (r *Runner) decode(ctx context.Context, request Request, session *cacheSession, d decoder, promptEval time.Duration) error {
+	// A sampled-but-undelivered result is still a produced token; record it.
+	defer func() {
+		results, _ := d.drain()
+		for _, res := range results {
+			session.outputs = append(session.outputs, int32(res.Token.Int()))
+		}
+	}()
+
 	detok := detokenizer{
 		tokenizer:       r.Tokenizer,
 		wantLogprobs:    request.SamplerOpts.Logprobs,
@@ -276,7 +291,6 @@ type pipelinedDecoder struct {
 	caches   []cache.Cache
 	position int
 	sample   sampler.Result // in flight: sampled, not yet forwarded
-	emitted  sampler.Result // last call's result, pinned until the next call
 }
 
 func (r *Runner) pipelinedDecoder(spec *speculationSession, caches []cache.Cache, seed *mlx.Array, position int) *pipelinedDecoder {
@@ -305,25 +319,23 @@ func (t *pipelinedDecoder) dispatch(token *mlx.Array) sampler.Result {
 }
 
 func (t *pipelinedDecoder) next(int) ([]sampler.Result, error) {
-	mlx.Unpin(t.emitted.Arrays()...)
-	t.emitted, t.sample = t.sample, t.dispatch(t.sample.Token.ExpandDims(-1))
-	return []sampler.Result{t.emitted}, nil
+	out := t.sample
+	t.sample = t.dispatch(out.Token.ExpandDims(-1))
+	mlx.Unpin(out.Arrays()...)
+	return []sampler.Result{out}, nil
 }
 
-// detach ends a parked stretch: it hands the in-flight sample (sampled but
-// never forwarded) and the resume position to the caller, releasing the
-// decoder's emitted pin but not settling the drafter. The caller drafts from
-// the sample next, and that round completes the still-open frontier pair.
-func (t *pipelinedDecoder) detach() (sampler.Result, int) {
-	mlx.Unpin(t.emitted.Arrays()...)
-	return t.sample, t.position
+// drain ends production: it returns the in-flight sample (sampled but never
+// forwarded) and the position its forward would have taken. The decoder
+// keeps the sample for close.
+func (t *pipelinedDecoder) drain() ([]sampler.Result, int) {
+	return []sampler.Result{t.sample}, t.position
 }
 
 func (t *pipelinedDecoder) close() {
 	// The in-flight sample's forward was never dispatched; its report settles
 	// the drafter level with the caches' resting offset.
-	t.spec.finish(t.sample.Token)
-	mlx.Unpin(t.emitted.Arrays()...)
+	t.spec.settle(t.sample.Token)
 	mlx.Unpin(t.sample.Arrays()...)
 }
 

--- a/x/mlxrunner/prefix_cache.go
+++ b/x/mlxrunner/prefix_cache.go
@@ -1,6 +1,7 @@
-// cache.go manages a shared KV cache across conversations using a compressed
-// prefix trie. Each trie node stores a token sequence (edge) and optional
-// per-layer snapshots that can be paged in/out of the live MLX cache arrays.
+// prefix_cache.go manages cache state shared across conversations using a
+// compressed prefix trie. Each trie node stores a token sequence (edge) and
+// optional per-layer snapshots that can be paged in/out of the live MLX cache
+// arrays.
 //
 // Key properties:
 //   - Only one path through the trie is "active" (backed by live MLX arrays)
@@ -31,7 +32,7 @@ import (
 
 const maxPagedOutBytes int64 = 8 << 30 // 8 GiB eviction threshold for paged-out snapshot memory
 
-type kvCache struct {
+type prefixCache struct {
 	root          *trieNode   // root of the prefix trie
 	activePath    []*trieNode // current root→leaf path with live MLX arrays
 	caches        []cache.Cache
@@ -48,7 +49,7 @@ type pendingSnapshot struct {
 // Callers should append generated tokens to outputs and
 // defer close to save the cache state.
 type cacheSession struct {
-	cache   *kvCache
+	cache   *prefixCache
 	inputs  []int32
 	outputs []int32
 
@@ -61,7 +62,7 @@ type cacheSession struct {
 	pendingSnapshots []pendingSnapshot
 }
 
-func (c *kvCache) ensureCaches(m base.Model) {
+func (c *prefixCache) ensureCaches(m base.Model) {
 	if len(c.caches) != 0 {
 		return
 	}
@@ -75,7 +76,7 @@ func (c *kvCache) ensureCaches(m base.Model) {
 	}
 }
 
-func (c *kvCache) ensureRoot() {
+func (c *prefixCache) ensureRoot() {
 	if c.root == nil {
 		c.root = &trieNode{
 			lastUsed: time.Now(),
@@ -86,7 +87,7 @@ func (c *kvCache) ensureRoot() {
 
 // begin prepares caches for a new request. It finds the nearest
 // matching cache or creates new caches if none match.
-func (c *kvCache) begin(m base.Model, inputs []int32) *cacheSession {
+func (c *prefixCache) begin(m base.Model, inputs []int32) *cacheSession {
 	c.ensureCaches(m)
 	c.ensureRoot()
 
@@ -130,7 +131,7 @@ func (c *kvCache) begin(m base.Model, inputs []int32) *cacheSession {
 
 // switchToPath transitions from the current active path to a new path,
 // paging out diverging segments and paging in the new path.
-func (c *kvCache) switchToPath(newPath []*trieNode, matched int) {
+func (c *prefixCache) switchToPath(newPath []*trieNode, matched int) {
 	defer c.enforceEvictionPolicy()
 
 	// Find common ancestor index.
@@ -401,7 +402,7 @@ func (s *cacheSession) attachCapturedSnapshots(node *trieNode, snaps []cache.Sna
 // advancePath advances the active path from the current frontier by matching
 // tokens against existing trie children, splitting partial matches, and
 // appending any remaining tokens as new nodes. Returns the new frontier.
-func (c *kvCache) advancePath(frontier *trieNode, tokens []int32, endOffset int) *trieNode {
+func (c *prefixCache) advancePath(frontier *trieNode, tokens []int32, endOffset int) *trieNode {
 	// Check if existing children already cover some or all of tokens.
 	// tokens may span multiple trie nodes when extending a previous run's
 	// leaf and this snapshot now overlaps that same range.
@@ -438,7 +439,7 @@ func (c *kvCache) advancePath(frontier *trieNode, tokens []int32, endOffset int)
 }
 
 // freeAll releases all cache layers.
-func (c *kvCache) freeAll() {
+func (c *prefixCache) freeAll() {
 	for _, kv := range c.caches {
 		if kv != nil {
 			kv.Free()
@@ -446,7 +447,7 @@ func (c *kvCache) freeAll() {
 	}
 }
 
-func (c *kvCache) minCacheOffset() int {
+func (c *prefixCache) minCacheOffset() int {
 	offset := 0
 	found := false
 	for _, kv := range c.caches {
@@ -503,7 +504,7 @@ func (s *cacheSession) close() {
 }
 
 // enforceEvictionPolicy evicts eligible nodes until paged-out memory is within limits.
-func (c *kvCache) enforceEvictionPolicy() {
+func (c *prefixCache) enforceEvictionPolicy() {
 	if c.pagedOutBytes <= maxPagedOutBytes {
 		return
 	}
@@ -537,7 +538,7 @@ func (c *kvCache) enforceEvictionPolicy() {
 }
 
 // evictNode evicts a single node from the trie, freeing its snapshot memory.
-func (c *kvCache) evictNode(node *trieNode) {
+func (c *prefixCache) evictNode(node *trieNode) {
 	if len(node.children) == 0 {
 		// Leaf: remove entirely.
 		slog.Debug("evicting leaf", "offset", node.startOffset(), "tokens", len(node.tokens), "freed", mlx.PrettyBytes(int(node.snapshotBytes())))
@@ -553,7 +554,7 @@ func (c *kvCache) evictNode(node *trieNode) {
 	}
 }
 
-func (c *kvCache) dumpTree() {
+func (c *prefixCache) dumpTree() {
 	// Summary stats
 	var cacheBytes int
 	for _, kv := range c.caches {
@@ -640,7 +641,7 @@ func (c *kvCache) dumpTree() {
 	dump(c.root, "", true)
 
 	offset := c.minCacheOffset()
-	logutil.Trace(fmt.Sprintf("kv cache active_tokens: %d, active_size: %s, paged_out: %s, trie: nodes=%d, snapshots=%d",
+	logutil.Trace(fmt.Sprintf("prefix cache active_tokens: %d, active_size: %s, paged_out: %s, trie: nodes=%d, snapshots=%d",
 		offset, mlx.PrettyBytes(cacheBytes), mlx.PrettyBytes(int(pagedBytes)), nodeCount, snapshotCount))
 	for i, l := range lines {
 		if i == 0 {

--- a/x/mlxrunner/prefix_cache.go
+++ b/x/mlxrunner/prefix_cache.go
@@ -62,18 +62,17 @@ type cacheSession struct {
 	pendingSnapshots []pendingSnapshot
 }
 
-func (c *prefixCache) ensureCaches(m base.Model) {
-	if len(c.caches) != 0 {
-		return
-	}
+func newPrefixCache(m base.Model) *prefixCache {
+	c := &prefixCache{}
 	if cacheFactory, ok := m.(interface{ NewCaches() []cache.Cache }); ok {
 		c.caches = cacheFactory.NewCaches()
-		return
+		return c
 	}
 	c.caches = make([]cache.Cache, m.NumLayers())
 	for i := range c.caches {
 		c.caches[i] = cache.NewKVCache()
 	}
+	return c
 }
 
 func (c *prefixCache) ensureRoot() {
@@ -87,8 +86,7 @@ func (c *prefixCache) ensureRoot() {
 
 // begin prepares caches for a new request. It finds the nearest
 // matching cache or creates new caches if none match.
-func (c *prefixCache) begin(m base.Model, inputs []int32) *cacheSession {
-	c.ensureCaches(m)
+func (c *prefixCache) begin(inputs []int32) *cacheSession {
 	c.ensureRoot()
 
 	matchPath, matched := findBestMatch(c.root, inputs)

--- a/x/mlxrunner/prefix_cache.go
+++ b/x/mlxrunner/prefix_cache.go
@@ -37,6 +37,10 @@ type prefixCache struct {
 	activePath    []*trieNode // current root→leaf path with live MLX arrays
 	caches        []cache.Cache
 	pagedOutBytes int64 // total bytes in paged-out snapshots across the trie
+
+	// draftLookahead is how far the draft caches' entries reference past
+	// their own slot; trie keys pack each token with its look-ahead (see key).
+	draftLookahead int
 }
 
 // pendingSnapshot is a snapshot scheduled to be taken during prefill.
@@ -89,13 +93,14 @@ func (c *prefixCache) ensureRoot() {
 func (c *prefixCache) begin(inputs []int32) *cacheSession {
 	c.ensureRoot()
 
-	matchPath, matched := findBestMatch(c.root, inputs)
+	keys := c.key(inputs)
+	matchPath, matched := findBestMatch(c.root, keys)
 	originalMatched := matched
 
 	// Always keep at least one token to re-evaluate so the
 	// pipeline can seed token generation from it.
 	if matched == len(inputs) && matched > 0 {
-		matchPath, matched = findBestMatch(c.root, inputs[:len(inputs)-1])
+		matchPath, matched = findBestMatch(c.root, keys[:matched-1])
 	}
 
 	// Switch to the matched path, paging in/out as needed.
@@ -125,6 +130,28 @@ func (c *prefixCache) begin(inputs []int32) *cacheSession {
 	slog.Info(msg, "total", len(inputs), "matched", originalMatched, "cached", prefix, "left", len(remaining))
 
 	return session
+}
+
+// key converts tokens to trie keys, one per restorable cache offset. A model
+// that drafts through MTP-style draft caches pairs each cache slot with the
+// token after it, so slot i is reusable only if token i+1 also matched. The
+// key for offset i then packs (token i, token i+1): matching k keys verifies
+// k+1 tokens, making every match a valid restore point.
+func (c *prefixCache) key(tokens []int32) []trieKey {
+	keys := make([]trieKey, max(len(tokens)-c.draftLookahead, 0))
+	switch c.draftLookahead {
+	case 0:
+		for i, t := range tokens {
+			keys[i] = trieKey(t)
+		}
+	case 1:
+		for i := range keys {
+			keys[i] = trieKey(uint32(tokens[i]))<<32 | trieKey(uint32(tokens[i+1]))
+		}
+	default:
+		panic(fmt.Sprintf("prefixCache: unsupported draft look-ahead %d", c.draftLookahead))
+	}
+	return keys
 }
 
 // switchToPath transitions from the current active path to a new path,
@@ -252,9 +279,11 @@ pageIn:
 
 // schedulePrefillSnapshots schedules every cache to capture snapshots as the
 // forward pass crosses the given absolute token offsets, so a single full-size
-// prefill records interior states without the caller breaking the batch. The
-// passed offsets are user-requested restore points; they are merged with any
-// snapshots begin already scheduled (e.g. a branch point), with coinciding
+// prefill records interior states without the caller breaking the batch. A
+// passed offset names a token prefix; the capture lands at the deepest
+// state that prefix alone determines (offset - draftLookahead), which is where
+// a prompt sharing exactly that prefix restores. The offsets are merged with
+// any snapshots begin already scheduled (e.g. a branch point), with coinciding
 // offsets upgraded to user so eviction preserves them.
 //
 // Offsets at or before the current cache position, or past the end of the
@@ -264,6 +293,7 @@ func (s *cacheSession) schedulePrefillSnapshots(offsets []int) {
 	c := s.cache
 	base := c.minCacheOffset()
 	for _, offset := range offsets {
+		offset -= c.draftLookahead
 		if offset <= base || offset > len(s.inputs) {
 			continue
 		}
@@ -360,7 +390,7 @@ func (s *cacheSession) attachPrefillSnapshots() {
 	// no captured state. Skip it rather than materialize a node whose edge
 	// claims tokens the cache never wrote. Closing its (nil) row is a no-op.
 	reached := c.minCacheOffset()
-	stored := append(s.inputs, s.outputs...)
+	stored := c.key(append(s.inputs, s.outputs...))
 	for i, p := range pending {
 		if p.offset > reached {
 			// Never crossed by a write, so the row is nil; close any entry
@@ -400,7 +430,7 @@ func (s *cacheSession) attachCapturedSnapshots(node *trieNode, snaps []cache.Sna
 // advancePath advances the active path from the current frontier by matching
 // tokens against existing trie children, splitting partial matches, and
 // appending any remaining tokens as new nodes. Returns the new frontier.
-func (c *prefixCache) advancePath(frontier *trieNode, tokens []int32, endOffset int) *trieNode {
+func (c *prefixCache) advancePath(frontier *trieNode, tokens []trieKey, endOffset int) *trieNode {
 	// Check if existing children already cover some or all of tokens.
 	// tokens may span multiple trie nodes when extending a previous run's
 	// leaf and this snapshot now overlaps that same range.
@@ -487,12 +517,17 @@ func (s *cacheSession) close() {
 	// that we also actually have the data.
 	mlx.AsyncEval(arrays...)
 
-	// Advance the trie frontier with any newly generated tokens.
+	// The caches never advance past the stored keys; anything more
+	// means positions desynced.
 	c := s.cache
+	stored := c.key(append(s.inputs, s.outputs...))
+	if offset > len(stored) {
+		panic(fmt.Sprintf("cache: offset %d exceeds %d stored keys", offset, len(stored)))
+	}
+
+	// Advance the trie frontier with any newly generated tokens.
 	if len(c.activePath) > 0 {
 		frontier := c.activePath[len(c.activePath)-1]
-		stored := append(s.inputs, s.outputs...)
-
 		if offset > frontier.endOffset {
 			newTokens := stored[frontier.endOffset:offset]
 			c.advancePath(frontier, newTokens, offset)

--- a/x/mlxrunner/prefix_cache_test.go
+++ b/x/mlxrunner/prefix_cache_test.go
@@ -495,23 +495,24 @@ func simulateRequest(t *testing.T, pc *prefixCache, inputs, generated []int32, u
 	assertCacheOffsetAlignment(t, pc, "after begin")
 
 	baseOffset := pc.minCacheOffset()
-	remaining := inputs[baseOffset:]
+	seed := len(inputs) - 1
 
-	// Prefill: schedule the pending snapshots, feed the whole prompt in one pass
-	// (the caches self-segment at the scheduled offsets), then attach the
-	// captures to the trie.
+	// Prefill: schedule the pending snapshots, feed the prompt up to the
+	// seed token in one pass (the caches self-segment at the scheduled
+	// offsets), then attach the captures to the trie.
 	session.schedulePrefillSnapshots(snapshotOffsets)
-	if len(remaining) > 0 {
-		feedAll(pc.caches, remaining)
+	if baseOffset < seed {
+		feedAll(pc.caches, inputs[baseOffset:seed])
 	}
 	session.attachPrefillSnapshots()
 
 	assertCacheOffsetAlignment(t, pc, "after prefill")
 
-	// Generate tokens.
+	// Decode: feed the seed and all but the last generated token.
 	if len(generated) > 0 {
 		session.outputs = generated
-		feedAll(pc.caches, generated)
+		feedAll(pc.caches, inputs[seed:])
+		feedAll(pc.caches, generated[:len(generated)-1])
 	}
 
 	assertCacheOffsetAlignment(t, pc, "before close")
@@ -586,7 +587,7 @@ func checkTrieInvariants(t *testing.T, root *trieNode) {
 			}
 		}
 		// No two siblings should start with the same token.
-		seen := make(map[int32]bool)
+		seen := make(map[trieKey]bool)
 		for _, c := range n.children {
 			if len(c.tokens) > 0 {
 				first := c.tokens[0]
@@ -641,21 +642,36 @@ func checkSnapshotLeaks(t *testing.T, tracker *snapshotTracker, root *trieNode) 
 	}
 }
 
-// forEachEnv runs fn as subtests for three realistic model configurations:
+// forEachEnv runs fn as subtests for three realistic model configurations —
 // pure transformer, transformer + sliding window (Mistral-style), and
-// transformer + recurrent (Jamba-style). Leak checking runs automatically
-// at the end of each subtest.
+// transformer + recurrent (Jamba-style) — each with and without a draft
+// look-ahead. Leak checking runs automatically at the end of each subtest.
 func forEachEnv(t *testing.T, fn func(t *testing.T, env *testEnv)) {
 	t.Helper()
-	run := func(t *testing.T, env *testEnv) {
-		t.Cleanup(func() {
-			checkSnapshotLeaks(t, env.tracker, env.pc.root)
-		})
-		fn(t, env)
+	envs := []struct {
+		name string
+		make func() *testEnv
+	}{
+		{"Transformer", newTransformerEnv},
+		{"SlidingWindow", newSlidingWindowEnv},
+		{"Recurrent", newRecurrentEnv},
 	}
-	t.Run("Transformer", func(t *testing.T) { run(t, newTransformerEnv()) })
-	t.Run("SlidingWindow", func(t *testing.T) { run(t, newSlidingWindowEnv()) })
-	t.Run("Recurrent", func(t *testing.T) { run(t, newRecurrentEnv()) })
+	for _, e := range envs {
+		for _, lookahead := range []int{0, 1} {
+			name := e.name
+			if lookahead > 0 {
+				name += "+Lookahead"
+			}
+			t.Run(name, func(t *testing.T) {
+				env := e.make()
+				env.pc.draftLookahead = lookahead
+				t.Cleanup(func() {
+					checkSnapshotLeaks(t, env.tracker, env.pc.root)
+				})
+				fn(t, env)
+			})
+		}
+	}
 }
 
 // TestBranchCreationAndReuse exercises the core multi-conversation lifecycle:
@@ -671,25 +687,28 @@ func TestBranchCreationAndReuse(t *testing.T) {
 		if len(resA.remaining) != 8 {
 			t.Fatalf("A: remaining = %d, want 8 (full miss)", len(resA.remaining))
 		}
-		env.assertAllTokens(t, "after A", []int32{1, 2, 3, 4, 5, 6, 7, 8, 20, 21})
+		env.assertAllTokens(t, "after A", []int32{1, 2, 3, 4, 5, 6, 7, 8, 20})
 
-		// Verify trie was populated by close().
-		_, mA := findBestMatch(pc.root, []int32{1, 2, 3, 4, 5, 6, 7, 8, 20, 21})
-		if mA != 10 {
-			t.Fatalf("A findable: expected 10 matched, got %d", mA)
+		// Verify trie was populated by close(): everything in the caches
+		// is findable; the last generated token is not.
+		seqA := []int32{1, 2, 3, 4, 5, 6, 7, 8, 20, 21}
+		_, mA := findBestMatch(pc.root, pc.key(seqA))
+		if want := len(seqA) - 1; mA != want {
+			t.Fatalf("A findable: expected %d matched, got %d", want, mA)
 		}
 
 		// Request B: [1,2,3,4,5,10,11,12] — shares 5-token prefix with A.
 		// For rewindable caches, switchToPath rewinds to the match point
-		// so only the non-matching suffix needs evaluation. For non-rewindable
-		// caches (RecurrentCache), the rewind fails and freeAll fires.
+		// (one below the shared tokens with a look-ahead) so only the suffix
+		// needs evaluation. For non-rewindable caches (RecurrentCache), the
+		// rewind fails and freeAll fires.
 		resB := simulateRequest(t, pc, []int32{1, 2, 3, 4, 5, 10, 11, 12}, []int32{30, 31})
 		if env.rewindable {
 			if resB.pendingSnapshots != 0 {
 				t.Fatalf("B: pendingSnapshots = %d, want 0 (rewind succeeded)", resB.pendingSnapshots)
 			}
-			if len(resB.remaining) != 3 {
-				t.Fatalf("B: remaining = %d, want 3 (rewind to match point)", len(resB.remaining))
+			if want := 3 + pc.draftLookahead; len(resB.remaining) != want {
+				t.Fatalf("B: remaining = %d, want %d (rewind to match point)", len(resB.remaining), want)
 			}
 		} else {
 			if resB.pendingSnapshots != 1 {
@@ -699,14 +718,14 @@ func TestBranchCreationAndReuse(t *testing.T) {
 				t.Fatalf("B: remaining = %d, want 8 (freeAll fallback)", len(resB.remaining))
 			}
 		}
-		env.assertAllTokens(t, "after B", []int32{1, 2, 3, 4, 5, 10, 11, 12, 30, 31})
+		env.assertAllTokens(t, "after B", []int32{1, 2, 3, 4, 5, 10, 11, 12, 30})
 
 		// Both A and B should be findable in the trie.
-		_, mA2 := findBestMatch(pc.root, []int32{1, 2, 3, 4, 5, 6, 7, 8, 20, 21})
+		_, mA2 := findBestMatch(pc.root, pc.key(seqA))
 		if mA2 < 5 {
 			t.Fatalf("A still findable: expected >= 5 matched, got %d", mA2)
 		}
-		_, mB := findBestMatch(pc.root, []int32{1, 2, 3, 4, 5, 10, 11, 12, 30, 31})
+		_, mB := findBestMatch(pc.root, pc.key([]int32{1, 2, 3, 4, 5, 10, 11, 12, 30, 31}))
 		if mB < 5 {
 			t.Fatalf("B findable: expected >= 5 matched, got %d", mB)
 		}
@@ -717,7 +736,7 @@ func TestBranchCreationAndReuse(t *testing.T) {
 		if len(resC.remaining) >= 10 {
 			t.Fatalf("C: remaining = %d, want < 10 (should get cache hit)", len(resC.remaining))
 		}
-		env.assertAllTokens(t, "after C", []int32{1, 2, 3, 4, 5, 6, 7, 8, 40, 41})
+		env.assertAllTokens(t, "after C", []int32{1, 2, 3, 4, 5, 6, 7, 8, 40})
 
 		checkTrieInvariants(t, pc.root)
 	})
@@ -753,7 +772,7 @@ func TestExactMatchSeedBehavior(t *testing.T) {
 				t.Fatalf("B: pendingSnapshots = %d, want 1", resB.pendingSnapshots)
 			}
 		}
-		env.assertAllTokens(t, "after B", []int32{1, 2, 3, 4, 5, 20, 21})
+		env.assertAllTokens(t, "after B", []int32{1, 2, 3, 4, 5, 20})
 
 		checkTrieInvariants(t, pc.root)
 	})
@@ -768,22 +787,22 @@ func TestConversationResumption(t *testing.T) {
 
 		// Turn 1: system prompt + user message, assistant generates response.
 		simulateRequest(t, pc, []int32{1, 2, 3, 4, 5}, []int32{10, 11, 12})
-		env.assertAllTokens(t, "turn 1", []int32{1, 2, 3, 4, 5, 10, 11, 12})
+		env.assertAllTokens(t, "turn 1", []int32{1, 2, 3, 4, 5, 10, 11})
 
-		// Turn 2: full history + new user message. Should get a cache hit on
-		// the prefix [1,2,3,4,5,10,11,12] and only need to evaluate [20,21].
+		// Turn 2: full history + new user message; the match lands exactly
+		// at the caches' offset, so even exact-offset state is reused.
 		resB := simulateRequest(t, pc, []int32{1, 2, 3, 4, 5, 10, 11, 12, 20, 21}, []int32{30})
 		if len(resB.remaining) > 5 {
 			t.Fatalf("turn 2: remaining = %d, want <= 5 (should reuse most of history)", len(resB.remaining))
 		}
-		env.assertAllTokens(t, "turn 2", []int32{1, 2, 3, 4, 5, 10, 11, 12, 20, 21, 30})
+		env.assertAllTokens(t, "turn 2", []int32{1, 2, 3, 4, 5, 10, 11, 12, 20, 21})
 
 		// Turn 3: even longer history.
 		resC := simulateRequest(t, pc, []int32{1, 2, 3, 4, 5, 10, 11, 12, 20, 21, 30, 40, 41}, nil)
 		if len(resC.remaining) > 5 {
 			t.Fatalf("turn 3: remaining = %d, want <= 5", len(resC.remaining))
 		}
-		env.assertAllTokens(t, "turn 3", []int32{1, 2, 3, 4, 5, 10, 11, 12, 20, 21, 30, 40, 41})
+		env.assertAllTokens(t, "turn 3", []int32{1, 2, 3, 4, 5, 10, 11, 12, 20, 21, 30, 40})
 
 		checkTrieInvariants(t, pc.root)
 	})
@@ -834,9 +853,9 @@ func TestEvictionPreservesActiveConversations(t *testing.T) {
 
 		// System prompt prefix should still be findable (multi-child
 		// branch points are protected from eviction entirely).
-		_, matched := findBestMatch(pc.root, systemPrompt)
-		if matched < len(systemPrompt) {
-			t.Fatalf("system prompt match = %d, want %d", matched, len(systemPrompt))
+		_, matched := findBestMatch(pc.root, pc.key(systemPrompt))
+		if want := len(pc.key(systemPrompt)); matched < want {
+			t.Fatalf("system prompt match = %d, want %d", matched, want)
 		}
 
 		checkTrieInvariants(t, pc.root)
@@ -844,30 +863,39 @@ func TestEvictionPreservesActiveConversations(t *testing.T) {
 }
 
 // TestUserSnapshotPreservesRestorePoint verifies that user-created snapshots
-// (snapshot(true)) resist structural changes that would destroy them:
+// (snapshot(true)) are exact restore points that resist structural changes:
 //   - A user node forces new tokens into a child instead of extending in-place
+//   - A prompt diverging at the snapshot resumes there, even for caches that
+//     cannot rewind
 //   - The snapshot remains restorable after other branches are added
 func TestUserSnapshotPreservesRestorePoint(t *testing.T) {
 	forEachEnv(t, func(t *testing.T, env *testEnv) {
 		pc := env.pc
+		inputs := []int32{1, 2, 3, 4, 5}
 
-		// Request A: user snapshot at offset 5, then generate.
-		simulateRequest(t, pc, []int32{1, 2, 3, 4, 5}, []int32{10, 11}, 5)
+		// Request A: user snapshot at offset 4, then generate.
+		simulateRequest(t, pc, inputs, []int32{10, 11}, 4)
 
 		assertUserNodeExists(t, pc, "after A")
 
-		// Request B: extends A's prefix. The user node at offset 5 should
-		// force tokens into a child rather than extending in-place.
+		// Request B: extends A's prefix. The user node should force tokens
+		// into a child rather than extending in-place.
 		simulateRequest(t, pc, []int32{1, 2, 3, 4, 5, 10, 11, 20, 21}, nil)
-		env.assertAllTokens(t, "after B", []int32{1, 2, 3, 4, 5, 10, 11, 20, 21})
+		env.assertAllTokens(t, "after B", []int32{1, 2, 3, 4, 5, 10, 11, 20})
 		assertUserNodeExists(t, pc, "after B")
 
-		// Request C: diverge from the user node.
-		simulateRequest(t, pc, []int32{1, 2, 3, 4, 5, 30, 31}, []int32{40})
+		// Request C: diverge at the snapshot — prefill resumes at its capture
+		// point, one token lower with a look-ahead (the boundary token
+		// re-evaluates to rebuild its draft pair).
+		divergeC := append(slices.Clone(inputs[:4]), 30, 31)
+		resC := simulateRequest(t, pc, divergeC, []int32{40})
+		if want := divergeC[4-pc.draftLookahead:]; !slices.Equal(resC.remaining, want) {
+			t.Fatalf("C: remaining = %v, want %v", resC.remaining, want)
+		}
 
 		// Request D: switch back to A's branch — user snapshot still restorable.
 		simulateRequest(t, pc, []int32{1, 2, 3, 4, 5, 10, 11, 20, 21, 50}, nil)
-		env.assertAllTokens(t, "back to A", []int32{1, 2, 3, 4, 5, 10, 11, 20, 21, 50})
+		env.assertAllTokens(t, "back to A", []int32{1, 2, 3, 4, 5, 10, 11, 20, 21})
 
 		checkTrieInvariants(t, pc.root)
 	})
@@ -878,9 +906,10 @@ func TestUserSnapshotPreservesRestorePoint(t *testing.T) {
 func TestUserSnapshotResistsAutoMerge(t *testing.T) {
 	forEachEnv(t, func(t *testing.T, env *testEnv) {
 		pc := env.pc
+		inputs := []int32{1, 2, 3, 4, 5}
 
 		// Request A: user snapshot at offset 3, then continue to offset 5.
-		simulateRequest(t, pc, []int32{1, 2, 3, 4, 5}, []int32{10}, 3)
+		simulateRequest(t, pc, inputs, []int32{10}, 3)
 
 		// Request B: diverges at the user node, creating a second child.
 		simulateRequest(t, pc, []int32{1, 2, 3, 6, 7}, []int32{20})
@@ -924,20 +953,25 @@ func TestSnapshotBeyondPrefillSkipped(t *testing.T) {
 		inputs := []int32{1, 2, 3, 4, 5}
 
 		session := pc.begin(inputs)
-		// Request a reachable snapshot at 3 and one at len(inputs), which a
-		// prefill that stops one token short never crosses.
+		// Request a snapshot at 3 and one at len(inputs); captures land at
+		// the requested prefix minus the look-ahead.
 		session.schedulePrefillSnapshots([]int{3, len(inputs)})
 		// Prefill writes all but the final token (mirrors total-processed > 1).
 		feedAll(pc.caches, inputs[pc.minCacheOffset():len(inputs)-1])
 		session.attachPrefillSnapshots()
 
-		// The reachable offset became a node; the unreached one did not.
-		if !nodeExistsAtOffset(pc.root, 3) {
-			t.Errorf("no trie node at reached offset 3")
+		// The first request became a node at its capture point; nothing may
+		// claim offsets the prefill never wrote.
+		if at := 3 - pc.draftLookahead; !nodeExistsAtOffset(pc.root, at) {
+			t.Errorf("no trie node at capture point %d", at)
 		}
-		if nodeExistsAtOffset(pc.root, len(inputs)) {
-			t.Errorf("trie node materialized at unreached offset %d", len(inputs))
-		}
+		reached := pc.minCacheOffset()
+		walkNodes(pc.root, func(n *trieNode) bool {
+			if n.endOffset > reached {
+				t.Errorf("trie node materialized at unwritten offset %d", n.endOffset)
+			}
+			return true
+		})
 
 		checkTrieInvariants(t, pc.root)
 	})
@@ -971,7 +1005,7 @@ func TestPrefillSnapshotsDiscardedOnCancel(t *testing.T) {
 
 		// A second request re-prepares snapshots on the same caches: if the
 		// discarded ones were not closed, prepare() orphans them here.
-		simulateRequest(t, pc, inputs, nil, 4)
+		simulateRequest(t, pc, inputs, nil, 5)
 
 		checkTrieInvariants(t, pc.root)
 	})
@@ -1027,15 +1061,15 @@ func TestBranchSwitchRestoresCorrectState(t *testing.T) {
 
 		// Request A: [1,2,3,4,5] + generate [10,11]
 		simulateRequest(t, pc, []int32{1, 2, 3, 4, 5}, []int32{10, 11})
-		env.assertAllTokens(t, "after A", []int32{1, 2, 3, 4, 5, 10, 11})
+		env.assertAllTokens(t, "after A", []int32{1, 2, 3, 4, 5, 10})
 
 		// Request B: [1,2,3,6,7] — diverges at token 4
 		simulateRequest(t, pc, []int32{1, 2, 3, 6, 7}, []int32{12, 13})
-		env.assertAllTokens(t, "after B", []int32{1, 2, 3, 6, 7, 12, 13})
+		env.assertAllTokens(t, "after B", []int32{1, 2, 3, 6, 7, 12})
 
 		// Request C: switch back to A's branch [1,2,3,4,5,10,11,20]
 		simulateRequest(t, pc, []int32{1, 2, 3, 4, 5, 10, 11, 20}, nil)
-		env.assertAllTokens(t, "after C (back to A)", []int32{1, 2, 3, 4, 5, 10, 11, 20})
+		env.assertAllTokens(t, "after C (back to A)", []int32{1, 2, 3, 4, 5, 10, 11})
 
 		checkTrieInvariants(t, pc.root)
 	})
@@ -1066,7 +1100,9 @@ func TestLRUOnlyUpdatesUsedNodes(t *testing.T) {
 		// and extend it. The branch point's snapshot may be paged in
 		// for some cache types but not others.
 		beforeRequest := time.Now()
-		simulateRequest(t, pc, []int32{1, 2, 3, 6, 7, 20, 21, 30}, nil)
+		inputsC := []int32{1, 2, 3, 6, 7, 20, 21, 30}
+		resC := simulateRequest(t, pc, inputsC, nil)
+		landing := len(inputsC) - len(resC.remaining)
 
 		// The path must have enough depth to exercise intermediate nodes.
 		if len(pc.activePath) < 3 {
@@ -1080,9 +1116,12 @@ func TestLRUOnlyUpdatesUsedNodes(t *testing.T) {
 				frontier.lastUsed, beforeRequest)
 		}
 
-		// Every non-frontier node on the active path (including root)
-		// should retain its old lastUsed — only the frontier gets refreshed.
+		// Only used nodes refresh — the frontier and the restore landing;
+		// merely traversed nodes keep their age so they can still evict.
 		for i, node := range pc.activePath[:len(pc.activePath)-1] {
+			if node.endOffset == landing {
+				continue
+			}
 			if !node.lastUsed.Before(beforeRequest) {
 				t.Errorf("activePath[%d] (endOffset=%d) lastUsed was refreshed: got %v, want < %v",
 					i, node.endOffset, node.lastUsed, beforeRequest)
@@ -1101,7 +1140,7 @@ func TestPagedOutBytesUpdatesOnMaterialize(t *testing.T) {
 	pc := &prefixCache{}
 	pc.ensureRoot()
 
-	node := &trieNode{parent: pc.root, tokens: []int32{1, 2, 3}, endOffset: 3}
+	node := &trieNode{parent: pc.root, tokens: []trieKey{1, 2, 3}, endOffset: 3}
 	pc.root.children = append(pc.root.children, node)
 
 	snap := &fakeSnapshot{from: 0, to: 3, byteSize: 0}
@@ -1127,7 +1166,7 @@ func TestSwapSnapshotsDetachesHook(t *testing.T) {
 	pc := &prefixCache{}
 	pc.ensureRoot()
 
-	node := &trieNode{parent: pc.root, tokens: []int32{1, 2, 3}, endOffset: 3}
+	node := &trieNode{parent: pc.root, tokens: []trieKey{1, 2, 3}, endOffset: 3}
 	pc.root.children = append(pc.root.children, node)
 
 	snap := &fakeSnapshot{from: 0, to: 3, byteSize: 0}

--- a/x/mlxrunner/prefix_cache_test.go
+++ b/x/mlxrunner/prefix_cache_test.go
@@ -479,7 +479,7 @@ type requestResult struct {
 func simulateRequest(t *testing.T, pc *prefixCache, inputs, generated []int32, userSnapshotAt ...int) requestResult {
 	t.Helper()
 
-	session := pc.begin(nil, inputs)
+	session := pc.begin(inputs)
 	var snapshotOffsets []int
 	for _, at := range userSnapshotAt {
 		if at > 0 {
@@ -923,7 +923,7 @@ func TestSnapshotBeyondPrefillSkipped(t *testing.T) {
 		pc := env.pc
 		inputs := []int32{1, 2, 3, 4, 5}
 
-		session := pc.begin(nil, inputs)
+		session := pc.begin(inputs)
 		// Request a reachable snapshot at 3 and one at len(inputs), which a
 		// prefill that stops one token short never crosses.
 		session.schedulePrefillSnapshots([]int{3, len(inputs)})
@@ -953,7 +953,7 @@ func TestPrefillSnapshotsDiscardedOnCancel(t *testing.T) {
 		pc := env.pc
 		inputs := []int32{1, 2, 3, 4, 5}
 
-		session := pc.begin(nil, inputs)
+		session := pc.begin(inputs)
 		session.schedulePrefillSnapshots([]int{3})
 		// Cross offset 3 so the caches capture it, then close the session as a
 		// canceled prefill would, before the captures are attached to the trie.

--- a/x/mlxrunner/prefix_cache_test.go
+++ b/x/mlxrunner/prefix_cache_test.go
@@ -398,9 +398,9 @@ type feedableCache interface {
 	feed(tokens []int32)
 }
 
-// testEnv encapsulates a kvCache and its fake caches for a test scenario.
+// testEnv encapsulates a prefixCache and its fake caches for a test scenario.
 type testEnv struct {
-	kvc        *kvCache
+	pc         *prefixCache
 	caches     []cache.Cache // typed references for assertions
 	tracker    *snapshotTracker
 	rewindable bool // true when all caches support arbitrary Restore(nil, target)
@@ -412,7 +412,7 @@ func newTransformerEnv() *testEnv {
 	tracker := &snapshotTracker{}
 	caches := []cache.Cache{&fakeRewindableCache{tracker: tracker}}
 	return &testEnv{
-		kvc:        &kvCache{caches: caches},
+		pc:         &prefixCache{caches: caches},
 		caches:     caches,
 		tracker:    tracker,
 		rewindable: true,
@@ -430,7 +430,7 @@ func newSlidingWindowEnv() *testEnv {
 	sw := &fakeSlidingWindowCache{maxSize: 4, tracker: tr}
 	caches := []cache.Cache{rc, sw}
 	return &testEnv{
-		kvc:        &kvCache{caches: caches},
+		pc:         &prefixCache{caches: caches},
 		caches:     caches,
 		tracker:    tr,
 		rewindable: false,
@@ -445,7 +445,7 @@ func newRecurrentEnv() *testEnv {
 	nrc := &fakeRecurrentCache{tracker: tr}
 	caches := []cache.Cache{rc, nrc}
 	return &testEnv{
-		kvc:        &kvCache{caches: caches},
+		pc:         &prefixCache{caches: caches},
 		caches:     caches,
 		tracker:    tr,
 		rewindable: false,
@@ -476,10 +476,10 @@ type requestResult struct {
 
 // simulateRequest runs a request through the harness. If userSnapshotAt > 0,
 // a user snapshot is requested at that offset during prefill.
-func simulateRequest(t *testing.T, kvc *kvCache, inputs, generated []int32, userSnapshotAt ...int) requestResult {
+func simulateRequest(t *testing.T, pc *prefixCache, inputs, generated []int32, userSnapshotAt ...int) requestResult {
 	t.Helper()
 
-	session := kvc.begin(nil, inputs)
+	session := pc.begin(nil, inputs)
 	var snapshotOffsets []int
 	for _, at := range userSnapshotAt {
 		if at > 0 {
@@ -492,9 +492,9 @@ func simulateRequest(t *testing.T, kvc *kvCache, inputs, generated []int32, user
 		pendingSnapshots: len(session.pendingSnapshots),
 	}
 
-	assertCacheOffsetAlignment(t, kvc, "after begin")
+	assertCacheOffsetAlignment(t, pc, "after begin")
 
-	baseOffset := kvc.minCacheOffset()
+	baseOffset := pc.minCacheOffset()
 	remaining := inputs[baseOffset:]
 
 	// Prefill: schedule the pending snapshots, feed the whole prompt in one pass
@@ -502,19 +502,19 @@ func simulateRequest(t *testing.T, kvc *kvCache, inputs, generated []int32, user
 	// captures to the trie.
 	session.schedulePrefillSnapshots(snapshotOffsets)
 	if len(remaining) > 0 {
-		feedAll(kvc.caches, remaining)
+		feedAll(pc.caches, remaining)
 	}
 	session.attachPrefillSnapshots()
 
-	assertCacheOffsetAlignment(t, kvc, "after prefill")
+	assertCacheOffsetAlignment(t, pc, "after prefill")
 
 	// Generate tokens.
 	if len(generated) > 0 {
 		session.outputs = generated
-		feedAll(kvc.caches, generated)
+		feedAll(pc.caches, generated)
 	}
 
-	assertCacheOffsetAlignment(t, kvc, "before close")
+	assertCacheOffsetAlignment(t, pc, "before close")
 	session.close()
 	return result
 }
@@ -528,14 +528,14 @@ func feedAll(caches []cache.Cache, tokens []int32) {
 }
 
 // assertCacheOffsetAlignment verifies all caches report the same offset.
-func assertCacheOffsetAlignment(t *testing.T, kvc *kvCache, label string) {
+func assertCacheOffsetAlignment(t *testing.T, pc *prefixCache, label string) {
 	t.Helper()
-	if len(kvc.caches) < 2 {
+	if len(pc.caches) < 2 {
 		return
 	}
-	expected := kvc.caches[0].Offset()
-	for i := 1; i < len(kvc.caches); i++ {
-		if got := kvc.caches[i].Offset(); got != expected {
+	expected := pc.caches[0].Offset()
+	for i := 1; i < len(pc.caches); i++ {
+		if got := pc.caches[i].Offset(); got != expected {
 			t.Errorf("%s: cache %d offset=%d != cache 0 offset=%d", label, i, got, expected)
 		}
 	}
@@ -649,7 +649,7 @@ func forEachEnv(t *testing.T, fn func(t *testing.T, env *testEnv)) {
 	t.Helper()
 	run := func(t *testing.T, env *testEnv) {
 		t.Cleanup(func() {
-			checkSnapshotLeaks(t, env.tracker, env.kvc.root)
+			checkSnapshotLeaks(t, env.tracker, env.pc.root)
 		})
 		fn(t, env)
 	}
@@ -664,17 +664,17 @@ func forEachEnv(t *testing.T, fn func(t *testing.T, env *testEnv)) {
 // hit lengths, and that semantic caches contain the correct token sequences.
 func TestBranchCreationAndReuse(t *testing.T) {
 	forEachEnv(t, func(t *testing.T, env *testEnv) {
-		kvc := env.kvc
+		pc := env.pc
 
 		// Request A: [1,2,3,4,5,6,7,8] + generate [20,21] — full miss.
-		resA := simulateRequest(t, kvc, []int32{1, 2, 3, 4, 5, 6, 7, 8}, []int32{20, 21})
+		resA := simulateRequest(t, pc, []int32{1, 2, 3, 4, 5, 6, 7, 8}, []int32{20, 21})
 		if len(resA.remaining) != 8 {
 			t.Fatalf("A: remaining = %d, want 8 (full miss)", len(resA.remaining))
 		}
 		env.assertAllTokens(t, "after A", []int32{1, 2, 3, 4, 5, 6, 7, 8, 20, 21})
 
 		// Verify trie was populated by close().
-		_, mA := findBestMatch(kvc.root, []int32{1, 2, 3, 4, 5, 6, 7, 8, 20, 21})
+		_, mA := findBestMatch(pc.root, []int32{1, 2, 3, 4, 5, 6, 7, 8, 20, 21})
 		if mA != 10 {
 			t.Fatalf("A findable: expected 10 matched, got %d", mA)
 		}
@@ -683,7 +683,7 @@ func TestBranchCreationAndReuse(t *testing.T) {
 		// For rewindable caches, switchToPath rewinds to the match point
 		// so only the non-matching suffix needs evaluation. For non-rewindable
 		// caches (RecurrentCache), the rewind fails and freeAll fires.
-		resB := simulateRequest(t, kvc, []int32{1, 2, 3, 4, 5, 10, 11, 12}, []int32{30, 31})
+		resB := simulateRequest(t, pc, []int32{1, 2, 3, 4, 5, 10, 11, 12}, []int32{30, 31})
 		if env.rewindable {
 			if resB.pendingSnapshots != 0 {
 				t.Fatalf("B: pendingSnapshots = %d, want 0 (rewind succeeded)", resB.pendingSnapshots)
@@ -702,24 +702,24 @@ func TestBranchCreationAndReuse(t *testing.T) {
 		env.assertAllTokens(t, "after B", []int32{1, 2, 3, 4, 5, 10, 11, 12, 30, 31})
 
 		// Both A and B should be findable in the trie.
-		_, mA2 := findBestMatch(kvc.root, []int32{1, 2, 3, 4, 5, 6, 7, 8, 20, 21})
+		_, mA2 := findBestMatch(pc.root, []int32{1, 2, 3, 4, 5, 6, 7, 8, 20, 21})
 		if mA2 < 5 {
 			t.Fatalf("A still findable: expected >= 5 matched, got %d", mA2)
 		}
-		_, mB := findBestMatch(kvc.root, []int32{1, 2, 3, 4, 5, 10, 11, 12, 30, 31})
+		_, mB := findBestMatch(pc.root, []int32{1, 2, 3, 4, 5, 10, 11, 12, 30, 31})
 		if mB < 5 {
 			t.Fatalf("B findable: expected >= 5 matched, got %d", mB)
 		}
 
 		// Request C: [1,2,3,4,5,6,7,8,40,41] — extends A's prefix.
 		// Should get a cache hit for the shared prefix.
-		resC := simulateRequest(t, kvc, []int32{1, 2, 3, 4, 5, 6, 7, 8, 40, 41}, nil)
+		resC := simulateRequest(t, pc, []int32{1, 2, 3, 4, 5, 6, 7, 8, 40, 41}, nil)
 		if len(resC.remaining) >= 10 {
 			t.Fatalf("C: remaining = %d, want < 10 (should get cache hit)", len(resC.remaining))
 		}
 		env.assertAllTokens(t, "after C", []int32{1, 2, 3, 4, 5, 6, 7, 8, 40, 41})
 
-		checkTrieInvariants(t, kvc.root)
+		checkTrieInvariants(t, pc.root)
 	})
 }
 
@@ -728,16 +728,16 @@ func TestBranchCreationAndReuse(t *testing.T) {
 // The last token must be re-evaluated to seed generation.
 func TestExactMatchSeedBehavior(t *testing.T) {
 	forEachEnv(t, func(t *testing.T, env *testEnv) {
-		kvc := env.kvc
+		pc := env.pc
 
 		// Request A: first time.
-		simulateRequest(t, kvc, []int32{1, 2, 3, 4, 5}, []int32{10, 11})
+		simulateRequest(t, pc, []int32{1, 2, 3, 4, 5}, []int32{10, 11})
 
 		// Request B: identical prompt. Holdback means matched=4, partial in
 		// the 5-token edge. For rewindable caches, switchToPath rewinds to
 		// offset 4, so only the held-back token needs re-evaluation. For
 		// non-rewindable caches, the rewind fails and freeAll fires.
-		resB := simulateRequest(t, kvc, []int32{1, 2, 3, 4, 5}, []int32{20, 21})
+		resB := simulateRequest(t, pc, []int32{1, 2, 3, 4, 5}, []int32{20, 21})
 		if env.rewindable {
 			if len(resB.remaining) != 1 {
 				t.Fatalf("B: remaining = %d, want 1 (rewind to holdback point)", len(resB.remaining))
@@ -755,7 +755,7 @@ func TestExactMatchSeedBehavior(t *testing.T) {
 		}
 		env.assertAllTokens(t, "after B", []int32{1, 2, 3, 4, 5, 20, 21})
 
-		checkTrieInvariants(t, kvc.root)
+		checkTrieInvariants(t, pc.root)
 	})
 }
 
@@ -764,28 +764,28 @@ func TestExactMatchSeedBehavior(t *testing.T) {
 // prefix (system prompt + first turn + assistant response).
 func TestConversationResumption(t *testing.T) {
 	forEachEnv(t, func(t *testing.T, env *testEnv) {
-		kvc := env.kvc
+		pc := env.pc
 
 		// Turn 1: system prompt + user message, assistant generates response.
-		simulateRequest(t, kvc, []int32{1, 2, 3, 4, 5}, []int32{10, 11, 12})
+		simulateRequest(t, pc, []int32{1, 2, 3, 4, 5}, []int32{10, 11, 12})
 		env.assertAllTokens(t, "turn 1", []int32{1, 2, 3, 4, 5, 10, 11, 12})
 
 		// Turn 2: full history + new user message. Should get a cache hit on
 		// the prefix [1,2,3,4,5,10,11,12] and only need to evaluate [20,21].
-		resB := simulateRequest(t, kvc, []int32{1, 2, 3, 4, 5, 10, 11, 12, 20, 21}, []int32{30})
+		resB := simulateRequest(t, pc, []int32{1, 2, 3, 4, 5, 10, 11, 12, 20, 21}, []int32{30})
 		if len(resB.remaining) > 5 {
 			t.Fatalf("turn 2: remaining = %d, want <= 5 (should reuse most of history)", len(resB.remaining))
 		}
 		env.assertAllTokens(t, "turn 2", []int32{1, 2, 3, 4, 5, 10, 11, 12, 20, 21, 30})
 
 		// Turn 3: even longer history.
-		resC := simulateRequest(t, kvc, []int32{1, 2, 3, 4, 5, 10, 11, 12, 20, 21, 30, 40, 41}, nil)
+		resC := simulateRequest(t, pc, []int32{1, 2, 3, 4, 5, 10, 11, 12, 20, 21, 30, 40, 41}, nil)
 		if len(resC.remaining) > 5 {
 			t.Fatalf("turn 3: remaining = %d, want <= 5", len(resC.remaining))
 		}
 		env.assertAllTokens(t, "turn 3", []int32{1, 2, 3, 4, 5, 10, 11, 12, 20, 21, 30, 40, 41})
 
-		checkTrieInvariants(t, kvc.root)
+		checkTrieInvariants(t, pc.root)
 	})
 }
 
@@ -794,18 +794,18 @@ func TestConversationResumption(t *testing.T) {
 // active path and shared prefix survive while memory stays bounded.
 func TestEvictionPreservesActiveConversations(t *testing.T) {
 	forEachEnv(t, func(t *testing.T, env *testEnv) {
-		kvc := env.kvc
+		pc := env.pc
 		systemPrompt := []int32{1, 2, 3, 4, 5}
 
 		// Create 5 conversations with unique suffixes.
 		for i := range 5 {
 			suffix := []int32{int32(100 + i*10), int32(101 + i*10), int32(102 + i*10)}
 			inputs := append(slices.Clone(systemPrompt), suffix...)
-			simulateRequest(t, kvc, inputs, []int32{int32(200 + i)})
+			simulateRequest(t, pc, inputs, []int32{int32(200 + i)})
 		}
 
 		// Inflate snapshot sizes to trigger eviction.
-		walkNodes(kvc.root, func(n *trieNode) bool {
+		walkNodes(pc.root, func(n *trieNode) bool {
 			if !n.hasSnapshots() {
 				return true
 			}
@@ -815,31 +815,31 @@ func TestEvictionPreservesActiveConversations(t *testing.T) {
 					snaps[i] = &fakeSnapshot{byteSize: 2 * 1024 * 1024 * 1024} // 2 GiB per snapshot
 				}
 			}
-			n.setSnapshots(snaps, &kvc.pagedOutBytes)
+			n.setSnapshots(snaps, &pc.pagedOutBytes)
 			return true
 		})
 
 		// Run eviction.
-		kvc.enforceEvictionPolicy()
+		pc.enforceEvictionPolicy()
 
 		// Memory should be within limits.
-		if kvc.pagedOutBytes > maxPagedOutBytes {
-			t.Fatalf("pagedOutBytes = %d, want <= %d", kvc.pagedOutBytes, maxPagedOutBytes)
+		if pc.pagedOutBytes > maxPagedOutBytes {
+			t.Fatalf("pagedOutBytes = %d, want <= %d", pc.pagedOutBytes, maxPagedOutBytes)
 		}
 
 		// Active path should be untouched.
-		if len(kvc.activePath) < 2 {
-			t.Fatalf("activePath should have >= 2 nodes, got %d", len(kvc.activePath))
+		if len(pc.activePath) < 2 {
+			t.Fatalf("activePath should have >= 2 nodes, got %d", len(pc.activePath))
 		}
 
 		// System prompt prefix should still be findable (multi-child
 		// branch points are protected from eviction entirely).
-		_, matched := findBestMatch(kvc.root, systemPrompt)
+		_, matched := findBestMatch(pc.root, systemPrompt)
 		if matched < len(systemPrompt) {
 			t.Fatalf("system prompt match = %d, want %d", matched, len(systemPrompt))
 		}
 
-		checkTrieInvariants(t, kvc.root)
+		checkTrieInvariants(t, pc.root)
 	})
 }
 
@@ -849,27 +849,27 @@ func TestEvictionPreservesActiveConversations(t *testing.T) {
 //   - The snapshot remains restorable after other branches are added
 func TestUserSnapshotPreservesRestorePoint(t *testing.T) {
 	forEachEnv(t, func(t *testing.T, env *testEnv) {
-		kvc := env.kvc
+		pc := env.pc
 
 		// Request A: user snapshot at offset 5, then generate.
-		simulateRequest(t, kvc, []int32{1, 2, 3, 4, 5}, []int32{10, 11}, 5)
+		simulateRequest(t, pc, []int32{1, 2, 3, 4, 5}, []int32{10, 11}, 5)
 
-		assertUserNodeExists(t, kvc, "after A")
+		assertUserNodeExists(t, pc, "after A")
 
 		// Request B: extends A's prefix. The user node at offset 5 should
 		// force tokens into a child rather than extending in-place.
-		simulateRequest(t, kvc, []int32{1, 2, 3, 4, 5, 10, 11, 20, 21}, nil)
+		simulateRequest(t, pc, []int32{1, 2, 3, 4, 5, 10, 11, 20, 21}, nil)
 		env.assertAllTokens(t, "after B", []int32{1, 2, 3, 4, 5, 10, 11, 20, 21})
-		assertUserNodeExists(t, kvc, "after B")
+		assertUserNodeExists(t, pc, "after B")
 
 		// Request C: diverge from the user node.
-		simulateRequest(t, kvc, []int32{1, 2, 3, 4, 5, 30, 31}, []int32{40})
+		simulateRequest(t, pc, []int32{1, 2, 3, 4, 5, 30, 31}, []int32{40})
 
 		// Request D: switch back to A's branch — user snapshot still restorable.
-		simulateRequest(t, kvc, []int32{1, 2, 3, 4, 5, 10, 11, 20, 21, 50}, nil)
+		simulateRequest(t, pc, []int32{1, 2, 3, 4, 5, 10, 11, 20, 21, 50}, nil)
 		env.assertAllTokens(t, "back to A", []int32{1, 2, 3, 4, 5, 10, 11, 20, 21, 50})
 
-		checkTrieInvariants(t, kvc.root)
+		checkTrieInvariants(t, pc.root)
 	})
 }
 
@@ -877,22 +877,22 @@ func TestUserSnapshotPreservesRestorePoint(t *testing.T) {
 // a user-marked parent node is not auto-merged with its remaining single child.
 func TestUserSnapshotResistsAutoMerge(t *testing.T) {
 	forEachEnv(t, func(t *testing.T, env *testEnv) {
-		kvc := env.kvc
+		pc := env.pc
 
 		// Request A: user snapshot at offset 3, then continue to offset 5.
-		simulateRequest(t, kvc, []int32{1, 2, 3, 4, 5}, []int32{10}, 3)
+		simulateRequest(t, pc, []int32{1, 2, 3, 4, 5}, []int32{10}, 3)
 
 		// Request B: diverges at the user node, creating a second child.
-		simulateRequest(t, kvc, []int32{1, 2, 3, 6, 7}, []int32{20})
+		simulateRequest(t, pc, []int32{1, 2, 3, 6, 7}, []int32{20})
 
-		userNode := findUserNode(t, kvc)
+		userNode := findUserNode(t, pc)
 		if len(userNode.children) != 2 {
 			t.Fatalf("user node children = %d, want 2", len(userNode.children))
 		}
 
 		// Inflate snapshot sizes and evict. The non-active branch should be
 		// evicted, leaving the user node with one child.
-		walkNodes(kvc.root, func(n *trieNode) bool {
+		walkNodes(pc.root, func(n *trieNode) bool {
 			if !n.hasSnapshots() {
 				return true
 			}
@@ -902,15 +902,15 @@ func TestUserSnapshotResistsAutoMerge(t *testing.T) {
 					snaps[i] = &fakeSnapshot{byteSize: 5 * 1024 * 1024 * 1024}
 				}
 			}
-			n.setSnapshots(snaps, &kvc.pagedOutBytes)
+			n.setSnapshots(snaps, &pc.pagedOutBytes)
 			return true
 		})
-		kvc.enforceEvictionPolicy()
+		pc.enforceEvictionPolicy()
 
 		// The user node should still exist (not auto-merged) even with one child.
-		assertUserNodeExists(t, kvc, "after eviction")
+		assertUserNodeExists(t, pc, "after eviction")
 
-		checkTrieInvariants(t, kvc.root)
+		checkTrieInvariants(t, pc.root)
 	})
 }
 
@@ -920,26 +920,26 @@ func TestUserSnapshotResistsAutoMerge(t *testing.T) {
 // than materialized as a trie node claiming tokens the cache never wrote.
 func TestSnapshotBeyondPrefillSkipped(t *testing.T) {
 	forEachEnv(t, func(t *testing.T, env *testEnv) {
-		kvc := env.kvc
+		pc := env.pc
 		inputs := []int32{1, 2, 3, 4, 5}
 
-		session := kvc.begin(nil, inputs)
+		session := pc.begin(nil, inputs)
 		// Request a reachable snapshot at 3 and one at len(inputs), which a
 		// prefill that stops one token short never crosses.
 		session.schedulePrefillSnapshots([]int{3, len(inputs)})
 		// Prefill writes all but the final token (mirrors total-processed > 1).
-		feedAll(kvc.caches, inputs[kvc.minCacheOffset():len(inputs)-1])
+		feedAll(pc.caches, inputs[pc.minCacheOffset():len(inputs)-1])
 		session.attachPrefillSnapshots()
 
 		// The reachable offset became a node; the unreached one did not.
-		if !nodeExistsAtOffset(kvc.root, 3) {
+		if !nodeExistsAtOffset(pc.root, 3) {
 			t.Errorf("no trie node at reached offset 3")
 		}
-		if nodeExistsAtOffset(kvc.root, len(inputs)) {
+		if nodeExistsAtOffset(pc.root, len(inputs)) {
 			t.Errorf("trie node materialized at unreached offset %d", len(inputs))
 		}
 
-		checkTrieInvariants(t, kvc.root)
+		checkTrieInvariants(t, pc.root)
 	})
 }
 
@@ -950,20 +950,20 @@ func TestSnapshotBeyondPrefillSkipped(t *testing.T) {
 // leaking the snapshots (caught by checkSnapshotLeaks in the env cleanup).
 func TestPrefillSnapshotsDiscardedOnCancel(t *testing.T) {
 	forEachEnv(t, func(t *testing.T, env *testEnv) {
-		kvc := env.kvc
+		pc := env.pc
 		inputs := []int32{1, 2, 3, 4, 5}
 
-		session := kvc.begin(nil, inputs)
+		session := pc.begin(nil, inputs)
 		session.schedulePrefillSnapshots([]int{3})
 		// Cross offset 3 so the caches capture it, then close the session as a
 		// canceled prefill would, before the captures are attached to the trie.
-		feedAll(kvc.caches, inputs[kvc.minCacheOffset():3])
+		feedAll(pc.caches, inputs[pc.minCacheOffset():3])
 		session.close()
 
 		// close advances the trie over the committed tokens, but the abandoned
 		// captures must not be attached as snapshots to any node.
-		walkNodes(kvc.root, func(n *trieNode) bool {
-			if n != kvc.root && n.hasSnapshots() {
+		walkNodes(pc.root, func(n *trieNode) bool {
+			if n != pc.root && n.hasSnapshots() {
 				t.Errorf("abandoned capture attached as snapshot at offset %d", n.endOffset)
 			}
 			return true
@@ -971,9 +971,9 @@ func TestPrefillSnapshotsDiscardedOnCancel(t *testing.T) {
 
 		// A second request re-prepares snapshots on the same caches: if the
 		// discarded ones were not closed, prepare() orphans them here.
-		simulateRequest(t, kvc, inputs, nil, 4)
+		simulateRequest(t, pc, inputs, nil, 4)
 
-		checkTrieInvariants(t, kvc.root)
+		checkTrieInvariants(t, pc.root)
 	})
 }
 
@@ -988,10 +988,10 @@ func nodeExistsAtOffset(root *trieNode, offset int) bool {
 	return found
 }
 
-func findUserNode(t *testing.T, kvc *kvCache) *trieNode {
+func findUserNode(t *testing.T, pc *prefixCache) *trieNode {
 	t.Helper()
 	var found *trieNode
-	walkNodes(kvc.root, func(n *trieNode) bool {
+	walkNodes(pc.root, func(n *trieNode) bool {
 		if n.user {
 			found = n
 		}
@@ -1003,10 +1003,10 @@ func findUserNode(t *testing.T, kvc *kvCache) *trieNode {
 	return found
 }
 
-func assertUserNodeExists(t *testing.T, kvc *kvCache, label string) {
+func assertUserNodeExists(t *testing.T, pc *prefixCache, label string) {
 	t.Helper()
 	var exists bool
-	walkNodes(kvc.root, func(n *trieNode) bool {
+	walkNodes(pc.root, func(n *trieNode) bool {
 		if n.user {
 			exists = true
 		}
@@ -1023,21 +1023,21 @@ func assertUserNodeExists(t *testing.T, kvc *kvCache, label string) {
 // non-rewindable caches.
 func TestBranchSwitchRestoresCorrectState(t *testing.T) {
 	forEachEnv(t, func(t *testing.T, env *testEnv) {
-		kvc := env.kvc
+		pc := env.pc
 
 		// Request A: [1,2,3,4,5] + generate [10,11]
-		simulateRequest(t, kvc, []int32{1, 2, 3, 4, 5}, []int32{10, 11})
+		simulateRequest(t, pc, []int32{1, 2, 3, 4, 5}, []int32{10, 11})
 		env.assertAllTokens(t, "after A", []int32{1, 2, 3, 4, 5, 10, 11})
 
 		// Request B: [1,2,3,6,7] — diverges at token 4
-		simulateRequest(t, kvc, []int32{1, 2, 3, 6, 7}, []int32{12, 13})
+		simulateRequest(t, pc, []int32{1, 2, 3, 6, 7}, []int32{12, 13})
 		env.assertAllTokens(t, "after B", []int32{1, 2, 3, 6, 7, 12, 13})
 
 		// Request C: switch back to A's branch [1,2,3,4,5,10,11,20]
-		simulateRequest(t, kvc, []int32{1, 2, 3, 4, 5, 10, 11, 20}, nil)
+		simulateRequest(t, pc, []int32{1, 2, 3, 4, 5, 10, 11, 20}, nil)
 		env.assertAllTokens(t, "after C (back to A)", []int32{1, 2, 3, 4, 5, 10, 11, 20})
 
-		checkTrieInvariants(t, kvc.root)
+		checkTrieInvariants(t, pc.root)
 	})
 }
 
@@ -1046,18 +1046,18 @@ func TestBranchSwitchRestoresCorrectState(t *testing.T) {
 // refreshed, allowing them to age out and collapse.
 func TestLRUOnlyUpdatesUsedNodes(t *testing.T) {
 	forEachEnv(t, func(t *testing.T, env *testEnv) {
-		kvc := env.kvc
+		pc := env.pc
 
 		// Request A: creates path [1,2,3,4,5] + generate [10,11]
-		simulateRequest(t, kvc, []int32{1, 2, 3, 4, 5}, []int32{10, 11})
+		simulateRequest(t, pc, []int32{1, 2, 3, 4, 5}, []int32{10, 11})
 
 		// Request B: diverges at token 4, creating a branch point at offset 3
 		// with a split snapshot.
-		simulateRequest(t, kvc, []int32{1, 2, 3, 6, 7}, []int32{20, 21})
+		simulateRequest(t, pc, []int32{1, 2, 3, 6, 7}, []int32{20, 21})
 
 		// Set all lastUsed to a known old time.
 		oldTime := time.Now().Add(-1 * time.Hour)
-		walkNodes(kvc.root, func(n *trieNode) bool {
+		walkNodes(pc.root, func(n *trieNode) bool {
 			n.lastUsed = oldTime
 			return true
 		})
@@ -1066,15 +1066,15 @@ func TestLRUOnlyUpdatesUsedNodes(t *testing.T) {
 		// and extend it. The branch point's snapshot may be paged in
 		// for some cache types but not others.
 		beforeRequest := time.Now()
-		simulateRequest(t, kvc, []int32{1, 2, 3, 6, 7, 20, 21, 30}, nil)
+		simulateRequest(t, pc, []int32{1, 2, 3, 6, 7, 20, 21, 30}, nil)
 
 		// The path must have enough depth to exercise intermediate nodes.
-		if len(kvc.activePath) < 3 {
-			t.Fatalf("activePath too short to test intermediate nodes: got %d nodes", len(kvc.activePath))
+		if len(pc.activePath) < 3 {
+			t.Fatalf("activePath too short to test intermediate nodes: got %d nodes", len(pc.activePath))
 		}
 
 		// The frontier (deepest node on the active path) must be updated.
-		frontier := kvc.activePath[len(kvc.activePath)-1]
+		frontier := pc.activePath[len(pc.activePath)-1]
 		if frontier.lastUsed.Before(beforeRequest) {
 			t.Errorf("frontier lastUsed was not updated: got %v, want >= %v",
 				frontier.lastUsed, beforeRequest)
@@ -1082,14 +1082,14 @@ func TestLRUOnlyUpdatesUsedNodes(t *testing.T) {
 
 		// Every non-frontier node on the active path (including root)
 		// should retain its old lastUsed — only the frontier gets refreshed.
-		for i, node := range kvc.activePath[:len(kvc.activePath)-1] {
+		for i, node := range pc.activePath[:len(pc.activePath)-1] {
 			if !node.lastUsed.Before(beforeRequest) {
 				t.Errorf("activePath[%d] (endOffset=%d) lastUsed was refreshed: got %v, want < %v",
 					i, node.endOffset, node.lastUsed, beforeRequest)
 			}
 		}
 
-		checkTrieInvariants(t, kvc.root)
+		checkTrieInvariants(t, pc.root)
 	})
 }
 
@@ -1098,24 +1098,24 @@ func TestLRUOnlyUpdatesUsedNodes(t *testing.T) {
 // state), the trie's pagedOutBytes counter picks up the delta via the
 // installed materialize hook.
 func TestPagedOutBytesUpdatesOnMaterialize(t *testing.T) {
-	kvc := &kvCache{}
-	kvc.ensureRoot()
+	pc := &prefixCache{}
+	pc.ensureRoot()
 
-	node := &trieNode{parent: kvc.root, tokens: []int32{1, 2, 3}, endOffset: 3}
-	kvc.root.children = append(kvc.root.children, node)
+	node := &trieNode{parent: pc.root, tokens: []int32{1, 2, 3}, endOffset: 3}
+	pc.root.children = append(pc.root.children, node)
 
 	snap := &fakeSnapshot{from: 0, to: 3, byteSize: 0}
-	node.setSnapshots([]cache.Snapshot{snap}, &kvc.pagedOutBytes)
+	node.setSnapshots([]cache.Snapshot{snap}, &pc.pagedOutBytes)
 
-	if kvc.pagedOutBytes != 0 {
-		t.Fatalf("pagedOutBytes after install = %d, want 0 (lazy snapshot)", kvc.pagedOutBytes)
+	if pc.pagedOutBytes != 0 {
+		t.Fatalf("pagedOutBytes after install = %d, want 0 (lazy snapshot)", pc.pagedOutBytes)
 	}
 
 	const materialized = 1 << 20
 	snap.materialize(materialized)
 
-	if kvc.pagedOutBytes != materialized {
-		t.Fatalf("pagedOutBytes after materialize = %d, want %d", kvc.pagedOutBytes, materialized)
+	if pc.pagedOutBytes != materialized {
+		t.Fatalf("pagedOutBytes after materialize = %d, want %d", pc.pagedOutBytes, materialized)
 	}
 }
 
@@ -1124,28 +1124,28 @@ func TestPagedOutBytesUpdatesOnMaterialize(t *testing.T) {
 // materialize. Without detach, a Split/Merge that folds an old snapshot
 // elsewhere would double-count its bytes if it copied out afterward.
 func TestSwapSnapshotsDetachesHook(t *testing.T) {
-	kvc := &kvCache{}
-	kvc.ensureRoot()
+	pc := &prefixCache{}
+	pc.ensureRoot()
 
-	node := &trieNode{parent: kvc.root, tokens: []int32{1, 2, 3}, endOffset: 3}
-	kvc.root.children = append(kvc.root.children, node)
+	node := &trieNode{parent: pc.root, tokens: []int32{1, 2, 3}, endOffset: 3}
+	pc.root.children = append(pc.root.children, node)
 
 	snap := &fakeSnapshot{from: 0, to: 3, byteSize: 0}
-	node.setSnapshots([]cache.Snapshot{snap}, &kvc.pagedOutBytes)
+	node.setSnapshots([]cache.Snapshot{snap}, &pc.pagedOutBytes)
 
 	replacement := &fakeSnapshot{from: 0, to: 3, byteSize: 0}
-	old := node.swapSnapshots([]cache.Snapshot{replacement}, &kvc.pagedOutBytes)
+	old := node.swapSnapshots([]cache.Snapshot{replacement}, &pc.pagedOutBytes)
 	if len(old) != 1 || old[0] != snap {
 		t.Fatalf("swapSnapshots returned %v, want the original snap", old)
 	}
 
 	snap.materialize(1 << 20)
-	if kvc.pagedOutBytes != 0 {
-		t.Fatalf("pagedOutBytes after detached materialize = %d, want 0", kvc.pagedOutBytes)
+	if pc.pagedOutBytes != 0 {
+		t.Fatalf("pagedOutBytes after detached materialize = %d, want 0", pc.pagedOutBytes)
 	}
 
 	replacement.materialize(2 << 20)
-	if kvc.pagedOutBytes != 2<<20 {
-		t.Fatalf("pagedOutBytes after replacement materialize = %d, want %d", kvc.pagedOutBytes, 2<<20)
+	if pc.pagedOutBytes != 2<<20 {
+		t.Fatalf("pagedOutBytes after replacement materialize = %d, want %d", pc.pagedOutBytes, 2<<20)
 	}
 }

--- a/x/mlxrunner/runner.go
+++ b/x/mlxrunner/runner.go
@@ -38,7 +38,7 @@ type Runner struct {
 	Tokenizer     *tokenizer.Tokenizer
 	Requests      chan Request
 	Sampler       *sample.Sampler
-	cache         prefixCache
+	cache         *prefixCache
 	contextLength int
 	mlxThread     *mlxthread.Thread
 	// spec is the speculative-decoding subsystem. Nil when the model ships no
@@ -105,6 +105,7 @@ func (r *Runner) Load(modelName string) error {
 	r.Model = m
 	r.Tokenizer = m.Tokenizer()
 	r.contextLength = m.MaxContextLength()
+	r.cache = newPrefixCache(m)
 	r.Sampler = sample.New(r.contextLength)
 	r.spec = newSpeculation(r, draftModel)
 

--- a/x/mlxrunner/runner.go
+++ b/x/mlxrunner/runner.go
@@ -38,7 +38,7 @@ type Runner struct {
 	Tokenizer     *tokenizer.Tokenizer
 	Requests      chan Request
 	Sampler       *sample.Sampler
-	cache         kvCache
+	cache         prefixCache
 	contextLength int
 	mlxThread     *mlxthread.Thread
 	// spec is the speculative-decoding subsystem. Nil when the model ships no

--- a/x/mlxrunner/speculate.go
+++ b/x/mlxrunner/speculate.go
@@ -25,13 +25,10 @@ type drafter interface {
 	// chunks, the decode seed, then each round's validated tokens.
 	committed(tokens, hiddens *mlx.Array, position int)
 
-	// finish reports generation ended with current sampled but never
-	// committed, so the drafter can settle state tracking the target caches.
-	finish(current *mlx.Array)
-
-	// flush writes any buffered committed reports through to the draft
-	// caches. A drafter without draft caches has nothing to write.
-	flush()
+	// settle completes any open frontier pair with next — the token after
+	// the last committed slot — and writes buffered reports through,
+	// leveling the draft caches with the target caches.
+	settle(next *mlx.Array)
 
 	close()
 }
@@ -184,21 +181,13 @@ func (s *speculationSession) committed(tokens, hiddens *mlx.Array, position int)
 	s.drafter.committed(tokens, hiddens, position)
 }
 
-// finish reports the end of generation to the drafter: current was sampled
-// after the last committed slot and will never be committed.
-func (s *speculationSession) finish(current *mlx.Array) {
+// settle completes the drafter's open frontier pair with next and writes
+// buffered reports through to the draft caches.
+func (s *speculationSession) settle(next *mlx.Array) {
 	if s == nil {
 		return
 	}
-	s.drafter.finish(current)
-}
-
-// flush writes the drafter's buffered committed reports to the draft caches.
-func (s *speculationSession) flush() {
-	if s == nil {
-		return
-	}
-	s.drafter.flush()
+	s.drafter.settle(next)
 }
 
 func (s *speculationSession) close() {
@@ -225,8 +214,8 @@ type speculativeDecoder struct {
 // decoder returns the decoder for this engine's session. A speculationSession that
 // cannot draft (logprobs) has no depth controller and permanently parks,
 // running the inner pipelined decoder whose reports keep the draft KV level.
-func (s *speculationSession) decoder(seed []int32, position int) decoder {
-	current := sampler.Result{Token: mlx.FromValues(seed, len(seed))}
+func (s *speculationSession) decoder(seed *mlx.Array, position int) decoder {
+	current := sampler.Result{Token: seed}
 	mlx.Pin(current.Arrays()...)
 	return &speculativeDecoder{s: s, position: position, current: current}
 }
@@ -284,14 +273,13 @@ func (st *speculativeDecoder) advance(next sampler.Result) {
 // but never forwarded) is exactly the current token a drafting round expects,
 // so emit it and let the next call draft from it.
 func (st *speculativeDecoder) resume() []sampler.Result {
-	next, position := st.inner.detach()
+	next, position := st.inner.drain()
 	st.position = position
+	st.inner.close()
 	st.inner = nil
 	// No round spans this call, so the next beginRound attributes no cost.
 	st.s.roundDrafts = -1
-	// detach handed over the pin; advance re-pins, no sweep in between.
-	mlx.Unpin(next.Arrays()...)
-	return []sampler.Result{next}
+	return next
 }
 
 // park decodes one pipelined plain token while the engine cannot draft. Each
@@ -305,6 +293,15 @@ func (st *speculativeDecoder) park(remaining int) ([]sampler.Result, error) {
 	return st.inner.next(remaining)
 }
 
+// drain surrenders the inner decoder's undelivered sample while parked; a
+// drafting decoder has already delivered everything it sampled.
+func (st *speculativeDecoder) drain() ([]sampler.Result, int) {
+	if st.inner != nil {
+		return st.inner.drain()
+	}
+	return nil, st.position
+}
+
 func (st *speculativeDecoder) close() {
 	if st.inner != nil {
 		// Ended while parked: the inner decoder's close settles the drafter
@@ -313,7 +310,7 @@ func (st *speculativeDecoder) close() {
 	} else {
 		// The final token was emitted but never forwarded; its report settles
 		// the drafter level with the caches' resting offset.
-		st.s.finish(st.current.Token)
+		st.s.settle(st.current.Token)
 	}
 	mlx.Unpin(st.current.Arrays()...)
 	st.s.logStats()

--- a/x/mlxrunner/speculate.go
+++ b/x/mlxrunner/speculate.go
@@ -56,6 +56,10 @@ type speculation struct {
 	draftKV []cache.Cache
 	targets []cache.Cache
 
+	// drafter is the persistent half of the MTP drafting machinery; each
+	// request's session comes from drafter.open.
+	drafter *mtpDrafter
+
 	// depth selects each request's draft length and owns the cost/acceptance
 	// models and probe cadence it learns across requests.
 	depth *depthController
@@ -67,7 +71,10 @@ func newSpeculation(r *Runner, draft base.DraftModel) *speculation {
 	if draft == nil {
 		return nil
 	}
-	return &speculation{r: r, draft: draft, depth: newDepthController()}
+	s := &speculation{r: r, draft: draft, depth: newDepthController()}
+	s.bind(r.cache.caches)
+	s.drafter = newMTPDrafter(s)
+	return s
 }
 
 // bind computes the draft/target cache partition the first time the persistent
@@ -123,7 +130,7 @@ func (s *speculation) open(request Request, caches []cache.Cache) *speculationSe
 		return nil
 	}
 	s.bind(caches)
-	d := newMTPDrafter(s)
+	d := s.drafter.open()
 
 	// Logprobs are not yet supported, so a logprobs request keeps a speculationSession
 	// only to maintain a draft cache in lockstep (permanently parked).

--- a/x/models/nn/recurrent.go
+++ b/x/models/nn/recurrent.go
@@ -146,7 +146,12 @@ func CausalConv1D(b *batch.Batch, input *mlx.Array, conv *Conv1d, convTail int, 
 	segs := segmentRanges(cfg.splits, L)
 	states = make([]*mlx.Array, 0, len(segs))
 	for _, s := range segs {
-		states = append(states, convStateAt(concat, b.SeqQueryLens, convTail, s.end))
+		st := convStateAt(concat, b.SeqQueryLens, convTail, s.end)
+		if L > 1 {
+			// Detach the small window from the forward-sized concat; at L==1 it's tiny.
+			st = mlx.Contiguous(st, false)
+		}
+		states = append(states, st)
 	}
 	return out, states
 }

--- a/x/models/nn/recurrent.go
+++ b/x/models/nn/recurrent.go
@@ -1,6 +1,8 @@
 package nn
 
 import (
+	"slices"
+
 	"github.com/ollama/ollama/x/mlxrunner/batch"
 	"github.com/ollama/ollama/x/mlxrunner/mlx"
 )
@@ -47,8 +49,6 @@ func WithSnapshotSplits(offsets []int) RecurrentOption {
 // seg is a half-open token range [start, end) within a forward.
 type seg struct{ start, end int32 }
 
-func (s seg) len() int32 { return s.end - s.start }
-
 // segmentRanges expands the interior cut offsets into consecutive [a,c) ranges
 // covering [0, L). Cuts are assumed sorted, deduped, and strictly interior; an
 // empty slice yields a single {0, L} segment.
@@ -62,21 +62,9 @@ func segmentRanges(splits []int, L int32) []seg {
 	return append(segs, seg{start, L})
 }
 
-// segmentLens returns each row's real query length within segment
-// [s.start, s.end): the portion of the row's full real length that falls
-// inside the segment, clamped to the segment width. Rows that already ended
-// before the segment contribute 0; rows extending past it are full.
-func segmentLens(b *batch.Batch, s seg) []int32 {
-	lens := make([]int32, len(b.SeqQueryLens))
-	for i := range lens {
-		lens[i] = min(max(b.SeqQueryLens[i]-s.start, 0), s.len())
-	}
-	return lens
-}
-
 // sliceSeg slices x to the segment's window [s.start, s.end) along the L axis
 // (axis 1), keeping all other axes whole. Works for any rank — [B, L],
-// [B, L, H], [B, L, H, D] — so the padding mask, conv/gate/beta, and q/k/v all
+// [B, L, H], [B, L, H, D] — so the padding mask, gate/beta, and q/k/v all
 // slice the same L range and stay aligned. Returns nil when x is nil (the
 // no-padding-mask fast path). Slicing the full-forward mask this way yields
 // the segment's own mask, so masks are built once per forward and reused
@@ -117,12 +105,7 @@ func resolveRecurrentConfig(opts []RecurrentOption) recurrentConfig {
 
 // CausalConv1D runs a depthwise causal 1D convolution with recurrent
 // state management. Prepends the prior conv state along axis 1 and runs
-// the conv.
-//
-// Conv selection: when conv is non-nil (a full nn.Conv1d layer), it
-// runs through conv.Forward. Otherwise weight is treated as the bare
-// depthwise kernel [C, K] and the fallback manual implementation runs.
-// Exactly one of conv or weight should be non-nil.
+// conv.Forward over the combined window.
 //
 // Shapes: input [B, L, D]; prior state [B, convTail, D]; output
 // [B, L, D] (the causal conv strips the prepended state).
@@ -132,10 +115,12 @@ func resolveRecurrentConfig(opts []RecurrentOption) recurrentConfig {
 //
 // Returns the output and the conv states at each boundary, ending with the
 // forward-end conv tail. Without WithSnapshotSplits there is one boundary (the
-// end), so states has length 1. With splits, the conv runs in segments and
-// states holds the conv tail at each interior split and at the end; out is
-// identical to the unsegmented conv.
-func CausalConv1D(b *batch.Batch, input *mlx.Array, conv *Conv1d, weight *mlx.Array, convTail int, opts ...RecurrentOption) (out *mlx.Array, states []*mlx.Array) {
+// end), so states has length 1. With splits, the conv still runs as a single
+// pass over the whole window and each boundary's conv tail is sliced out of the
+// shared input buffer (a boundary state is purely the trailing convTail input
+// positions, so no extra conv launch is needed); out is identical to the
+// unsegmented conv.
+func CausalConv1D(b *batch.Batch, input *mlx.Array, conv *Conv1d, convTail int, opts ...RecurrentOption) (out *mlx.Array, states []*mlx.Array) {
 	cfg := resolveRecurrentConfig(opts)
 	var prior *mlx.Array
 	if cfg.history != nil {
@@ -144,101 +129,57 @@ func CausalConv1D(b *batch.Batch, input *mlx.Array, conv *Conv1d, weight *mlx.Ar
 		prior = cfg.convState
 	}
 
+	// concat is [prior(convTail); input]; each boundary tail is sliced from it
+	// below.
 	L := int32(input.Dim(1))
-	mask := paddingMask(b, L) // built once per forward, sliced per segment
-	segs := segmentRanges(cfg.splits, L)
-	if len(segs) <= 1 {
-		out, end := causalConv1DSegment(input, prior, mask, b.SeqQueryLens, conv, weight, convTail)
-		return out, []*mlx.Array{end}
-	}
-
-	// Segmented conv: each piece prepends the prior piece's conv tail,
-	// recording the conv tail at every boundary (interior splits + end).
-	outs := make([]*mlx.Array, 0, len(segs))
-	states = make([]*mlx.Array, 0, len(segs))
-	state := prior
-	for _, s := range segs {
-		segOut, segNext := causalConv1DSegment(sliceSeg(input, s), state, sliceSeg(mask, s), segmentLens(b, s), conv, weight, convTail)
-		outs = append(outs, segOut)
-		state = segNext
-		states = append(states, segNext)
-	}
-	return mlx.Concatenate(outs, 1), states
-}
-
-// causalConv1DSegment convolves one segment: prepend prior, convolve, return
-// (output, conv tail). mask is the [B, L] padding mask for input (nil if no
-// row is padded); queryLens is each row's real query length (used to gather
-// the per-row conv tail when masking is in play).
-func causalConv1DSegment(input, prior *mlx.Array, mask *mlx.Array, queryLens []int32, conv *Conv1d, weight *mlx.Array, convTail int) (out, nextConv *mlx.Array) {
-	if mask != nil {
+	if mask := paddingMask(b, L); mask != nil {
 		zero := mlx.FromValue(float32(0)).AsType(input.DType())
 		input = mlx.Where(mlx.ExpandDims(mask, 2), input, zero)
 	}
-
 	concat := mlx.Concatenate([]*mlx.Array{prior, input}, 1)
-	if conv != nil {
-		out = conv.Forward(concat)
-	} else {
-		out = depthwiseCausalConv1d(concat, weight, int32(input.Dim(1)))
-	}
+	out = conv.Forward(concat)
 
+	// Snapshot the conv tail at each segment boundary: interior splits in
+	// ascending order, then the forward end at L. Each boundary at offset O
+	// captures input positions [O-convTail, O) — the trailing convTail rows of
+	// the window through token O.
+	segs := segmentRanges(cfg.splits, L)
+	states = make([]*mlx.Array, 0, len(segs))
+	for _, s := range segs {
+		states = append(states, convStateAt(concat, b.SeqQueryLens, convTail, s.end))
+	}
+	return out, states
+}
+
+// convStateAt returns the conv state to cache at boundary: the trailing convTail
+// input positions ending at boundary, clamped per row to the row's real length so
+// a padded row freezes at its real end rather than capturing padding. The prior
+// prefixed in concat shifts those positions to columns [boundary, boundary+convTail).
+func convStateAt(concat *mlx.Array, queryLens []int32, convTail int, boundary int32) *mlx.Array {
 	B := int32(concat.Dim(0))
-	total := int32(concat.Dim(1))
 	D := int32(concat.Dim(2))
 
-	// Gather the tail from each of the non-padded sequence ends
-	if mask != nil && convTail > 0 {
+	// A row shorter than boundary ends its window at its own real length (inputs
+	// are right-padded), so when any row falls short we gather per row instead of
+	// one shared slice. boundary itself is still batch-wide — per-sequence
+	// boundaries (real batching) are a future change to this gather and the callers.
+	clamped := slices.ContainsFunc(queryLens, func(q int32) bool { return boundary > q })
+
+	if clamped && convTail > 0 {
 		offsets := make([]int32, int(B)*convTail)
-
 		for i := range int(B) {
-			end := queryLens[i]
-
+			end := min(boundary, queryLens[i])
 			for k := range convTail {
 				offsets[i*convTail+k] = end + int32(k)
 			}
 		}
-
 		positions := mlx.NewArrayInt32(offsets, []int32{B, int32(convTail), 1})
-		nextConv = mlx.TakeAlongAxis(concat, positions, 1)
-	} else {
-		nextConv = mlx.SliceStartStop(concat,
-			[]int32{0, total - int32(convTail), 0},
-			[]int32{B, total, D})
+		return mlx.TakeAlongAxis(concat, positions, 1)
 	}
 
-	return out, nextConv
-}
-
-// depthwiseCausalConv1d implements a depthwise 1D causal convolution
-// manually as a sum of kernel-offset multiplies. x has shape
-// [B, inLen, C], weight has shape [C, K]; output has shape [B, outLen, C]
-// where outLen = inLen - K + 1 (the caller passes outLen to avoid the
-// subtraction). Used as the fallback path in CausalConv1D when no
-// full Conv1d layer is configured.
-func depthwiseCausalConv1d(x, w *mlx.Array, outLen int32) *mlx.Array {
-	if x == nil || w == nil {
-		return nil
-	}
-	if w.NumDims() != 2 {
-		return nil
-	}
-	B := int32(x.Dim(0))
-	C := int32(w.Dim(0))
-	K := int32(w.Dim(1))
-	var out *mlx.Array
-	for i := range K {
-		seg := mlx.SliceStartStop(x, []int32{0, i, 0}, []int32{B, i + outLen, C})
-		wi := mlx.SliceStartStop(w, []int32{0, i}, []int32{C, i + 1})
-		wi = mlx.Reshape(wi, 1, 1, C)
-		term := mlx.Mul(seg, wi)
-		if out == nil {
-			out = term
-		} else {
-			out = mlx.Add(out, term)
-		}
-	}
-	return out
+	return mlx.SliceStartStop(concat,
+		[]int32{0, boundary, 0},
+		[]int32{B, boundary + int32(convTail), D})
 }
 
 // GatedDelta wraps mlx.FastGatedDelta with recurrent state management.
@@ -337,14 +278,7 @@ type paddingMaskInputs struct {
 func (in paddingMaskInputs) build() *mlx.Array {
 	B := len(in.batch.SeqQueryLens)
 
-	needed := false
-	for i := range B {
-		if in.batch.SeqQueryLens[i] < in.L {
-			needed = true
-			break
-		}
-	}
-	if !needed {
+	if !slices.ContainsFunc(in.batch.SeqQueryLens, func(q int32) bool { return q < in.L }) {
 		return nil
 	}
 

--- a/x/models/nn/recurrent_test.go
+++ b/x/models/nn/recurrent_test.go
@@ -30,84 +30,11 @@ func fromValues(seed float32, shape ...int) *mlx.Array {
 	return mlx.FromValues(vals, shape...)
 }
 
-// depthwiseCausalRef is a Go-side reference for the depthwise causal
-// 1D conv fallback. concat is [B, total, C], weight is [C, K], output
-// is [B, total-K+1, C]. Used to anchor the wrapper's parity tests.
-func depthwiseCausalRef(concat, weight *mlx.Array) []float32 {
-	mlx.Eval(concat, weight)
-	cVals := concat.Floats()
-	wVals := weight.Floats()
-	B := concat.Dim(0)
-	total := concat.Dim(1)
-	C := concat.Dim(2)
-	K := weight.Dim(1)
-	outLen := total - K + 1
-	out := make([]float32, B*outLen*C)
-	for bi := range B {
-		for q := range outLen {
-			for c := range C {
-				var sum float32
-				for k := range K {
-					x := cVals[bi*total*C+(q+k)*C+c]
-					w := wVals[c*K+k]
-					sum += x * w
-				}
-				out[bi*outLen*C+q*C+c] = sum
-			}
-		}
-	}
-	return out
-}
-
-// TestCausalConv1DParity drives the wrapper with non-trivial prior,
-// input, and weight values, then compares against a direct depthwise-
-// causal-conv reference.
-func TestCausalConv1DParity(t *testing.T) {
-	skipIfNoMLX(t)
-	B, L, D, convTail := 1, 4, 3, 2
-	K := convTail + 1
-
-	input := fromValues(0.5, B, L, D)
-	prior := fromValues(-0.3, B, convTail, D)
-	weight := fromValues(0.2, D, K)
-
-	out, convStates := CausalConv1D(&batch.Batch{}, input, nil, weight, convTail, WithRecurrentState(prior, nil))
-	nextConv := lastState(convStates)
-	mlx.Eval(out, nextConv)
-
-	concat := mlx.Concatenate([]*mlx.Array{prior, input}, 1)
-	want := depthwiseCausalRef(concat, weight)
-	got := out.Floats()
-	if len(got) != len(want) {
-		t.Fatalf("out len = %d, want %d", len(got), len(want))
-	}
-	for i := range want {
-		if math.Abs(float64(got[i]-want[i])) > 1e-5 {
-			t.Fatalf("out[%d]: got %v, want %v", i, got[i], want[i])
-		}
-	}
-
-	// nextConv (no padding) is the trailing convTail rows of concat.
-	mlx.Eval(concat)
-	cVals := concat.Floats()
-	total := concat.Dim(1)
-	wantTail := make([]float32, B*convTail*D)
-	for bi := range B {
-		for k := range convTail {
-			for d := range D {
-				wantTail[bi*convTail*D+k*D+d] = cVals[bi*total*D+(total-convTail+k)*D+d]
-			}
-		}
-	}
-	tail := nextConv.Floats()
-	if len(tail) != len(wantTail) {
-		t.Fatalf("nextConv len = %d, want %d", len(tail), len(wantTail))
-	}
-	for i := range wantTail {
-		if tail[i] != wantTail[i] {
-			t.Fatalf("nextConv[%d]: got %v, want %v", i, tail[i], wantTail[i])
-		}
-	}
+// convFromKernel builds the depthwise causal Conv1d the model constructs at
+// load time from a bare [C, K] kernel, so the wrapper tests drive the same
+// mlx.Conv1d path production runs.
+func convFromKernel(w *mlx.Array) *Conv1d {
+	return NewConv1d(mlx.ExpandDims(w, 2), nil, 1, 0, 1, int32(w.Dim(0)))
 }
 
 // TestCausalConv1DPaddedRowParity drives a B=2 batch with one short
@@ -122,6 +49,7 @@ func TestCausalConv1DPaddedRowParity(t *testing.T) {
 	K := convTail + 1
 
 	weight := fromValues(0.2, D, K)
+	conv := convFromKernel(weight)
 	priorFull := fromValues(0.5, 2, convTail, D)
 	priorShort := mlx.SliceStartStop(priorFull,
 		[]int32{1, 0, 0},
@@ -148,20 +76,20 @@ func TestCausalConv1DPaddedRowParity(t *testing.T) {
 		SeqQueryLens: []int32{int32(L), int32(qLenShort)},
 	}
 
-	out, convStates := CausalConv1D(b, input, nil, weight, convTail, WithRecurrentState(priorFull, nil))
+	out, convStates := CausalConv1D(b, input, conv, convTail, WithRecurrentState(priorFull, nil))
 	nextConv := lastState(convStates)
 	mlx.Eval(out, nextConv)
 
 	// Reference for row 0: B=1 unpadded length-L call.
 	refOut0, refConvStates0 := CausalConv1D(&batch.Batch{},
-		inputFull, nil, weight, convTail,
+		inputFull, conv, convTail,
 		WithRecurrentState(mlx.SliceStartStop(priorFull,
 			[]int32{0, 0, 0},
 			[]int32{1, int32(convTail), int32(D)}), nil))
 	refNextConv0 := lastState(refConvStates0)
 	// Reference for row 1: B=1 unpadded length-qLenShort call.
 	refOut1, refConvStates1 := CausalConv1D(&batch.Batch{},
-		inputShortReal, nil, weight, convTail,
+		inputShortReal, conv, convTail,
 		WithRecurrentState(priorShort, nil))
 	refNextConv1 := lastState(refConvStates1)
 	mlx.Eval(refOut0, refNextConv0, refOut1, refNextConv1)
@@ -413,15 +341,16 @@ func TestCausalConv1DSegmentEquivalence(t *testing.T) {
 	input := fromValues(0.5, B, L, D)
 	prior := fromValues(-0.3, B, convTail, D)
 	weight := fromValues(0.2, D, K)
+	conv := convFromKernel(weight)
 
 	full := &batch.Batch{SeqOffsets: []int32{0}, SeqQueryLens: []int32{int32(L)}}
 
-	refOut, refStates := CausalConv1D(full, input, nil, weight, convTail, WithRecurrentState(prior, nil))
+	refOut, refStates := CausalConv1D(full, input, conv, convTail, WithRecurrentState(prior, nil))
 	if len(refStates) != 1 {
 		t.Fatalf("unsegmented call returned %d states, want 1", len(refStates))
 	}
 
-	segOut, segStates := CausalConv1D(full, input, nil, weight, convTail,
+	segOut, segStates := CausalConv1D(full, input, conv, convTail,
 		WithRecurrentState(prior, nil), WithSnapshotSplits([]int{1, 2, 3}))
 	mlx.Eval(refOut, segOut)
 
@@ -437,7 +366,7 @@ func TestCausalConv1DSegmentEquivalence(t *testing.T) {
 		pb := &batch.Batch{SeqOffsets: []int32{0}, SeqQueryLens: []int32{n}}
 		_, want := CausalConv1D(pb,
 			mlx.SliceStartStop(input, []int32{0, 0, 0}, []int32{int32(B), n, int32(D)}),
-			nil, weight, convTail, WithRecurrentState(prior, nil))
+			conv, convTail, WithRecurrentState(prior, nil))
 		mlx.Eval(segStates[i], lastState(want))
 		floatsClose(t, "boundary conv", segStates[i].Floats(), lastState(want).Floats(), 1e-4)
 	}
@@ -445,7 +374,8 @@ func TestCausalConv1DSegmentEquivalence(t *testing.T) {
 
 // TestGatedDeltaSegmentEquivalenceBatched checks the segmented scan matches the
 // single-shot scan for B>1, including a ragged batch where rows have different
-// real lengths — segmentLens must clamp each row's per-segment query length.
+// real lengths — the per-segment sliced mask must zero each row's padded
+// positions so a short row's boundary state freezes at its real end.
 func TestGatedDeltaSegmentEquivalenceBatched(t *testing.T) {
 	skipIfNoMLX(t)
 	B, T, Hk, Dk, Hv, Dv := 2, 4, 1, 32, 1, 32
@@ -496,8 +426,10 @@ func TestGatedDeltaSegmentEquivalenceBatched(t *testing.T) {
 	}
 }
 
-// TestCausalConv1DSegmentEquivalenceBatched is the conv analog: segmented vs
-// single-shot for a ragged B>1 batch.
+// TestCausalConv1DSegmentEquivalenceBatched is the conv analog of the gated-delta
+// batched test: boundary tails from the single conv pass vs per-row single-shot
+// references for a ragged B>1 batch, where a short row must freeze its tail at
+// its real end rather than reach into padding.
 func TestCausalConv1DSegmentEquivalenceBatched(t *testing.T) {
 	skipIfNoMLX(t)
 	B, L, D, convTail := 2, 4, 3, 2
@@ -506,11 +438,12 @@ func TestCausalConv1DSegmentEquivalenceBatched(t *testing.T) {
 	input := fromValues(0.5, B, L, D)
 	prior := fromValues(-0.3, B, convTail, D)
 	weight := fromValues(0.2, D, K)
+	conv := convFromKernel(weight)
 
 	full := &batch.Batch{SeqOffsets: []int32{0, 0}, SeqQueryLens: []int32{int32(L), 3}}
 
-	refOut, refStates := CausalConv1D(full, input, nil, weight, convTail, WithRecurrentState(prior, nil))
-	segOut, segStates := CausalConv1D(full, input, nil, weight, convTail,
+	refOut, refStates := CausalConv1D(full, input, conv, convTail, WithRecurrentState(prior, nil))
+	segOut, segStates := CausalConv1D(full, input, conv, convTail,
 		WithRecurrentState(prior, nil), WithSnapshotSplits([]int{1, 2, 3}))
 	mlx.Eval(refOut, segOut, lastState(refStates), lastState(segStates))
 
@@ -532,7 +465,7 @@ func TestCausalConv1DSegmentEquivalenceBatched(t *testing.T) {
 				[]int32{int32(r), 0, 0}, []int32{int32(r) + 1, int32(convTail), int32(D)})
 			rowInput := mlx.SliceStartStop(input,
 				[]int32{int32(r), 0, 0}, []int32{int32(r) + 1, n, int32(D)})
-			_, want := CausalConv1D(&batch.Batch{}, rowInput, nil, weight, convTail,
+			_, want := CausalConv1D(&batch.Batch{}, rowInput, conv, convTail,
 				WithRecurrentState(rowPrior, nil))
 			gotRow := mlx.SliceStartStop(segStates[i],
 				[]int32{int32(r), 0, 0}, []int32{int32(r) + 1, int32(convTail), int32(D)})

--- a/x/models/qwen3_5/qwen3_5.go
+++ b/x/models/qwen3_5/qwen3_5.go
@@ -127,7 +127,6 @@ type GatedDeltaNet struct {
 	OutProj    nn.LinearLayer
 
 	Conv1D     *nn.Conv1d
-	ConvWeight *mlx.Array
 	NormWeight *mlx.Array
 	DtBias     *mlx.Array
 	ALog       *mlx.Array
@@ -762,31 +761,6 @@ func sanitizeConvWeight(w *mlx.Array) *mlx.Array {
 	return w
 }
 
-func depthwiseConv1dKernelWeight(w *mlx.Array) *mlx.Array {
-	if w == nil {
-		return nil
-	}
-	switch w.NumDims() {
-	case 2:
-		// qwen3.5 manual path stores [C, K]; MLX grouped conv expects [Cout, K, Cin/groups].
-		// For depthwise conv (groups=C), that is [C, K, 1].
-		return mlx.ExpandDims(w, 2)
-	case 3:
-		switch {
-		case w.Dim(2) == 1:
-			// [C, K, 1]
-			return w
-		case w.Dim(1) == 1:
-			// [C, 1, K] -> [C, K, 1]
-			return mlx.Transpose(w, 0, 2, 1)
-		case w.Dim(0) == 1:
-			// [1, K, C] -> [C, K, 1]
-			return mlx.Transpose(w, 2, 1, 0)
-		}
-	}
-	return nil
-}
-
 func shouldShiftNormKey(key string) bool {
 	for _, suffix := range []string{
 		".input_layernorm.weight",
@@ -897,9 +871,9 @@ func (m *Model) LoadWeights(tensors map[string]*mlx.Array) error {
 			lin.InProjBA = linears.Make(layerPrefix + ".linear_attn.in_proj_ba")
 			lin.OutProj = linears.Make(layerPrefix + ".linear_attn.out_proj")
 
-			lin.ConvWeight = sanitizeConvWeight(tensors[layerPrefix+".linear_attn.conv1d.weight"])
-			if lin.ConvWeight == nil {
-				lin.ConvWeight = sanitizeConvWeight(tensors[layerPrefix+".linear_attn.conv1d"])
+			convWeight := sanitizeConvWeight(tensors[layerPrefix+".linear_attn.conv1d.weight"])
+			if convWeight == nil {
+				convWeight = sanitizeConvWeight(tensors[layerPrefix+".linear_attn.conv1d"])
 			}
 			lin.NormWeight, _ = tensorAny(tensors,
 				layerPrefix+".linear_attn.norm.weight",
@@ -922,15 +896,15 @@ func (m *Model) LoadWeights(tensors map[string]*mlx.Array) error {
 			if (!hasSplit && !hasCombined) || lin.OutProj == nil {
 				return fmt.Errorf("layer %d: missing linear attention projections", i)
 			}
-			if lin.ConvWeight == nil || lin.NormWeight == nil || lin.DtBias == nil || lin.ALog == nil || lin.AExp == nil {
+			if convWeight == nil || lin.NormWeight == nil || lin.DtBias == nil || lin.ALog == nil || lin.AExp == nil {
 				return fmt.Errorf("layer %d: missing linear attention state tensors", i)
 			}
-			if lin.ConvWeight.NumDims() != 2 {
-				return fmt.Errorf("layer %d: conv1d weight must be 2D after sanitization, got %dD", i, lin.ConvWeight.NumDims())
+			if convWeight.NumDims() != 2 {
+				return fmt.Errorf("layer %d: conv1d weight must be 2D after sanitization, got %dD", i, convWeight.NumDims())
 			}
-			if convKernel := depthwiseConv1dKernelWeight(lin.ConvWeight); convKernel != nil {
-				lin.Conv1D = nn.NewConv1d(convKernel, nil, 1, 0, 1, int32(lin.ConvWeight.Dim(0)))
-			}
+			// MLX grouped conv expects [Cout, K, Cin/groups]; for depthwise
+			// conv (groups=C) the [C, K] kernel becomes [C, K, 1].
+			lin.Conv1D = nn.NewConv1d(mlx.ExpandDims(convWeight, 2), nil, 1, 0, 1, int32(convWeight.Dim(0)))
 
 			layer.Linear = lin
 		} else {
@@ -1182,7 +1156,7 @@ func (g *GatedDeltaNet) Forward(x *mlx.Array, b *batch.Batch, c cache.Cache, B, 
 		))
 	}
 
-	convOut, convStates := nn.CausalConv1D(b, qkv, g.Conv1D, g.ConvWeight, int(convTail), opts...)
+	convOut, convStates := nn.CausalConv1D(b, qkv, g.Conv1D, int(convTail), opts...)
 	convOut = mlx.SiLU(convOut)
 
 	keyDim := cfg.LinearNumKeyHeads * cfg.LinearKeyHeadDim


### PR DESCRIPTION
Follow-up on MTP speculative decoding in the MLX runner. The MTP-facing pieces have no current impact: the only MTP model today (gemma4) uses neither recurrent caches nor draft caches. They land ahead of qwen3.6, which will draft through draft caches with MTP. Two of the changes also touch recurrent models used outside MTP.

**Recurrent models (outside MTP)**

- **Cache leak (#16698)** — boundary snapshots were slices of the forward-sized conv buffer. A slice pins the whole buffer, but eviction only counted the slice's bytes. So recurrent cache memory piled up across requests and could never be reclaimed. Each snapshot is now compacted to its real size, and eviction sees the true cost.
- **Conv boundary states** — the depthwise conv re-ran once per requested boundary. It now runs once over the window, and each boundary tail is sliced from the shared buffer. MTP validation drove this, since it snapshots at every drafted token. With no recurrent MTP model yet, the win instead lands on branch-point snapshots in ordinary recurrent decoding.

**Draft caches (for qwen3.6, no current model has them)**

- **Draft-cache acceptance** — a model drafting through its own draft caches referenced one token past each cache slot. Restoring at a prefix match reused that slot blind, so it went stale on a stripped stop token or any boundary divergence. This quietly lowered acceptance. The trie is now keyed by token pairs, making every match a valid restore point. Without draft caches the keys stay single tokens, so behavior is unchanged today.
- **Flush cap → 256 tokens** — this is the smallest cap past every fast-kernel threshold across the qwen3.6 heads, and it lands within a few percent of each head's per-token floor. The cost is bounded: up to 2.5 MiB of pinned hiddens per request, and a flush stall under one decode step.
