### PR TITLE
openai: emit response.failed when generation fails mid-stream

### DIFF
--- a/middleware/openai.go
+++ b/middleware/openai.go
@@ -55,6 +55,22 @@ type EmbedWriter struct {
 	encodingFormat string
 }
 
+// streamErrorMessage reports whether data is the error envelope that the
+// server writes when generation fails after a stream is already underway, and
+// returns its message. api.ChatResponse has no counterpart field, so the
+// envelope would otherwise unmarshal into a zero value and be written out as
+// an empty chunk. The message itself can be empty, so presence of the field is
+// what marks the envelope.
+func streamErrorMessage(data []byte) (string, bool) {
+	var envelope struct {
+		Error *string `json:"error"`
+	}
+	if err := json.Unmarshal(data, &envelope); err != nil || envelope.Error == nil {
+		return "", false
+	}
+	return *envelope.Error, true
+}
+
 func (w *BaseWriter) writeError(data []byte) (int, error) {
 	var serr api.StatusError
 	if err := json.Unmarshal(data, &serr); err != nil {
@@ -473,6 +489,20 @@ func (w *ResponsesWriter) writeEvent(eventType string, data any) error {
 }
 
 func (w *ResponsesWriter) writeResponse(data []byte) (int, error) {
+	if message, ok := streamErrorMessage(data); ok && w.stream {
+		w.ResponseWriter.Header().Set("Content-Type", "text/event-stream")
+		events := w.converter.ProcessError(message)
+		if len(events) == 0 {
+			slog.Warn("generation failed after the response already ended", "error", message)
+		}
+		for _, event := range events {
+			if err := w.writeEvent(event.Event, event.Data); err != nil {
+				return 0, err
+			}
+		}
+		return len(data), nil
+	}
+
 	var chatResponse api.ChatResponse
 	if err := json.Unmarshal(data, &chatResponse); err != nil {
 		return 0, err

--- a/middleware/openai_test.go
+++ b/middleware/openai_test.go
@@ -1354,3 +1354,134 @@ func TestResponsesMiddlewareZstd(t *testing.T) {
 		})
 	}
 }
+
+func TestResponsesMiddlewareStreamError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(ResponsesMiddleware())
+	router.Handle(http.MethodPost, "/v1/responses", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+
+		chunk, err := json.Marshal(api.ChatResponse{
+			Model:   "test-model",
+			Message: api.Message{Role: "assistant", Thinking: "Let me think..."},
+		})
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		if _, err := c.Writer.Write(chunk); err != nil {
+			t.Error(err)
+			return
+		}
+
+		// Generation fails once the stream is already underway.
+		if err := json.NewEncoder(c.Writer).Encode(gin.H{"error": "error parsing tool call"}); err != nil {
+			t.Error(err)
+		}
+	})
+
+	body := `{"model": "test-model", "input": "Hello", "stream": true}`
+	req, _ := http.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.Code, http.StatusOK)
+	}
+
+	got := resp.Body.String()
+	if n := strings.Count(got, "event: response.failed"); n != 1 {
+		t.Errorf("response.failed count = %d, want 1:\n%s", n, got)
+	}
+	if strings.Contains(got, "event: response.completed") {
+		t.Errorf("stream reported completion for a failed generation:\n%s", got)
+	}
+	if !strings.Contains(got, "event: response.reasoning_summary_text.done") {
+		t.Errorf("reasoning was left open when the stream ended:\n%s", got)
+	}
+	if !strings.Contains(got, "error parsing tool call") {
+		t.Errorf("terminal event is missing the error message:\n%s", got)
+	}
+
+	// Everything on the wire has to be a blank line delimited event and data
+	// pair. A bare JSON error blob, or events run together without a
+	// separator, would reach the client as unparseable.
+	for _, block := range strings.Split(strings.TrimSuffix(got, "\n\n"), "\n\n") {
+		lines := strings.Split(block, "\n")
+		if len(lines) != 2 || !strings.HasPrefix(lines[0], "event: ") || !strings.HasPrefix(lines[1], "data: ") {
+			t.Errorf("malformed event %q in stream:\n%s", block, got)
+		}
+	}
+}
+
+func TestResponsesMiddlewareStreamErrorBeforeAnyContent(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(ResponsesMiddleware())
+	router.Handle(http.MethodPost, "/v1/responses", func(c *gin.Context) {
+		// Nothing is written first and no status is set. Status() still reports
+		// 200, which is what routes an error envelope into the streaming path
+		// even when generation failed before producing a token.
+		if err := json.NewEncoder(c.Writer).Encode(gin.H{"error": "model runner exited"}); err != nil {
+			t.Error(err)
+		}
+	})
+
+	body := `{"model": "test-model", "input": "Hello", "stream": true}`
+	req, _ := http.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	got := resp.Body.String()
+	for _, event := range []string{"response.created", "response.in_progress", "response.failed"} {
+		if !strings.Contains(got, "event: "+event) {
+			t.Errorf("stream is missing %s:\n%s", event, got)
+		}
+	}
+	if !strings.Contains(got, "model runner exited") {
+		t.Errorf("terminal event is missing the error message:\n%s", got)
+	}
+}
+
+func TestStreamErrorMessage(t *testing.T) {
+	chatResponse, err := json.Marshal(api.ChatResponse{
+		Model:   "test-model",
+		Message: api.Message{Role: "assistant", Content: "hi"},
+		Done:    true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name        string
+		data        string
+		wantMessage string
+		wantOK      bool
+	}{
+		{name: "error envelope", data: `{"error":"error parsing tool call"}`, wantMessage: "error parsing tool call", wantOK: true},
+		{name: "error envelope with status", data: `{"error":"boom","status":500}`, wantMessage: "boom", wantOK: true},
+		// api.StatusError can carry an empty message, and an empty message
+		// still has to end the stream rather than fall through as content.
+		{name: "empty message", data: `{"error":""}`, wantMessage: "", wantOK: true},
+		{name: "chat response", data: string(chatResponse), wantOK: false},
+		{name: "not json", data: "who knows", wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			message, ok := streamErrorMessage([]byte(tt.data))
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if message != tt.wantMessage {
+				t.Errorf("message = %q, want %q", message, tt.wantMessage)
+			}
+		})
+	}
+}

