### PR TITLE
Add Hy3 llama.cpp override and deployment helper docs

### DIFF
--- a/cmake/local.cmake
+++ b/cmake/local.cmake
@@ -110,6 +110,16 @@ if(NOT OLLAMA_HAVE_LLAMA_SERVER)
 else()
     file(READ "${CMAKE_SOURCE_DIR}/LLAMA_CPP_VERSION" OLLAMA_LLAMA_CPP_GIT_TAG)
     string(STRIP "${OLLAMA_LLAMA_CPP_GIT_TAG}" OLLAMA_LLAMA_CPP_GIT_TAG)
+    set(_ollama_llama_cpp_repo "https://github.com/ggml-org/llama.cpp.git")
+    set(_ollama_llama_cpp_tag ${OLLAMA_LLAMA_CPP_GIT_TAG})
+    if(DEFINED ENV{OLLAMA_LLAMA_CPP_REPOSITORY})
+        set(_ollama_llama_cpp_repo "$ENV{OLLAMA_LLAMA_CPP_REPOSITORY}")
+        message(STATUS "Using overridden llama.cpp repository: ${_ollama_llama_cpp_repo}")
+    endif()
+    if(DEFINED ENV{OLLAMA_LLAMA_CPP_TAG})
+        set(_ollama_llama_cpp_tag "$ENV{OLLAMA_LLAMA_CPP_TAG}")
+        message(STATUS "Using overridden llama.cpp tag: ${_ollama_llama_cpp_tag}")
+    endif()
     include(${CMAKE_SOURCE_DIR}/llama/compat/compat.cmake)
     if(DEFINED FETCHCONTENT_SOURCE_DIR_LLAMA_CPP AND NOT "${FETCHCONTENT_SOURCE_DIR_LLAMA_CPP}" STREQUAL "")
         get_filename_component(OLLAMA_LLAMA_CPP_SOURCE_DIR
@@ -124,8 +134,8 @@ else()
     else()
         set(OLLAMA_LLAMA_CPP_SOURCE_DIR "${CMAKE_BINARY_DIR}/_deps/llama_cpp-src")
         ExternalProject_Add(ollama-llama-cpp-source
-            GIT_REPOSITORY "https://github.com/ggml-org/llama.cpp.git"
-            GIT_TAG ${OLLAMA_LLAMA_CPP_GIT_TAG}
+            GIT_REPOSITORY "${_ollama_llama_cpp_repo}"
+            GIT_TAG ${_ollama_llama_cpp_tag}
             GIT_SHALLOW TRUE
             SOURCE_DIR ${OLLAMA_LLAMA_CPP_SOURCE_DIR}
             CONFIGURE_COMMAND ""

--- a/docs/development.md
+++ b/docs/development.md
@@ -188,7 +188,7 @@ cmake --build build --parallel 8
 
 The Hy3 GGUF page currently recommends running against `hf.co/satgeze/Hy3-1M-GGUF`
 with a branch that has `hy_v3` support in llama.cpp (for example
-`satgeze/llama.cpp` at the `hy3-mtp` branch).
+`satindergrewal/llama.cpp` at the `hy3-mtp` branch).
 
 To keep model files on a dedicated data drive, set the cache location before any
 deploy or run:

--- a/docs/development.md
+++ b/docs/development.md
@@ -155,6 +155,64 @@ cmake -B build . -DOLLAMA_MLX_BACKENDS=cuda_v13
 cmake --build build --parallel 8
 ```
 
+### Local llama.cpp source overrides
+
+To validate against a local checkout (or a fork/branch you are iterating on), set:
+
+```shell
+export OLLAMA_LLAMA_CPP_SOURCE=/path/to/llama.cpp
+```
+
+For remote forks/branches (no local checkout), override the repository and tag/commit directly:
+
+```shell
+export OLLAMA_LLAMA_CPP_REPOSITORY=https://github.com/<your-llama.cpp-fork>/llama.cpp.git
+export OLLAMA_LLAMA_CPP_TAG=hy3-mtp
+```
+
+Then run the normal Linux build:
+
+```shell
+cmake -S llama/server --preset cpu
+cmake --build build/llama-server-cpu --parallel 8
+```
+
+And rebuild the full Ollama payload:
+
+```shell
+cmake -B build . -DOLLAMA_LLAMA_BACKENDS="cuda_v13"
+cmake --build build --parallel 8
+```
+
+### Hy3 deployment workflow
+
+The Hy3 GGUF page currently recommends running against `hf.co/satgeze/Hy3-1M-GGUF`
+with a branch that has `hy_v3` support in llama.cpp (for example
+`satgeze/llama.cpp` at the `hy3-mtp` branch).
+
+To keep model files on a dedicated data drive, set the cache location before any
+deploy or run:
+
+```shell
+export OLLAMA_MODELS=/srv/hy3
+export OLLAMA_HOST=127.0.0.1:11450
+```
+
+Use the helper script to pick a class and verify in terminal:
+
+```shell
+./scripts/deploy-hy3.sh [auto|Q2_K|MTP-Q2_K|IQ2_M|...] 
+```
+
+If a class is already present under `/srv/hy3/models/manifests/hf.co/satgeze/Hy3-1M-GGUF`,
+the script runs directly from disk. Otherwise it pulls the model from Hugging Face
+into the same directory.
+
+On this host profile (A100 80GB GPUs, `/srv` storage), pure GPU fit is limited:
+Q2_K and larger Hy3 classes are over the available VRAM budget without offload,
+so plan for CPU fallback or lower-memory contexts even though storage is available on
+`/srv`.
+
 ## Docker
 
 ```shell

--- a/llama/server/CMakeLists.txt
+++ b/llama/server/CMakeLists.txt
@@ -122,6 +122,18 @@ if(DEFINED ENV{OLLAMA_LLAMA_CPP_SOURCE})
     message(STATUS "Using local llama.cpp source: ${_src}")
 endif()
 
+set(_ollama_llama_cpp_repo "https://github.com/ggml-org/llama.cpp.git")
+if(DEFINED ENV{OLLAMA_LLAMA_CPP_REPOSITORY})
+    set(_ollama_llama_cpp_repo "$ENV{OLLAMA_LLAMA_CPP_REPOSITORY}")
+    message(STATUS "Using overridden llama.cpp repository: ${_ollama_llama_cpp_repo}")
+endif()
+
+set(_ollama_llama_cpp_tag ${LLAMA_CPP_GIT_TAG})
+if(DEFINED ENV{OLLAMA_LLAMA_CPP_TAG})
+    set(_ollama_llama_cpp_tag "$ENV{OLLAMA_LLAMA_CPP_TAG}")
+    message(STATUS "Using overridden llama.cpp tag: ${_ollama_llama_cpp_tag}")
+endif()
+
 # Ollama-compat shim: overlays the fetched llama.cpp source with a small
 # in-memory translation layer for existing published model blobs.
 # See llama/compat/README.md for details.
@@ -179,8 +191,8 @@ set(LLAMA_OPENSSL OFF CACHE BOOL "" FORCE)
 
 FetchContent_Declare(
     llama_cpp
-    GIT_REPOSITORY "https://github.com/ggml-org/llama.cpp.git"
-    GIT_TAG ${LLAMA_CPP_GIT_TAG}
+    GIT_REPOSITORY "${_ollama_llama_cpp_repo}"
+    GIT_TAG ${_ollama_llama_cpp_tag}
     GIT_SHALLOW TRUE
     ${_ollama_compat_patch_cmd}
 )

--- a/scripts/deploy-hy3.sh
+++ b/scripts/deploy-hy3.sh
@@ -6,8 +6,9 @@ set -euo pipefail
 # Keeps model artifacts in the configured OLLAMA_MODELS directory (default: /srv/hy3)
 # and exposes a one-off Ollama instance for terminal verification.
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MODEL_CLASS="${1:-auto}"
-OLLAMA_BIN="${OLLAMA_BIN:-ollama}"
+OLLAMA_BIN="${OLLAMA_BIN:-$SCRIPT_DIR/../ollama}"
 OLLAMA_MODELS_DIR="${OLLAMA_MODELS:-/srv/hy3}"
 OLLAMA_HOST="${OLLAMA_HOST:-127.0.0.1:11450}"
 MODEL_REPO="hf.co/satgeze/Hy3-1M-GGUF"
@@ -40,7 +41,7 @@ class: one of Q2_K, IQ2_M, IQ1_M, or any MTP-* variant supported by hf.co/satgez
 Environment:
   OLLAMA_MODELS   Directory used for cache (default: /srv/hy3)
   OLLAMA_HOST     Host for temporary run (default: 127.0.0.1:11450)
-  OLLAMA_BIN      Ollama executable (default: ollama)
+  OLLAMA_BIN      Ollama executable (default: <repo>/ollama)
   OLLAMA_HY3_PROMPT    Optional prompt to run for verification
 EOF
 }
