### PR TITLE
server: report template-only tool capability in /api/tags

### DIFF
--- a/server/model_list_cache.go
+++ b/server/model_list_cache.go
@@ -569,7 +569,22 @@ func readModelListGGUF(path string) (modelListGGUF, error) {
 			continue
 		}
 
-		if architecture != "" && strings.HasPrefix(key, "tokenizer.") {
+		// Template-only tool/thinking support (e.g. deepseek-r1) lives in
+		// tokenizer.chat_template, so /api/tags must read it to report the same
+		// capabilities as /api/show. It's the last KV we care about, so stop once
+		// we've seen it. Reaching it means skipping past the large tokenizer.ggml.*
+		// arrays; this could be made cheaper with a file seek if list latency regresses.
+		if architecture != "" && key == "tokenizer.chat_template" {
+			value, err := readModelListGGUFStringValue(r, byteOrder, version, valueType)
+			if err != nil {
+				return modelListGGUF{}, err
+			}
+			if chatTemplateHasToolSupport(value) {
+				info.Capabilities = appendModelListCapability(info.Capabilities, model.CapabilityTools)
+			}
+			if chatTemplateHasThinkingSupport(value) {
+				info.Capabilities = appendModelListCapability(info.Capabilities, model.CapabilityThinking)
+			}
 			break
 		}
 

--- a/server/model_list_cache_test.go
+++ b/server/model_list_cache_test.go
@@ -70,6 +70,32 @@ func TestModelListCacheHydratesSummary(t *testing.T) {
 	}
 }
 
+func TestModelListCacheToolsFromGGUFChatTemplate(t *testing.T) {
+	// Regression for #16969: tool support declared only in the GGUF
+	// tokenizer.chat_template (as with deepseek-r1) must surface in /api/tags to
+	// match /api/show. The Ollama Go template below has no tools var and there's
+	// no builtin parser, so the chat template is the only source of the tools cap.
+	gin.SetMode(gin.TestMode)
+	setTestHome(t, t.TempDir())
+	createListCacheModel(t, "list-cache-tmpl-tools", map[string]any{
+		"test.context_length":     uint32(4096),
+		"tokenizer.chat_template": "{% for m in messages %}{{ m.content }}{% endfor %}{{ tool_call }}",
+	}, "{{ .prompt }}")
+
+	cache := newModelListCache()
+	if err := cache.hydrate(context.Background()); err != nil {
+		t.Fatalf("hydrate failed: %v", err)
+	}
+
+	summary, ok := cache.Get(model.ParseName("list-cache-tmpl-tools"))
+	if !ok {
+		t.Fatal("list summary missing")
+	}
+	if !slices.Contains(summary.Capabilities, model.CapabilityTools) {
+		t.Fatalf("capabilities = %v, want tools", summary.Capabilities)
+	}
+}
+
 func TestModelListCacheRefreshUpdatesEntry(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	setTestHome(t, t.TempDir())


### PR DESCRIPTION
## What

`/api/tags` omits the `tools` capability for models whose tool support is declared only in the GGUF `tokenizer.chat_template` (e.g. `deepseek-r1`), while `/api/show` reports it correctly. Clients that read `/api/tags` (VS Code LM provider, Copilot Chat) then treat these models as non-tool. Fixes #16969.

## Why

`/api/tags` is served from the model list cache. Its GGUF reader (`readModelListGGUF`) broke out of the KV loop at the first `tokenizer.*` key, so it never read `tokenizer.chat_template`. Tool support in the list path was only picked up from an Ollama Go-template `tools` var or a builtin parser — neither of which `deepseek-r1` uses. `/api/show` (`Model.Capabilities`) does read the chat template, hence the mismatch.

## Change

Read `tokenizer.chat_template` in the list-cache reader and derive `tools`/`thinking` from it via the same `chatTemplateHasToolSupport`/`chatTemplateHasThinkingSupport` helpers `/api/show` uses. Added a regression test that declares tool support only in the chat template and asserts the capability now surfaces (it fails without the fix).

Note: reaching the chat template means skipping past the large `tokenizer.ggml.*` arrays; flagged inline as a spot that could use a file seek if list latency regresses.
