### PR TITLE
model/parsers: finalize incomplete deepseek tool calls

### DIFF
--- a/model/parsers/deepseek3.go
+++ b/model/parsers/deepseek3.go
@@ -3,6 +3,7 @@ package parsers
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
 	"unicode"
@@ -106,6 +107,17 @@ func (deepseekEventToolCall) isDeepSeekEvent()        {}
 func (p *DeepSeek3Parser) Add(s string, done bool) (content string, thinking string, calls []api.ToolCall, err error) {
 	p.buffer.WriteString(s)
 	events := p.parseEvents()
+
+	// an unterminated tool call is still buffered: the begin tag is only
+	// consumed once its matching end tag arrives, so its presence here means
+	// the stream ended mid call
+	if done && p.state == DeepSeekCollectingToolCalls && strings.Contains(p.buffer.String(), deepseekToolCallBeginTag) {
+		event, err := p.finalizeToolCall()
+		if err != nil {
+			return "", "", nil, fmt.Errorf("incomplete deepseek tool call: %v", err)
+		}
+		events = append(events, event)
+	}
 
 	var toolCalls []api.ToolCall
 	var contentSb strings.Builder
@@ -286,6 +298,32 @@ func (p *DeepSeek3Parser) eat() ([]deepseekEvent, bool) {
 	}
 
 	return events, false
+}
+
+// finalizeToolCall handles a tool call that is still buffered when the stream
+// ends. Only the trailing delimiters may be missing: the call itself must still
+// parse, since repairing a truncated call could turn partial model output into
+// a mutating tool call.
+func (p *DeepSeek3Parser) finalizeToolCall() (deepseekEventToolCall, error) {
+	raw := p.buffer.String()
+	if idx := strings.Index(raw, deepseekToolCallBeginTag); idx != -1 {
+		raw = raw[idx+len(deepseekToolCallBeginTag):]
+	}
+	// drop a partially emitted closing delimiter
+	for _, tag := range []string{deepseekToolCallEndTag, deepseekToolCallsEndTag} {
+		if overlapLen := overlap(raw, tag); overlapLen > 0 {
+			raw = raw[:len(raw)-overlapLen]
+		}
+	}
+
+	toolCall, err := p.parseToolCallContent(raw)
+	if err != nil {
+		return deepseekEventToolCall{}, err
+	}
+
+	p.buffer.Reset()
+	p.state = DeepSeekCollectingContent
+	return deepseekEventToolCall{toolCall: toolCall}, nil
 }
 
 func (p *DeepSeek3Parser) parseToolCallContent(content string) (api.ToolCall, error) {

--- a/model/parsers/deepseek3_test.go
+++ b/model/parsers/deepseek3_test.go
@@ -721,3 +721,116 @@ func TestDeepSeekParser_EdgeCases(t *testing.T) {
 		})
 	}
 }
