### PR TITLE
cmd: support suggesting cloud tag for ollama launch

### DIFF
--- a/cmd/cloud_suggest.go
+++ b/cmd/cloud_suggest.go
@@ -75,12 +75,21 @@ func cloudSuggestionName(name string, insecure bool) (string, bool) {
 	return ref.Base + ":cloud", true
 }
 
+// cloudSuggestionRetryCommand renders the command hinted at in
+// non-interactive errors for the plain CLI verbs ("run" and "pull").
+func cloudSuggestionRetryCommand(verb string) func(string) string {
+	return func(cloudName string) string {
+		return "ollama " + verb + " " + cloudName
+	}
+}
+
 // pullWithCloudSuggestion pulls `name`, and if the model's default tag
 // doesn't exist but a ":cloud" tag does, offers it: either interactively via
 // a confirmation prompt, or by augmenting the returned error when not at a
-// terminal. It returns the name that was actually pulled. `verb` is the
-// user-facing command ("run" or "pull") used in the hint text.
-func pullWithCloudSuggestion(ctx context.Context, client *api.Client, name string, insecure bool, verb string) (string, error) {
+// terminal. It returns the name that was actually pulled. `retryCommand`
+// renders the command suggested in the non-interactive hint for a given
+// cloud model name.
+func pullWithCloudSuggestion(ctx context.Context, client *api.Client, name string, insecure bool, retryCommand func(cloudName string) string) (string, error) {
 	// If a suggestion prompt may follow a failed pull, erase the failed
 	// attempt's progress display instead of leaving its "pulling manifest"
 	// line to stack up against the accepted pull's identical one.
@@ -92,6 +101,24 @@ func pullWithCloudSuggestion(ctx context.Context, client *api.Client, name strin
 		return name, nil
 	}
 
+	cloudName, err := suggestCloudModel(ctx, client, name, pullErr, insecure, retryCommand)
+	if err != nil {
+		return "", err
+	}
+
+	if err := pullModelWithProgress(ctx, client, cloudName, insecure, false); err != nil {
+		return "", err
+	}
+	return cloudName, nil
+}
+
+// suggestCloudModel offers name's ":cloud" variant after a pull failed with
+// pullErr. It returns the cloud model name only when the user accepts the
+// interactive prompt; in every other case it returns the error the caller
+// should surface: pullErr untouched (not eligible, no cloud variant,
+// declined, cancelled) or pullErr augmented with a retry hint when not at an
+// interactive terminal. Accepting does not pull the cloud model.
+func suggestCloudModel(ctx context.Context, client *api.Client, name string, pullErr error, insecure bool, retryCommand func(cloudName string) string) (string, error) {
 	cloudName, ok := cloudSuggestionCandidate(name, pullErr, insecure)
 	if !ok || ctx.Err() != nil {
 		return "", pullErr
@@ -105,17 +132,16 @@ func pullWithCloudSuggestion(ctx context.Context, client *api.Client, name strin
 	}
 
 	if !isInteractiveTerminal() {
-		return "", fmt.Errorf("%w\n\n%q is available as a cloud model. Try:\n  ollama %s %s", pullErr, cloudName, verb, cloudName)
+		if retryCommand == nil {
+			return "", fmt.Errorf("%w\n\n%q is available as a cloud model", pullErr, cloudName)
+		}
+		return "", fmt.Errorf("%w\n\n%q is available as a cloud model. Try:\n  %s", pullErr, cloudName, retryCommand(cloudName))
 	}
 
 	accepted, err := confirmCloudSuggestion(fmt.Sprintf("Did you mean %q?", cloudName))
 	if err != nil || !accepted {
 		// Declining or cancelling falls back to the original error.
 		return "", pullErr
-	}
-
-	if err := pullModelWithProgress(ctx, client, cloudName, insecure, false); err != nil {
-		return "", err
 	}
 	return cloudName, nil
 }

--- a/cmd/cloud_suggest_test.go
+++ b/cmd/cloud_suggest_test.go
@@ -362,6 +362,73 @@ func TestPullHandler_CloudSuggestionUnrelatedError(t *testing.T) {
 	}
 }
 
+func TestLaunchCloudSuggestHookWired(t *testing.T) {
+	server := newCloudSuggestServer(t)
+	stubCloudSuggest(t, true, func(string) (bool, error) { return true, nil })
+
+	if launch.DefaultCloudSuggest == nil {
+		t.Fatal("launch.DefaultCloudSuggest is not wired")
+	}
+
+	client, err := api.ClientFromEnvironment()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pullErr := errors.New("failed to pull some-model: pull model manifest: file does not exist")
+	resolved, err := launch.DefaultCloudSuggest(t.Context(), client, "some-model", pullErr)
+	if err != nil {
+		t.Fatalf("DefaultCloudSuggest returned error: %v", err)
+	}
+	if resolved != "some-model:cloud" {
+		t.Fatalf("resolved = %q, want %q", resolved, "some-model:cloud")
+	}
+	if len(server.pullModels) != 0 {
+		t.Fatalf("pulled models = %v, want none (the launch flow owns pulling)", server.pullModels)
+	}
+	if want := []string{"some-model:cloud"}; !slices.Equal(server.showModels, want) {
+		t.Fatalf("show models = %v, want the cloud existence probe %v", server.showModels, want)
+	}
+}
+
+func TestLaunchCloudSuggestHookNonInteractiveHint(t *testing.T) {
+	newCloudSuggestServer(t)
+	stubCloudSuggest(t, false, nil)
+
+	client, err := api.ClientFromEnvironment()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pullErr := errors.New("failed to pull some-model: pull model manifest: file does not exist")
+	_, err = launch.DefaultCloudSuggest(t.Context(), client, "some-model", pullErr)
+	if err == nil {
+		t.Fatal("DefaultCloudSuggest returned nil, want an error")
+	}
+	if !errors.Is(err, pullErr) {
+		t.Fatalf("error = %q, want it to wrap the original pull error", err)
+	}
+	if !strings.Contains(err.Error(), "--model some-model:cloud") {
+		t.Fatalf("error = %q, want it to hint at '--model some-model:cloud'", err)
+	}
+}
+
+func TestLaunchCloudSuggestHookDeclinedKeepsOriginalError(t *testing.T) {
+	newCloudSuggestServer(t)
+	stubCloudSuggest(t, true, func(string) (bool, error) { return false, launch.ErrCancelled })
+
+	client, err := api.ClientFromEnvironment()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pullErr := errors.New("failed to pull some-model: pull model manifest: file does not exist")
+	_, err = launch.DefaultCloudSuggest(t.Context(), client, "some-model", pullErr)
+	if err != pullErr {
+		t.Fatalf("error = %v, want the original pull error unchanged", err)
+	}
+}
+
 func TestRunHandler_CloudSuggestionAccepted_RunsCloudModel(t *testing.T) {
 	server := newCloudSuggestServer(t)
 	stubCloudSuggest(t, true, func(string) (bool, error) { return true, nil })

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -94,6 +94,12 @@ func init() {
 
 	launch.DefaultConfirmPrompt = tui.RunConfirmWithOptions
 
+	launch.DefaultCloudSuggest = func(ctx context.Context, client *api.Client, model string, pullErr error) (string, error) {
+		return suggestCloudModel(ctx, client, model, pullErr, false, func(cloudName string) string {
+			return "--model " + cloudName
+		})
+	}
+
 	launch.DefaultSpinner = tui.RunSpinner
 }
 
@@ -724,7 +730,7 @@ func showOrPullModel(cmd *cobra.Command, client *api.Client, name string, insecu
 		return nil, name, err
 	}
 
-	resolved, err := pullWithCloudSuggestion(cmd.Context(), client, name, insecure, verb)
+	resolved, err := pullWithCloudSuggestion(cmd.Context(), client, name, insecure, cloudSuggestionRetryCommand(verb))
 	if err != nil {
 		return nil, name, err
 	}
@@ -1523,7 +1529,7 @@ func PullHandler(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	_, err = pullWithCloudSuggestion(cmd.Context(), client, args[0], insecure, "pull")
+	_, err = pullWithCloudSuggestion(cmd.Context(), client, args[0], insecure, cloudSuggestionRetryCommand("pull"))
 	return err
 }
 

--- a/cmd/launch/cloud_suggest_test.go
+++ b/cmd/launch/cloud_suggest_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/cmd/config"
 )
 
 // newCloudSuggestTestClient serves a daemon where "some-model" doesn't exist
@@ -50,6 +51,10 @@ func newCloudSuggestTestClient(t *testing.T, pulled *[]string) *api.Client {
 			}
 		case "/api/me":
 			if err := json.NewEncoder(w).Encode(api.UserResponse{Name: "tester"}); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+		case "/api/tags":
+			if err := json.NewEncoder(w).Encode(api.ListResponse{}); err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 			}
 		default:
