### PR TITLE
scripts: recognize JetPack 7 (L4T r38+) in install.sh

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -181,6 +181,9 @@ if [ -f /etc/nv_tegra_release ] ; then
         download_and_extract "https://ollama.com/download" "$OLLAMA_INSTALL_DIR" "ollama-linux-${ARCH}-jetpack6"
     elif grep R35 /etc/nv_tegra_release > /dev/null ; then
         download_and_extract "https://ollama.com/download" "$OLLAMA_INSTALL_DIR" "ollama-linux-${ARCH}-jetpack5"
+    elif grep -E ' R(3[89]|[4-9][0-9]) ' /etc/nv_tegra_release > /dev/null ; then
+        # JetPack 7+ uses the SBSA cuda_v13 build already in the base package
+        status "NVIDIA JetPack detected."
     else
         warning "Unsupported JetPack version detected.  GPU may not be supported"
     fi


### PR DESCRIPTION
Follow-up to #16949, per @dhiltgen's request to handle this as a discrete PR (https://github.com/ollama/ollama/pull/16949#issuecomment-4867388430).

## Problem

#16949 lets JetPack 7 use the standard `cuda_v13` build at runtime, but the installer still prints `WARNING: Unsupported JetPack version detected. GPU may not be supported` on JetPack 7 (L4T r38/r39), because `install.sh` only recognizes r35/r36. The GPU actually works — `cuda_v13` ships in the base `linux-arm64` package — so the warning is misleading and has confused users (reported in #16602).

## Change

Add an L4T r38+ case so JetPack 7+ is recognized: it uses the bundled SBSA `cuda_v13` build, so no extra download is needed. r35 → jetpack5 and r36 → jetpack6 are unchanged, and genuinely old releases still warn.

## Testing

- `sh -n scripts/install.sh`.
- Ran the detection block against L4T r32/r35/r36/r37/r38/r39/r40: r38+ prints a status line (no warning), r35/r36 fetch their packages, r32/r37 still warn.
- On a real JetPack 7.2 Orin Nano (`/etc/nv_tegra_release` = r39): the installer prints `NVIDIA JetPack detected.` instead of the warning.
