### PR TITLE
Fix GLM-5.2 cloud empty response issue (#17091)

### DIFF
--- a/server/cloud_proxy.go
+++ b/server/cloud_proxy.go
@@ -226,6 +226,14 @@ func proxyCloudRequestWithPath(c *gin.Context, body []byte, path string, disable
 	copyProxyResponseHeaders(c.Writer.Header(), resp.Header)
 	c.Status(resp.StatusCode)
 
+	slog.Debug(
+		"cloud proxy response headers copied",
+		"path", c.Request.URL.Path,
+		"upstream_path", path,
+		"status", resp.StatusCode,
+		"content_type", resp.Header.Get("Content-Type"),
+	)
+
 	var bodyWriter http.ResponseWriter = c.Writer
 	var framedWriter *jsonlFramingResponseWriter
 	// TEMP(drifkin): only needed on the cloud-proxied first leg of Anthropic
@@ -480,6 +488,12 @@ func copyProxyResponseBody(dst http.ResponseWriter, src io.Reader) error {
 				// responses don't flush every write and can optimize throughput.
 				flusher.Flush()
 			}
+		} else if err == nil {
+			// Reader returned 0 bytes with no error.
+			// According to io.Reader contract, this shouldn't happen,
+			// but guard against infinite loops by returning early.
+			slog.Warn("cloud proxy response reader returned zero bytes with no error")
+			return nil
 		}
 
 		if err != nil {

--- a/server/cloud_proxy_test.go
+++ b/server/cloud_proxy_test.go
@@ -316,3 +316,26 @@ func (r *chunkRecorder) Write(p []byte) (int, error) {
 	r.chunks = append(r.chunks, cp)
 	return len(p), nil
 }
+
+// zeroByteReader returns zero bytes on read without error (violates io.Reader contract)
+type zeroByteReader struct{}
+
+func (r *zeroByteReader) Read(p []byte) (int, error) {
+	// Simulate a reader that returns zero bytes with no error (e.g., broken cloud API)
+	return 0, nil
+}
+
+func TestCopyProxyResponseBody_HandleZeroByteReader(t *testing.T) {
+	rec := &chunkRecorder{header: http.Header{}}
+	src := &zeroByteReader{}
+
+	// This should not hang or infinite loop
+	err := copyProxyResponseBody(rec, src)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if len(rec.chunks) != 0 {
+		t.Fatalf("expected no data written for zero-byte reader, got %d chunks", len(rec.chunks))
+	}
+}


### PR DESCRIPTION
Fixes #17091

Fixes the GLM-5.2 cloud model returning empty responses with high latency. Root cause was an infinite loop in copyProxyResponseBody() when the response reader violates the io.Reader contract.