### PR TITLE
server: preserve chat metrics across buffered tool chunks

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -2760,6 +2760,8 @@ func (s *Server) ChatHandler(c *gin.Context) {
 			// sets up new context given parent context per request
 			ctx, cancel := context.WithCancel(c.Request.Context())
 
+			var observedMetrics api.Metrics
+
 			err := r.Completion(ctx, llm.CompletionRequest{
 				Prompt:          prompt,
 				Media:           media,
@@ -2786,6 +2788,23 @@ func (s *Server) ChatHandler(c *gin.Context) {
 					},
 					Logprobs: toAPILogprobs(r.Logprobs),
 				}
+
+				if res.Metrics.PromptEvalCount > 0 {
+					observedMetrics.PromptEvalCount = res.Metrics.PromptEvalCount
+				}
+				if res.Metrics.PromptEvalDuration > 0 {
+					observedMetrics.PromptEvalDuration = res.Metrics.PromptEvalDuration
+				}
+				if res.Metrics.EvalCount > 0 {
+					observedMetrics.EvalCount = res.Metrics.EvalCount
+				}
+				if res.Metrics.EvalDuration > 0 {
+					observedMetrics.EvalDuration = res.Metrics.EvalDuration
+				}
+				res.Metrics.PromptEvalCount = observedMetrics.PromptEvalCount
+				res.Metrics.PromptEvalDuration = observedMetrics.PromptEvalDuration
+				res.Metrics.EvalCount = observedMetrics.EvalCount
+				res.Metrics.EvalDuration = observedMetrics.EvalDuration
 
 				if r.Done {
 					res.DoneReason = r.DoneReason.String()

--- a/server/routes_generate_test.go
+++ b/server/routes_generate_test.go
@@ -1187,6 +1187,94 @@ func TestGenerateChat(t *testing.T) {
 		}
 	})
 
+	t.Run("messages with tools preserves prompt metrics from buffered chunks", func(t *testing.T) {
+		tools := []api.Tool{
+			{
+				Type: "function",
+				Function: api.ToolFunction{
+					Name: "get_weather",
+					Parameters: api.ToolFunctionParameters{
+						Type: "object",
+						Properties: testPropsMap(map[string]api.ToolProperty{
+							"location": {Type: api.PropertyType{"string"}},
+						}),
+					},
+				},
+			},
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+
+		mock.CompletionFn = func(ctx context.Context, r llm.CompletionRequest, fn func(r llm.CompletionResponse)) error {
+			defer wg.Done()
+
+			responses := []llm.CompletionResponse{
+				{
+					Content:            `{"name":"get_weather",`,
+					PromptEvalCount:    42,
+					PromptEvalDuration: 7,
+				},
+				{
+					Content:    `"arguments":{"location":"Seattle"}}`,
+					Done:       true,
+					DoneReason: llm.DoneReasonStop,
+					EvalCount:  5,
+				},
+			}
+
+			for _, resp := range responses {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				default:
+					fn(resp)
+				}
+			}
+			return nil
+		}
+
+		stream := true
+		w := createRequest(t, s.ChatHandler, api.ChatRequest{
+			Model: "test-system",
+			Messages: []api.Message{
+				{Role: "user", Content: "What's the weather in Seattle?"},
+			},
+			Tools:  tools,
+			Stream: &stream,
+		})
+
+		wg.Wait()
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+		}
+
+		decoder := json.NewDecoder(w.Body)
+		var final api.ChatResponse
+		for {
+			var resp api.ChatResponse
+			if err := decoder.Decode(&resp); err == io.EOF {
+				break
+			} else if err != nil {
+				t.Fatal(err)
+			}
+			if resp.Done {
+				final = resp
+			}
+		}
+
+		if final.Metrics.PromptEvalCount != 42 {
+			t.Fatalf("expected prompt eval count 42, got %d", final.Metrics.PromptEvalCount)
+		}
+		if final.Metrics.PromptEvalDuration != 7 {
+			t.Fatalf("expected prompt eval duration 7, got %s", final.Metrics.PromptEvalDuration)
+		}
+		if final.Metrics.EvalCount != 5 {
+			t.Fatalf("expected eval count 5, got %d", final.Metrics.EvalCount)
+		}
+	})
+
 	t.Run("messages with tools (streaming)", func(t *testing.T) {
 		tools := []api.Tool{
 			{


### PR DESCRIPTION
## Summary

Fix tool-calling chat responses where `prompt_eval_count` and related metrics are lost when the tool parser buffers content across multiple completion chunks. The first chunk carries the prompt metrics but is discarded by an early return, and the final (done) chunk lacks them.

This addresses issue #15850 where `input_tokens` (the OpenAI-compatible usage field, sourced from `prompt_eval_count`) stagnated across tool call rounds instead of reflecting the growing context.

## Root Cause

In `ChatHandler`, the `r.Completion()` callback creates a new `api.ChatResponse` for each incoming chunk. Only the final chunk (`r.Done == true`) has `PromptEvalCount` populated by the LLM backend — all intermediate chunks report zero metrics.

When tools are present, the tool parser buffers partial JSON across chunks. If the tool call JSON spans multiple chunks:

1. **Chunk 1**: `{"name":"get_weather",` — `r.Done=false`, `r.PromptEvalCount=42`. The tool parser buffers this partial content and the callback returns early without sending anything to `ch` (line 2874).
2. **Chunk 2**: `"arguments":{"location":"Seattle"}}` — `r.Done=true`, `r.PromptEvalCount=0`. The tool parser detects a complete tool call and emits the response to `ch`, but the metrics are zero because only the final chunk carried `EvalCount`, not `PromptEvalCount`.

The streamed response (or the final accumulated response in non-streaming mode) ends up with `PromptEvalCount=0`, losing the prompt metrics from chunk 1.

## Fix

Introduce an `observedMetrics` accumulator (`api.Metrics`) scoped to each `r.Completion()` call. Before the callback emits or discards a chunk, it merges any non-zero metric values from the current chunk into the accumulator. Immediately after, the accumulator values are written back to `res.Metrics`, ensuring every emitted chunk carries the highest observed value for each metric field.

This preserves the first chunk's prompt metrics through the tool-parser buffering path, while correctly carrying forward eval metrics from the done chunk.

## Testing

Added `TestGenerateChat/messages_with_tools_preserves_prompt_metrics_from_buffered_chunks`:

- Simulates a two-chunk completion where `PromptEvalCount` and `PromptEvalDuration` appear only on the first (non-done) chunk and `EvalCount` appears only on the second (done) chunk.
- The tool call JSON is split across both chunks so the tool parser buffers the first and completes on the second — reproducing the exact scenario.
- Asserts `PromptEvalCount=42`, `PromptEvalDuration=7`, and `EvalCount=5` on the final streamed response.

All existing `TestGenerateChat` sub-tests continue to pass (19 total).

## Related

- Fixes #15850
- Closes PR #15858 (previously submitted, same root cause; this implementation applies the same logic to the current refactored codebase)
