### PR TITLE
server: retry stalled direct URL requests

### DIFF
--- a/server/download.go
+++ b/server/download.go
@@ -102,7 +102,10 @@ const (
 	maxDownloadPartSize int64 = 1000 * format.MegaByte
 )
 
-var downloadStallTimeout = 30 * time.Second
+var (
+	downloadStallTimeout    = 30 * time.Second
+	directURLAttemptTimeout = 10 * time.Second
+)
 
 func (p *blobDownloadPart) Name() string {
 	return strings.Join([]string{
@@ -255,7 +258,9 @@ func (b *blobDownload) run(ctx context.Context, requestURL *url.URL, opts *regis
 				return http.ErrUseLastResponse
 			}
 
-			resp, err := makeRequestWithRetry(ctx, http.MethodGet, requestURL, nil, nil, newOpts)
+			attemptCtx, cancel := context.WithTimeout(ctx, directURLAttemptTimeout)
+			resp, err := makeRequestWithRetry(attemptCtx, http.MethodGet, requestURL, nil, nil, newOpts)
+			cancel()
 			if err != nil {
 				slog.Warn("failed to get direct URL; backing off and retrying", "err", err)
 				if err := backoff(ctx); err != nil {

--- a/server/download_test.go
+++ b/server/download_test.go
@@ -10,9 +10,54 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 )
+
+func TestBlobDownloadRetriesStalledDirectURLRequest(t *testing.T) {
+	directURL, err := url.Parse("https://cdn.example.com/blob")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if attempts.Add(1) == 1 {
+			<-r.Context().Done()
+			return
+		}
+
+		w.Header().Set("Location", directURL.String())
+		w.WriteHeader(http.StatusTemporaryRedirect)
+	}))
+	t.Cleanup(server.Close)
+
+	requestURL, err := url.Parse(server.URL + "/v2/library/test/blobs/sha256:test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	originalAttemptTimeout := directURLAttemptTimeout
+	directURLAttemptTimeout = 50 * time.Millisecond
+	t.Cleanup(func() {
+		directURLAttemptTimeout = originalAttemptTimeout
+	})
+
+	download := &blobDownload{
+		Name:   filepath.Join(t.TempDir(), "blob"),
+		Digest: "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	if err := download.run(ctx, requestURL, &registryOptions{}); err != nil {
+		t.Fatalf("blobDownload.run() error = %v, want retry to succeed", err)
+	}
+	if attempts.Load() != 2 {
+		t.Fatalf("blobDownload.run() made %d direct URL requests, want 2", attempts.Load())
+	}
+}
 
 func BenchmarkDownloadChunkCompletion(b *testing.B) {
 	data := make([]byte, 1024*1024)


### PR DESCRIPTION
Fixes #17484.

## Problem

Direct URL resolution retries share a 30-second context. If the first registry
request hangs until that context expires, the backoff sees an already-canceled
context and returns immediately, so no retry actually occurs.

This matches the reported failure: a transiently stalled request consumes the
entire retry budget and aborts an otherwise completed model pull.

The root-cause analysis and per-attempt timeout direction are based on
[@adarshsm's issue analysis](https://github.com/ollama/ollama/issues/17484#issuecomment-5145984014).
This PR implements that approach and adds regression coverage.

## Change

- Bound each direct URL request to 10 seconds.
- Keep the existing 30-second overall resolution budget and backoff behavior.
- Add a regression test where the first request stalls and the second returns
  the CDN redirect successfully.

The change only affects direct URL resolution. Download chunk handling, the
overall timeout, and API behavior are unchanged.

## Verification

- `go test ./server -run '^(TestBlobDownloadRetriesStalledDirectURLRequest|TestDownloadChunk.*)$' -count=20`
- `go test ./server -count=1`
- `go test -race ./server -run '^TestBlobDownloadRetriesStalledDirectURLRequest$' -count=1`
- `go vet ./server`
- `git diff --check`

The regression test fails before the fix with one request and
`context deadline exceeded`; it passes after the fix with two requests.

I also ran `go test -count=1 -benchtime=1x ./...`. All runnable packages passed;
`app/cmd/app` and `app/ui` could not enter tests because the generated
`app/ui/app/dist` embed directory is absent from this checkout.