### PR TITLE
mlx: keep loaded model memory resident

### DIFF
--- a/x/mlxrunner/mlx/memory.go
+++ b/x/mlxrunner/mlx/memory.go
@@ -1,12 +1,14 @@
 package mlx
 
 // #include "generated.h"
+// #include <stdlib.h>
 import "C"
 
 import (
 	"fmt"
 	"log/slog"
 	"strconv"
+	"unsafe"
 )
 
 func (b Byte) String() string {
@@ -64,6 +66,46 @@ func PeakMemory() int {
 
 func ResetPeakMemory() {
 	C.mlx_reset_peak_memory()
+}
+
+// MaxRecommendedWorkingSetSize returns the device's recommended upper bound
+// for resident Metal allocations.
+func MaxRecommendedWorkingSetSize() (int, error) {
+	info := C.mlx_device_info_new()
+	if err := mlxCall("get device info failed", func() C.int {
+		return C.mlx_device_info_get(&info, DefaultDevice().ctx)
+	}); err != nil {
+		C.mlx_device_info_free(info)
+		return 0, err
+	}
+	defer C.mlx_device_info_free(info)
+
+	key := C.CString("max_recommended_working_set_size")
+	defer C.free(unsafe.Pointer(key))
+
+	var size C.size_t
+	if err := mlxCall("max recommended working set size unavailable", func() C.int {
+		return C.mlx_device_info_get_size(&size, info, key)
+	}); err != nil {
+		return 0, err
+	}
+	return int(size), nil
+}
+
+// SetWiredLimit sets the maximum amount of Metal memory MLX keeps resident and
+// returns the previous limit.
+func SetWiredLimit(limit int) (int, error) {
+	if limit < 0 {
+		return 0, fmt.Errorf("mlx: wired limit must be non-negative")
+	}
+
+	var previous C.size_t
+	if err := mlxCall("set wired limit failed", func() C.int {
+		return C.mlx_set_wired_limit(&previous, C.size_t(limit))
+	}); err != nil {
+		return 0, err
+	}
+	return int(previous), nil
 }
 
 type Memory struct{}

--- a/x/mlxrunner/mlx/memory_test.go
+++ b/x/mlxrunner/mlx/memory_test.go
@@ -1,0 +1,64 @@
+package mlx
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"slices"
+	"testing"
+)
+
+func TestSetWiredLimitRejectsOversizeWithoutChangingLimit(t *testing.T) {
+	skipIfNoMLX(t)
+	if !GPUIsAvailable() {
+		t.Skip("MLX GPU not available")
+	}
+
+	var testErr error
+	withMLXThread(t, func() {
+		testErr = checkWiredLimitRejectsOversize()
+	})
+	if testErr != nil {
+		t.Fatal(testErr)
+	}
+}
+
+func checkWiredLimitRejectsOversize() (err error) {
+	maxRecommended, err := MaxRecommendedWorkingSetSize()
+	if err != nil {
+		return err
+	}
+	if maxRecommended == math.MaxInt {
+		return errors.New("recommended working set cannot be exceeded by an int")
+	}
+
+	previous, err := SetWiredLimit(maxRecommended)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if _, restoreErr := SetWiredLimit(previous); restoreErr != nil {
+			err = errors.Join(err, fmt.Errorf("restore wired limit: %w", restoreErr))
+		}
+	}()
+
+	if _, err := SetWiredLimit(maxRecommended + 1); err == nil {
+		return errors.New("SetWiredLimit accepted a limit above the recommended working set")
+	}
+
+	current, err := SetWiredLimit(maxRecommended)
+	if err != nil {
+		return err
+	}
+	if current != maxRecommended {
+		return fmt.Errorf("wired limit after rejected update = %d, want %d", current, maxRecommended)
+	}
+
+	a := FromValues([]float32{1, 2, 3, 4}, 2, 2)
+	b := Matmul(a, a)
+	Eval(b)
+	if got, want := b.Floats(), []float32{7, 10, 15, 22}; !slices.Equal(got, want) {
+		return fmt.Errorf("evaluation after rejected update = %v, want %v", got, want)
+	}
+	return nil
+}

--- a/x/mlxrunner/mlx/mlx.go
+++ b/x/mlxrunner/mlx/mlx.go
@@ -35,7 +35,10 @@ package mlx
 // }
 import "C"
 
