### PR TITLE
server: clone cached tool call arguments

### DIFF
--- a/server/model_show_cache.go
+++ b/server/model_show_cache.go
@@ -620,7 +620,23 @@ func cloneMessages(in []api.Message) []api.Message {
 				out[i].Images[j] = slices.Clone(image)
 			}
 		}
-		out[i].ToolCalls = slices.Clone(msg.ToolCalls)
+		out[i].ToolCalls = cloneToolCalls(msg.ToolCalls)
+	}
+	return out
+}
+
+func cloneToolCalls(in []api.ToolCall) []api.ToolCall {
+	if in == nil {
+		return nil
+	}
+	out := make([]api.ToolCall, len(in))
+	for i, call := range in {
+		out[i] = call
+		var args api.ToolCallFunctionArguments
+		for key, value := range call.Function.Arguments.All() {
+			args.Set(key, cloneAny(value))
+		}
+		out[i].Function.Arguments = args
 	}
 	return out
 }

--- a/server/model_show_cache_test.go
+++ b/server/model_show_cache_test.go
@@ -433,6 +433,48 @@ func TestModelShowCacheCloudKeyNormalizesSourceTags(t *testing.T) {
 	}
 }
 
+func TestCloneShowResponseClonesToolCallArguments(t *testing.T) {
+	args := api.NewToolCallFunctionArguments()
+	args.Set("title", "original")
+	args.Set("metadata", map[string]any{"status": "original"})
+	args.Set("items", []any{map[string]any{"name": "original"}})
+
+	source := &api.ShowResponse{
+		Messages: []api.Message{{
+			ToolCalls: []api.ToolCall{{
+				Function: api.ToolCallFunction{Arguments: args},
+			}},
+		}},
+	}
+
+	clone := cloneShowResponse(source)
+	cloneArgs := &clone.Messages[0].ToolCalls[0].Function.Arguments
+	cloneArgs.Set("title", "changed")
+	cloneMetadata, ok := cloneArgs.Get("metadata")
+	if !ok {
+		t.Fatal("cloned metadata argument is missing")
+	}
+	cloneMetadata.(map[string]any)["status"] = "changed"
+	cloneItems, ok := cloneArgs.Get("items")
+	if !ok {
+		t.Fatal("cloned items argument is missing")
+	}
+	cloneItems.([]any)[0].(map[string]any)["name"] = "changed"
+
+	sourceArgs := &source.Messages[0].ToolCalls[0].Function.Arguments
+	if got, _ := sourceArgs.Get("title"); got != "original" {
+		t.Errorf("source title = %q, want original", got)
+	}
+	sourceMetadata, _ := sourceArgs.Get("metadata")
+	if got := sourceMetadata.(map[string]any)["status"]; got != "original" {
+		t.Errorf("source metadata status = %q, want original", got)
+	}
+	sourceItems, _ := sourceArgs.Get("items")
+	if got := sourceItems.([]any)[0].(map[string]any)["name"]; got != "original" {
+		t.Errorf("source item name = %q, want original", got)
+	}
+}
+
 func TestModelShowCacheCloudDisabledDoesNotServeStale(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	setTestHome(t, t.TempDir())


### PR DESCRIPTION
## Summary
- Deep-clone ordered tool-call arguments while cloning cached model-show responses.
- Clone nested JSON-shaped argument values so callers cannot mutate data retained by the cache.
- Add a regression test that mutates top-level and nested arguments in a cloned response.

## Why
`ToolCallFunctionArguments` wraps a pointer-backed ordered map. Copying the tool-call slice duplicated the struct but still shared that map with the cached response. Mutating a returned response could therefore alter a later cache hit.

## Testing
- `go test ./api -count=1`
- `go test ./server/` *(passed locally, including the new regression test)*