### PR TITLE
docs: add Cursor integration for Ollama.com cloud models

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -164,6 +164,7 @@
             "expanded": true,
             "pages": [
               "/integrations/vscode",
+              "/integrations/cursor",
               "/integrations/cline",
               "/integrations/jetbrains",
               "/integrations/roo-code",

--- a/docs/integrations/cursor.mdx
+++ b/docs/integrations/cursor.mdx
@@ -1,0 +1,55 @@
+---
+title: Cursor
+---
+
+Use Ollama.com models in Cursor without installing or running Ollama locally.
+
+## Connect Cursor to Ollama.com
+
+You need an Ollama.com account and an [Ollama API key](https://ollama.com/settings/keys). This is a direct API connection: `ollama signin` and a local Ollama server are not required.
+
+1. In Cursor, open **Settings** > **Models**.
+2. In the **OpenAI API Key** section, enter your Ollama API key.
+3. Enable **Override OpenAI Base URL** and set the base URL to:
+
+   ```
+   https://ollama.com/v1
+   ```
+
+4. Add a custom model using an Ollama.com cloud model ID, then select it from Cursor's model picker.
+
+For the direct Ollama.com API, use the model ID shown for that cloud model. Do not use the `:cloud` suffix used when a local Ollama installation forwards a request to the cloud. For example, use `qwen3-coder:480b`, not `qwen3-coder:480b-cloud`.
+
+Browse available [cloud models](https://ollama.com/search?c=cloud). Models that Cursor uses for agent work should support [tool calling](/capabilities/tool-calling).
+
+## What this connects to
+
+- **This page:** Cursor sends OpenAI-compatible requests directly to Ollama.com using your Ollama API key.
+- **Local Ollama:** Use `http://localhost:11434/v1` only when Ollama is installed and running on your computer. It can run local models and can forward `:cloud` models after you sign in. See [Cloud](/cloud).
+- **Ollama VS Code extension:** This is a separate integration for VS Code and Copilot Chat. See [VS Code](/integrations/vscode).
+
+This uses Cursor's OpenAI custom-base-URL setting, rather than a native Ollama provider. Turn off the override when you want Cursor to use its normal OpenAI route again.
+
+## Troubleshooting
+
+### Unauthorized or invalid API key
+
+Create a new key in [Ollama API keys](https://ollama.com/settings/keys) and paste that key into Cursor's **OpenAI API Key** field. An Ollama sign-in session or a local API key is not a replacement for an Ollama.com API key.
+
+### Model not found
+
+Use the exact direct API model ID from the [cloud model catalog](https://ollama.com/search?c=cloud). Remove `:cloud`; that suffix is for requests through local Ollama, not direct requests to Ollama.com.
+
+### Endpoint or connection error
+
+Set the base URL to exactly `https://ollama.com/v1`. Do not use `https://ollama.com/api`, which is Ollama's native API base URL rather than its OpenAI-compatible base URL.
+
+### Requests work locally but not in Cursor
+
+Verify the model supports tool calling, then try a new Cursor chat after selecting the custom model. For the API contract and supported OpenAI-compatible features, see [OpenAI compatibility](/api/openai-compatibility).
+
+## Related
+
+- [Cloud API access](/cloud#cloud-api-access)
+- [API authentication](/api/authentication)
+- [OpenAI compatibility](/api/openai-compatibility)

--- a/docs/integrations/cursor.mdx
+++ b/docs/integrations/cursor.mdx
@@ -6,7 +6,7 @@ Use Ollama.com models in Cursor without installing or running Ollama locally.
 
 ## Connect Cursor to Ollama.com
 
-You need an Ollama.com account and an [Ollama API key](https://ollama.com/settings/keys). This is a direct API connection: `ollama signin` and a local Ollama server are not required.
+You need an Ollama.com account and an [Ollama API key](https://ollama.com/settings/keys).
 
 1. In Cursor, open **Settings** > **Models**.
 2. In the **OpenAI API Key** section, enter your Ollama API key.
@@ -16,37 +16,9 @@ You need an Ollama.com account and an [Ollama API key](https://ollama.com/settin
    https://ollama.com/v1
    ```
 
-4. Add a custom model using an Ollama.com cloud model ID, then select it from Cursor's model picker.
+4. Add a model to use (e.g. glm-5.2:cloud), then select it from Cursor's model picker.
 
-For the direct Ollama.com API, use the model ID shown for that cloud model. Do not use the `:cloud` suffix used when a local Ollama installation forwards a request to the cloud. For example, use `qwen3-coder:480b`, not `qwen3-coder:480b-cloud`.
-
-Browse available [cloud models](https://ollama.com/search?c=cloud). Models that Cursor uses for agent work should support [tool calling](/capabilities/tool-calling).
-
-## What this connects to
-
-- **This page:** Cursor sends OpenAI-compatible requests directly to Ollama.com using your Ollama API key.
-- **Local Ollama:** Use `http://localhost:11434/v1` only when Ollama is installed and running on your computer. It can run local models and can forward `:cloud` models after you sign in. See [Cloud](/cloud).
-- **Ollama VS Code extension:** This is a separate integration for VS Code and Copilot Chat. See [VS Code](/integrations/vscode).
-
-This uses Cursor's OpenAI custom-base-URL setting, rather than a native Ollama provider. Turn off the override when you want Cursor to use its normal OpenAI route again.
-
-## Troubleshooting
-
-### Unauthorized or invalid API key
-
-Create a new key in [Ollama API keys](https://ollama.com/settings/keys) and paste that key into Cursor's **OpenAI API Key** field. An Ollama sign-in session or a local API key is not a replacement for an Ollama.com API key.
-
-### Model not found
-
-Use the exact direct API model ID from the [cloud model catalog](https://ollama.com/search?c=cloud). Remove `:cloud`; that suffix is for requests through local Ollama, not direct requests to Ollama.com.
-
-### Endpoint or connection error
-
-Set the base URL to exactly `https://ollama.com/v1`. Do not use `https://ollama.com/api`, which is Ollama's native API base URL rather than its OpenAI-compatible base URL.
-
-### Requests work locally but not in Cursor
-
-Verify the model supports tool calling, then try a new Cursor chat after selecting the custom model. For the API contract and supported OpenAI-compatible features, see [OpenAI compatibility](/api/openai-compatibility).
+Browse available [cloud models](https://ollama.com/search?c=cloud). 
 
 ## Related
 

--- a/docs/integrations/index.mdx
+++ b/docs/integrations/index.mdx
@@ -38,6 +38,10 @@ Assistants with memory, skills, and messaging app access.
 Use Ollama models inside your editor.
 
 <CardGroup cols={2}>
+  <Card title="Cursor" icon="cursor-arrow-rays" href="/integrations/cursor">
+    Use Ollama.com models directly with Cursor's OpenAI-compatible settings.
+  </Card>
+
   <Card title="VS Code" icon="/images/launch-icons/vscode.svg" href="/integrations/vscode">
     Select Ollama models from the Copilot Chat model picker in VS Code.
   </Card>


### PR DESCRIPTION
## Summary
Adds a new Cursor integration doc page for connecting Cursor directly to Ollama.com cloud models (no local Ollama server required).

- New page: `docs/integrations/cursor.mdx`
- Nav entry in `docs/docs.json`
- Card in `docs/integrations/index.mdx`

## Notes
- Covers direct Ollama.com API setup via Cursor's OpenAI-compatible custom base URL (`https://ollama.com/v1`) and an Ollama API key.
- Documents the `model-id` vs `:cloud` suffix distinction for direct vs local-forwarded requests.
- Troubleshooting section for auth, model-not-found, endpoint, and local-vs-Cursor issues.

## TODO / open questions
- [ ] Card icon: `cursor-arrow-rays` is not an SVG-path icon like the other cards. Need to add `images/launch-icons/cursor.svg` or confirm a valid built-in Mintlify icon name.
