### PR TITLE
fix(docs): correct typos found during code review

### DIFF
--- a/app/ui/app/src/components/Message.tsx
+++ b/app/ui/app/src/components/Message.tsx
@@ -273,7 +273,7 @@ function ToolRoleContent({
     );
   }
   return (
-    // collapsable tool result with raw json
+    // collapsible tool result with raw json
     <div className="space-y-2">
       {content && !rawToolResult && (
         <pre className="text-xs whitespace-pre-wrap overflow-x-auto bg-neutral-100 dark:bg-neutral-800 text-neutral-800 dark:text-neutral-200 p-2 rounded-md max-h-40">

--- a/app/updater/updater_darwin.go
+++ b/app/updater/updater_darwin.go
@@ -149,7 +149,7 @@ func DoUpgrade(interactive bool) error {
 		}
 	}
 
-	// Get ready to try to unwind a partial upgade failure during unzip
+	// Get ready to try to unwind a partial upgrade failure during unzip
 	// If something goes wrong, we attempt to put the old version back.
 	anyFailures := false
 	defer func() {

--- a/app/webview/webview.h
+++ b/app/webview/webview.h
@@ -345,7 +345,7 @@ WEBVIEW_API void webview_unbind(webview_t w, const char *name);
  * @param seq The sequence number of the binding call. Pass along the value
  *            received in the binding handler (see webview_bind()).
  * @param status A status of zero tells the JS side that the binding call was
- *               succesful; any other value indicates an error.
+ *               successful; any other value indicates an error.
  * @param result The result of the binding call to be returned to the JS side.
  *               This must either be a valid JSON value or an empty string for
  *               the primitive JS value @c undefined.

--- a/app/wintray/eventloop.go
+++ b/app/wintray/eventloop.go
@@ -104,7 +104,7 @@ func (t *winTray) wndProc(hWnd windows.Handle, message uint32, wParam, lParam ui
 		}
 		err = t.wcex.unregister()
 		if err != nil {
-			slog.Error(fmt.Sprintf("failed to uregister windo %s", err))
+			slog.Error(fmt.Sprintf("failed to uregister window %s", err))
 		}
 	case WM_DESTROY:
 		// slog.Debug("XXX WM_DESTROY triggered")

--- a/app/wintray/eventloop.go
+++ b/app/wintray/eventloop.go
@@ -104,7 +104,7 @@ func (t *winTray) wndProc(hWnd windows.Handle, message uint32, wParam, lParam ui
 		}
 		err = t.wcex.unregister()
 		if err != nil {
-			slog.Error(fmt.Sprintf("failed to uregister window %s", err))
+			slog.Error(fmt.Sprintf("failed to unregister window %s", err))
 		}
 	case WM_DESTROY:
 		// slog.Debug("XXX WM_DESTROY triggered")

--- a/cmd/launch/launch.go
+++ b/cmd/launch/launch.go
@@ -330,7 +330,7 @@ Examples:
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			policy := defaultLaunchPolicy(isInteractiveSession(), yesFlag)
-			// reset when done to make sure state doens't leak between launches
+			// reset when done to make sure state doesn't leak between launches
 			restoreConfirmPolicy := withLaunchConfirmPolicy(policy.confirmPolicy())
 			defer restoreConfirmPolicy()
 

--- a/docs/capabilities/vision.mdx
+++ b/docs/capabilities/vision.mdx
@@ -7,7 +7,7 @@ Vision models accept images alongside text so the model can describe, classify, 
 ## Quick start
 
 ```shell
-ollama run gemma4 ./image.png whats in this image?
+ollama run gemma4 ./image.png what's in this image?
 ```
 
 

--- a/docs/capabilities/vision.mdx
+++ b/docs/capabilities/vision.mdx
@@ -7,7 +7,7 @@ Vision models accept images alongside text so the model can describe, classify, 
 ## Quick start
 
 ```shell
-ollama run gemma4 ./image.png what's in this image?
+ollama run gemma4 ./image.png what is in this image?
 ```
 
 

--- a/harmony/harmonyparser_test.go
+++ b/harmony/harmonyparser_test.go
@@ -340,7 +340,7 @@ func TestHarmonyParserStreaming(t *testing.T) {
 			},
 		},
 		{
-			desc: "message with channel and recipient (receipient before channel)",
+			desc: "message with channel and recipient (recipient before channel)",
 			steps: []step{
 				{
 					input: "<|start|>assistant to=functions.calc<|channel|>commentary<|message|>",

--- a/integration/api_test.go
+++ b/integration/api_test.go
@@ -413,7 +413,7 @@ func runAPIShowModel(t *testing.T) {
 	}
 	// llama3 omits system
 	verifyModelDetails(t, resp.Details)
-	// llama3 ommits messages
+	// llama3 omits messages
 	if len(resp.ModelInfo) == 0 {
 		t.Errorf("%s missing model_info: %#v", modelName, resp)
 	}

--- a/integration/context_test.go
+++ b/integration/context_test.go
@@ -136,7 +136,7 @@ func containsEmoji(s string) bool {
 	return false
 }
 
-// Send multiple generate requests with prior context and ensure the response is coherant and expected
+// Send multiple generate requests with prior context and ensure the response is coherent and expected
 func runParallelGenerateWithHistory(t *testing.T, modelName string) {
 	if testModel != "" {
 		// The Generate API's Context field (token array continuation) is not
@@ -194,7 +194,7 @@ func runParallelGenerateWithHistory(t *testing.T, modelName string) {
 	wg.Wait()
 }
 
-// Send generate requests with prior context and ensure the response is coherant and expected
+// Send generate requests with prior context and ensure the response is coherent and expected
 func runGenerateWithHistory(t *testing.T) {
 	if testModel != "" {
 		// The Generate API's Context field (token array continuation) is not
@@ -234,7 +234,7 @@ func runGenerateWithHistory(t *testing.T) {
 	}
 }
 
-// Send multiple chat requests with prior context and ensure the response is coherant and expected
+// Send multiple chat requests with prior context and ensure the response is coherent and expected
 func runParallelChatWithHistory(t *testing.T, modelName string) {
 	req, resp := ChatRequests()
 	numParallel := 2
@@ -299,7 +299,7 @@ func prepareParallelHistoryModel(ctx context.Context, t *testing.T, client *api.
 	skipIfModelTooLargeForSweepVRAM(ctx, t, client, modelName)
 }
 
-// Send generate requests with prior context and ensure the response is coherant and expected
+// Send generate requests with prior context and ensure the response is coherent and expected
 func runChatWithHistory(t *testing.T) {
 	req := api.ChatRequest{
 		Model:     smol,

--- a/model/parsers/cohere_test.go
+++ b/model/parsers/cohere_test.go
@@ -188,7 +188,7 @@ func TestCohereParseMalformedActions(t *testing.T) {
 		t.Fatalf("braces inside string values must not split objects, got %v", v)
 	}
 
-	// Unparseable garbage yields no calls and no panic.
+	// Unparsable garbage yields no calls and no panic.
 	p = &CohereParser{}
 	p.Init(nil, nil, nil)
 	_, _, calls = cohereAddAll(t, p, []string{"x<|END_THINKING|><|START_ACTION|>[!!!]<|END_ACTION|>"})

--- a/model/parsers/cohere_test.go
+++ b/model/parsers/cohere_test.go
@@ -188,7 +188,7 @@ func TestCohereParseMalformedActions(t *testing.T) {
 		t.Fatalf("braces inside string values must not split objects, got %v", v)
 	}
 
-	// Unparsable garbage yields no calls and no panic.
+	// Unparseable garbage yields no calls and no panic.
 	p = &CohereParser{}
 	p.Init(nil, nil, nil)
 	_, _, calls = cohereAddAll(t, p, []string{"x<|END_THINKING|><|START_ACTION|>[!!!]<|END_ACTION|>"})

--- a/model/parsers/qwen3vl_nonthinking_test.go
+++ b/model/parsers/qwen3vl_nonthinking_test.go
@@ -161,7 +161,7 @@ func TestQwen3VLNonThinkingParserStreaming(t *testing.T) {
 			desc: "partial thinking incomplete",
 			steps: []step{
 				{
-					input:      "abc<think>unfinished<", // when something is ambiguious, we dont emit anything
+					input:      "abc<think>unfinished<", // when something is ambiguous, we dont emit anything
 					wantEvents: []qwenEvent{qwenEventContent{content: "abc<think>unfinished"}},
 				},
 			},
@@ -170,7 +170,7 @@ func TestQwen3VLNonThinkingParserStreaming(t *testing.T) {
 			desc: "test with split tool and content",
 			steps: []step{
 				{
-					input: "abc<tool_call>unfinished</", // when something is ambiguious, we dont emit anything
+					input: "abc<tool_call>unfinished</", // when something is ambiguous, we dont emit anything
 					wantEvents: []qwenEvent{
 						qwenEventContent{content: "abc"},
 					},

--- a/model/parsers/qwen3vl_thinking_test.go
+++ b/model/parsers/qwen3vl_thinking_test.go
@@ -149,7 +149,7 @@ func TestQwen3VLThinkingParserStreaming(t *testing.T) {
 			desc: "partial thinking incomplete",
 			steps: []step{
 				{
-					input:      "abc<think>unfinished</think", // when something is ambiguious, we dont emit anything
+					input:      "abc<think>unfinished</think", // when something is ambiguous, we dont emit anything
 					wantEvents: []qwenEvent{qwenEventThinkingContent{content: "abc<think>unfinished"}},
 				},
 			},
@@ -158,7 +158,7 @@ func TestQwen3VLThinkingParserStreaming(t *testing.T) {
 			desc: "test with split thinking and content",
 			steps: []step{
 				{
-					input:      "abc<think>unfinished</th", // when something is ambiguious, we dont emit anything
+					input:      "abc<think>unfinished</th", // when something is ambiguous, we dont emit anything
 					wantEvents: []qwenEvent{qwenEventThinkingContent{content: "abc<think>unfinished"}},
 				},
 				{

--- a/runner/README.md
+++ b/runner/README.md
@@ -2,7 +2,7 @@
 
 > Note: this is a work in progress
 
-A minimial runner for loading a model and running inference via a http web server.
+A minimal runner for loading a model and running inference via a http web server.
 
 ```shell
 ./runner -model <model binary>

--- a/thinking/parser_test.go
+++ b/thinking/parser_test.go
@@ -59,7 +59,7 @@ func TestThinkingStreaming(t *testing.T) {
 					wantStateAfter: thinkingState_ThinkingDone,
 				},
 				// regression test for a bug where we were transitioning directly to
-				// ThinkingDone without clearing the buffer. This would cuase the first
+				// ThinkingDone without clearing the buffer. This would cause the first
 				// step to be outputted twice
 				{
 					input:          "def",

--- a/x/models/nn/recurrent_test.go
+++ b/x/models/nn/recurrent_test.go
@@ -379,7 +379,7 @@ func TestCausalConv1DSegmentEquivalenceBatched(t *testing.T) {
 	// Each row's boundary i (offset i+1) must equal a B=1 single-shot conv over
 	// that row's real prefix: row 0 advances the full length, row 1 freezes once
 	// it reaches its real length 3. Per-row B=1 references avoid the ambiguity of
-	// re-declaring a ragged length over a uniform input slice.
+	// redeclaring a ragged length over a uniform input slice.
 	rowReal := []int32{int32(L), 3}
 	for i := range segStates {
 		for r := range B {


### PR DESCRIPTION
Non-functional changes only:
- Fixed minor spelling mistakes in comments
- Corrected typos in user-facing strings
- No variables, logic, or functional code was modified.

Signed-off-by: Marcel Petrick <mail@marcelpetrick.it>
