### PR TITLE
docs: add Libre WebUI to community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ console.log(response.message.content);
 - [Hollama](https://github.com/fmaclen/hollama) - Minimal web interface
 - [Chatbox](https://github.com/Bin-Huang/Chatbox) - Desktop and web AI client
 - [chat](https://github.com/swuecho/chat) - Chat web app for teams
+- [Libre WebUI](https://github.com/libre-webui/libre-webui) - Local-first workspace with private knowledge, artifacts, and sandboxed agent work
 - [Ollama RAG Chatbot](https://github.com/datvodinh/rag-chatbot.git) - Chat with multiple PDFs using RAG
 - [Tkinter-based client](https://github.com/chyok/ollama-gui) - Python desktop client
 


### PR DESCRIPTION
Adds Libre WebUI to Community Integrations → Chat Interfaces → Web.

Libre WebUI is an Apache-2.0, self-hosted AI workspace with first-class Ollama support: chat, RAG over your own documents, artifacts, and isolated sandboxed workspaces for model-driven work. No telemetry.

<img width="1624" height="1012" alt="screenshot" src="https://github.com/user-attachments/assets/e2e9df7a-67a5-47f7-b126-ba0309ef5233" />

- Repo: https://github.com/libre-webui/libre-webui
- Docs: https://docs.librewebui.org

One line added, based on current `main`.

Supersedes #13903, which was opened from a fork's `main` branch and fell into conflict after the Community Integrations section was restructured.