### PR TITLE
GPU support: add gfx1103 detection for AMD Radeon 780M (#17104)

### DIFF
--- a/discover/runner.go
+++ b/discover/runner.go
@@ -29,6 +29,8 @@ var (
 )
 
 var defaultIntegratedROCmGFXTargets = map[string]struct{}{
+	// AMD Radeon 780M / Ryzen AI 300/400 series.
+	"gfx1103": {},
 	// AMD Radeon 8060S / Ryzen AI Max+ 395.
 	"gfx1151": {},
 }

--- a/discover/runner_test.go
+++ b/discover/runner_test.go
@@ -161,6 +161,7 @@ func TestFilterIntegratedGPUs(t *testing.T) {
 		got := filterIntegratedGPUs(append([]ml.DeviceInfo{}, devices...))
 		want := []ml.DeviceID{
 			{Library: "CUDA", ID: "0"},
+			{Library: "ROCm", ID: "0"},
 			{Library: "ROCm", ID: "1"},
 			{Library: "Vulkan", ID: "1"},
 		}


### PR DESCRIPTION
Fixes #17104

Adds support for AMD Radeon 780M (gfx1103) GPU detection on systems with Ryzen AI 300/400 series processors and Unraid with AMDGPU driver loaded. 

Changes:
- Added gfx1103 to defaultIntegratedROCmGFXTargets in discover/runner.go
- Updated test expectations in runner_test.go to validate new GPU support