### PR TITLE
openai: keep tool metadata on messages with content parts

### DIFF
--- a/openai/openai.go
+++ b/openai/openai.go
@@ -497,6 +497,7 @@ func FromChatRequest(r ChatCompletionRequest) (*api.ChatRequest, error) {
 			}
 			messages = append(messages, api.Message{Role: msg.Role, Content: content, Thinking: msg.Reasoning, ToolCalls: toolCalls, ToolName: toolName, ToolCallID: msg.ToolCallID})
 		case []any:
+			first := len(messages)
 			for _, c := range content {
 				data, ok := c.(map[string]any)
 				if !ok {
@@ -545,17 +546,28 @@ func FromChatRequest(r ChatCompletionRequest) (*api.ChatRequest, error) {
 					return nil, errors.New("invalid message format")
 				}
 			}
-			// since we might have added multiple messages above, if we have tools
-			// calls we'll add them to the last message
-			if len(messages) > 0 && len(msg.ToolCalls) > 0 {
-				toolCalls, err := FromCompletionToolCall(msg.ToolCalls)
-				if err != nil {
-					return nil, err
+			toolCalls, err := FromCompletionToolCall(msg.ToolCalls)
+			if err != nil {
+				return nil, err
+			}
+
+			if len(messages) == first {
+				// there were no parts, so nothing was appended above. only emit
+				// a message if it carries metadata that would otherwise be lost
+				if len(toolCalls) == 0 && msg.Reasoning == "" && toolName == "" && msg.ToolCallID == "" {
+					continue
 				}
-				messages[len(messages)-1].ToolCalls = toolCalls
-				messages[len(messages)-1].ToolName = toolName
-				messages[len(messages)-1].ToolCallID = msg.ToolCallID
-				messages[len(messages)-1].Thinking = msg.Reasoning
+				messages = append(messages, api.Message{Role: msg.Role})
+			}
+
+			// the parts above may have produced multiple messages, so carry
+			// this message's metadata on the last of them
+			last := &messages[len(messages)-1]
+			last.Thinking = msg.Reasoning
+			last.ToolName = toolName
+			last.ToolCallID = msg.ToolCallID
+			if len(toolCalls) > 0 {
+				last.ToolCalls = toolCalls
 			}
 		default:
 			// content is only optional if tool calls are present

--- a/openai/openai_test.go
+++ b/openai/openai_test.go
@@ -907,3 +907,80 @@ func TestFromImageEditRequest_InvalidImage(t *testing.T) {
 		t.Error("expected error for invalid image")
 	}
 }
+
+func TestFromChatRequest_ToolMessageWithContentParts(t *testing.T) {
+	weatherCall := ToolCall{ID: "call_1", Type: "function"}
+	weatherCall.Function.Name = "get_weather"
+	weatherCall.Function.Arguments = "{}"
+
+	req := ChatCompletionRequest{
+		Model: "test-model",
+		Messages: []Message{
+			{Role: "user", Content: "what's the weather?"},
+			{Role: "assistant", ToolCalls: []ToolCall{weatherCall}},
+			{
+				Role:       "tool",
+				ToolCallID: "call_1",
+				Content:    []any{map[string]any{"type": "text", "text": "sunny"}},
+			},
+		},
+	}
+
+	result, err := FromChatRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Messages) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(result.Messages))
+	}
+
+	got := result.Messages[2]
+	if got.Content != "sunny" {
+		t.Errorf("expected content 'sunny', got %q", got.Content)
+	}
+
+	if got.ToolName != "get_weather" {
+		t.Errorf("expected tool name 'get_weather', got %q", got.ToolName)
+	}
+
+	if got.ToolCallID != "call_1" {
+		t.Errorf("expected tool call id 'call_1', got %q", got.ToolCallID)
+	}
+}
+
+func TestFromChatRequest_EmptyContentPartsKeepsToolCalls(t *testing.T) {
+	weatherCall := ToolCall{ID: "call_1", Type: "function"}
+	weatherCall.Function.Name = "get_weather"
+	weatherCall.Function.Arguments = "{}"
+
+	req := ChatCompletionRequest{
+		Model: "test-model",
+		Messages: []Message{
+			{Role: "user", Content: "what's the weather?"},
+			{Role: "assistant", Content: []any{}, ToolCalls: []ToolCall{weatherCall}},
+		},
+	}
+
+	result, err := FromChatRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Messages) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(result.Messages))
+	}
+
+	if len(result.Messages[0].ToolCalls) != 0 {
+		t.Errorf("expected user message to keep no tool calls, got %d", len(result.Messages[0].ToolCalls))
+	}
+
+	got := result.Messages[1]
+	if got.Role != "assistant" {
+		t.Errorf("expected role 'assistant', got %q", got.Role)
+	}
+
+	if len(got.ToolCalls) != 1 || got.ToolCalls[0].Function.Name != "get_weather" {
+		t.Errorf("expected assistant message to carry get_weather tool call, got %+v", got.ToolCalls)
+	}
+}


