### PR TITLE
docs: add required model name argument to ollama create example

### DIFF
--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -121,7 +121,7 @@ SYSTEM """You are a happy cat."""
 Then run `ollama create`:
 
 ```
-ollama create -f Modelfile
+ollama create my-model -f Modelfile
 ```
 
 ### List running models


### PR DESCRIPTION
## Problem

The CLI docs show `ollama create -f Modelfile` but this fails with `Error: accepts 1 arg(s), received 0` because `ollama create` requires a positional model name argument.

## Fix

Changed `ollama create -f Modelfile` to `ollama create my-model -f Modelfile` in `docs/cli.mdx`.

Fixes #17346