### PR TITLE
server/sched: guard needsReload against nil model and llama after concurrent unload

### DIFF
--- a/server/sched.go
+++ b/server/sched.go
@@ -1395,6 +1395,13 @@ func (runner *runnerRef) needsReload(ctx context.Context, req *LlmRequest) bool 
 	runner.refMu.Lock()
 	defer runner.refMu.Unlock()
 
+	// If the runner has been unloaded concurrently (e.g., expire timer
+	// fired between loadedMu.Unlock and refMu.Lock), signal that a reload
+	// is needed to avoid nil pointer dereference on runner.model fields.
+	if runner.llama == nil || runner.model == nil {
+		return true
+	}
+
 	// Check if runner type (imagegen vs mlxrunner) matches what's requested.
 	wantImagegen := slices.Contains(req.model.Config.Capabilities, "image")
 	if runner.isImagegen != wantImagegen {

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -900,6 +900,54 @@ func TestSchedNeedsReload(t *testing.T) {
 	require.True(t, resp)
 }
 
+func TestSchedNeedsReloadNilFields(t *testing.T) {
+	t.Run("nil llama and model", func(t *testing.T) {
+		ctx, done := context.WithTimeout(t.Context(), 100*time.Millisecond)
+		defer done()
+
+		// Runner that has been unloaded (llama and model set to nil by unload())
+		runner := &runnerRef{numParallel: 1}
+		req := &LlmRequest{
+			model: &Model{},
+			opts:  api.DefaultOptions(),
+		}
+		require.True(t, runner.needsReload(ctx, req),
+			"needsReload should return true when runner.llama and runner.model are nil")
+	})
+
+	t.Run("nil model only", func(t *testing.T) {
+		ctx, done := context.WithTimeout(t.Context(), 100*time.Millisecond)
+		defer done()
+
+		runner := &runnerRef{
+			llama:       &mockLlm{vramByGPU: map[ml.DeviceID]uint64{}},
+			numParallel: 1,
+		}
+		req := &LlmRequest{
+			model: &Model{},
+			opts:  api.DefaultOptions(),
+		}
+		require.True(t, runner.needsReload(ctx, req),
+			"needsReload should return true when runner.model is nil")
+	})
+
+	t.Run("nil llama only", func(t *testing.T) {
+		ctx, done := context.WithTimeout(t.Context(), 100*time.Millisecond)
+		defer done()
+
+		runner := &runnerRef{
+			model:       &Model{},
+			numParallel: 1,
+		}
+		req := &LlmRequest{
+			model: &Model{},
+			opts:  api.DefaultOptions(),
+		}
+		require.True(t, runner.needsReload(ctx, req),
+			"needsReload should return true when runner.llama is nil")
+	})
+}
+
 func TestResolveContextShift(t *testing.T) {
 	trueValue := true
 	falseValue := false


### PR DESCRIPTION
## Summary

Fix a potential nil pointer dereference in `needsReload` that can occur when a runner is unloaded concurrently between `loadedMu.Unlock()` and `refMu.Lock()` in the scheduler's `getRunner` flow.

## The Bug

In `getRunner`, the scheduler acquires `loadedMu`, reads the runner from `s.loaded`, and releases `loadedMu` before calling `runner.needsReload()`. During this window:

1. The expire timer can fire for the runner (if `refCount == 0`)
2. `processCompleted` handles the expired event and calls `runner.unload()`
3. `unload()` sets `runner.model = nil` and `runner.llama = nil`
4. `needsReload` acquires `refMu` (blocks until step 3 completes)
5. `needsReload` accesses `runner.model.AdapterPaths` — **nil pointer dereference / panic**

This race is more likely with short `keep_alive` durations (including zero).

## The Fix

Add a nil check for `runner.llama` and `runner.model` at the top of `needsReload` (after acquiring `refMu`). When either is nil, the runner has been unloaded and we correctly signal that a reload is needed. This is consistent with the existing `runner.Options == nil` guard already present in the function.

## Testing

Added `TestSchedNeedsReloadNilFields` with three sub-tests covering nil llama, nil model, and both nil scenarios. All existing scheduler tests continue to pass.