### PR TITLE
x/transfer: reject unsafe blob redirects

### DIFF
--- a/x/transfer/download.go
+++ b/x/transfer/download.go
@@ -8,11 +8,14 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -22,8 +25,11 @@ import (
 )
 
 var (
-	errStalled = errors.New("download stalled")
-	errSlow    = errors.New("download too slow")
+	errStalled        = errors.New("download stalled")
+	errSlow           = errors.New("download too slow")
+	errUnsafeRedirect = errors.New("unsafe redirect")
+
+	lookupNetIP = net.DefaultResolver.LookupNetIP
 )
 
 type downloader struct {
@@ -200,6 +206,8 @@ func (d *downloader) download(ctx context.Context, blob Blob) error {
 		switch {
 		case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
 			return err
+		case errors.Is(err, errUnsafeRedirect):
+			return err
 		case errors.Is(err, errStalled):
 			// Don't count stall retries against limit
 		case errors.Is(err, errSlow):
@@ -261,7 +269,7 @@ func (d *downloader) downloadOnce(ctx context.Context, blob Blob) (int64, error)
 		req.Header.Set("Range", fmt.Sprintf("bytes=%d-", existingSize))
 	}
 
-	resp, err := d.client.Do(req)
+	resp, err := noRedirectClient(d.client, baseURL).Do(req)
 	if err != nil {
 		return 0, err
 	}
@@ -399,6 +407,9 @@ func (d *downloader) copy(ctx context.Context, dst io.Writer, src io.Reader, h i
 // redirecting to CDN, while GET triggers the actual CDN redirect.
 func (d *downloader) resolve(ctx context.Context, rawURL string) (*url.URL, error) {
 	u, _ := url.Parse(rawURL)
+	baseURL, _ := url.Parse(d.baseURL)
+	client := noRedirectClient(d.client, baseURL)
+
 	for range 10 {
 		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 		req.Header.Set("User-Agent", d.userAgent)
@@ -407,7 +418,7 @@ func (d *downloader) resolve(ctx context.Context, rawURL string) (*url.URL, erro
 			req.Header.Set("Authorization", "Bearer "+prev)
 		}
 
-		resp, err := d.client.Do(req)
+		resp, err := client.Do(req)
 		if err != nil {
 			return nil, err
 		}
@@ -429,6 +440,9 @@ func (d *downloader) resolve(ctx context.Context, rawURL string) (*url.URL, erro
 		case http.StatusTemporaryRedirect, http.StatusFound, http.StatusMovedPermanently:
 			loc, _ := resp.Location()
 			if loc.Host != u.Host {
+				if err := validateRedirectURL(ctx, baseURL, loc, d.client); err != nil {
+					return nil, err
+				}
 				return loc, nil
 			}
 			u = loc
@@ -437,6 +451,233 @@ func (d *downloader) resolve(ctx context.Context, rawURL string) (*url.URL, erro
 		}
 	}
 	return nil, fmt.Errorf("too many redirects")
+}
+
+func noRedirectClient(client *http.Client, baseURL *url.URL) *http.Client {
+	if client == nil {
+		client = defaultClient
+	}
+
+	c := *client
+	c.Transport = guardedTransport(c.Transport, baseURL)
+	c.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	return &c
+}
+
+func guardedTransport(rt http.RoundTripper, baseURL *url.URL) http.RoundTripper {
+	if rt == nil {
+		rt = http.DefaultTransport
+	}
+
+	tr, ok := rt.(*http.Transport)
+	if !ok {
+		return rt
+	}
+
+	allowLocalTargets := baseURL != nil && isLocalHost(baseURL.Hostname())
+	if allowLocalTargets {
+		return tr.Clone()
+	}
+
+	direct := guardedDirectTransport(tr, allowLocalTargets)
+	if tr.Proxy == nil {
+		return direct
+	}
+
+	return guardedProxyTransport{
+		direct:  direct,
+		proxied: tr.Clone(),
+		proxy:   tr.Proxy,
+	}
+}
+
+type guardedProxyTransport struct {
+	direct  *http.Transport
+	proxied *http.Transport
+	proxy   func(*http.Request) (*url.URL, error)
+}
+
+func (t guardedProxyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	proxyURL, err := t.proxy(req)
+	if err != nil {
+		return nil, err
+	}
+	if proxyURL != nil {
+		return t.proxied.RoundTrip(req)
+	}
+	return t.direct.RoundTrip(req)
+}
+
+func guardedDirectTransport(tr *http.Transport, allowLocalTargets bool) *http.Transport {
+	clone := tr.Clone()
+	clone.Proxy = nil
+	dialContext := clone.DialContext
+	if dialContext == nil {
+		var dialer net.Dialer
+		dialContext = dialer.DialContext
+	}
+
+	clone.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		return dialResolved(ctx, network, addr, allowLocalTargets, dialContext)
+	}
+
+	// Custom TLS dialers perform their own network dialing, so they cannot be
+	// made to use the IP address checked above while preserving normal SNI
+	// behavior. Let net/http run TLS over the guarded DialContext instead.
+	clone.DialTLSContext = nil
+
+	return clone
+}
+
+type dialContextFunc func(context.Context, string, string) (net.Conn, error)
+
+func dialResolved(ctx context.Context, network, addr string, allowLocalTargets bool, dialContext dialContextFunc) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	addrs, err := resolveHostAddrs(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+
+	if !allowLocalTargets {
+		for _, addr := range addrs {
+			if isLocalAddr(addr) {
+				return nil, fmt.Errorf("%w: refusing connection to local address %s", errUnsafeRedirect, net.JoinHostPort(addr.String(), port))
+			}
+		}
+	}
+
+	var lastErr error
+	for _, addr := range addrs {
+		conn, err := dialContext(ctx, network, net.JoinHostPort(addr.String(), port))
+		if err == nil {
+			return conn, nil
+		}
+		lastErr = err
+	}
+
+	if lastErr != nil {
+		return nil, lastErr
+	}
+
+	return nil, fmt.Errorf("no addresses for %s", host)
+}
+
+func validateRedirectURL(ctx context.Context, baseURL, loc *url.URL, client *http.Client) error {
+	if loc.Scheme != "http" && loc.Scheme != "https" {
+		return fmt.Errorf("%w: refusing redirect to unsupported scheme %q", errUnsafeRedirect, loc.Scheme)
+	}
+
+	if loc.Hostname() == "" {
+		return fmt.Errorf("%w: refusing redirect to empty host", errUnsafeRedirect)
+	}
+
+	targetLocal, err := hostResolvesToLocal(ctx, loc.Hostname())
+	if err != nil {
+		return fmt.Errorf("%w: refusing redirect to unresolved host %s: %v", errUnsafeRedirect, loc.Host, err)
+	}
+
+	baseHost := ""
+	baseLocal := false
+	if baseURL != nil {
+		baseHost = baseURL.Host
+		baseLocal = isLocalHost(baseURL.Hostname())
+	}
+	if targetLocal && !baseLocal {
+		return fmt.Errorf("%w: refusing redirect from %s to local address %s", errUnsafeRedirect, baseHost, loc.Host)
+	}
+
+	if !baseLocal {
+		usesProxy, err := redirectUsesProxy(client, loc)
+		if err != nil {
+			return fmt.Errorf("%w: refusing redirect with proxy lookup error for %s: %v", errUnsafeRedirect, loc.Host, err)
+		}
+		if usesProxy {
+			return fmt.Errorf("%w: refusing redirect through proxy to %s", errUnsafeRedirect, loc.Host)
+		}
+	}
+
+	return nil
+}
+
+func redirectUsesProxy(client *http.Client, target *url.URL) (bool, error) {
+	tr, ok := effectiveTransport(client).(*http.Transport)
+	if !ok || tr.Proxy == nil {
+		return false, nil
+	}
+
+	req := &http.Request{
+		Method: http.MethodGet,
+		URL:    target,
+		Header: make(http.Header),
+	}
+	proxyURL, err := tr.Proxy(req)
+	return proxyURL != nil, err
+}
+
+func effectiveTransport(client *http.Client) http.RoundTripper {
+	if client == nil {
+		client = defaultClient
+	}
+	if client.Transport != nil {
+		return client.Transport
+	}
+	return http.DefaultTransport
+}
+
+func hostResolvesToLocal(ctx context.Context, host string) (bool, error) {
+	if isLocalHost(host) {
+		return true, nil
+	}
+
+	addrs, err := resolveHostAddrs(ctx, host)
+	if err != nil {
+		return false, err
+	}
+
+	for _, addr := range addrs {
+		if isLocalAddr(addr) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func resolveHostAddrs(ctx context.Context, host string) ([]netip.Addr, error) {
+	if addr, err := netip.ParseAddr(host); err == nil {
+		return []netip.Addr{addr.Unmap()}, nil
+	}
+
+	return lookupNetIP(ctx, "ip", host)
+}
+
+func isLocalHost(host string) bool {
+	host = strings.TrimSuffix(strings.ToLower(host), ".")
+	if host == "localhost" || strings.HasSuffix(host, ".localhost") {
+		return true
+	}
+
+	addr, err := netip.ParseAddr(host)
+	if err != nil {
+		return false
+	}
+
+	return isLocalAddr(addr)
+}
+
+func isLocalAddr(addr netip.Addr) bool {
+	addr = addr.Unmap()
+	return addr.IsLoopback() ||
+		addr.IsPrivate() ||
+		addr.IsLinkLocalUnicast() ||
+		addr.IsLinkLocalMulticast() ||
+		addr.IsUnspecified()
 }
 
 type speedTracker struct {

--- a/x/transfer/transfer_test.go
+++ b/x/transfer/transfer_test.go
@@ -8,8 +8,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/netip"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -25,6 +28,27 @@ import (
 type chunkedSession struct {
 	mu       sync.Mutex
 	sessions map[string]*bytes.Buffer
+}
+
+type transferRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f transferRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func stubLookupNetIP(t *testing.T, addrs map[string][]netip.Addr) {
+	t.Helper()
+
+	previous := lookupNetIP
+	lookupNetIP = func(ctx context.Context, network, host string) ([]netip.Addr, error) {
+		if ips, ok := addrs[host]; ok {
+			return ips, nil
+		}
+		return nil, fmt.Errorf("unexpected lookup for %q", host)
+	}
+	t.Cleanup(func() {
+		lookupNetIP = previous
+	})
 }
 
 func newChunkedSession() *chunkedSession {
@@ -184,6 +208,325 @@ func TestDownloadWithRedirect(t *testing.T) {
 	}
 
 	verifyBlob(t, clientDir, blob, data)
+}
+
+func TestDownloadRejectsPublicRegistryRedirectToLocalAddress(t *testing.T) {
+	var internalHits atomic.Int32
+	blob := Blob{
+		Digest: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		Size:   1,
+	}
+
+	client := &http.Client{
+		Transport: transferRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.Host {
+			case "registry.example":
+				header := http.Header{}
+				header.Set("Location", "http://169.254.169.254/latest/meta-data/")
+				return &http.Response{
+					StatusCode: http.StatusTemporaryRedirect,
+					Header:     header,
+					Body:       io.NopCloser(strings.NewReader("")),
+					Request:    req,
+				}, nil
+			case "169.254.169.254":
+				internalHits.Add(1)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader("x")),
+					Request:    req,
+				}, nil
+			default:
+				return nil, fmt.Errorf("unexpected host %q", req.URL.Host)
+			}
+		}),
+	}
+
+	err := Download(context.Background(), DownloadOptions{
+		Blobs:   []Blob{blob},
+		BaseURL: "http://registry.example",
+		DestDir: t.TempDir(),
+		Client:  client,
+	})
+	if err == nil {
+		t.Fatal("Download succeeded; want local redirect rejection")
+	}
+	if !strings.Contains(err.Error(), "refusing redirect") {
+		t.Fatalf("Download error = %v, want refusing redirect", err)
+	}
+	if internalHits.Load() != 0 {
+		t.Fatalf("internal redirect target was requested %d times", internalHits.Load())
+	}
+}
+
+func TestDownloadDoesNotFollowSecondHopRedirectFromCDN(t *testing.T) {
+	stubLookupNetIP(t, map[string][]netip.Addr{
+		"registry.example": {netip.MustParseAddr("203.0.113.10")},
+		"cdn.example":      {netip.MustParseAddr("203.0.113.20")},
+	})
+
+	var internalHits atomic.Int32
+	blob := Blob{
+		Digest: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		Size:   1,
+	}
+
+	client := &http.Client{
+		Transport: transferRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.Host {
+			case "registry.example":
+				header := http.Header{}
+				header.Set("Location", "https://cdn.example/v2/library/_/blobs/"+blob.Digest)
+				return &http.Response{
+					StatusCode: http.StatusTemporaryRedirect,
+					Header:     header,
+					Body:       io.NopCloser(strings.NewReader("")),
+					Request:    req,
+				}, nil
+			case "cdn.example":
+				header := http.Header{}
+				header.Set("Location", "http://169.254.169.254/latest/meta-data/")
+				return &http.Response{
+					StatusCode: http.StatusTemporaryRedirect,
+					Header:     header,
+					Body:       io.NopCloser(strings.NewReader("")),
+					Request:    req,
+				}, nil
+			case "169.254.169.254":
+				internalHits.Add(1)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader("x")),
+					Request:    req,
+				}, nil
+			default:
+				return nil, fmt.Errorf("unexpected host %q", req.URL.Host)
+			}
+		}),
+	}
+
+	err := Download(context.Background(), DownloadOptions{
+		Blobs:   []Blob{blob},
+		BaseURL: "http://registry.example",
+		DestDir: t.TempDir(),
+		Client:  client,
+	})
+	if err == nil {
+		t.Fatal("Download succeeded; want redirected CDN response to fail")
+	}
+	if !strings.Contains(err.Error(), "status 307") {
+		t.Fatalf("Download error = %v, want status 307", err)
+	}
+	if internalHits.Load() != 0 {
+		t.Fatalf("internal redirect target was requested %d times", internalHits.Load())
+	}
+}
+
+func TestDownloadRejectsPublicRegistryRedirectToPrivateDNSName(t *testing.T) {
+	stubLookupNetIP(t, map[string][]netip.Addr{
+		"registry.example": {netip.MustParseAddr("203.0.113.10")},
+		"metadata.example": {netip.MustParseAddr("169.254.169.254")},
+	})
+
+	var internalHits atomic.Int32
+	blob := Blob{
+		Digest: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		Size:   1,
+	}
+
+	client := &http.Client{
+		Transport: transferRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.Host {
+			case "registry.example":
+				header := http.Header{}
+				header.Set("Location", "http://metadata.example/latest/meta-data/")
+				return &http.Response{
+					StatusCode: http.StatusTemporaryRedirect,
+					Header:     header,
+					Body:       io.NopCloser(strings.NewReader("")),
+					Request:    req,
+				}, nil
+			case "metadata.example":
+				internalHits.Add(1)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader("x")),
+					Request:    req,
+				}, nil
+			default:
+				return nil, fmt.Errorf("unexpected host %q", req.URL.Host)
+			}
+		}),
+	}
+
+	err := Download(context.Background(), DownloadOptions{
+		Blobs:   []Blob{blob},
+		BaseURL: "http://registry.example",
+		DestDir: t.TempDir(),
+		Client:  client,
+	})
+	if err == nil {
+		t.Fatal("Download succeeded; want private DNS redirect rejection")
+	}
+	if !strings.Contains(err.Error(), "refusing redirect") {
+		t.Fatalf("Download error = %v, want refusing redirect", err)
+	}
+	if internalHits.Load() != 0 {
+		t.Fatalf("private redirect target was requested %d times", internalHits.Load())
+	}
+}
+
+func TestDownloadRejectsPublicRegistryRedirectThroughProxy(t *testing.T) {
+	stubLookupNetIP(t, map[string][]netip.Addr{
+		"cdn.example": {netip.MustParseAddr("203.0.113.20")},
+	})
+
+	blob := Blob{
+		Digest: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		Size:   1,
+	}
+
+	var registryProxyHits atomic.Int32
+	var cdnProxyHits atomic.Int32
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Host {
+		case "registry.example":
+			registryProxyHits.Add(1)
+			http.Redirect(w, r, "https://cdn.example/v2/library/_/blobs/"+blob.Digest, http.StatusTemporaryRedirect)
+		case "cdn.example":
+			cdnProxyHits.Add(1)
+			http.Error(w, "cdn should not be requested through proxy", http.StatusBadGateway)
+		default:
+			http.Error(w, fmt.Sprintf("unexpected proxied host %q", r.URL.Host), http.StatusBadGateway)
+		}
+	}))
+	defer proxy.Close()
+
+	proxyURL, err := url.Parse(proxy.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = Download(context.Background(), DownloadOptions{
+		Blobs:   []Blob{blob},
+		BaseURL: "http://registry.example",
+		DestDir: t.TempDir(),
+		Client: &http.Client{
+			Transport: &http.Transport{
+				Proxy: http.ProxyURL(proxyURL),
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("Download succeeded; want proxied cross-host redirect rejection")
+	}
+	if !strings.Contains(err.Error(), "refusing redirect through proxy") {
+		t.Fatalf("Download error = %v, want proxy redirect rejection", err)
+	}
+	if registryProxyHits.Load() != 1 {
+		t.Fatalf("proxy received %d registry requests, want one non-retried rejection", registryProxyHits.Load())
+	}
+	if cdnProxyHits.Load() != 0 {
+		t.Fatalf("proxy received %d CDN requests after redirect rejection", cdnProxyHits.Load())
+	}
+}
+
+func TestRedirectValidationAndDialRejectDNSRebind(t *testing.T) {
+	var lookupCalls atomic.Int32
+	previous := lookupNetIP
+	lookupNetIP = func(ctx context.Context, network, host string) ([]netip.Addr, error) {
+		if host != "cdn.example" {
+			return nil, fmt.Errorf("unexpected lookup for %q", host)
+		}
+		if lookupCalls.Add(1) == 1 {
+			return []netip.Addr{netip.MustParseAddr("203.0.113.20")}, nil
+		}
+		return []netip.Addr{netip.MustParseAddr("169.254.169.254")}, nil
+	}
+	t.Cleanup(func() {
+		lookupNetIP = previous
+	})
+
+	baseURL, err := url.Parse("http://registry.example")
+	if err != nil {
+		t.Fatal(err)
+	}
+	redirectURL, err := url.Parse("https://cdn.example/v2/library/_/blobs/sha256:abc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validateRedirectURL(context.Background(), baseURL, redirectURL, nil); err != nil {
+		t.Fatalf("validateRedirectURL returned error before rebind: %v", err)
+	}
+
+	var dialed atomic.Bool
+	_, err = dialResolved(
+		context.Background(),
+		"tcp",
+		"cdn.example:443",
+		false,
+		func(context.Context, string, string) (net.Conn, error) {
+			dialed.Store(true)
+			return nil, errors.New("dialed")
+		},
+	)
+	if err == nil {
+		t.Fatal("dialResolved succeeded; want local address rejection")
+	}
+	if !strings.Contains(err.Error(), "refusing connection") {
+		t.Fatalf("dialResolved error = %v, want refusing connection", err)
+	}
+	if dialed.Load() {
+		t.Fatal("dialer was called after DNS rebinding to a local address")
+	}
+}
+
+func TestGuardedTransportUsesGuardedDialForCustomTLSTransport(t *testing.T) {
+	baseURL, err := url.Parse("https://registry.example")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rt := guardedTransport(&http.Transport{
+		DialTLSContext: func(context.Context, string, string) (net.Conn, error) {
+			return nil, errors.New("custom TLS dialer should not run")
+		},
+	}, baseURL)
+
+	tr, ok := rt.(*http.Transport)
+	if !ok {
+		t.Fatalf("guardedTransport returned %T, want *http.Transport", rt)
+	}
+	if tr.DialTLSContext != nil {
+		t.Fatal("guarded transport kept custom DialTLSContext")
+	}
+	if tr.DialContext == nil {
+		t.Fatal("guarded transport did not install DialContext")
+	}
+}
+
+func TestIsLocalHost(t *testing.T) {
+	cases := []struct {
+		host string
+		want bool
+	}{
+		{host: "localhost", want: true},
+		{host: "metadata.localhost.", want: true},
+		{host: "127.0.0.1", want: true},
+		{host: "::ffff:127.0.0.1", want: true},
+		{host: "10.0.0.1", want: true},
+		{host: "169.254.169.254", want: true},
+		{host: "registry.example", want: false},
+		{host: "cdn.example", want: false},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.host, func(t *testing.T) {
+			if got := isLocalHost(tt.host); got != tt.want {
+				t.Fatalf("isLocalHost(%q) = %v, want %v", tt.host, got, tt.want)
+			}
+		})
+	}
 }
 
 func TestDownloadWithRetry(t *testing.T) {


### PR DESCRIPTION
## Summary
- reject tensor blob redirects from public registries to local/private/link-local targets
- keep cross-host blob downloads from automatically following second-hop redirects
- guard the final direct dial path against DNS rebinding before a connection is opened
- reject proxied cross-host redirects from public registries, since the client cannot pin the proxy's later target resolution
- add regression coverage for literal local targets, DNS-backed private targets, DNS rebinding, proxy redirects, and custom TLS dialer bypasses

Fixes #17041.

## Tests
- `go test ./x/transfer`
- `go test -race ./x/transfer -run 'TestDownloadWithRedirect|TestDownloadRejectsPublicRegistryRedirectToLocalAddress|TestDownloadRejectsPublicRegistryRedirectToPrivateDNSName|TestDownloadRejectsPublicRegistryRedirectThroughProxy|TestRedirectValidationAndDialRejectDNSRebind|TestDownloadDoesNotFollowSecondHopRedirectFromCDN|TestGuardedTransportUsesGuardedDialForCustomTLSTransport|TestIsLocalHost|TestDownloadParallelism'`
- `go test ./server -run 'Test.*Redirect|Test.*Download|Test.*Auth|Test.*Realm'`
- `go test ./x/transfer -run 'TestDownloadRejectsPublicRegistryRedirectToLocalAddress|TestDownloadRejectsPublicRegistryRedirectToPrivateDNSName|TestDownloadRejectsPublicRegistryRedirectThroughProxy|TestRedirectValidationAndDialRejectDNSRebind|TestDownloadDoesNotFollowSecondHopRedirectFromCDN|TestGuardedTransportUsesGuardedDialForCustomTLSTransport|TestIsLocalHost' -count=3`
- `git diff --check`