@@ -92,6 +97,69 @@ func TestReadyModel_CloudSuggestionRename(t *testing.T) {
 	}
 	if len(pulled) != 1 {
 		t.Fatalf("pull requests = %v, want just the original attempt", pulled)
+	}
+}
+
+// TestResolveRunModel_CloudSuggestionPersistsResolvedModel covers the
+// last_model lifecycle across an accepted suggestion: a saved model that no
+// longer resolves routes to the picker, picking a default-tag name whose
+// pull fails accepts the ":cloud" variant, the resolved name is what gets
+// persisted, and a rerun reuses it without prompting again.
+func TestResolveRunModel_CloudSuggestionPersistsResolvedModel(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	var pulled []string
+	client := newCloudSuggestTestClient(t, &pulled)
+
+	if err := config.SetLastModel("some-model"); err != nil {
+		t.Fatal(err)
+	}
+
+	oldSelector, oldHook := DefaultSingleSelector, DefaultCloudSuggest
+	t.Cleanup(func() { DefaultSingleSelector, DefaultCloudSuggest = oldSelector, oldHook })
+
+	var selectorCalls, hookCalls int
+	DefaultSingleSelector = func(title string, items []SelectionItem, current string) (string, error) {
+		selectorCalls++
+		return "some-model", nil
+	}
+	DefaultCloudSuggest = func(ctx context.Context, c *api.Client, model string, pullErr error) (string, error) {
+		hookCalls++
+		return model + ":cloud", nil
+	}
+
+	c := &launcherClient{apiClient: client, policy: LaunchPolicy{MissingModel: LaunchMissingModelAutoPull}}
+	model, err := c.resolveRunModel(context.Background(), RunModelRequest{})
+	if err != nil {
+		t.Fatalf("resolveRunModel returned error: %v", err)
+	}
+	if model != "some-model:cloud" {
+		t.Fatalf("model = %q, want %q", model, "some-model:cloud")
+	}
+	if selectorCalls != 1 || hookCalls != 1 {
+		t.Fatalf("selector calls = %d, hook calls = %d, want 1 and 1", selectorCalls, hookCalls)
+	}
+	if got := config.LastModel(); got != "some-model:cloud" {
+		t.Fatalf("saved last model = %q, want %q", got, "some-model:cloud")
+	}
+
+	// Rerunning with the persisted cloud name must not open the picker or
+	// re-prompt the suggestion.
+	DefaultSingleSelector = func(title string, items []SelectionItem, current string) (string, error) {
+		t.Error("unexpected model picker on rerun")
+		return "", ErrCancelled
+	}
+	DefaultCloudSuggest = func(ctx context.Context, c *api.Client, model string, pullErr error) (string, error) {
+		t.Error("unexpected cloud suggestion on rerun")
+		return "", pullErr
+	}
+
+	rerun := &launcherClient{apiClient: client, policy: LaunchPolicy{MissingModel: LaunchMissingModelAutoPull}}
+	model, err = rerun.resolveRunModel(context.Background(), RunModelRequest{})
+	if err != nil {
+		t.Fatalf("rerun resolveRunModel returned error: %v", err)
+	}
+	if model != "some-model:cloud" {
+		t.Fatalf("rerun model = %q, want %q", model, "some-model:cloud")
 	}
 }
 

