### PR TITLE
openai: map reasoning_effort "minimal" to "low" instead of rejecting it

### DIFF
--- a/openai/openai.go
+++ b/openai/openai.go
@@ -637,6 +637,12 @@ func FromChatRequest(r ChatCompletionRequest) (*api.ChatRequest, error) {
 	}
 
 	if effort != "" {
+		// OpenAI also accepts "minimal"; Ollama has no distinct minimal level so map it
+		// to the lowest thinking level instead of rejecting the request
+		if effort == "minimal" {
+			effort = "low"
+		}
+
 		if !slices.Contains([]string{"high", "medium", "low", "max", "none"}, effort) {
 			return nil, fmt.Errorf("invalid reasoning value: '%s' (must be \"high\", \"medium\", \"low\", \"max\", or \"none\")", effort)
 		}

--- a/openai/openai_test.go
+++ b/openai/openai_test.go
@@ -69,6 +69,7 @@ func TestFromChatRequest_ReasoningEffort(t *testing.T) {
 		{name: "medium", effort: effort("medium"), want: "medium"},
 		{name: "low", effort: effort("low"), want: "low"},
 		{name: "max", effort: effort("max"), want: "max"},
+		{name: "minimal maps to low", effort: effort("minimal"), want: "low"},
 		{name: "none disables", effort: effort("none"), want: false},
 		{name: "invalid", effort: effort("extreme"), wantErr: true},
 	}

--- a/openai/responses.go
+++ b/openai/responses.go
@@ -527,6 +527,12 @@ func FromResponsesRequest(r ResponsesRequest) (*api.ChatRequest, error) {
 
 	var think *api.ThinkValue
 	if effort := r.Reasoning.Effort; effort != "" {
+		// OpenAI also accepts "minimal"; Ollama has no distinct minimal level so map it
+		// to the lowest thinking level instead of rejecting the request
+		if effort == "minimal" {
+			effort = "low"
+		}
+
 		switch effort {
 		case "none":
 			think = &api.ThinkValue{Value: false}

--- a/openai/responses_test.go
+++ b/openai/responses_test.go
@@ -446,6 +446,11 @@ func TestFromResponsesRequest_ReasoningEffort(t *testing.T) {
 			wantThink: "max",
 		},
 		{
+			name:      "minimal maps to low",
+			effort:    "minimal",
+			wantThink: "low",
+		},
+		{
 			name:      "none",
 			effort:    "none",
 			wantThink: false,


### PR DESCRIPTION
## What

The OpenAI-compatible endpoints (`/v1/chat/completions` and `/v1/responses`) rejected `reasoning_effort: "minimal"` with a 400 error, even though it is a valid value in the OpenAI API (used by the GPT-5 series). This broke OpenAI SDK clients and agent frameworks that set the value generically and cannot rewrite it per backend.

## How

Ollama has no distinct "minimal" thinking level, so both translation layers now normalize `minimal` to `low` — the lowest level that keeps thinking enabled — before validation. Explicitly invalid values are still rejected with the same 400 as before.

- `openai/openai.go` (`FromChatRequest`): normalize before the allow-list check (covers both `reasoning_effort` and `reasoning: {"effort": ...}`, which share this path)
- `openai/responses.go` (Responses API): same normalization before the switch

## Testing

Added `minimal maps to low` cases to the existing `TestFromChatRequest_ReasoningEffort` and `TestFromResponsesRequest_ReasoningEffort` tables. Both fail with the 400 before this change and pass after. `go test ./openai/` is green, `gofmt`/`go vet` clean.

Fixes #17140

🤖 Generated with [Claude Code](https://claude.com/claude-code)