### PR TITLE
server: stop streaming goroutines blocking forever on client disconnect

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -661,7 +661,11 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 		// TODO (jmorganca): avoid building the response twice both here and below
 		var sb strings.Builder
 		defer close(ch)
-		if err := r.Completion(c.Request.Context(), llm.CompletionRequest{
+
+		ctx, cancel := context.WithCancel(c.Request.Context())
+		defer cancel()
+
+		if err := r.Completion(ctx, llm.CompletionRequest{
 			Prompt:          prompt,
 			Media:           media,
 			Format:          req.Format,
@@ -690,7 +694,9 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 			if builtinParser != nil {
 				content, thinking, toolCalls, err := builtinParser.Add(cr.Content, cr.Done)
 				if err != nil {
-					ch <- gin.H{"error": err.Error()}
+					if !sendStreamValue(ctx, ch, gin.H{"error": err.Error()}) {
+						cancel()
+					}
 					return
 				}
 				res.Response = content
@@ -705,7 +711,9 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 			}
 
 			if _, err := sb.WriteString(cr.Content); err != nil {
-				ch <- gin.H{"error": err.Error()}
+				if !sendStreamValue(ctx, ch, gin.H{"error": err.Error()}) {
+					cancel()
+				}
 			}
 
 			if cr.Done {
@@ -714,9 +722,11 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 				res.LoadDuration = checkpointLoaded.Sub(checkpointStart)
 
 				if !req.Raw {
-					tokens, err := r.Tokenize(c.Request.Context(), prompt+sb.String())
+					tokens, err := r.Tokenize(ctx, prompt+sb.String())
 					if err != nil {
-						ch <- gin.H{"error": err.Error()}
+						if !sendStreamValue(ctx, ch, gin.H{"error": err.Error()}) {
+							cancel()
+						}
 						return
 					}
 					res.Context = tokens
@@ -728,20 +738,26 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 				// visible content, otherwise generate logprobs disappear for models with
 				// builtin thinking/tool parsers.
 				if res.Response != "" || res.Thinking != "" || res.Done || len(res.ToolCalls) > 0 || len(res.Logprobs) > 0 {
-					ch <- res
+					if !sendStreamValue(ctx, ch, res) {
+						cancel()
+					}
 				}
 
 				return
 			}
 
-			ch <- res
+			if !sendStreamValue(ctx, ch, res) {
+				cancel()
+			}
 		}); err != nil {
 			s.sched.expireRunnersForRuntimeOOM(m, err)
-			var serr api.StatusError
-			if errors.As(err, &serr) {
-				ch <- gin.H{"error": serr.ErrorMessage, "status": serr.StatusCode}
-			} else {
-				ch <- gin.H{"error": err.Error()}
+			if !errors.Is(err, context.Canceled) {
+				var serr api.StatusError
+				if errors.As(err, &serr) {
+					sendStreamValue(ctx, ch, gin.H{"error": serr.ErrorMessage, "status": serr.StatusCode})
+				} else {
+					sendStreamValue(ctx, ch, gin.H{"error": err.Error()})
+				}
 			}
 		}
 	}()
@@ -1172,25 +1188,30 @@ func (s *Server) PushHandler(c *gin.Context) {
 	ch := make(chan any)
 	go func() {
 		defer close(ch)
+
+		ctx, cancel := context.WithCancel(c.Request.Context())
+		defer cancel()
+
 		fn := func(r api.ProgressResponse) {
-			ch <- r
+			if !sendStreamValue(ctx, ch, r) {
+				cancel()
+			}
 		}
 
 		regOpts := &registryOptions{
 			Insecure: req.Insecure,
 		}
 
-		ctx, cancel := context.WithCancel(c.Request.Context())
-		defer cancel()
-
 		name, err := getExistingName(model.ParseName(mname))
 		if err != nil {
-			ch <- gin.H{"error": err.Error()}
+			sendStreamValue(ctx, ch, gin.H{"error": err.Error()})
 			return
 		}
 
 		if err := PushModel(ctx, name.DisplayShortest(), regOpts, fn); err != nil {
-			ch <- gin.H{"error": err.Error()}
+			if !errors.Is(err, context.Canceled) {
+				sendStreamValue(ctx, ch, gin.H{"error": err.Error()})
+			}
 		}
 	}()
 
@@ -2088,6 +2109,15 @@ func waitForStream(c *gin.Context, ch chan any) {
 	}
 
 	c.JSON(http.StatusOK, latest)
+}
+
+func sendStreamValue(ctx context.Context, ch chan<- any, v any) bool {
+	select {
+	case ch <- v:
+		return true
+	case <-ctx.Done():
+		return false
+	}
 }
 
 func streamResponse(c *gin.Context, ch chan any) {
@@ -2994,7 +3024,10 @@ func (s *Server) handleNativeChat(c *gin.Context, req api.ChatRequest, m *Model,
 	go func() {
 		defer close(ch)
 
-		err := r.Chat(c.Request.Context(), nativeReq, func(r llm.ChatResponse) {
+		ctx, cancel := context.WithCancel(c.Request.Context())
+		defer cancel()
+
+		err := r.Chat(ctx, nativeReq, func(r llm.ChatResponse) {
 			res := api.ChatResponse{
 				Model:     req.Model,
 				CreatedAt: time.Now().UTC(),
@@ -3019,15 +3052,17 @@ func (s *Server) handleNativeChat(c *gin.Context, req api.ChatRequest, m *Model,
 				res.LoadDuration = checkpointLoaded.Sub(checkpointStart)
 			}
 
-			ch <- res
+			if !sendStreamValue(ctx, ch, res) {
+				cancel()
+			}
 		})
-		if err != nil {
+		if err != nil && !errors.Is(err, context.Canceled) {
 			s.sched.expireRunnersForRuntimeOOM(m, err)
 			var serr api.StatusError
 			if errors.As(err, &serr) {
-				ch <- gin.H{"error": serr.ErrorMessage, "status": serr.StatusCode}
+				sendStreamValue(ctx, ch, gin.H{"error": serr.ErrorMessage, "status": serr.StatusCode})
 			} else {
-				ch <- gin.H{"error": err.Error()}
+				sendStreamValue(ctx, ch, gin.H{"error": err.Error()})
 			}
 		}
 	}()

--- a/server/routes_generate_disconnect_test.go
+++ b/server/routes_generate_disconnect_test.go
@@ -1,0 +1,150 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/llm"
+)
+
+// disconnectRecorder is like the responseRecorder in routes_create_test.go, but
+// its CloseNotify channel is controllable so a test can simulate the client
+// going away mid-stream.
+type disconnectRecorder struct {
+	*httptest.ResponseRecorder
+	closeCh chan bool
+}
+
+func newDisconnectRecorder() *disconnectRecorder {
+	return &disconnectRecorder{
+		ResponseRecorder: httptest.NewRecorder(),
+		closeCh:          make(chan bool),
+	}
+}
+
+func (r *disconnectRecorder) CloseNotify() <-chan bool {
+	return r.closeCh
+}
+
+// TestGenerateStreamDisconnectDoesNotLeakGoroutine is a regression test: when
+// a streaming /api/generate client disconnects mid-response, the goroutine
+// driving the completion must not block forever trying to send into the now
+// unread response channel.
+//
+// Real disconnects surface through two signals that fire together in Go's
+// net/http server: the ResponseWriter's CloseNotify channel (what gin's
+// Context.Stream reacts to, to stop calling its step function) and the
+// request's context being cancelled (what net/http's connection handling
+// cancels once the underlying connection goes away, independently of
+// whether the handler ever calls CloseNotify). Both are simulated here
+// since routes.go's fix relies on the latter.
+func TestGenerateStreamDisconnectDoesNotLeakGoroutine(t *testing.T) {
+	t.Setenv("OLLAMA_CONTEXT_LENGTH", "4096")
+	gin.SetMode(gin.TestMode)
+
+	const extraChunksAfterDisconnect = 5
+
+	firstChunkSent := make(chan struct{})
+	clientDisconnected := make(chan struct{})
+	completionReturned := make(chan struct{})
+
+	mock := &mockRunner{
+		CompletionFn: func(ctx context.Context, r llm.CompletionRequest, fn func(llm.CompletionResponse)) error {
+			defer close(completionReturned)
+
+			// First chunk: lets the test know it can now simulate the client
+			// going away.
+			fn(llm.CompletionResponse{Content: "hello ", Done: false})
+			close(firstChunkSent)
+
+			<-clientDisconnected
+
+			// Deliberately keep calling fn without checking ctx here, the
+			// same way a real completion loop does between tokens - the
+			// protection against a leaked/blocked goroutine has to live in
+			// how routes.go sends into the channel, not in this mock.
+			for range extraChunksAfterDisconnect {
+				fn(llm.CompletionResponse{Content: "more ", Done: false})
+			}
+
+			fn(llm.CompletionResponse{
+				Content:    "done",
+				Done:       true,
+				DoneReason: llm.DoneReasonStop,
+			})
+			return nil
+		},
+	}
+
+	s := newServerWithMockRunner(t, mock)
+	createMinimalGGUFModel(t, s, "test", nil, "{{ .Prompt }}", nil)
+
+	streamTrue := true
+	reqBody, err := json.Marshal(api.GenerateRequest{
+		Model:  "test",
+		Prompt: "hi",
+		Stream: &streamTrue,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reqCtx, cancelReq := context.WithCancel(context.Background())
+	defer cancelReq()
+
+	rec := newDisconnectRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = (&http.Request{
+		Method: http.MethodPost,
+		Body:   io.NopCloser(bytes.NewReader(reqBody)),
+	}).WithContext(reqCtx)
+
+	handlerDone := make(chan struct{})
+	go func() {
+		defer close(handlerDone)
+		s.GenerateHandler(c)
+	}()
+
+	select {
+	case <-firstChunkSent:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the first streamed chunk")
+	}
+
+	// Simulate the client disconnecting. In Go's real net/http server these
+	// two things happen together as soon as the underlying connection goes
+	// away: the ResponseWriter's CloseNotify fires (which is what gin's
+	// Context.Stream reacts to) and the request's context is cancelled
+	// (which is what the fix in routes.go relies on to stop blocked sends).
+	close(rec.closeCh)
+	cancelReq()
+
+	select {
+	case <-handlerDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("GenerateHandler did not return after the client disconnected " +
+			"(streamResponse/c.Stream should exit as soon as CloseNotify fires)")
+	}
+
+	// Let the mock's completion loop run the rest of the way: since none of
+	// its sends after the disconnect have a reader anymore, an unguarded
+	// `ch <- res` in routes.go would block here forever, and this would time
+	// out instead of the completion function ever returning.
+	close(clientDisconnected)
+
+	select {
+	case <-completionReturned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the completion goroutine appears to be leaked: it never " +
+			"finished sending the remaining post-disconnect chunks")
+	}
+}


### PR DESCRIPTION
## What

`GenerateHandler`, `PushHandler`, and the non-legacy chat path in `ChatHandler` (`handleNativeChat`) each start a goroutine that streams progress into an unbuffered channel, which `gin.Context.Stream` reads from and forwards to the client. `Stream` internally does roughly:

```go
select {
case <-clientGone:
    return
default:
    keepOpen = step(w)
}
```

so once `CloseNotify()` fires it stops calling `step` and returns, but it never drains anything else out of the channel afterwards. If the producer goroutine is mid-way through a bare `ch <- value` (or issues one later, after the client already disconnected), and nothing is left reading from `ch`, that send blocks forever. The goroutine leaks along with whatever scheduler/runner resources it is holding onto for the duration of the request, so repeated client-side disconnects during long generations can leak scheduler capacity over time (relates to #17131).

## Fix

Added a small helper:

```go
func sendStreamValue(ctx context.Context, ch chan<- any, v any) bool {
	select {
	case ch <- v:
		return true
	case <-ctx.Done():
		return false
	}
}
```

`GenerateHandler`, `PushHandler`, and `handleNativeChat` now derive a cancellable context from `c.Request.Context()`, route their downstream calls (`Completion`, `Chat`, pull progress callback) through it, and send every value through `sendStreamValue`, cancelling as soon as a send fails. That way a blocked send unblocks the moment the client disconnects, and the cancellation also signals the underlying long-running call to stop instead of continuing to do wasted work.

`ChatHandler`s legacy retry loop is intentionally left untouched — it already creates its own per-iteration `ctx`/`cancel()` pair that doubles as internal control flow for restarting the request with structured-outputs constraints applied, and changing its disconnect handling safely needs a closer look at that interaction on its own.

## Testing

- `go build ./server/...`, `go vet ./server/...`, `gofmt -l` clean
- Existing `TestGenerate*`, `TestPush*`, `TestChat*` tests in `server/` still pass
- Added `TestGenerateStreamDisconnectDoesNotLeakGoroutine`: drives `GenerateHandler` through a mock completion function that keeps emitting chunks after a simulated client disconnect (closing both `CloseNotify` and the request context together, matching how a real `net/http` connection teardown cancels both), and asserts the completion call still returns rather than hanging. Confirmed this test fails without the `sendStreamValue` change and passes with it.

## Duplicate check

Searched open/closed PRs and issues for related goroutine-leak/streaming-disconnect reports before opening this; did not find an existing PR addressing this specific code path.