### PR TITLE
convert: accept c-radio_v4-h RADIO version for Nemotron 3 Omni

### DIFF
--- a/convert/convert_nemotron_h.go
+++ b/convert/convert_nemotron_h.go
@@ -153,7 +153,11 @@ func (n *nemotronHNanoVLModel) parseMore(fsys fs.FS) error {
 		return err
 	}
 
-	if version := strings.TrimSpace(n.VisionConfig.Version); version != "" && version != "radio_v2.5-h" {
+	// radio_v2.5-h and c-radio_v4-h are both ViT-H/16 with identical tensor
+	// layouts; the version string only reflects the distillation recipe.
+	switch version := strings.TrimSpace(n.VisionConfig.Version); version {
+	case "", "radio_v2.5-h", "c-radio_v4-h":
+	default:
 		return fmt.Errorf("nemotron_h_omni: unsupported RADIO version %q", version)
 	}
 	if patchSize := n.visionPatchSize(); patchSize != 16 {

--- a/convert/convert_nemotron_h_test.go
+++ b/convert/convert_nemotron_h_test.go
@@ -353,7 +353,7 @@ func TestNemotronHNanoOmniReasoningV3LoadModelMetadata(t *testing.T) {
 		"vit_hidden_size": 1280,
 		"projector_hidden_size": 4096,
 		"vision_config": {
-			"version": "radio_v2.5-h",
+			"version": "c-radio_v4-h",
 			"patch_size": 16,
 			"min_num_patches": 1024,
 			"max_num_patches": 13312,
@@ -432,6 +432,42 @@ func TestNemotronHNanoOmniReasoningV3LoadModelMetadata(t *testing.T) {
 	}
 	if got, want := kv["audio.sound_token_id"], uint32(27); got != want {
 		t.Fatalf("unexpected audio token id: got %v want %v", got, want)
+	}
+}
+
+func TestNemotronHNanoVLRadioVersions(t *testing.T) {
+	for version, wantErr := range map[string]bool{
+		"":              false,
+		"radio_v2.5-h":  false,
+		"c-radio_v4-h":  false,
+		" c-radio_v4-h": false,
+		"radio_v1":      true,
+		"c-radio_v4-b":  true,
+	} {
+		m := &nemotronHNanoVLModel{
+			LLMConfig: nemotronHModel{
+				NumHiddenLayers:       4,
+				HiddenSize:            512,
+				NumAttentionHeads:     8,
+				ConvKernel:            4,
+				SSMStateSize:          128,
+				MambaNumHeads:         16,
+				MambaHeadDim:          32,
+				HybridOverridePattern: "ME*M",
+				NRoutedExperts:        16,
+				NumExpertsPerTok:      4,
+				MoEIntermediateSize:   256,
+			},
+		}
+		m.VisionConfig.Version = version
+
+		err := m.parseMore(os.DirFS(t.TempDir()))
+		if wantErr && err == nil {
+			t.Fatalf("expected error for RADIO version %q", version)
+		}
+		if !wantErr && err != nil {
+			t.Fatalf("unexpected error for RADIO version %q: %v", version, err)
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes conversion of the published NVIDIA Nemotron 3 Nano Omni checkpoint, which the converter currently rejects because of its RADIO version string.

## Problem

`convert/convert_nemotron_h.go` (version gate added in #15861) accepts only `""` and `"radio_v2.5-h"` for `vision_config.version`. The published HF checkpoint [nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16](https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16) ships `vision_config.version = "c-radio_v4-h"` in its [config.json](https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16/blob/main/config.json), so converting it fails with:

    nemotron_h_omni: unsupported RADIO version "c-radio_v4-h"

The existing V3 Omni converter test masked this because its fixture used `radio_v2.5-h`.

## Why accepting c-radio_v4-h is safe

Checked the checkpoint's `model.safetensors.index.json` and parsed the shard safetensors headers for actual shapes. The c-radio_v4-h encoder is structurally identical to what the converter already handles for radio_v2.5-h:

- Same tensor names: fused `attn.qkv`, `mlp.fc1/fc2`, `norm1/norm2`, `patch_generator.{embedder,pos_embed,cls_token.token}`
- Same ViT-H/16 geometry matching every hardcoded converter assumption: 32 blocks (indices 0–31), hidden 1280, qkv `[3840,1280]` (16 heads), FFN 5120 = 4×1280, embedder `[1280,768]` (patch 16), `pos_embed [1,16384,1280]` (leading-1 squeeze path), `cls_token [10,1280]`
- `input_conditioner.*` and `video_embedder` tensors are present in the checkpoint and already correctly dropped by `isNemotronHNanoVLOmittedTensor`

The version string difference only reflects the C-RADIO v4 distillation recipe, not a layout change.

## Changes

- Allowlist `c-radio_v4-h` alongside `radio_v2.5-h` in `parseMore`, with a comment explaining why they are interchangeable here
- `TestNemotronHNanoOmniReasoningV3LoadModelMetadata` fixture now uses the real checkpoint's `c-radio_v4-h`
- New `TestNemotronHNanoVLRadioVersions` table test pins the version gate (accepted: `""`, `radio_v2.5-h`, `c-radio_v4-h` incl. whitespace trimming; rejected: `radio_v1`, `c-radio_v4-b`)

## Testing

- `go test ./convert/` passes
- `go vet ./convert/` and `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
