### PR TITLE
manifest: fix nil error wrapped with %w in Manifests

### DIFF
--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -204,7 +204,7 @@ func Manifests(continueOnError bool) (map[model.Name]*Manifest, error) {
 			n := model.ParseNameFromFilepath(rel)
 			if !n.IsValid() {
 				if !continueOnError {
-					return nil, fmt.Errorf("%s %w", rel, err)
+					return nil, fmt.Errorf("%s: %w", rel, model.ErrUnqualifiedName)
 				}
 				slog.Warn("bad manifest name", "path", rel)
 				continue


### PR DESCRIPTION
Fix a bug in Manifests() where fmt.Errorf("%s %w", rel, err) wrapped a nil error, producing confusing messages like 'model-name <nil>'. The fix wraps model.ErrUnqualifiedName instead, which accurately describes why the name failed validation.