### PR TITLE
docs: add ChatOSS to community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ console.log(response.message.content);
 
 #### Desktop
 
+- [ChatOSS](https://chatoss.ai) - Codex alternative built on Ollama
 - [Dify.AI](https://github.com/langgenius/dify) - LLM app development platform
 - [AnythingLLM](https://github.com/Mintplex-Labs/anything-llm) - All-in-one AI app for Mac, Windows, and Linux
 - [Maid](https://github.com/Mobile-Artificial-Intelligence/maid) - Cross-platform mobile and desktop client


### PR DESCRIPTION
## What

Adds [ChatOSS](https://chatoss.ai) to the Community Integrations list in the README, under the **Desktop** category.

ChatOSS is a Codex alternative built on Ollama — a desktop app for chatting and coding with local Ollama models.

## Why

ChatOSS integrates directly with Ollama and fits the "Desktop" category alongside the other local-model clients already listed (AnythingLLM, Maid, etc.). Adding it helps Ollama users discover it.

## Checklist

- [x] Added to the appropriate category (Desktop)
- [x] Follows the existing entry format
- [x] Single-line change to `README.md`