### PR TITLE
cmd: add ollama update command and upgrade guidance (#17219)

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -15,7 +15,9 @@ import (
 	"math"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
+	"os/exec"
 	"os/signal"
 	"path"
 	"path/filepath"
@@ -34,6 +36,7 @@ import (
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/mod/semver"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/term"
 
@@ -973,6 +976,145 @@ func SignoutHandler(cmd *cobra.Command, args []string) error {
 
 	fmt.Println("You have signed out of ollama.com")
 	fmt.Println()
+	return nil
+}
+
+type githubRelease struct {
+	TagName string `json:"tag_name"`
+}
+
+func getLatestRelease(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.com/repos/ollama/ollama/releases/latest", nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("User-Agent", fmt.Sprintf("ollama/%s (%s %s)", version.Version, runtime.GOARCH, runtime.GOOS))
+	resp, err := http.DefaultClient.Do(req)
+	if err == nil && resp.StatusCode == http.StatusOK {
+		defer resp.Body.Close()
+		var rel githubRelease
+		if json.NewDecoder(resp.Body).Decode(&rel) == nil && rel.TagName != "" {
+			return rel.TagName, nil
+		}
+	}
+	if resp != nil {
+		resp.Body.Close()
+	}
+
+	reqURL, err := url.Parse("https://ollama.com/api/update")
+	if err != nil {
+		return "", err
+	}
+	q := reqURL.Query()
+	q.Add("os", runtime.GOOS)
+	q.Add("arch", runtime.GOARCH)
+	q.Add("version", version.Version)
+	reqURL.RawQuery = q.Encode()
+
+	req, err = http.NewRequestWithContext(ctx, http.MethodGet, reqURL.String(), nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("User-Agent", fmt.Sprintf("ollama/%s (%s %s)", version.Version, runtime.GOARCH, runtime.GOOS))
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNoContent {
+		return version.Version, nil
+	}
+	if resp.StatusCode == http.StatusOK {
+		var updateResp struct {
+			URL     string `json:"url"`
+			Version string `json:"version"`
+		}
+		if json.NewDecoder(resp.Body).Decode(&updateResp) == nil {
+			if updateResp.Version != "" {
+				return updateResp.Version, nil
+			}
+			if updateResp.URL != "" {
+				ver := path.Base(path.Dir(updateResp.URL))
+				if ver != "" && ver != "." {
+					return ver, nil
+				}
+			}
+		}
+	}
+	return "", fmt.Errorf("failed to fetch latest release: status %d", resp.StatusCode)
+}
+
+func UpdateHandler(cmd *cobra.Command, args []string) error {
+	checkOnly, _ := cmd.Flags().GetBool("check")
+
+	latestTag, err := getLatestRelease(cmd.Context())
+	if err != nil {
+		slog.Debug("failed to fetch latest release", "error", err)
+	}
+
+	current := version.Version
+	if !strings.HasPrefix(current, "v") {
+		current = "v" + current
+	}
+
+	latest := latestTag
+	if latest != "" && !strings.HasPrefix(latest, "v") {
+		latest = "v" + latest
+	}
+
+	isUpToDate := false
+	if latest != "" && semver.IsValid(latest) && semver.IsValid(current) {
+		if semver.Compare(current, latest) >= 0 {
+			isUpToDate = true
+		}
+	}
+
+	if isUpToDate {
+		fmt.Fprintf(cmd.OutOrStdout(), "Ollama is already up to date (%s)\n", version.Version)
+		return nil
+	}
+
+	if latestTag != "" {
+		fmt.Fprintf(cmd.OutOrStdout(), "A new version of Ollama is available: %s (current: %s)\n", latestTag, version.Version)
+	}
+
+	if checkOnly {
+		if runtime.GOOS == "linux" {
+			fmt.Fprintln(cmd.OutOrStdout(), "To update, run:")
+			fmt.Fprintln(cmd.OutOrStdout(), "  curl -fsSL https://ollama.com/install.sh | sh")
+		} else {
+			fmt.Fprintln(cmd.OutOrStdout(), "To update, download the latest version from:")
+			fmt.Fprintln(cmd.OutOrStdout(), "  https://ollama.com/download")
+		}
+		return nil
+	}
+
+	switch runtime.GOOS {
+	case "linux":
+		fmt.Fprintln(cmd.OutOrStdout(), "Updating Ollama...")
+		c := exec.CommandContext(cmd.Context(), "sh", "-c", "curl -fsSL https://ollama.com/install.sh | sh")
+		c.Stdout = cmd.OutOrStdout()
+		c.Stderr = cmd.ErrOrStderr()
+		c.Stdin = os.Stdin
+		if err := c.Run(); err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Update failed: %v\n", err)
+			fmt.Fprintln(cmd.OutOrStdout(), "You can update manually by running:")
+			fmt.Fprintln(cmd.OutOrStdout(), "  curl -fsSL https://ollama.com/install.sh | sh")
+			return err
+		}
+	case "darwin":
+		fmt.Fprintln(cmd.OutOrStdout(), "Ollama on macOS updates automatically.")
+		fmt.Fprintln(cmd.OutOrStdout(), "Click on the Ollama menu bar icon and select \"Restart to update\".")
+		fmt.Fprintln(cmd.OutOrStdout(), "You can also download the latest release manually at:")
+		fmt.Fprintln(cmd.OutOrStdout(), "  https://ollama.com/download")
+	default:
+		fmt.Fprintln(cmd.OutOrStdout(), "Ollama on Windows updates automatically.")
+		fmt.Fprintln(cmd.OutOrStdout(), "Click on the Ollama taskbar icon and select \"Restart to update\".")
+		fmt.Fprintln(cmd.OutOrStdout(), "You can also download the latest release manually at:")
+		fmt.Fprintln(cmd.OutOrStdout(), "  https://ollama.com/download")
+	}
+
 	return nil
 }
 
@@ -2436,6 +2578,14 @@ func NewCLI() *cobra.Command {
 		RunE:    DeleteHandler,
 	}
 
+	updateCmd := &cobra.Command{
+		Use:     "update",
+		Aliases: []string{"upgrade"},
+		Short:   "Update Ollama to the latest version",
+		RunE:    UpdateHandler,
+	}
+	updateCmd.Flags().Bool("check", false, "Check for updates without installing")
+
 	runnerCmd := &cobra.Command{
 		Use:    "runner",
 		Hidden: true,
@@ -2524,6 +2674,7 @@ func NewCLI() *cobra.Command {
 		psCmd,
 		copyCmd,
 		deleteCmd,
+		updateCmd,
 		runnerCmd,
 		gpuDiscoverCmd,
 		launch.LaunchCmd(checkServerHeartbeat, runInteractiveTUI),

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -984,21 +984,21 @@ type githubRelease struct {
 }
 
 func getLatestRelease(ctx context.Context) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.com/repos/ollama/ollama/releases/latest", nil)
-	if err != nil {
-		return "", err
-	}
-	req.Header.Set("User-Agent", fmt.Sprintf("ollama/%s (%s %s)", version.Version, runtime.GOARCH, runtime.GOOS))
-	resp, err := http.DefaultClient.Do(req)
-	if err == nil && resp.StatusCode == http.StatusOK {
-		defer resp.Body.Close()
-		var rel githubRelease
-		if json.NewDecoder(resp.Body).Decode(&rel) == nil && rel.TagName != "" {
-			return rel.TagName, nil
+	if err == nil {
+		req.Header.Set("User-Agent", fmt.Sprintf("ollama/%s (%s %s)", version.Version, runtime.GOARCH, runtime.GOOS))
+		if resp, err := http.DefaultClient.Do(req); err == nil {
+			defer resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				var rel githubRelease
+				if json.NewDecoder(resp.Body).Decode(&rel) == nil && rel.TagName != "" {
+					return rel.TagName, nil
+				}
+			}
 		}
-	}
-	if resp != nil {
-		resp.Body.Close()
 	}
 
 	reqURL, err := url.Parse("https://ollama.com/api/update")
@@ -1016,7 +1016,7 @@ func getLatestRelease(ctx context.Context) (string, error) {
 		return "", err
 	}
 	req.Header.Set("User-Agent", fmt.Sprintf("ollama/%s (%s %s)", version.Version, runtime.GOARCH, runtime.GOOS))
-	resp, err = http.DefaultClient.Do(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", err
 	}
@@ -1080,6 +1080,10 @@ func UpdateHandler(cmd *cobra.Command, args []string) error {
 	}
 
 	if checkOnly {
+		if err != nil && latestTag == "" {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Error: could not check for updates: %v\n", err)
+			return err
+		}
 		if runtime.GOOS == "linux" {
 			fmt.Fprintln(cmd.OutOrStdout(), "To update, run:")
 			fmt.Fprintln(cmd.OutOrStdout(), "  curl -fsSL https://ollama.com/install.sh | sh")
@@ -2582,6 +2586,7 @@ func NewCLI() *cobra.Command {
 		Use:     "update",
 		Aliases: []string{"upgrade"},
 		Short:   "Update Ollama to the latest version",
+		Args:    cobra.NoArgs,
 		RunE:    UpdateHandler,
 	}
 	updateCmd.Flags().Bool("check", false, "Check for updates without installing")

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -2390,3 +2390,24 @@ func TestIsLocalhost(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateCommand(t *testing.T) {
+	t.Run("check flag execution", func(t *testing.T) {
+		cli := NewCLI()
+		var outBuf, errBuf bytes.Buffer
+		cli.SetOut(&outBuf)
+		cli.SetErr(&errBuf)
+		cli.SetArgs([]string{"update", "--check"})
+
+		err := cli.Execute()
+		if err != nil {
+			t.Fatalf("unexpected error executing update --check: %v", err)
+		}
+
+		output := outBuf.String()
+		if !strings.Contains(output, "up to date") && !strings.Contains(output, "To update") {
+			t.Errorf("unexpected output from update --check: %q", output)
+		}
+	})
+}
+

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -2410,4 +2410,3 @@ func TestUpdateCommand(t *testing.T) {
 		}
 	})
 }
-

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -4,13 +4,20 @@ title: FAQ
 
 ## How can I upgrade Ollama?
 
+You can upgrade Ollama directly using the CLI:
+
+```shell
+ollama update
+```
+
 Ollama on macOS and Windows will automatically download updates. Click on the taskbar or menubar item and then click "Restart to update" to apply the update. Updates can also be installed by downloading the latest version [manually](https://ollama.com/download/).
 
-On Linux, re-run the install script:
+On Linux, `ollama update` will automatically re-run the install script (or you can run it manually):
 
 ```shell
 curl -fsSL https://ollama.com/install.sh | sh
 ```
+
 
 ## How can I view the logs?
 


### PR DESCRIPTION
Fixes #17219

### Summary of Changes

Added `ollama update` (alias `ollama upgrade`) command and `--check` flag to easily check for and install updates directly from the CLI.

#### Features & Enhancements:
- **CLI Update Command**: Adds `ollama update` to check and trigger updates. Supports `--check` flag to check without executing the update script.
- **Fallback Strategy**: Checks GitHub Releases API (`api.github.com/repos/ollama/ollama/releases/latest`) first for official release tags, with fallback to `ollama.com/api/update`.
- **Resilience & Timeouts**: Includes a 10s context timeout (`context.WithTimeout`) to prevent hanging CLI execution when offline or on slow connections.
- **Improved UX & Error Handling**:
  - Gracefully reports network/connectivity errors when offline instead of executing fallbacks blindly.
  - Formats OS-specific guidance (`linux`, `darwin`, `windows`).
  - Added `cobra.NoArgs` validation to avoid unexpected arguments.
- **Documentation**: Updated `docs/faq.mdx` with `ollama update` usage instructions.

#### Verification
- Ran unit tests in `cmd`: `go test ./cmd -v -run TestUpdateCommand` (PASS)
- Tested `./ollama update --check` and `./ollama update` on Linux successfully.
