### PR TITLE
fix(sched): order multi-GPU spread by most free memory first

### DIFF
--- a/server/sched.go
+++ b/server/sched.go
@@ -1105,6 +1105,15 @@ func bestGPUGroupByAvailableMemory(systemInfo ml.SystemInfo, groups [][]ml.Devic
 		}
 	}
 
+	// llama-server treats the first device in the list as the main GPU, which
+	// holds the non-split output tensor and any KV-cache overflow, and its
+	// back-to-front layer fit is sensitive to device order. Pass the group with
+	// the most free memory first (discrete before integrated) so the output
+	// layer has a home and a smaller GPU isn't left with zero layers while it
+	// still has free VRAM. See https://github.com/ollama/ollama/issues/17018.
+	best = slices.Clone(best)
+	sort.Sort(sort.Reverse(ml.ByFreeMemory(best)))
+
 	return best
 }
 

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -1558,6 +1558,24 @@ func TestSelectLlamaServerPlacement(t *testing.T) {
 			wantLibrary:      "CUDA",
 			wantSelectedGPUs: 2,
 		},
+		{
+			// Regression for https://github.com/ollama/ollama/issues/17018: when a
+			// model must be split across GPUs, the group must be ordered with the
+			// most free memory first so the main GPU (which holds the output layer)
+			// isn't a smaller device that llama-server's fit leaves at zero layers.
+			name:          "multi-GPU split orders largest free GPU first",
+			predictedVRAM: 60 * format.GigaByte,
+			gpus: []ml.DeviceInfo{
+				{DeviceID: ml.DeviceID{ID: "0", Library: "Vulkan"}, Name: "provii-a", FreeMemory: 15 * format.GigaByte},
+				{DeviceID: ml.DeviceID{ID: "1", Library: "Vulkan"}, Name: "mi60-a", FreeMemory: 31 * format.GigaByte},
+				{DeviceID: ml.DeviceID{ID: "2", Library: "Vulkan"}, Name: "mi60-b", FreeMemory: 30 * format.GigaByte},
+				{DeviceID: ml.DeviceID{ID: "3", Library: "Vulkan"}, Name: "provii-b", FreeMemory: 16 * format.GigaByte},
+			},
+			opts:             api.DefaultOptions(),
+			wantLibrary:      "Vulkan",
+			wantSelectedGPUs: 4,
+			wantGPUID:        "1",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### Summary
On multi-GPU Vulkan setups the implicit main GPU is the first device in the list, which can be a smaller card. That leaves 0 layers assigned to it and forces the output tensor onto CPU.

### Fix
Order the selected multi-GPU spread group by most free memory first, so the largest-free device is the main GPU. Adds a scheduler regression test for the reported 4-GPU layout.

Fixes #17018
