### PR TITLE
app: hide macOS app after closing its window

### DIFF
--- a/app/cmd/app/app_darwin.m
+++ b/app/cmd/app/app_darwin.m
@@ -1484,7 +1484,7 @@ didCompleteWithError:(NSError *)error {
 }
 
 - (BOOL)windowShouldClose:(id)sender {
-    [NSApp hide:nil];
+    [self hide];
     return NO;
 }
 


### PR DESCRIPTION
## Summary

On macOS, closing the Ollama window hides it but leaves the application using the regular activation policy. As a result, Ollama remains visible in the Dock and application switcher even though no window is open.

Reuse the existing `hide` method when closing a window. This hides the UI and changes the activation policy to `NSApplicationActivationPolicyAccessory`, while leaving the menu bar app and Ollama server running.

Addresses the macOS behavior reported in https://github.com/ollama/ollama/issues/11604#issuecomment-3149998630.

## Testing

- `PATH="$(go env GOPATH)/bin:$PATH" go generate ./...`
- `go test -count=1 ./app/...`
- Built and launched the macOS desktop app.
- Verified that opening the UI changes its LaunchServices application type to `Foreground`.
- Invoked the window-close callback and verified that the application type changes to `UIElement`.
- Verified that the menu bar app and local Ollama server remain running after closing the window.
- Reopened and closed the UI again, confirming the `Foreground` to `UIElement` transition is repeatable.
