### PR TITLE
llm: stop guessing that a repetitive payload is a runaway

### DIFF
--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -1661,8 +1661,8 @@ func (s *llamaServerRunner) Completion(ctx context.Context, req CompletionReques
 	buf := make([]byte, 0, llamaServerStreamInitialBufferSize)
 	scanner.Buffer(buf, llamaServerStreamMaxBufferSize)
 
-	var lastToken string
-	var tokenRepeat int
+	var repeat repeatGuard
+	var evalCount int
 	var finalResp CompletionResponse
 	var hasFinalResp bool
 
@@ -1689,17 +1689,26 @@ func (s *llamaServerRunner) Completion(ctx context.Context, req CompletionReques
 				return fmt.Errorf("error unmarshalling llama-server response: %v", err)
 			}
 
-			// Token repeat detection
-			switch {
-			case strings.TrimSpace(lsResp.Content) == lastToken:
-				tokenRepeat++
-			default:
-				lastToken = strings.TrimSpace(lsResp.Content)
-				tokenRepeat = 0
+			if lsResp.Content != "" {
+				evalCount++
 			}
-			if tokenRepeat > 30 {
-				slog.Debug("prediction aborted, token repeat limit reached")
-				return ctx.Err()
+
+			// A generation that has come apart repeats one short unit until
+			// something stops it. Cut it off, and say so: the response is
+			// already partly streamed, so it ends as a normal completion with
+			// a reason the caller can act on.
+			if repeat.observe(lsResp.Content) {
+				slog.Warn("stopping generation, output repeated the same sequence past the limit",
+					"period", repeat.period(), "bytes", repeatGuardBudgetBytes)
+				if err := res.Body.Close(); err != nil {
+					return fmt.Errorf("error closing llama-server response: %v", err)
+				}
+				fn(CompletionResponse{
+					Done:       true,
+					DoneReason: DoneReasonRepeat,
+					EvalCount:  evalCount,
+				})
+				return nil
 			}
 
 			if lsResp.Content != "" && !lsResp.Stop {

--- a/llm/repeat_guard.go
+++ b/llm/repeat_guard.go
@@ -1,0 +1,72 @@
+package llm
+
+import "slices"
+
+// A model that has come apart and a payload that is legitimately repetitive
+// look the same for a while: both emit the same token over and over. Base64 of
+// an audio file, a hex dump, a run of indentation, a rule of dashes in a
+// markdown table — all of them repeat inside a bounded region and then carry on
+// with something else. A model that is stuck repeats until something stops it.
+//
+// So the guard measures two things the old one did not. It measures the run in
+// characters rather than in stream events, with a budget no realistic payload
+// reaches, and it looks for a repeating unit of several tokens rather than a
+// single one, which is the shape a stuck model actually produces ("Wait, let me
+// re-read the question." over and over) and which a single-token counter never
+// saw at all.
+const (
+	// longest repeating unit recognised, in tokens
+	repeatGuardMaxPeriod = 32
+	// how many trailing tokens to keep: three turns of the longest unit, the
+	// minimum needed to call something a repetition rather than a coincidence
+	repeatGuardWindow = repeatGuardMaxPeriod * 3
+	// characters of uninterrupted repetition tolerated before giving up
+	repeatGuardBudgetBytes = 16 * 1024
+)
+
+// repeatGuard reports when a generation has spent too long repeating one short
+// unit. The zero value is ready to use.
+type repeatGuard struct {
+	tokens []string
+	bytes  int
+}
+
+// observe records the next piece of generated text and reports whether the
+// stream has now repeated a single unit for longer than the budget allows.
+func (g *repeatGuard) observe(s string) bool {
+	if s == "" {
+		return false
+	}
+
+	if len(g.tokens) == repeatGuardWindow {
+		copy(g.tokens, g.tokens[1:])
+		g.tokens[repeatGuardWindow-1] = s
+	} else {
+		g.tokens = append(g.tokens, s)
+	}
+
+	if g.period() == 0 {
+		g.bytes = 0
+		return false
+	}
+
+	g.bytes += len(s)
+	return g.bytes > repeatGuardBudgetBytes
+}
+
+// period returns the length of the shortest unit that the tail of the window
+// repeats three times over, or zero when the tail is not repeating. Three turns
+// rather than two so that an ordinary "the ... the" pair does not read as a
+// cycle.
+func (g *repeatGuard) period() int {
+	for k := 1; k <= repeatGuardMaxPeriod; k++ {
+		if len(g.tokens) < 3*k {
+			break
+		}
+		tail := g.tokens[len(g.tokens)-3*k:]
+		if slices.Equal(tail[:k], tail[k:2*k]) && slices.Equal(tail[:k], tail[2*k:]) {
+			return k
+		}
+	}
+	return 0
+}

--- a/llm/repeat_guard_test.go
+++ b/llm/repeat_guard_test.go
@@ -1,0 +1,206 @@
+package llm
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ollama/ollama/api"
+	"golang.org/x/sync/semaphore"
+)
+
+func TestRepeatGuard(t *testing.T) {
+	// how many times a unit has to be emitted to spend the budget, with room
+	// for the turns that go into recognising the cycle in the first place
+	repeats := func(unit ...string) int {
+		n := 0
+		for _, s := range unit {
+			n += len(s)
+		}
+		return repeatGuardBudgetBytes/n + 8
+	}
+
+	tests := []struct {
+		name  string
+		emit  func(g *repeatGuard) bool
+		trips bool
+	}{
+		{
+			// the tail of an mp3 is a long run of one byte, so the tail of its
+			// base64 is a long run of one token
+			name: "a base64 payload is not a runaway",
+			emit: func(g *repeatGuard) bool {
+				return emitAll(g, strings.Split("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR", ""))
+			},
+		},
+		{
+			name: "a long run of one token below the budget is allowed",
+			emit: func(g *repeatGuard) bool {
+				return emitTimes(g, 1000, "VVVV")
+			},
+		},
+		{
+			name: "a run of one token past the budget stops",
+			emit: func(g *repeatGuard) bool {
+				return emitTimes(g, repeats("VVVV"), "VVVV")
+			},
+			trips: true,
+		},
+		{
+			// the shape a stuck model actually produces, which counting a
+			// single repeated token never caught
+			name: "a repeated phrase past the budget stops",
+			emit: func(g *repeatGuard) bool {
+				return emitTimes(g, repeats("Wait", ",", " let", " me", " re", "-read", " the", " question", "."),
+					"Wait", ",", " let", " me", " re", "-read", " the", " question", ".")
+			},
+			trips: true,
+		},
+		{
+			name: "indentation does not stop generation",
+			emit: func(g *repeatGuard) bool {
+				for range 200 {
+					if g.observe("\n") || g.observe("    ") || g.observe("if") || g.observe(" x") {
+						return true
+					}
+				}
+				return false
+			},
+		},
+		{
+			name: "ordinary prose does not stop generation",
+			emit: func(g *repeatGuard) bool {
+				words := strings.Fields("the quick brown fox jumps over the lazy dog and then the dog barks back")
+				for i := range 500 {
+					// the same words in a different order each time, which is
+					// what prose looks like and a loop does not
+					for j := range words {
+						if g.observe(words[(i+j*7)%len(words)]) {
+							return true
+						}
+					}
+				}
+				return false
+			},
+		},
+		{
+			// a payload that repeats and then moves on must not carry its
+			// count into whatever follows
+			name: "a run that ends resets the budget",
+			emit: func(g *repeatGuard) bool {
+				if emitTimes(g, repeats("VVVV")-16, "VVVV") {
+					return true
+				}
+				emitAll(g, strings.Fields("and that is the end of the file"))
+				return emitTimes(g, repeats("AAAA")-16, "AAAA")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var g repeatGuard
+			if got := tt.emit(&g); got != tt.trips {
+				t.Fatalf("tripped = %v, want %v", got, tt.trips)
+			}
+		})
+	}
+}
+
+// emitAll feeds a sequence to the guard once, reporting whether it tripped.
+func emitAll(g *repeatGuard, tokens []string) bool {
+	for _, tok := range tokens {
+		if g.observe(tok) {
+			return true
+		}
+	}
+	return false
+}
+
+// emitTimes feeds a unit to the guard n times, reporting whether it tripped.
+func emitTimes(g *repeatGuard, n int, unit ...string) bool {
+	for range n {
+		if emitAll(g, unit) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestLlamaServerCompletionRepeatedOutput(t *testing.T) {
+	tests := []struct {
+		name           string
+		emits          int
+		wantDoneReason DoneReason
+		wantContent    string
+	}{
+		{
+			// what reading an mp3 back as base64 looks like on the wire
+			name:           "a repetitive payload completes normally",
+			emits:          1000,
+			wantDoneReason: DoneReasonStop,
+			wantContent:    strings.Repeat("VVVV", 1000) + "done",
+		},
+		{
+			name:           "a runaway is stopped and reported",
+			emits:          repeatGuardBudgetBytes/len("VVVV") + 10,
+			wantDoneReason: DoneReasonRepeat,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/health" {
+					fmt.Fprint(w, `{"status":"ok"}`)
+					return
+				}
+				w.Header().Set("Content-Type", "text/event-stream")
+				for range tt.emits {
+					fmt.Fprintln(w, `data: {"content":"VVVV","stop":false}`)
+				}
+				fmt.Fprintln(w, `data: {"content":"done","stop":true,"stop_type":"eos","timings":{"prompt_n":1,"prompt_ms":1,"predicted_n":1,"predicted_ms":1}}`)
+			}))
+			defer srv.Close()
+
+			var portInt int
+			fmt.Sscanf(srv.URL[strings.LastIndex(srv.URL, ":")+1:], "%d", &portInt)
+
+			runner := &llamaServerRunner{
+				port:    portInt,
+				cmd:     fakeRunningCmd(),
+				sem:     semaphore.NewWeighted(1),
+				options: api.Options{Runner: api.Runner{NumCtx: 2048}},
+			}
+
+			opts := api.DefaultOptions()
+			var content strings.Builder
+			var final CompletionResponse
+			var sawDone bool
+			err := runner.Completion(t.Context(), CompletionRequest{Prompt: "read the file", Options: &opts}, func(cr CompletionResponse) {
+				content.WriteString(cr.Content)
+				if cr.Done {
+					final = cr
+					sawDone = true
+				}
+			})
+			if err != nil {
+				t.Fatalf("Completion error: %v", err)
+			}
+
+			// a caller that never sees Done cannot tell a finished stream from
+			// a broken connection, which is the whole point of this test
+			if !sawDone {
+				t.Fatal("no done response was sent")
+			}
+			if final.DoneReason != tt.wantDoneReason {
+				t.Errorf("done reason = %q, want %q", final.DoneReason, tt.wantDoneReason)
+			}
+			if tt.wantContent != "" && content.String() != tt.wantContent {
+				t.Errorf("content = %d chars, want %d", content.Len(), len(tt.wantContent))
+			}
+		})
+	}
+}

