### PR TITLE
discover: filter ROCm devices when visibility environment variables set to -1

### DIFF
--- a/discover/amd.go
+++ b/discover/amd.go
@@ -475,6 +475,43 @@ func filterUnsupportedROCmDevices(devices []ml.DeviceInfo, libDirs []string) []m
 	return filtered
 }
 
+// filterInvisibleROCmDevices removes ROCm devices when visibility environment variables
+// are set to -1, which per documentation should "ignore the GPUs and force CPU usage" for
+// the ROCm backend. Checks ROCR_VISIBLE_DEVICES (Linux), HIP_VISIBLE_DEVICES, and
+// GPU_DEVICE_ORDINAL (Windows fallback).
+func filterInvisibleROCmDevices(devices []ml.DeviceInfo, extraEnvs map[string]string) []ml.DeviceInfo {
+	// Check visibility variables in order of preference for ROCm
+	visibilityVars := []string{"ROCR_VISIBLE_DEVICES", "HIP_VISIBLE_DEVICES", "GPU_DEVICE_ORDINAL"}
+	disableROCm := false
+
+	for _, envVar := range visibilityVars {
+		value := extraEnvs[envVar]
+		if value == "" {
+			value = os.Getenv(envVar)
+		}
+		if strings.TrimSpace(value) == "-1" {
+			disableROCm = true
+			slog.Debug("ROCm devices disabled via environment variable", "variable", envVar)
+			break
+		}
+	}
+
+	if !disableROCm {
+		return devices
+	}
+
+	var filtered []ml.DeviceInfo
+	for _, dev := range devices {
+		if dev.Library == "ROCm" {
+			slog.Debug("filtering ROCm device due to visibility environment variable set to -1",
+				"device", dev.Name, "id", dev.ID, "pci_id", dev.PCIID)
+			continue
+		}
+		filtered = append(filtered, dev)
+	}
+	return filtered
+}
+
 func detectOldAMDDriverWindows() {
 	if runtime.GOOS != "windows" {
 		return

--- a/discover/amd_test.go
+++ b/discover/amd_test.go
@@ -287,3 +287,96 @@ func writeFakeSysfsFile(t *testing.T, dir, name, content string) {
 		t.Fatal(err)
 	}
 }
+
+func TestFilterInvisibleROCmDevices(t *testing.T) {
+	tests := []struct {
+		name      string
+		devices   []ml.DeviceInfo
+		extraEnvs map[string]string
+		setEnv    map[string]string
+		want      int
+	}{
+		{
+			name: "no filtering when ROCR_VISIBLE_DEVICES not set",
+			devices: []ml.DeviceInfo{
+				{DeviceID: ml.DeviceID{ID: "0", Library: "ROCm"}, Name: "ROCm0"},
+				{DeviceID: ml.DeviceID{ID: "0", Library: "CUDA"}, Name: "CUDA0"},
+			},
+			want: 2,
+		},
+		{
+			name: "filter ROCm when ROCR_VISIBLE_DEVICES=-1",
+			devices: []ml.DeviceInfo{
+				{DeviceID: ml.DeviceID{ID: "0", Library: "ROCm"}, Name: "ROCm0"},
+				{DeviceID: ml.DeviceID{ID: "0", Library: "CUDA"}, Name: "CUDA0"},
+			},
+			extraEnvs: map[string]string{"ROCR_VISIBLE_DEVICES": "-1"},
+			want:      1,
+		},
+		{
+			name: "filter ROCm when HIP_VISIBLE_DEVICES=-1",
+			devices: []ml.DeviceInfo{
+				{DeviceID: ml.DeviceID{ID: "0", Library: "ROCm"}, Name: "ROCm0"},
+				{DeviceID: ml.DeviceID{ID: "0", Library: "CUDA"}, Name: "CUDA0"},
+			},
+			extraEnvs: map[string]string{"HIP_VISIBLE_DEVICES": "-1"},
+			want:      1,
+		},
+		{
+			name: "filter ROCm when GPU_DEVICE_ORDINAL=-1",
+			devices: []ml.DeviceInfo{
+				{DeviceID: ml.DeviceID{ID: "0", Library: "ROCm"}, Name: "ROCm0"},
+				{DeviceID: ml.DeviceID{ID: "0", Library: "CUDA"}, Name: "CUDA0"},
+			},
+			extraEnvs: map[string]string{"GPU_DEVICE_ORDINAL": "-1"},
+			want:      1,
+		},
+		{
+			name: "filter ROCm from process environment",
+			devices: []ml.DeviceInfo{
+				{DeviceID: ml.DeviceID{ID: "0", Library: "ROCm"}, Name: "ROCm0"},
+				{DeviceID: ml.DeviceID{ID: "0", Library: "CUDA"}, Name: "CUDA0"},
+			},
+			setEnv: map[string]string{"ROCR_VISIBLE_DEVICES": "-1"},
+			want:   1,
+		},
+		{
+			name: "no filtering when visibility set to valid device",
+			devices: []ml.DeviceInfo{
+				{DeviceID: ml.DeviceID{ID: "0", Library: "ROCm"}, Name: "ROCm0"},
+				{DeviceID: ml.DeviceID{ID: "0", Library: "CUDA"}, Name: "CUDA0"},
+			},
+			extraEnvs: map[string]string{"ROCR_VISIBLE_DEVICES": "0"},
+			want:      2,
+		},
+		{
+			name: "filter multiple ROCm devices",
+			devices: []ml.DeviceInfo{
+				{DeviceID: ml.DeviceID{ID: "0", Library: "ROCm"}, Name: "ROCm0"},
+				{DeviceID: ml.DeviceID{ID: "1", Library: "ROCm"}, Name: "ROCm1"},
+				{DeviceID: ml.DeviceID{ID: "0", Library: "CUDA"}, Name: "CUDA0"},
+			},
+			extraEnvs: map[string]string{"ROCR_VISIBLE_DEVICES": "-1"},
+			want:      1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.setEnv {
+				t.Setenv(k, v)
+			}
+
+			filtered := filterInvisibleROCmDevices(tt.devices, tt.extraEnvs)
+			if len(filtered) != tt.want {
+				t.Fatalf("got %d devices, want %d", len(filtered), tt.want)
+			}
+
+			for _, dev := range filtered {
+				if dev.Library == "ROCm" && tt.want < len(tt.devices) {
+					t.Fatalf("ROCm device %s should have been filtered", dev.Name)
+				}
+			}
+		})
+	}
+}

