### PR TITLE
convert: reject num_hidden_layers values that would overflow the merge slice

### DIFF
--- a/convert/convert_deepseek2.go
+++ b/convert/convert_deepseek2.go
@@ -3,6 +3,7 @@ package convert
 import (
 	"cmp"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"regexp"
 	"strconv"
@@ -123,21 +124,47 @@ func (p *deepseek2Model) Replacements() []string {
 	}
 }
 
+// maxDeepSeek2HiddenLayers is a generous sanity bound on num_hidden_layers.
+// It is far above any known DeepSeek-V2/V3 configuration (~60-64 layers) but
+// keeps HiddenLayers*3 (used for merge-slice sizing below) well clear of
+// uint32 overflow, and keeps a hostile config.json from making conversion
+// allocate/iterate an unbounded number of times.
+const maxDeepSeek2HiddenLayers = 1024
+
+func (p *deepseek2Model) parseMore(_ fs.FS) error {
+	return p.validate()
+}
+
+func (p *deepseek2Model) validate() error {
+	if p.HiddenLayers == 0 {
+		return fmt.Errorf("deepseek2: num_hidden_layers must be set")
+	}
+	if p.HiddenLayers > maxDeepSeek2HiddenLayers {
+		return fmt.Errorf("deepseek2: num_hidden_layers (%d) exceeds max supported value (%d)", p.HiddenLayers, maxDeepSeek2HiddenLayers)
+	}
+	return nil
+}
+
 func (p *deepseek2Model) Tensors(s []Tensor) (out []*ggml.Tensor) {
-	merges := make([]merge, p.HiddenLayers*3)
+	// Built with append (not a pre-sized index-assigned slice) so a bad
+	// HiddenLayers value can never cause an out-of-bounds write here even
+	// if validate() above did not run on some future call path.
+	merges := make([]merge, 0, p.HiddenLayers*3)
 	for i := range p.HiddenLayers {
-		merges[i*3+0] = merge{
-			fmt.Sprintf("blk.%d.mlp.experts.*.gate_proj.weight", i),
-			fmt.Sprintf("blk.%d.ffn_gate_exps.weight", i),
-		}
-		merges[i*3+1] = merge{
-			fmt.Sprintf("blk.%d.mlp.experts.*.up_proj.weight", i),
-			fmt.Sprintf("blk.%d.ffn_up_exps.weight", i),
-		}
-		merges[i*3+2] = merge{
-			fmt.Sprintf("blk.%d.mlp.experts.*.down_proj.weight", i),
-			fmt.Sprintf("blk.%d.ffn_down_exps.weight", i),
-		}
+		merges = append(merges,
+			merge{
+				fmt.Sprintf("blk.%d.mlp.experts.*.gate_proj.weight", i),
+				fmt.Sprintf("blk.%d.ffn_gate_exps.weight", i),
+			},
+			merge{
+				fmt.Sprintf("blk.%d.mlp.experts.*.up_proj.weight", i),
+				fmt.Sprintf("blk.%d.ffn_up_exps.weight", i),
+			},
+			merge{
+				fmt.Sprintf("blk.%d.mlp.experts.*.down_proj.weight", i),
+				fmt.Sprintf("blk.%d.ffn_down_exps.weight", i),
+			},
+		)
 	}
 
 	skipLayer := func(n string, minValue uint32) bool {

--- a/convert/convert_deepseek2_test.go
+++ b/convert/convert_deepseek2_test.go
@@ -1,0 +1,65 @@
+package convert
+
+import "testing"
+
+// ollama/ollama#17177: a crafted num_hidden_layers made HiddenLayers*3 wrap
+// around under uint32 arithmetic, so `merges` was allocated far smaller than
+// the loop below it assumed, causing an out-of-bounds slice write panic
+// ("index out of range [2] with length 2") on the very first iteration.
+// validate() (wired in via parseMore) now rejects such values up front with
+// a clean error instead of letting conversion crash the server process.
+func TestDeepSeek2ValidateRejectsOverflowInducingHiddenLayers(t *testing.T) {
+	p := &deepseek2Model{HiddenLayers: 1431655766} // 3*1431655766 wraps to 2 (uint32)
+	if err := p.validate(); err == nil {
+		t.Fatal("validate() = nil, want an error for an overflow-inducing num_hidden_layers")
+	}
+	// NOTE: intentionally not also calling p.Tensors() here with this value.
+	// validate() is what must stop it; actually running Tensors() on an
+	// unvalidated ~1.4e9 layer count would (correctly) no longer panic after
+	// the append-based rewrite below, but it would still iterate ~1.4e9
+	// times, so it belongs behind validate(), not inside a fast unit test.
+}
+
+func TestDeepSeek2ValidateRejectsZeroHiddenLayers(t *testing.T) {
+	p := &deepseek2Model{HiddenLayers: 0}
+	if err := p.validate(); err == nil {
+		t.Fatal("validate() = nil, want an error for num_hidden_layers=0")
+	}
+}
+
+func TestDeepSeek2ValidateRejectsExcessiveHiddenLayers(t *testing.T) {
+	// A moderately large value that does NOT overflow uint32*3, to isolate
+	// the sanity-bound check from the overflow case above.
+	p := &deepseek2Model{HiddenLayers: maxDeepSeek2HiddenLayers + 1}
+	if err := p.validate(); err == nil {
+		t.Fatalf("validate() = nil, want an error for num_hidden_layers=%d (max is %d)", p.HiddenLayers, maxDeepSeek2HiddenLayers)
+	}
+}
+
+func TestDeepSeek2ValidateAcceptsRealisticHiddenLayers(t *testing.T) {
+	// DeepSeek-V3/V3.1 style configs use ~61 layers; well within bounds.
+	p := &deepseek2Model{HiddenLayers: 61}
+	if err := p.validate(); err != nil {
+		t.Fatalf("validate() = %v, want nil for a realistic num_hidden_layers", err)
+	}
+
+	out := p.Tensors(nil)
+	if len(out) != 0 {
+		t.Fatalf("Tensors(nil) = %d tensors, want 0 (no input tensors supplied)", len(out))
+	}
+}
+
+// TestDeepSeek2TensorsDoesNotPanicOnRejectedButBoundedValue is a fast defense-
+// in-depth check: even for a HiddenLayers value validate() would reject
+// (just above the max), Tensors() itself must not panic if some future call
+// path skips validation -- the append-based construction must stay safe on
+// its own, independent of the bound check. Kept small so the loop is cheap.
+func TestDeepSeek2TensorsDoesNotPanicOnRejectedButBoundedValue(t *testing.T) {
+	p := &deepseek2Model{HiddenLayers: maxDeepSeek2HiddenLayers + 1}
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Tensors() panicked despite the append-based rewrite: %v", r)
+		}
+	}()
+	_ = p.Tensors(nil)
+}

