### PR TITLE
server: detect download stalls before the first byte

### DIFF
--- a/server/download.go
+++ b/server/download.go
@@ -97,11 +97,12 @@ func (p *blobDownloadPart) UnmarshalJSON(b []byte) error {
 }
 
 const (
-	numDownloadParts           = 16
-	minDownloadPartSize  int64 = 100 * format.MegaByte
-	maxDownloadPartSize  int64 = 1000 * format.MegaByte
-	downloadStallTimeout       = 30 * time.Second
+	numDownloadParts          = 16
+	minDownloadPartSize int64 = 100 * format.MegaByte
+	maxDownloadPartSize int64 = 1000 * format.MegaByte
 )
+
+var downloadStallTimeout = 30 * time.Second
 
 func (p *blobDownloadPart) Name() string {
 	return strings.Join([]string{
@@ -285,7 +286,7 @@ func (b *blobDownload) run(ctx context.Context, requestURL *url.URL, opts *regis
 			var err error
 			for try := 0; try < maxRetries; try++ {
 				w := io.NewOffsetWriter(file, part.StartsAt())
-				err = b.downloadChunk(inner, directURL, w, part, downloadStallTimeout)
+				err = b.downloadChunk(inner, directURL, w, part)
 				switch {
 				case errors.Is(err, context.Canceled), errors.Is(err, syscall.ENOSPC):
 					// return immediately if the context is canceled or the device is out of space
@@ -329,7 +330,7 @@ func (b *blobDownload) run(ctx context.Context, requestURL *url.URL, opts *regis
 	return nil
 }
 
-func (b *blobDownload) downloadChunk(ctx context.Context, requestURL *url.URL, w io.Writer, part *blobDownloadPart, stallTimeout time.Duration) error {
+func (b *blobDownload) downloadChunk(ctx context.Context, requestURL *url.URL, w io.Writer, part *blobDownloadPart) error {
 	g, ctx := errgroup.WithContext(ctx)
 	attemptStarted := time.Now()
 	transferDone := make(chan struct{})
@@ -364,7 +365,7 @@ func (b *blobDownload) downloadChunk(ctx context.Context, requestURL *url.URL, w
 	})
 
 	g.Go(func() error {
-		ticker := time.NewTicker(min(time.Second, stallTimeout/2))
+		ticker := time.NewTicker(min(time.Second, downloadStallTimeout/2))
 		defer ticker.Stop()
 		for {
 			select {
@@ -378,7 +379,7 @@ func (b *blobDownload) downloadChunk(ctx context.Context, requestURL *url.URL, w
 					lastUpdated = attemptStarted
 				}
 
-				if time.Since(lastUpdated) > stallTimeout {
+				if time.Since(lastUpdated) > downloadStallTimeout {
 					const msg = "%s part %d stalled; retrying. If this persists, press ctrl-c to exit, then 'ollama pull' to find a faster connection."
 					slog.Info(fmt.Sprintf(msg, b.Digest[7:19], part.N))
 					// reset last updated

--- a/server/download.go
+++ b/server/download.go
@@ -97,9 +97,10 @@ func (p *blobDownloadPart) UnmarshalJSON(b []byte) error {
 }
 
 const (
-	numDownloadParts          = 16
-	minDownloadPartSize int64 = 100 * format.MegaByte
-	maxDownloadPartSize int64 = 1000 * format.MegaByte
+	numDownloadParts           = 16
+	minDownloadPartSize  int64 = 100 * format.MegaByte
+	maxDownloadPartSize  int64 = 1000 * format.MegaByte
+	downloadStallTimeout       = 30 * time.Second
 )
 
 func (p *blobDownloadPart) Name() string {
@@ -284,7 +285,7 @@ func (b *blobDownload) run(ctx context.Context, requestURL *url.URL, opts *regis
 			var err error
 			for try := 0; try < maxRetries; try++ {
 				w := io.NewOffsetWriter(file, part.StartsAt())
-				err = b.downloadChunk(inner, directURL, w, part)
+				err = b.downloadChunk(inner, directURL, w, part, downloadStallTimeout)
 				switch {
 				case errors.Is(err, context.Canceled), errors.Is(err, syscall.ENOSPC):
 					// return immediately if the context is canceled or the device is out of space
@@ -328,9 +329,13 @@ func (b *blobDownload) run(ctx context.Context, requestURL *url.URL, opts *regis
 	return nil
 }
 
-func (b *blobDownload) downloadChunk(ctx context.Context, requestURL *url.URL, w io.Writer, part *blobDownloadPart) error {
+func (b *blobDownload) downloadChunk(ctx context.Context, requestURL *url.URL, w io.Writer, part *blobDownloadPart, stallTimeout time.Duration) error {
 	g, ctx := errgroup.WithContext(ctx)
+	attemptStarted := time.Now()
+	transferDone := make(chan struct{})
 	g.Go(func() error {
+		defer close(transferDone)
+
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL.String(), nil)
 		if err != nil {
 			return err
@@ -359,19 +364,21 @@ func (b *blobDownload) downloadChunk(ctx context.Context, requestURL *url.URL, w
 	})
 
 	g.Go(func() error {
-		ticker := time.NewTicker(time.Second)
+		ticker := time.NewTicker(min(time.Second, stallTimeout/2))
+		defer ticker.Stop()
 		for {
 			select {
+			case <-transferDone:
+				return nil
 			case <-ticker.C:
-				if part.Completed.Load() >= part.Size {
-					return nil
-				}
-
 				part.lastUpdatedMu.Lock()
 				lastUpdated := part.lastUpdated
 				part.lastUpdatedMu.Unlock()
+				if lastUpdated.Before(attemptStarted) {
+					lastUpdated = attemptStarted
+				}
 
-				if !lastUpdated.IsZero() && time.Since(lastUpdated) > 30*time.Second {
+				if time.Since(lastUpdated) > stallTimeout {
 					const msg = "%s part %d stalled; retrying. If this persists, press ctrl-c to exit, then 'ollama pull' to find a faster connection."
 					slog.Info(fmt.Sprintf(msg, b.Digest[7:19], part.N))
 					// reset last updated

--- a/server/download_test.go
+++ b/server/download_test.go
@@ -36,7 +36,7 @@ func BenchmarkDownloadChunkCompletion(b *testing.B) {
 	for range b.N {
 		download := &blobDownload{Name: downloadPath, Digest: digest}
 		part := &blobDownloadPart{Size: int64(len(data)), blobDownload: download}
-		if err := download.downloadChunk(b.Context(), requestURL, io.Discard, part, downloadStallTimeout); err != nil {
+		if err := download.downloadChunk(b.Context(), requestURL, io.Discard, part); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -63,7 +63,7 @@ func TestDownloadChunkReturnsWhenTransferCompletes(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 250*time.Millisecond)
 	defer cancel()
 
-	if err := download.downloadChunk(ctx, requestURL, io.Discard, part, downloadStallTimeout); err != nil {
+	if err := download.downloadChunk(ctx, requestURL, io.Discard, part); err != nil {
 		t.Fatalf("downloadChunk() error = %v, want nil", err)
 	}
 }
@@ -89,9 +89,14 @@ func TestDownloadChunkDetectsStallBeforeFirstByte(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 	defer cancel()
 
-	const stallTimeout = 50 * time.Millisecond
+	originalStallTimeout := downloadStallTimeout
+	downloadStallTimeout = 50 * time.Millisecond
+	t.Cleanup(func() {
+		downloadStallTimeout = originalStallTimeout
+	})
+
 	started := time.Now()
-	err = download.downloadChunk(ctx, requestURL, io.Discard, part, stallTimeout)
+	err = download.downloadChunk(ctx, requestURL, io.Discard, part)
 	elapsed := time.Since(started)
 
 	select {
@@ -102,7 +107,7 @@ func TestDownloadChunkDetectsStallBeforeFirstByte(t *testing.T) {
 	if !errors.Is(err, errPartStalled) {
 		t.Fatalf("downloadChunk() error = %v after %v, want %v", err, elapsed, errPartStalled)
 	}
-	if elapsed >= 5*stallTimeout {
-		t.Fatalf("downloadChunk() detected the stall after %v, want less than %v", elapsed, 5*stallTimeout)
+	if elapsed >= 5*downloadStallTimeout {
+		t.Fatalf("downloadChunk() detected the stall after %v, want less than %v", elapsed, 5*downloadStallTimeout)
 	}
 }

--- a/server/download_test.go
+++ b/server/download_test.go
@@ -1,0 +1,108 @@
+package server
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func BenchmarkDownloadChunkCompletion(b *testing.B) {
+	data := make([]byte, 1024*1024)
+	digest := fmt.Sprintf("sha256:%x", sha256.Sum256(data))
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", fmt.Sprint(len(data)))
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write(data)
+	}))
+	b.Cleanup(server.Close)
+
+	requestURL, err := url.Parse(server.URL)
+	if err != nil {
+		b.Fatal(err)
+	}
+	downloadPath := filepath.Join(b.TempDir(), "blob")
+
+	b.SetBytes(int64(len(data)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		download := &blobDownload{Name: downloadPath, Digest: digest}
+		part := &blobDownloadPart{Size: int64(len(data)), blobDownload: download}
+		if err := download.downloadChunk(b.Context(), requestURL, io.Discard, part, downloadStallTimeout); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestDownloadChunkReturnsWhenTransferCompletes(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "1")
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write([]byte{0})
+	}))
+	t.Cleanup(server.Close)
+
+	requestURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	download := &blobDownload{
+		Name:   filepath.Join(t.TempDir(), "blob"),
+		Digest: "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+	}
+	part := &blobDownloadPart{Size: 1, blobDownload: download}
+	ctx, cancel := context.WithTimeout(t.Context(), 250*time.Millisecond)
+	defer cancel()
+
+	if err := download.downloadChunk(ctx, requestURL, io.Discard, part, downloadStallTimeout); err != nil {
+		t.Fatalf("downloadChunk() error = %v, want nil", err)
+	}
+}
+
+func TestDownloadChunkDetectsStallBeforeFirstByte(t *testing.T) {
+	requestStarted := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(requestStarted)
+		w.Header().Set("Content-Length", "1")
+		w.WriteHeader(http.StatusPartialContent)
+		w.(http.Flusher).Flush()
+		<-r.Context().Done()
+	}))
+	t.Cleanup(server.Close)
+
+	requestURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	download := &blobDownload{Digest: "sha256:0000000000000000000000000000000000000000000000000000000000000000"}
+	part := &blobDownloadPart{Size: 1, blobDownload: download}
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	const stallTimeout = 50 * time.Millisecond
+	started := time.Now()
+	err = download.downloadChunk(ctx, requestURL, io.Discard, part, stallTimeout)
+	elapsed := time.Since(started)
+
+	select {
+	case <-requestStarted:
+	default:
+		t.Fatal("download request did not start")
+	}
+	if !errors.Is(err, errPartStalled) {
+		t.Fatalf("downloadChunk() error = %v after %v, want %v", err, elapsed, errPartStalled)
+	}
+	if elapsed >= 5*stallTimeout {
+		t.Fatalf("downloadChunk() detected the stall after %v, want less than %v", elapsed, 5*stallTimeout)
+	}
+}


### PR DESCRIPTION
Hey, I had a look at #1736 and traced one current path that can still leave a pull stuck on its final part.

The existing inactivity monitor only started its timeout after `blobDownloadPart.Write` recorded some data. If a range request connected but never delivered its first body byte, `lastUpdated` stayed zero and the monitor skipped that attempt forever. The same monitor also polled for completion once per second, so a finished chunk waited for the next tick before returning.

Prior art: #15716 identified the same first-byte gap and was closed unmerged without review. This PR keeps that core behaviour, but uses a per-attempt start time instead of overwriting the shared progress timestamp, signals completed transfers immediately, and adds benchmark plus race-tested coverage for both paths.

### What changed

- Start the inactivity window when each range attempt begins, then move it forward whenever bytes arrive.
- Signal the monitor as soon as the transfer goroutine exits instead of polling for completion.
- Keep the existing 30-second production stall threshold and retry behaviour.
- Add regression coverage for a connection that sends headers but no body bytes, plus the completed-transfer path.

### Benchmark

Apple M4 (16 GB), macOS 26.5.2, Go 1.26.2, base `573386c3`, 10 samples:

| Completion path | Before | After | Delta |
| --- | ---: | ---: | ---: |
| `BenchmarkDownloadChunkCompletion` | 1.001113 s/op | 689.5 µs/op | -99.93% (p=0.000, n=10) |
| Allocated bytes | 49.16 KiB/op | 52.06 KiB/op | no significant change (p=0.853) |
| Allocations | 211.5 allocs/op | 210.0 allocs/op | no significant change (p=0.853) |

Commands:

```sh
go test ./server -run '^$' -bench '^BenchmarkDownloadChunkCompletion$' -benchmem -benchtime=1x -count=10
benchstat before.txt after.txt
```

This benchmark measures the completion/finalization wait after a local 1 MiB transfer. It isn't a claim that internet bandwidth is 1,500× faster; it shows the fixed polling tail is gone. In a real multipart pull, that removes up to one monitor tick after the last or retried part finishes.

I also captured CPU and allocation profiles over a two-second run. CPU time is dominated by the expected socket/syscall path, and the monitor doesn't appear as a hotspot.

### Validation

- `go test ./server -count=1`
- `go test ./server -run '^TestDownloadChunk' -count=50`
- `go test -race ./server -run '^TestDownloadChunk' -count=20`
- `go mod tidy -diff`
- `git diff --check`

I ran `go test ./... -count=1` as well. The server and the rest of the buildable Go packages passed, but the command exits non-zero in this fresh clone because `app/ui/app.go` embeds `app/dist`, which isn't present without the separate UI build step.

Related to #1736.