### PR TITLE
model: add Laguna MLX support with custom kernels

### DIFF
--- a/model/parsers/laguna.go
+++ b/model/parsers/laguna.go
@@ -94,6 +94,17 @@ func (p *LagunaParser) Init(tools []api.Tool, lastMessage *api.Message, thinkVal
 	return tools
 }
 
+// LagunaV8Parser matches the v8 renderer, which closes any assistant history
+// turn and emits a fresh assistant generation prompt instead of continuing the
+// final assistant message in place.
+type LagunaV8Parser struct {
+	LagunaParser
+}
+
+func (p *LagunaV8Parser) Init(tools []api.Tool, _ *api.Message, thinkValue *api.ThinkValue) []api.Tool {
+	return p.LagunaParser.Init(tools, nil, thinkValue)
+}
+
 func (p *LagunaParser) Add(s string, done bool) (content string, thinking string, calls []api.ToolCall, err error) {
 	p.buffer.WriteString(s)
 	var contentSB, thinkingSB strings.Builder

--- a/model/parsers/laguna_test.go
+++ b/model/parsers/laguna_test.go
@@ -20,6 +20,23 @@ func lagunaTestTools() []api.Tool {
 	}}
 }
 
+func lagunaParseChunks(t *testing.T, parser Parser, chunks ...string) (string, string, []api.ToolCall) {
+	t.Helper()
+
+	var content, thinking string
+	var calls []api.ToolCall
+	for i, chunk := range chunks {
+		chunkContent, chunkThinking, chunkCalls, err := parser.Add(chunk, i == len(chunks)-1)
+		if err != nil {
+			t.Fatalf("Add(%q, done=%t): %v", chunk, i == len(chunks)-1, err)
+		}
+		content += chunkContent
+		thinking += chunkThinking
+		calls = append(calls, chunkCalls...)
+	}
+	return content, thinking, calls
+}
+
 func TestLagunaParserToolCall(t *testing.T) {
 	parser := ParserForName("laguna")
 	if parser == nil {
@@ -515,6 +532,27 @@ func TestLagunaParserNonAssistantLastMessageStillPrimesThinking(t *testing.T) {
 	}
 }
 
+func TestLagunaV8ParserAssistantHistoryStillPrimesThinking(t *testing.T) {
+	// Laguna v8 closes assistant history and emits a fresh generation prompt,
+	// so an assistant tail message must not switch the parser into prefill mode.
+	parser := ParserForName("laguna-v8")
+	if parser == nil {
+		t.Fatal("expected laguna-v8 parser")
+	}
+	if !parser.HasToolSupport() || !parser.HasThinkingSupport() {
+		t.Fatal("laguna-v8 parser should advertise tools and thinking")
+	}
+
+	parser.Init(nil, &api.Message{Role: "assistant", Content: "Previous."}, &api.ThinkValue{Value: true})
+	content, thinking, calls, err := parser.Add("Reasoning.</think>Answer.", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if content != "Answer." || thinking != "Reasoning." || len(calls) != 0 {
+		t.Fatalf("content=%q thinking=%q calls=%d", content, thinking, len(calls))
+	}
+}
+
 func TestLagunaParserStripsLeadingContentWhitespace(t *testing.T) {
 	// No-think prompts prime </think>, so the model emits a leading newline
 	// before content; the parser drops it.
@@ -573,5 +611,91 @@ func TestLagunaParserSplitToolTag(t *testing.T) {
 	}
 	if content != "" || thinking != "" || len(calls) != 1 {
 		t.Fatalf("second chunk content=%q thinking=%q calls=%d", content, thinking, len(calls))
+	}
+}
+
+func TestLagunaParserPartialToolCallFakeoutInContent(t *testing.T) {
+	parser := ParserForName("laguna")
+	parser.Init(lagunaTestTools(), nil, nil)
+
+	content, thinking, calls := lagunaParseChunks(t, parser, "Document literal <tool_call", " fakeout")
+	if content != "Document literal <tool_call fakeout" || thinking != "" || len(calls) != 0 {
+		t.Fatalf("content=%q thinking=%q calls=%d", content, thinking, len(calls))
+	}
+}
+
+func TestLagunaParserPartialToolCallFakeoutInThinking(t *testing.T) {
+	parser := ParserForName("laguna")
+	parser.Init(lagunaTestTools(), nil, &api.ThinkValue{Value: true})
+
+	content, thinking, calls := lagunaParseChunks(t, parser, "<think>Document literal <tool_c", " fakeout")
+	if content != "" || thinking != "Document literal <tool_c fakeout" || len(calls) != 0 {
+		t.Fatalf("content=%q thinking=%q calls=%d", content, thinking, len(calls))
+	}
+}
+
+func TestLagunaParserPartialThinkOpenFakeoutInContent(t *testing.T) {
+	tests := []struct {
+		name       string
+		thinkValue *api.ThinkValue
+		last       *api.Message
+	}{
+		{
+			name: "default off",
+		},
+		{
+			name:       "explicit off",
+			thinkValue: &api.ThinkValue{Value: false},
+		},
+		{
+			name:       "enabled assistant prefill content",
+			thinkValue: &api.ThinkValue{Value: true},
+			last:       &api.Message{Role: "assistant", Content: "prefill"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := ParserForName("laguna")
+			parser.Init(nil, tt.last, tt.thinkValue)
+
+			content, thinking, calls := lagunaParseChunks(t, parser, "Document literal <think", " fakeout")
+			if content != "Document literal <think fakeout" || thinking != "" || len(calls) != 0 {
+				t.Fatalf("content=%q thinking=%q calls=%d", content, thinking, len(calls))
+			}
+		})
+	}
+}
+
+func TestLagunaParserPartialThinkCloseFakeoutAtContentStart(t *testing.T) {
+	tests := []struct {
+		name       string
+		thinkValue *api.ThinkValue
+		last       *api.Message
+	}{
+		{
+			name: "default off",
+		},
+		{
+			name:       "explicit off",
+			thinkValue: &api.ThinkValue{Value: false},
+		},
+		{
+			name:       "enabled assistant prefill content",
+			thinkValue: &api.ThinkValue{Value: true},
+			last:       &api.Message{Role: "assistant", Content: "prefill"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := ParserForName("laguna")
+			parser.Init(nil, tt.last, tt.thinkValue)
+
+			content, thinking, calls := lagunaParseChunks(t, parser, "</think", " fakeout")
+			if content != "</think fakeout" || thinking != "" || len(calls) != 0 {
+				t.Fatalf("content=%q thinking=%q calls=%d", content, thinking, len(calls))
+			}
+		})
 	}
 }

--- a/model/parsers/parsers.go
+++ b/model/parsers/parsers.go
@@ -94,6 +94,8 @@ func ParserForName(name string) Parser {
 		return &LFM2Parser{hasThinkingSupport: true}
 	case "laguna":
 		return &LagunaParser{}
+	case "laguna-v8":
+		return &LagunaV8Parser{}
 	case "cohere":
 		return &CohereParser{}
 	default:

--- a/model/renderers/laguna.go
+++ b/model/renderers/laguna.go
@@ -82,15 +82,16 @@ func (r *LagunaRenderer) Render(messages []api.Message, tools []api.Tool, think 
 			sb.WriteString(content)
 			sb.WriteString("\n</user>\n")
 		case "assistant":
+			content, reasoning := lagunaV2AssistantContent(message.Content, message.Thinking)
 			lastMessage := i == len(messages)-1
-			prefill := lastMessage && (strings.TrimSpace(content) != "" || strings.TrimSpace(message.Thinking) != "" || len(message.ToolCalls) > 0)
+			prefill := lastMessage && (strings.TrimSpace(content) != "" || strings.TrimSpace(reasoning) != "" || len(message.ToolCalls) > 0)
 
 			sb.WriteString("<assistant>\n")
 
 			// Every assistant turn opens with the reasoning block: a full
 			// <think>…</think> when there is reasoning, otherwise a bare
 			// </think> marking the turn as direct.
-			if reasoning := strings.TrimSpace(message.Thinking); reasoning != "" {
+			if reasoning := strings.TrimSpace(reasoning); reasoning != "" {
 				sb.WriteString("<think>\n")
 				sb.WriteString(reasoning)
 				sb.WriteString("\n</think>\n")
@@ -112,7 +113,7 @@ func (r *LagunaRenderer) Render(messages []api.Message, tools []api.Tool, think 
 					sb.WriteString(name)
 					sb.WriteString("</arg_key>\n")
 					sb.WriteString("<arg_value>")
-					sb.WriteString(formatToolCallArgument(value))
+					sb.WriteString(formatLagunaToolCallArgument(value))
 					sb.WriteString("</arg_value>\n")
 				}
 				sb.WriteString("</tool_call>\n")
@@ -145,4 +146,138 @@ func (r *LagunaRenderer) Render(messages []api.Message, tools []api.Tool, think 
 	}
 
 	return sb.String(), nil
+}
+
+func lagunaV2AssistantContent(content, reasoning string) (string, string) {
+	if !strings.Contains(content, lagunaThoughtClose) {
+		return content, reasoning
+	}
+
+	if reasoning == "" {
+		before, _, _ := strings.Cut(content, lagunaThoughtClose)
+		before = strings.TrimRight(before, "\n")
+		if i := strings.LastIndex(before, lagunaThoughtOpen); i >= 0 {
+			before = before[i+len(lagunaThoughtOpen):]
+		}
+		reasoning = strings.TrimLeft(before, "\n")
+	}
+
+	parts := strings.Split(content, lagunaThoughtClose)
+	content = strings.TrimLeft(parts[len(parts)-1], "\n")
+	return content, reasoning
+}
+
+type LagunaV8Renderer struct{}
+
+func (r *LagunaV8Renderer) LeadingBOS() string {
+	return lagunaBOS
+}
+
+func (r *LagunaV8Renderer) Render(messages []api.Message, tools []api.Tool, think *api.ThinkValue) (string, error) {
+	var sb strings.Builder
+	sb.WriteString(lagunaBOS)
+
+	thinkingEnabled := think != nil && think.Bool()
+
+	systemMessage := lagunaDefaultSystem
+	firstMessageIsSystem := len(messages) > 0 && messages[0].Role == "system"
+	if firstMessageIsSystem {
+		systemMessage = messages[0].Content
+	}
+
+	hasSystem := strings.TrimSpace(systemMessage) != ""
+	if hasSystem || len(tools) > 0 || thinkingEnabled {
+		sb.WriteString("<system>")
+		if hasSystem {
+			sb.WriteString(strings.TrimRightFunc(systemMessage, unicode.IsSpace))
+			if len(tools) > 0 {
+				sb.WriteString("\n\n")
+			}
+		}
+		if len(tools) > 0 {
+			sb.WriteString("### Tools\n\n")
+			sb.WriteString("You may call functions to assist with the user query.\n")
+			sb.WriteString("All available function signatures are listed below:\n")
+			sb.WriteString("<available_tools>\n")
+			for _, tool := range tools {
+				if b, err := marshalWithSpaces(tool); err == nil {
+					sb.Write(b)
+					sb.WriteByte('\n')
+				}
+			}
+			sb.WriteString("</available_tools>")
+		}
+		sb.WriteString("</system>\n")
+	}
+
+	for i, message := range messages {
+		if i == 0 && firstMessageIsSystem {
+			continue
+		}
+		content := message.Content
+		switch message.Role {
+		case "user":
+			sb.WriteString("<user>")
+			sb.WriteString(content)
+			sb.WriteString("</user>\n")
+		case "assistant":
+			sb.WriteString("<assistant>")
+			if thinkingEnabled {
+				sb.WriteString(lagunaThoughtOpen)
+				sb.WriteString(message.Thinking)
+				sb.WriteString(lagunaThoughtClose)
+			} else {
+				sb.WriteString(lagunaThoughtClose)
+			}
+			if content != "" {
+				sb.WriteString(content)
+			}
+			for _, toolCall := range message.ToolCalls {
+				sb.WriteString("<tool_call>")
+				sb.WriteString(toolCall.Function.Name)
+				for name, value := range toolCall.Function.Arguments.All() {
+					sb.WriteString("<arg_key>")
+					sb.WriteString(name)
+					sb.WriteString("</arg_key>")
+					sb.WriteString("<arg_value>")
+					sb.WriteString(formatLagunaToolCallArgument(value))
+					sb.WriteString("</arg_value>")
+				}
+				sb.WriteString("</tool_call>")
+			}
+			sb.WriteString("</assistant>\n")
+		case "tool":
+			sb.WriteString("<tool_response>")
+			sb.WriteString(content)
+			sb.WriteString("</tool_response>\n")
+		case "system":
+			sb.WriteString("<system>")
+			sb.WriteString(content)
+			sb.WriteString("</system>\n")
+		}
+	}
+
+	sb.WriteString("<assistant>")
+	if thinkingEnabled {
+		sb.WriteString(lagunaThoughtOpen)
+	} else {
+		sb.WriteString(lagunaThoughtClose)
+	}
+
+	return sb.String(), nil
+}
+
+func formatLagunaToolCallArgument(value any) string {
+	switch v := value.(type) {
+	case string:
+		return v
+	case []byte:
+		return string(v)
+	}
+
+	if b, err := marshalWithSpaces(value); err == nil {
+		return string(b)
+	}
+
+	return formatToolCallArgument(value)
 }

--- a/model/renderers/laguna_test.go
+++ b/model/renderers/laguna_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -11,17 +13,23 @@ import (
 	"github.com/ollama/ollama/api"
 )
 
+const (
+	lagunaV2Template = "testdata/laguna_v2_chat_template.jinja2"
+	lagunaV8Template = "testdata/laguna_v8_chat_template.jinja2"
+)
+
 // lagunaToolJSON is the get_weather tool as serialized into <available_tools>,
 // matching lagunaWeatherTool().
 const lagunaToolJSON = `{"type": "function", "function": {"name": "get_weather", "description": "Get weather", "parameters": {"type": "object", "required": ["location"], "properties": {"location": {"type": "string", "description": "City"}}}}}`
+const lagunaMathToolJSON = `{"type": "function", "function": {"name": "add", "description": "Add numbers", "parameters": {"type": "object", "required": ["a", "b"], "properties": {"a": {"type": "number", "description": "First number"}, "b": {"type": "number", "description": "Second number"}}}}}`
 
-// TestLagunaRendererReferenceFlowCoverage checks the renderer against the Laguna
-// chat template. Each want is byte-for-byte template output (verified by
-// rendering chat_template.jinja), except that history tool-calls use the clean
-// form — the template leaks Jinja indentation there.
+// TestLagunaRendererReferenceFlowCoverage checks the renderer against byte-for-byte
+// expected output from the Laguna v2 chat template. VERIFY_JINJA2=1 also verifies
+// these expected values against the checked-in Jinja fixture.
 func TestLagunaRendererReferenceFlowCoverage(t *testing.T) {
 	weather := lagunaWeatherTool()
 	think := func(v bool) *api.ThinkValue { return &api.ThinkValue{Value: v} }
+	verifyJinja2 := lagunaVerifyJinja2(t)
 
 	// system header is always emitted; with no system message the default is used
 	defaultHeader := "〈|EOS|〉<system>\n\n" + lagunaDefaultSystem + "\n</system>\n"
@@ -33,6 +41,10 @@ func TestLagunaRendererReferenceFlowCoverage(t *testing.T) {
 		think    *api.ThinkValue
 		want     string
 	}{
+		{
+			name: "empty_messages",
+			want: defaultHeader + "<assistant>\n</think>",
+		},
 		{
 			name:     "user_only_default",
 			messages: []api.Message{{Role: "user", Content: "Hello"}},
@@ -60,6 +72,14 @@ func TestLagunaRendererReferenceFlowCoverage(t *testing.T) {
 				"<user>\nHi\n</user>\n<assistant>\n</think>",
 		},
 		{
+			name: "empty_first_system_opts_out_of_header",
+			messages: []api.Message{
+				{Role: "system", Content: ""},
+				{Role: "user", Content: "Hi"},
+			},
+			want: "〈|EOS|〉<user>\nHi\n</user>\n<assistant>\n</think>",
+		},
+		{
 			name: "additional_system",
 			messages: []api.Message{
 				{Role: "system", Content: "Primary."},
@@ -70,6 +90,22 @@ func TestLagunaRendererReferenceFlowCoverage(t *testing.T) {
 				"<user>\nHi\n</user>\n" +
 				"<system>\nSecondary.\n</system>\n" +
 				"<assistant>\n</think>",
+		},
+		{
+			name: "empty_first_system_with_tools",
+			messages: []api.Message{
+				{Role: "system", Content: ""},
+				{Role: "user", Content: "Weather?"},
+			},
+			tools: weather,
+			want: "〈|EOS|〉<system>\n\n\n### Tools\n\n" +
+				"You may call functions to assist with the user query.\n" +
+				"All available function signatures are listed below:\n" +
+				"<available_tools>\n" + lagunaToolJSON + "\n</available_tools>\n\n" +
+				"For each function call, return an unescaped XML-like object with function name and arguments within '<tool_call>' and '</tool_call>' tags, like here:\n" +
+				"<tool_call>function-name\n<arg_key>argument-key</arg_key>\n<arg_value>value-of-argument-key</arg_value>\n</tool_call>" +
+				"\n</system>\n" +
+				"<user>\nWeather?\n</user>\n<assistant>\n</think>",
 		},
 		{
 			name: "tools_in_header",
@@ -101,6 +137,19 @@ func TestLagunaRendererReferenceFlowCoverage(t *testing.T) {
 				"<tool_call>function-name\n<arg_key>argument-key</arg_key>\n<arg_value>value-of-argument-key</arg_value>\n</tool_call>" +
 				"\n</system>\n" +
 				"<user>\nWeather?\n</user>\n<assistant>\n</think>",
+		},
+		{
+			name:     "multiple_tools_in_header",
+			messages: []api.Message{{Role: "user", Content: "Add then report weather"}},
+			tools:    append(weather, lagunaMathTool()...),
+			want: "〈|EOS|〉<system>\n\n" + lagunaDefaultSystem + "\n\n### Tools\n\n" +
+				"You may call functions to assist with the user query.\n" +
+				"All available function signatures are listed below:\n" +
+				"<available_tools>\n" + lagunaToolJSON + "\n" + lagunaMathToolJSON + "\n</available_tools>\n\n" +
+				"For each function call, return an unescaped XML-like object with function name and arguments within '<tool_call>' and '</tool_call>' tags, like here:\n" +
+				"<tool_call>function-name\n<arg_key>argument-key</arg_key>\n<arg_value>value-of-argument-key</arg_value>\n</tool_call>" +
+				"\n</system>\n" +
+				"<user>\nAdd then report weather\n</user>\n<assistant>\n</think>",
 		},
 		{
 			name: "assistant_history",
@@ -138,12 +187,80 @@ func TestLagunaRendererReferenceFlowCoverage(t *testing.T) {
 				"<user>\nThanks\n</user>\n<assistant>\n<think>",
 		},
 		{
-			name: "final_assistant_prefill",
+			name: "assistant_extracts_thinking_from_content",
 			messages: []api.Message{
-				{Role: "user", Content: "Complete this"},
-				{Role: "assistant", Content: "Partial"},
+				{Role: "user", Content: "Explain"},
+				{Role: "assistant", Content: "<think>\nPlan\n</think>\nAnswer\n\n"},
+				{Role: "user", Content: "Next"},
 			},
-			want: defaultHeader + "<user>\nComplete this\n</user>\n<assistant>\n</think>\nPartial\n",
+			think: think(true),
+			want: defaultHeader +
+				"<user>\nExplain\n</user>\n" +
+				"<assistant>\n<think>\nPlan\n</think>\nAnswer\n</assistant>\n" +
+				"<user>\nNext\n</user>\n<assistant>\n<think>",
+		},
+		{
+			name: "assistant_thinking_metadata_overrides_content_tags",
+			messages: []api.Message{
+				{Role: "user", Content: "Explain"},
+				{Role: "assistant", Thinking: "Use metadata.", Content: "<think>Ignore this</think>\nAnswer"},
+				{Role: "user", Content: "Next"},
+			},
+			want: defaultHeader +
+				"<user>\nExplain\n</user>\n" +
+				"<assistant>\n<think>\nUse metadata.\n</think>\nAnswer\n</assistant>\n" +
+				"<user>\nNext\n</user>\n<assistant>\n</think>",
+		},
+		{
+			name: "assistant_whitespace_content_only",
+			messages: []api.Message{
+				{Role: "user", Content: "Continue"},
+				{Role: "assistant", Content: " \n\t "},
+				{Role: "user", Content: "Next"},
+			},
+			want: defaultHeader +
+				"<user>\nContinue\n</user>\n" +
+				"<assistant>\n</think>\n</assistant>\n" +
+				"<user>\nNext\n</user>\n<assistant>\n</think>",
+		},
+		{
+			name: "assistant_multiple_tool_calls_mixed_args",
+			messages: []api.Message{
+				{Role: "user", Content: "Do calls"},
+				{
+					Role: "assistant",
+					ToolCalls: []api.ToolCall{
+						{Function: api.ToolCallFunction{
+							Name: "echo",
+							Arguments: testArgsOrdered([]orderedArg{
+								{Key: "text", Value: "hello"},
+								{Key: "count", Value: 2},
+							}),
+						}},
+						{Function: api.ToolCallFunction{
+							Name: "configure",
+							Arguments: testArgsOrdered([]orderedArg{
+								{Key: "flag", Value: true},
+								{Key: "options", Value: map[string]any{"mode": "fast"}},
+							}),
+						}},
+					},
+				},
+				{Role: "user", Content: "Done?"},
+			},
+			want: defaultHeader +
+				"<user>\nDo calls\n</user>\n" +
+				"<assistant>\n</think>\n" +
+				"<tool_call>echo\n" +
+				"<arg_key>text</arg_key>\n<arg_value>hello</arg_value>\n" +
+				"<arg_key>count</arg_key>\n<arg_value>2</arg_value>\n" +
+				"</tool_call>\n" +
+				"<tool_call>configure\n" +
+				"<arg_key>flag</arg_key>\n<arg_value>true</arg_value>\n" +
+				"<arg_key>options</arg_key>\n<arg_value>{\"mode\": \"fast\"}</arg_value>\n" +
+				"</tool_call>\n" +
+				"</assistant>\n" +
+				"<user>\nDone?\n</user>\n<assistant>\n</think>",
 		},
 	}
 
@@ -157,22 +274,346 @@ func TestLagunaRendererReferenceFlowCoverage(t *testing.T) {
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Fatalf("renderer output mismatch vs template (-want +got):\n%s", diff)
 			}
+			if verifyJinja2 {
+				jinja := renderLagunaJinja2Template(t, lagunaV2Template, tt.messages, tt.tools, tt.think)
+				if diff := cmp.Diff(jinja, tt.want); diff != "" {
+					t.Fatalf("hardcoded expected mismatch vs Jinja2 template (-jinja +want):\n%s", diff)
+				}
+				if diff := cmp.Diff(jinja, got); diff != "" {
+					t.Fatalf("renderer output mismatch vs Jinja2 template (-jinja +got):\n%s", diff)
+				}
+			}
 		})
 	}
 }
 
-func TestLagunaRendererMatchesLocalJinjaControlFlow(t *testing.T) {
-	if os.Getenv("VERIFY_LAGUNA_JINJA2") == "" {
-		t.Skip("set VERIFY_LAGUNA_JINJA2=1 to compare against the local Laguna chat_template.jinja")
+func TestLagunaRendererAssistantPrefill(t *testing.T) {
+	got, err := (&LagunaRenderer{}).Render([]api.Message{
+		{Role: "user", Content: "Complete this"},
+		{Role: "assistant", Content: "Partial"},
+	}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
 	}
-	python := "/Users/daniel/.codex/worktrees/7038/ollama/.venv/bin/python3"
-	if _, err := os.Stat(python); err != nil {
-		t.Fatalf("VERIFY_LAGUNA_JINJA2 requires %s with jinja2 installed", python)
+
+	want := "〈|EOS|〉<system>\n\n" + lagunaDefaultSystem + "\n</system>\n" +
+		"<user>\nComplete this\n</user>\n<assistant>\n</think>\nPartial\n"
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("renderer prefill mismatch (-want +got):\n%s", diff)
 	}
+}
+
+func TestLagunaRendererKnownJinja2Differences(t *testing.T) {
+	if !lagunaVerifyJinja2(t) {
+		t.Skip("set VERIFY_JINJA2=1 to run Jinja2 difference checks")
+	}
+
+	messages := []api.Message{
+		{Role: "user", Content: "Complete this"},
+		{Role: "assistant", Content: "Partial"},
+	}
+	got, err := (&LagunaRenderer{}).Render(messages, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	jinja := renderLagunaJinja2Template(t, lagunaV2Template, messages, nil, nil)
+	if got == jinja {
+		t.Fatal("v2 assistant prefill no longer differs from Jinja2 output")
+	}
+
+	wantJinja := "〈|EOS|〉<system>\n\n" + lagunaDefaultSystem + "\n</system>\n" +
+		"<user>\nComplete this\n</user>\n<assistant>\n</think>\nPartial\n</assistant>\n<assistant>\n</think>"
+	if diff := cmp.Diff(wantJinja, jinja); diff != "" {
+		t.Fatalf("v2 assistant prefill Jinja2 reference mismatch (-want +jinja):\n%s", diff)
+	}
+}
+
+func TestLagunaV8RendererReferenceFlowCoverage(t *testing.T) {
+	weather := lagunaWeatherTool()
+	think := func(v bool) *api.ThinkValue { return &api.ThinkValue{Value: v} }
+	verifyJinja2 := lagunaVerifyJinja2(t)
+
+	defaultHeader := "〈|EOS|〉<system>" + lagunaDefaultSystem + "</system>\n"
 
 	tests := []struct {
 		name     string
 		messages []api.Message
+		tools    []api.Tool
+		think    *api.ThinkValue
+		want     string
+	}{
+		{
+			name: "empty_messages",
+			want: defaultHeader + "<assistant></think>",
+		},
+		{
+			name:     "user_only_default",
+			messages: []api.Message{{Role: "user", Content: "Hello"}},
+			want:     defaultHeader + "<user>Hello</user>\n<assistant></think>",
+		},
+		{
+			name:     "user_only_think",
+			messages: []api.Message{{Role: "user", Content: "Hello"}},
+			think:    think(true),
+			want:     defaultHeader + "<user>Hello</user>\n<assistant><think>",
+		},
+		{
+			name:     "user_only_nothink",
+			messages: []api.Message{{Role: "user", Content: "Hello"}},
+			think:    think(false),
+			want:     defaultHeader + "<user>Hello</user>\n<assistant></think>",
+		},
+		{
+			name: "first_system_is_header",
+			messages: []api.Message{
+				{Role: "system", Content: "Stay concise.\n\n"},
+				{Role: "user", Content: "Hi"},
+			},
+			want: "〈|EOS|〉<system>Stay concise.</system>\n" +
+				"<user>Hi</user>\n<assistant></think>",
+		},
+		{
+			name: "empty_first_system_opts_out_of_header",
+			messages: []api.Message{
+				{Role: "system", Content: ""},
+				{Role: "user", Content: "Hi"},
+			},
+			want: "〈|EOS|〉<user>Hi</user>\n<assistant></think>",
+		},
+		{
+			name: "empty_first_system_with_tools",
+			messages: []api.Message{
+				{Role: "system", Content: ""},
+				{Role: "user", Content: "Weather?"},
+			},
+			tools: weather,
+			want: "〈|EOS|〉<system>" +
+				"### Tools\n\n" +
+				"You may call functions to assist with the user query.\n" +
+				"All available function signatures are listed below:\n" +
+				"<available_tools>\n" + lagunaToolJSON + "\n</available_tools>" +
+				"</system>\n" +
+				"<user>Weather?</user>\n<assistant></think>",
+		},
+		{
+			name: "empty_first_system_thinking_enabled",
+			messages: []api.Message{
+				{Role: "system", Content: ""},
+				{Role: "user", Content: "Hi"},
+			},
+			think: think(true),
+			want:  "〈|EOS|〉<system></system>\n<user>Hi</user>\n<assistant><think>",
+		},
+		{
+			name: "additional_system",
+			messages: []api.Message{
+				{Role: "system", Content: "Primary."},
+				{Role: "user", Content: "Hi"},
+				{Role: "system", Content: "Secondary."},
+			},
+			want: "〈|EOS|〉<system>Primary.</system>\n" +
+				"<user>Hi</user>\n" +
+				"<system>Secondary.</system>\n" +
+				"<assistant></think>",
+		},
+		{
+			name: "tools_in_header",
+			messages: []api.Message{
+				{Role: "system", Content: "Stay concise."},
+				{Role: "user", Content: "Weather?"},
+			},
+			tools: weather,
+			think: think(true),
+			want: "〈|EOS|〉<system>Stay concise.\n\n" +
+				"### Tools\n\n" +
+				"You may call functions to assist with the user query.\n" +
+				"All available function signatures are listed below:\n" +
+				"<available_tools>\n" + lagunaToolJSON + "\n</available_tools>" +
+				"</system>\n" +
+				"<user>Weather?</user>\n<assistant><think>",
+		},
+		{
+			name:     "tools_default",
+			messages: []api.Message{{Role: "user", Content: "Weather?"}},
+			tools:    weather,
+			want: "〈|EOS|〉<system>" + lagunaDefaultSystem + "\n\n" +
+				"### Tools\n\n" +
+				"You may call functions to assist with the user query.\n" +
+				"All available function signatures are listed below:\n" +
+				"<available_tools>\n" + lagunaToolJSON + "\n</available_tools>" +
+				"</system>\n" +
+				"<user>Weather?</user>\n<assistant></think>",
+		},
+		{
+			name:     "multiple_tools_in_header",
+			messages: []api.Message{{Role: "user", Content: "Add then report weather"}},
+			tools:    append(weather, lagunaMathTool()...),
+			want: "〈|EOS|〉<system>" + lagunaDefaultSystem + "\n\n" +
+				"### Tools\n\n" +
+				"You may call functions to assist with the user query.\n" +
+				"All available function signatures are listed below:\n" +
+				"<available_tools>\n" + lagunaToolJSON + "\n" + lagunaMathToolJSON + "\n</available_tools>" +
+				"</system>\n" +
+				"<user>Add then report weather</user>\n<assistant></think>",
+		},
+		{
+			name: "assistant_history",
+			messages: []api.Message{
+				{Role: "user", Content: "Add these."},
+				{
+					Role:     "assistant",
+					Content:  "\nCalling the tool.\n",
+					Thinking: "Need addition.",
+					ToolCalls: []api.ToolCall{{
+						Function: api.ToolCallFunction{
+							Name: "add",
+							Arguments: testArgsOrdered([]orderedArg{
+								{Key: "a", Value: 2},
+								{Key: "b", Value: 3},
+							}),
+						},
+					}},
+				},
+				{Role: "tool", Content: "5"},
+				{Role: "user", Content: "Thanks"},
+			},
+			think: think(true),
+			want: defaultHeader +
+				"<user>Add these.</user>\n" +
+				"<assistant>" +
+				"<think>Need addition.</think>" +
+				"\nCalling the tool.\n" +
+				"<tool_call>add" +
+				"<arg_key>a</arg_key><arg_value>2</arg_value>" +
+				"<arg_key>b</arg_key><arg_value>3</arg_value>" +
+				"</tool_call>" +
+				"</assistant>\n" +
+				"<tool_response>5</tool_response>\n" +
+				"<user>Thanks</user>\n<assistant><think>",
+		},
+		{
+			name: "assistant_reasoning_ignored_when_thinking_disabled",
+			messages: []api.Message{
+				{Role: "user", Content: "Explain"},
+				{Role: "assistant", Thinking: "Hidden plan.", Content: "Answer"},
+				{Role: "user", Content: "Next"},
+			},
+			want: defaultHeader +
+				"<user>Explain</user>\n" +
+				"<assistant></think>Answer</assistant>\n" +
+				"<user>Next</user>\n<assistant></think>",
+		},
+		{
+			name: "assistant_empty_reasoning_when_thinking_enabled",
+			messages: []api.Message{
+				{Role: "user", Content: "Explain"},
+				{Role: "assistant", Content: "Answer"},
+				{Role: "user", Content: "Next"},
+			},
+			think: think(true),
+			want: defaultHeader +
+				"<user>Explain</user>\n" +
+				"<assistant><think></think>Answer</assistant>\n" +
+				"<user>Next</user>\n<assistant><think>",
+		},
+		{
+			name: "assistant_preserves_content_whitespace",
+			messages: []api.Message{
+				{Role: "user", Content: "Explain"},
+				{Role: "assistant", Content: "\nAnswer\n"},
+				{Role: "user", Content: "Next"},
+			},
+			want: defaultHeader +
+				"<user>Explain</user>\n" +
+				"<assistant></think>\nAnswer\n</assistant>\n" +
+				"<user>Next</user>\n<assistant></think>",
+		},
+		{
+			name: "assistant_multiple_tool_calls_mixed_args",
+			messages: []api.Message{
+				{Role: "user", Content: "Do calls"},
+				{
+					Role: "assistant",
+					ToolCalls: []api.ToolCall{
+						{Function: api.ToolCallFunction{
+							Name: "echo",
+							Arguments: testArgsOrdered([]orderedArg{
+								{Key: "text", Value: "hello"},
+								{Key: "count", Value: 2},
+							}),
+						}},
+						{Function: api.ToolCallFunction{
+							Name: "configure",
+							Arguments: testArgsOrdered([]orderedArg{
+								{Key: "flag", Value: true},
+								{Key: "options", Value: map[string]any{"mode": "fast"}},
+							}),
+						}},
+					},
+				},
+				{Role: "user", Content: "Done?"},
+			},
+			want: defaultHeader +
+				"<user>Do calls</user>\n" +
+				"<assistant></think>" +
+				"<tool_call>echo" +
+				"<arg_key>text</arg_key><arg_value>hello</arg_value>" +
+				"<arg_key>count</arg_key><arg_value>2</arg_value>" +
+				"</tool_call>" +
+				"<tool_call>configure" +
+				"<arg_key>flag</arg_key><arg_value>true</arg_value>" +
+				"<arg_key>options</arg_key><arg_value>{\"mode\": \"fast\"}</arg_value>" +
+				"</tool_call>" +
+				"</assistant>\n" +
+				"<user>Done?</user>\n<assistant></think>",
+		},
+		{
+			name: "final_assistant_closes_then_generation_prompt",
+			messages: []api.Message{
+				{Role: "user", Content: "Complete this"},
+				{Role: "assistant", Content: "Partial"},
+			},
+			want: defaultHeader +
+				"<user>Complete this</user>\n" +
+				"<assistant></think>Partial</assistant>\n" +
+				"<assistant></think>",
+		},
+	}
+
+	renderer := &LagunaV8Renderer{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := renderer.Render(tt.messages, tt.tools, tt.think)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Fatalf("renderer output mismatch vs template (-want +got):\n%s", diff)
+			}
+			if verifyJinja2 {
+				jinja := renderLagunaJinja2Template(t, lagunaV8Template, tt.messages, tt.tools, tt.think)
+				if diff := cmp.Diff(jinja, tt.want); diff != "" {
+					t.Fatalf("hardcoded expected mismatch vs Jinja2 template (-jinja +want):\n%s", diff)
+				}
+				if diff := cmp.Diff(jinja, got); diff != "" {
+					t.Fatalf("renderer output mismatch vs Jinja2 template (-jinja +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}
+
+func TestLagunaRendererMatchesJinja2ExpandedParity(t *testing.T) {
+	if os.Getenv("VERIFY_JINJA2") == "" {
+		t.Skip("set VERIFY_JINJA2=1 to run expanded Jinja2 parity checks")
+	}
+	lagunaVerifyJinja2(t)
+
+	tests := []struct {
+		name     string
+		messages []api.Message
+		tools    []api.Tool
 		think    *api.ThinkValue
 	}{
 		{
@@ -206,75 +647,214 @@ func TestLagunaRendererMatchesLocalJinjaControlFlow(t *testing.T) {
 			messages: []api.Message{{Role: "user", Content: "Answer directly."}},
 			think:    &api.ThinkValue{Value: false},
 		},
+		{
+			name: "tools_and_assistant_history",
+			messages: []api.Message{
+				{Role: "system", Content: "Stay concise."},
+				{Role: "user", Content: "Weather?"},
+				{Role: "assistant", Content: "Calling.", Thinking: "Need weather.", ToolCalls: []api.ToolCall{{
+					Function: api.ToolCallFunction{
+						Name:      "get_weather",
+						Arguments: testArgsOrdered([]orderedArg{{Key: "location", Value: "Paris"}}),
+					},
+				}}},
+				{Role: "tool", Content: "Sunny"},
+				{Role: "user", Content: "Thanks"},
+			},
+			tools: lagunaWeatherTool(),
+			think: &api.ThinkValue{Value: true},
+		},
 	}
 
-	renderer := &LagunaRenderer{}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := renderer.Render(tt.messages, nil, tt.think)
-			if err != nil {
-				t.Fatal(err)
-			}
-			for _, modelDir := range []string{
-				"/Users/daniel/Models/poolside/laguna-xs-23-04-2026",
-			} {
-				want := renderLagunaChatTemplate(t, python, modelDir, tt.messages, tt.think)
-				if diff := cmp.Diff(want, got); diff != "" {
-					t.Fatalf("%s mismatch (-chat_template +renderer):\n%s", modelDir, diff)
-				}
+	variants := []struct {
+		name     string
+		renderer Renderer
+		template string
+	}{
+		{name: "v2", renderer: &LagunaRenderer{}, template: lagunaV2Template},
+		{name: "v8", renderer: &LagunaV8Renderer{}, template: lagunaV8Template},
+	}
+
+	for _, variant := range variants {
+		t.Run(variant.name, func(t *testing.T) {
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					got, err := variant.renderer.Render(tt.messages, tt.tools, tt.think)
+					if err != nil {
+						t.Fatal(err)
+					}
+					want := renderLagunaJinja2Template(t, variant.template, tt.messages, tt.tools, tt.think)
+					if diff := cmp.Diff(want, got); diff != "" {
+						t.Fatalf("renderer output mismatch vs Jinja2 template (-jinja +got):\n%s", diff)
+					}
+				})
 			}
 		})
 	}
 }
 
-func renderLagunaChatTemplate(t *testing.T, python, modelDir string, messages []api.Message, think *api.ThinkValue) string {
+func lagunaVerifyJinja2(t *testing.T) bool {
+	t.Helper()
+	if os.Getenv("VERIFY_JINJA2") == "" {
+		return false
+	}
+	python := lagunaJinjaPython(t)
+	if _, err := os.Stat(python); err != nil {
+		t.Fatalf("VERIFY_JINJA2=1 requires %s: %v", python, err)
+	}
+	cmd := exec.Command(python, "-c", "from transformers.utils.chat_template_utils import _compile_jinja_template")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("VERIFY_JINJA2=1 requires transformers chat template support in %s: %v\n%s", python, err, out)
+	}
+	return true
+}
+
+func lagunaJinjaPython(t *testing.T) string {
 	t.Helper()
 
-	type templateMessage struct {
-		Role    string `json:"role"`
-		Content string `json:"content"`
+	// Prefer the shared development venv so temporary worktrees do not need to
+	// duplicate Python dependencies.
+	if home, err := os.UserHomeDir(); err == nil {
+		python := filepath.Join(home, "code", "ollama", ".venv", "bin", "python3")
+		if _, err := os.Stat(python); err == nil {
+			return python
+		}
 	}
-	templateMessages := make([]templateMessage, 0, len(messages))
+
+	return filepath.Join(lagunaRepoRoot(t), ".venv", "bin", "python3")
+}
+
+func renderLagunaJinja2Template(t *testing.T, templateRelPath string, messages []api.Message, tools []api.Tool, think *api.ThinkValue) string {
+	t.Helper()
+
+	templatePath, err := filepath.Abs(templateRelPath)
+	if err != nil {
+		t.Fatalf("failed to get template path: %v", err)
+	}
+
+	type jinjaToolCall struct {
+		Function struct {
+			Name      string          `json:"name"`
+			Arguments json.RawMessage `json:"arguments"`
+		} `json:"function"`
+	}
+	type jinjaMessage struct {
+		Role             string          `json:"role"`
+		Content          string          `json:"content"`
+		Reasoning        string          `json:"reasoning,omitempty"`
+		ReasoningContent string          `json:"reasoning_content,omitempty"`
+		ToolCalls        []jinjaToolCall `json:"tool_calls,omitempty"`
+	}
+
+	jinjaMessages := make([]jinjaMessage, 0, len(messages))
 	for _, msg := range messages {
-		templateMessages = append(templateMessages, templateMessage{
-			Role:    msg.Role,
-			Content: msg.Content,
-		})
+		jm := jinjaMessage{
+			Role:             msg.Role,
+			Content:          msg.Content,
+			Reasoning:        msg.Thinking,
+			ReasoningContent: msg.Thinking,
+		}
+		for _, call := range msg.ToolCalls {
+			jc := jinjaToolCall{}
+			jc.Function.Name = call.Function.Name
+			raw, err := call.Function.Arguments.MarshalJSON()
+			if err != nil {
+				t.Fatalf("failed to marshal tool args: %v", err)
+			}
+			jc.Function.Arguments = json.RawMessage(raw)
+			jm.ToolCalls = append(jm.ToolCalls, jc)
+		}
+		jinjaMessages = append(jinjaMessages, jm)
 	}
-	messagesJSON, err := json.Marshal(templateMessages)
+
+	messagesJSON, err := json.Marshal(jinjaMessages)
 	if err != nil {
 		t.Fatalf("failed to marshal messages: %v", err)
 	}
 
-	enableThinking := "False"
-	if think != nil && think.Bool() {
-		enableThinking = "True"
+	toolsJSON := "None"
+	if len(tools) > 0 {
+		b, err := json.Marshal(tools)
+		if err != nil {
+			t.Fatalf("failed to marshal tools: %v", err)
+		}
+		toolsJSON = string(b)
+	}
+
+	enableThinking := "unset"
+	if think != nil {
+		if think.Bool() {
+			enableThinking = "true"
+		} else {
+			enableThinking = "false"
+		}
 	}
 
 	script := `
 import json
 import sys
-from transformers import AutoTokenizer
+from pathlib import Path
+from transformers.utils.chat_template_utils import _compile_jinja_template
 
-model_dir = sys.argv[1]
-messages = json.loads(sys.argv[2])
-enable_thinking = sys.argv[3] == "True"
-tok = AutoTokenizer.from_pretrained(model_dir, trust_remote_code=True)
-print(tok.apply_chat_template(
-    messages,
-    tokenize=False,
-    add_generation_prompt=True,
-    enable_thinking=enable_thinking,
-), end="")
+template_path, messages_json, tools_json, enable_thinking = sys.argv[1:5]
+tmpl = _compile_jinja_template(Path(template_path).read_text())
+kwargs = {
+    "messages": json.loads(messages_json),
+    "add_generation_prompt": True,
+}
+if tools_json != "None":
+    kwargs["tools"] = json.loads(tools_json)
+if enable_thinking == "true":
+    kwargs["enable_thinking"] = True
+elif enable_thinking == "false":
+    kwargs["enable_thinking"] = False
+print(tmpl.render(**kwargs), end="")
 `
-	cmd := exec.Command(python, "-c", script, modelDir, string(messagesJSON), enableThinking)
+	cmd := exec.Command(lagunaJinjaPython(t), "-c", script, templatePath, string(messagesJSON), toolsJSON, enableThinking)
 	var stdout, stderr strings.Builder
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		t.Fatalf("chat_template render failed: %v\nstderr: %s", err, stderr.String())
+		t.Fatalf("python render failed: %v\nstderr: %s", err, stderr.String())
 	}
 	return stdout.String()
+}
+
+func lagunaRepoRoot(t *testing.T) string {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("failed to locate test file")
+	}
+	return filepath.Dir(filepath.Dir(filepath.Dir(filename)))
+}
+
+func TestLagunaTemplateFixturesMatchExpectedVersions(t *testing.T) {
+	v2, err := os.ReadFile(lagunaV2Template)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", lagunaV2Template, err)
+	}
+
+	v8, err := os.ReadFile(lagunaV8Template)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", lagunaV8Template, err)
+	}
+
+	if !strings.Contains(string(v2), "laguna_glm_thinking_v5/chat_template.jinja") {
+		t.Fatalf("%s does not look like the v2 Laguna template fixture", lagunaV2Template)
+	}
+	if !strings.Contains(string(v8), "laguna_glm_thinking_v8/chat_template.jinja") {
+		t.Fatalf("%s does not look like the v8 Laguna template fixture", lagunaV8Template)
+	}
+	if !strings.Contains(string(v2), "render_assistant_messages_raw") {
+		t.Fatalf("%s should retain the v2 raw assistant branch", lagunaV2Template)
+	}
+	if strings.Contains(string(v8), "render_assistant_messages_raw") {
+		t.Fatalf("%s unexpectedly contains the v2 raw assistant branch", lagunaV8Template)
+	}
+	if diff := cmp.Diff(string(v2), string(v8)); diff == "" {
+		t.Fatal("Laguna v2 and v8 template fixtures unexpectedly match")
+	}
 }
 
 func lagunaWeatherTool() []api.Tool {
@@ -293,6 +873,36 @@ func lagunaWeatherTool() []api.Tool {
 						Description: "City",
 					},
 				}}),
+			},
+		},
+	}}
+}
+
+func lagunaMathTool() []api.Tool {
+	return []api.Tool{{
+		Type: "function",
+		Function: api.ToolFunction{
+			Name:        "add",
+			Description: "Add numbers",
+			Parameters: api.ToolFunctionParameters{
+				Type:     "object",
+				Required: []string{"a", "b"},
+				Properties: testPropsOrdered([]orderedProp{
+					{
+						Key: "a",
+						Value: api.ToolProperty{
+							Type:        api.PropertyType{"number"},
+							Description: "First number",
+						},
+					},
+					{
+						Key: "b",
+						Value: api.ToolProperty{
+							Type:        api.PropertyType{"number"},
+							Description: "Second number",
+						},
+					},
+				}),
 			},
 		},
 	}}

--- a/model/renderers/renderer.go
+++ b/model/renderers/renderer.go
@@ -109,6 +109,8 @@ func rendererForName(name string) Renderer {
 		return &LFM2Renderer{IsThinking: true, useImgTags: RenderImgTags}
 	case "laguna":
 		return &LagunaRenderer{}
+	case "laguna-v8":
+		return &LagunaV8Renderer{}
 	case "cohere":
 		return &CohereRenderer{}
 	default:

--- a/model/renderers/renderer_test.go
+++ b/model/renderers/renderer_test.go
@@ -69,6 +69,7 @@ func TestLeadingBOSForRenderer(t *testing.T) {
 		{name: "lfm2", want: "<|startoftext|>"},
 		{name: "lfm2-thinking", want: "<|startoftext|>"},
 		{name: "laguna", want: "〈|EOS|〉"},
+		{name: "laguna-v8", want: "〈|EOS|〉"},
 		{name: "deepseek3.1", want: "<｜begin▁of▁sentence｜>"},
 		{name: "cogito", want: "<｜begin▁of▁sentence｜>"},
 		{name: "qwen3-coder", want: ""},

--- a/model/renderers/testdata/laguna_v2_chat_template.jinja2
+++ b/model/renderers/testdata/laguna_v2_chat_template.jinja2
@@ -1,0 +1,132 @@
+{#- Iteration on laguna_glm_thinking_v5/chat_template.jinja -#}
+{#- Adds a default system message (used when no system message is provided in `messages`). -#}
+{{- "〈|EOS|〉" -}}
+{%- set enable_thinking = enable_thinking | default(false) -%}
+{%- set render_assistant_messages_raw = render_assistant_messages_raw | default(false) -%}
+{%- set add_generation_prompt = add_generation_prompt | default(false) -%}
+
+{#- ───── header (system message) ───── -#}
+{%- set system_message = "You are a helpful, conversationally-fluent assistant made by Poolside. You are here to be helpful to users through natural language conversations." -%}
+{%- if messages and messages[0].role == "system" -%}
+  {%- set system_message = messages[0].content -%}
+{%- endif -%}
+
+{%- if (system_message and system_message.strip()) or tools -%}
+  {{- "<system>\n" -}}
+
+  {%- if system_message and system_message.strip() -%}
+    {{- "\n" -}}
+    {{- system_message.rstrip() -}}
+  {%- endif -%}
+
+  {%- if tools -%}
+    {{- "\n\n### Tools\n\n" -}}
+    {%- set ns = namespace(tool_string="You may call functions to assist with the user query.\n"
+          ~ "All available function signatures are listed below:\n"
+          ~ "<available_tools>\n") -%}
+    {%- for tool in tools -%}
+      {%- set ns.tool_string = ns.tool_string ~ (tool | tojson) ~ "\n" -%}
+    {%- endfor -%}
+    {%- if enable_thinking -%}
+      {%- set tool_string = ns.tool_string + "</available_tools>\n\n" ~
+            "Wrap your thinking in '<think>', '</think>' tags, followed by a function call. For each function call, return an unescaped XML-like object with function name and arguments within '<tool_call>' and '</tool_call>' tags, like here:\n" ~
+            "<think> your thoughts here </think>\n" ~
+            "<tool_call>function-name\n<arg_key>argument-key</arg_key>\n<arg_value>value-of-argument-key</arg_value>\n" ~
+            "</tool_call>" -%}
+    {%- else -%}
+      {%- set tool_string = ns.tool_string + "</available_tools>\n\n" ~
+            "For each function call, return an unescaped XML-like object " ~
+            "with function name and arguments within '<tool_call>' and '</tool_call>' tags, like here:\n" ~
+            "<tool_call>function-name\n<arg_key>argument-key</arg_key>\n<arg_value>value-of-argument-key</arg_value>\n" ~
+            "</tool_call>" -%}
+    {%- endif -%}
+    {{- tool_string -}}
+  {%- endif -%}
+
+  {{- "\n</system>\n" -}}
+{%- endif -%}
+
+{#- ───── main loop ───── -#}
+{%- for message in messages -%}
+  {%- set content = message.content if message.content is string else "" -%}
+  {%- if message.role == "user" -%}
+    {{- "<user>\n" + content + "\n</user>\n" -}}
+  {%- elif message.role == "assistant" -%}
+    {%- generation -%}
+      {{- "<assistant>\n" -}}
+      {%- if render_assistant_messages_raw -%}
+        {#- Raw mode: prepend the generation prompt token, then dump content verbatim. -#}
+        {#- The generation prompt is <think> when enable_thinking, </think> otherwise. -#}
+        {#- Only prepend if content doesn't already start with it. -#}
+        {%- if enable_thinking -%}
+          {%- if not content.startswith('<think>') -%}
+            {{- '<think>' -}}
+          {%- endif -%}
+        {%- else -%}
+          {%- if not content.startswith('</think>') -%}
+            {{- '</think>' -}}
+          {%- endif -%}
+        {%- endif -%}
+        {{- content -}}
+        {#- Append closing tag if content doesn't already end with it. -#}
+        {%- if not content.endswith('</assistant>\n') and not content.endswith('</assistant>') -%}
+          {{- '\n</assistant>' -}}
+        {%- endif -%}
+        {{- "\n" -}}
+      {%- else -%}
+        {#- Extract reasoning content from message.reasoning (vLLM field name) or message.reasoning_content, or from <think> tags -#}
+        {%- set reasoning_content = '' %}
+        {%- if message.reasoning is string %}
+          {%- set reasoning_content = message.reasoning %}
+        {%- elif message.reasoning_content is string %}
+          {%- set reasoning_content = message.reasoning_content %}
+        {%- endif %}
+        {#- Always strip <think> tags from content if present to avoid duplication -#}
+        {%- if '</think>' in content %}
+          {%- if not reasoning_content %}
+            {%- set reasoning_content = content.split('</think>')[0].rstrip('\n').split('<think>')[-1].lstrip('\n') %}
+          {%- endif %}
+          {%- set content = content.split('</think>')[-1].lstrip('\n') %}
+        {%- endif %}
+        {#- Display reasoning content for all messages -#}
+        {%- if reasoning_content -%}
+          {{- '<think>\n' + reasoning_content.strip() + '\n</think>\n' -}}
+        {%- else -%}
+          {{- '</think>\n' -}}
+        {%- endif -%}
+        {#- Display main content -#}
+        {%- if content.strip() -%}
+          {{- content.strip() ~ "\n" -}}
+        {%- endif -%}
+        {%- if message.tool_calls -%}
+          {%- for tool_call in message.tool_calls -%}
+            {%- set function_data = tool_call.function -%}
+            {{- '<tool_call>' + function_data.name }}
+            {% set _args = function_data.arguments %}
+            {%- for k, v in _args.items() -%}
+              {{- "<arg_key>" ~ k ~ "</arg_key>\n" -}}
+              {{- "<arg_value>"}}{{ v | tojson(ensure_ascii=False) if v is not string else v }}{{ "</arg_value>\n" -}}
+            {%- endfor -%}
+            {{- "</tool_call>\n" -}}
+          {%- endfor -%}
+        {%- endif -%}
+        {{- "</assistant>\n" -}}
+      {%- endif -%}
+    {%- endgeneration -%}
+  {%- elif message.role == "tool" -%}
+    {{- "<tool_response>\n" + content + "\n</tool_response>\n" -}}
+  {%- elif message.role == "system" and loop.index0 != 0 -%}
+    {#- Render additional system messages (skip the first one which is handled separately in the header) -#}
+    {{- "<system>\n" + content + "\n</system>\n" -}}
+  {%- endif -%}
+{%- endfor -%}
+{#- ───── generation prompt ───── -#}
+{%- if add_generation_prompt -%}
+  {{- "<assistant>\n" -}}
+  {#- ───── Include reasoning mode directive ───── -#}
+  {%- if not enable_thinking %}
+    {{- '</think>' -}}
+  {%- else %}
+    {{- '<think>' -}}
+  {%- endif %}
+{%- endif -%}

--- a/model/renderers/testdata/laguna_v8_chat_template.jinja2
+++ b/model/renderers/testdata/laguna_v8_chat_template.jinja2
@@ -1,0 +1,93 @@
+{#- Iteration on laguna_glm_thinking_v8/chat_template.jinja -#}
+{#- No formatting instructions -#}
+{{- "〈|EOS|〉" -}}
+{%- set enable_thinking = enable_thinking | default(false) -%}
+{%- set add_generation_prompt = add_generation_prompt | default(false) -%}
+
+{#- ───── header (system message) ───── -#}
+{#- A caller-supplied system message with empty content opts out of the default below, producing no <system> block — used to train without a system message. -#}
+{%- set system_message = "You are a helpful, conversationally-fluent assistant made by Poolside. You are here to be helpful to users through natural language conversations." -%}
+{%- if messages and messages[0].role == "system" -%}
+  {%- set system_message = messages[0].content -%}
+  {%- set messages = messages[1:] -%}
+{%- endif -%}
+
+{%- set has_sys = system_message and system_message.strip() -%}
+{%- if has_sys or tools or enable_thinking -%}
+  {{- "<system>" -}}
+
+  {%- if has_sys -%}
+    {{- system_message.rstrip() -}}
+    {%- if tools -%}{{- "\n\n" -}}{%- endif -%}
+  {%- endif -%}
+
+  {%- if tools -%}
+    {{- "### Tools\n\n" -}}
+    {{- "You may call functions to assist with the user query.\n" -}}
+    {{- "All available function signatures are listed below:\n" -}}
+    {{- "<available_tools>\n" -}}
+    {%- for tool in tools -%}
+      {{- (tool | tojson) ~ "\n" -}}
+    {%- endfor -%}
+    {{- "</available_tools>" -}}
+  {%- endif -%}
+
+  {{- "</system>\n" -}}
+{%- endif -%}
+
+{#- ───── main loop ───── -#}
+{%- for message in messages -%}
+  {%- set content = message.content if message.content is string else "" -%}
+  {%- if message.role == "user" -%}
+    {{- "<user>" + content + "</user>\n" -}}
+  {%- elif message.role == "assistant" -%}
+    {%- generation -%}
+      {{- "<assistant>" -}}
+      {#- Extract reasoning content from message.reasoning (vLLM field name) or message.reasoning_content -#}
+      {%- set reasoning_content = '' -%}
+      {%- if message.reasoning is string -%}
+        {%- set reasoning_content = message.reasoning -%}
+      {%- elif message.reasoning_content is string -%}
+        {%- set reasoning_content = message.reasoning_content -%}
+      {%- endif -%}
+      {#- Display reasoning content for all messages if enable_thinking -#}
+      {%- if enable_thinking -%}
+        {{- '<think>' + reasoning_content + '</think>' -}}
+      {%- else -%}
+        {{- '</think>' -}}
+      {%- endif -%}
+      {#- Display main content (trailing newline only when no tool_calls follow) -#}
+      {%- if content -%}
+        {{- content -}}
+      {%- endif -%}
+      {%- if message.tool_calls -%}
+        {%- for tool_call in message.tool_calls -%}
+          {%- set function_data = tool_call.function -%}
+          {{- '<tool_call>' + function_data.name -}}
+          {%- set _args = function_data.arguments -%}
+          {%- for k, v in _args.items() -%}
+            {{- "<arg_key>" ~ k ~ "</arg_key>" -}}
+            {{- "<arg_value>" -}}{{- v | tojson(ensure_ascii=False) if v is not string else v -}}{{- "</arg_value>" -}}
+          {%- endfor -%}
+          {{- "</tool_call>" -}}
+        {%- endfor -%}
+      {%- endif -%}
+      {{- "</assistant>\n" -}}
+    {%- endgeneration -%}
+  {%- elif message.role == "tool" -%}
+    {{- "<tool_response>" + content + "</tool_response>\n" -}}
+  {%- elif message.role == "system" -%}
+    {#- Render additional system messages (the first one, if any, is handled separately in the header and was sliced off above) -#}
+    {{- "<system>" + content + "</system>\n" -}}
+  {%- endif -%}
+{%- endfor -%}
+{#- ───── generation prompt ───── -#}
+{%- if add_generation_prompt -%}
+  {{- "<assistant>" -}}
+  {#- ───── Include reasoning mode directive ───── -#}
+  {%- if enable_thinking -%}
+    {{- '<think>' -}}
+  {%- else -%}
+    {{- '</think>' -}}
+  {%- endif -%}
+{%- endif -%}

--- a/x/create/laguna.go
+++ b/x/create/laguna.go
@@ -2,22 +2,178 @@ package create
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 )
 
-type lagunaImportTransform struct{}
-
-func newLagunaImportTransform(json.RawMessage) (quantizePolicy, error) {
-	return lagunaImportTransform{}, nil
+type lagunaImportTransform struct {
+	denseMLPLayers map[int]bool
+	numLayers      int
 }
 
-func (lagunaImportTransform) quantizationType(name string, shape []int32, quantize string) string {
-	if !lagunaIsHFRoutedExpertWeight(name) {
+type lagunaConfig struct {
+	NumHiddenLayers int      `json:"num_hidden_layers"`
+	MLPOnlyLayers   []int    `json:"mlp_only_layers"`
+	MLPLayerTypes   []string `json:"mlp_layer_types"`
+}
+
+func newLagunaImportTransform(rawConfig json.RawMessage) (quantizePolicy, error) {
+	var cfg lagunaConfig
+	if len(rawConfig) > 0 {
+		if err := json.Unmarshal(rawConfig, &cfg); err != nil {
+			return nil, fmt.Errorf("laguna: parse config.json: %w", err)
+		}
+	}
+
+	denseLayers := make(map[int]bool)
+	for i, typ := range cfg.MLPLayerTypes {
+		if typ == "dense" {
+			denseLayers[i] = true
+		}
+	}
+	for _, layer := range cfg.MLPOnlyLayers {
+		denseLayers[layer] = true
+	}
+	if len(denseLayers) == 0 {
+		denseLayers[0] = true
+	}
+
+	numLayers := cfg.NumHiddenLayers
+	if numLayers == 0 {
+		numLayers = len(cfg.MLPLayerTypes)
+	}
+	if numLayers == 0 {
+		numLayers = 40
+	}
+
+	return lagunaImportTransform{
+		denseMLPLayers: denseLayers,
+		numLayers:      numLayers,
+	}, nil
+}
+
+func (t lagunaImportTransform) quantizationType(name string, shape []int32, quantize string) string {
+	base := normalizeQuantType(quantize)
+	if !lagunaFPQuant(base) {
+		return GetTensorQuantization(name, shape, quantize)
+	}
+
+	// Laguna keeps the tied output head and router at source precision.
+	switch {
+	case strings.HasSuffix(name, "lm_head.weight") || strings.HasSuffix(name, ".mlp.gate.weight"):
+		return ""
+	case base == "mxfp8" && lagunaAttentionProjection(name):
+		return ""
+	case lagunaAttentionProjection(name):
+		return lagunaQuantizationType(name, shape, base)
+	case lagunaDenseMLPProjection(name) && t.denseMLPLayers[layerIndex(name)]:
+		return lagunaQuantizationType(name, shape, base)
+	case base == "mxfp8" && lagunaRoutedExpertDownProjection(name):
+		if lagunaPromoteExpertDown(layerIndex(name), t.numLayers) {
+			return ""
+		}
+		return lagunaQuantizationType(name, shape, base)
+	case lagunaSharedExpertDownProjection(name):
+		return lagunaSensitiveType(lagunaPromoteExpertDown(layerIndex(name), t.numLayers), name, shape, base)
+	case lagunaSharedExpertProjection(name):
+		return lagunaQuantizationType(name, shape, base)
+	case lagunaRoutedExpertProjection(name):
+		return lagunaQuantizationType(name, shape, base)
+	default:
 		return ""
 	}
-	return GetTensorQuantization(name, shape, quantize)
 }
 
-func lagunaIsHFRoutedExpertWeight(name string) bool {
-	return strings.HasSuffix(name, ".weight") && strings.Contains(name, ".mlp.experts.")
+func lagunaFPQuant(quantize string) bool {
+	return quantize == "nvfp4" || quantize == "mxfp4" || quantize == "mxfp8"
+}
+
+func lagunaAttentionProjection(name string) bool {
+	return strings.Contains(name, ".self_attn.q_proj.weight") ||
+		strings.Contains(name, ".self_attn.k_proj.weight") ||
+		strings.Contains(name, ".self_attn.v_proj.weight") ||
+		strings.Contains(name, ".self_attn.o_proj.weight") ||
+		strings.Contains(name, ".self_attn.g_proj.weight")
+}
+
+func lagunaDenseMLPProjection(name string) bool {
+	return strings.Contains(name, ".mlp.gate_proj.weight") ||
+		strings.Contains(name, ".mlp.up_proj.weight") ||
+		strings.Contains(name, ".mlp.down_proj.weight")
+}
+
+func lagunaRoutedExpertProjection(name string) bool {
+	if !lagunaMLPProjectionWeight(name) {
+		return false
+	}
+	return strings.Contains(name, ".mlp.experts.")
+}
+
+func lagunaRoutedExpertDownProjection(name string) bool {
+	return strings.Contains(name, ".mlp.experts.") && strings.HasSuffix(name, ".down_proj.weight")
+}
+
+func lagunaSharedExpertProjection(name string) bool {
+	if !lagunaMLPProjectionWeight(name) {
+		return false
+	}
+	return strings.Contains(name, ".mlp.shared_expert.")
+}
+
+func lagunaSharedExpertDownProjection(name string) bool {
+	return strings.Contains(name, ".mlp.shared_expert.down_proj.weight")
+}
+
+// Laguna XS 2 and 2.1 are sensitive to fully quantizing expert down
+// projections. Keep the same cadence for both: use higher precision on the
+// input-side layers, final layers, and a sparse cadence early in the residual
+// stream. For 4-bit fp quants that higher precision is mxfp8. For mxfp8, the
+// shared expert down projections stay at source precision because the tensor
+// class is small; routed expert down projections use the cadence to avoid
+// pushing the model too close to bf16 size.
+func lagunaPromoteExpertDown(layerIdx, numLayers int) bool {
+	if layerIdx < 0 || numLayers <= 0 {
+		return false
+	}
+	first := numLayers / 8
+	last := 7 * numLayers / 8
+	middleEnd := numLayers/2 - 4
+	return layerIdx < first ||
+		layerIdx >= last ||
+		(layerIdx >= first && layerIdx < middleEnd && (layerIdx-first)%3 == 2)
+}
+
+func lagunaMLPProjectionWeight(name string) bool {
+	return strings.HasSuffix(name, ".gate_proj.weight") ||
+		strings.HasSuffix(name, ".up_proj.weight") ||
+		strings.HasSuffix(name, ".down_proj.weight")
+}
+
+func lagunaQuantizationType(name string, shape []int32, quantize string) string {
+	if !ShouldQuantize(name, "") {
+		return ""
+	}
+	if len(shape) != 2 && len(shape) != 3 {
+		return ""
+	}
+
+	var elems int64 = 1
+	for _, d := range shape {
+		elems *= int64(d)
+	}
+	if elems < 1024 || !isAligned(shape, quantize) {
+		return ""
+	}
+
+	return quantize
+}
+
+func lagunaSensitiveType(promote bool, name string, shape []int32, quantize string) string {
+	if !ShouldQuantize(name, "") {
+		return ""
+	}
+	if quantize == "mxfp8" {
+		return ""
+	}
+	return sensitiveType(promote, shape, quantize)
 }

--- a/x/create/laguna_test.go
+++ b/x/create/laguna_test.go
@@ -1,0 +1,378 @@
+package create
+
+import (
+	"encoding/json"
+	"strconv"
+	"testing"
+)
+
+func TestLagunaImportTransformRegistration(t *testing.T) {
+	inv := Inventory{
+		Config:    sourceModelConfig{Architectures: []string{"LagunaForCausalLM"}},
+		RawConfig: json.RawMessage(`{"num_hidden_layers":40,"mlp_layer_types":["dense","sparse","sparse"]}`),
+	}
+
+	policy, err := newTensorImportTransform(inv)
+	if err != nil {
+		t.Fatalf("newTensorImportTransform() error = %v", err)
+	}
+
+	transform, ok := policy.(lagunaImportTransform)
+	if !ok {
+		t.Fatalf("newTensorImportTransform() = %T, want lagunaImportTransform", policy)
+	}
+	if !transform.denseMLPLayers[0] || transform.denseMLPLayers[1] {
+		t.Fatalf("denseMLPLayers = %v, want only layer 0", transform.denseMLPLayers)
+	}
+	if transform.numLayers != 40 {
+		t.Fatalf("numLayers = %d, want 40", transform.numLayers)
+	}
+}
+
+func TestLagunaImportTransformSameRecipeAcrossConfigs(t *testing.T) {
+	configs := map[string]json.RawMessage{
+		"laguna xs.2": json.RawMessage(`{
+			"num_hidden_layers": 40,
+			"mlp_layer_types": ["dense", "sparse", "sparse"]
+		}`),
+		"laguna xs 2.1": json.RawMessage(`{
+			"num_hidden_layers": 40,
+			"mlp_only_layers": [0],
+			"gating_types": ["per_head"]
+		}`),
+	}
+
+	for name, rawConfig := range configs {
+		t.Run(name, func(t *testing.T) {
+			policy, err := newLagunaImportTransform(rawConfig)
+			if err != nil {
+				t.Fatal(err)
+			}
+			testLagunaQuantizationRecipe(t, policy)
+		})
+	}
+}
+
+func TestLagunaPlanExpertGroupUsesStackedDownProjectionPolicy(t *testing.T) {
+	policy, err := newLagunaImportTransform(json.RawMessage(`{
+		"num_hidden_layers": 40,
+		"mlp_layer_types": ["dense", "sparse"]
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	inv := Inventory{Tensors: map[string]SourceTensor{}}
+	for _, layer := range []int{1, 5} {
+		for expert := 0; expert < 2; expert++ {
+			for _, projection := range []string{"gate_proj", "down_proj"} {
+				name := "model.layers." + strconv.Itoa(layer) + ".mlp.experts." + strconv.Itoa(expert) + "." + projection + ".weight"
+				inv.Tensors[name] = SourceTensor{
+					Name:  name,
+					Dtype: "BF16",
+					Shape: []int32{2048, 512},
+				}
+			}
+		}
+	}
+
+	specs, err := Plan(inv, Classification{Kind: SourceFloat, Quantize: "mxfp8"}, policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := map[string]string{
+		"model.layers.1.mlp.experts.down_proj.weight": "",
+		"model.layers.1.mlp.experts.gate_proj.weight": "mxfp8",
+		"model.layers.5.mlp.experts.down_proj.weight": "mxfp8",
+	}
+	for tensor, want := range tests {
+		if got := quantizeForPlannedTensor(specs, tensor); got != want {
+			t.Fatalf("planned quantization for %s = %q, want %q", tensor, got, want)
+		}
+	}
+}
+
+func quantizeForPlannedTensor(specs []BlobSpec, name string) string {
+	for _, spec := range specs {
+		for _, ts := range spec.Tensors {
+			if ts.Name == name {
+				return ts.Quantize
+			}
+		}
+	}
+	return "<missing>"
+}
+
+func testLagunaQuantizationRecipe(t *testing.T, policy quantizePolicy) {
+	t.Helper()
+
+	tests := []struct {
+		name     string
+		tensor   string
+		shape    []int32
+		quantize string
+		want     string
+	}{
+		{
+			name:     "attention q projection uses requested fp4",
+			tensor:   "model.layers.1.self_attn.q_proj.weight",
+			shape:    []int32{8192, 2048},
+			quantize: "nvfp4",
+			want:     "nvfp4",
+		},
+		{
+			name:     "attention v projection uses requested fp4 before promotion layer",
+			tensor:   "model.layers.0.self_attn.v_proj.weight",
+			shape:    []int32{1024, 2048},
+			quantize: "nvfp4",
+			want:     "nvfp4",
+		},
+		{
+			name:     "attention v projection uses requested fp4 on layer 4",
+			tensor:   "model.layers.4.self_attn.v_proj.weight",
+			shape:    []int32{1024, 2048},
+			quantize: "nvfp4",
+			want:     "nvfp4",
+		},
+		{
+			name:     "attention v projection uses requested fp4 after promotion layer",
+			tensor:   "model.layers.5.self_attn.v_proj.weight",
+			shape:    []int32{1024, 2048},
+			quantize: "nvfp4",
+			want:     "nvfp4",
+		},
+		{
+			name:     "attention k projection uses requested fp4 on input layer",
+			tensor:   "model.layers.0.self_attn.k_proj.weight",
+			shape:    []int32{1024, 2048},
+			quantize: "nvfp4",
+			want:     "nvfp4",
+		},
+		{
+			name:     "attention k projection uses requested fp4 past layer 0",
+			tensor:   "model.layers.4.self_attn.k_proj.weight",
+			shape:    []int32{1024, 2048},
+			quantize: "nvfp4",
+			want:     "nvfp4",
+		},
+		{
+			name:     "attention k projection stays source precision for mxfp8",
+			tensor:   "model.layers.4.self_attn.k_proj.weight",
+			shape:    []int32{1024, 2048},
+			quantize: "mxfp8",
+			want:     "",
+		},
+		{
+			name:     "attention v projection stays source precision for mxfp8",
+			tensor:   "model.layers.4.self_attn.v_proj.weight",
+			shape:    []int32{1024, 2048},
+			quantize: "mxfp8",
+			want:     "",
+		},
+		{
+			name:     "attention q projection stays source precision for mxfp8",
+			tensor:   "model.layers.4.self_attn.q_proj.weight",
+			shape:    []int32{8192, 2048},
+			quantize: "mxfp8",
+			want:     "",
+		},
+		{
+			name:     "attention o projection stays source precision for mxfp8",
+			tensor:   "model.layers.4.self_attn.o_proj.weight",
+			shape:    []int32{2048, 8192},
+			quantize: "mxfp8",
+			want:     "",
+		},
+		{
+			name:     "attention gate projection stays source precision for mxfp8",
+			tensor:   "model.layers.4.self_attn.g_proj.weight",
+			shape:    []int32{64, 2048},
+			quantize: "mxfp8",
+			want:     "",
+		},
+		{
+			name:     "attention gate projection uses requested fp4",
+			tensor:   "model.layers.1.self_attn.g_proj.weight",
+			shape:    []int32{64, 2048},
+			quantize: "nvfp4",
+			want:     "nvfp4",
+		},
+		{
+			name:     "dense gate projection uses requested fp4",
+			tensor:   "model.layers.0.mlp.gate_proj.weight",
+			shape:    []int32{8192, 2048},
+			quantize: "nvfp4",
+			want:     "nvfp4",
+		},
+		{
+			name:     "dense down projection uses requested fp4",
+			tensor:   "model.layers.0.mlp.down_proj.weight",
+			shape:    []int32{2048, 8192},
+			quantize: "nvfp4",
+			want:     "nvfp4",
+		},
+		{
+			name:     "unsupported dense projection in sparse layer stays source precision",
+			tensor:   "model.layers.1.mlp.down_proj.weight",
+			shape:    []int32{2048, 8192},
+			quantize: "nvfp4",
+			want:     "",
+		},
+		{
+			name:     "routed expert gate uses requested fp4",
+			tensor:   "model.layers.1.mlp.experts.gate_proj.weight",
+			shape:    []int32{256, 512, 2048},
+			quantize: "nvfp4",
+			want:     "nvfp4",
+		},
+		{
+			name:     "routed expert down uses requested fp4 on cadence layer",
+			tensor:   "model.layers.1.mlp.experts.down_proj.weight",
+			shape:    []int32{256, 2048, 512},
+			quantize: "nvfp4",
+			want:     "nvfp4",
+		},
+		{
+			name:     "routed expert down uses requested fp4 on later layer",
+			tensor:   "model.layers.5.mlp.experts.down_proj.weight",
+			shape:    []int32{256, 2048, 512},
+			quantize: "nvfp4",
+			want:     "nvfp4",
+		},
+		{
+			name:     "shared expert gate uses requested fp4",
+			tensor:   "model.layers.1.mlp.shared_expert.gate_proj.weight",
+			shape:    []int32{512, 2048},
+			quantize: "nvfp4",
+			want:     "nvfp4",
+		},
+		{
+			name:     "shared expert down promotes to mxfp8 on input-side layer",
+			tensor:   "model.layers.1.mlp.shared_expert.down_proj.weight",
+			shape:    []int32{2048, 512},
+			quantize: "nvfp4",
+			want:     "mxfp8",
+		},
+		{
+			name:     "shared expert down uses requested fp4 before middle cadence",
+			tensor:   "model.layers.5.mlp.shared_expert.down_proj.weight",
+			shape:    []int32{2048, 512},
+			quantize: "nvfp4",
+			want:     "nvfp4",
+		},
+		{
+			name:     "shared expert down promotes to mxfp8 on first selected middle layer",
+			tensor:   "model.layers.7.mlp.shared_expert.down_proj.weight",
+			shape:    []int32{2048, 512},
+			quantize: "nvfp4",
+			want:     "mxfp8",
+		},
+		{
+			name:     "shared expert down promotes to mxfp8 on early middle layer",
+			tensor:   "model.layers.10.mlp.shared_expert.down_proj.weight",
+			shape:    []int32{2048, 512},
+			quantize: "nvfp4",
+			want:     "mxfp8",
+		},
+		{
+			name:     "shared expert down promotes to mxfp8 on last selected middle layer",
+			tensor:   "model.layers.13.mlp.shared_expert.down_proj.weight",
+			shape:    []int32{2048, 512},
+			quantize: "nvfp4",
+			want:     "mxfp8",
+		},
+		{
+			name:     "shared expert down uses requested fp4 after selected middle layers",
+			tensor:   "model.layers.16.mlp.shared_expert.down_proj.weight",
+			shape:    []int32{2048, 512},
+			quantize: "nvfp4",
+			want:     "nvfp4",
+		},
+		{
+			name:     "shared expert down uses requested fp4 on late middle layer",
+			tensor:   "model.layers.19.mlp.shared_expert.down_proj.weight",
+			shape:    []int32{2048, 512},
+			quantize: "nvfp4",
+			want:     "nvfp4",
+		},
+		{
+			name:     "shared expert down promotes to mxfp8 on final layers",
+			tensor:   "model.layers.39.mlp.shared_expert.down_proj.weight",
+			shape:    []int32{2048, 512},
+			quantize: "nvfp4",
+			want:     "mxfp8",
+		},
+		{
+			name:     "shared expert down stays source precision for mxfp8 on selected layer",
+			tensor:   "model.layers.1.mlp.shared_expert.down_proj.weight",
+			shape:    []int32{2048, 512},
+			quantize: "mxfp8",
+			want:     "",
+		},
+		{
+			name:     "shared expert down stays source precision for mxfp8 off selected layers",
+			tensor:   "model.layers.5.mlp.shared_expert.down_proj.weight",
+			shape:    []int32{2048, 512},
+			quantize: "mxfp8",
+			want:     "",
+		},
+		{
+			name:     "routed expert down stays source precision for mxfp8 on selected layer",
+			tensor:   "model.layers.1.mlp.experts.down_proj.weight",
+			shape:    []int32{256, 2048, 512},
+			quantize: "mxfp8",
+			want:     "",
+		},
+		{
+			name:     "per-expert routed down stays source precision for mxfp8 on selected layer",
+			tensor:   "model.layers.1.mlp.experts.0.down_proj.weight",
+			shape:    []int32{2048, 512},
+			quantize: "mxfp8",
+			want:     "",
+		},
+		{
+			name:     "routed expert down uses mxfp8 off selected layers",
+			tensor:   "model.layers.5.mlp.experts.down_proj.weight",
+			shape:    []int32{256, 2048, 512},
+			quantize: "mxfp8",
+			want:     "mxfp8",
+		},
+		{
+			name:     "per-expert routed down uses mxfp8 off selected layers",
+			tensor:   "model.layers.5.mlp.experts.0.down_proj.weight",
+			shape:    []int32{2048, 512},
+			quantize: "mxfp8",
+			want:     "mxfp8",
+		},
+		{
+			name:     "router gate stays source precision",
+			tensor:   "model.layers.1.mlp.gate.weight",
+			shape:    []int32{256, 2048},
+			quantize: "nvfp4",
+			want:     "",
+		},
+		{
+			name:     "embedding stays source precision",
+			tensor:   "model.embed_tokens.weight",
+			shape:    []int32{100352, 2048},
+			quantize: "nvfp4",
+			want:     "",
+		},
+		{
+			name:     "lm head stays source precision",
+			tensor:   "lm_head.weight",
+			shape:    []int32{100352, 2048},
+			quantize: "nvfp4",
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := policy.quantizationType(tt.tensor, tt.shape, tt.quantize); got != tt.want {
+				t.Fatalf("quantizationType(%q, %v, %q) = %q, want %q", tt.tensor, tt.shape, tt.quantize, got, tt.want)
+			}
+		})
+	}
+}

--- a/x/create/quantize.go
+++ b/x/create/quantize.go
@@ -55,30 +55,7 @@ func quantizeBlobLocked(items []quantizeItem) ([]byte, error) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	// Blob metadata: a single quant_type/group_size when every quantized
-	// tensor matches, otherwise per-tensor entries.
-	uniform, mixed, hasQuant := "", false, false
-	for _, it := range items {
-		if it.quantize == "" {
-			if hasQuant {
-				mixed = true
-			}
-			continue
-		}
-		if !hasQuant {
-			hasQuant, uniform = true, it.quantize
-			continue
-		}
-		if it.quantize != uniform {
-			mixed = true
-		}
-	}
-	var metadata map[string]string
-	if hasQuant && !mixed {
-		if gs, _, _ := quant.Params(uniform); gs > 0 {
-			metadata = map[string]string{"quant_type": uniform, "group_size": strconv.Itoa(gs)}
-		}
-	}
+	metadata, mixed := quantizeBlobMetadata(items)
 
 	for _, it := range items {
 		if err := func() error {
@@ -118,6 +95,41 @@ func quantizeBlobLocked(items []quantizeItem) ([]byte, error) {
 		return nil, fmt.Errorf("failed to save blob: %w", err)
 	}
 	return os.ReadFile(outPath)
+}
+
+// quantizeBlobMetadata returns blob-level quantization metadata. A uniform
+// quant_type is valid only when every tensor in the blob is quantized the same
+// way; mixed blobs, including blobs with unquantized tensors, use per-tensor
+// metadata for the quantized tensors instead.
+func quantizeBlobMetadata(items []quantizeItem) (map[string]string, bool) {
+	var uniform string
+	var hasQuant, hasPlain, mixed bool
+	for _, it := range items {
+		if it.quantize == "" {
+			hasPlain = true
+			continue
+		}
+		if !hasQuant {
+			hasQuant, uniform = true, it.quantize
+			continue
+		}
+		if it.quantize != uniform {
+			mixed = true
+		}
+	}
+	if !hasQuant {
+		return nil, false
+	}
+	if hasPlain {
+		mixed = true
+	}
+	if mixed {
+		return nil, true
+	}
+	if gs, _, _ := quant.Params(uniform); gs > 0 {
+		return map[string]string{"quant_type": uniform, "group_size": strconv.Itoa(gs)}, false
+	}
+	return nil, false
 }
 
 func arraysForItem(all map[string]*mlx.Array, it quantizeItem) []*mlx.Array {

--- a/x/create/quantize_test.go
+++ b/x/create/quantize_test.go
@@ -1,0 +1,70 @@
+package create
+
+import "testing"
+
+func TestQuantizeBlobMetadata(t *testing.T) {
+	tests := []struct {
+		name         string
+		items        []quantizeItem
+		wantMixed    bool
+		wantMetadata map[string]string
+	}{
+		{
+			name: "uniform quantized",
+			items: []quantizeItem{
+				{name: "a", quantize: "mxfp8"},
+				{name: "b", quantize: "mxfp8"},
+			},
+			wantMetadata: map[string]string{"quant_type": "mxfp8", "group_size": "32"},
+		},
+		{
+			name: "plain tensor before quantized tensors is mixed",
+			items: []quantizeItem{
+				{name: "a"},
+				{name: "b", quantize: "mxfp8"},
+				{name: "c", quantize: "mxfp8"},
+			},
+			wantMixed: true,
+		},
+		{
+			name: "quantized tensor before plain tensor is mixed",
+			items: []quantizeItem{
+				{name: "a", quantize: "mxfp8"},
+				{name: "b"},
+			},
+			wantMixed: true,
+		},
+		{
+			name: "different quantized types are mixed",
+			items: []quantizeItem{
+				{name: "a", quantize: "mxfp8"},
+				{name: "b", quantize: "nvfp4"},
+			},
+			wantMixed: true,
+		},
+		{
+			name: "unquantized only has no quant metadata",
+			items: []quantizeItem{
+				{name: "a"},
+				{name: "b"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotMetadata, gotMixed := quantizeBlobMetadata(tt.items)
+			if gotMixed != tt.wantMixed {
+				t.Fatalf("mixed = %v, want %v", gotMixed, tt.wantMixed)
+			}
+			if len(gotMetadata) != len(tt.wantMetadata) {
+				t.Fatalf("metadata = %v, want %v", gotMetadata, tt.wantMetadata)
+			}
+			for k, want := range tt.wantMetadata {
+				if got := gotMetadata[k]; got != want {
+					t.Fatalf("metadata[%q] = %q, want %q (all metadata: %v)", k, got, want, gotMetadata)
+				}
+			}
+		})
+	}
+}

--- a/x/mlxrunner/mlx/moe_gather_qmm_mapped.go
+++ b/x/mlxrunner/mlx/moe_gather_qmm_mapped.go
@@ -1,0 +1,2333 @@
+package mlx
+
+// #include <stdlib.h>
+// #include "generated.h"
+import "C"
+
+// The mapped MoE expert projection fast paths are shared by multiple MoE model
+// implementations. They are most useful for routed expert projections with
+// many small per-expert matmuls, where MLX's generic gathered matmul path can
+// leave avoidable routing and launch overhead on Metal.
+// Keep the public model-facing API narrow: exported FastMoE helpers perform
+// dtype dispatch and keep fallback decisions inside this package.
+// TODO(cuda): add CUDA equivalents for these custom Metal kernels before
+// enabling the same fast path on CUDA-backed MLX; non-Metal backends must keep
+// using the generic fallback.
+
+import (
+	"sync"
+	"unsafe"
+)
+
+var (
+	moeExpertMapMetalKernelOnce sync.Once
+	moeExpertMapMetalKernel     C.mlx_fast_metal_kernel
+	moeExpertMapMetalDisabled   bool
+
+	moeExpertBlockMapMetalKernelOnce sync.Once
+	moeExpertBlockMapMetalKernel     C.mlx_fast_metal_kernel
+	moeExpertBlockMapMetalDisabled   bool
+
+	nvfp4MoEMappedMetalKernelOnce sync.Once
+	nvfp4MoEMappedMetalKernel     C.mlx_fast_metal_kernel
+	nvfp4MoEMappedMetalDisabled   bool
+
+	nvfp4MoEBlockMappedMetalKernelOnce sync.Once
+	nvfp4MoEBlockMappedMetalKernel     C.mlx_fast_metal_kernel
+	nvfp4MoEBlockMappedMetalDisabled   bool
+
+	mxfp8MoEMappedMetalKernelOnce sync.Once
+	mxfp8MoEMappedMetalKernel     C.mlx_fast_metal_kernel
+	mxfp8MoEMappedMetalDisabled   bool
+
+	mxfp8MoEBlockMappedMetalKernelOnce sync.Once
+	mxfp8MoEBlockMappedMetalKernel     C.mlx_fast_metal_kernel
+	mxfp8MoEBlockMappedMetalDisabled   bool
+
+	moeGatherMMBlockMappedMetalKernelOnce sync.Once
+	moeGatherMMBlockMappedMetalKernel     C.mlx_fast_metal_kernel
+	moeGatherMMBlockMappedMetalDisabled   bool
+)
+
+const (
+	moeExpertBlockSize          = 32
+	maxMoEExpertBlockMapExperts = 1024
+)
+
+// Mapped MoE kernels use Metal 4 tensor ops when available, with a
+// simdgroup_matrix fallback for older OS releases. Keeping both paths in one
+// source string preserves the same Go-side kernel API across supported macOS
+// versions.
+const moeMappedMetalKernelHeader = `
+#include <metal_stdlib>
+#include <metal_simdgroup_matrix>
+
+#if __has_include(<metal_tensor>)
+#include <metal_tensor>
+#include <MetalPerformancePrimitives/MetalPerformancePrimitives.h>
+#define OLLAMA_MLX_HAS_METAL_TENSOR 1
+#else
+#define OLLAMA_MLX_HAS_METAL_TENSOR 0
+#endif
+
+using namespace metal;
+
+#if OLLAMA_MLX_HAS_METAL_TENSOR
+using namespace mpp::tensor_ops;
+#endif
+
+#define MOE_MAPPED_FOR_UNROLL(x) _Pragma("clang loop unroll(full)") for (x)
+
+inline half moe_mapped_nvfp4_value(uint nibble) {
+  half v = as_type<half>(ushort((nibble & 7) << 9));
+  v *= 16384.0h;
+  return (nibble & 8) ? -v : v;
+}
+
+inline half moe_mapped_nvfp4_scale(uint8_t sb) {
+  half scale = as_type<half>(ushort(uint16_t(sb & 127) << 7));
+  scale *= 256.0h;
+  return (sb & 128) ? -scale : scale;
+}
+
+inline half moe_mapped_mxfp8_value(uint8_t b) {
+  return moe_mapped_nvfp4_scale(b);
+}
+
+inline float moe_mapped_mxfp8_scale(uint8_t sb) {
+  uint32_t out = (sb == 0) ? 0x400000u : (uint32_t(sb) << 23);
+  return as_type<float>(out);
+}
+`
+
+const moeExpertMapMetalKernelSource = `
+constexpr int Threads = 128;
+
+auto expert = threadgroup_position_in_grid.x;
+if (expert >= E) {
+  return;
+}
+auto tid = thread_index_in_threadgroup;
+constexpr int Total = T * TopK;
+
+threadgroup int local_counts[Threads];
+
+uint n = 0;
+for (int flat = int(tid); flat < Total; flat += Threads) {
+  if (uint(indices[flat]) == expert) {
+    n++;
+  }
+}
+local_counts[tid] = int(n);
+threadgroup_barrier(mem_flags::mem_threadgroup);
+
+for (uint offset = 1; offset < Threads; offset <<= 1) {
+  int add = 0;
+  if (tid >= offset) {
+    add = local_counts[tid - offset];
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  local_counts[tid] += add;
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+}
+
+int out = local_counts[tid] - int(n);
+if (tid == Threads - 1) {
+  counts[expert] = local_counts[tid];
+}
+
+for (int flat = int(tid); flat < Total; flat += Threads) {
+  if (uint(indices[flat]) == expert) {
+    ids[size_t(expert) * T + out] = flat;
+    out++;
+  }
+}
+`
+
+const moeExpertBlockMapMetalKernelSource = `
+constexpr int Threads = 256;
+constexpr int NR1 = 32;
+constexpr int Total = T * TopK;
+
+auto tid = thread_index_in_threadgroup;
+
+threadgroup atomic_int local_counts[E];
+threadgroup atomic_int write_counts[E];
+threadgroup int block_bases[E];
+
+for (int expert = int(tid); expert < E; expert += Threads) {
+  atomic_store_explicit(&local_counts[expert], 0, memory_order_relaxed);
+  atomic_store_explicit(&write_counts[expert], 0, memory_order_relaxed);
+  block_bases[expert] = 0;
+}
+threadgroup_barrier(mem_flags::mem_threadgroup);
+
+for (int flat = int(tid); flat < Total; flat += Threads) {
+  int expert = int(indices[flat]);
+  if (expert >= 0 && expert < E) {
+    atomic_fetch_add_explicit(&local_counts[expert], 1, memory_order_relaxed);
+  }
+}
+threadgroup_barrier(mem_flags::mem_threadgroup);
+
+if (tid == 0) {
+  int next_block = 0;
+  for (int expert = 0; expert < E; expert++) {
+    int count = atomic_load_explicit(&local_counts[expert], memory_order_relaxed);
+    atomic_store_explicit(counts + expert, count, memory_order_relaxed);
+    block_bases[expert] = next_block;
+
+    int blocks = (count + NR1 - 1) / NR1;
+    for (int block = 0; block < blocks; block++) {
+      int dst = next_block + block;
+      if (dst < MaxBlocks) {
+        atomic_store_explicit(block_experts + dst, expert, memory_order_relaxed);
+        atomic_store_explicit(block_offsets + dst, block * NR1, memory_order_relaxed);
+      }
+    }
+    next_block += blocks;
+  }
+  atomic_store_explicit(block_count, next_block, memory_order_relaxed);
+}
+threadgroup_barrier(mem_flags::mem_threadgroup);
+
+for (int flat = int(tid); flat < Total; flat += Threads) {
+  int expert = int(indices[flat]);
+  if (expert >= 0 && expert < E) {
+    int out = atomic_fetch_add_explicit(&write_counts[expert], 1, memory_order_relaxed);
+    int dst = block_bases[expert] + out / NR1;
+    if (dst < MaxBlocks) {
+      atomic_store_explicit(block_ids + size_t(dst) * NR1 + size_t(out % NR1), flat, memory_order_relaxed);
+    }
+  }
+}
+`
+
+const moeGatherMMBlockMappedMetalKernelSource = `
+#if OLLAMA_MLX_HAS_METAL_TENSOR
+constexpr int NR0 = 64;
+constexpr int NR1 = 32;
+constexpr int NK = 32;
+constexpr int NL0 = NK / 16;
+constexpr int NL1 = NK / 8;
+
+const int block = int(threadgroup_position_in_grid.x);
+const int r0 = int(threadgroup_position_in_grid.y) * NR0;
+if (block >= int(block_count[0]) || r0 >= N) {
+  return;
+}
+
+const int expert = int(block_experts[block]);
+const int r1 = int(block_offsets[block]);
+if (expert >= E) {
+  return;
+}
+
+const int count = int(counts[expert]);
+if (r1 >= count) {
+  return;
+}
+
+const short tiitg = short(thread_index_in_threadgroup);
+const short tiisg = short(thread_index_in_simdgroup);
+const short sgitg = short(simdgroup_index_in_threadgroup);
+
+const short nr0 = short((N - r0 < NR0) ? (N - r0) : NR0);
+const short nr1 = short((count - r1 < NR1) ? (count - r1) : NR1);
+
+const short lr0 = short(((tiitg / NL0) < nr0) ? (tiitg / NL0) : (nr0 - 1));
+const short il0 = short(tiitg % NL0);
+const short row1 = short(tiitg / NL1);
+const short il1 = short(tiitg % NL1);
+const short iy = short(8 * il1);
+
+threadgroup bfloat sa[NR0 * NK];
+threadgroup bfloat sb[NR1 * NK];
+threadgroup float temp[NR1 * NR0];
+
+auto tA = tensor<threadgroup bfloat, dextents<int32_t, 2>, tensor_inline>(sa, dextents<int32_t, 2>(NK, NR0));
+auto tB = tensor<threadgroup bfloat, dextents<int32_t, 2>, tensor_inline>(sb, dextents<int32_t, 2>(NR1, NK));
+
+mpp::tensor_ops::matmul2d<
+  mpp::tensor_ops::matmul2d_descriptor(
+    NR1, NR0, NK, false, true, false,
+    mpp::tensor_ops::matmul2d_descriptor::mode::multiply_accumulate),
+  execution_simdgroups<4>> mm;
+
+auto cT = mm.template get_destination_cooperative_tensor<decltype(tA), decltype(tB), float>();
+
+MOE_MAPPED_FOR_UNROLL (uint16_t i = 0; i < cT.get_capacity(); ++i) {
+  if (cT.is_valid_element(i)) {
+    cT[i] = 0.0f;
+  }
+}
+
+for (int loop_k = 0; loop_k < K; loop_k += NK) {
+  const int col = r0 + lr0;
+  const int k0 = loop_k + 16 * il0;
+  const size_t w_base = WeightTransposed == 0
+    ? (size_t(expert) * K + size_t(k0)) * N + size_t(col)
+    : (size_t(expert) * N + size_t(col)) * K + size_t(k0);
+
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  MOE_MAPPED_FOR_UNROLL (short i = 0; i < 16; i++) {
+    const short sx = short(2 * il0 + i / 8);
+    const short sy = short((tiitg / NL0) / 8);
+    const short lx = short(i % 8);
+    const short ly = short((tiitg / NL0) % 8);
+    const size_t w_offset = WeightTransposed == 0 ? size_t(i) * N : size_t(i);
+    *(sa + NK * (8 * sy + ly) + 8 * sx + lx) = bfloat(static_cast<float>(w[w_base + w_offset]));
+  }
+
+  const size_t sb_base = NK * row1 + 8 * il1;
+  if (row1 < nr1) {
+    const int id = block_ids[size_t(block) * NR1 + size_t(row1)];
+    const int token = id / TopK;
+    const int slot = id - token * TopK;
+    const int inputSlot = InputSlots == 1 ? 0 : slot;
+    const size_t x_base = (size_t(token) * InputSlots + size_t(inputSlot)) * K + size_t(loop_k + iy);
+
+    MOE_MAPPED_FOR_UNROLL (short i = 0; i < 8; i++) {
+      float xv = static_cast<float>(x[x_base + i]);
+      if (ApplyReluSquared != 0) {
+        xv = (xv > 0.0f) ? (xv * xv) : 0.0f;
+      }
+      *(sb + sb_base + i) = bfloat(xv);
+    }
+  } else {
+    MOE_MAPPED_FOR_UNROLL (short i = 0; i < 8; i++) {
+      *(sb + sb_base + i) = bfloat(0.0f);
+    }
+  }
+
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  auto sA = tA.slice(0, 0);
+  auto sB = tB.slice(0, 0);
+  mm.run(sB, sA, cT);
+}
+
+threadgroup_barrier(mem_flags::mem_threadgroup);
+
+auto tC = tensor<threadgroup float, dextents<int32_t, 2>, tensor_inline>(temp, dextents<int32_t, 2>(NR0, NR1));
+cT.store(tC);
+
+threadgroup_barrier(mem_flags::mem_threadgroup);
+
+for (short j = sgitg; j < nr1; j += 4) {
+  const int id = block_ids[size_t(block) * NR1 + size_t(j)];
+  const int token = id / TopK;
+  const int slot = id - token * TopK;
+  device OutT* dst = y + (size_t(token) * TopK + size_t(slot)) * N + size_t(r0);
+  threadgroup float* src = temp + int(j) * NR0;
+  int i = tiisg;
+  for (; i < nr0; i += 32) {
+    dst[i] = static_cast<OutT>(src[i]);
+  }
+}
+#else
+constexpr int NR0 = 64;
+constexpr int NR1 = 32;
+constexpr int NK = 32;
+constexpr int NL0 = NK / 16;
+constexpr int NL1 = NK / 8;
+
+const int block = int(threadgroup_position_in_grid.x);
+const int r0 = int(threadgroup_position_in_grid.y) * NR0;
+if (block >= int(block_count[0]) || r0 >= N) {
+  return;
+}
+
+const int expert = int(block_experts[block]);
+const int r1 = int(block_offsets[block]);
+if (expert >= E) {
+  return;
+}
+
+const int count = int(counts[expert]);
+if (r1 >= count) {
+  return;
+}
+
+const short tiitg = short(thread_index_in_threadgroup);
+const short tiisg = short(thread_index_in_simdgroup);
+const short sgitg = short(simdgroup_index_in_threadgroup);
+
+const short nr0 = short((N - r0 < NR0) ? (N - r0) : NR0);
+const short nr1 = short((count - r1 < NR1) ? (count - r1) : NR1);
+
+const short lr0 = short(((tiitg / NL0) < nr0) ? (tiitg / NL0) : (nr0 - 1));
+const short il0 = short(tiitg % NL0);
+const short row1 = short(tiitg / NL1);
+const short il1 = short(tiitg % NL1);
+const short iy = short(8 * il1);
+
+threadgroup float sx[NR1 * NK];
+threadgroup float sw[NR0 * NK];
+threadgroup float temp[NR1 * NR0];
+
+for (int i = int(tiitg); i < NR1 * NR0; i += 128) {
+  temp[i] = 0.0f;
+}
+threadgroup_barrier(mem_flags::mem_threadgroup);
+
+for (int loop_k = 0; loop_k < K; loop_k += NK) {
+  const int col = r0 + lr0;
+  const int k0 = loop_k + 16 * il0;
+  const size_t w_base = WeightTransposed == 0
+    ? (size_t(expert) * K + size_t(k0)) * N + size_t(col)
+    : (size_t(expert) * N + size_t(col)) * K + size_t(k0);
+
+  MOE_MAPPED_FOR_UNROLL (short i = 0; i < 16; i++) {
+    const short local_k = short(16 * il0 + i);
+    const size_t w_offset = WeightTransposed == 0 ? size_t(i) * N : size_t(i);
+    sw[int(local_k) * NR0 + int(lr0)] = static_cast<float>(w[w_base + w_offset]);
+  }
+
+  const size_t sb_base = int(row1) * NK + int(iy);
+  if (row1 < nr1) {
+    const int id = block_ids[size_t(block) * NR1 + size_t(row1)];
+    const int token = id / TopK;
+    const int slot = id - token * TopK;
+    const int inputSlot = InputSlots == 1 ? 0 : slot;
+    const size_t x_base = (size_t(token) * InputSlots + size_t(inputSlot)) * K + size_t(loop_k + iy);
+
+    MOE_MAPPED_FOR_UNROLL (short i = 0; i < 8; i++) {
+      float xv = static_cast<float>(x[x_base + i]);
+      if (ApplyReluSquared != 0) {
+        xv = (xv > 0.0f) ? (xv * xv) : 0.0f;
+      }
+      sx[sb_base + i] = xv;
+    }
+  } else {
+    MOE_MAPPED_FOR_UNROLL (short i = 0; i < 8; i++) {
+      sx[sb_base + i] = 0.0f;
+    }
+  }
+
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  for (short tile = sgitg; tile < 32; tile += 4) {
+    const short tile_r1 = short((tile / 8) * 8);
+    const short tile_r0 = short((tile % 8) * 8);
+
+    simdgroup_float8x8 mx;
+    simdgroup_float8x8 mw;
+    simdgroup_float8x8 acc;
+
+    simdgroup_load(acc, temp + int(tile_r1) * NR0 + int(tile_r0), NR0);
+    MOE_MAPPED_FOR_UNROLL (short k = 0; k < NK; k += 8) {
+      simdgroup_load(mx, sx + int(tile_r1) * NK + int(k), NK);
+      simdgroup_load(mw, sw + int(k) * NR0 + int(tile_r0), NR0);
+      simdgroup_multiply_accumulate(acc, mx, mw, acc);
+    }
+    simdgroup_store(acc, temp + int(tile_r1) * NR0 + int(tile_r0), NR0);
+  }
+
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+}
+
+for (short j = sgitg; j < nr1; j += 4) {
+  const int id = block_ids[size_t(block) * NR1 + size_t(j)];
+  const int token = id / TopK;
+  const int slot = id - token * TopK;
+  device OutT* dst = y + (size_t(token) * TopK + size_t(slot)) * N + size_t(r0);
+  threadgroup float* src = temp + int(j) * NR0;
+  int i = tiisg;
+  for (; i < nr0; i += 32) {
+    dst[i] = static_cast<OutT>(src[i]);
+  }
+}
+#endif
+`
+
+const nvfp4MoEMappedMetalKernelSource = `
+#if OLLAMA_MLX_HAS_METAL_TENSOR
+constexpr int NR0 = 64;
+constexpr int NR1 = 32;
+constexpr int NK = 32;
+constexpr int NL0 = NK / 16;
+constexpr int NL1 = NK / 8;
+
+const int expert = int(threadgroup_position_in_grid.z);
+const int r1 = int(threadgroup_position_in_grid.x) * NR1;
+const int r0 = int(threadgroup_position_in_grid.y) * NR0;
+if (expert >= E || r0 >= N) {
+  return;
+}
+
+const int count = int(counts[expert]);
+if (r1 >= count) {
+  return;
+}
+
+const short tiitg = short(thread_index_in_threadgroup);
+const short tiisg = short(thread_index_in_simdgroup);
+const short sgitg = short(simdgroup_index_in_threadgroup);
+
+const short nr0 = short((N - r0 < NR0) ? (N - r0) : NR0);
+const short nr1 = short((count - r1 < NR1) ? (count - r1) : NR1);
+
+const short lr0 = short(((tiitg / NL0) < nr0) ? (tiitg / NL0) : (nr0 - 1));
+const short il0 = short(tiitg % NL0);
+const short row1 = short(tiitg / NL1);
+const short il1 = short(tiitg % NL1);
+const short iy = short(8 * il1);
+
+threadgroup bfloat sa[NR0 * NK];
+threadgroup bfloat sb[NR1 * NK];
+threadgroup float temp[NR1 * NR0];
+
+const device uint8_t* wb = reinterpret_cast<const device uint8_t*>(w);
+const size_t k_bytes = K / 2;
+const size_t k_groups = K / 16;
+
+auto tA = tensor<threadgroup bfloat, dextents<int32_t, 2>, tensor_inline>(sa, dextents<int32_t, 2>(NK, NR0));
+auto tB = tensor<threadgroup bfloat, dextents<int32_t, 2>, tensor_inline>(sb, dextents<int32_t, 2>(NR1, NK));
+
+mpp::tensor_ops::matmul2d<
+  mpp::tensor_ops::matmul2d_descriptor(
+    NR1, NR0, NK, false, true, false,
+    mpp::tensor_ops::matmul2d_descriptor::mode::multiply_accumulate),
+  execution_simdgroups<4>> mm;
+
+auto cT = mm.template get_destination_cooperative_tensor<decltype(tA), decltype(tB), float>();
+
+MOE_MAPPED_FOR_UNROLL (uint16_t i = 0; i < cT.get_capacity(); ++i) {
+  if (cT.is_valid_element(i)) {
+    cT[i] = 0.0f;
+  }
+}
+
+for (int loop_k = 0; loop_k < K; loop_k += NK) {
+  const int col = r0 + lr0;
+  const int k0 = loop_k + 16 * il0;
+  const size_t w_base = (size_t(expert) * N + col) * k_bytes + size_t(k0 / 2);
+  const size_t s_base = (size_t(expert) * N + col) * k_groups + size_t(k0 / 16);
+  const half scale = moe_mapped_nvfp4_scale(scales[s_base]);
+
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  MOE_MAPPED_FOR_UNROLL (short i = 0; i < 16; i++) {
+    const short sx = short(2 * il0 + i / 8);
+    const short sy = short((tiitg / NL0) / 8);
+    const short lx = short(i % 8);
+    const short ly = short((tiitg / NL0) % 8);
+
+    const uint8_t packed = wb[w_base + size_t(i / 2)];
+    const uint nibble = ((i & 1) == 0) ? uint(packed & 0x0f) : uint((packed >> 4) & 0x0f);
+    *(sa + NK * (8 * sy + ly) + 8 * sx + lx) = bfloat(scale * moe_mapped_nvfp4_value(nibble));
+  }
+
+  const size_t sb_base = NK * row1 + 8 * il1;
+  if (row1 < nr1) {
+    const int id = ids[size_t(expert) * T + size_t(r1 + row1)];
+    const int token = id / TopK;
+    const int slot = id - token * TopK;
+    const int inputSlot = InputSlots == 1 ? 0 : slot;
+    const size_t x_base = (size_t(token) * InputSlots + size_t(inputSlot)) * K + size_t(loop_k + iy);
+
+    MOE_MAPPED_FOR_UNROLL (short i = 0; i < 8; i++) {
+      float xv = static_cast<float>(x[x_base + i]);
+      if (ApplyReluSquared != 0) {
+        xv = (xv > 0.0f) ? (xv * xv) : 0.0f;
+      }
+      *(sb + sb_base + i) = bfloat(xv);
+    }
+  } else {
+    MOE_MAPPED_FOR_UNROLL (short i = 0; i < 8; i++) {
+      *(sb + sb_base + i) = bfloat(0.0f);
+    }
+  }
+
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  auto sA = tA.slice(0, 0);
+  auto sB = tB.slice(0, 0);
+  mm.run(sB, sA, cT);
+}
+
+threadgroup_barrier(mem_flags::mem_threadgroup);
+
+auto tC = tensor<threadgroup float, dextents<int32_t, 2>, tensor_inline>(temp, dextents<int32_t, 2>(NR0, NR1));
+cT.store(tC);
+
+threadgroup_barrier(mem_flags::mem_threadgroup);
+
+for (short j = sgitg; j < nr1; j += 4) {
+  const int id = ids[size_t(expert) * T + size_t(r1 + j)];
+  const int token = id / TopK;
+  const int slot = id - token * TopK;
+  device OutT* dst = y + (size_t(token) * TopK + size_t(slot)) * N + size_t(r0);
+  threadgroup float* src = temp + int(j) * NR0;
+  int i = tiisg;
+  for (; i < nr0; i += 32) {
+    dst[i] = static_cast<OutT>(src[i]);
+  }
+}
+#else
+constexpr int NR0 = 64;
+constexpr int NR1 = 32;
+constexpr int NK = 32;
+constexpr int NL0 = NK / 16;
+constexpr int NL1 = NK / 8;
+
+const int expert = int(threadgroup_position_in_grid.z);
+const int r1 = int(threadgroup_position_in_grid.x) * NR1;
+const int r0 = int(threadgroup_position_in_grid.y) * NR0;
+if (expert >= E || r0 >= N) {
+  return;
+}
+
+const int count = int(counts[expert]);
+if (r1 >= count) {
+  return;
+}
+
+const short tiitg = short(thread_index_in_threadgroup);
+const short tiisg = short(thread_index_in_simdgroup);
+const short sgitg = short(simdgroup_index_in_threadgroup);
+
+const short nr0 = short((N - r0 < NR0) ? (N - r0) : NR0);
+const short nr1 = short((count - r1 < NR1) ? (count - r1) : NR1);
+
+const short lr0 = short(((tiitg / NL0) < nr0) ? (tiitg / NL0) : (nr0 - 1));
+const short il0 = short(tiitg % NL0);
+const short row1 = short(tiitg / NL1);
+const short il1 = short(tiitg % NL1);
+const short iy = short(8 * il1);
+
+threadgroup half sx[NR1 * NK];
+threadgroup half sw[NR0 * NK];
+threadgroup float temp[NR1 * NR0];
+
+const device uint8_t* wb = reinterpret_cast<const device uint8_t*>(w);
+const size_t k_bytes = K / 2;
+const size_t k_groups = K / 16;
+
+for (int i = int(tiitg); i < NR1 * NR0; i += 128) {
+  temp[i] = 0.0f;
+}
+threadgroup_barrier(mem_flags::mem_threadgroup);
+
+for (int loop_k = 0; loop_k < K; loop_k += NK) {
+  const int col = r0 + lr0;
+  const int k0 = loop_k + 16 * il0;
+  const size_t w_base = (size_t(expert) * N + col) * k_bytes + size_t(k0 / 2);
+  const size_t s_base = (size_t(expert) * N + col) * k_groups + size_t(k0 / 16);
+  const half scale = moe_mapped_nvfp4_scale(scales[s_base]);
+
+  MOE_MAPPED_FOR_UNROLL (short i = 0; i < 16; i++) {
+    const short local_k = short(16 * il0 + i);
+    const uint8_t packed = wb[w_base + size_t(i / 2)];
+    const uint nibble = ((i & 1) == 0) ? uint(packed & 0x0f) : uint((packed >> 4) & 0x0f);
+    sw[int(local_k) * NR0 + int(lr0)] = scale * moe_mapped_nvfp4_value(nibble);
+  }
+
+  const size_t sb_base = int(row1) * NK + int(iy);
+  if (row1 < nr1) {
+    const int id = ids[size_t(expert) * T + size_t(r1 + row1)];
+    const int token = id / TopK;
+    const int slot = id - token * TopK;
+    const int inputSlot = InputSlots == 1 ? 0 : slot;
+    const size_t x_base = (size_t(token) * InputSlots + size_t(inputSlot)) * K + size_t(loop_k + iy);
+
+    MOE_MAPPED_FOR_UNROLL (short i = 0; i < 8; i++) {
+      float xv = static_cast<float>(x[x_base + i]);
+      if (ApplyReluSquared != 0) {
+        xv = (xv > 0.0f) ? (xv * xv) : 0.0f;
+      }
+      sx[sb_base + i] = half(xv);
+    }
+  } else {
+    MOE_MAPPED_FOR_UNROLL (short i = 0; i < 8; i++) {
+      sx[sb_base + i] = half(0.0h);
+    }
+  }
+
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  for (short tile = sgitg; tile < 32; tile += 4) {
+    const short tile_r1 = short((tile / 8) * 8);
+    const short tile_r0 = short((tile % 8) * 8);
+
+    simdgroup_half8x8 mx;
+    simdgroup_half8x8 mw;
+    simdgroup_float8x8 acc;
+
+    simdgroup_load(acc, temp + int(tile_r1) * NR0 + int(tile_r0), NR0);
+    MOE_MAPPED_FOR_UNROLL (short k = 0; k < NK; k += 8) {
+      simdgroup_load(mx, sx + int(tile_r1) * NK + int(k), NK);
+      simdgroup_load(mw, sw + int(k) * NR0 + int(tile_r0), NR0);
+      simdgroup_multiply_accumulate(acc, mx, mw, acc);
+    }
+    simdgroup_store(acc, temp + int(tile_r1) * NR0 + int(tile_r0), NR0);
+  }
+
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+}
+
+for (short j = sgitg; j < nr1; j += 4) {
+  const int id = ids[size_t(expert) * T + size_t(r1 + j)];
+  const int token = id / TopK;
+  const int slot = id - token * TopK;
+  device OutT* dst = y + (size_t(token) * TopK + size_t(slot)) * N + size_t(r0);
+  threadgroup float* src = temp + int(j) * NR0;
+  int i = tiisg;
+  for (; i < nr0; i += 32) {
+    dst[i] = static_cast<OutT>(src[i]);
+  }
+}
+#endif
+`
+
+const nvfp4MoEBlockMappedMetalKernelSource = `
+#if OLLAMA_MLX_HAS_METAL_TENSOR
+constexpr int NR0 = 64;
+constexpr int NR1 = 32;
+constexpr int NK = 32;
+constexpr int NL0 = NK / 16;
+constexpr int NL1 = NK / 8;
+
+const int block = int(threadgroup_position_in_grid.x);
+const int r0 = int(threadgroup_position_in_grid.y) * NR0;
+if (block >= int(block_count[0]) || r0 >= N) {
+  return;
+}
+
+const int expert = int(block_experts[block]);
+const int r1 = int(block_offsets[block]);
+if (expert >= E) {
+  return;
+}
+
+const int count = int(counts[expert]);
+if (r1 >= count) {
+  return;
+}
+
+const short tiitg = short(thread_index_in_threadgroup);
+const short tiisg = short(thread_index_in_simdgroup);
+const short sgitg = short(simdgroup_index_in_threadgroup);
+
+const short nr0 = short((N - r0 < NR0) ? (N - r0) : NR0);
+const short nr1 = short((count - r1 < NR1) ? (count - r1) : NR1);
+
+const short lr0 = short(((tiitg / NL0) < nr0) ? (tiitg / NL0) : (nr0 - 1));
+const short il0 = short(tiitg % NL0);
+const short row1 = short(tiitg / NL1);
+const short il1 = short(tiitg % NL1);
+const short iy = short(8 * il1);
+
+threadgroup bfloat sa[NR0 * NK];
+threadgroup bfloat sb[NR1 * NK];
+threadgroup float temp[NR1 * NR0];
+
+const device uint8_t* wb = reinterpret_cast<const device uint8_t*>(w);
+const size_t k_bytes = K / 2;
+const size_t k_groups = K / 16;
+
+auto tA = tensor<threadgroup bfloat, dextents<int32_t, 2>, tensor_inline>(sa, dextents<int32_t, 2>(NK, NR0));
+auto tB = tensor<threadgroup bfloat, dextents<int32_t, 2>, tensor_inline>(sb, dextents<int32_t, 2>(NR1, NK));
+
+mpp::tensor_ops::matmul2d<
+  mpp::tensor_ops::matmul2d_descriptor(
+    NR1, NR0, NK, false, true, false,
+    mpp::tensor_ops::matmul2d_descriptor::mode::multiply_accumulate),
+  execution_simdgroups<4>> mm;
+
+auto cT = mm.template get_destination_cooperative_tensor<decltype(tA), decltype(tB), float>();
+
+MOE_MAPPED_FOR_UNROLL (uint16_t i = 0; i < cT.get_capacity(); ++i) {
+  if (cT.is_valid_element(i)) {
+    cT[i] = 0.0f;
+  }
+}
+
+for (int loop_k = 0; loop_k < K; loop_k += NK) {
+  const int col = r0 + lr0;
+  const int k0 = loop_k + 16 * il0;
+  const size_t w_base = (size_t(expert) * N + col) * k_bytes + size_t(k0 / 2);
+  const size_t s_base = (size_t(expert) * N + col) * k_groups + size_t(k0 / 16);
+  const half scale = moe_mapped_nvfp4_scale(scales[s_base]);
+
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  MOE_MAPPED_FOR_UNROLL (short i = 0; i < 16; i++) {
+    const short sx = short(2 * il0 + i / 8);
+    const short sy = short((tiitg / NL0) / 8);
+    const short lx = short(i % 8);
+    const short ly = short((tiitg / NL0) % 8);
+
+    const uint8_t packed = wb[w_base + size_t(i / 2)];
+    const uint nibble = ((i & 1) == 0) ? uint(packed & 0x0f) : uint((packed >> 4) & 0x0f);
+    *(sa + NK * (8 * sy + ly) + 8 * sx + lx) = bfloat(scale * moe_mapped_nvfp4_value(nibble));
+  }
+
+  const size_t sb_base = NK * row1 + 8 * il1;
+  if (row1 < nr1) {
+    const int id = block_ids[size_t(block) * NR1 + size_t(row1)];
+    const int token = id / TopK;
+    const int slot = id - token * TopK;
+    const int inputSlot = InputSlots == 1 ? 0 : slot;
+    const size_t x_base = (size_t(token) * InputSlots + size_t(inputSlot)) * K + size_t(loop_k + iy);
+
+    MOE_MAPPED_FOR_UNROLL (short i = 0; i < 8; i++) {
+      float xv = static_cast<float>(x[x_base + i]);
+      if (ApplyReluSquared != 0) {
+        xv = (xv > 0.0f) ? (xv * xv) : 0.0f;
+      }
+      *(sb + sb_base + i) = bfloat(xv);
+    }
+  } else {
+    MOE_MAPPED_FOR_UNROLL (short i = 0; i < 8; i++) {
+      *(sb + sb_base + i) = bfloat(0.0f);
+    }
+  }
+
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  auto sA = tA.slice(0, 0);
+  auto sB = tB.slice(0, 0);
+  mm.run(sB, sA, cT);
+}
+
+threadgroup_barrier(mem_flags::mem_threadgroup);
+
+auto tC = tensor<threadgroup float, dextents<int32_t, 2>, tensor_inline>(temp, dextents<int32_t, 2>(NR0, NR1));
+cT.store(tC);
+
+threadgroup_barrier(mem_flags::mem_threadgroup);
+
+for (short j = sgitg; j < nr1; j += 4) {
+  const int id = block_ids[size_t(block) * NR1 + size_t(j)];
+  const int token = id / TopK;
+  const int slot = id - token * TopK;
+  device OutT* dst = y + (size_t(token) * TopK + size_t(slot)) * N + size_t(r0);
+  threadgroup float* src = temp + int(j) * NR0;
+  int i = tiisg;
+  for (; i < nr0; i += 32) {
+    dst[i] = static_cast<OutT>(src[i]);
+  }
+}
+#else
+constexpr int NR0 = 64;
+constexpr int NR1 = 32;
+constexpr int NK = 32;
+constexpr int NL0 = NK / 16;
+constexpr int NL1 = NK / 8;
+
+const int block = int(threadgroup_position_in_grid.x);
+const int r0 = int(threadgroup_position_in_grid.y) * NR0;
+if (block >= int(block_count[0]) || r0 >= N) {
+  return;
+}
+
+const int expert = int(block_experts[block]);
+const int r1 = int(block_offsets[block]);
+if (expert >= E) {
+  return;
+}
+
+const int count = int(counts[expert]);
+if (r1 >= count) {
+  return;
+}
+
+const short tiitg = short(thread_index_in_threadgroup);
+const short tiisg = short(thread_index_in_simdgroup);
+const short sgitg = short(simdgroup_index_in_threadgroup);
+
+const short nr0 = short((N - r0 < NR0) ? (N - r0) : NR0);
+const short nr1 = short((count - r1 < NR1) ? (count - r1) : NR1);
+
+const short lr0 = short(((tiitg / NL0) < nr0) ? (tiitg / NL0) : (nr0 - 1));
+const short il0 = short(tiitg % NL0);
+const short row1 = short(tiitg / NL1);
+const short il1 = short(tiitg % NL1);
+const short iy = short(8 * il1);
+
+threadgroup half sx[NR1 * NK];
+threadgroup half sw[NR0 * NK];
+threadgroup float temp[NR1 * NR0];
+
+const device uint8_t* wb = reinterpret_cast<const device uint8_t*>(w);
+const size_t k_bytes = K / 2;
+const size_t k_groups = K / 16;
+
+for (int i = int(tiitg); i < NR1 * NR0; i += 128) {
+  temp[i] = 0.0f;
+}
+threadgroup_barrier(mem_flags::mem_threadgroup);
+
+for (int loop_k = 0; loop_k < K; loop_k += NK) {
+  const int col = r0 + lr0;
+  const int k0 = loop_k + 16 * il0;
+  const size_t w_base = (size_t(expert) * N + col) * k_bytes + size_t(k0 / 2);
+  const size_t s_base = (size_t(expert) * N + col) * k_groups + size_t(k0 / 16);
+  const half scale = moe_mapped_nvfp4_scale(scales[s_base]);
+
+  MOE_MAPPED_FOR_UNROLL (short i = 0; i < 16; i++) {
+    const short local_k = short(16 * il0 + i);
+    const uint8_t packed = wb[w_base + size_t(i / 2)];
+    const uint nibble = ((i & 1) == 0) ? uint(packed & 0x0f) : uint((packed >> 4) & 0x0f);
+    sw[int(local_k) * NR0 + int(lr0)] = scale * moe_mapped_nvfp4_value(nibble);
+  }
+
+  const size_t sb_base = int(row1) * NK + int(iy);
+  if (row1 < nr1) {
+    const int id = block_ids[size_t(block) * NR1 + size_t(row1)];
+    const int token = id / TopK;
+    const int slot = id - token * TopK;
+    const int inputSlot = InputSlots == 1 ? 0 : slot;
+    const size_t x_base = (size_t(token) * InputSlots + size_t(inputSlot)) * K + size_t(loop_k + iy);
+
+    MOE_MAPPED_FOR_UNROLL (short i = 0; i < 8; i++) {
+      float xv = static_cast<float>(x[x_base + i]);
+      if (ApplyReluSquared != 0) {
+        xv = (xv > 0.0f) ? (xv * xv) : 0.0f;
+      }
+      sx[sb_base + i] = half(xv);
+    }
+  } else {
+    MOE_MAPPED_FOR_UNROLL (short i = 0; i < 8; i++) {
+      sx[sb_base + i] = half(0.0h);
+    }
+  }
+
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  for (short tile = sgitg; tile < 32; tile += 4) {
+    const short tile_r1 = short((tile / 8) * 8);
+    const short tile_r0 = short((tile % 8) * 8);
+
+    simdgroup_half8x8 mx;
+    simdgroup_half8x8 mw;
+    simdgroup_float8x8 acc;
+
+    simdgroup_load(acc, temp + int(tile_r1) * NR0 + int(tile_r0), NR0);
+    MOE_MAPPED_FOR_UNROLL (short k = 0; k < NK; k += 8) {
+      simdgroup_load(mx, sx + int(tile_r1) * NK + int(k), NK);
+      simdgroup_load(mw, sw + int(k) * NR0 + int(tile_r0), NR0);
+      simdgroup_multiply_accumulate(acc, mx, mw, acc);
+    }
+    simdgroup_store(acc, temp + int(tile_r1) * NR0 + int(tile_r0), NR0);
+  }
+
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+}
+
+for (short j = sgitg; j < nr1; j += 4) {
+  const int id = block_ids[size_t(block) * NR1 + size_t(j)];
+  const int token = id / TopK;
+  const int slot = id - token * TopK;
+  device OutT* dst = y + (size_t(token) * TopK + size_t(slot)) * N + size_t(r0);
+  threadgroup float* src = temp + int(j) * NR0;
+  int i = tiisg;
+  for (; i < nr0; i += 32) {
+    dst[i] = static_cast<OutT>(src[i]);
+  }
+}
+#endif
+`
+
+const mxfp8MoEMappedMetalKernelSource = `
+#if OLLAMA_MLX_HAS_METAL_TENSOR
+constexpr int NR0 = 64;
+constexpr int NR1 = 32;
+constexpr int NK = 32;
+constexpr int NL0 = NK / 16;
+constexpr int NL1 = NK / 8;
+
+const int expert = int(threadgroup_position_in_grid.z);
+const int r1 = int(threadgroup_position_in_grid.x) * NR1;
+const int r0 = int(threadgroup_position_in_grid.y) * NR0;
+if (expert >= E || r0 >= N) {
+  return;
+}
+
+const int count = int(counts[expert]);
+if (r1 >= count) {
+  return;
+}
+
+const short tiitg = short(thread_index_in_threadgroup);
+const short tiisg = short(thread_index_in_simdgroup);
+const short sgitg = short(simdgroup_index_in_threadgroup);
+
+const short nr0 = short((N - r0 < NR0) ? (N - r0) : NR0);
+const short nr1 = short((count - r1 < NR1) ? (count - r1) : NR1);
+
+const short lr0 = short(((tiitg / NL0) < nr0) ? (tiitg / NL0) : (nr0 - 1));
+const short il0 = short(tiitg % NL0);
+const short row1 = short(tiitg / NL1);
+const short il1 = short(tiitg % NL1);
+const short iy = short(8 * il1);
+
+threadgroup half sa[NR0 * NK];
+threadgroup half sb[NR1 * NK];
+threadgroup float temp[NR1 * NR0];
+
+const device uint8_t* wb = reinterpret_cast<const device uint8_t*>(w);
+const size_t k_bytes = K;
+const size_t k_groups = K / 32;
+
+auto tA = tensor<threadgroup half, dextents<int32_t, 2>, tensor_inline>(sa, dextents<int32_t, 2>(NK, NR0));
+auto tB = tensor<threadgroup half, dextents<int32_t, 2>, tensor_inline>(sb, dextents<int32_t, 2>(NR1, NK));
+
+mpp::tensor_ops::matmul2d<
+  mpp::tensor_ops::matmul2d_descriptor(
+    NR1, NR0, NK, false, true, false,
+    mpp::tensor_ops::matmul2d_descriptor::mode::multiply_accumulate),
+  execution_simdgroups<4>> mm;
+
+auto cT = mm.template get_destination_cooperative_tensor<decltype(tA), decltype(tB), float>();
+
+MOE_MAPPED_FOR_UNROLL (uint16_t i = 0; i < cT.get_capacity(); ++i) {
+  if (cT.is_valid_element(i)) {
+    cT[i] = 0.0f;
+  }
+}
+
+for (int loop_k = 0; loop_k < K; loop_k += NK) {
+  const int col = r0 + lr0;
+  const int k0 = loop_k + 16 * il0;
+  const size_t w_base = (size_t(expert) * N + col) * k_bytes + size_t(k0);
+  const size_t s_base = (size_t(expert) * N + col) * k_groups + size_t(loop_k / 32);
+  const float scale = moe_mapped_mxfp8_scale(scales[s_base]);
+
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  MOE_MAPPED_FOR_UNROLL (short i = 0; i < 16; i++) {
+    const short sx = short(2 * il0 + i / 8);
+    const short sy = short((tiitg / NL0) / 8);
+    const short lx = short(i % 8);
+    const short ly = short((tiitg / NL0) % 8);
+
+    const uint8_t packed = wb[w_base + size_t(i)];
+    *(sa + NK * (8 * sy + ly) + 8 * sx + lx) = half(scale * float(moe_mapped_mxfp8_value(packed)));
+  }
+
+  const size_t sb_base = NK * row1 + 8 * il1;
+  if (row1 < nr1) {
+    const int id = ids[size_t(expert) * T + size_t(r1 + row1)];
+    const int token = id / TopK;
+    const int slot = id - token * TopK;
+    const int inputSlot = InputSlots == 1 ? 0 : slot;
+    const size_t x_base = (size_t(token) * InputSlots + size_t(inputSlot)) * K + size_t(loop_k + iy);
+
+    MOE_MAPPED_FOR_UNROLL (short i = 0; i < 8; i++) {
+      float xv = static_cast<float>(x[x_base + i]);
+      if (ApplyReluSquared != 0) {
+        xv = (xv > 0.0f) ? (xv * xv) : 0.0f;
+      }
+      *(sb + sb_base + i) = half(xv);
+    }
+  } else {
+    MOE_MAPPED_FOR_UNROLL (short i = 0; i < 8; i++) {
+      *(sb + sb_base + i) = 0.0h;
+    }
+  }
+
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  auto sA = tA.slice(0, 0);
+  auto sB = tB.slice(0, 0);
+  mm.run(sB, sA, cT);
+}
+
+threadgroup_barrier(mem_flags::mem_threadgroup);
+
+auto tC = tensor<threadgroup float, dextents<int32_t, 2>, tensor_inline>(temp, dextents<int32_t, 2>(NR0, NR1));
+cT.store(tC);
+
+threadgroup_barrier(mem_flags::mem_threadgroup);
+
+for (short j = sgitg; j < nr1; j += 4) {
+  const int id = ids[size_t(expert) * T + size_t(r1 + j)];
+  const int token = id / TopK;
+  const int slot = id - token * TopK;
+  device OutT* dst = y + (size_t(token) * TopK + size_t(slot)) * N + size_t(r0);
+  threadgroup float* src = temp + int(j) * NR0;
+  int i = tiisg;
+  for (; i < nr0; i += 32) {
+    dst[i] = static_cast<OutT>(src[i]);
+  }
+}
+#else
+constexpr int NR0 = 64;
+constexpr int NR1 = 32;
+constexpr int NK = 32;
+constexpr int NL0 = NK / 16;
+constexpr int NL1 = NK / 8;
+
+const int expert = int(threadgroup_position_in_grid.z);
+const int r1 = int(threadgroup_position_in_grid.x) * NR1;
+const int r0 = int(threadgroup_position_in_grid.y) * NR0;
+if (expert >= E || r0 >= N) {
+  return;
+}
+
+const int count = int(counts[expert]);
+if (r1 >= count) {
+  return;
+}
+
+const short tiitg = short(thread_index_in_threadgroup);
+const short tiisg = short(thread_index_in_simdgroup);
+const short sgitg = short(simdgroup_index_in_threadgroup);
+
+const short nr0 = short((N - r0 < NR0) ? (N - r0) : NR0);
+const short nr1 = short((count - r1 < NR1) ? (count - r1) : NR1);
+
+const short lr0 = short(((tiitg / NL0) < nr0) ? (tiitg / NL0) : (nr0 - 1));
+const short il0 = short(tiitg % NL0);
+const short row1 = short(tiitg / NL1);
+const short il1 = short(tiitg % NL1);
+const short iy = short(8 * il1);
+
+threadgroup half sx[NR1 * NK];
+threadgroup half sw[NR0 * NK];
+threadgroup float temp[NR1 * NR0];
+
+const device uint8_t* wb = reinterpret_cast<const device uint8_t*>(w);
+const size_t k_bytes = K;
+const size_t k_groups = K / 32;
+
+for (int i = int(tiitg); i < NR1 * NR0; i += 128) {
+  temp[i] = 0.0f;
+}
+threadgroup_barrier(mem_flags::mem_threadgroup);
+
+for (int loop_k = 0; loop_k < K; loop_k += NK) {
+  const int col = r0 + lr0;
+  const int k0 = loop_k + 16 * il0;
+  const size_t w_base = (size_t(expert) * N + col) * k_bytes + size_t(k0);
+  const size_t s_base = (size_t(expert) * N + col) * k_groups + size_t(loop_k / 32);
+  const float scale = moe_mapped_mxfp8_scale(scales[s_base]);
+
+  MOE_MAPPED_FOR_UNROLL (short i = 0; i < 16; i++) {
+    const short local_k = short(16 * il0 + i);
+    const uint8_t packed = wb[w_base + size_t(i)];
+    sw[int(local_k) * NR0 + int(lr0)] = half(scale * float(moe_mapped_mxfp8_value(packed)));
+  }
+
+  const size_t sb_base = int(row1) * NK + int(iy);
+  if (row1 < nr1) {
+    const int id = ids[size_t(expert) * T + size_t(r1 + row1)];
+    const int token = id / TopK;
+    const int slot = id - token * TopK;
+    const int inputSlot = InputSlots == 1 ? 0 : slot;
+    const size_t x_base = (size_t(token) * InputSlots + size_t(inputSlot)) * K + size_t(loop_k + iy);
+
+    MOE_MAPPED_FOR_UNROLL (short i = 0; i < 8; i++) {
+      float xv = static_cast<float>(x[x_base + i]);
+      if (ApplyReluSquared != 0) {
+        xv = (xv > 0.0f) ? (xv * xv) : 0.0f;
+      }
+      sx[sb_base + i] = half(xv);
+    }
+  } else {
+    MOE_MAPPED_FOR_UNROLL (short i = 0; i < 8; i++) {
+      sx[sb_base + i] = 0.0h;
+    }
+  }
+
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  for (short tile = sgitg; tile < 32; tile += 4) {
+    const short tile_r1 = short((tile / 8) * 8);
+    const short tile_r0 = short((tile % 8) * 8);
+
+    simdgroup_half8x8 mx;
+    simdgroup_half8x8 mw;
+    simdgroup_float8x8 acc;
+
+    simdgroup_load(acc, temp + int(tile_r1) * NR0 + int(tile_r0), NR0);
+    MOE_MAPPED_FOR_UNROLL (short k = 0; k < NK; k += 8) {
+      simdgroup_load(mx, sx + int(tile_r1) * NK + int(k), NK);
+      simdgroup_load(mw, sw + int(k) * NR0 + int(tile_r0), NR0);
+      simdgroup_multiply_accumulate(acc, mx, mw, acc);
+    }
+    simdgroup_store(acc, temp + int(tile_r1) * NR0 + int(tile_r0), NR0);
+  }
+
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+}
+
+for (short j = sgitg; j < nr1; j += 4) {
+  const int id = ids[size_t(expert) * T + size_t(r1 + j)];
+  const int token = id / TopK;
+  const int slot = id - token * TopK;
+  device OutT* dst = y + (size_t(token) * TopK + size_t(slot)) * N + size_t(r0);
+  threadgroup float* src = temp + int(j) * NR0;
+  int i = tiisg;
+  for (; i < nr0; i += 32) {
+    dst[i] = static_cast<OutT>(src[i]);
+  }
+}
+#endif
+`
+
+const mxfp8MoEBlockMappedMetalKernelSource = `
+#if OLLAMA_MLX_HAS_METAL_TENSOR
+constexpr int NR0 = 64;
+constexpr int NR1 = 32;
+constexpr int NK = 32;
+constexpr int NL0 = NK / 16;
+constexpr int NL1 = NK / 8;
+
+const int block = int(threadgroup_position_in_grid.x);
+const int r0 = int(threadgroup_position_in_grid.y) * NR0;
+if (block >= int(block_count[0]) || r0 >= N) {
+  return;
+}
+
+const int expert = int(block_experts[block]);
+const int r1 = int(block_offsets[block]);
+if (expert >= E) {
+  return;
+}
+
+const int count = int(counts[expert]);
+if (r1 >= count) {
+  return;
+}
+
+const short tiitg = short(thread_index_in_threadgroup);
+const short tiisg = short(thread_index_in_simdgroup);
+const short sgitg = short(simdgroup_index_in_threadgroup);
+
+const short nr0 = short((N - r0 < NR0) ? (N - r0) : NR0);
+const short nr1 = short((count - r1 < NR1) ? (count - r1) : NR1);
+
+const short lr0 = short(((tiitg / NL0) < nr0) ? (tiitg / NL0) : (nr0 - 1));
+const short il0 = short(tiitg % NL0);
+const short row1 = short(tiitg / NL1);
+const short il1 = short(tiitg % NL1);
+const short iy = short(8 * il1);
+
+threadgroup half sa[NR0 * NK];
+threadgroup half sb[NR1 * NK];
+threadgroup float temp[NR1 * NR0];
+
+const device uint8_t* wb = reinterpret_cast<const device uint8_t*>(w);
+const size_t k_bytes = K;
+const size_t k_groups = K / 32;
+
+auto tA = tensor<threadgroup half, dextents<int32_t, 2>, tensor_inline>(sa, dextents<int32_t, 2>(NK, NR0));
+auto tB = tensor<threadgroup half, dextents<int32_t, 2>, tensor_inline>(sb, dextents<int32_t, 2>(NR1, NK));
+
+mpp::tensor_ops::matmul2d<
+  mpp::tensor_ops::matmul2d_descriptor(
+    NR1, NR0, NK, false, true, false,
+    mpp::tensor_ops::matmul2d_descriptor::mode::multiply_accumulate),
+  execution_simdgroups<4>> mm;
+
+auto cT = mm.template get_destination_cooperative_tensor<decltype(tA), decltype(tB), float>();
+
+MOE_MAPPED_FOR_UNROLL (uint16_t i = 0; i < cT.get_capacity(); ++i) {
+  if (cT.is_valid_element(i)) {
+    cT[i] = 0.0f;
+  }
+}
+
+for (int loop_k = 0; loop_k < K; loop_k += NK) {
+  const int col = r0 + lr0;
+  const int k0 = loop_k + 16 * il0;
+  const size_t w_base = (size_t(expert) * N + col) * k_bytes + size_t(k0);
+  const size_t s_base = (size_t(expert) * N + col) * k_groups + size_t(loop_k / 32);
+  const float scale = moe_mapped_mxfp8_scale(scales[s_base]);
+
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  MOE_MAPPED_FOR_UNROLL (short i = 0; i < 16; i++) {
+    const short sx = short(2 * il0 + i / 8);
+    const short sy = short((tiitg / NL0) / 8);
+    const short lx = short(i % 8);
+    const short ly = short((tiitg / NL0) % 8);
+
+    const uint8_t packed = wb[w_base + size_t(i)];
+    *(sa + NK * (8 * sy + ly) + 8 * sx + lx) = half(scale * float(moe_mapped_mxfp8_value(packed)));
+  }
+
+  const size_t sb_base = NK * row1 + 8 * il1;
+  if (row1 < nr1) {
+    const int id = block_ids[size_t(block) * NR1 + size_t(row1)];
+    const int token = id / TopK;
+    const int slot = id - token * TopK;
+    const int inputSlot = InputSlots == 1 ? 0 : slot;
+    const size_t x_base = (size_t(token) * InputSlots + size_t(inputSlot)) * K + size_t(loop_k + iy);
+
+    MOE_MAPPED_FOR_UNROLL (short i = 0; i < 8; i++) {
+      float xv = static_cast<float>(x[x_base + i]);
+      if (ApplyReluSquared != 0) {
+        xv = (xv > 0.0f) ? (xv * xv) : 0.0f;
+      }
+      *(sb + sb_base + i) = half(xv);
+    }
+  } else {
+    MOE_MAPPED_FOR_UNROLL (short i = 0; i < 8; i++) {
+      *(sb + sb_base + i) = 0.0h;
+    }
+  }
+
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  auto sA = tA.slice(0, 0);
+  auto sB = tB.slice(0, 0);
+  mm.run(sB, sA, cT);
+}
+
+threadgroup_barrier(mem_flags::mem_threadgroup);
+
+auto tC = tensor<threadgroup float, dextents<int32_t, 2>, tensor_inline>(temp, dextents<int32_t, 2>(NR0, NR1));
+cT.store(tC);
+
+threadgroup_barrier(mem_flags::mem_threadgroup);
+
+for (short j = sgitg; j < nr1; j += 4) {
+  const int id = block_ids[size_t(block) * NR1 + size_t(j)];
+  const int token = id / TopK;
+  const int slot = id - token * TopK;
+  device OutT* dst = y + (size_t(token) * TopK + size_t(slot)) * N + size_t(r0);
+  threadgroup float* src = temp + int(j) * NR0;
+  int i = tiisg;
+  for (; i < nr0; i += 32) {
+    dst[i] = static_cast<OutT>(src[i]);
+  }
+}
+#else
+constexpr int NR0 = 64;
+constexpr int NR1 = 32;
+constexpr int NK = 32;
+constexpr int NL0 = NK / 16;
+constexpr int NL1 = NK / 8;
+
+const int block = int(threadgroup_position_in_grid.x);
+const int r0 = int(threadgroup_position_in_grid.y) * NR0;
+if (block >= int(block_count[0]) || r0 >= N) {
+  return;
+}
+
+const int expert = int(block_experts[block]);
+const int r1 = int(block_offsets[block]);
+if (expert >= E) {
+  return;
+}
+
+const int count = int(counts[expert]);
+if (r1 >= count) {
+  return;
+}
+
+const short tiitg = short(thread_index_in_threadgroup);
+const short tiisg = short(thread_index_in_simdgroup);
+const short sgitg = short(simdgroup_index_in_threadgroup);
+
+const short nr0 = short((N - r0 < NR0) ? (N - r0) : NR0);
+const short nr1 = short((count - r1 < NR1) ? (count - r1) : NR1);
+
+const short lr0 = short(((tiitg / NL0) < nr0) ? (tiitg / NL0) : (nr0 - 1));
+const short il0 = short(tiitg % NL0);
+const short row1 = short(tiitg / NL1);
+const short il1 = short(tiitg % NL1);
+const short iy = short(8 * il1);
+
+threadgroup half sx[NR1 * NK];
+threadgroup half sw[NR0 * NK];
+threadgroup float temp[NR1 * NR0];
+
+const device uint8_t* wb = reinterpret_cast<const device uint8_t*>(w);
+const size_t k_bytes = K;
+const size_t k_groups = K / 32;
+
+for (int i = int(tiitg); i < NR1 * NR0; i += 128) {
+  temp[i] = 0.0f;
+}
+threadgroup_barrier(mem_flags::mem_threadgroup);
+
+for (int loop_k = 0; loop_k < K; loop_k += NK) {
+  const int col = r0 + lr0;
+  const int k0 = loop_k + 16 * il0;
+  const size_t w_base = (size_t(expert) * N + col) * k_bytes + size_t(k0);
+  const size_t s_base = (size_t(expert) * N + col) * k_groups + size_t(loop_k / 32);
+  const float scale = moe_mapped_mxfp8_scale(scales[s_base]);
+
+  MOE_MAPPED_FOR_UNROLL (short i = 0; i < 16; i++) {
+    const short local_k = short(16 * il0 + i);
+    const uint8_t packed = wb[w_base + size_t(i)];
+    sw[int(local_k) * NR0 + int(lr0)] = half(scale * float(moe_mapped_mxfp8_value(packed)));
+  }
+
+  const size_t sb_base = int(row1) * NK + int(iy);
+  if (row1 < nr1) {
+    const int id = block_ids[size_t(block) * NR1 + size_t(row1)];
+    const int token = id / TopK;
+    const int slot = id - token * TopK;
+    const int inputSlot = InputSlots == 1 ? 0 : slot;
+    const size_t x_base = (size_t(token) * InputSlots + size_t(inputSlot)) * K + size_t(loop_k + iy);
+
+    MOE_MAPPED_FOR_UNROLL (short i = 0; i < 8; i++) {
+      float xv = static_cast<float>(x[x_base + i]);
+      if (ApplyReluSquared != 0) {
+        xv = (xv > 0.0f) ? (xv * xv) : 0.0f;
+      }
+      sx[sb_base + i] = half(xv);
+    }
+  } else {
+    MOE_MAPPED_FOR_UNROLL (short i = 0; i < 8; i++) {
+      sx[sb_base + i] = 0.0h;
+    }
+  }
+
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  for (short tile = sgitg; tile < 32; tile += 4) {
+    const short tile_r1 = short((tile / 8) * 8);
+    const short tile_r0 = short((tile % 8) * 8);
+
+    simdgroup_half8x8 mx;
+    simdgroup_half8x8 mw;
+    simdgroup_float8x8 acc;
+
+    simdgroup_load(acc, temp + int(tile_r1) * NR0 + int(tile_r0), NR0);
+    MOE_MAPPED_FOR_UNROLL (short k = 0; k < NK; k += 8) {
+      simdgroup_load(mx, sx + int(tile_r1) * NK + int(k), NK);
+      simdgroup_load(mw, sw + int(k) * NR0 + int(tile_r0), NR0);
+      simdgroup_multiply_accumulate(acc, mx, mw, acc);
+    }
+    simdgroup_store(acc, temp + int(tile_r1) * NR0 + int(tile_r0), NR0);
+  }
+
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+}
+
+for (short j = sgitg; j < nr1; j += 4) {
+  const int id = block_ids[size_t(block) * NR1 + size_t(j)];
+  const int token = id / TopK;
+  const int slot = id - token * TopK;
+  device OutT* dst = y + (size_t(token) * TopK + size_t(slot)) * N + size_t(r0);
+  threadgroup float* src = temp + int(j) * NR0;
+  int i = tiisg;
+  for (; i < nr0; i += 32) {
+    dst[i] = static_cast<OutT>(src[i]);
+  }
+}
+#endif
+`
+
+func initMoEExpertMapMetalKernel() {
+	inputs, freeInputs, ok := cStringVector([]string{"indices"})
+	if !ok {
+		moeExpertMapMetalDisabled = true
+		freeInputs()
+		return
+	}
+	defer freeInputs()
+
+	outputs, freeOutputs, ok := cStringVector([]string{"counts", "ids"})
+	if !ok {
+		moeExpertMapMetalDisabled = true
+		freeOutputs()
+		return
+	}
+	defer freeOutputs()
+
+	cName := C.CString("moe_expert_map")
+	defer C.free(unsafe.Pointer(cName))
+	cSource := C.CString(moeExpertMapMetalKernelSource)
+	defer C.free(unsafe.Pointer(cSource))
+	cHeader := C.CString("")
+	defer C.free(unsafe.Pointer(cHeader))
+
+	moeExpertMapMetalKernel = C.mlx_fast_metal_kernel_new(
+		cName,
+		inputs,
+		outputs,
+		cSource,
+		cHeader,
+		C.bool(true),
+		C.bool(false),
+	)
+}
+
+func initMoEExpertBlockMapMetalKernel() {
+	inputs, freeInputs, ok := cStringVector([]string{"indices"})
+	if !ok {
+		moeExpertBlockMapMetalDisabled = true
+		freeInputs()
+		return
+	}
+	defer freeInputs()
+
+	outputs, freeOutputs, ok := cStringVector([]string{"block_count", "counts", "block_experts", "block_offsets", "block_ids"})
+	if !ok {
+		moeExpertBlockMapMetalDisabled = true
+		freeOutputs()
+		return
+	}
+	defer freeOutputs()
+
+	cName := C.CString("moe_expert_block_map")
+	defer C.free(unsafe.Pointer(cName))
+	cSource := C.CString(moeExpertBlockMapMetalKernelSource)
+	defer C.free(unsafe.Pointer(cSource))
+	cHeader := C.CString("")
+	defer C.free(unsafe.Pointer(cHeader))
+
+	moeExpertBlockMapMetalKernel = C.mlx_fast_metal_kernel_new(
+		cName,
+		inputs,
+		outputs,
+		cSource,
+		cHeader,
+		C.bool(true),
+		C.bool(true),
+	)
+}
+
+func initMoEMappedMetalKernel(target *C.mlx_fast_metal_kernel, disabled *bool, name, source string) {
+	inputs, freeInputs, ok := cStringVector([]string{"x", "w", "scales", "counts", "ids"})
+	if !ok {
+		*disabled = true
+		freeInputs()
+		return
+	}
+	defer freeInputs()
+
+	outputs, freeOutputs, ok := cStringVector([]string{"y"})
+	if !ok {
+		*disabled = true
+		freeOutputs()
+		return
+	}
+	defer freeOutputs()
+
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	cSource := C.CString(source)
+	defer C.free(unsafe.Pointer(cSource))
+	cHeader := C.CString(moeMappedMetalKernelHeader)
+	defer C.free(unsafe.Pointer(cHeader))
+
+	*target = C.mlx_fast_metal_kernel_new(
+		cName,
+		inputs,
+		outputs,
+		cSource,
+		cHeader,
+		C.bool(true),
+		C.bool(false),
+	)
+}
+
+func initMoEBlockMappedMetalKernel(target *C.mlx_fast_metal_kernel, disabled *bool, name, source string) {
+	inputs, freeInputs, ok := cStringVector([]string{"x", "w", "scales", "counts", "block_count", "block_experts", "block_offsets", "block_ids"})
+	if !ok {
+		*disabled = true
+		freeInputs()
+		return
+	}
+	defer freeInputs()
+
+	outputs, freeOutputs, ok := cStringVector([]string{"y"})
+	if !ok {
+		*disabled = true
+		freeOutputs()
+		return
+	}
+	defer freeOutputs()
+
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	cSource := C.CString(source)
+	defer C.free(unsafe.Pointer(cSource))
+	cHeader := C.CString(moeMappedMetalKernelHeader)
+	defer C.free(unsafe.Pointer(cHeader))
+
+	*target = C.mlx_fast_metal_kernel_new(
+		cName,
+		inputs,
+		outputs,
+		cSource,
+		cHeader,
+		C.bool(true),
+		C.bool(false),
+	)
+}
+
+func initMoEGatherMMBlockMappedMetalKernel() {
+	inputs, freeInputs, ok := cStringVector([]string{"x", "w", "counts", "block_count", "block_experts", "block_offsets", "block_ids"})
+	if !ok {
+		moeGatherMMBlockMappedMetalDisabled = true
+		freeInputs()
+		return
+	}
+	defer freeInputs()
+
+	outputs, freeOutputs, ok := cStringVector([]string{"y"})
+	if !ok {
+		moeGatherMMBlockMappedMetalDisabled = true
+		freeOutputs()
+		return
+	}
+	defer freeOutputs()
+
+	cName := C.CString("moe_gather_mm_block_mapped")
+	defer C.free(unsafe.Pointer(cName))
+	cSource := C.CString(moeGatherMMBlockMappedMetalKernelSource)
+	defer C.free(unsafe.Pointer(cSource))
+	cHeader := C.CString(moeMappedMetalKernelHeader)
+	defer C.free(unsafe.Pointer(cHeader))
+
+	moeGatherMMBlockMappedMetalKernel = C.mlx_fast_metal_kernel_new(
+		cName,
+		inputs,
+		outputs,
+		cSource,
+		cHeader,
+		C.bool(true),
+		C.bool(false),
+	)
+}
+
+func metalTensorOpsAvailable() bool {
+	// Dense quantized linear kernels currently only have a Metal 4 tensor-op
+	// implementation. The mapped MoE kernels carry their older-OS fallback in
+	// the Metal source itself and do not use this guard.
+	return macOSMajorVersion() >= 26
+}
+
+func initNVFP4MoEMappedMetalKernel() {
+	initMoEMappedMetalKernel(&nvfp4MoEMappedMetalKernel, &nvfp4MoEMappedMetalDisabled, "moe_gather_qmm_mapped_fp4", nvfp4MoEMappedMetalKernelSource)
+}
+
+func initNVFP4MoEBlockMappedMetalKernel() {
+	initMoEBlockMappedMetalKernel(&nvfp4MoEBlockMappedMetalKernel, &nvfp4MoEBlockMappedMetalDisabled, "moe_gather_qmm_block_mapped_fp4", nvfp4MoEBlockMappedMetalKernelSource)
+}
+
+func initMXFP8MoEMappedMetalKernel() {
+	initMoEMappedMetalKernel(&mxfp8MoEMappedMetalKernel, &mxfp8MoEMappedMetalDisabled, "moe_gather_qmm_mapped_fp8", mxfp8MoEMappedMetalKernelSource)
+}
+
+func initMXFP8MoEBlockMappedMetalKernel() {
+	initMoEBlockMappedMetalKernel(&mxfp8MoEBlockMappedMetalKernel, &mxfp8MoEBlockMappedMetalDisabled, "moe_gather_qmm_block_mapped_fp8", mxfp8MoEBlockMappedMetalKernelSource)
+}
+
+func addMoEExpertMapTemplateArgs(cfg C.mlx_fast_metal_kernel_config, tokens, topK, experts int) bool {
+	for _, tpl := range []struct {
+		name  string
+		value int
+	}{
+		{name: "T", value: tokens},
+		{name: "TopK", value: topK},
+		{name: "E", value: experts},
+	} {
+		cn := C.CString(tpl.name)
+		rc := C.mlx_fast_metal_kernel_config_add_template_arg_int(cfg, cn, C.int(tpl.value))
+		C.free(unsafe.Pointer(cn))
+		if rc != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func addMoEExpertBlockMapTemplateArgs(cfg C.mlx_fast_metal_kernel_config, tokens, topK, experts, maxBlocks int) bool {
+	for _, tpl := range []struct {
+		name  string
+		value int
+	}{
+		{name: "T", value: tokens},
+		{name: "TopK", value: topK},
+		{name: "E", value: experts},
+		{name: "MaxBlocks", value: maxBlocks},
+	} {
+		cn := C.CString(tpl.name)
+		rc := C.mlx_fast_metal_kernel_config_add_template_arg_int(cfg, cn, C.int(tpl.value))
+		C.free(unsafe.Pointer(cn))
+		if rc != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func addMoEMappedTemplateArgs(cfg C.mlx_fast_metal_kernel_config, tokens, topK, inputSlots, experts, N, K int, outDType DType, applyReluSquared, weightTransposed bool) bool {
+	reluSquaredValue := 0
+	if applyReluSquared {
+		reluSquaredValue = 1
+	}
+	weightTransposedValue := 0
+	if weightTransposed {
+		weightTransposedValue = 1
+	}
+	for _, tpl := range []struct {
+		name  string
+		value int
+	}{
+		{name: "T", value: tokens},
+		{name: "TopK", value: topK},
+		{name: "InputSlots", value: inputSlots},
+		{name: "E", value: experts},
+		{name: "N", value: N},
+		{name: "K", value: K},
+		{name: "ApplyReluSquared", value: reluSquaredValue},
+		{name: "WeightTransposed", value: weightTransposedValue},
+	} {
+		cn := C.CString(tpl.name)
+		rc := C.mlx_fast_metal_kernel_config_add_template_arg_int(cfg, cn, C.int(tpl.value))
+		C.free(unsafe.Pointer(cn))
+		if rc != 0 {
+			return false
+		}
+	}
+
+	cn := C.CString("OutT")
+	rc := C.mlx_fast_metal_kernel_config_add_template_arg_dtype(cfg, cn, C.mlx_dtype(outDType))
+	C.free(unsafe.Pointer(cn))
+	return rc == 0
+}
+
+func moeExpertMapValidate(indices *Array, experts int) (tokens, topK int, ok bool) {
+	if indices == nil || experts <= 0 {
+		return 0, 0, false
+	}
+	if indices.DType() != DTypeInt32 && indices.DType() != DTypeUint32 {
+		return 0, 0, false
+	}
+	dims := indices.Dims()
+	if len(dims) != 2 || dims[0] <= 0 || dims[1] <= 0 {
+		return 0, 0, false
+	}
+	return dims[0], dims[1], true
+}
+
+func maxMoEExpertBlocks(tokens, topK, experts int) int {
+	total := tokens * topK
+	nonEmpty := min(experts, total)
+	return nonEmpty + (total-nonEmpty)/moeExpertBlockSize
+}
+
+// fastMoEExpertMap builds per-expert token maps from unsorted top-k expert
+// indices. The ids output is shaped [experts, tokens] and stores
+// token*topK+slot for the first counts[expert] entries.
+func fastMoEExpertMap(indices *Array, experts int) (counts, ids *Array, ok bool) {
+	if !MetalIsAvailable() {
+		return nil, nil, false
+	}
+	if moeExpertMapMetalDisabled {
+		return nil, nil, false
+	}
+	tokens, topK, ok := moeExpertMapValidate(indices, experts)
+	if !ok {
+		return nil, nil, false
+	}
+
+	moeExpertMapMetalKernelOnce.Do(initMoEExpertMapMetalKernel)
+	if moeExpertMapMetalDisabled {
+		return nil, nil, false
+	}
+
+	cfg := C.mlx_fast_metal_kernel_config_new()
+	defer C.mlx_fast_metal_kernel_config_free(cfg)
+	if !addMoEExpertMapTemplateArgs(cfg, tokens, topK, experts) {
+		return nil, nil, false
+	}
+
+	countShape := []C.int{C.int(experts)}
+	if C.mlx_fast_metal_kernel_config_add_output_arg(cfg, unsafe.SliceData(countShape), C.size_t(len(countShape)), C.mlx_dtype(DTypeInt32)) != 0 {
+		return nil, nil, false
+	}
+	idsShape := []C.int{C.int(experts), C.int(tokens)}
+	if C.mlx_fast_metal_kernel_config_add_output_arg(cfg, unsafe.SliceData(idsShape), C.size_t(len(idsShape)), C.mlx_dtype(DTypeInt32)) != 0 {
+		return nil, nil, false
+	}
+	if C.mlx_fast_metal_kernel_config_set_grid(cfg, C.int(experts*128), 1, 1) != 0 {
+		return nil, nil, false
+	}
+	if C.mlx_fast_metal_kernel_config_set_thread_group(cfg, 128, 1, 1) != 0 {
+		return nil, nil, false
+	}
+
+	inputs := []C.mlx_array{indices.ctx}
+	inVec := C.mlx_vector_array_new_data(unsafe.SliceData(inputs), C.size_t(len(inputs)))
+	defer C.mlx_vector_array_free(inVec)
+
+	outVec := C.mlx_vector_array_new()
+	defer C.mlx_vector_array_free(outVec)
+	if C.mlx_fast_metal_kernel_apply(&outVec, moeExpertMapMetalKernel, inVec, cfg, DefaultStream().ctx) != 0 {
+		return nil, nil, false
+	}
+	if int(C.mlx_vector_array_size(outVec)) < 2 {
+		return nil, nil, false
+	}
+
+	counts = New("MOE_EXPERT_COUNTS")
+	C.mlx_vector_array_get(&counts.ctx, outVec, 0)
+	ids = New("MOE_EXPERT_IDS")
+	C.mlx_vector_array_get(&ids.ctx, outVec, 1)
+	return counts, ids, true
+}
+
+// fastMoEExpertBlockMap builds per-expert counts plus a compact list of
+// non-empty expert row blocks and their token ids for block-mapped MoE
+// kernels to dispatch over.
+func fastMoEExpertBlockMap(indices *Array, experts int) (counts, blockCount, blockExperts, blockOffsets, blockIDs *Array, ok bool) {
+	if !MetalIsAvailable() {
+		return nil, nil, nil, nil, nil, false
+	}
+	if moeExpertBlockMapMetalDisabled {
+		return nil, nil, nil, nil, nil, false
+	}
+	tokens, topK, ok := moeExpertMapValidate(indices, experts)
+	if !ok {
+		return nil, nil, nil, nil, nil, false
+	}
+	// The block-map kernel allocates threadgroup arrays indexed by expert.
+	// Larger expert sets fall back to the mapped expert path instead of
+	// risking a Metal compile failure on devices with smaller threadgroup
+	// memory limits.
+	if tokens*topK > 32768 || experts > maxMoEExpertBlockMapExperts {
+		return nil, nil, nil, nil, nil, false
+	}
+	maxBlocks := maxMoEExpertBlocks(tokens, topK, experts)
+
+	moeExpertBlockMapMetalKernelOnce.Do(initMoEExpertBlockMapMetalKernel)
+	if moeExpertBlockMapMetalDisabled {
+		return nil, nil, nil, nil, nil, false
+	}
+
+	cfg := C.mlx_fast_metal_kernel_config_new()
+	defer C.mlx_fast_metal_kernel_config_free(cfg)
+	if !addMoEExpertBlockMapTemplateArgs(cfg, tokens, topK, experts, maxBlocks) {
+		return nil, nil, nil, nil, nil, false
+	}
+
+	blockCountShape := []C.int{1}
+	if C.mlx_fast_metal_kernel_config_add_output_arg(cfg, unsafe.SliceData(blockCountShape), C.size_t(len(blockCountShape)), C.mlx_dtype(DTypeInt32)) != 0 {
+		return nil, nil, nil, nil, nil, false
+	}
+	countShape := []C.int{C.int(experts)}
+	if C.mlx_fast_metal_kernel_config_add_output_arg(cfg, unsafe.SliceData(countShape), C.size_t(len(countShape)), C.mlx_dtype(DTypeInt32)) != 0 {
+		return nil, nil, nil, nil, nil, false
+	}
+	blockShape := []C.int{C.int(maxBlocks)}
+	if C.mlx_fast_metal_kernel_config_add_output_arg(cfg, unsafe.SliceData(blockShape), C.size_t(len(blockShape)), C.mlx_dtype(DTypeInt32)) != 0 {
+		return nil, nil, nil, nil, nil, false
+	}
+	if C.mlx_fast_metal_kernel_config_add_output_arg(cfg, unsafe.SliceData(blockShape), C.size_t(len(blockShape)), C.mlx_dtype(DTypeInt32)) != 0 {
+		return nil, nil, nil, nil, nil, false
+	}
+	blockIDsShape := []C.int{C.int(maxBlocks * moeExpertBlockSize)}
+	if C.mlx_fast_metal_kernel_config_add_output_arg(cfg, unsafe.SliceData(blockIDsShape), C.size_t(len(blockIDsShape)), C.mlx_dtype(DTypeInt32)) != 0 {
+		return nil, nil, nil, nil, nil, false
+	}
+	if C.mlx_fast_metal_kernel_config_set_init_value(cfg, 0) != 0 {
+		return nil, nil, nil, nil, nil, false
+	}
+	if C.mlx_fast_metal_kernel_config_set_grid(cfg, 256, 1, 1) != 0 {
+		return nil, nil, nil, nil, nil, false
+	}
+	if C.mlx_fast_metal_kernel_config_set_thread_group(cfg, 256, 1, 1) != 0 {
+		return nil, nil, nil, nil, nil, false
+	}
+
+	inputs := []C.mlx_array{indices.ctx}
+	inVec := C.mlx_vector_array_new_data(unsafe.SliceData(inputs), C.size_t(len(inputs)))
+	defer C.mlx_vector_array_free(inVec)
+
+	outVec := C.mlx_vector_array_new()
+	defer C.mlx_vector_array_free(outVec)
+	if C.mlx_fast_metal_kernel_apply(&outVec, moeExpertBlockMapMetalKernel, inVec, cfg, DefaultStream().ctx) != 0 {
+		return nil, nil, nil, nil, nil, false
+	}
+	if int(C.mlx_vector_array_size(outVec)) < 5 {
+		return nil, nil, nil, nil, nil, false
+	}
+
+	blockCount = New("MOE_EXPERT_BLOCK_COUNT")
+	C.mlx_vector_array_get(&blockCount.ctx, outVec, 0)
+	counts = New("MOE_EXPERT_BLOCK_COUNTS")
+	C.mlx_vector_array_get(&counts.ctx, outVec, 1)
+	blockExperts = New("MOE_EXPERT_BLOCK_EXPERTS")
+	C.mlx_vector_array_get(&blockExperts.ctx, outVec, 2)
+	blockOffsets = New("MOE_EXPERT_BLOCK_OFFSETS")
+	C.mlx_vector_array_get(&blockOffsets.ctx, outVec, 3)
+	blockIDs = New("MOE_EXPERT_BLOCK_IDS")
+	C.mlx_vector_array_get(&blockIDs.ctx, outVec, 4)
+	return counts, blockCount, blockExperts, blockOffsets, blockIDs, true
+}
+
+func nvfp4MoEMappedValidate(x, w, scales, counts, ids *Array, topK int) (tokens, inputSlots, experts, N, K int, ok bool) {
+	tokens, inputSlots, experts, N, K, ok = nvfp4MoEValidateBase(x, w, scales, counts, topK)
+	if !ok || ids == nil || ids.DType() != DTypeInt32 {
+		return 0, 0, 0, 0, 0, false
+	}
+	id := ids.Dims()
+	if len(id) != 2 || id[0] != experts || id[1] != tokens {
+		return 0, 0, 0, 0, 0, false
+	}
+	return tokens, inputSlots, experts, N, K, true
+}
+
+func fpMoEValidateBase(x, w, scales, counts *Array, topK, weightDiv, scaleDiv int) (tokens, inputSlots, experts, N, K int, ok bool) {
+	if x == nil || w == nil || scales == nil || counts == nil || topK <= 0 {
+		return 0, 0, 0, 0, 0, false
+	}
+	xd := x.Dims()
+	wd := w.Dims()
+	sd := scales.Dims()
+	cd := counts.Dims()
+	if len(xd) != 3 || len(wd) != 3 || len(sd) != 3 || len(cd) != 1 {
+		return 0, 0, 0, 0, 0, false
+	}
+	if x.DType() != DTypeFloat32 && x.DType() != DTypeFloat16 && x.DType() != DTypeBFloat16 {
+		return 0, 0, 0, 0, 0, false
+	}
+	if w.DType() != DTypeUint32 || scales.DType() != DTypeUint8 || counts.DType() != DTypeInt32 {
+		return 0, 0, 0, 0, 0, false
+	}
+	tokens, inputSlots, K = xd[0], xd[1], xd[2]
+	experts, N = wd[0], wd[1]
+	if tokens <= 0 || inputSlots <= 0 || topK <= 0 || N <= 0 || K <= 0 || K%32 != 0 {
+		return 0, 0, 0, 0, 0, false
+	}
+	if inputSlots != 1 && inputSlots != topK {
+		return 0, 0, 0, 0, 0, false
+	}
+	if wd[2] != K/weightDiv || sd[0] != experts || sd[1] != N || sd[2] != K/scaleDiv || cd[0] != experts {
+		return 0, 0, 0, 0, 0, false
+	}
+	return tokens, inputSlots, experts, N, K, true
+}
+
+func nvfp4MoEValidateBase(x, w, scales, counts *Array, topK int) (tokens, inputSlots, experts, N, K int, ok bool) {
+	return fpMoEValidateBase(x, w, scales, counts, topK, 8, 16)
+}
+
+func mxfp8MoEMappedValidate(x, w, scales, counts, ids *Array, topK int) (tokens, inputSlots, experts, N, K int, ok bool) {
+	tokens, inputSlots, experts, N, K, ok = mxfp8MoEValidateBase(x, w, scales, counts, topK)
+	if !ok || ids == nil || ids.DType() != DTypeInt32 {
+		return 0, 0, 0, 0, 0, false
+	}
+	id := ids.Dims()
+	if len(id) != 2 || id[0] != experts || id[1] != tokens {
+		return 0, 0, 0, 0, 0, false
+	}
+	return tokens, inputSlots, experts, N, K, true
+}
+
+func mxfp8MoEValidateBase(x, w, scales, counts *Array, topK int) (tokens, inputSlots, experts, N, K int, ok bool) {
+	return fpMoEValidateBase(x, w, scales, counts, topK, 4, 32)
+}
+
+func moeBlockMapValidate(blockCount, blockExperts, blockOffsets, blockIDs *Array) (maxBlocks int, ok bool) {
+	if blockCount == nil || blockExperts == nil || blockOffsets == nil || blockIDs == nil {
+		return 0, false
+	}
+	if blockCount.DType() != DTypeInt32 || blockExperts.DType() != DTypeInt32 || blockOffsets.DType() != DTypeInt32 || blockIDs.DType() != DTypeInt32 {
+		return 0, false
+	}
+	cd := blockCount.Dims()
+	ed := blockExperts.Dims()
+	od := blockOffsets.Dims()
+	bd := blockIDs.Dims()
+	if len(cd) != 1 || cd[0] != 1 || len(ed) != 1 || len(od) != 1 || len(bd) != 1 ||
+		ed[0] <= 0 || od[0] != ed[0] || bd[0] != ed[0]*moeExpertBlockSize {
+		return 0, false
+	}
+	return ed[0], true
+}
+
+func nvfp4MoEBlockMappedValidate(x, w, scales, counts, blockCount, blockExperts, blockOffsets, blockIDs *Array, topK int) (tokens, inputSlots, experts, N, K, maxBlocks int, ok bool) {
+	tokens, inputSlots, experts, N, K, ok = nvfp4MoEValidateBase(x, w, scales, counts, topK)
+	if !ok {
+		return 0, 0, 0, 0, 0, 0, false
+	}
+	maxBlocks, ok = moeBlockMapValidate(blockCount, blockExperts, blockOffsets, blockIDs)
+	if !ok {
+		return 0, 0, 0, 0, 0, 0, false
+	}
+	return tokens, inputSlots, experts, N, K, maxBlocks, true
+}
+
+func mxfp8MoEBlockMappedValidate(x, w, scales, counts, blockCount, blockExperts, blockOffsets, blockIDs *Array, topK int) (tokens, inputSlots, experts, N, K, maxBlocks int, ok bool) {
+	tokens, inputSlots, experts, N, K, ok = mxfp8MoEValidateBase(x, w, scales, counts, topK)
+	if !ok {
+		return 0, 0, 0, 0, 0, 0, false
+	}
+	maxBlocks, ok = moeBlockMapValidate(blockCount, blockExperts, blockOffsets, blockIDs)
+	if !ok {
+		return 0, 0, 0, 0, 0, 0, false
+	}
+	return tokens, inputSlots, experts, N, K, maxBlocks, true
+}
+
+func moeGatherMMSupportedDType(dtype DType) bool {
+	return dtype == DTypeBFloat16 && MetalIsAvailable()
+}
+
+func moeGatherMMBlockMappedValidate(x, w, counts, blockCount, blockExperts, blockOffsets, blockIDs *Array, topK int) (tokens, inputSlots, experts, N, K, maxBlocks int, weightTransposed, ok bool) {
+	if x == nil || w == nil || counts == nil || topK <= 0 {
+		return 0, 0, 0, 0, 0, 0, false, false
+	}
+	xd := x.Dims()
+	wd := w.Dims()
+	cd := counts.Dims()
+	if len(xd) != 3 || len(wd) != 3 || len(cd) != 1 {
+		return 0, 0, 0, 0, 0, 0, false, false
+	}
+	if !moeGatherMMSupportedDType(x.DType()) || !moeGatherMMSupportedDType(w.DType()) || counts.DType() != DTypeInt32 {
+		return 0, 0, 0, 0, 0, 0, false, false
+	}
+	tokens, inputSlots, K = xd[0], xd[1], xd[2]
+	experts = wd[0]
+	switch {
+	case wd[1] == K:
+		N = wd[2]
+	case wd[2] == K:
+		N = wd[1]
+		weightTransposed = true
+	default:
+		return 0, 0, 0, 0, 0, 0, false, false
+	}
+	if tokens <= 0 || inputSlots <= 0 || experts <= 0 || N <= 0 || K <= 0 || K%32 != 0 {
+		return 0, 0, 0, 0, 0, 0, false, false
+	}
+	if inputSlots != 1 && inputSlots != topK {
+		return 0, 0, 0, 0, 0, 0, false, false
+	}
+	if cd[0] != experts {
+		return 0, 0, 0, 0, 0, 0, false, false
+	}
+	maxBlocks, ok = moeBlockMapValidate(blockCount, blockExperts, blockOffsets, blockIDs)
+	if !ok {
+		return 0, 0, 0, 0, 0, 0, false, false
+	}
+	return tokens, inputSlots, experts, N, K, maxBlocks, weightTransposed, true
+}
+
+// SupportsMoEGatherQMMBlockMapped reports whether FastMoEGatherQMMBlockMapped
+// can dispatch the quantized expert projection described by the quantization
+// parameters.
+func SupportsMoEGatherQMMBlockMapped(groupSize, bits int, mode string) bool {
+	return (groupSize == 16 && bits == 4 && mode == "nvfp4") ||
+		(groupSize == 32 && bits == 8 && mode == "mxfp8")
+}
+
+// MoEGatherQMMMap stores the routed-token map reused by multiple expert
+// projections in one MoE layer.
+type MoEGatherQMMMap struct {
+	indices *Array
+	experts int
+
+	counts *Array
+	ids    *Array
+
+	blockCount   *Array
+	blockExperts *Array
+	blockOffsets *Array
+	blockIDs     *Array
+}
+
+// MoEExpertMap is the routed-token map shared by mapped MoE kernels.
+type MoEExpertMap = MoEGatherQMMMap
+
+// NewMoEGatherQMMMap builds the routed-token map used by
+// FastMoEGatherQMMBlockMapped. It prefers the compact block map and falls back
+// to the older expert map when the shape cannot use the block-map kernel.
+func NewMoEGatherQMMMap(indices *Array, experts int) (*MoEGatherQMMMap, bool) {
+	counts, blockCount, blockExperts, blockOffsets, blockIDs, ok := fastMoEExpertBlockMap(indices, experts)
+	if ok {
+		return &MoEGatherQMMMap{
+			indices:      indices,
+			experts:      experts,
+			counts:       counts,
+			blockCount:   blockCount,
+			blockExperts: blockExperts,
+			blockOffsets: blockOffsets,
+			blockIDs:     blockIDs,
+		}, true
+	}
+
+	counts, ids, ok := fastMoEExpertMap(indices, experts)
+	if !ok {
+		return nil, false
+	}
+	return &MoEGatherQMMMap{
+		indices: indices,
+		experts: experts,
+		counts:  counts,
+		ids:     ids,
+	}, true
+}
+
+// NewMoEExpertMap builds the routed-token map used by mapped MoE kernels.
+func NewMoEExpertMap(indices *Array, experts int) (*MoEExpertMap, bool) {
+	return NewMoEGatherQMMMap(indices, experts)
+}
+
+func (m *MoEGatherQMMMap) expertMap() (counts, ids *Array, ok bool) {
+	if m == nil {
+		return nil, nil, false
+	}
+	if m.ids != nil {
+		return m.counts, m.ids, true
+	}
+	counts, ids, ok = fastMoEExpertMap(m.indices, m.experts)
+	if !ok {
+		return nil, nil, false
+	}
+	m.counts = counts
+	m.ids = ids
+	return counts, ids, true
+}
+
+func applyMoEGatherMappedKernel(kernel C.mlx_fast_metal_kernel, name string, outDType DType, inputs []C.mlx_array, tokens, topK, inputSlots, experts, N, K, gridX, gridY, gridZ int, applyReluSquared, weightTransposed bool) (y *Array, ok bool) {
+	cfg := C.mlx_fast_metal_kernel_config_new()
+	defer C.mlx_fast_metal_kernel_config_free(cfg)
+	if !addMoEMappedTemplateArgs(cfg, tokens, topK, inputSlots, experts, N, K, outDType, applyReluSquared, weightTransposed) {
+		return nil, false
+	}
+
+	yShape := []C.int{C.int(tokens), C.int(topK), C.int(N)}
+	if C.mlx_fast_metal_kernel_config_add_output_arg(cfg, unsafe.SliceData(yShape), C.size_t(len(yShape)), C.mlx_dtype(outDType)) != 0 {
+		return nil, false
+	}
+	if C.mlx_fast_metal_kernel_config_set_grid(cfg, C.int(gridX), C.int(gridY), C.int(gridZ)) != 0 {
+		return nil, false
+	}
+	if C.mlx_fast_metal_kernel_config_set_thread_group(cfg, 128, 1, 1) != 0 {
+		return nil, false
+	}
+
+	inVec := C.mlx_vector_array_new_data(unsafe.SliceData(inputs), C.size_t(len(inputs)))
+	defer C.mlx_vector_array_free(inVec)
+
+	outVec := C.mlx_vector_array_new()
+	defer C.mlx_vector_array_free(outVec)
+	if C.mlx_fast_metal_kernel_apply(&outVec, kernel, inVec, cfg, DefaultStream().ctx) != 0 {
+		return nil, false
+	}
+	if int(C.mlx_vector_array_size(outVec)) < 1 {
+		return nil, false
+	}
+
+	y = New(name)
+	C.mlx_vector_array_get(&y.ctx, outVec, 0)
+	return y, true
+}
+
+// FastMoEGatherQMMBlockMapped computes x @ W[expert].T in original token/slot
+// order for supported quantized MoE expert weights. It uses the compact block
+// map when available, then falls back to the non-block expert map if the current
+// Metal toolchain cannot use the block-mapped kernel.
+func FastMoEGatherQMMBlockMapped(x, w, scales *Array, expertMap *MoEGatherQMMMap, topK, groupSize, bits int, mode string) (y *Array, ok bool) {
+	return fastMoEGatherQMMBlockMapped(x, w, scales, expertMap, topK, groupSize, bits, mode, false)
+}
+
+// FastMoEGatherQMMBlockMappedReLUSquared is like
+// FastMoEGatherQMMBlockMapped, but applies relu(x)^2 inside the projection.
+// This matches Nemotron-H's routed down-projection shape without exposing the
+// dtype-specific mapped kernels.
+func FastMoEGatherQMMBlockMappedReLUSquared(x, w, scales *Array, expertMap *MoEGatherQMMMap, topK, groupSize, bits int, mode string) (y *Array, ok bool) {
+	return fastMoEGatherQMMBlockMapped(x, w, scales, expertMap, topK, groupSize, bits, mode, true)
+}
+
+// SupportsMoEGatherMMBlockMapped reports whether FastMoEGatherMMBlockMapped can
+// dispatch dense expert weights with the given dtype. Metal 4 uses BF16 tensor
+// ops; older Metal keeps BF16 precision by loading operands as float for
+// simdgroup-matrix accumulation instead of routing through FP16 math.
+func SupportsMoEGatherMMBlockMapped(dtype DType) bool {
+	return moeGatherMMSupportedDType(dtype)
+}
+
+// FastMoEGatherMMBlockMapped computes x @ W[expert] in original token/slot
+// order for dense MoE expert weights stored as [experts, in, out]. It only uses
+// the compact block map; callers should fall back to GatherMM when it returns
+// ok=false.
+func FastMoEGatherMMBlockMapped(x, w *Array, expertMap *MoEExpertMap, topK int) (y *Array, ok bool) {
+	return fastMoEGatherMMBlockMapped(x, w, expertMap, topK, false)
+}
+
+// FastMoEGatherMMBlockMappedReLUSquared is like FastMoEGatherMMBlockMapped, but
+// applies relu(x)^2 inside the projection.
+func FastMoEGatherMMBlockMappedReLUSquared(x, w *Array, expertMap *MoEExpertMap, topK int) (y *Array, ok bool) {
+	return fastMoEGatherMMBlockMapped(x, w, expertMap, topK, true)
+}
+
+func fastMoEGatherMMBlockMapped(x, w *Array, expertMap *MoEExpertMap, topK int, applyReluSquared bool) (y *Array, ok bool) {
+	if !MetalIsAvailable() {
+		return nil, false
+	}
+	if x == nil || w == nil || expertMap == nil {
+		return nil, false
+	}
+	if !SupportsMoEGatherMMBlockMapped(x.DType()) {
+		return nil, false
+	}
+	if expertMap.blockCount == nil || expertMap.blockExperts == nil || expertMap.blockOffsets == nil || expertMap.blockIDs == nil {
+		return nil, false
+	}
+
+	tokens, inputSlots, experts, N, K, maxBlocks, weightTransposed, ok := moeGatherMMBlockMappedValidate(x, w, expertMap.counts, expertMap.blockCount, expertMap.blockExperts, expertMap.blockOffsets, expertMap.blockIDs, topK)
+	if !ok {
+		return nil, false
+	}
+
+	if moeGatherMMBlockMappedMetalDisabled {
+		return nil, false
+	}
+	moeGatherMMBlockMappedMetalKernelOnce.Do(initMoEGatherMMBlockMappedMetalKernel)
+	if moeGatherMMBlockMappedMetalDisabled {
+		return nil, false
+	}
+
+	gridX := maxBlocks * 128
+	gridY := (N + 63) / 64
+	inputs := []C.mlx_array{x.ctx, w.ctx, expertMap.counts.ctx, expertMap.blockCount.ctx, expertMap.blockExperts.ctx, expertMap.blockOffsets.ctx, expertMap.blockIDs.ctx}
+	out, ok := applyMoEGatherMappedKernel(moeGatherMMBlockMappedMetalKernel, "MOE_GATHER_MM_BLOCK_MAPPED", x.DType(), inputs, tokens, topK, inputSlots, experts, N, K, gridX, gridY, 1, applyReluSquared, weightTransposed)
+	if !ok {
+		return nil, false
+	}
+	return out, true
+}
+
+func fastMoEGatherQMMBlockMapped(x, w, scales *Array, expertMap *MoEGatherQMMMap, topK, groupSize, bits int, mode string, applyReluSquared bool) (y *Array, ok bool) {
+	if !SupportsMoEGatherQMMBlockMapped(groupSize, bits, mode) {
+		return nil, false
+	}
+	if w == nil || !w.Valid() || w.NumDims() != 3 || expertMap == nil {
+		return nil, false
+	}
+	if expertMap.blockCount != nil && expertMap.blockExperts != nil && expertMap.blockOffsets != nil && expertMap.blockIDs != nil {
+		switch mode {
+		case "nvfp4":
+			if out, ok := fastNVFP4MoEGatherQMMBlockMapped(x, w, scales, expertMap.counts, expertMap.blockCount, expertMap.blockExperts, expertMap.blockOffsets, expertMap.blockIDs, topK, applyReluSquared); ok {
+				return out, true
+			}
+		case "mxfp8":
+			if out, ok := fastMXFP8MoEGatherQMMBlockMapped(x, w, scales, expertMap.counts, expertMap.blockCount, expertMap.blockExperts, expertMap.blockOffsets, expertMap.blockIDs, topK, applyReluSquared); ok {
+				return out, true
+			}
+		}
+	}
+
+	counts, ids, ok := expertMap.expertMap()
+	if !ok {
+		return nil, false
+	}
+	switch mode {
+	case "nvfp4":
+		return fastNVFP4MoEGatherQMMMapped(x, w, scales, counts, ids, topK, applyReluSquared)
+	case "mxfp8":
+		return fastMXFP8MoEGatherQMMMapped(x, w, scales, counts, ids, topK, applyReluSquared)
+	default:
+		return nil, false
+	}
+}
+
+// fastNVFP4MoEGatherQMMMapped computes x @ W[expert].T for ids produced by
+// fastMoEExpertMap. It returns [tokens, topK, N] in original token/slot order.
+func fastNVFP4MoEGatherQMMMapped(x, w, scales, counts, ids *Array, topK int, applyReluSquared bool) (y *Array, ok bool) {
+	if !MetalIsAvailable() {
+		return nil, false
+	}
+	tokens, inputSlots, experts, N, K, ok := nvfp4MoEMappedValidate(x, w, scales, counts, ids, topK)
+	if !ok {
+		return nil, false
+	}
+
+	if nvfp4MoEMappedMetalDisabled {
+		return nil, false
+	}
+	nvfp4MoEMappedMetalKernelOnce.Do(initNVFP4MoEMappedMetalKernel)
+	if nvfp4MoEMappedMetalDisabled {
+		return nil, false
+	}
+
+	gridX := ((tokens + 31) / 32) * 128
+	gridY := (N + 63) / 64
+	inputs := []C.mlx_array{x.ctx, w.ctx, scales.ctx, counts.ctx, ids.ctx}
+	return applyMoEGatherMappedKernel(nvfp4MoEMappedMetalKernel, "MOE_GATHER_QMM_MAPPED", x.DType(), inputs, tokens, topK, inputSlots, experts, N, K, gridX, gridY, experts, applyReluSquared, false)
+}
+
+// fastNVFP4MoEGatherQMMBlockMapped is like fastNVFP4MoEGatherQMMMapped, but
+// dispatches only the populated expert row blocks produced by
+// fastMoEExpertBlockMap.
+func fastNVFP4MoEGatherQMMBlockMapped(x, w, scales, counts, blockCount, blockExperts, blockOffsets, blockIDs *Array, topK int, applyReluSquared bool) (y *Array, ok bool) {
+	if !MetalIsAvailable() {
+		return nil, false
+	}
+	tokens, inputSlots, experts, N, K, maxBlocks, ok := nvfp4MoEBlockMappedValidate(x, w, scales, counts, blockCount, blockExperts, blockOffsets, blockIDs, topK)
+	if !ok {
+		return nil, false
+	}
+
+	if nvfp4MoEBlockMappedMetalDisabled {
+		return nil, false
+	}
+	nvfp4MoEBlockMappedMetalKernelOnce.Do(initNVFP4MoEBlockMappedMetalKernel)
+	if nvfp4MoEBlockMappedMetalDisabled {
+		return nil, false
+	}
+
+	gridX := maxBlocks * 128
+	gridY := (N + 63) / 64
+	inputs := []C.mlx_array{x.ctx, w.ctx, scales.ctx, counts.ctx, blockCount.ctx, blockExperts.ctx, blockOffsets.ctx, blockIDs.ctx}
+	return applyMoEGatherMappedKernel(nvfp4MoEBlockMappedMetalKernel, "MOE_GATHER_QMM_BLOCK_MAPPED", x.DType(), inputs, tokens, topK, inputSlots, experts, N, K, gridX, gridY, 1, applyReluSquared, false)
+}
+
+// fastMXFP8MoEGatherQMMMapped computes x @ W[expert].T for ids produced by
+// fastMoEExpertMap. It returns [tokens, topK, N] in original token/slot order.
+func fastMXFP8MoEGatherQMMMapped(x, w, scales, counts, ids *Array, topK int, applyReluSquared bool) (y *Array, ok bool) {
+	if !MetalIsAvailable() {
+		return nil, false
+	}
+	tokens, inputSlots, experts, N, K, ok := mxfp8MoEMappedValidate(x, w, scales, counts, ids, topK)
+	if !ok {
+		return nil, false
+	}
+
+	if mxfp8MoEMappedMetalDisabled {
+		return nil, false
+	}
+	mxfp8MoEMappedMetalKernelOnce.Do(initMXFP8MoEMappedMetalKernel)
+	if mxfp8MoEMappedMetalDisabled {
+		return nil, false
+	}
+
+	gridX := ((tokens + 31) / 32) * 128
+	gridY := (N + 63) / 64
+	inputs := []C.mlx_array{x.ctx, w.ctx, scales.ctx, counts.ctx, ids.ctx}
+	return applyMoEGatherMappedKernel(mxfp8MoEMappedMetalKernel, "MOE_GATHER_QMM_MAPPED", x.DType(), inputs, tokens, topK, inputSlots, experts, N, K, gridX, gridY, experts, applyReluSquared, false)
+}
+
+// fastMXFP8MoEGatherQMMBlockMapped is like fastMXFP8MoEGatherQMMMapped, but
+// dispatches only the populated expert row blocks produced by
+// fastMoEExpertBlockMap.
+func fastMXFP8MoEGatherQMMBlockMapped(x, w, scales, counts, blockCount, blockExperts, blockOffsets, blockIDs *Array, topK int, applyReluSquared bool) (y *Array, ok bool) {
+	if !MetalIsAvailable() {
+		return nil, false
+	}
+	tokens, inputSlots, experts, N, K, maxBlocks, ok := mxfp8MoEBlockMappedValidate(x, w, scales, counts, blockCount, blockExperts, blockOffsets, blockIDs, topK)
+	if !ok {
+		return nil, false
+	}
+
+	if mxfp8MoEBlockMappedMetalDisabled {
+		return nil, false
+	}
+	mxfp8MoEBlockMappedMetalKernelOnce.Do(initMXFP8MoEBlockMappedMetalKernel)
+	if mxfp8MoEBlockMappedMetalDisabled {
+		return nil, false
+	}
+
+	gridX := maxBlocks * 128
+	gridY := (N + 63) / 64
+	inputs := []C.mlx_array{x.ctx, w.ctx, scales.ctx, counts.ctx, blockCount.ctx, blockExperts.ctx, blockOffsets.ctx, blockIDs.ctx}
+	return applyMoEGatherMappedKernel(mxfp8MoEBlockMappedMetalKernel, "MOE_GATHER_QMM_BLOCK_MAPPED", x.DType(), inputs, tokens, topK, inputSlots, experts, N, K, gridX, gridY, 1, applyReluSquared, false)
+}

--- a/x/mlxrunner/mlx/moe_gather_qmm_mapped_test.go
+++ b/x/mlxrunner/mlx/moe_gather_qmm_mapped_test.go
@@ -1,0 +1,513 @@
+package mlx
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"testing"
+)
+
+func TestFastMoEExpertBlockMapMatchesExpertMap(t *testing.T) {
+	withMLXThread(t, func() {
+		if !MetalIsAvailable() {
+			t.Skip("requires Metal")
+		}
+
+		const (
+			tokens  = 73
+			topK    = 4
+			experts = 8
+		)
+
+		idxVals := make([]int32, tokens*topK)
+		for tok := range tokens {
+			idxVals[tok*topK] = int32(tok % experts)
+			idxVals[tok*topK+1] = int32((tok + 1) % experts)
+			idxVals[tok*topK+2] = int32((tok/2 + 3) % experts)
+			idxVals[tok*topK+3] = int32((tok/3 + 5) % experts)
+		}
+		idx := FromValues(idxVals, tokens, topK)
+
+		counts, ids, ok := fastMoEExpertMap(idx, experts)
+		if !ok {
+			t.Fatal("fastMoEExpertMap returned ok=false")
+		}
+		blockCounts, blockCount, blockExperts, blockOffsets, blockIDs, ok := fastMoEExpertBlockMap(idx, experts)
+		if !ok {
+			t.Fatal("fastMoEExpertBlockMap returned ok=false")
+		}
+		Eval(counts, ids, blockCounts, blockCount, blockExperts, blockOffsets, blockIDs)
+
+		countVals := counts.Ints()
+		blockCountVals := blockCounts.Ints()
+		if len(countVals) != len(blockCountVals) {
+			t.Fatalf("count lengths differ: %d vs %d", len(countVals), len(blockCountVals))
+		}
+
+		blockIDVals := blockIDs.Ints()
+		expectedBlocks := 0
+		expectedByExpert := make([][]int, experts)
+		for flat, expert := range idxVals {
+			expectedByExpert[int(expert)] = append(expectedByExpert[int(expert)], flat)
+		}
+		for expert, count := range countVals {
+			if count != blockCountVals[expert] {
+				t.Fatalf("expert %d count = %d, block count = %d", expert, count, blockCountVals[expert])
+			}
+			if count != len(expectedByExpert[expert]) {
+				t.Fatalf("expert %d count = %d, want %d", expert, count, len(expectedByExpert[expert]))
+			}
+			expectedBlocks += (count + moeExpertBlockSize - 1) / moeExpertBlockSize
+		}
+		if got := blockCount.Ints()[0]; got != expectedBlocks {
+			t.Fatalf("blockCount = %d, want %d", got, expectedBlocks)
+		}
+
+		seen := make(map[[2]int]bool)
+		gotByExpert := make([][]int, experts)
+		blockExpertVals := blockExperts.Ints()
+		blockOffsetVals := blockOffsets.Ints()
+		for i := range expectedBlocks {
+			expert := blockExpertVals[i]
+			offset := blockOffsetVals[i]
+			if expert < 0 || expert >= experts {
+				t.Fatalf("block %d expert = %d, want [0,%d)", i, expert, experts)
+			}
+			if offset < 0 || offset >= countVals[expert] || offset%moeExpertBlockSize != 0 {
+				t.Fatalf("block %d offset = %d for expert %d count %d", i, offset, expert, countVals[expert])
+			}
+			key := [2]int{expert, offset}
+			if seen[key] {
+				t.Fatalf("duplicate block descriptor expert=%d offset=%d", expert, offset)
+			}
+			seen[key] = true
+
+			limit := min(moeExpertBlockSize, countVals[expert]-offset)
+			for j := range limit {
+				flat := blockIDVals[i*moeExpertBlockSize+j]
+				if flat < 0 || flat >= len(idxVals) {
+					t.Fatalf("block %d id %d = %d, want [0,%d)", i, j, flat, len(idxVals))
+				}
+				if int(idxVals[flat]) != expert {
+					t.Fatalf("block %d id %d routes to expert %d, want %d", i, j, idxVals[flat], expert)
+				}
+				gotByExpert[expert] = append(gotByExpert[expert], flat)
+			}
+		}
+		for expert := range experts {
+			for offset := 0; offset < countVals[expert]; offset += moeExpertBlockSize {
+				if !seen[[2]int{expert, offset}] {
+					t.Fatalf("missing block descriptor expert=%d offset=%d", expert, offset)
+				}
+			}
+			sort.Ints(gotByExpert[expert])
+			sort.Ints(expectedByExpert[expert])
+			if len(gotByExpert[expert]) != len(expectedByExpert[expert]) {
+				t.Fatalf("expert %d ids = %d, want %d", expert, len(gotByExpert[expert]), len(expectedByExpert[expert]))
+			}
+			for i := range gotByExpert[expert] {
+				if gotByExpert[expert][i] != expectedByExpert[expert][i] {
+					t.Fatalf("expert %d sorted id %d = %d, want %d", expert, i, gotByExpert[expert][i], expectedByExpert[expert][i])
+				}
+			}
+		}
+	})
+}
+
+func TestFastMoEExpertBlockMapRejectsLargeExpertSets(t *testing.T) {
+	withMLXThread(t, func() {
+		if !MetalIsAvailable() {
+			t.Skip("requires Metal")
+		}
+
+		idx := FromValues([]int32{0, 1, 2, 3}, 1, 4)
+		counts, blockCount, blockExperts, blockOffsets, blockIDs, ok := fastMoEExpertBlockMap(idx, maxMoEExpertBlockMapExperts+1)
+		if ok {
+			t.Fatal("fastMoEExpertBlockMap returned ok=true for an oversized expert set")
+		}
+		if counts != nil || blockCount != nil || blockExperts != nil || blockOffsets != nil || blockIDs != nil {
+			t.Fatal("fastMoEExpertBlockMap returned outputs for an oversized expert set")
+		}
+	})
+}
+
+type fastMoEGatherQMMFunc func(x, w, scales, counts, ids *Array, topK int) (*Array, bool)
+
+type fastMoEBlockGatherQMMFunc func(x, w, scales, counts, blockCount, blockExperts, blockOffsets, blockIDs *Array, topK int) (*Array, bool)
+
+func TestFastNVFP4MoEGatherQMMMappedMatchesGatherQMM(t *testing.T) {
+	testFastMoEGatherQMMMappedMatchesGatherQMM(t, "nvfp4", 16, 4,
+		func(x, w, scales, counts, ids *Array, topK int) (*Array, bool) {
+			return fastNVFP4MoEGatherQMMMapped(x, w, scales, counts, ids, topK, false)
+		},
+		func(x, w, scales, counts, blockCount, blockExperts, blockOffsets, blockIDs *Array, topK int) (*Array, bool) {
+			return fastNVFP4MoEGatherQMMBlockMapped(x, w, scales, counts, blockCount, blockExperts, blockOffsets, blockIDs, topK, false)
+		},
+	)
+}
+
+func TestFastMXFP8MoEGatherQMMMappedMatchesGatherQMM(t *testing.T) {
+	testFastMoEGatherQMMMappedMatchesGatherQMM(t, "mxfp8", 32, 8,
+		func(x, w, scales, counts, ids *Array, topK int) (*Array, bool) {
+			return fastMXFP8MoEGatherQMMMapped(x, w, scales, counts, ids, topK, false)
+		},
+		func(x, w, scales, counts, blockCount, blockExperts, blockOffsets, blockIDs *Array, topK int) (*Array, bool) {
+			return fastMXFP8MoEGatherQMMBlockMapped(x, w, scales, counts, blockCount, blockExperts, blockOffsets, blockIDs, topK, false)
+		},
+	)
+}
+
+func TestFastMoEGatherMMBlockMappedMatchesGatherMM(t *testing.T) {
+	var testErr error
+	withMLXThread(t, func() {
+		if !MetalIsAvailable() {
+			t.Skip("requires Metal")
+		}
+		failf := func(format string, args ...any) {
+			if testErr == nil {
+				testErr = fmt.Errorf(format, args...)
+			}
+		}
+		dtype := DTypeBFloat16
+		if !SupportsMoEGatherMMBlockMapped(dtype) {
+			t.Skip("dense mapped MoE kernel unavailable")
+		}
+
+		for _, tc := range []struct {
+			name    string
+			tokens  int
+			topK    int
+			experts int
+			inDim   int
+			outDim  int
+		}{
+			{name: "small", tokens: 73, topK: 8, experts: 16, inDim: 128, outDim: 192},
+			{name: "many_experts", tokens: 56, topK: 8, experts: 256, inDim: 128, outDim: 192},
+			{name: "laguna_gate_up", tokens: 56, topK: 8, experts: 16, inDim: 2048, outDim: 1024},
+			{name: "laguna_down", tokens: 56, topK: 8, experts: 16, inDim: 512, outDim: 2048},
+		} {
+			wVals := make([]float32, tc.experts*tc.inDim*tc.outDim)
+			for i := range wVals {
+				wVals[i] = float32((i%43)-21) * 0.005
+			}
+			w := FromValues(wVals, tc.experts, tc.inDim, tc.outDim).AsType(dtype)
+
+			idxVals := make([]int32, tc.tokens*tc.topK)
+			for tok := range tc.tokens {
+				for k := range tc.topK {
+					idxVals[tok*tc.topK+k] = int32((tok*5 + k*3 + k*k) % tc.experts)
+				}
+			}
+			idx := FromValues(idxVals, tc.tokens, tc.topK)
+			expertMap, ok := NewMoEExpertMap(idx, tc.experts)
+			if !ok {
+				failf("%s: NewMoEExpertMap returned ok=false", tc.name)
+				return
+			}
+
+			if !runMoEGatherMMBlockMappedTestCase(tc.name+"_input_slots_1", tc.tokens, tc.topK, tc.inDim, tc.outDim, 1, dtype, w, w, idx, expertMap, failf) {
+				return
+			}
+			if !runMoEGatherMMBlockMappedTestCase(tc.name+"_input_slots_topk", tc.tokens, tc.topK, tc.inDim, tc.outDim, tc.topK, dtype, w, w, idx, expertMap, failf) {
+				return
+			}
+
+			sourceW := Transpose(w, 0, 2, 1).Clone()
+			Eval(sourceW)
+			if !runMoEGatherMMBlockMappedTestCase(tc.name+"_source_layout_input_slots_1", tc.tokens, tc.topK, tc.inDim, tc.outDim, 1, dtype, sourceW, w, idx, expertMap, failf) {
+				return
+			}
+			if !runMoEGatherMMBlockMappedTestCase(tc.name+"_source_layout_input_slots_topk", tc.tokens, tc.topK, tc.inDim, tc.outDim, tc.topK, dtype, sourceW, w, idx, expertMap, failf) {
+				return
+			}
+		}
+	})
+	if testErr != nil {
+		t.Fatal(testErr)
+	}
+}
+
+func runMoEGatherMMBlockMappedTestCase(name string, tokens, topK, inDim, outDim, inputSlots int, dtype DType, w, wantW, idx *Array, expertMap *MoEExpertMap, failf func(string, ...any)) bool {
+	tokens32 := int32(tokens)
+	topK32 := int32(topK)
+	inDim32 := int32(inDim)
+	outDim32 := int32(outDim)
+
+	xVals := make([]float32, tokens*inputSlots*inDim)
+	for i := range xVals {
+		xVals[i] = float32((i%37)-18) * 0.01
+	}
+	x := FromValues(xVals, tokens, inputSlots, inDim).AsType(dtype)
+	Pin(x, w, wantW, idx, expertMap.counts, expertMap.blockCount, expertMap.blockExperts, expertMap.blockOffsets, expertMap.blockIDs)
+	defer Unpin(x, w, wantW, idx, expertMap.counts, expertMap.blockCount, expertMap.blockExperts, expertMap.blockOffsets, expertMap.blockIDs)
+
+	got, ok := FastMoEGatherMMBlockMapped(x, w, expertMap, topK)
+	if !ok {
+		failf("%s: FastMoEGatherMMBlockMapped returned ok=false", name)
+		return false
+	}
+	gotRelu, ok := FastMoEGatherMMBlockMappedReLUSquared(x, w, expertMap, topK)
+	if !ok {
+		failf("%s: FastMoEGatherMMBlockMappedReLUSquared returned ok=false", name)
+		return false
+	}
+
+	zero := NewScalarArray(float32(0)).AsType(x.DType())
+	xRelu := Maximum(x, zero)
+	xRelu = Mul(xRelu, xRelu)
+
+	var want *Array
+	var wantRelu *Array
+	if inputSlots == 1 {
+		want = GatherMM(Reshape(x, tokens32, 1, 1, inDim32), wantW, nil, idx, false)
+		wantRelu = GatherMM(Reshape(xRelu, tokens32, 1, 1, inDim32), wantW, nil, idx, false)
+	} else {
+		want = GatherMM(Reshape(x, tokens32, topK32, 1, inDim32), wantW, nil, idx, false)
+		wantRelu = GatherMM(Reshape(xRelu, tokens32, topK32, 1, inDim32), wantW, nil, idx, false)
+	}
+	want = Reshape(want, tokens32, topK32, outDim32)
+	wantRelu = Reshape(wantRelu, tokens32, topK32, outDim32)
+
+	gotF := got.AsType(DTypeFloat32)
+	gotReluF := gotRelu.AsType(DTypeFloat32)
+	wantF := want.AsType(DTypeFloat32)
+	wantReluF := wantRelu.AsType(DTypeFloat32)
+	Eval(gotF, gotReluF, wantF, wantReluF)
+
+	if dims := got.Dims(); len(dims) != 3 || dims[0] != tokens || dims[1] != topK || dims[2] != outDim {
+		failf("%s: dims = %v, want [%d %d %d]", name, dims, tokens, topK, outDim)
+		return false
+	}
+	if err := checkMoEFloat32Close(name+" dense block mapped", gotF.Floats(), wantF.Floats(), 3e-2); err != nil {
+		failf("%v", err)
+		return false
+	}
+	if err := checkMoEFloat32Close(name+" dense relu-squared block mapped", gotReluF.Floats(), wantReluF.Floats(), 3e-2); err != nil {
+		failf("%v", err)
+		return false
+	}
+	return true
+}
+
+func testFastMoEGatherQMMMappedMatchesGatherQMM(t *testing.T, mode string, groupSize, bits int, mapped fastMoEGatherQMMFunc, blockMapped fastMoEBlockGatherQMMFunc) {
+	t.Helper()
+	withMLXThread(t, func() {
+		if !MetalIsAvailable() {
+			t.Skip("requires Metal")
+		}
+
+		const (
+			tokens  = 73
+			topK    = 8
+			experts = 16
+			inDim   = 128
+			outDim  = 192
+		)
+
+		wVals := make([]float32, experts*outDim*inDim)
+		for i := range wVals {
+			wVals[i] = float32((i%41)-20) * 0.006
+		}
+		w := FromValues(wVals, experts, outDim, inDim).AsType(DTypeBFloat16)
+		qw, scales, qbiases := Quantize(w, groupSize, bits, mode)
+		if qbiases != nil {
+			t.Fatalf("%s test expects no quantization bias", mode)
+		}
+
+		idxVals := make([]int32, tokens*topK)
+		for tok := range tokens {
+			for k := range topK {
+				idxVals[tok*topK+k] = int32((tok*5 + k*3 + k*k) % experts)
+			}
+		}
+		idx := FromValues(idxVals, tokens, topK)
+		counts, ids, ok := fastMoEExpertMap(idx, experts)
+		if !ok {
+			t.Fatal("fastMoEExpertMap returned ok=false")
+		}
+		blockCounts, blockCount, blockExperts, blockOffsets, blockIDs, ok := fastMoEExpertBlockMap(idx, experts)
+		if !ok {
+			t.Fatal("fastMoEExpertBlockMap returned ok=false")
+		}
+		expertMap, ok := NewMoEGatherQMMMap(idx, experts)
+		if !ok {
+			t.Fatal("NewMoEGatherQMMMap returned ok=false")
+		}
+
+		run := func(name string, inputSlots int) {
+			t.Helper()
+
+			xVals := make([]float32, tokens*inputSlots*inDim)
+			for i := range xVals {
+				xVals[i] = float32((i%37)-18) * 0.01
+			}
+			x := FromValues(xVals, tokens, inputSlots, inDim).AsType(DTypeBFloat16)
+			Pin(x, qw, scales, idx, counts, ids, blockCounts, blockIDs, blockCount, blockExperts, blockOffsets, expertMap.counts, expertMap.ids, expertMap.blockCount, expertMap.blockExperts, expertMap.blockOffsets, expertMap.blockIDs)
+			defer Unpin(x, qw, scales, idx, counts, ids, blockCounts, blockIDs, blockCount, blockExperts, blockOffsets, expertMap.counts, expertMap.ids, expertMap.blockCount, expertMap.blockExperts, expertMap.blockOffsets, expertMap.blockIDs)
+
+			got, ok := mapped(x, qw, scales, counts, ids, topK)
+			if !ok {
+				t.Fatalf("%s: %s mapped kernel returned ok=false", name, mode)
+			}
+			gotBlock, ok := blockMapped(x, qw, scales, blockCounts, blockCount, blockExperts, blockOffsets, blockIDs, topK)
+			if !ok {
+				t.Fatalf("%s: %s block mapped kernel returned ok=false", name, mode)
+			}
+			gotFast, ok := FastMoEGatherQMMBlockMapped(x, qw, scales, expertMap, topK, groupSize, bits, mode)
+			if !ok {
+				t.Fatalf("%s: %s generic mapped kernel returned ok=false", name, mode)
+			}
+			gotReluFast, ok := FastMoEGatherQMMBlockMappedReLUSquared(x, qw, scales, expertMap, topK, groupSize, bits, mode)
+			if !ok {
+				t.Fatalf("%s: %s generic relu-squared mapped kernel returned ok=false", name, mode)
+			}
+
+			zero := NewScalarArray(float32(0)).AsType(x.DType())
+			xRelu := Maximum(x, zero)
+			xRelu = Mul(xRelu, xRelu)
+
+			var want *Array
+			var wantRelu *Array
+			if inputSlots == 1 {
+				want = GatherQMM(Reshape(x, tokens, 1, 1, inDim), qw, scales, nil, nil, idx, true, groupSize, bits, mode, false)
+				wantRelu = GatherQMM(Reshape(xRelu, tokens, 1, 1, inDim), qw, scales, nil, nil, idx, true, groupSize, bits, mode, false)
+			} else {
+				want = GatherQMM(Reshape(x, tokens, topK, 1, inDim), qw, scales, nil, nil, idx, true, groupSize, bits, mode, false)
+				wantRelu = GatherQMM(Reshape(xRelu, tokens, topK, 1, inDim), qw, scales, nil, nil, idx, true, groupSize, bits, mode, false)
+			}
+			want = Reshape(want, tokens, topK, outDim)
+			wantRelu = Reshape(wantRelu, tokens, topK, outDim)
+
+			gotF := got.AsType(DTypeFloat32)
+			gotBlockF := gotBlock.AsType(DTypeFloat32)
+			gotFastF := gotFast.AsType(DTypeFloat32)
+			gotReluFastF := gotReluFast.AsType(DTypeFloat32)
+			wantF := want.AsType(DTypeFloat32)
+			wantReluF := wantRelu.AsType(DTypeFloat32)
+			Eval(gotF, gotBlockF, gotFastF, gotReluFastF, wantF, wantReluF)
+
+			if dims := got.Dims(); len(dims) != 3 || dims[0] != tokens || dims[1] != topK || dims[2] != outDim {
+				t.Fatalf("%s: dims = %v, want [%d %d %d]", name, dims, tokens, topK, outDim)
+			}
+			assertMoEFloat32Close(t, name+" mapped", gotF.Floats(), wantF.Floats(), 3e-2)
+			assertMoEFloat32Close(t, name+" block mapped", gotBlockF.Floats(), wantF.Floats(), 3e-2)
+			assertMoEFloat32Close(t, name+" generic mapped", gotFastF.Floats(), wantF.Floats(), 3e-2)
+			assertMoEFloat32Close(t, name+" generic relu-squared mapped", gotReluFastF.Floats(), wantReluF.Floats(), 3e-2)
+		}
+
+		run("input_slots_1", 1)
+		run("input_slots_topk", topK)
+	})
+}
+
+func TestFastNVFP4MoEGatherQMMMappedMatchesGatherQMMWithCTPackedWeights(t *testing.T) {
+	withMLXThread(t, func() {
+		if !MetalIsAvailable() {
+			t.Skip("requires Metal")
+		}
+
+		const (
+			tokens  = 17
+			topK    = 3
+			experts = 4
+			inDim   = 128
+			outDim  = 64
+		)
+
+		words := make([]uint32, experts*outDim*(inDim/8))
+		for e := range experts {
+			for row := range outDim {
+				rowWordBase := (e*outDim + row) * (inDim / 8)
+				for word := range inDim / 8 {
+					var packed uint32
+					for byteInWord := range 4 {
+						kByte := word*4 + byteInWord
+						lo := uint8((e + row + kByte) & 7)
+						hi := uint8((2*e + 3*row + kByte + 1) & 7)
+						if (row+kByte)&3 == 0 {
+							lo |= 8
+						}
+						if (e+kByte)&5 == 0 {
+							hi |= 8
+						}
+						packed |= uint32(lo|(hi<<4)) << (8 * byteInWord)
+					}
+					words[rowWordBase+word] = packed
+				}
+			}
+		}
+		w := FromValues(words, experts, outDim, inDim/8)
+
+		scaleVals := make([]uint8, experts*outDim*(inDim/16))
+		scalePattern := []uint8{0x6f, 0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x7e}
+		for i := range scaleVals {
+			scaleVals[i] = scalePattern[i%len(scalePattern)]
+		}
+		scales := FromValues(scaleVals, experts, outDim, inDim/16)
+
+		idxVals := make([]int32, tokens*topK)
+		for tok := range tokens {
+			for k := range topK {
+				idxVals[tok*topK+k] = int32((tok + 2*k) % experts)
+			}
+		}
+		idx := FromValues(idxVals, tokens, topK)
+		counts, ids, ok := fastMoEExpertMap(idx, experts)
+		if !ok {
+			t.Fatal("fastMoEExpertMap returned ok=false")
+		}
+
+		run := func(name string, inputSlots int) {
+			t.Helper()
+
+			xVals := make([]float32, tokens*inputSlots*inDim)
+			for i := range xVals {
+				xVals[i] = float32((i%53)-26) * 0.003
+			}
+			x := FromValues(xVals, tokens, inputSlots, inDim).AsType(DTypeBFloat16)
+			Pin(x, w, scales, idx, counts, ids)
+			defer Unpin(x, w, scales, idx, counts, ids)
+
+			got, ok := fastNVFP4MoEGatherQMMMapped(x, w, scales, counts, ids, topK, false)
+			if !ok {
+				t.Fatalf("%s: fastNVFP4MoEGatherQMMMapped returned ok=false", name)
+			}
+
+			var want *Array
+			if inputSlots == 1 {
+				want = GatherQMM(Reshape(x, tokens, 1, 1, inDim), w, scales, nil, nil, idx, true, 16, 4, "nvfp4", false)
+			} else {
+				want = GatherQMM(Reshape(x, tokens, topK, 1, inDim), w, scales, nil, nil, idx, true, 16, 4, "nvfp4", false)
+			}
+			want = Reshape(want, tokens, topK, outDim)
+
+			gotF := got.AsType(DTypeFloat32)
+			wantF := want.AsType(DTypeFloat32)
+			Eval(gotF, wantF)
+
+			assertMoEFloat32Close(t, name+" mapped", gotF.Floats(), wantF.Floats(), 3e-2)
+		}
+
+		run("input_slots_1", 1)
+		run("input_slots_topk", topK)
+	})
+}
+
+func assertMoEFloat32Close(t *testing.T, label string, got, want []float32, tol float64) {
+	t.Helper()
+	if err := checkMoEFloat32Close(label, got, want, tol); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func checkMoEFloat32Close(label string, got, want []float32, tol float64) error {
+	if len(got) != len(want) {
+		return fmt.Errorf("%s: len got=%d want=%d", label, len(got), len(want))
+	}
+	for i := range got {
+		if diff := math.Abs(float64(got[i] - want[i])); diff > tol {
+			return fmt.Errorf("%s: got[%d]=%v want %v diff %v", label, i, got[i], want[i], diff)
+		}
+	}
+	return nil
+}

--- a/x/mlxrunner/mlx/moe_weighted_sum.go
+++ b/x/mlxrunner/mlx/moe_weighted_sum.go
@@ -1,0 +1,426 @@
+package mlx
+
+// #include <stdlib.h>
+// #include "generated.h"
+import "C"
+
+// These fused MoE weighted-sum kernels are currently only used by Laguna. As
+// part of the retained Laguna fast path, the Apple M5 Max p2048/g128 run was
+// about 24% faster on prompt and 7% faster on generate than the GGML target.
+// Gemma and Qwen weighted-sum trials were neutral or slightly negative.
+// TODO: consider moving this implementation under x/models/laguna once the mlx
+// package has a refined custom-kernel API that can safely support model-local
+// kernels without exposing low-level MLX internals.
+// TODO(cuda): add CUDA equivalents for these custom Metal kernels before
+// enabling the same fast path on CUDA-backed MLX; non-Metal backends must keep
+// using the generic fallback.
+
+import (
+	"math"
+	"sync"
+	"unsafe"
+)
+
+var (
+	moeWeightedSumMetalKernelOnce sync.Once
+	moeWeightedSumMetalKernel     C.mlx_fast_metal_kernel
+	moeWeightedSumMetalDisabled   bool
+
+	moeWeightedSumAddMetalKernelOnce sync.Once
+	moeWeightedSumAddMetalKernel     C.mlx_fast_metal_kernel
+	moeWeightedSumAddMetalDisabled   bool
+
+	moeWeightedSumAdd2MetalKernelOnce sync.Once
+	moeWeightedSumAdd2MetalKernel     C.mlx_fast_metal_kernel
+	moeWeightedSumAdd2MetalDisabled   bool
+)
+
+const moeWeightedSumMetalKernelSource = `
+auto elem = thread_position_in_grid.x;
+auto total = B * L * H;
+if (elem >= total) {
+  return;
+}
+
+auto h = elem % H;
+auto token = elem / H;
+auto expert_base = token * TopK * H + h;
+auto score_base = token * TopK;
+
+float acc = 0.0f;
+for (int k = 0; k < TopK; ++k) {
+  acc += static_cast<float>(expert[expert_base + k * H]) * static_cast<float>(scores[score_base + k]);
+}
+y[elem] = static_cast<OutT>(acc * (float(ScaleNum) / float(ScaleDen)));
+`
+
+const moeWeightedSumAddMetalKernelSource = `
+auto elem = thread_position_in_grid.x;
+auto total = B * L * H;
+if (elem >= total) {
+  return;
+}
+
+auto h = elem % H;
+auto token = elem / H;
+auto expert_base = token * TopK * H + h;
+auto score_base = token * TopK;
+
+float acc = 0.0f;
+for (int k = 0; k < TopK; ++k) {
+  acc += static_cast<float>(expert[expert_base + k * H]) * static_cast<float>(scores[score_base + k]);
+}
+y[elem] = static_cast<OutT>(static_cast<float>(shared[elem]) + acc * (float(ScaleNum) / float(ScaleDen)));
+`
+
+const moeWeightedSumAdd2MetalKernelSource = `
+auto elem = thread_position_in_grid.x;
+auto total = B * L * H;
+if (elem >= total) {
+  return;
+}
+
+auto h = elem % H;
+auto token = elem / H;
+auto expert_base = token * TopK * H + h;
+auto score_base = token * TopK;
+
+float acc = 0.0f;
+for (int k = 0; k < TopK; ++k) {
+  acc += static_cast<float>(expert[expert_base + k * H]) * static_cast<float>(scores[score_base + k]);
+}
+y[elem] = static_cast<OutT>(static_cast<float>(add_a[elem]) + static_cast<float>(add_b[elem]) + acc * (float(ScaleNum) / float(ScaleDen)));
+`
+
+func initMoEWeightedSumKernel(target *C.mlx_fast_metal_kernel, disabled *bool, name string, inputsList []string, source string) {
+	inputs, freeInputs, ok := cStringVector(inputsList)
+	if !ok {
+		*disabled = true
+		freeInputs()
+		return
+	}
+	defer freeInputs()
+
+	outputs, freeOutputs, ok := cStringVector([]string{"y"})
+	if !ok {
+		*disabled = true
+		freeOutputs()
+		return
+	}
+	defer freeOutputs()
+
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	cSource := C.CString(source)
+	defer C.free(unsafe.Pointer(cSource))
+	cHeader := C.CString("")
+	defer C.free(unsafe.Pointer(cHeader))
+
+	*target = C.mlx_fast_metal_kernel_new(
+		cName,
+		inputs,
+		outputs,
+		cSource,
+		cHeader,
+		C.bool(true),
+		C.bool(false),
+	)
+}
+
+func initMoEWeightedSumMetalKernel() {
+	initMoEWeightedSumKernel(&moeWeightedSumMetalKernel, &moeWeightedSumMetalDisabled, "moe_weighted_sum", []string{"expert", "scores"}, moeWeightedSumMetalKernelSource)
+}
+
+func initMoEWeightedSumAddMetalKernel() {
+	initMoEWeightedSumKernel(&moeWeightedSumAddMetalKernel, &moeWeightedSumAddMetalDisabled, "moe_weighted_sum_add", []string{"expert", "scores", "shared"}, moeWeightedSumAddMetalKernelSource)
+}
+
+func initMoEWeightedSumAdd2MetalKernel() {
+	initMoEWeightedSumKernel(&moeWeightedSumAdd2MetalKernel, &moeWeightedSumAdd2MetalDisabled, "moe_weighted_sum_add2", []string{"expert", "scores", "add_a", "add_b"}, moeWeightedSumAdd2MetalKernelSource)
+}
+
+func moeWeightedSumValidate(expert, scores *Array, outDType DType) (B, L, topK, H int, ok bool) {
+	if expert == nil || scores == nil {
+		return 0, 0, 0, 0, false
+	}
+	if !moeWeightedSumSupportedDType(expert.DType()) || !moeWeightedSumSupportedDType(scores.DType()) || !moeWeightedSumSupportedDType(outDType) {
+		return 0, 0, 0, 0, false
+	}
+	ed := expert.Dims()
+	sd := scores.Dims()
+	if len(ed) != 4 || len(sd) != 3 {
+		return 0, 0, 0, 0, false
+	}
+	B, L, topK, H = ed[0], ed[1], ed[2], ed[3]
+	if B <= 0 || L <= 0 || topK <= 0 || H <= 0 {
+		return 0, 0, 0, 0, false
+	}
+	if sd[0] != B || sd[1] != L || sd[2] != topK {
+		return 0, 0, 0, 0, false
+	}
+	return B, L, topK, H, true
+}
+
+func moeWeightedSumAddValidate(expert, scores, shared *Array, outDType DType) (B, L, topK, H int, ok bool) {
+	B, L, topK, H, ok = moeWeightedSumValidate(expert, scores, outDType)
+	if !ok || shared == nil || !moeWeightedSumSupportedDType(shared.DType()) {
+		return 0, 0, 0, 0, false
+	}
+	sd := shared.Dims()
+	if len(sd) != 3 || sd[0] != B || sd[1] != L || sd[2] != H {
+		return 0, 0, 0, 0, false
+	}
+	return B, L, topK, H, true
+}
+
+func moeWeightedSumAdd2Validate(expert, scores, addA, addB *Array, outDType DType) (B, L, topK, H int, ok bool) {
+	B, L, topK, H, ok = moeWeightedSumAddValidate(expert, scores, addA, outDType)
+	if !ok || addB == nil || !moeWeightedSumSupportedDType(addB.DType()) {
+		return 0, 0, 0, 0, false
+	}
+	dims := addB.Dims()
+	if len(dims) != 3 || dims[0] != B || dims[1] != L || dims[2] != H {
+		return 0, 0, 0, 0, false
+	}
+	return B, L, topK, H, true
+}
+
+func moeWeightedSumSupportedDType(dtype DType) bool {
+	return dtype == DTypeFloat32 || dtype == DTypeFloat16 || dtype == DTypeBFloat16
+}
+
+func addMoEWeightedSumTemplateArgs(cfg C.mlx_fast_metal_kernel_config, B, L, topK, H int, outDType DType, scaleNum, scaleDen int) bool {
+	for _, tpl := range []struct {
+		name  string
+		value int
+	}{
+		{name: "B", value: B},
+		{name: "L", value: L},
+		{name: "TopK", value: topK},
+		{name: "H", value: H},
+		{name: "ScaleNum", value: scaleNum},
+		{name: "ScaleDen", value: scaleDen},
+	} {
+		cn := C.CString(tpl.name)
+		rc := C.mlx_fast_metal_kernel_config_add_template_arg_int(cfg, cn, C.int(tpl.value))
+		C.free(unsafe.Pointer(cn))
+		if rc != 0 {
+			return false
+		}
+	}
+
+	cn := C.CString("OutT")
+	rc := C.mlx_fast_metal_kernel_config_add_template_arg_dtype(cfg, cn, C.mlx_dtype(outDType))
+	C.free(unsafe.Pointer(cn))
+	return rc == 0
+}
+
+func moeWeightedSumScaleRatio(scale float32) (num, den int, ok bool) {
+	if math.IsNaN(float64(scale)) || math.IsInf(float64(scale), 0) {
+		return 0, 0, false
+	}
+	if scale == 1 {
+		return 1, 1, true
+	}
+
+	const fixedDen = 65536
+	n := math.Round(float64(scale) * fixedDen)
+	if n < math.MinInt32 || n > math.MaxInt32 {
+		return 0, 0, false
+	}
+	return int(n), fixedDen, true
+}
+
+// FastMoEWeightedSum computes addA + addB + scale *
+// sum_k expert[B,L,k,H] * scores[B,L,k] and returns [B,L,H]. addA and addB are
+// optional. It owns fused-variant dispatch and returns ok=false for unsupported
+// backends or shapes so callers can use a backend-neutral fallback.
+func FastMoEWeightedSum(expert, scores, addA, addB *Array, outDType DType, scale float32) (y *Array, ok bool) {
+	switch {
+	case addA == nil && addB == nil:
+		return fastMoEWeightedSumScaled(expert, scores, outDType, scale)
+	case addA != nil && addB == nil:
+		return fastMoEWeightedSumScaledAdd(expert, scores, addA, outDType, scale)
+	case addA != nil && addB != nil:
+		return fastMoEWeightedSumScaledAdd2(expert, scores, addA, addB, outDType, scale)
+	default:
+		return nil, false
+	}
+}
+
+func fastMoEWeightedSumScaled(expert, scores *Array, outDType DType, scale float32) (y *Array, ok bool) {
+	if !MetalIsAvailable() {
+		return nil, false
+	}
+	if moeWeightedSumMetalDisabled {
+		return nil, false
+	}
+	B, L, topK, H, ok := moeWeightedSumValidate(expert, scores, outDType)
+	if !ok {
+		return nil, false
+	}
+	scaleNum, scaleDen, ok := moeWeightedSumScaleRatio(scale)
+	if !ok {
+		return nil, false
+	}
+
+	moeWeightedSumMetalKernelOnce.Do(initMoEWeightedSumMetalKernel)
+	if moeWeightedSumMetalDisabled {
+		return nil, false
+	}
+
+	cfg := C.mlx_fast_metal_kernel_config_new()
+	defer C.mlx_fast_metal_kernel_config_free(cfg)
+	if !addMoEWeightedSumTemplateArgs(cfg, B, L, topK, H, outDType, scaleNum, scaleDen) {
+		return nil, false
+	}
+
+	yShape := []C.int{C.int(B), C.int(L), C.int(H)}
+	if C.mlx_fast_metal_kernel_config_add_output_arg(cfg, unsafe.SliceData(yShape), C.size_t(len(yShape)), C.mlx_dtype(outDType)) != 0 {
+		return nil, false
+	}
+
+	total := B * L * H
+	gridX := ((total + 255) / 256) * 256
+	if C.mlx_fast_metal_kernel_config_set_grid(cfg, C.int(gridX), 1, 1) != 0 {
+		return nil, false
+	}
+	if C.mlx_fast_metal_kernel_config_set_thread_group(cfg, 256, 1, 1) != 0 {
+		return nil, false
+	}
+
+	inputs := []C.mlx_array{expert.ctx, scores.ctx}
+	inVec := C.mlx_vector_array_new_data(unsafe.SliceData(inputs), C.size_t(len(inputs)))
+	defer C.mlx_vector_array_free(inVec)
+
+	outVec := C.mlx_vector_array_new()
+	defer C.mlx_vector_array_free(outVec)
+	if C.mlx_fast_metal_kernel_apply(&outVec, moeWeightedSumMetalKernel, inVec, cfg, DefaultStream().ctx) != 0 {
+		return nil, false
+	}
+	if int(C.mlx_vector_array_size(outVec)) < 1 {
+		return nil, false
+	}
+
+	y = New("MOE_WEIGHTED_SUM")
+	C.mlx_vector_array_get(&y.ctx, outVec, 0)
+	return y, true
+}
+
+func fastMoEWeightedSumScaledAdd(expert, scores, shared *Array, outDType DType, scale float32) (y *Array, ok bool) {
+	if !MetalIsAvailable() {
+		return nil, false
+	}
+	if moeWeightedSumAddMetalDisabled {
+		return nil, false
+	}
+	B, L, topK, H, ok := moeWeightedSumAddValidate(expert, scores, shared, outDType)
+	if !ok {
+		return nil, false
+	}
+	scaleNum, scaleDen, ok := moeWeightedSumScaleRatio(scale)
+	if !ok {
+		return nil, false
+	}
+
+	moeWeightedSumAddMetalKernelOnce.Do(initMoEWeightedSumAddMetalKernel)
+	if moeWeightedSumAddMetalDisabled {
+		return nil, false
+	}
+
+	cfg := C.mlx_fast_metal_kernel_config_new()
+	defer C.mlx_fast_metal_kernel_config_free(cfg)
+	if !addMoEWeightedSumTemplateArgs(cfg, B, L, topK, H, outDType, scaleNum, scaleDen) {
+		return nil, false
+	}
+
+	yShape := []C.int{C.int(B), C.int(L), C.int(H)}
+	if C.mlx_fast_metal_kernel_config_add_output_arg(cfg, unsafe.SliceData(yShape), C.size_t(len(yShape)), C.mlx_dtype(outDType)) != 0 {
+		return nil, false
+	}
+
+	total := B * L * H
+	gridX := ((total + 255) / 256) * 256
+	if C.mlx_fast_metal_kernel_config_set_grid(cfg, C.int(gridX), 1, 1) != 0 {
+		return nil, false
+	}
+	if C.mlx_fast_metal_kernel_config_set_thread_group(cfg, 256, 1, 1) != 0 {
+		return nil, false
+	}
+
+	inputs := []C.mlx_array{expert.ctx, scores.ctx, shared.ctx}
+	inVec := C.mlx_vector_array_new_data(unsafe.SliceData(inputs), C.size_t(len(inputs)))
+	defer C.mlx_vector_array_free(inVec)
+
+	outVec := C.mlx_vector_array_new()
+	defer C.mlx_vector_array_free(outVec)
+	if C.mlx_fast_metal_kernel_apply(&outVec, moeWeightedSumAddMetalKernel, inVec, cfg, DefaultStream().ctx) != 0 {
+		return nil, false
+	}
+	if int(C.mlx_vector_array_size(outVec)) < 1 {
+		return nil, false
+	}
+
+	y = New("MOE_WEIGHTED_SUM_ADD")
+	C.mlx_vector_array_get(&y.ctx, outVec, 0)
+	return y, true
+}
+
+func fastMoEWeightedSumScaledAdd2(expert, scores, addA, addB *Array, outDType DType, scale float32) (y *Array, ok bool) {
+	if !MetalIsAvailable() {
+		return nil, false
+	}
+	if moeWeightedSumAdd2MetalDisabled {
+		return nil, false
+	}
+	B, L, topK, H, ok := moeWeightedSumAdd2Validate(expert, scores, addA, addB, outDType)
+	if !ok {
+		return nil, false
+	}
+	scaleNum, scaleDen, ok := moeWeightedSumScaleRatio(scale)
+	if !ok {
+		return nil, false
+	}
+
+	moeWeightedSumAdd2MetalKernelOnce.Do(initMoEWeightedSumAdd2MetalKernel)
+	if moeWeightedSumAdd2MetalDisabled {
+		return nil, false
+	}
+
+	cfg := C.mlx_fast_metal_kernel_config_new()
+	defer C.mlx_fast_metal_kernel_config_free(cfg)
+	if !addMoEWeightedSumTemplateArgs(cfg, B, L, topK, H, outDType, scaleNum, scaleDen) {
+		return nil, false
+	}
+
+	yShape := []C.int{C.int(B), C.int(L), C.int(H)}
+	if C.mlx_fast_metal_kernel_config_add_output_arg(cfg, unsafe.SliceData(yShape), C.size_t(len(yShape)), C.mlx_dtype(outDType)) != 0 {
+		return nil, false
+	}
+
+	total := B * L * H
+	gridX := ((total + 255) / 256) * 256
+	if C.mlx_fast_metal_kernel_config_set_grid(cfg, C.int(gridX), 1, 1) != 0 {
+		return nil, false
+	}
+	if C.mlx_fast_metal_kernel_config_set_thread_group(cfg, 256, 1, 1) != 0 {
+		return nil, false
+	}
+
+	inputs := []C.mlx_array{expert.ctx, scores.ctx, addA.ctx, addB.ctx}
+	inVec := C.mlx_vector_array_new_data(unsafe.SliceData(inputs), C.size_t(len(inputs)))
+	defer C.mlx_vector_array_free(inVec)
+
+	outVec := C.mlx_vector_array_new()
+	defer C.mlx_vector_array_free(outVec)
+	if C.mlx_fast_metal_kernel_apply(&outVec, moeWeightedSumAdd2MetalKernel, inVec, cfg, DefaultStream().ctx) != 0 {
+		return nil, false
+	}
+	if int(C.mlx_vector_array_size(outVec)) < 1 {
+		return nil, false
+	}
+
+	y = New("MOE_WEIGHTED_SUM_ADD2")
+	C.mlx_vector_array_get(&y.ctx, outVec, 0)
+	return y, true
+}

--- a/x/mlxrunner/mlx/moe_weighted_sum_test.go
+++ b/x/mlxrunner/mlx/moe_weighted_sum_test.go
@@ -1,0 +1,169 @@
+package mlx
+
+import (
+	"math"
+	"testing"
+)
+
+func TestFastMoEWeightedSum(t *testing.T) {
+	withMLXThread(t, func() {
+		if !MetalIsAvailable() {
+			t.Skip("requires Metal")
+		}
+
+		expert := FromValues([]float32{
+			1, 2, 3, 4,
+			10, 20, 30, 40,
+			-1, -2, -3, -4,
+			2, 0, -2, 4,
+			1, 1, 1, 1,
+			3, 3, 3, 3,
+		}, 1, 2, 3, 4)
+		scores := FromValues([]float32{
+			0.5, 0.25, 0.25,
+			1, -1, 0.5,
+		}, 1, 2, 3)
+		Pin(expert, scores)
+		defer Unpin(expert, scores)
+
+		got, ok := FastMoEWeightedSum(expert, scores, nil, nil, DTypeFloat32, 1)
+		if !ok {
+			t.Fatal("FastMoEWeightedSum returned ok=false")
+		}
+		Eval(got)
+
+		if got.DType() != DTypeFloat32 {
+			t.Fatalf("dtype = %v, want %v", got.DType(), DTypeFloat32)
+		}
+		if dims := got.Dims(); len(dims) != 3 || dims[0] != 1 || dims[1] != 2 || dims[2] != 4 {
+			t.Fatalf("dims = %v, want [1 2 4]", dims)
+		}
+
+		want := []float32{2.75, 5.5, 8.25, 11, 2.5, 0.5, -1.5, 4.5}
+		for i, v := range got.Floats() {
+			if diff := math.Abs(float64(v - want[i])); diff > 1e-6 {
+				t.Fatalf("got[%d] = %v, want %v", i, v, want[i])
+			}
+		}
+	})
+}
+
+func TestFastMoEWeightedSumWithScale(t *testing.T) {
+	withMLXThread(t, func() {
+		if !MetalIsAvailable() {
+			t.Skip("requires Metal")
+		}
+
+		expert := FromValues([]float32{
+			1, 2, 3, 4,
+			10, 20, 30, 40,
+			-1, -2, -3, -4,
+			2, 0, -2, 4,
+			1, 1, 1, 1,
+			3, 3, 3, 3,
+		}, 1, 2, 3, 4)
+		scores := FromValues([]float32{
+			0.5, 0.25, 0.25,
+			1, -1, 0.5,
+		}, 1, 2, 3)
+		Pin(expert, scores)
+		defer Unpin(expert, scores)
+
+		got, ok := FastMoEWeightedSum(expert, scores, nil, nil, DTypeFloat32, 2.5)
+		if !ok {
+			t.Fatal("FastMoEWeightedSum returned ok=false")
+		}
+		Eval(got)
+
+		want := []float32{6.875, 13.75, 20.625, 27.5, 6.25, 1.25, -3.75, 11.25}
+		for i, v := range got.Floats() {
+			if diff := math.Abs(float64(v - want[i])); diff > 1e-6 {
+				t.Fatalf("got[%d] = %v, want %v", i, v, want[i])
+			}
+		}
+	})
+}
+
+func TestFastMoEWeightedSumWithAdd(t *testing.T) {
+	withMLXThread(t, func() {
+		if !MetalIsAvailable() {
+			t.Skip("requires Metal")
+		}
+
+		expert := FromValues([]float32{
+			1, 2, 3, 4,
+			10, 20, 30, 40,
+			-1, -2, -3, -4,
+			2, 0, -2, 4,
+			1, 1, 1, 1,
+			3, 3, 3, 3,
+		}, 1, 2, 3, 4)
+		scores := FromValues([]float32{
+			0.5, 0.25, 0.25,
+			1, -1, 0.5,
+		}, 1, 2, 3)
+		shared := FromValues([]float32{
+			100, 200, 300, 400,
+			-10, -20, -30, -40,
+		}, 1, 2, 4)
+		Pin(expert, scores, shared)
+		defer Unpin(expert, scores, shared)
+
+		got, ok := FastMoEWeightedSum(expert, scores, shared, nil, DTypeFloat32, 2.5)
+		if !ok {
+			t.Fatal("FastMoEWeightedSum returned ok=false")
+		}
+		Eval(got)
+
+		want := []float32{106.875, 213.75, 320.625, 427.5, -3.75, -18.75, -33.75, -28.75}
+		for i, v := range got.Floats() {
+			if diff := math.Abs(float64(v - want[i])); diff > 1e-6 {
+				t.Fatalf("got[%d] = %v, want %v", i, v, want[i])
+			}
+		}
+	})
+}
+
+func TestFastMoEWeightedSumWithTwoAddends(t *testing.T) {
+	withMLXThread(t, func() {
+		if !MetalIsAvailable() {
+			t.Skip("requires Metal")
+		}
+
+		expert := FromValues([]float32{
+			1, 2, 3, 4,
+			10, 20, 30, 40,
+			-1, -2, -3, -4,
+			2, 0, -2, 4,
+			1, 1, 1, 1,
+			3, 3, 3, 3,
+		}, 1, 2, 3, 4)
+		scores := FromValues([]float32{
+			0.5, 0.25, 0.25,
+			1, -1, 0.5,
+		}, 1, 2, 3)
+		addA := FromValues([]float32{
+			100, 200, 300, 400,
+			-10, -20, -30, -40,
+		}, 1, 2, 4)
+		addB := FromValues([]float32{
+			1, 2, 3, 4,
+			10, 20, 30, 40,
+		}, 1, 2, 4)
+		Pin(expert, scores, addA, addB)
+		defer Unpin(expert, scores, addA, addB)
+
+		got, ok := FastMoEWeightedSum(expert, scores, addA, addB, DTypeFloat32, 2.5)
+		if !ok {
+			t.Fatal("FastMoEWeightedSum returned ok=false")
+		}
+		Eval(got)
+
+		want := []float32{107.875, 215.75, 323.625, 431.5, 6.25, 1.25, -3.75, 11.25}
+		for i, v := range got.Floats() {
+			if diff := math.Abs(float64(v - want[i])); diff > 1e-6 {
+				t.Fatalf("got[%d] = %v, want %v", i, v, want[i])
+			}
+		}
+	})
+}

--- a/x/mlxrunner/mlx/nvfp4_linear.go
+++ b/x/mlxrunner/mlx/nvfp4_linear.go
@@ -1,0 +1,569 @@
+package mlx
+
+// #include <stdlib.h>
+// #include "generated.h"
+import "C"
+
+// These fast dense quantized-linear kernels are currently only used by Laguna.
+// As part of the retained Laguna fast path, the Apple M5 Max p2048/g128 run was
+// about 24% faster on prompt and 7% faster on generate than the GGML target.
+// No other model has shown a kept win from this path yet.
+// TODO: consider moving this implementation under x/models/laguna once the mlx
+// package has a refined custom-kernel API that can safely support model-local
+// kernels without exposing low-level MLX internals.
+// TODO(cuda): add CUDA equivalents for these custom Metal kernels before
+// enabling the same fast path on CUDA-backed MLX; non-Metal backends must keep
+// using the generic fallback.
+
+import (
+	"strings"
+	"sync"
+	"unsafe"
+)
+
+var (
+	nvfp4LinearMetalKernelOnce sync.Once
+	nvfp4LinearMetalKernel     C.mlx_fast_metal_kernel
+	nvfp4LinearMetalDisabled   bool
+
+	nvfp4LinearScaledMetalKernelOnce sync.Once
+	nvfp4LinearScaledMetalKernel     C.mlx_fast_metal_kernel
+	nvfp4LinearScaledMetalDisabled   bool
+
+	mxfp8LinearMetalKernelOnce sync.Once
+	mxfp8LinearMetalKernel     C.mlx_fast_metal_kernel
+	mxfp8LinearMetalDisabled   bool
+)
+
+const nvfp4LinearMetalKernelSource = `
+constexpr int NR0 = 64;
+constexpr int NR1 = 32;
+constexpr int NK = 32;
+constexpr int NL0 = NK / 16;
+constexpr int NL1 = NK / 8;
+
+const int r1 = int(threadgroup_position_in_grid.x) * NR1;
+const int r0 = int(threadgroup_position_in_grid.y) * NR0;
+if (r1 >= T || r0 >= N) {
+  return;
+}
+
+const short tiitg = short(thread_index_in_threadgroup);
+const short tiisg = short(thread_index_in_simdgroup);
+const short sgitg = short(simdgroup_index_in_threadgroup);
+
+const short nr0 = short((N - r0 < NR0) ? (N - r0) : NR0);
+const short nr1 = short((T - r1 < NR1) ? (T - r1) : NR1);
+
+const short lr0 = short(((tiitg / NL0) < nr0) ? (tiitg / NL0) : (nr0 - 1));
+const short lr1 = short(((tiitg / NL1) < nr1) ? (tiitg / NL1) : (nr1 - 1));
+const short il0 = short(tiitg % NL0);
+const short iy = short(8 * (tiitg % NL1));
+
+threadgroup half sa[NR0 * NK];
+threadgroup half sb[NR1 * NK];
+threadgroup float temp[NR1 * NR0];
+
+const device uint8_t* wb = reinterpret_cast<const device uint8_t*>(w);
+const size_t k_bytes = K / 2;
+const size_t k_groups = K / 16;
+
+auto tA = tensor<threadgroup half, dextents<int32_t, 2>, tensor_inline>(sa, dextents<int32_t, 2>(NK, NR0));
+auto tB = tensor<threadgroup half, dextents<int32_t, 2>, tensor_inline>(sb, dextents<int32_t, 2>(NR1, NK));
+
+mpp::tensor_ops::matmul2d<
+  mpp::tensor_ops::matmul2d_descriptor(
+    NR1, NR0, NK, false, true, false,
+    mpp::tensor_ops::matmul2d_descriptor::mode::multiply_accumulate),
+  execution_simdgroups<4>> mm;
+
+auto cT = mm.get_destination_cooperative_tensor<decltype(tA), decltype(tB), float>();
+
+MOE_MAPPED_FOR_UNROLL (uint16_t i = 0; i < cT.get_capacity(); ++i) {
+  if (cT.is_valid_element(i)) {
+    cT[i] = 0.0f;
+  }
+}
+
+for (int loop_k = 0; loop_k < K; loop_k += NK) {
+  const int col = r0 + lr0;
+  const int k0 = loop_k + 16 * il0;
+  const size_t w_base = size_t(col) * k_bytes + size_t(k0 / 2);
+  const size_t s_base = size_t(col) * k_groups + size_t(k0 / 16);
+  const half scale = moe_mapped_nvfp4_scale(scales[s_base]);
+
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  MOE_MAPPED_FOR_UNROLL (short i = 0; i < 16; i++) {
+    const short sx = short(2 * il0 + i / 8);
+    const short sy = short((tiitg / NL0) / 8);
+    const short lx = short(i % 8);
+    const short ly = short((tiitg / NL0) % 8);
+
+    const uint8_t packed = wb[w_base + size_t(i / 2)];
+    const uint nibble = ((i & 1) == 0) ? uint(packed & 0x0f) : uint((packed >> 4) & 0x0f);
+    *(sa + NK * (8 * sy + ly) + 8 * sx + lx) = scale * moe_mapped_nvfp4_value(nibble);
+  }
+
+  const short sx = short(tiitg % NL1);
+  const short sy = short((tiitg / NL1) / 8);
+  const short ly = short((tiitg / NL1) % 8);
+  const size_t x_base = size_t(r1 + lr1) * K + size_t(loop_k + iy);
+
+  MOE_MAPPED_FOR_UNROLL (short i = 0; i < 8; i++) {
+    *(sb + NK * (8 * sy + ly) + 8 * sx + i) = half(x[x_base + i]);
+  }
+
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  auto sA = tA.slice(0, 0);
+  auto sB = tB.slice(0, 0);
+  mm.run(sB, sA, cT);
+}
+
+threadgroup_barrier(mem_flags::mem_threadgroup);
+
+auto tC = tensor<threadgroup float, dextents<int32_t, 2>, tensor_inline>(temp, dextents<int32_t, 2>(NR0, NR1));
+cT.store(tC);
+
+threadgroup_barrier(mem_flags::mem_threadgroup);
+
+for (short j = sgitg; j < nr1; j += 4) {
+  device OutT* dst = y + size_t(r1 + j) * N + size_t(r0);
+  threadgroup float* src = temp + int(j) * NR0;
+  int i = tiisg;
+  for (; i < nr0; i += 32) {
+    dst[i] = static_cast<OutT>(src[i]);
+  }
+}
+`
+
+var nvfp4LinearScaledMetalKernelSource = strings.NewReplacer(
+	"for (short j = sgitg; j < nr1; j += 4) {",
+	"const float global = static_cast<float>(global_scale);\n\nfor (short j = sgitg; j < nr1; j += 4) {",
+	"    dst[i] = static_cast<OutT>(src[i]);",
+	"    OutT unscaled = static_cast<OutT>(src[i]);\n    dst[i] = static_cast<OutT>(static_cast<float>(unscaled) * global);",
+).Replace(nvfp4LinearMetalKernelSource)
+
+const mxfp8LinearMetalKernelSource = `
+constexpr int NR0 = 64;
+constexpr int NR1 = 32;
+constexpr int NK = 32;
+constexpr int NL0 = NK / 16;
+constexpr int NL1 = NK / 8;
+
+const int r1 = int(threadgroup_position_in_grid.x) * NR1;
+const int r0 = int(threadgroup_position_in_grid.y) * NR0;
+if (r1 >= T || r0 >= N) {
+  return;
+}
+
+const short tiitg = short(thread_index_in_threadgroup);
+const short tiisg = short(thread_index_in_simdgroup);
+const short sgitg = short(simdgroup_index_in_threadgroup);
+
+const short nr0 = short((N - r0 < NR0) ? (N - r0) : NR0);
+const short nr1 = short((T - r1 < NR1) ? (T - r1) : NR1);
+
+const short lr0 = short(((tiitg / NL0) < nr0) ? (tiitg / NL0) : (nr0 - 1));
+const short lr1 = short(((tiitg / NL1) < nr1) ? (tiitg / NL1) : (nr1 - 1));
+const short il0 = short(tiitg % NL0);
+const short iy = short(8 * (tiitg % NL1));
+
+threadgroup half sa[NR0 * NK];
+threadgroup half sb[NR1 * NK];
+threadgroup float temp[NR1 * NR0];
+
+const device uint8_t* wb = reinterpret_cast<const device uint8_t*>(w);
+const size_t k_bytes = K;
+const size_t k_groups = K / 32;
+
+auto tA = tensor<threadgroup half, dextents<int32_t, 2>, tensor_inline>(sa, dextents<int32_t, 2>(NK, NR0));
+auto tB = tensor<threadgroup half, dextents<int32_t, 2>, tensor_inline>(sb, dextents<int32_t, 2>(NR1, NK));
+
+mpp::tensor_ops::matmul2d<
+  mpp::tensor_ops::matmul2d_descriptor(
+    NR1, NR0, NK, false, true, false,
+    mpp::tensor_ops::matmul2d_descriptor::mode::multiply_accumulate),
+  execution_simdgroups<4>> mm;
+
+auto cT = mm.get_destination_cooperative_tensor<decltype(tA), decltype(tB), float>();
+
+MOE_MAPPED_FOR_UNROLL (uint16_t i = 0; i < cT.get_capacity(); ++i) {
+  if (cT.is_valid_element(i)) {
+    cT[i] = 0.0f;
+  }
+}
+
+for (int loop_k = 0; loop_k < K; loop_k += NK) {
+  const int col = r0 + lr0;
+  const int k0 = loop_k + 16 * il0;
+  const size_t w_base = size_t(col) * k_bytes + size_t(k0);
+  const size_t s_base = size_t(col) * k_groups + size_t(loop_k / 32);
+  const float scale = moe_mapped_mxfp8_scale(scales[s_base]);
+
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  MOE_MAPPED_FOR_UNROLL (short i = 0; i < 16; i++) {
+    const short sx = short(2 * il0 + i / 8);
+    const short sy = short((tiitg / NL0) / 8);
+    const short lx = short(i % 8);
+    const short ly = short((tiitg / NL0) % 8);
+
+    const uint8_t packed = wb[w_base + size_t(i)];
+    *(sa + NK * (8 * sy + ly) + 8 * sx + lx) = half(scale * float(moe_mapped_mxfp8_value(packed)));
+  }
+
+  const short sx = short(tiitg % NL1);
+  const short sy = short((tiitg / NL1) / 8);
+  const short ly = short((tiitg / NL1) % 8);
+  const size_t x_base = size_t(r1 + lr1) * K + size_t(loop_k + iy);
+
+  MOE_MAPPED_FOR_UNROLL (short i = 0; i < 8; i++) {
+    *(sb + NK * (8 * sy + ly) + 8 * sx + i) = half(x[x_base + i]);
+  }
+
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  auto sA = tA.slice(0, 0);
+  auto sB = tB.slice(0, 0);
+  mm.run(sB, sA, cT);
+}
+
+threadgroup_barrier(mem_flags::mem_threadgroup);
+
+auto tC = tensor<threadgroup float, dextents<int32_t, 2>, tensor_inline>(temp, dextents<int32_t, 2>(NR0, NR1));
+cT.store(tC);
+
+threadgroup_barrier(mem_flags::mem_threadgroup);
+
+for (short j = sgitg; j < nr1; j += 4) {
+  device OutT* dst = y + size_t(r1 + j) * N + size_t(r0);
+  threadgroup float* src = temp + int(j) * NR0;
+  int i = tiisg;
+  for (; i < nr0; i += 32) {
+    dst[i] = static_cast<OutT>(src[i]);
+  }
+}
+`
+
+func initNVFP4LinearMetalKernel() {
+	initNVFP4LinearKernel(&nvfp4LinearMetalKernel, &nvfp4LinearMetalDisabled, "nvfp4_linear", []string{"x", "w", "scales"}, nvfp4LinearMetalKernelSource)
+}
+
+func initNVFP4LinearScaledMetalKernel() {
+	initNVFP4LinearKernel(&nvfp4LinearScaledMetalKernel, &nvfp4LinearScaledMetalDisabled, "nvfp4_linear_scaled", []string{"x", "w", "scales", "global_scale"}, nvfp4LinearScaledMetalKernelSource)
+}
+
+func initNVFP4LinearKernel(target *C.mlx_fast_metal_kernel, disabled *bool, name string, inputsList []string, source string) {
+	if !metalTensorOpsAvailable() {
+		*disabled = true
+		return
+	}
+
+	inputs, freeInputs, ok := cStringVector(inputsList)
+	if !ok {
+		*disabled = true
+		freeInputs()
+		return
+	}
+	defer freeInputs()
+
+	outputs, freeOutputs, ok := cStringVector([]string{"y"})
+	if !ok {
+		*disabled = true
+		freeOutputs()
+		return
+	}
+	defer freeOutputs()
+
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	cSource := C.CString(source)
+	defer C.free(unsafe.Pointer(cSource))
+	cHeader := C.CString(moeMappedMetalKernelHeader)
+	defer C.free(unsafe.Pointer(cHeader))
+
+	*target = C.mlx_fast_metal_kernel_new(
+		cName,
+		inputs,
+		outputs,
+		cSource,
+		cHeader,
+		C.bool(true),
+		C.bool(false),
+	)
+}
+
+func initMXFP8LinearMetalKernel() {
+	if !metalTensorOpsAvailable() {
+		mxfp8LinearMetalDisabled = true
+		return
+	}
+
+	inputs, freeInputs, ok := cStringVector([]string{"x", "w", "scales"})
+	if !ok {
+		mxfp8LinearMetalDisabled = true
+		freeInputs()
+		return
+	}
+	defer freeInputs()
+
+	outputs, freeOutputs, ok := cStringVector([]string{"y"})
+	if !ok {
+		mxfp8LinearMetalDisabled = true
+		freeOutputs()
+		return
+	}
+	defer freeOutputs()
+
+	cName := C.CString("mxfp8_linear")
+	defer C.free(unsafe.Pointer(cName))
+	cSource := C.CString(mxfp8LinearMetalKernelSource)
+	defer C.free(unsafe.Pointer(cSource))
+	cHeader := C.CString(moeMappedMetalKernelHeader)
+	defer C.free(unsafe.Pointer(cHeader))
+
+	mxfp8LinearMetalKernel = C.mlx_fast_metal_kernel_new(
+		cName,
+		inputs,
+		outputs,
+		cSource,
+		cHeader,
+		C.bool(true),
+		C.bool(false),
+	)
+}
+
+func addNVFP4LinearTemplateArgs(cfg C.mlx_fast_metal_kernel_config, tokens, N, K int, outDType DType) bool {
+	for _, tpl := range []struct {
+		name  string
+		value int
+	}{
+		{name: "T", value: tokens},
+		{name: "N", value: N},
+		{name: "K", value: K},
+	} {
+		cn := C.CString(tpl.name)
+		rc := C.mlx_fast_metal_kernel_config_add_template_arg_int(cfg, cn, C.int(tpl.value))
+		C.free(unsafe.Pointer(cn))
+		if rc != 0 {
+			return false
+		}
+	}
+
+	cn := C.CString("OutT")
+	rc := C.mlx_fast_metal_kernel_config_add_template_arg_dtype(cfg, cn, C.mlx_dtype(outDType))
+	C.free(unsafe.Pointer(cn))
+	return rc == 0
+}
+
+func fpLinearValidate(x, w, scales *Array, weightDiv, scaleDiv int) (tokens, N, K int, outShape []C.int, ok bool) {
+	if x == nil || w == nil || scales == nil {
+		return 0, 0, 0, nil, false
+	}
+	if x.DType() != DTypeFloat32 && x.DType() != DTypeFloat16 && x.DType() != DTypeBFloat16 {
+		return 0, 0, 0, nil, false
+	}
+	if w.DType() != DTypeUint32 || scales.DType() != DTypeUint8 {
+		return 0, 0, 0, nil, false
+	}
+	xd := x.Dims()
+	wd := w.Dims()
+	sd := scales.Dims()
+	switch len(xd) {
+	case 2:
+		tokens, K = xd[0], xd[1]
+		outShape = []C.int{C.int(tokens), 0}
+	case 3:
+		if xd[0] != 1 {
+			return 0, 0, 0, nil, false
+		}
+		tokens, K = xd[1], xd[2]
+		outShape = []C.int{C.int(xd[0]), C.int(tokens), 0}
+	default:
+		return 0, 0, 0, nil, false
+	}
+	if len(wd) != 2 || len(sd) != 2 {
+		return 0, 0, 0, nil, false
+	}
+	N = wd[0]
+	if tokens <= 0 || N <= 0 || K < 512 || K%32 != 0 {
+		return 0, 0, 0, nil, false
+	}
+	if wd[1] != K/weightDiv || sd[0] != N || sd[1] != K/scaleDiv {
+		return 0, 0, 0, nil, false
+	}
+	outShape[len(outShape)-1] = C.int(N)
+	return tokens, N, K, outShape, true
+}
+
+func nvfp4LinearValidate(x, w, scales *Array) (tokens, N, K int, outShape []C.int, ok bool) {
+	return fpLinearValidate(x, w, scales, 8, 16)
+}
+
+func nvfp4LinearGlobalScaleValidate(globalScale *Array) bool {
+	if globalScale == nil || !globalScale.Valid() {
+		return false
+	}
+	switch globalScale.DType() {
+	case DTypeFloat32, DTypeFloat16, DTypeBFloat16:
+	default:
+		return false
+	}
+	dims := globalScale.Dims()
+	return len(dims) == 0
+}
+
+func mxfp8LinearValidate(x, w, scales *Array) (tokens, N, K int, outShape []C.int, ok bool) {
+	return fpLinearValidate(x, w, scales, 4, 32)
+}
+
+func applyFPLinearKernel(kernel C.mlx_fast_metal_kernel, name string, x, w, scales *Array, tokens, N, K int, yShape []C.int) (y *Array, ok bool) {
+	cfg := C.mlx_fast_metal_kernel_config_new()
+	defer C.mlx_fast_metal_kernel_config_free(cfg)
+	if !addNVFP4LinearTemplateArgs(cfg, tokens, N, K, x.DType()) {
+		return nil, false
+	}
+	if C.mlx_fast_metal_kernel_config_add_output_arg(cfg, unsafe.SliceData(yShape), C.size_t(len(yShape)), C.mlx_dtype(x.DType())) != 0 {
+		return nil, false
+	}
+	gridX := ((tokens + 31) / 32) * 128
+	gridY := (N + 63) / 64
+	if C.mlx_fast_metal_kernel_config_set_grid(cfg, C.int(gridX), C.int(gridY), 1) != 0 {
+		return nil, false
+	}
+	if C.mlx_fast_metal_kernel_config_set_thread_group(cfg, 128, 1, 1) != 0 {
+		return nil, false
+	}
+
+	inputs := []C.mlx_array{x.ctx, w.ctx, scales.ctx}
+	inVec := C.mlx_vector_array_new_data(unsafe.SliceData(inputs), C.size_t(len(inputs)))
+	defer C.mlx_vector_array_free(inVec)
+
+	outVec := C.mlx_vector_array_new()
+	defer C.mlx_vector_array_free(outVec)
+	if C.mlx_fast_metal_kernel_apply(&outVec, kernel, inVec, cfg, DefaultStream().ctx) != 0 {
+		return nil, false
+	}
+	if int(C.mlx_vector_array_size(outVec)) < 1 {
+		return nil, false
+	}
+
+	y = New(name)
+	C.mlx_vector_array_get(&y.ctx, outVec, 0)
+	return y, true
+}
+
+func fastNVFP4Linear(x, w, scales *Array) (y *Array, ok bool) {
+	if !MetalIsAvailable() {
+		return nil, false
+	}
+	if nvfp4LinearMetalDisabled {
+		return nil, false
+	}
+	tokens, N, K, yShape, ok := nvfp4LinearValidate(x, w, scales)
+	if !ok {
+		return nil, false
+	}
+
+	nvfp4LinearMetalKernelOnce.Do(initNVFP4LinearMetalKernel)
+	if nvfp4LinearMetalDisabled {
+		return nil, false
+	}
+	return applyFPLinearKernel(nvfp4LinearMetalKernel, "NVFP4_LINEAR", x, w, scales, tokens, N, K, yShape)
+}
+
+// fastNVFP4LinearScaled is equivalent to fastNVFP4Linear followed by a scalar
+// global-scale multiply cast back to the input dtype.
+func fastNVFP4LinearScaled(x, w, scales, globalScale *Array) (y *Array, ok bool) {
+	if !MetalIsAvailable() {
+		return nil, false
+	}
+	if nvfp4LinearScaledMetalDisabled {
+		return nil, false
+	}
+	tokens, N, K, yShape, ok := nvfp4LinearValidate(x, w, scales)
+	if !ok || !nvfp4LinearGlobalScaleValidate(globalScale) {
+		return nil, false
+	}
+
+	nvfp4LinearScaledMetalKernelOnce.Do(initNVFP4LinearScaledMetalKernel)
+	if nvfp4LinearScaledMetalDisabled {
+		return nil, false
+	}
+
+	cfg := C.mlx_fast_metal_kernel_config_new()
+	defer C.mlx_fast_metal_kernel_config_free(cfg)
+	if !addNVFP4LinearTemplateArgs(cfg, tokens, N, K, x.DType()) {
+		return nil, false
+	}
+	if C.mlx_fast_metal_kernel_config_add_output_arg(cfg, unsafe.SliceData(yShape), C.size_t(len(yShape)), C.mlx_dtype(x.DType())) != 0 {
+		return nil, false
+	}
+	gridX := ((tokens + 31) / 32) * 128
+	gridY := (N + 63) / 64
+	if C.mlx_fast_metal_kernel_config_set_grid(cfg, C.int(gridX), C.int(gridY), 1) != 0 {
+		return nil, false
+	}
+	if C.mlx_fast_metal_kernel_config_set_thread_group(cfg, 128, 1, 1) != 0 {
+		return nil, false
+	}
+
+	inputs := []C.mlx_array{x.ctx, w.ctx, scales.ctx, globalScale.ctx}
+	inVec := C.mlx_vector_array_new_data(unsafe.SliceData(inputs), C.size_t(len(inputs)))
+	defer C.mlx_vector_array_free(inVec)
+
+	outVec := C.mlx_vector_array_new()
+	defer C.mlx_vector_array_free(outVec)
+	if C.mlx_fast_metal_kernel_apply(&outVec, nvfp4LinearScaledMetalKernel, inVec, cfg, DefaultStream().ctx) != 0 {
+		return nil, false
+	}
+	if int(C.mlx_vector_array_size(outVec)) < 1 {
+		return nil, false
+	}
+
+	y = New("NVFP4_LINEAR_SCALED")
+	C.mlx_vector_array_get(&y.ctx, outVec, 0)
+	return y, true
+}
+
+func fastMXFP8Linear(x, w, scales *Array) (y *Array, ok bool) {
+	if !MetalIsAvailable() {
+		return nil, false
+	}
+	if mxfp8LinearMetalDisabled {
+		return nil, false
+	}
+	tokens, N, K, yShape, ok := mxfp8LinearValidate(x, w, scales)
+	if !ok {
+		return nil, false
+	}
+
+	mxfp8LinearMetalKernelOnce.Do(initMXFP8LinearMetalKernel)
+	if mxfp8LinearMetalDisabled {
+		return nil, false
+	}
+	return applyFPLinearKernel(mxfp8LinearMetalKernel, "MXFP8_LINEAR", x, w, scales, tokens, N, K, yShape)
+}
+
+// FastQuantizedLinear computes x @ w.T for supported block-quantized weights.
+// It owns dtype dispatch so model code only needs to provide the quantization
+// metadata it already carries. Unsupported modes, shapes, or global-scale forms
+// return ok=false and should use the generic QuantizedLinear fallback.
+func FastQuantizedLinear(x, w, scales, globalScale *Array, groupSize, bits int, mode string) (y *Array, ok bool) {
+	switch {
+	case mode == "nvfp4" && bits == 4 && groupSize == 16:
+		if globalScale != nil {
+			return fastNVFP4LinearScaled(x, w, scales, globalScale)
+		}
+		return fastNVFP4Linear(x, w, scales)
+	case mode == "mxfp8" && bits == 8 && groupSize == 32:
+		if globalScale != nil {
+			return nil, false
+		}
+		return fastMXFP8Linear(x, w, scales)
+	default:
+		return nil, false
+	}
+}

--- a/x/mlxrunner/mlx/nvfp4_linear_test.go
+++ b/x/mlxrunner/mlx/nvfp4_linear_test.go
@@ -1,0 +1,148 @@
+package mlx
+
+import "testing"
+
+func TestFastBlockLinearMatchesQuantizedMatmul(t *testing.T) {
+	withMLXThread(t, func() {
+		if !MetalIsAvailable() {
+			t.Skip("requires Metal")
+		}
+
+		for _, tc := range []struct {
+			name   string
+			tokens int
+			inDim  int
+			outDim int
+			group  int
+			bits   int
+			mode   string
+		}{
+			{name: "nvfp4_shared_down", tokens: 96, inDim: 512, outDim: 2048, group: 16, bits: 4, mode: "nvfp4"},
+			{name: "nvfp4_attention_kv", tokens: 96, inDim: 2048, outDim: 1024, group: 16, bits: 4, mode: "nvfp4"},
+			{name: "mxfp8_attention_kv", tokens: 96, inDim: 2048, outDim: 1024, group: 32, bits: 8, mode: "mxfp8"},
+		} {
+			xVals := make([]float32, tc.tokens*tc.inDim)
+			wVals := make([]float32, tc.outDim*tc.inDim)
+			for i := range xVals {
+				xVals[i] = float32((i%31)-15) * 0.01
+			}
+			for i := range wVals {
+				wVals[i] = float32((i%37)-18) * 0.008
+			}
+
+			x := FromValues(xVals, 1, tc.tokens, tc.inDim).AsType(DTypeBFloat16)
+			w := FromValues(wVals, tc.outDim, tc.inDim).AsType(DTypeBFloat16)
+			qw, scales, qbiases := Quantize(w, tc.group, tc.bits, tc.mode)
+			Eval(x, qw, scales)
+			Pin(x, qw, scales, qbiases)
+
+			got, ok := FastQuantizedLinear(x, qw, scales, nil, tc.group, tc.bits, tc.mode)
+			if !ok {
+				t.Fatalf("%s: fast linear returned ok=false", tc.name)
+			}
+			want := QuantizedMatmul(x, qw, scales, qbiases, true, tc.group, tc.bits, tc.mode)
+			gotF := got.AsType(DTypeFloat32)
+			wantF := want.AsType(DTypeFloat32)
+			Eval(gotF, wantF)
+
+			if dims := got.Dims(); len(dims) != 3 || dims[0] != 1 || dims[1] != tc.tokens || dims[2] != tc.outDim {
+				t.Fatalf("%s: dims = %v, want [1 %d %d]", tc.name, dims, tc.tokens, tc.outDim)
+			}
+			assertFloat32Close(t, gotF.Floats(), wantF.Floats(), 2e-2)
+			Unpin(x, qw, scales, qbiases)
+		}
+	})
+}
+
+func TestFastQuantizedLinearSmallOutputDimMatchesQuantizedMatmul(t *testing.T) {
+	withMLXThread(t, func() {
+		if !MetalIsAvailable() {
+			t.Skip("requires Metal")
+		}
+
+		const (
+			tokens = 96
+			inDim  = 2048
+			outDim = 64
+		)
+
+		xVals := make([]float32, tokens*inDim)
+		wVals := make([]float32, outDim*inDim)
+		for i := range xVals {
+			xVals[i] = float32((i%31)-15) * 0.01
+		}
+		for i := range wVals {
+			wVals[i] = float32((i%37)-18) * 0.008
+		}
+
+		x := FromValues(xVals, 1, tokens, inDim).AsType(DTypeBFloat16)
+		w := FromValues(wVals, outDim, inDim).AsType(DTypeBFloat16)
+		qw, scales, qbiases := Quantize(w, 16, 4, "nvfp4")
+		Eval(x, qw, scales)
+		Pin(x, qw, scales, qbiases)
+		defer Unpin(x, qw, scales, qbiases)
+
+		got, ok := FastQuantizedLinear(x, qw, scales, nil, 16, 4, "nvfp4")
+		if !ok {
+			t.Fatal("FastQuantizedLinear returned ok=false for small output dimension")
+		}
+		want := QuantizedMatmul(x, qw, scales, qbiases, true, 16, 4, "nvfp4")
+		gotF := got.AsType(DTypeFloat32)
+		wantF := want.AsType(DTypeFloat32)
+		Eval(gotF, wantF)
+
+		if dims := got.Dims(); len(dims) != 3 || dims[0] != 1 || dims[1] != tokens || dims[2] != outDim {
+			t.Fatalf("dims = %v, want [1 %d %d]", dims, tokens, outDim)
+		}
+		assertFloat32Close(t, gotF.Floats(), wantF.Floats(), 2e-2)
+	})
+}
+
+func TestFastQuantizedLinearScaledMatchesSeparateScale(t *testing.T) {
+	withMLXThread(t, func() {
+		if !MetalIsAvailable() {
+			t.Skip("requires Metal")
+		}
+
+		const (
+			tokens = 96
+			inDim  = 2048
+			outDim = 1024
+		)
+
+		xVals := make([]float32, tokens*inDim)
+		wVals := make([]float32, outDim*inDim)
+		for i := range xVals {
+			xVals[i] = float32((i%31)-15) * 0.01
+		}
+		for i := range wVals {
+			wVals[i] = float32((i%37)-18) * 0.008
+		}
+
+		x := FromValues(xVals, 1, tokens, inDim).AsType(DTypeBFloat16)
+		w := FromValues(wVals, outDim, inDim).AsType(DTypeBFloat16)
+		globalScale := FromValue[float32](0.375)
+		qw, scales, qbiases := Quantize(w, 16, 4, "nvfp4")
+		Eval(x, qw, scales, globalScale)
+		Pin(x, qw, scales, qbiases, globalScale)
+		defer Unpin(x, qw, scales, qbiases, globalScale)
+
+		got, ok := FastQuantizedLinear(x, qw, scales, globalScale, 16, 4, "nvfp4")
+		if !ok {
+			t.Fatal("FastQuantizedLinear returned ok=false with global scale")
+		}
+		base, ok := FastQuantizedLinear(x, qw, scales, nil, 16, 4, "nvfp4")
+		if !ok {
+			t.Fatal("FastQuantizedLinear returned ok=false")
+		}
+		want := Mul(base, globalScale).AsType(base.DType())
+		gotF := got.AsType(DTypeFloat32)
+		wantF := want.AsType(DTypeFloat32)
+		Eval(gotF, wantF)
+
+		if dims := got.Dims(); len(dims) != 3 || dims[0] != 1 || dims[1] != tokens || dims[2] != outDim {
+			t.Fatalf("dims = %v, want [1 %d %d]", dims, tokens, outDim)
+		}
+		assertFloat32Close(t, gotF.Floats(), wantF.Floats(), 2e-2)
+	})
+}

--- a/x/mlxrunner/mlx/sigmoid_topk_router.go
+++ b/x/mlxrunner/mlx/sigmoid_topk_router.go
@@ -1,0 +1,502 @@
+package mlx
+
+// #include <stdlib.h>
+// #include "generated.h"
+import "C"
+
+// These fused sigmoid/top-k router kernels are currently only used by Laguna.
+// As part of the retained Laguna fast path, the Apple M5 Max p2048/g128 run was
+// about 24% faster on prompt and 7% faster on generate than the GGML target.
+// No other model has shown a kept win from this path yet.
+// TODO: consider moving this implementation under x/models/laguna once the mlx
+// package has a refined custom-kernel API that can safely support model-local
+// kernels without exposing low-level MLX internals.
+// TODO(cuda): add CUDA equivalents for these custom Metal kernels before
+// enabling the same fast path on CUDA-backed MLX; non-Metal backends must keep
+// using the generic fallback.
+
+import (
+	"sync"
+	"unsafe"
+)
+
+var (
+	sigmoidTopKRouterMetalKernelOnce sync.Once
+	sigmoidTopKRouterMetalKernel     C.mlx_fast_metal_kernel
+	sigmoidTopKRouterMetalDisabled   bool
+
+	scaledSigmoidTopKRouterMetalKernelOnce sync.Once
+	scaledSigmoidTopKRouterMetalKernel     C.mlx_fast_metal_kernel
+	scaledSigmoidTopKRouterMetalDisabled   bool
+)
+
+const sigmoidTopKRouterMetalKernelSource = `
+constexpr int Threads = 128;
+constexpr int SIMDWidth = 32;
+constexpr int Groups = Threads / SIMDWidth;
+
+auto token = threadgroup_position_in_grid.x;
+if (token >= T) {
+  return;
+}
+auto tid = thread_index_in_threadgroup;
+auto lane = tid % SIMDWidth;
+auto group = tid / SIMDWidth;
+
+threadgroup float adjusted_values[E];
+threadgroup float prob_values[E];
+threadgroup float group_adjusted[Groups];
+threadgroup float group_prob[Groups];
+threadgroup int group_index[Groups];
+threadgroup float top_prob[TopK];
+threadgroup int top_index[TopK];
+
+auto row = gates + size_t(token) * E;
+for (int e = int(tid); e < E; e += Threads) {
+  float g = static_cast<float>(row[e]);
+  float p = 1.0f / (1.0f + exp(-g));
+  prob_values[e] = p;
+  adjusted_values[e] = p + static_cast<float>(bias[e]);
+}
+threadgroup_barrier(mem_flags::mem_threadgroup);
+
+for (int k = 0; k < TopK; ++k) {
+  float best_adjusted = -INFINITY;
+  float best_prob = 0.0f;
+  int best_index = 0;
+  for (int e = int(tid); e < E; e += Threads) {
+    float adjusted = adjusted_values[e];
+    if (adjusted > best_adjusted) {
+      best_adjusted = adjusted;
+      best_prob = prob_values[e];
+      best_index = e;
+    }
+  }
+
+  for (ushort offset = SIMDWidth / 2; offset > 0; offset >>= 1) {
+    float other_adjusted = simd_shuffle_down(best_adjusted, offset);
+    float other_prob = simd_shuffle_down(best_prob, offset);
+    int other_index = simd_shuffle_down(best_index, offset);
+    if (lane + offset < SIMDWidth && other_adjusted > best_adjusted) {
+      best_adjusted = other_adjusted;
+      best_prob = other_prob;
+      best_index = other_index;
+    }
+  }
+
+  if (lane == 0) {
+    group_adjusted[group] = best_adjusted;
+    group_prob[group] = best_prob;
+    group_index[group] = best_index;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  if (group == 0) {
+    best_adjusted = (lane < Groups) ? group_adjusted[lane] : -INFINITY;
+    best_prob = (lane < Groups) ? group_prob[lane] : 0.0f;
+    best_index = (lane < Groups) ? group_index[lane] : 0;
+
+    for (ushort offset = SIMDWidth / 2; offset > 0; offset >>= 1) {
+      float other_adjusted = simd_shuffle_down(best_adjusted, offset);
+      float other_prob = simd_shuffle_down(best_prob, offset);
+      int other_index = simd_shuffle_down(best_index, offset);
+      if (lane + offset < SIMDWidth && other_adjusted > best_adjusted) {
+        best_adjusted = other_adjusted;
+        best_prob = other_prob;
+        best_index = other_index;
+      }
+    }
+
+    if (lane == 0) {
+      top_prob[k] = best_prob;
+      top_index[k] = best_index;
+      adjusted_values[best_index] = -INFINITY;
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+}
+
+if (tid == 0) {
+  float denom = 1.0f;
+  if (Normalize != 0) {
+    denom = 0.0f;
+    for (int k = 0; k < TopK; ++k) {
+      denom += top_prob[k];
+    }
+  }
+
+  auto score_row = scores + size_t(token) * TopK;
+  auto index_row = indices + size_t(token) * TopK;
+  for (int k = 0; k < TopK; ++k) {
+    score_row[k] = top_prob[k] / denom;
+    index_row[k] = top_index[k];
+  }
+}
+`
+
+const scaledSigmoidTopKRouterMetalKernelSource = `
+constexpr int Threads = 128;
+constexpr int SIMDWidth = 32;
+constexpr int Groups = Threads / SIMDWidth;
+
+auto token = threadgroup_position_in_grid.x;
+if (token >= T) {
+  return;
+}
+auto tid = thread_index_in_threadgroup;
+auto lane = tid % SIMDWidth;
+auto group = tid / SIMDWidth;
+
+threadgroup float adjusted_values[E];
+threadgroup float prob_values[E];
+threadgroup float group_adjusted[Groups];
+threadgroup float group_prob[Groups];
+threadgroup int group_index[Groups];
+threadgroup float top_prob[TopK];
+threadgroup int top_index[TopK];
+
+auto row = gates + size_t(token) * E;
+for (int e = int(tid); e < E; e += Threads) {
+  float g = static_cast<float>(row[e]);
+  float p = 1.0f / (1.0f + exp(-g));
+  prob_values[e] = p;
+  adjusted_values[e] = p + static_cast<float>(bias[e]);
+}
+threadgroup_barrier(mem_flags::mem_threadgroup);
+
+for (int k = 0; k < TopK; ++k) {
+  float best_adjusted = -INFINITY;
+  float best_prob = 0.0f;
+  int best_index = 0;
+  for (int e = int(tid); e < E; e += Threads) {
+    float adjusted = adjusted_values[e];
+    if (adjusted > best_adjusted) {
+      best_adjusted = adjusted;
+      best_prob = prob_values[e];
+      best_index = e;
+    }
+  }
+
+  for (ushort offset = SIMDWidth / 2; offset > 0; offset >>= 1) {
+    float other_adjusted = simd_shuffle_down(best_adjusted, offset);
+    float other_prob = simd_shuffle_down(best_prob, offset);
+    int other_index = simd_shuffle_down(best_index, offset);
+    if (lane + offset < SIMDWidth && other_adjusted > best_adjusted) {
+      best_adjusted = other_adjusted;
+      best_prob = other_prob;
+      best_index = other_index;
+    }
+  }
+
+  if (lane == 0) {
+    group_adjusted[group] = best_adjusted;
+    group_prob[group] = best_prob;
+    group_index[group] = best_index;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  if (group == 0) {
+    best_adjusted = (lane < Groups) ? group_adjusted[lane] : -INFINITY;
+    best_prob = (lane < Groups) ? group_prob[lane] : 0.0f;
+    best_index = (lane < Groups) ? group_index[lane] : 0;
+
+    for (ushort offset = SIMDWidth / 2; offset > 0; offset >>= 1) {
+      float other_adjusted = simd_shuffle_down(best_adjusted, offset);
+      float other_prob = simd_shuffle_down(best_prob, offset);
+      int other_index = simd_shuffle_down(best_index, offset);
+      if (lane + offset < SIMDWidth && other_adjusted > best_adjusted) {
+        best_adjusted = other_adjusted;
+        best_prob = other_prob;
+        best_index = other_index;
+      }
+    }
+
+    if (lane == 0) {
+      top_prob[k] = best_prob;
+      top_index[k] = best_index;
+      adjusted_values[best_index] = -INFINITY;
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+}
+
+if (tid == 0) {
+  float denom = 1.0f;
+  if (Normalize != 0) {
+    denom = 0.0f;
+    for (int k = 0; k < TopK; ++k) {
+      denom += top_prob[k];
+    }
+  }
+
+  auto score_row = scores + size_t(token) * TopK;
+  auto index_row = indices + size_t(token) * TopK;
+  for (int k = 0; k < TopK; ++k) {
+    int expert = top_index[k];
+    float scale = static_cast<float>(scale_a[expert]) * static_cast<float>(scale_b[expert]);
+    score_row[k] = (top_prob[k] / denom) * scale;
+    index_row[k] = expert;
+  }
+}
+`
+
+func initSigmoidTopKRouterMetalKernel() {
+	inputs, freeInputs, ok := cStringVector([]string{"gates", "bias"})
+	if !ok {
+		sigmoidTopKRouterMetalDisabled = true
+		freeInputs()
+		return
+	}
+	defer freeInputs()
+
+	outputs, freeOutputs, ok := cStringVector([]string{"scores", "indices"})
+	if !ok {
+		sigmoidTopKRouterMetalDisabled = true
+		freeOutputs()
+		return
+	}
+	defer freeOutputs()
+
+	cName := C.CString("sigmoid_topk_router")
+	defer C.free(unsafe.Pointer(cName))
+	cSource := C.CString(sigmoidTopKRouterMetalKernelSource)
+	defer C.free(unsafe.Pointer(cSource))
+	cHeader := C.CString("")
+	defer C.free(unsafe.Pointer(cHeader))
+
+	sigmoidTopKRouterMetalKernel = C.mlx_fast_metal_kernel_new(
+		cName,
+		inputs,
+		outputs,
+		cSource,
+		cHeader,
+		C.bool(true),
+		C.bool(false),
+	)
+}
+
+func initScaledSigmoidTopKRouterMetalKernel() {
+	inputs, freeInputs, ok := cStringVector([]string{"gates", "bias", "scale_a", "scale_b"})
+	if !ok {
+		scaledSigmoidTopKRouterMetalDisabled = true
+		freeInputs()
+		return
+	}
+	defer freeInputs()
+
+	outputs, freeOutputs, ok := cStringVector([]string{"scores", "indices"})
+	if !ok {
+		scaledSigmoidTopKRouterMetalDisabled = true
+		freeOutputs()
+		return
+	}
+	defer freeOutputs()
+
+	cName := C.CString("scaled_sigmoid_topk_router")
+	defer C.free(unsafe.Pointer(cName))
+	cSource := C.CString(scaledSigmoidTopKRouterMetalKernelSource)
+	defer C.free(unsafe.Pointer(cSource))
+	cHeader := C.CString("")
+	defer C.free(unsafe.Pointer(cHeader))
+
+	scaledSigmoidTopKRouterMetalKernel = C.mlx_fast_metal_kernel_new(
+		cName,
+		inputs,
+		outputs,
+		cSource,
+		cHeader,
+		C.bool(true),
+		C.bool(false),
+	)
+}
+
+func sigmoidTopKRouterValidate(gates, bias *Array, topK int) (tokens, experts int, ok bool) {
+	if gates == nil || bias == nil || topK <= 0 {
+		return 0, 0, false
+	}
+	if !sigmoidTopKRouterSupportedDType(gates.DType()) || !sigmoidTopKRouterSupportedDType(bias.DType()) {
+		return 0, 0, false
+	}
+	gd := gates.Dims()
+	bd := bias.Dims()
+	if len(gd) != 2 || len(bd) != 1 {
+		return 0, 0, false
+	}
+	tokens, experts = gd[0], gd[1]
+	if tokens <= 0 || experts <= 0 || experts > 1024 || topK > experts || bd[0] != experts {
+		return 0, 0, false
+	}
+	return tokens, experts, true
+}
+
+func scaledSigmoidTopKRouterValidate(gates, bias, scaleA, scaleB *Array, topK int) (tokens, experts int, ok bool) {
+	tokens, experts, ok = sigmoidTopKRouterValidate(gates, bias, topK)
+	if !ok || scaleA == nil || scaleB == nil {
+		return 0, 0, false
+	}
+	if !sigmoidTopKRouterSupportedDType(scaleA.DType()) || !sigmoidTopKRouterSupportedDType(scaleB.DType()) {
+		return 0, 0, false
+	}
+	ad := scaleA.Dims()
+	bd := scaleB.Dims()
+	if len(ad) != 1 || len(bd) != 1 || ad[0] != experts || bd[0] != experts {
+		return 0, 0, false
+	}
+	return tokens, experts, true
+}
+
+func sigmoidTopKRouterSupportedDType(dtype DType) bool {
+	return dtype == DTypeFloat32 || dtype == DTypeFloat16 || dtype == DTypeBFloat16
+}
+
+func addSigmoidTopKRouterTemplateArgs(cfg C.mlx_fast_metal_kernel_config, tokens, experts, topK int, normalize bool) bool {
+	for _, tpl := range []struct {
+		name  string
+		value int
+	}{
+		{name: "T", value: tokens},
+		{name: "E", value: experts},
+		{name: "TopK", value: topK},
+	} {
+		cn := C.CString(tpl.name)
+		rc := C.mlx_fast_metal_kernel_config_add_template_arg_int(cfg, cn, C.int(tpl.value))
+		C.free(unsafe.Pointer(cn))
+		if rc != 0 {
+			return false
+		}
+	}
+
+	normalizeValue := 0
+	if normalize {
+		normalizeValue = 1
+	}
+	cn := C.CString("Normalize")
+	rc := C.mlx_fast_metal_kernel_config_add_template_arg_int(cfg, cn, C.int(normalizeValue))
+	C.free(unsafe.Pointer(cn))
+	return rc == 0
+}
+
+// FastSigmoidTopKRouter selects top-k experts by sigmoid(gates)+bias and
+// returns the corresponding unbiased sigmoid scores plus int32 expert indices.
+// It returns ok=false for unsupported backends or shapes so callers can use a
+// backend-neutral fallback.
+func FastSigmoidTopKRouter(gates, bias *Array, topK int, normalize bool) (scores, indices *Array, ok bool) {
+	if !MetalIsAvailable() {
+		return nil, nil, false
+	}
+	if sigmoidTopKRouterMetalDisabled {
+		return nil, nil, false
+	}
+	tokens, experts, ok := sigmoidTopKRouterValidate(gates, bias, topK)
+	if !ok {
+		return nil, nil, false
+	}
+
+	sigmoidTopKRouterMetalKernelOnce.Do(initSigmoidTopKRouterMetalKernel)
+	if sigmoidTopKRouterMetalDisabled {
+		return nil, nil, false
+	}
+
+	cfg := C.mlx_fast_metal_kernel_config_new()
+	defer C.mlx_fast_metal_kernel_config_free(cfg)
+	if !addSigmoidTopKRouterTemplateArgs(cfg, tokens, experts, topK, normalize) {
+		return nil, nil, false
+	}
+
+	outShape := []C.int{C.int(tokens), C.int(topK)}
+	if C.mlx_fast_metal_kernel_config_add_output_arg(cfg, unsafe.SliceData(outShape), C.size_t(len(outShape)), C.mlx_dtype(DTypeFloat32)) != 0 {
+		return nil, nil, false
+	}
+	if C.mlx_fast_metal_kernel_config_add_output_arg(cfg, unsafe.SliceData(outShape), C.size_t(len(outShape)), C.mlx_dtype(DTypeInt32)) != 0 {
+		return nil, nil, false
+	}
+
+	gridX := tokens * 128
+	if C.mlx_fast_metal_kernel_config_set_grid(cfg, C.int(gridX), 1, 1) != 0 {
+		return nil, nil, false
+	}
+	if C.mlx_fast_metal_kernel_config_set_thread_group(cfg, 128, 1, 1) != 0 {
+		return nil, nil, false
+	}
+
+	inputs := []C.mlx_array{gates.ctx, bias.ctx}
+	inVec := C.mlx_vector_array_new_data(unsafe.SliceData(inputs), C.size_t(len(inputs)))
+	defer C.mlx_vector_array_free(inVec)
+
+	outVec := C.mlx_vector_array_new()
+	defer C.mlx_vector_array_free(outVec)
+	if C.mlx_fast_metal_kernel_apply(&outVec, sigmoidTopKRouterMetalKernel, inVec, cfg, DefaultStream().ctx) != 0 {
+		return nil, nil, false
+	}
+	if int(C.mlx_vector_array_size(outVec)) < 2 {
+		return nil, nil, false
+	}
+
+	scores = New("SIGMOID_TOPK_ROUTER_SCORES")
+	C.mlx_vector_array_get(&scores.ctx, outVec, 0)
+	indices = New("SIGMOID_TOPK_ROUTER_INDICES")
+	C.mlx_vector_array_get(&indices.ctx, outVec, 1)
+	return scores, indices, true
+}
+
+// FastSigmoidTopKRouterScaled is like FastSigmoidTopKRouter, but also folds
+// scaleA[index] * scaleB[index] into each returned score after optional top-k
+// normalization.
+func FastSigmoidTopKRouterScaled(gates, bias, scaleA, scaleB *Array, topK int, normalize bool) (scores, indices *Array, ok bool) {
+	if !MetalIsAvailable() {
+		return nil, nil, false
+	}
+	if scaledSigmoidTopKRouterMetalDisabled {
+		return nil, nil, false
+	}
+	tokens, experts, ok := scaledSigmoidTopKRouterValidate(gates, bias, scaleA, scaleB, topK)
+	if !ok {
+		return nil, nil, false
+	}
+
+	scaledSigmoidTopKRouterMetalKernelOnce.Do(initScaledSigmoidTopKRouterMetalKernel)
+	if scaledSigmoidTopKRouterMetalDisabled {
+		return nil, nil, false
+	}
+
+	cfg := C.mlx_fast_metal_kernel_config_new()
+	defer C.mlx_fast_metal_kernel_config_free(cfg)
+	if !addSigmoidTopKRouterTemplateArgs(cfg, tokens, experts, topK, normalize) {
+		return nil, nil, false
+	}
+
+	outShape := []C.int{C.int(tokens), C.int(topK)}
+	if C.mlx_fast_metal_kernel_config_add_output_arg(cfg, unsafe.SliceData(outShape), C.size_t(len(outShape)), C.mlx_dtype(DTypeFloat32)) != 0 {
+		return nil, nil, false
+	}
+	if C.mlx_fast_metal_kernel_config_add_output_arg(cfg, unsafe.SliceData(outShape), C.size_t(len(outShape)), C.mlx_dtype(DTypeInt32)) != 0 {
+		return nil, nil, false
+	}
+
+	gridX := tokens * 128
+	if C.mlx_fast_metal_kernel_config_set_grid(cfg, C.int(gridX), 1, 1) != 0 {
+		return nil, nil, false
+	}
+	if C.mlx_fast_metal_kernel_config_set_thread_group(cfg, 128, 1, 1) != 0 {
+		return nil, nil, false
+	}
+
+	inputs := []C.mlx_array{gates.ctx, bias.ctx, scaleA.ctx, scaleB.ctx}
+	inVec := C.mlx_vector_array_new_data(unsafe.SliceData(inputs), C.size_t(len(inputs)))
+	defer C.mlx_vector_array_free(inVec)
+
+	outVec := C.mlx_vector_array_new()
+	defer C.mlx_vector_array_free(outVec)
+	if C.mlx_fast_metal_kernel_apply(&outVec, scaledSigmoidTopKRouterMetalKernel, inVec, cfg, DefaultStream().ctx) != 0 {
+		return nil, nil, false
+	}
+	if int(C.mlx_vector_array_size(outVec)) < 2 {
+		return nil, nil, false
+	}
+
+	scores = New("SCALED_SIGMOID_TOPK_ROUTER_SCORES")
+	C.mlx_vector_array_get(&scores.ctx, outVec, 0)
+	indices = New("SCALED_SIGMOID_TOPK_ROUTER_INDICES")
+	C.mlx_vector_array_get(&indices.ctx, outVec, 1)
+	return scores, indices, true
+}

--- a/x/mlxrunner/mlx/sigmoid_topk_router_test.go
+++ b/x/mlxrunner/mlx/sigmoid_topk_router_test.go
@@ -1,0 +1,186 @@
+package mlx
+
+import (
+	"math"
+	"sort"
+	"testing"
+)
+
+func TestFastSigmoidTopKRouter(t *testing.T) {
+	withMLXThread(t, func() {
+		if !MetalIsAvailable() {
+			t.Skip("requires Metal")
+		}
+
+		gates := FromValues([]float32{
+			-4, -3, 2, 0, 1,
+			3, -1, 0.5, 4, -2,
+		}, 2, 5)
+		bias := FromValues([]float32{0.5, 0, 0, 0.4, 0}, 5).AsType(DTypeBFloat16)
+		Pin(gates, bias)
+		defer Unpin(gates, bias)
+
+		scores, indices, ok := FastSigmoidTopKRouter(gates, bias, 2, true)
+		if !ok {
+			t.Fatal("FastSigmoidTopKRouter returned ok=false")
+		}
+		Eval(scores, indices)
+
+		if got := scores.Dims(); len(got) != 2 || got[0] != 2 || got[1] != 2 {
+			t.Fatalf("scores dims = %v, want [2 2]", got)
+		}
+		if got := indices.Dims(); len(got) != 2 || got[0] != 2 || got[1] != 2 {
+			t.Fatalf("indices dims = %v, want [2 2]", got)
+		}
+
+		wantIndices, wantScores := sigmoidTopKRouterWant(
+			[]float32{
+				-4, -3, 2, 0, 1,
+				3, -1, 0.5, 4, -2,
+			},
+			[]float32{0.5, 0, 0, 0.4, 0},
+			2,
+			5,
+			2,
+			true,
+		)
+		if got := indices.Ints(); !equalInts(got, wantIndices) {
+			t.Fatalf("indices = %v, want %v", got, wantIndices)
+		}
+		assertFloat32Close(t, scores.Floats(), wantScores, 1e-5)
+	})
+}
+
+func TestFastSigmoidTopKRouterScaled(t *testing.T) {
+	withMLXThread(t, func() {
+		if !MetalIsAvailable() {
+			t.Skip("requires Metal")
+		}
+
+		gates := FromValues([]float32{
+			-4, -3, 2, 0, 1,
+			3, -1, 0.5, 4, -2,
+		}, 2, 5)
+		bias := FromValues([]float32{0.5, 0, 0, 0.4, 0}, 5)
+		scaleA := FromValues([]float32{2, 3, 5, 7, 11}, 5)
+		scaleB := FromValues([]float32{0.5, 0.25, 0.125, 2, 4}, 5)
+		Pin(gates, bias, scaleA, scaleB)
+		defer Unpin(gates, bias, scaleA, scaleB)
+
+		scores, indices, ok := FastSigmoidTopKRouterScaled(gates, bias, scaleA, scaleB, 2, true)
+		if !ok {
+			t.Fatal("FastSigmoidTopKRouterScaled returned ok=false")
+		}
+		Eval(scores, indices)
+
+		wantIndices, wantScores := sigmoidTopKRouterWant(
+			[]float32{
+				-4, -3, 2, 0, 1,
+				3, -1, 0.5, 4, -2,
+			},
+			[]float32{0.5, 0, 0, 0.4, 0},
+			2,
+			5,
+			2,
+			true,
+		)
+		scaleAVals := []float32{2, 3, 5, 7, 11}
+		scaleBVals := []float32{0.5, 0.25, 0.125, 2, 4}
+		for i, expert := range wantIndices {
+			wantScores[i] *= scaleAVals[expert] * scaleBVals[expert]
+		}
+		if got := indices.Ints(); !equalInts(got, wantIndices) {
+			t.Fatalf("indices = %v, want %v", got, wantIndices)
+		}
+		assertFloat32Close(t, scores.Floats(), wantScores, 1e-5)
+	})
+}
+
+func TestFastSigmoidTopKRouterBF16MatchesWidenedF32(t *testing.T) {
+	withMLXThread(t, func() {
+		if !MetalIsAvailable() {
+			t.Skip("requires Metal")
+		}
+
+		gates := FromValues([]float32{
+			-4.125, -3.25, 2.5, 0, 1.75,
+			3.5, -1.125, 0.5, 4.25, -2.75,
+		}, 2, 5).AsType(DTypeBFloat16)
+		bias := FromValues([]float32{0.5, 0, 0, 0.4, 0}, 5)
+		Pin(gates, bias)
+		defer Unpin(gates, bias)
+
+		bf16Scores, bf16Indices, ok := FastSigmoidTopKRouter(gates, bias, 2, true)
+		if !ok {
+			t.Fatal("FastSigmoidTopKRouter returned ok=false for BF16 gates")
+		}
+		f32Scores, f32Indices, ok := FastSigmoidTopKRouter(gates.AsType(DTypeFloat32), bias.AsType(DTypeFloat32), 2, true)
+		if !ok {
+			t.Fatal("FastSigmoidTopKRouter returned ok=false for widened F32 gates")
+		}
+		Eval(bf16Scores, bf16Indices, f32Scores, f32Indices)
+
+		if got, want := bf16Indices.Ints(), f32Indices.Ints(); !equalInts(got, want) {
+			t.Fatalf("indices = %v, want %v", got, want)
+		}
+		assertFloat32Close(t, bf16Scores.Floats(), f32Scores.Floats(), 1e-5)
+	})
+}
+
+func sigmoidTopKRouterWant(gates, bias []float32, tokens, experts, topK int, normalize bool) ([]int, []float32) {
+	type candidate struct {
+		index    int
+		prob     float32
+		adjusted float32
+	}
+
+	indices := make([]int, 0, tokens*topK)
+	scores := make([]float32, 0, tokens*topK)
+	for t := range tokens {
+		row := make([]candidate, 0, experts)
+		for e := range experts {
+			p := float32(1 / (1 + math.Exp(-float64(gates[t*experts+e]))))
+			row = append(row, candidate{index: e, prob: p, adjusted: p + bias[e]})
+		}
+		sort.Slice(row, func(i, j int) bool {
+			return row[i].adjusted > row[j].adjusted
+		})
+
+		denom := float32(1)
+		if normalize {
+			denom = 0
+			for k := range topK {
+				denom += row[k].prob
+			}
+		}
+		for k := range topK {
+			indices = append(indices, row[k].index)
+			scores = append(scores, row[k].prob/denom)
+		}
+	}
+	return indices, scores
+}
+
+func equalInts(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func assertFloat32Close(t *testing.T, got, want []float32, tol float64) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("len got=%d want=%d", len(got), len(want))
+	}
+	for i := range got {
+		if diff := math.Abs(float64(got[i] - want[i])); diff > tol {
+			t.Fatalf("got[%d]=%v want %v diff %v", i, got[i], want[i], diff)
+		}
+	}
+}

--- a/x/mlxrunner/mlx/swiglu_gathered_gate_scale.go
+++ b/x/mlxrunner/mlx/swiglu_gathered_gate_scale.go
@@ -1,0 +1,197 @@
+package mlx
+
+// #include <stdlib.h>
+// #include "generated.h"
+import "C"
+
+// This gathered SwiGLU gate-scale kernel is currently only used by Laguna. As
+// part of the retained Laguna fast path, the Apple M5 Max p2048/g128 run was
+// about 24% faster on prompt and 7% faster on generate than the GGML target.
+// No other model has shown a kept win from this path yet.
+// TODO: consider moving this implementation under x/models/laguna once the mlx
+// package has a refined custom-kernel API that can safely support model-local
+// kernels without exposing low-level MLX internals.
+// TODO(cuda): add CUDA equivalents for these custom Metal kernels before
+// enabling the same fast path on CUDA-backed MLX; non-Metal backends must keep
+// using the generic fallback.
+
+import (
+	"sync"
+	"unsafe"
+)
+
+var (
+	swiGLUGatheredGateScaleMetalKernelOnce sync.Once
+	swiGLUGatheredGateScaleMetalKernel     C.mlx_fast_metal_kernel
+	swiGLUGatheredGateScaleMetalDisabled   bool
+)
+
+const swiGLUGatheredGateScaleMetalKernelSource = `
+auto elem = thread_position_in_grid.x;
+auto total = Rows * H;
+if (elem >= total) {
+  return;
+}
+
+auto row = elem / H;
+auto expert = (ScaleCount == 1) ? 0 : int(indices[row]);
+float g = static_cast<float>(gate[elem]) * static_cast<float>(scales[expert]);
+float u = static_cast<float>(up[elem]);
+float s = 1.0f / (1.0f + exp(-g));
+y[elem] = static_cast<OutT>((g * s) * u);
+`
+
+func initSwiGLUGatheredGateScaleMetalKernel() {
+	inputs, freeInputs, ok := cStringVector([]string{"gate", "up", "scales", "indices"})
+	if !ok {
+		swiGLUGatheredGateScaleMetalDisabled = true
+		freeInputs()
+		return
+	}
+	defer freeInputs()
+
+	outputs, freeOutputs, ok := cStringVector([]string{"y"})
+	if !ok {
+		swiGLUGatheredGateScaleMetalDisabled = true
+		freeOutputs()
+		return
+	}
+	defer freeOutputs()
+
+	cName := C.CString("swiglu_gathered_gate_scale")
+	defer C.free(unsafe.Pointer(cName))
+	cSource := C.CString(swiGLUGatheredGateScaleMetalKernelSource)
+	defer C.free(unsafe.Pointer(cSource))
+	cHeader := C.CString("")
+	defer C.free(unsafe.Pointer(cHeader))
+
+	swiGLUGatheredGateScaleMetalKernel = C.mlx_fast_metal_kernel_new(
+		cName,
+		inputs,
+		outputs,
+		cSource,
+		cHeader,
+		C.bool(true),
+		C.bool(false),
+	)
+}
+
+func swiGLUGatheredGateScaleValidate(gate, up, scales, indices *Array) (dims []int, rows, H, scaleCount int, outDType DType, ok bool) {
+	if gate == nil || up == nil || scales == nil || indices == nil {
+		return nil, 0, 0, 0, 0, false
+	}
+	outDType = gate.DType()
+	if !swiGLUGatheredGateScaleSupportedDType(outDType) || up.DType() != outDType || !swiGLUGatheredGateScaleSupportedDType(scales.DType()) || indices.DType() != DTypeInt32 {
+		return nil, 0, 0, 0, 0, false
+	}
+	dims = gate.Dims()
+	ud := up.Dims()
+	sd := scales.Dims()
+	id := indices.Dims()
+	if len(dims) != 4 || len(ud) != 4 || len(sd) != 1 || len(id) != 2 {
+		return nil, 0, 0, 0, 0, false
+	}
+	for i := range dims {
+		if dims[i] <= 0 || dims[i] != ud[i] {
+			return nil, 0, 0, 0, 0, false
+		}
+	}
+	if dims[2] != 1 || id[0] != dims[0] || id[1] != dims[1] || sd[0] <= 0 {
+		return nil, 0, 0, 0, 0, false
+	}
+	H = dims[3]
+	rows = dims[0] * dims[1]
+	scaleCount = sd[0]
+	if rows <= 0 || H <= 0 {
+		return nil, 0, 0, 0, 0, false
+	}
+	return dims, rows, H, scaleCount, outDType, true
+}
+
+func swiGLUGatheredGateScaleSupportedDType(dtype DType) bool {
+	return dtype == DTypeFloat32 || dtype == DTypeFloat16 || dtype == DTypeBFloat16
+}
+
+func addSwiGLUGatheredGateScaleTemplateArgs(cfg C.mlx_fast_metal_kernel_config, rows, H, scaleCount int, outDType DType) bool {
+	for _, tpl := range []struct {
+		name  string
+		value int
+	}{
+		{name: "Rows", value: rows},
+		{name: "H", value: H},
+		{name: "ScaleCount", value: scaleCount},
+	} {
+		cn := C.CString(tpl.name)
+		rc := C.mlx_fast_metal_kernel_config_add_template_arg_int(cfg, cn, C.int(tpl.value))
+		C.free(unsafe.Pointer(cn))
+		if rc != 0 {
+			return false
+		}
+	}
+
+	cn := C.CString("OutT")
+	rc := C.mlx_fast_metal_kernel_config_add_template_arg_dtype(cfg, cn, C.mlx_dtype(outDType))
+	C.free(unsafe.Pointer(cn))
+	return rc == 0
+}
+
+// FastSwiGLUGatheredGateScale computes SiLU(gate * scales[indices]) * up for
+// gate/up shaped [tokens, topK, 1, hidden]. It returns ok=false for unsupported
+// shapes, dtypes, or backends so callers can use generic MLX ops.
+func FastSwiGLUGatheredGateScale(gate, up, scales, indices *Array) (y *Array, ok bool) {
+	if !MetalIsAvailable() {
+		return nil, false
+	}
+	if swiGLUGatheredGateScaleMetalDisabled {
+		return nil, false
+	}
+	dims, rows, H, scaleCount, outDType, ok := swiGLUGatheredGateScaleValidate(gate, up, scales, indices)
+	if !ok {
+		return nil, false
+	}
+
+	swiGLUGatheredGateScaleMetalKernelOnce.Do(initSwiGLUGatheredGateScaleMetalKernel)
+	if swiGLUGatheredGateScaleMetalDisabled {
+		return nil, false
+	}
+
+	cfg := C.mlx_fast_metal_kernel_config_new()
+	defer C.mlx_fast_metal_kernel_config_free(cfg)
+	if !addSwiGLUGatheredGateScaleTemplateArgs(cfg, rows, H, scaleCount, outDType) {
+		return nil, false
+	}
+
+	outShape := make([]C.int, len(dims))
+	for i, dim := range dims {
+		outShape[i] = C.int(dim)
+	}
+	if C.mlx_fast_metal_kernel_config_add_output_arg(cfg, unsafe.SliceData(outShape), C.size_t(len(outShape)), C.mlx_dtype(outDType)) != 0 {
+		return nil, false
+	}
+
+	total := rows * H
+	gridX := ((total + 127) / 128) * 128
+	if C.mlx_fast_metal_kernel_config_set_grid(cfg, C.int(gridX), 1, 1) != 0 {
+		return nil, false
+	}
+	if C.mlx_fast_metal_kernel_config_set_thread_group(cfg, 128, 1, 1) != 0 {
+		return nil, false
+	}
+
+	inputs := []C.mlx_array{gate.ctx, up.ctx, scales.ctx, indices.ctx}
+	inVec := C.mlx_vector_array_new_data(unsafe.SliceData(inputs), C.size_t(len(inputs)))
+	defer C.mlx_vector_array_free(inVec)
+
+	outVec := C.mlx_vector_array_new()
+	defer C.mlx_vector_array_free(outVec)
+	if C.mlx_fast_metal_kernel_apply(&outVec, swiGLUGatheredGateScaleMetalKernel, inVec, cfg, DefaultStream().ctx) != 0 {
+		return nil, false
+	}
+	if int(C.mlx_vector_array_size(outVec)) < 1 {
+		return nil, false
+	}
+
+	y = New("SWIGLU_GATHERED_GATE_SCALE")
+	C.mlx_vector_array_get(&y.ctx, outVec, 0)
+	return y, true
+}

--- a/x/mlxrunner/mlx/swiglu_gathered_gate_scale_test.go
+++ b/x/mlxrunner/mlx/swiglu_gathered_gate_scale_test.go
@@ -1,0 +1,71 @@
+package mlx
+
+import "testing"
+
+func TestFastSwiGLUGatheredGateScale(t *testing.T) {
+	withMLXThread(t, func() {
+		if !MetalIsAvailable() {
+			t.Skip("requires Metal")
+		}
+
+		gate := FromValues([]float32{
+			-2, -1, 0,
+			1, 2, 3,
+			-3, 0.5, 4,
+			2, -0.5, 1.5,
+		}, 2, 2, 1, 3)
+		up := FromValues([]float32{
+			1, 2, 3,
+			4, 5, 6,
+			-1, -2, -3,
+			0.5, 1.5, 2.5,
+		}, 2, 2, 1, 3)
+		scales := FromValues([]float32{0.5, 2, 3}, 3)
+		indices := FromValues([]int32{0, 2, 1, 0}, 2, 2)
+		Pin(gate, up, scales, indices)
+		defer Unpin(gate, up, scales, indices)
+
+		got, ok := FastSwiGLUGatheredGateScale(gate, up, scales, indices)
+		if !ok {
+			t.Fatal("FastSwiGLUGatheredGateScale returned ok=false")
+		}
+		want := SwiGLU(Mul(gate, ExpandDims(ExpandDims(Take(scales, indices, 0), -1), -1)), up)
+		Eval(got, want)
+
+		assertFloat32Close(t, got.Floats(), want.Floats(), 1e-5)
+	})
+}
+
+func TestFastSwiGLUGatheredGateScaleScalarScale(t *testing.T) {
+	withMLXThread(t, func() {
+		if !MetalIsAvailable() {
+			t.Skip("requires Metal")
+		}
+
+		gate := FromValues([]float32{
+			-2, -1, 0,
+			1, 2, 3,
+			-3, 0.5, 4,
+			2, -0.5, 1.5,
+		}, 2, 2, 1, 3)
+		up := FromValues([]float32{
+			1, 2, 3,
+			4, 5, 6,
+			-1, -2, -3,
+			0.5, 1.5, 2.5,
+		}, 2, 2, 1, 3)
+		scales := FromValues([]float32{0.5}, 1)
+		indices := FromValues([]int32{0, 2, 1, 0}, 2, 2)
+		Pin(gate, up, scales, indices)
+		defer Unpin(gate, up, scales, indices)
+
+		got, ok := FastSwiGLUGatheredGateScale(gate, up, scales, indices)
+		if !ok {
+			t.Fatal("FastSwiGLUGatheredGateScale returned ok=false")
+		}
+		want := SwiGLU(Mul(gate, Reshape(scales, 1, 1, 1, 1)), up)
+		Eval(got, want)
+
+		assertFloat32Close(t, got.Floats(), want.Floats(), 1e-5)
+	})
+}

--- a/x/models/laguna/laguna.go
+++ b/x/models/laguna/laguna.go
@@ -114,10 +114,21 @@ type MLPBlock interface {
 	Forward(x *mlx.Array, cfg *Config) *mlx.Array
 }
 
+type MLPBlockAdd interface {
+	ForwardAdd(x, residual *mlx.Array, cfg *Config) *mlx.Array
+}
+
 type DenseMLP struct {
-	GateProj nn.LinearLayer
-	UpProj   nn.LinearLayer
-	DownProj nn.LinearLayer
+	GateProj        nn.LinearLayer
+	UpProj          nn.LinearLayer
+	DownProj        nn.LinearLayer
+	GateUpProj      nn.LinearLayer
+	GateUpGateScale *mlx.Array
+	GateUpUpScale   *mlx.Array
+}
+
+type lagunaQuantizedLinear struct {
+	*nn.QuantizedLinear
 }
 
 type SparseMoE struct {
@@ -657,6 +668,149 @@ func canFuseQuantizedGateUp(gateW, upW *stackedExpertWeights) bool {
 	return gateW.Weight.NumDims() == 3 && upW.Weight.NumDims() == 3
 }
 
+func canFuseDenseQuantizedLinears(a, b *nn.QuantizedLinear) bool {
+	if a == nil || b == nil || a.Scales == nil || b.Scales == nil {
+		return false
+	}
+	if a.QBiases != nil || b.QBiases != nil ||
+		a.Bias != nil || b.Bias != nil {
+		return false
+	}
+	if !isScalarGlobalScale(a.GlobalScale) || !isScalarGlobalScale(b.GlobalScale) {
+		return false
+	}
+	if a.Bits != b.Bits || a.GroupSize != b.GroupSize || a.Mode != b.Mode {
+		return false
+	}
+	if a.Weight.NumDims() != 2 || b.Weight.NumDims() != 2 ||
+		a.Scales.NumDims() != 2 || b.Scales.NumDims() != 2 {
+		return false
+	}
+	if a.Weight.Dim(1) != b.Weight.Dim(1) || a.Scales.Dim(1) != b.Scales.Dim(1) {
+		return false
+	}
+	if a.Mode == "nvfp4" && a.Bits == 4 && a.GroupSize == 16 {
+		return a.Weight.Dim(0)+b.Weight.Dim(0) >= 512 && a.Weight.Dim(1)*8 >= 512
+	}
+	if a.Mode == "mxfp8" && a.Bits == 8 && a.GroupSize == 32 {
+		return a.Weight.Dim(0)+b.Weight.Dim(0) >= 512 && a.Weight.Dim(1)*4 >= 512
+	}
+	return false
+}
+
+func isScalarGlobalScale(scale *mlx.Array) bool {
+	if scale == nil {
+		return true
+	}
+	return scale.NumDims() == 0 || (scale.NumDims() == 1 && scale.Dim(0) == 1)
+}
+
+func wrapLagunaLinear(l nn.LinearLayer) nn.LinearLayer {
+	q, ok := l.(*nn.QuantizedLinear)
+	if !ok {
+		return l
+	}
+	if q.Scales == nil || q.QBiases != nil || q.Bias != nil {
+		return l
+	}
+	if q.Mode == "nvfp4" && q.Bits == 4 && q.GroupSize == 16 && isScalarGlobalScale(q.GlobalScale) {
+		return &lagunaQuantizedLinear{QuantizedLinear: q}
+	}
+	if q.Mode == "mxfp8" && q.Bits == 8 && q.GroupSize == 32 && q.GlobalScale == nil {
+		return &lagunaQuantizedLinear{QuantizedLinear: q}
+	}
+	return l
+}
+
+func (l *lagunaQuantizedLinear) Forward(x *mlx.Array) *mlx.Array {
+	if x.NumDims() == 3 && x.Dim(0) == 1 && x.Dim(1) >= 64 {
+		if y, ok := mlx.FastQuantizedLinear(x, l.Weight, l.Scales, l.GlobalScale, l.GroupSize, l.Bits, l.Mode); ok {
+			return y
+		}
+	}
+	return l.QuantizedLinear.Forward(x)
+}
+
+func fuseDenseQuantizedLinears(a, b nn.LinearLayer) nn.LinearLayer {
+	aq, ok := a.(*lagunaQuantizedLinear)
+	if !ok {
+		if q, ok := a.(*nn.QuantizedLinear); ok {
+			aq = &lagunaQuantizedLinear{QuantizedLinear: q}
+		} else {
+			return nil
+		}
+	}
+	bq, ok := b.(*lagunaQuantizedLinear)
+	if !ok {
+		if q, ok := b.(*nn.QuantizedLinear); ok {
+			bq = &lagunaQuantizedLinear{QuantizedLinear: q}
+		} else {
+			return nil
+		}
+	}
+	if !canFuseDenseQuantizedLinears(aq.QuantizedLinear, bq.QuantizedLinear) {
+		return nil
+	}
+	return &lagunaQuantizedLinear{QuantizedLinear: &nn.QuantizedLinear{
+		Weight:    fuseExpertStacks(aq.Weight, bq.Weight, 0),
+		Scales:    fuseExpertStacks(aq.Scales, bq.Scales, 0),
+		GroupSize: aq.GroupSize,
+		Bits:      aq.Bits,
+		Mode:      aq.Mode,
+	}}
+}
+
+// fuseDenseGateUp fuses only the quantized weights and scales. Scalar global
+// scales from the original projections stay on DenseMLP and are applied after
+// the fused output is split back into gate/up halves.
+func fuseDenseGateUp(gate, up nn.LinearLayer) nn.LinearLayer {
+	return fuseDenseQuantizedLinears(gate, up)
+}
+
+func linearGlobalScale(l nn.LinearLayer) *mlx.Array {
+	switch q := l.(type) {
+	case *lagunaQuantizedLinear:
+		return q.GlobalScale
+	case *nn.QuantizedLinear:
+		return q.GlobalScale
+	default:
+		return nil
+	}
+}
+
+func applyDenseGlobalScale(x, globalScale *mlx.Array) *mlx.Array {
+	if globalScale == nil {
+		return x
+	}
+	return mlx.Mul(x, globalScale).AsType(x.DType())
+}
+
+func splitLastDim(x *mlx.Array, first int32) (*mlx.Array, *mlx.Array) {
+	dims := x.Dims()
+	starts := make([]int32, len(dims))
+	leftStops := make([]int32, len(dims))
+	rightStarts := make([]int32, len(dims))
+	rightStops := make([]int32, len(dims))
+	for i, dim := range dims {
+		leftStops[i] = int32(dim)
+		rightStops[i] = int32(dim)
+	}
+	leftStops[len(leftStops)-1] = first
+	rightStarts[len(rightStarts)-1] = first
+	return mlx.SliceStartStop(x, starts, leftStops), mlx.SliceStartStop(x, rightStarts, rightStops)
+}
+
+func shouldMapMoEExperts(tokens int32) bool {
+	return tokens >= 64
+}
+
+func shouldMapDenseMoEExperts(tokens int32) bool {
+	// Dense mapped MM is gated separately by dtype/backend support. When it is
+	// available, use it for both prompt and decode because Laguna BF16 otherwise
+	// spends heavily in generic GatherMM at all batch sizes.
+	return tokens > 0
+}
+
 func fuseExpertStacks(a, b *mlx.Array, axis int) *mlx.Array {
 	if a == nil || !a.Valid() || b == nil || !b.Valid() {
 		return nil
@@ -825,6 +979,9 @@ func (m *Model) LoadWeights(tensors map[string]*mlx.Array) error {
 	prefix := resolveWeightPrefix(tensors)
 	cfg := m.Config
 	linears := model.NewLinearFactory(tensors, cfg.QuantGroupSize, cfg.QuantBits, cfg.QuantMode, cfg.TensorQuant)
+	makeLinear := func(name string) nn.LinearLayer {
+		return wrapLagunaLinear(linears.Make(name))
+	}
 
 	m.EmbedTokens = model.MakeEmbeddingLayer(tensors, prefix+"embed_tokens", cfg.QuantGroupSize, cfg.QuantBits, cfg.QuantMode, cfg.TensorQuant)
 	if m.EmbedTokens == nil {
@@ -836,10 +993,10 @@ func (m *Model) LoadWeights(tensors map[string]*mlx.Array) error {
 		return fmt.Errorf("missing final norm weight: %snorm.weight", prefix)
 	}
 	if cfg.TieWordEmbeddings {
-		m.LMHead = m.EmbedTokens.AsLinear()
-	} else if lmHead := linears.Make("lm_head"); lmHead != nil {
+		m.LMHead = wrapLagunaLinear(m.EmbedTokens.AsLinear())
+	} else if lmHead := makeLinear("lm_head"); lmHead != nil {
 		m.LMHead = lmHead
-	} else if lmHead := linears.Make(prefix + "lm_head"); lmHead != nil {
+	} else if lmHead := makeLinear(prefix + "lm_head"); lmHead != nil {
 		m.LMHead = lmHead
 	} else {
 		return fmt.Errorf("missing lm_head.weight")
@@ -876,11 +1033,11 @@ func (m *Model) LoadWeights(tensors map[string]*mlx.Array) error {
 			return fmt.Errorf("layer %d: missing layer norms", i)
 		}
 
-		layer.Attention.QProj = linears.Make(layerPrefix + ".self_attn.q_proj")
-		layer.Attention.KProj = linears.Make(layerPrefix + ".self_attn.k_proj")
-		layer.Attention.VProj = linears.Make(layerPrefix + ".self_attn.v_proj")
-		layer.Attention.OProj = linears.Make(layerPrefix + ".self_attn.o_proj")
-		layer.Attention.GProj = linears.Make(layerPrefix + ".self_attn.g_proj")
+		layer.Attention.QProj = makeLinear(layerPrefix + ".self_attn.q_proj")
+		layer.Attention.KProj = makeLinear(layerPrefix + ".self_attn.k_proj")
+		layer.Attention.VProj = makeLinear(layerPrefix + ".self_attn.v_proj")
+		layer.Attention.OProj = makeLinear(layerPrefix + ".self_attn.o_proj")
+		layer.Attention.GProj = makeLinear(layerPrefix + ".self_attn.g_proj")
 		if w := tensors[layerPrefix+".self_attn.q_norm.weight"]; w != nil {
 			layer.Attention.QNorm = nn.NewRMSNorm(w, cfg.RMSNormEps)
 		}
@@ -895,7 +1052,7 @@ func (m *Model) LoadWeights(tensors map[string]*mlx.Array) error {
 		}
 
 		if layerUsesMoE(cfg, i) {
-			moe := &SparseMoE{Gate: linears.Make(layerPrefix + ".mlp.gate")}
+			moe := &SparseMoE{Gate: makeLinear(layerPrefix + ".mlp.gate")}
 			if moe.Gate == nil {
 				return fmt.Errorf("layer %d: missing moe gate", i)
 			}
@@ -966,20 +1123,30 @@ func (m *Model) LoadWeights(tensors map[string]*mlx.Array) error {
 				sw.UseFusedGateUp = sw.GateUpWeight != nil
 			}
 			moe.SwitchMLP = sw
+			sharedGate := makeLinear(layerPrefix + ".mlp.shared_expert.gate_proj")
+			sharedUp := makeLinear(layerPrefix + ".mlp.shared_expert.up_proj")
 			moe.SharedExpert = &DenseMLP{
-				GateProj: linears.Make(layerPrefix + ".mlp.shared_expert.gate_proj"),
-				UpProj:   linears.Make(layerPrefix + ".mlp.shared_expert.up_proj"),
-				DownProj: linears.Make(layerPrefix + ".mlp.shared_expert.down_proj"),
+				GateProj:        sharedGate,
+				UpProj:          sharedUp,
+				DownProj:        makeLinear(layerPrefix + ".mlp.shared_expert.down_proj"),
+				GateUpProj:      fuseDenseGateUp(sharedGate, sharedUp),
+				GateUpGateScale: linearGlobalScale(sharedGate),
+				GateUpUpScale:   linearGlobalScale(sharedUp),
 			}
 			if moe.SharedExpert.GateProj == nil || moe.SharedExpert.UpProj == nil || moe.SharedExpert.DownProj == nil {
 				return fmt.Errorf("layer %d: missing shared expert weights", i)
 			}
 			layer.MLP = moe
 		} else {
+			gate := makeLinear(layerPrefix + ".mlp.gate_proj")
+			up := makeLinear(layerPrefix + ".mlp.up_proj")
 			mlp := &DenseMLP{
-				GateProj: linears.Make(layerPrefix + ".mlp.gate_proj"),
-				UpProj:   linears.Make(layerPrefix + ".mlp.up_proj"),
-				DownProj: linears.Make(layerPrefix + ".mlp.down_proj"),
+				GateProj:        gate,
+				UpProj:          up,
+				DownProj:        makeLinear(layerPrefix + ".mlp.down_proj"),
+				GateUpProj:      fuseDenseGateUp(gate, up),
+				GateUpGateScale: linearGlobalScale(gate),
+				GateUpUpScale:   linearGlobalScale(up),
 			}
 			if mlp.GateProj == nil || mlp.UpProj == nil || mlp.DownProj == nil {
 				return fmt.Errorf("layer %d: missing dense mlp projections", i)
@@ -1031,10 +1198,240 @@ func (a *Attention) Forward(x *mlx.Array, b *batch.Batch, c cache.Cache, positio
 }
 
 func (m *DenseMLP) Forward(x *mlx.Array, _ *Config) *mlx.Array {
+	if m.GateUpProj != nil {
+		gateUp := m.GateUpProj.Forward(x)
+		gate, up := splitLastDim(gateUp, int32(gateUp.Dim(len(gateUp.Dims())-1))/2)
+		gate = applyDenseGlobalScale(gate, m.GateUpGateScale)
+		up = applyDenseGlobalScale(up, m.GateUpUpScale)
+		return m.DownProj.Forward(mlx.SwiGLU(gate, up))
+	}
 	return m.DownProj.Forward(mlx.SwiGLU(m.GateProj.Forward(x), m.UpProj.Forward(x)))
 }
 
 func (s *SwitchMLP) Forward(x *mlx.Array, indices *mlx.Array, cfg *Config) *mlx.Array {
+	if out, ok := s.mappedQuantizedForward(x, indices, cfg); ok {
+		return out
+	}
+	if out, ok := s.mappedDenseForward(x, indices, cfg); ok {
+		return out
+	}
+	// If a mapped path is supported by the model shape but not by the current
+	// Metal toolchain, keep the fallback on the unsorted gathered-matmul path.
+	// MLX's sorted GatherQMM route can lazily compile Metal tensor-op sources,
+	// which are unavailable on macOS 15.
+	sortExperts := !s.canMapQuantizedExpert() && !s.canMapDenseExpert()
+	return s.gatherForward(x, indices, cfg, sortExperts)
+}
+
+func (s *SwitchMLP) canMapQuantizedExpert() bool {
+	if !s.UseQuantized {
+		return false
+	}
+	if s.DownWeightQ == nil || s.DownScales == nil || s.DownBiases != nil {
+		return false
+	}
+	if s.UseFusedGateUp {
+		if s.GateUpWeightQ == nil || s.GateUpScales == nil || s.GateUpBiases != nil {
+			return false
+		}
+		return mlx.SupportsMoEGatherQMMBlockMapped(s.GateUpGroupSize, s.GateUpBits, s.GateUpMode) &&
+			mlx.SupportsMoEGatherQMMBlockMapped(s.DownGroupSize, s.DownBits, s.DownMode)
+	}
+	if s.GateWeightQ == nil || s.GateScales == nil ||
+		s.UpWeightQ == nil || s.UpScales == nil ||
+		s.GateBiases != nil || s.UpBiases != nil {
+		return false
+	}
+	return mlx.SupportsMoEGatherQMMBlockMapped(s.GateGroupSize, s.GateBits, s.GateMode) &&
+		mlx.SupportsMoEGatherQMMBlockMapped(s.UpGroupSize, s.UpBits, s.UpMode) &&
+		mlx.SupportsMoEGatherQMMBlockMapped(s.DownGroupSize, s.DownBits, s.DownMode)
+}
+
+func (s *SwitchMLP) canMapDenseExpert() bool {
+	if s.UseQuantized || s.DownWeight == nil {
+		return false
+	}
+	if !mlx.SupportsMoEGatherMMBlockMapped(s.DownWeight.DType()) {
+		return false
+	}
+	if s.UseFusedGateUp {
+		return s.GateUpWeight != nil &&
+			s.GateUpWeight.DType() == s.DownWeight.DType() &&
+			mlx.SupportsMoEGatherMMBlockMapped(s.GateUpWeight.DType())
+	}
+	return s.GateWeight != nil && s.UpWeight != nil &&
+		s.GateWeight.DType() == s.DownWeight.DType() &&
+		s.UpWeight.DType() == s.DownWeight.DType() &&
+		mlx.SupportsMoEGatherMMBlockMapped(s.GateWeight.DType()) &&
+		mlx.SupportsMoEGatherMMBlockMapped(s.UpWeight.DType())
+}
+
+func (s *SwitchMLP) weightForGatherMM(w *mlx.Array) *mlx.Array {
+	if s.DenseWeightsSourceLayout {
+		return transposeExpertWeightViewForGatherMM(w)
+	}
+	return w
+}
+
+func (s *SwitchMLP) mappedQuantizedForward(x *mlx.Array, indices *mlx.Array, cfg *Config) (*mlx.Array, bool) {
+	if !s.canMapQuantizedExpert() {
+		return nil, false
+	}
+
+	dims := x.Dims()
+	if len(dims) != 3 || dims[0] <= 0 || dims[1] <= 0 || dims[2] <= 0 || cfg.NumExpertsPerTok <= 0 {
+		return nil, false
+	}
+	B, L := int32(dims[0]), int32(dims[1])
+	tokens := B * L
+	if !shouldMapMoEExperts(tokens) {
+		return nil, false
+	}
+
+	topK := int(cfg.NumExpertsPerTok)
+	idxFlat := mlx.Reshape(indices, tokens, cfg.NumExpertsPerTok)
+	var experts int
+	if s.UseFusedGateUp {
+		experts = s.GateUpWeightQ.Dim(0)
+	} else {
+		experts = s.GateWeightQ.Dim(0)
+	}
+	expertMap, ok := mlx.NewMoEGatherQMMMap(idxFlat, experts)
+	if !ok {
+		return nil, false
+	}
+
+	xFlat := mlx.Reshape(x, tokens, 1, cfg.HiddenSize)
+	if s.UseFusedGateUp {
+		gateUp, ok := mlx.FastMoEGatherQMMBlockMapped(xFlat, s.GateUpWeightQ, s.GateUpScales, expertMap, topK, s.GateUpGroupSize, s.GateUpBits, s.GateUpMode)
+		if !ok {
+			return nil, false
+		}
+		guDims := gateUp.Dims()
+		if len(guDims) != 3 || guDims[2]%2 != 0 {
+			return nil, false
+		}
+		mid := int32(guDims[len(guDims)-1] / 2)
+		gate := mlx.SliceStartStop(gateUp, []int32{0, 0, 0}, []int32{tokens, cfg.NumExpertsPerTok, mid})
+		up := mlx.SliceStartStop(gateUp, []int32{0, 0, mid}, []int32{tokens, cfg.NumExpertsPerTok, int32(guDims[len(guDims)-1])})
+		hidden := mlx.SwiGLU(gate, up)
+		down, ok := mlx.FastMoEGatherQMMBlockMapped(hidden, s.DownWeightQ, s.DownScales, expertMap, topK, s.DownGroupSize, s.DownBits, s.DownMode)
+		if !ok {
+			return nil, false
+		}
+		return mlx.Reshape(down, B, L, cfg.NumExpertsPerTok, cfg.HiddenSize), true
+	}
+
+	gate, ok := mlx.FastMoEGatherQMMBlockMapped(xFlat, s.GateWeightQ, s.GateScales, expertMap, topK, s.GateGroupSize, s.GateBits, s.GateMode)
+	if !ok {
+		return nil, false
+	}
+	up, ok := mlx.FastMoEGatherQMMBlockMapped(xFlat, s.UpWeightQ, s.UpScales, expertMap, topK, s.UpGroupSize, s.UpBits, s.UpMode)
+	if !ok {
+		return nil, false
+	}
+
+	gate = mlx.Reshape(gate, tokens, cfg.NumExpertsPerTok, 1, int32(gate.Dim(2)))
+	up = mlx.Reshape(up, tokens, cfg.NumExpertsPerTok, 1, int32(up.Dim(2)))
+	var hidden *mlx.Array
+	if s.GateGlobalScale != nil {
+		if fused, ok := mlx.FastSwiGLUGatheredGateScale(gate, up, s.GateGlobalScale, idxFlat); ok {
+			hidden = fused
+		}
+	}
+	if hidden == nil {
+		gate = applyExpertGlobalScale(gate, s.GateGlobalScale, idxFlat)
+		hidden = mlx.SwiGLU(gate, up)
+	}
+	hidden = mlx.Reshape(hidden, tokens, cfg.NumExpertsPerTok, int32(hidden.Dim(3)))
+
+	down, ok := mlx.FastMoEGatherQMMBlockMapped(hidden, s.DownWeightQ, s.DownScales, expertMap, topK, s.DownGroupSize, s.DownBits, s.DownMode)
+	if !ok {
+		return nil, false
+	}
+	return mlx.Reshape(down, B, L, cfg.NumExpertsPerTok, cfg.HiddenSize), true
+}
+
+func (s *SwitchMLP) mappedDenseForward(x *mlx.Array, indices *mlx.Array, cfg *Config) (*mlx.Array, bool) {
+	if !s.canMapDenseExpert() {
+		return nil, false
+	}
+
+	dims := x.Dims()
+	if len(dims) != 3 || dims[0] <= 0 || dims[1] <= 0 || dims[2] <= 0 || cfg.NumExpertsPerTok <= 0 {
+		return nil, false
+	}
+	B, L := int32(dims[0]), int32(dims[1])
+	tokens := B * L
+	if !shouldMapDenseMoEExperts(tokens) {
+		return nil, false
+	}
+
+	topK := int(cfg.NumExpertsPerTok)
+	idxFlat := mlx.Reshape(indices, tokens, cfg.NumExpertsPerTok)
+	var experts int
+	if s.UseFusedGateUp {
+		experts = s.GateUpWeight.Dim(0)
+	} else {
+		experts = s.GateWeight.Dim(0)
+	}
+	expertMap, ok := mlx.NewMoEExpertMap(idxFlat, experts)
+	if !ok {
+		return nil, false
+	}
+
+	xFlat := mlx.Reshape(x, tokens, 1, cfg.HiddenSize)
+	if s.UseFusedGateUp {
+		gateUp, ok := mlx.FastMoEGatherMMBlockMapped(xFlat, s.GateUpWeight, expertMap, topK)
+		if !ok {
+			return nil, false
+		}
+		guDims := gateUp.Dims()
+		if len(guDims) != 3 || guDims[2]%2 != 0 {
+			return nil, false
+		}
+		mid := int32(guDims[len(guDims)-1] / 2)
+		gate := mlx.SliceStartStop(gateUp, []int32{0, 0, 0}, []int32{tokens, cfg.NumExpertsPerTok, mid})
+		up := mlx.SliceStartStop(gateUp, []int32{0, 0, mid}, []int32{tokens, cfg.NumExpertsPerTok, int32(guDims[len(guDims)-1])})
+		hidden := mlx.SwiGLU(gate, up)
+		down, ok := mlx.FastMoEGatherMMBlockMapped(hidden, s.DownWeight, expertMap, topK)
+		if !ok {
+			return nil, false
+		}
+		return mlx.Reshape(down, B, L, cfg.NumExpertsPerTok, cfg.HiddenSize), true
+	}
+
+	gate, ok := mlx.FastMoEGatherMMBlockMapped(xFlat, s.GateWeight, expertMap, topK)
+	if !ok {
+		return nil, false
+	}
+	up, ok := mlx.FastMoEGatherMMBlockMapped(xFlat, s.UpWeight, expertMap, topK)
+	if !ok {
+		return nil, false
+	}
+
+	gate = mlx.Reshape(gate, tokens, cfg.NumExpertsPerTok, 1, int32(gate.Dim(2)))
+	up = mlx.Reshape(up, tokens, cfg.NumExpertsPerTok, 1, int32(up.Dim(2)))
+	var hidden *mlx.Array
+	if s.GateGlobalScale != nil {
+		if fused, ok := mlx.FastSwiGLUGatheredGateScale(gate, up, s.GateGlobalScale, idxFlat); ok {
+			hidden = fused
+		}
+	}
+	if hidden == nil {
+		gate = applyExpertGlobalScale(gate, s.GateGlobalScale, idxFlat)
+		hidden = mlx.SwiGLU(gate, up)
+	}
+	hidden = mlx.Reshape(hidden, tokens, cfg.NumExpertsPerTok, int32(hidden.Dim(3)))
+
+	down, ok := mlx.FastMoEGatherMMBlockMapped(hidden, s.DownWeight, expertMap, topK)
+	if !ok {
+		return nil, false
+	}
+	return mlx.Reshape(down, B, L, cfg.NumExpertsPerTok, cfg.HiddenSize), true
+}
+
+func (s *SwitchMLP) gatherForward(x *mlx.Array, indices *mlx.Array, cfg *Config, sortExperts bool) *mlx.Array {
 	dims := x.Dims()
 	B, L := int32(dims[0]), int32(dims[1])
 	topK := cfg.NumExpertsPerTok
@@ -1042,10 +1439,7 @@ func (s *SwitchMLP) Forward(x *mlx.Array, indices *mlx.Array, cfg *Config) *mlx.
 	xExpanded := mlx.ExpandDims(mlx.ExpandDims(x, -2), -2)
 	xFlat := mlx.Reshape(xExpanded, B*L, 1, 1, cfg.HiddenSize)
 	idxFlat := mlx.Reshape(indices, B*L, topK)
-	doSort := B*L >= 64
-	if s.UseQuantized && s.usesFPQuantizedExperts() {
-		doSort = false
-	}
+	doSort := sortExperts && shouldMapMoEExperts(B*L)
 	var invOrder *mlx.Array
 	n := B * L * topK
 
@@ -1069,8 +1463,15 @@ func (s *SwitchMLP) Forward(x *mlx.Array, indices *mlx.Array, cfg *Config) *mlx.
 		} else {
 			gate = mlx.GatherQMM(xFlat, s.GateWeightQ, s.GateScales, s.GateBiases, nil, idxFlat, true, s.GateGroupSize, s.GateBits, s.GateMode, doSort)
 			up = mlx.GatherQMM(xFlat, s.UpWeightQ, s.UpScales, s.UpBiases, nil, idxFlat, true, s.UpGroupSize, s.UpBits, s.UpMode, doSort)
-			gate = applyExpertGlobalScale(gate, s.GateGlobalScale, idxFlat)
-			hidden = mlx.SwiGLU(gate, up)
+			if s.GateGlobalScale != nil {
+				if fused, ok := mlx.FastSwiGLUGatheredGateScale(gate, up, s.GateGlobalScale, idxFlat); ok {
+					hidden = fused
+				}
+			}
+			if hidden == nil {
+				gate = applyExpertGlobalScale(gate, s.GateGlobalScale, idxFlat)
+				hidden = mlx.SwiGLU(gate, up)
+			}
 		}
 		down = mlx.GatherQMM(hidden, s.DownWeightQ, s.DownScales, s.DownBiases, nil, idxFlat, true, s.DownGroupSize, s.DownBits, s.DownMode, doSort)
 	} else {
@@ -1096,19 +1497,6 @@ func (s *SwitchMLP) Forward(x *mlx.Array, indices *mlx.Array, cfg *Config) *mlx.
 	return mlx.Reshape(down, B, L, topK, cfg.HiddenSize)
 }
 
-func (s *SwitchMLP) weightForGatherMM(w *mlx.Array) *mlx.Array {
-	if s.DenseWeightsSourceLayout {
-		return transposeExpertWeightViewForGatherMM(w)
-	}
-	return w
-}
-
-func (s *SwitchMLP) usesFPQuantizedExperts() bool {
-	return s.GateUpMode == "nvfp4" || s.GateMode == "nvfp4" || s.UpMode == "nvfp4" || s.DownMode == "nvfp4" ||
-		s.GateUpMode == "mxfp4" || s.GateMode == "mxfp4" || s.UpMode == "mxfp4" || s.DownMode == "mxfp4" ||
-		s.GateUpMode == "mxfp8" || s.GateMode == "mxfp8" || s.UpMode == "mxfp8" || s.DownMode == "mxfp8"
-}
-
 func scaleScoresByExpert(scores, inds, globalScale *mlx.Array) *mlx.Array {
 	if globalScale == nil {
 		return scores
@@ -1123,12 +1511,22 @@ func scaleScoresByExpert(scores, inds, globalScale *mlx.Array) *mlx.Array {
 	return mlx.Mul(scores, mlx.Take(scale, inds, 0))
 }
 
-func (m *SparseMoE) route(xFlat *mlx.Array, cfg *Config) (scores, inds *mlx.Array) {
-	gates := m.Gate.Forward(xFlat).AsType(mlx.DTypeFloat32)
+func (m *SparseMoE) route(xFlat *mlx.Array, cfg *Config) (scores, inds *mlx.Array, scalesFolded bool) {
+	gates := m.Gate.Forward(xFlat)
 	var probs, neg *mlx.Array
 	if m.EScoreCorrectionBias != nil {
+		if m.SwitchMLP != nil && m.SwitchMLP.UpGlobalScale != nil && m.SwitchMLP.DownGlobalScale != nil {
+			if scores, inds, ok := mlx.FastSigmoidTopKRouterScaled(gates, m.EScoreCorrectionBias, m.SwitchMLP.UpGlobalScale, m.SwitchMLP.DownGlobalScale, int(cfg.NumExpertsPerTok), cfg.NormTopKProb && cfg.NumExpertsPerTok > 1); ok {
+				return scores, inds, true
+			}
+		}
+		if scores, inds, ok := mlx.FastSigmoidTopKRouter(gates, m.EScoreCorrectionBias, int(cfg.NumExpertsPerTok), cfg.NormTopKProb && cfg.NumExpertsPerTok > 1); ok {
+			return scores, inds, false
+		}
+		gates = gates.AsType(mlx.DTypeFloat32)
 		probs, neg = mlx.SigmoidRouter(gates, m.EScoreCorrectionBias)
 	} else {
+		gates = gates.AsType(mlx.DTypeFloat32)
 		probs = mlx.Sigmoid(gates)
 		neg = mlx.Neg(probs)
 	}
@@ -1138,39 +1536,125 @@ func (m *SparseMoE) route(xFlat *mlx.Array, cfg *Config) (scores, inds *mlx.Arra
 	if cfg.NormTopKProb && cfg.NumExpertsPerTok > 1 {
 		scores = mlx.Div(scores, mlx.Sum(scores, -1, true))
 	}
-	return scores, inds
+	return scores, inds, false
 }
 
 func (m *SparseMoE) Forward(x *mlx.Array, cfg *Config) *mlx.Array {
+	return m.forward(x, nil, cfg)
+}
+
+func (m *SparseMoE) ForwardAdd(x, residual *mlx.Array, cfg *Config) *mlx.Array {
+	return m.forward(x, residual, cfg)
+}
+
+func (m *SparseMoE) forward(x, residual *mlx.Array, cfg *Config) *mlx.Array {
 	dims := x.Dims()
 	B, L := int32(dims[0]), int32(dims[1])
 	BL := B * L
 
 	shared := m.SharedExpert.Forward(x, cfg)
 	xFlat := mlx.Reshape(x, BL, cfg.HiddenSize)
-	scores, inds := m.route(xFlat, cfg)
-	scores = scaleScoresByExpert(scores, inds, m.SwitchMLP.UpGlobalScale)
-	scores = scaleScoresByExpert(scores, inds, m.SwitchMLP.DownGlobalScale)
-	scores = scores.AsType(x.DType())
+	scores, inds, scalesFolded := m.route(xFlat, cfg)
+	if !scalesFolded {
+		scores = scaleScoresByExpert(scores, inds, m.SwitchMLP.UpGlobalScale)
+		scores = scaleScoresByExpert(scores, inds, m.SwitchMLP.DownGlobalScale)
+	}
 
 	expertOut := m.SwitchMLP.Forward(x, inds, cfg)
-	routed := mlx.Sum(mlx.Mul(expertOut, mlx.ExpandDims(mlx.Reshape(scores, B, L, cfg.NumExpertsPerTok), -1)), 2, false)
-	if cfg.MoeRoutedScalingFactor != 1 {
-		routed = mlx.MulScalar(routed, cfg.MoeRoutedScalingFactor)
+	scoreDims := mlx.Reshape(scores, B, L, cfg.NumExpertsPerTok)
+	if residual != nil {
+		return moeWeightedSumAdd2(expertOut, scoreDims, shared, residual, x.DType(), cfg.MoeRoutedScalingFactor)
 	}
-	return mlx.Add(routed, shared)
+	return moeWeightedSumAdd(expertOut, scoreDims, shared, x.DType(), cfg.MoeRoutedScalingFactor)
+}
+
+func moeWeightedSum(expertOut, scores *mlx.Array, dtype mlx.DType, scale float32) *mlx.Array {
+	if y, ok := mlx.FastMoEWeightedSum(expertOut, scores, nil, nil, dtype, scale); ok {
+		return y
+	}
+	y := mlx.Sum(mlx.Mul(expertOut, mlx.ExpandDims(scores.AsType(expertOut.DType()), -1)), 2, false).AsType(dtype)
+	if scale != 1 {
+		y = mlx.MulScalar(y, scale)
+	}
+	return y
+}
+
+func moeWeightedSumAdd(expertOut, scores, shared *mlx.Array, dtype mlx.DType, scale float32) *mlx.Array {
+	if y, ok := mlx.FastMoEWeightedSum(expertOut, scores, shared, nil, dtype, scale); ok {
+		return y
+	}
+	return mlx.Add(moeWeightedSum(expertOut, scores, dtype, scale), shared)
+}
+
+func moeWeightedSumAdd2(expertOut, scores, addA, addB *mlx.Array, dtype mlx.DType, scale float32) *mlx.Array {
+	if y, ok := mlx.FastMoEWeightedSum(expertOut, scores, addA, addB, dtype, scale); ok {
+		return y
+	}
+	return mlx.Add(moeWeightedSumAdd(expertOut, scores, addA, dtype, scale), addB)
 }
 
 func (l *Layer) Forward(x *mlx.Array, b *batch.Batch, c cache.Cache, positions *mlx.Array, B, L int32, cfg *Config) *mlx.Array {
-	r := l.Attention.Forward(l.InputNorm.Forward(x, cfg.RMSNormEps), b, c, positions, B, L, l, cfg)
+	xn := l.InputNorm.Forward(x, cfg.RMSNormEps)
+	r := l.Attention.Forward(xn, b, c, positions, B, L, l, cfg)
 	h := mlx.Add(x, r)
-	r = l.MLP.Forward(l.PostAttentionNorm.Forward(h, cfg.RMSNormEps), cfg)
+	mn := l.PostAttentionNorm.Forward(h, cfg.RMSNormEps)
+	if mlp, ok := l.MLP.(MLPBlockAdd); ok {
+		return mlp.ForwardAdd(mn, h, cfg)
+	}
+	r = l.MLP.Forward(mn, cfg)
 	return mlx.Add(h, r)
 }
+
+// Laguna prefill is faster in cache-backed 512-token slices than in the
+// runner's larger default chunk because attention work grows with query span.
+const lagunaPrefillChunkSize = 512
 
 func (m *Model) Forward(b *batch.Batch, caches []cache.Cache) *mlx.Array {
 	dims := b.InputIDs.Dims()
 	B, L := int32(dims[0]), int32(dims[1])
+	// Keep Laguna's long prefill on the smaller attention shape that benchmarks
+	// well on Metal without changing the runner's global chunking contract.
+	if m.shouldChunkPrefill(b, caches, B, L) {
+		return m.forwardChunked(b, caches, int(L))
+	}
+
+	return m.forward(b, caches, B, L)
+}
+
+func (m *Model) shouldChunkPrefill(b *batch.Batch, caches []cache.Cache, B, L int32) bool {
+	if B != 1 || L <= lagunaPrefillChunkSize {
+		return false
+	}
+	if len(b.SeqOffsets) != 1 || len(b.SeqQueryLens) != 1 || b.SeqQueryLens[0] != L {
+		return false
+	}
+	if len(caches) < len(m.Layers) {
+		return false
+	}
+	for i := range m.Layers {
+		if caches[i] == nil {
+			return false
+		}
+	}
+	return true
+}
+
+func (m *Model) forwardChunked(b *batch.Batch, caches []cache.Cache, total int) *mlx.Array {
+	hidden := make([]*mlx.Array, 0, (total+lagunaPrefillChunkSize-1)/lagunaPrefillChunkSize)
+	for start := 0; start < total; start += lagunaPrefillChunkSize {
+		stop := min(start+lagunaPrefillChunkSize, total)
+		chunkIDs := mlx.SliceStartStop(b.InputIDs, []int32{0, int32(start)}, []int32{1, int32(stop)})
+		chunk := &batch.Batch{
+			InputIDs:     chunkIDs,
+			SeqOffsets:   []int32{b.SeqOffsets[0] + int32(start)},
+			SeqQueryLens: []int32{int32(stop - start)},
+		}
+		hidden = append(hidden, m.forward(chunk, caches, 1, int32(stop-start)))
+	}
+	return mlx.Concatenate(hidden, 1)
+}
+
+func (m *Model) forward(b *batch.Batch, caches []cache.Cache, B, L int32) *mlx.Array {
 	positions := mlx.FromValues(b.SeqOffsets, len(b.SeqOffsets))
 	h := m.EmbedTokens.Forward(b.InputIDs)
 	for i, layer := range m.Layers {

--- a/x/models/laguna/laguna.go
+++ b/x/models/laguna/laguna.go
@@ -132,6 +132,10 @@ type SwitchMLP struct {
 	GateWeight   *mlx.Array
 	UpWeight     *mlx.Array
 	DownWeight   *mlx.Array
+	// DenseWeightsSourceLayout means dense expert weights are stored as
+	// [experts, out, in], matching the published tensors. GatherMM fallback
+	// transposes lazily so load does not materialize huge BF16 expert tensors.
+	DenseWeightsSourceLayout bool
 
 	GateUpWeightQ, GateUpScales, GateUpBiases *mlx.Array
 	GateWeightQ, GateScales, GateBiases       *mlx.Array
@@ -588,6 +592,55 @@ func transposeExpertWeightForGatherMM(w *mlx.Array) *mlx.Array {
 	return t
 }
 
+func transposeExpertWeightViewForGatherMM(w *mlx.Array) *mlx.Array {
+	if w == nil || !w.Valid() || w.NumDims() != 3 {
+		return w
+	}
+	return mlx.Transpose(w, 0, 2, 1)
+}
+
+func denseExpertWeight(w *stackedExpertWeights) *mlx.Array {
+	if w == nil {
+		return nil
+	}
+	weight := w.Weight
+	if w.Scales != nil {
+		weight = mlx.Dequantize(w.Weight, w.Scales, w.Biases, w.GroupSize, w.Bits, w.Mode)
+		if w.GlobalScales != nil {
+			scale := w.GlobalScales
+			if scale.DType() != weight.DType() {
+				scale = scale.AsType(weight.DType())
+			}
+			if !(scale.NumDims() == 0 || (scale.NumDims() == 1 && scale.Dim(0) == 1)) {
+				scale = mlx.ExpandDims(mlx.ExpandDims(scale, -1), -1)
+			}
+			weight = mlx.Mul(weight, scale)
+		}
+	}
+	return weight
+}
+
+func denseExpertWeightForGatherMM(w *stackedExpertWeights) *mlx.Array {
+	weight := denseExpertWeight(w)
+	if weight == nil {
+		return nil
+	}
+	return transposeExpertWeightForGatherMM(weight)
+}
+
+func denseExpertWeightSupportsSourceLayout(w *stackedExpertWeights) bool {
+	return w != nil && w.Weight != nil && w.Weight.Valid() && w.Scales == nil && w.Weight.DType() == mlx.DTypeBFloat16
+}
+
+func denseExpertWeightsSupportSourceLayout(weights ...*stackedExpertWeights) bool {
+	for _, w := range weights {
+		if !denseExpertWeightSupportsSourceLayout(w) {
+			return false
+		}
+	}
+	return true
+}
+
 func canFuseQuantizedGateUp(gateW, upW *stackedExpertWeights) bool {
 	if gateW == nil || upW == nil || gateW.Scales == nil || upW.Scales == nil {
 		return false
@@ -611,6 +664,17 @@ func fuseExpertStacks(a, b *mlx.Array, axis int) *mlx.Array {
 	out := mlx.Concatenate([]*mlx.Array{a, b}, axis).Clone()
 	mlx.Eval(out)
 	return out
+}
+
+func applyExpertGlobalScale(x, globalScale, idx *mlx.Array) *mlx.Array {
+	if globalScale == nil {
+		return x
+	}
+	if globalScale.NumDims() == 0 || (globalScale.NumDims() == 1 && globalScale.Dim(0) == 1) {
+		return mlx.Mul(x, globalScale).AsType(x.DType())
+	}
+	scale := mlx.ExpandDims(mlx.ExpandDims(mlx.Take(globalScale, idx, 0), -1), -1)
+	return mlx.Mul(x, scale).AsType(x.DType())
 }
 
 func combinedTensorGlobalScale(tensors map[string]*mlx.Array, key string) (*mlx.Array, []string) {
@@ -715,26 +779,43 @@ func loadStackedProjection(tensors map[string]*mlx.Array, cfg *Config, useQuanti
 		if w == nil {
 			continue
 		}
+		consumedKeys := []string{key}
 		s := tensors[key+"_scale"]
-		if s == nil {
-			s = tensors[key+".scale"]
+		if s != nil {
+			consumedKeys = append(consumedKeys, key+"_scale")
 		}
 		if s == nil {
+			s = tensors[key+".scale"]
+			if s != nil {
+				consumedKeys = append(consumedKeys, key+".scale")
+			}
+		}
+		if s == nil {
+			freeTensorKeys(tensors, consumedKeys...)
 			return &stackedExpertWeights{Weight: w}
 		}
 		qb := tensors[key+"_qbias"]
+		if qb != nil {
+			consumedKeys = append(consumedKeys, key+"_qbias")
+		}
 		if qb == nil {
 			qb = tensors[key+".bias"]
+			if qb != nil {
+				consumedKeys = append(consumedKeys, key+".bias")
+			}
 		}
-		globalScale, _ := combinedTensorGlobalScale(tensors, key)
+		globalScale, globalScaleKeys := combinedTensorGlobalScale(tensors, key)
+		consumedKeys = append(consumedKeys, globalScaleKeys...)
 		gs, b, m := model.ResolveLinearQuantParams(cfg.QuantGroupSize, cfg.QuantBits, cfg.QuantMode, cfg.TensorQuant, key, w, s)
 		if useQuantized && supportsGatherQMM(m, b) {
+			freeTensorKeys(tensors, consumedKeys...)
 			return &stackedExpertWeights{Weight: w, Scales: s, Biases: qb, GlobalScales: globalScale, Bits: b, GroupSize: gs, Mode: m}
 		}
 		deq := mlx.Dequantize(w, s, qb, gs, b, m)
 		if globalScale != nil {
 			deq = mlx.Mul(deq, globalScale)
 		}
+		freeTensorKeys(tensors, consumedKeys...)
 		return &stackedExpertWeights{Weight: deq, GlobalScales: globalScale, Bits: b, GroupSize: gs, Mode: m}
 	}
 	return nil
@@ -869,10 +950,19 @@ func (m *Model) LoadWeights(tensors map[string]*mlx.Array) error {
 					sw.UpBits, sw.UpGroupSize, sw.UpMode = upW.Bits, upW.GroupSize, upW.Mode
 				}
 			} else {
-				sw.GateWeight = transposeExpertWeightForGatherMM(gateW.Weight)
-				sw.UpWeight = transposeExpertWeightForGatherMM(upW.Weight)
-				sw.DownWeight = transposeExpertWeightForGatherMM(downW.Weight)
-				sw.GateUpWeight = fuseExpertStacks(sw.GateWeight, sw.UpWeight, 2)
+				sw.DenseWeightsSourceLayout = denseExpertWeightsSupportSourceLayout(gateW, upW, downW)
+				if sw.DenseWeightsSourceLayout {
+					sw.GateWeight = denseExpertWeight(gateW)
+					sw.UpWeight = denseExpertWeight(upW)
+					sw.DownWeight = denseExpertWeight(downW)
+					// Avoid pre-fusing source-layout BF16 gate/up weights: the
+					// full-size concatenate can time out during model load.
+				} else {
+					sw.GateWeight = denseExpertWeightForGatherMM(gateW)
+					sw.UpWeight = denseExpertWeightForGatherMM(upW)
+					sw.DownWeight = denseExpertWeightForGatherMM(downW)
+					sw.GateUpWeight = fuseExpertStacks(sw.GateWeight, sw.UpWeight, 2)
+				}
 				sw.UseFusedGateUp = sw.GateUpWeight != nil
 			}
 			moe.SwitchMLP = sw
@@ -953,6 +1043,9 @@ func (s *SwitchMLP) Forward(x *mlx.Array, indices *mlx.Array, cfg *Config) *mlx.
 	xFlat := mlx.Reshape(xExpanded, B*L, 1, 1, cfg.HiddenSize)
 	idxFlat := mlx.Reshape(indices, B*L, topK)
 	doSort := B*L >= 64
+	if s.UseQuantized && s.usesFPQuantizedExperts() {
+		doSort = false
+	}
 	var invOrder *mlx.Array
 	n := B * L * topK
 
@@ -975,33 +1068,25 @@ func (s *SwitchMLP) Forward(x *mlx.Array, indices *mlx.Array, cfg *Config) *mlx.
 			hidden = mlx.SwiGLU(gate, up)
 		} else {
 			gate = mlx.GatherQMM(xFlat, s.GateWeightQ, s.GateScales, s.GateBiases, nil, idxFlat, true, s.GateGroupSize, s.GateBits, s.GateMode, doSort)
-			if s.GateGlobalScale != nil {
-				gate = mlx.Mul(gate, mlx.Take(s.GateGlobalScale, idxFlat, 0))
-			}
 			up = mlx.GatherQMM(xFlat, s.UpWeightQ, s.UpScales, s.UpBiases, nil, idxFlat, true, s.UpGroupSize, s.UpBits, s.UpMode, doSort)
-			if s.UpGlobalScale != nil {
-				up = mlx.Mul(up, mlx.Take(s.UpGlobalScale, idxFlat, 0))
-			}
+			gate = applyExpertGlobalScale(gate, s.GateGlobalScale, idxFlat)
 			hidden = mlx.SwiGLU(gate, up)
 		}
 		down = mlx.GatherQMM(hidden, s.DownWeightQ, s.DownScales, s.DownBiases, nil, idxFlat, true, s.DownGroupSize, s.DownBits, s.DownMode, doSort)
-		if s.DownGlobalScale != nil {
-			down = mlx.Mul(down, mlx.Take(s.DownGlobalScale, idxFlat, 0))
-		}
 	} else {
 		if s.UseFusedGateUp && s.GateUpWeight != nil {
-			gateUp := mlx.GatherMM(xFlat, s.GateUpWeight, nil, idxFlat, doSort)
+			gateUp := mlx.GatherMM(xFlat, s.weightForGatherMM(s.GateUpWeight), nil, idxFlat, doSort)
 			guDims := gateUp.Dims()
 			mid := int32(guDims[len(guDims)-1] / 2)
 			gate = mlx.SliceStartStop(gateUp, []int32{0, 0, 0, 0}, []int32{int32(guDims[0]), int32(guDims[1]), int32(guDims[2]), mid})
 			up = mlx.SliceStartStop(gateUp, []int32{0, 0, 0, mid}, []int32{int32(guDims[0]), int32(guDims[1]), int32(guDims[2]), int32(guDims[len(guDims)-1])})
 			hidden = mlx.SwiGLU(gate, up)
 		} else {
-			gate = mlx.GatherMM(xFlat, s.GateWeight, nil, idxFlat, doSort)
-			up = mlx.GatherMM(xFlat, s.UpWeight, nil, idxFlat, doSort)
+			gate = mlx.GatherMM(xFlat, s.weightForGatherMM(s.GateWeight), nil, idxFlat, doSort)
+			up = mlx.GatherMM(xFlat, s.weightForGatherMM(s.UpWeight), nil, idxFlat, doSort)
 			hidden = mlx.SwiGLU(gate, up)
 		}
-		down = mlx.GatherMM(hidden, s.DownWeight, nil, idxFlat, doSort)
+		down = mlx.GatherMM(hidden, s.weightForGatherMM(s.DownWeight), nil, idxFlat, doSort)
 	}
 	if doSort {
 		down = mlx.Reshape(mlx.Take(mlx.Squeeze(mlx.Squeeze(down, 2), 1), invOrder, 0), B*L, topK, cfg.HiddenSize)
@@ -1009,6 +1094,33 @@ func (s *SwitchMLP) Forward(x *mlx.Array, indices *mlx.Array, cfg *Config) *mlx.
 		down = mlx.Squeeze(down, 2)
 	}
 	return mlx.Reshape(down, B, L, topK, cfg.HiddenSize)
+}
+
+func (s *SwitchMLP) weightForGatherMM(w *mlx.Array) *mlx.Array {
+	if s.DenseWeightsSourceLayout {
+		return transposeExpertWeightViewForGatherMM(w)
+	}
+	return w
+}
+
+func (s *SwitchMLP) usesFPQuantizedExperts() bool {
+	return s.GateUpMode == "nvfp4" || s.GateMode == "nvfp4" || s.UpMode == "nvfp4" || s.DownMode == "nvfp4" ||
+		s.GateUpMode == "mxfp4" || s.GateMode == "mxfp4" || s.UpMode == "mxfp4" || s.DownMode == "mxfp4" ||
+		s.GateUpMode == "mxfp8" || s.GateMode == "mxfp8" || s.UpMode == "mxfp8" || s.DownMode == "mxfp8"
+}
+
+func scaleScoresByExpert(scores, inds, globalScale *mlx.Array) *mlx.Array {
+	if globalScale == nil {
+		return scores
+	}
+	scale := globalScale
+	if scale.DType() != scores.DType() {
+		scale = scale.AsType(scores.DType())
+	}
+	if scale.NumDims() == 0 || (scale.NumDims() == 1 && scale.Dim(0) == 1) {
+		return mlx.Mul(scores, scale)
+	}
+	return mlx.Mul(scores, mlx.Take(scale, inds, 0))
 }
 
 func (m *SparseMoE) route(xFlat *mlx.Array, cfg *Config) (scores, inds *mlx.Array) {
@@ -1037,6 +1149,8 @@ func (m *SparseMoE) Forward(x *mlx.Array, cfg *Config) *mlx.Array {
 	shared := m.SharedExpert.Forward(x, cfg)
 	xFlat := mlx.Reshape(x, BL, cfg.HiddenSize)
 	scores, inds := m.route(xFlat, cfg)
+	scores = scaleScoresByExpert(scores, inds, m.SwitchMLP.UpGlobalScale)
+	scores = scaleScoresByExpert(scores, inds, m.SwitchMLP.DownGlobalScale)
 	scores = scores.AsType(x.DType())
 
 	expertOut := m.SwitchMLP.Forward(x, inds, cfg)

--- a/x/models/laguna/laguna_test.go
+++ b/x/models/laguna/laguna_test.go
@@ -2,6 +2,7 @@ package laguna
 
 import (
 	"math"
+	"strings"
 	"testing"
 
 	"github.com/ollama/ollama/x/mlxrunner/batch"
@@ -330,6 +331,68 @@ func TestTinyLagunaLoadWeightsFusesDenseGateUp(t *testing.T) {
 	}
 }
 
+func TestTinyLagunaLoadWeightsKeepsBF16SourceLayout(t *testing.T) {
+	skipIfNoMLX(t)
+	cfg, err := parseConfig([]byte(`{
+		"model_type": "laguna",
+		"hidden_size": 8,
+		"intermediate_size": 12,
+		"moe_intermediate_size": 4,
+		"shared_expert_intermediate_size": 4,
+		"num_hidden_layers": 2,
+		"num_attention_heads": 2,
+		"num_attention_heads_per_layer": [2, 2],
+		"num_key_value_heads": 1,
+		"head_dim": 4,
+		"vocab_size": 16,
+		"max_position_embeddings": 64,
+		"layer_types": ["full_attention", "sliding_attention"],
+		"sliding_window": 2,
+		"mlp_only_layers": [0],
+		"decoder_sparse_step": 1,
+		"num_experts": 2,
+		"num_experts_per_tok": 1,
+		"norm_topk_prob": false,
+		"moe_routed_scaling_factor": 2.5,
+		"gating": "per-head",
+		"rms_norm_eps": 1e-5
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tensors := tinyLagunaTensors()
+	for key, tensor := range tensors {
+		if strings.Contains(key, ".mlp.experts.") && strings.HasSuffix(key, ".weight") {
+			tensors[key] = tensor.AsType(mlx.DTypeBFloat16)
+		}
+	}
+	m := &Model{
+		Config: &cfg,
+		Layers: []*Layer{
+			{LayerIdx: 0, IsSliding: false},
+			{LayerIdx: 1, IsSliding: true},
+		},
+	}
+	if err := m.LoadWeights(tensors); err != nil {
+		t.Fatalf("LoadWeights failed: %v", err)
+	}
+
+	moe, ok := m.Layers[1].MLP.(*SparseMoE)
+	if !ok {
+		t.Fatalf("layer 1 MLP type = %T, want *SparseMoE", m.Layers[1].MLP)
+	}
+	if !moe.SwitchMLP.DenseWeightsSourceLayout {
+		t.Fatal("expected BF16 dense SwitchMLP to keep source-layout expert weights")
+	}
+	if moe.SwitchMLP.UseFusedGateUp || moe.SwitchMLP.GateUpWeight != nil {
+		t.Fatal("expected BF16 source-layout SwitchMLP to avoid pre-fused gate/up weights")
+	}
+	if got, want := moe.SwitchMLP.GateWeight.Dims(), []int{2, 4, 8}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] || got[2] != want[2] {
+		t.Fatalf("GateWeight dims = %v, want %v", got, want)
+	}
+}
+
 func TestSparseMoERouteBiasAffectsSelectionNotRoutingWeights(t *testing.T) {
 	skipIfNoMLX(t)
 	cfg := &Config{
@@ -404,6 +467,33 @@ func TestSwitchMLPFusedGateUpMatchesSeparate(t *testing.T) {
 	gotSeparateF32 := gotSeparate.AsType(mlx.DTypeFloat32)
 	mlx.Eval(gotFusedF32, gotSeparateF32)
 	assertFloatSlicesClose(t, gotFusedF32.Floats(), gotSeparateF32.Floats(), 1e-5)
+}
+
+func TestDenseExpertWeightForGatherMMDequantizesQuantizedWeight(t *testing.T) {
+	skipIfNoMLX(t)
+	weight := makePatternExpertWeight(2, 4, 32, 0.011)
+	qweight, scales, qbiases := mlx.Quantize(weight, 32, 8, "mxfp8")
+	mlx.Eval(qweight, scales)
+
+	got := denseExpertWeightForGatherMM(&stackedExpertWeights{
+		Weight:    qweight,
+		Scales:    scales,
+		Biases:    qbiases,
+		GroupSize: 32,
+		Bits:      8,
+		Mode:      "mxfp8",
+	})
+	mlx.Eval(got)
+
+	if got == nil {
+		t.Fatal("denseExpertWeightForGatherMM returned nil")
+	}
+	if dims := got.Dims(); len(dims) != 3 || dims[0] != 2 || dims[1] != 32 || dims[2] != 4 {
+		t.Fatalf("dense expert dims = %v, want [2 32 4]", dims)
+	}
+	if got.DType() == mlx.DTypeUint32 {
+		t.Fatal("dense expert fallback kept packed U32 weight")
+	}
 }
 
 func TestCombinedTensorGlobalScaleIgnoresInputGlobalScale(t *testing.T) {

--- a/x/models/laguna/laguna_test.go
+++ b/x/models/laguna/laguna_test.go
@@ -2,10 +2,12 @@ package laguna
 
 import (
 	"math"
+	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/ollama/ollama/x/mlxrunner/batch"
+	"github.com/ollama/ollama/x/mlxrunner/cache"
 	"github.com/ollama/ollama/x/mlxrunner/mlx"
 	"github.com/ollama/ollama/x/models/nn"
 )
@@ -113,6 +115,34 @@ func TestParseConfigLagunaFP8RopeScaling(t *testing.T) {
 	}
 	if cfg.FullRopeDim != 64 {
 		t.Fatalf("FullRopeDim = %d, want 64", cfg.FullRopeDim)
+	}
+}
+
+func TestShouldChunkPrefillOnlyForLongSingleSequenceCacheBackedForwards(t *testing.T) {
+	m := &Model{Layers: []*Layer{{}, {}}}
+	caches := []cache.Cache{cache.NewKVCache(), cache.NewRotatingKVCache(512)}
+	b := &batch.Batch{
+		SeqOffsets:   []int32{0},
+		SeqQueryLens: []int32{lagunaPrefillChunkSize + 1},
+	}
+
+	if !m.shouldChunkPrefill(b, caches, 1, lagunaPrefillChunkSize+1) {
+		t.Fatal("expected long single-sequence cache-backed prefill to chunk")
+	}
+	if m.shouldChunkPrefill(b, caches, 1, lagunaPrefillChunkSize) {
+		t.Fatal("short prefill should not chunk")
+	}
+	if m.shouldChunkPrefill(b, caches, 2, lagunaPrefillChunkSize+1) {
+		t.Fatal("batched prefill should not chunk")
+	}
+	if m.shouldChunkPrefill(&batch.Batch{
+		SeqOffsets:   []int32{0},
+		SeqQueryLens: []int32{lagunaPrefillChunkSize},
+	}, caches, 1, lagunaPrefillChunkSize+1) {
+		t.Fatal("padded query rows should not chunk")
+	}
+	if m.shouldChunkPrefill(b, caches[:1], 1, lagunaPrefillChunkSize+1) {
+		t.Fatal("missing layer caches should not chunk")
 	}
 }
 
@@ -408,7 +438,10 @@ func TestSparseMoERouteBiasAffectsSelectionNotRoutingWeights(t *testing.T) {
 	}
 
 	xFlat := mlx.FromValues([]float32{1}, 1, int(cfg.HiddenSize)).AsType(mlx.DTypeBFloat16)
-	scores, inds := moe.route(xFlat, cfg)
+	scores, inds, scalesFolded := moe.route(xFlat, cfg)
+	if scalesFolded {
+		t.Fatal("route folded scales without expert projection scales")
+	}
 	scores = scores.AsType(mlx.DTypeFloat32)
 	inds = inds.AsType(mlx.DTypeInt32)
 	mlx.Eval(scores, inds)
@@ -467,6 +500,52 @@ func TestSwitchMLPFusedGateUpMatchesSeparate(t *testing.T) {
 	gotSeparateF32 := gotSeparate.AsType(mlx.DTypeFloat32)
 	mlx.Eval(gotFusedF32, gotSeparateF32)
 	assertFloatSlicesClose(t, gotFusedF32.Floats(), gotSeparateF32.Floats(), 1e-5)
+}
+
+func TestSwitchMLPMappedDenseForwardMatchesGatherForward(t *testing.T) {
+	useMLXTestThread(t)
+	cfg := &Config{HiddenSize: 128, NumExpertsPerTok: 8}
+	const (
+		batch       = 1
+		seqLen      = 56
+		numExperts  = 16
+		moeHidden   = 64
+		hiddenSize  = 128
+		routedTopK  = 8
+		totalTokens = batch * seqLen
+	)
+
+	xVals := make([]float32, totalTokens*hiddenSize)
+	for i := range xVals {
+		xVals[i] = float32((i%37)-18) * 0.01
+	}
+	x := mlx.FromValues(xVals, batch, seqLen, hiddenSize).AsType(mlx.DTypeBFloat16)
+
+	indicesVals := make([]int32, totalTokens*routedTopK)
+	for tok := range totalTokens {
+		for k := range routedTopK {
+			indicesVals[tok*routedTopK+k] = int32((tok*5 + k*3 + k*k) % numExperts)
+		}
+	}
+	indices := mlx.FromValues(indicesVals, totalTokens, routedTopK)
+
+	s := &SwitchMLP{
+		GateWeight: makePatternExpertWeight(numExperts, hiddenSize, moeHidden, 0.011),
+		UpWeight:   makePatternExpertWeight(numExperts, hiddenSize, moeHidden, 0.017),
+		DownWeight: makePatternExpertWeight(numExperts, moeHidden, hiddenSize, 0.013),
+	}
+	s.GateUpWeight = fuseExpertStacks(s.GateWeight, s.UpWeight, 2)
+	s.UseFusedGateUp = s.GateUpWeight != nil
+
+	got, ok := s.mappedDenseForward(x, indices, cfg)
+	if !ok {
+		t.Skip("mapped dense fast path unavailable")
+	}
+	want := s.gatherForward(x, indices, cfg, false)
+	gotF32 := got.AsType(mlx.DTypeFloat32)
+	wantF32 := want.AsType(mlx.DTypeFloat32)
+	mlx.Eval(gotF32, wantF32)
+	assertFloatSlicesClose(t, gotF32.Floats(), wantF32.Floats(), 3e-2)
 }
 
 func TestDenseExpertWeightForGatherMMDequantizesQuantizedWeight(t *testing.T) {
@@ -595,5 +674,30 @@ func skipIfNoMLX(t *testing.T) {
 	t.Helper()
 	if err := mlx.CheckInit(); err != nil {
 		t.Skipf("MLX not available: %v", err)
+	}
+}
+
+func useMLXTestThread(t *testing.T) {
+	t.Helper()
+
+	runtime.LockOSThread()
+	initialized := false
+	t.Cleanup(func() {
+		if initialized {
+			mlx.Sweep()
+			mlx.ClearCache()
+			if mlx.GPUIsAvailable() {
+				mlx.SetDefaultDeviceGPU()
+			}
+		}
+		runtime.UnlockOSThread()
+	})
+
+	if err := mlx.CheckInit(); err != nil {
+		t.Skipf("MLX not available: %v", err)
+	}
+	initialized = true
+	if mlx.GPUIsAvailable() {
+		mlx.SetDefaultDeviceGPU()
 	}
 }

--- a/x/models/qwen3_5/qwen3_5.go
+++ b/x/models/qwen3_5/qwen3_5.go
@@ -170,6 +170,9 @@ type SwitchMLP struct {
 	GateGroupSize int
 	UpGroupSize   int
 	DownGroupSize int
+	GateMode      string
+	UpMode        string
+	DownMode      string
 
 	UseQuantized bool
 }
@@ -431,6 +434,10 @@ func supportsGatherQMM(mode string, bits int) bool {
 	default:
 		return false
 	}
+}
+
+func shouldMapMoEExperts(tokens int32) bool {
+	return tokens >= 64
 }
 
 func freeTensorKeys(tensors map[string]*mlx.Array, keys ...string) {
@@ -979,16 +986,19 @@ func (m *Model) LoadWeights(tensors map[string]*mlx.Array) error {
 				switchMLP.GateBiases = gateW.Biases
 				switchMLP.GateBits = gateW.Bits
 				switchMLP.GateGroupSize = gateW.GroupSize
+				switchMLP.GateMode = gateW.Mode
 				switchMLP.UpWeightQ = upW.Weight
 				switchMLP.UpScales = upW.Scales
 				switchMLP.UpBiases = upW.Biases
 				switchMLP.UpBits = upW.Bits
 				switchMLP.UpGroupSize = upW.GroupSize
+				switchMLP.UpMode = upW.Mode
 				switchMLP.DownWeightQ = downW.Weight
 				switchMLP.DownScales = downW.Scales
 				switchMLP.DownBiases = downW.Biases
 				switchMLP.DownBits = downW.Bits
 				switchMLP.DownGroupSize = downW.GroupSize
+				switchMLP.DownMode = downW.Mode
 			} else {
 				switchMLP.GateWeight = transposeExpertWeightForGatherMM(gateW.Weight)
 				switchMLP.UpWeight = transposeExpertWeightForGatherMM(upW.Weight)
@@ -1195,6 +1205,10 @@ func (m *DenseMLP) Forward(x *mlx.Array, _ *Config) *mlx.Array {
 }
 
 func (s *SwitchMLP) Forward(x *mlx.Array, indices *mlx.Array, cfg *Config) *mlx.Array {
+	if out, ok := s.mappedQuantizedForward(x, indices, cfg); ok {
+		return out
+	}
+
 	dims := x.Dims()
 	B, L := int32(dims[0]), int32(dims[1])
 	topK := cfg.NumExpertsPerTok
@@ -1218,12 +1232,12 @@ func (s *SwitchMLP) Forward(x *mlx.Array, indices *mlx.Array, cfg *Config) *mlx.
 	var gate, up, hidden, down *mlx.Array
 	if s.UseQuantized {
 		gate = mlx.GatherQMM(xFlat, s.GateWeightQ, s.GateScales, s.GateBiases,
-			nil, idxFlat, true, s.GateGroupSize, s.GateBits, cfg.QuantMode, doSort)
+			nil, idxFlat, true, s.GateGroupSize, s.GateBits, s.GateMode, doSort)
 		up = mlx.GatherQMM(xFlat, s.UpWeightQ, s.UpScales, s.UpBiases,
-			nil, idxFlat, true, s.UpGroupSize, s.UpBits, cfg.QuantMode, doSort)
+			nil, idxFlat, true, s.UpGroupSize, s.UpBits, s.UpMode, doSort)
 		hidden = mlx.SwiGLU(gate, up)
 		down = mlx.GatherQMM(hidden, s.DownWeightQ, s.DownScales, s.DownBiases,
-			nil, idxFlat, true, s.DownGroupSize, s.DownBits, cfg.QuantMode, doSort)
+			nil, idxFlat, true, s.DownGroupSize, s.DownBits, s.DownMode, doSort)
 	} else {
 		gate = mlx.GatherMM(xFlat, s.GateWeight, nil, idxFlat, doSort)
 		up = mlx.GatherMM(xFlat, s.UpWeight, nil, idxFlat, doSort)
@@ -1238,6 +1252,61 @@ func (s *SwitchMLP) Forward(x *mlx.Array, indices *mlx.Array, cfg *Config) *mlx.
 	}
 
 	return mlx.Reshape(down, B, L, topK, cfg.HiddenSize)
+}
+
+func (s *SwitchMLP) canMapQuantizedExpert() bool {
+	if !s.UseQuantized {
+		return false
+	}
+	if s.GateWeightQ == nil || s.GateScales == nil ||
+		s.UpWeightQ == nil || s.UpScales == nil ||
+		s.DownWeightQ == nil || s.DownScales == nil {
+		return false
+	}
+	if s.GateBiases != nil || s.UpBiases != nil || s.DownBiases != nil {
+		return false
+	}
+	return mlx.SupportsMoEGatherQMMBlockMapped(s.GateGroupSize, s.GateBits, s.GateMode) &&
+		mlx.SupportsMoEGatherQMMBlockMapped(s.UpGroupSize, s.UpBits, s.UpMode) &&
+		mlx.SupportsMoEGatherQMMBlockMapped(s.DownGroupSize, s.DownBits, s.DownMode)
+}
+
+func (s *SwitchMLP) mappedQuantizedForward(x *mlx.Array, indices *mlx.Array, cfg *Config) (*mlx.Array, bool) {
+	if !s.canMapQuantizedExpert() {
+		return nil, false
+	}
+
+	dims := x.Dims()
+	if len(dims) != 3 || dims[0] <= 0 || dims[1] <= 0 || dims[2] <= 0 || cfg.NumExpertsPerTok <= 0 {
+		return nil, false
+	}
+	B, L := int32(dims[0]), int32(dims[1])
+	tokens := B * L
+	if !shouldMapMoEExperts(tokens) {
+		return nil, false
+	}
+
+	topK := int(cfg.NumExpertsPerTok)
+	idxFlat := mlx.Reshape(indices, tokens, cfg.NumExpertsPerTok)
+	expertMap, ok := mlx.NewMoEGatherQMMMap(idxFlat, s.GateWeightQ.Dim(0))
+	if !ok {
+		return nil, false
+	}
+	xFlat := mlx.Reshape(x, tokens, 1, cfg.HiddenSize)
+	gate, ok := mlx.FastMoEGatherQMMBlockMapped(xFlat, s.GateWeightQ, s.GateScales, expertMap, topK, s.GateGroupSize, s.GateBits, s.GateMode)
+	if !ok {
+		return nil, false
+	}
+	up, ok := mlx.FastMoEGatherQMMBlockMapped(xFlat, s.UpWeightQ, s.UpScales, expertMap, topK, s.UpGroupSize, s.UpBits, s.UpMode)
+	if !ok {
+		return nil, false
+	}
+	hidden := mlx.SwiGLU(gate, up)
+	down, ok := mlx.FastMoEGatherQMMBlockMapped(hidden, s.DownWeightQ, s.DownScales, expertMap, topK, s.DownGroupSize, s.DownBits, s.DownMode)
+	if !ok {
+		return nil, false
+	}
+	return mlx.Reshape(down, B, L, cfg.NumExpertsPerTok, cfg.HiddenSize), true
 }
 
 func (m *SparseMoE) Forward(x *mlx.Array, cfg *Config) *mlx.Array {


### PR DESCRIPTION
Follow up to #17237


This adds a set of custom kernels (one is reusable across multiple MoE models) to improve prompt performance and bring this up to parity with llama-server.