### PR TITLE
Skip unsupported ARM CPU variants instead of failing the build

### DIFF
--- a/llama/compat/004-ggml-cpu-arm-march-guard.patch
+++ b/llama/compat/004-ggml-cpu-arm-march-guard.patch
@@ -1,0 +1,69 @@
+diff --git a/ggml/src/CMakeLists.txt b/ggml/src/CMakeLists.txt
+index 1158347..bee9959 100644
+--- a/ggml/src/CMakeLists.txt
++++ b/ggml/src/CMakeLists.txt
+@@ -405,14 +405,56 @@ if (GGML_CPU_ALL_VARIANTS)
+             # Many of these features are optional so we build versions with popular
+             # combinations and name the backends based on the version they were
+             # first released with
+-            ggml_add_cpu_backend_variant(armv8.0_1)
+-            ggml_add_cpu_backend_variant(armv8.2_1    DOTPROD)
+-            ggml_add_cpu_backend_variant(armv8.2_2    DOTPROD FP16_VECTOR_ARITHMETIC)
+-            ggml_add_cpu_backend_variant(armv8.2_3    DOTPROD FP16_VECTOR_ARITHMETIC SVE)
+-            ggml_add_cpu_backend_variant(armv8.6_1    DOTPROD FP16_VECTOR_ARITHMETIC SVE MATMUL_INT8)
+-            ggml_add_cpu_backend_variant(armv8.6_2    DOTPROD FP16_VECTOR_ARITHMETIC SVE MATMUL_INT8 SVE2)
+-            ggml_add_cpu_backend_variant(armv9.2_1    DOTPROD FP16_VECTOR_ARITHMETIC SVE MATMUL_INT8 SME)
+-            ggml_add_cpu_backend_variant(armv9.2_2    DOTPROD FP16_VECTOR_ARITHMETIC SVE MATMUL_INT8 SVE2 SME)
++            # Some of these variants target -march values (e.g. armv9.2-a) that
++            # are only understood by newer toolchains. Older compilers (such as
++            # GCC 11 shipped on Ubuntu 22.04 / Jetson) abort with
++            # "unknown value '...' for '-march'" and take the whole build down.
++            # Probe the -march each variant needs and skip the unsupported ones
++            # instead of failing, mirroring the POWER11 handling below.
++            function(ggml_add_cpu_backend_variant_guarded tag_name)
++                set(GGML_CPU_GUARD_MARCH "armv8-a")
++                set(GGML_CPU_GUARD_TAGS  "")
++                foreach (feat IN LISTS ARGN)
++                    if (feat STREQUAL "DOTPROD")
++                        set(GGML_CPU_GUARD_MARCH "armv8.2-a")
++                        string(APPEND GGML_CPU_GUARD_TAGS "+dotprod")
++                    elseif (feat STREQUAL "FP16_VECTOR_ARITHMETIC")
++                        set(GGML_CPU_GUARD_MARCH "armv8.2-a")
++                        string(APPEND GGML_CPU_GUARD_TAGS "+fp16")
++                    elseif (feat STREQUAL "SVE")
++                        set(GGML_CPU_GUARD_MARCH "armv8.2-a")
++                        string(APPEND GGML_CPU_GUARD_TAGS "+sve")
++                    elseif (feat STREQUAL "MATMUL_INT8")
++                        set(GGML_CPU_GUARD_MARCH "armv8.6-a")
++                        string(APPEND GGML_CPU_GUARD_TAGS "+i8mm")
++                    elseif (feat STREQUAL "SVE2")
++                        set(GGML_CPU_GUARD_MARCH "armv8.6-a")
++                        string(APPEND GGML_CPU_GUARD_TAGS "+sve2")
++                    elseif (feat STREQUAL "NOSVE")
++                        string(APPEND GGML_CPU_GUARD_TAGS "+nosve")
++                    elseif (feat STREQUAL "SME")
++                        set(GGML_CPU_GUARD_MARCH "armv9.2-a")
++                        string(APPEND GGML_CPU_GUARD_TAGS "+sme")
++                    endif()
++                endforeach()
++                set(GGML_CPU_GUARD_FLAG "-march=${GGML_CPU_GUARD_MARCH}${GGML_CPU_GUARD_TAGS}")
++                string(MAKE_C_IDENTIFIER "GGML_MARCH_SUPPORTED_${GGML_CPU_GUARD_MARCH}${GGML_CPU_GUARD_TAGS}" GGML_CPU_GUARD_VAR)
++                check_cxx_compiler_flag("${GGML_CPU_GUARD_FLAG}" ${GGML_CPU_GUARD_VAR})
++                if (${GGML_CPU_GUARD_VAR})
++                    ggml_add_cpu_backend_variant(${tag_name} ${ARGN})
++                else()
++                    message(STATUS "ggml-cpu: skipping variant ${tag_name}; compiler does not support ${GGML_CPU_GUARD_FLAG}")
++                endif()
++            endfunction()
++
++            ggml_add_cpu_backend_variant_guarded(armv8.0_1)
++            ggml_add_cpu_backend_variant_guarded(armv8.2_1    DOTPROD)
++            ggml_add_cpu_backend_variant_guarded(armv8.2_2    DOTPROD FP16_VECTOR_ARITHMETIC)
++            ggml_add_cpu_backend_variant_guarded(armv8.2_3    DOTPROD FP16_VECTOR_ARITHMETIC SVE)
++            ggml_add_cpu_backend_variant_guarded(armv8.6_1    DOTPROD FP16_VECTOR_ARITHMETIC SVE MATMUL_INT8)
++            ggml_add_cpu_backend_variant_guarded(armv8.6_2    DOTPROD FP16_VECTOR_ARITHMETIC SVE MATMUL_INT8 SVE2)
++            ggml_add_cpu_backend_variant_guarded(armv9.2_1    DOTPROD FP16_VECTOR_ARITHMETIC SVE MATMUL_INT8 SME)
++            ggml_add_cpu_backend_variant_guarded(armv9.2_2    DOTPROD FP16_VECTOR_ARITHMETIC SVE MATMUL_INT8 SVE2 SME)
+         elseif (CMAKE_SYSTEM_NAME MATCHES "Android")
+             # Android-specific backends with SoC-compatible feature sets
+             ggml_add_cpu_backend_variant(android_armv8.0_1)

