### PR TITLE
convert: harden safetensors header parsing against malformed input

### DIFF
--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -229,6 +229,17 @@ func generateSafetensorTestData(t *testing.T, tempDir string, tensorData map[str
 		t.Fatal(err)
 	}
 
+	// Append a data section large enough to cover every tensor's declared
+	// data_offsets so the fixture is a valid safetensors file (offsets must
+	// lie within the data section that follows the JSON header).
+	var dataLen int
+	for _, td := range tensorData {
+		if len(td.Offsets) == 2 && td.Offsets[1] > dataLen {
+			dataLen = td.Offsets[1]
+		}
+	}
+	buf.Write(make([]byte, dataLen))
+
 	fdata, err := os.Create(filepath.Join(tempDir, "model-00001-of-00001.safetensors"))
 	if err != nil {
 		t.Fatal(err)

--- a/convert/reader_safetensors.go
+++ b/convert/reader_safetensors.go
@@ -24,6 +24,28 @@ type safetensorMetadata struct {
 	Offsets []int64  `json:"data_offsets"`
 }
 
+// safetensorsMaxHeaderSize bounds the JSON header length prefix of a
+// safetensors file. The header is a metadata map that is fully buffered in
+// memory before parsing, so an unbounded length prefix from an untrusted file
+// would allow a single request to trigger an arbitrarily large allocation.
+const safetensorsMaxHeaderSize = 100 << 20 // 100 MiB
+
+// validSafetensorsOffsets reports whether a tensor's data_offsets slice is
+// well formed: exactly two entries describing a non-negative, non-inverted
+// region that lies within the file's data section (dataSize bytes). The
+// safetensors header is attacker-controlled when converting an uploaded model,
+// so these bounds must be checked before the offsets are used to size slices
+// or seek within the file.
+func validSafetensorsOffsets(offsets []int64, dataSize int64) error {
+	if len(offsets) != 2 {
+		return fmt.Errorf("expected 2 data_offsets, got %d", len(offsets))
+	}
+	if offsets[0] < 0 || offsets[1] < offsets[0] || offsets[1] > dataSize {
+		return fmt.Errorf("invalid data_offsets [%d %d] for data section of %d bytes", offsets[0], offsets[1], dataSize)
+	}
+	return nil
+}
+
 func parseSafetensors(fsys fs.FS, replacer *strings.Replacer, ps ...string) ([]Tensor, error) {
 	fp8Block, err := safetensorsFP8BlockSize(fsys)
 	if err != nil {
@@ -32,6 +54,12 @@ func parseSafetensors(fsys fs.FS, replacer *strings.Replacer, ps ...string) ([]T
 
 	var ts []Tensor
 	for _, p := range ps {
+		fi, err := fs.Stat(fsys, p)
+		if err != nil {
+			return nil, err
+		}
+		fileSize := fi.Size()
+
 		f, err := fsys.Open(p)
 		if err != nil {
 			return nil, err
@@ -42,6 +70,18 @@ func parseSafetensors(fsys fs.FS, replacer *strings.Replacer, ps ...string) ([]T
 		if err := binary.Read(f, binary.LittleEndian, &n); err != nil {
 			return nil, err
 		}
+
+		// n is read directly from the file and is used below to size an
+		// in-memory buffer, so it must be validated before use: reject
+		// negative, oversized, or out-of-file header lengths.
+		if n < 0 || n > safetensorsMaxHeaderSize || 8+n > fileSize {
+			return nil, fmt.Errorf("invalid safetensors header length %d for file of %d bytes", n, fileSize)
+		}
+
+		// dataSize is the number of bytes in the tensor data section that
+		// follows the 8-byte length prefix and the n-byte JSON header. All
+		// tensor data_offsets are relative to the start of this section.
+		dataSize := fileSize - 8 - n
 
 		b := bytes.NewBuffer(make([]byte, 0, n))
 		if _, err = io.CopyN(b, f, n); err != nil {
@@ -57,7 +97,7 @@ func parseSafetensors(fsys fs.FS, replacer *strings.Replacer, ps ...string) ([]T
 
 		names := make(map[string]struct{}, len(keys))
 
-		fp8Scales, err := collectSafetensorsFP8Scales(n, headers)
+		fp8Scales, err := collectSafetensorsFP8Scales(n, dataSize, headers)
 		if err != nil {
 			return nil, err
 		}
@@ -66,6 +106,10 @@ func parseSafetensors(fsys fs.FS, replacer *strings.Replacer, ps ...string) ([]T
 			if value := headers[key]; value.Type != "" {
 				if _, ok := fp8Scales.consumed[key]; ok {
 					continue
+				}
+
+				if err := validSafetensorsOffsets(value.Offsets, dataSize); err != nil {
+					return nil, fmt.Errorf("tensor %q: %w", key, err)
 				}
 
 				// Scalar tensors (e.g. clipped linear min/max) are 0-dim in safetensors.
@@ -286,7 +330,7 @@ type safetensorsFP8Scales struct {
 	consumed map[string]struct{}
 }
 
-func collectSafetensorsFP8Scales(n int64, headers map[string]safetensorMetadata) (safetensorsFP8Scales, error) {
+func collectSafetensorsFP8Scales(n, dataSize int64, headers map[string]safetensorMetadata) (safetensorsFP8Scales, error) {
 	scales := safetensorsFP8Scales{
 		byWeight: make(map[string]*safetensorScale),
 		consumed: make(map[string]struct{}),
@@ -306,6 +350,10 @@ func collectSafetensorsFP8Scales(n int64, headers map[string]safetensorMetadata)
 		}
 		if _, ok := scales.consumed[scaleKey]; ok {
 			return safetensorsFP8Scales{}, fmt.Errorf("fp8 scale companion %q is used by multiple tensors", scaleKey)
+		}
+
+		if err := validSafetensorsOffsets(scaleValue.Offsets, dataSize); err != nil {
+			return safetensorsFP8Scales{}, fmt.Errorf("fp8 scale companion %q: %w", scaleKey, err)
 		}
 
 		scales.byWeight[key] = &safetensorScale{

--- a/convert/reader_test.go
+++ b/convert/reader_test.go
@@ -449,6 +449,93 @@ func writeFP8BlockConfig(t *testing.T, dir string, rows, cols int) {
 	}
 }
 
+// writeRawSafetensors writes a safetensors file with an arbitrary JSON header
+// and no tensor data, allowing tests to exercise malformed headers.
+func writeRawSafetensors(t *testing.T, dir, header string) {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := binary.Write(&buf, binary.LittleEndian, int64(len(header))); err != nil {
+		t.Fatal(err)
+	}
+	buf.WriteString(header)
+	if err := os.WriteFile(filepath.Join(dir, "model-00001-of-00001.safetensors"), buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestParseSafetensorsRejectsMalformedHeader ensures a crafted safetensors
+// file yields an error instead of panicking. Model conversion runs on
+// attacker-controlled bytes (uploaded blobs referenced by /api/create) inside a
+// goroutine with no recover, so a panic here would crash the whole server.
+func TestParseSafetensorsRejectsMalformedHeader(t *testing.T) {
+	cases := []struct {
+		name   string
+		header string // if empty, raw bytes are written instead
+		raw    []byte
+		substr string
+	}{
+		{
+			name:   "empty data_offsets",
+			header: `{"t":{"dtype":"F32","shape":[1],"data_offsets":[]}}`,
+			substr: "data_offsets",
+		},
+		{
+			name:   "single data_offset",
+			header: `{"t":{"dtype":"F32","shape":[1],"data_offsets":[0]}}`,
+			substr: "data_offsets",
+		},
+		{
+			name:   "inverted data_offsets",
+			header: `{"t":{"dtype":"F32","shape":[1],"data_offsets":[100,0]}}`,
+			substr: "data_offsets",
+		},
+		{
+			name:   "negative data_offset",
+			header: `{"t":{"dtype":"F32","shape":[1],"data_offsets":[-8,0]}}`,
+			substr: "data_offsets",
+		},
+		{
+			name:   "offsets past end of data",
+			header: `{"t":{"dtype":"F32","shape":[1],"data_offsets":[0,999999]}}`,
+			substr: "data_offsets",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeRawSafetensors(t, dir, tc.header)
+			_, err := parseSafetensors(os.DirFS(dir), strings.NewReplacer(), "model-00001-of-00001.safetensors")
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.substr) {
+				t.Fatalf("expected error containing %q, got %v", tc.substr, err)
+			}
+		})
+	}
+}
+
+// TestParseSafetensorsRejectsOversizedHeaderLength ensures an out-of-range
+// header length prefix is rejected before it is used to size an in-memory
+// buffer, preventing a huge or negative allocation from a crafted file.
+func TestParseSafetensorsRejectsOversizedHeaderLength(t *testing.T) {
+	for _, n := range []int64{-1, 1 << 62, 0x7000000000000000} {
+		dir := t.TempDir()
+		var buf bytes.Buffer
+		if err := binary.Write(&buf, binary.LittleEndian, n); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "model-00001-of-00001.safetensors"), buf.Bytes(), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		_, err := parseSafetensors(os.DirFS(dir), strings.NewReplacer(), "model-00001-of-00001.safetensors")
+		if err == nil || !strings.Contains(err.Error(), "invalid safetensors header length") {
+			t.Fatalf("n=%d: expected invalid header length error, got %v", n, err)
+		}
+	}
+}
+
 func TestSafetensorKind(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
Fixes #17148

### Summary

The safetensors reader (`convert/reader_safetensors.go`) trusts several fields that come directly from the file contents during model conversion, unlike the GGUF readers (`fs/ggml`, `fs/gguf`) which bound every length and offset. A malformed header therefore panics instead of returning an error.

This PR adds the missing bounds checks:

- **Header length prefix**: validate the leading `int64` length is `>= 0`, `<=` a fixed cap (100 MiB), and within the file before it is used as the capacity of an in-memory buffer. Previously a negative or huge value caused a `makeslice` panic / oversized allocation.
- **`data_offsets`**: a new `validSafetensorsOffsets` helper requires exactly two entries describing a non-negative, non-inverted region within the data section. Previously `Offsets[0]`/`Offsets[1]` were indexed with no length check (`index out of range` on an empty/short array), and inverted offsets produced a negative tensor `size` that panicked in the `make([]T, size/n)` calls in `WriteTo`. Applied to both the tensor path and the FP8-scale companion path.

Since conversion runs in a goroutine without `recover`, these panics are not contained, so turning them into errors is the right behavior.

### Testing

- `go test ./convert/` — passes.
- New `TestParseSafetensorsRejectsMalformedHeader` (empty / single / inverted / negative / out-of-range offsets) and `TestParseSafetensorsRejectsOversizedHeaderLength` (negative and huge length prefixes) assert an error is returned instead of a panic.
- The shared `generateSafetensorTestData` fixture now writes a real data section so its declared offsets are valid (they previously pointed into a zero-length data region).

🤖 Generated with [Claude Code](https://claude.com/claude-code)