### PR TITLE
agent/tools: surface actionable web auth error

### DIFF
--- a/agent/tools/web.go
+++ b/agent/tools/web.go
@@ -13,16 +13,13 @@ import (
 	internalcloud "github.com/ollama/ollama/internal/cloud"
 )
 
-var (
-	ErrWebSearchAuthRequired = errors.New("web search requires authentication")
-	ErrWebFetchAuthRequired  = errors.New("web fetch requires authentication")
-)
-
 const (
 	maxWebFetchContentRunes = 60_000
 	webSearchTimeout        = 15 * time.Second
 	webFetchTimeout         = 30 * time.Second
 )
+
+var ErrWebAuthRequired = errors.New("Not authenticated. Run `ollama signin` and try again.")
 
 type WebSearch struct{}
 
@@ -76,7 +73,7 @@ func (w *WebSearch) Execute(ctx context.Context, _ agent.ToolContext, args map[s
 	if err != nil {
 		var authErr api.AuthorizationError
 		if errors.As(err, &authErr) {
-			return agent.ToolResult{}, fmt.Errorf("%w: %s", ErrWebSearchAuthRequired, authErr)
+			return agent.ToolResult{}, ErrWebAuthRequired
 		}
 		return agent.ToolResult{}, err
 	}
@@ -160,7 +157,7 @@ func (w *WebFetch) Execute(ctx context.Context, _ agent.ToolContext, args map[st
 	if err != nil {
 		var authErr api.AuthorizationError
 		if errors.As(err, &authErr) {
-			return agent.ToolResult{}, fmt.Errorf("%w: %s", ErrWebFetchAuthRequired, authErr)
+			return agent.ToolResult{}, ErrWebAuthRequired
 		}
 		return agent.ToolResult{}, err
 	}

--- a/agent/tools/web_test.go
+++ b/agent/tools/web_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -17,6 +18,61 @@ func TestWebToolsRequireApproval(t *testing.T) {
 	}
 	if !coreagent.ToolRequiresApproval((&WebFetch{}), map[string]any{"url": "https://ollama.com"}) {
 		t.Fatal("web fetch should require approval")
+	}
+}
+
+var webToolCases = []struct {
+	name string
+	tool coreagent.Tool
+	args map[string]any
+	path string
+}{
+	{"search", &WebSearch{}, map[string]any{"query": "ollama"}, "/api/experimental/web_search"},
+	{"fetch", &WebFetch{}, map[string]any{"url": "https://ollama.com"}, "/api/experimental/web_fetch"},
+}
+
+// runWebTool executes tool against a stub server that responds to every
+// request with status and body, returning the resulting error.
+func runWebTool(t *testing.T, tool coreagent.Tool, args map[string]any, path string, status int, body string) error {
+	t.Helper()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != path {
+			t.Fatalf("path = %q, want %q", r.URL.Path, path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(ts.Close)
+	t.Setenv("OLLAMA_HOST", ts.URL)
+	_, err := tool.Execute(t.Context(), coreagent.ToolContext{}, args)
+	return err
+}
+
+func TestWebToolsReportAuthenticationError(t *testing.T) {
+	for _, tt := range webToolCases {
+		t.Run(tt.name, func(t *testing.T) {
+			err := runWebTool(t, tt.tool, tt.args, tt.path, http.StatusUnauthorized,
+				`{"error":"unauthorized","signin_url":"https://ollama.com/signin"}`)
+			if !errors.Is(err, ErrWebAuthRequired) {
+				t.Fatalf("error = %v, want %v", err, ErrWebAuthRequired)
+			}
+		})
+	}
+}
+
+func TestWebToolsPreserveNonAuthenticationErrors(t *testing.T) {
+	for _, tt := range webToolCases {
+		t.Run(tt.name, func(t *testing.T) {
+			err := runWebTool(t, tt.tool, tt.args, tt.path, http.StatusTooManyRequests,
+				`{"error":"web search quota exceeded"}`)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), "web search quota exceeded") {
+				t.Fatalf("error = %q, want original error message", err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
When `web_search` or `web_fetch` hit a 401, they previously surfaced a generic "web search requires authentication" / "web fetch requires authentication" message wrapped with the underlying `api.AuthorizationError` text — which only contained the HTTP status (e.g. "401 Unauthorized") and gave the agent no usable guidance.

This replaces the two per-tool auth sentinels with a single shared `ErrWebAuthRequired` carrying an actionable message:

> Not authenticated. Run `ollama signin` and try again.

The underlying `AuthorizationError` text is no longer appended, since its `Error()` returns HTTP status text rather than anything actionable (the `signin_url` is not surfaced; that guidance lives in the CLI's `handleCloudAuthorizationError` for interactive use).

## Changes

- `agent/tools/web.go`: merge `ErrWebSearchAuthRequired` / `ErrWebFetchAuthRequired` into a single `ErrWebAuthRequired`; return it directly from both tools' auth-error branches.
- `agent/tools/web_test.go`: add a shared `runWebTool` stub helper and `webToolCases` table, plus two lean table-driven tests:
  - `TestWebToolsReportAuthenticationError` — 401 stub, asserts both tools return `ErrWebAuthRequired` via `errors.Is`.
  - `TestWebToolsPreserveNonAuthenticationErrors` — 429 stub, asserts non-auth errors are preserved verbatim and not mislabeled as auth.

## Verification

- `go vet ./agent/tools/`
- `go test ./agent/tools/ -run Web -count=1 -race`

## Notes / open questions

- Dropped surfacing of `AuthorizationError.SigninURL`. Intentional for the agent-tool context (runs server-side without a TTY); flagging in case the signin URL should still be included in the message.