### PR TITLE
fix(ui): disable sidebar transition on initial load

### DIFF
--- a/app/ui/app/src/components/layout/layout.tsx
+++ b/app/ui/app/src/components/layout/layout.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from "react";
 import { Link } from "@tanstack/react-router";
 import { useSettings } from "@/hooks/useSettings";
 
@@ -11,11 +12,18 @@ export function SidebarLayout({
 }>) {
   const { settings, setSettings } = useSettings();
   const isWindows = navigator.platform.toLowerCase().includes("win");
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    // Delay adding transition classes so they don't fire on initial load
+    const timer = setTimeout(() => setIsMounted(true), 50);
+    return () => clearTimeout(timer);
+  }, []);
 
   return (
-    <div className={`flex transition-[width] duration-300 dark:bg-neutral-900`}>
+    <div className={`flex ${isMounted ? "transition-[width] duration-300" : ""} dark:bg-neutral-900`} >
       <div
-        className={`absolute flex mx-2 py-2 z-20 items-center transition-[left] duration-375 text-neutral-500 dark:text-neutral-400 ${settings.sidebarOpen ? (isWindows ? "left-2" : "left-[204px]") : isWindows ? "left-2" : "left-20"}`}
+        className={`absolute flex mx-2 py-2 z-20 items-center ${isMounted ? "transition-[left] duration-375" : ""} text-neutral-500 dark:text-neutral-400 ${settings.sidebarOpen ? (isWindows ? "left-2" : "left-[204px]") : isWindows ? "left-2" : "left-20"}`}
       >
         <button
           onClick={() => setSettings({ SidebarOpen: !settings.sidebarOpen })}
@@ -39,7 +47,7 @@ export function SidebarLayout({
           to="/c/$chatId"
           params={{ chatId: "new" }}
           title="New chat"
-          className={`flex ml-1 items-center justify-center rounded-full transition-opacity duration-375 h-9 w-9 hover:bg-neutral-100 dark:hover:bg-neutral-700 ${
+          className={`flex ml-1 items-center justify-center rounded-full ${isMounted ? "transition-opacity duration-375" : ""} h-9 w-9 hover:bg-neutral-100 dark:hover:bg-neutral-700 ${
             settings.sidebarOpen
               ? "opacity-0 pointer-events-none"
               : "opacity-100"
@@ -57,7 +65,7 @@ export function SidebarLayout({
         </Link>
       </div>
       <div
-        className={`flex flex-col transition-[width] duration-300 max-h-screen ${settings.sidebarOpen ? "w-64" : "w-0"}`}
+        className={`flex flex-col ${isMounted ? "transition-[width] duration-300" : ""} max-h-screen ${settings.sidebarOpen ? "w-64" : "w-0"}`}
       >
         <div
           onDoubleClick={() => window.doubleClick && window.doubleClick()}
@@ -67,7 +75,7 @@ export function SidebarLayout({
         {settings.sidebarOpen && sidebar}
       </div>
       <main
-        className={`flex flex-1 flex-col min-w-0 transition-all duration-300`}
+        className={`flex flex-1 flex-col min-w-0 ${isMounted ? "transition-all duration-300" : ""}`}
       >
         <div
           className={`h-13 flex-none w-full z-10 flex items-center bg-white dark:bg-neutral-900 ${isWindows ? "xl:hidden" : "xl:fixed xl:bg-transparent xl:dark:bg-transparent"}`}


### PR DESCRIPTION
Fixes #12954

**What changed?**
- Used `isMounted` state in `layout.tsx` to delay applying `transition-[width]` classes by 50ms.
- This ensures the sidebar doesn't animate/slide on the initial load and respects the user's saved layout state immediately.