### PR DESCRIPTION
A tool result sent to `/v1/chat/completions` as an array of content parts loses its tool name and tool call id.

The OpenAI API accepts either encoding for the same message, and SDKs and agent frameworks routinely emit the array form:

```jsonc
// both are valid, and mean the same thing
{"role": "tool", "tool_call_id": "call_1", "content": "sunny"}
{"role": "tool", "tool_call_id": "call_1", "content": [{"type": "text", "text": "sunny"}]}
```

Only the first survives the translation in `FromChatRequest`:

| content encoding | `ToolName` | `ToolCallID` |
|---|---|---|
| `"sunny"` | `get_weather` | `call_1` |
| `[{"type":"text","text":"sunny"}]` | `""` | `""` |

`toolName` is resolved for every `role: "tool"` message, but in the `[]any` branch it is only attached inside `if len(messages) > 0 && len(msg.ToolCalls) > 0`. A tool result never carries tool calls, so the branch is skipped and the metadata is dropped. The `string` branch attaches it unconditionally.

The visible effect is on prompt rendering: chat templates address tool results as `{{ .ToolName }}`, so with the array encoding the model is handed a tool result with no function name and cannot tell which of its calls was answered.

### Second issue in the same block

The block indexed `messages[len(messages)-1]` — the last message overall, not the last one appended for the message being converted. When the content parts list is empty, nothing is appended, and the tool calls are written onto the *previous* message:

```jsonc
{"role": "user", "content": "what's the weather?"},
{"role": "assistant", "content": [], "tool_calls": [{"id": "call_1", ...}]}
```

Before this change that produces a single `user` message carrying the assistant's tool calls, and the assistant message disappears.

### Change

Record where the current message's parts begin, attach `Thinking` / `ToolName` / `ToolCallID` to the last message actually appended from them, and set `ToolCalls` when present. When there are no parts, emit a message so the metadata is not dropped — unless there is no metadata to carry, in which case nothing is appended, as before.

### Tests

Two tests in `openai/openai_test.go`, both failing before the change:

```
--- FAIL: TestFromChatRequest_ToolMessageWithContentParts (0.00s)
    openai_test.go:944: expected tool name 'get_weather', got ""
    openai_test.go:948: expected tool call id 'call_1', got ""
--- FAIL: TestFromChatRequest_EmptyContentPartsKeepsToolCalls (0.00s)
    openai_test.go:971: expected 2 messages, got 1
```

`./openai/...`, `./middleware/...`, `./api/...`, `./anthropic/...`, `./template/...`, `./tools/...` and `./server/...` pass.

### Note

#17373 fixes the adjacent `default` (`content: null`) branch. The two changes touch different lines and are independent; note that that PR's description states the `[]any` case already propagates `ToolName`, which is what this change corrects.
