### PR TITLE
server/model: fix file descriptor leak in parseFromModel

### DIFF
--- a/server/model.go
+++ b/server/model.go
@@ -74,9 +74,11 @@ func parseFromModel(ctx context.Context, name model.Name, fn func(api.ProgressRe
 			if err != nil {
 				return nil, err
 			}
-			defer blob.Close()
 
-			f, err := ggml.Decode(blob, -1)
+			f, err := func() (*ggml.GGML, error) {
+				defer blob.Close()
+				return ggml.Decode(blob, -1)
+			}()
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Fix a file descriptor leak in parseFromModel where defer blob.Close() inside a for loop accumulated open file descriptors until the function returned. For models with many layers like split GGUF shards, this could exhaust file descriptors. The fix wraps the decode+close in an anonymous function so each blob is closed immediately after decoding.