### PR TITLE
tools: stop dropping content generated after bare-JSON tool calls

### DIFF
--- a/tools/tools.go
+++ b/tools/tools.go
@@ -99,6 +99,29 @@ func (p *Parser) Add(s string) (calls []api.ToolCall, content string) {
 		p.state = toolsState_Done
 		content = string(p.buffer)
 		p.buffer = []byte{}
+	} else if p.n > 0 && (p.tag == "{" || p.tag == "[") {
+		// after a bare-JSON tool call, decide whether the rest of
+		// the buffer can still be part of tool calling. if it
+		// cannot, stop parsing so the model's remaining output is
+		// sent to the user instead of being buffered forever
+		trimmed := bytes.TrimLeft(p.buffer, " \t\r\n")
+		if p.tag == "[" {
+			// skip list closing brackets, including stray
+			// duplicates some models emit
+			for len(trimmed) > 0 && trimmed[0] == ']' {
+				trimmed = bytes.TrimLeft(trimmed[1:], " \t\r\n")
+			}
+		}
+		switch {
+		case len(trimmed) == 0:
+			// nothing to decide yet
+		case trimmed[0] == '{', p.tag == "[" && trimmed[0] == ',':
+			// may be another tool call, keep buffering
+		default:
+			p.state = toolsState_Done
+			content = string(trimmed)
+			p.buffer = []byte{}
+		}
 	}
 
 	return calls, content
@@ -136,8 +159,10 @@ func (p *Parser) parseToolCall() *api.ToolCall {
 		return nil
 	} else {
 		argsMap = found
-		if i > end {
-			end = i
+		// i is the index of the closing brace of the parsed
+		// object, consume it along with the rest of the call
+		if i >= end {
+			end = i + 1
 		}
 	}
 

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -453,6 +453,75 @@ func TestParser(t *testing.T) {
 			tmpl:    json,
 		},
 		{
+			name: "json content after tool call",
+			inputs: []string{
+				"{\"name\": \"get_temperature\", \"arguments\": {\"city\": \"Tokyo\"}}",
+				" I called the tool for you.",
+			},
+			content: "I called the tool for you.",
+			tmpl:    json,
+			calls: []api.ToolCall{
+				{
+					Function: api.ToolCallFunction{
+						Index: 0,
+						Name:  "get_temperature",
+						Arguments: testArgs(map[string]any{
+							"city": "Tokyo",
+						}),
+					},
+				},
+			},
+		},
+		{
+			name: "json content after tool call same chunk",
+			inputs: []string{
+				"{\"name\": \"get_temperature\", \"arguments\": {\"city\": \"Tokyo\"}}\nDone!",
+			},
+			content: "Done!",
+			tmpl:    json,
+			calls: []api.ToolCall{
+				{
+					Function: api.ToolCallFunction{
+						Index: 0,
+						Name:  "get_temperature",
+						Arguments: testArgs(map[string]any{
+							"city": "Tokyo",
+						}),
+					},
+				},
+			},
+		},
+		{
+			name: "list content after tool calls",
+			inputs: []string{
+				"[{\"name\": \"get_temperature\", \"arguments\": {\"city\": \"London\"}},",
+				" {\"name\": \"get_conditions\", \"arguments\": {\"location\": \"Tokyo\"}}]",
+				" All done.",
+			},
+			content: "All done.",
+			tmpl:    list,
+			calls: []api.ToolCall{
+				{
+					Function: api.ToolCallFunction{
+						Index: 0,
+						Name:  "get_temperature",
+						Arguments: testArgs(map[string]any{
+							"city": "London",
+						}),
+					},
+				},
+				{
+					Function: api.ToolCallFunction{
+						Index: 1,
+						Name:  "get_conditions",
+						Arguments: testArgs(map[string]any{
+							"location": "Tokyo",
+						}),
+					},
+				},
+			},
+		},
+		{
 			name: "list multiple",
 			inputs: []string{
 				"[",


### PR DESCRIPTION
Fixes #17323

For models whose template has no text tool-call tag, the parser treats bare JSON as tool calls (the `{` and `[` tags). After a successful call, any content the model generated afterwards was silently dropped and the parser never left tool-calling state.

Two combined causes in `tools/tools.go`:

1. `parseToolCall` advanced the buffer to the index of the closing brace returned by `findArguments`, leaving the `}` of the parsed call at the front of the buffer.
2. `done()` decides completion by brace counting from the current buffer, so the leftover `}` drove the count negative and it could never reach zero again. The parser stayed in tool-calling state for the rest of the stream, returning `""` for every subsequent chunk.

Changes:

- consume the closing brace when a call is parsed
- after a bare-JSON call, if the remaining buffer can no longer be part of tool calling (not another object, not a list separator, not a closing bracket), stop parsing and return the rest of the output as content

Behavior preserved on purpose:

- text tags such as `<tool_call>` are untouched, trailing template scaffolding is still discarded
- stray duplicated `]` after a tool call list is still swallowed (the tolerance added in #11101, covered by the existing "list trailing ]" test)
- non-tool-call JSON is still returned as content, all existing tests pass unchanged except for the three new cases

Tests: new `TestParser` cases covering trailing content after a `{` tool call (split and same-chunk) and after a `[` list, plus the full existing suite.

Related: same silent-output-loss family as #17284, which covers the parse-failure path for text tags. This covers the success path for bare-JSON tags. The two are independent and merge cleanly in either order.
