### PR TITLE
README: add OpenTypeless to community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ console.log(response.message.content);
 - [AppFlowy](https://github.com/AppFlowy-IO/AppFlowy) - AI collaborative workspace, self-hostable Notion alternative
 - [Screenpipe](https://github.com/mediar-ai/screenpipe) - 24/7 screen and mic recording with AI-powered search
 - [Vibe](https://github.com/thewh1teagle/vibe) - Transcribe and analyze meetings
+- [OpenTypeless](https://github.com/tover0314-w/opentypeless) - Cross-platform voice typing with local text polishing through Ollama
 - [Page Assist](https://github.com/n4ze3m/page-assist) - Chrome extension for AI-powered browsing
 - [NativeMind](https://github.com/NativeMindBrowser/NativeMindExtension) - Private, on-device browser AI assistant
 - [Ollama Fortress](https://github.com/ParisNeo/ollama_proxy_server) - Security proxy for Ollama


### PR DESCRIPTION
## Summary

Add OpenTypeless to the README's Productivity & Apps community integrations.

OpenTypeless is an MIT-licensed, cross-platform voice typing application. It supports Ollama as a local LLM provider for optional transcript polishing, selected-text transformations, and app-aware writing.

## Validation

- Confirmed the Ollama provider is implemented in the OpenTypeless repository.
- Confirmed there is no existing OpenTypeless README entry or pull request.
- Ran `git diff --check`.

This is a documentation-only change.
