### PR TITLE
mlx: qwen3.5 MTP speculative decoding

### DIFF
--- a/x/mlxrunner/cache/recurrent_test.go
+++ b/x/mlxrunner/cache/recurrent_test.go
@@ -89,52 +89,28 @@ func TestRecurrentCachePaddedRoundTrip(t *testing.T) {
 	const L = 4
 	const qLen = 2
 
-	// Use distinct values for the real prefix and the padded tail so
-	// we can detect any leak from padded positions into the result.
-	makeQKV := func(seed float32, T int) (q, k, v *mlx.Array) {
-		mkLast := func(off float32, T, n, d int) *mlx.Array {
-			vals := make([]float32, 1*T*n*d)
-			for i := range vals {
-				vals[i] = off + 0.05*float32(i)
-			}
-			return mlx.FromValues(vals, 1, T, n, d)
+	// Distinct values for the real prefix and large junk in the padded
+	// tail so any leak from padded positions is visible.
+	const packedDim = 2*headKDim + numVHeads*headVDim
+	mkPacked := func(seed float32, T int) (packed, ba *mlx.Array) {
+		pv := make([]float32, T*packedDim)
+		bv := make([]float32, T*2*numVHeads)
+		for i := range pv {
+			pv[i] = seed + 0.05*float32(i)
 		}
-		q = mkLast(seed, T, 1, headKDim)
-		k = mkLast(seed+0.1, T, 1, headKDim)
-		v = mkLast(seed+0.2, T, numVHeads, headVDim)
-		return
-	}
-	makeGB := func(seed float32, T int) (g, beta *mlx.Array) {
-		gVals := make([]float32, 1*T*numVHeads)
-		bVals := make([]float32, 1*T*numVHeads)
-		for i := range gVals {
-			gVals[i] = seed + 0.01*float32(i)
-			bVals[i] = seed - 0.02*float32(i)
+		for i := range bv {
+			bv[i] = seed - 0.02*float32(i)
 		}
-		g = mlx.FromValues(gVals, 1, T, numVHeads)
-		beta = mlx.FromValues(bVals, 1, T, numVHeads)
-		return
+		return mlx.FromValues(pv, 1, T, packedDim), mlx.FromValues(bv, 1, T, 2*numVHeads)
 	}
-	makeQKVPadded := func() (q, k, v *mlx.Array) {
-		qReal, kReal, vReal := makeQKV(0.3, qLen)
-		// Distinct, large junk values in the padded tail to surface
-		// any leak (real outputs are O(1)).
-		qPad := mlx.AddScalar(mlx.Zeros(mlx.DTypeFloat32, 1, L-qLen, 1, headKDim), 99)
-		kPad := mlx.AddScalar(mlx.Zeros(mlx.DTypeFloat32, 1, L-qLen, 1, headKDim), 99)
-		vPad := mlx.AddScalar(mlx.Zeros(mlx.DTypeFloat32, 1, L-qLen, numVHeads, headVDim), 99)
-		q = mlx.Concatenate([]*mlx.Array{qReal, qPad}, 1)
-		k = mlx.Concatenate([]*mlx.Array{kReal, kPad}, 1)
-		v = mlx.Concatenate([]*mlx.Array{vReal, vPad}, 1)
-		return
+	mkPackedPadded := func() (packed, ba *mlx.Array) {
+		pReal, baReal := mkPacked(0.3, qLen)
+		pPad := mlx.AddScalar(mlx.Zeros(mlx.DTypeFloat32, 1, L-qLen, packedDim), 99)
+		baPad := mlx.AddScalar(mlx.Zeros(mlx.DTypeFloat32, 1, L-qLen, 2*numVHeads), 99)
+		return mlx.Concatenate([]*mlx.Array{pReal, pPad}, 1), mlx.Concatenate([]*mlx.Array{baReal, baPad}, 1)
 	}
-	makeGBPadded := func() (g, beta *mlx.Array) {
-		gReal, betaReal := makeGB(0.1, qLen)
-		gPad := mlx.AddScalar(mlx.Zeros(mlx.DTypeFloat32, 1, L-qLen, numVHeads), 99)
-		betaPad := mlx.AddScalar(mlx.Zeros(mlx.DTypeFloat32, 1, L-qLen, numVHeads), 99)
-		g = mlx.Concatenate([]*mlx.Array{gReal, gPad}, 1)
-		beta = mlx.Concatenate([]*mlx.Array{betaReal, betaPad}, 1)
-		return
-	}
+	dtBias := mlx.FromValues([]float32{0.3}, numVHeads)
+	aExp := mlx.FromValues([]float32{0.12}, numVHeads)
 
 	// The conv input dimension must match the cache's convDim.
 	mkConvInput := func(seed float32, T int) *mlx.Array {
@@ -170,16 +146,13 @@ func TestRecurrentCachePaddedRoundTrip(t *testing.T) {
 		_, convStates := nn.CausalConv1D(b, convInput, conv, convTail,
 			nn.WithRecurrentHistory(history))
 
-		var q, k, v, g, beta *mlx.Array
+		var packed, ba *mlx.Array
 		if T == L {
-			q, k, v = makeQKVPadded()
-			g, beta = makeGBPadded()
+			packed, ba = mkPackedPadded()
 		} else {
-			q, k, v = makeQKV(0.3, T)
-			g, beta = makeGB(0.1, T)
+			packed, ba = mkPacked(0.3, T)
 		}
-		_, deltaStates := nn.GatedDelta(b, q, k, v, g, beta,
-			nn.WithRecurrentHistory(history))
+		_, deltaStates := nn.GatedDelta(b, packed, ba, dtBias, aExp, nn.WithRecurrentHistory(history))
 
 		c.Put(b, convStates, deltaStates)
 		return convStates[len(convStates)-1], deltaStates[len(deltaStates)-1]

--- a/x/mlxrunner/mlx/array.go
+++ b/x/mlxrunner/mlx/array.go
@@ -237,15 +237,41 @@ func (t *Array) DType() DType {
 // data utilities
 
 func (t *Array) Int() int {
-	var item C.int64_t
-	C.mlx_array_item_int64(&item, t.ctx)
-	return int(item)
+	switch dt := t.DType(); dt {
+	case DTypeInt32:
+		var item C.int32_t
+		C.mlx_array_item_int32(&item, t.ctx)
+		return int(item)
+	case DTypeUint32:
+		var item C.uint32_t
+		C.mlx_array_item_uint32(&item, t.ctx)
+		return int(item)
+	case DTypeInt64:
+		var item C.int64_t
+		C.mlx_array_item_int64(&item, t.ctx)
+		return int(item)
+	case DTypeUint64:
+		var item C.uint64_t
+		C.mlx_array_item_uint64(&item, t.ctx)
+		return int(item)
+	default:
+		panic(fmt.Sprintf("mlx: Int requires an integer array, got %v", dt))
+	}
 }
 
 func (t *Array) Float() float64 {
-	var item C.double
-	C.mlx_array_item_float64(&item, t.ctx)
-	return float64(item)
+	switch dt := t.DType(); dt {
+	case DTypeFloat32:
+		var item C.float
+		C.mlx_array_item_float32(&item, t.ctx)
+		return float64(item)
+	case DTypeFloat64:
+		var item C.double
+		C.mlx_array_item_float64(&item, t.ctx)
+		return float64(item)
+	default:
+		panic(fmt.Sprintf("mlx: Float requires a float32 or float64 array, got %v", dt))
+	}
 }
 
 func (t *Array) Ints() []int {

--- a/x/mlxrunner/mlx/depthwise_conv.go
+++ b/x/mlxrunner/mlx/depthwise_conv.go
@@ -1,0 +1,88 @@
+package mlx
+
+import "fmt"
+
+// B and T arrive as runtime scalars rather than template arguments so
+// windows of any length share one compiled pipeline; only the channel
+// geometry specializes the kernel.
+const depthwiseConvSiLUMetalSource = `
+auto elem = thread_position_in_grid.x;
+int B = dims[0];
+int T = dims[1];
+uint total = uint(B) * uint(T) * uint(C);
+if (elem >= total) {
+  return;
+}
+
+int c = int(elem % uint(C));
+int t = int(elem / uint(C)) % T;
+int b = int(elem) / (C * T);
+auto in_base = (b * (T + K - 1) + t) * C + c;
+
+float acc = 0.0f;
+for (int i = 0; i < K; ++i) {
+  acc += static_cast<float>(x[in_base + i * C]) * static_cast<float>(w[c * K + i]);
+}
+
+InT conv_out = static_cast<InT>(acc);
+InT sigmoid = stable_sigmoid(conv_out);
+out[elem] = static_cast<InT>(conv_out * sigmoid);
+`
+
+const depthwiseConvSiLUMetalHeader = `
+template <typename T>
+T stable_sigmoid(T x) {
+  auto y = 1 / (1 + metal::exp(metal::abs(x)));
+  return (x < 0) ? y : 1 - y;
+}
+`
+
+var depthwiseConvSiLU = &gpuKernel{
+	name:    "depthwise_conv_silu",
+	inputs:  []string{"x", "w", "dims"},
+	outputs: []string{"out"},
+	metal: gpuSource{
+		source: depthwiseConvSiLUMetalSource,
+		header: depthwiseConvSiLUMetalHeader,
+	},
+	fallback: func(launch gpuLaunch) []*Array {
+		return []*Array{depthwiseConvSiLUGraph(launch.inputs[0], launch.inputs[1])}
+	},
+}
+
+func depthwiseConvSiLUGraph(x, w *Array) *Array {
+	Cdim, K := int32(w.Dim(0)), int32(w.Dim(1))
+	return SiLU(Conv1d(x, Reshape(w, Cdim, K, 1), nil, 1, 0, 1, Cdim))
+}
+
+// DepthwiseConvSiLU computes SiLU of a valid depthwise conv: x
+// [B, T+K-1, C] and w [C, K] give [B, T, C], each output reading the K
+// trailing input rows starting at its own index. Inputs that fit the fused
+// kernel's contract run there; anything else runs the same computation as
+// graph ops. The accumulator is rounded to the input dtype before the
+// activation so the result matches SiLU applied to the graph conv's output.
+func DepthwiseConvSiLU(x, w *Array, outLen int) *Array {
+	if x == nil || w == nil || x.NumDims() != 3 || w.NumDims() != 2 {
+		panic("mlx.DepthwiseConvSiLU: need x [B, T+K-1, C] and w [C, K]")
+	}
+	B, Cdim, K := x.Dim(0), x.Dim(2), w.Dim(1)
+	if w.Dim(0) != Cdim || K <= 0 || x.Dim(1) != outLen+K-1 {
+		panic(fmt.Sprintf("mlx.DepthwiseConvSiLU: shapes x %v, w %v do not fit outLen %d", x.Dims(), w.Dims(), outLen))
+	}
+	if x.DType() != w.DType() || (x.DType() != DTypeBFloat16 && x.DType() != DTypeFloat32) {
+		return depthwiseConvSiLUGraph(x, w)
+	}
+
+	total := B * outLen * Cdim
+	outs := depthwiseConvSiLU.run(gpuLaunch{
+		dtypes: []gpuDTypeArg{{"InT", x.DType()}},
+		ints:   []gpuIntArg{{"C", Cdim}, {"K", K}},
+		outputs: []gpuOutputSpec{
+			{"DEPTHWISE_CONV_SILU", []int32{int32(B), int32(outLen), int32(Cdim)}, x.DType()},
+		},
+		grid:        [3]int{(total + 255) / 256 * 256, 1, 1},
+		threadGroup: [3]int{256, 1, 1},
+		inputs:      []*Array{x, w, NewArrayInt32([]int32{int32(B), int32(outLen)}, []int32{2})},
+	})
+	return outs[0]
+}

--- a/x/mlxrunner/mlx/depthwise_conv_test.go
+++ b/x/mlxrunner/mlx/depthwise_conv_test.go
@@ -1,0 +1,37 @@
+package mlx
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestDepthwiseConvSiLUMatchesGraph(t *testing.T) {
+	skipIfNoMLX(t)
+	withMLXThread(t, func() {
+		testDepthwiseConvSiLUMatchesGraph(t)
+	})
+}
+
+func testDepthwiseConvSiLUMatchesGraph(t *testing.T) {
+	for _, dtype := range []DType{DTypeBFloat16, DTypeFloat32} {
+		for _, shape := range []struct{ B, T, C, K int }{
+			{1, 1, 64, 4},
+			{1, 4, 64, 4},
+			{1, 11, 96, 4},
+			{1, 64, 64, 4},
+			{1, 333, 64, 4},
+			{3, 7, 64, 4},
+			{2, 5, 32, 2},
+		} {
+			name := fmt.Sprintf("%v_b%d_t%d_c%d_k%d", dtype, shape.B, shape.T, shape.C, shape.K)
+			x := patternArray(dtype, []int{shape.B, shape.T + shape.K - 1, shape.C}, 0.02, 0.004, 41, 263)
+			w := patternArray(dtype, []int{shape.C, shape.K}, 0.1, 0.01, 7, 53)
+
+			ref := SiLU(Conv1d(x, Reshape(w, int32(shape.C), int32(shape.K), 1), nil, 1, 0, 1, int32(shape.C)))
+			y := DepthwiseConvSiLU(x, w, shape.T)
+			if err := requireExact("y", y, ref); err != nil {
+				t.Fatalf("%s: %v", name, err)
+			}
+		}
+	}
+}

--- a/x/mlxrunner/mlx/gated_delta.go
+++ b/x/mlxrunner/mlx/gated_delta.go
@@ -1,23 +1,17 @@
 package mlx
 
-// #include <stdlib.h>
-// #include "generated.h"
-import "C"
-
-import (
-	"sync"
-	"unsafe"
-)
-
-var (
-	gatedDeltaMetalKernelOnce sync.Once
-	gatedDeltaMetalKernel     C.mlx_fast_metal_kernel
-	gatedDeltaMetalDisabled   bool
-
-	gatedDeltaCUDAKernelOnce sync.Once
-	gatedDeltaCUDAKernel     C.mlx_fast_cuda_kernel
-	gatedDeltaCUDADisabled   bool
-)
+var gatedDelta = &gpuKernel{
+	name:    "gated_delta_step",
+	inputs:  []string{"q", "k", "v", "g", "beta", "state_in", "T"},
+	outputs: []string{"y", "state_out"},
+	metal:   gpuSource{source: gatedDeltaMetalKernelSource},
+	cuda:    gpuSource{source: gatedDeltaCUDAKernelSource},
+	fallback: func(launch gpuLaunch) []*Array {
+		in := launch.inputs
+		y, state := gatedDeltaFallback(in[0], in[1], in[2], in[3], in[4], in[5])
+		return []*Array{y, state}
+	},
+}
 
 const gatedDeltaMetalKernelSource = `
 auto n = thread_position_in_grid.z;
@@ -167,196 +161,49 @@ for (int i = 0; i < n_per_t; ++i) {
 }
 `
 
-func cStringVector(values []string) (C.mlx_vector_string, func(), bool) {
-	vec := C.mlx_vector_string_new()
-	ok := true
-	for _, s := range values {
-		cs := C.CString(s)
-		if C.mlx_vector_string_append_value(vec, cs) != 0 {
-			ok = false
-		}
-		C.free(unsafe.Pointer(cs))
-		if !ok {
-			break
-		}
-	}
-	cleanup := func() {
-		C.mlx_vector_string_free(vec)
-	}
-	return vec, cleanup, ok
+// gatedDeltaDims are the batch and head geometry of one scan, recovered
+// from the input shapes.
+type gatedDeltaDims struct {
+	B, T, Hk, Dk, Hv, Dv int
 }
 
-func initGatedDeltaMetalKernel() {
-	inputs, freeInputs, ok := cStringVector([]string{"q", "k", "v", "g", "beta", "state_in", "T"})
-	if !ok {
-		gatedDeltaMetalDisabled = true
-		freeInputs()
-		return
-	}
-	defer freeInputs()
-
-	outputs, freeOutputs, ok := cStringVector([]string{"y", "state_out"})
-	if !ok {
-		gatedDeltaMetalDisabled = true
-		freeOutputs()
-		return
-	}
-	defer freeOutputs()
-
-	cName := C.CString("gated_delta_step")
-	defer C.free(unsafe.Pointer(cName))
-	cSource := C.CString(gatedDeltaMetalKernelSource)
-	defer C.free(unsafe.Pointer(cSource))
-	cHeader := C.CString("")
-	defer C.free(unsafe.Pointer(cHeader))
-
-	gatedDeltaMetalKernel = C.mlx_fast_metal_kernel_new(
-		cName,
-		inputs,
-		outputs,
-		cSource,
-		cHeader,
-		C.bool(true),
-		C.bool(false),
-	)
-}
-
-// gatedDeltaKernel runs a fused Metal kernel for the qwen3.5 recurrent update.
-// It returns ok=false on unsupported shapes/devices or kernel setup/apply failure.
-func gatedDeltaKernel(q, k, v, g, beta, state *Array) (y, nextState *Array, ok bool) {
-	if gatedDeltaMetalDisabled {
-		return nil, nil, false
-	}
+// resolveGatedDeltaDims validates the inputs against the GPU kernels'
+// contract and recovers the launch geometry. ok=false routes to the graph
+// fallback: shapes that disagree, Dk not a multiple of the 32-lane simd
+// width, or mixed input dtypes.
+func resolveGatedDeltaDims(q, k, v, g, beta, state *Array) (gatedDeltaDims, bool) {
+	var dims gatedDeltaDims
 	if q == nil || k == nil || v == nil || g == nil || beta == nil || state == nil {
-		return nil, nil, false
+		return dims, false
 	}
-
-	qd := q.Dims()
-	kd := k.Dims()
-	vd := v.Dims()
-	gd := g.Dims()
-	bd := beta.Dims()
-	sd := state.Dims()
+	qd, kd, vd, gd, bd, sd := q.Dims(), k.Dims(), v.Dims(), g.Dims(), beta.Dims(), state.Dims()
 	if len(qd) != 4 || len(kd) != 4 || len(vd) != 4 || len(gd) != 3 || len(bd) != 3 || len(sd) != 4 {
-		return nil, nil, false
+		return dims, false
 	}
-
-	B, T, Hk, Dk := qd[0], qd[1], qd[2], qd[3]
-	if T <= 0 || Hk <= 0 || Dk <= 0 || Dk%32 != 0 {
-		return nil, nil, false
+	dims.B, dims.T, dims.Hk, dims.Dk = qd[0], qd[1], qd[2], qd[3]
+	if dims.T <= 0 || dims.Hk <= 0 || dims.Dk <= 0 || dims.Dk%32 != 0 {
+		return dims, false
 	}
-	if kd[0] != B || kd[1] != T || kd[2] != Hk || kd[3] != Dk {
-		return nil, nil, false
+	if kd[0] != dims.B || kd[1] != dims.T || kd[2] != dims.Hk || kd[3] != dims.Dk {
+		return dims, false
 	}
-	Hv, Dv := vd[2], vd[3]
-	if vd[0] != B || vd[1] != T || Hv <= 0 || Dv <= 0 || Hv%Hk != 0 {
-		return nil, nil, false
+	dims.Hv, dims.Dv = vd[2], vd[3]
+	if vd[0] != dims.B || vd[1] != dims.T || dims.Hv <= 0 || dims.Dv <= 0 || dims.Hv%dims.Hk != 0 {
+		return dims, false
 	}
-	if gd[0] != B || gd[1] != T || gd[2] != Hv {
-		return nil, nil, false
+	if gd[0] != dims.B || gd[1] != dims.T || gd[2] != dims.Hv {
+		return dims, false
 	}
-	if bd[0] != B || bd[1] != T || bd[2] != Hv {
-		return nil, nil, false
+	if bd[0] != dims.B || bd[1] != dims.T || bd[2] != dims.Hv {
+		return dims, false
 	}
-	if sd[0] != B || sd[1] != Hv || sd[2] != Dv || sd[3] != Dk {
-		return nil, nil, false
+	if sd[0] != dims.B || sd[1] != dims.Hv || sd[2] != dims.Dv || sd[3] != dims.Dk {
+		return dims, false
 	}
-
-	inputDType := q.DType()
-	stateDType := state.DType()
-	if k.DType() != inputDType || v.DType() != inputDType || g.DType() != inputDType || beta.DType() != inputDType {
-		return nil, nil, false
+	if k.DType() != q.DType() || v.DType() != q.DType() || g.DType() != q.DType() || beta.DType() != q.DType() {
+		return dims, false
 	}
-
-	gatedDeltaMetalKernelOnce.Do(initGatedDeltaMetalKernel)
-	if gatedDeltaMetalDisabled {
-		return nil, nil, false
-	}
-
-	cfg := C.mlx_fast_metal_kernel_config_new()
-	defer C.mlx_fast_metal_kernel_config_free(cfg)
-
-	cInT := C.CString("InT")
-	defer C.free(unsafe.Pointer(cInT))
-	if C.mlx_fast_metal_kernel_config_add_template_arg_dtype(cfg, cInT, C.mlx_dtype(inputDType)) != 0 {
-		gatedDeltaMetalDisabled = true
-		return nil, nil, false
-	}
-	cStT := C.CString("StT")
-	defer C.free(unsafe.Pointer(cStT))
-	if C.mlx_fast_metal_kernel_config_add_template_arg_dtype(cfg, cStT, C.mlx_dtype(stateDType)) != 0 {
-		gatedDeltaMetalDisabled = true
-		return nil, nil, false
-	}
-	for _, tpl := range []struct {
-		name  string
-		value int
-	}{
-		{name: "Dk", value: Dk},
-		{name: "Dv", value: Dv},
-		{name: "Hk", value: Hk},
-		{name: "Hv", value: Hv},
-	} {
-		cn := C.CString(tpl.name)
-		rc := C.mlx_fast_metal_kernel_config_add_template_arg_int(cfg, cn, C.int(tpl.value))
-		C.free(unsafe.Pointer(cn))
-		if rc != 0 {
-			gatedDeltaMetalDisabled = true
-			return nil, nil, false
-		}
-	}
-
-	yShape := []C.int{C.int(B), C.int(T), C.int(Hv), C.int(Dv)}
-	stateShape := []C.int{C.int(B), C.int(Hv), C.int(Dv), C.int(Dk)}
-	if C.mlx_fast_metal_kernel_config_add_output_arg(cfg, unsafe.SliceData(yShape), C.size_t(len(yShape)), C.mlx_dtype(inputDType)) != 0 {
-		gatedDeltaMetalDisabled = true
-		return nil, nil, false
-	}
-	if C.mlx_fast_metal_kernel_config_add_output_arg(cfg, unsafe.SliceData(stateShape), C.size_t(len(stateShape)), C.mlx_dtype(stateDType)) != 0 {
-		gatedDeltaMetalDisabled = true
-		return nil, nil, false
-	}
-	if C.mlx_fast_metal_kernel_config_set_grid(cfg, 32, C.int(Dv), C.int(B*Hv)) != 0 {
-		gatedDeltaMetalDisabled = true
-		return nil, nil, false
-	}
-	threadY := Dv
-	if threadY > 4 {
-		threadY = 4
-	}
-	if C.mlx_fast_metal_kernel_config_set_thread_group(cfg, 32, C.int(threadY), 1) != 0 {
-		gatedDeltaMetalDisabled = true
-		return nil, nil, false
-	}
-
-	tScalar := FromValue(T)
-	inputs := []C.mlx_array{
-		q.ctx,
-		k.ctx,
-		v.ctx,
-		g.ctx,
-		beta.ctx,
-		state.ctx,
-		tScalar.ctx,
-	}
-	inVec := C.mlx_vector_array_new_data(unsafe.SliceData(inputs), C.size_t(len(inputs)))
-	defer C.mlx_vector_array_free(inVec)
-
-	outVec := C.mlx_vector_array_new()
-	defer C.mlx_vector_array_free(outVec)
-	if C.mlx_fast_metal_kernel_apply(&outVec, gatedDeltaMetalKernel, inVec, cfg, DefaultStream().ctx) != 0 {
-		gatedDeltaMetalDisabled = true
-		return nil, nil, false
-	}
-	if int(C.mlx_vector_array_size(outVec)) < 2 {
-		return nil, nil, false
-	}
-
-	y = New("GATED_DELTA_METAL_Y")
-	nextState = New("GATED_DELTA_METAL_STATE")
-	C.mlx_vector_array_get(&y.ctx, outVec, 0)
-	C.mlx_vector_array_get(&nextState.ctx, outVec, 1)
-	return y, nextState, true
+	return dims, true
 }
 
 func repeatHeadsForGatedDelta(x *Array, repeatFactor int) *Array {
@@ -443,183 +290,6 @@ func gatedDeltaFallback(q, k, v, g, beta, state *Array) (y, nextState *Array) {
 	return Concatenate(outs, 1), nextState
 }
 
-func initGatedDeltaCUDAKernel() {
-	var cudaAvail C.bool
-	if C.mlx_cuda_is_available(&cudaAvail) != 0 || !bool(cudaAvail) {
-		gatedDeltaCUDADisabled = true
-		return
-	}
-
-	inputs, freeInputs, ok := cStringVector([]string{"q", "k", "v", "g", "beta", "state_in", "T"})
-	if !ok {
-		gatedDeltaCUDADisabled = true
-		freeInputs()
-		return
-	}
-	defer freeInputs()
-
-	outputs, freeOutputs, ok := cStringVector([]string{"y", "state_out"})
-	if !ok {
-		gatedDeltaCUDADisabled = true
-		freeOutputs()
-		return
-	}
-	defer freeOutputs()
-
-	cName := C.CString("gated_delta_step")
-	defer C.free(unsafe.Pointer(cName))
-	cSource := C.CString(gatedDeltaCUDAKernelSource)
-	defer C.free(unsafe.Pointer(cSource))
-	cHeader := C.CString("")
-	defer C.free(unsafe.Pointer(cHeader))
-
-	gatedDeltaCUDAKernel = C.mlx_fast_cuda_kernel_new(
-		cName,
-		inputs,
-		outputs,
-		cSource,
-		cHeader,
-		C.bool(true),
-		C.int(0),
-	)
-}
-
-func gatedDeltaCUDAKernelApply(q, k, v, g, beta, state *Array) (y, nextState *Array, ok bool) {
-	if gatedDeltaCUDADisabled {
-		return nil, nil, false
-	}
-	if q == nil || k == nil || v == nil || g == nil || beta == nil || state == nil {
-		return nil, nil, false
-	}
-
-	qd := q.Dims()
-	kd := k.Dims()
-	vd := v.Dims()
-	gd := g.Dims()
-	bd := beta.Dims()
-	sd := state.Dims()
-	if len(qd) != 4 || len(kd) != 4 || len(vd) != 4 || len(gd) != 3 || len(bd) != 3 || len(sd) != 4 {
-		return nil, nil, false
-	}
-
-	B, T, Hk, Dk := qd[0], qd[1], qd[2], qd[3]
-	if T <= 0 || Hk <= 0 || Dk <= 0 || Dk%32 != 0 {
-		return nil, nil, false
-	}
-	if kd[0] != B || kd[1] != T || kd[2] != Hk || kd[3] != Dk {
-		return nil, nil, false
-	}
-	Hv, Dv := vd[2], vd[3]
-	if vd[0] != B || vd[1] != T || Hv <= 0 || Dv <= 0 || Hv%Hk != 0 {
-		return nil, nil, false
-	}
-	if gd[0] != B || gd[1] != T || gd[2] != Hv {
-		return nil, nil, false
-	}
-	if bd[0] != B || bd[1] != T || bd[2] != Hv {
-		return nil, nil, false
-	}
-	if sd[0] != B || sd[1] != Hv || sd[2] != Dv || sd[3] != Dk {
-		return nil, nil, false
-	}
-
-	inputDType := q.DType()
-	stateDType := state.DType()
-	if k.DType() != inputDType || v.DType() != inputDType || g.DType() != inputDType || beta.DType() != inputDType {
-		return nil, nil, false
-	}
-
-	gatedDeltaCUDAKernelOnce.Do(initGatedDeltaCUDAKernel)
-	if gatedDeltaCUDADisabled {
-		return nil, nil, false
-	}
-
-	cfg := C.mlx_fast_cuda_kernel_config_new()
-	defer C.mlx_fast_cuda_kernel_config_free(cfg)
-
-	cInT := C.CString("InT")
-	defer C.free(unsafe.Pointer(cInT))
-	if C.mlx_fast_cuda_kernel_config_add_template_arg_dtype(cfg, cInT, C.mlx_dtype(inputDType)) != 0 {
-		gatedDeltaCUDADisabled = true
-		return nil, nil, false
-	}
-	cStT := C.CString("StT")
-	defer C.free(unsafe.Pointer(cStT))
-	if C.mlx_fast_cuda_kernel_config_add_template_arg_dtype(cfg, cStT, C.mlx_dtype(stateDType)) != 0 {
-		gatedDeltaCUDADisabled = true
-		return nil, nil, false
-	}
-	for _, tpl := range []struct {
-		name  string
-		value int
-	}{
-		{name: "Dk", value: Dk},
-		{name: "Dv", value: Dv},
-		{name: "Hk", value: Hk},
-		{name: "Hv", value: Hv},
-	} {
-		cn := C.CString(tpl.name)
-		rc := C.mlx_fast_cuda_kernel_config_add_template_arg_int(cfg, cn, C.int(tpl.value))
-		C.free(unsafe.Pointer(cn))
-		if rc != 0 {
-			gatedDeltaCUDADisabled = true
-			return nil, nil, false
-		}
-	}
-
-	yShape := []C.int{C.int(B), C.int(T), C.int(Hv), C.int(Dv)}
-	stateShape := []C.int{C.int(B), C.int(Hv), C.int(Dv), C.int(Dk)}
-	if C.mlx_fast_cuda_kernel_config_add_output_arg(cfg, unsafe.SliceData(yShape), C.size_t(len(yShape)), C.mlx_dtype(inputDType)) != 0 {
-		gatedDeltaCUDADisabled = true
-		return nil, nil, false
-	}
-	if C.mlx_fast_cuda_kernel_config_add_output_arg(cfg, unsafe.SliceData(stateShape), C.size_t(len(stateShape)), C.mlx_dtype(stateDType)) != 0 {
-		gatedDeltaCUDADisabled = true
-		return nil, nil, false
-	}
-	if C.mlx_fast_cuda_kernel_config_set_grid(cfg, 32, C.int(Dv), C.int(B*Hv)) != 0 {
-		gatedDeltaCUDADisabled = true
-		return nil, nil, false
-	}
-	threadY := Dv
-	if threadY > 4 {
-		threadY = 4
-	}
-	if C.mlx_fast_cuda_kernel_config_set_thread_group(cfg, 32, C.int(threadY), 1) != 0 {
-		gatedDeltaCUDADisabled = true
-		return nil, nil, false
-	}
-
-	tScalar := FromValue(T)
-	inputs := []C.mlx_array{
-		q.ctx,
-		k.ctx,
-		v.ctx,
-		g.ctx,
-		beta.ctx,
-		state.ctx,
-		tScalar.ctx,
-	}
-	inVec := C.mlx_vector_array_new_data(unsafe.SliceData(inputs), C.size_t(len(inputs)))
-	defer C.mlx_vector_array_free(inVec)
-
-	outVec := C.mlx_vector_array_new()
-	defer C.mlx_vector_array_free(outVec)
-	if C.mlx_fast_cuda_kernel_apply(&outVec, gatedDeltaCUDAKernel, inVec, cfg, DefaultStream().ctx) != 0 {
-		gatedDeltaCUDADisabled = true
-		return nil, nil, false
-	}
-	if int(C.mlx_vector_array_size(outVec)) < 2 {
-		return nil, nil, false
-	}
-
-	y = New("GATED_DELTA_CUDA_Y")
-	nextState = New("GATED_DELTA_CUDA_STATE")
-	C.mlx_vector_array_get(&y.ctx, outVec, 0)
-	C.mlx_vector_array_get(&nextState.ctx, outVec, 1)
-	return y, nextState, true
-}
-
 // FastGatedDelta runs the recurrent update operation.
 //
 // When mask is non-nil, it must be a [B, T] bool tensor identifying real
@@ -628,8 +298,9 @@ func gatedDeltaCUDAKernelApply(q, k, v, g, beta, state *Array) (y, nextState *Ar
 // kernel iteration is a no-op — state passes through unchanged and the
 // final state equals the state after the last real token of each row.
 //
-// It tries the fused CUDA kernel first, then Metal, then falls back to a
-// backend-agnostic MLX implementation with identical inputs/outputs.
+// Inputs that fit the GPU kernels' contract run there (CUDA or Metal, with
+// the graph implementation covering boxes where neither can run); anything
+// else runs the graph implementation directly.
 func FastGatedDelta(q, k, v, g, beta, state, mask *Array) (y, nextState *Array) {
 	// TODO: handle this more efficiently with a masked kernel (MLX-LM has one).
 	if mask != nil {
@@ -649,12 +320,21 @@ func FastGatedDelta(q, k, v, g, beta, state, mask *Array) (y, nextState *Array) 
 		g = Where(m3, g, oneG)
 	}
 
-	if y, nextState, ok := gatedDeltaCUDAKernelApply(q, k, v, g, beta, state); ok {
-		return y, nextState
+	if dims, ok := resolveGatedDeltaDims(q, k, v, g, beta, state); ok {
+		outs := gatedDelta.run(gpuLaunch{
+			dtypes: []gpuDTypeArg{{"InT", q.DType()}, {"StT", state.DType()}},
+			ints:   []gpuIntArg{{"Dk", dims.Dk}, {"Dv", dims.Dv}, {"Hk", dims.Hk}, {"Hv", dims.Hv}},
+			outputs: []gpuOutputSpec{
+				{"GATED_DELTA_Y", []int32{int32(dims.B), int32(dims.T), int32(dims.Hv), int32(dims.Dv)}, q.DType()},
+				{"GATED_DELTA_STATE", []int32{int32(dims.B), int32(dims.Hv), int32(dims.Dv), int32(dims.Dk)}, state.DType()},
+			},
+			grid:        [3]int{32, dims.Dv, dims.B * dims.Hv},
+			threadGroup: [3]int{32, min(dims.Dv, 4), 1},
+			inputs:      []*Array{q, k, v, g, beta, state, FromValue(dims.T)},
+		})
+		return outs[0], outs[1]
 	}
-	if y, nextState, ok := gatedDeltaKernel(q, k, v, g, beta, state); ok {
-		return y, nextState
-	}
+
 	y, nextState = gatedDeltaFallback(q, k, v, g, beta, state)
 	if y == nil || nextState == nil {
 		panic("mlx.FastGatedDelta: fallback failed (invalid inputs or unsupported shapes)")

--- a/x/mlxrunner/mlx/gated_delta.go
+++ b/x/mlxrunner/mlx/gated_delta.go
@@ -1,19 +1,21 @@
 package mlx
 
-var gatedDelta = &gpuKernel{
-	name:    "gated_delta_step",
+import "math"
+
+var gatedDeltaRecurrenceKernel = &gpuKernel{
+	name:    "gated_delta_recurrence",
 	inputs:  []string{"q", "k", "v", "g", "beta", "state_in", "T"},
 	outputs: []string{"y", "state_out"},
-	metal:   gpuSource{source: gatedDeltaMetalKernelSource},
-	cuda:    gpuSource{source: gatedDeltaCUDAKernelSource},
+	metal:   gpuSource{source: gatedDeltaRecurrenceMetalSource},
+	cuda:    gpuSource{source: gatedDeltaRecurrenceCUDASource},
 	fallback: func(launch gpuLaunch) []*Array {
 		in := launch.inputs
-		y, state := gatedDeltaFallback(in[0], in[1], in[2], in[3], in[4], in[5])
+		y, state := gatedDeltaRecurrenceGraph(in[0], in[1], in[2], in[3], in[4], in[5])
 		return []*Array{y, state}
 	},
 }
 
-const gatedDeltaMetalKernelSource = `
+const gatedDeltaRecurrenceMetalSource = `
 auto n = thread_position_in_grid.z;
 auto b_idx = n / Hv;
 auto hv_idx = n % Hv;
@@ -81,7 +83,7 @@ for (int i = 0; i < n_per_t; ++i) {
 }
 `
 
-const gatedDeltaCUDAKernelSource = `
+const gatedDeltaRecurrenceCUDASource = `
 auto tid_x = threadIdx.x;
 auto tid_y = threadIdx.y;
 auto grid_y = blockIdx.y * blockDim.y + tid_y;
@@ -161,18 +163,18 @@ for (int i = 0; i < n_per_t; ++i) {
 }
 `
 
-// gatedDeltaDims are the batch and head geometry of one scan, recovered
-// from the input shapes.
-type gatedDeltaDims struct {
+// gatedDeltaRecurrenceDims are the batch and head geometry of one scan,
+// recovered from the input shapes.
+type gatedDeltaRecurrenceDims struct {
 	B, T, Hk, Dk, Hv, Dv int
 }
 
-// resolveGatedDeltaDims validates the inputs against the GPU kernels'
-// contract and recovers the launch geometry. ok=false routes to the graph
-// fallback: shapes that disagree, Dk not a multiple of the 32-lane simd
-// width, or mixed input dtypes.
-func resolveGatedDeltaDims(q, k, v, g, beta, state *Array) (gatedDeltaDims, bool) {
-	var dims gatedDeltaDims
+// resolveGatedDeltaRecurrenceDims validates the inputs against the GPU
+// kernels' contract and recovers the launch geometry. ok=false routes to
+// the graph implementation: shapes that disagree, Dk not a multiple of the
+// 32-lane simd width, or mixed input dtypes.
+func resolveGatedDeltaRecurrenceDims(q, k, v, g, beta, state *Array) (gatedDeltaRecurrenceDims, bool) {
+	var dims gatedDeltaRecurrenceDims
 	if q == nil || k == nil || v == nil || g == nil || beta == nil || state == nil {
 		return dims, false
 	}
@@ -216,7 +218,7 @@ func repeatHeadsForGatedDelta(x *Array, repeatFactor int) *Array {
 	return Reshape(x, int32(shape[0]), int32(shape[1]), int32(shape[2]*repeatFactor), int32(shape[3]))
 }
 
-func gatedDeltaFallback(q, k, v, g, beta, state *Array) (y, nextState *Array) {
+func gatedDeltaRecurrenceGraph(q, k, v, g, beta, state *Array) (y, nextState *Array) {
 	if q == nil || k == nil || v == nil || g == nil || beta == nil || state == nil {
 		return nil, nil
 	}
@@ -290,43 +292,18 @@ func gatedDeltaFallback(q, k, v, g, beta, state *Array) (y, nextState *Array) {
 	return Concatenate(outs, 1), nextState
 }
 
-// FastGatedDelta runs the recurrent update operation.
-//
-// When mask is non-nil, it must be a [B, T] bool tensor identifying real
-// (true) vs. padded (false) positions in q/k/v/g/beta. Padded positions
-// are substituted with neutral values (q=k=v=beta=0, g=1) so each padded
-// kernel iteration is a no-op — state passes through unchanged and the
-// final state equals the state after the last real token of each row.
-//
-// Inputs that fit the GPU kernels' contract run there (CUDA or Metal, with
-// the graph implementation covering boxes where neither can run); anything
-// else runs the graph implementation directly.
-func FastGatedDelta(q, k, v, g, beta, state, mask *Array) (y, nextState *Array) {
-	// TODO: handle this more efficiently with a masked kernel (MLX-LM has one).
-	if mask != nil {
-		B := int32(mask.Dim(0))
-		T := int32(mask.Dim(1))
-		m4 := Reshape(mask, B, T, 1, 1)
-		m3 := Reshape(mask, B, T, 1)
-		zeroQ := FromValue(float32(0)).AsType(q.DType())
-		zeroK := FromValue(float32(0)).AsType(k.DType())
-		zeroV := FromValue(float32(0)).AsType(v.DType())
-		zeroBeta := FromValue(float32(0)).AsType(beta.DType())
-		oneG := FromValue(float32(1)).AsType(g.DType())
-		q = Where(m4, q, zeroQ)
-		k = Where(m4, k, zeroK)
-		v = Where(m4, v, zeroV)
-		beta = Where(m3, beta, zeroBeta)
-		g = Where(m3, g, oneG)
-	}
-
-	if dims, ok := resolveGatedDeltaDims(q, k, v, g, beta, state); ok {
-		outs := gatedDelta.run(gpuLaunch{
+// gatedDeltaRecurrence runs the scan. Inputs that fit the GPU kernels'
+// contract run there (CUDA or Metal, with the graph implementation covering
+// boxes where neither can run); anything else runs the graph implementation
+// directly.
+func gatedDeltaRecurrence(q, k, v, g, beta, state *Array) (y, nextState *Array) {
+	if dims, ok := resolveGatedDeltaRecurrenceDims(q, k, v, g, beta, state); ok {
+		outs := gatedDeltaRecurrenceKernel.run(gpuLaunch{
 			dtypes: []gpuDTypeArg{{"InT", q.DType()}, {"StT", state.DType()}},
 			ints:   []gpuIntArg{{"Dk", dims.Dk}, {"Dv", dims.Dv}, {"Hk", dims.Hk}, {"Hv", dims.Hv}},
 			outputs: []gpuOutputSpec{
-				{"GATED_DELTA_Y", []int32{int32(dims.B), int32(dims.T), int32(dims.Hv), int32(dims.Dv)}, q.DType()},
-				{"GATED_DELTA_STATE", []int32{int32(dims.B), int32(dims.Hv), int32(dims.Dv), int32(dims.Dk)}, state.DType()},
+				{"GATED_DELTA_RECURRENCE_Y", []int32{int32(dims.B), int32(dims.T), int32(dims.Hv), int32(dims.Dv)}, q.DType()},
+				{"GATED_DELTA_RECURRENCE_STATE", []int32{int32(dims.B), int32(dims.Hv), int32(dims.Dv), int32(dims.Dk)}, state.DType()},
 			},
 			grid:        [3]int{32, dims.Dv, dims.B * dims.Hv},
 			threadGroup: [3]int{32, min(dims.Dv, 4), 1},
@@ -335,9 +312,391 @@ func FastGatedDelta(q, k, v, g, beta, state, mask *Array) (y, nextState *Array) 
 		return outs[0], outs[1]
 	}
 
-	y, nextState = gatedDeltaFallback(q, k, v, g, beta, state)
+	y, nextState = gatedDeltaRecurrenceGraph(q, k, v, g, beta, state)
 	if y == nil || nextState == nil {
-		panic("mlx.FastGatedDelta: fallback failed (invalid inputs or unsupported shapes)")
+		panic("mlx: gated-delta recurrence: invalid inputs or unsupported shapes")
 	}
 	return y, nextState
+}
+
+// gatedDeltaMaxTokens caps the fused scan length at the current token plus
+// a ten-token draft — several times the depth the EV controller selects in
+// practice. SeqT is a template argument, so every accepted length compiles
+// its own pipeline variant; the cap bounds that set, and longer windows run
+// the same step as graph ops.
+const gatedDeltaMaxTokens = 11
+
+var (
+	gatedDelta = &gpuKernel{
+		name:    "gated_delta",
+		inputs:  []string{"packed", "ba", "dt_bias", "a_exp", "qk_scale", "state_in"},
+		outputs: []string{"y", "state_out"},
+		metal: gpuSource{
+			source: gatedDeltaMetalSource,
+			header: gatedDeltaMetalHeader + "#define GDN_STORE_INTERIOR(index, value)\n",
+		},
+		fallback: func(launch gpuLaunch) []*Array {
+			in := launch.inputs
+			y, end, _ := gatedDeltaGraph(in[0], in[1], in[2], in[3], in[5], false)
+			return []*Array{y, end}
+		},
+	}
+	gatedDeltaStates = &gpuKernel{
+		name:    "gated_delta_states",
+		inputs:  []string{"packed", "ba", "dt_bias", "a_exp", "qk_scale", "state_in"},
+		outputs: []string{"y", "state_out", "state_seq"},
+		metal: gpuSource{
+			source: gatedDeltaMetalSource,
+			header: gatedDeltaMetalHeader + "#define GDN_STORE_INTERIOR(index, value) state_seq[index] = value\n",
+		},
+		fallback: func(launch gpuLaunch) []*Array {
+			in := launch.inputs
+			y, end, interior := gatedDeltaGraph(in[0], in[1], in[2], in[3], in[5], true)
+			for i, s := range interior {
+				interior[i] = ExpandDims(s, 0)
+			}
+			return []*Array{y, end, Concatenate(interior, 0)}
+		},
+	}
+)
+
+// gatedDeltaGraph is the graph implementation of the fused gated-delta step
+// over the kernels' contract domain: q/k RMS norm and scaling, the decay
+// gate, and the (per-token, for captureAll) scan. Geometry is recovered
+// from the packed and state shapes, and the q/k scales are recomputed from
+// Dk with the same bits the kernel input carries.
+func gatedDeltaGraph(packed, ba, dtBias, aExp, state *Array, captureAll bool) (y, nextState *Array, interior []*Array) {
+	B, T := int32(packed.Dim(0)), int32(packed.Dim(1))
+	sd := state.Dims()
+	Hv, Dv, Dk := int32(sd[1]), int32(sd[2]), int32(sd[3])
+	keyDim := (int32(packed.Dim(2)) - Hv*Dv) / 2
+	Hk := keyDim / Dk
+
+	q := SliceStartStop(packed, []int32{0, 0, 0}, []int32{B, T, keyDim})
+	k := SliceStartStop(packed, []int32{0, 0, keyDim}, []int32{B, T, 2 * keyDim})
+	v := SliceStartStop(packed, []int32{0, 0, 2 * keyDim}, []int32{B, T, 2*keyDim + Hv*Dv})
+	q = Reshape(q, B, T, Hk, Dk)
+	k = Reshape(k, B, T, Hk, Dk)
+	v = Reshape(v, B, T, Hv, Dv)
+	invScale := gatedDeltaInvScale(int(Dk))
+	q = MulScalar(RMSNormFn(q, nil, 1e-6), invScale*invScale)
+	k = MulScalar(RMSNormFn(k, nil, 1e-6), invScale)
+
+	beta := SliceStartStop(ba, []int32{0, 0, 0}, []int32{B, T, Hv})
+	alpha := SliceStartStop(ba, []int32{0, 0, Hv}, []int32{B, T, 2 * Hv})
+	decay := Softplus(Add(alpha, dtBias))
+	decay = Mul(decay, aExp)
+	decay = Exp(MulScalar(decay, -1)).AsType(alpha.DType())
+	betaGate := Sigmoid(beta)
+
+	if !captureAll || T == 1 {
+		y, nextState = gatedDeltaRecurrence(q, k, v, decay, betaGate, state)
+		return y, nextState, nil
+	}
+
+	sliceT := func(a *Array, t int32) *Array {
+		dims := a.Dims()
+		start := make([]int32, len(dims))
+		stop := make([]int32, len(dims))
+		for d := range dims {
+			stop[d] = int32(dims[d])
+		}
+		start[1], stop[1] = t, t+1
+		return SliceStartStop(a, start, stop)
+	}
+	outs := make([]*Array, T)
+	for t := range T {
+		outs[t], state = gatedDeltaRecurrence(sliceT(q, t), sliceT(k, t), sliceT(v, t), sliceT(decay, t), sliceT(betaGate, t), state)
+		if t+1 < T {
+			interior = append(interior, state)
+		}
+	}
+	return Concatenate(outs, 1), state, interior
+}
+
+// The fused scan consumes the activated causal-conv output rows [q | k | v]
+// plus the packed [beta | alpha] projection and performs q/k RMS norm and
+// scaling, the decay gate, and the gated-delta recurrence in one launch.
+const gatedDeltaMetalSource = `
+constexpr int SIMDGroups = 4;
+constexpr int ValuesPerSIMD = DvTile / SIMDGroups;
+constexpr int StatePerLane = Dk / 32;
+constexpr int QDim = Hk * Dk;
+
+auto lane = thread_position_in_threadgroup.x;
+auto simd_idx = thread_position_in_threadgroup.y;
+auto n = thread_position_in_grid.z;
+auto b_idx = n / Hv;
+auto hv_idx = n % Hv;
+auto hk_idx = hv_idx / (Hv / Hk);
+auto value_tile = threadgroup_position_in_grid.y;
+
+threadgroup InT q_cache[Dk];
+threadgroup InT k_cache[Dk];
+threadgroup InT decay_cache[1];
+threadgroup InT beta_cache[1];
+
+float state[ValuesPerSIMD][StatePerLane];
+for (int value_iter = 0; value_iter < ValuesPerSIMD; ++value_iter) {
+  auto dv_idx = value_tile * DvTile + simd_idx + value_iter * SIMDGroups;
+  auto state_offset = (n * Dv + dv_idx) * Dk;
+  for (int i = 0; i < StatePerLane; ++i) {
+    auto d = StatePerLane * lane + i;
+    state[value_iter][i] = state_in[state_offset + d];
+  }
+}
+
+for (int t = 0; t < SeqT; ++t) {
+  if (simd_idx == 0) {
+    auto token = packed + (b_idx * SeqT + t) * PackedDim;
+    float q_values[StatePerLane];
+    float k_values[StatePerLane];
+    float q_squares = 0.0f;
+    float k_squares = 0.0f;
+
+    for (int i = 0; i < StatePerLane; ++i) {
+      auto d = StatePerLane * lane + i;
+      float q_value = static_cast<float>(token[hk_idx * Dk + d]);
+      float k_value = static_cast<float>(token[QDim + hk_idx * Dk + d]);
+      q_values[i] = q_value;
+      k_values[i] = k_value;
+      q_squares += q_value * q_value;
+      k_squares += k_value * k_value;
+    }
+
+    q_squares = simd_sum(q_squares);
+    k_squares = simd_sum(k_squares);
+    float q_inv_rms = metal::precise::rsqrt(q_squares / float(Dk) + 1.0e-6f);
+    float k_inv_rms = metal::precise::rsqrt(k_squares / float(Dk) + 1.0e-6f);
+    InT q_scale = static_cast<InT>(qk_scale[0]);
+    InT k_scale = static_cast<InT>(qk_scale[1]);
+    for (int i = 0; i < StatePerLane; ++i) {
+      auto d = StatePerLane * lane + i;
+      InT q_norm = static_cast<InT>(q_values[i] * q_inv_rms);
+      InT k_norm = static_cast<InT>(k_values[i] * k_inv_rms);
+      q_cache[d] = static_cast<InT>(q_norm * q_scale);
+      k_cache[d] = static_cast<InT>(k_norm * k_scale);
+    }
+
+    if (lane == 0) {
+      auto ba_row = (b_idx * SeqT + t) * 2 * Hv;
+      InT gate_input = static_cast<InT>(ba[ba_row + Hv + hv_idx] + dt_bias[hv_idx]);
+      InT softplus = gdn_logaddexp(gate_input, static_cast<InT>(0));
+      float decay = metal::precise::exp(-static_cast<float>(softplus) * a_exp[hv_idx]);
+      decay_cache[0] = static_cast<InT>(decay);
+      beta_cache[0] = gdn_sigmoid(ba[ba_row + hv_idx]);
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  for (int value_iter = 0; value_iter < ValuesPerSIMD; ++value_iter) {
+    auto dv_idx = value_tile * DvTile + simd_idx + value_iter * SIMDGroups;
+    float projection = 0.0f;
+    for (int i = 0; i < StatePerLane; ++i) {
+      auto d = StatePerLane * lane + i;
+      state[value_iter][i] *= static_cast<float>(decay_cache[0]);
+      projection += state[value_iter][i] * static_cast<float>(k_cache[d]);
+    }
+    projection = simd_sum(projection);
+
+    auto token = packed + (b_idx * SeqT + t) * PackedDim;
+    float v_value = static_cast<float>(token[2 * QDim + hv_idx * Dv + dv_idx]);
+    float delta = (v_value - projection) * static_cast<float>(beta_cache[0]);
+
+    float out = 0.0f;
+    for (int i = 0; i < StatePerLane; ++i) {
+      auto d = StatePerLane * lane + i;
+      state[value_iter][i] += static_cast<float>(k_cache[d]) * delta;
+      out += state[value_iter][i] * static_cast<float>(q_cache[d]);
+    }
+    out = simd_sum(out);
+    if (lane == 0) {
+      y[((b_idx * SeqT + t) * Hv + hv_idx) * Dv + dv_idx] = static_cast<InT>(out);
+    }
+
+    if (t + 1 < SeqT) {
+      auto seq_offset = ((t * threads_per_grid.z + n) * Dv + dv_idx) * Dk;
+      for (int i = 0; i < StatePerLane; ++i) {
+        auto d = StatePerLane * lane + i;
+        GDN_STORE_INTERIOR(seq_offset + d, state[value_iter][i]);
+      }
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+}
+
+for (int value_iter = 0; value_iter < ValuesPerSIMD; ++value_iter) {
+  auto dv_idx = value_tile * DvTile + simd_idx + value_iter * SIMDGroups;
+  auto state_offset = (n * Dv + dv_idx) * Dk;
+  for (int i = 0; i < StatePerLane; ++i) {
+    auto d = StatePerLane * lane + i;
+    state_out[state_offset + d] = state[value_iter][i];
+  }
+}
+`
+
+const gatedDeltaMetalHeader = `
+template <typename T>
+T gdn_sigmoid(T x) {
+  auto y = 1 / (1 + metal::exp(metal::abs(x)));
+  return (x < 0) ? y : 1 - y;
+}
+
+template <typename T>
+T gdn_logaddexp(T x, T y) {
+  if (metal::isnan(x) || metal::isnan(y)) {
+    return metal::numeric_limits<T>::quiet_NaN();
+  }
+  constexpr T inf = metal::numeric_limits<T>::infinity();
+  T maxval = metal::max(x, y);
+  T minval = metal::min(x, y);
+  return (minval == -inf || maxval == inf)
+      ? maxval
+      : (maxval + log1p(metal::exp(minval - maxval)));
+}
+`
+
+// gatedDeltaInvScale is the q/k norm scale for key dimension dk; the
+// kernel's qk_scale input and the graph implementation share these bits.
+func gatedDeltaInvScale(dk int) float32 {
+	return float32(1.0 / math.Sqrt(float64(dk)))
+}
+
+// gatedDeltaDims are the batch and head geometry the kernel is instantiated
+// for, recovered from the input shapes.
+type gatedDeltaDims struct {
+	B, Hk, Dk, Hv, Dv, PackedDim, T int
+}
+
+// GatedDelta runs the whole gated-delta step — q/k norms, decay gate, and
+// the scan — in one launch over the activated causal-conv output. packed is
+// [B, T, 2*Hk*Dk + Hv*Dv] with rows packed [q | k | v], ba is [B, T, 2*Hv]
+// packed [beta | alpha] rows, and state is [B, Hv, Dv, Dk]. captureAll
+// additionally emits every interior per-token state. Inputs that fit the
+// one-launch kernels' contract run there; anything else runs the same step
+// as graph ops.
+//
+// When mask is non-nil, it must be a [B, T] bool tensor identifying real
+// (true) vs. padded (false) positions. Padded rows are neutralized before
+// the kernels' own preprocessing: zeroed conv rows make the q/k/v norms
+// emit zeros, and -inf beta/alpha rows yield beta 0 and decay 1, so each
+// padded position is an identity step with zero output, exactly as on the
+// recurrence path.
+func GatedDelta(packed, ba, dtBias, aExp, state, mask *Array, captureAll bool) (y, nextState *Array, interior []*Array) {
+	if mask != nil {
+		mask3 := Reshape(mask, int32(mask.Dim(0)), int32(mask.Dim(1)), 1)
+		zero := FromValue(float32(0)).AsType(packed.DType())
+		packed = Where(mask3, packed, zero)
+		negInf := FromValue(float32(math.Inf(-1))).AsType(ba.DType())
+		ba = Where(mask3, ba, negInf)
+	}
+
+	dims, ok := resolveGatedDeltaDims(packed, ba, dtBias, aExp, state)
+	if !ok {
+		return gatedDeltaGraph(packed, ba, dtBias, aExp, state, captureAll)
+	}
+
+	inv := gatedDeltaInvScale(dims.Dk)
+	qkScale := FromValues([]float32{inv * inv, inv}, 2)
+	dvTile := 32
+	if dims.Dv%dvTile != 0 {
+		// resolveGatedDeltaDims guarantees Dv%16 == 0.
+		dvTile = 16
+	}
+	useAllStates := captureAll && dims.T > 1
+	kernel := gatedDelta
+	outputs := []gpuOutputSpec{
+		{"GATED_DELTA_Y", []int32{int32(dims.B), int32(dims.T), int32(dims.Hv), int32(dims.Dv)}, packed.DType()},
+		{"GATED_DELTA_STATE", []int32{int32(dims.B), int32(dims.Hv), int32(dims.Dv), int32(dims.Dk)}, DTypeFloat32},
+	}
+	if useAllStates {
+		kernel = gatedDeltaStates
+		outputs = append(outputs, gpuOutputSpec{
+			"GATED_DELTA_STATE_SEQ", []int32{int32(dims.T - 1), int32(dims.B), int32(dims.Hv), int32(dims.Dv), int32(dims.Dk)}, DTypeFloat32,
+		})
+	}
+
+	outs := kernel.run(gpuLaunch{
+		dtypes: []gpuDTypeArg{{"InT", packed.DType()}},
+		ints: []gpuIntArg{
+			{"Hk", dims.Hk},
+			{"Dk", dims.Dk},
+			{"Hv", dims.Hv},
+			{"Dv", dims.Dv},
+			{"PackedDim", dims.PackedDim},
+			{"SeqT", dims.T},
+			{"DvTile", dvTile},
+		},
+		outputs:     outputs,
+		grid:        [3]int{32, (dims.Dv / dvTile) * 4, dims.B * dims.Hv},
+		threadGroup: [3]int{32, 4, 1},
+		inputs:      []*Array{packed, ba, dtBias, aExp, qkScale, state},
+	})
+	if useAllStates {
+		interior = sliceGatedDeltaStates(outs[2], dims)
+	}
+	return outs[0], outs[1], interior
+}
+
+func resolveGatedDeltaDims(packed, ba, dtBias, aExp, state *Array) (gatedDeltaDims, bool) {
+	var dims gatedDeltaDims
+	if packed == nil || ba == nil || dtBias == nil || aExp == nil || state == nil {
+		return dims, false
+	}
+	sd := state.Dims()
+	if len(sd) != 4 || sd[0] < 1 {
+		return dims, false
+	}
+	dims.B, dims.Hv, dims.Dv, dims.Dk = sd[0], sd[1], sd[2], sd[3]
+
+	pd := packed.Dims()
+	if len(pd) != 3 || pd[0] != dims.B || pd[1] < 1 || pd[1] > gatedDeltaMaxTokens {
+		return dims, false
+	}
+	dims.T, dims.PackedDim = pd[1], pd[2]
+
+	keyRows := dims.PackedDim - dims.Hv*dims.Dv
+	if keyRows <= 0 || dims.Dk <= 0 || keyRows%(2*dims.Dk) != 0 {
+		return dims, false
+	}
+	dims.Hk = keyRows / (2 * dims.Dk)
+	if dims.Hk <= 0 || dims.Hv%dims.Hk != 0 || dims.Dk%32 != 0 || dims.Dv%16 != 0 {
+		return dims, false
+	}
+
+	if !exactShape(ba, dims.B, dims.T, 2*dims.Hv) ||
+		!exactShape(dtBias, dims.Hv) ||
+		!exactShape(aExp, dims.Hv) {
+		return dims, false
+	}
+	if packed.DType() != DTypeBFloat16 || ba.DType() != DTypeBFloat16 ||
+		dtBias.DType() != DTypeBFloat16 || aExp.DType() != DTypeFloat32 ||
+		state.DType() != DTypeFloat32 {
+		return dims, false
+	}
+	return dims, true
+}
+
+func sliceGatedDeltaStates(stateSeq *Array, dims gatedDeltaDims) []*Array {
+	interior := make([]*Array, dims.T-1)
+	for t := range interior {
+		s := SliceStartStop(stateSeq,
+			[]int32{int32(t), 0, 0, 0, 0},
+			[]int32{int32(t) + 1, int32(dims.B), int32(dims.Hv), int32(dims.Dv), int32(dims.Dk)})
+		interior[t] = Reshape(s, int32(dims.B), int32(dims.Hv), int32(dims.Dv), int32(dims.Dk))
+	}
+	return interior
+}
+
+func exactShape(value *Array, shape ...int) bool {
+	dims := value.Dims()
+	if len(dims) != len(shape) {
+		return false
+	}
+	for i := range shape {
+		if dims[i] != shape[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/x/mlxrunner/mlx/gated_delta_test.go
+++ b/x/mlxrunner/mlx/gated_delta_test.go
@@ -1,0 +1,242 @@
+package mlx
+
+import (
+	"fmt"
+	"math"
+	"testing"
+)
+
+type gatedDeltaTestGeometry struct {
+	Hk, Dk, Hv, Dv int
+}
+
+func (g gatedDeltaTestGeometry) packedDim() int { return 2*g.Hk*g.Dk + g.Hv*g.Dv }
+
+type gatedDeltaTestInputs struct {
+	packed, ba, dtBias, aExp, state *Array
+}
+
+func gatedDeltaTestInputs36(g gatedDeltaTestGeometry, T int) gatedDeltaTestInputs {
+	return gatedDeltaTestInputs{
+		packed: patternArray(DTypeBFloat16, []int{1, T, g.packedDim()}, 0.01, 0.003, 37, 257),
+		ba:     patternArray(DTypeBFloat16, []int{1, T, 2 * g.Hv}, 0, 0.4, 13, 37),
+		dtBias: patternArray(DTypeBFloat16, []int{g.Hv}, -2.5, 0.08, 5, 29),
+		aExp:   patternArray(DTypeFloat32, []int{g.Hv}, 0.12, 0.002, 3, 19),
+		state:  patternArray(DTypeFloat32, []int{1, g.Hv, g.Dv, g.Dk}, 0, 0.0001, 17, 101),
+	}
+}
+
+// gatedDeltaReference runs the graph implementation the fused kernels fall
+// back to; the test pins the kernels against it bit-for-bit.
+func gatedDeltaReference(in gatedDeltaTestInputs, captureAll bool) (y, nextState *Array, interior []*Array) {
+	return gatedDeltaGraph(in.packed, in.ba, in.dtBias, in.aExp, in.state, captureAll)
+}
+
+// Exactness is per compiler pair: the metallib and the runtime JIT round
+// metal::exp a float ulp apart, which after bf16 rounding leaves rare
+// differing inputs (beta sigmoid at -6.84375); the lattice here avoids them.
+func TestGatedDeltaMatchesGraph(t *testing.T) {
+	skipIfNoMLX(t)
+	withMLXThread(t, func() {
+		testGatedDeltaMatchesGraph(t)
+	})
+}
+
+func testGatedDeltaMatchesGraph(t *testing.T) {
+	geometries := []gatedDeltaTestGeometry{
+		{Hk: 16, Dk: 128, Hv: 32, Dv: 128},
+		{Hk: 4, Dk: 64, Hv: 8, Dv: 32},
+	}
+	for _, g := range geometries {
+		for T := 1; T <= gatedDeltaMaxTokens; T++ {
+			for _, B := range []int{1, 3} {
+				for _, captureAll := range []bool{false, true} {
+					name := fmt.Sprintf("hk%d_dk%d_T%d_B%d_all%v", g.Hk, g.Dk, T, B, captureAll)
+					in := batchGatedDeltaRows(gatedDeltaTestInputs36(g, T), B)
+					refY, refState, refInterior := gatedDeltaReference(in, captureAll)
+					y, state, interior := GatedDelta(in.packed, in.ba, in.dtBias, in.aExp, in.state, nil, captureAll)
+					if err := requireExact("y", y, refY); err != nil {
+						t.Fatalf("%s: %v", name, err)
+					}
+					if err := requireExact("state", state, refState); err != nil {
+						t.Fatalf("%s: %v", name, err)
+					}
+					if captureAll && len(interior) != len(refInterior) {
+						t.Fatalf("%s: interior count = %d, want %d", name, len(interior), len(refInterior))
+					}
+					for i := range interior {
+						if err := requireExact(fmt.Sprintf("interior[%d]", i), interior[i], refInterior[i]); err != nil {
+							t.Fatalf("%s: %v", name, err)
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestGatedDeltaGraphRouting(t *testing.T) {
+	skipIfNoMLX(t)
+	withMLXThread(t, func() {
+		testGatedDeltaGraphRouting(t)
+	})
+}
+
+// Contract misses — T beyond the kernel cap and a float32 packed input —
+// run the same step as graph ops.
+func testGatedDeltaGraphRouting(t *testing.T) {
+	g := gatedDeltaTestGeometry{Hk: 4, Dk: 64, Hv: 8, Dv: 32}
+
+	check := func(name string, in gatedDeltaTestInputs, captureAll bool) {
+		y, end, interior := GatedDelta(in.packed, in.ba, in.dtBias, in.aExp, in.state, nil, captureAll)
+		refY, refEnd, refInterior := gatedDeltaReference(in, captureAll)
+		if err := requireExact("y", y, refY); err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		if err := requireExact("state", end, refEnd); err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		if len(interior) != len(refInterior) {
+			t.Fatalf("%s: interior count = %d, want %d", name, len(interior), len(refInterior))
+		}
+	}
+
+	check("tooLong", gatedDeltaTestInputs36(g, gatedDeltaMaxTokens+1), true)
+
+	f32 := gatedDeltaTestInputs36(g, 2)
+	f32.packed = f32.packed.AsType(DTypeFloat32)
+	check("float32", f32, false)
+}
+
+// batchGatedDeltaRows widens a single-row input to B rows with distinct
+// per-row contents.
+func batchGatedDeltaRows(row gatedDeltaTestInputs, B int) gatedDeltaTestInputs {
+	if B == 1 {
+		return row
+	}
+	packed := make([]*Array, B)
+	ba := make([]*Array, B)
+	state := make([]*Array, B)
+	for i := range B {
+		r := row
+		if i > 0 {
+			r = scaledGatedDeltaRow(row, 1-0.3*float32(i))
+		}
+		packed[i], ba[i], state[i] = r.packed, r.ba, r.state
+	}
+	return gatedDeltaTestInputs{
+		packed: Concatenate(packed, 0),
+		ba:     Concatenate(ba, 0),
+		dtBias: row.dtBias,
+		aExp:   row.aExp,
+		state:  Concatenate(state, 0),
+	}
+}
+
+func scaledGatedDeltaRow(base gatedDeltaTestInputs, scale float32) gatedDeltaTestInputs {
+	return gatedDeltaTestInputs{
+		packed: MulScalar(base.packed, scale),
+		ba:     MulScalar(base.ba, -scale),
+		dtBias: base.dtBias,
+		aExp:   base.aExp,
+		state:  MulScalar(base.state, scale),
+	}
+}
+
+func TestGatedDeltaBatchedRows(t *testing.T) {
+	skipIfNoMLX(t)
+	withMLXThread(t, func() {
+		testGatedDeltaBatchedRows(t)
+	})
+}
+
+// Each batched row must match its own single-row launch bit-for-bit.
+func testGatedDeltaBatchedRows(t *testing.T) {
+	g := gatedDeltaTestGeometry{Hk: 4, Dk: 64, Hv: 8, Dv: 32}
+	for _, T := range []int{1, 5, 11} {
+		rows := []gatedDeltaTestInputs{gatedDeltaTestInputs36(g, T)}
+		rows = append(rows, scaledGatedDeltaRow(rows[0], 0.7), scaledGatedDeltaRow(rows[0], 0.4))
+
+		packed := Concatenate([]*Array{rows[0].packed, rows[1].packed, rows[2].packed}, 0)
+		ba := Concatenate([]*Array{rows[0].ba, rows[1].ba, rows[2].ba}, 0)
+		state := Concatenate([]*Array{rows[0].state, rows[1].state, rows[2].state}, 0)
+
+		y, end, _ := GatedDelta(packed, ba, rows[0].dtBias, rows[0].aExp, state, nil, false)
+		for i, row := range rows {
+			refY, refEnd, _ := GatedDelta(row.packed, row.ba, row.dtBias, row.aExp, row.state, nil, false)
+			gotY := SliceStartStop(y,
+				[]int32{int32(i), 0, 0, 0},
+				[]int32{int32(i) + 1, int32(T), int32(g.Hv), int32(g.Dv)})
+			gotEnd := SliceStartStop(end,
+				[]int32{int32(i), 0, 0, 0},
+				[]int32{int32(i) + 1, int32(g.Hv), int32(g.Dv), int32(g.Dk)})
+			if err := requireExact("y", gotY, refY); err != nil {
+				t.Fatalf("T=%d row %d: %v", T, i, err)
+			}
+			if err := requireExact("state", gotEnd, refEnd); err != nil {
+				t.Fatalf("T=%d row %d: %v", T, i, err)
+			}
+		}
+	}
+}
+
+func TestGatedDeltaRaggedRows(t *testing.T) {
+	skipIfNoMLX(t)
+	withMLXThread(t, func() {
+		testGatedDeltaRaggedRows(t)
+	})
+}
+
+// A padded row neutralized the way the nn seam does it — zeroed conv rows,
+// ba tail poisoned to -inf — runs identity steps with zero output there: its
+// full output and final state must match a launch of only its real tokens
+// with zeros appended, while the full-length row is unaffected.
+func testGatedDeltaRaggedRows(t *testing.T) {
+	g := gatedDeltaTestGeometry{Hk: 4, Dk: 64, Hv: 8, Dv: 32}
+	const T, realLen = 6, 4
+	row0 := gatedDeltaTestInputs36(g, T)
+	row1 := scaledGatedDeltaRow(row0, 0.7)
+
+	pad := make([]float32, (T-realLen)*2*g.Hv)
+	negInf := float32(math.Inf(-1))
+	for i := range pad {
+		pad[i] = negInf
+	}
+	row1BA := Concatenate([]*Array{
+		SliceStartStop(row1.ba, []int32{0, 0, 0}, []int32{1, realLen, int32(2 * g.Hv)}),
+		FromValues(pad, 1, T-realLen, 2*g.Hv).AsType(DTypeBFloat16),
+	}, 1)
+	row1Packed := Concatenate([]*Array{
+		SliceStartStop(row1.packed, []int32{0, 0, 0}, []int32{1, realLen, int32(g.packedDim())}),
+		Zeros(DTypeBFloat16, 1, T-realLen, g.packedDim()),
+	}, 1)
+
+	packed := Concatenate([]*Array{row0.packed, row1Packed}, 0)
+	ba := Concatenate([]*Array{row0.ba, row1BA}, 0)
+	state := Concatenate([]*Array{row0.state, row1.state}, 0)
+
+	y, end, _ := GatedDelta(packed, ba, row0.dtBias, row0.aExp, state, nil, false)
+
+	ref0Y, ref0End, _ := GatedDelta(row0.packed, row0.ba, row0.dtBias, row0.aExp, row0.state, nil, false)
+	got0Y := SliceStartStop(y, []int32{0, 0, 0, 0}, []int32{1, T, int32(g.Hv), int32(g.Dv)})
+	got0End := SliceStartStop(end, []int32{0, 0, 0, 0}, []int32{1, int32(g.Hv), int32(g.Dv), int32(g.Dk)})
+	if err := requireExact("row0 y", got0Y, ref0Y); err != nil {
+		t.Fatal(err)
+	}
+	if err := requireExact("row0 state", got0End, ref0End); err != nil {
+		t.Fatal(err)
+	}
+
+	prefixPacked := SliceStartStop(row1.packed, []int32{0, 0, 0}, []int32{1, realLen, int32(g.packedDim())})
+	prefixBA := SliceStartStop(row1.ba, []int32{0, 0, 0}, []int32{1, realLen, int32(2 * g.Hv)})
+	ref1Y, ref1End, _ := GatedDelta(prefixPacked, prefixBA, row1.dtBias, row1.aExp, row1.state, nil, false)
+	want1Y := Concatenate([]*Array{ref1Y, Zeros(DTypeBFloat16, 1, T-realLen, g.Hv, g.Dv)}, 1)
+	got1Y := SliceStartStop(y, []int32{1, 0, 0, 0}, []int32{2, T, int32(g.Hv), int32(g.Dv)})
+	got1End := SliceStartStop(end, []int32{1, 0, 0, 0}, []int32{2, int32(g.Hv), int32(g.Dv), int32(g.Dk)})
+	if err := requireExact("row1 y", got1Y, want1Y); err != nil {
+		t.Fatal(err)
+	}
+	if err := requireExact("row1 state", got1End, ref1End); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/x/mlxrunner/mlx/gpu_kernel.go
+++ b/x/mlxrunner/mlx/gpu_kernel.go
@@ -1,0 +1,359 @@
+package mlx
+
+// #include <stdlib.h>
+// #include "generated.h"
+import "C"
+
+import (
+	"log/slog"
+	"sync"
+	"unsafe"
+)
+
+// gpuSource is one backend's implementation of a kernel.
+type gpuSource struct {
+	source string
+	header string
+}
+
+// gpuKernel is a custom kernel with per-backend sources and a graph
+// fallback. Either backend may be absent; a backend that cannot be created
+// or launched disables itself permanently. Contract checks belong to the
+// caller, before run: run itself cannot fail.
+type gpuKernel struct {
+	name    string
+	inputs  []string
+	outputs []string
+	metal   gpuSource
+	cuda    gpuSource
+
+	// fallback computes the same outputs with graph ops when no GPU
+	// backend can run the launch.
+	fallback func(launch gpuLaunch) []*Array
+
+	metalOnce     sync.Once
+	metalKernel   C.mlx_fast_metal_kernel
+	metalDisabled bool
+
+	cudaOnce     sync.Once
+	cudaKernel   C.mlx_fast_cuda_kernel
+	cudaDisabled bool
+}
+
+// gpuDTypeArg and gpuIntArg name template arguments for one launch.
+type gpuDTypeArg struct {
+	name  string
+	dtype DType
+}
+
+type gpuIntArg struct {
+	name  string
+	value int
+}
+
+// gpuOutputSpec declares one kernel output buffer.
+type gpuOutputSpec struct {
+	name  string
+	shape []int32
+	dtype DType
+}
+
+// gpuLaunch is the per-call configuration for gpuKernel.run. Grid and
+// thread-group units are shared across backends.
+type gpuLaunch struct {
+	dtypes      []gpuDTypeArg
+	ints        []gpuIntArg
+	outputs     []gpuOutputSpec
+	grid        [3]int
+	threadGroup [3]int
+	inputs      []*Array
+}
+
+func cStringVector(values []string) (C.mlx_vector_string, func(), bool) {
+	vec := C.mlx_vector_string_new()
+	ok := true
+	for _, s := range values {
+		cs := C.CString(s)
+		if C.mlx_vector_string_append_value(vec, cs) != 0 {
+			ok = false
+		}
+		C.free(unsafe.Pointer(cs))
+		if !ok {
+			break
+		}
+	}
+	cleanup := func() {
+		C.mlx_vector_string_free(vec)
+	}
+	return vec, cleanup, ok
+}
+
+// run executes the kernel with the first backend that works, in CUDA,
+// Metal, fallback order. It panics if no variant can run the launch.
+func (k *gpuKernel) run(launch gpuLaunch) []*Array {
+	if outs, ok := k.applyCUDA(launch); ok {
+		return outs
+	}
+	if outs, ok := k.applyMetal(launch); ok {
+		return outs
+	}
+	if k.fallback == nil {
+		panic("mlx: kernel " + k.name + " has no usable implementation")
+	}
+	outs := k.fallback(launch)
+	if len(outs) != len(k.outputs) {
+		panic("mlx: kernel " + k.name + " fallback returned wrong output count")
+	}
+	return outs
+}
+
+func (k *gpuKernel) disableMetal(reason string) {
+	k.metalDisabled = true
+	slog.Warn("custom GPU kernel backend disabled", "kernel", k.name, "backend", "metal", "reason", reason)
+}
+
+func (k *gpuKernel) disableCUDA(reason string) {
+	k.cudaDisabled = true
+	slog.Warn("custom GPU kernel backend disabled", "kernel", k.name, "backend", "cuda", "reason", reason)
+}
+
+func (k *gpuKernel) getMetal() (C.mlx_fast_metal_kernel, bool) {
+	k.metalOnce.Do(func() {
+		if !MetalIsAvailable() {
+			k.metalDisabled = true
+			return
+		}
+
+		if k.metal.source == "" {
+			k.disableMetal("no source")
+			return
+		}
+
+		inputs, freeInputs, ok := cStringVector(k.inputs)
+		if !ok {
+			freeInputs()
+			k.disableMetal("creating input names failed")
+			return
+		}
+		defer freeInputs()
+
+		outputs, freeOutputs, ok := cStringVector(k.outputs)
+		if !ok {
+			freeOutputs()
+			k.disableMetal("creating output names failed")
+			return
+		}
+		defer freeOutputs()
+
+		cName := C.CString(k.name)
+		defer C.free(unsafe.Pointer(cName))
+		cSource := C.CString(k.metal.source)
+		defer C.free(unsafe.Pointer(cSource))
+		cHeader := C.CString(k.metal.header)
+		defer C.free(unsafe.Pointer(cHeader))
+
+		k.metalKernel = C.mlx_fast_metal_kernel_new(
+			cName,
+			inputs,
+			outputs,
+			cSource,
+			cHeader,
+			// ensure_row_contiguous, so kernels can index inputs linearly.
+			C.bool(true),
+			C.bool(false),
+		)
+		if k.metalKernel.ctx == nil {
+			k.disableMetal("creating kernel failed")
+		}
+	})
+	return k.metalKernel, !k.metalDisabled
+}
+
+func (k *gpuKernel) applyMetal(launch gpuLaunch) ([]*Array, bool) {
+	if k.metalDisabled {
+		return nil, false
+	}
+	kernel, ok := k.getMetal()
+	if !ok {
+		return nil, false
+	}
+
+	cfg := C.mlx_fast_metal_kernel_config_new()
+	defer C.mlx_fast_metal_kernel_config_free(cfg)
+	for _, arg := range launch.dtypes {
+		name := C.CString(arg.name)
+		rc := C.mlx_fast_metal_kernel_config_add_template_arg_dtype(cfg, name, C.mlx_dtype(arg.dtype))
+		C.free(unsafe.Pointer(name))
+		if rc != 0 {
+			k.disableMetal("setting dtype template arg failed")
+			return nil, false
+		}
+	}
+	for _, arg := range launch.ints {
+		name := C.CString(arg.name)
+		rc := C.mlx_fast_metal_kernel_config_add_template_arg_int(cfg, name, C.int(arg.value))
+		C.free(unsafe.Pointer(name))
+		if rc != 0 {
+			k.disableMetal("setting int template arg failed")
+			return nil, false
+		}
+	}
+	for _, out := range launch.outputs {
+		shape := make([]C.int, len(out.shape))
+		for i, d := range out.shape {
+			shape[i] = C.int(d)
+		}
+		if C.mlx_fast_metal_kernel_config_add_output_arg(cfg, unsafe.SliceData(shape), C.size_t(len(shape)), C.mlx_dtype(out.dtype)) != 0 {
+			k.disableMetal("adding output failed")
+			return nil, false
+		}
+	}
+	if C.mlx_fast_metal_kernel_config_set_grid(cfg, C.int(launch.grid[0]), C.int(launch.grid[1]), C.int(launch.grid[2])) != 0 ||
+		C.mlx_fast_metal_kernel_config_set_thread_group(cfg, C.int(launch.threadGroup[0]), C.int(launch.threadGroup[1]), C.int(launch.threadGroup[2])) != 0 {
+		k.disableMetal("setting grid failed")
+		return nil, false
+	}
+
+	inputs := make([]C.mlx_array, len(launch.inputs))
+	for i, in := range launch.inputs {
+		inputs[i] = in.ctx
+	}
+	inVec := C.mlx_vector_array_new_data(unsafe.SliceData(inputs), C.size_t(len(inputs)))
+	defer C.mlx_vector_array_free(inVec)
+	outVec := C.mlx_vector_array_new()
+	defer C.mlx_vector_array_free(outVec)
+	if C.mlx_fast_metal_kernel_apply(&outVec, kernel, inVec, cfg, DefaultStream().ctx) != 0 {
+		k.disableMetal("launching failed")
+		return nil, false
+	}
+	if int(C.mlx_vector_array_size(outVec)) < len(launch.outputs) {
+		return nil, false
+	}
+
+	outs := make([]*Array, len(launch.outputs))
+	for i, out := range launch.outputs {
+		outs[i] = New(out.name)
+		C.mlx_vector_array_get(&outs[i].ctx, outVec, C.size_t(i))
+	}
+	return outs, true
+}
+
+func (k *gpuKernel) getCUDA() (C.mlx_fast_cuda_kernel, bool) {
+	k.cudaOnce.Do(func() {
+		if !CUDAIsAvailable() {
+			k.cudaDisabled = true
+			return
+		}
+
+		if k.cuda.source == "" {
+			k.disableCUDA("no source")
+			return
+		}
+
+		inputs, freeInputs, ok := cStringVector(k.inputs)
+		if !ok {
+			freeInputs()
+			k.disableCUDA("creating input names failed")
+			return
+		}
+		defer freeInputs()
+
+		outputs, freeOutputs, ok := cStringVector(k.outputs)
+		if !ok {
+			freeOutputs()
+			k.disableCUDA("creating output names failed")
+			return
+		}
+		defer freeOutputs()
+
+		cName := C.CString(k.name)
+		defer C.free(unsafe.Pointer(cName))
+		cSource := C.CString(k.cuda.source)
+		defer C.free(unsafe.Pointer(cSource))
+		cHeader := C.CString(k.cuda.header)
+		defer C.free(unsafe.Pointer(cHeader))
+
+		k.cudaKernel = C.mlx_fast_cuda_kernel_new(
+			cName,
+			inputs,
+			outputs,
+			cSource,
+			cHeader,
+			C.bool(true),
+			C.int(0),
+		)
+		if k.cudaKernel.ctx == nil {
+			k.disableCUDA("creating kernel failed")
+		}
+	})
+	return k.cudaKernel, !k.cudaDisabled
+}
+
+func (k *gpuKernel) applyCUDA(launch gpuLaunch) ([]*Array, bool) {
+	if k.cudaDisabled {
+		return nil, false
+	}
+	kernel, ok := k.getCUDA()
+	if !ok {
+		return nil, false
+	}
+
+	cfg := C.mlx_fast_cuda_kernel_config_new()
+	defer C.mlx_fast_cuda_kernel_config_free(cfg)
+	for _, arg := range launch.dtypes {
+		name := C.CString(arg.name)
+		rc := C.mlx_fast_cuda_kernel_config_add_template_arg_dtype(cfg, name, C.mlx_dtype(arg.dtype))
+		C.free(unsafe.Pointer(name))
+		if rc != 0 {
+			k.disableCUDA("setting dtype template arg failed")
+			return nil, false
+		}
+	}
+	for _, arg := range launch.ints {
+		name := C.CString(arg.name)
+		rc := C.mlx_fast_cuda_kernel_config_add_template_arg_int(cfg, name, C.int(arg.value))
+		C.free(unsafe.Pointer(name))
+		if rc != 0 {
+			k.disableCUDA("setting int template arg failed")
+			return nil, false
+		}
+	}
+	for _, out := range launch.outputs {
+		shape := make([]C.int, len(out.shape))
+		for i, d := range out.shape {
+			shape[i] = C.int(d)
+		}
+		if C.mlx_fast_cuda_kernel_config_add_output_arg(cfg, unsafe.SliceData(shape), C.size_t(len(shape)), C.mlx_dtype(out.dtype)) != 0 {
+			k.disableCUDA("adding output failed")
+			return nil, false
+		}
+	}
+	if C.mlx_fast_cuda_kernel_config_set_grid(cfg, C.int(launch.grid[0]), C.int(launch.grid[1]), C.int(launch.grid[2])) != 0 ||
+		C.mlx_fast_cuda_kernel_config_set_thread_group(cfg, C.int(launch.threadGroup[0]), C.int(launch.threadGroup[1]), C.int(launch.threadGroup[2])) != 0 {
+		k.disableCUDA("setting grid failed")
+		return nil, false
+	}
+
+	inputs := make([]C.mlx_array, len(launch.inputs))
+	for i, in := range launch.inputs {
+		inputs[i] = in.ctx
+	}
+	inVec := C.mlx_vector_array_new_data(unsafe.SliceData(inputs), C.size_t(len(inputs)))
+	defer C.mlx_vector_array_free(inVec)
+	outVec := C.mlx_vector_array_new()
+	defer C.mlx_vector_array_free(outVec)
+	if C.mlx_fast_cuda_kernel_apply(&outVec, kernel, inVec, cfg, DefaultStream().ctx) != 0 {
+		k.disableCUDA("launching failed")
+		return nil, false
+	}
+	if int(C.mlx_vector_array_size(outVec)) < len(launch.outputs) {
+		return nil, false
+	}
+
+	outs := make([]*Array, len(launch.outputs))
+	for i, out := range launch.outputs {
+		outs[i] = New(out.name)
+		C.mlx_vector_array_get(&outs[i].ctx, outVec, C.size_t(i))
+	}
+	return outs, true
+}

--- a/x/mlxrunner/mlx/kernel_test.go
+++ b/x/mlxrunner/mlx/kernel_test.go
@@ -1,0 +1,36 @@
+package mlx
+
+import (
+	"fmt"
+	"math"
+)
+
+// patternArray builds a deterministic value lattice for kernel parity tests.
+func patternArray(dtype DType, shape []int, bias, scale float32, stride, modulus int) *Array {
+	size := 1
+	for _, dim := range shape {
+		size *= dim
+	}
+	values := make([]float32, size)
+	center := modulus / 2
+	for i := range values {
+		values[i] = bias + float32((i*stride)%modulus-center)*scale
+	}
+	return FromValues(values, shape...).AsType(dtype)
+}
+
+// requireExact compares two arrays bit-for-bit after widening to float32.
+func requireExact(label string, got, want *Array) error {
+	got32, want32 := got.AsType(DTypeFloat32), want.AsType(DTypeFloat32)
+	Eval(got32, want32)
+	gotValues, wantValues := got32.Floats(), want32.Floats()
+	if len(gotValues) != len(wantValues) {
+		return fmt.Errorf("%s length = %d, want %d", label, len(gotValues), len(wantValues))
+	}
+	for i := range wantValues {
+		if math.Float32bits(gotValues[i]) != math.Float32bits(wantValues[i]) {
+			return fmt.Errorf("%s[%d] = %v, want %v", label, i, gotValues[i], wantValues[i])
+		}
+	}
+	return nil
+}

--- a/x/mlxrunner/mlx/mlx.go
+++ b/x/mlxrunner/mlx/mlx.go
@@ -115,3 +115,10 @@ func MetalIsAvailable() bool {
 	C.mlx_metal_is_available(&available)
 	return bool(available)
 }
+
+// CUDAIsAvailable returns true if a CUDA GPU is available.
+func CUDAIsAvailable() bool {
+	var available C._Bool
+	C.mlx_cuda_is_available(&available)
+	return bool(available)
+}

--- a/x/mlxrunner/mlx/ops_extra.go
+++ b/x/mlxrunner/mlx/ops_extra.go
@@ -45,7 +45,7 @@ func ToFP8(x *Array) *Array {
 	return out
 }
 
-func Dequantize(w, scales, biases *Array, groupSize, bits int, mode string) *Array {
+func Dequantize(w, scales, biases *Array, groupSize, bits int, mode string, globalScale *Array) *Array {
 	cMode := C.CString(mode)
 	defer C.free(unsafe.Pointer(cMode))
 	optGroupSize := C.mlx_optional_int{value: C.int(groupSize), has_value: true}
@@ -58,8 +58,18 @@ func Dequantize(w, scales, biases *Array, groupSize, bits int, mode string) *Arr
 	}
 
 	out := New("DEQUANTIZE")
-	var globalScale C.mlx_array
-	C.mlx_dequantize(&out.ctx, w.ctx, scales.ctx, b, optGroupSize, optBits, cMode, globalScale, optDtype, DefaultStream().ctx)
+	var noGlobalScale C.mlx_array
+	C.mlx_dequantize(&out.ctx, w.ctx, scales.ctx, b, optGroupSize, optBits, cMode, noGlobalScale, optDtype, DefaultStream().ctx)
+	if globalScale != nil {
+		// The C-level global_scale argument is rejected on Metal; apply it on top.
+		gs := globalScale
+		if gs.Size() > 1 {
+			// A vector scale is per-row; bind it to the weight's leading axis.
+			gs = Reshape(gs, int32(gs.Size()), 1)
+		}
+		outType := out.DType()
+		out = Mul(out, gs).AsType(outType)
+	}
 	return out
 }
 

--- a/x/mlxrunner/mlx/ops_extra_test.go
+++ b/x/mlxrunner/mlx/ops_extra_test.go
@@ -1,0 +1,80 @@
+package mlx
+
+import (
+	"math"
+	"testing"
+)
+
+// fp4Values decodes an fp4 (E2M1) code to its value.
+var fp4Values = [16]float32{0, 0.5, 1, 1.5, 2, 3, 4, 6, 0, -0.5, -1, -1.5, -2, -3, -4, -6}
+
+func TestDequantizeGlobalScale(t *testing.T) {
+	skipIfNoMLX(t)
+	withMLXThread(t, func() {
+		testDequantizeGlobalScale(t)
+	})
+}
+
+// The quantized payload is built directly, the way an nvfp4 checkpoint ships
+// it: packed fp4 codes, e4m3 group-scale bytes, and a separate global scale.
+// Only the dequantize consumer path runs, so expectations are exact.
+func testDequantizeGlobalScale(t *testing.T) {
+	const rows, cols, group = 4, 64, 16
+	// Every group cycles through all 16 codes; group g of row r has scale
+	// 2^((r+g)%4-1), a power of two so every expected product is exact.
+	scaleOf := func(r, g int) float32 {
+		return float32(math.Ldexp(1, (r+g)%4-1))
+	}
+
+	packed := make([]uint32, rows*cols/8)
+	for i := range packed {
+		for j := range 8 {
+			packed[i] |= uint32((i*8+j)%16) << (4 * j)
+		}
+	}
+	scaleBits := make([]uint8, rows*(cols/group))
+	for i := range scaleBits {
+		exp := (i/(cols/group)+i%(cols/group))%4 - 1
+		scaleBits[i] = uint8((exp + 7) << 3)
+	}
+	wq := FromValues(packed, rows, cols/8)
+	scales := FromValues(scaleBits, rows, cols/group)
+
+	check := func(name string, got *Array, gs func(r int) float32) {
+		t.Helper()
+		g32 := got.AsType(DTypeFloat32)
+		Eval(g32)
+		values := g32.Floats()
+		if len(values) != rows*cols {
+			t.Errorf("%s: length = %d, want %d", name, len(values), rows*cols)
+			return
+		}
+		for i, v := range values {
+			r, c := i/cols, i%cols
+			if want := fp4Values[c%16] * scaleOf(r, c/group) * gs(r); v != want {
+				t.Errorf("%s[%d] = %v, want %v", name, i, v, want)
+				return
+			}
+		}
+	}
+
+	base := Dequantize(wq, scales, nil, group, 4, "nvfp4", nil)
+	check("no scale", base, func(int) float32 { return 1 })
+
+	perRow := []float32{0.5, 1, 2, 4}
+	cases := []struct {
+		name  string
+		scale *Array
+		gs    func(r int) float32
+	}{
+		{"scalar", FromValues([]float32{2}, 1), func(int) float32 { return 2 }},
+		{"perRow", FromValues(perRow, rows), func(r int) float32 { return perRow[r] }},
+	}
+	for _, tc := range cases {
+		got := Dequantize(wq, scales, nil, group, 4, "nvfp4", tc.scale)
+		if got.DType() != base.DType() {
+			t.Errorf("%s: dtype = %v, want %v", tc.name, got.DType(), base.DType())
+		}
+		check(tc.name, got, tc.gs)
+	}
+}

--- a/x/models/cohere2_moe/cohere2_moe.go
+++ b/x/models/cohere2_moe/cohere2_moe.go
@@ -439,7 +439,7 @@ func loadStackedProjection(tensors map[string]*mlx.Array, cfg *Config, useQuanti
 	}
 
 	return &stackedExpertWeights{
-		Weight:    mlx.Dequantize(w, scales, qbiases, groupSize, bits, mode),
+		Weight:    mlx.Dequantize(w, scales, qbiases, groupSize, bits, mode, nil),
 		Bits:      bits,
 		GroupSize: groupSize,
 		Mode:      mode,

--- a/x/models/glm4_moe_lite/glm4_moe_lite.go
+++ b/x/models/glm4_moe_lite/glm4_moe_lite.go
@@ -403,7 +403,7 @@ func loadExpertWeight(tensors map[string]*mlx.Array, path string, useQuantized b
 			return &ExpertWeight{Weight: w, Scales: scales, Biases: qbiases, Bits: bits, GroupSize: groupSize}
 		}
 
-		return &ExpertWeight{Weight: mlx.Dequantize(w, scales, qbiases, groupSize, bits, mode)}
+		return &ExpertWeight{Weight: mlx.Dequantize(w, scales, qbiases, groupSize, bits, mode, nil)}
 	}
 
 	return &ExpertWeight{Weight: w}
@@ -441,7 +441,7 @@ func loadStackedProjection(tensors map[string]*mlx.Array, base string, useQuanti
 		return &StackedExpertWeights{Weight: w, Scales: scales, Biases: qbiases, Bits: bits, GroupSize: groupSize}
 	}
 
-	return &StackedExpertWeights{Weight: mlx.Dequantize(w, scales, qbiases, groupSize, bits, mode)}
+	return &StackedExpertWeights{Weight: mlx.Dequantize(w, scales, qbiases, groupSize, bits, mode, nil)}
 }
 
 // loadStackedExperts loads a stacked expert projection by its .experts name,
@@ -532,7 +532,7 @@ func sanitizeMLAWeights(tensors map[string]*mlx.Array, prefix string, cfg *Confi
 			w,
 			scales,
 		)
-		w = mlx.Dequantize(w, scales, qbiases, groupSize, bits, mode)
+		w = mlx.Dequantize(w, scales, qbiases, groupSize, bits, mode, nil)
 	}
 
 	headDim := cfg.QKNopeHeadDim + cfg.VHeadDim

--- a/x/models/laguna/laguna.go
+++ b/x/models/laguna/laguna.go
@@ -613,7 +613,7 @@ func denseExpertWeight(w *stackedExpertWeights) *mlx.Array {
 	}
 	weight := w.Weight
 	if w.Scales != nil {
-		weight = mlx.Dequantize(w.Weight, w.Scales, w.Biases, w.GroupSize, w.Bits, w.Mode)
+		weight = mlx.Dequantize(w.Weight, w.Scales, w.Biases, w.GroupSize, w.Bits, w.Mode, nil)
 		if w.GlobalScales != nil {
 			scale := w.GlobalScales
 			if scale.DType() != weight.DType() {
@@ -907,7 +907,7 @@ func collectPerExpertProjection(tensors map[string]*mlx.Array, cfg *Config, useQ
 				biases = append(biases, qb)
 			}
 		} else {
-			deq := mlx.Dequantize(w, s, qb, gs, b, m)
+			deq := mlx.Dequantize(w, s, qb, gs, b, m, nil)
 			if globalScale != nil {
 				deq = mlx.Mul(deq, globalScale)
 				globalScales = append(globalScales, globalScale)
@@ -968,7 +968,7 @@ func loadStackedProjection(tensors map[string]*mlx.Array, cfg *Config, useQuanti
 			freeTensorKeys(tensors, consumedKeys...)
 			return &stackedExpertWeights{Weight: w, Scales: s, Biases: qb, GlobalScales: globalScale, Bits: b, GroupSize: gs, Mode: m}
 		}
-		deq := mlx.Dequantize(w, s, qb, gs, b, m)
+		deq := mlx.Dequantize(w, s, qb, gs, b, m, nil)
 		if globalScale != nil {
 			deq = mlx.Mul(deq, globalScale)
 		}

--- a/x/models/nn/nn.go
+++ b/x/models/nn/nn.go
@@ -190,12 +190,7 @@ func (qe *QuantizedEmbedding) Forward(indices *mlx.Array) *mlx.Array {
 	if qe.QBiases != nil && qe.QBiases.Valid() {
 		qbiases = qe.QBiases.TakeAxis(indices, 0)
 	}
-	out := mlx.Dequantize(weight, scales, qbiases, qe.GroupSize, qe.Bits, qe.Mode)
-	if qe.GlobalScale != nil {
-		outDType := out.DType()
-		out = mlx.Mul(out, qe.GlobalScale).AsType(outDType)
-	}
-	return out
+	return mlx.Dequantize(weight, scales, qbiases, qe.GroupSize, qe.Bits, qe.Mode, qe.GlobalScale)
 }
 
 func (qe *QuantizedEmbedding) AsLinear() LinearLayer {

--- a/x/models/nn/nn.go
+++ b/x/models/nn/nn.go
@@ -85,7 +85,7 @@ type QuantizedLinear struct {
 	Scales      *mlx.Array // Scale factors for dequantization
 	QBiases     *mlx.Array // Quantization biases (nil for nvfp4)
 	Bias        *mlx.Array // Layer bias [output_dims] or nil
-	GlobalScale *mlx.Array // Per-tensor global scale for double-scale nvfp4 (nil for standard)
+	GlobalScale *mlx.Array // Per-tensor or per-row global scale for double-scale nvfp4 (nil for standard)
 	GroupSize   int
 	Bits        int
 	Mode        string
@@ -116,8 +116,8 @@ func (ql *QuantizedLinear) Forward(x *mlx.Array) *mlx.Array {
 	out := mlx.QuantizedMatmul(x, ql.Weight, ql.Scales, ql.QBiases, true, ql.GroupSize, ql.Bits, ql.Mode)
 	if ql.GlobalScale != nil {
 		// Double-scale nvfp4 (e.g., NVIDIA ModelOpt): standard quantized_matmul
-		// followed by global_scale multiply. The global_scale is a per-tensor
-		// F32 scalar (weight_scale_2 in NVIDIA's format).
+		// followed by global_scale multiply. The global_scale is F32, per-tensor
+		// (weight_scale_2 in NVIDIA's format) or per-row.
 		// TODO: switch to a fused double-scale matmul once MLX has kernel
 		// coverage for this path.
 		outDType := out.DType()

--- a/x/models/nn/nn_test.go
+++ b/x/models/nn/nn_test.go
@@ -166,7 +166,7 @@ func TestQuantizedLinearMXFP4MatchesDequantizedWeight(t *testing.T) {
 		t.Fatalf("mxfp4 qbiases = %v, want nil", ql.QBiases)
 	}
 
-	dequantizedWeight := mlx.Dequantize(ql.Weight, ql.Scales, ql.QBiases, 32, 4, "mxfp4")
+	dequantizedWeight := mlx.Dequantize(ql.Weight, ql.Scales, ql.QBiases, 32, 4, "mxfp4", nil)
 	mlx.Eval(dequantizedWeight)
 
 	qOut := ql.Forward(input).AsType(mlx.DTypeFloat32)

--- a/x/models/nn/recurrent.go
+++ b/x/models/nn/recurrent.go
@@ -18,6 +18,7 @@ type recurrentConfig struct {
 	convState  *mlx.Array
 	deltaState *mlx.Array
 	splits     []int
+	convSiLU   bool
 }
 
 // WithRecurrentHistory supplies a cache's per-layer view of conv and
@@ -35,6 +36,13 @@ func WithRecurrentState(convState, deltaState *mlx.Array) RecurrentOption {
 		c.convState = convState
 		c.deltaState = deltaState
 	}
+}
+
+// WithConvSiLU applies SiLU to the conv output inside CausalConv1D,
+// fused into the conv kernel when the conv fits its contract. GatedDelta
+// ignores it, so it can ride a shared option list.
+func WithConvSiLU() RecurrentOption {
+	return func(c *recurrentConfig) { c.convSiLU = true }
 }
 
 // WithSnapshotSplits requests that the scan run in segments cut at the given
@@ -105,7 +113,7 @@ func resolveRecurrentConfig(opts []RecurrentOption) recurrentConfig {
 
 // CausalConv1D runs a depthwise causal 1D convolution with recurrent
 // state management. Prepends the prior conv state along axis 1 and runs
-// conv.Forward over the combined window.
+// the conv over the combined window.
 //
 // Shapes: input [B, L, D]; prior state [B, convTail, D]; output
 // [B, L, D] (the causal conv strips the prepended state).
@@ -137,7 +145,15 @@ func CausalConv1D(b *batch.Batch, input *mlx.Array, conv *Conv1d, convTail int, 
 		input = mlx.Where(mlx.ExpandDims(mask, 2), input, zero)
 	}
 	concat := mlx.Concatenate([]*mlx.Array{prior, input}, 1)
-	out = conv.Forward(concat)
+	if cfg.convSiLU {
+		if w := depthwiseConvWeight(conv); w != nil {
+			out = mlx.DepthwiseConvSiLU(concat, w, int(L))
+		} else {
+			out = mlx.SiLU(conv.Forward(concat))
+		}
+	} else {
+		out = conv.Forward(concat)
+	}
 
 	// Snapshot the conv tail at each segment boundary: interior splits in
 	// ascending order, then the forward end at L. Each boundary at offset O
@@ -154,6 +170,18 @@ func CausalConv1D(b *batch.Batch, input *mlx.Array, conv *Conv1d, convTail int, 
 		states = append(states, st)
 	}
 	return out, states
+}
+
+// depthwiseConvWeight returns the [C, K] weight view the fused conv kernel
+// takes, or nil when the conv is not a plain depthwise causal conv.
+func depthwiseConvWeight(c *Conv1d) *mlx.Array {
+	if c.Bias != nil || c.Stride != 1 || c.Padding != 0 || c.Dilation != 1 {
+		return nil
+	}
+	if c.Weight.NumDims() != 3 || c.Weight.Dim(2) != 1 || int(c.Groups) != c.Weight.Dim(0) {
+		return nil
+	}
+	return mlx.Reshape(c.Weight, int32(c.Weight.Dim(0)), int32(c.Weight.Dim(1)))
 }
 
 // convStateAt returns the conv state to cache at boundary: the trailing convTail

--- a/x/models/nn/recurrent.go
+++ b/x/models/nn/recurrent.go
@@ -48,8 +48,7 @@ func WithConvSiLU() RecurrentOption {
 // WithSnapshotSplits requests that the scan run in segments cut at the given
 // offsets within this forward (0 < offset < L), capturing the recurrent state
 // at each boundary. The wrapper returns those per-boundary states to the
-// caller. Offsets must be sorted ascending and strictly interior; out-of-range
-// or duplicate offsets are ignored.
+// caller. Offsets must be sorted ascending, unique, and strictly interior.
 func WithSnapshotSplits(offsets []int) RecurrentOption {
 	return func(c *recurrentConfig) { c.splits = offsets }
 }
@@ -72,7 +71,7 @@ func segmentRanges(splits []int, L int32) []seg {
 
 // sliceSeg slices x to the segment's window [s.start, s.end) along the L axis
 // (axis 1), keeping all other axes whole. Works for any rank — [B, L],
-// [B, L, H], [B, L, H, D] — so the padding mask, gate/beta, and q/k/v all
+// [B, L, H], [B, L, H, D] — so the padding mask and the packed projections
 // slice the same L range and stay aligned. Returns nil when x is nil (the
 // no-padding-mask fast path). Slicing the full-forward mask this way yields
 // the segment's own mask, so masks are built once per forward and reused
@@ -215,57 +214,42 @@ func convStateAt(concat *mlx.Array, queryLens []int32, convTail int, boundary in
 		[]int32{B, boundary + int32(convTail), D})
 }
 
-// GatedDelta wraps mlx.FastGatedDelta with recurrent state management.
-// Reads prior delta state from the supplied option and returns the output
-// and the delta states at each boundary. The boundary states end with the
-// forward-end state. Without WithSnapshotSplits there is one boundary (the
-// end), so states has length 1.
-//
-// Shape conventions:
-//
-//	q:     [B, L, numKeyHeads,   headKDim]
-//	k:     [B, L, numKeyHeads,   headKDim]
-//	v:     [B, L, numValueHeads, headVDim]
-//	state: [B, numValueHeads,    headVDim, headKDim]
-//
-// Prior state comes from exactly one of WithRecurrentHistory (cache
-// path) or WithRecurrentState (no-cache path).
-//
-// When WithSnapshotSplits supplies interior offsets, the scan runs in
-// segments cut at those offsets, threading delta state between them; states
-// holds the delta state at each interior split and at the end. out is
-// identical to the unsegmented scan.
-func GatedDelta(b *batch.Batch, q, k, v, gDecay, beta *mlx.Array, opts ...RecurrentOption) (out *mlx.Array, states []*mlx.Array) {
+// GatedDelta runs the whole gated-delta step over the activated causal-conv
+// output: q/k norms, decay gate, and the scan. convOut rows are packed
+// [q | k | v]; ba is the packed [beta | alpha] projection output. Per-token
+// splits map to the kernels' captureAll shape — one launch emitting every
+// interior state — and any other split pattern composes mlx.GatedDelta per
+// segment, threading the delta state, so each segment runs the fused kernel
+// when it fits. Returns the output and the delta states at each boundary,
+// ending with the forward-end state; without WithSnapshotSplits there is one
+// boundary (the end), so states has length 1.
+func GatedDelta(b *batch.Batch, convOut, ba, dtBias, aExp *mlx.Array, opts ...RecurrentOption) (*mlx.Array, []*mlx.Array) {
 	cfg := resolveRecurrentConfig(opts)
-	var prior *mlx.Array
+	prior := cfg.deltaState
 	if cfg.history != nil {
 		prior = cfg.history.DeltaState()
-	} else {
-		prior = cfg.deltaState
 	}
 
-	L := int32(q.Dim(1))
-	mask := paddingMask(b, L) // built once per forward, sliced per segment
+	L := int32(convOut.Dim(1))
+	mask := paddingMask(b, L)
+
+	// No splits and per-token splits are both a single whole-forward call:
+	// len(splits) == L-1 means the sorted interior offsets are exactly
+	// 1..L-1, the kernels' captureAll shape.
+	if n := len(cfg.splits); n == 0 || n == int(L)-1 {
+		y, end, interior := mlx.GatedDelta(convOut, ba, dtBias, aExp, prior, mask, n > 0)
+		return y, append(interior, end)
+	}
+
 	segs := segmentRanges(cfg.splits, L)
-	if len(segs) <= 1 {
-		out, end := mlx.FastGatedDelta(q, k, v, gDecay, beta, prior, mask)
-		return out, []*mlx.Array{end}
-	}
-
-	// Segmented scan: run each [a,c) piece with the prior segment's state,
-	// recording the delta state at every boundary (interior splits + end).
 	outs := make([]*mlx.Array, 0, len(segs))
-	states = make([]*mlx.Array, 0, len(segs))
+	states := make([]*mlx.Array, 0, len(segs))
 	state := prior
 	for _, seg := range segs {
-		segOut, segState := mlx.FastGatedDelta(
-			sliceSeg(q, seg), sliceSeg(k, seg), sliceSeg(v, seg),
-			sliceSeg(gDecay, seg), sliceSeg(beta, seg),
-			state, sliceSeg(mask, seg),
-		)
-		outs = append(outs, segOut)
-		state = segState
-		states = append(states, segState)
+		var y *mlx.Array
+		y, state, _ = mlx.GatedDelta(sliceSeg(convOut, seg), sliceSeg(ba, seg), dtBias, aExp, state, sliceSeg(mask, seg), false)
+		outs = append(outs, y)
+		states = append(states, state)
 	}
 	return mlx.Concatenate(outs, 1), states
 }

--- a/x/models/nn/recurrent_test.go
+++ b/x/models/nn/recurrent_test.go
@@ -8,10 +8,6 @@ import (
 	"github.com/ollama/ollama/x/mlxrunner/mlx"
 )
 
-func ones(dtype mlx.DType, shape ...int) *mlx.Array {
-	return mlx.AddScalar(mlx.Zeros(dtype, shape...), 1)
-}
-
 // lastState returns the forward-end state — the last boundary the recurrent
 // wrappers return.
 func lastState(states []*mlx.Array) *mlx.Array { return states[len(states)-1] }
@@ -142,130 +138,30 @@ func TestCausalConv1DPaddedRowParity(t *testing.T) {
 	}
 }
 
-// TestGatedDeltaDelegatesToKernel checks the wrapper produces the same output
-// and final state as a direct mlx.FastGatedDelta call, for both a zero prior
-// state and a non-zero one (so the wrapper is shown to thread the prior through,
-// not just handle the zero path).
-func TestGatedDeltaDelegatesToKernel(t *testing.T) {
-	skipIfNoMLX(t)
-	B, L, nK, nV, dK, dV := 1, 2, 1, 1, 4, 4
-	q := ones(mlx.DTypeFloat32, B, L, nK, dK)
-	k := ones(mlx.DTypeFloat32, B, L, nK, dK)
-	v := ones(mlx.DTypeFloat32, B, L, nV, dV)
-	gDecay := ones(mlx.DTypeFloat32, B, L, nV)
-	beta := ones(mlx.DTypeFloat32, B, L, nV)
-
-	cases := []struct {
-		name  string
-		prior *mlx.Array
-	}{
-		{"zero", mlx.Zeros(mlx.DTypeFloat32, B, nV, dV, dK)},
-		{"non-zero", mlx.MulScalar(ones(mlx.DTypeFloat32, B, nV, dV, dK), 3)},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			outA, statesA := GatedDelta(&batch.Batch{}, q, k, v, gDecay, beta, WithRecurrentState(nil, tc.prior))
-			stateA := lastState(statesA)
-			outB, stateB := mlx.FastGatedDelta(q, k, v, gDecay, beta, tc.prior, nil)
-			mlx.Eval(outA, stateA, outB, stateB)
-
-			gotOut, wantOut := outA.Floats(), outB.Floats()
-			for i := range wantOut {
-				if gotOut[i] != wantOut[i] {
-					t.Fatalf("output[%d]: wrapper=%v direct=%v", i, gotOut[i], wantOut[i])
-				}
-			}
-			gotState, wantState := stateA.Floats(), stateB.Floats()
-			for i := range wantState {
-				if gotState[i] != wantState[i] {
-					t.Fatalf("state[%d]: wrapper=%v direct=%v", i, gotState[i], wantState[i])
-				}
-			}
-		})
-	}
+// gatedDeltaPackedInputs builds deterministic packed conv-output and
+// projection rows plus the per-head parameters for a GatedDelta call.
+func gatedDeltaPackedInputs(B, T, Hk, Dk, Hv, Dv int) (packed, ba, dtBias, aExp *mlx.Array) {
+	packed = fromValues(0.05, B, T, 2*Hk*Dk+Hv*Dv)
+	ba = fromValues(-0.2, B, T, 2*Hv)
+	dtBias = fromValues(0.3, Hv)
+	aExp = fromValues(0.12, Hv)
+	return packed, ba, dtBias, aExp
 }
 
-// TestGatedDeltaPaddedRowParity drives a B=2 batch where row 1 is
-// short (qLen < L). The wrapper must substitute neutral values
-// (q=k=v=beta=0, g=1) at row 1's padded positions so the recurrence
-// is a no-op there — and row 1's final state must equal the state
-// after its last real token. Pinned via parity against a B=1 length-
-// qLen call on the same row.
-func TestGatedDeltaPaddedRowParity(t *testing.T) {
-	skipIfNoMLX(t)
-	L, nK, nV, dK, dV := 4, 1, 1, 4, 4
-	qLenShort := 2
-
-	makeRows := func(seedA, seedB float32, shape ...int) *mlx.Array {
-		// Build a rank-(len(shape)+1) tensor with B=2 rows from two
-		// distinct seeds so the rows are not accidentally identical.
-		n := 1
-		for _, d := range shape {
-			n *= d
-		}
-		vals := make([]float32, 2*n)
-		for i := range n {
-			vals[i] = seedA + 0.1*float32(i)
-		}
-		for i := range n {
-			vals[n+i] = seedB + 0.1*float32(i)
-		}
-		full := append([]int{2}, shape...)
-		return mlx.FromValues(vals, full...)
+// slicePrefix returns rows [lo, hi) of a truncated to the first n positions
+// along axis 1.
+func slicePrefix(a *mlx.Array, lo, hi, n int32) *mlx.Array {
+	dims := a.Dims()
+	start := make([]int32, len(dims))
+	stop := make([]int32, len(dims))
+	start[0], stop[0] = lo, hi
+	for i := 1; i < len(dims); i++ {
+		stop[i] = int32(dims[i])
 	}
-
-	q := makeRows(0.5, -0.5, L, nK, dK)
-	k := makeRows(0.7, -0.7, L, nK, dK)
-	v := makeRows(0.3, -0.3, L, nV, dV)
-	gDecay := makeRows(0.1, -0.1, L, nV)
-	beta := makeRows(0.4, -0.4, L, nV)
-	priorState := makeRows(0.2, -0.2, nV, dV, dK)
-
-	b := &batch.Batch{
-		InputIDs:     mlx.Zeros(mlx.DTypeInt32, 2, L),
-		SeqOffsets:   []int32{0, 0},
-		SeqQueryLens: []int32{int32(L), int32(qLenShort)},
+	if len(dims) >= 2 {
+		stop[1] = n
 	}
-	_, states := GatedDelta(b, q, k, v, gDecay, beta, WithRecurrentState(nil, priorState))
-	state := lastState(states)
-	mlx.Eval(state)
-
-	// Reference for row 1: B=1 length-qLenShort call against the
-	// row's real prefix and its prior state slice.
-	row1Slice := func(a *mlx.Array, axisLens ...int32) *mlx.Array {
-		dims := a.Dims()
-		start := make([]int32, len(dims))
-		stop := make([]int32, len(dims))
-		start[0], stop[0] = 1, 2
-		for i := 1; i < len(dims); i++ {
-			stop[i] = int32(dims[i])
-		}
-		// Optionally truncate axis 1 (sequence axis) to qLenShort.
-		if len(axisLens) >= 1 && len(dims) >= 2 {
-			stop[1] = axisLens[0]
-		}
-		return mlx.SliceStartStop(a, start, stop)
-	}
-	q1 := row1Slice(q, int32(qLenShort))
-	k1 := row1Slice(k, int32(qLenShort))
-	v1 := row1Slice(v, int32(qLenShort))
-	gDecay1 := row1Slice(gDecay, int32(qLenShort))
-	beta1 := row1Slice(beta, int32(qLenShort))
-	priorRow1 := row1Slice(priorState)
-
-	_, refState := mlx.FastGatedDelta(q1, k1, v1, gDecay1, beta1, priorRow1, nil)
-	mlx.Eval(refState)
-
-	gotState := state.Floats()
-	wantState := refState.Floats()
-	row1Stride := nV * dV * dK
-	for i := range row1Stride {
-		gotV := gotState[row1Stride+i]
-		wantV := wantState[i]
-		if math.Abs(float64(gotV-wantV)) > 1e-4 {
-			t.Fatalf("row 1 final state[%d]: got %v, want %v", i, gotV, wantV)
-		}
-	}
+	return mlx.SliceStartStop(a, start, stop)
 }
 
 // floatsClose compares two flat float slices within tolerance.
@@ -281,53 +177,48 @@ func floatsClose(t *testing.T, label string, got, want []float32, tol float64) {
 	}
 }
 
-// TestGatedDeltaSegmentEquivalence checks that running the scan in segments
-// cut at WithSnapshotSplits offsets yields identical output and final state to
-// the single-shot scan, and that each boundary state equals the single-shot
-// state over the corresponding prefix.
+// TestGatedDeltaSegmentEquivalence checks that split forwards match the
+// single-shot call — both the per-token split pattern (the kernels'
+// captureAll shape) and a sparse split (the per-segment composition) — and
+// that each boundary state equals the single-shot state over the
+// corresponding prefix.
 func TestGatedDeltaSegmentEquivalence(t *testing.T) {
 	skipIfNoMLX(t)
-	B, T, Hk, Dk, Hv, Dv := 1, 4, 1, 32, 1, 32
-
-	q := fromValues(0.1, B, T, Hk, Dk)
-	k := fromValues(-0.2, B, T, Hk, Dk)
-	v := fromValues(0.3, B, T, Hv, Dv)
-	gDecay := mlx.MulScalar(ones(mlx.DTypeFloat32, B, T, Hv), 0.9)
-	beta := mlx.MulScalar(ones(mlx.DTypeFloat32, B, T, Hv), 0.5)
+	B, T, Hk, Dk, Hv, Dv := 1, 5, 1, 32, 1, 32
+	packed, ba, dtBias, aExp := gatedDeltaPackedInputs(B, T, Hk, Dk, Hv, Dv)
 	prior := mlx.Zeros(mlx.DTypeFloat32, B, Hv, Dv, Dk)
-
 	full := &batch.Batch{SeqOffsets: []int32{0}, SeqQueryLens: []int32{int32(T)}}
 
-	refOut, refStates := GatedDelta(full, q, k, v, gDecay, beta, WithRecurrentState(nil, prior))
+	refOut, refStates := GatedDelta(full, packed, ba, dtBias, aExp, WithRecurrentState(nil, prior))
 	if len(refStates) != 1 {
 		t.Fatalf("unsegmented call returned %d states, want 1", len(refStates))
 	}
 
-	segOut, segStates := GatedDelta(full, q, k, v, gDecay, beta,
-		WithRecurrentState(nil, prior), WithSnapshotSplits([]int{1, 2, 3}))
-	mlx.Eval(refOut, segOut)
-
-	floatsClose(t, "out", segOut.Floats(), refOut.Floats(), 1e-4)
-	// 3 splits + end = 4 boundary states.
-	if len(segStates) != 4 {
-		t.Fatalf("got %d boundary states, want 4", len(segStates))
+	cases := []struct {
+		name   string
+		splits []int
+	}{
+		{"perToken", []int{1, 2, 3, 4}},
+		{"sparse", []int{2}},
 	}
-	mlx.Eval(lastState(segStates), lastState(refStates))
-	floatsClose(t, "final state", lastState(segStates).Floats(), lastState(refStates).Floats(), 1e-4)
-
-	// boundary i (offset i+1) must equal a single-shot scan over prefix [0, i+1).
-	for i := range segStates {
-		n := int32(i + 1)
-		pb := &batch.Batch{SeqOffsets: []int32{0}, SeqQueryLens: []int32{n}}
-		_, want := GatedDelta(pb,
-			mlx.SliceStartStop(q, []int32{0, 0, 0, 0}, []int32{int32(B), n, int32(Hk), int32(Dk)}),
-			mlx.SliceStartStop(k, []int32{0, 0, 0, 0}, []int32{int32(B), n, int32(Hk), int32(Dk)}),
-			mlx.SliceStartStop(v, []int32{0, 0, 0, 0}, []int32{int32(B), n, int32(Hv), int32(Dv)}),
-			mlx.SliceStartStop(gDecay, []int32{0, 0, 0}, []int32{int32(B), n, int32(Hv)}),
-			mlx.SliceStartStop(beta, []int32{0, 0, 0}, []int32{int32(B), n, int32(Hv)}),
-			WithRecurrentState(nil, prior))
-		mlx.Eval(segStates[i], lastState(want))
-		floatsClose(t, "boundary delta", segStates[i].Floats(), lastState(want).Floats(), 1e-4)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			segOut, segStates := GatedDelta(full, packed, ba, dtBias, aExp,
+				WithRecurrentState(nil, prior), WithSnapshotSplits(tc.splits))
+			mlx.Eval(refOut, segOut)
+			floatsClose(t, "out", segOut.Floats(), refOut.Floats(), 1e-4)
+			if len(segStates) != len(tc.splits)+1 {
+				t.Fatalf("got %d boundary states, want %d", len(segStates), len(tc.splits)+1)
+			}
+			boundaries := append(append([]int{}, tc.splits...), T)
+			for i, n := range boundaries {
+				_, want, _ := mlx.GatedDelta(
+					slicePrefix(packed, 0, 1, int32(n)), slicePrefix(ba, 0, 1, int32(n)),
+					dtBias, aExp, prior, nil, false)
+				mlx.Eval(segStates[i], want)
+				floatsClose(t, "boundary delta", segStates[i].Floats(), want.Floats(), 1e-4)
+			}
+		})
 	}
 }
 
@@ -372,57 +263,64 @@ func TestCausalConv1DSegmentEquivalence(t *testing.T) {
 	}
 }
 
-// TestGatedDeltaSegmentEquivalenceBatched checks the segmented scan matches the
-// single-shot scan for B>1, including a ragged batch where rows have different
-// real lengths — the per-segment sliced mask must zero each row's padded
-// positions so a short row's boundary state freezes at its real end.
+// TestGatedDeltaSegmentEquivalenceBatched checks split forwards match the
+// single-shot call for B>1 with a ragged batch, for both the per-token and
+// sparse split patterns — the per-segment sliced mask must neutralize each
+// row's padded positions so a short row's boundary state freezes at its
+// real end.
 func TestGatedDeltaSegmentEquivalenceBatched(t *testing.T) {
 	skipIfNoMLX(t)
 	B, T, Hk, Dk, Hv, Dv := 2, 4, 1, 32, 1, 32
-
-	q := fromValues(0.1, B, T, Hk, Dk)
-	k := fromValues(-0.2, B, T, Hk, Dk)
-	v := fromValues(0.3, B, T, Hv, Dv)
-	gDecay := mlx.MulScalar(ones(mlx.DTypeFloat32, B, T, Hv), 0.9)
-	beta := mlx.MulScalar(ones(mlx.DTypeFloat32, B, T, Hv), 0.5)
+	packed, ba, dtBias, aExp := gatedDeltaPackedInputs(B, T, Hk, Dk, Hv, Dv)
 	prior := mlx.Zeros(mlx.DTypeFloat32, B, Hv, Dv, Dk)
 
 	// Row 0 full length T; row 1 ends at 3 (so segment [3,4) is all padding
 	// for row 1).
-	full := &batch.Batch{SeqOffsets: []int32{0, 0}, SeqQueryLens: []int32{int32(T), 3}}
-
-	refOut, refStates := GatedDelta(full, q, k, v, gDecay, beta, WithRecurrentState(nil, prior))
-	segOut, segStates := GatedDelta(full, q, k, v, gDecay, beta,
-		WithRecurrentState(nil, prior), WithSnapshotSplits([]int{1, 2, 3}))
-	mlx.Eval(refOut, segOut, lastState(refStates), lastState(segStates))
-
-	floatsClose(t, "batched out", segOut.Floats(), refOut.Floats(), 1e-4)
-	floatsClose(t, "batched final state", lastState(segStates).Floats(), lastState(refStates).Floats(), 1e-4)
-	if len(segStates) != 4 {
-		t.Fatalf("got %d boundary states, want 4", len(segStates))
+	rowReal := []int32{int32(T), 3}
+	full := &batch.Batch{
+		InputIDs:     mlx.Zeros(mlx.DTypeInt32, B, T),
+		SeqOffsets:   []int32{0, 0},
+		SeqQueryLens: rowReal,
 	}
 
-	// Each row's boundary i (offset i+1) must equal a B=1 single-shot scan over
-	// that row's real prefix: row 0 advances the full length, row 1 freezes once
-	// it reaches its real length 3. Per-row B=1 references avoid the ambiguity of
-	// re-declaring a ragged length over a uniform input slice.
-	rowReal := []int32{int32(T), 3}
-	for i := range segStates {
-		for r := range B {
-			n := min(int32(i+1), rowReal[r])
-			lo, hi := int32(r), int32(r)+1
-			rowPrior := mlx.SliceStartStop(prior, []int32{lo, 0, 0, 0}, []int32{hi, int32(Hv), int32(Dv), int32(Dk)})
-			_, want := GatedDelta(&batch.Batch{},
-				mlx.SliceStartStop(q, []int32{lo, 0, 0, 0}, []int32{hi, n, int32(Hk), int32(Dk)}),
-				mlx.SliceStartStop(k, []int32{lo, 0, 0, 0}, []int32{hi, n, int32(Hk), int32(Dk)}),
-				mlx.SliceStartStop(v, []int32{lo, 0, 0, 0}, []int32{hi, n, int32(Hv), int32(Dv)}),
-				mlx.SliceStartStop(gDecay, []int32{lo, 0, 0}, []int32{hi, n, int32(Hv)}),
-				mlx.SliceStartStop(beta, []int32{lo, 0, 0}, []int32{hi, n, int32(Hv)}),
-				WithRecurrentState(nil, rowPrior))
-			gotRow := mlx.SliceStartStop(segStates[i], []int32{lo, 0, 0, 0}, []int32{hi, int32(Hv), int32(Dv), int32(Dk)})
-			mlx.Eval(gotRow, lastState(want))
-			floatsClose(t, "batched boundary delta", gotRow.Floats(), lastState(want).Floats(), 1e-4)
-		}
+	refOut, refStates := GatedDelta(full, packed, ba, dtBias, aExp, WithRecurrentState(nil, prior))
+
+	cases := []struct {
+		name   string
+		splits []int
+	}{
+		{"perToken", []int{1, 2, 3}},
+		{"sparse", []int{2}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			segOut, segStates := GatedDelta(full, packed, ba, dtBias, aExp,
+				WithRecurrentState(nil, prior), WithSnapshotSplits(tc.splits))
+			mlx.Eval(refOut, segOut, lastState(refStates), lastState(segStates))
+			floatsClose(t, "batched out", segOut.Floats(), refOut.Floats(), 1e-4)
+			floatsClose(t, "batched final state", lastState(segStates).Floats(), lastState(refStates).Floats(), 1e-4)
+			if len(segStates) != len(tc.splits)+1 {
+				t.Fatalf("got %d boundary states, want %d", len(segStates), len(tc.splits)+1)
+			}
+
+			// Each row's boundary must equal a B=1 single-shot call over that
+			// row's real prefix: row 0 advances the full length, row 1 freezes
+			// once it reaches its real length.
+			boundaries := append(append([]int{}, tc.splits...), T)
+			for i, bound := range boundaries {
+				for r := range B {
+					n := min(int32(bound), rowReal[r])
+					lo, hi := int32(r), int32(r)+1
+					rowPrior := mlx.SliceStartStop(prior, []int32{lo, 0, 0, 0}, []int32{hi, int32(Hv), int32(Dv), int32(Dk)})
+					_, want, _ := mlx.GatedDelta(
+						slicePrefix(packed, lo, hi, n), slicePrefix(ba, lo, hi, n),
+						dtBias, aExp, rowPrior, nil, false)
+					gotRow := mlx.SliceStartStop(segStates[i], []int32{lo, 0, 0, 0}, []int32{hi, int32(Hv), int32(Dv), int32(Dk)})
+					mlx.Eval(gotRow, want)
+					floatsClose(t, "batched boundary delta", gotRow.Floats(), want.Floats(), 1e-4)
+				}
+			}
+		})
 	}
 }
 

--- a/x/models/qwen3_5/gdn_projections.go
+++ b/x/models/qwen3_5/gdn_projections.go
@@ -1,0 +1,205 @@
+package qwen3_5
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/models/nn"
+)
+
+// The runtime keeps one layout for the linear-attention input projections:
+// InProjQKVZ rows form [q | k | v | z] blocks and InProjBA rows form
+// [beta | alpha], so the causal conv consumes a contiguous qkv slice and
+// beta/alpha sit at fixed offsets. Split checkpoints concatenate into that
+// layout; native combined checkpoints ship rows interleaved per key head and
+// are permuted into it once at load.
+
+func packGatedDeltaProjections(qkv, z, b, a, qkvz, ba nn.LinearLayer, cfg *Config) (packedQKVZ, packedBA nn.LinearLayer, err error) {
+	switch {
+	case (qkvz != nil || ba != nil) && (qkv != nil || z != nil || b != nil || a != nil):
+		return nil, nil, fmt.Errorf("both combined and split linear attention projections present")
+	case qkvz != nil && ba != nil:
+		packedQKVZ, err = permuteProjectionRows(qkvz, nativeQKVZPerm(cfg))
+		if err != nil {
+			return nil, nil, err
+		}
+		packedBA, err = permuteProjectionRows(ba, nativeBAPerm(cfg))
+		return packedQKVZ, packedBA, err
+	case qkv != nil && z != nil && b != nil && a != nil:
+		packedQKVZ, err = concatProjectionPair(qkv, z)
+		if err != nil {
+			return nil, nil, err
+		}
+		packedBA, err = concatProjectionPair(b, a)
+		return packedQKVZ, packedBA, err
+	}
+	return nil, nil, fmt.Errorf("missing linear attention projections")
+}
+
+// nativeQKVZPerm maps packed row -> native row. Native in_proj_qkvz rows are
+// grouped per key head as [q(dk) | k(dk) | v(vPerK*dv) | z(vPerK*dv)].
+func nativeQKVZPerm(cfg *Config) []int32 {
+	nk, nv := int(cfg.LinearNumKeyHeads), int(cfg.LinearNumValueHeads)
+	dk, dv := int(cfg.LinearKeyHeadDim), int(cfg.LinearValueHeadDim)
+	vPerK := nv / nk
+	group := 2*dk + 2*vPerK*dv
+	keyDim, valueDim := nk*dk, nv*dv
+
+	perm := make([]int32, 2*keyDim+2*valueDim)
+	for kh := range nk {
+		base := kh * group
+		for i := range dk {
+			perm[kh*dk+i] = int32(base + i)
+			perm[keyDim+kh*dk+i] = int32(base + dk + i)
+		}
+		for j := range vPerK * dv {
+			perm[2*keyDim+kh*vPerK*dv+j] = int32(base + 2*dk + j)
+			perm[2*keyDim+valueDim+kh*vPerK*dv+j] = int32(base + 2*dk + vPerK*dv + j)
+		}
+	}
+	return perm
+}
+
+// nativeBAPerm maps packed row -> native row. Native in_proj_ba rows are
+// grouped per key head as [beta(vPerK) | alpha(vPerK)].
+func nativeBAPerm(cfg *Config) []int32 {
+	nk, nv := int(cfg.LinearNumKeyHeads), int(cfg.LinearNumValueHeads)
+	vPerK := nv / nk
+
+	perm := make([]int32, 2*nv)
+	for kh := range nk {
+		for j := range vPerK {
+			perm[kh*vPerK+j] = int32(kh*2*vPerK + j)
+			perm[nv+kh*vPerK+j] = int32(kh*2*vPerK + vPerK + j)
+		}
+	}
+	return perm
+}
+
+func permuteProjectionRows(layer nn.LinearLayer, perm []int32) (nn.LinearLayer, error) {
+	indices := mlx.NewArrayInt32(perm, []int32{int32(len(perm))})
+	takeRows := func(a *mlx.Array) *mlx.Array {
+		if a == nil {
+			return nil
+		}
+		return mlx.Take(a, indices, 0)
+	}
+
+	switch l := layer.(type) {
+	case *nn.Linear:
+		if l.Weight.Dim(0) != len(perm) {
+			return nil, fmt.Errorf("projection has %d rows, want %d", l.Weight.Dim(0), len(perm))
+		}
+		return nn.NewLinear(takeRows(l.Weight), takeRows(l.Bias)), nil
+	case *nn.QuantizedLinear:
+		if l.Weight.Dim(0) != len(perm) {
+			return nil, fmt.Errorf("projection has %d rows, want %d", l.Weight.Dim(0), len(perm))
+		}
+		globalScale := l.GlobalScale
+		if globalScale != nil && globalScale.Size() > 1 {
+			globalScale = takeRows(globalScale)
+		}
+		return &nn.QuantizedLinear{
+			Weight:      takeRows(l.Weight),
+			Scales:      takeRows(l.Scales),
+			QBiases:     takeRows(l.QBiases),
+			Bias:        takeRows(l.Bias),
+			GlobalScale: globalScale,
+			GroupSize:   l.GroupSize,
+			Bits:        l.Bits,
+			Mode:        l.Mode,
+		}, nil
+	}
+	return nil, fmt.Errorf("unsupported projection type %T", layer)
+}
+
+func concatProjectionPair(hi, lo nn.LinearLayer) (nn.LinearLayer, error) {
+	hiQ, hiQuant := hi.(*nn.QuantizedLinear)
+	loQ, loQuant := lo.(*nn.QuantizedLinear)
+	if hiQuant && loQuant &&
+		hiQ.GroupSize == loQ.GroupSize && hiQ.Bits == loQ.Bits && hiQ.Mode == loQ.Mode {
+		return concatQuantizedPair(hiQ, loQ)
+	}
+	if hiQuant || loQuant {
+		slog.Warn("dequantizing linear attention projections: pair quantization differs")
+	}
+
+	hiD, err := denseProjection(hi)
+	if err != nil {
+		return nil, err
+	}
+	loD, err := denseProjection(lo)
+	if err != nil {
+		return nil, err
+	}
+	weight := mlx.Concatenate([]*mlx.Array{hiD.Weight, loD.Weight.AsType(hiD.Weight.DType())}, 0)
+	return nn.NewLinear(weight, concatOptionalRows(hiD.Bias, loD.Bias, hiD.Weight, loD.Weight)), nil
+}
+
+func concatQuantizedPair(hi, lo *nn.QuantizedLinear) (nn.LinearLayer, error) {
+	var qbiases *mlx.Array
+	if hi.QBiases != nil || lo.QBiases != nil {
+		if hi.QBiases == nil || lo.QBiases == nil {
+			return nil, fmt.Errorf("quantized projections disagree on qbiases")
+		}
+		qbiases = mlx.Concatenate([]*mlx.Array{hi.QBiases, lo.QBiases}, 0)
+	}
+	return &nn.QuantizedLinear{
+		Weight:      mlx.Concatenate([]*mlx.Array{hi.Weight, lo.Weight}, 0),
+		Scales:      mlx.Concatenate([]*mlx.Array{hi.Scales, lo.Scales}, 0),
+		QBiases:     qbiases,
+		Bias:        concatOptionalRows(hi.Bias, lo.Bias, hi.Scales, lo.Scales),
+		GlobalScale: concatGlobalScales(hi.GlobalScale, lo.GlobalScale, hi.Weight, lo.Weight),
+		GroupSize:   hi.GroupSize,
+		Bits:        hi.Bits,
+		Mode:        hi.Mode,
+	}, nil
+}
+
+func denseProjection(layer nn.LinearLayer) (*nn.Linear, error) {
+	switch l := layer.(type) {
+	case *nn.Linear:
+		return l, nil
+	case *nn.QuantizedLinear:
+		weight := mlx.Dequantize(l.Weight, l.Scales, l.QBiases, l.GroupSize, l.Bits, l.Mode, l.GlobalScale)
+		return nn.NewLinear(weight, l.Bias), nil
+	}
+	return nil, fmt.Errorf("unsupported projection type %T", layer)
+}
+
+// concatOptionalRows concatenates two per-row vectors where nil means zero,
+// sized by the paired weights' row counts.
+func concatOptionalRows(hi, lo, hiRows, loRows *mlx.Array) *mlx.Array {
+	switch {
+	case hi == nil && lo == nil:
+		return nil
+	case hi == nil:
+		hi = mlx.Zeros(lo.DType(), hiRows.Dim(0))
+	case lo == nil:
+		lo = mlx.Zeros(hi.DType(), loRows.Dim(0))
+	}
+	return mlx.Concatenate([]*mlx.Array{hi, lo.AsType(hi.DType())}, 0)
+}
+
+// concatGlobalScales concatenates per-tensor or per-row global scales into a
+// per-row vector, where nil means one.
+func concatGlobalScales(hi, lo, hiRows, loRows *mlx.Array) *mlx.Array {
+	if hi == nil && lo == nil {
+		return nil
+	}
+	expand := func(scale *mlx.Array, rows int32) *mlx.Array {
+		switch {
+		case scale == nil:
+			return mlx.Tile(mlx.FromValues([]float32{1}, 1), []int32{rows})
+		case scale.Size() == 1:
+			return mlx.Tile(mlx.Reshape(scale.AsType(mlx.DTypeFloat32), 1), []int32{rows})
+		default:
+			return scale.AsType(mlx.DTypeFloat32)
+		}
+	}
+	return mlx.Concatenate([]*mlx.Array{
+		expand(hi, int32(hiRows.Dim(0))),
+		expand(lo, int32(loRows.Dim(0))),
+	}, 0)
+}

--- a/x/models/qwen3_5/gdn_projections_test.go
+++ b/x/models/qwen3_5/gdn_projections_test.go
@@ -1,0 +1,138 @@
+package qwen3_5
+
+import (
+	"math"
+	"testing"
+
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/models/nn"
+)
+
+func gdnTestConfig() *Config {
+	return &Config{
+		LinearNumKeyHeads:   2,
+		LinearNumValueHeads: 4,
+		LinearKeyHeadDim:    4,
+		LinearValueHeadDim:  4,
+	}
+}
+
+func patternArray(rows, cols int) *mlx.Array {
+	values := make([]float32, rows*cols)
+	for i := range values {
+		values[i] = float32((i*37)%113-56) * 0.03
+	}
+	return mlx.FromValues(values, rows, cols).AsType(mlx.DTypeBFloat16)
+}
+
+func assertBitEqual(t *testing.T, label string, got, want *mlx.Array) {
+	t.Helper()
+	if got == nil || want == nil {
+		if got != want {
+			t.Fatalf("%s: got %v, want %v", label, got, want)
+		}
+		return
+	}
+	got32, want32 := got.AsType(mlx.DTypeFloat32), want.AsType(mlx.DTypeFloat32)
+	mlx.Eval(got32, want32)
+	gotValues, wantValues := got32.Floats(), want32.Floats()
+	if len(gotValues) != len(wantValues) {
+		t.Fatalf("%s: length %d, want %d", label, len(gotValues), len(wantValues))
+	}
+	for i := range wantValues {
+		if math.Float32bits(gotValues[i]) != math.Float32bits(wantValues[i]) {
+			t.Fatalf("%s[%d] = %v, want %v", label, i, gotValues[i], wantValues[i])
+		}
+	}
+}
+
+// scatterRows builds the native interleaved tensor from a packed tensor and
+// the packed->native row map, inverting what the loader's permutation does.
+func scatterRows(packed *mlx.Array, perm []int32) *mlx.Array {
+	inverse := make([]int32, len(perm))
+	for dst, src := range perm {
+		inverse[src] = int32(dst)
+	}
+	return mlx.Take(packed, mlx.NewArrayInt32(inverse, []int32{int32(len(inverse))}), 0)
+}
+
+func TestPackGatedDeltaProjectionsNativeMatchesSplit(t *testing.T) {
+	skipIfNoMLX(t)
+	cfg := gdnTestConfig()
+	keyDim := int(cfg.LinearNumKeyHeads * cfg.LinearKeyHeadDim)
+	valueDim := int(cfg.LinearNumValueHeads * cfg.LinearValueHeadDim)
+	in := 8
+
+	qkvW := patternArray(2*keyDim+valueDim, in)
+	zW := patternArray(valueDim, in)
+	bW := patternArray(int(cfg.LinearNumValueHeads), in)
+	aW := patternArray(int(cfg.LinearNumValueHeads), in)
+
+	fromSplitQKVZ, fromSplitBA, err := packGatedDeltaProjections(
+		nn.NewLinear(qkvW, nil), nn.NewLinear(zW, nil),
+		nn.NewLinear(bW, nil), nn.NewLinear(aW, nil),
+		nil, nil, cfg,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	packedQKVZ := mlx.Concatenate([]*mlx.Array{qkvW, zW}, 0)
+	packedBA := mlx.Concatenate([]*mlx.Array{bW, aW}, 0)
+	nativeQKVZ := scatterRows(packedQKVZ, nativeQKVZPerm(cfg))
+	nativeBA := scatterRows(packedBA, nativeBAPerm(cfg))
+
+	fromNativeQKVZ, fromNativeBA, err := packGatedDeltaProjections(
+		nil, nil, nil, nil,
+		nn.NewLinear(nativeQKVZ, nil), nn.NewLinear(nativeBA, nil),
+		cfg,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertBitEqual(t, "qkvz", fromNativeQKVZ.(*nn.Linear).Weight, fromSplitQKVZ.(*nn.Linear).Weight)
+	assertBitEqual(t, "ba", fromNativeBA.(*nn.Linear).Weight, fromSplitBA.(*nn.Linear).Weight)
+}
+
+func TestConcatProjectionPairQuantized(t *testing.T) {
+	skipIfNoMLX(t)
+	in := 64
+	hi := nn.NewQuantizedLinear(patternArray(16, in).AsType(mlx.DTypeFloat32), nil, 32, 4, "affine")
+	lo := nn.NewQuantizedLinear(patternArray(8, in).AsType(mlx.DTypeFloat32), nil, 32, 4, "affine")
+
+	packed, err := concatProjectionPair(hi, lo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, ok := packed.(*nn.QuantizedLinear)
+	if !ok {
+		t.Fatalf("packed projection is %T, want *nn.QuantizedLinear", packed)
+	}
+	assertBitEqual(t, "weight", q.Weight, mlx.Concatenate([]*mlx.Array{hi.Weight, lo.Weight}, 0))
+	assertBitEqual(t, "scales", q.Scales, mlx.Concatenate([]*mlx.Array{hi.Scales, lo.Scales}, 0))
+}
+
+func TestConcatProjectionPairMixedFallsBackToDense(t *testing.T) {
+	skipIfNoMLX(t)
+	in := 64
+	hi := nn.NewQuantizedLinear(patternArray(16, in).AsType(mlx.DTypeFloat32), nil, 32, 4, "affine")
+	loW := patternArray(8, in)
+
+	packed, err := concatProjectionPair(hi, nn.NewLinear(loW, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	dense, ok := packed.(*nn.Linear)
+	if !ok {
+		t.Fatalf("packed projection is %T, want *nn.Linear", packed)
+	}
+	want := mlx.Concatenate([]*mlx.Array{
+		mlx.Dequantize(hi.Weight, hi.Scales, hi.QBiases, hi.GroupSize, hi.Bits, hi.Mode, nil),
+		loW.AsType(mlx.DTypeFloat16),
+	}, 0)
+	if dense.Weight.Dim(0) != 24 {
+		t.Fatalf("packed rows = %d, want 24", dense.Weight.Dim(0))
+	}
+	assertBitEqual(t, "weight", dense.Weight, want.AsType(dense.Weight.DType()))
+}

--- a/x/models/qwen3_5/qwen3_5.go
+++ b/x/models/qwen3_5/qwen3_5.go
@@ -501,11 +501,11 @@ func fuseGateUpProjections(gate, up *stackedExpertWeights) *stackedExpertWeights
 	}
 	gateWeight := gate.Weight
 	if gate.Scales != nil {
-		gateWeight = mlx.Dequantize(gate.Weight, gate.Scales, gate.Biases, gate.GroupSize, gate.Bits, gate.Mode)
+		gateWeight = mlx.Dequantize(gate.Weight, gate.Scales, gate.Biases, gate.GroupSize, gate.Bits, gate.Mode, nil)
 	}
 	upWeight := up.Weight
 	if up.Scales != nil {
-		upWeight = mlx.Dequantize(up.Weight, up.Scales, up.Biases, up.GroupSize, up.Bits, up.Mode)
+		upWeight = mlx.Dequantize(up.Weight, up.Scales, up.Biases, up.GroupSize, up.Bits, up.Mode, nil)
 	}
 	return &stackedExpertWeights{
 		Weight:    mlx.Concatenate([]*mlx.Array{gateWeight, upWeight}, 1),
@@ -552,7 +552,7 @@ func loadStackedProjection(tensors map[string]*mlx.Array, cfg *Config, useQuanti
 			slog.Warn("dequantizing expert weights: no gather kernel for format", "tensor", key, "mode", mode, "bits", bits)
 		}
 		return &stackedExpertWeights{
-			Weight:    mlx.Dequantize(w, scales, qbiases, groupSize, bits, mode),
+			Weight:    mlx.Dequantize(w, scales, qbiases, groupSize, bits, mode, nil),
 			Bits:      bits,
 			GroupSize: groupSize,
 			Mode:      mode,
@@ -611,7 +611,7 @@ func collectPerExpertProjection(tensors map[string]*mlx.Array, cfg *Config, useQ
 				biases = append(biases, qb)
 			}
 		} else {
-			weights = append(weights, mlx.Dequantize(w, s, qb, gs, b, m))
+			weights = append(weights, mlx.Dequantize(w, s, qb, gs, b, m, nil))
 			numDequantized++
 		}
 	}
@@ -676,7 +676,7 @@ func combinedGateUpProjection(tensors map[string]*mlx.Array, cfg *Config, useQua
 		slog.Warn("dequantizing expert weights: no gather kernel for format", "tensor", key, "mode", mode, "bits", bits)
 	}
 	return &stackedExpertWeights{
-		Weight:    mlx.Dequantize(gateUp, scales, qbiases, groupSize, bits, mode),
+		Weight:    mlx.Dequantize(gateUp, scales, qbiases, groupSize, bits, mode, nil),
 		Bits:      bits,
 		GroupSize: groupSize,
 		Mode:      mode,

--- a/x/models/qwen3_5/qwen3_5.go
+++ b/x/models/qwen3_5/qwen3_5.go
@@ -24,6 +24,12 @@ func init() {
 	base.Register("Qwen3NextForConditionalGeneration", NewModel)
 }
 
+var (
+	_ base.Model      = (*Model)(nil)
+	_ base.SelfDraft  = (*Model)(nil)
+	_ base.DraftModel = (*Model)(nil)
+)
+
 // RopeParameters carries optional rope metadata embedded under rope_parameters.
 type RopeParameters struct {
 	Type                string  `json:"type"`
@@ -88,10 +94,22 @@ type Model struct {
 	Norm        *nn.RMSNorm
 	LMHead      nn.LinearLayer
 
+	MTP *MTPHead
+
 	tok *tokenizer.Tokenizer
 	*Config
 
 	weightPrefix string
+}
+
+// MTPHead is the multi-token-prediction draft head; it owns a KV cache appended
+// after the per-layer caches and reuses the model's lm_head.
+type MTPHead struct {
+	Enorm *nn.RMSNorm
+	Hnorm *nn.RMSNorm
+	FC    nn.LinearLayer
+	Layer *Layer
+	Norm  *nn.RMSNorm
 }
 
 // Layer is a transformer decoder layer.
@@ -767,26 +785,17 @@ func sanitizeConvWeight(w *mlx.Array) *mlx.Array {
 	return w
 }
 
-func shouldShiftNormKey(key string) bool {
-	for _, suffix := range []string{
-		".input_layernorm.weight",
-		".post_attention_layernorm.weight",
-		"model.norm.weight",
-		".self_attn.q_norm.weight",
-		".self_attn.k_norm.weight",
-	} {
-		if strings.HasSuffix(key, suffix) {
-			return true
-		}
+// loadNorm builds an RMSNorm from tensors[key], adding 1 to weights from
+// checkpoints that store them zero-centered.
+func loadNorm(tensors map[string]*mlx.Array, key string, shift bool, eps float32) *nn.RMSNorm {
+	w := tensors[key]
+	if w == nil {
+		return nil
 	}
-	return false
-}
-
-func maybeShiftNormWeight(key string, w *mlx.Array, shouldShift bool) *mlx.Array {
-	if !shouldShift || w == nil || w.NumDims() != 1 || !shouldShiftNormKey(key) {
-		return w
+	if shift && w.NumDims() == 1 {
+		w = mlx.AddScalar(w, 1.0)
 	}
-	return mlx.AddScalar(w, 1.0)
+	return nn.NewRMSNorm(w, eps)
 }
 
 // LoadWeights assigns tensors to model fields.
@@ -800,19 +809,12 @@ func (m *Model) LoadWeights(tensors map[string]*mlx.Array) error {
 	linears := model.NewLinearFactory(tensors, cfg.QuantGroupSize, cfg.QuantBits, cfg.QuantMode, cfg.TensorQuant)
 
 	shouldShiftNormWeights := false
-	mtpKeys := make([]string, 0)
 	for name, t := range tensors {
-		if strings.Contains(name, "mtp.") {
+		if strings.Contains(name, "mtp.") ||
+			(strings.Contains(name, ".linear_attn.conv1d.weight") && t != nil && t.NumDims() == 3 && t.Dim(2) != 1) {
 			shouldShiftNormWeights = true
-			mtpKeys = append(mtpKeys, name)
-			continue
+			break
 		}
-		if !shouldShiftNormWeights && strings.Contains(name, ".linear_attn.conv1d.weight") && t != nil && t.NumDims() == 3 && t.Dim(2) != 1 {
-			shouldShiftNormWeights = true
-		}
-	}
-	if len(mtpKeys) > 0 {
-		freeTensorKeys(tensors, mtpKeys...)
 	}
 
 	embedTokens := model.MakeEmbeddingLayer(tensors, modelPrefix+"embed_tokens", cfg.QuantGroupSize, cfg.QuantBits, cfg.QuantMode, cfg.TensorQuant)
@@ -821,12 +823,10 @@ func (m *Model) LoadWeights(tensors map[string]*mlx.Array) error {
 	}
 	m.EmbedTokens = embedTokens
 
-	normKey := modelPrefix + "norm.weight"
-	normWeight := maybeShiftNormWeight(normKey, tensors[normKey], shouldShiftNormWeights)
-	if normWeight == nil {
+	m.Norm = loadNorm(tensors, modelPrefix+"norm.weight", shouldShiftNormWeights, cfg.RMSNormEps)
+	if m.Norm == nil {
 		return fmt.Errorf("missing final norm weight: %snorm.weight", modelPrefix)
 	}
-	m.Norm = nn.NewRMSNorm(normWeight, cfg.RMSNormEps)
 
 	if cfg.TieWordEmbeddings {
 		m.LMHead = m.EmbedTokens.AsLinear()
@@ -854,133 +854,170 @@ func (m *Model) LoadWeights(tensors map[string]*mlx.Array) error {
 
 	for i := range cfg.NumHiddenLayers {
 		layerPrefix := fmt.Sprintf("%slayers.%d", modelPrefix, i)
-		layer := &Layer{IsLinear: layerIsLinear(cfg, i)}
-
-		if w := maybeShiftNormWeight(layerPrefix+".input_layernorm.weight", tensors[layerPrefix+".input_layernorm.weight"], shouldShiftNormWeights); w != nil {
-			layer.InputNorm = nn.NewRMSNorm(w, cfg.RMSNormEps)
+		layer, err := loadLayer(linears, tensors, cfg, layerPrefix, layerIsLinear(cfg, i), layerUsesMoE(cfg, i), useQuantizedExperts, shouldShiftNormWeights)
+		if err != nil {
+			return err
 		}
-		if w := maybeShiftNormWeight(layerPrefix+".post_attention_layernorm.weight", tensors[layerPrefix+".post_attention_layernorm.weight"], shouldShiftNormWeights); w != nil {
-			layer.PostAttentionNorm = nn.NewRMSNorm(w, cfg.RMSNormEps)
-		}
-		if layer.InputNorm == nil || layer.PostAttentionNorm == nil {
-			return fmt.Errorf("layer %d: missing layer norms", i)
-		}
-
-		if layer.IsLinear {
-			lin := &GatedDeltaNet{}
-			var err error
-			lin.InProjQKVZ, lin.InProjBA, err = packGatedDeltaProjections(
-				linears.Make(layerPrefix+".linear_attn.in_proj_qkv"),
-				linears.Make(layerPrefix+".linear_attn.in_proj_z"),
-				linears.Make(layerPrefix+".linear_attn.in_proj_b"),
-				linears.Make(layerPrefix+".linear_attn.in_proj_a"),
-				linears.Make(layerPrefix+".linear_attn.in_proj_qkvz"),
-				linears.Make(layerPrefix+".linear_attn.in_proj_ba"),
-				cfg,
-			)
-			if err != nil {
-				return fmt.Errorf("layer %d: %w", i, err)
-			}
-			lin.OutProj = linears.Make(layerPrefix + ".linear_attn.out_proj")
-
-			convWeight := sanitizeConvWeight(tensors[layerPrefix+".linear_attn.conv1d.weight"])
-			if convWeight == nil {
-				convWeight = sanitizeConvWeight(tensors[layerPrefix+".linear_attn.conv1d"])
-			}
-			lin.NormWeight, _ = tensorAny(tensors,
-				layerPrefix+".linear_attn.norm.weight",
-				layerPrefix+".linear_attn.norm",
-			)
-			lin.DtBias, _ = tensorAny(tensors,
-				layerPrefix+".linear_attn.dt_bias",
-				layerPrefix+".linear_attn.dt_proj",
-			)
-			lin.ALog, _ = tensorAny(tensors,
-				layerPrefix+".linear_attn.A_log",
-				layerPrefix+".linear_attn.a_log",
-			)
-			if lin.ALog != nil {
-				lin.AExp = mlx.Exp(lin.ALog.AsType(mlx.DTypeFloat32))
-			}
-
-			if lin.OutProj == nil {
-				return fmt.Errorf("layer %d: missing linear attention projections", i)
-			}
-			if convWeight == nil || lin.NormWeight == nil || lin.DtBias == nil || lin.ALog == nil || lin.AExp == nil {
-				return fmt.Errorf("layer %d: missing linear attention state tensors", i)
-			}
-			if convWeight.NumDims() != 2 {
-				return fmt.Errorf("layer %d: conv1d weight must be 2D after sanitization, got %dD", i, convWeight.NumDims())
-			}
-			// MLX grouped conv expects [Cout, K, Cin/groups]; for depthwise
-			// conv (groups=C) the [C, K] kernel becomes [C, K, 1].
-			lin.Conv1D = nn.NewConv1d(mlx.ExpandDims(convWeight, 2), nil, 1, 0, 1, int32(convWeight.Dim(0)))
-
-			layer.Linear = lin
-		} else {
-			attn := &FullAttention{}
-			attn.QProj = linears.Make(layerPrefix + ".self_attn.q_proj")
-			attn.KProj = linears.Make(layerPrefix + ".self_attn.k_proj")
-			attn.VProj = linears.Make(layerPrefix + ".self_attn.v_proj")
-			attn.OProj = linears.Make(layerPrefix + ".self_attn.o_proj")
-
-			if w := maybeShiftNormWeight(layerPrefix+".self_attn.q_norm.weight", tensors[layerPrefix+".self_attn.q_norm.weight"], shouldShiftNormWeights); w != nil {
-				attn.QNorm = nn.NewRMSNorm(w, cfg.RMSNormEps)
-			}
-			if w := maybeShiftNormWeight(layerPrefix+".self_attn.k_norm.weight", tensors[layerPrefix+".self_attn.k_norm.weight"], shouldShiftNormWeights); w != nil {
-				attn.KNorm = nn.NewRMSNorm(w, cfg.RMSNormEps)
-			}
-
-			if attn.QProj == nil || attn.KProj == nil || attn.VProj == nil || attn.OProj == nil {
-				return fmt.Errorf("layer %d: missing full attention projections", i)
-			}
-			if attn.QNorm == nil || attn.KNorm == nil {
-				return fmt.Errorf("layer %d: missing full attention q/k norms", i)
-			}
-			layer.FullAttn = attn
-		}
-
-		if layerUsesMoE(cfg, i) {
-			moe := &SparseMoE{}
-			moe.Gate = linears.Make(layerPrefix + ".mlp.gate")
-			if moe.Gate == nil {
-				return fmt.Errorf("layer %d: missing moe gate", i)
-			}
-
-			switchMLP, err := loadSwitchMLP(tensors, cfg, useQuantizedExperts, layerPrefix)
-			if err != nil {
-				return fmt.Errorf("layer %d: %w", i, err)
-			}
-			moe.SwitchMLP = switchMLP
-
-			sharedGateProj := linears.Make(layerPrefix + ".mlp.shared_expert.gate_proj")
-			sharedUpProj := linears.Make(layerPrefix + ".mlp.shared_expert.up_proj")
-			sharedDownProj := linears.Make(layerPrefix + ".mlp.shared_expert.down_proj")
-			if sharedGateProj != nil && sharedUpProj != nil && sharedDownProj != nil {
-				moe.SharedExpert = &DenseMLP{
-					GateProj: sharedGateProj,
-					UpProj:   sharedUpProj,
-					DownProj: sharedDownProj,
-				}
-				moe.SharedExpertGate = linears.Make(layerPrefix + ".mlp.shared_expert_gate")
-			}
-
-			layer.MLP = moe
-		} else {
-			mlp := &DenseMLP{
-				GateProj: linears.Make(layerPrefix + ".mlp.gate_proj"),
-				UpProj:   linears.Make(layerPrefix + ".mlp.up_proj"),
-				DownProj: linears.Make(layerPrefix + ".mlp.down_proj"),
-			}
-			if mlp.GateProj == nil || mlp.UpProj == nil || mlp.DownProj == nil {
-				return fmt.Errorf("layer %d: missing dense mlp projections", i)
-			}
-			layer.MLP = mlp
-		}
-
 		m.Layers[i] = layer
 	}
 
+	// Load the MTP head only when its tensors are present: a config may declare
+	// num_nextn_predict_layers while a package ships without them. mtp.* names
+	// carry no container prefix.
+	if fc, _ := tensorByBase(tensors, "mtp.fc"); fc != nil {
+		if err := m.loadMTPHead(linears, tensors, useQuantizedExperts, shouldShiftNormWeights); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// loadLayer builds a decoder layer from tensors at layerPrefix. It serves both
+// the main stack and the MTP head's single full-attention layer.
+func loadLayer(linears model.LinearFactory, tensors map[string]*mlx.Array, cfg *Config, layerPrefix string, isLinear, useMoE, useQuantizedExperts, shiftNorms bool) (*Layer, error) {
+	layer := &Layer{IsLinear: isLinear}
+
+	layer.InputNorm = loadNorm(tensors, layerPrefix+".input_layernorm.weight", shiftNorms, cfg.RMSNormEps)
+	layer.PostAttentionNorm = loadNorm(tensors, layerPrefix+".post_attention_layernorm.weight", shiftNorms, cfg.RMSNormEps)
+	if layer.InputNorm == nil || layer.PostAttentionNorm == nil {
+		return nil, fmt.Errorf("layer %s: missing layer norms", layerPrefix)
+	}
+
+	if isLinear {
+		lin := &GatedDeltaNet{}
+		var err error
+		lin.InProjQKVZ, lin.InProjBA, err = packGatedDeltaProjections(
+			linears.Make(layerPrefix+".linear_attn.in_proj_qkv"),
+			linears.Make(layerPrefix+".linear_attn.in_proj_z"),
+			linears.Make(layerPrefix+".linear_attn.in_proj_b"),
+			linears.Make(layerPrefix+".linear_attn.in_proj_a"),
+			linears.Make(layerPrefix+".linear_attn.in_proj_qkvz"),
+			linears.Make(layerPrefix+".linear_attn.in_proj_ba"),
+			cfg,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("layer %s: %w", layerPrefix, err)
+		}
+		lin.OutProj = linears.Make(layerPrefix + ".linear_attn.out_proj")
+
+		convWeight := sanitizeConvWeight(tensors[layerPrefix+".linear_attn.conv1d.weight"])
+		if convWeight == nil {
+			convWeight = sanitizeConvWeight(tensors[layerPrefix+".linear_attn.conv1d"])
+		}
+		lin.NormWeight, _ = tensorAny(tensors,
+			layerPrefix+".linear_attn.norm.weight",
+			layerPrefix+".linear_attn.norm",
+		)
+		lin.DtBias, _ = tensorAny(tensors,
+			layerPrefix+".linear_attn.dt_bias",
+			layerPrefix+".linear_attn.dt_proj",
+		)
+		lin.ALog, _ = tensorAny(tensors,
+			layerPrefix+".linear_attn.A_log",
+			layerPrefix+".linear_attn.a_log",
+		)
+		if lin.ALog != nil {
+			lin.AExp = mlx.Exp(lin.ALog.AsType(mlx.DTypeFloat32))
+		}
+
+		if lin.OutProj == nil {
+			return nil, fmt.Errorf("layer %s: missing linear attention projections", layerPrefix)
+		}
+		if convWeight == nil || lin.NormWeight == nil || lin.DtBias == nil || lin.ALog == nil || lin.AExp == nil {
+			return nil, fmt.Errorf("layer %s: missing linear attention state tensors", layerPrefix)
+		}
+		if convWeight.NumDims() != 2 {
+			return nil, fmt.Errorf("layer %s: conv1d weight must be 2D after sanitization, got %dD", layerPrefix, convWeight.NumDims())
+		}
+		// MLX grouped conv expects [Cout, K, Cin/groups]; for depthwise
+		// conv (groups=C) the [C, K] kernel becomes [C, K, 1].
+		lin.Conv1D = nn.NewConv1d(mlx.ExpandDims(convWeight, 2), nil, 1, 0, 1, int32(convWeight.Dim(0)))
+
+		layer.Linear = lin
+	} else {
+		attn := &FullAttention{}
+		attn.QProj = linears.Make(layerPrefix + ".self_attn.q_proj")
+		attn.KProj = linears.Make(layerPrefix + ".self_attn.k_proj")
+		attn.VProj = linears.Make(layerPrefix + ".self_attn.v_proj")
+		attn.OProj = linears.Make(layerPrefix + ".self_attn.o_proj")
+
+		attn.QNorm = loadNorm(tensors, layerPrefix+".self_attn.q_norm.weight", shiftNorms, cfg.RMSNormEps)
+		attn.KNorm = loadNorm(tensors, layerPrefix+".self_attn.k_norm.weight", shiftNorms, cfg.RMSNormEps)
+
+		if attn.QProj == nil || attn.KProj == nil || attn.VProj == nil || attn.OProj == nil {
+			return nil, fmt.Errorf("layer %s: missing full attention projections", layerPrefix)
+		}
+		if attn.QNorm == nil || attn.KNorm == nil {
+			return nil, fmt.Errorf("layer %s: missing full attention q/k norms", layerPrefix)
+		}
+		layer.FullAttn = attn
+	}
+
+	if useMoE {
+		moe := &SparseMoE{}
+		moe.Gate = linears.Make(layerPrefix + ".mlp.gate")
+		if moe.Gate == nil {
+			return nil, fmt.Errorf("layer %s: missing moe gate", layerPrefix)
+		}
+
+		switchMLP, err := loadSwitchMLP(tensors, cfg, useQuantizedExperts, layerPrefix)
+		if err != nil {
+			return nil, fmt.Errorf("layer %s: %w", layerPrefix, err)
+		}
+		moe.SwitchMLP = switchMLP
+
+		sharedGateProj := linears.Make(layerPrefix + ".mlp.shared_expert.gate_proj")
+		sharedUpProj := linears.Make(layerPrefix + ".mlp.shared_expert.up_proj")
+		sharedDownProj := linears.Make(layerPrefix + ".mlp.shared_expert.down_proj")
+		if sharedGateProj != nil && sharedUpProj != nil && sharedDownProj != nil {
+			moe.SharedExpert = &DenseMLP{
+				GateProj: sharedGateProj,
+				UpProj:   sharedUpProj,
+				DownProj: sharedDownProj,
+			}
+			moe.SharedExpertGate = linears.Make(layerPrefix + ".mlp.shared_expert_gate")
+		}
+
+		layer.MLP = moe
+	} else {
+		mlp := &DenseMLP{
+			GateProj: linears.Make(layerPrefix + ".mlp.gate_proj"),
+			UpProj:   linears.Make(layerPrefix + ".mlp.up_proj"),
+			DownProj: linears.Make(layerPrefix + ".mlp.down_proj"),
+		}
+		if mlp.GateProj == nil || mlp.UpProj == nil || mlp.DownProj == nil {
+			return nil, fmt.Errorf("layer %s: missing dense mlp projections", layerPrefix)
+		}
+		layer.MLP = mlp
+	}
+
+	return layer, nil
+}
+
+// loadMTPHead builds the MTP head from the mtp.* tensors. Its single decoder
+// layer is full attention even when the main stack is hybrid; lm_head and
+// embeddings are shared with the target.
+func (m *Model) loadMTPHead(linears model.LinearFactory, tensors map[string]*mlx.Array, useQuantizedExperts, shiftNorms bool) error {
+	cfg := m.Config
+	mtpPrefix := "mtp."
+
+	head := &MTPHead{}
+	head.Enorm = loadNorm(tensors, mtpPrefix+"pre_fc_norm_embedding.weight", shiftNorms, cfg.RMSNormEps)
+	head.Hnorm = loadNorm(tensors, mtpPrefix+"pre_fc_norm_hidden.weight", shiftNorms, cfg.RMSNormEps)
+	head.FC = linears.Make(mtpPrefix + "fc")
+	head.Norm = loadNorm(tensors, mtpPrefix+"norm.weight", shiftNorms, cfg.RMSNormEps)
+	if head.Enorm == nil || head.Hnorm == nil || head.FC == nil || head.Norm == nil {
+		return fmt.Errorf("mtp head: missing enorm/hnorm/fc/norm tensors")
+	}
+
+	layer, err := loadLayer(linears, tensors, cfg, mtpPrefix+"layers.0", false, cfg.NumExperts > 0, useQuantizedExperts, shiftNorms)
+	if err != nil {
+		return err
+	}
+	head.Layer = layer
+
+	m.MTP = head
 	return nil
 }
 
@@ -1178,6 +1215,41 @@ func (m *Model) Unembed(x *mlx.Array) *mlx.Array {
 	return m.LMHead.Forward(x)
 }
 
+// DraftCaches returns the MTP head's KV caches: the trailing slots NewCaches
+// appended after the per-layer caches.
+func (m *Model) DraftCaches(caches []cache.Cache) []cache.Cache {
+	if m.MTP == nil {
+		return nil
+	}
+	return caches[len(m.Layers):]
+}
+
+// SelfDraft returns the model as its own draft when an MTP head loaded, else
+// nil; Draft exists either way, so availability is reported here.
+func (m *Model) SelfDraft() base.DraftModel {
+	if m.MTP == nil {
+		return nil
+	}
+	return m
+}
+
+// Draft runs one MTP step; the head's hidden also serves as the projected
+// hidden seeding the next step.
+func (m *Model) Draft(b *batch.Batch, caches []cache.Cache) (hidden, projected *mlx.Array) {
+	dims := b.InputIDs.Dims()
+	B, L := int32(dims[0]), int32(dims[1])
+	positions := mlx.FromValues(b.SeqOffsets, len(b.SeqOffsets))
+
+	emb := m.MTP.Enorm.Forward(m.EmbedTokens.Forward(b.InputIDs), m.RMSNormEps)
+	h := m.MTP.Hnorm.Forward(b.Hidden, m.RMSNormEps)
+	fused := m.MTP.FC.Forward(emb.Concatenate(-1, h))
+
+	c := m.DraftCaches(caches)[0]
+	out := m.MTP.Layer.Forward(fused, b, c, positions, B, L, m.Config)
+	hidden = m.MTP.Norm.Forward(out, m.RMSNormEps)
+	return hidden, hidden
+}
+
 func (m *Model) NumLayers() int {
 	return len(m.Layers)
 }
@@ -1191,7 +1263,8 @@ func (m *Model) Tokenizer() *tokenizer.Tokenizer {
 }
 
 func (m *Model) NewCaches() []cache.Cache {
-	caches := make([]cache.Cache, len(m.Layers))
+	// Reserve a trailing slot for the MTP head's KV cache when present.
+	caches := make([]cache.Cache, len(m.Layers), len(m.Layers)+1)
 	convTail := m.LinearConvKernelDim - 1
 	convDim := 2*m.LinearNumKeyHeads*m.LinearKeyHeadDim + m.LinearNumValueHeads*m.LinearValueHeadDim
 	for i, layer := range m.Layers {
@@ -1200,6 +1273,10 @@ func (m *Model) NewCaches() []cache.Cache {
 		} else {
 			caches[i] = cache.NewKVCache()
 		}
+	}
+	// Trailing slot is the MTP head's (DraftCaches); Model.Forward never touches it.
+	if m.MTP != nil {
+		caches = append(caches, cache.NewKVCache())
 	}
 	return caches
 }

--- a/x/models/qwen3_5/qwen3_5.go
+++ b/x/models/qwen3_5/qwen3_5.go
@@ -118,10 +118,6 @@ type FullAttention struct {
 
 // GatedDeltaNet is the recurrent linear-attention branch.
 type GatedDeltaNet struct {
-	InProjQKV  nn.LinearLayer
-	InProjZ    nn.LinearLayer
-	InProjB    nn.LinearLayer
-	InProjA    nn.LinearLayer
 	InProjQKVZ nn.LinearLayer
 	InProjBA   nn.LinearLayer
 	OutProj    nn.LinearLayer
@@ -872,12 +868,19 @@ func (m *Model) LoadWeights(tensors map[string]*mlx.Array) error {
 
 		if layer.IsLinear {
 			lin := &GatedDeltaNet{}
-			lin.InProjQKV = linears.Make(layerPrefix + ".linear_attn.in_proj_qkv")
-			lin.InProjZ = linears.Make(layerPrefix + ".linear_attn.in_proj_z")
-			lin.InProjB = linears.Make(layerPrefix + ".linear_attn.in_proj_b")
-			lin.InProjA = linears.Make(layerPrefix + ".linear_attn.in_proj_a")
-			lin.InProjQKVZ = linears.Make(layerPrefix + ".linear_attn.in_proj_qkvz")
-			lin.InProjBA = linears.Make(layerPrefix + ".linear_attn.in_proj_ba")
+			var err error
+			lin.InProjQKVZ, lin.InProjBA, err = packGatedDeltaProjections(
+				linears.Make(layerPrefix+".linear_attn.in_proj_qkv"),
+				linears.Make(layerPrefix+".linear_attn.in_proj_z"),
+				linears.Make(layerPrefix+".linear_attn.in_proj_b"),
+				linears.Make(layerPrefix+".linear_attn.in_proj_a"),
+				linears.Make(layerPrefix+".linear_attn.in_proj_qkvz"),
+				linears.Make(layerPrefix+".linear_attn.in_proj_ba"),
+				cfg,
+			)
+			if err != nil {
+				return fmt.Errorf("layer %d: %w", i, err)
+			}
 			lin.OutProj = linears.Make(layerPrefix + ".linear_attn.out_proj")
 
 			convWeight := sanitizeConvWeight(tensors[layerPrefix+".linear_attn.conv1d.weight"])
@@ -900,9 +903,7 @@ func (m *Model) LoadWeights(tensors map[string]*mlx.Array) error {
 				lin.AExp = mlx.Exp(lin.ALog.AsType(mlx.DTypeFloat32))
 			}
 
-			hasSplit := lin.InProjQKV != nil && lin.InProjZ != nil && lin.InProjB != nil && lin.InProjA != nil
-			hasCombined := lin.InProjQKVZ != nil && lin.InProjBA != nil
-			if (!hasSplit && !hasCombined) || lin.OutProj == nil {
+			if lin.OutProj == nil {
 				return fmt.Errorf("layer %d: missing linear attention projections", i)
 			}
 			if convWeight == nil || lin.NormWeight == nil || lin.DtBias == nil || lin.ALog == nil || lin.AExp == nil {
@@ -987,31 +988,6 @@ func softplus(x *mlx.Array) *mlx.Array {
 	return mlx.Logaddexp(x, mlx.Zeros(x.DType(), x.Dims()...))
 }
 
-func splitQKVZBA(mixedQKVZ, mixedBA *mlx.Array, cfg *Config, B, L int32) (q, k, v, z, beta, alpha *mlx.Array) {
-	nk := cfg.LinearNumKeyHeads
-	nv := cfg.LinearNumValueHeads
-	dk := cfg.LinearKeyHeadDim
-	dv := cfg.LinearValueHeadDim
-	vPerK := nv / nk
-
-	mixedQKVZ = mlx.Reshape(mixedQKVZ, B, L, nk, 2*dk+2*vPerK*dv)
-	q = mlx.SliceStartStop(mixedQKVZ, []int32{0, 0, 0, 0}, []int32{B, L, nk, dk})
-	k = mlx.SliceStartStop(mixedQKVZ, []int32{0, 0, 0, dk}, []int32{B, L, nk, 2 * dk})
-	v = mlx.SliceStartStop(mixedQKVZ, []int32{0, 0, 0, 2 * dk}, []int32{B, L, nk, 2*dk + vPerK*dv})
-	z = mlx.SliceStartStop(mixedQKVZ, []int32{0, 0, 0, 2*dk + vPerK*dv}, []int32{B, L, nk, 2*dk + 2*vPerK*dv})
-
-	v = mlx.Reshape(v, B, L, nv, dv)
-	z = mlx.Reshape(z, B, L, nv, dv)
-
-	mixedBA = mlx.Reshape(mixedBA, B, L, nk, 2*vPerK)
-	beta = mlx.SliceStartStop(mixedBA, []int32{0, 0, 0, 0}, []int32{B, L, nk, vPerK})
-	alpha = mlx.SliceStartStop(mixedBA, []int32{0, 0, 0, vPerK}, []int32{B, L, nk, 2 * vPerK})
-	beta = mlx.Reshape(beta, B, L, nv)
-	alpha = mlx.Reshape(alpha, B, L, nv)
-
-	return q, k, v, z, beta, alpha
-}
-
 func (a *FullAttention) Forward(x *mlx.Array, b *batch.Batch, c cache.Cache, positions *mlx.Array, B, L int32, cfg *Config) *mlx.Array {
 	qg := a.QProj.Forward(x)
 	qg = mlx.Reshape(qg, B, L, cfg.NumAttentionHeads, cfg.HeadDim*2)
@@ -1050,25 +1026,17 @@ func (a *FullAttention) Forward(x *mlx.Array, b *batch.Batch, c cache.Cache, pos
 }
 
 func (g *GatedDeltaNet) Forward(x *mlx.Array, b *batch.Batch, c cache.Cache, B, L int32, cfg *Config) *mlx.Array {
-	var qkv, z, beta, alpha *mlx.Array
-	useSplitProj := g.InProjQKV != nil && g.InProjZ != nil && g.InProjB != nil && g.InProjA != nil
-	if useSplitProj {
-		qkv = g.InProjQKV.Forward(x)
-		z = g.InProjZ.Forward(x)
-		z = mlx.Reshape(z, B, L, cfg.LinearNumValueHeads, cfg.LinearValueHeadDim)
-		beta = g.InProjB.Forward(x)
-		alpha = g.InProjA.Forward(x)
-	} else {
-		mixedQKVZ := g.InProjQKVZ.Forward(x)
-		mixedBA := g.InProjBA.Forward(x)
-		var q, k, v *mlx.Array
-		q, k, v, z, beta, alpha = splitQKVZBA(mixedQKVZ, mixedBA, cfg, B, L)
-		qkv = mlx.Concatenate([]*mlx.Array{
-			mlx.Reshape(q, B, L, cfg.LinearNumKeyHeads*cfg.LinearKeyHeadDim),
-			mlx.Reshape(k, B, L, cfg.LinearNumKeyHeads*cfg.LinearKeyHeadDim),
-			mlx.Reshape(v, B, L, cfg.LinearNumValueHeads*cfg.LinearValueHeadDim),
-		}, -1)
-	}
+	keyDim := cfg.LinearNumKeyHeads * cfg.LinearKeyHeadDim
+	valueDim := cfg.LinearNumValueHeads * cfg.LinearValueHeadDim
+	qkvDim := 2*keyDim + valueDim
+
+	mixedQKVZ := g.InProjQKVZ.Forward(x)
+	mixedBA := g.InProjBA.Forward(x)
+	qkv := mlx.SliceStartStop(mixedQKVZ, []int32{0, 0, 0}, []int32{B, L, qkvDim})
+	z := mlx.SliceStartStop(mixedQKVZ, []int32{0, 0, qkvDim}, []int32{B, L, qkvDim + valueDim})
+	z = mlx.Reshape(z, B, L, cfg.LinearNumValueHeads, cfg.LinearValueHeadDim)
+	beta := mlx.SliceStartStop(mixedBA, []int32{0, 0, 0}, []int32{B, L, cfg.LinearNumValueHeads})
+	alpha := mlx.SliceStartStop(mixedBA, []int32{0, 0, cfg.LinearNumValueHeads}, []int32{B, L, 2 * cfg.LinearNumValueHeads})
 	convTail := cfg.LinearConvKernelDim - 1
 	var rc *cache.RecurrentCache
 	opts := make([]nn.RecurrentOption, 0, 2)
@@ -1091,8 +1059,6 @@ func (g *GatedDeltaNet) Forward(x *mlx.Array, b *batch.Batch, c cache.Cache, B, 
 	convOut, convStates := nn.CausalConv1D(b, qkv, g.Conv1D, int(convTail), opts...)
 	convOut = mlx.SiLU(convOut)
 
-	keyDim := cfg.LinearNumKeyHeads * cfg.LinearKeyHeadDim
-	valueDim := cfg.LinearNumValueHeads * cfg.LinearValueHeadDim
 	q := mlx.SliceStartStop(convOut, []int32{0, 0, 0}, []int32{B, L, keyDim})
 	k := mlx.SliceStartStop(convOut, []int32{0, 0, keyDim}, []int32{B, L, 2 * keyDim})
 	v := mlx.SliceStartStop(convOut, []int32{0, 0, 2 * keyDim}, []int32{B, L, 2*keyDim + valueDim})

--- a/x/models/qwen3_5/qwen3_5.go
+++ b/x/models/qwen3_5/qwen3_5.go
@@ -984,10 +984,6 @@ func (m *Model) LoadWeights(tensors map[string]*mlx.Array) error {
 	return nil
 }
 
-func softplus(x *mlx.Array) *mlx.Array {
-	return mlx.Logaddexp(x, mlx.Zeros(x.DType(), x.Dims()...))
-}
-
 func (a *FullAttention) Forward(x *mlx.Array, b *batch.Batch, c cache.Cache, positions *mlx.Array, B, L int32, cfg *Config) *mlx.Array {
 	qg := a.QProj.Forward(x)
 	qg = mlx.Reshape(qg, B, L, cfg.NumAttentionHeads, cfg.HeadDim*2)
@@ -1035,8 +1031,6 @@ func (g *GatedDeltaNet) Forward(x *mlx.Array, b *batch.Batch, c cache.Cache, B, 
 	qkv := mlx.SliceStartStop(mixedQKVZ, []int32{0, 0, 0}, []int32{B, L, qkvDim})
 	z := mlx.SliceStartStop(mixedQKVZ, []int32{0, 0, qkvDim}, []int32{B, L, qkvDim + valueDim})
 	z = mlx.Reshape(z, B, L, cfg.LinearNumValueHeads, cfg.LinearValueHeadDim)
-	beta := mlx.SliceStartStop(mixedBA, []int32{0, 0, 0}, []int32{B, L, cfg.LinearNumValueHeads})
-	alpha := mlx.SliceStartStop(mixedBA, []int32{0, 0, cfg.LinearNumValueHeads}, []int32{B, L, 2 * cfg.LinearNumValueHeads})
 	convTail := cfg.LinearConvKernelDim - 1
 	var rc *cache.RecurrentCache
 	opts := make([]nn.RecurrentOption, 0, 3)
@@ -1058,25 +1052,7 @@ func (g *GatedDeltaNet) Forward(x *mlx.Array, b *batch.Batch, c cache.Cache, B, 
 	}
 
 	convOut, convStates := nn.CausalConv1D(b, qkv, g.Conv1D, int(convTail), opts...)
-
-	q := mlx.SliceStartStop(convOut, []int32{0, 0, 0}, []int32{B, L, keyDim})
-	k := mlx.SliceStartStop(convOut, []int32{0, 0, keyDim}, []int32{B, L, 2 * keyDim})
-	v := mlx.SliceStartStop(convOut, []int32{0, 0, 2 * keyDim}, []int32{B, L, 2*keyDim + valueDim})
-	q = mlx.Reshape(q, B, L, cfg.LinearNumKeyHeads, cfg.LinearKeyHeadDim)
-	k = mlx.Reshape(k, B, L, cfg.LinearNumKeyHeads, cfg.LinearKeyHeadDim)
-	v = mlx.Reshape(v, B, L, cfg.LinearNumValueHeads, cfg.LinearValueHeadDim)
-	invScale := float32(1.0 / math.Sqrt(float64(cfg.LinearKeyHeadDim)))
-	q = mlx.MulScalar(mlx.RMSNormFn(q, nil, 1e-6), invScale*invScale)
-	k = mlx.MulScalar(mlx.RMSNormFn(k, nil, 1e-6), invScale)
-
-	gDecay := softplus(mlx.Add(alpha, g.DtBias))
-	gDecay = mlx.Mul(gDecay, g.AExp)
-	gDecay = mlx.Exp(mlx.MulScalar(gDecay, -1))
-	gDecay = gDecay.AsType(alpha.DType())
-
-	betaGate := mlx.Sigmoid(beta)
-
-	out, deltaStates := nn.GatedDelta(b, q, k, v, gDecay, betaGate, opts...)
+	out, deltaStates := nn.GatedDelta(b, convOut, mixedBA, g.DtBias, g.AExp, opts...)
 	outDType := out.DType()
 	out = mlx.RMSNormFn(out, g.NormWeight, cfg.RMSNormEps)
 	out = mlx.Mul(out.AsType(mlx.DTypeFloat32), mlx.SiLU(z.AsType(mlx.DTypeFloat32))).AsType(outDType)

--- a/x/models/qwen3_5/qwen3_5.go
+++ b/x/models/qwen3_5/qwen3_5.go
@@ -1039,7 +1039,8 @@ func (g *GatedDeltaNet) Forward(x *mlx.Array, b *batch.Batch, c cache.Cache, B, 
 	alpha := mlx.SliceStartStop(mixedBA, []int32{0, 0, cfg.LinearNumValueHeads}, []int32{B, L, 2 * cfg.LinearNumValueHeads})
 	convTail := cfg.LinearConvKernelDim - 1
 	var rc *cache.RecurrentCache
-	opts := make([]nn.RecurrentOption, 0, 2)
+	opts := make([]nn.RecurrentOption, 0, 3)
+	opts = append(opts, nn.WithConvSiLU())
 	if typed, ok := c.(*cache.RecurrentCache); ok {
 		rc = typed
 		opts = append(opts, nn.WithRecurrentHistory(rc.Get(b, x.DType())))
@@ -1057,7 +1058,6 @@ func (g *GatedDeltaNet) Forward(x *mlx.Array, b *batch.Batch, c cache.Cache, B, 
 	}
 
 	convOut, convStates := nn.CausalConv1D(b, qkv, g.Conv1D, int(convTail), opts...)
-	convOut = mlx.SiLU(convOut)
 
 	q := mlx.SliceStartStop(convOut, []int32{0, 0, 0}, []int32{B, L, keyDim})
 	k := mlx.SliceStartStop(convOut, []int32{0, 0, keyDim}, []int32{B, L, 2 * keyDim})


### PR DESCRIPTION
qwen3.5 checkpoints include an MTP head, which we currently discard when loading the model. This change loads it and uses it as a draft model for speculative decoding in the MLX engine. Speculation turns on automatically when the head is present and doesn't need any configuration. On an M5 Max, the 35B MoE goes from 131 to 162 tokens/s on coding prompts (about 24% faster) and 15-20% faster on prose. The dense 27B goes from 31 to 53 tokens/s on code (about 70% faster) and 32 to 50 on prose (about 60%).

The dense model benefits more because verifying several drafted tokens in a single forward pass reads the weights once instead of once per token. On a MoE, each token is routed to different experts, so verification reads about as many weights as decoding the tokens individually. The remaining savings come from overhead that is paid per forward pass rather than per token, mostly the dispatch cost of the hundreds of small kernels in each pass, so speculation only pays off there if that overhead is kept small.

To reduce it, the GatedDeltaNet step now runs as two fused Metal kernels (conv+SiLU and the recurrence) instead of dozens of graph ops. This also makes regular decoding about 11% faster. During verification, the recurrence kernel returns the state after each drafted token so that rejected tokens can be rolled back without launching additional kernels for each layer and position. Backends without these kernels, or inputs that they don't handle, use the same step built from graph ops.

The GDN input projections are now packed into a single layout when the model is loaded. This handles the different checkpoint variants that have been published (split or fused projections, bf16 or quantized, including nvfp4's per-tensor and per-row global scales) and lets the kernels read one tensor instead of four.

This also fixes scalar reads in the MLX bindings to use the array's element width - previously, reading an Int from an int32 array would read 8 bytes.