### PR TITLE
server: verify blob digest before trusting a same-size cache hit

### DIFF
--- a/server/download.go
+++ b/server/download.go
@@ -489,14 +489,20 @@ func downloadBlob(ctx context.Context, opts downloadOpts) (cacheHit bool, _ erro
 	case err != nil:
 		return false, err
 	default:
-		opts.fn(api.ProgressResponse{
-			Status:    fmt.Sprintf("pulling %s", opts.digest[7:19]),
-			Digest:    opts.digest,
-			Total:     fi.Size(),
-			Completed: fi.Size(),
-		})
+		// A size-only check can't tell a valid blob from one a stalled
+		// write or disk error left corrupted at the right length, so
+		// confirm its digest before trusting it as a cache hit.
+		if err := verifyBlob(opts.digest); err == nil {
+			opts.fn(api.ProgressResponse{
+				Status:    fmt.Sprintf("pulling %s", opts.digest[7:19]),
+				Digest:    opts.digest,
+				Total:     fi.Size(),
+				Completed: fi.Size(),
+			})
 
-		return true, nil
+			return true, nil
+		}
+		slog.Warn("existing blob failed digest verification, re-downloading", "digest", opts.digest)
 	}
 
 	data, ok := blobDownloadManager.LoadOrStore(opts.digest, &blobDownload{Name: fp, Digest: opts.digest})

