### PR TITLE
tools: prevent findTool matching short tool names inside longer identifiers

### DIFF
--- a/tools/tools.go
+++ b/tools/tools.go
@@ -159,6 +159,12 @@ func (p *Parser) parseToolCall() *api.ToolCall {
 	return tc
 }
 
+// isIdentByte reports whether b is a byte that can appear in a
+// Go/JSON identifier: letters, digits, or underscore.
+func isIdentByte(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '_'
+}
+
 // findTool finds the first tool name in the list that matches the
 // beginning of the buffer, returning nil if no tool is found
 // or if the buffer ends with a partial tool name since we need
@@ -199,6 +205,16 @@ func findTool(tools []api.Tool, buf []byte) (*api.Tool, int) {
 		name := []byte(tools[i].Function.Name)
 		pos := bytes.Index(buf, name)
 		if pos == -1 {
+			continue
+		}
+
+		// Ignore matches that are a substring of a longer identifier
+		// (e.g., matching "add" inside "add_numbers"). Only accept the
+		// match when it is not preceded or followed by an identifier byte.
+		if pos > 0 && isIdentByte(buf[pos-1]) {
+			continue
+		}
+		if end := pos + len(name); end < len(buf) && isIdentByte(buf[end]) {
 			continue
 		}
 

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -756,6 +756,13 @@ func TestParser(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:   "tool name substring inside longer identifier",
+			inputs: []string{`<tool_call>{"name": "add_numbers", "arguments": {"a": "5", "b": "10"}}</tool_call>`},
+			content: "",
+			tmpl:    qwen,
+			calls:   nil,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Fix findTool to reject matches where the tool name is a substring of a longer identifier, preventing short tool names like "add" from matching inside "add_numbers" in JSON string values.

## The Bug

findTool uses bytes.Index for a raw substring search. When a short tool name like "add" appears inside a JSON string value like "add_numbers", it would match and be returned as the correct tool. This causes parseToolCall to create a ToolCall with the wrong name and arguments from a different JSON object.

## The Fix

Add word-boundary checks using isIdentByte (alphanumeric + underscore). After bytes.Index finds a match, verify:
- The character before is not an identifier byte (not part of a longer prefix)
- The character after is not an identifier byte (not part of a longer suffix)

Only accept the match when it is a standalone identifier, not a substring.