### PR TITLE
tools: return buffered output as content when no tool call is parsed

### DIFF
--- a/tools/tools.go
+++ b/tools/tools.go
@@ -389,16 +389,14 @@ func (p *Parser) done() bool {
 }
 
 // Content returns any remaining content that
-// should be sent to the user. This should be the empty string
-// string unless the tag is { or [ and a tool call was not found
+// should be sent to the user. If no tool call was parsed,
+// the buffered output is returned so it is not silently
+// dropped; otherwise any leftover is template scaffolding
+// (e.g. a closing tag) and is discarded
 func (p *Parser) Content() string {
 	if p.n > 0 {
 		return ""
 	}
 
-	if p.tag == "{" || p.tag == "[" {
-		return string(p.buffer)
-	}
-
-	return ""
+	return string(p.buffer)
 }

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -895,8 +895,15 @@ func TestContent(t *testing.T) {
 			name:    "tag",
 			tag:     "<tool_call>",
 			content: []byte("<tool_call>{\"name\": \"get_temperature\""),
-			want:    "",
+			want:    "<tool_call>{\"name\": \"get_temperature\"",
 			n:       0,
+		},
+		{
+			name:    "tag after called",
+			tag:     "<tool_call>",
+			content: []byte("</tool_call>"),
+			want:    "",
+			n:       1,
 		},
 		{
 			name:    "json object",
@@ -945,6 +952,83 @@ func TestContent(t *testing.T) {
 			got := parser.Content()
 			if got != tt.want {
 				t.Errorf("Content() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestUnparsedToolCallContent verifies that model output buffered while
+// looking for a tool call is returned as content at the end of the stream
+// when no tool call could be parsed, instead of being silently dropped
+func TestUnparsedToolCallContent(t *testing.T) {
+	tmpl, err := template.New("qwen").Parse(`{{if .ToolCalls}}<tool_call>{{range .ToolCalls}}{"name": "{{.Function.Name}}", "arguments": {{.Function.Arguments}}}{{end}}</tool_call>{{end}}`)
+	if err != nil {
+		t.Fatalf("Failed to parse template: %v", err)
+	}
+
+	tools := []api.Tool{
+		{
+			Type: "function",
+			Function: api.ToolFunction{
+				Name: "get_temperature",
+			},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		output  string
+		content string
+		calls   int
+	}{
+		{
+			name:    "unknown tool name",
+			output:  `<tool_call>{"name": "get_weather", "arguments": {"city": "Tokyo"}}</tool_call>`,
+			content: `<tool_call>{"name": "get_weather", "arguments": {"city": "Tokyo"}}</tool_call>`,
+			calls:   0,
+		},
+		{
+			name:    "truncated arguments",
+			output:  `<tool_call>{"name": "get_temperature", "arguments": {"city": `,
+			content: `<tool_call>{"name": "get_temperature", "arguments": {"city": `,
+			calls:   0,
+		},
+		{
+			name:    "valid tool call discards scaffolding",
+			output:  `<tool_call>{"name": "get_temperature", "arguments": {"city": "Tokyo"}}</tool_call>`,
+			content: "",
+			calls:   1,
+		},
+		{
+			name:    "content before unparsed tool call",
+			output:  `Let me check. <tool_call>{"name": "get_weather", "arguments": {}}</tool_call>`,
+			content: `Let me check. <tool_call>{"name": "get_weather", "arguments": {}}</tool_call>`,
+			calls:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// stream the output in small chunks to exercise partial parsing
+			for _, chunkSize := range []int{1, 3, len(tt.output)} {
+				parser := NewParser(tmpl, tools)
+
+				var calls []api.ToolCall
+				var content string
+				for i := 0; i < len(tt.output); i += chunkSize {
+					tcs, c := parser.Add(tt.output[i:min(i+chunkSize, len(tt.output))])
+					calls = append(calls, tcs...)
+					content += c
+				}
+				content += parser.Content()
+
+				if content != tt.content {
+					t.Errorf("chunk size %d: expected content %q, got %q", chunkSize, tt.content, content)
+				}
+
+				if len(calls) != tt.calls {
+					t.Errorf("chunk size %d: expected %d tool calls, got %d", chunkSize, tt.calls, len(calls))
+				}
 			}
 		})
 	}


### PR DESCRIPTION
When a template-based model emits its tool-call tag but the parser never completes a tool call (hallucinated or unknown tool name, truncated or malformed arguments), the entire buffered output is silently dropped at the end of the stream. The response reports completion tokens but contains neither `content` nor `tool_calls`, which makes these failures impossible for users to debug (see the symptom described in #17274, and the same silent-drop failure mode in #16932).

`Parser.Content()` only returned the buffer for the `{` and `[` tags. For text tags such as `<tool_call>` it always returned `""`, so at `r.Done` the server sent an empty final message and everything the model generated after the tag was lost.

This change returns the buffered output for all tags when no tool call was parsed. The success path is unchanged: once a tool call has been parsed, any leftover buffer is template scaffolding (e.g. a closing `</tool_call>` tag) and is still discarded. Surfacing the raw text on parse failure also matches what llama.cpp does when serving the same weights, and gives issue reporters actionable output instead of an empty message.

Related work, for clarity: #14995 adds a server-side warning log for this scenario but the client still receives an empty message, and #15466 recovers truncated arguments into a successful call. This change is complementary to both, covering every parse-failure shape (unknown name, malformed JSON, truncation) by surfacing the output instead of dropping it.

Tests:
- updated `TestContent` for the new expectation (plus a new case covering scaffolding after a parsed call)
- new `TestUnparsedToolCallContent` streams output at several chunk sizes and covers: unknown tool name, truncated arguments, valid call (scaffolding still dropped), and content preceding an unparsed tool call
