### PR TITLE
llm: compute TrimSpace once in token repeat detection

### DIFF
--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -1648,11 +1648,12 @@ func (s *llamaServerRunner) Completion(ctx context.Context, req CompletionReques
 			}
 
 			// Token repeat detection
+			token := strings.TrimSpace(lsResp.Content)
 			switch {
-			case strings.TrimSpace(lsResp.Content) == lastToken:
+			case token == lastToken:
 				tokenRepeat++
 			default:
-				lastToken = strings.TrimSpace(lsResp.Content)
+				lastToken = token
 				tokenRepeat = 0
 			}
 			if tokenRepeat > 30 {


### PR DESCRIPTION
## Summary
- Cache `strings.TrimSpace(lsResp.Content)` once per streamed token instead of evaluating it in both the repeat-check case and the `lastToken` assignment.