### PR TITLE
mlxrunner: add DFlash block-diffusion speculative decoding

### DIFF
--- a/x/mlxrunner/batch/batch.go
+++ b/x/mlxrunner/batch/batch.go
@@ -17,8 +17,8 @@ type Batch struct {
 	// Length equals the batch dimension of InputIDs.
 	SeqQueryLens []int32
 
-	// Hidden is the target hidden state a draft model fuses with its input
-	// embedding for this step. It is nil for ordinary forward passes.
+	// Hidden is the draft-conditioning state for a draft model's forward.
+	// It is nil for ordinary forward passes.
 	Hidden *mlx.Array
 
 	// Memo is per-forward memoization used to cache results, such as masks,

--- a/x/mlxrunner/dflash.go
+++ b/x/mlxrunner/dflash.go
@@ -1,0 +1,180 @@
+package mlxrunner
+
+import (
+	"fmt"
+
+	"github.com/ollama/ollama/x/mlxrunner/batch"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/mlxrunner/model/base"
+)
+
+// dflashPendingFlushTokens bounds the pinned feature rows between flushes.
+const dflashPendingFlushTokens = 256
+
+// dflashDrafter drafts with a block-diffusion draft model (DFlash): one
+// forward proposes a whole block. A context-cache entry depends only on its
+// own position, so the trie keys need no look-ahead.
+type dflashDrafter struct {
+	spec      *speculation
+	blockSize int
+	maskToken int32
+}
+
+func newDFlashDrafter(s *speculation, draft base.BlockDraft) *dflashDrafter {
+	blockSize, maskToken := draft.BlockParams()
+	return &dflashDrafter{spec: s, blockSize: blockSize, maskToken: maskToken}
+}
+
+func (d *dflashDrafter) draftLimit() int { return d.blockSize - 1 }
+
+// open returns a session synced to the draft caches' restored offset.
+func (d *dflashDrafter) open() draftSession {
+	s := &dflashDraftSession{drafter: d}
+	if kv := d.spec.draftKV; len(kv) > 0 {
+		s.ctxOffset = kv[0].Offset()
+	}
+	return s
+}
+
+// dflashDraftSession runs one request's drafting. A context entry at slot S
+// derives only from the features at S; ctxOffset+pendingCount is the slot
+// after the last reported token.
+type dflashDraftSession struct {
+	drafter *dflashDrafter
+
+	// ctxOffset is the slot after the last feature row written; pendingCount
+	// rows are buffered past it.
+	ctxOffset       int
+	pendingFeatures []*mlx.Array
+	pendingCount    int
+
+	// blockOutstanding tracks the proposal's scheduled rollback point, which
+	// commitBlock has to drain even when it needs no rewind.
+	blockOutstanding bool
+}
+
+func (d *dflashDraftSession) committed(tokens, features *mlx.Array, position int) {
+	n := tokens.Dim(1)
+	// Skip leading rows the session already has (a restored prefix). A run
+	// that starts past the frontier would leave a gap, which is a bug.
+	start := d.ctxOffset + d.pendingCount - position
+	if start < 0 {
+		panic(fmt.Sprintf("dflash: committed run at %d leaves a context gap at %d", position, d.ctxOffset+d.pendingCount))
+	}
+	if start < n {
+		f := features.Slice(mlx.Slice(), mlx.Slice(start, n), mlx.Slice())
+		mlx.Pin(f)
+		d.pendingFeatures = append(d.pendingFeatures, f)
+		d.pendingCount += n - start
+		if d.pendingCount >= dflashPendingFlushTokens {
+			d.flush()
+		}
+	}
+}
+
+// settle writes buffered rows through, leveling the draft caches with the
+// target's; next is unused.
+func (d *dflashDraftSession) settle(_ *mlx.Array) {
+	d.flush()
+}
+
+func (d *dflashDraftSession) close() {
+	d.flush()
+}
+
+// takePending returns the buffered rows, advancing ctxOffset past them.
+func (d *dflashDraftSession) takePending() *mlx.Array {
+	if len(d.pendingFeatures) == 0 {
+		return nil
+	}
+	features := mlx.Concatenate(d.pendingFeatures, 1)
+	mlx.Unpin(d.pendingFeatures...)
+	d.pendingFeatures = nil
+	d.ctxOffset += d.pendingCount
+	d.pendingCount = 0
+	return features
+}
+
+// commitBlock rewinds the round's block out of the draft caches; the caches
+// keep only context rows, and accepted tokens arrive as context later. Every
+// write path must run this first, otherwise the new rows land after the block
+// and the cache contents no longer match their positions.
+func (d *dflashDraftSession) commitBlock() {
+	if !d.blockOutstanding {
+		return
+	}
+	commitSpeculation(d.drafter.spec.draftKV, 0, 1, d.ctxOffset)
+	d.blockOutstanding = false
+}
+
+// flush rewinds the round's block, then writes the pending rows in one
+// context-only forward. The block is rewound even when nothing is pending.
+func (d *dflashDraftSession) flush() {
+	spec := d.drafter.spec
+	d.commitBlock()
+
+	offset := d.ctxOffset
+	features := d.takePending()
+	if features == nil {
+		return
+	}
+	spec.draft.Forward(&batch.Batch{
+		SeqOffsets: []int32{int32(offset)},
+		Hidden:     features,
+	}, spec.targets, spec.draftKV)
+
+	// Force the cache writes: a session that never drafts would otherwise
+	// leave the flush chain unevaluated, pinning every feature until close.
+	state := make([]*mlx.Array, 0, 2*len(spec.draftKV))
+	for _, c := range spec.draftKV {
+		state = append(state, c.State()...)
+	}
+	mlx.AsyncEval(state...)
+}
+
+// propose drafts a block after the not-yet-validated current token, one
+// forward filling every mask position.
+func (d *dflashDraftSession) propose(current *mlx.Array, maxTokens int) *draftCandidates {
+	spec := d.drafter.spec
+	r := spec.r
+	blockSize := d.drafter.blockSize
+
+	n := min(maxTokens, blockSize-1)
+	if n <= 0 || d.ctxOffset+d.pendingCount == 0 {
+		return nil
+	}
+	d.commitBlock()
+
+	// Send only the anchor and the rows being sampled, not the full trained
+	// block. Exact for causal layers, and measured as free for bidirectional
+	// ones.
+	masks := make([]int32, n)
+	for i := range masks {
+		masks[i] = d.drafter.maskToken
+	}
+	block := current.ExpandDims(-1).Concatenate(1, mlx.FromValues(masks, 1, len(masks)))
+
+	offset := d.ctxOffset
+	features := d.takePending()
+
+	scheduleSpeculation(spec.draftKV, d.ctxOffset, 1)
+	d.blockOutstanding = true
+
+	hidden, _ := spec.draft.Forward(&batch.Batch{
+		InputIDs:     block,
+		SeqOffsets:   []int32{int32(offset)},
+		SeqQueryLens: []int32{int32(n + 1)},
+		Hidden:       features,
+	}, spec.targets, spec.draftKV)
+
+	// Row i predicts the token at its own position, so the anchor row is
+	// unused. Rows 1..n are sampled from one batched distribution; penalties
+	// see only the committed history, not the other rows of the block.
+	logits := spec.draft.Unembed(hidden.Slice(mlx.Slice(), mlx.Slice(1, n+1), mlx.Slice()))
+	dist := r.Sampler.Distribution(pipelineSlot, logits, nil)
+	tokens := r.Sampler.SampleDistribution(pipelineSlot, dist)
+	return &draftCandidates{
+		tokens: tokens.ExpandDims(0),
+		dist:   dist,
+	}
+}

--- a/x/mlxrunner/dflash_test.go
+++ b/x/mlxrunner/dflash_test.go
@@ -1,0 +1,347 @@
+package mlxrunner
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/x/mlxrunner/batch"
+	"github.com/ollama/ollama/x/mlxrunner/cache"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/mlxrunner/model/base"
+	sampler "github.com/ollama/ollama/x/mlxrunner/sample"
+)
+
+// fakeBlockDraft is a block-diffusion draft: one Draft call ingests context
+// feature rows and fills a block's mask positions in parallel. It feeds the
+// context rows' hot indices and then the block's token ids to its cache
+// (advancing the offset like the real model's single write), records each
+// call, and scripts block row i as the i-th successor of the anchor under
+// predict.
+type fakeBlockDraft struct {
+	predict     map[int32]int32
+	blockSize   int
+	maskToken   int32
+	draftCaches []cache.Cache
+	calls       []blockCall
+}
+
+// blockCall is one recorded Draft call: the absolute slot of the first
+// context row, the hot index of each context feature row (nil for a
+// block-only call), and the block's token ids (nil for a context-only call).
+type blockCall struct {
+	offset int32
+	ctx    []int32
+	block  []int32
+}
+
+func (d *fakeBlockDraft) LoadWeights(map[string]*mlx.Array) error { return nil }
+
+func (d *fakeBlockDraft) NewCaches() []cache.Cache { return d.draftCaches }
+
+func (d *fakeBlockDraft) BlockParams() (int, int32) { return d.blockSize, d.maskToken }
+
+func (d *fakeBlockDraft) Forward(b *batch.Batch, _, draftCaches []cache.Cache) (hidden, auxHidden *mlx.Array) {
+	call := blockCall{offset: b.SeqOffsets[0]}
+
+	if b.Hidden != nil {
+		mlx.Eval(b.Hidden)
+		call.ctx = make([]int32, b.Hidden.Dim(1))
+		flat := b.Hidden.Floats()
+		for r := range call.ctx {
+			call.ctx[r] = -1
+			for v := range mtpTestVocab {
+				if flat[r*mtpTestVocab+v] != 0 {
+					call.ctx[r] = int32(v)
+					break
+				}
+			}
+		}
+	}
+	if b.InputIDs != nil {
+		mlx.Eval(b.InputIDs)
+		ids := b.InputIDs.Ints()
+		call.block = make([]int32, len(ids))
+		for i, id := range ids {
+			call.block[i] = int32(id)
+		}
+	}
+	d.calls = append(d.calls, call)
+
+	if rc, ok := draftCaches[0].(*fakeRewindableCache); ok {
+		rc.feed(call.ctx)
+		rc.feed(call.block)
+	}
+
+	if call.block == nil {
+		return nil, nil
+	}
+	// Row i predicts the token at its own position: the anchor row restates
+	// the anchor, mask row i the i-th successor of the anchor.
+	preds := make([]int32, len(call.block))
+	preds[0] = call.block[0]
+	for i := 1; i < len(preds); i++ {
+		preds[i] = d.predict[preds[i-1]]
+	}
+	h := oneHotLogits(preds)
+	return h, h
+}
+
+// Unembed is the identity: the fake's hidden already is its one-hot logits.
+func (d *fakeBlockDraft) Unembed(x *mlx.Array) *mlx.Array { return x }
+
+var _ base.BlockDraft = (*fakeBlockDraft)(nil)
+
+// newBlockTestSession wires a runner around a fakeBlockDraft and opens one
+// request's drafting session, returning the concrete session for
+// internal-state assertions.
+func newBlockTestSession(t *testing.T, predict map[int32]int32, blockSize int) (*Runner, *fakeBlockDraft, *dflashDraftSession, []cache.Cache) {
+	t.Helper()
+	r := mtpTestRunner(t, predict, []int32{7}, sampler.Options{})
+	caches, _ := newMTPTestCaches(2) // caches[0] target, caches[1] draft context
+	draft := &fakeBlockDraft{predict: predict, blockSize: blockSize, maskToken: 6, draftCaches: caches[1:]}
+	r.cache.caches = caches
+	r.spec = newSpeculation(r, draft, caches[:1], caches[1:])
+	return r, draft, r.spec.drafter.open().(*dflashDraftSession), caches
+}
+
+// draftTokensOf reads the draft cache's fed token stream.
+func draftTokensOf(caches []cache.Cache) []int32 {
+	return caches[1].(*fakeRewindableCache).tokens
+}
+
+func TestDFlashCommittedBuffersPastFlushCap(t *testing.T) {
+	skipIfNoMLX(t)
+	_, draft, session, caches := newBlockTestSession(t, nil, 4)
+
+	// One prefill-sized run at the flush cap writes through immediately in a
+	// single context-only Draft call.
+	n := dflashPendingFlushTokens
+	ids := make([]int32, n)
+	for i := range ids {
+		ids[i] = int32(i % mtpTestVocab)
+	}
+	session.committed(mlx.FromValues(ids, 1, n), oneHotLogits(ids), 0)
+	if got := len(draft.calls); got != 1 {
+		t.Fatalf("draft calls after cap-sized run = %d, want 1", got)
+	}
+	if got := caches[1].Offset(); got != n {
+		t.Fatalf("draft cache offset = %d, want %d", got, n)
+	}
+
+	// A run below the cap only buffers; settle writes it through, skipping
+	// the leading rows the flush already covered.
+	tail := []int32{1, 2, 3}
+	session.committed(mlx.FromValues(tail, 1, 3), oneHotLogits(tail), n-1)
+	if got := len(draft.calls); got != 1 {
+		t.Fatalf("draft calls after buffered run = %d, want 1 (buffered)", got)
+	}
+	session.settle(nil)
+	want := blockCall{offset: int32(n), ctx: []int32{2, 3}}
+	if got := draft.calls[1]; got.offset != want.offset || !slices.Equal(got.ctx, want.ctx) || got.block != nil {
+		t.Fatalf("settle flush = %+v, want %+v", got, want)
+	}
+	if got := caches[1].Offset(); got != n+2 {
+		t.Fatalf("draft cache offset = %d, want %d (level with reports)", got, n+2)
+	}
+}
+
+func TestDFlashCommittedGapPanics(t *testing.T) {
+	skipIfNoMLX(t)
+	_, _, session, _ := newBlockTestSession(t, nil, 4)
+
+	session.committed(mlx.FromValues([]int32{1}, 1, 1), oneHotLogits([]int32{1}), 0)
+	defer func() {
+		if recover() == nil {
+			t.Fatalf("committed run past the frontier did not panic")
+		}
+	}()
+	// The frontier is at slot 1; a run starting at 3 leaves slot 1..2 unfed.
+	session.committed(mlx.FromValues([]int32{4}, 1, 1), oneHotLogits([]int32{4}), 3)
+}
+
+func TestDFlashRestoredPrefixResumes(t *testing.T) {
+	skipIfNoMLX(t)
+	r := mtpTestRunner(t, nil, []int32{7}, sampler.Options{})
+	caches, _ := newMTPTestCaches(2)
+	draft := &fakeBlockDraft{blockSize: 4, maskToken: 6, draftCaches: caches[1:]}
+	r.cache.caches = caches
+	r.spec = newSpeculation(r, draft, caches[:1], caches[1:])
+
+	// A restored prefix arrives with the draft caches already written.
+	restored := []int32{1, 2, 3, 4, 5}
+	caches[1].(*fakeRewindableCache).feed(restored)
+	session := r.spec.drafter.open().(*dflashDraftSession)
+	if session.ctxOffset != len(restored) {
+		t.Fatalf("ctxOffset = %d, want %d (synced to restored offset)", session.ctxOffset, len(restored))
+	}
+
+	// The resumed prefill's run overlaps the restore point; only the rows
+	// past the frontier are buffered and written.
+	run := []int32{2, 3, 0, 1}
+	session.committed(mlx.FromValues(run, 1, 4), oneHotLogits(run), 3)
+	session.settle(nil)
+	want := blockCall{offset: 5, ctx: []int32{0, 1}}
+	if got := draft.calls[0]; got.offset != want.offset || !slices.Equal(got.ctx, want.ctx) || got.block != nil {
+		t.Fatalf("resume flush = %+v, want %+v", got, want)
+	}
+	if got, wantTok := draftTokensOf(caches), append(restored, 0, 1); !slices.Equal(got, wantTok) {
+		t.Fatalf("draft cache = %v, want %v", got, wantTok)
+	}
+}
+
+func TestDFlashProposeBounds(t *testing.T) {
+	skipIfNoMLX(t)
+	predict := map[int32]int32{1: 2, 2: 3, 3: 4, 4: 5}
+	_, draft, session, _ := newBlockTestSession(t, predict, 4)
+	current := mlx.FromValues([]int32{1}, 1)
+
+	// Nothing committed yet: no context to draft from.
+	if session.propose(current, 4) != nil {
+		t.Fatalf("propose with no context did not decline")
+	}
+	session.committed(mlx.FromValues([]int32{1}, 1, 1), oneHotLogits([]int32{1}), 0)
+	if session.propose(current, 0) != nil {
+		t.Fatalf("propose with no budget did not decline")
+	}
+
+	// The block caps the draft at blockSize-1 mask rows regardless of budget.
+	cand := session.propose(current, 10)
+	if cand == nil {
+		t.Fatalf("propose declined with context and budget")
+	}
+	mlx.Eval(cand.tokens)
+	if got := cand.tokens.Ints(); !slices.Equal(got, []int{2, 3, 4}) {
+		t.Fatalf("draft tokens = %v, want [2 3 4]", got)
+	}
+	if got, want := draft.calls[0].block, []int32{1, 6, 6, 6}; !slices.Equal(got, want) {
+		t.Fatalf("block = %v, want %v (anchor plus blockSize-1 masks)", got, want)
+	}
+}
+
+func TestDFlashBlockRewoundBeforeContextWrites(t *testing.T) {
+	skipIfNoMLX(t)
+	predict := map[int32]int32{2: 3, 3: 4, 4: 5}
+	_, draft, session, caches := newBlockTestSession(t, predict, 4)
+
+	session.committed(mlx.FromValues([]int32{1}, 1, 1), oneHotLogits([]int32{1}), 0)
+	if session.propose(mlx.FromValues([]int32{2}, 1), 3) == nil {
+		t.Fatalf("propose declined")
+	}
+	// The proposal's block sits in the caches until the next write.
+	if got, want := draftTokensOf(caches), []int32{1, 2, 6, 6, 6}; !slices.Equal(got, want) {
+		t.Fatalf("draft cache after propose = %v, want %v", got, want)
+	}
+
+	// The next round's report rewinds the block before appending context, so
+	// the accepted tokens' rows land at their true slots.
+	run := []int32{2, 3, 4}
+	session.committed(mlx.FromValues(run, 1, 3), oneHotLogits(run), 1)
+	session.settle(nil)
+	if got, want := draftTokensOf(caches), []int32{1, 2, 3, 4}; !slices.Equal(got, want) {
+		t.Fatalf("draft cache after settle = %v, want %v (block rewound)", got, want)
+	}
+	if got := caches[1].Offset(); got != 4 {
+		t.Fatalf("draft cache offset = %d, want 4 (level with reports)", got)
+	}
+	want := blockCall{offset: 1, ctx: []int32{2, 3, 4}}
+	if got := draft.calls[1]; got.offset != want.offset || !slices.Equal(got.ctx, want.ctx) || got.block != nil {
+		t.Fatalf("context flush = %+v, want %+v", got, want)
+	}
+}
+
+func TestDFlashCloseDrainsOutstandingBlock(t *testing.T) {
+	skipIfNoMLX(t)
+	predict := map[int32]int32{2: 3, 3: 4, 4: 5}
+	_, _, session, caches := newBlockTestSession(t, predict, 4)
+
+	session.committed(mlx.FromValues([]int32{1}, 1, 1), oneHotLogits([]int32{1}), 0)
+	if session.propose(mlx.FromValues([]int32{2}, 1), 3) == nil {
+		t.Fatalf("propose declined")
+	}
+	// A session that ends with a proposal in flight still leaves the caches
+	// level: close rewinds the block even with nothing pending to flush.
+	session.close()
+	if got, want := draftTokensOf(caches), []int32{1}; !slices.Equal(got, want) {
+		t.Fatalf("draft cache after close = %v, want %v", got, want)
+	}
+}
+
+func TestDecodeBlockDraft(t *testing.T) {
+	skipIfNoMLX(t)
+	// The block draft mirrors the target chain, so one proposal round accepts
+	// every draft and the bonus token is the EOS.
+	const eos int32 = 7
+	predict := map[int32]int32{1: 2, 2: 3, 3: 4, 4: 5, 5: eos, eos: 0}
+	r := mtpTestRunner(t, predict, []int32{eos}, sampler.Options{})
+	caches, _ := newMTPTestCaches(2)
+	draft := &fakeBlockDraft{predict: predict, blockSize: 3, maskToken: 6, draftCaches: caches[1:]}
+	r.cache.caches = caches
+	r.spec = newSpeculation(r, draft, caches[:1], caches[1:])
+	session, ch := newMTPTestSession(caches)
+
+	req := Request{
+		Responses:         ch,
+		Tokens:            []int32{1},
+		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
+		SamplerOpts:       sampler.Options{},
+	}
+	spec := r.spec.open(req)
+	if spec == nil || !spec.enabled {
+		t.Fatalf("open rejected a block-draft request")
+	}
+	pinDraftLimit(spec, 4)
+	d := spec.decoder(mlx.FromValues([]int32{1}, 1), 0)
+	if err := r.decode(context.Background(), req, session, d, 0); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	d.close()
+	spec.close()
+
+	content, final := collectResponses(ch)
+	if content != "2345" {
+		t.Fatalf("content = %q, want %q", content, "2345")
+	}
+	if !final.Done || final.DoneReason != 0 {
+		t.Fatalf("final = %+v, want Done with EOS reason", final)
+	}
+	if want := []int32{2, 3, 4, 5, eos}; !slices.Equal(session.outputs, want) {
+		t.Fatalf("session outputs = %v, want %v", session.outputs, want)
+	}
+
+	// The unprimed drafter parks the first call, so two tokens decode as
+	// pipelined plain forwards; the resumed round then validates the current
+	// token and blockSize-1 drafts in one fused forward.
+	wantForwards := []forwardCall{{offset: 0, n: 1}, {offset: 1, n: 1}, {offset: 2, n: 3}}
+	model := r.Model.(*fakeMTPModel)
+	if !slices.Equal(model.forwards, wantForwards) {
+		t.Fatalf("target forwards = %v, want %v", model.forwards, wantForwards)
+	}
+
+	// Ending the parked stretch settles the buffered context through, so the
+	// proposal runs block-only; close's flush then writes the accepted rows
+	// after rewinding the block.
+	wantCalls := []blockCall{
+		{offset: 0, ctx: []int32{2, 3}},
+		{offset: 2, block: []int32{3, 6, 6}},
+		{offset: 2, ctx: []int32{4, 5, 7}},
+	}
+	if len(draft.calls) != len(wantCalls) {
+		t.Fatalf("draft calls = %+v, want %+v", draft.calls, wantCalls)
+	}
+	for i, want := range wantCalls {
+		got := draft.calls[i]
+		if got.offset != want.offset || !slices.Equal(got.ctx, want.ctx) || !slices.Equal(got.block, want.block) {
+			t.Fatalf("draft call %d = %+v, want %+v", i, got, want)
+		}
+	}
+
+	// The draft caches end level with the target, holding only context rows.
+	if got, want := caches[1].Offset(), caches[0].Offset(); got != want {
+		t.Fatalf("draft cache offset = %d, want %d (level with target)", got, want)
+	}
+	if toks := draftTokensOf(caches); slices.Contains(toks, 6) {
+		t.Fatalf("draft cache retains block rows: %v", toks)
+	}
+}

