### PR TITLE
progress: suppress ANSI control characters when stderr is not a TTY

### DIFF
--- a/progress/progress.go
+++ b/progress/progress.go
@@ -29,7 +29,7 @@ type Progress struct {
 
 	ticker *time.Ticker
 	states []State
-	isTTY bool
+	isTTY  bool
 }
 
 func NewProgress(w io.Writer) *Progress {

--- a/progress/progress.go
+++ b/progress/progress.go
@@ -29,11 +29,25 @@ type Progress struct {
 
 	ticker *time.Ticker
 	states []State
+	isTTY bool
 }
 
 func NewProgress(w io.Writer) *Progress {
-	p := &Progress{w: bufio.NewWriter(w)}
-	go p.start()
+	// Check if the writer is a terminal
+	isTTY := false
+	if f, ok := w.(*os.File); ok {
+		isTTY = term.IsTerminal(int(f.Fd()))
+	}
+
+	p := &Progress{
+		w:     bufio.NewWriter(w),
+		isTTY: isTTY,
+	}
+
+	// Only start rendering if we have a TTY
+	if isTTY {
+		go p.start()
+	}
 	return p
 }
 
@@ -56,7 +70,7 @@ func (p *Progress) stop() bool {
 
 func (p *Progress) Stop() bool {
 	stopped := p.stop()
-	if stopped {
+	if stopped && p.isTTY {
 		fmt.Fprint(p.w, "\n")
 		p.w.Flush()
 	}
@@ -64,6 +78,10 @@ func (p *Progress) Stop() bool {
 }
 
 func (p *Progress) StopAndClear() bool {
+	if !p.isTTY {
+		return p.stop()
+	}
+
 	defer p.w.Flush()
 
 	fmt.Fprint(p.w, "\033[?25l")
@@ -91,6 +109,10 @@ func (p *Progress) Add(key string, state State) {
 }
 
 func (p *Progress) render() {
+	if !p.isTTY {
+		return
+	}
+
 	_, termHeight, err := term.GetSize(int(os.Stderr.Fd()))
 	if err != nil {
 		termHeight = defaultTermHeight


### PR DESCRIPTION
The progress package was unconditionally outputting ANSI control characters to stderr, causing garbage output when `ollama run` was used in non-interactive contexts like scripts, pipes, or when stderr was redirected to a file. This made it difficult for tools to parse ollama output cleanly.

This change adds TTY detection in `progress.NewProgress()` using `term.IsTerminal()` on the stderr file descriptor. When stderr is not a terminal, the progress rendering is completely suppressed, including all ANSI escape sequences. This matches the behavior of standard CLI tools like curl and wget.

The fix modifies `progress/progress.go` to store an `isTTY` flag and conditionally disable progress rendering when not connected to a terminal. The rendering goroutine is not started, and all methods that output ANSI codes check the flag first.

Fixes #14571
