### PR TITLE
launch: add minimax-m3 to recommended models

### DIFF
--- a/cmd/launch/integrations_test.go
+++ b/cmd/launch/integrations_test.go
@@ -497,7 +497,7 @@ func TestBuildModelList_ExistingRecommendedMarked(t *testing.T) {
 			if !strings.HasSuffix(item.Description, "(not downloaded)") {
 				t.Errorf("non-installed recommended %q should have '(not downloaded)' suffix, got %q", item.Name, item.Description)
 			}
-		case "minimax-m2.7:cloud", "kimi-k2.6:cloud", "qwen3.5:cloud":
+		case "minimax-m3:cloud", "minimax-m2.7:cloud", "kimi-k2.6:cloud", "qwen3.5:cloud":
 			if strings.HasSuffix(item.Description, "(not downloaded)") {
 				t.Errorf("cloud model %q should not have '(not downloaded)' suffix, got %q", item.Name, item.Description)
 			}
@@ -710,7 +710,7 @@ func TestBuildModelList_RecsAboveNonRecs(t *testing.T) {
 	lastRecIdx := -1
 	firstNonRecIdx := len(got)
 	for i, name := range got {
-		isRec := name == "gemma4" || name == "qwen3.5" || name == "minimax-m2.7:cloud" || name == "glm-5.1:cloud" || name == "kimi-k2.6:cloud" || name == "qwen3.5:cloud"
+		isRec := name == "gemma4" || name == "qwen3.5" || name == "minimax-m3:cloud" || name == "minimax-m2.7:cloud" || name == "glm-5.1:cloud" || name == "kimi-k2.6:cloud" || name == "qwen3.5:cloud"
 		if isRec && i > lastRecIdx {
 			lastRecIdx = i
 		}
@@ -1591,6 +1591,9 @@ func TestRecommendedModelsDoNotIncludeRequiredPlanStubs(t *testing.T) {
 
 	if item := byName["kimi-k2.6:cloud"]; item.RequiredPlan != "" {
 		t.Fatalf("kimi fallback required plan should not be stubbed: %#v", item)
+	}
+	if item := byName["minimax-m3:cloud"]; item.RequiredPlan != "" {
+		t.Fatalf("minimax m3 fallback required plan should not be stubbed: %#v", item)
 	}
 	if item := byName["minimax-m2.7:cloud"]; item.RequiredPlan != "" {
 		t.Fatalf("minimax fallback required plan should not be stubbed: %#v", item)

--- a/cmd/launch/launch_test.go
+++ b/cmd/launch/launch_test.go
@@ -1081,7 +1081,7 @@ func TestLaunchIntegration_ManagedSingleIntegrationCanConfigureWithModelList(t *
 		t.Fatalf("LaunchIntegration returned error: %v", err)
 	}
 
-	if diff := compareStringSlices(runner.configuredModelLists, [][]string{{"gemma4", "kimi-k2.6:cloud", "qwen3.5:cloud", "glm-5.1:cloud", "minimax-m2.7:cloud", "qwen3.5", "qwen3:8b"}}); diff != "" {
+	if diff := compareStringSlices(runner.configuredModelLists, [][]string{{"gemma4", "kimi-k2.6:cloud", "qwen3.5:cloud", "glm-5.1:cloud", "minimax-m3:cloud", "minimax-m2.7:cloud", "qwen3.5", "qwen3:8b"}}); diff != "" {
 		t.Fatalf("configured model list mismatch (-want +got):\n%s", diff)
 	}
 	if diff := compareStrings(runner.configured, []string{"gemma4"}); diff != "" {

--- a/cmd/launch/models.go
+++ b/cmd/launch/models.go
@@ -26,6 +26,7 @@ var recommendedModels = []ModelItem{
 	{Name: "kimi-k2.6:cloud", Description: "State-of-the-art coding, long-horizon execution, and multimodal agent swarm capability", Recommended: true, Details: api.ModelDetails{ContextLength: 262_144}, MaxOutputTokens: 262_144},
 	{Name: "qwen3.5:cloud", Description: "Reasoning, coding, and agentic tool use with vision", Recommended: true, Details: api.ModelDetails{ContextLength: 262_144}, MaxOutputTokens: 32_768},
 	{Name: "glm-5.1:cloud", Description: "Reasoning and code generation", Recommended: true, Details: api.ModelDetails{ContextLength: 202_752}, MaxOutputTokens: 131_072},
+	{Name: "minimax-m3:cloud", Description: "Long-context coding and agentic tool use with vision", Recommended: true, Details: api.ModelDetails{ContextLength: 1_000_000}, MaxOutputTokens: 128_000},
 	{Name: "minimax-m2.7:cloud", Description: "Fast, efficient coding and real-world productivity", Recommended: true, Details: api.ModelDetails{ContextLength: 204_800}, MaxOutputTokens: 128_000},
 	{Name: "gemma4", Description: "Reasoning and code generation locally", Recommended: true, VRAMBytes: 12 * format.GigaByte},
 	{Name: "qwen3.5", Description: "Reasoning, coding, and visual understanding locally", Recommended: true, VRAMBytes: 14 * format.GigaByte},

--- a/docs/api/anthropic-compatibility.mdx
+++ b/docs/api/anthropic-compatibility.mdx
@@ -238,7 +238,7 @@ curl -X POST http://localhost:11434/v1/messages \
 
 ### Recommended models
 
-For coding use cases, models like `glm-4.7`, `minimax-m2.1`, and `qwen3-coder` are recommended.
+For coding use cases, models like `glm-4.7`, `minimax-m3`, and `qwen3-coder` are recommended.
 
 Download a model before use:
 
@@ -363,7 +363,7 @@ Recommended local models:
 Cloud models are available immediately without pulling:
 
 - `glm-4.7:cloud` - High-performance cloud model
-- `minimax-m2.1:cloud` - Fast cloud model
+- `minimax-m3:cloud` - Long-context cloud model
 
 ### Default model names
 

--- a/docs/integrations/copilot-cli.mdx
+++ b/docs/integrations/copilot-cli.mdx
@@ -48,6 +48,7 @@ ollama launch copilot --model kimi-k2.5:cloud
 
 - `kimi-k2.5:cloud`
 - `glm-5:cloud`
+- `minimax-m3:cloud`
 - `minimax-m2.7:cloud`
 - `qwen3.5:cloud`
 - `glm-4.7-flash`

--- a/docs/integrations/hermes.mdx
+++ b/docs/integrations/hermes.mdx
@@ -26,6 +26,7 @@ Ollama handles everything automatically:
 - `kimi-k2.5:cloud` — Multimodal reasoning with subagents
 - `glm-5.1:cloud` — Reasoning and code generation
 - `qwen3.5:cloud` — Reasoning, coding, and agentic tool use with vision
+- `minimax-m3:cloud` — Long-context coding and agentic tool use with vision
 - `minimax-m2.7:cloud` — Fast, efficient coding and real-world productivity
 
 **Local models:**

--- a/docs/integrations/openclaw.mdx
+++ b/docs/integrations/openclaw.mdx
@@ -61,6 +61,7 @@ If the gateway is already running, it restarts automatically to pick up the new 
 - `kimi-k2.5:cloud` — Multimodal reasoning with subagents
 - `qwen3.5:cloud` — Reasoning, coding, and agentic tool use with vision
 - `glm-5.1:cloud` — Reasoning and code generation
+- `minimax-m3:cloud` — Long-context coding and agentic tool use with vision
 - `minimax-m2.7:cloud` — Fast, efficient coding and real-world productivity
 
 **Local models:**

--- a/server/model_recommendations.go
+++ b/server/model_recommendations.go
@@ -384,6 +384,12 @@ var defaultModelRecommendations = []api.ModelRecommendation{
 		MaxOutputTokens: 32_768,
 	},
 	{
+		Model:           "minimax-m3:cloud",
+		Description:     "Long-context coding and agentic tool use with vision",
+		ContextLength:   1_000_000,
+		MaxOutputTokens: 128_000,
+	},
+	{
 		Model:           "minimax-m2.7:cloud",
 		Description:     "Fast, efficient coding and real-world productivity",
 		ContextLength:   204_800,

--- a/server/model_recommendations_test.go
+++ b/server/model_recommendations_test.go
@@ -27,6 +27,7 @@ func TestModelRecommendationsDefaultOrder(t *testing.T) {
 		"kimi-k2.6:cloud",
 		"glm-5.1:cloud",
 		"qwen3.5:cloud",
+		"minimax-m3:cloud",
 		"minimax-m2.7:cloud",
 		"gemma4",
 		"qwen3.5",


### PR DESCRIPTION
Reason: The built-in launch and model-recommendation fallbacks list MiniMax-M2.7 but omit the current MiniMax-M3 model.

## Changes
- Add `minimax-m3:cloud` to `recommendedModels` in `cmd/launch/models.go` with a 1,000,000-token context window.
- Add `minimax-m3:cloud` to `defaultModelRecommendations` in `server/model_recommendations.go` with the same context window.
- Update the recommendation/order assertions in `server/model_recommendations_test.go`, `cmd/launch/integrations_test.go`, and `cmd/launch/launch_test.go` to include the new entry.

The MiniMax-M3 context window is set to 1,000,000 tokens, matching the current MiniMax-M3 configuration (rather than an earlier 524,288-token value).

## Checks
- `go vet ./cmd/launch/ ./server/`
- `go test ./cmd/launch/ -count=1`
- `go test ./server/ -run 'TestModelRecommendations|TestValidateModelRecommendations' -count=1`
- `gofmt` clean on all touched files
