### PR TITLE
fs/ggml: avoid strings.Reader alloc in writeGGUFString

### DIFF
--- a/fs/ggml/gguf.go
+++ b/fs/ggml/gguf.go
@@ -431,7 +431,7 @@ func writeGGUFString(w io.Writer, s string) error {
 		return err
 	}
 
-	_, err := io.Copy(w, strings.NewReader(s))
+	_, err := io.WriteString(w, s)
 	return err
 }
 


### PR DESCRIPTION
## Summary
- Replace `io.Copy(w, strings.NewReader(s))` with `io.WriteString(w, s)` in `writeGGUFString`.
- `strings.Reader.WriteTo` already called `WriteString`, so this drops a pure overhead allocation per scalar string KV.

## Benchmarks (median of 5, Apple M4 Pro, `io.Discard`)

Full `writeGGUFString` (type + length + body):

| | before | after |
|---|---:|---:|
| ns/op | ~35.6 | ~23.4 (~1.5×) |
| ops/s | ~28M | ~43M |
| allocs/op | 3 (48 B) | 2 (16 B) |

Contested line only (`Copy`+`NewReader` vs `WriteString`):

| | before | after |
|---|---:|---:|
| ns/op | ~17.8 | ~2.7 (~6.6×) |
| ops/s | ~56M | ~370M |
| allocs/op | 1 (32 B) | 0 |

## Test plan
- [x] `go test ./fs/ggml/`