### PR TITLE
app/ui: stop recreating image thumbnail blob URLs on every render

### DIFF
--- a/app/ui/app/src/components/ChatForm.tsx
+++ b/app/ui/app/src/components/ChatForm.tsx
@@ -34,6 +34,11 @@ import { PlusIcon } from "@heroicons/react/24/outline";
 
 export type ThinkingLevel = "low" | "medium" | "high";
 
+// Stable placeholder so attachments without data don't produce a new
+// Uint8Array on every render, which would retrigger ImageThumbnail's
+// blob URL effect each time.
+const EMPTY_BYTES = new Uint8Array(0);
+
 interface FileAttachment {
   filename: string;
   data: Uint8Array;
@@ -754,7 +759,7 @@ function ChatForm({
                   <ImageThumbnail
                     image={{
                       filename: attachment.filename,
-                      data: attachment.data || new Uint8Array(0),
+                      data: attachment.data || EMPTY_BYTES,
                     }}
                     className="w-8 h-8 object-cover rounded-md flex-shrink-0"
                   />

--- a/app/ui/app/src/components/ImageThumbnail.tsx
+++ b/app/ui/app/src/components/ImageThumbnail.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { isImageFile } from "@/utils/imageUtils";
 
 export interface ImageData {
@@ -14,6 +14,61 @@ interface ImageThumbnailProps {
   onError?: () => void;
 }
 
+function buildImageUrl(filename: string, data: ImageData["data"]): string {
+  if (!isImageFile(filename)) return "";
+
+  try {
+    // Determine MIME type from file extension
+    const extension = filename.toLowerCase().split(".").pop();
+    let mimeType = "application/octet-stream";
+
+    switch (extension) {
+      case "png":
+        mimeType = "image/png";
+        break;
+      case "jpg":
+      case "jpeg":
+        mimeType = "image/jpeg";
+        break;
+      case "gif":
+        mimeType = "image/gif";
+        break;
+      case "webp":
+        mimeType = "image/webp";
+        break;
+    }
+
+    // Convert to Uint8Array if needed
+    let bytes: Uint8Array;
+    if (data instanceof Uint8Array) {
+      bytes = data;
+    } else if (Array.isArray(data)) {
+      bytes = new Uint8Array(data);
+    } else if (typeof data === "string") {
+      // Convert base64 string to Uint8Array
+      const binaryString = atob(data);
+      bytes = new Uint8Array(binaryString.length);
+      for (let i = 0; i < binaryString.length; i++) {
+        bytes[i] = binaryString.charCodeAt(i);
+      }
+    } else {
+      console.error("Invalid data format for:", filename, typeof data);
+      return "";
+    }
+
+    const blob = new Blob([bytes], { type: mimeType });
+    return URL.createObjectURL(blob);
+  } catch (error) {
+    console.error(
+      "Error converting file data to URL for",
+      filename,
+      ":",
+      error,
+    );
+    return "";
+  }
+}
+
 export function ImageThumbnail({
   image,
   className = "w-16 h-16 object-cover rounded-md select-none",
@@ -21,75 +76,23 @@ export function ImageThumbnail({
   onError,
 }: ImageThumbnailProps) {
   const [imageLoadError, setImageLoadError] = useState(false);
+  const [imageUrl, setImageUrl] = useState("");
 
-  const imageUrl = useMemo(() => {
-    if (!isImageFile(image.filename)) return "";
-
-    try {
-      // Determine MIME type from file extension
-      const extension = image.filename.toLowerCase().split(".").pop();
-      let mimeType = "application/octet-stream";
-
-      switch (extension) {
-        case "png":
-          mimeType = "image/png";
-          break;
-        case "jpg":
-        case "jpeg":
-          mimeType = "image/jpeg";
-          break;
-        case "gif":
-          mimeType = "image/gif";
-          break;
-        case "webp":
-          mimeType = "image/webp";
-          break;
-      }
-
-      // Convert to Uint8Array if needed
-      let bytes: Uint8Array;
-      if (image.data instanceof Uint8Array) {
-        bytes = image.data;
-      } else if (Array.isArray(image.data)) {
-        bytes = new Uint8Array(image.data);
-      } else if (typeof image.data === "string") {
-        // Convert base64 string to Uint8Array
-        const binaryString = atob(image.data);
-        bytes = new Uint8Array(binaryString.length);
-        for (let i = 0; i < binaryString.length; i++) {
-          bytes[i] = binaryString.charCodeAt(i);
-        }
-      } else {
-        console.error(
-          "Invalid data format for:",
-          image.filename,
-          typeof image.data,
-        );
-        return "";
-      }
-
-      const blob = new Blob([bytes], { type: mimeType });
-      return URL.createObjectURL(blob);
-    } catch (error) {
-      console.error(
-        "Error converting file data to URL for",
-        image.filename,
-        ":",
-        error,
-      );
-      return "";
-    }
-  }, [image]);
-
-  // Cleanup blob URL on unmount and reset error state when image changes
+  // Create the blob URL in an effect keyed on the image fields rather than
+  // object identity: callers may build a fresh `image` object on every
+  // render, and recreating the URL each render forces the <img> to re-decode
+  // on each keystroke (#17540). An effect (unlike useMemo) also revokes and
+  // recreates the URL correctly under StrictMode's remount cycle.
   useEffect(() => {
+    const url = buildImageUrl(image.filename, image.data);
+    setImageUrl(url);
     setImageLoadError(false);
     return () => {
-      if (imageUrl) {
-        URL.revokeObjectURL(imageUrl);
+      if (url) {
+        URL.revokeObjectURL(url);
       }
     };
-  }, [imageUrl]);
+  }, [image.filename, image.data]);
 
   if (!isImageFile(image.filename) || !imageUrl) {
     return null;


### PR DESCRIPTION
When one or more images are attached in the chat form, typing becomes increasingly slow (#17540). Each keystroke re-copies every attached image into a new Blob, creates a new object URL, revokes the previous one, and forces the thumbnail `<img>` to re-decode.

Root cause: `ImageThumbnail` memoizes its blob URL on the identity of the `image` prop, but `ChatForm` builds a fresh `image` object literal on every render, so the memo never holds while typing re-renders the form.

This keys the URL on the image fields instead, and moves creation/revocation into a single effect so the URL also stays valid through StrictMode's remount cycle (revoking a memoized URL in an effect cleanup leaves a dead URL in the rendered `<img>`). `ChatForm`'s empty-data placeholder is hoisted to a stable constant for the same reason.

**Validation** (dev UI, 1.2 MB PNG attached, typing 23 characters, `URL.createObjectURL`/`revokeObjectURL` instrumented):

- before: 5,730 `createObjectURL` calls while typing; any re-render with an attachment recreated the URL and re-decoded the image
- after: 0 calls while typing or idle; thumbnails still render, and the error-fallback and revoke-on-unmount behavior is unchanged

`vitest` (27 tests), `eslint` (no new warnings), and `tsc -b && vite build` pass.

Fixes #17540