### PR TITLE
cmd: suggest :cloud when a model has no default tag

### DIFF
--- a/cmd/agent_tui.go
+++ b/cmd/agent_tui.go
@@ -48,24 +48,16 @@ func saveLastAgentModel(model string) error {
 }
 
 func prepareAgentModel(cmd *cobra.Command, client *api.Client, opts *agentTUIOptions, thinkExplicit bool) (*api.ShowResponse, error) {
-	requestedCloud := modelref.HasExplicitCloudSource(opts.Model)
-	info, err := func() (*api.ShowResponse, error) {
-		info, err := client.Show(cmd.Context(), &api.ShowRequest{Model: opts.Model})
-		var se api.StatusError
-		if errors.As(err, &se) && se.StatusCode == http.StatusNotFound {
-			if requestedCloud {
-				return nil, err
-			}
-			if err := PullHandler(cmd, []string{opts.Model}); err != nil {
-				return nil, err
-			}
-			return client.Show(cmd.Context(), &api.ShowRequest{Model: opts.Model})
-		}
-		return info, err
-	}()
+	// Unlike `ollama run`, the bare `ollama` root command doesn't define
+	// --insecure, so GetBool would error; treat it as false.
+	insecure, _ := cmd.Flags().GetBool("insecure")
+	info, resolved, err := showOrPullModel(cmd, client, opts.Model, insecure, "run")
 	if err != nil {
 		return nil, err
 	}
+	// The model may have been resolved to a different name (e.g. its
+	// ":cloud" variant).
+	opts.Model = resolved
 
 	ensureCloudStub(cmd.Context(), client, opts.Model)
 	opts.Think, err = inferThinkingOption(&info.Capabilities, &runOptions{Model: opts.Model, Think: opts.Think}, thinkExplicit)

--- a/cmd/cloud_suggest.go
+++ b/cmd/cloud_suggest.go
@@ -26,15 +26,31 @@ var (
 	}
 )
 
