### PR TITLE
cmd/tui: accept file mentions with Enter in the agent TUI

### DIFF
--- a/cmd/tui/chat/chat.go
+++ b/cmd/tui/chat/chat.go
@@ -597,6 +597,9 @@ func (m chatModel) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.applySlashCompletion() {
 			return m, nil
 		}
+		if m.applyMentionCompletion() {
+			return m, nil
+		}
 		return m.handleSubmit()
 	case tea.KeyCtrlJ:
 		m.insertInputNewline()

--- a/cmd/tui/chat/input.go
+++ b/cmd/tui/chat/input.go
@@ -1324,8 +1324,7 @@ func slashCommandInvocation(input string) (string, string, bool) {
 }
 
 func (m chatModel) mentionCompletions() []chatCompletion {
-	input := string(m.input)
-	_, query, ok := activeMentionToken(input)
+	_, query, ok := activeMentionToken(m.input, m.normalizedInputCursor())
 	if !ok {
 		return nil
 	}
@@ -1389,13 +1388,13 @@ func (m chatModel) mentionCompletions() []chatCompletion {
 	return completions
 }
 
-func activeMentionToken(input string) (int, string, bool) {
-	runes := []rune(input)
-	start := len(runes)
-	for start > 0 && !unicode.IsSpace(runes[start-1]) {
+func activeMentionToken(input []rune, cursor int) (int, string, bool) {
+	cursor = clamp(cursor, 0, len(input))
+	start := cursor
+	for start > 0 && !unicode.IsSpace(input[start-1]) {
 		start--
 	}
-	token := string(runes[start:])
+	token := string(input[start:cursor])
 	if !strings.HasPrefix(token, "@") {
 		return 0, "", false
 	}
@@ -1453,6 +1452,7 @@ func (m *chatModel) applyCompletion() bool {
 	}
 	m.resetPromptHistoryCursor()
 	selected := completions[clamp(m.complete, 0, len(completions)-1)]
+	cursor := m.normalizedInputCursor()
 	input := string(m.input)
 	if strings.HasPrefix(strings.TrimSpace(input), "/") {
 		m.input = []rune(selected.value)
@@ -1462,20 +1462,33 @@ func (m *chatModel) applyCompletion() bool {
 		return true
 	}
 
-	start, _, ok := activeMentionToken(input)
+	start, _, ok := activeMentionToken(m.input, cursor)
 	if !ok {
 		return false
 	}
-	suffix := ""
-	if !selected.directory {
-		suffix = " "
+	completed := []rune("@" + selected.value)
+	if !selected.directory && (cursor == len(m.input) || !unicode.IsSpace(m.input[cursor])) {
+		completed = append(completed, ' ')
 	}
-	next := string([]rune(input)[:start]) + "@" + selected.value + suffix
-	m.input = []rune(next)
-	m.inputCursor = len(m.input)
+	next := make([]rune, 0, len(m.input)-cursor+start+len(completed))
+	next = append(next, m.input[:start]...)
+	next = append(next, completed...)
+	next = append(next, m.input[cursor:]...)
+	m.input = next
+	m.inputCursor = start + len(completed)
+	if !selected.directory && m.inputCursor < len(m.input) && unicode.IsSpace(m.input[m.inputCursor]) {
+		m.inputCursor++
+	}
 	m.inputCursorSet = true
 	m.complete = 0
 	return true
+}
+
+func (m *chatModel) applyMentionCompletion() bool {
+	if strings.HasPrefix(strings.TrimSpace(string(m.input)), "/") {
+		return false
+	}
+	return m.applyCompletion()
 }
 
 func completionIsSelectable(completions []chatCompletion) bool {

--- a/cmd/tui/chat/input_test.go
+++ b/cmd/tui/chat/input_test.go
@@ -1155,3 +1155,44 @@ func TestChatFileMentionSuggestionsFilterAndComplete(t *testing.T) {
 		t.Fatalf("completed input = %q", got)
 	}
 }
+
+func TestChatEnterCompletesHighlightedFileMentionWithoutSubmitting(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "alpha.md"), []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "target.md"), []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := chatModel{
+		workingDir:     dir,
+		input:          []rune("review @ after this"),
+		inputCursor:    len([]rune("review @")),
+		inputCursorSet: true,
+	}
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = updated.(chatModel)
+	if got, want := m.complete, 1; got != want {
+		t.Fatalf("selected completion = %d, want %d", got, want)
+	}
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd != nil {
+		t.Fatal("selecting a file mention should not submit the prompt")
+	}
+	m = updated.(chatModel)
+	if got, want := string(m.input), "review @target.md after this"; got != want {
+		t.Fatalf("input = %q, want %q", got, want)
+	}
+	if got, want := m.inputCursor, len([]rune("review @target.md ")); got != want || !m.inputCursorSet {
+		t.Fatalf("cursor = %d (set=%v), want %d after the inserted mention", got, m.inputCursorSet, want)
+	}
+	if len(m.entries) != 0 || len(m.messages) != 0 {
+		t.Fatalf("selecting a file mention submitted the prompt: entries=%#v messages=%#v", m.entries, m.messages)
+	}
+	if completions := m.mentionCompletions(); completions != nil {
+		t.Fatalf("mention selector remained visible after selection: %#v", completions)
+	}
+}


### PR DESCRIPTION
## Summary

- Accept the highlighted `@` file completion when the user presses Enter.
- Replace only the active mention at the input cursor.
- Keep text after the mention. Place the cursor after the file reference.
- Do not submit the prompt when a file completion is selected.

## Root cause

Enter checked slash completions only. It did not accept file completions.

## Tests

- `go test ./cmd/tui/chat -count=1`
- `go test -race ./cmd/tui/chat -run 'TestChat(EnterCompletesHighlightedFileMentionWithoutSubmitting|FileMentionSuggestionsFilterAndComplete|EnterFillsSelectedSlashCommandBeforeSubmitting)' -count=1`
- `go test ./cmd/tui -count=1`
- Headless Bubble Tea trace for arrow selection, Enter acceptance, prompt preservation, cursor placement, and selector dismissal.