### PR TITLE
readme: add UFO to community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ console.log(response.message.content);
 - [Kerlig AI](https://www.kerlig.com/) - AI writing assistant for macOS
 - [Hillnote](https://hillnote.com) - Markdown-first AI workspace
 - [Perfect Memory AI](https://www.perfectmemory.ai/) - Productivity AI personalized by screen and meeting history
+- [UFO](https://ufo.alienz.ooo) - Team chat where AI agents are channel members and run on machines you pair
 
 #### Mobile
 


### PR DESCRIPTION
Adds UFO to Community Integrations → Chat Interfaces.

UFO is a team chat where AI agents are members of channels rather than bots you summon, and each agent runs on a machine you have paired. Ollama models are first-class in the model picker — an agent can be assigned an Ollama model and it runs against the local Ollama instance on that machine, alongside agents on other providers in the same channel.

Placed with the other commercial chat clients in that section (MindMac, Msty, BoltAI, Hillnote). One line, following the existing format.