### PR TITLE
CUDA error from the newest updates

### DIFF
--- a/.claude-run.log
+++ b/.claude-run.log
@@ -1,0 +1,27 @@
+Done. Working tree has the fix, focused tests, and NOTES.md — no commits made.
+
+## What was wrong
+
+Ollama's Windows CUDA 12 build compiles Maxwell/Pascal as **PTX-only** (`50-virtual;52-virtual;60-virtual;61-virtual;...` in `llama/server/CMakePresets.json`), so those GPUs need the driver to JIT the PTX at model load. PTX from the CUDA 12.8 toolkit needs driver ≥ 570; an older driver rejects it, ggml's `CUDA_CHECK` calls `abort()`, and Windows reports that as `0xc0000409`. That's the reported crash.
+
+`discover.filterOldCUDADriver` exists to prevent exactly this by dropping GPUs whose driver is below the floor. **On Windows it was a no-op**, for two compounding reasons in `cudaRuntimeVersion`:
+
+1. `cudaRuntimeDLLRegex` was `^cudart64_(\d{2})(\d)\.dll$` — three digits, the **CUDA ≤ 11** naming (`cudart64_110.dll`). CUDA 12/13 ship `cudart64_12.dll` / `cudart64_13.dll`, so it never matched the shipped runtime at all.
+2. It then fell back to the directory name (`cuda_v12`) and **fabricated a minor of `0`** — it had no way to say "major known, minor unknown."
+
+So the gate concluded the runtime was CUDA *12.0*: too old for compressed fatbins (needs ≥12.4) and too old to JIT legacy compute (needs ≥12.8). Both guards went false, it took the early return, and nothing was filtered.
+
+This also explains why the previous fix for this same crash (#16994) looked like it worked: every existing test uses the Linux layout `libcudart.so.12.8.90`, which parses fine. Linux got fixed; Windows — the one platform where Pascal is PTX-only, and where the crash was actually reported — did not.
+
+## The fix
+
+Make "minor unknown" a real value (`cudaRuntimeMinorUnknown`) instead of silently coercing to `0`, fix the DLL regex to accept the CUDA 12+ naming, and have `cuda_compat.go` treat an unknown minor as *at least* the runtime we ship. That direction matters: guessing low disables the driver floors and crashes the runner; guessing high drops the GPU with the existing "NVIDIA driver too old" warning and falls back to CPU.
+
+## Verification
+
+I reverted the source but kept the new tests, and they fail on the unfixed code in exactly the shape of the bug — `got 2 devices, want 1`, with the GTX 1060 (CC 6.1, driver 560) still in the list, i.e. still on its way to llama-server to JIT PTX its driver can't consume. With the fix: `go test ./discover/... ./ml/... ./llm/...` all pass, vet and gofmt clean, and `GOOS=windows go build` on the affected packages succeeds.
+
+Two things worth flagging, both written up in NOTES.md:
+
+- **A real trade-off:** a Windows user *building from source* with an old toolkit **and** old driver now gets dropped to CPU, because on Windows the runtime minor genuinely isn't in the filename. The precise alternative is reading the DLL's Win32 `VERSIONINFO` (which does carry `12.8.90`) — I left that out as a larger platform-specific change I can't exercise from Linux.
+- **I could not run this on real Windows/NVIDIA hardware.** The driver-rejects-PTX step itself isn't reproducible here; what I tested is the discovery-time decision that leads into it.

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,148 @@
+# Issue #17116 — "CUDA error: the provided PTX was compiled with an unsupported toolchain"
+
+## 1. Root cause
+
+Ollama's Windows CUDA 12 build compiles the older compute targets as **PTX only**
+(`llama/server/CMakePresets.json`, `llama_cuda_v12_windows`):
+
+```
+CMAKE_CUDA_ARCHITECTURES = 50-virtual;52-virtual;60-virtual;61-virtual;70;75;80;86;89;90;90a;120
+```
+
+So on a Maxwell/Pascal card (CC 5.x/6.x — e.g. the GTX 1060 in the near-identical
+issue #17012) there is no SASS in the fatbin; the NVIDIA driver must JIT the PTX at
+model load. That PTX is emitted by the CUDA 12.8 toolkit, and a driver older than
+570 cannot consume it. The driver rejects it with `CUDA_ERROR_UNSUPPORTED_PTX_VERSION`
+("the provided PTX was compiled with an unsupported toolchain"), ggml's `CUDA_CHECK`
+calls `abort()`, and the user sees llama-server die with `0xc0000409`
+(STATUS_STACK_BUFFER_OVERRUN — how the Windows CRT reports `abort()`).
+
+`discover.filterOldCUDADriver` (`discover/cuda_compat.go`) exists precisely to catch
+this: it drops CUDA devices whose driver is below the floor implied by the CUDA
+runtime about to be loaded (550 for compressed fatbins, 570 for JIT-ing legacy
+compute targets). **On Windows it silently did nothing.**
+
+The gate is keyed off the CUDA runtime *minor* version, which `cudaRuntimeVersion`
+(`discover/llama_server.go`) infers from the filenames staged in the variant
+directory. Two bugs made it report `12.0` on every Windows install:
+
+1. `cudaRuntimeDLLRegex` was `^cudart64_(\d{2})(\d)\.dll$` — three digits, which is
+   the **CUDA ≤ 11** naming scheme (`cudart64_110.dll`). CUDA 12 and 13 ship
+   `cudart64_12.dll` / `cudart64_13.dll`, carrying only the major. The regex never
+   matched, so the shipped runtime was not seen at all.
+2. `cudaRuntimeVersion` then fell through to its directory-name fallback
+   (`cuda_v12`) and called `update(major, 0)` — **fabricating a minor of `0`**. It
+   had no way to express "major known, minor unknown", and its `libcudart.so.<major>`
+   path had the same defect (`matches[2] == ""` → `minor = 0`).
+
+`filterOldCUDADriver` therefore concluded the runtime was CUDA **12.0**: too old to
+use compressed fatbins (needs ≥ 12.4) and too old to JIT legacy compute (needs ≥ 12.8).
+Both guards evaluated false, it hit the early return, and **no device was filtered**.
+The Pascal GPU was handed to llama-server, which then aborted JIT-ing the PTX.
+
+This is why the earlier fix for the same crash (#16994, which added
+`filterOldCUDADriver`) appeared to work and why the existing tests all passed: they
+only ever exercise the Linux layout (`libcudart.so.12.8.90`), which parses correctly.
+Linux was fixed; Windows — the platform where Pascal is PTX-only and where the crash
+was actually reported — was not.
+
+## 2. The fix and why
+
+Make "minor version unknown" a first-class value instead of silently coercing it to `0`:
+
+- **`discover/llama_server.go`**
+  - `cudaRuntimeDLLRegex` → `^cudart64_(\d{2})(\d)?\.dll$`, so it matches both the
+    legacy `cudart64_110.dll` and the modern `cudart64_12.dll` / `cudart64_13.dll`.
+  - New `cudaRuntimeMinorUnknown = -1`. `cudaRuntimeVersion` now returns it whenever
+    only the major is discoverable (CUDA 12+ DLL, bare `libcudart.so.12`, or the
+    directory-name fallback) rather than claiming `.0`. Its `update` closure already
+    keeps the highest value seen, so a real minor from a fully-versioned `.so` still
+    wins over an unknown from the directory name.
+  - Guarded the one other consumer so the sentinel never leaks into
+    `DeviceInfo.DriverMinor`.
+
+- **`discover/cuda_compat.go`** — an unknown minor is now treated as *at least* the
+  runtime we ship, via a `runtimeMinorAtLeast` helper. This is the safety-critical
+  half: guessing low disables the driver floors and crashes the runner, whereas
+  guessing high drops the GPU with the existing `"NVIDIA driver too old"` warning and
+  falls back to CPU. A wrong guess in the safe direction costs performance; a wrong
+  guess in the unsafe direction costs the whole server.
+
+The source-build carve-out the gate was written for still works wherever the minor is
+actually discoverable — i.e. every Linux build, which is where it was aimed
+(`libcudart.so.12.2.140` → 12.2 → no filtering, as covered by the existing
+"source build with older CUDA runtime keeps devices" test).
+
+I deliberately did **not** touch the CMake arch lists. Adding real SASS for Pascal to
+the Windows build would also fix the crash but inflates the binary for every user, and
+the driver gate is the mechanism the project already chose for this.
+
+## 3. Files changed
+
+| File | Change |
+|---|---|
+| `discover/llama_server.go` | Fix `cudaRuntimeDLLRegex` for CUDA 12+ DLL naming; add `cudaRuntimeMinorUnknown`; return it from `cudaRuntimeVersion` instead of a fabricated `0`; guard the `DriverMinor` assignment. |
+| `discover/cuda_compat.go` | Treat an unknown runtime minor as "at least what we ship" so the 550/570 driver floors are applied instead of skipped. |
+| `discover/cuda_compat_test.go` | Two regression cases on the Windows `cudart64_12.dll` layout: driver 560 drops the GTX 1060 but keeps the RTX 4060 Ti; driver 535 drops all CUDA devices. |
+| `discover/llama_server_test.go` | Extend the `cuda runtime version` subtest: legacy `cudart64_110.dll` → 11.0; `cudart64_12.dll` → 12.unknown; directory fallback → unknown, not `.0`. |
+
+## 4. Risk / uncertainty
+
+- **The behavioural trade-off is real but strongly favourable.** A Windows user who
+  *builds from source* with an old CUDA toolkit (12.0–12.7) **and** an old driver now
+  has their GPU dropped to CPU, because on Windows the minor genuinely cannot be read
+  from the file layout. Previously they'd have worked, since a source build defaults
+  to `CMAKE_CUDA_ARCHITECTURES=native` (real SASS, no JIT). This is a small, silent-
+  failure-free population (they get an explicit "NVIDIA driver too old" warning), and
+  the alternative is that every Windows *release* user on Pascal/Maxwell with a
+  pre-570 driver hard-crashes. If that trade-off is unacceptable, the precise fix is to
+  read the DLL's Win32 `VERSIONINFO` resource (`cudart64_12.dll` does carry the full
+  `12.8.90`), which removes the guess entirely — I left it out as it's a larger,
+  platform-specific change I can't exercise from Linux.
+- **I could not run this on real Windows/NVIDIA hardware.** The crash path itself
+  (driver rejecting the PTX) is not reproducible here; I verified the *decision* that
+  leads into it, which is the code under test.
+- The CUDA 12 DLL naming (`cudart64_12.dll`, major only) is the load-bearing external
+  fact. Confirmed against NVIDIA's toolkit layout
+  (`C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.6\bin\cudart64_12.dll`)
+  rather than assumed.
+- `cuda_v13` is still never passed through `filterOldCUDADriver` (`discover/runner.go:119`
+  gates on `cuda_v12` exactly). That's benign today — a driver too old for CUDA 13
+  fails device enumeration outright, so the variant drops out on its own — but it is a
+  latent asymmetry. Left alone to keep this change scoped to the reported issue.
+
+## 5. How I verified it
+
+Go toolchain at `/home/pjsump/go-sdk/go/bin` (go1.26.0).
+
+**Proved the new tests actually catch the bug** — reverted the two source files,
+kept the new tests, and ran them against the unfixed code:
+
+```
+--- FAIL: TestFilterOldCUDADriver/cuda_12_runtime_without_a_minor_version_filters_older_CUDA_devices
+    cuda_compat_test.go:174: got 2 devices, want 1: [... "NVIDIA GeForce GTX 1060 6GB", ComputeMajor:6, ComputeMinor:1, NVIDIADriverMajor:560 ...]
+--- FAIL: TestFilterOldCUDADriver/cuda_12_runtime_without_a_minor_version_filters_all_CUDA_devices_on_a_pre-compression_driver
+    cuda_compat_test.go:174: got 1 devices, want 0: [... "NVIDIA V100" ... NVIDIADriverMajor:535 ...]
+--- FAIL: TestLlamaServerDiscovery/cuda_runtime_version
+    llama_server_test.go:472: cudaRuntimeVersion cuda 12 dll = 12.0, true, want 12.unknown, true
+```
+
+The first failure *is* issue #17116: the GTX 1060 on driver 560 is kept, and is then
+handed to llama-server to JIT PTX its driver cannot consume.
+
+**With the fix applied:**
+
+- `go test ./discover/... ./ml/... ./llm/...` → all `ok`. No existing test needed its
+  expectations changed except the one that pinned the buggy `minor = 0` fallback.
+- `go test ./discover/ -run 'TestFilterOldCUDADriver|TestLlamaServerDiscovery' -v` →
+  all 7 `TestFilterOldCUDADriver` cases pass, including both new ones, alongside the
+  pre-existing arch-filter and source-build cases.
+- `go vet ./discover/...` clean; `gofmt -l discover/` clean.
+- `GOOS=windows go build ./discover/... ./llm/... ./ml/...` → OK (the fix is
+  Windows-facing, so this matters).
+
+Two failures I confirmed are **pre-existing and unrelated** by reproducing them on a
+stashed clean tree: `GOOS=windows go vet` flags `native_probe_windows.go:456`
+(already carries a `//nolint:govet`), and `GOOS=darwin go build` reports
+`undefined: GetCPUMem` (it lives in the cgo-gated `gpu_darwin.go`, excluded when
+cross-compiling with `CGO_ENABLED=0`).

--- a/discover/cuda_compat.go
+++ b/discover/cuda_compat.go
@@ -42,15 +42,21 @@ func filterOldCUDADriver(_ context.Context, devices []ml.DeviceInfo) []ml.Device
 
 	// Match the driver floor to the CUDA runtime we are about to load, so source
 	// builds with older CUDA runtimes can still run on matching older drivers.
+	// CUDA 12 and later don't carry the minor version in the runtime library
+	// name, so it is often unknown (notably on Windows, where we only ever see
+	// cudart64_12.dll). Assume such a runtime is as new as the one we ship:
+	// guessing low would skip the driver floors below and let llama-server abort
+	// while JITing PTX for a driver that can't consume it.
 	runtimeMajor, runtimeMinor, hasRuntime := cudaRuntimeVersionFromDevices(devices)
-	runtimeMayUseCompressedFatbins := hasRuntime &&
-		runtimeMajor == cudaV12RuntimeMajor &&
-		runtimeMinor >= minFatbinCompressionCUDARuntimeMinor
+	runtimeMinorAtLeast := func(minor int) bool {
+		return hasRuntime &&
+			runtimeMajor == cudaV12RuntimeMajor &&
+			(runtimeMinor == cudaRuntimeMinorUnknown || runtimeMinor >= minor)
+	}
+	runtimeMayUseCompressedFatbins := runtimeMinorAtLeast(minFatbinCompressionCUDARuntimeMinor)
 	// CUDA v12.8+ source builds are expected to either use Ollama's PTX packaging
 	// for older compute targets or be built against a matching local driver/toolkit.
-	runtimeMayJITLegacyCompute := hasRuntime &&
-		runtimeMajor == cudaV12RuntimeMajor &&
-		runtimeMinor >= minLegacyComputeJITCUDARuntimeMinor
+	runtimeMayJITLegacyCompute := runtimeMinorAtLeast(minLegacyComputeJITCUDARuntimeMinor)
 	if driver >= minLegacyComputeJITNVIDIADriverMajor || (!runtimeMayUseCompressedFatbins && !runtimeMayJITLegacyCompute) {
 		return devices
 	}

--- a/discover/cuda_compat_test.go
+++ b/discover/cuda_compat_test.go
@@ -104,6 +104,44 @@ func TestFilterOldCUDADriver(t *testing.T) {
 			wantIDs: []string{"GPU-0", "GPU-1"},
 		},
 		{
+			// CUDA 12 names the runtime DLL cudart64_12.dll, so the minor version
+			// is unknown. Assume it is new enough to need the driver floor rather
+			// than letting llama-server abort JITing PTX for Pascal.
+			name:       "cuda 12 runtime without a minor version filters older CUDA devices",
+			runtimeLib: "cudart64_12.dll",
+			devices: []ml.DeviceInfo{
+				{
+					DeviceID:          ml.DeviceID{ID: "GPU-0", Library: "CUDA"},
+					Description:       "NVIDIA GeForce GTX 1060 6GB",
+					ComputeMajor:      6,
+					ComputeMinor:      1,
+					NVIDIADriverMajor: 560,
+				},
+				{
+					DeviceID:          ml.DeviceID{ID: "GPU-1", Library: "CUDA"},
+					Description:       "NVIDIA GeForce RTX 4060 Ti",
+					ComputeMajor:      8,
+					ComputeMinor:      9,
+					NVIDIADriverMajor: 560,
+				},
+			},
+			wantIDs: []string{"GPU-1"},
+		},
+		{
+			name:       "cuda 12 runtime without a minor version filters all CUDA devices on a pre-compression driver",
+			runtimeLib: "cudart64_12.dll",
+			devices: []ml.DeviceInfo{
+				{
+					DeviceID:          ml.DeviceID{ID: "GPU-0", Library: "CUDA"},
+					Description:       "NVIDIA V100",
+					ComputeMajor:      7,
+					ComputeMinor:      0,
+					NVIDIADriverMajor: 535,
+				},
+			},
+			wantIDs: []string{},
+		},
+		{
 			name: "unknown driver keeps devices",
 			devices: []ml.DeviceInfo{
 				{

--- a/discover/llama_server.go
+++ b/discover/llama_server.go
@@ -194,10 +194,18 @@ var cudaArchsRegex = regexp.MustCompile(
 )
 
 var (
-	cudaRuntimeSORegex  = regexp.MustCompile(`^libcudart\.so\.(\d+)(?:\.(\d+))?`)
-	cudaRuntimeDLLRegex = regexp.MustCompile(`^cudart64_(\d{2})(\d)\.dll$`)
+	cudaRuntimeSORegex = regexp.MustCompile(`^libcudart\.so\.(\d+)(?:\.(\d+))?`)
+	// CUDA 11 and earlier put the minor version in the runtime DLL name
+	// (cudart64_110.dll). CUDA 12 and later only carry the major
+	// (cudart64_12.dll), so the minor is not knowable from the file layout.
+	cudaRuntimeDLLRegex = regexp.MustCompile(`^cudart64_(\d{2})(\d)?\.dll$`)
 	cudaRuntimeDirRegex = regexp.MustCompile(`^cuda_v(\d+)$`)
 )
+
+// cudaRuntimeMinorUnknown is reported by cudaRuntimeVersion when the runtime
+// major version is known but the minor version is not. Callers must not treat
+// this as ".0" — an unknown minor may still be the newest runtime we ship.
+const cudaRuntimeMinorUnknown = -1
 
 // parseLlamaServerDevices parses the combined output of llama-server discovery.
 // It extracts device info, ROCm gfx targets, CUDA compute capabilities, and
@@ -361,7 +369,9 @@ func parseLlamaServerDevicesWithNative(output, nativeOutput string, libDirs []st
 		setROCmGFXTarget(&dev, rocmGFXOverride)
 		if library == "CUDA" && dev.DriverMajor == 0 && hasCUDARuntime {
 			dev.DriverMajor = cudaRuntimeMajor
-			dev.DriverMinor = cudaRuntimeMinor
+			if cudaRuntimeMinor != cudaRuntimeMinorUnknown {
+				dev.DriverMinor = cudaRuntimeMinor
+			}
 		}
 
 		devices = append(devices, dev)
@@ -397,34 +407,39 @@ func nativeProbeMatchesLlamaServerDevice(library, description string, totalBytes
 	return true
 }
 
+// cudaRuntimeVersion reports the newest CUDA runtime staged in libDirs. The
+// minor version is cudaRuntimeMinorUnknown when only the major can be
+// determined, which is the norm for CUDA 12 and later on Windows.
 func cudaRuntimeVersion(libDirs []string) (int, int, bool) {
-	bestMajor, bestMinor := -1, -1
+	bestMajor, bestMinor := -1, cudaRuntimeMinorUnknown
 	update := func(major, minor int) {
 		if major > bestMajor || (major == bestMajor && minor > bestMinor) {
 			bestMajor, bestMinor = major, minor
 		}
+	}
+	parseMinor := func(match string) int {
+		if match == "" {
+			return cudaRuntimeMinorUnknown
+		}
+		minor, _ := strconv.Atoi(match)
+		return minor
 	}
 
 	for _, dir := range libDirs {
 		for _, entry := range readDirNames(dir) {
 			if matches := cudaRuntimeSORegex.FindStringSubmatch(entry); matches != nil {
 				major, _ := strconv.Atoi(matches[1])
-				minor := 0
-				if matches[2] != "" {
-					minor, _ = strconv.Atoi(matches[2])
-				}
-				update(major, minor)
+				update(major, parseMinor(matches[2]))
 			}
 			if matches := cudaRuntimeDLLRegex.FindStringSubmatch(entry); matches != nil {
 				major, _ := strconv.Atoi(matches[1])
-				minor, _ := strconv.Atoi(matches[2])
-				update(major, minor)
+				update(major, parseMinor(matches[2]))
 			}
 		}
 
 		if matches := cudaRuntimeDirRegex.FindStringSubmatch(filepath.Base(dir)); matches != nil {
 			major, _ := strconv.Atoi(matches[1])
-			update(major, 0)
+			update(major, cudaRuntimeMinorUnknown)
 		}
 	}
 

--- a/discover/llama_server_test.go
+++ b/discover/llama_server_test.go
@@ -449,9 +449,32 @@ ggml_vulkan: 1 = Intel(R) RaptorLake-S Mobile Graphics Controller (Intel Corpora
 			t.Fatalf("cudaRuntimeVersion = %d.%d, %v, want 12.8, true", major, minor, ok)
 		}
 
+		// CUDA 11 and earlier name the runtime DLL with the minor version.
+		legacy := t.TempDir()
+		if err := os.WriteFile(filepath.Join(legacy, "cudart64_110.dll"), nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		major, minor, ok = cudaRuntimeVersion([]string{legacy})
+		if !ok || major != 11 || minor != 0 {
+			t.Fatalf("cudaRuntimeVersion legacy dll = %d.%d, %v, want 11.0, true", major, minor, ok)
+		}
+
+		// CUDA 12 and later don't, so the minor is unknown rather than zero.
+		windows := filepath.Join(t.TempDir(), "cuda_v12")
+		if err := os.MkdirAll(windows, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(windows, "cudart64_12.dll"), nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		major, minor, ok = cudaRuntimeVersion([]string{windows})
+		if !ok || major != 12 || minor != cudaRuntimeMinorUnknown {
+			t.Fatalf("cudaRuntimeVersion cuda 12 dll = %d.%d, %v, want 12.unknown, true", major, minor, ok)
+		}
+
 		major, minor, ok = cudaRuntimeVersion([]string{filepath.Join(t.TempDir(), "cuda_v13")})
-		if !ok || major != 13 || minor != 0 {
-			t.Fatalf("cudaRuntimeVersion fallback = %d.%d, %v, want 13.0, true", major, minor, ok)
+		if !ok || major != 13 || minor != cudaRuntimeMinorUnknown {
+			t.Fatalf("cudaRuntimeVersion fallback = %d.%d, %v, want 13.unknown, true", major, minor, ok)
 		}
 	})
 


### PR DESCRIPTION
# Issue #17116 — "CUDA error: the provided PTX was compiled with an unsupported toolchain"

## 1. Root cause

Ollama's Windows CUDA 12 build compiles the older compute targets as **PTX only**
(`llama/server/CMakePresets.json`, `llama_cuda_v12_windows`):

```
CMAKE_CUDA_ARCHITECTURES = 50-virtual;52-virtual;60-virtual;61-virtual;70;75;80;86;89;90;90a;120
```

So on a Maxwell/Pascal card (CC 5.x/6.x — e.g. the GTX 1060 in the near-identical
issue #17012) there is no SASS in the fatbin; the NVIDIA driver must JIT the PTX at
model load. That PTX is emitted by the CUDA 12.8 toolkit, and a driver older than
570 cannot consume it. The driver rejects it with `CUDA_ERROR_UNSUPPORTED_PTX_VERSION`
("the provided PTX was compiled with an unsupported toolchain"), ggml's `CUDA_CHECK`
calls `abort()`, and the user sees llama-server die with `0xc0000409`
(STATUS_STACK_BUFFER_OVERRUN — how the Windows CRT reports `abort()`).

`discover.filterOldCUDADriver` (`discover/cuda_compat.go`) exists precisely to catch
this: it drops CUDA devices whose driver is below the floor implied by the CUDA
runtime about to be loaded (550 for compressed fatbins, 570 for JIT-ing legacy
compute targets). **On Windows it silently did nothing.**

The gate is keyed off the CUDA runtime *minor* version, which `cudaRuntimeVersion`
(`discover/llama_server.go`) infers from the filenames staged in the variant
directory. Two bugs made it report `12.0` on every Windows install:

1. `cudaRuntimeDLLRegex` was `^cudart64_(\d{2})(\d)\.dll$` — three digits, which is
   the **CUDA ≤ 11** naming scheme (`cudart64_110.dll`). CUDA 12 and 13 ship
   `cudart64_12.dll` / `cudart64_13.dll`, carrying only the major. The regex never
   matched, so the shipped runtime was not seen at all.
2. `cudaRuntimeVersion` then fell through to its directory-name fallback
   (`cuda_v12`) and called `update(major, 0)` — **fabricating a minor of `0`**. It
   had no way to express "major known, minor unknown", and its `libcudart.so.<major>`
   path had the same defect (`matches[2] == ""` → `minor = 0`).

`filterOldCUDADriver` therefore concluded the runtime was CUDA **12.0**: too old to
use compressed fatbins (needs ≥ 12.4) and too old to JIT legacy compute (needs ≥ 12.8).
Both guards evaluated false, it hit the early return, and **no device was filtered**.
The Pascal GPU was handed to llama-server, which then aborted JIT-ing the PTX.

This is why the earlier fix for the same crash (#16994, which added
`filterOldCUDADriver`) appeared to work and why the existing tests all passed: they
only ever exercise the Linux layout (`libcudart.so.12.8.90`), which parses correctly.
Linux was fixed; Windows — the platform where Pascal is PTX-only and where the crash
was actually reported — was not.

## 2. The fix and why

Make "minor version unknown" a first-class value instead of silently coercing it to `0`:

- **`discover/llama_server.go`**
  - `cudaRuntimeDLLRegex` → `^cudart64_(\d{2})(\d)?\.dll$`, so it matches both the
    legacy `cudart64_110.dll` and the modern `cudart64_12.dll` / `cudart64_13.dll`.
  - New `cudaRuntimeMinorUnknown = -1`. `cudaRuntimeVersion` now returns it whenever
    only the major is discoverable (CUDA 12+ DLL, bare `libcudart.so.12`, or the
    directory-name fallback) rather than claiming `.0`. Its `update` closure already
    keeps the highest value seen, so a real minor from a fully-versioned `.so` still
    wins over an unknown from the directory name.
  - Guarded the one other consumer so the sentinel never leaks into
    `DeviceInfo.DriverMinor`.

- **`discover/cuda_compat.go`** — an unknown minor is now treated as *at least* the
  runtime we ship, via a `runtimeMinorAtLeast` helper. This is the safety-critical
  half: guessing low disables the driver floors and crashes the runner, whereas
  guessing high drops the GPU with the existing `"NVIDIA driver too old"` warning and
  falls back to CPU. A wrong guess in the safe direction costs performance; a wrong
  guess in the unsafe direction costs the whole server.

The source-build carve-out the gate was written for still works wherever the minor is
actually discoverable — i.e. every Linux build, which is where it was aimed
(`libcudart.so.12.2.140` → 12.2 → no filtering, as covered by the existing
"source build with older CUDA runtime keeps devices" test).

I deliberately did **not** touch the CMake arch lists. Adding real SASS for Pascal to
the Windows build would also fix the crash but inflates the binary for every user, and
the driver gate is the mechanism the project already chose for this.

## 3. Files changed

| File | Change |
|---|---|
| `discover/llama_server.go` | Fix `cudaRuntimeDLLRegex` for CUDA 12+ DLL naming; add `cudaRuntimeMinorUnknown`; return it from `cudaRuntimeVersion` instead of a fabricated `0`; guard the `DriverMinor` assignment. |
| `discover/cuda_compat.go` | Treat an unknown runtime minor as "at least what we ship" so the 550/570 driver floors are applied instead of skipped. |
| `discover/cuda_compat_test.go` | Two regression cases on the Windows `cudart64_12.dll` layout: driver 560 drops the GTX 1060 but keeps the RTX 4060 Ti; driver 535 drops all CUDA devices. |
| `discover/llama_server_test.go` | Extend the `cuda runtime version` subtest: legacy `cudart64_110.dll` → 11.0; `cudart64_12.dll` → 12.unknown; directory fallback → unknown, not `.0`. |

## 4. Risk / uncertainty

- **The behavioural trade-off is real but strongly favourable.** A Windows user who
  *builds from source* with an old CUDA toolkit (12.0–12.7) **and** an old driver now
  has their GPU dropped to CPU, because on Windows the minor genuinely cannot be read
  from the file layout. Previously they'd have worked, since a source build defaults
  to `CMAKE_CUDA_ARCHITECTURES=native` (real SASS, no JIT). This is a small, silent-
  failure-free population (they get an explicit "NVIDIA driver too old" warning), and
  the alternative is that every Windows *release* user on Pascal/Maxwell with a
  pre-570 driver hard-crashes. If that trade-off is unacceptable, the precise fix is to
  read the DLL's Win32 `VERSIONINFO` resource (`cudart64_12.dll` does carry the full
  `12.8.90`), which removes the guess entirely — I left it out as it's a larger,
  platform-specific change I can't exercise from Linux.
- **I could not run this on real Windows/NVIDIA hardware.** The crash path itself
  (driver rejecting the PTX) is not reproducible here; I verified the *decision* that
  leads into it, which is the code under test.
- The CUDA 12 DLL naming (`cudart64_12.dll`, major only) is the load-bearing external
  fact. Confirmed against NVIDIA's toolkit layout
  (`C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.6\bin\cudart64_12.dll`)
  rather than assumed.
- `cuda_v13` is still never passed through `filterOldCUDADriver` (`discover/runner.go:119`
  gates on `cuda_v12` exactly). That's benign today — a driver too old for CUDA 13
  fails device enumeration outright, so the variant drops out on its own — but it is a
  latent asymmetry. Left alone to keep this change scoped to the reported issue.

## 5. How I verified it

Go toolchain at `/home/pjsump/go-sdk/go/bin` (go1.26.0).

**Proved the new tests actually catch the bug** — reverted the two source files,
kept the new tests, and ran them against the unfixed code:

```
--- FAIL: TestFilterOldCUDADriver/cuda_12_runtime_without_a_minor_version_filters_older_CUDA_devices
    cuda_compat_test.go:174: got 2 devices, want 1: [... "NVIDIA GeForce GTX 1060 6GB", ComputeMajor:6, ComputeMinor:1, NVIDIADriverMajor:560 ...]
--- FAIL: TestFilterOldCUDADriver/cuda_12_runtime_without_a_minor_version_filters_all_CUDA_devices_on_a_pre-compression_driver
    cuda_compat_test.go:174: got 1 devices, want 0: [... "NVIDIA V100" ... NVIDIADriverMajor:535 ...]
--- FAIL: TestLlamaServerDiscovery/cuda_runtime_version
    llama_server_test.go:472: cudaRuntimeVersion cuda 12 dll = 12.0, true, want 12.unknown, true
```

The first failure *is* issue #17116: the GTX 1060 on driver 560 is kept, and is then
handed to llama-server to JIT PTX its driver cannot consume.

**With the fix applied:**

- `go test ./discover/... ./ml/... ./llm/...` → all `ok`. No existing test needed its
  expectations changed except the one that pinned the buggy `minor = 0` fallback.
- `go test ./discover/ -run 'TestFilterOldCUDADriver|TestLlamaServerDiscovery' -v` →
  all 7 `TestFilterOldCUDADriver` cases pass, including both new ones, alongside the
  pre-existing arch-filter and source-build cases.
- `go vet ./discover/...` clean; `gofmt -l discover/` clean.
- `GOOS=windows go build ./discover/... ./llm/... ./ml/...` → OK (the fix is
  Windows-facing, so this matters).

Two failures I confirmed are **pre-existing and unrelated** by reproducing them on a
stashed clean tree: `GOOS=windows go vet` flags `native_probe_windows.go:456`
(already carries a `//nolint:govet`), and `GOOS=darwin go build` reports
`undefined: GetCPUMem` (it lives in the cgo-gated `gpu_darwin.go`, excluded when
cross-compiling with `CGO_ENABLED=0`).
