### PR TITLE
server: prevent nil CancelFunc panic in blobDownload/Upload release

### DIFF
--- a/server/download.go
+++ b/server/download.go
@@ -438,7 +438,7 @@ func (b *blobDownload) acquire() {
 }
 
 func (b *blobDownload) release() {
-	if b.references.Add(-1) == 0 {
+	if b.references.Add(-1) == 0 && b.CancelFunc != nil {
 		b.CancelFunc()
 	}
 }

--- a/server/upload.go
+++ b/server/upload.go
@@ -311,7 +311,7 @@ func (b *blobUpload) acquire() {
 }
 
 func (b *blobUpload) release() {
-	if b.references.Add(-1) == 0 {
+	if b.references.Add(-1) == 0 && b.CancelFunc != nil {
 		b.CancelFunc()
 	}
 }


### PR DESCRIPTION
Fix a nil function call panic in blobDownload.release() and blobUpload.release() when CancelFunc has not been initialized yet. In blobDownload Run sets CancelFunc inside run via context.WithCancel. In blobUpload Run skips setting CancelFunc when the blob was already mounted. Both fixed with a nil-check.