### PR TITLE
server: retry interrupted model manifest pulls

### DIFF
--- a/server/images.go
+++ b/server/images.go
@@ -1223,15 +1223,30 @@ func pullModelManifest(ctx context.Context, n model.Name, regOpts *registryOptio
 
 	headers := make(http.Header)
 	headers.Set("Accept", "application/vnd.docker.distribution.manifest.v2+json")
-	resp, err := makeRequestWithRetry(ctx, http.MethodGet, requestURL, headers, nil, regOpts)
-	if err != nil {
+
+	data, retryable, err := requestModelManifest(ctx, requestURL, headers, regOpts)
+	if err != nil && !retryable {
 		return nil, nil, err
 	}
-	defer resp.Body.Close()
-
-	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, nil, err
+		retryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+		backoff := newBackoff(2 * time.Second)
+
+		for err != nil {
+			slog.Warn("failed to pull model manifest; backing off and retrying", "error", err)
+			if backoffErr := backoff(retryCtx); backoffErr != nil {
+				if ctx.Err() != nil {
+					return nil, nil, ctx.Err()
+				}
+				return nil, nil, err
+			}
+
+			data, retryable, err = requestModelManifest(retryCtx, requestURL, headers, regOpts)
+			if err != nil && !retryable {
+				return nil, nil, err
+			}
+		}
 	}
 
 	var m manifest.Manifest
@@ -1239,7 +1254,20 @@ func pullModelManifest(ctx context.Context, n model.Name, regOpts *registryOptio
 		return nil, nil, err
 	}
 
-	return &m, data, err
+	return &m, data, nil
+}
+
+func requestModelManifest(ctx context.Context, requestURL *url.URL, headers http.Header, regOpts *registryOptions) ([]byte, bool, error) {
+	resp, err := makeRequestWithRetry(ctx, http.MethodGet, requestURL, headers, nil, regOpts)
+	if err != nil {
+		var urlErr *url.Error
+		retryable := errors.As(err, &urlErr) || errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF)
+		return nil, retryable, err
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	return data, err != nil, err
 }
 
 // GetSHA256Digest returns the SHA256 hash of a given buffer and returns it, and the size of buffer

