### PR TITLE
README: add Tura community integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ console.log(response.message.content);
 - [AI ST Completion](https://github.com/yaroslavyaroslav/OpenAI-sublime-text) - Sublime Text 4 AI assistant
 - [VT Code](https://github.com/vinhnx/vtcode) - Rust-based terminal coding agent with Tree-sitter
 - [QodeAssist](https://github.com/Palm1r/QodeAssist) - AI coding assistant for Qt Creator
+- [Tura](https://github.com/Tura-AI/tura) - Local, open-source coding agent with CLI, TUI, desktop interfaces, and native Ollama support
 - [AI Toolkit for VS Code](https://aka.ms/ai-tooklit/ollama-docs) - Microsoft-official VS Code extension
 - [Open Interpreter](https://docs.openinterpreter.com/language-model-setup/local-models/ollama) - Natural language interface for computers
 


### PR DESCRIPTION
## Summary

Add Tura to **Community Integrations → Code Editors & Development**.

Tura is a local, open-source coding agent with CLI, TUI, and desktop interfaces. Its provider configuration includes Ollama's local API style and default http://localhost:11434 endpoint.

## Verification

- Confirmed there is no existing Tura entry or submission
- Confirmed the rendered link and description
- README-only change: one addition and no deletions

Disclosure: I am affiliated with Tura and am submitting it on the project's behalf.