### PR TITLE
cmd: recognize tilde home directory and file:// URL image paths

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -583,6 +584,27 @@ func NewCreateRequest(name string, opts runOptions) *api.CreateRequest {
 }
 
 func normalizeFilePath(fp string) string {
+	if strings.HasPrefix(fp, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			fp = filepath.Join(home, fp[2:])
+		}
+	}
+
+	if u, err := url.Parse(fp); err == nil && strings.EqualFold(u.Scheme, "file") {
+		if unescaped, err := url.PathUnescape(u.Path); err == nil {
+			fp = unescaped
+		} else {
+			fp = u.Path
+		}
+		if u.Host != "" && !strings.EqualFold(u.Host, "localhost") {
+			fp = `\\` + u.Host + filepath.FromSlash(fp)
+		} else {
+			fp = filepath.FromSlash(fp)
+		}
+		return fp
+	}
+
+	fp = strings.Trim(fp, "\"")
 	return strings.NewReplacer(
 		"\\ ", " ", // Escaped space
 		"\\(", "(", // Escaped left parenthesis
@@ -603,10 +625,10 @@ func normalizeFilePath(fp string) string {
 }
 
 func extractFileNames(input string) []string {
-	// Regex to match file paths starting with optional drive letter, / ./ \ or .\ and include escaped or unescaped spaces (\ or %20)
-	// and followed by more characters and a file extension
+	// Regex to match file paths starting with optional drive letter, ~/ ./ / \ or .\ and include escaped or unescaped spaces (\ or %20)
+	// and followed by more characters and a file extension. Also matches file:// URLs.
 	// This will capture non filename strings, but we'll check for file existence to remove mismatches
-	regexPattern := `(?:[a-zA-Z]:)?(?:\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp|wav)\b`
+	regexPattern := `(?:file://\S+?\.(?i:jpg|jpeg|png|webp|wav)\b)|(?:(?:[a-zA-Z]:)?(?:~/|\./|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp|wav)\b)`
 	re := regexp.MustCompile(regexPattern)
 
 	return re.FindAllString(input, -1)

--- a/cmd/interactive_test.go
+++ b/cmd/interactive_test.go
@@ -64,6 +64,29 @@ d:\path with\spaces\thirteen.WEBP some ending
 	assert.Contains(t, res[12], "d:")
 }
 
+func TestExtractFilenamesTildePath(t *testing.T) {
+	input := "~/Pictures/photo.png some text ~/Documents/image with spaces/scene.jpg"
+	res := extractFileNames(input)
+	assert.Len(t, res, 2)
+	assert.Contains(t, res[0], "~/Pictures/photo.png")
+	assert.Contains(t, res[1], "~/Documents/image with spaces/scene.jpg")
+}
+
+func TestExtractFilenamesFileURL(t *testing.T) {
+	input := "check this file:///Users/test/image.png and file:///tmp/photo.jpg"
+	res := extractFileNames(input)
+	assert.Len(t, res, 2)
+	assert.Contains(t, res[0], "file:///Users/test/image.png")
+	assert.Contains(t, res[1], "file:///tmp/photo.jpg")
+}
+
+func TestExtractFilenamesMacOSDragDrop(t *testing.T) {
+	input := `/Users/ollama/Library/Mobile\ Documents/com\~apple\~CloudDocs/screenshots/CleanShot\ 2025-04-17\ at\ 21.26.40@2x.png`
+	res := extractFileNames(input)
+	assert.Len(t, res, 1)
+	assert.Contains(t, res[0], "CleanShot\\ 2025-04-17\\ at\\ 21.26.40@2x.png")
+}
+
 // Ensure that file paths wrapped in single quotes are removed with the quotes.
 func TestExtractFileDataRemovesQuotedFilepath(t *testing.T) {
 	dir := t.TempDir()

--- a/cmd/internal/filedata/filedata.go
+++ b/cmd/internal/filedata/filedata.go
@@ -21,6 +21,12 @@ type File struct {
 }
 
 func NormalizePath(fp string) string {
+	if strings.HasPrefix(fp, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			fp = filepath.Join(home, fp[2:])
+		}
+	}
+
 	fp = strings.Trim(fp, "\"")
 	fp = strings.NewReplacer(
 		"\\ ", " ",
@@ -50,10 +56,10 @@ func NormalizePath(fp string) string {
 }
 
 // fileExtractRe matches file:// URLs and filesystem paths ending in image/audio
-// extensions. Hoisted to package scope so the per-keystroke slash-completion
-// path (chat.slashInputIsMultimodalFile -> ExtractNames) doesn't recompile it
-// on every call.
-var fileExtractRe = regexp.MustCompile(`(?:file://\S+?\.(?i:jpg|jpeg|png|webp|wav)\b)|(?:(?:[a-zA-Z]:)?(?:\./|\.\\|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp|wav)\b)`)
+// extensions, including ~/ for home directory paths. Hoisted to package scope so
+// the per-keystroke slash-completion path (chat.slashInputIsMultimodalFile ->
+// ExtractNames) doesn't recompile it on every call.
+var fileExtractRe = regexp.MustCompile(`(?:file://\S+?\.(?i:jpg|jpeg|png|webp|wav)\b)|(?:(?:[a-zA-Z]:)?(?:~/|\./|\.\\|/|\\)[\S\\ ]+?\.(?i:jpg|jpeg|png|webp|wav)\b)`)
 
 func ExtractNames(input string) []string {
 	return fileExtractRe.FindAllString(input, -1)

--- a/cmd/internal/filedata/filedata_test.go
+++ b/cmd/internal/filedata/filedata_test.go
@@ -107,6 +107,37 @@ func TestExtractNamesDragDropPaths(t *testing.T) {
 	assertContains(t, res[3], `.\relative\four.png`)
 }
 
+func TestExtractNamesTildePath(t *testing.T) {
+	input := `~/Pictures/photo.png some text ~/Documents/image with spaces/scene.jpg`
+	res := ExtractNames(input)
+	if len(res) != 2 {
+		t.Fatalf("len = %d, want 2", len(res))
+	}
+	assertContains(t, res[0], "~/Pictures/photo.png")
+	assertContains(t, res[1], "~/Documents/image with spaces/scene.jpg")
+}
+
+func TestExtractNamesEscapedTilde(t *testing.T) {
+	input := `/Users/jdoe/Library/Mobile\ Documents/com\~apple\~CloudDocs/screenshot.png`
+	res := ExtractNames(input)
+	if len(res) != 1 {
+		t.Fatalf("len = %d, want 1", len(res))
+	}
+	assertContains(t, res[0], "screenshot.png")
+}
+
+func TestNormalizePathTilde(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home directory")
+	}
+	got := NormalizePath(`~/Pictures/img.png`)
+	want := filepath.Join(home, "Pictures", "img.png")
+	if got != want {
+		t.Fatalf("path = %q, want %q", got, want)
+	}
+}
+
 func TestNormalizePathFileURL(t *testing.T) {
 	got := NormalizePath("file:///C:/Users/jdoe/Pictures/img.png")
 	want := filepath.FromSlash("C:/Users/jdoe/Pictures/img.png")


### PR DESCRIPTION
Image file paths starting with `~/` and `file://` URLs were not recognized
because the path extraction regex did not include them as valid prefixes.
`~/` paths lost the leading tilde (matching as bare `/` paths that don't exist),
and `file://` URLs were partially consumed, leaving malformed paths.

Update both `cmd/interactive.go` and `cmd/internal/filedata/filedata.go` regexes
to match `~/` and `file://` prefixes. Add tilde expansion to `NormalizePath` /
`normalizeFilePath` so `~` gets resolved to the user's home directory. Also add
`file://` URL path unescaping to the interactive.go normalization path.

Fixes #10333