### PR TITLE
mlxrunner: continuous batching for OLLAMA_NUM_PARALLEL

### DIFF
--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -333,6 +333,8 @@ The following server settings may be used to adjust how Ollama handles concurren
 
 - `OLLAMA_MAX_LOADED_MODELS` - The maximum number of models that can be loaded concurrently provided they fit in available memory. The default is 3 \* the number of GPUs or 3 for CPU inference.
 - `OLLAMA_NUM_PARALLEL` - The maximum number of parallel requests each model will process at the same time, default 1.  Required RAM will scale by `OLLAMA_NUM_PARALLEL` * `OLLAMA_CONTEXT_LENGTH`.
+
+For the **MLX engine** (Apple Silicon / `ollama runner --mlx-engine`), `OLLAMA_NUM_PARALLEL` enables continuous batching when the model uses standard KV caches. Prefills still run one sequence at a time; decode steps are fused across active sequences. Models that use rotating or recurrent caches fall back to serial decode. Speculative decoding is not used in the parallel path.
 - `OLLAMA_MAX_QUEUE` - The maximum number of requests Ollama will queue when busy before rejecting additional requests. The default is 512
 
 Note: Windows with Radeon GPUs currently default to 1 model maximum due to limitations in ROCm v5.7 for available VRAM reporting. Once ROCm v6.2 is available, Windows Radeon will follow the defaults above. You may enable concurrent model loads on Radeon on Windows, but ensure you don't load more models than will fit into your GPU's VRAM.

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -334,7 +334,7 @@ The following server settings may be used to adjust how Ollama handles concurren
 - `OLLAMA_MAX_LOADED_MODELS` - The maximum number of models that can be loaded concurrently provided they fit in available memory. The default is 3 \* the number of GPUs or 3 for CPU inference.
 - `OLLAMA_NUM_PARALLEL` - The maximum number of parallel requests each model will process at the same time, default 1.  Required RAM will scale by `OLLAMA_NUM_PARALLEL` * `OLLAMA_CONTEXT_LENGTH`.
 
-For the **MLX engine** (Apple Silicon / `ollama runner --mlx-engine`), `OLLAMA_NUM_PARALLEL` enables continuous batching when the model uses standard KV caches. Prefills still run one sequence at a time; decode steps are fused across active sequences. Models that use rotating or recurrent caches fall back to serial decode. Speculative decoding is not used in the parallel path.
+For the **MLX engine** (Apple Silicon / `ollama runner --mlx-engine`), `OLLAMA_NUM_PARALLEL` enables continuous batching for models with KV, rotating KV, and/or recurrent caches. Prefills still run one sequence at a time; decode steps are fused across active sequences. Speculative decoding and prefix-cache reuse are not used in the parallel path.
 - `OLLAMA_MAX_QUEUE` - The maximum number of requests Ollama will queue when busy before rejecting additional requests. The default is 512
 
 Note: Windows with Radeon GPUs currently default to 1 model maximum due to limitations in ROCm v5.7 for available VRAM reporting. Once ROCm v6.2 is available, Windows Radeon will follow the defaults above. You may enable concurrent model loads on Radeon on Windows, but ensure you don't load more models than will fit into your GPU's VRAM.

