### PR TITLE
fix: replace fork/exec with posix_spawn on macOS to prevent atfork handler hang

### DIFF
--- a/internal/posixspawn/posix_spawn_darwin.go
+++ b/internal/posixspawn/posix_spawn_darwin.go
@@ -1,0 +1,174 @@
+//go:build darwin
+
+// Package posixspawn provides a posix_spawnp-based replacement for
+// exec.Cmd.Start on macOS to work around atfork-handler hangs.
+//
+// On macOS, fork() in a process that has loaded libmlx.dylib or initialized
+// Metal/Network.framework can dead-loop inside the atfork child handlers
+// (nw_settings_child_has_forked -> _os_log_preferences_refresh).
+// posix_spawnp bypasses atfork handlers entirely.
+//
+// See: https://github.com/ollama/ollama/issues/17057
+package posixspawn
+
+/*
+#include <errno.h>
+#include <spawn.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+static int ollamaPosixSpawnp(pid_t *pid, const char *file,
+                             char *const argv[], char *const envp[],
+                             int outfd, int errfd) {
+	posix_spawn_file_actions_t actions;
+	posix_spawnattr_t attr;
+	int ret;
+
+	posix_spawn_file_actions_init(&actions);
+	posix_spawnattr_init(&attr);
+
+	// Queue all dup2 operations first — a close before a dup2 would destroy
+	// the source fd needed for a subsequent dup2 (combined-pipe case).
+	if (outfd >= 0) {
+		posix_spawn_file_actions_adddup2(&actions, outfd, STDOUT_FILENO);
+	}
+	if (errfd >= 0 && errfd != outfd) {
+		posix_spawn_file_actions_adddup2(&actions, errfd, STDERR_FILENO);
+	} else if (outfd >= 0) {
+		posix_spawn_file_actions_adddup2(&actions, outfd, STDERR_FILENO);
+	}
+
+	// Now close the original fds — they have already been dup'd above.
+	if (outfd >= 0) {
+		posix_spawn_file_actions_addclose(&actions, outfd);
+	}
+	if (errfd >= 0 && errfd != outfd) {
+		posix_spawn_file_actions_addclose(&actions, errfd);
+	}
+
+	posix_spawnattr_setflags(&attr, POSIX_SPAWN_SETPGROUP);
+	posix_spawnattr_setpgroup(&attr, 0);
+
+	ret = posix_spawnp(pid, file, &actions, &attr, argv, envp);
+
+	posix_spawn_file_actions_destroy(&actions);
+	posix_spawnattr_destroy(&attr);
+
+	return ret;
+}
+*/
+import "C"
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"syscall"
+	"unsafe"
+)
+
+// StartCmd spawns cmd using posix_spawnp instead of fork/exec.
+//
+// It handles pipe creation for cmd.Stdout and cmd.Stderr, launches the
+// child via posix_spawnp, and starts goroutines that copy from the pipe
+// read ends to the cmd output writers.
+func StartCmd(cmd *exec.Cmd) error {
+	cArgv := make([]*C.char, len(cmd.Args)+1)
+	for i, s := range cmd.Args {
+		cArgv[i] = C.CString(s)
+	}
+	cArgv[len(cmd.Args)] = nil
+	defer func() {
+		for i := range len(cmd.Args) {
+			C.free(unsafe.Pointer(cArgv[i]))
+		}
+	}()
+
+	cEnvp := make([]*C.char, len(cmd.Env)+1)
+	for i, s := range cmd.Env {
+		cEnvp[i] = C.CString(s)
+	}
+	cEnvp[len(cmd.Env)] = nil
+	defer func() {
+		for i := range len(cmd.Env) {
+			C.free(unsafe.Pointer(cEnvp[i]))
+		}
+	}()
+
+	var (
+		outRead, outWrite *os.File
+		errRead, errWrite *os.File
+		pipeErr           error
+		combined          bool
+	)
+	if cmd.Stdout != nil {
+		outRead, outWrite, pipeErr = os.Pipe()
+		if pipeErr != nil {
+			return fmt.Errorf("stdout pipe: %w", pipeErr)
+		}
+	}
+
+	if cmd.Stderr != nil {
+		if cmd.Stderr == cmd.Stdout {
+			errRead, errWrite = outRead, outWrite
+			combined = true
+		} else {
+			errRead, errWrite, pipeErr = os.Pipe()
+			if pipeErr != nil {
+				if outRead != nil {
+					outRead.Close()
+					outWrite.Close()
+				}
+				return fmt.Errorf("stderr pipe: %w", pipeErr)
+			}
+		}
+	}
+
+	outFd := C.int(-1)
+	errFd := C.int(-1)
+	if outWrite != nil {
+		outFd = C.int(outWrite.Fd())
+	}
+	if errWrite != nil && errWrite != outWrite {
+		errFd = C.int(errWrite.Fd())
+	}
+
+	var pid C.pid_t
+	ret := C.ollamaPosixSpawnp(&pid, cArgv[0], &cArgv[0], &cEnvp[0], outFd, errFd)
+	if ret != 0 {
+		if outRead != nil {
+			outRead.Close()
+			outWrite.Close()
+		}
+		if errRead != nil && errRead != outRead {
+			errRead.Close()
+			errWrite.Close()
+		}
+		return fmt.Errorf("posix_spawnp: %w", syscall.Errno(ret))
+	}
+
+	if outWrite != nil {
+		outWrite.Close()
+	}
+	if errWrite != nil && errWrite != outWrite {
+		errWrite.Close()
+	}
+
+	cmd.Process, _ = os.FindProcess(int(pid))
+
+	if outRead != nil && cmd.Stdout != nil {
+		go func() {
+			io.Copy(cmd.Stdout, outRead)
+			outRead.Close()
+		}()
+	}
+	if errRead != nil && errRead != outRead && cmd.Stderr != nil {
+		go func() {
+			io.Copy(cmd.Stderr, errRead)
+			errRead.Close()
+		}()
+	}
+
+	return nil
+}