--- a/llm/server.go
+++ b/llm/server.go
@@ -253,6 +253,9 @@ const (
 	DoneReasonStop DoneReason = iota
 	DoneReasonLength
 	DoneReasonConnectionClosed
+	// DoneReasonRepeat is reported when a generation was stopped because it
+	// had degenerated into repeating the same short sequence.
+	DoneReasonRepeat
 )
 
 func (d DoneReason) String() string {
@@ -261,6 +264,8 @@ func (d DoneReason) String() string {
 		return "length"
 	case DoneReasonStop:
 		return "stop"
+	case DoneReasonRepeat:
+		return "repeat"
 	default:
 		return ""
 	}

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -291,7 +291,7 @@ func ToChatCompletion(id string, r api.ChatResponse) ChatCompletion {
 					return &reason
 				}
 				return nil
-			}(r.DoneReason),
+			}(openAIFinishReason(r.DoneReason)),
 			Logprobs: logprobs,
 		}}, Usage: ToUsage(r),
 		DebugInfo: r.DebugInfo,
@@ -364,13 +364,23 @@ func ToStreamChunks(id string, r api.ChatResponse, includeRole bool) []ChatCompl
 	}
 }
 
+// openAIFinishReason maps ollama's done reasons onto the values OpenAI clients
+// expect. A generation stopped for repeating itself was cut short, which is
+// what "length" means to them; anything else already carries a name they know.
+func openAIFinishReason(reason string) string {
+	if reason == "repeat" {
+		return "length"
+	}
+	return reason
+}
+
 // FinishChunk creates a dedicated finish-reason chunk with an empty delta,
 // matching the OpenAI spec where finish_reason is sent on its own chunk.
 func FinishChunk(id string, r api.ChatResponse, toolCallSent bool) ChatCompletionChunk {
 	// Only remap known terminal reasons; pass anything else through untouched.
 	// tool_calls only overrides stop — an unfinished or unknown done reason
 	// must not be relabeled tool_calls.
-	reason := cmp.Or(r.DoneReason, "stop")
+	reason := cmp.Or(openAIFinishReason(r.DoneReason), "stop")
 	if reason == "stop" && toolCallSent {
 		reason = "tool_calls"
 	}
@@ -419,7 +429,7 @@ func ToCompletion(id string, r api.GenerateResponse) Completion {
 					return &reason
 				}
 				return nil
-			}(r.DoneReason),
+			}(openAIFinishReason(r.DoneReason)),
 		}},
 		Usage: ToUsageGenerate(r),
 	}
