### PR TITLE
ci: on release builds dont fail fast

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -93,6 +93,7 @@ jobs:
   windows-depends:
     needs: setup-environment
     strategy:
+      fail-fast: false
       matrix:
         os: [windows]
         arch: [amd64]
@@ -450,6 +451,7 @@ jobs:
 
   linux-depends:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - arch: amd64
@@ -531,6 +533,7 @@ jobs:
   # and just assembles, runs the Go build, pushes the final image, and extracts release bundles.
   docker-build-push:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: linux
@@ -681,6 +684,7 @@ jobs:
   # Merge Docker images for the same flavor into a single multi-arch manifest
   docker-merge-push:
     strategy:
+      fail-fast: false
       matrix:
         suffix: ['', '-rocm']
     runs-on: linux


### PR DESCRIPTION
If we have one flake, don't stop other jobs that will most likely work so when we re-run failed jobs, only the flake and dependents need to be run.  This should help reduce the time it takes to get past a flake and finish a release build.

Example scenario this will help:

<img width="209" height="403" alt="Screenshot 2026-07-26 at 5 25 13 PM" src="https://github.com/user-attachments/assets/3cde08cb-e880-4e94-a40e-28d952342813" />
