### PR TITLE
Launch codex-app not working after Codex update

### DIFF
--- a/cmd/launch/codex_app.go
+++ b/cmd/launch/codex_app.go
@@ -992,12 +992,20 @@ func defaultCodexAppRunningAppPath() string {
 	return strings.TrimSpace(string(out))
 }
 
+// codexAppStartAppsScript resolves the ChatGPT/Codex desktop Start menu AppID.
+// It matches the stable Store package identity (OpenAI.Codex_*!App) first so
+// detection survives the display name changing or being localized, then falls
+// back to the display name for installs that surface differently. Since Codex
+// merged into the ChatGPT desktop app the Store entry shows as "ChatGPT" while
+// keeping the OpenAI.Codex package family, so name-only matching missed it on
+// systems where the display name is not exactly "ChatGPT" or "Codex".
+const codexAppStartAppsScript = `(Get-StartApps | Where-Object { $_.AppID -like 'OpenAI.Codex_*!App' -or $_.Name -eq 'ChatGPT' -or $_.Name -like 'ChatGPT*' -or $_.Name -eq 'Codex' -or $_.Name -like 'Codex*' } | Select-Object -First 1 -ExpandProperty AppID)`
+
 func defaultCodexAppStartAppID() string {
 	if codexAppGOOS != "windows" {
 		return ""
 	}
-	script := `(Get-StartApps | Where-Object { $_.Name -eq 'ChatGPT' -or $_.Name -like 'ChatGPT*' -or $_.Name -eq 'Codex' -or $_.Name -like 'Codex*' } | Select-Object -First 1 -ExpandProperty AppID)`
-	out, err := exec.Command("powershell.exe", "-NoProfile", "-Command", script).Output()
+	out, err := exec.Command("powershell.exe", "-NoProfile", "-Command", codexAppStartAppsScript).Output()
 	if err != nil {
 		return ""
 	}

--- a/cmd/launch/codex_app_test.go
+++ b/cmd/launch/codex_app_test.go
@@ -142,6 +142,22 @@ func TestCodexAppInstalledUsesWindowsStartMenuFallback(t *testing.T) {
 	}
 }
 
