### PR TITLE
server: also log responses when OLLAMA_DEBUG_LOG_REQUESTS is set

### DIFF
--- a/server/inference_request_log.go
+++ b/server/inference_request_log.go
@@ -79,12 +79,34 @@ func (l *inferenceRequestLogger) middleware(route string) gin.HandlerFunc {
 			}
 		}
 
+		capture := &responseCapture{ResponseWriter: c.Writer}
+		c.Writer = capture
+
 		c.Next()
-		l.log(route, method, scheme, host, contentType, body)
+		l.log(route, method, scheme, host, contentType, body, capture.buf.Bytes(), capture.Header().Get("Content-Type"))
 	}
 }
 
-func (l *inferenceRequestLogger) log(route, method, scheme, host, contentType string, body []byte) {
+// responseCapture tees everything written to the client into a buffer so the
+// debug logger can persist the response after the handler completes. Streaming
+// handlers call Write per chunk, so the capture works for both streamed and
+// non-streamed responses without changing flush behavior.
+type responseCapture struct {
+	gin.ResponseWriter
+	buf bytes.Buffer
+}
+
+func (w *responseCapture) Write(b []byte) (int, error) {
+	w.buf.Write(b)
+	return w.ResponseWriter.Write(b)
+}
+
+func (w *responseCapture) WriteString(s string) (int, error) {
+	w.buf.WriteString(s)
+	return w.ResponseWriter.WriteString(s)
+}
+
+func (l *inferenceRequestLogger) log(route, method, scheme, host, contentType string, body, response []byte, responseContentType string) {
 	if l == nil || l.dir == "" {
 		return
 	}
@@ -121,7 +143,20 @@ func (l *inferenceRequestLogger) log(route, method, scheme, host, contentType st
 		return
 	}
 
-	slog.Info(fmt.Sprintf("logged to %s, replay using curl with `sh %s`", bodyPath, curlPath))
+	// Streamed responses (NDJSON, SSE) are concatenated chunks rather than a
+	// single JSON document, so only use a .json extension for application/json.
+	responseExt := "txt"
+	if responseContentType == "application/json" || strings.HasPrefix(responseContentType, "application/json;") {
+		responseExt = "json"
+	}
+	responseFilename := fmt.Sprintf("%s_%s_response.%s", timestamp, routeForFilename, responseExt)
+	responsePath := filepath.Join(l.dir, responseFilename)
+	if err := os.WriteFile(responsePath, response, 0o600); err != nil {
+		slog.Warn("failed to write debug response body", "route", route, "error", err)
+		return
+	}
+
+	slog.Info(fmt.Sprintf("logged to %s with response in %s, replay using curl with `sh %s`", bodyPath, responsePath, curlPath))
 }
 
 func sanitizeRouteForFilename(route string) string {

--- a/server/routes_request_log_test.go
+++ b/server/routes_request_log_test.go
@@ -20,6 +20,7 @@ func TestInferenceRequestLoggerMiddlewareWritesReplayArtifacts(t *testing.T) {
 
 	const route = "/v1/chat/completions"
 	const requestBody = `{"model":"test-model","messages":[{"role":"user","content":"hello"}]}`
+	const responseBody = `{"id":"chatcmpl-1","choices":[{"message":{"role":"assistant","content":"hi"}}]}`
 
 	var bodySeenByHandler string
 
@@ -31,7 +32,7 @@ func TestInferenceRequestLoggerMiddlewareWritesReplayArtifacts(t *testing.T) {
 		}
 
 		bodySeenByHandler = string(body)
-		c.Status(http.StatusOK)
+		c.Data(http.StatusOK, "application/json", []byte(responseBody))
 	})
 
 	req := httptest.NewRequest(http.MethodPost, route, strings.NewReader(requestBody))
@@ -85,6 +86,120 @@ func TestInferenceRequestLoggerMiddlewareWritesReplayArtifacts(t *testing.T) {
 	bodyFileName := filepath.Base(bodyFiles[0])
 	if !strings.Contains(curlString, "@\"${SCRIPT_DIR}/"+bodyFileName+"\"") {
 		t.Fatalf("curl log does not reference sibling body file: %s", curlString)
+	}
+
+	if w.Body.String() != responseBody {
+		t.Fatalf("client response mismatch:\nexpected: %s\ngot: %s", responseBody, w.Body.String())
+	}
+
+	responseFiles, err := filepath.Glob(filepath.Join(logDir, "*_v1_chat_completions_response.json"))
+	if err != nil {
+		t.Fatalf("failed to glob response logs: %v", err)
+	}
+	if len(responseFiles) != 1 {
+		t.Fatalf("expected 1 response log, got %d (%v)", len(responseFiles), responseFiles)
+	}
+
+	responseData, err := os.ReadFile(responseFiles[0])
+	if err != nil {
+		t.Fatalf("failed to read response log: %v", err)
+	}
+	if string(responseData) != responseBody {
+		t.Fatalf("response log mismatch:\nexpected: %s\ngot: %s", responseBody, string(responseData))
+	}
+}
+
+func TestInferenceRequestLoggerMiddlewareCapturesStreamedResponse(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	logDir := t.TempDir()
+	requestLogger := &inferenceRequestLogger{dir: logDir}
+
+	const route = "/api/chat"
+	chunks := []string{
+		`{"message":{"role":"assistant","content":"he"},"done":false}` + "\n",
+		`{"message":{"role":"assistant","content":"llo"},"done":false}` + "\n",
+		`{"message":{"role":"assistant","content":""},"done":true}` + "\n",
+	}
+
+	r := gin.New()
+	r.POST(route, requestLogger.middleware(route), func(c *gin.Context) {
+		c.Header("Content-Type", "application/x-ndjson")
+		c.Status(http.StatusOK)
+		for _, chunk := range chunks {
+			if _, err := c.Writer.Write([]byte(chunk)); err != nil {
+				t.Fatalf("failed to write chunk: %v", err)
+			}
+			c.Writer.Flush()
+		}
+	})
+
+	req := httptest.NewRequest(http.MethodPost, route, strings.NewReader(`{"model":"test-model"}`))
+	req.Host = "127.0.0.1:11434"
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	want := strings.Join(chunks, "")
+	if w.Body.String() != want {
+		t.Fatalf("client response mismatch:\nexpected: %s\ngot: %s", want, w.Body.String())
+	}
+
+	responseFiles, err := filepath.Glob(filepath.Join(logDir, "*_api_chat_response.txt"))
+	if err != nil {
+		t.Fatalf("failed to glob response logs: %v", err)
+	}
+	if len(responseFiles) != 1 {
+		t.Fatalf("expected 1 response log, got %d (%v)", len(responseFiles), responseFiles)
+	}
+
+	responseData, err := os.ReadFile(responseFiles[0])
+	if err != nil {
+		t.Fatalf("failed to read response log: %v", err)
+	}
+	if string(responseData) != want {
+		t.Fatalf("response log mismatch:\nexpected: %s\ngot: %s", want, string(responseData))
+	}
+}
+
+func TestInferenceRequestLoggerMiddlewareCapturesErrorResponse(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	logDir := t.TempDir()
+	requestLogger := &inferenceRequestLogger{dir: logDir}
+
+	const route = "/api/generate"
+	const errorBody = `{"error":"model not found"}`
+
+	r := gin.New()
+	r.POST(route, requestLogger.middleware(route), func(c *gin.Context) {
+		c.Data(http.StatusNotFound, "application/json", []byte(errorBody))
+	})
+
+	req := httptest.NewRequest(http.MethodPost, route, strings.NewReader(`{"model":"missing"}`))
+	req.Host = "127.0.0.1:11434"
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected status 404, got %d", w.Code)
+	}
+
+	responseFiles, err := filepath.Glob(filepath.Join(logDir, "*_api_generate_response.json"))
+	if err != nil {
+		t.Fatalf("failed to glob response logs: %v", err)
+	}
+	if len(responseFiles) != 1 {
+		t.Fatalf("expected 1 response log, got %d (%v)", len(responseFiles), responseFiles)
+	}
+
+	responseData, err := os.ReadFile(responseFiles[0])
+	if err != nil {
+		t.Fatalf("failed to read response log: %v", err)
+	}
+	if string(responseData) != errorBody {
+		t.Fatalf("response log mismatch:\nexpected: %s\ngot: %s", errorBody, string(responseData))
 	}
 }
 


