### PR TITLE
fix(server): write debug request log on arrival, not after response

### DIFF
--- a/server/inference_request_log.go
+++ b/server/inference_request_log.go
@@ -79,8 +79,12 @@ func (l *inferenceRequestLogger) middleware(route string) gin.HandlerFunc {
 			}
 		}
 
-		c.Next()
+		// Log the request as soon as it arrives, not after the (potentially
+		// long-running) handler returns, so the log reflects incoming traffic
+		// in real time (#17437).
 		l.log(route, method, scheme, host, contentType, body)
+
+		c.Next()
 	}
 }
 

--- a/server/routes_request_log_test.go
+++ b/server/routes_request_log_test.go
@@ -88,6 +88,40 @@ func TestInferenceRequestLoggerMiddlewareWritesReplayArtifacts(t *testing.T) {
 	}
 }
 
+func TestInferenceRequestLoggerMiddlewareWritesLogBeforeHandlerRuns(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	logDir := t.TempDir()
+	requestLogger := &inferenceRequestLogger{dir: logDir}
+
+	const route = "/api/generate"
+	const requestBody = `{"model":"m","prompt":"hi"}`
+
+	// The handler asserts the log artifacts already exist at the moment it
+	// runs. With the pre-fix behaviour (log written after c.Next()), the
+	// files would not exist yet and this test would fail (#17437).
+	handlerSawBodyLog := false
+	r := gin.New()
+	r.POST(route, requestLogger.middleware(route), func(c *gin.Context) {
+		bodyFiles, _ := filepath.Glob(filepath.Join(logDir, "*_api_generate_body.json"))
+		handlerSawBodyLog = len(bodyFiles) == 1
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, route, strings.NewReader(requestBody))
+	req.Host = "127.0.0.1:11434"
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if !handlerSawBodyLog {
+		t.Fatal("request log was not written before the handler ran; expected the log to be written on request arrival (#17437)")
+	}
+}
+
 func TestNewInferenceRequestLoggerCreatesDirectory(t *testing.T) {
 	requestLogger, err := newInferenceRequestLogger()
 	if err != nil {


### PR DESCRIPTION
## Summary

Fixes #17437

`OLLAMA_DEBUG_LOG_REQUESTS` wrote the request body and replay curl script only **after** the handler returned (`c.Next()` completed). For long-running inference requests this meant the log appeared minutes after the request arrived, making it useless for debugging in-flight issues.

## Fix

Move `l.log()` before `c.Next()` so the artifacts are written as soon as the request is received.

```diff
+// Log the request as soon as it arrives, not after the (potentially
+// long-running) handler returns, so the log reflects incoming traffic
+// in real time (#17437).
+l.log(route, method, scheme, host, contentType, body)
+
 c.Next()
-l.log(route, method, scheme, host, contentType, body)
```

## Test

Added `TestInferenceRequestLoggerMiddlewareWritesLogBeforeHandlerRuns`: the handler asserts the log files already exist at the moment it runs. With the pre-fix behaviour the files would not exist yet and the test fails.

Note: I could not run the full server test suite locally (sparse checkout without the full module graph), but the change is a two-line reorder and the new test is self-contained.