### PR TITLE
openai: pass options map from request body to generate options

### DIFF
--- a/openai/openai.go
+++ b/openai/openai.go
@@ -109,6 +109,7 @@ type ChatCompletionRequest struct {
 	TopP             *float64        `json:"top_p"`
 	ResponseFormat   *ResponseFormat `json:"response_format"`
 	Tools            []api.Tool      `json:"tools"`
+	Options          map[string]any  `json:"options"`
 	Reasoning        *Reasoning      `json:"reasoning,omitempty"`
 	ReasoningEffort  *string         `json:"reasoning_effort,omitempty"`
 	Logprobs         *bool           `json:"logprobs"`
@@ -588,6 +589,10 @@ func FromChatRequest(r ChatCompletionRequest) (*api.ChatRequest, error) {
 
 	if r.MaxTokens != nil {
 		options["num_predict"] = *r.MaxTokens
+	}
+
+	for k, v := range r.Options {
+		options[k] = v
 	}
 
 	if r.Temperature != nil {


### PR DESCRIPTION
The `/v1/chat/completions` endpoint silently ignored any fields passed
under the `"options"` key in the request body, even though Ollama's own
`/api/chat` endpoint accepts exactly this structure.

For example, sending:

```json
{
  "model": "qwen3:8b",
  "messages": [...],
  "options": { "num_ctx": 131072 }
}
```

had no effect — `num_ctx` was never forwarded to the generate options.

## Changes

- Add `Options map[string]any \`json:"options"\`` field to
  `ChatCompletionRequest` (matching the structure of `api.GenerateRequest`
  and `api.ChatRequest`)
- In `fromChatRequest()`, merge all entries from `r.Options` into the
  generate options map after the other option mappings

## Why this matters

Tools that use the OpenAI-compatible endpoint (e.g. Hermes Agent) already
send context-length configuration as `options.num_ctx`, matching the
native `/api/chat` API shape. Without this fix the context window falls
back to the server default even when the client explicitly requested a
larger one.

Backward compatible: adding a new JSON field does not affect any existing
requests that do not include it.

Related: #6504 (which proposed top-level `num_ctx`/`context_length` fields
instead — this approach is lower-surface and consistent with the native API
structure)