--- a/openai/responses.go
+++ b/openai/responses.go
@@ -901,6 +901,7 @@ type ResponsesStreamConverter struct {
 	toolCallsSent   bool
 	accumulatedText string
 	sequenceNumber  int
+	terminated      bool
 
 	// Reasoning/thinking state
 	accumulatedThinking string
@@ -943,12 +944,7 @@ func (c *ResponsesStreamConverter) Process(r api.ChatResponse) []ResponsesStream
 	hasToolCalls := len(r.Message.ToolCalls) > 0
 	hasThinking := r.Message.Thinking != ""
 
-	// First chunk - emit initial events
-	if c.firstWrite {
-		c.firstWrite = false
-		events = append(events, c.createResponseCreatedEvent())
-		events = append(events, c.createResponseInProgressEvent())
-	}
+	events = append(events, c.openStream()...)
 
 	// Handle reasoning/thinking (before other content)
 	if hasThinking {
@@ -969,9 +965,44 @@ func (c *ResponsesStreamConverter) Process(r api.ChatResponse) []ResponsesStream
 	// Done - emit closing events
 	if r.Done {
 		events = append(events, c.processCompletion(r)...)
+		c.terminated = true
 	}
 
 	return events
+}
+
+// ProcessError returns the events that end a stream on a generation error.
+// Every accepted stream ends with exactly one terminal event, so callers that
+// stop early emit these instead of closing the stream silently, and nothing is
+// emitted once Process has already closed the stream. Output is left empty
+// because the partial content was already delivered as deltas, and the items
+// buildFinalOutput produces are marked completed.
+func (c *ResponsesStreamConverter) ProcessError(message string) []ResponsesStreamEvent {
+	if c.terminated {
+		return nil
+	}
+	c.terminated = true
+
+	// A generation can fail before it produces a single token, in which case
+	// Process never ran and the stream is not open yet.
+	events := c.openStream()
+
+	// Reasoning that was streaming when the failure arrived still has an open
+	// item. Close it so the client is not left holding one, which is the
+	// missing reasoning_summary_text.done reported in #17118. An open message
+	// item is left as it is: the only close for one reports the item as
+	// completed, and a generation that failed did not complete it.
+	events = append(events, c.finishReasoning()...)
+
+	response := c.buildResponseObject("failed", []any{}, nil)
+	response["error"] = map[string]any{
+		"code":    "server_error",
+		"message": message,
+	}
+
+	return append(events, c.newEvent("response.failed", map[string]any{
+		"response": response,
+	}))
 }
 
 // buildResponseObject creates a full response object with all required fields for streaming events.
@@ -1077,6 +1108,17 @@ func (c *ResponsesStreamConverter) buildResponseObject(status string, output []a
 		"safety_identifier":    nil,
 		"prompt_cache_key":     nil,
 	}
+}
+
+// openStream returns the events that open a stream, or nil if it is already
+// open. Both the success and the failure path start a stream this way.
+func (c *ResponsesStreamConverter) openStream() []ResponsesStreamEvent {
+	if !c.firstWrite {
+		return nil
+	}
+	c.firstWrite = false
+
+	return []ResponsesStreamEvent{c.createResponseCreatedEvent(), c.createResponseInProgressEvent()}
 }
 
 func (c *ResponsesStreamConverter) createResponseCreatedEvent() ResponsesStreamEvent {

--- a/openai/responses_test.go
+++ b/openai/responses_test.go
@@ -2049,3 +2049,118 @@ func TestResponsesStreamConverter_FunctionCallStatus(t *testing.T) {
 		t.Errorf("output_item.done status = %q, want %q", doneItem["status"], "completed")
 	}
 }
