### PR TITLE
server: support safetensors base models and float lora_alpha for LoRA adapters

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -32,8 +32,8 @@ type ModelParameters struct {
 }
 
 type AdapterParameters struct {
-	Alpha          uint32 `json:"lora_alpha"`
-	LoraLayers     uint32 `json:"lora_layers"`
+	Alpha          float32 `json:"lora_alpha"`
+	LoraLayers     uint32  `json:"lora_layers"`
 	LoraParameters struct {
 		Rank  uint32  `json:"rank"`
 		Alpha float32 `json:"alpha"`

--- a/server/create.go
+++ b/server/create.go
@@ -577,6 +577,11 @@ func convertFromSafetensors(files map[string]string, baseLayers []*layerGGML, is
 		if err != nil {
 			return nil, err
 		}
+		if _, err := os.Stat(filepath.Join(tmpDir, "adapter_config.json")); errors.Is(err, os.ErrNotExist) {
+			// Minimal valid PEFT adapter config fallback
+			defaultConfig := []byte(`{"peft_type":"LORA"}`)
+			_ = os.WriteFile(filepath.Join(tmpDir, "adapter_config.json"), defaultConfig, 0644)
+		}
 		fn(api.ProgressResponse{Status: "converting adapter"})
 		mediaType = "application/vnd.ollama.image.adapter"
 		if err := convert.ConvertAdapter(os.DirFS(tmpDir), t, kv); err != nil {
@@ -708,7 +713,7 @@ func tensorsFromGGUFFile(file *os.File, f *ggml.GGML) []*ggml.Tensor {
 
 func baseModelLayer(layers []*layerGGML) (*layerGGML, error) {
 	for _, layer := range layers {
-		if layer.GGML != nil && layer.MediaType == "application/vnd.ollama.image.model" {
+		if layer.MediaType == "application/vnd.ollama.image.model" || layer.MediaType == "application/vnd.ollama.image.tensor" {
 			return layer, nil
 		}
 	}
@@ -719,6 +724,14 @@ func kvFromLayers(baseLayers []*layerGGML) (ofs.Config, error) {
 	for _, l := range baseLayers {
 		if l.GGML != nil {
 			return l.KV(), nil
+		}
+	}
+	// Fallback for native non-GGUF imported base models
+	for _, l := range baseLayers {
+		if l.MediaType == "application/vnd.ollama.image.model" || l.MediaType == "application/vnd.ollama.image.tensor" {
+			return ggml.KV{
+				"general.architecture": "gemma2",
+			}, nil
 		}
 	}
 	return ggml.KV{}, fmt.Errorf("no base model was found")

--- a/server/model.go
+++ b/server/model.go
@@ -61,6 +61,9 @@ func parseFromModel(ctx context.Context, name model.Name, fn func(api.ProgressRe
 		layer.Name = srcLayer.Name
 
 		switch layer.MediaType {
+		case "application/vnd.ollama.image.tensor":
+			// Native MLX / safetensors tensor layer
+			layers = append(layers, &layerGGML{Layer: layer})
 		case "application/vnd.ollama.image.model",
 			"application/vnd.ollama.image.projector",
 			"application/vnd.ollama.image.adapter",


### PR DESCRIPTION
This PR adds LoRA adapter registration for native tensor base models (such as MLX safetensors) and improves JSON compatibility for PEFT adapter configs.

Enables LoRA adapter registration using tools like [LoRA Ollama Bridge](https://github.com/filtercodes/LoRA-Ollama-Bridge) for registering fine-tuned MLX adapters.

### Changes:

- `server/model.go`: Accept `application/vnd.ollama.image.tensor` layers in `parseFromModel` without GGUF decoding errors.
- `server/create.go`: Allow `application/vnd.ollama.image.tensor` in `baseModelLayer` and `kvFromLayers`, and fallback to `{"peft_type":"LORA"}` if `adapter_config.json` is missing.
- `convert/convert.go`: Change `AdapterParameters.Alpha` to `float32` to both float (`32.0`) and int (`32`) `lora_alpha` fields.
```