### PR TITLE
app/ui: prevent sidebar animation on initial load

### DIFF
--- a/app/ui/app/src/components/layout/layout.tsx
+++ b/app/ui/app/src/components/layout/layout.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { Link } from "@tanstack/react-router";
 import { useSettings } from "@/hooks/useSettings";
 
@@ -9,13 +10,22 @@ export function SidebarLayout({
   collapsible?: boolean;
   chatId?: string;
 }>) {
-  const { settings, setSettings } = useSettings();
+  const { settings, settingsData, setSettings } = useSettings();
   const isWindows = navigator.platform.toLowerCase().includes("win");
+  const [animate, setAnimate] = useState(false);
+
+  useEffect(() => {
+    if (settingsData) {
+      setAnimate(true);
+    }
+  }, [settingsData]);
 
   return (
-    <div className={`flex transition-[width] duration-300 dark:bg-neutral-900`}>
+    <div
+      className={`flex ${animate ? "transition-[width] duration-300" : ""} dark:bg-neutral-900`}
+    >
       <div
-        className={`absolute flex mx-2 py-2 z-20 items-center transition-[left] duration-375 text-neutral-500 dark:text-neutral-400 ${settings.sidebarOpen ? (isWindows ? "left-2" : "left-[204px]") : isWindows ? "left-2" : "left-20"}`}
+        className={`absolute flex mx-2 py-2 z-20 items-center ${animate ? "transition-[left] duration-375" : ""} text-neutral-500 dark:text-neutral-400 ${settings.sidebarOpen ? (isWindows ? "left-2" : "left-[204px]") : isWindows ? "left-2" : "left-20"}`}
       >
         <button
           onClick={() => setSettings({ SidebarOpen: !settings.sidebarOpen })}
@@ -57,7 +67,7 @@ export function SidebarLayout({
         </Link>
       </div>
       <div
-        className={`flex flex-col transition-[width] duration-300 max-h-screen ${settings.sidebarOpen ? "w-64" : "w-0"}`}
+        className={`flex flex-col ${animate ? "transition-[width] duration-300" : ""} max-h-screen ${settings.sidebarOpen ? "w-64" : "w-0"}`}
       >
         <div
           onDoubleClick={() => window.doubleClick && window.doubleClick()}
@@ -67,7 +77,7 @@ export function SidebarLayout({
         {settings.sidebarOpen && sidebar}
       </div>
       <main
-        className={`flex flex-1 flex-col min-w-0 transition-all duration-300`}
+        className={`flex flex-1 flex-col min-w-0 ${animate ? "transition-all duration-300" : ""}`}
       >
         <div
           className={`h-13 flex-none w-full z-10 flex items-center bg-white dark:bg-neutral-900 ${isWindows ? "xl:hidden" : "xl:fixed xl:bg-transparent xl:dark:bg-transparent"}`}


### PR DESCRIPTION
## Summary

The desktop app's sidebar animates open on first load instead of appearing already open (issue #12954).

## Root cause

`SidebarLayout` applied width/left transition classes unconditionally. Settings load asynchronously via `useSettings()`, so the first render uses the collapsed defaults (`w-0`), and when the persisted `SidebarOpen` value arrives, the sidebar, the toggle button, and the main content all animate from collapsed to open.

## Fix

Gate every layout transition class on settings having loaded (`settingsData` truthy). The initial render applies the persisted layout instantly with no transition, and transitions re-enable afterwards for normal user toggles. This covers all four animated elements (outer container width, toggle button `left`, sidebar width, main content), not just the main content area.

## Validation

- `tsc -b` passes
- `eslint` clean on changed file
- `prettier --check` clean

Fixes #12954