### PR TITLE
openai: include model context_length in /v1/models response

### DIFF
--- a/docs/api/openai-compatibility.mdx
+++ b/docs/api/openai-compatibility.mdx
@@ -257,6 +257,7 @@ curl -X POST http://localhost:11434/v1/chat/completions \
 
 - `created` corresponds to when the model was last modified
 - `owned_by` corresponds to the ollama username, defaulting to `"library"`
+- `context_length` contains the maximum context window size in tokens for the model (if available)
 
 ### `/v1/models/{model}`
 
@@ -264,6 +265,7 @@ curl -X POST http://localhost:11434/v1/chat/completions \
 
 - `created` corresponds to when the model was last modified
 - `owned_by` corresponds to the ollama username, defaulting to `"library"`
+- `context_length` contains the maximum context window size in tokens for the model (if available)
 
 ### `/v1/embeddings`
 

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -186,10 +186,11 @@ type ToolCall struct {
 }
 
 type Model struct {
-	Id      string `json:"id"`
-	Object  string `json:"object"`
-	Created int64  `json:"created"`
-	OwnedBy string `json:"owned_by"`
+	Id            string `json:"id"`
+	Object        string `json:"object"`
+	Created       int64  `json:"created"`
+	OwnedBy       string `json:"owned_by"`
+	ContextLength int    `json:"context_length,omitempty"`
 }
 
 type Embedding struct {
@@ -406,7 +407,7 @@ func ToCompleteChunk(id string, r api.GenerateResponse) CompletionChunk {
 
 // ToListCompletion converts an api.ListResponse to ListCompletion
 func ToListCompletion(r api.ListResponse) ListCompletion {
-	var data []Model
+	data := make([]Model, 0, len(r.Models))
 	for _, m := range r.Models {
 		id := m.Model
 		if id == "" {
@@ -414,10 +415,11 @@ func ToListCompletion(r api.ListResponse) ListCompletion {
 		}
 
 		data = append(data, Model{
-			Id:      id,
-			Object:  "model",
-			Created: m.ModifiedAt.Unix(),
-			OwnedBy: model.ParseName(id).Namespace,
+			Id:            id,
+			Object:        "model",
+			Created:       m.ModifiedAt.Unix(),
+			OwnedBy:       model.ParseName(id).Namespace,
+			ContextLength: m.Details.ContextLength,
 		})
 	}
 
@@ -471,10 +473,11 @@ func floatsToBase64(floats []float32) string {
 // ToModel converts an api.ShowResponse to Model
 func ToModel(r api.ShowResponse, m string) Model {
 	return Model{
-		Id:      m,
-		Object:  "model",
-		Created: r.ModifiedAt.Unix(),
-		OwnedBy: model.ParseName(m).Namespace,
+		Id:            m,
+		Object:        "model",
+		Created:       r.ModifiedAt.Unix(),
+		OwnedBy:       model.ParseName(m).Namespace,
+		ContextLength: r.Details.ContextLength,
 	}
 }
 

--- a/openai/openai_test.go
+++ b/openai/openai_test.go
@@ -365,6 +365,7 @@ func TestToListCompletionUsesModelIdentity(t *testing.T) {
 				Name:       "legacy-name:latest",
 				Model:      "namespace/exposed-model:latest",
 				ModifiedAt: modified,
+				Details:    api.ModelDetails{ContextLength: 131072},
 			},
 			{
 				Name:       "fallback-name:latest",
@@ -389,12 +390,50 @@ func TestToListCompletionUsesModelIdentity(t *testing.T) {
 	if result.Data[0].Created != modified.Unix() {
 		t.Fatalf("created = %d, want %d", result.Data[0].Created, modified.Unix())
 	}
+	if result.Data[0].ContextLength != 131072 {
+		t.Fatalf("context_length = %d, want 131072", result.Data[0].ContextLength)
+	}
 
 	if result.Data[1].Id != "fallback-name:latest" {
 		t.Fatalf("fallback id = %q, want name field", result.Data[1].Id)
 	}
 	if result.Data[1].OwnedBy != "library" {
 		t.Fatalf("fallback owned_by = %q, want library", result.Data[1].OwnedBy)
+	}
+}
+
+func TestToListCompletionEmpty(t *testing.T) {
+	result := ToListCompletion(api.ListResponse{})
+	if result.Data == nil {
+		t.Fatal("Data is nil, want non-nil empty slice []")
+	}
+	if len(result.Data) != 0 {
+		t.Fatalf("len(Data) = %d, want 0", len(result.Data))
+	}
+}
+
+func TestToModel(t *testing.T) {
+	modified := time.Unix(1234567890, 0).UTC()
+	resp := api.ShowResponse{
+		ModifiedAt: modified,
+		Details:    api.ModelDetails{ContextLength: 262144},
+	}
+
+	model := ToModel(resp, "test-model:latest")
+	if model.Id != "test-model:latest" {
+		t.Fatalf("id = %q, want test-model:latest", model.Id)
+	}
+	if model.Object != "model" {
+		t.Fatalf("object = %q, want model", model.Object)
+	}
+	if model.Created != modified.Unix() {
+		t.Fatalf("created = %d, want %d", model.Created, modified.Unix())
+	}
+	if model.OwnedBy != "library" {
+		t.Fatalf("owned_by = %q, want library", model.OwnedBy)
+	}
+	if model.ContextLength != 262144 {
+		t.Fatalf("context_length = %d, want 262144", model.ContextLength)
 	}
 }
 


### PR DESCRIPTION
Fixes #17417

This PR adds `context_length` to the `openai.Model` struct and populates it from model details in `ToListCompletion` and `ToModel`.

### Changes:
- Added `context_length` to `openai.Model` JSON response for `/v1/models` and `/v1/models/{model}`.
- Initialized `data` slice in `ToListCompletion` to avoid `null` serialization when no models are loaded.
- Added unit tests for `ContextLength` mapping and empty list response in `openai_test.go`.
- Updated OpenAI compatibility API documentation.