--- a/discover/llama_server.go
+++ b/discover/llama_server.go
@@ -513,7 +513,9 @@ func llamaServerBootstrapDevicesWithStatus(ctx context.Context, ollamaLibDirs []
 		return devices, status, nil
 	}
 
-	return filterUnsupportedROCmDevices(devices, ollamaLibDirs), status, nil
+	devices = filterUnsupportedROCmDevices(devices, ollamaLibDirs)
+	devices = filterInvisibleROCmDevices(devices, extraEnvs)
+	return devices, status, nil
 }
 
 // Ensure stderrPipe is fully consumed to avoid blocking


### PR DESCRIPTION
On mixed-GPU systems with both NVIDIA and AMD hardware, setting `ROCR_VISIBLE_DEVICES=-1` (or `HIP_VISIBLE_DEVICES=-1`, `GPU_DEVICE_ORDINAL=-1`) to disable ROCm devices was not being respected during GPU discovery and scheduling. The environment variable was correctly read into the server config and passed to llama-server, but the ROCm devices were not filtered out from the scheduler's candidate list, allowing them to be selected even when explicitly disabled.

The root cause was in `llamaServerBootstrapDevicesWithStatus` in `discover/llama_server.go`. After llama-server returned discovered devices, Ollama would filter out unsupported ROCm devices (those without matching rocblas kernels) but did not check whether ROCm devices should be excluded entirely based on visibility environment variables. The fix adds a new filtering step via `filterInvisibleROCmDevices` in `discover/amd.go` that removes all ROCm devices when any of the ROCm visibility variables (`ROCR_VISIBLE_DEVICES`, `HIP_VISIBLE_DEVICES`, or `GPU_DEVICE_ORDINAL`) are set to `-1`. This allows the remaining healthy GPU backend (CUDA in the reported case) to be selected for inference as documented.

Fixes #17136
