### PR TITLE
server: cache GGUF metadata to avoid re-parsing on warm requests

### DIFF
--- a/server/gguf_metadata_cache.go
+++ b/server/gguf_metadata_cache.go
@@ -1,0 +1,74 @@
+package server
+
+import (
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/ollama/ollama/fs/gguf"
+)
+
+// ggufMetadata holds the GGUF values the server reads during capability
+// detection and template selection. They are properties of the blob itself,
+// identical regardless of which model references it, so they can be cached and
+// shared.
+type ggufMetadata struct {
+	architecture string
+	chatTemplate string
+	hasPooling   bool
+	hasVision    bool
+	hasAudio     bool
+}
+
+// ggufMetadataCache maps a blob identity to its derived metadata so a given
+// GGUF file is read at most once. Blobs are content-addressed, so a re-pull with
+// changed metadata yields a new key; size and mtime guard against a file being
+// replaced in place. Like modelShowCache, it is process-local, bounded in
+// practice by the number of distinct blobs loaded, and cleared on restart.
+var ggufMetadataCache sync.Map // map[string]*ggufMetadata
+
+// ggufBlobKey identifies a blob by path, size and mtime. The path alone is
+// insufficient because callers such as ggufCapabilities only have the model
+// path, not the layer digest.
+func ggufBlobKey(path string, fi os.FileInfo) string {
+	return fmt.Sprintf("%s|%d|%d", path, fi.Size(), fi.ModTime().UnixNano())
+}
+
+// loadGGUFMetadata returns the derived metadata for the GGUF blob at path,
+// reading the file the first time a blob is seen and serving subsequent calls
+// from the cache.
+func loadGGUFMetadata(path string) (*ggufMetadata, error) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+
+	key := ggufBlobKey(path, fi)
+	if v, ok := ggufMetadataCache.Load(key); ok {
+		return v.(*ggufMetadata), nil
+	}
+
+	f, err := gguf.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	// architecture must be read first: KeyValue prefixes non-general,
+	// non-tokenizer keys with it. Absent keys (e.g. pooling_type on a model with
+	// no pooling) scan to the end of the metadata block, but the reader caches
+	// decoded values on f, so the file is scanned at most once here.
+	md := &ggufMetadata{
+		architecture: f.KeyValue("general.architecture").String(),
+		chatTemplate: f.KeyValue("tokenizer.chat_template").String(),
+		hasPooling:   f.KeyValue("pooling_type").Valid(),
+		hasVision:    f.KeyValue("vision.block_count").Valid(),
+		hasAudio:     f.KeyValue("audio.block_count").Valid(),
+	}
+
+	// Concurrent first requests for the same uncached blob may each parse it,
+	// but LoadOrStore keeps a single shared value. This happens at most once per
+	// blob per process, so it is not worth singleflighting.
+	actual, _ := ggufMetadataCache.LoadOrStore(key, md)
+	return actual.(*ggufMetadata), nil
+}

