### PR TITLE
server: return the upstream status from /api/embeddings

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -1066,6 +1066,13 @@ func (s *Server) EmbeddingsHandler(c *gin.Context) {
 	embedding, _, err := r.Embedding(c.Request.Context(), req.Prompt)
 	if err != nil {
 		s.sched.expireRunnersForRuntimeOOM(m, err)
+
+		var serr api.StatusError
+		if errors.As(err, &serr) {
+			c.AbortWithStatusJSON(serr.StatusCode, gin.H{"error": serr.ErrorMessage})
+			return
+		}
+
 		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": strings.TrimSpace(err.Error())})
 		return
 	}

--- a/server/routes_generate_test.go
+++ b/server/routes_generate_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -62,6 +63,7 @@ type mockRunner struct {
 	Template      string
 	TemplateFn    func(context.Context, llm.ChatRequest) (string, error)
 	DetokenizeFn  func(context.Context, []int) (string, error)
+	EmbeddingFn   func(context.Context, string) ([]float32, int, error)
 	contextLength int
 }
 
@@ -104,6 +106,13 @@ func (mockRunner) Tokenize(_ context.Context, s string) (tokens []int, err error
 	}
 
 	return
+}
+
+func (m *mockRunner) Embedding(ctx context.Context, s string) ([]float32, int, error) {
+	if m.EmbeddingFn != nil {
+		return m.EmbeddingFn(ctx, s)
+	}
+	return []float32{0.1, 0.2}, len(strings.Fields(s)), nil
 }
 
 func (mockRunner) Ping(_ context.Context) error { return nil }
@@ -3215,5 +3224,41 @@ func TestImageGenerateUnsupported(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), "image generation models are not currently supported") {
 		t.Fatalf("expected unsupported error in body, got %q", w.Body.String())
+	}
+}
+
+func TestEmbeddingsHandlerPreservesUpstreamStatus(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name     string
+		err      error
+		wantCode int
+	}{
+		{"client error keeps its status", api.StatusError{
+			StatusCode:   http.StatusBadRequest,
+			ErrorMessage: "the input length exceeds the context length",
+		}, http.StatusBadRequest},
+		{"plain error is still a server error", errors.New("boom"), http.StatusInternalServerError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := mockRunner{
+				EmbeddingFn: func(context.Context, string) ([]float32, int, error) {
+					return nil, 0, tt.err
+				},
+			}
+			s := newServerWithMockRunner(t, &mock)
+			createMinimalGGUFModel(t, s, "embeddings-status", ggml.KV{}, "", nil)
+
+			w := createRequest(t, s.EmbeddingsHandler, api.EmbeddingRequest{
+				Model:  "embeddings-status",
+				Prompt: "some text",
+			})
+			if w.Code != tt.wantCode {
+				t.Errorf("status = %d, want %d: %s", w.Code, tt.wantCode, w.Body.String())
+			}
+		})
 	}
 }


### PR DESCRIPTION
`/api/embeddings` returns **500** when the input is longer than the context window:

```
$ curl -s localhost:11434/api/embeddings -d '{"model":"nomic-embed-text","prompt":"<180KB>"}'
HTTP 500  {"error":"the input length exceeds the context length"}
```

`/api/embed` returns **400** for the same condition and the same message. A client that retries on 5xx
will retry forever on a request that can never succeed.

The handler blanket-wraps every runner error as `StatusInternalServerError`, discarding the
`api.StatusError` the runner already returns (`llm/llama_server.go`). The completion paths in this same
file already honour it:

```go
var serr api.StatusError
if errors.As(err, &serr) {
    c.JSON(serr.StatusCode, gin.H{"error": serr.ErrorMessage})
}
```

This applies that pattern to `EmbeddingsHandler`. Non-status errors still return 500.

### Testing

`TestEmbeddingsHandlerPreservesUpstreamStatus`: an `api.StatusError{400}` from the runner comes back as
400; a plain error still comes back as 500. The first subtest fails without the change.

`gofmt`, `go vet ./server/`, the full `./server/` suite and `go build ./...` pass.

Note: this adds an `Embedding` method to `mockRunner`, which #17543 also does, so happy to rebase
whichever lands second.

