### PR TITLE
docs: fix broken link in examples.md

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -11,4 +11,4 @@ Ollama JavaScript examples at [ollama-js/examples](https://github.com/ollama/oll
 
 
 ## OpenAI compatibility examples
-Ollama OpenAI compatibility examples at [ollama/examples/openai](../docs/openai.md)
+Ollama OpenAI compatibility examples at [OpenAI compatibility](https://docs.ollama.com/api/openai-compatibility)


### PR DESCRIPTION
docs/examples.md links to ../docs/openai.md, which no longer exists
(the file was removed as part of the docs.ollama.com migration).

This updates the link to the live OpenAI compatibility page, matching
the reference already used in docs/README.md.

Docs only, no functional changes.