### PR TITLE
fix(server): omit tensors from /api/show response unless verbose

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -1573,11 +1573,13 @@ func GetModelInfo(req api.ShowRequest) (*api.ShowResponse, error) {
 	delete(kvData, "tokenizer.chat_template")
 	resp.ModelInfo = kvData
 
-	tensorData := make([]api.Tensor, len(tensors.Items()))
-	for cnt, t := range tensors.Items() {
-		tensorData[cnt] = api.Tensor{Name: t.Name, Type: t.Type(), Shape: t.Shape}
+	if req.Verbose {
+		tensorData := make([]api.Tensor, len(tensors.Items()))
+		for cnt, t := range tensors.Items() {
+			tensorData[cnt] = api.Tensor{Name: t.Name, Type: t.Type(), Shape: t.Shape}
+		}
+		resp.Tensors = tensorData
 	}
-	resp.Tensors = tensorData
 
 	if len(m.ProjectorPaths) > 0 {
 		projectorData, _, err := getModelData(m.ProjectorPaths[0], req.Verbose)

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -815,6 +815,52 @@ func TestShow(t *testing.T) {
 	}
 }
 
+func TestShowTensorsOnlyPopulatedWhenVerbose(t *testing.T) {
+	t.Setenv("OLLAMA_MODELS", t.TempDir())
+
+	var s Server
+
+	_, digest := createBinFile(t, ggml.KV{"general.architecture": "test"}, []*ggml.Tensor{
+		{Name: "token_embd.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+	})
+
+	createRequest(t, s.CreateHandler, api.CreateRequest{
+		Name:  "show-tensors-verbose",
+		Files: map[string]string{"model.gguf": digest},
+	})
+
+	w := createRequest(t, s.ShowHandler, api.ShowRequest{
+		Name: "show-tensors-verbose",
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status code 200, actual %d", w.Code)
+	}
+
+	var resp api.ShowResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Tensors) != 0 {
+		t.Fatalf("expected no tensors when verbose is false, got %d", len(resp.Tensors))
+	}
+
+	w = createRequest(t, s.ShowHandler, api.ShowRequest{
+		Name:    "show-tensors-verbose",
+		Verbose: true,
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status code 200, actual %d", w.Code)
+	}
+
+	resp = api.ShowResponse{}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Tensors) != 1 {
+		t.Fatalf("expected 1 tensor when verbose is true, got %d", len(resp.Tensors))
+	}
+}
+
 func TestShowTemplateUsesSelectedRuntimeTemplate(t *testing.T) {
 	t.Setenv("OLLAMA_MODELS", t.TempDir())
 	t.Setenv("OLLAMA_GO_TEMPLATE", "")


### PR DESCRIPTION
## Summary

`POST /api/show` was returning the `tensors` field even when `verbose` was `false` or omitted, contradicting the documented behavior in `docs/api.md` (verbose only fields, including tensors, should populate only when `verbose` is `true`). For models with many tensors this makes the terse response unnecessarily huge, as reported in the issue for `mistral-nemo:12b`.

The bug was in the default GGUF path of `GetModelInfo` in `server/routes.go`: `resp.Tensors` was assigned unconditionally, unlike the image and safetensors LLM branches of the same function, which already gate tensor population behind `req.Verbose`. This change applies the same gate to the default path.

Fixes #10286

## Test plan

- Added `TestShowTensorsOnlyPopulatedWhenVerbose` in `server/routes_test.go`, asserting `tensors` is empty when verbose is false/omitted and populated when verbose is true.
- `go build ./server/...` passes.
- `go test ./server/...` passes (all existing tests plus the new one).