### PR TITLE
x/mlxrunner/mlx: link against libdl on linux

### DIFF
--- a/x/mlxrunner/mlx/mlx.go
+++ b/x/mlxrunner/mlx/mlx.go
@@ -5,6 +5,10 @@ package mlx
 // #cgo CXXFLAGS: -std=c++17
 // #cgo CPPFLAGS: -I${SRCDIR}/include
 // #cgo LDFLAGS: -lstdc++
+// // dynamic.c calls dlopen/dlsym/dlclose, which only moved into libc in glibc
+// // 2.34. Older distributions keep them in libdl, where the linker will not
+// // find them unless it is asked to.
+// #cgo linux LDFLAGS: -ldl
 // #cgo darwin LDFLAGS: -framework Foundation -framework Metal -framework Accelerate
 // #include "generated.h"
 // #include <string.h>


### PR DESCRIPTION
`go build ./...` fails to link on Linux with glibc older than 2.34.

On Debian 11 (glibc 2.31):

```
# github.com/ollama/ollama/cmd/runner
/usr/bin/ld: x/mlxrunner/mlx/generated.c:2396: undefined reference to `dlsym'
/usr/bin/ld: ...: undefined reference to `dlopen'
/usr/bin/ld: ...: undefined reference to `dlclose'
collect2: error: ld returned 1 exit status
```

`x/mlxrunner/mlx/dynamic.c` calls `dlopen`/`dlsym`/`dlclose`. Those symbols only moved into libc in **glibc 2.34**; before that they live in `libdl`, and the linker will not find them unless it is asked to. The package builds on newer distributions purely because the split no longer exists there.

This matters beyond a developer's laptop: the officially supported floor for the Linux binary is glibc 2.28, which covers RHEL 8, Ubuntu 20.04 and Debian 11 — every one of them below 2.34.

## The fix

One `#cgo` directive, Linux only:

```go
// #cgo linux LDFLAGS: -ldl
```

`-ldl` is harmless on glibc 2.34 and later, where `libdl` remains as an empty compatibility stub, so this does not need a version guard.

Verified on Debian 11 / glibc 2.31: `go build ./...` fails on `main` and is clean with this applied. No change on darwin, which links `dl` via libSystem.
