### PR TITLE
model/parsers: finalize incomplete function_call tool calls

### DIFF
--- a/model/parsers/functiongemma.go
+++ b/model/parsers/functiongemma.go
@@ -64,6 +64,16 @@ func (p *FunctionGemmaParser) Add(s string, done bool) (content string, thinking
 	p.buffer.WriteString(s)
 	events := p.parseEvents()
 
+	// in this state anything still buffered is tool call content whose closing
+	// tag never arrived
+	if done && p.state == FunctionGemmaCollectingToolCalls && strings.TrimSpace(p.buffer.String()) != "" {
+		event, err := p.finalizeToolCall()
+		if err != nil {
+			return "", "", nil, fmt.Errorf("incomplete function_call: %v", err)
+		}
+		events = append(events, event)
+	}
+
 	var toolCalls []api.ToolCall
 	var contentSb strings.Builder
 	for _, event := range events {
@@ -155,6 +165,33 @@ func (p *FunctionGemmaParser) eat() ([]functionGemmaEvent, bool) {
 	}
 
 	return nil, false
+}
+
+// finalizeToolCall handles a tool call that is still buffered when the stream
+// ends. Only the closing tag may be missing: the call itself must still match,
+// since repairing a truncated call could turn partial model output into a
+// mutating tool call. parseToolCall reports a regex miss as an empty call
+// rather than an error, so the name is checked explicitly. A leading open tag
+// needs no special handling because the call pattern is matched anywhere in
+// the buffer.
+func (p *FunctionGemmaParser) finalizeToolCall() (functionGemmaEventToolCall, error) {
+	raw := p.buffer.String()
+	// drop a partially emitted closing tag
+	if overlapLen := overlap(raw, functionGemmaFunctionCallClose); overlapLen > 0 {
+		raw = raw[:len(raw)-overlapLen]
+	}
+
+	toolCall, err := p.parseToolCall(raw)
+	if err != nil {
+		return functionGemmaEventToolCall{}, err
+	}
+	if toolCall.Function.Name == "" {
+		return functionGemmaEventToolCall{}, fmt.Errorf("truncated call %q", raw)
+	}
+
+	p.buffer.Reset()
+	p.state = FunctionGemmaCollectingContent
+	return functionGemmaEventToolCall{toolCall: toolCall}, nil
 }
 
 // Matches call:function_name{args}

--- a/model/parsers/functiongemma_test.go
+++ b/model/parsers/functiongemma_test.go
@@ -430,3 +430,130 @@ func TestFunctionGemmaParser_HasSupport(t *testing.T) {
 	assert.True(t, parser.HasToolSupport())
 	assert.False(t, parser.HasThinkingSupport())
 }
+
+func TestFunctionGemmaParserFinalizesCompleteToolCallOnDone(t *testing.T) {
+	parser := &FunctionGemmaParser{}
+	parser.Init(nil, nil, nil)
+
+	// the call is complete but the stream ended before the closing tag
+	input := functionGemmaFunctionCallOpen + "call:get_weather{city:San Francisco}"
+
+	content, _, calls, err := parser.Add(input, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if content != "" {
+		t.Errorf("expected no content, got %q", content)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(calls))
+	}
+	if calls[0].Function.Name != "get_weather" {
+		t.Errorf("expected tool name %q, got %q", "get_weather", calls[0].Function.Name)
+	}
+}
+
+func TestFunctionGemmaParserFinalizesToolCallWithPartialCloseTagOnDone(t *testing.T) {
+	parser := &FunctionGemmaParser{}
+	parser.Init(nil, nil, nil)
+
+	// the stream died partway through the closing tag, so the fragment has to be
+	// trimmed before the call will match
+	partial := functionGemmaFunctionCallClose[:len(functionGemmaFunctionCallClose)/2]
+	input := functionGemmaFunctionCallOpen + "call:get_weather{city:San Francisco}" + partial
+
+	_, _, calls, err := parser.Add(input, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(calls))
+	}
+	if calls[0].Function.Name != "get_weather" {
+		t.Errorf("expected tool name %q, got %q", "get_weather", calls[0].Function.Name)
+	}
+}
+
+func TestFunctionGemmaParserRejectsIncompleteToolCallOnDone(t *testing.T) {
+	parser := &FunctionGemmaParser{}
+	parser.Init(nil, nil, nil)
+
+	// truncated mid arguments. parseToolCall reports this as an empty call
+	// rather than an error, so it must not surface as a nameless tool call
+	input := functionGemmaFunctionCallOpen + "call:get_weather{city:San Fran"
+
+	_, _, calls, err := parser.Add(input, true)
+	if err == nil {
+		t.Fatal("expected an error for a truncated tool call, got none")
+	}
+	if len(calls) != 0 {
+		t.Errorf("expected no tool calls, got %d", len(calls))
+	}
+}
+
+func TestFunctionGemmaParserDoesNotFinalizeMidStream(t *testing.T) {
+	parser := &FunctionGemmaParser{}
+	parser.Init(nil, nil, nil)
+
+	input := functionGemmaFunctionCallOpen + "call:get_weather{city:San Francisco}"
+
+	_, _, calls, err := parser.Add(input, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("expected no tool calls before done, got %d", len(calls))
+	}
+
+	// the closing tag arrives and the call is emitted exactly once
+	_, _, calls, err = parser.Add(functionGemmaFunctionCallClose, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(calls))
+	}
+}
+
+func TestFunctionGemmaParserKeepsCompletedToolCallOnDone(t *testing.T) {
+	parser := &FunctionGemmaParser{}
+	parser.Init(nil, nil, nil)
+
+	// a properly closed call: eat already emitted it, so the finalize path must
+	// not fire again
+	input := functionGemmaFunctionCallOpen + "call:get_weather{city:San Francisco}" +
+		functionGemmaFunctionCallClose
+
+	_, _, calls, err := parser.Add(input, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(calls))
+	}
+}
+
+func TestFunctionGemmaParserFinalizesSecondToolCallOnDone(t *testing.T) {
+	parser := &FunctionGemmaParser{}
+	parser.Init(nil, nil, nil)
+
+	// first call closes cleanly, second one does not. the second call carries its
+	// own open tag at the front of the buffer, which has to be stripped
+	input := functionGemmaFunctionCallOpen + "call:get_weather{city:San Francisco}" +
+		functionGemmaFunctionCallClose +
+		functionGemmaFunctionCallOpen + "call:get_time{city:San Francisco}"
+
+	_, _, calls, err := parser.Add(input, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 tool calls, got %d", len(calls))
+	}
+	if calls[0].Function.Name != "get_weather" {
+		t.Errorf("expected first call %q, got %q", "get_weather", calls[0].Function.Name)
+	}
+	if calls[1].Function.Name != "get_time" {
+		t.Errorf("expected second call %q, got %q", "get_time", calls[1].Function.Name)
+	}
+}