+
+func TestDeepSeek3ParserFinalizesCompleteToolCallOnDone(t *testing.T) {
+	parser := &DeepSeek3Parser{}
+	parser.Init(nil, nil, nil)
+
+	// the model emitted a complete call but the stream ended before the
+	// closing delimiters arrived
+	input := deepseekToolCallsBeginTag + deepseekToolCallBeginTag +
+		"get_weather" + deepseekToolSepTag + "{\"city\":\"San Francisco\"}"
+
+	content, thinking, calls, err := parser.Add(input, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if content != "" {
+		t.Errorf("expected no content, got %q", content)
+	}
+	if thinking != "" {
+		t.Errorf("expected no thinking, got %q", thinking)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(calls))
+	}
+	if calls[0].Function.Name != "get_weather" {
+		t.Errorf("expected tool name %q, got %q", "get_weather", calls[0].Function.Name)
+	}
+}
+
+func TestDeepSeek3ParserRejectsIncompleteToolCallOnDone(t *testing.T) {
+	parser := &DeepSeek3Parser{}
+	parser.Init(nil, nil, nil)
+
+	// truncated mid arguments, so there is nothing safe to recover
+	input := deepseekToolCallsBeginTag + deepseekToolCallBeginTag +
+		"get_weather" + deepseekToolSepTag + "{\"city\":\"San Fran"
+
+	_, _, calls, err := parser.Add(input, true)
+	if err == nil {
+		t.Fatal("expected an error for a truncated tool call, got none")
+	}
+	if len(calls) != 0 {
+		t.Errorf("expected no tool calls, got %d", len(calls))
+	}
+}
+
+func TestDeepSeek3ParserDoesNotFinalizeMidStream(t *testing.T) {
+	parser := &DeepSeek3Parser{}
+	parser.Init(nil, nil, nil)
+
+	// same complete call, but the stream is not done, so the parser should keep
+	// buffering and wait for the closing delimiter
+	input := deepseekToolCallsBeginTag + deepseekToolCallBeginTag +
+		"get_weather" + deepseekToolSepTag + "{\"city\":\"San Francisco\"}"
+
+	_, _, calls, err := parser.Add(input, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("expected no tool calls before done, got %d", len(calls))
+	}
+
+	// the closing delimiter arrives and the call is emitted exactly once
+	_, _, calls, err = parser.Add(deepseekToolCallEndTag, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(calls))
+	}
+}
+
+func TestDeepSeek3ParserKeepsCompletedToolCallWithTrailingJunkOnDone(t *testing.T) {
+	parser := &DeepSeek3Parser{}
+	parser.Init(nil, nil, nil)
+
+	// a complete call, then stray text instead of the outer end delimiter. eat
+	// has already emitted the call, so this guards the finalize path against
+	// firing a second time and turning leftover text into an error
+	input := deepseekToolCallsBeginTag + deepseekToolCallBeginTag +
+		"get_weather" + deepseekToolSepTag + "{\"city\":\"San Francisco\"}" +
+		deepseekToolCallEndTag + "trailing"
+
+	_, _, calls, err := parser.Add(input, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(calls))
+	}
+}
+
+func TestDeepSeek3ParserFinalizesToolCallWithPartialEndTagOnDone(t *testing.T) {
+	parser := &DeepSeek3Parser{}
+	parser.Init(nil, nil, nil)
+
+	// the stream died partway through emitting the closing delimiter, so the
+	// fragment has to be trimmed before the arguments will parse as JSON
+	partial := deepseekToolCallEndTag[:len(deepseekToolCallEndTag)/2]
+	input := deepseekToolCallsBeginTag + deepseekToolCallBeginTag +
+		"get_weather" + deepseekToolSepTag + "{\"city\":\"San Francisco\"}" + partial
+
+	_, _, calls, err := parser.Add(input, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(calls))
+	}
+	if calls[0].Function.Name != "get_weather" {
+		t.Errorf("expected tool name %q, got %q", "get_weather", calls[0].Function.Name)
+	}
+}


### PR DESCRIPTION
The deepseek parser buffers a tool call until it sees the closing delimiters, but `Add` took the terminal `done` signal without using it (model/parsers/deepseek3.go:106). If the model ended the stream after emitting a complete call but before `<｜tool▁call▁end｜>`, the buffered call was dropped and the caller got a successful empty response, so an agent waiting on that call just stalls.

This is the same defect dhiltgen fixed for the GLM parser in #17250, and I am deliberately following that fix rather than inventing different semantics. On end of stream a still-buffered call is finalized only if it parses on its own, with a partially emitted closing delimiter trimmed first; genuinely truncated calls return an explicit error instead of vanishing, since repairing half an argument list could invent a mutating tool call. The finalize path only runs when an unterminated `<｜tool▁call▁begin｜>` is actually in the buffer, so a call that already parsed normally is never re-emitted or turned into an error by trailing text.

Verified with five tests in model/parsers/deepseek3_test.go: complete but unterminated, truncated, a partially emitted end delimiter, not-done-yet, and completed-call-plus-trailing-text. The first two fail on main and pass here, and I checked the delimiter trimming is load bearing by removing it and watching that test fail. `go test ./model/... ./server/...`, `golangci-lint run model/parsers/`, and `go mod tidy` are clean locally. Verification is at the parser level rather than a live model, since I do not have deepseek weights on this machine.

Worth noting one thing: deepseek's `parseToolCallContent` unmarshals everything after the separator as JSON, unlike the cogito parser which bounds it with a fence, which is exactly why the partial delimiter has to be trimmed before parsing. Also flagging that #17125 touches this same file, but in the thinking state rather than tool calls, so the two should not conflict.

small disclosure: I'm a college freshman contributing where I can :) Claude Code helped me with this one, and I ran the tests, lint, and the fail-on-main checks myself. Happy to change the error behavior if you would rather it degrade quietly here, and glad to learn if I have misread anything.