### PR TITLE
Add whatbroke to community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ console.log(response.message.content);
 - [Langfuse](https://langfuse.com/docs/integrations/ollama) - Open source LLM observability
 - [HoneyHive](https://docs.honeyhive.ai/integrations/ollama) - AI observability and evaluation for agents
 - [MLflow Tracing](https://mlflow.org/docs/latest/llms/tracing/index.html#automatic-tracing) - Open source LLM observability
+- [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) - CLI to diff an agent's tool calls, cost and latency between two runs
 
 ### Database & Embeddings
 


### PR DESCRIPTION
Adds whatbroke under Observability & Monitoring. It is a CLI that diffs an agent's behavior between two recorded runs: tool calls added, dropped or reordered, argument diffs, cost and latency changes. Works against Ollama's OpenAI-compatible endpoint, and the repo includes a case study run entirely on Ollama (llama3.2:3b vs 1b). MIT, on npm as whatbroke-cli.