### PR TITLE
docs: clarify desktop update check in FAQ

### DIFF
--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -158,7 +158,11 @@ docker run -d -e HTTPS_PROXY=https://my.proxy.example.com -p 11434:11434 ollama-
 
 ## Does Ollama send my prompts and answers back to ollama.com?
 
-Ollama runs locally. We don't see your prompts or data when you run locally. When using cloud-hosted models, we process your prompts and responses to provide the service but do not store or log that content and never train on it. We collect basic account info and limited usage metadata to provide the service that does not include prompt or response content. We don't sell your data. You can delete your account anytime.
+Ollama runs locally. We don't see your prompts or data when you run locally.
+
+The desktop application periodically checks for updates by contacting `https://ollama.com/api/update`. These requests include the application version, operating system, architecture, and are authenticated using the installation's key, which serves as a stable per-installation identifier.
+
+When using cloud-hosted models, we process your prompts and responses to provide the service but do not store or log that content and never train on it. We collect basic account info and limited usage metadata to provide the service that does not include prompt or response content. We don't sell your data. You can delete your account anytime.
 
 ## How do I disable Ollama's cloud features?
 

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -160,7 +160,7 @@ docker run -d -e HTTPS_PROXY=https://my.proxy.example.com -p 11434:11434 ollama-
 
 Ollama runs locally. We don't see your prompts or data when you run locally.
 
-The desktop application periodically checks for updates by contacting `https://ollama.com/api/update`. These requests include the application version, operating system, architecture, and are authenticated using the installation's key, which serves as a stable per-installation identifier.
+The desktop application periodically checks for updates by contacting `https://ollama.com/api/update`. These requests include the application version, operating system, architecture, and are authenticated using the installation's key. Update checks can be disabled in the desktop application's Settings.
 
 When using cloud-hosted models, we process your prompts and responses to provide the service but do not store or log that content and never train on it. We collect basic account info and limited usage metadata to provide the service that does not include prompt or response content. We don't sell your data. You can delete your account anytime.
 


### PR DESCRIPTION
## Summary

This updates the FAQ to clarify that the desktop application periodically checks for updates and that update requests are authenticated using the installation's key.

Closes #17155