### PR TITLE
cmd: support suggesting cloud tag for ollama launch

### DIFF
--- a/cmd/cloud_suggest.go
+++ b/cmd/cloud_suggest.go
@@ -75,12 +75,21 @@ func cloudSuggestionName(name string, insecure bool) (string, bool) {
 	return ref.Base + ":cloud", true
 }
 
+// cloudSuggestionRetryCommand renders the command hinted at in
+// non-interactive errors for the plain CLI verbs ("run" and "pull").
+func cloudSuggestionRetryCommand(verb string) func(string) string {
+	return func(cloudName string) string {
+		return "ollama " + verb + " " + cloudName
+	}
+}
+
 // pullWithCloudSuggestion pulls `name`, and if the model's default tag
 // doesn't exist but a ":cloud" tag does, offers it: either interactively via
 // a confirmation prompt, or by augmenting the returned error when not at a
-// terminal. It returns the name that was actually pulled. `verb` is the
-// user-facing command ("run" or "pull") used in the hint text.
-func pullWithCloudSuggestion(ctx context.Context, client *api.Client, name string, insecure bool, verb string) (string, error) {
+// terminal. It returns the name that was actually pulled. `retryCommand`
+// renders the command suggested in the non-interactive hint for a given
+// cloud model name.
+func pullWithCloudSuggestion(ctx context.Context, client *api.Client, name string, insecure bool, retryCommand func(cloudName string) string) (string, error) {
 	// If a suggestion prompt may follow a failed pull, erase the failed
 	// attempt's progress display instead of leaving its "pulling manifest"
 	// line to stack up against the accepted pull's identical one.
@@ -105,7 +114,10 @@ func pullWithCloudSuggestion(ctx context.Context, client *api.Client, name strin
 	}
 
 	if !isInteractiveTerminal() {
-		return "", fmt.Errorf("%w\n\n%q is available as a cloud model. Try:\n  ollama %s %s", pullErr, cloudName, verb, cloudName)
+		if retryCommand == nil {
+			return "", fmt.Errorf("%w\n\n%q is available as a cloud model", pullErr, cloudName)
+		}
+		return "", fmt.Errorf("%w\n\n%q is available as a cloud model. Try:\n  %s", pullErr, cloudName, retryCommand(cloudName))
 	}
 
 	accepted, err := confirmCloudSuggestion(fmt.Sprintf("Did you mean %q?", cloudName))

--- a/cmd/cloud_suggest_test.go
+++ b/cmd/cloud_suggest_test.go
@@ -362,6 +362,53 @@ func TestPullHandler_CloudSuggestionUnrelatedError(t *testing.T) {
 	}
 }
 
+func TestLaunchCloudSuggestPullHookWired(t *testing.T) {
+	server := newCloudSuggestServer(t)
+	stubCloudSuggest(t, true, func(string) (bool, error) { return true, nil })
+
+	if launch.DefaultCloudSuggestPull == nil {
+		t.Fatal("launch.DefaultCloudSuggestPull is not wired")
+	}
+
+	client, err := api.ClientFromEnvironment()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resolved, err := launch.DefaultCloudSuggestPull(t.Context(), client, "some-model", func(cloudName string) string {
+		return "ollama launch claude --model " + cloudName
+	})
+	if err != nil {
+		t.Fatalf("DefaultCloudSuggestPull returned error: %v", err)
+	}
+	if resolved != "some-model:cloud" {
+		t.Fatalf("resolved = %q, want %q", resolved, "some-model:cloud")
+	}
+	if want := []string{"some-model", "some-model:cloud"}; !slices.Equal(server.pullModels, want) {
+		t.Fatalf("pulled models = %v, want %v", server.pullModels, want)
+	}
+}
+
+func TestLaunchCloudSuggestPullHookNonInteractiveHint(t *testing.T) {
+	newCloudSuggestServer(t)
+	stubCloudSuggest(t, false, nil)
+
+	client, err := api.ClientFromEnvironment()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = launch.DefaultCloudSuggestPull(t.Context(), client, "some-model", func(cloudName string) string {
+		return "ollama launch claude --model " + cloudName
+	})
+	if err == nil {
+		t.Fatal("DefaultCloudSuggestPull returned nil, want an error")
+	}
+	if !strings.Contains(err.Error(), "ollama launch claude --model some-model:cloud") {
+		t.Fatalf("error = %q, want it to hint at the launch retry command", err)
+	}
+}
+
 func TestRunHandler_CloudSuggestionAccepted_RunsCloudModel(t *testing.T) {
 	server := newCloudSuggestServer(t)
 	stubCloudSuggest(t, true, func(string) (bool, error) { return true, nil })

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -94,6 +94,10 @@ func init() {
 
 	launch.DefaultConfirmPrompt = tui.RunConfirmWithOptions
 
+	launch.DefaultCloudSuggestPull = func(ctx context.Context, client *api.Client, model string, retryCommand func(string) string) (string, error) {
+		return pullWithCloudSuggestion(ctx, client, model, false, retryCommand)
+	}
+
 	launch.DefaultSpinner = tui.RunSpinner
 }
 
@@ -724,7 +728,7 @@ func showOrPullModel(cmd *cobra.Command, client *api.Client, name string, insecu
 		return nil, name, err
 	}
 
-	resolved, err := pullWithCloudSuggestion(cmd.Context(), client, name, insecure, verb)
+	resolved, err := pullWithCloudSuggestion(cmd.Context(), client, name, insecure, cloudSuggestionRetryCommand(verb))
 	if err != nil {
 		return nil, name, err
 	}
@@ -1523,7 +1527,7 @@ func PullHandler(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	_, err = pullWithCloudSuggestion(cmd.Context(), client, args[0], insecure, "pull")
+	_, err = pullWithCloudSuggestion(cmd.Context(), client, args[0], insecure, cloudSuggestionRetryCommand("pull"))
 	return err
 }
 

--- a/cmd/launch/cloud_suggest_test.go
+++ b/cmd/launch/cloud_suggest_test.go
@@ -1,0 +1,87 @@
+package launch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/ollama/ollama/api"
+)
+
+func TestLaunchRetryCommand(t *testing.T) {
+	if got, want := launchRetryCommand("claude")("some-model:cloud"), "ollama launch claude --model some-model:cloud"; got != want {
+		t.Fatalf("launchRetryCommand(claude) = %q, want %q", got, want)
+	}
+	if got, want := launchRetryCommand("")("some-model:cloud"), "ollama launch --model some-model:cloud"; got != want {
+		t.Fatalf("launchRetryCommand(\"\") = %q, want %q", got, want)
+	}
+}
+
+func newMissingModelClient(t *testing.T) *api.Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/show" {
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprintf(w, `{"error":"model not found"}`)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	u, _ := url.Parse(srv.URL)
+	return api.NewClient(u, srv.Client())
+}
+
+func TestShowOrPullWithPolicy_CloudSuggestionRename(t *testing.T) {
+	client := newMissingModelClient(t)
+
+	oldHook := DefaultCloudSuggestPull
+	t.Cleanup(func() { DefaultCloudSuggestPull = oldHook })
+
+	var hookModel, hookRetry string
+	DefaultCloudSuggestPull = func(ctx context.Context, c *api.Client, model string, retryCommand func(string) string) (string, error) {
+		hookModel = model
+		if retryCommand != nil {
+			hookRetry = retryCommand(model + ":cloud")
+		}
+		return model + ":cloud", nil
+	}
+
+	resolved, err := showOrPullWithPolicy(context.Background(), client, "some-model", missingModelAutoPull, false, launchRetryCommand("claude"))
+	if err != nil {
+		t.Fatalf("showOrPullWithPolicy returned error: %v", err)
+	}
+	if resolved != "some-model:cloud" {
+		t.Fatalf("resolved = %q, want %q", resolved, "some-model:cloud")
+	}
+	if hookModel != "some-model" {
+		t.Fatalf("hook model = %q, want %q", hookModel, "some-model")
+	}
+	if want := "ollama launch claude --model some-model:cloud"; hookRetry != want {
+		t.Fatalf("hook retry command = %q, want %q", hookRetry, want)
+	}
+}
+
+func TestShowOrPullWithPolicy_CloudSuggestionErrorWrapped(t *testing.T) {
+	client := newMissingModelClient(t)
+
+	oldHook := DefaultCloudSuggestPull
+	t.Cleanup(func() { DefaultCloudSuggestPull = oldHook })
+
+	DefaultCloudSuggestPull = func(ctx context.Context, c *api.Client, model string, retryCommand func(string) string) (string, error) {
+		return "", errors.New("boom")
+	}
+
+	_, err := showOrPullWithPolicy(context.Background(), client, "some-model", missingModelAutoPull, false, nil)
+	if err == nil {
+		t.Fatal("showOrPullWithPolicy returned nil, want an error")
+	}
+	if !strings.Contains(err.Error(), "failed to pull some-model") || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("error = %q, want it to wrap the hook error with the pull context", err)
+	}
+}

