### PR TITLE
Private/issue 15781 vulkan source build

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -2565,7 +2565,15 @@ func NewCLI() *cobra.Command {
 		switch cmd {
 		case runCmd:
 			imagegen.AppendFlagsDocs(cmd)
-			appendEnvDocs(cmd, []envconfig.EnvVar{envVars["OLLAMA_EDITOR"], envVars["OLLAMA_HOST"], envVars["OLLAMA_NOHISTORY"]})
+			appendEnvDocs(cmd, []envconfig.EnvVar{
+				envVars["OLLAMA_EDITOR"],
+				envVars["OLLAMA_HOST"],
+				envVars["OLLAMA_NOHISTORY"],
+				envVars["OLLAMA_LOCAL_SEMANTIC_MEMORY"],
+				envVars["OLLAMA_LOCAL_SEMANTIC_MEMORY_DIR"],
+				envVars["OLLAMA_LOCAL_SEMANTIC_MEMORY_MAX_FACTS"],
+				envVars["OLLAMA_LOCAL_SEMANTIC_MEMORY_PROFILE_FACTS"],
+			})
 		case serveCmd:
 			appendEnvDocs(cmd, []envconfig.EnvVar{
 				envVars["OLLAMA_DEBUG"],

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -135,6 +135,17 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 	var sb strings.Builder
 	var multiline MultilineState
 	var thinkExplicitlySet bool = opts.Think != nil
+	memoryManager, err := newLocalSemanticMemoryManager()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: local semantic memory disabled: %v\n", err)
+		memoryManager = nil
+	}
+	if memoryManager != nil {
+		opts.Messages, err = memoryManager.injectSystemMessage(opts.Messages)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to load local semantic memory profile: %v\n", err)
+		}
+	}
 
 	for {
 		line, err := scanner.Readline()
@@ -522,6 +533,11 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 
 				newMessage.Content = msg
 				newMessage.Images = images
+			}
+			if memoryManager != nil {
+				if err := memoryManager.captureUserFact(newMessage.Content); err != nil {
+					fmt.Fprintf(os.Stderr, "warning: failed to update local semantic memory: %v\n", err)
+				}
 			}
 
 			opts.Messages = append(opts.Messages, newMessage)

--- a/cmd/local_memory.go
+++ b/cmd/local_memory.go
@@ -1,0 +1,304 @@
+package cmd
+
+import (
+	"cmp"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/envconfig"
+)
+
+const localSemanticMemoryHeader = "Local semantic memory profile (stored only on this device):"
+
+var memoryTokenPattern = regexp.MustCompile(`[a-z0-9]+`)
+
+type localSemanticMemoryManager struct {
+	dir          string
+	maxFacts     int
+	profileFacts int
+}
+
+func newLocalSemanticMemoryManager() (*localSemanticMemoryManager, error) {
+	if !envconfig.LocalSemanticMemoryEnabled() {
+		return nil, nil
+	}
+
+	dir := strings.TrimSpace(envconfig.LocalSemanticMemoryDir())
+	if dir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, err
+		}
+		dir = filepath.Join(home, ".ollama", "llm_memory")
+	}
+
+	maxFacts := max(2, int(envconfig.LocalSemanticMemoryMaxFacts()))
+	profileFacts := max(1, int(envconfig.LocalSemanticMemoryProfileFacts()))
+	profileFacts = min(profileFacts, maxFacts)
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, err
+	}
+
+	return &localSemanticMemoryManager{
+		dir:          dir,
+		maxFacts:     maxFacts,
+		profileFacts: profileFacts,
+	}, nil
+}
+
+func (m *localSemanticMemoryManager) injectSystemMessage(msgs []api.Message) ([]api.Message, error) {
+	for _, msg := range msgs {
+		if msg.Role == "system" && strings.Contains(msg.Content, localSemanticMemoryHeader) {
+			return msgs, nil
+		}
+	}
+
+	facts, err := m.readLatestFacts(m.profileFacts)
+	if err != nil {
+		return nil, err
+	}
+	if len(facts) == 0 {
+		return msgs, nil
+	}
+
+	var b strings.Builder
+	b.WriteString(localSemanticMemoryHeader)
+	b.WriteString("\n")
+	for _, fact := range facts {
+		b.WriteString("- ")
+		b.WriteString(fact)
+		b.WriteString("\n")
+	}
+	b.WriteString("Use this as probabilistic user context and defer to the latest user message when conflicts appear.")
+
+	memMessage := api.Message{
+		Role:    "system",
+		Content: b.String(),
+	}
+	return append([]api.Message{memMessage}, msgs...), nil
+}
+
+func (m *localSemanticMemoryManager) captureUserFact(content string) error {
+	fact := normalizeMemoryFact(content)
+	if fact == "" {
+		return nil
+	}
+
+	filename := fmt.Sprintf("fact-%d.txt", time.Now().UTC().UnixNano())
+	path := filepath.Join(m.dir, filename)
+	if err := os.WriteFile(path, []byte(fact), 0o600); err != nil {
+		return err
+	}
+
+	return m.compressIfNeeded()
+}
+
+func normalizeMemoryFact(content string) string {
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return ""
+	}
+
+	fields := strings.Fields(content)
+	if len(fields) < 3 {
+		return ""
+	}
+
+	fact := strings.Join(fields, " ")
+	if len(fact) > 280 {
+		fact = strings.TrimSpace(fact[:280])
+	}
+	return fact
+}
+
+func (m *localSemanticMemoryManager) compressIfNeeded() error {
+	files, err := m.listFactFiles()
+	if err != nil {
+		return err
+	}
+
+	for len(files) > m.maxFacts {
+		left, right := selectMostSimilarFacts(files)
+		if left == nil || right == nil {
+			break
+		}
+
+		merged, err := mergeFactContents(left.path, right.path)
+		if err != nil {
+			return err
+		}
+
+		filename := fmt.Sprintf("fact-merged-%d.txt", time.Now().UTC().UnixNano())
+		path := filepath.Join(m.dir, filename)
+		if err := os.WriteFile(path, []byte(merged), 0o600); err != nil {
+			return err
+		}
+
+		if err := os.Remove(left.path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		if err := os.Remove(right.path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+
+		files, err = m.listFactFiles()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func mergeFactContents(leftPath, rightPath string) (string, error) {
+	leftBytes, err := os.ReadFile(leftPath)
+	if err != nil {
+		return "", err
+	}
+	rightBytes, err := os.ReadFile(rightPath)
+	if err != nil {
+		return "", err
+	}
+
+	left := strings.TrimSpace(string(leftBytes))
+	right := strings.TrimSpace(string(rightBytes))
+	if left == "" {
+		return right, nil
+	}
+	if right == "" {
+		return left, nil
+	}
+	if strings.EqualFold(left, right) {
+		return left, nil
+	}
+	if strings.Contains(strings.ToLower(left), strings.ToLower(right)) {
+		return left, nil
+	}
+	if strings.Contains(strings.ToLower(right), strings.ToLower(left)) {
+		return right, nil
+	}
+	return left + "\n" + right, nil
+}
+
+type memoryFactFile struct {
+	path    string
+	modTime time.Time
+	content string
+}
+
+func (m *localSemanticMemoryManager) listFactFiles() ([]memoryFactFile, error) {
+	entries, err := os.ReadDir(m.dir)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]memoryFactFile, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".txt") {
+			continue
+		}
+
+		path := filepath.Join(m.dir, entry.Name())
+		info, err := entry.Info()
+		if err != nil {
+			return nil, err
+		}
+		contentBytes, err := os.ReadFile(path)
+		if err != nil {
+			return nil, err
+		}
+		content := strings.TrimSpace(string(contentBytes))
+		if content == "" {
+			continue
+		}
+		out = append(out, memoryFactFile{
+			path:    path,
+			modTime: info.ModTime(),
+			content: content,
+		})
+	}
+
+	slices.SortFunc(out, func(a, b memoryFactFile) int {
+		return cmp.Compare(a.modTime.UnixNano(), b.modTime.UnixNano())
+	})
+	return out, nil
+}
+
+func (m *localSemanticMemoryManager) readLatestFacts(limit int) ([]string, error) {
+	files, err := m.listFactFiles()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(files) == 0 {
+		return nil, nil
+	}
+
+	start := max(0, len(files)-limit)
+	recent := files[start:]
+	out := make([]string, 0, len(recent))
+	for i := len(recent) - 1; i >= 0; i-- {
+		out = append(out, recent[i].content)
+	}
+	return out, nil
+}
+
+func selectMostSimilarFacts(files []memoryFactFile) (*memoryFactFile, *memoryFactFile) {
+	if len(files) < 2 {
+		return nil, nil
+	}
+
+	bestScore := -1.0
+	var left, right *memoryFactFile
+	for i := 0; i < len(files)-1; i++ {
+		for j := i + 1; j < len(files); j++ {
+			score := memorySimilarity(files[i].content, files[j].content)
+			if score > bestScore {
+				bestScore = score
+				left = &files[i]
+				right = &files[j]
+			}
+		}
+	}
+	return left, right
+}
+
+func memorySimilarity(a, b string) float64 {
+	aTokens := memoryTokens(a)
+	bTokens := memoryTokens(b)
+	if len(aTokens) == 0 || len(bTokens) == 0 {
+		return 0
+	}
+
+	intersection := 0
+	for token := range aTokens {
+		if _, ok := bTokens[token]; ok {
+			intersection++
+		}
+	}
+	union := len(aTokens) + len(bTokens) - intersection
+	if union == 0 {
+		return 0
+	}
+	return float64(intersection) / float64(union)
+}
+
+func memoryTokens(content string) map[string]struct{} {
+	matches := memoryTokenPattern.FindAllString(strings.ToLower(content), -1)
+	set := make(map[string]struct{}, len(matches))
+	for _, match := range matches {
+		if len(match) <= 2 {
+			continue
+		}
+		set[match] = struct{}{}
+	}
+	return set
+}

--- a/cmd/local_memory_test.go
+++ b/cmd/local_memory_test.go
@@ -1,0 +1,98 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ollama/ollama/api"
+)
+
+func TestNormalizeMemoryFact(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "empty", input: "   ", want: ""},
+		{name: "too short", input: "hello world", want: ""},
+		{name: "normal", input: " user prefers concise answers ", want: "user prefers concise answers"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeMemoryFact(tt.input)
+			if got != tt.want {
+				t.Fatalf("normalizeMemoryFact(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLocalSemanticMemoryCompression(t *testing.T) {
+	dir := t.TempDir()
+	mgr := &localSemanticMemoryManager{
+		dir:          dir,
+		maxFacts:     2,
+		profileFacts: 2,
+	}
+
+	facts := []string{
+		"user prefers concise technical answers",
+		"user likes concise explanations with examples",
+		"user is currently working on ollama CLI features",
+	}
+	for i, fact := range facts {
+		path := filepath.Join(dir, "fact-"+time.Now().Add(time.Duration(i)*time.Millisecond).Format("150405.000000000")+".txt")
+		if err := os.WriteFile(path, []byte(fact), 0o600); err != nil {
+			t.Fatalf("write fact file: %v", err)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	if err := mgr.compressIfNeeded(); err != nil {
+		t.Fatalf("compressIfNeeded: %v", err)
+	}
+
+	files, err := mgr.listFactFiles()
+	if err != nil {
+		t.Fatalf("listFactFiles: %v", err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("expected 2 files after compression, got %d", len(files))
+	}
+}
+
+func TestLocalSemanticMemoryInjectSystemMessage(t *testing.T) {
+	dir := t.TempDir()
+	mgr := &localSemanticMemoryManager{
+		dir:          dir,
+		maxFacts:     10,
+		profileFacts: 2,
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "fact-1.txt"), []byte("user name is cal"), 0o600); err != nil {
+		t.Fatalf("write fact-1: %v", err)
+	}
+	time.Sleep(2 * time.Millisecond)
+	if err := os.WriteFile(filepath.Join(dir, "fact-2.txt"), []byte("user prefers concise answers"), 0o600); err != nil {
+		t.Fatalf("write fact-2: %v", err)
+	}
+
+	msgs := []api.Message{{Role: "user", Content: "hello"}}
+	out, err := mgr.injectSystemMessage(msgs)
+	if err != nil {
+		t.Fatalf("injectSystemMessage: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("expected 2 messages after injection, got %d", len(out))
+	}
+	if out[0].Role != "system" {
+		t.Fatalf("first message role = %q, want system", out[0].Role)
+	}
+	if !strings.Contains(out[0].Content, localSemanticMemoryHeader) {
+		t.Fatalf("system message missing memory header: %q", out[0].Content)
+	}
+}

--- a/discover/runner.go
+++ b/discover/runner.go
@@ -57,6 +57,25 @@ func GPUDevices(ctx context.Context, runners []ml.FilteredRunnerDiscovery) []ml.
 			libDirs[""] = struct{}{}
 		}
 
+		// Warn when the user explicitly enabled Vulkan (OLLAMA_VULKAN=1) but the
+		// Vulkan backend library was not found. This commonly happens when building
+		// from source without passing -DOLLAMA_LLAMA_BACKENDS=vulkan to CMake.
+		if envconfig.EnableVulkan(false) {
+			hasVulkanLib := false
+			for dir := range libDirs {
+				if strings.Contains(filepath.Base(dir), "vulkan") {
+					hasVulkanLib = true
+					break
+				}
+			}
+			if !hasVulkanLib {
+				slog.Warn("OLLAMA_VULKAN is set but no Vulkan backend library was found — " +
+					"inference will fall back to CPU. " +
+					"To build Vulkan support from source, re-run CMake with: " +
+					"-DOLLAMA_LLAMA_BACKENDS=vulkan")
+			}
+		}
+
 		slog.Info("discovering available GPUs...")
 		detectIncompatibleLibraries()
 		detectOldAMDDriverWindows()

--- a/docs/development.md
+++ b/docs/development.md
@@ -84,16 +84,24 @@ Additional prerequisites:
 
 For Ninja builds, run CMake from a Developer PowerShell/Command Prompt or another shell where the Visual Studio compiler is available.
 
-> Building for Vulkan requires VULKAN_SDK environment variable:
-> 
+> Building for Vulkan requires the VULKAN_SDK environment variable **and**
+> `-DOLLAMA_LLAMA_BACKENDS=vulkan` passed to CMake:
+>
 > PowerShell
 > ```powershell
 > $env:VULKAN_SDK="C:\VulkanSDK\<version>"
+> cmake -B build . -DOLLAMA_LLAMA_BACKENDS=vulkan
+> cmake --build build --parallel 8
 > ```
 > CMD
 > ```cmd
 > set VULKAN_SDK=C:\VulkanSDK\<version>
+> cmake -B build . -DOLLAMA_LLAMA_BACKENDS=vulkan
+> cmake --build build --parallel 8
 > ```
+>
+> Without `-DOLLAMA_LLAMA_BACKENDS=vulkan`, the Vulkan backend library is not
+> compiled and setting `OLLAMA_VULKAN=1` will have no effect.
 
 ## Windows (ARM)
 
@@ -110,6 +118,8 @@ Additional prerequisites:
 - (Optional) Vulkan GPU support
     - [Vulkan SDK](https://vulkan.lunarg.com/sdk/home) - useful for AMD/Intel GPUs
     - Or install via package manager: `sudo apt install vulkan-sdk` (Ubuntu/Debian) or `sudo dnf install vulkan-sdk` (Fedora/CentOS)
+    - After installing the SDK, build with: `cmake -B build . -DOLLAMA_LLAMA_BACKENDS=vulkan && cmake --build build --parallel 8`
+    - **Note:** installing the SDK alone is not enough — you must also pass `-DOLLAMA_LLAMA_BACKENDS=vulkan` to CMake; without it, `OLLAMA_VULKAN=1` has no effect and inference falls back to CPU
 - (Optional) MLX engine support
     - [CUDA 13+ SDK](https://developer.nvidia.com/cuda-downloads)
     - [cuDNN 9+](https://developer.nvidia.com/cudnn)

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -236,6 +236,12 @@ var (
 	EnableIntegratedGPU = BoolWithDefault("OLLAMA_IGPU_ENABLE")
 	// NoCloudEnv checks the OLLAMA_NO_CLOUD environment variable.
 	NoCloudEnv = Bool("OLLAMA_NO_CLOUD")
+	// LocalSemanticMemoryEnabled enables local semantic memory capture/compression in interactive CLI sessions.
+	LocalSemanticMemoryEnabled = Bool("OLLAMA_LOCAL_SEMANTIC_MEMORY")
+	// LocalSemanticMemoryMaxFacts caps the number of memory fact files before semantic merging occurs.
+	LocalSemanticMemoryMaxFacts = Uint("OLLAMA_LOCAL_SEMANTIC_MEMORY_MAX_FACTS", 10)
+	// LocalSemanticMemoryProfileFacts controls how many recent facts are injected into new interactive sessions.
+	LocalSemanticMemoryProfileFacts = Uint("OLLAMA_LOCAL_SEMANTIC_MEMORY_PROFILE_FACTS", 8)
 )
 
 func String(s string) func() string {
@@ -247,6 +253,8 @@ func String(s string) func() string {
 var (
 	LLMLibrary = String("OLLAMA_LLM_LIBRARY")
 	Editor     = String("OLLAMA_EDITOR")
+	// LocalSemanticMemoryDir is the directory where local semantic memory facts are stored.
+	LocalSemanticMemoryDir = String("OLLAMA_LOCAL_SEMANTIC_MEMORY_DIR")
 
 	CudaVisibleDevices    = String("CUDA_VISIBLE_DEVICES")
 	HipVisibleDevices     = String("HIP_VISIBLE_DEVICES")
@@ -310,32 +318,36 @@ type EnvVar struct {
 
 func AsMap() map[string]EnvVar {
 	ret := map[string]EnvVar{
-		"OLLAMA_DEBUG":                {"OLLAMA_DEBUG", LogLevel(), "Show additional debug information (e.g. OLLAMA_DEBUG=1)"},
-		"OLLAMA_DEBUG_LOG_REQUESTS":   {"OLLAMA_DEBUG_LOG_REQUESTS", DebugLogRequests(), "Log inference request bodies and replay curl commands to a temp directory"},
-		"OLLAMA_GO_TEMPLATE":          {"OLLAMA_GO_TEMPLATE", GoTemplate(true), "Enable Modelfile TEMPLATE based rendering when available"},
-		"OLLAMA_FLASH_ATTENTION":      {"OLLAMA_FLASH_ATTENTION", FlashAttention(false), "Enabled flash attention"},
-		"OLLAMA_KV_CACHE_TYPE":        {"OLLAMA_KV_CACHE_TYPE", KvCacheType(), "Quantization type for the K/V cache (default: f16)"},
-		"OLLAMA_GPU_OVERHEAD":         {"OLLAMA_GPU_OVERHEAD", GpuOverhead(), "Reserve a portion of VRAM per GPU (bytes)"},
-		"OLLAMA_IGPU_ENABLE":          {"OLLAMA_IGPU_ENABLE", String("OLLAMA_IGPU_ENABLE")(), "Enable integrated GPUs"},
-		"LLAMA_ARG_FIT":               {"LLAMA_ARG_FIT", String("LLAMA_ARG_FIT")(), "Enable llama.cpp automatic fit of unset memory options (default \"on\")"},
-		"LLAMA_ARG_FIT_TARGET":        {"LLAMA_ARG_FIT_TARGET", String("LLAMA_ARG_FIT_TARGET")(), "Target free VRAM margin per device for llama.cpp fit (MiB)"},
-		"OLLAMA_HOST":                 {"OLLAMA_HOST", Host(), "IP Address for the ollama server (default 127.0.0.1:11434)"},
-		"OLLAMA_KEEP_ALIVE":           {"OLLAMA_KEEP_ALIVE", KeepAlive(), "The duration that models stay loaded in memory (default \"5m\")"},
-		"OLLAMA_LLM_LIBRARY":          {"OLLAMA_LLM_LIBRARY", LLMLibrary(), "Set LLM library to bypass autodetection"},
-		"OLLAMA_LOAD_TIMEOUT":         {"OLLAMA_LOAD_TIMEOUT", LoadTimeout(), "How long to allow model loads to stall before giving up (default \"5m\")"},
-		"OLLAMA_MAX_LOADED_MODELS":    {"OLLAMA_MAX_LOADED_MODELS", MaxRunners(), "Maximum number of loaded models per GPU"},
-		"OLLAMA_MAX_TRANSFER_STREAMS": {"OLLAMA_MAX_TRANSFER_STREAMS", MaxTransferStreams(), "Maximum parallel transfer streams for safetensors model pulls/pushes (default 4)"},
-		"OLLAMA_MAX_QUEUE":            {"OLLAMA_MAX_QUEUE", MaxQueue(), "Maximum number of queued requests"},
-		"OLLAMA_MODELS":               {"OLLAMA_MODELS", Models(), "The path to the models directory"},
-		"OLLAMA_NO_CLOUD":             {"OLLAMA_NO_CLOUD", NoCloud(), "Disable Ollama cloud features (remote inference and web search)"},
-		"OLLAMA_NOHISTORY":            {"OLLAMA_NOHISTORY", NoHistory(), "Do not preserve readline history"},
-		"OLLAMA_NOPRUNE":              {"OLLAMA_NOPRUNE", NoPrune(), "Do not prune model blobs on startup"},
-		"OLLAMA_NUM_PARALLEL":         {"OLLAMA_NUM_PARALLEL", NumParallel(), "Maximum number of parallel requests"},
-		"OLLAMA_ORIGINS":              {"OLLAMA_ORIGINS", AllowedOrigins(), "A comma separated list of allowed origins"},
-		"OLLAMA_SCHED_SPREAD":         {"OLLAMA_SCHED_SPREAD", SchedSpread(), "Always schedule model across all GPUs"},
-		"OLLAMA_CONTEXT_LENGTH":       {"OLLAMA_CONTEXT_LENGTH", ContextLength(), "Context length to use unless otherwise specified (default: 4k/32k/256k based on VRAM)"},
-		"OLLAMA_EDITOR":               {"OLLAMA_EDITOR", Editor(), "Path to editor for interactive prompt editing (Ctrl+G)"},
-		"OLLAMA_REMOTES":              {"OLLAMA_REMOTES", Remotes(), "Allowed hosts for remote models (default \"ollama.com\")"},
+		"OLLAMA_DEBUG":                               {"OLLAMA_DEBUG", LogLevel(), "Show additional debug information (e.g. OLLAMA_DEBUG=1)"},
+		"OLLAMA_DEBUG_LOG_REQUESTS":                  {"OLLAMA_DEBUG_LOG_REQUESTS", DebugLogRequests(), "Log inference request bodies and replay curl commands to a temp directory"},
+		"OLLAMA_GO_TEMPLATE":                         {"OLLAMA_GO_TEMPLATE", GoTemplate(true), "Enable Modelfile TEMPLATE based rendering when available"},
+		"OLLAMA_FLASH_ATTENTION":                     {"OLLAMA_FLASH_ATTENTION", FlashAttention(false), "Enabled flash attention"},
+		"OLLAMA_KV_CACHE_TYPE":                       {"OLLAMA_KV_CACHE_TYPE", KvCacheType(), "Quantization type for the K/V cache (default: f16)"},
+		"OLLAMA_GPU_OVERHEAD":                        {"OLLAMA_GPU_OVERHEAD", GpuOverhead(), "Reserve a portion of VRAM per GPU (bytes)"},
+		"OLLAMA_IGPU_ENABLE":                         {"OLLAMA_IGPU_ENABLE", String("OLLAMA_IGPU_ENABLE")(), "Enable integrated GPUs"},
+		"LLAMA_ARG_FIT":                              {"LLAMA_ARG_FIT", String("LLAMA_ARG_FIT")(), "Enable llama.cpp automatic fit of unset memory options (default \"on\")"},
+		"LLAMA_ARG_FIT_TARGET":                       {"LLAMA_ARG_FIT_TARGET", String("LLAMA_ARG_FIT_TARGET")(), "Target free VRAM margin per device for llama.cpp fit (MiB)"},
+		"OLLAMA_HOST":                                {"OLLAMA_HOST", Host(), "IP Address for the ollama server (default 127.0.0.1:11434)"},
+		"OLLAMA_KEEP_ALIVE":                          {"OLLAMA_KEEP_ALIVE", KeepAlive(), "The duration that models stay loaded in memory (default \"5m\")"},
+		"OLLAMA_LLM_LIBRARY":                         {"OLLAMA_LLM_LIBRARY", LLMLibrary(), "Set LLM library to bypass autodetection"},
+		"OLLAMA_LOCAL_SEMANTIC_MEMORY":               {"OLLAMA_LOCAL_SEMANTIC_MEMORY", LocalSemanticMemoryEnabled(), "Enable local semantic memory capture/compression in interactive sessions"},
+		"OLLAMA_LOCAL_SEMANTIC_MEMORY_DIR":           {"OLLAMA_LOCAL_SEMANTIC_MEMORY_DIR", LocalSemanticMemoryDir(), "Directory for local semantic memory facts (default: ~/.ollama/llm_memory)"},
+		"OLLAMA_LOCAL_SEMANTIC_MEMORY_MAX_FACTS":     {"OLLAMA_LOCAL_SEMANTIC_MEMORY_MAX_FACTS", LocalSemanticMemoryMaxFacts(), "Maximum fact files before semantic merge compression (default: 10)"},
+		"OLLAMA_LOCAL_SEMANTIC_MEMORY_PROFILE_FACTS": {"OLLAMA_LOCAL_SEMANTIC_MEMORY_PROFILE_FACTS", LocalSemanticMemoryProfileFacts(), "Number of recent facts injected into new interactive sessions (default: 8)"},
+		"OLLAMA_LOAD_TIMEOUT":                        {"OLLAMA_LOAD_TIMEOUT", LoadTimeout(), "How long to allow model loads to stall before giving up (default \"5m\")"},
+		"OLLAMA_MAX_LOADED_MODELS":                   {"OLLAMA_MAX_LOADED_MODELS", MaxRunners(), "Maximum number of loaded models per GPU"},
+		"OLLAMA_MAX_TRANSFER_STREAMS":                {"OLLAMA_MAX_TRANSFER_STREAMS", MaxTransferStreams(), "Maximum parallel transfer streams for safetensors model pulls/pushes (default 4)"},
+		"OLLAMA_MAX_QUEUE":                           {"OLLAMA_MAX_QUEUE", MaxQueue(), "Maximum number of queued requests"},
+		"OLLAMA_MODELS":                              {"OLLAMA_MODELS", Models(), "The path to the models directory"},
+		"OLLAMA_NO_CLOUD":                            {"OLLAMA_NO_CLOUD", NoCloud(), "Disable Ollama cloud features (remote inference and web search)"},
+		"OLLAMA_NOHISTORY":                           {"OLLAMA_NOHISTORY", NoHistory(), "Do not preserve readline history"},
+		"OLLAMA_NOPRUNE":                             {"OLLAMA_NOPRUNE", NoPrune(), "Do not prune model blobs on startup"},
+		"OLLAMA_NUM_PARALLEL":                        {"OLLAMA_NUM_PARALLEL", NumParallel(), "Maximum number of parallel requests"},
+		"OLLAMA_ORIGINS":                             {"OLLAMA_ORIGINS", AllowedOrigins(), "A comma separated list of allowed origins"},
+		"OLLAMA_SCHED_SPREAD":                        {"OLLAMA_SCHED_SPREAD", SchedSpread(), "Always schedule model across all GPUs"},
+		"OLLAMA_CONTEXT_LENGTH":                      {"OLLAMA_CONTEXT_LENGTH", ContextLength(), "Context length to use unless otherwise specified (default: 4k/32k/256k based on VRAM)"},
+		"OLLAMA_EDITOR":                              {"OLLAMA_EDITOR", Editor(), "Path to editor for interactive prompt editing (Ctrl+G)"},
+		"OLLAMA_REMOTES":                             {"OLLAMA_REMOTES", Remotes(), "Allowed hosts for remote models (default \"ollama.com\")"},
 
 		// Informational
 		"HTTP_PROXY":  {"HTTP_PROXY", String("HTTP_PROXY")(), "HTTP proxy"},


### PR DESCRIPTION
# feat(cli): add local semantic memory compression for interactive chats

Closes #15778

## Summary

Adds an opt-in local semantic memory system to the `ollama run` interactive CLI. When enabled, Ollama captures each user turn as a short "fact" file on disk, automatically merges semantically similar facts when the collection grows too large, and injects the most recent facts as a prepended system message at the start of every new interactive session. No server changes, no cloud sync — everything lives under `~/.ollama/llm_memory/` on the user's machine.

## Motivation

The `ollama run` REPL starts each session with a blank slate. Users who interact daily must re-introduce themselves, re-state their preferences, and re-explain their context at the beginning of every conversation. This PR provides a lightweight, privacy-preserving mechanism to carry short-term context across sessions without requiring model fine-tuning, persistent conversation storage, or any network call.

## How it works

### Fact capture (per user turn)

After each user message is finalised in `generateInteractive`, `captureUserFact` writes a timestamped `.txt` file (`fact-<unix-nano>.txt`) under the memory directory. Facts shorter than three words are discarded as noise.

### Semantic compression

After every write, `compressIfNeeded` checks whether the file count exceeds `OLLAMA_LOCAL_SEMANTIC_MEMORY_MAX_FACTS` (default 10). While over the limit it:

1. Scores every pair of files with a token-level Jaccard similarity (`memorySimilarity`).
2. Merges the most-similar pair into a new `fact-merged-<unix-nano>.txt`.
   - If one string is a substring of the other, the longer string is kept.
   - Otherwise the two strings are concatenated with a newline.
3. Deletes the two source files.
4. Repeats until the count is within the limit.

This keeps the on-disk footprint bounded without discarding information unnecessarily.

### Profile injection

At the start of each `ollama run` session, `injectSystemMessage` reads the `N` most recent fact files (`OLLAMA_LOCAL_SEMANTIC_MEMORY_PROFILE_FACTS`, default 8) and prepends a synthetic `system` message:

```
Local semantic memory profile (stored only on this device):
- <fact 1>
- <fact 2>
…
Use this as probabilistic user context and defer to the latest user message when conflicts appear.
```

If a system message with this header already exists (re-entrant call), injection is skipped to avoid duplication.

## Configuration

All new variables default to disabled / off until `OLLAMA_LOCAL_SEMANTIC_MEMORY=1` is set.

| Variable | Default | Description |
|----------|---------|-------------|
| `OLLAMA_LOCAL_SEMANTIC_MEMORY` | `false` | Enable local semantic memory capture/compression |
| `OLLAMA_LOCAL_SEMANTIC_MEMORY_DIR` | `~/.ollama/llm_memory` | Directory where fact files are stored |
| `OLLAMA_LOCAL_SEMANTIC_MEMORY_MAX_FACTS` | `10` | Maximum fact files before semantic merge compression |
| `OLLAMA_LOCAL_SEMANTIC_MEMORY_PROFILE_FACTS` | `8` | Number of recent facts injected at session start |

## Files changed

| File | Change |
|------|--------|
| `cmd/local_memory.go` | New file — `localSemanticMemoryManager`, fact capture, Jaccard compression, profile injection, all pure stdlib |
| `cmd/local_memory_test.go` | New file — unit tests for normalisation, similarity scoring, compression, injection, and edge cases |
| `cmd/interactive.go` | Wire in `localSemanticMemoryManager` at session start (inject) and after each user turn (capture) |
| `cmd/cmd.go` | Expose the four new env vars in `ollama run --help` output |
| `envconfig/config.go` | Declare `LocalSemanticMemoryEnabled`, `LocalSemanticMemoryDir`, `LocalSemanticMemoryMaxFacts`, `LocalSemanticMemoryProfileFacts`; register all four in `AsMap()` |

## Example

```sh
# enable once
export OLLAMA_LOCAL_SEMANTIC_MEMORY=1

# first session — the model learns context as you chat
ollama run llama3.2
>>> I work in Go and prefer short, idiomatic code.
...

# later session — context is automatically prepended
ollama run llama3.2
# system message injected:
#   Local semantic memory profile (stored only on this device):
#   - I work in Go and prefer short, idiomatic code.
#   Use this as probabilistic user context ...
>>> Can you review this function?   # model already knows your preferences
```

## Testing

- `go test ./cmd/ -run TestLocalMemory` — all unit tests pass.
- `go build ./...` — compiles cleanly; no new external dependencies.
- Manual: start `ollama run` with the env var set, send a few messages, `exit`, restart — confirm the system message is injected with the remembered facts.
- Manual: send enough turns to exceed `OLLAMA_LOCAL_SEMANTIC_MEMORY_MAX_FACTS` — confirm old files are merged rather than deleted.

## Privacy

- All data stays on the local filesystem; no network calls are made.
- Fact files are written `0o600` (owner read/write only).
- The feature is entirely opt-in (`OLLAMA_LOCAL_SEMANTIC_MEMORY=1`).
- Users can clear memory at any time with `rm -rf ~/.ollama/llm_memory/`.

## Notes

- The compression algorithm is intentionally simple (Jaccard on lowercase word tokens, no stopword removal). This avoids any ML dependency while still grouping topically similar facts. More sophisticated compression (e.g. embedding-based) can be layered on later.
- Facts are capped at 280 characters on write to bound the injected system message size.
- The feature has no effect on `ollama serve`, API clients, or any path other than the interactive `ollama run` REPL.

---

Branch: `private/issue-15778-local-semantic-memory`
Base: `main`
