### PR TITLE
mlxrunner: reuse the cache across non-thinking turns on MTP models

### DIFF
--- a/x/mlxrunner/mtp.go
+++ b/x/mlxrunner/mtp.go
@@ -133,13 +133,10 @@ func (d *mtpDraftSession) queueCacheWrites(tokens, hiddens *mlx.Array) {
 	}
 }
 
-// flush writes the pending pairs to the draft caches in one head forward,
-// dropping speculative entries past the committed range first and holding
-// the last row's logits and projected hidden for the next proposal chain.
+// flush drops speculative entries past the committed range from the draft
+// caches, then writes the pending pairs in one head forward, holding the
+// last row's logits and projected hidden for the next proposal chain.
 func (d *mtpDraftSession) flush() {
-	if len(d.pendingTokens) == 0 {
-		return
-	}
 	spec := d.drafter.spec
 	for _, c := range spec.draftKV {
 		if c.Offset() > d.committedDraftOffset {
@@ -147,6 +144,10 @@ func (d *mtpDraftSession) flush() {
 				panic(fmt.Sprintf("mtp: draft cache rewind to %d failed", d.committedDraftOffset))
 			}
 		}
+	}
+
+	if len(d.pendingTokens) == 0 {
+		return
 	}
 
 	ids := mlx.Concatenate(d.pendingTokens, 1)

--- a/x/mlxrunner/mtp_test.go
+++ b/x/mlxrunner/mtp_test.go
@@ -330,8 +330,9 @@ func TestAcceptMTPDraftsGreedyMismatch(t *testing.T) {
 func TestAcceptMTPDraftsGreedyEOS(t *testing.T) {
 	skipIfNoMLX(t)
 	// The second accepted draft token is EOS: it is recorded but stops
-	// generation and no bonus token is produced. The EOS's own KV is rolled
-	// back so the caches rest one token behind the recorded outputs.
+	// generation and no bonus token is produced. The round commits one below
+	// the last content token — the EOS and the token whose key packs it stay
+	// uncommitted — so a continuation restores exactly.
 	const eos int32 = 6
 	predict := map[int32]int32{1: 2, 2: eos, eos: 0}
 	r := mtpTestRunner(t, predict, []int32{eos}, sampler.Options{})
@@ -360,11 +361,11 @@ func TestAcceptMTPDraftsGreedyEOS(t *testing.T) {
 	if len(results) != accepted {
 		t.Fatalf("results has %d tokens, want exactly the %d accepted with no bonus after EOS", len(results), accepted)
 	}
-	if position != 2 {
-		t.Fatalf("position = %d, want 2 (current + kept draft, EOS dropped)", position)
+	if position != 1 {
+		t.Fatalf("position = %d, want 1 (one below the last content token)", position)
 	}
-	if got := caches[0].Offset(); got != 2 {
-		t.Fatalf("cache offset = %d, want 2 (one behind the recorded outputs, EOS dropped)", got)
+	if got := caches[0].Offset(); got != 1 {
+		t.Fatalf("cache offset = %d, want 1 (one below the last content token)", got)
 	}
 }
 
@@ -745,12 +746,12 @@ func TestDecodeKVDraft(t *testing.T) {
 		t.Fatalf("speculation engine not built around the draft caches")
 	}
 	pinDraftLimit(spec, 4)
-	defer spec.close()
 	d := spec.decoder(mlx.FromValues([]int32{1}, 1), position)
 	if err := r.decode(context.Background(), req, session, d, 0); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
 	d.close()
+	spec.close()
 
 	content, final := collectResponses(ch)
 	if content != "23456" {
@@ -763,13 +764,13 @@ func TestDecodeKVDraft(t *testing.T) {
 		t.Fatalf("session outputs = %v, want %v", session.outputs, got)
 	}
 
-	// All caches rest together at the trie frontier: the prompt token plus
-	// five generated tokens; the EOS's KV is never committed.
-	if got := caches[0].Offset(); got != 6 {
-		t.Fatalf("target offset = %d, want 6", got)
+	// All caches are committed together one below the last content token:
+	// the EOS and the token whose key packs it stay uncommitted.
+	if got := caches[0].Offset(); got != 5 {
+		t.Fatalf("target offset = %d, want 5", got)
 	}
-	if got := caches[1].Offset(); got != 6 {
-		t.Fatalf("draft cache offset = %d, want 6 (lockstep with target)", got)
+	if got := caches[1].Offset(); got != 5 {
+		t.Fatalf("draft cache offset = %d, want 5 (lockstep with target)", got)
 	}
 
 	// Every committed draft slot S fuses look-ahead token x_{S+1} with the
@@ -781,18 +782,18 @@ func TestDecodeKVDraft(t *testing.T) {
 	// consumes the catch-up's held logits — the four-token draft makes only
 	// three head calls before the rebuild.
 	wantExtends := []extendCall{
-		{offset: 0, ids: []int32{2, 3}, hiddens: []int32{2, 3}},                 // parked pairs flushed at the first proposal
-		{offset: 2, ids: []int32{4}, hiddens: []int32{-1}},                      // speculative step 2 (held projection)
-		{offset: 3, ids: []int32{5}, hiddens: []int32{-1}},                      // speculative step 3 (projection)
-		{offset: 4, ids: []int32{6}, hiddens: []int32{-1}},                      // speculative step 4 (projection)
-		{offset: 2, ids: []int32{4, 5, 6, eos}, hiddens: []int32{4, 5, 6, eos}}, // committed pairs from the validated run + finish
+		{offset: 0, ids: []int32{2, 3}, hiddens: []int32{2, 3}},       // parked pairs flushed at the first proposal
+		{offset: 2, ids: []int32{4}, hiddens: []int32{-1}},            // speculative step 2 (held projection)
+		{offset: 3, ids: []int32{5}, hiddens: []int32{-1}},            // speculative step 3 (projection)
+		{offset: 4, ids: []int32{6}, hiddens: []int32{-1}},            // speculative step 4 (projection)
+		{offset: 2, ids: []int32{4, 5, 6}, hiddens: []int32{4, 5, 6}}, // committed pairs from the validated run; nothing names the EOS
 	}
 	if !reflect.DeepEqual(draft.extends, wantExtends) {
 		t.Fatalf("draft extends = %+v, want %+v", draft.extends, wantExtends)
 	}
 
 	// The committed draft KV holds the look-ahead tokens, one per slot.
-	if got, want := caches[1].(*fakeRewindableCache).tokens, []int32{2, 3, 4, 5, 6, eos}; !slices.Equal(got, want) {
+	if got, want := caches[1].(*fakeRewindableCache).tokens, []int32{2, 3, 4, 5, 6}; !slices.Equal(got, want) {
 		t.Fatalf("draft cache = %v, want %v", got, want)
 	}
 }
@@ -826,12 +827,12 @@ func TestDecodeKVDraftRejectionRebuildsFromTarget(t *testing.T) {
 	}
 	spec := r.spec.open(req, caches)
 	pinDraftLimit(spec, 4)
-	defer spec.close()
 	d := spec.decoder(mlx.FromValues([]int32{1}, 1), position)
 	if err := r.decode(context.Background(), req, session, d, 0); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
 	d.close()
+	spec.close()
 
 	content, final := collectResponses(ch)
 	if content != "2345" {
@@ -857,13 +858,13 @@ func TestDecodeKVDraftRejectionRebuildsFromTarget(t *testing.T) {
 	// ...but the rejection rolled it back: both caches rest in lockstep at the
 	// target chain, and the committed draft KV holds only the validated
 	// look-ahead tokens.
-	if got := caches[0].Offset(); got != 5 {
-		t.Fatalf("target offset = %d, want 5", got)
+	if got := caches[0].Offset(); got != 4 {
+		t.Fatalf("target offset = %d, want 4", got)
 	}
-	if got := caches[1].Offset(); got != 5 {
-		t.Fatalf("draft cache offset = %d, want 5 (lockstep with target)", got)
+	if got := caches[1].Offset(); got != 4 {
+		t.Fatalf("draft cache offset = %d, want 4 (lockstep with target)", got)
 	}
-	if got, want := caches[1].(*fakeRewindableCache).tokens, []int32{2, 3, 4, 5, eos}; !slices.Equal(got, want) {
+	if got, want := caches[1].(*fakeRewindableCache).tokens, []int32{2, 3, 4, 5}; !slices.Equal(got, want) {
 		t.Fatalf("draft cache = %v, want %v (rejected proposals rolled back)", got, want)
 	}
 }
@@ -1012,12 +1013,12 @@ func TestCommittedRunBatchesPastFlushCap(t *testing.T) {
 	}
 }
 
-func TestRestoredPrefixRewritesBoundaryPair(t *testing.T) {
+func TestRestoredPrefixBuildsBoundaryPair(t *testing.T) {
 	skipIfNoMLX(t)
-	// A finished generation levels the draft with the target, its boundary
-	// pair naming the never-committed EOS. The next request restores one
-	// token below the match (the draft look-ahead), so the re-evaluated
-	// boundary token's report rewrites that pair with the token that follows.
+	// A finished generation is committed one below the last content token
+	// with no pair naming the EOS. A continuation's match is exactly that
+	// offset, so the restore no-ops; the re-evaluated boundary token's
+	// report builds the boundary pair with the token that actually follows.
 	const eos int32 = 7
 	predict := map[int32]int32{1: 2, 2: 3, 3: 4, 4: 5, 5: 6, 6: eos, eos: 0}
 	r := mtpTestRunner(t, predict, []int32{eos}, sampler.Options{})
@@ -1041,14 +1042,15 @@ func TestRestoredPrefixRewritesBoundaryPair(t *testing.T) {
 	d.close()
 	spec.close()
 
-	// The leveled rest: the draft's last pair names the EOS.
-	if got, want := caches[1].(*fakeRewindableCache).tokens, []int32{2, 3, 4, 5, 6, eos}; !slices.Equal(got, want) {
+	// After close, the draft holds pairs through the last committed token;
+	// nothing names the EOS.
+	if got, want := caches[1].(*fakeRewindableCache).tokens, []int32{2, 3, 4, 5, 6}; !slices.Equal(got, want) {
 		t.Fatalf("draft cache = %v, want %v", got, want)
 	}
 
-	// The next request matches the six stored tokens and restores at 5, as
-	// begin does for the draft look-ahead; its prefill re-evaluates token 6,
-	// and the token that follows is 1, not the EOS.
+	// The next request's match is the caches' offset, so the restore no-ops;
+	// its prefill re-evaluates token 6, and the token that follows is 1,
+	// not the EOS.
 	for _, c := range caches {
 		if !c.Restore(nil, 5) {
 			t.Fatal("restore to 5 failed")
@@ -1060,10 +1062,10 @@ func TestRestoredPrefixRewritesBoundaryPair(t *testing.T) {
 
 	last := draft.extends[len(draft.extends)-1]
 	if want := (extendCall{offset: 5, ids: []int32{1}, hiddens: []int32{eos}}); !reflect.DeepEqual(last, want) {
-		t.Fatalf("boundary rewrite = %+v, want %+v", last, want)
+		t.Fatalf("boundary pair = %+v, want %+v", last, want)
 	}
 	if got, want := caches[1].(*fakeRewindableCache).tokens, []int32{2, 3, 4, 5, 6, 1}; !slices.Equal(got, want) {
-		t.Fatalf("draft cache = %v, want %v (stale EOS pair rewritten)", got, want)
+		t.Fatalf("draft cache = %v, want %v (boundary pair built from the actual follower)", got, want)
 	}
 }
 
@@ -1142,15 +1144,15 @@ func TestDecodeParkedDraftResume(t *testing.T) {
 	wantExtends := []extendCall{
 		{offset: 0, ids: []int32{2, 3, 4}, hiddens: []int32{2, 3, 4}},
 		{offset: 3, ids: []int32{5}, hiddens: []int32{-1}},
-		{offset: 3, ids: []int32{5, 6, eos}, hiddens: []int32{5, 6, eos}},
+		{offset: 3, ids: []int32{5, 6}, hiddens: []int32{5, 6}},
 	}
 	if !reflect.DeepEqual(draft.extends, wantExtends) {
 		t.Fatalf("draft extends = %+v, want %+v", draft.extends, wantExtends)
 	}
-	if got, want := caches[0].Offset(), 6; got != want {
-		t.Fatalf("target offset = %d, want %d (EOS never forwarded)", got, want)
+	if got, want := caches[0].Offset(), 5; got != want {
+		t.Fatalf("target offset = %d, want %d (one below the last content token)", got, want)
 	}
-	if got, want := caches[1].Offset(), 6; got != want {
+	if got, want := caches[1].Offset(), 5; got != want {
 		t.Fatalf("draft cache offset = %d, want %d (lockstep with target)", got, want)
 	}
 }

--- a/x/mlxrunner/speculate.go
+++ b/x/mlxrunner/speculate.go
@@ -30,6 +30,8 @@ type drafter interface {
 	// leveling the draft caches with the target caches.
 	settle(next *mlx.Array)
 
+	// close writes any buffered committed reports through to the draft
+	// caches without completing the frontier pair.
 	close()
 }
 
@@ -109,6 +111,7 @@ type speculationSession struct {
 	spec    *speculation
 	drafter drafter
 	enabled bool // whether this request drafts; false parks (maintain-only)
+	done    bool // a round ended generation; settle flushes without pairing
 	limit   int  // current draft length
 	stats   specStats
 
@@ -182,9 +185,14 @@ func (s *speculationSession) committed(tokens, hiddens *mlx.Array, position int)
 }
 
 // settle completes the drafter's open frontier pair with next and writes
-// buffered reports through to the draft caches.
+// buffered reports through to the draft caches. After a round ending, next is
+// the terminator: no pair may name it, so nothing settles and the buffered
+// reports write through at close.
 func (s *speculationSession) settle(next *mlx.Array) {
 	if s == nil {
+		return
+	}
+	if s.done {
 		return
 	}
 	s.drafter.settle(next)
@@ -334,10 +342,10 @@ func (c *draftCandidates) Arrays() []*mlx.Array {
 }
 
 // scheduleSpeculation schedules per-token snapshots at offsets
-// [before, before+draftCount) on every cache, so the speculative forward
-// captures a rollback point before each draft token's write.
-func scheduleSpeculation(caches []cache.Cache, before, draftCount int) {
-	offsets := make([]int, draftCount)
+// [before, before+count) on every cache, so the round holds a rollback point
+// at every offset a commit can target.
+func scheduleSpeculation(caches []cache.Cache, before, count int) {
+	offsets := make([]int, count)
 	for i := range offsets {
 		offsets[i] = before + i
 	}
@@ -348,29 +356,30 @@ func scheduleSpeculation(caches []cache.Cache, before, draftCount int) {
 	}
 }
 
-// commitSpeculation rolls every cache back to before+accepted, keeping only
-// the accepted prefix; full acceptance needs no restore. Rollback tries a
-// live rewind first (Restore(nil)) and falls back to the captured snapshot.
-func commitSpeculation(caches []cache.Cache, accepted, draftCount, before int) {
-	target := before + accepted
+// commitSpeculation rolls every cache back to target and drains the round's
+// snapshot schedule; a target keeping the whole round needs no restore.
+// Rollback tries a live rewind first (Restore(nil)) and falls back to the
+// captured snapshot.
+func commitSpeculation(caches []cache.Cache, target, count, before int) {
+	slot := target - before
 	for _, c := range caches {
 		if c == nil {
 			continue
 		}
 		snaps := c.TakeSnapshots()
-		if accepted < draftCount {
+		if slot < count {
 			// Close the snapshots we won't restore from before restoring: a
 			// snapshot restore on a wrapped RotatingKVCache copies out every
 			// outstanding lazy snapshot before it rebuilds the buffer, so
 			// dropping the unused ones first stops that copy-out from
 			// materializing snapshots we are about to discard anyway.
 			for i, s := range snaps {
-				if s != nil && i != accepted {
+				if s != nil && i != slot {
 					s.Close()
 					snaps[i] = nil
 				}
 			}
-			if !c.Restore(nil, target) && !c.Restore(snaps[accepted], target) {
+			if !c.Restore(nil, target) && !c.Restore(snaps[slot], target) {
 				panic(fmt.Sprintf("speculation: cache restore to %d failed", target))
 			}
 		}
@@ -397,21 +406,24 @@ func (s *speculationSession) accept(position *int, current sampler.Result, candi
 	r := s.spec.r
 	before := *position
 	draftCount := candidates.tokens.Dim(1)
-	scheduleSpeculation(s.spec.targets, before+1, draftCount)
+	// One slot per offset a commit can target: the pre-round boundary (a
+	// round whose first token ends generation commits there) through full
+	// acceptance.
+	scheduleSpeculation(s.spec.targets, before, draftCount+1)
 
 	// Every exit between schedule and commit must drain the snapshot
 	// schedule and roll the speculative writes back out of the live caches:
 	// an undrained schedule panics the next PrepareSnapshots, and
 	// uncommitted speculative tokens reach the trie through session.close.
 	committed := false
-	commit := func(keep int) {
+	commit := func(target int) {
 		if committed {
 			return
 		}
 		committed = true
-		commitSpeculation(s.spec.targets, keep, draftCount, before+1)
+		commitSpeculation(s.spec.targets, target, draftCount+1, before)
 	}
-	defer commit(0)
+	defer commit(before)
 
 	hiddenSeq := r.Model.Forward(&batch.Batch{
 		InputIDs:     current.Token.ExpandDims(-1).Concatenate(1, candidates.tokens),
@@ -470,21 +482,42 @@ func (s *speculationSession) accept(position *int, current sampler.Result, candi
 			done = true
 			accepted = i + 1
 			observed = accepted
-			// Leave the EOS's own state uncommitted: the next sequence won't
-			// contain this EOS, and recurrent state can't drop a folded-in
-			// token, so committing it would carry the caches past the
-			// reusable prefix and force the next sequence to recompute.
 			keep = i
 			break
 		}
 	}
 
-	commit(keep)
-	*position = before + 1 + keep
+	// The next token (the residual at a rejection, the bonus past a full run)
+	// is read before committing: an EOS there ends generation the same way an
+	// accepted EOS draft does.
+	emitNext := !done
+	var nextID int32
+	if emitNext {
+		if accepted < draftCount {
+			nextID = int32(residualTokens.Ints()[accepted])
+		} else {
+			nextID = int32(bonusToken.Int())
+		}
+		done = r.Tokenizer.IsEOS(nextID)
+	}
+
+	// A round that ends generation commits one below its last content token:
+	// the terminator's state is never committed (the next sequence won't
+	// contain it), and the last content token's key packs the terminator
+	// (see prefixCache.key), so leaving it uncommitted keeps the deepest key
+	// pure content and a continuation restores exactly. settle then no-ops
+	// so no pair ever names the terminator.
+	target := before + keep + 1
+	if done {
+		target = before + keep
+		s.done = true
+	}
+	commit(target)
+	*position = target
 
 	// Report the validated run (current plus kept drafts) to the drafter before
 	// returning, so a cancelled emission still leaves it matching the caches. A
-	// done generation's final token is uncommitted; it reaches finish instead.
+	// done generation's terminator is uncommitted and never settled.
 	runIDs := append([]int32{int32(current.Token.Int())}, commitIDs[:keep]...)
 	s.drafter.committed(
 		mlx.FromValues(runIDs, 1, len(runIDs)),
@@ -492,21 +525,11 @@ func (s *speculationSession) accept(position *int, current sampler.Result, candi
 		before)
 
 	results = draftResults(draftIDs[:accepted])
-	if done {
-		r.Sampler.Commit(pipelineSlot, commitIDs)
-		return results, accepted, observed, nil
+	if emitNext {
+		commitIDs = append(commitIDs, nextID)
+		results = append(results, sampler.Result{Token: mlx.FromValues([]int32{nextID}, 1)})
 	}
-
-	var nextID int32
-	if accepted < draftCount {
-		nextID = int32(residualTokens.Ints()[accepted])
-	} else {
-		nextID = int32(bonusToken.Int())
-	}
-	commitIDs = append(commitIDs, nextID)
 	r.Sampler.Commit(pipelineSlot, commitIDs)
-
-	results = append(results, sampler.Result{Token: mlx.FromValues([]int32{nextID}, 1)})
 	return results, accepted, observed, nil
 }
 


### PR DESCRIPTION
MTP pairs each cache position with the token that follows it, and the token following a finished response's last content token is the stop token. The deepest cached state is therefore only reachable by a follow-up prompt that re-sends the stop token; one that doesn't — a continuation prefill, or a client that rebuilds the prompt without it — matches one position short. KV caches rewind the difference, but recurrent state cannot, so such follow-ups re-prefill the entire response.

When generation ends, commit the caches one token lower, below the last content token: nothing cached then depends on the stop token, and any prompt containing the response matches exactly.

This pays off where the next prompt reproduces the response — non-thinking chats and reasoning-preserving agent flows. Thinking chats strip prior turns' reasoning from the prompt, so their responses re-prefill regardless of the cache boundary.