### PR TITLE
cmd/tui: agent system prompt command

### DIFF
--- a/agent/skills.go
+++ b/agent/skills.go
@@ -675,6 +675,31 @@ func (c *SkillCatalog) Diagnostics() []error {
 	return append([]error(nil), c.diagnostics...)
 }
 
+// ExcludeNames removes skills whose names are reserved by a caller. It returns
+// the excluded names in sorted order.
+func (c *SkillCatalog) ExcludeNames(names []string) []string {
+	if c == nil {
+		return nil
+	}
+	reserved := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		name = strings.TrimPrefix(strings.ToLower(strings.TrimSpace(name)), "/")
+		if name != "" {
+			reserved[name] = struct{}{}
+		}
+	}
+	var excluded []string
+	for name := range c.skills {
+		if _, ok := reserved[name]; !ok {
+			continue
+		}
+		delete(c.skills, name)
+		excluded = append(excluded, name)
+	}
+	sort.Strings(excluded)
+	return excluded
+}
+
 func (c *SkillCatalog) Load(name string) (Skill, error) {
 	name = strings.TrimSpace(name)
 	if !skillName.MatchString(name) {

--- a/agent/skills_test.go
+++ b/agent/skills_test.go
@@ -272,6 +272,30 @@ func TestLoadDefaultSkillsPrecedenceAndCollisions(t *testing.T) {
 	}
 }
 
+func TestSkillCatalogExcludeNames(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"release-notes", "system", "exit"} {
+		writeCatalogSkill(t, dir, name, "instructions")
+	}
+	catalog, err := DiscoverSkills(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := strings.Join(catalog.ExcludeNames([]string{"/system", "EXIT"}), ","), "exit,system"; got != want {
+		t.Fatalf("excluded skills = %q, want %q", got, want)
+	}
+	if _, err := catalog.Load("system"); err == nil {
+		t.Fatal("excluded system skill should not load")
+	}
+	if _, err := catalog.Load("exit"); err == nil {
+		t.Fatal("excluded exit skill should not load")
+	}
+	if _, err := catalog.Load("release-notes"); err != nil {
+		t.Fatalf("non-conflicting skill should remain available: %v", err)
+	}
+}
+
 func TestSkillContentListsDirectoryAndResources(t *testing.T) {
 	root := t.TempDir()
 	skillDir := filepath.Join(root, "pdf-processing")

--- a/cmd/agent_tui.go
+++ b/cmd/agent_tui.go
@@ -89,6 +89,9 @@ func GenerateAgentTUI(cmd *cobra.Command, client *api.Client, opts agentTUIOptio
 		if err != nil {
 			return nil, err
 		}
+		if ignored := catalog.ExcludeNames(agentchat.BuiltinSlashCommandNames()); len(ignored) > 0 {
+			fmt.Fprintf(os.Stderr, "\033[1mwarning:\033[0m ignoring agent skill(s): %s\n", strings.Join(ignored, ", "))
+		}
 		for _, diagnostic := range catalog.Diagnostics() {
 			fmt.Fprintf(os.Stderr, "\033[1mwarning:\033[0m ignored invalid agent skill: %v\n", diagnostic)
 		}

--- a/cmd/agent_tui_test.go
+++ b/cmd/agent_tui_test.go
@@ -95,6 +95,39 @@ func TestAgentSkillSystemContextRequiresAvailableEnabledSkillTool(t *testing.T) 
 	}
 }
 
+func TestAgentSkillCommandCollisionsAreIgnored(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"release-notes", "system", "exit"} {
+		if err := os.Mkdir(filepath.Join(dir, name), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		content := "---\nname: " + name + "\ndescription: Test skill.\n---\nInstructions."
+		if err := os.WriteFile(filepath.Join(dir, name, "SKILL.md"), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	catalog, err := coreagent.DiscoverSkills(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ignored := catalog.ExcludeNames(agentchat.BuiltinSlashCommandNames())
+	if got, want := strings.Join(ignored, ", "), "exit, system"; got != want {
+		t.Fatalf("ignored skills = %q, want %q", got, want)
+	}
+	if _, err := catalog.Load("release-notes"); err != nil {
+		t.Fatalf("non-conflicting skill should remain available: %v", err)
+	}
+	if context := catalog.SystemContext(); !strings.Contains(context, "release-notes: Test skill.") || strings.Contains(context, "system: Test skill.") || strings.Contains(context, "exit: Test skill.") {
+		t.Fatalf("skill context = %q", context)
+	}
+	for _, name := range []string{"system", "exit"} {
+		if _, err := catalog.Load(name); err == nil {
+			t.Fatalf("conflicting skill %q should be ignored", name)
+		}
+	}
+}
+
 func TestAgentSelectionItemsUseLaunchSections(t *testing.T) {
 	items := agentSelectionItems([]agentchat.ModelOption{
 		{Name: "glm-5.2:cloud", Description: "cloud", Recommended: true, Cloud: true},

--- a/cmd/tui/chat/chat.go
+++ b/cmd/tui/chat/chat.go
@@ -141,6 +141,8 @@ type chatModel struct {
 	permissionNotice   string
 	selection          chatSelection
 
+	systemPromptDisabled bool
+
 	width              int
 	height             int
 	status             string

--- a/cmd/tui/chat/input.go
+++ b/cmd/tui/chat/input.go
@@ -55,6 +55,7 @@ var chatSlashCommands = []chatSlashCommand{
 	{name: "/new", description: "start a new chat"},
 	{name: "/think", description: "set thinking mode"},
 	{name: "/tools", description: "toggle tools on or off"},
+	{name: "/system", usage: "/system [on|off]", description: "show or set the built-in system prompt"},
 	{name: "/skills", usage: "/skills [import codex|claude|pi]", description: "list or import skills"},
 	{name: "/compact", description: "summarize older context"},
 	{name: "/help", description: "show commands", aliases: []string{"/?"}},
@@ -94,11 +95,12 @@ func (m *chatModel) handleSubmit() (tea.Model, tea.Cmd) {
 }
 
 func (m *chatModel) applySlashCompletion() bool {
-	input := strings.TrimSpace(string(m.input))
+	rawInput := string(m.input)
+	input := strings.TrimSpace(rawInput)
 	if !strings.HasPrefix(input, "/") {
 		return false
 	}
-	if _, _, known := slashCommandInvocation(input); known {
+	if _, _, known := slashCommandInvocation(input); known && !hasSystemCommandArgument(rawInput) {
 		return false
 	}
 	completions := m.slashCompletions()
@@ -106,7 +108,7 @@ func (m *chatModel) applySlashCompletion() bool {
 		return false
 	}
 	selected := completions[clamp(m.complete, 0, len(completions)-1)]
-	if selected.value == input {
+	if strings.EqualFold(selected.value, input) {
 		return false
 	}
 	// Reset prompt-history state: Up/Down is shared between history recall and
@@ -142,6 +144,8 @@ func (m *chatModel) submitInput(input string) (tea.Model, tea.Cmd) {
 		return m.handleThinkCommand(args)
 	case command == "/tools":
 		return m.handleToolsCommand(args)
+	case command == "/system":
+		return m.handleSystemCommand(args)
 	case command == "/skills":
 		return m.handleSkillsCommand(args)
 	case command == "/prompt":
@@ -298,6 +302,40 @@ func (m *chatModel) handleToolsCommand(args string) (tea.Model, tea.Cmd) {
 		m.opts.SystemPrompt = m.opts.SystemPromptForModel(m.ctx, m.opts.Model, m.opts.Tools, m.opts.ToolsDisabled)
 	}
 	return *m, nil
+}
+
+func (m *chatModel) handleSystemCommand(args string) (tea.Model, tea.Cmd) {
+	switch strings.ToLower(strings.TrimSpace(args)) {
+	case "":
+		m.entries = append(m.entries, newSlashEntry(m.systemCommandOutput()))
+	case "on":
+		m.systemPromptDisabled = false
+		m.status = "system prompt on"
+		m.entries = append(m.entries, newSlashEntry(m.systemCommandOutput()))
+	case "off":
+		m.systemPromptDisabled = true
+		m.status = "system prompt off"
+		m.entries = append(m.entries, newSlashEntry(m.systemCommandOutput()))
+	default:
+		m.status = "error"
+		m.entries = append(m.entries, newChatEntry(chatEntry{role: "error", content: "usage: /system [on|off]"}))
+	}
+	return *m, nil
+}
+
+func (m chatModel) systemPromptState() string {
+	if m.systemPromptDisabled {
+		return "off"
+	}
+	return "on"
+}
+
+func (m chatModel) systemCommandOutput() string {
+	prompt := strings.TrimSpace(m.opts.SystemPrompt)
+	if prompt == "" {
+		prompt = "(empty)"
+	}
+	return "Built-in system prompt is " + m.systemPromptState() + ".\n\n" + prompt + "\n\nWarning: Changing the system prompt during a session breaks the prompt cache."
 }
 
 func (m chatModel) slashInputIsMultimodalFile(input string) bool {
@@ -1184,6 +1222,9 @@ func (m chatModel) slashCompletions() []chatCompletion {
 	if !strings.HasPrefix(input, "/") {
 		return nil
 	}
+	if argument, ok := systemCommandArgument(rawInput); ok {
+		return systemCommandCompletions(argument)
+	}
 	if m.skillSlashPromptStarted(rawInput) {
 		return nil
 	}
@@ -1264,6 +1305,42 @@ func matchingSkillsImportCompletions(input string) []chatCompletion {
 	}
 	if len(completions) == 0 {
 		return []chatCompletion{{label: "No matching skill sources"}}
+	}
+	return completions
+}
+
+func hasSystemCommandArgument(input string) bool {
+	_, ok := systemCommandArgument(input)
+	return ok
+}
+
+func systemCommandArgument(input string) (string, bool) {
+	input = strings.TrimLeftFunc(input, unicode.IsSpace)
+	end := strings.IndexFunc(input, unicode.IsSpace)
+	if end < 0 {
+		return "", false
+	}
+	command, _, known := slashCommandInvocation(input[:end])
+	if !known || command != "/system" {
+		return "", false
+	}
+	return strings.TrimSpace(input[end:]), true
+}
+
+func systemCommandCompletions(argument string) []chatCompletion {
+	argument = strings.ToLower(argument)
+	options := []chatCompletion{
+		{value: "/system on", label: "on", description: "enable the built-in system prompt"},
+		{value: "/system off", label: "off", description: "disable the built-in system prompt"},
+	}
+	completions := make([]chatCompletion, 0, len(options))
+	for _, option := range options {
+		if strings.HasPrefix(option.label, argument) {
+			completions = append(completions, option)
+		}
+	}
+	if len(completions) == 0 {
+		return []chatCompletion{{label: "No matching options"}}
 	}
 	return completions
 }
@@ -1511,7 +1588,7 @@ func (m chatModel) helpSummary() string {
 
 func (m chatModel) systemPrompt(extra string) string {
 	var parts []string
-	if strings.TrimSpace(m.opts.SystemPrompt) != "" {
+	if !m.systemPromptDisabled && strings.TrimSpace(m.opts.SystemPrompt) != "" {
 		parts = append(parts, strings.TrimSpace(m.opts.SystemPrompt))
 	}
 	if strings.TrimSpace(extra) != "" {

--- a/cmd/tui/chat/input.go
+++ b/cmd/tui/chat/input.go
@@ -70,6 +70,24 @@ var skillsImportCompletions = []chatCompletion{
 	{value: "/skills import pi", label: "/skills import pi", description: "import from ~/.pi/agent/skills"},
 }
 
+// BuiltinSlashCommandNames returns the names reserved by built-in slash
+// commands, including aliases.
+func BuiltinSlashCommandNames() []string {
+	names := make(map[string]struct{})
+	for _, command := range chatSlashCommands {
+		names[strings.TrimPrefix(command.name, "/")] = struct{}{}
+		for _, alias := range command.aliases {
+			names[strings.TrimPrefix(alias, "/")] = struct{}{}
+		}
+	}
+	reserved := make([]string, 0, len(names))
+	for name := range names {
+		reserved = append(reserved, name)
+	}
+	sort.Strings(reserved)
+	return reserved
+}
+
 func (m *chatModel) handleSubmit() (tea.Model, tea.Cmd) {
 	m.syncInputPlaceholders()
 	input := strings.TrimSpace(string(m.input))

--- a/cmd/tui/chat/input_test.go
+++ b/cmd/tui/chat/input_test.go
@@ -30,6 +30,7 @@ func TestChatHelpCommandShowsV1Commands(t *testing.T) {
 		"**Commands**",
 		"- `/model`: switch models",
 		"- `/think`: set thinking mode",
+		"- `/system [on|off]`: show or set the built-in system prompt",
 		"- `/compact`: summarize older context",
 		"- `/help`: show commands",
 		"- `/bye`: exit",
@@ -803,7 +804,7 @@ func TestSkillSlashNameResolvesAndRejectsArgsAndUnknown(t *testing.T) {
 }
 
 func TestChatDeletedSlashCommandsAreUnknown(t *testing.T) {
-	for _, command := range []string{"/clear", "/copy", "/copy-all", "/launch", "/system", "/history", "/load", "/raw", "/resume", "/set", "/show", "/verbose"} {
+	for _, command := range []string{"/clear", "/copy", "/copy-all", "/launch", "/history", "/load", "/raw", "/resume", "/set", "/show", "/verbose"} {
 		t.Run(command, func(t *testing.T) {
 			m := chatModel{input: []rune(command)}
 
@@ -827,7 +828,7 @@ func TestChatViewRendersSlashCommandSuggestions(t *testing.T) {
 	}
 
 	view := stripANSI(m.View())
-	for _, want := range []string{"/model", "/new", "/think", "/tools", "/skills"} {
+	for _, want := range []string{"/model", "/new", "/think", "/tools", "/system"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("view missing %s suggestion: %q", want, view)
 		}
@@ -935,6 +936,127 @@ func TestChatToolsCommandUsage(t *testing.T) {
 	m = updated.(chatModel)
 	if m.status != "error" || len(m.entries) != 1 || !strings.Contains(m.entries[0].content, "usage: /tools") {
 		t.Fatalf("invalid /tools result = status:%q entries:%#v", m.status, m.entries)
+	}
+}
+
+func TestChatSystemCommandControlsBuiltInSystemPrompt(t *testing.T) {
+	client := &chatCaptureClient{}
+	m := chatModel{
+		ctx:   context.Background(),
+		input: []rune("/system"),
+		opts: Options{
+			Model:        "test",
+			Client:       client,
+			SystemPrompt: "canonical agent prompt",
+		},
+	}
+
+	updated, cmd := m.handleSubmit()
+	if cmd != nil {
+		t.Fatal("/system should not start a run")
+	}
+	m = updated.(chatModel)
+	if len(m.entries) != 1 || m.entries[0].role != "slash" || m.entries[0].content != "Built-in system prompt is on.\n\ncanonical agent prompt\n\nWarning: Changing the system prompt during a session breaks the prompt cache." {
+		t.Fatalf("/system entry = %#v", m.entries)
+	}
+
+	m.input = []rune("/system off")
+	updated, _ = m.handleSubmit()
+	m = updated.(chatModel)
+	if !m.systemPromptDisabled || m.status != "system prompt off" {
+		t.Fatalf("/system off state = disabled:%v status:%q", m.systemPromptDisabled, m.status)
+	}
+	m.input = []rune("/system")
+	updated, _ = m.handleSubmit()
+	m = updated.(chatModel)
+	if got := m.entries[len(m.entries)-1].content; got != "Built-in system prompt is off.\n\ncanonical agent prompt\n\nWarning: Changing the system prompt during a session breaks the prompt cache." {
+		t.Fatalf("/system off entry = %q", got)
+	}
+	updated, cmd = m.startRun("hello")
+	if cmd == nil {
+		t.Fatal("run after /system off should start")
+	}
+	m = updated.(chatModel)
+	if done := waitForRunDone(t, m.events); done.err != nil {
+		t.Fatalf("run after /system off: %v", done.err)
+	}
+	if len(client.requests) != 1 || len(client.requests[0].Messages) != 1 || client.requests[0].Messages[0].Role != "user" {
+		t.Fatalf("request after /system off = %#v", client.requests)
+	}
+
+	m.input = []rune("/system ON")
+	updated, _ = m.handleSubmit()
+	m = updated.(chatModel)
+	if m.systemPromptDisabled || m.status != "system prompt on" {
+		t.Fatalf("/system on state = disabled:%v status:%q", m.systemPromptDisabled, m.status)
+	}
+	updated, cmd = m.startRun("hello again")
+	if cmd == nil {
+		t.Fatal("run after /system on should start")
+	}
+	m = updated.(chatModel)
+	if done := waitForRunDone(t, m.events); done.err != nil {
+		t.Fatalf("run after /system on: %v", done.err)
+	}
+	if len(client.requests) != 2 {
+		t.Fatalf("client requests = %d, want 2", len(client.requests))
+	}
+	request := client.requests[1]
+	if len(request.Messages) != 2 || request.Messages[0].Role != "system" || request.Messages[0].Content != "canonical agent prompt" {
+		t.Fatalf("request after /system on = %#v", request.Messages)
+	}
+
+	m.input = []rune("/system sometimes")
+	updated, _ = m.handleSubmit()
+	m = updated.(chatModel)
+	if m.status != "error" || len(m.entries) == 0 || m.entries[len(m.entries)-1].content != "usage: /system [on|off]" {
+		t.Fatalf("invalid /system result = status:%q entries:%#v", m.status, m.entries)
+	}
+}
+
+func TestChatSystemCommandArgumentCompletions(t *testing.T) {
+	for _, tt := range []struct {
+		input string
+		want  []string
+	}{
+		{input: "/system ", want: []string{"/system on", "/system off"}},
+		{input: "/system o", want: []string{"/system on", "/system off"}},
+		{input: "/system on", want: []string{"/system on"}},
+	} {
+		t.Run(tt.input, func(t *testing.T) {
+			m := chatModel{input: []rune(tt.input)}
+			completions := m.slashCompletions()
+			if len(completions) != len(tt.want) {
+				t.Fatalf("completions = %#v, want %d", completions, len(tt.want))
+			}
+			for i, want := range tt.want {
+				if completions[i].value != want {
+					t.Fatalf("completion %d = %q, want %q", i, completions[i].value, want)
+				}
+			}
+		})
+	}
+
+	m := chatModel{input: []rune("/system ")}
+	lines := stripANSI(strings.Join(m.slashCommandLines(80), "\n"))
+	for _, want := range []string{"on", "enable the built-in system prompt", "off", "disable the built-in system prompt"} {
+		if !strings.Contains(lines, want) {
+			t.Fatalf("/system option suggestions missing %q: %q", want, lines)
+		}
+	}
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd != nil {
+		t.Fatal("selecting /system on should not submit the command")
+	}
+	m = updated.(chatModel)
+	if got := string(m.input); got != "/system on" {
+		t.Fatalf("input = %q, want /system on", got)
+	}
+
+	m.input = []rune("/system maybe")
+	completions := m.slashCompletions()
+	if len(completions) != 1 || completions[0].label != "No matching options" {
+		t.Fatalf("invalid argument completions = %#v", completions)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add /system prompt inspection and on/off toggles for the agent TUI
- show cache-impact warning and current canonical prompt
- offer on/off completions while typing the command

## Validation
- go test ./cmd/tui/chat