### PR TITLE
app: coalesce chat stream updates

### DIFF
--- a/app/ui/app/src/hooks/useChats.ts
+++ b/app/ui/app/src/hooks/useChats.ts
@@ -9,6 +9,8 @@ import { useStreamingContext } from "@/contexts/StreamingContext";
 import { getModelCapabilities } from "@/api";
 import { useCloudStatus } from "./useCloudStatus";
 
+const CHAT_STREAM_BATCH_INTERVAL = 16;
+
 export const useChats = () => {
   return useQuery({
     queryKey: ["chats"],
@@ -335,12 +337,15 @@ export const useSendMessage = (chatId: string) => {
         isCancelled = true;
       });
 
-      // Create batcher for streaming updates with smoother intervals, prevents state update depth being exceeded
-      // and allows for smoother updates at high frame rates
+      // Keep streaming updates within a browser frame budget while preserving
+      // the first update immediately and flushing the final state.
       let batcher = createQueryBatcher<{ chat: Chat }>(
         queryClient,
         ["chat", currentChatId],
-        { batchInterval: 4, immediateFirst: true }, // ~250fps for smoother updates
+        {
+          batchInterval: CHAT_STREAM_BATCH_INTERVAL,
+          immediateFirst: true,
+        },
       );
 
       for await (const event of events) {
@@ -692,7 +697,10 @@ export const useSendMessage = (chatId: string) => {
             batcher = createQueryBatcher<{ chat: Chat }>(
               queryClient,
               ["chat", currentChatId],
-              { batchInterval: 4, immediateFirst: true },
+              {
+                batchInterval: CHAT_STREAM_BATCH_INTERVAL,
+                immediateFirst: true,
+              },
             );
 
             // Create initial chat data for the new chat

--- a/app/ui/app/src/hooks/useQueryBatcher.test.ts
+++ b/app/ui/app/src/hooks/useQueryBatcher.test.ts
@@ -1,0 +1,59 @@
+import { QueryClient } from "@tanstack/react-query";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createQueryBatcher } from "./useQueryBatcher";
+
+describe("createQueryBatcher", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("coalesces a high-rate stream", () => {
+    vi.useFakeTimers();
+
+    const queryClient = new QueryClient();
+    const queryKey = ["chat", "benchmark"] as const;
+    queryClient.setQueryData(queryKey, 0);
+
+    const setQueryData = vi.spyOn(queryClient, "setQueryData");
+    const batcher = createQueryBatcher<number>(queryClient, queryKey, {
+      immediateFirst: true,
+    });
+
+    batcher.scheduleBatch((value = 0) => value + 1);
+    expect(queryClient.getQueryData(queryKey)).toBe(1);
+
+    // Simulate the remaining chunks arriving over one second. A 5 ms cadence
+    // is fast enough to expose excessive cache commits without using wall time.
+    for (let i = 1; i < 200; i += 1) {
+      batcher.scheduleBatch((value = 0) => value + 1);
+      vi.advanceTimersByTime(5);
+    }
+    batcher.flushBatch();
+
+    const streamCommits = setQueryData.mock.calls.length;
+    expect(queryClient.getQueryData(queryKey)).toBe(200);
+    expect(streamCommits).toBeLessThanOrEqual(64);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("cancels a pending batch during cleanup", () => {
+    vi.useFakeTimers();
+
+    const queryClient = new QueryClient();
+    const queryKey = ["chat", "cancelled"] as const;
+    queryClient.setQueryData(queryKey, 0);
+
+    const batcher = createQueryBatcher<number>(queryClient, queryKey, {
+      immediateFirst: true,
+    });
+
+    batcher.scheduleBatch((value = 0) => value + 1);
+    batcher.scheduleBatch((value = 0) => value + 1);
+    batcher.cleanup();
+    vi.runAllTimers();
+
+    expect(queryClient.getQueryData(queryKey)).toBe(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/app/ui/app/src/hooks/useQueryBatcher.ts
+++ b/app/ui/app/src/hooks/useQueryBatcher.ts
@@ -2,16 +2,19 @@ import { useCallback, useRef } from "react";
 import { useQueryClient, QueryClient } from "@tanstack/react-query";
 
 interface BatcherConfig {
-  batchInterval?: number; // milliseconds, default 8ms (~120fps)
+  batchInterval?: number; // milliseconds, default 16ms (~60fps)
   immediateFirst?: boolean; // if true, first update is immediate
 }
+
+const DEFAULT_BATCH_INTERVAL = 16;
 
 export const useQueryBatcher = <T>(
   queryKey: readonly unknown[],
   config: BatcherConfig = {},
 ) => {
   const queryClient = useQueryClient();
-  const { batchInterval = 8, immediateFirst = false } = config;
+  const { batchInterval = DEFAULT_BATCH_INTERVAL, immediateFirst = false } =
+    config;
 
   const batchRef = useRef<{
     updateBatch: T | undefined;
@@ -29,7 +32,7 @@ export const useQueryBatcher = <T>(
       queryClient.setQueryData(queryKey, updateBatch);
       batchRef.current.updateBatch = undefined;
     }
-    if (batchTimeout) {
+    if (batchTimeout !== null) {
       clearTimeout(batchTimeout);
       batchRef.current.batchTimeout = null;
     }
@@ -49,16 +52,17 @@ export const useQueryBatcher = <T>(
         return;
       }
 
-      if (batchRef.current.batchTimeout) {
-        clearTimeout(batchRef.current.batchTimeout);
+      // Keep the first scheduled flush in place so subsequent updates join
+      // the same frame-sized batch instead of restarting a debounce timer.
+      if (batchRef.current.batchTimeout === null) {
+        batchRef.current.batchTimeout = setTimeout(flushBatch, batchInterval);
       }
-      batchRef.current.batchTimeout = setTimeout(flushBatch, batchInterval);
     },
     [queryClient, queryKey, flushBatch, batchInterval, immediateFirst],
   );
 
   const cleanup = useCallback(() => {
-    if (batchRef.current.batchTimeout) {
+    if (batchRef.current.batchTimeout !== null) {
       clearTimeout(batchRef.current.batchTimeout);
       batchRef.current.batchTimeout = null;
     }
@@ -78,7 +82,8 @@ export const createQueryBatcher = <T>(
   queryKey: readonly unknown[],
   config: BatcherConfig = {},
 ) => {
-  const { batchInterval = 8, immediateFirst = false } = config;
+  const { batchInterval = DEFAULT_BATCH_INTERVAL, immediateFirst = false } =
+    config;
 
   let updateBatch: T | undefined = undefined;
   let batchTimeout: number | null = null;
@@ -89,7 +94,7 @@ export const createQueryBatcher = <T>(
       queryClient.setQueryData(queryKey, updateBatch);
       updateBatch = undefined;
     }
-    if (batchTimeout) {
+    if (batchTimeout !== null) {
       clearTimeout(batchTimeout);
       batchTimeout = null;
     }
@@ -107,14 +112,15 @@ export const createQueryBatcher = <T>(
       return;
     }
 
-    if (batchTimeout) {
-      clearTimeout(batchTimeout);
+    // Keep the first scheduled flush in place so subsequent updates join
+    // the same frame-sized batch instead of restarting a debounce timer.
+    if (batchTimeout === null) {
+      batchTimeout = setTimeout(flushBatch, batchInterval);
     }
-    batchTimeout = setTimeout(flushBatch, batchInterval);
   };
 
   const cleanup = () => {
-    if (batchTimeout) {
+    if (batchTimeout !== null) {
       clearTimeout(batchTimeout);
       batchTimeout = null;
     }


### PR DESCRIPTION
Hey, I had a look at #15797 and traced one source of the WebContent work during high-rate thinking streams.

The chat stream currently asks the query batcher to flush every 4 ms. The batcher also restarts its timer for every chunk, so a stream delivering chunks every 5 ms produces one React Query cache commit per chunk instead of coalescing the work.

This changes the batcher to use a fixed 16 ms window. The first chunk is still applied immediately, updates within the same frame budget are combined, and the final state is explicitly flushed as before.

### Before / after

I used a deterministic Vitest benchmark on an Apple M4 MacBook Air with Node 24.18.0. It sends 200 chat updates at 5 ms intervals over roughly one second and counts `QueryClient.setQueryData` calls.

| | Cache commits | Change |
|---|---:|---:|
| Before | 200 | — |
| After | 51 | -74.5% |

The test also checks that the first update is immediate, all 200 updates reach the final state, and cleanup cancels pending work.

### Validation

- `npm test -- --run` — 29 tests passed
- `npm run build` — production build passed
- ESLint passed for the changed batching implementation and tests
- Prettier passed for all three changed files

This is separate from #16006: that PR handles the `ResizeObserver` and hidden markdown rendering in the thinking component. This PR only reduces how often high-rate stream data is committed to the UI cache.
