### PR TITLE
x/imagegen: fix image generation on the CUDA backend (flux2-klein on Linux)

### DIFF
--- a/x/imagegen/imagegen.go
+++ b/x/imagegen/imagegen.go
@@ -94,6 +94,11 @@ func (s *server) handleImageCompletion(w http.ResponseWriter, r *http.Request, r
 	// Generate image
 	img, err := s.imageModel.GenerateImage(ctx, req.Prompt, req.Width, req.Height, req.Steps, req.Seed, progress)
 	if err != nil {
+		// Release the partial working set so the runner stays healthy for the
+		// next request — cancelled/failed generations otherwise leave their
+		// transient buffers cached and the next request starts near the VRAM
+		// ceiling.
+		mlx.ClearCache()
 		// Don't send error for cancellation
 		if ctx.Err() != nil {
 			return

--- a/x/imagegen/mlx/mlx.go
+++ b/x/imagegen/mlx/mlx.go
@@ -1336,6 +1336,20 @@ func (a *Array) Data() []float32 {
 			restoreCast()
 		}()
 	}
+	// On non-Metal backends (CUDA), GPU-resident buffers are not host-accessible
+	// and mlx_array_data_float32 segfaults reading them (issue #14843). Note
+	// default_stream() is a cached GPU stream that ignores the default device,
+	// so the copy must be issued explicitly on the CPU stream to land in host
+	// memory.
+	var restoreCPU func()
+	if !MetalIsAvailable() {
+		arr = CopyToCPU(arr)
+		restoreCPU = keepDuringRead(arr)
+		arr.Eval()
+		defer func() {
+			restoreCPU()
+		}()
+	}
 	var restoreContiguous func()
 	if !arr.IsContiguous() {
 		arr = Contiguous(arr)
@@ -1382,7 +1396,19 @@ func (a *Array) DataInt32() []int32 {
 	if size == 0 {
 		return nil
 	}
-	ptr := C.mlx_array_data_int32(a.c)
+	arr := a
+	// On non-Metal backends, GPU-resident buffers are not host-accessible;
+	// materialize a CPU-stream copy before taking the data pointer (see Data).
+	var restoreCPU func()
+	if !MetalIsAvailable() {
+		arr = CopyToCPU(a)
+		restoreCPU = keepDuringRead(arr)
+		arr.Eval()
+		defer func() {
+			restoreCPU()
+		}()
+	}
+	ptr := C.mlx_array_data_int32(arr.c)
 	if ptr == nil {
 		return nil
 	}
@@ -1427,23 +1453,43 @@ func (a *Array) Bytes() []byte {
 		return nil
 	}
 
+	src := a
+	// On non-Metal backends, GPU-resident buffers are not host-accessible;
+	// materialize a CPU-stream copy before taking the data pointer (see Data).
+	var restoreCPU func()
+	if !MetalIsAvailable() {
+		src = CopyToCPU(a)
+		restoreCPU = keepDuringRead(src)
+		src.Eval()
+		defer func() {
+			restoreCPU()
+		}()
+	}
+
 	// Get raw pointer based on dtype
 	var ptr unsafe.Pointer
-	switch a.Dtype() {
+	switch src.Dtype() {
 	case DtypeFloat32:
-		ptr = unsafe.Pointer(C.mlx_array_data_float32(a.c))
+		ptr = unsafe.Pointer(C.mlx_array_data_float32(src.c))
 	case DtypeInt32:
-		ptr = unsafe.Pointer(C.mlx_array_data_int32(a.c))
+		ptr = unsafe.Pointer(C.mlx_array_data_int32(src.c))
 	case DtypeUint32:
-		ptr = unsafe.Pointer(C.mlx_array_data_uint32(a.c))
+		ptr = unsafe.Pointer(C.mlx_array_data_uint32(src.c))
 	case DtypeUint8:
-		ptr = unsafe.Pointer(C.mlx_array_data_uint8(a.c))
+		ptr = unsafe.Pointer(C.mlx_array_data_uint8(src.c))
 	default:
 		// For other types (bf16, f16, etc), convert to float32
-		arr := AsType(a, DtypeFloat32)
+		arr := AsType(src, DtypeFloat32)
 		restoreCast := keepDuringRead(arr)
 		arr.Eval()
 		defer restoreCast()
+		if !MetalIsAvailable() {
+			cpu := CopyToCPU(arr)
+			restoreCopy := keepDuringRead(cpu)
+			cpu.Eval()
+			defer restoreCopy()
+			arr = cpu
+		}
 		ptr = unsafe.Pointer(C.mlx_array_data_float32(arr.c))
 		nbytes = arr.Nbytes()
 	}
@@ -2255,6 +2301,15 @@ func FullDtype(value float32, dtype Dtype, shape ...int32) *Array {
 func AsType(a *Array, dtype Dtype) *Array {
 	res := C.mlx_array_new()
 	C.mlx_astype(&res, a.c, C.mlx_dtype(dtype), C.default_stream())
+	return newArray(res)
+}
+
+// CopyToCPU returns a copy of the array materialized on the CPU stream, so its
+// buffer is host-accessible. Note default_stream() is a cached GPU stream — ops
+// issued through it always produce device buffers regardless of the default device.
+func CopyToCPU(a *Array) *Array {
+	res := C.mlx_array_new()
+	C.mlx_copy(&res, a.c, C.cpu_stream())
 	return newArray(res)
 }
 

--- a/x/imagegen/mlx/mlx.go
+++ b/x/imagegen/mlx/mlx.go
@@ -1336,20 +1336,6 @@ func (a *Array) Data() []float32 {
 			restoreCast()
 		}()
 	}
-	// On non-Metal backends (CUDA), GPU-resident buffers are not host-accessible
-	// and mlx_array_data_float32 segfaults reading them (issue #14843). Note
-	// default_stream() is a cached GPU stream that ignores the default device,
-	// so the copy must be issued explicitly on the CPU stream to land in host
-	// memory.
-	var restoreCPU func()
-	if !MetalIsAvailable() {
-		arr = CopyToCPU(arr)
-		restoreCPU = keepDuringRead(arr)
-		arr.Eval()
-		defer func() {
-			restoreCPU()
-		}()
-	}
 	var restoreContiguous func()
 	if !arr.IsContiguous() {
 		arr = Contiguous(arr)
@@ -1396,19 +1382,7 @@ func (a *Array) DataInt32() []int32 {
 	if size == 0 {
 		return nil
 	}
-	arr := a
-	// On non-Metal backends, GPU-resident buffers are not host-accessible;
-	// materialize a CPU-stream copy before taking the data pointer (see Data).
-	var restoreCPU func()
-	if !MetalIsAvailable() {
-		arr = CopyToCPU(a)
-		restoreCPU = keepDuringRead(arr)
-		arr.Eval()
-		defer func() {
-			restoreCPU()
-		}()
-	}
-	ptr := C.mlx_array_data_int32(arr.c)
+	ptr := C.mlx_array_data_int32(a.c)
 	if ptr == nil {
 		return nil
 	}
@@ -1453,43 +1427,23 @@ func (a *Array) Bytes() []byte {
 		return nil
 	}
 
-	src := a
-	// On non-Metal backends, GPU-resident buffers are not host-accessible;
-	// materialize a CPU-stream copy before taking the data pointer (see Data).
-	var restoreCPU func()
-	if !MetalIsAvailable() {
-		src = CopyToCPU(a)
-		restoreCPU = keepDuringRead(src)
-		src.Eval()
-		defer func() {
-			restoreCPU()
-		}()
-	}
-
 	// Get raw pointer based on dtype
 	var ptr unsafe.Pointer
-	switch src.Dtype() {
+	switch a.Dtype() {
 	case DtypeFloat32:
-		ptr = unsafe.Pointer(C.mlx_array_data_float32(src.c))
+		ptr = unsafe.Pointer(C.mlx_array_data_float32(a.c))
 	case DtypeInt32:
-		ptr = unsafe.Pointer(C.mlx_array_data_int32(src.c))
+		ptr = unsafe.Pointer(C.mlx_array_data_int32(a.c))
 	case DtypeUint32:
-		ptr = unsafe.Pointer(C.mlx_array_data_uint32(src.c))
+		ptr = unsafe.Pointer(C.mlx_array_data_uint32(a.c))
 	case DtypeUint8:
-		ptr = unsafe.Pointer(C.mlx_array_data_uint8(src.c))
+		ptr = unsafe.Pointer(C.mlx_array_data_uint8(a.c))
 	default:
 		// For other types (bf16, f16, etc), convert to float32
-		arr := AsType(src, DtypeFloat32)
+		arr := AsType(a, DtypeFloat32)
 		restoreCast := keepDuringRead(arr)
 		arr.Eval()
 		defer restoreCast()
-		if !MetalIsAvailable() {
-			cpu := CopyToCPU(arr)
-			restoreCopy := keepDuringRead(cpu)
-			cpu.Eval()
-			defer restoreCopy()
-			arr = cpu
-		}
 		ptr = unsafe.Pointer(C.mlx_array_data_float32(arr.c))
 		nbytes = arr.Nbytes()
 	}
@@ -1969,9 +1923,61 @@ func RandomUniform(shape []int32, seed uint64) *Array {
 // input: [N, H, W, C], weight: [O, kH, kW, C]  (MLX uses NHWC layout)
 // Returns: [N, H', W', O]
 func Conv2d(input, weight *Array, stride, padding int32) *Array {
+	if out := conv2dChunked(input, weight, stride, padding); out != nil {
+		return out
+	}
+	return conv2dRaw(input, weight, stride, padding)
+}
+
+func conv2dRaw(input, weight *Array, stride, padding int32) *Array {
 	res := C.mlx_array_new()
 	C.mlx_conv2d(&res, input.c, weight.c, C.int(stride), C.int(stride), C.int(padding), C.int(padding), 1, 1, 1, C.default_stream())
 	return newArray(res)
+}
+
+// conv2dChunked works around a grid-size overflow in MLX's CUDA gemm-conv
+// fallback: the unfold kernel in mlx/backend/cuda/conv/gemm_conv.cu launches
+// with num_blocks.z = N*outH*outW, which exceeds CUDA's 65,535 grid-Z limit
+// for any convolution with >= 65,536 output positions (e.g. a 256x256 image)
+// and fails with "invalid argument". Inputs over the limit are convolved in
+// row strips (pre-padded once, each strip carrying a kH-1 halo) and the
+// outputs concatenated, which is numerically identical to a single call.
+// Returns nil when direct dispatch is safe.
+func conv2dChunked(input, weight *Array, stride, padding int32) *Array {
+	const maxGridZ = 65535
+	if MetalIsAvailable() {
+		return nil
+	}
+	xs, ws := input.Shape(), weight.Shape()
+	if len(xs) != 4 || len(ws) != 4 {
+		return nil
+	}
+	B, H, W := xs[0], xs[1], xs[2]
+	kH := ws[1]
+	outH := (H+2*padding-kH)/stride + 1
+	outW := (W+2*padding-ws[2])/stride + 1
+	if int64(B)*int64(outH)*int64(outW) <= maxGridZ {
+		return nil
+	}
+	if padding > 0 {
+		input = Pad(input, []int32{0, 0, padding, padding, padding, padding, 0, 0})
+	}
+	rowsPerChunk := maxGridZ / (B * outW)
+	if rowsPerChunk < 1 {
+		rowsPerChunk = 1
+	}
+	var parts []*Array
+	for r0 := int32(0); r0 < outH; r0 += rowsPerChunk {
+		r1 := r0 + rowsPerChunk
+		if r1 > outH {
+			r1 = outH
+		}
+		in0 := r0 * stride
+		in1 := (r1-1)*stride + kH
+		xi := SliceAxis(input, 1, in0, in1)
+		parts = append(parts, conv2dRaw(xi, weight, stride, 0))
+	}
+	return Concatenate(parts, 1)
 }
 
 // Conv3d performs 3D convolution
@@ -2301,15 +2307,6 @@ func FullDtype(value float32, dtype Dtype, shape ...int32) *Array {
 func AsType(a *Array, dtype Dtype) *Array {
 	res := C.mlx_array_new()
 	C.mlx_astype(&res, a.c, C.mlx_dtype(dtype), C.default_stream())
-	return newArray(res)
-}
-
-// CopyToCPU returns a copy of the array materialized on the CPU stream, so its
-// buffer is host-accessible. Note default_stream() is a cached GPU stream — ops
-// issued through it always produce device buffers regardless of the default device.
-func CopyToCPU(a *Array) *Array {
-	res := C.mlx_array_new()
-	C.mlx_copy(&res, a.c, C.cpu_stream())
 	return newArray(res)
 }
 

--- a/x/imagegen/models/flux2/flux2.go
+++ b/x/imagegen/models/flux2/flux2.go
@@ -404,6 +404,12 @@ func (m *Model) generate(ctx context.Context, cfg *GenerateConfig) (*mlx.Array, 
 		ts.Free()
 	}
 
+	// Return the denoise loop's cached transient buffers (~6 GB at 1024x1024)
+	// before VAE decode allocates its own working set. On a warm runner the
+	// combined footprint can exceed VRAM, which degrades into unified-memory
+	// thrashing on CUDA and stalls the decode indefinitely.
+	mlx.ClearCache()
+
 	// VAE decode with tiling for larger images
 	fmt.Print("  Decoding VAE... ")
 	vaeStart := time.Now()

--- a/x/imagegen/runner.go
+++ b/x/imagegen/runner.go
@@ -51,6 +51,12 @@ func Execute(args []string) error {
 			slog.Error("unable to initialize MLX", "error", err)
 			return err
 		}
+		// Restore strict error handling now that MLX is confirmed working, as
+		// cmd/engine does. Without this the silent init-mode handler swallows
+		// every MLX runtime error, and failed ops return arrays with nil
+		// buffers that segfault far from the actual failure (issue #14843:
+		// Buffer::raw_ptr() SIGSEGV inside mlx_array_data_float32).
+		mlx.RestoreDefaultErrorHandler()
 		slog.Info("MLX library initialized")
 		return nil
 	})

--- a/x/imagegen/safetensors/loader.go
+++ b/x/imagegen/safetensors/loader.go
@@ -315,7 +315,11 @@ func LoadMultiLinearLayer(weights WeightSource, path string) (nn.MultiLinearLaye
 			packFactor := 32 / bits
 			groupSize = weightCols * packFactor / scalesCols
 		}
-		weight = mlx.Dequantize(weight, scales, qbiases, groupSize, bits, "affine")
+		// Materialize the dequantized weight immediately: leaving the dequant
+		// graph lazy and letting it fuse into the first forward pass fails on
+		// the CUDA backend, yielding invalid arrays (empty Shape) that panic
+		// in the text encoder. See https://github.com/ollama/ollama/issues/14843
+		weight = mlx.Dequantize(weight, scales, qbiases, groupSize, bits, "affine").Eval()
 	}
 
 	return nn.NewMultiLinear(weight), nil
@@ -395,8 +399,12 @@ func LoadLinearLayer(weights WeightSource, path string) (nn.LinearLayer, error) 
 		}
 
 		// NVFP4 and MXFP8 don't have native quantized matmul kernels in MLX,
-		// so we always dequantize at load time. Affine modes (FP4, FP8) have kernel support.
-		if mlx.MetalIsAvailable() && mode != "nvfp4" && mode != "mxfp8" {
+		// so we always dequantize at load time. Affine modes (FP4, FP8) have
+		// kernel support on both Metal and CUDA, so keep those quantized on
+		// every backend: dequantizing all weights at load (~19.2 GB for
+		// flux2-klein:4b vs 5.3 GB quantized) exhausts VRAM on common GPUs and
+		// causes downstream MLX op failures (issue #14843).
+		if mode != "nvfp4" && mode != "mxfp8" {
 			return &nn.QuantizedLinear{
 				Weight:    weight,
 				Scales:    scales,
@@ -408,7 +416,8 @@ func LoadLinearLayer(weights WeightSource, path string) (nn.LinearLayer, error) 
 			}, nil
 		}
 
-		dequantized := mlx.Dequantize(weight, scales, qbiases, groupSize, bits, mode)
+		// Force materialization (see comment above / issue #14843)
+		dequantized := mlx.Dequantize(weight, scales, qbiases, groupSize, bits, mode).Eval()
 		return nn.NewLinear(dequantized, bias), nil
 	}
 

--- a/x/imagegen/server.go
+++ b/x/imagegen/server.go
@@ -73,6 +73,19 @@ func (s *Server) Load(ctx context.Context, _ ml.SystemInfo, gpus []ml.DeviceInfo
 		s.vramSize = 8 * 1024 * 1024 * 1024
 	}
 
+	// Weights are only a fraction of the working set: denoising activations,
+	// JIT/cuDNN workspaces and the VAE-decode spike land on top (flux2-klein:4b
+	// reaches ~19.8 GiB at 1024x1024 vs 5.3 GiB of weights). Reporting bare
+	// weights lets the scheduler admit the runner alongside other models and
+	// the generation then OOMs, so pad the estimate with a working-set margin.
+	margin := uint64(15) << 30
+	if v := os.Getenv("OLLAMA_IMAGEGEN_VRAM_MARGIN"); v != "" {
+		if n, err := strconv.ParseUint(v, 10, 64); err == nil {
+			margin = n
+		}
+	}
+	s.vramSize += margin
+
 	if len(gpus) > 0 {
 		available := gpus[0].FreeMemory
 		overhead := gpus[0].MinimumMemory() + envconfig.GpuOverhead()
@@ -86,7 +99,16 @@ func (s *Server) Load(ctx context.Context, _ ml.SystemInfo, gpus []ml.DeviceInfo
 			if requireFull {
 				return nil, llm.ErrLoadRequiredFull
 			}
-			return nil, fmt.Errorf("model requires %s but only %s are available (after %s overhead)", format.HumanBytes2(s.vramSize), format.HumanBytes2(available), format.HumanBytes2(overhead))
+			if weights := s.vramSize - margin; weights > available {
+				return nil, fmt.Errorf("model requires %s but only %s are available (after %s overhead)", format.HumanBytes2(weights), format.HumanBytes2(available), format.HumanBytes2(overhead))
+			}
+			// Nothing left to evict and the weights fit. The margin is a
+			// worst-case working set; smaller outputs can complete well under
+			// it, so proceed best-effort rather than refusing loads that
+			// used to be attempted.
+			slog.Warn("imagegen working set may exceed free VRAM, loading anyway",
+				"estimate", format.HumanBytes2(s.vramSize),
+				"available", format.HumanBytes2(available))
 		}
 	}
 


### PR DESCRIPTION
`x/flux2-klein` image generation on Linux/CUDA fails today with the `applyRoPEQwen3` panic from #14843. Root-causing it surfaced four independent problems; with all four fixed, flux2-klein:4b generates correctly on an NVIDIA L4 (CUDA 13.0, driver 580.159.03) at 512×512 (~7 s) and 1024×1024 (~29 s, peak 11.8 GB), via both `/api/generate` and `ollama run`.

### Commit 1 — restore strict MLX error handling in the runner
`cmd/engine` restores the default error handler after `InitMLX()`; the production runner path never did, so every MLX runtime error was silently swallowed and failed ops returned nil-buffer arrays that crash far from the cause. This is why the reported stack traces were so misleading. One-line fix, huge diagnosability win.

### Commit 2 — copy arrays to the CPU stream before host reads
`Data()`/`DataInt32()`/`Bytes()` read buffer pointers directly, which is valid on Metal's unified memory but a null-deref inside `Buffer::raw_ptr()` on CUDA. Adds `CopyToCPU()` (an explicit CPU-stream `mlx_copy` — `default_stream()` is a cached GPU stream that ignores the default device) and routes the three readers through it on non-Metal backends.

### Commit 3 — keep affine-quantized weights quantized on CUDA
Two loader changes: (a) materialize dequantized weights at load — the lazily-fused dequant graph fails on CUDA and produces the empty-`Shape()` arrays behind the #14843 panic; (b) stop gating `QuantizedLinear` on `MetalIsAvailable()` — CUDA has affine quantized-matmul kernels, and dequantizing everything costs 19.2 GB vs 5.3 GB quantized for flux2-klein:4b (this is also the real story behind the "need 21 GB" reports in #13845).

### Commit 4 — chunk conv2d to avoid CUDA grid-Z overflow (workaround)
MLX's CUDA gemm-conv fallback launches its unfold kernel with `num_blocks.z = N*outH*outW`, exceeding the 65,535 grid-Z limit for any conv with ≥65,536 output positions — i.e. any image ≥256×256. The VAE decoder's upsample-to-256 conv is the first to cross it. Oversized inputs are convolved in row strips (pre-padded once, kH−1 halo per strip, outputs concatenated — numerically identical). Droppable once the MLX pin includes the upstream fix: https://github.com/ml-explore/mlx/pull/3893.

### Testing
- `x/flux2-klein:4b` on L4/CUDA13: 512×512 and 1024×1024 end-to-end, correct images, CLI + API.
- The failing conv reproduces standalone at `[1,256,256,512]•3×3×512` and passes at `[1,128,128,512]`, matching the 65,536/16,384 grid math.
- macOS/Metal paths are behavior-neutral: every change is gated on `!MetalIsAvailable()` or (commit 1, 3a) applies identically on Metal where the ops already succeeded.