+// pullModelNotFoundMessage is how a registry 404 during pull surfaces to
+// clients: os.ErrNotExist wrapped server-side and flattened into the error
+// string of the pull stream.
+const pullModelNotFoundMessage = "pull model manifest: file does not exist"
+
+// isPullNotFoundErr reports whether err is a pull failure caused by the
+// requested model or tag not existing in the registry.
+func isPullNotFoundErr(err error) bool {
+	return err != nil && strings.Contains(err.Error(), pullModelNotFoundMessage)
+}
+
 // cloudSuggestionCandidate reports whether a failed pull of name should
 // trigger a ":cloud" suggestion, and if so returns the cloud model name to
 // suggest. It only applies to default-tag lookups (e.g. "kimi-k3") against
 // the default registry whose pull failed because the tag doesn't exist.
 func cloudSuggestionCandidate(name string, pullErr error, insecure bool) (string, bool) {
-	if pullErr == nil || !strings.Contains(pullErr.Error(), "pull model manifest: file does not exist") {
+	if !isPullNotFoundErr(pullErr) {
 		return "", false
 	}
+	return cloudSuggestionName(name, insecure)
+}
 
+// cloudSuggestionName applies the name-based eligibility checks for the
+// ":cloud" suggestion, returning the cloud model name to suggest.
+func cloudSuggestionName(name string, insecure bool) (string, bool) {
 	// --insecure implies a non-default registry, where an ollama.com cloud
 	// model wouldn't be a meaningful suggestion.
 	if insecure {
@@ -65,7 +81,13 @@ func cloudSuggestionCandidate(name string, pullErr error, insecure bool) (string
 // terminal. It returns the name that was actually pulled. `verb` is the
 // user-facing command ("run" or "pull") used in the hint text.
 func pullWithCloudSuggestion(ctx context.Context, client *api.Client, name string, insecure bool, verb string) (string, error) {
-	pullErr := pullModelWithProgress(ctx, client, name, insecure)
+	// If a suggestion prompt may follow a failed pull, erase the failed
+	// attempt's progress display instead of leaving its "pulling manifest"
+	// line to stack up against the accepted pull's identical one.
+	_, eligible := cloudSuggestionName(name, insecure)
+	clearNotFound := eligible && isInteractiveTerminal()
+
+	pullErr := pullModelWithProgress(ctx, client, name, insecure, clearNotFound)
 	if pullErr == nil {
 		return name, nil
 	}
@@ -92,7 +114,7 @@ func pullWithCloudSuggestion(ctx context.Context, client *api.Client, name strin
 		return "", pullErr
 	}
 
-	if err := pullModelWithProgress(ctx, client, cloudName, insecure); err != nil {
+	if err := pullModelWithProgress(ctx, client, cloudName, insecure, false); err != nil {
 		return "", err
 	}
 	return cloudName, nil

--- a/cmd/cloud_suggest.go
+++ b/cmd/cloud_suggest.go
@@ -1,0 +1,99 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"golang.org/x/term"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/cmd/launch"
+	"github.com/ollama/ollama/internal/modelref"
+	"github.com/ollama/ollama/types/model"
+)
+
+// for testing
+var (
+	isInteractiveTerminal = func() bool {
+		return term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stdout.Fd()))
+	}
+
+	confirmCloudSuggestion = func(prompt string) (bool, error) {
+		// Zero-value options default to Yes being preselected.
+		return launch.ConfirmPromptWithOptions(prompt, launch.ConfirmOptions{})
+	}
+)
+
+// cloudSuggestionCandidate reports whether a failed pull of name should
+// trigger a ":cloud" suggestion, and if so returns the cloud model name to
+// suggest. It only applies to default-tag lookups (e.g. "kimi-k3") against
+// the default registry whose pull failed because the tag doesn't exist.
+func cloudSuggestionCandidate(name string, pullErr error, insecure bool) (string, bool) {
+	if pullErr == nil || !strings.Contains(pullErr.Error(), "pull model manifest: file does not exist") {
+		return "", false
+	}
+
+	// --insecure implies a non-default registry, where an ollama.com cloud
+	// model wouldn't be a meaningful suggestion.
+	if insecure {
+		return "", false
+	}
+
+	ref, err := modelref.ParseRef(name)
+	if err != nil || ref.Source != modelref.ModelSourceUnspecified {
+		return "", false
+	}
+
+	if modelref.HasExplicitTag(ref.Base) {
+		return "", false
+	}
+
+	// Only default-registry names qualify: the existence probe forwards the name
+	// to ollama.com, and custom-registry model names shouldn't be sent there.
+	if n := model.ParseName(ref.Base); !n.IsValid() || !strings.EqualFold(n.Host, model.DefaultName().Host) {
+		return "", false
+	}
+
+	return ref.Base + ":cloud", true
+}
+
+// pullWithCloudSuggestion pulls `name`, and if the model's default tag
+// doesn't exist but a ":cloud" tag does, offers it: either interactively via
+// a confirmation prompt, or by augmenting the returned error when not at a
+// terminal. It returns the name that was actually pulled. `verb` is the
+// user-facing command ("run" or "pull") used in the hint text.
+func pullWithCloudSuggestion(ctx context.Context, client *api.Client, name string, insecure bool, verb string) (string, error) {
+	pullErr := pullModelWithProgress(ctx, client, name, insecure)
+	if pullErr == nil {
+		return name, nil
+	}
+
+	cloudName, ok := cloudSuggestionCandidate(name, pullErr, insecure)
+	if !ok || ctx.Err() != nil {
+		return "", pullErr
+	}
+
+	// Showing a ":cloud" model is proxied to ollama.com and mirrors its status,
+	// so this reliably answers "does a cloud version exist?". Any error (no
+	// cloud tag, cloud disabled, older server, offline) means no suggestion.
+	if _, err := client.Show(ctx, &api.ShowRequest{Model: cloudName}); err != nil {
+		return "", pullErr
+	}
+
+	if !isInteractiveTerminal() {
+		return "", fmt.Errorf("%w\n\n%q is available as a cloud model. Try:\n  ollama %s %s", pullErr, cloudName, verb, cloudName)
+	}
+
+	accepted, err := confirmCloudSuggestion(fmt.Sprintf("Did you mean %q?", cloudName))
+	if err != nil || !accepted {
+		// Declining or cancelling falls back to the original error.
+		return "", pullErr
+	}
+
+	if err := pullModelWithProgress(ctx, client, cloudName, insecure); err != nil {
+		return "", err
+	}
+	return cloudName, nil
+}

--- a/cmd/cloud_suggest_test.go
+++ b/cmd/cloud_suggest_test.go
@@ -1,0 +1,411 @@
+package cmd
+
+import (
+	"cmp"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/cmd/launch"
+	"github.com/ollama/ollama/types/model"
+)
+
+func TestCloudSuggestionCandidate(t *testing.T) {
+	notFoundErr := errors.New("pull model manifest: file does not exist")
+	suggestedErr := errors.New("pull model manifest: file does not exist\n\nTry one of these models:\n  some-model:cloud")
+
+	tests := []struct {
+		name     string
+		model    string
+		pullErr  error
+		insecure bool
+		want     string
+		wantOK   bool
+	}{
+		{name: "default tag not found", model: "some-model", pullErr: notFoundErr, want: "some-model:cloud", wantOK: true},
+		{name: "composes with server tag suggestions", model: "some-model", pullErr: suggestedErr, want: "some-model:cloud", wantOK: true},
+		{name: "namespaced default tag", model: "user/some-model", pullErr: notFoundErr, want: "user/some-model:cloud", wantOK: true},
+		{name: "nil error", model: "some-model", pullErr: nil},
+		{name: "unrelated error", model: "some-model", pullErr: errors.New("boom")},
+		{name: "insecure registry", model: "some-model", pullErr: notFoundErr, insecure: true},
+		{name: "explicit tag", model: "some-model:9b", pullErr: notFoundErr},
+		{name: "explicit latest tag", model: "some-model:latest", pullErr: notFoundErr},
+		{name: "explicit cloud source", model: "some-model:cloud", pullErr: notFoundErr},
+		{name: "explicit legacy cloud tag", model: "some-model:9b-cloud", pullErr: notFoundErr},
+		{name: "explicit local source", model: "some-model:local", pullErr: notFoundErr},
+		{name: "custom registry host", model: "internal.example.com/team/private-model", pullErr: notFoundErr},
+		{name: "custom registry host with port", model: "registry.example.com:5000/team/private-model", pullErr: notFoundErr},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := cloudSuggestionCandidate(tt.model, tt.pullErr, tt.insecure)
+			if ok != tt.wantOK {
+				t.Fatalf("cloudSuggestionCandidate(%q) ok = %v, want %v", tt.model, ok, tt.wantOK)
+			}
+			if got != tt.want {
+				t.Fatalf("cloudSuggestionCandidate(%q) = %q, want %q", tt.model, got, tt.want)
+			}
+		})
+	}
+}
+
+// stubCloudSuggest replaces the TTY check and confirmation prompt for the
+// duration of the test. If confirm is nil, any prompt fails the test.
+func stubCloudSuggest(t *testing.T, interactive bool, confirm func(prompt string) (bool, error)) *[]string {
+	t.Helper()
+
+	oldTTY, oldConfirm := isInteractiveTerminal, confirmCloudSuggestion
+	t.Cleanup(func() {
+		isInteractiveTerminal, confirmCloudSuggestion = oldTTY, oldConfirm
+	})
+
+	isInteractiveTerminal = func() bool { return interactive }
+
+	prompts := &[]string{}
+	confirmCloudSuggestion = func(prompt string) (bool, error) {
+		*prompts = append(*prompts, prompt)
+		if confirm == nil {
+			t.Errorf("unexpected cloud suggestion prompt: %q", prompt)
+			return false, nil
+		}
+		return confirm(prompt)
+	}
+	return prompts
+}
+
+type cloudSuggestServer struct {
+	cloudName   string // model name whose show/pull succeeds (e.g. "some-model:cloud")
+	cloudExists bool   // whether showing/pulling cloudName succeeds
+	pullErr     string // error message for failing pulls
+
+	showModels     []string
+	pullModels     []string
+	generateModels []string
+}
+
+// start serves mock /api/show, /api/pull, /api/tags, and /api/generate
+// endpoints: only cloudName is known (when cloudExists), and pulling any other
+// model fails with pullErr streamed the way real servers do (an in-band error
+// under HTTP 200).
+func (s *cloudSuggestServer) start(t *testing.T) {
+	t.Helper()
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/show" && r.Method == http.MethodPost:
+			var req api.ShowRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			name := cmp.Or(req.Model, req.Name)
+			s.showModels = append(s.showModels, name)
+			if s.cloudExists && name == s.cloudName {
+				if err := json.NewEncoder(w).Encode(api.ShowResponse{
+					Capabilities: []model.Capability{model.CapabilityCompletion},
+					RemoteModel:  strings.TrimSuffix(s.cloudName, ":cloud"),
+				}); err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+				}
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+			if err := json.NewEncoder(w).Encode(map[string]string{
+				"error": "model '" + name + "' not found",
+			}); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+		case r.URL.Path == "/api/pull" && r.Method == http.MethodPost:
+			var req api.PullRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			name := cmp.Or(req.Model, req.Name)
+			s.pullModels = append(s.pullModels, name)
+			var body any
+			if s.cloudExists && name == s.cloudName {
+				body = api.ProgressResponse{Status: "success"}
+			} else {
+				body = map[string]string{"error": s.pullErr}
+			}
+			if err := json.NewEncoder(w).Encode(body); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+		case r.URL.Path == "/api/tags" && r.Method == http.MethodGet:
+			if err := json.NewEncoder(w).Encode(api.ListResponse{
+				Models: []api.ListModelResponse{{Name: s.cloudName}},
+			}); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+		case r.URL.Path == "/api/generate" && r.Method == http.MethodPost:
+			var req api.GenerateRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			s.generateModels = append(s.generateModels, req.Model)
+			if err := json.NewEncoder(w).Encode(api.GenerateResponse{Done: true}); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+
+	t.Setenv("OLLAMA_HOST", mockServer.URL)
+	t.Cleanup(mockServer.Close)
+}
+
+func newCloudSuggestServer(t *testing.T) *cloudSuggestServer {
+	t.Helper()
+	s := &cloudSuggestServer{
+		cloudName:   "some-model:cloud",
+		cloudExists: true,
+		pullErr:     "pull model manifest: file does not exist",
+	}
+	s.start(t)
+	return s
+}
+
+func newPullTestCmd(t *testing.T) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+	cmd.Flags().Bool("insecure", false, "")
+	return cmd
+}
+
+func newRunTestCmd(t *testing.T) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+	cmd.Flags().String("keepalive", "", "")
+	cmd.Flags().Bool("truncate", false, "")
+	cmd.Flags().Int("dimensions", 0, "")
+	cmd.Flags().Bool("verbose", false, "")
+	cmd.Flags().Bool("insecure", false, "")
+	cmd.Flags().Bool("nowordwrap", false, "")
+	cmd.Flags().String("format", "", "")
+	cmd.Flags().String("think", "", "")
+	cmd.Flags().Bool("hidethinking", false, "")
+	return cmd
+}
+
+func TestPullHandler_SuccessfulPullNoSuggestion(t *testing.T) {
+	server := newCloudSuggestServer(t)
+	server.cloudName = "some-model" // the requested model itself pulls fine
+	stubCloudSuggest(t, true, nil)
+
+	if err := PullHandler(newPullTestCmd(t), []string{"some-model"}); err != nil {
+		t.Fatalf("PullHandler returned error: %v", err)
+	}
+	if want := []string{"some-model"}; !slices.Equal(server.pullModels, want) {
+		t.Fatalf("pulled models = %v, want %v", server.pullModels, want)
+	}
+	if len(server.showModels) != 0 {
+		t.Fatalf("show models = %v, want no probe after a successful pull", server.showModels)
+	}
+}
+
+func TestPullHandler_CloudSuggestionAccepted(t *testing.T) {
+	server := newCloudSuggestServer(t)
+	prompts := stubCloudSuggest(t, true, func(string) (bool, error) { return true, nil })
+
+	if err := PullHandler(newPullTestCmd(t), []string{"some-model"}); err != nil {
+		t.Fatalf("PullHandler returned error: %v", err)
+	}
+
+	if want := []string{"some-model", "some-model:cloud"}; !slices.Equal(server.pullModels, want) {
+		t.Fatalf("pulled models = %v, want %v", server.pullModels, want)
+	}
+	if len(*prompts) != 1 || !strings.Contains((*prompts)[0], `"some-model:cloud"`) {
+		t.Fatalf("prompts = %v, want one prompt mentioning some-model:cloud", *prompts)
+	}
+}
+
+func TestPullHandler_CloudSuggestionDeclined(t *testing.T) {
+	server := newCloudSuggestServer(t)
+	stubCloudSuggest(t, true, func(string) (bool, error) { return false, nil })
+
+	err := PullHandler(newPullTestCmd(t), []string{"some-model"})
+	if err == nil {
+		t.Fatal("PullHandler returned nil, want an error")
+	}
+	if !strings.Contains(err.Error(), "pull model manifest: file does not exist") {
+		t.Fatalf("error = %q, want it to contain the original pull error", err)
+	}
+	if strings.Contains(err.Error(), "Try:") {
+		t.Fatalf("error = %q, want no non-interactive hint after declining", err)
+	}
+	if want := []string{"some-model"}; !slices.Equal(server.pullModels, want) {
+		t.Fatalf("pulled models = %v, want %v", server.pullModels, want)
+	}
+}
+
+func TestPullHandler_CloudSuggestionCancelled(t *testing.T) {
+	server := newCloudSuggestServer(t)
+	stubCloudSuggest(t, true, func(string) (bool, error) { return false, launch.ErrCancelled })
+
+	err := PullHandler(newPullTestCmd(t), []string{"some-model"})
+	if err == nil {
+		t.Fatal("PullHandler returned nil, want an error")
+	}
+	if errors.Is(err, launch.ErrCancelled) {
+		t.Fatalf("error = %v, want the original pull error rather than ErrCancelled", err)
+	}
+	if !strings.Contains(err.Error(), "pull model manifest: file does not exist") {
+		t.Fatalf("error = %q, want it to contain the original pull error", err)
+	}
+	if want := []string{"some-model"}; !slices.Equal(server.pullModels, want) {
+		t.Fatalf("pulled models = %v, want %v", server.pullModels, want)
+	}
+}
+
+func TestPullHandler_CloudSuggestionNonInteractive(t *testing.T) {
+	server := newCloudSuggestServer(t)
+	stubCloudSuggest(t, false, nil)
+
+	err := PullHandler(newPullTestCmd(t), []string{"some-model"})
+	if err == nil {
+		t.Fatal("PullHandler returned nil, want an error")
+	}
+	if !strings.Contains(err.Error(), "pull model manifest: file does not exist") {
+		t.Fatalf("error = %q, want it to contain the original pull error", err)
+	}
+	if !strings.Contains(err.Error(), "ollama pull some-model:cloud") {
+		t.Fatalf("error = %q, want it to hint at 'ollama pull some-model:cloud'", err)
+	}
+	if want := []string{"some-model"}; !slices.Equal(server.pullModels, want) {
+		t.Fatalf("pulled models = %v, want %v", server.pullModels, want)
+	}
+}
+
+func TestPullHandler_CloudSuggestionNoCloudTag(t *testing.T) {
+	server := newCloudSuggestServer(t)
+	server.cloudExists = false
+	stubCloudSuggest(t, true, nil)
+
+	err := PullHandler(newPullTestCmd(t), []string{"some-model"})
+	if err == nil || err.Error() != "pull model manifest: file does not exist" {
+		t.Fatalf("error = %v, want the unmodified pull error", err)
+	}
+	if want := []string{"some-model:cloud"}; !slices.Equal(server.showModels, want) {
+		t.Fatalf("show models = %v, want the cloud existence probe %v", server.showModels, want)
+	}
+}
+
+func TestPullHandler_CloudSuggestionExplicitTag(t *testing.T) {
+	server := newCloudSuggestServer(t)
+	stubCloudSuggest(t, true, nil)
+
+	err := PullHandler(newPullTestCmd(t), []string{"some-model:9b"})
+	if err == nil || err.Error() != "pull model manifest: file does not exist" {
+		t.Fatalf("error = %v, want the unmodified pull error", err)
+	}
+	if len(server.showModels) != 0 {
+		t.Fatalf("show models = %v, want no cloud probe for explicitly tagged models", server.showModels)
+	}
+}
+
+func TestPullHandler_CloudSuggestionExplicitCloud(t *testing.T) {
+	server := newCloudSuggestServer(t)
+	server.cloudExists = false // make the explicit :cloud pull fail too
+	stubCloudSuggest(t, true, nil)
+
+	err := PullHandler(newPullTestCmd(t), []string{"some-model:cloud"})
+	if err == nil || err.Error() != "pull model manifest: file does not exist" {
+		t.Fatalf("error = %v, want the unmodified pull error", err)
+	}
+	if len(server.showModels) != 0 {
+		t.Fatalf("show models = %v, want no probe for explicit :cloud requests", server.showModels)
+	}
+}
+
+func TestPullHandler_CloudSuggestionInsecure(t *testing.T) {
+	server := newCloudSuggestServer(t)
+	stubCloudSuggest(t, true, nil)
+
+	cmd := newPullTestCmd(t)
+	if err := cmd.Flags().Set("insecure", "true"); err != nil {
+		t.Fatal(err)
+	}
+
+	err := PullHandler(cmd, []string{"some-model"})
+	if err == nil || err.Error() != "pull model manifest: file does not exist" {
+		t.Fatalf("error = %v, want the unmodified pull error", err)
+	}
+	if len(server.showModels) != 0 {
+		t.Fatalf("show models = %v, want no probe for --insecure pulls", server.showModels)
+	}
+}
+
+func TestPullHandler_CloudSuggestionUnrelatedError(t *testing.T) {
+	server := newCloudSuggestServer(t)
+	server.pullErr = "boom"
+	stubCloudSuggest(t, true, nil)
+
+	err := PullHandler(newPullTestCmd(t), []string{"some-model"})
+	if err == nil || err.Error() != "boom" {
+		t.Fatalf("error = %v, want the unmodified pull error %q", err, "boom")
+	}
+	if len(server.showModels) != 0 {
+		t.Fatalf("show models = %v, want no probe for unrelated pull errors", server.showModels)
+	}
+}
+
+func TestRunHandler_CloudSuggestionAccepted_RunsCloudModel(t *testing.T) {
+	server := newCloudSuggestServer(t)
+	stubCloudSuggest(t, true, func(string) (bool, error) { return true, nil })
+
+	if err := RunHandler(newRunTestCmd(t), []string{"some-model", "hi"}); err != nil {
+		t.Fatalf("RunHandler returned error: %v", err)
+	}
+
+	if want := []string{"some-model", "some-model:cloud"}; !slices.Equal(server.pullModels, want) {
+		t.Fatalf("pulled models = %v, want %v", server.pullModels, want)
+	}
+	if want := []string{"some-model:cloud"}; !slices.Equal(server.generateModels, want) {
+		t.Fatalf("generate models = %v, want %v", server.generateModels, want)
+	}
+}
+
+func TestRunHandler_CloudSuggestionDeclined_ReturnsNotFound(t *testing.T) {
+	server := newCloudSuggestServer(t)
+	stubCloudSuggest(t, true, func(string) (bool, error) { return false, nil })
+
+	err := RunHandler(newRunTestCmd(t), []string{"some-model", "hi"})
+	if err == nil {
+		t.Fatal("RunHandler returned nil, want an error")
+	}
+	if !strings.Contains(err.Error(), "pull model manifest: file does not exist") {
+		t.Fatalf("error = %q, want it to contain the original pull error", err)
+	}
+	if len(server.generateModels) != 0 {
+		t.Fatalf("generate models = %v, want none after declining", server.generateModels)
+	}
+}
+
+func TestRunHandler_CloudSuggestionNonInteractive_Hint(t *testing.T) {
+	server := newCloudSuggestServer(t)
+	stubCloudSuggest(t, false, nil)
+
+	err := RunHandler(newRunTestCmd(t), []string{"some-model", "hi"})
+	if err == nil {
+		t.Fatal("RunHandler returned nil, want an error")
+	}
+	if !strings.Contains(err.Error(), "ollama run some-model:cloud") {
+		t.Fatalf("error = %q, want it to hint at 'ollama run some-model:cloud'", err)
+	}
+	if len(server.generateModels) != 0 {
+		t.Fatalf("generate models = %v, want none in non-interactive mode", server.generateModels)
+	}
+}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1527,7 +1527,11 @@ func PullHandler(cmd *cobra.Command, args []string) error {
 	return err
 }
 
