### PR TITLE
cmd/tui: keep pipe-delimited prose out of tables

### DIFF
--- a/cmd/tui/chat/markdown.go
+++ b/cmd/tui/chat/markdown.go
@@ -387,8 +387,10 @@ func isMarkdownTableSeparator(line string) bool {
 		return false
 	}
 	for _, cell := range cells {
-		cell = strings.Trim(cell, " :-")
-		if cell != "" {
+		cell = strings.TrimSpace(cell)
+		cell = strings.TrimPrefix(cell, ":")
+		cell = strings.TrimSuffix(cell, ":")
+		if cell == "" || strings.Trim(cell, "-") != "" {
 			return false
 		}
 	}

--- a/cmd/tui/chat/render_test.go
+++ b/cmd/tui/chat/render_test.go
@@ -2075,3 +2075,39 @@ func TestRenderMarkdownTableWrapsLongCells(t *testing.T) {
 		}
 	}
 }
+
+func TestRenderMarkdownProseWithPipeExamplesIsNotTable(t *testing.T) {
+	markdown := strings.Join([]string{
+		"- **Regression confirmed** vs. `fdbe8d33`: the bare `< | open | >` remains prose.",
+		"| | |",
+		"- **Severity**: `< | close | >` is another inline example.",
+	}, "\n")
+
+	rendered := renderMarkdownForView(markdown, 120)
+	plain := stripANSI(rendered)
+	if !strings.Contains(plain, "| | |") || !strings.Contains(plain, "the bare < | open | > remains") || !strings.Contains(plain, "< | close | > is another") {
+		t.Fatalf("pipe-delimited prose rendered as a table:\n%s", plain)
+	}
+	if !strings.Contains(rendered, chatStrongStyle.Render("Regression confirmed")) {
+		t.Fatalf("bold prose was not emphasized: %q", rendered)
+	}
+	if !strings.Contains(rendered, chatInlineCodeStyle.Render("fdbe8d33")) {
+		t.Fatalf("inline code was not styled: %q", rendered)
+	}
+}
+
+func TestRenderMarkdownTablePreservesValidSeparator(t *testing.T) {
+	markdown := strings.Join([]string{
+		"| Name | State |",
+		"| --- | :---: |",
+		"| Ollama | Ready |",
+	}, "\n")
+
+	plain := stripANSI(renderMarkdownForView(markdown, 80))
+	if strings.Contains(plain, "---") {
+		t.Fatalf("table separator should not render as prose:\n%s", plain)
+	}
+	if !strings.Contains(plain, "Name") || !strings.Contains(plain, "Ollama") {
+		t.Fatalf("valid Markdown table was not rendered:\n%s", plain)
+	}
+}


### PR DESCRIPTION
## What changed

- Require each Markdown table separator cell to contain hyphens.
- Keep pipe-delimited prose as normal text.
- Add regressions for bold prose, inline code, angle brackets, pipes, and valid tables.

## Root cause

The renderer accepted a pipe-only line as a table separator. It then rendered nearby prose as a table.

## Validation

- `go test ./cmd/tui/chat -count=1`
- `go test ./cmd/tui/... -count=1`