### PR TITLE
model/parsers: avoid a panic when a tool call value is a lone delimiter

### DIFF
--- a/model/parsers/functiongemma.go
+++ b/model/parsers/functiongemma.go
@@ -257,10 +257,12 @@ func (p *FunctionGemmaParser) splitArguments(argsStr string) []string {
 
 // parseValue parses a single value from the FunctionGemma format
 func (p *FunctionGemmaParser) parseValue(value string) any {
-	// Check for escaped string
-	if strings.HasPrefix(value, "<escape>") && strings.HasSuffix(value, "<escape>") {
-		// Remove the escape tags
-		return value[8 : len(value)-8]
+	// Check for escaped string. Both markers have to be present: a value that is
+	// a single <escape> matches as prefix and suffix at once.
+	if trimmed, ok := strings.CutPrefix(value, "<escape>"); ok {
+		if trimmed, ok := strings.CutSuffix(trimmed, "<escape>"); ok {
+			return trimmed
+		}
 	}
 
 	// Check for boolean

--- a/model/parsers/functiongemma_test.go
+++ b/model/parsers/functiongemma_test.go
@@ -391,6 +391,36 @@ func TestFunctionGemmaParser(t *testing.T) {
 			},
 			expectedText: "Some text here",
 		},
+		{
+			name: "unterminated_escape_marker",
+			chunks: []string{
+				"<start_function_call>call:get_weather{city:<escape>}<end_function_call>",
+			},
+			expectedCalls: []api.ToolCall{
+				{
+					Function: api.ToolCallFunction{
+						Name:      "get_weather",
+						Arguments: testArgs(map[string]any{"city": "<escape>"}),
+					},
+				},
+			},
+			expectedText: "",
+		},
+		{
+			name: "unterminated_escape_marker_in_object",
+			chunks: []string{
+				"<start_function_call>call:get_weather{opts:{city:<escape>}}<end_function_call>",
+			},
+			expectedCalls: []api.ToolCall{
+				{
+					Function: api.ToolCallFunction{
+						Name:      "get_weather",
+						Arguments: testArgs(map[string]any{"opts": map[string]any{"city": "<escape>"}}),
+					},
+				},
+			},
+			expectedText: "",
+		},
 	}
 
 	for _, tt := range tests {

--- a/model/parsers/olmo3.go
+++ b/model/parsers/olmo3.go
@@ -364,9 +364,11 @@ func splitArguments(s string) []string {
 func parseOlmo3Value(s string) (any, error) {
 	s = strings.TrimSpace(s)
 
-	// Check for quoted string
-	if (strings.HasPrefix(s, `"`) && strings.HasSuffix(s, `"`)) ||
-		(strings.HasPrefix(s, `'`) && strings.HasSuffix(s, `'`)) {
+	// Check for quoted string. A lone quote character is both a prefix and a
+	// suffix match, so require an opening and a closing one.
+	if len(s) >= 2 &&
+		((strings.HasPrefix(s, `"`) && strings.HasSuffix(s, `"`)) ||
+			(strings.HasPrefix(s, `'`) && strings.HasSuffix(s, `'`))) {
 		// Remove quotes and unescape
 		inner := s[1 : len(s)-1]
 		return unescapeString(inner), nil
@@ -450,8 +452,9 @@ func parseOlmo3Object(s string) (map[string]any, error) {
 		valueStr := strings.TrimSpace(part[colonIdx+1:])
 
 		// Remove quotes from key if present
-		if (strings.HasPrefix(keyStr, `"`) && strings.HasSuffix(keyStr, `"`)) ||
-			(strings.HasPrefix(keyStr, `'`) && strings.HasSuffix(keyStr, `'`)) {
+		if len(keyStr) >= 2 &&
+			((strings.HasPrefix(keyStr, `"`) && strings.HasSuffix(keyStr, `"`)) ||
+				(strings.HasPrefix(keyStr, `'`) && strings.HasSuffix(keyStr, `'`))) {
 			keyStr = keyStr[1 : len(keyStr)-1]
 		}
 

--- a/model/parsers/olmo3_test.go
+++ b/model/parsers/olmo3_test.go
@@ -232,6 +232,18 @@ get_weather(location="New York")</function_calls>`,
 				},
 			},
 		},
+		{
+			name:  "tool call with unterminated quote",
+			input: `<function_calls>get_weather(location=")</function_calls>`,
+			expectedCalls: []api.ToolCall{
+				{
+					Function: api.ToolCallFunction{
+						Name:      "get_weather",
+						Arguments: testArgs(map[string]any{"location": `"`}),
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -469,6 +481,9 @@ func TestParseOlmo3Value(t *testing.T) {
 		{"simple object", `{"name": "John"}`, map[string]any{"name": "John"}},
 		{"object with number", `{"age": 30}`, map[string]any{"age": int64(30)}},
 		{"object with multiple keys", `{"a": 1, "b": 2}`, map[string]any{"a": int64(1), "b": int64(2)}},
+		{"lone double quote", `"`, `"`},
+		{"lone single quote", `'`, `'`},
+		{"object with lone double quote key", `{":1}`, map[string]any{`"`: int64(1)}},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What

`FunctionGemmaParser.parseValue` strips an escaped value with `value[8:len(value)-8]` after checking that it both starts and ends with `<escape>`. A single `<escape>` satisfies both checks at once, so the slice becomes `value[8:0]`:

```
panic: runtime error: slice bounds out of range [8:0]

github.com/ollama/ollama/model/parsers.(*FunctionGemmaParser).parseValue
	model/parsers/functiongemma.go:263
github.com/ollama/ollama/model/parsers.(*FunctionGemmaParser).parseArguments
	model/parsers/functiongemma.go:202
github.com/ollama/ollama/model/parsers.(*FunctionGemmaParser).Add
	model/parsers/functiongemma.go:65
```

`<start_function_call>call:get_weather{city:<escape>}<end_function_call>` is enough to reach it.

`parseOlmo3Value` and `parseOlmo3Object` have the same shape one character wide: a value or a key that is a single `"` or `'` matches as prefix and suffix at once and slices `[1:0]`. `<function_calls>get_weather(location=")</function_calls>` reaches that one.

These parsers are already written to survive malformed output; `Olmo3Parser.eat` logs the parse error and carries on. But `Add` runs on the streaming goroutine started in `server/routes.go`, which has no `recover`, so a model that emits an unterminated marker takes the whole server process down instead of degrading to text.

## Fix

Require an opening and a closing delimiter before stripping. An unbalanced marker now falls through to the plain-string branch and the argument keeps its literal text.

## Testing

Added cases to the existing tables: an unterminated `<escape>` both at top level and nested in an object argument, a lone `"` and a lone `'` value, a lone-quote object key, and an olmo3 tool call with an unterminated quote. Each one panics before this change and passes after.

- `go test ./model/...`
- `go vet ./model/parsers/...`
