### PR TITLE
cmd/bench: truncate output files before writing

### DIFF
--- a/cmd/bench/bench.go
+++ b/cmd/bench/bench.go
@@ -282,7 +282,7 @@ func BenchmarkModel(fOpt flagOptions) error {
 
 	var out io.Writer = os.Stdout
 	if fOpt.outputFile != nil && *fOpt.outputFile != "" {
-		f, err := os.OpenFile(*fOpt.outputFile, os.O_CREATE|os.O_WRONLY, 0o644)
+		f, err := os.OpenFile(*fOpt.outputFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "ERROR: cannot open output file %s: %v\n", *fOpt.outputFile, err)
 			return err

--- a/cmd/bench/bench_test.go
+++ b/cmd/bench/bench_test.go
@@ -191,6 +191,35 @@ func TestBenchmarkModel_Success(t *testing.T) {
 	}
 }
 
+func TestBenchmarkModel_TruncatesOutputFile(t *testing.T) {
+	fOpt := createTestFlagOptions()
+	outputFile := t.TempDir() + "/results.bench"
+	fOpt.outputFile = &outputFile
+
+	const stale = "stale output from a previous benchmark"
+	if err := os.WriteFile(outputFile, []byte(strings.Repeat(stale, 1024)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	server := createMockOllamaServer(t, mockServerOptions{
+		generateResponses: defaultGenerateResponses(),
+	})
+	defer server.Close()
+	t.Setenv("OLLAMA_HOST", server.URL)
+
+	if err := BenchmarkModel(fOpt); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(outputFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(got), stale) {
+		t.Fatal("output file retained data from the previous benchmark")
+	}
+}
+
 func TestBenchmarkModel_ServerError(t *testing.T) {
 	fOpt := createTestFlagOptions()
 


### PR DESCRIPTION
## Problem

`ollama-bench -output` opens an existing destination with `O_CREATE|O_WRONLY`.
When a later benchmark writes fewer bytes than the previous run, the old tail
remains in the file. This can leave invalid CSV or benchstat data even though
the latest run completed successfully.

## Change

- Truncate an existing output file before writing the new benchmark results.
- Add a regression test that starts with a longer stale file and verifies that
  no previous-run data remains.

The change only affects explicit `-output` destinations. Standard output and
benchmark formatting are unchanged.

## Verification

- Before the fix:
  `go test ./cmd/bench -run '^TestBenchmarkModel_TruncatesOutputFile$' -count=1`
  fails with `output file retained data from the previous benchmark`.
- After the fix:
  - `go test ./cmd/bench -count=1`
  - `go test -race ./cmd/bench -run '^TestBenchmarkModel_TruncatesOutputFile$' -count=1`
  - `go vet ./cmd/bench`
  - `git diff --check`
