### PR TITLE
fix(server): escape </think> in user messages to prevent Jinja2 template corruption

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -2938,7 +2938,40 @@ func (s *Server) ChatHandler(c *gin.Context) {
 	writeChatResponse(c, req, ch)
 }
 
+// escapeUserThinkCloseTag prevents Jinja2 chat templates that use
+// content.split('</think>') from corrupting user messages containing
+// literal </think> text (issue #17248).
+// The zero-width space (U+200B) after < in </think> breaks the
+// split() match without changing model semantics or output.
+func escapeUserThinkCloseTag(content string) string {
+	return strings.ReplaceAll(content, "</think>", "<\u200B/think>")
+}
+
+// applyUserThinkEscaping escapes </think> in user messages for models
+// whose native Jinja2 chat template splits content on </think>.
+// Only applicable to native chat path with thinking-capable models;
+// renderer-path models handle this in Go code.
+func applyUserThinkEscaping(msgs []api.Message, m *Model) []api.Message {
+	if chatModeForModel(m) != chatExecutionModeNative {
+		return msgs
+	}
+	if !slices.Contains(m.Capabilities(), model.CapabilityThinking) {
+		return msgs
+	}
+
+	result := make([]api.Message, len(msgs))
+	for i, msg := range msgs {
+		result[i] = msg
+		if msg.Role == "user" && strings.Contains(msg.Content, "</think>") {
+			result[i].Content = escapeUserThinkCloseTag(msg.Content)
+		}
+	}
+	return result
+}
+
 func prepareNativeChatRequest(ctx context.Context, m *Model, r llm.LlamaServer, opts *api.Options, nativeReq llm.ChatRequest, truncate bool) (llm.ChatRequest, error) {
+	nativeReq.Messages = applyUserThinkEscaping(nativeReq.Messages, m)
+
 	var err error
 	nativeReq.Messages, err = truncateNativeChatMessages(ctx, m, r, optionsForPrompt(opts, r), nativeReq, truncate)
 	return nativeReq, err

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -1204,3 +1204,150 @@ func TestWaitForStream(t *testing.T) {
 		})
 	}
 }