--- a/server/download_test.go
+++ b/server/download_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"errors"
@@ -9,9 +10,16 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"path/filepath"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/manifest"
+	"github.com/ollama/ollama/types/model"
 )
 
 func BenchmarkDownloadChunkCompletion(b *testing.B) {
@@ -109,5 +117,79 @@ func TestDownloadChunkDetectsStallBeforeFirstByte(t *testing.T) {
 	}
 	if elapsed >= 5*downloadStallTimeout {
 		t.Fatalf("downloadChunk() detected the stall after %v, want less than %v", elapsed, 5*downloadStallTimeout)
+	}
+}
+
+// TestDownloadBlobRedownloadsCorruptedExisting reproduces
+// https://github.com/ollama/ollama/issues/17520: a blob on disk whose
+// content doesn't match its digest, but whose size happens to match, must
+// not be trusted as a cache hit just because a same-size file exists at its
+// path.
+func TestDownloadBlobRedownloadsCorruptedExisting(t *testing.T) {
+	t.Setenv("OLLAMA_MODELS", t.TempDir())
+
+	goodData := []byte("the quick brown fox jumps over the lazy dog")
+	digest := fmt.Sprintf("sha256:%x", sha256.Sum256(goodData))
+
+	fp, err := manifest.BlobsPath(digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Pre-populate the blob store with a same-size but corrupted blob, as a
+	// stalled write or disk error would leave behind.
+	if err := os.WriteFile(fp, make([]byte, len(goodData)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var directRequests atomic.Int32
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodHead:
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", len(goodData)))
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/direct/"):
+			directRequests.Add(1)
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", len(goodData)))
+			w.WriteHeader(http.StatusPartialContent)
+			w.Write(goodData)
+		case r.Method == http.MethodGet:
+			// Resolution request: redirect to the direct blob URL, mirroring
+			// a registry handing off to a CDN.
+			w.Header().Set("Location", serverURL+"/direct/blob")
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	serverURL = server.URL
+
+	n := model.ParseName("test/model:latest")
+	n.ProtocolScheme = "http"
+	n.Host = strings.TrimPrefix(server.URL, "http://")
+
+	cacheHit, err := downloadBlob(t.Context(), downloadOpts{
+		n:       n,
+		digest:  digest,
+		regOpts: &registryOptions{},
+		fn:      func(api.ProgressResponse) {},
+	})
+	if err != nil {
+		t.Fatalf("downloadBlob failed: %v", err)
+	}
+	if cacheHit {
+		t.Error("cacheHit = true for a corrupted blob; want a fresh download")
+	}
+	if directRequests.Load() == 0 {
+		t.Error("no request made to fetch blob content; corrupted same-size blob was trusted instead of re-downloaded")
+	}
+
+	got, err := os.ReadFile(fp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, goodData) {
+		t.Error("blob on disk does not match expected content after re-download")
 	}
 }

--- a/x/transfer/download.go
+++ b/x/transfer/download.go
@@ -88,6 +88,69 @@ func (d *downloader) holdBody(ctx context.Context) (func(), error) {
 	return func() { d.bodySem.Release(1) }, nil
 }
 
+// verifyExisting checks blobs already present at destDir against their
+// digest, concurrently. Blobs that are missing, wrong-sized, or fail digest
+// verification are returned for (re)download; the rest count toward the
+// returned already-verified byte total.
+func verifyExisting(ctx context.Context, blobs []Blob, destDir string, concurrency int, logger *slog.Logger) ([]Blob, int64, error) {
+	var (
+		mu           sync.Mutex
+		needDownload []Blob
+		verified     int64
+	)
+
+	sem := semaphore.NewWeighted(int64(max(1, concurrency)))
+	g, ctx := errgroup.WithContext(ctx)
+	for _, blob := range blobs {
+		g.Go(func() error {
+			if err := sem.Acquire(ctx, 1); err != nil {
+				return err
+			}
+			defer sem.Release(1)
+
+			path := filepath.Join(destDir, digestToPath(blob.Digest))
+			ok := blobMatchesDigest(path, blob.Size, blob.Digest)
+
+			mu.Lock()
+			defer mu.Unlock()
+			if ok {
+				if logger != nil {
+					logger.Debug("blob already exists", "digest", blob.Digest, "size", blob.Size)
+				}
+				verified += blob.Size
+			} else {
+				needDownload = append(needDownload, blob)
+			}
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, 0, err
+	}
+	return needDownload, verified, nil
+}
+
+// blobMatchesDigest reports whether the file at path exists, matches size,
+// and its content hashes to digest.
+func blobMatchesDigest(path string, size int64, digest string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	fi, err := f.Stat()
+	if err != nil || fi.Size() != size {
+		return false
+	}
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return false
+	}
+	return fmt.Sprintf("sha256:%x", h.Sum(nil)) == digest
+}
+
 func download(ctx context.Context, opts DownloadOptions) error {
 	if len(opts.Blobs) == 0 {
 		return nil
@@ -99,25 +162,23 @@ func download(ctx context.Context, opts DownloadOptions) error {
 		total += b.Size
 	}
 
-	// Filter out already-downloaded blobs and track completed bytes
-	var blobs []Blob
-	var alreadyCompleted int64
-	for _, b := range opts.Blobs {
-		if fi, _ := os.Stat(filepath.Join(opts.DestDir, digestToPath(b.Digest))); fi != nil && fi.Size() == b.Size {
-			if opts.Logger != nil {
-				opts.Logger.Debug("blob already exists", "digest", b.Digest, "size", b.Size)
-			}
-			alreadyCompleted += b.Size
-			continue
-		}
-		blobs = append(blobs, b)
-	}
-	if len(blobs) == 0 {
-		return nil
+	concurrency := cmp.Or(opts.Concurrency, DefaultDownloadConcurrency)
+
+	// Blobs already on disk are verified against their digest, not just
+	// stat'd, before being trusted: a size-only check can't tell a valid
+	// blob from one a stalled write or disk error left corrupted at the
+	// right length.
+	blobs, alreadyCompleted, err := verifyExisting(ctx, opts.Blobs, opts.DestDir, concurrency, opts.Logger)
+	if err != nil {
+		return err
 	}
 
 	progress := newProgressTracker(total, opts.Progress)
-	progress.add(alreadyCompleted) // Report already-downloaded bytes upfront
+	progress.add(alreadyCompleted) // Report already-verified bytes upfront
+
+	if len(blobs) == 0 {
+		return nil
+	}
 
 	d := &downloader{
 		client:       cmp.Or(opts.Client, defaultClient),
@@ -135,7 +196,6 @@ func download(ctx context.Context, opts DownloadOptions) error {
 	// 0 or negative serializes; never unbounded.
 	d.bodySem = semaphore.NewWeighted(int64(max(1, opts.BodyConcurrency)))
 
-	concurrency := cmp.Or(opts.Concurrency, DefaultDownloadConcurrency)
 	sem := semaphore.NewWeighted(int64(concurrency))
 
 	start := time.Now()
@@ -149,7 +209,7 @@ func download(ctx context.Context, opts DownloadOptions) error {
 			return d.download(ctx, blob)
 		})
 	}
-	err := g.Wait()
+	err = g.Wait()
 	elapsed := time.Since(start)
 	done := d.progress.completed.Load() - alreadyCompleted
 	mbps := float64(done) / 1e6 / max(0.001, elapsed.Seconds())

--- a/x/transfer/transfer_test.go
+++ b/x/transfer/transfer_test.go
@@ -324,6 +324,58 @@ func TestDownloadSkipsExisting(t *testing.T) {
 	}
 }
 
+// TestDownloadRedownloadsCorruptedExisting reproduces
+// https://github.com/ollama/ollama/issues/17520: a blob on disk whose
+// content doesn't match its digest, but whose size happens to match, must
+// not be silently trusted just because a same-size file exists at its path.
+func TestDownloadRedownloadsCorruptedExisting(t *testing.T) {
+	serverDir := t.TempDir()
+	blob1, goodData := createTestBlob(t, serverDir, 1024)
+
+	// Pre-populate client dir with a same-size but corrupted blob, as a
+	// stalled write or disk error would leave behind.
+	clientDir := t.TempDir()
+	path := filepath.Join(clientDir, digestToPath(blob1.Digest))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	corrupted := make([]byte, len(goodData))
+	if err := os.WriteFile(path, corrupted, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var requestCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		digest := filepath.Base(r.URL.Path)
+		path := filepath.Join(serverDir, digestToPath(digest))
+		data, err := os.ReadFile(path)
+		if err != nil {
+			http.NotFound(w, r)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write(data)
+	}))
+	defer server.Close()
+
+	err := Download(context.Background(), DownloadOptions{
+		Blobs:   []Blob{blob1},
+		BaseURL: server.URL,
+		DestDir: clientDir,
+	})
+	if err != nil {
+		t.Fatalf("Download failed: %v", err)
+	}
+
+	// The corrupted blob must have been re-fetched from the registry.
+	if requestCount.Load() == 0 {
+		t.Error("No requests made; corrupted same-size blob was trusted instead of re-downloaded")
+	}
+
+	verifyBlob(t, clientDir, blob1, goodData)
+}
+
 func TestDownloadResumeProgressTotal(t *testing.T) {
 	// Test that when resuming a download with some blobs already present:
 	// 1. Total reflects ALL blob sizes (not just remaining)


### PR DESCRIPTION
## Summary
- `pull`'s "already downloaded" checks in both the fast-transfer path (`x/transfer/download.go`) and the legacy path (`server/download.go`) only compared file size against the manifest, never re-hashing content already on disk.
- A blob a stalled write or disk error left corrupted at the right size passed both checks forever: `pull` kept reporting `success`, `list` showed the model as healthy, and only `run` failed, with an error (`invalid character '\x00' looking for beginning of value`) that didn't identify the blob or the corruption.
- Both cache-hit checks now confirm the blob's sha256 digest before trusting it, falling through to a real (re)download on mismatch.

## Root cause
Both pull paths use a filename-as-hash content-addressed blob store, but neither one actually confirmed the filename matched the content before skipping a re-download:
- `x/transfer/download.go`'s `download()` filtered "already downloaded" blobs with `os.Stat(...).Size() == b.Size` only.
- `server/download.go`'s `downloadBlob()` treated any existing file at the blob path as a cache hit (`os.Stat` success), which also caused `PullModel` to skip its own `verifyBlob()` call for that layer (`skipVerify[layer.Digest] = cacheHit`).

## Changes
- `x/transfer/download.go`: replaced the sequential stat-only filter with a new `verifyExisting()` that hashes candidate blobs concurrently (reusing the existing semaphore-bounded concurrency), plus a `blobMatchesDigest()` helper. Mismatches fall through to a normal download.
- `server/download.go`: `downloadBlob`'s cache-hit branch now calls the existing `verifyBlob()` before trusting a same-size file; on mismatch it logs a warning and falls through to the existing download flow instead of returning early.

## Testing
- Added `TestDownloadRedownloadsCorruptedExisting` (`x/transfer/transfer_test.go`) and `TestDownloadBlobRedownloadsCorruptedExisting` (`server/download_test.go`): both pre-populate a same-size, wrong-content blob and assert it gets re-fetched and the content is corrected. Both fail against the pre-fix code and pass after the fix.
- `go test ./server/... ./x/transfer/...` — pass
- `go test -race ./server/... ./x/transfer/...` — pass, no races
- Full non-`app` package test suite (`go test` across every top-level package except `app/`, which needs a separate frontend build unrelated to this change) — all pass
- `go vet`, `gofmt -l`, `golangci-lint run` (repo's own `.golangci.yaml`) — clean

Note: verifying existing blobs by digest adds a bounded, local-disk-only cost to `pull` proportional to already-present model size (no network round trip). This trades a small amount of pull latency for pull always being able to self-heal a corrupted blob store, rather than requiring a failed `run` first.

Fixes #17520