### PR TITLE
fix(parsers): use LastIndex instead of SplitN for DeepSeek think tag closing

### DIFF
--- a/model/parsers/deepseek3.go
+++ b/model/parsers/deepseek3.go
@@ -154,11 +154,17 @@ func (p *DeepSeek3Parser) eat() ([]deepseekEvent, bool) {
 	switch p.state {
 	case DeepSeekCollectingThinking:
 		if strings.Contains(bufStr, deepseekThinkingCloseTag) { // thinking[</think>] -> content
-			split := strings.SplitN(bufStr, deepseekThinkingCloseTag, 2)
-			thinking := split[0]
+			// Use LastIndex + manual split instead of SplitN to find the LAST
+			// occurrence of </think>. DeepSeek models output exactly one structural
+			// think block per message, but the reasoning text may contain literal
+			// mentions of </think> (e.g., when the user asks about think tags).
+			// Splitting at the last occurrence ensures we capture all reasoning
+			// content up to the real structural tag boundary.
+			idx := strings.LastIndex(bufStr, deepseekThinkingCloseTag)
+			thinking := bufStr[:idx]
 			thinking = strings.TrimRightFunc(thinking, unicode.IsSpace)
 
-			remaining := split[1]
+			remaining := bufStr[idx+len(deepseekThinkingCloseTag):]
 			remaining = strings.TrimLeftFunc(remaining, unicode.IsSpace)
 
 			p.buffer.Reset()

--- a/model/parsers/deepseek3_test.go
+++ b/model/parsers/deepseek3_test.go
@@ -626,15 +626,15 @@ func TestDeepSeekParser_EdgeCases(t *testing.T) {
 		{
 			name:             "nested_think_tags_in_thinking",
 			input:            "Outer thinking <think>inner</think> content</think>Final content",
-			expectedThinking: "Outer thinking <think>inner",
-			expectedContent:  "content</think>Final content",
+			expectedThinking: "Outer thinking <think>inner</think> content",
+			expectedContent:  "Final content",
 			hasThinking:      true,
 		},
 		{
 			name:             "multiple_think_close_tags",
 			input:            "First thought</think>Second thought</think>Final content",
-			expectedThinking: "First thought",
-			expectedContent:  "Second thought</think>Final content",
+			expectedThinking: "First thought</think>Second thought",
+			expectedContent:  "Final content",
 			hasThinking:      true,
 		},
 		{


### PR DESCRIPTION
## Summary

DeepSeek R1/V3 reasoning content gets truncated when the reasoning text contains literal `</think>` strings. This happens when users ask meta questions about think tags themselves (e.g., "Explain what `<think>` and `</think>` tags mean").

## Root Cause

In `model/parsers/deepseek3.go`, the `DeepSeekCollectingThinking` state handler uses `strings.SplitN(buf, "</think>", 2)` which matches the **first** occurrence of `</think>`. When the reasoning text itself contains literal `</think>` mentions, this incorrectly terminates the thinking block prematurely.

## Fix

Replace `strings.SplitN` with `strings.LastIndex` to find the **last** `</think>` occurrence. DeepSeek models output exactly one structural think block per message, so the last `</think>` is always the correct boundary.

```go
// Before (buggy):
split := strings.SplitN(bufStr, deepseekThinkingCloseTag, 2)

// After (fixed):
idx := strings.LastIndex(bufStr, deepseekThinkingCloseTag)
```

## Verification

- Updated `nested_think_tags_in_thinking` and `multiple_think_close_tags` test cases to reflect the corrected behavior (last `</think>` is the real boundary)
- All 12 existing `TestDeepSeekParser_EdgeCases` tests pass
- Full `model/parsers` test suite passes (`go test ./model/parsers/...`)