### PR TITLE
model/parsers: report incomplete ministral tool calls

### DIFF
--- a/model/parsers/ministral.go
+++ b/model/parsers/ministral.go
@@ -304,6 +304,20 @@ func (p *MinistralParser) Add(s string, done bool) (content string, thinking str
 		p.callIndex++
 	}
 
+	// The stream ended midway through a tool call. Nothing here is safe to
+	// recover: a complete argument object would already have been emitted by
+	// eat, so guessing at the rest could invent a mutating call. Report it
+	// instead of returning a successful empty response.
+	if done {
+		switch p.state {
+		case ministralCollectingToolName:
+			return "", "", nil, fmt.Errorf("incomplete tool call: stream ended before %s, name so far %q",
+				ministralArgsTag, strings.TrimSpace(p.buffer.String()))
+		case ministralCollectingToolArgs:
+			return "", "", nil, fmt.Errorf("incomplete tool call: truncated arguments for %q", p.pendingToolName)
+		}
+	}
+
 	return contentBuilder.String(), thinkingBuilder.String(), toolCalls, nil
 }
 

--- a/model/parsers/ministral_test.go
+++ b/model/parsers/ministral_test.go
@@ -592,3 +592,88 @@ func TestMinistralParser_HasThinkingSupport(t *testing.T) {
 		t.Error("expected HasThinkingSupport to return true")
 	}
 }
+
+func TestMinistralParserIncompleteToolCallOnDone(t *testing.T) {
+	tools := []api.Tool{{Function: api.ToolFunction{Name: "get_weather"}}}
+
+	cases := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{
+			name:    "truncated arguments",
+			input:   ministralToolCallsTag + "get_weather" + ministralArgsTag + `{"city":"San Fran`,
+			wantErr: true,
+		},
+		{
+			name:    "missing args tag",
+			input:   ministralToolCallsTag + "get_weather",
+			wantErr: true,
+		},
+		{
+			name:    "bare tool calls tag",
+			input:   ministralToolCallsTag,
+			wantErr: true,
+		},
+		{
+			name:    "complete call is unaffected",
+			input:   ministralToolCallsTag + "get_weather" + ministralArgsTag + `{"city":"San Francisco"}`,
+			wantErr: false,
+		},
+		{
+			name:    "plain content is unaffected",
+			input:   "here is the weather",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := &MinistralParser{}
+			parser.Init(tools, nil, nil)
+
+			content, thinking, calls, err := parser.Add(tt.input, true)
+			if !tt.wantErr {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("expected an error for an incomplete tool call, got none")
+			}
+			// nothing partial should leak out alongside the error
+			if content != "" || thinking != "" || len(calls) != 0 {
+				t.Errorf("expected empty results on error, got content %q thinking %q calls %d", content, thinking, len(calls))
+			}
+		})
+	}
+}
+
+func TestMinistralParserDoesNotReportIncompleteMidStream(t *testing.T) {
+	tools := []api.Tool{{Function: api.ToolFunction{Name: "get_weather"}}}
+	parser := &MinistralParser{}
+	parser.Init(tools, nil, nil)
+
+	// the same truncated arguments are fine while the stream is still open
+	_, _, calls, err := parser.Add(ministralToolCallsTag+"get_weather"+ministralArgsTag+`{"city":"San Fran`, false)
+	if err != nil {
+		t.Fatalf("unexpected error before done: %v", err)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("expected no tool calls yet, got %d", len(calls))
+	}
+
+	// the rest arrives and the call is emitted
+	_, _, calls, err = parser.Add(`cisco"}`, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(calls))
+	}
+	if calls[0].Function.Name != "get_weather" {
+		t.Errorf("expected tool name %q, got %q", "get_weather", calls[0].Function.Name)
+	}
+}


### PR DESCRIPTION
The ministral parser accepted the terminal `done` signal in `Add` without using it (model/parsers/ministral.go:268), so if the stream ended midway through `[TOOL_CALLS]name[ARGS]{json}` the buffered call was dropped and the caller got a successful empty response. An agent waiting on that call has nothing to act on and no idea anything went wrong.

Same defect dhiltgen fixed for the GLM parser in #17250. Unlike that fix this one has no recovery path, deliberately: `eat` emits the call as soon as `findJSONEnd` sees a complete argument object, so if the parser is still in the args state at end of stream the JSON is necessarily incomplete, and being in the name state means no `[ARGS]` arrived so there are no arguments at all. Neither case has anything safe to reconstruct, and inventing the rest of an argument list could turn partial output into a mutating call, so both now return an explicit error instead of vanishing.

Verified with a table-driven test covering truncated arguments, a missing `[ARGS]` tag, a bare `[TOOL_CALLS]` tag, a complete call, and plain content, plus a streaming test confirming the same truncated input is still fine while the stream is open and completes normally once the rest arrives. Four cases fail on main and pass here. `go test ./model/... ./server/...`, `golangci-lint run model/parsers/`, and `go mod tidy` are clean locally. Verification is at the parser level rather than a live model, since I do not have these weights here.

Two notes. The error returns empty content rather than the partial content, matching the sibling parsers, since both call sites in server/routes.go discard the values on a non-nil error anyway. And #16942 plus #15217 also touch this file, in `eat` and in a new `CanDisableThinking`, so neither should conflict with the hunk here.

quick disclosure: I'm a college freshman contributing where I can :) Claude Code helped me work through this one and I ran the tests, lint, and the fail-on-main checks myself. If you would rather this degrade quietly than error, I am glad to change it, and glad to be corrected on anything I have misjudged.