### PR TITLE
docs: add missing model name to ollama create example

### DIFF
--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -121,7 +121,7 @@ SYSTEM """You are a happy cat."""
 Then run `ollama create`:
 
 ```
-ollama create -f Modelfile
+ollama create my-model -f Modelfile
 ```
 
 ### List running models


### PR DESCRIPTION
Fixes #17346

The ollama create command requires a model name argument. The docs example was missing it.