### PR TITLE
fix(missing_documentation): Go function `Whoami` in api/client.go has no doc comment — a

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -503,6 +503,7 @@ func (c *Client) Disconnect(ctx context.Context, encodedKey string) error {
 	return c.do(ctx, http.MethodDelete, fmt.Sprintf("/api/user/keys/%s", encodedKey), nil, nil)
 }
 
+// Whoami returns information about the currently authenticated user from the ollama server.
 func (c *Client) Whoami(ctx context.Context) (*UserResponse, error) {
 	var resp UserResponse
 	if err := c.do(ctx, http.MethodPost, "/api/me", nil, &resp); err != nil {


### PR DESCRIPTION
## TLDR

**Gap:** Go function `Whoami` in api/client.go has no doc comment — add a // Whoami ... comment

**Wedge type:** `missing_documentation`

**Issue:** https://github.com/ollama/ollama/blob/main/api/client.go#L506

## Changes

- `api/client.go`

**Diff size:** 1 lines across 1 file(s)

## Pre-submission checklist

- [x] Minimal change — touches at most 3 files
- [x] Tests updated (if test suite present)
- [x] No CI/CD, Dockerfile, or lock file modifications
- [x] Diff reviewed for secrets

## AI Assistance Disclosure

This contribution was AI-assisted using Hermes Agent (Nous Research).

Co-authored-by: Hermes Agent <hermes-agent@nousresearch.com>