### PR TITLE
create: select the qwen3.5 parser and renderer for Qwen3.5/Next

### DIFF
--- a/x/create/client/create.go
+++ b/x/create/client/create.go
@@ -628,6 +628,9 @@ func getParserName(modelDir string) string {
 		if strings.Contains(archLower, "gemma4") {
 			return "gemma4"
 		}
+		if isQwen35Family(archLower) {
+			return "qwen3.5"
+		}
 		if strings.Contains(archLower, "qwen3") {
 			return "qwen3"
 		}
@@ -650,6 +653,9 @@ func getParserName(modelDir string) string {
 		}
 		if strings.Contains(typeLower, "gemma4") {
 			return "gemma4"
+		}
+		if isQwen35Family(typeLower) {
+			return "qwen3.5"
 		}
 		if strings.Contains(typeLower, "qwen3") {
 			return "qwen3"
@@ -694,6 +700,9 @@ func getRendererName(modelDir string) string {
 		if strings.Contains(archLower, "deepseek") {
 			return "deepseek3"
 		}
+		if isQwen35Family(archLower) {
+			return "qwen3.5"
+		}
 		if strings.Contains(archLower, "qwen3") {
 			return "qwen3-coder"
 		}
@@ -716,6 +725,9 @@ func getRendererName(modelDir string) string {
 		}
 		if strings.Contains(typeLower, "deepseek") {
 			return "deepseek3"
+		}
+		if isQwen35Family(typeLower) {
+			return "qwen3.5"
 		}
 		if strings.Contains(typeLower, "qwen3") {
 			return "qwen3-coder"

--- a/x/create/client/create_test.go
+++ b/x/create/client/create_test.go
@@ -700,6 +700,11 @@ func TestGetParserName(t *testing.T) {
 			want:       "qwen3",
 		},
 		{
+			name:       "qwen3.5 model",
+			configJSON: `{"architectures": ["Qwen3_5ForConditionalGeneration"]}`,
+			want:       "qwen3.5",
+		},
+		{
 			name:       "deepseek model",
 			configJSON: `{"architectures": ["DeepseekV3ForCausalLM"]}`,
 			want:       "deepseek3",
@@ -753,6 +758,11 @@ func TestGetRendererName(t *testing.T) {
 			name:       "qwen3 model",
 			configJSON: `{"architectures": ["Qwen3ForCausalLM"]}`,
 			want:       "qwen3-coder",
+		},
+		{
+			name:       "qwen3.5 model",
+			configJSON: `{"architectures": ["Qwen3_5ForConditionalGeneration"]}`,
+			want:       "qwen3.5",
 		},
 		{
 			name:       "deepseek model",


### PR DESCRIPTION
Qwen3.5/Qwen3-Next architecture strings contain the substring "qwen3", so the broad qwen3 match claimed them for the generic parser and qwen3-coder renderer, whose template doesn't frame the thinking block — an empty <think></think> leaked into content and think=false was ignored. Match the family first via isQwen35Family so the parser, renderer, and thinking-capability checks share one variant list.