### PR TITLE
gemma4: recover a finished tool call that is missing its closing brace

### DIFF
--- a/model/parsers/gemma4.go
+++ b/model/parsers/gemma4.go
@@ -315,7 +315,7 @@ func (p *Gemma4Parser) eat(done bool) ([]gemma4Event, bool) {
 			p.buffer.WriteString(remaining)
 			p.state = Gemma4IgnoringPostToolCallNoise
 
-			if toolCall, err := parseGemma4ToolCall(toolCallContent, p.tools); err == nil {
+			if toolCall, err := parseGemma4ClosedToolCall(toolCallContent, p.tools); err == nil {
 				events = append(events, gemma4EventToolCall{toolCall: toolCall})
 			} else {
 				slog.Warn("gemma4 tool call parsing failed", "error", err, "content", toolCallContent)
@@ -390,6 +390,38 @@ func (p *Gemma4Parser) eat(done bool) ([]gemma4Event, bool) {
 
 // parseGemma4ToolCall parses a tool call in Gemma 4 format:
 // call:NAME{key:value,key:value}
+// parseGemma4ClosedToolCall parses a tool call the model finished: its closing
+// tag was emitted, so the call is not truncated and a missing final brace is a
+// formatting slip rather than an argument that never arrived.
+//
+// The general repair path deliberately leaves an unclosed object alone, because
+// closing one that a token limit cut short would turn a partial call into a
+// plausible-looking call with arguments missing. That reasoning does not apply
+// once the model has closed the call itself, and the case is common enough to
+// matter: one missing brace otherwise costs the whole call, which reaches the
+// caller as an empty response with the tool call silently dropped.
+func parseGemma4ClosedToolCall(content string, tools []api.Tool) (api.ToolCall, error) {
+	toolCall, err := parseGemma4ToolCall(content, tools)
+	if err == nil {
+		return toolCall, nil
+	}
+
+	open := strings.Index(content, "{")
+	if open == -1 {
+		return api.ToolCall{}, err
+	}
+
+	closed := content[:open] + repairGemma4MissingObjectClose(content[open:])
+	if closed == content {
+		return api.ToolCall{}, err
+	}
+
+	if toolCall, retryErr := parseGemma4ToolCall(closed, tools); retryErr == nil {
+		return toolCall, nil
+	}
+	return api.ToolCall{}, err
+}
+
 func parseGemma4ToolCall(content string, tools []api.Tool) (api.ToolCall, error) {
 	// Expected format: call:NAME{args}
 	if !strings.HasPrefix(content, "call:") {

--- a/model/parsers/gemma4_test.go
+++ b/model/parsers/gemma4_test.go
@@ -1501,3 +1501,63 @@ func TestParseGemma4ToolCall_RawQuotedStructuralString(t *testing.T) {
 		t.Fatalf("tool call mismatch (-want +got):\n%s", diff)
 	}
 }
+
+func TestGemma4ClosedToolCallMissingObjectClose(t *testing.T) {
+	tools := []api.Tool{gemma4TestStringTool("read_files", "files")}
+
+	tests := []struct {
+		name     string
+		content  string
+		wantName string
+	}{
+		{
+			// captured from a live session: the model emitted the closing tag
+			// but not the brace before it, and the whole call was dropped
+			name:     "a closed call missing only its final brace is recovered",
+			content:  `call:read_files{files:[{path:<|"|>c:\Users\bob\assets.json<|"|>,start_line:1}]`,
+			wantName: "read_files",
+		},
+		{
+			name:     "a well formed call is unaffected",
+			content:  `call:read_files{files:[{path:<|"|>c:\Users\bob\assets.json<|"|>}]}`,
+			wantName: "read_files",
+		},
+		{
+			// a brace is not the only thing wrong here, so nothing is invented
+			name:    "a call broken in other ways still fails",
+			content: `call:read_files{files:[{path:`,
+		},
+		{
+			name:    "content with no arguments at all still fails",
+			content: `call:read_files`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseGemma4ClosedToolCall(tt.content, tools)
+			if tt.wantName == "" {
+				if err == nil {
+					t.Fatalf("parsed %+v, want an error", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Function.Name != tt.wantName {
+				t.Errorf("tool = %q, want %q", got.Function.Name, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestGemma4UnclosedToolCallIsStillLeftAlone(t *testing.T) {
+	// the flush-on-done path has no closing tag, so the call may have been cut
+	// short by a token limit; closing the brace there would turn a truncated
+	// call into a plausible one with arguments missing
+	got := gemma4RepairCandidates(`{n:1`, "count", []api.Tool{gemma4TestStringTool("count", "name")})
+	if len(got) != 1 || got[0] != `{n:1` {
+		t.Fatalf("candidates = %q, want the input unchanged", got)
+	}
+}


### PR DESCRIPTION
Discussed in #17562, item 3. Independent of the other two fixes in that issue.

Found while stress-testing #17561 in a coding agent; independent of it, of the repetition-guard fix and of the truncated-tool-call fix.

## What happens

The model emits a tool call that is complete apart from its final brace. The parser cannot parse it, drops it, and the turn has nothing else in it — so the caller receives a message with no content and no tool calls. A coding agent reports **"Model returned empty response"** and offers a retry. The reason is in the server log, at WARN, where the agent will never look:

```
level=WARN source=gemma4.go:330 msg="gemma4 tool call parsing failed"
error="unexpected end of JSON input
repair failed to produce valid JSON arguments"
content="call:read_files{files:[{path:<|\"|>c:\Users\...\assets.json<|\"|>,start_line:1}]"
```

Captured from a live session. Everything is there — the tool name, the file, the line — except the `}` that closes `{files:[...]`. The turn ended naturally (`deactivated (natural end)`, 12,369 tokens, well inside `num_predict`), and the model emitted the tool-call *closing tag* after that content, so it had finished writing the call. It simply left out one brace.

## Why the existing repair does not fire

`repairGemma4MissingObjectClose` already exists and fixes exactly this. Probed against the captured content:

```
as shipped:        err=unexpected end of JSON input, call dropped
with object close: err=<nil>, call=read_files
```

But `gemma4RepairCandidates` only offers that repair when some *other* repair already changed the string, and `TestGemma4RepairCandidates/does_not_add_missing_object_close_without_another_repair` pins that behaviour deliberately. The reasoning is sound and worth preserving: closing an object that a token limit cut short would turn a truncated call into a plausible-looking call with arguments silently missing — the failure the truncated-tool-call fix exists to prevent.

## What this changes

The discriminator is not whether to close braces, it is **whether the model finished**. The parser collects a tool call until it sees the closing tag; it also has a second path that flushes on `done` when no closing tag ever arrived. Those two are not equally trustworthy:

- **Closing tag seen** — the model finished the call. A missing brace is a formatting slip. `parseGemma4ClosedToolCall` retries once with the object close applied.
- **Flushed on done, no closing tag** — the call may have been cut off. Unchanged, along with its test.

So the recovery is confined to the path where truncation is ruled out by the model's own closing tag, and the conservative default stays exactly where it was.

## Open questions for review

1. **One retry, one repair.** The retry applies only the object close, on top of a parse that already failed with every existing candidate. It does not attempt to balance brackets in general, which would start inventing structure.
2. **Is the closing tag proof enough?** It is emitted by the model, so a model that emits it in the wrong place would defeat the reasoning. Against that: this is the same signal the parser already trusts to decide the call is over.
3. **The `done` flush path is left broken for this case.** A model that forgets the brace *and* runs out of tokens before the closing tag still loses the call. That seems right — there is no way to tell that case from a genuine truncation — but it means the fix is not complete by construction.
4. **Silence is the real problem underneath.** Even with this, a call that fails to parse for any other reason is dropped and the caller sees an empty response with no explanation. Whether a parse failure should surface as an error, or as the raw text in `content`, is a bigger question this PR does not answer.

## How it is tested

`TestGemma4ClosedToolCallMissingObjectClose` — the captured content recovered, a well-formed call unaffected, a call broken in other ways still failing, content with no arguments still failing.

`TestGemma4UnclosedToolCallIsStillLeftAlone` — pins that the flush-on-done path did not change.

`go build ./...`, `go vet ./...` and the package tests are clean against current `main`. On hosts with glibc below 2.34 `go build ./...` also needs #17567, which fixes a `cmd/runner` cgo link failure present on `main` (`undefined reference to 'dlopen'`); it is a separate one-line fix and this change does not depend on it.

