### PR TITLE
docs(cli): add missing model name to ollama create example (#17346)

### DIFF
--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -118,10 +118,10 @@ FROM gemma4
 SYSTEM """You are a happy cat."""
 ```
 
-Then run `ollama create`:
+Then run `ollama create` with a model name:
 
 ```
-ollama create -f Modelfile
+ollama create my-model -f Modelfile
 ```
 
 ### List running models


### PR DESCRIPTION
## Description

The `ollama create -f Modelfile` example in the CLI docs is missing the required positional model name argument. Running it as shown produces:

```
Error: accepts 1 arg(s), received 0
```

## Fix

Add `my-model` as the positional argument and clarify the instruction text:

```diff
-Then run `ollama create`:
-ollama create -f Modelfile
+Then run `ollama create` with a model name:
+ollama create my-model -f Modelfile
```

This matches the usage shown in `docs/modelfile.mdx` which already has the correct form.

## Related Issue

Closes #17346