@@ -132,7 +133,7 @@ fi
 echo "Running verify prompt: ${PROMPT}"
 if ! "$OLLAMA_BIN" run "$MODEL_NAME" "$PROMPT"; then
     echo "Run failed. If this is 'unknown model architecture: hy_v3', rebuild Ollama"
-    echo "with OLLAMA_LLAMA_CPP_REPOSITORY=https://github.com/satgeze/llama.cpp.git"
+    echo "with OLLAMA_LLAMA_CPP_REPOSITORY=https://github.com/satindergrewal/llama.cpp.git"
     echo "and OLLAMA_LLAMA_CPP_TAG=hy3-mtp before deploying again."
     exit 1
 fi

--- a/scripts/deploy-hy3.sh
+++ b/scripts/deploy-hy3.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Simple, host-local Hy3 deployment helper.
+# Keeps model artifacts in the configured OLLAMA_MODELS directory (default: /srv/hy3)
+# and exposes a one-off Ollama instance for terminal verification.
+
+MODEL_CLASS="${1:-auto}"
+OLLAMA_BIN="${OLLAMA_BIN:-ollama}"
+OLLAMA_MODELS_DIR="${OLLAMA_MODELS:-/srv/hy3}"
+OLLAMA_HOST="${OLLAMA_HOST:-127.0.0.1:11450}"
+MODEL_REPO="hf.co/satgeze/Hy3-1M-GGUF"
+PROMPT="${OLLAMA_HY3_PROMPT:-One sentence: what is a language model?}"
+
+LOG_FILE="/tmp/ollama-hy3-serve.log"
+
+declare -A MODEL_GB=(
+    [MTP-Q6_K]=245
+    [MTP-Q5_K_M]=199
+    [MTP-Q4_K_M]=183
+    [MTP-Q3_K_M]=145
+    [MTP-Q3_XXS]=117
+    [MTP-IQ2_M]=100
+    [MTP-Q2_K]=111
+    [IQ2_M]=96
+    [Q2_K]=101
+    [IQ1_M]=62
+)
+
+MODEL_CLASS_PRIORITY=(MTP-Q6_K MTP-Q5_K_M MTP-Q4_K_M MTP-Q3_K_M MTP-Q3_XXS MTP-IQ2_M MTP-Q2_K IQ2_M Q2_K IQ1_M)
+
+usage() {
+    cat <<'EOF'
+Usage:
+  scripts/deploy-hy3.sh [class|auto]
+
+class: one of Q2_K, IQ2_M, IQ1_M, or any MTP-* variant supported by hf.co/satgeze/Hy3-1M-GGUF
+
+Environment:
+  OLLAMA_MODELS   Directory used for cache (default: /srv/hy3)
+  OLLAMA_HOST     Host for temporary run (default: 127.0.0.1:11450)
+  OLLAMA_BIN      Ollama executable (default: ollama)
+  OLLAMA_HY3_PROMPT    Optional prompt to run for verification
+EOF
+}
+
+if [[ "$MODEL_CLASS" == "-h" || "$MODEL_CLASS" == "--help" ]]; then
+    usage
+    exit 0
+fi
+
+if [[ -n "${MODEL_CLASS}" && "$MODEL_CLASS" != "auto" && -z "${MODEL_GB[$MODEL_CLASS]:-}" ]]; then
+    echo "Unsupported class: $MODEL_CLASS"
+    usage
+    exit 1
+fi
+
+get_free_gib() {
+    if ! command -v nvidia-smi >/dev/null 2>&1; then
+        echo 0
+        return
+    fi
+
+    local total_mib=0
+    total_mib=$(nvidia-smi --query-gpu=memory.free --format=csv,noheader,nounits 2>/dev/null \
+        | awk '{total += $1} END {if (NR==0) print 0; else print int(total)}')
+    if [[ -z "$total_mib" ]]; then
+        echo 0
+        return
+    fi
+
+    awk -v mib="$total_mib" 'BEGIN { printf "%d", mib / 1024 }'
+}
+
+pick_auto_class() {
+    local free_gib
+    free_gib=$(get_free_gib)
+    if (( free_gib == 0 )); then
+        echo "Q2_K"
+        return
+    fi
+
+    # Conservative estimate includes runtime overhead and mmap/kv cache.
+    local threshold
+    for cls in "${MODEL_CLASS_PRIORITY[@]}"; do
+        threshold=$(awk -v size="${MODEL_GB[$cls]}" 'BEGIN { printf "%d", size * 1.35 }')
+        if (( free_gib >= threshold )); then
+            echo "$cls"
+            return
+        fi
+    done
+
+    echo "Q2_K"
+}
+
+if [[ "$MODEL_CLASS" == "auto" ]]; then
+    MODEL_CLASS=$(pick_auto_class)
+fi
+
+export OLLAMA_MODELS="$OLLAMA_MODELS_DIR"
+export OLLAMA_HOST="http://$OLLAMA_HOST"
+
+mkdir -p "$OLLAMA_MODELS_DIR"
+MODEL_NAME="${MODEL_REPO}:${MODEL_CLASS}"
+
+echo "Selected model: ${MODEL_NAME}"
+echo "Model cache: ${OLLAMA_MODELS_DIR}"
+echo "Ollama host: ${OLLAMA_HOST}"
+
+"$OLLAMA_BIN" serve >"$LOG_FILE" 2>&1 &
+PID=$!
+cleanup() {
+    if ps -p "$PID" >/dev/null 2>&1; then
+        kill "$PID" >/dev/null 2>&1 || true
+    fi
+}
+trap cleanup EXIT
+
+for _ in {1..90}; do
+    if curl -s --max-time 2 "$OLLAMA_HOST/api/version" >/dev/null; then
+        break
+    fi
+    sleep 1
+done
+
+if [[ ! -f "$OLLAMA_MODELS_DIR/models/manifests/hf.co/satgeze/Hy3-1M-GGUF/$MODEL_CLASS" ]]; then
+    echo "Model ${MODEL_CLASS} not present locally; pulling into ${OLLAMA_MODELS_DIR}..."
+    "$OLLAMA_BIN" pull "$MODEL_NAME"
+fi
+
+echo "Running verify prompt: ${PROMPT}"
+if ! "$OLLAMA_BIN" run "$MODEL_NAME" "$PROMPT"; then
+    echo "Run failed. If this is 'unknown model architecture: hy_v3', rebuild Ollama"
+    echo "with OLLAMA_LLAMA_CPP_REPOSITORY=https://github.com/satgeze/llama.cpp.git"
+    echo "and OLLAMA_LLAMA_CPP_TAG=hy3-mtp before deploying again."
+    exit 1
+fi
+echo "Done"


