### PR TITLE
docs: allow numeric keep_alive in openapi embed schema

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -444,8 +444,10 @@ components:
           type: integer
           description: Number of dimensions to generate embeddings for
         keep_alive:
-          type: string
-          description: Model keep-alive duration
+          oneOf:
+            - type: string
+            - type: number
+          description: Model keep-alive duration (for example `5m` or `0` to unload immediately)
         options:
           $ref: "#/components/schemas/ModelOptions"
     EmbedResponse:


### PR DESCRIPTION

The `EmbedRequest` schema in `docs/openapi.yaml` declares `keep_alive` as
`type: string` only, but the `/api/embed` endpoint accepts a string *or* a
number. On the server, `keep_alive` maps to `EmbedRequest.KeepAlive`, an
`api.Duration` (`api/types.go`), whose `UnmarshalJSON` parses both:

- a JSON string, treated as a Go duration such as `"5m"`, and
- a JSON number, treated as seconds (for example `300`; `0` unloads immediately,
  a negative value keeps the model loaded indefinitely).

`GenerateRequest` and `ChatRequest` already document `keep_alive` correctly as
`oneOf: [ {type: string}, {type: number} ]`, so the `EmbedRequest` schema was
internally inconsistent with its two siblings and with the code. A client
generated from the spec (openapi-generator and similar) would type embed's
`keep_alive` as string-only and reject a numeric value that `/api/embed`
actually accepts, even though the same numeric value works on `/api/generate`
and `/api/chat`.

This change mirrors the existing `oneOf` from `GenerateRequest`/`ChatRequest`
onto `EmbedRequest` (and adopts their fuller description), so the three request
schemas describe `keep_alive` identically and the spec matches the server.

### Diff

```diff
         keep_alive:
-          type: string
-          description: Model keep-alive duration
+          oneOf:
+            - type: string
+            - type: number
+          description: Model keep-alive duration (for example `5m` or `0` to unload immediately)
```

### Testing

Docs/spec-only change; no Go code is affected. Verified that `docs/openapi.yaml`
still parses as a valid OpenAPI 3.1 document and that the `keep_alive` blocks on
`GenerateRequest`, `ChatRequest`, and `EmbedRequest` are now identical. The
change only widens the documented type (adds `number` alongside `string`), so it
is backwards compatible and does not invalidate any existing client.
