### PR TITLE
launch: keep Claude Code channels available

### DIFF
--- a/cmd/launch/claude.go
+++ b/cmd/launch/claude.go
@@ -60,8 +60,23 @@ func (c *Claude) Run(model string, _ []LaunchModel, args []string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	cmd.Env = append(os.Environ(), c.envVars(model)...)
+	cmd.Env = c.launchEnv(model, os.Environ())
 	return cmd.Run()
+}
+
+func (c *Claude) launchEnv(model string, inherited []string) []string {
+	const disabledTraffic = "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"
+
+	overrides := c.envVars(model)
+	env := make([]string, 0, len(inherited)+len(overrides))
+	for _, entry := range inherited {
+		key, _, _ := strings.Cut(entry, "=")
+		if strings.EqualFold(key, disabledTraffic) {
+			continue
+		}
+		env = append(env, entry)
+	}
+	return append(env, overrides...)
 }
 
 func (c *Claude) envVars(model string) []string {
@@ -74,7 +89,6 @@ func (c *Claude) envVars(model string) []string {
 		"DISABLE_ERROR_REPORTING=1",
 		"DISABLE_FEEDBACK_COMMAND=1",
 		"CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY=1",
-		"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1",
 	}
 
 	env = append(env, c.modelEnvVars(model)...)

--- a/cmd/launch/claude_test.go
+++ b/cmd/launch/claude_test.go
@@ -348,23 +348,55 @@ func TestClaudeEnvVars(t *testing.T) {
 
 	got := envMap(c.envVars("llama3.2"))
 	for key, want := range map[string]string{
-		"ANTHROPIC_BASE_URL":                       envconfig.Host().String(),
-		"ANTHROPIC_API_KEY":                        "",
-		"ANTHROPIC_AUTH_TOKEN":                     "ollama",
-		"CLAUDE_CODE_ATTRIBUTION_HEADER":           "0",
-		"DISABLE_TELEMETRY":                        "1",
-		"DISABLE_ERROR_REPORTING":                  "1",
-		"DISABLE_FEEDBACK_COMMAND":                 "1",
-		"CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY":      "1",
-		"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
-		"ANTHROPIC_DEFAULT_OPUS_MODEL":             "llama3.2",
-		"ANTHROPIC_DEFAULT_SONNET_MODEL":           "llama3.2",
-		"ANTHROPIC_DEFAULT_HAIKU_MODEL":            "llama3.2",
-		"CLAUDE_CODE_SUBAGENT_MODEL":               "llama3.2",
+		"ANTHROPIC_BASE_URL":                  envconfig.Host().String(),
+		"ANTHROPIC_API_KEY":                   "",
+		"ANTHROPIC_AUTH_TOKEN":                "ollama",
+		"CLAUDE_CODE_ATTRIBUTION_HEADER":      "0",
+		"DISABLE_TELEMETRY":                   "1",
+		"DISABLE_ERROR_REPORTING":             "1",
+		"DISABLE_FEEDBACK_COMMAND":            "1",
+		"CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY": "1",
+		"ANTHROPIC_DEFAULT_OPUS_MODEL":        "llama3.2",
+		"ANTHROPIC_DEFAULT_SONNET_MODEL":      "llama3.2",
+		"ANTHROPIC_DEFAULT_HAIKU_MODEL":       "llama3.2",
+		"CLAUDE_CODE_SUBAGENT_MODEL":          "llama3.2",
 	} {
 		if got[key] != want {
 			t.Errorf("%s = %q, want %q", key, got[key], want)
 		}
+	}
+
+	if _, ok := got["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"]; ok {
+		t.Error("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC must remain unset so Claude Code channels stay available")
+	}
+}
+
+func TestClaudeLaunchEnv(t *testing.T) {
+	c := &Claude{}
+	inherited := []string{
+		"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1",
+		"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=0",
+		"claude_code_disable_nonessential_traffic=1",
+		"Claude_Code_Disable_Nonessential_Traffic=1",
+		"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC_BACKUP=1",
+		"UNRELATED=value",
+	}
+
+	got := c.launchEnv("llama3.2", inherited)
+	for _, entry := range got {
+		key, _, _ := strings.Cut(entry, "=")
+		if strings.EqualFold(key, "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC") {
+			t.Fatalf("launch environment inherited %q", entry)
+		}
+	}
+	if !slices.Contains(got, "UNRELATED=value") {
+		t.Error("launch environment did not preserve unrelated inherited variable")
+	}
+	if !slices.Contains(got, "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC_BACKUP=1") {
+		t.Error("launch environment removed similarly named inherited variable")
+	}
+	if !slices.Contains(got, "ANTHROPIC_AUTH_TOKEN=ollama") {
+		t.Error("launch environment did not include Claude overrides")
 	}
 }
 


### PR DESCRIPTION
## Summary

- stop setting or inheriting `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` when launching Claude Code
- retain the narrower telemetry, error-reporting, and feedback opt-outs
- add regression coverage for Ollama-added and inherited launch environment variables, including Windows-style case variants

## Root cause

`ollama launch claude` began setting `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1` in #17061. Claude Code reports document that this variable disables GrowthBook feature-flag evaluation, causing the Channels gate to default off and producing `Channels are not currently available`:

- https://github.com/anthropics/claude-code/issues/45918
- https://github.com/anthropics/claude-code/issues/38450

The #17132 reporter first confirmed that changing Ollama's base URL from `127.0.0.1` to `localhost` does not change the failure. They then added `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1` to their otherwise working direct Claude launch and reproduced the exact same unavailable Channels state, isolating this variable as the regression: https://github.com/ollama/ollama/issues/17132#issuecomment-4966147890

This change removes only the broad nonessential-traffic opt-out and filters that key case-insensitively from the inherited process environment so an existing shell export cannot reintroduce the regression on Windows or Unix-like systems. The explicit telemetry, error-reporting, feedback-command, and feedback-survey opt-outs remain in place.

## Validation

- `go test ./cmd/launch -run 'TestClaude(LaunchEnv|EnvVars|Args|Integration)$' -count=1`
- `go test ./cmd/launch -count=1`
- `go vet ./cmd/launch`
- `git diff --check origin/main...HEAD`
- reporter reproduced the exact Channels failure by adding `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1` to their working direct launch

Fixes #17132
