### PR TITLE
docs: Document the Ollama VS Code extension

### DIFF
--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -21,7 +21,6 @@ Configure and launch external applications to use Ollama models. This provides a
 - **OpenCode** - Open-source coding assistant
 - **Claude Code** - Anthropic's agentic coding tool
 - **Codex** - OpenAI's coding assistant
-- **VS Code** - Microsoft's IDE with built-in AI chat
 - **Droid** - Factory's AI coding agent
 
 #### Examples

--- a/docs/integrations/index.mdx
+++ b/docs/integrations/index.mdx
@@ -39,6 +39,6 @@ Use Ollama models inside your editor.
 
 <CardGroup cols={2}>
   <Card title="VS Code" icon="/images/launch-icons/vscode.svg" href="/integrations/vscode">
-    Select Ollama models from the Copilot Chat model picker in VS Code.
+    Use Ollama models in VS Code Chat.
   </Card>
 </CardGroup>

--- a/docs/integrations/vscode.mdx
+++ b/docs/integrations/vscode.mdx
@@ -2,84 +2,27 @@
 title: VS Code
 ---
 
-VS Code includes built-in AI chat through GitHub Copilot Chat. Ollama models can be used directly in the Copilot Chat model picker.
+Use Ollama models in VS Code Chat with the [Ollama extension](https://marketplace.visualstudio.com/items?itemName=Ollama.ollama).
 
+## Requirements
 
-![VS Code with Ollama](/images/vscode.png)
+- [Visual Studio Code 1.120 or newer](https://code.visualstudio.com/download)
+- Ollama installed and running
 
+## Get started
 
-## Prerequisites
+1. Install the [Ollama extension](https://marketplace.visualstudio.com/items?itemName=Ollama.ollama) from the VS Code Marketplace.
+2. Open Chat in VS Code.
+3. Open the model picker at the bottom of the chat input.
+4. Choose a model from the **Ollama** section.
 
-- Ollama v0.18.3+
-- [VS Code 1.113+](https://code.visualstudio.com/download)
-- [GitHub Copilot Chat extension 0.41.0+](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot-chat)
+The extension discovers models from `http://127.0.0.1:11434` by default.
 
-<Note> VS Code requires you to be logged in to use its model selector, even for custom models. This doesn't require a paid GitHub Copilot account; GitHub Copilot Free will enable model selection for custom models.</Note>
+## Troubleshooting
 
-## Quick setup
+If Ollama models do not appear in the model picker:
 
-```shell
-ollama launch vscode
-```
-
-Recommended models will be shown after running the command. See the latest models at [ollama.com](https://ollama.com/search?c=tools).
-
-Make sure **Local** is selected at the bottom of the Copilot Chat panel to use your Ollama models.
-<div style={{ display: "flex", justifyContent: "center" }}>
-  <img
-    src="/images/local.png"
-    alt="Ollama Local Models"
-    width="60%"
-    style={{ borderRadius: "4px", marginTop: "10px", marginBottom: "10px" }}
-  />
-</div>
-
-
-## Run directly with a model
-
-```shell
-ollama launch vscode --model qwen3.5:cloud
-```
-Cloud models are also available at [ollama.com](https://ollama.com/search?c=cloud).
-
-## Manual setup
-
-To configure Ollama manually without `ollama launch`:
-
-1. Open the **Copilot Chat** side bar from the top right corner
-   <div style={{ display: "flex", justifyContent: "center" }}>
-     <img
-       src="/images/vscode-sidebar.png"
-       alt="VS Code chat Sidebar"
-       width="75%"
-       style={{ borderRadius: "4px" }}
-     />
-   </div>
-2. Click the **settings gear icon** (<Icon icon="gear" />) to bring up the Language Models window
-   <div style={{ display: "flex", justifyContent: "center" }}>
-     <img
-       src="/images/vscode-other-models.png"
-       alt="VS Code model picker"
-       width="75%"
-       style={{ borderRadius: "4px" }}
-     />
-   </div>
-3. Click **Add Models** and select **Ollama** to load all your Ollama models into VS Code
-   <div style={{ display: "flex", justifyContent: "center" }}>
-     <img
-       src="/images/vscode-add-ollama.png"
-       alt="VS Code model options dropdown to add ollama models"
-       width="75%"
-       style={{ borderRadius: "4px" }}
-     />
-   </div>
-
-4. Click the **Unhide** button in the model picker to show your Ollama models  
-   <div style={{ display: "flex", justifyContent: "center" }}>
-     <img
-       src="/images/vscode-unhide.png"
-       alt="VS Code unhide models button"
-       width="75%"
-       style={{ borderRadius: "4px" }}
-     />
-   </div>
+1. Make sure Ollama is running.
+2. Run `ollama list` and confirm that models are available.
+3. Run **Ollama: Refresh Models** from the Command Palette.
+4. Run **Ollama: Diagnose Models** and check the **Ollama** output channel.


### PR DESCRIPTION
Summary:

- Replace legacy VS Code launcher instructions with the released Marketplace extension setup.
- Add a concise VS Code Chat onboarding flow and troubleshooting steps.
- Update the integrations overview to point users to VS Code Chat.
- Remove VS Code from documented ollama launch integrations until that flow is released.
