### PR TITLE
progress: fix Spinner data races and stop its ticker

### DIFF
--- a/progress/spinner.go
+++ b/progress/spinner.go
@@ -3,6 +3,7 @@ package progress
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 )
@@ -13,11 +14,15 @@ type Spinner struct {
 
 	parts []string
 
-	value int
+	mu      sync.Mutex
+	value   int
+	stopped time.Time
 
 	ticker  *time.Ticker
 	started time.Time
-	stopped time.Time
+
+	// done is closed by Stop to terminate the animation goroutine
+	done chan struct{}
 }
 
 func NewSpinner(message string) *Spinner {
@@ -26,6 +31,10 @@ func NewSpinner(message string) *Spinner {
 			"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏",
 		},
 		started: time.Now(),
+		// create the ticker before the animation goroutine exists so a Stop
+		// that arrives before the first tick still stops it
+		ticker: time.NewTicker(100 * time.Millisecond),
+		done:   make(chan struct{}),
 	}
 	s.SetMessage(message)
 	go s.start()
@@ -53,27 +62,36 @@ func (s *Spinner) String() string {
 		sb.WriteString(" ")
 	}
 
+	s.mu.Lock()
 	if s.stopped.IsZero() {
-		spinner := s.parts[s.value]
-		sb.WriteString(spinner)
+		sb.WriteString(s.parts[s.value])
 		sb.WriteString(" ")
 	}
