### PR TITLE
mlx: add Gemma4 vision support

### DIFF
--- a/integration/reg_groups_test.go
+++ b/integration/reg_groups_test.go
@@ -84,6 +84,7 @@ func TestVision(t *testing.T) {
 		"vision-detail",
 		"vision-multi-image",
 		"vision-description",
+		"vision-ocr-document",
 		"vision-split-batch",
 		"vision-text",
 	)

--- a/integration/reg_library_test.go
+++ b/integration/reg_library_test.go
@@ -228,4 +228,5 @@ func init() {
 	registerLibraryEmbeddingCases(testModels(libraryModels))
 	registerToolCases(testModels(libraryModels))
 	registerVisionTextCases(testModels(libraryModels))
+	registerVisionOCRDocumentCases(testModels([]string{"gemma4"}))
 }

--- a/integration/reg_release_test.go
+++ b/integration/reg_release_test.go
@@ -117,7 +117,6 @@ func init() {
 		integrationTestCase("create-safetensors", "", runCreateSafetensorsLLM),
 		integrationTestCase("create-gguf", "", runCreateGGUF),
 		integrationTestCase("quantization", "qwen2.5:0.5b-instruct-fp16", runQuantization),
-		integrationTestCase("image-generation", "", runImageGeneration),
 	)
 
 	// Model-parametric cases
@@ -126,6 +125,7 @@ func init() {
 	registerChatCases(testModels(modelNames(releaseChatModels)))
 	registerEmbeddingCases(testModels(releaseEmbedModels))
 	registerVisionTextCases(testModels(releaseVisionTextModels))
+	registerVisionOCRDocumentCases(testModels([]string{"gemma4"}))
 	registerToolCases(testModels(releaseToolsModels))
 	registerToolStressCases(testModels(releaseToolsModels))
 	registerAudioTranscriptionCases(testModels(releaseAudioModels))

--- a/integration/vision_ocr_test.go
+++ b/integration/vision_ocr_test.go
@@ -1,0 +1,153 @@
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"image"
+	"image/color"
+	"image/draw"
+	"image/png"
+	"testing"
+	"time"
+
+	"github.com/ollama/ollama/api"
+	"golang.org/x/image/font"
+	"golang.org/x/image/font/gofont/goregular"
+	"golang.org/x/image/font/opentype"
+	"golang.org/x/image/math/fixed"
+)
+
+const visionOCRReference = "HARBOR-DELTA-8061"
+
+func registerVisionOCRDocumentCases(models []string) {
+	registerModelIntegrationCases("vision-ocr-document", models, runVisionOCRDocument)
+}
+
+func runVisionOCRDocument(t *testing.T, model string) {
+	t.Helper()
+
+	skipUnderMinVRAM(t, 8)
+	skipKnownIntegrationFlake(t, "vision-ocr-document", model)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
+	defer cancel()
+	client, _, cleanup := InitServerConnection(ctx, t)
+	defer cleanup()
+
+	requireCapability(ctx, t, client, model, "vision")
+	pullOrSkip(ctx, t, client, model)
+
+	document, err := visionOCRDocument()
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := api.ChatRequest{
+		Model: model,
+		Messages: []api.Message{
+			{
+				Role: "user",
+				Content: "Scan the entire document and read the unique FINAL AUDIT CODE field. " +
+					"Reply with only its value.",
+				Images: []api.ImageData{document},
+			},
+		},
+		Stream: &stream,
+		Options: map[string]any{
+			"seed":        42,
+			"temperature": 0.0,
+		},
+		KeepAlive: &api.Duration{Duration: 10 * time.Second},
+	}
+
+	preloadGenerateModel(ctx, t, client, api.GenerateRequest{Model: req.Model})
+	skipIfNotGPULoaded(ctx, t, client, req.Model, 80)
+	DoChat(ctx, t, client, req, []string{visionOCRReference}, 240*time.Second, 30*time.Second)
+}
+
+func visionOCRDocument() ([]byte, error) {
+	const (
+		tileWidth  = 800
+		tileHeight = 800
+		columns    = 3
+		rows       = 4
+	)
+
+	parsedFont, err := opentype.Parse(goregular.TTF)
+	if err != nil {
+		return nil, fmt.Errorf("parse document font: %w", err)
+	}
+	bodyFace, err := opentype.NewFace(parsedFont, &opentype.FaceOptions{
+		Size:    40,
+		DPI:     72,
+		Hinting: font.HintingFull,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create document font: %w", err)
+	}
+	referenceFace, err := opentype.NewFace(parsedFont, &opentype.FaceOptions{
+		Size:    48,
+		DPI:     72,
+		Hinting: font.HintingFull,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create reference font: %w", err)
+	}
+
+	white := color.RGBA{R: 255, G: 255, B: 255, A: 255}
+	ink := image.NewUniform(color.RGBA{R: 24, G: 29, B: 36, A: 255})
+	rule := color.RGBA{R: 180, G: 186, B: 194, A: 255}
+	tile := image.NewRGBA(image.Rect(0, 0, tileWidth, tileHeight))
+	draw.Draw(tile, tile.Bounds(), image.NewUniform(white), image.Point{}, draw.Src)
+	drawOCRRule(tile, image.Rect(40, 40, tileWidth-40, 44), rule)
+	drawOCRRule(tile, image.Rect(40, 130, tileWidth-40, 134), rule)
+	drawOCRRule(tile, image.Rect(40, 520, tileWidth-40, 524), rule)
+	drawOCRText(tile, bodyFace, ink, 48, 110, "FIELD SERVICE RECORD")
+	drawOCRText(tile, bodyFace, ink, 48, 220, "Equipment: turbine assembly")
+	drawOCRText(tile, bodyFace, ink, 48, 290, "Inspection: pressure and seals")
+	drawOCRText(tile, bodyFace, ink, 48, 360, "Status: passed")
+	drawOCRText(tile, bodyFace, ink, 48, 470, "Technician notes: no defects")
+
+	page := image.NewRGBA(image.Rect(0, 0, columns*tileWidth, rows*tileHeight))
+	draw.Draw(page, page.Bounds(), image.NewUniform(white), image.Point{}, draw.Src)
+	for row := range rows {
+		for column := range columns {
+			cell := image.NewRGBA(tile.Bounds())
+			draw.Draw(cell, cell.Bounds(), tile, image.Point{}, draw.Src)
+			drawOCRText(cell, bodyFace, ink, 48, 190, fmt.Sprintf("ROW %d  COLUMN %d", row+1, column+1))
+
+			label := "REFERENCE:"
+			reference := fmt.Sprintf("CELL-R%d-C%d-%04d", row+1, column+1, (row+1)*100+column+1)
+			if row == rows-1 && column == columns-1 {
+				label = "FINAL AUDIT CODE:"
+				reference = visionOCRReference
+			}
+			drawOCRText(cell, referenceFace, ink, 48, 640, label)
+			drawOCRText(cell, referenceFace, ink, 48, 710, reference)
+
+			origin := image.Pt(column*tileWidth, row*tileHeight)
+			draw.Draw(page, image.Rectangle{Min: origin, Max: origin.Add(cell.Bounds().Size())}, cell, image.Point{}, draw.Src)
+		}
+	}
+
+	var encoded bytes.Buffer
+	if err := png.Encode(&encoded, page); err != nil {
+		return nil, fmt.Errorf("encode OCR document: %w", err)
+	}
+	return encoded.Bytes(), nil
+}
+
+func drawOCRText(dst draw.Image, face font.Face, source image.Image, x, y int, text string) {
+	drawer := font.Drawer{
+		Dst:  dst,
+		Src:  source,
+		Face: face,
+		Dot:  fixed.P(x, y),
+	}
+	drawer.DrawString(text)
+}
+
+func drawOCRRule(dst draw.Image, bounds image.Rectangle, fill color.Color) {
+	draw.Draw(dst, bounds, image.NewUniform(fill), image.Point{}, draw.Src)
+}

--- a/server/images.go
+++ b/server/images.go
@@ -455,11 +455,6 @@ func (m *Model) filterUnsupportedCapabilities(capabilities []model.Capability, m
 			return c == model.CapabilityAudio
 		})
 	}
-	if isGemma4Renderer(m.Config.Renderer) && m.Config.ModelFormat == "safetensors" {
-		capabilities = slices.DeleteFunc(capabilities, func(c model.Capability) bool {
-			return c == model.CapabilityVision
-		})
-	}
 
 	return capabilities
 }