--- a/server/images_test.go
+++ b/server/images_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -782,4 +783,121 @@ func TestPullModelManifest(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPullModelManifestRetriesInterruptedResponse(t *testing.T) {
+	manifestData := `{"schemaVersion":2,"mediaType":"application/vnd.docker.distribution.manifest.v2+json","config":{"digest":"sha256:abc","mediaType":"application/vnd.docker.container.image.v1+json","size":50},"layers":[]}`
+	var requests atomic.Int32
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if requests.Add(1) == 1 {
+			w.Header().Set("Content-Length", fmt.Sprint(len(manifestData)))
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(manifestData[:len(manifestData)/2]))
+			return
+		}
+
+		w.Write([]byte(manifestData))
+	}))
+	defer ts.Close()
+
+	n := model.ParseName("test/model:latest")
+	n.ProtocolScheme = "http"
+	n.Host = strings.TrimPrefix(ts.URL, "http://")
+
+	_, data, err := pullModelManifest(t.Context(), n, &registryOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != manifestData {
+		t.Fatalf("manifest data = %q, want %q", data, manifestData)
+	}
+	if got := requests.Load(); got != 2 {
+		t.Fatalf("requests = %d, want 2", got)
+	}
+}
+
+func TestPullModelManifestRetriesInterruptedRequest(t *testing.T) {
+	manifestData := `{"schemaVersion":2,"mediaType":"application/vnd.docker.distribution.manifest.v2+json","config":{"digest":"sha256:abc","mediaType":"application/vnd.docker.container.image.v1+json","size":50},"layers":[]}`
+	var requests atomic.Int32
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if requests.Add(1) == 1 {
+			conn, _, err := w.(http.Hijacker).Hijack()
+			if err != nil {
+				t.Errorf("hijack connection: %v", err)
+				return
+			}
+			conn.Close()
+			return
+		}
+
+		w.Write([]byte(manifestData))
+	}))
+	defer ts.Close()
+
+	n := model.ParseName("test/model:latest")
+	n.ProtocolScheme = "http"
+	n.Host = strings.TrimPrefix(ts.URL, "http://")
+
+	_, data, err := pullModelManifest(t.Context(), n, &registryOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != manifestData {
+		t.Fatalf("manifest data = %q, want %q", data, manifestData)
+	}
+	if got := requests.Load(); got != 2 {
+		t.Fatalf("requests = %d, want 2", got)
+	}
+}
+
+func BenchmarkPullModelManifest(b *testing.B) {
+	manifestData := `{"schemaVersion":2,"mediaType":"application/vnd.docker.distribution.manifest.v2+json","config":{"digest":"sha256:abc","mediaType":"application/vnd.docker.container.image.v1+json","size":50},"layers":[]}`
+
+	b.Run("healthy", func(b *testing.B) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(manifestData))
+		}))
+		defer ts.Close()
+
+		n := model.ParseName("test/model:latest")
+		n.ProtocolScheme = "http"
+		n.Host = strings.TrimPrefix(ts.URL, "http://")
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			if _, _, err := pullModelManifest(b.Context(), n, &registryOptions{}); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("interrupted_response", func(b *testing.B) {
+		var requests atomic.Int32
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if requests.Add(1)%2 == 1 {
+				w.Header().Set("Content-Length", fmt.Sprint(len(manifestData)))
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(manifestData[:len(manifestData)/2]))
+				return
+			}
+
+			w.Write([]byte(manifestData))
+		}))
+		defer ts.Close()
+
+		n := model.ParseName("test/model:latest")
+		n.ProtocolScheme = "http"
+		n.Host = strings.TrimPrefix(ts.URL, "http://")
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for b.Loop() {
+			if _, _, err := pullModelManifest(b.Context(), n, &registryOptions{}); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
 }


### PR DESCRIPTION
## What changed

Hey, I had a look at the manifest EOF reported in #16917.

The pull path retried authentication, but it returned immediately when the connection died before the response headers or while reading the manifest body. That leaves the CLI at `pulling manifest` with an `EOF`, even though a fresh request can succeed once the network is back.

This change retries those transport and body-read failures with the existing jittered backoff for up to 30 seconds. HTTP errors and invalid manifests still fail immediately. The retry context is created lazily, so successful pulls don't pay for a timer or backoff state.

## Reproduction

I added deterministic local registry tests for both failure modes:

- close the connection before response headers arrive
- send half the manifest with a full `Content-Length`, then close the connection

On current `main`, the interrupted-body case fails after one request with `unexpected EOF`. With this change, both cases recover on the second request and return the original manifest bytes.

| Scenario | Current `main` | This PR |
| --- | --- | --- |
| Interrupted manifest body | fails, 1 request | succeeds, 2 requests |
| Interrupted request before headers | fails | succeeds, 2 requests |
| Healthy-path allocations | 94 allocs/op | 94 allocs/op |
| Healthy-path median | 32.99 µs/op | 33.40 µs/op |

The healthy-path timing difference is within local benchmark noise. A 10,000-iteration pprof run measured 33.59 µs/op and 94 allocs/op; allocation space remains dominated by `net/http`, header parsing, and `io.ReadAll`, with no retry context created on successful pulls.

Benchmark command:

```sh
go test ./server -run '^$' -bench '^BenchmarkPullModelManifest/healthy$' -benchtime=1000x -benchmem -count=5
```

## Validation

- `go test ./server -count=1`
- `go test -race ./server -run '^TestPullModelManifest' -count=1`
- `go vet ./server`
- `go test ./... -count=1`
- `npm ci && npm run build` in `app/ui/app` (required for the embedded desktop UI)
- `cmake --build build --parallel 8` on macOS arm64 / Apple M4

Fixes #16917
