### PR TITLE
fix(llm): only feed content-carrying events to the repeat detector

### DIFF
--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -1647,17 +1647,35 @@ func (s *llamaServerRunner) Completion(ctx context.Context, req CompletionReques
 				return fmt.Errorf("error unmarshalling llama-server response: %v", err)
 			}
 
-			// Token repeat detection
-			switch {
-			case strings.TrimSpace(lsResp.Content) == lastToken:
-				tokenRepeat++
-			default:
-				lastToken = strings.TrimSpace(lsResp.Content)
-				tokenRepeat = 0
-			}
-			if tokenRepeat > 30 {
-				slog.Debug("prediction aborted, token repeat limit reached")
-				return ctx.Err()
+			// Token repeat detection. llama-server streams an event for every
+			// sampled token, including ones that carry no text: tokens held back
+			// while a stop sequence is partially matched, special tokens that are
+			// not preserved, and the terminating stop event. Those all compare
+			// equal once trimmed, so only chunks that carry model output are
+			// considered here, otherwise content-free events pile up and abort a
+			// healthy generation.
+			if lsResp.Content != "" {
+				switch {
+				case strings.TrimSpace(lsResp.Content) == lastToken:
+					tokenRepeat++
+				default:
+					lastToken = strings.TrimSpace(lsResp.Content)
+					tokenRepeat = 0
+				}
+
+				// 30 picked as an arbitrary max token repeat limit, modify as needed
+				if tokenRepeat > 30 {
+					slog.Debug("prediction aborted, token repeat limit reached")
+
+					// Close before the Done callback for the same reason as the
+					// normal path below, and to stop llama-server generating.
+					if err := res.Body.Close(); err != nil {
+						return fmt.Errorf("error closing llama-server response: %v", err)
+					}
+
+					fn(CompletionResponse{Done: true, DoneReason: DoneReasonLength})
+					return nil
+				}
 			}
 
 			if lsResp.Content != "" && !lsResp.Stop {

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -933,6 +933,122 @@ func TestLlamaServerCompletionLengthStop(t *testing.T) {
 	}
 }
 
+// llama-server streams an event for every sampled token, including ones that
+// carry no text. Those must not be mistaken for a repeating token.
+func TestLlamaServerCompletionContentFreeChunksDoNotTripRepeatLimit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			fmt.Fprint(w, `{"status":"ok"}`)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprintln(w, `data: {"content":"hello","stop":false}`)
+		fmt.Fprintln(w, ``)
+		// tokens withheld while a stop sequence is partially matched
+		for range 40 {
+			fmt.Fprintln(w, `data: {"content":"","stop":false}`)
+			fmt.Fprintln(w, ``)
+		}
+		fmt.Fprintln(w, `data: {"content":" world","stop":false}`)
+		fmt.Fprintln(w, ``)
+		fmt.Fprintln(w, `data: {"content":"","stop":true,"stop_type":"eos","timings":{"prompt_n":1,"prompt_ms":1,"predicted_n":42,"predicted_ms":1}}`)
+	}))
+	defer srv.Close()
+
+	parts := strings.Split(srv.URL, ":")
+	var portInt int
+	fmt.Sscanf(parts[len(parts)-1], "%d", &portInt)
+
+	runner := &llamaServerRunner{
+		port:    portInt,
+		cmd:     fakeRunningCmd(),
+		sem:     semaphore.NewWeighted(1),
+		options: api.Options{Runner: api.Runner{NumCtx: 2048}},
+	}
+
+	var content strings.Builder
+	var lastResp CompletionResponse
+	opts := api.DefaultOptions()
+	err := runner.Completion(t.Context(), CompletionRequest{
+		Prompt:  "test",
+		Options: &opts,
+	}, func(cr CompletionResponse) {
+		content.WriteString(cr.Content)
+		lastResp = cr
+	})
+	if err != nil {
+		t.Fatalf("Completion error: %v", err)
+	}
+
+	if content.String() != "hello world" {
+		t.Errorf("content = %q, want %q", content.String(), "hello world")
+	}
+	if !lastResp.Done {
+		t.Error("final response should be done")
+	}
+	if lastResp.DoneReason != DoneReasonStop {
+		t.Errorf("DoneReason = %v, want %v", lastResp.DoneReason, DoneReasonStop)
+	}
+	if lastResp.EvalCount != 42 {
+		t.Errorf("EvalCount = %d, want 42", lastResp.EvalCount)
+	}
+}
+
+// A generation that really is looping still stops, but it has to end with a
+// done response so clients are not left with a silently truncated stream.
+func TestLlamaServerCompletionTokenRepeatLimitSendsDone(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			fmt.Fprint(w, `{"status":"ok"}`)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		for range 40 {
+			fmt.Fprintln(w, `data: {"content":"tok","stop":false}`)
+			fmt.Fprintln(w, ``)
+		}
+	}))
+	defer srv.Close()
+
+	parts := strings.Split(srv.URL, ":")
+	var portInt int
+	fmt.Sscanf(parts[len(parts)-1], "%d", &portInt)
+
+	runner := &llamaServerRunner{
+		port:    portInt,
+		cmd:     fakeRunningCmd(),
+		sem:     semaphore.NewWeighted(1),
+		options: api.Options{Runner: api.Runner{NumCtx: 2048}},
+	}
+
+	var responses []CompletionResponse
+	opts := api.DefaultOptions()
+	err := runner.Completion(t.Context(), CompletionRequest{
+		Prompt:  "test",
+		Options: &opts,
+	}, func(cr CompletionResponse) {
+		responses = append(responses, cr)
+	})
+	if err != nil {
+		t.Fatalf("Completion error: %v", err)
+	}
+
+	if len(responses) == 0 {
+		t.Fatal("got no responses")
+	}
+	last := responses[len(responses)-1]
+	if !last.Done {
+		t.Error("final response should be done")
+	}
+	if last.DoneReason != DoneReasonLength {
+		t.Errorf("DoneReason = %v, want %v", last.DoneReason, DoneReasonLength)
+	}
+	// 31 content chunks are streamed before the 32nd trips the limit.
+	if got := len(responses) - 1; got != 31 {
+		t.Errorf("streamed %d content chunks, want 31", got)
+	}
+}
+
 func TestLlamaServerStatusErrorMessageIncludesOOMStatus(t *testing.T) {
 	status := &StatusWriter{}
 	status.SetLastError("error: Insufficient Memory (00000008:kIOGPUCommandBufferCallbackErrorOutOfMemory)")


### PR DESCRIPTION
# Issue #17270 — `/api/generate` aborts with "token repeat limit reached"

## 1. Root cause

`llm/llama_server.go`'s `llamaServerRunner.Completion` carries a loop-detection
kill switch: if 31 consecutive stream events have the same whitespace-trimmed
`content`, the generation is aborted. The heuristic itself is old — it was in
`llm/server.go` unchanged as far back as v0.20.7 — but the stream it inspects
changed underneath it in 0.32.x, when `runner: Remove CGO engines, use
llama-server exclusively for GGML models` (#16031) made llama-server the only
GGML backend.

**The two streams do not have the same semantics.**

The Go runner never emitted a content-free event. `runner/ollamarunner`'s
`flushPending` bailed out before writing anything when the flushed text was
empty:

```go
if len(joined) == 0 {
    return true
}
```

So every event the detector saw carried real model output.

llama-server does the opposite: `process_token` calls `send_partial_response`
for *every* sampled token, including ones whose visible delta is empty
(`tools/server/server-context.cpp`, llama.cpp `b10091` — the ref pinned in
`LLAMA_CPP_VERSION`):

```cpp
if (send_text) {
    result.text_to_send = slot.generated_text.substr(pos, std::string::npos);
    slot.n_sent_text += result.text_to_send.size();
} else {
    result.text_to_send = "";      // withheld, but still streamed
}
slot.add_token(result);
if (slot.task->params.stream) {
    send_partial_response(slot, result, false);
}
```

and `to_json_non_oaicompat` always serialises that as `{"content": "", "stop":
false, ...}`. Content-free events are emitted when a token is withheld because
the tail of the output partially matches a stop sequence, when a special token
is not in `preserved_tokens` and renders to `""`, and for the terminating
`stop` event.

Because the detector compares `strings.TrimSpace(content)`, every one of those
events collapses to `""` and therefore compares equal to the previous one.
A run of structurally content-free events — which is a normal artifact of the
stream, not model output — walks `tokenRepeat` up to the limit and kills a
perfectly healthy generation.

There is a second defect in the same block. When the limit trips, the code did:

```go
return ctx.Err()
```

The `select` at the top of the loop already returns on `ctx.Done()`, so at this
point the context is essentially never cancelled and `ctx.Err()` is `nil`.
`Completion` therefore reported *success* while never delivering a final
`Done` response. `server/routes.go` `GenerateHandler` builds its reply from
that callback, so the client got the partial text with `"done": false`, no
`done_reason`, no metrics and no `context` — and the streaming path just
stopped mid-stream. This is why the failure presents as an "abort" rather than
an early stop, and it is the same broken response shape reported in #14117.

Note this matches the issue title exactly: the sibling `Chat` method
(`/v1/chat/completions` path) has no repeat detection at all, so only
`/api/generate` and the Go-rendered chat path are affected.

## 2. The fix and why

`llm/llama_server.go`, in the `Completion` SSE loop:

1. **Only feed events that carry model output into the detector**
   (`if lsResp.Content != ""`). This restores the invariant the heuristic was
   written against — one event, one piece of visible model output — which the
   Go runner used to guarantee. Genuine degenerate output (including a model
   spewing whitespace, which still trims to `""` but arrives as non-empty
   content) is still detected; only llama-server's content-free framing events
   are excluded. The guard deliberately wraps just the detector, because the
   `stop` event carries empty content and still has to be processed below.

2. **End cleanly when the limit does trip.** Close the response body (which
   also disconnects llama-server and cancels the task) and emit a real
   `CompletionResponse{Done: true, DoneReason: DoneReasonLength}` instead of
   returning `ctx.Err()`. `DoneReasonLength` (`"length"`) is used because a
   repeat abort is a server-side truncation, and that is the existing
   done reason that tells a client the output was cut short by a limit; it also
   maps correctly through the OpenAI compatibility layer. Body-close happens
   before the callback for the reason already documented above the loop:
   `routes` tokenizes from the Done callback to build the Generate context.

The 30 threshold, the `TrimSpace` comparison and the debug log are left exactly
as they were — this change is about *what counts as a token*, not about
retuning the heuristic.

## 3. Files changed

| File | Change |
|------|--------|
| `llm/llama_server.go` | Skip content-free stream events in the token-repeat detector; emit a proper `Done`/`length` response instead of `return ctx.Err()` when the limit trips |
| `llm/llama_server_test.go` | `TestLlamaServerCompletionContentFreeChunksDoNotTripRepeatLimit`, `TestLlamaServerCompletionTokenRepeatLimitSendsDone` |
| `NOTES.md` | This file |

## 4. Risk / uncertainty

**What I am confident about.** The stream-semantics mismatch and the
`return ctx.Err()` → silent-truncation bug are both real and both verified
against the pinned llama.cpp source and against the pre-0.32 Go runner. The
second one alone fully explains the shape of the user-visible failure
(truncated text, `done: false`, no context) — the pre-fix test run reproduces
it literally: `content = "hello", want "hello world"`.

**What I am not certain about.** I could not reproduce the reporter's exact
run, and their later comments describe a second, deeper symptom that this
change does not address: generation is fine right after startup and only
degenerates *after many requests*, with llama-server prompt-cache selection and
reuse in the log immediately before the failure. If the model is genuinely
looping by then, the detector is doing its job and the real bug is upstream
state corruption — most likely llama.cpp's RAM prompt cache (ollama never
passes `--cache-ram`, so llama.cpp's default applies) possibly combined with
`--context-shift`, which ollama passes in `appendContextShiftArgs`. That is a
llama.cpp-side investigation and out of scope for a minimal Go fix. With this
change such a case now terminates as a well-formed `done`/`length` response
instead of a silently truncated one, which should also make it much easier to
diagnose from the client side.

**Behaviour changes callers may notice.** A repeat-limit stop now produces a
final response where it previously produced none; clients that tolerated the
missing `done` chunk are unaffected, and `/api/generate` now returns
`done_reason: "length"` plus a `context` for these responses. The final
response carries zero `eval_count`/`prompt_eval_count`, because llama-server
only includes `timings` on the terminating event, which an aborted stream never
reaches. Populating those would mean plumbing `tokens_predicted` /
`tokens_evaluated` from the partial events into
`llamaServerCompletionResponse`, which is more surface than this issue
warrants.

I deliberately did not take the approach of open PR #14523 (a new
`token_repeat_limit` API option plus a new `DoneReasonRepeat`): that adds
public API surface and touches `api/types.go`, `openai/openai.go` and three doc
files, which is well beyond the scope of this issue.

## 5. How I verified it

Go 1.26.0 (`/home/pjsump/go-sdk/go`).

```
gofmt -l llm/                 # clean
go vet ./llm/                 # clean
go test ./llm/ ./server/ -count=1
    ok  github.com/ollama/ollama/llm     1.965s
    ok  github.com/ollama/ollama/server  2.843s
```

Both new tests were confirmed to fail on the unmodified source (reverted
`llm/llama_server.go`, kept the tests) and pass with the fix:

```
--- FAIL: TestLlamaServerCompletionContentFreeChunksDoNotTripRepeatLimit
    content = "hello", want "hello world"
    final response should be done
    EvalCount = 0, want 42
--- FAIL: TestLlamaServerCompletionTokenRepeatLimitSendsDone
    final response should be done
    DoneReason = stop, want length
    streamed 30 content chunks, want 31
```

The first test streams `"hello"`, then 40 consecutive `{"content":""}` events
(the withheld-token case), then `" world"`, then the `stop` event: before the
fix the generation is killed after `"hello"` and the caller never sees a `done`
response. The second streams 40 identical `"tok"` chunks — a genuinely looping
model — and asserts generation still stops at the limit but now terminates with
`done: true` / `done_reason: "length"`.

Source evidence was cross-checked against upstream rather than assumed:
`llm/server.go` and `runner/ollamarunner/runner.go` at tag `v0.20.7`, and
`tools/server/server-context.cpp` / `server-task.cpp` at llama.cpp `b10091`.

Not verified: end-to-end behaviour against a real llama-server and a real
model, which needs a GPU host and a model blob that neither is available here.