--- a/convert/convert_deepseekocr.go
+++ b/convert/convert_deepseekocr.go
@@ -2,6 +2,7 @@ package convert
 
 import (
 	"fmt"
+	"io/fs"
 
 	"github.com/ollama/ollama/fs/ggml"
 )
@@ -67,21 +68,45 @@ func (m *deepseekocr) KV(t *Tokenizer) KV {
 	return kv
 }
 
+// maxDeepSeekOCRHiddenLayers mirrors maxDeepSeek2HiddenLayers's rationale:
+// far above any known config, but keeps HiddenLayers*3 clear of uint32
+// overflow and bounds how many times Tensors() below can iterate.
+const maxDeepSeekOCRHiddenLayers = 1024
+
+func (m *deepseekocr) parseMore(_ fs.FS) error {
+	return m.validate()
+}
+
+func (m *deepseekocr) validate() error {
+	if m.LanguageConfig.HiddenLayers == 0 {
+		return fmt.Errorf("deepseekocr: language_config.num_hidden_layers must be set")
+	}
+	if m.LanguageConfig.HiddenLayers > maxDeepSeekOCRHiddenLayers {
+		return fmt.Errorf("deepseekocr: language_config.num_hidden_layers (%d) exceeds max supported value (%d)", m.LanguageConfig.HiddenLayers, maxDeepSeekOCRHiddenLayers)
+	}
+	return nil
+}
+
 func (m *deepseekocr) Tensors(s []Tensor) (out []*ggml.Tensor) {
-	merges := make([]merge, m.LanguageConfig.HiddenLayers*3)
+	// Built with append (not a pre-sized index-assigned slice) so a bad
+	// HiddenLayers value can never cause an out-of-bounds write here even
+	// if validate() above did not run on some future call path.
+	merges := make([]merge, 0, m.LanguageConfig.HiddenLayers*3)
 	for i := range m.LanguageConfig.HiddenLayers {
-		merges[i*3+0] = merge{
-			fmt.Sprintf("blk.%d.mlp.experts.*.gate_proj.weight", i),
-			fmt.Sprintf("blk.%d.ffn_gate_exps.weight", i),
-		}
-		merges[i*3+1] = merge{
-			fmt.Sprintf("blk.%d.mlp.experts.*.up_proj.weight", i),
-			fmt.Sprintf("blk.%d.ffn_up_exps.weight", i),
-		}
-		merges[i*3+2] = merge{
-			fmt.Sprintf("blk.%d.mlp.experts.*.down_proj.weight", i),
-			fmt.Sprintf("blk.%d.ffn_down_exps.weight", i),
-		}
+		merges = append(merges,
+			merge{
+				fmt.Sprintf("blk.%d.mlp.experts.*.gate_proj.weight", i),
+				fmt.Sprintf("blk.%d.ffn_gate_exps.weight", i),
+			},
+			merge{
+				fmt.Sprintf("blk.%d.mlp.experts.*.up_proj.weight", i),
+				fmt.Sprintf("blk.%d.ffn_up_exps.weight", i),
+			},
+			merge{
+				fmt.Sprintf("blk.%d.mlp.experts.*.down_proj.weight", i),
+				fmt.Sprintf("blk.%d.ffn_down_exps.weight", i),
+			},
+		)
 	}
 
 	out, s = mergeTensors(s, merges...)

--- a/convert/convert_deepseekocr_test.go
+++ b/convert/convert_deepseekocr_test.go
@@ -1,0 +1,44 @@
+package convert
+
+import "testing"
+
+// Same overflow-panic class as ollama/ollama#17177 (convert_deepseek2.go),
+// found by auditing sibling converters that share the same merges := make +
+// direct-index pattern. See convert_deepseek2_test.go for the full writeup.
+func TestDeepSeekOCRValidateRejectsOverflowInducingHiddenLayers(t *testing.T) {
+	m := &deepseekocr{}
+	m.LanguageConfig.HiddenLayers = 1431655766 // 3*1431655766 wraps to 2 (uint32)
+	if err := m.validate(); err == nil {
+		t.Fatal("validate() = nil, want an error for an overflow-inducing num_hidden_layers")
+	}
+}
+
+func TestDeepSeekOCRValidateRejectsZeroHiddenLayers(t *testing.T) {
+	m := &deepseekocr{}
+	if err := m.validate(); err == nil {
+		t.Fatal("validate() = nil, want an error for num_hidden_layers=0")
+	}
+}
+
+func TestDeepSeekOCRValidateAcceptsRealisticHiddenLayers(t *testing.T) {
+	m := &deepseekocr{}
+	m.LanguageConfig.HiddenLayers = 27
+	if err := m.validate(); err != nil {
+		t.Fatalf("validate() = %v, want nil for a realistic num_hidden_layers", err)
+	}
+	out := m.Tensors(nil)
+	if len(out) != 0 {
+		t.Fatalf("Tensors(nil) = %d tensors, want 0 (no input tensors supplied)", len(out))
+	}
+}
+
+func TestDeepSeekOCRTensorsDoesNotPanicOnRejectedButBoundedValue(t *testing.T) {
+	m := &deepseekocr{}
+	m.LanguageConfig.HiddenLayers = maxDeepSeekOCRHiddenLayers + 1
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Tensors() panicked despite the append-based rewrite: %v", r)
+		}
+	}()
+	_ = m.Tensors(nil)
+}