@@ -441,7 +451,7 @@ func ToCompleteChunk(id string, r api.GenerateResponse) CompletionChunk {
 					return &reason
 				}
 				return nil
-			}(r.DoneReason),
+			}(openAIFinishReason(r.DoneReason)),
 		}},
 	}
 }


### PR DESCRIPTION
Discussed in #17562, item 1. The detector is the part worth arguing about; the reporting bug is not.

The detector is the part worth arguing about; the reporting bug is not.

## The bug, as it was hit

A coding agent was asked to embed sound effects in a page. It ran

```
powershell -Command "[Convert]::ToBase64String([System.IO.File]::ReadAllBytes('sounds/coin.mp3'))"
```

fed the result back, and the next turn died with

> Did not receive done or success response in stream.

which names neither the model, the reason, nor the request. The server logged nothing: no error, no warning, and a `200`.

What actually happened is in `llm/llama_server.go`:

```go
// Token repeat detection
switch {
case strings.TrimSpace(lsResp.Content) == lastToken:
    tokenRepeat++
default:
    lastToken = strings.TrimSpace(lsResp.Content)
    tokenRepeat = 0
}
if tokenRepeat > 30 {
    slog.Debug("prediction aborted, token repeat limit reached")
    return ctx.Err()
}
```

The tail of an mp3 is a long run of one byte, so the tail of its base64 is a long run of one token — `VVVVVVVV…`. Thirty-one of those and the guard fires.

