### PR TITLE
llm: account for compute buffer and per-layer KV in the VRAM estimate

### DIFF
--- a/fs/ggml/ggml.go
+++ b/fs/ggml/ggml.go
@@ -135,6 +135,14 @@ func (kv KV) EmbeddingHeadCountV() uint64 {
 	return uint64(kv.Uint("attention.value_length", uint32(kv.EmbeddingHeadCountMax())))
 }
 
+func (kv KV) ExpertCount() uint64 {
+	return uint64(kv.Uint("expert_count", 0))
+}
+
+func (kv KV) ExpertUsedCount() uint64 {
+	return uint64(kv.Uint("expert_used_count", 0))
+}
+
 func (kv KV) ContextLength() uint64 {
 	return uint64(kv.Uint("context_length"))
 }

--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -2606,22 +2606,48 @@ func (s *llamaServerRunner) MemorySize() (total, vram uint64) {
 func PredictServerVRAM(modelPath string, f *ggml.GGML, numCtx int) uint64 {
 	var weights uint64
 	if info, err := os.Stat(modelPath); err == nil {
-		weights = uint64(info.Size())
+		weights = uint64(info.Size()) // all experts are resident, so file size is the full weight footprint
 	}
 
-	// KV cache: 2 (K+V) * layers * kv_heads * head_dim * context * 2 bytes (f16)
-	layers := f.KV().BlockCount()
-	kvHeads := f.KV().HeadCountKVMin()
-	if kvHeads == 0 {
-		kvHeads = 1
-	}
-	headDim := uint64(0)
-	if f.KV().HeadCountMax() > 0 {
-		headDim = f.KV().EmbeddingLength() / f.KV().HeadCountMax()
-	}
-	kvCache := 2 * layers * kvHeads * headDim * uint64(numCtx) * 2
+	kv := f.KV()
+	ctx := uint64(numCtx)
 
-	return weights + kvCache
+	// KV cache: sum per layer, using each layer's KV head count and the model's
+	// declared K/V head dimensions. Layers with zero KV heads are recurrent or
+	// linear-attention blocks (hybrid MoE such as qwen3next or nemotron_h) and
+	// hold no attention cache. The previous formula counted every block as full
+	// attention with head_dim = embedding/head_count; that over-counts hybrid MoE
+	// and mis-sizes any model that sets attention.key_length / value_length
+	// (DeepSeek MLA, Qwen3, Gemma). For a uniform-GQA dense model it reduces to
+	// the same value as before.
+	dimK, dimV := kv.EmbeddingHeadCountK(), kv.EmbeddingHeadCountV()
+	var kvCache uint64
+	for _, h := range kv.HeadCountKV() {
+		if h == 0 {
+			continue
+		}
+		kvCache += ctx * h * (dimK + dimV) * 2 // f16
+	}
+
+	// Compute (graph) buffer. The previous estimate omitted this entirely, which
+	// under-counts models that just fit by weights+KV and leaves llama-server to
+	// spill a layer to CPU (a known MoE mis-placement, e.g. #5136). Model a dense
+	// activation working set of one ubatch (mirrors the per-arch shapes in
+	// ggml.GraphSize), plus a surcharge for the routed-FFN buffer that scales with
+	// the per-expert feed-forward width. This is a deliberately conservative
+	// approximation: the real compute buffer depends on whether flash attention is
+	// active, which is not known at estimation time.
+	const batch = 512
+	embedding := kv.EmbeddingLength()
+	heads := kv.HeadCountMax()
+	headsKV := kv.HeadCountKVMax()
+	compute := 4 * batch * (2 + 3*embedding + ctx*(1+heads) + 2*headsKV)
+	if kv.ExpertCount() > 0 {
+		ffExp := uint64(kv.Uint("expert_feed_forward_length", kv.Uint("feed_forward_length", 0)))
+		compute += 4 * batch * ffExp
+	}
+
+	return weights + kvCache + compute
 }
 
 // memoryParsingWriter wraps an io.Writer and parses llama-server log output

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -3584,6 +3584,65 @@ func writeTestGGML(t *testing.T, kv ggml.KV, tensors []*ggml.Tensor) (string, *g
 	return f.Name(), model
 }
 
+func TestPredictServerVRAM(t *testing.T) {
+	base := func() ggml.KV {
+		return ggml.KV{
+			"general.architecture":                "qwen3moe",
+			"qwen3moe.block_count":                uint32(4),
+			"qwen3moe.embedding_length":           uint32(2048),
+			"qwen3moe.attention.head_count":       uint32(8),
+			"qwen3moe.attention.head_count_kv":    uint32(4),
+			"qwen3moe.expert_count":               uint32(128),
+			"qwen3moe.expert_used_count":          uint32(8),
+			"qwen3moe.expert_feed_forward_length": uint32(768),
+			"tokenizer.ggml.tokens":               []string{" "},
+			"tokenizer.ggml.scores":               []float32{0},
+			"tokenizer.ggml.token_type":           []int32{0},
+		}
+	}
+	const ctx = 8192
+
+	// extra returns the KV + compute portion of the estimate, subtracting the GGUF
+	// file size so metadata differences between cases cancel out.
+	extra := func(kv ggml.KV) uint64 {
+		path, model := writeTestGGML(t, kv, nil)
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return PredictServerVRAM(path, model, ctx) - uint64(info.Size())
+	}
+
+	// Declared attention.key_length/value_length must size the KV cache. Without
+	// them the estimate falls back to embedding_length/head_count (2048/8 = 256);
+	// with them (128) the per-head size is smaller. The compute buffer is the same
+	// in both cases, so the difference is exactly the KV delta over all layers.
+	withoutDims := base()
+	withDims := base()
+	withDims["qwen3moe.attention.key_length"] = uint32(128)
+	withDims["qwen3moe.attention.value_length"] = uint32(128)
+	const layers, kvHeads = 4, 4
+	wantKVDelta := uint64(layers) * kvHeads * ((256 + 256) - (128 + 128)) * ctx * 2
+	if got := extra(withoutDims) - extra(withDims); got != wantKVDelta {
+		t.Errorf("KV delta from explicit key/value_length = %d, want %d", got, wantKVDelta)
+	}
+
+	// A MoE model adds a routed-FFN compute surcharge (4 * ubatch * per-expert
+	// feed-forward width); an otherwise identical dense model does not.
+	dense := base()
+	delete(dense, "qwen3moe.expert_count")
+	delete(dense, "qwen3moe.expert_used_count")
+	wantSurcharge := uint64(4 * 512 * 768)
+	if got := extra(base()) - extra(dense); got != wantSurcharge {
+		t.Errorf("MoE compute surcharge = %d, want %d", got, wantSurcharge)
+	}
+
+	// The estimate accounts for KV and compute on top of the raw weights.
+	if extra(base()) == 0 {
+		t.Error("estimate added nothing beyond weights")
+	}
+}
+
 func testGGMLTensor(name string, kind ggml.TensorType, shape []uint64) *ggml.Tensor {
 	tensor := &ggml.Tensor{
 		Name:  name,


### PR DESCRIPTION
## Summary

`PredictServerVRAM` estimates a model's VRAM before llama-server is spawned; the scheduler uses that estimate to choose a GPU, decide whether to evict a loaded model, size the batch, and set mmap. The estimate is `weights + KV`, where KV is `2 * block_count * head_count_kv_min * (embedding_length / head_count) * context * 2`. Two parts of this are inaccurate for mixture-of-experts models, and the error is large enough to change placement decisions.

1. **The compute (graph) buffer is not counted at all.** For DeepSeek-V2-Lite at its default 32K context it is ~2.4 GB. When a model fits by weights+KV but not by weights+KV+compute, ollama loads it and llama-server then offloads a layer to CPU — the behavior in #5136.
2. **The per-head KV size uses `embedding_length / head_count`.** Models that declare `attention.key_length` / `attention.value_length` (DeepSeek MLA, Qwen3, Gemma), or that vary `head_count_kv` per layer, are sized incorrectly.

The asymmetric-KV half of this was previously handled: #5192 fixed it ("e.g. deepseek v2") in the old estimator (`llm/memory.go`). #16031 replaced that path with `PredictServerVRAM`, which reverted to `embedding_length / head_count` and never carried a compute-buffer term, so the mis-prediction regressed on current builds.

## Changes

- KV cache is summed per layer using each layer's `head_count_kv` and the declared `key_length` / `value_length`, skipping layers with no KV heads (the recurrent / linear-attention blocks in hybrid MoE such as `qwen3next` and `nemotron_h`). For a uniform-GQA dense model this reduces to the previous value, so dense models are unaffected.
- The compute buffer is added: a one-ubatch dense activation working set (the shape used by the per-arch cases in `ggml.GraphSize`) plus a routed-FFN surcharge scaled by the per-expert feed-forward width. The real compute buffer depends on whether flash attention is active, which is not known at estimation time, so this term is a deliberately conservative approximation.
- Two `KV` helpers, `ExpertCount` and `ExpertUsedCount`, read the expert metadata.

No new dependencies, no new configuration or API surface.

## Measured impact

Predicted against the buffer sizes llama-server reports, on an RTX 3090.

**deepseek-v2:16b** (arch `deepseek2`, MLA, 64 experts / 6 active), 32768 context — actual footprint 19392 MiB (model 8376 + KV 8640 + compute 2376):

| estimate | KV term | total | error |
|---|--:|--:|--:|
| before | 6912 | 15405 | −20.6% |
| after | 8640 | 18235 | −6.0% |

**qwen3:30b-a3b** (arch `qwen3moe`, GQA, 128 experts / 8 active), 8192 context — actual footprint 18384 MiB (model 17524 + KV 768 + compute 92):

| estimate | KV term | total | error |
|---|--:|--:|--:|
| before | 384 | 18081 | −1.6% |
| after | 768 | 19007 | +3.4% |

The previous estimate was 21% low on the #5136 model, which is what causes the layer-to-CPU spill. After the change both land within 6% and lean toward over-estimation, matching the function's stated intent ("intentionally conservative — overestimates to avoid VRAM contention"). The KV term matches llama-server exactly on both models.

## Testing

`go test ./llm/ ./fs/ggml/` passes. Added `TestPredictServerVRAM`, which checks that the declared `key_length` / `value_length` size the KV cache and that a MoE model adds the expert compute surcharge.

Relates to #5136.
