### PR TITLE
api: add input token count routes

### DIFF
--- a/anthropic/anthropic.go
+++ b/anthropic/anthropic.go
@@ -1073,6 +1073,22 @@ type CountTokensRequest struct {
 	Thinking *ThinkingConfig `json:"thinking,omitempty"`
 }
 
+// FromCountTokensRequest converts an Anthropic count_tokens request to an Ollama chat request.
+// count_tokens carries no max_tokens, but FromMessagesRequest maps it straight to
+// num_predict, where 0 means "generate nothing" rather than "unset", so ask for the
+// smallest non-degenerate value. Nothing is generated either way - the caller sets
+// DebugRenderOnly.
+func FromCountTokensRequest(r CountTokensRequest) (*api.ChatRequest, error) {
+	return FromMessagesRequest(MessagesRequest{
+		Model:     r.Model,
+		MaxTokens: 1,
+		Messages:  r.Messages,
+		System:    r.System,
+		Tools:     r.Tools,
+		Thinking:  r.Thinking,
+	})
+}
+
 // EstimateInputTokens estimates input tokens from a MessagesRequest (reuses CountTokensRequest logic)
 func EstimateInputTokens(req MessagesRequest) int {
 	return estimateTokens(CountTokensRequest{

--- a/api/client.go
+++ b/api/client.go
@@ -305,6 +305,35 @@ func (c *Client) Chat(ctx context.Context, req *ChatRequest, fn ChatResponseFunc
 	})
 }
 
+// ChatInputTokens returns the rendered input token count for a chat request
+// without running model inference.
+func (c *Client) ChatInputTokens(ctx context.Context, req *ChatRequest) (*InputTokensResponse, error) {
+	if req == nil {
+		return nil, errors.New("nil chat request")
+	}
+
+	renderReq := *req
+	stream := false
+	renderReq.Stream = &stream
+	renderReq.DebugRenderOnly = true
+
+	var result InputTokensResponse
+	if err := c.Chat(ctx, &renderReq, func(resp ChatResponse) error {
+		if resp.DebugInfo == nil {
+			return errors.New("chat input token count response missing debug info")
+		}
+		if resp.DebugInfo.InputTokens == nil {
+			return errors.New("chat input token count response missing input tokens")
+		}
+		result.InputTokens = *resp.DebugInfo.InputTokens
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
 // PullProgressFunc is a function that [Client.Pull] invokes every time there
 // is progress with a "pull" request sent to the service. If this function
 // returns an error, [Client.Pull] will stop the process and return this error.

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -48,6 +49,46 @@ func TestClientFromEnvironment(t *testing.T) {
 				t.Fatalf("expected %s, got %s", v.expect, client.base.String())
 			}
 		})
+	}
+}
+
+func TestClientChatInputTokens(t *testing.T) {
+	inputTokens := 42
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/chat" {
+			t.Fatalf("path = %q, want /api/chat", r.URL.Path)
+		}
+		var req ChatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatal(err)
+		}
+		if !req.DebugRenderOnly {
+			t.Fatal("DebugRenderOnly = false, want true")
+		}
+		if req.Stream == nil || *req.Stream {
+			t.Fatalf("Stream = %v, want false", req.Stream)
+		}
+		_ = json.NewEncoder(w).Encode(ChatResponse{
+			DebugInfo: &DebugInfo{InputTokens: &inputTokens},
+		})
+	}))
+	defer server.Close()
+
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := NewClient(u, server.Client())
+
+	resp, err := client.ChatInputTokens(context.Background(), &ChatRequest{
+		Model:    "test-model",
+		Messages: []Message{{Role: "user", Content: "hello"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.InputTokens != 42 {
+		t.Fatalf("InputTokens = %d, want 42", resp.InputTokens)
 	}
 }
 

--- a/api/types.go
+++ b/api/types.go
@@ -548,10 +548,15 @@ type ChatResponse struct {
 	Metrics
 }
 
-// DebugInfo contains debug information for template rendering
+// DebugInfo contains debug information for template rendering.
 type DebugInfo struct {
 	RenderedTemplate string `json:"rendered_template"`
 	ImageCount       int    `json:"image_count,omitempty"`
+	InputTokens      *int   `json:"input_tokens,omitempty"`
+}
+
+type InputTokensResponse struct {
+	InputTokens int `json:"input_tokens"`
 }
 
 type Metrics struct {

--- a/docs/api/anthropic-compatibility.mdx
+++ b/docs/api/anthropic-compatibility.mdx
@@ -342,6 +342,42 @@ claude --model qwen3-coder
 - [x] `ping`
 - [x] `error`
 
+### `/v1/messages/count_tokens`
+
+Returns the number of input tokens a request would consume, without generating
+anything:
+
+```shell
+curl -X POST http://localhost:11434/v1/messages/count_tokens \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "qwen3-coder",
+    "messages": [{"role": "user", "content": "Hello"}]
+  }'
+```
+
+```json
+{
+  "input_tokens": 11
+}
+```
+
+#### Supported request fields
+
+- [x] `model`
+- [x] `messages`
+- [x] `system`
+- [x] `tools`
+- [x] `thinking`
+
+The count is of the prompt rendered from the whole request, so it reflects the
+chat template, the tool definitions and the thinking delimiters - not just the
+message text. Unlike `/v1/messages`, the request is never truncated to fit the
+context window, so the count can legitimately exceed it.
+
+Requests containing images are counted as text only: the image markers in the
+rendered prompt are counted, the image embeddings they stand for are not.
+
 ## Models
 
 Ollama supports both local and cloud models.
@@ -396,7 +432,11 @@ curl http://localhost:11434/v1/messages \
 
 - API key is accepted but not validated
 - `anthropic-version` header is accepted but not used
-- Token counts are approximations based on the underlying model's tokenizer
+- `/v1/messages/count_tokens` counts the rendered prompt with the underlying
+  model's tokenizer, and a non-streaming `/v1/messages` response reports the
+  count the model itself evaluated. A streaming response has neither available
+  when it must emit `message_start`, so its `usage.input_tokens` can be an
+  approximation
 
 ### Not supported
 
@@ -404,7 +444,6 @@ The following Anthropic API features are not currently supported:
 
 | Feature | Description |
 |---------|-------------|
-| `/v1/messages/count_tokens` | Token counting endpoint |
 | `tool_choice` | Forcing specific tool use or disabling tools |
 | `metadata` | Request metadata (user_id) |
 | Prompt caching | `cache_control` blocks for caching prefixes |

--- a/docs/api/openai-compatibility.mdx
+++ b/docs/api/openai-compatibility.mdx
@@ -306,6 +306,36 @@ Ollama supports the [OpenAI Responses API](https://platform.openai.com/docs/api-
 - [ ] `conversation` (stateful v1/responses not supported)
 - [ ] `truncation`
 
+### `/v1/chat/completions/input_tokens` and `/v1/responses/input_tokens`
+
+Ollama extensions, with no counterpart in the OpenAI API. Each accepts the same
+request body as the endpoint it hangs off and returns the number of input tokens
+that request would consume, without generating anything:
+
+```shell
+curl -X POST http://localhost:11434/v1/chat/completions/input_tokens \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "llama3.2",
+    "messages": [{"role": "user", "content": "Hello"}]
+  }'
+```
+
+```json
+{
+  "object": "response.input_tokens",
+  "input_tokens": 11
+}
+```
+
+The count is of the prompt rendered from the whole request, so it reflects the
+chat template and the tool definitions, not just the message text. Unlike the
+generating endpoints, the request is never truncated to fit the context window,
+so the count can legitimately exceed it.
+
+Requests containing images are counted as text only: the image markers in the
+rendered prompt are counted, the image embeddings they stand for are not.
+
 ## Models
 
 Before using a model, pull it locally `ollama pull`:

--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -2464,6 +2464,16 @@ func (s *llamaServerRunner) Tokenize(ctx context.Context, content string) ([]int
 	return s.tokenize(ctx, content, false, nil)
 }
 
+// TokenizeForCompletion implements llm.LlamaServer. It applies the same BOS
+// normalization Completion does before handing the prompt to /tokenize with
+// add_special set, so the count matches what /completion will see. A prompt
+// llama-server templated itself and will send through /v1/chat/completions is
+// only approximated: it passes through the same normalization even though that
+// path tokenizes internally.
+func (s *llamaServerRunner) TokenizeForCompletion(ctx context.Context, prompt, leadingBOS string) ([]int, error) {
+	return s.tokenize(ctx, s.completionPrompt(prompt, leadingBOS), true, nil)
+}
+
 // Detokenize calls llama-server's /detokenize endpoint.
 func (s *llamaServerRunner) Detokenize(ctx context.Context, tokens []int) (string, error) {
 	data, err := json.Marshal(map[string][]int{"tokens": tokens})

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -1628,6 +1628,50 @@ func TestLlamaServerTokenize(t *testing.T) {
 	}
 }
 
+func TestLlamaServerTokenizeForCompletion(t *testing.T) {
+	var got struct {
+		Content    string `json:"content"`
+		AddSpecial bool   `json:"add_special"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/tokenize" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			return
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatal(err)
+		}
+		fmt.Fprint(w, `{"tokens":[1,2,3]}`)
+	}))
+	defer srv.Close()
+
+	parts := strings.Split(srv.URL, ":")
+	var portInt int
+	fmt.Sscanf(parts[len(parts)-1], "%d", &portInt)
+
+	runner := &llamaServerRunner{
+		port: portInt,
+		cmd:  fakeRunningCmd(),
+		ggml: loadTestGGML(t, ggml.KV{
+			"general.architecture":         "gemma3",
+			"tokenizer.ggml.add_bos_token": true,
+		}),
+	}
+	tokens, err := runner.TokenizeForCompletion(t.Context(), "<bos>hello world", "<bos>")
+	if err != nil {
+		t.Fatalf("TokenizeForCompletion error: %v", err)
+	}
+	if got.Content != "hello world" {
+		t.Fatalf("content = %q, want hello world", got.Content)
+	}
+	if !got.AddSpecial {
+		t.Fatal("add_special = false, want true")
+	}
+	if len(tokens) != 3 || tokens[0] != 1 || tokens[1] != 2 || tokens[2] != 3 {
+		t.Errorf("tokens = %v, want [1,2,3]", tokens)
+	}
+}
+
 func TestLlamaServerTokenizeDoesNotReuseIdleConnections(t *testing.T) {
 	var newConns atomic.Int64
 

--- a/llm/server.go
+++ b/llm/server.go
@@ -66,6 +66,12 @@ type LlamaServer interface {
 	ApplyChatTemplate(ctx context.Context, req ChatRequest) (string, error)
 	Embedding(ctx context.Context, input string) ([]float32, int, error)
 	Tokenize(ctx context.Context, content string) ([]int, error)
+	// TokenizeForCompletion counts the prompt the way the runner will see it,
+	// applying whatever prompt normalization the runner's own completion path
+	// applies. leadingBOS is the BOS string the renderer emitted, if any, so
+	// implementations that let the tokenizer add BOS can avoid double-counting
+	// it; implementations that tokenize the prompt verbatim ignore it.
+	TokenizeForCompletion(ctx context.Context, prompt, leadingBOS string) ([]int, error)
 	Detokenize(ctx context.Context, tokens []int) (string, error)
 	Close() error
 	MemorySize() (total, vram uint64)

--- a/middleware/anthropic.go
+++ b/middleware/anthropic.go
@@ -29,7 +29,11 @@ type AnthropicWriter struct {
 	converter *anthropic.StreamConverter
 }
 
-func (w *AnthropicWriter) writeError(data []byte) (int, error) {
+type AnthropicCountTokensWriter struct {
+	BaseWriter
+}
+
+func writeAnthropicError(w gin.ResponseWriter, data []byte) (int, error) {
 	var errData struct {
 		Error string `json:"error"`
 	}
@@ -39,12 +43,16 @@ func (w *AnthropicWriter) writeError(data []byte) (int, error) {
 		errData.Error = string(data)
 	}
 
-	w.ResponseWriter.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w.ResponseWriter).Encode(anthropic.NewError(w.Status(), errData.Error)); err != nil {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(anthropic.NewError(w.Status(), errData.Error)); err != nil {
 		return 0, err
 	}
 
 	return len(data), nil
+}
+
+func (w *AnthropicWriter) writeError(data []byte) (int, error) {
+	return writeAnthropicError(w.ResponseWriter, data)
 }
 
 func (w *AnthropicWriter) writeEvent(eventType string, data any) error {
@@ -81,6 +89,38 @@ func (w *AnthropicWriter) Write(data []byte) (int, error) {
 	code := w.ResponseWriter.Status()
 	if code != http.StatusOK {
 		return w.writeError(data)
+	}
+
+	return w.writeResponse(data)
+}
+
+func (w *AnthropicCountTokensWriter) writeInputTokensError(message string) (int, error) {
+	w.ResponseWriter.Header().Set("Content-Type", "application/json")
+	w.ResponseWriter.WriteHeader(http.StatusInternalServerError)
+	return 0, json.NewEncoder(w.ResponseWriter).Encode(anthropic.NewError(http.StatusInternalServerError, message))
+}
+
+func (w *AnthropicCountTokensWriter) writeResponse(data []byte) (int, error) {
+	var chatResponse api.ChatResponse
+	if err := json.Unmarshal(data, &chatResponse); err != nil {
+		return 0, err
+	}
+	if chatResponse.DebugInfo == nil {
+		return w.writeInputTokensError("input token count response missing debug info")
+	}
+	if chatResponse.DebugInfo.InputTokens == nil {
+		return w.writeInputTokensError("input token count response missing input tokens")
+	}
+
+	w.ResponseWriter.Header().Set("Content-Type", "application/json")
+	return len(data), json.NewEncoder(w.ResponseWriter).Encode(anthropic.CountTokensResponse{
+		InputTokens: *chatResponse.DebugInfo.InputTokens,
+	})
+}
+
+func (w *AnthropicCountTokensWriter) Write(data []byte) (int, error) {
+	if w.ResponseWriter.Status() != http.StatusOK {
+		return writeAnthropicError(w.ResponseWriter, data)
 	}
 
 	return w.writeResponse(data)
@@ -807,6 +847,71 @@ func (w *WebSearchAnthropicWriter) sendError(errorCode, query string, usage anth
 	response := w.webSearchErrorResponse(errorCode, query, usage)
 	logutil.Trace("anthropic middleware: web_search error", "code", errorCode, "query", query, "usage", usage)
 	return w.writeTerminalResponse(response)
+}
+
+func prepareAnthropicCountTokensRequest(c *gin.Context, chatReq *api.ChatRequest) bool {
+	// ChatHandler answers a request with no messages by reporting a model load,
+	// which carries no count for the writer to convert.
+	if len(chatReq.Messages) == 0 {
+		c.AbortWithStatusJSON(http.StatusBadRequest, anthropic.NewError(http.StatusBadRequest, "messages is required"))
+		return false
+	}
+
+	stream := false
+	chatReq.Stream = &stream
+	chatReq.DebugRenderOnly = true
+	// Count what the caller sent. Truncation defaults to on, which would drop
+	// leading messages until the render fits the context window and report the
+	// count of what survived - the opposite of what a caller asking "how big is
+	// my input" needs.
+	truncate := false
+	chatReq.Truncate = &truncate
+
+	var b bytes.Buffer
+	if err := json.NewEncoder(&b).Encode(chatReq); err != nil {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, anthropic.NewError(http.StatusInternalServerError, err.Error()))
+		return false
+	}
+
+	c.Request.Body = io.NopCloser(&b)
+	c.Writer = &AnthropicCountTokensWriter{
+		BaseWriter: BaseWriter{ResponseWriter: c.Writer},
+	}
+	return true
+}
+
+// AnthropicCountTokensMiddleware handles Anthropic count_tokens requests.
+func AnthropicCountTokensMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var req anthropic.CountTokensRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, anthropic.NewError(http.StatusBadRequest, err.Error()))
+			return
+		}
+
+		if req.Model == "" {
+			c.AbortWithStatusJSON(http.StatusBadRequest, anthropic.NewError(http.StatusBadRequest, "model is required"))
+			return
+		}
+
+		if len(req.Messages) == 0 {
+			c.AbortWithStatusJSON(http.StatusBadRequest, anthropic.NewError(http.StatusBadRequest, "messages is required"))
+			return
+		}
+
+		chatReq, err := anthropic.FromCountTokensRequest(req)
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, anthropic.NewError(http.StatusBadRequest, err.Error()))
+			return
+		}
+
+		c.Set("relax_thinking", true)
+		if !prepareAnthropicCountTokensRequest(c, chatReq) {
+			return
+		}
+
+		c.Next()
+	}
 }
 
 // AnthropicMessagesMiddleware handles Anthropic Messages API requests

--- a/middleware/anthropic_test.go
+++ b/middleware/anthropic_test.go
@@ -402,6 +402,135 @@ func TestAnthropicMessagesMiddleware_Headers(t *testing.T) {
 	})
 }
 
+func TestAnthropicCountTokensMiddleware(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var capturedRequest api.ChatRequest
+	var flagSet bool
+	inputTokens := 42
+
+	router := gin.New()
+	router.Use(AnthropicCountTokensMiddleware(), captureAnthropicRequest(&capturedRequest))
+	router.POST("/v1/messages/count_tokens", func(c *gin.Context) {
+		_, flagSet = c.Get("relax_thinking")
+		c.JSON(http.StatusOK, api.ChatResponse{
+			DebugInfo: &api.DebugInfo{InputTokens: &inputTokens},
+		})
+	})
+
+	body := `{
+		"model": "test-model",
+		"system": "You are helpful.",
+		"messages": [{"role": "user", "content": "Hi"}],
+		"tools": [{
+			"name": "lookup",
+			"description": "Look up a value",
+			"input_schema": {"type": "object"}
+		}],
+		"thinking": {"type": "enabled", "budget_tokens": 1024}
+	}`
+	req, _ := http.NewRequest(http.MethodPost, "/v1/messages/count_tokens", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	var result anthropic.CountTokensResponse
+	if err := json.Unmarshal(resp.Body.Bytes(), &result); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if result.InputTokens != inputTokens {
+		t.Fatalf("expected input_tokens %d, got %d", inputTokens, result.InputTokens)
+	}
+
+	if !flagSet {
+		t.Error("expected relax_thinking flag to be set in context")
+	}
+	if !capturedRequest.DebugRenderOnly {
+		t.Error("expected debug_render_only to be set")
+	}
+	if capturedRequest.Stream == nil || *capturedRequest.Stream {
+		t.Fatalf("expected stream false, got %v", capturedRequest.Stream)
+	}
+	if capturedRequest.Model != "test-model" {
+		t.Fatalf("expected model test-model, got %q", capturedRequest.Model)
+	}
+	if len(capturedRequest.Messages) != 2 {
+		t.Fatalf("expected system and user messages, got %d", len(capturedRequest.Messages))
+	}
+	if capturedRequest.Messages[0].Role != "system" || capturedRequest.Messages[0].Content != "You are helpful." {
+		t.Fatalf("unexpected system message: %+v", capturedRequest.Messages[0])
+	}
+	if capturedRequest.Messages[1].Role != "user" || capturedRequest.Messages[1].Content != "Hi" {
+		t.Fatalf("unexpected user message: %+v", capturedRequest.Messages[1])
+	}
+	if len(capturedRequest.Tools) != 1 || capturedRequest.Tools[0].Function.Name != "lookup" {
+		t.Fatalf("unexpected tools: %+v", capturedRequest.Tools)
+	}
+	if capturedRequest.Think == nil || capturedRequest.Think.Value != true {
+		t.Fatalf("expected thinking enabled, got %+v", capturedRequest.Think)
+	}
+	if got, ok := capturedRequest.Options["num_predict"].(float64); !ok || got != 1 {
+		t.Fatalf("expected num_predict 1, got %#v", capturedRequest.Options["num_predict"])
+	}
+}
+
+func TestAnthropicCountTokensMiddleware_InvalidRequest(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name        string
+		body        string
+		wantMessage string
+	}{
+		{
+			name:        "missing model",
+			body:        `{"messages":[{"role":"user","content":"Hi"}]}`,
+			wantMessage: "model is required",
+		},
+		{
+			name:        "missing messages",
+			body:        `{"model":"test-model"}`,
+			wantMessage: "messages is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := gin.New()
+			router.Use(AnthropicCountTokensMiddleware())
+			router.POST("/v1/messages/count_tokens", func(c *gin.Context) {
+				t.Fatal("handler should not be called")
+			})
+
+			req, _ := http.NewRequest(http.MethodPost, "/v1/messages/count_tokens", strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+
+			resp := httptest.NewRecorder()
+			router.ServeHTTP(resp, req)
+
+			if resp.Code != http.StatusBadRequest {
+				t.Fatalf("expected status 400, got %d: %s", resp.Code, resp.Body.String())
+			}
+
+			var errResp anthropic.ErrorResponse
+			if err := json.Unmarshal(resp.Body.Bytes(), &errResp); err != nil {
+				t.Fatalf("failed to unmarshal error response: %v", err)
+			}
+			if errResp.Error.Type != "invalid_request_error" {
+				t.Fatalf("expected invalid_request_error, got %q", errResp.Error.Type)
+			}
+			if errResp.Error.Message != tt.wantMessage {
+				t.Fatalf("expected message %q, got %q", tt.wantMessage, errResp.Error.Message)
+			}
+		})
+	}
+}
+
 func TestAnthropicMessagesMiddleware_InvalidJSON(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.New()

--- a/middleware/openai.go
+++ b/middleware/openai.go
@@ -447,6 +447,107 @@ func ChatMiddleware() gin.HandlerFunc {
 	}
 }
 
+type InputTokensWriter struct {
+	object string
+	BaseWriter
+}
+
+func (w *InputTokensWriter) writeInputTokensError(message string) (int, error) {
+	w.ResponseWriter.Header().Set("Content-Type", "application/json")
+	w.ResponseWriter.WriteHeader(http.StatusInternalServerError)
+	return 0, json.NewEncoder(w.ResponseWriter).Encode(openai.NewError(http.StatusInternalServerError, message))
+}
+
+func (w *InputTokensWriter) writeResponse(data []byte) (int, error) {
+	var chatResponse api.ChatResponse
+	if err := json.Unmarshal(data, &chatResponse); err != nil {
+		return 0, err
+	}
+	// ChatHandler always populates both on a 200 for a debug_render_only
+	// request, and a failure to count is a non-200 handled by Write. Should
+	// never happen, but reporting no count beats reporting a zero one.
+	if chatResponse.DebugInfo == nil {
+		return w.writeInputTokensError("input token count response missing debug info")
+	}
+	if chatResponse.DebugInfo.InputTokens == nil {
+		return w.writeInputTokensError("input token count response missing input tokens")
+	}
+
+	w.ResponseWriter.Header().Set("Content-Type", "application/json")
+	return len(data), json.NewEncoder(w.ResponseWriter).Encode(openai.InputTokensResponse{
+		Object:      w.object,
+		InputTokens: *chatResponse.DebugInfo.InputTokens,
+	})
+}
+
+func (w *InputTokensWriter) Write(data []byte) (int, error) {
+	code := w.ResponseWriter.Status()
+	if code != http.StatusOK {
+		return w.writeError(data)
+	}
+
+	return w.writeResponse(data)
+}
+
+func prepareInputTokensChatRequest(c *gin.Context, chatReq *api.ChatRequest) bool {
+	// ChatHandler answers a request with no messages by reporting a model load,
+	// which carries no count for the writer to convert.
+	if len(chatReq.Messages) == 0 {
+		c.AbortWithStatusJSON(http.StatusBadRequest, openai.NewError(http.StatusBadRequest, "[] is too short - 'messages'"))
+		return false
+	}
+
+	stream := false
+	chatReq.Stream = &stream
+	chatReq.DebugRenderOnly = true
+	// Count what the caller sent. Truncation defaults to on, which would drop
+	// leading messages until the render fits the context window and report the
+	// count of what survived - the opposite of what a caller asking "how big is
+	// my input" needs.
+	truncate := false
+	chatReq.Truncate = &truncate
+
+	var b bytes.Buffer
+	if err := json.NewEncoder(&b).Encode(chatReq); err != nil {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, openai.NewError(http.StatusInternalServerError, err.Error()))
+		return false
+	}
+
+	c.Request.Body = io.NopCloser(&b)
+	c.Writer = &InputTokensWriter{
+		BaseWriter: BaseWriter{ResponseWriter: c.Writer},
+		object:     "response.input_tokens",
+	}
+	return true
+}
+
+func ChatInputTokensMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var req openai.ChatCompletionRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, openai.NewError(http.StatusBadRequest, err.Error()))
+			return
+		}
+
+		if len(req.Messages) == 0 {
+			c.AbortWithStatusJSON(http.StatusBadRequest, openai.NewError(http.StatusBadRequest, "[] is too short - 'messages'"))
+			return
+		}
+
+		chatReq, err := openai.FromChatRequest(req)
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, openai.NewError(http.StatusBadRequest, err.Error()))
+			return
+		}
+
+		if !prepareInputTokensChatRequest(c, chatReq) {
+			return
+		}
+
+		c.Next()
+	}
+}
+
 type ResponsesWriter struct {
 	BaseWriter
 	converter  *openai.ResponsesStreamConverter
@@ -506,18 +607,29 @@ func (w *ResponsesWriter) Write(data []byte) (int, error) {
 	return w.writeResponse(data)
 }
 
+func decompressZstdRequestBody(c *gin.Context) (func(), bool) {
+	if c.GetHeader("Content-Encoding") != "zstd" {
+		return func() {}, true
+	}
+
+	reader, err := zstd.NewReader(c.Request.Body, zstd.WithDecoderMaxMemory(8<<20))
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, openai.NewError(http.StatusBadRequest, "failed to decompress zstd body"))
+		return nil, false
+	}
+
+	c.Request.Body = http.MaxBytesReader(c.Writer, io.NopCloser(reader), maxDecompressedBodySize)
+	c.Request.Header.Del("Content-Encoding")
+	return reader.Close, true
+}
+
 func ResponsesMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		if c.GetHeader("Content-Encoding") == "zstd" {
-			reader, err := zstd.NewReader(c.Request.Body, zstd.WithDecoderMaxMemory(8<<20))
-			if err != nil {
-				c.AbortWithStatusJSON(http.StatusBadRequest, openai.NewError(http.StatusBadRequest, "failed to decompress zstd body"))
-				return
-			}
-			defer reader.Close()
-			c.Request.Body = http.MaxBytesReader(c.Writer, io.NopCloser(reader), maxDecompressedBodySize)
-			c.Request.Header.Del("Content-Encoding")
+		closeBody, ok := decompressZstdRequestBody(c)
+		if !ok {
+			return
 		}
+		defer closeBody()
 
 		var req openai.ResponsesRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
@@ -566,6 +678,34 @@ func ResponsesMiddleware() gin.HandlerFunc {
 		}
 
 		c.Writer = w
+		c.Next()
+	}
+}
+
+func ResponsesInputTokensMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		closeBody, ok := decompressZstdRequestBody(c)
+		if !ok {
+			return
+		}
+		defer closeBody()
+
+		var req openai.ResponsesRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, openai.NewError(http.StatusBadRequest, err.Error()))
+			return
+		}
+
+		chatReq, err := openai.FromResponsesRequest(req)
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, openai.NewError(http.StatusBadRequest, err.Error()))
+			return
+		}
+
+		if !prepareInputTokensChatRequest(c, chatReq) {
+			return
+		}
+
 		c.Next()
 	}
 }

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -71,6 +71,11 @@ type Usage struct {
 	TotalTokens      int `json:"total_tokens"`
 }
 
+type InputTokensResponse struct {
+	Object      string `json:"object,omitempty"`
+	InputTokens int    `json:"input_tokens"`
+}
+
 type ResponseFormat struct {
 	Type       string      `json:"type"`
 	JsonSchema *JsonSchema `json:"json_schema,omitempty"`

--- a/server/routes.go
+++ b/server/routes.go
@@ -1896,15 +1896,18 @@ func (s *Server) GenerateRoutes() (http.Handler, error) {
 	// TODO(cloud-stage-a): apply Modelfile overlay deltas for local models with cloud
 	// parents on v1 request families while preserving this explicit :cloud passthrough.
 	r.POST("/v1/chat/completions", s.withInferenceRequestLogging("/v1/chat/completions", cloudPassthroughMiddleware(cloudErrRemoteInferenceUnavailable), middleware.ChatMiddleware(), s.ChatHandler)...)
+	r.POST("/v1/chat/completions/input_tokens", s.withInferenceRequestLogging("/v1/chat/completions/input_tokens", cloudPassthroughMiddleware(cloudErrRemoteInferenceUnavailable), middleware.ChatInputTokensMiddleware(), s.ChatHandler)...)
 	r.POST("/v1/completions", s.withInferenceRequestLogging("/v1/completions", cloudPassthroughMiddleware(cloudErrRemoteInferenceUnavailable), middleware.CompletionsMiddleware(), s.GenerateHandler)...)
 	r.POST("/v1/embeddings", cloudPassthroughMiddleware(cloudErrRemoteInferenceUnavailable), middleware.EmbeddingsMiddleware(), s.EmbedHandler)
 	r.GET("/v1/models", middleware.ListMiddleware(), s.ListHandler)
 	r.GET("/v1/models/:model", cloudModelPathPassthroughMiddleware(cloudErrRemoteModelDetailsUnavailable), middleware.RetrieveMiddleware(), s.ShowHandler)
 	r.POST("/v1/responses", s.withInferenceRequestLogging("/v1/responses", cloudPassthroughMiddleware(cloudErrRemoteInferenceUnavailable), middleware.ResponsesMiddleware(), s.ChatHandler)...)
+	r.POST("/v1/responses/input_tokens", s.withInferenceRequestLogging("/v1/responses/input_tokens", cloudPassthroughMiddleware(cloudErrRemoteInferenceUnavailable), middleware.ResponsesInputTokensMiddleware(), s.ChatHandler)...)
 	// OpenAI-compatible audio endpoint
 	r.POST("/v1/audio/transcriptions", middleware.TranscriptionMiddleware(), s.ChatHandler)
 
 	// Inference (Anthropic compatibility)
+	r.POST("/v1/messages/count_tokens", s.withInferenceRequestLogging("/v1/messages/count_tokens", cloudPassthroughMiddleware(cloudErrRemoteInferenceUnavailable), middleware.AnthropicCountTokensMiddleware(), s.ChatHandler)...)
 	r.POST("/v1/messages", s.withInferenceRequestLogging("/v1/messages", cloudPassthroughMiddleware(cloudErrRemoteInferenceUnavailable), middleware.AnthropicMessagesMiddleware(), s.ChatHandler)...)
 
 	return r, nil
@@ -2683,13 +2686,17 @@ func (s *Server) ChatHandler(c *gin.Context) {
 
 	// If debug mode is enabled, return the rendered template instead of calling the model
 	if req.DebugRenderOnly {
+		debugInfo, err := chatDebugInfo(c.Request.Context(), r, prompt, len(media), leadingBOSForModel(m))
+		if err != nil {
+			slog.Error("chat prompt token count error", "error", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
 		c.JSON(http.StatusOK, api.ChatResponse{
 			Model:     req.Model,
 			CreatedAt: time.Now().UTC(),
-			DebugInfo: &api.DebugInfo{
-				RenderedTemplate: prompt,
-				ImageCount:       len(media),
-			},
+			DebugInfo: debugInfo,
 		})
 		return
 	}
@@ -2951,13 +2958,17 @@ func (s *Server) handleNativeChat(c *gin.Context, req api.ChatRequest, m *Model,
 			return
 		}
 
+		debugInfo, err := chatDebugInfo(c.Request.Context(), r, prompt, countChatImages(msgs), leadingBOSForModel(m))
+		if err != nil {
+			slog.Error("chat prompt token count error", "error", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
 		c.JSON(http.StatusOK, api.ChatResponse{
 			Model:     req.Model,
 			CreatedAt: time.Now().UTC(),
-			DebugInfo: &api.DebugInfo{
-				RenderedTemplate: prompt,
-				ImageCount:       countChatImages(msgs),
-			},
+			DebugInfo: debugInfo,
 		})
 		return
 	}
@@ -3072,6 +3083,20 @@ func countChatImages(msgs []api.Message) int {
 		count += len(msg.Images)
 	}
 	return count
+}
+
+func chatDebugInfo(ctx context.Context, r llm.LlamaServer, prompt string, imageCount int, leadingBOS string) (*api.DebugInfo, error) {
+	tokens, err := r.TokenizeForCompletion(ctx, prompt, leadingBOS)
+	if err != nil {
+		return nil, err
+	}
+	inputTokens := len(tokens)
+
+	return &api.DebugInfo{
+		RenderedTemplate: prompt,
+		ImageCount:       imageCount,
+		InputTokens:      &inputTokens,
+	}, nil
 }
 
 func handleScheduleError(c *gin.Context, name string, err error) {

--- a/server/routes_generate_test.go
+++ b/server/routes_generate_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -17,6 +19,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/go-cmp/cmp"
 
+	"github.com/ollama/ollama/anthropic"
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/fs/ggml"
 	"github.com/ollama/ollama/llm"
@@ -63,6 +66,8 @@ type mockRunner struct {
 	TemplateFn    func(context.Context, llm.ChatRequest) (string, error)
 	DetokenizeFn  func(context.Context, []int) (string, error)
 	contextLength int
+
+	TokenizeForCompletionFn func(ctx context.Context, prompt, leadingBOS string) ([]int, error)
 }
 
 func (m *mockRunner) Completion(ctx context.Context, r llm.CompletionRequest, fn func(r llm.CompletionResponse)) error {
@@ -104,6 +109,20 @@ func (mockRunner) Tokenize(_ context.Context, s string) (tokens []int, err error
 	}
 
 	return
+}
+
+// TokenizeForCompletion mirrors llamaServerRunner: the renderer's leading BOS is
+// dropped because the tokenizer adds one of its own, which this mock represents
+// as a single extra token.
+func (m *mockRunner) TokenizeForCompletion(ctx context.Context, prompt, leadingBOS string) ([]int, error) {
+	if m.TokenizeForCompletionFn != nil {
+		return m.TokenizeForCompletionFn(ctx, prompt, leadingBOS)
+	}
+	tokens, err := m.Tokenize(ctx, strings.TrimPrefix(prompt, leadingBOS))
+	if err != nil {
+		return nil, err
+	}
+	return append(tokens, len(tokens)), nil
 }
 
 func (mockRunner) Ping(_ context.Context) error { return nil }
@@ -268,6 +287,220 @@ func TestChatModeForModel(t *testing.T) {
 	}
 	if got := llamaServerConfigForModel(goTemplateModel); !got.DisableJinja {
 		t.Fatalf("llamaServerConfigForModel with Go TEMPLATE should disable jinja")
+	}
+}
+
+// countTokensTemplate renders one line per message, so the token count of a
+// request is derivable from mockRunner.Tokenize's whitespace split.
+const countTokensTemplate = "{{ range .Messages }}{{ .Role }}: {{ .Content }}\n{{ end }}"
+
+func TestInputTokensRoutes(t *testing.T) {
+	t.Setenv("OLLAMA_GO_TEMPLATE", "1")
+	gin.SetMode(gin.TestMode)
+
+	mock := mockRunner{}
+	s := newServerWithMockRunner(t, &mock)
+	createMinimalGGUFModel(t, s, "input-token-model", nil, countTokensTemplate, nil)
+
+	router, err := s.GenerateRoutes()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// "user: count these tokens\n" splits into four whitespace-separated
+	// tokens, plus the BOS mockRunner.TokenizeForCompletion adds.
+	const want = 4 + 1
+
+	for _, tt := range []struct {
+		name       string
+		path       string
+		body       string
+		wantObject string
+	}{
+		{
+			name:       "chat completions",
+			path:       "/v1/chat/completions/input_tokens",
+			body:       `{"model":"input-token-model","messages":[{"role":"user","content":"count these tokens"}]}`,
+			wantObject: "response.input_tokens",
+		},
+		{
+			name:       "responses",
+			path:       "/v1/responses/input_tokens",
+			body:       `{"model":"input-token-model","input":"count these tokens"}`,
+			wantObject: "response.input_tokens",
+		},
+		{
+			name: "anthropic count tokens",
+			path: "/v1/messages/count_tokens",
+			body: `{"model":"input-token-model","messages":[{"role":"user","content":"count these tokens"}]}`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, tt.path, strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+
+			router.ServeHTTP(w, req)
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, body: %s", w.Code, w.Body.String())
+			}
+
+			var got struct {
+				Object      string `json:"object"`
+				InputTokens int    `json:"input_tokens"`
+			}
+			if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+				t.Fatal(err)
+			}
+			if got.Object != tt.wantObject {
+				t.Errorf("object = %q, want %q", got.Object, tt.wantObject)
+			}
+			if got.InputTokens != want {
+				t.Errorf("input_tokens = %d, want %d", got.InputTokens, want)
+			}
+		})
+	}
+}
+
+// TestInputTokensRoutesCountUntruncatedInput pins that the count routes report
+// the size of the caller's input rather than of the truncated prompt the model
+// would have been given.
+func TestInputTokensRoutesCountUntruncatedInput(t *testing.T) {
+	t.Setenv("OLLAMA_GO_TEMPLATE", "1")
+	t.Setenv("OLLAMA_CONTEXT_LENGTH", "8")
+	gin.SetMode(gin.TestMode)
+
+	mock := mockRunner{}
+	s := newServerWithMockRunner(t, &mock)
+	createMinimalGGUFModel(t, s, "input-token-model", nil, countTokensTemplate, nil)
+
+	router, err := s.GenerateRoutes()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Four messages of ten words each, far past the eight token context above.
+	// Each renders as "<role>: <ten words>\n" for eleven tokens, plus BOS.
+	const (
+		words = 10
+		msgs  = 4
+		want  = msgs*(1+words) + 1
+	)
+	content := strings.TrimSpace(strings.Repeat("word ", words))
+	chatBody := fmt.Sprintf(`{"model":"input-token-model","messages":[
+		{"role":"user","content":%[1]q},
+		{"role":"assistant","content":%[1]q},
+		{"role":"user","content":%[1]q},
+		{"role":"assistant","content":%[1]q}]}`, content)
+	responsesBody := fmt.Sprintf(`{"model":"input-token-model","input":[
+		{"role":"user","content":%[1]q},
+		{"role":"assistant","content":%[1]q},
+		{"role":"user","content":%[1]q},
+		{"role":"assistant","content":%[1]q}]}`, content)
+
+	for path, body := range map[string]string{
+		"/v1/chat/completions/input_tokens": chatBody,
+		"/v1/responses/input_tokens":        responsesBody,
+		"/v1/messages/count_tokens":         chatBody,
+	} {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+
+			router.ServeHTTP(w, req)
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, body: %s", w.Code, w.Body.String())
+			}
+
+			var got struct {
+				InputTokens int `json:"input_tokens"`
+			}
+			if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+				t.Fatal(err)
+			}
+			if got.InputTokens != want {
+				t.Errorf("input_tokens = %d, want %d", got.InputTokens, want)
+			}
+		})
+	}
+}
+
+// TestInputTokensRouteTokenizeError pins that a runner that cannot tokenize
+// fails the request rather than reporting a count of zero.
+func TestInputTokensRouteTokenizeError(t *testing.T) {
+	t.Setenv("OLLAMA_GO_TEMPLATE", "1")
+	gin.SetMode(gin.TestMode)
+
+	mock := mockRunner{
+		TokenizeForCompletionFn: func(context.Context, string, string) ([]int, error) {
+			return nil, errors.New("tokenizer unavailable")
+		},
+	}
+	s := newServerWithMockRunner(t, &mock)
+	createMinimalGGUFModel(t, s, "input-token-model", nil, countTokensTemplate, nil)
+
+	router, err := s.GenerateRoutes()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages/count_tokens", strings.NewReader(
+		`{"model":"input-token-model","messages":[{"role":"user","content":"hi"}]}`,
+	))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500, body: %s", w.Code, w.Body.String())
+	}
+
+	var errResp anthropic.ErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &errResp); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(errResp.Error.Message, "tokenizer unavailable") {
+		t.Errorf("error message = %q, want it to name the tokenizer failure", errResp.Error.Message)
+	}
+}
+
+// TestInputTokensRouteNativeChat covers the llama-server-templated execution
+// path, which renders through ApplyChatTemplate rather than a Go template.
+func TestInputTokensRouteNativeChat(t *testing.T) {
+	t.Setenv("OLLAMA_GO_TEMPLATE", "")
+	gin.SetMode(gin.TestMode)
+
+	mock := mockRunner{Template: "<s>user: count these tokens"}
+	s := newServerWithMockRunner(t, &mock)
+	createMinimalGGUFModel(t, s, "native-input-token-model", nil, "", nil)
+
+	router, err := s.GenerateRoutes()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages/count_tokens", strings.NewReader(
+		`{"model":"native-input-token-model","messages":[{"role":"user","content":"count these tokens"}]}`,
+	))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body: %s", w.Code, w.Body.String())
+	}
+
+	var got anthropic.CountTokensResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	// "<s>user: count these tokens" is four whitespace-separated tokens, plus BOS.
+	if want := 4 + 1; got.InputTokens != want {
+		t.Errorf("input_tokens = %d, want %d", got.InputTokens, want)
+	}
+	if mock.ChatRequest.Messages == nil {
+		t.Error("ApplyChatTemplate was not reached; the request did not take the native path")
 	}
 }
 

--- a/server/routes_request_log_test.go
+++ b/server/routes_request_log_test.go
@@ -118,6 +118,7 @@ func TestSanitizeRouteForFilename(t *testing.T) {
 		{route: "/api/generate", want: "api_generate"},
 		{route: "/v1/chat/completions", want: "v1_chat_completions"},
 		{route: "/v1/messages", want: "v1_messages"},
+		{route: "/v1/messages/count_tokens", want: "v1_messages_count_tokens"},
 	}
 
 	for _, tt := range tests {

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -2140,6 +2140,10 @@ func (s *mockLlm) Tokenize(ctx context.Context, content string) ([]int, error) {
 	return s.tokenizeResp, s.tokenizeRespErr
 }
 
+func (s *mockLlm) TokenizeForCompletion(ctx context.Context, prompt, leadingBOS string) ([]int, error) {
+	return s.tokenizeResp, s.tokenizeRespErr
+}
+
 func (s *mockLlm) Detokenize(ctx context.Context, tokens []int) (string, error) {
 	return s.detokenizeResp, s.detonekizeRespErr
 }

--- a/x/mlxrunner/client.go
+++ b/x/mlxrunner/client.go
@@ -472,6 +472,14 @@ func (c *Client) Tokenize(ctx context.Context, content string) ([]int, error) {
 	return tokens, nil
 }
 
+// TokenizeForCompletion implements llm.LlamaServer. The MLX runner's /v1/tokenize
+// applies the same tokenizer and add-BOS policy its completion path does (see
+// pipeline.go), so the prompt is passed through verbatim - normalizing away a
+// leading BOS here would undercount by exactly the token completion will add.
+func (c *Client) TokenizeForCompletion(ctx context.Context, prompt, _ string) ([]int, error) {
+	return c.Tokenize(ctx, prompt)
+}
+
 func (c *Client) currentMemory() uint64 {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()


### PR DESCRIPTION
Add /v1/messages/count_tokens plus the Ollama-specific /v1/chat/completions/input_tokens and /v1/responses/input_tokens. All three reuse the existing debug_render_only path, which now also returns DebugInfo.InputTokens, so the count comes from the runner's tokenizer applied to the fully rendered prompt. Unlike the generating endpoints these requests are not truncated to fit the context window, so the count reflects what the caller actually sent.

Generating requests are unaffected: the count runs only in the debug_render_only branches, which return before generation.

Images are counted as text. The rendered prompt still carries Ollama's [img-N] markers when we tokenize it, so those are counted as literal text while the image embeddings they stand for are not counted at all - the real completion path swaps each marker for the media marker and ships the payloads separately. Callers get ImageCount alongside the count and can see images were present, but the number is wrong for multimodal requests.  Fixing it needs the projector-aware media accounting server/prompt.go already carries a TODO for.