## Two separate defects

**1. The abort is reported as success.** `ctx.Err()` is nil unless the context is done, and here it is alive — the guard is what wants to stop, not the caller. So `Completion` returns nil without ever calling `fn` with a `Done` response. The handler's channel closes, gin finishes the response normally, and the client sees a well-formed stream that simply ends. Every ollama client raises the same unhelpful error, because a stream with no terminator is indistinguishable from a dropped connection.

Reproduced with a fake llama-server emitting 40 identical events:

```
Completion returned err=<nil>, callbacks=31, sawDone=false
```

**2. Thirty-one events is not evidence of anything.** `VVVV` × 31 is 124 characters. Things that produce more than 124 characters of repetition and are not runaways:

| payload | what repeats |
| --- | --- |
| base64 of any file with a run of equal bytes | one token, thousands of times |
| a hex dump | `00 00 00 00 …` |
| generated code | one indentation token per line |
| a markdown rule or table separator | `---`, `===` |
| CSV of a sparse matrix | `0,0,0,0,…` |

The whitespace case is worse than it looks: the comparison is on `strings.TrimSpace`, so *every* whitespace-only token equals every other one. A run of `"\n"`, `"    "`, `"\t"` in any order counts as 31 repeats of the same thing.

## What this changes

`llm/repeat_guard.go`, a small type with two knobs:

