### PR TITLE
CI: enable lint on the whole tree

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -416,5 +416,3 @@ jobs:
         run: go test -count=1 -tags updater_live ./app/...
 
       - uses: golangci/golangci-lint-action@v9
-        with:
-          only-new-issues: true

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -83,14 +83,6 @@ func createTestFile(t *testing.T, name string) (string, string) {
 	return f.Name(), digest
 }
 
-type panicTransport struct{}
-
-func (t *panicTransport) RoundTrip(r *http.Request) (*http.Response, error) {
-	panic("unexpected RoundTrip call")
-}
-
-var panicOnRoundTrip = &http.Client{Transport: &panicTransport{}}
-
 func TestRoutes(t *testing.T) {
 	modelsDir := t.TempDir()
 	t.Setenv("OLLAMA_MODELS", modelsDir)

--- a/x/create/create.go
+++ b/x/create/create.go
@@ -314,9 +314,7 @@ func GetTensorQuantization(name string, shape []int32, quantize string) string {
 	return quantNorm
 }
 
-var (
-	expertLayerPrefixRegexp = regexp.MustCompile(`^(?:model\.language_model\.|language_model(?:\.model)?\.|model\.)?layers\.\d+$`)
-)
+var expertLayerPrefixRegexp = regexp.MustCompile(`^(?:model\.language_model\.|language_model(?:\.model)?\.|model\.)?layers\.\d+$`)
 
 // ExpertGroupPrefix returns the group prefix for expert tensors that should be packed together.
 // For example:


### PR DESCRIPTION
golangci-lint ran with only-new-issues, which filters findings down to the lines a PR adds. That silently drops any issue a diff introduces at a distance, where the report anchors to a line the diff never touched. CI now is enabled to scan all files.  This PR also fixes the last few straggler lint glitches outside of integration, which I'll tackle in a follow up PR.