### PR TITLE
agent: allow unlimited tool rounds for cloud models by default

### DIFF
--- a/agent/session.go
+++ b/agent/session.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/internal/modelref"
 )
 
 type ChatClient interface {
@@ -39,9 +40,10 @@ type RunOptions struct {
 	Options      map[string]any
 	Think        *api.ThinkValue
 	KeepAlive    *api.Duration
-	// MaxToolRounds limits consecutive model/tool cycles.
-	// Zero uses the default guard; negative disables the guard for tests or
-	// special callers.
+	// MaxToolRounds limits consecutive model/tool cycles. A positive value is
+	// an explicit limit. Zero selects the model-specific default: local models
+	// use the default guard and cloud models are unlimited. A negative value
+	// disables the guard for tests or special callers.
 	MaxToolRounds int
 }
 
@@ -174,7 +176,7 @@ func (s *Session) Run(ctx context.Context, opts RunOptions) (*RunResult, error) 
 		opts:          opts,
 		phase:         runPhaseModel,
 		messages:      messages,
-		maxToolRounds: resolvedMaxToolRounds(opts.MaxToolRounds),
+		maxToolRounds: resolvedMaxToolRounds(opts.Model, opts.MaxToolRounds),
 	}
 	for {
 		switch st.phase {
@@ -833,11 +835,14 @@ func CompactionSkippedMessage(reason string) string {
 	return reason
 }
 
-func resolvedMaxToolRounds(value int) int {
-	if value == 0 {
-		return defaultMaxToolRounds
+func resolvedMaxToolRounds(model string, value int) int {
+	if value != 0 {
+		return value
 	}
-	return value
+	if modelref.HasExplicitCloudSource(model) {
+		return -1
+	}
+	return defaultMaxToolRounds
 }
 
 func (s *Session) toolMessageForContext(toolName, toolCallID, content string, opts RunOptions, messages []api.Message) api.Message {

--- a/agent/session_test.go
+++ b/agent/session_test.go
@@ -853,7 +853,7 @@ func TestSessionToolLoopAllowsRoundsUnderDefaultCap(t *testing.T) {
 	}
 }
 
-func TestSessionToolRoundLimitAppendsSkippedToolMessages(t *testing.T) {
+func TestSessionLocalToolRoundLimitAppendsSkippedToolMessages(t *testing.T) {
 	firstArgs := api.NewToolCallFunctionArguments()
 	firstArgs.Set("value", "first")
 	secondArgs := api.NewToolCallFunctionArguments()
@@ -902,7 +902,7 @@ func TestSessionToolRoundLimitAppendsSkippedToolMessages(t *testing.T) {
 
 	result, err := session.Run(context.Background(), RunOptions{
 		ChatID:        "chat-1",
-		Model:         "model",
+		Model:         "test:local",
 		NewMessages:   []api.Message{{Role: "user", Content: "hit cap"}},
 		MaxToolRounds: 1,
 	})
@@ -926,7 +926,7 @@ func TestSessionToolRoundLimitAppendsSkippedToolMessages(t *testing.T) {
 	}
 }
 
-func TestSessionToolLoopStopsAtDefaultRoundCap(t *testing.T) {
+func TestSessionLocalToolLoopStopsAtDefaultRoundCap(t *testing.T) {
 	responses := make([][]api.ChatResponse, 0, defaultMaxToolRounds+1)
 	for range defaultMaxToolRounds + 1 {
 		args := api.NewToolCallFunctionArguments()
@@ -952,7 +952,7 @@ func TestSessionToolLoopStopsAtDefaultRoundCap(t *testing.T) {
 	}
 
 	_, err := session.Run(context.Background(), RunOptions{
-		Model:       "model",
+		Model:       "test:local",
 		NewMessages: []api.Message{{Role: "user", Content: "keep going"}},
 	})
 	if err == nil || !strings.Contains(err.Error(), "tool round limit reached after 100 rounds") {
@@ -960,6 +960,53 @@ func TestSessionToolLoopStopsAtDefaultRoundCap(t *testing.T) {
 	}
 	if client.calls != defaultMaxToolRounds+1 {
 		t.Fatalf("client calls = %d, want %d", client.calls, defaultMaxToolRounds+1)
+	}
+}
+
+func TestSessionCloudToolLoopHonorsExplicitRoundCap(t *testing.T) {
+	args := api.NewToolCallFunctionArguments()
+	args.Set("value", "hello")
+	client := &fakeClient{responses: [][]api.ChatResponse{
+		{{
+			Message: api.Message{Role: "assistant", ToolCalls: []api.ToolCall{{
+				ID: "call-1",
+				Function: api.ToolCallFunction{
+					Name:      "echo_tool",
+					Arguments: args,
+				},
+			}}},
+		}},
+		{{
+			Message: api.Message{Role: "assistant", ToolCalls: []api.ToolCall{{
+				ID: "call-2",
+				Function: api.ToolCallFunction{
+					Name:      "echo_tool",
+					Arguments: args,
+				},
+			}}},
+		}},
+	}}
+	registry := &Registry{}
+	registry.Register(staticTool{})
+	session := &Session{
+		Client:        client,
+		Tools:         registry,
+		ApprovalState: approvalStateForTest(true, nil),
+	}
+
+	result, err := session.Run(context.Background(), RunOptions{
+		Model:         "test:cloud",
+		NewMessages:   []api.Message{{Role: "user", Content: "keep going"}},
+		MaxToolRounds: 1,
+	})
+	if err == nil || !strings.Contains(err.Error(), "tool round limit reached after 1 rounds") {
+		t.Fatalf("error = %v, want explicit tool-round limit", err)
+	}
+	if result == nil {
+		t.Fatal("expected partial result with skipped tool message")
+	}
+	if client.calls != 2 {
+		t.Fatalf("client calls = %d, want 2", client.calls)
 	}
 }
 

--- a/cmd/tui/chat/input_test.go
+++ b/cmd/tui/chat/input_test.go
@@ -419,6 +419,35 @@ func TestChatInputAcceptsSpace(t *testing.T) {
 	}
 }
 
+func TestChatCloudModelDefaultToolRoundsAreUnlimited(t *testing.T) {
+	const formerDefaultLimit = 100
+	client := &chatToolLoopClient{toolRounds: formerDefaultLimit + 1}
+	registry := &coreagent.Registry{}
+	registry.Register(chatTestTool{})
+	m := chatModel{
+		ctx: context.Background(),
+		opts: Options{
+			Model:         "test:cloud",
+			Client:        client,
+			Tools:         registry,
+			AllowAllTools: true,
+		},
+	}
+
+	updated, cmd := m.startRun("keep going")
+	m = updated.(chatModel)
+	if cmd == nil {
+		t.Fatal("startRun should start a cloud model run")
+	}
+	done := waitForRunDone(t, m.events)
+	if done.err != nil {
+		t.Fatalf("cloud run returned error: %v", done.err)
+	}
+	if client.calls != formerDefaultLimit+2 {
+		t.Fatalf("client calls = %d, want %d", client.calls, formerDefaultLimit+2)
+	}
+}
+
 func TestChatLargePasteUsesPlaceholderAndExpandsOnSubmit(t *testing.T) {
 	pasted := strings.Repeat("line\n", pastedTextPlaceholderMinLines-1) + "line"
 	m := chatModel{

--- a/cmd/tui/chat/test_helpers_test.go
+++ b/cmd/tui/chat/test_helpers_test.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"testing"
 	"time"
@@ -18,6 +19,11 @@ type chatTestClient struct{}
 
 type chatCaptureClient struct {
 	requests []*api.ChatRequest
+}
+
+type chatToolLoopClient struct {
+	calls      int
+	toolRounds int
 }
 
 func (chatTestClient) Chat(ctx context.Context, req *api.ChatRequest, fn api.ChatResponseFunc) error {
@@ -39,6 +45,26 @@ func (c *chatCaptureClient) Chat(ctx context.Context, req *api.ChatRequest, fn a
 		Message: api.Message{Role: "assistant", Content: "ok"},
 		Done:    true,
 	})
+}
+
+func (c *chatToolLoopClient) Chat(ctx context.Context, req *api.ChatRequest, fn api.ChatResponseFunc) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	c.calls++
+	if c.calls > c.toolRounds {
+		return fn(api.ChatResponse{Message: api.Message{Role: "assistant", Content: "done"}, Done: true})
+	}
+
+	args := api.NewToolCallFunctionArguments()
+	args.Set("value", "keep going")
+	return fn(api.ChatResponse{Message: api.Message{Role: "assistant", ToolCalls: []api.ToolCall{{
+		ID: fmt.Sprintf("call-%d", c.calls),
+		Function: api.ToolCallFunction{
+			Name:      "fake_tool",
+			Arguments: args,
+		},
+	}}}})
 }
 
 func (chatTestTool) Name() string {


### PR DESCRIPTION
## Summary

Makes the agent's tool-round guard model-source aware. Cloud models (`:cloud`) get **unlimited** tool rounds by default, while local models keep the existing default cap of 100. An explicit positive `MaxToolRounds` still bounds both; negative values remain an opt-out for tests/special callers.

## Why

Cloud-backed runs can sustain longer agentic loops than the local default guard was tuned for. Keeping the cap for local models preserves the existing safety behavior, while cloud models are no longer cut off at 100 rounds when no limit is specified.

## Changes

- `agent/session.go`: `resolvedMaxToolRounds` now takes the model name and, when `MaxToolRounds == 0`, returns `-1` (unlimited) for cloud-sourced models via `modelref.HasExplicitCloudSource`, otherwise the default cap. Updated the `MaxToolRounds` doc comment.
- `agent/session_test.go`: renamed two existing tests to `...Local...` and pointed them at `test:local`; added `TestSessionCloudToolLoopHonorsExplicitRoundCap` confirming an explicit cap still binds cloud models.
- `cmd/tui/chat/input_test.go` + `test_helpers_test.go`: new `chatToolLoopClient` fake and `TestChatCloudModelDefaultToolRoundsAreUnlimited` verifying the TUI run path lets a `test:cloud` model exceed the old 100-round default.

## Notes / discussion

- Default callers (TUI / `ollama run`) pass `MaxToolRounds: 0`, so cloud models will be **genuinely unbounded** -- a model that keeps emitting tool calls loops until context cancellation. This is intentional but worth confirming as the desired product behavior vs. a higher cloud-specific ceiling.
- Explicit `MaxToolRounds` still works to bound cloud runs if a caller wants a guard.

## Verification

- `go test ./agent/... ./cmd/tui/chat/...` -- pass
- `go vet` / `gofmt` -- clean

