### PR TITLE
fix(missing_documentation): Go function `NewClient` in api/client.go has no doc comment 

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -78,6 +78,9 @@ func ClientFromEnvironment() (*Client, error) {
 	}, nil
 }
 
+// NewClient creates a new [Client] with the given base URL and HTTP client.
+// Use [ClientFromEnvironment] to create a Client configured from the
+// OLLAMA_HOST environment variable instead.
 func NewClient(base *url.URL, http *http.Client) *Client {
 	return &Client{
 		base: base,


### PR DESCRIPTION
## TLDR

**Gap:** Go function `NewClient` in api/client.go has no doc comment — add a // NewClient ... comment

**Wedge type:** `missing_documentation`

**Issue:** https://github.com/ollama/ollama/blob/main/api/client.go#L81

## Changes

- `api/client.go`

**Diff size:** 3 lines across 1 file(s)

## Pre-submission checklist

- [x] Minimal change — touches at most 3 files
- [x] Tests updated (if test suite present)
- [x] No CI/CD, Dockerfile, or lock file modifications
- [x] Diff reviewed for secrets

## AI Assistance Disclosure

This contribution was AI-assisted using Hermes Agent (Nous Research).

Co-authored-by: Hermes Agent <hermes-agent@nousresearch.com>