### PR TITLE
docs: add model name to ollama create example

### DIFF
--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -121,7 +121,7 @@ SYSTEM """You are a happy cat."""
 Then run `ollama create`:
 
 ```
-ollama create -f Modelfile
+ollama create my-model -f Modelfile
 ```
 
 ### List running models


### PR DESCRIPTION
The `ollama create` example was missing the required model name argument.

Running `ollama create -f Modelfile` as documented fails with:
```
Error: accepts 1 arg(s), received 0
```

Fixed to: `ollama create my-model -f Modelfile`

Fixes #17346