-import "runtime"
+import (
+	"fmt"
+	"runtime"
+)
 
 func init() {
 	// Replace the default exit(-1) error handler with one that captures
@@ -51,11 +54,9 @@ func Version() string {
 	return C.GoString(C.mlx_string_data(str))
 }
 
-// mlxCheck locks the goroutine to its OS thread, clears the captured error
-// state, calls fn, and panics with the captured message if fn returns non-zero.
-// The thread lock ensures the thread-local error state is read from the same
-// thread that executed the call.
-func mlxCheck(fallback string, fn func() C.int) {
+// mlxCall locks the goroutine to its OS thread so the thread-local error state
+// is read from the same thread that executed fn.
+func mlxCall(fallback string, fn func() C.int) error {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
@@ -65,7 +66,16 @@ func mlxCheck(fallback string, fn func() C.int) {
 		if msg == "" {
 			msg = fallback
 		}
-		panic("mlx: " + msg)
+		return fmt.Errorf("mlx: %s", msg)
+	}
+	return nil
+}
+
+// mlxCheck panics with the captured MLX error. Most array operations cannot
+// recover from a failed graph construction or evaluation.
+func mlxCheck(fallback string, fn func() C.int) {
+	if err := mlxCall(fallback, fn); err != nil {
+		panic(err.Error())
 	}
 }
 

--- a/x/mlxrunner/runner.go
+++ b/x/mlxrunner/runner.go
@@ -101,6 +101,7 @@ func (r *Runner) Load(modelName string) error {
 	}
 	mlx.Sweep()
 	mlx.Eval(collected...)
+	configureWiredMemory()
 
 	r.Model = m
 	r.Tokenizer = m.Tokenizer()
@@ -112,6 +113,41 @@ func (r *Runner) Load(modelName string) error {
 	mlx.EnableCompile()
 
 	return nil
+}
+
+func configureWiredMemory() {
+	if !mlx.GPUIsAvailable() {
+		return
+	}
+
+	active := mlx.ActiveMemory()
+	maxRecommended, err := mlx.MaxRecommendedWorkingSetSize()
+	if err != nil {
+		slog.Warn("Unable to query MLX recommended working set; using pageable memory", "error", err)
+		return
+	}
+
+	limit := min(active, maxRecommended)
+	previous, err := mlx.SetWiredLimit(limit)
+	if err != nil {
+		slog.Warn("Unable to configure MLX wired memory; using pageable memory",
+			"active", mlx.PrettyBytes(active),
+			"limit", mlx.PrettyBytes(limit),
+			"error", err)
+		return
+	}
+
+	if active > maxRecommended {
+		slog.Warn("MLX model exceeds the recommended working set; performance may be degraded",
+			"active", mlx.PrettyBytes(active),
+			"recommended", mlx.PrettyBytes(maxRecommended))
+	}
+	// Limiting residency to the loaded model's active allocations avoids
+	// reserving the remaining capacity for growing KV caches.
+	slog.Debug("Configured MLX wired memory",
+		"active", mlx.PrettyBytes(active),
+		"limit", mlx.PrettyBytes(limit),
+		"previous", mlx.PrettyBytes(previous))
 }
 
 // loadTensorsFromManifest loads all tensor blobs from the manifest into a


### PR DESCRIPTION
Follow up to #17237 - required for Laguna S 2.1 performance gains.

Configure Metal residency after the MLX runner materializes model weights.

Wire up to the smaller of active model memory and the recommended working set, leaving pageable headroom for KV caches and request allocations. If residency setup fails, warn and continue with pageable memory.

Expose recoverable MLX C API errors and verify that an oversized wired limit preserves the previous state and leaves subsequent evaluation usable.

Testing results:

| System | RAM | GPU available | Model | Results |
|---|---:|---:|---|---|
| M5 Max, macOS 26 | 128 GB | 107.5 GiB | Laguna S 2.1 NVFP4 | No performance change |
| M3 Ultra, macOS 15 | 512 GB | 384.0 GiB | Laguna XS 2.1 NVFP4 | Prompt performance improved 31%; generation unchanged |
| M3 Ultra, macOS 15 | 512 GB | 384.0 GiB | Laguna S 2.1 NVFP4 | Eliminated severe paging; prompt improved 18% and generation recovered from 0.6 to 64 tok/s || M1, macOS 14 | 16 GB | 10.7 GiB | Qwen 3.5 2B NVFP4 | No performance change |
| M2 Pro, macOS 14 | 32 GB | 21.3 GiB | Gemma 4 12B MTP MLX | No performance change |
| M1, macOS 15 | 8 GB | 5.3 GiB | Qwen 3.5 2B NVFP4 | No performance change |
| M1, macOS 15 | 8 GB | 5.3 GiB | Qwen 3.5 4B NVFP4 | No performance change; KV-cache growth pushed MLX memory beyond the recommended GPU working set without swap-outs, throttling, or correctness failures |
| M1, macOS 15 | 8 GB | 5.3 GiB | Gemma 4 E2B NVFP4 | Scheduler rejected the model before MLX due to insufficient memory |
| M1 Pro, macOS 26 | 32 GB | 25.0 GiB | Qwen 3.5 27B NVFP4 | No performance change; a 32K context pushed memory near the GPU working-set limit without swap-outs, throttling, or correctness failures |
