### PR TITLE
server: isolate model messages from chat requests

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -2519,7 +2519,7 @@ func (s *Server) ChatHandler(c *gin.Context) {
 
 		var msgs []api.Message
 		if len(req.Messages) > 0 {
-			msgs = append(m.Messages, req.Messages...)
+			msgs = mergeModelMessages(m.Messages, req.Messages)
 			if req.Messages[0].Role != "system" && m.System != "" {
 				msgs = append([]api.Message{{Role: "system", Content: m.System}}, msgs...)
 			}
@@ -2630,7 +2630,7 @@ func (s *Server) ChatHandler(c *gin.Context) {
 		return
 	}
 
-	msgs := append(m.Messages, req.Messages...)
+	msgs := mergeModelMessages(m.Messages, req.Messages)
 	if req.Messages[0].Role != "system" && m.System != "" {
 		msgs = append([]api.Message{{Role: "system", Content: m.System}}, msgs...)
 	}
@@ -3115,4 +3115,8 @@ func filterThinkTags(msgs []api.Message, m *Model) []api.Message {
 		}
 	}
 	return msgs
+}
+
+func mergeModelMessages(modelMessages, requestMessages []api.Message) []api.Message {
+	return append(slices.Clone(modelMessages), requestMessages...)
 }

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -988,6 +988,19 @@ func TestNormalize(t *testing.T) {
 	}
 }
 
+func TestMergeModelMessagesDoesNotAliasModel(t *testing.T) {
+	modelMessages := make([]api.Message, 1, 2)
+	modelMessages[0] = api.Message{Role: "assistant", Content: "model content"}
+	requestMessages := []api.Message{{Role: "user", Content: "request content"}}
+
+	merged := mergeModelMessages(modelMessages, requestMessages)
+	merged[0].Content = "mutated"
+
+	if got := modelMessages[0].Content; got != "model content" {
+		t.Fatalf("model message was mutated through merged slice: %q", got)
+	}
+}
+
 func TestFilterThinkTags(t *testing.T) {
 	type testCase struct {
 		msgs  []api.Message


### PR DESCRIPTION
## Problem

`ChatHandler` appends request history directly to `m.Messages`. If the model
message slice has spare capacity, the merged slice shares the model's backing
array. `filterThinkTags` then edits assistant messages in place, so handling
one request can permanently mutate the model-defined messages used by later
requests.

The same append pattern is used by local and remote chat paths.

## Change

- Clone model-defined messages before appending request messages.
- Use the same merge helper in both chat paths.
- Add a regression test with spare slice capacity that verifies mutations to
  the merged history cannot reach the model messages.

Request messages and filtering behavior are otherwise unchanged.

## Verification

- Before the fix:
  `go test ./server -run '^TestMergeModelMessagesDoesNotAliasModel$' -count=1`
  fails because the model message changes to `"mutated"`.
- After the fix:
  - `go test ./server -count=1`
  - `go test -race ./server -run '^(TestMergeModelMessagesDoesNotAliasModel|TestFilterThinkTags)$' -count=1`
  - `go vet ./server`
  - `git diff --check`