--- a/llama/compat/README.md
+++ b/llama/compat/README.md
@@ -27,6 +27,11 @@ intentionally skipped so a developer can iterate on a local llama.cpp tree.
   It currently touches `src/llama-model-loader.cpp` and `tools/mtmd/clip.cpp`.
 - `002-llama-cpp-ui-empty-assets.patch` - lets the llama.cpp UI embed helper
   generate an empty asset table when no UI assets are present.
+- `004-ggml-cpu-arm-march-guard.patch` - probes each ARM CPU backend variant's
+  `-march` value with `check_cxx_compiler_flag` before adding it, so
+  `GGML_CPU_ALL_VARIANTS=ON` skips variants an older toolchain cannot build
+  (e.g. the `armv9.2-a` variants on GCC 11) instead of failing the whole build.
+  Touches `ggml/src/CMakeLists.txt`.
 - `compat.cmake`, `apply-patch.cmake` - CMake glue and an idempotent applier
   (used by `llama/server/CMakeLists.txt`) that applies every `*.patch` under
   this directory by numeric filename order — the hooks patch plus each


### PR DESCRIPTION
## What

With `GGML_CPU_ALL_VARIANTS=ON` on Linux ARM, ggml adds `armv9.2-a` CPU backend variants. Toolchains older than GCC 12 (e.g. GCC 11.4 on Jetson AGX Orin / Ubuntu 22.04) don't understand `-march=armv9.2-a+…` and `cc1` aborts the entire build.

## How

Adds `llama/compat/004-ggml-cpu-arm-march-guard.patch`, which probes each ARM variant's `-march` via `check_cxx_compiler_flag` before adding it and skips the unsupported ones — the same pattern ggml already uses for POWER11. Supported baselines still build; newer compilers keep all variants. Only the ARM `GGML_CPU_ALL_VARIANTS` Linux path is affected — x86, Apple, Android, and native ARM paths are unchanged.

## Verification

On GCC 11.4.0 / aarch64 (the issue's compiler): all six `armv8.x` variants build, both `armv9.2` variants are skipped with a STATUS message, and configure completes without a fatal error. On GCC 12+ the probe passes and the `armv9.2` variants are kept as before.

Fixes #17340