### PR DESCRIPTION
The functiongemma parser buffers a tool call until it sees `<end_function_call>`, but `Add` took the terminal `done` signal without using it (model/parsers/functiongemma.go:63). If the model ended the stream after emitting a complete call but before the closing tag, the buffered call was dropped and the caller got a successful empty response, so an agent waiting on that call just stalls.

Same defect dhiltgen fixed for the GLM parser in #17250, and I am following that fix rather than inventing different semantics. On end of stream a still-buffered call is finalized only if it still matches, with a partially emitted closing tag trimmed first; anything truncated returns an explicit error instead of vanishing, since repairing half an argument list could invent a mutating tool call. One wrinkle specific to this parser: `parseToolCall` reports a regex miss as an empty `api.ToolCall` with a nil error rather than as a failure, so finalize checks the function name explicitly, otherwise a truncated call would surface as a nameless tool call instead of an error.

Verified with six tests in model/parsers/functiongemma_test.go: complete but unterminated, a partially emitted closing tag, truncated arguments, not-done-yet, a properly closed call (guards against double emission), and a second unterminated call in the same turn. Four of the six fail on main and pass here. `go test ./model/... ./server/...`, `golangci-lint run model/parsers/`, and `go mod tidy` are clean locally. Verification is at the parser level rather than a live model, since I do not have these weights on this machine.

Flagging that #17492 also touches this file, but in `splitArguments` and inside the existing test table, so it should not conflict with the hunks here.

quick disclosure: I'm a college freshman contributing where I can :) Claude Code helped me with this one and I ran the tests, lint, and the fail-on-main checks myself. Happy to make this degrade quietly instead of erroring if that fits the codebase better, and glad to be corrected on anything I have misread.