### PR TITLE
feat(cmd): add --json flag to list and ps commands

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1081,6 +1081,13 @@ func ListHandler(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	jsonFormat, _ := cmd.Flags().GetBool("json")
+	if jsonFormat {
+		encoder := json.NewEncoder(os.Stdout)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(models)
+	}
+
 	var data [][]string
 
 	for _, m := range models.Models {
@@ -1119,6 +1126,13 @@ func ListRunningHandler(cmd *cobra.Command, args []string) error {
 	models, err := client.ListRunning(cmd.Context())
 	if err != nil {
 		return err
+	}
+
+	jsonFormat, _ := cmd.Flags().GetBool("json")
+	if jsonFormat {
+		encoder := json.NewEncoder(os.Stdout)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(models)
 	}
 
 	var data [][]string
@@ -2413,6 +2427,7 @@ func NewCLI() *cobra.Command {
 		PreRunE: checkServerHeartbeat,
 		RunE:    ListHandler,
 	}
+	listCmd.Flags().Bool("json", false, "Format output as JSON")
 
 	psCmd := &cobra.Command{
 		Use:     "ps",
@@ -2420,6 +2435,7 @@ func NewCLI() *cobra.Command {
 		PreRunE: checkServerHeartbeat,
 		RunE:    ListRunningHandler,
 	}
+	psCmd.Flags().Bool("json", false, "Format output as JSON")
 	copyCmd := &cobra.Command{
 		Use:     "cp SOURCE DESTINATION",
 		Short:   "Copy a model",


### PR DESCRIPTION
## What does this PR do?

The Ollama CLI currently outputs model information from `ollama list` and `ollama ps` as plain text tables. While this is great for human readability, it makes it difficult for developers to write scripts or automation tools that parse this output. 

This PR adds a `--json` flag to `ollama list` and `ollama ps`. When used, the commands will output the raw API response in structured JSON format instead of rendering a table.

## Changes
- Registered the `--json` boolean flag for both `listCmd` and `psCmd`.
- Updated `ListHandler` and `ListRunningHandler` to check for the `--json` flag and output using `json.NewEncoder(os.Stdout)` if provided.