### PR TITLE
api: preserve JSON-Schema constraints on tool parameters

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -437,6 +437,24 @@ type ToolProperty struct {
 	Enum        []any              `json:"enum,omitempty"`
 	Properties  *ToolPropertiesMap `json:"properties,omitempty"`
 	Required    []string           `json:"required,omitempty"`
+
+	// JSON-Schema validation keywords. Without these fields json.Unmarshal
+	// silently drops the constraints, so they never reach the model. Numeric
+	// bounds are pointers so a valid zero (e.g. "minimum":0) survives re-marshal
+	// instead of being erased by omitempty.
+	Default          any      `json:"default,omitempty"`
+	Const            any      `json:"const,omitempty"`
+	Format           string   `json:"format,omitempty"`
+	Pattern          string   `json:"pattern,omitempty"`
+	Minimum          *float64 `json:"minimum,omitempty"`
+	Maximum          *float64 `json:"maximum,omitempty"`
+	ExclusiveMinimum *float64 `json:"exclusiveMinimum,omitempty"`
+	ExclusiveMaximum *float64 `json:"exclusiveMaximum,omitempty"`
+	MultipleOf       *float64 `json:"multipleOf,omitempty"`
+	MinLength        *int     `json:"minLength,omitempty"`
+	MaxLength        *int     `json:"maxLength,omitempty"`
+	MinItems         *int     `json:"minItems,omitempty"`
+	MaxItems         *int     `json:"maxItems,omitempty"`
 }
 
 // ToTypeScriptType converts a ToolProperty to a TypeScript type string

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -405,6 +405,54 @@ func TestToolFunctionParameters_MarshalJSON(t *testing.T) {
 	}
 }
 
+func TestToolProperty_ConstraintsSurviveRoundTrip(t *testing.T) {
+	// Regression for #17142: JSON-Schema validation keywords were silently
+	// dropped at unmarshal because ToolProperty had no fields for them, so they
+	// never reached the model. They must survive an unmarshal -> marshal round
+	// trip, including zero-valued bounds and a falsy default.
+	input := `{
+		"type":"integer",
+		"description":"Results per page.",
+		"minimum":0,
+		"maximum":100,
+		"exclusiveMinimum":0,
+		"exclusiveMaximum":100,
+		"multipleOf":0.01,
+		"default":false,
+		"const":42,
+		"format":"int32",
+		"pattern":"^[0-9]+$",
+		"minLength":1,
+		"maxLength":8,
+		"minItems":0,
+		"maxItems":5
+	}`
+
+	var prop ToolProperty
+	require.NoError(t, json.Unmarshal([]byte(input), &prop))
+
+	out, err := json.Marshal(prop)
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(out, &got))
+
+	for _, key := range []string{
+		"minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum", "multipleOf",
+		"default", "const", "format", "pattern", "minLength", "maxLength", "minItems", "maxItems",
+	} {
+		if _, ok := got[key]; !ok {
+			t.Errorf("keyword %q dropped on round-trip; got %s", key, out)
+		}
+	}
+
+	// Zero-valued bounds must survive rather than be erased by omitempty.
+	assert.Equal(t, float64(0), got["minimum"], "minimum:0 must survive")
+	assert.Equal(t, float64(0), got["minItems"], "minItems:0 must survive")
+	// A falsy default must survive (nil interface is absent, false is present).
+	assert.Equal(t, false, got["default"], "default:false must survive")
+}
+
 func TestToolCallFunction_IndexAlwaysMarshals(t *testing.T) {
 	fn := ToolCallFunction{
 		Name:      "echo",


### PR DESCRIPTION
## What

JSON-Schema validation keywords on tool parameters (`minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf`, `default`, `const`, `format`, `pattern`, `minLength`, `maxLength`, `minItems`, `maxItems`) were silently dropped when a request was parsed, so they never reached the model. Fixes #17142.

## Why

`json.Unmarshal` discards any object key without a matching struct field. `api.ToolProperty` only had fields for `anyOf`, `type`, `items`, `description`, `enum`, `properties`, and `required`, so every other keyword was gone before any template or renderer ran — independent of model.

## Change

Add the missing keywords to `ToolProperty`, consistent with `enum`/`anyOf` already being retained. Numeric bounds (`minimum`, `maximum`, `multipleOf`, the length/items counts) are pointers so a valid zero (e.g. `"minimum": 0`) survives an `omitempty` re-marshal instead of being erased — the same silent-drop this issue is about, one layer down. `default`/`const` are `any`, so a falsy value like `default: false` is kept while an absent field stays absent.

Added a round-trip test asserting every keyword survives unmarshal -> marshal, including the zero-bound and falsy-default edge cases (it fails without the struct change).

## Scope

This is the parse-level fix (part 1 of the two the issue describes). Renderers that `json.Marshal` the whole tool/parameters (e.g. `deepseek3`, `cogito`, `glm46`, `glmocr`) now pass the constraints through to the model end-to-end. Renderers that build the schema field-by-field (e.g. `gemma4`, `qwen3coder`, `nemotron3nano`, `functiongemma`, and the `toTypeScriptType` template path) will need per-renderer handling to surface them; the issue flags that presentation choice as one for maintainers, so I've left it as follow-up rather than guess a direction here. Preserving the data at parse is the prerequisite either way and is safe on its own.