--- a/cmd/launch/cloud_suggest_test.go
+++ b/cmd/launch/cloud_suggest_test.go
@@ -1,0 +1,129 @@
+package launch
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/ollama/ollama/api"
+)
+
+// newCloudSuggestTestClient serves a daemon where "some-model" doesn't exist
+// (locally or in the registry), "some-model:cloud" does, and the user is
+// signed in. It records pull requests in pulled.
+func newCloudSuggestTestClient(t *testing.T, pulled *[]string) *api.Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/show":
+			var req api.ShowRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			if req.Model == "some-model:cloud" {
+				if err := json.NewEncoder(w).Encode(api.ShowResponse{RemoteModel: "some-model"}); err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+				}
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+			if err := json.NewEncoder(w).Encode(map[string]string{"error": "model not found"}); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+		case "/api/pull":
+			var req api.PullRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			*pulled = append(*pulled, req.Model+req.Name)
+			if err := json.NewEncoder(w).Encode(map[string]string{
+				"error": "pull model manifest: file does not exist",
+			}); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+		case "/api/me":
+			if err := json.NewEncoder(w).Encode(api.UserResponse{Name: "tester"}); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	u, _ := url.Parse(srv.URL)
+	return api.NewClient(u, srv.Client())
+}
+
+func TestReadyModel_CloudSuggestionRename(t *testing.T) {
+	var pulled []string
+	client := newCloudSuggestTestClient(t, &pulled)
+
+	oldHook := DefaultCloudSuggest
+	t.Cleanup(func() { DefaultCloudSuggest = oldHook })
+
+	var hookModel string
+	var hookErr error
+	DefaultCloudSuggest = func(ctx context.Context, c *api.Client, model string, pullErr error) (string, error) {
+		hookModel = model
+		hookErr = pullErr
+		return model + ":cloud", nil
+	}
+
+	c := &launcherClient{apiClient: client, policy: LaunchPolicy{MissingModel: LaunchMissingModelAutoPull}}
+	resolved, err := c.readyModel(context.Background(), "some-model", "ollama launch", "claude")
+	if err != nil {
+		t.Fatalf("readyModel returned error: %v", err)
+	}
+	if resolved != "some-model:cloud" {
+		t.Fatalf("resolved = %q, want %q", resolved, "some-model:cloud")
+	}
+	if hookModel != "some-model" {
+		t.Fatalf("hook model = %q, want %q", hookModel, "some-model")
+	}
+	if hookErr == nil || !strings.Contains(hookErr.Error(), "failed to pull some-model") {
+		t.Fatalf("hook pull error = %v, want the wrapped pull failure", hookErr)
+	}
+	if len(pulled) != 1 {
+		t.Fatalf("pull requests = %v, want just the original attempt", pulled)
+	}
+}
+
+func TestReadyModel_CloudSuggestionErrorSurfaces(t *testing.T) {
+	var pulled []string
+	client := newCloudSuggestTestClient(t, &pulled)
+
+	oldHook := DefaultCloudSuggest
+	t.Cleanup(func() { DefaultCloudSuggest = oldHook })
+
+	suggestErr := errors.New("augmented pull error")
+	DefaultCloudSuggest = func(ctx context.Context, c *api.Client, model string, pullErr error) (string, error) {
+		return "", suggestErr
+	}
+
+	c := &launcherClient{apiClient: client, policy: LaunchPolicy{MissingModel: LaunchMissingModelAutoPull}}
+	if _, err := c.readyModel(context.Background(), "some-model", "ollama launch", ""); !errors.Is(err, suggestErr) {
+		t.Fatalf("readyModel error = %v, want the hook's error", err)
+	}
+}
+
+func TestReadyModel_NoHookKeepsPullError(t *testing.T) {
+	var pulled []string
+	client := newCloudSuggestTestClient(t, &pulled)
+
+	oldHook := DefaultCloudSuggest
+	t.Cleanup(func() { DefaultCloudSuggest = oldHook })
+	DefaultCloudSuggest = nil
+
+	c := &launcherClient{apiClient: client, policy: LaunchPolicy{MissingModel: LaunchMissingModelAutoPull}}
+	_, err := c.readyModel(context.Background(), "some-model", "ollama launch", "")
+	if err == nil || !strings.Contains(err.Error(), "failed to pull some-model") {
+		t.Fatalf("readyModel error = %v, want the plain pull failure", err)
+	}
+}

