### PR TITLE
docs: include model name in ollama create example

### DIFF
--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -121,7 +121,7 @@ SYSTEM """You are a happy cat."""
 Then run `ollama create`:
 
 ```
-ollama create -f Modelfile
+ollama create my-model -f Modelfile
 ```
 
 ### List running models


### PR DESCRIPTION
## Summary
- Fix the CLI docs example for creating a customized model so it includes the required positional model name.
- `ollama create -f Modelfile` currently fails with `Error: accepts 1 arg(s), received 0`.

Fixes #17346

## Test plan
- [ ] Confirm `docs/cli.mdx` example matches `ollama create --help` (requires 1 arg)
- [ ] Spot-check the Create a customized model section on the docs site preview if available

Made with [Cursor](https://cursor.com)