### PR TITLE
server: centralize backend load planning

### DIFF
--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -78,9 +78,6 @@ const (
 )
 
 const (
-	llamaArgFitTargetEnv = "LLAMA_ARG_FIT_TARGET"
-	bytesPerMiB          = 1 << 20
-
 	// mmprojOffloadHeadroom leaves 1 GiB for backend buffers beyond projector weights.
 	mmprojOffloadHeadroom = 1 << 30
 )
@@ -428,7 +425,7 @@ func startLlamaServer(launch llamaServerLaunchConfig, out io.Writer) (cmd *exec.
 		cmd.Stderr = out
 	}
 	cmd.SysProcAttr = LlamaServerSysProcAttr
-	SetupLlamaServerCommandEnv(cmd, exe, launch.gpuLibs, launch.extraEnvsForStart())
+	SetupLlamaServerCommandEnv(cmd, exe, launch.gpuLibs, launch.extraEnvs)
 
 	slog.Info("starting llama-server", "cmd", cmd)
 	slog.Debug("subprocess", "", filteredEnv(cmd.Env))
@@ -673,48 +670,8 @@ func shouldDisableMMProjOffload(opts api.Options, gpus []ml.DeviceInfo, modelLay
 	return false, ""
 }
 
-func (launch llamaServerLaunchConfig) extraEnvsForStart() map[string]string {
-	pad, ok := launch.mmprojFitTargetMiB()
-	if !ok {
-		return launch.extraEnvs
-	}
-
-	if existing, ok := launch.extraEnvs[llamaArgFitTargetEnv]; ok {
-		existingTarget, err := strconv.ParseUint(existing, 10, 64)
-		if err != nil {
-			slog.Warn("invalid llama-server fit target", "env", llamaArgFitTargetEnv, "value", existing, "error", err)
-			return launch.extraEnvs
-		}
-
-		envs := cloneStringMap(launch.extraEnvs)
-		envs[llamaArgFitTargetEnv] = strconv.FormatUint(existingTarget+pad, 10)
-		return envs
-	}
-
-	if _, ok := os.LookupEnv(llamaArgFitTargetEnv); ok {
-		// Preserve an inherited user override. SetupLlamaServerCommandEnv
-		// will pass it through unless extraEnvs overrides it.
-		return launch.extraEnvs
-	}
-
-	envs := cloneStringMap(launch.extraEnvs)
-	envs[llamaArgFitTargetEnv] = strconv.FormatUint(pad, 10)
-	return envs
-}
-
-func (launch llamaServerLaunchConfig) mmprojFitTargetMiB() (uint64, bool) {
-	if len(launch.projectors) == 0 || launch.mmprojMemory == 0 {
-		return 0, false
-	}
-	if disable, _ := launch.mmprojOffloadDisabled(); disable {
-		return 0, false
-	}
-
-	requiredMemory := launch.mmprojMemory + mmprojOffloadHeadroom
-	return (requiredMemory + bytesPerMiB - 1) / bytesPerMiB, true
-}
-
-// mmprojMemoryRequirement is a stopgap until fit accounts for mmproj memory directly.
+// mmprojMemoryRequirement estimates whether projector GPU offload is worth
+// attempting. llama-server's fit pass accounts for mmproj memory directly.
 func mmprojMemoryRequirement(modelPath string, f *ggml.GGML, projectors []string) (uint64, error) {
 	if len(projectors) == 0 {
 		return 0, nil
@@ -875,11 +832,14 @@ func NewLlamaServerRunner(
 
 	mediaMarker := newLlamaServerMediaMarker()
 	extraEnvs := ml.GetDevicesEnv(gpus)
-	serverEnvs := make(map[string]string, len(extraEnvs)+1)
+	serverEnvs := make(map[string]string, len(extraEnvs)+2)
 	for k, v := range extraEnvs {
 		serverEnvs[k] = v
 	}
 	serverEnvs["LLAMA_MEDIA_MARKER"] = mediaMarker
+	if config.FitTargetMiB > 0 {
+		serverEnvs[llamaArgFitTargetEnv] = strconv.FormatUint(config.FitTargetMiB, 10)
+	}
 
 	launch := llamaServerLaunchConfig{
 		modelPath:    modelPath,
@@ -1093,6 +1053,16 @@ func (s *llamaServerRunner) hasParsedVRAM() bool {
 	defer s.memoryMu.RUnlock()
 
 	return len(s.vramByDevice) > 0
+}
+
+// LayerOffloadStatus returns the final model-layer placement parsed from
+// llama-server logs. overflow reports layers selected for GPU by fit that still
+// overflowed to CPU.
+func (s *llamaServerRunner) LayerOffloadStatus() (gpuLayers, totalLayers uint64, overflow int, ok bool) {
+	s.memoryMu.RLock()
+	defer s.memoryMu.RUnlock()
+
+	return s.gpuLayers, s.totalLayers, s.gpuLayerOverflow, s.totalLayers > 0
 }
 
 func (s *llamaServerRunner) startLoadTracking(t time.Time) {

--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -74,13 +74,11 @@ ws ::= ([ \t\n] ws)?
 // when neither the model nor the request specifies num_batch.
 const (
 	DefaultEmbeddingNumBatch             = 2048
+	LlamaServerDefaultFitTargetMiB       = 1024
 	openEndedGenerationContextMultiplier = 10
 )
 
 const (
-	llamaArgFitTargetEnv = "LLAMA_ARG_FIT_TARGET"
-	bytesPerMiB          = 1 << 20
-
 	// mmprojOffloadHeadroom leaves 1 GiB for backend buffers beyond projector weights.
 	mmprojOffloadHeadroom = 1 << 30
 )
@@ -426,7 +424,7 @@ func startLlamaServer(launch llamaServerLaunchConfig, out io.Writer) (cmd *exec.
 		cmd.Stderr = out
 	}
 	cmd.SysProcAttr = LlamaServerSysProcAttr
-	SetupLlamaServerCommandEnv(cmd, exe, launch.gpuLibs, launch.extraEnvsForStart())
+	SetupLlamaServerCommandEnv(cmd, exe, launch.gpuLibs, launch.extraEnvs)
 
 	slog.Info("starting llama-server", "cmd", cmd)
 	slog.Debug("subprocess", "", filteredEnv(cmd.Env))
@@ -688,48 +686,8 @@ func shouldDisableMMProjOffload(opts api.Options, gpus []ml.DeviceInfo, modelLay
 	return false, ""
 }
 
-func (launch llamaServerLaunchConfig) extraEnvsForStart() map[string]string {
-	pad, ok := launch.mmprojFitTargetMiB()
-	if !ok {
-		return launch.extraEnvs
-	}
-
-	if existing, ok := launch.extraEnvs[llamaArgFitTargetEnv]; ok {
-		existingTarget, err := strconv.ParseUint(existing, 10, 64)
-		if err != nil {
-			slog.Warn("invalid llama-server fit target", "env", llamaArgFitTargetEnv, "value", existing, "error", err)
-			return launch.extraEnvs
-		}
-
-		envs := cloneStringMap(launch.extraEnvs)
-		envs[llamaArgFitTargetEnv] = strconv.FormatUint(existingTarget+pad, 10)
-		return envs
-	}
-
-	if _, ok := os.LookupEnv(llamaArgFitTargetEnv); ok {
-		// Preserve an inherited user override. SetupLlamaServerCommandEnv
-		// will pass it through unless extraEnvs overrides it.
-		return launch.extraEnvs
-	}
-
-	envs := cloneStringMap(launch.extraEnvs)
-	envs[llamaArgFitTargetEnv] = strconv.FormatUint(pad, 10)
-	return envs
-}
-
-func (launch llamaServerLaunchConfig) mmprojFitTargetMiB() (uint64, bool) {
-	if len(launch.projectors) == 0 || launch.mmprojMemory == 0 {
-		return 0, false
-	}
-	if disable, _ := launch.mmprojOffloadDisabled(); disable {
-		return 0, false
-	}
-
-	requiredMemory := launch.mmprojMemory + mmprojOffloadHeadroom
-	return (requiredMemory + bytesPerMiB - 1) / bytesPerMiB, true
-}
-
-// mmprojMemoryRequirement is a stopgap until fit accounts for mmproj memory directly.
+// mmprojMemoryRequirement estimates whether projector GPU offload is worth
+// attempting. llama-server's fit pass accounts for mmproj memory directly.
 func mmprojMemoryRequirement(modelPath string, f *ggml.GGML, projectors []string) (uint64, error) {
 	if len(projectors) == 0 {
 		return 0, nil
@@ -919,11 +877,18 @@ func NewLlamaServerRunner(
 
 	mediaMarker := newLlamaServerMediaMarker()
 	extraEnvs := ml.GetDevicesEnv(gpus)
-	serverEnvs := make(map[string]string, len(extraEnvs)+1)
+	serverEnvs := make(map[string]string, len(extraEnvs)+2)
 	for k, v := range extraEnvs {
 		serverEnvs[k] = v
 	}
 	serverEnvs["LLAMA_MEDIA_MARKER"] = mediaMarker
+	if len(config.FitTargetsMiB) > 0 {
+		targets := make([]string, len(config.FitTargetsMiB))
+		for i, target := range config.FitTargetsMiB {
+			targets[i] = strconv.FormatUint(target, 10)
+		}
+		serverEnvs[LlamaServerFitTargetEnv] = strings.Join(targets, ",")
+	}
 
 	launch := llamaServerLaunchConfig{
 		modelPath:    modelPath,
@@ -1138,6 +1103,16 @@ func (s *llamaServerRunner) hasParsedVRAM() bool {
 	defer s.memoryMu.RUnlock()
 
 	return len(s.vramByDevice) > 0
+}
+
+// LayerOffloadStatus returns the final model-layer placement parsed from
+// llama-server logs. overflow reports layers selected for GPU by fit that still
+// overflowed to CPU.
+func (s *llamaServerRunner) LayerOffloadStatus() (gpuLayers, totalLayers uint64, overflow int, ok bool) {
+	s.memoryMu.RLock()
+	defer s.memoryMu.RUnlock()
+
+	return s.gpuLayers, s.totalLayers, s.gpuLayerOverflow, s.totalLayers > 0
 }
 
 func (s *llamaServerRunner) startLoadTracking(t time.Time) {

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -2204,71 +2204,45 @@ func TestAppendMMProjArgs(t *testing.T) {
 	}
 }
 
-func TestMMProjFitTargetExtraEnvs(t *testing.T) {
-	t.Setenv(llamaArgFitTargetEnv, "")
-	_ = os.Unsetenv(llamaArgFitTargetEnv)
+func TestSetupLlamaServerCommandEnvLeavesFitTargetToLlamaServer(t *testing.T) {
+	const fitTargetEnv = llamaArgFitTargetEnv
 
-	const (
-		projectorMemoryMiB = uint64(933)
-		projectorPadMiB    = projectorMemoryMiB + mmprojOffloadHeadroom/bytesPerMiB
-	)
+	t.Run("does not synthesize fit target", func(t *testing.T) {
+		t.Setenv(fitTargetEnv, "")
+		_ = os.Unsetenv(fitTargetEnv)
 
-	fitTargetValue := func(mib uint64) string {
-		return fmt.Sprint(mib)
-	}
+		cmd := exec.Command("llama-server")
+		SetupLlamaServerCommandEnv(cmd, "/tmp/llama-server", nil, map[string]string{"LLAMA_MEDIA_MARKER": "marker"})
 
-	assertFitTarget := func(t *testing.T, got map[string]string, wantMiB uint64) {
-		t.Helper()
-		if got[llamaArgFitTargetEnv] != fitTargetValue(wantMiB) {
-			t.Fatalf("fit target = %q, want %d", got[llamaArgFitTargetEnv], wantMiB)
-		}
-	}
-
-	newLaunch := func(extraEnvs map[string]string) llamaServerLaunchConfig {
-		return llamaServerLaunchConfig{
-			projectors:   []string{"model.gguf"},
-			mmprojMemory: projectorMemoryMiB * bytesPerMiB,
-			opts:         api.DefaultOptions(),
-			gpus:         []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}, Integrated: true, FreeMemory: 32 << 30}},
-			modelLayers:  81,
-			extraEnvs:    extraEnvs,
-		}
-	}
-
-	t.Run("sets projector pad when no fit target exists", func(t *testing.T) {
-		launch := newLaunch(map[string]string{"KEEP": "1"})
-
-		got := launch.extraEnvsForStart()
-		assertFitTarget(t, got, projectorPadMiB)
-		if _, ok := launch.extraEnvs[llamaArgFitTargetEnv]; ok {
-			t.Fatal("extraEnvsForStart mutated launch.extraEnvs")
+		for _, env := range cmd.Env {
+			if strings.HasPrefix(env, fitTargetEnv+"=") {
+				t.Fatalf("unexpected synthesized fit target env: %q", env)
+			}
 		}
 	})
 
-	for _, tt := range []struct {
-		name               string
-		launchFitTargetMiB uint64
-	}{
-		{name: "adds projector pad to existing launch fit target", launchFitTargetMiB: 2048},
-		{name: "adds projector pad to smaller launch fit target", launchFitTargetMiB: 512},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			launch := newLaunch(map[string]string{
-				llamaArgFitTargetEnv: fitTargetValue(tt.launchFitTargetMiB),
-			})
-
-			got := launch.extraEnvsForStart()
-			assertFitTarget(t, got, tt.launchFitTargetMiB+projectorPadMiB)
-		})
-	}
-
 	t.Run("preserves inherited user fit target", func(t *testing.T) {
-		t.Setenv(llamaArgFitTargetEnv, fitTargetValue(256))
-		launch := newLaunch(map[string]string{})
+		t.Setenv(fitTargetEnv, "256")
 
-		got := launch.extraEnvsForStart()
-		if _, ok := got[llamaArgFitTargetEnv]; ok {
-			t.Fatalf("user env should not be overridden, got extra env %q", got[llamaArgFitTargetEnv])
+		cmd := exec.Command("llama-server")
+		SetupLlamaServerCommandEnv(cmd, "/tmp/llama-server", nil, map[string]string{"LLAMA_MEDIA_MARKER": "marker"})
+
+		if !slices.Contains(cmd.Env, fitTargetEnv+"=256") {
+			t.Fatalf("expected inherited %s to pass through", fitTargetEnv)
+		}
+	})
+
+	t.Run("applies load plan fit target", func(t *testing.T) {
+		t.Setenv(fitTargetEnv, "")
+
+		cmd := exec.Command("llama-server")
+		SetupLlamaServerCommandEnv(cmd, "/tmp/llama-server", nil, map[string]string{
+			"LLAMA_MEDIA_MARKER": "marker",
+			fitTargetEnv:         "2048",
+		})
+
+		if !slices.Contains(cmd.Env, fitTargetEnv+"=2048") {
+			t.Fatalf("expected load plan %s to be applied", fitTargetEnv)
 		}
 	})
 }

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -2295,71 +2295,45 @@ func TestAppendMMProjArgs(t *testing.T) {
 	}
 }
 
-func TestMMProjFitTargetExtraEnvs(t *testing.T) {
-	t.Setenv(llamaArgFitTargetEnv, "")
-	_ = os.Unsetenv(llamaArgFitTargetEnv)
+func TestSetupLlamaServerCommandEnvLeavesFitTargetToLlamaServer(t *testing.T) {
+	const fitTargetEnv = LlamaServerFitTargetEnv
 
-	const (
-		projectorMemoryMiB = uint64(933)
-		projectorPadMiB    = projectorMemoryMiB + mmprojOffloadHeadroom/bytesPerMiB
-	)
+	t.Run("does not synthesize fit target", func(t *testing.T) {
+		t.Setenv(fitTargetEnv, "")
+		_ = os.Unsetenv(fitTargetEnv)
 
-	fitTargetValue := func(mib uint64) string {
-		return fmt.Sprint(mib)
-	}
+		cmd := exec.Command("llama-server")
+		SetupLlamaServerCommandEnv(cmd, "/tmp/llama-server", nil, map[string]string{"LLAMA_MEDIA_MARKER": "marker"})
 
-	assertFitTarget := func(t *testing.T, got map[string]string, wantMiB uint64) {
-		t.Helper()
-		if got[llamaArgFitTargetEnv] != fitTargetValue(wantMiB) {
-			t.Fatalf("fit target = %q, want %d", got[llamaArgFitTargetEnv], wantMiB)
-		}
-	}
-
-	newLaunch := func(extraEnvs map[string]string) llamaServerLaunchConfig {
-		return llamaServerLaunchConfig{
-			projectors:   []string{"model.gguf"},
-			mmprojMemory: projectorMemoryMiB * bytesPerMiB,
-			opts:         api.DefaultOptions(),
-			gpus:         []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}, Integrated: true, FreeMemory: 32 << 30}},
-			modelLayers:  81,
-			extraEnvs:    extraEnvs,
-		}
-	}
-
-	t.Run("sets projector pad when no fit target exists", func(t *testing.T) {
-		launch := newLaunch(map[string]string{"KEEP": "1"})
-
-		got := launch.extraEnvsForStart()
-		assertFitTarget(t, got, projectorPadMiB)
-		if _, ok := launch.extraEnvs[llamaArgFitTargetEnv]; ok {
-			t.Fatal("extraEnvsForStart mutated launch.extraEnvs")
+		for _, env := range cmd.Env {
+			if strings.HasPrefix(env, fitTargetEnv+"=") {
+				t.Fatalf("unexpected synthesized fit target env: %q", env)
+			}
 		}
 	})
 
-	for _, tt := range []struct {
-		name               string
-		launchFitTargetMiB uint64
-	}{
-		{name: "adds projector pad to existing launch fit target", launchFitTargetMiB: 2048},
-		{name: "adds projector pad to smaller launch fit target", launchFitTargetMiB: 512},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			launch := newLaunch(map[string]string{
-				llamaArgFitTargetEnv: fitTargetValue(tt.launchFitTargetMiB),
-			})
-
-			got := launch.extraEnvsForStart()
-			assertFitTarget(t, got, tt.launchFitTargetMiB+projectorPadMiB)
-		})
-	}
-
 	t.Run("preserves inherited user fit target", func(t *testing.T) {
-		t.Setenv(llamaArgFitTargetEnv, fitTargetValue(256))
-		launch := newLaunch(map[string]string{})
+		t.Setenv(fitTargetEnv, "256")
 
-		got := launch.extraEnvsForStart()
-		if _, ok := got[llamaArgFitTargetEnv]; ok {
-			t.Fatalf("user env should not be overridden, got extra env %q", got[llamaArgFitTargetEnv])
+		cmd := exec.Command("llama-server")
+		SetupLlamaServerCommandEnv(cmd, "/tmp/llama-server", nil, map[string]string{"LLAMA_MEDIA_MARKER": "marker"})
+
+		if !slices.Contains(cmd.Env, fitTargetEnv+"=256") {
+			t.Fatalf("expected inherited %s to pass through", fitTargetEnv)
+		}
+	})
+
+	t.Run("applies load plan fit target", func(t *testing.T) {
+		t.Setenv(fitTargetEnv, "")
+
+		cmd := exec.Command("llama-server")
+		SetupLlamaServerCommandEnv(cmd, "/tmp/llama-server", nil, map[string]string{
+			"LLAMA_MEDIA_MARKER": "marker",
+			fitTargetEnv:         "2048",
+		})
+
+		if !slices.Contains(cmd.Env, fitTargetEnv+"=2048") {
+			t.Fatalf("expected load plan %s to be applied", fitTargetEnv)
 		}
 	})
 }

--- a/llm/server.go
+++ b/llm/server.go
@@ -19,6 +19,8 @@ import (
 
 var ErrLoadRequiredFull = errors.New("unable to load full model on GPU")
 
+const llamaArgFitTargetEnv = "LLAMA_ARG_FIT_TARGET"
+
 type filteredEnv []string
 
 func (e filteredEnv) LogValue() slog.Value {
@@ -41,6 +43,7 @@ func filteredEnvLogKey(key string) bool {
 		strings.HasPrefix(key, "HSA_") ||
 		strings.HasPrefix(key, "GGML_") ||
 		slices.Contains([]string{
+			llamaArgFitTargetEnv,
 			"PATH",
 			"LD_LIBRARY_PATH",
 			"DYLD_LIBRARY_PATH",
@@ -82,6 +85,14 @@ type LlamaServerConfig struct {
 	ContextShift   bool
 	EnableMTP      bool
 	DraftModelPath string
+	// PredictedVRAM and AvailableVRAM are scheduler estimates used to tune
+	// llama-server startup policy before the subprocess can report fit data.
+	PredictedVRAM uint64
+	AvailableVRAM uint64
+	// FitTargetMiB sets LLAMA_ARG_FIT_TARGET for this launch so llama.cpp fit
+	// uses the same per-device reserve the scheduler used for placement. A
+	// zero value leaves the inherited environment or llama.cpp default in place.
+	FitTargetMiB uint64
 }
 
 // LoadModel will load a model from disk. The model must be in the GGML format.

--- a/llm/server.go
+++ b/llm/server.go
@@ -19,6 +19,10 @@ import (
 
 var ErrLoadRequiredFull = errors.New("unable to load full model on GPU")
 
+// LlamaServerFitTargetEnv is llama.cpp's env form of --fit-target: the
+// per-device MiB margin its fit pass reserves when auto-sizing a load.
+const LlamaServerFitTargetEnv = "LLAMA_ARG_FIT_TARGET"
+
 type filteredEnv []string
 
 func (e filteredEnv) LogValue() slog.Value {
@@ -41,6 +45,7 @@ func filteredEnvLogKey(key string) bool {
 		strings.HasPrefix(key, "HSA_") ||
 		strings.HasPrefix(key, "GGML_") ||
 		slices.Contains([]string{
+			LlamaServerFitTargetEnv,
 			"PATH",
 			"LD_LIBRARY_PATH",
 			"DYLD_LIBRARY_PATH",
@@ -82,6 +87,11 @@ type LlamaServerConfig struct {
 	ContextShift   bool
 	EnableMTP      bool
 	DraftModelPath string
+	// FitTargetsMiB sets LLAMA_ARG_FIT_TARGET for this launch, one MiB value
+	// per visible device, so llama.cpp fit uses the same per-device reserve
+	// the scheduler used for placement. Empty leaves the inherited environment
+	// or llama.cpp default in place.
+	FitTargetsMiB []uint64
 }
 
 // LoadModel will load a model from disk. The model must be in the GGML format.

--- a/server/load_plan.go
+++ b/server/load_plan.go
@@ -1,0 +1,80 @@
+package server
+
+import (
+	"log/slog"
+
+	"github.com/ollama/ollama/llm"
+	"github.com/ollama/ollama/ml"
+)
+
+// loadMemoryAssessment is the scheduler-facing memory view for a proposed
+// load. It keeps eviction decisions in Scheduler.load while hiding the
+// backend-specific details used to produce the estimate.
+type loadMemoryAssessment struct {
+	predictedModel uint64
+	predictedLoad  uint64
+	available      uint64
+	gpuFree        uint64
+	systemLimited  bool
+}
+
+// loadProposal is the stable set of scheduler inputs that backend-specific
+// planners need to estimate and prepare a runner load.
+type loadProposal struct {
+	systemInfo  ml.SystemInfo
+	gpus        []ml.DeviceInfo
+	numParallel int
+	completion  bool
+}
+
+// loadRetryPlanner lets Scheduler.load ask the selected backend plan to apply
+// a retry when backend-specific Load behavior proves the first attempt was too
+// aggressive. Runners whose startup failures surface later from
+// WaitUntilRunning should not wire this in.
+type loadRetryPlanner interface {
+	maybeRetryLoadFailure(req *LlmRequest, systemInfo ml.SystemInfo, loadedCount int, err error) bool
+	maybeRetryCPUSpill(req *LlmRequest, runner llm.LlamaServer, requireFull bool, loadedCount int, totalSize, vramSize uint64) bool
+}
+
+// loadedRunnerFit reports whether a proposed load can safely coexist with
+// already loaded runners, when that backend has enough information to tell.
+type loadedRunnerFit int
+
+const (
+	loadedRunnerFitSkipped loadedRunnerFit = iota
+	loadedRunnerFits
+	loadedRunnerNeedsEviction
+)
+
+// runnerLoadPlan is the backend-specific preflight result Scheduler.load needs
+// after selecting llama-server or MLX. It keeps runner construction and backend
+// load details in the plan while leaving eviction execution in the scheduler.
+type runnerLoadPlan interface {
+	slog.LogValuer
+	assessLoadedRunnerFit(requireFull bool, loadedCount int) loadedRunnerFit
+	applyToRequest(req *LlmRequest)
+	gpusForLoad() []ml.DeviceInfo
+	newServer(s *Scheduler, req *LlmRequest) (llm.LlamaServer, error)
+	retryPlanner() loadRetryPlanner
+	trainContext() int
+}
+
+func (a loadMemoryAssessment) fitsAvailable() bool {
+	if a.predictedLoad == 0 {
+		return true
+	}
+	if a.available == 0 {
+		return false
+	}
+	return a.predictedLoad <= a.available
+}
+
+func (a loadMemoryAssessment) fitsWithHeadroom(percent uint64) bool {
+	if a.predictedLoad == 0 {
+		return true
+	}
+	if a.available == 0 {
+		return false
+	}
+	return a.predictedLoad <= a.available*percent/100
+}

--- a/server/load_plan_llama.go
+++ b/server/load_plan_llama.go
@@ -1,0 +1,786 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"runtime"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/envconfig"
+	"github.com/ollama/ollama/format"
+	"github.com/ollama/ollama/fs/ggml"
+	"github.com/ollama/ollama/llm"
+	"github.com/ollama/ollama/ml"
+)
+
+// llamaServerLoadPlan is the llama-server preflight result. It collects the
+// GGUF metadata, placement, request options, launch config, and memory estimate
+// needed by Scheduler.load while keeping llama-server sizing rules in one
+// place.
+type llamaServerLoadPlan struct {
+	model        *ggml.GGML
+	gpus         []ml.DeviceInfo
+	requestOpts  api.Options
+	launchOpts   api.Options
+	config       llm.LlamaServerConfig
+	systemInfo   ml.SystemInfo
+	contextShift bool
+	useMMapAuto  bool
+
+	numParallel      int
+	completion       bool
+	effectiveContext int
+	memory           loadMemoryAssessment
+}
+
+const (
+	llamaServerGenerationBatchDefault     = 512
+	llamaServerGenerationBatchConstrained = 256
+	llamaServerGenerationBatchMedium      = 1024
+	llamaServerGenerationBatchLarge       = 2048
+
+	llamaServerGenerationBatchMediumHeadroomPercent = 75
+	llamaServerGenerationBatchLargeHeadroomPercent  = 60
+	llamaServerLoadHeadroomPercent                  = 80
+	llamaServerDefaultFitTargetMiB                  = 1024
+
+	llamaServerFitTargetEnv = "LLAMA_ARG_FIT_TARGET"
+)
+
+// newLlamaServerLoadPlan translates a scheduler load proposal into the concrete
+// llama-server launch plan. It reads GGUF metadata up front so placement,
+// automatic context/batch sizing, mmap defaults, and eviction checks all use
+// the same predicted memory view before the subprocess is started.
+func newLlamaServerLoadPlan(req *LlmRequest, proposal loadProposal) (llamaServerLoadPlan, error) {
+	f, err := llm.LoadModel(req.model.ModelPath, 1024)
+	if err != nil {
+		return llamaServerLoadPlan{}, err
+	}
+
+	effectiveCtx := effectiveLlamaServerContext(req.opts.NumCtx, f, proposal.numParallel)
+	predictedModel := llm.PredictServerVRAM(req.model.ModelPath, f, effectiveCtx)
+	loadGpus, launchOpts := selectLlamaServerPlacement(proposal.systemInfo, proposal.gpus, predictedModel, req.opts)
+	available, gpuFree, systemLimited := availableMemoryForPlacement(proposal.systemInfo, loadGpus, launchOpts)
+
+	requestOpts := optionsWithAutomaticGenerationBatch(
+		req.opts,
+		req.numBatchAuto,
+		proposal.completion,
+		effectiveCtx,
+		predictedModel,
+		available,
+		llm.LlamaServerFlashAttention(loadGpus),
+		loadGpus,
+	)
+	launchOpts.NumBatch = requestOpts.NumBatch
+
+	config := llamaServerConfigForModel(req.model)
+	config.ContextShift = resolveContextShift(req.shift, req.model)
+	config.PredictedVRAM = predictedModel + generationBatchSurchargeForCompletion(proposal.completion, launchOpts.NumBatch)
+	config.AvailableVRAM = available
+	config.FitTargetMiB = llamaServerFitTargetForRunner()
+
+	return llamaServerLoadPlan{
+		model:        f,
+		gpus:         loadGpus,
+		requestOpts:  requestOpts,
+		launchOpts:   launchOpts,
+		config:       config,
+		systemInfo:   proposal.systemInfo,
+		contextShift: config.ContextShift,
+
+		numParallel:      proposal.numParallel,
+		completion:       proposal.completion,
+		effectiveContext: effectiveCtx,
+		memory: loadMemoryAssessment{
+			predictedModel: predictedModel,
+			predictedLoad:  config.PredictedVRAM,
+			available:      available,
+			gpuFree:        gpuFree,
+			systemLimited:  systemLimited,
+		},
+	}, nil
+}
+
+// maybeRetryLoadFailure handles llama-server OOMs that surface only after the
+// runner starts. The fit estimate is imperfect, and auto selected context and
+// batch size can be too aggressive even when preflight predicts the load will
+// fit. It also covers the case where the pre-load fit check missed allocation
+// pressure from resident runners. Projector GPU-offload OOMs are retried inside
+// llamaServerRunner.Load before this hook sees the error.
+func (p llamaServerLoadPlan) maybeRetryLoadFailure(req *LlmRequest, systemInfo ml.SystemInfo, loadedCount int, err error) bool {
+	if req.loadRetryAttempted || !llm.IsOutOfMemory(err) {
+		return false
+	}
+	if p.maybeReduceContextForLoadRetry(req, systemInfo, loadedCount, err) {
+		return true
+	}
+	if loadedCount == 0 {
+		return false
+	}
+
+	req.loadRetryAttempted = true
+	slog.Warn("model load failed; evicting all other models and retrying once", "model", req.model.ModelPath, "error", err)
+	return true
+}
+
+func (p llamaServerLoadPlan) maybeReduceContextForLoadRetry(req *LlmRequest, systemInfo ml.SystemInfo, loadedCount int, err error) bool {
+	if !req.numCtxAuto {
+		return false
+	}
+
+	oldNumCtx := req.opts.NumCtx
+	oldNumBatch := req.opts.NumBatch
+	effectiveNumCtx := oldNumCtx
+	if trainCtx := int(p.model.KV().ContextLength()); trainCtx > 0 && effectiveNumCtx > trainCtx {
+		effectiveNumCtx = trainCtx
+	}
+
+	newNumCtx, ok := nextLowerAutoNumCtx(effectiveNumCtx)
+	if !ok || newNumCtx >= oldNumCtx {
+		return false
+	}
+
+	opts := p.requestOpts
+	opts.NumCtx = newNumCtx
+	predictedCtx := effectiveLlamaServerContext(opts.NumCtx, p.model, p.numParallel)
+	predictedVRAM := llm.PredictServerVRAM(req.model.ModelPath, p.model, predictedCtx)
+	available, _, _ := availableMemoryForPlacement(systemInfo, p.gpus, p.launchOpts)
+	opts = optionsWithAutomaticGenerationBatch(opts, req.numBatchAuto, p.completion, predictedCtx, predictedVRAM, available, llm.LlamaServerFlashAttention(p.gpus), p.gpus)
+
+	req.loadRetryAttempted = true
+	req.opts = opts
+	slog.Warn("llama-server load failed; reducing automatic context and retrying once",
+		"model", req.model.ModelPath,
+		"old_num_ctx", oldNumCtx,
+		"effective_num_ctx", effectiveNumCtx,
+		"new_num_ctx", newNumCtx,
+		"old_num_batch", oldNumBatch,
+		"new_num_batch", opts.NumBatch,
+		"loaded_count", loadedCount,
+		"evict_all", loadedCount > 0,
+		"error", err)
+	return true
+}
+
+func (p llamaServerLoadPlan) assessLoadedRunnerFit(requireFull bool, loadedCount int) loadedRunnerFit {
+	if !requireFull || loadedCount == 0 || len(p.gpus) == 0 {
+		return loadedRunnerFitSkipped
+	}
+	if explicitPartialGPUOffload(p.launchOpts, p.model) {
+		return loadedRunnerFitSkipped
+	}
+	if !p.memory.fitsWithHeadroom(llamaServerLoadHeadroomPercent) {
+		return loadedRunnerNeedsEviction
+	}
+	return loadedRunnerFits
+}
+
+func (p llamaServerLoadPlan) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("backend", "llama-server"),
+		slog.String("predicted", format.HumanBytes2(p.memory.predictedLoad)),
+		slog.Int("predicted_num_ctx", p.effectiveContext),
+		slog.Int("num_batch", p.launchOpts.NumBatch),
+		slog.String("available", format.HumanBytes2(p.memory.available)),
+		slog.String("gpu_free", format.HumanBytes2(p.memory.gpuFree)),
+		slog.Bool("system_limited", p.memory.systemLimited),
+	)
+}
+
+func (s *Scheduler) applyLlamaServerMmapDefaults(req *LlmRequest, plan llamaServerLoadPlan, systemInfo ml.SystemInfo) llamaServerLoadPlan {
+	requestOpts := plan.requestOpts
+	launchOpts := plan.launchOpts
+	disableMmap := false
+
+	if requestOpts.UseMMap == nil {
+		reason := ""
+		hasCUDA := false
+		hasMetal := false
+		allCPU := len(plan.gpus) > 0
+		for _, gpu := range plan.gpus {
+			hasCUDA = hasCUDA || strings.EqualFold(gpu.Library, "cuda")
+			hasMetal = hasMetal || strings.EqualFold(gpu.Library, "metal")
+			allCPU = allCPU && strings.EqualFold(gpu.Library, "cpu")
+		}
+
+		switch {
+		case requestOpts.NumGPU == 0 || len(plan.gpus) == 0 || allCPU:
+			reason = "cpu"
+		case runtime.GOOS == "windows" && hasCUDA:
+			reason = "windows_cuda"
+		case hasMetal && requestOpts.NumGPU > 0 && uint64(requestOpts.NumGPU) < plan.model.KV().BlockCount()+1:
+			reason = "metal_partial_offload"
+		case hasMetal && requestOpts.NumGPU < 0 && plan.memory.predictedModel > 0 && plan.memory.available > 0 && plan.memory.predictedModel > plan.memory.available:
+			reason = "metal_partial_offload"
+		}
+
+		if reason != "" {
+			disableMmap = true
+			slog.Info("disabling mmap for llama-server load by default",
+				"model", req.model.ModelPath,
+				"reason", reason)
+		} else if runtime.GOOS == "linux" {
+			placementGpus := gpusForPlacement(plan.gpus, launchOpts)
+			allDiscrete := len(placementGpus) > 0
+			for _, gpu := range placementGpus {
+				allDiscrete = allDiscrete && !gpu.Integrated
+			}
+
+			modelSize := modelFileSize(req.model.ModelPath)
+			loadedMmapSize := s.loadedMmapModelSizeLocked()
+			predictedFits := plan.memory.predictedModel > 0 &&
+				plan.memory.available > 0 &&
+				plan.memory.predictedModel <= plan.memory.available*llamaServerLoadHeadroomPercent/100
+			pressure := modelSize + loadedMmapSize + mmapHostPressureHeadroom(systemInfo.TotalMemory)
+
+			// Only back off mmap when we still expect the model to fit on a
+			// discrete GPU. If VRAM is already tight, disabling mmap can make
+			// partial CPU offload worse by turning file-backed mappings into
+			// anonymous memory.
+			disableMmap = modelSize > 0 &&
+				systemInfo.FreeMemory > 0 &&
+				allDiscrete &&
+				predictedFits &&
+				systemInfo.FreeMemory < pressure
+			if disableMmap {
+				slog.Info("disabling mmap for llama-server load due to host memory pressure",
+					"model", req.model.ModelPath,
+					"model_size", format.HumanBytes2(modelSize),
+					"loaded_mmap_size", format.HumanBytes2(loadedMmapSize),
+					"headroom", format.HumanBytes2(mmapHostPressureHeadroom(systemInfo.TotalMemory)),
+					"system_free", format.HumanBytes2(systemInfo.FreeMemory),
+					"system_total", format.HumanBytes2(systemInfo.TotalMemory),
+					"predicted_vram", format.HumanBytes2(plan.memory.predictedModel),
+					"available_vram", format.HumanBytes2(plan.memory.available),
+				)
+			}
+		}
+	}
+	if disableMmap {
+		useMmap := false
+		requestOpts.UseMMap = &useMmap
+		plan.useMMapAuto = true
+	}
+
+	launchOpts.UseMMap = requestOpts.UseMMap
+	plan.requestOpts = requestOpts
+	plan.launchOpts = launchOpts
+	return plan
+}
+
+func (p llamaServerLoadPlan) applyToRequest(req *LlmRequest) {
+	req.opts = p.requestOpts
+	req.useMMapAuto = p.useMMapAuto
+	req.contextShift = p.contextShift
+}
+
+func (p llamaServerLoadPlan) gpusForLoad() []ml.DeviceInfo {
+	return p.gpus
+}
+
+func (p llamaServerLoadPlan) newServer(s *Scheduler, req *LlmRequest) (llm.LlamaServer, error) {
+	server, err := s.newServerFn(
+		p.systemInfo,
+		p.gpus,
+		req.model.ModelPath,
+		p.model,
+		req.model.AdapterPaths,
+		req.model.ProjectorPaths,
+		p.launchOpts,
+		p.numParallel,
+		p.config,
+	)
+	if err == nil {
+		return server, nil
+	}
+
+	// Some older models are not compatible with newer versions of llama.cpp.
+	// Show a generalized compatibility error until there is a better way to
+	// check for model compatibility.
+	if errors.Is(err, ggml.ErrUnsupportedFormat) || strings.Contains(err.Error(), "failed to load model") {
+		err = fmt.Errorf("%v: this model may be incompatible with your version of Ollama. If you previously pulled this model, try updating it by running `ollama pull %s`", err, req.model.ShortName)
+	}
+	return nil, err
+}
+
+func (p llamaServerLoadPlan) retryPlanner() loadRetryPlanner {
+	return p
+}
+
+func (p llamaServerLoadPlan) trainContext() int {
+	return modelTrainContext(p.model)
+}
+
+type llamaServerLayerOffloadReporter interface {
+	LayerOffloadStatus() (gpuLayers, totalLayers uint64, overflow int, ok bool)
+}
+
+func (p llamaServerLoadPlan) maybeRetryCPUSpill(req *LlmRequest, runner llm.LlamaServer, requireFull bool, loadedCount int, totalSize, vramSize uint64) bool {
+	if req.loadRetryAttempted || !requireFull || loadedCount == 0 || len(p.gpus) == 0 {
+		return false
+	}
+
+	reporter, ok := runner.(llamaServerLayerOffloadReporter)
+	if !ok {
+		return false
+	}
+
+	gpuLayers, totalLayers, overflow, ok := reporter.LayerOffloadStatus()
+	if !ok || (gpuLayers >= totalLayers && overflow == 0) {
+		return false
+	}
+	// Explicit partial GPU offload intentionally leaves layers on CPU.
+	if req.opts.NumGPU > 0 && uint64(req.opts.NumGPU) < totalLayers {
+		return false
+	}
+
+	req.loadRetryAttempted = true
+	slog.Warn("llama-server spilled layers to CPU with other models resident; evicting residents and retrying",
+		"model", req.model.ModelPath,
+		"loaded_count", loadedCount,
+		"gpu_layers", gpuLayers,
+		"total_layers", totalLayers,
+		"fit_overflow_layers", overflow,
+		"size", format.HumanBytes2(totalSize),
+		"vram", format.HumanBytes2(vramSize))
+	return true
+}
+
+func explicitPartialGPUOffload(opts api.Options, f *ggml.GGML) bool {
+	if opts.NumGPU <= 0 || f == nil {
+		return false
+	}
+
+	return uint64(opts.NumGPU) < f.KV().BlockCount()+1
+}
+
+func effectiveLlamaServerContext(numCtx int, f *ggml.GGML, numParallel int) int {
+	return effectiveModelContext(numCtx, f) * max(numParallel, 1)
+}
+
+func optionsWithAutomaticGenerationBatch(opts api.Options, numBatchAuto, completion bool, effectiveCtx int, predictedVRAM, availableMemory uint64, flashAttention ml.FlashAttentionType, gpus []ml.DeviceInfo) api.Options {
+	if completion && numBatchAuto {
+		opts.NumBatch = automaticGenerationBatch(effectiveCtx, predictedVRAM, availableMemory, flashAttention, gpus)
+	}
+	return opts
+}
+
+func generationBatchSurchargeForCompletion(completion bool, batch int) uint64 {
+	if !completion {
+		return 0
+	}
+	return generationBatchSurcharge(batch)
+}
+
+func automaticGenerationBatch(effectiveCtx int, predictedVRAM, availableMemory uint64, flashAttention ml.FlashAttentionType, gpus []ml.DeviceInfo) int {
+	if flashAttention == ml.FlashAttentionDisabled && hasCUDADevice(gpus) {
+		if constrainedCUDAWithoutFlashAttention(effectiveCtx, gpus) {
+			return llamaServerGenerationBatchConstrained
+		}
+		return llamaServerGenerationBatchDefault
+	}
+
+	batch := generationBatchForContext(effectiveCtx)
+	for batch > llamaServerGenerationBatchDefault && !generationBatchFits(batch, predictedVRAM, availableMemory) {
+		batch = nextLowerGenerationBatch(batch)
+	}
+	return batch
+}
+
+func hasCUDADevice(gpus []ml.DeviceInfo) bool {
+	return slices.ContainsFunc(gpus, func(gpu ml.DeviceInfo) bool {
+		return gpu.Library == "CUDA"
+	})
+}
+
+func constrainedCUDAWithoutFlashAttention(effectiveCtx int, gpus []ml.DeviceInfo) bool {
+	if effectiveCtx <= 4096 {
+		return false
+	}
+	return slices.ContainsFunc(gpus, func(gpu ml.DeviceInfo) bool {
+		if gpu.Library != "CUDA" {
+			return false
+		}
+		memory := gpu.FreeMemory
+		if memory == 0 || (gpu.TotalMemory > 0 && gpu.TotalMemory < memory) {
+			memory = gpu.TotalMemory
+		}
+		return memory > 0 && memory <= 8*format.GibiByte
+	})
+}
+
+func generationBatchForContext(effectiveCtx int) int {
+	switch {
+	case effectiveCtx > 32768:
+		return llamaServerGenerationBatchLarge
+	case effectiveCtx > 4096:
+		return llamaServerGenerationBatchMedium
+	default:
+		return llamaServerGenerationBatchDefault
+	}
+}
+
+func generationBatchFits(batch int, predictedVRAM, availableMemory uint64) bool {
+	if predictedVRAM == 0 || availableMemory == 0 {
+		return true
+	}
+
+	threshold := availableMemory * llamaServerLoadHeadroomPercent / 100
+	if predictedVRAM > threshold {
+		return false
+	}
+	if !generationBatchHasHeadroom(batch, predictedVRAM, availableMemory) {
+		return false
+	}
+
+	return generationBatchSurcharge(batch) <= threshold-predictedVRAM
+}
+
+func generationBatchHasHeadroom(batch int, predictedVRAM, availableMemory uint64) bool {
+	switch {
+	case batch >= llamaServerGenerationBatchLarge:
+		return predictedVRAM <= availableMemory*llamaServerGenerationBatchLargeHeadroomPercent/100
+	case batch >= llamaServerGenerationBatchMedium:
+		return predictedVRAM <= availableMemory*llamaServerGenerationBatchMediumHeadroomPercent/100
+	default:
+		return true
+	}
+}
+
+func nextLowerGenerationBatch(batch int) int {
+	switch {
+	case batch > llamaServerGenerationBatchMedium:
+		return llamaServerGenerationBatchMedium
+	default:
+		return llamaServerGenerationBatchDefault
+	}
+}
+
+func generationBatchSurcharge(batch int) uint64 {
+	switch {
+	case batch >= llamaServerGenerationBatchLarge:
+		return 2 * format.GibiByte
+	case batch >= llamaServerGenerationBatchMedium:
+		return 768 * format.MebiByte
+	default:
+		return 0
+	}
+}
+
+func nextLowerAutoNumCtx(numCtx int) (int, bool) {
+	switch {
+	case numCtx > 32768:
+		return 32768, true
+	case numCtx > 4096:
+		return 4096, true
+	default:
+		return 0, false
+	}
+}
+
+func availableMemoryForLoad(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo) (available, gpuFree uint64, systemLimited bool) {
+	var sharedGPUFree uint64
+	var discreteGPUFree uint64
+	var reserve uint64
+	for i, gpu := range gpus {
+		gpuFree += gpu.FreeMemory
+		reserve += llamaServerDeviceReserve(gpu, i)
+		if gpu.Integrated {
+			sharedGPUFree += gpu.FreeMemory
+		} else {
+			discreteGPUFree += gpu.FreeMemory
+		}
+	}
+
+	available = gpuFree
+	// On iGPUs, GPU free memory can be a static or slowly refreshed device
+	// baseline. updateFreeSpace has already subtracted known Ollama runner
+	// allocations from that baseline. Current system free memory is a separate
+	// live measurement that already includes those loaded runners, so use the
+	// smaller value for shared-memory GPUs without discounting discrete VRAM.
+	if systemInfo.FreeMemory > 0 && sharedGPUFree > 0 && systemInfo.FreeMemory < sharedGPUFree {
+		available, systemLimited = discreteGPUFree+systemInfo.FreeMemory, true
+	}
+
+	if reserve >= available {
+		available = 0
+	} else {
+		available -= reserve
+	}
+	return available, gpuFree, systemLimited
+}
+
+func availableMemoryForPlacement(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, opts api.Options) (available, gpuFree uint64, systemLimited bool) {
+	placementGpus := gpusForPlacement(gpus, opts)
+	if len(placementGpus) == 1 && opts.MainGPU != nil {
+		gpu := placementGpus[0]
+		gpuFree = gpu.FreeMemory
+		available = availableMemoryForGPU(systemInfo, gpu, 0)
+		systemLimited = gpu.Integrated && systemInfo.FreeMemory > 0 && systemInfo.FreeMemory < gpu.FreeMemory
+		return available, gpuFree, systemLimited
+	}
+
+	return availableMemoryForLoad(systemInfo, placementGpus)
+}
+
+func gpusForPlacement(gpus []ml.DeviceInfo, opts api.Options) []ml.DeviceInfo {
+	if opts.MainGPU != nil && *opts.MainGPU >= 0 && *opts.MainGPU < len(gpus) {
+		return []ml.DeviceInfo{gpus[*opts.MainGPU]}
+	}
+
+	return gpus
+}
+
+func selectLlamaServerPlacement(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, predictedVRAM uint64, opts api.Options) ([]ml.DeviceInfo, api.Options) {
+	launchOpts := opts
+	if len(gpus) <= 1 || opts.NumGPU == 0 {
+		return gpus, launchOpts
+	}
+
+	groups := ml.ByLibrary(gpus)
+	if len(groups) == 0 {
+		return gpus, launchOpts
+	}
+
+	if opts.MainGPU != nil {
+		gpu, available, ok := bestExplicitMainGPU(systemInfo, groups, *opts.MainGPU)
+		if !ok {
+			selected := bestGPUGroupByAvailableMemory(systemInfo, groups)
+			slog.Warn("requested main_gpu is outside the selected GPU group; passing value through to llama-server",
+				"main_gpu", *opts.MainGPU,
+				"gpu_count", len(selected))
+			logSelectedGPUGroup(gpus, selected)
+			return selected, launchOpts
+		}
+
+		selected, launchOpts := singleLlamaServerGPUPlacement(gpu, launchOpts)
+		slog.Info("selecting requested single GPU for llama-server model",
+			"requested_main_gpu", *opts.MainGPU,
+			"main_gpu", *launchOpts.MainGPU,
+			"id", gpu.ID,
+			"filter_id", gpu.FilterID,
+			"library", gpu.Library,
+			"name", gpu.Name,
+			"description", gpu.Description,
+			"integrated", gpu.Integrated,
+			"available", format.HumanBytes2(available))
+		logSelectedGPUGroup(gpus, selected)
+		return selected, launchOpts
+	}
+
+	if !envconfig.SchedSpread() && predictedVRAM > 0 {
+		gpu, available, ok := bestSingleGPUFit(systemInfo, groups, predictedVRAM)
+		if ok {
+			selected, launchOpts := singleLlamaServerGPUPlacement(gpu, launchOpts)
+			slog.Info("selecting single GPU for llama-server model",
+				"main_gpu", *launchOpts.MainGPU,
+				"id", gpu.ID,
+				"filter_id", gpu.FilterID,
+				"library", gpu.Library,
+				"name", gpu.Name,
+				"description", gpu.Description,
+				"integrated", gpu.Integrated,
+				"predicted", format.HumanBytes2(predictedVRAM),
+				"available", format.HumanBytes2(available))
+			logSelectedGPUGroup(gpus, selected)
+			return selected, launchOpts
+		}
+	}
+
+	selected := bestGPUGroupByAvailableMemory(systemInfo, groups)
+	logSelectedGPUGroup(gpus, selected)
+	return selected, launchOpts
+}
+
+func singleLlamaServerGPUPlacement(gpu ml.DeviceInfo, opts api.Options) ([]ml.DeviceInfo, api.Options) {
+	// llama-server sees only this GPU after filtering, so the selected device is
+	// index 0 for both main_gpu and per-device fit-target values.
+	mainGPU := 0
+	opts.MainGPU = &mainGPU
+	return []ml.DeviceInfo{gpu}, opts
+}
+
+func bestExplicitMainGPU(systemInfo ml.SystemInfo, groups [][]ml.DeviceInfo, mainGPU int) (gpu ml.DeviceInfo, available uint64, ok bool) {
+	if mainGPU < 0 {
+		return ml.DeviceInfo{}, 0, false
+	}
+
+	for _, group := range groups {
+		if mainGPU >= len(group) {
+			continue
+		}
+		candidate := group[mainGPU]
+		candidateAvailable := availableMemoryForGPU(systemInfo, candidate, 0)
+		if !ok || betterPlacementGPU(candidate, candidateAvailable, gpu, available) {
+			gpu = candidate
+			available = candidateAvailable
+			ok = true
+		}
+	}
+
+	return gpu, available, ok
+}
+
+func bestSingleGPUFit(systemInfo ml.SystemInfo, groups [][]ml.DeviceInfo, predictedVRAM uint64) (gpu ml.DeviceInfo, available uint64, ok bool) {
+	for _, group := range groups {
+		for _, candidate := range group {
+			candidateAvailable := availableMemoryForGPU(systemInfo, candidate, 0)
+			if predictedVRAM > candidateAvailable {
+				continue
+			}
+			if !ok || betterPlacementGPU(candidate, candidateAvailable, gpu, available) {
+				gpu = candidate
+				available = candidateAvailable
+				ok = true
+			}
+		}
+	}
+
+	return gpu, available, ok
+}
+
+func betterPlacementGPU(candidate ml.DeviceInfo, candidateAvailable uint64, current ml.DeviceInfo, currentAvailable uint64) bool {
+	if candidate.Integrated != current.Integrated {
+		return !candidate.Integrated
+	}
+
+	return candidateAvailable > currentAvailable
+}
+
+func bestGPUGroupByAvailableMemory(systemInfo ml.SystemInfo, groups [][]ml.DeviceInfo) []ml.DeviceInfo {
+	var best []ml.DeviceInfo
+	var bestAvailable uint64
+	for _, group := range groups {
+		available, _, _ := availableMemoryForLoad(systemInfo, group)
+		if best == nil || betterPlacementGroup(group, available, best, bestAvailable) {
+			best = group
+			bestAvailable = available
+		}
+	}
+
+	return best
+}
+
+func betterPlacementGroup(candidate []ml.DeviceInfo, candidateAvailable uint64, current []ml.DeviceInfo, currentAvailable uint64) bool {
+	candidateDiscrete := hasDiscreteGPU(candidate)
+	currentDiscrete := hasDiscreteGPU(current)
+	if candidateDiscrete != currentDiscrete {
+		return candidateDiscrete
+	}
+
+	return candidateAvailable > currentAvailable
+}
+
+func hasDiscreteGPU(gpus []ml.DeviceInfo) bool {
+	for _, gpu := range gpus {
+		if !gpu.Integrated {
+			return true
+		}
+	}
+	return false
+}
+
+func availableMemoryForGPU(systemInfo ml.SystemInfo, gpu ml.DeviceInfo, visibleIndex int) uint64 {
+	available := gpu.FreeMemory
+	if gpu.Integrated && systemInfo.FreeMemory > 0 && systemInfo.FreeMemory < gpu.FreeMemory {
+		available = systemInfo.FreeMemory
+	}
+
+	reserve := llamaServerDeviceReserve(gpu, visibleIndex)
+	if reserve >= available {
+		return 0
+	}
+	return available - reserve
+}
+
+func llamaServerDeviceReserve(gpu ml.DeviceInfo, visibleIndex int) uint64 {
+	return gpu.MinimumMemory() + max(envconfig.GpuOverhead(), llamaServerFitTargetBytes(visibleIndex))
+}
+
+func llamaServerFitTargetBytes(visibleIndex int) uint64 {
+	value := envconfig.Var(llamaServerFitTargetEnv)
+	if value != "" {
+		targets := strings.Split(value, ",")
+		if len(targets) == 1 {
+			visibleIndex = 0
+		}
+		if visibleIndex >= 0 && visibleIndex < len(targets) {
+			if target, err := strconv.ParseUint(strings.TrimSpace(targets[visibleIndex]), 10, 64); err == nil {
+				return target * format.MebiByte
+			}
+		}
+	}
+
+	return llamaServerDefaultFitTargetMiB * format.MebiByte
+}
+
+func llamaServerFitTargetForRunner() uint64 {
+	if envconfig.Var(llamaServerFitTargetEnv) != "" {
+		return 0
+	}
+
+	overhead := envconfig.GpuOverhead()
+	defaultFitTarget := uint64(llamaServerDefaultFitTargetMiB * format.MebiByte)
+	if overhead <= defaultFitTarget {
+		return 0
+	}
+
+	return (overhead + format.MebiByte - 1) / format.MebiByte
+}
+
+func logSelectedGPUGroup(all, selected []ml.DeviceInfo) {
+	if len(selected) == 0 || len(selected) == len(all) {
+		return
+	}
+
+	slog.Info("selecting GPU backend for llama-server model",
+		"library", selected[0].Library,
+		"gpu_count", len(selected),
+		"available_gpu_count", len(all))
+}
+
+func mmapHostPressureHeadroom(totalMemory uint64) uint64 {
+	if totalMemory == 0 {
+		return 8 * format.GigaByte
+	}
+	return max(8*format.GigaByte, totalMemory/10)
+}
+
+func modelFileSize(path string) uint64 {
+	if path == "" {
+		return 0
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0
+	}
+	return uint64(info.Size())
+}
+
+func (s *Scheduler) loadedMmapModelSizeLocked() uint64 {
+	var total uint64
+	for _, r := range s.loaded {
+		if !runnerUsesMmap(r) {
+			continue
+		}
+		if size := modelFileSize(r.modelPath); size > 0 {
+			total += size
+		} else {
+			total += r.totalSize
+		}
+	}
+	return total
+}
+
+func runnerUsesMmap(r *runnerRef) bool {
+	if r == nil || r.Options == nil || r.Options.UseMMap == nil {
+		return true
+	}
+	return *r.Options.UseMMap
+}

--- a/server/load_plan_llama.go
+++ b/server/load_plan_llama.go
@@ -1,0 +1,849 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"runtime"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/envconfig"
+	"github.com/ollama/ollama/format"
+	"github.com/ollama/ollama/fs/ggml"
+	"github.com/ollama/ollama/llm"
+	"github.com/ollama/ollama/ml"
+)
+
+// llamaServerLoadPlan is the llama-server preflight result. It collects the
+// GGUF metadata, placement, request options, launch config, and memory estimate
+// needed by Scheduler.load while keeping llama-server sizing rules in one
+// place.
+type llamaServerLoadPlan struct {
+	model        *ggml.GGML
+	gpus         []ml.DeviceInfo
+	requestOpts  api.Options
+	launchOpts   api.Options
+	config       llm.LlamaServerConfig
+	systemInfo   ml.SystemInfo
+	contextShift bool
+	useMMapAuto  bool
+
+	numParallel      int
+	completion       bool
+	effectiveContext int
+	memory           loadMemoryAssessment
+}
+
+const (
+	llamaServerGenerationBatchDefault     = 512
+	llamaServerGenerationBatchConstrained = 256
+	llamaServerGenerationBatchMedium      = 1024
+	llamaServerGenerationBatchLarge       = 2048
+
+	llamaServerGenerationBatchMediumHeadroomPercent = 75
+	llamaServerGenerationBatchLargeHeadroomPercent  = 60
+
+	// llamaServerLoadHeadroomPercent leaves 20% of available memory as slack
+	// when judging whether a predicted load fits, since both the prediction
+	// and the free-memory measurements are estimates.
+	llamaServerLoadHeadroomPercent = 80
+)
+
+// newLlamaServerLoadPlan translates a scheduler load proposal into the concrete
+// llama-server launch plan. It reads GGUF metadata up front so placement,
+// automatic context/batch sizing, mmap defaults, and eviction checks all use
+// the same predicted memory view before the subprocess is started.
+func newLlamaServerLoadPlan(req *LlmRequest, proposal loadProposal) (llamaServerLoadPlan, error) {
+	f, err := llm.LoadModel(req.model.ModelPath, 1024)
+	if err != nil {
+		return llamaServerLoadPlan{}, err
+	}
+
+	effectiveCtx := effectiveLlamaServerContext(req.opts.NumCtx, f, proposal.numParallel)
+	predictedModel := llm.PredictServerVRAM(req.model.ModelPath, f, effectiveCtx)
+	loadGpus, launchOpts := selectLlamaServerPlacement(proposal.systemInfo, proposal.gpus, predictedModel, req.opts)
+	available, gpuFree, systemLimited := availableMemoryForPlacement(proposal.systemInfo, loadGpus, launchOpts)
+
+	requestOpts := optionsWithAutomaticGenerationBatch(
+		req.opts,
+		req.numBatchAuto,
+		proposal.completion,
+		effectiveCtx,
+		predictedModel,
+		available,
+		llm.LlamaServerFlashAttention(loadGpus),
+		loadGpus,
+	)
+	launchOpts.NumBatch = requestOpts.NumBatch
+
+	config := llamaServerConfigForModel(req.model)
+	config.ContextShift = resolveContextShift(req.shift, req.model)
+	config.FitTargetsMiB = llamaServerFitTargetsForRunner(loadGpus)
+	predictedLoad := predictedModel + generationBatchSurchargeForCompletion(proposal.completion, launchOpts.NumBatch)
+
+	return llamaServerLoadPlan{
+		model:        f,
+		gpus:         loadGpus,
+		requestOpts:  requestOpts,
+		launchOpts:   launchOpts,
+		config:       config,
+		systemInfo:   proposal.systemInfo,
+		contextShift: config.ContextShift,
+
+		numParallel:      proposal.numParallel,
+		completion:       proposal.completion,
+		effectiveContext: effectiveCtx,
+		memory: loadMemoryAssessment{
+			predictedModel: predictedModel,
+			predictedLoad:  predictedLoad,
+			available:      available,
+			gpuFree:        gpuFree,
+			systemLimited:  systemLimited,
+		},
+	}, nil
+}
+
+// maybeRetryLoadFailure handles llama-server OOMs that surface only after the
+// runner starts. The fit estimate is imperfect, and auto selected context and
+// batch size can be too aggressive even when preflight predicts the load will
+// fit. It also covers the case where the pre-load fit check missed allocation
+// pressure from resident runners. Projector GPU-offload OOMs are retried inside
+// llamaServerRunner.Load before this hook sees the error.
+func (p llamaServerLoadPlan) maybeRetryLoadFailure(req *LlmRequest, systemInfo ml.SystemInfo, loadedCount int, err error) bool {
+	if req.loadRetryAttempted || !llm.IsOutOfMemory(err) {
+		return false
+	}
+	if p.maybeReduceContextForLoadRetry(req, systemInfo, loadedCount, err) {
+		return true
+	}
+	if loadedCount == 0 {
+		return false
+	}
+
+	req.loadRetryAttempted = true
+	slog.Warn("model load failed; evicting all other models and retrying once", "model", req.model.ModelPath, "error", err)
+	return true
+}
+
+func (p llamaServerLoadPlan) maybeReduceContextForLoadRetry(req *LlmRequest, systemInfo ml.SystemInfo, loadedCount int, err error) bool {
+	if !req.numCtxAuto {
+		return false
+	}
+
+	oldNumCtx := req.opts.NumCtx
+	oldNumBatch := req.opts.NumBatch
+	effectiveNumCtx := oldNumCtx
+	if trainCtx := int(p.model.KV().ContextLength()); trainCtx > 0 && effectiveNumCtx > trainCtx {
+		effectiveNumCtx = trainCtx
+	}
+
+	newNumCtx, ok := nextLowerAutoNumCtx(effectiveNumCtx)
+	if !ok || newNumCtx >= oldNumCtx {
+		return false
+	}
+
+	opts := p.requestOpts
+	opts.NumCtx = newNumCtx
+	predictedCtx := effectiveLlamaServerContext(opts.NumCtx, p.model, p.numParallel)
+	predictedVRAM := llm.PredictServerVRAM(req.model.ModelPath, p.model, predictedCtx)
+	available, _, _ := availableMemoryForPlacement(systemInfo, p.gpus, p.launchOpts)
+	opts = optionsWithAutomaticGenerationBatch(opts, req.numBatchAuto, p.completion, predictedCtx, predictedVRAM, available, llm.LlamaServerFlashAttention(p.gpus), p.gpus)
+
+	req.loadRetryAttempted = true
+	req.opts = opts
+	slog.Warn("llama-server load failed; reducing automatic context and retrying once",
+		"model", req.model.ModelPath,
+		"old_num_ctx", oldNumCtx,
+		"effective_num_ctx", effectiveNumCtx,
+		"new_num_ctx", newNumCtx,
+		"old_num_batch", oldNumBatch,
+		"new_num_batch", opts.NumBatch,
+		"loaded_count", loadedCount,
+		"evict_all", loadedCount > 0,
+		"error", err)
+	return true
+}
+
+func (p llamaServerLoadPlan) assessLoadedRunnerFit(requireFull bool, loadedCount int) loadedRunnerFit {
+	if !requireFull || loadedCount == 0 || len(p.gpus) == 0 {
+		return loadedRunnerFitSkipped
+	}
+	if explicitPartialGPUOffload(p.launchOpts, p.model) {
+		return loadedRunnerFitSkipped
+	}
+	if !p.memory.fitsWithHeadroom(llamaServerLoadHeadroomPercent) {
+		return loadedRunnerNeedsEviction
+	}
+	return loadedRunnerFits
+}
+
+func (p llamaServerLoadPlan) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("backend", "llama-server"),
+		slog.String("predicted", format.HumanBytes2(p.memory.predictedLoad)),
+		slog.Int("predicted_num_ctx", p.effectiveContext),
+		slog.Int("num_batch", p.launchOpts.NumBatch),
+		slog.String("available", format.HumanBytes2(p.memory.available)),
+		slog.String("gpu_free", format.HumanBytes2(p.memory.gpuFree)),
+		slog.Bool("system_limited", p.memory.systemLimited),
+	)
+}
+
+func (s *Scheduler) applyLlamaServerMmapDefaults(req *LlmRequest, plan llamaServerLoadPlan, systemInfo ml.SystemInfo) llamaServerLoadPlan {
+	modelSize := modelFileSize(req.model.ModelPath)
+	loadedMmapSize := s.loadedMmapModelSizeLocked()
+	reason := llamaServerDisableMmapReason(runtime.GOOS, plan, systemInfo, modelSize, loadedMmapSize)
+	if reason != "" {
+		useMmap := false
+		plan.requestOpts.UseMMap = &useMmap
+		plan.useMMapAuto = true
+		slog.Info("disabling mmap for llama-server load by default",
+			"model", req.model.ModelPath,
+			"reason", reason,
+			"model_size", format.HumanBytes2(modelSize),
+			"loaded_mmap_size", format.HumanBytes2(loadedMmapSize),
+			"system_free", format.HumanBytes2(systemInfo.FreeMemory),
+			"system_total", format.HumanBytes2(systemInfo.TotalMemory),
+			"predicted_vram", format.HumanBytes2(plan.memory.predictedModel),
+			"available_vram", format.HumanBytes2(plan.memory.available),
+		)
+	}
+
+	plan.launchOpts.UseMMap = plan.requestOpts.UseMMap
+	return plan
+}
+
+// llamaServerDisableMmapReason decides whether an unset use_mmap should
+// default to off for this load, returning the reason or "" to keep mmap.
+// loadedMmapSize is the total file size of already loaded mmap-backed runners,
+// which competes with this model for host page cache.
+func llamaServerDisableMmapReason(goos string, plan llamaServerLoadPlan, systemInfo ml.SystemInfo, modelSize, loadedMmapSize uint64) string {
+	opts := plan.requestOpts
+	if opts.UseMMap != nil {
+		return ""
+	}
+
+	hasCUDA := false
+	hasMetal := false
+	allCPU := len(plan.gpus) > 0
+	for _, gpu := range plan.gpus {
+		hasCUDA = hasCUDA || strings.EqualFold(gpu.Library, "cuda")
+		hasMetal = hasMetal || strings.EqualFold(gpu.Library, "metal")
+		allCPU = allCPU && strings.EqualFold(gpu.Library, "cpu")
+	}
+
+	switch {
+	case opts.NumGPU == 0 || len(plan.gpus) == 0 || allCPU:
+		return "cpu"
+	case goos == "windows" && hasCUDA:
+		return "windows_cuda"
+	case hasMetal && opts.NumGPU > 0 && uint64(opts.NumGPU) < plan.model.KV().BlockCount()+1:
+		return "metal_partial_offload"
+	case hasMetal && opts.NumGPU < 0 && plan.memory.predictedModel > 0 && plan.memory.available > 0 && plan.memory.predictedModel > plan.memory.available:
+		return "metal_partial_offload"
+	}
+
+	if goos != "linux" {
+		return ""
+	}
+
+	placementGpus := gpusForPlacement(plan.gpus, plan.launchOpts)
+	allDiscrete := len(placementGpus) > 0
+	for _, gpu := range placementGpus {
+		allDiscrete = allDiscrete && !gpu.Integrated
+	}
+
+	predictedFits := plan.memory.predictedModel > 0 &&
+		plan.memory.available > 0 &&
+		plan.memory.predictedModel <= plan.memory.available*llamaServerLoadHeadroomPercent/100
+	pressure := modelSize + loadedMmapSize + mmapHostPressureHeadroom(systemInfo.TotalMemory)
+
+	// Only back off mmap when we still expect the model to fit on a discrete
+	// GPU. If VRAM is already tight, disabling mmap can make partial CPU
+	// offload worse by turning file-backed mappings into anonymous memory.
+	if modelSize > 0 &&
+		systemInfo.FreeMemory > 0 &&
+		allDiscrete &&
+		predictedFits &&
+		systemInfo.FreeMemory < pressure {
+		return "host_memory_pressure"
+	}
+	return ""
+}
+
+func (p llamaServerLoadPlan) applyToRequest(req *LlmRequest) {
+	req.opts = p.requestOpts
+	req.useMMapAuto = p.useMMapAuto
+	req.contextShift = p.contextShift
+}
+
+func (p llamaServerLoadPlan) gpusForLoad() []ml.DeviceInfo {
+	return p.gpus
+}
+
+func (p llamaServerLoadPlan) newServer(s *Scheduler, req *LlmRequest) (llm.LlamaServer, error) {
+	server, err := s.newServerFn(
+		p.systemInfo,
+		p.gpus,
+		req.model.ModelPath,
+		p.model,
+		req.model.AdapterPaths,
+		req.model.ProjectorPaths,
+		p.launchOpts,
+		p.numParallel,
+		p.config,
+	)
+	if err == nil {
+		return server, nil
+	}
+
+	// Some older models are not compatible with newer versions of llama.cpp.
+	// Show a generalized compatibility error until there is a better way to
+	// check for model compatibility.
+	if errors.Is(err, ggml.ErrUnsupportedFormat) || strings.Contains(err.Error(), "failed to load model") {
+		err = fmt.Errorf("%v: this model may be incompatible with your version of Ollama. If you previously pulled this model, try updating it by running `ollama pull %s`", err, req.model.ShortName)
+	}
+	return nil, err
+}
+
+func (p llamaServerLoadPlan) retryPlanner() loadRetryPlanner {
+	return p
+}
+
+func (p llamaServerLoadPlan) trainContext() int {
+	return modelTrainContext(p.model)
+}
+
+type llamaServerLayerOffloadReporter interface {
+	LayerOffloadStatus() (gpuLayers, totalLayers uint64, overflow int, ok bool)
+}
+
+func (p llamaServerLoadPlan) maybeRetryCPUSpill(req *LlmRequest, runner llm.LlamaServer, requireFull bool, loadedCount int, totalSize, vramSize uint64) bool {
+	if req.loadRetryAttempted || !requireFull || loadedCount == 0 || len(p.gpus) == 0 {
+		return false
+	}
+
+	reporter, ok := runner.(llamaServerLayerOffloadReporter)
+	if !ok {
+		return false
+	}
+
+	gpuLayers, totalLayers, overflow, ok := reporter.LayerOffloadStatus()
+	if !ok || (gpuLayers >= totalLayers && overflow == 0) {
+		return false
+	}
+	// Explicit partial GPU offload intentionally leaves layers on CPU.
+	if req.opts.NumGPU > 0 && uint64(req.opts.NumGPU) < totalLayers {
+		return false
+	}
+
+	req.loadRetryAttempted = true
+	slog.Warn("llama-server spilled layers to CPU with other models resident; evicting residents and retrying",
+		"model", req.model.ModelPath,
+		"loaded_count", loadedCount,
+		"gpu_layers", gpuLayers,
+		"total_layers", totalLayers,
+		"fit_overflow_layers", overflow,
+		"size", format.HumanBytes2(totalSize),
+		"vram", format.HumanBytes2(vramSize))
+	return true
+}
+
+func explicitPartialGPUOffload(opts api.Options, f *ggml.GGML) bool {
+	if opts.NumGPU <= 0 || f == nil {
+		return false
+	}
+
+	return uint64(opts.NumGPU) < f.KV().BlockCount()+1
+}
+
+func effectiveLlamaServerContext(numCtx int, f *ggml.GGML, numParallel int) int {
+	return effectiveModelContext(numCtx, f) * max(numParallel, 1)
+}
+
+func optionsWithAutomaticGenerationBatch(opts api.Options, numBatchAuto, completion bool, effectiveCtx int, predictedVRAM, availableMemory uint64, flashAttention ml.FlashAttentionType, gpus []ml.DeviceInfo) api.Options {
+	if completion && numBatchAuto {
+		opts.NumBatch = automaticGenerationBatch(effectiveCtx, predictedVRAM, availableMemory, flashAttention, gpus)
+	}
+	return opts
+}
+
+func generationBatchSurchargeForCompletion(completion bool, batch int) uint64 {
+	if !completion {
+		return 0
+	}
+	return generationBatchSurcharge(batch)
+}
+
+func automaticGenerationBatch(effectiveCtx int, predictedVRAM, availableMemory uint64, flashAttention ml.FlashAttentionType, gpus []ml.DeviceInfo) int {
+	if flashAttention == ml.FlashAttentionDisabled && hasCUDADevice(gpus) {
+		if constrainedCUDAWithoutFlashAttention(effectiveCtx, gpus) {
+			return llamaServerGenerationBatchConstrained
+		}
+		return llamaServerGenerationBatchDefault
+	}
+
+	batch := generationBatchForContext(effectiveCtx)
+	for batch > llamaServerGenerationBatchDefault && !generationBatchFits(batch, predictedVRAM, availableMemory) {
+		batch = nextLowerGenerationBatch(batch)
+	}
+	return batch
+}
+
+func hasCUDADevice(gpus []ml.DeviceInfo) bool {
+	return slices.ContainsFunc(gpus, func(gpu ml.DeviceInfo) bool {
+		return gpu.Library == "CUDA"
+	})
+}
+
+func constrainedCUDAWithoutFlashAttention(effectiveCtx int, gpus []ml.DeviceInfo) bool {
+	if effectiveCtx <= 4096 {
+		return false
+	}
+	return slices.ContainsFunc(gpus, func(gpu ml.DeviceInfo) bool {
+		if gpu.Library != "CUDA" {
+			return false
+		}
+		memory := gpu.FreeMemory
+		if memory == 0 || (gpu.TotalMemory > 0 && gpu.TotalMemory < memory) {
+			memory = gpu.TotalMemory
+		}
+		return memory > 0 && memory <= 8*format.GibiByte
+	})
+}
+
+func generationBatchForContext(effectiveCtx int) int {
+	switch {
+	case effectiveCtx > 32768:
+		return llamaServerGenerationBatchLarge
+	case effectiveCtx > 4096:
+		return llamaServerGenerationBatchMedium
+	default:
+		return llamaServerGenerationBatchDefault
+	}
+}
+
+func generationBatchFits(batch int, predictedVRAM, availableMemory uint64) bool {
+	if predictedVRAM == 0 || availableMemory == 0 {
+		return true
+	}
+
+	threshold := availableMemory * llamaServerLoadHeadroomPercent / 100
+	if predictedVRAM > threshold {
+		return false
+	}
+	if !generationBatchHasHeadroom(batch, predictedVRAM, availableMemory) {
+		return false
+	}
+
+	return generationBatchSurcharge(batch) <= threshold-predictedVRAM
+}
+
+func generationBatchHasHeadroom(batch int, predictedVRAM, availableMemory uint64) bool {
+	switch {
+	case batch >= llamaServerGenerationBatchLarge:
+		return predictedVRAM <= availableMemory*llamaServerGenerationBatchLargeHeadroomPercent/100
+	case batch >= llamaServerGenerationBatchMedium:
+		return predictedVRAM <= availableMemory*llamaServerGenerationBatchMediumHeadroomPercent/100
+	default:
+		return true
+	}
+}
+
+func nextLowerGenerationBatch(batch int) int {
+	switch {
+	case batch > llamaServerGenerationBatchMedium:
+		return llamaServerGenerationBatchMedium
+	default:
+		return llamaServerGenerationBatchDefault
+	}
+}
+
+func generationBatchSurcharge(batch int) uint64 {
+	switch {
+	case batch >= llamaServerGenerationBatchLarge:
+		return 2 * format.GibiByte
+	case batch >= llamaServerGenerationBatchMedium:
+		return 768 * format.MebiByte
+	default:
+		return 0
+	}
+}
+
+func nextLowerAutoNumCtx(numCtx int) (int, bool) {
+	switch {
+	case numCtx > 32768:
+		return 32768, true
+	case numCtx > 4096:
+		return 4096, true
+	default:
+		return 0, false
+	}
+}
+
+func availableMemoryForLoad(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo) (available, gpuFree uint64, systemLimited bool) {
+	var sharedGPUFree uint64
+	var discreteGPUFree uint64
+	var reserve uint64
+	for i, gpu := range gpus {
+		gpuFree += gpu.FreeMemory
+		reserve += llamaServerDeviceReserve(gpu, i)
+		if gpu.Integrated {
+			sharedGPUFree += gpu.FreeMemory
+		} else {
+			discreteGPUFree += gpu.FreeMemory
+		}
+	}
+
+	available = gpuFree
+	// On iGPUs, GPU free memory can be a static or slowly refreshed device
+	// baseline. updateFreeSpace has already subtracted known Ollama runner
+	// allocations from that baseline. Current system free memory is a separate
+	// live measurement that already includes those loaded runners, so use the
+	// smaller value for shared-memory GPUs without discounting discrete VRAM.
+	if systemInfo.FreeMemory > 0 && sharedGPUFree > 0 && systemInfo.FreeMemory < sharedGPUFree {
+		available, systemLimited = discreteGPUFree+systemInfo.FreeMemory, true
+	}
+
+	if reserve >= available {
+		available = 0
+	} else {
+		available -= reserve
+	}
+	return available, gpuFree, systemLimited
+}
+
+func availableMemoryForPlacement(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, opts api.Options) (available, gpuFree uint64, systemLimited bool) {
+	placementGpus := gpusForPlacement(gpus, opts)
+	if len(placementGpus) == 1 && opts.MainGPU != nil {
+		gpu := placementGpus[0]
+		gpuFree = gpu.FreeMemory
+		available = availableMemoryForGPU(systemInfo, gpu, 0)
+		systemLimited = gpu.Integrated && systemInfo.FreeMemory > 0 && systemInfo.FreeMemory < gpu.FreeMemory
+		return available, gpuFree, systemLimited
+	}
+
+	return availableMemoryForLoad(systemInfo, placementGpus)
+}
+
+func gpusForPlacement(gpus []ml.DeviceInfo, opts api.Options) []ml.DeviceInfo {
+	if opts.MainGPU != nil && *opts.MainGPU >= 0 && *opts.MainGPU < len(gpus) {
+		return []ml.DeviceInfo{gpus[*opts.MainGPU]}
+	}
+
+	return gpus
+}
+
+func selectLlamaServerPlacement(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, predictedVRAM uint64, opts api.Options) ([]ml.DeviceInfo, api.Options) {
+	launchOpts := opts
+	if len(gpus) <= 1 || opts.NumGPU == 0 {
+		return gpus, launchOpts
+	}
+
+	groups := ml.ByLibrary(gpus)
+	if len(groups) == 0 {
+		return gpus, launchOpts
+	}
+
+	if opts.MainGPU != nil {
+		gpu, available, ok := bestExplicitMainGPU(systemInfo, groups, *opts.MainGPU)
+		if !ok {
+			selected := bestGPUGroupByAvailableMemory(systemInfo, groups)
+			slog.Warn("requested main_gpu is outside the selected GPU group; passing value through to llama-server",
+				"main_gpu", *opts.MainGPU,
+				"gpu_count", len(selected))
+			logSelectedGPUGroup(gpus, selected)
+			return selected, launchOpts
+		}
+
+		selected, launchOpts := singleLlamaServerGPUPlacement(gpu, launchOpts)
+		slog.Info("selecting requested single GPU for llama-server model",
+			"requested_main_gpu", *opts.MainGPU,
+			"main_gpu", *launchOpts.MainGPU,
+			"id", gpu.ID,
+			"filter_id", gpu.FilterID,
+			"library", gpu.Library,
+			"name", gpu.Name,
+			"description", gpu.Description,
+			"integrated", gpu.Integrated,
+			"available", format.HumanBytes2(available))
+		logSelectedGPUGroup(gpus, selected)
+		return selected, launchOpts
+	}
+
+	if !envconfig.SchedSpread() && predictedVRAM > 0 {
+		gpu, available, ok := bestSingleGPUFit(systemInfo, groups, predictedVRAM)
+		if ok {
+			selected, launchOpts := singleLlamaServerGPUPlacement(gpu, launchOpts)
+			slog.Info("selecting single GPU for llama-server model",
+				"main_gpu", *launchOpts.MainGPU,
+				"id", gpu.ID,
+				"filter_id", gpu.FilterID,
+				"library", gpu.Library,
+				"name", gpu.Name,
+				"description", gpu.Description,
+				"integrated", gpu.Integrated,
+				"predicted", format.HumanBytes2(predictedVRAM),
+				"available", format.HumanBytes2(available))
+			logSelectedGPUGroup(gpus, selected)
+			return selected, launchOpts
+		}
+	}
+
+	selected := bestGPUGroupByAvailableMemory(systemInfo, groups)
+	logSelectedGPUGroup(gpus, selected)
+	return selected, launchOpts
+}
+
+func singleLlamaServerGPUPlacement(gpu ml.DeviceInfo, opts api.Options) ([]ml.DeviceInfo, api.Options) {
+	// llama-server sees only this GPU after filtering, so the selected device is
+	// index 0 for both main_gpu and per-device fit-target values.
+	mainGPU := 0
+	opts.MainGPU = &mainGPU
+	return []ml.DeviceInfo{gpu}, opts
+}
+
+func bestExplicitMainGPU(systemInfo ml.SystemInfo, groups [][]ml.DeviceInfo, mainGPU int) (gpu ml.DeviceInfo, available uint64, ok bool) {
+	if mainGPU < 0 {
+		return ml.DeviceInfo{}, 0, false
+	}
+
+	for _, group := range groups {
+		if mainGPU >= len(group) {
+			continue
+		}
+		candidate := group[mainGPU]
+		candidateAvailable := availableMemoryForGPU(systemInfo, candidate, 0)
+		if !ok || betterPlacementGPU(candidate, candidateAvailable, gpu, available) {
+			gpu = candidate
+			available = candidateAvailable
+			ok = true
+		}
+	}
+
+	return gpu, available, ok
+}
+
+func bestSingleGPUFit(systemInfo ml.SystemInfo, groups [][]ml.DeviceInfo, predictedVRAM uint64) (gpu ml.DeviceInfo, available uint64, ok bool) {
+	for _, group := range groups {
+		for _, candidate := range group {
+			candidateAvailable := availableMemoryForGPU(systemInfo, candidate, 0)
+			if predictedVRAM > candidateAvailable {
+				continue
+			}
+			if !ok || betterPlacementGPU(candidate, candidateAvailable, gpu, available) {
+				gpu = candidate
+				available = candidateAvailable
+				ok = true
+			}
+		}
+	}
+
+	return gpu, available, ok
+}
+
+func betterPlacementGPU(candidate ml.DeviceInfo, candidateAvailable uint64, current ml.DeviceInfo, currentAvailable uint64) bool {
+	if candidate.Integrated != current.Integrated {
+		return !candidate.Integrated
+	}
+
+	return candidateAvailable > currentAvailable
+}
+
+func bestGPUGroupByAvailableMemory(systemInfo ml.SystemInfo, groups [][]ml.DeviceInfo) []ml.DeviceInfo {
+	var best []ml.DeviceInfo
+	var bestAvailable uint64
+	for _, group := range groups {
+		available, _, _ := availableMemoryForLoad(systemInfo, group)
+		if best == nil || betterPlacementGroup(group, available, best, bestAvailable) {
+			best = group
+			bestAvailable = available
+		}
+	}
+
+	return best
+}
+
+func betterPlacementGroup(candidate []ml.DeviceInfo, candidateAvailable uint64, current []ml.DeviceInfo, currentAvailable uint64) bool {
+	candidateDiscrete := hasDiscreteGPU(candidate)
+	currentDiscrete := hasDiscreteGPU(current)
+	if candidateDiscrete != currentDiscrete {
+		return candidateDiscrete
+	}
+
+	return candidateAvailable > currentAvailable
+}
+
+func hasDiscreteGPU(gpus []ml.DeviceInfo) bool {
+	for _, gpu := range gpus {
+		if !gpu.Integrated {
+			return true
+		}
+	}
+	return false
+}
+
+func availableMemoryForGPU(systemInfo ml.SystemInfo, gpu ml.DeviceInfo, visibleIndex int) uint64 {
+	available := gpu.FreeMemory
+	if gpu.Integrated && systemInfo.FreeMemory > 0 && systemInfo.FreeMemory < gpu.FreeMemory {
+		available = systemInfo.FreeMemory
+	}
+
+	reserve := llamaServerDeviceReserve(gpu, visibleIndex)
+	if reserve >= available {
+		return 0
+	}
+	return available - reserve
+}
+
+func llamaServerDeviceReserve(gpu ml.DeviceInfo, visibleIndex int) uint64 {
+	return gpu.MinimumMemory() + max(envconfig.GpuOverhead(), llamaServerFitTargetBytes(visibleIndex))
+}
+
+func llamaServerFitTargetBytes(visibleIndex int) uint64 {
+	value := envconfig.Var(llm.LlamaServerFitTargetEnv)
+	if value != "" {
+		target, ok, err := parseLlamaServerFitTargetMiB(value, visibleIndex)
+		if err != nil {
+			slog.Warn("invalid llama-server fit target; using default",
+				"env", llm.LlamaServerFitTargetEnv,
+				"value", value,
+				"error", err)
+		} else if ok {
+			return target * format.MebiByte
+		}
+	}
+
+	// llama.cpp's default --fit-target margin: scheduler placement reserves
+	// the same memory the llama-server fit pass will.
+	return llm.LlamaServerDefaultFitTargetMiB * format.MebiByte
+}
+
+func parseLlamaServerFitTargetMiB(value string, visibleIndex int) (uint64, bool, error) {
+	// Match llama.cpp's parsing: values separated by "," or "/", a single
+	// value broadcast to every device, and devices beyond the list keeping
+	// the default margin.
+	targets := strings.FieldsFunc(value, func(r rune) bool { return r == ',' || r == '/' })
+	if len(targets) == 1 {
+		visibleIndex = 0
+	}
+	if visibleIndex < 0 || visibleIndex >= len(targets) {
+		return 0, false, nil
+	}
+
+	target, err := strconv.ParseUint(strings.TrimSpace(targets[visibleIndex]), 10, 64)
+	if err != nil {
+		return 0, true, err
+	}
+	return target, true, nil
+}
+
+// llamaServerFitTargetsForRunner composes the per-device LLAMA_ARG_FIT_TARGET
+// values (MiB, visible-device order) for a llama-server launch. Each device
+// gets the largest applicable margin from llama.cpp's default fit margin,
+// OLLAMA_GPU_OVERHEAD, and per-device runner environment overrides discovered
+// during bootstrap. Returns nil to leave the inherited environment or
+// llama.cpp default in place: when the user set LLAMA_ARG_FIT_TARGET
+// themselves, or when no per-device override exists and every device would use
+// llama.cpp's default anyway.
+func llamaServerFitTargetsForRunner(gpus []ml.DeviceInfo) []uint64 {
+	if envconfig.Var(llm.LlamaServerFitTargetEnv) != "" {
+		return nil
+	}
+
+	marginMiB := uint64(llm.LlamaServerDefaultFitTargetMiB)
+	if overheadMiB := (envconfig.GpuOverhead() + format.MebiByte - 1) / format.MebiByte; overheadMiB > marginMiB {
+		marginMiB = overheadMiB
+	}
+
+	allDefault := true
+	targets := make([]uint64, len(gpus))
+	for i, gpu := range gpus {
+		target := marginMiB
+		if value, ok := gpu.RunnerEnvOverrides[llm.LlamaServerFitTargetEnv]; ok {
+			allDefault = false
+			override, parsed, err := parseLlamaServerFitTargetMiB(value, i)
+			if err != nil {
+				slog.Warn("invalid per-device llama-server fit target; using scheduler margin",
+					"env", llm.LlamaServerFitTargetEnv,
+					"value", value,
+					"id", gpu.ID,
+					"library", gpu.Library,
+					"error", err)
+			} else if parsed {
+				target = max(target, override)
+			}
+		}
+		if marginMiB != llm.LlamaServerDefaultFitTargetMiB {
+			allDefault = false
+		}
+		targets[i] = target
+	}
+
+	if allDefault {
+		return nil
+	}
+
+	slog.Info("setting llama-server fit target",
+		"env", llm.LlamaServerFitTargetEnv,
+		"margin_mib", marginMiB,
+		"targets_mib", targets)
+	return targets
+}
+
+func logSelectedGPUGroup(all, selected []ml.DeviceInfo) {
+	if len(selected) == 0 || len(selected) == len(all) {
+		return
+	}
+
+	slog.Info("selecting GPU backend for llama-server model",
+		"library", selected[0].Library,
+		"gpu_count", len(selected),
+		"available_gpu_count", len(all))
+}
+
+func mmapHostPressureHeadroom(totalMemory uint64) uint64 {
+	if totalMemory == 0 {
+		return 8 * format.GigaByte
+	}
+	return max(8*format.GigaByte, totalMemory/10)
+}
+
+func modelFileSize(path string) uint64 {
+	if path == "" {
+		return 0
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0
+	}
+	return uint64(info.Size())
+}
+
+func (s *Scheduler) loadedMmapModelSizeLocked() uint64 {
+	var total uint64
+	for _, r := range s.loaded {
+		if r == nil {
+			continue
+		}
+		r.refMu.Lock()
+		usesMmap := r.Options == nil || r.Options.UseMMap == nil || *r.Options.UseMMap
+		modelPath := r.modelPath
+		totalSize := r.totalSize
+		r.refMu.Unlock()
+
+		if !usesMmap {
+			continue
+		}
+		if size := modelFileSize(modelPath); size > 0 {
+			total += size
+		} else {
+			total += totalSize
+		}
+	}
+	return total
+}

--- a/server/load_plan_llama_test.go
+++ b/server/load_plan_llama_test.go
@@ -1,0 +1,439 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/format"
+	"github.com/ollama/ollama/fs/ggml"
+	"github.com/ollama/ollama/llm"
+	"github.com/ollama/ollama/ml"
+)
+
+func TestSchedLlamaServerConfigCarriesMemoryAssessment(t *testing.T) {
+	ctx, done := context.WithTimeout(t.Context(), 500*time.Millisecond)
+	defer done()
+	t.Setenv("OLLAMA_NUM_PARALLEL", "1")
+
+	s := InitScheduler(ctx)
+	scenario := newScenarioRequestWithContext(t, ctx, "vision-regression-model", 1*format.GigaByte, nil, nil, 131072)
+	scenario.req.opts.NumCtx = 32768
+
+	systemInfo := ml.SystemInfo{
+		TotalMemory: 64 * format.GibiByte,
+		FreeMemory:  64 * format.GibiByte,
+	}
+	gpus := []ml.DeviceInfo{{
+		DeviceID:    ml.DeviceID{ID: "0", Library: "CUDA"},
+		TotalMemory: 24 * format.GibiByte,
+		FreeMemory:  20 * format.GibiByte,
+	}}
+
+	requestedCtx := scenario.req.opts.NumCtx
+	var gotConfig llm.LlamaServerConfig
+	var gotOpts api.Options
+	var gotGpus []ml.DeviceInfo
+	var gotModel *ggml.GGML
+	s.newServerFn = func(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, model string, f *ggml.GGML, adapters []string, projectors []string, opts api.Options, numParallel int, config llm.LlamaServerConfig) (llm.LlamaServer, error) {
+		gotConfig = config
+		gotOpts = opts
+		gotGpus = append([]ml.DeviceInfo(nil), gpus...)
+		gotModel = f
+		scenario.srv.modelPath = model
+		return scenario.srv, nil
+	}
+
+	require.False(t, s.load(scenario.req, systemInfo, gpus, false))
+	select {
+	case err := <-scenario.req.errCh:
+		require.NoError(t, err)
+	case <-scenario.req.successCh:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for load")
+	}
+
+	require.NotNil(t, gotModel)
+	require.NotEmpty(t, gotGpus)
+	predictedCtx := effectiveLlamaServerContext(requestedCtx, gotModel, 1)
+	predictedModel := llm.PredictServerVRAM(scenario.req.model.ModelPath, gotModel, predictedCtx)
+	available, _, _ := availableMemoryForPlacement(systemInfo, gotGpus, gotOpts)
+	require.Equal(t, predictedModel+generationBatchSurchargeForCompletion(true, gotOpts.NumBatch), gotConfig.PredictedVRAM)
+	require.Equal(t, available, gotConfig.AvailableVRAM)
+	require.NotZero(t, gotConfig.PredictedVRAM)
+	require.NotZero(t, gotConfig.AvailableVRAM)
+}
+
+func TestLlamaServerLoadPlanCarriesFitTargetFromGPUOverhead(t *testing.T) {
+	ctx, done := context.WithTimeout(t.Context(), 500*time.Millisecond)
+	defer done()
+	t.Setenv("OLLAMA_GPU_OVERHEAD", "2147483648")
+	t.Setenv(llamaServerFitTargetEnv, "")
+
+	scenario := newScenarioRequestWithContext(t, ctx, "fit-target-model", 1*format.GigaByte, nil, nil, 32768)
+	plan, err := newLlamaServerLoadPlan(scenario.req, loadProposal{
+		systemInfo: ml.SystemInfo{FreeMemory: 64 * format.GibiByte},
+		gpus: []ml.DeviceInfo{{
+			DeviceID:   ml.DeviceID{ID: "0", Library: "CUDA"},
+			FreeMemory: 24 * format.GibiByte,
+		}},
+		numParallel: 1,
+		completion:  true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint64(2048), plan.config.FitTargetMiB)
+}
+
+func TestAvailableMemoryForLoadUsesWorstSharedMemoryMeasurement(t *testing.T) {
+	t.Setenv("OLLAMA_GPU_OVERHEAD", "")
+	t.Setenv(llamaServerFitTargetEnv, "")
+
+	metalReserve := llamaServerReserveForTest("Metal")
+	vulkanReserve := llamaServerReserveForTest("Vulkan")
+	cudaReserve := llamaServerReserveForTest("CUDA")
+
+	tests := []struct {
+		name              string
+		systemFree        uint64
+		gpus              []ml.DeviceInfo
+		wantAvailable     uint64
+		wantGPUFree       uint64
+		wantSystemLimited bool
+	}{
+		{
+			name:       "integrated metal uses lower system free",
+			systemFree: 80 * format.GigaByte,
+			gpus: []ml.DeviceInfo{{
+				DeviceID:   ml.DeviceID{Library: "Metal"},
+				Integrated: true,
+				FreeMemory: 300 * format.GigaByte,
+			}},
+			wantAvailable:     80*format.GigaByte - metalReserve,
+			wantGPUFree:       300 * format.GigaByte,
+			wantSystemLimited: true,
+		},
+		{
+			name:       "integrated gpu uses lower system free",
+			systemFree: 6 * format.GigaByte,
+			gpus: []ml.DeviceInfo{{
+				DeviceID:   ml.DeviceID{Library: "Vulkan"},
+				Integrated: true,
+				FreeMemory: 12 * format.GigaByte,
+			}},
+			wantAvailable:     6*format.GigaByte - vulkanReserve,
+			wantGPUFree:       12 * format.GigaByte,
+			wantSystemLimited: true,
+		},
+		{
+			name:       "discrete metal ignores lower system free",
+			systemFree: 6 * format.GigaByte,
+			gpus: []ml.DeviceInfo{{
+				DeviceID:   ml.DeviceID{Library: "Metal"},
+				FreeMemory: 12 * format.GigaByte,
+			}},
+			wantAvailable: 12*format.GigaByte - metalReserve,
+			wantGPUFree:   12 * format.GigaByte,
+		},
+		{
+			name:       "discrete gpu ignores lower system free",
+			systemFree: 6 * format.GigaByte,
+			gpus: []ml.DeviceInfo{{
+				DeviceID:   ml.DeviceID{Library: "CUDA"},
+				FreeMemory: 12 * format.GigaByte,
+			}},
+			wantAvailable: 12*format.GigaByte - cudaReserve,
+			wantGPUFree:   12 * format.GigaByte,
+		},
+		{
+			name:       "mixed gpus only clamp integrated contribution",
+			systemFree: 6 * format.GigaByte,
+			gpus: []ml.DeviceInfo{
+				{
+					DeviceID:   ml.DeviceID{Library: "CUDA"},
+					FreeMemory: 12 * format.GigaByte,
+				},
+				{
+					DeviceID:   ml.DeviceID{Library: "Vulkan"},
+					Integrated: true,
+					FreeMemory: 10 * format.GigaByte,
+				},
+			},
+			wantAvailable:     18*format.GigaByte - cudaReserve - vulkanReserve,
+			wantGPUFree:       22 * format.GigaByte,
+			wantSystemLimited: true,
+		},
+		{
+			name:       "shared gpu keeps lower adjusted gpu baseline",
+			systemFree: 20 * format.GigaByte,
+			gpus: []ml.DeviceInfo{{
+				DeviceID:   ml.DeviceID{Library: "Metal"},
+				Integrated: true,
+				FreeMemory: 12 * format.GigaByte,
+			}},
+			wantAvailable: 12*format.GigaByte - metalReserve,
+			wantGPUFree:   12 * format.GigaByte,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			available, gpuFree, systemLimited := availableMemoryForLoad(ml.SystemInfo{FreeMemory: tt.systemFree}, tt.gpus)
+			require.Equal(t, tt.wantAvailable, available)
+			require.Equal(t, tt.wantGPUFree, gpuFree)
+			require.Equal(t, tt.wantSystemLimited, systemLimited)
+		})
+	}
+}
+
+func llamaServerReserveForTest(library string) uint64 {
+	gpu := ml.DeviceInfo{DeviceID: ml.DeviceID{Library: library}}
+	return gpu.MinimumMemory() + llamaServerDefaultFitTargetMiB*format.MebiByte
+}
+
+func TestSelectLlamaServerPlacement(t *testing.T) {
+	t.Setenv("OLLAMA_GPU_OVERHEAD", "")
+	t.Setenv(llamaServerFitTargetEnv, "")
+
+	systemInfo := ml.SystemInfo{FreeMemory: 14 * format.GigaByte}
+
+	tests := []struct {
+		name             string
+		gpus             []ml.DeviceInfo
+		predictedVRAM    uint64
+		opts             api.Options
+		schedSpread      string
+		wantLibrary      string
+		wantMainGPU      *int
+		wantSelectedGPUs int
+		wantGPUID        string
+	}{
+		{
+			name:          "selects largest same-backend GPU",
+			predictedVRAM: 8 * format.GigaByte,
+			gpus: []ml.DeviceInfo{
+				{DeviceID: ml.DeviceID{ID: "0", Library: "CUDA"}, Name: "small", FreeMemory: 10 * format.GigaByte},
+				{DeviceID: ml.DeviceID{ID: "1", Library: "CUDA"}, Name: "large", FreeMemory: 20 * format.GigaByte},
+			},
+			opts:             api.DefaultOptions(),
+			wantLibrary:      "CUDA",
+			wantMainGPU:      testIntPtr(0),
+			wantSelectedGPUs: 1,
+			wantGPUID:        "1",
+		},
+		{
+			name:          "explicit main gpu selects matching backend group",
+			predictedVRAM: 8 * format.GigaByte,
+			gpus: []ml.DeviceInfo{
+				{DeviceID: ml.DeviceID{ID: "0", Library: "CUDA"}, FreeMemory: 10 * format.GigaByte},
+				{DeviceID: ml.DeviceID{ID: "0", Library: "ROCm"}, FreeMemory: 20 * format.GigaByte},
+				{DeviceID: ml.DeviceID{ID: "1", Library: "ROCm"}, FreeMemory: 24 * format.GigaByte},
+			},
+			opts: api.Options{
+				Runner: api.Runner{MainGPU: testIntPtr(1), NumGPU: -1},
+			},
+			wantLibrary:      "ROCm",
+			wantMainGPU:      testIntPtr(0),
+			wantSelectedGPUs: 1,
+			wantGPUID:        "1",
+		},
+		{
+			name:          "integrated GPU is capped by system free memory",
+			predictedVRAM: 12 * format.GigaByte,
+			gpus: []ml.DeviceInfo{
+				{DeviceID: ml.DeviceID{ID: "0", Library: "Metal"}, Integrated: true, FreeMemory: 32 * format.GigaByte},
+				{DeviceID: ml.DeviceID{ID: "1", Library: "Metal"}, FreeMemory: 16 * format.GigaByte},
+			},
+			opts:             api.DefaultOptions(),
+			wantLibrary:      "Metal",
+			wantMainGPU:      testIntPtr(0),
+			wantSelectedGPUs: 1,
+			wantGPUID:        "1",
+		},
+		{
+			name:          "prefers discrete GPU over integrated GPU with more available memory",
+			predictedVRAM: 8 * format.GigaByte,
+			gpus: []ml.DeviceInfo{
+				{DeviceID: ml.DeviceID{ID: "0", Library: "Vulkan"}, Name: "integrated", Integrated: true, FreeMemory: 32 * format.GigaByte},
+				{DeviceID: ml.DeviceID{ID: "1", Library: "Vulkan"}, Name: "discrete", FreeMemory: 10 * format.GigaByte},
+			},
+			opts:             api.DefaultOptions(),
+			wantLibrary:      "Vulkan",
+			wantMainGPU:      testIntPtr(0),
+			wantSelectedGPUs: 1,
+			wantGPUID:        "1",
+		},
+		{
+			name:          "spread disables automatic single GPU selection",
+			predictedVRAM: 8 * format.GigaByte,
+			schedSpread:   "1",
+			gpus: []ml.DeviceInfo{
+				{DeviceID: ml.DeviceID{ID: "0", Library: "CUDA"}, FreeMemory: 10 * format.GigaByte},
+				{DeviceID: ml.DeviceID{ID: "1", Library: "CUDA"}, FreeMemory: 20 * format.GigaByte},
+			},
+			opts:             api.DefaultOptions(),
+			wantLibrary:      "CUDA",
+			wantSelectedGPUs: 2,
+		},
+		{
+			name:          "no single fit chooses best backend group for llama-server split",
+			predictedVRAM: 30 * format.GigaByte,
+			gpus: []ml.DeviceInfo{
+				{DeviceID: ml.DeviceID{ID: "0", Library: "CUDA"}, FreeMemory: 10 * format.GigaByte},
+				{DeviceID: ml.DeviceID{ID: "1", Library: "CUDA"}, FreeMemory: 18 * format.GigaByte},
+				{DeviceID: ml.DeviceID{ID: "0", Library: "ROCm"}, FreeMemory: 12 * format.GigaByte},
+			},
+			opts:             api.DefaultOptions(),
+			wantLibrary:      "CUDA",
+			wantSelectedGPUs: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("OLLAMA_SCHED_SPREAD", tt.schedSpread)
+
+			selected, launchOpts := selectLlamaServerPlacement(systemInfo, tt.gpus, tt.predictedVRAM, tt.opts)
+			require.Len(t, selected, tt.wantSelectedGPUs)
+			require.Equal(t, tt.wantLibrary, selected[0].Library)
+			if tt.wantGPUID != "" {
+				require.Equal(t, tt.wantGPUID, selected[0].ID)
+			}
+			if tt.wantMainGPU == nil {
+				require.Nil(t, launchOpts.MainGPU)
+			} else {
+				require.NotNil(t, launchOpts.MainGPU)
+				require.Equal(t, *tt.wantMainGPU, *launchOpts.MainGPU)
+			}
+		})
+	}
+}
+
+func TestSelectLlamaServerPlacementReserveEnv(t *testing.T) {
+	check := func(name string, gpus []ml.DeviceInfo, overhead, fitTarget string, want int) {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("OLLAMA_GPU_OVERHEAD", overhead)
+			t.Setenv(llamaServerFitTargetEnv, fitTarget)
+
+			selected, _ := selectLlamaServerPlacement(ml.SystemInfo{}, gpus, 20307*format.MebiByte, api.DefaultOptions())
+			require.Len(t, selected, want)
+		})
+	}
+
+	issue16599GPUs := []ml.DeviceInfo{
+		{DeviceID: ml.DeviceID{ID: "0", Library: "CUDA"}, FreeMemory: 23336 * format.MebiByte},
+		{DeviceID: ml.DeviceID{ID: "1", Library: "CUDA"}, FreeMemory: 7106 * format.MebiByte},
+	}
+	check("issue 16599 selects single GPU with default reserve", issue16599GPUs, "", "", 1)
+	check("gpu overhead prevents single GPU selection", issue16599GPUs, "3221225472", "", 2)
+	check("fit target prevents single GPU selection", issue16599GPUs, "", "4096", 2)
+
+	reversedGPUs := []ml.DeviceInfo{
+		{DeviceID: ml.DeviceID{ID: "0", Library: "CUDA"}, FreeMemory: 7106 * format.MebiByte},
+		{DeviceID: ml.DeviceID{ID: "1", Library: "CUDA"}, FreeMemory: 23336 * format.MebiByte},
+	}
+	check("comma fit target uses selected visible gpu index", reversedGPUs, "", "1024,4096", 1)
+
+	t.Run("comma fit target uses selected backend visible order", func(t *testing.T) {
+		t.Setenv("OLLAMA_GPU_OVERHEAD", "")
+		t.Setenv(llamaServerFitTargetEnv, "1024,4096,4096")
+
+		mixedVendorGPUs := []ml.DeviceInfo{
+			{DeviceID: ml.DeviceID{ID: "0", Library: "CUDA"}, FreeMemory: 7106 * format.MebiByte},
+			{DeviceID: ml.DeviceID{ID: "0", Library: "ROCm"}, FreeMemory: 7106 * format.MebiByte},
+			{DeviceID: ml.DeviceID{ID: "1", Library: "ROCm"}, FreeMemory: 23336 * format.MebiByte},
+		}
+		selected, launchOpts := selectLlamaServerPlacement(ml.SystemInfo{}, mixedVendorGPUs, 20307*format.MebiByte, api.DefaultOptions())
+
+		require.Len(t, selected, 1)
+		require.Equal(t, "ROCm", selected[0].Library)
+		require.Equal(t, "1", selected[0].ID)
+		require.NotNil(t, launchOpts.MainGPU)
+		require.Equal(t, 0, *launchOpts.MainGPU)
+	})
+}
+
+func TestLlamaServerFitTargetForRunner(t *testing.T) {
+	check := func(name, overhead, fitTarget string, want uint64) {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("OLLAMA_GPU_OVERHEAD", overhead)
+			t.Setenv(llamaServerFitTargetEnv, fitTarget)
+
+			require.Equal(t, want, llamaServerFitTargetForRunner())
+		})
+	}
+
+	check("below default", "536870912", "", 0)
+	check("above default", "2147483648", "", 2048)
+	check("rounds up", "1073741825", "", 1025)
+	check("explicit fit target wins", "2147483648", "512", 0)
+}
+
+func TestLlamaServerLoadPlanEvictionHeadroom(t *testing.T) {
+	tests := []struct {
+		name        string
+		plan        llamaServerLoadPlan
+		requireFull bool
+		loadedCount int
+		want        loadedRunnerFit
+	}{
+		{
+			name: "does not evict when no runners are loaded",
+			plan: llamaServerLoadPlan{
+				gpus:   []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}}},
+				memory: loadMemoryAssessment{predictedLoad: 17 * format.GigaByte, available: 20 * format.GigaByte},
+			},
+			requireFull: true,
+		},
+		{
+			name: "does not evict when partial offload is allowed",
+			plan: llamaServerLoadPlan{
+				gpus:   []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}}},
+				memory: loadMemoryAssessment{predictedLoad: 17 * format.GigaByte, available: 20 * format.GigaByte},
+			},
+			loadedCount: 1,
+		},
+		{
+			name: "does not evict at headroom boundary",
+			plan: llamaServerLoadPlan{
+				gpus:   []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}}},
+				memory: loadMemoryAssessment{predictedLoad: 16 * format.GigaByte, available: 20 * format.GigaByte},
+			},
+			requireFull: true,
+			loadedCount: 1,
+			want:        loadedRunnerFits,
+		},
+		{
+			name: "evicts above headroom boundary",
+			plan: llamaServerLoadPlan{
+				gpus:   []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}}},
+				memory: loadMemoryAssessment{predictedLoad: 17 * format.GigaByte, available: 20 * format.GigaByte},
+			},
+			requireFull: true,
+			loadedCount: 1,
+			want:        loadedRunnerNeedsEviction,
+		},
+		{
+			name: "evicts when available memory is unknown",
+			plan: llamaServerLoadPlan{
+				gpus:   []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}}},
+				memory: loadMemoryAssessment{predictedLoad: 1 * format.GigaByte},
+			},
+			requireFull: true,
+			loadedCount: 1,
+			want:        loadedRunnerNeedsEviction,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.plan.assessLoadedRunnerFit(tt.requireFull, tt.loadedCount))
+		})
+	}
+}
+
+func testIntPtr(v int) *int {
+	return &v
+}

--- a/server/load_plan_llama_test.go
+++ b/server/load_plan_llama_test.go
@@ -1,0 +1,615 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/format"
+	"github.com/ollama/ollama/llm"
+	"github.com/ollama/ollama/ml"
+)
+
+func TestLlamaServerLoadPlanMemoryAssessment(t *testing.T) {
+	ctx, done := context.WithTimeout(t.Context(), 500*time.Millisecond)
+	defer done()
+
+	scenario := newScenarioRequestWithContext(t, ctx, "memory-assessment-model", 1*format.GigaByte, nil, nil, 131072)
+	scenario.req.opts.NumCtx = 32768
+
+	proposal := loadProposal{
+		systemInfo: ml.SystemInfo{
+			TotalMemory: 64 * format.GibiByte,
+			FreeMemory:  64 * format.GibiByte,
+		},
+		gpus: []ml.DeviceInfo{{
+			DeviceID:    ml.DeviceID{ID: "0", Library: "CUDA"},
+			TotalMemory: 24 * format.GibiByte,
+			FreeMemory:  20 * format.GibiByte,
+		}},
+		numParallel: 1,
+		completion:  true,
+	}
+	plan, err := newLlamaServerLoadPlan(scenario.req, proposal)
+	require.NoError(t, err)
+
+	predictedCtx := effectiveLlamaServerContext(scenario.req.opts.NumCtx, plan.model, proposal.numParallel)
+	predictedModel := llm.PredictServerVRAM(scenario.req.model.ModelPath, plan.model, predictedCtx)
+	available, _, _ := availableMemoryForPlacement(proposal.systemInfo, plan.gpus, plan.launchOpts)
+	require.Equal(t, predictedModel, plan.memory.predictedModel)
+	require.Equal(t, predictedModel+generationBatchSurchargeForCompletion(true, plan.launchOpts.NumBatch), plan.memory.predictedLoad)
+	require.Equal(t, available, plan.memory.available)
+	require.NotZero(t, plan.memory.predictedLoad)
+	require.NotZero(t, plan.memory.available)
+}
+
+func TestLlamaServerLoadPlanCarriesFitTargetFromGPUOverhead(t *testing.T) {
+	ctx, done := context.WithTimeout(t.Context(), 500*time.Millisecond)
+	defer done()
+	t.Setenv("OLLAMA_GPU_OVERHEAD", "2147483648")
+	t.Setenv(llm.LlamaServerFitTargetEnv, "")
+
+	scenario := newScenarioRequestWithContext(t, ctx, "fit-target-model", 1*format.GigaByte, nil, nil, 32768)
+	plan, err := newLlamaServerLoadPlan(scenario.req, loadProposal{
+		systemInfo: ml.SystemInfo{FreeMemory: 64 * format.GibiByte},
+		gpus: []ml.DeviceInfo{{
+			DeviceID:   ml.DeviceID{ID: "0", Library: "CUDA"},
+			FreeMemory: 24 * format.GibiByte,
+		}},
+		numParallel: 1,
+		completion:  true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []uint64{2048}, plan.config.FitTargetsMiB)
+}
+
+func TestAvailableMemoryForLoadUsesWorstSharedMemoryMeasurement(t *testing.T) {
+	t.Setenv("OLLAMA_GPU_OVERHEAD", "")
+	t.Setenv(llm.LlamaServerFitTargetEnv, "")
+
+	metalReserve := llamaServerReserveForTest("Metal")
+	vulkanReserve := llamaServerReserveForTest("Vulkan")
+	cudaReserve := llamaServerReserveForTest("CUDA")
+
+	tests := []struct {
+		name              string
+		systemFree        uint64
+		gpus              []ml.DeviceInfo
+		wantAvailable     uint64
+		wantGPUFree       uint64
+		wantSystemLimited bool
+	}{
+		{
+			name:       "integrated metal uses lower system free",
+			systemFree: 80 * format.GigaByte,
+			gpus: []ml.DeviceInfo{{
+				DeviceID:   ml.DeviceID{Library: "Metal"},
+				Integrated: true,
+				FreeMemory: 300 * format.GigaByte,
+			}},
+			wantAvailable:     80*format.GigaByte - metalReserve,
+			wantGPUFree:       300 * format.GigaByte,
+			wantSystemLimited: true,
+		},
+		{
+			name:       "integrated gpu uses lower system free",
+			systemFree: 6 * format.GigaByte,
+			gpus: []ml.DeviceInfo{{
+				DeviceID:   ml.DeviceID{Library: "Vulkan"},
+				Integrated: true,
+				FreeMemory: 12 * format.GigaByte,
+			}},
+			wantAvailable:     6*format.GigaByte - vulkanReserve,
+			wantGPUFree:       12 * format.GigaByte,
+			wantSystemLimited: true,
+		},
+		{
+			name:       "discrete metal ignores lower system free",
+			systemFree: 6 * format.GigaByte,
+			gpus: []ml.DeviceInfo{{
+				DeviceID:   ml.DeviceID{Library: "Metal"},
+				FreeMemory: 12 * format.GigaByte,
+			}},
+			wantAvailable: 12*format.GigaByte - metalReserve,
+			wantGPUFree:   12 * format.GigaByte,
+		},
+		{
+			name:       "discrete gpu ignores lower system free",
+			systemFree: 6 * format.GigaByte,
+			gpus: []ml.DeviceInfo{{
+				DeviceID:   ml.DeviceID{Library: "CUDA"},
+				FreeMemory: 12 * format.GigaByte,
+			}},
+			wantAvailable: 12*format.GigaByte - cudaReserve,
+			wantGPUFree:   12 * format.GigaByte,
+		},
+		{
+			name:       "mixed gpus only clamp integrated contribution",
+			systemFree: 6 * format.GigaByte,
+			gpus: []ml.DeviceInfo{
+				{
+					DeviceID:   ml.DeviceID{Library: "CUDA"},
+					FreeMemory: 12 * format.GigaByte,
+				},
+				{
+					DeviceID:   ml.DeviceID{Library: "Vulkan"},
+					Integrated: true,
+					FreeMemory: 10 * format.GigaByte,
+				},
+			},
+			wantAvailable:     18*format.GigaByte - cudaReserve - vulkanReserve,
+			wantGPUFree:       22 * format.GigaByte,
+			wantSystemLimited: true,
+		},
+		{
+			name:       "shared gpu keeps lower adjusted gpu baseline",
+			systemFree: 20 * format.GigaByte,
+			gpus: []ml.DeviceInfo{{
+				DeviceID:   ml.DeviceID{Library: "Metal"},
+				Integrated: true,
+				FreeMemory: 12 * format.GigaByte,
+			}},
+			wantAvailable: 12*format.GigaByte - metalReserve,
+			wantGPUFree:   12 * format.GigaByte,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			available, gpuFree, systemLimited := availableMemoryForLoad(ml.SystemInfo{FreeMemory: tt.systemFree}, tt.gpus)
+			require.Equal(t, tt.wantAvailable, available)
+			require.Equal(t, tt.wantGPUFree, gpuFree)
+			require.Equal(t, tt.wantSystemLimited, systemLimited)
+		})
+	}
+}
+
+// llamaServerReserveForTest computes the production device reserve; callers
+// must clear OLLAMA_GPU_OVERHEAD and LLAMA_ARG_FIT_TARGET first.
+func llamaServerReserveForTest(library string) uint64 {
+	gpu := ml.DeviceInfo{DeviceID: ml.DeviceID{Library: library}}
+	return llamaServerDeviceReserve(gpu, 0)
+}
+
+func TestSelectLlamaServerPlacement(t *testing.T) {
+	t.Setenv("OLLAMA_GPU_OVERHEAD", "")
+	t.Setenv(llm.LlamaServerFitTargetEnv, "")
+
+	systemInfo := ml.SystemInfo{FreeMemory: 14 * format.GigaByte}
+
+	tests := []struct {
+		name             string
+		gpus             []ml.DeviceInfo
+		predictedVRAM    uint64
+		opts             api.Options
+		schedSpread      string
+		wantLibrary      string
+		wantMainGPU      *int
+		wantSelectedGPUs int
+		wantGPUID        string
+	}{
+		{
+			name:          "selects largest same-backend GPU",
+			predictedVRAM: 8 * format.GigaByte,
+			gpus: []ml.DeviceInfo{
+				{DeviceID: ml.DeviceID{ID: "0", Library: "CUDA"}, Name: "small", FreeMemory: 10 * format.GigaByte},
+				{DeviceID: ml.DeviceID{ID: "1", Library: "CUDA"}, Name: "large", FreeMemory: 20 * format.GigaByte},
+			},
+			opts:             api.DefaultOptions(),
+			wantLibrary:      "CUDA",
+			wantMainGPU:      new(0),
+			wantSelectedGPUs: 1,
+			wantGPUID:        "1",
+		},
+		{
+			name:          "explicit main gpu selects matching backend group",
+			predictedVRAM: 8 * format.GigaByte,
+			gpus: []ml.DeviceInfo{
+				{DeviceID: ml.DeviceID{ID: "0", Library: "CUDA"}, FreeMemory: 10 * format.GigaByte},
+				{DeviceID: ml.DeviceID{ID: "0", Library: "ROCm"}, FreeMemory: 20 * format.GigaByte},
+				{DeviceID: ml.DeviceID{ID: "1", Library: "ROCm"}, FreeMemory: 24 * format.GigaByte},
+			},
+			opts: api.Options{
+				Runner: api.Runner{MainGPU: new(1), NumGPU: -1},
+			},
+			wantLibrary:      "ROCm",
+			wantMainGPU:      new(0),
+			wantSelectedGPUs: 1,
+			wantGPUID:        "1",
+		},
+		{
+			name:          "integrated GPU is capped by system free memory",
+			predictedVRAM: 12 * format.GigaByte,
+			gpus: []ml.DeviceInfo{
+				{DeviceID: ml.DeviceID{ID: "0", Library: "Metal"}, Integrated: true, FreeMemory: 32 * format.GigaByte},
+				{DeviceID: ml.DeviceID{ID: "1", Library: "Metal"}, FreeMemory: 16 * format.GigaByte},
+			},
+			opts:             api.DefaultOptions(),
+			wantLibrary:      "Metal",
+			wantMainGPU:      new(0),
+			wantSelectedGPUs: 1,
+			wantGPUID:        "1",
+		},
+		{
+			name:          "prefers discrete GPU over integrated GPU with more available memory",
+			predictedVRAM: 8 * format.GigaByte,
+			gpus: []ml.DeviceInfo{
+				{DeviceID: ml.DeviceID{ID: "0", Library: "Vulkan"}, Name: "integrated", Integrated: true, FreeMemory: 32 * format.GigaByte},
+				{DeviceID: ml.DeviceID{ID: "1", Library: "Vulkan"}, Name: "discrete", FreeMemory: 10 * format.GigaByte},
+			},
+			opts:             api.DefaultOptions(),
+			wantLibrary:      "Vulkan",
+			wantMainGPU:      new(0),
+			wantSelectedGPUs: 1,
+			wantGPUID:        "1",
+		},
+		{
+			name:          "spread disables automatic single GPU selection",
+			predictedVRAM: 8 * format.GigaByte,
+			schedSpread:   "1",
+			gpus: []ml.DeviceInfo{
+				{DeviceID: ml.DeviceID{ID: "0", Library: "CUDA"}, FreeMemory: 10 * format.GigaByte},
+				{DeviceID: ml.DeviceID{ID: "1", Library: "CUDA"}, FreeMemory: 20 * format.GigaByte},
+			},
+			opts:             api.DefaultOptions(),
+			wantLibrary:      "CUDA",
+			wantSelectedGPUs: 2,
+		},
+		{
+			name:          "no single fit chooses best backend group for llama-server split",
+			predictedVRAM: 30 * format.GigaByte,
+			gpus: []ml.DeviceInfo{
+				{DeviceID: ml.DeviceID{ID: "0", Library: "CUDA"}, FreeMemory: 10 * format.GigaByte},
+				{DeviceID: ml.DeviceID{ID: "1", Library: "CUDA"}, FreeMemory: 18 * format.GigaByte},
+				{DeviceID: ml.DeviceID{ID: "0", Library: "ROCm"}, FreeMemory: 12 * format.GigaByte},
+			},
+			opts:             api.DefaultOptions(),
+			wantLibrary:      "CUDA",
+			wantSelectedGPUs: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("OLLAMA_SCHED_SPREAD", tt.schedSpread)
+
+			selected, launchOpts := selectLlamaServerPlacement(systemInfo, tt.gpus, tt.predictedVRAM, tt.opts)
+			require.Len(t, selected, tt.wantSelectedGPUs)
+			require.Equal(t, tt.wantLibrary, selected[0].Library)
+			if tt.wantGPUID != "" {
+				require.Equal(t, tt.wantGPUID, selected[0].ID)
+			}
+			if tt.wantMainGPU == nil {
+				require.Nil(t, launchOpts.MainGPU)
+			} else {
+				require.NotNil(t, launchOpts.MainGPU)
+				require.Equal(t, *tt.wantMainGPU, *launchOpts.MainGPU)
+			}
+		})
+	}
+}
+
+func TestSelectLlamaServerPlacementReserveEnv(t *testing.T) {
+	check := func(name string, gpus []ml.DeviceInfo, overhead, fitTarget string, want int) {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("OLLAMA_GPU_OVERHEAD", overhead)
+			t.Setenv(llm.LlamaServerFitTargetEnv, fitTarget)
+
+			selected, _ := selectLlamaServerPlacement(ml.SystemInfo{}, gpus, 20307*format.MebiByte, api.DefaultOptions())
+			require.Len(t, selected, want)
+		})
+	}
+
+	issue16599GPUs := []ml.DeviceInfo{
+		{DeviceID: ml.DeviceID{ID: "0", Library: "CUDA"}, FreeMemory: 23336 * format.MebiByte},
+		{DeviceID: ml.DeviceID{ID: "1", Library: "CUDA"}, FreeMemory: 7106 * format.MebiByte},
+	}
+	check("issue 16599 selects single GPU with default reserve", issue16599GPUs, "", "", 1)
+	check("gpu overhead prevents single GPU selection", issue16599GPUs, "3221225472", "", 2)
+	check("fit target prevents single GPU selection", issue16599GPUs, "", "4096", 2)
+
+	reversedGPUs := []ml.DeviceInfo{
+		{DeviceID: ml.DeviceID{ID: "0", Library: "CUDA"}, FreeMemory: 7106 * format.MebiByte},
+		{DeviceID: ml.DeviceID{ID: "1", Library: "CUDA"}, FreeMemory: 23336 * format.MebiByte},
+	}
+	check("comma fit target uses selected visible gpu index", reversedGPUs, "", "1024,4096", 1)
+
+	t.Run("comma fit target uses selected backend visible order", func(t *testing.T) {
+		t.Setenv("OLLAMA_GPU_OVERHEAD", "")
+		t.Setenv(llm.LlamaServerFitTargetEnv, "1024,4096,4096")
+
+		mixedVendorGPUs := []ml.DeviceInfo{
+			{DeviceID: ml.DeviceID{ID: "0", Library: "CUDA"}, FreeMemory: 7106 * format.MebiByte},
+			{DeviceID: ml.DeviceID{ID: "0", Library: "ROCm"}, FreeMemory: 7106 * format.MebiByte},
+			{DeviceID: ml.DeviceID{ID: "1", Library: "ROCm"}, FreeMemory: 23336 * format.MebiByte},
+		}
+		selected, launchOpts := selectLlamaServerPlacement(ml.SystemInfo{}, mixedVendorGPUs, 20307*format.MebiByte, api.DefaultOptions())
+
+		require.Len(t, selected, 1)
+		require.Equal(t, "ROCm", selected[0].Library)
+		require.Equal(t, "1", selected[0].ID)
+		require.NotNil(t, launchOpts.MainGPU)
+		require.Equal(t, 0, *launchOpts.MainGPU)
+	})
+}
+
+func TestLlamaServerFitTargetsForRunner(t *testing.T) {
+	cudaGPU := func(id string, fitTarget ...string) ml.DeviceInfo {
+		gpu := ml.DeviceInfo{
+			DeviceID: ml.DeviceID{ID: id, Library: "CUDA"},
+		}
+		if len(fitTarget) > 0 {
+			gpu.RunnerEnvOverrides = map[string]string{
+				llm.LlamaServerFitTargetEnv: fitTarget[0],
+			}
+		}
+		return gpu
+	}
+
+	rocmGPU := func(id string, fitTarget string) ml.DeviceInfo {
+		return ml.DeviceInfo{
+			DeviceID: ml.DeviceID{ID: id, Library: "ROCm"},
+			RunnerEnvOverrides: map[string]string{
+				llm.LlamaServerFitTargetEnv: fitTarget,
+			},
+		}
+	}
+
+	check := func(name, overhead, fitTarget string, gpus []ml.DeviceInfo, want []uint64) {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("OLLAMA_GPU_OVERHEAD", overhead)
+			t.Setenv(llm.LlamaServerFitTargetEnv, fitTarget)
+
+			require.Equal(t, want, llamaServerFitTargetsForRunner(gpus))
+		})
+	}
+
+	oneGPU := []ml.DeviceInfo{cudaGPU("0")}
+	check("overhead below default keeps llama.cpp default", "536870912", "", oneGPU, nil)
+	check("overhead above default becomes the margin", "2147483648", "", oneGPU, []uint64{2048})
+	check("overhead rounds up", "1073741825", "", oneGPU, []uint64{1025})
+	check("explicit fit target wins", "2147483648", "512", oneGPU, nil)
+	check("no devices", "2147483648", "", nil, nil)
+	check("per-device override is preserved", "", "",
+		[]ml.DeviceInfo{rocmGPU("0", "61440")}, []uint64{61440})
+	check("per-device override composes with overhead by visible order", "2147483648", "",
+		[]ml.DeviceInfo{cudaGPU("0"), rocmGPU("1", "61440")}, []uint64{2048, 61440})
+	check("larger overhead wins over smaller per-device override", "2147483648", "",
+		[]ml.DeviceInfo{rocmGPU("0", "512")}, []uint64{2048})
+	check("small per-device override is normalized to llama.cpp default", "", "",
+		[]ml.DeviceInfo{rocmGPU("0", "512")}, []uint64{1024})
+	check("explicit fit target wins over per-device override", "2147483648", "512",
+		[]ml.DeviceInfo{rocmGPU("0", "61440")}, nil)
+	check("invalid per-device override is normalized to llama.cpp default", "", "",
+		[]ml.DeviceInfo{rocmGPU("0", "not-a-number")}, []uint64{1024})
+	check("overhead applies per device", "2147483648", "",
+		[]ml.DeviceInfo{cudaGPU("0"), cudaGPU("1")}, []uint64{2048, 2048})
+	check("all-default devices stay unset", "", "",
+		[]ml.DeviceInfo{cudaGPU("0"), cudaGPU("1")}, nil)
+}
+
+func TestLlamaServerLoadPlanEvictionHeadroom(t *testing.T) {
+	tests := []struct {
+		name        string
+		plan        llamaServerLoadPlan
+		requireFull bool
+		loadedCount int
+		want        loadedRunnerFit
+	}{
+		{
+			name: "does not evict when no runners are loaded",
+			plan: llamaServerLoadPlan{
+				gpus:   []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}}},
+				memory: loadMemoryAssessment{predictedLoad: 17 * format.GigaByte, available: 20 * format.GigaByte},
+			},
+			requireFull: true,
+		},
+		{
+			name: "does not evict when partial offload is allowed",
+			plan: llamaServerLoadPlan{
+				gpus:   []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}}},
+				memory: loadMemoryAssessment{predictedLoad: 17 * format.GigaByte, available: 20 * format.GigaByte},
+			},
+			loadedCount: 1,
+		},
+		{
+			name: "does not evict at headroom boundary",
+			plan: llamaServerLoadPlan{
+				gpus:   []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}}},
+				memory: loadMemoryAssessment{predictedLoad: 16 * format.GigaByte, available: 20 * format.GigaByte},
+			},
+			requireFull: true,
+			loadedCount: 1,
+			want:        loadedRunnerFits,
+		},
+		{
+			name: "evicts above headroom boundary",
+			plan: llamaServerLoadPlan{
+				gpus:   []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}}},
+				memory: loadMemoryAssessment{predictedLoad: 17 * format.GigaByte, available: 20 * format.GigaByte},
+			},
+			requireFull: true,
+			loadedCount: 1,
+			want:        loadedRunnerNeedsEviction,
+		},
+		{
+			name: "evicts when available memory is unknown",
+			plan: llamaServerLoadPlan{
+				gpus:   []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}}},
+				memory: loadMemoryAssessment{predictedLoad: 1 * format.GigaByte},
+			},
+			requireFull: true,
+			loadedCount: 1,
+			want:        loadedRunnerNeedsEviction,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.plan.assessLoadedRunnerFit(tt.requireFull, tt.loadedCount))
+		})
+	}
+}
+
+func TestLlamaServerFitTargetBytes(t *testing.T) {
+	check := func(name, value string, visibleIndex int, wantMiB uint64) {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv(llm.LlamaServerFitTargetEnv, value)
+			require.Equal(t, wantMiB*format.MebiByte, llamaServerFitTargetBytes(visibleIndex))
+		})
+	}
+
+	check("unset uses llama.cpp default", "", 0, llm.LlamaServerDefaultFitTargetMiB)
+	check("single value broadcasts to all devices", "512", 3, 512)
+	check("comma separated selects device", "512,2048", 1, 2048)
+	check("slash separated selects device", "512/2048", 1, 2048)
+	check("device beyond list keeps default", "512,2048", 2, llm.LlamaServerDefaultFitTargetMiB)
+	check("invalid value keeps default", "not-a-number", 0, llm.LlamaServerDefaultFitTargetMiB)
+}
+
+func TestLlamaServerDisableMmapReason(t *testing.T) {
+	ctx, done := context.WithTimeout(t.Context(), 500*time.Millisecond)
+	defer done()
+
+	scenario := newScenarioRequestWithContext(t, ctx, "mmap-default-model", 1*format.GigaByte, nil, nil, 8192)
+	f, err := llm.LoadModel(scenario.req.model.ModelPath, 1024)
+	require.NoError(t, err)
+	fullOffloadLayers := int(f.KV().BlockCount()) + 1
+
+	useMmap := true
+	cudaGPU := []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}, TotalMemory: 100 * format.GigaByte, FreeMemory: 80 * format.GigaByte}}
+	metalGPU := []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "Metal"}}}
+	integratedGPU := []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}, Integrated: true, TotalMemory: 100 * format.GigaByte, FreeMemory: 80 * format.GigaByte}}
+	pressureSystem := ml.SystemInfo{TotalMemory: 100 * format.GigaByte, FreeMemory: 50 * format.GigaByte}
+	pressureMemory := loadMemoryAssessment{predictedModel: 30 * format.GigaByte, available: 80 * format.GigaByte}
+
+	tests := []struct {
+		name           string
+		goos           string
+		opts           api.Options
+		gpus           []ml.DeviceInfo
+		memory         loadMemoryAssessment
+		systemInfo     ml.SystemInfo
+		modelSize      uint64
+		loadedMmapSize uint64
+		want           string
+	}{
+		{
+			name: "explicit use_mmap true wins",
+			goos: "windows",
+			opts: api.Options{Runner: api.Runner{NumGPU: -1, UseMMap: &useMmap}},
+			gpus: cudaGPU,
+		},
+		{
+			name: "cpu-only request disables mmap",
+			goos: "linux",
+			opts: api.Options{Runner: api.Runner{NumGPU: 0}},
+			gpus: cudaGPU,
+			want: "cpu",
+		},
+		{
+			name: "no GPU devices disables mmap",
+			goos: "linux",
+			opts: api.Options{Runner: api.Runner{NumGPU: -1}},
+			want: "cpu",
+		},
+		{
+			name: "windows cuda disables mmap",
+			goos: "windows",
+			opts: api.Options{Runner: api.Runner{NumGPU: -1}},
+			gpus: cudaGPU,
+			want: "windows_cuda",
+		},
+		{
+			name: "metal partial offload disables mmap",
+			goos: "darwin",
+			opts: api.Options{Runner: api.Runner{NumGPU: fullOffloadLayers - 1}},
+			gpus: metalGPU,
+			want: "metal_partial_offload",
+		},
+		{
+			name: "metal full offload keeps default",
+			goos: "darwin",
+			opts: api.Options{Runner: api.Runner{NumGPU: fullOffloadLayers}},
+			gpus: metalGPU,
+		},
+		{
+			name:   "metal auto partial offload disables mmap",
+			goos:   "darwin",
+			opts:   api.Options{Runner: api.Runner{NumGPU: -1}},
+			gpus:   metalGPU,
+			memory: loadMemoryAssessment{predictedModel: 30 * format.GigaByte, available: 20 * format.GigaByte},
+			want:   "metal_partial_offload",
+		},
+		{
+			name:   "metal auto full offload keeps default",
+			goos:   "darwin",
+			opts:   api.Options{Runner: api.Runner{NumGPU: -1}},
+			gpus:   metalGPU,
+			memory: loadMemoryAssessment{predictedModel: 10 * format.GigaByte, available: 20 * format.GigaByte},
+		},
+		{
+			name: "linux cuda keeps default",
+			goos: "linux",
+			opts: api.Options{Runner: api.Runner{NumGPU: -1}},
+			gpus: cudaGPU,
+		},
+		{
+			name:           "linux host memory pressure disables mmap",
+			goos:           "linux",
+			opts:           api.Options{Runner: api.Runner{NumGPU: -1}},
+			gpus:           cudaGPU,
+			memory:         pressureMemory,
+			systemInfo:     pressureSystem,
+			modelSize:      20 * format.GigaByte,
+			loadedMmapSize: 25 * format.GigaByte,
+			want:           "host_memory_pressure",
+		},
+		{
+			name:           "only the Linux pressure heuristic applies",
+			goos:           "darwin",
+			opts:           api.Options{Runner: api.Runner{NumGPU: -1}},
+			gpus:           cudaGPU,
+			memory:         pressureMemory,
+			systemInfo:     pressureSystem,
+			modelSize:      20 * format.GigaByte,
+			loadedMmapSize: 25 * format.GigaByte,
+		},
+		{
+			name:           "shared-memory GPU keeps the normal mmap path",
+			goos:           "linux",
+			opts:           api.Options{Runner: api.Runner{NumGPU: -1}},
+			gpus:           integratedGPU,
+			memory:         pressureMemory,
+			systemInfo:     pressureSystem,
+			modelSize:      20 * format.GigaByte,
+			loadedMmapSize: 25 * format.GigaByte,
+		},
+		{
+			name:           "tight VRAM keeps mmap so partial offload stays file-backed",
+			goos:           "linux",
+			opts:           api.Options{Runner: api.Runner{NumGPU: -1}},
+			gpus:           cudaGPU,
+			memory:         loadMemoryAssessment{predictedModel: 70 * format.GigaByte, available: 80 * format.GigaByte},
+			systemInfo:     pressureSystem,
+			modelSize:      20 * format.GigaByte,
+			loadedMmapSize: 25 * format.GigaByte,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plan := llamaServerLoadPlan{
+				model:       f,
+				gpus:        tt.gpus,
+				requestOpts: tt.opts,
+				launchOpts:  tt.opts,
+				memory:      tt.memory,
+			}
+			require.Equal(t, tt.want, llamaServerDisableMmapReason(tt.goos, plan, tt.systemInfo, tt.modelSize, tt.loadedMmapSize))
+		})
+	}
+}

--- a/server/load_plan_mlx.go
+++ b/server/load_plan_mlx.go
@@ -1,0 +1,107 @@
+package server
+
+import (
+	"log/slog"
+	"slices"
+
+	"github.com/ollama/ollama/format"
+	"github.com/ollama/ollama/llm"
+	"github.com/ollama/ollama/ml"
+	"github.com/ollama/ollama/x/imagegen"
+	"github.com/ollama/ollama/x/mlxrunner"
+)
+
+// mlxLoadPlan is the MLX preflight result. MLX can estimate model size and
+// context before loading, but startup allocation failures are reported later
+// from runner readiness checks rather than synchronously from Load.
+type mlxLoadPlan struct {
+	modelName         string
+	softContextLength int
+	modelContext      int
+	image             bool
+	hasGPU            bool
+	gpus              []ml.DeviceInfo
+	memory            loadMemoryAssessment
+}
+
+// newMLXLoadPlan translates a scheduler load proposal into the MLX runner plan.
+// It uses manifest metadata for context and memory preflight before the
+// subprocess starts so scheduler eviction decisions use the same estimate MLX
+// will recheck during Load.
+func newMLXLoadPlan(req *LlmRequest, proposal loadProposal) (mlxLoadPlan, error) {
+	plan := mlxLoadPlan{
+		modelName:         req.model.ShortName,
+		softContextLength: req.opts.NumCtx,
+		image:             slices.Contains(req.model.Config.Capabilities, "image"),
+		gpus:              slices.Clone(proposal.gpus),
+	}
+	if plan.image {
+		return plan, nil
+	}
+
+	if err := mlxrunner.CheckPlatformSupport(); err != nil {
+		return mlxLoadPlan{}, err
+	}
+
+	estimate, err := mlxrunner.EstimateLoad(plan.modelName, proposal.gpus)
+	if err != nil {
+		return mlxLoadPlan{}, err
+	}
+	plan.modelContext = estimate.ContextLength
+	plan.softContextLength = effectiveContext(plan.softContextLength, plan.modelContext)
+	plan.hasGPU = estimate.HasGPU
+
+	plan.memory = loadMemoryAssessment{
+		predictedModel: estimate.ModelSize,
+		predictedLoad:  estimate.ModelSize,
+		available:      estimate.Available,
+		gpuFree:        estimate.GPUFree,
+	}
+	return plan, nil
+}
+
+func (p mlxLoadPlan) applyToRequest(_ *LlmRequest) {}
+
+func (p mlxLoadPlan) gpusForLoad() []ml.DeviceInfo {
+	return p.gpus
+}
+
+func (p mlxLoadPlan) newServer(_ *Scheduler, _ *LlmRequest) (llm.LlamaServer, error) {
+	if p.image {
+		return imagegen.NewServer(p.modelName)
+	}
+	return mlxrunner.NewClient(p.modelName, p.softContextLength)
+}
+
+func (p mlxLoadPlan) retryPlanner() loadRetryPlanner {
+	// MLX Load only rechecks preflight fit and starts the subprocess. Real
+	// startup allocation failures surface later from WaitUntilRunning, after
+	// Scheduler.load has returned, so there is no synchronous Load retry hook
+	// to wire here.
+	return nil
+}
+
+func (p mlxLoadPlan) trainContext() int {
+	return p.modelContext
+}
+
+func (p mlxLoadPlan) assessLoadedRunnerFit(requireFull bool, loadedCount int) loadedRunnerFit {
+	if p.image || !p.hasGPU || !requireFull || loadedCount == 0 {
+		return loadedRunnerFitSkipped
+	}
+	if !p.memory.fitsAvailable() {
+		return loadedRunnerNeedsEviction
+	}
+	return loadedRunnerFits
+}
+
+func (p mlxLoadPlan) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("backend", "mlx"),
+		slog.String("predicted", format.HumanBytes2(p.memory.predictedLoad)),
+		slog.Int("num_ctx", p.softContextLength),
+		slog.Int("model_context", p.modelContext),
+		slog.String("available", format.HumanBytes2(p.memory.available)),
+		slog.String("gpu_free", format.HumanBytes2(p.memory.gpuFree)),
+	)
+}

--- a/server/load_plan_mlx.go
+++ b/server/load_plan_mlx.go
@@ -1,0 +1,100 @@
+package server
+
+import (
+	"log/slog"
+	"slices"
+
+	"github.com/ollama/ollama/format"
+	"github.com/ollama/ollama/llm"
+	"github.com/ollama/ollama/ml"
+	"github.com/ollama/ollama/x/mlxrunner"
+)
+
+// mlxLoadPlan is the MLX preflight result. MLX can estimate model size and
+// context before loading, but startup allocation failures are reported later
+// from runner readiness checks rather than synchronously from Load.
+type mlxLoadPlan struct {
+	modelName         string
+	softContextLength int
+	modelContext      int
+	hasGPU            bool
+	gpus              []ml.DeviceInfo
+	memory            loadMemoryAssessment
+}
+
+// newMLXLoadPlan translates a scheduler load proposal into the MLX runner plan.
+// It uses manifest metadata for context and memory preflight before the
+// subprocess starts so scheduler eviction decisions use the same estimate MLX
+// will recheck during Load.
+func newMLXLoadPlan(req *LlmRequest, proposal loadProposal) (mlxLoadPlan, error) {
+	plan := mlxLoadPlan{
+		modelName:         req.model.ShortName,
+		softContextLength: req.opts.NumCtx,
+		gpus:              slices.Clone(proposal.gpus),
+	}
+
+	if err := mlxrunner.CheckPlatformSupport(); err != nil {
+		return mlxLoadPlan{}, err
+	}
+
+	estimate, err := mlxrunner.EstimateLoad(plan.modelName, proposal.gpus)
+	if err != nil {
+		return mlxLoadPlan{}, err
+	}
+	plan.modelContext = estimate.ContextLength
+	plan.softContextLength = effectiveContext(plan.softContextLength, plan.modelContext)
+	plan.hasGPU = estimate.HasGPU
+
+	plan.memory = loadMemoryAssessment{
+		predictedModel: estimate.ModelSize,
+		predictedLoad:  estimate.ModelSize,
+		available:      estimate.Available,
+		gpuFree:        estimate.GPUFree,
+	}
+	return plan, nil
+}
+
+// applyToRequest is a no-op: MLX planning does not rewrite request options.
+// The effective context is passed to the runner client in newServer instead.
+func (p mlxLoadPlan) applyToRequest(_ *LlmRequest) {}
+
+func (p mlxLoadPlan) gpusForLoad() []ml.DeviceInfo {
+	return p.gpus
+}
+
+func (p mlxLoadPlan) newServer(_ *Scheduler, _ *LlmRequest) (llm.LlamaServer, error) {
+	return mlxrunner.NewClient(p.modelName, p.softContextLength)
+}
+
+func (p mlxLoadPlan) retryPlanner() loadRetryPlanner {
+	// MLX Load only rechecks preflight fit and starts the subprocess. Real
+	// startup allocation failures surface later from WaitUntilRunning, after
+	// Scheduler.load has returned, so there is no synchronous Load retry hook
+	// to wire here.
+	return nil
+}
+
+func (p mlxLoadPlan) trainContext() int {
+	return p.modelContext
+}
+
+func (p mlxLoadPlan) assessLoadedRunnerFit(requireFull bool, loadedCount int) loadedRunnerFit {
+	if !p.hasGPU || !requireFull || loadedCount == 0 {
+		return loadedRunnerFitSkipped
+	}
+	if !p.memory.fitsAvailable() {
+		return loadedRunnerNeedsEviction
+	}
+	return loadedRunnerFits
+}
+
+func (p mlxLoadPlan) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("backend", "mlx"),
+		slog.String("predicted", format.HumanBytes2(p.memory.predictedLoad)),
+		slog.Int("num_ctx", p.softContextLength),
+		slog.Int("model_context", p.modelContext),
+		slog.String("available", format.HumanBytes2(p.memory.available)),
+		slog.String("gpu_free", format.HumanBytes2(p.memory.gpuFree)),
+	)
+}

--- a/server/load_plan_mlx_test.go
+++ b/server/load_plan_mlx_test.go
@@ -1,0 +1,49 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/types/model"
+)
+
+func TestMLXLoadPlanEvictionRequiresGPU(t *testing.T) {
+	plan := mlxLoadPlan{
+		modelContext: 32768,
+		memory: loadMemoryAssessment{
+			predictedLoad: 10,
+			available:     0,
+		},
+	}
+
+	require.Equal(t, 32768, plan.trainContext())
+
+	require.Equal(t, loadedRunnerFitSkipped, plan.assessLoadedRunnerFit(true, 1))
+
+	plan.hasGPU = true
+	require.Equal(t, loadedRunnerNeedsEviction, plan.assessLoadedRunnerFit(true, 1))
+
+	plan.image = true
+	require.Equal(t, loadedRunnerFitSkipped, plan.assessLoadedRunnerFit(true, 1))
+}
+
+func TestMLXLoadPlanImageSkipsMemoryPreflight(t *testing.T) {
+	req := &LlmRequest{
+		model: &Model{
+			ShortName: "image-model",
+			Config: model.ConfigV2{
+				Capabilities: []string{"image"},
+			},
+		},
+		opts: api.Options{Runner: api.Runner{NumCtx: 8192}},
+	}
+
+	plan, err := newMLXLoadPlan(req, loadProposal{})
+	require.NoError(t, err)
+	require.True(t, plan.image)
+	require.Equal(t, "image-model", plan.modelName)
+	require.Equal(t, 8192, plan.softContextLength)
+	require.Equal(t, loadedRunnerFitSkipped, plan.assessLoadedRunnerFit(true, 1))
+}

--- a/server/load_plan_mlx_test.go
+++ b/server/load_plan_mlx_test.go
@@ -1,0 +1,24 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMLXLoadPlanEvictionRequiresGPU(t *testing.T) {
+	plan := mlxLoadPlan{
+		modelContext: 32768,
+		memory: loadMemoryAssessment{
+			predictedLoad: 10,
+			available:     0,
+		},
+	}
+
+	require.Equal(t, 32768, plan.trainContext())
+
+	require.Equal(t, loadedRunnerFitSkipped, plan.assessLoadedRunnerFit(true, 1))
+
+	plan.hasGPU = true
+	require.Equal(t, loadedRunnerNeedsEviction, plan.assessLoadedRunnerFit(true, 1))
+}

--- a/server/routes.go
+++ b/server/routes.go
@@ -225,15 +225,12 @@ func (s *Server) scheduleRunner(ctx context.Context, name string, caps []model.C
 		return nil, nil, nil, err
 	}
 
-	runnerCh, errCh := s.sched.getRunner(ctx, model, opts, keepAlive, numCtxAuto, numBatchAuto, shift)
-	var runner *runnerRef
-	select {
-	case runner = <-runnerCh:
-	case err = <-errCh:
+	llama, err := s.sched.acquireRunner(ctx, model, opts, keepAlive, numCtxAuto, numBatchAuto, shift)
+	if err != nil {
 		return nil, nil, nil, err
 	}
 
-	return runner.llama, model, &opts, nil
+	return llama, model, &opts, nil
 }
 
 func signinURL() (string, error) {

--- a/server/sched.go
+++ b/server/sched.go
@@ -5,12 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"os"
 	"reflect"
-	"runtime"
 	"slices"
 	"sort"
-	"strings"
 	"sync"
 	"time"
 
@@ -23,8 +20,6 @@ import (
 	"github.com/ollama/ollama/logutil"
 	"github.com/ollama/ollama/ml"
 	"github.com/ollama/ollama/types/model"
-	"github.com/ollama/ollama/x/imagegen"
-	"github.com/ollama/ollama/x/mlxrunner"
 )
 
 type LlmRequest struct {
@@ -36,9 +31,10 @@ type LlmRequest struct {
 	errCh           chan error
 	schedAttempts   uint
 
-	// oomRetryAttempted is set after a llama-server load crash triggers an
-	// evict-all-and-retry. Prevents infinite retry on persistent load failures.
-	oomRetryAttempted bool
+	// loadRetryAttempted is set after a backend load outcome triggers a retry
+	// through the eviction path. It prevents infinite retry on persistent load
+	// failures or CPU spills.
+	loadRetryAttempted bool
 
 	// numCtxAuto is true when NumCtx came from Ollama's automatic VRAM-tier
 	// default rather than explicit request, model, or environment config.
@@ -319,12 +315,12 @@ func (s *Scheduler) processPending(ctx context.Context) {
 						break
 					}
 
-					// OOM retry path: load() crashed post-spawn and we still
-					// have other models resident. Evict all of them, wait for
-					// every unload, then loop back to retry the load once.
-					// load() has already set oomRetryAttempted so a second
-					// crash falls through to the fail-fast path.
-					if pending.oomRetryAttempted {
+					// Load retry path: Load failed or llama-server spilled to
+					// CPU with resident models still loaded. Evict all of them,
+					// wait for every unload, then loop back to retry once.
+					// load() has already set loadRetryAttempted so a second
+					// failure falls through to the fail-fast path.
+					if pending.loadRetryAttempted {
 						if !s.evictAllAndWait(ctx, pendingKey) {
 							return
 						}
@@ -522,81 +518,55 @@ func (s *Scheduler) load(req *LlmRequest, systemInfo ml.SystemInfo, gpus []ml.De
 
 	s.loadedMu.Lock()
 	llama := s.activeLoading
-	var f *ggml.GGML
 	loadGpus := gpus
-	var launchOpts api.Options
+	var retryPlanner loadRetryPlanner
+	var trainContext int
+	loadedCountAtLoadStart := len(s.loaded)
+	proposal := loadProposal{
+		systemInfo:  systemInfo,
+		gpus:        gpus,
+		numParallel: numParallel,
+		completion:  completion,
+	}
 
 	if llama == nil {
+		var plan runnerLoadPlan
 		var err error
-		if !req.model.IsMLX() {
-			var loadErr error
-			f, loadErr = llm.LoadModel(req.model.ModelPath, 1024)
-			if loadErr != nil {
-				slog.Info("failed to load model metadata", "model", req.model.ModelPath, "error", loadErr)
-				req.errCh <- loadErr
-				s.loadedMu.Unlock()
-				return false
-			}
-
-			predictedCtx := effectiveLlamaServerContext(req.opts.NumCtx, f, numParallel)
-			predicted := llm.PredictServerVRAM(req.model.ModelPath, f, predictedCtx)
-			loadGpus, launchOpts = selectLlamaServerPlacement(systemInfo, gpus, predicted, req.opts)
-			availableForBatch, _, _ := availableMemoryForPlacement(systemInfo, loadGpus, launchOpts)
-			flashAttention := llm.LlamaServerFlashAttention(loadGpus)
-			req.applyAutomaticGenerationBatch(completion, predictedCtx, predicted, availableForBatch, flashAttention, loadGpus)
-			launchOpts.NumBatch = req.opts.NumBatch
-			predictedForLoad := predicted + generationBatchSurchargeForCompletion(completion, launchOpts.NumBatch)
-
-			// Pre-flight check: estimate whether the model fits in remaining memory.
-			// llama-server auto-detects layers based on available VRAM, so if
-			// we predict it won't fit, evict before spawning.
-			if requireFull && !explicitPartialGPUOffload(launchOpts, f) && len(s.loaded) > 0 && len(loadGpus) > 0 {
-				freeMemory, gpuFreeMemory, systemLimited := availableMemoryForPlacement(systemInfo, loadGpus, launchOpts)
-				// Use 80% of free memory as threshold to leave headroom.
-				if predictedForLoad > freeMemory*80/100 {
-					slog.Info("llama-server model predicted to exceed available memory, evicting",
-						"predicted", format.HumanBytes2(predictedForLoad),
-						"predicted_num_ctx", predictedCtx,
-						"num_batch", launchOpts.NumBatch,
-						"available", format.HumanBytes2(freeMemory),
-						"gpu_free", format.HumanBytes2(gpuFreeMemory),
-						"system_free", format.HumanBytes2(systemInfo.FreeMemory),
-						"system_limited", systemLimited)
-					s.loadedMu.Unlock()
-					return true
-				}
-				slog.Info("llama-server model fits alongside existing models",
-					"predicted", format.HumanBytes2(predictedForLoad),
-					"predicted_num_ctx", predictedCtx,
-					"num_batch", launchOpts.NumBatch,
-					"available", format.HumanBytes2(freeMemory),
-					"gpu_free", format.HumanBytes2(gpuFreeMemory),
-					"system_free", format.HumanBytes2(systemInfo.FreeMemory),
-					"system_limited", systemLimited)
-			}
-
-			launchOpts = s.applyLlamaServerMmapDefaults(req, launchOpts, systemInfo, loadGpus, f, numParallel)
-			req.contextShift = resolveContextShift(req.shift, req.model)
-
-			config := llamaServerConfigForModel(req.model)
-			config.ContextShift = req.contextShift
-			llama, err = s.newServerFn(systemInfo, loadGpus, req.model.ModelPath, f, req.model.AdapterPaths, req.model.ProjectorPaths, launchOpts, numParallel, config)
-			if err != nil {
-				// some older models are not compatible with newer versions of llama.cpp
-				// show a generalized compatibility error until there is a better way to
-				// check for model compatibility
-				if errors.Is(err, ggml.ErrUnsupportedFormat) || strings.Contains(err.Error(), "failed to load model") {
-					err = fmt.Errorf("%v: this model may be incompatible with your version of Ollama. If you previously pulled this model, try updating it by running `ollama pull %s`", err, req.model.ShortName)
-				}
-			}
+		if req.model.IsMLX() {
+			plan, err = newMLXLoadPlan(req, proposal)
 		} else {
-			modelName := req.model.ShortName
-			if slices.Contains(req.model.Config.Capabilities, "image") {
-				llama, err = imagegen.NewServer(modelName)
-			} else {
-				llama, err = mlxrunner.NewClient(modelName, req.opts.NumCtx)
+			var llamaPlan llamaServerLoadPlan
+			llamaPlan, err = newLlamaServerLoadPlan(req, proposal)
+			if err == nil {
+				plan = s.applyLlamaServerMmapDefaults(req, llamaPlan, systemInfo)
 			}
 		}
+		if err != nil {
+			slog.Info("failed to plan model load", "model", req.model.ShortName, "error", err)
+			req.errCh <- err
+			s.loadedMu.Unlock()
+			return false
+		}
+
+		switch plan.assessLoadedRunnerFit(requireFull, loadedCountAtLoadStart) {
+		case loadedRunnerNeedsEviction:
+			slog.Info("model predicted to exceed available memory, evicting",
+				"load_plan", plan,
+				"system_free", format.HumanBytes2(systemInfo.FreeMemory))
+			s.loadedMu.Unlock()
+			return true
+		case loadedRunnerFits:
+			slog.Info("model fits alongside existing models",
+				"load_plan", plan,
+				"system_free", format.HumanBytes2(systemInfo.FreeMemory))
+		}
+
+		plan.applyToRequest(req)
+		loadGpus = plan.gpusForLoad()
+		retryPlanner = plan.retryPlanner()
+		trainContext = plan.trainContext()
+		// newServer starts llama-server now; MLX constructs a client and starts during Load below.
+		llama, err = plan.newServer(s, req)
 		if err != nil {
 			slog.Info("failed to create server", "model", req.model.ShortName, "error", err)
 			req.errCh <- err
@@ -634,6 +604,7 @@ func (s *Scheduler) load(req *LlmRequest, systemInfo ml.SystemInfo, gpus []ml.De
 			"overhead", format.HumanBytes2(envconfig.GpuOverhead()))
 	}
 
+	// Load completes backend startup: llama-server waits for readiness, while MLX starts here.
 	gpuIDs, err := llama.Load(req.ctx, systemInfo, loadGpus, requireFull)
 	if err != nil {
 		if errors.Is(err, llm.ErrLoadRequiredFull) {
@@ -655,31 +626,24 @@ func (s *Scheduler) load(req *LlmRequest, systemInfo ml.SystemInfo, gpus []ml.De
 		s.loadedMu.Lock()
 		loadedCount := len(s.loaded)
 		s.loadedMu.Unlock()
-		otherLoaded := loadedCount > 0
-		if !req.oomRetryAttempted && llm.IsOutOfMemory(err) {
-			if oldNumCtx, effectiveNumCtx, newNumCtx, oldNumBatch, newNumBatch, ok := req.reduceAutoNumCtxForLoadOOM(f, numParallel, completion, systemInfo, loadGpus, launchOpts); ok {
-				req.oomRetryAttempted = true
-				slog.Warn("llama-server load failed; reducing automatic context and retrying once",
-					"model", req.model.ModelPath,
-					"old_num_ctx", oldNumCtx,
-					"effective_num_ctx", effectiveNumCtx,
-					"new_num_ctx", newNumCtx,
-					"old_num_batch", oldNumBatch,
-					"new_num_batch", newNumBatch,
-					"loaded_count", loadedCount,
-					"evict_all", otherLoaded,
-					"error", err)
-				return true
-			}
-		}
-		if otherLoaded && !req.oomRetryAttempted && llm.IsOutOfMemory(err) {
-			req.oomRetryAttempted = true
-			slog.Warn("llama-server load failed; evicting all other models and retrying once", "model", req.model.ModelPath, "error", err)
+
+		// MLX is a no-op here; llama-server may crash during Load, so retry with a smaller auto context or by evicting other models.
+		if retryPlanner != nil && retryPlanner.maybeRetryLoadFailure(req, systemInfo, loadedCount, err) {
 			return true
 		}
 
 		req.errCh <- err
 		return false
+	}
+
+	totalSize, vramSize := llama.MemorySize()
+	// After a successful llama-server Load, retry if it spilled to CPU while other models were resident.
+	if retryPlanner != nil && retryPlanner.maybeRetryCPUSpill(req, llama, requireFull, loadedCountAtLoadStart, totalSize, vramSize) {
+		llama.Close()
+		s.loadedMu.Lock()
+		s.activeLoading = nil
+		s.loadedMu.Unlock()
+		return true
 	}
 	logTemplateSelection(req.model)
 
@@ -697,8 +661,6 @@ iGPUScan:
 		}
 	}
 
-	totalSize, vramSize := llama.MemorySize()
-	trainContext := modelTrainContext(f)
 	if effectiveNumCtx := llama.ContextLength(); req.model.ModelPath != "" && effectiveNumCtx > 0 {
 		req.opts.NumCtx = effectiveNumCtx
 		req.contextShift = resolveContextShift(req.shift, req.model)
@@ -741,6 +703,9 @@ iGPUScan:
 
 	go func() {
 		defer runner.refMu.Unlock()
+		// llama-server usually returns immediately here because Load already
+		// waited for startup. Keep the scheduler-level readiness gate for
+		// backends whose Load only starts a subprocess, such as MLX/imagegen.
 		if err = llama.WaitUntilRunning(req.ctx); err != nil {
 			slog.Error("error loading llama server", "error", err)
 			req.errCh <- err
@@ -763,544 +728,6 @@ iGPUScan:
 	}()
 
 	return false
-}
-
-func (req *LlmRequest) reduceAutoNumCtxForLoadOOM(f *ggml.GGML, numParallel int, completion bool, systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, launchOpts api.Options) (oldNumCtx, effectiveNumCtx, newNumCtx, oldNumBatch, newNumBatch int, ok bool) {
-	if !req.numCtxAuto {
-		return 0, 0, 0, 0, 0, false
-	}
-
-	oldNumCtx = req.opts.NumCtx
-	oldNumBatch = req.opts.NumBatch
-	effectiveNumCtx = oldNumCtx
-	if f != nil {
-		if trainCtx := int(f.KV().ContextLength()); trainCtx > 0 && effectiveNumCtx > trainCtx {
-			effectiveNumCtx = trainCtx
-		}
-	}
-
-	newNumCtx, ok = nextLowerAutoNumCtx(effectiveNumCtx)
-	if !ok || newNumCtx >= oldNumCtx {
-		return 0, 0, 0, 0, 0, false
-	}
-
-	req.opts.NumCtx = newNumCtx
-	predictedCtx := effectiveLlamaServerContext(req.opts.NumCtx, f, numParallel)
-	predictedVRAM := llm.PredictServerVRAM(req.model.ModelPath, f, predictedCtx)
-	available, _, _ := availableMemoryForPlacement(systemInfo, gpus, launchOpts)
-	req.applyAutomaticGenerationBatch(completion, predictedCtx, predictedVRAM, available, llm.LlamaServerFlashAttention(gpus), gpus)
-	newNumBatch = req.opts.NumBatch
-	return oldNumCtx, effectiveNumCtx, newNumCtx, oldNumBatch, newNumBatch, true
-}
-
-func explicitPartialGPUOffload(opts api.Options, f *ggml.GGML) bool {
-	if opts.NumGPU <= 0 || f == nil {
-		return false
-	}
-
-	return uint64(opts.NumGPU) < f.KV().BlockCount()+1
-}
-
-func effectiveLlamaServerContext(numCtx int, f *ggml.GGML, numParallel int) int {
-	return effectiveModelContext(numCtx, f) * max(numParallel, 1)
-}
-
-const (
-	llamaServerGenerationBatchDefault     = 512
-	llamaServerGenerationBatchConstrained = 256
-	llamaServerGenerationBatchMedium      = 1024
-	llamaServerGenerationBatchLarge       = 2048
-
-	llamaServerGenerationBatchMediumHeadroomPercent = 75
-	llamaServerGenerationBatchLargeHeadroomPercent  = 60
-)
-
-func (req *LlmRequest) applyAutomaticGenerationBatch(completion bool, effectiveCtx int, predictedVRAM, availableMemory uint64, flashAttention ml.FlashAttentionType, gpus []ml.DeviceInfo) {
-	if !completion || !req.numBatchAuto {
-		return
-	}
-
-	req.opts.NumBatch = automaticGenerationBatch(effectiveCtx, predictedVRAM, availableMemory, flashAttention, gpus)
-}
-
-func generationBatchSurchargeForCompletion(completion bool, batch int) uint64 {
-	if !completion {
-		return 0
-	}
-	return generationBatchSurcharge(batch)
-}
-
-func automaticGenerationBatch(effectiveCtx int, predictedVRAM, availableMemory uint64, flashAttention ml.FlashAttentionType, gpus []ml.DeviceInfo) int {
-	if flashAttention == ml.FlashAttentionDisabled && hasCUDADevice(gpus) {
-		if constrainedCUDAWithoutFlashAttention(effectiveCtx, gpus) {
-			return llamaServerGenerationBatchConstrained
-		}
-		return llamaServerGenerationBatchDefault
-	}
-
-	batch := generationBatchForContext(effectiveCtx)
-	for batch > llamaServerGenerationBatchDefault && !generationBatchFits(batch, predictedVRAM, availableMemory) {
-		batch = nextLowerGenerationBatch(batch)
-	}
-	return batch
-}
-
-func hasCUDADevice(gpus []ml.DeviceInfo) bool {
-	return slices.ContainsFunc(gpus, func(gpu ml.DeviceInfo) bool {
-		return gpu.Library == "CUDA"
-	})
-}
-
-func constrainedCUDAWithoutFlashAttention(effectiveCtx int, gpus []ml.DeviceInfo) bool {
-	if effectiveCtx <= 4096 {
-		return false
-	}
-	return slices.ContainsFunc(gpus, func(gpu ml.DeviceInfo) bool {
-		if gpu.Library != "CUDA" {
-			return false
-		}
-		memory := gpu.FreeMemory
-		if memory == 0 || (gpu.TotalMemory > 0 && gpu.TotalMemory < memory) {
-			memory = gpu.TotalMemory
-		}
-		return memory > 0 && memory <= 8*format.GibiByte
-	})
-}
-
-func generationBatchForContext(effectiveCtx int) int {
-	switch {
-	case effectiveCtx > 32768:
-		return llamaServerGenerationBatchLarge
-	case effectiveCtx > 4096:
-		return llamaServerGenerationBatchMedium
-	default:
-		return llamaServerGenerationBatchDefault
-	}
-}
-
-func generationBatchFits(batch int, predictedVRAM, availableMemory uint64) bool {
-	if predictedVRAM == 0 || availableMemory == 0 {
-		return true
-	}
-
-	threshold := availableMemory * 80 / 100
-	if predictedVRAM > threshold {
-		return false
-	}
-	if !generationBatchHasHeadroom(batch, predictedVRAM, availableMemory) {
-		return false
-	}
-
-	return generationBatchSurcharge(batch) <= threshold-predictedVRAM
-}
-
-func generationBatchHasHeadroom(batch int, predictedVRAM, availableMemory uint64) bool {
-	switch {
-	case batch >= llamaServerGenerationBatchLarge:
-		return predictedVRAM <= availableMemory*llamaServerGenerationBatchLargeHeadroomPercent/100
-	case batch >= llamaServerGenerationBatchMedium:
-		return predictedVRAM <= availableMemory*llamaServerGenerationBatchMediumHeadroomPercent/100
-	default:
-		return true
-	}
-}
-
-func nextLowerGenerationBatch(batch int) int {
-	switch {
-	case batch > llamaServerGenerationBatchMedium:
-		return llamaServerGenerationBatchMedium
-	default:
-		return llamaServerGenerationBatchDefault
-	}
-}
-
-func generationBatchSurcharge(batch int) uint64 {
-	switch {
-	case batch >= llamaServerGenerationBatchLarge:
-		return 2 * format.GibiByte
-	case batch >= llamaServerGenerationBatchMedium:
-		return 768 * format.MebiByte
-	default:
-		return 0
-	}
-}
-
-func nextLowerAutoNumCtx(numCtx int) (int, bool) {
-	switch {
-	case numCtx > 32768:
-		return 32768, true
-	case numCtx > 4096:
-		return 4096, true
-	default:
-		return 0, false
-	}
-}
-
-func availableMemoryForLoad(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo) (available, gpuFree uint64, systemLimited bool) {
-	var sharedGPUFree uint64
-	var discreteGPUFree uint64
-	for _, gpu := range gpus {
-		gpuFree += gpu.FreeMemory
-		if gpu.Integrated {
-			sharedGPUFree += gpu.FreeMemory
-		} else {
-			discreteGPUFree += gpu.FreeMemory
-		}
-	}
-
-	// On iGPUs, GPU free memory can be a static or slowly refreshed device
-	// baseline. updateFreeSpace has already subtracted known Ollama runner
-	// allocations from that baseline. Current system free memory is a separate
-	// live measurement that already includes those loaded runners, so use the
-	// smaller value for shared-memory GPUs without discounting discrete VRAM.
-	if systemInfo.FreeMemory > 0 && sharedGPUFree > 0 && systemInfo.FreeMemory < sharedGPUFree {
-		return discreteGPUFree + systemInfo.FreeMemory, gpuFree, true
-	}
-
-	return gpuFree, gpuFree, false
-}
-
-func availableMemoryForPlacement(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, opts api.Options) (available, gpuFree uint64, systemLimited bool) {
-	placementGpus := gpusForPlacement(gpus, opts)
-	if len(placementGpus) == 1 && opts.MainGPU != nil {
-		gpuFree = placementGpus[0].FreeMemory
-		available = availableMemoryForGPU(systemInfo, placementGpus[0])
-		systemLimited = available < gpuFree
-		return available, gpuFree, systemLimited
-	}
-
-	return availableMemoryForLoad(systemInfo, placementGpus)
-}
-
-func gpusForPlacement(gpus []ml.DeviceInfo, opts api.Options) []ml.DeviceInfo {
-	if opts.MainGPU != nil && *opts.MainGPU >= 0 && *opts.MainGPU < len(gpus) {
-		return []ml.DeviceInfo{gpus[*opts.MainGPU]}
-	}
-
-	return gpus
-}
-
-func selectLlamaServerPlacement(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, predictedVRAM uint64, opts api.Options) ([]ml.DeviceInfo, api.Options) {
-	launchOpts := opts
-	if len(gpus) <= 1 || opts.NumGPU == 0 {
-		return gpus, launchOpts
-	}
-
-	groups := ml.ByLibrary(gpus)
-	if len(groups) == 0 {
-		return gpus, launchOpts
-	}
-
-	if opts.MainGPU != nil {
-		gpu, available, ok := bestExplicitMainGPU(systemInfo, groups, *opts.MainGPU)
-		if !ok {
-			selected := bestGPUGroupByAvailableMemory(systemInfo, groups)
-			slog.Warn("requested main_gpu is outside the selected GPU group; passing value through to llama-server",
-				"main_gpu", *opts.MainGPU,
-				"gpu_count", len(selected))
-			logSelectedGPUGroup(gpus, selected)
-			return selected, launchOpts
-		}
-
-		selected, launchOpts := singleLlamaServerGPUPlacement(gpu, launchOpts)
-		slog.Info("selecting requested single GPU for llama-server model",
-			"requested_main_gpu", *opts.MainGPU,
-			"main_gpu", *launchOpts.MainGPU,
-			"id", gpu.ID,
-			"filter_id", gpu.FilterID,
-			"library", gpu.Library,
-			"name", gpu.Name,
-			"description", gpu.Description,
-			"integrated", gpu.Integrated,
-			"available", format.HumanBytes2(available))
-		logSelectedGPUGroup(gpus, selected)
-		return selected, launchOpts
-	}
-
-	if !envconfig.SchedSpread() && predictedVRAM > 0 {
-		gpu, available, ok := bestSingleGPUFit(systemInfo, groups, predictedVRAM)
-		if ok {
-			selected, launchOpts := singleLlamaServerGPUPlacement(gpu, launchOpts)
-			slog.Info("selecting single GPU for llama-server model",
-				"main_gpu", *launchOpts.MainGPU,
-				"id", gpu.ID,
-				"filter_id", gpu.FilterID,
-				"library", gpu.Library,
-				"name", gpu.Name,
-				"description", gpu.Description,
-				"integrated", gpu.Integrated,
-				"predicted", format.HumanBytes2(predictedVRAM),
-				"available", format.HumanBytes2(available))
-			logSelectedGPUGroup(gpus, selected)
-			return selected, launchOpts
-		}
-	}
-
-	selected := bestGPUGroupByAvailableMemory(systemInfo, groups)
-	logSelectedGPUGroup(gpus, selected)
-	return selected, launchOpts
-}
-
-func singleLlamaServerGPUPlacement(gpu ml.DeviceInfo, opts api.Options) ([]ml.DeviceInfo, api.Options) {
-	mainGPU := 0
-	opts.MainGPU = &mainGPU
-	return []ml.DeviceInfo{gpu}, opts
-}
-
-func bestExplicitMainGPU(systemInfo ml.SystemInfo, groups [][]ml.DeviceInfo, mainGPU int) (gpu ml.DeviceInfo, available uint64, ok bool) {
-	if mainGPU < 0 {
-		return ml.DeviceInfo{}, 0, false
-	}
-
-	for _, group := range groups {
-		if mainGPU >= len(group) {
-			continue
-		}
-		candidate := group[mainGPU]
-		candidateAvailable := availableMemoryForGPU(systemInfo, candidate)
-		if !ok || betterPlacementGPU(candidate, candidateAvailable, gpu, available) {
-			gpu = candidate
-			available = candidateAvailable
-			ok = true
-		}
-	}
-
-	return gpu, available, ok
-}
-
-func bestSingleGPUFit(systemInfo ml.SystemInfo, groups [][]ml.DeviceInfo, predictedVRAM uint64) (gpu ml.DeviceInfo, available uint64, ok bool) {
-	for _, group := range groups {
-		for _, candidate := range group {
-			candidateAvailable := availableMemoryForGPU(systemInfo, candidate)
-			if predictedVRAM > candidateAvailable*80/100 {
-				continue
-			}
-			if !ok || betterPlacementGPU(candidate, candidateAvailable, gpu, available) {
-				gpu = candidate
-				available = candidateAvailable
-				ok = true
-			}
-		}
-	}
-
-	return gpu, available, ok
-}
-
-func betterPlacementGPU(candidate ml.DeviceInfo, candidateAvailable uint64, current ml.DeviceInfo, currentAvailable uint64) bool {
-	if candidate.Integrated != current.Integrated {
-		return !candidate.Integrated
-	}
-
-	return candidateAvailable > currentAvailable
-}
-
-func bestGPUGroupByAvailableMemory(systemInfo ml.SystemInfo, groups [][]ml.DeviceInfo) []ml.DeviceInfo {
-	var best []ml.DeviceInfo
-	var bestAvailable uint64
-	for _, group := range groups {
-		available, _, _ := availableMemoryForLoad(systemInfo, group)
-		if best == nil || betterPlacementGroup(group, available, best, bestAvailable) {
-			best = group
-			bestAvailable = available
-		}
-	}
-
-	return best
-}
-
-func betterPlacementGroup(candidate []ml.DeviceInfo, candidateAvailable uint64, current []ml.DeviceInfo, currentAvailable uint64) bool {
-	candidateDiscrete := hasDiscreteGPU(candidate)
-	currentDiscrete := hasDiscreteGPU(current)
-	if candidateDiscrete != currentDiscrete {
-		return candidateDiscrete
-	}
-
-	return candidateAvailable > currentAvailable
-}
-
-func hasDiscreteGPU(gpus []ml.DeviceInfo) bool {
-	for _, gpu := range gpus {
-		if !gpu.Integrated {
-			return true
-		}
-	}
-	return false
-}
-
-func availableMemoryForGPU(systemInfo ml.SystemInfo, gpu ml.DeviceInfo) uint64 {
-	if gpu.Integrated && systemInfo.FreeMemory > 0 && systemInfo.FreeMemory < gpu.FreeMemory {
-		return systemInfo.FreeMemory
-	}
-
-	return gpu.FreeMemory
-}
-
-func logSelectedGPUGroup(all, selected []ml.DeviceInfo) {
-	if len(selected) == 0 || len(selected) == len(all) {
-		return
-	}
-
-	slog.Info("selecting GPU backend for llama-server model",
-		"library", selected[0].Library,
-		"gpu_count", len(selected),
-		"available_gpu_count", len(all))
-}
-
-func (s *Scheduler) applyLlamaServerMmapDefaults(req *LlmRequest, launchOpts api.Options, systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, f *ggml.GGML, numParallel int) api.Options {
-	predictedCtx := effectiveLlamaServerContext(req.opts.NumCtx, f, numParallel)
-	predictedVRAM := llm.PredictServerVRAM(req.model.ModelPath, f, predictedCtx)
-	availableVRAM, _, _ := availableMemoryForPlacement(systemInfo, gpus, launchOpts)
-
-	if reason := disableMmapDefaultReason(runtime.GOOS, req.opts, gpus, f.KV().BlockCount(), predictedVRAM, availableVRAM); reason != "" {
-		useMmap := false
-		req.opts.UseMMap = &useMmap
-		req.useMMapAuto = true
-		slog.Info("disabling mmap for llama-server load by default",
-			"model", req.model.ModelPath,
-			"reason", reason)
-	} else {
-		s.maybeDisableMmapForHostPressure(req, launchOpts, systemInfo, gpus, f, numParallel)
-	}
-
-	launchOpts.UseMMap = req.opts.UseMMap
-	return launchOpts
-}
-
-func disableMmapDefaultReason(goos string, opts api.Options, gpus []ml.DeviceInfo, blockCount, predictedVRAM, availableVRAM uint64) string {
-	if opts.UseMMap != nil {
-		return ""
-	}
-	if opts.NumGPU == 0 || len(gpus) == 0 || allDevicesLibrary(gpus, "cpu") {
-		return "cpu"
-	}
-	if goos == "windows" && hasDeviceLibrary(gpus, "cuda") {
-		return "windows_cuda"
-	}
-	if hasDeviceLibrary(gpus, "metal") {
-		if opts.NumGPU > 0 && blockCount > 0 && uint64(opts.NumGPU) < blockCount+1 {
-			return "metal_partial_offload"
-		}
-		if opts.NumGPU < 0 && predictedVRAM > 0 && availableVRAM > 0 && predictedVRAM > availableVRAM {
-			return "metal_partial_offload"
-		}
-	}
-	return ""
-}
-
-func hasDeviceLibrary(gpus []ml.DeviceInfo, library string) bool {
-	for _, gpu := range gpus {
-		if strings.EqualFold(gpu.Library, library) {
-			return true
-		}
-	}
-	return false
-}
-
-func allDevicesLibrary(gpus []ml.DeviceInfo, library string) bool {
-	if len(gpus) == 0 {
-		return false
-	}
-	for _, gpu := range gpus {
-		if !strings.EqualFold(gpu.Library, library) {
-			return false
-		}
-	}
-	return true
-}
-
-func (s *Scheduler) maybeDisableMmapForHostPressure(req *LlmRequest, launchOpts api.Options, systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, f *ggml.GGML, numParallel int) {
-	modelSize := modelFileSize(req.model.ModelPath)
-	loadedMmapSize := s.loadedMmapModelSizeLocked()
-	predictedCtx := effectiveLlamaServerContext(req.opts.NumCtx, f, numParallel)
-	predictedVRAM := llm.PredictServerVRAM(req.model.ModelPath, f, predictedCtx)
-	availableVRAM, _, _ := availableMemoryForPlacement(systemInfo, gpus, launchOpts)
-	placementGpus := gpusForPlacement(gpus, launchOpts)
-
-	if !disableMmapForHostPressure(runtime.GOOS, req.opts, systemInfo, placementGpus, modelSize, loadedMmapSize, predictedVRAM, availableVRAM) {
-		return
-	}
-
-	useMmap := false
-	req.opts.UseMMap = &useMmap
-	req.useMMapAuto = true
-	slog.Info("disabling mmap for llama-server load due to host memory pressure",
-		"model", req.model.ModelPath,
-		"model_size", format.HumanBytes2(modelSize),
-		"loaded_mmap_size", format.HumanBytes2(loadedMmapSize),
-		"headroom", format.HumanBytes2(mmapHostPressureHeadroom(systemInfo.TotalMemory)),
-		"system_free", format.HumanBytes2(systemInfo.FreeMemory),
-		"system_total", format.HumanBytes2(systemInfo.TotalMemory),
-		"predicted_vram", format.HumanBytes2(predictedVRAM),
-		"available_vram", format.HumanBytes2(availableVRAM),
-	)
-}
-
-func disableMmapForHostPressure(goos string, opts api.Options, systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, modelSize, loadedMmapSize, predictedVRAM, availableVRAM uint64) bool {
-	if opts.UseMMap != nil || goos != "linux" || modelSize == 0 || systemInfo.FreeMemory == 0 || !allDiscreteGPUs(gpus) {
-		return false
-	}
-
-	// Only back off mmap when we still expect the model to fit on discrete GPU.
-	// If VRAM is already tight, disabling mmap can make partial CPU offload
-	// worse by turning file-backed mappings into anonymous memory.
-	if predictedVRAM == 0 || availableVRAM == 0 || predictedVRAM > availableVRAM*80/100 {
-		return false
-	}
-
-	pressure := modelSize + loadedMmapSize + mmapHostPressureHeadroom(systemInfo.TotalMemory)
-	return systemInfo.FreeMemory < pressure
-}
-
-func allDiscreteGPUs(gpus []ml.DeviceInfo) bool {
-	if len(gpus) == 0 {
-		return false
-	}
-	for _, gpu := range gpus {
-		if gpu.Integrated {
-			return false
-		}
-	}
-	return true
-}
-
-func mmapHostPressureHeadroom(totalMemory uint64) uint64 {
-	if totalMemory == 0 {
-		return 8 * format.GigaByte
-	}
-	return max(8*format.GigaByte, totalMemory/10)
-}
-
-func modelFileSize(path string) uint64 {
-	if path == "" {
-		return 0
-	}
-	info, err := os.Stat(path)
-	if err != nil {
-		return 0
-	}
-	return uint64(info.Size())
-}
-
-func (s *Scheduler) loadedMmapModelSizeLocked() uint64 {
-	var total uint64
-	for _, r := range s.loaded {
-		if !runnerUsesMmap(r) {
-			continue
-		}
-		if size := modelFileSize(r.modelPath); size > 0 {
-			total += size
-		} else {
-			total += r.totalSize
-		}
-	}
-	return total
-}
-
-func runnerUsesMmap(r *runnerRef) bool {
-	if r == nil || r.Options == nil || r.Options.UseMMap == nil {
-		return true
-	}
-	return *r.Options.UseMMap
 }
 
 func (s *Scheduler) updateFreeSpace(allGpus []ml.DeviceInfo) {
@@ -1604,7 +1031,7 @@ func (a ByDurationAndName) Less(i, j int) bool {
 // evictAllAndWait synchronously expires every currently loaded runner except
 // the one being loaded (matched by modelKey) and waits for all unload events
 // to drain. Returns false if the context was cancelled mid-wait so the caller
-// can exit the scheduling loop. Used by the OOM retry path in processPending.
+// can exit the scheduling loop. Used by the load retry path in processPending.
 func (s *Scheduler) evictAllAndWait(ctx context.Context, keepKey string) bool {
 	s.loadedMu.Lock()
 	runnersToExpire := make([]*runnerRef, 0, len(s.loaded))
@@ -1620,7 +1047,7 @@ func (s *Scheduler) evictAllAndWait(ctx context.Context, keepKey string) bool {
 		return true
 	}
 
-	slog.Info("evicting all other loaded models for OOM retry", "count", len(runnersToExpire))
+	slog.Info("evicting all other loaded models for load retry", "count", len(runnersToExpire))
 	for _, runner := range runnersToExpire {
 		runner.refMu.Lock()
 		if runner.expireTimer != nil {

--- a/server/sched.go
+++ b/server/sched.go
@@ -5,12 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"os"
 	"reflect"
-	"runtime"
 	"slices"
 	"sort"
-	"strings"
 	"sync"
 	"time"
 
@@ -23,7 +20,6 @@ import (
 	"github.com/ollama/ollama/logutil"
 	"github.com/ollama/ollama/ml"
 	"github.com/ollama/ollama/types/model"
-	"github.com/ollama/ollama/x/mlxrunner"
 )
 
 type LlmRequest struct {
@@ -35,9 +31,10 @@ type LlmRequest struct {
 	errCh           chan error
 	schedAttempts   uint
 
-	// oomRetryAttempted is set after a llama-server load crash triggers an
-	// evict-all-and-retry. Prevents infinite retry on persistent load failures.
-	oomRetryAttempted bool
+	// loadRetryAttempted is set after a backend load outcome triggers a retry
+	// through the eviction path. It prevents infinite retry on persistent load
+	// failures or CPU spills.
+	loadRetryAttempted bool
 
 	// numCtxAuto is true when NumCtx came from Ollama's automatic VRAM-tier
 	// default rather than explicit request, model, or environment config.
@@ -55,6 +52,25 @@ type LlmRequest struct {
 	// request-level shift option before scheduling.
 	contextShift bool
 	shift        *bool
+}
+
+func (pending *LlmRequest) fail(err error) {
+	if err == nil {
+		return
+	}
+
+	select {
+	case pending.errCh <- err:
+	default:
+	}
+}
+
+func (pending *LlmRequest) failIfCanceled() bool {
+	if err := pending.ctx.Err(); err != nil {
+		pending.fail(err)
+		return true
+	}
+	return false
 }
 
 type Scheduler struct {
@@ -195,19 +211,47 @@ func (s *Scheduler) getRunner(c context.Context, m *Model, opts api.Options, ses
 	}
 
 	key := schedulerModelKey(req.model)
+	if req.failIfCanceled() {
+		return req.successCh, req.errCh
+	}
+
 	s.loadedMu.Lock()
 	runner := s.loaded[key]
 	s.loadedMu.Unlock()
 	if runner != nil && !runner.needsReload(c, req) {
-		req.useLoadedRunner(runner, s.finishedReqCh)
+		if req.tryUseLoadedRunner(runner, s.finishedReqCh) {
+			return req.successCh, req.errCh
+		}
+	}
+
+	if req.failIfCanceled() {
+		return req.successCh, req.errCh
 	} else {
 		select {
 		case s.pendingReqCh <- req:
 		default:
-			req.errCh <- ErrMaxQueue
+			req.fail(ErrMaxQueue)
 		}
 	}
 	return req.successCh, req.errCh
+}
+
+// acquireRunner schedules the model and blocks until it is loaded or fails,
+// returning its server. The context must be canceled to decrement the ref
+// count and release the runner.
+func (s *Scheduler) acquireRunner(c context.Context, m *Model, opts api.Options, sessionDuration *api.Duration, numCtxAuto bool, numBatchAuto bool, shift *bool) (llm.LlamaServer, error) {
+	runnerCh, errCh := s.getRunner(c, m, opts, sessionDuration, numCtxAuto, numBatchAuto, shift)
+	select {
+	case runner := <-runnerCh:
+		runner.refMu.Lock()
+		llama := runner.llama
+		runner.refMu.Unlock()
+		return llama, nil
+	case err := <-errCh:
+		return nil, err
+	case <-c.Done():
+		return nil, c.Err()
+	}
 }
 
 // Returns immediately, spawns go routines for the scheduler which will shutdown when ctx is done
@@ -225,6 +269,7 @@ func (s *Scheduler) Run(ctx context.Context) {
 func (s *Scheduler) processPending(ctx context.Context) {
 	maxRunners := envconfig.MaxRunners()
 
+nextPending:
 	for {
 		select {
 		case <-ctx.Done():
@@ -234,13 +279,18 @@ func (s *Scheduler) processPending(ctx context.Context) {
 			// Block other requests until we get this pending request running
 			pending.schedAttempts++
 
-			if pending.ctx.Err() != nil {
+			if pending.failIfCanceled() {
 				slog.Debug("pending request cancelled or timed out, skipping scheduling")
 				continue
 			}
 			logutil.Trace("processing incoming request", "model", pending.model.ModelPath)
 
 			for {
+				if pending.failIfCanceled() {
+					slog.Debug("pending request cancelled or timed out, stopping scheduling")
+					continue nextPending
+				}
+
 				var runnerToExpire *runnerRef
 				pendingKey := schedulerModelKey(pending.model)
 				s.loadedMu.Lock()
@@ -259,8 +309,10 @@ func (s *Scheduler) processPending(ctx context.Context) {
 					} else {
 						// Runner is usable, return it
 						logutil.Trace("using existing loaded runner", "model", pendingKey)
-						pending.useLoadedRunner(runner, s.finishedReqCh)
-						break
+						if pending.tryUseLoadedRunner(runner, s.finishedReqCh) {
+							break
+						}
+						continue
 					}
 				} else if maxRunners > 0 && loadedCount >= int(maxRunners) {
 					slog.Debug("max runners achieved, unloading one to make room", "runner_count", loadedCount)
@@ -293,6 +345,10 @@ func (s *Scheduler) processPending(ctx context.Context) {
 					// Update free memory from currently loaded models
 					logutil.Trace("updating free space", "gpu_count", len(gpus), "model", pending.model.ModelPath)
 					s.updateFreeSpace(gpus)
+					if pending.failIfCanceled() {
+						slog.Debug("pending request cancelled or timed out before load")
+						continue nextPending
+					}
 
 					if loadedCount == 0 {
 						// No models loaded. Load the model but prefer the best fit.
@@ -313,12 +369,12 @@ func (s *Scheduler) processPending(ctx context.Context) {
 						break
 					}
 
-					// OOM retry path: load() crashed post-spawn and we still
-					// have other models resident. Evict all of them, wait for
-					// every unload, then loop back to retry the load once.
-					// load() has already set oomRetryAttempted so a second
-					// crash falls through to the fail-fast path.
-					if pending.oomRetryAttempted {
+					// Load retry path: Load failed or llama-server spilled to
+					// CPU with resident models still loaded. Evict all of them,
+					// wait for every unload, then loop back to retry once.
+					// load() has already set loadRetryAttempted so a second
+					// failure falls through to the fail-fast path.
+					if pending.loadRetryAttempted {
 						if !s.evictAllAndWait(ctx, pendingKey) {
 							return
 						}
@@ -335,17 +391,14 @@ func (s *Scheduler) processPending(ctx context.Context) {
 					continue
 				}
 				// Trigger an expiration to unload once it's done
+				var expireNow bool
 				runnerToExpire.refMu.Lock()
 				slog.Debug("resetting model to expire immediately to make room", "runner", runnerToExpire, "refCount", runnerToExpire.refCount)
-				if runnerToExpire.expireTimer != nil {
-					runnerToExpire.expireTimer.Stop()
-					runnerToExpire.expireTimer = nil
-				}
-				runnerToExpire.sessionDuration = 0
-				if runnerToExpire.refCount <= 0 {
+				expireNow = runnerToExpire.requestImmediateExpirationLocked()
+				runnerToExpire.refMu.Unlock()
+				if expireNow {
 					s.expiredCh <- runnerToExpire
 				}
-				runnerToExpire.refMu.Unlock()
 				// Wait for the unload to happen
 				slog.Debug("waiting for pending requests to complete and unload to occur", "runner", runnerToExpire)
 				select {
@@ -354,6 +407,10 @@ func (s *Scheduler) processPending(ctx context.Context) {
 					return
 				case <-s.unloadedCh:
 					slog.Debug("unload completed", "runner", runnerToExpire)
+					if pending.failIfCanceled() {
+						slog.Debug("pending request cancelled or timed out after unload")
+						continue nextPending
+					}
 					continue
 				}
 			}
@@ -382,23 +439,33 @@ func (s *Scheduler) processCompleted(ctx context.Context) {
 			}
 			runner.refMu.Lock()
 			runner.refCount--
+			expireNow := false
 			if runner.refCount <= 0 {
-				if runner.sessionDuration <= 0 {
+				if runner.expireOnIdle || runner.sessionDuration <= 0 {
 					slog.Debug("runner with zero duration has gone idle, expiring to unload", "runner", runner)
 					if runner.expireTimer != nil {
 						runner.expireTimer.Stop()
 						runner.expireTimer = nil
 					}
-					s.expiredCh <- runner
+					runner.expireOnIdle = false
+					expireNow = true
 				} else if runner.expireTimer == nil {
 					slog.Debug("runner with non-zero duration has gone idle, adding timer", "runner", runner, "duration", runner.sessionDuration)
 					runner.expireTimer = time.AfterFunc(runner.sessionDuration, func() {
 						slog.Debug("timer expired, expiring to unload", "runner", runner)
 						runner.refMu.Lock()
-						defer runner.refMu.Unlock()
-						if runner.expireTimer != nil {
-							runner.expireTimer.Stop()
-							runner.expireTimer = nil
+						if runner.expireTimer == nil {
+							runner.refMu.Unlock()
+							return
+						}
+						runner.expireTimer = nil
+						expireNow := runner.refCount <= 0
+						if !expireNow {
+							runner.expireOnIdle = true
+						}
+						runner.refMu.Unlock()
+						if !expireNow {
+							return
 						}
 						s.expiredCh <- runner
 					})
@@ -411,20 +478,26 @@ func (s *Scheduler) processCompleted(ctx context.Context) {
 			}
 			slog.Debug("after processing request finished event", "runner", runner, "refCount", runner.refCount)
 			runner.refMu.Unlock()
+			if expireNow {
+				s.expiredCh <- runner
+			}
 		case runner := <-s.expiredCh:
 			slog.Debug("runner expired event received", "runner", runner)
 			runner.refMu.Lock()
 			if runner.refCount > 0 {
-				slog.Debug("expired event with positive ref count, retrying", "runner", runner, "refCount", runner.refCount)
-				go func(runner *runnerRef) {
-					// We can't unload yet, but want to as soon as the current request completes
-					// So queue up another expired event
-					time.Sleep(10 * time.Millisecond)
-					s.expiredCh <- runner
-				}(runner)
+				runner.expireOnIdle = true
 				runner.refMu.Unlock()
+				slog.Debug("expired event with positive ref count, expiring when idle", "runner", runner, "refCount", runner.refCount)
 				continue
 			}
+			if runner.unloading {
+				runner.refMu.Unlock()
+				slog.Debug("duplicate expired event, ignoring runner already unloading", "runner", runner)
+				continue
+			}
+			runner.unloading = true
+			runner.expireOnIdle = false
+			runner.refMu.Unlock()
 
 			s.loadedMu.Lock()
 			slog.Debug("got lock to unload expired event", "runner", runner)
@@ -436,7 +509,6 @@ func (s *Scheduler) processCompleted(ctx context.Context) {
 				// that requires this one to be evicted, or the settings change
 				// and require a reload
 				s.loadedMu.Unlock()
-				runner.refMu.Unlock()
 				slog.Debug("duplicate expired event, ignoring", "runner", runner)
 			} else if runner.pid != runnerToUnload.pid {
 				// If the pids do not match, we likely had multiple load
@@ -446,22 +518,20 @@ func (s *Scheduler) processCompleted(ctx context.Context) {
 				// do not delete the mismatched loaded runner, or wait for VRAM
 				// convergence.
 				slog.Debug("orphaned runner shutting down", "orphan", runner, "loaded", runnerToUnload)
-				runner.unload()
 				s.loadedMu.Unlock()
-				runner.refMu.Unlock()
+				runner.unload()
 			} else {
 				slog.Debug("starting background wait for VRAM recovery", "runner", runner)
 				runnersSnapshot := make([]ml.FilteredRunnerDiscovery, 0, len(s.loaded))
 				for _, r := range s.loaded {
 					runnersSnapshot = append(runnersSnapshot, r)
 				}
-				finished := s.waitForVRAMRecovery(runner, runnersSnapshot)
-				runner.unload()
 				delete(s.loaded, runner.modelKey)
 				s.loadedMu.Unlock()
+				finished := s.waitForVRAMRecovery(runner, runnersSnapshot)
+				runner.unload()
 				slog.Debug("runner terminated and removed from list, blocking for VRAM recovery", "runner", runner)
 				<-finished
-				runner.refMu.Unlock()
 				slog.Debug("sending an unloaded event", "runner", runner)
 				s.unloadedCh <- struct{}{}
 			}
@@ -472,9 +542,20 @@ func (s *Scheduler) processCompleted(ctx context.Context) {
 // Complete the pending request and send the runner back to the requester
 // Wires up a finished event after the request context is completed
 // Updates session duration, and resets expiration timer
-func (pending *LlmRequest) useLoadedRunner(runner *runnerRef, finished chan *LlmRequest) {
+func (pending *LlmRequest) tryUseLoadedRunner(runner *runnerRef, finished chan *LlmRequest) bool {
+	if pending.failIfCanceled() {
+		return true
+	}
+
 	runner.refMu.Lock()
-	defer runner.refMu.Unlock()
+	if pending.failIfCanceled() {
+		runner.refMu.Unlock()
+		return true
+	}
+	if runner.unloading {
+		runner.refMu.Unlock()
+		return false
+	}
 	runner.refCount++
 	if runner.expireTimer != nil {
 		runner.expireTimer.Stop()
@@ -483,12 +564,15 @@ func (pending *LlmRequest) useLoadedRunner(runner *runnerRef, finished chan *Llm
 	if pending.sessionDuration != nil {
 		runner.sessionDuration = pending.sessionDuration.Duration
 	}
+	runner.refMu.Unlock()
+
 	pending.successCh <- runner
 	go func() {
 		<-pending.ctx.Done()
 		slog.Debug("context for request finished", "runner", runner)
 		finished <- pending
 	}()
+	return true
 }
 
 // load creates a new model based on req and loads it. If requireFull is true then the model must be loaded fully onto GPUs
@@ -516,77 +600,55 @@ func (s *Scheduler) load(req *LlmRequest, systemInfo ml.SystemInfo, gpus []ml.De
 
 	s.loadedMu.Lock()
 	llama := s.activeLoading
-	var f *ggml.GGML
 	loadGpus := gpus
-	var launchOpts api.Options
+	var retryPlanner loadRetryPlanner
+	var trainContext int
+	loadedCountAtLoadStart := len(s.loaded)
+	proposal := loadProposal{
+		systemInfo:  systemInfo,
+		gpus:        gpus,
+		numParallel: numParallel,
+		completion:  completion,
+	}
 
 	if llama == nil {
+		var plan runnerLoadPlan
 		var err error
-		if !req.model.IsMLX() {
-			var loadErr error
-			f, loadErr = llm.LoadModel(req.model.ModelPath, 1024)
-			if loadErr != nil {
-				slog.Info("failed to load model metadata", "model", req.model.ModelPath, "error", loadErr)
-				req.errCh <- loadErr
-				s.loadedMu.Unlock()
-				return false
-			}
-
-			predictedCtx := effectiveLlamaServerContext(req.opts.NumCtx, f, numParallel)
-			predicted := llm.PredictServerVRAM(req.model.ModelPath, f, predictedCtx)
-			loadGpus, launchOpts = selectLlamaServerPlacement(systemInfo, gpus, predicted, req.opts)
-			availableForBatch, _, _ := availableMemoryForPlacement(systemInfo, loadGpus, launchOpts)
-			flashAttention := llm.LlamaServerFlashAttention(loadGpus)
-			req.applyAutomaticGenerationBatch(completion, predictedCtx, predicted, availableForBatch, flashAttention, loadGpus)
-			launchOpts.NumBatch = req.opts.NumBatch
-			predictedForLoad := predicted + generationBatchSurchargeForCompletion(completion, launchOpts.NumBatch)
-
-			// Pre-flight check: estimate whether the model fits in remaining memory.
-			// llama-server auto-detects layers based on available VRAM, so if
-			// we predict it won't fit, evict before spawning.
-			if requireFull && !explicitPartialGPUOffload(launchOpts, f) && len(s.loaded) > 0 && len(loadGpus) > 0 {
-				freeMemory, gpuFreeMemory, systemLimited := availableMemoryForPlacement(systemInfo, loadGpus, launchOpts)
-				// Use 80% of free memory as threshold to leave headroom.
-				if predictedForLoad > freeMemory*80/100 {
-					slog.Info("llama-server model predicted to exceed available memory, evicting",
-						"predicted", format.HumanBytes2(predictedForLoad),
-						"predicted_num_ctx", predictedCtx,
-						"num_batch", launchOpts.NumBatch,
-						"available", format.HumanBytes2(freeMemory),
-						"gpu_free", format.HumanBytes2(gpuFreeMemory),
-						"system_free", format.HumanBytes2(systemInfo.FreeMemory),
-						"system_limited", systemLimited)
-					s.loadedMu.Unlock()
-					return true
-				}
-				slog.Info("llama-server model fits alongside existing models",
-					"predicted", format.HumanBytes2(predictedForLoad),
-					"predicted_num_ctx", predictedCtx,
-					"num_batch", launchOpts.NumBatch,
-					"available", format.HumanBytes2(freeMemory),
-					"gpu_free", format.HumanBytes2(gpuFreeMemory),
-					"system_free", format.HumanBytes2(systemInfo.FreeMemory),
-					"system_limited", systemLimited)
-			}
-
-			launchOpts = s.applyLlamaServerMmapDefaults(req, launchOpts, systemInfo, loadGpus, f, numParallel)
-			req.contextShift = resolveContextShift(req.shift, req.model)
-
-			config := llamaServerConfigForModel(req.model)
-			config.ContextShift = req.contextShift
-			llama, err = s.newServerFn(systemInfo, loadGpus, req.model.ModelPath, f, req.model.AdapterPaths, req.model.ProjectorPaths, launchOpts, numParallel, config)
-			if err != nil {
-				// some older models are not compatible with newer versions of llama.cpp
-				// show a generalized compatibility error until there is a better way to
-				// check for model compatibility
-				if errors.Is(err, ggml.ErrUnsupportedFormat) || strings.Contains(err.Error(), "failed to load model") {
-					err = fmt.Errorf("%v: this model may be incompatible with your version of Ollama. If you previously pulled this model, try updating it by running `ollama pull %s`", err, req.model.ShortName)
-				}
-			}
+		if req.model.IsMLX() {
+			plan, err = newMLXLoadPlan(req, proposal)
 		} else {
-			modelName := req.model.ShortName
-			llama, err = mlxrunner.NewClient(modelName, req.opts.NumCtx)
+			var llamaPlan llamaServerLoadPlan
+			llamaPlan, err = newLlamaServerLoadPlan(req, proposal)
+			if err == nil {
+				plan = s.applyLlamaServerMmapDefaults(req, llamaPlan, systemInfo)
+			}
 		}
+		if err != nil {
+			slog.Info("failed to plan model load", "model", req.model.ShortName, "error", err)
+			req.errCh <- err
+			s.loadedMu.Unlock()
+			return false
+		}
+
+		switch plan.assessLoadedRunnerFit(requireFull, loadedCountAtLoadStart) {
+		case loadedRunnerNeedsEviction:
+			slog.Info("model predicted to exceed available memory, evicting",
+				"load_plan", plan,
+				"system_free", format.HumanBytes2(systemInfo.FreeMemory))
+			s.loadedMu.Unlock()
+			return true
+		case loadedRunnerFits:
+			slog.Info("model fits alongside existing models",
+				"load_plan", plan,
+				"system_free", format.HumanBytes2(systemInfo.FreeMemory))
+		}
+
+		plan.applyToRequest(req)
+		loadGpus = plan.gpusForLoad()
+		retryPlanner = plan.retryPlanner()
+		trainContext = plan.trainContext()
+		// newServer starts llama-server now; MLX constructs a client and starts during Load below.
+		llama, err = plan.newServer(s, req)
 		if err != nil {
 			slog.Info("failed to create server", "model", req.model.ShortName, "error", err)
 			req.errCh <- err
@@ -624,14 +686,17 @@ func (s *Scheduler) load(req *LlmRequest, systemInfo ml.SystemInfo, gpus []ml.De
 			"overhead", format.HumanBytes2(envconfig.GpuOverhead()))
 	}
 
+	// Load completes backend startup: llama-server waits for readiness, while MLX starts here.
 	gpuIDs, err := llama.Load(req.ctx, systemInfo, loadGpus, requireFull)
 	if err != nil {
 		if errors.Is(err, llm.ErrLoadRequiredFull) {
 			if !requireFull {
 				// No other models loaded, yet we still don't fit, so report an error
 				slog.Info("model is too large for system memory", "requireFull", requireFull)
-				s.activeLoading.Close()
+				llama.Close()
+				s.loadedMu.Lock()
 				s.activeLoading = nil
+				s.loadedMu.Unlock()
 				req.errCh <- err
 				return false
 			}
@@ -639,56 +704,49 @@ func (s *Scheduler) load(req *LlmRequest, systemInfo ml.SystemInfo, gpus []ml.De
 		}
 
 		slog.Info("Load failed", "model", req.model.ModelPath, "error", err)
-		s.activeLoading.Close()
+		llama.Close()
+		s.loadedMu.Lock()
 		s.activeLoading = nil
+		s.loadedMu.Unlock()
 
 		s.loadedMu.Lock()
 		loadedCount := len(s.loaded)
 		s.loadedMu.Unlock()
-		otherLoaded := loadedCount > 0
-		if !req.oomRetryAttempted && llm.IsOutOfMemory(err) {
-			if oldNumCtx, effectiveNumCtx, newNumCtx, oldNumBatch, newNumBatch, ok := req.reduceAutoNumCtxForLoadOOM(f, numParallel, completion, systemInfo, loadGpus, launchOpts); ok {
-				req.oomRetryAttempted = true
-				slog.Warn("llama-server load failed; reducing automatic context and retrying once",
-					"model", req.model.ModelPath,
-					"old_num_ctx", oldNumCtx,
-					"effective_num_ctx", effectiveNumCtx,
-					"new_num_ctx", newNumCtx,
-					"old_num_batch", oldNumBatch,
-					"new_num_batch", newNumBatch,
-					"loaded_count", loadedCount,
-					"evict_all", otherLoaded,
-					"error", err)
-				return true
-			}
-		}
-		if otherLoaded && !req.oomRetryAttempted && llm.IsOutOfMemory(err) {
-			req.oomRetryAttempted = true
-			slog.Warn("llama-server load failed; evicting all other models and retrying once", "model", req.model.ModelPath, "error", err)
+
+		// MLX is a no-op here; llama-server may crash during Load, so retry with a smaller auto context or by evicting other models.
+		if retryPlanner != nil && retryPlanner.maybeRetryLoadFailure(req, systemInfo, loadedCount, err) {
 			return true
 		}
 
 		req.errCh <- err
 		return false
 	}
+
+	totalSize, vramSize := llama.MemorySize()
+	// After a successful llama-server Load, retry if it spilled to CPU while other models were resident.
+	if retryPlanner != nil && retryPlanner.maybeRetryCPUSpill(req, llama, requireFull, loadedCountAtLoadStart, totalSize, vramSize) {
+		llama.Close()
+		s.loadedMu.Lock()
+		s.activeLoading = nil
+		s.loadedMu.Unlock()
+		return true
+	}
 	logTemplateSelection(req.model)
 
 	// Determine if we have discrete GPUs which we should monitor VRAM usage on during shutdown
-	discreteGPUs := false
+	usesDiscreteGPU := false
 iGPUScan:
 	for _, devid := range gpuIDs {
 		for _, dev := range loadGpus {
 			if dev.DeviceID == devid {
 				if !dev.Integrated {
-					discreteGPUs = true
+					usesDiscreteGPU = true
 					break iGPUScan
 				}
 			}
 		}
 	}
 
-	totalSize, vramSize := llama.MemorySize()
-	trainContext := modelTrainContext(f)
 	if effectiveNumCtx := llama.ContextLength(); req.model.ModelPath != "" && effectiveNumCtx > 0 {
 		req.opts.NumCtx = effectiveNumCtx
 		req.contextShift = resolveContextShift(req.shift, req.model)
@@ -701,7 +759,7 @@ iGPUScan:
 		Options:         &req.opts,
 		sessionDuration: sessionDuration,
 		gpus:            gpuIDs,
-		discreteGPUs:    discreteGPUs,
+		usesDiscreteGPU: usesDiscreteGPU,
 		totalSize:       totalSize,
 		vramSize:        vramSize,
 		loading:         true,
@@ -716,24 +774,29 @@ iGPUScan:
 	runner.refMu.Lock() // hold lock until running or aborted
 
 	s.loadedMu.Lock()
-	if oldRunner, ok := s.loaded[runner.modelKey]; ok {
+	var oldRunner *runnerRef
+	if existing, ok := s.loaded[runner.modelKey]; ok {
 		// Shouldn't happen, but safeguard against leaking a runner
+		oldRunner = existing
 		slog.Warn("model was still loaded", "old_runner", oldRunner, "new_runner", runner)
-		oldRunner.refMu.Lock()
-		oldRunner.unload()
-		oldRunner.refMu.Unlock()
 	}
 	s.activeLoading = nil
 	s.loaded[runner.modelKey] = runner
 	slog.Info("loaded runners", "count", len(s.loaded))
 	s.loadedMu.Unlock()
+	if oldRunner != nil {
+		oldRunner.unload()
+	}
 
 	go func() {
-		defer runner.refMu.Unlock()
+		// llama-server usually returns immediately here because Load already
+		// waited for startup. Keep the scheduler-level readiness gate for
+		// backends whose Load only starts a subprocess, such as MLX.
 		if err = llama.WaitUntilRunning(req.ctx); err != nil {
 			slog.Error("error loading llama server", "error", err)
 			req.errCh <- err
 			slog.Debug("triggering expiration for failed load", "runner", runner)
+			runner.refMu.Unlock()
 			s.expiredCh <- runner
 			return
 		}
@@ -749,547 +812,10 @@ iGPUScan:
 			s.finishedReqCh <- req
 		}()
 		req.successCh <- runner
+		runner.refMu.Unlock()
 	}()
 
 	return false
-}
-
-func (req *LlmRequest) reduceAutoNumCtxForLoadOOM(f *ggml.GGML, numParallel int, completion bool, systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, launchOpts api.Options) (oldNumCtx, effectiveNumCtx, newNumCtx, oldNumBatch, newNumBatch int, ok bool) {
-	if !req.numCtxAuto {
-		return 0, 0, 0, 0, 0, false
-	}
-
-	oldNumCtx = req.opts.NumCtx
-	oldNumBatch = req.opts.NumBatch
-	effectiveNumCtx = oldNumCtx
-	if f != nil {
-		if trainCtx := int(f.KV().ContextLength()); trainCtx > 0 && effectiveNumCtx > trainCtx {
-			effectiveNumCtx = trainCtx
-		}
-	}
-
-	newNumCtx, ok = nextLowerAutoNumCtx(effectiveNumCtx)
-	if !ok || newNumCtx >= oldNumCtx {
-		return 0, 0, 0, 0, 0, false
-	}
-
-	req.opts.NumCtx = newNumCtx
-	predictedCtx := effectiveLlamaServerContext(req.opts.NumCtx, f, numParallel)
-	predictedVRAM := llm.PredictServerVRAM(req.model.ModelPath, f, predictedCtx)
-	available, _, _ := availableMemoryForPlacement(systemInfo, gpus, launchOpts)
-	req.applyAutomaticGenerationBatch(completion, predictedCtx, predictedVRAM, available, llm.LlamaServerFlashAttention(gpus), gpus)
-	newNumBatch = req.opts.NumBatch
-	return oldNumCtx, effectiveNumCtx, newNumCtx, oldNumBatch, newNumBatch, true
-}
-
-func explicitPartialGPUOffload(opts api.Options, f *ggml.GGML) bool {
-	if opts.NumGPU <= 0 || f == nil {
-		return false
-	}
-
-	return uint64(opts.NumGPU) < f.KV().BlockCount()+1
-}
-
-func effectiveLlamaServerContext(numCtx int, f *ggml.GGML, numParallel int) int {
-	return effectiveModelContext(numCtx, f) * max(numParallel, 1)
-}
-
-const (
-	llamaServerGenerationBatchDefault     = 512
-	llamaServerGenerationBatchConstrained = 256
-	llamaServerGenerationBatchMedium      = 1024
-	llamaServerGenerationBatchLarge       = 2048
-
-	llamaServerGenerationBatchMediumHeadroomPercent = 75
-	llamaServerGenerationBatchLargeHeadroomPercent  = 60
-)
-
-func (req *LlmRequest) applyAutomaticGenerationBatch(completion bool, effectiveCtx int, predictedVRAM, availableMemory uint64, flashAttention ml.FlashAttentionType, gpus []ml.DeviceInfo) {
-	if !completion || !req.numBatchAuto {
-		return
-	}
-
-	req.opts.NumBatch = automaticGenerationBatch(effectiveCtx, predictedVRAM, availableMemory, flashAttention, gpus)
-}
-
-func generationBatchSurchargeForCompletion(completion bool, batch int) uint64 {
-	if !completion {
-		return 0
-	}
-	return generationBatchSurcharge(batch)
-}
-
-func automaticGenerationBatch(effectiveCtx int, predictedVRAM, availableMemory uint64, flashAttention ml.FlashAttentionType, gpus []ml.DeviceInfo) int {
-	if flashAttention == ml.FlashAttentionDisabled && hasCUDADevice(gpus) {
-		if constrainedCUDAWithoutFlashAttention(effectiveCtx, gpus) {
-			return llamaServerGenerationBatchConstrained
-		}
-		return llamaServerGenerationBatchDefault
-	}
-
-	batch := generationBatchForContext(effectiveCtx)
-	for batch > llamaServerGenerationBatchDefault && !generationBatchFits(batch, predictedVRAM, availableMemory) {
-		batch = nextLowerGenerationBatch(batch)
-	}
-	return batch
-}
-
-func hasCUDADevice(gpus []ml.DeviceInfo) bool {
-	return slices.ContainsFunc(gpus, func(gpu ml.DeviceInfo) bool {
-		return gpu.Library == "CUDA"
-	})
-}
-
-func constrainedCUDAWithoutFlashAttention(effectiveCtx int, gpus []ml.DeviceInfo) bool {
-	if effectiveCtx <= 4096 {
-		return false
-	}
-	return slices.ContainsFunc(gpus, func(gpu ml.DeviceInfo) bool {
-		if gpu.Library != "CUDA" {
-			return false
-		}
-		memory := gpu.FreeMemory
-		if memory == 0 || (gpu.TotalMemory > 0 && gpu.TotalMemory < memory) {
-			memory = gpu.TotalMemory
-		}
-		return memory > 0 && memory <= 8*format.GibiByte
-	})
-}
-
-func generationBatchForContext(effectiveCtx int) int {
-	switch {
-	case effectiveCtx > 32768:
-		return llamaServerGenerationBatchLarge
-	case effectiveCtx > 4096:
-		return llamaServerGenerationBatchMedium
-	default:
-		return llamaServerGenerationBatchDefault
-	}
-}
-
-func generationBatchFits(batch int, predictedVRAM, availableMemory uint64) bool {
-	if predictedVRAM == 0 || availableMemory == 0 {
-		return true
-	}
-
-	threshold := availableMemory * 80 / 100
-	if predictedVRAM > threshold {
-		return false
-	}
-	if !generationBatchHasHeadroom(batch, predictedVRAM, availableMemory) {
-		return false
-	}
-
-	return generationBatchSurcharge(batch) <= threshold-predictedVRAM
-}
-
-func generationBatchHasHeadroom(batch int, predictedVRAM, availableMemory uint64) bool {
-	switch {
-	case batch >= llamaServerGenerationBatchLarge:
-		return predictedVRAM <= availableMemory*llamaServerGenerationBatchLargeHeadroomPercent/100
-	case batch >= llamaServerGenerationBatchMedium:
-		return predictedVRAM <= availableMemory*llamaServerGenerationBatchMediumHeadroomPercent/100
-	default:
-		return true
-	}
-}
-
-func nextLowerGenerationBatch(batch int) int {
-	switch {
-	case batch > llamaServerGenerationBatchMedium:
-		return llamaServerGenerationBatchMedium
-	default:
-		return llamaServerGenerationBatchDefault
-	}
-}
-
-func generationBatchSurcharge(batch int) uint64 {
-	switch {
-	case batch >= llamaServerGenerationBatchLarge:
-		return 2 * format.GibiByte
-	case batch >= llamaServerGenerationBatchMedium:
-		return 768 * format.MebiByte
-	default:
-		return 0
-	}
-}
-
-func nextLowerAutoNumCtx(numCtx int) (int, bool) {
-	switch {
-	case numCtx > 32768:
-		return 32768, true
-	case numCtx > 4096:
-		return 4096, true
-	default:
-		return 0, false
-	}
-}
-
-func availableMemoryForLoad(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo) (available, gpuFree uint64, systemLimited bool) {
-	var sharedGPUFree uint64
-	var discreteGPUFree uint64
-	for _, gpu := range gpus {
-		gpuFree += gpu.FreeMemory
-		if gpu.Integrated {
-			sharedGPUFree += gpu.FreeMemory
-		} else {
-			discreteGPUFree += gpu.FreeMemory
-		}
-	}
-
-	// On iGPUs, GPU free memory can be a static or slowly refreshed device
-	// baseline. updateFreeSpace has already subtracted known Ollama runner
-	// allocations from that baseline. Current system free memory is a separate
-	// live measurement that already includes those loaded runners, so use the
-	// smaller value for shared-memory GPUs without discounting discrete VRAM.
-	if systemInfo.FreeMemory > 0 && sharedGPUFree > 0 && systemInfo.FreeMemory < sharedGPUFree {
-		return discreteGPUFree + systemInfo.FreeMemory, gpuFree, true
-	}
-
-	return gpuFree, gpuFree, false
-}
-
-func availableMemoryForPlacement(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, opts api.Options) (available, gpuFree uint64, systemLimited bool) {
-	placementGpus := gpusForPlacement(gpus, opts)
-	if len(placementGpus) == 1 && opts.MainGPU != nil {
-		gpuFree = placementGpus[0].FreeMemory
-		available = availableMemoryForGPU(systemInfo, placementGpus[0])
-		systemLimited = available < gpuFree
-		return available, gpuFree, systemLimited
-	}
-
-	return availableMemoryForLoad(systemInfo, placementGpus)
-}
-
-func gpusForPlacement(gpus []ml.DeviceInfo, opts api.Options) []ml.DeviceInfo {
-	if opts.MainGPU != nil && *opts.MainGPU >= 0 && *opts.MainGPU < len(gpus) {
-		return []ml.DeviceInfo{gpus[*opts.MainGPU]}
-	}
-
-	return gpus
-}
-
-func selectLlamaServerPlacement(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, predictedVRAM uint64, opts api.Options) ([]ml.DeviceInfo, api.Options) {
-	launchOpts := opts
-	if len(gpus) <= 1 || opts.NumGPU == 0 {
-		return gpus, launchOpts
-	}
-
-	groups := ml.ByLibrary(gpus)
-	if len(groups) == 0 {
-		return gpus, launchOpts
-	}
-
-	if opts.MainGPU != nil {
-		gpu, available, ok := bestExplicitMainGPU(systemInfo, groups, *opts.MainGPU)
-		if !ok {
-			selected := bestGPUGroupByAvailableMemory(systemInfo, groups)
-			slog.Warn("requested main_gpu is outside the selected GPU group; passing value through to llama-server",
-				"main_gpu", *opts.MainGPU,
-				"gpu_count", len(selected))
-			logSelectedGPUGroup(gpus, selected)
-			return selected, launchOpts
-		}
-
-		selected, launchOpts := singleLlamaServerGPUPlacement(gpu, launchOpts)
-		slog.Info("selecting requested single GPU for llama-server model",
-			"requested_main_gpu", *opts.MainGPU,
-			"main_gpu", *launchOpts.MainGPU,
-			"id", gpu.ID,
-			"filter_id", gpu.FilterID,
-			"library", gpu.Library,
-			"name", gpu.Name,
-			"description", gpu.Description,
-			"integrated", gpu.Integrated,
-			"available", format.HumanBytes2(available))
-		logSelectedGPUGroup(gpus, selected)
-		return selected, launchOpts
-	}
-
-	if !envconfig.SchedSpread() && predictedVRAM > 0 {
-		gpu, available, ok := bestSingleGPUFit(systemInfo, groups, predictedVRAM)
-		if ok {
-			selected, launchOpts := singleLlamaServerGPUPlacement(gpu, launchOpts)
-			slog.Info("selecting single GPU for llama-server model",
-				"main_gpu", *launchOpts.MainGPU,
-				"id", gpu.ID,
-				"filter_id", gpu.FilterID,
-				"library", gpu.Library,
-				"name", gpu.Name,
-				"description", gpu.Description,
-				"integrated", gpu.Integrated,
-				"predicted", format.HumanBytes2(predictedVRAM),
-				"available", format.HumanBytes2(available))
-			logSelectedGPUGroup(gpus, selected)
-			return selected, launchOpts
-		}
-	}
-
-	selected := bestGPUGroupByAvailableMemory(systemInfo, groups)
-	logSelectedGPUGroup(gpus, selected)
-	return selected, launchOpts
-}
-
-func singleLlamaServerGPUPlacement(gpu ml.DeviceInfo, opts api.Options) ([]ml.DeviceInfo, api.Options) {
-	mainGPU := 0
-	opts.MainGPU = &mainGPU
-	return []ml.DeviceInfo{gpu}, opts
-}
-
-func bestExplicitMainGPU(systemInfo ml.SystemInfo, groups [][]ml.DeviceInfo, mainGPU int) (gpu ml.DeviceInfo, available uint64, ok bool) {
-	if mainGPU < 0 {
-		return ml.DeviceInfo{}, 0, false
-	}
-
-	for _, group := range groups {
-		if mainGPU >= len(group) {
-			continue
-		}
-		candidate := group[mainGPU]
-		candidateAvailable := availableMemoryForGPU(systemInfo, candidate)
-		if !ok || betterPlacementGPU(candidate, candidateAvailable, gpu, available) {
-			gpu = candidate
-			available = candidateAvailable
-			ok = true
-		}
-	}
-
-	return gpu, available, ok
-}
-
-func bestSingleGPUFit(systemInfo ml.SystemInfo, groups [][]ml.DeviceInfo, predictedVRAM uint64) (gpu ml.DeviceInfo, available uint64, ok bool) {
-	for _, group := range groups {
-		for _, candidate := range group {
-			candidateAvailable := availableMemoryForGPU(systemInfo, candidate)
-			if predictedVRAM > candidateAvailable*80/100 {
-				continue
-			}
-			if !ok || betterPlacementGPU(candidate, candidateAvailable, gpu, available) {
-				gpu = candidate
-				available = candidateAvailable
-				ok = true
-			}
-		}
-	}
-
-	return gpu, available, ok
-}
-
-func betterPlacementGPU(candidate ml.DeviceInfo, candidateAvailable uint64, current ml.DeviceInfo, currentAvailable uint64) bool {
-	if candidate.Integrated != current.Integrated {
-		return !candidate.Integrated
-	}
-
-	return candidateAvailable > currentAvailable
-}
-
-func bestGPUGroupByAvailableMemory(systemInfo ml.SystemInfo, groups [][]ml.DeviceInfo) []ml.DeviceInfo {
-	var best []ml.DeviceInfo
-	var bestAvailable uint64
-	for _, group := range groups {
-		available, _, _ := availableMemoryForLoad(systemInfo, group)
-		if best == nil || betterPlacementGroup(group, available, best, bestAvailable) {
-			best = group
-			bestAvailable = available
-		}
-	}
-
-	return best
-}
-
-func betterPlacementGroup(candidate []ml.DeviceInfo, candidateAvailable uint64, current []ml.DeviceInfo, currentAvailable uint64) bool {
-	candidateDiscrete := hasDiscreteGPU(candidate)
-	currentDiscrete := hasDiscreteGPU(current)
-	if candidateDiscrete != currentDiscrete {
-		return candidateDiscrete
-	}
-
-	return candidateAvailable > currentAvailable
-}
-
-func hasDiscreteGPU(gpus []ml.DeviceInfo) bool {
-	for _, gpu := range gpus {
-		if !gpu.Integrated {
-			return true
-		}
-	}
-	return false
-}
-
-func availableMemoryForGPU(systemInfo ml.SystemInfo, gpu ml.DeviceInfo) uint64 {
-	if gpu.Integrated && systemInfo.FreeMemory > 0 && systemInfo.FreeMemory < gpu.FreeMemory {
-		return systemInfo.FreeMemory
-	}
-
-	return gpu.FreeMemory
-}
-
-func logSelectedGPUGroup(all, selected []ml.DeviceInfo) {
-	if len(selected) == 0 || len(selected) == len(all) {
-		return
-	}
-
-	slog.Info("selecting GPU backend for llama-server model",
-		"library", selected[0].Library,
-		"gpu_count", len(selected),
-		"available_gpu_count", len(all))
-}
-
-func (s *Scheduler) applyLlamaServerMmapDefaults(req *LlmRequest, launchOpts api.Options, systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, f *ggml.GGML, numParallel int) api.Options {
-	predictedCtx := effectiveLlamaServerContext(req.opts.NumCtx, f, numParallel)
-	predictedVRAM := llm.PredictServerVRAM(req.model.ModelPath, f, predictedCtx)
-	availableVRAM, _, _ := availableMemoryForPlacement(systemInfo, gpus, launchOpts)
-
-	if reason := disableMmapDefaultReason(runtime.GOOS, req.opts, gpus, f.KV().BlockCount(), predictedVRAM, availableVRAM); reason != "" {
-		useMmap := false
-		req.opts.UseMMap = &useMmap
-		req.useMMapAuto = true
-		slog.Info("disabling mmap for llama-server load by default",
-			"model", req.model.ModelPath,
-			"reason", reason)
-	} else {
-		s.maybeDisableMmapForHostPressure(req, launchOpts, systemInfo, gpus, f, numParallel)
-	}
-
-	launchOpts.UseMMap = req.opts.UseMMap
-	return launchOpts
-}
-
-func disableMmapDefaultReason(goos string, opts api.Options, gpus []ml.DeviceInfo, blockCount, predictedVRAM, availableVRAM uint64) string {
-	if opts.UseMMap != nil {
-		return ""
-	}
-	if opts.NumGPU == 0 || len(gpus) == 0 || allDevicesLibrary(gpus, "cpu") {
-		return "cpu"
-	}
-	if goos == "windows" && hasDeviceLibrary(gpus, "cuda") {
-		return "windows_cuda"
-	}
-	if hasDeviceLibrary(gpus, "metal") {
-		if opts.NumGPU > 0 && blockCount > 0 && uint64(opts.NumGPU) < blockCount+1 {
-			return "metal_partial_offload"
-		}
-		if opts.NumGPU < 0 && predictedVRAM > 0 && availableVRAM > 0 && predictedVRAM > availableVRAM {
-			return "metal_partial_offload"
-		}
-	}
-	return ""
-}
-
-func hasDeviceLibrary(gpus []ml.DeviceInfo, library string) bool {
-	for _, gpu := range gpus {
-		if strings.EqualFold(gpu.Library, library) {
-			return true
-		}
-	}
-	return false
-}
-
-func allDevicesLibrary(gpus []ml.DeviceInfo, library string) bool {
-	if len(gpus) == 0 {
-		return false
-	}
-	for _, gpu := range gpus {
-		if !strings.EqualFold(gpu.Library, library) {
-			return false
-		}
-	}
-	return true
-}
-
-func (s *Scheduler) maybeDisableMmapForHostPressure(req *LlmRequest, launchOpts api.Options, systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, f *ggml.GGML, numParallel int) {
-	modelSize := modelFileSize(req.model.ModelPath)
-	loadedMmapSize := s.loadedMmapModelSizeLocked()
-	predictedCtx := effectiveLlamaServerContext(req.opts.NumCtx, f, numParallel)
-	predictedVRAM := llm.PredictServerVRAM(req.model.ModelPath, f, predictedCtx)
-	availableVRAM, _, _ := availableMemoryForPlacement(systemInfo, gpus, launchOpts)
-	placementGpus := gpusForPlacement(gpus, launchOpts)
-
-	if !disableMmapForHostPressure(runtime.GOOS, req.opts, systemInfo, placementGpus, modelSize, loadedMmapSize, predictedVRAM, availableVRAM) {
-		return
-	}
-
-	useMmap := false
-	req.opts.UseMMap = &useMmap
-	req.useMMapAuto = true
-	slog.Info("disabling mmap for llama-server load due to host memory pressure",
-		"model", req.model.ModelPath,
-		"model_size", format.HumanBytes2(modelSize),
-		"loaded_mmap_size", format.HumanBytes2(loadedMmapSize),
-		"headroom", format.HumanBytes2(mmapHostPressureHeadroom(systemInfo.TotalMemory)),
-		"system_free", format.HumanBytes2(systemInfo.FreeMemory),
-		"system_total", format.HumanBytes2(systemInfo.TotalMemory),
-		"predicted_vram", format.HumanBytes2(predictedVRAM),
-		"available_vram", format.HumanBytes2(availableVRAM),
-	)
-}
-
-func disableMmapForHostPressure(goos string, opts api.Options, systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, modelSize, loadedMmapSize, predictedVRAM, availableVRAM uint64) bool {
-	if opts.UseMMap != nil || goos != "linux" || modelSize == 0 || systemInfo.FreeMemory == 0 || !allDiscreteGPUs(gpus) {
-		return false
-	}
-
-	// Only back off mmap when we still expect the model to fit on discrete GPU.
-	// If VRAM is already tight, disabling mmap can make partial CPU offload
-	// worse by turning file-backed mappings into anonymous memory.
-	if predictedVRAM == 0 || availableVRAM == 0 || predictedVRAM > availableVRAM*80/100 {
-		return false
-	}
-
-	pressure := modelSize + loadedMmapSize + mmapHostPressureHeadroom(systemInfo.TotalMemory)
-	return systemInfo.FreeMemory < pressure
-}
-
-func allDiscreteGPUs(gpus []ml.DeviceInfo) bool {
-	if len(gpus) == 0 {
-		return false
-	}
-	for _, gpu := range gpus {
-		if gpu.Integrated {
-			return false
-		}
-	}
-	return true
-}
-
-func mmapHostPressureHeadroom(totalMemory uint64) uint64 {
-	if totalMemory == 0 {
-		return 8 * format.GigaByte
-	}
-	return max(8*format.GigaByte, totalMemory/10)
-}
-
-func modelFileSize(path string) uint64 {
-	if path == "" {
-		return 0
-	}
-	info, err := os.Stat(path)
-	if err != nil {
-		return 0
-	}
-	return uint64(info.Size())
-}
-
-func (s *Scheduler) loadedMmapModelSizeLocked() uint64 {
-	var total uint64
-	for _, r := range s.loaded {
-		if !runnerUsesMmap(r) {
-			continue
-		}
-		if size := modelFileSize(r.modelPath); size > 0 {
-			total += size
-		} else {
-			total += r.totalSize
-		}
-	}
-	return total
-}
-
-func runnerUsesMmap(r *runnerRef) bool {
-	if r == nil || r.Options == nil || r.Options.UseMMap == nil {
-		return true
-	}
-	return *r.Options.UseMMap
 }
 
 func (s *Scheduler) updateFreeSpace(allGpus []ml.DeviceInfo) {
@@ -1305,14 +831,15 @@ func (s *Scheduler) updateFreeSpace(allGpus []ml.DeviceInfo) {
 	s.loadedMu.Unlock()
 	for _, r := range runners {
 		r.refMu.Lock()
-		if r.llama != nil {
-			for _, gpu := range allGpus {
-				predMap[gpu.DeviceID] += r.llama.VRAMByGPU(gpu.DeviceID)
-			}
-		} else {
-			slog.Warn("unexpected nil runner reference, memory prediction may be incorrect")
-		}
+		llama := r.llama
 		r.refMu.Unlock()
+		if llama == nil {
+			slog.Warn("unexpected nil runner reference, memory prediction may be incorrect")
+			continue
+		}
+		for _, gpu := range allGpus {
+			predMap[gpu.DeviceID] += llama.VRAMByGPU(gpu.DeviceID)
+		}
 	}
 
 	// Now that we've summed up all the GPU usage predictions across all the loaded runners, update the gpu list
@@ -1334,22 +861,29 @@ func (s *Scheduler) updateFreeSpace(allGpus []ml.DeviceInfo) {
 	}
 }
 
-// TODO consolidate sched_types.go
 type runnerRef struct {
-	refMu    sync.Mutex
-	refCount uint // prevent unloading if > 0
+	// refMu guards refCount, loading, unloading, expireOnIdle,
+	// sessionDuration, expireTimer, expiresAt, llama, model, Options, gpus, and
+	// contextShift. Fields set once at construction, such as modelKey and
+	// totalSize, may be read lock-free. LogValue uses a best-effort TryLock so
+	// it can still render while refMu is already held.
+	refMu sync.Mutex
 
-	llama        llm.LlamaServer
-	pid          int
-	loading      bool          // True only during initial load, then false forever
-	gpus         []ml.DeviceID // Recorded at time of provisioning
-	discreteGPUs bool          // True if all devices are discrete GPUs - used to skip VRAM recovery check for iGPUs
-	vramSize     uint64
-	totalSize    uint64
+	refCount     uint // prevent unloading if > 0
+	loading      bool // True only during initial load, then false forever
+	unloading    bool
+	expireOnIdle bool
 
 	sessionDuration time.Duration
 	expireTimer     *time.Timer
 	expiresAt       time.Time
+
+	llama           llm.LlamaServer
+	pid             int
+	gpus            []ml.DeviceID // Recorded at time of provisioning
+	usesDiscreteGPU bool          // Used to skip VRAM recovery for CPU and iGPU-only runners.
+	vramSize        uint64
+	totalSize       uint64
 
 	model        *Model
 	modelPath    string
@@ -1363,25 +897,50 @@ type runnerRef struct {
 	*api.Options
 }
 
-// The refMu must already be held when calling unload
-func (runner *runnerRef) unload() {
+// requestImmediateExpirationLocked records that the runner should unload as
+// soon as its refcount reaches zero. It returns true when the caller should
+// send the runner to expiredCh immediately after releasing refMu.
+func (runner *runnerRef) requestImmediateExpirationLocked() bool {
 	if runner.expireTimer != nil {
 		runner.expireTimer.Stop()
 		runner.expireTimer = nil
 	}
-	if runner.llama != nil {
-		runner.llama.Close()
+	runner.sessionDuration = 0
+	if runner.refCount > 0 {
+		runner.expireOnIdle = true
+		return false
 	}
+	return true
+}
+
+func (runner *runnerRef) unload() {
+	runner.refMu.Lock()
+	if runner.expireTimer != nil {
+		runner.expireTimer.Stop()
+		runner.expireTimer = nil
+	}
+	llama := runner.llama
+	runner.llama = nil
 	runner.model = nil
 	runner.Options = nil
 	runner.gpus = nil
 	runner.contextShift = false
+	runner.loading = false
+	runner.unloading = true
+	runner.refMu.Unlock()
+
+	if llama != nil {
+		llama.Close()
+	}
 }
 
 func (runner *runnerRef) needsReload(ctx context.Context, req *LlmRequest) bool {
 	slog.Debug("evaluating already loaded", "model", schedulerModelKey(req.model))
 	runner.refMu.Lock()
 	defer runner.refMu.Unlock()
+	if runner.unloading {
+		return true
+	}
 
 	timeout := 10 * time.Second
 	if runner.loading {
@@ -1441,9 +1000,15 @@ func (runner *runnerRef) needsReload(ctx context.Context, req *LlmRequest) bool 
 func (s *Scheduler) waitForVRAMRecovery(runner *runnerRef, runners []ml.FilteredRunnerDiscovery) chan any {
 	finished := make(chan any, 1)
 
+	runner.refMu.Lock()
+	gpus := slices.Clone(runner.gpus)
+	usesDiscreteGPU := runner.usesDiscreteGPU
+	vramSize := runner.vramSize
+	runner.refMu.Unlock()
+
 	// CPU, Metal and iGPUs don't need checking, so no waiting required
-	if len(runner.gpus) == 0 || !runner.discreteGPUs ||
-		(len(runner.gpus) == 1 && runner.gpus[0].Library == "Metal") {
+	if len(gpus) == 0 || !usesDiscreteGPU ||
+		(len(gpus) == 1 && gpus[0].Library == "Metal") {
 		finished <- struct{}{}
 		slog.Debug("no need to wait for VRAM recovery", "runner", runner)
 		return finished
@@ -1478,12 +1043,12 @@ func (s *Scheduler) waitForVRAMRecovery(runner *runnerRef, runners []ml.Filtered
 					freeMemoryNow += gpu.FreeMemory
 				}
 				if freeMemoryNow > freeMemoryBefore {
-					logutil.Trace("gpu VRAM convergence", "percent", int(float32(freeMemoryNow-freeMemoryBefore)/float32(runner.vramSize)*100))
+					logutil.Trace("gpu VRAM convergence", "percent", int(float32(freeMemoryNow-freeMemoryBefore)/float32(vramSize)*100))
 				} else {
 					logutil.Trace("gpu VRAM convergence", "percent", 0)
 				}
 				// If we're within ~75% of the estimated memory usage recovered, bail out
-				if float32(freeMemoryNow-freeMemoryBefore) > float32(runner.vramSize)*0.75 {
+				if float32(freeMemoryNow-freeMemoryBefore) > float32(vramSize)*0.75 {
 					slog.Debug(fmt.Sprintf("gpu VRAM free memory converged after %0.2f seconds", time.Since(start).Seconds()), "free_before", format.HumanBytes2(freeMemoryBefore), "free_now", format.HumanBytes2(freeMemoryNow), "runner", runner)
 					finished <- struct{}{}
 					return
@@ -1507,74 +1072,90 @@ func (runner *runnerRef) LogValue() slog.Value {
 		modelID = runner.modelKey
 	}
 	attrs := []slog.Attr{}
-	if runner.model != nil {
-		attrs = append(attrs, slog.String("name", runner.model.Name))
-	}
-	if len(runner.gpus) > 0 {
-		attrs = append(attrs,
-			slog.Any("inference", runner.gpus),
-		)
+	if runner.refMu.TryLock() {
+		if runner.model != nil {
+			attrs = append(attrs, slog.String("name", runner.model.Name))
+		}
+		if len(runner.gpus) > 0 {
+			attrs = append(attrs,
+				slog.Any("inference", slices.Clone(runner.gpus)),
+			)
+		}
+		attrs = append(attrs, slog.Int("pid", runner.pid))
+		if runner.Options != nil {
+			attrs = append(attrs, slog.Int("num_ctx", runner.Options.NumCtx))
+		}
+		runner.refMu.Unlock()
 	}
 	attrs = append(attrs,
 		slog.String("size", format.HumanBytes2(runner.totalSize)),
 		slog.String("vram", format.HumanBytes2(runner.vramSize)),
 		slog.Int("parallel", runner.numParallel),
-		slog.Int("pid", runner.pid),
 		slog.String("model", modelID),
 	)
-	if runner.Options != nil {
-		attrs = append(attrs, slog.Int("num_ctx", runner.Options.NumCtx))
-	}
 	return slog.GroupValue(attrs...)
 }
 
 // Implements discover.RunnerDiscovery
 func (runner *runnerRef) GetPort() int {
-	if runner.llama != nil {
-		return runner.llama.GetPort()
+	runner.refMu.Lock()
+	llama := runner.llama
+	runner.refMu.Unlock()
+	if llama != nil {
+		return llama.GetPort()
 	}
 	return -1
 }
 
 func (runner *runnerRef) GetDeviceInfos(ctx context.Context) []ml.DeviceInfo {
-	if runner.llama != nil {
-		return runner.llama.GetDeviceInfos(ctx)
+	runner.refMu.Lock()
+	llama := runner.llama
+	runner.refMu.Unlock()
+	if llama != nil {
+		return llama.GetDeviceInfos(ctx)
 	}
 	return nil
 }
 
 func (runner *runnerRef) GetActiveDeviceIDs() []ml.DeviceID {
-	return runner.gpus
+	runner.refMu.Lock()
+	gpus := slices.Clone(runner.gpus)
+	runner.refMu.Unlock()
+	return gpus
 }
 
 func (runner *runnerRef) HasExited() bool {
-	if runner.llama != nil {
-		return runner.llama.HasExited()
+	runner.refMu.Lock()
+	llama := runner.llama
+	runner.refMu.Unlock()
+	if llama != nil {
+		return llama.HasExited()
 	}
 	return true
 }
 
-type ByDurationAndName []*runnerRef
+type runnerUnloadCandidate struct {
+	runner          *runnerRef
+	refCount        uint
+	sessionDuration time.Duration
+	name            string
+}
 
-func (a ByDurationAndName) Len() int      { return len(a) }
-func (a ByDurationAndName) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
-func (a ByDurationAndName) Less(i, j int) bool {
-	// Primary sort by session duration (uint64 to handle negatives)
-	d1 := uint64(a[i].sessionDuration)
-	d2 := uint64(a[j].sessionDuration)
-	if d1 != d2 {
-		return d1 < d2
+func newRunnerUnloadCandidate(runner *runnerRef) runnerUnloadCandidate {
+	runner.refMu.Lock()
+	defer runner.refMu.Unlock()
+
+	name := runner.modelPath
+	if name == "" {
+		name = runner.modelKey
 	}
-	// Secondary sort by model key/path lex order
-	n1 := a[i].modelPath
-	if n1 == "" {
-		n1 = a[i].modelKey
+
+	return runnerUnloadCandidate{
+		runner:          runner,
+		refCount:        runner.refCount,
+		sessionDuration: runner.sessionDuration,
+		name:            name,
 	}
-	n2 := a[j].modelPath
-	if n2 == "" {
-		n2 = a[j].modelKey
-	}
-	return n1 < n2
 }
 
 // TODO - future consideration to pick runners based on size
@@ -1586,7 +1167,7 @@ func (a ByDurationAndName) Less(i, j int) bool {
 // evictAllAndWait synchronously expires every currently loaded runner except
 // the one being loaded (matched by modelKey) and waits for all unload events
 // to drain. Returns false if the context was cancelled mid-wait so the caller
-// can exit the scheduling loop. Used by the OOM retry path in processPending.
+// can exit the scheduling loop. Used by the load retry path in processPending.
 func (s *Scheduler) evictAllAndWait(ctx context.Context, keepKey string) bool {
 	s.loadedMu.Lock()
 	runnersToExpire := make([]*runnerRef, 0, len(s.loaded))
@@ -1602,18 +1183,15 @@ func (s *Scheduler) evictAllAndWait(ctx context.Context, keepKey string) bool {
 		return true
 	}
 
-	slog.Info("evicting all other loaded models for OOM retry", "count", len(runnersToExpire))
+	slog.Info("evicting all other loaded models for load retry", "count", len(runnersToExpire))
 	for _, runner := range runnersToExpire {
+		var expireNow bool
 		runner.refMu.Lock()
-		if runner.expireTimer != nil {
-			runner.expireTimer.Stop()
-			runner.expireTimer = nil
-		}
-		runner.sessionDuration = 0
-		if runner.refCount <= 0 {
+		expireNow = runner.requestImmediateExpirationLocked()
+		runner.refMu.Unlock()
+		if expireNow {
 			s.expiredCh <- runner
 		}
-		runner.refMu.Unlock()
 	}
 
 	// Wait for every unload event. Each runner produces exactly one
@@ -1647,16 +1225,13 @@ func (s *Scheduler) expireRunnersForRuntimeOOM(model *Model, err error) {
 
 	slog.Warn("runtime OOM detected; expiring loaded models to clear memory before next request", "model", schedulerModelKey(model), "error", err)
 	for _, runner := range runners {
+		var expireNow bool
 		runner.refMu.Lock()
-		if runner.expireTimer != nil {
-			runner.expireTimer.Stop()
-			runner.expireTimer = nil
-		}
-		runner.sessionDuration = 0
-		if runner.refCount <= 0 {
+		expireNow = runner.requestImmediateExpirationLocked()
+		runner.refMu.Unlock()
+		if expireNow {
 			s.expiredCh <- runner
 		}
-		runner.refMu.Unlock()
 	}
 }
 
@@ -1675,38 +1250,51 @@ func (s *Scheduler) findRunnerToUnload() *runnerRef {
 
 	// In the future we can enhance the algorithm to be smarter about picking the optimal runner to unload
 	// e.g., if we have multiple options, will one make room for the request?
-	sort.Sort(ByDurationAndName(runnerList))
+	candidates := make([]runnerUnloadCandidate, 0, len(runnerList))
+	for _, runner := range runnerList {
+		candidates = append(candidates, newRunnerUnloadCandidate(runner))
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		// Primary sort by session duration (uint64 to handle negatives)
+		d1 := uint64(candidates[i].sessionDuration)
+		d2 := uint64(candidates[j].sessionDuration)
+		if d1 != d2 {
+			return d1 < d2
+		}
+		// Secondary sort by model key/path lex order
+		return candidates[i].name < candidates[j].name
+	})
 
 	// First try to find a runner that's already idle
-	for _, runner := range runnerList {
-		runner.refMu.Lock()
-		rc := runner.refCount
-		runner.refMu.Unlock()
-		if rc == 0 {
-			slog.Debug("found an idle runner to unload", "runner", runner)
-			return runner
+	for _, candidate := range candidates {
+		if candidate.refCount == 0 {
+			slog.Debug("found an idle runner to unload", "runner", candidate.runner)
+			return candidate.runner
 		}
 	}
 	// None appear idle, just wait for the one with the shortest duration
-	slog.Debug("no idle runners, picking the shortest duration", "runner_count", len(runnerList), "runner", runnerList[0])
-	return runnerList[0]
+	slog.Debug("no idle runners, picking the shortest duration", "runner_count", len(candidates), "runner", candidates[0].runner)
+	return candidates[0].runner
 }
 
 func (s *Scheduler) unloadAllRunners() {
 	s.loadedMu.Lock()
-	defer s.loadedMu.Unlock()
-
-	if s.activeLoading != nil {
-		slog.Debug("shutting down currently loading runner")
-		s.activeLoading.Close()
-		s.activeLoading = nil
-	}
-
+	activeLoading := s.activeLoading
+	s.activeLoading = nil
+	runners := make([]*runnerRef, 0, len(s.loaded))
 	for model, runner := range s.loaded {
-		if runner.llama != nil {
-			slog.Debug("shutting down runner", "model", model)
-			runner.llama.Close()
-		}
+		slog.Debug("shutting down runner", "model", model)
+		runners = append(runners, runner)
+		delete(s.loaded, model)
+	}
+	s.loadedMu.Unlock()
+
+	if activeLoading != nil {
+		slog.Debug("shutting down currently loading runner")
+		activeLoading.Close()
+	}
+	for _, runner := range runners {
+		runner.unload()
 	}
 }
 
@@ -1716,17 +1304,14 @@ func (s *Scheduler) expireRunner(model *Model) {
 	runner, ok := s.loaded[modelKey]
 	s.loadedMu.Unlock()
 	if ok {
+		var expireNow bool
 		runner.refMu.Lock()
 		runner.expiresAt = time.Now()
-		if runner.expireTimer != nil {
-			runner.expireTimer.Stop()
-			runner.expireTimer = nil
-		}
-		runner.sessionDuration = 0
-		if runner.refCount <= 0 {
+		expireNow = runner.requestImmediateExpirationLocked()
+		runner.refMu.Unlock()
+		if expireNow {
 			s.expiredCh <- runner
 		}
-		runner.refMu.Unlock()
 	}
 }
 
@@ -1750,8 +1335,8 @@ func (s *Scheduler) loadedModels() []loadedModel {
 	}
 	s.loadedMu.Unlock()
 
-	// refMu must not be acquired while holding loadedMu: the expiration path
-	// locks them in the opposite order.
+	// Keep loadedMu scoped to the map snapshot so status reporting does not
+	// block scheduler map updates while it inspects per-runner state.
 	models := make([]loadedModel, 0, len(runners))
 	for _, r := range runners {
 		r.refMu.Lock()
@@ -1760,15 +1345,18 @@ func (s *Scheduler) loadedModels() []loadedModel {
 			r.refMu.Unlock()
 			continue
 		}
+		llama := r.llama
+		sessionDuration := r.sessionDuration
 		lm := loadedModel{
 			model:     r.model,
 			size:      int64(r.totalSize),
 			sizeVRAM:  int64(r.vramSize),
 			expiresAt: r.expiresAt,
 		}
-		if r.llama != nil {
-			lm.contextLength = r.llama.ContextLength()
-			total, vram := r.llama.MemorySize()
+		r.refMu.Unlock()
+		if llama != nil {
+			lm.contextLength = llama.ContextLength()
+			total, vram := llama.MemorySize()
 			lm.size = int64(total)
 			lm.sizeVRAM = int64(vram)
 		}
@@ -1776,9 +1364,8 @@ func (s *Scheduler) loadedModels() []loadedModel {
 		// loading may have the zero value. Estimate expiration from the
 		// session duration instead.
 		if lm.expiresAt.IsZero() {
-			lm.expiresAt = time.Now().Add(r.sessionDuration)
+			lm.expiresAt = time.Now().Add(sessionDuration)
 		}
-		r.refMu.Unlock()
 		models = append(models, lm)
 	}
 	return models

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -1088,45 +1088,45 @@ func TestAutomaticGenerationBatch(t *testing.T) {
 			name:         "small context keeps default",
 			effectiveCtx: 4096,
 			flash:        ml.FlashAttentionAuto,
-			want:         512,
+			want:         llamaServerGenerationBatchDefault,
 		},
 		{
-			name:         "medium context uses 1024 with unknown memory",
+			name:         "medium context uses medium batch with unknown memory",
 			effectiveCtx: 32768,
 			flash:        ml.FlashAttentionAuto,
-			want:         1024,
+			want:         llamaServerGenerationBatchMedium,
 		},
 		{
-			name:         "large context uses 2048 with headroom",
+			name:         "large context uses large batch with headroom",
 			effectiveCtx: 131072,
 			predicted:    8 * format.GibiByte,
 			available:    14 * format.GibiByte,
 			flash:        ml.FlashAttentionAuto,
-			want:         2048,
+			want:         llamaServerGenerationBatchLarge,
 		},
 		{
-			name:         "large context steps down to 1024 without 2048 headroom",
+			name:         "large context steps down to medium batch without large batch headroom",
 			effectiveCtx: 131072,
 			predicted:    9 * format.GibiByte,
 			available:    14 * format.GibiByte,
 			flash:        ml.FlashAttentionAuto,
-			want:         1024,
+			want:         llamaServerGenerationBatchMedium,
 		},
 		{
-			name:         "large context steps down to 1024 for headroom",
+			name:         "large context steps down to medium batch for headroom",
 			effectiveCtx: 131072,
 			predicted:    8 * format.GibiByte,
 			available:    11 * format.GibiByte,
 			flash:        ml.FlashAttentionAuto,
-			want:         1024,
+			want:         llamaServerGenerationBatchMedium,
 		},
 		{
-			name:         "medium context steps down to 512 for headroom",
+			name:         "medium context steps down to default batch for headroom",
 			effectiveCtx: 32768,
 			predicted:    8500 * format.MebiByte,
 			available:    11 * format.GibiByte,
 			flash:        ml.FlashAttentionAuto,
-			want:         512,
+			want:         llamaServerGenerationBatchDefault,
 		},
 		{
 			name:         "flash attention disabled suppresses promotion",
@@ -1135,7 +1135,7 @@ func TestAutomaticGenerationBatch(t *testing.T) {
 			available:    14 * format.GibiByte,
 			flash:        ml.FlashAttentionDisabled,
 			gpus:         []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}, FreeMemory: 14 * format.GibiByte}},
-			want:         512,
+			want:         llamaServerGenerationBatchDefault,
 		},
 		{
 			name:         "constrained CUDA without flash attention uses smaller batch",
@@ -1144,7 +1144,7 @@ func TestAutomaticGenerationBatch(t *testing.T) {
 			available:    6 * format.GibiByte,
 			flash:        ml.FlashAttentionDisabled,
 			gpus:         []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}, FreeMemory: 6 * format.GibiByte}},
-			want:         256,
+			want:         llamaServerGenerationBatchConstrained,
 		},
 	}
 
@@ -1332,6 +1332,124 @@ func TestSchedLlamaServerFitsAlongside(t *testing.T) {
 	require.False(t, needEvict, "expected no eviction when model fits in available VRAM")
 }
 
+func TestSchedRetriesWhenLlamaServerSpillsToCPUWithLoadedRunner(t *testing.T) {
+	ctx, done := context.WithTimeout(t.Context(), 500*time.Millisecond)
+	defer done()
+
+	var buf bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(previous)
+
+	s := InitScheduler(ctx)
+	s.waitForRecovery = 10 * time.Millisecond
+	s.getGpuFn = func(ctx context.Context, runners []ml.FilteredRunnerDiscovery) []ml.DeviceInfo {
+		g := ml.DeviceInfo{DeviceID: ml.DeviceID{Library: "Metal"}}
+		g.TotalMemory = 24 * format.GigaByte
+		g.FreeMemory = 20 * format.GigaByte
+		return []ml.DeviceInfo{g}
+	}
+	s.getSystemInfoFn = getSystemInfoFn
+
+	s.loadedMu.Lock()
+	s.loaded["existing-model"] = &runnerRef{
+		llama:    &mockLlm{modelPath: "/fake/existing"},
+		modelKey: "existing-model",
+	}
+	s.loadedMu.Unlock()
+
+	scenario := newScenarioRequest(t, ctx, "cpu-spill-model", 1*format.GigaByte, nil, nil)
+	scenario.srv.totalSize = 2 * format.GigaByte
+	scenario.srv.vramSize = 1 * format.GigaByte
+	scenario.srv.gpuLayers = 20
+	scenario.srv.totalLayers = 33
+	s.newServerFn = scenario.newServer
+
+	systemInfo := getSystemInfoFn()
+	gpus := s.getGpuFn(ctx, nil)
+
+	require.True(t, s.load(scenario.req, systemInfo, gpus, true))
+	require.True(t, scenario.req.loadRetryAttempted)
+	require.True(t, scenario.srv.closeCalled)
+	require.Nil(t, s.activeLoading)
+	require.Contains(t, buf.String(), "llama-server spilled layers to CPU with other models resident; evicting residents and retrying")
+	require.Contains(t, buf.String(), "gpu_layers=20")
+	require.Contains(t, buf.String(), "total_layers=33")
+}
+
+func TestSchedAllowsCPUOnlyLlamaServerLoadWithLoadedRunner(t *testing.T) {
+	ctx, done := context.WithTimeout(t.Context(), 500*time.Millisecond)
+	defer done()
+
+	var buf bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(previous)
+
+	s := InitScheduler(ctx)
+	s.waitForRecovery = 10 * time.Millisecond
+	s.getGpuFn = func(ctx context.Context, runners []ml.FilteredRunnerDiscovery) []ml.DeviceInfo {
+		return nil
+	}
+	s.getSystemInfoFn = getSystemInfoFn
+
+	s.loadedMu.Lock()
+	s.loaded["existing-model"] = &runnerRef{
+		llama:    &mockLlm{modelPath: "/fake/existing"},
+		modelKey: "existing-model",
+	}
+	s.loadedMu.Unlock()
+
+	scenario := newScenarioRequest(t, ctx, "cpu-only-model", 1*format.GigaByte, nil, nil)
+	scenario.srv.totalSize = 2 * format.GigaByte
+	scenario.srv.gpuLayers = 0
+	scenario.srv.totalLayers = 33
+	s.newServerFn = scenario.newServer
+
+	systemInfo := getSystemInfoFn()
+	gpus := s.getGpuFn(ctx, nil)
+
+	require.False(t, s.load(scenario.req, systemInfo, gpus, true))
+	require.False(t, scenario.req.loadRetryAttempted)
+	require.False(t, scenario.srv.closeCalled)
+	require.NotContains(t, buf.String(), "llama-server spilled layers to CPU with other models resident")
+}
+
+func TestSchedAllowsLlamaServerCPUOverflowWithoutLoadedRunner(t *testing.T) {
+	ctx, done := context.WithTimeout(t.Context(), 500*time.Millisecond)
+	defer done()
+
+	var buf bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(previous)
+
+	s := InitScheduler(ctx)
+	s.waitForRecovery = 10 * time.Millisecond
+	s.getGpuFn = func(ctx context.Context, runners []ml.FilteredRunnerDiscovery) []ml.DeviceInfo {
+		g := ml.DeviceInfo{DeviceID: ml.DeviceID{Library: "Metal"}}
+		g.TotalMemory = 24 * format.GigaByte
+		g.FreeMemory = 20 * format.GigaByte
+		return []ml.DeviceInfo{g}
+	}
+	s.getSystemInfoFn = getSystemInfoFn
+
+	scenario := newScenarioRequest(t, ctx, "cpu-spill-model", 1*format.GigaByte, nil, nil)
+	scenario.srv.totalSize = 2 * format.GigaByte
+	scenario.srv.vramSize = 1 * format.GigaByte
+	scenario.srv.gpuLayers = 20
+	scenario.srv.totalLayers = 33
+	s.newServerFn = scenario.newServer
+
+	systemInfo := getSystemInfoFn()
+	gpus := s.getGpuFn(ctx, nil)
+
+	require.False(t, s.load(scenario.req, systemInfo, gpus, false))
+	require.False(t, scenario.req.loadRetryAttempted)
+	require.False(t, scenario.srv.closeCalled)
+	require.NotContains(t, buf.String(), "llama-server spilled layers to CPU with other models resident")
+}
+
 func TestSchedLlamaServerPredictionUsesTotalParallelContext(t *testing.T) {
 	ctx, done := context.WithTimeout(t.Context(), 500*time.Millisecond)
 	defer done()
@@ -1371,374 +1489,6 @@ func TestSchedLlamaServerPredictionUsesTotalParallelContext(t *testing.T) {
 	require.False(t, called, "preflight prediction should reject before spawning llama-server")
 }
 
-func TestAvailableMemoryForLoadUsesWorstSharedMemoryMeasurement(t *testing.T) {
-	tests := []struct {
-		name              string
-		systemFree        uint64
-		gpus              []ml.DeviceInfo
-		wantAvailable     uint64
-		wantGPUFree       uint64
-		wantSystemLimited bool
-	}{
-		{
-			name:       "integrated metal uses lower system free",
-			systemFree: 80 * format.GigaByte,
-			gpus: []ml.DeviceInfo{{
-				DeviceID:   ml.DeviceID{Library: "Metal"},
-				Integrated: true,
-				FreeMemory: 300 * format.GigaByte,
-			}},
-			wantAvailable:     80 * format.GigaByte,
-			wantGPUFree:       300 * format.GigaByte,
-			wantSystemLimited: true,
-		},
-		{
-			name:       "integrated gpu uses lower system free",
-			systemFree: 6 * format.GigaByte,
-			gpus: []ml.DeviceInfo{{
-				DeviceID:   ml.DeviceID{Library: "Vulkan"},
-				Integrated: true,
-				FreeMemory: 12 * format.GigaByte,
-			}},
-			wantAvailable:     6 * format.GigaByte,
-			wantGPUFree:       12 * format.GigaByte,
-			wantSystemLimited: true,
-		},
-		{
-			name:       "discrete metal ignores lower system free",
-			systemFree: 6 * format.GigaByte,
-			gpus: []ml.DeviceInfo{{
-				DeviceID:   ml.DeviceID{Library: "Metal"},
-				FreeMemory: 12 * format.GigaByte,
-			}},
-			wantAvailable: 12 * format.GigaByte,
-			wantGPUFree:   12 * format.GigaByte,
-		},
-		{
-			name:       "discrete gpu ignores lower system free",
-			systemFree: 6 * format.GigaByte,
-			gpus: []ml.DeviceInfo{{
-				DeviceID:   ml.DeviceID{Library: "CUDA"},
-				FreeMemory: 12 * format.GigaByte,
-			}},
-			wantAvailable: 12 * format.GigaByte,
-			wantGPUFree:   12 * format.GigaByte,
-		},
-		{
-			name:       "mixed gpus only clamp integrated contribution",
-			systemFree: 6 * format.GigaByte,
-			gpus: []ml.DeviceInfo{
-				{
-					DeviceID:   ml.DeviceID{Library: "CUDA"},
-					FreeMemory: 12 * format.GigaByte,
-				},
-				{
-					DeviceID:   ml.DeviceID{Library: "Vulkan"},
-					Integrated: true,
-					FreeMemory: 10 * format.GigaByte,
-				},
-			},
-			wantAvailable:     18 * format.GigaByte,
-			wantGPUFree:       22 * format.GigaByte,
-			wantSystemLimited: true,
-		},
-		{
-			name:       "shared gpu keeps lower adjusted gpu baseline",
-			systemFree: 20 * format.GigaByte,
-			gpus: []ml.DeviceInfo{{
-				DeviceID:   ml.DeviceID{Library: "Metal"},
-				Integrated: true,
-				FreeMemory: 12 * format.GigaByte,
-			}},
-			wantAvailable: 12 * format.GigaByte,
-			wantGPUFree:   12 * format.GigaByte,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			available, gpuFree, systemLimited := availableMemoryForLoad(ml.SystemInfo{FreeMemory: tt.systemFree}, tt.gpus)
-			require.Equal(t, tt.wantAvailable, available)
-			require.Equal(t, tt.wantGPUFree, gpuFree)
-			require.Equal(t, tt.wantSystemLimited, systemLimited)
-		})
-	}
-}
-
-func TestSelectLlamaServerPlacement(t *testing.T) {
-	systemInfo := ml.SystemInfo{FreeMemory: 14 * format.GigaByte}
-
-	tests := []struct {
-		name             string
-		gpus             []ml.DeviceInfo
-		predictedVRAM    uint64
-		opts             api.Options
-		schedSpread      string
-		wantLibrary      string
-		wantMainGPU      *int
-		wantSelectedGPUs int
-		wantGPUID        string
-	}{
-		{
-			name:          "compacts onto largest same-backend GPU",
-			predictedVRAM: 8 * format.GigaByte,
-			gpus: []ml.DeviceInfo{
-				{DeviceID: ml.DeviceID{ID: "0", Library: "CUDA"}, Name: "small", FreeMemory: 10 * format.GigaByte},
-				{DeviceID: ml.DeviceID{ID: "1", Library: "CUDA"}, Name: "large", FreeMemory: 20 * format.GigaByte},
-			},
-			opts:             api.DefaultOptions(),
-			wantLibrary:      "CUDA",
-			wantMainGPU:      testIntPtr(0),
-			wantSelectedGPUs: 1,
-			wantGPUID:        "1",
-		},
-		{
-			name:          "explicit main gpu selects matching backend group",
-			predictedVRAM: 8 * format.GigaByte,
-			gpus: []ml.DeviceInfo{
-				{DeviceID: ml.DeviceID{ID: "0", Library: "CUDA"}, FreeMemory: 10 * format.GigaByte},
-				{DeviceID: ml.DeviceID{ID: "0", Library: "ROCm"}, FreeMemory: 20 * format.GigaByte},
-				{DeviceID: ml.DeviceID{ID: "1", Library: "ROCm"}, FreeMemory: 24 * format.GigaByte},
-			},
-			opts: api.Options{
-				Runner: api.Runner{MainGPU: testIntPtr(1), NumGPU: -1},
-			},
-			wantLibrary:      "ROCm",
-			wantMainGPU:      testIntPtr(0),
-			wantSelectedGPUs: 1,
-			wantGPUID:        "1",
-		},
-		{
-			name:          "integrated GPU is capped by system free memory",
-			predictedVRAM: 12 * format.GigaByte,
-			gpus: []ml.DeviceInfo{
-				{DeviceID: ml.DeviceID{ID: "0", Library: "Metal"}, Integrated: true, FreeMemory: 32 * format.GigaByte},
-				{DeviceID: ml.DeviceID{ID: "1", Library: "Metal"}, FreeMemory: 16 * format.GigaByte},
-			},
-			opts:             api.DefaultOptions(),
-			wantLibrary:      "Metal",
-			wantMainGPU:      testIntPtr(0),
-			wantSelectedGPUs: 1,
-			wantGPUID:        "1",
-		},
-		{
-			name:          "prefers discrete GPU over integrated GPU with more available memory",
-			predictedVRAM: 8 * format.GigaByte,
-			gpus: []ml.DeviceInfo{
-				{DeviceID: ml.DeviceID{ID: "0", Library: "Vulkan"}, Name: "integrated", Integrated: true, FreeMemory: 32 * format.GigaByte},
-				{DeviceID: ml.DeviceID{ID: "1", Library: "Vulkan"}, Name: "discrete", FreeMemory: 10 * format.GigaByte},
-			},
-			opts:             api.DefaultOptions(),
-			wantLibrary:      "Vulkan",
-			wantMainGPU:      testIntPtr(0),
-			wantSelectedGPUs: 1,
-			wantGPUID:        "1",
-		},
-		{
-			name:          "spread disables automatic compaction",
-			predictedVRAM: 8 * format.GigaByte,
-			schedSpread:   "1",
-			gpus: []ml.DeviceInfo{
-				{DeviceID: ml.DeviceID{ID: "0", Library: "CUDA"}, FreeMemory: 10 * format.GigaByte},
-				{DeviceID: ml.DeviceID{ID: "1", Library: "CUDA"}, FreeMemory: 20 * format.GigaByte},
-			},
-			opts:             api.DefaultOptions(),
-			wantLibrary:      "CUDA",
-			wantSelectedGPUs: 2,
-		},
-		{
-			name:          "no single fit chooses best backend group for llama-server split",
-			predictedVRAM: 30 * format.GigaByte,
-			gpus: []ml.DeviceInfo{
-				{DeviceID: ml.DeviceID{ID: "0", Library: "CUDA"}, FreeMemory: 10 * format.GigaByte},
-				{DeviceID: ml.DeviceID{ID: "1", Library: "CUDA"}, FreeMemory: 18 * format.GigaByte},
-				{DeviceID: ml.DeviceID{ID: "0", Library: "ROCm"}, FreeMemory: 12 * format.GigaByte},
-			},
-			opts:             api.DefaultOptions(),
-			wantLibrary:      "CUDA",
-			wantSelectedGPUs: 2,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("OLLAMA_SCHED_SPREAD", tt.schedSpread)
-
-			selected, launchOpts := selectLlamaServerPlacement(systemInfo, tt.gpus, tt.predictedVRAM, tt.opts)
-			require.Len(t, selected, tt.wantSelectedGPUs)
-			require.Equal(t, tt.wantLibrary, selected[0].Library)
-			if tt.wantGPUID != "" {
-				require.Equal(t, tt.wantGPUID, selected[0].ID)
-			}
-			if tt.wantMainGPU == nil {
-				require.Nil(t, launchOpts.MainGPU)
-			} else {
-				require.NotNil(t, launchOpts.MainGPU)
-				require.Equal(t, *tt.wantMainGPU, *launchOpts.MainGPU)
-			}
-		})
-	}
-}
-
-func testIntPtr(v int) *int {
-	return &v
-}
-
-func TestDisableMmapDefaultReason(t *testing.T) {
-	useMmap := true
-	tests := []struct {
-		name          string
-		goos          string
-		opts          api.Options
-		gpus          []ml.DeviceInfo
-		blockCount    uint64
-		predictedVRAM uint64
-		availableVRAM uint64
-		want          string
-	}{
-		{
-			name: "explicit use_mmap true wins",
-			goos: "windows",
-			opts: api.Options{Runner: api.Runner{NumGPU: -1, UseMMap: &useMmap}},
-			gpus: []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}}},
-		},
-		{
-			name: "cpu-only request disables mmap",
-			goos: "linux",
-			opts: api.Options{Runner: api.Runner{NumGPU: 0}},
-			gpus: []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}}},
-			want: "cpu",
-		},
-		{
-			name: "no GPU devices disables mmap",
-			goos: "linux",
-			opts: api.Options{Runner: api.Runner{NumGPU: -1}},
-			want: "cpu",
-		},
-		{
-			name: "windows cuda disables mmap",
-			goos: "windows",
-			opts: api.Options{Runner: api.Runner{NumGPU: -1}},
-			gpus: []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}}},
-			want: "windows_cuda",
-		},
-		{
-			name:       "metal partial offload disables mmap",
-			goos:       "darwin",
-			opts:       api.Options{Runner: api.Runner{NumGPU: 10}},
-			gpus:       []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "Metal"}}},
-			blockCount: 20,
-			want:       "metal_partial_offload",
-		},
-		{
-			name:       "metal full offload keeps default",
-			goos:       "darwin",
-			opts:       api.Options{Runner: api.Runner{NumGPU: 21}},
-			gpus:       []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "Metal"}}},
-			blockCount: 20,
-		},
-		{
-			name:          "metal auto partial offload disables mmap",
-			goos:          "darwin",
-			opts:          api.Options{Runner: api.Runner{NumGPU: -1}},
-			gpus:          []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "Metal"}}},
-			predictedVRAM: 30 * format.GigaByte,
-			availableVRAM: 20 * format.GigaByte,
-			want:          "metal_partial_offload",
-		},
-		{
-			name:          "metal auto full offload keeps default",
-			goos:          "darwin",
-			opts:          api.Options{Runner: api.Runner{NumGPU: -1}},
-			gpus:          []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "Metal"}}},
-			predictedVRAM: 10 * format.GigaByte,
-			availableVRAM: 20 * format.GigaByte,
-		},
-		{
-			name: "linux cuda keeps default",
-			goos: "linux",
-			opts: api.Options{Runner: api.Runner{NumGPU: -1}},
-			gpus: []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}}},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, disableMmapDefaultReason(tt.goos, tt.opts, tt.gpus, tt.blockCount, tt.predictedVRAM, tt.availableVRAM))
-		})
-	}
-}
-
-func TestDisableMmapForHostPressure(t *testing.T) {
-	gpus := []ml.DeviceInfo{{
-		DeviceID:    ml.DeviceID{Library: "CUDA"},
-		TotalMemory: 100 * format.GigaByte,
-		FreeMemory:  80 * format.GigaByte,
-	}}
-	systemInfo := ml.SystemInfo{
-		TotalMemory: 100 * format.GigaByte,
-		FreeMemory:  50 * format.GigaByte,
-	}
-
-	require.True(t, disableMmapForHostPressure(
-		"linux",
-		api.Options{},
-		systemInfo,
-		gpus,
-		20*format.GigaByte,
-		25*format.GigaByte,
-		30*format.GigaByte,
-		80*format.GigaByte,
-	))
-
-	useMmap := true
-	require.False(t, disableMmapForHostPressure(
-		"linux",
-		api.Options{Runner: api.Runner{UseMMap: &useMmap}},
-		systemInfo,
-		gpus,
-		20*format.GigaByte,
-		25*format.GigaByte,
-		30*format.GigaByte,
-		80*format.GigaByte,
-	), "explicit use_mmap=true should win")
-
-	require.False(t, disableMmapForHostPressure(
-		"darwin",
-		api.Options{},
-		systemInfo,
-		gpus,
-		20*format.GigaByte,
-		25*format.GigaByte,
-		30*format.GigaByte,
-		80*format.GigaByte,
-	), "only the Linux pressure heuristic is restored")
-
-	igpu := append([]ml.DeviceInfo(nil), gpus...)
-	igpu[0].Integrated = true
-	require.False(t, disableMmapForHostPressure(
-		"linux",
-		api.Options{},
-		systemInfo,
-		igpu,
-		20*format.GigaByte,
-		25*format.GigaByte,
-		30*format.GigaByte,
-		80*format.GigaByte,
-	), "shared-memory GPU loads should keep the normal mmap path")
-
-	require.False(t, disableMmapForHostPressure(
-		"linux",
-		api.Options{},
-		systemInfo,
-		gpus,
-		20*format.GigaByte,
-		25*format.GigaByte,
-		70*format.GigaByte,
-		80*format.GigaByte,
-	), "when VRAM is tight, no-mmap could make partial CPU offload worse")
-}
-
 // TestSchedLoadCrashTriggersEvictAllAndRetry verifies that a post-spawn
 // Load() OOM while other models are resident signals evict-all-and-retry
 // on the first attempt, but fails fast on the second attempt.
@@ -1776,8 +1526,8 @@ func TestSchedLoadCrashTriggersEvictAllAndRetry(t *testing.T) {
 	// First attempt: should signal evict-all by returning true and NOT send
 	// the error to errCh (so the caller will retry).
 	needEvict := s.load(scenario.req, systemInfo, gpus, true)
-	require.True(t, needEvict, "first load OOM should signal eviction")
-	require.True(t, scenario.req.oomRetryAttempted, "oomRetryAttempted should be set")
+	require.True(t, needEvict, "first load retry should signal eviction")
+	require.True(t, scenario.req.loadRetryAttempted, "loadRetryAttempted should be set")
 	select {
 	case err := <-scenario.req.errCh:
 		t.Fatalf("errCh should be empty on first crash, got %v", err)
@@ -1785,10 +1535,10 @@ func TestSchedLoadCrashTriggersEvictAllAndRetry(t *testing.T) {
 	}
 
 	// Second attempt (simulating the retry after processPending evicted all
-	// other runners): same crash, but this time oomRetryAttempted is set so
+	// other runners): same crash, but this time loadRetryAttempted is set so
 	// load() should fail fast and report the error.
 	needEvict = s.load(scenario.req, systemInfo, gpus, true)
-	require.False(t, needEvict, "second load OOM should not ask for another eviction")
+	require.False(t, needEvict, "second load retry should not ask for another eviction")
 	select {
 	case err := <-scenario.req.errCh:
 		require.ErrorIs(t, err, loadCrash)
@@ -1834,10 +1584,10 @@ func TestSchedLoadOOMReducesAutomaticContextBeforeRetry(t *testing.T) {
 	gpus := s.getGpuFn(ctx, nil)
 
 	needEvict := s.load(scenario.req, systemInfo, gpus, true)
-	require.True(t, needEvict, "first automatic-context load OOM should signal eviction and retry")
-	require.True(t, scenario.req.oomRetryAttempted)
+	require.True(t, needEvict, "first automatic-context load retry should signal eviction and retry")
+	require.True(t, scenario.req.loadRetryAttempted)
 	require.Equal(t, 32768, scenario.req.opts.NumCtx)
-	require.Equal(t, 1024, scenario.req.opts.NumBatch)
+	require.Equal(t, llamaServerGenerationBatchMedium, scenario.req.opts.NumBatch)
 	select {
 	case err := <-scenario.req.errCh:
 		t.Fatalf("errCh should be empty on first crash, got %v", err)
@@ -1845,9 +1595,9 @@ func TestSchedLoadOOMReducesAutomaticContextBeforeRetry(t *testing.T) {
 	}
 
 	needEvict = s.load(scenario.req, systemInfo, gpus, true)
-	require.False(t, needEvict, "second load OOM should not ask for another eviction")
+	require.False(t, needEvict, "second load retry should not ask for another eviction")
 	require.Equal(t, []int{262144, 32768}, seenNumCtx)
-	require.Equal(t, []int{2048, 1024}, seenNumBatch)
+	require.Equal(t, []int{llamaServerGenerationBatchLarge, llamaServerGenerationBatchMedium}, seenNumBatch)
 	select {
 	case err := <-scenario.req.errCh:
 		require.ErrorIs(t, err, loadCrash)
@@ -1888,8 +1638,8 @@ func TestSchedLoadOOMKeepsExplicitContextBeforeRetry(t *testing.T) {
 	gpus := s.getGpuFn(ctx, nil)
 
 	needEvict := s.load(scenario.req, systemInfo, gpus, true)
-	require.True(t, needEvict, "explicit-context load OOM should still evict and retry once")
-	require.True(t, scenario.req.oomRetryAttempted)
+	require.True(t, needEvict, "explicit-context load retry should still evict and retry once")
+	require.True(t, scenario.req.loadRetryAttempted)
 	require.Equal(t, 262144, scenario.req.opts.NumCtx)
 	select {
 	case err := <-scenario.req.errCh:
@@ -1965,7 +1715,7 @@ func TestSchedLoadCrashNoOtherModelsFailsFast(t *testing.T) {
 
 	needEvict := s.load(scenario.req, systemInfo, gpus, true)
 	require.False(t, needEvict, "crash with no other runners should not ask for eviction")
-	require.False(t, scenario.req.oomRetryAttempted, "oomRetryAttempted must stay false")
+	require.False(t, scenario.req.loadRetryAttempted, "loadRetryAttempted must stay false")
 	select {
 	case err := <-scenario.req.errCh:
 		require.ErrorIs(t, err, loadCrash)
@@ -2005,7 +1755,7 @@ func TestSchedLoadNonOOMWithOtherModelsFailsFast(t *testing.T) {
 
 	needEvict := s.load(scenario.req, systemInfo, gpus, true)
 	require.False(t, needEvict, "non-OOM load crash should not ask for eviction")
-	require.False(t, scenario.req.oomRetryAttempted, "oomRetryAttempted must stay false")
+	require.False(t, scenario.req.loadRetryAttempted, "loadRetryAttempted must stay false")
 	select {
 	case err := <-scenario.req.errCh:
 		require.ErrorIs(t, err, loadCrash)
@@ -2085,6 +1835,9 @@ type mockLlm struct {
 	totalSize         uint64
 	contextLength     int
 	vramByGPU         map[ml.DeviceID]uint64
+	gpuLayers         uint64
+	totalLayers       uint64
+	gpuLayerOverflow  int
 
 	// loadErr, if non-nil, is returned from Load() to simulate a post-spawn
 	// load failure (e.g. llama-server crashing due to under-predicted VRAM).
@@ -2156,6 +1909,9 @@ func (s *mockLlm) GetDeviceInfos(ctx context.Context) []ml.DeviceInfo { return n
 func (s *mockLlm) HasExited() bool                                    { return false }
 func (s *mockLlm) GetActiveDeviceIDs() []ml.DeviceID                  { return nil }
 func (s *mockLlm) ContextLength() int                                 { return s.contextLength }
+func (s *mockLlm) LayerOffloadStatus() (gpuLayers, totalLayers uint64, overflow int, ok bool) {
+	return s.gpuLayers, s.totalLayers, s.gpuLayerOverflow, s.totalLayers > 0
+}
 
 // TestImageGenRunnerCanBeEvicted verifies that an image generation model
 // loaded in the scheduler can be evicted when idle.

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -7,7 +7,9 @@ import (
 	"log/slog"
 	"os"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -27,6 +29,47 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+// syncBuffer is a goroutine-safe sink for capturing slog output: scheduler
+// goroutines from a previous test can still be draining — and logging through
+// slog.Default — while the current test writes and reads its capture buffer.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func withSynctestScheduler(t *testing.T, fn func(t *testing.T, ctx context.Context)) {
+	t.Helper()
+
+	// Tests inside this helper can use time.Sleep to advance synctest's fake
+	// clock for scheduler timers without adding wall-clock delay or CI flake.
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		fn(t, ctx)
+		cancel()
+		synctest.Wait()
+	})
+}
+
+func requireLoadedCount(t *testing.T, s *Scheduler, want int) {
+	t.Helper()
+
+	s.loadedMu.Lock()
+	defer s.loadedMu.Unlock()
+	require.Len(t, s.loaded, want)
+}
+
 func TestSchedInit(t *testing.T) {
 	ctx, done := context.WithCancel(t.Context())
 	defer done()
@@ -37,97 +80,94 @@ func TestSchedInit(t *testing.T) {
 }
 
 func TestSchedLoad(t *testing.T) {
-	ctx, done := context.WithTimeout(t.Context(), 20*time.Millisecond)
-	defer done()
-	s := InitScheduler(ctx)
-	s.waitForRecovery = 10 * time.Millisecond
+	withSynctestScheduler(t, func(t *testing.T, ctx context.Context) {
+		s := InitScheduler(ctx)
+		s.waitForRecovery = 10 * time.Millisecond
 
-	modelPath, _ := createBinFile(t, ggml.KV{
-		"general.architecture":          "llama",
-		"llama.context_length":          uint32(32),
-		"llama.embedding_length":        uint32(4096),
-		"llama.block_count":             uint32(1),
-		"llama.attention.head_count":    uint32(32),
-		"llama.attention.head_count_kv": uint32(32),
-		"tokenizer.ggml.tokens":         []string{" "},
-		"tokenizer.ggml.scores":         []float32{0},
-		"tokenizer.ggml.token_type":     []int32{0},
-	}, []*ggml.Tensor{
-		{Name: "blk.0.attn.weight", Kind: uint32(0), Offset: uint64(0), Shape: []uint64{1, 1, 1, 1}, WriterTo: bytes.NewReader(make([]byte, 32))},
-		{Name: "output.weight", Kind: uint32(0), Offset: uint64(0), Shape: []uint64{1, 1, 1, 1}, WriterTo: bytes.NewReader(make([]byte, 32))},
-	})
+		modelPath, _ := createBinFile(t, ggml.KV{
+			"general.architecture":          "llama",
+			"llama.context_length":          uint32(32),
+			"llama.embedding_length":        uint32(4096),
+			"llama.block_count":             uint32(1),
+			"llama.attention.head_count":    uint32(32),
+			"llama.attention.head_count_kv": uint32(32),
+			"tokenizer.ggml.tokens":         []string{" "},
+			"tokenizer.ggml.scores":         []float32{0},
+			"tokenizer.ggml.token_type":     []int32{0},
+		}, []*ggml.Tensor{
+			{Name: "blk.0.attn.weight", Kind: uint32(0), Offset: uint64(0), Shape: []uint64{1, 1, 1, 1}, WriterTo: bytes.NewReader(make([]byte, 32))},
+			{Name: "output.weight", Kind: uint32(0), Offset: uint64(0), Shape: []uint64{1, 1, 1, 1}, WriterTo: bytes.NewReader(make([]byte, 32))},
+		})
 
-	req := &LlmRequest{
-		ctx:             ctx,
-		model:           &Model{ModelPath: modelPath},
-		opts:            api.DefaultOptions(),
-		successCh:       make(chan *runnerRef, 1),
-		errCh:           make(chan error, 1),
-		sessionDuration: &api.Duration{Duration: 2 * time.Second},
-	}
-	// Fail to load model first
-	s.newServerFn = func(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, model string, f *ggml.GGML, adapters []string, projectors []string, opts api.Options, numParallel int, _ llm.LlamaServerConfig) (llm.LlamaServer, error) {
-		return nil, errors.New("something failed to load model blah")
-	}
-	gpus := []ml.DeviceInfo{}
-	systemInfo := ml.SystemInfo{}
-	s.load(req, systemInfo, gpus, false)
-	require.Empty(t, req.successCh)
-	require.Len(t, req.errCh, 1)
-	s.loadedMu.Lock()
-	require.Empty(t, s.loaded)
-	s.loadedMu.Unlock()
-	err := <-req.errCh
-	require.Contains(t, err.Error(), "this model may be incompatible")
+		req := &LlmRequest{
+			ctx:             ctx,
+			model:           &Model{ModelPath: modelPath},
+			opts:            api.DefaultOptions(),
+			successCh:       make(chan *runnerRef, 1),
+			errCh:           make(chan error, 1),
+			sessionDuration: &api.Duration{Duration: 2 * time.Second},
+		}
+		// Fail to load model first
+		s.newServerFn = func(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, model string, f *ggml.GGML, adapters []string, projectors []string, opts api.Options, numParallel int, _ llm.LlamaServerConfig) (llm.LlamaServer, error) {
+			return nil, errors.New("something failed to load model blah")
+		}
+		gpus := []ml.DeviceInfo{}
+		systemInfo := ml.SystemInfo{}
+		s.load(req, systemInfo, gpus, false)
+		require.Empty(t, req.successCh)
+		require.Len(t, req.errCh, 1)
+		requireLoadedCount(t, s, 0)
+		err := <-req.errCh
+		require.Contains(t, err.Error(), "this model may be incompatible")
 
-	server := &mockLlm{vramSize: 10, vramByGPU: map[ml.DeviceID]uint64{}}
-	s.newServerFn = func(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, model string, f *ggml.GGML, adapters []string, projectors []string, opts api.Options, numParallel int, _ llm.LlamaServerConfig) (llm.LlamaServer, error) {
-		server.modelPath = model
-		return server, nil
-	}
-	s.load(req, systemInfo, gpus, false)
-	select {
-	case err := <-req.errCh:
-		require.NoError(t, err)
-	case resp := <-req.successCh:
-		require.Equal(t, uint64(10), resp.vramSize)
-		require.Equal(t, uint(1), resp.refCount)
+		server := &mockLlm{vramSize: 10, vramByGPU: map[ml.DeviceID]uint64{}}
+		s.newServerFn = func(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, model string, f *ggml.GGML, adapters []string, projectors []string, opts api.Options, numParallel int, _ llm.LlamaServerConfig) (llm.LlamaServer, error) {
+			server.modelPath = model
+			return server, nil
+		}
+		s.load(req, systemInfo, gpus, false)
+		synctest.Wait()
+		select {
+		case err := <-req.errCh:
+			require.NoError(t, err)
+		case resp := <-req.successCh:
+			require.Equal(t, uint64(10), resp.vramSize)
+			require.Equal(t, uint(1), resp.refCount)
+		}
+		requireLoadedCount(t, s, 1)
+
+		modelPath2, _ := createBinFile(t, ggml.KV{
+			"general.architecture":          "llama",
+			"llama.context_length":          uint32(32),
+			"llama.embedding_length":        uint32(4096),
+			"llama.block_count":             uint32(1),
+			"llama.attention.head_count":    uint32(32),
+			"llama.attention.head_count_kv": uint32(32),
+			"tokenizer.ggml.tokens":         []string{" "},
+			"tokenizer.ggml.scores":         []float32{0},
+			"tokenizer.ggml.token_type":     []int32{0},
+		}, []*ggml.Tensor{
+			{Name: "blk.0.attn.weight", Kind: uint32(0), Offset: uint64(0), Shape: []uint64{1, 1, 1, 1}, WriterTo: bytes.NewReader(make([]byte, 32))},
+			{Name: "output.weight", Kind: uint32(0), Offset: uint64(0), Shape: []uint64{1, 1, 1, 1}, WriterTo: bytes.NewReader(make([]byte, 32))},
+		})
+
+		req.model.ModelPath = modelPath2
+		server.waitResp = errors.New("wait failure")
+		s.load(req, systemInfo, gpus, false)
+		synctest.Wait()
+		select {
+		case err := <-req.errCh:
+			require.Contains(t, err.Error(), "wait failure")
+		case resp := <-req.successCh:
+			t.Fatalf("unexpected success %v", resp)
+		}
 		s.loadedMu.Lock()
-		require.Len(t, s.loaded, 1)
+		runner := s.loaded[modelPath2]
 		s.loadedMu.Unlock()
-	}
-
-	modelPath2, _ := createBinFile(t, ggml.KV{
-		"general.architecture":          "llama",
-		"llama.context_length":          uint32(32),
-		"llama.embedding_length":        uint32(4096),
-		"llama.block_count":             uint32(1),
-		"llama.attention.head_count":    uint32(32),
-		"llama.attention.head_count_kv": uint32(32),
-		"tokenizer.ggml.tokens":         []string{" "},
-		"tokenizer.ggml.scores":         []float32{0},
-		"tokenizer.ggml.token_type":     []int32{0},
-	}, []*ggml.Tensor{
-		{Name: "blk.0.attn.weight", Kind: uint32(0), Offset: uint64(0), Shape: []uint64{1, 1, 1, 1}, WriterTo: bytes.NewReader(make([]byte, 32))},
-		{Name: "output.weight", Kind: uint32(0), Offset: uint64(0), Shape: []uint64{1, 1, 1, 1}, WriterTo: bytes.NewReader(make([]byte, 32))},
+		require.NotNil(t, runner)
+		require.Equal(t, uint(0), runner.refCount)
+		require.Len(t, s.expiredCh, 1)
 	})
-
-	req.model.ModelPath = modelPath2
-	server.waitResp = errors.New("wait failure")
-	s.load(req, systemInfo, gpus, false)
-	select {
-	case err := <-req.errCh:
-		require.Contains(t, err.Error(), "wait failure")
-	case resp := <-req.successCh:
-		t.Fatalf("unexpected success %v", resp)
-	}
-	s.loadedMu.Lock()
-	runner := s.loaded[modelPath2]
-	s.loadedMu.Unlock()
-	require.NotNil(t, runner)
-	require.Equal(t, uint(0), runner.refCount)
-	time.Sleep(1 * time.Millisecond)
-	require.Len(t, s.expiredCh, 1)
 }
 
 func TestSchedLoadStoresEffectiveContextLength(t *testing.T) {
@@ -319,249 +359,213 @@ func TestSchedRequestsSameModelSameRequest(t *testing.T) {
 }
 
 func TestSchedRequestsSimpleReloadSameModel(t *testing.T) {
-	ctx, done := context.WithTimeout(t.Context(), 5000*time.Millisecond)
-	defer done()
-	s := InitScheduler(ctx)
-	s.waitForRecovery = 10 * time.Millisecond
-	g := ml.DeviceInfo{DeviceID: ml.DeviceID{Library: "Metal"}}
-	g.TotalMemory = 24 * format.GigaByte
-	g.FreeMemory = 12 * format.GigaByte
-	gMu := sync.Mutex{}
-	s.getGpuFn = func(ctx context.Context, runners []ml.FilteredRunnerDiscovery) []ml.DeviceInfo {
-		slog.Info("test getGpuFn called", "runners", runners)
+	withSynctestScheduler(t, func(t *testing.T, ctx context.Context) {
+		s := InitScheduler(ctx)
+		s.waitForRecovery = 10 * time.Millisecond
+		g := ml.DeviceInfo{DeviceID: ml.DeviceID{Library: "Metal"}}
+		g.TotalMemory = 24 * format.GigaByte
+		g.FreeMemory = 12 * format.GigaByte
+		gMu := sync.Mutex{}
+		s.getGpuFn = func(ctx context.Context, runners []ml.FilteredRunnerDiscovery) []ml.DeviceInfo {
+			slog.Info("test getGpuFn called", "runners", runners)
+			gMu.Lock()
+			defer gMu.Unlock()
+			return []ml.DeviceInfo{g}
+		}
+		s.getSystemInfoFn = getSystemInfoFn
+		a := newScenarioRequest(t, ctx, "ollama-model-1", 10, &api.Duration{Duration: 5 * time.Millisecond}, nil)
+		b := newScenarioRequest(t, ctx, "ollama-model-1", 20, &api.Duration{Duration: 5 * time.Millisecond}, nil)
+		tmpModel := *a.req.model
+		b.req.model = &tmpModel
+
+		s.newServerFn = a.newServer
+		slog.Info("a")
+		s.pendingReqCh <- a.req
+		require.Len(t, s.pendingReqCh, 1)
+		s.Run(ctx)
+		synctest.Wait()
+		select {
+		case resp := <-a.req.successCh:
+			require.Equal(t, resp.llama, a.srv)
+			require.Empty(t, s.pendingReqCh)
+			require.Empty(t, a.req.errCh)
+		case err := <-a.req.errCh:
+			t.Fatal(err.Error())
+		}
+
+		// Trigger a reload
+		s.newServerFn = b.newServer
+		b.req.model.AdapterPaths = []string{"new"}
+		slog.Info("b")
+		s.pendingReqCh <- b.req
+		synctest.Wait()
+		s.loadedMu.Lock()
+		runner := s.loaded[schedulerModelKey(a.req.model)]
+		s.loadedMu.Unlock()
+		require.NotNil(t, runner)
+		runner.refMu.Lock()
+		require.True(t, runner.expireOnIdle)
+		require.Equal(t, time.Duration(0), runner.sessionDuration)
+		runner.refMu.Unlock()
+		a.ctxDone()
 		gMu.Lock()
-		defer gMu.Unlock()
-		return []ml.DeviceInfo{g}
-	}
-	s.getSystemInfoFn = getSystemInfoFn
-	a := newScenarioRequest(t, ctx, "ollama-model-1", 10, &api.Duration{Duration: 5 * time.Millisecond}, nil)
-	b := newScenarioRequest(t, ctx, "ollama-model-1", 20, &api.Duration{Duration: 5 * time.Millisecond}, nil)
-	tmpModel := *a.req.model
-	b.req.model = &tmpModel
-
-	s.newServerFn = a.newServer
-	slog.Info("a")
-	s.pendingReqCh <- a.req
-	require.Len(t, s.pendingReqCh, 1)
-	s.Run(ctx)
-	select {
-	case resp := <-a.req.successCh:
-		require.Equal(t, resp.llama, a.srv)
-		require.Empty(t, s.pendingReqCh)
-		require.Empty(t, a.req.errCh)
-	case err := <-a.req.errCh:
-		t.Fatal(err.Error())
-	case <-ctx.Done():
-		t.Fatal("timeout")
-	}
-
-	// Trigger a reload
-	s.newServerFn = b.newServer
-	b.req.model.AdapterPaths = []string{"new"}
-	slog.Info("b")
-	s.pendingReqCh <- b.req
-	// finish first two requests, so model can reload
-	time.Sleep(1 * time.Millisecond)
-	a.ctxDone()
-	// Report recovered VRAM usage
-	time.Sleep(1 * time.Millisecond)
-	gMu.Lock()
-	g.FreeMemory = 24 * format.GigaByte
-	gMu.Unlock()
-	select {
-	case resp := <-b.req.successCh:
-		require.Equal(t, resp.llama, b.srv)
-		require.Empty(t, s.pendingReqCh)
-		require.Empty(t, b.req.errCh)
-	case err := <-b.req.errCh:
-		t.Fatal(err.Error())
-	case <-ctx.Done():
-		t.Fatal("timeout")
-	}
+		g.FreeMemory = 24 * format.GigaByte
+		gMu.Unlock()
+		synctest.Wait()
+		select {
+		case resp := <-b.req.successCh:
+			require.Equal(t, resp.llama, b.srv)
+			require.Empty(t, s.pendingReqCh)
+			require.Empty(t, b.req.errCh)
+		case err := <-b.req.errCh:
+			t.Fatal(err.Error())
+		}
+	})
 }
 
 func TestSchedRequestsMultipleLoadedModels(t *testing.T) {
-	slog.Info("TestRequestsMultipleLoadedModels")
-	ctx, done := context.WithTimeout(t.Context(), 1000*time.Millisecond)
-	defer done()
-	s := InitScheduler(ctx)
-	s.waitForRecovery = 10 * time.Millisecond
-	g := ml.DeviceInfo{DeviceID: ml.DeviceID{Library: "Metal"}}
-	g.TotalMemory = 24 * format.GigaByte
-	g.FreeMemory = 12 * format.GigaByte
-	gMu := sync.Mutex{}
-	s.getGpuFn = func(ctx context.Context, runners []ml.FilteredRunnerDiscovery) []ml.DeviceInfo {
-		slog.Info("test getGpuFn called", "runners", runners)
+	withSynctestScheduler(t, func(t *testing.T, ctx context.Context) {
+		slog.Info("TestRequestsMultipleLoadedModels")
+		s := InitScheduler(ctx)
+		s.waitForRecovery = 10 * time.Millisecond
+		g := ml.DeviceInfo{DeviceID: ml.DeviceID{Library: "Metal"}}
+		g.TotalMemory = 24 * format.GigaByte
+		g.FreeMemory = 12 * format.GigaByte
+		gMu := sync.Mutex{}
+		s.getGpuFn = func(ctx context.Context, runners []ml.FilteredRunnerDiscovery) []ml.DeviceInfo {
+			slog.Info("test getGpuFn called", "runners", runners)
+			gMu.Lock()
+			defer gMu.Unlock()
+			return []ml.DeviceInfo{g}
+		}
+		s.getSystemInfoFn = getSystemInfoFn
+
+		// Multiple loaded models
+		a := newScenarioRequest(t, ctx, "model-a-1g-gpu", 1*format.GigaByte, nil, map[ml.DeviceID]uint64{{Library: "Metal"}: 1 * format.GigaByte})
+		a.req.sessionDuration = &api.Duration{Duration: 5 * time.Millisecond}
+		b := newScenarioRequest(t, ctx, "model-b-10g-gpu", 10*format.GigaByte, nil, map[ml.DeviceID]uint64{{Library: "Metal"}: 10 * format.GigaByte})
+		b.req.sessionDuration = &api.Duration{Duration: 5 * time.Millisecond}
+		c := newScenarioRequest(t, ctx, "model-c-10g-cpu", 10*format.GigaByte, nil, nil /* No GPU load */)
+		c.req.opts.NumGPU = 0                                                                                                                         // CPU load, will be allowed
+		b.req.sessionDuration = &api.Duration{Duration: 10 * time.Millisecond}                                                                        // longer than b to cause the scheduler to favor unloading b over c
+		d := newScenarioRequest(t, ctx, "model-d-10g-gpu", 13*format.GigaByte, nil, map[ml.DeviceID]uint64{{Library: "Metal"}: 13 * format.GigaByte}) // Needs prior unloaded
+
+		s.newServerFn = a.newServer
+		slog.Info("Loading A")
+		s.pendingReqCh <- a.req
+		s.Run(ctx)
+		synctest.Wait()
+		select {
+		case resp := <-a.req.successCh:
+			require.Equal(t, resp.llama, a.srv)
+			require.Empty(t, s.pendingReqCh)
+			require.Empty(t, a.req.errCh)
+		case err := <-a.req.errCh:
+			t.Fatal(err.Error())
+		}
+		requireLoadedCount(t, s, 1)
+
+		t.Setenv("OLLAMA_MAX_LOADED_MODELS", "0")
+		s.newServerFn = b.newServer
+		slog.Info("Loading B")
+		s.pendingReqCh <- b.req
+		synctest.Wait()
+		select {
+		case resp := <-b.req.successCh:
+			require.Equal(t, resp.llama, b.srv)
+			require.Empty(t, s.pendingReqCh)
+			require.Empty(t, b.req.errCh)
+		case err := <-b.req.errCh:
+			t.Fatal(err.Error())
+		}
+		requireLoadedCount(t, s, 2)
+
+		// This is a CPU load with NumGPU = 0 so it should load
+		s.newServerFn = c.newServer
+		slog.Info("Loading C")
+		s.pendingReqCh <- c.req
+		synctest.Wait()
+		select {
+		case resp := <-c.req.successCh:
+			require.Equal(t, resp.llama, c.srv)
+			require.Empty(t, s.pendingReqCh)
+			require.Empty(t, c.req.errCh)
+		case err := <-c.req.errCh:
+			t.Fatal(err.Error())
+		}
+		requireLoadedCount(t, s, 3)
+
+		// Try to load a model that won't fit
+		s.newServerFn = d.newServer
+		slog.Info("d")
+		requireLoadedCount(t, s, 3)
+		a.ctxDone() // Won't help since this one isn't big enough to make room
+		s.pendingReqCh <- d.req
+		synctest.Wait()
+		requireLoadedCount(t, s, 2)
+
+		// Mark b done so it can unload
+		b.ctxDone()
+		// Report recovered VRAM usage so scheduler will finish waiting and unload
 		gMu.Lock()
-		defer gMu.Unlock()
-		return []ml.DeviceInfo{g}
-	}
-	s.getSystemInfoFn = getSystemInfoFn
-
-	// Multiple loaded models
-	a := newScenarioRequest(t, ctx, "model-a-1g-gpu", 1*format.GigaByte, nil, map[ml.DeviceID]uint64{{Library: "Metal"}: 1 * format.GigaByte})
-	a.req.sessionDuration = &api.Duration{Duration: 5 * time.Millisecond}
-	b := newScenarioRequest(t, ctx, "model-b-10g-gpu", 10*format.GigaByte, nil, map[ml.DeviceID]uint64{{Library: "Metal"}: 10 * format.GigaByte})
-	b.req.sessionDuration = &api.Duration{Duration: 5 * time.Millisecond}
-	c := newScenarioRequest(t, ctx, "model-c-10g-cpu", 10*format.GigaByte, nil, nil /* No GPU load */)
-	c.req.opts.NumGPU = 0                                                                                                                         // CPU load, will be allowed
-	b.req.sessionDuration = &api.Duration{Duration: 10 * time.Millisecond}                                                                        // longer than b to cause the scheduler to favor unloading b over c
-	d := newScenarioRequest(t, ctx, "model-d-10g-gpu", 13*format.GigaByte, nil, map[ml.DeviceID]uint64{{Library: "Metal"}: 13 * format.GigaByte}) // Needs prior unloaded
-
-	s.newServerFn = a.newServer
-	slog.Info("Loading A")
-	s.pendingReqCh <- a.req
-	s.Run(ctx)
-	select {
-	case resp := <-a.req.successCh:
-		require.Equal(t, resp.llama, a.srv)
-		require.Empty(t, s.pendingReqCh)
-		require.Empty(t, a.req.errCh)
-	case err := <-a.req.errCh:
-		t.Fatal(err.Error())
-	case <-ctx.Done():
-		t.Fatal("timeout")
-	}
-	s.loadedMu.Lock()
-	require.Len(t, s.loaded, 1)
-	s.loadedMu.Unlock()
-
-	t.Setenv("OLLAMA_MAX_LOADED_MODELS", "0")
-	s.newServerFn = b.newServer
-	slog.Info("Loading B")
-	s.pendingReqCh <- b.req
-	select {
-	case resp := <-b.req.successCh:
-		require.Equal(t, resp.llama, b.srv)
-		require.Empty(t, s.pendingReqCh)
-		require.Empty(t, b.req.errCh)
-	case err := <-b.req.errCh:
-		t.Fatal(err.Error())
-	case <-ctx.Done():
-		t.Fatal("timeout")
-	}
-	s.loadedMu.Lock()
-	require.Len(t, s.loaded, 2)
-	s.loadedMu.Unlock()
-
-	// This is a CPU load with NumGPU = 0 so it should load
-	s.newServerFn = c.newServer
-	slog.Info("Loading C")
-	s.pendingReqCh <- c.req
-	select {
-	case resp := <-c.req.successCh:
-		require.Equal(t, resp.llama, c.srv)
-		require.Empty(t, s.pendingReqCh)
-		require.Empty(t, c.req.errCh)
-	case err := <-c.req.errCh:
-		t.Fatal(err.Error())
-	case <-ctx.Done():
-		slog.Info("FAIL: scheduler state", "s.loaded", s.loaded)
-		t.Fatal("timeout")
-	}
-	s.loadedMu.Lock()
-	require.Len(t, s.loaded, 3)
-	s.loadedMu.Unlock()
-
-	// Try to load a model that won't fit
-	s.newServerFn = d.newServer
-	slog.Info("d")
-	s.loadedMu.Lock()
-	require.Len(t, s.loaded, 3)
-	s.loadedMu.Unlock()
-	a.ctxDone() // Won't help since this one isn't big enough to make room
-	time.Sleep(2 * time.Millisecond)
-	s.pendingReqCh <- d.req
-	// finish prior request, so new model can load
-	time.Sleep(6 * time.Millisecond)
-	s.loadedMu.Lock()
-	require.Len(t, s.loaded, 2)
-	s.loadedMu.Unlock()
-	// Mark b done so it can unload
-	b.ctxDone()
-	// Report recovered VRAM usage so scheduler will finish waiting and unload
-	time.Sleep(1 * time.Millisecond)
-	gMu.Lock()
-	g.FreeMemory = 24 * format.GigaByte
-	gMu.Unlock()
-	select {
-	case resp := <-d.req.successCh:
+		g.FreeMemory = 24 * format.GigaByte
+		gMu.Unlock()
+		synctest.Wait()
+		resp := <-d.req.successCh
 		require.Equal(t, resp.llama, d.srv)
 		require.Empty(t, s.pendingReqCh)
 		require.Empty(t, d.req.errCh)
-	case <-ctx.Done():
-		t.Fatal("timeout")
-	}
-	// Wait for b to close
-closeWait:
-	for {
-		select {
-		case <-ctx.Done():
-			t.Fatal("timeout")
-		default:
-			if b.srv.closeCalled {
-				break closeWait
-			}
-			time.Sleep(1 * time.Millisecond)
-		}
-	}
-	s.loadedMu.Lock()
-	require.Len(t, s.loaded, 2)
-	s.loadedMu.Unlock()
+		require.True(t, b.srv.closeCalled)
+		requireLoadedCount(t, s, 2)
+	})
 }
 
 func TestSchedGetRunner(t *testing.T) {
-	ctx, done := context.WithTimeout(t.Context(), 3*time.Second)
-	defer done()
+	withSynctestScheduler(t, func(t *testing.T, ctx context.Context) {
+		a := newScenarioRequest(t, ctx, "ollama-model-1a", 10, &api.Duration{Duration: 2 * time.Millisecond}, nil)
+		b := newScenarioRequest(t, ctx, "ollama-model-1b", 10, &api.Duration{Duration: 2 * time.Millisecond}, nil)
+		c := newScenarioRequest(t, ctx, "ollama-model-1c", 10, &api.Duration{Duration: 2 * time.Millisecond}, nil)
+		t.Setenv("OLLAMA_MAX_QUEUE", "1")
+		s := InitScheduler(ctx)
+		s.waitForRecovery = 10 * time.Millisecond
+		s.getGpuFn = getGpuFn
+		s.getSystemInfoFn = getSystemInfoFn
+		s.newServerFn = a.newServer
+		slog.Info("a")
+		successCh1a, errCh1a := s.getRunner(a.ctx, a.req.model, a.req.opts, a.req.sessionDuration, false, false, nil)
+		require.Len(t, s.pendingReqCh, 1)
+		slog.Info("b")
+		successCh1b, errCh1b := s.getRunner(b.ctx, b.req.model, b.req.opts, b.req.sessionDuration, false, false, nil)
+		require.Len(t, s.pendingReqCh, 1)
+		require.Empty(t, successCh1b)
+		require.Len(t, errCh1b, 1)
+		err := <-errCh1b
+		require.Contains(t, err.Error(), "server busy")
+		s.Run(ctx)
+		synctest.Wait()
+		select {
+		case resp := <-successCh1a:
+			require.Equal(t, resp.llama, a.srv)
+			require.Empty(t, s.pendingReqCh)
+			require.Empty(t, errCh1a)
+		case err := <-errCh1a:
+			t.Fatal(err.Error())
+		}
+		a.ctxDone() // Set "a" model to idle so it can unload
+		requireLoadedCount(t, s, 1)
 
-	a := newScenarioRequest(t, ctx, "ollama-model-1a", 10, &api.Duration{Duration: 2 * time.Millisecond}, nil)
-	b := newScenarioRequest(t, ctx, "ollama-model-1b", 10, &api.Duration{Duration: 2 * time.Millisecond}, nil)
-	c := newScenarioRequest(t, ctx, "ollama-model-1c", 10, &api.Duration{Duration: 2 * time.Millisecond}, nil)
-	t.Setenv("OLLAMA_MAX_QUEUE", "1")
-	s := InitScheduler(ctx)
-	s.waitForRecovery = 10 * time.Millisecond
-	s.getGpuFn = getGpuFn
-	s.getSystemInfoFn = getSystemInfoFn
-	s.newServerFn = a.newServer
-	slog.Info("a")
-	successCh1a, errCh1a := s.getRunner(a.ctx, a.req.model, a.req.opts, a.req.sessionDuration, false, false, nil)
-	require.Len(t, s.pendingReqCh, 1)
-	slog.Info("b")
-	successCh1b, errCh1b := s.getRunner(b.ctx, b.req.model, b.req.opts, b.req.sessionDuration, false, false, nil)
-	require.Len(t, s.pendingReqCh, 1)
-	require.Empty(t, successCh1b)
-	require.Len(t, errCh1b, 1)
-	err := <-errCh1b
-	require.Contains(t, err.Error(), "server busy")
-	s.Run(ctx)
-	select {
-	case resp := <-successCh1a:
-		require.Equal(t, resp.llama, a.srv)
-		require.Empty(t, s.pendingReqCh)
-		require.Empty(t, errCh1a)
-	case err := <-errCh1a:
-		t.Fatal(err.Error())
-	case <-ctx.Done():
-		t.Fatal("timeout")
-	}
-	a.ctxDone() // Set "a" model to idle so it can unload
-	s.loadedMu.Lock()
-	require.Len(t, s.loaded, 1)
-	s.loadedMu.Unlock()
-
-	c.req.model.ModelPath = "bad path"
-	slog.Info("c")
-	successCh1c, errCh1c := s.getRunner(c.ctx, c.req.model, c.req.opts, c.req.sessionDuration, false, false, nil)
-	// Starts in pending channel, then should be quickly processed to return an error
-	time.Sleep(50 * time.Millisecond) // Long enough for the "a" model to expire and unload
-	require.Empty(t, successCh1c)
-	s.loadedMu.Lock()
-	require.Empty(t, s.loaded)
-	s.loadedMu.Unlock()
-	require.Len(t, errCh1c, 1)
-	err = <-errCh1c
-	require.Contains(t, err.Error(), "bad path")
-	b.ctxDone()
+		c.req.model.ModelPath = "bad path"
+		slog.Info("c")
+		successCh1c, errCh1c := s.getRunner(c.ctx, c.req.model, c.req.opts, c.req.sessionDuration, false, false, nil)
+		synctest.Wait()
+		require.Empty(t, successCh1c)
+		time.Sleep(a.req.sessionDuration.Duration)
+		synctest.Wait()
+		requireLoadedCount(t, s, 0)
+		err = <-errCh1c
+		require.Contains(t, err.Error(), "bad path")
+		b.ctxDone()
+	})
 }
 
 func TestSchedGetRunnerUsesDigestKeyWhenModelPathEmpty(t *testing.T) {
@@ -630,132 +634,121 @@ func TestSchedGetRunnerReusesSameDigestWhenModelPathEmpty(t *testing.T) {
 }
 
 func TestSchedExpireRunner(t *testing.T) {
-	ctx, done := context.WithCancel(t.Context())
-	defer done()
-	s := InitScheduler(ctx)
-	s.waitForRecovery = 10 * time.Millisecond
+	withSynctestScheduler(t, func(t *testing.T, ctx context.Context) {
+		schedCtx, done := context.WithCancel(ctx)
+		s := InitScheduler(schedCtx)
+		s.waitForRecovery = 10 * time.Millisecond
 
-	modelPath, _ := createBinFile(t, ggml.KV{
-		"general.architecture":          "llama",
-		"llama.context_length":          uint32(32),
-		"llama.embedding_length":        uint32(4096),
-		"llama.block_count":             uint32(1),
-		"llama.attention.head_count":    uint32(32),
-		"llama.attention.head_count_kv": uint32(32),
-		"tokenizer.ggml.tokens":         []string{" "},
-		"tokenizer.ggml.scores":         []float32{0},
-		"tokenizer.ggml.token_type":     []int32{0},
-	}, []*ggml.Tensor{
-		{Name: "blk.0.attn.weight", Kind: uint32(0), Offset: uint64(0), Shape: []uint64{1, 1, 1, 1}, WriterTo: bytes.NewReader(make([]byte, 32))},
-		{Name: "output.weight", Kind: uint32(0), Offset: uint64(0), Shape: []uint64{1, 1, 1, 1}, WriterTo: bytes.NewReader(make([]byte, 32))},
+		modelPath, _ := createBinFile(t, ggml.KV{
+			"general.architecture":          "llama",
+			"llama.context_length":          uint32(32),
+			"llama.embedding_length":        uint32(4096),
+			"llama.block_count":             uint32(1),
+			"llama.attention.head_count":    uint32(32),
+			"llama.attention.head_count_kv": uint32(32),
+			"tokenizer.ggml.tokens":         []string{" "},
+			"tokenizer.ggml.scores":         []float32{0},
+			"tokenizer.ggml.token_type":     []int32{0},
+		}, []*ggml.Tensor{
+			{Name: "blk.0.attn.weight", Kind: uint32(0), Offset: uint64(0), Shape: []uint64{1, 1, 1, 1}, WriterTo: bytes.NewReader(make([]byte, 32))},
+			{Name: "output.weight", Kind: uint32(0), Offset: uint64(0), Shape: []uint64{1, 1, 1, 1}, WriterTo: bytes.NewReader(make([]byte, 32))},
+		})
+
+		reqCtx, cancelReq := context.WithCancel(schedCtx)
+		defer cancelReq()
+
+		req := &LlmRequest{
+			ctx:             reqCtx,
+			model:           &Model{ModelPath: modelPath},
+			opts:            api.DefaultOptions(),
+			successCh:       make(chan *runnerRef, 1),
+			errCh:           make(chan error, 1),
+			sessionDuration: &api.Duration{Duration: 2 * time.Minute},
+		}
+
+		gpus := []ml.DeviceInfo{}
+		systemInfo := ml.SystemInfo{}
+		server := &mockLlm{vramSize: 10, vramByGPU: map[ml.DeviceID]uint64{}}
+		s.newServerFn = func(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, model string, f *ggml.GGML, adapters []string, projectors []string, opts api.Options, numParallel int, _ llm.LlamaServerConfig) (llm.LlamaServer, error) {
+			server.modelPath = model
+			return server, nil
+		}
+		s.load(req, systemInfo, gpus, false)
+		synctest.Wait()
+
+		select {
+		case err := <-req.errCh:
+			if err != nil {
+				t.Fatalf("expected no errors when loading, got '%s'", err.Error())
+			}
+		case resp := <-req.successCh:
+			require.Equal(t, uint(1), resp.refCount)
+			requireLoadedCount(t, s, 1)
+		}
+
+		completedDone := make(chan struct{})
+		go func() {
+			defer close(completedDone)
+			s.processCompleted(schedCtx)
+		}()
+
+		s.expireRunner(&Model{ModelPath: modelPath})
+		cancelReq()
+		synctest.Wait()
+		require.Len(t, s.unloadedCh, 1)
+		<-s.unloadedCh
+		requireLoadedCount(t, s, 0)
+
+		done()
+		synctest.Wait()
+		select {
+		case <-completedDone:
+		default:
+			t.Fatal("expected completed loop to stop")
+		}
 	})
-
-	reqCtx, cancelReq := context.WithCancel(ctx)
-	defer cancelReq()
-
-	req := &LlmRequest{
-		ctx:             reqCtx,
-		model:           &Model{ModelPath: modelPath},
-		opts:            api.DefaultOptions(),
-		successCh:       make(chan *runnerRef, 1),
-		errCh:           make(chan error, 1),
-		sessionDuration: &api.Duration{Duration: 2 * time.Minute},
-	}
-
-	gpus := []ml.DeviceInfo{}
-	systemInfo := ml.SystemInfo{}
-	server := &mockLlm{vramSize: 10, vramByGPU: map[ml.DeviceID]uint64{}}
-	s.newServerFn = func(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, model string, f *ggml.GGML, adapters []string, projectors []string, opts api.Options, numParallel int, _ llm.LlamaServerConfig) (llm.LlamaServer, error) {
-		server.modelPath = model
-		return server, nil
-	}
-	s.load(req, systemInfo, gpus, false)
-
-	select {
-	case err := <-req.errCh:
-		if err != nil {
-			t.Fatalf("expected no errors when loading, got '%s'", err.Error())
-		}
-	case resp := <-req.successCh:
-		s.loadedMu.Lock()
-		if resp.refCount != uint(1) || len(s.loaded) != 1 {
-			t.Fatalf("expected a model to be loaded")
-		}
-		s.loadedMu.Unlock()
-	}
-
-	completedDone := make(chan struct{})
-	go func() {
-		defer close(completedDone)
-		s.processCompleted(ctx)
-	}()
-
-	s.expireRunner(&Model{ModelPath: modelPath})
-	cancelReq()
-
-	select {
-	case <-s.unloadedCh:
-	case <-time.After(5 * time.Second):
-		t.Fatal("expected model to be unloaded")
-	}
-
-	s.loadedMu.Lock()
-	if len(s.loaded) != 0 {
-		t.Fatalf("expected model to be unloaded")
-	}
-	s.loadedMu.Unlock()
-
-	done()
-	select {
-	case <-completedDone:
-	case <-time.After(5 * time.Second):
-		t.Fatal("expected completed loop to stop")
-	}
 }
 
 // TODO - add one scenario that triggers the bogus finished event with positive ref count
 func TestSchedPrematureExpired(t *testing.T) {
-	ctx, done := context.WithTimeout(t.Context(), 1000*time.Millisecond)
-	defer done()
+	withSynctestScheduler(t, func(t *testing.T, ctx context.Context) {
+		// Same model, same request
+		scenario1a := newScenarioRequest(t, ctx, "ollama-model-1a", 10, &api.Duration{Duration: 100 * time.Millisecond}, nil)
+		s := InitScheduler(ctx)
+		s.waitForRecovery = 10 * time.Millisecond
+		s.getGpuFn = getGpuFn
+		s.getSystemInfoFn = getSystemInfoFn
+		s.newServerFn = scenario1a.newServer
+		successCh1a, errCh1a := s.getRunner(scenario1a.ctx, scenario1a.req.model, scenario1a.req.opts, scenario1a.req.sessionDuration, false, false, nil)
+		require.Len(t, s.pendingReqCh, 1)
+		s.Run(ctx)
+		synctest.Wait()
+		var resp *runnerRef
+		select {
+		case resp = <-successCh1a:
+			require.Equal(t, resp.llama, scenario1a.srv)
+			require.Empty(t, s.pendingReqCh)
+			require.Empty(t, errCh1a)
+			requireLoadedCount(t, s, 1)
+			slog.Info("sending premature expired event now")
+			s.expiredCh <- resp // Shouldn't happen in real life, but make sure its safe
+		case err := <-errCh1a:
+			t.Fatal(err.Error())
+		}
+		synctest.Wait()
+		resp.refMu.Lock()
+		require.True(t, resp.expireOnIdle)
+		resp.refMu.Unlock()
+		scenario1a.ctxDone()
+		synctest.Wait()
+		requireLoadedCount(t, s, 0)
 
-	// Same model, same request
-	scenario1a := newScenarioRequest(t, ctx, "ollama-model-1a", 10, &api.Duration{Duration: 100 * time.Millisecond}, nil)
-	s := InitScheduler(ctx)
-	s.waitForRecovery = 10 * time.Millisecond
-	s.getGpuFn = getGpuFn
-	s.getSystemInfoFn = getSystemInfoFn
-	s.newServerFn = scenario1a.newServer
-	successCh1a, errCh1a := s.getRunner(scenario1a.ctx, scenario1a.req.model, scenario1a.req.opts, scenario1a.req.sessionDuration, false, false, nil)
-	require.Len(t, s.pendingReqCh, 1)
-	s.Run(ctx)
-	select {
-	case resp := <-successCh1a:
-		require.Equal(t, resp.llama, scenario1a.srv)
-		require.Empty(t, s.pendingReqCh)
-		require.Empty(t, errCh1a)
-		s.loadedMu.Lock()
-		require.Len(t, s.loaded, 1)
-		s.loadedMu.Unlock()
-		slog.Info("sending premature expired event now")
-		s.expiredCh <- resp // Shouldn't happen in real life, but make sure its safe
-	case err := <-errCh1a:
-		t.Fatal(err.Error())
-	case <-ctx.Done():
-		t.Fatal("timeout")
-	}
-	time.Sleep(scenario1a.req.sessionDuration.Duration)
-	scenario1a.ctxDone()
-	time.Sleep(20 * time.Millisecond)
-	require.LessOrEqual(t, len(s.finishedReqCh), 1)
-	time.Sleep(10 * time.Millisecond)
-	require.Empty(t, s.finishedReqCh)
-	s.loadedMu.Lock()
-	require.Empty(t, s.loaded)
-	s.loadedMu.Unlock()
-
-	// also shouldn't happen in real life
-	s.finishedReqCh <- scenario1a.req
-	time.Sleep(5 * time.Millisecond)
+		// also shouldn't happen in real life; wait until the scheduler has safely
+		// consumed the bogus event
+		s.finishedReqCh <- scenario1a.req
+		synctest.Wait()
+		require.Empty(t, s.finishedReqCh)
+	})
 }
 
 func TestSchedUseLoadedRunner(t *testing.T) {
@@ -769,7 +762,7 @@ func TestSchedUseLoadedRunner(t *testing.T) {
 	finished := make(chan *LlmRequest)
 	llm1 := &mockLlm{vramByGPU: map[ml.DeviceID]uint64{}}
 	r1 := &runnerRef{llama: llm1, sessionDuration: 1, numParallel: 1}
-	req.useLoadedRunner(r1, finished)
+	req.tryUseLoadedRunner(r1, finished)
 	require.Equal(t, uint(1), r1.refCount)
 	require.Equal(t, time.Duration(2), r1.sessionDuration)
 	select {
@@ -783,6 +776,32 @@ func TestSchedUseLoadedRunner(t *testing.T) {
 	done()
 	fin := <-finished
 	require.Equal(t, req, fin)
+}
+
+func TestSchedUseLoadedRunnerCanceledDoesNotIncrementRefCount(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	req := &LlmRequest{
+		ctx:             ctx,
+		opts:            api.DefaultOptions(),
+		successCh:       make(chan *runnerRef, 1),
+		errCh:           make(chan error, 1),
+		sessionDuration: &api.Duration{Duration: 2},
+	}
+	finished := make(chan *LlmRequest)
+	runner := &runnerRef{llama: &mockLlm{vramByGPU: map[ml.DeviceID]uint64{}}, sessionDuration: 1, numParallel: 1}
+
+	require.True(t, req.tryUseLoadedRunner(runner, finished))
+	require.Equal(t, uint(0), runner.refCount)
+	require.Equal(t, time.Duration(1), runner.sessionDuration)
+	require.Empty(t, req.successCh)
+	select {
+	case err := <-req.errCh:
+		require.ErrorIs(t, err, context.Canceled)
+	default:
+		t.Fatal("expected canceled request error")
+	}
 }
 
 func TestSchedUpdateFreeSpace(t *testing.T) {
@@ -827,6 +846,37 @@ func TestSchedUpdateFreeSpace(t *testing.T) {
 	s.updateFreeSpace(gpus)
 	require.Equal(t, uint64(1000-50-125), gpus[0].FreeMemory)
 	require.Equal(t, uint64(2000-50-75), gpus[1].FreeMemory)
+}
+
+func TestSchedUpdateFreeSpaceDoesNotHoldRunnerLockDuringVRAMRefresh(t *testing.T) {
+	ctx, done := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer done()
+
+	gpuID := ml.DeviceID{ID: "1", Library: "CUDA"}
+	gpus := []ml.DeviceInfo{{
+		DeviceID:    gpuID,
+		TotalMemory: 1000,
+		FreeMemory:  900,
+	}}
+
+	var runner *runnerRef
+	llm := &mockLlm{
+		vramByGPUFn: func(id ml.DeviceID) uint64 {
+			require.True(t, runner.refMu.TryLock(), "VRAMByGPU called while runner.refMu was held")
+			runner.refMu.Unlock()
+			require.Equal(t, gpuID, id)
+			return 125
+		},
+	}
+	runner = &runnerRef{llama: llm, gpus: []ml.DeviceID{gpuID}, numParallel: 1}
+
+	s := InitScheduler(ctx)
+	s.loadedMu.Lock()
+	s.loaded["a"] = runner
+	s.loadedMu.Unlock()
+
+	s.updateFreeSpace(gpus)
+	require.Equal(t, uint64(1000-125), gpus[0].FreeMemory)
 }
 
 func TestSchedFindRunnerToUnload(t *testing.T) {
@@ -1088,45 +1138,45 @@ func TestAutomaticGenerationBatch(t *testing.T) {
 			name:         "small context keeps default",
 			effectiveCtx: 4096,
 			flash:        ml.FlashAttentionAuto,
-			want:         512,
+			want:         llamaServerGenerationBatchDefault,
 		},
 		{
-			name:         "medium context uses 1024 with unknown memory",
+			name:         "medium context uses medium batch with unknown memory",
 			effectiveCtx: 32768,
 			flash:        ml.FlashAttentionAuto,
-			want:         1024,
+			want:         llamaServerGenerationBatchMedium,
 		},
 		{
-			name:         "large context uses 2048 with headroom",
+			name:         "large context uses large batch with headroom",
 			effectiveCtx: 131072,
 			predicted:    8 * format.GibiByte,
 			available:    14 * format.GibiByte,
 			flash:        ml.FlashAttentionAuto,
-			want:         2048,
+			want:         llamaServerGenerationBatchLarge,
 		},
 		{
-			name:         "large context steps down to 1024 without 2048 headroom",
+			name:         "large context steps down to medium batch without large batch headroom",
 			effectiveCtx: 131072,
 			predicted:    9 * format.GibiByte,
 			available:    14 * format.GibiByte,
 			flash:        ml.FlashAttentionAuto,
-			want:         1024,
+			want:         llamaServerGenerationBatchMedium,
 		},
 		{
-			name:         "large context steps down to 1024 for headroom",
+			name:         "large context steps down to medium batch for headroom",
 			effectiveCtx: 131072,
 			predicted:    8 * format.GibiByte,
 			available:    11 * format.GibiByte,
 			flash:        ml.FlashAttentionAuto,
-			want:         1024,
+			want:         llamaServerGenerationBatchMedium,
 		},
 		{
-			name:         "medium context steps down to 512 for headroom",
+			name:         "medium context steps down to default batch for headroom",
 			effectiveCtx: 32768,
 			predicted:    8500 * format.MebiByte,
 			available:    11 * format.GibiByte,
 			flash:        ml.FlashAttentionAuto,
-			want:         512,
+			want:         llamaServerGenerationBatchDefault,
 		},
 		{
 			name:         "flash attention disabled suppresses promotion",
@@ -1135,7 +1185,7 @@ func TestAutomaticGenerationBatch(t *testing.T) {
 			available:    14 * format.GibiByte,
 			flash:        ml.FlashAttentionDisabled,
 			gpus:         []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}, FreeMemory: 14 * format.GibiByte}},
-			want:         512,
+			want:         llamaServerGenerationBatchDefault,
 		},
 		{
 			name:         "constrained CUDA without flash attention uses smaller batch",
@@ -1144,7 +1194,7 @@ func TestAutomaticGenerationBatch(t *testing.T) {
 			available:    6 * format.GibiByte,
 			flash:        ml.FlashAttentionDisabled,
 			gpus:         []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}, FreeMemory: 6 * format.GibiByte}},
-			want:         256,
+			want:         llamaServerGenerationBatchConstrained,
 		},
 	}
 
@@ -1188,22 +1238,228 @@ func TestSchedUnload(t *testing.T) {
 	require.Nil(t, r2.model)
 }
 
-func TestSchedAlreadyCanceled(t *testing.T) {
-	ctx, done := context.WithTimeout(t.Context(), 500*time.Millisecond)
+func TestRunnerRefDiscoveryAccessorsUseSnapshots(t *testing.T) {
+	gpuID := ml.DeviceID{ID: "0", Library: "CUDA"}
+	opts := api.DefaultOptions()
+	opts.NumCtx = 2048
+	runner := &runnerRef{
+		llama:     &mockLlm{port: 12345, deviceInfos: []ml.DeviceInfo{{DeviceID: gpuID}}},
+		model:     &Model{Name: "test"},
+		modelPath: "test",
+		modelKey:  "test",
+		gpus:      []ml.DeviceID{gpuID},
+		totalSize: 1,
+		vramSize:  1,
+		Options:   &opts,
+	}
+
+	require.Equal(t, 12345, runner.GetPort())
+	require.False(t, runner.HasExited())
+	require.Equal(t, []ml.DeviceInfo{{DeviceID: gpuID}}, runner.GetDeviceInfos(t.Context()))
+
+	gpus := runner.GetActiveDeviceIDs()
+	require.Equal(t, []ml.DeviceID{gpuID}, gpus)
+	gpus[0].ID = "changed"
+	runner.refMu.Lock()
+	require.Equal(t, gpuID, runner.gpus[0])
+	_ = runner.LogValue()
+	runner.refMu.Unlock()
+
+	runner.unload()
+	require.Equal(t, -1, runner.GetPort())
+	require.True(t, runner.HasExited())
+	require.Nil(t, runner.GetDeviceInfos(t.Context()))
+	require.Empty(t, runner.GetActiveDeviceIDs())
+}
+
+func TestSchedLoadedModelsDoesNotBlockDuringVRAMRecovery(t *testing.T) {
+	withSynctestScheduler(t, func(t *testing.T, ctx context.Context) {
+		s := InitScheduler(ctx)
+		s.waitForRecovery = 10 * time.Millisecond
+
+		gpuQueryEntered := make(chan struct{})
+		releaseGPUQuery := make(chan struct{})
+		var enterOnce sync.Once
+		s.getGpuFn = func(ctx context.Context, runners []ml.FilteredRunnerDiscovery) []ml.DeviceInfo {
+			enterOnce.Do(func() {
+				close(gpuQueryEntered)
+				select {
+				case <-releaseGPUQuery:
+				case <-ctx.Done():
+				}
+			})
+			gpu := ml.DeviceInfo{DeviceID: ml.DeviceID{ID: "0", Library: "CUDA"}}
+			gpu.TotalMemory = 24 * format.GigaByte
+			gpu.FreeMemory = 12 * format.GigaByte
+			return []ml.DeviceInfo{gpu}
+		}
+
+		model := &Model{ModelPath: "resident"}
+		runner := &runnerRef{
+			llama:           &mockLlm{vramByGPU: map[ml.DeviceID]uint64{}},
+			model:           model,
+			modelPath:       model.ModelPath,
+			modelKey:        schedulerModelKey(model),
+			pid:             1,
+			gpus:            []ml.DeviceID{{ID: "0", Library: "CUDA"}},
+			usesDiscreteGPU: true,
+			vramSize:        1 * format.GigaByte,
+		}
+		s.loadedMu.Lock()
+		s.loaded[runner.modelKey] = runner
+		s.loadedMu.Unlock()
+
+		go s.processCompleted(ctx)
+		s.expiredCh <- runner
+		synctest.Wait()
+		select {
+		case <-gpuQueryEntered:
+		default:
+			t.Fatal("expected VRAM recovery to start GPU discovery")
+		}
+
+		loadedModelsDone := make(chan []loadedModel, 1)
+		go func() {
+			loadedModelsDone <- s.loadedModels()
+		}()
+		synctest.Wait()
+		select {
+		case models := <-loadedModelsDone:
+			require.Empty(t, models)
+		default:
+			t.Fatal("loadedModels blocked behind VRAM recovery")
+		}
+
+		close(releaseGPUQuery)
+		synctest.Wait()
+		time.Sleep(s.waitForRecovery)
+		synctest.Wait()
+		require.Len(t, s.unloadedCh, 1)
+		<-s.unloadedCh
+	})
+}
+
+func TestSchedLoadedModelsDoesNotHoldRunnerLockDuringMemoryRefresh(t *testing.T) {
+	ctx, done := context.WithTimeout(t.Context(), 100*time.Millisecond)
 	defer done()
-	dctx, done2 := context.WithCancel(ctx)
-	done2()
-	scenario1a := newScenarioRequest(t, dctx, "ollama-model-1", 10, &api.Duration{Duration: 0}, nil)
+
+	model := &Model{Name: "test", ModelPath: "/fake/model"}
+	var runner *runnerRef
+	llm := &mockLlm{
+		contextLength: 2048,
+		memorySizeFn: func() (uint64, uint64) {
+			require.True(t, runner.refMu.TryLock(), "MemorySize called while runner.refMu was held")
+			runner.refMu.Unlock()
+			return 10 * format.GigaByte, 8 * format.GigaByte
+		},
+	}
+	runner = &runnerRef{
+		model:           model,
+		modelPath:       model.ModelPath,
+		modelKey:        schedulerModelKey(model),
+		llama:           llm,
+		sessionDuration: time.Minute,
+		totalSize:       1,
+		vramSize:        1,
+	}
+
 	s := InitScheduler(ctx)
-	s.waitForRecovery = 10 * time.Millisecond
-	slog.Info("scenario1a")
-	s.pendingReqCh <- scenario1a.req
-	require.Len(t, s.pendingReqCh, 1)
-	s.Run(ctx)
-	time.Sleep(5 * time.Millisecond)
+	s.loadedMu.Lock()
+	s.loaded[runner.modelKey] = runner
+	s.loadedMu.Unlock()
+
+	models := s.loadedModels()
+	require.Len(t, models, 1)
+	require.Equal(t, int64(10*format.GigaByte), models[0].size)
+	require.Equal(t, int64(8*format.GigaByte), models[0].sizeVRAM)
+	require.Equal(t, 2048, models[0].contextLength)
+}
+
+func TestSchedAlreadyCanceled(t *testing.T) {
+	withSynctestScheduler(t, func(t *testing.T, ctx context.Context) {
+		dctx, done2 := context.WithCancel(ctx)
+		done2()
+		scenario1a := newScenarioRequest(t, dctx, "ollama-model-1", 10, &api.Duration{Duration: 0}, nil)
+		s := InitScheduler(ctx)
+		s.waitForRecovery = 10 * time.Millisecond
+		slog.Info("scenario1a")
+		s.pendingReqCh <- scenario1a.req
+		require.Len(t, s.pendingReqCh, 1)
+		s.Run(ctx)
+		synctest.Wait()
+		require.Empty(t, s.pendingReqCh)
+		select {
+		case err := <-scenario1a.req.errCh:
+			require.ErrorIs(t, err, context.Canceled)
+		default:
+			t.Fatal("expected canceled request error")
+		}
+		require.Empty(t, scenario1a.req.successCh)
+	})
+}
+
+func TestSchedCanceledRequestDoesNotEnterPendingQueue(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	s := InitScheduler(t.Context())
+	_, errCh := s.getRunner(ctx, &Model{Name: "canceled"}, api.DefaultOptions(), nil, false, false, nil)
+
+	select {
+	case err := <-errCh:
+		require.ErrorIs(t, err, context.Canceled)
+	default:
+		t.Fatal("expected canceled request error")
+	}
 	require.Empty(t, s.pendingReqCh)
-	require.Empty(t, scenario1a.req.errCh)
-	require.Empty(t, scenario1a.req.successCh)
+}
+
+func TestSchedPendingCanceledDuringUnloadWaitDoesNotRetry(t *testing.T) {
+	withSynctestScheduler(t, func(t *testing.T, ctx context.Context) {
+		s := InitScheduler(ctx)
+		s.waitForRecovery = 10 * time.Millisecond
+		s.getGpuFn = getGpuFn
+		s.getSystemInfoFn = getSystemInfoFn
+
+		resident := &runnerRef{
+			llama:     &mockLlm{vramByGPU: map[ml.DeviceID]uint64{}},
+			modelPath: "resident",
+			modelKey:  "resident",
+		}
+		s.loadedMu.Lock()
+		s.loaded[resident.modelKey] = resident
+		s.loadedMu.Unlock()
+
+		var loadCalls atomic.Int32
+		s.loadFn = func(req *LlmRequest, systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, requireFull bool) bool {
+			loadCalls.Add(1)
+			return true
+		}
+
+		pending := newScenarioRequest(t, ctx, "pending", 1, nil, nil)
+		go s.processPending(ctx)
+		s.pendingReqCh <- pending.req
+		synctest.Wait()
+
+		select {
+		case runner := <-s.expiredCh:
+			require.Equal(t, resident, runner)
+		default:
+			t.Fatal("expected resident runner to be marked for expiration")
+		}
+
+		pending.ctxDone()
+		s.unloadedCh <- struct{}{}
+		synctest.Wait()
+
+		select {
+		case err := <-pending.req.errCh:
+			require.ErrorIs(t, err, context.Canceled)
+		default:
+			t.Fatal("expected canceled request error")
+		}
+		require.Equal(t, int32(1), loadCalls.Load())
+	})
 }
 
 // hasLoadedRunner is a test helper that checks if any runner is loaded.
@@ -1211,7 +1467,10 @@ func hasLoadedRunner(s *Scheduler) bool {
 	s.loadedMu.Lock()
 	defer s.loadedMu.Unlock()
 	for _, r := range s.loaded {
-		if r.llama != nil {
+		r.refMu.Lock()
+		llama := r.llama
+		r.refMu.Unlock()
+		if llama != nil {
 			return true
 		}
 	}
@@ -1332,6 +1591,124 @@ func TestSchedLlamaServerFitsAlongside(t *testing.T) {
 	require.False(t, needEvict, "expected no eviction when model fits in available VRAM")
 }
 
+func TestSchedRetriesWhenLlamaServerSpillsToCPUWithLoadedRunner(t *testing.T) {
+	ctx, done := context.WithTimeout(t.Context(), 500*time.Millisecond)
+	defer done()
+
+	var buf syncBuffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(previous)
+
+	s := InitScheduler(ctx)
+	s.waitForRecovery = 10 * time.Millisecond
+	s.getGpuFn = func(ctx context.Context, runners []ml.FilteredRunnerDiscovery) []ml.DeviceInfo {
+		g := ml.DeviceInfo{DeviceID: ml.DeviceID{Library: "Metal"}}
+		g.TotalMemory = 24 * format.GigaByte
+		g.FreeMemory = 20 * format.GigaByte
+		return []ml.DeviceInfo{g}
+	}
+	s.getSystemInfoFn = getSystemInfoFn
+
+	s.loadedMu.Lock()
+	s.loaded["existing-model"] = &runnerRef{
+		llama:    &mockLlm{modelPath: "/fake/existing"},
+		modelKey: "existing-model",
+	}
+	s.loadedMu.Unlock()
+
+	scenario := newScenarioRequest(t, ctx, "cpu-spill-model", 1*format.GigaByte, nil, nil)
+	scenario.srv.totalSize = 2 * format.GigaByte
+	scenario.srv.vramSize = 1 * format.GigaByte
+	scenario.srv.gpuLayers = 20
+	scenario.srv.totalLayers = 33
+	s.newServerFn = scenario.newServer
+
+	systemInfo := getSystemInfoFn()
+	gpus := s.getGpuFn(ctx, nil)
+
+	require.True(t, s.load(scenario.req, systemInfo, gpus, true))
+	require.True(t, scenario.req.loadRetryAttempted)
+	require.True(t, scenario.srv.closeCalled)
+	require.Nil(t, s.activeLoading)
+	require.Contains(t, buf.String(), "llama-server spilled layers to CPU with other models resident; evicting residents and retrying")
+	require.Contains(t, buf.String(), "gpu_layers=20")
+	require.Contains(t, buf.String(), "total_layers=33")
+}
+
+func TestSchedAllowsCPUOnlyLlamaServerLoadWithLoadedRunner(t *testing.T) {
+	ctx, done := context.WithTimeout(t.Context(), 500*time.Millisecond)
+	defer done()
+
+	var buf syncBuffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(previous)
+
+	s := InitScheduler(ctx)
+	s.waitForRecovery = 10 * time.Millisecond
+	s.getGpuFn = func(ctx context.Context, runners []ml.FilteredRunnerDiscovery) []ml.DeviceInfo {
+		return nil
+	}
+	s.getSystemInfoFn = getSystemInfoFn
+
+	s.loadedMu.Lock()
+	s.loaded["existing-model"] = &runnerRef{
+		llama:    &mockLlm{modelPath: "/fake/existing"},
+		modelKey: "existing-model",
+	}
+	s.loadedMu.Unlock()
+
+	scenario := newScenarioRequest(t, ctx, "cpu-only-model", 1*format.GigaByte, nil, nil)
+	scenario.srv.totalSize = 2 * format.GigaByte
+	scenario.srv.gpuLayers = 0
+	scenario.srv.totalLayers = 33
+	s.newServerFn = scenario.newServer
+
+	systemInfo := getSystemInfoFn()
+	gpus := s.getGpuFn(ctx, nil)
+
+	require.False(t, s.load(scenario.req, systemInfo, gpus, true))
+	require.False(t, scenario.req.loadRetryAttempted)
+	require.False(t, scenario.srv.closeCalled)
+	require.NotContains(t, buf.String(), "llama-server spilled layers to CPU with other models resident")
+}
+
+func TestSchedAllowsLlamaServerCPUOverflowWithoutLoadedRunner(t *testing.T) {
+	ctx, done := context.WithTimeout(t.Context(), 500*time.Millisecond)
+	defer done()
+
+	var buf syncBuffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(previous)
+
+	s := InitScheduler(ctx)
+	s.waitForRecovery = 10 * time.Millisecond
+	s.getGpuFn = func(ctx context.Context, runners []ml.FilteredRunnerDiscovery) []ml.DeviceInfo {
+		g := ml.DeviceInfo{DeviceID: ml.DeviceID{Library: "Metal"}}
+		g.TotalMemory = 24 * format.GigaByte
+		g.FreeMemory = 20 * format.GigaByte
+		return []ml.DeviceInfo{g}
+	}
+	s.getSystemInfoFn = getSystemInfoFn
+
+	scenario := newScenarioRequest(t, ctx, "cpu-spill-model", 1*format.GigaByte, nil, nil)
+	scenario.srv.totalSize = 2 * format.GigaByte
+	scenario.srv.vramSize = 1 * format.GigaByte
+	scenario.srv.gpuLayers = 20
+	scenario.srv.totalLayers = 33
+	s.newServerFn = scenario.newServer
+
+	systemInfo := getSystemInfoFn()
+	gpus := s.getGpuFn(ctx, nil)
+
+	require.False(t, s.load(scenario.req, systemInfo, gpus, false))
+	require.False(t, scenario.req.loadRetryAttempted)
+	require.False(t, scenario.srv.closeCalled)
+	require.NotContains(t, buf.String(), "llama-server spilled layers to CPU with other models resident")
+}
+
 func TestSchedLlamaServerPredictionUsesTotalParallelContext(t *testing.T) {
 	ctx, done := context.WithTimeout(t.Context(), 500*time.Millisecond)
 	defer done()
@@ -1371,374 +1748,6 @@ func TestSchedLlamaServerPredictionUsesTotalParallelContext(t *testing.T) {
 	require.False(t, called, "preflight prediction should reject before spawning llama-server")
 }
 
-func TestAvailableMemoryForLoadUsesWorstSharedMemoryMeasurement(t *testing.T) {
-	tests := []struct {
-		name              string
-		systemFree        uint64
-		gpus              []ml.DeviceInfo
-		wantAvailable     uint64
-		wantGPUFree       uint64
-		wantSystemLimited bool
-	}{
-		{
-			name:       "integrated metal uses lower system free",
-			systemFree: 80 * format.GigaByte,
-			gpus: []ml.DeviceInfo{{
-				DeviceID:   ml.DeviceID{Library: "Metal"},
-				Integrated: true,
-				FreeMemory: 300 * format.GigaByte,
-			}},
-			wantAvailable:     80 * format.GigaByte,
-			wantGPUFree:       300 * format.GigaByte,
-			wantSystemLimited: true,
-		},
-		{
-			name:       "integrated gpu uses lower system free",
-			systemFree: 6 * format.GigaByte,
-			gpus: []ml.DeviceInfo{{
-				DeviceID:   ml.DeviceID{Library: "Vulkan"},
-				Integrated: true,
-				FreeMemory: 12 * format.GigaByte,
-			}},
-			wantAvailable:     6 * format.GigaByte,
-			wantGPUFree:       12 * format.GigaByte,
-			wantSystemLimited: true,
-		},
-		{
-			name:       "discrete metal ignores lower system free",
-			systemFree: 6 * format.GigaByte,
-			gpus: []ml.DeviceInfo{{
-				DeviceID:   ml.DeviceID{Library: "Metal"},
-				FreeMemory: 12 * format.GigaByte,
-			}},
-			wantAvailable: 12 * format.GigaByte,
-			wantGPUFree:   12 * format.GigaByte,
-		},
-		{
-			name:       "discrete gpu ignores lower system free",
-			systemFree: 6 * format.GigaByte,
-			gpus: []ml.DeviceInfo{{
-				DeviceID:   ml.DeviceID{Library: "CUDA"},
-				FreeMemory: 12 * format.GigaByte,
-			}},
-			wantAvailable: 12 * format.GigaByte,
-			wantGPUFree:   12 * format.GigaByte,
-		},
-		{
-			name:       "mixed gpus only clamp integrated contribution",
-			systemFree: 6 * format.GigaByte,
-			gpus: []ml.DeviceInfo{
-				{
-					DeviceID:   ml.DeviceID{Library: "CUDA"},
-					FreeMemory: 12 * format.GigaByte,
-				},
-				{
-					DeviceID:   ml.DeviceID{Library: "Vulkan"},
-					Integrated: true,
-					FreeMemory: 10 * format.GigaByte,
-				},
-			},
-			wantAvailable:     18 * format.GigaByte,
-			wantGPUFree:       22 * format.GigaByte,
-			wantSystemLimited: true,
-		},
-		{
-			name:       "shared gpu keeps lower adjusted gpu baseline",
-			systemFree: 20 * format.GigaByte,
-			gpus: []ml.DeviceInfo{{
-				DeviceID:   ml.DeviceID{Library: "Metal"},
-				Integrated: true,
-				FreeMemory: 12 * format.GigaByte,
-			}},
-			wantAvailable: 12 * format.GigaByte,
-			wantGPUFree:   12 * format.GigaByte,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			available, gpuFree, systemLimited := availableMemoryForLoad(ml.SystemInfo{FreeMemory: tt.systemFree}, tt.gpus)
-			require.Equal(t, tt.wantAvailable, available)
-			require.Equal(t, tt.wantGPUFree, gpuFree)
-			require.Equal(t, tt.wantSystemLimited, systemLimited)
-		})
-	}
-}
-
-func TestSelectLlamaServerPlacement(t *testing.T) {
-	systemInfo := ml.SystemInfo{FreeMemory: 14 * format.GigaByte}
-
-	tests := []struct {
-		name             string
-		gpus             []ml.DeviceInfo
-		predictedVRAM    uint64
-		opts             api.Options
-		schedSpread      string
-		wantLibrary      string
-		wantMainGPU      *int
-		wantSelectedGPUs int
-		wantGPUID        string
-	}{
-		{
-			name:          "compacts onto largest same-backend GPU",
-			predictedVRAM: 8 * format.GigaByte,
-			gpus: []ml.DeviceInfo{
-				{DeviceID: ml.DeviceID{ID: "0", Library: "CUDA"}, Name: "small", FreeMemory: 10 * format.GigaByte},
-				{DeviceID: ml.DeviceID{ID: "1", Library: "CUDA"}, Name: "large", FreeMemory: 20 * format.GigaByte},
-			},
-			opts:             api.DefaultOptions(),
-			wantLibrary:      "CUDA",
-			wantMainGPU:      testIntPtr(0),
-			wantSelectedGPUs: 1,
-			wantGPUID:        "1",
-		},
-		{
-			name:          "explicit main gpu selects matching backend group",
-			predictedVRAM: 8 * format.GigaByte,
-			gpus: []ml.DeviceInfo{
-				{DeviceID: ml.DeviceID{ID: "0", Library: "CUDA"}, FreeMemory: 10 * format.GigaByte},
-				{DeviceID: ml.DeviceID{ID: "0", Library: "ROCm"}, FreeMemory: 20 * format.GigaByte},
-				{DeviceID: ml.DeviceID{ID: "1", Library: "ROCm"}, FreeMemory: 24 * format.GigaByte},
-			},
-			opts: api.Options{
-				Runner: api.Runner{MainGPU: testIntPtr(1), NumGPU: -1},
-			},
-			wantLibrary:      "ROCm",
-			wantMainGPU:      testIntPtr(0),
-			wantSelectedGPUs: 1,
-			wantGPUID:        "1",
-		},
-		{
-			name:          "integrated GPU is capped by system free memory",
-			predictedVRAM: 12 * format.GigaByte,
-			gpus: []ml.DeviceInfo{
-				{DeviceID: ml.DeviceID{ID: "0", Library: "Metal"}, Integrated: true, FreeMemory: 32 * format.GigaByte},
-				{DeviceID: ml.DeviceID{ID: "1", Library: "Metal"}, FreeMemory: 16 * format.GigaByte},
-			},
-			opts:             api.DefaultOptions(),
-			wantLibrary:      "Metal",
-			wantMainGPU:      testIntPtr(0),
-			wantSelectedGPUs: 1,
-			wantGPUID:        "1",
-		},
-		{
-			name:          "prefers discrete GPU over integrated GPU with more available memory",
-			predictedVRAM: 8 * format.GigaByte,
-			gpus: []ml.DeviceInfo{
-				{DeviceID: ml.DeviceID{ID: "0", Library: "Vulkan"}, Name: "integrated", Integrated: true, FreeMemory: 32 * format.GigaByte},
-				{DeviceID: ml.DeviceID{ID: "1", Library: "Vulkan"}, Name: "discrete", FreeMemory: 10 * format.GigaByte},
-			},
-			opts:             api.DefaultOptions(),
-			wantLibrary:      "Vulkan",
-			wantMainGPU:      testIntPtr(0),
-			wantSelectedGPUs: 1,
-			wantGPUID:        "1",
-		},
-		{
-			name:          "spread disables automatic compaction",
-			predictedVRAM: 8 * format.GigaByte,
-			schedSpread:   "1",
-			gpus: []ml.DeviceInfo{
-				{DeviceID: ml.DeviceID{ID: "0", Library: "CUDA"}, FreeMemory: 10 * format.GigaByte},
-				{DeviceID: ml.DeviceID{ID: "1", Library: "CUDA"}, FreeMemory: 20 * format.GigaByte},
-			},
-			opts:             api.DefaultOptions(),
-			wantLibrary:      "CUDA",
-			wantSelectedGPUs: 2,
-		},
-		{
-			name:          "no single fit chooses best backend group for llama-server split",
-			predictedVRAM: 30 * format.GigaByte,
-			gpus: []ml.DeviceInfo{
-				{DeviceID: ml.DeviceID{ID: "0", Library: "CUDA"}, FreeMemory: 10 * format.GigaByte},
-				{DeviceID: ml.DeviceID{ID: "1", Library: "CUDA"}, FreeMemory: 18 * format.GigaByte},
-				{DeviceID: ml.DeviceID{ID: "0", Library: "ROCm"}, FreeMemory: 12 * format.GigaByte},
-			},
-			opts:             api.DefaultOptions(),
-			wantLibrary:      "CUDA",
-			wantSelectedGPUs: 2,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("OLLAMA_SCHED_SPREAD", tt.schedSpread)
-
-			selected, launchOpts := selectLlamaServerPlacement(systemInfo, tt.gpus, tt.predictedVRAM, tt.opts)
-			require.Len(t, selected, tt.wantSelectedGPUs)
-			require.Equal(t, tt.wantLibrary, selected[0].Library)
-			if tt.wantGPUID != "" {
-				require.Equal(t, tt.wantGPUID, selected[0].ID)
-			}
-			if tt.wantMainGPU == nil {
-				require.Nil(t, launchOpts.MainGPU)
-			} else {
-				require.NotNil(t, launchOpts.MainGPU)
-				require.Equal(t, *tt.wantMainGPU, *launchOpts.MainGPU)
-			}
-		})
-	}
-}
-
-func testIntPtr(v int) *int {
-	return &v
-}
-
-func TestDisableMmapDefaultReason(t *testing.T) {
-	useMmap := true
-	tests := []struct {
-		name          string
-		goos          string
-		opts          api.Options
-		gpus          []ml.DeviceInfo
-		blockCount    uint64
-		predictedVRAM uint64
-		availableVRAM uint64
-		want          string
-	}{
-		{
-			name: "explicit use_mmap true wins",
-			goos: "windows",
-			opts: api.Options{Runner: api.Runner{NumGPU: -1, UseMMap: &useMmap}},
-			gpus: []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}}},
-		},
-		{
-			name: "cpu-only request disables mmap",
-			goos: "linux",
-			opts: api.Options{Runner: api.Runner{NumGPU: 0}},
-			gpus: []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}}},
-			want: "cpu",
-		},
-		{
-			name: "no GPU devices disables mmap",
-			goos: "linux",
-			opts: api.Options{Runner: api.Runner{NumGPU: -1}},
-			want: "cpu",
-		},
-		{
-			name: "windows cuda disables mmap",
-			goos: "windows",
-			opts: api.Options{Runner: api.Runner{NumGPU: -1}},
-			gpus: []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}}},
-			want: "windows_cuda",
-		},
-		{
-			name:       "metal partial offload disables mmap",
-			goos:       "darwin",
-			opts:       api.Options{Runner: api.Runner{NumGPU: 10}},
-			gpus:       []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "Metal"}}},
-			blockCount: 20,
-			want:       "metal_partial_offload",
-		},
-		{
-			name:       "metal full offload keeps default",
-			goos:       "darwin",
-			opts:       api.Options{Runner: api.Runner{NumGPU: 21}},
-			gpus:       []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "Metal"}}},
-			blockCount: 20,
-		},
-		{
-			name:          "metal auto partial offload disables mmap",
-			goos:          "darwin",
-			opts:          api.Options{Runner: api.Runner{NumGPU: -1}},
-			gpus:          []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "Metal"}}},
-			predictedVRAM: 30 * format.GigaByte,
-			availableVRAM: 20 * format.GigaByte,
-			want:          "metal_partial_offload",
-		},
-		{
-			name:          "metal auto full offload keeps default",
-			goos:          "darwin",
-			opts:          api.Options{Runner: api.Runner{NumGPU: -1}},
-			gpus:          []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "Metal"}}},
-			predictedVRAM: 10 * format.GigaByte,
-			availableVRAM: 20 * format.GigaByte,
-		},
-		{
-			name: "linux cuda keeps default",
-			goos: "linux",
-			opts: api.Options{Runner: api.Runner{NumGPU: -1}},
-			gpus: []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}}},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, disableMmapDefaultReason(tt.goos, tt.opts, tt.gpus, tt.blockCount, tt.predictedVRAM, tt.availableVRAM))
-		})
-	}
-}
-
-func TestDisableMmapForHostPressure(t *testing.T) {
-	gpus := []ml.DeviceInfo{{
-		DeviceID:    ml.DeviceID{Library: "CUDA"},
-		TotalMemory: 100 * format.GigaByte,
-		FreeMemory:  80 * format.GigaByte,
-	}}
-	systemInfo := ml.SystemInfo{
-		TotalMemory: 100 * format.GigaByte,
-		FreeMemory:  50 * format.GigaByte,
-	}
-
-	require.True(t, disableMmapForHostPressure(
-		"linux",
-		api.Options{},
-		systemInfo,
-		gpus,
-		20*format.GigaByte,
-		25*format.GigaByte,
-		30*format.GigaByte,
-		80*format.GigaByte,
-	))
-
-	useMmap := true
-	require.False(t, disableMmapForHostPressure(
-		"linux",
-		api.Options{Runner: api.Runner{UseMMap: &useMmap}},
-		systemInfo,
-		gpus,
-		20*format.GigaByte,
-		25*format.GigaByte,
-		30*format.GigaByte,
-		80*format.GigaByte,
-	), "explicit use_mmap=true should win")
-
-	require.False(t, disableMmapForHostPressure(
-		"darwin",
-		api.Options{},
-		systemInfo,
-		gpus,
-		20*format.GigaByte,
-		25*format.GigaByte,
-		30*format.GigaByte,
-		80*format.GigaByte,
-	), "only the Linux pressure heuristic is restored")
-
-	igpu := append([]ml.DeviceInfo(nil), gpus...)
-	igpu[0].Integrated = true
-	require.False(t, disableMmapForHostPressure(
-		"linux",
-		api.Options{},
-		systemInfo,
-		igpu,
-		20*format.GigaByte,
-		25*format.GigaByte,
-		30*format.GigaByte,
-		80*format.GigaByte,
-	), "shared-memory GPU loads should keep the normal mmap path")
-
-	require.False(t, disableMmapForHostPressure(
-		"linux",
-		api.Options{},
-		systemInfo,
-		gpus,
-		20*format.GigaByte,
-		25*format.GigaByte,
-		70*format.GigaByte,
-		80*format.GigaByte,
-	), "when VRAM is tight, no-mmap could make partial CPU offload worse")
-}
-
 // TestSchedLoadCrashTriggersEvictAllAndRetry verifies that a post-spawn
 // Load() OOM while other models are resident signals evict-all-and-retry
 // on the first attempt, but fails fast on the second attempt.
@@ -1776,8 +1785,8 @@ func TestSchedLoadCrashTriggersEvictAllAndRetry(t *testing.T) {
 	// First attempt: should signal evict-all by returning true and NOT send
 	// the error to errCh (so the caller will retry).
 	needEvict := s.load(scenario.req, systemInfo, gpus, true)
-	require.True(t, needEvict, "first load OOM should signal eviction")
-	require.True(t, scenario.req.oomRetryAttempted, "oomRetryAttempted should be set")
+	require.True(t, needEvict, "first load retry should signal eviction")
+	require.True(t, scenario.req.loadRetryAttempted, "loadRetryAttempted should be set")
 	select {
 	case err := <-scenario.req.errCh:
 		t.Fatalf("errCh should be empty on first crash, got %v", err)
@@ -1785,14 +1794,14 @@ func TestSchedLoadCrashTriggersEvictAllAndRetry(t *testing.T) {
 	}
 
 	// Second attempt (simulating the retry after processPending evicted all
-	// other runners): same crash, but this time oomRetryAttempted is set so
+	// other runners): same crash, but this time loadRetryAttempted is set so
 	// load() should fail fast and report the error.
 	needEvict = s.load(scenario.req, systemInfo, gpus, true)
-	require.False(t, needEvict, "second load OOM should not ask for another eviction")
+	require.False(t, needEvict, "second load retry should not ask for another eviction")
 	select {
 	case err := <-scenario.req.errCh:
 		require.ErrorIs(t, err, loadCrash)
-	case <-time.After(100 * time.Millisecond):
+	default:
 		t.Fatal("expected error on errCh after second crash")
 	}
 }
@@ -1834,10 +1843,10 @@ func TestSchedLoadOOMReducesAutomaticContextBeforeRetry(t *testing.T) {
 	gpus := s.getGpuFn(ctx, nil)
 
 	needEvict := s.load(scenario.req, systemInfo, gpus, true)
-	require.True(t, needEvict, "first automatic-context load OOM should signal eviction and retry")
-	require.True(t, scenario.req.oomRetryAttempted)
+	require.True(t, needEvict, "first automatic-context load retry should signal eviction and retry")
+	require.True(t, scenario.req.loadRetryAttempted)
 	require.Equal(t, 32768, scenario.req.opts.NumCtx)
-	require.Equal(t, 1024, scenario.req.opts.NumBatch)
+	require.Equal(t, llamaServerGenerationBatchMedium, scenario.req.opts.NumBatch)
 	select {
 	case err := <-scenario.req.errCh:
 		t.Fatalf("errCh should be empty on first crash, got %v", err)
@@ -1845,13 +1854,13 @@ func TestSchedLoadOOMReducesAutomaticContextBeforeRetry(t *testing.T) {
 	}
 
 	needEvict = s.load(scenario.req, systemInfo, gpus, true)
-	require.False(t, needEvict, "second load OOM should not ask for another eviction")
+	require.False(t, needEvict, "second load retry should not ask for another eviction")
 	require.Equal(t, []int{262144, 32768}, seenNumCtx)
-	require.Equal(t, []int{2048, 1024}, seenNumBatch)
+	require.Equal(t, []int{llamaServerGenerationBatchLarge, llamaServerGenerationBatchMedium}, seenNumBatch)
 	select {
 	case err := <-scenario.req.errCh:
 		require.ErrorIs(t, err, loadCrash)
-	case <-time.After(100 * time.Millisecond):
+	default:
 		t.Fatal("expected error on errCh after second crash")
 	}
 }
@@ -1888,8 +1897,8 @@ func TestSchedLoadOOMKeepsExplicitContextBeforeRetry(t *testing.T) {
 	gpus := s.getGpuFn(ctx, nil)
 
 	needEvict := s.load(scenario.req, systemInfo, gpus, true)
-	require.True(t, needEvict, "explicit-context load OOM should still evict and retry once")
-	require.True(t, scenario.req.oomRetryAttempted)
+	require.True(t, needEvict, "explicit-context load retry should still evict and retry once")
+	require.True(t, scenario.req.loadRetryAttempted)
 	require.Equal(t, 262144, scenario.req.opts.NumCtx)
 	select {
 	case err := <-scenario.req.errCh:
@@ -1965,11 +1974,11 @@ func TestSchedLoadCrashNoOtherModelsFailsFast(t *testing.T) {
 
 	needEvict := s.load(scenario.req, systemInfo, gpus, true)
 	require.False(t, needEvict, "crash with no other runners should not ask for eviction")
-	require.False(t, scenario.req.oomRetryAttempted, "oomRetryAttempted must stay false")
+	require.False(t, scenario.req.loadRetryAttempted, "loadRetryAttempted must stay false")
 	select {
 	case err := <-scenario.req.errCh:
 		require.ErrorIs(t, err, loadCrash)
-	case <-time.After(100 * time.Millisecond):
+	default:
 		t.Fatal("expected error on errCh immediately")
 	}
 }
@@ -2005,11 +2014,11 @@ func TestSchedLoadNonOOMWithOtherModelsFailsFast(t *testing.T) {
 
 	needEvict := s.load(scenario.req, systemInfo, gpus, true)
 	require.False(t, needEvict, "non-OOM load crash should not ask for eviction")
-	require.False(t, scenario.req.oomRetryAttempted, "oomRetryAttempted must stay false")
+	require.False(t, scenario.req.loadRetryAttempted, "loadRetryAttempted must stay false")
 	select {
 	case err := <-scenario.req.errCh:
 		require.ErrorIs(t, err, loadCrash)
-	case <-time.After(100 * time.Millisecond):
+	default:
 		t.Fatal("expected error on errCh immediately")
 	}
 }
@@ -2085,6 +2094,14 @@ type mockLlm struct {
 	totalSize         uint64
 	contextLength     int
 	vramByGPU         map[ml.DeviceID]uint64
+	memorySizeFn      func() (uint64, uint64)
+	vramByGPUFn       func(ml.DeviceID) uint64
+	gpuLayers         uint64
+	totalLayers       uint64
+	gpuLayerOverflow  int
+	port              int
+	deviceInfos       []ml.DeviceInfo
+	exited            bool
 
 	// loadErr, if non-nil, is returned from Load() to simulate a post-spawn
 	// load failure (e.g. llama-server crashing due to under-predicted VRAM).
@@ -2095,7 +2112,7 @@ func (s *mockLlm) ModelPath() string {
 	return s.modelPath
 }
 
-func (s *mockLlm) Load(ctx context.Context, sytemInfo ml.SystemInfo, gpus []ml.DeviceInfo, requireFull bool) ([]ml.DeviceID, error) {
+func (s *mockLlm) Load(ctx context.Context, systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, requireFull bool) ([]ml.DeviceID, error) {
 	if s.loadErr != nil {
 		return nil, s.loadErr
 	}
@@ -2148,14 +2165,36 @@ func (s *mockLlm) Close() error {
 	s.closeCalled = true
 	return s.closeResp
 }
-func (s *mockLlm) MemorySize() (uint64, uint64)                       { return s.totalSize, s.vramSize }
-func (s *mockLlm) VRAMByGPU(id ml.DeviceID) uint64                    { return s.vramByGPU[id] }
-func (s *mockLlm) Pid() int                                           { return -1 }
-func (s *mockLlm) GetPort() int                                       { return -1 }
-func (s *mockLlm) GetDeviceInfos(ctx context.Context) []ml.DeviceInfo { return nil }
-func (s *mockLlm) HasExited() bool                                    { return false }
-func (s *mockLlm) GetActiveDeviceIDs() []ml.DeviceID                  { return nil }
-func (s *mockLlm) ContextLength() int                                 { return s.contextLength }
+
+func (s *mockLlm) MemorySize() (uint64, uint64) {
+	if s.memorySizeFn != nil {
+		return s.memorySizeFn()
+	}
+	return s.totalSize, s.vramSize
+}
+
+func (s *mockLlm) VRAMByGPU(id ml.DeviceID) uint64 {
+	if s.vramByGPUFn != nil {
+		return s.vramByGPUFn(id)
+	}
+	return s.vramByGPU[id]
+}
+func (s *mockLlm) Pid() int { return -1 }
+func (s *mockLlm) GetPort() int {
+	if s.port == 0 {
+		return -1
+	}
+	return s.port
+}
+func (s *mockLlm) GetDeviceInfos(ctx context.Context) []ml.DeviceInfo {
+	return s.deviceInfos
+}
+func (s *mockLlm) HasExited() bool                   { return s.exited }
+func (s *mockLlm) GetActiveDeviceIDs() []ml.DeviceID { return nil }
+func (s *mockLlm) ContextLength() int                { return s.contextLength }
+func (s *mockLlm) LayerOffloadStatus() (gpuLayers, totalLayers uint64, overflow int, ok bool) {
+	return s.gpuLayers, s.totalLayers, s.gpuLayerOverflow, s.totalLayers > 0
+}
 
 func TestRunnerCanBeEvicted(t *testing.T) {
 	ctx, done := context.WithTimeout(t.Context(), 500*time.Millisecond)

--- a/x/mlxrunner/cache/cache_test.go
+++ b/x/mlxrunner/cache/cache_test.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/ollama/ollama/x/mlxrunner/batch"
@@ -9,9 +10,18 @@ import (
 
 func skipIfNoMLX(t *testing.T) {
 	t.Helper()
+	runtime.LockOSThread()
+	t.Cleanup(runtime.UnlockOSThread)
 	if err := mlx.CheckInit(); err != nil {
 		t.Skipf("MLX not available: %v", err)
 	}
+	if mlx.GPUIsAvailable() {
+		mlx.SetDefaultDeviceGPU()
+	}
+	t.Cleanup(func() {
+		mlx.Sweep()
+		mlx.ClearCache()
+	})
 }
 
 // newKVBatch builds a B=1 batch at SeqOffsets=off with all-real

--- a/x/mlxrunner/cache/cache_test.go
+++ b/x/mlxrunner/cache/cache_test.go
@@ -3,15 +3,16 @@ package cache
 import (
 	"testing"
 
+	"github.com/ollama/ollama/x/internal/mlxtest"
 	"github.com/ollama/ollama/x/mlxrunner/batch"
 	"github.com/ollama/ollama/x/mlxrunner/mlx"
 )
 
+// skipIfNoMLX preserves the cache package's existing test helper name while
+// using the shared MLX setup shape from mac-mlx-ci.
 func skipIfNoMLX(t *testing.T) {
 	t.Helper()
-	if err := mlx.CheckInit(); err != nil {
-		t.Skipf("MLX not available: %v", err)
-	}
+	mlxtest.Setup(t)
 }
 
 // newKVBatch builds a B=1 batch at SeqOffsets=off with all-real

--- a/x/mlxrunner/cache/rotating_attention_test.go
+++ b/x/mlxrunner/cache/rotating_attention_test.go
@@ -95,22 +95,20 @@ func TestRotatingKVCacheDecodeParity(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := nn.ScaledDotProductAttention(b, q, scale,
-				nn.WithKVHistory(history),
-				nn.WithMask(tc.model))
+		got := nn.ScaledDotProductAttention(b, q, scale,
+			nn.WithKVHistory(history),
+			nn.WithMask(tc.model))
 
-			want := mlx.FastScaledDotProductAttention(q, kLogical, vLogical, scale,
-				tc.refMode, tc.refMask)
+		want := mlx.FastScaledDotProductAttention(q, kLogical, vLogical, scale,
+			tc.refMode, tc.refMask)
 
-			mlx.Eval(got, want)
-			gs, ws := got.Floats(), want.Floats()
-			for i := range ws {
-				if math.Abs(float64(gs[i]-ws[i])) > 1e-5 {
-					t.Fatalf("index %d: got %v, want %v", i, gs[i], ws[i])
-				}
+		mlx.Eval(got, want)
+		gs, ws := got.Floats(), want.Floats()
+		for i := range ws {
+			if math.Abs(float64(gs[i]-ws[i])) > 1e-5 {
+				t.Fatalf("%s index %d: got %v, want %v", tc.name, i, gs[i], ws[i])
 			}
-		})
+		}
 	}
 }
 
@@ -153,18 +151,16 @@ func TestAssistantSharedHistoryL1MasksMatchNoMask(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := nn.ScaledDotProductAttention(b, q, scale, nn.WithKVHistory(tc.h), nn.WithMask(tc.mask))
-			want := mlx.FastScaledDotProductAttention(q, tc.h.K(), tc.h.V(), scale, "", nil)
+		got := nn.ScaledDotProductAttention(b, q, scale, nn.WithKVHistory(tc.h), nn.WithMask(tc.mask))
+		want := mlx.FastScaledDotProductAttention(q, tc.h.K(), tc.h.V(), scale, "", nil)
 
-			mlx.Eval(got, want)
-			gs, ws := got.Floats(), want.Floats()
-			for i := range ws {
-				if math.Abs(float64(gs[i]-ws[i])) > 1e-5 {
-					t.Fatalf("index %d: got %v, want %v", i, gs[i], ws[i])
-				}
+		mlx.Eval(got, want)
+		gs, ws := got.Floats(), want.Floats()
+		for i := range ws {
+			if math.Abs(float64(gs[i]-ws[i])) > 1e-5 {
+				t.Fatalf("%s index %d: got %v, want %v", tc.name, i, gs[i], ws[i])
 			}
-		})
+		}
 	}
 }
 
@@ -205,49 +201,47 @@ func TestRotatingKVCachePrefillParity(t *testing.T) {
 
 	negInf := float32(math.Inf(-1))
 	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			c := NewRotatingKVCache(window)
-			history := c.Update(b, k, v)
+		c := NewRotatingKVCache(window)
+		history := c.Update(b, k, v)
 
-			got := nn.ScaledDotProductAttention(b, q, scale,
-				nn.WithKVHistory(history),
-				nn.WithMask(tc.mask))
+		got := nn.ScaledDotProductAttention(b, q, scale,
+			nn.WithKVHistory(history),
+			nn.WithMask(tc.mask))
 
-			// Reference mask: causal blocks k > absQ; relax rectangles
-			// release causal-blocked cells; window blocks k < absQ - window + 1.
-			refVals := make([]float32, L*L)
-			for qi := range L {
-				absQ := qi
-				for ki := range L {
-					blocked := false
-					if tc.causal && ki > absQ {
-						blocked = true
-					}
-					for _, r := range tc.relax {
-						qLo, qHi, kLo, kHi := r[0], r[1], r[2], r[3]
-						if absQ >= qLo && absQ < qHi && ki >= kLo && ki < kHi {
-							blocked = false
-						}
-					}
-					if window > 0 && ki < absQ-window+1 {
-						blocked = true
-					}
-					if blocked {
-						refVals[qi*L+ki] = negInf
+		// Reference mask: causal blocks k > absQ; relax rectangles
+		// release causal-blocked cells; window blocks k < absQ - window + 1.
+		refVals := make([]float32, L*L)
+		for qi := range L {
+			absQ := qi
+			for ki := range L {
+				blocked := false
+				if tc.causal && ki > absQ {
+					blocked = true
+				}
+				for _, r := range tc.relax {
+					qLo, qHi, kLo, kHi := r[0], r[1], r[2], r[3]
+					if absQ >= qLo && absQ < qHi && ki >= kLo && ki < kHi {
+						blocked = false
 					}
 				}
-			}
-			refMask := mlx.FromValues(refVals, 1, 1, L, L)
-			want := mlx.FastScaledDotProductAttention(q, k, v, scale, "array", refMask)
-
-			mlx.Eval(got, want)
-			gs, ws := got.Floats(), want.Floats()
-			for i := range ws {
-				if math.Abs(float64(gs[i]-ws[i])) > 1e-4 {
-					t.Fatalf("index %d: got %v, want %v", i, gs[i], ws[i])
+				if window > 0 && ki < absQ-window+1 {
+					blocked = true
+				}
+				if blocked {
+					refVals[qi*L+ki] = negInf
 				}
 			}
-		})
+		}
+		refMask := mlx.FromValues(refVals, 1, 1, L, L)
+		want := mlx.FastScaledDotProductAttention(q, k, v, scale, "array", refMask)
+
+		mlx.Eval(got, want)
+		gs, ws := got.Floats(), want.Floats()
+		for i := range ws {
+			if math.Abs(float64(gs[i]-ws[i])) > 1e-4 {
+				t.Fatalf("%s index %d: got %v, want %v", tc.name, i, gs[i], ws[i])
+			}
+		}
 	}
 }
 

--- a/x/mlxrunner/cache/snapshot_capture_test.go
+++ b/x/mlxrunner/cache/snapshot_capture_test.go
@@ -233,57 +233,55 @@ func TestRotatingPerTokenSnapshotRestore(t *testing.T) {
 
 	const draft = 4
 	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			for accepted := 0; accepted <= draft; accepted++ {
-				c := NewRotatingKVCache(tc.window)
-				fillTagged(c, tc.before)
+		for accepted := 0; accepted <= draft; accepted++ {
+			c := NewRotatingKVCache(tc.window)
+			fillTagged(c, tc.before)
 
-				offsets := make([]int, draft)
-				for i := range offsets {
-					offsets[i] = tc.before + i
-				}
-				c.PrepareSnapshots(offsets)
+			offsets := make([]int, draft)
+			for i := range offsets {
+				offsets[i] = tc.before + i
+			}
+			c.PrepareSnapshots(offsets)
 
-				k, v := taggedKV(tc.before, draft)
-				c.Update(newKVBatch(tc.before, draft), k, v)
+			k, v := taggedKV(tc.before, draft)
+			c.Update(newKVBatch(tc.before, draft), k, v)
 
-				snaps := c.TakeSnapshots()
-				if len(snaps) != draft {
-					t.Fatalf("accepted=%d: got %d snapshots, want %d", accepted, len(snaps), draft)
-				}
+			snaps := c.TakeSnapshots()
+			if len(snaps) != draft {
+				t.Fatalf("%s accepted=%d: got %d snapshots, want %d", tc.name, accepted, len(snaps), draft)
+			}
 
-				if accepted < draft {
-					if !c.Restore(snaps[accepted], tc.before+accepted) {
-						t.Fatalf("accepted=%d: restore failed", accepted)
-					}
-				}
-				for _, s := range snaps {
-					s.Close()
-				}
-
-				want := tc.before + draft
-				if accepted < draft {
-					want = tc.before + accepted
-				}
-				if c.Offset() != want {
-					t.Fatalf("accepted=%d: offset after commit = %d, want %d", accepted, c.Offset(), want)
-				}
-				// The logical window holds the trailing min(offset, window)
-				// absolute positions in order — a slot-math error would keep the
-				// right count but the wrong positions, which a dimension check
-				// would miss. A batched write through concat can leave the raw
-				// buffer larger than the window (it retains maxSize-1+L slots);
-				// View trims to the trailing window at SDPA time, so compare the
-				// trailing window of the linearized buffer.
-				got := windowTags(t, c)
-				if len(got) > tc.window {
-					got = got[len(got)-tc.window:]
-				}
-				if wantTags := wantWindowTags(want, tc.window); !slices.Equal(got, wantTags) {
-					t.Fatalf("accepted=%d: window tags = %v, want %v", accepted, got, wantTags)
+			if accepted < draft {
+				if !c.Restore(snaps[accepted], tc.before+accepted) {
+					t.Fatalf("%s accepted=%d: restore failed", tc.name, accepted)
 				}
 			}
-		})
+			for _, s := range snaps {
+				s.Close()
+			}
+
+			want := tc.before + draft
+			if accepted < draft {
+				want = tc.before + accepted
+			}
+			if c.Offset() != want {
+				t.Fatalf("%s accepted=%d: offset after commit = %d, want %d", tc.name, accepted, c.Offset(), want)
+			}
+			// The logical window holds the trailing min(offset, window)
+			// absolute positions in order — a slot-math error would keep the
+			// right count but the wrong positions, which a dimension check
+			// would miss. A batched write through concat can leave the raw
+			// buffer larger than the window (it retains maxSize-1+L slots);
+			// View trims to the trailing window at SDPA time, so compare the
+			// trailing window of the linearized buffer.
+			got := windowTags(t, c)
+			if len(got) > tc.window {
+				got = got[len(got)-tc.window:]
+			}
+			if wantTags := wantWindowTags(want, tc.window); !slices.Equal(got, wantTags) {
+				t.Fatalf("%s accepted=%d: window tags = %v, want %v", tc.name, accepted, got, wantTags)
+			}
+		}
 	}
 }
 
@@ -308,74 +306,72 @@ func TestRotatingRestoreLazyOwnSnapshotSlices(t *testing.T) {
 
 	const draft, accepted = 4, 2
 	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			c := NewRotatingKVCache(tc.window)
-			fillTagged(c, tc.before)
+		c := NewRotatingKVCache(tc.window)
+		fillTagged(c, tc.before)
 
-			offsets := make([]int, draft)
-			for i := range offsets {
-				offsets[i] = tc.before + i
-			}
-			c.PrepareSnapshots(offsets)
+		offsets := make([]int, draft)
+		for i := range offsets {
+			offsets[i] = tc.before + i
+		}
+		c.PrepareSnapshots(offsets)
 
-			k, v := taggedKV(tc.before, draft)
-			c.Update(newKVBatch(tc.before, draft), k, v)
+		k, v := taggedKV(tc.before, draft)
+		c.Update(newKVBatch(tc.before, draft), k, v)
 
-			snaps := c.TakeSnapshots()
-			snap := snaps[accepted].(*rotatingSnapshot)
-			if snap.keys != nil {
-				t.Fatal("snapshot materialized before restore; expected lazy")
-			}
+		snaps := c.TakeSnapshots()
+		snap := snaps[accepted].(*rotatingSnapshot)
+		if snap.keys != nil {
+			t.Fatalf("%s: snapshot materialized before restore; expected lazy", tc.name)
+		}
 
-			if !c.Restore(snap, tc.before+accepted) {
-				t.Fatal("restore failed")
-			}
+		if !c.Restore(snap, tc.before+accepted) {
+			t.Fatalf("%s: restore failed", tc.name)
+		}
 
-			// Fast path: the snapshot was sliced, not copied out, and stays a
-			// valid lazy snapshot re-pointed at the new buffer.
-			if snap.keys != nil {
-				t.Fatal("snapshot was copied out; expected the slice fast path")
-			}
-			if snap.cache != c {
-				t.Fatal("snapshot lost its lazy cache reference")
-			}
-			if !slices.Contains(c.lazySnapshots, snap) {
-				t.Fatal("snapshot not re-added to the lazy set")
-			}
-			if snap.sliceStart != 0 || snap.sliceEnd != min(tc.before+accepted, tc.window) {
-				t.Fatalf("snapshot slots = [%d,%d), want [0,%d)", snap.sliceStart, snap.sliceEnd, min(tc.before+accepted, tc.window))
-			}
+		// Fast path: the snapshot was sliced, not copied out, and stays a
+		// valid lazy snapshot re-pointed at the new buffer.
+		if snap.keys != nil {
+			t.Fatalf("%s: snapshot was copied out; expected the slice fast path", tc.name)
+		}
+		if snap.cache != c {
+			t.Fatalf("%s: snapshot lost its lazy cache reference", tc.name)
+		}
+		if !slices.Contains(c.lazySnapshots, snap) {
+			t.Fatalf("%s: snapshot not re-added to the lazy set", tc.name)
+		}
+		if snap.sliceStart != 0 || snap.sliceEnd != min(tc.before+accepted, tc.window) {
+			t.Fatalf("%s: snapshot slots = [%d,%d), want [0,%d)", tc.name, snap.sliceStart, snap.sliceEnd, min(tc.before+accepted, tc.window))
+		}
 
-			got := windowTags(t, c)
-			want := wantWindowTags(tc.before+accepted, tc.window)
-			if !slices.Equal(got, want) {
-				t.Fatalf("window tags = %v, want %v", got, want)
-			}
+		got := windowTags(t, c)
+		want := wantWindowTags(tc.before+accepted, tc.window)
+		if !slices.Equal(got, want) {
+			t.Fatalf("%s: window tags = %v, want %v", tc.name, got, want)
+		}
 
-			// A following decode write must produce correct content (the sliced
-			// buffer feeds update's ring math unchanged). The write copies the
-			// re-pointed snapshot out first; it must capture the same window.
-			wk, wv := taggedKV(c.Offset(), 1)
-			c.Update(newKVBatch(c.Offset(), 1), wk, wv)
-			if snap.keys == nil {
-				t.Fatal("following write did not copy out the re-pointed snapshot")
-			}
-			mlx.Eval(snap.keys)
-			if head := int(snap.keys.Floats()[0]) - 1; head != tc.before+accepted-min(tc.before+accepted, tc.window) {
-				t.Fatalf("re-pointed snapshot head tag = %d, want %d", head, tc.before+accepted-min(tc.before+accepted, tc.window))
-			}
-			got = windowTags(t, c)
-			want = wantWindowTags(tc.before+accepted+1, tc.window)
-			if !slices.Equal(got, want) {
-				t.Fatalf("after follow-up write: window tags = %v, want %v", got, want)
-			}
+		// A following decode write must produce correct content (the sliced
+		// buffer feeds update's ring math unchanged). The write copies the
+		// re-pointed snapshot out first; it must capture the same window.
+		wk, wv := taggedKV(c.Offset(), 1)
+		c.Update(newKVBatch(c.Offset(), 1), wk, wv)
+		if snap.keys == nil {
+			t.Fatalf("%s: following write did not copy out the re-pointed snapshot", tc.name)
+		}
+		mlx.Eval(snap.keys)
+		if head := int(snap.keys.Floats()[0]) - 1; head != tc.before+accepted-min(tc.before+accepted, tc.window) {
+			t.Fatalf("%s: re-pointed snapshot head tag = %d, want %d", tc.name, head, tc.before+accepted-min(tc.before+accepted, tc.window))
+		}
+		got = windowTags(t, c)
+		want = wantWindowTags(tc.before+accepted+1, tc.window)
+		if !slices.Equal(got, want) {
+			t.Fatalf("%s: after follow-up write: window tags = %v, want %v", tc.name, got, want)
+		}
 
-			for _, s := range snaps {
-				if s != nil {
-					s.Close()
-				}
+		for _, s := range snaps {
+			if s != nil {
+				s.Close()
 			}
-		})
+		}
 	}
 }
 
@@ -463,30 +459,28 @@ func TestRotatingSnapshotSingleTokenWrite(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			c := NewRotatingKVCache(tc.window)
-			fillTagged(c, tc.before)
+		c := NewRotatingKVCache(tc.window)
+		fillTagged(c, tc.before)
 
-			// Schedule the offset the single-token write reaches as its end
-			// boundary, then perform that write.
-			c.PrepareSnapshots([]int{tc.before + 1})
-			k, v := taggedKV(tc.before, 1)
-			c.Update(newKVBatch(tc.before, 1), k, v)
+		// Schedule the offset the single-token write reaches as its end
+		// boundary, then perform that write.
+		c.PrepareSnapshots([]int{tc.before + 1})
+		k, v := taggedKV(tc.before, 1)
+		c.Update(newKVBatch(tc.before, 1), k, v)
 
-			snaps := c.TakeSnapshots()
-			if len(snaps) != 1 || snaps[0] == nil {
-				t.Fatalf("snapshot not captured: %v", snaps)
-			}
+		snaps := c.TakeSnapshots()
+		if len(snaps) != 1 || snaps[0] == nil {
+			t.Fatalf("%s: snapshot not captured: %v", tc.name, snaps)
+		}
 
-			if !c.Restore(snaps[0], tc.before+1) {
-				t.Fatal("restore failed")
-			}
-			snaps[0].Close()
+		if !c.Restore(snaps[0], tc.before+1) {
+			t.Fatalf("%s: restore failed", tc.name)
+		}
+		snaps[0].Close()
 
-			if got, want := windowTags(t, c), wantWindowTags(tc.before+1, tc.window); !slices.Equal(got, want) {
-				t.Fatalf("window tags = %v, want %v", got, want)
-			}
-		})
+		if got, want := windowTags(t, c), wantWindowTags(tc.before+1, tc.window); !slices.Equal(got, want) {
+			t.Fatalf("%s: window tags = %v, want %v", tc.name, got, want)
+		}
 	}
 }
 

--- a/x/mlxrunner/client.go
+++ b/x/mlxrunner/client.go
@@ -15,6 +15,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -28,6 +29,8 @@ import (
 	"github.com/ollama/ollama/ml"
 	"github.com/ollama/ollama/x/imagegen"
 	"github.com/ollama/ollama/x/imagegen/manifest"
+	mlxmodel "github.com/ollama/ollama/x/mlxrunner/model"
+	"github.com/ollama/ollama/x/mlxrunner/model/base"
 )
 
 // Client wraps an MLX runner subprocess to implement llm.LlamaServer for LLM models.
@@ -43,12 +46,13 @@ type Client struct {
 	status            *llm.StatusWriter
 	mu                sync.Mutex
 	cmd               *exec.Cmd
+	gpus              []ml.DeviceID
 }
 
 // NewClient prepares a new MLX runner client for LLM models.
 // The subprocess is not started until Load() is called.
 func NewClient(modelName string, softContextLength int) (*Client, error) {
-	if err := imagegen.CheckPlatformSupport(); err != nil {
+	if err := CheckPlatformSupport(); err != nil {
 		return nil, err
 	}
 
@@ -59,13 +63,79 @@ func NewClient(modelName string, softContextLength int) (*Client, error) {
 		client:            http.DefaultClient,
 	}
 
-	modelManifest, err := manifest.LoadManifest(modelName)
+	memory, err := EstimateMemory(modelName)
 	if err != nil {
 		return nil, err
 	}
-	c.memory.Store(uint64(modelManifest.TotalTensorSize()))
+	c.memory.Store(memory)
 
 	return c, nil
+}
+
+// CheckPlatformSupport reports whether the local platform can run MLX models.
+func CheckPlatformSupport() error {
+	return imagegen.CheckPlatformSupport()
+}
+
+// LoadEstimate is MLX's current pre-load memory view for a proposed GPU set.
+type LoadEstimate struct {
+	ModelSize     uint64
+	ContextLength int
+	Available     uint64
+	GPUFree       uint64
+	Overhead      uint64
+	HasGPU        bool
+}
+
+func (e LoadEstimate) Fits() bool {
+	return !e.HasGPU || e.ModelSize <= e.Available
+}
+
+// EstimateMemory returns the tensor memory recorded in the MLX manifest.
+func EstimateMemory(modelName string) (uint64, error) {
+	modelManifest, err := manifest.LoadManifest(modelName)
+	if err != nil {
+		return 0, err
+	}
+	return uint64(modelManifest.TotalTensorSize()), nil
+}
+
+// EstimateLoad returns MLX's current best pre-load memory estimate.
+func EstimateLoad(modelName string, gpus []ml.DeviceInfo) (LoadEstimate, error) {
+	modelSize, contextLength, err := estimateModelMetadata(modelName)
+	if err != nil {
+		return LoadEstimate{}, err
+	}
+	return estimateLoadMemory(modelSize, contextLength, gpus), nil
+}
+
+func estimateModelMetadata(modelName string) (uint64, int, error) {
+	modelManifest, err := manifest.LoadManifest(modelName)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	model, err := base.New(&mlxmodel.Root{Manifest: modelManifest})
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return uint64(modelManifest.TotalTensorSize()), model.MaxContextLength(), nil
+}
+
+func estimateLoadMemory(modelSize uint64, contextLength int, gpus []ml.DeviceInfo) LoadEstimate {
+	estimate := LoadEstimate{ModelSize: modelSize, ContextLength: contextLength}
+	if len(gpus) == 0 {
+		return estimate
+	}
+
+	estimate.HasGPU = true
+	estimate.GPUFree = gpus[0].FreeMemory
+	estimate.Overhead = gpus[0].MinimumMemory() + envconfig.GpuOverhead()
+	if estimate.GPUFree > estimate.Overhead {
+		estimate.Available = estimate.GPUFree - estimate.Overhead
+	}
+	return estimate
 }
 
 // WaitUntilRunning waits for the subprocess to be ready.
@@ -264,23 +334,13 @@ func (c *Client) HasExited() bool {
 
 // Load checks whether the model fits in GPU memory and starts the subprocess.
 func (c *Client) Load(ctx context.Context, _ ml.SystemInfo, gpus []ml.DeviceInfo, requireFull bool) ([]ml.DeviceID, error) {
-	if len(gpus) > 0 {
-		modelSize := c.memory.Load()
-		// We currently only use the first GPU with MLX
-		available := gpus[0].FreeMemory
-		overhead := gpus[0].MinimumMemory() + envconfig.GpuOverhead()
-		if available > overhead {
-			available -= overhead
-		} else {
-			available = 0
+	gpuIDs := mlxGPUIDs(gpus)
+	estimate := estimateLoadMemory(c.memory.Load(), 0, gpus)
+	if estimate.HasGPU && !estimate.Fits() {
+		if requireFull {
+			return nil, llm.ErrLoadRequiredFull
 		}
-
-		if modelSize > available {
-			if requireFull {
-				return nil, llm.ErrLoadRequiredFull
-			}
-			return nil, fmt.Errorf("model requires %s but only %s are available (after %s overhead)", format.HumanBytes2(modelSize), format.HumanBytes2(available), format.HumanBytes2(overhead))
-		}
+		return nil, fmt.Errorf("model requires %s but only %s are available (after %s overhead)", format.HumanBytes2(estimate.ModelSize), format.HumanBytes2(estimate.Available), format.HumanBytes2(estimate.Overhead))
 	}
 
 	// Find a free port
@@ -364,8 +424,6 @@ func (c *Client) Load(ctx context.Context, _ ml.SystemInfo, gpus []ml.DeviceInfo
 		}
 	}
 
-	c.cmd = cmd
-
 	status := llm.NewStatusWriter(os.Stderr)
 	c.status = status
 	// os/exec serializes Write calls when shared, which keeps the status writer
@@ -378,13 +436,25 @@ func (c *Client) Load(ctx context.Context, _ ml.SystemInfo, gpus []ml.DeviceInfo
 		return nil, fmt.Errorf("failed to start mlx runner: %w", err)
 	}
 
+	c.mu.Lock()
+	c.cmd = cmd
+	c.gpus = gpuIDs
+	c.mu.Unlock()
+
 	// Reap subprocess when it exits
 	go func() {
 		c.doneErr = cmd.Wait()
 		close(c.done)
 	}()
 
-	return nil, nil
+	return gpuIDs, nil
+}
+
+func mlxGPUIDs(gpus []ml.DeviceInfo) []ml.DeviceID {
+	if len(gpus) == 0 {
+		return nil
+	}
+	return []ml.DeviceID{gpus[0].DeviceID}
 }
 
 // ModelPath implements llm.LlamaServer.
@@ -474,6 +544,12 @@ func (c *Client) MemorySize() (total, vram uint64) {
 
 // VRAMByGPU implements llm.LlamaServer.
 func (c *Client) VRAMByGPU(id ml.DeviceID) uint64 {
+	c.mu.Lock()
+	loaded := slices.Contains(c.gpus, id)
+	c.mu.Unlock()
+	if !loaded {
+		return 0
+	}
 	return c.currentMemory()
 }
 

--- a/x/mlxrunner/client.go
+++ b/x/mlxrunner/client.go
@@ -15,6 +15,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -27,6 +28,8 @@ import (
 	"github.com/ollama/ollama/llm"
 	"github.com/ollama/ollama/ml"
 	"github.com/ollama/ollama/x/imagegen/manifest"
+	mlxmodel "github.com/ollama/ollama/x/mlxrunner/model"
+	"github.com/ollama/ollama/x/mlxrunner/model/base"
 )
 
 // Client wraps an MLX runner subprocess to implement llm.LlamaServer for LLM models.
@@ -42,12 +45,13 @@ type Client struct {
 	status            *llm.StatusWriter
 	mu                sync.Mutex
 	cmd               *exec.Cmd
+	gpus              []ml.DeviceID
 }
 
 // NewClient prepares a new MLX runner client for LLM models.
 // The subprocess is not started until Load() is called.
 func NewClient(modelName string, softContextLength int) (*Client, error) {
-	if err := checkPlatformSupport(); err != nil {
+	if err := CheckPlatformSupport(); err != nil {
 		return nil, err
 	}
 
@@ -58,16 +62,17 @@ func NewClient(modelName string, softContextLength int) (*Client, error) {
 		client:            http.DefaultClient,
 	}
 
-	modelManifest, err := manifest.LoadManifest(modelName)
+	memory, err := EstimateMemory(modelName)
 	if err != nil {
 		return nil, err
 	}
-	c.memory.Store(uint64(modelManifest.TotalTensorSize()))
+	c.memory.Store(memory)
 
 	return c, nil
 }
 
-func checkPlatformSupport() error {
+// CheckPlatformSupport reports whether the local platform can run MLX models.
+func CheckPlatformSupport() error {
 	switch runtime.GOOS {
 	case "darwin":
 		if runtime.GOARCH != "arm64" {
@@ -79,6 +84,67 @@ func checkPlatformSupport() error {
 	default:
 		return fmt.Errorf("MLX is not supported on %s", runtime.GOOS)
 	}
+}
+
+// LoadEstimate is MLX's current pre-load memory view for a proposed GPU set.
+type LoadEstimate struct {
+	ModelSize     uint64
+	ContextLength int
+	Available     uint64
+	GPUFree       uint64
+	Overhead      uint64
+	HasGPU        bool
+}
+
+func (e LoadEstimate) Fits() bool {
+	return !e.HasGPU || e.ModelSize <= e.Available
+}
+
+// EstimateMemory returns the tensor memory recorded in the MLX manifest.
+func EstimateMemory(modelName string) (uint64, error) {
+	modelManifest, err := manifest.LoadManifest(modelName)
+	if err != nil {
+		return 0, err
+	}
+	return uint64(modelManifest.TotalTensorSize()), nil
+}
+
+// EstimateLoad returns MLX's current best pre-load memory estimate.
+func EstimateLoad(modelName string, gpus []ml.DeviceInfo) (LoadEstimate, error) {
+	modelSize, contextLength, err := estimateModelMetadata(modelName)
+	if err != nil {
+		return LoadEstimate{}, err
+	}
+	return estimateLoadMemory(modelSize, contextLength, gpus), nil
+}
+
+func estimateModelMetadata(modelName string) (uint64, int, error) {
+	modelManifest, err := manifest.LoadManifest(modelName)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	model, err := base.New(&mlxmodel.Root{Manifest: modelManifest})
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return uint64(modelManifest.TotalTensorSize()), model.MaxContextLength(), nil
+}
+
+func estimateLoadMemory(modelSize uint64, contextLength int, gpus []ml.DeviceInfo) LoadEstimate {
+	estimate := LoadEstimate{ModelSize: modelSize, ContextLength: contextLength}
+	if len(gpus) == 0 {
+		return estimate
+	}
+
+	estimate.HasGPU = true
+	estimate.GPUFree = gpus[0].FreeMemory
+	estimate.Overhead = gpus[0].MinimumMemory() + envconfig.GpuOverhead()
+	if estimate.GPUFree > estimate.Overhead {
+		estimate.Available = estimate.GPUFree - estimate.Overhead
+	}
+	return estimate
 }
 
 // WaitUntilRunning waits for the subprocess to be ready.
@@ -279,23 +345,13 @@ func (c *Client) HasExited() bool {
 
 // Load checks whether the model fits in GPU memory and starts the subprocess.
 func (c *Client) Load(ctx context.Context, _ ml.SystemInfo, gpus []ml.DeviceInfo, requireFull bool) ([]ml.DeviceID, error) {
-	if len(gpus) > 0 {
-		modelSize := c.memory.Load()
-		// We currently only use the first GPU with MLX
-		available := gpus[0].FreeMemory
-		overhead := gpus[0].MinimumMemory() + envconfig.GpuOverhead()
-		if available > overhead {
-			available -= overhead
-		} else {
-			available = 0
+	gpuIDs := mlxGPUIDs(gpus)
+	estimate := estimateLoadMemory(c.memory.Load(), 0, gpus)
+	if estimate.HasGPU && !estimate.Fits() {
+		if requireFull {
+			return nil, llm.ErrLoadRequiredFull
 		}
-
-		if modelSize > available {
-			if requireFull {
-				return nil, llm.ErrLoadRequiredFull
-			}
-			return nil, fmt.Errorf("model requires %s but only %s are available (after %s overhead)", format.HumanBytes2(modelSize), format.HumanBytes2(available), format.HumanBytes2(overhead))
-		}
+		return nil, fmt.Errorf("model requires %s but only %s are available (after %s overhead)", format.HumanBytes2(estimate.ModelSize), format.HumanBytes2(estimate.Available), format.HumanBytes2(estimate.Overhead))
 	}
 
 	// Find a free port
@@ -379,8 +435,6 @@ func (c *Client) Load(ctx context.Context, _ ml.SystemInfo, gpus []ml.DeviceInfo
 		}
 	}
 
-	c.cmd = cmd
-
 	status := llm.NewStatusWriter(os.Stderr)
 	c.status = status
 	// os/exec serializes Write calls when shared, which keeps the status writer
@@ -393,13 +447,25 @@ func (c *Client) Load(ctx context.Context, _ ml.SystemInfo, gpus []ml.DeviceInfo
 		return nil, fmt.Errorf("failed to start mlx runner: %w", err)
 	}
 
+	c.mu.Lock()
+	c.cmd = cmd
+	c.gpus = gpuIDs
+	c.mu.Unlock()
+
 	// Reap subprocess when it exits
 	go func() {
 		c.doneErr = cmd.Wait()
 		close(c.done)
 	}()
 
-	return nil, nil
+	return gpuIDs, nil
+}
+
+func mlxGPUIDs(gpus []ml.DeviceInfo) []ml.DeviceID {
+	if len(gpus) == 0 {
+		return nil
+	}
+	return []ml.DeviceID{gpus[0].DeviceID}
 }
 
 // ModelPath implements llm.LlamaServer.
@@ -489,6 +555,12 @@ func (c *Client) MemorySize() (total, vram uint64) {
 
 // VRAMByGPU implements llm.LlamaServer.
 func (c *Client) VRAMByGPU(id ml.DeviceID) uint64 {
+	c.mu.Lock()
+	loaded := slices.Contains(c.gpus, id)
+	c.mu.Unlock()
+	if !loaded {
+		return 0
+	}
 	return c.currentMemory()
 }
 

--- a/x/mlxrunner/client_test.go
+++ b/x/mlxrunner/client_test.go
@@ -1,0 +1,61 @@
+package mlxrunner
+
+import (
+	"testing"
+
+	"github.com/ollama/ollama/format"
+	"github.com/ollama/ollama/ml"
+)
+
+func TestMLXGPUIDsUsesFirstDevice(t *testing.T) {
+	gpus := []ml.DeviceInfo{
+		{DeviceID: ml.DeviceID{ID: "0", Library: "Metal"}},
+		{DeviceID: ml.DeviceID{ID: "1", Library: "Metal"}},
+	}
+
+	got := mlxGPUIDs(gpus)
+	if len(got) != 1 || got[0] != gpus[0].DeviceID {
+		t.Fatalf("mlxGPUIDs() = %#v, want first GPU %v", got, gpus[0].DeviceID)
+	}
+}
+
+func TestMLXGPUIDsNoDevices(t *testing.T) {
+	if got := mlxGPUIDs(nil); len(got) != 0 {
+		t.Fatalf("mlxGPUIDs(nil) = %#v, want no devices", got)
+	}
+}
+
+func TestEstimateLoadMemoryUsesFirstDevice(t *testing.T) {
+	gpus := []ml.DeviceInfo{
+		{DeviceID: ml.DeviceID{ID: "0", Library: "Metal"}, FreeMemory: 8 * format.GibiByte},
+		{DeviceID: ml.DeviceID{ID: "1", Library: "Metal"}, FreeMemory: 64 * format.GibiByte},
+	}
+
+	estimate := estimateLoadMemory(7*format.GibiByte, 32768, gpus)
+	if !estimate.HasGPU {
+		t.Fatal("estimate.HasGPU = false, want true")
+	}
+	if estimate.ContextLength != 32768 {
+		t.Fatalf("estimate.ContextLength = %d, want 32768", estimate.ContextLength)
+	}
+	if !estimate.Fits() {
+		t.Fatal("estimate.Fits() = false, want true")
+	}
+	if estimate.GPUFree != gpus[0].FreeMemory {
+		t.Fatalf("estimate.GPUFree = %d, want %d", estimate.GPUFree, gpus[0].FreeMemory)
+	}
+	if estimate.Available >= gpus[1].FreeMemory {
+		t.Fatalf("estimate.Available = %d, want first GPU availability", estimate.Available)
+	}
+}
+
+func TestEstimateLoadMemoryDetectsOversize(t *testing.T) {
+	gpus := []ml.DeviceInfo{
+		{DeviceID: ml.DeviceID{ID: "0", Library: "Metal"}, FreeMemory: 8 * format.GibiByte},
+	}
+
+	estimate := estimateLoadMemory(9*format.GibiByte, 0, gpus)
+	if estimate.Fits() {
+		t.Fatal("estimate.Fits() = true, want false")
+	}
+}

--- a/x/mlxrunner/mlx/doc.go
+++ b/x/mlxrunner/mlx/doc.go
@@ -1,0 +1,14 @@
+// Package mlx wraps the MLX C API.
+//
+// # Threading contract
+//
+// MLX default streams are thread-local: an array records the default stream of
+// the thread that created it and can only be evaluated on that thread.
+// Cross-thread evaluation can panic with "There is no Stream(gpu, N) in current
+// thread".
+//
+// Callers must therefore do MLX work from a single pinned goroutine per
+// component. Production uses x/internal/mlxthread for inference and tests use
+// x/internal/mlxtest. DefaultStream resolves per thread. To pass arrays across
+// threads, evaluate them first.
+package mlx

--- a/x/mlxrunner/mlx/stream.go
+++ b/x/mlxrunner/mlx/stream.go
@@ -3,7 +3,10 @@ package mlx
 // #include "generated.h"
 import "C"
 
-import "log/slog"
+import (
+	"log/slog"
+	"sync"
+)
 
 type Device struct {
 	ctx C.mlx_device
@@ -17,18 +20,26 @@ func (d Device) LogValue() slog.Value {
 }
 
 var (
+	defaultDeviceMu  sync.Mutex
 	defaultDevice    Device
 	defaultDeviceSet bool
-	defaultStream    Stream
-	defaultStreamSet bool
+	defaultStreams   sync.Map // map[uint64]Stream, keyed by thread ID
 )
 
 func resetDefaultStreamCache() {
+	defaultDeviceMu.Lock()
 	defaultDeviceSet = false
-	defaultStreamSet = false
+	defaultDeviceMu.Unlock()
+	defaultStreams.Range(func(k, _ any) bool {
+		defaultStreams.Delete(k)
+		return true
+	})
 }
 
 func DefaultDevice() Device {
+	defaultDeviceMu.Lock()
+	defer defaultDeviceMu.Unlock()
+
 	if !defaultDeviceSet {
 		d := C.mlx_device_new()
 		C.mlx_get_default_device(&d)
@@ -68,12 +79,15 @@ func (s Stream) LogValue() slog.Value {
 }
 
 func DefaultStream() Stream {
-	if !defaultStreamSet {
-		s := C.mlx_stream_new()
-		C.mlx_get_default_stream(&s, DefaultDevice().ctx)
-		defaultStream = Stream{s}
-		defaultStreamSet = true
+	tid := currentThreadID()
+	if s, ok := defaultStreams.Load(tid); ok {
+		return s.(Stream)
 	}
 
-	return defaultStream
+	dev := DefaultDevice()
+	s := C.mlx_stream_new()
+	C.mlx_get_default_stream(&s, dev.ctx)
+	stream := Stream{s}
+	defaultStreams.Store(tid, stream)
+	return stream
 }

--- a/x/mlxrunner/mlx/stream_tid_darwin.go
+++ b/x/mlxrunner/mlx/stream_tid_darwin.go
@@ -1,0 +1,12 @@
+//go:build darwin
+
+package mlx
+
+import "syscall"
+
+// currentThreadID returns the current kernel thread ID, used as the cache key
+// for the thread-local default stream.
+func currentThreadID() uint64 {
+	id, _, _ := syscall.RawSyscall(syscall.SYS_THREAD_SELFID, 0, 0, 0)
+	return uint64(id)
+}

--- a/x/mlxrunner/mlx/stream_tid_linux.go
+++ b/x/mlxrunner/mlx/stream_tid_linux.go
@@ -1,0 +1,12 @@
+//go:build linux
+
+package mlx
+
+import "syscall"
+
+// currentThreadID returns the current kernel thread ID, used as the cache key
+// for the thread-local default stream.
+func currentThreadID() uint64 {
+	id, _, _ := syscall.RawSyscall(syscall.SYS_GETTID, 0, 0, 0)
+	return uint64(id)
+}

--- a/x/mlxrunner/mlx/stream_tid_windows.go
+++ b/x/mlxrunner/mlx/stream_tid_windows.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package mlx
+
+import "golang.org/x/sys/windows"
+
+// currentThreadID returns the current kernel thread ID, used as the cache key
+// for the thread-local default stream.
+func currentThreadID() uint64 {
+	return uint64(windows.GetCurrentThreadId())
+}


### PR DESCRIPTION
The llama-server migration left backend-specific memory policy split across scheduler preflight, request option setup, and runner startup. That made Ollama compare slightly different estimates at different points in the load path, and the iGPU/mmproj fix in #16996 exposed the weakness: Ollama synthesized extra LLAMA_ARG_FIT_TARGET padding for projectors even though current llama-server fit accounts for mmproj memory. On discrete GPUs near the VRAM limit, that padding could push text layers to CPU and turn a model that previously fit into a very slow partial offload.

Move llama-server and MLX load preparation behind small load-plan types. The scheduler still owns scheduling, eviction, and retry decisions, while each backend now builds one memory assessment and applies request/load options from that same assessment.

For llama-server, keep placement, mmap defaults, automatic context/batch sizing, memory logging, and retry policy together. Remove the synthetic projector fit target padding, retry projector GPU-offload OOMs inside the runner, retry load OOMs once with a smaller automatic context or after evicting resident models, and retry if a load succeeds only by spilling text layers to CPU while other models are still resident. MLX gets the same scheduler-facing shape without pretending it has llama-server's startup retry behavior.

This fixes the 0.31.2 vision-model regression caused by the #16996 overshoot while preserving the original iGPU/mmproj protections.

Fixes #17099
Fixes #17089
Fixes #16599 