### PR TITLE
fix(cuda): correct Windows CUDA 12+ runtime version detection

### DIFF
--- a/discover/cuda_compat.go
+++ b/discover/cuda_compat.go
@@ -42,15 +42,21 @@ func filterOldCUDADriver(_ context.Context, devices []ml.DeviceInfo) []ml.Device
 
 	// Match the driver floor to the CUDA runtime we are about to load, so source
 	// builds with older CUDA runtimes can still run on matching older drivers.
+	// CUDA 12 and later don't carry the minor version in the runtime library
+	// name, so it is often unknown (notably on Windows, where we only ever see
+	// cudart64_12.dll). Assume such a runtime is as new as the one we ship:
+	// guessing low would skip the driver floors below and let llama-server abort
+	// while JITing PTX for a driver that can't consume it.
 	runtimeMajor, runtimeMinor, hasRuntime := cudaRuntimeVersionFromDevices(devices)
-	runtimeMayUseCompressedFatbins := hasRuntime &&
-		runtimeMajor == cudaV12RuntimeMajor &&
-		runtimeMinor >= minFatbinCompressionCUDARuntimeMinor
+	runtimeMinorAtLeast := func(minor int) bool {
+		return hasRuntime &&
+			runtimeMajor == cudaV12RuntimeMajor &&
+			(runtimeMinor == cudaRuntimeMinorUnknown || runtimeMinor >= minor)
+	}
+	runtimeMayUseCompressedFatbins := runtimeMinorAtLeast(minFatbinCompressionCUDARuntimeMinor)
 	// CUDA v12.8+ source builds are expected to either use Ollama's PTX packaging
 	// for older compute targets or be built against a matching local driver/toolkit.
-	runtimeMayJITLegacyCompute := hasRuntime &&
-		runtimeMajor == cudaV12RuntimeMajor &&
-		runtimeMinor >= minLegacyComputeJITCUDARuntimeMinor
+	runtimeMayJITLegacyCompute := runtimeMinorAtLeast(minLegacyComputeJITCUDARuntimeMinor)
 	if driver >= minLegacyComputeJITNVIDIADriverMajor || (!runtimeMayUseCompressedFatbins && !runtimeMayJITLegacyCompute) {
 		return devices
 	}