--- a/convert/convert_glm4moelite.go
+++ b/convert/convert_glm4moelite.go
@@ -3,6 +3,7 @@ package convert
 import (
 	"cmp"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"regexp"
 	"strconv"
@@ -192,21 +193,45 @@ func (p *glm4MoeLiteModel) repackKVB(extractK bool, kvFirst bool, numHeads int) 
 	}
 }
 
+// maxGLM4MoeLiteHiddenLayers mirrors maxDeepSeek2HiddenLayers's rationale:
+// far above any known config, but keeps HiddenLayers*3 clear of uint32
+// overflow and bounds how many times Tensors() below can iterate.
+const maxGLM4MoeLiteHiddenLayers = 1024
+
+func (p *glm4MoeLiteModel) parseMore(_ fs.FS) error {
+	return p.validate()
+}
+
+func (p *glm4MoeLiteModel) validate() error {
+	if p.HiddenLayers == 0 {
+		return fmt.Errorf("glm4moelite: num_hidden_layers must be set")
+	}
+	if p.HiddenLayers > maxGLM4MoeLiteHiddenLayers {
+		return fmt.Errorf("glm4moelite: num_hidden_layers (%d) exceeds max supported value (%d)", p.HiddenLayers, maxGLM4MoeLiteHiddenLayers)
+	}
+	return nil
+}
+
 func (p *glm4MoeLiteModel) Tensors(s []Tensor) (out []*ggml.Tensor) {
-	merges := make([]merge, p.HiddenLayers*3)
+	// Built with append (not a pre-sized index-assigned slice) so a bad
+	// HiddenLayers value can never cause an out-of-bounds write here even
+	// if validate() above did not run on some future call path.
+	merges := make([]merge, 0, p.HiddenLayers*3)
 	for i := range p.HiddenLayers {
-		merges[i*3+0] = merge{
-			fmt.Sprintf("blk.%d.mlp.experts.*.gate_proj.weight", i),
-			fmt.Sprintf("blk.%d.ffn_gate_exps.weight", i),
-		}
-		merges[i*3+1] = merge{
-			fmt.Sprintf("blk.%d.mlp.experts.*.up_proj.weight", i),
-			fmt.Sprintf("blk.%d.ffn_up_exps.weight", i),
-		}
-		merges[i*3+2] = merge{
-			fmt.Sprintf("blk.%d.mlp.experts.*.down_proj.weight", i),
-			fmt.Sprintf("blk.%d.ffn_down_exps.weight", i),
-		}
+		merges = append(merges,
+			merge{
+				fmt.Sprintf("blk.%d.mlp.experts.*.gate_proj.weight", i),
+				fmt.Sprintf("blk.%d.ffn_gate_exps.weight", i),
+			},
+			merge{
+				fmt.Sprintf("blk.%d.mlp.experts.*.up_proj.weight", i),
+				fmt.Sprintf("blk.%d.ffn_up_exps.weight", i),
+			},
+			merge{
+				fmt.Sprintf("blk.%d.mlp.experts.*.down_proj.weight", i),
+				fmt.Sprintf("blk.%d.ffn_down_exps.weight", i),
+			},
+		)
 	}
 
 	skipLayer := func(n string, minValue uint32) bool {

--- a/convert/convert_glm4moelite_overflow_test.go
+++ b/convert/convert_glm4moelite_overflow_test.go
@@ -1,0 +1,30 @@
+package convert
+
+import "testing"
+
+// Same overflow-panic class as ollama/ollama#17177 (convert_deepseek2.go),
+// found by auditing sibling converters that share the same merges := make +
+// direct-index pattern. See convert_deepseek2_test.go for the full writeup.
+func TestGLM4MoeLiteValidateRejectsOverflowInducingHiddenLayers(t *testing.T) {
+	p := &glm4MoeLiteModel{HiddenLayers: 1431655766} // 3*1431655766 wraps to 2 (uint32)
+	if err := p.validate(); err == nil {
+		t.Fatal("validate() = nil, want an error for an overflow-inducing num_hidden_layers")
+	}
+}
+
+func TestGLM4MoeLiteValidateRejectsZeroHiddenLayers(t *testing.T) {
+	p := &glm4MoeLiteModel{HiddenLayers: 0}
+	if err := p.validate(); err == nil {
+		t.Fatal("validate() = nil, want an error for num_hidden_layers=0")
+	}
+}
+
+func TestGLM4MoeLiteTensorsDoesNotPanicOnRejectedButBoundedValue(t *testing.T) {
+	p := &glm4MoeLiteModel{HiddenLayers: maxGLM4MoeLiteHiddenLayers + 1}
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Tensors() panicked despite the append-based rewrite: %v", r)
+		}
+	}()
+	_ = p.Tensors(nil)
+}

