### PR TITLE
docs: note that reasoning_effort and think accept different values

### DIFF
--- a/docs/api/openai-compatibility.mdx
+++ b/docs/api/openai-compatibility.mdx
@@ -216,6 +216,11 @@ curl -X POST http://localhost:11434/v1/chat/completions \
 - [ ] `user`
 - [ ] `n`
 
+#### Notes
+
+- Thinking is controlled with `reasoning_effort` on this endpoint. Use `"none"` to disable it.
+- The native `/api/chat` endpoint uses a `think` field for the same purpose, and the two are not interchangeable: `reasoning_effort` does not accept `true` or `false`, and `think` does not accept `"none"`. Both accept `"high"`, `"medium"`, `"low"`, and `"max"`.
+
 ### `/v1/completions`
 
 #### Supported features


### PR DESCRIPTION
## What

Adds a Notes section under `/v1/chat/completions` covering how thinking
is disabled on this endpoint and how it differs from the native `think`
field. Docs only, no code change.

## Why

Both endpoints control the same feature with different field names and
disjoint value sets, and neither page references the other. Moving
between them returns a 400 with no pointer to the correct spelling.

Tested on Ollama 0.30.10, qwen3.5:4b, Linux:

| Endpoint  | Field            | Accepts                             | "none" | true/false |
|-----------|------------------|-------------------------------------|--------|------------|
| /api/chat | think            | high, medium, low, max, true, false | 400    | accepted   |
| /v1       | reasoning_effort | high, medium, low, max, none        | ok     | 400        |

Each file is individually accurate. `docs/openapi.yaml` describes
`think` as a boolean or one of high/medium/low/max; this page lists
`reasoning_effort` as high/medium/low/max/none. The gap is that neither
cross-references the other.

#12004 is the same collision from the opposite direction:
`reasoning_effort: false` returns `cannot unmarshal bool into Go struct
field`.

## Context

Hit this building a router that fans work across several Ollama nodes
and has to normalise between both paths:
https://github.com/jnpatel1/local-inference

NousResearch/hermes-agent ran into it too and patched their provider
layer to emit `reasoning_effort=none` on `/v1`, citing #14820 in the
commit message: NousResearch/hermes-agent@8662254

## Open questions

- Placement: I used a new `#### Notes` block to match the other
  endpoints. Happy to move it under `## Models` alongside "Setting the
  context size" instead.
- Should the mirror note go on the `think` description in
  `docs/openapi.yaml` as well? Left it out to keep the diff to one
  file, but can add it.