### PR TITLE
model/renderers: add qwen3.5-preserve-thinking renderer variant (Qwen3.6 preserve_thinking)

### DIFF
--- a/model/renderers/qwen35_test.go
+++ b/model/renderers/qwen35_test.go
@@ -387,3 +387,39 @@ func qwen35WeatherUVTools() []api.Tool {
 		},
 	}
 }
+
+func TestQwen35RendererPreserveThinkingAcrossUserTurns(t *testing.T) {
+	msgs := []api.Message{
+		{Role: "user", Content: "What is 2+2?"},
+		{Role: "assistant", Content: "4.", Thinking: "Simple arithmetic."},
+		{Role: "user", Content: "And 3+3?"},
+	}
+
+	// Default behaviour: assistant thinking from before the most recent
+	// user message is dropped.
+	def := &Qwen35Renderer{isThinking: true}
+	got, err := def.Render(msgs, nil, nil)
+	if err != nil {
+		t.Fatalf("render failed: %v", err)
+	}
+	if strings.Contains(got, "Simple arithmetic.") {
+		t.Errorf("default renderer should drop pre-last-user-turn thinking, got:\n%s", got)
+	}
+
+	// preserve-thinking variant: historical assistant thinking is retained
+	// on every turn — the Qwen3.6 chat template's preserve_thinking
+	// behaviour, which the model is trained to leverage in agent scenarios.
+	preserve := &Qwen35Renderer{isThinking: true, alwaysRenderAssistantThinkBlock: true}
+	got, err = preserve.Render(msgs, nil, nil)
+	if err != nil {
+		t.Fatalf("render failed: %v", err)
+	}
+	if !strings.Contains(got, "<think>\nSimple arithmetic.\n</think>") {
+		t.Errorf("preserve variant should retain pre-last-user-turn thinking, got:\n%s", got)
+	}
+
+	// The variant is reachable by name (Modelfile: RENDERER qwen3.5-preserve-thinking).
+	if rendererForName("qwen3.5-preserve-thinking") == nil {
+		t.Error("qwen3.5-preserve-thinking renderer not registered")
+	}
+}

--- a/model/renderers/renderer.go
+++ b/model/renderers/renderer.go
@@ -69,6 +69,16 @@ func rendererForName(name string) Renderer {
 	case "qwen3.5":
 		renderer := &Qwen35Renderer{isThinking: true, emitEmptyThinkOnNoThink: true, useImgTags: RenderImgTags}
 		return renderer
+	case "qwen3.5-preserve-thinking":
+		// Opt-in equivalent of the Qwen3.6 chat template's preserve_thinking
+		// flag: render passed-back assistant thinking on ALL turns, not just
+		// those after the last user message. Qwen3.6 (which shares the
+		// qwen3.5 architecture and renderer) is trained to leverage retained
+		// reasoning traces in agent scenarios. Select via a derived Modelfile:
+		//   FROM qwen3.6
+		//   RENDERER qwen3.5-preserve-thinking
+		renderer := &Qwen35Renderer{isThinking: true, emitEmptyThinkOnNoThink: true, useImgTags: RenderImgTags, alwaysRenderAssistantThinkBlock: true}
+		return renderer
 	case "ornith":
 		return newOrnithRenderer()
 	case "cogito":


### PR DESCRIPTION
## What

Registers an opt-in renderer name, `qwen3.5-preserve-thinking`, that constructs the existing `Qwen35Renderer` with `alwaysRenderAssistantThinkBlock: true` — following the same pattern as `qwen3-vl-instruct` / `qwen3-vl-thinking`. Includes a renderer test.

Usage, via a derived Modelfile:

```
FROM qwen3.6
RENDERER qwen3.5-preserve-thinking
```

## Why

Qwen3.6 (qwen3.5 architecture family) ships a chat template with a `preserve_thinking` flag, and per Qwen's model card guidance the model is *additionally trained to preserve and leverage thinking traces from historical messages* in agent scenarios. The built-in `qwen3.5` renderer predates this: assistant `thinking` from before the most recent user message is dropped, and there is currently no way to reach the behaviour —

- Modelfile `TEMPLATE` is not consulted for models with a built-in `RENDERER` (verified empirically: a derived model's TEMPLATE produced zero change in `prompt_eval_count`),
- `chat_template_kwargs` is not plumbed to renderers (see #16240 for the OpenAI-compat side),
- the struct field `alwaysRenderAssistantThinkBlock` already exists (and is exercised in-tree by `ornith`) but nothing constructs a qwen3.5-family renderer with it set.

## Field evidence

We run qwen3.6:35b-mlx as the model behind a long-horizon tool-calling agent (40–60 tool calls per task). A/B on the same task:

- **Thinking passed back, rendered by the current renderer** (in-turn interleaved only): late-run reasoning ratcheted (3K → 13K → 28K-char thinking blocks), with the model repeatedly re-deriving earlier conclusions.
- **Same, with `alwaysRenderAssistantThinkBlock: true` (this patch, locally built)**: thinking stayed oscillating/disciplined across 60 steps (max ~6K chars), no re-derivation loops — consistent with the model being trained to *consult* retained traces in the format this produces.

Happy to adjust naming (e.g. `qwen3.5-thinking-preserve`) or approach (e.g. plumbing a renderer option instead of a variant name) if maintainers prefer.