+func TestCodexAppStartAppsScriptMatchesStablePackageIdentity(t *testing.T) {
+	// After Codex merged into the ChatGPT desktop app the Store entry shows as
+	// "ChatGPT" while keeping the OpenAI.Codex package family, and the display
+	// name may be localized. Detection must key off the stable AppID family so
+	// it doesn't false-negative on those installs (issue #17119).
+	if !strings.Contains(codexAppStartAppsScript, "$_.AppID -like 'OpenAI.Codex_*!App'") {
+		t.Fatalf("Start menu detection must match the stable OpenAI.Codex package AppID, got: %s", codexAppStartAppsScript)
+	}
+	// Keep the display-name fallbacks for installs that only surface by name.
+	for _, want := range []string{"$_.Name -eq 'ChatGPT'", "$_.Name -eq 'Codex'"} {
+		if !strings.Contains(codexAppStartAppsScript, want) {
+			t.Fatalf("Start menu detection should retain name fallback %q, got: %s", want, codexAppStartAppsScript)
+		}
+	}
+}
+
 func TestCodexAppInstalledUsesMacBundleIDFallback(t *testing.T) {
 	withCodexAppPlatform(t, "darwin")
 


### PR DESCRIPTION
# Issue #17119 — "Launch codex-app not working after Codex update"

> After Codex merged into the ChatGPT app, `ollama launch codex-app` can no longer
> find the app.

## 1. Root cause

`ollama launch codex-app` resolves to the `chatgpt` integration (`codex-app` is an
alias). Before launching, the launcher must decide whether the desktop app is
**installed** (`codexAppInstalled`) and, on Windows, how to open/restart it. On
Windows the app is now shipped as a **Microsoft Store (AppX/MSIX) package**, so
detection falls back to the Start menu entry via `codexAppStartID`
(`defaultCodexAppStartAppID`).

The bulk of the Codex→ChatGPT rename was already handled upstream by
[#17161](https://github.com/ollama/ollama/pull/17161) (in this tree), which added
`ChatGPT.app`/`ChatGPT.exe` paths and `ChatGPT` process/app names. But the Windows
Start-menu lookup it left in place still matches **only by display name**:

```powershell
Get-StartApps | Where-Object { $_.Name -eq 'ChatGPT' -or $_.Name -like 'ChatGPT*' -or $_.Name -eq 'Codex' -or $_.Name -like 'Codex*' }
```

Display names are variable and localized. The stable identity of the merged app is
its Store **package family**, which stays `OpenAI.Codex` even though the entry now
displays as `ChatGPT` (AppID `OpenAI.Codex_2p2nqsd0c76g0!App`, installed under
`C:\Program Files\WindowsApps\`). When the display name is not exactly `ChatGPT`/
`Codex` (localized Windows, or a future rename), `Get-StartApps` returns nothing, so
`codexAppStartID()` is empty and — when the app isn't running —
`codexAppInstalled()` returns false. The launcher then reports the app as not
found: the exact #17119 symptom on Windows Store installs. OpenAI's own CLI hit and
fixed this same class of bug by keying off the package identity instead of the
display name (openai/codex #32464; migration details in #32022).

## 2. The fix and why

Match the **stable Store package-identity AppID** first, then keep the existing
display-name matches as fallbacks:

```powershell
Get-StartApps | Where-Object { $_.AppID -like 'OpenAI.Codex_*!App' -or $_.Name -eq 'ChatGPT' -or ... }
```

- `OpenAI.Codex_*!App` matches the unified ChatGPT app (and the legacy standalone
  Codex app) regardless of how the Start menu entry is named or localized.
- In PowerShell `-like`, `_` is a literal and `*` is the wildcard, so the pattern
  matches `OpenAI.Codex_<hash>!App` exactly as intended.
- It returns the same launchable AppID already used by the restart path
  (`Start-Process shell:AppsFolder\<AppID>`), so no other logic changes.
- It does **not** match the separate `ChatGPT Classic` app (package `com.openai.chat`
  / `OpenAI.Chat*`), which the launcher should ignore.
- Display-name matches are retained so non-Store/electron installs keep working.

The PowerShell was extracted into a package-level const `codexAppStartAppsScript`
so the behavior is testable without a Windows host, matching how the repo already
asserts on generated command strings (e.g. `hermes_test.go`).

This is the minimal change that closes the remaining Windows gap; macOS detection
(`/Applications/ChatGPT.app` + `mdfind com.openai.codex`) was already correct and is
untouched.

## 3. Files changed

- `cmd/launch/codex_app.go` — extract the Start-menu PowerShell into
  `codexAppStartAppsScript` and add `$_.AppID -like 'OpenAI.Codex_*!App'` as the
  primary matcher (display-name matches kept as fallback).
- `cmd/launch/codex_app_test.go` — `TestCodexAppStartAppsScriptMatchesStablePackageIdentity`
  guards that detection keys off the stable package AppID and retains the name fallbacks.

## 4. Risk / uncertainty

- **Low risk.** The change only *widens* what counts as installed; it adds a matcher
  and removes nothing. The returned value is still a launchable AppID.
- The PowerShell itself runs only on Windows and cannot be executed in this
  Linux/CI environment, so the new test asserts on the script content (a regression
  guard) rather than PowerShell execution — consistent with existing tests, which
  stub the `codexAppStartID` hook (e.g. `TestCodexAppInstalledUsesWindowsStartMenuFallback`
  already uses `OpenAI.Codex_..!App`).
- The package family `OpenAI.Codex_*` is taken from OpenAI's shipped package
  identity (confirmed in openai/codex #32464 and by the fixtures already present in
  this repo's tests). If OpenAI ever changes the package family (not just the display
  name), the name fallbacks still apply.

## 5. How I verified it

- `go build ./cmd/...` — succeeds.
- `go vet ./cmd/launch/` — clean.
- `go test ./cmd/launch/` — full package passes (incl. the new test and all
  existing Codex/ChatGPT detection, restart, and migration tests).
- Traced the launch path end-to-end: `ollama launch codex-app` →
  `LookupIntegration` (alias → `chatgpt`, `*CodexApp`) → `EnsureIntegrationInstalled`
  → `codexAppInstalled` → Windows branch → `codexAppStartID`, confirming the
  display-name-only filter was the single point that failed for Store installs.
