### PR TITLE
launch: update glm-5.2:cloud metadata and OMP reasoning flag

### DIFF
--- a/anthropic/anthropic.go
+++ b/anthropic/anthropic.go
@@ -180,7 +180,9 @@ type Tool struct {
 	InputSchema json.RawMessage `json:"input_schema,omitempty"`
 
 	// Web search specific fields
-	MaxUses int `json:"max_uses,omitempty"`
+	MaxUses        int      `json:"max_uses,omitempty"`
+	AllowedDomains []string `json:"allowed_domains,omitempty"`
+	BlockedDomains []string `json:"blocked_domains,omitempty"`
 }
 
 // ToolChoice controls how the model uses tools
@@ -1276,4 +1278,81 @@ func ConvertOllamaToAnthropicResults(ollamaResults *OllamaWebSearchResponse) []W
 		})
 	}
 	return results
+}
+
+// ValidateDomainFilters returns an error when both allow and block lists are set.
+func ValidateDomainFilters(allowed, blocked []string) error {
+	if len(allowed) > 0 && len(blocked) > 0 {
+		return errors.New("allowed_domains and blocked_domains are mutually exclusive")
+	}
+	return nil
+}
+
+// WebSearchDomainFilters returns domain filters from the first web_search tool.
+func WebSearchDomainFilters(tools []Tool) (allowed, blocked []string, err error) {
+	for _, t := range tools {
+		if !strings.HasPrefix(t.Type, "web_search") {
+			continue
+		}
+		if err := ValidateDomainFilters(t.AllowedDomains, t.BlockedDomains); err != nil {
+			return nil, nil, err
+		}
+		return t.AllowedDomains, t.BlockedDomains, nil
+	}
+	return nil, nil, nil
+}
+
+// FilterOllamaWebSearchResults keeps or drops results by allowed/blocked domain entries.
+// Entries are bare hosts with an optional path (e.g. "example.com" or "example.com/blog").
+func FilterOllamaWebSearchResults(results []OllamaWebSearchResult, allowed, blocked []string) []OllamaWebSearchResult {
+	if len(allowed) == 0 && len(blocked) == 0 {
+		return results
+	}
+	out := make([]OllamaWebSearchResult, 0, len(results))
+	for _, r := range results {
+		if len(allowed) > 0 {
+			if !urlMatchesAnyDomain(r.URL, allowed) {
+				continue
+			}
+		} else if urlMatchesAnyDomain(r.URL, blocked) {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+func urlMatchesAnyDomain(rawURL string, entries []string) bool {
+	for _, entry := range entries {
+		if urlMatchesDomainEntry(rawURL, entry) {
+			return true
+		}
+	}
+	return false
+}
+
+func urlMatchesDomainEntry(rawURL, entry string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Hostname() == "" {
+		return false
+	}
+	entry = strings.TrimSpace(entry)
+	entry = strings.TrimPrefix(entry, "https://")
+	entry = strings.TrimPrefix(entry, "http://")
+	if entry == "" {
+		return false
+	}
+
+	hostPart, pathPart, hasPath := strings.Cut(entry, "/")
+	hostPart = strings.ToLower(strings.TrimSuffix(hostPart, "."))
+	host := strings.ToLower(u.Hostname())
+	if host != hostPart && !strings.HasSuffix(host, "."+hostPart) {
+		return false
+	}
+	if !hasPath || pathPart == "" {
+		return true
+	}
+	want := "/" + pathPart
+	path := u.EscapedPath()
+	return path == want || strings.HasPrefix(path, want+"/")
 }

--- a/anthropic/anthropic_test.go
+++ b/anthropic/anthropic_test.go
@@ -1884,6 +1884,70 @@ func TestConvertOllamaToAnthropicResults(t *testing.T) {
 	}
 }
 
+func TestValidateDomainFilters(t *testing.T) {
+	if err := ValidateDomainFilters(nil, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := ValidateDomainFilters([]string{"a.com"}, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := ValidateDomainFilters(nil, []string{"b.com"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := ValidateDomainFilters([]string{"a.com"}, []string{"b.com"}); err == nil {
+		t.Fatal("expected mutual exclusivity error")
+	}
+}
+
+func TestFilterOllamaWebSearchResults(t *testing.T) {
+	results := []OllamaWebSearchResult{
+		{Title: "NIH", URL: "https://www.nih.gov/news", Content: "a"},
+		{Title: "Blog", URL: "https://example.com/blog/post", Content: "b"},
+		{Title: "Spam", URL: "https://spam.com/x", Content: "c"},
+		{Title: "Other", URL: "https://other.org/", Content: "d"},
+	}
+
+	t.Run("no filters", func(t *testing.T) {
+		got := FilterOllamaWebSearchResults(results, nil, nil)
+		if len(got) != len(results) {
+			t.Fatalf("got %d, want %d", len(got), len(results))
+		}
+	})
+
+	t.Run("allowed domains", func(t *testing.T) {
+		got := FilterOllamaWebSearchResults(results, []string{"nih.gov", "example.com/blog"}, nil)
+		if len(got) != 2 {
+			t.Fatalf("got %d results, want 2: %+v", len(got), got)
+		}
+		if got[0].URL != results[0].URL || got[1].URL != results[1].URL {
+			t.Fatalf("unexpected results: %+v", got)
+		}
+	})
+
+	t.Run("blocked domains", func(t *testing.T) {
+		got := FilterOllamaWebSearchResults(results, nil, []string{"spam.com"})
+		if len(got) != 3 {
+			t.Fatalf("got %d results, want 3: %+v", len(got), got)
+		}
+		for _, r := range got {
+			if strings.Contains(r.URL, "spam.com") {
+				t.Fatalf("blocked domain still present: %s", r.URL)
+			}
+		}
+	})
+
+	t.Run("path prefix does not match sibling path", func(t *testing.T) {
+		got := FilterOllamaWebSearchResults(
+			[]OllamaWebSearchResult{{URL: "https://example.com/docs"}},
+			[]string{"example.com/blog"},
+			nil,
+		)
+		if len(got) != 0 {
+			t.Fatalf("expected empty, got %+v", got)
+		}
+	})
+}
+
 func TestWebSearchTypes(t *testing.T) {
 	// Test that WebSearchResult serializes correctly
 	result := WebSearchResult{

--- a/anthropic/trace.go
+++ b/anthropic/trace.go
@@ -215,7 +215,9 @@ func TraceTool(t Tool) map[string]any {
 		"name":         t.Name,
 		"description":  TraceTruncateString(t.Description),
 		"input_schema": TraceJSON(t.InputSchema),
-		"max_uses":     t.MaxUses,
+		"max_uses":         t.MaxUses,
+		"allowed_domains":  t.AllowedDomains,
+		"blocked_domains":  t.BlockedDomains,
 	}
 }
 

--- a/cmd/launch/models.go
+++ b/cmd/launch/models.go
@@ -25,7 +25,7 @@ import (
 var recommendedModels = []ModelItem{
 	{Name: "kimi-k2.6:cloud", Description: "State-of-the-art coding, long-horizon execution, and multimodal agent swarm capability", Recommended: true, Details: api.ModelDetails{ContextLength: 262_144}, MaxOutputTokens: 262_144},
 	{Name: "qwen3.5:cloud", Description: "Reasoning, coding, and agentic tool use with vision", Recommended: true, Details: api.ModelDetails{ContextLength: 262_144}, MaxOutputTokens: 32_768},
-	{Name: "glm-5.1:cloud", Description: "Reasoning and code generation", Recommended: true, Details: api.ModelDetails{ContextLength: 202_752}, MaxOutputTokens: 131_072},
+	{Name: "glm-5.2:cloud", Description: "Reasoning and code generation", Recommended: true, Details: api.ModelDetails{ContextLength: 1_048_576}, MaxOutputTokens: 131_072},
 	{Name: "minimax-m2.7:cloud", Description: "Fast, efficient coding and real-world productivity", Recommended: true, Details: api.ModelDetails{ContextLength: 204_800}, MaxOutputTokens: 128_000},
 	{Name: "gemma4", Description: "Reasoning and code generation locally", Recommended: true, VRAMBytes: 12 * format.GigaByte},
 	{Name: "qwen3.5", Description: "Reasoning, coding, and visual understanding locally", Recommended: true, VRAMBytes: 14 * format.GigaByte},
@@ -60,6 +60,7 @@ var extraCloudModelLimits = map[string]cloudModelLimit{
 	"glm-4.7":             {Context: 202_752, Output: 131_072},
 	"glm-5":               {Context: 202_752, Output: 131_072},
 	"glm-5.1":             {Context: 202_752, Output: 131_072},
+	"glm-5.2":             {Context: 1_048_576, Output: 131_072},
 	"gpt-oss:120b":        {Context: 131_072, Output: 131_072},
 	"gpt-oss:20b":         {Context: 131_072, Output: 131_072},
 	"kimi-k2:1t":          {Context: 262_144, Output: 262_144},

--- a/cmd/launch/omp.go
+++ b/cmd/launch/omp.go
@@ -439,6 +439,9 @@ func ompModelConfig(modelInfo LaunchModel) map[string]any {
 	if modelInfo.MaxOutputTokens > 0 {
 		entry["maxTokens"] = modelInfo.MaxOutputTokens
 	}
+	if slices.Contains(modelInfo.Capabilities, model.CapabilityThinking) {
+		entry["reasoning"] = true
+	}
 	return entry
 }
 

--- a/cmd/launch/omp_test.go
+++ b/cmd/launch/omp_test.go
@@ -313,6 +313,25 @@ func TestOMPFindPath(t *testing.T) {
 	})
 }
 
+func TestOMPModelConfig(t *testing.T) {
+	t.Run("sets reasoning when model has thinking capability", func(t *testing.T) {
+		cfg := ompModelConfig(LaunchModel{
+			Name:         "glm-5.2:cloud",
+			Capabilities: []modelpkg.Capability{modelpkg.CapabilityThinking},
+		})
+		if cfg["reasoning"] != true {
+			t.Error("expected reasoning = true for thinking model")
+		}
+	})
+
+	t.Run("omits reasoning for non-thinking model", func(t *testing.T) {
+		cfg := ompModelConfig(LaunchModel{Name: "llama3.2"})
+		if _, ok := cfg["reasoning"]; ok {
+			t.Error("reasoning should not be set for non-thinking model")
+		}
+	})
+}
+
 func TestOMPConfigureWithModelsWritesModelsYML(t *testing.T) {
 	home := t.TempDir()
 	setOMPTestHome(t, home)
@@ -321,16 +340,17 @@ func TestOMPConfigureWithModelsWritesModelsYML(t *testing.T) {
 	o := &OMP{}
 	models := []LaunchModel{
 		{
-			Name:            "glm-5.1:cloud",
-			ContextLength:   202_752,
+			Name:            "glm-5.2:cloud",
+			ContextLength:   1_048_576,
 			MaxOutputTokens: 131_072,
+			Capabilities:    []modelpkg.Capability{modelpkg.CapabilityThinking},
 		},
 		{
 			Name:         "qwen3.6",
 			Capabilities: []modelpkg.Capability{modelpkg.CapabilityVision},
 		},
 	}
-	if err := o.ConfigureWithModels("glm-5.1:cloud", models); err != nil {
+	if err := o.ConfigureWithModels("glm-5.2:cloud", models); err != nil {
 		t.Fatalf("ConfigureWithModels returned error: %v", err)
 	}
 
@@ -360,20 +380,23 @@ func TestOMPConfigureWithModelsWritesModelsYML(t *testing.T) {
 	if len(entries) != 2 {
 		t.Fatalf("models length = %d, want 2", len(entries))
 	}
-	if entries[0]["id"] != "glm-5.1:cloud" {
+	if entries[0]["id"] != "glm-5.2:cloud" {
 		t.Fatalf("first model id = %v, want primary first", entries[0]["id"])
 	}
-	if got := numericYAMLValue(entries[0]["contextWindow"]); got != 202_752 {
-		t.Fatalf("contextWindow = %d, want 202752", got)
+	if got := numericYAMLValue(entries[0]["contextWindow"]); got != 1_048_576 {
+		t.Fatalf("contextWindow = %d, want 1048576", got)
 	}
 	if got := numericYAMLValue(entries[0]["maxTokens"]); got != 131_072 {
 		t.Fatalf("maxTokens = %d, want 131072", got)
 	}
+	if entries[0]["reasoning"] != true {
+		t.Fatalf("reasoning = %v, want true", entries[0]["reasoning"])
+	}
 	if input := stringSliceYAMLValue(entries[1]["input"]); !slices.Equal(input, []string{"text", "image"}) {
 		t.Fatalf("vision input = %v, want [text image]", input)
 	}
-	if got := o.CurrentModel(); got != "glm-5.1:cloud" {
-		t.Fatalf("CurrentModel = %q, want glm-5.1:cloud", got)
+	if got := o.CurrentModel(); got != "glm-5.2:cloud" {
+		t.Fatalf("CurrentModel = %q, want glm-5.2:cloud", got)
 	}
 
 	configPath := filepath.Join(home, ".omp", "agent", "config.yml")

--- a/cmd/launch/opencode_test.go
+++ b/cmd/launch/opencode_test.go
@@ -304,6 +304,7 @@ func TestLookupCloudModelLimit(t *testing.T) {
 		{"glm-4.7:cloud", true, 202_752, 131_072},
 		{"glm-5:cloud", true, 202_752, 131_072},
 		{"glm-5.1:cloud", true, 202_752, 131_072},
+		{"glm-5.2:cloud", true, 1_048_576, 131_072},
 		{"gemma4:31b-cloud", true, 262_144, 131_072},
 		{"gpt-oss:120b-cloud", true, 131_072, 131_072},
 		{"gpt-oss:20b-cloud", true, 131_072, 131_072},

--- a/docs/integrations/copilot-cli.mdx
+++ b/docs/integrations/copilot-cli.mdx
@@ -4,7 +4,7 @@ title: Copilot CLI
 
 GitHub Copilot CLI is GitHub's AI coding agent for the terminal. It can understand your codebase, make edits, run commands, and help you build software faster.
 
-Open models can be used with Copilot CLI through Ollama, enabling you to use models such as `qwen3.5`, `glm-5.1:cloud`, `kimi-k2.5:cloud`.
+Open models can be used with Copilot CLI through Ollama, enabling you to use models such as `qwen3.5`, `glm-5.2:cloud`, `kimi-k2.5:cloud`.
 
 ## Install
 

--- a/docs/integrations/hermes.mdx
+++ b/docs/integrations/hermes.mdx
@@ -24,7 +24,7 @@ Ollama handles everything automatically:
 **Cloud models**:
 
 - `kimi-k2.5:cloud` — Multimodal reasoning with subagents
-- `glm-5.1:cloud` — Reasoning and code generation
+- `glm-5.2:cloud` — Reasoning and code generation
 - `qwen3.5:cloud` — Reasoning, coding, and agentic tool use with vision
 - `minimax-m2.7:cloud` — Fast, efficient coding and real-world productivity
 

--- a/docs/integrations/openclaw.mdx
+++ b/docs/integrations/openclaw.mdx
@@ -60,7 +60,7 @@ If the gateway is already running, it restarts automatically to pick up the new 
 
 - `kimi-k2.5:cloud` — Multimodal reasoning with subagents
 - `qwen3.5:cloud` — Reasoning, coding, and agentic tool use with vision
-- `glm-5.1:cloud` — Reasoning and code generation
+- `glm-5.2:cloud` — Reasoning and code generation
 - `minimax-m2.7:cloud` — Fast, efficient coding and real-world productivity
 
 **Local models:**

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -463,3 +463,8 @@ func NoCloudSource() string {
 		return "none"
 	}
 }
+
+// PrefillCacheDir returns the process-local directory for persisted prefill caches.
+func PrefillCacheDir() string {
+	return filepath.Join(os.TempDir(), "ollama-prefill-cache", fmt.Sprintf("%d", os.Getpid()))
+}

--- a/middleware/anthropic.go
+++ b/middleware/anthropic.go
@@ -257,7 +257,13 @@ func (w *WebSearchAnthropicWriter) runWebSearchLoop(ctx context.Context, initial
 		}
 
 		const defaultMaxResults = 5
-		searchResp, err := anthropic.WebSearch(ctx, query, defaultMaxResults)
+		maxResults := defaultMaxResults
+		allowed, blocked, _ := anthropic.WebSearchDomainFilters(w.req.Tools)
+		if len(allowed) > 0 || len(blocked) > 0 {
+			// Ask for more results so filtering still leaves something useful.
+			maxResults = 10
+		}
+		searchResp, err := anthropic.WebSearch(ctx, query, maxResults)
 		if err != nil {
 			logutil.TraceContext(ctx, "anthropic middleware: web_search request failed",
 				"loop", loop,
@@ -271,9 +277,12 @@ func (w *WebSearchAnthropicWriter) runWebSearchLoop(ctx context.Context, initial
 				err:   err,
 			}
 		}
+		searchResp.Results = anthropic.FilterOllamaWebSearchResults(searchResp.Results, allowed, blocked)
 		logutil.TraceContext(ctx, "anthropic middleware: web_search results",
 			"loop", loop,
 			"results", len(searchResp.Results),
+			"allowed_domains", len(allowed),
+			"blocked_domains", len(blocked),
 		)
 
 		toolUseID := loopServerToolUseID(w.inner.id, loop)
@@ -872,6 +881,10 @@ func AnthropicMessagesMiddleware() gin.HandlerFunc {
 		}
 
 		if hasWebSearchTool(req.Tools) {
+			if _, _, err := anthropic.WebSearchDomainFilters(req.Tools); err != nil {
+				c.AbortWithStatusJSON(http.StatusBadRequest, anthropic.NewError(http.StatusBadRequest, err.Error()))
+				return
+			}
 			// Guard against runtime cloud-disable policy (OLLAMA_NO_CLOUD/server.json)
 			// for cloud models. Local models may still receive web_search tool definitions;
 			// execution is validated when the model actually emits a web_search tool call.

--- a/middleware/anthropic_test.go
+++ b/middleware/anthropic_test.go
@@ -1065,6 +1065,144 @@ func TestWebSearchToolPresent_ModelCallsIt_NonStreaming(t *testing.T) {
 	}
 }
 
+func TestWebSearchDomainFiltersMutuallyExclusive(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	router.Use(AnthropicMessagesMiddleware())
+	router.POST("/v1/messages", func(c *gin.Context) {
+		t.Fatal("handler should not run when domain filters are invalid")
+	})
+
+	body := `{
+		"model":"test-model",
+		"max_tokens":100,
+		"messages":[{"role":"user","content":"hi"}],
+		"tools":[{
+			"type":"web_search_20250305",
+			"name":"web_search",
+			"allowed_domains":["nih.gov"],
+			"blocked_domains":["spam.com"]
+		}]
+	}`
+	req, _ := http.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", resp.Code, resp.Body.String())
+	}
+	if !strings.Contains(resp.Body.String(), "mutually exclusive") {
+		t.Fatalf("expected mutual exclusivity error, got %s", resp.Body.String())
+	}
+}
+
+func TestWebSearchAllowedDomainsFiltersResults(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	enableCloudForTest(t)
+
+	followupServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := api.ChatResponse{
+			Model:      "test-model",
+			Message:    api.Message{Role: "assistant", Content: "Filtered answer."},
+			Done:       true,
+			DoneReason: "stop",
+			Metrics:    api.Metrics{PromptEvalCount: 50, EvalCount: 20},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer followupServer.Close()
+	t.Setenv("OLLAMA_HOST", followupServer.URL)
+
+	var gotMaxResults int
+	searchServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req anthropic.OllamaWebSearchRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		gotMaxResults = req.MaxResults
+		resp := anthropic.OllamaWebSearchResponse{
+			Results: []anthropic.OllamaWebSearchResult{
+				{Title: "NIH", URL: "https://www.nih.gov/a", Content: "ok"},
+				{Title: "Other", URL: "https://example.com/x", Content: "nope"},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer searchServer.Close()
+
+	originalEndpoint := anthropic.WebSearchEndpoint
+	anthropic.WebSearchEndpoint = searchServer.URL
+	defer func() { anthropic.WebSearchEndpoint = originalEndpoint }()
+
+	router := gin.New()
+	router.Use(AnthropicMessagesMiddleware())
+	router.POST("/v1/messages", func(c *gin.Context) {
+		resp := api.ChatResponse{
+			Model: "test-model",
+			Message: api.Message{
+				Role: "assistant",
+				ToolCalls: []api.ToolCall{{
+					ID: "call_ws_001",
+					Function: api.ToolCallFunction{
+						Name:      "web_search",
+						Arguments: makeArgs("query", "nih guidelines"),
+					},
+				}},
+			},
+			Done:       true,
+			DoneReason: "stop",
+			Metrics:    api.Metrics{PromptEvalCount: 15, EvalCount: 3},
+		}
+		data, _ := json.Marshal(resp)
+		c.Writer.WriteHeader(http.StatusOK)
+		_, _ = c.Writer.Write(data)
+	})
+
+	body := `{
+		"model":"test-model:cloud",
+		"max_tokens":100,
+		"messages":[{"role":"user","content":"nih?"}],
+		"tools":[{
+			"type":"web_search_20250305",
+			"name":"web_search",
+			"allowed_domains":["nih.gov"]
+		}]
+	}`
+	req, _ := http.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+	if gotMaxResults != 10 {
+		t.Fatalf("max_results = %d, want 10 when domain filters are set", gotMaxResults)
+	}
+
+	var result anthropic.MessagesResponse
+	if err := json.Unmarshal(resp.Body.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal error: %v\nbody: %s", err, resp.Body.String())
+	}
+	if len(result.Content) < 2 {
+		t.Fatalf("expected search result block, got %+v", result.Content)
+	}
+
+	raw, err := json.Marshal(result.Content[1].Content)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var searchResults []anthropic.WebSearchResult
+	if err := json.Unmarshal(raw, &searchResults); err != nil {
+		t.Fatalf("unmarshal search results: %v (%s)", err, string(raw))
+	}
+	if len(searchResults) != 1 || searchResults[0].URL != "https://www.nih.gov/a" {
+		t.Fatalf("expected only nih.gov result, got %+v", searchResults)
+	}
+}
+
 // TestWebSearchToolPresent_ModelCallsIt_Streaming tests the streaming SSE output
 // when the model calls web_search with mocked search and followup endpoints.
 func TestWebSearchToolPresent_ModelCallsIt_Streaming(t *testing.T) {

--- a/server/model_recommendations.go
+++ b/server/model_recommendations.go
@@ -372,9 +372,9 @@ var defaultModelRecommendations = []api.ModelRecommendation{
 		MaxOutputTokens: 262_144,
 	},
 	{
-		Model:           "glm-5.1:cloud",
+		Model:           "glm-5.2:cloud",
 		Description:     "Reasoning and code generation",
-		ContextLength:   202_752,
+		ContextLength:   1_048_576,
 		MaxOutputTokens: 131_072,
 	},
 	{

--- a/server/model_recommendations_test.go
+++ b/server/model_recommendations_test.go
@@ -25,7 +25,7 @@ import (
 func TestModelRecommendationsDefaultOrder(t *testing.T) {
 	want := []string{
 		"kimi-k2.6:cloud",
-		"glm-5.1:cloud",
+		"glm-5.2:cloud",
 		"qwen3.5:cloud",
 		"minimax-m2.7:cloud",
 		"gemma4",

--- a/server/routes_cloud_test.go
+++ b/server/routes_cloud_test.go
@@ -256,6 +256,48 @@ func TestExplicitCloudPassthroughAPIAndV1(t *testing.T) {
 		}
 	})
 
+	t.Run("api chat glm-5.2 cloud preserves think", func(t *testing.T) {
+		upstream, capture := newUpstream(t, `{"message":{"role":"assistant","content":"ok","thinking":"reasoning"},"done":true}`)
+		defer upstream.Close()
+
+		original := cloudProxyBaseURL
+		cloudProxyBaseURL = upstream.URL
+		t.Cleanup(func() { cloudProxyBaseURL = original })
+
+		s := &Server{}
+		router, err := s.GenerateRoutes()
+		if err != nil {
+			t.Fatal(err)
+		}
+		local := httptest.NewServer(router)
+		defer local.Close()
+
+		reqBody := `{"model":"glm-5.2:cloud","messages":[{"role":"user","content":"hello"}],"stream":false,"think":true}`
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, local.URL+"/api/chat", bytes.NewBufferString(reqBody))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := local.Client().Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200, got %d (%s)", resp.StatusCode, string(body))
+		}
+
+		if !strings.Contains(capture.body, `"model":"glm-5.2"`) {
+			t.Fatalf("expected normalized model in upstream body, got %q", capture.body)
+		}
+		if !strings.Contains(capture.body, `"think":true`) {
+			t.Fatalf("expected think field preserved in upstream body, got %q", capture.body)
+		}
+	})
+
 	t.Run("api embed", func(t *testing.T) {
 		upstream, capture := newUpstream(t, `{"model":"kimi-k2.5:cloud","embeddings":[[0.1,0.2]]}`)
 		defer upstream.Close()


### PR DESCRIPTION
Recommendations and cloud limits still pointed at glm-5.1. OMP also omitted reasoning for thinking-capable models, unlike Pi.