### PR TITLE
mlxrunner: reject structured output requests instead of ignoring them

### DIFF
--- a/x/mlxrunner/client.go
+++ b/x/mlxrunner/client.go
@@ -153,6 +153,18 @@ func (c *Client) Close() error {
 
 // Completion implements llm.LlamaServer.
 func (c *Client) Completion(ctx context.Context, req llm.CompletionRequest, fn func(llm.CompletionResponse)) error {
+	// The MLX runner has no constrained sampling, so a format request would be
+	// silently ignored and the caller handed output that never conformed to
+	// its schema. Reject it up front instead.
+	switch string(req.Format) {
+	case ``, `null`, `""`:
+	default:
+		return api.StatusError{
+			StatusCode:   http.StatusBadRequest,
+			ErrorMessage: fmt.Sprintf("%q does not support structured outputs (format) on the MLX engine", c.modelName),
+		}
+	}
+
 	creq := CompletionRequest{
 		Prompt:      req.Prompt,
 		Logprobs:    req.Logprobs,

--- a/x/mlxrunner/client_test.go
+++ b/x/mlxrunner/client_test.go
@@ -1,0 +1,108 @@
+package mlxrunner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/llm"
+)
+
+// newTestClient returns a Client pointed at a fake runner that streams a
+// single successful completion response, plus a counter of requests received.
+func newTestClient(t *testing.T) (*Client, *atomic.Int64) {
+	t.Helper()
+
+	var hits atomic.Int64
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		resp, err := json.Marshal(CompletionResponse{Content: "hi", Done: true})
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		w.Write(append(resp, '\n'))
+	}))
+	t.Cleanup(ts.Close)
+
+	u, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return &Client{
+		modelName: "test-model",
+		port:      port,
+		client:    ts.Client(),
+	}, &hits
+}
+
+func TestCompletionRejectsFormat(t *testing.T) {
+	cases := []struct {
+		name   string
+		format json.RawMessage
+		reject bool
+	}{
+		{name: "unset", format: nil, reject: false},
+		{name: "empty", format: json.RawMessage(``), reject: false},
+		{name: "null", format: json.RawMessage(`null`), reject: false},
+		{name: "empty string", format: json.RawMessage(`""`), reject: false},
+		{name: "json mode", format: json.RawMessage(`"json"`), reject: true},
+		{name: "schema", format: json.RawMessage(`{"type":"object"}`), reject: true},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			c, hits := newTestClient(t)
+
+			var got []llm.CompletionResponse
+			err := c.Completion(context.Background(), llm.CompletionRequest{
+				Prompt: "Say hi",
+				Format: tt.format,
+			}, func(r llm.CompletionResponse) {
+				got = append(got, r)
+			})
+
+			if tt.reject {
+				var serr api.StatusError
+				if !errors.As(err, &serr) {
+					t.Fatalf("expected api.StatusError, got %v", err)
+				}
+				if serr.StatusCode != http.StatusBadRequest {
+					t.Errorf("expected status %d, got %d", http.StatusBadRequest, serr.StatusCode)
+				}
+				if !strings.Contains(serr.ErrorMessage, "structured outputs") {
+					t.Errorf("unexpected error message: %q", serr.ErrorMessage)
+				}
+				if hits.Load() != 0 {
+					t.Errorf("request should not reach the runner, got %d requests", hits.Load())
+				}
+				if len(got) != 0 {
+					t.Errorf("no responses should be delivered, got %d", len(got))
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if len(got) != 1 || got[0].Content != "hi" {
+					t.Errorf("expected one response with content %q, got %+v", "hi", got)
+				}
+				if hits.Load() != 1 {
+					t.Errorf("expected exactly one runner request, got %d", hits.Load())
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #16563

Structured outputs on MLX models silently do nothing: `Client.Completion` in `x/mlxrunner/client.go` never forwards `req.Format` (the runner request struct has no format field, and the MLX sampler has no constrained sampling), so a request with a schema comes back 200 with output that never saw the schema. That matches what the reports in the issue describe with the qwen3.5 and gemma4 MLX variants.

Until the MLX engine grows constrained sampling, this makes the failure explicit: a format request against an MLX model now returns a 400 saying the model does not support structured outputs on the MLX engine, the same shape as the existing thinking capability check in `server/routes.go`. Unset values (missing, `null`, `""`) still pass through, mirroring the llama-server path's semantics in `llm/llama_server.go`.

Testing: added a regression test (table of set/unset format values) that fails on main and passes with the change, and go build/test/golangci-lint are clean on the touched package. I also traced the error path through the chat and generate handlers: the 400 surfaces via `api.StatusError`, and it does not trigger the scheduler's runtime OOM eviction (that path is guarded by `llm.IsOutOfMemory`). Two things to be upfront about: my machine has no Metal toolchain for the MLX native build, so I could not run a live MLX model end to end (verification is the unit test plus the code trace above). And for thinking-capable MLX models the server defers format to a second request, so the error there surfaces mid-stream rather than up front. That is an artifact of the existing deferral flow, and still strictly better than silently returning non-conforming output.

quick note: I'm a college freshman trying to contribute for the greater good :) this fix came together with Claude Code's help (we dug through the runner plumbing together and I ran the build, tests and lint locally). apologies if I've missed something obvious, and if there is a mistake here I'd honestly love to learn from it.