--- a/cmd/launch/launch.go
+++ b/cmd/launch/launch.go
@@ -693,9 +693,11 @@ func (c *launcherClient) launcherManagedAutodiscoveryState(ctx context.Context, 
 func (c *launcherClient) resolveRunModel(ctx context.Context, req RunModelRequest) (string, error) {
 	current := config.LastModel()
 	if !req.ForcePicker && current != "" && c.policy.Confirm == LaunchConfirmAutoApprove && !isInteractiveSession() {
-		if err := c.ensureModelsReady(ctx, []string{current}); err != nil {
+		resolved, err := c.readyModel(ctx, current, "ollama launch", "")
+		if err != nil {
 			return "", err
 		}
+		current = resolved
 		fmt.Fprintf(os.Stderr, "Headless mode: auto-selected last used model %q\n", current)
 		return current, nil
 	}
@@ -706,12 +708,12 @@ func (c *launcherClient) resolveRunModel(ctx context.Context, req RunModelReques
 			return "", err
 		}
 		if usable {
-			if err := c.ensureModelsReady(ctx, []string{current}); err != nil {
+			if resolved, err := c.readyModel(ctx, current, "ollama launch", ""); err != nil {
 				if !errors.Is(err, errDeprecatedLaunchModelDeclined) {
 					return "", err
 				}
 			} else {
-				return current, nil
+				return resolved, nil
 			}
 		}
 	}
@@ -757,7 +759,7 @@ func (c *launcherClient) launchEditorIntegration(ctx context.Context, name strin
 		}
 		models = selected
 	} else if len(models) > 0 {
-		if err := c.ensureModelsReadyFor(ctx, models[:1], runner.String(), name); err != nil {
+		if resolved, err := c.readyModel(ctx, models[0], runner.String(), name); err != nil {
 			if !errors.Is(err, errDeprecatedLaunchModelDeclined) || req.ModelOverride != "" {
 				return err
 			}
@@ -767,6 +769,8 @@ func (c *launcherClient) launchEditorIntegration(ctx context.Context, name strin
 			}
 			models = selected
 			needsConfigure = true
+		} else {
+			models[0] = resolved
 		}
 	}
 
@@ -995,7 +999,7 @@ func (c *launcherClient) resolveSingleIntegrationTarget(ctx context.Context, nam
 		}
 		target = selected
 	} else if !skipReadiness {
-		if err := c.ensureModelsReadyFor(ctx, []string{target}, runner.String(), name); err != nil {
+		if resolved, err := c.readyModel(ctx, target, runner.String(), name); err != nil {
 			if !errors.Is(err, errDeprecatedLaunchModelDeclined) {
 				return "", false, err
 			}
@@ -1007,6 +1011,8 @@ func (c *launcherClient) resolveSingleIntegrationTarget(ctx context.Context, nam
 			}
 			target = selected
 			needsConfigure = true
+		} else {
+			target = resolved
 		}
 	}
 
@@ -1079,7 +1085,8 @@ func (c *launcherClient) selectSingleModelWithSelectorReady(ctx context.Context,
 			return "", ErrCancelled
 		}
 		if ensureReady {
-			if err := c.ensureModelsReadyFor(ctx, []string{selected}, label, commandName); err != nil {
+			resolved, err := c.readyModel(ctx, selected, label, commandName)
+			if err != nil {
 				if errors.Is(err, errUpgradeCancelled) {
 					current = selected
 					continue
@@ -1090,6 +1097,7 @@ func (c *launcherClient) selectSingleModelWithSelectorReady(ctx context.Context,
 				}
 				return "", err
 			}
+			selected = resolved
 		}
 		return selected, nil
 	}
@@ -1242,44 +1250,51 @@ func (c *launcherClient) requestRecommendations(ctx context.Context) ([]ModelIte
 	return items, nil
 }
 
-func (c *launcherClient) ensureModelsReady(ctx context.Context, models []string) error {
-	return c.ensureModelsReadyFor(ctx, models, "ollama launch", "")
-}
-
-func (c *launcherClient) ensureModelsReadyFor(ctx context.Context, models []string, label, commandName string) error {
-	models = dedupeModelList(models)
-	if len(models) == 0 {
-		return nil
-	}
+// readyModel makes sure model is ready to run (downloading it and checking
+// cloud access and auth as needed) and returns the model name to continue
+// with. The returned name differs from the requested one when a missing
+// default tag was resolved to its ":cloud" variant (see DefaultCloudSuggest).
+func (c *launcherClient) readyModel(ctx context.Context, model, label, commandName string) (string, error) {
 	cloudRec, localRec := c.agentCapableRecommendations(ctx)
-
-	cloudModels := make(map[string]bool, len(models))
-	for _, model := range models {
-		if prompt := deprecatedLaunchModelPrompt(model, label, commandName, cloudRec, localRec); prompt != "" {
-			ok, err := ConfirmPromptWithOptions(prompt, ConfirmOptions{
-				YesLabel: "Launch anyway",
-				NoLabel:  "Pick another model",
-				Default:  ConfirmDefaultNo,
-			})
-			if err != nil {
-				return err
-			}
-			if !ok {
-				return errDeprecatedLaunchModelDeclined
-			}
+	if prompt := deprecatedLaunchModelPrompt(model, label, commandName, cloudRec, localRec); prompt != "" {
+		ok, err := ConfirmPromptWithOptions(prompt, ConfirmOptions{
+			YesLabel: "Launch anyway",
+			NoLabel:  "Pick another model",
+			Default:  ConfirmDefaultNo,
+		})
+		if err != nil {
+			return "", err
 		}
-		isCloudModel := isCloudModelName(model)
-		if isCloudModel {
-			cloudModels[model] = true
-			if err := c.ensureCloudModelAccess(ctx, model); err != nil {
-				return err
-			}
-		}
-		if err := showOrPullWithPolicy(ctx, c.apiClient, model, c.policy.missingModelPolicy(), isCloudModel); err != nil {
-			return err
+		if !ok {
+			return "", errDeprecatedLaunchModelDeclined
 		}
 	}
-	return ensureAuth(ctx, c.apiClient, cloudModels, models)
+
+	isCloudModel := isCloudModelName(model)
+	if isCloudModel {
+		if err := c.ensureCloudModelAccess(ctx, model); err != nil {
+			return "", err
+		}
+	}
+
+	if err := showOrPullWithPolicy(ctx, c.apiClient, model, c.policy.missingModelPolicy(), isCloudModel); err != nil {
+		if !isCloudModel && DefaultCloudSuggest != nil {
+			resolved, serr := DefaultCloudSuggest(ctx, c.apiClient, model, err)
+			if serr != nil {
+				return "", serr
+			}
+			// The user accepted the ":cloud" variant; re-enter so it gets the
+			// cloud access and auth checks the original name skipped.
+			return c.readyModel(ctx, resolved, label, commandName)
+		}
+		return "", err
+	}
+
+	var cloudModels map[string]bool
+	if isCloudModel {
+		cloudModels = map[string]bool{model: true}
+	}
+	return model, ensureAuth(ctx, c.apiClient, cloudModels, []string{model})
 }
 
 func (c *launcherClient) agentCapableRecommendations(ctx context.Context) (cloud, local string) {
@@ -1327,7 +1342,8 @@ func (c *launcherClient) selectReadyModelsForSave(ctx context.Context, selected 
 	skipped := make([]skippedModel, 0, len(selected))
 
 	for _, model := range selected {
-		if err := c.ensureModelsReadyFor(ctx, []string{model}, label, commandName); err != nil {
+		resolved, err := c.readyModel(ctx, model, label, commandName)
+		if err != nil {
 			if errors.Is(err, errUpgradeCancelled) {
 				return nil, nil, err
 			}
@@ -1343,7 +1359,7 @@ func (c *launcherClient) selectReadyModelsForSave(ctx context.Context, selected 
 			})
 			continue
 		}
-		accepted = append(accepted, model)
+		accepted = append(accepted, resolved)
 	}
 
 	return accepted, skipped, nil

--- a/cmd/launch/models.go
+++ b/cmd/launch/models.go
@@ -141,6 +141,13 @@ func mergeCloudModelLimits(base map[string]cloudModelLimit, overlay map[string]c
 	return out
 }
 
+// DefaultCloudSuggest, when set (the cmd package wires it up), offers the
+// ":cloud" variant of a model whose pull failed because its default tag
+// doesn't exist. It returns the cloud model name to continue with when the
+// user accepts; otherwise it returns the error the caller should surface
+// (the original one, possibly augmented with a hint).
+var DefaultCloudSuggest func(ctx context.Context, client *api.Client, model string, pullErr error) (string, error)
+
 // missingModelPolicy controls how model-not-found errors should be handled.
 type missingModelPolicy int
 


### PR DESCRIPTION
Follow-on from #17483 that adds similar support to ollama launch.

Now something like `ollama launch claude --model=kimi-k3` will prompt if you want the cloud model. Same caveats as in #17483, in the future we may want to play with defaults or persist the choice, etc., but this is designed to be a quick change to iterate on.