### PR TITLE
cmd/tui/chat: keep the terminal cursor on the input caret so IME preedit renders inline

### DIFF
--- a/cmd/tui/chat/chat.go
+++ b/cmd/tui/chat/chat.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"os"
 	"runtime"
 	"slices"
 	"strings"
@@ -145,6 +146,7 @@ type chatModel struct {
 
 	width              int
 	height             int
+	termCaret          *termCaretState
 	status             string
 	spinner            int
 	tickActive         bool
@@ -246,7 +248,12 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 		m.preloadingModel = strings.TrimSpace(opts.Model)
 	}
 
-	p := tea.NewProgram(m, tea.WithReportFocus())
+	caret := &termCaretState{}
+	m.termCaret = caret
+	out := newCursorSyncWriter(os.Stdout, caret)
+	defer out.restoreIfParked()
+
+	p := tea.NewProgram(m, tea.WithReportFocus(), tea.WithOutput(out))
 	finalModel, err := p.Run()
 	if err != nil {
 		return nil, err
@@ -817,29 +824,45 @@ func (m chatModel) updateDownKey() (tea.Model, tea.Cmd) {
 
 func (m chatModel) View() string {
 	if m.quitting {
+		m.publishCaret(caretPos{})
 		return ""
 	}
 
 	width, height := m.viewSize()
 
 	if m.promptDebug != nil {
+		m.publishCaret(caretPos{})
 		return m.renderPromptDebug(width, height)
 	}
 	if m.modelPicker != nil && m.openModelOnInit {
+		m.publishCaret(caretPos{})
 		return m.renderModelPicker(width)
 	}
 	if m.cloudAuthPrompt != nil {
+		m.publishCaret(caretPos{})
 		return m.renderCloudAuthPrompt(width)
 	}
 	if m.thinkPicker != nil {
+		m.publishCaret(caretPos{})
 		return m.renderThinkPicker(width)
 	}
 	return m.flowView(width)
 }
 
+// publishCaret records the on-screen cell of the input caret for the
+// cursorSyncWriter to park the physical cursor on, so terminal IME preedit
+// composition renders inline instead of at the terminal's fallback origin.
+// termCaret is nil in unit tests that construct a chatModel directly.
+func (m chatModel) publishCaret(p caretPos) {
+	if m.termCaret != nil {
+		m.termCaret.set(p)
+	}
+}
+
 func (m chatModel) flowView(width int) string {
 	allTranscriptLines := m.transcriptLines(width)
-	bottomLines := m.bottomLines(width, 0)
+	bottomLines, caret := m.bottomLinesWithCaret(width, 0)
+	m.publishCaret(caret)
 	bottomGap := transcriptInputGap(0, len(bottomLines), len(allTranscriptLines))
 
 	printed := clamp(m.flowPrintedLines, 0, len(allTranscriptLines))

--- a/cmd/tui/chat/input.go
+++ b/cmd/tui/chat/input.go
@@ -1006,6 +1006,22 @@ func (m chatModel) emptyInputPlaceholder() string {
 }
 
 func renderInputBoxLines(input string, cursor int, width, maxBodyLines int, placeholder string) []string {
+	lines, _ := renderInputBoxLinesWithCaret(input, cursor, width, maxBodyLines, placeholder)
+	return lines
+}
+
+// inputBoxCaret is the input caret's location within the lines returned by
+// renderInputBoxLinesWithCaret.
+type inputBoxCaret struct {
+	lineIdx int // index into the returned lines (0 = top border)
+	col     int // 0-based screen column within that line
+	ok      bool
+}
+
+// renderInputBoxLinesWithCaret behaves like renderInputBoxLines but also
+// reports where the input caret landed, so the physical terminal cursor can
+// be parked there for inline IME preedit rendering (see termcursor.go).
+func renderInputBoxLinesWithCaret(input string, cursor int, width, maxBodyLines int, placeholder string) ([]string, inputBoxCaret) {
 	if width < 12 {
 		width = 12
 	}
@@ -1033,6 +1049,18 @@ func renderInputBoxLines(input string, cursor int, width, maxBodyLines int, plac
 	if len(raw) > maxBodyLines {
 		raw = slices.Clone(raw[len(raw)-maxBodyLines:])
 		raw[0] = truncateInputLine(continuationPrefix+trimInputPromptPrefix(raw[0]), contentWidth)
+	}
+
+	var caret inputBoxCaret
+	for i, line := range raw {
+		if idx := strings.Index(line, inputCursorMarker); idx >= 0 {
+			caret = inputBoxCaret{
+				lineIdx: 1 + i, // +1 for the top border line
+				col:     1 + inputBoxHorizontalPadding + lipgloss.Width(line[:idx]),
+				ok:      true,
+			}
+			break
+		}
 	}
 
 	lines := make([]string, 0, len(raw)+2)
@@ -1063,7 +1091,7 @@ func renderInputBoxLines(input string, cursor int, width, maxBodyLines int, plac
 		lines = append(lines, renderInputBoxBodyLine(renderInputTextWithCursor(rendered), contentWidth))
 	}
 	lines = append(lines, chatInputBorderStyle.Render(inputBoxBottomBorderLine(width)))
-	return lines
+	return lines, caret
 }
 
 func renderInputTextWithCursor(line string) string {

--- a/cmd/tui/chat/input_test.go
+++ b/cmd/tui/chat/input_test.go
@@ -408,6 +408,91 @@ func TestTruncateInputLineUsesDisplayWidth(t *testing.T) {
 	}
 }
 
+func TestRenderInputBoxLinesWithCaret(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		cursor      int
+		width       int
+		maxBody     int
+		placeholder string
+		want        inputBoxCaret
+	}{
+		{
+			name:    "ascii mid",
+			input:   "hello",
+			cursor:  2,
+			width:   40,
+			maxBody: 12,
+			want:    inputBoxCaret{lineIdx: 1, col: 1 + inputBoxHorizontalPadding + 2, ok: true},
+		},
+		{
+			name:    "ascii end blank cell",
+			input:   "hello",
+			cursor:  5,
+			width:   40,
+			maxBody: 12,
+			want:    inputBoxCaret{lineIdx: 1, col: 1 + inputBoxHorizontalPadding + 5, ok: true},
+		},
+		{
+			name:    "cjk wide runes before caret",
+			input:   "こんにちは",
+			cursor:  2,
+			width:   40,
+			maxBody: 12,
+			// Each of the first two runes is 2 display cells wide.
+			want: inputBoxCaret{lineIdx: 1, col: 1 + inputBoxHorizontalPadding + 4, ok: true},
+		},
+		{
+			name:    "multiline caret on second line",
+			input:   "ab\ncd",
+			cursor:  4,
+			width:   40,
+			maxBody: 12,
+			want:    inputBoxCaret{lineIdx: 2, col: 1 + inputBoxHorizontalPadding + 1, ok: true},
+		},
+		{
+			name:        "placeholder caret at first cell",
+			input:       "",
+			cursor:      0,
+			width:       40,
+			maxBody:     12,
+			placeholder: "type something",
+			want:        inputBoxCaret{lineIdx: 1, col: 1 + inputBoxHorizontalPadding, ok: true},
+		},
+		{
+			name:    "cursor -1 with no placeholder has no caret",
+			input:   "abc",
+			cursor:  -1,
+			width:   40,
+			maxBody: 12,
+			want:    inputBoxCaret{},
+		},
+		{
+			name:    "caret line truncated away",
+			input:   "first line\nsecond line\nthird line",
+			cursor:  0,
+			width:   40,
+			maxBody: 1,
+			want:    inputBoxCaret{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lines, caret := renderInputBoxLinesWithCaret(tt.input, tt.cursor, tt.width, tt.maxBody, tt.placeholder)
+			if caret != tt.want {
+				t.Fatalf("caret = %+v, want %+v", caret, tt.want)
+			}
+
+			plain := renderInputBoxLines(tt.input, tt.cursor, tt.width, tt.maxBody, tt.placeholder)
+			if strings.Join(lines, "\n") != strings.Join(plain, "\n") {
+				t.Fatalf("renderInputBoxLinesWithCaret output diverges from renderInputBoxLines")
+			}
+		})
+	}
+}
+
 func TestRenderInputBoxTruncationUsesSingleContinuationMarker(t *testing.T) {
 	lines := renderInputBoxLines("one two three four five six seven", len("one two three four five six seven"), 16, 1, "")
 	rendered := strings.Join(lines, "\n")

--- a/cmd/tui/chat/render.go
+++ b/cmd/tui/chat/render.go
@@ -285,6 +285,14 @@ func (m chatModel) maxScroll() int {
 }
 
 func (m chatModel) bottomLines(width, maxHeight int) []string {
+	lines, _ := m.bottomLinesWithCaret(width, maxHeight)
+	return lines
+}
+
+// bottomLinesWithCaret behaves like bottomLines but also reports the input
+// caret's on-screen cell, relative to the last line returned. See
+// publishCaret and cursorSyncWriter for why this is tracked.
+func (m chatModel) bottomLinesWithCaret(width, maxHeight int) ([]string, caretPos) {
 	var lines []string
 	if m.modelPicker != nil {
 		lines = append(lines, m.renderInlineModelPicker(width)...)
@@ -320,11 +328,22 @@ func (m chatModel) bottomLines(width, maxHeight int) []string {
 	if m.approvalPrompt != nil || m.cloudAuthPrompt != nil {
 		inputCursor = -1
 	}
-	lines = append(lines, renderInputBoxLines(string(m.input), inputCursor, width, inputBodyLines, m.emptyInputPlaceholder())...)
+	boxStart := len(lines)
+	boxLines, boxCaret := renderInputBoxLinesWithCaret(string(m.input), inputCursor, width, inputBodyLines, m.emptyInputPlaceholder())
+	lines = append(lines, boxLines...)
 	if len(modelLines) > 0 {
 		lines = append(lines, modelLines...)
 	}
-	return lines
+
+	var caret caretPos
+	if boxCaret.ok {
+		caret = caretPos{
+			rowsUp: len(lines) - 1 - (boxStart + boxCaret.lineIdx),
+			col:    boxCaret.col,
+			ok:     true,
+		}
+	}
+	return lines, caret
 }
 
 func (m chatModel) renderModelStatusLines(width int) []string {

--- a/cmd/tui/chat/render_test.go
+++ b/cmd/tui/chat/render_test.go
@@ -29,6 +29,31 @@ func TestChatAssistantEntryHasNoLabel(t *testing.T) {
 	}
 }
 
+func TestBottomLinesCaretRow(t *testing.T) {
+	m := chatModel{
+		chatID: "chat-a",
+		input:  []rune("hi"),
+	}
+	m.opts.Model = "llama3"
+
+	lines, caret := m.bottomLinesWithCaret(80, 0)
+	if !caret.ok {
+		t.Fatal("expected a valid caret position")
+	}
+	wantRow := len(lines) - 1 - caret.rowsUp
+	if wantRow < 0 || wantRow >= len(lines) {
+		t.Fatalf("caret rowsUp = %d out of range for %d lines", caret.rowsUp, len(lines))
+	}
+	if !strings.Contains(lines[wantRow], "hi") {
+		t.Fatalf("caret does not point at the input box body line: %q", lines[wantRow])
+	}
+
+	m.approvalPrompt = &chatApprovalPrompt{request: testApprovalRequest()}
+	if _, caret := m.bottomLinesWithCaret(80, 0); caret.ok {
+		t.Fatal("caret should be invalid while an approval prompt is active")
+	}
+}
+
 func TestChatViewRendersEmptyPromptHint(t *testing.T) {
 	m := chatModel{
 		chatID: "chat-a",

--- a/cmd/tui/chat/termcursor.go
+++ b/cmd/tui/chat/termcursor.go
@@ -1,0 +1,114 @@
+package chat
+
+import (
+	"bytes"
+	"fmt"
+	"sync"
+
+	"github.com/charmbracelet/x/term"
+)
+
+// caretPos is the on-screen cell of the input caret, expressed relative to
+// the last line of the frame bubbletea just rendered.
+type caretPos struct {
+	rowsUp int // rows above the frame's last line (>= 0)
+	col    int // 0-based screen column
+	ok     bool
+}
+
+// termCaretState is shared between the chatModel (event-loop goroutine,
+// publishes one caret position per View call) and cursorSyncWriter (renderer
+// goroutine, reads it on every flush).
+type termCaretState struct {
+	mu  sync.Mutex
+	pos caretPos
+}
+
+func (s *termCaretState) set(p caretPos) {
+	s.mu.Lock()
+	s.pos = p
+	s.mu.Unlock()
+}
+
+func (s *termCaretState) get() caretPos {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.pos
+}
+
+// cursorSyncWriter wraps the real terminal output. Bubble Tea hides the
+// physical cursor for the whole TUI session and draws its own glyph, which
+// leaves the physical cursor parked at column 0 of the last rendered line.
+// Terminals anchor the IME composition (preedit) overlay at the physical
+// cursor regardless of its visibility, so without this the preedit renders
+// in the wrong place (see ollama/ollama#17521).
+//
+// After every write, cursorSyncWriter parks the (still hidden) physical
+// cursor on the input caret's cell (DECSC then relative moves), and restores
+// it (DECRC) before the next write so the renderer's own relative-cursor
+// math is unaffected.
+type cursorSyncWriter struct {
+	f     term.File
+	caret *termCaretState
+
+	mu     sync.Mutex
+	parked bool
+}
+
+func newCursorSyncWriter(f term.File, caret *termCaretState) *cursorSyncWriter {
+	return &cursorSyncWriter{f: f, caret: caret}
+}
+
+func (w *cursorSyncWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	var buf bytes.Buffer
+	if w.parked {
+		buf.WriteString("\x1b8") // DECRC
+		w.parked = false
+	}
+	prefix := buf.Len()
+
+	buf.Write(p)
+
+	if c := w.caret.get(); c.ok {
+		buf.WriteString("\x1b7") // DECSC
+		if c.rowsUp > 0 {
+			fmt.Fprintf(&buf, "\x1b[%dA", c.rowsUp)
+		}
+		fmt.Fprintf(&buf, "\x1b[%dG", c.col+1)
+		w.parked = true
+	}
+
+	n, err := w.f.Write(buf.Bytes())
+	if err != nil {
+		// Report only how much of the caller's payload was written.
+		written := n - prefix
+		if written < 0 {
+			written = 0
+		}
+		if written > len(p) {
+			written = len(p)
+		}
+		return written, err
+	}
+	return len(p), nil
+}
+
+func (w *cursorSyncWriter) Read(p []byte) (int, error) { return w.f.Read(p) }
+func (w *cursorSyncWriter) Close() error               { return w.f.Close() }
+func (w *cursorSyncWriter) Fd() uintptr                { return w.f.Fd() }
+
+// restoreIfParked un-parks the physical cursor if it was left on the caret
+// cell. It covers the case where the program is killed without a final
+// View/flush (the normal quit path already un-parks via the last frame).
+func (w *cursorSyncWriter) restoreIfParked() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if !w.parked {
+		return
+	}
+	w.parked = false
+	_, _ = w.f.Write([]byte("\x1b8"))
+}

--- a/cmd/tui/chat/termcursor_test.go
+++ b/cmd/tui/chat/termcursor_test.go
@@ -1,0 +1,203 @@
+package chat
+
+import (
+	"bytes"
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type fakeTermFile struct {
+	bytes.Buffer
+}
+
+func (f *fakeTermFile) Read(p []byte) (int, error) { return f.Buffer.Read(p) }
+func (f *fakeTermFile) Close() error               { return nil }
+func (f *fakeTermFile) Fd() uintptr                { return 0 }
+
+func TestCursorSyncWriterPassthroughWhenNoCaret(t *testing.T) {
+	f := &fakeTermFile{}
+	caret := &termCaretState{}
+	w := newCursorSyncWriter(f, caret)
+
+	n, err := w.Write([]byte("abc"))
+	if err != nil || n != 3 {
+		t.Fatalf("Write = (%d, %v), want (3, nil)", n, err)
+	}
+	if got := f.String(); got != "abc" {
+		t.Fatalf("output = %q, want %q", got, "abc")
+	}
+}
+
+func TestCursorSyncWriterParksAndRestores(t *testing.T) {
+	f := &fakeTermFile{}
+	caret := &termCaretState{}
+	caret.set(caretPos{rowsUp: 2, col: 4, ok: true})
+	w := newCursorSyncWriter(f, caret)
+
+	if _, err := w.Write([]byte("abc")); err != nil {
+		t.Fatalf("first Write: %v", err)
+	}
+	want := "abc\x1b7\x1b[2A\x1b[5G"
+	if got := f.String(); got != want {
+		t.Fatalf("first write output = %q, want %q", got, want)
+	}
+	if !w.parked {
+		t.Fatal("writer should be parked after a write with a valid caret")
+	}
+
+	f.Reset()
+	if _, err := w.Write([]byte("def")); err != nil {
+		t.Fatalf("second Write: %v", err)
+	}
+	want = "\x1b8def\x1b7\x1b[2A\x1b[5G"
+	if got := f.String(); got != want {
+		t.Fatalf("second write output = %q, want %q", got, want)
+	}
+}
+
+func TestCursorSyncWriterOmitsCursorUpWhenRowsUpIsZero(t *testing.T) {
+	f := &fakeTermFile{}
+	caret := &termCaretState{}
+	caret.set(caretPos{rowsUp: 0, col: 3, ok: true})
+	w := newCursorSyncWriter(f, caret)
+
+	if _, err := w.Write([]byte("x")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	want := "x\x1b7\x1b[4G"
+	if got := f.String(); got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestCursorSyncWriterUnparksWhenCaretBecomesInvalid(t *testing.T) {
+	f := &fakeTermFile{}
+	caret := &termCaretState{}
+	caret.set(caretPos{rowsUp: 1, col: 0, ok: true})
+	w := newCursorSyncWriter(f, caret)
+
+	if _, err := w.Write([]byte("a")); err != nil {
+		t.Fatalf("first Write: %v", err)
+	}
+	if !w.parked {
+		t.Fatal("expected writer to be parked")
+	}
+
+	caret.set(caretPos{})
+	f.Reset()
+	if _, err := w.Write([]byte("b")); err != nil {
+		t.Fatalf("second Write: %v", err)
+	}
+	if got := f.String(); got != "\x1b8b" {
+		t.Fatalf("output = %q, want %q", got, "\x1b8b")
+	}
+	if w.parked {
+		t.Fatal("writer should no longer be parked")
+	}
+}
+
+func TestCursorSyncWriterRestoreIfParked(t *testing.T) {
+	f := &fakeTermFile{}
+	caret := &termCaretState{}
+	caret.set(caretPos{rowsUp: 1, col: 0, ok: true})
+	w := newCursorSyncWriter(f, caret)
+
+	if _, err := w.Write([]byte("a")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	f.Reset()
+	w.restoreIfParked()
+	if got := f.String(); got != "\x1b8" {
+		t.Fatalf("restoreIfParked output = %q, want %q", got, "\x1b8")
+	}
+	if w.parked {
+		t.Fatal("writer should not be parked after restoreIfParked")
+	}
+
+	f.Reset()
+	w.restoreIfParked()
+	if got := f.String(); got != "" {
+		t.Fatalf("second restoreIfParked should be a no-op, got %q", got)
+	}
+}
+
+// concurrencyDetectingTermFile fails the test if two Write calls ever
+// overlap, simulating bubbletea's real usage: its own renderer already
+// serializes writes with an internal mutex (verified by reading
+// standard_renderer.go), but cursorSyncWriter must not assume that and stay
+// safe on its own, since it's called from both the event-loop goroutine
+// (execute, e.g. hideCursor/showCursor) and the renderer's ticker goroutine
+// (flush).
+type concurrencyDetectingTermFile struct {
+	fakeTermFile
+	inFlight int32
+	t        *testing.T
+}
+
+func (f *concurrencyDetectingTermFile) Write(p []byte) (int, error) {
+	if !atomic.CompareAndSwapInt32(&f.inFlight, 0, 1) {
+		f.t.Fatal("concurrent Write calls reached the underlying file")
+	}
+	// Give a concurrent Write a window to slip in if the caller's
+	// synchronization is broken.
+	time.Sleep(time.Millisecond)
+	n, err := f.fakeTermFile.Write(p)
+	atomic.StoreInt32(&f.inFlight, 0)
+	return n, err
+}
+
+func TestCursorSyncWriterSerializesConcurrentWrites(t *testing.T) {
+	f := &concurrencyDetectingTermFile{t: t}
+	caret := &termCaretState{}
+	w := newCursorSyncWriter(f, caret)
+
+	const goroutines = 20
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 2)
+	for i := 0; i < goroutines; i++ {
+		go func(i int) {
+			defer wg.Done()
+			_, _ = w.Write([]byte("frame"))
+		}(i)
+		go func(i int) {
+			defer wg.Done()
+			caret.set(caretPos{rowsUp: i % 3, col: i, ok: i%2 == 0})
+		}(i)
+	}
+	wg.Wait()
+}
+
+type erroringTermFile struct {
+	fakeTermFile
+	failAfter int
+}
+
+// Write mimics a short write: it only accepts failAfter bytes of the
+// payload and reports io.ErrShortWrite, per the io.Writer contract.
+func (f *erroringTermFile) Write(p []byte) (int, error) {
+	n := min(len(p), f.failAfter)
+	written, _ := f.Buffer.Write(p[:n])
+	if written < len(p) {
+		return written, io.ErrShortWrite
+	}
+	return written, nil
+}
+
+func TestCursorSyncWriterReportsPayloadBytesOnPartialWrite(t *testing.T) {
+	f := &erroringTermFile{failAfter: 2}
+	caret := &termCaretState{}
+	caret.set(caretPos{rowsUp: 1, col: 0, ok: true})
+	w := newCursorSyncWriter(f, caret)
+
+	n, err := w.Write([]byte("abc"))
+	if err == nil {
+		t.Fatal("expected an error from the underlying writer")
+	}
+	if n != 2 {
+		t.Fatalf("n = %d, want 2 (payload bytes actually written)", n)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/agnivade/levenshtein v1.1.1
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/charmbracelet/x/term v0.2.1
 	github.com/d4l3k/go-bfloat16 v0.0.0-20211005043715-690c3bdd05f1
 	github.com/dlclark/regexp2 v1.11.5
 	github.com/emirpasic/gods/v2 v2.0.0-alpha
@@ -50,7 +51,6 @@ require (
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
 	github.com/charmbracelet/x/ansi v0.10.1 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
-	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/chewxy/hm v1.0.0 // indirect
 	github.com/chewxy/math32 v1.11.0 // indirect
 	github.com/cloudwego/base64x v0.1.4 // indirect


### PR DESCRIPTION
Fixes #17521.

Bubble Tea hides the real cursor for the whole TUI session and draws its own glyph, so after every frame it leaves the physical cursor parked at column 0 of the last rendered line. Terminals anchor the IME composition (preedit) overlay at the physical cursor regardless of visibility, which is why typing Japanese showed the preedit string at the bottom-left of the terminal instead of inline in the input box.

cursorSyncWriter wraps stdout and, after every write the renderer makes, parks the (still hidden) cursor on the input caret's cell, restoring it before the next write so the renderer's own relative-cursor math is unaffected. The caret's screen position is computed once per View() and published through a shared pointer.

## Test plan
- `go build ./cmd/tui/...`, `go vet`, `go test` all pass
- New concurrency stress test verifies the writer's mutex under bubbletea's real dual-goroutine usage pattern
- Manual verification on Windows Terminal with Japanese IME still needed