--- a/server/gguf_metadata_cache_test.go
+++ b/server/gguf_metadata_cache_test.go
@@ -1,0 +1,123 @@
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ollama/ollama/fs/ggml"
+)
+
+// writeTestGGUF writes a minimal GGUF file with the given metadata to path.
+func writeTestGGUF(t *testing.T, path string, kv ggml.KV) {
+	t.Helper()
+
+	if _, ok := kv["general.architecture"]; !ok {
+		kv["general.architecture"] = "test"
+	}
+
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	if err := ggml.WriteGGUF(f, kv, nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLoadGGUFMetadataValues(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "vision.gguf")
+	writeTestGGUF(t, path, ggml.KV{
+		"general.architecture":      "gemma4",
+		"tokenizer.chat_template":   "{{ .Prompt }}",
+		"gemma4.vision.block_count": uint32(12),
+	})
+
+	md, err := loadGGUFMetadata(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if md.architecture != "gemma4" {
+		t.Errorf("architecture = %q, want %q", md.architecture, "gemma4")
+	}
+	if md.chatTemplate != "{{ .Prompt }}" {
+		t.Errorf("chatTemplate = %q, want %q", md.chatTemplate, "{{ .Prompt }}")
+	}
+	if !md.hasVision {
+		t.Error("hasVision = false, want true")
+	}
+	if md.hasPooling {
+		t.Error("hasPooling = true, want false")
+	}
+	if md.hasAudio {
+		t.Error("hasAudio = true, want false")
+	}
+}
+
+func TestLoadGGUFMetadataCacheHit(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "model.gguf")
+	writeTestGGUF(t, path, ggml.KV{"general.architecture": "test"})
+
+	first, err := loadGGUFMetadata(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A second lookup returns the same *ggufMetadata pointer, confirming the
+	// blob was parsed once and served from the cache thereafter.
+	second, err := loadGGUFMetadata(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if first != second {
+		t.Errorf("cache miss: got a different *ggufMetadata on the second call")
+	}
+}
+
+func TestLoadGGUFMetadataInvalidatesOnMtimeAndSize(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "model.gguf")
+	writeTestGGUF(t, path, ggml.KV{
+		"general.architecture": "test",
+		"pooling_type":         uint32(1),
+	})
+
+	first, err := loadGGUFMetadata(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !first.hasPooling {
+		t.Fatal("expected first blob to report pooling")
+	}
+
+	// Rewrite the same path with different content and a later mtime. The
+	// key (path|size|mtime) must change, forcing a re-read rather than a
+	// stale cache hit.
+	writeTestGGUF(t, path, ggml.KV{"general.architecture": "test"})
+	if err := os.Chtimes(path, time.Now().Add(time.Hour), time.Now().Add(time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+
+	second, err := loadGGUFMetadata(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if first == second {
+		t.Error("expected a fresh *ggufMetadata after the file changed")
+	}
+	if second.hasPooling {
+		t.Error("hasPooling = true after rewrite without pooling_type; stale cache")
+	}
+}
+
+func TestLoadGGUFMetadataMissingFile(t *testing.T) {
+	_, err := loadGGUFMetadata(filepath.Join(t.TempDir(), "does-not-exist.gguf"))
+	if err == nil {
+		t.Error("expected an error for a missing file")
+	}
+}

--- a/server/images.go
+++ b/server/images.go
@@ -106,7 +106,7 @@ const (
 
 // Capabilities returns the capabilities that the model supports
 func (m *Model) Capabilities() []model.Capability {
-	capabilities := m.capabilitiesForTemplate(templateCapabilitySelected, nil)
+	capabilities := m.capabilitiesForTemplate(templateCapabilitySelected)
 	if len(capabilities) == 0 {
 		slog.Warn("unknown capabilities for model", "model", m.Name)
 	}
@@ -114,12 +114,12 @@ func (m *Model) Capabilities() []model.Capability {
 	return capabilities
 }
 
-func (m *Model) capabilitiesForTemplate(source templateCapabilitySource, f *gguf.File) []model.Capability {
+func (m *Model) capabilitiesForTemplate(source templateCapabilitySource) []model.Capability {
 	capabilities := []model.Capability{}
 	var modelArch string
 
 	capabilities = m.configCapabilities(capabilities)
-	capabilities, modelArch = m.ggufCapabilities(capabilities, source, f)
+	capabilities, modelArch = m.ggufCapabilities(capabilities, source)
 	capabilities = m.projectorCapabilities(capabilities)
 	capabilities = m.templateCapabilities(capabilities, source)
 	capabilities = m.parserCapabilities(capabilities)
@@ -136,40 +136,36 @@ func (m *Model) configCapabilities(capabilities []model.Capability) []model.Capa
 	return capabilities
 }
 
-func (m *Model) ggufCapabilities(capabilities []model.Capability, source templateCapabilitySource, f *gguf.File) ([]model.Capability, string) {
+func (m *Model) ggufCapabilities(capabilities []model.Capability, source templateCapabilitySource) ([]model.Capability, string) {
 	if m.ModelPath == "" || !m.isGGUF() {
 		return capabilities, ""
 	}
 
-	if f == nil {
-		var err error
-		f, err = gguf.Open(m.ModelPath)
-		if err != nil {
-			slog.Error("couldn't open model file", "error", err)
-			return capabilities, ""
-		}
-		defer f.Close()
+	md, err := loadGGUFMetadata(m.ModelPath)
+	if err != nil {
+		slog.Error("couldn't open model file", "error", err)
+		return capabilities, ""
 	}
 
-	modelArch := f.KeyValue("general.architecture").String()
+	modelArch := md.architecture
 	switch source {
 	case templateCapabilitySelected:
 		if !usesOllamaRenderedChat(m) {
-			capabilities = chatTemplateCapabilities(capabilities, f.KeyValue("tokenizer.chat_template").String())
+			capabilities = chatTemplateCapabilities(capabilities, md.chatTemplate)
 		}
 	case templateCapabilityChat:
-		capabilities = chatTemplateCapabilities(capabilities, f.KeyValue("tokenizer.chat_template").String())
+		capabilities = chatTemplateCapabilities(capabilities, md.chatTemplate)
 	}
-	if f.KeyValue("pooling_type").Valid() {
+	if md.hasPooling {
 		capabilities = appendCapability(capabilities, model.CapabilityEmbedding)
 	} else {
 		// If no embedding is specified, we assume the model supports completion.
 		capabilities = appendCapability(capabilities, model.CapabilityCompletion)
 	}
-	if f.KeyValue("vision.block_count").Valid() {
+	if md.hasVision {
 		capabilities = appendCapability(capabilities, model.CapabilityVision)
 	}
-	if f.KeyValue("audio.block_count").Valid() {
+	if md.hasAudio {
 		capabilities = appendCapability(capabilities, model.CapabilityAudio)
 	}
 
@@ -339,28 +335,17 @@ func capabilityLogValue(present bool, capabilities []model.Capability) any {
 }
 
 func (m *Model) templateSelectionCapabilities(usesHarmony bool) (goTemplate, chatTemplate, harmony, rendererParser []model.Capability) {
-	var f *gguf.File
-	if m.ModelPath != "" && m.isGGUF() {
-		var err error
-		f, err = gguf.Open(m.ModelPath)
-		if err != nil {
-			slog.Error("couldn't open model file", "error", err)
-		} else {
-			defer f.Close()
-		}
-	}
-
 	if m.HasGoTemplate {
-		goTemplate = m.capabilitiesForTemplate(templateCapabilityGo, f)
+		goTemplate = m.capabilitiesForTemplate(templateCapabilityGo)
 	}
 	if m.HasChatTemplate {
-		chatTemplate = m.capabilitiesForTemplate(templateCapabilityChat, f)
+		chatTemplate = m.capabilitiesForTemplate(templateCapabilityChat)
 	}
 	if usesHarmony {
-		harmony = m.capabilitiesForTemplate(templateCapabilitySelected, f)
+		harmony = m.capabilitiesForTemplate(templateCapabilitySelected)
 	}
 	if m.Config.Renderer != "" || m.Config.Parser != "" {
-		rendererParser = m.capabilitiesForTemplate(templateCapabilitySelected, f)
+		rendererParser = m.capabilitiesForTemplate(templateCapabilitySelected)
 	}
 
 	return goTemplate, chatTemplate, harmony, rendererParser
@@ -682,15 +667,14 @@ func GetModel(name string) (*Model, error) {
 			m.ModelPath = filename
 			m.ParentModel = layer.From
 			if m.isGGUF() {
-				f, err := gguf.Open(filename)
+				md, err := loadGGUFMetadata(filename)
 				if err != nil {
 					slog.Error("couldn't open model file", "error", err)
 					break
 				}
-				ggufChatTemplate = f.KeyValue("tokenizer.chat_template").String()
+				ggufChatTemplate = md.chatTemplate
 				m.HasChatTemplate = ggufChatTemplate != ""
-				modelHasPooling = f.KeyValue("pooling_type").Valid()
-				f.Close()
+				modelHasPooling = md.hasPooling
 			}
 		case manifest.MediaTypeImageDraft:
 			m.DraftPath = filename


### PR DESCRIPTION
# server: cache GGUF metadata to avoid re-parsing on warm requests

**AI Disclaimer**: I'm not personally a go expert (Java/Elixir is more my bag) but armed with Fable/Opus 4.8 I figured I'd take a stab at this PR as a discussion point at least. I started off with an issue but figured may as well put up a PR! Let me know if that's not desirable. 

## Problem

Every request to a **warm** model (already resident in VRAM, `keep_alive` active) reports a large, constant `load_duration` that has nothing to do with loading the model:

| Model | Warm `load_duration` |
|---|---|
| qwen2:0.5b | ~94 ms |
| Qwen 1.7B / 4B | ~95 ms |
| Gemma 4 4B | ~257 ms |
| Gemma 4 12B (Q4_0, 6.5 GB blob) | ~250 ms |

The overhead is constant within a model family regardless of parameter count (0.5B ≈ 1.7B ≈ 4B), which points at metadata handling rather than tensors. `strace` on the serve process shows the multi-GB weights blob being re-opened 2–3× per warm request.

Related reports: #12443, #15237.

## Root cause

On every request the server re-opens the GGUF blob and re-derives a small set of values, discarding the parsed file each time:

- `GetModel` opens the blob to read `tokenizer.chat_template` and `pooling_type`.
- `Capabilities()` / `CheckCapabilities()` open it again in `ggufCapabilities` to
  read `general.architecture`, `tokenizer.chat_template`, `pooling_type`,
  `vision.block_count` and `audio.block_count`.

Both run several times per request (handler plus `scheduleRunner`), so a single warm `/api/generate` opens the blob ~5 times.

`gguf.KeyValue` scans key/values sequentially and prefixes architecture-scoped keys, so probing a key that is **absent** — which several of the probes above are on many architectures (e.g. `gemma4.pooling_type`) — decodes the entire metadata block, including the full tokenizer vocab (~262K entries for Gemma). That is ~38 ms per open, paid ~5× per warm request.

## Change

Cache the derived values per blob and share them between `GetModel` and `ggufCapabilities`, so the file is read at most once per distinct blob. Warm requests then perform no GGUF file I/O.

- `loadGGUFMetadata(path)` returns a cached  `{architecture, chatTemplate, hasPooling, hasVision, hasAudio}`, backed by a `sync.Map` keyed on `path|size|mtime`.
- `GetModel` and `ggufCapabilities` read from it instead of opening the blob; the now-unnecessary `*gguf.File` parameter is dropped from `capabilitiesForTemplate` / `ggufCapabilities`.

Blobs are content-addressed, so a re-pull with changed metadata produces a new key; `size`/`mtime` guard against a file replaced in place. The cache is process-local and grows by at most one small entry per distinct blob, matching the lifecycle of the existing `modelShowCache`.

## Validation

Measured on RTX 5080 / Linux against the real blobs.

**Warm `load_duration`, Gemma 4 12B (Q4_0):**

| | Warm `load_duration` |
|---|---|
| Before | ~250 ms |
| After | **~0.8–1.1 ms** |

**Warm `load_duration`, Qwen3:1.7b:**

| | Warm `load_duration` |
|---|---|
| Before | ~95 ms |
| After | **~0.9–1.2 ms** |

`strace -f -e trace=openat` on the serve process during a warm request confirms the 6.5 GB weights blob is not re-opened after the first (cache-filling) request; only the small manifest-layer blobs are read.

## Tests

Unit tests cover value correctness, cache hit, path/size/mtime invalidation and the missing-file error path. `go build ./server/`, `go vet ./server/` and `go test ./server/` pass.

## Notes

- First-fill concurrency: `LoadOrStore` deduplicates the stored value, not the work, so concurrent first requests for the same uncached blob may each parse it once. This happens at most once per blob per process, so it is left un-singleflighted for simplicity.
- `loadGGUFMetadata` calls `os.Stat` on every lookup, so a removed or replaced blob is detected rather than served stale from the cache.
