### PR TITLE
anthropic: serialize empty message content as an empty array instead of null

### DIFF
--- a/anthropic/anthropic.go
+++ b/anthropic/anthropic.go
@@ -654,7 +654,9 @@ func convertTool(t Tool) (api.Tool, bool, error) {
 
 // ToMessagesResponse converts an Ollama api.ChatResponse to an Anthropic MessagesResponse
 func ToMessagesResponse(id string, r api.ChatResponse) MessagesResponse {
-	var content []ContentBlock
+	// content must serialize as [] rather than null when the message is empty,
+	// matching the Anthropic API and the streaming message_start event
+	content := []ContentBlock{}
 
 	if r.Message.Thinking != "" {
 		content = append(content, ContentBlock{

--- a/anthropic/anthropic_test.go
+++ b/anthropic/anthropic_test.go
@@ -845,6 +845,34 @@ func TestToMessagesResponse_WithThinking(t *testing.T) {
 	}
 }
 
+func TestToMessagesResponse_EmptyMessage(t *testing.T) {
+	resp := api.ChatResponse{
+		Model: "test-model",
+		Message: api.Message{
+			Role: "assistant",
+		},
+		Done:       true,
+		DoneReason: "stop",
+	}
+
+	result := ToMessagesResponse("msg_123", resp)
+
+	if result.Content == nil {
+		t.Fatal("expected non-nil content for empty message")
+	}
+	if len(result.Content) != 0 {
+		t.Fatalf("expected 0 content blocks, got %d", len(result.Content))
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("failed to marshal response: %v", err)
+	}
+	if !strings.Contains(string(data), `"content":[]`) {
+		t.Errorf(`expected "content":[] in JSON, got %s`, data)
+	}
+}
+
 func TestMapStopReason(t *testing.T) {
 	tests := []struct {
 		reason       string


### PR DESCRIPTION
When a chat completion produces no output (for example when a stop sequence matches the first sampled token), the non-streaming /v1/messages endpoint returns "content": null. The real Anthropic API always returns an array, and the streaming path already sends "content": [] in its message_start event (anthropic.go:769), so strictly typed clients that expect an array can trip on the null. Root cause is the nil []ContentBlock slice in ToMessagesResponse (anthropic/anthropic.go:657), which encoding/json marshals as null.

Fixed by initializing the slice as empty, matching what the streaming path already does. Added a regression test that fails on main, and verified live on my Mac (Metal) with smollm2:135m: a request with stop_sequences matching the first token returned "content":null before and "content":[] after, with normal non-empty responses unchanged. go build, go test ./anthropic/... ./middleware/..., and golangci-lint are all green locally.

small disclosure: I'm a college freshman contributing for the greater good :) Claude Code helped me work through this one (I ran the build, tests, lint, and the live repro above myself on my Mac). sorry in advance if anything looks off, and if there are mistakes I'd honestly love to learn from them.