### PR TITLE
server: return digest read errors instead of exiting the process

### DIFF
--- a/server/images.go
+++ b/server/images.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"log/slog"
 	"net"
 	"net/http"
@@ -1243,14 +1242,14 @@ func pullModelManifest(ctx context.Context, n model.Name, regOpts *registryOptio
 }
 
 // GetSHA256Digest returns the SHA256 hash of a given buffer and returns it, and the size of buffer
-func GetSHA256Digest(r io.Reader) (string, int64) {
+func GetSHA256Digest(r io.Reader) (string, int64, error) {
 	h := sha256.New()
 	n, err := io.Copy(h, r)
 	if err != nil {
-		log.Fatal(err)
+		return "", n, err
 	}
 
-	return fmt.Sprintf("sha256:%x", h.Sum(nil)), n
+	return fmt.Sprintf("sha256:%x", h.Sum(nil)), n, nil
 }
 
 var errUnauthorized = errors.New("unauthorized: access denied")
@@ -1407,7 +1406,11 @@ func verifyBlob(digest string) error {
 	}
 	defer f.Close()
 
-	fileDigest, _ := GetSHA256Digest(f)
+	fileDigest, _, err := GetSHA256Digest(f)
+	if err != nil {
+		return fmt.Errorf("reading %s to verify its digest: %w", fp, err)
+	}
+
 	if digest != fileDigest {
 		return fmt.Errorf("%w: want %s, got %s", errDigestMismatch, digest, fileDigest)
 	}

--- a/server/images_test.go
+++ b/server/images_test.go
@@ -2,10 +2,12 @@ package server
 
 import (
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -781,5 +783,60 @@ func TestPullModelManifest(t *testing.T) {
 				t.Fatal("expected at least one layer")
 			}
 		})
+	}
+}
+
+type errReader struct{ err error }
+
+func (r errReader) Read([]byte) (int, error) { return 0, r.err }
+
+// GetSHA256Digest used to call log.Fatal on a read error, which terminates the
+// whole server process rather than letting the caller handle it.
+func TestGetSHA256DigestReturnsReadError(t *testing.T) {
+	wantErr := errors.New("simulated disk failure")
+
+	digest, n, err := GetSHA256Digest(errReader{err: wantErr})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected the read error back, got %v", err)
+	}
+	if digest != "" {
+		t.Errorf("expected no digest on failure, got %q", digest)
+	}
+	if n != 0 {
+		t.Errorf("expected 0 bytes hashed, got %d", n)
+	}
+}
+
+func TestVerifyBlobReportsReadErrorNotDigestMismatch(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// the directory trick below needs os.Open on a directory to succeed,
+		// which it does not do on Windows
+		t.Skip("relies on POSIX directory open semantics")
+	}
+
+	t.Setenv("OLLAMA_MODELS", t.TempDir())
+
+	digest := "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+	fp, err := manifest.BlobsPath(digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// a directory opens fine but fails on read, standing in for an unreadable blob
+	if err := os.MkdirAll(fp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	err = verifyBlob(digest)
+	if err == nil {
+		t.Fatal("expected an error, got none")
+	}
+	if errors.Is(err, errDigestMismatch) {
+		t.Fatalf("read failure was reported as a digest mismatch: %v", err)
+	}
+	// assert it came from the hashing step, not from os.Open, so this cannot
+	// pass for the wrong reason
+	if !strings.Contains(err.Error(), "to verify its digest") {
+		t.Errorf("expected the digest-read error, got %v", err)
 	}
 }

--- a/server/routes_create_test.go
+++ b/server/routes_create_test.go
@@ -54,7 +54,10 @@ func createBinFile(t *testing.T, kv map[string]any, ti []*ggml.Tensor) (string, 
 		t.Fatal(err)
 	}
 
-	digest, _ := GetSHA256Digest(f)
+	digest, _, err := GetSHA256Digest(f)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := f.Close(); err != nil {
 		t.Fatal(err)
 	}

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -71,7 +71,10 @@ func createTestFile(t *testing.T, name string) (string, string) {
 		t.Fatal(err)
 	}
 
-	digest, _ := GetSHA256Digest(f)
+	digest, _, err := GetSHA256Digest(f)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := f.Close(); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
`GetSHA256Digest` called `log.Fatal(err)` when `io.Copy` failed (server/images.go:1248), and `log.Fatal` calls `os.Exit(1)`. So a read error while hashing a blob does not fail the request, it terminates the whole server and drops every other in-flight request with it. A bad sector, a flaky network filesystem under the models directory, or an unreadable blob is enough. It is the only `log.Fatal` left in server, x or llm, which is why it looks like an oversight rather than a deliberate choice.

This returns the error instead. The one production caller is `verifyBlob`, which now reports the read failure rather than falling through to compare against an empty digest and blaming `errDigestMismatch`, so a disk problem no longer looks like a corrupt or tampered blob. Genuine mismatches still report `errDigestMismatch` exactly as before. The signature gains an error return and I updated all three call sites, two of which are test helpers; I checked for others including under the `integration` build tag, since a normal vet does not compile that tree.

Verified two ways. There is a unit test that the read error now comes back instead of killing the process, plus a `verifyBlob` test that a read failure is not reported as a digest mismatch. To confirm the old behaviour I ran an equivalent probe against unpatched main and watched the test binary exit mid-run with no test failure line at all, which is the `os.Exit` signature. `go test ./server/...`, `golangci-lint run server/`, and `go mod tidy` are clean locally.

One caveat I want to be straight about: the `verifyBlob` test makes the blob path a directory so that open succeeds and the read fails, which relies on POSIX semantics, so it skips on Windows rather than quietly passing there for the wrong reason. The assertion also checks the error came from the hashing step and not from `os.Open`.

quick disclosure: I'm a college freshman contributing where I can :) Claude Code helped me with this one and I ran the tests, lint, and the before/after checks myself. If you would rather keep the signature and log-and-continue instead, I am happy to redo it that way.