### PR TITLE
openai: report incomplete status when responses hit the output token limit

### DIFF
--- a/middleware/openai.go
+++ b/middleware/openai.go
@@ -493,8 +493,10 @@ func (w *ResponsesWriter) writeResponse(data []byte) (int, error) {
 	// Non-streaming response
 	w.ResponseWriter.Header().Set("Content-Type", "application/json")
 	response := openai.ToResponse(w.model, w.responseID, w.itemID, chatResponse, w.request)
-	completedAt := time.Now().Unix()
-	response.CompletedAt = &completedAt
+	if response.Status == "completed" {
+		completedAt := time.Now().Unix()
+		response.CompletedAt = &completedAt
+	}
 	return len(data), json.NewEncoder(w.ResponseWriter).Encode(response)
 }
 

--- a/middleware/openai_test.go
+++ b/middleware/openai_test.go
@@ -1354,3 +1354,53 @@ func TestResponsesMiddlewareZstd(t *testing.T) {
 		})
 	}
 }
+
+func TestResponsesMiddlewareIncompleteOnLength(t *testing.T) {
+	tests := []struct {
+		name            string
+		doneReason      string
+		wantStatus      string
+		wantCompletedAt bool
+	}{
+		{name: "length truncation", doneReason: "length", wantStatus: "incomplete", wantCompletedAt: false},
+		{name: "natural stop", doneReason: "stop", wantStatus: "completed", wantCompletedAt: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			router := gin.New()
+			router.Use(ResponsesMiddleware())
+			router.Handle(http.MethodPost, "/v1/responses", func(c *gin.Context) {
+				c.JSON(http.StatusOK, api.ChatResponse{
+					Model:      "test-model",
+					Message:    api.Message{Role: "assistant", Content: "truncated tex"},
+					Done:       true,
+					DoneReason: tt.doneReason,
+				})
+			})
+
+			body := `{"model": "test-model", "input": "Hello", "max_output_tokens": 16}`
+			req, _ := http.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+
+			resp := httptest.NewRecorder()
+			router.ServeHTTP(resp, req)
+
+			if resp.Code != http.StatusOK {
+				t.Fatalf("expected status 200, got %d: %s", resp.Code, resp.Body.String())
+			}
+
+			var got map[string]any
+			if err := json.Unmarshal(resp.Body.Bytes(), &got); err != nil {
+				t.Fatal(err)
+			}
+			if got["status"] != tt.wantStatus {
+				t.Errorf("status = %q, want %q", got["status"], tt.wantStatus)
+			}
+			if (got["completed_at"] != nil) != tt.wantCompletedAt {
+				t.Errorf("completed_at = %v, want set=%v", got["completed_at"], tt.wantCompletedAt)
+			}
+		})
+	}
+}

--- a/openai/responses.go
+++ b/openai/responses.go
@@ -768,6 +768,14 @@ func ToResponse(model, responseID, itemID string, chatResponse api.ChatResponse,
 		})
 	}
 
