### PR TITLE
parser: report both expected and detected content type on mismatch

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -326,7 +326,7 @@ func filesForModel(path string) ([]string, error) {
 			if ct, err := detectContentType(match); err != nil {
 				return nil, err
 			} else if len(contentType) > 0 && ct != contentType {
-				return nil, fmt.Errorf("invalid content type: expected %s for %s", ct, match)
+				return nil, fmt.Errorf("invalid content type: expected %s but got %s for %s", contentType, ct, match)
 			}
 		}
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -927,6 +927,7 @@ func TestFilesForModel(t *testing.T) {
 		wantFiles     []string
 		wantErr       bool
 		expectErrType error
+		expectErrMsg  string
 	}{
 		{
 			name: "safetensors model files",
@@ -1194,6 +1195,25 @@ func TestFilesForModel(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "invalid content type reports expected and detected types",
+			setup: func(dir string) error {
+				// Binary content is detected as application/octet-stream (a valid gguf).
+				binaryContent := make([]byte, 512)
+				for i := range binaryContent {
+					binaryContent[i] = byte(i % 256)
+				}
+				if err := os.WriteFile(filepath.Join(dir, "model.gguf"), binaryContent, 0o644); err != nil {
+					return err
+				}
+				// A config.json that is actually binary (e.g. an unresolved git lfs
+				// pointer or a mislabeled file) is detected as application/octet-stream,
+				// not the expected text/plain, so the *.json glob rejects it.
+				return os.WriteFile(filepath.Join(dir, "config.json"), binaryContent, 0o644)
+			},
+			wantErr:      true,
+			expectErrMsg: "invalid content type: expected text/plain but got application/octet-stream for ",
+		},
 	}
 
 	tmpDir := t.TempDir()
@@ -1217,6 +1237,9 @@ func TestFilesForModel(t *testing.T) {
 				}
 				if tt.expectErrType != nil && err != tt.expectErrType {
 					t.Errorf("Expected error type %v, got %v", tt.expectErrType, err)
+				}
+				if tt.expectErrMsg != "" && (err == nil || !strings.Contains(err.Error(), tt.expectErrMsg)) {
+					t.Errorf("Expected error message to contain %q, got %v", tt.expectErrMsg, err)
 				}
 				return
 			}


### PR DESCRIPTION

### What

When importing a model directory, `filesForModel` validates each matched file's
content type. On a mismatch it returned:

```
invalid content type: expected <detected> for <file>
```

The detected type was interpolated after the word "expected", and the type that
was actually required was never printed. The message was therefore backwards and
omitted the expected value entirely.

For example, a `config.json` that is an unresolved git lfs pointer (or otherwise
binary) is detected as `application/octet-stream`. The `*.json` glob requires
`text/plain`, so the import fails, but the user sees:

```
invalid content type: expected application/octet-stream for .../config.json
```

which claims the detected type was the expected one and hides that `text/plain`
was required.

### Change

Report both types with the roles in the correct order:

```
invalid content type: expected <wanted> but got <detected> for <file>
```

This is a one-line fix to the single `fmt.Errorf` in the `glob` helper inside
`filesForModel` (`parser/parser.go`). The error is reachable during
`ollama create`: the `*.json` config glob passes a non-empty expected type
(`text/plain`) and propagates the error to the caller.

### Tests

Adds a table-driven regression case to `TestFilesForModel` that writes a valid
gguf plus a binary `config.json` (detected as `application/octet-stream`),
triggering the propagated error via the `*.json` glob, and asserts the message
now contains both the expected and detected types. Verified red -> green by
reverting the one-line fix (the old message asserts `expected
application/octet-stream`, hiding `text/plain`).

Checks run locally (`parser` package):

```
gofmt -l parser/parser.go parser/parser_test.go   # clean
go vet ./parser/                                   # clean
go build ./parser/...                              # ok
go test ./parser/ -count=1                         # ok
go test ./parser/ -race -count=1                   # ok
```

No new dependencies. No API or behavioral change beyond the corrected wording of
this diagnostic; the function is package-private and the string is not part of
any public contract.
