### PR TITLE
server: prevent expiring runners from being resurrected

### DIFF
--- a/server/sched.go
+++ b/server/sched.go
@@ -342,6 +342,7 @@ func (s *Scheduler) processPending(ctx context.Context) {
 					runnerToExpire.expireTimer.Stop()
 					runnerToExpire.expireTimer = nil
 				}
+				runnerToExpire.expiring = true
 				runnerToExpire.sessionDuration = 0
 				if runnerToExpire.refCount <= 0 {
 					s.expiredCh <- runnerToExpire
@@ -481,7 +482,7 @@ func (pending *LlmRequest) useLoadedRunner(runner *runnerRef, finished chan *Llm
 		runner.expireTimer.Stop()
 		runner.expireTimer = nil
 	}
-	if pending.sessionDuration != nil {
+	if pending.sessionDuration != nil && !runner.expiring {
 		runner.sessionDuration = pending.sessionDuration.Duration
 	}
 	pending.successCh <- runner
@@ -1344,6 +1345,7 @@ func (s *Scheduler) updateFreeSpace(allGpus []ml.DeviceInfo) {
 type runnerRef struct {
 	refMu    sync.Mutex
 	refCount uint // prevent unloading if > 0
+	expiring bool // prevents new requests from extending a runner marked for eviction
 
 	llama        llm.LlamaServer
 	pid          int
@@ -1389,6 +1391,9 @@ func (runner *runnerRef) needsReload(ctx context.Context, req *LlmRequest) bool 
 	slog.Debug("evaluating already loaded", "model", schedulerModelKey(req.model))
 	runner.refMu.Lock()
 	defer runner.refMu.Unlock()
+	if runner.expiring {
+		return true
+	}
 
 	// Check if runner type (imagegen vs mlxrunner) matches what's requested.
 	wantImagegen := slices.Contains(req.model.Config.Capabilities, "image")
@@ -1623,6 +1628,7 @@ func (s *Scheduler) evictAllAndWait(ctx context.Context, keepKey string) bool {
 			runner.expireTimer = nil
 		}
 		runner.sessionDuration = 0
+		runner.expiring = true
 		if runner.refCount <= 0 {
 			s.expiredCh <- runner
 		}
@@ -1666,6 +1672,7 @@ func (s *Scheduler) expireRunnersForRuntimeOOM(model *Model, err error) {
 			runner.expireTimer = nil
 		}
 		runner.sessionDuration = 0
+		runner.expiring = true
 		if runner.refCount <= 0 {
 			s.expiredCh <- runner
 		}
@@ -1736,6 +1743,7 @@ func (s *Scheduler) expireRunner(model *Model) {
 			runner.expireTimer = nil
 		}
 		runner.sessionDuration = 0
+		runner.expiring = true
 		if runner.refCount <= 0 {
 			s.expiredCh <- runner
 		}

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -785,6 +785,42 @@ func TestSchedUseLoadedRunner(t *testing.T) {
 	require.Equal(t, req, fin)
 }
 
+func TestSchedUseLoadedRunnerDoesNotExtendExpiringRunner(t *testing.T) {
+	ctx, done := context.WithCancel(t.Context())
+	finished := make(chan *LlmRequest, 1)
+	req := &LlmRequest{
+		ctx:             ctx,
+		successCh:       make(chan *runnerRef, 1),
+		sessionDuration: &api.Duration{Duration: time.Hour},
+	}
+	runner := &runnerRef{
+		expiring:        true,
+		sessionDuration: 0,
+		numParallel:     1,
+	}
+
+	req.useLoadedRunner(runner, finished)
+	require.Equal(t, uint(1), runner.refCount)
+	require.Zero(t, runner.sessionDuration)
+	require.Same(t, runner, <-req.successCh)
+
+	done()
+	require.Same(t, req, <-finished)
+}
+
+func TestSchedGetRunnerQueuesExpiringRunner(t *testing.T) {
+	ctx, done := context.WithCancel(t.Context())
+	defer done()
+	s := InitScheduler(ctx)
+	model := &Model{Name: "expiring-model", ModelPath: "expiring-model"}
+	s.loaded[schedulerModelKey(model)] = &runnerRef{expiring: true}
+
+	success, errCh := s.getRunner(ctx, model, api.DefaultOptions(), nil, false, false, nil)
+	require.Empty(t, success)
+	require.Empty(t, errCh)
+	require.Len(t, s.pendingReqCh, 1)
+}
+
 func TestSchedUpdateFreeSpace(t *testing.T) {
 	ctx, done := context.WithTimeout(t.Context(), 100*time.Millisecond)
 	defer done()


### PR DESCRIPTION
## Summary

Prevent a runner marked for eviction from being resurrected by a concurrent request.

Closes #17408

## Root cause

The scheduler represented an immediate eviction only by setting `sessionDuration` to zero. A request that entered through the loaded-runner fast path could then overwrite that value with its requested keep-alive duration. If the runner was still referenced, the scheduler waited for an unload signal that was never emitted.

## Changes

- Track the eviction state explicitly with a runner-local `expiring` flag.
- Treat expiring runners as requiring reload so new requests are queued for the scheduler.
- Keep the expiration state when a request races with an eviction and attempts to use the loaded runner.
- Set the flag in all scheduler-driven eviction paths.
- Add regression coverage for both fast-path reuse and request queueing.

## Validation

- `gofmt -w server/sched.go server/sched_test.go`
- `git diff --check`
- Focused Go tests could not compile in the local Windows environment because the repository's MLX cgo package requires a C compiler; `CGO_ENABLED=1` reported that `gcc` is not installed, while `CGO_ENABLED=0` omits the MLX API used by the server package.
