### PR TITLE
tools: support parsing tool calls with omitted arguments

### DIFF
--- a/tools/tools.go
+++ b/tools/tools.go
@@ -132,13 +132,17 @@ func (p *Parser) parseToolCall() *api.ToolCall {
 	}
 
 	var argsMap map[string]any
-	if found, i := findArguments(tool, p.buffer); found == nil {
+	found, i := findArguments(tool, p.buffer)
+	if found == nil && i == 0 {
 		return nil
-	} else {
+	}
+	if found != nil {
 		argsMap = found
-		if i > end {
-			end = i
-		}
+	} else {
+		argsMap = make(map[string]any)
+	}
+	if i > end {
+		end = i
 	}
 
 	args := api.NewToolCallFunctionArguments()
@@ -226,11 +230,10 @@ func findTool(tools []api.Tool, buf []byte) (*api.Tool, int) {
 
 // findArguments returns the first object that appears to be
 // arguments for the provided tool in the provided buffer,
-// returning nil if no arguments are found and the end position
-// TODO (jmorganca): this does not support parsing omitted arguments
-// objects for functions that have all-optional parameters
-// e.g. `{"name": "get_conditions", "arguments": {}}` will work but
-// `{"name": "get_conditions"}` will not currently work
+// returning nil if no arguments are found and the end position.
+// When a tool call has no explicit arguments field (e.g.
+// {"name": "get_conditions"}), it returns nil args with a
+// non-zero position to signal that the tool call was recognized.
 func findArguments(tool *api.Tool, buffer []byte) (map[string]any, int) {
 	if len(buffer) == 0 {
 		return nil, 0

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -188,21 +188,36 @@ func TestParser(t *testing.T) {
 			},
 		},
 		{
-			name:    "empty args",
-			inputs:  []string{`<tool_call>{"name": "get_conditions", "arguments": {}}</tool_call>`},
-			content: "",
-			tmpl:    qwen,
-			calls: []api.ToolCall{
-				{
-					Function: api.ToolCallFunction{
-						Index:     0,
-						Name:      "get_conditions",
-						Arguments: api.NewToolCallFunctionArguments(),
-					},
+		name:    "empty args",
+		inputs:  []string{`<tool_call>{"name": "get_conditions", "arguments": {}}</tool_call>`},
+		content: "",
+		tmpl:    qwen,
+		calls: []api.ToolCall{
+			{
+				Function: api.ToolCallFunction{
+					Index:     0,
+					Name:      "get_conditions",
+					Arguments: api.NewToolCallFunctionArguments(),
 				},
 			},
 		},
-		{
+	},
+	{
+		name:    "omitted args",
+		inputs:  []string{`<tool_call>{"name": "get_conditions"}</tool_call>`},
+		content: "",
+		tmpl:    qwen,
+		calls: []api.ToolCall{
+			{
+				Function: api.ToolCallFunction{
+					Index:     0,
+					Name:      "get_conditions",
+					Arguments: api.NewToolCallFunctionArguments(),
+				},
+			},
+		},
+	},
+	{
 			name:    "text before tool call",
 			inputs:  []string{`Let me check the weather. <tool_call>{"name": "get_temperature", "arguments": {"city": "New York"}}</tool_call>`},
 			content: "Let me check the weather. ",
@@ -1349,6 +1364,12 @@ func TestFindArguments(t *testing.T) {
 				"format":   "fahrenheit",
 				"location": "San Francisco, CA",
 			},
+		},
+		{
+			name: "omitted arguments",
+			tool: "get_conditions",
+			buffer: []byte(`{"name": "get_conditions"}`),
+			want: nil,
 		},
 	}
 


### PR DESCRIPTION
## Problem

When a model generates a tool call without an explicit `arguments` field — e.g. `{"name": "get_conditions"}` — the `parseToolCall` function would silently discard the call. This is because `findArguments` returns `nil` args with a non-zero position to signal a recognized tool call with no arguments, but `parseToolCall` treated `nil` args as "not found."

This caused models to fail silently when they omitted optional arguments.

## Fix

`parseToolCall` now checks whether `findArguments` returned `nil, 0` (truly not found) vs `nil, i (i > 0)` (recognized but no explicit args). In the latter case, it uses an empty arguments map instead of discarding the call.

## Changes

- `tools/tools.go`: Updated `parseToolCall` to handle nil args from `findArguments` when position > 0; updated `findArguments` doc comment to clarify the contract
- `tools/tools_test.go`: Added `TestFindArguments` test case for omitted arguments; added end-to-end `TestParser` test case for tool calls with omitted args