+
+func TestResponsesStreamConverter_ProcessError(t *testing.T) {
+	t.Run("mid stream", func(t *testing.T) {
+		converter := NewResponsesStreamConverter("resp_123", "msg_456", "gpt-oss:20b", ResponsesRequest{})
+
+		// Stream a reasoning delta so the error arrives once the stream is underway.
+		events := converter.Process(api.ChatResponse{
+			Message: api.Message{
+				Thinking: "Let me think...",
+			},
+		})
+		if len(events) != 4 {
+			t.Fatalf("expected 4 events, got %d", len(events))
+		}
+
+		// The reasoning item opened above has to be closed before the stream
+		// ends, otherwise the client is left holding an item that never
+		// finishes.
+		events = converter.ProcessError("error parsing tool call")
+		want := []string{"response.reasoning_summary_text.done", "response.output_item.done", "response.failed"}
+		if len(events) != len(want) {
+			t.Fatalf("expected %d events, got %d", len(want), len(events))
+		}
+		for i, event := range events {
+			if event.Event != want[i] {
+				t.Errorf("event %d = %q, want %q", i, event.Event, want[i])
+			}
+			if data := event.Data.(map[string]any); data["sequence_number"] != 4+i {
+				t.Errorf("event %d sequence_number = %v, want %d", i, data["sequence_number"], 4+i)
+			}
+		}
+
+		data := events[len(events)-1].Data.(map[string]any)
+
+		response := data["response"].(map[string]any)
+		if response["status"] != "failed" {
+			t.Errorf("status = %q, want %q", response["status"], "failed")
+		}
+		if response["completed_at"] != nil {
+			t.Errorf("completed_at = %v, want nil", response["completed_at"])
+		}
+		// The partial content already went out as deltas, and every item
+		// buildFinalOutput produces is marked completed, which a failed
+		// generation did not do.
+		if output, ok := response["output"].([]any); !ok || output == nil || len(output) != 0 {
+			t.Errorf("output = %v, want empty", response["output"])
+		}
+
+		responseError, ok := response["error"].(map[string]any)
+		if !ok {
+			t.Fatalf("error = %v, want an object", response["error"])
+		}
+		if responseError["message"] != "error parsing tool call" {
+			t.Errorf("error.message = %q, want %q", responseError["message"], "error parsing tool call")
+		}
+		if responseError["code"] != "server_error" {
+			t.Errorf("error.code = %q, want %q", responseError["code"], "server_error")
+		}
+	})
+
+	t.Run("does not complete an open message item", func(t *testing.T) {
+		converter := NewResponsesStreamConverter("resp_123", "msg_456", "gpt-oss:20b", ResponsesRequest{})
+
+		converter.Process(api.ChatResponse{
+			Message: api.Message{Content: "partial answer"},
+		})
+
+		// The only close for a message item reports it completed, so a failed
+		// generation leaves it open rather than claiming it finished. The
+		// terminal event is still the one thing the stream has to end on.
+		events := converter.ProcessError("error parsing tool call")
+		if len(events) != 1 {
+			t.Fatalf("expected 1 event, got %d", len(events))
+		}
+		if events[0].Event != "response.failed" {
+			t.Errorf("event = %q, want %q", events[0].Event, "response.failed")
+		}
+	})
+
+	t.Run("before any content", func(t *testing.T) {
+		converter := NewResponsesStreamConverter("resp_123", "msg_456", "gpt-oss:20b", ResponsesRequest{})
+
+		// A failure with no preceding content still has to open the stream, so
+		// a client that keys off response.created is not handed a lone
+		// terminal event.
+		events := converter.ProcessError("model runner exited")
+		want := []string{"response.created", "response.in_progress", "response.failed"}
+		if len(events) != len(want) {
+			t.Fatalf("expected %d events, got %d", len(want), len(events))
+		}
+		for i, event := range events {
+			if event.Event != want[i] {
+				t.Errorf("event %d = %q, want %q", i, event.Event, want[i])
+			}
+			if data := event.Data.(map[string]any); data["sequence_number"] != i {
+				t.Errorf("event %d sequence_number = %v, want %d", i, data["sequence_number"], i)
+			}
+		}
+	})
+
+	t.Run("after completion", func(t *testing.T) {
+		converter := NewResponsesStreamConverter("resp_123", "msg_456", "gpt-oss:20b", ResponsesRequest{})
+
+		converter.Process(api.ChatResponse{
+			Message: api.Message{Content: "The answer is 42"},
+			Done:    true,
+		})
+
+		// The stream already ended with response.completed, so a late error
+		// must not add a second terminal event.
+		if events := converter.ProcessError("model runner exited"); events != nil {
+			t.Errorf("expected no events after completion, got %d", len(events))
+		}
+	})
+}


