### PR TITLE
server/llm: stop parsing special-token literals inside message content

### DIFF
--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -44,6 +44,7 @@ import (
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/envconfig"
 	"github.com/ollama/ollama/fs/ggml"
+	"github.com/ollama/ollama/fs/gguf"
 	"github.com/ollama/ollama/ml"
 )
 
@@ -152,12 +153,18 @@ type llamaServerRunner struct {
 	// used to map DeviceIDs to device names for VRAMByGPU lookups.
 	gpus []ml.DeviceInfo
 
-	ggml          *ggml.GGML
-	totalLayers   uint64 // maximum offloadable model layers
-	loadStart     time.Time
-	loadActivity  atomic.Int64
-	loadTracking  atomic.Bool
-	rawEmbeddings bool
+	ggml        *ggml.GGML
+	totalLayers uint64 // maximum offloadable model layers
+
+	// special token literals from the model vocabulary, read lazily from the
+	// GGUF for segment-aware prompt tokenization
+	specialTokensOnce      sync.Once
+	specialTokens          []string
+	specialTokenFirstChars string
+	loadStart              time.Time
+	loadActivity           atomic.Int64
+	loadTracking           atomic.Bool
+	rawEmbeddings          bool
 
 	sem *semaphore.Weighted
 
@@ -275,17 +282,42 @@ func (s *llamaServerRunner) tokenizerAddsBOS() bool {
 
 func (s *llamaServerRunner) completionPromptForRequest(ctx context.Context, req CompletionRequest) (any, error) {
 	prompt := s.completionPrompt(req.Prompt, req.LeadingBOS)
-	if !req.Truncate || len(req.Media) > 0 || s.options.NumCtx <= 1 || len(prompt) < s.options.NumCtx {
+
+	// When the renderer marked which parts of the prompt are message content
+	// and any of them contains a special-token literal (e.g. "</think>"),
+	// tokenize the segments separately so the literal stays plain text
+	// instead of being parsed into a control token, and submit token IDs.
+	var tokens []int
+	haveTokens := false
+	if len(req.Media) == 0 && s.segmentsNeedSplitTokenization(req.Segments) {
+		var err error
+		tokens, err = s.tokenizeSegments(ctx, req.Segments, req.LeadingBOS)
+		if err != nil {
+			return nil, err
+		}
+		haveTokens = true
+	}
+
+	if !req.Truncate || len(req.Media) > 0 || s.options.NumCtx <= 1 || (!haveTokens && len(prompt) < s.options.NumCtx) {
+		if haveTokens {
+			return tokens, nil
+		}
 		return prompt, nil
 	}
 
-	tokens, err := s.tokenize(ctx, prompt, true, nil)
-	if err != nil {
-		return nil, err
+	if !haveTokens {
+		var err error
+		tokens, err = s.tokenize(ctx, prompt, true, nil)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	fullPromptLimit := s.options.NumCtx - 1
 	if len(tokens) <= fullPromptLimit {
+		if haveTokens {
+			return tokens, nil
+		}
 		return prompt, nil
 	}
 
@@ -313,6 +345,118 @@ func (s *llamaServerRunner) completionPromptForRequest(ctx context.Context, req 
 
 	slog.Warn("truncating input prompt", "limit", limit, "prompt", len(tokens), "keep", nKeep, "new", len(truncated))
 	return truncated, nil
+}
+
+// segmentsNeedSplitTokenization reports whether any content segment contains
+// a literal that the tokenizer would otherwise parse into a special token.
+// The common case — no special-token literal in message content — keeps the
+// plain string prompt path with no extra tokenize calls.
+func (s *llamaServerRunner) segmentsNeedSplitTokenization(segments []PromptSegment) bool {
+	if len(segments) == 0 {
+		return false
+	}
+
+	literals, firstChars := s.specialTokenLiterals()
+	if len(literals) == 0 {
+		return false
+	}
+
+	for _, seg := range segments {
+		if !seg.Content || !strings.ContainsAny(seg.Text, firstChars) {
+			continue
+		}
+		for _, literal := range literals {
+			if strings.Contains(seg.Text, literal) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// tokenizeSegments tokenizes a segmented prompt, parsing special-token
+// literals only in control segments. Content segments are tokenized with
+// parse_special disabled so user-supplied text like "</think>" is encoded
+// as plain text.
+func (s *llamaServerRunner) tokenizeSegments(ctx context.Context, segments []PromptSegment, leadingBOS string) ([]int, error) {
+	parseSpecialOff := false
+
+	var tokens []int
+	first := true
+	for i, seg := range segments {
+		text := seg.Text
+		if i == 0 && !seg.Content {
+			// mirror the textual BOS handling of the string prompt path
+			text = s.completionPrompt(text, leadingBOS)
+		}
+		if text == "" {
+			continue
+		}
+
+		var parseSpecial *bool
+		if seg.Content {
+			parseSpecial = &parseSpecialOff
+		}
+
+		t, err := s.tokenize(ctx, text, first, parseSpecial)
+		if err != nil {
+			return nil, err
+		}
+		first = false
+		tokens = append(tokens, t...)
+	}
+
+	return tokens, nil
+}
+
+// llama token types from the GGUF tokenizer.ggml.token_type metadata for
+// which llama.cpp parses the token's literal text as a special token.
+const (
+	ggufTokenTypeControl     = 3
+	ggufTokenTypeUserDefined = 4
+)
+
+// specialTokenLiterals returns the literal strings of vocabulary entries the
+// tokenizer parses as special tokens, along with the set of their first
+// characters (used as a cheap prescan filter). The vocabulary arrays are too
+// large to be retained in s.ggml, so they are read lazily from the GGUF once
+// per runner.
+func (s *llamaServerRunner) specialTokenLiterals() ([]string, string) {
+	s.specialTokensOnce.Do(func() {
+		f, err := gguf.Open(s.modelPath)
+		if err != nil {
+			slog.Warn("failed to open model to read special tokens", "model", s.modelPath, "error", err)
+			return
+		}
+		defer f.Close()
+
+		tokens := f.KeyValue("tokenizer.ggml.tokens").Strings()
+		types := f.KeyValue("tokenizer.ggml.token_type").Ints()
+		if len(tokens) == 0 || len(tokens) != len(types) {
+			return
+		}
+
+		firstChars := make(map[rune]struct{})
+		for i, typ := range types {
+			if typ != ggufTokenTypeControl && typ != ggufTokenTypeUserDefined {
+				continue
+			}
+			if tokens[i] == "" {
+				continue
+			}
+			s.specialTokens = append(s.specialTokens, tokens[i])
+			firstChars[[]rune(tokens[i])[0]] = struct{}{}
+		}
+
+		var sb strings.Builder
+		for r := range firstChars {
+			sb.WriteRune(r)
+		}
+		s.specialTokenFirstChars = sb.String()
+	})
+
+	return s.specialTokens, s.specialTokenFirstChars
 }
 
 func contextShiftPromptLimit(numCtx, numKeep int) int {

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -3605,3 +3605,244 @@ func fakeRunningCmd() *exec.Cmd {
 	// SIGKILL children when the test process exits.
 	return cmd
 }
+
+func TestSegmentsNeedSplitTokenization(t *testing.T) {
+	newRunner := func(specials []string, firstChars string) *llamaServerRunner {
+		runner := &llamaServerRunner{}
+		runner.specialTokensOnce.Do(func() {
+			runner.specialTokens = specials
+			runner.specialTokenFirstChars = firstChars
+		})
+		return runner
+	}
+
+	cases := []struct {
+		name     string
+		specials []string
+		first    string
+		segments []PromptSegment
+		want     bool
+	}{
+		{
+			name: "no segments",
+		},
+		{
+			name:     "content without special literal",
+			specials: []string{"</think>", "<|user|>"},
+			first:    "<",
+			segments: []PromptSegment{
+				{Text: "<|user|>"},
+				{Text: "hello world", Content: true},
+			},
+			want: false,
+		},
+		{
+			name:     "content with special literal",
+			specials: []string{"</think>", "<|user|>"},
+			first:    "<",
+			segments: []PromptSegment{
+				{Text: "<|user|>"},
+				{Text: "hello </think> world", Content: true},
+			},
+			want: true,
+		},
+		{
+			name:     "special literal only in control segment",
+			specials: []string{"</think>", "<|user|>"},
+			first:    "<",
+			segments: []PromptSegment{
+				{Text: "<|assistant|></think>"},
+				{Text: "hello world", Content: true},
+			},
+			want: false,
+		},
+		{
+			name: "no special vocabulary available",
+			segments: []PromptSegment{
+				{Text: "hello </think> world", Content: true},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := newRunner(tt.specials, tt.first)
+			if got := runner.segmentsNeedSplitTokenization(tt.segments); got != tt.want {
+				t.Errorf("segmentsNeedSplitTokenization() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLlamaServerCompletionSegmentTokenization(t *testing.T) {
+	type tokenizeCall struct {
+		Content      string `json:"content"`
+		AddSpecial   bool   `json:"add_special"`
+		ParseSpecial *bool  `json:"parse_special"`
+	}
+
+	var tokenizeCalls []tokenizeCall
+	var capturedReq llamaServerCompletionRequest
+
+	next := 100
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health":
+			fmt.Fprint(w, `{"status":"ok"}`)
+		case "/tokenize":
+			var call tokenizeCall
+			if err := json.NewDecoder(r.Body).Decode(&call); err != nil {
+				t.Errorf("invalid tokenize request body: %v", err)
+				return
+			}
+			tokenizeCalls = append(tokenizeCalls, call)
+			// two distinct tokens per call so concatenation order is visible
+			fmt.Fprintf(w, `{"tokens":[%d,%d]}`, next, next+1)
+			next += 100
+		case "/completion":
+			if err := json.NewDecoder(r.Body).Decode(&capturedReq); err != nil {
+				t.Errorf("invalid completion request body: %v", err)
+				return
+			}
+			w.Header().Set("Content-Type", "text/event-stream")
+			fmt.Fprintln(w, `data: {"content":"ok","stop":true,"timings":{"prompt_n":6,"prompt_ms":1,"predicted_n":1,"predicted_ms":1}}`)
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	parts := strings.Split(srv.URL, ":")
+	var portInt int
+	fmt.Sscanf(parts[len(parts)-1], "%d", &portInt)
+
+	runner := &llamaServerRunner{
+		port:    portInt,
+		cmd:     fakeRunningCmd(),
+		sem:     semaphore.NewWeighted(1),
+		options: api.Options{Runner: api.Runner{NumCtx: 4096}},
+	}
+	runner.specialTokensOnce.Do(func() {
+		runner.specialTokens = []string{"</think>", "<think>", "<|user|>", "<|assistant|>"}
+		runner.specialTokenFirstChars = "<"
+	})
+
+	segments := []PromptSegment{
+		{Text: "<|user|>"},
+		{Text: "hello </think> world", Content: true},
+		{Text: "<|assistant|><think>"},
+	}
+	var prompt strings.Builder
+	for _, seg := range segments {
+		prompt.WriteString(seg.Text)
+	}
+
+	opts := api.DefaultOptions()
+	err := runner.Completion(t.Context(), CompletionRequest{
+		Prompt:   prompt.String(),
+		Segments: segments,
+		Options:  &opts,
+		Truncate: true,
+	}, func(cr CompletionResponse) {})
+	if err != nil {
+		t.Fatalf("Completion error: %v", err)
+	}
+
+	if len(tokenizeCalls) != 3 {
+		t.Fatalf("tokenize calls = %d, want 3", len(tokenizeCalls))
+	}
+
+	if tokenizeCalls[0].Content != "<|user|>" || !tokenizeCalls[0].AddSpecial || tokenizeCalls[0].ParseSpecial != nil {
+		t.Errorf("control segment call = %+v, want add_special=true, parse_special unset", tokenizeCalls[0])
+	}
+	if tokenizeCalls[1].Content != "hello </think> world" || tokenizeCalls[1].AddSpecial ||
+		tokenizeCalls[1].ParseSpecial == nil || *tokenizeCalls[1].ParseSpecial {
+		t.Errorf("content segment call = %+v, want add_special=false, parse_special=false", tokenizeCalls[1])
+	}
+	if tokenizeCalls[2].Content != "<|assistant|><think>" || tokenizeCalls[2].AddSpecial || tokenizeCalls[2].ParseSpecial != nil {
+		t.Errorf("control segment call = %+v, want add_special=false, parse_special unset", tokenizeCalls[2])
+	}
+
+	got, ok := capturedReq.Prompt.([]any)
+	if !ok {
+		t.Fatalf("completion prompt = %T %v, want token array", capturedReq.Prompt, capturedReq.Prompt)
+	}
+	want := []float64{100, 101, 200, 201, 300, 301}
+	if len(got) != len(want) {
+		t.Fatalf("completion prompt tokens = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("completion prompt tokens = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestLlamaServerCompletionSegmentsWithoutSpecialLiteralUseStringPrompt(t *testing.T) {
+	tokenizeCalled := false
+	var capturedReq llamaServerCompletionRequest
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health":
+			fmt.Fprint(w, `{"status":"ok"}`)
+		case "/tokenize":
+			tokenizeCalled = true
+			fmt.Fprint(w, `{"tokens":[1,2,3]}`)
+		case "/completion":
+			if err := json.NewDecoder(r.Body).Decode(&capturedReq); err != nil {
+				t.Errorf("invalid completion request body: %v", err)
+				return
+			}
+			w.Header().Set("Content-Type", "text/event-stream")
+			fmt.Fprintln(w, `data: {"content":"ok","stop":true,"timings":{"prompt_n":6,"prompt_ms":1,"predicted_n":1,"predicted_ms":1}}`)
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	parts := strings.Split(srv.URL, ":")
+	var portInt int
+	fmt.Sscanf(parts[len(parts)-1], "%d", &portInt)
+
+	runner := &llamaServerRunner{
+		port:    portInt,
+		cmd:     fakeRunningCmd(),
+		sem:     semaphore.NewWeighted(1),
+		options: api.Options{Runner: api.Runner{NumCtx: 4096}},
+	}
+	runner.specialTokensOnce.Do(func() {
+		runner.specialTokens = []string{"</think>", "<think>", "<|user|>", "<|assistant|>"}
+		runner.specialTokenFirstChars = "<"
+	})
+
+	segments := []PromptSegment{
+		{Text: "<|user|>"},
+		{Text: "hello world", Content: true},
+		{Text: "<|assistant|><think>"},
+	}
+	var prompt strings.Builder
+	for _, seg := range segments {
+		prompt.WriteString(seg.Text)
+	}
+
+	opts := api.DefaultOptions()
+	err := runner.Completion(t.Context(), CompletionRequest{
+		Prompt:   prompt.String(),
+		Segments: segments,
+		Options:  &opts,
+		Truncate: true,
+	}, func(cr CompletionResponse) {})
+	if err != nil {
+		t.Fatalf("Completion error: %v", err)
+	}
+
+	if tokenizeCalled {
+		t.Fatal("tokenize endpoint was called for a prompt without special-token literals in content")
+	}
+	if capturedReq.Prompt != prompt.String() {
+		t.Fatalf("completion prompt = %v, want %q", capturedReq.Prompt, prompt.String())
+	}
+}

--- a/llm/server.go
+++ b/llm/server.go
@@ -203,11 +203,26 @@ func MessageFromAPI(msg api.Message) Message {
 	}
 }
 
+// PromptSegment is a piece of a rendered prompt. Control segments carry
+// template markup whose special-token literals should be parsed as special
+// tokens. Content segments carry user- or tool-supplied message data whose
+// special-token-like literals (e.g. "</think>") must be tokenized as plain
+// text.
+type PromptSegment struct {
+	Text    string
+	Content bool
+}
+
 type CompletionRequest struct {
-	Prompt  string
-	Format  json.RawMessage
-	Media   []MediaData
-	Options *api.Options
+	Prompt string
+	// Segments optionally carries Prompt split into control/content segments.
+	// When set, the concatenated segment text equals Prompt. Runners may use
+	// it to avoid parsing special-token literals inside message content;
+	// runners that ignore it fall back to Prompt.
+	Segments []PromptSegment
+	Format   json.RawMessage
+	Media    []MediaData
+	Options  *api.Options
 
 	Grammar         string // set before sending the request to the subprocess
 	Shift           bool

--- a/model/renderers/deepseek3.go
+++ b/model/renderers/deepseek3.go
@@ -23,51 +23,60 @@ func (r *DeepSeek3Renderer) LeadingBOS() string {
 }
 
 func (r *DeepSeek3Renderer) Render(messages []api.Message, tools []api.Tool, thinkValue *api.ThinkValue) (string, error) {
-	var sb strings.Builder
+	segments, err := r.RenderSegments(messages, tools, thinkValue)
+	if err != nil {
+		return "", err
+	}
+	return JoinSegments(segments), nil
+}
+
+func (r *DeepSeek3Renderer) RenderSegments(messages []api.Message, tools []api.Tool, thinkValue *api.ThinkValue) ([]Segment, error) {
+	var sb segmentBuilder
 
 	// thinking is enabled: model must support it AND user must request it
 	thinking := r.IsThinking && (thinkValue != nil && thinkValue.Bool())
 
-	// extract system messages first
-	var systemPrompt strings.Builder
-	isFirstSystemPrompt := true
+	sb.control("<｜begin▁of▁sentence｜>")
 
+	// extract system messages first
+	isFirstSystemPrompt := true
 	for _, message := range messages {
 		if message.Role == "system" {
 			if isFirstSystemPrompt {
-				systemPrompt.WriteString(message.Content)
 				isFirstSystemPrompt = false
 			} else {
-				systemPrompt.WriteString("\n\n" + message.Content)
+				sb.content("\n\n")
 			}
+			sb.content(message.Content)
 		}
 	}
 
-	sb.WriteString("<｜begin▁of▁sentence｜>")
-	sb.WriteString(systemPrompt.String())
-
 	// tool definitions
 	if len(tools) > 0 {
-		sb.WriteString("\n\n## Tools\nYou have access to the following tools:\n")
+		sb.control("\n\n## Tools\nYou have access to the following tools:\n")
 
 		for _, tool := range tools {
-			sb.WriteString("\n### " + tool.Function.Name)
-			sb.WriteString("\nDescription: " + tool.Function.Description)
+			sb.control("\n### ")
+			sb.content(tool.Function.Name)
+			sb.control("\nDescription: ")
+			sb.content(tool.Function.Description)
 
 			// parameters as JSON
 			parametersJSON, err := json.Marshal(tool.Function.Parameters)
 			if err == nil {
-				sb.WriteString("\n\nParameters: " + string(parametersJSON) + "\n")
+				sb.control("\n\nParameters: ")
+				sb.content(string(parametersJSON))
+				sb.control("\n")
 			}
 		}
 
 		// usage instructions
-		sb.WriteString("\nIMPORTANT: ALWAYS adhere to this exact format for tool use:\n")
-		sb.WriteString("<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>tool_call_name<｜tool▁sep｜>tool_call_arguments<｜tool▁call▁end｜>{{additional_tool_calls}}<｜tool▁calls▁end｜>\n\n")
-		sb.WriteString("Where:\n\n")
-		sb.WriteString("- `tool_call_name` must be an exact match to one of the available tools\n")
-		sb.WriteString("- `tool_call_arguments` must be valid JSON that strictly follows the tool's Parameters Schema\n")
-		sb.WriteString("- For multiple tool calls, chain them directly without separators or spaces\n")
+		sb.control("\nIMPORTANT: ALWAYS adhere to this exact format for tool use:\n")
+		sb.control("<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>tool_call_name<｜tool▁sep｜>tool_call_arguments<｜tool▁call▁end｜>{{additional_tool_calls}}<｜tool▁calls▁end｜>\n\n")
+		sb.control("Where:\n\n")
+		sb.control("- `tool_call_name` must be an exact match to one of the available tools\n")
+		sb.control("- `tool_call_arguments` must be valid JSON that strictly follows the tool's Parameters Schema\n")
+		sb.control("- For multiple tool calls, chain them directly without separators or spaces\n")
 	}
 
 	// state tracking
@@ -88,74 +97,80 @@ func (r *DeepSeek3Renderer) Render(messages []api.Message, tools []api.Tool, thi
 		case "user":
 			isTool = false
 			isLastUser = true
-			sb.WriteString("<｜User｜>" + message.Content)
+			sb.control("<｜User｜>")
+			sb.content(message.Content)
 
 		case "assistant":
 			if len(message.ToolCalls) > 0 {
 				if isLastUser {
-					sb.WriteString("<｜Assistant｜></think>")
+					sb.control("<｜Assistant｜></think>")
 				}
 				isLastUser = false
 				isTool = false
 
 				if message.Content != "" {
-					sb.WriteString(message.Content)
+					sb.content(message.Content)
 				}
 
-				sb.WriteString("<｜tool▁calls▁begin｜>")
+				sb.control("<｜tool▁calls▁begin｜>")
 				for _, toolCall := range message.ToolCalls {
-					sb.WriteString("<｜tool▁call▁begin｜>" + toolCall.Function.Name + "<｜tool▁sep｜>")
+					sb.control("<｜tool▁call▁begin｜>")
+					sb.content(toolCall.Function.Name)
+					sb.control("<｜tool▁sep｜>")
 
 					argsJSON, _ := json.Marshal(toolCall.Function.Arguments)
-					sb.WriteString(string(argsJSON))
-					sb.WriteString("<｜tool▁call▁end｜>")
+					sb.content(string(argsJSON))
+					sb.control("<｜tool▁call▁end｜>")
 				}
-				sb.WriteString("<｜tool▁calls▁end｜><｜end▁of▁sentence｜>")
+				sb.control("<｜tool▁calls▁end｜><｜end▁of▁sentence｜>")
 			} else {
 				if isLastUser {
-					sb.WriteString("<｜Assistant｜>")
+					sb.control("<｜Assistant｜>")
 					hasThinking := message.Thinking != ""
 
 					// only use <think> for the current turn (after last user message)
 					isCurrentTurn := i > lastUserIndex
 					if hasThinking && thinking && isCurrentTurn {
-						sb.WriteString("<think>")
+						sb.control("<think>")
 					} else {
-						sb.WriteString("</think>")
+						sb.control("</think>")
 					}
 				}
 				isLastUser = false
 
 				content := message.Content
 				if isTool {
-					sb.WriteString(content + "<｜end▁of▁sentence｜>")
 					isTool = false
-				} else {
-					if strings.Contains(content, "</think>") {
-						parts := strings.SplitN(content, "</think>", 2)
-						if len(parts) > 1 {
-							content = parts[1]
-						}
+				} else if strings.HasPrefix(content, "<think>") {
+					// Strip a replayed reasoning block from clients that resend
+					// the model's raw output as content. Content that merely
+					// mentions "</think>" without a leading "<think>" is
+					// ordinary text and is preserved verbatim (#17248).
+					if parts := strings.SplitN(content, "</think>", 2); len(parts) > 1 {
+						content = parts[1]
 					}
-					sb.WriteString(content + "<｜end▁of▁sentence｜>")
 				}
+				sb.content(content)
+				sb.control("<｜end▁of▁sentence｜>")
 			}
 
 		case "tool":
 			isLastUser = false
 			isTool = true
-			sb.WriteString("<｜tool▁output▁begin｜>" + message.Content + "<｜tool▁output▁end｜>")
+			sb.control("<｜tool▁output▁begin｜>")
+			sb.content(message.Content)
+			sb.control("<｜tool▁output▁end｜>")
 		}
 	}
 
 	if isLastUser && !isTool {
-		sb.WriteString("<｜Assistant｜>")
+		sb.control("<｜Assistant｜>")
 		if thinking {
-			sb.WriteString("<think>")
+			sb.control("<think>")
 		} else {
-			sb.WriteString("</think>")
+			sb.control("</think>")
 		}
 	}
 
-	return sb.String(), nil
+	return sb.Segments(), nil
 }

--- a/model/renderers/deepseek3_test.go
+++ b/model/renderers/deepseek3_test.go
@@ -169,10 +169,19 @@ Second instruction<｜User｜>Hello<｜Assistant｜></think>`,
 			expected:   `<｜begin▁of▁sentence｜><｜User｜>Get weather for Paris and London<｜Assistant｜></think><｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"Paris"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"London"}<｜tool▁call▁end｜><｜tool▁calls▁end｜><｜end▁of▁sentence｜><｜tool▁output▁begin｜>Paris: 22°C, Sunny<｜tool▁output▁end｜><｜tool▁output▁begin｜>London: 18°C, Cloudy<｜tool▁output▁end｜>`,
 		},
 		{
-			name: "content with </think> tag removal",
+			name: "literal </think> in content is preserved",
 			messages: []api.Message{
 				{Role: "user", Content: "Think about this"},
 				{Role: "assistant", Content: "I'm thinking about this.</think>The answer is 42."},
+			},
+			thinkValue: &api.ThinkValue{Value: false},
+			expected:   `<｜begin▁of▁sentence｜><｜User｜>Think about this<｜Assistant｜></think>I'm thinking about this.</think>The answer is 42.<｜end▁of▁sentence｜>`,
+		},
+		{
+			name: "replayed reasoning block in content is stripped",
+			messages: []api.Message{
+				{Role: "user", Content: "Think about this"},
+				{Role: "assistant", Content: "<think>I'm thinking about this.</think>The answer is 42."},
 			},
 			thinkValue: &api.ThinkValue{Value: false},
 			expected:   `<｜begin▁of▁sentence｜><｜User｜>Think about this<｜Assistant｜></think>The answer is 42.<｜end▁of▁sentence｜>`,
@@ -263,10 +272,19 @@ Second instruction<｜User｜>Hello<｜Assistant｜></think>`,
 			expected:   `<｜begin▁of▁sentence｜>System instruction`,
 		},
 		{
-			name: "multiple think tags in content",
+			name: "multiple literal think tags in content are preserved",
 			messages: []api.Message{
 				{Role: "user", Content: "Complex question"},
 				{Role: "assistant", Content: "First thought</think>Second thought</think>Final answer"},
+			},
+			thinkValue: &api.ThinkValue{Value: false},
+			expected:   `<｜begin▁of▁sentence｜><｜User｜>Complex question<｜Assistant｜></think>First thought</think>Second thought</think>Final answer<｜end▁of▁sentence｜>`,
+		},
+		{
+			name: "replayed reasoning block with literal </think> after it",
+			messages: []api.Message{
+				{Role: "user", Content: "Complex question"},
+				{Role: "assistant", Content: "<think>First thought</think>Second thought</think>Final answer"},
 			},
 			thinkValue: &api.ThinkValue{Value: false},
 			expected:   `<｜begin▁of▁sentence｜><｜User｜>Complex question<｜Assistant｜></think>Second thought</think>Final answer<｜end▁of▁sentence｜>`,

--- a/model/renderers/glm46.go
+++ b/model/renderers/glm46.go
@@ -15,9 +15,17 @@ func (r *GLM46Renderer) LeadingBOS() string {
 }
 
 func (r *GLM46Renderer) Render(messages []api.Message, tools []api.Tool, thinkValue *api.ThinkValue) (string, error) {
-	var sb strings.Builder
+	segments, err := r.RenderSegments(messages, tools, thinkValue)
+	if err != nil {
+		return "", err
+	}
+	return JoinSegments(segments), nil
+}
 
-	sb.WriteString("[gMASK]<sop>")
+func (r *GLM46Renderer) RenderSegments(messages []api.Message, tools []api.Tool, thinkValue *api.ThinkValue) ([]Segment, error) {
+	var sb segmentBuilder
+
+	sb.control("[gMASK]<sop>")
 
 	var lastUserIndex int
 	for i, message := range messages {
@@ -27,51 +35,59 @@ func (r *GLM46Renderer) Render(messages []api.Message, tools []api.Tool, thinkVa
 	}
 
 	if len(tools) > 0 {
-		sb.WriteString("<|system|>\n")
-		sb.WriteString("# Tools\n\n")
-		sb.WriteString("You may call one or more functions to assist with the user query.\n\n")
-		sb.WriteString("You are provided with function signatures within <tools></tools> XML tags:\n")
-		sb.WriteString("<tools>\n")
+		sb.control("<|system|>\n")
+		sb.control("# Tools\n\n")
+		sb.control("You may call one or more functions to assist with the user query.\n\n")
+		sb.control("You are provided with function signatures within <tools></tools> XML tags:\n")
+		sb.control("<tools>\n")
 		for _, tool := range tools {
 			d, _ := json.Marshal(tool)
-			sb.WriteString(string(d) + "\n")
+			sb.content(string(d))
+			sb.control("\n")
 		}
-		sb.WriteString("</tools>\n\n")
-		sb.WriteString("For each function call, output the function name and arguments within the following XML format:\n")
-		sb.WriteString("<tool_call>{function-name}\n")
-		sb.WriteString("<arg_key>{arg-key-1}</arg_key>\n")
-		sb.WriteString("<arg_value>{arg-value-1}</arg_value>\n")
-		sb.WriteString("<arg_key>{arg-key-2}</arg_key>\n")
-		sb.WriteString("<arg_value>{arg-value-2}</arg_value>\n")
-		sb.WriteString("...\n")
-		sb.WriteString("</tool_call>")
+		sb.control("</tools>\n\n")
+		sb.control("For each function call, output the function name and arguments within the following XML format:\n")
+		sb.control("<tool_call>{function-name}\n")
+		sb.control("<arg_key>{arg-key-1}</arg_key>\n")
+		sb.control("<arg_value>{arg-value-1}</arg_value>\n")
+		sb.control("<arg_key>{arg-key-2}</arg_key>\n")
+		sb.control("<arg_value>{arg-value-2}</arg_value>\n")
+		sb.control("...\n")
+		sb.control("</tool_call>")
 	}
 
 	for i, message := range messages {
 		switch message.Role {
 		case "user":
-			sb.WriteString("<|user|>\n")
-			sb.WriteString(message.Content)
+			sb.control("<|user|>\n")
+			sb.content(message.Content)
 			if thinkValue != nil && !thinkValue.Bool() && !strings.HasSuffix(message.Content, "/nothink") {
-				sb.WriteString("/nothink")
+				sb.control("/nothink")
 			}
 		case "assistant":
-			sb.WriteString("<|assistant|>")
+			sb.control("<|assistant|>")
 			if i > lastUserIndex {
 				if message.Thinking != "" {
-					sb.WriteString("\n<think>" + message.Thinking + "</think>")
+					sb.control("\n<think>")
+					sb.content(message.Thinking)
+					sb.control("</think>")
 				} else {
-					sb.WriteString("\n<think></think>")
+					sb.control("\n<think></think>")
 				}
 			}
 			if message.Content != "" {
-				sb.WriteString("\n" + message.Content)
+				sb.control("\n")
+				sb.content(message.Content)
 			}
 			if len(message.ToolCalls) > 0 {
 				for _, toolCall := range message.ToolCalls {
-					sb.WriteString("\n<tool_call>" + toolCall.Function.Name + "\n")
+					sb.control("\n<tool_call>")
+					sb.content(toolCall.Function.Name)
+					sb.control("\n")
 					for key, value := range toolCall.Function.Arguments.All() {
-						sb.WriteString("<arg_key>" + key + "</arg_key>\n")
+						sb.control("<arg_key>")
+						sb.content(key)
+						sb.control("</arg_key>\n")
 
 						var valueStr string
 						if str, ok := value.(string); ok {
@@ -85,30 +101,32 @@ func (r *GLM46Renderer) Render(messages []api.Message, tools []api.Tool, thinkVa
 							}
 						}
 
-						sb.WriteString("<arg_value>" + valueStr + "</arg_value>\n")
+						sb.control("<arg_value>")
+						sb.content(valueStr)
+						sb.control("</arg_value>\n")
 					}
 
-					sb.WriteString("</tool_call>")
+					sb.control("</tool_call>")
 				}
 			}
 		case "tool":
 			if i == 0 || messages[i-1].Role != "tool" {
-				sb.WriteString("<|observation|>")
+				sb.control("<|observation|>")
 			}
-			sb.WriteString("\n<tool_response>\n")
-			sb.WriteString(message.Content)
-			sb.WriteString("\n</tool_response>")
+			sb.control("\n<tool_response>\n")
+			sb.content(message.Content)
+			sb.control("\n</tool_response>")
 		case "system":
-			sb.WriteString("<|system|>\n")
-			sb.WriteString(message.Content)
+			sb.control("<|system|>\n")
+			sb.content(message.Content)
 		}
 	}
 
 	// Add generation prompt
-	sb.WriteString("<|assistant|>")
+	sb.control("<|assistant|>")
 	if thinkValue != nil && !thinkValue.Bool() {
-		sb.WriteString("\n<think></think>\n")
+		sb.control("\n<think></think>\n")
 	}
 
-	return sb.String(), nil
+	return sb.Segments(), nil
 }

--- a/model/renderers/glm47.go
+++ b/model/renderers/glm47.go
@@ -43,24 +43,32 @@ func (r *GLM47Renderer) LeadingBOS() string {
 }
 
 func (r *GLM47Renderer) Render(messages []api.Message, tools []api.Tool, thinkValue *api.ThinkValue) (string, error) {
-	var sb strings.Builder
+	segments, err := r.RenderSegments(messages, tools, thinkValue)
+	if err != nil {
+		return "", err
+	}
+	return JoinSegments(segments), nil
+}
 
-	sb.WriteString("[gMASK]<sop>")
+func (r *GLM47Renderer) RenderSegments(messages []api.Message, tools []api.Tool, thinkValue *api.ThinkValue) ([]Segment, error) {
+	var sb segmentBuilder
+
+	sb.control("[gMASK]<sop>")
 
 	if len(tools) > 0 {
-		sb.WriteString("<|system|>\n")
-		sb.WriteString("# Tools\n\n")
-		sb.WriteString("You may call one or more functions to assist with the user query.\n\n")
-		sb.WriteString("You are provided with function signatures within <tools></tools> XML tags:\n")
-		sb.WriteString("<tools>\n")
+		sb.control("<|system|>\n")
+		sb.control("# Tools\n\n")
+		sb.control("You may call one or more functions to assist with the user query.\n\n")
+		sb.control("You are provided with function signatures within <tools></tools> XML tags:\n")
+		sb.control("<tools>\n")
 		for _, tool := range tools {
 			d, _ := json.Marshal(tool)
-			sb.WriteString(formatGLM47ToolJSON(d))
-			sb.WriteString("\n")
+			sb.content(formatGLM47ToolJSON(d))
+			sb.control("\n")
 		}
-		sb.WriteString("</tools>\n\n")
-		sb.WriteString("For each function call, output the function name and arguments within the following XML format:\n")
-		sb.WriteString("<tool_call>{function-name}<arg_key>{arg-key-1}</arg_key><arg_value>{arg-value-1}</arg_value><arg_key>{arg-key-2}</arg_key><arg_value>{arg-value-2}</arg_value>...</tool_call>")
+		sb.control("</tools>\n\n")
+		sb.control("For each function call, output the function name and arguments within the following XML format:\n")
+		sb.control("<tool_call>{function-name}<arg_key>{arg-key-1}</arg_key><arg_value>{arg-value-1}</arg_value><arg_key>{arg-key-2}</arg_key><arg_value>{arg-value-2}</arg_value>...</tool_call>")
 	}
 
 	think := true
@@ -71,52 +79,56 @@ func (r *GLM47Renderer) Render(messages []api.Message, tools []api.Tool, thinkVa
 	for i, message := range messages {
 		switch message.Role {
 		case "user":
-			sb.WriteString("<|user|>")
-			sb.WriteString(message.Content)
+			sb.control("<|user|>")
+			sb.content(message.Content)
 		case "assistant":
-			sb.WriteString("<|assistant|>")
+			sb.control("<|assistant|>")
 			if message.Thinking != "" {
-				sb.WriteString("<think>" + message.Thinking + "</think>")
+				sb.control("<think>")
+				sb.content(message.Thinking)
+				sb.control("</think>")
 			} else {
-				sb.WriteString("</think>")
+				sb.control("</think>")
 			}
 			if message.Content != "" {
-				sb.WriteString(message.Content)
+				sb.content(message.Content)
 			}
 			if len(message.ToolCalls) > 0 {
 				for _, toolCall := range message.ToolCalls {
-					sb.WriteString("<tool_call>" + toolCall.Function.Name)
-					sb.WriteString(renderGLM47ToolArguments(toolCall.Function.Arguments))
-					sb.WriteString("</tool_call>")
+					sb.control("<tool_call>")
+					sb.content(toolCall.Function.Name)
+					renderGLM47ToolArguments(&sb, toolCall.Function.Arguments)
+					sb.control("</tool_call>")
 				}
 			}
 		case "tool":
 			if i == 0 || messages[i-1].Role != "tool" {
-				sb.WriteString("<|observation|>")
+				sb.control("<|observation|>")
 			}
-			sb.WriteString("<tool_response>")
-			sb.WriteString(message.Content)
-			sb.WriteString("</tool_response>")
+			sb.control("<tool_response>")
+			sb.content(message.Content)
+			sb.control("</tool_response>")
 		case "system":
-			sb.WriteString("<|system|>")
-			sb.WriteString(message.Content)
+			sb.control("<|system|>")
+			sb.content(message.Content)
 		}
 	}
 
-	sb.WriteString("<|assistant|>")
+	sb.control("<|assistant|>")
 	if think {
-		sb.WriteString("<think>")
+		sb.control("<think>")
 	} else {
-		sb.WriteString("</think>")
+		sb.control("</think>")
 	}
 
-	return sb.String(), nil
+	return sb.Segments(), nil
 }
 
-func renderGLM47ToolArguments(args api.ToolCallFunctionArguments) string {
-	var sb strings.Builder
+func renderGLM47ToolArguments(sb *segmentBuilder, args api.ToolCallFunctionArguments) {
 	for key, value := range args.All() {
-		sb.WriteString("<arg_key>" + key + "</arg_key>")
+		sb.control("<arg_key>")
+		sb.content(key)
+		sb.control("</arg_key>")
 		var valueStr string
 		if str, ok := value.(string); ok {
 			valueStr = str
@@ -129,10 +141,10 @@ func renderGLM47ToolArguments(args api.ToolCallFunctionArguments) string {
 			}
 		}
 
-		sb.WriteString("<arg_value>" + valueStr + "</arg_value>")
+		sb.control("<arg_value>")
+		sb.content(valueStr)
+		sb.control("</arg_value>")
 	}
-
-	return sb.String()
 }
 
 func formatGLM47ToolJSON(raw []byte) string {

--- a/model/renderers/segments.go
+++ b/model/renderers/segments.go
@@ -1,0 +1,80 @@
+package renderers
+
+import (
+	"strings"
+
+	"github.com/ollama/ollama/api"
+)
+
+// Segment is a piece of a rendered prompt. Control segments carry template
+// markup whose special-token literals are meant to be parsed as special
+// tokens. Content segments carry user- or tool-supplied message data that
+// must be tokenized verbatim, so that special-token-like literals in it
+// (e.g. "</think>") are not encoded as control tokens.
+type Segment struct {
+	Text    string
+	Content bool
+}
+
+// SegmentRenderer is implemented by renderers that can distinguish template
+// markup from message content in their rendered output.
+type SegmentRenderer interface {
+	RenderSegments(messages []api.Message, tools []api.Tool, think *api.ThinkValue) ([]Segment, error)
+}
+
+// RenderSegmentsWithRenderer renders messages with the named renderer and
+// returns the prompt as control/content segments. It returns nil segments
+// (and no error) if the renderer does not support segmented rendering.
+func RenderSegmentsWithRenderer(name string, msgs []api.Message, tools []api.Tool, think *api.ThinkValue) ([]Segment, error) {
+	renderer := rendererForName(name)
+	if renderer == nil {
+		return nil, nil
+	}
+
+	sr, ok := renderer.(SegmentRenderer)
+	if !ok {
+		return nil, nil
+	}
+
+	return sr.RenderSegments(msgs, tools, think)
+}
+
+// JoinSegments concatenates segments back into a flat prompt string.
+func JoinSegments(segments []Segment) string {
+	var sb strings.Builder
+	for _, s := range segments {
+		sb.WriteString(s.Text)
+	}
+	return sb.String()
+}
+
+// segmentBuilder accumulates a rendered prompt as segments, merging adjacent
+// writes of the same kind.
+type segmentBuilder struct {
+	segments []Segment
+}
+
+func (b *segmentBuilder) write(text string, content bool) {
+	if text == "" {
+		return
+	}
+	if n := len(b.segments); n > 0 && b.segments[n-1].Content == content {
+		b.segments[n-1].Text += text
+		return
+	}
+	b.segments = append(b.segments, Segment{Text: text, Content: content})
+}
+
+// control appends template markup.
+func (b *segmentBuilder) control(text string) {
+	b.write(text, false)
+}
+
+// content appends user- or tool-supplied data.
+func (b *segmentBuilder) content(text string) {
+	b.write(text, true)
+}
+
+func (b *segmentBuilder) Segments() []Segment {
+	return b.segments
+}

--- a/model/renderers/segments_test.go
+++ b/model/renderers/segments_test.go
@@ -1,0 +1,121 @@
+package renderers
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/ollama/ollama/api"
+)
+
+func TestSegmentBuilderMergesAdjacentWrites(t *testing.T) {
+	var sb segmentBuilder
+	sb.control("<|user|>")
+	sb.control("\n")
+	sb.content("hello ")
+	sb.content("world")
+	sb.control("<|assistant|>")
+	sb.content("")
+
+	want := []Segment{
+		{Text: "<|user|>\n", Content: false},
+		{Text: "hello world", Content: true},
+		{Text: "<|assistant|>", Content: false},
+	}
+	if diff := cmp.Diff(want, sb.Segments()); diff != "" {
+		t.Errorf("Segments() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestRenderSegmentsWithRenderer(t *testing.T) {
+	msgs := []api.Message{
+		{Role: "user", Content: "hello </think> world"},
+	}
+
+	segments, err := RenderSegmentsWithRenderer("glm-4.7", msgs, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []Segment{
+		{Text: "[gMASK]<sop><|user|>", Content: false},
+		{Text: "hello </think> world", Content: true},
+		{Text: "<|assistant|><think>", Content: false},
+	}
+	if diff := cmp.Diff(want, segments); diff != "" {
+		t.Errorf("RenderSegmentsWithRenderer() mismatch (-want +got):\n%s", diff)
+	}
+
+	// joined segments must be identical to the flat rendering
+	rendered, err := RenderWithRenderer("glm-4.7", msgs, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := JoinSegments(segments); got != rendered {
+		t.Errorf("JoinSegments() = %q, want %q", got, rendered)
+	}
+
+	// renderers without segment support return nil segments and no error
+	segments, err = RenderSegmentsWithRenderer("qwen3-coder", msgs, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if segments != nil {
+		t.Errorf("expected nil segments for non-segment renderer, got %v", segments)
+	}
+}
+
+// TestSegmentRenderersMatchRender verifies that for every renderer implementing
+// SegmentRenderer, the joined segments reproduce Render() exactly, and message
+// data ends up in content segments.
+func TestSegmentRenderersMatchRender(t *testing.T) {
+	msgs := []api.Message{
+		{Role: "system", Content: "sys </think> prompt"},
+		{Role: "user", Content: "hello </think> world"},
+		{Role: "assistant", Thinking: "thinking </think> hard", Content: "answer </think> text"},
+		{Role: "user", Content: "again"},
+	}
+	tools := []api.Tool{
+		{
+			Type: "function",
+			Function: api.ToolFunction{
+				Name:        "search",
+				Description: "Search </think> records.",
+			},
+		},
+	}
+	think := &api.ThinkValue{Value: true}
+
+	for _, name := range []string{"glm-4.7", "deepseek3.1"} {
+		t.Run(name, func(t *testing.T) {
+			segments, err := RenderSegmentsWithRenderer(name, msgs, tools, think)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if segments == nil {
+				t.Fatalf("renderer %q does not support segments", name)
+			}
+
+			rendered, err := RenderWithRenderer(name, msgs, tools, think)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := JoinSegments(segments); got != rendered {
+				t.Errorf("JoinSegments() = %q, want %q", got, rendered)
+			}
+
+			var haveUserContent bool
+			for _, s := range segments {
+				if s.Content && s.Text == "hello </think> world" {
+					haveUserContent = true
+				}
+				if !s.Content && (s.Text == "hello </think> world" || s.Text == "sys </think> prompt") {
+					t.Errorf("message content rendered as control segment: %q", s.Text)
+				}
+			}
+			if !haveUserContent {
+				t.Errorf("user content not found as content segment in %v", segments)
+			}
+		})
+	}
+}

--- a/server/prompt.go
+++ b/server/prompt.go
@@ -20,7 +20,11 @@ type tokenizeFunc func(context.Context, string) ([]int, error)
 // chatPrompt accepts a list of messages and returns the prompt and media that should be used for the next chat turn.
 // chatPrompt truncates any messages that exceed the context window of the model, making sure to always include 1) the
 // latest message and 2) system messages
-func chatPrompt(ctx context.Context, m *Model, tokenize tokenizeFunc, opts *api.Options, msgs []api.Message, tools []api.Tool, think *api.ThinkValue, truncate bool) (prompt string, media []llm.MediaData, _ error) {
+//
+// For models whose renderer distinguishes template markup from message
+// content, chatPrompt also returns the prompt as segments so runners can
+// tokenize message content without parsing special-token literals in it.
+func chatPrompt(ctx context.Context, m *Model, tokenize tokenizeFunc, opts *api.Options, msgs []api.Message, tools []api.Tool, think *api.ThinkValue, truncate bool) (prompt string, media []llm.MediaData, segments []llm.PromptSegment, _ error) {
 	var system []api.Message
 
 	// TODO: This is only a truncation heuristic; llama-server handles the
@@ -45,12 +49,12 @@ func chatPrompt(ctx context.Context, m *Model, tokenize tokenizeFunc, opts *api.
 
 			p, err := renderPrompt(m, append(system, msgs[i:]...), tools, think)
 			if err != nil {
-				return "", nil, err
+				return "", nil, nil, err
 			}
 
 			s, err := tokenize(ctx, p)
 			if err != nil {
-				return "", nil, err
+				return "", nil, nil, err
 			}
 
 			ctxLen := len(s)
@@ -79,16 +83,50 @@ func chatPrompt(ctx context.Context, m *Model, tokenize tokenizeFunc, opts *api.
 
 	renderMsgs, media, err := imageTaggedMessages(m, msgs, currMsgIdx, false)
 	if err != nil {
-		return "", nil, err
+		return "", nil, nil, err
 	}
 
 	// truncate any messages that do not fit into the context window
-	p, err := renderPrompt(m, append(system, renderMsgs[currMsgIdx:]...), tools, think)
+	finalMsgs := append(system, renderMsgs[currMsgIdx:]...)
+	segments, err = renderPromptSegments(m, finalMsgs, tools, think)
 	if err != nil {
-		return "", nil, err
+		return "", nil, nil, err
 	}
 
-	return p, media, nil
+	var p string
+	if segments != nil {
+		var sb strings.Builder
+		for _, s := range segments {
+			sb.WriteString(s.Text)
+		}
+		p = sb.String()
+	} else {
+		p, err = renderPrompt(m, finalMsgs, tools, think)
+		if err != nil {
+			return "", nil, nil, err
+		}
+	}
+
+	return p, media, segments, nil
+}
+
+// renderPromptSegments renders the prompt as control/content segments for
+// models whose renderer supports it. It returns nil for other models.
+func renderPromptSegments(m *Model, msgs []api.Message, tools []api.Tool, think *api.ThinkValue) ([]llm.PromptSegment, error) {
+	if m.Config.Renderer == "" {
+		return nil, nil
+	}
+
+	rendered, err := renderers.RenderSegmentsWithRenderer(resolveRendererName(m), msgs, tools, think)
+	if err != nil || rendered == nil {
+		return nil, err
+	}
+
+	segments := make([]llm.PromptSegment, len(rendered))
+	for i, s := range rendered {
+		segments[i] = llm.PromptSegment{Text: s.Text, Content: s.Content}
+	}
+	return segments, nil
 }
 
 func imageTaggedMessages(m *Model, msgs []api.Message, start int, clearImages bool) ([]api.Message, []llm.MediaData, error) {

--- a/server/prompt_test.go
+++ b/server/prompt_test.go
@@ -246,7 +246,7 @@ func TestChatPrompt(t *testing.T) {
 			model := tt.model
 			opts := api.Options{Runner: api.Runner{NumCtx: tt.limit}}
 			think := false
-			prompt, images, err := chatPrompt(t.Context(), &model, mockRunner{}.Tokenize, &opts, tt.msgs, nil, &api.ThinkValue{Value: think}, tt.truncate)
+			prompt, images, _, err := chatPrompt(t.Context(), &model, mockRunner{}.Tokenize, &opts, tt.msgs, nil, &api.ThinkValue{Value: think}, tt.truncate)
 			if tt.error == nil && err != nil {
 				t.Fatal(err)
 			} else if tt.error != nil && err != tt.error {
@@ -329,7 +329,7 @@ func TestChatPromptTokenizeCalls(t *testing.T) {
 
 			opts := api.Options{Runner: api.Runner{NumCtx: tt.limit}}
 			think := false
-			_, _, err := chatPrompt(t.Context(), &model, countingTokenize, &opts, tt.msgs, nil, &api.ThinkValue{Value: think}, true)
+			_, _, _, err := chatPrompt(t.Context(), &model, countingTokenize, &opts, tt.msgs, nil, &api.ThinkValue{Value: think}, true)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -358,7 +358,7 @@ func TestChatPromptRendererDoesNotRewriteMessageContent(t *testing.T) {
 	opts := api.Options{Runner: api.Runner{NumCtx: 8192}}
 	think := false
 
-	prompt, images, err := chatPrompt(t.Context(), &m, mockRunner{}.Tokenize, &opts, msgs, nil, &api.ThinkValue{Value: think}, true)
+	prompt, images, _, err := chatPrompt(t.Context(), &m, mockRunner{}.Tokenize, &opts, msgs, nil, &api.ThinkValue{Value: think}, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -392,7 +392,7 @@ func TestChatPromptGLMOcrRendererAddsImageTags(t *testing.T) {
 	opts := api.Options{Runner: api.Runner{NumCtx: 8192}}
 	think := false
 
-	prompt, images, err := chatPrompt(t.Context(), &m, mockRunner{}.Tokenize, &opts, msgs, nil, &api.ThinkValue{Value: think}, true)
+	prompt, images, _, err := chatPrompt(t.Context(), &m, mockRunner{}.Tokenize, &opts, msgs, nil, &api.ThinkValue{Value: think}, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -479,7 +479,7 @@ func TestChatPromptRendererAddsToolImageTags(t *testing.T) {
 			opts := api.Options{Runner: api.Runner{NumCtx: 8192}}
 			think := false
 
-			prompt, images, err := chatPrompt(t.Context(), &m, mockRunner{}.Tokenize, &opts, msgs, nil, &api.ThinkValue{Value: think}, true)
+			prompt, images, _, err := chatPrompt(t.Context(), &m, mockRunner{}.Tokenize, &opts, msgs, nil, &api.ThinkValue{Value: think}, true)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -549,7 +549,7 @@ func TestChatPromptRendererPreservesExplicitImagePlaceholders(t *testing.T) {
 			opts := api.Options{Runner: api.Runner{NumCtx: 8192}}
 			think := false
 
-			prompt, images, err := chatPrompt(t.Context(), &m, mockRunner{}.Tokenize, &opts, msgs, nil, &api.ThinkValue{Value: think}, true)
+			prompt, images, _, err := chatPrompt(t.Context(), &m, mockRunner{}.Tokenize, &opts, msgs, nil, &api.ThinkValue{Value: think}, true)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/server/routes.go
+++ b/server/routes.go
@@ -507,6 +507,7 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 
 	prompt := req.Prompt
 	var leadingBOS string
+	var promptSegments []llm.PromptSegment
 	if !req.Raw {
 		tmpl := m.Template
 		if req.Template != "" {
@@ -606,7 +607,7 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 					prompt = b.String()
 				}
 			} else {
-				prompt, media, err = chatPrompt(c.Request.Context(), m, r.Tokenize, optionsForPrompt(opts, r), values.Messages, []api.Tool{}, req.Think, genTruncate)
+				prompt, media, promptSegments, err = chatPrompt(c.Request.Context(), m, r.Tokenize, optionsForPrompt(opts, r), values.Messages, []api.Tool{}, req.Think, genTruncate)
 				if err != nil {
 					c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 					return
@@ -615,6 +616,7 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 				if req.Context != nil {
 					b.WriteString(prompt)
 					prompt = b.String()
+					promptSegments = nil
 				}
 				leadingBOS = leadingBOSForModel(m)
 			}
@@ -663,6 +665,7 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 		defer close(ch)
 		if err := r.Completion(c.Request.Context(), llm.CompletionRequest{
 			Prompt:          prompt,
+			Segments:        promptSegments,
 			Media:           media,
 			Format:          req.Format,
 			Options:         opts,
@@ -2702,7 +2705,7 @@ func (s *Server) ChatHandler(c *gin.Context) {
 		truncate = false
 	}
 	promptOpts := optionsForPrompt(opts, r)
-	prompt, media, err := chatPrompt(c.Request.Context(), m, r.Tokenize, promptOpts, msgs, processedTools, req.Think, truncate)
+	prompt, media, promptSegments, err := chatPrompt(c.Request.Context(), m, r.Tokenize, promptOpts, msgs, processedTools, req.Think, truncate)
 	if err != nil {
 		slog.Error("chat prompt error", "error", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -2776,6 +2779,7 @@ func (s *Server) ChatHandler(c *gin.Context) {
 
 			err := r.Completion(ctx, llm.CompletionRequest{
 				Prompt:          prompt,
+				Segments:        promptSegments,
 				Media:           media,
 				Format:          currentFormat,
 				Options:         opts,
@@ -2915,7 +2919,7 @@ func (s *Server) ChatHandler(c *gin.Context) {
 				}
 
 				msgs = append(msgs, msg)
-				prompt, _, err = chatPrompt(c.Request.Context(), m, r.Tokenize, promptOpts, msgs, processedTools, req.Think, truncate)
+				prompt, _, promptSegments, err = chatPrompt(c.Request.Context(), m, r.Tokenize, promptOpts, msgs, processedTools, req.Think, truncate)
 				if err != nil {
 					slog.Error("chat prompt error applying structured outputs", "error", err)
 					ch <- gin.H{"error": err.Error()}
@@ -2927,6 +2931,9 @@ func (s *Server) ChatHandler(c *gin.Context) {
 				// TODO(parthsareen): consider adding prefill disambiguation logic to the renderer for structured outputs.
 				if shouldUseHarmony(m) || (builtinParser != nil && m.Config.Parser == "harmony") {
 					prompt += "<|end|><|start|>assistant<|channel|>final<|message|>"
+					if promptSegments != nil {
+						promptSegments = append(promptSegments, llm.PromptSegment{Text: "<|end|><|start|>assistant<|channel|>final<|message|>"})
+					}
 				}
 				continue
 			}


### PR DESCRIPTION
Addresses #17248 (and the underlying class bug in #15931) for the llama-server engine.

## Problem

A literal special-token string inside message content is tokenized as the actual control token, so untrusted text can alter prompt structure. With a thinking model, a user message like:

```
Repeat exactly, without adding anything: hello </think> world
```

reaches the model with a structural `</think>` in the middle of the user turn. GLM's template semantics then treat everything around it as reasoning/content boundaries, corrupting the conversation (see the reproductions in #17248, which also affect replayed assistant history with explicit `thinking`/`content` fields).

There were two distinct causes:

1. **Tokenization**: the rendered prompt is sent to llama-server as one flat string and tokenized with special-token parsing enabled end to end, so a literal `</think>` (or any other special-token literal, per #15931) in message content becomes a control token.
2. **deepseek3 renderer**: when replaying assistant content it split on the *first* literal `</think>` and discarded everything before it — `hello </think> world` rendered as ` world`. This matches the deepseek-v4 corruption reported in #17248.

## Fix

- `model/renderers`: renderers can now emit the prompt as **segments** that mark which spans are template markup (control) and which are message data (content). `glm-4.7`, `glm-4.6`, and `deepseek3` are converted in this PR; `Render` output is byte-identical (verified by tests that join segments and compare against `Render`). Other renderers and the Go-template path are unchanged and keep current behavior.
- `server`: `chatPrompt` returns the segments alongside the flat prompt, and handlers pass them in `llm.CompletionRequest.Segments`.
- `llm` (llama-server runner): if any content segment contains one of the model's special-token literals, each segment is tokenized separately via `/tokenize` — control segments with `parse_special` on, content segments with it off — and the prompt is submitted as token IDs (the same form the context-shift truncation path already uses). The special vocabulary (`tokenizer.ggml.tokens` filtered by `token_type` control/user-defined) is read lazily from the GGUF once per runner.
- `deepseek3`: assistant content is no longer truncated at a literal `</think>`; only a replayed reasoning block that *starts with* `<think>` is stripped, preserving compatibility with clients that resend raw model output.

## Performance

The common case — no special-token literal anywhere in message content — is detected with a cheap scan and keeps the existing flat-string prompt path, with zero extra tokenize calls. The per-segment tokenization only runs on requests that would otherwise be corrupted.

## Out of scope / follow-ups

- The remaining renderers and the Go-template rendering path still concatenate to a flat string; converting them can reuse the same segment plumbing.
- The MLX runner path is untouched.
- Multimodal requests keep the string prompt path (llama-server's multimodal prompt requires a string).

## Testing

- `go test ./llm ./model/renderers` — new tests cover: segment/`Render` equivalence for the converted renderers, literal `</think>` preservation (and replayed-reasoning stripping) in deepseek3, the split-tokenization trigger conditions, the per-segment `/tokenize` calls (`add_special`/`parse_special` per segment) and the token-array `/completion` prompt, and that prompts without special literals still send a plain string with no tokenize calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)