### PR TITLE
anthropic: close text block before starting thinking block

### DIFF
--- a/anthropic/anthropic.go
+++ b/anthropic/anthropic.go
@@ -777,6 +777,18 @@ func (c *StreamConverter) Process(r api.ChatResponse) []StreamEvent {
 	}
 
 	if r.Message.Thinking != "" && !c.thinkingDone {
+		if c.textStarted {
+			events = append(events, StreamEvent{
+				Event: "content_block_stop",
+				Data: ContentBlockStopEvent{
+					Type:  "content_block_stop",
+					Index: c.contentIndex,
+				},
+			})
+			c.contentIndex++
+			c.textStarted = false
+		}
+
 		if !c.thinkingStarted {
 			c.thinkingStarted = true
 			events = append(events, StreamEvent{

--- a/anthropic/anthropic_test.go
+++ b/anthropic/anthropic_test.go
@@ -3,6 +3,7 @@ package anthropic
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -1137,6 +1138,56 @@ func TestStreamConverter_ThinkingDirectlyFollowedByToolCall(t *testing.T) {
 	}
 	if toolStop == nil {
 		t.Error("expected content_block_stop for tool_use block (index 1)")
+	}
+}
+
+func TestStreamConverter_TextBeforeThinking(t *testing.T) {
+	conv := NewStreamConverter("msg_123", "test-model", 0)
+
+	responses := []api.ChatResponse{
+		{Message: api.Message{Role: "assistant", Content: "---\n"}},
+		{Message: api.Message{Role: "assistant", Thinking: "Let me think."}},
+		{
+			Message:    api.Message{Role: "assistant", Content: "The answer."},
+			Done:       true,
+			DoneReason: "stop",
+			Metrics:    api.Metrics{PromptEvalCount: 10, EvalCount: 5},
+		},
+	}
+
+	var got []string
+	for _, response := range responses {
+		for _, event := range conv.Process(response) {
+			switch data := event.Data.(type) {
+			case ContentBlockStartEvent:
+				got = append(got, fmt.Sprintf("%s:%s:%d", event.Event, data.ContentBlock.Type, data.Index))
+			case ContentBlockDeltaEvent:
+				got = append(got, fmt.Sprintf("%s:%s:%d", event.Event, data.Delta.Type, data.Index))
+			case ContentBlockStopEvent:
+				got = append(got, fmt.Sprintf("%s:%d", event.Event, data.Index))
+			default:
+				got = append(got, event.Event)
+			}
+		}
+	}
+
+	want := []string{
+		"message_start",
+		"content_block_start:text:0",
+		"content_block_delta:text_delta:0",
+		"content_block_stop:0",
+		"content_block_start:thinking:1",
+		"content_block_delta:thinking_delta:1",
+		"content_block_stop:1",
+		"content_block_start:text:2",
+		"content_block_delta:text_delta:2",
+		"content_block_stop:2",
+		"message_delta",
+		"message_stop",
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("unexpected stream events (-want +got):\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
## Summary

Close an active text content block before starting a thinking block in the
Anthropic streaming converter.

## Problem

Some thinking-capable models can emit text before their thinking content. For
example, Gemma 4 may emit a leading `---` before beginning to think.

The converter started the text block at index 0, but did not close it before
starting the thinking block. The thinking block therefore reused index 0,
producing an invalid Anthropic stream:

```text
content_block_start  index=0  type=text
content_block_delta  index=0  type=text_delta
content_block_start  index=0  type=thinking
```

Clients such as Claude Code reject this stream with:
```
API Error: Content block not found
```

## Fix
Before starting a thinking block:
- close any active text block
- advance the content block index
- clear the text block state

This produces sequential text, thinking, and final-answer blocks with indexes
0, 1, and 2.

## Testing
Added TestStreamConverter_TextBeforeThinking, covering the complete:
```
text → thinking → final text
```
transition and asserting the exact event types, ordering, and indexes.
```
go test ./anthropic -count=1
```