### PR TITLE
Fix CLI backslash-escaped image path parsing (#10333)

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -583,7 +583,8 @@ func NewCreateRequest(name string, opts runOptions) *api.CreateRequest {
 }
 
 func normalizeFilePath(fp string) string {
-	return strings.NewReplacer(
+	fp = strings.Trim(fp, "\"'")
+	fp = strings.NewReplacer(
 		"\\ ", " ", // Escaped space
 		"\\(", "(", // Escaped left parenthesis
 		"\\)", ")", // Escaped right parenthesis
@@ -595,18 +596,29 @@ func normalizeFilePath(fp string) string {
 		"\\&", "&", // Escaped ampersand
 		"\\;", ";", // Escaped semicolon
 		"\\'", "'", // Escaped single quote
+		"\\\"", "\"", // Escaped double quote
 		"\\\\", "\\", // Escaped backslash
 		"\\*", "*", // Escaped asterisk
 		"\\?", "?", // Escaped question mark
 		"\\~", "~", // Escaped tilde
 	).Replace(fp)
+
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		if fp == "~" {
+			fp = home
+		} else if strings.HasPrefix(fp, "~/") || strings.HasPrefix(fp, "~\\") {
+			fp = filepath.Join(home, fp[2:])
+		}
+	}
+
+	return fp
 }
 
 func extractFileNames(input string) []string {
-	// Regex to match file paths starting with optional drive letter, / ./ \ or .\ and include escaped or unescaped spaces (\ or %20)
+	// Regex to match file paths starting with optional drive letter, / ./ \ .\ or ~ \~ and include escaped or unescaped spaces (\ or %20)
 	// and followed by more characters and a file extension
 	// This will capture non filename strings, but we'll check for file existence to remove mismatches
-	regexPattern := `(?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp|wav)\b`
+	regexPattern := `(?:[a-zA-Z]:)?(?:\./|\.\\|/|\\|\\?~[/\\])[\S\\ ]+?\.(?i:jpg|jpeg|png|webp|wav)\b`
 	re := regexp.MustCompile(regexPattern)
 
 	return re.FindAllString(input, -1)
@@ -634,6 +646,8 @@ func extractFileData(input string) (string, []api.ImageData, error) {
 		}
 		input = strings.ReplaceAll(input, "'"+nfp+"'", "")
 		input = strings.ReplaceAll(input, "'"+fp+"'", "")
+		input = strings.ReplaceAll(input, `"`+nfp+`"`, "")
+		input = strings.ReplaceAll(input, `"`+fp+`"`, "")
 		input = strings.ReplaceAll(input, fp, "")
 		imgs = append(imgs, data)
 	}

--- a/cmd/interactive_test.go
+++ b/cmd/interactive_test.go
@@ -108,8 +108,42 @@ func TestExtractFileDataWAV(t *testing.T) {
 		t.Fatalf("failed to write test audio: %v", err)
 	}
 
-	input := "before " + fp + " after"
+	input = "before " + fp + " after"
 	cleaned, imgs, err := extractFileData(input)
+	assert.NoError(t, err)
+	assert.Len(t, imgs, 1)
+	assert.Equal(t, "before  after", cleaned)
+}
+
+func TestNormalizeFilePathBackslashEscapedAndQuoted(t *testing.T) {
+	assert.Equal(t, "/path/to/my image (1).png", normalizeFilePath(`"/path/to/my\ image\ \(1\).png"`))
+	assert.Equal(t, "/path/to/my image (1).png", normalizeFilePath(`'/path/to/my\ image\ \(1\).png'`))
+}
+
+func TestExtractFileDataBackslashEscapedAndQuoted(t *testing.T) {
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "my image (1).jpg")
+	data := make([]byte, 600)
+	copy(data, []byte{
+		0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 'J', 'F', 'I', 'F',
+		0x00, 0x01, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0xff, 0xd9,
+	})
+	if err := os.WriteFile(fp, data, 0o600); err != nil {
+		t.Fatalf("failed to write test image: %v", err)
+	}
+
+	// Escaped path
+	escapedFp := filepath.Join(dir, `my\ image\ \(1\).jpg`)
+	input := "before " + escapedFp + " after"
+	cleaned, imgs, err := extractFileData(input)
+	assert.NoError(t, err)
+	assert.Len(t, imgs, 1)
+	assert.Equal(t, "before  after", cleaned)
+
+	// Double-quoted escaped path
+	input = `before "` + escapedFp + `" after`
+	cleaned, imgs, err = extractFileData(input)
 	assert.NoError(t, err)
 	assert.Len(t, imgs, 1)
 	assert.Equal(t, "before  after", cleaned)

--- a/cmd/internal/filedata/filedata.go
+++ b/cmd/internal/filedata/filedata.go
@@ -21,7 +21,7 @@ type File struct {
 }
 
 func NormalizePath(fp string) string {
-	fp = strings.Trim(fp, "\"")
+	fp = strings.Trim(fp, "\"'")
 	fp = strings.NewReplacer(
 		"\\ ", " ",
 		"\\(", "(",
@@ -34,11 +34,20 @@ func NormalizePath(fp string) string {
 		"\\&", "&",
 		"\\;", ";",
 		"\\'", "'",
+		"\\\"", "\"",
 		"\\\\", "\\",
 		"\\*", "*",
 		"\\?", "?",
 		"\\~", "~",
 	).Replace(fp)
+
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		if fp == "~" {
+			fp = home
+		} else if strings.HasPrefix(fp, "~/") || strings.HasPrefix(fp, "~\\") {
+			fp = filepath.Join(home, fp[2:])
+		}
+	}
 
 	if u, err := url.Parse(fp); err == nil && strings.EqualFold(u.Scheme, "file") {
 		return normalizeFileURL(u)
@@ -53,7 +62,7 @@ func NormalizePath(fp string) string {
 // extensions. Hoisted to package scope so the per-keystroke slash-completion
 // path (chat.slashInputIsMultimodalFile -> ExtractNames) doesn't recompile it
 // on every call.
-var fileExtractRe = regexp.MustCompile(`(?:file://\S+?\.(?i:jpg|jpeg|png|webp|wav)\b)|(?:(?:[a-zA-Z]:)?(?:\./|\.\\|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp|wav)\b)`)
+var fileExtractRe = regexp.MustCompile(`(?:file://\S+?\.(?i:jpg|jpeg|png|webp|wav)\b)|(?:(?:[a-zA-Z]:)?(?:\./|\.\\|/|\\|\\?~[/\\])[\S\\ ]+?\.(?i:jpg|jpeg|png|webp|wav)\b)`)
 
 func ExtractNames(input string) []string {
 	return fileExtractRe.FindAllString(input, -1)

--- a/cmd/internal/filedata/filedata_test.go
+++ b/cmd/internal/filedata/filedata_test.go
@@ -199,6 +199,59 @@ func TestExtractWAV(t *testing.T) {
 	}
 }
 
+func TestNormalizePathBackslashEscapedAndQuoted(t *testing.T) {
+	got1 := NormalizePath(`"/path/to/my\ image\ \(1\).png"`)
+	want1 := "/path/to/my image (1).png"
+	if got1 != want1 {
+		t.Fatalf("got = %q, want %q", got1, want1)
+	}
+
+	got2 := NormalizePath(`'/path/to/my\ image\ \(1\).png'`)
+	want2 := "/path/to/my image (1).png"
+	if got2 != want2 {
+		t.Fatalf("got = %q, want %q", got2, want2)
+	}
+}
+
+func TestExtractBackslashEscapedAndQuoted(t *testing.T) {
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "my image (1).jpg")
+	data := make([]byte, 600)
+	copy(data, []byte{
+		0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 'J', 'F', 'I', 'F',
+		0x00, 0x01, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0xff, 0xd9,
+	})
+	if err := os.WriteFile(fp, data, 0o600); err != nil {
+		t.Fatalf("failed to write test image: %v", err)
+	}
+
+	escapedFp := filepath.Join(dir, `my\ image\ \(1\).jpg`)
+	input := "before " + escapedFp + " after"
+	cleaned, imgs, err := Extract(input)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(imgs) != 1 {
+		t.Fatalf("imgs = %d, want 1", len(imgs))
+	}
+	if cleaned != "before  after" {
+		t.Fatalf("cleaned = %q, want %q", cleaned, "before  after")
+	}
+
+	input = `before "` + escapedFp + `" after`
+	cleaned, imgs, err = Extract(input)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(imgs) != 1 {
+		t.Fatalf("imgs = %d, want 1", len(imgs))
+	}
+	if cleaned != "before  after" {
+		t.Fatalf("cleaned = %q, want %q", cleaned, "before  after")
+	}
+}
+
 func assertContains(t *testing.T, s, want string) {
 	t.Helper()
 	if !strings.Contains(s, want) {


### PR DESCRIPTION
Fixes #10333

### Summary of Changes

- Quote Stripping: Updated path normalization in cmd/interactive.go and cmd/internal/filedata/filedata.go to strip both single and double surrounding quotes ('...' and ...).
- Unescaping Backslashes: Added handling for backslash-escaped characters such as \ , \~, \(, \), ", etc.
- Tilde Expansion: Expanded ~ / \~ prefixes to the user's home directory (os.UserHomeDir()).
- Regex Updates: Updated regex pattern in both path extraction implementations to support ~ and \~ path prefixes.
- Unit Tests: Added unit test coverage for quoted and backslash-escaped image paths.