+	s.mu.Unlock()
 
 	return sb.String()
 }
 
 func (s *Spinner) start() {
-	s.ticker = time.NewTicker(100 * time.Millisecond)
-	for range s.ticker.C {
-		s.value = (s.value + 1) % len(s.parts)
-		if !s.stopped.IsZero() {
+	for {
+		select {
+		case <-s.done:
 			return
+		case <-s.ticker.C:
+			s.mu.Lock()
+			s.value = (s.value + 1) % len(s.parts)
+			s.mu.Unlock()
 		}
 	}
 }
 
 func (s *Spinner) Stop() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	if s.stopped.IsZero() {
 		s.stopped = time.Now()
+		s.ticker.Stop()
+		close(s.done)
 	}
 }

--- a/progress/spinner_test.go
+++ b/progress/spinner_test.go
@@ -1,0 +1,191 @@
+package progress
+
+import (
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestSpinnerStopRace exercises the three goroutines that touch a Spinner
+// concurrently — the renderer (String), message updates (SetMessage), and
+// cancellation (Stop) — across several animation ticks so the value updates
+// in start() genuinely overlap the readers. Run with -race.
+func TestSpinnerStopRace(t *testing.T) {
+	for range 3 {
+		s := NewSpinner("test")
+		quit := make(chan struct{})
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-quit:
+					return
+				default:
+					_ = s.String()
+				}
+			}
+		}()
+
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-quit:
+					return
+				default:
+					s.SetMessage("updated")
+				}
+			}
+		}()
+
+		// span at least one 100ms animation tick so the goroutine's value
+		// writes overlap the String reads
+		time.Sleep(150 * time.Millisecond)
+		s.Stop()
+		close(quit)
+		wg.Wait()
+	}
+}
+
+// TestSpinnerConcurrentStop verifies concurrent Stop calls are safe: the
+// ticker must be stopped and the done channel closed exactly once.
+func TestSpinnerConcurrentStop(t *testing.T) {
+	for range 200 {
+		s := NewSpinner("test")
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			s.Stop()
+		}()
+		go func() {
+			defer wg.Done()
+			s.Stop()
+		}()
+		wg.Wait()
+	}
+}
+
+// TestSpinnerStopIdempotent verifies Stop can be called multiple times
+// sequentially without double-stopping the ticker or double-closing the done
+// channel.
+func TestSpinnerStopIdempotent(t *testing.T) {
+	s := NewSpinner("test")
+	s.Stop()
+	s.Stop()
+}
+
+// TestSpinnerStringAfterStop verifies a stopped spinner still shows its
+// message but no longer shows an animation frame.
+func TestSpinnerStringAfterStop(t *testing.T) {
+	s := NewSpinner("hello")
+
+	if got := s.String(); !strings.Contains(got, "hello") {
+		t.Errorf("running spinner should show its message, got %q", got)
+	}
+
+	s.Stop()
+
+	got := s.String()
+	if !strings.Contains(got, "hello") {
+		t.Errorf("stopped spinner should still show its message, got %q", got)
+	}
+	for _, part := range s.parts {
+		if strings.Contains(got, part) {
+			t.Errorf("stopped spinner still shows an animation frame: %q", got)
+		}
+	}
+}
+
+// TestSpinnerStopStopsTicker verifies Stop actually stops the ticker: no
+// tick may arrive after Stop returns. Before this fix ticker.Stop was never
+// called, so the ticker kept firing for the life of the process.
+func TestSpinnerStopStopsTicker(t *testing.T) {
+	s := NewSpinner("test")
+	time.Sleep(10 * time.Millisecond)
+	s.Stop()
+
+	// drain a tick that may already have been buffered when Stop ran
+	select {
+	case <-s.ticker.C:
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	select {
+	case <-s.ticker.C:
+		t.Fatal("ticker still firing after Stop")
+	case <-time.After(250 * time.Millisecond):
+	}
+}
+
+// TestSpinnerAdvancesFrames verifies the animation goroutine actually
+// advances through the frame glyphs while running.
+func TestSpinnerAdvancesFrames(t *testing.T) {
+	s := NewSpinner("")
+	defer s.Stop()
+
+	seen := make(map[string]bool)
+	deadline := time.Now().Add(2 * time.Second)
+	for len(seen) < 3 && time.Now().Before(deadline) {
+		if frame := strings.TrimSpace(s.String()); frame != "" {
+			seen[frame] = true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if len(seen) < 3 {
+		t.Fatalf("spinner did not advance through its frames: saw %d distinct frames", len(seen))
+	}
+}
+
+// TestSpinnerEmptyMessage verifies a spinner with no message renders just the
+// frame glyph.
+func TestSpinnerEmptyMessage(t *testing.T) {
+	s := NewSpinner("")
+	defer s.Stop()
+
+	if got, want := s.String(), s.parts[0]+" "; got != want {
+		t.Errorf("empty-message spinner: got %q, want %q", got, want)
+	}
+}
+
+// TestSpinnerMessageWidth verifies the message truncation and padding logic.
+func TestSpinnerMessageWidth(t *testing.T) {
+	long := NewSpinner("this is a long message")
+	defer long.Stop()
+	long.messageWidth = 10
+	if got, want := long.String(), "this is a "+" "+long.parts[0]+" "; got != want {
+		t.Errorf("truncated message: got %q, want %q", got, want)
+	}
+
+	short := NewSpinner("hi")
+	defer short.Stop()
+	short.messageWidth = 10
+	if got, want := short.String(), "hi"+strings.Repeat(" ", 8)+" "+short.parts[0]+" "; got != want {
+		t.Errorf("padded message: got %q, want %q", got, want)
+	}
+}
+
+// TestSpinnerStopReleasesGoroutine verifies the animation goroutine exits on
+// Stop instead of leaking for the process lifetime.
+func TestSpinnerStopReleasesGoroutine(t *testing.T) {
+	before := runtime.NumGoroutine()
+
+	for range 50 {
+		NewSpinner("test").Stop()
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for runtime.NumGoroutine() > before+2 {
+		if time.Now().After(deadline) {
+			t.Fatalf("spinner goroutines leaked: %d before, %d after", before, runtime.NumGoroutine())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
Fixes the `Spinner`-internal data races described in [this comment on #16271](https://github.com/ollama/ollama/issues/16271#issuecomment-4967035198). The open PRs on that issue (#16629 and siblings) all fix the `Progress` struct's fields in `progress/progress.go`; none of them touch `Spinner`'s own unsynchronized state in `progress/spinner.go`, so the package cannot become race-clean without this change.

## Root cause

`Spinner` keeps `message` in an `atomic.Value` but leaves three fields as plain state shared by three goroutines — the animation loop (`start()`), the renderer (`String()`, called from `Progress`'s render goroutine), and `Stop()` (called from any goroutine, including `Progress.stop`):

- `value` — written by `start()` (`spinner.go:68`), read by `String()` (`spinner.go:57`)
- `stopped` — a multi-word `time.Time`, written by `Stop()` (`spinner.go:77`), read by `start()` (`spinner.go:69`) and `String()` (`spinner.go:56`), so torn reads are possible
- `ticker` — assigned inside the goroutine (`spinner.go:66`) after `NewSpinner` has already returned

Reproduced on current main with the race detector: `String()` vs `Stop()` reports read at `spinner.go:56` / write at `spinner.go:77`.

Separately, nothing ever calls `ticker.Stop()`, so a stopped spinner's ticker keeps firing for as long as the spinner stays referenced.

## Fix

Mirrors the `Progress` lifecycle being established in #16629:

- guard `value` and `stopped` with a mutex; `message` stays on its existing `atomic.Value` path
- create the ticker in `NewSpinner`, before the animation goroutine exists, so it is assigned exactly once and an immediate `Stop` is safe
- `Stop` (idempotent, now safe to call concurrently) stops the ticker and closes a `done` channel; the animation goroutine exits promptly via `select` instead of up to 100ms later

No exported API changes; `String()` output is unchanged (message + frame while running, message only once stopped).

## Relationship to #16629

Complementary, not competing — either can merge first. #16629 fixes the `Progress`-level races; this fixes `Spinner`'s. They are both needed: on the #16629 branch, `go test -race -count=20 -run TestProgressAddThenStop ./progress/` still fails inside `spinner.go` even with the `Progress` fix applied.

## Tests

`progress/spinner_test.go` (new), all run with `-race`:

- `TestSpinnerStopRace` — `String`/`SetMessage` hammer across animation ticks racing `Stop` (fails on main with the race reports above)
- `TestSpinnerConcurrentStop` — two goroutines calling `Stop` (close-once/stop-once guard)
- `TestSpinnerStopIdempotent` — sequential double `Stop`
- `TestSpinnerStringAfterStop` — message still shown, no frame glyph after stop
- `TestSpinnerStopStopsTicker` — no tick arrives after `Stop` returns (fails on main: `ticker still firing after Stop`)
- `TestSpinnerStopReleasesGoroutine` — animation goroutine exits instead of leaking
- `TestSpinnerAdvancesFrames` / `TestSpinnerEmptyMessage` / `TestSpinnerMessageWidth` — rendering behavior (frame progression, exact output shape, truncation/padding)

```
go test -race -count=20 ./progress/   # passes with this change
```

<details>
<summary>Race detector evidence — before (current main + these tests) and after</summary>

Before, on current main with this PR's tests: `go test -race -run TestSpinnerStopRace ./progress/`

```
WARNING: DATA RACE
Write at 0x00c000188288 by goroutine 7:
  github.com/ollama/ollama/progress.(*Spinner).Stop()
      progress/spinner.go:77 +0x290
  github.com/ollama/ollama/progress.TestSpinnerStopRace()
      progress/spinner_test.go:50 +0x25c

Previous read at 0x00c000188288 by goroutine 28:
  github.com/ollama/ollama/progress.(*Spinner).String()
      progress/spinner.go:56 +0x458
  github.com/ollama/ollama/progress.TestSpinnerStopRace.func1()
      progress/spinner_test.go:30 +0x88
...
--- FAIL: TestSpinnerStopRace
FAIL	github.com/ollama/ollama/progress
```

Before, the ticker keeps firing after Stop (no `-race` needed): `go test -run TestSpinnerStopStopsTicker ./progress/`

```
--- FAIL: TestSpinnerStopStopsTicker (0.20s)
    spinner_test.go:123: ticker still firing after Stop
FAIL	github.com/ollama/ollama/progress	0.992s
```

After, on this branch:

```
$ go test -race -count=20 ./progress/
ok  	github.com/ollama/ollama/progress	23.781s
```

</details>

Review history: https://gist.github.com/anagnorisis2peripeteia/b07811dd02f461bd6cd7d5bd2f096e2e

| file | +/− |
|---|---|
| `progress/spinner.go` | +26/−8 |
| `progress/spinner_test.go` | +191/−0 (new) |

