### PR TITLE
llm: use direct I/O for Vulkan iGPUs

### DIFF
--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -390,14 +390,7 @@ func startLlamaServer(launch llamaServerLaunchConfig, out io.Writer) (cmd *exec.
 		params = append(params, "--no-mmap")
 	}
 
-	// Direct I/O skips the page cache on load for integrated CUDA/ROCm GPUs, which
-	// share system memory with the CPU and would otherwise double-buffer weights.
-	for _, g := range launch.gpus {
-		if runtime.GOOS == "linux" && g.Integrated && (strings.EqualFold(g.Library, "CUDA") || strings.EqualFold(g.Library, "ROCm")) {
-			params = append(params, "--direct-io")
-			break
-		}
-	}
+	params = appendDirectIOArgs(params, launch.gpus, runtime.GOOS)
 
 	// KV cache type
 	if launch.kvCacheType != "" {
@@ -628,6 +621,29 @@ func appendFlashAttentionArgs(params []string, gpus []ml.DeviceInfo) []string {
 	default:
 		return append(params, "--flash-attn", "auto")
 	}
+}
+
+func appendDirectIOArgs(params []string, gpus []ml.DeviceInfo, goos string) []string {
+	if goos != "linux" {
+		return params
+	}
+
+	// Direct I/O skips the page cache on load for integrated GPUs, which share
+	// system memory with the CPU and would otherwise double-buffer weights.
+	for _, g := range gpus {
+		if !g.Integrated {
+			continue
+		}
+
+		switch {
+		case strings.EqualFold(g.Library, "CUDA"),
+			strings.EqualFold(g.Library, "ROCm"),
+			strings.EqualFold(g.Library, "Vulkan"):
+			return append(params, "--direct-io")
+		}
+	}
+
+	return params
 }
 
 func appendMainGPUArgs(params []string, opts api.Options) []string {

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -2036,6 +2036,76 @@ func TestAppendFlashAttentionArgs(t *testing.T) {
 	}
 }
 
+func TestAppendDirectIOArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		goos string
+		gpus []ml.DeviceInfo
+		want []string
+	}{
+		{
+			name: "linux integrated CUDA",
+			goos: "linux",
+			gpus: []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}, Integrated: true}},
+			want: []string{"base", "--direct-io"},
+		},
+		{
+			name: "linux integrated ROCm",
+			goos: "linux",
+			gpus: []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "ROCm"}, Integrated: true}},
+			want: []string{"base", "--direct-io"},
+		},
+		{
+			name: "linux integrated Vulkan",
+			goos: "linux",
+			gpus: []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "Vulkan"}, Integrated: true}},
+			want: []string{"base", "--direct-io"},
+		},
+		{
+			name: "library match is case insensitive",
+			goos: "linux",
+			gpus: []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "vulkan"}, Integrated: true}},
+			want: []string{"base", "--direct-io"},
+		},
+		{
+			name: "linux discrete Vulkan",
+			goos: "linux",
+			gpus: []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "Vulkan"}}},
+			want: []string{"base"},
+		},
+		{
+			name: "non-linux integrated Vulkan",
+			goos: "windows",
+			gpus: []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "Vulkan"}, Integrated: true}},
+			want: []string{"base"},
+		},
+		{
+			name: "unsupported integrated backend",
+			goos: "linux",
+			gpus: []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "Metal"}, Integrated: true}},
+			want: []string{"base"},
+		},
+		{
+			name: "multiple eligible GPUs append one flag",
+			goos: "linux",
+			gpus: []ml.DeviceInfo{
+				{DeviceID: ml.DeviceID{Library: "Vulkan"}, Integrated: true},
+				{DeviceID: ml.DeviceID{Library: "ROCm"}, Integrated: true},
+			},
+			want: []string{"base", "--direct-io"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := appendDirectIOArgs([]string{"base"}, tt.gpus, tt.goos)
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("appendDirectIOArgs = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestAppendMainGPUArgs(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
Fixes #17285

## Summary

- enable direct I/O for integrated Vulkan GPUs on Linux, matching the existing CUDA and ROCm behavior
- keep discrete GPUs, non-Linux systems, and other backends unchanged
- add table-driven coverage for backend, device type, OS, case-insensitive matching, and duplicate flag prevention

## Root Cause

Ollama only passed `--direct-io` to integrated CUDA and ROCm devices. On the affected integrated Vulkan setup, mmap fails with `No such device`, while the buffered non-mmap upload path fails with `Bad address`. The same models load with the corresponding upstream llama.cpp Vulkan image.

When direct I/O is available, llama.cpp disables mmap and uses its aligned direct-read path. Extending Ollama's existing integrated-GPU policy to Vulkan selects that path without changing behavior for discrete GPUs.

## Verification

- `go test ./llm -run TestAppendDirectIOArgs -count=1 -v`
- `go test ./llm -count=1`
- `go test -count=1 -benchtime=1x ./...`
- `go vet ./llm`
- `go mod tidy -diff`
- `git diff --check`

## Notes for Reviewers

- Hardware end-to-end validation was not available locally; the regression test verifies the generated llama-server argument policy.
- The scope is limited to Linux integrated GPUs already identified by Ollama's device discovery.
