### PR TITLE
fix(gemma4): trim channel-boundary whitespace independent of chunk boundaries

### DIFF
--- a/model/parsers/gemma4.go
+++ b/model/parsers/gemma4.go
@@ -40,6 +40,7 @@ type Gemma4Parser struct {
 	hasThinkingSupport    bool
 	thinkingEnabled       bool // true when both model supports and user requested thinking
 	needsChannelNameStrip bool // true when we just entered thinking and need to strip "thought\n"
+	needsContentTrim      bool // true when we just left thinking and need to strip leading whitespace
 }
 
 func (p *Gemma4Parser) HasToolSupport() bool {
@@ -177,6 +178,19 @@ func (p *Gemma4Parser) eat(done bool) ([]gemma4Event, bool) {
 
 	switch p.state {
 	case Gemma4CollectingContent:
+		// Whitespace between <channel|> and the answer is dropped, even when it
+		// arrives in a later chunk than the closing tag itself.
+		if p.needsContentTrim {
+			trimmed := strings.TrimLeftFunc(bufStr, unicode.IsSpace)
+			p.buffer.Reset()
+			p.buffer.WriteString(trimmed)
+			if trimmed == "" {
+				return events, false
+			}
+			bufStr = trimmed
+			p.needsContentTrim = false
+		}
+
 		// Check for thinking open tag
 		if idx := strings.Index(bufStr, gemma4ThinkingOpenTag); idx != -1 {
 			contentBefore := bufStr[:idx]
@@ -226,7 +240,22 @@ func (p *Gemma4Parser) eat(done bool) ([]gemma4Event, bool) {
 			}
 		}
 
-		// No tags found, emit all content
+		// No tags found, emit content (hold back trailing whitespace, which is
+		// dropped if an opening tag turns out to follow it)
+		if !done {
+			whitespaceLen := trailingWhitespaceLen(bufStr)
+			ambiguousStart := len(bufStr) - whitespaceLen
+
+			unambiguous := bufStr[:ambiguousStart]
+			ambiguous := bufStr[ambiguousStart:]
+			p.buffer.Reset()
+			p.buffer.WriteString(ambiguous)
+			if len(unambiguous) > 0 {
+				events = append(events, gemma4EventContent{content: unambiguous})
+			}
+			return events, false
+		}
+
 		p.buffer.Reset()
 		if len(bufStr) > 0 {
 			events = append(events, gemma4EventContent{content: bufStr})
@@ -260,6 +289,7 @@ func (p *Gemma4Parser) eat(done bool) ([]gemma4Event, bool) {
 			p.buffer.Reset()
 			p.buffer.WriteString(remaining)
 			p.state = Gemma4CollectingContent
+			p.needsContentTrim = true
 
 			if len(thinking) > 0 {
 				events = append(events, gemma4EventThinkingContent{content: thinking})

--- a/model/parsers/gemma4_test.go
+++ b/model/parsers/gemma4_test.go
@@ -784,6 +784,82 @@ func TestGemma4Parser_StreamingSplitThinkingTag(t *testing.T) {
 	}
 }
 
+// Whitespace around <|channel>/<channel|> must be dropped regardless of where
+// the chunk boundaries fall. Leaking it into the answer changes how the client
+// renders the markdown that follows, e.g. indenting the first line turns it
+// into a code block.
+func TestGemma4Parser_StreamingChannelBoundaryWhitespace(t *testing.T) {
+	tests := []struct {
+		name             string
+		chunks           []string
+		expectedContent  string
+		expectedThinking string
+	}{
+		{
+			name: "newlines_after_close_tag_in_later_chunk",
+			chunks: []string{
+				"<|channel>thought\nreason\n<channel|>",
+				"\n\n",
+				"**bold** -> arrow",
+			},
+			expectedContent:  "**bold** -> arrow",
+			expectedThinking: "reason",
+		},
+		{
+			name: "indentation_after_close_tag_in_later_chunk",
+			chunks: []string{
+				"<|channel>thought\nreason<channel|>",
+				"\t",
+				"answer",
+			},
+			expectedContent:  "answer",
+			expectedThinking: "reason",
+		},
+		{
+			name: "whitespace_before_open_tag_in_earlier_chunk",
+			chunks: []string{
+				"answer\n\n",
+				"<|channel>thought\nmore reasoning<channel|>",
+				"rest",
+			},
+			expectedContent:  "answerrest",
+			expectedThinking: "more reasoning",
+		},
+		{
+			name:   "one_byte_at_a_time",
+			chunks: strings.Split("<|channel>thought\nreason\n<channel|>\n\nanswer", ""),
+
+			expectedContent:  "answer",
+			expectedThinking: "reason",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := &Gemma4Parser{hasThinkingSupport: true}
+			parser.Init(nil, nil, &api.ThinkValue{Value: true})
+
+			var finalContent, finalThinking strings.Builder
+			for i, chunk := range tt.chunks {
+				done := i == len(tt.chunks)-1
+				content, thinking, _, err := parser.Add(chunk, done)
+				if err != nil {
+					t.Fatalf("Add() error on chunk %d: %v", i, err)
+				}
+				finalContent.WriteString(content)
+				finalThinking.WriteString(thinking)
+			}
+
+			if diff := cmp.Diff(tt.expectedContent, finalContent.String()); diff != "" {
+				t.Errorf("content mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tt.expectedThinking, finalThinking.String()); diff != "" {
+				t.Errorf("thinking mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestGemma4ArgsToJSON(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
# Issue #17518 — Gemma4:26b: "->" is not translated, and thinking is sometimes not aborted

## 1. Root cause

The issue reports two symptoms for `gemma4:26b`:

1. *"The markup for `->` is often not translated, so it stays markup."*
2. *"Sometimes the answer is only 'Thought for X seconds' without any output and when
   you look into 'Thinking' you see that the answer is not separated and collapsed."*

Symptom 1 is a real, reproducible defect in `model/parsers/gemma4.go`.

Gemma 4 wraps its reasoning in `<|channel>thought\n … <channel|>`. `Gemma4Parser`
trims the whitespace around those boundaries, but only when the whitespace happens
to sit in the *same* streamed chunk as the tag:

* On the closing side, the parser does
  `remaining := strings.TrimLeftFunc(split[1], unicode.IsSpace)` once, when it finds
  `<channel|>`. If the tag ends the chunk (`split[1] == ""`), there is nothing left
  to trim, and the whitespace that arrives in the *next* chunk is emitted verbatim
  as the first bytes of `content`. Unlike `thinking/parser.go`, which has a
  dedicated `thinkingState_ThinkingDoneEatingWhitespace` state for exactly this, the
  Gemma 4 parser had no equivalent.
* On the opening side, the same asymmetry existed in reverse: the thinking branch
  holds back trailing whitespace while waiting for a possible `<channel|>`
  (`gemma4.go`, "hold back trailing whitespace"), but the content branch emitted it
  immediately, so whitespace preceding a `<|channel>` in a later chunk leaked into
  `content`.

During real generation the tags are single special tokens, so the boundary almost
always *is* a chunk boundary — which means streamed responses systematically began
with the model's raw separator (typically `"\n\n"`, sometimes a tab or spaces),
while the same response parsed in one piece was trimmed. A response body that
starts with an indent is exactly the input that makes a Markdown renderer treat the
first block as an indented code block, so the answer is shown as raw source and its
markup (`**bold**`, `->`, …) is never converted — the reported "stays markup".

Verified before the change with a chunking-differential harness (same input, many
chunkings, compared against the single-chunk parse):

```
input "<|channel>thought\nreason<channel|>   \tanswer"
 got content="\tanswer"  want content="answer"
input "<|channel>thought\nreason\n<channel|>\n\nHere is the **answer** -> yes"
 got content="\n\nHere is the **answer** -> yes"  want content="Here is the ..."
input "  \n<|channel>thought\nx<channel|>y"
 got content="  y"  want content="y"
```

Symptom 2 (**not fixed** — see §4) is a different failure: `content` is empty and
the whole answer is inside `thinking`. That happens when the model ends its turn
while still inside the thought channel, i.e. it emits the `<turn|>` stop string (or
hits `num_predict`/the context limit) without ever emitting `<channel|>`. The
parser then flushes its buffer as thinking on `done`, so the client shows only
"Thought for N seconds". I could not find a code path where a `<channel|>` that
*is* present gets missed: exhaustive single-split, byte-by-byte and randomized
chunking over the tag all detect it correctly.

## 2. The fix and why

`model/parsers/gemma4.go` — make whitespace trimming at channel boundaries
independent of where the chunk boundaries fall:

* New `needsContentTrim` field, set when `<channel|>` moves the parser into
  `Gemma4CollectingContent`. While it is set, `Gemma4CollectingContent` strips
  leading whitespace from the buffer and keeps waiting if only whitespace has
  arrived so far. This mirrors the existing `needsChannelNameStrip` flag used for
  the `"thought\n"` channel name on the opening side, so the style matches the file.
* The "no tags found" branch of `Gemma4CollectingContent` now holds back trailing
  whitespace when `!done`, exactly like the equivalent branch in
  `Gemma4CollectingThinking`. The held-back whitespace is emitted with the next
  chunk, or dropped if a `<|channel>` turns out to follow it.

Net effect: the parse result no longer depends on chunking, and streamed answers
start at the first real character, as non-streamed ones already did.

I deliberately did not add a "flush unterminated thinking as content" recovery for
symptom 2 (the analogue of the existing tool-call recovery a few lines below).
Thinking is streamed to the client incrementally, so by the time `done` arrives
almost all of it has already been delivered as `thinking` deltas; converting only
the final buffer to `content` would make streaming and non-streaming disagree
without giving the user their answer back. Fixing that properly means buffering the
entire thought channel, which is a much larger behavioural change than this issue
justifies.

## 3. Files changed

* `model/parsers/gemma4.go` — the fix (one new field, two branches in `eat`).
* `model/parsers/gemma4_test.go` — new `TestGemma4Parser_StreamingChannelBoundaryWhitespace`
  covering newlines after the close tag in a later chunk, a tab after the close tag
  (the Markdown-breaking case), whitespace before an open tag in an earlier chunk,
  and one-byte-at-a-time streaming.
* `NOTES.md` — this file.

## 4. Risk / uncertainty

* **Symptom 2 is not addressed.** The report has no logs, no OS/version and no raw
  model output, and I cannot reproduce it from the parser: every `<channel|>` that
  reaches the parser is detected under all chunkings I tried. The most likely
  explanations are (a) the model ending its turn inside the thought channel and
  (b) generation being truncated mid-thought by `num_predict`/context. Both need
  the reporter's raw output (`/api/chat` with `"stream": false`, or the server log)
  to confirm. If the fix here does not make symptom 1 go away either, that would
  point at the desktop app's Markdown renderer rather than the server.
* Content now lags by any trailing whitespace until the next chunk arrives (or
  until `done`). No text is lost or reordered, and `Gemma4CollectingThinking`
  already behaved this way, but it is a small change to streaming granularity —
  a client that echoes deltas character-by-character will see whitespace grouped
  with the following word instead of the preceding one.
* Whitespace that the model intentionally puts immediately after `<channel|>` is
  now always dropped. That matched the existing single-chunk behaviour and the
  upstream Jinja template's `strip_thinking` (`| trim`), so it is not a new policy.
* While tracing this I found a smaller, separate mismatch that I left alone as
  out of scope: `Gemma4Parser.Init` starts in `Gemma4CollectingThinking` whenever
  the last message has role `tool`, but `Gemma4Renderer` only pre-opens
  `<|channel>thought\n` when the preceding assistant message actually carried
  `tool_calls`. A malformed conversation (a `tool` message with no matching
  assistant tool call) therefore starts the parser in the thinking state against a
  prompt that never opened the channel, which puts the whole answer into
  `thinking` — the same visible symptom as #2, but from a different cause.

## 5. How I verified it

Go 1.26.5, from the repo root:

* `go build ./...` — clean.
* `go test ./model/parsers/` — passes, including the existing Gemma 4 streaming and
  tool-call tests.
* `go test ./model/... ./server/...` — `model/parsers`, `model/renderers` and
  `server` all pass.
* `go vet ./model/parsers/` and `gofmt -l model/parsers/` — clean.
* New test fails on the unpatched parser and passes after the change.
* A temporary differential harness (not committed) parsed each sample response
  under every single-split point, byte-by-byte, and 500 random chunkings, asserting
  the result equals the single-chunk parse. It reported the three divergences quoted
  in §1 before the fix and reports none after it.

Not verified: end-to-end against a real `gemma4:26b`. No GPU/model weights are
available in this environment, so the evidence is parser-level only.
