### PR TITLE
server: fix ps data race on scheduler loaded map

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -2262,7 +2262,7 @@ func (s *Server) SignoutHandler(c *gin.Context) {
 func (s *Server) PsHandler(c *gin.Context) {
 	models := []api.ProcessModelResponse{}
 
-	for _, v := range s.sched.loaded {
+	for _, v := range s.sched.loadedModels() {
 		m := v.model
 		displayName := model.ParseName(m.ShortName).DisplayShortest()
 		modelDetails := api.ModelDetails{
@@ -2273,30 +2273,16 @@ func (s *Server) PsHandler(c *gin.Context) {
 			QuantizationLevel: m.Config.FileType,
 		}
 
-		mr := api.ProcessModelResponse{
-			Model:     displayName,
-			Name:      displayName,
-			Size:      int64(v.totalSize),
-			SizeVRAM:  int64(v.vramSize),
-			Digest:    m.Digest,
-			Details:   modelDetails,
-			ExpiresAt: v.expiresAt,
-		}
-		if v.llama != nil {
-			mr.ContextLength = v.llama.ContextLength()
-			total, vram := v.llama.MemorySize()
-			mr.Size = int64(total)
-			mr.SizeVRAM = int64(vram)
-		}
-		// The scheduler waits to set expiresAt, so if a model is loading it's
-		// possible that it will be set to the unix epoch. For those cases, just
-		// calculate the time w/ the sessionDuration instead.
-		var epoch time.Time
-		if v.expiresAt == epoch {
-			mr.ExpiresAt = time.Now().Add(v.sessionDuration)
-		}
-
-		models = append(models, mr)
+		models = append(models, api.ProcessModelResponse{
+			Model:         displayName,
+			Name:          displayName,
+			Size:          v.size,
+			SizeVRAM:      v.sizeVRAM,
+			Digest:        m.Digest,
+			Details:       modelDetails,
+			ExpiresAt:     v.expiresAt,
+			ContextLength: v.contextLength,
+		})
 	}
 
 	slices.SortStableFunc(models, func(i, j api.ProcessModelResponse) int {

--- a/server/sched.go
+++ b/server/sched.go
@@ -127,11 +127,6 @@ func schedulerModelKey(m *Model) string {
 	return ""
 }
 
-// context must be canceled to decrement ref count and release the runner
-func (s *Scheduler) GetRunner(c context.Context, m *Model, opts api.Options, sessionDuration *api.Duration) (chan *runnerRef, chan error) {
-	return s.getRunner(c, m, opts, sessionDuration, false, false, nil)
-}
-
 func resolveContextShift(shift *bool, m *Model) bool {
 	if shift != nil {
 		return *shift
@@ -1746,4 +1741,58 @@ func (s *Scheduler) expireRunner(model *Model) {
 		}
 		runner.refMu.Unlock()
 	}
+}
+
+// loadedModel is a point-in-time snapshot of a loaded runner's state, safe to
+// use without holding any scheduler locks.
+type loadedModel struct {
+	model         *Model
+	size          int64
+	sizeVRAM      int64
+	contextLength int
+	expiresAt     time.Time
+}
+
+// loadedModels returns a snapshot of the currently loaded models for status
+// reporting without exposing the scheduler's internal runner bookkeeping.
+func (s *Scheduler) loadedModels() []loadedModel {
+	s.loadedMu.Lock()
+	runners := make([]*runnerRef, 0, len(s.loaded))
+	for _, r := range s.loaded {
+		runners = append(runners, r)
+	}
+	s.loadedMu.Unlock()
+
+	// refMu must not be acquired while holding loadedMu: the expiration path
+	// locks them in the opposite order.
+	models := make([]loadedModel, 0, len(runners))
+	for _, r := range runners {
+		r.refMu.Lock()
+		if r.model == nil {
+			// Unloaded after the snapshot above was taken
+			r.refMu.Unlock()
+			continue
+		}
+		lm := loadedModel{
+			model:     r.model,
+			size:      int64(r.totalSize),
+			sizeVRAM:  int64(r.vramSize),
+			expiresAt: r.expiresAt,
+		}
+		if r.llama != nil {
+			lm.contextLength = r.llama.ContextLength()
+			total, vram := r.llama.MemorySize()
+			lm.size = int64(total)
+			lm.sizeVRAM = int64(vram)
+		}
+		// The scheduler waits to set expiresAt, so a model that is still
+		// loading may have the zero value. Estimate expiration from the
+		// session duration instead.
+		if lm.expiresAt.IsZero() {
+			lm.expiresAt = time.Now().Add(r.sessionDuration)
+		}
+		r.refMu.Unlock()
+		models = append(models, lm)
+	}
+	return models
 }

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -524,10 +524,10 @@ func TestSchedGetRunner(t *testing.T) {
 	s.getSystemInfoFn = getSystemInfoFn
 	s.newServerFn = a.newServer
 	slog.Info("a")
-	successCh1a, errCh1a := s.GetRunner(a.ctx, a.req.model, a.req.opts, a.req.sessionDuration)
+	successCh1a, errCh1a := s.getRunner(a.ctx, a.req.model, a.req.opts, a.req.sessionDuration, false, false, nil)
 	require.Len(t, s.pendingReqCh, 1)
 	slog.Info("b")
-	successCh1b, errCh1b := s.GetRunner(b.ctx, b.req.model, b.req.opts, b.req.sessionDuration)
+	successCh1b, errCh1b := s.getRunner(b.ctx, b.req.model, b.req.opts, b.req.sessionDuration, false, false, nil)
 	require.Len(t, s.pendingReqCh, 1)
 	require.Empty(t, successCh1b)
 	require.Len(t, errCh1b, 1)
@@ -551,7 +551,7 @@ func TestSchedGetRunner(t *testing.T) {
 
 	c.req.model.ModelPath = "bad path"
 	slog.Info("c")
-	successCh1c, errCh1c := s.GetRunner(c.ctx, c.req.model, c.req.opts, c.req.sessionDuration)
+	successCh1c, errCh1c := s.getRunner(c.ctx, c.req.model, c.req.opts, c.req.sessionDuration, false, false, nil)
 	// Starts in pending channel, then should be quickly processed to return an error
 	time.Sleep(50 * time.Millisecond) // Long enough for the "a" model to expire and unload
 	require.Empty(t, successCh1c)
@@ -586,7 +586,7 @@ func TestSchedGetRunnerUsesDigestKeyWhenModelPathEmpty(t *testing.T) {
 	s.loadedMu.Unlock()
 
 	reqModel := &Model{Name: "safetensors-b", Digest: "sha-b"}
-	successCh, errCh := s.GetRunner(ctx, reqModel, opts, nil)
+	successCh, errCh := s.getRunner(ctx, reqModel, opts, nil, false, false, nil)
 
 	require.Empty(t, successCh)
 	require.Empty(t, errCh)
@@ -615,7 +615,7 @@ func TestSchedGetRunnerReusesSameDigestWhenModelPathEmpty(t *testing.T) {
 	s.loadedMu.Unlock()
 
 	reqCtx, cancelReq := context.WithCancel(ctx)
-	successCh, errCh := s.GetRunner(reqCtx, &Model{Name: "safetensors-a-copy", Digest: "sha-a"}, opts, nil)
+	successCh, errCh := s.getRunner(reqCtx, &Model{Name: "safetensors-a-copy", Digest: "sha-a"}, opts, nil, false, false, nil)
 	cancelReq()
 
 	select {
@@ -725,7 +725,7 @@ func TestSchedPrematureExpired(t *testing.T) {
 	s.getGpuFn = getGpuFn
 	s.getSystemInfoFn = getSystemInfoFn
 	s.newServerFn = scenario1a.newServer
-	successCh1a, errCh1a := s.GetRunner(scenario1a.ctx, scenario1a.req.model, scenario1a.req.opts, scenario1a.req.sessionDuration)
+	successCh1a, errCh1a := s.getRunner(scenario1a.ctx, scenario1a.req.model, scenario1a.req.opts, scenario1a.req.sessionDuration, false, false, nil)
 	require.Len(t, s.pendingReqCh, 1)
 	s.Run(ctx)
 	select {


### PR DESCRIPTION
PsHandler iterated sched.loaded without holding loadedMu, racing with scheduler goroutines that mutate the map. It also read runnerRef fields (model, llama, expiresAt) that unload() and the expiration path mutate under refMu, so a concurrently unloading runner could nil model out from under the handler.

Instead of adding locking in routes.go, give the scheduler a small snapshot API: loadedModels() copies the runner list under loadedMu, then captures each runner's reporting fields under its refMu, respecting the refMu-before-loadedMu lock ordering used by the expiration path. The zero-expiresAt estimate for still-loading models moves into the scheduler too, since it exists because of scheduler behavior.

Also remove the dead code Scheduler.GetRunner