### PR TITLE
app: stop server waits when context is canceled

### DIFF
--- a/app/ui/ui.go
+++ b/app/ui/ui.go
@@ -414,19 +414,31 @@ func (s *Server) UserData(ctx context.Context) (*api.UserResponse, error) {
 
 // WaitForServer waits for the Ollama server to be ready
 func WaitForServer(ctx context.Context, timeout time.Duration) error {
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
 		c, err := api.ClientFromEnvironment()
 		if err != nil {
 			return err
 		}
-		if _, err := c.Version(ctx); err == nil {
+		if _, err := c.Version(waitCtx); err == nil {
 			slog.Debug("ollama server is ready")
 			return nil
 		}
-		time.Sleep(10 * time.Millisecond)
+
+		select {
+		case <-waitCtx.Done():
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			return errors.New("timeout waiting for Ollama server to be ready")
+		case <-ticker.C:
+		}
 	}
-	return errors.New("timeout waiting for Ollama server to be ready")
 }
 
 func (s *Server) createChat(w http.ResponseWriter, r *http.Request) error {

--- a/app/ui/ui_test.go
+++ b/app/ui/ui_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -14,6 +15,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/app/store"
@@ -525,6 +527,25 @@ func TestUserAgentTransport(t *testing.T) {
 	}
 
 	t.Logf("User-Agent transport successfully set: %s", receivedUA)
+}
+
+func TestWaitForServerReturnsWhenContextIsCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- WaitForServer(ctx, time.Second)
+	}()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("WaitForServer() error = %v, want context.Canceled", err)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("WaitForServer did not return after context cancellation")
+	}
 }
 
 func TestInferenceClientUsesUserAgent(t *testing.T) {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -11,15 +11,21 @@ import (
 )
 
 func waitForServer(ctx context.Context, client *api.Client) error {
-	// wait for the server to start
-	timeout := time.After(5 * time.Second)
-	tick := time.Tick(500 * time.Millisecond)
+	waitCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
 	for {
 		select {
-		case <-timeout:
+		case <-waitCtx.Done():
+			if err := ctx.Err(); err != nil {
+				return err
+			}
 			return errors.New("timed out waiting for server to start")
-		case <-tick:
-			if err := client.Heartbeat(ctx); err == nil {
+		case <-ticker.C:
+			if err := client.Heartbeat(waitCtx); err == nil {
 				return nil // server has started
 			}
 		}

--- a/cmd/start_test.go
+++ b/cmd/start_test.go
@@ -1,0 +1,36 @@
+//go:build darwin || windows
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ollama/ollama/api"
+)
+
+func TestWaitForServerReturnsWhenContextIsCanceled(t *testing.T) {
+	client, err := api.ClientFromEnvironment()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- waitForServer(ctx, client)
+	}()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("waitForServer() error = %v, want context.Canceled", err)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("waitForServer did not return after context cancellation")
+	}
+}


### PR DESCRIPTION
## Problem

The desktop startup readiness loops accept a caller context but do not observe
its cancellation while polling:

- `cmd.waitForServer` continues until its fixed five-second timeout.
- `app/ui.WaitForServer` continues until its supplied timeout.

This delays canceled startup and request flows, and the command implementation
also uses unmanaged `time.After`/`time.Tick` timers.

## Change

- Combine caller cancellation with the existing fixed timeout using
  `context.WithTimeout`.
- Return the caller's context error when it ends first.
- Preserve the existing user-facing timeout errors when the internal deadline
  ends first.
- Replace polling timers with stoppable tickers.
- Add cancellation regression tests for both implementations.

## Verification

Before the fix, both targeted tests fail after 100ms because the functions are
still waiting:

- `go test ./cmd -run '^TestWaitForServerReturnsWhenContextIsCanceled$' -count=1`
- `go test ./app/ui -run '^TestWaitForServerReturnsWhenContextIsCanceled$' -count=1`

After the fix:

- `go test ./cmd -count=1`
- `go test ./app/ui -count=1`
- `go test -race ./cmd ./app/ui -run '^TestWaitForServerReturnsWhenContextIsCanceled$' -count=1`
- `go vet ./cmd ./app/ui`
- `git diff --check`

The UI embed prerequisite was generated with `npm ci && npm run build`; generated
assets are ignored and are not part of this change.
