### PR TITLE
api: coerce tool call arguments declared with oneOf

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"os"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -431,6 +432,7 @@ func (t *ToolPropertiesMap) UnmarshalJSON(data []byte) error {
 
 type ToolProperty struct {
 	AnyOf       []ToolProperty     `json:"anyOf,omitempty"`
+	OneOf       []ToolProperty     `json:"oneOf,omitempty"`
 	Type        PropertyType       `json:"type,omitempty"`
 	Items       any                `json:"items,omitempty"`
 	Description string             `json:"description,omitempty"`
@@ -439,12 +441,41 @@ type ToolProperty struct {
 	Required    []string           `json:"required,omitempty"`
 }
 
+// unionBranches returns the alternative schemas of a union property. JSON
+// Schema spells a union either "anyOf" or "oneOf"; both describe a value that
+// may take any of the listed shapes, so tools treat them the same.
+func (tp ToolProperty) unionBranches() []ToolProperty {
+	if len(tp.AnyOf) > 0 {
+		return tp.AnyOf
+	}
+	return tp.OneOf
+}
+
+// EffectiveTypes returns the JSON Schema types a value for this property may
+// take, flattening unions so that {"oneOf":[{"type":"string"},{"type":"object"}]}
+// coerces the same way as {"type":["string","object"]}. Parsers that reconstruct
+// tool call arguments from text need this: a property whose types they cannot
+// see is left as the raw string the model emitted, so a nested object arrives
+// at the caller stringified.
+func (tp ToolProperty) EffectiveTypes() PropertyType {
+	branches := tp.unionBranches()
+	if len(branches) == 0 {
+		return tp.Type
+	}
+
+	types := slices.Clone(tp.Type)
+	for _, branch := range branches {
+		types = append(types, branch.EffectiveTypes()...)
+	}
+	return types
+}
+
 // ToTypeScriptType converts a ToolProperty to a TypeScript type string
 func (tp ToolProperty) ToTypeScriptType() string {
-	if len(tp.AnyOf) > 0 {
+	if branches := tp.unionBranches(); len(branches) > 0 {
 		var types []string
-		for _, anyOf := range tp.AnyOf {
-			types = append(types, anyOf.ToTypeScriptType())
+		for _, branch := range branches {
+			types = append(types, branch.ToTypeScriptType())
 		}
 		return strings.Join(types, " | ")
 	}

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -966,3 +966,83 @@ func TestToolPropertiesMap_NestedProperties(t *testing.T) {
 		assert.Equal(t, expected, string(data))
 	})
 }
+
+func TestToolPropertyEffectiveTypes(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected PropertyType
+	}{
+		{
+			name:     "plain type",
+			input:    `{"type": "string"}`,
+			expected: PropertyType{"string"},
+		},
+		{
+			name:     "no type",
+			input:    `{"description": "untyped"}`,
+			expected: nil,
+		},
+		{
+			name:     "anyOf union",
+			input:    `{"anyOf": [{"type": "string"}, {"type": "object"}]}`,
+			expected: PropertyType{"string", "object"},
+		},
+		{
+			name:     "oneOf union",
+			input:    `{"oneOf": [{"type": "string"}, {"type": "object"}]}`,
+			expected: PropertyType{"string", "object"},
+		},
+		{
+			name:     "nested union",
+			input:    `{"oneOf": [{"type": "string"}, {"anyOf": [{"type": "integer"}, {"type": "object"}]}]}`,
+			expected: PropertyType{"string", "integer", "object"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var prop ToolProperty
+			if err := json.Unmarshal([]byte(tt.input), &prop); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			assert.Equal(t, tt.expected, prop.EffectiveTypes())
+		})
+	}
+}
+
+// EffectiveTypes must not append into the backing array of Type, which would
+// corrupt a caller still holding the original slice.
+func TestToolPropertyEffectiveTypesDoesNotAliasType(t *testing.T) {
+	prop := ToolProperty{
+		Type:  append(make(PropertyType, 0, 4), "null"),
+		OneOf: []ToolProperty{{Type: PropertyType{"object"}}},
+	}
+
+	require.Equal(t, PropertyType{"null", "object"}, prop.EffectiveTypes())
+	assert.Equal(t, PropertyType{"null"}, prop.Type)
+}
+
+func TestToolPropertyOneOfRoundTrip(t *testing.T) {
+	input := `{"oneOf":[{"type":"string"},{"type":"object"}]}`
+
+	var prop ToolProperty
+	if err := json.Unmarshal([]byte(input), &prop); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(prop.OneOf) != 2 {
+		t.Fatalf("OneOf = %v, want 2 branches", prop.OneOf)
+	}
+	if got := prop.ToTypeScriptType(); got != "string | Record<string, any>" {
+		t.Errorf("ToTypeScriptType() = %q, want %q", got, "string | Record<string, any>")
+	}
+
+	// oneOf must survive being handed back to a model, not be silently dropped.
+	out, err := json.Marshal(prop)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(out) != input {
+		t.Errorf("round trip = %s, want %s", out, input)
+	}
+}

--- a/model/parsers/glm46.go
+++ b/model/parsers/glm46.go
@@ -644,14 +644,7 @@ func parseGLM46ToolCall(raw glm46EventRawToolCall, tools []api.Tool) (api.ToolCa
 		var paramType api.PropertyType
 		if matchedTool != nil && matchedTool.Function.Parameters.Properties != nil {
 			if prop, ok := matchedTool.Function.Parameters.Properties.Get(key); ok {
-				// Handle anyOf by collecting all types from the union
-				if len(prop.AnyOf) > 0 {
-					for _, anyOfProp := range prop.AnyOf {
-						paramType = append(paramType, anyOfProp.Type...)
-					}
-				} else {
-					paramType = prop.Type
-				}
+				paramType = prop.EffectiveTypes()
 			}
 		}
 

--- a/model/parsers/laguna.go
+++ b/model/parsers/laguna.go
@@ -554,13 +554,7 @@ func parseLagunaToolCall(raw string, tools []api.Tool) (api.ToolCall, error) {
 		var paramType api.PropertyType
 		if matchedTool != nil && matchedTool.Function.Parameters.Properties != nil {
 			if prop, ok := matchedTool.Function.Parameters.Properties.Get(key); ok {
-				if len(prop.AnyOf) > 0 {
-					for _, anyOfProp := range prop.AnyOf {
-						paramType = append(paramType, anyOfProp.Type...)
-					}
-				} else {
-					paramType = prop.Type
-				}
+				paramType = prop.EffectiveTypes()
 			}
 		}
 		call.Function.Arguments.Set(key, parseValue(value, paramType))

--- a/model/parsers/qwen3coder.go
+++ b/model/parsers/qwen3coder.go
@@ -256,14 +256,7 @@ func parseToolCall(raw qwenEventRawToolCall, tools []api.Tool) (api.ToolCall, er
 		var paramType api.PropertyType
 		if matchedTool != nil && matchedTool.Function.Parameters.Properties != nil {
 			if prop, ok := matchedTool.Function.Parameters.Properties.Get(parameter.Name); ok {
-				// Handle anyOf by collecting all types from the union
-				if len(prop.AnyOf) > 0 {
-					for _, anyOfProp := range prop.AnyOf {
-						paramType = append(paramType, anyOfProp.Type...)
-					}
-				} else {
-					paramType = prop.Type
-				}
+				paramType = prop.EffectiveTypes()
 			}
 		}
 

--- a/model/parsers/qwen3coder_test.go
+++ b/model/parsers/qwen3coder_test.go
@@ -1246,20 +1246,13 @@ func TestOverlapFunction(t *testing.T) {
 // modelled the property looked untyped and a nested object was handed back to
 // the caller as a JSON string.
 func TestQwenParseToolCallUnionParameter(t *testing.T) {
-	unionTool := func(keyword string) api.Tool {
-		return tool("send_structured", map[string]api.ToolProperty{
-			"to": {Type: api.PropertyType{"string"}},
-			"message": func() api.ToolProperty {
-				branches := []api.ToolProperty{
-					{Type: api.PropertyType{"string"}},
-					{Type: api.PropertyType{"object"}},
-				}
-				if keyword == "anyOf" {
-					return api.ToolProperty{AnyOf: branches}
-				}
-				return api.ToolProperty{OneOf: branches}
-			}(),
-		})
+	branches := []api.ToolProperty{
+		{Type: api.PropertyType{"string"}},
+		{Type: api.PropertyType{"object"}},
+	}
+	unions := map[string]api.ToolProperty{
+		"anyOf": {AnyOf: branches},
+		"oneOf": {OneOf: branches},
 	}
 
 	raw := `<function=send_structured>
@@ -1286,7 +1279,12 @@ agent-1
 
 	for _, keyword := range []string{"anyOf", "oneOf"} {
 		t.Run(keyword, func(t *testing.T) {
-			got, err := parseToolCall(qwenEventRawToolCall{raw: raw}, []api.Tool{unionTool(keyword)})
+			tools := []api.Tool{tool("send_structured", map[string]api.ToolProperty{
+				"to":      {Type: api.PropertyType{"string"}},
+				"message": unions[keyword],
+			})}
+
+			got, err := parseToolCall(qwenEventRawToolCall{raw: raw}, tools)
 			if err != nil {
 				t.Fatalf("parseToolCall: %v", err)
 			}

--- a/model/parsers/qwen3coder_test.go
+++ b/model/parsers/qwen3coder_test.go
@@ -1240,3 +1240,88 @@ func TestOverlapFunction(t *testing.T) {
 		})
 	}
 }
+
+// A tool parameter declared as a JSON Schema union must still be type-coerced.
+// Claude Code and the Anthropic SDK spell unions "oneOf"; before it was
+// modelled the property looked untyped and a nested object was handed back to
+// the caller as a JSON string.
+func TestQwenParseToolCallUnionParameter(t *testing.T) {
+	unionTool := func(keyword string) api.Tool {
+		return tool("send_structured", map[string]api.ToolProperty{
+			"to": {Type: api.PropertyType{"string"}},
+			"message": func() api.ToolProperty {
+				branches := []api.ToolProperty{
+					{Type: api.PropertyType{"string"}},
+					{Type: api.PropertyType{"object"}},
+				}
+				if keyword == "anyOf" {
+					return api.ToolProperty{AnyOf: branches}
+				}
+				return api.ToolProperty{OneOf: branches}
+			}(),
+		})
+	}
+
+	raw := `<function=send_structured>
+<parameter=to>
+agent-1
+</parameter>
+<parameter=message>
+{"type": "shutdown_response", "ok": true}
+</parameter>
+</function>`
+
+	want := api.ToolCall{
+		Function: api.ToolCallFunction{
+			Name: "send_structured",
+			Arguments: testArgs(map[string]any{
+				"to": "agent-1",
+				"message": map[string]any{
+					"type": "shutdown_response",
+					"ok":   true,
+				},
+			}),
+		},
+	}
+
+	for _, keyword := range []string{"anyOf", "oneOf"} {
+		t.Run(keyword, func(t *testing.T) {
+			got, err := parseToolCall(qwenEventRawToolCall{raw: raw}, []api.Tool{unionTool(keyword)})
+			if err != nil {
+				t.Fatalf("parseToolCall: %v", err)
+			}
+			if !toolCallEqual(got, want) {
+				t.Errorf("got %#v, want %#v", got, want)
+			}
+		})
+	}
+}
+
+// A union that admits both string and object still coerces a plain string.
+func TestQwenParseToolCallUnionParameterString(t *testing.T) {
+	tools := []api.Tool{tool("send_structured", map[string]api.ToolProperty{
+		"message": {OneOf: []api.ToolProperty{
+			{Type: api.PropertyType{"string"}},
+			{Type: api.PropertyType{"object"}},
+		}},
+	})}
+
+	got, err := parseToolCall(qwenEventRawToolCall{raw: `<function=send_structured>
+<parameter=message>
+just text
+</parameter>
+</function>`}, tools)
+	if err != nil {
+		t.Fatalf("parseToolCall: %v", err)
+	}
+
+	want := api.ToolCall{
+		Function: api.ToolCallFunction{
+			Name:      "send_structured",
+			Arguments: testArgs(map[string]any{"message": "just text"}),
+		},
+	}
+	if !toolCallEqual(got, want) {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+}


### PR DESCRIPTION
`ToolProperty` modelled `anyOf` but not `oneOf`, so a parameter declared
`{"oneOf":[{"type":"string"},{"type":"object"}]}` lost its types at unmarshal.
The tool call parsers look those types up to decide how to decode the text a
model emits; finding none, `parseValue` takes its untyped path and returns the
raw string. A nested object then reaches the caller stringified.

Reproduced at HEAD with the schema from #15645:

```
ARGS: {"to":"agent-1","message":"{\"type\": \"shutdown_response\", \"ok\": true}"}
```

`message` should be an object. Anthropic-protocol clients hit this often
because their SDKs spell unions `oneOf`; the same schema written `anyOf`
already worked, which is what makes it look model-specific.

`oneOf` was also being dropped when a schema was marshalled back out, so a
model was never told the parameter could be an object in the first place.

## Summary

- Add `OneOf` alongside `AnyOf` on `api.ToolProperty`, so the union survives
  unmarshal and round-trip.
- Read both through one `EffectiveTypes()` helper, replacing the anyOf-only
  lookup that `qwen3coder`, `glm46` and `laguna` each carried a copy of. Fixing
  the shared lookup rather than one parser keeps the three in step.
- `EffectiveTypes` clones `Type` before appending, so flattening a union cannot
  mutate the caller's slice.
- `ToTypeScriptType` renders `oneOf` as a union, as it already did for `anyOf`.

Scoped to case 2 of #15645. Case 1 (Kimi K2.5 native tool-call tokens leaking
as text) is a separate, cloud-side problem and is not addressed here.

`simpleAnyOfTypes` in the gemma4 renderer still reads only `anyOf`. That is a
separate rendering concern in a bespoke declaration format, so it is left
alone.

## Validation

- `go test ./api/... ./model/parsers/... ./model/renderers/... ./server/... ./openai/... ./middleware/... ./template/... ./anthropic/... ./agent/... ./tools/... ./cmd/... ./x/models/...`
- `go build ./...`, `go vet`, `go mod tidy --diff` clean
- New tests fail on the `oneOf` case with the old lookup restored and pass with
  it, while the existing `anyOf` case keeps passing.

Fixes #15645

---
Authored with AI assistance. The reproduction, the tests, and the package runs listed above were executed locally against this branch.
