### PR TITLE
server: allow parallel requests for qwen35 / qwen35moe now that the upstream llama.cpp crash is fixed

### DIFF
--- a/server/sched.go
+++ b/server/sched.go
@@ -510,7 +510,7 @@ func (s *Scheduler) load(req *LlmRequest, systemInfo ml.SystemInfo, gpus []ml.De
 
 	// Some architectures are not safe with num_parallel > 1.
 	// ref: https://github.com/ollama/ollama/issues/4165
-	if slices.Contains([]string{"mllama", "qwen3vl", "qwen3vlmoe", "qwen35", "qwen35moe", "qwen3next", "lfm2", "lfm2moe", "nemotron_h", "nemotron_h_moe", "nemotron_h_omni"}, req.model.Config.ModelFamily) && numParallel != 1 {
+	if slices.Contains([]string{"mllama", "qwen3vl", "qwen3vlmoe", "qwen3next", "lfm2", "lfm2moe", "nemotron_h", "nemotron_h_moe", "nemotron_h_omni"}, req.model.Config.ModelFamily) && numParallel != 1 {
 		numParallel = 1
 		slog.Warn("model architecture does not currently support parallel requests", "architecture", req.model.Config.ModelFamily)
 	}


### PR DESCRIPTION
## Summary

`qwen35` and `qwen35moe` are currently forced to `numParallel = 1` by a hardcoded architecture blocklist in `server/sched.go`, added as a safety measure against a llama.cpp crash under parallel load on this hybrid architecture. That crash was fixed upstream in llama.cpp on 2026-03-08 (`ggml-org/llama.cpp#20232`, resolving `ggml-org/llama.cpp#20222`, "Chunk not found" under parallel load). Ollama's vendored llama.cpp (`LLAMA_CPP_VERSION b9888`, matching the `v0.31.2` tag) already includes this fix, but the blocklist entry was never removed to match.

This PR removes `qwen35` and `qwen35moe` from the blocklist so `OLLAMA_NUM_PARALLEL` becomes functional for these architectures again, as it already is for other non-blocklisted architectures.

Closes #4165
Closes #14510
Closes #14621
Closes #14638

## The change

```diff
--- a/server/sched.go
+++ b/server/sched.go
@@ -510,7 +510,7 @@ func (s *Scheduler) load(req *LlmRequest, systemInfo ml.SystemInfo, gpus []ml.De

 	// Some architectures are not safe with num_parallel > 1.
 	// ref: https://github.com/ollama/ollama/issues/4165
-	if slices.Contains([]string{"mllama", "qwen3vl", "qwen3vlmoe", "qwen35", "qwen35moe", "qwen3next", "lfm2", "lfm2moe", "nemotron_h", "nemotron_h_moe", "nemotron_h_omni"}, req.model.Config.ModelFamily) && numParallel != 1 {
+	if slices.Contains([]string{"mllama", "qwen3vl", "qwen3vlmoe", "qwen3next", "lfm2", "lfm2moe", "nemotron_h", "nemotron_h_moe", "nemotron_h_omni"}, req.model.Config.ModelFamily) && numParallel != 1 {
 		numParallel = 1
 		slog.Warn("model architecture does not currently support parallel requests", "architecture", req.model.Config.ModelFamily)
 	}
```

One line. No other architectures in the blocklist are touched — `qwen3vl`/`qwen3vlmoe`/`qwen3next`/`lfm2`/`lfm2moe`/`nemotron_h*` are unrelated architectures with their own (unverified, out of scope here) parallel-safety status and are left blocked.

## Why this is safe

The blocklist comment cites `#4165`, which traces to the llama.cpp hybrid/recurrent-architecture crash (`ggml-org/llama.cpp#20222`). That crash was root-caused and fixed in llama.cpp PR `#20232` (merged 2026-03-08). Ollama's `LLAMA_CPP_VERSION` file already pins `b9888`, the same llama.cpp version as the `v0.31.2` release tag — i.e. the fix is already vendored in current Ollama builds. The blocklist is now stale safety debt, not an active guard against a live bug.

## Testing performed

Built and ran this exact patch on real hardware (not simulated) — a single RTX 3060 (12GB VRAM), CUDA v13 backend, based on commit `82f905c` (2026-07-09, `LLAMA_CPP_VERSION b9888`). Confirmed via GitHub's compare API that this base commit differs from the `v0.31.2` tag only in CLI-tooling code (`cmd/`, `agent/`, `x/create/`), none of it touching the model-serving path — so results should generalize to `v0.31.2` and later.

**Context-size sweep** (three separate rebuild-and-reload cycles, each independently validated):
| `num_ctx` | Result |
|---|---|
| 98304 (98K, 3x parallel) | Loads; `n_seq_max=3` confirmed in logs. Vision-projector-carrying variant needed `LLAMA_ARG_MMPROJ_OFFLOAD=false` to avoid an OOM-then-CPU-fallback crash cycle on this 12GB card at this KV-cache size — see note below, not a parallel-support bug. |
| 65536 (64K, 3x parallel) | Loads cleanly, no OOM. |
| 73728 (72K, 3x parallel) | Loads cleanly; final config used in production (see below). |

**Concurrency correctness**, run at each context size above:
- Fired short-answer prompts (single-fact questions) concurrently against the same loaded model instance — confirmed distinct, correct, non-interleaved answers per request.
- Fired a long-form (~200-word) generation concurrently alongside short-answer requests — confirmed the long-running request did not block or corrupt the short ones, and vice versa.
- Repeated slot reuse across many sequential concurrent-request rounds (not just one load) — no crash, no "Chunk not found" error, no degraded output observed at any point.

**Production soak**: rolled out to a real, actively-used Ollama deployment (agent-facing, not a toy benchmark) running `OLLAMA_NUM_PARALLEL=3` against a 9B-parameter `qwen35`-family model at `num_ctx=73728`. Post-rollout verification: `n_seq_max=3` confirmed live in container logs, VRAM steady at 9,849/12,288 MiB (~2.4GB headroom, no leak), a genuine 3-way concurrent request returned three correct, distinct answers in 2.477s total with zero errors, and normal agentic traffic through the full pipeline continued to succeed cleanly afterward.

## Known related issue (separate, not blocking this PR)

On this specific card/config, a `qwen35` variant carrying a vision projector (~1GB) could not fit the projector on GPU simultaneously with a 3x-parallel KV-cache at large context sizes, causing a `cudaMalloc` OOM on load (Ollama's existing retry logic auto-recovered by placing the projector on CPU, but with an unnecessary crash+retry cycle each time). This is a VRAM-budgeting issue orthogonal to the parallel-request restriction being lifted here, and is already avoidable today via the existing `LLAMA_ARG_MMPROJ_OFFLOAD=false` env var. Flagging in case it's useful context, not proposing a code change for it in this PR.

## Trade-offs / scope

- This only re-enables parallelism for `qwen35`/`qwen35moe`. It does not touch `qwen3vl`/`qwen3vlmoe`/`qwen3next`/`lfm2`/`lfm2moe`/`nemotron_h*`, which remain blocked pending their own verification.
- Testing was performed on CUDA (RTX 3060, 12GB). Other backends (ROCm, Vulkan, CPU, Metal) were not part of this validation pass and may warrant their own confirmation before merge, though the change itself is backend-agnostic (a scheduler-level Go check, not a backend-specific code path).
