### PR TITLE
runner: fix typo in README

### DIFF
--- a/runner/README.md
+++ b/runner/README.md
@@ -2,7 +2,7 @@
 
 > Note: this is a work in progress
 
-A minimial runner for loading a model and running inference via a http web server.
+A minimal runner for loading a model and running inference via a http web server.
 
 ```shell
 ./runner -model <model binary>


### PR DESCRIPTION
Small typo fix: "minimial" -> "minimal" in the runner package README.

Docs only, no functional changes.