### PR TITLE
model/parsers: classify assistant prefill by role

### DIFF
--- a/model/parsers/qwen35.go
+++ b/model/parsers/qwen35.go
@@ -63,7 +63,7 @@ func (p *Qwen35Parser) Init(tools []api.Tool, lastMessage *api.Message, thinkVal
 		thinkingEnabled = true
 	}
 
-	assistantPrefill := lastMessage != nil && lastMessage.Role == "assistant" && lastMessage.Content != ""
+	assistantPrefill := lastMessage != nil && lastMessage.Role == "assistant"
 	if thinkingEnabled && !assistantPrefill {
 		p.state = qwen35ParserStateCollectingThinking
 		p.allowLeadingThinkOpenTag = true

--- a/model/parsers/qwen35_test.go
+++ b/model/parsers/qwen35_test.go
@@ -108,6 +108,34 @@ func TestQwen35ParserAssistantPrefillStartsInContent(t *testing.T) {
 	}
 }
 
+func TestQwen35ParserAssistantThinkingOnlyPrefillStartsInContent(t *testing.T) {
+	for _, name := range []string{"qwen3.5", "ornith"} {
+		t.Run(name, func(t *testing.T) {
+			parser := ParserForName(name)
+			if parser == nil {
+				t.Fatalf("expected %s parser", name)
+			}
+
+			last := &api.Message{Role: "assistant", Thinking: "Keep it brief."}
+			parser.Init(nil, last, &api.ThinkValue{Value: true})
+
+			content, thinking, calls, err := parser.Add("Done.", true)
+			if err != nil {
+				t.Fatalf("parse failed: %v", err)
+			}
+			if content != "Done." {
+				t.Fatalf("expected content %q, got %q", "Done.", content)
+			}
+			if thinking != "" {
+				t.Fatalf("expected no thinking for assistant prefill continuation, got %q", thinking)
+			}
+			if len(calls) != 0 {
+				t.Fatalf("expected no tool calls, got %d", len(calls))
+			}
+		})
+	}
+}
+
 func TestQwen35ParserToolCallEmittedInThinkingIsParsed(t *testing.T) {
 	parser := ParserForName("qwen3.5")
 	if parser == nil {


### PR DESCRIPTION
## Summary

- Classify every trailing assistant message as a Qwen3.5/Ornith prefill.
- Preserve generated continuations after a thinking-only prefill as response content.
- Add regression coverage for both parser aliases.

## Root cause

The renderer leaves a trailing assistant turn open as a prefill even when it contains only thinking. The parser entered content mode only when that turn had nonempty content, so the visible continuation was emitted as thinking.

## Testing

- `go test ./model/parsers ./model/renderers -count=1`
- `go vet ./model/parsers ./model/renderers`
