### PR TITLE
README: add PickySteve to community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ console.log(response.message.content);
 - [Stakpak](https://github.com/stakpak/agent) - Open source DevOps agent
 - [Hexabot](https://github.com/hexastack/hexabot) - Conversational AI builder
 - [Neuro SAN](https://github.com/cognizant-ai-lab/neuro-san-studio) - Multi-agent orchestration ([docs](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/user_guide.md#ollama))
+- [PickySteve](https://github.com/KernelLord/pickysteve) - Local-first skill router and context picker for coding agents, with prompt-injection scanning
 
 ### RAG & Knowledge Bases
 


### PR DESCRIPTION
Adds PickySteve to Community Integrations → Frameworks & Agents.

PickySteve is a local-first skill router and context picker for coding agents. It runs on Ollama natively (qwen3:8b by default, via the native /api/chat endpoint with think:false) — routing, reranking, and its prompt-injection gate all run locally with no cloud key. One line added to README.md only.

Disclosure: I am the project author; this PR was prepared by Claude (agent) on my behalf.