### PR TITLE
docs: add Scaffold Engine to community integrations (Frameworks & Agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ console.log(response.message.content);
 - [Stakpak](https://github.com/stakpak/agent) - Open source DevOps agent
 - [Hexabot](https://github.com/hexastack/hexabot) - Conversational AI builder
 - [Neuro SAN](https://github.com/cognizant-ai-lab/neuro-san-studio) - Multi-agent orchestration ([docs](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/user_guide.md#ollama))
+- [Scaffold Engine](https://github.com/LocketKeyLLC/scaffold-engine) - Self-hosted agent engine that researches, plans a DAG, and executes with verification
 
 ### RAG & Knowledge Bases
 


### PR DESCRIPTION
Adds [Scaffold Engine](https://github.com/LocketKeyLLC/scaffold-engine) to the Frameworks & Agents section.

It's a self-hosted DAG orchestration engine for multi-step LLM workflows built on Ollama as the inference backend (default `http://localhost:11434`, 7 configurable model roles): give it an idea and it researches the topic, plans an execution DAG, runs each step with verification and auto-retry, and compiles the result. Runs on CPU-only hardware; Docker compose stack with Milvus, Postgres, SearXNG.

One line, matches the existing entry format.