+	status := "completed"
+	var incompleteDetails *ResponsesIncompleteDetails
+	if chatResponse.DoneReason == "length" {
+		// Generation was cut off by the output token limit, not finished.
+		status = "incomplete"
+		incompleteDetails = &ResponsesIncompleteDetails{Reason: "max_output_tokens"}
+	}
+
 	if len(chatResponse.Message.ToolCalls) > 0 {
 		toolCalls := ToToolCalls(chatResponse.Message.ToolCalls)
 		for i, tc := range toolCalls {
@@ -784,7 +792,7 @@ func ToResponse(model, responseID, itemID string, chatResponse api.ChatResponse,
 		output = append(output, ResponsesOutputItem{
 			ID:     itemID,
 			Type:   "message",
-			Status: "completed",
+			Status: status,
 			Role:   "assistant",
 			Content: []ResponsesOutputContent{
 				{
@@ -837,8 +845,8 @@ func ToResponse(model, responseID, itemID string, chatResponse api.ChatResponse,
 		Object:             "response",
 		CreatedAt:          chatResponse.CreatedAt.Unix(),
 		CompletedAt:        nil, // Set by middleware when writing final response
-		Status:             "completed",
-		IncompleteDetails:  nil, // Only populated if response incomplete
+		Status:             status,
+		IncompleteDetails:  incompleteDetails,
 		Model:              model,
 		PreviousResponseID: nil, // Not supported
 		Instructions:       instructions,
@@ -1275,7 +1283,10 @@ func (c *ResponsesStreamConverter) processTextContent(content string) []Response
 	return events
 }
 
-func (c *ResponsesStreamConverter) buildFinalOutput() []any {
+// buildFinalOutput assembles the final output items; messageStatus is the
+// status for the text message item ("completed", or "incomplete" when
+// generation was truncated).
+func (c *ResponsesStreamConverter) buildFinalOutput(messageStatus string) []any {
 	var output []any
 
 	// Add reasoning item if present
@@ -1298,7 +1309,7 @@ func (c *ResponsesStreamConverter) buildFinalOutput() []any {
 		output = append(output, map[string]any{
 			"id":     c.itemID,
 			"type":   "message",
-			"status": "completed",
+			"status": messageStatus,
 			"role":   "assistant",
 			"content": []map[string]any{{
 				"type":        "output_text",
@@ -1314,6 +1325,14 @@ func (c *ResponsesStreamConverter) buildFinalOutput() []any {
 
 func (c *ResponsesStreamConverter) processCompletion(r api.ChatResponse) []ResponsesStreamEvent {
 	var events []ResponsesStreamEvent
+
+	status := "completed"
+	eventType := "response.completed"
+	if r.DoneReason == "length" {
+		// Generation was cut off by the output token limit, not finished.
+		status = "incomplete"
+		eventType = "response.incomplete"
+	}
 
 	// Finish reasoning if not done
 	events = append(events, c.finishReasoning()...)
@@ -1348,7 +1367,7 @@ func (c *ResponsesStreamConverter) processCompletion(r api.ChatResponse) []Respo
 			"item": map[string]any{
 				"id":     c.itemID,
 				"type":   "message",
-				"status": "completed",
+				"status": status,
 				"role":   "assistant",
 				"content": []map[string]any{{
 					"type":        "output_text",
@@ -1372,9 +1391,13 @@ func (c *ResponsesStreamConverter) processCompletion(r api.ChatResponse) []Respo
 			"reasoning_tokens": 0,
 		},
 	}
-	response := c.buildResponseObject("completed", c.buildFinalOutput(), usage)
-	response["completed_at"] = time.Now().Unix()
-	events = append(events, c.newEvent("response.completed", map[string]any{
+	response := c.buildResponseObject(status, c.buildFinalOutput(status), usage)
+	if status == "completed" {
+		response["completed_at"] = time.Now().Unix()
+	} else {
+		response["incomplete_details"] = map[string]any{"reason": "max_output_tokens"}
+	}
+	events = append(events, c.newEvent(eventType, map[string]any{
 		"response": response,
 	}))
 

--- a/openai/responses.go
+++ b/openai/responses.go
@@ -844,7 +844,7 @@ func ToResponse(model, responseID, itemID string, chatResponse api.ChatResponse,
 		ID:                 responseID,
 		Object:             "response",
 		CreatedAt:          chatResponse.CreatedAt.Unix(),
-		CompletedAt:        nil, // Set by middleware when writing final response
+		CompletedAt:        nil, // Set by middleware when writing completed responses; stays null for incomplete ones
 		Status:             status,
 		IncompleteDetails:  incompleteDetails,
 		Model:              model,
@@ -1379,7 +1379,7 @@ func (c *ResponsesStreamConverter) processCompletion(r api.ChatResponse) []Respo
 		}))
 	}
 
-	// response.completed
+	// terminal event: response.completed, or response.incomplete when truncated
 	usage := map[string]any{
 		"input_tokens":  r.PromptEvalCount,
 		"output_tokens": r.EvalCount,

--- a/openai/responses_test.go
+++ b/openai/responses_test.go
@@ -2049,3 +2049,111 @@ func TestResponsesStreamConverter_FunctionCallStatus(t *testing.T) {
 		t.Errorf("output_item.done status = %q, want %q", doneItem["status"], "completed")
 	}
 }
+
+func TestToResponse_IncompleteOnLength(t *testing.T) {
+	chatResponse := api.ChatResponse{
+		Message:    api.Message{Role: "assistant", Content: "truncated tex"},
+		Done:       true,
+		DoneReason: "length",
+	}
+
+	response := ToResponse("gpt-oss:20b", "resp_123", "msg_456", chatResponse, ResponsesRequest{})
+	if response.Status != "incomplete" {
+		t.Errorf("status = %q, want %q", response.Status, "incomplete")
+	}
+	if response.IncompleteDetails == nil {
+		t.Fatal("incomplete_details = nil, want reason max_output_tokens")
+	}
+	if response.IncompleteDetails.Reason != "max_output_tokens" {
+		t.Errorf("incomplete_details.reason = %q, want %q", response.IncompleteDetails.Reason, "max_output_tokens")
+	}
+	if response.CompletedAt != nil {
+		t.Errorf("completed_at = %v, want nil", *response.CompletedAt)
+	}
+	if len(response.Output) != 1 {
+		t.Fatalf("output items = %d, want 1", len(response.Output))
+	}
+	if response.Output[0].Status != "incomplete" {
+		t.Errorf("output message status = %q, want %q", response.Output[0].Status, "incomplete")
+	}
+
+	chatResponse.DoneReason = "stop"
+	response = ToResponse("gpt-oss:20b", "resp_123", "msg_456", chatResponse, ResponsesRequest{})
+	if response.Status != "completed" {
+		t.Errorf("status = %q, want %q", response.Status, "completed")
+	}
+	if response.IncompleteDetails != nil {
+		t.Errorf("incomplete_details = %+v, want nil", response.IncompleteDetails)
+	}
+	if response.Output[0].Status != "completed" {
+		t.Errorf("output message status = %q, want %q", response.Output[0].Status, "completed")
+	}
+}
+
+func TestResponsesStreamConverter_IncompleteOnLength(t *testing.T) {
+	converter := NewResponsesStreamConverter("resp_123", "msg_456", "gpt-oss:20b", ResponsesRequest{})
+
+	converter.Process(api.ChatResponse{
+		Message: api.Message{Role: "assistant", Content: "partial"},
+	})
+	events := converter.Process(api.ChatResponse{
+		Message:    api.Message{Role: "assistant"},
+		Done:       true,
+		DoneReason: "length",
+	})
+
+	var terminalType string
+	var terminal map[string]any
+	var doneItem map[string]any
+	for _, event := range events {
+		data := event.Data.(map[string]any)
+		eventType, _ := data["type"].(string)
+		if eventType == "response.completed" || eventType == "response.incomplete" {
+			terminalType = eventType
+			terminal = data["response"].(map[string]any)
+		}
+		if eventType == "response.output_item.done" {
+			if item, ok := data["item"].(map[string]any); ok && item["type"] == "message" {
+				doneItem = item
+			}
+		}
+	}
+
+	if doneItem == nil {
+		t.Fatal("expected message output_item.done event")
+	}
+	if doneItem["status"] != "incomplete" {
+		t.Errorf("output_item.done message status = %q, want %q", doneItem["status"], "incomplete")
+	}
+
+	if terminal == nil {
+		t.Fatal("expected a terminal response event")
+	}
+	if terminalType != "response.incomplete" {
+		t.Errorf("terminal event type = %q, want %q", terminalType, "response.incomplete")
+	}
+	if terminal["status"] != "incomplete" {
+		t.Errorf("response.status = %q, want %q", terminal["status"], "incomplete")
+	}
+	details, ok := terminal["incomplete_details"].(map[string]any)
+	if !ok {
+		t.Fatalf("incomplete_details = %v, want object with reason", terminal["incomplete_details"])
+	}
+	if details["reason"] != "max_output_tokens" {
+		t.Errorf("incomplete_details.reason = %q, want %q", details["reason"], "max_output_tokens")
+	}
+	if terminal["completed_at"] != nil {
+		t.Errorf("completed_at = %v, want nil for incomplete response", terminal["completed_at"])
+	}
+	outputs, ok := terminal["output"].([]any)
+	if !ok || len(outputs) == 0 {
+		t.Fatalf("terminal response output = %v, want message item", terminal["output"])
+	}
+	finalMsg, ok := outputs[len(outputs)-1].(map[string]any)
+	if !ok || finalMsg["type"] != "message" {
+		t.Fatalf("last output item = %v, want message", outputs[len(outputs)-1])
+	}
+	if finalMsg["status"] != "incomplete" {
+		t.Errorf("final output message status = %q, want %q", finalMsg["status"], "incomplete")
+	}
+}


### PR DESCRIPTION
The /v1/responses endpoint always reports `status: "completed"`, even when generation was cut off by `max_output_tokens`. `ToResponse` hardcodes the status and never populates `IncompleteDetails` (the type exists in `openai/responses.go` but was never used), and the streaming converter always emits a `response.completed` event. Per the OpenAI Responses API, a truncated response should have `status: "incomplete"` with `incomplete_details: {"reason": "max_output_tokens"}`, the stream should end with a `response.incomplete` event, and the truncated message item should carry `status: "incomplete"` too. Clients relying on that signal (to retry with a bigger budget, or to flag partial output) currently see truncated responses as complete.

This maps `done_reason == "length"` to the incomplete status in both the non-streaming and streaming paths, sets the item-level status on the message output item, and leaves `completed_at` null for incomplete responses (it was previously stamped unconditionally in the middleware). Natural stops are unchanged, and `function_call` items keep `completed` since the parser only emits fully parsed calls.

Verified three ways: regression tests in `openai/responses_test.go` and `middleware/openai_test.go` that fail on main and pass here, the full `go test ./openai/ ./middleware/` suites plus golangci-lint clean, and a live check on my Mac against `ollama serve` with smollm2:135m, where `max_output_tokens: 16` now returns status incomplete with the right details object in both stream and non-stream modes, and a natural finish still returns completed with `completed_at` set.

quick note from a college freshman trying to contribute for the greater good :) I built this fix together with Claude Code (it did a lot of the heavy lifting while I drove and reviewed, and I ran the tests and live checks on my machine). if anything here misses the mark I would genuinely love the feedback, still learning!