### PR TITLE
docs: add tool_call_id and ToolCall.id to the OpenAPI spec

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -505,6 +505,7 @@ The `message` object has the following fields:
 - `images` (optional): a list of images to include in the message (for multimodal models such as `llava`)
 - `tool_calls` (optional): a list of tools in JSON that the model wants to use
 - `tool_name` (optional): add the name of the tool that was executed to inform the model of the result
+- `tool_call_id` (optional): the identifier of the tool call this message responds to (for `role: tool` messages)
 
 Advanced parameters (optional):
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -222,9 +222,18 @@ components:
           items:
             $ref: "#/components/schemas/ToolCall"
           description: Tool call requests produced by the model
+        tool_name:
+          type: string
+          description: Name of the tool whose result is provided in this message (when role is `tool`)
+        tool_call_id:
+          type: string
+          description: Identifier of the tool call this message is the result of (when role is `tool`)
     ToolCall:
       type: object
       properties:
+        id:
+          type: string
+          description: Unique identifier for this tool call, used to match a tool result message to its tool call
         function:
           type: object
           required: [name]
@@ -238,6 +247,9 @@ components:
             arguments:
               type: object
               description: JSON object of arguments to pass to the function
+            index:
+              type: integer
+              description: Position of this tool call among multiple tool calls in the same turn
     ToolDefinition:
       type: object
       required: [type, function]


### PR DESCRIPTION
`docs/openapi.yaml` is out of sync with the server implementation. It is missing four tool-call fields already defined in `api/types.go` and emitted/accepted by the API: `ToolCall.id`, `ToolCall.function.index`, `ChatMessage.tool_name`, and `ChatMessage.tool_call_id`. This updates the OpenAPI spec to match the implementation and documents `tool_call_id` in `docs/api.md`.

History:

* #12805 introduced `docs/openapi.yaml` without these fields.
* #12956 added tool-call IDs to the Go types/server, but the OpenAPI spec was never updated.
