### PR TITLE
agent: reorder working directory instruction

### DIFF
--- a/cmd/agent_tui.go
+++ b/cmd/agent_tui.go
@@ -371,9 +371,6 @@ func agentDefaultSystemPromptWithWorkingDir(now time.Time, modelName string, wor
 		"Current date: " + date + ".",
 		"",
 	}
-	if workingDir != "" {
-		parts = append(parts, "Current working directory: "+strconv.Quote(workingDir)+".", "")
-	}
 	parts = append(parts,
 		"Be concise, practical, and action-oriented. Use tools when they materially help. Verify current or fast-changing facts with web tools when available; otherwise state uncertainty.",
 		"",
@@ -381,6 +378,9 @@ func agentDefaultSystemPromptWithWorkingDir(now time.Time, modelName string, wor
 		"",
 		"Tell the user about meaningful changes, verification, failures, blockers, assumptions, and risks. Summarize routine tool output instead of dumping it.",
 	)
+	if workingDir != "" {
+		parts = append(parts, "Current working directory: "+strconv.Quote(workingDir)+".")
+	}
 	return strings.Join(parts, "\n")
 }
 


### PR DESCRIPTION
## Summary
- move the agent working-directory instruction immediately below the meaningful-changes instruction
- preserve the instruction text and all other prompt copy


## Why
Improve cache hits. Probably.

## Validation
- `go test ./cmd -run '^TestAgentSystemPromptIncludesSessionWorkingDirOnce$' -count=1`