### PR TITLE
server: allow the default registry to delegate authentication to ollama.com

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -25,6 +25,27 @@ type registryChallenge struct {
 	Scope   string
 }
 
+// trustedRealmHosts maps a registry host to the additional hosts it is allowed
+// to delegate token issuance to. Some registries serve their API and their
+// authentication endpoint from different hosts: the default Ollama registry
+// serves its API from registry.ollama.ai but issues tokens from ollama.com.
+var trustedRealmHosts = map[string][]string{
+	"registry.ollama.ai": {"ollama.com"},
+}
+
+// realmHostAllowed reports whether a token realm served from realmHost is
+// trusted for a registry that was contacted at originalHost. It is used to
+// permit known registry/auth host pairs while still rejecting arbitrary
+// cross-origin realms.
+func realmHostAllowed(originalHost, realmHost string) bool {
+	for _, host := range trustedRealmHosts[originalHost] {
+		if host == realmHost {
+			return true
+		}
+	}
+	return false
+}
+
 func (r registryChallenge) URL() (*url.URL, error) {
 	redirectURL, err := url.Parse(r.Realm)
 	if err != nil {
@@ -56,8 +77,10 @@ func getAuthorizationToken(ctx context.Context, challenge registryChallenge, ori
 		return "", err
 	}
 
-	// Validate that the realm host matches the original request host to prevent sending tokens cross-origin.
-	if redirectURL.Host != originalHost {
+	// Validate that the realm host is allowed for the original request host to
+	// prevent sending tokens cross-origin. The realm host is accepted when it
+	// matches the original host or is a known host of the same registry.
+	if redirectURL.Host != originalHost && !realmHostAllowed(originalHost, redirectURL.Host) {
 		return "", fmt.Errorf("realm host %q does not match original host %q", redirectURL.Host, originalHost)
 	}
 

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -18,6 +18,11 @@ func TestGetAuthorizationTokenRejectsCrossDomain(t *testing.T) {
 		{"https://example.com/token", "localhost:8000", true},
 		{"https://localhost:5000/token", "localhost:5000", false},
 		{"https://localhost:5000/token", "localhost:6000", true},
+		// The default registry serves its API from registry.ollama.ai but
+		// issues tokens from ollama.com, so that delegation is allowed.
+		{"https://ollama.com/token", "registry.ollama.ai", false},
+		// An arbitrary realm host is still rejected for the default registry.
+		{"https://evil.com/token", "registry.ollama.ai", true},
 	}
 
 	for _, tt := range tests {
@@ -34,6 +39,28 @@ func TestGetAuthorizationTokenRejectsCrossDomain(t *testing.T) {
 			}
 			if !tt.wantMismatch && isMismatch {
 				t.Errorf("unexpected domain mismatch error: %v", err)
+			}
+		})
+	}
+}
+
+func TestRealmHostAllowed(t *testing.T) {
+	tests := []struct {
+		originalHost string
+		realmHost    string
+		want         bool
+	}{
+		{"registry.ollama.ai", "ollama.com", true},
+		{"registry.ollama.ai", "registry.ollama.ai", false}, // same host handled by the caller, not the allowlist
+		{"registry.ollama.ai", "evil.com", false},
+		{"example.com", "ollama.com", false},
+		{"example.com", "auth.example.com", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.originalHost+"->"+tt.realmHost, func(t *testing.T) {
+			if got := realmHostAllowed(tt.originalHost, tt.realmHost); got != tt.want {
+				t.Errorf("realmHostAllowed(%q, %q) = %v, want %v", tt.originalHost, tt.realmHost, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #17361

## Problem
Pulling a model from the default registry can fail with:

    Error: pull model manifest: realm host "ollama.com" does not match original host "registry.ollama.ai"

The default registry serves its API from registry.ollama.ai but issues auth
tokens from ollama.com. Before sending a signed token request, the client
reads the realm from the registry's auth challenge and checks that the realm
host matches the host originally contacted. That check used strict equality,
so the legitimate registry.ollama.ai to ollama.com delegation was rejected
and the pull failed.

## Fix
Add a small allowlist of realm hosts trusted for a given registry host, and
accept the realm when it matches the original host or is a trusted host for
it. The registry.ollama.ai to ollama.com delegation is allowed; any other
cross-origin realm is still rejected, so the original protection against
sending tokens to an arbitrary host is preserved.

## Tests
Added a unit test for the allowlist helper and extended the existing
cross-domain test with the accepted default-registry case and a rejected
arbitrary-host case.
