### PR TITLE
docs: fix dead OpenAI compatibility link in examples

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -11,4 +11,4 @@ Ollama JavaScript examples at [ollama-js/examples](https://github.com/ollama/oll
 
 
 ## OpenAI compatibility examples
-Ollama OpenAI compatibility examples at [ollama/examples/openai](../docs/openai.md)
+Ollama OpenAI compatibility examples at [ollama/examples/openai](https://docs.ollama.com/api/openai-compatibility)


### PR DESCRIPTION
`docs/examples.md` links `../docs/openai.md` for the OpenAI compatibility examples, but that file no longer exists in the repo — the content now lives on the docs site. Point the link at the canonical page instead: https://docs.ollama.com/api/openai-compatibility (verified 200).

One-line docs change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)