--- a/server/images_test.go
+++ b/server/images_test.go
@@ -516,7 +516,7 @@ func TestModelCapabilities(t *testing.T) {
 			expectedCaps: []model.Capability{model.CapabilityCompletion, model.CapabilityVision},
 		},
 		{
-			name: "gemma4 small safetensors suppresses vision and audio",
+			name: "gemma4 small safetensors exposes vision and suppresses audio",
 			model: Model{
 				Config: model.ConfigV2{
 					ModelFormat:  "safetensors",
@@ -525,9 +525,10 @@ func TestModelCapabilities(t *testing.T) {
 				},
 				Template: chatTemplate,
 			},
+			expectedCaps: []model.Capability{model.CapabilityVision},
 		},
 		{
-			name: "gemma4 large safetensors suppresses vision and audio",
+			name: "gemma4 large safetensors exposes vision and suppresses audio",
 			model: Model{
 				Config: model.ConfigV2{
 					ModelFormat:  "safetensors",
@@ -536,9 +537,10 @@ func TestModelCapabilities(t *testing.T) {
 				},
 				Template: chatTemplate,
 			},
+			expectedCaps: []model.Capability{model.CapabilityVision},
 		},
 		{
-			name: "default gemma4 safetensors suppresses vision and audio",
+			name: "default gemma4 safetensors exposes vision and suppresses audio",
 			model: Model{
 				Config: model.ConfigV2{
 					ModelFormat:  "safetensors",
@@ -547,6 +549,20 @@ func TestModelCapabilities(t *testing.T) {
 				},
 				Template: chatTemplate,
 			},
+			expectedCaps: []model.Capability{model.CapabilityVision},
+		},
+		{
+			name: "legacy gemma4 e2b safetensors exposes vision and suppresses audio",
+			model: Model{
+				ShortName: "gemma4:e2b-nvfp4",
+				Config: model.ConfigV2{
+					ModelFormat:  "safetensors",
+					Renderer:     gemma4RendererLegacy,
+					Capabilities: []string{"vision", "audio"},
+				},
+				Template: chatTemplate,
+			},
+			expectedCaps: []model.Capability{model.CapabilityVision},
 		},
 	}
 

--- a/server/model_list_cache.go
+++ b/server/model_list_cache.go
@@ -391,9 +391,11 @@ func buildModelListSummary(name model.Name, mf *manifest.Manifest) (modelListSum
 		summary.Capabilities = appendModelListCapability(summary.Capabilities, model.CapabilityVision)
 	}
 
+	// Mirrors suppressAudioCapability in images.go so /api/tags and /api/show
+	// agree for safetensors models whose MLX runner supports vision but not audio.
 	if cfg.ModelFormat == "safetensors" && isGemma4Renderer(cfg.Renderer) {
 		summary.Capabilities = slices.DeleteFunc(summary.Capabilities, func(c model.Capability) bool {
-			return c == model.CapabilityVision || c == model.CapabilityAudio
+			return c == model.CapabilityAudio
 		})
 	}
 

--- a/server/model_list_cache_test.go
+++ b/server/model_list_cache_test.go
@@ -339,3 +339,42 @@ func writeModelListGGUFUint64(t *testing.T, b *bytes.Buffer, v uint64) {
 		t.Fatal(err)
 	}
 }
+
+// TestModelListCacheGemma4SafetensorsCapabilities pins /api/tags to the same
+// answer filterUnsupportedCapabilities gives /api/show for gemma4 safetensors
+// models: the MLX runner serves vision but not audio. The two filters live in
+// separate files, so without this the list path can silently drift.
+func TestModelListCacheGemma4SafetensorsCapabilities(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setTestHome(t, t.TempDir())
+
+	name := model.ParseName("gemma4-list")
+	configLayer, err := createConfigLayer(nil, model.ConfigV2{
+		ModelFormat:  "safetensors",
+		ModelFamily:  "gemma4",
+		Renderer:     gemma4RendererSmall,
+		Capabilities: []string{"completion", "vision", "audio"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := manifest.WriteManifest(name, *configLayer, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	cache := newModelListCache()
+	if err := cache.hydrate(context.Background()); err != nil {
+		t.Fatalf("hydrate failed: %v", err)
+	}
+	summary, ok := cache.Get(name)
+	if !ok {
+		t.Fatal("list summary missing")
+	}
+
+	if !slices.Contains(summary.Capabilities, model.CapabilityVision) {
+		t.Errorf("capabilities = %v, want vision", summary.Capabilities)
+	}
+	if slices.Contains(summary.Capabilities, model.CapabilityAudio) {
+		t.Errorf("capabilities = %v, want no audio", summary.Capabilities)
+	}
+}

--- a/x/internal/mlxtest/mlxtest.go
+++ b/x/internal/mlxtest/mlxtest.go
@@ -1,0 +1,41 @@
+// Package mlxtest provides shared scaffolding for tests that exercise MLX
+// through the cgo wrapper in x/mlxrunner/mlx.
+package mlxtest
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+)
+
+// SkipIfUnavailable skips the test when the MLX dynamic library cannot be
+// loaded (e.g. no MLX backend built for this platform).
+func SkipIfUnavailable(t *testing.T) {
+	t.Helper()
+	if err := mlx.CheckInit(); err != nil {
+		t.Skipf("MLX not available: %v", err)
+	}
+}
+
+// Setup prepares a test that calls into MLX natively: it skips when MLX is
+// unavailable and pins the test goroutine to its OS thread for the duration
+// of the test.
+//
+// The thread pin is load-bearing, not defensive: MLX's default stream cache
+// is thread-local, and anything that migrates the goroutine mid-test (the
+// race detector's scheduler in particular) otherwise panics with
+// "There is no Stream(gpu, 0) in current thread".
+//
+// Setup deliberately does not switch devices or sweep caches: switching the
+// default device re-creates the process-wide default stream, and sweeping the
+// allocator cache between tests changes allocator reuse — both perturbed
+// tests that share lazy arrays with subtests running on other threads.
+func Setup(t *testing.T) {
+	t.Helper()
+
+	SkipIfUnavailable(t)
+
+	runtime.LockOSThread()
+	t.Cleanup(runtime.UnlockOSThread)
+}

--- a/x/mlxrunner/client.go
+++ b/x/mlxrunner/client.go
@@ -112,6 +112,7 @@ func (c *Client) WaitUntilRunning(ctx context.Context) error {
 
 type CompletionRequest struct {
 	Prompt      string
+	Media       []llm.MediaData
 	Options     api.Options
 	Logprobs    bool
 	TopLogprobs int
@@ -155,6 +156,7 @@ func (c *Client) Close() error {
 func (c *Client) Completion(ctx context.Context, req llm.CompletionRequest, fn func(llm.CompletionResponse)) error {
 	creq := CompletionRequest{
 		Prompt:      req.Prompt,
+		Media:       req.Media,
 		Logprobs:    req.Logprobs,
 		TopLogprobs: req.TopLogprobs,
 	}

--- a/x/mlxrunner/client_test.go
+++ b/x/mlxrunner/client_test.go
@@ -1,0 +1,57 @@
+package mlxrunner
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/ollama/ollama/llm"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestCompletionForwardsMedia(t *testing.T) {
+	var got CompletionRequest
+	client := &Client{
+		port: 1,
+		client: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				if err := json.NewDecoder(req.Body).Decode(&got); err != nil {
+					t.Fatal(err)
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"Done":true}` + "\n")),
+					Header:     make(http.Header),
+				}, nil
+			}),
+		},
+	}
+
+	media := llm.NewMediaData(7, []byte("\x89PNG\r\n\x1a\nimage"))
+	err := client.Completion(context.Background(), llm.CompletionRequest{
+		Prompt: "describe [img-7]",
+		Media:  []llm.MediaData{media},
+	}, func(llm.CompletionResponse) {})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got.Prompt != "describe [img-7]" {
+		t.Fatalf("prompt = %q", got.Prompt)
+	}
+	if len(got.Media) != 1 {
+		t.Fatalf("media count = %d, want 1", len(got.Media))
+	}
+	if got.Media[0].ID != media.ID || got.Media[0].Kind != llm.MediaKindImage ||
+		string(got.Media[0].Data) != string(media.Data) {
+		t.Fatalf("media = %+v, want %+v", got.Media[0], media)
+	}
+}

--- a/x/mlxrunner/model/base/media_cache.go
+++ b/x/mlxrunner/model/base/media_cache.go
@@ -1,0 +1,197 @@
+package base
+
+import (
+	"container/list"
+	"crypto/sha256"
+	"encoding/binary"
+	"sync"
+	"sync/atomic"
+
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+)
+
+const (
+	// Keep only a few recent attachments and cap their projected features so
+	// this stopgap cannot consume a material share of the model's memory.
+	mediaFeatureCacheEntries = 4
+	mediaFeatureCacheBytes   = 128 << 20
+)
+
+// MediaFeatureKey identifies projected media features within one loaded model.
+// variant must describe preprocessing choices that can change the features.
+type MediaFeatureKey [sha256.Size]byte
+
+// NewMediaFeatureKey hashes media bytes and their preprocessing variant.
+func NewMediaFeatureKey(data []byte, variant string) MediaFeatureKey {
+	hash := sha256.New()
+	var size [8]byte
+	binary.LittleEndian.PutUint64(size[:], uint64(len(variant)))
+	_, _ = hash.Write(size[:])
+	_, _ = hash.Write([]byte(variant))
+	_, _ = hash.Write(data)
+
+	var key MediaFeatureKey
+	copy(key[:], hash.Sum(nil))
+	return key
+}
+
+// MediaFeatureCache is a bounded stopgap that retains projected media features
+// while multimodal requests use a request-local KV cache. It is intentionally
+// independent of the runner caches and should be removed or absorbed once
+// multimodal inputs participate in their normal lifecycle.
+type MediaFeatureCache struct {
+	// mu guards the cache accounting, LRU, entries map, and every mutable
+	// mediaFeatureEntry field.
+	mu sync.Mutex
+
+	maxEntries int
+	maxBytes   int
+	usedBytes  int
+	entries    map[MediaFeatureKey]*mediaFeatureEntry
+	lru        list.List
+}
+
+type mediaFeatureEntry struct {
+	key        MediaFeatureKey
+	features   *mlx.Array
+	tokenCount int
+	size       int
+	leases     int
+	element    *list.Element
+	resident   bool
+}
+
+// MediaFeatureLease keeps cached features alive while a prepared prompt uses
+// them. Release must be called when the prompt is closed.
+type MediaFeatureLease struct {
+	cache    *MediaFeatureCache
+	entry    *mediaFeatureEntry
+	released atomic.Bool
+}
+
+// NewMediaFeatureCache creates a cache with fixed entry and memory bounds.
+func NewMediaFeatureCache() *MediaFeatureCache {
+	return newMediaFeatureCache(mediaFeatureCacheEntries, mediaFeatureCacheBytes)
+}
+
+func newMediaFeatureCache(maxEntries, maxBytes int) *MediaFeatureCache {
+	if maxEntries <= 0 {
+		panic("media feature cache requires at least one entry")
+	}
+	if maxBytes <= 0 {
+		panic("media feature cache requires a positive byte limit")
+	}
+	return &MediaFeatureCache{
+		maxEntries: maxEntries,
+		maxBytes:   maxBytes,
+		entries:    make(map[MediaFeatureKey]*mediaFeatureEntry),
+	}
+}
+
+// Acquire returns a lease for cached features and updates their recency.
+func (c *MediaFeatureCache) Acquire(key MediaFeatureKey) (*MediaFeatureLease, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	entry, ok := c.entries[key]
+	if !ok {
+		return nil, false
+	}
+	entry.leases++
+	c.lru.MoveToFront(entry.element)
+	return &MediaFeatureLease{cache: c, entry: entry}, true
+}
+
+// Store retains features and returns a lease for the caller. If another caller
+// stored the key first, Store returns the existing features instead.
+func (c *MediaFeatureCache) Store(key MediaFeatureKey, features *mlx.Array, tokenCount int) *MediaFeatureLease {
+	// The three panics below are here only because this stopgap cache has
+	// no error channel back to the pipeline; when multimodal inputs join the
+	// normal cache lifecycle these become returned errors.
+	if features == nil || !features.Valid() {
+		panic("cannot cache invalid media features")
+	}
+	if tokenCount <= 0 {
+		panic("cannot cache media features without tokens")
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if entry, ok := c.entries[key]; ok {
+		if entry.tokenCount != tokenCount {
+			panic("media feature cache token count changed for the same key")
+		}
+		entry.leases++
+		c.lru.MoveToFront(entry.element)
+		return &MediaFeatureLease{cache: c, entry: entry}
+	}
+
+	mlx.Pin(features)
+	entry := &mediaFeatureEntry{
+		key:        key,
+		features:   features,
+		tokenCount: tokenCount,
+		size:       features.NumBytes(),
+		leases:     1,
+		resident:   true,
+	}
+	entry.element = c.lru.PushFront(entry)
+	c.entries[key] = entry
+	c.usedBytes += entry.size
+	c.evictLocked()
+
+	return &MediaFeatureLease{cache: c, entry: entry}
+}
+
+// Features returns the projected features while the lease is active.
+func (l *MediaFeatureLease) Features() *mlx.Array {
+	if l == nil || l.released.Load() {
+		return nil
+	}
+	return l.entry.features
+}
+
+// TokenCount returns the number of soft tokens represented by the features.
+func (l *MediaFeatureLease) TokenCount() int {
+	if l == nil || l.released.Load() {
+		return 0
+	}
+	return l.entry.tokenCount
+}
+
+// Release relinquishes a lease. It is safe to call more than once.
+func (l *MediaFeatureLease) Release() {
+	if l == nil || !l.released.CompareAndSwap(false, true) {
+		return
+	}
+
+	l.cache.mu.Lock()
+	defer l.cache.mu.Unlock()
+
+	l.entry.leases--
+	if l.entry.leases < 0 {
+		// Request-goroutine panic, kept only for the stopgap's shape; see Store.
+		panic("media feature cache lease count became negative")
+	}
+	if !l.entry.resident && l.entry.leases == 0 {
+		mlx.Unpin(l.entry.features)
+	}
+}
+
+func (c *MediaFeatureCache) evictLocked() {
+	for len(c.entries) > c.maxEntries || c.usedBytes > c.maxBytes {
+		c.removeLocked(c.lru.Back().Value.(*mediaFeatureEntry))
+	}
+}
+
+func (c *MediaFeatureCache) removeLocked(entry *mediaFeatureEntry) {
+	delete(c.entries, entry.key)
+	c.lru.Remove(entry.element)
+	c.usedBytes -= entry.size
+	entry.element = nil
+	entry.resident = false
+	if entry.leases == 0 {
+		mlx.Unpin(entry.features)
+	}
+}

--- a/x/mlxrunner/model/base/media_cache_test.go
+++ b/x/mlxrunner/model/base/media_cache_test.go
@@ -3,6 +3,7 @@ package base
 import (
 	"testing"
 
+	"github.com/ollama/ollama/x/internal/mlxtest"
 	"github.com/ollama/ollama/x/mlxrunner/mlx"
 )
 
@@ -29,6 +30,8 @@ func TestMediaFeatureKey(t *testing.T) {
 }
 
 func TestMediaFeatureCacheLeaseLifetime(t *testing.T) {
+	mlxtest.Setup(t)
+
 	cache := newMediaFeatureCache(1, 4)
 	features := mlx.FromValues([]float32{1}, 1, 1)
 	lease := cache.Store(NewMediaFeatureKey([]byte("a"), ""), features, 1)
@@ -48,6 +51,8 @@ func TestMediaFeatureCacheLeaseLifetime(t *testing.T) {
 }
 
 func TestMediaFeatureCacheLRU(t *testing.T) {
+	mlxtest.Setup(t)
+
 	cache := newMediaFeatureCache(2, 1<<20)
 	keys := []MediaFeatureKey{
 		NewMediaFeatureKey([]byte("a"), ""),
@@ -85,6 +90,8 @@ func TestMediaFeatureCacheLRU(t *testing.T) {
 }
 
 func TestMediaFeatureCacheByteLimit(t *testing.T) {
+	mlxtest.Setup(t)
+
 	cache := newMediaFeatureCache(4, 4)
 	first := mlx.FromValues([]float32{1}, 1, 1)
 	firstLease := cache.Store(NewMediaFeatureKey([]byte("a"), ""), first, 1)
@@ -107,6 +114,8 @@ func TestMediaFeatureCacheByteLimit(t *testing.T) {
 }
 
 func TestMediaFeatureCacheMultipleLeases(t *testing.T) {
+	mlxtest.Setup(t)
+
 	cache := newMediaFeatureCache(1, 4)
 	key := NewMediaFeatureKey([]byte("a"), "")
 	features := mlx.FromValues([]float32{1}, 1, 1)
@@ -131,6 +140,8 @@ func TestMediaFeatureCacheMultipleLeases(t *testing.T) {
 }
 
 func TestMediaFeatureCacheStoreExisting(t *testing.T) {
+	mlxtest.Setup(t)
+
 	cache := newMediaFeatureCache(1, 1<<20)
 	key := NewMediaFeatureKey([]byte("a"), "")
 	firstFeatures := mlx.FromValues([]float32{1}, 1, 1)

--- a/x/mlxrunner/model/base/media_cache_test.go
+++ b/x/mlxrunner/model/base/media_cache_test.go
@@ -1,0 +1,160 @@
+package base
+
+import (
+	"testing"
+
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+)
+
+func clearMediaFeatureCache(cache *MediaFeatureCache) {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+
+	for cache.lru.Len() > 0 {
+		cache.removeLocked(cache.lru.Back().Value.(*mediaFeatureEntry))
+	}
+}
+
+func TestMediaFeatureKey(t *testing.T) {
+	key := NewMediaFeatureKey([]byte("image"), "tokens=280")
+	if key != NewMediaFeatureKey([]byte("image"), "tokens=280") {
+		t.Fatal("same input produced different keys")
+	}
+	if key == NewMediaFeatureKey([]byte("different"), "tokens=280") {
+		t.Fatal("different media produced the same key")
+	}
+	if key == NewMediaFeatureKey([]byte("image"), "tokens=560") {
+		t.Fatal("different preprocessing variants produced the same key")
+	}
+}
+
+func TestMediaFeatureCacheLeaseLifetime(t *testing.T) {
+	cache := newMediaFeatureCache(1, 4)
+	features := mlx.FromValues([]float32{1}, 1, 1)
+	lease := cache.Store(NewMediaFeatureKey([]byte("a"), ""), features, 1)
+
+	clearMediaFeatureCache(cache)
+	mlx.Sweep()
+	if !features.Valid() {
+		t.Fatal("features were freed while leased")
+	}
+
+	lease.Release()
+	lease.Release()
+	mlx.Sweep()
+	if features.Valid() {
+		t.Fatal("evicted features remained valid after their lease was released")
+	}
+}
+
+func TestMediaFeatureCacheLRU(t *testing.T) {
+	cache := newMediaFeatureCache(2, 1<<20)
+	keys := []MediaFeatureKey{
+		NewMediaFeatureKey([]byte("a"), ""),
+		NewMediaFeatureKey([]byte("b"), ""),
+		NewMediaFeatureKey([]byte("c"), ""),
+	}
+
+	for i := range 2 {
+		lease := cache.Store(keys[i], mlx.FromValues([]float32{float32(i)}, 1, 1), 1)
+		lease.Release()
+	}
+	recent, ok := cache.Acquire(keys[0])
+	if !ok {
+		t.Fatal("failed to acquire resident entry")
+	}
+	recent.Release()
+
+	inserted := cache.Store(keys[2], mlx.FromValues([]float32{2}, 1, 1), 1)
+	inserted.Release()
+
+	if lease, ok := cache.Acquire(keys[1]); ok {
+		lease.Release()
+		t.Fatal("least recently used entry was not evicted")
+	}
+	for _, key := range []MediaFeatureKey{keys[0], keys[2]} {
+		lease, ok := cache.Acquire(key)
+		if !ok {
+			t.Fatal("recent entry was evicted")
+		}
+		lease.Release()
+	}
+
+	clearMediaFeatureCache(cache)
+	mlx.Sweep()
+}
+
+func TestMediaFeatureCacheByteLimit(t *testing.T) {
+	cache := newMediaFeatureCache(4, 4)
+	first := mlx.FromValues([]float32{1}, 1, 1)
+	firstLease := cache.Store(NewMediaFeatureKey([]byte("a"), ""), first, 1)
+	firstLease.Release()
+
+	second := mlx.FromValues([]float32{2}, 1, 1)
+	secondLease := cache.Store(NewMediaFeatureKey([]byte("b"), ""), second, 1)
+	secondLease.Release()
+	mlx.Sweep()
+
+	if first.Valid() {
+		t.Fatal("oldest features were not evicted at the byte limit")
+	}
+	if !second.Valid() {
+		t.Fatal("newest features were evicted")
+	}
+
+	clearMediaFeatureCache(cache)
+	mlx.Sweep()
+}
+
+func TestMediaFeatureCacheMultipleLeases(t *testing.T) {
+	cache := newMediaFeatureCache(1, 4)
+	key := NewMediaFeatureKey([]byte("a"), "")
+	features := mlx.FromValues([]float32{1}, 1, 1)
+	first := cache.Store(key, features, 1)
+	second, ok := cache.Acquire(key)
+	if !ok {
+		t.Fatal("failed to acquire second lease")
+	}
+
+	clearMediaFeatureCache(cache)
+	first.Release()
+	mlx.Sweep()
+	if !features.Valid() {
+		t.Fatal("features were freed before the final lease was released")
+	}
+
+	second.Release()
+	mlx.Sweep()
+	if features.Valid() {
+		t.Fatal("features remained valid after the final lease was released")
+	}
+}
+
+func TestMediaFeatureCacheStoreExisting(t *testing.T) {
+	cache := newMediaFeatureCache(1, 1<<20)
+	key := NewMediaFeatureKey([]byte("a"), "")
+	firstFeatures := mlx.FromValues([]float32{1}, 1, 1)
+	first := cache.Store(key, firstFeatures, 1)
+
+	secondFeatures := mlx.FromValues([]float32{2}, 1, 1)
+	second := cache.Store(key, secondFeatures, 1)
+	if second.Features() != firstFeatures {
+		t.Fatal("second store did not reuse resident features")
+	}
+
+	clearMediaFeatureCache(cache)
+	first.Release()
+	mlx.Sweep()
+	if !firstFeatures.Valid() {
+		t.Fatal("features were freed while another lease was active")
+	}
+
+	second.Release()
+	mlx.Sweep()
+	if firstFeatures.Valid() {
+		t.Fatal("resident features remained valid after the final lease was released")
+	}
+	if secondFeatures.Valid() {
+		t.Fatal("unused duplicate features remained valid")
+	}
+}

--- a/x/mlxrunner/model/base/multimodal.go
+++ b/x/mlxrunner/model/base/multimodal.go
@@ -1,0 +1,34 @@
+package base
+
+import (
+	"github.com/ollama/ollama/x/mlxrunner/batch"
+	"github.com/ollama/ollama/x/mlxrunner/cache"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+)
+
+// MediaInput is one media attachment referenced by a tagged prompt.
+type MediaInput struct {
+	ID   int
+	Kind string
+	Data []byte
+}
+
+// PreparedMultimodalPrompt owns request-scoped model inputs used during
+// multimodal prefill. Decode continues through Model.Forward after prefill.
+type PreparedMultimodalPrompt interface {
+	Tokens() []int32
+	Forward(b *batch.Batch, caches []cache.Cache) *mlx.Array
+	Close()
+}
+
+// MultimodalModel is optionally implemented by models that prepare media and
+// inject its embeddings during prompt prefill.
+//
+// headroomBytes is how much memory the runner has left over beyond the resident
+// model. The runner owns the budget; the model owns the cost curve, so it is
+// the model's job to turn a byte count into a fidelity choice. Zero means the
+// runner could not determine a budget and the model should use its cheapest
+// setting rather than fail.
+type MultimodalModel interface {
+	PrepareMultimodalPrompt(prompt string, media []MediaInput, headroomBytes int) (PreparedMultimodalPrompt, error)
+}

--- a/x/mlxrunner/multimodal.go
+++ b/x/mlxrunner/multimodal.go
@@ -1,0 +1,147 @@
+package mlxrunner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sync"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/x/mlxrunner/batch"
+	"github.com/ollama/ollama/x/mlxrunner/cache"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/mlxrunner/model/base"
+)
+
+// mediaHeadroom reports how many bytes are left of the device's recommended
+// working set once the model is resident, for models to size media work
+// against. It is sampled once rather than per request because both inputs are
+// fixed for the life of the runner: the recommended working set is a device
+// property, and residency does not change after the model loads. Sampling it
+// per request would also make the answer drift with unrelated allocator
+// activity, which matters because a model may fold the budget into a cache key.
+//
+// This lives here rather than beside the runner's other memory setup because
+// the multimodal path is temporary; it should move once media inputs join the
+// normal request lifecycle.
+//
+// Returns 0 when the device cannot report a working set, which models read as
+// a request for their cheapest setting rather than as an error.
+var mediaHeadroom = sync.OnceValue(func() int {
+	if !mlx.GPUIsAvailable() {
+		slog.Warn("MLX GPU unavailable; media inputs will use their most conservative memory budget")
+		return 0
+	}
+
+	recommended, err := mlx.MaxRecommendedWorkingSetSize()
+	if err != nil {
+		slog.Warn("Unable to query the MLX recommended working set; media inputs will use their most conservative memory budget", "error", err)
+		return 0
+	}
+
+	active := mlx.ActiveMemory()
+	headroom := max(0, recommended-active)
+	slog.Info("media memory budget",
+		"headroom", mlx.PrettyBytes(headroom),
+		"active", mlx.PrettyBytes(active),
+		"recommended", mlx.PrettyBytes(recommended))
+	return headroom
+})
+
+// multimodalRequestModel uses the prepared media inputs while processing the
+// prompt, then delegates ordinary generation to the loaded model.
+type multimodalRequestModel struct {
+	base.Model
+	prompt     base.PreparedMultimodalPrompt
+	prefillEnd int
+}
+
+func (m *multimodalRequestModel) Forward(b *batch.Batch, caches []cache.Cache) *mlx.Array {
+	if len(b.SeqOffsets) == 1 && int(b.SeqOffsets[0]) < m.prefillEnd {
+		return m.prompt.Forward(b, caches)
+	}
+	return m.Model.Forward(b, caches)
+}
+
+// MultimodalPipeline prepares request-local media state and delegates the
+// generation lifecycle to TextGenerationPipeline.
+func (r *Runner) MultimodalPipeline(ctx context.Context, request Request) error {
+	prompt, err := r.prepareMultimodal(&request)
+	if err != nil {
+		return err
+	}
+	if prompt == nil {
+		return errors.New("multimodal request contains no media")
+	}
+	defer prompt.Close()
+
+	requestRunner := *r
+	requestRunner.Model = &multimodalRequestModel{
+		Model:      r.Model,
+		prompt:     prompt,
+		prefillEnd: len(request.Tokens) - 1,
+	}
+	requestRunner.cache = newPrefixCache(r.Model)
+	requestRunner.spec = nil
+	requestRunner.disablePrefillSnapshots = true
+	defer requestRunner.cache.freeAll()
+
+	return requestRunner.TextGenerationPipeline(ctx, request)
+}
+
+func (r *Runner) prepareMultimodal(request *Request) (base.PreparedMultimodalPrompt, error) {
+	if len(request.Media) == 0 {
+		return nil, nil
+	}
+
+	model, ok := r.Model.(base.MultimodalModel)
+	if !ok {
+		return nil, errors.New("model does not support multimodal input")
+	}
+
+	media := make([]base.MediaInput, len(request.Media))
+	for i := range request.Media {
+		media[i] = base.MediaInput{
+			ID:   request.Media[i].ID,
+			Kind: string(request.Media[i].Kind),
+			Data: request.Media[i].Data,
+		}
+	}
+
+	prompt, err := model.PrepareMultimodalPrompt(request.Prompt, media, mediaHeadroom())
+	if err != nil {
+		return nil, api.StatusError{StatusCode: http.StatusBadRequest, ErrorMessage: err.Error()}
+	}
+	if prompt == nil {
+		return nil, errors.New("model returned an empty multimodal prompt")
+	}
+
+	inputs := prompt.Tokens()
+	if len(inputs) == 0 {
+		prompt.Close()
+		return nil, api.StatusError{StatusCode: http.StatusBadRequest, ErrorMessage: "empty prompt"}
+	}
+	if len(inputs) >= r.contextLength {
+		prompt.Close()
+		return nil, api.StatusError{
+			StatusCode: http.StatusBadRequest,
+			ErrorMessage: fmt.Sprintf(
+				"input length (%d tokens) exceeds the model's maximum context length (%d tokens)",
+				len(inputs),
+				r.contextLength,
+			),
+		}
+	}
+
+	maxGenerate := r.contextLength - len(inputs)
+	if request.Options.NumPredict <= 0 {
+		request.Options.NumPredict = maxGenerate
+	} else {
+		request.Options.NumPredict = min(request.Options.NumPredict, maxGenerate)
+	}
+	request.Tokens = inputs
+
+	return prompt, nil
+}

--- a/x/mlxrunner/pipeline.go
+++ b/x/mlxrunner/pipeline.go
@@ -121,6 +121,9 @@ func (r *Runner) prefill(ctx context.Context, session *cacheSession, spec *specu
 	if end := len(inputs) - preThinking; end > 0 {
 		snapshotOffsets = append(snapshotOffsets, end)
 	}
+	if r.disablePrefillSnapshots {
+		snapshotOffsets = nil
+	}
 
 	materializeCaches := func() {
 		state := make([]*mlx.Array, 0, 2*len(caches))

--- a/x/mlxrunner/runner.go
+++ b/x/mlxrunner/runner.go
@@ -41,6 +41,9 @@ type Runner struct {
 	cache         *prefixCache
 	contextLength int
 	mlxThread     *mlxthread.Thread
+	// disablePrefillSnapshots is set only on request-scoped runners whose
+	// cache is discarded when the request completes.
+	disablePrefillSnapshots bool
 	// spec is the speculative-decoding subsystem. Nil when the model ships no
 	// draft head.
 	spec *speculation

--- a/x/mlxrunner/server.go
+++ b/x/mlxrunner/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ollama/ollama/logutil"
 	"github.com/ollama/ollama/x/internal/mlxthread"
 	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/mlxrunner/model/base"
 	"github.com/ollama/ollama/x/mlxrunner/sample"
 )
 
@@ -127,6 +128,13 @@ func Execute(args []string) error {
 		}
 
 		request.Pipeline = runner.TextGenerationPipeline
+		if len(request.Media) > 0 {
+			if _, ok := runner.Model.(base.MultimodalModel); !ok {
+				http.Error(w, "model does not support multimodal input", http.StatusBadRequest)
+				return
+			}
+			request.Pipeline = runner.MultimodalPipeline
+		}
 		request.SamplerOpts = sample.Options{
 			Temperature:      request.Options.Temperature,
 			TopP:             request.Options.TopP,
@@ -142,9 +150,11 @@ func Execute(args []string) error {
 			TopLogprobs:      request.TopLogprobs,
 		}
 
-		if err := runner.Prepare(&request); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
+		if len(request.Media) == 0 {
+			if err := runner.Prepare(&request); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
 		}
 
 		var cancel context.CancelFunc

--- a/x/models/gemma4/gemma4.go
+++ b/x/models/gemma4/gemma4.go
@@ -29,7 +29,34 @@ func init() {
 }
 
 // Compile-time interface checks.
-var _ base.Model = (*Model)(nil)
+var (
+	_ base.Model           = (*Model)(nil)
+	_ base.MultimodalModel = (*Model)(nil)
+)
+
+// bidirectionalAttention is the config's use_bidirectional_attention value.
+// The Gemma family spells this key both as a mode string ("vision") and as a
+// plain bool, so decoding accepts either form; only the string form names a
+// mode, and a bool decodes to "" (false) or "true".
+type bidirectionalAttention string
+
+func (a *bidirectionalAttention) UnmarshalJSON(data []byte) error {
+	var mode string
+	if err := json.Unmarshal(data, &mode); err == nil {
+		*a = bidirectionalAttention(mode)
+		return nil
+	}
+
+	var enabled bool
+	if err := json.Unmarshal(data, &enabled); err != nil {
+		return fmt.Errorf("use_bidirectional_attention: want a string or bool, got %s", data)
+	}
+	*a = ""
+	if enabled {
+		*a = "true"
+	}
+	return nil
+}
 
 // RopeParams holds per-layer-type RoPE settings.
 type RopeParams struct {
@@ -67,6 +94,11 @@ type TextConfig struct {
 	ExpertIntermediateSize int32                  `json:"moe_intermediate_size"`
 	RopeParameters         map[string]*RopeParams `json:"rope_parameters"`
 	ImageTokenIDValue      int32                  `json:"image_token_id"`
+	// UseBidirectionalAttn is "vision" when image tokens attend to each other
+	// bidirectionally on sliding layers. Gemma configs spell this key as either
+	// a string or a bool, so it decodes leniently rather than failing the whole
+	// config parse on an unexpected JSON type.
+	UseBidirectionalAttn bidirectionalAttention `json:"use_bidirectional_attention"`
 
 	// Quantization parameters.
 	QuantGroupSize int                               `json:"-"`
@@ -380,6 +412,10 @@ type Model struct {
 	Norm        *nn.RMSNorm
 	LMHead      nn.LinearLayer
 
+	VisionEncoder   *VisionEncoder
+	MultimodalEmbed *MultimodalEmbedder
+	VisionConfig    *VisionConfig
+
 	// PLE model-level components (nil if no PLE).
 	EmbedTokensPerLayer nn.EmbeddingLayer
 	PerLayerModelProj   nn.LinearLayer
@@ -394,6 +430,11 @@ type Model struct {
 
 	SuppressLogitBias *mlx.Array
 	weightPrefix      string
+
+	imageStartTokenID int32
+	imageTokenID      int32
+	imageEndTokenID   int32
+	mediaFeatures     *base.MediaFeatureCache
 }
 
 func parseTextConfig(configData []byte) (TextConfig, error) {
@@ -646,11 +687,31 @@ func newModel(root *model.Root) (base.Model, error) {
 		return nil, fmt.Errorf("parse tokenizer: %w", err)
 	}
 
+	visionConfig, err := parseVisionConfig(configData)
+	if err != nil {
+		return nil, err
+	}
+
 	m := &Model{
 		Layers:            make([]*DecoderLayer, cfg.NumHiddenLayers),
 		TextConfig:        &cfg,
 		tok:               tok,
 		SuppressLogitBias: makeSuppressLogitBias(suppressTokens, cfg.VocabSize),
+		VisionConfig:      visionConfig,
+	}
+	if visionConfig != nil {
+		m.VisionEncoder = &VisionEncoder{Cfg: visionConfig}
+		m.mediaFeatures = base.NewMediaFeatureCache()
+		var ok bool
+		if m.imageStartTokenID, ok = tok.GetSpecialToken("<|image>"); !ok {
+			return nil, fmt.Errorf("tokenizer is missing <|image>")
+		}
+		if m.imageTokenID, ok = tok.GetSpecialToken("<|image|>"); !ok {
+			return nil, fmt.Errorf("tokenizer is missing <|image|>")
+		}
+		if m.imageEndTokenID, ok = tok.GetSpecialToken("<image|>"); !ok {
+			return nil, fmt.Errorf("tokenizer is missing <image|>")
+		}
 	}
 
 	for i := range m.Layers {
@@ -981,20 +1042,40 @@ func (m *Model) LoadWeights(tensors map[string]*mlx.Array) error {
 		return fmt.Errorf("missing precomputed final norm weight")
 	}
 
+	if m.VisionEncoder != nil {
+		if err := m.loadVisionWeights(tensors, linears); err != nil {
+			return err
+		}
+		precomputeVisionScaledWeights(m.VisionEncoder)
+	}
+
 	return nil
 }
 
 func (m *Model) Forward(b *batch.Batch, caches []cache.Cache) *mlx.Array {
+	h := m.embed(b.InputIDs)
+	return m.forwardEmbeddings(h, b, caches, b.InputIDs, nn.CausalMask())
+}
+
+func (m *Model) embed(inputIDs *mlx.Array) *mlx.Array {
+	return mlx.MulScalar(m.EmbedTokens.Forward(inputIDs), m.EmbedScale)
+}
+
+func (m *Model) forwardEmbeddings(
+	h *mlx.Array,
+	b *batch.Batch,
+	caches []cache.Cache,
+	pleTokens *mlx.Array,
+	attentionMask nn.AttentionMask,
+) *mlx.Array {
 	dims := b.InputIDs.Dims()
 	B, L := int32(dims[0]), int32(dims[1])
 	positions := mlx.FromValues(b.SeqOffsets, len(b.SeqOffsets))
-	h := m.EmbedTokens.Forward(b.InputIDs)
-	h = mlx.MulScalar(h, m.EmbedScale)
 
 	// Compute PLE inputs if configured.
 	var perLayerInputs *mlx.Array
-	if m.HiddenSizePerLayer > 0 && m.EmbedTokensPerLayer != nil {
-		perLayerInputs = m.computePLEInputs(b.InputIDs, h)
+	if m.HiddenSizePerLayer > 0 && m.EmbedTokensPerLayer != nil && pleTokens != nil {
+		perLayerInputs = m.computePLEInputs(pleTokens, h)
 	}
 
 	// KV sharing: each donor layer stores its KVHistory here so later
@@ -1025,7 +1106,14 @@ func (m *Model) Forward(b *batch.Batch, caches []cache.Cache) *mlx.Array {
 		}
 
 		var donorKV *sharedHistory
-		h, donorKV = layer.Forward(h, b, c, positions, B, L, m.TextConfig, pleInput, donor)
+		// Gemma 4 relaxes causality for image tokens on sliding layers only;
+		// full-attention layers stay strictly causal. Deliberate, and matched
+		// against the reference implementation - see UseBidirectionalAttn.
+		layerMask := nn.CausalMask()
+		if layer.IsSliding {
+			layerMask = attentionMask
+		}
+		h, donorKV = layer.Forward(h, b, c, positions, B, L, m.TextConfig, pleInput, donor, layerMask)
 
 		// If this layer is a donor, store its cached KV for later shared layers.
 		if layer.IsDonor && donorKV != nil {
@@ -1094,7 +1182,7 @@ func (m *Model) Tokenizer() *tokenizer.Tokenizer {
 
 // TokenEmbeddings returns the target model's scaled token embeddings for MTP.
 func (m *Model) TokenEmbeddings(inputIDs *mlx.Array) *mlx.Array {
-	return mlx.MulScalar(m.EmbedTokens.Forward(inputIDs), m.EmbedScale)
+	return m.embed(inputIDs)
 }
 
 // NewCaches creates cache objects for layers that own KV state.
@@ -1158,9 +1246,19 @@ func sliceLayerDim(combined *mlx.Array, layerIdx, B, L, pleDim int32) *mlx.Array
 	return mlx.Squeeze(sliced, 2)
 }
 
-func (l *DecoderLayer) Forward(x *mlx.Array, b *batch.Batch, c cache.Cache, positions *mlx.Array, B, L int32, cfg *TextConfig, pleInput *mlx.Array, donor *sharedHistory) (*mlx.Array, *sharedHistory) {
+func (l *DecoderLayer) Forward(
+	x *mlx.Array,
+	b *batch.Batch,
+	c cache.Cache,
+	positions *mlx.Array,
+	B, L int32,
+	cfg *TextConfig,
+	pleInput *mlx.Array,
+	donor *sharedHistory,
+	attentionMask nn.AttentionMask,
+) (*mlx.Array, *sharedHistory) {
 	normed := mlx.RMSNormFn(x, l.InputNormScaled, cfg.RMSNormEps)
-	attnOut, kv := l.Attention.Forward(normed, b, c, positions, B, L, l.IsSliding, cfg, donor)
+	attnOut, kv := l.Attention.Forward(normed, b, c, positions, B, L, l.IsSliding, cfg, donor, attentionMask)
 	attnOut = mlx.RMSNormFn(attnOut, l.PostAttnNormScaled, cfg.RMSNormEps)
 	h := mlx.Add(x, attnOut)
 
@@ -1208,7 +1306,17 @@ func (l *DecoderLayer) Forward(x *mlx.Array, b *batch.Batch, c cache.Cache, posi
 	return h, kv
 }
 
-func (a *Attention) Forward(x *mlx.Array, b *batch.Batch, c cache.Cache, positions *mlx.Array, B, L int32, isSliding bool, cfg *TextConfig, donor *sharedHistory) (*mlx.Array, *sharedHistory) {
+func (a *Attention) Forward(
+	x *mlx.Array,
+	b *batch.Batch,
+	c cache.Cache,
+	positions *mlx.Array,
+	B, L int32,
+	isSliding bool,
+	cfg *TextConfig,
+	donor *sharedHistory,
+	attentionMask nn.AttentionMask,
+) (*mlx.Array, *sharedHistory) {
 	// Determine head dim and scale based on layer type.
 	headDim := cfg.HeadDim
 	scale := cfg.SlidingScale
@@ -1284,7 +1392,7 @@ func (a *Attention) Forward(x *mlx.Array, b *batch.Batch, c cache.Cache, positio
 		// kernel only handles L < 4 (generation). For prefill, we fall back
 		// to explicit matmul+softmax+matmul on CUDA.
 		var k, v *mlx.Array
-		mask := nn.CausalMask().Intersect(nn.QPaddingMask(b, q.DType()))
+		mask := attentionMask.Intersect(nn.QPaddingMask(b, q.DType()))
 		if kv.history != nil {
 			k, v = kv.history.K(), kv.history.V()
 			mask = kv.history.Mask(mask)
@@ -1314,7 +1422,7 @@ func (a *Attention) Forward(x *mlx.Array, b *batch.Batch, c cache.Cache, positio
 		out = mlx.Reshape(out, B, cfg.NumAttentionHeads, L, headDim)
 	} else {
 		var opt nn.SDPAOption
-		mask := nn.CausalMask()
+		mask := attentionMask
 		if kv.history != nil {
 			opt = nn.WithKVHistory(kv.history)
 		} else {

--- a/x/models/gemma4/gemma4_test.go
+++ b/x/models/gemma4/gemma4_test.go
@@ -24,6 +24,38 @@ func TestParseSuppressTokens(t *testing.T) {
 	}
 }
 
+// TestParseTextConfigBidirectionalAttention covers both spellings the Gemma
+// family uses for use_bidirectional_attention. A plain json.Unmarshal into a
+// string field fails the whole config parse on the bool spelling, which would
+// stop the model loading at all rather than just disabling the vision mask.
+func TestParseTextConfigBidirectionalAttention(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		raw  string
+		want bidirectionalAttention
+	}{
+		{name: "absent", raw: `{}`, want: ""},
+		{name: "vision mode string", raw: `{"use_bidirectional_attention": "vision"}`, want: "vision"},
+		{name: "bool true", raw: `{"use_bidirectional_attention": true}`, want: "true"},
+		{name: "bool false", raw: `{"use_bidirectional_attention": false}`, want: ""},
+		{name: "nested text config", raw: `{"text_config": {"use_bidirectional_attention": "vision"}}`, want: "vision"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := parseTextConfig([]byte(tt.raw))
+			if err != nil {
+				t.Fatalf("parseTextConfig() error = %v", err)
+			}
+			if cfg.UseBidirectionalAttn != tt.want {
+				t.Fatalf("UseBidirectionalAttn = %q, want %q", cfg.UseBidirectionalAttn, tt.want)
+			}
+		})
+	}
+
+	if _, err := parseTextConfig([]byte(`{"use_bidirectional_attention": 3}`)); err == nil {
+		t.Fatal("parseTextConfig() with a numeric value = nil error, want an error naming the field")
+	}
+}
+
 func TestParseTextConfigE2B(t *testing.T) {
 	skipIfNoMLX(t)
 	data := []byte(`{

--- a/x/models/gemma4/gemma4_vision.go
+++ b/x/models/gemma4/gemma4_vision.go
@@ -1,0 +1,799 @@
+// Vision encoder for Gemma 4 multimodal models.
+package gemma4
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/mlxrunner/model"
+	"github.com/ollama/ollama/x/models/nn"
+)
+
+// VisionConfig holds configuration for the vision encoder.
+type VisionConfig struct {
+	ModelType             string          `json:"model_type"`
+	HiddenSize            int32           `json:"hidden_size"`             // 768
+	IntermediateSize      int32           `json:"intermediate_size"`       // 3072
+	NumHiddenLayers       int32           `json:"num_hidden_layers"`       // 16
+	NumAttentionHeads     int32           `json:"num_attention_heads"`     // 12
+	NumKeyValueHeads      int32           `json:"num_key_value_heads"`     // 12
+	HeadDim               int32           `json:"head_dim"`                // 64
+	PatchSize             int32           `json:"patch_size"`              // 16
+	PositionEmbeddingSize int32           `json:"position_embedding_size"` // 10240
+	ImageSeqLength        int32           `json:"image_seq_length"`        // 280
+	DefaultOutputLength   int32           `json:"default_output_length"`
+	PoolingKernelSize     int32           `json:"pooling_kernel_size"` // 3
+	RMSNormEps            float32         `json:"rms_norm_eps"`        // 1e-6
+	Standardize           bool            `json:"standardize"`
+	RopeParameters        json.RawMessage `json:"rope_parameters"`
+	LayerTypes            []string        `json:"layer_types"`
+
+	// Unified vision uses a transformer-less patch embedder with different
+	// names for the equivalent dimensions.
+	MMEmbeddingDim          int32 `json:"mm_embed_dim"`
+	MMPositionEmbeddingSize int32 `json:"mm_posemb_size"`
+	ModelPatchSize          int32 `json:"model_patch_size"`
+	NumSoftTokens           int32 `json:"num_soft_tokens"`
+
+	// Computed fields.
+	RopeTheta float32 `json:"-"` // from rope_parameters
+	Scale     float32 `json:"-"` // 1/sqrt(head_dim)
+}
+
+// ClipBounds holds input/output clamp bounds for a clippable linear layer.
+type ClipBounds struct {
+	InputMin  *mlx.Array
+	InputMax  *mlx.Array
+	OutputMin *mlx.Array
+	OutputMax *mlx.Array
+}
+
+// ClippableLinear wraps a linear layer with optional input/output clamping.
+type ClippableLinear struct {
+	Linear nn.LinearLayer
+	Clip   *ClipBounds
+}
+
+func (cl *ClippableLinear) Forward(x *mlx.Array) *mlx.Array {
+	if cl.Clip != nil && cl.Clip.InputMin != nil && cl.Clip.InputMax != nil {
+		x = mlx.Clip(x, cl.Clip.InputMin, cl.Clip.InputMax)
+	}
+	x = cl.Linear.Forward(x)
+	if cl.Clip != nil && cl.Clip.OutputMin != nil && cl.Clip.OutputMax != nil {
+		x = mlx.Clip(x, cl.Clip.OutputMin, cl.Clip.OutputMax)
+	}
+	return x
+}
+
+// VisionAttention implements multi-head attention for the vision encoder.
+type VisionAttention struct {
+	QProj *ClippableLinear
+	KProj *ClippableLinear
+	VProj *ClippableLinear
+	OProj *ClippableLinear
+
+	QNorm *nn.RMSNorm
+	KNorm *nn.RMSNorm
+
+	// Norm weight for Q/K RMSNorm.
+	QNormScaled *mlx.Array
+	KNormScaled *mlx.Array
+}
+
+// VisionMLP is the feed-forward network for vision layers.
+type VisionMLP struct {
+	GateProj *ClippableLinear
+	UpProj   *ClippableLinear
+	DownProj *ClippableLinear
+}
+
+// VisionDecoderLayer is a single vision transformer block.
+type VisionDecoderLayer struct {
+	InputNorm    *nn.RMSNorm
+	Attention    *VisionAttention
+	PostAttnNorm *nn.RMSNorm
+	PreFFNorm    *nn.RMSNorm
+	MLP          *VisionMLP
+	PostFFNorm   *nn.RMSNorm
+
+	// Layer scalar (vision layers have this too).
+	LayerScalar *mlx.Array
+
+	// Norm weight for RMSNorm.
+	InputNormScaled    *mlx.Array
+	PostAttnNormScaled *mlx.Array
+	PreFFNormScaled    *mlx.Array
+	PostFFNormScaled   *mlx.Array
+}
+
+// VisionPatchEmbedder converts images to patch embeddings with 2D position info.
+type VisionPatchEmbedder struct {
+	InputProj              nn.LinearLayer // Linear(3*patch_size^2, hidden_size)
+	PositionEmbeddingTable *mlx.Array     // [2, position_embedding_size, hidden_size]
+}
+
+// UnifiedVisionPatchEmbedder implements Gemma4's transformer-less vision path.
+type UnifiedVisionPatchEmbedder struct {
+	PatchNorm1        *nn.LayerNorm
+	PatchDense        nn.LinearLayer
+	PatchNorm2        *nn.LayerNorm
+	PositionEmbedding *mlx.Array
+	PositionNorm      *nn.LayerNorm
+}
+
+// VisionEncoder orchestrates the full vision encoding pipeline.
+type VisionEncoder struct {
+	PatchEmbedder        *VisionPatchEmbedder
+	UnifiedPatchEmbedder *UnifiedVisionPatchEmbedder
+	Layers               []*VisionDecoderLayer
+	Cfg                  *VisionConfig
+	StdBias              *mlx.Array
+	StdScale             *mlx.Array
+}
+
+// MultimodalEmbedder projects vision tokens into language model space.
+type MultimodalEmbedder struct {
+	EmbeddingProjection nn.LinearLayer // Linear(multimodal_hidden, text_hidden)
+	Eps                 float32        // RMSNorm epsilon
+}
+
+// Forward normalizes and projects multimodal embeddings.
+func (me *MultimodalEmbedder) Forward(x *mlx.Array) *mlx.Array {
+	x = mlx.RMSNormFn(x, nil, me.Eps)
+	return me.EmbeddingProjection.Forward(x)
+}
+
+// makeClippableLinear creates a ClippableLinear from a linear layer and optional clip bounds.
+// ClippableLinear wraps nn.Linear as self.linear, so the weight path is
+// prefix.linear.weight (e.g., self_attn.q_proj.linear.weight).
+func makeClippableLinear(linears model.LinearFactory, tensors map[string]*mlx.Array, prefix string) *ClippableLinear {
+	linear := linears.Make(prefix + ".linear")
+	if linear == nil {
+		return nil
+	}
+	cl := &ClippableLinear{Linear: linear}
+
+	// Load clip bounds if present.
+	inputMin := tensors[prefix+".input_min"]
+	inputMax := tensors[prefix+".input_max"]
+	outputMin := tensors[prefix+".output_min"]
+	outputMax := tensors[prefix+".output_max"]
+
+	if inputMin != nil || outputMin != nil {
+		cl.Clip = &ClipBounds{
+			InputMin:  inputMin,
+			InputMax:  inputMax,
+			OutputMin: outputMin,
+			OutputMax: outputMax,
+		}
+	}
+	return cl
+}
+
+func parseVisionConfig(configData []byte) (*VisionConfig, error) {
+	var wrapper struct {
+		VisionConfig *VisionConfig `json:"vision_config"`
+	}
+	if err := json.Unmarshal(configData, &wrapper); err != nil {
+		return nil, fmt.Errorf("parse vision config: %w", err)
+	}
+	if wrapper.VisionConfig == nil {
+		return nil, nil // No vision config means a text-only model.
+	}
+
+	cfg := wrapper.VisionConfig
+	switch cfg.ModelType {
+	case "", "gemma4_vision":
+	case "gemma4_unified_vision":
+		if cfg.ModelPatchSize == 0 {
+			cfg.ModelPatchSize = cfg.PatchSize * cfg.PoolingKernelSize
+		}
+		cfg.PatchSize = cfg.ModelPatchSize
+		cfg.PoolingKernelSize = 1
+		cfg.HiddenSize = cfg.MMEmbeddingDim
+		cfg.PositionEmbeddingSize = cfg.MMPositionEmbeddingSize
+		cfg.ImageSeqLength = cfg.NumSoftTokens
+	default:
+		// The manifest advertises vision whenever a vision_config is present
+		// (x/create/client/create.go), so degrading to text-only here would
+		// leave the capability claiming a tower we cannot run.
+		return nil, fmt.Errorf("unsupported vision tower %q", cfg.ModelType)
+	}
+
+	// Defaults.
+	if cfg.HeadDim == 0 {
+		cfg.HeadDim = 64
+	}
+	if cfg.NumKeyValueHeads == 0 {
+		cfg.NumKeyValueHeads = cfg.NumAttentionHeads
+	}
+	if cfg.PatchSize == 0 {
+		cfg.PatchSize = 16
+	}
+	if cfg.PoolingKernelSize == 0 {
+		cfg.PoolingKernelSize = 3
+	}
+	if cfg.ImageSeqLength == 0 {
+		cfg.ImageSeqLength = cfg.DefaultOutputLength
+		if cfg.ImageSeqLength == 0 {
+			cfg.ImageSeqLength = 280
+		}
+	}
+	if cfg.PositionEmbeddingSize == 0 {
+		cfg.PositionEmbeddingSize = 10240
+	}
+	if cfg.RMSNormEps == 0 {
+		cfg.RMSNormEps = 1e-6
+	}
+
+	cfg.Scale = 1.0 // Gemma 4 vision uses scale=1.0 (Q/K norms handle magnitude)
+
+	// Extract RoPE theta from rope_parameters: {"rope_theta": 100.0, "rope_type": "default"}
+	cfg.RopeTheta = 100.0
+	if len(cfg.RopeParameters) > 0 {
+		var rp struct {
+			RopeTheta float32 `json:"rope_theta"`
+		}
+		if json.Unmarshal(cfg.RopeParameters, &rp) == nil && rp.RopeTheta > 0 {
+			cfg.RopeTheta = rp.RopeTheta
+		}
+	}
+
+	return cfg, nil
+}
+
+// loadVisionWeights loads vision encoder and multimodal embedder weights.
+func (m *Model) loadVisionWeights(tensors map[string]*mlx.Array, linears model.LinearFactory) error {
+	if m.VisionConfig.ModelType == "gemma4_unified_vision" {
+		return m.loadUnifiedVisionWeights(tensors, linears)
+	}
+
+	prefix := "model."
+
+	// Resolve prefix: try "model.vision_tower." first, then "vision_tower.".
+	visionPrefix := prefix + "vision_tower."
+	if tensors[visionPrefix+"patch_embedder.input_proj.weight"] == nil {
+		visionPrefix = "vision_tower."
+		if tensors[visionPrefix+"patch_embedder.input_proj.weight"] == nil {
+			return fmt.Errorf("missing vision tower weights")
+		}
+	}
+
+	// Patch embedder.
+	m.VisionEncoder.PatchEmbedder = &VisionPatchEmbedder{}
+	m.VisionEncoder.PatchEmbedder.InputProj = linears.Make(visionPrefix + "patch_embedder.input_proj")
+	if m.VisionEncoder.PatchEmbedder.InputProj == nil {
+		return fmt.Errorf("missing vision patch embedder input_proj")
+	}
+	m.VisionEncoder.PatchEmbedder.PositionEmbeddingTable = tensors[visionPrefix+"patch_embedder.position_embedding_table"]
+	if m.VisionEncoder.PatchEmbedder.PositionEmbeddingTable == nil {
+		return fmt.Errorf("missing vision patch embedder position_embedding_table")
+	}
+
+	// Vision transformer layers.
+	vcfg := m.VisionConfig
+	m.VisionEncoder.Layers = make([]*VisionDecoderLayer, vcfg.NumHiddenLayers)
+	for i := range vcfg.NumHiddenLayers {
+		layerPrefix := fmt.Sprintf("%sencoder.layers.%d", visionPrefix, i)
+
+		layer := &VisionDecoderLayer{
+			Attention: &VisionAttention{},
+			MLP:       &VisionMLP{},
+		}
+
+		// Norms.
+		if w := tensors[layerPrefix+".input_layernorm.weight"]; w != nil {
+			layer.InputNorm = nn.NewRMSNorm(w, vcfg.RMSNormEps)
+		}
+		if w := tensors[layerPrefix+".post_attention_layernorm.weight"]; w != nil {
+			layer.PostAttnNorm = nn.NewRMSNorm(w, vcfg.RMSNormEps)
+		}
+		if w := tensors[layerPrefix+".pre_feedforward_layernorm.weight"]; w != nil {
+			layer.PreFFNorm = nn.NewRMSNorm(w, vcfg.RMSNormEps)
+		}
+		if w := tensors[layerPrefix+".post_feedforward_layernorm.weight"]; w != nil {
+			layer.PostFFNorm = nn.NewRMSNorm(w, vcfg.RMSNormEps)
+		}
+
+		// Attention projections (with clip bounds).
+		layer.Attention.QProj = makeClippableLinear(linears, tensors, layerPrefix+".self_attn.q_proj")
+		layer.Attention.KProj = makeClippableLinear(linears, tensors, layerPrefix+".self_attn.k_proj")
+		layer.Attention.VProj = makeClippableLinear(linears, tensors, layerPrefix+".self_attn.v_proj")
+		layer.Attention.OProj = makeClippableLinear(linears, tensors, layerPrefix+".self_attn.o_proj")
+
+		if w := tensors[layerPrefix+".self_attn.q_norm.weight"]; w != nil {
+			layer.Attention.QNorm = nn.NewRMSNorm(w, vcfg.RMSNormEps)
+		}
+		if w := tensors[layerPrefix+".self_attn.k_norm.weight"]; w != nil {
+			layer.Attention.KNorm = nn.NewRMSNorm(w, vcfg.RMSNormEps)
+		}
+
+		// MLP (with clip bounds).
+		layer.MLP.GateProj = makeClippableLinear(linears, tensors, layerPrefix+".mlp.gate_proj")
+		layer.MLP.UpProj = makeClippableLinear(linears, tensors, layerPrefix+".mlp.up_proj")
+		layer.MLP.DownProj = makeClippableLinear(linears, tensors, layerPrefix+".mlp.down_proj")
+
+		// Layer scalar.
+		if w := tensors[layerPrefix+".layer_scalar"]; w != nil {
+			layer.LayerScalar = w
+		}
+
+		// Validation.
+		if layer.InputNorm == nil || layer.PostAttnNorm == nil ||
+			layer.PreFFNorm == nil || layer.PostFFNorm == nil {
+			return fmt.Errorf("vision layer %d: missing norm weights", i)
+		}
+		if layer.Attention.QProj == nil || layer.Attention.KProj == nil ||
+			layer.Attention.VProj == nil || layer.Attention.OProj == nil {
+			return fmt.Errorf("vision layer %d: missing attention projections", i)
+		}
+		if layer.Attention.QNorm == nil || layer.Attention.KNorm == nil {
+			return fmt.Errorf("vision layer %d: missing attention q/k norms", i)
+		}
+		if layer.MLP.GateProj == nil || layer.MLP.UpProj == nil || layer.MLP.DownProj == nil {
+			return fmt.Errorf("vision layer %d: missing mlp projections", i)
+		}
+		if layer.Attention.QProj.Linear == nil || layer.Attention.KProj.Linear == nil ||
+			layer.Attention.VProj.Linear == nil || layer.Attention.OProj.Linear == nil {
+			return fmt.Errorf("vision layer %d: missing attention linear weights", i)
+		}
+		if layer.MLP.GateProj.Linear == nil || layer.MLP.UpProj.Linear == nil || layer.MLP.DownProj.Linear == nil {
+			return fmt.Errorf("vision layer %d: missing mlp linear weights", i)
+		}
+
+		m.VisionEncoder.Layers[i] = layer
+	}
+	if vcfg.Standardize {
+		m.VisionEncoder.StdBias = tensors[visionPrefix+"std_bias"]
+		m.VisionEncoder.StdScale = tensors[visionPrefix+"std_scale"]
+		if m.VisionEncoder.StdBias == nil || m.VisionEncoder.StdScale == nil {
+			return fmt.Errorf("missing vision standardization weights")
+		}
+	}
+
+	return m.loadVisionProjection(tensors, linears)
+}
+
+func (m *Model) loadUnifiedVisionWeights(tensors map[string]*mlx.Array, linears model.LinearFactory) error {
+	const prefix = "model.vision_embedder."
+
+	patchDense := linears.Make(prefix + "patch_dense")
+	patchNorm1Weight := tensors[prefix+"patch_ln1.weight"]
+	patchNorm1Bias := tensors[prefix+"patch_ln1.bias"]
+	patchNorm2Weight := tensors[prefix+"patch_ln2.weight"]
+	patchNorm2Bias := tensors[prefix+"patch_ln2.bias"]
+	positionEmbedding := tensors[prefix+"pos_embedding"]
+	positionNormWeight := tensors[prefix+"pos_norm.weight"]
+	positionNormBias := tensors[prefix+"pos_norm.bias"]
+	if patchDense == nil || patchNorm1Weight == nil || patchNorm1Bias == nil ||
+		patchNorm2Weight == nil || patchNorm2Bias == nil || positionEmbedding == nil ||
+		positionNormWeight == nil || positionNormBias == nil {
+		return fmt.Errorf("missing unified vision embedder weights")
+	}
+	if dims := positionEmbedding.Dims(); len(dims) != 3 ||
+		dims[0] != int(m.VisionConfig.PositionEmbeddingSize) ||
+		dims[1] != 2 ||
+		dims[2] != int(m.VisionConfig.HiddenSize) {
+		return fmt.Errorf("unexpected unified vision position embedding shape %v", dims)
+	}
+	// Unified checkpoints store this as [position, axis, hidden], while the
+	// regular vision tower and the shared lookup path use [axis, position, hidden].
+	positionEmbedding = mlx.Transpose(positionEmbedding, 1, 0, 2)
+
+	m.VisionEncoder.UnifiedPatchEmbedder = &UnifiedVisionPatchEmbedder{
+		PatchNorm1: &nn.LayerNorm{
+			Weight: patchNorm1Weight,
+			Bias:   patchNorm1Bias,
+		},
+		PatchDense: patchDense,
+		PatchNorm2: &nn.LayerNorm{
+			Weight: patchNorm2Weight,
+			Bias:   patchNorm2Bias,
+		},
+		PositionEmbedding: positionEmbedding,
+		PositionNorm: &nn.LayerNorm{
+			Weight: positionNormWeight,
+			Bias:   positionNormBias,
+		},
+	}
+
+	return m.loadVisionProjection(tensors, linears)
+}
+
+func (m *Model) loadVisionProjection(tensors map[string]*mlx.Array, linears model.LinearFactory) error {
+	embedPrefix := "model.embed_vision."
+	if tensors[embedPrefix+"embedding_projection.weight"] == nil {
+		embedPrefix = "embed_vision."
+	}
+	m.MultimodalEmbed = &MultimodalEmbedder{
+		EmbeddingProjection: linears.Make(embedPrefix + "embedding_projection"),
+		Eps:                 m.VisionConfig.RMSNormEps,
+	}
+	if m.MultimodalEmbed.EmbeddingProjection == nil {
+		return fmt.Errorf("missing multimodal embedder embedding_projection")
+	}
+
+	return nil
+}
+
+// precomputeVisionScaledWeights assigns raw norm weights to the *Scaled fields.
+// Gemma 4 uses scale_shift=0.0 for all norms (no +1.0 adjustment).
+func precomputeVisionScaledWeights(ve *VisionEncoder) {
+	for _, layer := range ve.Layers {
+		if layer.InputNorm != nil {
+			layer.InputNormScaled = layer.InputNorm.Weight
+		}
+		if layer.PostAttnNorm != nil {
+			layer.PostAttnNormScaled = layer.PostAttnNorm.Weight
+		}
+		if layer.PreFFNorm != nil {
+			layer.PreFFNormScaled = layer.PreFFNorm.Weight
+		}
+		if layer.PostFFNorm != nil {
+			layer.PostFFNormScaled = layer.PostFFNorm.Weight
+		}
+		if layer.Attention.QNorm != nil {
+			layer.Attention.QNormScaled = layer.Attention.QNorm.Weight
+		}
+		if layer.Attention.KNorm != nil {
+			layer.Attention.KNormScaled = layer.Attention.KNorm.Weight
+		}
+	}
+}
+
+// patchify converts pixel values to patch embeddings.
+// Input: pixelValues [B, 3, H, W] (channels-first, float32, rescaled to [0,1])
+// Output: patches [B, numPatches, 3*patchSize^2]
+func patchify(pixelValues *mlx.Array, patchSize int32) *mlx.Array {
+	dims := pixelValues.Dims()
+	B := int32(dims[0])
+	H, W := int32(dims[2]), int32(dims[3])
+	patchH := H / patchSize
+	patchW := W / patchSize
+	C := int32(3) // channels
+
+	// Reshape: [B, C, pH, pS, pW, pS]
+	x := mlx.Reshape(pixelValues, B, C, patchH, patchSize, patchW, patchSize)
+	// Permute to: [B, pH, pW, pS, pS, C]
+	x = mlx.Transpose(x, 0, 2, 4, 3, 5, 1)
+	// Flatten to: [B, pH*pW, pS*pS*C]
+	return mlx.Reshape(x, B, patchH*patchW, patchSize*patchSize*C)
+}
+
+// compute2DRoPE precomputes cos/sin arrays for 2D rotary position embeddings.
+// positions is a flat slice of [x0, y0, x1, y1, ...] patch coordinates.
+// Returns cos, sin arrays of shape [1, 1, numPatches, headDim] for broadcasting.
+func compute2DRoPE(positions []int32, headDim int32, theta float32) (*mlx.Array, *mlx.Array) {
+	numPatches := int32(len(positions) / 2)
+	ndim := int32(2)
+	dimPerSpatial := headDim / ndim // 32 for head_dim=64
+	halfDim := dimPerSpatial / 2    // 16
+
+	// Compute inverse frequencies for each spatial dimension.
+	invFreq := make([]float64, halfDim)
+	for i := range halfDim {
+		invFreq[i] = 1.0 / math.Pow(float64(theta), 2.0*float64(i)/float64(dimPerSpatial))
+	}
+
+	cosVals := make([]float32, numPatches*headDim)
+	sinVals := make([]float32, numPatches*headDim)
+
+	for p := range numPatches {
+		px := float64(positions[p*2])
+		py := float64(positions[p*2+1])
+		offset := p * headDim
+
+		// X-dimension: dims [0, dimPerSpatial)
+		// emb_x = [freqs_x, freqs_x] (duplicated for rotate_half convention)
+		for i := range halfDim {
+			freq := px * invFreq[i]
+			c, s := float32(math.Cos(freq)), float32(math.Sin(freq))
+			cosVals[offset+i] = c
+			sinVals[offset+i] = s
+			cosVals[offset+halfDim+i] = c
+			sinVals[offset+halfDim+i] = s
+		}
+
+		// Y-dimension: dims [dimPerSpatial, headDim)
+		for i := range halfDim {
+			freq := py * invFreq[i]
+			c, s := float32(math.Cos(freq)), float32(math.Sin(freq))
+			cosVals[offset+dimPerSpatial+i] = c
+			sinVals[offset+dimPerSpatial+i] = s
+			cosVals[offset+dimPerSpatial+halfDim+i] = c
+			sinVals[offset+dimPerSpatial+halfDim+i] = s
+		}
+	}
+
+	// Shape: [1, 1, numPatches, headDim] for broadcasting with [B, numHeads, seq, headDim]
+	cos := mlx.FromValues(cosVals, 1, 1, int(numPatches), int(headDim))
+	sin := mlx.FromValues(sinVals, 1, 1, int(numPatches), int(headDim))
+	return cos, sin
+}
+
+// applyRoPE2D applies 2D rotary position embeddings using precomputed cos/sin.
+// x: [B, numHeads, seq, headDim], cos/sin: [1, 1, seq, headDim]
+// The rotation is applied per spatial dimension (headDim/2 each), matching
+// Python's apply_multidimensional_rope which splits into ndim=2 parts.
+func applyRoPE2D(x, cos, sin *mlx.Array) *mlx.Array {
+	dims := x.Dims()
+	B, H, S := int32(dims[0]), int32(dims[1]), int32(dims[2])
+	headDim := int32(dims[3])
+	dimPerSpatial := headDim / 2 // 32 for headDim=64
+	halfDim := dimPerSpatial / 2 // 16
+
+	// Process each spatial dimension independently.
+	var parts []*mlx.Array
+	for d := range int32(2) {
+		off := d * dimPerSpatial
+
+		// Extract this spatial dimension's slice: x[..., off:off+dimPerSpatial]
+		xPart := mlx.SliceStartStop(x,
+			[]int32{0, 0, 0, off},
+			[]int32{B, H, S, off + dimPerSpatial},
+		)
+		cosPart := mlx.SliceStartStop(cos,
+			[]int32{0, 0, 0, off},
+			[]int32{1, 1, S, off + dimPerSpatial},
+		)
+		sinPart := mlx.SliceStartStop(sin,
+			[]int32{0, 0, 0, off},
+			[]int32{1, 1, S, off + dimPerSpatial},
+		)
+
+		// rotate_half within this part: [-x2, x1]
+		x1 := mlx.SliceStartStop(xPart,
+			[]int32{0, 0, 0, 0},
+			[]int32{B, H, S, halfDim},
+		)
+		x2 := mlx.SliceStartStop(xPart,
+			[]int32{0, 0, 0, halfDim},
+			[]int32{B, H, S, dimPerSpatial},
+		)
+		rotated := mlx.Concatenate([]*mlx.Array{mlx.Neg(x2), x1}, 3)
+
+		// xPart * cos + rotated * sin
+		parts = append(parts, mlx.Add(mlx.Mul(xPart, cosPart), mlx.Mul(rotated, sinPart)))
+	}
+
+	return mlx.Concatenate(parts, 3)
+}
+
+// buildPatchPositions creates patch coordinates in row-major image order.
+func buildPatchPositions(patchH, patchW int32) []int32 {
+	positions := make([]int32, patchH*patchW*2)
+	idx := int32(0)
+	for y := range patchH {
+		for x := range patchW {
+			positions[idx*2] = x
+			positions[idx*2+1] = y
+			idx++
+		}
+	}
+
+	return positions
+}
+
+// compute2DPositionEmbeddings computes position embeddings from the embedding table.
+// positions: [numPatches*2] flat (x0,y0,...)
+// table: [2, posEmbSize, hiddenSize]
+// Returns: [1, numPatches, hiddenSize]
+func compute2DPositionEmbeddings(positions []int32, table *mlx.Array, posEmbSize, hiddenSize int32) *mlx.Array {
+	numPatches := int32(len(positions) / 2)
+
+	// Build index arrays for each spatial dimension.
+	xIndices := make([]int32, numPatches)
+	yIndices := make([]int32, numPatches)
+	for p := range numPatches {
+		xIndices[p] = positions[p*2]
+		yIndices[p] = positions[p*2+1]
+	}
+
+	// table: [2, posEmbSize, hiddenSize]
+	// Extract x-dim table (table[0]) and y-dim table (table[1]).
+	xTable := mlx.SliceStartStop(table,
+		[]int32{0, 0, 0},
+		[]int32{1, posEmbSize, hiddenSize},
+	)
+	xTable = mlx.Squeeze(xTable, 0) // [posEmbSize, hiddenSize]
+
+	yTable := mlx.SliceStartStop(table,
+		[]int32{1, 0, 0},
+		[]int32{2, posEmbSize, hiddenSize},
+	)
+	yTable = mlx.Squeeze(yTable, 0) // [posEmbSize, hiddenSize]
+
+	// Gather: look up positions from each table.
+	xIdx := mlx.NewArrayInt32(xIndices, []int32{numPatches})
+	yIdx := mlx.NewArrayInt32(yIndices, []int32{numPatches})
+
+	xEmb := mlx.Take(xTable, xIdx, 0) // [numPatches, hiddenSize]
+	yEmb := mlx.Take(yTable, yIdx, 0) // [numPatches, hiddenSize]
+
+	// Sum x and y embeddings.
+	posEmb := mlx.Add(xEmb, yEmb) // [numPatches, hiddenSize]
+
+	// Add batch dim: [1, numPatches, hiddenSize]
+	return mlx.ExpandDims(posEmb, 0)
+}
+
+// VisionTokenCount computes how many soft tokens a given image size will produce,
+// without running the vision encoder. This allows the pipeline to determine the
+// token count before deciding whether vision encoding is needed.
+func (m *Model) VisionTokenCount(height, width int) int {
+	vcfg := m.VisionConfig
+	if vcfg == nil {
+		return 0
+	}
+	patchH := int32(height) / vcfg.PatchSize
+	patchW := int32(width) / vcfg.PatchSize
+	k := vcfg.PoolingKernelSize
+	return int((patchH / k) * (patchW / k))
+}
+
+// ForwardVision encodes pixel values into soft tokens in text embedding space.
+// pixelValues: [B, 3, H, W] float32 tensor (channels-first, values in [0, 1]).
+// Returns: soft tokens [1, numRealTokens, textHiddenSize].
+func (m *Model) ForwardVision(pixelValues *mlx.Array) *mlx.Array {
+	ve := m.VisionEncoder
+	vcfg := ve.Cfg
+	if ve.UnifiedPatchEmbedder != nil {
+		return m.forwardUnifiedVision(pixelValues)
+	}
+
+	dims := pixelValues.Dims()
+	B := int32(dims[0])
+	H, W := int32(dims[2]), int32(dims[3])
+	patchH := H / vcfg.PatchSize
+	patchW := W / vcfg.PatchSize
+
+	positions := buildPatchPositions(patchH, patchW)
+
+	// Patchify and project.
+	patches := patchify(pixelValues, vcfg.PatchSize)
+	patches = mlx.AddScalar(mlx.MulScalar(patches, 2.0), -1.0)
+	h := ve.PatchEmbedder.InputProj.Forward(patches)
+
+	// Add 2D position embeddings.
+	posEmb := compute2DPositionEmbeddings(positions,
+		ve.PatchEmbedder.PositionEmbeddingTable, vcfg.PositionEmbeddingSize, vcfg.HiddenSize)
+	h = mlx.Add(h, posEmb)
+
+	cos, sin := compute2DRoPE(positions, vcfg.HeadDim, vcfg.RopeTheta)
+	materializeVisionState(h, cos, sin)
+
+	// Run through vision transformer layers.
+	for _, layer := range ve.Layers {
+		h = visionLayerForward(layer, h, cos, sin, B, vcfg)
+		materializeVisionState(h, cos, sin)
+	}
+
+	h = visionPool(h, patchH, patchW, vcfg.PoolingKernelSize)
+
+	// Scale by sqrt(hidden_size).
+	h = mlx.MulScalar(h, float32(math.Sqrt(float64(vcfg.HiddenSize))))
+
+	if vcfg.Standardize {
+		h = mlx.Mul(mlx.Sub(h, ve.StdBias), ve.StdScale)
+	}
+
+	// Project to text embedding space via multimodal embedder.
+	h = m.MultimodalEmbed.Forward(h)
+
+	return h
+}
+
+func (m *Model) forwardUnifiedVision(pixelValues *mlx.Array) *mlx.Array {
+	ve := m.VisionEncoder
+	cfg := ve.Cfg
+	embedder := ve.UnifiedPatchEmbedder
+
+	dims := pixelValues.Dims()
+	patchH := int32(dims[2]) / cfg.PatchSize
+	patchW := int32(dims[3]) / cfg.PatchSize
+	positions := buildPatchPositions(patchH, patchW)
+
+	h := embedder.PatchNorm1.Forward(patchify(pixelValues, cfg.PatchSize))
+	h = embedder.PatchDense.Forward(h)
+	h = embedder.PatchNorm2.Forward(h)
+	h = mlx.Add(h, compute2DPositionEmbeddings(
+		positions,
+		embedder.PositionEmbedding,
+		cfg.PositionEmbeddingSize,
+		cfg.HiddenSize,
+	))
+	h = embedder.PositionNorm.Forward(h)
+	return m.MultimodalEmbed.Forward(h)
+}
+
+func materializeVisionState(h, cos, sin *mlx.Array) {
+	mlx.Eval(h, cos, sin)
+	mlx.Pin(h, cos, sin)
+	mlx.Sweep()
+	mlx.Unpin(h, cos, sin)
+}
+
+func visionLayerForward(layer *VisionDecoderLayer, x, cos, sin *mlx.Array, B int32, cfg *VisionConfig) *mlx.Array {
+	S := int32(x.Dim(1))
+
+	// Pre-attention norm.
+	normed := mlx.RMSNormFn(x, layer.InputNormScaled, cfg.RMSNormEps)
+
+	// Self-attention.
+	attnOut := visionAttentionForward(layer.Attention, normed, cos, sin, B, S, cfg)
+	attnOut = mlx.RMSNormFn(attnOut, layer.PostAttnNormScaled, cfg.RMSNormEps)
+	h := mlx.Add(x, attnOut)
+
+	// MLP.
+	normed = mlx.RMSNormFn(h, layer.PreFFNormScaled, cfg.RMSNormEps)
+	mlpOut := visionMLPForward(layer.MLP, normed)
+	mlpOut = mlx.RMSNormFn(mlpOut, layer.PostFFNormScaled, cfg.RMSNormEps)
+	h = mlx.Add(h, mlpOut)
+
+	// Layer scalar.
+	if layer.LayerScalar != nil {
+		h = mlx.Mul(h, layer.LayerScalar)
+	}
+
+	return h
+}
+
+func visionAttentionForward(a *VisionAttention, x, cos, sin *mlx.Array, B, S int32, cfg *VisionConfig) *mlx.Array {
+	headDim := cfg.HeadDim
+	numHeads := cfg.NumAttentionHeads
+	numKVHeads := cfg.NumKeyValueHeads
+
+	q := a.QProj.Forward(x)
+	q = mlx.Reshape(q, B, S, numHeads, headDim)
+
+	k := a.KProj.Forward(x)
+	k = mlx.Reshape(k, B, S, numKVHeads, headDim)
+
+	v := a.VProj.Forward(x)
+	v = mlx.Reshape(v, B, S, numKVHeads, headDim)
+
+	// Apply Q/K norms.
+	q = mlx.RMSNormFn(q, a.QNormScaled, cfg.RMSNormEps)
+	k = mlx.RMSNormFn(k, a.KNormScaled, cfg.RMSNormEps)
+
+	// Apply V norm (no learnable weight).
+	v = mlx.RMSNormFn(v, nil, cfg.RMSNormEps)
+
+	// Apply 2D RoPE (after norms, before transpose).
+	q = mlx.Transpose(q, 0, 2, 1, 3)
+	k = mlx.Transpose(k, 0, 2, 1, 3)
+
+	q = applyRoPE2D(q, cos, sin)
+	k = applyRoPE2D(k, cos, sin)
+
+	v = mlx.Transpose(v, 0, 2, 1, 3)
+
+	// Bidirectional attention over the image's real patches.
+	out := mlx.FastScaledDotProductAttention(q, k, v, cfg.Scale, "", nil)
+
+	// Reshape and project output.
+	out = mlx.Transpose(out, 0, 2, 1, 3)
+	out = mlx.Reshape(out, B, S, numHeads*headDim)
+	return a.OProj.Forward(out)
+}
+
+func visionMLPForward(mlp *VisionMLP, x *mlx.Array) *mlx.Array {
+	gate := mlx.GELUApprox(mlp.GateProj.Forward(x))
+	up := mlp.UpProj.Forward(x)
+	return mlp.DownProj.Forward(mlx.Mul(gate, up))
+}
+
+// visionPool performs non-overlapping 2D spatial average pooling.
+func visionPool(h *mlx.Array, patchH, patchW, kernel int32) *mlx.Array {
+	B := int32(h.Dim(0))
+	hidden := int32(h.Dim(2))
+	pooledH := patchH / kernel
+	pooledW := patchW / kernel
+
+	h = mlx.Reshape(h, B, pooledH, kernel, pooledW, kernel, hidden)
+	h = mlx.Mean(h, 4, false)
+	h = mlx.Mean(h, 2, false)
+	return mlx.Reshape(h, B, pooledH*pooledW, hidden)
+}

--- a/x/models/gemma4/gemma4_vision_test.go
+++ b/x/models/gemma4/gemma4_vision_test.go
@@ -1,0 +1,189 @@
+package gemma4
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseVisionConfig(t *testing.T) {
+	t.Run("small vision tower", func(t *testing.T) {
+		cfg, err := parseVisionConfig([]byte(`{
+			"vision_config": {
+				"model_type": "gemma4_vision",
+				"hidden_size": 768,
+				"num_hidden_layers": 16,
+				"num_attention_heads": 12,
+				"patch_size": 16,
+				"pooling_kernel_size": 3,
+				"default_output_length": 280
+			}
+		}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg == nil {
+			t.Fatal("expected supported vision config")
+		}
+		if cfg.ImageSeqLength != 280 {
+			t.Fatalf("image sequence length = %d, want 280", cfg.ImageSeqLength)
+		}
+	})
+
+	t.Run("unified vision tower", func(t *testing.T) {
+		cfg, err := parseVisionConfig([]byte(`{
+			"vision_config": {
+				"model_type": "gemma4_unified_vision",
+				"mm_embed_dim": 3840,
+				"mm_posemb_size": 1120,
+				"model_patch_size": 48,
+				"patch_size": 16,
+				"pooling_kernel_size": 3,
+				"num_soft_tokens": 280
+			}
+		}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg == nil {
+			t.Fatal("expected supported unified vision config")
+		}
+		if cfg.HiddenSize != 3840 || cfg.PositionEmbeddingSize != 1120 {
+			t.Fatalf("embedding dimensions = (%d, %d), want (3840, 1120)", cfg.HiddenSize, cfg.PositionEmbeddingSize)
+		}
+		if cfg.PatchSize != 48 || cfg.PoolingKernelSize != 1 {
+			t.Fatalf("patch configuration = (%d, %d), want (48, 1)", cfg.PatchSize, cfg.PoolingKernelSize)
+		}
+		if cfg.ImageSeqLength != 280 {
+			t.Fatalf("image sequence length = %d, want 280", cfg.ImageSeqLength)
+		}
+	})
+
+	t.Run("no vision config is text only", func(t *testing.T) {
+		cfg, err := parseVisionConfig([]byte(`{"hidden_size": 768}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg != nil {
+			t.Fatalf("vision config = %+v, want nil for a text-only model", cfg)
+		}
+	})
+
+	t.Run("unsupported vision tower is an error", func(t *testing.T) {
+		// The manifest advertises vision for any config carrying a
+		// vision_config, so a silent text-only fallback here would leave
+		// /api/show claiming a tower the runner cannot execute.
+		cfg, err := parseVisionConfig([]byte(`{"vision_config": {"model_type": "gemma4_future_vision"}}`))
+		if err == nil {
+			t.Fatalf("vision config = %+v, want an error naming the tower", cfg)
+		}
+		if !strings.Contains(err.Error(), "gemma4_future_vision") {
+			t.Fatalf("error = %v, want it to name the unsupported tower", err)
+		}
+	})
+
+	t.Run("large vision tower", func(t *testing.T) {
+		cfg, err := parseVisionConfig([]byte(`{
+			"vision_config": {
+				"model_type": "gemma4_vision",
+				"hidden_size": 1152,
+				"num_hidden_layers": 27,
+				"num_attention_heads": 16,
+				"head_dim": 72,
+				"standardize": true
+			}
+		}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg == nil {
+			t.Fatal("expected supported vision config")
+		}
+		if !cfg.Standardize {
+			t.Fatal("expected vision output standardization")
+		}
+	})
+}
+
+func TestVisionTokenCount(t *testing.T) {
+	m := &Model{VisionConfig: &VisionConfig{
+		PatchSize:         16,
+		PoolingKernelSize: 3,
+		ImageSeqLength:    280,
+	}}
+
+	if got := m.VisionTokenCount(48, 48); got != 1 {
+		t.Fatalf("48x48 token count = %d, want 1", got)
+	}
+	if got := m.VisionTokenCount(48, 96); got != 2 {
+		t.Fatalf("96x48 token count = %d, want 2", got)
+	}
+
+	m.VisionConfig = &VisionConfig{
+		ModelType:         "gemma4_unified_vision",
+		PatchSize:         48,
+		PoolingKernelSize: 1,
+		ImageSeqLength:    280,
+	}
+	if got := m.VisionTokenCount(48, 96); got != 2 {
+		t.Fatalf("unified 96x48 token count = %d, want 2", got)
+	}
+}
+
+func TestGemma4ImageSize(t *testing.T) {
+	const alignment = 48
+
+	for _, tt := range []struct {
+		name                  string
+		height, width         int
+		minTokens, maxTokens  int
+		wantHeight, wantWidth int
+	}{
+		{name: "small square", height: 100, width: 100, minTokens: 280, maxTokens: 1120, wantHeight: 768, wantWidth: 768},
+		{name: "small landscape", height: 300, width: 600, minTokens: 280, maxTokens: 1120, wantHeight: 528, wantWidth: 1104},
+		{name: "preserve high resolution", height: 1080, width: 1920, minTokens: 280, maxTokens: 1120, wantHeight: 1104, wantWidth: 1920},
+		{name: "downscale high resolution", height: 1080, width: 1920, minTokens: 280, maxTokens: 280, wantHeight: 576, wantWidth: 1056},
+		{name: "very wide", height: 1, width: 10000, minTokens: 280, maxTokens: 1120, wantHeight: 48, wantWidth: 13440},
+		{name: "very tall", height: 10000, width: 1, minTokens: 280, maxTokens: 1120, wantHeight: 13440, wantWidth: 48},
+		{name: "extreme wide", height: 1, width: 1000000000, minTokens: 280, maxTokens: 1120, wantHeight: 48, wantWidth: 53760},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			minPixels := tt.minTokens * alignment * alignment
+			maxPixels := tt.maxTokens * alignment * alignment
+			gotH, gotW := gemma4ImageSize(tt.height, tt.width, alignment, minPixels, maxPixels)
+			if gotH != tt.wantHeight || gotW != tt.wantWidth {
+				t.Fatalf("size = %dx%d, want %dx%d", gotH, gotW, tt.wantHeight, tt.wantWidth)
+			}
+			if gotH%alignment != 0 || gotW%alignment != 0 {
+				t.Fatalf("size %dx%d is not aligned to %d", gotH, gotW, alignment)
+			}
+			if gotH*gotW > maxPixels {
+				t.Fatalf("size %dx%d exceeds pixel budget %d", gotH, gotW, maxPixels)
+			}
+		})
+	}
+}
+
+// TestGemma4ImageTokenLimit pins every fidelity step and the boundary on each
+// side of it, so neither a threshold nor the order of the switch can be changed
+// without the test noticing. The measurements the thresholds derive from are
+// above the budget constants in vision_prompt.go.
+func TestGemma4ImageTokenLimit(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		headroom int
+		want     int
+	}{
+		{name: "no budget reported falls back", headroom: 0, want: gemma4FallbackImageTokens},
+		{name: "just below the standard step", headroom: gemma4StandardResHeadroom - 1, want: gemma4FallbackImageTokens},
+		{name: "exactly the standard step", headroom: gemma4StandardResHeadroom, want: gemma4StandardImageTokens},
+		{name: "just below the high step", headroom: gemma4HighResHeadroom - 1, want: gemma4StandardImageTokens},
+		{name: "exactly the high step", headroom: gemma4HighResHeadroom, want: gemma4MaxImageTokens},
+		{name: "well above the high step", headroom: 96 << 30, want: gemma4MaxImageTokens},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := gemma4ImageTokenLimit(tt.headroom); got != tt.want {
+				t.Fatalf("token limit = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/x/models/gemma4/vision_prompt.go
+++ b/x/models/gemma4/vision_prompt.go
@@ -1,0 +1,369 @@
+package gemma4
+
+import (
+	"bytes"
+	"fmt"
+	"image"
+	_ "image/gif"
+	_ "image/jpeg"
+	_ "image/png"
+	"log/slog"
+	"math"
+	"regexp"
+	"strconv"
+
+	"golang.org/x/image/draw"
+
+	"github.com/ollama/ollama/x/mlxrunner/batch"
+	"github.com/ollama/ollama/x/mlxrunner/cache"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/mlxrunner/model/base"
+	"github.com/ollama/ollama/x/models/nn"
+)
+
+var imageTagPattern = regexp.MustCompile(`\[img-(\d+)\]`)
+
+// Image fidelity is bought with memory, so we take the highest budget the device
+// can hold rather than defaulting low: a machine with room to spare reads tables
+// and small text, and a small machine still answers at lower fidelity.
+//
+// Measured with gemma4:e4b-nvfp4 (8.37 GiB resident, the more expensive of the
+// two towers) transcribing the OCR document from vision_ocr_test.go on an
+// M5 Max, reading peak memory at the end of prefill:
+//
+//	budget  prompt tokens      peak   above the resident model
+//	   280            304  8.85 GiB                   0.48 GiB
+//	   560            578  9.31 GiB                   0.94 GiB
+//	  1120           1102 10.21 GiB                   1.84 GiB
+//
+// Cost is linear in soft tokens - about 1.6 MiB each - because an image token
+// costs roughly what a text token costs; the tower's own activations are
+// near-noise beside the KV cache for the tokens it produces. The headroom
+// thresholds carry about a 2x margin over the measured cost of the budget they
+// unlock. A model with a larger KV footprint per token than e4b will cost
+// proportionally more at the same budget.
+const (
+	// gemma4MinImageTokens floors the resize so a tiny image is still upscaled
+	// to something the tower can read.
+	gemma4MinImageTokens = 40
+
+	gemma4FallbackImageTokens = 280
+	gemma4StandardImageTokens = 560
+	gemma4MaxImageTokens      = 1120
+
+	gemma4StandardResHeadroom = 2 << 30 // 2 GiB, ~2x the measured 0.94 GiB
+	gemma4HighResHeadroom     = 4 << 30 // 4 GiB, ~2x the measured 1.84 GiB
+)
+
+type visionInput struct {
+	pixels    *mlx.Array
+	numTokens int
+}
+
+type visionSegment struct {
+	start      int
+	end        int
+	numTokens  int
+	input      *visionInput
+	featureKey base.MediaFeatureKey
+	features   *base.MediaFeatureLease
+}
+
+type preparedMultimodalPrompt struct {
+	model        *Model
+	tokens       []int32
+	maskedTokens []int32
+	segments     []visionSegment
+	closed       bool
+}
+
+func (p *preparedMultimodalPrompt) Tokens() []int32 {
+	return p.tokens
+}
+
+func (p *preparedMultimodalPrompt) Forward(b *batch.Batch, caches []cache.Cache) *mlx.Array {
+	chunkStart := int(b.SeqOffsets[0])
+	chunkEnd := chunkStart + b.InputIDs.Dim(1)
+
+	mlx.Pin(b.InputIDs)
+	defer mlx.Unpin(b.InputIDs)
+	for i := range p.segments {
+		segment := &p.segments[i]
+		overlapStart := max(chunkStart, segment.start)
+		overlapEnd := min(chunkEnd, segment.end)
+		if overlapStart >= overlapEnd {
+			continue
+		}
+
+		if segment.features == nil {
+			if features, ok := p.model.mediaFeatures.Acquire(segment.featureKey); ok {
+				if features.TokenCount() != segment.numTokens {
+					// Request-goroutine panic, kept only because Forward has no
+					// error return in the pipeline's current shape. It belongs
+					// with the stopgap media cache and should become a returned
+					// error once multimodal inputs use the normal cache
+					// lifecycle. See base.MediaFeatureCache.Store.
+					panic("gemma4 cached vision token count changed")
+				}
+				segment.features = features
+				mlx.Unpin(segment.input.pixels)
+				segment.input = nil
+			} else {
+				features := p.model.ForwardVision(segment.input.pixels)
+				mlx.Eval(features)
+				segment.features = p.model.mediaFeatures.Store(
+					segment.featureKey,
+					features,
+					segment.numTokens,
+				)
+			}
+		}
+	}
+
+	h := p.model.embed(b.InputIDs)
+	for i := range p.segments {
+		segment := &p.segments[i]
+		overlapStart := max(chunkStart, segment.start)
+		overlapEnd := min(chunkEnd, segment.end)
+		if overlapStart >= overlapEnd {
+			continue
+		}
+
+		featureStart := overlapStart - segment.start
+		featureEnd := featureStart + overlapEnd - overlapStart
+		replacement := segment.features.Features().Slice(
+			mlx.Slice(),
+			mlx.Slice(featureStart, featureEnd),
+			mlx.Slice(),
+		).AsType(h.DType())
+		h = h.SliceUpdate(
+			replacement,
+			mlx.Slice(),
+			mlx.Slice(overlapStart-chunkStart, overlapEnd-chunkStart),
+			mlx.Slice(),
+		)
+	}
+
+	var pleTokens *mlx.Array
+	if p.model.HiddenSizePerLayer > 0 {
+		masked := p.maskedTokens[chunkStart:chunkEnd]
+		pleTokens = mlx.FromValues(masked, 1, len(masked))
+	}
+
+	attentionMask := nn.CausalMask()
+	if p.model.UseBidirectionalAttn == "vision" {
+		for _, segment := range p.segments {
+			attentionMask = attentionMask.Relax(0, segment.start, segment.end, segment.start, segment.end)
+		}
+	}
+	return p.model.forwardEmbeddings(h, b, caches, pleTokens, attentionMask)
+}
+
+func (p *preparedMultimodalPrompt) Close() {
+	if p.closed {
+		return
+	}
+	p.closed = true
+	for i := range p.segments {
+		if p.segments[i].input != nil {
+			mlx.Unpin(p.segments[i].input.pixels)
+		}
+		if p.segments[i].features != nil {
+			p.segments[i].features.Release()
+		}
+	}
+}
+
+func (m *Model) PrepareMultimodalPrompt(prompt string, media []base.MediaInput, headroomBytes int) (base.PreparedMultimodalPrompt, error) {
+	if m.VisionEncoder == nil || m.MultimodalEmbed == nil {
+		return nil, fmt.Errorf("gemma4 model has no supported vision encoder")
+	}
+
+	byID := make(map[int]base.MediaInput, len(media))
+	for _, item := range media {
+		if item.Kind != "" && item.Kind != "image" {
+			return nil, fmt.Errorf("gemma4 does not support %s input", item.Kind)
+		}
+		if _, exists := byID[item.ID]; exists {
+			return nil, fmt.Errorf("duplicate media ID %d", item.ID)
+		}
+		byID[item.ID] = item
+	}
+
+	parts := imageTagPattern.Split(prompt, -1)
+	matches := imageTagPattern.FindAllStringSubmatch(prompt, -1)
+	if len(matches) != len(media) {
+		return nil, fmt.Errorf("prompt contains %d image markers for %d images", len(matches), len(media))
+	}
+
+	prepared := &preparedMultimodalPrompt{model: m}
+	used := make(map[int]bool, len(media))
+	imageTokenLimit := gemma4ImageTokenLimit(headroomBytes)
+	slog.Debug("gemma4 vision token limit",
+		"tokens", imageTokenLimit,
+		"headroom", mlx.PrettyBytes(headroomBytes),
+	)
+	featureVariant := "gemma4:image:tokens=" + strconv.Itoa(imageTokenLimit)
+	cleanup := func(err error) (base.PreparedMultimodalPrompt, error) {
+		prepared.Close()
+		return nil, err
+	}
+
+	for i, part := range parts {
+		prepared.tokens = append(prepared.tokens, m.tok.Encode(part, i == 0 && m.tok.AddBOS())...)
+		if i >= len(matches) {
+			continue
+		}
+
+		id, err := strconv.Atoi(matches[i][1])
+		if err != nil {
+			return cleanup(fmt.Errorf("invalid image marker %q: %w", matches[i][0], err))
+		}
+		item, ok := byID[id]
+		if !ok {
+			return cleanup(fmt.Errorf("image marker references missing media ID %d", id))
+		}
+		if used[id] {
+			return cleanup(fmt.Errorf("image media ID %d is referenced more than once", id))
+		}
+		used[id] = true
+
+		featureKey := base.NewMediaFeatureKey(item.Data, featureVariant)
+		features, cached := m.mediaFeatures.Acquire(featureKey)
+		var input *visionInput
+		var numTokens int
+		if cached {
+			numTokens = features.TokenCount()
+		} else {
+			input, err = m.preprocessImage(item.Data, imageTokenLimit)
+			if err != nil {
+				return cleanup(fmt.Errorf("preprocess image %d: %w", id, err))
+			}
+			mlx.Eval(input.pixels)
+			mlx.Pin(input.pixels)
+			numTokens = input.numTokens
+		}
+		slog.Debug("gemma4 vision feature cache", "hit", cached, "tokens", numTokens)
+
+		prepared.tokens = append(prepared.tokens, m.imageStartTokenID)
+		start := len(prepared.tokens)
+		for range numTokens {
+			prepared.tokens = append(prepared.tokens, m.imageTokenID)
+		}
+		prepared.segments = append(prepared.segments, visionSegment{
+			start:      start,
+			end:        len(prepared.tokens),
+			numTokens:  numTokens,
+			input:      input,
+			featureKey: featureKey,
+			features:   features,
+		})
+		prepared.tokens = append(prepared.tokens, m.imageEndTokenID)
+	}
+
+	prepared.maskedTokens = append([]int32(nil), prepared.tokens...)
+	for _, segment := range prepared.segments {
+		clear(prepared.maskedTokens[segment.start:segment.end])
+	}
+	return prepared, nil
+}
+
+func (m *Model) preprocessImage(data []byte, maxTokens int) (*visionInput, error) {
+	cfg := m.VisionConfig
+	if cfg == nil {
+		return nil, fmt.Errorf("model has no vision config")
+	}
+
+	src, _, err := image.Decode(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("decode image: %w", err)
+	}
+
+	bounds := src.Bounds()
+	srcW, srcH := bounds.Dx(), bounds.Dy()
+	if srcW <= 0 || srcH <= 0 {
+		return nil, fmt.Errorf("invalid image dimensions %dx%d", srcW, srcH)
+	}
+
+	patchSize := int(cfg.PatchSize)
+	alignSize := int(cfg.PoolingKernelSize) * patchSize
+	pixelsPerToken := alignSize * alignSize
+	minTokens := min(maxTokens, max(gemma4MinImageTokens, int(cfg.ImageSeqLength)))
+	targetH, targetW := gemma4ImageSize(
+		srcH,
+		srcW,
+		alignSize,
+		minTokens*pixelsPerToken,
+		maxTokens*pixelsPerToken,
+	)
+
+	dst := image.NewRGBA(image.Rect(0, 0, targetW, targetH))
+	draw.CatmullRom.Scale(dst, dst.Bounds(), src, bounds, draw.Over, nil)
+
+	pixels := make([]float32, 3*targetH*targetW)
+	for y := range targetH {
+		for x := range targetW {
+			offset := y*dst.Stride + x*4
+			pixels[y*targetW+x] = float32(dst.Pix[offset]) / 255
+			pixels[targetH*targetW+y*targetW+x] = float32(dst.Pix[offset+1]) / 255
+			pixels[2*targetH*targetW+y*targetW+x] = float32(dst.Pix[offset+2]) / 255
+		}
+	}
+
+	return &visionInput{
+		pixels:    mlx.FromValues(pixels, 1, 3, targetH, targetW),
+		numTokens: m.VisionTokenCount(targetH, targetW),
+	}, nil
+}
+
+// gemma4ImageTokenLimit picks the highest image fidelity the memory left over
+// after loading the model can hold. See the budget constants for the
+// measurements behind each step.
+func gemma4ImageTokenLimit(headroom int) int {
+	switch {
+	case headroom >= gemma4HighResHeadroom:
+		return gemma4MaxImageTokens
+	case headroom >= gemma4StandardResHeadroom:
+		return gemma4StandardImageTokens
+	default:
+		return gemma4FallbackImageTokens
+	}
+}
+
+func gemma4ImageSize(height, width, alignment, minPixels, maxPixels int) (int, int) {
+	roundTo := func(value float64) int {
+		return int(math.Round(value/float64(alignment))) * alignment
+	}
+
+	targetH := max(alignment, roundTo(float64(height)))
+	targetW := max(alignment, roundTo(float64(width)))
+
+	switch {
+	case float64(targetH)*float64(targetW) > float64(maxPixels):
+		targetH, targetW = gemma4FitImageSize(height, width, alignment, maxPixels)
+	case float64(targetH)*float64(targetW) < float64(minPixels):
+		targetH, targetW = gemma4FitImageSize(height, width, alignment, minPixels)
+	}
+
+	return targetH, targetW
+}
+
+func gemma4FitImageSize(height, width, alignment, pixelBudget int) (int, int) {
+	scale := math.Sqrt(float64(pixelBudget) / (float64(height) * float64(width)))
+	targetH := int(math.Floor(scale*float64(height)/float64(alignment))) * alignment
+	targetW := int(math.Floor(scale*float64(width)/float64(alignment))) * alignment
+
+	maxSide := pixelBudget / (alignment * alignment) * alignment
+	switch {
+	case targetH == 0 && targetW == 0:
+		return alignment, alignment
+	case targetH == 0:
+		targetH = alignment
+		targetW = min(int(math.Floor(float64(width)/float64(height)))*alignment, maxSide)
+	case targetW == 0:
+		targetW = alignment
+		targetH = min(int(math.Floor(float64(height)/float64(width)))*alignment, maxSide)
+	}
+
+	return targetH, targetW
+}


### PR DESCRIPTION
While the MLX runner pipeline and cache continue to evolve, this wires up a temporary multimodal integration framework, with a simple media cache to reduce the overhead of ongoing sessions with images.  Once the pipeline and KV cache stabilize, this temporary wiring should be discarded and properly integrated into the runner.

