### PR TITLE
server/upload: fix data race on blobUpload.done and err

### DIFF
--- a/server/upload.go
+++ b/server/upload.go
@@ -41,7 +41,7 @@ type blobUpload struct {
 
 	file *os.File
 
-	done       bool
+	done       chan struct{}
 	err        error
 	references atomic.Int32
 }
@@ -87,7 +87,6 @@ func (b *blobUpload) Prepare(ctx context.Context, requestURL *url.URL, opts *reg
 	// ref: https://distribution.github.io/distribution/spec/api/#cross-repository-blob-mount
 	if resp.StatusCode == http.StatusCreated {
 		b.Completed.Store(b.Total)
-		b.done = true
 		return nil
 	}
 
@@ -127,7 +126,14 @@ func (b *blobUpload) Prepare(ctx context.Context, requestURL *url.URL, opts *reg
 // Run uploads blob parts to the upstream. If the upstream supports redirection, parts will be uploaded
 // in parallel as defined by Prepare. Otherwise, parts will be uploaded serially. Run sets b.err on error.
 func (b *blobUpload) Run(ctx context.Context, opts *registryOptions) {
+	defer close(b.done)
 	defer blobUploadManager.Delete(b.Digest)
+
+	// Blob was already mounted on the registry (StatusCreated in Prepare)
+	if b.Completed.Load() == b.Total {
+		return
+	}
+
 	ctx, b.CancelFunc = context.WithCancel(ctx)
 
 	p, err := manifest.BlobsPath(b.Digest)
@@ -212,7 +218,6 @@ func (b *blobUpload) Run(ctx context.Context, opts *registryOptions) {
 	}
 
 	b.err = err
-	b.done = true
 }
 
 func (b *blobUpload) uploadPart(ctx context.Context, method string, requestURL *url.URL, part *blobUploadPart, opts *registryOptions) error {
@@ -321,8 +326,11 @@ func (b *blobUpload) Wait(ctx context.Context, fn func(api.ProgressResponse)) er
 	defer b.release()
 
 	ticker := time.NewTicker(60 * time.Millisecond)
+	defer ticker.Stop()
 	for {
 		select {
+		case <-b.done:
+			return b.err
 		case <-ticker.C:
 		case <-ctx.Done():
 			return ctx.Err()
@@ -334,10 +342,6 @@ func (b *blobUpload) Wait(ctx context.Context, fn func(api.ProgressResponse)) er
 			Total:     b.Total,
 			Completed: b.Completed.Load(),
 		})
-
-		if b.done || b.err != nil {
-			return b.err
-		}
 	}
 }
 
@@ -387,7 +391,7 @@ func uploadBlob(ctx context.Context, n model.Name, layer manifest.Layer, opts *r
 		return nil
 	}
 
-	data, ok := blobUploadManager.LoadOrStore(layer.Digest, &blobUpload{Layer: layer})
+	data, ok := blobUploadManager.LoadOrStore(layer.Digest, &blobUpload{Layer: layer, done: make(chan struct{})})
 	upload := data.(*blobUpload)
 	if !ok {
 		requestURL := n.BaseURL()


### PR DESCRIPTION
## Summary

Fix a data race in blobUpload where `done` (bool) and `err` (error) were written in the `Run()` goroutine and read in `Wait()` without synchronization.

## The Bug

`blobUpload` had `done bool` and `err error` fields that were set in `Run()` (running in a goroutine) and polled in `Wait()`:

```go
// Run - goroutine
b.err = err
b.done = true

// Wait - polling loop
if b.done || b.err != nil {
    return b.err
}
```

There was no happens-before relationship between these operations. The Go memory model provides no guarantees that `Wait()` would see the writes from `Run()`. This is a concrete data race detectable with `go run -race`.

In contrast, `blobDownload` already used the correct pattern: `done chan struct{}` where `close(b.done)` establishes happens-before for `b.err`.

## The Fix

1. Change `done bool` → `done chan struct{}` in `blobUpload`
2. Initialize `done` channel before `LoadOrStore` to prevent nil-channel window for concurrent callers
3. In `Run()`: `defer close(b.done)` at the top, remove `b.done = true`
4. Add early return in `Run()` for StatusCreated case (blob already mounted on registry)
5. In `Wait()`: use `select` on `<-b.done` channel to receive the signal, then read `b.err`
6. Add `defer ticker.Stop()` (pre-existing resource leak)

This matches the synchronization pattern already used by `blobDownload`.