### PR TITLE
fix(glm-ocr): register <|user|> as EOT for legacy glmocr GGUFs

### DIFF
--- a/convert/convert_glmocr_test.go
+++ b/convert/convert_glmocr_test.go
@@ -1,0 +1,29 @@
+package convert
+
+import "testing"
+
+// GLM-OCR ends a turn with `<|user|>` as well as `<|endoftext|>`. llama.cpp only
+// treats eos/eot/eom as end-of-generation, so `<|user|>` has to be written as the
+// EOT token or generation runs past the end of the answer and repeats it.
+func TestGlmOcrTokenizerKVMarksUserTokenAsEOT(t *testing.T) {
+	tokenizer := &Tokenizer{Vocabulary: &Vocabulary{
+		Model:  "gpt2",
+		Tokens: []string{"a", "<|endoftext|>", "b", "<|user|>", "<|assistant|>"},
+	}}
+
+	kv := KV{}
+	applyGlmOcrTokenizerKV(kv, tokenizer)
+
+	if got := kv.String("tokenizer.ggml.pre"); got != "chatglm-bpe" {
+		t.Errorf("tokenizer.ggml.pre = %q, want chatglm-bpe", got)
+	}
+	for key, want := range map[string]uint32{
+		"tokenizer.ggml.eot_token_id":     3,
+		"tokenizer.ggml.bos_token_id":     1,
+		"tokenizer.ggml.unknown_token_id": 1,
+	} {
+		if got := kv.Uint(key); got != want {
+			t.Errorf("%s = %d, want %d", key, got, want)
+		}
+	}
+}

--- a/llama/compat/README.md
+++ b/llama/compat/README.md
@@ -86,7 +86,7 @@ This table tracks the dispatch surface. Keep it brief; the handler comments in
 | `qwen25vl` | Maps to `qwen2vl` metadata conventions. | Qwen2.5-VL projector translation. |
 | `qwen3vl`, `qwen3vlmoe` | Adds missing Qwen3-VL metadata and hides embedded vision/projector tensors. | Qwen3-VL projector translation, including QKV merge and patch-embedding split/repack. |
 | `deepseekocr` | Maps to `deepseek2-ocr`, injects missing OCR/MoE metadata, and hides embedded SAM/vision/projector tensors. | DeepSeek OCR projector translation. |
-| `glmocr` | Maps GLM OCR metadata/tensors to the llama.cpp-compatible view. | GLM OCR projector translation. |
+| `glmocr` | Maps GLM OCR metadata/tensors to the llama.cpp-compatible view and fixes tokenizer/EOG metadata. | GLM OCR projector translation. |
 | `glm4moelite` | Maps GLM-4.7 Flash MLA metadata to the `deepseek2` path and fixes special-token metadata. | n/a |
 | `nemotron_h_moe` | Fixes latent-FFN variants and hides MTP tensors. | n/a |
 | `nemotron_h_omni` | Selects the Nemotron text loader and hides audio/vision/projector tensors from the text loader. | Nemotron V2 VL projector translation; audio remains disabled. |

--- a/llama/compat/llama-ollama-compat.cpp
+++ b/llama/compat/llama-ollama-compat.cpp
@@ -147,6 +147,22 @@ bool token_at_equals(const gguf_context * meta, size_t idx, const char * want) {
     return tok && std::strcmp(tok, want) == 0;
 }
 
+// Look up a token id by its literal text in `tokenizer.ggml.tokens`.
+// Returns -1 when the vocab or the token is missing.
+int64_t find_token_id(const gguf_context * meta, const char * want) {
+    const int64_t kid = gguf_find_key(meta, "tokenizer.ggml.tokens");
+    if (kid < 0 || gguf_get_kv_type(meta, kid) != GGUF_TYPE_ARRAY) return -1;
+    if (gguf_get_arr_type(meta, kid) != GGUF_TYPE_STRING) return -1;
+
+    const size_t n = gguf_get_arr_n(meta, kid);
+    for (size_t i = 0; i < n; ++i) {
+        const char * tok = gguf_get_arr_str(meta, kid, i);
+        if (tok && std::strcmp(tok, want) == 0) return (int64_t) i;
+    }
+
+    return -1;
+}
+
 bool string_kv_equals(const gguf_context * meta, const char * key, const char * want) {
     const int64_t kid = gguf_find_key(meta, key);
     if (kid < 0 || gguf_get_kv_type(meta, kid) != GGUF_TYPE_STRING) return false;
@@ -1429,6 +1445,20 @@ void handle_glmocr(const llama_model_loader * ml, gguf_context * meta,
             }
         }
     }
+    // End of generation: GLM-OCR ends its turn with `<|user|>` as well as
+    // `<|endoftext|>`. Existing files only record the second id in Ollama's
+    // `tokenizer.ggml.eos_token_ids` array, which llama.cpp does not read, and
+    // `<|user|>` is not in its list of assumed-EOG token names. llama.cpp then
+    // decodes straight through the end of the answer and the model re-emits it
+    // until the token limit. Mirror convert/convert_glmocr.go and publish
+    // `<|user|>` as the EOT token, which llama.cpp does treat as EOG.
+    if (!has_key(meta, "tokenizer.ggml.eot_token_id")) {
+        const int64_t eot = find_token_id(meta, "<|user|>");
+        if (eot >= 0) {
+            gguf_set_val_u32(meta, "tokenizer.ggml.eot_token_id", (uint32_t) eot);
+        }
+    }
+
     // Tensor renames (substring): each leaf appears once per block and
     // doesn't overlap the others.
     rename_tensors_containing(meta, ctx, ".attn_out.",       ".attn_output.");


### PR DESCRIPTION
### Summary
`glm-ocr` produces runaway and repeated output under llama-server because legacy `glmocr` GGUFs do not register `<|user|>` as an end-of-generation token.

### Fix
In the llama.cpp compat layer, set `tokenizer.ggml.eot_token_id` to `<|user|>` for `glmocr` blobs that lack it. Adds a converter unit test.

Fixes #17113
