### PR TITLE
server: split qwen3.5 instruct variants

### DIFF
--- a/model/parsers/parsers.go
+++ b/model/parsers/parsers.go
@@ -52,10 +52,12 @@ func ParserForName(name string) Parser {
 		p = &Qwen3Parser{hasThinkingSupport: false, defaultThinking: false}
 	case "qwen3-thinking":
 		p = &Qwen3Parser{hasThinkingSupport: true, defaultThinking: true}
-	case "qwen3.5":
-		p = &Qwen35Parser{}
+	case "qwen3.5", "qwen3.5-thinking":
+		p = &Qwen35Parser{hasThinkingSupport: true, defaultThinking: true}
+	case "qwen3.5-instruct":
+		p = &Qwen35Parser{hasThinkingSupport: false, defaultThinking: false}
 	case "ornith":
-		p = &Qwen35Parser{}
+		p = &Qwen35Parser{hasThinkingSupport: true, defaultThinking: true}
 	case "qwen3-coder":
 		p = &Qwen3CoderParser{}
 	case "qwen3-vl-instruct":

--- a/model/parsers/parsers.go
+++ b/model/parsers/parsers.go
@@ -52,7 +52,7 @@ func ParserForName(name string) Parser {
 		p = &Qwen3Parser{hasThinkingSupport: false, defaultThinking: false}
 	case "qwen3-thinking":
 		p = &Qwen3Parser{hasThinkingSupport: true, defaultThinking: true}
-	case "qwen3.5", "qwen3.5-thinking":
+	case "qwen3.5":
 		p = &Qwen35Parser{hasThinkingSupport: true, defaultThinking: true}
 	case "qwen3.5-instruct":
 		p = &Qwen35Parser{hasThinkingSupport: false, defaultThinking: false}

--- a/model/parsers/parsers_test.go
+++ b/model/parsers/parsers_test.go
@@ -65,6 +65,8 @@ func TestBuiltInParsersStillWork(t *testing.T) {
 		{"lfm2"},
 		{"lfm2-thinking"},
 		{"qwen3.5"},
+		{"qwen3.5-instruct"},
+		{"qwen3.5-thinking"},
 		{"ornith"},
 		{"harmony"},
 	}

--- a/model/parsers/parsers_test.go
+++ b/model/parsers/parsers_test.go
@@ -66,7 +66,6 @@ func TestBuiltInParsersStillWork(t *testing.T) {
 		{"lfm2-thinking"},
 		{"qwen3.5"},
 		{"qwen3.5-instruct"},
-		{"qwen3.5-thinking"},
 		{"ornith"},
 		{"harmony"},
 	}

--- a/model/parsers/qwen35.go
+++ b/model/parsers/qwen35.go
@@ -29,8 +29,10 @@ const (
 type Qwen35Parser struct {
 	toolParser Qwen3CoderParser
 
-	state  qwen35ParserState
-	buffer strings.Builder
+	state              qwen35ParserState
+	buffer             strings.Builder
+	hasThinkingSupport bool
+	defaultThinking    bool
 	// Some checkpoints may emit an explicit leading <think> even when the
 	// prompt already opened thinking. Strip at most one such tag.
 	allowLeadingThinkOpenTag bool
@@ -41,7 +43,7 @@ func (p *Qwen35Parser) HasToolSupport() bool {
 }
 
 func (p *Qwen35Parser) HasThinkingSupport() bool {
-	return true
+	return p.hasThinkingSupport
 }
 
 func (p *Qwen35Parser) PreservedTokens() []string {
@@ -60,11 +62,11 @@ func (p *Qwen35Parser) Init(tools []api.Tool, lastMessage *api.Message, thinkVal
 
 	thinkingEnabled := thinkValue != nil && thinkValue.Bool()
 	if thinkValue == nil {
-		thinkingEnabled = true
+		thinkingEnabled = p.defaultThinking
 	}
 
 	assistantPrefill := lastMessage != nil && lastMessage.Role == "assistant" && lastMessage.Content != ""
-	if thinkingEnabled && !assistantPrefill {
+	if p.hasThinkingSupport && thinkingEnabled && !assistantPrefill {
 		p.state = qwen35ParserStateCollectingThinking
 		p.allowLeadingThinkOpenTag = true
 	} else {

--- a/model/parsers/qwen3_test.go
+++ b/model/parsers/qwen3_test.go
@@ -260,13 +260,13 @@ func TestQwen35InstructParserDefaultsToContent(t *testing.T) {
 	}
 }
 
-func TestQwen35ThinkingParserDefaultsToThinking(t *testing.T) {
-	parser := ParserForName("qwen3.5-thinking")
+func TestQwen35DefaultParserDefaultsToThinking(t *testing.T) {
+	parser := ParserForName("qwen3.5")
 	if parser == nil {
-		t.Fatal("expected qwen3.5-thinking parser")
+		t.Fatal("expected qwen3.5 parser")
 	}
 	if !parser.HasThinkingSupport() {
-		t.Fatal("expected thinking parser to advertise thinking support")
+		t.Fatal("expected default parser to advertise thinking support")
 	}
 
 	parser.Init(nil, nil, nil)

--- a/model/parsers/qwen3_test.go
+++ b/model/parsers/qwen3_test.go
@@ -231,6 +231,58 @@ func TestQwen35ParserRespectsNoThink(t *testing.T) {
 	}
 }
 
+func TestQwen35InstructParserDefaultsToContent(t *testing.T) {
+	parser := ParserForName("qwen3.5-instruct")
+	if parser == nil {
+		t.Fatal("expected qwen3.5-instruct parser")
+	}
+	if parser.HasThinkingSupport() {
+		t.Fatal("expected instruct parser not to advertise thinking support")
+	}
+	if !parser.HasToolSupport() {
+		t.Fatal("expected instruct parser to keep tool support")
+	}
+
+	parser.Init(nil, nil, nil)
+	content, thinking, calls, err := parser.Add("Direct answer", true)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+
+	if thinking != "" {
+		t.Fatalf("expected no thinking, got %q", thinking)
+	}
+	if content != "Direct answer" {
+		t.Fatalf("expected content %q, got %q", "Direct answer", content)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("expected no tool calls, got %d", len(calls))
+	}
+}
+
+func TestQwen35ThinkingParserDefaultsToThinking(t *testing.T) {
+	parser := ParserForName("qwen3.5-thinking")
+	if parser == nil {
+		t.Fatal("expected qwen3.5-thinking parser")
+	}
+	if !parser.HasThinkingSupport() {
+		t.Fatal("expected thinking parser to advertise thinking support")
+	}
+
+	parser.Init(nil, nil, nil)
+	content, thinking, _, err := parser.Add("Plan first.</think>Answer.", true)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+
+	if thinking != "Plan first." {
+		t.Fatalf("expected thinking %q, got %q", "Plan first.", thinking)
+	}
+	if content != "Answer." {
+		t.Fatalf("expected content %q, got %q", "Answer.", content)
+	}
+}
+
 func TestQwen3ParserToolCallIndexing(t *testing.T) {
 	parser := &Qwen3Parser{hasThinkingSupport: false, defaultThinking: false}
 	parser.Init(nil, nil, &api.ThinkValue{Value: false})

--- a/model/renderers/qwen35_test.go
+++ b/model/renderers/qwen35_test.go
@@ -90,6 +90,47 @@ func TestQwen35RendererNoThinkPrefill(t *testing.T) {
 	}
 }
 
+func TestQwen35InstructRendererDoesNotInjectThinking(t *testing.T) {
+	renderer := &Qwen35Renderer{isThinking: false}
+	msgs := []api.Message{
+		{Role: "user", Content: "hello"},
+	}
+
+	got, err := renderer.Render(msgs, nil, nil)
+	if err != nil {
+		t.Fatalf("render failed: %v", err)
+	}
+
+	if strings.Contains(got, "<think>") || strings.Contains(got, "</think>") {
+		t.Fatalf("did not expect think tags for instruct renderer, got:\n%s", got)
+	}
+	if !strings.HasSuffix(got, "<|im_start|>assistant\n") {
+		t.Fatalf("expected plain assistant prefill, got:\n%s", got)
+	}
+}
+
+func TestQwen35RendererNamesSplitThinkingDefaults(t *testing.T) {
+	msgs := []api.Message{
+		{Role: "user", Content: "hello"},
+	}
+
+	instruct, err := RenderWithRenderer("qwen3.5-instruct", msgs, nil, nil)
+	if err != nil {
+		t.Fatalf("render instruct failed: %v", err)
+	}
+	if strings.Contains(instruct, "<think>") || strings.Contains(instruct, "</think>") {
+		t.Fatalf("did not expect think tags for qwen3.5-instruct, got:\n%s", instruct)
+	}
+
+	thinking, err := RenderWithRenderer("qwen3.5-thinking", msgs, nil, nil)
+	if err != nil {
+		t.Fatalf("render thinking failed: %v", err)
+	}
+	if !strings.HasSuffix(thinking, "<|im_start|>assistant\n<think>\n") {
+		t.Fatalf("expected thinking prefill for qwen3.5-thinking, got:\n%s", thinking)
+	}
+}
+
 func TestQwen35RendererBackToBackToolCallsAndResponses(t *testing.T) {
 	renderer := &Qwen35Renderer{isThinking: true}
 

--- a/model/renderers/qwen35_test.go
+++ b/model/renderers/qwen35_test.go
@@ -109,7 +109,7 @@ func TestQwen35InstructRendererDoesNotInjectThinking(t *testing.T) {
 	}
 }
 
-func TestQwen35RendererNamesSplitThinkingDefaults(t *testing.T) {
+func TestQwen35RendererNamesSplitInstructAndDefault(t *testing.T) {
 	msgs := []api.Message{
 		{Role: "user", Content: "hello"},
 	}
@@ -122,12 +122,12 @@ func TestQwen35RendererNamesSplitThinkingDefaults(t *testing.T) {
 		t.Fatalf("did not expect think tags for qwen3.5-instruct, got:\n%s", instruct)
 	}
 
-	thinking, err := RenderWithRenderer("qwen3.5-thinking", msgs, nil, nil)
+	thinking, err := RenderWithRenderer("qwen3.5", msgs, nil, nil)
 	if err != nil {
-		t.Fatalf("render thinking failed: %v", err)
+		t.Fatalf("render default failed: %v", err)
 	}
 	if !strings.HasSuffix(thinking, "<|im_start|>assistant\n<think>\n") {
-		t.Fatalf("expected thinking prefill for qwen3.5-thinking, got:\n%s", thinking)
+		t.Fatalf("expected thinking prefill for qwen3.5, got:\n%s", thinking)
 	}
 }
 

--- a/model/renderers/renderer.go
+++ b/model/renderers/renderer.go
@@ -66,8 +66,11 @@ func rendererForName(name string) Renderer {
 	case "qwen3-vl-thinking":
 		renderer := &Qwen3VLRenderer{isThinking: true, useImgTags: RenderImgTags}
 		return renderer
-	case "qwen3.5":
+	case "qwen3.5", "qwen3.5-thinking":
 		renderer := &Qwen35Renderer{isThinking: true, emitEmptyThinkOnNoThink: true, useImgTags: RenderImgTags}
+		return renderer
+	case "qwen3.5-instruct":
+		renderer := &Qwen35Renderer{isThinking: false, useImgTags: RenderImgTags}
 		return renderer
 	case "ornith":
 		return newOrnithRenderer()

--- a/model/renderers/renderer.go
+++ b/model/renderers/renderer.go
@@ -66,7 +66,7 @@ func rendererForName(name string) Renderer {
 	case "qwen3-vl-thinking":
 		renderer := &Qwen3VLRenderer{isThinking: true, useImgTags: RenderImgTags}
 		return renderer
-	case "qwen3.5", "qwen3.5-thinking":
+	case "qwen3.5":
 		renderer := &Qwen35Renderer{isThinking: true, emitEmptyThinkOnNoThink: true, useImgTags: RenderImgTags}
 		return renderer
 	case "qwen3.5-instruct":

--- a/server/images.go
+++ b/server/images.go
@@ -425,7 +425,7 @@ func (m *Model) templateCapabilities(capabilities []model.Capability, source tem
 }
 
 func (m *Model) parserCapabilities(capabilities []model.Capability) []model.Capability {
-	builtinParser := parsers.ParserForName(m.Config.Parser)
+	builtinParser := parsers.ParserForName(resolveParserName(m))
 	if builtinParser == nil {
 		return capabilities
 	}

--- a/server/model_list_cache.go
+++ b/server/model_list_cache.go
@@ -365,7 +365,12 @@ func buildModelListSummary(name model.Name, mf *manifest.Manifest) (modelListSum
 		summary.Capabilities = appendModelListCapability(summary.Capabilities, model.Capability(c))
 	}
 
-	builtinParser := parsers.ParserForName(cfg.Parser)
+	parserModel := Model{
+		Name:      name.String(),
+		ShortName: name.DisplayShortest(),
+		Config:    cfg,
+	}
+	builtinParser := parsers.ParserForName(resolveParserName(&parserModel))
 	if tmpl != nil {
 		vars, err := tmpl.Vars()
 		if err != nil {

--- a/server/model_list_cache_test.go
+++ b/server/model_list_cache_test.go
@@ -70,6 +70,42 @@ func TestModelListCacheHydratesSummary(t *testing.T) {
 	}
 }
 
+func TestModelListCacheResolvesQwen35InstructParserCapabilities(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setTestHome(t, t.TempDir())
+
+	_, digest := createBinFile(t, map[string]any{"test.context_length": uint32(4096)}, nil)
+	var s Server
+	w := createRequest(t, s.CreateHandler, api.CreateRequest{
+		Model:    "qwen3.5:instruct",
+		Files:    map[string]string{"model.gguf": digest},
+		Template: "{{ .Prompt }}",
+		Renderer: qwen35Legacy,
+		Parser:   qwen35Legacy,
+		Stream:   &stream,
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("create model status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+
+	cache := newModelListCache()
+	if err := cache.hydrate(context.Background()); err != nil {
+		t.Fatalf("hydrate failed: %v", err)
+	}
+
+	summary, ok := cache.Get(model.ParseName("qwen3.5:instruct"))
+	if !ok {
+		t.Fatal("list summary missing")
+	}
+
+	if !slices.Contains(summary.Capabilities, model.CapabilityTools) {
+		t.Fatalf("capabilities = %v, want tools", summary.Capabilities)
+	}
+	if slices.Contains(summary.Capabilities, model.CapabilityThinking) {
+		t.Fatalf("capabilities = %v, did not want thinking", summary.Capabilities)
+	}
+}
+
 func TestModelListCacheRefreshUpdatesEntry(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	setTestHome(t, t.TempDir())

--- a/server/model_list_cache_test.go
+++ b/server/model_list_cache_test.go
@@ -80,8 +80,8 @@ func TestModelListCacheResolvesQwen35InstructParserCapabilities(t *testing.T) {
 		Model:    "qwen3.5:instruct",
 		Files:    map[string]string{"model.gguf": digest},
 		Template: "{{ .Prompt }}",
-		Renderer: qwen35Legacy,
-		Parser:   qwen35Legacy,
+		Renderer: qwen35Default,
+		Parser:   qwen35Default,
 		Stream:   &stream,
 	})
 	if w.Code != http.StatusOK {

--- a/server/qwen35_test.go
+++ b/server/qwen35_test.go
@@ -1,0 +1,118 @@
+package server
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/types/model"
+)
+
+func TestResolveQwen35Variant(t *testing.T) {
+	tests := []struct {
+		name  string
+		model *Model
+		want  string
+	}{
+		{
+			name: "instruct from short name",
+			model: &Model{
+				Name:      "registry.ollama.ai/frob/qwen3.5-instruct:latest",
+				ShortName: "frob/qwen3.5-instruct:latest",
+				Config:    model.ConfigV2{Renderer: qwen35Legacy, Parser: qwen35Legacy},
+			},
+			want: qwen35Instruct,
+		},
+		{
+			name: "instruct from base name",
+			model: &Model{
+				Config: model.ConfigV2{
+					Renderer: qwen35Legacy,
+					Parser:   qwen35Legacy,
+					BaseName: "Qwen3.5-Instruct",
+				},
+			},
+			want: qwen35Instruct,
+		},
+		{
+			name: "thinking from short name",
+			model: &Model{
+				ShortName: "library/qwen3.5-thinking:latest",
+				Config:    model.ConfigV2{Renderer: qwen35Legacy, Parser: qwen35Legacy},
+			},
+			want: qwen35Thinking,
+		},
+		{
+			name: "plain remains legacy",
+			model: &Model{
+				ShortName: "library/qwen3.5:latest",
+				Config:    model.ConfigV2{Renderer: qwen35Legacy, Parser: qwen35Legacy},
+			},
+			want: qwen35Legacy,
+		},
+		{
+			name: "instruct from tag",
+			model: &Model{
+				ShortName: "library/qwen3.5:instruct",
+				Config:    model.ConfigV2{Renderer: qwen35Legacy, Parser: qwen35Legacy},
+			},
+			want: qwen35Instruct,
+		},
+		{
+			name: "namespace does not select instruct variant",
+			model: &Model{
+				ShortName: "instruct-lab/qwen3.5:latest",
+				Config:    model.ConfigV2{Renderer: qwen35Legacy, Parser: qwen35Legacy},
+			},
+			want: qwen35Legacy,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveRendererName(tt.model); got != tt.want {
+				t.Fatalf("resolveRendererName() = %q, want %q", got, tt.want)
+			}
+			if got := resolveParserName(tt.model); got != tt.want {
+				t.Fatalf("resolveParserName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestQwen35InstructModelDoesNotAdvertiseThinking(t *testing.T) {
+	m := Model{
+		Name:      "registry.ollama.ai/frob/qwen3.5-instruct:latest",
+		ShortName: "frob/qwen3.5-instruct:latest",
+		Config:    model.ConfigV2{Parser: qwen35Legacy},
+	}
+
+	caps := m.Capabilities()
+	if !slices.Contains(caps, model.CapabilityTools) {
+		t.Fatalf("expected tools capability, got %#v", caps)
+	}
+	if slices.Contains(caps, model.CapabilityThinking) {
+		t.Fatalf("did not expect thinking capability, got %#v", caps)
+	}
+}
+
+func TestRenderPromptResolvesQwen35InstructRenderer(t *testing.T) {
+	m := Model{
+		Name:      "registry.ollama.ai/frob/qwen3.5-instruct:latest",
+		ShortName: "frob/qwen3.5-instruct:latest",
+		Config:    model.ConfigV2{Renderer: qwen35Legacy},
+	}
+
+	got, err := renderPrompt(&m, []api.Message{{Role: "user", Content: "Hello"}}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.Contains(got, "<think>") || strings.Contains(got, "</think>") {
+		t.Fatalf("did not expect think tags for instruct renderer, got:\n%s", got)
+	}
+	if !strings.HasSuffix(got, "<|im_start|>assistant\n") {
+		t.Fatalf("expected plain assistant prefill, got:\n%s", got)
+	}
+}

--- a/server/qwen35_test.go
+++ b/server/qwen35_test.go
@@ -36,14 +36,6 @@ func TestResolveQwen35Variant(t *testing.T) {
 			want: qwen35Instruct,
 		},
 		{
-			name: "thinking from short name",
-			model: &Model{
-				ShortName: "library/qwen3.5-thinking:latest",
-				Config:    model.ConfigV2{Renderer: qwen35Default, Parser: qwen35Default},
-			},
-			want: qwen35Thinking,
-		},
-		{
 			name: "plain remains default",
 			model: &Model{
 				ShortName: "library/qwen3.5:latest",

--- a/server/qwen35_test.go
+++ b/server/qwen35_test.go
@@ -20,7 +20,7 @@ func TestResolveQwen35Variant(t *testing.T) {
 			model: &Model{
 				Name:      "registry.ollama.ai/frob/qwen3.5-instruct:latest",
 				ShortName: "frob/qwen3.5-instruct:latest",
-				Config:    model.ConfigV2{Renderer: qwen35Legacy, Parser: qwen35Legacy},
+				Config:    model.ConfigV2{Renderer: qwen35Default, Parser: qwen35Default},
 			},
 			want: qwen35Instruct,
 		},
@@ -28,8 +28,8 @@ func TestResolveQwen35Variant(t *testing.T) {
 			name: "instruct from base name",
 			model: &Model{
 				Config: model.ConfigV2{
-					Renderer: qwen35Legacy,
-					Parser:   qwen35Legacy,
+					Renderer: qwen35Default,
+					Parser:   qwen35Default,
 					BaseName: "Qwen3.5-Instruct",
 				},
 			},
@@ -39,23 +39,23 @@ func TestResolveQwen35Variant(t *testing.T) {
 			name: "thinking from short name",
 			model: &Model{
 				ShortName: "library/qwen3.5-thinking:latest",
-				Config:    model.ConfigV2{Renderer: qwen35Legacy, Parser: qwen35Legacy},
+				Config:    model.ConfigV2{Renderer: qwen35Default, Parser: qwen35Default},
 			},
 			want: qwen35Thinking,
 		},
 		{
-			name: "plain remains legacy",
+			name: "plain remains default",
 			model: &Model{
 				ShortName: "library/qwen3.5:latest",
-				Config:    model.ConfigV2{Renderer: qwen35Legacy, Parser: qwen35Legacy},
+				Config:    model.ConfigV2{Renderer: qwen35Default, Parser: qwen35Default},
 			},
-			want: qwen35Legacy,
+			want: qwen35Default,
 		},
 		{
 			name: "instruct from tag",
 			model: &Model{
 				ShortName: "library/qwen3.5:instruct",
-				Config:    model.ConfigV2{Renderer: qwen35Legacy, Parser: qwen35Legacy},
+				Config:    model.ConfigV2{Renderer: qwen35Default, Parser: qwen35Default},
 			},
 			want: qwen35Instruct,
 		},
@@ -63,9 +63,9 @@ func TestResolveQwen35Variant(t *testing.T) {
 			name: "namespace does not select instruct variant",
 			model: &Model{
 				ShortName: "instruct-lab/qwen3.5:latest",
-				Config:    model.ConfigV2{Renderer: qwen35Legacy, Parser: qwen35Legacy},
+				Config:    model.ConfigV2{Renderer: qwen35Default, Parser: qwen35Default},
 			},
-			want: qwen35Legacy,
+			want: qwen35Default,
 		},
 	}
 
@@ -85,7 +85,7 @@ func TestQwen35InstructModelDoesNotAdvertiseThinking(t *testing.T) {
 	m := Model{
 		Name:      "registry.ollama.ai/frob/qwen3.5-instruct:latest",
 		ShortName: "frob/qwen3.5-instruct:latest",
-		Config:    model.ConfigV2{Parser: qwen35Legacy},
+		Config:    model.ConfigV2{Parser: qwen35Default},
 	}
 
 	caps := m.Capabilities()
@@ -101,7 +101,7 @@ func TestRenderPromptResolvesQwen35InstructRenderer(t *testing.T) {
 	m := Model{
 		Name:      "registry.ollama.ai/frob/qwen3.5-instruct:latest",
 		ShortName: "frob/qwen3.5-instruct:latest",
-		Config:    model.ConfigV2{Renderer: qwen35Legacy},
+		Config:    model.ConfigV2{Renderer: qwen35Default},
 	}
 
 	got, err := renderPrompt(&m, []api.Message{{Role: "user", Content: "Hello"}}, nil, nil)

--- a/server/renderer_resolution.go
+++ b/server/renderer_resolution.go
@@ -11,6 +11,9 @@ const (
 	gemma4RendererLegacy = "gemma4"
 	gemma4RendererSmall  = "gemma4-small"
 	gemma4RendererLarge  = "gemma4-large"
+	qwen35Legacy         = "qwen3.5"
+	qwen35Instruct       = "qwen3.5-instruct"
+	qwen35Thinking       = "qwen3.5-thinking"
 
 	// Gemma 4 small templates cover the e2b/e4b family, while 12b/26b/31b use
 	// the large template. Default to the small prompt unless the model is
@@ -26,8 +29,23 @@ func resolveRendererName(m *Model) string {
 	switch m.Config.Renderer {
 	case gemma4RendererLegacy:
 		return resolveGemma4Renderer(m)
+	case qwen35Legacy:
+		return resolveQwen35Variant(m)
 	default:
 		return m.Config.Renderer
+	}
+}
+
+func resolveParserName(m *Model) string {
+	if m == nil || m.Config.Parser == "" {
+		return ""
+	}
+
+	switch m.Config.Parser {
+	case qwen35Legacy:
+		return resolveQwen35Variant(m)
+	default:
+		return m.Config.Parser
 	}
 }
 
@@ -69,6 +87,45 @@ func gemma4RendererFromName(name string) (string, bool) {
 		return gemma4RendererSmall, true
 	case strings.Contains(lower, "12b"), strings.Contains(lower, "26b"), strings.Contains(lower, "31b"):
 		return gemma4RendererLarge, true
+	default:
+		return "", false
+	}
+}
+
+func resolveQwen35Variant(m *Model) string {
+	if m == nil {
+		return qwen35Legacy
+	}
+
+	for _, name := range []string{m.ShortName, m.Name, m.Config.BaseName, m.Config.RemoteModel} {
+		if variant, ok := qwen35VariantFromName(name); ok {
+			return variant
+		}
+	}
+
+	return qwen35Legacy
+}
+
+func qwen35VariantFromName(name string) (string, bool) {
+	lower := strings.ToLower(name)
+	if idx := strings.LastIndex(lower, "/"); idx != -1 {
+		lower = lower[idx+1:]
+	}
+
+	if !strings.Contains(lower, "qwen3.5") && !strings.Contains(lower, "qwen35") {
+		return "", false
+	}
+
+	switch {
+	case strings.Contains(lower, "instruct"),
+		strings.Contains(lower, "non-thinking"),
+		strings.Contains(lower, "non_thinking"),
+		strings.Contains(lower, "nothink"),
+		strings.Contains(lower, "no-think"):
+		return qwen35Instruct, true
+	case strings.Contains(lower, "thinking"),
+		strings.Contains(lower, "think"):
+		return qwen35Thinking, true
 	default:
 		return "", false
 	}

--- a/server/renderer_resolution.go
+++ b/server/renderer_resolution.go
@@ -13,7 +13,6 @@ const (
 	gemma4RendererLarge  = "gemma4-large"
 	qwen35Default        = "qwen3.5"
 	qwen35Instruct       = "qwen3.5-instruct"
-	qwen35Thinking       = "qwen3.5-thinking"
 
 	// Gemma 4 small templates cover the e2b/e4b family, while 12b/26b/31b use
 	// the large template. Default to the small prompt unless the model is
@@ -123,9 +122,6 @@ func qwen35VariantFromName(name string) (string, bool) {
 		strings.Contains(lower, "nothink"),
 		strings.Contains(lower, "no-think"):
 		return qwen35Instruct, true
-	case strings.Contains(lower, "thinking"),
-		strings.Contains(lower, "think"):
-		return qwen35Thinking, true
 	default:
 		return "", false
 	}

--- a/server/renderer_resolution.go
+++ b/server/renderer_resolution.go
@@ -11,7 +11,7 @@ const (
 	gemma4RendererLegacy = "gemma4"
 	gemma4RendererSmall  = "gemma4-small"
 	gemma4RendererLarge  = "gemma4-large"
-	qwen35Legacy         = "qwen3.5"
+	qwen35Default        = "qwen3.5"
 	qwen35Instruct       = "qwen3.5-instruct"
 	qwen35Thinking       = "qwen3.5-thinking"
 
@@ -29,7 +29,7 @@ func resolveRendererName(m *Model) string {
 	switch m.Config.Renderer {
 	case gemma4RendererLegacy:
 		return resolveGemma4Renderer(m)
-	case qwen35Legacy:
+	case qwen35Default:
 		return resolveQwen35Variant(m)
 	default:
 		return m.Config.Renderer
@@ -42,7 +42,7 @@ func resolveParserName(m *Model) string {
 	}
 
 	switch m.Config.Parser {
-	case qwen35Legacy:
+	case qwen35Default:
 		return resolveQwen35Variant(m)
 	default:
 		return m.Config.Parser
@@ -94,7 +94,7 @@ func gemma4RendererFromName(name string) (string, bool) {
 
 func resolveQwen35Variant(m *Model) string {
 	if m == nil {
-		return qwen35Legacy
+		return qwen35Default
 	}
 
 	for _, name := range []string{m.ShortName, m.Name, m.Config.BaseName, m.Config.RemoteModel} {
@@ -103,7 +103,7 @@ func resolveQwen35Variant(m *Model) string {
 		}
 	}
 
-	return qwen35Legacy
+	return qwen35Default
 }
 
 func qwen35VariantFromName(name string) (string, bool) {

--- a/server/routes.go
+++ b/server/routes.go
@@ -448,7 +448,7 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 	}
 
 	if !req.Raw && m.Config.Parser != "" {
-		builtinParser = parsers.ParserForName(m.Config.Parser)
+		builtinParser = parsers.ParserForName(resolveParserName(m))
 		if builtinParser != nil {
 			// no tools or last message for generate endpoint
 			builtinParser.Init(nil, nil, req.Think)
@@ -2685,7 +2685,7 @@ func (s *Server) ChatHandler(c *gin.Context) {
 	processedTools := req.Tools
 
 	if m.Config.Parser != "" {
-		builtinParser = parsers.ParserForName(m.Config.Parser)
+		builtinParser = parsers.ParserForName(resolveParserName(m))
 		if builtinParser != nil {
 			// Determine last message for chat prefill
 			var lastMessage *api.Message


### PR DESCRIPTION
## Summary
- add an explicit `qwen3.5-instruct` parser/renderer variant for non-thinking Qwen 3.5 instruct models
- keep plain `qwen3.5` on the existing thinking-capable behavior while resolving instruct/non-thinking names, tags, base names, and remote model metadata to the instruct variant
- use the resolved parser name for model capabilities, model-list summaries, and generate/chat parser initialization

Fixes #17083.

## Tests
- `go test -count=1 ./model/parsers ./model/renderers ./server -run "TestBuiltInParsersStillWork|TestQwen35|TestQwenRendererName|TestChatFormatWithThinkFalse|TestGenerate.*Parser|TestRenderPrompt|TestModel.*Capabilities|TestResolveQwen35Variant|TestModelListCacheResolvesQwen35InstructParserCapabilities"`
- `go test -count=1 ./server -run "TestModelListCache|TestReadModelListGGUFRejectsMalformedMetadata"`
- `git diff --check`
