### PR TITLE
llm: warn when a model is loaded entirely on CPU

### DIFF
--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -1032,6 +1032,8 @@ func (s *llamaServerRunner) Load(ctx context.Context, systemInfo ml.SystemInfo, 
 			"model", s.modelPath, "gpus", len(s.gpus))
 	}
 
+	s.warnIfCPUFallback()
+
 	if s.options.MainGPU != nil && *s.options.MainGPU >= 0 && *s.options.MainGPU < len(gpus) {
 		return []ml.DeviceID{gpus[*s.options.MainGPU].DeviceID}, nil
 	}
@@ -1102,6 +1104,26 @@ func (s *llamaServerRunner) hasParsedVRAM() bool {
 	defer s.memoryMu.RUnlock()
 
 	return len(s.vramByDevice) > 0
+}
+
+// warnIfCPUFallback reports a load that ended up entirely on CPU despite GPUs
+// being present. Partial offload is left to `ollama ps`, and num_gpu=0 is
+// intentional rather than a fallback.
+func (s *llamaServerRunner) warnIfCPUFallback() {
+	if len(s.gpus) == 0 || s.options.NumGPU == 0 {
+		return
+	}
+
+	s.memoryMu.RLock()
+	gpuLayers, totalLayers := s.gpuLayers, s.totalLayers
+	s.memoryMu.RUnlock()
+
+	if totalLayers == 0 || gpuLayers > 0 {
+		return
+	}
+
+	slog.Warn("model loaded entirely on CPU: no layers fit in available VRAM",
+		"model", s.modelPath, "layers", totalLayers, "gpus", len(s.gpus))
 }
 
 func (s *llamaServerRunner) startLoadTracking(t time.Time) {

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -3604,4 +3605,50 @@ func fakeRunningCmd() *exec.Cmd {
 	// pass *testing.T here without changing all call sites. The OS will
 	// SIGKILL children when the test process exits.
 	return cmd
+}
+
+func TestWarnIfCPUFallback(t *testing.T) {
+	gpu := ml.DeviceInfo{DeviceID: ml.DeviceID{ID: "0", Library: "CUDA"}, Name: "CUDA0"}
+
+	tests := []struct {
+		name     string
+		numGPU   int
+		gpus     []ml.DeviceInfo
+		line     string
+		wantWarn bool
+	}{
+		{"no layers offloaded", -1, []ml.DeviceInfo{gpu}, "llm_load_tensors: offloaded 0/33 layers to GPU\n", true},
+		{"partial offload", -1, []ml.DeviceInfo{gpu}, "llm_load_tensors: offloaded 22/33 layers to GPU\n", false},
+		{"full offload", -1, []ml.DeviceInfo{gpu}, "llm_load_tensors: offloaded 33/33 layers to GPU\n", false},
+		{"cpu requested", 0, []ml.DeviceInfo{gpu}, "llm_load_tensors: offloaded 0/33 layers to GPU\n", false},
+		{"no gpus", -1, nil, "llm_load_tensors: offloaded 0/33 layers to GPU\n", false},
+		{"nothing parsed", -1, []ml.DeviceInfo{gpu}, "llm_load_tensors: loading model\n", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := &llamaServerRunner{
+				modelPath:        "/models/test.gguf",
+				options:          api.Options{Runner: api.Runner{NumGPU: tt.numGPU}},
+				gpus:             tt.gpus,
+				vramByDevice:     make(map[string]uint64),
+				systemFreeAtLoad: make(map[string]uint64),
+			}
+
+			w := &memoryParsingWriter{inner: io.Discard, runner: runner}
+			if _, err := w.Write([]byte(tt.line)); err != nil {
+				t.Fatal(err)
+			}
+
+			var buf bytes.Buffer
+			restore := slog.Default()
+			slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+			runner.warnIfCPUFallback()
+			slog.SetDefault(restore)
+
+			if warned := strings.Contains(buf.String(), "entirely on CPU"); warned != tt.wantWarn {
+				t.Errorf("warned = %v, want %v (log: %q)", warned, tt.wantWarn, buf.String())
+			}
+		})
+	}
 }


### PR DESCRIPTION
Addresses #14258.

When no layers fit in available VRAM, llama-server runs the whole model on CPU and nothing is logged
at default level.

### Scope

@rick-github noted on the issue that `ollama ps` already shows when a model has spilled to system
RAM. Agreed, this does not re-add general GPU/CPU split logging. Partial offload stays silent; only
total fallback warns.

That case is different because the symptom often appears elsewhere. In
[a report on the issue](https://github.com/ollama/ollama/issues/14258), a 14B model silently on CPU
saturated the host until an unrelated embeddings model on the same daemon returned zero-byte
responses, and `ollama ps` on the embedding model showed nothing wrong. `ollama ps` answers which
processor a model landed on once you already suspect that model.

An explicit `num_gpu: 0` is intentional and stays silent.

### On #14261

#14261 proposes this and has been open since February, but it patches `llm/server.go`, which since
the move to llama-server auto-detection no longer contains the `NumGPU = 0` guard or the
`insufficient VRAM to load any model layers` string, so I don't think it can still apply. Happy to
close this in favour of an updated #14261 if you'd prefer.

### Implementation

`memoryParsingWriter` already parses `offloaded N/M layers to GPU` for memory accounting, so `Load`
just reports it. Logging only, no behaviour change.

```
level=WARN msg="model loaded entirely on CPU: no layers fit in available VRAM"
  model=/models/qwen2.5-14b.gguf layers=49 gpus=1
```

### Testing

`TestWarnIfCPUFallback` drives real llama-server log lines through `memoryParsingWriter` and asserts
whether a warning is emitted: zero offload, partial, full, `num_gpu=0`, no GPUs, nothing parsed. It
fails if the `num_gpu=0` guard is removed.

`gofmt`, `go vet ./llm/`, the full `./llm/` suite and `go build ./...` pass. No new dependencies.

I don't have an NVIDIA GPU to hand, so this hasn't been observed firing during a real
VRAM-constrained load: the parsing and the decision are tested, not the end-to-end. Happy to reword
or drop to `slog.Info`.

