### PR TITLE
tools: unwrap duplicated tool-call argument envelopes

### DIFF
--- a/tools/tools.go
+++ b/tools/tools.go
@@ -295,10 +295,10 @@ func findArguments(tool *api.Tool, buffer []byte) (map[string]any, int) {
 					}
 					if _, hasName := obj["name"]; hasName {
 						if args, ok := findMap("arguments", obj); ok {
-							return args, true
+							return unwrapNestedToolCall(tool, args), true
 						}
 						if args, ok := findMap("parameters", obj); ok {
-							return args, true
+							return unwrapNestedToolCall(tool, args), true
 						}
 						return nil, true
 					}
@@ -340,6 +340,45 @@ func findArguments(tool *api.Tool, buffer []byte) (map[string]any, int) {
 	}
 
 	return nil, 0
+}
+
+// unwrapNestedToolCall removes a duplicated tool-call envelope from arguments.
+// Some models repeat {"name": ..., "arguments": ...} inside the outer
+// arguments object. Preserve it when both fields are declared by the tool
+// schema, since in that case it may be the intended payload.
+func unwrapNestedToolCall(tool *api.Tool, args map[string]any) map[string]any {
+	if len(args) != 2 {
+		return args
+	}
+
+	name, ok := args["name"].(string)
+	if !ok || name != tool.Function.Name {
+		return args
+	}
+
+	for _, key := range []string{"arguments", "parameters"} {
+		nested, ok := args[key].(map[string]any)
+		if !ok {
+			if nestedJSON, ok := args[key].(string); ok {
+				if err := json.Unmarshal([]byte(nestedJSON), &nested); err != nil {
+					continue
+				}
+			} else {
+				continue
+			}
+		}
+
+		properties := tool.Function.Parameters.Properties
+		_, hasName := properties.Get("name")
+		_, hasNested := properties.Get(key)
+		if hasName && hasNested {
+			return args
+		}
+
+		return nested
+	}
+
+	return args
 }
 
 // done checks if the parser is done parsing by looking

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -1350,6 +1350,14 @@ func TestFindArguments(t *testing.T) {
 				"location": "San Francisco, CA",
 			},
 		},
+		{
+			name:   "duplicated tool call envelope in arguments",
+			tool:   "extract_name",
+			buffer: []byte(`{"name": "extract_name", "arguments": {"name": "extract_name", "arguments": {"name": "John"}}}`),
+			want: map[string]any{
+				"name": "John",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1360,5 +1368,29 @@ func TestFindArguments(t *testing.T) {
 				t.Errorf("findArguments() args mismatch (-got +want):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestUnwrapNestedToolCallPreservesDeclaredFields(t *testing.T) {
+	tool := &api.Tool{
+		Function: api.ToolFunction{
+			Name: "dispatch",
+			Parameters: api.ToolFunctionParameters{
+				Properties: testPropsMap(map[string]api.ToolProperty{
+					"name":      {Type: api.PropertyType{"string"}},
+					"arguments": {Type: api.PropertyType{"object"}},
+				}),
+			},
+		},
+	}
+	args := map[string]any{
+		"name": "dispatch",
+		"arguments": map[string]any{
+			"name": "John",
+		},
+	}
+
+	if diff := cmp.Diff(args, unwrapNestedToolCall(tool, args)); diff != "" {
+		t.Errorf("unwrapNestedToolCall() mismatch (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
## Summary

- unwrap a duplicated `{"name": ..., "arguments": ...}` envelope when a model emits it inside the outer tool-call arguments
- require the nested tool name to match and the wrapper to contain exactly two fields
- preserve the object when both wrapper-like fields are explicitly declared by the tool schema

This keeps the API-facing argument object consistent for tools whose actual schema contains a field such as `name`.

Fixes #11805.

## Root cause

The generic tool parser extracted the first outer `arguments` map and returned it unchanged. When a model repeated the full tool-call envelope inside that map, the duplicated `name` and `arguments` fields leaked into `ToolCall.Function.Arguments`.

## Validation

- `go test ./tools -count=1`
- `go test ./api ./tools -count=1`
- `go vet ./tools/...`
- `git diff --check`