--- a/convert/convert_qwen3next.go
+++ b/convert/convert_qwen3next.go
@@ -115,6 +115,8 @@ var (
 	_ MultimodalConverter = (*qwen3NextModel)(nil)
 )
 
+const maxQwen3NextBlockCount = 1024
+
 func (q *qwen3NextModel) parseMore(fsys fs.FS) error {
 	if q.TextConfig != nil {
 		q.qwen3NextTextConfig = *q.TextConfig
@@ -183,6 +185,13 @@ func (q *qwen3NextModel) parseMore(fsys fs.FS) error {
 
 	if q.NumHiddenLayers == 0 {
 		return fmt.Errorf("qwen3next: num_hidden_layers must be set")
+	}
+	// maxQwen3NextBlockCount mirrors convert_deepseek2.go's maxDeepSeek2HiddenLayers
+	// rationale: far above any known config, but keeps blockCount*3 (used for
+	// merge-slice sizing in Tensors()) clear of uint32 overflow and bounds how
+	// many times that loop can iterate.
+	if blockCount := q.NumHiddenLayers + q.NumNextNPredictLayers; blockCount > maxQwen3NextBlockCount {
+		return fmt.Errorf("qwen3next: num_hidden_layers+num_next_n_predict_layers (%d) exceeds max supported value (%d)", blockCount, maxQwen3NextBlockCount)
 	}
 	if q.NumAttentionHeads == 0 {
 		return fmt.Errorf("qwen3next: num_attention_heads must be set")
@@ -937,20 +946,25 @@ func (q *qwen3NextModel) Tensors(ts []Tensor) []*ggml.Tensor {
 	ts = q.renameMTPLayerTensors(ts)
 
 	blockCount := q.NumHiddenLayers + q.NumNextNPredictLayers
-	merges := make([]merge, blockCount*3)
+	// Built with append (not a pre-sized index-assigned slice) so a bad
+	// blockCount value can never cause an out-of-bounds write here even if
+	// the parseMore bound check above did not run on some future call path.
+	merges := make([]merge, 0, blockCount*3)
 	for i := range blockCount {
-		merges[i*3+0] = merge{
-			fmt.Sprintf("blk.%d.mlp.experts.*.gate_proj.weight", i),
-			fmt.Sprintf("blk.%d.ffn_gate_exps.weight", i),
-		}
-		merges[i*3+1] = merge{
-			fmt.Sprintf("blk.%d.mlp.experts.*.up_proj.weight", i),
-			fmt.Sprintf("blk.%d.ffn_up_exps.weight", i),
-		}
-		merges[i*3+2] = merge{
-			fmt.Sprintf("blk.%d.mlp.experts.*.down_proj.weight", i),
-			fmt.Sprintf("blk.%d.ffn_down_exps.weight", i),
-		}
+		merges = append(merges,
+			merge{
+				fmt.Sprintf("blk.%d.mlp.experts.*.gate_proj.weight", i),
+				fmt.Sprintf("blk.%d.ffn_gate_exps.weight", i),
+			},
+			merge{
+				fmt.Sprintf("blk.%d.mlp.experts.*.up_proj.weight", i),
+				fmt.Sprintf("blk.%d.ffn_up_exps.weight", i),
+			},
+			merge{
+				fmt.Sprintf("blk.%d.mlp.experts.*.down_proj.weight", i),
+				fmt.Sprintf("blk.%d.ffn_down_exps.weight", i),
+			},
+		)
 	}
 
 	merged, remaining := mergeTensors(ts, merges...)

--- a/convert/convert_qwen3next_overflow_test.go
+++ b/convert/convert_qwen3next_overflow_test.go
@@ -1,0 +1,19 @@
+package convert
+
+import "testing"
+
+// Same overflow-panic class as ollama/ollama#17177 (convert_deepseek2.go),
+// found by auditing sibling converters that share the same merges := make +
+// direct-index pattern -- here blockCount = NumHiddenLayers +
+// NumNextNPredictLayers, so either summand can push the total over the
+// bound. See convert_deepseek2_test.go for the full writeup.
+func TestQwen3NextTensorsDoesNotPanicOnBoundedBlockCount(t *testing.T) {
+	q := &qwen3NextModel{}
+	q.NumHiddenLayers = maxQwen3NextBlockCount + 1
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Tensors() panicked despite the append-based rewrite: %v", r)
+		}
+	}()
+	_ = q.Tensors(nil)
+}


### PR DESCRIPTION
## Summary

A crafted `num_hidden_layers` in a DeepSeek-V2/V3-family model's `config.json` crashes the whole `ollama serve` process during `/api/create` conversion with an unrecovered panic. Fixes #17177.

## Root cause

`convert_deepseek2.go`'s `Tensors()` did:

```go
merges := make([]merge, p.HiddenLayers*3)
for i := range p.HiddenLayers {
    merges[i*3+0] = merge{...}
    merges[i*3+1] = merge{...}
    merges[i*3+2] = merge{...}
}
```

`HiddenLayers` (`uint32`) comes directly from the untrusted `num_hidden_layers` field with no bounds check, and `p.HiddenLayers*3` is `uint32` arithmetic that silently wraps. `num_hidden_layers = 1431655766` makes `3*1431655766 = 4294967298` wrap to `2`, so `merges` is allocated with length 2, but the loop still iterates the full, unwrapped `1431655766` times and writes `merges[2]` on its very first pass — `panic: runtime error: index out of range [2] with length 2`. The conversion runs in a background goroutine with no `defer recover()` (a separate, already-in-flight fix in #17185), so today this panic takes the entire server down, not just the one request.

Auditing the codebase for the same `merges := make([]merge, N*k)` + direct-index pattern turned up three more converters with the identical defect: `convert_deepseekocr.go` (`LanguageConfig.HiddenLayers`), `convert_glm4moelite.go` (`HiddenLayers`), and `convert_qwen3next.go` (`NumHiddenLayers + NumNextNPredictLayers` — either summand can push the total over the bound). This PR fixes all four the same way.

## Change

For each of the four models:
- Reject the layer count up front (`parseMore`/`validate()`, or an added check inside `qwen3next`'s existing `parseMore`) if it is `0` or above a generous sanity bound (1024 — far beyond any known real config for these architectures), returning a normal error that fails the `/api/create` request instead of crashing the process.
- Switch `Tensors()` from a pre-sized, index-assigned `merges` slice to `append()` (the same idiom already used in `convert_laguna.go`, `convert_lfm2.go`, `convert_mixtral.go`, and `convert_nemotron_h.go`), so an out-of-bounds write is not possible there even on a call path that skipped validation.

4 files changed, 143 insertions(+), 52 deletions(-); 4 new test files.

## Validation

- Reproduced the exact reported panic on unpatched code with a unit test constructing `deepseek2Model{HiddenLayers: 1431655766}` and calling `Tensors(nil)` — panics with `index out of range [2] with length 2`, verbatim matching the issue.
- Added regression tests for all four models (rejects the overflow-inducing value / rejects zero / accepts a realistic layer count / `Tensors()` does not panic on a rejected-but-bounded value).
- `go test ./convert/...` — all 94 tests pass (81 pre-existing + 13 new), 0 failures.
- `go build ./...` (whole repo) and `go vet ./convert/...` pass.
- Patch verified to apply cleanly (`git apply --check`) to a fresh pristine clone, and the full test suite passes there too.

> AI usage disclosure: this change was prepared with AI assistance; a human reviewed and verified it and can explain every line. Verified: exact panic reproduced pre-fix, root cause confirmed in source, fix build- and test-validated on a pristine clone, sibling defect found by auditing the same code pattern across the package.
