### PR TITLE
fix: compare layer digests to avoid false model staleness

### DIFF
--- a/app/ui/ui.go
+++ b/app/ui/ui.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httputil"
@@ -456,30 +457,25 @@ func (s *Server) listChats(w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 
-// checkModelUpstream makes a HEAD request to the Ollama registry to get the upstream digest and push time
-func (s *Server) checkModelUpstream(ctx context.Context, modelName string, timeout time.Duration) (string, int64, error) {
+// checkModelUpstream makes a GET request to the Ollama registry to get the upstream
+// digest, push time, and manifest body. The manifest body is used to compare layer
+// digests when the manifest digest doesn't match, to avoid false staleness reports
+// caused by manifest re-serialization differences.
+func (s *Server) checkModelUpstream(ctx context.Context, modelName string, timeout time.Duration) (string, []byte, int64, error) {
 	// Create a context with timeout for the registry check
 	checkCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	// Parse model name to get namespace, model, and tag
-	parts := strings.Split(modelName, ":")
-	name := parts[0]
-	tag := "latest"
-	if len(parts) > 1 {
-		tag = parts[1]
+	n := model.ParseName(modelName)
+	if !n.IsFullyQualified() {
+		return "", nil, 0, fmt.Errorf("invalid model name: %s", modelName)
 	}
 
-	if !strings.Contains(name, "/") {
-		// If the model name does not contain a slash, assume it's a library model
-		name = "library/" + name
-	}
-
-	// Check the model in the Ollama registry using HEAD request
-	url := OllamaDotCom + "/v2/" + name + "/manifests/" + tag
-	req, err := http.NewRequestWithContext(checkCtx, "HEAD", url, nil)
+	// Check the model in the Ollama registry using GET request to retrieve manifest body
+	url := OllamaDotCom + "/v2/" + n.DisplayNamespaceModel() + "/manifests/" + n.Tag
+	req, err := http.NewRequestWithContext(checkCtx, "GET", url, nil)
 	if err != nil {
-		return "", 0, err
+		return "", nil, 0, err
 	}
 
 	httpClient := s.httpClient()
@@ -487,17 +483,22 @@ func (s *Server) checkModelUpstream(ctx context.Context, modelName string, timeo
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return "", 0, err
+		return "", nil, 0, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", 0, fmt.Errorf("registry returned status %d", resp.StatusCode)
+		return "", nil, 0, fmt.Errorf("registry returned status %d", resp.StatusCode)
 	}
 
 	digest := resp.Header.Get("ollama-content-digest")
 	if digest == "" {
-		return "", 0, fmt.Errorf("no digest header found")
+		return "", nil, 0, fmt.Errorf("no digest header found")
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", nil, 0, err
 	}
 
 	var pushTime int64
@@ -507,7 +508,38 @@ func (s *Server) checkModelUpstream(ctx context.Context, modelName string, timeo
 		}
 	}
 
-	return digest, pushTime, nil
+	return digest, body, pushTime, nil
+}
+
+// manifestsContentEqual compares the config and layer digests of two manifests.
+// Returns true if all config and layer digests match, meaning the actual model
+// content is the same even if the manifest serialization differs.
+func manifestsContentEqual(local *manifest.Manifest, upstreamBody []byte) bool {
+	var upstream manifest.Manifest
+	if err := json.Unmarshal(upstreamBody, &upstream); err != nil {
+		return false
+	}
+
+	if local.Config.Digest != upstream.Config.Digest {
+		return false
+	}
+
+	if len(local.Layers) != len(upstream.Layers) {
+		return false
+	}
+
+	localDigests := make(map[string]bool)
+	for _, layer := range local.Layers {
+		localDigests[layer.Digest] = true
+	}
+
+	for _, layer := range upstream.Layers {
+		if !localDigests[layer.Digest] {
+			return false
+		}
+	}
+
+	return true
 }
 
 // isNetworkError checks if an error string contains common network/connection error patterns
@@ -1583,7 +1615,7 @@ func (s *Server) modelUpstream(w http.ResponseWriter, r *http.Request) error {
 		return fmt.Errorf("model is required")
 	}
 
-	digest, pushTime, err := s.checkModelUpstream(r.Context(), req.Model, 5*time.Second)
+	digest, upstreamBody, pushTime, err := s.checkModelUpstream(r.Context(), req.Model, 5*time.Second)
 	if err != nil {
 		s.log().Warn("failed to check upstream digest", "error", err, "model", req.Model)
 		response := responses.ModelUpstreamResponse{
@@ -1597,6 +1629,11 @@ func (s *Server) modelUpstream(w http.ResponseWriter, r *http.Request) error {
 	stale := true
 	if m, err := manifest.ParseNamedManifest(n); err == nil {
 		if m.Digest() == digest {
+			stale = false
+		} else if manifestsContentEqual(m, upstreamBody) {
+			// Manifest digest mismatch can be caused by serialization differences
+			// (e.g. models pulled before the raw-bytes manifest write fix).
+			// Compare actual content digests to avoid false staleness.
 			stale = false
 		} else if pushTime > 0 && m.FileInfo().ModTime().Unix() >= pushTime {
 			stale = false

--- a/app/ui/ui_test.go
+++ b/app/ui/ui_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/app/store"
 	"github.com/ollama/ollama/app/updater"
+	"github.com/ollama/ollama/manifest"
 )
 
 func TestHandlePostApiSettings(t *testing.T) {
@@ -838,5 +839,72 @@ func TestSettingsToggleAutoUpdateOn_NoPendingUpdate_TriggersCheck(t *testing.T) 
 	// UpdateAvailableFunc should NOT be called since there's no pending update
 	if notificationCalled.Load() {
 		t.Fatal("UpdateAvailableFunc should not be called when there is no pending update")
+	}
+}
+
+func TestManifestsContentEqual(t *testing.T) {
+	configDigest := "sha256:abc"
+	layer1Digest := "sha256:layer1"
+	layer2Digest := "sha256:layer2"
+
+	localManifest := &manifest.Manifest{
+		Config: manifest.Layer{Digest: configDigest},
+		Layers: []manifest.Layer{
+			{Digest: layer1Digest},
+			{Digest: layer2Digest},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		local    *manifest.Manifest
+		upstream string
+		want     bool
+	}{
+		{
+			name:     "identical content",
+			local:    localManifest,
+			upstream: `{"schemaVersion":2,"mediaType":"application/vnd.docker.distribution.manifest.v2+json","config":{"mediaType":"application/vnd.docker.container.image.v1+json","digest":"` + configDigest + `","size":100},"layers":[{"mediaType":"application/vnd.ollama.image.model","digest":"` + layer1Digest + `","size":1000},{"mediaType":"application/vnd.ollama.image.model","digest":"` + layer2Digest + `","size":2000}]}`,
+			want:     true,
+		},
+		{
+			name:     "different config digest",
+			local:    localManifest,
+			upstream: `{"schemaVersion":2,"config":{"digest":"sha256:different"},"layers":[{"digest":"` + layer1Digest + `"},{"digest":"` + layer2Digest + `"}]}`,
+			want:     false,
+		},
+		{
+			name:     "different layer digest",
+			local:    localManifest,
+			upstream: `{"schemaVersion":2,"config":{"digest":"` + configDigest + `"},"layers":[{"digest":"` + layer1Digest + `"},{"digest":"sha256:different"}]}`,
+			want:     false,
+		},
+		{
+			name:     "different number of layers",
+			local:    localManifest,
+			upstream: `{"schemaVersion":2,"config":{"digest":"` + configDigest + `"},"layers":[{"digest":"` + layer1Digest + `"}]}`,
+			want:     false,
+		},
+		{
+			name:     "layers in different order still match",
+			local:    localManifest,
+			upstream: `{"schemaVersion":2,"config":{"digest":"` + configDigest + `"},"layers":[{"digest":"` + layer2Digest + `"},{"digest":"` + layer1Digest + `"}]}`,
+			want:     true,
+		},
+		{
+			name:     "invalid JSON",
+			local:    localManifest,
+			upstream: `not json`,
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := manifestsContentEqual(tt.local, []byte(tt.upstream))
+			if got != tt.want {
+				t.Errorf("manifestsContentEqual() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Problem

Fixes #16844

The Ollama desktop app shows a "model update available" notification and, when the user clicks Update, the download dialog flashes briefly (~1 sec) then disappears with no actual download happening.

## Root Cause

The staleness check in `modelUpstream` (`app/ui/ui.go`) compares the local manifest digest (SHA256 of the raw manifest file) against the upstream manifest digest from the registry. This produces **false positives** when:

- **Models pulled before v0.19.0** (PR #15104): `PullModel` re-serialized the manifest JSON before writing, producing different bytes than the registry, resulting in a different SHA256.
- **Registry manifest format changes**: field ordering or metadata updates that don't change actual model content (layer digests).

When the manifest digest mismatches (and the `pushTime` fallback also fails), the model is falsely marked stale. Clicking "Update" triggers `c.Pull()`, which downloads the new manifest but finds all blob digests unchanged → all blobs cached → Pull completes instantly → download dialog flashes and disappears.

## Fix

When the manifest digest doesn't match, now also compare **config and layer digests** (the actual model content). If all content digests match, the model is not stale.

Additionally, `checkModelUpstream` now:
- Uses `model.ParseName` instead of naive `strings.Split` for proper model name parsing
- Makes a GET request instead of HEAD to retrieve the manifest body for layer digest comparison

## Testing

- Added `TestManifestsContentEqual` unit test covering: identical content, different config/layer digests, different layer count, reordered layers, invalid JSON
- Verified `go vet` and `gofmt` pass
- Verified compilation with `GOOS=windows` and `GOOS=darwin`