+
+func TestEscapeUserThinkCloseTag(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "user message with </think>",
+			input:    "hello </think> world",
+			expected: "hello <\u200B/think> world",
+		},
+		{
+			name:     "multiple </think> occurrences",
+			input:    "</think> and </think>",
+			expected: "<\u200B/think> and <\u200B/think>",
+		},
+		{
+			name:     "message without </think> unchanged",
+			input:    "hello world",
+			expected: "hello world",
+		},
+		{
+			name:     "think without closing tag unchanged",
+			input:    "<think>reasoning...",
+			expected: "<think>reasoning...",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := escapeUserThinkCloseTag(tt.input)
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestApplyUserThinkEscaping(t *testing.T) {
+	nativeThinkingModel := &Model{
+		Name: "deepseek-v4-flash",
+		Config: model.ConfigV2{
+			ModelFamily:  "deepseek3",
+			Capabilities: []string{"thinking"},
+		},
+	}
+
+	renderedModel := &Model{
+		Name: "deepseek-v4-pro",
+		Config: model.ConfigV2{
+			Renderer: "deepseek3",
+		},
+	}
+
+	nonThinkingModel := &Model{
+		Name: "llama3",
+		Config: model.ConfigV2{
+			ModelFamily: "llama3",
+		},
+	}
+
+	tests := []struct {
+		name     string
+		msgs     []api.Message
+		model    *Model
+		expected []api.Message
+	}{
+		{
+			name: "user with </think> on native chat path gets escaped",
+			msgs: []api.Message{
+				{Role: "user", Content: "explain </think> tags"},
+			},
+			model: nativeThinkingModel,
+			expected: []api.Message{
+				{Role: "user", Content: "explain <\u200B/think> tags"},
+			},
+		},
+		{
+			name: "user without </think> unchanged",
+			msgs: []api.Message{
+				{Role: "user", Content: "hello world"},
+			},
+			model: nativeThinkingModel,
+			expected: []api.Message{
+				{Role: "user", Content: "hello world"},
+			},
+		},
+		{
+			name: "assistant message NOT escaped",
+			msgs: []api.Message{
+				{Role: "assistant", Content: "<think>reasoning</think>response"},
+			},
+			model: nativeThinkingModel,
+			expected: []api.Message{
+				{Role: "assistant", Content: "<think>reasoning</think>response"},
+			},
+		},
+		{
+			name: "system message NOT escaped",
+			msgs: []api.Message{
+				{Role: "system", Content: "use </think> for reasoning"},
+			},
+			model: nativeThinkingModel,
+			expected: []api.Message{
+				{Role: "system", Content: "use </think> for reasoning"},
+			},
+		},
+		{
+			name: "rendered path model does NOT escape user",
+			msgs: []api.Message{
+				{Role: "user", Content: "explain </think> tags"},
+			},
+			model: renderedModel,
+			expected: []api.Message{
+				{Role: "user", Content: "explain </think> tags"},
+			},
+		},
+		{
+			name: "non-thinking model does NOT escape user",
+			msgs: []api.Message{
+				{Role: "user", Content: "explain </think> tags"},
+			},
+			model: nonThinkingModel,
+			expected: []api.Message{
+				{Role: "user", Content: "explain </think> tags"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := applyUserThinkEscaping(tt.msgs, tt.model)
+			if !reflect.DeepEqual(result, tt.expected) {
+				for i := range tt.expected {
+					if i >= len(result) || result[i].Content != tt.expected[i].Content {
+						t.Errorf("msg[%d]: expected %q, got %q", i, tt.expected[i].Content, result[i].Content)
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

When a thinking model uses native chat execution (`chatExecutionModeNative`), llama.cpp applies the GGUF's Jinja2 chat template. For some Qwen/DeepSeek models, this template contains `content.split('</think>')` without checking message role (`server/images.go:220-225`). This causes user messages containing literal `</think>` to be corrupted before inference.

Reproduction: send `"hello </think> world"` as a user message.

| Model | Observed behavior |
|-------|------------------|
| `deepseek-v4-flash` | `</think>` → `response` |
| `glm-5.2` | everything after `</think>` dropped |
| `deepseek-v4-pro` | input structure altered |

Same request to DeepSeek native API preserves the text correctly.

## Root Cause

`chatTemplateHasThinkingSupport` (`server/images.go:222`) explicitly detects this pattern:

```go
content.split('</think>')
```

The Jinja2 template applies this split to ALL messages, treating `</think>` in user content as a structural delimiter.

## Fix

Insert a zero-width space (U+200B) into `</think>` in user messages before they reach the Jinja2 template:

```
</think> → <​/think>    ← ZWSP between < and /think>
```

### Gating conditions

- Only **native chat path** (`chatExecutionModeNative`) — renderer-path models handle this in Go
- Only **thinking-capable** models (`CapabilityThinking`)
- Only **user-role** messages — assistant and system messages unchanged

### Code

Two small functions in `server/routes.go`, called from `prepareNativeChatRequest` before `truncateNativeChatMessages`:

- `escapeUserThinkCloseTag()` — pure string replacement
- `applyUserThinkEscaping()` — applies gating and iterates messages

## Testing

- Unit tests: `TestEscapeUserThinkCloseTag` (5 cases), `TestApplyUserThinkEscaping` (6 cases)
- `go vet ./server/` — clean
- `go test ./server/...` — all pass, no regressions
- `go build .` — passes

## Notes

Fixes #17248

The zero-width space approach is used instead of modifying GGUF files or llama.cpp, since those are upstream/model-publisher concerns. The ZWSP breaks `split()` matching without changing model semantics — tokenizers treat it as a separate invisible token.