### PR TITLE
server: do not hand over a tool call the model did not finish writing

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -2795,6 +2795,7 @@ func (s *Server) ChatHandler(c *gin.Context) {
 
 					res.Message.Content = content
 					res.Message.Thinking = thinking
+					toolCalls = completeToolCalls(toolCalls, req.Tools, r.Done && r.DoneReason == llm.DoneReasonLength)
 					for i := range toolCalls {
 						toolCalls[i].ID = toolCallId()
 					}
@@ -2839,6 +2840,7 @@ func (s *Server) ChatHandler(c *gin.Context) {
 
 				if len(req.Tools) > 0 {
 					toolCalls, content := toolParser.Add(res.Message.Content)
+					toolCalls = completeToolCalls(toolCalls, req.Tools, r.Done && r.DoneReason == llm.DoneReasonLength)
 					if len(content) > 0 {
 						res.Message.Content = content
 					} else if len(toolCalls) > 0 {

--- a/server/toolcalls.go
+++ b/server/toolcalls.go
@@ -1,0 +1,58 @@
+package server
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/logutil"
+)
+
+// completeToolCalls drops tool calls the model never finished writing.
+//
+// A response that ends on the token limit can stop in the middle of a tool
+// call's arguments. The fields that did arrive parse cleanly, so the call
+// reaches the caller looking complete while a required argument is simply
+// absent — a coding agent then rejects it with a schema error that names a
+// field the model was still on its way to producing, and the reason (the
+// response was cut short) is nowhere in sight.
+//
+// done_reason already says "length", but a tool call is the part of a response
+// callers act on, and acting on half a tool call is worse than not seeing one.
+// So an unfinished call is dropped rather than handed over, and only when the
+// generation actually stopped at the limit: a call missing a required argument
+// in a response that ended normally is the model's own error to report, not
+// something to hide.
+func completeToolCalls(toolCalls []api.ToolCall, tools []api.Tool, truncated bool) []api.ToolCall {
+	if !truncated || len(toolCalls) == 0 {
+		return toolCalls
+	}
+
+	required := make(map[string][]string, len(tools))
+	for _, tool := range tools {
+		required[tool.Function.Name] = tool.Function.Parameters.Required
+	}
+
+	kept := toolCalls[:0]
+	for _, call := range toolCalls {
+		if missing := missingArguments(call, required[call.Function.Name]); missing != "" {
+			slog.Warn("dropping a tool call the model did not finish writing",
+				"tool", call.Function.Name, "missing", missing, "done_reason", "length")
+			continue
+		}
+		slog.Log(context.TODO(), logutil.LevelTrace, "keeping a complete tool call from a truncated response", "tool", call.Function.Name)
+		kept = append(kept, call)
+	}
+	return kept
+}
+
+// missingArguments returns the first required argument the call does not carry,
+// or the empty string when it carries all of them.
+func missingArguments(call api.ToolCall, required []string) string {
+	for _, name := range required {
+		if _, ok := call.Function.Arguments.Get(name); !ok {
+			return name
+		}
+	}
+	return ""
+}

--- a/server/toolcalls_test.go
+++ b/server/toolcalls_test.go
@@ -1,0 +1,97 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/ollama/ollama/api"
+)
+
+func TestCompleteToolCalls(t *testing.T) {
+	// the editor tool from a coding agent: the shape that produced this
+	editor := api.Tool{
+		Type: "function",
+		Function: api.ToolFunction{
+			Name: "editor",
+			Parameters: api.ToolFunctionParameters{
+				Type:     "object",
+				Required: []string{"path", "new_text"},
+			},
+		},
+	}
+	shell := api.Tool{
+		Type: "function",
+		Function: api.ToolFunction{
+			Name: "shell",
+			Parameters: api.ToolFunctionParameters{
+				Type:     "object",
+				Required: []string{"command"},
+			},
+		},
+	}
+
+	call := func(name string, args ...string) api.ToolCall {
+		a := api.NewToolCallFunctionArguments()
+		for i := 0; i < len(args); i += 2 {
+			a.Set(args[i], args[i+1])
+		}
+		return api.ToolCall{Function: api.ToolCallFunction{Name: name, Arguments: a}}
+	}
+
+	tests := []struct {
+		name      string
+		toolCalls []api.ToolCall
+		truncated bool
+		want      int
+	}{
+		{
+			// a 62k-character new_text ran out of tokens before path was
+			// written, so the call arrives with two of its four arguments
+			name:      "an unfinished call is dropped when the response was cut short",
+			toolCalls: []api.ToolCall{call("editor", "insert_line", "48", "new_text", "const SOUND_DATA = {")},
+			truncated: true,
+			want:      0,
+		},
+		{
+			name:      "a complete call survives a truncated response",
+			toolCalls: []api.ToolCall{call("editor", "path", "index.html", "new_text", "hello")},
+			truncated: true,
+			want:      1,
+		},
+		{
+			// the model's own mistake to report, not something to hide
+			name:      "an incomplete call is kept when the response ended normally",
+			toolCalls: []api.ToolCall{call("editor", "new_text", "hello")},
+			want:      1,
+		},
+		{
+			name: "only the unfinished call in a batch is dropped",
+			toolCalls: []api.ToolCall{
+				call("shell", "command", "ls"),
+				call("editor", "new_text", "hello"),
+			},
+			truncated: true,
+			want:      1,
+		},
+		{
+			// a tool the request never declared has no schema to check against
+			name:      "an unknown tool is left alone",
+			toolCalls: []api.ToolCall{call("mystery", "anything", "here")},
+			truncated: true,
+			want:      1,
+		},
+		{
+			name:      "no tool calls is not a special case",
+			truncated: true,
+			want:      0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := completeToolCalls(tt.toolCalls, []api.Tool{editor, shell}, tt.truncated)
+			if len(got) != tt.want {
+				t.Fatalf("kept %d tool calls, want %d", len(got), tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Discussed in #17562, item 2. Found while stress-testing the thinking budget (#17561) in a real coding agent; independent of it.

Found while stress-testing #17561 in a real coding agent; independent of it and of the repetition-guard fix.

## What happens

A response that ends on the token limit can stop in the middle of a tool call's arguments. The fields that did arrive parse cleanly, so the call is handed to the caller looking complete, with a required argument simply absent.

The instance, captured from a Cline session against a Gemma 4 model with `num_predict` 32000:

```
tool:      editor
arguments: insert_line = 48
           new_text    = 62,288 characters   ← 76% base64
           (no path)
```

`editor` declares `required: ["path", "new_text"]`. The agent rejected the call with

> ✖ Invalid input: expected string, received undefined → at path

which names a field the model was still on its way to producing. Nothing in that error says the response was cut short. The reason was in the same response — `done_reason: "length"` — and the agent, like most callers, acted on the tool call and not on the done reason.

The tail of `new_text` shows how the argument got that long, and is worth quoting because it is the shape of the failure rather than an accident of this task:

> *"Let's go. Actually, I'll run the command now. **Wait!** The user said: 'The sprites are all messed up…'"*

The model resumed reasoning **inside the string argument** and kept going until the cap stopped it.

## What this changes

`completeToolCalls` drops a tool call that is missing a required argument, **and only when the generation actually stopped at the limit**. A call missing a required argument in a response that ended normally is the model's own mistake and is passed through unchanged — that is a real signal about the model, not something to hide.

The drop is logged at WARN with the tool and the argument that never arrived:

```
level=WARN msg="dropping a tool call the model did not finish writing" tool=editor missing=path done_reason=length
```

Wired into both chat paths — models with a built-in parser and models going through the generic tool parser — since either can be cut mid-call.

## Why drop it rather than leave it to the caller

`done_reason` already carries the truth, so this is defence in depth, and that is a fair thing to argue about. The case for dropping:

- A tool call is the part of a response callers act on. Handing over half of one asks every client to remember that a tool call is only trustworthy in the presence of a done reason it did not have to check before.
- The failure it produces is actively misleading. A schema error blames the model for omitting an argument it was writing, and points the user at the tool definition instead of at the token cap.
- ollama knows both halves — the schema is in the request, the done reason is in the response — and no client can reconstruct the first one as reliably.

The counter-argument is that a caller may want to see the partial call, for instance to retry with the same intent. Nothing here prevents adding that later as an opt-in; the current default hands over something that cannot be executed.

## Open questions for review

1. **Required arguments only.** A call can be truncated and still carry every required argument — a `new_text` cut in half is undetectable this way. Catching that needs the arguments to be validated against types and, for strings, something the schema does not express. This is the cheap check that covers the common shape, not a complete one.
2. **Tools the request did not declare** have no schema to check and are passed through. That is the conservative direction, but it means a truncated call to an undeclared tool still reaches the caller.
3. **Silence versus a signal.** Dropping the call leaves a response with `done_reason: "length"` and no tool call at all. An alternative is to keep it and add a field marking it incomplete, which is more informative and a larger API change.
4. **Streaming.** The check runs on the final chunk, where the parser flushes. A caller that has already acted on a partially streamed call has acted on it before the drop; whether ollama should ever stream an unterminated call is a separate question.

## How it is tested

`TestCompleteToolCalls` — an unfinished call dropped when the response was cut short, a complete call surviving one, an incomplete call kept when the response ended normally, only the unfinished member of a batch dropped, an unknown tool left alone, and the empty case.

`go build ./...`, `go vet ./...` and the package tests are clean against current `main`. On hosts with glibc below 2.34 `go build ./...` also needs #17567, which fixes a `cmd/runner` cgo link failure present on `main` (`undefined reference to 'dlopen'`); it is a separate one-line fix and this change does not depend on it.

