### PR TITLE
app/server: isolate inference log polling snapshots

### DIFF
--- a/app/server/server.go
+++ b/app/server/server.go
@@ -364,10 +364,13 @@ func GetInferenceInfo(ctx context.Context) (*InferenceInfo, error) {
 		file, err := os.Open(serverLogPath)
 		if err != nil {
 			slog.Debug("failed to open server log", "log", serverLogPath, "error", err)
-			time.Sleep(time.Second)
+			select {
+			case <-ctx.Done():
+				return nil, fmt.Errorf("timeout scanning server log for inference compute details")
+			case <-time.After(time.Second):
+			}
 			continue
 		}
-		defer file.Close()
 		scanner := bufio.NewScanner(file)
 		for scanner.Scan() {
 			line := scanner.Text()
@@ -396,14 +399,29 @@ func GetInferenceInfo(ctx context.Context) (*InferenceInfo, error) {
 						slog.Info("Matched default context length", "default_num_ctx", numCtx)
 					}
 				}
+				file.Close()
 				return info, nil
 			}
 			// If we've found compute info but hit a non-matching line, return what we have
 			// This handles older server versions that don't log the default context line
 			if len(info.Computes) > 0 {
+				file.Close()
 				return info, nil
 			}
 		}
-		time.Sleep(100 * time.Millisecond)
+		scanErr := scanner.Err()
+		file.Close()
+		if scanErr != nil {
+			return nil, scanErr
+		}
+
+		// The log may still be mid-write. Rescan it as a fresh snapshot so
+		// entries from an incomplete pass are not duplicated.
+		info = &InferenceInfo{}
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("timeout scanning server log for inference compute details")
+		case <-time.After(100 * time.Millisecond):
+		}
 	}
 }

--- a/app/server/server_test.go
+++ b/app/server/server_test.go
@@ -398,3 +398,32 @@ func TestGetInferenceInfoTimeout(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 }
+
+func TestGetInferenceInfoDoesNotDuplicateDevicesWhilePolling(t *testing.T) {
+	tmpDir := t.TempDir()
+	serverLogPath = filepath.Join(tmpDir, "server.log")
+	logLine := `time=2026-08-05T00:00:00Z level=INFO msg="inference compute" library=cpu total="16.0 GiB"` + "\n"
+	if err := os.WriteFile(serverLogPath, []byte(logLine), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	go func() {
+		time.Sleep(250 * time.Millisecond)
+		f, err := os.OpenFile(serverLogPath, os.O_APPEND|os.O_WRONLY, 0o644)
+		if err != nil {
+			return
+		}
+		defer f.Close()
+		_, _ = f.WriteString("server startup complete\n")
+	}()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	info, err := GetInferenceInfo(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := len(info.Computes); got != 1 {
+		t.Fatalf("compute count = %d, want 1: %#v", got, info.Computes)
+	}
+}


### PR DESCRIPTION
## Problem

`GetInferenceInfo` repeatedly rescans the complete server log while startup is
still writing it. Results from incomplete scans are retained, so an
`inference compute` line at the current end of the file is appended again on
every poll. When the next log line arrives, callers receive duplicate devices.

Each poll also defers closing its log file until the function returns, keeping
all intermediate file handles open.

## Change

- Treat every incomplete log scan as a fresh snapshot.
- Close the log file immediately after each scan.
- Make both polling delays return promptly when the context ends.
- Add a regression test that writes the startup log in two stages.

Completed log parsing and the older-server fallback remain unchanged.

## Verification

- Before the fix:
  `go test ./app/server -run '^TestGetInferenceInfoDoesNotDuplicateDevicesWhilePolling$' -count=1`
  returns four copies of one CPU device.
- After the fix:
  - `go test ./app/server -count=1`
  - `go test -race ./app/server -run '^TestGetInferenceInfo' -count=1`
  - `go vet ./app/server`
  - `git diff --check`
