### PR TITLE
fix: validate manifest digest in x/transfer to prevent path traversal

### DIFF
--- a/x/transfer/download.go
+++ b/x/transfer/download.go
@@ -92,6 +92,11 @@ func download(ctx context.Context, opts DownloadOptions) error {
 	if len(opts.Blobs) == 0 {
 		return nil
 	}
+	for _, b := range opts.Blobs {
+		if _, err := digestToPath(b.Digest); err != nil {
+			return err
+		}
+	}
 
 	// Calculate total from all blobs (for accurate progress reporting on resume)
 	var total int64
@@ -103,7 +108,8 @@ func download(ctx context.Context, opts DownloadOptions) error {
 	var blobs []Blob
 	var alreadyCompleted int64
 	for _, b := range opts.Blobs {
-		if fi, _ := os.Stat(filepath.Join(opts.DestDir, digestToPath(b.Digest))); fi != nil && fi.Size() == b.Size {
+		name, _ := digestToPath(b.Digest) // validated above
+		if fi, _ := os.Stat(filepath.Join(opts.DestDir, name)); fi != nil && fi.Size() == b.Size {
 			if opts.Logger != nil {
 				opts.Logger.Debug("blob already exists", "digest", b.Digest, "size", b.Size)
 			}
@@ -193,7 +199,11 @@ func (d *downloader) download(ctx context.Context, blob Blob) error {
 
 		// Preserve partial .tmp files for large blobs to enable resume
 		if blob.Size < resumeThreshold {
-			dest := filepath.Join(d.destDir, digestToPath(blob.Digest))
+			name, err := digestToPath(blob.Digest)
+			if err != nil {
+				return err
+			}
+			dest := filepath.Join(d.destDir, name)
 			os.Remove(dest + ".tmp")
 		}
 
@@ -218,6 +228,10 @@ func (d *downloader) downloadOnce(ctx context.Context, blob Blob) (int64, error)
 	if d.logger != nil {
 		d.logger.Debug("downloading blob", "digest", blob.Digest, "size", blob.Size)
 	}
+	name, err := digestToPath(blob.Digest)
+	if err != nil {
+		return 0, err
+	}
 
 	// Hold a body slot for the duration of the GET — released when the body
 	// has been read and the response closed.
@@ -234,7 +248,7 @@ func (d *downloader) downloadOnce(ctx context.Context, blob Blob) (int64, error)
 	}
 
 	// Check for existing partial .tmp file for resume
-	dest := filepath.Join(d.destDir, digestToPath(blob.Digest))
+	dest := filepath.Join(d.destDir, name)
 	tmp := dest + ".tmp"
 	var existingSize int64
 	if blob.Size >= resumeThreshold {
@@ -281,19 +295,23 @@ func (d *downloader) downloadOnce(ctx context.Context, blob Blob) (int64, error)
 }
 
 func (d *downloader) save(ctx context.Context, blob Blob, r io.Reader, existingSize int64) (int64, error) {
-	dest := filepath.Join(d.destDir, digestToPath(blob.Digest))
+	name, err := digestToPath(blob.Digest)
+	if err != nil {
+		return 0, err
+	}
+	dest := filepath.Join(d.destDir, name)
 	tmp := dest + ".tmp"
 	os.MkdirAll(filepath.Dir(dest), 0o755)
 
 	h := sha256.New()
 
 	var f *os.File
-	var err error
+	var fErr error
 
 	if existingSize > 0 {
 		// Resume — re-hash existing partial data, then append
-		f, err = os.OpenFile(tmp, os.O_RDWR, 0o644)
-		if err != nil {
+		f, fErr = os.OpenFile(tmp, os.O_RDWR, 0o644)
+		if fErr != nil {
 			// Can't open partial file, start fresh
 			existingSize = 0
 		} else {
@@ -310,9 +328,9 @@ func (d *downloader) save(ctx context.Context, blob Blob, r io.Reader, existingS
 	}
 
 	if existingSize == 0 {
-		f, err = os.Create(tmp)
-		if err != nil {
-			return 0, err
+		f, fErr = os.Create(tmp)
+		if fErr != nil {
+			return 0, fErr
 		}
 		setSparse(f)
 	}

--- a/x/transfer/transfer.go
+++ b/x/transfer/transfer.go
@@ -30,9 +30,11 @@ package transfer
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"math/rand/v2"
 	"net/http"
+	"regexp"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -116,7 +118,11 @@ const (
 	smallBlobSpeedThreshold = 100 << 10 // 100 KB
 )
 
-var errMaxRetriesExceeded = errors.New("max retries exceeded")
+var (
+	errMaxRetriesExceeded  = errors.New("max retries exceeded")
+	errInvalidDigestFormat = errors.New("invalid digest format")
+	sha256DigestPattern    = regexp.MustCompile(`^sha256[:-][0-9a-fA-F]{64}$`)
+)
 
 // defaultClient is a shared HTTP client with connection pooling.
 var defaultClient = &http.Client{
@@ -167,12 +173,14 @@ func Upload(ctx context.Context, opts UploadOptions) error {
 	return upload(ctx, opts)
 }
 
-// digestToPath converts sha256:abc123 to sha256-abc123
-func digestToPath(digest string) string {
-	if len(digest) > 7 && digest[6] == ':' {
-		return digest[:6] + "-" + digest[7:]
+// digestToPath validates a sha256 digest and converts its separator to the
+// format used for blob filenames. The validation matches manifest.BlobsPath.
+func digestToPath(digest string) (string, error) {
+	if strings.ContainsAny(digest, `/\\`) || strings.Contains(digest, "..") || !sha256DigestPattern.MatchString(digest) {
+		return "", fmt.Errorf("%w: %q", errInvalidDigestFormat, digest)
 	}
-	return digest
+
+	return strings.Replace(digest, ":", "-", 1), nil
 }
 
 // parseAuthChallenge parses a WWW-Authenticate header value.

--- a/x/transfer/transfer_test.go
+++ b/x/transfer/transfer_test.go
@@ -72,7 +72,7 @@ func createTestBlob(t *testing.T, dir string, size int) (Blob, []byte) {
 	digest := fmt.Sprintf("sha256:%x", h)
 
 	// Write to file
-	path := filepath.Join(dir, digestToPath(digest))
+	path := filepath.Join(dir, mustDigestToPath(t, digest))
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -81,6 +81,15 @@ func createTestBlob(t *testing.T, dir string, size int) (Blob, []byte) {
 	}
 
 	return Blob{Digest: digest, Size: int64(size)}, data
+}
+
+func mustDigestToPath(t testing.TB, digest string) string {
+	t.Helper()
+	path, err := digestToPath(digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return path
 }
 
 func TestDownload(t *testing.T) {
@@ -95,7 +104,7 @@ func TestDownload(t *testing.T) {
 		// Extract digest from URL: /v2/library/_/blobs/sha256:...
 		digest := filepath.Base(r.URL.Path)
 
-		path := filepath.Join(serverDir, digestToPath(digest))
+		path := filepath.Join(serverDir, mustDigestToPath(t, digest))
 		data, err := os.ReadFile(path)
 		if err != nil {
 			http.NotFound(w, r)
@@ -152,7 +161,7 @@ func TestDownloadWithRedirect(t *testing.T) {
 	cdn := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Serve the blob content
 		digest := filepath.Base(r.URL.Path)
-		path := filepath.Join(cdnDir, digestToPath(digest))
+		path := filepath.Join(cdnDir, mustDigestToPath(t, digest))
 		blobData, err := os.ReadFile(path)
 		if err != nil {
 			http.NotFound(w, r)
@@ -203,7 +212,7 @@ func TestDownloadWithRetry(t *testing.T) {
 		}
 
 		digest := filepath.Base(r.URL.Path)
-		path := filepath.Join(serverDir, digestToPath(digest))
+		path := filepath.Join(serverDir, mustDigestToPath(t, digest))
 		blobData, err := os.ReadFile(path)
 		if err != nil {
 			http.NotFound(w, r)
@@ -249,7 +258,7 @@ func TestDownloadWithAuth(t *testing.T) {
 		}
 
 		digest := filepath.Base(r.URL.Path)
-		path := filepath.Join(serverDir, digestToPath(digest))
+		path := filepath.Join(serverDir, mustDigestToPath(t, digest))
 		blobData, err := os.ReadFile(path)
 		if err != nil {
 			http.NotFound(w, r)
@@ -294,7 +303,7 @@ func TestDownloadSkipsExisting(t *testing.T) {
 
 	// Pre-populate client dir
 	clientDir := t.TempDir()
-	path := filepath.Join(clientDir, digestToPath(blob1.Digest))
+	path := filepath.Join(clientDir, mustDigestToPath(t, blob1.Digest))
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -339,7 +348,7 @@ func TestDownloadResumeProgressTotal(t *testing.T) {
 		blob Blob
 		data []byte
 	}{{blob1, data1}, {blob2, data2}} {
-		path := filepath.Join(clientDir, digestToPath(b.blob.Digest))
+		path := filepath.Join(clientDir, mustDigestToPath(t, b.blob.Digest))
 		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 			t.Fatal(err)
 		}
@@ -350,7 +359,7 @@ func TestDownloadResumeProgressTotal(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		digest := filepath.Base(r.URL.Path)
-		path := filepath.Join(serverDir, digestToPath(digest))
+		path := filepath.Join(serverDir, mustDigestToPath(t, digest))
 		data, err := os.ReadFile(path)
 		if err != nil {
 			http.NotFound(w, r)
@@ -745,7 +754,7 @@ func TestDownloadWithCustomRepository(t *testing.T) {
 
 		// Serve blob from any path
 		digest := filepath.Base(r.URL.Path)
-		path := filepath.Join(serverDir, digestToPath(digest))
+		path := filepath.Join(serverDir, mustDigestToPath(t, digest))
 		blobData, err := os.ReadFile(path)
 		if err != nil {
 			http.NotFound(w, r)
@@ -783,20 +792,83 @@ func TestDownloadWithCustomRepository(t *testing.T) {
 }
 
 func TestDigestToPath(t *testing.T) {
-	tests := []struct {
-		input string
-		want  string
+	valid := []struct {
+		name   string
+		digest string
+		want   string
 	}{
-		{"sha256:abc123", "sha256-abc123"},
-		{"sha256-abc123", "sha256-abc123"},
-		{"other", "other"},
+		{"colon separator", "sha256:" + strings.Repeat("a", 64), "sha256-" + strings.Repeat("a", 64)},
+		{"hyphen separator", "sha256-" + strings.Repeat("b", 64), "sha256-" + strings.Repeat("b", 64)},
+		{"uppercase hex", "sha256:" + strings.Repeat("A1", 32), "sha256-" + strings.Repeat("A1", 32)},
 	}
 
-	for _, tt := range tests {
-		got := digestToPath(tt.input)
-		if got != tt.want {
-			t.Errorf("digestToPath(%q) = %q, want %q", tt.input, got, tt.want)
-		}
+	for _, tt := range valid {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := digestToPath(tt.digest)
+			if err != nil {
+				t.Fatalf("digestToPath(%q) returned error: %v", tt.digest, err)
+			}
+			if got != tt.want {
+				t.Errorf("digestToPath(%q) = %q, want %q", tt.digest, got, tt.want)
+			}
+		})
+	}
+
+	invalid := []struct {
+		name   string
+		digest string
+	}{
+		{"parent traversal", "sha256:../../outside"},
+		{"forward slash", "sha256:" + strings.Repeat("a", 32) + "/" + strings.Repeat("b", 31)},
+		{"backslash", "sha256:" + strings.Repeat("a", 32) + `\` + strings.Repeat("b", 31)},
+		{"dot segments", "sha256:" + strings.Repeat("a", 31) + ".." + strings.Repeat("b", 31)},
+		{"short hash", "sha256:abc123"},
+		{"long hash", "sha256:" + strings.Repeat("a", 65)},
+		{"non hex", "sha256:" + strings.Repeat("g", 64)},
+		{"wrong algorithm", "sha512:" + strings.Repeat("a", 64)},
+		{"wrong separator", "sha256_" + strings.Repeat("a", 64)},
+		{"empty", ""},
+	}
+
+	for _, tt := range invalid {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := digestToPath(tt.digest)
+			if !errors.Is(err, errInvalidDigestFormat) {
+				t.Fatalf("digestToPath(%q) error = %v, want %v", tt.digest, err, errInvalidDigestFormat)
+			}
+			if got != "" {
+				t.Errorf("digestToPath(%q) = %q, want empty path", tt.digest, got)
+			}
+		})
+	}
+}
+
+func TestDownloadRejectsInvalidDigest(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	destDir := t.TempDir()
+	err := Download(context.Background(), DownloadOptions{
+		Blobs:   []Blob{{Digest: "sha256:../../outside", Size: 1}},
+		BaseURL: server.URL,
+		DestDir: destDir,
+	})
+	if !errors.Is(err, errInvalidDigestFormat) {
+		t.Fatalf("Download() error = %v, want %v", err, errInvalidDigestFormat)
+	}
+	if got := requests.Load(); got != 0 {
+		t.Errorf("registry received %d requests for invalid digest, want 0", got)
+	}
+	entries, readErr := os.ReadDir(destDir)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if len(entries) != 0 {
+		t.Errorf("destination contains %d entries after rejected download, want 0", len(entries))
 	}
 }
 
@@ -838,7 +910,7 @@ func TestParseAuthChallenge(t *testing.T) {
 func verifyBlob(t *testing.T, dir string, blob Blob, expected []byte) {
 	t.Helper()
 
-	path := filepath.Join(dir, digestToPath(blob.Digest))
+	path := filepath.Join(dir, mustDigestToPath(t, blob.Digest))
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Errorf("Failed to read %s: %v", blob.Digest[:19], err)
@@ -889,7 +961,7 @@ func TestDownloadParallelism(t *testing.T) {
 		time.Sleep(50 * time.Millisecond)
 
 		digest := filepath.Base(r.URL.Path)
-		path := filepath.Join(serverDir, digestToPath(digest))
+		path := filepath.Join(serverDir, mustDigestToPath(t, digest))
 		data, err := os.ReadFile(path)
 		if err != nil {
 			http.NotFound(w, r)
@@ -1031,7 +1103,7 @@ func TestDownloadStallDetection(t *testing.T) {
 		count := requestCount.Add(1)
 
 		digest := filepath.Base(r.URL.Path)
-		path := filepath.Join(serverDir, digestToPath(digest))
+		path := filepath.Join(serverDir, mustDigestToPath(t, digest))
 		data, err := os.ReadFile(path)
 		if err != nil {
 			http.NotFound(w, r)
@@ -1096,7 +1168,7 @@ func TestDownloadCancellation(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		digest := filepath.Base(r.URL.Path)
-		path := filepath.Join(serverDir, digestToPath(digest))
+		path := filepath.Join(serverDir, mustDigestToPath(t, digest))
 		data, _ := os.ReadFile(path)
 
 		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(data)))
@@ -1226,7 +1298,7 @@ func TestProgressTracking(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		digest := filepath.Base(r.URL.Path)
-		path := filepath.Join(serverDir, digestToPath(digest))
+		path := filepath.Join(serverDir, mustDigestToPath(t, digest))
 		data, _ := os.ReadFile(path)
 		w.WriteHeader(http.StatusOK)
 		w.Write(data)
@@ -1375,7 +1447,7 @@ func TestProgressRollback(t *testing.T) {
 	blob := Blob{Digest: digest, Size: int64(len(content))}
 
 	clientDir := t.TempDir()
-	path := filepath.Join(clientDir, digestToPath(digest))
+	path := filepath.Join(clientDir, mustDigestToPath(t, digest))
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -1652,7 +1724,7 @@ func BenchmarkUploadThroughput(b *testing.B) {
 
 	// Create source file once
 	srcDir := b.TempDir()
-	path := filepath.Join(srcDir, digestToPath(digest))
+	path := filepath.Join(srcDir, mustDigestToPath(b, digest))
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		b.Fatal(err)
 	}
@@ -1742,7 +1814,7 @@ func TestResumeFromPartialFile(t *testing.T) {
 
 	// Pre-create a partial .tmp file (first half)
 	partialSize := blobSize / 2
-	dest := filepath.Join(clientDir, digestToPath(digest))
+	dest := filepath.Join(clientDir, mustDigestToPath(t, digest))
 	os.MkdirAll(filepath.Dir(dest), 0o755)
 	os.WriteFile(dest+".tmp", data[:partialSize], 0o644)
 
@@ -1824,7 +1896,7 @@ func TestResumeCorruptPartialFile(t *testing.T) {
 	for i := range corruptData {
 		corruptData[i] = 0xFF // All 0xFF — definitely wrong
 	}
-	dest := filepath.Join(clientDir, digestToPath(digest))
+	dest := filepath.Join(clientDir, mustDigestToPath(t, digest))
 	os.MkdirAll(filepath.Dir(dest), 0o755)
 	os.WriteFile(dest+".tmp", corruptData, 0o644)
 
@@ -1875,7 +1947,7 @@ func TestResumePartialFileLargerThanBlob(t *testing.T) {
 
 	// Pre-create .tmp file LARGER than expected blob
 	oversizedData := make([]byte, blobSize+1000)
-	dest := filepath.Join(clientDir, digestToPath(digest))
+	dest := filepath.Join(clientDir, mustDigestToPath(t, digest))
 	os.MkdirAll(filepath.Dir(dest), 0o755)
 	os.WriteFile(dest+".tmp", oversizedData, 0o644)
 
@@ -1929,7 +2001,7 @@ func TestResumeBelowThreshold(t *testing.T) {
 	clientDir := t.TempDir()
 
 	// Pre-create a partial .tmp file
-	dest := filepath.Join(clientDir, digestToPath(digest))
+	dest := filepath.Join(clientDir, mustDigestToPath(t, digest))
 	os.MkdirAll(filepath.Dir(dest), 0o755)
 	os.WriteFile(dest+".tmp", data[:blobSize/2], 0o644)
 
@@ -1983,7 +2055,7 @@ func TestResumeServerDoesNotSupportRange(t *testing.T) {
 	clientDir := t.TempDir()
 
 	// Pre-create partial .tmp file
-	dest := filepath.Join(clientDir, digestToPath(digest))
+	dest := filepath.Join(clientDir, mustDigestToPath(t, digest))
 	os.MkdirAll(filepath.Dir(dest), 0o755)
 	os.WriteFile(dest+".tmp", data[:blobSize/2], 0o644)
 
@@ -2054,7 +2126,7 @@ func TestResumePartialFileExactSize(t *testing.T) {
 
 	// Pre-create .tmp file with exact correct content (full size)
 	// This simulates a download that completed but wasn't renamed
-	dest := filepath.Join(clientDir, digestToPath(digest))
+	dest := filepath.Join(clientDir, mustDigestToPath(t, digest))
 	os.MkdirAll(filepath.Dir(dest), 0o755)
 	os.WriteFile(dest+".tmp", data, 0o644)
 
@@ -2248,7 +2320,7 @@ func TestChunkedUploadBasic(t *testing.T) {
 	blob := Blob{Digest: digest, Size: int64(blobSize)}
 
 	clientDir := t.TempDir()
-	path := filepath.Join(clientDir, digestToPath(digest))
+	path := filepath.Join(clientDir, mustDigestToPath(t, digest))
 	os.MkdirAll(filepath.Dir(path), 0o755)
 	os.WriteFile(path, data, 0o644)
 
@@ -2313,7 +2385,7 @@ func TestChunkedUploadCDNRedirect(t *testing.T) {
 	blob := Blob{Digest: digest, Size: int64(blobSize)}
 
 	clientDir := t.TempDir()
-	path := filepath.Join(clientDir, digestToPath(digest))
+	path := filepath.Join(clientDir, mustDigestToPath(t, digest))
 	os.MkdirAll(filepath.Dir(path), 0o755)
 	os.WriteFile(path, data, 0o644)
 
@@ -2392,7 +2464,7 @@ func TestChunkedUploadPartRetry(t *testing.T) {
 	blob := Blob{Digest: digest, Size: int64(blobSize)}
 
 	clientDir := t.TempDir()
-	path := filepath.Join(clientDir, digestToPath(digest))
+	path := filepath.Join(clientDir, mustDigestToPath(t, digest))
 	os.MkdirAll(filepath.Dir(path), 0o755)
 	os.WriteFile(path, data, 0o644)
 
@@ -2446,7 +2518,7 @@ func multiPartTestHelper(t *testing.T, blobSize int, partSize int64, serverURL s
 	blob := Blob{Digest: digest, Size: int64(blobSize)}
 
 	clientDir := t.TempDir()
-	path := filepath.Join(clientDir, digestToPath(digest))
+	path := filepath.Join(clientDir, mustDigestToPath(t, digest))
 	os.MkdirAll(filepath.Dir(path), 0o755)
 	os.WriteFile(path, data, 0o644)
 
@@ -2486,7 +2558,7 @@ func TestChunkedUploadMultiPartSessionURLChain(t *testing.T) {
 
 	u, blob, data := multiPartTestHelper(t, blobSize, partSize, server.URL)
 
-	f, err := os.Open(filepath.Join(u.srcDir, digestToPath(blob.Digest)))
+	f, err := os.Open(filepath.Join(u.srcDir, mustDigestToPath(t, blob.Digest)))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2545,7 +2617,7 @@ func TestChunkedUploadMultiPartDataIntegrity(t *testing.T) {
 
 	u, blob, data := multiPartTestHelper(t, blobSize, partSize, server.URL)
 
-	f, err := os.Open(filepath.Join(u.srcDir, digestToPath(blob.Digest)))
+	f, err := os.Open(filepath.Join(u.srcDir, mustDigestToPath(t, blob.Digest)))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2605,7 +2677,7 @@ func TestChunkedUploadMultiPartProgressRollback(t *testing.T) {
 		mu.Unlock()
 	})
 
-	f, err := os.Open(filepath.Join(u.srcDir, digestToPath(blob.Digest)))
+	f, err := os.Open(filepath.Join(u.srcDir, mustDigestToPath(t, blob.Digest)))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/x/transfer/upload.go
+++ b/x/transfer/upload.go
@@ -90,6 +90,11 @@ func upload(ctx context.Context, opts UploadOptions) error {
 	if len(opts.Blobs) == 0 && len(opts.Manifest) == 0 {
 		return nil
 	}
+	for _, blob := range opts.Blobs {
+		if _, err := digestToPath(blob.Digest); err != nil {
+			return err
+		}
+	}
 
 	u := &uploader{
 		client:     cmp.Or(opts.Client, defaultClient),
@@ -231,6 +236,10 @@ func (u *uploader) uploadOnce(ctx context.Context, blob Blob) (int64, error) {
 	if u.logger != nil {
 		u.logger.Debug("uploading blob", "digest", blob.Digest, "size", blob.Size)
 	}
+	name, err := digestToPath(blob.Digest)
+	if err != nil {
+		return 0, err
+	}
 
 	ep, err := u.initUpload(ctx, blob)
 	if err != nil {
@@ -245,7 +254,7 @@ func (u *uploader) uploadOnce(ctx context.Context, blob Blob) (int64, error) {
 		return blob.Size, nil
 	}
 
-	f, err := os.Open(filepath.Join(u.srcDir, digestToPath(blob.Digest)))
+	f, err := os.Open(filepath.Join(u.srcDir, name))
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
## Summary

This change prevents attacker-controlled manifest digests from escaping the configured blob directory when tensor-model layers use the fast `x/transfer` download path.

Blob digests are now required to match the same format accepted by the legacy `manifest.BlobsPath` path: `^sha256[:-][0-9a-fA-F]{64}$`. Digests containing path separators or parent-directory sequences are rejected before any registry request or filesystem operation.

Fixes #17178.

## Root Cause

`pullWithTransfer` constructs `transfer.Blob` values directly from layer metadata in a registry manifest. For tensor-model layers, those values are passed to `x/transfer` instead of the legacy path guarded by `manifest.BlobsPath`.

Within `x/transfer`, `digestToPath` only converted a colon at offset 6 into a hyphen. It did not verify the algorithm, encoded digest length, character set, or presence of path traversal characters. As a result, an untrusted digest containing sequences such as `../` could reach `filepath.Join` in the downloader. `downloader.save` then created parent directories and opened the resulting temporary file before content digest verification, allowing an arbitrary file write outside the blob directory.

## Fix

`digestToPath` now returns an error unless the complete digest:

- Uses the `sha256` algorithm.
- Uses either `:` or `-` as the separator, matching `manifest.BlobsPath`.
- Contains exactly 64 hexadecimal characters after the separator.
- Contains no forward slash, backslash, or `..` sequence.

The transfer entry points validate all blob digests before starting network activity. Internal download and upload code also validates immediately before constructing filesystem paths, including code paths exercised directly by package tests.

## Changes

- Added a compiled SHA-256 digest validation pattern to `x/transfer`.
- Changed `digestToPath` to return an explicit invalid-format error for malformed or traversal-containing input.
- Propagated validation errors through download and upload filesystem paths.
- Added table-driven coverage for accepted colon/hyphen digests, uppercase hexadecimal input, traversal payloads, path separators, invalid lengths, non-hex input, unsupported algorithms, invalid separators, and empty input.
- Added a download regression test verifying that a traversal digest causes no registry request and no destination-directory changes.

## Test Plan

- `go build ./...` — passes (after generating the clean clone's ignored `app/ui/app/dist` bundle required by `go:embed`).
- `go test ./x/transfer/...` — passes.
- `go vet ./x/transfer/...` — passes.
- `go vet ./...` — reports two existing findings in files unchanged from `origin/main`:
  - `tokenizer/bytepairencoding_test.go:542:5: result of slices.Collect call not used`
  - `x/imagegen/mlx/compile.go:84:3: possible misuse of unsafe.Pointer`
