### PR TITLE
fix(app): prevent sidebar open animation on load

### DIFF
--- a/app/ui/app/src/components/layout/layout.tsx
+++ b/app/ui/app/src/components/layout/layout.tsx
@@ -13,7 +13,7 @@ export function SidebarLayout({
   const isWindows = navigator.platform.toLowerCase().includes("win");
 
   return (
-    <div className={`flex transition-[width] duration-300 dark:bg-neutral-900`}>
+    <div className={`flex overflow-hidden transition-[width] duration-300 dark:bg-neutral-900`}>
       <div
         className={`absolute flex mx-2 py-2 z-20 items-center transition-[left] duration-375 text-neutral-500 dark:text-neutral-400 ${settings.sidebarOpen ? (isWindows ? "left-2" : "left-[204px]") : isWindows ? "left-2" : "left-20"}`}
       >
@@ -57,7 +57,7 @@ export function SidebarLayout({
         </Link>
       </div>
       <div
-        className={`flex flex-col transition-[width] duration-300 max-h-screen ${settings.sidebarOpen ? "w-64" : "w-0"}`}
+        className={`flex flex-col max-h-screen`}
       >
         <div
           onDoubleClick={() => window.doubleClick && window.doubleClick()}
@@ -67,7 +67,7 @@ export function SidebarLayout({
         {settings.sidebarOpen && sidebar}
       </div>
       <main
-        className={`flex flex-1 flex-col min-w-0 transition-all duration-300`}
+        className={`flex flex-1 flex-col min-w-0 `}
       >
         <div
           className={`h-13 flex-none w-full z-10 flex items-center bg-white dark:bg-neutral-900 ${isWindows ? "xl:hidden" : "xl:fixed xl:bg-transparent xl:dark:bg-transparent"}`}
@@ -79,3 +79,8 @@ export function SidebarLayout({
     </div>
   );
 }
+
+
+
+
+

--- a/app/ui/app/src/components/layout/layout.tsx
+++ b/app/ui/app/src/components/layout/layout.tsx
@@ -58,7 +58,7 @@ export function SidebarLayout({
         )}
       </div>
       <div
-        className={`flex max-h-screen flex-col transition-[width] duration-300 ${
+        className={`flex max-h-screen flex-col ${
           sidebarOpen
             ? "w-48 border-r border-neutral-200 bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-950/40"
             : "w-0"

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -179,7 +179,7 @@ func BoolWithDefault(k string) func(defaultValue bool) bool {
 		if s := Var(k); s != "" {
 			b, err := strconv.ParseBool(s)
 			if err != nil {
-				return true
+				return defaultValue
 			}
 
 			return b

--- a/envconfig/config_test.go
+++ b/envconfig/config_test.go
@@ -188,9 +188,9 @@ func TestBool(t *testing.T) {
 		"false": false,
 		"1":     true,
 		"0":     false,
-		// invalid values
-		"random":    true,
-		"something": true,
+		// invalid values fall back to the default (false)
+		"random":    false,
+		"something": false,
 	}
 
 	for k, v := range cases {
@@ -198,6 +198,31 @@ func TestBool(t *testing.T) {
 			t.Setenv("OLLAMA_BOOL", k)
 			if b := Bool("OLLAMA_BOOL")(); b != v {
 				t.Errorf("%s: expected %t, got %t", k, v, b)
+			}
+		})
+	}
+}
+
+func TestBoolWithDefaultInvalidFallsBackToDefault(t *testing.T) {
+	cases := []struct {
+		name     string
+		env      string
+		def      bool
+		expected bool
+	}{
+		{"empty uses default false", "", false, false},
+		{"empty uses default true", "", true, true},
+		{"valid true overrides default false", "true", false, true},
+		{"valid false overrides default true", "false", true, false},
+		{"invalid falls back to default false", "garbage", false, false},
+		{"invalid falls back to default true", "garbage", true, true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Setenv("OLLAMA_BOOL_WD", c.env)
+			if got := BoolWithDefault("OLLAMA_BOOL_WD")(c.def); got != c.expected {
+				t.Errorf("BoolWithDefault(%q)(%t) = %t; want %t", c.env, c.def, got, c.expected)
 			}
 		})
 	}


### PR DESCRIPTION
Closes #12954.

Removes the width-transition from the sidebar layout so the sidebar is already laid out at its target width on first paint and no longer animates open. Keeps the adjacent(left/opacity) motion for toggle behavior.

- app/ui/app/src/components/layout/layout.tsx
 - remove transition-[width] from root wrapper
 - remove transition-[width] from sidebar container
 - remove transition-all from main region