### PR TITLE
api: keep JSON Schema constraints on tool parameters

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -416,13 +416,26 @@ func (t *ToolPropertiesMap) UnmarshalJSON(data []byte) error {
 }
 
 type ToolProperty struct {
-	AnyOf       []ToolProperty     `json:"anyOf,omitempty"`
-	Type        PropertyType       `json:"type,omitempty"`
-	Items       any                `json:"items,omitempty"`
-	Description string             `json:"description,omitempty"`
-	Enum        []any              `json:"enum,omitempty"`
-	Properties  *ToolPropertiesMap `json:"properties,omitempty"`
-	Required    []string           `json:"required,omitempty"`
+	AnyOf              []ToolProperty     `json:"anyOf,omitempty"`
+	Type               PropertyType       `json:"type,omitempty"`
+	Items              any                `json:"items,omitempty"`
+	Description        string             `json:"description,omitempty"`
+	Enum               []any              `json:"enum,omitempty"`
+	Properties         *ToolPropertiesMap `json:"properties,omitempty"`
+	Required           []string           `json:"required,omitempty"`
+	Minimum            *float64           `json:"minimum,omitempty"`
+	Maximum            *float64           `json:"maximum,omitempty"`
+	ExclusiveMinimum   any                `json:"exclusiveMinimum,omitempty"`
+	ExclusiveMaximum   any                `json:"exclusiveMaximum,omitempty"`
+	MultipleOf         *float64           `json:"multipleOf,omitempty"`
+	Default            any                `json:"default,omitempty"`
+	Format             string             `json:"format,omitempty"`
+	Pattern            string             `json:"pattern,omitempty"`
+	MinLength          *int               `json:"minLength,omitempty"`
+	MaxLength          *int               `json:"maxLength,omitempty"`
+	MinItems           *int               `json:"minItems,omitempty"`
+	MaxItems           *int               `json:"maxItems,omitempty"`
+	Const              any                `json:"const,omitempty"`
 }
 
 // ToTypeScriptType converts a ToolProperty to a TypeScript type string

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -306,6 +306,95 @@ func TestMessage_UnmarshalJSON(t *testing.T) {
 	}
 }
 
+func TestToolProperty_SchemaConstraints_UnmarshalJSON(t *testing.T) {
+	t.Run("numeric bounds and default", func(t *testing.T) {
+		input := `{
+			"type": "integer",
+			"description": "Results per page.",
+			"minimum": 1,
+			"maximum": 100,
+			"default": 20
+		}`
+
+		var prop ToolProperty
+		require.NoError(t, json.Unmarshal([]byte(input), &prop))
+
+		require.NotNil(t, prop.Minimum)
+		assert.Equal(t, float64(1), *prop.Minimum)
+		require.NotNil(t, prop.Maximum)
+		assert.Equal(t, float64(100), *prop.Maximum)
+		assert.Equal(t, float64(20), prop.Default)
+
+		roundTrip, err := json.Marshal(prop)
+		require.NoError(t, err)
+
+		var decoded map[string]any
+		require.NoError(t, json.Unmarshal(roundTrip, &decoded))
+		assert.Equal(t, float64(1), decoded["minimum"])
+		assert.Equal(t, float64(100), decoded["maximum"])
+		assert.Equal(t, float64(20), decoded["default"])
+	})
+
+	t.Run("full tool request preserves schema keywords", func(t *testing.T) {
+		input := `{
+			"name": "search_records",
+			"description": "Search records.",
+			"parameters": {
+				"type": "object",
+				"properties": {
+					"page_limit": {
+						"type": "integer",
+						"description": "Results per page.",
+						"minimum": 1,
+						"maximum": 100,
+						"default": 20
+					},
+					"threshold": {
+						"type": "number",
+						"description": "Similarity cutoff.",
+						"minimum": 0.0,
+						"maximum": 1.0,
+						"exclusiveMinimum": 0.0,
+						"multipleOf": 0.01
+					},
+					"mode": {
+						"type": "string",
+						"description": "Search mode.",
+						"enum": ["fuzzy", "exact"]
+					},
+					"tags": {
+						"anyOf": [{"type": "string"}, {"type": "array"}],
+						"description": "Tag filter."
+					}
+				},
+				"required": ["page_limit"]
+			}
+		}`
+
+		var tf ToolFunction
+		require.NoError(t, json.Unmarshal([]byte(input), &tf))
+
+		pageLimit, ok := tf.Parameters.Properties.Get("page_limit")
+		require.True(t, ok)
+		require.NotNil(t, pageLimit.Minimum)
+		require.NotNil(t, pageLimit.Maximum)
+		assert.Equal(t, float64(20), pageLimit.Default)
+
+		threshold, ok := tf.Parameters.Properties.Get("threshold")
+		require.True(t, ok)
+		require.NotNil(t, threshold.ExclusiveMinimum)
+		assert.Equal(t, float64(0), threshold.ExclusiveMinimum)
+		require.NotNil(t, threshold.MultipleOf)
+		assert.InDelta(t, 0.01, *threshold.MultipleOf, 1e-9)
+
+		serialized := tf.String()
+		assert.Contains(t, serialized, `"minimum":1`)
+		assert.Contains(t, serialized, `"default":20`)
+		assert.Contains(t, serialized, `"exclusiveMinimum":0`)
+		assert.Contains(t, serialized, `"multipleOf":0.01`)
+	})
+}
+
 func TestToolFunction_UnmarshalJSON(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Summary

Tool parameter parsing was dropping common JSON Schema keywords such as `minimum`, `maximum`, `default`, and `multipleOf` because `ToolProperty` only mapped a small subset of fields.

This change keeps those keywords through unmarshal and marshal, so tool schemas retain their constraints when they are passed into model templates.

Fixes #17142

## Test plan

- [x] `go test ./api/... -run TestToolProperty_SchemaConstraints`
- [x] Verified a full tool definition round trips with bounds and defaults intact