--- a/server/sched.go
+++ b/server/sched.go
@@ -594,7 +594,7 @@ func (s *Scheduler) load(req *LlmRequest, systemInfo ml.SystemInfo, gpus []ml.De
 			if slices.Contains(req.model.Config.Capabilities, "image") {
 				llama, err = imagegen.NewServer(modelName)
 			} else {
-				llama, err = mlxrunner.NewClient(modelName, req.opts.NumCtx)
+				llama, err = mlxrunner.NewClient(modelName, req.opts.NumCtx, numParallel)
 			}
 		}
 		if err != nil {

--- a/x/mlxrunner/batch/batch.go
+++ b/x/mlxrunner/batch/batch.go
@@ -17,6 +17,10 @@ type Batch struct {
 	// Length equals the batch dimension of InputIDs.
 	SeqQueryLens []int32
 
+	// SeqIDs maps each batch row to a cache sequence index for multi-sequence
+	// caches. Nil means row i uses sequence i.
+	SeqIDs []int32
+
 	// Hidden is the target hidden state a draft model fuses with its input
 	// embedding for this step. It is nil for ordinary forward passes.
 	Hidden *mlx.Array

--- a/x/mlxrunner/cache/multiseq.go
+++ b/x/mlxrunner/cache/multiseq.go
@@ -1,0 +1,193 @@
+package cache
+
+import (
+	"fmt"
+
+	"github.com/ollama/ollama/x/mlxrunner/batch"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/models/nn"
+)
+
+// MultiSeq fans a batched Forward across independent per-sequence Attention
+// caches and returns a stacked KVHistory for SDPA. Used when OLLAMA_NUM_PARALLEL > 1.
+type MultiSeq struct {
+	seqs []Attention
+}
+
+// NewMultiSeq builds a multi-sequence cache from per-sequence Attention caches.
+func NewMultiSeq(seqs []Attention) *MultiSeq {
+	if len(seqs) == 0 {
+		panic("cache.NewMultiSeq: empty")
+	}
+	return &MultiSeq{seqs: seqs}
+}
+
+// NumSeq returns the number of sequence slots.
+func (m *MultiSeq) NumSeq() int { return len(m.seqs) }
+
+// ResetSeq frees and replaces one sequence's cache with a fresh KVCache.
+// Only plain KVCache sequences are supported for parallel decode.
+func (m *MultiSeq) ResetSeq(i int) error {
+	if i < 0 || i >= len(m.seqs) {
+		return fmt.Errorf("sequence %d out of range", i)
+	}
+	if _, ok := m.seqs[i].(*KVCache); !ok {
+		return fmt.Errorf("sequence %d is not a KVCache", i)
+	}
+	m.seqs[i].Free()
+	m.seqs[i] = NewKVCache()
+	return nil
+}
+
+func (m *MultiSeq) seqIndex(b *batch.Batch, row int) int {
+	if b != nil && row < len(b.SeqIDs) {
+		return int(b.SeqIDs[row])
+	}
+	return row
+}
+
+func (m *MultiSeq) Update(b *batch.Batch, keys, values *mlx.Array) *nn.KVHistory {
+	B := keys.Dim(0)
+	for i := range B {
+		seq := m.seqIndex(b, i)
+		if seq < 0 || seq >= len(m.seqs) {
+			panic(fmt.Sprintf("cache.MultiSeq: seq id %d out of range [0,%d)", seq, len(m.seqs)))
+		}
+		rowBatch := &batch.Batch{
+			InputIDs:     b.InputIDs,
+			SeqOffsets:   []int32{b.SeqOffsets[i]},
+			SeqQueryLens: []int32{b.SeqQueryLens[i]},
+		}
+		k := keys.Slice(mlx.Slice(i, i+1), mlx.Slice(), mlx.Slice(), mlx.Slice())
+		v := values.Slice(mlx.Slice(i, i+1), mlx.Slice(), mlx.Slice(), mlx.Slice())
+		_ = m.seqs[seq].Update(rowBatch, k, v)
+	}
+	return m.stack(b)
+}
+
+func (m *MultiSeq) View(b *batch.Batch) *nn.KVHistory {
+	return m.stack(b)
+}
+
+func (m *MultiSeq) stack(b *batch.Batch) *nn.KVHistory {
+	B := len(b.SeqOffsets)
+	histories := make([]*nn.KVHistory, B)
+	kLens := make([]int32, B)
+	maxK := 0
+	dtype := mlx.DTypeFloat16
+	var H, Dk, Dv int
+	for i := range B {
+		seq := m.seqIndex(b, i)
+		rowBatch := &batch.Batch{
+			SeqOffsets:   []int32{b.SeqOffsets[i]},
+			SeqQueryLens: []int32{b.SeqQueryLens[i]},
+		}
+		h := m.seqs[seq].View(rowBatch)
+		histories[i] = h
+		if h == nil || h.K() == nil {
+			kLens[i] = 0
+			continue
+		}
+		k := h.K()
+		dtype = k.DType()
+		H, Dk = k.Dim(1), k.Dim(3)
+		Dv = h.V().Dim(3)
+		kLens[i] = int32(k.Dim(2))
+		if int(kLens[i]) > maxK {
+			maxK = int(kLens[i])
+		}
+	}
+	if maxK == 0 {
+		return nn.NewKVHistory(nil, nil, nil)
+	}
+
+	stackedK := mlx.Zeros(dtype, B, H, maxK, Dk)
+	stackedV := mlx.Zeros(dtype, B, H, maxK, Dv)
+	for i, h := range histories {
+		if h == nil || h.K() == nil || kLens[i] == 0 {
+			continue
+		}
+		n := int(kLens[i])
+		stackedK.Set(stackedK.SliceUpdate(h.K(), mlx.Slice(i, i+1), mlx.Slice(), mlx.Slice(0, n), mlx.Slice()))
+		stackedV.Set(stackedV.SliceUpdate(h.V(), mlx.Slice(i, i+1), mlx.Slice(), mlx.Slice(0, n), mlx.Slice()))
+	}
+	return nn.NewKVHistory(stackedK, stackedV, kLensApplier{b: b, K: maxK, kLens: kLens, dtype: dtype})
+}
+
+type kLensApplier struct {
+	b     *batch.Batch
+	K     int
+	kLens []int32
+	dtype mlx.DType
+}
+
+func (a kLensApplier) ApplyMask(logical nn.AttentionMask) nn.AttentionMask {
+	return logical.Intersect(nn.KPaddingMask(a.b, a.K, a.kLens, a.dtype))
+}
+
+func (m *MultiSeq) State() []*mlx.Array {
+	var out []*mlx.Array
+	for _, s := range m.seqs {
+		out = append(out, s.State()...)
+	}
+	return out
+}
+
+func (m *MultiSeq) Free() {
+	for _, s := range m.seqs {
+		s.Free()
+	}
+}
+
+func (m *MultiSeq) Offset() int {
+	max := 0
+	for _, s := range m.seqs {
+		if o := s.Offset(); o > max {
+			max = o
+		}
+	}
+	return max
+}
+
+// Snapshot/Prepare/Take/Restore/Merge/Split are unused when the prefix trie is
+// disabled for parallel > 1. They panic so misuse is obvious.
+func (m *MultiSeq) Snapshot(int) Snapshot {
+	panic("cache.MultiSeq: Snapshot not supported")
+}
+func (m *MultiSeq) PrepareSnapshots([]int) {
+	panic("cache.MultiSeq: PrepareSnapshots not supported")
+}
+func (m *MultiSeq) TakeSnapshots() []Snapshot {
+	panic("cache.MultiSeq: TakeSnapshots not supported")
+}
+func (m *MultiSeq) Restore(Snapshot, int) bool {
+	panic("cache.MultiSeq: Restore not supported")
+}
+func (m *MultiSeq) Merge(Snapshot, Snapshot) Snapshot {
+	panic("cache.MultiSeq: Merge not supported")
+}
+func (m *MultiSeq) Split(Snapshot, int) (Snapshot, Snapshot) {
+	panic("cache.MultiSeq: Split not supported")
+}
+
+// WrapParallelCaches replaces each plain KVCache layer with a MultiSeq of n
+// sequences. Returns ok=false when any layer is not a *KVCache.
+func WrapParallelCaches(caches []Cache, n int) ([]Cache, bool) {
+	if n <= 1 {
+		return caches, true
+	}
+	out := make([]Cache, len(caches))
+	for i, c := range caches {
+		kv, ok := c.(*KVCache)
+		if !ok {
+			return nil, false
+		}
+		seqs := make([]Attention, n)
+		seqs[0] = kv
+		for j := 1; j < n; j++ {
+			seqs[j] = NewKVCache()
+		}
+		out[i] = NewMultiSeq(seqs)
+	}
+	return out, true
+}

--- a/x/mlxrunner/cache/multiseq.go
+++ b/x/mlxrunner/cache/multiseq.go
@@ -25,18 +25,30 @@ func NewMultiSeq(seqs []Attention) *MultiSeq {
 // NumSeq returns the number of sequence slots.
 func (m *MultiSeq) NumSeq() int { return len(m.seqs) }
 
-// ResetSeq frees and replaces one sequence's cache with a fresh KVCache.
-// Only plain KVCache sequences are supported for parallel decode.
+// ResetSeq frees and replaces one sequence's Attention cache with a fresh
+// instance of the same type (KV or rotating).
 func (m *MultiSeq) ResetSeq(i int) error {
 	if i < 0 || i >= len(m.seqs) {
 		return fmt.Errorf("sequence %d out of range", i)
 	}
-	if _, ok := m.seqs[i].(*KVCache); !ok {
-		return fmt.Errorf("sequence %d is not a KVCache", i)
+	fresh, ok := cloneAttention(m.seqs[i])
+	if !ok {
+		return fmt.Errorf("sequence %d: unsupported attention cache %T", i, m.seqs[i])
 	}
 	m.seqs[i].Free()
-	m.seqs[i] = NewKVCache()
+	m.seqs[i] = fresh
 	return nil
+}
+
+func cloneAttention(c Attention) (Attention, bool) {
+	switch t := c.(type) {
+	case *KVCache:
+		return NewKVCache(), true
+	case *RotatingKVCache:
+		return NewRotatingKVCache(t.maxSize), true
+	default:
+		return nil, false
+	}
 }
 
 func (m *MultiSeq) seqIndex(b *batch.Batch, row int) int {
@@ -170,24 +182,40 @@ func (m *MultiSeq) Split(Snapshot, int) (Snapshot, Snapshot) {
 	panic("cache.MultiSeq: Split not supported")
 }
 
-// WrapParallelCaches replaces each plain KVCache layer with a MultiSeq of n
-// sequences. Returns ok=false when any layer is not a *KVCache.
+// WrapParallelCaches replaces each supported layer with an n-way multi-seq
+// cache. Supports *KVCache, *RotatingKVCache, and *RecurrentCache. Returns
+// ok=false when any layer type is unsupported.
 func WrapParallelCaches(caches []Cache, n int) ([]Cache, bool) {
 	if n <= 1 {
 		return caches, true
 	}
 	out := make([]Cache, len(caches))
 	for i, c := range caches {
-		kv, ok := c.(*KVCache)
-		if !ok {
+		switch t := c.(type) {
+		case *KVCache:
+			seqs := make([]Attention, n)
+			seqs[0] = t
+			for j := 1; j < n; j++ {
+				seqs[j] = NewKVCache()
+			}
+			out[i] = NewMultiSeq(seqs)
+		case *RotatingKVCache:
+			seqs := make([]Attention, n)
+			seqs[0] = t
+			for j := 1; j < n; j++ {
+				seqs[j] = NewRotatingKVCache(t.maxSize)
+			}
+			out[i] = NewMultiSeq(seqs)
+		case *RecurrentCache:
+			seqs := make([]*RecurrentCache, n)
+			seqs[0] = t
+			for j := 1; j < n; j++ {
+				seqs[j] = NewRecurrentCache(int32(t.convTail), int32(t.convDim), int32(t.numVHeads), int32(t.headVDim), int32(t.headKDim))
+			}
+			out[i] = NewMultiSeqRecurrent(seqs)
+		default:
 			return nil, false
 		}
-		seqs := make([]Attention, n)
-		seqs[0] = kv
-		for j := 1; j < n; j++ {
-			seqs[j] = NewKVCache()
-		}
-		out[i] = NewMultiSeq(seqs)
 	}
 	return out, true
 }

--- a/x/mlxrunner/cache/multiseq_recurrent.go
+++ b/x/mlxrunner/cache/multiseq_recurrent.go
@@ -1,0 +1,157 @@
+package cache
+
+import (
+	"fmt"
+
+	"github.com/ollama/ollama/x/mlxrunner/batch"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/models/nn"
+)
+
+// Recurrent is the subset of RecurrentCache used by model Forward paths.
+type Recurrent interface {
+	Get(b *batch.Batch, dtype mlx.DType) *nn.RecurrentHistory
+	Put(b *batch.Batch, convStates, deltaStates []*mlx.Array)
+	SnapshotSplits(forwardLen int) []int
+}
+
+// MultiSeqRecurrent fans a batched recurrent Forward across per-sequence
+// RecurrentCaches. Each sequence keeps B=1 state so the active set can change.
+type MultiSeqRecurrent struct {
+	seqs []*RecurrentCache
+
+	convTail  int32
+	convDim   int32
+	numVHeads int32
+	headVDim  int32
+	headKDim  int32
+}
+
+// NewMultiSeqRecurrent builds a multi-sequence recurrent cache.
+func NewMultiSeqRecurrent(seqs []*RecurrentCache) *MultiSeqRecurrent {
+	if len(seqs) == 0 {
+		panic("cache.NewMultiSeqRecurrent: empty")
+	}
+	s0 := seqs[0]
+	return &MultiSeqRecurrent{
+		seqs:      seqs,
+		convTail:  int32(s0.convTail),
+		convDim:   int32(s0.convDim),
+		numVHeads: int32(s0.numVHeads),
+		headVDim:  int32(s0.headVDim),
+		headKDim:  int32(s0.headKDim),
+	}
+}
+
+func (m *MultiSeqRecurrent) NumSeq() int { return len(m.seqs) }
+
+func (m *MultiSeqRecurrent) ResetSeq(i int) error {
+	if i < 0 || i >= len(m.seqs) {
+		return fmt.Errorf("sequence %d out of range", i)
+	}
+	m.seqs[i].Free()
+	m.seqs[i] = NewRecurrentCache(m.convTail, m.convDim, m.numVHeads, m.headVDim, m.headKDim)
+	return nil
+}
+
+func (m *MultiSeqRecurrent) seqIndex(b *batch.Batch, row int) int {
+	if b != nil && row < len(b.SeqIDs) {
+		return int(b.SeqIDs[row])
+	}
+	return row
+}
+
+func (m *MultiSeqRecurrent) Get(b *batch.Batch, dtype mlx.DType) *nn.RecurrentHistory {
+	B := b.InputIDs.Dim(0)
+	var convRows, deltaRows []*mlx.Array
+	for i := range B {
+		seq := m.seqIndex(b, i)
+		rowBatch := &batch.Batch{
+			InputIDs:     b.InputIDs.Slice(mlx.Slice(i, i+1), mlx.Slice()),
+			SeqOffsets:   []int32{b.SeqOffsets[i]},
+			SeqQueryLens: []int32{b.SeqQueryLens[i]},
+		}
+		h := m.seqs[seq].Get(rowBatch, dtype)
+		convRows = append(convRows, h.ConvState())
+		deltaRows = append(deltaRows, h.DeltaState())
+	}
+	return nn.NewRecurrentHistory(stackRows(convRows), stackRows(deltaRows))
+}
+
+func (m *MultiSeqRecurrent) Put(b *batch.Batch, convStates, deltaStates []*mlx.Array) {
+	// Parallel path does not segment recurrent kernels for prefix snapshots.
+	if len(convStates) == 0 || len(deltaStates) == 0 {
+		panic("cache.MultiSeqRecurrent: empty boundary states")
+	}
+	convEnd := convStates[len(convStates)-1]
+	deltaEnd := deltaStates[len(deltaStates)-1]
+	B := b.InputIDs.Dim(0)
+	for i := range B {
+		seq := m.seqIndex(b, i)
+		rowBatch := &batch.Batch{
+			InputIDs:     b.InputIDs.Slice(mlx.Slice(i, i+1), mlx.Slice()),
+			SeqOffsets:   []int32{b.SeqOffsets[i]},
+			SeqQueryLens: []int32{b.SeqQueryLens[i]},
+		}
+		m.seqs[seq].Put(rowBatch,
+			[]*mlx.Array{convEnd.Slice(mlx.Slice(i, i+1), mlx.Slice(), mlx.Slice())},
+			[]*mlx.Array{deltaEnd.Slice(mlx.Slice(i, i+1), mlx.Slice(), mlx.Slice(), mlx.Slice())},
+		)
+	}
+}
+
+func (m *MultiSeqRecurrent) SnapshotSplits(int) []int { return nil }
+
+func stackRows(rows []*mlx.Array) *mlx.Array {
+	if len(rows) == 1 {
+		return rows[0]
+	}
+	out := rows[0]
+	for _, r := range rows[1:] {
+		out = out.Concatenate(0, r)
+	}
+	return out
+}
+
+func (m *MultiSeqRecurrent) State() []*mlx.Array {
+	var out []*mlx.Array
+	for _, s := range m.seqs {
+		out = append(out, s.State()...)
+	}
+	return out
+}
+
+func (m *MultiSeqRecurrent) Free() {
+	for _, s := range m.seqs {
+		s.Free()
+	}
+}
+
+func (m *MultiSeqRecurrent) Offset() int {
+	max := 0
+	for _, s := range m.seqs {
+		if o := s.Offset(); o > max {
+			max = o
+		}
+	}
+	return max
+}
+
+func (m *MultiSeqRecurrent) Snapshot(int) Snapshot {
+	panic("cache.MultiSeqRecurrent: Snapshot not supported")
+}
+func (m *MultiSeqRecurrent) PrepareSnapshots([]int) {
+	panic("cache.MultiSeqRecurrent: PrepareSnapshots not supported")
+}
+func (m *MultiSeqRecurrent) TakeSnapshots() []Snapshot {
+	panic("cache.MultiSeqRecurrent: TakeSnapshots not supported")
+}
+func (m *MultiSeqRecurrent) Restore(Snapshot, int) bool {
+	panic("cache.MultiSeqRecurrent: Restore not supported")
+}
+func (m *MultiSeqRecurrent) Merge(Snapshot, Snapshot) Snapshot {
+	panic("cache.MultiSeqRecurrent: Merge not supported")
+}
+func (m *MultiSeqRecurrent) Split(Snapshot, int) (Snapshot, Snapshot) {
+	panic("cache.MultiSeqRecurrent: Split not supported")
+}

--- a/x/mlxrunner/cache/multiseq_test.go
+++ b/x/mlxrunner/cache/multiseq_test.go
@@ -1,0 +1,40 @@
+package cache
+
+import "testing"
+
+func TestWrapParallelCaches(t *testing.T) {
+	caches := []Cache{NewKVCache(), NewKVCache()}
+	wrapped, ok := WrapParallelCaches(caches, 4)
+	if !ok {
+		t.Fatal("expected WrapParallelCaches to succeed for KVCache layers")
+	}
+	if len(wrapped) != 2 {
+		t.Fatalf("len=%d want 2", len(wrapped))
+	}
+	for i, c := range wrapped {
+		ms, ok := c.(*MultiSeq)
+		if !ok {
+			t.Fatalf("layer %d: got %T, want *MultiSeq", i, c)
+		}
+		if ms.NumSeq() != 4 {
+			t.Fatalf("layer %d: NumSeq=%d want 4", i, ms.NumSeq())
+		}
+	}
+}
+
+func TestWrapParallelCachesRejectsRotating(t *testing.T) {
+	caches := []Cache{NewRotatingKVCache(128)}
+	if _, ok := WrapParallelCaches(caches, 2); ok {
+		t.Fatal("expected WrapParallelCaches to reject rotating cache")
+	}
+}
+
+func TestMultiSeqResetSeq(t *testing.T) {
+	ms := NewMultiSeq([]Attention{NewKVCache(), NewKVCache()})
+	if err := ms.ResetSeq(1); err != nil {
+		t.Fatal(err)
+	}
+	if err := ms.ResetSeq(2); err == nil {
+		t.Fatal("expected out of range error")
+	}
+}

--- a/x/mlxrunner/cache/multiseq_test.go
+++ b/x/mlxrunner/cache/multiseq_test.go
@@ -22,19 +22,63 @@ func TestWrapParallelCaches(t *testing.T) {
 	}
 }
 
-func TestWrapParallelCachesRejectsRotating(t *testing.T) {
-	caches := []Cache{NewRotatingKVCache(128)}
+func TestWrapParallelCachesRotatingAndRecurrent(t *testing.T) {
+	caches := []Cache{
+		NewKVCache(),
+		NewRotatingKVCache(128),
+		NewRecurrentCache(3, 64, 4, 16, 16),
+	}
+	wrapped, ok := WrapParallelCaches(caches, 2)
+	if !ok {
+		t.Fatal("expected WrapParallelCaches to succeed for KV/rotating/recurrent mix")
+	}
+	if _, ok := wrapped[0].(*MultiSeq); !ok {
+		t.Fatalf("layer 0: got %T, want *MultiSeq", wrapped[0])
+	}
+	if _, ok := wrapped[1].(*MultiSeq); !ok {
+		t.Fatalf("layer 1: got %T, want *MultiSeq", wrapped[1])
+	}
+	mr, ok := wrapped[2].(*MultiSeqRecurrent)
+	if !ok {
+		t.Fatalf("layer 2: got %T, want *MultiSeqRecurrent", wrapped[2])
+	}
+	if mr.NumSeq() != 2 {
+		t.Fatalf("recurrent NumSeq=%d want 2", mr.NumSeq())
+	}
+}
+
+func TestWrapParallelCachesRejectsUnknown(t *testing.T) {
+	caches := []Cache{nil}
 	if _, ok := WrapParallelCaches(caches, 2); ok {
-		t.Fatal("expected WrapParallelCaches to reject rotating cache")
+		t.Fatal("expected WrapParallelCaches to reject nil layer")
 	}
 }
 
 func TestMultiSeqResetSeq(t *testing.T) {
-	ms := NewMultiSeq([]Attention{NewKVCache(), NewKVCache()})
+	ms := NewMultiSeq([]Attention{NewKVCache(), NewRotatingKVCache(32)})
+	if err := ms.ResetSeq(0); err != nil {
+		t.Fatal(err)
+	}
 	if err := ms.ResetSeq(1); err != nil {
 		t.Fatal(err)
 	}
+	if _, ok := ms.seqs[1].(*RotatingKVCache); !ok {
+		t.Fatalf("after reset got %T, want *RotatingKVCache", ms.seqs[1])
+	}
 	if err := ms.ResetSeq(2); err == nil {
+		t.Fatal("expected out of range error")
+	}
+}
+
+func TestMultiSeqRecurrentResetSeq(t *testing.T) {
+	mr := NewMultiSeqRecurrent([]*RecurrentCache{
+		NewRecurrentCache(3, 64, 4, 16, 16),
+		NewRecurrentCache(3, 64, 4, 16, 16),
+	})
+	if err := mr.ResetSeq(1); err != nil {
+		t.Fatal(err)
+	}
+	if err := mr.ResetSeq(2); err == nil {
 		t.Fatal("expected out of range error")
 	}
 }

--- a/x/mlxrunner/client.go
+++ b/x/mlxrunner/client.go
@@ -21,6 +21,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"golang.org/x/sync/semaphore"
+
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/envconfig"
 	"github.com/ollama/ollama/format"
@@ -36,6 +38,8 @@ type Client struct {
 	modelName         string
 	contextLength     atomic.Int64
 	softContextLength int // recommended limit to avoid poor performance
+	numParallel       int
+	sem               *semaphore.Weighted
 	memory            atomic.Uint64
 	done              chan struct{}
 	doneErr           error // valid after done is closed
@@ -47,14 +51,19 @@ type Client struct {
 
 // NewClient prepares a new MLX runner client for LLM models.
 // The subprocess is not started until Load() is called.
-func NewClient(modelName string, softContextLength int) (*Client, error) {
+func NewClient(modelName string, softContextLength, numParallel int) (*Client, error) {
 	if err := imagegen.CheckPlatformSupport(); err != nil {
 		return nil, err
+	}
+	if numParallel < 1 {
+		numParallel = 1
 	}
 
 	c := &Client{
 		modelName:         modelName,
 		softContextLength: softContextLength,
+		numParallel:       numParallel,
+		sem:               semaphore.NewWeighted(int64(numParallel)),
 		done:              make(chan struct{}),
 		client:            http.DefaultClient,
 	}
@@ -140,6 +149,11 @@ func (c *Client) Close() error {
 
 // Completion implements llm.LlamaServer.
 func (c *Client) Completion(ctx context.Context, req llm.CompletionRequest, fn func(llm.CompletionResponse)) error {
+	if err := c.sem.Acquire(ctx, 1); err != nil {
+		return err
+	}
+	defer c.sem.Release(1)
+
 	creq := CompletionRequest{
 		Prompt:      req.Prompt,
 		Logprobs:    req.Logprobs,
@@ -305,8 +319,8 @@ func (c *Client) Load(ctx context.Context, _ ml.SystemInfo, gpus []ml.DeviceInfo
 		exe = eval
 	}
 
-	// Spawn subprocess: ollama runner --mlx-engine --model <name> --port <port>
-	cmd := exec.Command(exe, "runner", "--mlx-engine", "--model", c.modelName, "--port", strconv.Itoa(port))
+	// Spawn subprocess: ollama runner --mlx-engine --model <name> --port <port> --parallel <n>
+	cmd := exec.Command(exe, "runner", "--mlx-engine", "--model", c.modelName, "--port", strconv.Itoa(port), "--parallel", strconv.Itoa(c.numParallel))
 	cmd.Env = os.Environ()
 
 	// Set library path environment variable for MLX libraries

--- a/x/mlxrunner/client.go
+++ b/x/mlxrunner/client.go
@@ -280,6 +280,16 @@ func (c *Client) HasExited() bool {
 func (c *Client) Load(ctx context.Context, _ ml.SystemInfo, gpus []ml.DeviceInfo, requireFull bool) ([]ml.DeviceID, error) {
 	if len(gpus) > 0 {
 		modelSize := c.memory.Load()
+		// KV working set scales with parallel sequences × context.
+		// ponytail: ~2 KiB/token/seq is a coarse fit check, not exact accounting.
+		required := modelSize
+		if c.numParallel > 1 {
+			ctxLen := c.softContextLength
+			if ctxLen <= 0 {
+				ctxLen = 2048
+			}
+			required += uint64(c.numParallel) * uint64(ctxLen) * 2048
+		}
 		// We currently only use the first GPU with MLX
 		available := gpus[0].FreeMemory
 		overhead := gpus[0].MinimumMemory() + envconfig.GpuOverhead()
@@ -289,11 +299,11 @@ func (c *Client) Load(ctx context.Context, _ ml.SystemInfo, gpus []ml.DeviceInfo
 			available = 0
 		}
 
-		if modelSize > available {
+		if required > available {
 			if requireFull {
 				return nil, llm.ErrLoadRequiredFull
 			}
-			return nil, fmt.Errorf("model requires %s but only %s are available (after %s overhead)", format.HumanBytes2(modelSize), format.HumanBytes2(available), format.HumanBytes2(overhead))
+			return nil, fmt.Errorf("model requires %s but only %s are available (after %s overhead)", format.HumanBytes2(required), format.HumanBytes2(available), format.HumanBytes2(overhead))
 		}
 	}
 

--- a/x/mlxrunner/continuous.go
+++ b/x/mlxrunner/continuous.go
@@ -1,0 +1,326 @@
+package mlxrunner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/x/mlxrunner/batch"
+	"github.com/ollama/ollama/x/mlxrunner/cache"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	sampler "github.com/ollama/ollama/x/mlxrunner/sample"
+)
+
+// genSlot is one parallel generation sequence in the continuous batcher.
+type genSlot struct {
+	id         int
+	req        Request
+	position   int
+	promptLen  int
+	generated  int
+	promptEval time.Duration
+	detok      detokenizer
+	done       bool
+	err        error
+	// nextInput is the token id array shape [1] to feed on the next decode step.
+	nextInput *mlx.Array
+	started   time.Time
+}
+
+// runContinuousBatcher admits up to numParallel requests and fuses decode
+// steps across active slots. Prefills run one slot at a time into a shared
+// MultiSeq cache. Speculation and prefix-trie reuse are disabled.
+//
+// ponytail: rotating/recurrent caches are not wrapped — only enabled when
+// WrapParallelCaches succeeded.
+func (r *Runner) runContinuousBatcher(ctx context.Context) error {
+	slots := make([]*genSlot, r.numParallel)
+	caches := r.parallelCaches
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+
+		admitted := false
+		for i := range slots {
+			if slots[i] != nil {
+				continue
+			}
+			select {
+			case <-ctx.Done():
+				return nil
+			case req := <-r.Requests:
+				admitted = true
+				if err := r.resetParallelSeq(caches, i); err != nil {
+					r.failRequest(req, err)
+					continue
+				}
+				slot, err := r.prefillSlot(req.Ctx, caches, i, req)
+				if err != nil {
+					r.failRequest(req, err)
+					continue
+				}
+				slots[i] = slot
+			default:
+			}
+		}
+
+		active := make([]*genSlot, 0, r.numParallel)
+		for _, s := range slots {
+			if s != nil && !s.done {
+				active = append(active, s)
+			}
+		}
+		if len(active) == 0 {
+			if admitted {
+				continue
+			}
+			select {
+			case <-ctx.Done():
+				return nil
+			case req := <-r.Requests:
+				if err := r.resetParallelSeq(caches, 0); err != nil {
+					r.failRequest(req, err)
+					continue
+				}
+				slot, err := r.prefillSlot(req.Ctx, caches, 0, req)
+				if err != nil {
+					r.failRequest(req, err)
+					continue
+				}
+				slots[0] = slot
+			}
+			continue
+		}
+
+		if err := r.decodeBatchStep(caches, active); err != nil {
+			for _, s := range active {
+				if !s.done {
+					s.err = err
+					s.done = true
+				}
+			}
+		}
+
+		for i, s := range slots {
+			if s == nil || !s.done {
+				continue
+			}
+			r.finishSlot(s)
+			r.Sampler.Remove(s.id)
+			slots[i] = nil
+		}
+	}
+}
+
+func (r *Runner) failRequest(req Request, err error) {
+	slog.Info("Request terminated", "error", err)
+	var statusErr api.StatusError
+	if !errors.As(err, &statusErr) {
+		statusErr = api.StatusError{
+			StatusCode:   http.StatusInternalServerError,
+			ErrorMessage: err.Error(),
+		}
+	}
+	select {
+	case req.Responses <- CompletionResponse{Error: &statusErr}:
+	case <-req.Ctx.Done():
+	}
+	close(req.Responses)
+}
+
+func (r *Runner) resetParallelSeq(caches []cache.Cache, seq int) error {
+	for _, c := range caches {
+		ms, ok := c.(*cache.MultiSeq)
+		if !ok {
+			return fmt.Errorf("expected MultiSeq cache")
+		}
+		if err := ms.ResetSeq(seq); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *Runner) prefillSlot(ctx context.Context, caches []cache.Cache, seq int, req Request) (*genSlot, error) {
+	mlx.ResetPeakMemory()
+	tokens := req.Tokens
+	position := 0
+	start := time.Now()
+	prefillChunk := prefillChunkSize()
+
+	materialize := func() {
+		state := make([]*mlx.Array, 0, 2*len(caches))
+		for _, c := range caches {
+			state = append(state, c.State()...)
+		}
+		if len(state) > 0 {
+			mlx.Eval(state...)
+		}
+	}
+
+	total, processed := len(tokens), 0
+	for total-processed > 1 {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		n := min(prefillChunk, total-processed-1)
+		chunkIDs := mlx.FromValues(tokens[processed:processed+n], 1, n)
+		_ = r.Model.Forward(&batch.Batch{
+			InputIDs:     chunkIDs,
+			SeqOffsets:   []int32{int32(position)},
+			SeqQueryLens: []int32{int32(n)},
+			SeqIDs:       []int32{int32(seq)},
+		}, caches)
+		mlx.Sweep()
+		materialize()
+		processed += n
+		position += n
+		slog.Info("Prompt processing progress", "slot", seq, "processed", processed, "total", total)
+		mlx.ClearCache()
+	}
+
+	seed := mlx.NewArrayInt32([]int32{tokens[processed]}, []int32{1})
+	r.Sampler.Add(seq, req.SamplerOpts, req.Tokens)
+
+	return &genSlot{
+		id:         seq,
+		req:        req,
+		position:   position,
+		promptLen:  len(req.Tokens),
+		promptEval: time.Since(start),
+		nextInput:  seed,
+		started:    time.Now(),
+		detok: detokenizer{
+			tokenizer:       r.Tokenizer,
+			wantLogprobs:    req.SamplerOpts.Logprobs,
+			wantTopLogprobs: req.SamplerOpts.TopLogprobs,
+		},
+	}, nil
+}
+
+func (r *Runner) decodeBatchStep(caches []cache.Cache, active []*genSlot) error {
+	B := len(active)
+	tokenIDs := make([]int32, B)
+	offsets := make([]int32, B)
+	qLens := make([]int32, B)
+	seqIDs := make([]int32, B)
+	slotIDs := make([]int, B)
+
+	for i, s := range active {
+		if err := s.req.Ctx.Err(); err != nil {
+			s.done = true
+			s.err = err
+			continue
+		}
+		tokenIDs[i] = int32(s.nextInput.Int())
+		offsets[i] = int32(s.position)
+		qLens[i] = 1
+		seqIDs[i] = int32(s.id)
+		slotIDs[i] = s.id
+	}
+
+	// Drop slots cancelled before the forward.
+	alive := active[:0]
+	aliveIDs := tokenIDs[:0]
+	aliveOff := offsets[:0]
+	aliveQ := qLens[:0]
+	aliveSeq := seqIDs[:0]
+	aliveSlots := slotIDs[:0]
+	for i, s := range active {
+		if s.done {
+			continue
+		}
+		alive = append(alive, s)
+		aliveIDs = append(aliveIDs, tokenIDs[i])
+		aliveOff = append(aliveOff, offsets[i])
+		aliveQ = append(aliveQ, qLens[i])
+		aliveSeq = append(aliveSeq, seqIDs[i])
+		aliveSlots = append(aliveSlots, slotIDs[i])
+	}
+	active = alive
+	if len(active) == 0 {
+		return nil
+	}
+	B = len(active)
+
+	input := mlx.FromValues(aliveIDs, B, 1)
+	hidden := r.Model.Forward(&batch.Batch{
+		InputIDs:     input,
+		SeqOffsets:   aliveOff,
+		SeqQueryLens: aliveQ,
+		SeqIDs:       aliveSeq,
+	}, caches)
+	for _, s := range active {
+		s.position++
+	}
+
+	logits := r.Model.Unembed(hidden)
+	rowLogits := logits.Slice(mlx.Slice(), mlx.Slice(logits.Dim(1)-1), mlx.Slice()).Squeeze(1)
+	next := r.Sampler.Sample(aliveSlots, rowLogits)
+	mlx.Pin(next.Arrays()...)
+	mlx.Sweep()
+	mlx.Eval(next.Arrays()...)
+
+	for i, s := range active {
+		tok := next.Token.Slice(mlx.Slice(i)).Squeeze(0)
+		id := int32(tok.Int())
+		s.nextInput = mlx.NewArrayInt32([]int32{id}, []int32{1})
+
+		if r.Tokenizer.IsEOS(id) {
+			s.done = true
+			r.emitFinal(s, 0)
+			continue
+		}
+		s.generated++
+		res := sampler.Result{Token: tok}
+		if next.Logprob != nil {
+			res.Logprob = next.Logprob.Slice(mlx.Slice(i), mlx.Slice())
+		}
+		resp, ok := s.detok.detokenize(res)
+		if ok {
+			select {
+			case <-s.req.Ctx.Done():
+				s.done = true
+				s.err = s.req.Ctx.Err()
+				continue
+			case s.req.Responses <- resp:
+			}
+		}
+		if s.generated >= s.req.Options.NumPredict {
+			s.done = true
+			r.emitFinal(s, 1)
+		}
+	}
+	mlx.Unpin(next.Arrays()...)
+	mlx.ClearCache()
+	return nil
+}
+
+func (r *Runner) emitFinal(s *genSlot, reason int) {
+	final := CompletionResponse{
+		Done:               true,
+		PromptEvalCount:    s.promptLen,
+		EvalCount:          s.generated,
+		DoneReason:         reason,
+		PromptEvalDuration: s.promptEval,
+		EvalDuration:       time.Since(s.started),
+	}
+	select {
+	case <-s.req.Ctx.Done():
+		s.err = s.req.Ctx.Err()
+	case s.req.Responses <- final:
+	}
+}
+
+func (r *Runner) finishSlot(s *genSlot) {
+	close(s.req.Responses)
+	slog.Info("peak memory", "slot", s.id, "size", mlx.PrettyBytes(mlx.PeakMemory()))
+}

--- a/x/mlxrunner/continuous.go
+++ b/x/mlxrunner/continuous.go
@@ -33,10 +33,7 @@ type genSlot struct {
 
 // runContinuousBatcher admits up to numParallel requests and fuses decode
 // steps across active slots. Prefills run one slot at a time into a shared
-// MultiSeq cache. Speculation and prefix-trie reuse are disabled.
-//
-// ponytail: rotating/recurrent caches are not wrapped — only enabled when
-// WrapParallelCaches succeeded.
+// multi-seq cache. Speculation and prefix-trie reuse are disabled.
 func (r *Runner) runContinuousBatcher(ctx context.Context) error {
 	slots := make([]*genSlot, r.numParallel)
 	caches := r.parallelCaches
@@ -138,12 +135,17 @@ func (r *Runner) failRequest(req Request, err error) {
 
 func (r *Runner) resetParallelSeq(caches []cache.Cache, seq int) error {
 	for _, c := range caches {
-		ms, ok := c.(*cache.MultiSeq)
-		if !ok {
-			return fmt.Errorf("expected MultiSeq cache")
-		}
-		if err := ms.ResetSeq(seq); err != nil {
-			return err
+		switch t := c.(type) {
+		case *cache.MultiSeq:
+			if err := t.ResetSeq(seq); err != nil {
+				return err
+			}
+		case *cache.MultiSeqRecurrent:
+			if err := t.ResetSeq(seq); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("expected multi-seq cache, got %T", c)
 		}
 	}
 	return nil
@@ -321,6 +323,20 @@ func (r *Runner) emitFinal(s *genSlot, reason int) {
 }
 
 func (r *Runner) finishSlot(s *genSlot) {
+	if s.err != nil {
+		var statusErr api.StatusError
+		if !errors.As(s.err, &statusErr) {
+			statusErr = api.StatusError{
+				StatusCode:   http.StatusInternalServerError,
+				ErrorMessage: s.err.Error(),
+			}
+		}
+		select {
+		case s.req.Responses <- CompletionResponse{Error: &statusErr}:
+		case <-s.req.Ctx.Done():
+		default:
+		}
+	}
 	close(s.req.Responses)
 	slog.Info("peak memory", "slot", s.id, "size", mlx.PrettyBytes(mlx.PeakMemory()))
 }

--- a/x/mlxrunner/continuous_test.go
+++ b/x/mlxrunner/continuous_test.go
@@ -1,0 +1,33 @@
+package mlxrunner
+
+import (
+	"testing"
+
+	"github.com/ollama/ollama/x/mlxrunner/cache"
+)
+
+func TestResetParallelSeqMixedCaches(t *testing.T) {
+	r := &Runner{}
+	caches := []cache.Cache{
+		cache.NewMultiSeq([]cache.Attention{cache.NewKVCache(), cache.NewKVCache()}),
+		cache.NewMultiSeq([]cache.Attention{cache.NewRotatingKVCache(16), cache.NewRotatingKVCache(16)}),
+		cache.NewMultiSeqRecurrent([]*cache.RecurrentCache{
+			cache.NewRecurrentCache(2, 8, 1, 4, 4),
+			cache.NewRecurrentCache(2, 8, 1, 4, 4),
+		}),
+	}
+	if err := r.resetParallelSeq(caches, 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.resetParallelSeq(caches, 0); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestResetParallelSeqRejectsPlain(t *testing.T) {
+	r := &Runner{}
+	err := r.resetParallelSeq([]cache.Cache{cache.NewKVCache()}, 0)
+	if err == nil {
+		t.Fatal("expected error for plain KVCache")
+	}
+}

--- a/x/mlxrunner/runner.go
+++ b/x/mlxrunner/runner.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/x/internal/mlxthread"
+	"github.com/ollama/ollama/x/mlxrunner/cache"
 	"github.com/ollama/ollama/x/mlxrunner/mlx"
 	"github.com/ollama/ollama/x/mlxrunner/model"
 	"github.com/ollama/ollama/x/mlxrunner/model/base"
@@ -44,6 +45,12 @@ type Runner struct {
 	// spec is the speculative-decoding subsystem. Nil when the model ships no
 	// draft head.
 	spec *speculation
+
+	// numParallel is the max concurrent sequences (OLLAMA_NUM_PARALLEL).
+	numParallel int
+	// parallelCaches is set when numParallel > 1 and caches were wrapped for
+	// multi-sequence continuous batching. Nil keeps the legacy serial path.
+	parallelCaches []cache.Cache
 }
 
 func (r *Runner) Load(modelName string) error {
@@ -106,8 +113,22 @@ func (r *Runner) Load(modelName string) error {
 	r.Tokenizer = m.Tokenizer()
 	r.contextLength = m.MaxContextLength()
 	r.cache = newPrefixCache(m)
+	if r.numParallel < 1 {
+		r.numParallel = 1
+	}
 	r.Sampler = sample.New(r.contextLength)
 	r.spec = newSpeculation(r, draftModel)
+
+	if r.numParallel > 1 {
+		if wrapped, ok := cache.WrapParallelCaches(r.cache.caches, r.numParallel); ok {
+			r.parallelCaches = wrapped
+			slog.Info("MLX continuous batching enabled", "parallel", r.numParallel)
+		} else {
+			slog.Warn("MLX model caches do not support parallel requests; using serial decode", "parallel", r.numParallel)
+			r.numParallel = 1
+			r.parallelCaches = nil
+		}
+	}
 
 	mlx.EnableCompile()
 
@@ -172,6 +193,11 @@ func (r *Runner) Run(host, port string, mux http.Handler) error {
 	g, ctx := errgroup.WithContext(context.Background())
 
 	g.Go(func() error {
+		if r.parallelCaches != nil {
+			return r.mlxThread.Do(ctx, func() error {
+				return r.runContinuousBatcher(ctx)
+			})
+		}
 		for {
 			select {
 			case <-ctx.Done():

--- a/x/mlxrunner/server.go
+++ b/x/mlxrunner/server.go
@@ -24,15 +24,21 @@ func Execute(args []string) error {
 	slog.SetDefault(logutil.NewLogger(os.Stderr, envconfig.LogLevel()))
 
 	var (
-		modelName string
-		port      int
+		modelName  string
+		port       int
+		numParallel int
 	)
 
 	flagSet := flag.NewFlagSet("mlxrunner", flag.ExitOnError)
 	flagSet.StringVar(&modelName, "model", "", "Model name")
 	flagSet.IntVar(&port, "port", 0, "Port to listen on")
+	flagSet.IntVar(&numParallel, "parallel", 1, "Max parallel sequences (OLLAMA_NUM_PARALLEL)")
 	_ = flagSet.Bool("verbose", false, "Enable debug logging")
 	flagSet.Parse(args)
+
+	if numParallel < 1 {
+		numParallel = 1
+	}
 
 	worker, err := mlxthread.Start("mlxrunner", func() error {
 		if err := mlx.CheckInit(); err != nil {
@@ -59,8 +65,9 @@ func Execute(args []string) error {
 	defer cancelRunner()
 
 	runner := Runner{
-		Requests:  make(chan Request),
-		mlxThread: worker,
+		Requests:    make(chan Request),
+		mlxThread:   worker,
+		numParallel: numParallel,
 	}
 
 	if err := worker.Do(context.Background(), func() error {

--- a/x/models/qwen3_5/qwen3_5.go
+++ b/x/models/qwen3_5/qwen3_5.go
@@ -1138,9 +1138,9 @@ func (g *GatedDeltaNet) Forward(x *mlx.Array, b *batch.Batch, c cache.Cache, B, 
 		}, -1)
 	}
 	convTail := cfg.LinearConvKernelDim - 1
-	var rc *cache.RecurrentCache
+	var rc cache.Recurrent
 	opts := make([]nn.RecurrentOption, 0, 2)
-	if typed, ok := c.(*cache.RecurrentCache); ok {
+	if typed, ok := c.(cache.Recurrent); ok {
 		rc = typed
 		opts = append(opts, nn.WithRecurrentHistory(rc.Get(b, x.DType())))
 		// When the cache has scheduled per-token snapshots, segment the


### PR DESCRIPTION
## Summary
- Pass `OLLAMA_NUM_PARALLEL` into the MLX runner (`--parallel`) and gate completions with a semaphore
- Add `MultiSeq` caches and a continuous-batch decode loop for standard KV-cache models
- Document MLX parallel behavior and fallbacks in the FAQ

Fixes #17280

## Test plan
- [x] `go test ./x/mlxrunner/cache/ -run 'TestWrapParallel|TestMultiSeq'`
- [x] `go build ./x/mlxrunner/ ./server/`
- [x] On Apple Silicon: `OLLAMA_NUM_PARALLEL=4` with an MLX KV-cache model; confirm overlapping decode vs serial baseline