### PR TITLE
server/download: fix ticker leak in blobDownload.Wait

### DIFF
--- a/server/download.go
+++ b/server/download.go
@@ -448,6 +448,7 @@ func (b *blobDownload) Wait(ctx context.Context, fn func(api.ProgressResponse)) 
 	defer b.release()
 
 	ticker := time.NewTicker(60 * time.Millisecond)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-b.done:


### PR DESCRIPTION
Add defer ticker.Stop() to blobDownload.Wait() to fix a ticker resource leak. The ticker was created with time.NewTicker(60ms) but never stopped, causing it to run indefinitely. This matches the fix already applied to blobUpload.Wait() in a prior PR.