### PR TITLE
parser/renderer: add Apertus 1.5 support

### DIFF
--- a/model/parsers/apertus15.go
+++ b/model/parsers/apertus15.go
@@ -1,0 +1,223 @@
+package parsers
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/ollama/ollama/api"
+)
+
+const (
+	apertus15InnerStart     = "<|inner_prefix|>"
+	apertus15InnerEnd       = "<|inner_suffix|>"
+	apertus15ToolsStart     = "<|tools_prefix|>"
+	apertus15ToolsEnd       = "<|tools_suffix|>"
+	apertus15AssistantStart = "<|assistant_start|>"
+	apertus15AssistantEnd   = "<|assistant_end|>"
+)
+
+type apertus15ParserState int
+
+const (
+	apertus15ParserContent apertus15ParserState = iota
+	apertus15ParserThinking
+	apertus15ParserTools
+)
+
+type Apertus15Parser struct {
+	state           apertus15ParserState
+	buffer          strings.Builder
+	thinkingEnabled bool
+	callIndex       int
+}
+
+func (p *Apertus15Parser) Init(tools []api.Tool, _ *api.Message, thinkValue *api.ThinkValue) []api.Tool {
+	p.state = apertus15ParserContent
+	p.buffer.Reset()
+	p.thinkingEnabled = thinkValue != nil && thinkValue.Bool()
+	p.callIndex = 0
+	return tools
+}
+
+func (p *Apertus15Parser) HasToolSupport() bool {
+	return true
+}
+
+func (p *Apertus15Parser) HasThinkingSupport() bool {
+	return true
+}
+
+func (p *Apertus15Parser) PreservedTokens() []string {
+	return []string{
+		apertus15InnerStart,
+		apertus15InnerEnd,
+		apertus15ToolsStart,
+		apertus15ToolsEnd,
+		apertus15AssistantStart,
+		apertus15AssistantEnd,
+	}
+}
+
+func (p *Apertus15Parser) Add(s string, done bool) (content string, thinking string, calls []api.ToolCall, err error) {
+	p.buffer.WriteString(s)
+	var contentBuilder, thinkingBuilder strings.Builder
+
+	for {
+		switch p.state {
+		case apertus15ParserContent, apertus15ParserThinking:
+			sourceState := p.state
+			progress, text, err := p.consumeText(done)
+			if err != nil {
+				return "", "", nil, err
+			}
+			if sourceState == apertus15ParserThinking {
+				if p.thinkingEnabled {
+					thinkingBuilder.WriteString(text)
+				}
+			} else {
+				contentBuilder.WriteString(text)
+			}
+			if !progress {
+				return contentBuilder.String(), thinkingBuilder.String(), calls, nil
+			}
+		case apertus15ParserTools:
+			progress, parsedCalls, err := p.consumeTools(done)
+			if err != nil {
+				return "", "", nil, err
+			}
+			calls = append(calls, parsedCalls...)
+			if !progress {
+				return contentBuilder.String(), thinkingBuilder.String(), calls, nil
+			}
+		default:
+			return "", "", nil, fmt.Errorf("invalid apertus 1.5 parser state %d", p.state)
+		}
+	}
+}
+
+func (p *Apertus15Parser) consumeText(done bool) (bool, string, error) {
+	acc := p.buffer.String()
+	if acc == "" {
+		return false, "", nil
+	}
+
+	tag, index := earliestApertus15Tag(acc)
+	if index >= 0 {
+		text := acc[:index]
+		p.buffer.Reset()
+		p.buffer.WriteString(acc[index+len(tag):])
+		switch tag {
+		case apertus15InnerStart:
+			p.state = apertus15ParserThinking
+		case apertus15InnerEnd:
+			p.state = apertus15ParserContent
+		case apertus15ToolsStart:
+			p.state = apertus15ParserTools
+		case apertus15ToolsEnd, apertus15AssistantStart, apertus15AssistantEnd:
+			p.state = apertus15ParserContent
+		}
+		return true, text, nil
+	}
+
+	if done {
+		p.buffer.Reset()
+		return acc != "", acc, nil
+	}
+
+	keep := apertus15TagOverlap(acc)
+	emitLen := len(acc) - keep
+	if emitLen == 0 {
+		return false, "", nil
+	}
+	text := acc[:emitLen]
+	p.buffer.Reset()
+	p.buffer.WriteString(acc[emitLen:])
+	return true, text, nil
+}
+
+func (p *Apertus15Parser) consumeTools(done bool) (bool, []api.ToolCall, error) {
+	acc := p.buffer.String()
+	if index := strings.Index(acc, apertus15ToolsEnd); index >= 0 {
+		payload := acc[:index]
+		p.buffer.Reset()
+		p.buffer.WriteString(acc[index+len(apertus15ToolsEnd):])
+		p.state = apertus15ParserContent
+		calls, err := p.parseToolCalls(payload)
+		return true, calls, err
+	}
+	if !done {
+		return false, nil, nil
+	}
+
+	p.buffer.Reset()
+	p.state = apertus15ParserContent
+	calls, err := p.parseToolCalls(acc)
+	return true, calls, err
+}
+
+func (p *Apertus15Parser) parseToolCalls(payload string) ([]api.ToolCall, error) {
+	var entries []json.RawMessage
+	if err := json.Unmarshal([]byte(strings.TrimSpace(payload)), &entries); err != nil {
+		return nil, fmt.Errorf("parse apertus 1.5 tool calls: %w", err)
+	}
+
+	calls := make([]api.ToolCall, 0, len(entries))
+	for _, entry := range entries {
+		var callObject map[string]json.RawMessage
+		if err := json.Unmarshal(entry, &callObject); err != nil {
+			return nil, fmt.Errorf("parse apertus 1.5 tool call: %w", err)
+		}
+		if len(callObject) != 1 {
+			return nil, fmt.Errorf("parse apertus 1.5 tool call: expected one function, got %d", len(callObject))
+		}
+		for name, rawArguments := range callObject {
+			if name == "" {
+				return nil, fmt.Errorf("parse apertus 1.5 tool call: empty function name")
+			}
+			var arguments api.ToolCallFunctionArguments
+			if err := json.Unmarshal(rawArguments, &arguments); err != nil {
+				return nil, fmt.Errorf("parse apertus 1.5 tool call %q arguments: %w", name, err)
+			}
+			calls = append(calls, api.ToolCall{
+				Function: api.ToolCallFunction{
+					Index:     p.callIndex,
+					Name:      name,
+					Arguments: arguments,
+				},
+			})
+			p.callIndex++
+		}
+	}
+	return calls, nil
+}
+
+func earliestApertus15Tag(s string) (string, int) {
+	tag := ""
+	index := -1
+	for _, candidate := range apertus15ParserTags {
+		candidateIndex := strings.Index(s, candidate)
+		if candidateIndex >= 0 && (index < 0 || candidateIndex < index) {
+			tag = candidate
+			index = candidateIndex
+		}
+	}
+	return tag, index
+}
+
+func apertus15TagOverlap(s string) int {
+	keep := 0
+	for _, tag := range apertus15ParserTags {
+		keep = max(keep, overlap(s, tag))
+	}
+	return keep
+}
+
+var apertus15ParserTags = []string{
+	apertus15InnerStart,
+	apertus15InnerEnd,
+	apertus15ToolsStart,
+	apertus15ToolsEnd,
+	apertus15AssistantStart,
+	apertus15AssistantEnd,
+}