-func pullModelWithProgress(ctx context.Context, client *api.Client, name string, insecure bool) error {
+// pullModelWithProgress pulls name, rendering progress to stderr. When
+// clearNotFound is set and the pull fails because the model doesn't exist,
+// the progress display is erased rather than left behind; callers set it
+// when a ":cloud" suggestion prompt may immediately follow the failure.
+func pullModelWithProgress(ctx context.Context, client *api.Client, name string, insecure, clearNotFound bool) error {
 	p := progress.NewProgress(os.Stderr)
 	defer p.Stop()
 
@@ -1589,7 +1593,12 @@ func pullModelWithProgress(ctx context.Context, client *api.Client, name string,
 	}
 
 	request := api.PullRequest{Name: name, Insecure: insecure}
-	return client.Pull(ctx, &request, fn)
+	err := client.Pull(ctx, &request, fn)
+	if clearNotFound && isPullNotFoundErr(err) {
+		// The deferred Stop becomes a no-op after this.
+		p.StopAndClear()
+	}
+	return err
 }
 
 type generateContextKey string

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -707,6 +707,32 @@ func hasListedModelName(models []api.ListModelResponse, name string) bool {
 	return false
 }
 
+// showOrPullModel returns model info for name, pulling the model if it isn't
+// available locally. If the pull finds no default tag but a ":cloud" tag
+// exists, the user may be offered the cloud model instead (see
+// pullWithCloudSuggestion), in which case the returned name is the cloud
+// name the caller should continue with. verb is the user-facing command
+// ("run" or "pull") used in hint text.
+func showOrPullModel(cmd *cobra.Command, client *api.Client, name string, insecure bool, verb string) (*api.ShowResponse, string, error) {
+	info, err := client.Show(cmd.Context(), &api.ShowRequest{Model: name})
+	if err == nil {
+		return info, name, nil
+	}
+
+	var se api.StatusError
+	if !errors.As(err, &se) || se.StatusCode != http.StatusNotFound || modelref.HasExplicitCloudSource(name) {
+		return nil, name, err
+	}
+
+	resolved, err := pullWithCloudSuggestion(cmd.Context(), client, name, insecure, verb)
+	if err != nil {
+		return nil, name, err
+	}
+
+	info, err = client.Show(cmd.Context(), &api.ShowRequest{Model: resolved})
+	return info, resolved, err
+}
+
 func RunHandler(cmd *cobra.Command, args []string) error {
 	interactive := true
 
@@ -802,30 +828,21 @@ func RunHandler(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	name := args[0]
-	requestedCloud := modelref.HasExplicitCloudSource(name)
+	insecure, err := cmd.Flags().GetBool("insecure")
+	if err != nil {
+		return err
+	}
 
-	info, err := func() (*api.ShowResponse, error) {
-		showReq := &api.ShowRequest{Name: name}
-		info, err := client.Show(cmd.Context(), showReq)
-		var se api.StatusError
-		if errors.As(err, &se) && se.StatusCode == http.StatusNotFound {
-			if requestedCloud {
-				return nil, err
-			}
-			if err := PullHandler(cmd, []string{name}); err != nil {
-				return nil, err
-			}
-			return client.Show(cmd.Context(), &api.ShowRequest{Name: name})
-		}
-		return info, err
-	}()
+	info, name, err := showOrPullModel(cmd, client, args[0], insecure, "run")
 	if err != nil {
 		if handleCloudAuthorizationError(err) {
 			return nil
 		}
 		return err
 	}
+	// The model may have been resolved to a different name (e.g. its ":cloud"
+	// variant), so make sure downstream requests use it.
+	opts.Model = name
 
 	ensureCloudStub(cmd.Context(), client, name)
 
@@ -1506,6 +1523,11 @@ func PullHandler(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	_, err = pullWithCloudSuggestion(cmd.Context(), client, args[0], insecure, "pull")
+	return err
+}
+
+func pullModelWithProgress(ctx context.Context, client *api.Client, name string, insecure bool) error {
 	p := progress.NewProgress(os.Stderr)
 	defer p.Stop()
 
@@ -1566,8 +1588,8 @@ func PullHandler(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	request := api.PullRequest{Name: args[0], Insecure: insecure}
-	return client.Pull(cmd.Context(), &request, fn)
+	request := api.PullRequest{Name: name, Insecure: insecure}
+	return client.Pull(ctx, &request, fn)
 }
 
 type generateContextKey string

--- a/internal/modelref/modelref.go
+++ b/internal/modelref/modelref.go
@@ -80,14 +80,17 @@ func NormalizePullName(raw string) (string, bool, error) {
 }
 
 func toLegacyCloudPullName(base string) string {
-	if hasExplicitTag(base) {
+	if HasExplicitTag(base) {
 		return base + "-cloud"
 	}
 
 	return base + ":cloud"
 }
 
-func hasExplicitTag(name string) bool {
+// HasExplicitTag reports whether name contains an explicit tag (e.g.
+// "model:8b"), as opposed to relying on the default tag. Colons in a
+// registry host (e.g. "registry.example.com:5000/model") don't count.
+func HasExplicitTag(name string) bool {
 	lastSlash := strings.LastIndex(name, "/")
 	lastColon := strings.LastIndex(name, ":")
 	return lastColon > lastSlash

--- a/internal/modelref/modelref_test.go
+++ b/internal/modelref/modelref_test.go
@@ -185,6 +185,30 @@ func TestNormalizePullName(t *testing.T) {
 	}
 }
 
+func TestHasExplicitTag(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{name: "no tag", input: "some-model", want: false},
+		{name: "explicit tag", input: "some-model:9b", want: true},
+		{name: "explicit latest tag", input: "some-model:latest", want: true},
+		{name: "namespace without tag", input: "user/some-model", want: false},
+		{name: "namespace with tag", input: "user/some-model:9b", want: true},
+		{name: "host port without tag", input: "registry.example.com:5000/some-model", want: false},
+		{name: "host port with tag", input: "registry.example.com:5000/some-model:9b", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := HasExplicitTag(tt.input); got != tt.want {
+				t.Fatalf("HasExplicitTag(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestParseSourceSuffix(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
Cloud-only models (e.g. kimi-k3) publish only a "cloud" tag, so `ollama run kimi-k3` and `ollama pull kimi-k3` fail with a bare "file does not exist" error and users never discover kimi-k3:cloud.

When pulling a default-tag model fails with not-found, probe whether a ":cloud" variant exists (via /api/show, which proxies to ollama.com and mirrors its status). If it does, prompt "Did you mean kimi-k3:cloud?" at an interactive terminal and continue as if the user had typed the cloud name, or append a hint with the exact command to the error when non-interactive. Declining, cancelling, or any probe failure falls back to the original error, and explicit tags, :cloud/:local suffixes, and --insecure pulls are left alone.

The show/pull logic shared by RunHandler and the bare-ollama TUI moves into showOrPullModel so the resolved name propagates to downstream requests. This also fixes prepareAgentModel reading the unregistered --insecure flag through PullHandler, which errored any time the bare `ollama` TUI needed to pull a model.

In the future we might want to have an "Always" option that remembers their choice. The intent behind this change is to do something stateless quickly to cover this current gap that currently causes confusion.