### PR DESCRIPTION
Fixes #17118

A streaming request to `/v1/responses` can close without any terminal event. No `response.completed`, no `response.incomplete`, no `response.failed`. The client sees HTTP 200 and a clean EOF, so a failed generation looks the same as a finished one.

## Root cause

When generation fails after streaming has started, the server puts `gin.H{"error": ...}` on the response channel and `streamResponse` writes it to `c.Writer`. `ResponsesWriter.Write` picks the error path or the content path by status code:

```go
code := w.ResponseWriter.Status()
if code != http.StatusOK {
    return w.writeError(data)
}
return w.writeResponse(data)
```

The status is pinned at 200 once the first chunk goes out, so the envelope reaches `writeResponse`, which unmarshals it into `api.ChatResponse`. That struct has no `Error` field, so the unmarshal succeeds and yields a zero value with `Done` false. The converter emits no events for it and the stream ends there.

## Change

`writeResponse` now recognizes the error envelope before treating the payload as a chat response, and emits a `response.failed` terminal event. `ProcessError` on `ResponsesStreamConverter` builds that event. The converter had no failure event before this. The check reads the payload rather than taking a typed error from `streamResponse`, since `writeError` already recognizes the same envelope the same way, and giving the writers a typed error signal would change the contract for all of them.

Two ordering details come with that. If the generation fails before producing a single token, `Process` never ran and the stream was never opened, so `ProcessError` emits `response.created` and `response.in_progress` first, rather than handing the client a lone terminal event. And if reasoning was streaming when the failure arrived, the reasoning item is still open, so `ProcessError` closes it through the existing `finishReasoning()`. That covers the missing `response.reasoning_summary_text.done` noted in the issue.

An open message item is deliberately left alone. The only close for one reports the item as `completed`, and a generation that failed did not complete it, so the stream ends with the item still open rather than claiming otherwise. That is the same reason the failed response carries an empty `output`. If you would rather it be closed with an explicit non-completed status, that is easy to add, and it looks related to what #17239 is doing to `buildFinalOutput`.

`Process` and `ProcessError` open a stream the same way, so that pair moved into a small `openStream` helper rather than being written twice.

- `middleware/openai.go`: `streamErrorMessage` envelope check, early branch in `ResponsesWriter.writeResponse`
- `openai/responses.go`: `ProcessError`, the `openStream` helper, and a `terminated` flag so a stream ends on exactly one terminal event

## Tests

`TestResponsesMiddlewareStreamError` drives the middleware end to end with a reasoning chunk followed by an error envelope. With the writer branch reverted it fails, and the captured stream ends on `response.reasoning_summary_text.delta` with nothing after it, which is the signature reported in #17118. `TestResponsesMiddlewareStreamErrorBeforeAnyContent` does the same for a failure with no preceding chunk, where the handler sets no status at all, since that is the case where `Status()` reporting 200 by default is doing the routing. `TestResponsesStreamConverter_ProcessError` covers the four converter states: mid stream, a failure while a message item is open, before any content, and after the stream already closed. `TestStreamErrorMessage` covers the envelope check itself, including an error with an empty message, which is still an error rather than a chat response.

`go test ./openai/ ./middleware/` passes. `gofumpt` and `golangci-lint` are clean. I could not build `./server/` locally because `x/mlxrunner/mlx` needs a toolchain I don't have on this machine, and that failure is present on a clean checkout too.

## Left out

`ChatWriter` and `CompleteWriter` route on status the same way, and neither `api.ChatResponse` nor `api.GenerateResponse` has an `Error` field, so a mid-stream error on `/v1/chat/completions` or `/v1/completions` hits the same path. `CompleteWriter` is the worse of the two: it emits a chunk built from the zero value, so the client gets an empty completion chunk and then no `data: [DONE]`.

I kept this PR to the Responses writer because the right behavior for the other two is less clear. The Responses API defines `response.failed` as a terminal event, while chat completions has no equivalent, and sending `[DONE]` after a failure would read to a client as a normal finish. That is a call for whoever owns the compatibility surface, not mine to make in a bug fix. Happy to do both in a follow-up, or fold them in here, if you have a preference for how they should behave.

@BrandXX did the diagnosis and put together the sanitized reproducer in #17118, and this fix rests on that work.