--- a/discover/cuda_compat_test.go
+++ b/discover/cuda_compat_test.go
@@ -104,6 +104,44 @@ func TestFilterOldCUDADriver(t *testing.T) {
 			wantIDs: []string{"GPU-0", "GPU-1"},
 		},
 		{
+			// CUDA 12 names the runtime DLL cudart64_12.dll, so the minor version
+			// is unknown. Assume it is new enough to need the driver floor rather
+			// than letting llama-server abort JITing PTX for Pascal.
+			name:       "cuda 12 runtime without a minor version filters older CUDA devices",
+			runtimeLib: "cudart64_12.dll",
+			devices: []ml.DeviceInfo{
+				{
+					DeviceID:          ml.DeviceID{ID: "GPU-0", Library: "CUDA"},
+					Description:       "NVIDIA GeForce GTX 1060 6GB",
+					ComputeMajor:      6,
+					ComputeMinor:      1,
+					NVIDIADriverMajor: 560,
+				},
+				{
+					DeviceID:          ml.DeviceID{ID: "GPU-1", Library: "CUDA"},
+					Description:       "NVIDIA GeForce RTX 4060 Ti",
+					ComputeMajor:      8,
+					ComputeMinor:      9,
+					NVIDIADriverMajor: 560,
+				},
+			},
+			wantIDs: []string{"GPU-1"},
+		},
+		{
+			name:       "cuda 12 runtime without a minor version filters all CUDA devices on a pre-compression driver",
+			runtimeLib: "cudart64_12.dll",
+			devices: []ml.DeviceInfo{
+				{
+					DeviceID:          ml.DeviceID{ID: "GPU-0", Library: "CUDA"},
+					Description:       "NVIDIA V100",
+					ComputeMajor:      7,
+					ComputeMinor:      0,
+					NVIDIADriverMajor: 535,
+				},
+			},
+			wantIDs: []string{},
+		},
+		{
 			name: "unknown driver keeps devices",
 			devices: []ml.DeviceInfo{
 				{

--- a/discover/llama_server.go
+++ b/discover/llama_server.go
@@ -194,10 +194,18 @@ var cudaArchsRegex = regexp.MustCompile(
 )
 
 var (
-	cudaRuntimeSORegex  = regexp.MustCompile(`^libcudart\.so\.(\d+)(?:\.(\d+))?`)
-	cudaRuntimeDLLRegex = regexp.MustCompile(`^cudart64_(\d{2})(\d)\.dll$`)
+	cudaRuntimeSORegex = regexp.MustCompile(`^libcudart\.so\.(\d+)(?:\.(\d+))?`)
+	// CUDA 11 and earlier put the minor version in the runtime DLL name
+	// (cudart64_110.dll). CUDA 12 and later only carry the major
+	// (cudart64_12.dll), so the minor is not knowable from the file layout.
+	cudaRuntimeDLLRegex = regexp.MustCompile(`^cudart64_(\d{2})(\d)?\.dll$`)
 	cudaRuntimeDirRegex = regexp.MustCompile(`^cuda_v(\d+)$`)
 )
+
+// cudaRuntimeMinorUnknown is reported by cudaRuntimeVersion when the runtime
+// major version is known but the minor version is not. Callers must not treat
+// this as ".0" — an unknown minor may still be the newest runtime we ship.
+const cudaRuntimeMinorUnknown = -1
 
 // parseLlamaServerDevices parses the combined output of llama-server discovery.
 // It extracts device info, ROCm gfx targets, CUDA compute capabilities, and
@@ -361,7 +369,9 @@ func parseLlamaServerDevicesWithNative(output, nativeOutput string, libDirs []st
 		setROCmGFXTarget(&dev, rocmGFXOverride)
 		if library == "CUDA" && dev.DriverMajor == 0 && hasCUDARuntime {
 			dev.DriverMajor = cudaRuntimeMajor
-			dev.DriverMinor = cudaRuntimeMinor
+			if cudaRuntimeMinor != cudaRuntimeMinorUnknown {
+				dev.DriverMinor = cudaRuntimeMinor
+			}
 		}
 
 		devices = append(devices, dev)
@@ -397,34 +407,39 @@ func nativeProbeMatchesLlamaServerDevice(library, description string, totalBytes
 	return true
 }
 
+// cudaRuntimeVersion reports the newest CUDA runtime staged in libDirs. The
+// minor version is cudaRuntimeMinorUnknown when only the major can be
+// determined, which is the norm for CUDA 12 and later on Windows.
 func cudaRuntimeVersion(libDirs []string) (int, int, bool) {
-	bestMajor, bestMinor := -1, -1
+	bestMajor, bestMinor := -1, cudaRuntimeMinorUnknown
 	update := func(major, minor int) {
 		if major > bestMajor || (major == bestMajor && minor > bestMinor) {
 			bestMajor, bestMinor = major, minor
 		}
+	}
+	parseMinor := func(match string) int {
+		if match == "" {
+			return cudaRuntimeMinorUnknown
+		}
+		minor, _ := strconv.Atoi(match)
+		return minor
 	}
 
 	for _, dir := range libDirs {
 		for _, entry := range readDirNames(dir) {
 			if matches := cudaRuntimeSORegex.FindStringSubmatch(entry); matches != nil {
 				major, _ := strconv.Atoi(matches[1])
-				minor := 0
-				if matches[2] != "" {
-					minor, _ = strconv.Atoi(matches[2])
-				}
-				update(major, minor)
+				update(major, parseMinor(matches[2]))
 			}
 			if matches := cudaRuntimeDLLRegex.FindStringSubmatch(entry); matches != nil {
 				major, _ := strconv.Atoi(matches[1])
-				minor, _ := strconv.Atoi(matches[2])
-				update(major, minor)
+				update(major, parseMinor(matches[2]))
 			}
 		}
 
 		if matches := cudaRuntimeDirRegex.FindStringSubmatch(filepath.Base(dir)); matches != nil {
 			major, _ := strconv.Atoi(matches[1])
-			update(major, 0)
+			update(major, cudaRuntimeMinorUnknown)
 		}
 	}
 

--- a/discover/llama_server.go
+++ b/discover/llama_server.go
@@ -194,10 +194,18 @@ var cudaArchsRegex = regexp.MustCompile(
 )
 
 var (
-	cudaRuntimeSORegex  = regexp.MustCompile(`^libcudart\.so\.(\d+)(?:\.(\d+))?`)
-	cudaRuntimeDLLRegex = regexp.MustCompile(`^cudart64_(\d{2})(\d)\.dll$`)
+	cudaRuntimeSORegex = regexp.MustCompile(`^libcudart\.so\.(\d+)(?:\.(\d+))?`)
+	// CUDA 11 and earlier put the minor version in the runtime DLL name
+	// (cudart64_110.dll). CUDA 12 and later only carry the major
+	// (cudart64_12.dll), so the minor is not knowable from the file layout.
+	cudaRuntimeDLLRegex = regexp.MustCompile(`^cudart64_(\d{2})(\d)?\.dll$`)
 	cudaRuntimeDirRegex = regexp.MustCompile(`^cuda_v(\d+)$`)
 )
+
+// cudaRuntimeMinorUnknown is reported by cudaRuntimeVersion when the runtime
+// major version is known but the minor version is not. Callers must not treat
+// this as ".0" — an unknown minor may still be the newest runtime we ship.
+const cudaRuntimeMinorUnknown = -1
 
 // parseLlamaServerDevicesWithNative parses the combined output of llama-server
 // discovery. It extracts device info, ROCm gfx targets, CUDA compute
@@ -357,7 +365,9 @@ func parseLlamaServerDevicesWithNative(output, nativeOutput string, libDirs []st
 		setROCmGFXTarget(&dev, rocmGFXOverride)
 		if library == "CUDA" && dev.DriverMajor == 0 && hasCUDARuntime {
 			dev.DriverMajor = cudaRuntimeMajor
-			dev.DriverMinor = cudaRuntimeMinor
+			if cudaRuntimeMinor != cudaRuntimeMinorUnknown {
+				dev.DriverMinor = cudaRuntimeMinor
+			}
 		}
 
 		devices = append(devices, dev)
@@ -393,34 +403,39 @@ func nativeProbeMatchesLlamaServerDevice(library, description string, totalBytes
 	return true
 }
 
+// cudaRuntimeVersion reports the newest CUDA runtime staged in libDirs. The
+// minor version is cudaRuntimeMinorUnknown when only the major can be
+// determined, which is the norm for CUDA 12 and later on Windows.
 func cudaRuntimeVersion(libDirs []string) (int, int, bool) {
-	bestMajor, bestMinor := -1, -1
+	bestMajor, bestMinor := -1, cudaRuntimeMinorUnknown
 	update := func(major, minor int) {
 		if major > bestMajor || (major == bestMajor && minor > bestMinor) {
 			bestMajor, bestMinor = major, minor
 		}
+	}
+	parseMinor := func(match string) int {
+		if match == "" {
+			return cudaRuntimeMinorUnknown
+		}
+		minor, _ := strconv.Atoi(match)
+		return minor
 	}
 
 	for _, dir := range libDirs {
 		for _, entry := range readDirNames(dir) {
 			if matches := cudaRuntimeSORegex.FindStringSubmatch(entry); matches != nil {
 				major, _ := strconv.Atoi(matches[1])
-				minor := 0
-				if matches[2] != "" {
-					minor, _ = strconv.Atoi(matches[2])
-				}
-				update(major, minor)
+				update(major, parseMinor(matches[2]))
 			}
 			if matches := cudaRuntimeDLLRegex.FindStringSubmatch(entry); matches != nil {
 				major, _ := strconv.Atoi(matches[1])
-				minor, _ := strconv.Atoi(matches[2])
-				update(major, minor)
+				update(major, parseMinor(matches[2]))
 			}
 		}
 
 		if matches := cudaRuntimeDirRegex.FindStringSubmatch(filepath.Base(dir)); matches != nil {
 			major, _ := strconv.Atoi(matches[1])
-			update(major, 0)
+			update(major, cudaRuntimeMinorUnknown)
 		}
 	}
 

--- a/discover/llama_server_test.go
+++ b/discover/llama_server_test.go
@@ -449,9 +449,32 @@ ggml_vulkan: 1 = Intel(R) RaptorLake-S Mobile Graphics Controller (Intel Corpora
 			t.Fatalf("cudaRuntimeVersion = %d.%d, %v, want 12.8, true", major, minor, ok)
 		}
 
+		// CUDA 11 and earlier name the runtime DLL with the minor version.
+		legacy := t.TempDir()
+		if err := os.WriteFile(filepath.Join(legacy, "cudart64_110.dll"), nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		major, minor, ok = cudaRuntimeVersion([]string{legacy})
+		if !ok || major != 11 || minor != 0 {
+			t.Fatalf("cudaRuntimeVersion legacy dll = %d.%d, %v, want 11.0, true", major, minor, ok)
+		}
+
+		// CUDA 12 and later don't, so the minor is unknown rather than zero.
+		windows := filepath.Join(t.TempDir(), "cuda_v12")
+		if err := os.MkdirAll(windows, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(windows, "cudart64_12.dll"), nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		major, minor, ok = cudaRuntimeVersion([]string{windows})
+		if !ok || major != 12 || minor != cudaRuntimeMinorUnknown {
+			t.Fatalf("cudaRuntimeVersion cuda 12 dll = %d.%d, %v, want 12.unknown, true", major, minor, ok)
+		}
+
 		major, minor, ok = cudaRuntimeVersion([]string{filepath.Join(t.TempDir(), "cuda_v13")})
-		if !ok || major != 13 || minor != 0 {
-			t.Fatalf("cudaRuntimeVersion fallback = %d.%d, %v, want 13.0, true", major, minor, ok)
+		if !ok || major != 13 || minor != cudaRuntimeMinorUnknown {
+			t.Fatalf("cudaRuntimeVersion fallback = %d.%d, %v, want 13.unknown, true", major, minor, ok)
 		}
 	})
 


### PR DESCRIPTION
### Summary
On Windows, CUDA 12+ runtime detection reported a `.0` minor version, so `filterOldCUDADriver` could not drop GPUs that need a newer NVIDIA driver, and `llama-server` aborted when PTX JIT required one.

### Fix
Parse `cudart64_12.dll` and `cudart64_13.dll`, represent an unknown minor with a sentinel instead of fabricating `.0`, and treat unknown-minor as new enough to apply the driver floor. Adds regression tests for the Windows DLL naming and version expectations.

Fixes #17116
