### PR TITLE
convert: hoist static regexps to package level

### DIFF
--- a/convert/convert_deepseek2.go
+++ b/convert/convert_deepseek2.go
@@ -10,6 +10,8 @@ import (
 	"github.com/ollama/ollama/fs/ggml"
 )
 
+var deepseek2BlockRe = regexp.MustCompile(`^blk\.(\d+)`)
+
 type deepseek2Model struct {
 	ModelParameters               // architectures, vocab_size
 	MaxPositionEmbeddings uint32  `json:"max_position_embeddings"`
@@ -141,8 +143,7 @@ func (p *deepseek2Model) Tensors(s []Tensor) (out []*ggml.Tensor) {
 	}
 
 	skipLayer := func(n string, minValue uint32) bool {
-		re := regexp.MustCompile(`^blk\.(\d+)`)
-		matches := re.FindStringSubmatch(n)
+		matches := deepseek2BlockRe.FindStringSubmatch(n)
 		if matches == nil {
 			return false
 		}

--- a/convert/convert_glm4moelite.go
+++ b/convert/convert_glm4moelite.go
@@ -14,6 +14,8 @@ import (
 	"github.com/ollama/ollama/fs/ggml"
 )
 
+var glm4MoeLiteBlockRe = regexp.MustCompile(`^blk\.(\d+)`)
+
 type glm4MoeLiteModel struct {
 	ModelParameters
 	MaxPositionEmbeddings uint32  `json:"max_position_embeddings"`
@@ -210,8 +212,7 @@ func (p *glm4MoeLiteModel) Tensors(s []Tensor) (out []*ggml.Tensor) {
 	}
 
 	skipLayer := func(n string, minValue uint32) bool {
-		re := regexp.MustCompile(`^blk\.(\d+)`)
-		matches := re.FindStringSubmatch(n)
+		matches := glm4MoeLiteBlockRe.FindStringSubmatch(n)
 		if matches == nil {
 			return false
 		}

--- a/convert/convert_qwen3vl.go
+++ b/convert/convert_qwen3vl.go
@@ -15,6 +15,8 @@ import (
 	"github.com/ollama/ollama/fs/ggml"
 )
 
+var qwen3VLDeepstackRe = regexp.MustCompile(`^v\.deepstack\.(\d+)\.(.+)$`)
+
 type qwen3VLModel struct {
 	qwen3Model `json:"text_config"`
 
@@ -214,8 +216,7 @@ func (m *qwen3VLModel) qwen3VLProjectorRename(name string) string {
 	}
 
 	if strings.HasPrefix(name, "v.deepstack.") {
-		re := regexp.MustCompile(`^v\.deepstack\.(\d+)\.(.+)$`)
-		if matches := re.FindStringSubmatch(name); matches != nil {
+		if matches := qwen3VLDeepstackRe.FindStringSubmatch(name); matches != nil {
 			seqIdx, err := strconv.Atoi(matches[1])
 			if err == nil && seqIdx < len(m.VisionModel.DeepstackVisualIndexes) {
 				blockIdx := m.VisionModel.DeepstackVisualIndexes[seqIdx]


### PR DESCRIPTION
## Summary
- Move static `regexp.MustCompile` calls in deepseek2, glm4moelite, and qwen3vl converters to package-level vars
- Avoid recompiling the same patterns on every tensor during convert loops

## Test plan
- [x] `go test ./convert/...`
