### PR TITLE
app: render single-dollar inline LaTeX in chat markdown

### DIFF
--- a/app/ui/app/package.json
+++ b/app/ui/app/package.json
@@ -35,8 +35,10 @@
     "rehype-sanitize": "^6.0.0",
     "remark-math": "^6.0.0",
     "streamdown": "^1.4.0",
+    "unified": "^11.0.5",
     "unist-builder": "^4.0.0",
-    "unist-util-parents": "^3.0.0"
+    "unist-util-parents": "^3.0.0",
+    "unist-util-visit": "^5.1.0"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^4.0.1",
@@ -49,6 +51,7 @@
     "@tailwindcss/typography": "^0.5.16",
     "@tailwindcss/vite": "^4.1.11",
     "@tanstack/router-plugin": "^1.120.20",
+    "@types/mdast": "^4.0.4",
     "@types/node": "^24.7.2",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
@@ -67,11 +70,13 @@
     "react-markdown": "^10.1.0",
     "remark": "^15.0.1",
     "remark-gfm": "^4.0.1",
+    "remark-parse": "^11.0.0",
     "remark-stringify": "^11.0.0",
     "storybook": "^9.0.14",
     "tailwindcss": "^4.1.9",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
+    "vfile": "^6.0.3",
     "vite": "^6.3.5",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.2.4"

--- a/app/ui/app/src/components/StreamingMarkdownContent.test.tsx
+++ b/app/ui/app/src/components/StreamingMarkdownContent.test.tsx
@@ -8,6 +8,7 @@ type MockStreamdownProps = {
     img: React.ComponentType<React.ImgHTMLAttributes<HTMLImageElement>>;
   };
   rehypePlugins?: unknown[];