### PR DESCRIPTION
## Summary

- Add CMake override hooks for llama.cpp source and ref selection via environment variables:
  - `OLLAMA_LLAMA_CPP_REPOSITORY`
  - `OLLAMA_LLAMA_CPP_TAG`
  in both top-level and `llama/server` build paths.
- Add `scripts/deploy-hy3.sh` to simplify Hy3 deployment on a data disk and expose the model selection/pull path for `hf.co/satgeze/Hy3-1M-GGUF`.
- Document the flow in `docs/development.md`, including:
  - local/remote llama.cpp overrides
  - the helper script usage
  - dedicated model cache location usage.

## Verification

- `bash -n scripts/deploy-hy3.sh`
- `OLLAMA_LLAMA_CPP_REPOSITORY=https://github.com/satindergrewal/llama.cpp.git OLLAMA_LLAMA_CPP_TAG=hy3-mtp cmake -B build .`
- `cmake --build build --parallel 4`
- Data-disk deployment smoke check:
  - `export OLLAMA_BIN=/tmp/ollama-fork/ollama`
  - `export OLLAMA_MODELS=/srv/hy3`
  - `export OLLAMA_HOST=127.0.0.1:11450`
  - `./scripts/deploy-hy3.sh Q2_K`

  This successfully:
  - Pulled the model into `/srv/hy3` (symlinked to `/srv/ollama/models` in this environment),
  - started an `ollama serve` session,
  - and returned a valid response from the `Q2_K` model.

- `scripts/deploy-hy3.sh auto` reports `hy3` class selection on this host as:
  - `Selected model: hf.co/satgeze/Hy3-1M-GGUF:MTP-Q3_K_M` (based on total free GPU memory 236078 MiB).