--- a/x/mlxrunner/imports.go
+++ b/x/mlxrunner/imports.go
@@ -2,6 +2,7 @@ package mlxrunner
 
 import (
 	_ "github.com/ollama/ollama/x/models/cohere2_moe"
+	_ "github.com/ollama/ollama/x/models/dflash"
 	_ "github.com/ollama/ollama/x/models/gemma3"
 	_ "github.com/ollama/ollama/x/models/gemma4"
 	_ "github.com/ollama/ollama/x/models/glm4_moe_lite"

--- a/x/mlxrunner/model/base/base.go
+++ b/x/mlxrunner/model/base/base.go
@@ -15,7 +15,9 @@ import (
 
 // Model is the interface that model implementations must satisfy.
 type Model interface {
-	Forward(b *batch.Batch, cache []cache.Cache) *mlx.Array
+	// Forward returns the hidden state to unembed and the state a draft
+	// model conditions on; plain models return the final hidden for both.
+	Forward(b *batch.Batch, cache []cache.Cache) (hidden, auxHidden *mlx.Array)
 	Unembed(x *mlx.Array) *mlx.Array
 	NumLayers() int
 	Tokenizer() *tokenizer.Tokenizer
@@ -31,8 +33,8 @@ type Model interface {
 // tokens.
 type DraftModel interface {
 	// Draft fuses b.Hidden (the target hidden state) into its own forward and
-	// returns the head's hidden plus the projected hidden seeding the next step.
-	Draft(b *batch.Batch, caches []cache.Cache) (hidden, projected *mlx.Array)
+	// returns the head's hidden plus the aux hidden seeding the next step.
+	Draft(b *batch.Batch, caches []cache.Cache) (hidden, auxHidden *mlx.Array)
 
 	// Unembed projects a hidden state to vocabulary logits.
 	Unembed(x *mlx.Array) *mlx.Array

--- a/x/mlxrunner/model/base/base.go
+++ b/x/mlxrunner/model/base/base.go
@@ -15,36 +15,41 @@ import (
 
 // Model is the interface that model implementations must satisfy.
 type Model interface {
-	// Forward returns the hidden state to unembed and the state a draft
-	// model conditions on; plain models return the final hidden for both.
-	Forward(b *batch.Batch, cache []cache.Cache) (hidden, auxHidden *mlx.Array)
-	Unembed(x *mlx.Array) *mlx.Array
-	NumLayers() int
-	Tokenizer() *tokenizer.Tokenizer
-	MaxContextLength() int
-
 	// LoadWeights receives all tensors loaded from the manifest and assigns
 	// them to model fields. Model-specific logic (MLA absorption, expert
 	// stacking, quantized layer creation) happens here.
 	LoadWeights(tensors map[string]*mlx.Array) error
+
+	// NewCaches builds the cache slots this model's layers need.
+	NewCaches() []cache.Cache
+
+	// Forward returns the hidden state to unembed and the state a draft
+	// model conditions on; plain models return the final hidden for both.
+	Forward(b *batch.Batch, cache []cache.Cache) (hidden, auxHidden *mlx.Array)
+	Unembed(x *mlx.Array) *mlx.Array
+
+	Tokenizer() *tokenizer.Tokenizer
+	MaxContextLength() int
 }
 
 // DraftModel is an auxiliary model alongside a target that proposes speculative
 // tokens.
 type DraftModel interface {
-	// Draft fuses b.Hidden (the target hidden state) into its own forward and
-	// returns the head's hidden plus the aux hidden seeding the next step.
-	Draft(b *batch.Batch, caches []cache.Cache) (hidden, auxHidden *mlx.Array)
+	// LoadWeights assigns manifest tensors to the draft model's fields. An
+	// inline head has nothing to do here; its weights load with the target's.
+	LoadWeights(tensors map[string]*mlx.Array) error
+
+	// NewCaches builds the cache slots this draft model writes, or nil
+	// when it keeps no KV.
+	NewCaches() []cache.Cache
+
+	// Forward consumes b.Hidden (the draft-conditioning state) and returns
+	// its hidden plus the aux hidden that seeds the next step. targetCaches
+	// is read-only, for drafts that attend over the target's history.
+	Forward(b *batch.Batch, targetCaches, draftCaches []cache.Cache) (hidden, auxHidden *mlx.Array)
 
 	// Unembed projects a hidden state to vocabulary logits.
 	Unembed(x *mlx.Array) *mlx.Array
-
-	// DraftCaches selects the draft model's own KV caches from the full
-	// per-request slice — any subset, or nil when the draft keeps no KV.
-	DraftCaches(caches []cache.Cache) []cache.Cache
-
-	// LoadWeights assigns manifest tensors to the draft head's fields.
-	LoadWeights(tensors map[string]*mlx.Array) error
 }
 
 // SelfDraft is implemented by models whose draft head ships inline with the

--- a/x/mlxrunner/model/base/base.go
+++ b/x/mlxrunner/model/base/base.go
@@ -52,6 +52,17 @@ type DraftModel interface {
 	Unembed(x *mlx.Array) *mlx.Array
 }
 
+// BlockDraft is a DraftModel that drafts a whole block per forward (block
+// diffusion), conditioned on features tapped from target layers rather than
+// the final hidden state.
+type BlockDraft interface {
+	DraftModel
+
+	// BlockParams returns the trained block length and the mask token
+	// standing in for undrafted positions.
+	BlockParams() (blockSize int, maskToken int32)
+}
+
 // SelfDraft is implemented by models whose draft head ships inline with the
 // target weights; it returns the head, or nil when the checkpoint shipped none.
 type SelfDraft interface {

--- a/x/mlxrunner/mtp.go
+++ b/x/mlxrunner/mtp.go
@@ -29,9 +29,13 @@ func newMTPDrafter(s *speculation) *mtpDrafter {
 	return &mtpDrafter{spec: s}
 }
 
+// draftLimit reports no bound; the head makes one call per draft token, so
+// any depth is reachable.
+func (d *mtpDrafter) draftLimit() int { return 0 }
+
 // open returns the drafting session for one request, its pairing frontier
 // synced to the draft caches' restored offset.
-func (d *mtpDrafter) open() *mtpDraftSession {
+func (d *mtpDrafter) open() draftSession {
 	s := &mtpDraftSession{drafter: d}
 	if kv := d.spec.draftKV; len(kv) > 0 {
 		// A restored prefix arrives with the draft caches already written;

--- a/x/mlxrunner/mtp.go
+++ b/x/mlxrunner/mtp.go
@@ -151,12 +151,12 @@ func (d *mtpDraftSession) flush() {
 
 	ids := mlx.Concatenate(d.pendingTokens, 1)
 	hiddens := mlx.Concatenate(d.pendingHiddens, 1)
-	hidden, auxHidden := spec.draft.Draft(&batch.Batch{
+	hidden, auxHidden := spec.draft.Forward(&batch.Batch{
 		InputIDs:     ids,
 		SeqOffsets:   []int32{int32(d.committedDraftOffset)},
 		SeqQueryLens: []int32{int32(ids.Dim(1))},
 		Hidden:       hiddens,
-	}, spec.caches)
+	}, spec.targets, spec.draftKV)
 	d.setHeld(lastHiddenRow(hidden), lastHiddenRow(auxHidden))
 	d.committedDraftOffset += ids.Dim(1)
 
@@ -226,12 +226,12 @@ func (d *mtpDraftSession) propose(current *mlx.Array, maxTokens int) *draftCandi
 			if len(spec.draftKV) > 0 {
 				pos = d.frontier - 1 + i
 			}
-			hidden, auxHidden = spec.draft.Draft(&batch.Batch{
+			hidden, auxHidden = spec.draft.Forward(&batch.Batch{
 				InputIDs:     lastToken,
 				SeqOffsets:   []int32{int32(pos)},
 				SeqQueryLens: []int32{1},
 				Hidden:       lastHidden,
-			}, spec.caches)
+			}, spec.targets, spec.draftKV)
 		}
 		// Unembed only the row being sampled, never the batch.
 		stepLogits := spec.draft.Unembed(hidden).Squeeze(1)

--- a/x/mlxrunner/mtp.go
+++ b/x/mlxrunner/mtp.go
@@ -63,11 +63,11 @@ type mtpDraftSession struct {
 	pendingHiddens       []*mlx.Array
 	pendingCount         int
 
-	// heldHidden is the frontier row's pre-unembed hidden and heldProjected
+	// heldHidden is the frontier row's pre-unembed hidden and heldAuxHidden
 	// its fusion hidden, carried from the last flush so the first proposal
 	// reuses them without a head call.
 	heldHidden    *mlx.Array
-	heldProjected *mlx.Array
+	heldAuxHidden *mlx.Array
 }
 
 func (d *mtpDraftSession) committed(tokens, hiddens *mlx.Array, position int) {
@@ -135,7 +135,7 @@ func (d *mtpDraftSession) queueCacheWrites(tokens, hiddens *mlx.Array) {
 
 // flush writes the pending pairs to the draft caches in one head forward,
 // dropping speculative entries past the committed range first and holding
-// the last row's logits and projected hidden for the next proposal chain.
+// the last row's logits and aux hidden for the next proposal chain.
 func (d *mtpDraftSession) flush() {
 	if len(d.pendingTokens) == 0 {
 		return
@@ -151,13 +151,13 @@ func (d *mtpDraftSession) flush() {
 
 	ids := mlx.Concatenate(d.pendingTokens, 1)
 	hiddens := mlx.Concatenate(d.pendingHiddens, 1)
-	hidden, projected := spec.draft.Draft(&batch.Batch{
+	hidden, auxHidden := spec.draft.Draft(&batch.Batch{
 		InputIDs:     ids,
 		SeqOffsets:   []int32{int32(d.committedDraftOffset)},
 		SeqQueryLens: []int32{int32(ids.Dim(1))},
 		Hidden:       hiddens,
 	}, spec.caches)
-	d.setHeld(lastHiddenRow(hidden), lastHiddenRow(projected))
+	d.setHeld(lastHiddenRow(hidden), lastHiddenRow(auxHidden))
 	d.committedDraftOffset += ids.Dim(1)
 
 	// Force the draft writes: a session that never drafts would otherwise
@@ -181,10 +181,10 @@ func (d *mtpDraftSession) setFrontierHidden(h *mlx.Array) {
 }
 
 // setHeld replaces the held flush outputs, pinned until the next flush or close.
-func (d *mtpDraftSession) setHeld(hidden, projected *mlx.Array) {
-	mlx.Pin(hidden, projected)
-	mlx.Unpin(d.heldHidden, d.heldProjected)
-	d.heldHidden, d.heldProjected = hidden, projected
+func (d *mtpDraftSession) setHeld(hidden, auxHidden *mlx.Array) {
+	mlx.Pin(hidden, auxHidden)
+	mlx.Unpin(d.heldHidden, d.heldAuxHidden)
+	d.heldHidden, d.heldAuxHidden = hidden, auxHidden
 }
 
 // propose drafts a token chain after the not-yet-validated current token.
@@ -211,11 +211,11 @@ func (d *mtpDraftSession) propose(current *mlx.Array, maxTokens int) *draftCandi
 	var prefix *mlx.Array
 
 	for i := range maxTokens {
-		var hidden, projected *mlx.Array
+		var hidden, auxHidden *mlx.Array
 		if i == 0 && len(spec.draftKV) > 0 {
 			// The settle flush already produced the frontier row; reuse it
 			// instead of re-running the head.
-			hidden, projected = d.heldHidden, d.heldProjected
+			hidden, auxHidden = d.heldHidden, d.heldAuxHidden
 		} else {
 			// A head with draft caches writes each draft token to the next
 			// draft-cache slot, advancing one per step from the last committed
@@ -226,7 +226,7 @@ func (d *mtpDraftSession) propose(current *mlx.Array, maxTokens int) *draftCandi
 			if len(spec.draftKV) > 0 {
 				pos = d.frontier - 1 + i
 			}
-			hidden, projected = spec.draft.Draft(&batch.Batch{
+			hidden, auxHidden = spec.draft.Draft(&batch.Batch{
 				InputIDs:     lastToken,
 				SeqOffsets:   []int32{int32(pos)},
 				SeqQueryLens: []int32{1},
@@ -235,7 +235,7 @@ func (d *mtpDraftSession) propose(current *mlx.Array, maxTokens int) *draftCandi
 		}
 		// Unembed only the row being sampled, never the batch.
 		stepLogits := spec.draft.Unembed(hidden).Squeeze(1)
-		lastHidden = projected
+		lastHidden = auxHidden
 		// The chain's earlier drafts ride along as the row's history, so
 		// penalties shape proposals the same way they shape validation.
 		dist := r.Sampler.Distribution(pipelineSlot, stepLogits, prefix)

--- a/x/mlxrunner/mtp_test.go
+++ b/x/mlxrunner/mtp_test.go
@@ -82,6 +82,7 @@ func (m *fakeMTPModel) Forward(b *batch.Batch, caches []cache.Cache) (hidden, au
 	return out, out
 }
 
+func (m *fakeMTPModel) NewCaches() []cache.Cache        { return nil }
 func (m *fakeMTPModel) Unembed(x *mlx.Array) *mlx.Array { return x }
 func (m *fakeMTPModel) NumLayers() int                  { return 1 }
 func (m *fakeMTPModel) Tokenizer() *tokenizer.Tokenizer { return m.tok }
@@ -107,9 +108,9 @@ type draftCall struct {
 
 func (d *fakeMTPDraft) LoadWeights(map[string]*mlx.Array) error { return nil }
 
-func (d *fakeMTPDraft) DraftCaches([]cache.Cache) []cache.Cache { return nil }
+func (d *fakeMTPDraft) NewCaches() []cache.Cache { return nil }
 
-func (d *fakeMTPDraft) Draft(b *batch.Batch, caches []cache.Cache) (hidden, auxHidden *mlx.Array) {
+func (d *fakeMTPDraft) Forward(b *batch.Batch, _, _ []cache.Cache) (hidden, auxHidden *mlx.Array) {
 	mlx.Eval(b.InputIDs)
 	prev := int32(b.InputIDs.Ints()[0])
 	d.calls = append(d.calls, draftCall{position: b.SeqOffsets[0], from: prev})
@@ -121,18 +122,19 @@ func (d *fakeMTPDraft) Unembed(x *mlx.Array) *mlx.Array { return x }
 
 var _ base.DraftModel = (*fakeMTPDraft)(nil)
 
-// fakeKVDraft is a draft head with its own KV cache: it claims the trailing
-// cache slot, writes its input ids there on every Draft call (advancing the
+// fakeKVDraft is a draft head that declares a KV cache: it writes its
+// input ids there on every Draft call (advancing the
 // offset like a real KV write), and records each call's offset, ids, and
 // the identity of every fused hidden row. A target hidden row is one-hot
 // (its hot index identifies which position it came from); the head's own
 // aux hidden is all-zero and records as -1.
 type fakeKVDraft struct {
-	predict map[int32]int32
-	extends []extendCall
+	predict     map[int32]int32
+	draftCaches []cache.Cache
+	extends     []extendCall
 }
 
-// extendCall is one recorded Draft call: the absolute slot of the first
+// extendCall is one recorded Forward call: the absolute slot of the first
 // entry written, the look-ahead token ids, and the hot index of each fused
 // hidden row (-1 for the head's own aux hidden).
 type extendCall struct {
@@ -143,11 +145,9 @@ type extendCall struct {
 
 func (d *fakeKVDraft) LoadWeights(map[string]*mlx.Array) error { return nil }
 
-func (d *fakeKVDraft) DraftCaches(caches []cache.Cache) []cache.Cache {
-	return caches[len(caches)-1:]
-}
+func (d *fakeKVDraft) NewCaches() []cache.Cache { return d.draftCaches }
 
-func (d *fakeKVDraft) Draft(b *batch.Batch, caches []cache.Cache) (hidden, auxHidden *mlx.Array) {
+func (d *fakeKVDraft) Forward(b *batch.Batch, _, draftCaches []cache.Cache) (hidden, auxHidden *mlx.Array) {
 	mlx.Eval(b.InputIDs, b.Hidden)
 	rawIDs := b.InputIDs.Ints()
 	ids := make([]int32, len(rawIDs))
@@ -168,7 +168,7 @@ func (d *fakeKVDraft) Draft(b *batch.Batch, caches []cache.Cache) (hidden, auxHi
 	}
 	d.extends = append(d.extends, extendCall{offset: b.SeqOffsets[0], ids: ids, hiddens: hot})
 
-	if rc, ok := d.DraftCaches(caches)[0].(*fakeRewindableCache); ok {
+	if rc, ok := draftCaches[0].(*fakeRewindableCache); ok {
 		rc.feed(ids)
 	}
 
@@ -381,7 +381,7 @@ func TestRunMTPDecodeGreedy(t *testing.T) {
 	draft := &fakeMTPDraft{predict: predict}
 	caches, _ := newMTPTestCaches(1)
 	r.cache.caches = caches
-	r.spec = newSpeculation(r, draft)
+	r.spec = newSpeculation(r, draft, caches[:1], caches[1:])
 	session, ch := newMTPTestSession(caches)
 	position := 1 // one prefill token already processed
 
@@ -442,7 +442,7 @@ func TestRunMTPDecodeSampled(t *testing.T) {
 	r := mtpTestRunner(t, predict, []int32{eos}, sampler.Options{Temperature: 1, Seed: 42, UseSeed: true})
 	caches, _ := newMTPTestCaches(1)
 	r.cache.caches = caches
-	r.spec = newSpeculation(r, &fakeMTPDraft{predict: predict})
+	r.spec = newSpeculation(r, &fakeMTPDraft{predict: predict}, caches, nil)
 	session, ch := newMTPTestSession(caches)
 	position := 1
 
@@ -452,7 +452,7 @@ func TestRunMTPDecodeSampled(t *testing.T) {
 		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
 		SamplerOpts:       sampler.Options{Temperature: 1, Seed: 42, UseSeed: true},
 	}
-	spec := r.spec.open(req, caches)
+	spec := r.spec.open(req)
 	if spec == nil || !spec.enabled {
 		t.Fatalf("open rejected a sampled request")
 	}
@@ -486,7 +486,7 @@ func TestRunMTPDecodeWarmDrafter(t *testing.T) {
 	draft := &fakeMTPDraft{predict: predict}
 	caches, _ := newMTPTestCaches(1)
 	r.cache.caches = caches
-	r.spec = newSpeculation(r, draft)
+	r.spec = newSpeculation(r, draft, caches[:1], caches[1:])
 	session, ch := newMTPTestSession(caches)
 	position := 1 // one prefill token already processed
 
@@ -496,7 +496,7 @@ func TestRunMTPDecodeWarmDrafter(t *testing.T) {
 		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
 		SamplerOpts:       sampler.Options{},
 	}
-	spec := r.spec.open(req, caches)
+	spec := r.spec.open(req)
 	pinDraftLimit(spec, 4)
 	// The prefill chunk's committed report: token 0 at slot 0 with its
 	// hidden row, leaving the drafter ready to propose from slot 1.
@@ -547,7 +547,7 @@ func TestRunMTPDecodeEOSCutLeavesPositionsUnjudged(t *testing.T) {
 	r := mtpTestRunner(t, predict, []int32{eos}, sampler.Options{})
 	caches, _ := newMTPTestCaches(1)
 	r.cache.caches = caches
-	r.spec = newSpeculation(r, &fakeMTPDraft{predict: predict})
+	r.spec = newSpeculation(r, &fakeMTPDraft{predict: predict}, caches, nil)
 	session, ch := newMTPTestSession(caches)
 	position := 1
 
@@ -557,7 +557,7 @@ func TestRunMTPDecodeEOSCutLeavesPositionsUnjudged(t *testing.T) {
 		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
 		SamplerOpts:       sampler.Options{},
 	}
-	spec := r.spec.open(req, caches)
+	spec := r.spec.open(req)
 	if spec == nil || !spec.enabled {
 		t.Fatalf("want an enabled speculationSession with a depth controller, got %+v", spec)
 	}
@@ -652,7 +652,7 @@ func TestDecodeCancelledMidStream(t *testing.T) {
 	r := mtpTestRunner(t, predict, []int32{eos}, sampler.Options{})
 	caches, tr := newMTPTestCaches(1)
 	r.cache.caches = caches
-	r.spec = newSpeculation(r, &fakeMTPDraft{predict: predict})
+	r.spec = newSpeculation(r, &fakeMTPDraft{predict: predict}, caches, nil)
 	session := &cacheSession{caches: caches}
 	ch := make(chan CompletionResponse) // unbuffered: every send must rendezvous
 
@@ -707,7 +707,7 @@ func pinDraftLimit(spec *speculationSession, limit int) {
 // this request, with the draft length pinned to a fixed width; tests close it
 // explicitly so close-time effects are visible to assertions.
 func testDecoder(r *Runner, req Request, caches []cache.Cache, seed []int32, position int) decoder {
-	if spec := r.spec.open(req, caches); spec != nil {
+	if spec := r.spec.open(req); spec != nil {
 		if spec.enabled {
 			pinDraftLimit(spec, 4)
 		}
@@ -728,10 +728,11 @@ func TestDecodeKVDraft(t *testing.T) {
 	const eos int32 = 7
 	predict := map[int32]int32{1: 2, 2: 3, 3: 4, 4: 5, 5: 6, 6: eos, eos: 0}
 	r := mtpTestRunner(t, predict, []int32{eos}, sampler.Options{})
-	draft := &fakeKVDraft{predict: predict}
+	draft := &fakeKVDraft{predict: predict, draftCaches: nil}
 	caches, _ := newMTPTestCaches(2) // caches[0] target, caches[1] draft KV
+	draft.draftCaches = caches[1:]
 	r.cache.caches = caches
-	r.spec = newSpeculation(r, draft)
+	r.spec = newSpeculation(r, draft, caches[:1], caches[1:])
 	session, ch := newMTPTestSession(caches)
 	position := 0
 
@@ -741,7 +742,7 @@ func TestDecodeKVDraft(t *testing.T) {
 		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
 		SamplerOpts:       sampler.Options{},
 	}
-	spec := r.spec.open(req, caches)
+	spec := r.spec.open(req)
 	if spec == nil || !spec.enabled || len(spec.spec.targets) != 1 {
 		t.Fatalf("speculation engine not built around the draft caches")
 	}
@@ -812,10 +813,11 @@ func TestDecodeKVDraftRejectionRebuildsFromTarget(t *testing.T) {
 	// The draft mirrors the target except at 3, where it proposes 6 (absent from
 	// the target chain); once the target corrects 3->4 the next proposal
 	// re-aligns on the shared chain.
-	draft := &fakeKVDraft{predict: map[int32]int32{1: 2, 2: 3, 3: 6, 6: 0, 4: 5, 5: eos, eos: 0}}
+	draft := &fakeKVDraft{predict: map[int32]int32{1: 2, 2: 3, 3: 6, 6: 0, 4: 5, 5: eos, eos: 0}, draftCaches: nil}
 	caches, _ := newMTPTestCaches(2) // caches[0] target, caches[1] draft KV
+	draft.draftCaches = caches[1:]
 	r.cache.caches = caches
-	r.spec = newSpeculation(r, draft)
+	r.spec = newSpeculation(r, draft, caches[:1], caches[1:])
 	session, ch := newMTPTestSession(caches)
 	position := 0
 
@@ -825,7 +827,7 @@ func TestDecodeKVDraftRejectionRebuildsFromTarget(t *testing.T) {
 		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
 		SamplerOpts:       sampler.Options{},
 	}
-	spec := r.spec.open(req, caches)
+	spec := r.spec.open(req)
 	pinDraftLimit(spec, 4)
 	defer spec.close()
 	d := spec.decoder(mlx.FromValues([]int32{1}, 1), position)
@@ -881,10 +883,11 @@ func TestDecodeMaintainsDraftCacheWithoutDrafting(t *testing.T) {
 	predict := map[int32]int32{1: 2, 2: 3, 3: 4, 4: 5, 5: 6, 6: eos, eos: 0}
 	opts := sampler.Options{Logprobs: true}
 	r := mtpTestRunner(t, predict, []int32{eos}, opts)
-	draft := &fakeKVDraft{predict: predict}
+	draft := &fakeKVDraft{predict: predict, draftCaches: nil}
 	caches, _ := newMTPTestCaches(2)
+	draft.draftCaches = caches[1:]
 	r.cache.caches = caches
-	r.spec = newSpeculation(r, draft)
+	r.spec = newSpeculation(r, draft, caches[:1], caches[1:])
 	session, ch := newMTPTestSession(caches)
 	position := 0
 
@@ -894,7 +897,7 @@ func TestDecodeMaintainsDraftCacheWithoutDrafting(t *testing.T) {
 		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
 		SamplerOpts:       opts,
 	}
-	spec := r.spec.open(req, caches)
+	spec := r.spec.open(req)
 	if spec == nil || spec.enabled {
 		t.Fatalf("want a permanent-park speculationSession, got %+v", spec)
 	}
@@ -943,15 +946,16 @@ func TestSettleLevelsDraftCacheWithPrefill(t *testing.T) {
 	const eos int32 = 7
 	predict := map[int32]int32{2: 3, 3: 4, 4: 5}
 	r := mtpTestRunner(t, predict, []int32{eos}, sampler.Options{})
-	draft := &fakeKVDraft{predict: predict}
+	draft := &fakeKVDraft{predict: predict, draftCaches: nil}
 	caches, _ := newMTPTestCaches(2)
+	draft.draftCaches = caches[1:]
 	r.cache.caches = caches
-	r.spec = newSpeculation(r, draft)
+	r.spec = newSpeculation(r, draft, caches[:1], caches[1:])
 	req := Request{
 		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
 		SamplerOpts:       sampler.Options{},
 	}
-	spec := r.spec.open(req, caches)
+	spec := r.spec.open(req)
 	defer spec.close()
 
 	// The prompt's only chunk: tokens 1..4 at slots 0..3 with their hiddens;
@@ -984,15 +988,16 @@ func TestCommittedRunBatchesPastFlushCap(t *testing.T) {
 	}
 
 	r := mtpTestRunner(t, predict, []int32{0}, sampler.Options{})
-	draft := &fakeKVDraft{predict: predict}
+	draft := &fakeKVDraft{predict: predict, draftCaches: nil}
 	caches, _ := newMTPTestCaches(2)
+	draft.draftCaches = caches[1:]
 	r.cache.caches = caches
-	r.spec = newSpeculation(r, draft)
+	r.spec = newSpeculation(r, draft, caches[:1], caches[1:])
 	req := Request{
 		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
 		SamplerOpts:       sampler.Options{},
 	}
-	spec := r.spec.open(req, caches)
+	spec := r.spec.open(req)
 	defer spec.close()
 
 	// One prefill-sized chunk: n tokens at slots 0..n-1 with their hiddens.
@@ -1022,10 +1027,11 @@ func TestRestoredPrefixRewritesBoundaryPair(t *testing.T) {
 	const eos int32 = 7
 	predict := map[int32]int32{1: 2, 2: 3, 3: 4, 4: 5, 5: 6, 6: eos, eos: 0}
 	r := mtpTestRunner(t, predict, []int32{eos}, sampler.Options{})
-	draft := &fakeKVDraft{predict: predict}
+	draft := &fakeKVDraft{predict: predict, draftCaches: nil}
 	caches, _ := newMTPTestCaches(2)
+	draft.draftCaches = caches[1:]
 	r.cache.caches = caches
-	r.spec = newSpeculation(r, draft)
+	r.spec = newSpeculation(r, draft, caches[:1], caches[1:])
 	session, ch := newMTPTestSession(caches)
 	req := Request{
 		Responses:         ch,
@@ -1033,7 +1039,7 @@ func TestRestoredPrefixRewritesBoundaryPair(t *testing.T) {
 		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
 		SamplerOpts:       sampler.Options{},
 	}
-	spec := r.spec.open(req, caches)
+	spec := r.spec.open(req)
 	pinDraftLimit(spec, 4)
 	d := spec.decoder(mlx.FromValues([]int32{1}, 1), 0)
 	if err := r.decode(context.Background(), req, session, d, 0); err != nil {
@@ -1055,7 +1061,7 @@ func TestRestoredPrefixRewritesBoundaryPair(t *testing.T) {
 			t.Fatal("restore to 5 failed")
 		}
 	}
-	spec = r.spec.open(req, caches)
+	spec = r.spec.open(req)
 	spec.committed(mlx.FromValues([]int32{6, 1}, 1, 2), oneHotLogits([]int32{eos, 2}), 5)
 	spec.close()
 
@@ -1077,16 +1083,17 @@ func TestDecodeParkedDraftResume(t *testing.T) {
 	const eos int32 = 7
 	predict := map[int32]int32{1: 2, 2: 3, 3: 4, 4: 5, 5: 6, 6: eos, eos: 0}
 	r := mtpTestRunner(t, predict, []int32{eos}, sampler.Options{})
-	draft := &fakeKVDraft{predict: predict}
+	draft := &fakeKVDraft{predict: predict, draftCaches: nil}
 	caches, _ := newMTPTestCaches(2)
+	draft.draftCaches = caches[1:]
 	r.cache.caches = caches
-	r.spec = newSpeculation(r, draft)
+	r.spec = newSpeculation(r, draft, caches[:1], caches[1:])
 	req := Request{
 		Tokens:            []int32{1},
 		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
 		SamplerOpts:       sampler.Options{},
 	}
-	spec := r.spec.open(req, caches)
+	spec := r.spec.open(req)
 	if spec == nil || !spec.enabled {
 		t.Fatalf("want a drafting speculationSession, got %+v", spec)
 	}
@@ -1179,14 +1186,13 @@ func newMTPTestSession(caches []cache.Cache) (*cacheSession, chan CompletionResp
 // no-op drafter, since the engine requires one.
 func testSpeculationSession(r *Runner, caches []cache.Cache) *speculationSession {
 	if r.spec != nil {
-		r.spec.bind(caches)
 		return &speculationSession{spec: r.spec, drafter: r.spec.drafter.open()}
 	}
-	s := &speculation{r: r, caches: caches, targets: caches}
+	s := &speculation{r: r, targets: caches}
 	return &speculationSession{spec: s, drafter: nopDrafter{}}
 }
 
-// nopDrafter satisfies drafter for engine tests that supply candidates
+// nopDrafter satisfies draftSession for engine tests that supply candidates
 // directly and never propose.
 type nopDrafter struct{}
 

--- a/x/mlxrunner/mtp_test.go
+++ b/x/mlxrunner/mtp_test.go
@@ -57,7 +57,7 @@ type forwardCall struct {
 	n      int32
 }
 
-func (m *fakeMTPModel) Forward(b *batch.Batch, caches []cache.Cache) *mlx.Array {
+func (m *fakeMTPModel) Forward(b *batch.Batch, caches []cache.Cache) (hidden, auxHidden *mlx.Array) {
 	mlx.Eval(b.InputIDs)
 	ids := b.InputIDs.Ints()
 	m.forwards = append(m.forwards, forwardCall{offset: b.SeqOffsets[0], n: int32(len(ids))})
@@ -78,7 +78,8 @@ func (m *fakeMTPModel) Forward(b *batch.Batch, caches []cache.Cache) *mlx.Array 
 	for i, id := range ids {
 		preds[i] = m.predict[int32(id)]
 	}
-	return oneHotLogits(preds)
+	out := oneHotLogits(preds)
+	return out, out
 }
 
 func (m *fakeMTPModel) Unembed(x *mlx.Array) *mlx.Array { return x }
@@ -108,7 +109,7 @@ func (d *fakeMTPDraft) LoadWeights(map[string]*mlx.Array) error { return nil }
 
 func (d *fakeMTPDraft) DraftCaches([]cache.Cache) []cache.Cache { return nil }
 
-func (d *fakeMTPDraft) Draft(b *batch.Batch, caches []cache.Cache) (hidden, projected *mlx.Array) {
+func (d *fakeMTPDraft) Draft(b *batch.Batch, caches []cache.Cache) (hidden, auxHidden *mlx.Array) {
 	mlx.Eval(b.InputIDs)
 	prev := int32(b.InputIDs.Ints()[0])
 	d.calls = append(d.calls, draftCall{position: b.SeqOffsets[0], from: prev})
@@ -125,7 +126,7 @@ var _ base.DraftModel = (*fakeMTPDraft)(nil)
 // offset like a real KV write), and records each call's offset, ids, and
 // the identity of every fused hidden row. A target hidden row is one-hot
 // (its hot index identifies which position it came from); the head's own
-// projected hidden is all-zero and records as -1.
+// aux hidden is all-zero and records as -1.
 type fakeKVDraft struct {
 	predict map[int32]int32
 	extends []extendCall
@@ -133,7 +134,7 @@ type fakeKVDraft struct {
 
 // extendCall is one recorded Draft call: the absolute slot of the first
 // entry written, the look-ahead token ids, and the hot index of each fused
-// hidden row (-1 for the head's own projected hidden).
+// hidden row (-1 for the head's own aux hidden).
 type extendCall struct {
 	offset  int32
 	ids     []int32
@@ -146,7 +147,7 @@ func (d *fakeKVDraft) DraftCaches(caches []cache.Cache) []cache.Cache {
 	return caches[len(caches)-1:]
 }
 
-func (d *fakeKVDraft) Draft(b *batch.Batch, caches []cache.Cache) (hidden, projected *mlx.Array) {
+func (d *fakeKVDraft) Draft(b *batch.Batch, caches []cache.Cache) (hidden, auxHidden *mlx.Array) {
 	mlx.Eval(b.InputIDs, b.Hidden)
 	rawIDs := b.InputIDs.Ints()
 	ids := make([]int32, len(rawIDs))

--- a/x/mlxrunner/pipeline.go
+++ b/x/mlxrunner/pipeline.go
@@ -145,12 +145,12 @@ func (r *Runner) prefill(ctx context.Context, session *cacheSession, spec *specu
 		n := min(prefillChunk, total-processed-1)
 
 		chunkIDs := mlx.FromValues(tokens[processed:processed+n], 1, n)
-		hidden := r.Model.Forward(&batch.Batch{
+		_, auxHidden := r.Model.Forward(&batch.Batch{
 			InputIDs:     chunkIDs,
 			SeqOffsets:   []int32{int32(position)},
 			SeqQueryLens: []int32{int32(n)},
 		}, caches)
-		spec.committed(chunkIDs, hidden, position)
+		spec.committed(chunkIDs, auxHidden, position)
 		mlx.Sweep()
 		materializeCaches()
 		processed += n
@@ -303,12 +303,12 @@ func (r *Runner) pipelinedDecoder(spec *speculationSession, caches []cache.Cache
 // value, so it is in flight before the previous token is synchronized.
 func (t *pipelinedDecoder) dispatch(token *mlx.Array) sampler.Result {
 	r := t.r
-	hidden := r.Model.Forward(&batch.Batch{
+	hidden, auxHidden := r.Model.Forward(&batch.Batch{
 		InputIDs:     token,
 		SeqOffsets:   []int32{int32(t.position)},
 		SeqQueryLens: []int32{int32(token.Dim(1))},
 	}, t.caches)
-	t.spec.committed(token, hidden, t.position)
+	t.spec.committed(token, auxHidden, t.position)
 	t.position += token.Dim(1)
 	logits := r.Model.Unembed(hidden)
 	next := r.Sampler.Sample([]int{pipelineSlot}, logits.Slice(mlx.Slice(), mlx.Slice(logits.Dim(1)-1), mlx.Slice()).Squeeze(1))

--- a/x/mlxrunner/pipeline.go
+++ b/x/mlxrunner/pipeline.go
@@ -77,7 +77,7 @@ func (r *Runner) TextGenerationPipeline(ctx context.Context, request Request) er
 
 	// Built before prefill so a drafter with draft caches follows the prompt
 	// through prefill alongside the target.
-	spec := r.spec.open(request, caches)
+	spec := r.spec.open(request)
 	defer spec.close()
 
 	seed, position, promptEval, err := r.prefill(ctx, session, spec)

--- a/x/mlxrunner/prefix_cache.go
+++ b/x/mlxrunner/prefix_cache.go
@@ -27,7 +27,6 @@ import (
 	"github.com/ollama/ollama/logutil"
 	"github.com/ollama/ollama/x/mlxrunner/cache"
 	"github.com/ollama/ollama/x/mlxrunner/mlx"
-	"github.com/ollama/ollama/x/mlxrunner/model/base"
 )
 
 const maxPagedOutBytes int64 = 8 << 30 // 8 GiB eviction threshold for paged-out snapshot memory
@@ -66,17 +65,9 @@ type cacheSession struct {
 	pendingSnapshots []pendingSnapshot
 }
 
-func newPrefixCache(m base.Model) *prefixCache {
-	c := &prefixCache{}
-	if cacheFactory, ok := m.(interface{ NewCaches() []cache.Cache }); ok {
-		c.caches = cacheFactory.NewCaches()
-		return c
-	}
-	c.caches = make([]cache.Cache, m.NumLayers())
-	for i := range c.caches {
-		c.caches[i] = cache.NewKVCache()
-	}
-	return c
+// newPrefixCache manages the given cache slots for the model's life.
+func newPrefixCache(caches []cache.Cache) *prefixCache {
+	return &prefixCache{caches: caches}
 }
 
 func (c *prefixCache) ensureRoot() {

--- a/x/mlxrunner/runner.go
+++ b/x/mlxrunner/runner.go
@@ -6,12 +6,14 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"slices"
 	"strings"
 
 	"golang.org/x/sync/errgroup"
 
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/x/internal/mlxthread"
+	"github.com/ollama/ollama/x/mlxrunner/cache"
 	"github.com/ollama/ollama/x/mlxrunner/mlx"
 	"github.com/ollama/ollama/x/mlxrunner/model"
 	"github.com/ollama/ollama/x/mlxrunner/model/base"
@@ -106,13 +108,23 @@ func (r *Runner) Load(modelName string) error {
 	r.Model = m
 	r.Tokenizer = m.Tokenizer()
 	r.contextLength = m.MaxContextLength()
-	r.cache = newPrefixCache(m)
+	caches := m.NewCaches()
+	draftCaches := newDraftCaches(draftModel)
+	r.cache = newPrefixCache(slices.Concat(caches, draftCaches))
 	r.Sampler = sample.New(r.contextLength)
-	r.spec = newSpeculation(r, draftModel)
+	r.spec = newSpeculation(r, draftModel, caches, draftCaches)
 
 	mlx.EnableCompile()
 
 	return nil
+}
+
+// newDraftCaches returns nil when the model ships no draft.
+func newDraftCaches(draft base.DraftModel) []cache.Cache {
+	if draft == nil {
+		return nil
+	}
+	return draft.NewCaches()
 }
 
 func configureWiredMemory() {

--- a/x/mlxrunner/sample/sample.go
+++ b/x/mlxrunner/sample/sample.go
@@ -446,8 +446,8 @@ func (s *Sampler) Sample(seqIDs []int, logits *mlx.Array) Result {
 // mutating sampler state. Rows align with the end of the draft chain: the
 // final row is built as if every draft token had already been appended to
 // the slot history, each earlier row with one fewer. Validation passes
-// len(draftTokens)+1 rows, so row i sees draftTokens[:i]; a proposal step
-// passes a single row, which sees the whole chain so far. logits must be
+// len(draftTokens)+1 rows, so row i sees draftTokens[:i]; a proposal passes
+// no chain and every row sees the slot history as it stands. logits must be
 // [R,V] or [1,R,V].
 func (s *Sampler) Distribution(seqID int, logits *mlx.Array, draftTokens *mlx.Array) Distribution {
 	slot, logits, draftTokens := s.speculativeInputs("Distribution", seqID, logits, draftTokens)
@@ -529,14 +529,10 @@ func (s *Sampler) speculativeInputs(caller string, seqID int, logits *mlx.Array,
 	}
 
 	// Rows align with the end of the draft chain, so the earliest row sees
-	// draftCount-rows+1 prior drafts. More rows than draftCount+1 would make
-	// that count negative and silently drop the prefix; reject it loudly.
-	draftCount := 0
-	if draftTokens != nil {
-		draftCount = draftTokens.Dim(1)
-	}
-	if logits.Dim(0) > draftCount+1 {
-		panic(fmt.Sprintf("sample.Sampler.%s: %d logit rows exceed the %d-token draft chain", caller, logits.Dim(0), draftCount))
+	// draftCount-rows+1 prior drafts; more rows than that would silently drop
+	// prefix — reject loudly. Without a chain, rows see the history unchanged.
+	if draftTokens != nil && logits.Dim(0) > draftTokens.Dim(1)+1 {
+		panic(fmt.Sprintf("sample.Sampler.%s: %d logit rows exceed the %d-token draft chain", caller, logits.Dim(0), draftTokens.Dim(1)))
 	}
 	return slot, logits, draftTokens
 }

--- a/x/mlxrunner/sample/sample_test.go
+++ b/x/mlxrunner/sample/sample_test.go
@@ -364,6 +364,39 @@ func TestDistributionSingleRowAppliesDraftPrefix(t *testing.T) {
 	}
 }
 
+func TestDistributionMultiRowWithoutChain(t *testing.T) {
+	skipIfNoMLX(t)
+
+	s := New(128)
+	t.Cleanup(func() {
+		s.Free()
+		mlx.Sweep()
+	})
+
+	// A block drafter's proposal batch samples every row from one call with
+	// no draft chain: each row sees the slot history unchanged. Slot 0
+	// exercises the batched history path (full ring), slot 1 the serial path
+	// (ring not yet full).
+	s.Add(0, Options{RepeatLastN: 2, RepeatPenalty: 10}, []int32{3, 4})
+	s.Add(1, Options{RepeatLastN: 8, RepeatPenalty: 10}, []int32{3, 4})
+
+	for _, seqID := range []int{0, 1} {
+		// Tokens 3 and 4 are penalized in every row alike; rows 1 and 3
+		// share logits, so a chain alignment leaking between rows would
+		// split their winners.
+		dist := s.Distribution(seqID, batchLogits(
+			[]float32{0, 0, 8, 9, 9},
+			[]float32{0, 8, 0, 9, 9},
+			[]float32{0, 0, 8, 9, 9},
+		), nil)
+		top := dist.IDs.Slice(mlx.Slice(), mlx.Slice(0, 1))
+		mlx.Eval(top)
+		if got, want := top.Ints(), []int{2, 1, 2}; !slices.Equal(got, want) {
+			t.Fatalf("seq %d top tokens = %v, want %v", seqID, got, want)
+		}
+	}
+}
+
 func TestCommitBatchesRingWrites(t *testing.T) {
 	skipIfNoMLX(t)
 

--- a/x/mlxrunner/speculate.go
+++ b/x/mlxrunner/speculate.go
@@ -413,7 +413,7 @@ func (s *speculationSession) accept(position *int, current sampler.Result, candi
 	}
 	defer commit(0)
 
-	hiddenSeq := r.Model.Forward(&batch.Batch{
+	hiddenSeq, auxHiddenSeq := r.Model.Forward(&batch.Batch{
 		InputIDs:     current.Token.ExpandDims(-1).Concatenate(1, candidates.tokens),
 		SeqOffsets:   []int32{int32(before)},
 		SeqQueryLens: []int32{int32(draftCount + 1)},
@@ -439,7 +439,7 @@ func (s *speculationSession) accept(position *int, current sampler.Result, candi
 	// chain and this validation forward's intermediates are freed as the eval
 	// consumes them, the way the plain decode dispatch sweeps before its eval.
 	// current and the candidate tokens stay pinned by the caller across the call.
-	live := []*mlx.Array{hiddenSeq, acceptedMask, residualTokens, bonusToken}
+	live := []*mlx.Array{hiddenSeq, auxHiddenSeq, acceptedMask, residualTokens, bonusToken}
 	mlx.Pin(live...)
 	defer mlx.Unpin(live...)
 	mlx.Sweep()
@@ -488,7 +488,7 @@ func (s *speculationSession) accept(position *int, current sampler.Result, candi
 	runIDs := append([]int32{int32(current.Token.Int())}, commitIDs[:keep]...)
 	s.drafter.committed(
 		mlx.FromValues(runIDs, 1, len(runIDs)),
-		hiddenSeq.Slice(mlx.Slice(), mlx.Slice(0, len(runIDs)), mlx.Slice()),
+		auxHiddenSeq.Slice(mlx.Slice(), mlx.Slice(0, len(runIDs)), mlx.Slice()),
 		before)
 
 	results = draftResults(draftIDs[:accepted])

--- a/x/mlxrunner/speculate.go
+++ b/x/mlxrunner/speculate.go
@@ -2,7 +2,6 @@ package mlxrunner
 
 import (
 	"fmt"
-	"slices"
 	"time"
 
 	"github.com/ollama/ollama/x/mlxrunner/batch"
@@ -44,14 +43,10 @@ type speculation struct {
 	r     *Runner
 	draft base.DraftModel
 
-	// caches is the whole persistent slice, passed to every forward; draftKV
-	// are the draft head's own caches and targets are the rest — the caches the
-	// target forward writes, which speculation snapshots and rollback cover.
-	// Bound the first time the caches exist (the Runner reuses one cache slice
-	// for its life) and stable thereafter.
-	caches  []cache.Cache
-	draftKV []cache.Cache
+	// targets are the model's slots — what speculation snapshots and rolls
+	// back; draftKV the drafter's. Built at load, stable for the model's life.
 	targets []cache.Cache
+	draftKV []cache.Cache
 
 	// drafter is the persistent half of the MTP drafting machinery; each
 	// request's session comes from drafter.open.
@@ -64,42 +59,13 @@ type speculation struct {
 
 // newSpeculation builds the speculative-decoding subsystem for a loaded model,
 // or nil when the checkpoint ships no draft head.
-func newSpeculation(r *Runner, draft base.DraftModel) *speculation {
+func newSpeculation(r *Runner, draft base.DraftModel, targets, draftKV []cache.Cache) *speculation {
 	if draft == nil {
 		return nil
 	}
-	s := &speculation{r: r, draft: draft, depth: newDepthController()}
-	s.bind(r.cache.caches)
+	s := &speculation{r: r, draft: draft, targets: targets, draftKV: draftKV, depth: newDepthController()}
 	s.drafter = newMTPDrafter(s)
 	return s
-}
-
-// bind computes the draft/target cache partition the first time the persistent
-// caches exist; later requests reuse the same slice, so it runs once.
-func (s *speculation) bind(caches []cache.Cache) {
-	if s.caches != nil {
-		if !slices.Equal(s.caches, caches) {
-			panic("speculation: cache slice changed between requests")
-		}
-		return
-	}
-	draftKV := s.draft.DraftCaches(caches)
-
-	// Partition caches into target slots (everything not in draftKV) in one
-	// pass. The count check rejects a draft slot that isn't a member of caches.
-	targets := make([]cache.Cache, 0, len(caches))
-	for _, c := range caches {
-		if !slices.Contains(draftKV, c) {
-			targets = append(targets, c)
-		}
-	}
-	if len(caches)-len(targets) != len(draftKV) {
-		panic("speculation: DraftCaches must select slots of the cache slice")
-	}
-
-	s.caches = caches
-	s.draftKV = draftKV
-	s.targets = targets
 }
 
 // speculationSession is the per-request cursor over the persistent speculation:
@@ -122,11 +88,10 @@ type speculationSession struct {
 
 // open returns the speculation cursor for this request or nil when the model ships
 // no draft head (a nil receiver), which decodes plainly.
-func (s *speculation) open(request Request, caches []cache.Cache) *speculationSession {
+func (s *speculation) open(request Request) *speculationSession {
 	if s == nil {
 		return nil
 	}
-	s.bind(caches)
 	d := s.drafter.open()
 
 	// Logprobs are not yet supported, so a logprobs request keeps a speculationSession
@@ -291,7 +256,7 @@ func (st *speculativeDecoder) resume() []sampler.Result {
 func (st *speculativeDecoder) park(remaining int) ([]sampler.Result, error) {
 	s := st.s
 	if st.inner == nil {
-		st.inner = s.spec.r.pipelinedDecoder(s, s.spec.caches, st.current.Token.ExpandDims(-1), st.position)
+		st.inner = s.spec.r.pipelinedDecoder(s, s.spec.targets, st.current.Token.ExpandDims(-1), st.position)
 	}
 	return st.inner.next(remaining)
 }
@@ -417,7 +382,7 @@ func (s *speculationSession) accept(position *int, current sampler.Result, candi
 		InputIDs:     current.Token.ExpandDims(-1).Concatenate(1, candidates.tokens),
 		SeqOffsets:   []int32{int32(before)},
 		SeqQueryLens: []int32{int32(draftCount + 1)},
-	}, s.spec.caches)
+	}, s.spec.targets)
 
 	// Row i of the fused hidden is the state after the token at before+i, so
 	// the rows already line up with the drafts: row 0 (current's state)

--- a/x/mlxrunner/speculate.go
+++ b/x/mlxrunner/speculate.go
@@ -11,9 +11,9 @@ import (
 	sampler "github.com/ollama/ollama/x/mlxrunner/sample"
 )
 
-// drafter proposes speculative tokens for the engine to validate, learning
-// the conversation through the committed-stream reports.
-type drafter interface {
+// draftSession proposes speculative tokens for one request, learning the
+// conversation through the committed-stream reports.
+type draftSession interface {
 	// propose returns up to maxTokens draft tokens with their proposal
 	// distributions, or nil to decode this round plainly.
 	propose(current *mlx.Array, maxTokens int) *draftCandidates
@@ -43,18 +43,30 @@ type speculation struct {
 	r     *Runner
 	draft base.DraftModel
 
-	// targets are the model's slots — what speculation snapshots and rolls
-	// back; draftKV the drafter's. Built at load, stable for the model's life.
+	// targets are the model's cache slots, which speculation snapshots and
+	// rolls back; draftKV are the drafter's. Both are built at load and
+	// never change.
 	targets []cache.Cache
 	draftKV []cache.Cache
 
-	// drafter is the persistent half of the MTP drafting machinery; each
+	// drafter is the persistent half of the drafting machinery; each
 	// request's session comes from drafter.open.
-	drafter *mtpDrafter
+	drafter drafter
 
 	// depth selects each request's draft length and owns the cost/acceptance
 	// models and probe cadence it learns across requests.
 	depth *depthController
+}
+
+// drafter is the per-model half of a drafting implementation, opening each
+// request's drafting session.
+type drafter interface {
+	open() draftSession
+
+	// draftLimit is the deepest draft this drafter can produce, 0 when nothing
+	// bounds it. A depth past it is never measured, so the depth search must
+	// not schedule one.
+	draftLimit() int
 }
 
 // newSpeculation builds the speculative-decoding subsystem for a loaded model,
@@ -64,7 +76,12 @@ func newSpeculation(r *Runner, draft base.DraftModel, targets, draftKV []cache.C
 		return nil
 	}
 	s := &speculation{r: r, draft: draft, targets: targets, draftKV: draftKV, depth: newDepthController()}
-	s.drafter = newMTPDrafter(s)
+	if bd, ok := draft.(base.BlockDraft); ok {
+		s.drafter = newDFlashDrafter(s, bd)
+	} else {
+		s.drafter = newMTPDrafter(s)
+	}
+	s.depth.drafterLimit = s.drafter.draftLimit()
 	return s
 }
 
@@ -73,7 +90,7 @@ func newSpeculation(r *Runner, draft base.DraftModel, targets, draftKV []cache.C
 // decode.
 type speculationSession struct {
 	spec    *speculation
-	drafter drafter
+	drafter draftSession
 	enabled bool // whether this request drafts; false parks (maintain-only)
 	limit   int  // current draft length
 	stats   specStats
@@ -102,7 +119,6 @@ func (s *speculation) open(request Request) *speculationSession {
 	spec := &speculationSession{spec: s, drafter: d, enabled: enabled, prevDrafts: -1, roundDrafts: -1}
 	if enabled {
 		spec.limit = s.depth.scheduled
-		spec.stats.maxDraft = spec.limit
 	}
 	return spec
 }
@@ -126,6 +142,7 @@ func (s *speculationSession) beginRound() {
 // positions past it (a terminator, not a target rejection).
 func (s *speculationSession) endRound(drafted, accepted, observed int) {
 	s.roundDrafts = drafted
+	s.stats.maxDraft = max(s.stats.maxDraft, drafted)
 	s.stats.recordRound(drafted)
 	s.stats.iterations++
 	s.stats.drafted += drafted
@@ -135,7 +152,6 @@ func (s *speculationSession) endRound(drafted, accepted, observed int) {
 			s.spec.depth.acc.observe(observed, accepted)
 		}
 		s.limit = s.spec.depth.next()
-		s.stats.maxDraft = max(s.stats.maxDraft, s.limit)
 	}
 }
 

--- a/x/mlxrunner/speculate_depth.go
+++ b/x/mlxrunner/speculate_depth.go
@@ -18,10 +18,11 @@ const depthProbeInterval = 4
 const depthProbeIntervalMax = 512
 
 // depthController drafts argmax_N EV(N) where EV(N) = committed(N) / cost(N), over
-// depths from 0 (plain decode) up to one past the frontier. The depth-0 floor lets
-// it stop speculating when no draft pays; the frontier ceiling keeps it from scoring
-// a depth on the optimistic inherited rate, so it climbs outward one position at a
-// time as acceptance is measured rather than leaping deep.
+// depths from 0 (plain decode) up to one past the frontier, or the drafter's limit
+// where that is shallower. The depth-0 floor lets it stop speculating when no draft
+// pays; the frontier ceiling keeps it from scoring a depth on the optimistic
+// inherited rate, so it climbs outward one position at a time as acceptance is
+// measured rather than leaping deep.
 //
 // It holds the depth-selection state learned across requests — the target forward's
 // per-depth cost curve, the drafts' per-position acceptance rates, the probe cadence,
@@ -31,6 +32,11 @@ type depthController struct {
 	cost   *costModel
 	acc    *acceptanceModel
 	probed bool // the previous round drafted a probe
+
+	// drafterLimit is the deepest draft this model's drafter can produce, 0 when
+	// nothing bounds it. A depth the drafter never produces is never measured,
+	// and an unmeasured depth would always look best, pinning the search there.
+	drafterLimit int
 
 	// scheduled is the draft depth next() chose for the upcoming round, carried
 	// across requests so a new request's first round consumes it instead of
@@ -49,9 +55,19 @@ func newDepthController() *depthController {
 
 func (c *depthController) frontier() int { return c.acc.frontier() }
 
-// next returns the draft depth for the upcoming step: the EV-optimal depth (capped
-// at frontier+1), except periodically it probes one past the selection to refresh
-// the next position up. The probe stays within the frontier window. The cadence
+// limit is the deepest depth the search considers: one past the frontier, held
+// to what the drafter can produce.
+func (c *depthController) limit() int {
+	limit := c.frontier() + 1
+	if c.drafterLimit > 0 {
+		limit = min(limit, c.drafterLimit)
+	}
+	return limit
+}
+
+// next returns the draft depth for the upcoming step: the EV-optimal depth (held
+// to the search limit), except periodically it probes one past the selection to
+// refresh the next position up. The probe stays within that limit. The cadence
 // doubles toward its cap while probes change nothing and resets on any selection
 // change, giving the new selection a full interval to settle. The chosen depth is
 // recorded in c.scheduled for the next request's open to consume.
@@ -70,7 +86,7 @@ func (c *depthController) next() (depth int) {
 	c.probeSince++
 	if c.probeSince >= c.probeInterval {
 		c.probeSince = 0
-		if probe := min(sel+1, c.frontier()+1); probe != sel {
+		if probe := min(sel+1, c.limit()); probe != sel {
 			c.probed = true
 			return probe
 		}
@@ -87,11 +103,11 @@ func (c *depthController) next() (depth int) {
 	return sel
 }
 
-// costSeedDepth is the shallowest depth in [0, frontier+1] with no clean
-// cost sample, or -1 if all are sampled; bounding to frontier+1 keeps cost-seeding
-// from outrunning the acceptance frontier.
+// costSeedDepth is the shallowest depth within the search limit with no clean
+// cost sample, or -1 if all are sampled; the bound keeps cost-seeding from
+// outrunning the acceptance frontier or the drafter.
 func (c *depthController) costSeedDepth() int {
-	limit := c.frontier() + 1
+	limit := c.limit()
 	for n := 0; n <= limit; n++ {
 		if !c.cost.sampled(n) {
 			return n
@@ -101,14 +117,14 @@ func (c *depthController) costSeedDepth() int {
 }
 
 // selected returns the EV-optimal draft depth without mutating probe state, the
-// argmax over [0, frontier+1]. The frontier bound keeps the inherited optimistic
+// argmax within the search limit. The frontier bound keeps the inherited optimistic
 // rate from making ever-deeper depths look best; the depth-0 floor lets it stop
 // speculating. Returns 0 until the cost model can compare depths.
 func (c *depthController) selected() int {
 	if !c.cost.ready() {
 		return 0
 	}
-	limit := c.frontier() + 1
+	limit := c.limit()
 	best, bestEV := 0, c.acc.expectedCommitted(0)/c.cost.cost(0)
 	for n := 1; n <= limit; n++ {
 		if ev := c.acc.expectedCommitted(n) / c.cost.cost(n); ev > bestEV {

--- a/x/mlxrunner/speculate_stats.go
+++ b/x/mlxrunner/speculate_stats.go
@@ -66,7 +66,7 @@ func (s *speculationSession) logStats() {
 	}
 
 	// Log learned acceptance over the trusted positions [1, frontier] and
-	// expected throughput over the searched window [0, frontier+1]; deeper
+	// expected throughput over the searched window [0, limit]; deeper
 	// depths have no data of their own.
 	d := s.spec.depth
 	frontier := d.frontier()
@@ -74,7 +74,7 @@ func (s *speculationSession) logStats() {
 	for n := 1; n <= frontier; n++ {
 		rates = append(rates, fmt.Sprintf("%d:%.2f", n, d.acc.acceptance(n)))
 	}
-	limit := frontier + 1
+	limit := d.limit()
 	tps := make([]string, 0, limit+1)
 	if d.cost.ready() {
 		for n := 0; n <= limit; n++ {

--- a/x/models/cohere2_moe/cohere2_moe.go
+++ b/x/models/cohere2_moe/cohere2_moe.go
@@ -754,10 +754,6 @@ func (m *Model) Unembed(x *mlx.Array) *mlx.Array {
 	return logits
 }
 
-func (m *Model) NumLayers() int {
-	return len(m.Layers)
-}
-
 func (m *Model) MaxContextLength() int {
 	return int(m.MaxPositionEmbeddings)
 }

--- a/x/models/cohere2_moe/cohere2_moe.go
+++ b/x/models/cohere2_moe/cohere2_moe.go
@@ -728,7 +728,7 @@ func (l *Layer) Forward(x *mlx.Array, b *batch.Batch, c cache.Cache, positions *
 	return mlx.Add(x, mlx.Add(attnOut, mlpOut))
 }
 
-func (m *Model) Forward(b *batch.Batch, caches []cache.Cache) *mlx.Array {
+func (m *Model) Forward(b *batch.Batch, caches []cache.Cache) (hidden, auxHidden *mlx.Array) {
 	dims := b.InputIDs.Dims()
 	B, L := int32(dims[0]), int32(dims[1])
 	positions := mlx.FromValues(b.SeqOffsets, len(b.SeqOffsets))
@@ -742,7 +742,8 @@ func (m *Model) Forward(b *batch.Batch, caches []cache.Cache) *mlx.Array {
 		h = layer.Forward(h, b, c, positions, B, L, m.Config)
 	}
 
-	return m.Norm.Forward(h)
+	out := m.Norm.Forward(h)
+	return out, out
 }
 
 func (m *Model) Unembed(x *mlx.Array) *mlx.Array {

--- a/x/models/dflash/dflash.go
+++ b/x/models/dflash/dflash.go
@@ -1,0 +1,662 @@
+// Package dflash implements the DFlash block-diffusion draft model:
+// qwen3-shaped layers drafting a whole block per forward, conditioned on
+// tapped target hidden states as key/value context.
+package dflash
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+
+	"github.com/ollama/ollama/x/mlxrunner/batch"
+	"github.com/ollama/ollama/x/mlxrunner/cache"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/mlxrunner/model"
+	"github.com/ollama/ollama/x/mlxrunner/model/base"
+	"github.com/ollama/ollama/x/models/nn"
+)
+
+func init() {
+	base.RegisterDraft("DFlashDraftModel", func(root *model.Root, target base.Model) (base.DraftModel, error) {
+		return newModel(root, target, false)
+	})
+}
+
+var _ base.BlockDraft = (*Model)(nil)
+
+type Config struct {
+	HiddenSize        int32
+	NumHiddenLayers   int32
+	NumAttentionHeads int32
+	NumKeyValueHeads  int32
+	HeadDim           int32
+	RMSNormEps        float32
+	RopeTheta         float32
+	Scale             float32
+	SlidingWindow     int32
+	LayerTypes        []string
+
+	BlockSize      int
+	MaskTokenID    int32
+	VocabSize      int32
+	TargetLayerIDs []int
+
+	// Causal, when set, overrides every layer's attention direction;
+	// otherwise only sliding layers run causal.
+	Causal *bool
+}
+
+// draftTarget is what dflash requires of its target beyond base.Model.
+type draftTarget interface {
+	base.Model
+
+	// TokenEmbeddings is the raw table lookup; the draft has no table of
+	// its own.
+	TokenEmbeddings(ids *mlx.Array) *mlx.Array
+
+	// RawLogits is the raw head projection, skipping any output decoration
+	// the target's own Unembed applies.
+	RawLogits(hidden *mlx.Array) *mlx.Array
+
+	// SetAuxHiddenLayers taps layer outputs: id i means the hidden state
+	// after layer i, the same convention as checkpoint target_layer_ids.
+	SetAuxHiddenLayers(layers []int)
+
+	// NumLayers is used to validate the config's tap ids.
+	NumLayers() int
+}
+
+type Model struct {
+	FC         nn.LinearLayer
+	HiddenNorm *nn.RMSNorm
+	Norm       *nn.RMSNorm
+	Layers     []*Layer
+
+	// AuxNorms, when shipped, normalize each target slice before fusion.
+	AuxNorms []*nn.RMSNorm
+
+	// ctxLayerNorm passes context rows through each layer's input norm, a
+	// laguna convention that neither tensors nor config indicate.
+	ctxLayerNorm bool
+
+	*Config
+
+	target draftTarget
+
+	tensorPrefix string
+
+	QuantGroupSize int
+	QuantBits      int
+	QuantMode      string
+	TensorQuant    map[string]*model.TensorQuantInfo
+}
+
+type Layer struct {
+	InputNorm    *nn.RMSNorm
+	PostAttnNorm *nn.RMSNorm
+	Attention    *Attention
+	MLP          *MLP
+	IsSliding    bool
+	IsCausal     bool
+}
+
+// Attention holds a q projection and a fused k|v projection: split
+// checkpoints are stacked at load, fused ones sliced. Context rows produce
+// no queries, so the context path uses only KVProj.
+type Attention struct {
+	QProj  nn.LinearLayer
+	KVProj nn.LinearLayer
+	GProj  nn.LinearLayer
+	OProj  nn.LinearLayer
+	QNorm  *nn.RMSNorm
+	KNorm  *nn.RMSNorm
+
+	// ctxInputNorm applies the layer's input norm to context rows (laguna).
+	ctxInputNorm *nn.RMSNorm
+}
+
+type MLP struct {
+	// GateUpProj is gate|up stacked at load; SwiGLU splits the halves.
+	GateUpProj nn.LinearLayer
+	DownProj   nn.LinearLayer
+}
+
+func parseConfig(data []byte) (*Config, error) {
+	var raw struct {
+		HiddenSize        int32   `json:"hidden_size"`
+		NumHiddenLayers   int32   `json:"num_hidden_layers"`
+		NumAttentionHeads int32   `json:"num_attention_heads"`
+		NumKeyValueHeads  int32   `json:"num_key_value_heads"`
+		HeadDim           int32   `json:"head_dim"`
+		RMSNormEps        float32 `json:"rms_norm_eps"`
+		RopeTheta         float32 `json:"rope_theta"`
+		RopeParameters    struct {
+			RopeTheta float32 `json:"rope_theta"`
+		} `json:"rope_parameters"`
+		BlockSize    int `json:"block_size"`
+		DFlashConfig struct {
+			BlockSize       int    `json:"block_size"`
+			MaskTokenID     *int32 `json:"mask_token_id"`
+			TargetLayerIDs  []int  `json:"target_layer_ids"`
+			NumTargetLayers int    `json:"num_target_layers"`
+			Causal          *bool  `json:"causal"`
+		} `json:"dflash_config"`
+		NumTargetLayers int      `json:"num_target_layers"`
+		VocabSize       int32    `json:"vocab_size"`
+		LayerTypes      []string `json:"layer_types"`
+		SlidingWindow   int32    `json:"sliding_window"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parse dflash config: %w", err)
+	}
+
+	cfg := &Config{
+		HiddenSize:        raw.HiddenSize,
+		NumHiddenLayers:   raw.NumHiddenLayers,
+		NumAttentionHeads: raw.NumAttentionHeads,
+		NumKeyValueHeads:  raw.NumKeyValueHeads,
+		HeadDim:           raw.HeadDim,
+		RMSNormEps:        raw.RMSNormEps,
+		RopeTheta:         raw.RopeTheta,
+		SlidingWindow:     raw.SlidingWindow,
+		LayerTypes:        raw.LayerTypes,
+		BlockSize:         raw.DFlashConfig.BlockSize,
+		VocabSize:         raw.VocabSize,
+		TargetLayerIDs:    raw.DFlashConfig.TargetLayerIDs,
+		Causal:            raw.DFlashConfig.Causal,
+	}
+	if cfg.RopeTheta == 0 {
+		cfg.RopeTheta = raw.RopeParameters.RopeTheta
+	}
+	if cfg.BlockSize == 0 {
+		cfg.BlockSize = raw.BlockSize
+	}
+	cfg.Scale = float32(math.Pow(float64(cfg.HeadDim), -0.5))
+
+	if cfg.BlockSize < 2 {
+		return nil, fmt.Errorf("dflash block size %d must be at least 2", cfg.BlockSize)
+	}
+	if raw.DFlashConfig.MaskTokenID == nil {
+		return nil, fmt.Errorf("dflash config missing mask_token_id")
+	}
+	cfg.MaskTokenID = *raw.DFlashConfig.MaskTokenID
+	if len(cfg.TargetLayerIDs) == 0 {
+		return nil, fmt.Errorf("dflash config missing target_layer_ids")
+	}
+	for i, id := range cfg.TargetLayerIDs {
+		if id < 0 || (i > 0 && id <= cfg.TargetLayerIDs[i-1]) {
+			return nil, fmt.Errorf("dflash target_layer_ids must be ascending and non-negative")
+		}
+	}
+	if n := max(raw.NumTargetLayers, raw.DFlashConfig.NumTargetLayers); n > 0 && cfg.TargetLayerIDs[len(cfg.TargetLayerIDs)-1] >= n {
+		return nil, fmt.Errorf("dflash target layer %d out of range for %d target layers",
+			cfg.TargetLayerIDs[len(cfg.TargetLayerIDs)-1], n)
+	}
+	if len(cfg.LayerTypes) == 0 {
+		cfg.LayerTypes = make([]string, cfg.NumHiddenLayers)
+		for i := range cfg.LayerTypes {
+			cfg.LayerTypes[i] = "full_attention"
+		}
+	}
+	if len(cfg.LayerTypes) != int(cfg.NumHiddenLayers) {
+		return nil, fmt.Errorf("dflash layer_types length %d != num_hidden_layers %d", len(cfg.LayerTypes), cfg.NumHiddenLayers)
+	}
+	for _, t := range cfg.LayerTypes {
+		switch t {
+		case "full_attention":
+		case "sliding_attention":
+			if cfg.SlidingWindow <= 0 {
+				return nil, fmt.Errorf("dflash sliding_attention layers require sliding_window")
+			}
+		default:
+			return nil, fmt.Errorf("unsupported dflash layer type %q", t)
+		}
+	}
+	return cfg, nil
+}
+
+func newModel(root *model.Root, targetModel base.Model, ctxLayerNorm bool) (base.DraftModel, error) {
+	if root == nil || root.Draft == nil {
+		return nil, fmt.Errorf("draft metadata missing")
+	}
+
+	configPath := root.Draft.Config
+	if configPath == "" {
+		configPath = "draft/config.json"
+	}
+	configData, err := root.Manifest.ReadConfig(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("load draft config: %w", err)
+	}
+	cfg, err := parseConfig(configData)
+	if err != nil {
+		return nil, err
+	}
+
+	target, ok := targetModel.(draftTarget)
+	if !ok {
+		return nil, fmt.Errorf("dflash draft is not supported with this target model")
+	}
+
+	var trained struct {
+		NumTargetLayers int `json:"num_target_layers"`
+		DFlashConfig    struct {
+			NumTargetLayers int `json:"num_target_layers"`
+		} `json:"dflash_config"`
+	}
+	_ = json.Unmarshal(configData, &trained)
+	if n := max(trained.NumTargetLayers, trained.DFlashConfig.NumTargetLayers); n > 0 && n != target.NumLayers() {
+		return nil, fmt.Errorf("dflash draft trained for %d target layers, target has %d", n, target.NumLayers())
+	}
+	if last := cfg.TargetLayerIDs[len(cfg.TargetLayerIDs)-1]; last >= target.NumLayers() {
+		return nil, fmt.Errorf("dflash target layer %d out of range for %d target layers", last, target.NumLayers())
+	}
+
+	// The manifest can pair any draft with any target; probe the borrowed
+	// table and head (static shapes, nothing evaluated) to verify the fit.
+	emb := target.TokenEmbeddings(mlx.FromValues([]int32{0}, 1, 1))
+	if w := emb.Dim(2); w != int(cfg.HiddenSize) {
+		return nil, fmt.Errorf("dflash draft trained for hidden size %d, target has %d", cfg.HiddenSize, w)
+	}
+	vocab := target.RawLogits(emb).Dim(2)
+	if cfg.VocabSize > 0 && int(cfg.VocabSize) != vocab {
+		return nil, fmt.Errorf("dflash draft trained for a %d-token vocabulary, target has %d", cfg.VocabSize, vocab)
+	}
+	if cfg.MaskTokenID < 0 || int(cfg.MaskTokenID) >= vocab {
+		return nil, fmt.Errorf("dflash mask token %d outside the target's %d-token vocabulary", cfg.MaskTokenID, vocab)
+	}
+	target.SetAuxHiddenLayers(cfg.TargetLayerIDs)
+
+	tensorPrefix := root.Draft.TensorPrefix
+	if tensorPrefix == "" {
+		tensorPrefix = "draft."
+	}
+
+	m := &Model{
+		Config:       cfg,
+		target:       target,
+		ctxLayerNorm: ctxLayerNorm,
+		tensorPrefix: tensorPrefix,
+		Layers:       make([]*Layer, cfg.NumHiddenLayers),
+		TensorQuant:  root.AllTensorQuant(),
+	}
+	if qt := root.QuantType(); qt != "" {
+		m.QuantGroupSize, m.QuantBits, m.QuantMode = model.QuantizationParams(qt)
+		if gs := root.GroupSize(); gs > 0 {
+			m.QuantGroupSize = gs
+		}
+	}
+	return m, nil
+}
+
+func (m *Model) LoadWeights(tensors map[string]*mlx.Array) error {
+	prefix := m.tensorPrefix
+	linears := model.NewLinearFactory(tensors, m.QuantGroupSize, m.QuantBits, m.QuantMode, m.TensorQuant)
+
+	if m.FC = linears.Make(prefix + "fc"); m.FC == nil {
+		return fmt.Errorf("missing dflash fc weight")
+	}
+	for name, dst := range map[string]**nn.RMSNorm{
+		"hidden_norm.weight": &m.HiddenNorm,
+		"norm.weight":        &m.Norm,
+	} {
+		w := tensors[prefix+name]
+		if w == nil {
+			return fmt.Errorf("missing dflash %s", name)
+		}
+		*dst = nn.NewRMSNorm(w, m.RMSNormEps)
+	}
+
+	for i := 0; ; i++ {
+		w := tensors[fmt.Sprintf("%saux_hidden_norms.%d.weight", prefix, i)]
+		if w == nil {
+			break
+		}
+		m.AuxNorms = append(m.AuxNorms, nn.NewRMSNorm(w, m.RMSNormEps))
+	}
+	if len(m.AuxNorms) > 0 && len(m.AuxNorms) != len(m.TargetLayerIDs) {
+		return fmt.Errorf("dflash has %d aux hidden norms for %d target layers", len(m.AuxNorms), len(m.TargetLayerIDs))
+	}
+
+	for i := range m.Layers {
+		layerPrefix := fmt.Sprintf("%slayers.%d", prefix, i)
+		layer := &Layer{
+			IsSliding: m.LayerTypes[i] == "sliding_attention",
+			Attention: &Attention{
+				GProj: linears.Make(layerPrefix + ".self_attn.g_proj"),
+				OProj: linears.Make(layerPrefix + ".self_attn.o_proj"),
+			},
+			MLP: &MLP{
+				DownProj: linears.Make(layerPrefix + ".mlp.down_proj"),
+			},
+		}
+		a := layer.Attention
+		qDim := m.NumAttentionHeads * m.HeadDim
+		kvDim := m.NumKeyValueHeads * m.HeadDim
+		if fused := linears.Make(layerPrefix + ".self_attn.qkv_proj"); fused != nil {
+			a.QProj = sliceLinearRows(fused, 0, qDim)
+			a.KVProj = sliceLinearRows(fused, qDim, qDim+2*kvDim)
+		} else if q := linears.Make(layerPrefix + ".self_attn.q_proj"); q != nil {
+			k := linears.Make(layerPrefix + ".self_attn.k_proj")
+			v := linears.Make(layerPrefix + ".self_attn.v_proj")
+			if k != nil && v != nil {
+				kv, err := stackLinears(k, v)
+				if err != nil {
+					return fmt.Errorf("dflash layer %d k|v: %w", i, err)
+				}
+				a.QProj, a.KVProj = q, kv
+			}
+		}
+		if gate := linears.Make(layerPrefix + ".mlp.gate_proj"); gate != nil {
+			if up := linears.Make(layerPrefix + ".mlp.up_proj"); up != nil {
+				gu, err := stackLinears(gate, up)
+				if err != nil {
+					return fmt.Errorf("dflash layer %d gate|up: %w", i, err)
+				}
+				layer.MLP.GateUpProj = gu
+			}
+		}
+		layer.IsCausal = layer.IsSliding
+		if m.Causal != nil {
+			layer.IsCausal = *m.Causal
+		}
+		if w := tensors[layerPrefix+".input_layernorm.weight"]; w != nil {
+			layer.InputNorm = nn.NewRMSNorm(w, m.RMSNormEps)
+		}
+		if w := tensors[layerPrefix+".post_attention_layernorm.weight"]; w != nil {
+			layer.PostAttnNorm = nn.NewRMSNorm(w, m.RMSNormEps)
+		}
+		if w := tensors[layerPrefix+".self_attn.q_norm.weight"]; w != nil {
+			layer.Attention.QNorm = nn.NewRMSNorm(w, m.RMSNormEps)
+		}
+		if w := tensors[layerPrefix+".self_attn.k_norm.weight"]; w != nil {
+			layer.Attention.KNorm = nn.NewRMSNorm(w, m.RMSNormEps)
+		}
+		if m.ctxLayerNorm {
+			layer.Attention.ctxInputNorm = layer.InputNorm
+		}
+
+		if a.QProj == nil || a.KVProj == nil || a.OProj == nil || a.QNorm == nil || a.KNorm == nil {
+			return fmt.Errorf("dflash layer %d: missing attention weights", i)
+		}
+		if layer.MLP.GateUpProj == nil || layer.MLP.DownProj == nil {
+			return fmt.Errorf("dflash layer %d: missing mlp weights", i)
+		}
+		if layer.InputNorm == nil || layer.PostAttnNorm == nil {
+			return fmt.Errorf("dflash layer %d: missing norm weights", i)
+		}
+		m.Layers[i] = layer
+	}
+	return nil
+}
+
+// stackLinears concatenates two linears along the output dimension. Quant
+// groups run along the input dimension, so this is exact; per-tensor global
+// scales are expanded to per-row so each half keeps its own.
+func stackLinears(a, b nn.LinearLayer) (nn.LinearLayer, error) {
+	if pa, ok := a.(*nn.Linear); ok {
+		pb, ok := b.(*nn.Linear)
+		if !ok {
+			return nil, fmt.Errorf("stack linears: mixed plain and quantized parts")
+		}
+		return &nn.Linear{
+			Weight: mlx.Concatenate([]*mlx.Array{pa.Weight, pb.Weight}, 0),
+			Bias:   concatBias(pa.Bias, int32(pa.Weight.Dim(0)), pb.Bias, int32(pb.Weight.Dim(0))),
+		}, nil
+	}
+	qa, ok := a.(*nn.QuantizedLinear)
+	if !ok {
+		return nil, fmt.Errorf("stack linears: unsupported layer type %T", a)
+	}
+	qb, ok := b.(*nn.QuantizedLinear)
+	if !ok {
+		return nil, fmt.Errorf("stack linears: mixed plain and quantized parts")
+	}
+	if qa.GroupSize != qb.GroupSize || qa.Bits != qb.Bits || qa.Mode != qb.Mode {
+		return nil, fmt.Errorf("stack linears: quant mode mismatch %s/%d/%d vs %s/%d/%d",
+			qa.Mode, qa.Bits, qa.GroupSize, qb.Mode, qb.Bits, qb.GroupSize)
+	}
+	if (qa.QBiases == nil) != (qb.QBiases == nil) {
+		return nil, fmt.Errorf("stack linears: quant bias layout mismatch")
+	}
+	out := &nn.QuantizedLinear{
+		Weight:    mlx.Concatenate([]*mlx.Array{qa.Weight, qb.Weight}, 0),
+		Scales:    mlx.Concatenate([]*mlx.Array{qa.Scales, qb.Scales}, 0),
+		GroupSize: qa.GroupSize,
+		Bits:      qa.Bits,
+		Mode:      qa.Mode,
+	}
+	if qa.QBiases != nil {
+		out.QBiases = mlx.Concatenate([]*mlx.Array{qa.QBiases, qb.QBiases}, 0)
+	}
+	out.Bias = concatBias(qa.Bias, int32(qa.Scales.Dim(0)), qb.Bias, int32(qb.Scales.Dim(0)))
+	if qa.GlobalScale != nil || qb.GlobalScale != nil {
+		out.GlobalScale = mlx.Concatenate([]*mlx.Array{
+			perRowGlobal(qa.GlobalScale, int32(qa.Scales.Dim(0))),
+			perRowGlobal(qb.GlobalScale, int32(qb.Scales.Dim(0))),
+		}, 0)
+	}
+	return out, nil
+}
+
+// perRowGlobal expands a per-tensor (or nil, meaning 1.0) global scale to a
+// per-row vector; an already per-row scale passes through unchanged.
+func perRowGlobal(g *mlx.Array, rows int32) *mlx.Array {
+	ones := make([]float32, rows)
+	for i := range ones {
+		ones[i] = 1
+	}
+	v := mlx.FromValues(ones, int(rows))
+	if g == nil {
+		return v
+	}
+	return mlx.Mul(v, g)
+}
+
+func concatBias(a *mlx.Array, aRows int32, b *mlx.Array, bRows int32) *mlx.Array {
+	if a == nil && b == nil {
+		return nil
+	}
+	fill := func(bias *mlx.Array, rows int32, like *mlx.Array) *mlx.Array {
+		if bias != nil {
+			return bias
+		}
+		return mlx.ZerosF32([]int32{rows}).AsType(like.DType())
+	}
+	if a == nil {
+		a = fill(nil, aRows, b)
+	}
+	if b == nil {
+		b = fill(nil, bRows, a)
+	}
+	return mlx.Concatenate([]*mlx.Array{a, b}, 0)
+}
+
+// sliceLinearRows returns rows [start, stop) of l along the output dimension.
+func sliceLinearRows(l nn.LinearLayer, start, stop int32) nn.LinearLayer {
+	rows := func(t *mlx.Array) *mlx.Array {
+		if t == nil {
+			return nil
+		}
+		dims := t.Dims()
+		starts := make([]int32, len(dims))
+		stops := make([]int32, len(dims))
+		for i, d := range dims {
+			stops[i] = int32(d)
+		}
+		starts[0], stops[0] = start, stop
+		return mlx.SliceStartStop(t, starts, stops)
+	}
+	switch q := l.(type) {
+	case *nn.Linear:
+		return &nn.Linear{Weight: rows(q.Weight), Bias: rows(q.Bias)}
+	case *nn.QuantizedLinear:
+		g := q.GlobalScale
+		if g != nil && len(g.Dims()) == 1 && g.Dim(0) == q.Scales.Dim(0) {
+			g = rows(g)
+		}
+		return &nn.QuantizedLinear{
+			Weight:      rows(q.Weight),
+			Scales:      rows(q.Scales),
+			QBiases:     rows(q.QBiases),
+			Bias:        rows(q.Bias),
+			GlobalScale: g,
+			GroupSize:   q.GroupSize,
+			Bits:        q.Bits,
+			Mode:        q.Mode,
+		}
+	}
+	return nil
+}
+
+func (m *Model) BlockParams() (int, int32) { return m.BlockSize, m.MaskTokenID }
+
+// NewCaches builds the per-layer context caches.
+func (m *Model) NewCaches() []cache.Cache {
+	caches := make([]cache.Cache, len(m.Layers))
+	for i, layer := range m.Layers {
+		if layer.IsSliding {
+			caches[i] = cache.NewRotatingKVCache(int(m.SlidingWindow))
+		} else {
+			caches[i] = cache.NewKVCache()
+		}
+	}
+	return caches
+}
+
+func (m *Model) Unembed(x *mlx.Array) *mlx.Array {
+	return m.target.RawLogits(x)
+}
+
+// Forward writes b.Hidden's rows into each layer's context cache starting at
+// SeqOffsets[0] and runs b.InputIDs as a block positioned after them; queries
+// come from the block only. Either input may be absent: with no block the
+// call just extends the context, with no context the block drafts from
+// whatever is already cached.
+func (m *Model) Forward(b *batch.Batch, _, draftCaches []cache.Cache) (hidden, auxHidden *mlx.Array) {
+	kv := draftCaches
+
+	var hctx *mlx.Array
+	nCtx := int32(0)
+	if b.Hidden != nil {
+		features := b.Hidden
+		if len(m.AuxNorms) > 0 {
+			slices := make([]*mlx.Array, len(m.AuxNorms))
+			for i, norm := range m.AuxNorms {
+				lo := int32(i) * m.HiddenSize
+				slices[i] = norm.Forward(features.Slice(mlx.Slice(), mlx.Slice(), mlx.Slice(int(lo), int(lo+m.HiddenSize))), m.RMSNormEps)
+			}
+			features = mlx.Concatenate(slices, -1)
+		}
+		hctx = m.HiddenNorm.Forward(m.FC.Forward(features), m.RMSNormEps)
+		nCtx = int32(b.Hidden.Dim(1))
+	}
+	ctxPositions := mlx.FromValues([]int32{b.SeqOffsets[0]}, 1)
+
+	var h, blockPositions *mlx.Array
+	var bb *batch.Batch
+	var B, L int32
+	if b.InputIDs != nil {
+		dims := b.InputIDs.Dims()
+		B, L = int32(dims[0]), int32(dims[1])
+		h = m.target.TokenEmbeddings(b.InputIDs)
+		blockStart := b.SeqOffsets[0] + nCtx
+		bb = &batch.Batch{InputIDs: b.InputIDs, SeqOffsets: []int32{blockStart}, SeqQueryLens: b.SeqQueryLens}
+		blockPositions = mlx.FromValues([]int32{blockStart}, 1)
+	}
+
+	for i, layer := range m.Layers {
+		var ctxK, ctxV *mlx.Array
+		if hctx != nil {
+			ctxK, ctxV = layer.Attention.contextKV(hctx, ctxPositions, m.Config)
+		}
+		if h == nil {
+			if ctxK != nil {
+				kv[i].(cache.Attention).Update(b, ctxK, ctxV)
+			}
+			continue
+		}
+		var mask nn.AttentionMask
+		// A sliding layer's window comes from its cache, not from this mask.
+		if layer.IsCausal {
+			mask = nn.CausalMask()
+		}
+		h = layer.Forward(h, ctxK, ctxV, kv[i], bb, blockPositions, mask, B, L, m.Config)
+	}
+	if h == nil {
+		return nil, nil
+	}
+	hidden = m.Norm.Forward(h, m.RMSNormEps)
+	return hidden, hidden
+}
+
+func (l *Layer) Forward(x, ctxK, ctxV *mlx.Array, c cache.Cache, bb *batch.Batch, positions *mlx.Array, mask nn.AttentionMask, B, L int32, cfg *Config) *mlx.Array {
+	h := mlx.Add(x, l.Attention.Forward(l.InputNorm.Forward(x, cfg.RMSNormEps), ctxK, ctxV, c, bb, positions, mask, B, L, cfg))
+	return mlx.Add(h, l.MLP.Forward(l.PostAttnNorm.Forward(h, cfg.RMSNormEps)))
+}
+
+// contextKV projects feature rows into the layer's context K/V.
+func (a *Attention) contextKV(hctx *mlx.Array, positions *mlx.Array, cfg *Config) (k, v *mlx.Array) {
+	if a.ctxInputNorm != nil {
+		hctx = a.ctxInputNorm.Forward(hctx, cfg.RMSNormEps)
+	}
+	dims := hctx.Dims()
+	B, S := int32(dims[0]), int32(dims[1])
+	k, v = a.splitKV(a.KVProj.Forward(hctx), B, S, cfg)
+	k = a.KNorm.Forward(k, cfg.RMSNormEps)
+	k = mlx.Transpose(k, 0, 2, 1, 3)
+	v = mlx.Transpose(v, 0, 2, 1, 3)
+	k = mlx.RoPEWithBase(k, int(cfg.HeadDim), false, cfg.RopeTheta, 1.0, positions)
+	return k, v
+}
+
+func (a *Attention) splitKV(kv *mlx.Array, B, L int32, cfg *Config) (k, v *mlx.Array) {
+	kvDim := cfg.NumKeyValueHeads * cfg.HeadDim
+	k = mlx.Reshape(mlx.SliceStartStop(kv, []int32{0, 0, 0}, []int32{B, L, kvDim}), B, L, cfg.NumKeyValueHeads, cfg.HeadDim)
+	v = mlx.Reshape(mlx.SliceStartStop(kv, []int32{0, 0, kvDim}, []int32{B, L, 2 * kvDim}), B, L, cfg.NumKeyValueHeads, cfg.HeadDim)
+	return k, v
+}
+
+func (a *Attention) Forward(x, ctxK, ctxV *mlx.Array, c cache.Cache, bb *batch.Batch, positions *mlx.Array, mask nn.AttentionMask, B, L int32, cfg *Config) *mlx.Array {
+	q := mlx.Reshape(a.QProj.Forward(x), B, L, cfg.NumAttentionHeads, cfg.HeadDim)
+	k, v := a.splitKV(a.KVProj.Forward(x), B, L, cfg)
+
+	q = a.QNorm.Forward(q, cfg.RMSNormEps)
+	k = a.KNorm.Forward(k, cfg.RMSNormEps)
+
+	q = mlx.Transpose(q, 0, 2, 1, 3)
+	k = mlx.Transpose(k, 0, 2, 1, 3)
+	v = mlx.Transpose(v, 0, 2, 1, 3)
+
+	q = mlx.RoPEWithBase(q, int(cfg.HeadDim), false, cfg.RopeTheta, 1.0, positions)
+	k = mlx.RoPEWithBase(k, int(cfg.HeadDim), false, cfg.RopeTheta, 1.0, positions)
+
+	if ctxK != nil {
+		k = ctxK.Concatenate(2, k)
+		v = ctxV.Concatenate(2, v)
+	}
+
+	// Write the context and block K/V together: a rollback point between two
+	// writes would force a wrapped rotating cache to copy its window out.
+	hist := c.(cache.Attention).Update(bb, k, v)
+
+	out := nn.ScaledDotProductAttention(bb, q, cfg.Scale, nn.WithKVHistory(hist), nn.WithMask(mask))
+	if a.GProj != nil {
+		// Per-head softplus output gate, applied before the head merge.
+		gate := mlx.ExpandDims(mlx.SoftplusF32(a.GProj.Forward(x)), -1)
+		out = mlx.Mul(mlx.Transpose(out, 0, 2, 1, 3), gate)
+		out = mlx.Reshape(out, B, L, cfg.NumAttentionHeads*cfg.HeadDim)
+	} else {
+		out = mlx.Reshape(mlx.Transpose(out, 0, 2, 1, 3), B, L, cfg.NumAttentionHeads*cfg.HeadDim)
+	}
+	return a.OProj.Forward(out)
+}
+
+func (m *MLP) Forward(x *mlx.Array) *mlx.Array {
+	gu := m.GateUpProj.Forward(x)
+	dims := gu.Dims()
+	B, L, half := int32(dims[0]), int32(dims[1]), int32(dims[2])/2
+	gate := mlx.SliceStartStop(gu, []int32{0, 0, 0}, []int32{B, L, half})
+	up := mlx.SliceStartStop(gu, []int32{0, 0, half}, []int32{B, L, 2 * half})
+	return m.DownProj.Forward(mlx.SwiGLU(gate, up))
+}

--- a/x/models/dflash/dflash.go
+++ b/x/models/dflash/dflash.go
@@ -20,6 +20,9 @@ func init() {
 	base.RegisterDraft("DFlashDraftModel", func(root *model.Root, target base.Model) (base.DraftModel, error) {
 		return newModel(root, target, false)
 	})
+	base.RegisterDraft("DFlashLagunaForCausalLM", func(root *model.Root, target base.Model) (base.DraftModel, error) {
+		return newModel(root, target, true)
+	})
 }
 
 var _ base.BlockDraft = (*Model)(nil)

--- a/x/models/gemma3/gemma3.go
+++ b/x/models/gemma3/gemma3.go
@@ -427,10 +427,6 @@ func (m *Model) Unembed(x *mlx.Array) *mlx.Array {
 	return m.LMHead.Forward(x)
 }
 
-func (m *Model) NumLayers() int {
-	return len(m.Layers)
-}
-
 func (m *Model) MaxContextLength() int {
 	return int(m.MaxPositionEmbeddings)
 }

--- a/x/models/gemma3/gemma3.go
+++ b/x/models/gemma3/gemma3.go
@@ -403,7 +403,7 @@ func (m *Model) LoadWeights(tensors map[string]*mlx.Array) error {
 	return nil
 }
 
-func (m *Model) Forward(b *batch.Batch, caches []cache.Cache) *mlx.Array {
+func (m *Model) Forward(b *batch.Batch, caches []cache.Cache) (hidden, auxHidden *mlx.Array) {
 	dims := b.InputIDs.Dims()
 	B, L := int32(dims[0]), int32(dims[1])
 	positions := mlx.FromValues(b.SeqOffsets, len(b.SeqOffsets))
@@ -419,7 +419,8 @@ func (m *Model) Forward(b *batch.Batch, caches []cache.Cache) *mlx.Array {
 		h = layer.Forward(h, b, c, positions, B, L, m.TextConfig)
 	}
 
-	return mlx.RMSNormFn(h, m.NormScaled, m.RMSNormEps)
+	out := mlx.RMSNormFn(h, m.NormScaled, m.RMSNormEps)
+	return out, out
 }
 
 func (m *Model) Unembed(x *mlx.Array) *mlx.Array {

--- a/x/models/gemma4/assistant.go
+++ b/x/models/gemma4/assistant.go
@@ -269,22 +269,22 @@ func (m *AssistantModel) precomputeScaledWeights() {
 	}
 }
 
-// DraftCaches returns nil: the assistant keeps no KV and re-attends the
+// NewCaches returns nil: the assistant keeps no KV and re-attends the
 // target's caches read-only each step.
-func (m *AssistantModel) DraftCaches([]cache.Cache) []cache.Cache { return nil }
+func (m *AssistantModel) NewCaches() []cache.Cache { return nil }
 
-// Draft is single-position: the head drafts every token as if it sat at the
+// Forward is single-position: the head drafts every token as if it sat at the
 // last target-seen position, so it anchors RoPE and the mask there — from the
 // non-moving target full-attention cache — regardless of the advancing offset
 // in b. The input fuses the target's scaled token embedding with b.Hidden.
-func (m *AssistantModel) Draft(b *batch.Batch, caches []cache.Cache) (hidden, auxHidden *mlx.Array) {
+func (m *AssistantModel) Forward(b *batch.Batch, targetCaches, _ []cache.Cache) (hidden, auxHidden *mlx.Array) {
 	inputsEmbeds := m.target.TokenEmbeddings(b.InputIDs).Concatenate(-1, b.Hidden)
 	dims := inputsEmbeds.Dims()
 	B, L := int32(dims[0]), int32(dims[1])
 
 	anchor := int32(0)
-	if len(caches) > 0 {
-		if full := caches[len(caches)-1]; full != nil {
+	if len(targetCaches) > 0 {
+		if full := targetCaches[len(targetCaches)-1]; full != nil {
 			anchor = int32(full.Offset() - 1)
 		}
 	}
@@ -294,7 +294,7 @@ func (m *AssistantModel) Draft(b *batch.Batch, caches []cache.Cache) (hidden, au
 		SeqQueryLens: []int32{L},
 	}
 
-	sliding, full := m.sharedHistories(ab, caches)
+	sliding, full := m.sharedHistories(ab, targetCaches)
 	h := m.PreProjection.Forward(inputsEmbeds)
 
 	positions := mlx.FromValues([]int32{anchor}, 1)

--- a/x/models/gemma4/assistant.go
+++ b/x/models/gemma4/assistant.go
@@ -277,7 +277,7 @@ func (m *AssistantModel) DraftCaches([]cache.Cache) []cache.Cache { return nil }
 // last target-seen position, so it anchors RoPE and the mask there — from the
 // non-moving target full-attention cache — regardless of the advancing offset
 // in b. The input fuses the target's scaled token embedding with b.Hidden.
-func (m *AssistantModel) Draft(b *batch.Batch, caches []cache.Cache) (hidden, projected *mlx.Array) {
+func (m *AssistantModel) Draft(b *batch.Batch, caches []cache.Cache) (hidden, auxHidden *mlx.Array) {
 	inputsEmbeds := m.target.TokenEmbeddings(b.InputIDs).Concatenate(-1, b.Hidden)
 	dims := inputsEmbeds.Dims()
 	B, L := int32(dims[0]), int32(dims[1])
@@ -303,8 +303,8 @@ func (m *AssistantModel) Draft(b *batch.Batch, caches []cache.Cache) (hidden, pr
 	}
 
 	hidden = mlx.RMSNormFn(h, m.NormScaled, m.TextConfig.RMSNormEps)
-	projected = m.PostProjection.Forward(hidden)
-	return hidden, projected
+	auxHidden = m.PostProjection.Forward(hidden)
+	return hidden, auxHidden
 }
 
 func (m *AssistantModel) sharedHistories(b *batch.Batch, caches []cache.Cache) (sliding, full *nn.KVHistory) {

--- a/x/models/gemma4/gemma4.go
+++ b/x/models/gemma4/gemma4.go
@@ -1081,10 +1081,6 @@ func suppressTokenLogits(logits, bias *mlx.Array) *mlx.Array {
 	return logits.Add(bias.AsType(logits.DType()))
 }
 
-func (m *Model) NumLayers() int {
-	return len(m.Layers)
-}
-
 func (m *Model) MaxContextLength() int {
 	return int(m.MaxPositionEmbeddings)
 }

--- a/x/models/gemma4/gemma4.go
+++ b/x/models/gemma4/gemma4.go
@@ -984,7 +984,7 @@ func (m *Model) LoadWeights(tensors map[string]*mlx.Array) error {
 	return nil
 }
 
-func (m *Model) Forward(b *batch.Batch, caches []cache.Cache) *mlx.Array {
+func (m *Model) Forward(b *batch.Batch, caches []cache.Cache) (hidden, auxHidden *mlx.Array) {
 	dims := b.InputIDs.Dims()
 	B, L := int32(dims[0]), int32(dims[1])
 	positions := mlx.FromValues(b.SeqOffsets, len(b.SeqOffsets))
@@ -1033,7 +1033,8 @@ func (m *Model) Forward(b *batch.Batch, caches []cache.Cache) *mlx.Array {
 		}
 	}
 
-	return mlx.RMSNormFn(h, m.NormScaled, m.RMSNormEps)
+	out := mlx.RMSNormFn(h, m.NormScaled, m.RMSNormEps)
+	return out, out
 }
 
 func (m *Model) Unembed(x *mlx.Array) *mlx.Array {

--- a/x/models/glm4_moe_lite/glm4_moe_lite.go
+++ b/x/models/glm4_moe_lite/glm4_moe_lite.go
@@ -743,7 +743,7 @@ func (m *Model) LoadWeights(tensors map[string]*mlx.Array) error {
 }
 
 // Forward computes the forward pass of the model
-func (m *Model) Forward(b *batch.Batch, caches []cache.Cache) *mlx.Array {
+func (m *Model) Forward(b *batch.Batch, caches []cache.Cache) (hidden, auxHidden *mlx.Array) {
 	dims := b.InputIDs.Dims()
 	B, L := int32(dims[0]), int32(dims[1])
 	positions := mlx.FromValues(b.SeqOffsets, len(b.SeqOffsets))
@@ -759,7 +759,7 @@ func (m *Model) Forward(b *batch.Batch, caches []cache.Cache) *mlx.Array {
 	}
 
 	h = m.Norm.Forward(h, m.RMSNormEps)
-	return h
+	return h, h
 }
 
 // Unembed applies the LM head to get logits.

--- a/x/models/glm4_moe_lite/glm4_moe_lite.go
+++ b/x/models/glm4_moe_lite/glm4_moe_lite.go
@@ -767,8 +767,14 @@ func (m *Model) Unembed(x *mlx.Array) *mlx.Array {
 	return m.LMHead.Forward(x)
 }
 
-// NumLayers returns the number of transformer layers
-func (m *Model) NumLayers() int { return len(m.Layers) }
+// NewCaches builds a KV cache per layer.
+func (m *Model) NewCaches() []cache.Cache {
+	caches := make([]cache.Cache, len(m.Layers))
+	for i := range caches {
+		caches[i] = cache.NewKVCache()
+	}
+	return caches
+}
 
 // MaxContextLength returns the maximum context length
 func (m *Model) MaxContextLength() int { return int(m.MaxPositionEmbeddings) }

--- a/x/models/laguna/laguna.go
+++ b/x/models/laguna/laguna.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"slices"
 	"strings"
 
 	"github.com/ollama/ollama/x/mlxrunner/batch"
@@ -82,6 +83,9 @@ type Model struct {
 	Layers      []*Layer
 	Norm        *nn.RMSNorm
 	LMHead      nn.LinearLayer
+
+	// auxHiddenLayers are the tapped layers; empty means the final hidden.
+	auxHiddenLayers []int
 
 	tok *tokenizer.Tokenizer
 	*Config
@@ -1395,6 +1399,7 @@ func (m *Model) Forward(b *batch.Batch, caches []cache.Cache) (hidden, auxHidden
 
 func (m *Model) forward(b *batch.Batch, caches []cache.Cache, B, L int32) (hidden, auxHidden *mlx.Array) {
 	positions := mlx.FromValues(b.SeqOffsets, len(b.SeqOffsets))
+	var features []*mlx.Array
 	h := m.EmbedTokens.Forward(b.InputIDs)
 	for i, layer := range m.Layers {
 		var c cache.Cache
@@ -1402,9 +1407,32 @@ func (m *Model) forward(b *batch.Batch, caches []cache.Cache, B, L int32) (hidde
 			c = caches[i]
 		}
 		h = layer.Forward(h, b, c, positions, B, L, m.Config)
+		if slices.Contains(m.auxHiddenLayers, i) {
+			features = append(features, h)
+		}
 	}
 	out := m.Norm.Forward(h, m.RMSNormEps)
+	if features != nil {
+		return out, mlx.Concatenate(features, -1)
+	}
 	return out, out
+}
+
+// SetAuxHiddenLayers taps the listed layers' outputs, which Forward then
+// returns as the draft-conditioning state in place of the final hidden.
+func (m *Model) SetAuxHiddenLayers(layers []int) {
+	m.auxHiddenLayers = layers
+}
+
+// TokenEmbeddings is the raw lookup, for a draft that embeds with the
+// target's table.
+func (m *Model) TokenEmbeddings(ids *mlx.Array) *mlx.Array {
+	return m.EmbedTokens.Forward(ids)
+}
+
+// RawLogits matches Unembed: this head applies no output decoration.
+func (m *Model) RawLogits(hidden *mlx.Array) *mlx.Array {
+	return m.LMHead.Forward(hidden)
 }
 
 func (m *Model) Unembed(x *mlx.Array) *mlx.Array {

--- a/x/models/laguna/laguna.go
+++ b/x/models/laguna/laguna.go
@@ -1387,13 +1387,13 @@ func (l *Layer) Forward(x *mlx.Array, b *batch.Batch, c cache.Cache, positions *
 	return mlx.Add(h, r)
 }
 
-func (m *Model) Forward(b *batch.Batch, caches []cache.Cache) *mlx.Array {
+func (m *Model) Forward(b *batch.Batch, caches []cache.Cache) (hidden, auxHidden *mlx.Array) {
 	dims := b.InputIDs.Dims()
 	B, L := int32(dims[0]), int32(dims[1])
 	return m.forward(b, caches, B, L)
 }
 
-func (m *Model) forward(b *batch.Batch, caches []cache.Cache, B, L int32) *mlx.Array {
+func (m *Model) forward(b *batch.Batch, caches []cache.Cache, B, L int32) (hidden, auxHidden *mlx.Array) {
 	positions := mlx.FromValues(b.SeqOffsets, len(b.SeqOffsets))
 	h := m.EmbedTokens.Forward(b.InputIDs)
 	for i, layer := range m.Layers {
@@ -1403,7 +1403,8 @@ func (m *Model) forward(b *batch.Batch, caches []cache.Cache, B, L int32) *mlx.A
 		}
 		h = layer.Forward(h, b, c, positions, B, L, m.Config)
 	}
-	return m.Norm.Forward(h, m.RMSNormEps)
+	out := m.Norm.Forward(h, m.RMSNormEps)
+	return out, out
 }
 
 func (m *Model) Unembed(x *mlx.Array) *mlx.Array {

--- a/x/models/laguna/laguna_test.go
+++ b/x/models/laguna/laguna_test.go
@@ -254,7 +254,7 @@ func TestTinyLagunaLoadAndForward(t *testing.T) {
 			}
 		}
 	}()
-	hidden := m.Forward(&batch.Batch{
+	hidden, _ := m.Forward(&batch.Batch{
 		InputIDs:     tokens,
 		SeqOffsets:   []int32{0},
 		SeqQueryLens: []int32{int32(tokens.Dim(1))},

--- a/x/models/llama/llama.go
+++ b/x/models/llama/llama.go
@@ -259,10 +259,6 @@ func (m *Model) Unembed(x *mlx.Array) *mlx.Array {
 	return m.LMHead.Forward(x)
 }
 
-func (m *Model) NumLayers() int {
-	return len(m.Layers)
-}
-
 func (m *Model) MaxContextLength() int {
 	return int(m.MaxPositionEmbeddings)
 }

--- a/x/models/llama/llama.go
+++ b/x/models/llama/llama.go
@@ -237,7 +237,7 @@ func (m *Model) LoadWeights(tensors map[string]*mlx.Array) error {
 	return nil
 }
 
-func (m *Model) Forward(b *batch.Batch, caches []cache.Cache) *mlx.Array {
+func (m *Model) Forward(b *batch.Batch, caches []cache.Cache) (hidden, auxHidden *mlx.Array) {
 	dims := b.InputIDs.Dims()
 	B, L := int32(dims[0]), int32(dims[1])
 	positions := mlx.FromValues(b.SeqOffsets, len(b.SeqOffsets))
@@ -251,7 +251,8 @@ func (m *Model) Forward(b *batch.Batch, caches []cache.Cache) *mlx.Array {
 		h = layer.Forward(h, b, c, positions, B, L, m.Config)
 	}
 
-	return m.Norm.Forward(h, m.RMSNormEps)
+	out := m.Norm.Forward(h, m.RMSNormEps)
+	return out, out
 }
 
 func (m *Model) Unembed(x *mlx.Array) *mlx.Array {

--- a/x/models/qwen3/qwen3.go
+++ b/x/models/qwen3/qwen3.go
@@ -276,10 +276,6 @@ func (m *Model) Unembed(x *mlx.Array) *mlx.Array {
 	return m.LMHead.Forward(x)
 }
 
-func (m *Model) NumLayers() int {
-	return len(m.Layers)
-}
-
 func (m *Model) MaxContextLength() int {
 	return int(m.MaxPositionEmbeddings)
 }

--- a/x/models/qwen3/qwen3.go
+++ b/x/models/qwen3/qwen3.go
@@ -254,7 +254,7 @@ func (m *Model) LoadWeights(tensors map[string]*mlx.Array) error {
 	return nil
 }
 
-func (m *Model) Forward(b *batch.Batch, caches []cache.Cache) *mlx.Array {
+func (m *Model) Forward(b *batch.Batch, caches []cache.Cache) (hidden, auxHidden *mlx.Array) {
 	dims := b.InputIDs.Dims()
 	B, L := int32(dims[0]), int32(dims[1])
 	positions := mlx.FromValues(b.SeqOffsets, len(b.SeqOffsets))
@@ -268,7 +268,8 @@ func (m *Model) Forward(b *batch.Batch, caches []cache.Cache) *mlx.Array {
 		h = layer.Forward(h, b, c, positions, B, L, m.Config)
 	}
 
-	return m.Norm.Forward(h, m.RMSNormEps)
+	out := m.Norm.Forward(h, m.RMSNormEps)
+	return out, out
 }
 
 func (m *Model) Unembed(x *mlx.Array) *mlx.Array {

--- a/x/models/qwen3_5/qwen3_5.go
+++ b/x/models/qwen3_5/qwen3_5.go
@@ -27,7 +27,7 @@ func init() {
 var (
 	_ base.Model      = (*Model)(nil)
 	_ base.SelfDraft  = (*Model)(nil)
-	_ base.DraftModel = (*Model)(nil)
+	_ base.DraftModel = (*mtpDraft)(nil)
 )
 
 // RopeParameters carries optional rope metadata embedded under rope_parameters.
@@ -102,8 +102,8 @@ type Model struct {
 	weightPrefix string
 }
 
-// MTPHead is the multi-token-prediction draft head; it owns a KV cache appended
-// after the per-layer caches and reuses the model's lm_head.
+// MTPHead is the multi-token-prediction draft head; it writes one KV cache
+// and reuses the model's lm_head.
 type MTPHead struct {
 	Enorm *nn.RMSNorm
 	Hnorm *nn.RMSNorm
@@ -1215,27 +1215,35 @@ func (m *Model) Unembed(x *mlx.Array) *mlx.Array {
 	return m.LMHead.Forward(x)
 }
 
-// DraftCaches returns the MTP head's KV caches: the trailing slots NewCaches
-// appended after the per-layer caches.
-func (m *Model) DraftCaches(caches []cache.Cache) []cache.Cache {
+// mtpDraft is the model viewed as its own draft: the same struct, carrying
+// the DraftModel method set for the inline MTP head.
+type mtpDraft Model
+
+// NewCaches builds the MTP head's KV cache.
+func (m *mtpDraft) NewCaches() []cache.Cache {
 	if m.MTP == nil {
 		return nil
 	}
-	return caches[len(m.Layers):]
+	return []cache.Cache{cache.NewKVCache()}
 }
 
-// SelfDraft returns the model as its own draft when an MTP head loaded, else
-// nil; Draft exists either way, so availability is reported here.
+// LoadWeights does nothing: an inline head's weights load with the target's.
+func (m *mtpDraft) LoadWeights(map[string]*mlx.Array) error { return nil }
+
+func (m *mtpDraft) Unembed(x *mlx.Array) *mlx.Array { return (*Model)(m).Unembed(x) }
+
+// SelfDraft returns the model's drafting view, or nil when no MTP head was
+// loaded. The methods exist either way, so this is what decides availability.
 func (m *Model) SelfDraft() base.DraftModel {
 	if m.MTP == nil {
 		return nil
 	}
-	return m
+	return (*mtpDraft)(m)
 }
 
-// Draft runs one MTP step; the head's hidden also serves as the aux
+// Forward runs one MTP step; the head's hidden also serves as the aux
 // hidden seeding the next step.
-func (m *Model) Draft(b *batch.Batch, caches []cache.Cache) (hidden, auxHidden *mlx.Array) {
+func (m *mtpDraft) Forward(b *batch.Batch, _, draftCaches []cache.Cache) (hidden, auxHidden *mlx.Array) {
 	dims := b.InputIDs.Dims()
 	B, L := int32(dims[0]), int32(dims[1])
 	positions := mlx.FromValues(b.SeqOffsets, len(b.SeqOffsets))
@@ -1244,8 +1252,7 @@ func (m *Model) Draft(b *batch.Batch, caches []cache.Cache) (hidden, auxHidden *
 	h := m.MTP.Hnorm.Forward(b.Hidden, m.RMSNormEps)
 	fused := m.MTP.FC.Forward(emb.Concatenate(-1, h))
 
-	c := m.DraftCaches(caches)[0]
-	out := m.MTP.Layer.Forward(fused, b, c, positions, B, L, m.Config)
+	out := m.MTP.Layer.Forward(fused, b, draftCaches[0], positions, B, L, m.Config)
 	hidden = m.MTP.Norm.Forward(out, m.RMSNormEps)
 	return hidden, hidden
 }
@@ -1263,8 +1270,7 @@ func (m *Model) Tokenizer() *tokenizer.Tokenizer {
 }
 
 func (m *Model) NewCaches() []cache.Cache {
-	// Reserve a trailing slot for the MTP head's KV cache when present.
-	caches := make([]cache.Cache, len(m.Layers), len(m.Layers)+1)
+	caches := make([]cache.Cache, len(m.Layers))
 	convTail := m.LinearConvKernelDim - 1
 	convDim := 2*m.LinearNumKeyHeads*m.LinearKeyHeadDim + m.LinearNumValueHeads*m.LinearValueHeadDim
 	for i, layer := range m.Layers {
@@ -1273,10 +1279,6 @@ func (m *Model) NewCaches() []cache.Cache {
 		} else {
 			caches[i] = cache.NewKVCache()
 		}
-	}
-	// Trailing slot is the MTP head's (DraftCaches); Model.Forward never touches it.
-	if m.MTP != nil {
-		caches = append(caches, cache.NewKVCache())
 	}
 	return caches
 }

--- a/x/models/qwen3_5/qwen3_5.go
+++ b/x/models/qwen3_5/qwen3_5.go
@@ -1194,7 +1194,7 @@ func (l *Layer) Forward(x *mlx.Array, b *batch.Batch, c cache.Cache, positions *
 	return mlx.Add(h, r)
 }
 
-func (m *Model) Forward(b *batch.Batch, caches []cache.Cache) *mlx.Array {
+func (m *Model) Forward(b *batch.Batch, caches []cache.Cache) (hidden, auxHidden *mlx.Array) {
 	dims := b.InputIDs.Dims()
 	B, L := int32(dims[0]), int32(dims[1])
 	positions := mlx.FromValues(b.SeqOffsets, len(b.SeqOffsets))
@@ -1208,7 +1208,7 @@ func (m *Model) Forward(b *batch.Batch, caches []cache.Cache) *mlx.Array {
 		h = layer.Forward(h, b, c, positions, B, L, m.Config)
 	}
 	out := m.Norm.Forward(h, m.RMSNormEps)
-	return out
+	return out, out
 }
 
 func (m *Model) Unembed(x *mlx.Array) *mlx.Array {
@@ -1233,9 +1233,9 @@ func (m *Model) SelfDraft() base.DraftModel {
 	return m
 }
 
-// Draft runs one MTP step; the head's hidden also serves as the projected
+// Draft runs one MTP step; the head's hidden also serves as the aux
 // hidden seeding the next step.
-func (m *Model) Draft(b *batch.Batch, caches []cache.Cache) (hidden, projected *mlx.Array) {
+func (m *Model) Draft(b *batch.Batch, caches []cache.Cache) (hidden, auxHidden *mlx.Array) {
 	dims := b.InputIDs.Dims()
 	B, L := int32(dims[0]), int32(dims[1])
 	positions := mlx.FromValues(b.SeqOffsets, len(b.SeqOffsets))


### PR DESCRIPTION
DFlash is a draft model that proposes a whole block of tokens in one forward pass, attending over hidden states tapped from several target layers. It has no embedding table or output head of its own — it borrows the target's.

- `x/models/dflash`: the draft model. A manifest can pair any draft with any target; a bad pairing fails at load.
- The runner gets a second drafting session for block proposals, alongside the existing one-token-per-call MTP chain. Rollback and adaptive depth reuse the existing speculative machinery.
- Groundwork: model `Forward` returns the draft-conditioning state, and each model declares its own cache slots instead of the engine recovering them by identity.

Laguna is the first wired target; other models are unchanged. Matched nvfp4 pairs, M5 Max, temp 0.8, adaptive depth; decode tok/s:

| model     |        | prose | code  | edit  |
|-----------|--------|-------|-------|-------|
| laguna-xs | plain  | 139.4 | 139.7 | 137.3 |
|           | DFlash | 142.3 | 139.2 | 145.1 |
| laguna-s  | plain  | 75.4  | 70.0  | 72.4  |
|           | DFlash | 74.6  | 80.8  | 115.3 |

The speedup depends on how often the target accepts drafted tokens. Acceptance is high on repetitive text like code edits (+59% on laguna-s) and low on prose, where the depth controller shrinks the draft length to zero and decode runs at plain speed — DFlash never makes decode slower than not having it.