### PR DESCRIPTION
Implements #17438.

`OLLAMA_DEBUG_LOG_REQUESTS` currently writes two artifacts per inference request — the raw body (`*_body.json`) and a replay curl script (`*_request.sh`) — but never captures what the server answered, which is usually the half you need when debugging generations, tool-calling behavior, or the `/v1/*` compat middleware transformations.

This wraps `gin.ResponseWriter` in the existing debug middleware with a small tee (`responseCapture`) that copies every chunk written to the client into a buffer, and writes a third artifact after the handler completes:

- `<timestamp>_<route>_response.json` when the response Content-Type is `application/json`
- `<timestamp>_<route>_response.txt` otherwise (streamed NDJSON/SSE output is concatenated chunks, not a single JSON document)

Design notes:

- Tee-ing happens inside `Write`/`WriteString`, so it works identically for streamed and non-streamed responses and doesn't change flush behavior — the client receives exactly the same bytes (asserted in tests).
- Responses are logged for non-2xx statuses too, since error responses are typically the thing being debugged.
- No new env var: this completes what the existing flag already promises.
- Scoped to response capture only. #17437 (write request artifacts on arrival, PR #17440) touches the same `log()` call site but composes with this either way; #17439 (continuous log file) is intentionally left alone.
- Like the request side, the response is buffered in memory for the duration of the request. This is a debug-only, opt-in path, but happy to add a size cap if you'd prefer.

Tests (extends `routes_request_log_test.go`):

- existing replay-artifacts test now also asserts the response artifact exists and matches the handler output byte-for-byte
- new streamed-response test: 3 NDJSON chunks with explicit `Flush`, asserts both the client bytes and the captured `_response.txt` equal the concatenation
- new non-2xx test: 404 with JSON error body still produces a `_response.json` with the error payload

Verified with `go build`, `go vet`, `gofmt` locally, and the full `test` workflow (ubuntu/windows/macos) green on my fork before opening this PR.
