### PR TITLE
docs: add Inferpal to community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ console.log(response.message.content);
 - [AI ST Completion](https://github.com/yaroslavyaroslav/OpenAI-sublime-text) - Sublime Text 4 AI assistant
 - [VT Code](https://github.com/vinhnx/vtcode) - Rust-based terminal coding agent with Tree-sitter
 - [QodeAssist](https://github.com/Palm1r/QodeAssist) - AI coding assistant for Qt Creator
+- [Inferpal](https://github.com/EstaxNet/Inferpal) - Local agentic AI assistant for Visual Studio 2022/2026
 - [AI Toolkit for VS Code](https://aka.ms/ai-tooklit/ollama-docs) - Microsoft-official VS Code extension
 - [Open Interpreter](https://docs.openinterpreter.com/language-model-setup/local-models/ollama) - Natural language interface for computers
 


### PR DESCRIPTION
Adds [Inferpal](https://github.com/EstaxNet/Inferpal) to **Community Integrations → Code Editors & Development**.

Inferpal is a GPL v3 extension for Visual Studio 2022/2026 (the full IDE, not VS Code) that turns an Ollama model into an agentic coding assistant: autonomous tool-calling loop (26 built-in tools — file read/write, run commands, build/test, hybrid semantic code search), inline FIM ghost-text completions, and RAG. Ollama is the default, hardware-aware backend (VRAM-based model fit, keep-alive management). 100% local: no API key, no telemetry.

One line added, matching the existing entry format.