### PR TITLE
Update minimum CMake version to 3.10

### DIFF
--- a/x/mlxrunner/mlx/CMakeLists.txt
+++ b/x/mlxrunner/mlx/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 project(mlx)
 


### PR DESCRIPTION
Compatibility with CMake < 3.10 will be removed from a future version of  CMake.