### PR TITLE
mlx: install required libraries for docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -300,7 +300,7 @@ RUN sed -i \
         -e "s|http://ports.ubuntu.com/ubuntu-ports|$APT_PORTS_MIRROR|g" \
         /etc/apt/sources.list.d/ubuntu.sources \
     && apt-get update \
-    && apt-get install -y ca-certificates libvulkan1 libopenblas0 \
+    && apt-get install -y ca-certificates libvulkan1 libopenblas0 libquadmath0 \
     && sed -i \
         -e "s|$APT_MIRROR|http://archive.ubuntu.com/ubuntu|g" \
         -e "s|$APT_PORTS_MIRROR|http://ports.ubuntu.com/ubuntu-ports|g" \
@@ -310,7 +310,7 @@ RUN sed -i \
 COPY --from=image-archive /bin /usr/bin
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 COPY --from=image-archive /lib/ollama /usr/lib/ollama
-ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64
+ENV LD_LIBRARY_PATH=/usr/lib/ollama/mlx_cuda_v13:/usr/local/nvidia/lib:/usr/local/nvidia/lib64
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV OLLAMA_HOST=0.0.0.0:11434

--- a/cmake/mlx/CMakeLists.txt
+++ b/cmake/mlx/CMakeLists.txt
@@ -302,14 +302,26 @@ endif()
 # Manually install CUDA runtime libraries that MLX loads via dlopen
 # (not detected by RUNTIME_DEPENDENCIES since they aren't link-time deps).
 if(CUDAToolkit_FOUND)
-    file(GLOB MLX_CUDA_LIBS
-        "${CUDAToolkit_LIBRARY_DIR}/libcudart.so*"
-        "${CUDAToolkit_LIBRARY_DIR}/libcublas.so*"
-        "${CUDAToolkit_LIBRARY_DIR}/libcublasLt.so*"
-        "${CUDAToolkit_LIBRARY_DIR}/libnvrtc.so*"
-        "${CUDAToolkit_LIBRARY_DIR}/libnvrtc-builtins.so*"
-        "${CUDAToolkit_LIBRARY_DIR}/libcufft.so*"
-        "${CUDAToolkit_LIBRARY_DIR}/libcudnn.so*")
+    set(_dlopen_libs
+        cudart
+        cublas
+        cublasLt
+        nvrtc
+        nvrtc-builtins
+        cufft
+        cudnn
+        cudnn_engines_tensor_ir
+    )
+    foreach(lib_name IN LISTS _dlopen_libs)
+        find_library(_CUDA_LIBRARY NAMES ${lib_name} HINTS ${CUDAToolkit_LIBRARY_DIR})
+        if(_CUDA_LIBRARY)
+            get_filename_component(_CUDA_LIBRARY_DIR "${_CUDA_LIBRARY}" DIRECTORY)
+            file(GLOB _CUDA_LIBRARY_DIR_LIBS "${_CUDA_LIBRARY_DIR}/lib${lib_name}.so*")
+            list(APPEND MLX_CUDA_LIBS ${_CUDA_LIBRARY_DIR_LIBS})
+        endif()
+        unset(_CUDA_LIBRARY CACHE)
+    endforeach()
+
     if(MLX_CUDA_LIBS)
         install(FILES ${MLX_CUDA_LIBS}
             DESTINATION ${OLLAMA_INSTALL_DIR}


### PR DESCRIPTION
Not all CUDA libraries are located in $CUDAToolkit_LIBRARY_DIR (notably cudnn_engines_tensor_ir), use `find_library` to find them rather than path.

Install required library libquadmath0.

Include mlx_cuda_v13 in LD_LIBRARY_PATH so that dlopen() can find libraries.

Fixes: #14016