### PR TITLE
cmd, x/imagegen: fix extractFileNames fracturing paths on embedded extensions

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"unicode"
 
 	"github.com/spf13/cobra"
 
@@ -609,7 +610,44 @@ func extractFileNames(input string) []string {
 	regexPattern := `(?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp|wav)\b`
 	re := regexp.MustCompile(regexPattern)
 
-	return re.FindAllString(input, -1)
+	var out []string
+	pos := 0
+	for pos < len(input) {
+		loc := re.FindStringIndex(input[pos:])
+		if loc == nil {
+			break
+		}
+		start, end := pos+loc[0], pos+loc[1]
+
+		// The extension match above is intentionally lazy so that several
+		// paths in one message (e.g. "compare a.png and b.jpg") are
+		// captured as separate matches. That means it can stop early if a
+		// parent directory happens to contain what looks like a valid
+		// extension, e.g. ".../vacation.png.bak/beach.jpg" would
+		// otherwise be fractured into "vacation.png" and "beach.jpg",
+		// neither of which is the real file. Detect that case: if the
+		// text right after the match runs straight into another path
+		// separator with no whitespace in between, this is almost
+		// certainly still the same path, so keep extending to the next
+		// extension boundary.
+		for end < len(input) {
+			rest := input[end:]
+			sep := strings.IndexAny(rest, `/\`)
+			ws := strings.IndexFunc(rest, unicode.IsSpace)
+			if sep == -1 || (ws != -1 && ws < sep) {
+				break
+			}
+			next := re.FindStringIndex(rest)
+			if next == nil {
+				break
+			}
+			end += next[1]
+		}
+
+		out = append(out, input[start:end])
+		pos = end
+	}
+	return out
 }
 
 func extractFileData(input string) (string, []api.ImageData, error) {

--- a/cmd/interactive_test.go
+++ b/cmd/interactive_test.go
@@ -64,6 +64,35 @@ d:\path with\spaces\thirteen.WEBP some ending
 	assert.Contains(t, res[12], "d:")
 }
 
+// Ensure a parent directory that itself contains a valid image extension
+// (e.g. "vacation.png.bak/") doesn't fracture the real path into two
+// nonexistent fragments, while paths to genuinely separate images in the
+// same message are still captured separately.
+func TestExtractFilenamesDoesNotFractureOnEmbeddedExtension(t *testing.T) {
+	input := `/Users/alex/vacation.png.bak/beach.jpg describe this photo`
+	res := extractFileNames(input)
+	assert.Len(t, res, 1)
+	assert.Equal(t, "/Users/alex/vacation.png.bak/beach.jpg", res[0])
+
+	input = `look at C:\Users\alex\shots.folder.png\final.jpg now`
+	res = extractFileNames(input)
+	assert.Len(t, res, 1)
+	assert.Equal(t, `C:\Users\alex\shots.folder.png\final.jpg`, res[0])
+
+	input = `open /a/one.png.bak/two.jpg.old/three.webp thanks`
+	res = extractFileNames(input)
+	assert.Len(t, res, 1)
+	assert.Equal(t, "/a/one.png.bak/two.jpg.old/three.webp", res[0])
+
+	// two real, separate images mentioned in the same message must not be
+	// merged together just because they're both path-like
+	input = `compare /Users/alex/cat.png and /Users/alex/dog.jpg please`
+	res = extractFileNames(input)
+	assert.Len(t, res, 2)
+	assert.Equal(t, "/Users/alex/cat.png", res[0])
+	assert.Equal(t, "/Users/alex/dog.jpg", res[1])
+}
+
 // Ensure that file paths wrapped in single quotes are removed with the quotes.
 func TestExtractFileDataRemovesQuotedFilepath(t *testing.T) {
 	dir := t.TempDir()

--- a/x/imagegen/cli.go
+++ b/x/imagegen/cli.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/spf13/cobra"
 
@@ -522,7 +523,44 @@ func extractFileNames(input string) []string {
 	// Regex to match file paths with image extensions
 	regexPattern := `(?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp)\b`
 	re := regexp.MustCompile(regexPattern)
-	return re.FindAllString(input, -1)
+
+	var out []string
+	pos := 0
+	for pos < len(input) {
+		loc := re.FindStringIndex(input[pos:])
+		if loc == nil {
+			break
+		}
+		start, end := pos+loc[0], pos+loc[1]
+
+		// The extension match above is intentionally lazy so that several
+		// paths in one message are captured as separate matches. That
+		// means it can stop early if a parent directory happens to
+		// contain what looks like a valid extension, e.g.
+		// ".../vacation.png.bak/beach.jpg" would otherwise be fractured
+		// into "vacation.png" and "beach.jpg", neither of which is the
+		// real file. Detect that case: if the text right after the match
+		// runs straight into another path separator with no whitespace
+		// in between, this is almost certainly still the same path, so
+		// keep extending to the next extension boundary.
+		for end < len(input) {
+			rest := input[end:]
+			sep := strings.IndexAny(rest, `/\`)
+			ws := strings.IndexFunc(rest, unicode.IsSpace)
+			if sep == -1 || (ws != -1 && ws < sep) {
+				break
+			}
+			next := re.FindStringIndex(rest)
+			if next == nil {
+				break
+			}
+			end += next[1]
+		}
+
+		out = append(out, input[start:end])
+		pos = end
+	}
+	return out
 }
 
 // extractFileData extracts image data from file paths found in the input.

--- a/x/imagegen/cli_test.go
+++ b/x/imagegen/cli_test.go
@@ -1,0 +1,45 @@
+package imagegen
+
+import "testing"
+
+// Ensure a parent directory that itself contains a valid image extension
+// (e.g. "vacation.png.bak/") doesn't fracture the real path into two
+// nonexistent fragments, while paths to genuinely separate images in the
+// same message are still captured separately. See cmd/interactive_test.go
+// for the equivalent test against the CLI's copy of this function.
+func TestExtractFilenamesDoesNotFractureOnEmbeddedExtension(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "extension-like directory name",
+			input: "/Users/alex/vacation.png.bak/beach.jpg describe this photo",
+			want:  []string{"/Users/alex/vacation.png.bak/beach.jpg"},
+		},
+		{
+			name:  "windows drive path with embedded extension in dir name",
+			input: `look at C:\Users\alex\shots.folder.png\final.jpg now`,
+			want:  []string{`C:\Users\alex\shots.folder.png\final.jpg`},
+		},
+		{
+			name:  "two genuinely separate images stay separate",
+			input: "compare /Users/alex/cat.png and /Users/alex/dog.jpg please",
+			want:  []string{"/Users/alex/cat.png", "/Users/alex/dog.jpg"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := extractFileNames(c.input)
+			if len(got) != len(c.want) {
+				t.Fatalf("got %d matches %#v, want %d %#v", len(got), got, len(c.want), c.want)
+			}
+			for i := range got {
+				if got[i] != c.want[i] {
+					t.Errorf("match %d = %q, want %q", i, got[i], c.want[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
extractFileNames() uses a lazy regex that stops at the first ".png"/
".jpg"/etc it encounters. If a parent directory in the path itself
contains what looks like a valid extension (e.g.
"/Users/alex/vacation.png.bak/beach.jpg"), the match is fractured into
two fragments ("vacation.png" and "beach.jpg") -- neither of which
exists on disk -- so the real image is silently never attached, with
no clear error.

The same lazy regex is duplicated in cmd/interactive.go and
x/imagegen/cli.go, so both are fixed here.

The fix keeps extending a match past an extension boundary only when
the text immediately following runs straight into another path
separator with no whitespace in between -- a strong, low-risk signal
that the match landed inside a directory name rather than the real
terminal file. This deliberately does NOT just make the match greedy,
since that would incorrectly merge two genuinely separate images
mentioned in the same message (e.g. "compare a.png and b.jpg") into
one bogus path -- verified with a dedicated regression test.

Verified against the existing Unix and Windows path test suites in
cmd/interactive_test.go (20 cases covering spaces, quotes, drive
letters) with no regressions, plus new test cases covering the
embedded-extension bug, a Windows drive-letter variant, a chained
double-embedded case, and the separate-images guard.

Fixes #16680