### PR TITLE
openai: normalize reasoning_effort "minimal" to "low"

### DIFF
--- a/openai/openai.go
+++ b/openai/openai.go
@@ -637,6 +637,13 @@ func FromChatRequest(r ChatCompletionRequest) (*api.ChatRequest, error) {
 	}
 
 	if effort != "" {
+		// OpenAI's GPT-5 series accepts "minimal" as a reasoning_effort value.
+		// Ollama has no distinct minimal think level, so treat it as the
+		// closest equivalent ("low") rather than rejecting the request.
+		if effort == "minimal" {
+			effort = "low"
+		}
+
 		if !slices.Contains([]string{"high", "medium", "low", "max", "none"}, effort) {
 			return nil, fmt.Errorf("invalid reasoning value: '%s' (must be \"high\", \"medium\", \"low\", \"max\", or \"none\")", effort)
 		}

--- a/openai/openai_test.go
+++ b/openai/openai_test.go
@@ -65,6 +65,7 @@ func TestFromChatRequest_ReasoningEffort(t *testing.T) {
 		wantErr bool
 	}{
 		{name: "unset", effort: nil, want: nil},
+		{name: "minimal maps to low", effort: effort("minimal"), want: "low"},
 		{name: "high", effort: effort("high"), want: "high"},
 		{name: "medium", effort: effort("medium"), want: "medium"},
 		{name: "low", effort: effort("low"), want: "low"},

--- a/openai/responses.go
+++ b/openai/responses.go
@@ -527,6 +527,13 @@ func FromResponsesRequest(r ResponsesRequest) (*api.ChatRequest, error) {
 
 	var think *api.ThinkValue
 	if effort := r.Reasoning.Effort; effort != "" {
+		// OpenAI's GPT-5 series accepts "minimal" as a reasoning effort value.
+		// Ollama has no distinct minimal think level, so treat it as the
+		// closest equivalent ("low") rather than rejecting the request.
+		if effort == "minimal" {
+			effort = "low"
+		}
+
 		switch effort {
 		case "none":
 			think = &api.ThinkValue{Value: false}

--- a/openai/responses_test.go
+++ b/openai/responses_test.go
@@ -426,6 +426,11 @@ func TestFromResponsesRequest_ReasoningEffort(t *testing.T) {
 			name: "unset",
 		},
 		{
+			name:      "minimal maps to low",
+			effort:    "minimal",
+			wantThink: "low",
+		},
+		{
 			name:      "low",
 			effort:    "low",
 			wantThink: "low",


### PR DESCRIPTION
OpenAI's GPT-5 series accepts `reasoning_effort: "minimal"`, but Ollama's
OpenAI-compatible layer only recognized high/medium/low/max/none and
rejected "minimal" with a 400 before any inference ran. This breaks OpenAI
SDK clients, agent frameworks, and shared configs that target the OpenAI
API generically and can't rewrite this field per-backend.

The same validation is duplicated in two places -- `/v1/chat/completions`
(openai.go) and `/v1/responses` (responses.go) -- so both are fixed here.

Since Ollama has no distinct "minimal" think level, "minimal" is now
normalized to "low" (the closest equivalent) before validation, rather
than being rejected.

Added test cases to the existing reasoning-effort tables in both
openai_test.go and responses_test.go confirming the mapping.

Fixes #17140