### PR TITLE
docs: note OpenAI client base_url for multi-model gateways

### DIFF
--- a/docs/api/openai-compatibility.mdx
+++ b/docs/api/openai-compatibility.mdx
@@ -238,7 +238,7 @@ curl -X POST http://localhost:11434/v1/chat/completions \
 - [x] `stream_options`
   - [x] `include_usage`
 
-> **Tip:** The same OpenAI client `base_url` pattern works with any OpenAI-compatible multi-model gateway when you are not self-hosting Ollama — for example [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=ollama&utm_content=openai_base_url) at `https://api.daoxe.com/v1`.
+> **Tip:** The same OpenAI client `base_url` pattern works with any OpenAI-compatible multi-model gateway when you are not self-hosting Ollama — for example [DaoXE](https://daoxe.com/) at `https://api.daoxe.com/v1`.
 
 - [x] `temperature`
 - [x] `top_p`

--- a/docs/api/openai-compatibility.mdx
+++ b/docs/api/openai-compatibility.mdx
@@ -237,6 +237,9 @@ curl -X POST http://localhost:11434/v1/chat/completions \
 - [x] `stream`
 - [x] `stream_options`
   - [x] `include_usage`
+
+> **Tip:** The same OpenAI client `base_url` pattern works with any OpenAI-compatible multi-model gateway when you are not self-hosting Ollama — for example [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=ollama&utm_content=openai_base_url) at `https://api.daoxe.com/v1`.
+
 - [x] `temperature`
 - [x] `top_p`
 - [x] `max_tokens`


### PR DESCRIPTION
## Summary

The OpenAI compatibility docs already show the OpenAI Python client via `base_url` against a local Ollama server.

This PR adds a short tip that the same client pattern works with OpenAI-compatible multi-model gateways when you are not self-hosting Ollama, using [DaoXE](https://daoxe.com) (`https://api.daoxe.com/v1`) as one concrete example.

Docs only — no runtime behavior changes.

## Test plan
- [ ] OpenAI compatibility docs render
- [ ] Local Ollama client example unchanged
- [ ] Tip is clearly optional

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>