--- a/cmd/launch/integrations_test.go
+++ b/cmd/launch/integrations_test.go
@@ -921,7 +921,7 @@ func TestShowOrPull_ModelExists(t *testing.T) {
 	u, _ := url.Parse(srv.URL)
 	client := api.NewClient(u, srv.Client())
 
-	err := showOrPullWithPolicy(context.Background(), client, "test-model", missingModelPromptPull, false)
+	_, err := showOrPullWithPolicy(context.Background(), client, "test-model", missingModelPromptPull, false, nil)
 	if err != nil {
 		t.Errorf("showOrPull should return nil when model exists, got: %v", err)
 	}
@@ -941,7 +941,7 @@ func TestShowOrPullWithPolicy_ModelExists(t *testing.T) {
 	u, _ := url.Parse(srv.URL)
 	client := api.NewClient(u, srv.Client())
 
-	err := showOrPullWithPolicy(context.Background(), client, "test-model", missingModelFail, false)
+	_, err := showOrPullWithPolicy(context.Background(), client, "test-model", missingModelFail, false, nil)
 	if err != nil {
 		t.Errorf("showOrPullWithPolicy should return nil when model exists, got: %v", err)
 	}
@@ -974,7 +974,7 @@ func TestShowOrPullWithPolicy_ModelNotFound_FailDoesNotPromptOrPull(t *testing.T
 	u, _ := url.Parse(srv.URL)
 	client := api.NewClient(u, srv.Client())
 
-	err := showOrPullWithPolicy(context.Background(), client, "missing-model", missingModelFail, false)
+	_, err := showOrPullWithPolicy(context.Background(), client, "missing-model", missingModelFail, false, nil)
 	if err == nil {
 		t.Fatal("expected fail policy to return an error for missing model")
 	}
@@ -1015,7 +1015,7 @@ func TestShowOrPullWithPolicy_ModelNotFound_PromptPolicyPulls(t *testing.T) {
 	u, _ := url.Parse(srv.URL)
 	client := api.NewClient(u, srv.Client())
 
-	err := showOrPullWithPolicy(context.Background(), client, "missing-model", missingModelPromptPull, false)
+	_, err := showOrPullWithPolicy(context.Background(), client, "missing-model", missingModelPromptPull, false, nil)
 	if err != nil {
 		t.Fatalf("expected prompt policy to pull and succeed, got %v", err)
 	}
@@ -1051,7 +1051,7 @@ func TestShowOrPullWithPolicy_ModelNotFound_AutoPullPolicyPullsWithoutPrompt(t *
 	u, _ := url.Parse(srv.URL)
 	client := api.NewClient(u, srv.Client())
 
-	err := showOrPullWithPolicy(context.Background(), client, "missing-model", missingModelAutoPull, false)
+	_, err := showOrPullWithPolicy(context.Background(), client, "missing-model", missingModelAutoPull, false, nil)
 	if err != nil {
 		t.Fatalf("expected auto-pull policy to pull and succeed, got %v", err)
 	}
@@ -1092,7 +1092,7 @@ func TestShowOrPullWithPolicy_CloudModelNotFound_FailsEarlyForAllPolicies(t *tes
 			u, _ := url.Parse(srv.URL)
 			client := api.NewClient(u, srv.Client())
 
-			err := showOrPullWithPolicy(context.Background(), client, "glm-5.1:cloud", policy, true)
+			_, err := showOrPullWithPolicy(context.Background(), client, "glm-5.1:cloud", policy, true, nil)
 			if err == nil {
 				t.Fatalf("expected cloud model not-found error for policy %d", policy)
 			}
@@ -1133,7 +1133,7 @@ func TestShowOrPullWithPolicy_CloudModelShowUnavailableAllowsSelection(t *testin
 	u, _ := url.Parse(srv.URL)
 	client := api.NewClient(u, srv.Client())
 
-	if err := showOrPullWithPolicy(context.Background(), client, "glm-5.1:cloud", missingModelFail, true); err != nil {
+	if _, err := showOrPullWithPolicy(context.Background(), client, "glm-5.1:cloud", missingModelFail, true, nil); err != nil {
 		t.Fatalf("showOrPullWithPolicy returned error: %v", err)
 	}
 }
@@ -1146,7 +1146,7 @@ func TestShowOrPullWithPolicy_CloudModelShowUnreachableAllowsSelection(t *testin
 	client := api.NewClient(u, srv.Client())
 	srv.Close()
 
-	if err := showOrPullWithPolicy(context.Background(), client, "glm-5.1:cloud", missingModelFail, true); err != nil {
+	if _, err := showOrPullWithPolicy(context.Background(), client, "glm-5.1:cloud", missingModelFail, true, nil); err != nil {
 		t.Fatalf("showOrPullWithPolicy returned error: %v", err)
 	}
 }
@@ -1183,7 +1183,7 @@ func TestShowOrPullWithPolicy_CloudModelDisabled_FailsWithCloudDisabledError(t *
 			u, _ := url.Parse(srv.URL)
 			client := api.NewClient(u, srv.Client())
 
-			err := showOrPullWithPolicy(context.Background(), client, "glm-5.1:cloud", policy, true)
+			_, err := showOrPullWithPolicy(context.Background(), client, "glm-5.1:cloud", policy, true, nil)
 			if err == nil {
 				t.Fatalf("expected cloud disabled error for policy %d", policy)
 			}
@@ -1208,7 +1208,7 @@ func TestShowOrPull_ModelNotFound_NoTerminal(t *testing.T) {
 	client := api.NewClient(u, srv.Client())
 
 	// confirmPrompt will fail in test (no terminal), so showOrPull should return an error
-	err := showOrPullWithPolicy(context.Background(), client, "missing-model", missingModelPromptPull, false)
+	_, err := showOrPullWithPolicy(context.Background(), client, "missing-model", missingModelPromptPull, false, nil)
 	if err == nil {
 		t.Error("showOrPull should return error when model not found and no terminal available")
 	}
@@ -1233,7 +1233,7 @@ func TestShowOrPull_ShowCalledWithCorrectModel(t *testing.T) {
 	u, _ := url.Parse(srv.URL)
 	client := api.NewClient(u, srv.Client())
 
-	_ = showOrPullWithPolicy(context.Background(), client, "qwen3.5", missingModelPromptPull, false)
+	_, _ = showOrPullWithPolicy(context.Background(), client, "qwen3.5", missingModelPromptPull, false, nil)
 	if receivedModel != "qwen3.5" {
 		t.Errorf("expected Show to be called with %q, got %q", "qwen3.5", receivedModel)
 	}
@@ -1269,7 +1269,7 @@ func TestShowOrPull_ModelNotFound_ConfirmYes_Pulls(t *testing.T) {
 	u, _ := url.Parse(srv.URL)
 	client := api.NewClient(u, srv.Client())
 
-	err := showOrPullWithPolicy(context.Background(), client, "missing-model", missingModelPromptPull, false)
+	_, err := showOrPullWithPolicy(context.Background(), client, "missing-model", missingModelPromptPull, false, nil)
 	if err != nil {
 		t.Errorf("ShowOrPull should succeed after pull, got: %v", err)
 	}
@@ -1301,7 +1301,7 @@ func TestShowOrPull_ModelNotFound_ConfirmNo_Cancelled(t *testing.T) {
 	u, _ := url.Parse(srv.URL)
 	client := api.NewClient(u, srv.Client())
 
-	err := showOrPullWithPolicy(context.Background(), client, "missing-model", missingModelPromptPull, false)
+	_, err := showOrPullWithPolicy(context.Background(), client, "missing-model", missingModelPromptPull, false, nil)
 	if err == nil {
 		t.Error("ShowOrPull should return error when user declines")
 	}
@@ -1335,7 +1335,7 @@ func TestShowOrPull_CloudModel_NotFoundDoesNotPull(t *testing.T) {
 	u, _ := url.Parse(srv.URL)
 	client := api.NewClient(u, srv.Client())
 
-	err := showOrPullWithPolicy(context.Background(), client, "glm-5.1:cloud", missingModelPromptPull, true)
+	_, err := showOrPullWithPolicy(context.Background(), client, "glm-5.1:cloud", missingModelPromptPull, true, nil)
 	if err == nil {
 		t.Error("ShowOrPull should return not-found error for cloud model")
 	}
@@ -1375,7 +1375,7 @@ func TestShowOrPull_CloudLegacySuffix_NotFoundDoesNotPull(t *testing.T) {
 	u, _ := url.Parse(srv.URL)
 	client := api.NewClient(u, srv.Client())
 
-	err := showOrPullWithPolicy(context.Background(), client, "gpt-oss:20b-cloud", missingModelPromptPull, true)
+	_, err := showOrPullWithPolicy(context.Background(), client, "gpt-oss:20b-cloud", missingModelPromptPull, true, nil)
 	if err == nil {
 		t.Error("ShowOrPull should return not-found error for cloud model")
 	}

--- a/cmd/launch/launch.go
+++ b/cmd/launch/launch.go
@@ -693,9 +693,11 @@ func (c *launcherClient) launcherManagedAutodiscoveryState(ctx context.Context, 
 func (c *launcherClient) resolveRunModel(ctx context.Context, req RunModelRequest) (string, error) {
 	current := config.LastModel()
 	if !req.ForcePicker && current != "" && c.policy.Confirm == LaunchConfirmAutoApprove && !isInteractiveSession() {
-		if err := c.ensureModelsReady(ctx, []string{current}); err != nil {
+		ready, err := c.ensureModelsReady(ctx, []string{current})
+		if err != nil {
 			return "", err
 		}
+		current = ready[0]
 		fmt.Fprintf(os.Stderr, "Headless mode: auto-selected last used model %q\n", current)
 		return current, nil
 	}
@@ -706,12 +708,12 @@ func (c *launcherClient) resolveRunModel(ctx context.Context, req RunModelReques
 			return "", err
 		}
 		if usable {
-			if err := c.ensureModelsReady(ctx, []string{current}); err != nil {
+			if ready, err := c.ensureModelsReady(ctx, []string{current}); err != nil {
 				if !errors.Is(err, errDeprecatedLaunchModelDeclined) {
 					return "", err
 				}
 			} else {
-				return current, nil
+				return ready[0], nil
 			}
 		}
 	}
@@ -757,7 +759,7 @@ func (c *launcherClient) launchEditorIntegration(ctx context.Context, name strin
 		}
 		models = selected
 	} else if len(models) > 0 {
-		if err := c.ensureModelsReadyFor(ctx, models[:1], runner.String(), name); err != nil {
+		if ready, err := c.ensureModelsReadyFor(ctx, models[:1], runner.String(), name); err != nil {
 			if !errors.Is(err, errDeprecatedLaunchModelDeclined) || req.ModelOverride != "" {
 				return err
 			}
@@ -767,6 +769,8 @@ func (c *launcherClient) launchEditorIntegration(ctx context.Context, name strin
 			}
 			models = selected
 			needsConfigure = true
+		} else {
+			models[0] = ready[0]
 		}
 	}
 
@@ -995,7 +999,7 @@ func (c *launcherClient) resolveSingleIntegrationTarget(ctx context.Context, nam
 		}
 		target = selected
 	} else if !skipReadiness {
-		if err := c.ensureModelsReadyFor(ctx, []string{target}, runner.String(), name); err != nil {
+		if ready, err := c.ensureModelsReadyFor(ctx, []string{target}, runner.String(), name); err != nil {
 			if !errors.Is(err, errDeprecatedLaunchModelDeclined) {
 				return "", false, err
 			}
@@ -1007,6 +1011,8 @@ func (c *launcherClient) resolveSingleIntegrationTarget(ctx context.Context, nam
 			}
 			target = selected
 			needsConfigure = true
+		} else {
+			target = ready[0]
 		}
 	}
 
@@ -1079,7 +1085,8 @@ func (c *launcherClient) selectSingleModelWithSelectorReady(ctx context.Context,
 			return "", ErrCancelled
 		}
 		if ensureReady {
-			if err := c.ensureModelsReadyFor(ctx, []string{selected}, label, commandName); err != nil {
+			ready, err := c.ensureModelsReadyFor(ctx, []string{selected}, label, commandName)
+			if err != nil {
 				if errors.Is(err, errUpgradeCancelled) {
 					current = selected
 					continue
@@ -1090,6 +1097,7 @@ func (c *launcherClient) selectSingleModelWithSelectorReady(ctx context.Context,
 				}
 				return "", err
 			}
+			selected = ready[0]
 		}
 		return selected, nil
 	}
@@ -1242,19 +1250,23 @@ func (c *launcherClient) requestRecommendations(ctx context.Context) ([]ModelIte
 	return items, nil
 }
 
-func (c *launcherClient) ensureModelsReady(ctx context.Context, models []string) error {
+func (c *launcherClient) ensureModelsReady(ctx context.Context, models []string) ([]string, error) {
 	return c.ensureModelsReadyFor(ctx, models, "ollama launch", "")
 }
 
-func (c *launcherClient) ensureModelsReadyFor(ctx context.Context, models []string, label, commandName string) error {
+// ensureModelsReadyFor returns the models to continue with, which differ
+// from the requested ones when a missing default tag was resolved to its
+// ":cloud" variant (see showOrPullWithPolicy).
+func (c *launcherClient) ensureModelsReadyFor(ctx context.Context, models []string, label, commandName string) ([]string, error) {
 	models = dedupeModelList(models)
 	if len(models) == 0 {
-		return nil
+		return models, nil
 	}
 	cloudRec, localRec := c.agentCapableRecommendations(ctx)
 
+	retryCommand := launchRetryCommand(commandName)
 	cloudModels := make(map[string]bool, len(models))
-	for _, model := range models {
+	for i, model := range models {
 		if prompt := deprecatedLaunchModelPrompt(model, label, commandName, cloudRec, localRec); prompt != "" {
 			ok, err := ConfirmPromptWithOptions(prompt, ConfirmOptions{
 				YesLabel: "Launch anyway",
@@ -1262,24 +1274,34 @@ func (c *launcherClient) ensureModelsReadyFor(ctx context.Context, models []stri
 				Default:  ConfirmDefaultNo,
 			})
 			if err != nil {
-				return err
+				return nil, err
 			}
 			if !ok {
-				return errDeprecatedLaunchModelDeclined
+				return nil, errDeprecatedLaunchModelDeclined
 			}
 		}
 		isCloudModel := isCloudModelName(model)
 		if isCloudModel {
 			cloudModels[model] = true
 			if err := c.ensureCloudModelAccess(ctx, model); err != nil {
-				return err
+				return nil, err
 			}
 		}
-		if err := showOrPullWithPolicy(ctx, c.apiClient, model, c.policy.missingModelPolicy(), isCloudModel); err != nil {
-			return err
+		resolved, err := showOrPullWithPolicy(ctx, c.apiClient, model, c.policy.missingModelPolicy(), isCloudModel, retryCommand)
+		if err != nil {
+			return nil, err
+		}
+		if resolved != model {
+			// The user accepted the ":cloud" variant, so apply the cloud
+			// bookkeeping the original name skipped.
+			models[i] = resolved
+			cloudModels[resolved] = true
+			if err := c.ensureCloudModelAccess(ctx, resolved); err != nil {
+				return nil, err
+			}
 		}
 	}
-	return ensureAuth(ctx, c.apiClient, cloudModels, models)
+	return models, ensureAuth(ctx, c.apiClient, cloudModels, models)
 }
 
 func (c *launcherClient) agentCapableRecommendations(ctx context.Context) (cloud, local string) {
@@ -1327,7 +1349,8 @@ func (c *launcherClient) selectReadyModelsForSave(ctx context.Context, selected 
 	skipped := make([]skippedModel, 0, len(selected))
 
 	for _, model := range selected {
-		if err := c.ensureModelsReadyFor(ctx, []string{model}, label, commandName); err != nil {
+		ready, err := c.ensureModelsReadyFor(ctx, []string{model}, label, commandName)
+		if err != nil {
 			if errors.Is(err, errUpgradeCancelled) {
 				return nil, nil, err
 			}
@@ -1343,7 +1366,7 @@ func (c *launcherClient) selectReadyModelsForSave(ctx context.Context, selected 
 			})
 			continue
 		}
-		accepted = append(accepted, model)
+		accepted = append(accepted, ready[0])
 	}
 
 	return accepted, skipped, nil

--- a/cmd/launch/models.go
+++ b/cmd/launch/models.go
@@ -253,46 +253,78 @@ func ensureCloudAuth(ctx context.Context, client *api.Client, modelList string) 
 	}
 }
 
-// showOrPullWithPolicy checks if a model exists and applies the provided missing-model policy.
-func showOrPullWithPolicy(ctx context.Context, client *api.Client, model string, policy missingModelPolicy, isCloudModel bool) error {
+// DefaultCloudSuggestPull, when set (the cmd package wires it up), pulls a
+// model and, if its default tag doesn't exist but a ":cloud" tag does,
+// offers the cloud model instead. It returns the name that was actually
+// pulled. retryCommand renders the command suggested in non-interactive
+// error hints for a given cloud model name.
+var DefaultCloudSuggestPull func(ctx context.Context, client *api.Client, model string, retryCommand func(cloudName string) string) (string, error)
+
+// launchRetryCommand builds the retry command hinted at when a cloud
+// suggestion is raised outside an interactive terminal.
+func launchRetryCommand(commandName string) func(string) string {
+	return func(cloudName string) string {
+		if commandName != "" {
+			return fmt.Sprintf("ollama launch %s --model %s", commandName, cloudName)
+		}
+		return fmt.Sprintf("ollama launch --model %s", cloudName)
+	}
+}
+
+// showOrPullWithPolicy checks if a model exists and applies the provided
+// missing-model policy. It returns the model name to continue with, which
+// differs from the requested one when a missing default tag was resolved to
+// its ":cloud" variant (see DefaultCloudSuggestPull).
+func showOrPullWithPolicy(ctx context.Context, client *api.Client, model string, policy missingModelPolicy, isCloudModel bool, retryCommand func(string) string) (string, error) {
 	if _, err := client.Show(ctx, &api.ShowRequest{Model: model}); err == nil {
-		return nil
+		return model, nil
 	} else {
 		if isCloudModel {
 			if disabled, known := cloudStatusDisabled(ctx, client); known && disabled {
-				return errors.New(internalcloud.DisabledError("remote inference is unavailable"))
+				return "", errors.New(internalcloud.DisabledError("remote inference is unavailable"))
 			}
 			var statusErr api.StatusError
 			if errors.As(err, &statusErr) && statusErr.StatusCode == http.StatusNotFound {
-				return fmt.Errorf("model %q not found", model)
+				return "", fmt.Errorf("model %q not found", model)
 			}
-			return nil
+			return model, nil
 		}
 
 		var statusErr api.StatusError
 		if !errors.As(err, &statusErr) || statusErr.StatusCode != http.StatusNotFound {
-			return err
+			return "", err
 		}
 	}
 
 	switch policy {
 	case missingModelAutoPull:
-		return pullMissingModel(ctx, client, model)
+		return pullOrSuggestCloud(ctx, client, model, retryCommand)
 	case missingModelFail:
-		return fmt.Errorf("model %q not found; run 'ollama pull %s' first, or use --yes to auto-pull", model, model)
+		return "", fmt.Errorf("model %q not found; run 'ollama pull %s' first, or use --yes to auto-pull", model, model)
 	default:
-		return confirmAndPull(ctx, client, model)
+		return confirmAndPull(ctx, client, model, retryCommand)
 	}
 }
 
-func confirmAndPull(ctx context.Context, client *api.Client, model string) error {
+func confirmAndPull(ctx context.Context, client *api.Client, model string, retryCommand func(string) string) (string, error) {
 	if ok, err := ConfirmPrompt(fmt.Sprintf("Download %s?", model)); err != nil {
-		return err
+		return "", err
 	} else if !ok {
-		return errCancelled
+		return "", errCancelled
 	}
 	fmt.Fprintf(os.Stderr, "\n")
-	return pullMissingModel(ctx, client, model)
+	return pullOrSuggestCloud(ctx, client, model, retryCommand)
+}
+
+func pullOrSuggestCloud(ctx context.Context, client *api.Client, model string, retryCommand func(string) string) (string, error) {
+	if DefaultCloudSuggestPull == nil {
+		return model, pullMissingModel(ctx, client, model)
+	}
+	resolved, err := DefaultCloudSuggestPull(ctx, client, model, retryCommand)
+	if err != nil {
+		return "", fmt.Errorf("failed to pull %s: %w", model, err)
+	}
+	return resolved, nil
 }
 
 func pullMissingModel(ctx context.Context, client *api.Client, model string) error {


### PR DESCRIPTION
Follow-on from #17483 that adds similar support to ollama launch.

Now something like `ollama launch claude --model=kimi-k3` will prompt if you want the cloud model. Same caveats as in #17483, in the future we may want to play with defaults or persist the choice, etc., but this is designed to be a quick change to iterate on.