### PR TITLE
api: expose default context length in status

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -865,7 +865,8 @@ type CloudStatus struct {
 
 // StatusResponse is the response from [Client.CloudStatusExperimental].
 type StatusResponse struct {
-	Cloud CloudStatus `json:"cloud"`
+	Cloud         CloudStatus `json:"cloud"`
+	ContextLength int         `json:"context_length,omitempty"`
 }
 
 // WebSearchRequest is the request for [Client.WebSearchExperimental].

--- a/server/routes.go
+++ b/server/routes.go
@@ -2141,11 +2141,16 @@ func streamResponse(c *gin.Context, ch chan any) {
 
 func (s *Server) StatusHandler(c *gin.Context) {
 	disabled, source := internalcloud.Status()
+	contextLength := int(envconfig.ContextLength())
+	if contextLength == 0 {
+		contextLength = s.defaultNumCtx
+	}
 	c.JSON(http.StatusOK, api.StatusResponse{
 		Cloud: api.CloudStatus{
 			Disabled: disabled,
 			Source:   source,
 		},
+		ContextLength: contextLength,
 	})
 }
 

--- a/server/routes_cloud_test.go
+++ b/server/routes_cloud_test.go
@@ -44,6 +44,64 @@ func TestStatusHandler(t *testing.T) {
 	}
 }
 
+func TestStatusHandlerContextLength(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setTestHome(t, t.TempDir())
+
+	tests := []struct {
+		name           string
+		envContextLen  string
+		defaultNumCtx  int
+		wantContextLen int
+	}{
+		{
+			name:           "environment context length wins",
+			envContextLen:  "8192",
+			defaultNumCtx:  32768,
+			wantContextLen: 8192,
+		},
+		{
+			name:           "server default context length is used when environment is unset",
+			defaultNumCtx:  32768,
+			wantContextLen: 32768,
+		},
+		{
+			name: "context length is omitted when unavailable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("OLLAMA_CONTEXT_LENGTH", tt.envContextLen)
+
+			s := Server{defaultNumCtx: tt.defaultNumCtx}
+			w := createRequest(t, s.StatusHandler, nil)
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected status 200, got %d", w.Code)
+			}
+
+			var body map[string]any
+			if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+				t.Fatal(err)
+			}
+
+			got, ok := body["context_length"]
+			if tt.wantContextLen == 0 {
+				if ok {
+					t.Fatalf("context_length = %v, want omitted", got)
+				}
+				return
+			}
+			if !ok {
+				t.Fatal("context_length is missing")
+			}
+			if got != float64(tt.wantContextLen) {
+				t.Fatalf("context_length = %v, want %d", got, tt.wantContextLen)
+			}
+		})
+	}
+}
+
 func TestCloudDisabledBlocksRemoteOperations(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	setTestHome(t, t.TempDir())


### PR DESCRIPTION
## Summary

Expose the configured default context length through `GET /api/status` before any model is loaded.

`context_length` uses `OLLAMA_CONTEXT_LENGTH` when it is set; otherwise it reports the server's computed default. It is omitted when no value is known, preserving the prior response shape in that case.

## Scope

Extracted only the API-status context-length material from #17058. This intentionally excludes all `ollama launch`, Claude, OpenCode, UI, model rendering, integration, and configuration changes.

## Validation

- `go test ./server -count=1`
- `go test ./api -count=1`
- Handler-level JSON checks for environment override, server-default fallback, and zero-value omission.