### PR TITLE
build: forward explicit CUDAToolkit_ROOT to CUDA sub-builds on Linux

### DIFF
--- a/cmake/local.cmake
+++ b/cmake/local.cmake
@@ -302,9 +302,12 @@ function(ollama_append_cuda_toolkit_args output backend)
         ollama_find_windows_cuda_root("${_cuda_major}" _cuda_root)
         if(NOT "${_cuda_root}" STREQUAL "")
             ollama_escape_cmake_list("${_cuda_root}" _value)
-            set(${output} ${${output}} "-DCUDAToolkit_ROOT=${_value}" PARENT_SCOPE)
+            list(APPEND ${output} "-DCUDAToolkit_ROOT=${_value}")
         endif()
     endif()
+    # ollama_append_cache_arg_if_set/list(APPEND) only update this function's
+    # scope; propagate the result to the caller.
+    set(${output} "${${output}}" PARENT_SCOPE)
 endfunction()
 
 function(ollama_llama_cuda_preset backend output)


### PR DESCRIPTION
### What

`ollama_append_cuda_toolkit_args()` in `cmake/local.cmake` accumulates `-DCUDAToolkit_ROOT=...` into its output list, but only the Windows auto-discovery branch propagates that list back to the caller with `PARENT_SCOPE`. When `CUDAToolkit_ROOT` is set explicitly (the first branch), the appended argument stays in the function's local scope and is silently dropped.

This PR unconditionally propagates the accumulated list at the end of the function.

### Why

On Linux, configuring with an explicit toolkit root:

```sh
cmake -B build . -DOLLAMA_LLAMA_BACKENDS=cuda_v12 -DCUDAToolkit_ROOT=/opt/cuda-12.2
```

does not forward `CUDAToolkit_ROOT` into the nested `llama-server` ExternalProject configure. The sub-build then runs its own `find_package(CUDAToolkit)`, which can resolve to a different toolkit — e.g. a distro CUDA 11 under `/usr/lib/x86_64 linux-gnu` — while `nvcc` from the intended toolkit is used for compilation. The resulting `libggml-cuda.so` links against the wrong CUDA runtime:

```
$ ldd build/lib/ollama/cuda_v12/libggml-cuda.so | grep cudart libcudart.so.11.0 => /usr/lib/x86_64-linux-gnu/libcudart.so.11.0
```

This affects any Linux machine with more than one CUDA toolkit installed (system packages + conda/manual installs), which is common on shared dev boxes.

### How reproduced / verified

Machine with a system CUDA 11.5 (`/usr/lib/x86_64-linux-gnu/libcudart.so.11.0`) and a CUDA 12.2 toolkit at a non-standard prefix.
Before: sub-build cache shows `CUDA_cudart_LIBRARY=/usr/lib/x86_64-linux-gnu/libcudart.so`, backend links `libcudart.so.11.0`.

After: `CUDA_cudart_LIBRARY=<toolkit>/lib/libcudart.so`, backend links `libcudart.so.12`, bundled runtime libs in `lib/ollama/cuda_v12/` are the CUDA 12 ones. Windows auto-discovery path is unchanged (its `list(APPEND ...)` result now flows through the same final `set(... PARENT_SCOPE)`).

**This issue was found and fixed with the help of Claude (Fable 5) while debugging a local build — submitting for reference. If the analysis is wrong, or the maintainers prefer to fix this differently, I'm happy to close this PR.**