- **The run is measured in characters, not events** — 16 KiB, against roughly 124 today. A model that has come apart repeats until something stops it, so a budget large enough to clear any realistic payload still catches it, just later. `num_predict` and the context length already bound the total.
- **The repeating unit may be up to 32 tokens** — a stuck model repeats a *phrase* ("Wait, let me re-read the question." over and over), not a token. The old counter never caught that shape at all; a single repeated token, which is what it did catch, is the shape most likely to be legitimate. A unit must recur three times before it counts as a cycle, and any token that breaks the cycle resets the budget, so a payload that repeats and then moves on carries nothing forward.

When the budget is spent the stream ends as a completion with `done_reason: "repeat"` rather than vanishing: the partial response is kept, the server logs it at WARN, and the caller can decide what to do. OpenAI-compatible clients get `"length"` — the value they already understand for a response that was cut short — and the Anthropic layer already maps unknown reasons to `stop_sequence`.

## Why not leave it to the samplers

The obvious smaller patch is to delete the heuristic and let `repeat_penalty` and DRY do the job. They cannot:

- `repeat_penalty` is set per model, in the model's own parameters, so it is not a behaviour ollama controls or can rely on. It is also frequently absent, and where it is present its reach is whatever `repeat_last_n` happens to be — the common 256-token window is too short to see a long run at all.
- It does not even hold where it *is* configured. The model in the report above ships a `repeat_penalty`, and produced the base64 stall anyway.
- Turning it up is worse than leaving it alone. Measured on that model across a seed sweep: a repeat penalty strong enough to suppress a thinking-channel loop **relocates** the failure into the answer channel as an unbounded runaway — one run produced 63,774 characters of answer and ended on `length`. A weak window looked clean only because it never engaged.
- DRY costs output quality badly enough that it is not usable as a default; that was tested on the same model and abandoned.

Which is the argument for the guard existing at all: it is the backstop for when nothing else is configured, and for when what is configured does not reach. What it must not do is fire on ordinary payloads, or lie about why it fired.

## Open questions for review

1. **Exact repeats only.** A unit has to recur verbatim, which is also what the old counter required. Under an active repeat penalty a degenerating model tends to produce *near*-repeats — the same sentence with a word swapped — and neither version sees those. Catching them needs a similarity measure rather than equality, which is a bigger change and a much easier one to get wrong; worth deciding deliberately rather than by omission.
2. **16 KiB and 32 tokens are judgement calls.** 16 KiB of *uninterrupted* repetition is about four seconds of generation at 100 tok/s, and no payload I could construct reaches it — but a long enough run of silence in a large audio file would. An env knob (`OLLAMA_REPEAT_BUDGET=0` to disable) is easy to add if that is preferred to a constant.
3. **`done_reason: "repeat"` is a new value on the native API.** The alternative is to reuse `"length"` everywhere and say nothing about why, which no client has to learn but which also tells the user nothing.
4. **The period search is O(32) slice comparisons per token.** Negligible against decoding, but a rolling hash would make it O(1) if that is a concern.

## How it is tested

`TestRepeatGuard` — base64, a long-but-bounded single-token run, a run past the budget, a repeated phrase past the budget, indentation, prose, and a run that ends and must not carry its count forward.

`TestLlamaServerCompletionRepeatedOutput` — end to end against a fake llama-server: a repetitive payload completes normally with every character delivered, and a runaway ends with a `Done` response carrying `repeat`. Both assert that a `Done` response arrives at all, which is the regression that started this.

`go build ./...`, `go vet ./...` and the package tests are clean against current `main`. On hosts with glibc below 2.34 `go build ./...` also needs #17567, which fixes a `cmd/runner` cgo link failure present on `main` (`undefined reference to 'dlopen'`); it is a separate one-line fix and this change does not depend on it.

