### PR TITLE
cmd: create SSH keypair with O_EXCL to avoid overwrite race

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -2010,40 +2010,46 @@ func initializeKeypair() error {
 	privKeyPath := filepath.Join(home, ".ollama", "id_ed25519")
 	pubKeyPath := filepath.Join(home, ".ollama", "id_ed25519.pub")
 
-	_, err = os.Stat(privKeyPath)
-	if os.IsNotExist(err) {
-		fmt.Printf("Couldn't find '%s'. Generating new private key.\n", privKeyPath)
-		cryptoPublicKey, cryptoPrivateKey, err := ed25519.GenerateKey(rand.Reader)
-		if err != nil {
-			return err
-		}
-
-		privateKeyBytes, err := ssh.MarshalPrivateKey(cryptoPrivateKey, "")
-		if err != nil {
-			return err
-		}
-
-		if err := os.MkdirAll(filepath.Dir(privKeyPath), 0o755); err != nil {
-			return fmt.Errorf("could not create directory %w", err)
-		}
-
-		if err := os.WriteFile(privKeyPath, pem.EncodeToMemory(privateKeyBytes), 0o600); err != nil {
-			return err
-		}
-
-		sshPublicKey, err := ssh.NewPublicKey(cryptoPublicKey)
-		if err != nil {
-			return err
-		}
-
-		publicKeyBytes := ssh.MarshalAuthorizedKey(sshPublicKey)
-
-		if err := os.WriteFile(pubKeyPath, publicKeyBytes, 0o644); err != nil {
-			return err
-		}
-
-		fmt.Printf("Your new public key is: \n\n%s\n", publicKeyBytes)
+	if err := os.MkdirAll(filepath.Dir(privKeyPath), 0o755); err != nil {
+		return fmt.Errorf("could not create directory %w", err)
 	}
+
+	// O_EXCL makes creation atomic: only one process wins if keys are missing.
+	privFile, err := os.OpenFile(privKeyPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		if os.IsExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer privFile.Close()
+
+	fmt.Printf("Couldn't find '%s'. Generating new private key.\n", privKeyPath)
+	cryptoPublicKey, cryptoPrivateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return err
+	}
+
+	privateKeyBytes, err := ssh.MarshalPrivateKey(cryptoPrivateKey, "")
+	if err != nil {
+		return err
+	}
+
+	if _, err := privFile.Write(pem.EncodeToMemory(privateKeyBytes)); err != nil {
+		return err
+	}
+
+	sshPublicKey, err := ssh.NewPublicKey(cryptoPublicKey)
+	if err != nil {
+		return err
+	}
+
+	publicKeyBytes := ssh.MarshalAuthorizedKey(sshPublicKey)
+	if err := os.WriteFile(pubKeyPath, publicKeyBytes, 0o644); err != nil {
+		return err
+	}
+
+	fmt.Printf("Your new public key is: \n\n%s\n", publicKeyBytes)
 	return nil
 }
 

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -12,11 +12,13 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/spf13/cobra"
+	"golang.org/x/crypto/ssh"
 
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/types/model"
@@ -2388,5 +2390,60 @@ func TestIsLocalhost(t *testing.T) {
 				t.Errorf("isLocalhost() with OLLAMA_HOST=%q = %v, want %v", tt.host, got, tt.expected)
 			}
 		})
+	}
+}
+
+func TestInitializeKeypairConcurrent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	const n = 16
+	errs := make([]error, n)
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := range n {
+		go func(i int) {
+			defer wg.Done()
+			errs[i] = initializeKeypair()
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("initializeKeypair goroutine %d: %v", i, err)
+		}
+	}
+
+	privPath := filepath.Join(home, ".ollama", "id_ed25519")
+	pubPath := filepath.Join(home, ".ollama", "id_ed25519.pub")
+	privBytes, err := os.ReadFile(privPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pubBytes, err := os.ReadFile(pubPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	signer, err := ssh.ParsePrivateKey(privBytes)
+	if err != nil {
+		t.Fatalf("parse private key: %v", err)
+	}
+	wantPub := string(ssh.MarshalAuthorizedKey(signer.PublicKey()))
+	if string(pubBytes) != wantPub {
+		t.Fatalf("public key does not match private key")
+	}
+
+	if err := initializeKeypair(); err != nil {
+		t.Fatal(err)
+	}
+	privAfter, err := os.ReadFile(privPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(privBytes, privAfter) {
+		t.Fatal("initializeKeypair overwrote an existing private key")
 	}
 }


### PR DESCRIPTION
## Summary
- Replace Stat+WriteFile TOCTOU with `O_CREAT|O_EXCL` for `~/.ollama/id_ed25519`
- Losers that lose the create race reuse the existing key
- Add concurrent + idempotent coverage
Fixes #17310
## Test plan
- [x] `go test ./cmd/ -run TestInitializeKeypairConcurrent`