### PR TITLE
install: detect Intel Arc by PCI ID (Battlemage) and fetch oneAPI package

### DIFF
--- a/docs/linux.mdx
+++ b/docs/linux.mdx
@@ -45,6 +45,20 @@ curl -fsSL https://ollama.com/download/ollama-linux-amd64-rocm.tar.zst \
     | sudo tar x -C /usr
 ```
 
+### Intel Arc GPU install
+
+The install script detects discrete Intel Arc GPUs by PCI device ID (Alchemist
+and Battlemage, including Arc Pro B60) via `/sys/bus/pci/devices` — not by OS
+version. The base package includes the Vulkan backend for Intel GPUs.
+
+When a oneAPI package is published for the release, the install script also
+downloads it automatically. You can install it manually the same way as ROCm:
+
+```shell
+curl -fsSL https://ollama.com/download/ollama-linux-amd64-oneapi.tar.zst \
+    | sudo tar x -C /usr
+```
+
 ### ARM64 install
 
 Download and extract the ARM64-specific package:

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -54,17 +54,23 @@ if echo $PLATFORM | grep "," > /dev/null ; then
         tar c -C ./dist/linux_arm64 --exclude cuda_jetpack5 --exclude cuda_jetpack6 . | zstd -9 -T0 >./dist/ollama-linux-arm64.tar.zst
         tar c -C ./dist/linux_arm64 ./lib/ollama/cuda_jetpack5  | zstd -9 -T0 >./dist/ollama-linux-arm64-jetpack5.tar.zst
         tar c -C ./dist/linux_arm64 ./lib/ollama/cuda_jetpack6  | zstd -9 -T0 >./dist/ollama-linux-arm64-jetpack6.tar.zst
-        tar c -C ./dist/linux_amd64 --exclude './lib/ollama/rocm*' --exclude './lib/ollama/mlx*' --exclude './lib/ollama/include' . | zstd -9 -T0 >./dist/ollama-linux-amd64.tar.zst
+        tar c -C ./dist/linux_amd64 --exclude './lib/ollama/rocm*' --exclude './lib/ollama/mlx*' --exclude './lib/ollama/oneapi*' --exclude './lib/ollama/include' . | zstd -9 -T0 >./dist/ollama-linux-amd64.tar.zst
         ( cd ./dist/linux_amd64 && tar c lib/ollama/rocm_v* ) | zstd -9 -T0 >./dist/ollama-linux-amd64-rocm.tar.zst
         ( cd ./dist/linux_amd64 && if [ -e lib/ollama/include ]; then tar c lib/ollama/mlx* lib/ollama/include; else tar c lib/ollama/mlx*; fi ) | zstd -9 -T0 >./dist/ollama-linux-amd64-mlx.tar.zst
+        if ls ./dist/linux_amd64/lib/ollama/oneapi* >/dev/null 2>&1; then
+            ( cd ./dist/linux_amd64 && tar c lib/ollama/oneapi* ) | zstd -9 -T0 >./dist/ollama-linux-amd64-oneapi.tar.zst
+        fi
 elif echo $PLATFORM | grep "arm64" > /dev/null ; then
         tar c -C ./dist/ --exclude cuda_jetpack5 --exclude cuda_jetpack6 bin lib | zstd -9 -T0 >./dist/ollama-linux-arm64.tar.zst
         tar c -C ./dist/ ./lib/ollama/cuda_jetpack5  | zstd -9 -T0 >./dist/ollama-linux-arm64-jetpack5.tar.zst
         tar c -C ./dist/ ./lib/ollama/cuda_jetpack6  | zstd -9 -T0 >./dist/ollama-linux-arm64-jetpack6.tar.zst
 elif echo $PLATFORM | grep "amd64" > /dev/null ; then
-        tar c -C ./dist/ --exclude 'lib/ollama/rocm*' --exclude 'lib/ollama/mlx*' --exclude 'lib/ollama/include' bin lib | zstd -9 -T0 >./dist/ollama-linux-amd64.tar.zst
+        tar c -C ./dist/ --exclude 'lib/ollama/rocm*' --exclude 'lib/ollama/mlx*' --exclude 'lib/ollama/oneapi*' --exclude 'lib/ollama/include' bin lib | zstd -9 -T0 >./dist/ollama-linux-amd64.tar.zst
         ( cd ./dist/ && tar c lib/ollama/rocm_v* ) | zstd -9 -T0 >./dist/ollama-linux-amd64-rocm.tar.zst
         ( cd ./dist/ && if [ -e lib/ollama/include ]; then tar c lib/ollama/mlx* lib/ollama/include; else tar c lib/ollama/mlx*; fi ) | zstd -9 -T0 >./dist/ollama-linux-amd64-mlx.tar.zst
+        if ls ./dist/lib/ollama/oneapi* >/dev/null 2>&1; then
+            ( cd ./dist/ && tar c lib/ollama/oneapi* ) | zstd -9 -T0 >./dist/ollama-linux-amd64-oneapi.tar.zst
+        fi
 fi
 
 LIMIT=2147483648

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -269,8 +269,96 @@ if [ -f /etc/nv_tegra_release ] ; then
 fi
 
 # Install GPU dependencies on Linux
-if ! available lspci && ! available lshw; then
-    warning "Unable to detect NVIDIA/AMD GPU. Install lspci or lshw to automatically detect and install GPU dependencies."
+#
+# Discrete Intel Arc GPUs are detected from PCI device IDs under
+# /sys/bus/pci/devices (no OS VERSION_ID allowlist). lspci/lshw are only
+# required as fallbacks for NVIDIA/AMD and for older systems without sysfs.
+
+# Return 0 if $1 is a known discrete Intel Arc PCI device ID (0x.... or bare hex).
+# Ranges: Alchemist DG2 (0x4F80-0x4F8F, 0x5600-0x56FF), Battlemage (0xE200-0xE2FF).
+# Explicit IDs include Arc Pro B60 (0xE211) and other shipping B-series cards.
+is_intel_arc_device_id() {
+    local id dec
+    id=$(printf '%s' "$1" | tr 'A-F' 'a-f')
+    id=${id#0x}
+    # Require 4 hex digits
+    case "$id" in
+        [0-9a-f][0-9a-f][0-9a-f][0-9a-f]) ;;
+        *) return 1 ;;
+    esac
+    dec=$(printf '%d' "0x$id" 2>/dev/null) || return 1
+    # Battlemage (Xe2 / BMG): 0xE200-0xE2FF
+    if [ "$dec" -ge 57856 ] && [ "$dec" -le 58111 ]; then
+        return 0
+    fi
+    # Alchemist (Xe-HPG / DG2): 0x5600-0x56FF
+    if [ "$dec" -ge 22016 ] && [ "$dec" -le 22271 ]; then
+        return 0
+    fi
+    # Alchemist early DG2 IDs: 0x4F80-0x4F8F
+    if [ "$dec" -ge 20352 ] && [ "$dec" -le 20367 ]; then
+        return 0
+    fi
+    return 1
+}
+
+# Detect discrete Intel Arc via sysfs PCI enumeration (preferred: no extra tools).
+check_intel_arc_sysfs() {
+    local dev vendor class device
+    [ -d /sys/bus/pci/devices ] || return 1
+    for dev in /sys/bus/pci/devices/*; do
+        [ -r "$dev/vendor" ] || continue
+        vendor=$(cat "$dev/vendor" 2>/dev/null) || continue
+        [ "$vendor" = "0x8086" ] || continue
+        class=$(cat "$dev/class" 2>/dev/null) || continue
+        # VGA-compatible (0x030000) or other display controller (0x038000)
+        case "$class" in
+            0x030000|0x038000) ;;
+            *) continue ;;
+        esac
+        device=$(cat "$dev/device" 2>/dev/null) || continue
+        if is_intel_arc_device_id "$device"; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Fallback: parse lspci -nn for Intel display devices with Arc device IDs.
+check_intel_arc_lspci() {
+    local line id
+    available lspci || return 1
+    # Example: 06:00.0 VGA compatible controller [0300]: Intel ... [8086:e211]
+    # Use a here-doc so the loop is not a pipe subshell (return must exit this function).
+    while IFS= read -r line; do
+        case "$line" in
+            *VGA*|*Display*|*3D*)
+                id=$(printf '%s\n' "$line" | sed -n 's/.*\[8086:\([0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f]\)\].*/\1/p')
+                if [ -n "$id" ] && is_intel_arc_device_id "$id"; then
+                    return 0
+                fi
+                ;;
+        esac
+    done <<EOF
+$(lspci -nn -d '8086:' 2>/dev/null)
+EOF
+    return 1
+}
+
+check_intel_arc() {
+    check_intel_arc_sysfs || check_intel_arc_lspci
+}
+
+# True if an optional download package exists (HEAD succeeds for .tar.zst or .tgz).
+package_available() {
+    local url_base="$1"
+    local filename="$2"
+    curl --fail --silent --head --location "${url_base}/${filename}.tar.zst${VER_PARAM}" >/dev/null 2>&1 \
+        || curl --fail --silent --head --location "${url_base}/${filename}.tgz${VER_PARAM}" >/dev/null 2>&1
+}
+
+if ! available lspci && ! available lshw && ! [ -d /sys/bus/pci/devices ]; then
+    warning "Unable to detect NVIDIA/AMD/Intel GPU. Install lspci or lshw to automatically detect and install GPU dependencies."
     exit 0
 fi
 
@@ -291,22 +379,54 @@ check_gpu() {
     esac
 }
 
+# Optional AMD ROCm package (also used for multi-GPU hosts that already have NVIDIA).
+install_amd_rocm_if_present() {
+    if check_gpu lspci amdgpu || check_gpu lshw amdgpu; then
+        download_and_extract "https://ollama.com/download" "$OLLAMA_INSTALL_DIR" "ollama-linux-${ARCH}-rocm"
+        status "AMD GPU ready."
+        return 0
+    fi
+    return 1
+}
+
+# Intel Arc: detect by PCI device ID (Battlemage/Alchemist), never by OS version.
+# Download the optional oneAPI package when published for this release (same
+# pattern as ROCm). Base install already includes the Vulkan backend.
+install_intel_oneapi_if_present() {
+    if ! check_intel_arc; then
+        return 1
+    fi
+    status "Intel Arc GPU detected."
+    if package_available "https://ollama.com/download" "ollama-linux-${ARCH}-oneapi"; then
+        download_and_extract "https://ollama.com/download" "$OLLAMA_INSTALL_DIR" "ollama-linux-${ARCH}-oneapi"
+        status "Intel GPU (oneAPI) ready."
+    else
+        status "Intel Arc GPU detected. oneAPI package not available for this release; Vulkan backend is included in the base install."
+    fi
+    return 0
+}
+
 if check_gpu nvidia-smi; then
     status "NVIDIA GPU installed."
+    # Multi-GPU: still pull optional AMD/Intel packages when those devices exist.
+    install_amd_rocm_if_present || true
+    install_intel_oneapi_if_present || true
     exit 0
 fi
 
-if ! check_gpu lspci nvidia && ! check_gpu lshw nvidia && ! check_gpu lspci amdgpu && ! check_gpu lshw amdgpu; then
+if install_amd_rocm_if_present; then
     install_success
-    warning "No NVIDIA/AMD GPU detected. Ollama will run in CPU-only mode."
     exit 0
 fi
 
-if check_gpu lspci amdgpu || check_gpu lshw amdgpu; then
-    download_and_extract "https://ollama.com/download" "$OLLAMA_INSTALL_DIR" "ollama-linux-${ARCH}-rocm"
-
+if install_intel_oneapi_if_present; then
     install_success
-    status "AMD GPU ready."
+    exit 0
+fi
+
+if ! check_gpu lspci nvidia && ! check_gpu lshw nvidia; then
+    install_success
+    warning "No NVIDIA/AMD/Intel Arc GPU detected. Ollama will run in CPU-only mode."
     exit 0
 fi
 


### PR DESCRIPTION
## Summary

- Fixes [#15827](https://github.com/ollama/ollama/issues/15827): the Linux installer never detected discrete Intel Arc GPUs, so Intel-only hosts were treated as CPU-only and the optional oneAPI package was never fetched.
- Detects Arc **by PCI device ID** under `/sys/bus/pci/devices` (vendor `0x8086`, class VGA/display), with ranges for Alchemist (`0x4F80–0x4F8F`, `0x5600–0x56FF`) and Battlemage (`0xE200–0xE2FF`, includes **0xE211 Arc Pro B60**). Falls back to `lspci -nn` when sysfs is unavailable.
- **No OS `VERSION_ID` allowlist** for Intel — detection does not depend on Ubuntu release strings.
- Downloads `ollama-linux-${ARCH}-oneapi` when that artifact is published (same optional-package pattern as ROCm). If the package is absent for a given release, the installer still reports the Arc GPU and notes that Vulkan is in the base install.
- Multi-GPU hosts with a working NVIDIA driver still pull AMD/Intel optional packages when those devices are present.
- `build_linux.sh` packages `lib/ollama/oneapi*` into `ollama-linux-amd64-oneapi.tar.zst` when those libs exist in the build tree.
- Documents the Intel path in `docs/linux.mdx`.

## Hardware validation (Arc Pro B60)

On a machine with Battlemage G21 (`8086:e211` at `0000:06:00.0`, `xe` driver):

| Check | Result |
| --- | --- |
| `is_intel_arc_device_id 0xe211` | match |
| sysfs scan | `MATCH slot=0000:06:00.0 device=0xe211` |
| `lspci -nn -d 8086:` | `Intel Corporation Device [8086:e211]` |
| `package_available …-oneapi` | **not published** on current releases (CDN → GitHub asset **404**); ROCm package still available |
| Full install of `libggml-oneapi.so` | **blocked until the oneAPI release artifact is built and published** — installer path is ready and will fetch it automatically once present |

## Note for maintainers

Current official release assets (`v0.31.x`) include base / rocm / mlx / jetpack, but **not** `ollama-linux-amd64-oneapi.tar.zst`. This PR fixes installer detection and the download/package wiring so oneAPI can be opted in the same way as ROCm once CI produces that artifact. Runtime SYCL backend support remains a separate track if not already present in the tree.

## Test plan

- [x] `sh -n` / `dash -n` on `scripts/install.sh`
- [x] PCI ID unit checks: `e211`, `E20B`, `56a0`, `4f80` match; non-Arc IDs rejected
- [x] Live sysfs detection of Arc Pro B60 (`0xe211`)
- [x] Confirm oneAPI package HEAD is soft-skipped when 404; ROCm still available
- [ ] CI / maintainer: when oneAPI libs are in `dist/`, `build_linux.sh` emits `ollama-linux-amd64-oneapi.tar.zst`
- [ ] After oneAPI artifact is published: clean install on Arc-only host → `/usr/local/lib/ollama/oneapi` (or `libggml-oneapi.so`) present and GPU reports non-zero VRAM