### PR TITLE
model/parsers: finalize incomplete cogito tool calls

### DIFF
--- a/model/parsers/cogito.go
+++ b/model/parsers/cogito.go
@@ -3,6 +3,7 @@ package parsers
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
 	"unicode"
@@ -116,6 +117,17 @@ func (cogitoEventToolCall) isCogitoEvent()        {}
 func (p *CogitoParser) Add(s string, done bool) (content string, thinking string, calls []api.ToolCall, err error) {
 	p.buffer.WriteString(s)
 	events := p.parseEvents()
+
+	// an unterminated tool call is still buffered: the begin tag is only
+	// consumed once its matching end tag arrives, so its presence here means
+	// the stream ended mid call
+	if done && p.state == CogitoCollectingToolCalls && strings.Contains(p.buffer.String(), cogitoToolCallBeginTag) {
+		event, err := p.finalizeToolCall()
+		if err != nil {
+			return "", "", nil, fmt.Errorf("incomplete cogito tool call: %v", err)
+		}
+		events = append(events, event)
+	}
 
 	var toolCalls []api.ToolCall
 	var contentSb strings.Builder
@@ -304,6 +316,32 @@ func (p *CogitoParser) eat() ([]cogitoEvent, bool) {
 	}
 
 	return events, false
+}
+
+// finalizeToolCall handles a tool call that is still buffered when the stream
+// ends. Only the trailing delimiters may be missing: the call itself must still
+// parse, since repairing a truncated call could turn partial model output into
+// a mutating tool call.
+func (p *CogitoParser) finalizeToolCall() (cogitoEventToolCall, error) {
+	raw := p.buffer.String()
+	if idx := strings.Index(raw, cogitoToolCallBeginTag); idx != -1 {
+		raw = raw[idx+len(cogitoToolCallBeginTag):]
+	}
+	// drop a partially emitted closing delimiter
+	for _, tag := range []string{cogitoToolCallEndTag, cogitoToolCallsEndTag} {
+		if overlapLen := overlap(raw, tag); overlapLen > 0 {
+			raw = raw[:len(raw)-overlapLen]
+		}
+	}
+
+	toolCall, err := p.parseToolCallContent(raw)
+	if err != nil {
+		return cogitoEventToolCall{}, err
+	}
+
+	p.buffer.Reset()
+	p.state = CogitoCollectingContent
+	return cogitoEventToolCall{toolCall: toolCall}, nil
 }
 
 func (p *CogitoParser) parseToolCallContent(content string) (api.ToolCall, error) {

--- a/model/parsers/cogito_test.go
+++ b/model/parsers/cogito_test.go
@@ -565,3 +565,97 @@ func TestCogitoParser_parseToolCallContent(t *testing.T) {
 		})
 	}
 }
+
+func TestCogitoParserFinalizesCompleteToolCallOnDone(t *testing.T) {
+	parser := &CogitoParser{}
+	parser.Init(nil, nil, nil)
+
+	// the model emitted a complete call but the stream ended before the
+	// closing delimiters arrived
+	input := cogitoToolCallsBeginTag + cogitoToolCallBeginTag +
+		"function" + cogitoToolSepTag + "get_weather\n```json\n{\"city\":\"San Francisco\"}\n```"
+
+	content, thinking, calls, err := parser.Add(input, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if content != "" {
+		t.Errorf("expected no content, got %q", content)
+	}
+	if thinking != "" {
+		t.Errorf("expected no thinking, got %q", thinking)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(calls))
+	}
+	if calls[0].Function.Name != "get_weather" {
+		t.Errorf("expected tool name %q, got %q", "get_weather", calls[0].Function.Name)
+	}
+}
+
+func TestCogitoParserRejectsIncompleteToolCallOnDone(t *testing.T) {
+	parser := &CogitoParser{}
+	parser.Init(nil, nil, nil)
+
+	// truncated mid arguments, so there is nothing safe to recover
+	input := cogitoToolCallsBeginTag + cogitoToolCallBeginTag +
+		"function" + cogitoToolSepTag + "get_weather\n```json\n{\"city\":\"San Fran"
+
+	_, _, calls, err := parser.Add(input, true)
+	if err == nil {
+		t.Fatal("expected an error for a truncated tool call, got none")
+	}
+	if len(calls) != 0 {
+		t.Errorf("expected no tool calls, got %d", len(calls))
+	}
+}
+
+func TestCogitoParserDoesNotFinalizeMidStream(t *testing.T) {
+	parser := &CogitoParser{}
+	parser.Init(nil, nil, nil)
+
+	// same complete call, but the stream is not done yet, so the parser should
+	// keep buffering and wait for the closing delimiter
+	input := cogitoToolCallsBeginTag + cogitoToolCallBeginTag +
+		"function" + cogitoToolSepTag + "get_weather\n```json\n{\"city\":\"San Francisco\"}\n```"
+
+	_, _, calls, err := parser.Add(input, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("expected no tool calls before done, got %d", len(calls))
+	}
+
+	// the closing delimiter arrives and the call is emitted exactly once
+	_, _, calls, err = parser.Add(cogitoToolCallEndTag, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(calls))
+	}
+}
+
+func TestCogitoParserKeepsCompletedToolCallWithTrailingJunkOnDone(t *testing.T) {
+	parser := &CogitoParser{}
+	parser.Init(nil, nil, nil)
+
+	// a complete call, then stray text instead of the outer end delimiter.
+	// the call was already parsed, so finalizing must not turn this into an
+	// error and lose it
+	input := cogitoToolCallsBeginTag + cogitoToolCallBeginTag +
+		"function" + cogitoToolSepTag + "get_weather\n```json\n{\"city\":\"San Francisco\"}\n```" +
+		cogitoToolCallEndTag + "trailing"
+
+	_, _, calls, err := parser.Add(input, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(calls))
+	}
+	if calls[0].Function.Name != "get_weather" {
+		t.Errorf("expected tool name %q, got %q", "get_weather", calls[0].Function.Name)
+	}
+}


### PR DESCRIPTION
The cogito parser buffers a tool call until it sees the closing delimiters, but `Add` accepted the terminal `done` signal without using it (model/parsers/cogito.go:116). If the model ended the stream after emitting a complete call but before `<｜tool▁call▁end｜>`, the buffered call was dropped and the caller got a successful empty response, which leaves agents with nothing to act on. This is the same failure the GLM parser had in #16497, fixed in #17250, so this change follows that fix closely.

On end of stream, a call that is still buffered is finalized only if it parses on its own, with a partially emitted closing delimiter trimmed first. Genuinely truncated calls now return an explicit error instead of vanishing, since repairing half an argument list could invent a mutating tool call. The finalize path only triggers when an unterminated `<｜tool▁call▁begin｜>` is actually in the buffer, so a call that already parsed normally is never re-emitted or turned into an error by trailing text.

Verified with four tests in model/parsers/cogito_test.go covering the complete-but-unterminated case, the truncated case, the not-done-yet case, and the completed-call-plus-trailing-text case. The first two fail on main and pass here. `go test ./model/... ./server/...`, `golangci-lint run model/parsers/`, and `go mod tidy` are clean locally. Verification is at the parser level rather than a live model, since I do not have cogito weights on this machine.

quick disclosure: I'm a college freshman trying to help out where I can :) I worked through this one with Claude Code, and I ran the tests, lint, and the fail-on-main check myself. I patterned it on #17250 deliberately rather than inventing different semantics, but if the stricter error behavior is not what you want here I'm very happy to change it, and I'd genuinely like to learn from anything I got wrong.