### PR TITLE
feat: separate Cloud Models and Web Search toggles

### DIFF
--- a/app/tools/cloud_policy.go
+++ b/app/tools/cloud_policy.go
@@ -11,10 +11,11 @@ import (
 )
 
 // ensureCloudEnabledForTool checks cloud policy from the connected Ollama server.
+// It only blocks when cloud is disabled via the OLLAMA_NO_CLOUD environment variable
+// (source "env" or "both"), allowing web search/fetch to work when cloud is disabled
+// via the user-facing toggle alone (source "config").
 // If policy cannot be determined, this fails closed and blocks the operation.
 func ensureCloudEnabledForTool(ctx context.Context, operation string) error {
-	// Reuse shared message formatting; policy evaluation is still done via
-	// the connected server's /api/status endpoint below.
 	disabledMessage := internalcloud.DisabledError(operation)
 
 	client, err := api.ClientFromEnvironment()
@@ -27,7 +28,7 @@ func ensureCloudEnabledForTool(ctx context.Context, operation string) error {
 		return errors.New(disabledMessage + " (unable to verify server cloud policy)")
 	}
 
-	if status.Cloud.Disabled {
+	if status.Cloud.Disabled && (status.Cloud.Source == "env" || status.Cloud.Source == "both") {
 		return errors.New(disabledMessage)
 	}
 

--- a/app/tools/cloud_policy_test.go
+++ b/app/tools/cloud_policy_test.go
@@ -31,7 +31,49 @@ func TestEnsureCloudEnabledForTool(t *testing.T) {
 		}
 	})
 
