### PR TITLE
openai: expand namespace tool declarations in the responses API

### DIFF
--- a/openai/responses.go
+++ b/openai/responses.go
@@ -347,11 +347,16 @@ type ResponsesText struct {
 // ResponsesTool represents a tool in the Responses API format.
 // Note: This differs from api.Tool which nests fields under "function".
 type ResponsesTool struct {
-	Type        string         `json:"type"` // "function"
+	Type        string         `json:"type"` // "function" or "namespace"
 	Name        string         `json:"name"`
 	Description *string        `json:"description"` // nullable but required
 	Strict      *bool          `json:"strict"`      // nullable but required
 	Parameters  map[string]any `json:"parameters"`  // nullable but required
+
+	// Tools carries a "namespace" declaration's member functions. The
+	// Responses API groups related tools by domain under a namespace tool
+	// whose nested tools array holds the real function definitions.
+	Tools []ResponsesTool `json:"tools,omitempty"`
 }
 
 type ResponsesRequest struct {
@@ -540,11 +545,11 @@ func FromResponsesRequest(r ResponsesRequest) (*api.ChatRequest, error) {
 	// Convert tools from Responses API format to api.Tool format
 	var tools []api.Tool
 	for _, t := range r.Tools {
-		tool, err := convertTool(t)
+		expanded, err := convertTools(t)
 		if err != nil {
 			return nil, err
 		}
-		tools = append(tools, tool)
+		tools = append(tools, expanded...)
 	}
 
 	// Handle text format (e.g. json_schema)
@@ -566,6 +571,37 @@ func FromResponsesRequest(r ResponsesRequest) (*api.ChatRequest, error) {
 		Format:   format,
 		Think:    think,
 	}, nil
+}
+
+// convertTools converts one Responses-API tool declaration to api.Tools. A
+// "namespace" declaration groups member functions under a common name; it
+// expands to those members with namespace-qualified names, since api.Tool
+// carries only a flat function name. Dropping the members instead would
+// leave the model with one schema-less pseudo-function and make every
+// namespaced call undeclarable.
+func convertTools(t ResponsesTool) ([]api.Tool, error) {
+	if t.Type != "namespace" {
+		tool, err := convertTool(t)
+		if err != nil {
+			return nil, err
+		}
+		return []api.Tool{tool}, nil
+	}
+
+	var tools []api.Tool
+	for _, member := range t.Tools {
+		expanded, err := convertTools(member)
+		if err != nil {
+			return nil, err
+		}
+		for i := range expanded {
+			if prefix := t.Name + "."; t.Name != "" && !strings.HasPrefix(expanded[i].Function.Name, prefix) {
+				expanded[i].Function.Name = prefix + expanded[i].Function.Name
+			}
+		}
+		tools = append(tools, expanded...)
+	}
+	return tools, nil
 }
 
 func convertTool(t ResponsesTool) (api.Tool, error) {

--- a/openai/responses_test.go
+++ b/openai/responses_test.go
@@ -415,6 +415,97 @@ func TestFromResponsesRequest_Tools(t *testing.T) {
 	}
 }
 
+// TestFromResponsesRequest_NamespaceTools covers the "namespace" tool
+// declaration: one namespace whose members are the real functions must
+// expand to namespace-qualified function tools with their schemas intact,
+// since dropping the members leaves the model with a single schema-less
+// pseudo-function and makes every namespaced call undeclarable.
+func TestFromResponsesRequest_NamespaceTools(t *testing.T) {
+	reqJSON := `{
+		"model": "gpt-oss:20b",
+		"input": "hello",
+		"tools": [
+			{
+				"type": "namespace",
+				"name": "muse",
+				"description": "Muse Code tool set.",
+				"tools": [
+					{
+						"type": "function",
+						"name": "bash",
+						"description": "Runs a shell command",
+						"strict": true,
+						"parameters": {
+							"type": "object",
+							"properties": {
+								"command": {"type": "string"}
+							},
+							"required": ["command"]
+						}
+					},
+					{
+						"type": "function",
+						"name": "muse.read_file",
+						"description": "Reads a file",
+						"strict": true,
+						"parameters": {
+							"type": "object",
+							"properties": {
+								"path": {"type": "string"}
+							},
+							"required": ["path"]
+						}
+					}
+				]
+			},
+			{
+				"type": "function",
+				"name": "plain",
+				"description": "A non-namespaced tool",
+				"strict": false,
+				"parameters": {"type": "object"}
+			}
+		]
+	}`
+
+	var req ResponsesRequest
+	if err := json.Unmarshal([]byte(reqJSON), &req); err != nil {
+		t.Fatalf("failed to unmarshal request: %v", err)
+	}
+
+	chatReq, err := FromResponsesRequest(req)
+	if err != nil {
+		t.Fatalf("failed to convert request: %v", err)
+	}
+
+	if len(chatReq.Tools) != 3 {
+		t.Fatalf("expected 3 converted tools, got %d: %v", len(chatReq.Tools), chatReq.Tools)
+	}
+
+	// Member functions carry the namespace-qualified name; an already
+	// qualified member is not double-prefixed.
+	if got := chatReq.Tools[0].Function.Name; got != "muse.bash" {
+		t.Errorf("expected function name 'muse.bash', got %q", got)
+	}
+	if got := chatReq.Tools[1].Function.Name; got != "muse.read_file" {
+		t.Errorf("expected function name 'muse.read_file', got %q", got)
+	}
+	if got := chatReq.Tools[2].Function.Name; got != "plain" {
+		t.Errorf("expected function name 'plain', got %q", got)
+	}
+
+	// Member schemas and descriptions survive the expansion.
+	if got := chatReq.Tools[0].Function.Description; got != "Runs a shell command" {
+		t.Errorf("expected bash description, got %q", got)
+	}
+	if req := chatReq.Tools[0].Function.Parameters.Required; len(req) != 1 || req[0] != "command" {
+		t.Errorf("expected required ['command'], got %v", req)
+	}
+	if chatReq.Tools[0].Type != "function" {
+		t.Errorf("expected member type 'function', got %q", chatReq.Tools[0].Type)
+	}
+}
+
 func TestFromResponsesRequest_ReasoningEffort(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
The Responses API groups related tools by domain: a tool with type "namespace" carries the real function definitions in a nested tools array. The conversion dropped that array, leaving the model a single schema-less pseudo-function and making every namespaced call undeclarable.

Expand namespace declarations into their member functions with namespace-qualified names, since api.Tool carries only a flat function name.

Relates to #15921: full Responses API parity also wants the namespace preserved as a separate field on tool calls in the output, which needs new api surface and is not addressed here.