--- a/internal/posixspawn/posix_spawn_default.go
+++ b/internal/posixspawn/posix_spawn_default.go
@@ -1,0 +1,10 @@
+//go:build !darwin
+
+package posixspawn
+
+import "os/exec"
+
+// StartCmd calls cmd.Start() on non-macOS platforms.
+func StartCmd(cmd *exec.Cmd) error {
+	return cmd.Start()
+}

--- a/x/imagegen/server.go
+++ b/x/imagegen/server.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ollama/ollama/envconfig"
 	"github.com/ollama/ollama/format"
+	"github.com/ollama/ollama/internal/posixspawn"
 	"github.com/ollama/ollama/llm"
 	"github.com/ollama/ollama/ml"
 	"github.com/ollama/ollama/x/imagegen/manifest"
@@ -119,17 +120,20 @@ func (s *Server) Load(ctx context.Context, _ ml.SystemInfo, gpus []ml.DeviceInfo
 
 	s.cmd = cmd
 
-	// Forward subprocess stdout/stderr to server logs
-	stdout, _ := cmd.StdoutPipe()
-	stderr, _ := cmd.StderrPipe()
+	// Use io.Pipe so that posixspawn.StartCmd (which copies child output to
+	// cmd.Stdout / cmd.Stderr) feeds our line-scanner goroutines.
+	outR, outW := io.Pipe()
+	cmd.Stdout = outW
 	go func() {
-		scanner := bufio.NewScanner(stdout)
+		scanner := bufio.NewScanner(outR)
 		for scanner.Scan() {
 			slog.Info("mlx-runner", "msg", scanner.Text())
 		}
 	}()
+	errR, errW := io.Pipe()
+	cmd.Stderr = errW
 	go func() {
-		scanner := bufio.NewScanner(stderr)
+		scanner := bufio.NewScanner(errR)
 		for scanner.Scan() {
 			line := scanner.Text()
 			slog.Warn("mlx-runner", "msg", line)
@@ -140,13 +144,16 @@ func (s *Server) Load(ctx context.Context, _ ml.SystemInfo, gpus []ml.DeviceInfo
 	}()
 
 	slog.Info("starting mlx runner subprocess", "model", s.modelName, "port", s.port)
-	if err := cmd.Start(); err != nil {
+	if err := posixspawn.StartCmd(cmd); err != nil {
 		return nil, fmt.Errorf("failed to start mlx runner: %w", err)
 	}
 
-	// Reap subprocess when it exits
+	// Reap subprocess when it exits.
 	go func() {
 		err := cmd.Wait()
+		// Close the io.Pipe writers so the scanner goroutines see EOF.
+		outW.Close()
+		errW.Close()
 		s.done <- err
 	}()
 

--- a/x/mlxrunner/client.go
+++ b/x/mlxrunner/client.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/envconfig"
 	"github.com/ollama/ollama/format"
+	"github.com/ollama/ollama/internal/posixspawn"
 	"github.com/ollama/ollama/llm"
 	"github.com/ollama/ollama/ml"
 	"github.com/ollama/ollama/x/imagegen"
@@ -374,7 +375,7 @@ func (c *Client) Load(ctx context.Context, _ ml.SystemInfo, gpus []ml.DeviceInfo
 	cmd.Stderr = status
 
 	slog.Info("starting mlx runner subprocess", "model", c.modelName, "port", c.port)
-	if err := cmd.Start(); err != nil {
+	if err := posixspawn.StartCmd(cmd); err != nil {
 		return nil, fmt.Errorf("failed to start mlx runner: %w", err)
 	}
 


### PR DESCRIPTION
Fixes #17057.

fork() under macOS triggers pthread atfork handlers registered by Metal and Network.framework, which can deadloop. Replaced with posix_spawnp which bypasses atfork handlers entirely.

Added internal/posixspawn package with macOS CGo wrapper and non-macOS fallback. Applied to both MLX runner and image generation server.