### PR TITLE
template: add thinking support for gemma3-instruct models

### DIFF
--- a/model/parsers/deepseek3.go
+++ b/model/parsers/deepseek3.go
@@ -154,11 +154,17 @@ func (p *DeepSeek3Parser) eat() ([]deepseekEvent, bool) {
 	switch p.state {
 	case DeepSeekCollectingThinking:
 		if strings.Contains(bufStr, deepseekThinkingCloseTag) { // thinking[</think>] -> content
-			split := strings.SplitN(bufStr, deepseekThinkingCloseTag, 2)
-			thinking := split[0]
+			// Use LastIndex + manual split instead of SplitN to find the LAST
+			// occurrence of </think>. DeepSeek models output exactly one structural
+			// think block per message, but the reasoning text may contain literal
+			// mentions of </think> (e.g., when the user asks about think tags).
+			// Splitting at the last occurrence ensures we capture all reasoning
+			// content up to the real structural tag boundary.
+			idx := strings.LastIndex(bufStr, deepseekThinkingCloseTag)
+			thinking := bufStr[:idx]
 			thinking = strings.TrimRightFunc(thinking, unicode.IsSpace)
 
-			remaining := split[1]
+			remaining := bufStr[idx+len(deepseekThinkingCloseTag):]
 			remaining = strings.TrimLeftFunc(remaining, unicode.IsSpace)
 
 			p.buffer.Reset()

--- a/model/parsers/deepseek3_test.go
+++ b/model/parsers/deepseek3_test.go
@@ -626,15 +626,15 @@ func TestDeepSeekParser_EdgeCases(t *testing.T) {
 		{
 			name:             "nested_think_tags_in_thinking",
 			input:            "Outer thinking <think>inner</think> content</think>Final content",
-			expectedThinking: "Outer thinking <think>inner",
-			expectedContent:  "content</think>Final content",
+			expectedThinking: "Outer thinking <think>inner</think> content",
+			expectedContent:  "Final content",
 			hasThinking:      true,
 		},
 		{
 			name:             "multiple_think_close_tags",
 			input:            "First thought</think>Second thought</think>Final content",
-			expectedThinking: "First thought",
-			expectedContent:  "Second thought</think>Final content",
+			expectedThinking: "First thought</think>Second thought",
+			expectedContent:  "Final content",
 			hasThinking:      true,
 		},
 		{

--- a/server/routes.go
+++ b/server/routes.go
@@ -645,7 +645,7 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 	var thinkingState *thinking.Parser
 	if builtinParser == nil {
 		openingTag, closingTag := thinking.InferTags(m.Template.Template)
-		if req.Think != nil && req.Think.Bool() && openingTag != "" && closingTag != "" {
+		if openingTag != "" && closingTag != "" {
 			thinkingState = &thinking.Parser{
 				OpeningTag: openingTag,
 				ClosingTag: closingTag,
@@ -2724,7 +2724,7 @@ func (s *Server) ChatHandler(c *gin.Context) {
 
 	var thinkingState *thinking.Parser
 	openingTag, closingTag := thinking.InferTags(m.Template.Template)
-	if req.Think != nil && req.Think.Bool() && openingTag != "" && closingTag != "" {
+	if openingTag != "" && closingTag != "" {
 		thinkingState = &thinking.Parser{
 			OpeningTag: openingTag,
 			ClosingTag: closingTag,

--- a/template/gemma3-instruct.gotmpl
+++ b/template/gemma3-instruct.gotmpl
@@ -6,8 +6,10 @@
 {{ end }}
 {{ .Content }}<end_of_turn>
 {{ else if eq .Role "assistant" }}<start_of_turn>model
+{{- if and $last .Thinking }}<unused94>{{ .Thinking }}<unused95>
+{{ end }}
 {{ .Content }}<end_of_turn>
 {{ end }}
-{{- if $last }}<start_of_turn>model
+{{- if $last }}<start_of_turn>model{{ if $.Think }}<unused94>{{ end }}
 {{ end }}
 {{- end }}

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -417,6 +417,32 @@ What is your name?<|im_end|>
 	}
 }
 
+func TestGemma3InstructThinkPrompt(t *testing.T) {
+	bts, err := os.ReadFile("gemma3-instruct.gotmpl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl, err := Parse(string(bts))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var b bytes.Buffer
+	err = tmpl.Execute(&b, Values{
+		Think: true,
+		Messages: []api.Message{
+			{Role: "user", Content: "hey"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := strings.TrimSpace(b.String())
+	if !strings.HasSuffix(out, "<unused94>") {
+		t.Errorf("expected generation prompt to end with <unused94>, got:\n%s", out)
+	}
+}
+
 func TestExecuteWithSuffix(t *testing.T) {
 	tmpl, err := Parse(`{{- if .Suffix }}<PRE> {{ .Prompt }} <SUF>{{ .Suffix }} <MID>
 {{- else }}{{ .Prompt }}

--- a/thinking/template_test.go
+++ b/thinking/template_test.go
@@ -63,6 +63,26 @@ func TestInferThinkingTags(t *testing.T) {
 			wantClosingTag: "Some text after",
 		},
 		{
+			desc: "gemma3-instruct",
+			tmplString: `{{- range $i, $_ := .Messages }}
+{{- $last := eq (len (slice $.Messages $i)) 1 }}
+{{- if eq .Role "user" }}<start_of_turn>user
+{{- if and (eq $i 1) $.System }}
+{{ $.System }}
+{{ end }}
+{{ .Content }}<end_of_turn>
+{{ else if eq .Role "assistant" }}<start_of_turn>model
+{{- if and $last .Thinking }}<unused94>{{ .Thinking }}<unused95>
+{{ end }}
+{{ .Content }}<end_of_turn>
+{{ end }}
+{{- if $last }}<start_of_turn>model{{ if $.Think }}<unused94>{{ end }}
+{{ end }}
+{{- end }}`,
+			wantOpeningTag: "<unused94>",
+			wantClosingTag: "<unused95>",
+		},
+		{
 			desc: "qwen3",
 			tmplString: `
 {{- if or .System .Tools .Thinking }}<|im_start|>system


### PR DESCRIPTION
## Problem

`ollama run medgemma1.5` leaks raw tokens into user output:

```
>>> hey
<unused94>thought
Thinking Process:
1. **Identify the user's input:** ...
<unused95>Hello!
```

## Solution

Two issues, fixed together:

1. `gemma3-instruct.gotmpl` has no `{{.Thinking}}` → `InferTags()` can't detect `<unused94>/<unused95>`. Added the bindings.
2. Even with tags detected, `routes.go` requires `req.Think.Bool()` to create the Parser — so `think=off` or unset still leaks. Removed the gate. The Parser now always runs when tags are detected; `req.Think` still controls display.

Path: model emits tokens → Parser separates thinking from content → template renders `.Thinking` and `.Content` separately → CLI shows/hides based on `Think`.

## Changes

| File | What |
|------|------|
| `template/gemma3-instruct.gotmpl` | +3: `{{.Thinking}}` bindings; prompt ends with `<unused94>` when Think=true |
| `server/routes.go` | −2: Parser always runs when tags detected |
| `thinking/template_test.go` | `InferTags` detects `<unused94>/<unused95>` from actual template |
| `template/template_test.go` | Prompt ends with `<unused94>` when Think=true |

## Why safe

No existing template uses `{{.Thinking}}` — `InferTags()` returns empty for all other models. Zero blast radius.

## Why remove `req.Think.Bool()`?

builtinParser models (gemma4, qwen3) already work this way — their parsers always run. `Think` controls *display*, not *parsing*. This change brings template-based thinking to parity.

Fixes #15754