### PR TITLE
docs: fix typo in vision capability example

### DIFF
--- a/docs/capabilities/vision.mdx
+++ b/docs/capabilities/vision.mdx
@@ -7,7 +7,7 @@ Vision models accept images alongside text so the model can describe, classify, 
 ## Quick start
 
 ```shell
-ollama run gemma4 ./image.png whats in this image?
+ollama run gemma4 ./image.png what's in this image?
 ```
 
 


### PR DESCRIPTION
Small typo: "whats" -> "what's" in the Quick start shell example.
docs/cli.mdx already uses the correctly-punctuated "What's in this
image?" for the same command, so this just makes vision.mdx consistent.

Docs only, no functional changes.