### PR TITLE
lint: clean up current tree

### DIFF
--- a/agent/session.go
+++ b/agent/session.go
@@ -474,7 +474,6 @@ func (s *Session) executeToolCalls(ctx context.Context, runID string, opts RunOp
 	batch := toolBatchResult{
 		messages: make([]api.Message, 0, len(calls)),
 	}
-	projectedMessages := append([]api.Message(nil), messages...)
 	// Pre-compute the full-history token estimate once per batch instead of
 	// re-marshaling the entire history for each tool call. Per-call deltas
 	// (tool messages already appended this batch) are tracked in batchTokens
@@ -530,7 +529,6 @@ func (s *Session) executeToolCalls(ctx context.Context, runID string, opts RunOp
 			for _, plan := range plans {
 				msg := s.toolMessageForContext(plan.toolName, plan.call.ID, content, opts, historyTokens+batchTokens)
 				batch.messages = append(batch.messages, msg)
-				projectedMessages = append(projectedMessages, msg)
 				batchTokens += estimateMessagesTokens([]api.Message{msg})
 				deniedContent := msg.Content
 				if emitErr := s.emit(newToolFinished(meta, "denied", plan.call.ID, plan.toolName, "", plan.args, deniedContent, deniedContent)); emitErr != nil {
@@ -559,7 +557,6 @@ func (s *Session) executeToolCalls(ctx context.Context, runID string, opts RunOp
 			content := fmt.Sprintf("Error: unknown tool: %s", toolName)
 			msg := s.toolMessageForContext(toolName, call.ID, content, opts, historyTokens+batchTokens)
 			batch.messages = append(batch.messages, msg)
-			projectedMessages = append(projectedMessages, msg)
 			batchTokens += estimateMessagesTokens([]api.Message{msg})
 			content = msg.Content
 			if toolOutputFullyOmitted(content) {
@@ -580,7 +577,6 @@ func (s *Session) executeToolCalls(ctx context.Context, runID string, opts RunOp
 			rawContent := fmt.Sprintf("Error: %v", err)
 			msg := s.toolMessageForContext(toolName, call.ID, rawContent, opts, historyTokens+batchTokens)
 			batch.messages = append(batch.messages, msg)
-			projectedMessages = append(projectedMessages, msg)
 			batchTokens += estimateMessagesTokens([]api.Message{msg})
 			content := msg.Content
 			if toolOutputFullyOmitted(content) {
@@ -609,7 +605,6 @@ func (s *Session) executeToolCalls(ctx context.Context, runID string, opts RunOp
 
 		msg := s.toolMessageForContext(toolName, call.ID, rawContent, opts, historyTokens+batchTokens)
 		batch.messages = append(batch.messages, msg)
-		projectedMessages = append(projectedMessages, msg)
 		batchTokens += estimateMessagesTokens([]api.Message{msg})
 		content := msg.Content
 
@@ -637,7 +632,6 @@ func (s *Session) disabledToolCalls(ctx context.Context, runID string, opts RunO
 	batch := toolBatchResult{
 		messages: make([]api.Message, 0, len(calls)),
 	}
-	projectedMessages := append([]api.Message(nil), messages...)
 	historyTokens := s.estimateRunPromptTokens(opts, messages)
 	batchTokens := 0
 	for _, call := range calls {
@@ -645,7 +639,6 @@ func (s *Session) disabledToolCalls(ctx context.Context, runID string, opts RunO
 		args := call.Function.Arguments.ToMap()
 		msg := s.toolMessageForContext(toolName, call.ID, toolExecutionDisabledMessage, opts, historyTokens+batchTokens)
 		batch.messages = append(batch.messages, msg)
-		projectedMessages = append(projectedMessages, msg)
 		batchTokens += estimateMessagesTokens([]api.Message{msg})
 		if emitErr := s.emitIgnoringCanceled(ctx, newToolFinished(meta, "disabled", call.ID, toolName, "", args, msg.Content, msg.Content)); emitErr != nil {
 			return toolBatchResult{}, emitErr

--- a/api/types.go
+++ b/api/types.go
@@ -696,7 +696,7 @@ type CreateRequest struct {
 	Renderer string `json:"renderer,omitempty"`
 
 	// Parser is the name of the parser used to parse the output of the request.
-	Parser   string `json:"parser,omitempty"`
+	Parser string `json:"parser,omitempty"`
 
 	// Requires is the minimum version of Ollama required by the model.
 	Requires string `json:"requires,omitempty"`

--- a/cmd/agent_tui.go
+++ b/cmd/agent_tui.go
@@ -178,41 +178,17 @@ func agentSkillSystemContext(catalog *coreagent.SkillCatalog, registry *coreagen
 	return catalog.SystemContext()
 }
 
-func selectAgentModel(ctx context.Context, client *api.Client, current string) (string, error) {
-	models, err := agentModelOptions(ctx, client)
-	if err != nil {
-		return "", err
-	}
-	if len(models) == 0 {
-		return "", errors.New("no models available, run 'ollama pull <model>' first")
-	}
-
-	items := agentSelectionItems(models)
-	switch {
-	case launch.DefaultSingleSelectorWithUpdates != nil:
-		return launch.DefaultSingleSelectorWithUpdates("Select model to run:", items, current, nil)
-	case launch.DefaultSingleSelector != nil:
-		return launch.DefaultSingleSelector("Select model to run:", items, current)
-	default:
-		return "", errors.New("no selector configured")
-	}
-}
-
 func agentSelectionItems(models []agentchat.ModelOption) []launch.SelectionItem {
 	items := make([]launch.SelectionItem, 0, len(models))
 	for _, model := range models {
 		items = append(items, launch.SelectionItem{
 			Name:              model.Name,
-			Description:       agentSelectionDescription(model),
+			Description:       strings.TrimSpace(model.Description),
 			Recommended:       model.Recommended,
 			AvailabilityBadge: model.AvailabilityBadge,
 		})
 	}
 	return items
-}
-
-func agentSelectionDescription(model agentchat.ModelOption) string {
-	return strings.TrimSpace(model.Description)
 }
 
 var agentGetwd = os.Getwd

--- a/model/renderers/laguna_test.go
+++ b/model/renderers/laguna_test.go
@@ -19,8 +19,10 @@ const (
 
 // lagunaToolJSON is the get_weather tool as serialized into <available_tools>,
 // matching lagunaWeatherTool().
-const lagunaToolJSON = `{"type": "function", "function": {"name": "get_weather", "description": "Get weather", "parameters": {"type": "object", "required": ["location"], "properties": {"location": {"type": "string", "description": "City"}}}}}`
-const lagunaMathToolJSON = `{"type": "function", "function": {"name": "add", "description": "Add numbers", "parameters": {"type": "object", "required": ["a", "b"], "properties": {"a": {"type": "number", "description": "First number"}, "b": {"type": "number", "description": "Second number"}}}}}`
+const (
+	lagunaToolJSON     = `{"type": "function", "function": {"name": "get_weather", "description": "Get weather", "parameters": {"type": "object", "required": ["location"], "properties": {"location": {"type": "string", "description": "City"}}}}}`
+	lagunaMathToolJSON = `{"type": "function", "function": {"name": "add", "description": "Add numbers", "parameters": {"type": "object", "required": ["a", "b"], "properties": {"a": {"type": "number", "description": "First number"}, "b": {"type": "number", "description": "Second number"}}}}}`
+)
 
 // TestLagunaRendererReferenceFlowCoverage checks the renderer against byte-for-byte
 // expected output from the Laguna v2 chat template. VERIFY_JINJA2=1 also verifies


### PR DESCRIPTION
Other large PRs are tripping over github actions CI quirks and linting the whole tree instead of just the touched files.  This should get the whole tree lint clean so those PRs can go green without having to carry unrelated lint fixes.