### PR TITLE
openai: map reasoning_effort "minimal" to "low"

### DIFF
--- a/openai/openai.go
+++ b/openai/openai.go
@@ -636,6 +636,12 @@ func FromChatRequest(r ChatCompletionRequest) (*api.ChatRequest, error) {
 		effort = *r.ReasoningEffort
 	}
 
+	// OpenAI's "minimal" reasoning effort has no direct ollama think level;
+	// "low" is the closest supported level (least thinking without disabling it).
+	if effort == "minimal" {
+		effort = "low"
+	}
+
 	if effort != "" {
 		if !slices.Contains([]string{"high", "medium", "low", "max", "none"}, effort) {
 			return nil, fmt.Errorf("invalid reasoning value: '%s' (must be \"high\", \"medium\", \"low\", \"max\", or \"none\")", effort)

--- a/openai/openai_test.go
+++ b/openai/openai_test.go
@@ -68,6 +68,7 @@ func TestFromChatRequest_ReasoningEffort(t *testing.T) {
 		{name: "high", effort: effort("high"), want: "high"},
 		{name: "medium", effort: effort("medium"), want: "medium"},
 		{name: "low", effort: effort("low"), want: "low"},
+		{name: "minimal maps to low", effort: effort("minimal"), want: "low"},
 		{name: "max", effort: effort("max"), want: "max"},
 		{name: "none disables", effort: effort("none"), want: false},
 		{name: "invalid", effort: effort("extreme"), wantErr: true},


### PR DESCRIPTION
The `/v1/chat/completions` OpenAI-compatible endpoint rejects `reasoning_effort: "minimal"` with a 400, even though `"minimal"` is a valid value in the OpenAI API. Only `high`, `medium`, `low`, `max`, and `none` are accepted:

    invalid reasoning value: 'minimal' (must be "high", "medium", "low", "max", or "none")

The rejection is in the request translation layer (`openai/openai.go`, `FromChatRequest`), where `effort` is validated against `{high, medium, low, max, none}`. It returns the 400 before any inference runs, so no model or GPU is involved. The `reasoning: {"effort": "minimal"}` form fails identically, since both share the same code path.

ollama has no distinct "minimal" think level, but `low` is the natural equivalent (the least thinking without disabling it entirely), so this normalizes `minimal` to `low` before validation. Mapping it server-side rather than telling users to send `low` matters because the value is often set by SDKs, agent frameworks, or shared configs that target the OpenAI API generically — those clients cannot rewrite the field per-backend.

Added a `minimal` case to the existing `TestFromChatRequest_ReasoningEffort` table.