### PR TITLE
app: honor OLLAMA_MODELS over desktop settings path

### DIFF
--- a/app/server/server.go
+++ b/app/server/server.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/ollama/ollama/app/logrotate"
 	"github.com/ollama/ollama/app/store"
+	"github.com/ollama/ollama/envconfig"
 )
 
 const restartDelay = time.Second
@@ -253,7 +254,10 @@ func (s *Server) cmd(ctx context.Context) (*exec.Cmd, error) {
 	if settings.Browser {
 		env["OLLAMA_ORIGINS"] = "*"
 	}
-	if settings.Models != "" {
+	if modelsEnv := envconfig.Var("OLLAMA_MODELS"); modelsEnv != "" {
+		env["OLLAMA_MODELS"] = modelsEnv
+		slog.Info("using OLLAMA_MODELS from environment", "path", modelsEnv)
+	} else if settings.Models != "" {
 		if _, err := os.Stat(settings.Models); err == nil {
 			env["OLLAMA_MODELS"] = settings.Models
 		} else {

--- a/app/server/server_test.go
+++ b/app/server/server_test.go
@@ -41,9 +41,11 @@ func TestServerCmd(t *testing.T) {
 	}
 
 	tmpModels := t.TempDir()
+	envModels := t.TempDir()
 	tests := []struct {
 		name     string
 		settings store.Settings
+		env      map[string]string
 		want     []string
 		dont     []string
 	}{
@@ -91,10 +93,49 @@ func TestServerCmd(t *testing.T) {
 			},
 			dont: []string{},
 		},
+		{
+			name:     "env_models_overrides_settings",
+			settings: store.Settings{Models: tmpModels},
+			env:      map[string]string{"OLLAMA_MODELS": envModels},
+			want:     []string{"OLLAMA_MODELS=" + envModels},
+			dont:     []string{"OLLAMA_MODELS=" + tmpModels},
+		},
+		{
+			name:     "env_models_without_settings",
+			settings: store.Settings{},
+			env:      map[string]string{"OLLAMA_MODELS": envModels},
+			want:     []string{"OLLAMA_MODELS=" + envModels},
+			dont:     []string{"OLLAMA_MODELS=" + defaultModels},
+		},
+		{
+			name:     "env_whitespace_only_falls_back_to_settings",
+			settings: store.Settings{Models: tmpModels},
+			env:      map[string]string{"OLLAMA_MODELS": "   "},
+			want:     []string{"OLLAMA_MODELS=" + tmpModels},
+			dont:     []string{},
+		},
+		{
+			name:     "env_quoted_path_normalized",
+			settings: store.Settings{},
+			env:      map[string]string{"OLLAMA_MODELS": "\"" + envModels + "\""},
+			want:     []string{"OLLAMA_MODELS=" + envModels},
+			dont:     []string{"OLLAMA_MODELS=\"" + envModels + "\""},
+		},
+		{
+			name:     "env_spaced_path_normalized",
+			settings: store.Settings{},
+			env:      map[string]string{"OLLAMA_MODELS": " " + envModels + " "},
+			want:     []string{"OLLAMA_MODELS=" + envModels},
+			dont:     []string{},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+
 			tmpDir := t.TempDir()
 			st := &store.Store{DBPath: filepath.Join(tmpDir, "db.sqlite")}
 			defer st.Close() // Ensure database is closed before cleanup

--- a/app/store/store.go
+++ b/app/store/store.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/ollama/ollama/app/types/not"
+	"github.com/ollama/ollama/envconfig"
 )
 
 type File struct {
@@ -381,7 +382,7 @@ func (s *Store) Settings() (Settings, error) {
 
 	// Set default models directory if not set
 	if settings.Models == "" {
-		dir := os.Getenv("OLLAMA_MODELS")
+		dir := envconfig.Var("OLLAMA_MODELS")
 		if dir != "" {
 			settings.Models = dir
 		} else {

--- a/app/ui/app/codegen/gotypes.gen.ts
+++ b/app/ui/app/codegen/gotypes.gen.ts
@@ -439,10 +439,12 @@ export class Settings {
 }
 export class SettingsResponse {
     settings: Settings;
+    modelsFromEnv: boolean;
 
     constructor(source: any = {}) {
         if ('string' === typeof source) source = JSON.parse(source);
         this.settings = this.convertValues(source["settings"], Settings);
+        this.modelsFromEnv = source["modelsFromEnv"];
     }
 
 	convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/app/ui/app/src/api.ts
+++ b/app/ui/app/src/api.ts
@@ -259,6 +259,7 @@ export async function* sendMessage(
 
 export async function getSettings(): Promise<{
   settings: Settings;
+  modelsFromEnv: boolean;
 }> {
   const response = await fetch(`${API_BASE}/api/v1/settings`);
   if (!response.ok) {
@@ -267,11 +268,13 @@ export async function getSettings(): Promise<{
   const data = await response.json();
   return {
     settings: new Settings(data.settings),
+    modelsFromEnv: Boolean(data.modelsFromEnv),
   };
 }
 
 export async function updateSettings(settings: Settings): Promise<{
   settings: Settings;
+  modelsFromEnv: boolean;
 }> {
   const response = await fetch(`${API_BASE}/api/v1/settings`, {
     method: "POST",
@@ -287,6 +290,7 @@ export async function updateSettings(settings: Settings): Promise<{
   const data = await response.json();
   return {
     settings: new Settings(data.settings),
+    modelsFromEnv: Boolean(data.modelsFromEnv),
   };
 }
 

--- a/app/ui/app/src/components/Settings.tsx
+++ b/app/ui/app/src/components/Settings.tsx
@@ -496,7 +496,11 @@ export default function Settings() {
                   <FolderIcon className="mt-1 h-5 w-5 flex-shrink-0 text-black dark:text-neutral-100" />
                   <div className="w-full">
                     <Label>Model location</Label>
-                    <Description>Location where models are stored.</Description>
+                    <Description>
+                      {settingsData?.modelsFromEnv
+                        ? "Using OLLAMA_MODELS. The path below is from the environment. Clear the variable and restart to choose a path here."
+                        : "Location where models are stored."}
+                    </Description>
                     <div className="mt-2 flex items-center space-x-2">
                       <Input
                         value={settings.Models || ""}
@@ -507,7 +511,11 @@ export default function Settings() {
                         type="button"
                         color="white"
                         className="px-2"
+                        disabled={settingsData?.modelsFromEnv}
                         onClick={async () => {
+                          if (settingsData?.modelsFromEnv) {
+                            return;
+                          }
                           if (window.webview?.selectModelsDirectory) {
                             try {
                               const directory =

--- a/app/ui/app/src/components/ui/button.tsx
+++ b/app/ui/app/src/components/ui/button.tsx
@@ -195,7 +195,10 @@ export const Button = forwardRef(function Button(
   ) : (
     <Headless.Button
       {...(props as Omit<Headless.ButtonProps, "as" | "className">)}
-      className={clsx(classes, "cursor-pointer")}
+      className={clsx(
+        classes,
+        "cursor-pointer data-disabled:cursor-not-allowed",
+      )}
       ref={ref as React.ForwardedRef<HTMLButtonElement>}
     >
       <TouchTarget>{children}</TouchTarget>

--- a/app/ui/responses/types.go
+++ b/app/ui/responses/types.go
@@ -94,7 +94,8 @@ type ErrorEvent struct {
 }
 
 type SettingsResponse struct {
-	Settings store.Settings `json:"settings"`
+	Settings      store.Settings `json:"settings"`
+	ModelsFromEnv bool           `json:"modelsFromEnv"`
 }
 
 type HealthResponse struct {

--- a/app/ui/ui.go
+++ b/app/ui/ui.go
@@ -1442,8 +1442,12 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) error {
 		return fmt.Errorf("failed to load settings: %w", err)
 	}
 
-	// set default models directory if not set
-	if settings.Models == "" {
+	// Effective models path: OLLAMA_MODELS env wins over saved settings, then default.
+	modelsFromEnv := false
+	if modelsEnv := envconfig.Var("OLLAMA_MODELS"); modelsEnv != "" {
+		settings.Models = modelsEnv
+		modelsFromEnv = true
+	} else if settings.Models == "" {
 		settings.Models = envconfig.Models()
 	}
 
@@ -1454,7 +1458,8 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) error {
 
 	w.Header().Set("Content-Type", "application/json")
 	return json.NewEncoder(w).Encode(responses.SettingsResponse{
-		Settings: settings,
+		Settings:      settings,
+		ModelsFromEnv: modelsFromEnv,
 	})
 }
 
@@ -1467,6 +1472,18 @@ func (s *Server) settings(w http.ResponseWriter, r *http.Request) error {
 	var settings store.Settings
 	if err := json.NewDecoder(r.Body).Decode(&settings); err != nil {
 		return fmt.Errorf("invalid request body: %w", err)
+	}
+
+	// Don't persist OLLAMA_MODELS into the DB. old.Models may be env-synthesized
+	// when the store is empty; only keep a path that differs from the env value.
+	modelsEnv := envconfig.Var("OLLAMA_MODELS")
+	modelsFromEnv := modelsEnv != ""
+	if modelsFromEnv {
+		if old.Models != "" && old.Models != modelsEnv {
+			settings.Models = old.Models
+		} else {
+			settings.Models = ""
+		}
 	}
 
 	if err := s.Store.SetSettings(settings); err != nil {
@@ -1491,15 +1508,22 @@ func (s *Server) settings(w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 
+	// Models changes are ignored while OLLAMA_MODELS owns the path.
+	modelsChanged := !modelsFromEnv && old.Models != settings.Models
 	if old.ContextLength != settings.ContextLength ||
-		old.Models != settings.Models ||
+		modelsChanged ||
 		old.Expose != settings.Expose {
 		s.Restart()
 	}
 
+	if modelsFromEnv {
+		settings.Models = modelsEnv
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	return json.NewEncoder(w).Encode(responses.SettingsResponse{
-		Settings: settings,
+		Settings:      settings,
+		ModelsFromEnv: modelsFromEnv,
 	})
 }
 

--- a/app/ui/ui_test.go
+++ b/app/ui/ui_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/app/store"
+	"github.com/ollama/ollama/app/ui/responses"
 	"github.com/ollama/ollama/app/updater"
 )
 
@@ -60,6 +61,7 @@ func TestHandlePostApiSettings(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("OLLAMA_MODELS", "")
 			testStore := &store.Store{
 				DBPath: filepath.Join(t.TempDir(), "db.sqlite"),
 			}
@@ -838,5 +840,138 @@ func TestSettingsToggleAutoUpdateOn_NoPendingUpdate_TriggersCheck(t *testing.T) 
 	// UpdateAvailableFunc should NOT be called since there's no pending update
 	if notificationCalled.Load() {
 		t.Fatal("UpdateAvailableFunc should not be called when there is no pending update")
+	}
+}
+
+func TestSettingsModelsFromEnvPreserved(t *testing.T) {
+	tmpDir := t.TempDir()
+	storedModels := filepath.Join(tmpDir, "stored")
+	envModels := filepath.Join(tmpDir, "env")
+
+	// Pre-populate the store with a user-chosen models path
+	testStore := &store.Store{
+		DBPath: filepath.Join(t.TempDir(), "db.sqlite"),
+	}
+	defer testStore.Close()
+	if err := testStore.SetSettings(store.Settings{Models: storedModels}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate env var controlling the path
+	t.Setenv("OLLAMA_MODELS", envModels)
+
+	// POST a settings update that includes Models set to the env-derived value
+	// (mimicking the auto-save from the frontend when user changes another field)
+	reqBody, _ := json.Marshal(store.Settings{
+		Expose:  true,
+		Models:  envModels, // env-derived from GET response
+		Browser: false,
+	})
+
+	server := &Server{
+		Store:   testStore,
+		Restart: func() {},
+	}
+
+	req := httptest.NewRequest("POST", "/api/v1/settings", bytes.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	if err := server.settings(rr, req); err != nil {
+		t.Fatal(err)
+	}
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d", rr.Code)
+	}
+
+	// DB must still have the ORIGINAL path, not the env-derived one
+	saved, err := testStore.Settings()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if saved.Models != storedModels {
+		t.Errorf("Models persisted to DB: got %q, want %q (original stored path)", saved.Models, storedModels)
+	}
+
+	// Other fields should still be saved
+	if !saved.Expose {
+		t.Error("Expose should be saved")
+	}
+
+	// Response must report env is in charge with the env path
+	var resp responses.SettingsResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if !resp.ModelsFromEnv {
+		t.Error("response ModelsFromEnv should be true")
+	}
+	if resp.Settings.Models != envModels {
+		t.Errorf("response Settings.Models = %q, want %q (env path)", resp.Settings.Models, envModels)
+	}
+}
+
+func TestSettingsModelsFromEnvNotPersistedWhenStoreEmpty(t *testing.T) {
+	// Empty DB + OLLAMA_MODELS: saving another setting must not persist the env path.
+	envModels := filepath.Join(t.TempDir(), "env")
+	t.Setenv("OLLAMA_MODELS", envModels)
+
+	testStore := &store.Store{
+		DBPath: filepath.Join(t.TempDir(), "db.sqlite"),
+	}
+	defer testStore.Close()
+
+	// store.Settings() synthesizes the env path when DB is empty.
+	before, err := testStore.Settings()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before.Models != envModels {
+		t.Fatalf("precondition: Settings().Models = %q, want synthesized env path %q", before.Models, envModels)
+	}
+
+	reqBody, _ := json.Marshal(store.Settings{
+		Expose: true,
+		Models: envModels,
+	})
+
+	server := &Server{
+		Store:   testStore,
+		Restart: func() {},
+	}
+
+	req := httptest.NewRequest("POST", "/api/v1/settings", bytes.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	if err := server.settings(rr, req); err != nil {
+		t.Fatal(err)
+	}
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d", rr.Code)
+	}
+
+	// Clear env so Settings() returns the real stored value.
+	t.Setenv("OLLAMA_MODELS", "")
+	saved, err := testStore.Settings()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if saved.Models == envModels {
+		t.Fatalf("env path was persisted to DB: got %q", saved.Models)
+	}
+	if !saved.Expose {
+		t.Error("Expose should be saved")
+	}
+
+	var resp responses.SettingsResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if !resp.ModelsFromEnv {
+		t.Error("response ModelsFromEnv should be true")
+	}
+	if resp.Settings.Models != envModels {
+		t.Fatalf("response Settings.Models = %q, want %q", resp.Settings.Models, envModels)
 	}
 }

--- a/server/routes_create_test.go
+++ b/server/routes_create_test.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"bytes"
-	"cmp"
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
@@ -31,9 +30,19 @@ import (
 
 var stream bool = false
 
+// ensureTestModelsDir isolates tests from a developer OLLAMA_MODELS while
+// reusing one directory for every helper call within the same test. Always
+// calling t.TempDir() here would break createBinFile → createRequest flows.
+func ensureTestModelsDir(t *testing.T) {
+	t.Helper()
+	if envconfig.Var("OLLAMA_MODELS") == "" {
+		t.Setenv("OLLAMA_MODELS", t.TempDir())
+	}
+}
+
 func createBinFile(t *testing.T, kv map[string]any, ti []*ggml.Tensor) (string, string) {
 	t.Helper()
-	t.Setenv("OLLAMA_MODELS", cmp.Or(os.Getenv("OLLAMA_MODELS"), t.TempDir()))
+	ensureTestModelsDir(t)
 
 	modelDir := envconfig.Models()
 
@@ -83,8 +92,7 @@ func (t *responseRecorder) CloseNotify() <-chan bool {
 
 func createRequest(t *testing.T, fn func(*gin.Context), body any) *httptest.ResponseRecorder {
 	t.Helper()
-	// if OLLAMA_MODELS is not set, set it to the temp directory
-	t.Setenv("OLLAMA_MODELS", cmp.Or(os.Getenv("OLLAMA_MODELS"), t.TempDir()))
+	ensureTestModelsDir(t)
 
 	w := NewRecorder()
 	c, _ := gin.CreateTestContext(w)

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -21,6 +21,9 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	// Drop ambient OLLAMA_MODELS so package helpers (ensureTestModelsDir) never
+	// write fixtures into a developer's real models directory (e.g. C:\models).
+	os.Unsetenv("OLLAMA_MODELS")
 	os.Setenv("OLLAMA_DEBUG", "1")
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	slog.SetDefault(logger)


### PR DESCRIPTION
## Summary

Fixes the desktop app ignoring `OLLAMA_MODELS` when a models path is already saved in Settings (Windows).

Closes #17374

Previously, the app always applied the stored Settings models path when spawning `ollama serve`, so the env var was overwritten even when set. Manual `ollama serve` respected `OLLAMA_MODELS`; the app did not.

### Changes

- Prefer `OLLAMA_MODELS` over the Settings models path when starting the server
- Surface the effective path in Settings and set `modelsFromEnv` when the env var owns the path
- Disable **Browse** while the env var is in control
- Do not persist the env-derived path into the store (so a prior user choice survives after the variable is cleared; empty store stays empty)

## Screenshots

### Before
For context, env OLLAMA_MODELS is set to `C:\ai\models`

Settings shows the stored path (e.g. `C:\models`) even when `OLLAMA_MODELS` is set to something else (`C:\ai\models` in this case)

<img width="842" height="256" alt="{BA390842-5957-4205-B766-394B3D22D19D}" src="https://github.com/user-attachments/assets/7522e87f-02e1-45c0-9bb5-25b17a7f7412" />


### After — `OLLAMA_MODELS` set

Settings shows the env path, notes that the path comes from the environment, and **Browse** is disabled.

<img width="912" height="368" alt="image" src="https://github.com/user-attachments/assets/7f6d2f21-49c4-4503-b58d-4cd70c2a66ad" />



### `OLLAMA_MODELS` unset

Settings path and **Browse** behave as before (user-chosen / default location) when there is no OLLAMA_MODELS env 


### Testing DX
Tests use a temp dir for `OLLAMA_MODELS` so they don’t accidentally write artifacts into the user’s real models directory

## Steps to reproduce locally

- [ ] Set `OLLAMA_MODELS` to a custom directory, restart the app
  - [ ] Settings → Model location shows the env path
  - [ ] Description indicates `OLLAMA_MODELS` is in use
  - [ ] **Browse** is disabled
  - [ ] Server log / config uses the env path (not the old Settings path)
- [ ] With env still set, toggle another setting (e.g. Expose) and save
  - [ ] Env path is **not** written into the store
- [ ] Unset `OLLAMA_MODELS`, restart the app
  - [ ] Previous user-chosen path (if any) is restored; otherwise default
  - [ ] **Browse** works again
- [ ] No env var: choosing a models directory via Browse still works and restarts the server as before