-	t.Run("disabled blocks tool execution", func(t *testing.T) {
+	t.Run("disabled via env blocks tool execution", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/api/status" {
+				http.NotFound(w, r)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"cloud":{"disabled":true,"source":"env"}}`))
+		}))
+		t.Cleanup(ts.Close)
+		t.Setenv("OLLAMA_HOST", ts.URL)
+
+		err := ensureCloudEnabledForTool(context.Background(), op)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if got := err.Error(); got != disabledPrefix {
+			t.Fatalf("unexpected error: %q", got)
+		}
+	})
+
+	t.Run("disabled via both blocks tool execution", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/api/status" {
+				http.NotFound(w, r)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"cloud":{"disabled":true,"source":"both"}}`))
+		}))
+		t.Cleanup(ts.Close)
+		t.Setenv("OLLAMA_HOST", ts.URL)
+
+		err := ensureCloudEnabledForTool(context.Background(), op)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if got := err.Error(); got != disabledPrefix {
+			t.Fatalf("unexpected error: %q", got)
+		}
+	})
+
+	t.Run("disabled via config allows tool execution", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.URL.Path != "/api/status" {
 				http.NotFound(w, r)
@@ -43,12 +85,8 @@ func TestEnsureCloudEnabledForTool(t *testing.T) {
 		t.Cleanup(ts.Close)
 		t.Setenv("OLLAMA_HOST", ts.URL)
 
-		err := ensureCloudEnabledForTool(context.Background(), op)
-		if err == nil {
-			t.Fatal("expected error, got nil")
-		}
-		if got := err.Error(); got != disabledPrefix {
-			t.Fatalf("unexpected error: %q", got)
+		if err := ensureCloudEnabledForTool(context.Background(), op); err != nil {
+			t.Fatalf("expected nil error, got %v", err)
 		}
 	})
 

--- a/app/ui/app/src/components/ChatForm.tsx
+++ b/app/ui/app/src/components/ChatForm.tsx
@@ -179,12 +179,6 @@ function ChatForm({
     setSettings,
   ]);
 
-  useEffect(() => {
-    if (cloudDisabled && webSearchEnabled) {
-      setSettings({ WebSearchEnabled: false });
-    }
-  }, [cloudDisabled, webSearchEnabled, setSettings]);
-
   const removeFile = (index: number) => {
     setMessage((prev) => ({
       ...prev,
@@ -239,19 +233,18 @@ function ChatForm({
 
   // Determine if login banner should be shown
   const shouldShowLoginBanner =
-    !cloudDisabled &&
     !isLoadingUser &&
     !isAuthenticated &&
-    ((webSearchEnabled && supportsWebSearch) || selectedModel?.isCloud());
+    ((!cloudDisabled && selectedModel?.isCloud()) ||
+      (webSearchEnabled && supportsWebSearch));
 
   // Determine which feature to highlight in the banner
   const getActiveFeatureForBanner = () => {
-    if (cloudDisabled) return null;
     if (!isAuthenticated) {
       if (loginPromptFeature) return loginPromptFeature;
       if (webSearchEnabled && selectedModel?.isCloud()) return "webSearch";
       if (webSearchEnabled) return "webSearch";
-      if (selectedModel?.isCloud()) return "turbo";
+      if (!cloudDisabled && selectedModel?.isCloud()) return "turbo";
     }
     return null;
   };
@@ -274,8 +267,7 @@ function ChatForm({
   useEffect(() => {
     if (
       isAuthenticated ||
-      cloudDisabled ||
-      (!webSearchEnabled && !!selectedModel?.isCloud())
+      (!webSearchEnabled && (cloudDisabled || !selectedModel?.isCloud()))
     ) {
       setLoginPromptFeature(null);
     }
@@ -490,8 +482,7 @@ function ChatForm({
         data: att.data || new Uint8Array(0), // Empty data for existing files
       }));
 
-    const useWebSearch =
-      supportsWebSearch && webSearchEnabled && !cloudDisabled;
+    const useWebSearch = supportsWebSearch && webSearchEnabled;
     const useThink = modelSupportsThinkingLevels
       ? thinkLevel
       : supportsThinkToggling
@@ -927,7 +918,7 @@ function ChatForm({
                 )}
                 <WebSearchButton
                   ref={webSearchButtonRef}
-                  isVisible={supportsWebSearch && cloudDisabled === false}
+                  isVisible={supportsWebSearch}
                   isActive={webSearchEnabled}
                   onToggle={() => {
                     if (!webSearchEnabled && !isAuthenticated) {

--- a/app/ui/app/src/components/Settings.tsx
+++ b/app/ui/app/src/components/Settings.tsx
@@ -455,13 +455,16 @@ export default function Settings() {
                     <div>
                       <Label>Web Search</Label>
                       <Description>
-                        Enable web search for supported models.
+                        {cloudOverriddenByEnv
+                          ? "The OLLAMA_NO_CLOUD environment variable is currently forcing cloud off."
+                          : "Enable web search for supported models."}
                       </Description>
                     </div>
                   </div>
                   <div className="flex-shrink-0">
                     <Switch
                       checked={settings.WebSearchEnabled}
+                      disabled={cloudOverriddenByEnv}
                       onChange={(checked) =>
                         handleChange("WebSearchEnabled", checked)
                       }

--- a/app/ui/app/src/components/Settings.tsx
+++ b/app/ui/app/src/components/Settings.tsx
@@ -12,6 +12,7 @@ import {
   BoltIcon,
   WrenchIcon,
   CloudIcon,
+  MagnifyingGlassIcon,
   XMarkIcon,
   CogIcon,
   ArrowLeftIcon,
@@ -423,11 +424,11 @@ export default function Settings() {
                   <div className="flex items-start space-x-3 flex-1">
                     <CloudIcon className="mt-1 h-5 w-5 flex-shrink-0 text-black dark:text-neutral-100" />
                     <div>
-                      <Label>Cloud</Label>
+                      <Label>Cloud Models</Label>
                       <Description>
                         {cloudOverriddenByEnv
                           ? "The OLLAMA_NO_CLOUD environment variable is currently forcing cloud off."
-                          : "Enable cloud models and web search."}
+                          : "Enable cloud-hosted models."}
                       </Description>
                     </div>
                   </div>
@@ -441,6 +442,29 @@ export default function Settings() {
                         }
                         updateCloudMutation.mutate(checked);
                       }}
+                    />
+                  </div>
+                </div>
+              </Field>
+
+              {/* Web Search */}
+              <Field>
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex items-start space-x-3 flex-1">
+                    <MagnifyingGlassIcon className="mt-1 h-5 w-5 flex-shrink-0 text-black dark:text-neutral-100" />
+                    <div>
+                      <Label>Web Search</Label>
+                      <Description>
+                        Enable web search for supported models.
+                      </Description>
+                    </div>
+                  </div>
+                  <div className="flex-shrink-0">
+                    <Switch
+                      checked={settings.WebSearchEnabled}
+                      onChange={(checked) =>
+                        handleChange("WebSearchEnabled", checked)
+                      }
                     />
                   </div>
                 </div>


### PR DESCRIPTION
Fixes #17094.

Split the combined toggle into independent Cloud Models and Web Search controls:

Front-end: decoupled shouldShowLoginBanner, getActiveFeatureForBanner, useWebSearch, and WebSearchButton visibility from cloudDisabled. Added separate Web Search toggle in Settings.

Back-end: narrowed ensureCloudEnabledForTool to only block on env/both sources, so disabling cloud via the user toggle doesn't silently reject web search calls.

Web Search toggle mirrors Cloud Models behavior when OLLAMA_NO_CLOUD is set (disabled with explanation).