### PR TITLE
docs: document reasoning effort values for Codex integrations

### DIFF
--- a/docs/api/openai-compatibility.mdx
+++ b/docs/api/openai-compatibility.mdx
@@ -216,6 +216,12 @@ curl -X POST http://localhost:11434/v1/chat/completions \
 - [ ] `user`
 - [ ] `n`
 
+<Note>
+  OpenAI's `"minimal"` and `"xhigh"` reasoning effort values are not supported
+  and are rejected with an `invalid reasoning value` error. Use `"low"` or
+  `"max"` instead.
+</Note>
+
 ### `/v1/completions`
 
 #### Supported features
@@ -369,6 +375,8 @@ Ollama supports the [OpenAI Responses API](https://platform.openai.com/docs/api-
 - [x] `temperature`
 - [x] `top_p`
 - [x] `max_output_tokens`
+- [x] `reasoning`
+  - [x] `effort` (`"high"`, `"medium"`, `"low"`, `"max"`, `"none"`)
 - [ ] `previous_response_id` (stateful v1/responses not supported)
 - [ ] `conversation` (stateful v1/responses not supported)
 - [ ] `truncation`

--- a/docs/integrations/codex-app.mdx
+++ b/docs/integrations/codex-app.mdx
@@ -59,6 +59,21 @@ ollama launch codex-app --model gemma4:31b
 
 Running `ollama launch codex-app` is persistent and will have your model selected next time you open Codex.
 
+### Reasoning effort
+
+Codex controls how much a thinking model reasons through the `model_reasoning_effort` setting in `~/.codex/config.toml`. With Ollama, the value must be one of `low`, `medium`, `high`, `max`, or `none`.
+
+The OpenAI-only values `minimal` and `xhigh` are not supported. If your existing Codex profile sets one of them, requests fail with:
+
+```
+invalid reasoning value: "xhigh" (must be "high", "medium", "low", "max", or "none")
+```
+
+To fix this, edit `~/.codex/config.toml` and set a supported value, then restart Codex App:
+
+```toml
+model_reasoning_effort = "max"
+```
 
 ### Restore Codex App
 
@@ -80,3 +95,7 @@ Before overwriting Codex App config files, Ollama Launch saves backups under `~/
 If Codex App does not open after setup, open Codex manually once and run `ollama launch codex-app` again.
 
 If Codex App is already running and does not switch models, allow Ollama to restart it when prompted, or quit Codex App and run `ollama launch codex-app` again.
+
+If `ollama launch codex-app` fails with `Error: unknown integration: codex-app`, your installed Ollama is older than v0.24.0. Upgrade Ollama and run the command again.
+
+If requests fail with an `invalid reasoning value` error, see [Reasoning effort](#reasoning-effort).

--- a/docs/integrations/codex.mdx
+++ b/docs/integrations/codex.mdx
@@ -76,3 +76,13 @@ Then run:
 ```
 codex --profile ollama-launch
 ```
+
+### Reasoning effort
+
+Codex controls how much a thinking model reasons through the `model_reasoning_effort` setting in `~/.codex/config.toml`. With Ollama, the value must be one of `low`, `medium`, `high`, `max`, or `none`.
+
+The OpenAI-only values `minimal` and `xhigh` are not supported and are rejected with an `invalid reasoning value` error. If your existing Codex profile sets one of them, update it to a supported value:
+
+```toml
+model_reasoning_effort = "max"
+```


### PR DESCRIPTION
## Summary

Users running Codex (App or CLI) against Ollama via `ollama launch codex-app` hit a hard failure when their existing Codex profile sets `model_reasoning_effort = "xhigh"` (the default for many GPT-5.x setups) or `"minimal"`:

```
invalid reasoning value: "xhigh" (must be "high", "medium", "low", "max", or "none")
```

`ollama launch` carries the existing top-level `model_reasoning_effort` setting into the Ollama profile, and the OpenAI-compatible API rejects both values (`openai/openai.go`, `openai/responses.go`). None of this was documented, so the error is hard to self-serve. This PR fills in the missing documentation.

## Changes

- `docs/integrations/codex-app.mdx`: add a "Reasoning effort" section documenting supported values and the config fix, plus troubleshooting entries for `unknown integration: codex-app` (Ollama older than v0.24.0) and the `invalid reasoning value` error
- `docs/integrations/codex.mdx`: add a matching "Reasoning effort" section for the CLI
- `docs/api/openai-compatibility.mdx`: document the `reasoning.effort` request field for `/v1/responses` (already supported in code but missing from the supported-fields list), and note that `minimal`/`xhigh` are rejected on both endpoints

## Testing

Verified against Ollama v0.32.1 with `glm-5.2:cloud`:

- `/v1/responses` with `"reasoning": {"effort": "xhigh"}` → `invalid reasoning value` error; with `"max"` → completes with reasoning output
- `/v1/chat/completions` with `"reasoning_effort": "minimal"` → `invalid reasoning value` error
- Codex CLI 0.144.1 with `model_reasoning_effort = "max"` against the `ollama launch` profile → works end to end
- `ollama launch codex-app` on v0.23.0 → `Error: unknown integration: codex-app`; works after upgrading
