### PR TITLE
Add DeepCellar to Community Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ console.log(response.message.content);
 - [chat](https://github.com/swuecho/chat) - Chat web app for teams
 - [Ollama RAG Chatbot](https://github.com/datvodinh/rag-chatbot.git) - Chat with multiple PDFs using RAG
 - [Tkinter-based client](https://github.com/chyok/ollama-gui) - Python desktop client
+- [DeepCellar](https://github.com/alouiadel/DeepCellar) - Minimalist self-hosted AI hub for companies
 
 #### Desktop
 


### PR DESCRIPTION
Adds [DeepCellar](https://github.com/alouiadel/DeepCellar) to the Community Integrations → Chat Interfaces → Web list.

DeepCellar is a minimalist, self-hosted AI hub for companies built on Ollama — streaming chat with thinking-model support, persistent sessions, and real auth today; RAG (sqlite-vec + embeddinggemma), shared knowledge bases with admin roles, and MCP agents on the [public roadmap](https://github.com/alouiadel/DeepCellar/blob/main/next.md).

The philosophy: FastAPI + vanilla JS + one SQLite file, 5 runtime dependencies, no build step — an AI hub a team can read, audit, and customize in an afternoon.

Thanks for maintaining Ollama!