### PR TITLE
docs: add WebBrain to integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ console.log(response.message.content);
 - [Vibe](https://github.com/thewh1teagle/vibe) - Transcribe and analyze meetings
 - [Page Assist](https://github.com/n4ze3m/page-assist) - Chrome extension for AI-powered browsing
 - [NativeMind](https://github.com/NativeMindBrowser/NativeMindExtension) - Private, on-device browser AI assistant
+- [WebBrain](https://github.com/webbrain-one/webbrain) - Browser AI agent for automating web tasks
 - [Ollama Fortress](https://github.com/ParisNeo/ollama_proxy_server) - Security proxy for Ollama
 - [1Panel](https://github.com/1Panel-dev/1Panel/) - Web-based Linux server management
 - [Writeopia](https://github.com/Writeopia/Writeopia) - Text editor with Ollama integration


### PR DESCRIPTION
## Summary

- add WebBrain to the README's Productivity & Apps section
- link to the WebBrain GitHub repository

## Impact

Ollama users can discover WebBrain as a browser AI agent for automating web tasks.

## Validation

- `git diff --check`
