### PR TITLE
launch: add Talos

### DIFF
--- a/cmd/launch/registry.go
+++ b/cmd/launch/registry.go
@@ -33,7 +33,7 @@ type IntegrationInfo struct {
 	Description string
 }
 
-var launcherIntegrationOrder = []string{"claude", "chatgpt", "hermes", "openclaw", "opencode", "hermes-desktop", "codex", "copilot", "omp", "cline", "droid", "pi", "pool", "qwen"}
+var launcherIntegrationOrder = []string{"claude", "chatgpt", "hermes", "openclaw", "opencode", "hermes-desktop", "codex", "copilot", "omp", "cline", "droid", "pi", "pool", "qwen", "talos"}
 
 var integrationSpecs = []*IntegrationSpec{
 	{
@@ -121,6 +121,18 @@ var integrationSpecs = []*IntegrationSpec{
 				return err
 			},
 			URL: "https://moonshotai.github.io/kimi-cli/en/guides/getting-started.html",
+		},
+	},
+	{
+		Name:        "talos",
+		Runner:      &Talos{},
+		Description: "Agent with a deterministic permission kernel",
+		Install: IntegrationInstallSpec{
+			CheckInstalled: func() bool {
+				_, _, err := (&Talos{}).findPath()
+				return err == nil
+			},
+			URL: "https://talos-agent.ch",
 		},
 	},
 	{

--- a/cmd/launch/talos.go
+++ b/cmd/launch/talos.go
@@ -88,7 +88,7 @@ func (t *Talos) Run(model string, _ []LaunchModel, args []string) error {
 func (t *Talos) envVars(model string) []string {
 	env := []string{
 		"TALOS_MODEL_PROVIDER=openai-api",
-		"TALOS_BASE_URL_OPENAI_API=" + envconfig.Host().String() + "/v1",
+		"TALOS_BASE_URL_OPENAI_API=" + envconfig.ConnectableHost().String() + "/v1",
 	}
 
 	if model != "" {

--- a/cmd/launch/talos.go
+++ b/cmd/launch/talos.go
@@ -1,0 +1,99 @@
+package launch
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+
+	"github.com/ollama/ollama/envconfig"
+)
+
+// Talos implements Runner for the Talos agent.
+//
+// Talos ships as a Python package rather than a single binary: its installer creates
+// a virtual environment under ~/talos and the agent is started with `python -m talos`.
+// findPath therefore looks for a `talos` wrapper on PATH first and falls back to that
+// interpreter, and args prepends `-m talos` only in the fallback case.
+type Talos struct{}
+
+func (t *Talos) String() string { return "Talos" }
+
+// defaultPrefix is where the official installer puts Talos unless TALOS_PREFIX says
+// otherwise. It is the only location guessed, and only after PATH has been tried.
+func (t *Talos) defaultPrefix() (string, error) {
+	if prefix := os.Getenv("TALOS_PREFIX"); prefix != "" {
+		return prefix, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "talos"), nil
+}
+
+// findPath returns the executable and whether it is the virtual environment's
+// interpreter (which needs `-m talos` in front of the arguments).
+func (t *Talos) findPath() (string, bool, error) {
+	if p, err := exec.LookPath("talos"); err == nil {
+		return p, false, nil
+	}
+	prefix, err := t.defaultPrefix()
+	if err != nil {
+		return "", false, err
+	}
+	python := filepath.Join(prefix, ".venv", "bin", "python")
+	if runtime.GOOS == "windows" {
+		python = filepath.Join(prefix, ".venv", "Scripts", "python.exe")
+	}
+	if _, err := os.Stat(python); err != nil {
+		return "", false, err
+	}
+	return python, true, nil
+}
+
+func (t *Talos) args(viaPython bool, extra []string) []string {
+	var args []string
+	if viaPython {
+		args = append(args, "-m", "talos")
+	}
+	// `chat` is the interactive session. `ask` answers once and exits, which is not
+	// what launching an assistant means.
+	args = append(args, "chat")
+	return append(args, extra...)
+}
+
+func (t *Talos) Run(model string, _ []LaunchModel, args []string) error {
+	talosPath, viaPython, err := t.findPath()
+	if err != nil {
+		return fmt.Errorf("talos is not installed, install from https://talos-agent.ch")
+	}
+
+	cmd := exec.Command(talosPath, t.args(viaPython, args)...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	cmd.Env = append(os.Environ(), t.envVars(model)...)
+
+	return cmd.Run()
+}
+
+// envVars returns the environment variables that point Talos at Ollama.
+//
+// Talos speaks the OpenAI wire protocol through its `openai-api` provider. Naming the
+// base URL explicitly is also what tells Talos to trust the configured model name: its
+// own catalogue cannot know which models a local server offers.
+func (t *Talos) envVars(model string) []string {
+	env := []string{
+		"TALOS_MODEL_PROVIDER=openai-api",
+		"TALOS_BASE_URL_OPENAI_API=" + envconfig.Host().String() + "/v1",
+	}
+
+	if model != "" {
+		env = append(env, "TALOS_MODEL="+model)
+	}
+
+	return env
+}

--- a/cmd/launch/talos_test.go
+++ b/cmd/launch/talos_test.go
@@ -153,4 +153,15 @@ func TestTalosEnvVars(t *testing.T) {
 			t.Errorf("TALOS_BASE_URL_OPENAI_API = %q, want custom host", got["TALOS_BASE_URL_OPENAI_API"])
 		}
 	})
+
+	t.Run("translates a wildcard bind address to a connectable one", func(t *testing.T) {
+		t.Setenv("OLLAMA_HOST", "http://0.0.0.0:11434")
+		got := envMap(tl.envVars("test"))
+		if strings.Contains(got["TALOS_BASE_URL_OPENAI_API"], "0.0.0.0") {
+			t.Errorf("TALOS_BASE_URL_OPENAI_API = %q, must not pass a wildcard bind address through", got["TALOS_BASE_URL_OPENAI_API"])
+		}
+		if !strings.Contains(got["TALOS_BASE_URL_OPENAI_API"], "127.0.0.1:11434") {
+			t.Errorf("TALOS_BASE_URL_OPENAI_API = %q, want loopback with the same port", got["TALOS_BASE_URL_OPENAI_API"])
+		}
+	})
 }

--- a/cmd/launch/talos_test.go
+++ b/cmd/launch/talos_test.go
@@ -1,0 +1,156 @@
+package launch
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestTalosIntegration(t *testing.T) {
+	tl := &Talos{}
+
+	t.Run("String", func(t *testing.T) {
+		if got := tl.String(); got != "Talos" {
+			t.Errorf("String() = %q, want %q", got, "Talos")
+		}
+	})
+
+	t.Run("implements Runner", func(t *testing.T) {
+		var _ Runner = tl
+	})
+}
+
+func TestTalosFindPath(t *testing.T) {
+	tl := &Talos{}
+
+	t.Run("finds talos in PATH", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		name := "talos"
+		if runtime.GOOS == "windows" {
+			name = "talos.exe"
+		}
+		fakeBin := filepath.Join(tmpDir, name)
+		os.WriteFile(fakeBin, []byte("#!/bin/sh\n"), 0o755)
+		t.Setenv("PATH", tmpDir)
+
+		got, viaPython, err := tl.findPath()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != fakeBin {
+			t.Errorf("findPath() = %q, want %q", got, fakeBin)
+		}
+		if viaPython {
+			t.Error("a wrapper on PATH should not be invoked through -m talos")
+		}
+	})
+
+	t.Run("falls back to the virtual environment under the install prefix", func(t *testing.T) {
+		prefix := t.TempDir()
+		bin := filepath.Join(prefix, ".venv", "bin")
+		name := "python"
+		if runtime.GOOS == "windows" {
+			bin = filepath.Join(prefix, ".venv", "Scripts")
+			name = "python.exe"
+		}
+		if err := os.MkdirAll(bin, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		python := filepath.Join(bin, name)
+		os.WriteFile(python, []byte("#!/bin/sh\n"), 0o755)
+		t.Setenv("TALOS_PREFIX", prefix)
+		t.Setenv("PATH", t.TempDir()) // empty dir, no talos wrapper
+
+		got, viaPython, err := tl.findPath()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != python {
+			t.Errorf("findPath() = %q, want %q", got, python)
+		}
+		if !viaPython {
+			t.Error("the interpreter must be invoked through -m talos")
+		}
+	})
+
+	t.Run("returns error when not installed", func(t *testing.T) {
+		t.Setenv("TALOS_PREFIX", t.TempDir()) // empty prefix, no .venv
+		t.Setenv("PATH", t.TempDir())         // empty dir, no talos wrapper
+
+		if _, _, err := tl.findPath(); err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+}
+
+func TestTalosArgs(t *testing.T) {
+	tl := &Talos{}
+
+	tests := []struct {
+		name      string
+		viaPython bool
+		args      []string
+		want      []string
+	}{
+		{"wrapper on PATH", false, nil, []string{"chat"}},
+		{"through the interpreter", true, nil, []string{"-m", "talos", "chat"}},
+		{"extra args are passed through", false, []string{"--verbose"}, []string{"chat", "--verbose"}},
+		{"interpreter with extra args", true, []string{"--verbose"}, []string{"-m", "talos", "chat", "--verbose"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tl.args(tt.viaPython, tt.args)
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("args(%v, %v) = %v, want %v", tt.viaPython, tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTalosEnvVars(t *testing.T) {
+	tl := &Talos{}
+
+	envMap := func(envs []string) map[string]string {
+		m := make(map[string]string)
+		for _, e := range envs {
+			k, v, _ := strings.Cut(e, "=")
+			m[k] = v
+		}
+		return m
+	}
+
+	t.Run("points Talos at Ollama through its OpenAI-compatible provider", func(t *testing.T) {
+		got := envMap(tl.envVars("llama3.2"))
+		if got["TALOS_MODEL_PROVIDER"] != "openai-api" {
+			t.Errorf("TALOS_MODEL_PROVIDER = %q, want %q", got["TALOS_MODEL_PROVIDER"], "openai-api")
+		}
+		if got["TALOS_BASE_URL_OPENAI_API"] == "" {
+			t.Error("TALOS_BASE_URL_OPENAI_API should be set")
+		}
+		if !strings.HasSuffix(got["TALOS_BASE_URL_OPENAI_API"], "/v1") {
+			t.Errorf("TALOS_BASE_URL_OPENAI_API = %q, want /v1 suffix", got["TALOS_BASE_URL_OPENAI_API"])
+		}
+		if got["TALOS_MODEL"] != "llama3.2" {
+			t.Errorf("TALOS_MODEL = %q, want %q", got["TALOS_MODEL"], "llama3.2")
+		}
+	})
+
+	t.Run("omits TALOS_MODEL when model is empty", func(t *testing.T) {
+		got := envMap(tl.envVars(""))
+		if _, ok := got["TALOS_MODEL"]; ok {
+			t.Errorf("TALOS_MODEL should not be set for empty model, got %q", got["TALOS_MODEL"])
+		}
+	})
+
+	t.Run("uses custom OLLAMA_HOST", func(t *testing.T) {
+		t.Setenv("OLLAMA_HOST", "http://myhost:9999")
+		got := envMap(tl.envVars("test"))
+		if !strings.Contains(got["TALOS_BASE_URL_OPENAI_API"], "myhost:9999") {
+			t.Errorf("TALOS_BASE_URL_OPENAI_API = %q, want custom host", got["TALOS_BASE_URL_OPENAI_API"])
+		}
+	})
+}

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -139,7 +139,8 @@
             "pages": [
               "/integrations/openclaw",
               "/integrations/hermes",
-              "/integrations/hermes-desktop"
+              "/integrations/hermes-desktop",
+              "/integrations/talos"
             ]
           },
           {

--- a/docs/integrations/talos.mdx
+++ b/docs/integrations/talos.mdx
@@ -1,0 +1,63 @@
+---
+title: Talos
+---
+
+Talos is an agent you can hand a shell to, because every effect passes a deterministic permission kernel before it happens. The model proposes; it never decides. It runs on your own machine, takes instructions over a chat channel or the terminal, and keeps an event log you can read afterwards.
+
+Open models can be used with Talos through Ollama, enabling you to use models such as `qwen3.5`, `glm-5.1:cloud`, `kimi-k2.5:cloud`.
+
+## Install
+
+Install [Talos](https://talos-agent.ch):
+
+```shell
+curl -fsSL https://talos-agent.ch/install.sh | sh
+```
+
+The installer verifies the release checksum and its Ed25519 signature, runs the full test suite and the adversarial suite in front of you, and then stops. Nothing starts listening until you say so.
+
+## Usage with Ollama
+
+### Quick setup
+
+```shell
+ollama launch talos
+```
+
+### Run directly with a model
+
+```shell
+ollama launch talos --model qwen3.5
+```
+
+## Recommended Models
+
+- `qwen3.5`
+- `glm-4.7-flash`
+- `kimi-k2.5:cloud`
+- `glm-5:cloud`
+- `qwen3.5:cloud`
+
+Cloud models are also available at [ollama.com/search?c=cloud](https://ollama.com/search?c=cloud).
+
+## Manual setup
+
+Talos connects to Ollama through its OpenAI-compatible provider.
+
+1. Set the environment variables:
+
+```shell
+export TALOS_MODEL_PROVIDER=openai-api
+export TALOS_BASE_URL_OPENAI_API=http://localhost:11434/v1
+export TALOS_MODEL=qwen3.5
+```
+
+1. Start a session:
+
+```shell
+talos chat
+```
+
+Naming the base URL is what tells Talos to trust the model name you configured: its own catalogue cannot know which models a local server offers.
+
+**Note:** Talos asks the operator before any effect that changes something, so a model with a reasonable context window helps it keep the conversation while it works. See the [context length documentation](/context-length) for how to adjust context length in Ollama.


### PR DESCRIPTION
Adds `ollama launch talos`.

[Talos](https://talos-agent.ch) is an agent with a deterministic permission kernel: the model proposes tool calls, and a separate kernel decides whether they happen. Authority is a per-action token bound to exact arguments, valid once, for thirty seconds — forgetting to call the gate produces no effect rather than an unchecked one. It runs entirely on the operator's machine, which makes Ollama a natural provider for it.

### What this adds

- `cmd/launch/talos.go` — the runner, following the Copilot pattern.
- `cmd/launch/talos_test.go` — 12 subtests.
- `cmd/launch/registry.go` — one integration spec; `"talos"` appended to `launcherIntegrationOrder`.
- `docs/integrations/talos.mdx` + its entry in `docs/docs.json` (Assistants group).

### Two things that differ from the other runners

**It is not a single binary.** Talos ships as a Python package; its installer creates a virtual environment under `~/talos`. So `findPath` looks for a `talos` wrapper on `PATH` first, and falls back to that interpreter (honouring `TALOS_PREFIX`, and `.venv/Scripts/python.exe` on Windows). Only the fallback gets `-m talos` prepended — there is a test for each branch.

**`chat`, not `ask`.** `talos ask` answers once and exits, which is not what launching an assistant means.

### Wiring

```
TALOS_MODEL_PROVIDER=openai-api
TALOS_BASE_URL_OPENAI_API=<envconfig.Host()>/v1
TALOS_MODEL=<model>          # omitted when no model is selected
```

The base URL comes from `envconfig.Host()`, so a custom `OLLAMA_HOST` is honoured — covered by `TestTalosEnvVars/uses_custom_OLLAMA_HOST`, matching the Copilot test.

Naming the base URL is also what makes Talos trust the model name passed in: its own catalogue cannot know which models a local server offers. That side was fixed first (Talos ≥ 0.9.2), so `ollama launch talos --model qwen3.5` runs the model that was asked for rather than silently falling back to a name the server does not have.

### Checks

- `go test ./cmd/launch/` — the whole package passes, including every pre-existing test.
- `gofmt` clean, `go vet` clean.
- **No existing test was modified.** `"talos"` goes at the end of `launcherIntegrationOrder` rather than in the middle, so the curated priority order and `TestListIntegrationInfos/prioritizes_primary_launcher_integrations` are untouched.

### Notes

- No credentials are required: the install is `curl -fsSL https://talos-agent.ch/install.sh | sh`, and the installer verifies the release checksum and its Ed25519 signature, runs the full test suite and the adversarial suite in front of the user, and then starts nothing.
- Happy to move the docs page to the Coding group, rename the integration, or promote it in `launcherIntegrationOrder` if you would rather place it differently.