### PR TITLE
model/renderers: keep qwen images separate

### DIFF
--- a/model/renderers/image_tags.go
+++ b/model/renderers/image_tags.go
@@ -11,6 +11,12 @@ import (
 // semantics for explicit [img] tokens: replace placeholders in order, and
 // only prepend tags for any remaining images without placeholders.
 func renderContentWithImageTags(content string, imageCount int, imageOffset int) (string, int) {
+	return renderContentWithImageTagSeparator(content, imageCount, imageOffset, "")
+}
+
+// renderContentWithImageTagSeparator behaves like renderContentWithImageTags,
+// but places separator between automatically prepended image tags.
+func renderContentWithImageTagSeparator(content string, imageCount int, imageOffset int, separator string) (string, int) {
 	if imageCount == 0 {
 		return content, imageOffset
 	}
@@ -25,6 +31,9 @@ func renderContentWithImageTags(content string, imageCount int, imageOffset int)
 		if strings.Contains(content, "[img]") {
 			content = strings.Replace(content, "[img]", imgTag, 1)
 		} else {
+			if prefix.Len() > 0 {
+				prefix.WriteString(separator)
+			}
 			prefix.WriteString(imgTag)
 		}
 	}

--- a/model/renderers/image_tags_test.go
+++ b/model/renderers/image_tags_test.go
@@ -65,3 +65,13 @@ func TestRenderContentWithImageTags(t *testing.T) {
 		})
 	}
 }
+
+func TestRenderContentWithImageTagSeparator(t *testing.T) {
+	content, offset := renderContentWithImageTagSeparator("describe these images", 2, 0, " ")
+	if content != "[img-0] [img-1] describe these images" {
+		t.Fatalf("content = %q", content)
+	}
+	if offset != 2 {
+		t.Fatalf("offset = %d, want 2", offset)
+	}
+}

--- a/model/renderers/qwen35.go
+++ b/model/renderers/qwen35.go
@@ -50,7 +50,8 @@ func (r *Qwen35Renderer) LeadingBOS() string {
 
 func (r *Qwen35Renderer) renderContent(content api.Message, imageOffset int) (string, int) {
 	if r.useImgTags {
-		return renderContentWithImageTags(content.Content, len(content.Images), imageOffset)
+		// Keep independent images from being interpreted as consecutive video frames.
+		return renderContentWithImageTagSeparator(content.Content, len(content.Images), imageOffset, " ")
 	}
 
 	// This assumes all images are at the front of the message - same assumption as ollama/ollama/runner.go

--- a/model/renderers/qwen35_test.go
+++ b/model/renderers/qwen35_test.go
@@ -7,6 +7,21 @@ import (
 	"github.com/ollama/ollama/api"
 )
 
+func TestQwen35RendererSeparatesImageTags(t *testing.T) {
+	renderer := &Qwen35Renderer{useImgTags: true}
+	content, offset := renderer.renderContent(api.Message{
+		Content: "compare these images",
+		Images:  []api.ImageData{api.ImageData("one"), api.ImageData("two")},
+	}, 0)
+
+	if content != "[img-0] [img-1] compare these images" {
+		t.Fatalf("content = %q", content)
+	}
+	if offset != 2 {
+		t.Fatalf("offset = %d, want 2", offset)
+	}
+}
+
 func TestQwen35RendererUsesXMLToolCallingFormat(t *testing.T) {
 	renderer := &Qwen35Renderer{isThinking: true}
 	msgs := []api.Message{

--- a/model/renderers/qwen3vl.go
+++ b/model/renderers/qwen3vl.go
@@ -19,7 +19,8 @@ func (r *Qwen3VLRenderer) LeadingBOS() string {
 
 func (r *Qwen3VLRenderer) renderContent(content api.Message, imageOffset int) (string, int) {
 	if r.useImgTags {
-		return renderContentWithImageTags(content.Content, len(content.Images), imageOffset)
+		// Keep independent images from being interpreted as consecutive video frames.
+		return renderContentWithImageTagSeparator(content.Content, len(content.Images), imageOffset, " ")
 	}
 
 	// This assumes all images are at the front of the message - same assumption as ollama/ollama/runner.go

--- a/model/renderers/qwen3vl_nonthinking_test.go
+++ b/model/renderers/qwen3vl_nonthinking_test.go
@@ -123,7 +123,7 @@ Let me analyze this image.`,
 			},
 			useImgTags: true,
 			expected: `<|im_start|>user
-[img-0][img-1] Describe these images.<|im_end|>
+[img-0] [img-1] Describe these images.<|im_end|>
 <|im_start|>assistant
 Let me analyze this image.`,
 		},


### PR DESCRIPTION
Fixes #17321.

Qwen image tags were prepended back-to-back. For same-size images, llama.cpp treats the resulting adjacent bitmap parts as video frames and temporally merges them, so the model receives a single image sequence instead of two independent images.

This adds an optional separator for automatically prepended image tags and uses a single space for the Qwen 3 VL and Qwen 3.5 renderers. Explicit `[img]` placement is unchanged, and other vision renderers keep their existing output.

I reproduced this locally with `qwen2.5vl:7b` and two same-size images: the existing prompt reported that only one image was provided, while the separated tags made the model describe both images.

Tests:
- `go test ./model/renderers`
- `env -u OLLAMA_CONTEXT_LENGTH go test ./server -run TestChatPrompt -count=1`