### PR TITLE
agent/tui: remove redundant context-window refreshes from event loop

### DIFF
--- a/cmd/tui/chat/chat.go
+++ b/cmd/tui/chat/chat.go
@@ -224,9 +224,11 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 	m.nextImageID, m.nextAudioID = nextInputAttachmentIDsFromMessages(m.messages)
 	m.nextPastedTextID = nextInputPastedTextIDFromMessages(m.messages)
 	m.entries = entriesFromMessages(m.messages)
-	if !m.openModelOnInit {
-		m.refreshContextWindowTokens(m.opts.Model)
-	}
+	// Context window is resolved post-load (chatModelPreloadDoneMsg) rather than
+	// here: for local models /api/ps only reports the running num_ctx after the
+	// model loads, and opts.ContextWindowTokens already holds Show's max as a
+	// pre-load fallback. Refreshing now would just re-derive that same value
+	// (and block construction on a network call).
 	m.contextTokens = m.estimatePromptTokens(m.messages, "")
 	m.contextEstimate = true
 	if m.openModelOnInit {
@@ -375,7 +377,8 @@ func (m chatModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if msg.result.WorkingDir != "" {
 				m.workingDir = msg.result.WorkingDir
 			}
-			m.refreshContextWindowTokens(m.responseModelName(&msg.result.Latest))
+			// Context window is settled by preload (local num_ctx) or is
+			// static (cloud); no refresh needed post-run.
 			m.contextTokens = m.estimatePromptTokens(m.messages, "")
 			m.contextEstimate = true
 			if !messagesEndWithCompactionResult(m.messages) {
@@ -1093,7 +1096,6 @@ func (m *chatModel) startSkillRun(name, prompt string) (tea.Model, tea.Cmd) {
 }
 
 func (m *chatModel) startRunWithMessages(displayInput, historyInput string, newMessages []api.Message, extraSystemPrompt, skillName string) (tea.Model, tea.Cmd) {
-	m.refreshContextWindowTokens(m.opts.Model)
 	m.addPromptHistory(historyInput)
 	m.entries = append(m.entries, newChatEntry(chatEntry{role: "user", content: displayInput}))
 	if len(newMessages) > 1 {

--- a/cmd/tui/chat/events.go
+++ b/cmd/tui/chat/events.go
@@ -109,7 +109,6 @@ func (m *chatModel) applyAgentEvent(event coreagent.Event) {
 		contextChanged = true
 	case coreagent.EventToolStarted:
 		m.resetStreamingState()
-		m.refreshContextWindowTokens(m.opts.Model)
 		startedAt := time.Now()
 		idx := m.findActiveToolEntry(event.ToolCallID)
 		if idx < 0 {
@@ -127,7 +126,6 @@ func (m *chatModel) applyAgentEvent(event coreagent.Event) {
 		m.markEntryDirty(idx)
 	case coreagent.EventToolFinished:
 		m.resetStreamingState()
-		m.refreshContextWindowTokens(m.opts.Model)
 		if event.WorkingDir != "" {
 			m.workingDir = event.WorkingDir
 		}

--- a/cmd/tui/chat/render.go
+++ b/cmd/tui/chat/render.go
@@ -1435,18 +1435,6 @@ func (m *chatModel) updateContextWindowTokens(tokens int) {
 	}
 }
 
-func (m chatModel) responseModelName(response *api.ChatResponse) string {
-	if response != nil {
-		if strings.TrimSpace(response.Model) != "" {
-			return response.Model
-		}
-		if strings.TrimSpace(response.RemoteModel) != "" {
-			return response.RemoteModel
-		}
-	}
-	return m.opts.Model
-}
-
 func (m chatModel) currentWorkingDir() string {
 	if strings.TrimSpace(m.workingDir) != "" {
 		return m.workingDir


### PR DESCRIPTION
## Summary

`refreshContextWindowTokens` is synchronous — it blocks the Bubble Tea `Update` loop with an HTTP call. It was being invoked on every tool start, tool finish, run start, and run completion, even though the context window does not change during a session after preload.

### What changed
Removed `refreshContextWindowTokens` calls from:
- `EventToolStarted` / `EventToolFinished` (`events.go`) — fired on every tool call during agentic sessions
- `startRunWithMessages` (`chat.go`) — redundant with preload resolution
- `chatRunDoneMsg` handler (`chat.go`) — redundant with preload resolution
- `Run` init when `!openModelOnInit` (`chat.go`) — pre-load refresh just re-derives the same fallback

Also deleted the now-unused `responseModelName` helper (`render.go`).

### Why this is safe
The context window is settled at preload time:
- **Local models**: `chatModelPreloadDoneMsg` carries the authoritative `num_ctx` from `/api/ps`, which only becomes available after the model loads. This value does not change mid-session.
- **Cloud models**: context length is static for the session. The server already SWR-caches the recommendations feed (`modelRecommendationsCache`) and lazily hydrates `/api/show` responses (`modelShowCache`) for arbitrary cloud models.

### What was considered and dropped
An earlier iteration added a client-side `sync.Map` cache for cloud model context lengths. This was reverted because:
1. The server already caches both recommendation lookups and show responses (SWR, in-memory).
2. It broke non-recommended cloud models — the early `return fallback` cut off access to the server's lazy-hydrated `modelShowCache` via `/api/show`, which is the only source of context length for cloud models not in the recommendations feed.

The real win is removing the blocking calls from the event loop, not adding another cache layer.

### Testing
- `go build ./cmd/...` ✅
- `go vet ./cmd/... ./cmd/tui/chat/...` ✅
- `go test ./cmd/tui/chat/...` ✅