### PR TITLE
server: route Anthropic cloud images through chat

### DIFF
--- a/server/cloud_proxy.go
+++ b/server/cloud_proxy.go
@@ -28,7 +28,7 @@ const (
 	defaultCloudProxyBaseURL      = "https://ollama.com:443"
 	defaultCloudProxySigningHost  = "ollama.com"
 	cloudProxyBaseURLEnv          = "OLLAMA_CLOUD_BASE_URL"
-	legacyCloudAnthropicKey       = "legacy_cloud_anthropic_web_search"
+	cloudAnthropicChatFallbackKey = "cloud_anthropic_chat_fallback"
 	cloudProxyClientVersionHeader = "X-Ollama-Client-Version"
 
 	// maxDecompressedBodySize limits the size of a decompressed request body
@@ -120,11 +120,12 @@ func cloudPassthroughMiddleware(disabledOperation string) gin.HandlerFunc {
 			return
 		}
 
-		// TEMP(drifkin): keep Anthropic web search requests on the local middleware
-		// path so WebSearchAnthropicWriter can orchestrate follow-up calls.
+		// Keep Anthropic requests that need Ollama-native handling on the local
+		// middleware path. Web search requires orchestration, while image blocks
+		// need conversion to the native chat image format.
 		if c.Request.URL.Path == "/v1/messages" {
-			if hasAnthropicWebSearchTool(body) {
-				c.Set(legacyCloudAnthropicKey, true)
+			if hasAnthropicWebSearchTool(body) || hasAnthropicBase64ImageBlock(body) {
+				c.Set(cloudAnthropicChatFallbackKey, true)
 				c.Next()
 				return
 			}
@@ -234,7 +235,7 @@ func proxyCloudRequestWithPath(c *gin.Context, body []byte, path string, disable
 	// into WebSearchAnthropicWriter, but this proxy copy loop may coalesce
 	// multiple jsonl records into one Write.  WebSearchAnthropicWriter currently
 	// unmarshals one JSON value per Write.
-	if path == "/api/chat" && resp.StatusCode == http.StatusOK && c.GetBool(legacyCloudAnthropicKey) {
+	if path == "/api/chat" && resp.StatusCode == http.StatusOK && c.GetBool(cloudAnthropicChatFallbackKey) {
 		framedWriter = &jsonlFramingResponseWriter{ResponseWriter: c.Writer}
 		bodyWriter = framedWriter
 	}
@@ -340,6 +341,54 @@ func hasAnthropicWebSearchTool(body []byte) bool {
 
 	for _, tool := range payload.Tools {
 		if strings.HasPrefix(strings.TrimSpace(tool.Type), "web_search") {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasAnthropicBase64ImageBlock(body []byte) bool {
+	if len(body) == 0 {
+		return false
+	}
+
+	var payload struct {
+		Messages []struct {
+			Content any `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return false
+	}
+
+	var containsImageBlock func(any) bool
+	containsImageBlock = func(value any) bool {
+		switch value := value.(type) {
+		case []any:
+			for _, item := range value {
+				if containsImageBlock(item) {
+					return true
+				}
+			}
+		case map[string]any:
+			if blockType, ok := value["type"].(string); ok && blockType == "image" {
+				source, ok := value["source"].(map[string]any)
+				if !ok {
+					return false
+				}
+				sourceType, ok := source["type"].(string)
+				return ok && sourceType == "base64"
+			}
+			if content, ok := value["content"]; ok && containsImageBlock(content) {
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, message := range payload.Messages {
+		if containsImageBlock(message.Content) {
 			return true
 		}
 	}

--- a/server/routes.go
+++ b/server/routes.go
@@ -2453,7 +2453,7 @@ func (s *Server) ChatHandler(c *gin.Context) {
 
 	if modelRef.Source == modelSourceCloud {
 		req.Model = modelRef.Base
-		if c.GetBool(legacyCloudAnthropicKey) {
+		if c.GetBool(cloudAnthropicChatFallbackKey) {
 			proxyCloudJSONRequestWithPath(c, req, "/api/chat", cloudErrRemoteInferenceUnavailable)
 			return
 		}

--- a/server/routes_cloud_test.go
+++ b/server/routes_cloud_test.go
@@ -599,6 +599,129 @@ func TestExplicitCloudPassthroughAPIAndV1(t *testing.T) {
 		}
 	})
 
+	t.Run("v1 messages image fallback uses cloud api chat path", func(t *testing.T) {
+		upstream, capture := newUpstream(t, `{"model":"minimax-m3","created_at":"2024-01-01T00:00:00Z","message":{"role":"assistant","content":"red and white"},"done":true}`)
+		defer upstream.Close()
+
+		original := cloudProxyBaseURL
+		cloudProxyBaseURL = upstream.URL
+		t.Cleanup(func() { cloudProxyBaseURL = original })
+
+		s := &Server{}
+		router, err := s.GenerateRoutes()
+		if err != nil {
+			t.Fatal(err)
+		}
+		local := httptest.NewServer(router)
+		defer local.Close()
+
+		reqBody := `{
+				"model":"minimax-m3:cloud",
+				"max_tokens":10,
+				"stream":false,
+				"messages":[{
+					"role":"user",
+					"content":[
+						{"type":"text","text":"What colors are in this image?"},
+						{"type":"image","source":{"type":"base64","media_type":"image/png","data":"aW1hZ2U="}}
+					]
+				}]
+			}`
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, local.URL+"/v1/messages", bytes.NewBufferString(reqBody))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := local.Client().Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200, got %d (%s)", resp.StatusCode, string(body))
+		}
+
+		if capture.path != "/api/chat" {
+			t.Fatalf("expected upstream path /api/chat for image fallback, got %q", capture.path)
+		}
+
+		if !strings.Contains(capture.body, `"model":"minimax-m3"`) {
+			t.Fatalf("expected normalized model in upstream body, got %q", capture.body)
+		}
+
+		if !strings.Contains(capture.body, `"images":["aW1hZ2U="]`) {
+			t.Fatalf("expected converted image in upstream body, got %q", capture.body)
+		}
+
+		if !strings.Contains(capture.body, `"num_predict":10`) {
+			t.Fatalf("expected converted ollama options in upstream body, got %q", capture.body)
+		}
+
+		if !strings.Contains(string(body), `"type":"message"`) {
+			t.Fatalf("expected Anthropic response body, got %q", string(body))
+		}
+	})
+
+	t.Run("v1 messages non-base64 image bypasses conversion", func(t *testing.T) {
+		upstream, capture := newUpstream(t, `{"id":"msg_1","type":"message"}`)
+		defer upstream.Close()
+
+		original := cloudProxyBaseURL
+		cloudProxyBaseURL = upstream.URL
+		t.Cleanup(func() { cloudProxyBaseURL = original })
+
+		s := &Server{}
+		router, err := s.GenerateRoutes()
+		if err != nil {
+			t.Fatal(err)
+		}
+		local := httptest.NewServer(router)
+		defer local.Close()
+
+		reqBody := `{
+				"model":"minimax-m3:cloud",
+				"max_tokens":10,
+				"messages":[{
+					"role":"user",
+					"content":[{
+						"type":"image",
+						"source":{"type":"url","url":"https://example.com/image.png"}
+					}]
+				}]
+			}`
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, local.URL+"/v1/messages", bytes.NewBufferString(reqBody))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := local.Client().Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200, got %d (%s)", resp.StatusCode, string(body))
+		}
+
+		if capture.path != "/v1/messages" {
+			t.Fatalf("expected upstream path /v1/messages, got %q", capture.path)
+		}
+
+		if !strings.Contains(capture.body, `"type":"url"`) {
+			t.Fatalf("expected original Anthropic image source in upstream body, got %q", capture.body)
+		}
+
+		if strings.Contains(capture.body, `"options"`) {
+			t.Fatalf("expected no converted Ollama options in upstream body, got %q", capture.body)
+		}
+	})
+
 	t.Run("v1 messages web_search fallback uses legacy cloud /api/chat path", func(t *testing.T) {
 		upstream, capture := newUpstream(t, `{"model":"gpt-oss:120b","created_at":"2024-01-01T00:00:00Z","message":{"role":"assistant","content":"hello"},"done":true}`)
 		defer upstream.Close()


### PR DESCRIPTION
## Summary

- route Anthropic-compatible cloud requests containing base64 image blocks through Ollama's native chat fallback
- preserve direct `/v1/messages` passthrough for text-only requests and other image source types
- return the native cloud response through the existing Anthropic response converter

Fixes #17398.

## Why

Cloud requests normally bypass the local compatibility middleware and are sent
directly to the matching upstream endpoint. That leaves Anthropic base64 image
blocks in a shape the cloud `/v1/messages` endpoint rejects, even though the
same model accepts the image through `/api/chat`.

The existing Anthropic web-search fallback already converts selected cloud
requests to native chat. This change uses that path for base64 image blocks as
well, while leaving ordinary passthrough behavior unchanged.

## Validation

- `go test ./server -run '^(TestExplicitCloudPassthroughAPIAndV1|TestCloudPassthrough.*)$' -count=1`
- `go test ./anthropic ./middleware -count=1`
- `go vet ./server ./anthropic ./middleware`
- the unrelated hardware-sensitive failures from the full server suite were
  reproduced unchanged on a clean worktree at the same upstream commit

_Disclosure: AI assistance was used to investigate the request path and draft
the implementation. The implementation was validated with the local tests
listed above._
