### PR TITLE
tools: prevent infinite loop when non-tool JSON precedes valid tool call

### DIFF
--- a/tools/tools.go
+++ b/tools/tools.go
@@ -126,37 +126,46 @@ func (p *Parser) findTag() (int, bool) {
 // parseToolCall finds the next complete tool call in the buffer
 // incrementing n and advancing the buffer.
 func (p *Parser) parseToolCall() *api.ToolCall {
-	tool, end := findTool(p.tools, p.buffer)
-	if tool == nil {
-		return nil
-	}
+	for {
+		tool, end := findTool(p.tools, p.buffer)
+		if tool == nil {
+			return nil
+		}
 
-	var argsMap map[string]any
-	if found, i := findArguments(tool, p.buffer); found == nil {
-		return nil
-	} else {
-		argsMap = found
-		if i > end {
-			end = i
+		if found, i := findArguments(tool, p.buffer); found == nil {
+			if i == 0 {
+				return nil
+			}
+			// A JSON object was found but it doesn't match the
+			// expected tool (e.g., it has a "name" key without
+			// "arguments" or "parameters"). Skip it and try
+			// again to prevent an infinite parse loop.
+			p.buffer = p.buffer[i:]
+			continue
+		} else {
+			argsMap := found
+			if i > end {
+				end = i
+			}
+
+			args := api.NewToolCallFunctionArguments()
+			for k, v := range argsMap {
+				args.Set(k, v)
+			}
+
+			tc := &api.ToolCall{
+				Function: api.ToolCallFunction{
+					Name:      tool.Function.Name,
+					Arguments: args,
+					Index:     p.n,
+				},
+			}
+
+			p.n++
+			p.buffer = p.buffer[end:]
+			return tc
 		}
 	}
-
-	args := api.NewToolCallFunctionArguments()
-	for k, v := range argsMap {
-		args.Set(k, v)
-	}
-
-	tc := &api.ToolCall{
-		Function: api.ToolCallFunction{
-			Name:      tool.Function.Name,
-			Arguments: args,
-			Index:     p.n,
-		},
-	}
-
-	p.n++
-	p.buffer = p.buffer[end:]
-	return tc
 }
 
 // findTool finds the first tool name in the list that matches the

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -735,10 +735,9 @@ func TestParser(t *testing.T) {
 					},
 				},
 			},
-		},
-		{
-			name: "args before name",
-			inputs: []string{
+		},		{
+			name:    "args before name",
+			inputs:  []string{
 				`<tool_call>{"arguments": {"a": "5", "b": "10"}, "name": "add"}</tool_call>`,
 			},
 			content: "",
@@ -751,6 +750,23 @@ func TestParser(t *testing.T) {
 						Arguments: testArgs(map[string]any{
 							"a": "5",
 							"b": "10",
+						}),
+					},
+				},
+			},
+		},
+		{
+			name:   "skip non-tool JSON before valid tool call",
+			inputs: []string{`<tool_call>{"name": "unknown_tool"}</tool_call><tool_call>{"name": "get_conditions", "arguments": {"location": "Tokyo"}}</tool_call>`},
+			content: "",
+			tmpl:    qwen,
+			calls: []api.ToolCall{
+				{
+					Function: api.ToolCallFunction{
+						Index: 0,
+						Name:  "get_conditions",
+						Arguments: testArgs(map[string]any{
+							"location": "Tokyo",
 						}),
 					},
 				},


### PR DESCRIPTION
Fix an infinite loop in parseToolCall where a non-tool JSON object (with a name key but no arguments) appearing before a valid tool call would cause the parser to loop forever. The fix advances the buffer past the unrecognized JSON and retries findTool + findArguments.

When findArguments returns (nil, position) with position > 0 for a JSON object that doesn't match the expected tool, the old code returned nil without advancing the buffer. For non-{/[ tags like <tool_call>, done() returns false, so Add's loop would retry parseToolCall on the same buffer indefinitely.

The fix wraps parseToolCall in a for loop and advances past unrecognized JSON objects before retrying.