### PR TITLE
fix(api): report response status when the stream has no scannable lines

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -263,6 +263,22 @@ func (c *Client) stream(ctx context.Context, method, path string, data any, fn f
 		return err
 	}
 
+	// An error status with an empty (or newline-only) body yields no scannable
+	// lines, so the loop above never runs. Surface the status here so failures
+	// like an upstream cloud 401 aren't silently swallowed as a successful,
+	// empty response.
+	if response.StatusCode == http.StatusUnauthorized {
+		return AuthorizationError{
+			StatusCode: response.StatusCode,
+			Status:     response.Status,
+		}
+	} else if response.StatusCode >= http.StatusBadRequest {
+		return StatusError{
+			StatusCode: response.StatusCode,
+			Status:     response.Status,
+		}
+	}
+
 	return nil
 }
 

--- a/api/client.go
+++ b/api/client.go
@@ -263,10 +263,9 @@ func (c *Client) stream(ctx context.Context, method, path string, data any, fn f
 		return err
 	}
 
-	// An error status with an empty (or newline-only) body yields no scannable
-	// lines, so the loop above never runs. Surface the status here so failures
-	// like an upstream cloud 401 aren't silently swallowed as a successful,
-	// empty response.
+	// An error status with an empty body yields no scannable lines, so the loop
+	// above never runs. Surface the status here so failures like an upstream
+	// cloud 401 aren't silently swallowed as a successful, empty response.
 	if response.StatusCode == http.StatusUnauthorized {
 		return AuthorizationError{
 			StatusCode: response.StatusCode,

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -2,11 +2,13 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -188,6 +190,51 @@ func TestClientStream(t *testing.T) {
 			}
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestClientStreamReportsEmptyBodyErrors(t *testing.T) {
+	testCases := []struct {
+		name       string
+		statusCode int
+		wantAuth   bool
+	}{
+		{name: "unauthorized", statusCode: http.StatusUnauthorized, wantAuth: true},
+		{name: "server error", statusCode: http.StatusInternalServerError},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/x-ndjson")
+				w.WriteHeader(tc.statusCode)
+			}))
+			defer ts.Close()
+
+			client := NewClient(&url.URL{Scheme: "http", Host: ts.Listener.Addr().String()}, http.DefaultClient)
+
+			err := client.stream(t.Context(), http.MethodPost, "/api/chat", nil, func([]byte) error {
+				return nil
+			})
+			if err == nil {
+				t.Fatalf("expected error for status %d with empty body, got nil", tc.statusCode)
+			}
+
+			var authErr AuthorizationError
+			if tc.wantAuth {
+				if !errors.As(err, &authErr) {
+					t.Fatalf("expected AuthorizationError, got %T: %v", err, err)
+				}
+				return
+			}
+
+			if errors.As(err, &authErr) {
+				t.Fatalf("did not expect AuthorizationError, got %v", err)
+			}
+			if !strings.Contains(err.Error(), strconv.Itoa(tc.statusCode)) {
+				t.Fatalf("expected error mentioning status %d, got %v", tc.statusCode, err)
 			}
 		})
 	}


### PR DESCRIPTION
# Issue #17103 — "Ollama cloud not working with any model"

## 1. Root cause

The bug report is sparse (a max-plan user says "today I'm stunned I can't work
with any model", with a screenshot but no logs). The symptom class — cloud
inference silently failing across *every* model — is reproducible from a real
defect in the API client's streaming path.

`(*Client).stream` in `api/client.go` is the code path used by all streaming
inference calls (`/api/chat`, `/api/generate`, embeddings, etc.), including
cloud models that the local server proxies to `ollama.com` via
`server/cloud_proxy.go`. Its error handling lived **entirely inside** the
response-scanning loop:

```go
for scanner.Scan() {
    ...
    if response.StatusCode == http.StatusUnauthorized { return AuthorizationError{...} }
    else if response.StatusCode >= http.StatusBadRequest { return StatusError{...} }
    ...
}
if err := scanner.Err(); err != nil { return err }
return nil   // <-- reached for an error response with an empty body
```

If the server responds with an error status **but an empty (or newline-only)
body**, `scanner.Scan()` returns `false` immediately, the loop body never runs,
`scanner.Err()` is `nil`, and `stream` returns `nil` — i.e. the client treats a
failed request as a *successful, empty* response.

For cloud models this is exactly the "nothing works" experience: a cloud request
that fails upstream with an empty-bodied error (e.g. an expired/invalid token
producing a bare `401`, or a `5xx`/gateway error with no JSON body) yields **no
output and no error**. The user sees the model produce nothing and has no
actionable message (not even the "run `ollama signin`" prompt the CLI shows for
a normal `AuthorizationError`). Because the flaw is in generic client error
handling, it affects every model uniformly — matching "any model".

Reproduction (confirmed before fixing, via a temporary test): a stubbed
transport returning `401`/`500` with an empty body made `stream` return `nil`.

The non-streaming path (`checkError`) already handles this correctly by keying
off the status code regardless of body, so only the streaming path was affected.

## 2. The fix and why

Surface the response status **after** the scan loop, so an error status with no
scannable lines is still reported instead of swallowed (`api/client.go`):

```go
if err := scanner.Err(); err != nil { return err }

if response.StatusCode == http.StatusUnauthorized {
    return AuthorizationError{StatusCode: response.StatusCode, Status: response.Status}
} else if response.StatusCode >= http.StatusBadRequest {
    return StatusError{StatusCode: response.StatusCode, Status: response.Status}
}
return nil
```

Why this shape:
- It mirrors the existing per-line status handling (same error types, same
  `Unauthorized`-vs-generic split), so a `401` still becomes an
  `AuthorizationError` and the CLI's `handleCloudAuthorizationError` prints the
  sign-in guidance (it already tolerates an empty `SigninURL`).
- It is additive and only runs when the loop produced no terminal result, so
  responses that *do* carry an error body (the previously-covered cases) keep
  returning inside the loop with their original message — no behavior change for
  success streams (status < 400) or non-empty error bodies.

## 3. Files changed

- `api/client.go` — added a post-loop status-code check in `(*Client).stream`.
- `api/client_test.go` — added `TestClientStreamReportsEmptyBodyErrors`
  (table test covering `401` → `AuthorizationError` and `500` → `StatusError`
  for empty-bodied error responses), plus `errors`/`strconv` imports.

## 4. Risk / uncertainty

- **Issue attribution is a hypothesis.** The report has no logs, so I cannot
  prove this specific defect is what the reporter hit rather than a purely
  server-side ollama.com outage. What is certain: this is a genuine
  client-side correctness bug that produces the exact reported symptom
  (cloud silently doing nothing for all models), and the fix makes the failure
  visible and actionable instead of silent.
- **Low regression risk.** The added code only executes when the stream loop
  returned nothing and the status is an error; success paths and non-empty
  error bodies are untouched. All pre-existing `stream` tests still pass.
- The fix improves error surfacing; it does not (and cannot) change ollama.com's
  auth outcome. A user whose token is genuinely rejected will now see a clear
  `401`/sign-in prompt rather than empty output.

## 5. How I verified

- Wrote a temporary reproduction test that stubbed the HTTP transport to return
  `401`/`500` with an empty body; confirmed `stream` returned `nil` (bug), then
  confirmed it returns the correct error after the fix.
- `go test ./api/` — passes, including the existing `TestClientStream`,
  `TestClientStreamReportsReadErrors`, and the new
  `TestClientStreamReportsEmptyBodyErrors`.
- `go vet ./api/` — clean.
