### PR TITLE
cmd: remove dead agent prompt wrappers

### DIFF
--- a/cmd/agent_tui.go
+++ b/cmd/agent_tui.go
@@ -331,16 +331,8 @@ func agentWorkingDir() string {
 	return cwd
 }
 
-func agentSystemPrompt(modelName string, modelSystem string, extra string) string {
-	return agentSystemPromptWithWorkingDir(modelName, modelSystem, extra, agentWorkingDir())
-}
-
 func agentSystemPromptWithWorkingDir(modelName string, modelSystem string, extra string, workingDir string) string {
 	return agentSystemPromptAtWithWorkingDir(time.Now(), modelName, modelSystem, extra, workingDir)
-}
-
-func agentSystemPromptAt(now time.Time, modelName string, modelSystem string, extra string) string {
-	return agentSystemPromptAtWithWorkingDir(now, modelName, modelSystem, extra, agentWorkingDir())
 }
 
 func agentSystemPromptAtWithWorkingDir(now time.Time, modelName string, modelSystem string, extra string, workingDir string) string {
@@ -353,10 +345,6 @@ func agentSystemPromptAtWithWorkingDir(now time.Time, modelName string, modelSys
 		parts = append(parts, strings.TrimSpace(extra))
 	}
 	return strings.Join(parts, "\n\n")
-}
-
-func agentDefaultSystemPrompt(now time.Time, modelName string) string {
-	return agentDefaultSystemPromptWithWorkingDir(now, modelName, agentWorkingDir())
 }
 
 func agentDefaultSystemPromptWithWorkingDir(now time.Time, modelName string, workingDir string) string {


### PR DESCRIPTION
## Summary

Remove three unreferenced agent system-prompt wrappers.

## Root cause

The working-directory prompt change retained wrappers that are no longer used by production code. `golangci-lint` reports them as unused when it falls back from new-issues mode to a full lint run.

## Validation

- `golangci-lint run ./cmd/...`
- `go test -count=1 ./cmd/...`

Production prompt behavior continues to use the explicit working-directory helpers.