### PR TITLE
convert: guard gemma3n activation sparsity values before Quantile

### DIFF
--- a/convert/convert_gemma3n.go
+++ b/convert/convert_gemma3n.go
@@ -3,6 +3,7 @@ package convert
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"slices"
 	"strings"
 
@@ -74,7 +75,15 @@ func (m *gemma3nModel) KV(t *Tokenizer) KV {
 	kv["gemma3n.activation_sparsity_scale"] = slices.Collect(func(yield func(float32) bool) {
 		norm := distuv.Normal{Mu: 0, Sigma: 1}
 		for _, v := range m.TextModel.ActivationSparsityPattern {
-			if !yield(float32(norm.Quantile(float64(v)))) {
+			// activation_sparsity_pattern holds a per-layer sparsity fraction that
+			// must be in [0, 1]. distuv.Normal.Quantile panics outside that domain,
+			// so map an out-of-range value to NaN (matching the reference converter)
+			// rather than crashing model conversion.
+			scale := float32(math.NaN())
+			if v >= 0 && v <= 1 {
+				scale = float32(norm.Quantile(float64(v)))
+			}
+			if !yield(scale) {
 				break
 			}
 		}

--- a/convert/convert_gemma3n_test.go
+++ b/convert/convert_gemma3n_test.go
@@ -2,7 +2,10 @@ package convert
 
 import (
 	"encoding/json"
+	"math"
 	"testing"
+
+	"gonum.org/v1/gonum/stat/distuv"
 )
 
 func TestGemma3nIntermediateSize(t *testing.T) {
@@ -52,4 +55,48 @@ func TestGemma3nIntermediateSize(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGemma3nActivationSparsityScale(t *testing.T) {
+	tok := &Tokenizer{Vocabulary: &Vocabulary{}}
+
+	kvFor := func(pattern []float32) []float32 {
+		var m gemma3nModel
+		m.TextModel.ActivationSparsityPattern = pattern
+		scale, ok := m.KV(tok)["gemma3n.activation_sparsity_scale"].([]float32)
+		if !ok {
+			t.Fatalf("gemma3n.activation_sparsity_scale is not a []float32")
+		}
+		return scale
+	}
+
+	t.Run("in range", func(t *testing.T) {
+		// 0.0 and 1.0 map to the -Inf/+Inf boundaries and 0.95 to the standard
+		// normal quantile; guard the values that a valid config actually uses.
+		got := kvFor([]float32{0.0, 0.95, 1.0})
+		if len(got) != 3 {
+			t.Fatalf("got %d scales, want 3", len(got))
+		}
+		if !math.IsInf(float64(got[0]), -1) {
+			t.Errorf("scale for 0.0 = %v, want -Inf", got[0])
+		}
+		if want := float32(distuv.Normal{Mu: 0, Sigma: 1}.Quantile(float64(float32(0.95)))); got[1] != want {
+			t.Errorf("scale for 0.95 = %v, want %v", got[1], want)
+		}
+		if !math.IsInf(float64(got[2]), 1) {
+			t.Errorf("scale for 1.0 = %v, want +Inf", got[2])
+		}
+	})
+
+	t.Run("out of range does not panic", func(t *testing.T) {
+		// A value outside [0, 1] previously panicked distuv.Normal.Quantile and
+		// crashed conversion; it must now yield NaN instead.
+		got := kvFor([]float32{0.0, 0.95, 2.0})
+		if len(got) != 3 {
+			t.Fatalf("got %d scales, want 3", len(got))
+		}
+		if !math.IsNaN(float64(got[2])) {
+			t.Errorf("scale for 2.0 = %v, want NaN", got[2])
+		}
+	})
 }


### PR DESCRIPTION
```
`gemma3nModel.KV` builds the `gemma3n.activation_sparsity_scale` GGUF value by
mapping each entry of `activation_sparsity_pattern` (a `[]float32` read verbatim
from a model's `config.json`) through `distuv.Normal.Quantile`. That value is a
per-layer sparsity fraction that must be in `[0, 1]`, but the config value is
passed straight in with no range check.

gonum's `Normal.Quantile(p)` panics with `distuv: percentile out of bounds` for
any `p < 0` or `p > 1`
(https://github.com/gonum/gonum/blob/v0.15.0/stat/distuv/norm.go#L131-L135), so a
malformed or out-of-spec config, for example a corrupt export or a hand-edited
`config.json`, panics `ollama create`. `KV` is reached from `ConvertModel`
(`convert/convert.go`) with no `recover`, so the panic crashes model conversion.

This guards the value before the call: `Quantile` is only invoked for entries in
`[0, 1]`, and an out-of-range entry yields `NaN` instead. That matches the
reference converter (`convert_hf_to_gguf.py`), whose torch `icdf` returns `NaN`
for out-of-domain input rather than crashing. The in-range path, including the
existing `0.0 -> -Inf` and `1.0 -> +Inf` boundaries that a valid gemma3n config
relies on, is byte-identical to before.

Testing: added `TestGemma3nActivationSparsityScale` in
`convert/convert_gemma3n_test.go`. It asserts the in-range path (0.0, 0.95, 1.0)
still produces the same scales, and that an out-of-range value (2.0) now yields
`NaN` instead of panicking. Verified red -> green: reverting only the source
change makes the out-of-range subtest panic `distuv: percentile out of bounds`;
with the fix the whole `convert` package passes. `gofmt`, `go vet ./convert/...`,
and `go test ./convert/...` are clean.
```

## Verification commands (all pass locally as of this draft)
```
gofmt -l convert/                                                  # empty
go vet ./convert/...                                               # clean
go test ./convert/...                                              # ok
go test ./convert/ -run TestGemma3nActivationSparsityScale -v      # PASS (2 subtests)
```
