### PR TITLE
llm: account for multiple model memory buffers

### DIFF
--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -2637,12 +2637,16 @@ func PredictServerVRAM(modelPath string, f *ggml.GGML, numCtx int) uint64 {
 //	MTL0_Mapped model buffer size =  1918.35 MiB
 //	ROCm0 model buffer size =  1918.35 MiB
 type memoryParsingWriter struct {
-	inner   io.Writer
-	runner  *llamaServerRunner
-	buffers map[memoryBufferKey]memoryBuffer
+	inner         io.Writer
+	runner        *llamaServerRunner
+	buffers       map[memoryBufferKey]memoryBuffer
+	modelInstance int
+	kvCache       int
 }
 
 type memoryBufferKey struct {
+	model     int
+	kvCache   int
 	component string
 	backend   string
 	kind      string
@@ -2662,6 +2666,9 @@ var deviceFreeRegex = regexp.MustCompile(`using device (\S+)\s+\(.*\)\s+-\s+(\d+
 // bufferSizeRegex matches llama-server buffer size lines and captures the
 // component so repeated fit/probe values can be replaced by the final load.
 var bufferSizeRegex = regexp.MustCompile(`(?m)(?:^|\n)[^\n:]*?([A-Za-z_][A-Za-z0-9_]*):\s+(\S+)\s+(model|KV|compute|output|RS)\s+buffer size\s*=\s*([\d.]+)\s*MiB`)
+
+var draftModelLoadMarker = []byte("loading draft model")
+var kvCacheStartRegex = regexp.MustCompile(`creating\s+(?:non-SWA|SWA)\s+KV cache`)
 
 var (
 	offloadedLayersRegex      = regexp.MustCompile(`offloaded\s+(\d+)/(\d+)\s+layers to GPU`)
@@ -2724,20 +2731,27 @@ func (w *memoryParsingWriter) Write(b []byte) (int, error) {
 					w.runner.gpuLayerOverflow += int(overflowing)
 				}
 			}
-			for _, match := range bufferSizeRegex.FindAllSubmatch(b, -1) {
-				backendName := string(match[2])
-				if mib, err := strconv.ParseFloat(string(match[4]), 64); err == nil {
+			for _, match := range bufferSizeRegex.FindAllSubmatchIndex(b, -1) {
+				backendName := string(b[match[4]:match[5]])
+				if mib, err := strconv.ParseFloat(string(b[match[8]:match[9]]), 64); err == nil {
 					if w.buffers == nil {
 						w.buffers = make(map[memoryBufferKey]memoryBuffer)
 					}
-					w.buffers[memoryBufferKey{
-						component: string(match[1]),
+					key := memoryBufferKey{
+						model:     w.modelInstance + bytes.Count(b[:match[0]], draftModelLoadMarker),
+						component: string(b[match[2]:match[3]]),
 						backend:   backendName,
-						kind:      string(match[3]),
-					}] = memoryBuffer{bytes: uint64(mib * 1024 * 1024)}
+						kind:      string(b[match[6]:match[7]]),
+					}
+					if key.kind == "KV" {
+						key.kvCache = w.kvCache + len(kvCacheStartRegex.FindAllIndex(b[:match[0]], -1))
+					}
+					w.buffers[key] = memoryBuffer{bytes: uint64(mib * 1024 * 1024)}
 					w.updateRunnerMemoryLocked()
 				}
 			}
+			w.modelInstance += bytes.Count(b, draftModelLoadMarker)
+			w.kvCache += len(kvCacheStartRegex.FindAllIndex(b, -1))
 		}()
 	}
 	return w.inner.Write(b)

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -3129,6 +3129,50 @@ func TestMemoryParsingWriterMemorySizeFullOffload(t *testing.T) {
 	}
 }
 
+func TestMemoryParsingWriterIncludesDraftModelBuffers(t *testing.T) {
+	lines := []string{
+		"load_tensors:      Vulkan0 model buffer size =  9000.00 MiB\n",
+		"llama_kv_cache_iswa: creating non-SWA KV cache, size = 262144 cells\n",
+		"llama_kv_cache:    Vulkan0 KV buffer size =  2000.00 MiB\n",
+		"llama_kv_cache_iswa: creating SWA KV cache, size = 1536 cells\n",
+		"llama_kv_cache:    Vulkan0 KV buffer size =   500.00 MiB\n",
+		"sched_reserve:     Vulkan0 compute buffer size =  1200.00 MiB\n",
+		"srv load_model: loading draft model 'draft.gguf'\n",
+		"load_tensors:      Vulkan0 model buffer size =   200.00 MiB\n",
+		"llama_kv_cache_iswa: creating non-SWA KV cache, size = 262144 cells\n",
+		"llama_kv_cache:    Vulkan0 KV buffer size =   100.00 MiB\n",
+		"llama_kv_cache_iswa: creating SWA KV cache, size = 1536 cells\n",
+		"llama_kv_cache:    Vulkan0 KV buffer size =    50.00 MiB\n",
+		"sched_reserve:     Vulkan0 compute buffer size =   300.00 MiB\n",
+		// llama-server can reserve the draft compute buffer more than once.
+		// The latest value replaces the earlier value within the same model.
+		"sched_reserve:     Vulkan0 compute buffer size =   350.00 MiB\n",
+	}
+	for _, tt := range []struct {
+		name   string
+		writes []string
+	}{
+		{name: "line by line", writes: lines},
+		{name: "single write", writes: []string{strings.Join(lines, "")}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := &llamaServerRunner{}
+			w := &memoryParsingWriter{inner: io.Discard, runner: runner}
+			for _, text := range tt.writes {
+				if _, err := w.Write([]byte(text)); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			total, vram := runner.MemorySize()
+			want := uint64(13400 * 1024 * 1024)
+			if total != want || vram != want {
+				t.Fatalf("MemorySize() = %d/%d, want %d/%d", total, vram, want, want)
+			}
+		})
+	}
+}
+
 func TestMemoryParsingWriterMemorySizeMmapPartialOffload(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
Fixes #17251.

The memory parser was treating buffers from the target model and speculative draft model as the same allocation. The same collision happened between non-SWA and SWA KV caches. In both cases, the later log line replaced the earlier value, so `ollama ps` could under-report VRAM.

This scopes parser keys to the model and cache instance. Repeated reservations within one instance still replace the previous value, while allocations belonging to separate models or caches are added together.

Tested with `go test ./llm -count=1`. The regression cases cover split and multi-line logs, two KV caches, a draft model, and repeated draft compute reservations.