--- a/model/parsers/apertus15.go
+++ b/model/parsers/apertus15.go
@@ -32,11 +32,16 @@ type Apertus15Parser struct {
 	callIndex       int
 }
 
-func (p *Apertus15Parser) Init(tools []api.Tool, _ *api.Message, thinkValue *api.ThinkValue) []api.Tool {
+func (p *Apertus15Parser) Init(tools []api.Tool, lastMessage *api.Message, thinkValue *api.ThinkValue) []api.Tool {
 	p.state = apertus15ParserContent
 	p.buffer.Reset()
 	p.thinkingEnabled = thinkValue != nil && thinkValue.Bool()
 	p.callIndex = 0
+
+	if lastMessage != nil && lastMessage.Role == "assistant" && lastMessage.Thinking != "" && lastMessage.Content == "" {
+		p.state = apertus15ParserThinking
+	}
+
 	return tools
 }
 

--- a/model/parsers/apertus15.go
+++ b/model/parsers/apertus15.go
@@ -175,6 +175,10 @@ func (p *Apertus15Parser) parseToolCalls(payload string) ([]api.ToolCall, error)
 			if name == "" {
 				return nil, fmt.Errorf("parse apertus 1.5 tool call: empty function name")
 			}
+			argumentJSON := strings.TrimSpace(string(rawArguments))
+			if !strings.HasPrefix(argumentJSON, "{") || !strings.HasSuffix(argumentJSON, "}") {
+				return nil, fmt.Errorf("parse apertus 1.5 tool call %q arguments: expected object", name)
+			}
 			var arguments api.ToolCallFunctionArguments
 			if err := json.Unmarshal(rawArguments, &arguments); err != nil {
 				return nil, fmt.Errorf("parse apertus 1.5 tool call %q arguments: %w", name, err)

--- a/model/parsers/apertus15_test.go
+++ b/model/parsers/apertus15_test.go
@@ -130,6 +130,46 @@ func TestApertus15ParserAcceptsConsumedToolSuffix(t *testing.T) {
 	}
 }
 
+func TestApertus15ParserMultipleToolEnvelopesWithContent(t *testing.T) {
+	parser := &Apertus15Parser{}
+	parser.Init(nil, nil, nil)
+	content, thinking, calls, err := parser.Add(
+		"Before."+
+			apertus15ToolsStart+`[{"first":{"x":1}}]`+apertus15ToolsEnd+
+			"Between."+
+			apertus15ToolsStart+`[{"second":{"y":2}}]`+apertus15ToolsEnd+
+			"After.",
+		true,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if content != "Before.Between.After." || thinking != "" {
+		t.Fatalf("content = %q, thinking = %q", content, thinking)
+	}
+	if len(calls) != 2 || calls[0].Function.Index != 0 || calls[0].Function.Name != "first" ||
+		calls[1].Function.Index != 1 || calls[1].Function.Name != "second" {
+		t.Fatalf("tool calls = %#v", calls)
+	}
+}
+
+func TestApertus15ParserInitResetsToolCallIndexes(t *testing.T) {
+	parser := &Apertus15Parser{}
+	for _, name := range []string{"first", "second"} {
+		parser.Init(nil, nil, nil)
+		_, _, calls, err := parser.Add(
+			apertus15ToolsStart+`[{"`+name+`":{}}]`+apertus15ToolsEnd,
+			true,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(calls) != 1 || calls[0].Function.Index != 0 || calls[0].Function.Name != name {
+			t.Fatalf("tool calls after Init = %#v", calls)
+		}
+	}
+}
+
 func TestApertus15ParserEveryByteBoundary(t *testing.T) {
 	raw := apertus15AssistantStart +
 		apertus15InnerStart + "Think." + apertus15InnerEnd +
@@ -194,6 +234,8 @@ func TestApertus15ParserRejectsMalformedToolCalls(t *testing.T) {
 		apertus15ToolsStart + `[{"lookup":` + apertus15ToolsEnd,
 		apertus15ToolsStart + `[{"one":{},"two":{}}]` + apertus15ToolsEnd,
 		apertus15ToolsStart + `[{"lookup":"not-an-object"}]` + apertus15ToolsEnd,
+		apertus15ToolsStart + `[{"lookup":[1,2]}]` + apertus15ToolsEnd,
+		apertus15ToolsStart + `[{"lookup":null}]` + apertus15ToolsEnd,
 	}
 	for _, raw := range tests {
 		parser := &Apertus15Parser{}

--- a/model/parsers/apertus15_test.go
+++ b/model/parsers/apertus15_test.go
@@ -1,0 +1,205 @@
+package parsers
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/ollama/ollama/api"
+)
+
+func TestApertus15ParserCapabilities(t *testing.T) {
+	parser := ParserForName("apertus1.5")
+	if parser == nil {
+		t.Fatal("apertus1.5 parser is not registered")
+	}
+	if !parser.HasToolSupport() {
+		t.Fatal("apertus1.5 parser should support tools")
+	}
+	if !parser.HasThinkingSupport() {
+		t.Fatal("apertus1.5 parser should support thinking")
+	}
+	for _, token := range []string{
+		apertus15InnerStart,
+		apertus15InnerEnd,
+		apertus15ToolsStart,
+		apertus15ToolsEnd,
+	} {
+		if !slices.Contains(parser.PreservedTokens(), token) {
+			t.Fatalf("PreservedTokens() does not contain %q", token)
+		}
+	}
+}
+
+func TestApertus15ParserContentAndThinking(t *testing.T) {
+	parser := &Apertus15Parser{}
+	parser.Init(nil, nil, &api.ThinkValue{Value: true})
+	content, thinking, calls, err := parser.Add(
+		apertus15AssistantStart+
+			"Before."+
+			apertus15InnerStart+"Reason carefully."+apertus15InnerEnd+
+			"After."+
+			apertus15AssistantEnd,
+		true,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if content != "Before.After." {
+		t.Fatalf("content = %q, want %q", content, "Before.After.")
+	}
+	if thinking != "Reason carefully." {
+		t.Fatalf("thinking = %q, want %q", thinking, "Reason carefully.")
+	}
+	if len(calls) != 0 {
+		t.Fatalf("tool calls = %d, want 0", len(calls))
+	}
+}
+
+func TestApertus15ParserSuppressesUnexpectedThinking(t *testing.T) {
+	parser := &Apertus15Parser{}
+	parser.Init(nil, nil, &api.ThinkValue{Value: false})
+	content, thinking, _, err := parser.Add(
+		apertus15InnerStart+"Hidden."+apertus15InnerEnd+"Visible.",
+		true,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if content != "Visible." || thinking != "" {
+		t.Fatalf("content = %q, thinking = %q, want visible content and suppressed thinking", content, thinking)
+	}
+}
+
+func TestApertus15ParserToolCalls(t *testing.T) {
+	parser := &Apertus15Parser{}
+	parser.Init(nil, nil, &api.ThinkValue{Value: true})
+	raw := "I will check." +
+		apertus15ToolsStart +
+		`[{"get_weather":{"city":"Zurich"}},{"get_time":{"offset":2,"dst":true}}]` +
+		apertus15ToolsEnd
+	content, thinking, calls, err := parser.Add(raw, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if content != "I will check." || thinking != "" {
+		t.Fatalf("content = %q, thinking = %q", content, thinking)
+	}
+	if len(calls) != 2 {
+		t.Fatalf("tool calls = %d, want 2", len(calls))
+	}
+	if calls[0].Function.Index != 0 || calls[0].Function.Name != "get_weather" {
+		t.Fatalf("first tool call = %#v", calls[0].Function)
+	}
+	if city, ok := calls[0].Function.Arguments.Get("city"); !ok || city != "Zurich" {
+		t.Fatalf("city argument = %#v, %v", city, ok)
+	}
+	if calls[1].Function.Index != 1 || calls[1].Function.Name != "get_time" {
+		t.Fatalf("second tool call = %#v", calls[1].Function)
+	}
+}
+
+func TestApertus15ParserToolCallInsideThinking(t *testing.T) {
+	parser := &Apertus15Parser{}
+	parser.Init(nil, nil, &api.ThinkValue{Value: true})
+	content, thinking, calls, err := parser.Add(
+		apertus15InnerStart+"Need weather."+
+			apertus15ToolsStart+`[{"get_weather":{"city":"Bern"}}]`+apertus15ToolsEnd,
+		true,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if content != "" || thinking != "Need weather." || len(calls) != 1 {
+		t.Fatalf("content = %q, thinking = %q, calls = %d", content, thinking, len(calls))
+	}
+}
+
+func TestApertus15ParserAcceptsConsumedToolSuffix(t *testing.T) {
+	parser := &Apertus15Parser{}
+	parser.Init(nil, nil, nil)
+	_, _, calls, err := parser.Add(
+		apertus15ToolsStart+`[{"lookup":{"id":"42"}}]`,
+		true,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(calls) != 1 || calls[0].Function.Name != "lookup" {
+		t.Fatalf("tool calls = %#v", calls)
+	}
+}
+
+func TestApertus15ParserEveryByteBoundary(t *testing.T) {
+	raw := apertus15AssistantStart +
+		apertus15InnerStart + "Think." + apertus15InnerEnd +
+		"Answer." +
+		apertus15ToolsStart + `[{"lookup":{"id":"42"}}]` + apertus15ToolsEnd +
+		apertus15AssistantEnd
+
+	for split := 0; split <= len(raw); split++ {
+		t.Run("", func(t *testing.T) {
+			parser := &Apertus15Parser{}
+			parser.Init(nil, nil, &api.ThinkValue{Value: true})
+			var content, thinking strings.Builder
+			var calls []api.ToolCall
+
+			for index, chunk := range []string{raw[:split], raw[split:]} {
+				gotContent, gotThinking, gotCalls, err := parser.Add(chunk, index == 1)
+				if err != nil {
+					t.Fatalf("split %d: %v", split, err)
+				}
+				content.WriteString(gotContent)
+				thinking.WriteString(gotThinking)
+				calls = append(calls, gotCalls...)
+			}
+			if content.String() != "Answer." || thinking.String() != "Think." ||
+				len(calls) != 1 || calls[0].Function.Name != "lookup" {
+				t.Fatalf("split %d: content = %q, thinking = %q, calls = %#v", split, content.String(), thinking.String(), calls)
+			}
+		})
+	}
+}
+
+func TestApertus15ParserByteAtATime(t *testing.T) {
+	raw := apertus15InnerStart + "Reason." + apertus15InnerEnd +
+		apertus15ToolsStart + `[{"first":{"x":1}},{"second":{"y":[1,2]}}]` + apertus15ToolsEnd
+	parser := &Apertus15Parser{}
+	parser.Init(nil, nil, &api.ThinkValue{Value: true})
+	var content, thinking strings.Builder
+	var calls []api.ToolCall
+	for index := range len(raw) {
+		gotContent, gotThinking, gotCalls, err := parser.Add(raw[index:index+1], false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		content.WriteString(gotContent)
+		thinking.WriteString(gotThinking)
+		calls = append(calls, gotCalls...)
+	}
+	gotContent, gotThinking, gotCalls, err := parser.Add("", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content.WriteString(gotContent)
+	thinking.WriteString(gotThinking)
+	calls = append(calls, gotCalls...)
+	if content.String() != "" || thinking.String() != "Reason." || len(calls) != 2 {
+		t.Fatalf("content = %q, thinking = %q, calls = %d", content.String(), thinking.String(), len(calls))
+	}
+}
+
+func TestApertus15ParserRejectsMalformedToolCalls(t *testing.T) {
+	tests := []string{
+		apertus15ToolsStart + `[{"lookup":` + apertus15ToolsEnd,
+		apertus15ToolsStart + `[{"one":{},"two":{}}]` + apertus15ToolsEnd,
+		apertus15ToolsStart + `[{"lookup":"not-an-object"}]` + apertus15ToolsEnd,
+	}
+	for _, raw := range tests {
+		parser := &Apertus15Parser{}
+		parser.Init(nil, nil, nil)
+		if _, _, _, err := parser.Add(raw, true); err == nil {
+			t.Fatalf("expected parsing error for %q", raw)
+		}
+	}
+}

--- a/model/parsers/apertus15_test.go
+++ b/model/parsers/apertus15_test.go
@@ -71,6 +71,28 @@ func TestApertus15ParserSuppressesUnexpectedThinking(t *testing.T) {
 	}
 }
 
+func TestApertus15ParserContinuesThinkingPrefill(t *testing.T) {
+	parser := &Apertus15Parser{}
+	parser.Init(nil, &api.Message{
+		Role:     "assistant",
+		Thinking: "Existing reasoning.",
+	}, &api.ThinkValue{Value: true})
+
+	content, thinking, calls, err := parser.Add(
+		" Continued reasoning."+apertus15InnerEnd+"Answer.",
+		true,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if content != "Answer." || thinking != " Continued reasoning." {
+		t.Fatalf("content = %q, thinking = %q", content, thinking)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("tool calls = %d, want 0", len(calls))
+	}
+}
+
 func TestApertus15ParserToolCalls(t *testing.T) {
 	parser := &Apertus15Parser{}
 	parser.Init(nil, nil, &api.ThinkValue{Value: true})

--- a/model/parsers/parsers.go
+++ b/model/parsers/parsers.go
@@ -98,6 +98,8 @@ func ParserForName(name string) Parser {
 		return &LagunaV8Parser{}
 	case "cohere":
 		return &CohereParser{}
+	case "apertus1.5":
+		return &Apertus15Parser{}
 	default:
 		return nil
 	}

--- a/model/renderers/apertus15.go
+++ b/model/renderers/apertus15.go
@@ -1,0 +1,339 @@
+package renderers
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/ollama/ollama/api"
+)
+
+const (
+	apertus15BOS             = "<s>"
+	apertus15SystemStart     = "<|system_start|>"
+	apertus15SystemEnd       = "<|system_end|>"
+	apertus15DeveloperStart  = "<|developer_start|>"
+	apertus15DeveloperEnd    = "<|developer_end|>"
+	apertus15UserStart       = "<|user_start|>"
+	apertus15UserEnd         = "<|user_end|>"
+	apertus15AssistantStart  = "<|assistant_start|>"
+	apertus15AssistantEnd    = "<|assistant_end|>"
+	apertus15InnerStart      = "<|inner_prefix|>"
+	apertus15InnerEnd        = "<|inner_suffix|>"
+	apertus15ToolsStart      = "<|tools_prefix|>"
+	apertus15ToolsEnd        = "<|tools_suffix|>"
+	apertus15ToolOutputStart = "<|tool_output_start|>"
+	apertus15ToolOutputEnd   = "<|tool_output_end|>"
+	apertus15Image           = "<|image|>"
+
+	apertus15DefaultSystem = "You are Apertus 1.5 Omni, a multimodal assistant developed by the Swiss AI Initiative. Extended from Apertus 1 via continued pretraining, you understand images and audio and respond in text."
+)
+
+type Apertus15Renderer struct {
+	useImgTags bool
+}
+
+func (r *Apertus15Renderer) LeadingBOS() string {
+	return apertus15BOS
+}
+
+func (r *Apertus15Renderer) Render(messages []api.Message, tools []api.Tool, think *api.ThinkValue) (string, error) {
+	var sb strings.Builder
+	sb.WriteString(apertus15BOS)
+
+	messageStart := 0
+	system := apertus15DefaultSystem
+	if len(messages) > 0 && messages[0].Role == "system" {
+		system = messages[0].Content
+		messageStart = 1
+	}
+	sb.WriteString(apertus15SystemStart)
+	sb.WriteString(system)
+	sb.WriteString(apertus15SystemEnd)
+
+	sb.WriteString(apertus15DeveloperStart)
+	if think != nil && think.Bool() {
+		sb.WriteString("Deliberation: enabled\n")
+	} else {
+		sb.WriteString("Deliberation: disabled\n")
+	}
+	if len(tools) == 0 {
+		sb.WriteString("Tool Capabilities: disabled")
+	} else {
+		sb.WriteString("Tool Capabilities:\n")
+		if err := renderApertus15Tools(&sb, tools); err != nil {
+			return "", err
+		}
+	}
+	sb.WriteString(apertus15DeveloperEnd)
+
+	imageOffset := 0
+	inAssistant := false
+	inInner := false
+	inToolOutput := false
+	waitingForToolOutputs := false
+
+	closeToolOutput := func() {
+		if inToolOutput {
+			sb.WriteString(apertus15ToolOutputEnd)
+			inToolOutput = false
+		}
+	}
+	closeAssistant := func() {
+		closeToolOutput()
+		if inAssistant {
+			sb.WriteString(apertus15AssistantEnd)
+			inAssistant = false
+		}
+		inInner = false
+		waitingForToolOutputs = false
+	}
+
+	for _, message := range messages[messageStart:] {
+		switch message.Role {
+		case "user":
+			closeAssistant()
+			sb.WriteString(apertus15UserStart)
+			content, nextOffset := r.renderContent(message, imageOffset)
+			imageOffset = nextOffset
+			sb.WriteString(content)
+			sb.WriteString(apertus15UserEnd)
+		case "assistant":
+			if !inAssistant {
+				sb.WriteString(apertus15AssistantStart)
+				inAssistant = true
+			}
+			closeToolOutput()
+
+			if message.Thinking != "" {
+				if !inInner {
+					sb.WriteString(apertus15InnerStart)
+					inInner = true
+				}
+				sb.WriteString(message.Thinking)
+			}
+
+			if message.Content != "" {
+				if inInner {
+					sb.WriteString(apertus15InnerEnd)
+					inInner = false
+				}
+				sb.WriteString(message.Content)
+			}
+
+			if len(message.ToolCalls) > 0 {
+				if err := renderApertus15ToolCalls(&sb, message.ToolCalls); err != nil {
+					return "", err
+				}
+				waitingForToolOutputs = true
+			}
+		case "tool":
+			if !inAssistant {
+				return "", fmt.Errorf("apertus 1.5 tool message outside assistant turn")
+			}
+			if !inToolOutput {
+				sb.WriteString(apertus15ToolOutputStart)
+				inToolOutput = true
+			} else {
+				sb.WriteString(", ")
+			}
+			sb.WriteString(message.Content)
+			waitingForToolOutputs = false
+		case "system":
+			return "", fmt.Errorf("apertus 1.5 system message must be the first message")
+		default:
+			return "", fmt.Errorf("unsupported apertus 1.5 message role %q", message.Role)
+		}
+	}
+
+	closeToolOutput()
+	lastRole := ""
+	if len(messages) > 0 {
+		lastRole = messages[len(messages)-1].Role
+	}
+	if inAssistant && !waitingForToolOutputs && lastRole != "assistant" {
+		sb.WriteString(apertus15AssistantEnd)
+	}
+	if lastRole != "assistant" {
+		sb.WriteString(apertus15AssistantStart)
+	}
+
+	return sb.String(), nil
+}
+
+func (r *Apertus15Renderer) renderContent(message api.Message, imageOffset int) (string, int) {
+	if r.useImgTags {
+		return renderContentWithImageTags(message.Content, len(message.Images), imageOffset)
+	}
+
+	var sb strings.Builder
+	for range message.Images {
+		sb.WriteString(apertus15Image)
+	}
+	sb.WriteString(message.Content)
+	return sb.String(), imageOffset + len(message.Images)
+}
+
+func renderApertus15Tools(sb *strings.Builder, tools []api.Tool) error {
+	for i, tool := range tools {
+		sb.WriteString("// ")
+		sb.WriteString(tool.Function.Description)
+		sb.WriteByte('\n')
+		sb.WriteString("type ")
+		sb.WriteString(tool.Function.Name)
+		sb.WriteString(" = ")
+
+		params := tool.Function.Parameters
+		if params.Properties == nil || params.Properties.Len() == 0 {
+			sb.WriteString("() => any;")
+		} else {
+			sb.WriteString("(_: {\n")
+			required := make(map[string]struct{}, len(params.Required))
+			for _, name := range params.Required {
+				required[name] = struct{}{}
+			}
+			propertyIndex := 0
+			for name, property := range params.Properties.All() {
+				if property.Description != "" {
+					sb.WriteString("// ")
+					sb.WriteString(property.Description)
+					sb.WriteByte('\n')
+				}
+				sb.WriteString(name)
+				if _, ok := required[name]; !ok {
+					sb.WriteByte('?')
+				}
+				sb.WriteString(": ")
+				typeName, err := apertus15TypeScriptType(property)
+				if err != nil {
+					return fmt.Errorf("render apertus 1.5 tool %q property %q: %w", tool.Function.Name, name, err)
+				}
+				sb.WriteString(typeName)
+				propertyIndex++
+				if propertyIndex < params.Properties.Len() {
+					sb.WriteString(",\n")
+				} else {
+					sb.WriteByte('\n')
+				}
+			}
+			sb.WriteString("}) => any;")
+		}
+		if i < len(tools)-1 {
+			sb.WriteByte('\n')
+		}
+	}
+	return nil
+}
+
+func apertus15TypeScriptType(property api.ToolProperty) (string, error) {
+	if len(property.AnyOf) > 0 {
+		// The source template only recognizes oneOf. Ollama preserves anyOf,
+		// so match the template's fallback for this distinct schema keyword.
+		return "any", nil
+	}
+
+	if len(property.Type) > 1 {
+		return strings.Join(property.Type, " | "), nil
+	}
+	typeName := ""
+	if len(property.Type) == 1 {
+		typeName = property.Type[0]
+	}
+	switch typeName {
+	case "array":
+		if property.Items == nil {
+			return "any[]", nil
+		}
+		encoded, err := json.Marshal(property.Items)
+		if err != nil {
+			return "", err
+		}
+		var item api.ToolProperty
+		if err := json.Unmarshal(encoded, &item); err != nil {
+			return "any[]", nil
+		}
+		inner, err := apertus15TypeScriptType(item)
+		if err != nil {
+			return "", err
+		}
+		if inner == "object | object" || len(inner) > 50 {
+			inner = "any"
+		}
+		return inner + "[]", nil
+	case "string":
+		if len(property.Enum) == 0 {
+			return "string", nil
+		}
+		values := make([]string, 0, len(property.Enum))
+		for _, value := range property.Enum {
+			values = append(values, fmt.Sprintf("\"%v\"", value))
+		}
+		return strings.Join(values, " | "), nil
+	case "number", "integer":
+		return "number", nil
+	case "boolean":
+		return "boolean", nil
+	case "object":
+		if property.Properties == nil || property.Properties.Len() == 0 {
+			return "object", nil
+		}
+		return apertus15ObjectType(property.Properties, property.Required)
+	default:
+		return "any", nil
+	}
+}
+
+func apertus15ObjectType(properties *api.ToolPropertiesMap, required []string) (string, error) {
+	requiredSet := make(map[string]struct{}, len(required))
+	for _, name := range required {
+		requiredSet[name] = struct{}{}
+	}
+
+	var sb strings.Builder
+	sb.WriteString("{\n")
+	index := 0
+	for name, property := range properties.All() {
+		sb.WriteString(name)
+		if _, ok := requiredSet[name]; !ok {
+			sb.WriteByte('?')
+		}
+		sb.WriteString(": \n                ")
+		typeName, err := apertus15TypeScriptType(property)
+		if err != nil {
+			return "", err
+		}
+		sb.WriteString(typeName)
+		index++
+		if index < properties.Len() {
+			sb.WriteString(", ")
+		}
+	}
+	sb.WriteByte('}')
+	return sb.String(), nil
+}
+
+func renderApertus15ToolCalls(sb *strings.Builder, calls []api.ToolCall) error {
+	sb.WriteString(apertus15ToolsStart)
+	sb.WriteByte('[')
+	for i, call := range calls {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		name, err := json.Marshal(call.Function.Name)
+		if err != nil {
+			return err
+		}
+		arguments, err := marshalWithSpaces(call.Function.Arguments)
+		if err != nil {
+			return err
+		}
+		sb.WriteByte('{')
+		sb.Write(name)
+		sb.WriteString(": ")
+		sb.Write(arguments)
+		sb.WriteByte('}')
+	}
+	sb.WriteByte(']')
+	sb.WriteString(apertus15ToolsEnd)
+	return nil
+}

--- a/model/renderers/apertus15.go
+++ b/model/renderers/apertus15.go
@@ -266,7 +266,7 @@ func apertus15TypeScriptType(property api.ToolProperty) (string, error) {
 		}
 		values := make([]string, 0, len(property.Enum))
 		for _, value := range property.Enum {
-			values = append(values, fmt.Sprintf("\"%v\"", value))
+			values = append(values, fmt.Sprintf("\"%s\"", apertus15JinjaString(value)))
 		}
 		return strings.Join(values, " | "), nil
 	case "number", "integer":
@@ -280,6 +280,20 @@ func apertus15TypeScriptType(property api.ToolProperty) (string, error) {
 		return apertus15ObjectType(property.Properties, property.Required)
 	default:
 		return "any", nil
+	}
+}
+
+func apertus15JinjaString(value any) string {
+	switch value := value.(type) {
+	case bool:
+		if value {
+			return "True"
+		}
+		return "False"
+	case nil:
+		return "None"
+	default:
+		return fmt.Sprint(value)
 	}
 }
 
@@ -319,21 +333,42 @@ func renderApertus15ToolCalls(sb *strings.Builder, calls []api.ToolCall) error {
 		if i > 0 {
 			sb.WriteString(", ")
 		}
-		name, err := json.Marshal(call.Function.Name)
+		arguments, err := marshalApertus15Arguments(call.Function.Arguments)
 		if err != nil {
 			return err
 		}
-		arguments, err := marshalWithSpaces(call.Function.Arguments)
-		if err != nil {
-			return err
-		}
-		sb.WriteByte('{')
-		sb.Write(name)
-		sb.WriteString(": ")
+		sb.WriteString("{\"")
+		sb.WriteString(call.Function.Name)
+		sb.WriteString("\": ")
 		sb.Write(arguments)
 		sb.WriteByte('}')
 	}
 	sb.WriteByte(']')
 	sb.WriteString(apertus15ToolsEnd)
 	return nil
+}
+
+func marshalApertus15Arguments(arguments api.ToolCallFunctionArguments) ([]byte, error) {
+	var sb strings.Builder
+	sb.WriteByte('{')
+	index := 0
+	for name, value := range arguments.All() {
+		if index > 0 {
+			sb.WriteString(", ")
+		}
+		encodedName, err := marshalWithSpacesNoHTMLEscape(name)
+		if err != nil {
+			return nil, err
+		}
+		encodedValue, err := marshalWithSpacesNoHTMLEscape(value)
+		if err != nil {
+			return nil, err
+		}
+		sb.Write(encodedName)
+		sb.WriteString(": ")
+		sb.Write(encodedValue)
+		index++
+	}
+	sb.WriteByte('}')
+	return []byte(sb.String()), nil
 }

--- a/model/renderers/apertus15_test.go
+++ b/model/renderers/apertus15_test.go
@@ -158,6 +158,113 @@ func TestApertus15RendererAnyOfMatchesTemplateFallback(t *testing.T) {
 	}
 }
 
+func TestApertus15RendererUsesJinjaEnumStrings(t *testing.T) {
+	var tool api.Tool
+	if err := json.Unmarshal([]byte(`{
+		"type": "function",
+		"function": {
+			"name": "choose",
+			"description": "Choose a value.",
+			"parameters": {
+				"type": "object",
+				"properties": {
+					"value": {"type": "string", "enum": [true, false, null, 1]}
+				},
+				"required": ["value"]
+			}
+		}
+	}`), &tool); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := (&Apertus15Renderer{}).Render([]api.Message{{Role: "user", Content: "Choose."}}, []api.Tool{tool}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, `value: "True" | "False" | "None" | "1"`) {
+		t.Fatalf("enum values do not match Jinja string conversion:\n%s", got)
+	}
+}
+
+func TestApertus15RendererDoesNotEscapeHTMLToolArguments(t *testing.T) {
+	call := apertus15ToolCall("echo", map[string]any{"value": "<tag>&value</tag>"})
+	got, err := (&Apertus15Renderer{}).Render([]api.Message{
+		{Role: "user", Content: "Echo"},
+		{Role: "assistant", ToolCalls: []api.ToolCall{call}},
+	}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, `[{"echo": {"value": "<tag>&value</tag>"}}]`) {
+		t.Fatalf("tool arguments do not match Jinja escaping:\n%s", got)
+	}
+}
+
+func TestApertus15RendererPreservesToolNameAndTopLevelArgumentOrder(t *testing.T) {
+	arguments := api.NewToolCallFunctionArguments()
+	arguments.Set("zeta", "<tag>&value")
+	arguments.Set("alpha", 2)
+	call := api.ToolCall{Function: api.ToolCallFunction{
+		Name:      "echo<tag>",
+		Arguments: arguments,
+	}}
+
+	got, err := (&Apertus15Renderer{}).Render([]api.Message{
+		{Role: "user", Content: "Echo"},
+		{Role: "assistant", ToolCalls: []api.ToolCall{call}},
+	}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, `[{"echo<tag>": {"zeta": "<tag>&value", "alpha": 2}}]`) {
+		t.Fatalf("tool call does not match Jinja spelling and order:\n%s", got)
+	}
+}
+
+func TestApertus15RendererPreservesAdjacentAssistantBlockOrder(t *testing.T) {
+	call := apertus15ToolCall("lookup", map[string]any{"id": "42"})
+	got, err := (&Apertus15Renderer{}).Render([]api.Message{
+		{Role: "user", Content: "Look up"},
+		{Role: "assistant", ToolCalls: []api.ToolCall{call}},
+		{Role: "assistant", Thinking: "Reconsider."},
+		{Role: "assistant", Content: "Done."},
+		{Role: "user", Content: "Next"},
+	}, nil, &api.ThinkValue{Value: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := apertus15AssistantStart +
+		apertus15ToolsStart + `[{"lookup": {"id": "42"}}]` + apertus15ToolsEnd +
+		apertus15InnerStart + "Reconsider." + apertus15InnerEnd + "Done." +
+		apertus15AssistantEnd + apertus15UserStart + "Next" + apertus15UserEnd
+	if !strings.Contains(got, want) {
+		t.Fatalf("adjacent assistant messages lost block order\nwant fragment: %q\nrendered: %s", want, got)
+	}
+}
+
+func TestApertus15RendererPreservesRepeatedToolOutputBlocks(t *testing.T) {
+	got, err := (&Apertus15Renderer{}).Render([]api.Message{
+		{Role: "user", Content: "Observe"},
+		{Role: "assistant"},
+		{Role: "tool", Content: "one"},
+		{Role: "assistant"},
+		{Role: "tool", Content: "two"},
+		{Role: "user", Content: "Next"},
+	}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := apertus15AssistantStart +
+		apertus15ToolOutputStart + "one" + apertus15ToolOutputEnd +
+		apertus15ToolOutputStart + "two" + apertus15ToolOutputEnd +
+		apertus15AssistantEnd
+	if !strings.Contains(got, want) {
+		t.Fatalf("repeated tool output boundaries were merged\nwant fragment: %q\nrendered: %s", want, got)
+	}
+}
+
 func TestApertus15RendererThinkingWithDisplayAnswers(t *testing.T) {
 	call := apertus15ToolCall("display_answers", map[string]any{"answer": "Done"})
 	got, err := (&Apertus15Renderer{}).Render([]api.Message{

--- a/model/renderers/apertus15_test.go
+++ b/model/renderers/apertus15_test.go
@@ -1,0 +1,222 @@
+package renderers
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/ollama/ollama/api"
+)
+
+func apertus15WeatherTool(t *testing.T) api.Tool {
+	t.Helper()
+	var tool api.Tool
+	if err := json.Unmarshal([]byte(`{
+		"type": "function",
+		"function": {
+			"name": "get_weather",
+			"description": "Get current weather.",
+			"parameters": {
+				"type": "object",
+				"properties": {
+					"city": {"type": "string", "description": "City name."},
+					"unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}
+				},
+				"required": ["city"]
+			}
+		}
+	}`), &tool); err != nil {
+		t.Fatal(err)
+	}
+	return tool
+}
+
+func apertus15ToolCall(name string, values map[string]any) api.ToolCall {
+	arguments := api.NewToolCallFunctionArguments()
+	for key, value := range values {
+		arguments.Set(key, value)
+	}
+	return api.ToolCall{Function: api.ToolCallFunction{Name: name, Arguments: arguments}}
+}
+
+func TestApertus15RendererDefaultSystem(t *testing.T) {
+	got, err := (&Apertus15Renderer{}).Render([]api.Message{
+		{Role: "user", Content: "Hello"},
+	}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := apertus15BOS +
+		apertus15SystemStart + apertus15DefaultSystem + apertus15SystemEnd +
+		apertus15DeveloperStart + "Deliberation: disabled\nTool Capabilities: disabled" + apertus15DeveloperEnd +
+		apertus15UserStart + "Hello" + apertus15UserEnd + apertus15AssistantStart
+	if got != want {
+		t.Fatalf("rendered prompt mismatch\nwant: %q\n got: %q", want, got)
+	}
+	if leading := (&Apertus15Renderer{}).LeadingBOS(); leading != apertus15BOS {
+		t.Fatalf("LeadingBOS() = %q, want %q", leading, apertus15BOS)
+	}
+}
+
+func TestApertus15RendererThinkingHistory(t *testing.T) {
+	got, err := (&Apertus15Renderer{}).Render([]api.Message{
+		{Role: "system", Content: "Be concise."},
+		{Role: "user", Content: "Question"},
+		{Role: "assistant", Thinking: "Reasoning.", Content: "Answer."},
+		{Role: "user", Content: "Next"},
+	}, nil, &api.ThinkValue{Value: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, want := range []string{
+		apertus15SystemStart + "Be concise." + apertus15SystemEnd,
+		apertus15DeveloperStart + "Deliberation: enabled\nTool Capabilities: disabled" + apertus15DeveloperEnd,
+		apertus15AssistantStart + apertus15InnerStart + "Reasoning." + apertus15InnerEnd + "Answer." + apertus15AssistantEnd,
+		apertus15UserStart + "Next" + apertus15UserEnd + apertus15AssistantStart,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("rendered prompt missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestApertus15RendererKeepsHistoricalThinkingWhenDisabled(t *testing.T) {
+	got, err := (&Apertus15Renderer{}).Render([]api.Message{
+		{Role: "user", Content: "Question"},
+		{Role: "assistant", Thinking: "Stored reasoning.", Content: "Stored answer."},
+	}, nil, &api.ThinkValue{Value: false})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, apertus15InnerStart+"Stored reasoning."+apertus15InnerEnd+"Stored answer.") {
+		t.Fatalf("rendered prompt dropped historical thinking:\n%s", got)
+	}
+	if !strings.HasSuffix(got, "Stored answer.") {
+		t.Fatalf("assistant prefill should remain open:\n%s", got)
+	}
+}
+
+func TestApertus15RendererToolsAndOutputs(t *testing.T) {
+	tool := apertus15WeatherTool(t)
+	call := apertus15ToolCall("get_weather", map[string]any{"city": "Zurich"})
+	got, err := (&Apertus15Renderer{}).Render([]api.Message{
+		{Role: "user", Content: "Weather?"},
+		{Role: "assistant", Thinking: "I should check.", ToolCalls: []api.ToolCall{call}},
+		{Role: "tool", Content: `{"temperature":22}`},
+		{Role: "tool", Content: `{"condition":"clear"}`},
+	}, []api.Tool{tool}, &api.ThinkValue{Value: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantTools := "Tool Capabilities:\n" +
+		"// Get current weather.\n" +
+		"type get_weather = (_: {\n" +
+		"// City name.\n" +
+		"city: string,\n" +
+		"unit?: \"celsius\" | \"fahrenheit\"\n" +
+		"}) => any;"
+	if !strings.Contains(got, wantTools) {
+		t.Fatalf("rendered prompt missing TypeScript tools\nwant fragment: %q\nrendered: %s", wantTools, got)
+	}
+	wantTurn := apertus15AssistantStart + apertus15InnerStart + "I should check." +
+		apertus15ToolsStart + `[{"get_weather": {"city": "Zurich"}}]` + apertus15ToolsEnd +
+		apertus15ToolOutputStart + `{"temperature":22}, {"condition":"clear"}` + apertus15ToolOutputEnd +
+		apertus15AssistantEnd + apertus15AssistantStart
+	if !strings.Contains(got, wantTurn) {
+		t.Fatalf("rendered prompt missing tool turn\nwant fragment: %q\nrendered: %s", wantTurn, got)
+	}
+}
+
+func TestApertus15RendererAnyOfMatchesTemplateFallback(t *testing.T) {
+	var tool api.Tool
+	if err := json.Unmarshal([]byte(`{
+		"type": "function",
+		"function": {
+			"name": "accept_value",
+			"description": "Accept a value.",
+			"parameters": {
+				"type": "object",
+				"properties": {
+					"value": {"anyOf": [{"type": "string"}, {"type": "number"}]}
+				},
+				"required": ["value"]
+			}
+		}
+	}`), &tool); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := (&Apertus15Renderer{}).Render([]api.Message{{Role: "user", Content: "Use it."}}, []api.Tool{tool}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "type accept_value = (_: {\nvalue: any\n}) => any;") {
+		t.Fatalf("anyOf did not use the source template fallback:\n%s", got)
+	}
+}
+
+func TestApertus15RendererThinkingWithDisplayAnswers(t *testing.T) {
+	call := apertus15ToolCall("display_answers", map[string]any{"answer": "Done"})
+	got, err := (&Apertus15Renderer{}).Render([]api.Message{
+		{Role: "user", Content: "Solve"},
+		{Role: "assistant", Thinking: "Finished.", ToolCalls: []api.ToolCall{call}},
+	}, nil, &api.ThinkValue{Value: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The wrapped function-call representation does not trigger the template's
+	// direct-call-only display_answers transition.
+	want := apertus15InnerStart + "Finished." +
+		apertus15ToolsStart + `[{"display_answers": {"answer": "Done"}}]` + apertus15ToolsEnd
+	if !strings.Contains(got, want) {
+		t.Fatalf("rendered prompt missing display_answers transition\nwant fragment: %q\nrendered: %s", want, got)
+	}
+}
+
+func TestApertus15RendererImages(t *testing.T) {
+	messages := []api.Message{
+		{Role: "user", Content: "First", Images: []api.ImageData{api.ImageData("a")}},
+		{Role: "assistant", Content: "Seen"},
+		{Role: "user", Content: "Second", Images: []api.ImageData{api.ImageData("b"), api.ImageData("c")}},
+	}
+
+	canonical, err := (&Apertus15Renderer{}).Render(messages, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(canonical, apertus15UserStart+apertus15Image+"First"+apertus15UserEnd) ||
+		!strings.Contains(canonical, apertus15UserStart+apertus15Image+apertus15Image+"Second"+apertus15UserEnd) {
+		t.Fatalf("canonical rendering has incorrect image tokens:\n%s", canonical)
+	}
+
+	native, err := (&Apertus15Renderer{useImgTags: true}).Render(messages, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"[img-0] First", "[img-1][img-2] Second"} {
+		if !strings.Contains(native, want) {
+			t.Fatalf("native rendering missing %q:\n%s", want, native)
+		}
+	}
+}
+
+func TestApertus15RendererRejectsInvalidSequences(t *testing.T) {
+	tests := []struct {
+		name     string
+		messages []api.Message
+	}{
+		{name: "non-initial system", messages: []api.Message{{Role: "user", Content: "Hi"}, {Role: "system", Content: "Late"}}},
+		{name: "tool outside assistant", messages: []api.Message{{Role: "tool", Content: "result"}}},
+		{name: "unknown role", messages: []api.Message{{Role: "developer", Content: "no"}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := (&Apertus15Renderer{}).Render(tt.messages, nil, nil); err == nil {
+				t.Fatal("expected rendering error")
+			}
+		})
+	}
+}

--- a/model/renderers/json.go
+++ b/model/renderers/json.go
@@ -1,6 +1,9 @@
 package renderers
 
-import "encoding/json"
+import (
+	"bytes"
+	"encoding/json"
+)
 
 // marshalWithSpaces marshals v to JSON and adds a space after each ':' and ','
 // that appears outside of string values. This matches the formatting expected
@@ -10,7 +13,22 @@ func marshalWithSpaces(v any) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	return addJSONSpaces(b), nil
+}
 
+// marshalWithSpacesNoHTMLEscape matches Python/Jinja JSON string escaping while
+// retaining the spaced separators used by model chat templates.
+func marshalWithSpacesNoHTMLEscape(v any) ([]byte, error) {
+	var b bytes.Buffer
+	encoder := json.NewEncoder(&b)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(v); err != nil {
+		return nil, err
+	}
+	return addJSONSpaces(bytes.TrimSuffix(b.Bytes(), []byte{'\n'})), nil
+}
+
+func addJSONSpaces(b []byte) []byte {
 	out := make([]byte, 0, len(b)+len(b)/8)
 	inStr, esc := false, false
 	for _, c := range b {
@@ -41,5 +59,5 @@ func marshalWithSpaces(v any) ([]byte, error) {
 			out = append(out, c)
 		}
 	}
-	return out, nil
+	return out
 }

--- a/model/renderers/json_test.go
+++ b/model/renderers/json_test.go
@@ -343,3 +343,15 @@ func TestMarshalWithSpaces(t *testing.T) {
 		})
 	}
 }
+
+func TestMarshalWithSpacesNoHTMLEscape(t *testing.T) {
+	got, err := marshalWithSpacesNoHTMLEscape(map[string]any{
+		"value": "<tag>&value</tag>",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := `{"value": "<tag>&value</tag>"}`; string(got) != want {
+		t.Fatalf("marshalWithSpacesNoHTMLEscape() = %q, want %q", got, want)
+	}
+}

--- a/model/renderers/renderer.go
+++ b/model/renderers/renderer.go
@@ -113,6 +113,8 @@ func rendererForName(name string) Renderer {
 		return &LagunaV8Renderer{}
 	case "cohere":
 		return &CohereRenderer{}
+	case "apertus1.5":
+		return &Apertus15Renderer{useImgTags: RenderImgTags}
 	default:
 		return nil
 	}

--- a/x/create/client/create.go
+++ b/x/create/client/create.go
@@ -580,6 +580,11 @@ func isQwen35Family(s string) bool {
 	return strings.Contains(s, "qwen3_5") || strings.Contains(s, "qwen3next")
 }
 
+func isApertus15Family(s string) bool {
+	s = strings.ToLower(s)
+	return strings.Contains(s, "apertus1p5") || strings.Contains(s, "apertus1_5")
+}
+
 func lagunaRendererParserName(modelDir string) string {
 	const poolsideV1Marker = "laguna_glm_thinking_v8"
 
@@ -617,6 +622,9 @@ func getParserName(modelDir string) string {
 	// Check architectures for known parsers
 	for _, arch := range cfg.Architectures {
 		archLower := strings.ToLower(arch)
+		if isApertus15Family(archLower) {
+			return "apertus1.5"
+		}
 		if strings.Contains(archLower, "laguna") {
 			return lagunaRendererParserName(modelDir)
 		}
@@ -643,6 +651,9 @@ func getParserName(modelDir string) string {
 	// Also check model_type
 	if cfg.ModelType != "" {
 		typeLower := strings.ToLower(cfg.ModelType)
+		if isApertus15Family(typeLower) {
+			return "apertus1.5"
+		}
 		if strings.Contains(typeLower, "laguna") {
 			return lagunaRendererParserName(modelDir)
 		}
@@ -689,6 +700,9 @@ func getRendererName(modelDir string) string {
 	// Check architectures for known renderers
 	for _, arch := range cfg.Architectures {
 		archLower := strings.ToLower(arch)
+		if isApertus15Family(archLower) {
+			return "apertus1.5"
+		}
 		if strings.Contains(archLower, "laguna") {
 			return lagunaRendererParserName(modelDir)
 		}
@@ -715,6 +729,9 @@ func getRendererName(modelDir string) string {
 	// Also check model_type
 	if cfg.ModelType != "" {
 		typeLower := strings.ToLower(cfg.ModelType)
+		if isApertus15Family(typeLower) {
+			return "apertus1.5"
+		}
 		if strings.Contains(typeLower, "laguna") {
 			return lagunaRendererParserName(modelDir)
 		}

--- a/x/create/client/create_test.go
+++ b/x/create/client/create_test.go
@@ -660,6 +660,11 @@ func TestInferSafetensorsCapabilitiesFromParser(t *testing.T) {
 			parserName: "functiongemma",
 			want:       []string{"completion", "tools"},
 		},
+		{
+			name:       "apertus 1.5 tools and thinking",
+			parserName: "apertus1.5",
+			want:       []string{"completion", "tools", "thinking"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -710,6 +715,11 @@ func TestGetParserName(t *testing.T) {
 			want:       "qwen3.5",
 		},
 		{
+			name:       "apertus 1.5 model",
+			configJSON: `{"architectures": ["Apertus1p5ForConditionalGeneration"]}`,
+			want:       "apertus1.5",
+		},
+		{
 			name:       "deepseek model",
 			configJSON: `{"architectures": ["DeepseekV3ForCausalLM"]}`,
 			want:       "deepseek3",
@@ -728,6 +738,11 @@ func TestGetParserName(t *testing.T) {
 			name:       "qwen3 via model_type",
 			configJSON: `{"model_type": "qwen3"}`,
 			want:       "qwen3",
+		},
+		{
+			name:       "apertus 1.5 via model_type",
+			configJSON: `{"model_type": "apertus1p5"}`,
+			want:       "apertus1.5",
 		},
 		{
 			name:       "laguna model",
@@ -770,6 +785,11 @@ func TestGetRendererName(t *testing.T) {
 			want:       "qwen3.5",
 		},
 		{
+			name:       "apertus 1.5 model",
+			configJSON: `{"architectures": ["Apertus1p5ForConditionalGeneration"]}`,
+			want:       "apertus1.5",
+		},
+		{
 			name:       "deepseek model",
 			configJSON: `{"architectures": ["DeepseekV3ForCausalLM"]}`,
 			want:       "deepseek3",
@@ -788,6 +808,11 @@ func TestGetRendererName(t *testing.T) {
 			name:       "laguna model",
 			configJSON: `{"architectures": ["LagunaForCausalLM"], "model_type": "laguna"}`,
 			want:       "laguna",
+		},
+		{
+			name:       "apertus 1.5 via model_type",
+			configJSON: `{"model_type": "apertus1p5"}`,
+			want:       "apertus1.5",
 		},
 	}
 


### PR DESCRIPTION
## Summary

[Apertus v1.5 8B](https://huggingface.co/swiss-ai/Apertus-v1.5-8B) and [Apertus v1.5 70B](https://huggingface.co/swiss-ai/Apertus-v1.5-70B) are fully open Swiss multimodal language models developed within the Swiss AI Initiative.

This adds native Apertus v1.5 chat handling:

- render system, user, assistant, tool-call, and tool-result messages
- support thinking prompts and preserve reasoning history, including reasoning-only assistant prefills
- parse streamed reasoning, content, and native tool calls
- reject malformed tool-call arguments
- render Ollama image inputs with the Apertus image placeholder
- select the handlers from the model's architecture metadata

The implementation aims to reproduce the functionality of the official Jinja chat template as faithfully as possible.

Apertus thinking is binary, so Ollama's named thinking levels all enable deliberation. Ollama enables thinking when `think` is omitted. Since Apertus does not support tool calling in thinking mode, tool requests should set `think: false`.

Related to #12149.

## Tests

```console
go test ./model/renderers ./model/parsers ./x/create/client
```

Renderer output was compared with the official 8B and 70B templates across multi-turn conversations, thinking, tools, images, empty content, and malformed inputs. Parser tests cover streamed content, reasoning, reasoning-only prefills, tool calls, and invalid arguments.

## Backend status

Audio input is not included in this PR. Ollama supports audio input for selected models, but the Apertus-specific audio tokenizer and inference path are not yet available in llama.cpp.

It does not make Apertus v1.5 runnable through Ollama yet. The inference backend still depends on complete Apertus v1.5 support in llama.cpp. The open [ggml-org/llama.cpp#26226](https://github.com/ggml-org/llama.cpp/pull/26226) pull request implements the separate output vocabulary size required by the model, but not the complete backend.