### PR TITLE
Fix broken GPU docs link in FAQ

### DIFF
--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -18,7 +18,7 @@ Review the [Troubleshooting](./troubleshooting.mdx) docs for more about using lo
 
 ## Is my GPU compatible with Ollama?
 
-Please refer to the [GPU docs](./gpu.mdx).
+Please refer to the [GPU docs](./gpu).
 
 ## How can I specify the context window size?
 


### PR DESCRIPTION
Fixes #14243

Remove .mdx extension from GPU docs link in FAQ.