### PR TITLE
server: fail the pull when the registry omits Content-Length

### DIFF
--- a/server/download.go
+++ b/server/download.go
@@ -153,7 +153,15 @@ func (b *blobDownload) Prepare(ctx context.Context, requestURL *url.URL, opts *r
 		}
 		defer resp.Body.Close()
 
-		b.Total, _ = strconv.ParseInt(resp.Header.Get("Content-Length"), 10, 64)
+		// Without a usable Content-Length the loop below creates no parts, so
+		// the download completes instantly and promotes an empty file. That
+		// surfaces later as a digest mismatch, which reads like a corrupt or
+		// tampered blob rather than a registry that did not report a size.
+		contentLength := resp.Header.Get("Content-Length")
+		b.Total, err = strconv.ParseInt(contentLength, 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid Content-Length %q for %s: %w", contentLength, b.Digest[7:19], err)
+		}
 
 		size := b.Total / numDownloadParts
 		switch {

--- a/server/download_test.go
+++ b/server/download_test.go
@@ -111,3 +111,58 @@ func TestDownloadChunkDetectsStallBeforeFirstByte(t *testing.T) {
 		t.Fatalf("downloadChunk() detected the stall after %v, want less than %v", elapsed, 5*downloadStallTimeout)
 	}
 }
+
+func TestPrepareRejectsMissingContentLength(t *testing.T) {
+	data := make([]byte, 512)
+	digest := fmt.Sprintf("sha256:%x", sha256.Sum256(data))
+
+	// A non-numeric Content-Length is not covered here: net/http rejects it in
+	// the transport before Prepare ever sees the header.
+	cases := []struct {
+		name          string
+		contentLength string
+		wantErr       bool
+		wantParts     bool
+	}{
+		{name: "valid", contentLength: fmt.Sprint(len(data)), wantErr: false, wantParts: true},
+		// a genuinely empty blob is still legal and must keep working
+		{name: "zero", contentLength: "0", wantErr: false, wantParts: false},
+		{name: "missing", contentLength: "", wantErr: true},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tt.contentLength != "" {
+					w.Header().Set("Content-Length", tt.contentLength)
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			t.Cleanup(server.Close)
+
+			requestURL, err := url.Parse(server.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			download := &blobDownload{
+				Name:   filepath.Join(t.TempDir(), "blob"),
+				Digest: digest,
+			}
+
+			err = download.Prepare(t.Context(), requestURL, &registryOptions{})
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected an error for an unusable Content-Length, got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if gotParts := len(download.Parts) > 0; gotParts != tt.wantParts {
+				t.Errorf("parts created = %v, want %v (total %d)", gotParts, tt.wantParts, download.Total)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`blobDownload.Prepare` discarded the error from parsing `Content-Length` (server/download.go:156). If a registry or a proxy in front of one answers the HEAD without that header, `b.Total` silently becomes 0, so the part-building loop at :167 never runs and no parts are created. `Prepare` then returns nil, `run` truncates the file to zero, the errgroup has nothing to download, and `os.Rename` promotes an empty file to the blob path while returning success.

The empty blob is caught later by `verifyBlob` (server/images.go:1027), so nothing corrupt gets stored, but the user sees a digest mismatch. That reads like a corrupted or tampered blob when the actual cause is a registry that did not report a size, which sends you looking in entirely the wrong place. This returns the parse error instead, naming the header value it got.

Kept `Content-Length: 0` working, since a genuinely empty blob is still legal and verifies fine. Resumed downloads are unaffected because they take the `len(b.Parts) > 0` path and skip this block entirely.

Verified with a table-driven test in server/download_test.go covering a valid length, a zero length, and a missing header. The missing case fails on main and passes here. `go test ./server/...`, `golangci-lint run server/`, and `go mod tidy` are clean locally.

One note on test coverage, so it is not overstated: I first added a non-numeric `Content-Length` case, then found it passed on main too, because net/http rejects that in the transport before `Prepare` ever sees the header. It was testing the standard library rather than this change, so I dropped it and left a comment saying why.

small disclosure: I'm a college freshman contributing where I can :) Claude Code helped me with this one, and I ran the tests, lint, and the fail-on-main checks myself. Happy to downgrade this to a warning that still proceeds if you would rather a missing header not be fatal.