+  remarkPlugins?: unknown[];
 };
 
 const streamdownMock = vi.hoisted(() =>
@@ -27,6 +28,7 @@ vi.mock("streamdown", () => ({
 }));
 
 import StreamingMarkdownContent from "./StreamingMarkdownContent";
+import remarkSingleDollarMathGuard from "@/utils/remarkSingleDollarMathGuard";
 
 describe("StreamingMarkdownContent", () => {
   beforeEach(() => {
@@ -57,5 +59,24 @@ describe("StreamingMarkdownContent", () => {
     expect(html).not.toContain("<img");
     expect(html).not.toContain("attacker.example");
     expect(html).toContain("secret");
+  });
+
+  it("enables single-dollar math and includes the currency guard, in order", () => {
+    renderToStaticMarkup(<StreamingMarkdownContent content="$x$" />);
+
+    const props = streamdownMock.mock.calls[0][0] as MockStreamdownProps & {
+      remarkPlugins: unknown[];
+    };
+    const plugins = props.remarkPlugins;
+    // gfm (mocked as "gfm"), then [remarkMath, {singleDollarTextMath:true}],
+    // then the guard, then the citation parser.
+    expect(plugins[0]).toBe("gfm");
+    expect(Array.isArray(plugins[1])).toBe(true);
+    expect(
+      (plugins[1] as [unknown, { singleDollarTextMath?: boolean }])[1],
+    ).toEqual({
+      singleDollarTextMath: true,
+    });
+    expect(plugins[2]).toBe(remarkSingleDollarMathGuard);
   });
 });

--- a/app/ui/app/src/components/StreamingMarkdownContent.tsx
+++ b/app/ui/app/src/components/StreamingMarkdownContent.tsx
@@ -4,6 +4,9 @@ import {
   defaultRehypePlugins,
   defaultRemarkPlugins,
 } from "streamdown";
+import type { Pluggable } from "unified";
+import remarkMath from "remark-math";
+import remarkSingleDollarMathGuard from "@/utils/remarkSingleDollarMathGuard";
 import remarkCitationParser from "@/utils/remarkCitationParser";
 import CopyButton from "./CopyButton";
 import type { BundledLanguage } from "shiki";
@@ -132,11 +135,13 @@ const CodeBlock = React.memo(
 
 const StreamingMarkdownContent: React.FC<StreamingMarkdownContentProps> =
   React.memo(({ content, isStreaming = false, size, browserToolResult }) => {
-    // Build the remark plugins array - keep default GFM and Math, add citations
-    const remarkPlugins = React.useMemo(() => {
+    // Build the remark plugins array - keep default GFM, enable single-dollar
+    // math (guarded against currency text), add citations
+    const remarkPlugins = React.useMemo<Pluggable[]>(() => {
       return [
         defaultRemarkPlugins.gfm,
-        defaultRemarkPlugins.math,
+        [remarkMath, { singleDollarTextMath: true }],
+        remarkSingleDollarMathGuard,
         remarkCitationParser,
       ];
     }, []);

--- a/app/ui/app/src/utils/remarkSingleDollarMathGuard.test.ts
+++ b/app/ui/app/src/utils/remarkSingleDollarMathGuard.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from "vitest";
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
+import { VFile } from "vfile";
+import { visit } from "unist-util-visit";
+import type { Root } from "mdast";
+import remarkSingleDollarMathGuard from "./remarkSingleDollarMathGuard";
+
+// Runs the same mdast pipeline StreamingMarkdownContent configures, minus the
+// citation parser (not relevant to this guard), and returns every node type
+// plus its rendered text so tests can assert both what got parsed as math and
+// what the reader would actually see.
+function parse(markdown: string) {
+  const processor = unified()
+    .use(remarkParse)
+    .use(remarkGfm)
+    .use(remarkMath, { singleDollarTextMath: true })
+    .use(remarkSingleDollarMathGuard);
+  const file = new VFile({ value: markdown });
+  const tree = processor.runSync(processor.parse(file), file) as Root;
+
+  const nodes: { type: string; value?: string }[] = [];
+  visit(tree, (node) => {
+    const value = (node as { value?: string }).value;
+    nodes.push({ type: node.type, value });
+  });
+
+  const text = nodes
+    .filter((n) => typeof n.value === "string")
+    .map((n) => n.value)
+    .join("");
+
+  return { nodes, text };
+}
+
+function inlineMathValues(markdown: string): string[] {
+  return parse(markdown)
+    .nodes.filter((n) => n.type === "inlineMath")
+    .map((n) => n.value ?? "");
+}
+
+describe("remarkSingleDollarMathGuard", () => {
+  it("keeps a single-dollar TeX span (issue #15310)", () => {
+    const values = inlineMathValues(
+      "$C \\rightarrow S \\rightarrow L \\rightarrow P \\rightarrow A$",
+    );
+    expect(values).toEqual([
+      "C \\rightarrow S \\rightarrow L \\rightarrow P \\rightarrow A",
+    ]);
+  });
+
+  it("keeps a short single-dollar TeX span (issue #17074)", () => {
+    expect(inlineMathValues("$\\rightarrow$")).toEqual(["\\rightarrow"]);
+  });
+
+  it("keeps two separate single-dollar spans on one line", () => {
+    expect(inlineMathValues("Both $a$ and $b$ are vars.")).toEqual(["a", "b"]);
+  });
+
+  it("never touches double-dollar math", () => {
+    // A single-line "$$...$$" isn't a math fence (that needs its own line),
+    // so remark-math still parses it as inlineMath. The guard must recognize
+    // the doubled delimiter and leave it alone rather than demoting it.
+    expect(inlineMathValues("$$e^{i\\pi} + 1 = 0$$")).toEqual([
+      "e^{i\\pi} + 1 = 0",
+    ]);
+  });
+
+  it("demotes currency mentioned twice on one line", () => {
+    const { nodes, text } = parse("It costs $5 and $10 in total.");
+    expect(nodes.some((n) => n.type === "inlineMath")).toBe(false);
+    expect(text).toContain("It costs $5 and $10 in total.");
+  });
+
+  it("demotes currency repeated across sentences", () => {
+    const { nodes, text } = parse("He paid $50. She paid $30. Total was $80.");
+    expect(nodes.some((n) => n.type === "inlineMath")).toBe(false);
+    expect(text).toContain("He paid $50. She paid $30. Total was $80.");
+  });
+
+  it("demotes comma-grouped currency ranges", () => {
+    const { nodes, text } = parse("between $1,500 and $2,000 per month");
+    expect(nodes.some((n) => n.type === "inlineMath")).toBe(false);
+    expect(text).toContain("between $1,500 and $2,000 per month");
+  });
+
+  it("demotes postfix currency notation", () => {
+    const { nodes, text } = parse("He paid 5 $ and 10 $ in total");
+    expect(nodes.some((n) => n.type === "inlineMath")).toBe(false);
+    expect(text).toContain("5 $ and 10 $");
+  });
+
+  it("demotes parenthesized currency", () => {
+    const { nodes, text } = parse("Prices are ($5) and ($10) respectively.");
+    expect(nodes.some((n) => n.type === "inlineMath")).toBe(false);
+    expect(text).toContain("($5) and ($10)");
+  });
+
+  it("demotes word characters butting the delimiters", () => {
+    const { nodes, text } = parse("BEWARE OF $HA$TA BEA$T$");
+    expect(nodes.some((n) => n.type === "inlineMath")).toBe(false);
+    expect(text).toContain("$HA$TA BEA$T$");
+  });
+
+  it("demotes a span padded with whitespace inside the delimiters", () => {
+    const { nodes, text } = parse("padded $ x^2 $ here");
+    expect(nodes.some((n) => n.type === "inlineMath")).toBe(false);
+    expect(text).toContain("$ x^2 $");
+  });
+
+  it("leaves escaped dollars as literal text", () => {
+    const { nodes, text } = parse("Escaped: \\$5 and \\$10 stay text");
+    expect(nodes.some((n) => n.type === "inlineMath")).toBe(false);
+    expect(text).toContain("$5 and $10 stay text");
+  });
+
+  it("demotes a span flanked by CJK characters", () => {
+    const { nodes, text } = parse("预算是$充足$的");
+    expect(nodes.some((n) => n.type === "inlineMath")).toBe(false);
+    expect(text).toContain("预算是$充足$的");
+  });
+
+  it("demotes a span whose closing delimiter butts an accented letter", () => {
+    const { nodes, text } = parse("This is $x$é");
+    expect(nodes.some((n) => n.type === "inlineMath")).toBe(false);
+    expect(text).toContain("$x$é");
+  });
+
+  // Known limitation: when a currency "$" precedes real math on the SAME line,
+  // remark-math pairs the currency dollar with the math opener, so the span is
+  // demoted wholesale and the trailing math is not rendered. This must at least
+  // degrade safely - visible text is preserved and no currency leaks as math.
+  it("degrades safely when currency precedes real math on one line", () => {
+    const { nodes, text } = parse("Cost $5. Formula $x$ works.");
+    expect(nodes.some((n) => n.type === "inlineMath")).toBe(false);
+    expect(text).toContain("Cost $5. Formula $x$ works.");
+  });
+
+  it("keeps real math that appears before a currency amount", () => {
+    const { nodes } = parse("Formula $x$ then it costs $5 total.");
+    const math = nodes
+      .filter((n) => n.type === "inlineMath")
+      .map((n) => n.value);
+    expect(math).toEqual(["x"]);
+  });
+});

--- a/app/ui/app/src/utils/remarkSingleDollarMathGuard.ts
+++ b/app/ui/app/src/utils/remarkSingleDollarMathGuard.ts
@@ -1,0 +1,37 @@
+import { visit } from "unist-util-visit";
+import type { Root, Text } from "mdast";
+
+// remark-math's `singleDollarTextMath` treats any `$...$` span as math, which
+// turns currency like "$5 and $10" into a formula. Demote a single-dollar
+// span back to literal text unless it plausibly is TeX: the content must not
+// start or end with whitespace, and the delimiters must not butt against
+// word characters outside the span.
+export default function remarkSingleDollarMathGuard() {
+  return (tree: Root, file: { value?: unknown }) => {
+    const source = String(file.value ?? "");
+    visit(tree, "inlineMath", (node, index, parent) => {
+      if (!parent || index === undefined) return;
+      const start = node.position?.start.offset;
+      const end = node.position?.end.offset;
+      if (start == null || end == null) return;
+      const raw = source.slice(start, end);
+      // Only guard single-dollar spans; `$$...$$` is always intentional math.
+      if (!raw.startsWith("$") || raw.startsWith("$$")) return;
+      // Pandoc's tex_math_dollars rules: the opening $ must be immediately
+      // followed by a non-space, the closing $ immediately preceded by one,
+      // and the delimiters must not butt against word characters outside.
+      // The outer-boundary check is Unicode-aware (letters/numbers in any
+      // script, not just ASCII), so spans abutting CJK, accented Latin,
+      // Cyrillic, Greek, or other non-ASCII word characters are also demoted.
+      const looksLikeMath =
+        raw.length >= 3 &&
+        !/\s/.test(raw[1]) &&
+        !/\s/.test(raw[raw.length - 2]) &&
+        !/[\p{L}\p{N}_$]/u.test(source[start - 1] ?? "") &&
+        !/[\p{L}\p{N}_$]/u.test(source[end] ?? "");
+      if (looksLikeMath) return;
+      const replacement: Text = { type: "text", value: raw };
+      parent.children[index] = replacement;
+    });
+  };
+}


### PR DESCRIPTION
### What this does

The desktop app renders single-dollar inline LaTeX (`$C \rightarrow S$`) as raw source text instead of math. Double-dollar (`$$...$$`) and `\(...\)` already render, but the far more common single-`$` form does not, so model output with inline math is unreadable in chat.

Fixes #15310
Fixes #17074

### Root cause

The chat renderer passes Streamdown's `defaultRemarkPlugins.math`, which is configured with `singleDollarTextMath: false` — so single-`$` spans are never tokenized as math. The app already aliases `micromark-extension-math` → `micromark-extension-llm-math` in `vite.config.ts`, but that alias can't help while the flag rejects single-`$` at the tokenizer.

Simply flipping the flag to `true` is not safe: it turns ordinary currency like `It costs $5 and $10` into a garbled formula. That is exactly why Streamdown ships the flag off. So this PR enables single-`$` math **and** adds a small guard that demotes any single-`$` span that doesn't look like TeX back to literal text, following Pandoc's well-known `tex_math_dollars` rules (no whitespace immediately inside the delimiters; the delimiters must not butt against letters, digits, or another `$`).

The guard only ever inspects already-parsed `inlineMath` nodes, so it never touches `$` inside code spans/blocks, and `$$...$$` is left untouched.

### Behavior (before → after)

Rendered through the real Streamdown pipeline (`renderToStaticMarkup`) with the production vite alias active:

| Input | main | this PR |
|---|---|---|
| `$C \rightarrow S \rightarrow L \rightarrow P \rightarrow A$` | raw text | **math** |
| `$\rightarrow$` | raw text | **math** |
| `It costs $5 and $10 in total.` | literal | literal (unchanged) |
| `between $1,500 and $2,000 per month` | literal | literal (unchanged) |
| `BEWARE OF $HA$TA BEA$T$` | literal | literal (unchanged) |
| `预算是$充足$的` (CJK) | literal | literal (unchanged) |
| `$$e^{i\pi} + 1 = 0$$` | math | math (unchanged) |

### Known limitation

When a **currency amount precedes real math on the same line** — e.g. `Cost $5. Formula $x$ works.` — `remark-math` greedily pairs the currency `$` with the math opener, so the span is demoted wholesale and `$x$` is not rendered as math. This degrades safely: the visible text is preserved verbatim and no currency ever leaks as a formula, so it is **no worse than current behavior** (where single-`$` math never renders at all). Fully resolving it would require a tokenizer-level rewrite that can't distinguish currency from math without also risking `$` inside code, which is out of scope for this fix. Both orderings are covered by tests, and the reverse ordering (math before currency) renders correctly.

### Tests

- `remarkSingleDollarMathGuard.test.ts` — 16 unit tests over the real mdast pipeline: both issue repros, multiple spans per line, `$$` non-interference, currency/decorative/postfix/parenthesized/escaped cases, CJK and accented-Latin boundaries, and safe degradation for the mixed currency-then-math case.
- `StreamingMarkdownContent.test.tsx` — a wiring test asserting the component enables `singleDollarTextMath: true` and includes the guard in the correct plugin order.

Full app UI suite: 44 passing. `tsc`, `eslint`, and `prettier` are clean on the changed files.

### Credit

Thanks to @deckar01 for diagnosing this in #15310 and prototyping a single-`$` approach in their fork; this PR takes a smaller post-parse-guard route.
