### PR TITLE
Add nika to Community Integrations (Terminal & CLI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ console.log(response.message.content);
 - [LLM-X](https://github.com/mrdjohnson/llm-x) - Progressive web app for LLMs
 - [cmdh](https://github.com/pgibler/cmdh) - Natural language to shell commands
 - [VT](https://github.com/vinhnx/vt.ai) - Minimal multimodal AI chat app
+- [nika](https://github.com/supernovae-st/nika) - Intent-as-code AI workflows against local models: reviewable YAML DAGs, cost and permit checks before any token is spent, tamper-evident traces (Ollama works out of the box)
 
 ### Productivity & Apps
 


### PR DESCRIPTION
Adds **nika** to Community Integrations → Terminal & CLI.

Nika is a single-binary (Rust, AGPL-3.0) workflow engine for AI: repeated AI work is authored as a reviewable `.nika.yaml` DAG, statically checked (cost floor, permits, schema) before any token is spent, and every run leaves a tamper-evident trace. Ollama is a first-class provider — the local-first tutorial in our docs runs end-to-end against `qwen3.5:4b` with zero API keys.

Disclosure: I'm the author.
