### PR TITLE
docs/api: add streaming OpenAI compatibility examples

### DIFF
--- a/docs/api/openai-compatibility.mdx
+++ b/docs/api/openai-compatibility.mdx
@@ -57,6 +57,63 @@ curl -X POST http://localhost:11434/v1/chat/completions \
 
 </CodeGroup>
 
+### Streaming `/v1/chat/completions` example
+
+Set `stream` to `true` and consume each content delta as it arrives.
+
+<CodeGroup dropdown>
+
+```python streaming.py
+from openai import OpenAI
+
+client = OpenAI(
+    base_url='http://localhost:11434/v1/',
+    api_key='ollama',  # required but ignored
+)
+
+stream = client.chat.completions.create(
+    model='gpt-oss:20b',
+    messages=[{'role': 'user', 'content': 'Explain why the sky is blue'}],
+    stream=True,
+)
+
+for chunk in stream:
+    print(chunk.choices[0].delta.content or '', end='', flush=True)
+print()
+```
+
+```javascript streaming.js
+import OpenAI from "openai";
+
+const openai = new OpenAI({
+  baseURL: "http://localhost:11434/v1/",
+  apiKey: "ollama", // required but ignored
+});
+
+const stream = await openai.chat.completions.create({
+  model: "gpt-oss:20b",
+  messages: [{ role: "user", content: "Explain why the sky is blue" }],
+  stream: true,
+});
+
+for await (const chunk of stream) {
+  process.stdout.write(chunk.choices[0]?.delta?.content ?? "");
+}
+process.stdout.write("\n");
+```
+
+```shell streaming.sh
+curl --no-buffer http://localhost:11434/v1/chat/completions \
+-H "Content-Type: application/json" \
+-d '{
+  "model": "gpt-oss:20b",
+  "messages": [{ "role": "user", "content": "Explain why the sky is blue" }],
+  "stream": true
+}'
+```
+
+</CodeGroup>
+
 ### Simple `/v1/responses` example
 
 <CodeGroup dropdown>


### PR DESCRIPTION
## Summary

- add streaming chat completion examples for Python, JavaScript, and curl
- show how to consume content deltas incrementally
- keep the examples aligned with the existing OpenAI compatibility page and model

## Why

The compatibility page lists streaming as supported but only shows a non-streaming chat completion. These examples make the streaming path directly usable in each language already documented on the page.

## Validation

- `git diff --check`
- syntax-checked all 15 named Python, JavaScript, and shell examples on the page

The repository's Go extraction helper was not available locally because Go is not installed; the named fenced blocks were validated with language-native syntax checks and can be exercised by upstream CI.
