### PR TITLE
openai: propagate ToolName for tool messages with nil content

### DIFF
--- a/openai/openai.go
+++ b/openai/openai.go
@@ -567,7 +567,7 @@ func FromChatRequest(r ChatCompletionRequest) (*api.ChatRequest, error) {
 			if err != nil {
 				return nil, err
 			}
-			messages = append(messages, api.Message{Role: msg.Role, Thinking: msg.Reasoning, ToolCalls: toolCalls, ToolCallID: msg.ToolCallID})
+			messages = append(messages, api.Message{Role: msg.Role, Thinking: msg.Reasoning, ToolCalls: toolCalls, ToolName: toolName, ToolCallID: msg.ToolCallID})
 		}
 	}
 


### PR DESCRIPTION
Fix a bug in FromChatRequest where tool response messages with nil Content (JSON null) lost their ToolName. The default case in the content type switch constructed api.Message without ToolName, even though toolName was computed earlier. Both the string and []any cases already propagated ToolName; this aligns the default (nil content) case.