### PR TITLE
model/parsers: accept bare qwen tool calls

### DIFF
--- a/model/parsers/qwen3coder.go
+++ b/model/parsers/qwen3coder.go
@@ -19,13 +19,16 @@ import (
 type qwenParserState int
 
 const (
-	toolOpenTag  = "<tool_call>"
-	toolCloseTag = "</tool_call>"
+	toolOpenTag          = "<tool_call>"
+	toolCloseTag         = "</tool_call>"
+	bareFunctionOpenTag  = "<function="
+	bareFunctionCloseTag = "</function>"
 )
 
 const (
 	qwenParserState_LookingForToolStart qwenParserState = iota
 	qwenParserState_CollectingToolContent
+	qwenParserState_CollectingBareFunction
 )
 
 type Qwen3CoderParser struct {
@@ -135,21 +138,36 @@ func eat(p *Qwen3CoderParser) ([]qwenEvent, bool) {
 
 	switch p.state {
 	case qwenParserState_LookingForToolStart:
-		if strings.Contains(p.acc.String(), toolOpenTag) {
-			// we found a full tool open tag, so we can emit the content before the
-			// tag, being sure to trim any trailing whitespace
-			split := strings.SplitN(p.acc.String(), toolOpenTag, 2)
-			before := split[0]
+		toolStart := strings.Index(p.acc.String(), toolOpenTag)
+		bareFunctionStart := p.bareFunctionStart(p.acc.String())
+		if bareFunctionStart >= 0 && (toolStart < 0 || bareFunctionStart < toolStart) {
+			// Some Qwen checkpoints omit the outer <tool_call> wrapper. Keep the
+			// function tag in the buffer so parseToolCall receives the same raw
+			// function XML as it does for wrapped calls.
+			before := p.acc.String()[:bareFunctionStart]
 			before = strings.TrimRightFunc(before, unicode.IsSpace)
 			if len(before) > 0 {
 				events = append(events, qwenEventContent{content: before})
 			}
-			after := split[1]
+			after := p.acc.String()[bareFunctionStart:]
+			p.acc.Reset()
+			p.acc.WriteString(after)
+			p.state = qwenParserState_CollectingBareFunction
+			return events, true
+		} else if toolStart >= 0 {
+			// we found a full tool open tag, so we can emit the content before the
+			// tag, being sure to trim any trailing whitespace
+			before := p.acc.String()[:toolStart]
+			before = strings.TrimRightFunc(before, unicode.IsSpace)
+			if len(before) > 0 {
+				events = append(events, qwenEventContent{content: before})
+			}
+			after := p.acc.String()[toolStart+len(toolOpenTag):]
 			p.acc.Reset()
 			p.acc.WriteString(after)
 			p.state = qwenParserState_CollectingToolContent
 			return events, true
-		} else if overlap := overlap(p.acc.String(), toolOpenTag); overlap > 0 {
+		} else if overlap := max(overlap(p.acc.String(), toolOpenTag), bareFunctionOverlap(p.acc.String())); overlap > 0 {
 			// we found a partial tool open tag, so we can emit the unambiguous part,
 			// which is the (trailing-whitespace trimmed) content before the partial
 			// tool open tag
@@ -199,9 +217,64 @@ func eat(p *Qwen3CoderParser) ([]qwenEvent, bool) {
 			// here
 			return events, false
 		}
+	case qwenParserState_CollectingBareFunction:
+		if strings.Contains(p.acc.String(), bareFunctionCloseTag) {
+			split := strings.SplitN(p.acc.String(), bareFunctionCloseTag, 2)
+			before := split[0]
+			after := strings.TrimLeftFunc(split[1], unicode.IsSpace)
+			// The malformed output usually omits only the opening wrapper, leaving
+			// its closing tag behind. Consume that orphaned tag with the implicit
+			// tool call instead of leaking it into assistant content.
+			after = strings.TrimPrefix(after, toolCloseTag)
+			after = strings.TrimLeftFunc(after, unicode.IsSpace)
+			p.acc.Reset()
+			p.acc.WriteString(after)
+			events = append(events, qwenEventRawToolCall{raw: before + bareFunctionCloseTag})
+			p.state = qwenParserState_LookingForToolStart
+			return events, true
+		}
+		return events, false
 	default:
 		panic("unreachable")
 	}
+}
+
+func (p *Qwen3CoderParser) bareFunctionStart(s string) int {
+	searchFrom := 0
+	for searchFrom < len(s) {
+		start := strings.Index(s[searchFrom:], bareFunctionOpenTag)
+		if start < 0 {
+			return -1
+		}
+		start += searchFrom
+		nameStart := start + len(bareFunctionOpenTag)
+		nameEnd := strings.IndexByte(s[nameStart:], '>')
+		if nameEnd < 0 {
+			return -1
+		}
+		nameEnd += nameStart
+		name := s[nameStart:nameEnd]
+		for _, tool := range p.tools {
+			if tool.Function.Name == name {
+				return start
+			}
+		}
+		searchFrom = nameEnd + 1
+	}
+	return -1
+}
+
+func bareFunctionOverlap(s string) int {
+	start := strings.LastIndexByte(s, '<')
+	if start < 0 {
+		return 0
+	}
+	suffix := s[start:]
+	if strings.HasPrefix(bareFunctionOpenTag, suffix) ||
+		(strings.HasPrefix(suffix, bareFunctionOpenTag) && !strings.ContainsRune(suffix, '>')) {
+		return len(suffix)
+	}
+	return 0
 }
 
 type XMLFunctionCall struct {

--- a/model/parsers/qwen3coder_test.go
+++ b/model/parsers/qwen3coder_test.go
@@ -23,6 +23,7 @@ func TestQwenParserStreaming(t *testing.T) {
 
 	cases := []struct {
 		desc  string
+		tools []api.Tool
 		steps []step
 		only  bool
 	}{
@@ -60,6 +61,55 @@ func TestQwenParserStreaming(t *testing.T) {
 						qwenEventRawToolCall{raw: "in tool call 2"},
 						qwenEventContent{content: "after2"},
 					},
+				},
+			},
+		},
+		{
+			desc:  "bare function call for a known tool",
+			tools: []api.Tool{tool("write_file", nil)},
+			steps: []step{
+				{
+					input: "before<function=write_file>\n<parameter=path>\na.txt\n</parameter>\n</function>after",
+					wantEvents: []qwenEvent{
+						qwenEventContent{content: "before"},
+						qwenEventRawToolCall{raw: "<function=write_file>\n<parameter=path>\na.txt\n</parameter>\n</function>"},
+						qwenEventContent{content: "after"},
+					},
+				},
+			},
+		},
+		{
+			desc:  "bare function call streamed across chunks",
+			tools: []api.Tool{tool("write_file", nil)},
+			steps: []step{
+				{
+					input:      "before<func",
+					wantEvents: []qwenEvent{qwenEventContent{content: "before"}},
+				},
+				{
+					input:      "tion=write_",
+					wantEvents: []qwenEvent{},
+				},
+				{
+					input:      "file>\n<parameter=path>\na.txt\n</parameter>\n</func",
+					wantEvents: []qwenEvent{},
+				},
+				{
+					input: "tion>after",
+					wantEvents: []qwenEvent{
+						qwenEventRawToolCall{raw: "<function=write_file>\n<parameter=path>\na.txt\n</parameter>\n</function>"},
+						qwenEventContent{content: "after"},
+					},
+				},
+			},
+		},
+		{
+			desc:  "bare function for an unknown tool remains content",
+			tools: []api.Tool{tool("write_file", nil)},
+			steps: []step{
+				{
+					input:      "<function=delete_file></function>",
+					wantEvents: []qwenEvent{qwenEventContent{content: "<function=delete_file></function>"}},
 				},
 			},
 		},
@@ -359,6 +409,7 @@ func TestQwenParserStreaming(t *testing.T) {
 
 		t.Run(tc.desc, func(t *testing.T) {
 			parser := Qwen3CoderParser{}
+			parser.Init(tc.tools, nil, nil)
 
 			for i, step := range tc.steps {
 				parser.acc.WriteString(step.input)
@@ -1032,6 +1083,44 @@ func TestQwenToolCallValueParsing(t *testing.T) {
 				t.Errorf("got %v (type %T), want %v (type %T)", got, got, tc.want, tc.want)
 			}
 		})
+	}
+}
+
+func TestQwen3CoderParserBareFunctionCall(t *testing.T) {
+	parser := Qwen3CoderParser{}
+	parser.Init(
+		[]api.Tool{
+			tool("write_file", map[string]api.ToolProperty{
+				"path": {Type: api.PropertyType{"string"}},
+			}),
+		},
+		nil,
+		nil,
+	)
+
+	content, _, calls, err := parser.Add(
+		`<function=write_file><parameter=path>a.txt</parameter></function></tool_call>`,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if content != "" {
+		t.Fatalf("expected no content, got %q", content)
+	}
+
+	want := api.ToolCall{
+		Function: api.ToolCallFunction{
+			Name:      "write_file",
+			Arguments: testArgs(map[string]any{"path": "a.txt"}),
+			Index:     0,
+		},
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(calls))
+	}
+	if !toolCallEqual(calls[0], want) {
+		t.Fatalf("call mismatch: got %#v, want %#v", calls[0], want)
 	}
 }
 


### PR DESCRIPTION
## Summary

Qwen3 Coder occasionally emits a valid `<function=...>` block without its opening `<tool_call>` wrapper. The parser currently returns that XML as assistant content, so clients never receive the tool call.

This change:

- recognizes a bare function only when its name matches an offered tool
- supports tags split across streaming chunks
- consumes the orphaned `</tool_call>` that the malformed output commonly retains
- leaves unknown function-shaped text untouched

This addresses the specific missing-wrapper case discussed in #13093 and reported separately in #17353.

## Testing

- `go test ./model/parsers`
- `go test -race ./model/parsers`
- `go test ./model/...`
- `go vet ./model/parsers`

The regression tests cover a complete bare call, chunked input, the orphaned wrapper close, and an unknown function that must remain content.