### PR TITLE
mlxrunner: Add image input support

### DIFF
--- a/x/create/create.go
+++ b/x/create/create.go
@@ -297,6 +297,11 @@ func GetTensorQuantization(name string, shape []int32, quantize string) string {
 		return ""
 	}
 
+	// Vision components are too quantization-sensitive; keep source precision.
+	if isVision(name) {
+		return ""
+	}
+
 	// MLX quantization requires last dimension to be divisible by group size.
 	if !isAligned(shape, quantNorm) {
 		return ""

--- a/x/create/gemma4.go
+++ b/x/create/gemma4.go
@@ -64,10 +64,10 @@ func (t gemma4ImportTransform) quantizationType(name string, shape []int32, quan
 
 // isSensitiveProjection reports the value/key/down projections whose precision
 // most affects quality — attention output (v/k) and the residual stream
-// (down). Audio and vision tower tensors are excluded and follow the generic
+// (down). Audio and vision tensors are excluded and follow the generic
 // policy.
 func (t gemma4ImportTransform) isSensitiveProjection(name string) bool {
-	if isVisionTower(name) || isAudioTower(name) {
+	if isVision(name) || isAudioTower(name) {
 		return false
 	}
 	return strings.Contains(name, ".v_proj") ||

--- a/x/create/gemma4_test.go
+++ b/x/create/gemma4_test.go
@@ -159,11 +159,12 @@ func TestGemma4QuantizationType(t *testing.T) {
 		// Audio tower v_proj — must NOT be promoted despite containing .v_proj
 		{"audio v_proj int4", transform26B, "model.audio_tower.layers.0.self_attn.v_proj.linear.weight", aligned, "int4", ""},
 		{"audio v_proj nvfp4", transform26B, "model.audio_tower.layers.0.self_attn.v_proj.linear.weight", aligned, "nvfp4", ""},
-		// Vision tower v_proj — vision tower IS quantized (unlike audio tower),
-		// but not intercepted by gemma4's layer-position heuristic.
-		// Falls through to GetTensorQuantization which applies uniform promotion.
-		{"vision v_proj int4", transform26B, "model.vision_tower.encoder.layers.0.self_attn.v_proj.linear.weight", aligned, "int4", "int8"},
-		{"vision v_proj nvfp4", transform26B, "model.vision_tower.encoder.layers.0.self_attn.v_proj.linear.weight", aligned, "nvfp4", "mxfp8"},
+		// Vision tower — source precision for every quant family.
+		{"vision v_proj int4", transform26B, "model.vision_tower.encoder.layers.0.self_attn.v_proj.linear.weight", aligned, "int4", ""},
+		{"vision v_proj nvfp4", transform26B, "model.vision_tower.encoder.layers.0.self_attn.v_proj.linear.weight", aligned, "nvfp4", ""},
+		{"vision q_proj nvfp4", transform26B, "model.vision_tower.encoder.layers.0.self_attn.q_proj.linear.weight", aligned, "nvfp4", ""},
+		{"unified vision embedder nvfp4", transform26B, "model.vision_embedder.patch_dense.weight", aligned, "nvfp4", ""},
+		{"vision projection nvfp4", transform26B, "model.embed_vision.embedding_projection.linear.weight", aligned, "nvfp4", ""},
 		// Audio tower down_proj
 		{"audio down_proj int4", transform26B, "model.audio_tower.layers.0.mlp.down_proj.linear.weight", aligned, "int4", ""},
 		{"audio down_proj nvfp4", transform26B, "model.audio_tower.layers.0.mlp.down_proj.linear.weight", aligned, "nvfp4", ""},

--- a/x/create/quantpolicy.go
+++ b/x/create/quantpolicy.go
@@ -96,9 +96,10 @@ func isEmbedTokensWeight(name string) bool {
 		!strings.Contains(name, "per_layer")
 }
 
-// isVisionTower reports tensors under a model's vision tower.
-func isVisionTower(name string) bool {
-	return strings.Contains(name, "vision_tower") || strings.Contains(name, ".visual.")
+// isVision reports tensors under a model's vision components: towers,
+// encoder-free embedders, and vision-to-text projections alike.
+func isVision(name string) bool {
+	return strings.Contains(name, "vision") || strings.Contains(name, "visual")
 }
 
 // isAudioTower reports tensors under a model's audio tower or audio embedding.

--- a/x/create/qwen35.go
+++ b/x/create/qwen35.go
@@ -12,11 +12,9 @@ func newQwen35ImportTransform(json.RawMessage) (quantizePolicy, error) {
 }
 
 func (qwen35ImportTransform) quantizationType(name string, shape []int32, quantize string) string {
-	// The vision tower is not yet supported and the low-rank linear-attention
-	// projections are sensitive; keep both at source precision. Everything else
-	// follows the generic policy, which already keeps embeddings, norms, biases,
-	// and routing gates unquantized.
-	if isVisionTower(name) || qwen35IsLowRankProjection(name) {
+	// The low-rank linear-attention projections are sensitive; keep them
+	// at source precision.
+	if qwen35IsLowRankProjection(name) {
 		return ""
 	}
 	return GetTensorQuantization(name, shape, quantize)

--- a/x/mlxrunner/batch/batch.go
+++ b/x/mlxrunner/batch/batch.go
@@ -21,9 +21,37 @@ type Batch struct {
 	// It is nil for ordinary forward passes.
 	Hidden *mlx.Array
 
+	// Media lists a row's media items, on prefill forwards and draft
+	// forwards that embed prompt tokens; items outside the query range
+	// ride featureless. Nil at decode and for text-only requests.
+	Media []MediaItem
+
+	// Layout carries each row's opaque layout state from PrepareMedia,
+	// identical on every forward of the request; the runner never reads
+	// it. Nil entries derive nothing from layout.
+	Layout []any
+
 	// Memo is per-forward memoization used to cache results, such as masks,
 	// which are often the same across layers.
 	Memo Memo
+}
+
+// MediaItem is one media occurrence in a row's sequence. The runner
+// knows only where the expansion was spliced; which positions bear
+// features is the model's, derived from Pos and Opaque.
+type MediaItem struct {
+	// Seq is the batch row the item belongs to.
+	Seq int
+
+	// Pos is the absolute sequence position of the expansion's first token.
+	Pos int
+
+	// Features is the item's whole feature-row array, attached only while
+	// the item's token range overlaps this forward's query range.
+	Features *mlx.Array
+
+	// Opaque is the item's PreparedMedia.Opaque, round-tripped untouched.
+	Opaque any
 }
 
 type Memo struct {

--- a/x/mlxrunner/client.go
+++ b/x/mlxrunner/client.go
@@ -112,6 +112,7 @@ func (c *Client) WaitUntilRunning(ctx context.Context) error {
 
 type CompletionRequest struct {
 	Prompt      string
+	Media       []llm.MediaData
 	Options     api.Options
 	Logprobs    bool
 	TopLogprobs int
@@ -155,6 +156,7 @@ func (c *Client) Close() error {
 func (c *Client) Completion(ctx context.Context, req llm.CompletionRequest, fn func(llm.CompletionResponse)) error {
 	creq := CompletionRequest{
 		Prompt:      req.Prompt,
+		Media:       req.Media,
 		Logprobs:    req.Logprobs,
 		TopLogprobs: req.TopLogprobs,
 	}

--- a/x/mlxrunner/dflash.go
+++ b/x/mlxrunner/dflash.go
@@ -28,8 +28,8 @@ func newDFlashDrafter(s *speculation, draft base.BlockDraft) *dflashDrafter {
 func (d *dflashDrafter) draftLimit() int { return d.blockSize - 1 }
 
 // open returns a session synced to the draft caches' restored offset.
-func (d *dflashDrafter) open() draftSession {
-	s := &dflashDraftSession{drafter: d}
+func (d *dflashDrafter) open(layout []any) draftSession {
+	s := &dflashDraftSession{drafter: d, layout: layout}
 	if kv := d.spec.draftKV; len(kv) > 0 {
 		s.ctxOffset = kv[0].Offset()
 	}
@@ -41,6 +41,7 @@ func (d *dflashDrafter) open() draftSession {
 // after the last reported token.
 type dflashDraftSession struct {
 	drafter *dflashDrafter
+	layout  []any
 
 	// ctxOffset is the slot after the last feature row written; pendingCount
 	// rows are buffered past it.
@@ -53,7 +54,9 @@ type dflashDraftSession struct {
 	blockOutstanding bool
 }
 
-func (d *dflashDraftSession) committed(tokens, features *mlx.Array, position int) {
+// committed ignores the media manifest: a context row derives from the
+// target hidden at its slot, which already carries any image content.
+func (d *dflashDraftSession) committed(tokens, features *mlx.Array, position int, _ []batch.MediaItem) {
 	n := tokens.Dim(1)
 	// Skip leading rows the session already has (a restored prefix). A run
 	// that starts past the frontier would leave a gap, which is a bug.
@@ -121,6 +124,7 @@ func (d *dflashDraftSession) flush() {
 	spec.draft.Forward(&batch.Batch{
 		SeqOffsets: []int32{int32(offset)},
 		Hidden:     features,
+		Layout:     d.layout,
 	}, spec.targets, spec.draftKV)
 
 	// Force the cache writes: a session that never drafts would otherwise
@@ -165,6 +169,7 @@ func (d *dflashDraftSession) propose(current *mlx.Array, maxTokens int) *draftCa
 		SeqOffsets:   []int32{int32(offset)},
 		SeqQueryLens: []int32{int32(n + 1)},
 		Hidden:       features,
+		Layout:       d.layout,
 	}, spec.targets, spec.draftKV)
 
 	// Row i predicts the token at its own position, so the anchor row is

--- a/x/mlxrunner/dflash_test.go
+++ b/x/mlxrunner/dflash_test.go
@@ -103,7 +103,7 @@ func newBlockTestSession(t *testing.T, predict map[int32]int32, blockSize int) (
 	draft := &fakeBlockDraft{predict: predict, blockSize: blockSize, maskToken: 6, draftCaches: caches[1:]}
 	r.cache.caches = caches
 	r.spec = newSpeculation(r, draft, caches[:1], caches[1:])
-	return r, draft, r.spec.drafter.open().(*dflashDraftSession), caches
+	return r, draft, r.spec.drafter.open(nil).(*dflashDraftSession), caches
 }
 
 // draftTokensOf reads the draft cache's fed token stream.
@@ -122,7 +122,7 @@ func TestDFlashCommittedBuffersPastFlushCap(t *testing.T) {
 	for i := range ids {
 		ids[i] = int32(i % mtpTestVocab)
 	}
-	session.committed(mlx.FromValues(ids, 1, n), oneHotLogits(ids), 0)
+	session.committed(mlx.FromValues(ids, 1, n), oneHotLogits(ids), 0, nil)
 	if got := len(draft.calls); got != 1 {
 		t.Fatalf("draft calls after cap-sized run = %d, want 1", got)
 	}
@@ -133,7 +133,7 @@ func TestDFlashCommittedBuffersPastFlushCap(t *testing.T) {
 	// A run below the cap only buffers; settle writes it through, skipping
 	// the leading rows the flush already covered.
 	tail := []int32{1, 2, 3}
-	session.committed(mlx.FromValues(tail, 1, 3), oneHotLogits(tail), n-1)
+	session.committed(mlx.FromValues(tail, 1, 3), oneHotLogits(tail), n-1, nil)
 	if got := len(draft.calls); got != 1 {
 		t.Fatalf("draft calls after buffered run = %d, want 1 (buffered)", got)
 	}
@@ -151,14 +151,14 @@ func TestDFlashCommittedGapPanics(t *testing.T) {
 	skipIfNoMLX(t)
 	_, _, session, _ := newBlockTestSession(t, nil, 4)
 
-	session.committed(mlx.FromValues([]int32{1}, 1, 1), oneHotLogits([]int32{1}), 0)
+	session.committed(mlx.FromValues([]int32{1}, 1, 1), oneHotLogits([]int32{1}), 0, nil)
 	defer func() {
 		if recover() == nil {
 			t.Fatalf("committed run past the frontier did not panic")
 		}
 	}()
 	// The frontier is at slot 1; a run starting at 3 leaves slot 1..2 unfed.
-	session.committed(mlx.FromValues([]int32{4}, 1, 1), oneHotLogits([]int32{4}), 3)
+	session.committed(mlx.FromValues([]int32{4}, 1, 1), oneHotLogits([]int32{4}), 3, nil)
 }
 
 func TestDFlashRestoredPrefixResumes(t *testing.T) {
@@ -172,7 +172,7 @@ func TestDFlashRestoredPrefixResumes(t *testing.T) {
 	// A restored prefix arrives with the draft caches already written.
 	restored := []int32{1, 2, 3, 4, 5}
 	caches[1].(*fakeRewindableCache).feed(restored)
-	session := r.spec.drafter.open().(*dflashDraftSession)
+	session := r.spec.drafter.open(nil).(*dflashDraftSession)
 	if session.ctxOffset != len(restored) {
 		t.Fatalf("ctxOffset = %d, want %d (synced to restored offset)", session.ctxOffset, len(restored))
 	}
@@ -180,7 +180,7 @@ func TestDFlashRestoredPrefixResumes(t *testing.T) {
 	// The resumed prefill's run overlaps the restore point; only the rows
 	// past the frontier are buffered and written.
 	run := []int32{2, 3, 0, 1}
-	session.committed(mlx.FromValues(run, 1, 4), oneHotLogits(run), 3)
+	session.committed(mlx.FromValues(run, 1, 4), oneHotLogits(run), 3, nil)
 	session.settle(nil)
 	want := blockCall{offset: 5, ctx: []int32{0, 1}}
 	if got := draft.calls[0]; got.offset != want.offset || !slices.Equal(got.ctx, want.ctx) || got.block != nil {
@@ -201,7 +201,7 @@ func TestDFlashProposeBounds(t *testing.T) {
 	if session.propose(current, 4) != nil {
 		t.Fatalf("propose with no context did not decline")
 	}
-	session.committed(mlx.FromValues([]int32{1}, 1, 1), oneHotLogits([]int32{1}), 0)
+	session.committed(mlx.FromValues([]int32{1}, 1, 1), oneHotLogits([]int32{1}), 0, nil)
 	if session.propose(current, 0) != nil {
 		t.Fatalf("propose with no budget did not decline")
 	}
@@ -225,7 +225,7 @@ func TestDFlashBlockRewoundBeforeContextWrites(t *testing.T) {
 	predict := map[int32]int32{2: 3, 3: 4, 4: 5}
 	_, draft, session, caches := newBlockTestSession(t, predict, 4)
 
-	session.committed(mlx.FromValues([]int32{1}, 1, 1), oneHotLogits([]int32{1}), 0)
+	session.committed(mlx.FromValues([]int32{1}, 1, 1), oneHotLogits([]int32{1}), 0, nil)
 	if session.propose(mlx.FromValues([]int32{2}, 1), 3) == nil {
 		t.Fatalf("propose declined")
 	}
@@ -237,7 +237,7 @@ func TestDFlashBlockRewoundBeforeContextWrites(t *testing.T) {
 	// The next round's report rewinds the block before appending context, so
 	// the accepted tokens' rows land at their true slots.
 	run := []int32{2, 3, 4}
-	session.committed(mlx.FromValues(run, 1, 3), oneHotLogits(run), 1)
+	session.committed(mlx.FromValues(run, 1, 3), oneHotLogits(run), 1, nil)
 	session.settle(nil)
 	if got, want := draftTokensOf(caches), []int32{1, 2, 3, 4}; !slices.Equal(got, want) {
 		t.Fatalf("draft cache after settle = %v, want %v (block rewound)", got, want)
@@ -256,7 +256,7 @@ func TestDFlashCloseDrainsOutstandingBlock(t *testing.T) {
 	predict := map[int32]int32{2: 3, 3: 4, 4: 5}
 	_, _, session, caches := newBlockTestSession(t, predict, 4)
 
-	session.committed(mlx.FromValues([]int32{1}, 1, 1), oneHotLogits([]int32{1}), 0)
+	session.committed(mlx.FromValues([]int32{1}, 1, 1), oneHotLogits([]int32{1}), 0, nil)
 	if session.propose(mlx.FromValues([]int32{2}, 1), 3) == nil {
 		t.Fatalf("propose declined")
 	}
@@ -287,7 +287,7 @@ func TestDecodeBlockDraft(t *testing.T) {
 		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
 		SamplerOpts:       sampler.Options{},
 	}
-	spec := r.spec.open(req)
+	spec := r.spec.open(req, nil)
 	if spec == nil || !spec.enabled {
 		t.Fatalf("open rejected a block-draft request")
 	}

--- a/x/mlxrunner/media.go
+++ b/x/mlxrunner/media.go
@@ -10,12 +10,16 @@ import (
 	"strconv"
 
 	"github.com/ollama/ollama/llm"
+	"github.com/ollama/ollama/x/mlxrunner/batch"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
 	"github.com/ollama/ollama/x/mlxrunner/model/base"
 )
 
 var imgTagPattern = regexp.MustCompile(`\[img-(\d+)\]`)
 
-// mediaItem is one media occurrence in a request's token stream.
+// mediaItem is one media occurrence in a request's token stream: the
+// absolute position and length of its placeholder expansion, its trie-key
+// fold value, and the prepared item.
 type mediaItem struct {
 	pos    int
 	length int
@@ -23,9 +27,9 @@ type mediaItem struct {
 	item   *base.PreparedItem
 }
 
-// foldValue derives an item's trie-key substitute: a hash of the raw
-// bytes and preprocessing dims, with bit 31 forced so it can never equal
-// a token ID.
+// foldValue derives the trie-key substitute for a media item: a hash of the
+// raw bytes and the preprocessing dims (which pin the feature geometry for
+// given bytes), with bit 31 forced so it can never equal a token ID.
 func foldValue(data []byte, dims []int) uint32 {
 	h := fnv.New64a()
 	h.Write(data)
@@ -36,6 +40,133 @@ func foldValue(data []byte, dims []int) uint32 {
 	}
 	sum := h.Sum64()
 	return (uint32(sum>>32) ^ uint32(sum)) | 1<<31
+}
+
+// requestMedia manages one request's media features: encoded on first
+// use, released when the expansion is fully evaluated. A nil
+// *requestMedia is a text-only request; every method is nil-safe.
+type requestMedia struct {
+	model    base.MediaModel
+	items    []mediaItem
+	inputLen int
+
+	// manifest is the request-scoped batch view of items; Features is
+	// toggled in place so every batch shares the same slice.
+	manifest []batch.MediaItem
+	features []*mlx.Array // parallel to items; nil until encoded
+
+	// layout is the request's one-row Batch.Layout, shared by every batch
+	// like the manifest; nil when the model returned no layout.
+	layout []any
+}
+
+func (r *Runner) openMedia(request Request) *requestMedia {
+	if len(request.MediaItems) == 0 {
+		return nil
+	}
+	m := &requestMedia{
+		model:    r.Model.(base.MediaModel),
+		items:    request.MediaItems,
+		inputLen: len(request.Tokens),
+		manifest: make([]batch.MediaItem, len(request.MediaItems)),
+		features: make([]*mlx.Array, len(request.MediaItems)),
+	}
+	if request.Layout != nil {
+		m.layout = []any{request.Layout}
+	}
+	for i, item := range m.items {
+		m.manifest[i] = batch.MediaItem{Pos: item.pos, Opaque: item.item.Opaque}
+	}
+	return m
+}
+
+// rowLayout returns the request's per-row Batch.Layout value.
+func (m *requestMedia) rowLayout() []any {
+	if m == nil {
+		return nil
+	}
+	return m.layout
+}
+
+func (item *mediaItem) atomic() bool { return !item.item.Causal }
+
+// extendChunk keeps a chunk from ending strictly inside an atomic
+// expansion: cut before one starting inside the chunk, else grow to its
+// end, clipped one short of the prompt to preserve the decode seed.
+func (m *requestMedia) extendChunk(pos, n int) int {
+	if m == nil {
+		return n
+	}
+	end := pos + n
+	for i := range m.items {
+		item := &m.items[i]
+		if !item.atomic() {
+			continue
+		}
+		if item.pos < end && end < item.pos+item.length {
+			if item.pos > pos {
+				return item.pos - pos
+			}
+			return min(item.pos+item.length, m.inputLen-1) - pos
+		}
+	}
+	return n
+}
+
+// batchMedia returns the manifest for chunk [pos, pos+n), encoding and
+// pinning each item's features on first overlap; nothing evaluates here —
+// the consuming forward pulls the encoder.
+func (m *requestMedia) batchMedia(pos, n int) []batch.MediaItem {
+	if m == nil {
+		return nil
+	}
+	for i, item := range m.items {
+		if item.pos >= pos+n || item.pos+item.length <= pos {
+			continue
+		}
+		if m.features[i] == nil {
+			data := mlx.FromValues(item.item.MediaData, item.item.Dims...)
+			m.features[i] = m.model.EncodeMedia(item.item, data)
+			mlx.Pin(m.features[i])
+			// The upload copied the pixels; free them here — release never
+			// passes the end of an expansion reaching the prompt's last token.
+			item.item.MediaData = nil
+		}
+		m.manifest[i].Features = m.features[i]
+	}
+	return m.manifest
+}
+
+// release frees what items fully evaluated or restored at position pos no
+// longer need: the pinned features and the preprocessed pixel buffer.
+func (m *requestMedia) release(pos int) {
+	if m == nil {
+		return
+	}
+	for i, item := range m.items {
+		if item.pos+item.length <= pos {
+			item.item.MediaData = nil
+			if m.features[i] != nil {
+				mlx.Unpin(m.features[i])
+				m.features[i] = nil
+				m.manifest[i].Features = nil
+			}
+		}
+	}
+}
+
+// close unpins whatever remains when the pipeline exits.
+func (m *requestMedia) close() {
+	if m == nil {
+		return
+	}
+	for i, f := range m.features {
+		if f != nil {
+			mlx.Unpin(f)
+			m.features[i] = nil
+			m.manifest[i].Features = nil
+		}
+	}
 }
 
 // expandMedia tokenizes the [img-N]-tagged prompt into segments, expands

--- a/x/mlxrunner/media.go
+++ b/x/mlxrunner/media.go
@@ -1,0 +1,31 @@
+package mlxrunner
+
+import (
+	"encoding/binary"
+	"hash/fnv"
+
+	"github.com/ollama/ollama/x/mlxrunner/model/base"
+)
+
+// mediaItem is one media occurrence in a request's token stream.
+type mediaItem struct {
+	pos    int
+	length int
+	fold   uint32
+	item   *base.PreparedItem
+}
+
+// foldValue derives an item's trie-key substitute: a hash of the raw
+// bytes and preprocessing dims, with bit 31 forced so it can never equal
+// a token ID.
+func foldValue(data []byte, dims []int) uint32 {
+	h := fnv.New64a()
+	h.Write(data)
+	var b [8]byte
+	for _, d := range dims {
+		binary.LittleEndian.PutUint64(b[:], uint64(d))
+		h.Write(b[:])
+	}
+	sum := h.Sum64()
+	return (uint32(sum>>32) ^ uint32(sum)) | 1<<31
+}

--- a/x/mlxrunner/media.go
+++ b/x/mlxrunner/media.go
@@ -2,10 +2,18 @@ package mlxrunner
 
 import (
 	"encoding/binary"
+	"errors"
+	"fmt"
 	"hash/fnv"
+	"log/slog"
+	"regexp"
+	"strconv"
 
+	"github.com/ollama/ollama/llm"
 	"github.com/ollama/ollama/x/mlxrunner/model/base"
 )
+
+var imgTagPattern = regexp.MustCompile(`\[img-(\d+)\]`)
 
 // mediaItem is one media occurrence in a request's token stream.
 type mediaItem struct {
@@ -28,4 +36,84 @@ func foldValue(data []byte, dims []int) uint32 {
 	}
 	sum := h.Sum64()
 	return (uint32(sum>>32) ^ uint32(sum)) | 1<<31
+}
+
+// expandMedia tokenizes the [img-N]-tagged prompt into segments, expands
+// them in a single PrepareMedia call, and validates the authored items
+// before keying cache identity on them.
+func (r *Runner) expandMedia(mm base.MediaModel, prompt string, media []llm.MediaData) (*base.PreparedRequest, []mediaItem, error) {
+	matches := imgTagPattern.FindAllStringSubmatch(prompt, -1)
+	parts := imgTagPattern.Split(prompt, -1)
+
+	referenced := make([]bool, len(media))
+	var segments []base.Segment
+	for i, part := range parts {
+		segments = append(segments, base.Segment{Tokens: r.Tokenizer.Encode(part, i == 0 && r.Tokenizer.AddBOS())})
+		if i >= len(matches) {
+			continue
+		}
+
+		id, _ := strconv.Atoi(matches[i][1])
+		idx := -1
+		for j := range media {
+			if media[j].ID == id {
+				idx = j
+				break
+			}
+		}
+		if idx < 0 {
+			return nil, nil, fmt.Errorf("invalid image index: %d", id)
+		}
+		referenced[idx] = true
+		segments = append(segments, base.Segment{Kind: string(media[idx].Kind), Data: media[idx].Data})
+	}
+
+	for j := range media {
+		if !referenced[j] {
+			slog.Warn("media not referenced by prompt", "id", media[j].ID)
+		}
+	}
+
+	prepared, err := mm.PrepareMedia(segments)
+	if err != nil {
+		return nil, nil, err
+	}
+	items, err := bindItems(prepared, segments)
+	if err != nil {
+		return nil, nil, err
+	}
+	return prepared, items, nil
+}
+
+// bindItems validates the authored ranges before cache identity is keyed
+// on them and binds each item to its source segment's bytes.
+func bindItems(prepared *base.PreparedRequest, segments []base.Segment) ([]mediaItem, error) {
+	covered := make([]bool, len(segments))
+	items := make([]mediaItem, 0, len(prepared.Items))
+	end := 0
+	for i := range prepared.Items {
+		item := &prepared.Items[i]
+		rg := item.Range
+		if rg[0] < end || rg[1] <= rg[0] || rg[1] > len(prepared.Tokens) {
+			return nil, fmt.Errorf("media expansion has invalid range %v", rg)
+		}
+		if item.Source < 0 || item.Source >= len(segments) || segments[item.Source].Data == nil {
+			return nil, fmt.Errorf("media expansion references non-media segment %d", item.Source)
+		}
+		covered[item.Source] = true
+		end = rg[1]
+
+		items = append(items, mediaItem{
+			pos:    rg[0],
+			length: rg[1] - rg[0],
+			fold:   foldValue(segments[item.Source].Data, item.Dims),
+			item:   item,
+		})
+	}
+	for s, seg := range segments {
+		if seg.Data != nil && !covered[s] {
+			return nil, errors.New("media expansion produced no tokens")
+		}
+	}
+	return items, nil
 }

--- a/x/mlxrunner/media_test.go
+++ b/x/mlxrunner/media_test.go
@@ -1,0 +1,68 @@
+package mlxrunner
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestEffectiveKeyTokens(t *testing.T) {
+	tokens := []int32{10, 20, 500, 500, 500, 30}
+	items := []mediaItem{{pos: 2, length: 3, fold: foldValue([]byte("img"), []int{1})}}
+
+	eff := effectiveKeyTokens(tokens, items)
+	want := []uint32{10, 20, items[0].fold, items[0].fold, items[0].fold, 30}
+	if !slices.Equal(eff, want) {
+		t.Fatalf("got %v, want %v", eff, want)
+	}
+
+	// Text-only streams never alias a media stream: folds carry bit 31.
+	for _, e := range effectiveKeyTokens(tokens, nil) {
+		if e&(1<<31) != 0 {
+			t.Fatalf("token key %d has bit 31 set", e)
+		}
+	}
+}
+
+// Two prompts that differ only in their image diverge at the expansion's
+// first key — one position earlier under bigram packing — and prompts with
+// the same image share keys through the whole expansion.
+func TestKeyFoldDivergence(t *testing.T) {
+	prompt := func(fold uint32) []uint32 {
+		tokens := []int32{1, 2, 900, 900, 900, 3, 4}
+		return effectiveKeyTokens(tokens, []mediaItem{{pos: 2, length: 3, fold: fold}})
+	}
+	imgA := foldValue([]byte("a"), []int{1})
+	imgB := foldValue([]byte("b"), []int{1})
+	if imgA != foldValue([]byte("a"), []int{1}) {
+		t.Fatal("fold not deterministic")
+	}
+	if imgA == foldValue([]byte("a"), []int{2}) {
+		t.Fatal("different dims produced the same fold under identical bytes")
+	}
+
+	for _, lookahead := range []int{0, 1} {
+		pc := &prefixCache{draftLookahead: lookahead}
+		keysA := pc.key(prompt(imgA))
+		keysB := pc.key(prompt(imgB))
+		keysA2 := pc.key(prompt(imgA))
+
+		if !slices.Equal(keysA, keysA2) {
+			t.Fatalf("lookahead %d: same image produced different keys", lookahead)
+		}
+
+		// Bigram packing pulls the divergence one position early: the key
+		// before the expansion packs (token, fold). Keys re-converge in value
+		// after the expansion (shared trailing text), which is fine — the trie
+		// paths forked at the first difference.
+		divergeAt, convergeAt := 2-lookahead, 5
+		for i := range keysA {
+			same := keysA[i] == keysB[i]
+			if i < divergeAt && !same {
+				t.Fatalf("lookahead %d: keys diverge at %d, before the expansion", lookahead, i)
+			}
+			if i >= divergeAt && i < convergeAt && same {
+				t.Fatalf("lookahead %d: keys agree at %d, inside the expansion", lookahead, i)
+			}
+		}
+	}
+}

--- a/x/mlxrunner/media_test.go
+++ b/x/mlxrunner/media_test.go
@@ -3,6 +3,9 @@ package mlxrunner
 import (
 	"slices"
 	"testing"
+
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/mlxrunner/model/base"
 )
 
 func TestEffectiveKeyTokens(t *testing.T) {
@@ -20,6 +23,100 @@ func TestEffectiveKeyTokens(t *testing.T) {
 		if e&(1<<31) != 0 {
 			t.Fatalf("token key %d has bit 31 set", e)
 		}
+	}
+}
+
+func TestExtendChunk(t *testing.T) {
+	m := &requestMedia{
+		items: []mediaItem{
+			{pos: 10, length: 4, item: &base.PreparedItem{}},
+			{pos: 40, length: 8, item: &base.PreparedItem{Causal: true}},
+			{pos: 96, length: 4, item: &base.PreparedItem{}},
+		},
+		inputLen: 100,
+	}
+
+	cases := []struct{ pos, n, want int }{
+		{0, 10, 10}, // ends at the expansion start: not inside
+		{0, 12, 10}, // expansion starts inside: cut so it begins the next chunk
+		{0, 14, 14}, // ends at the expansion end: not inside
+		{10, 2, 4},  // chunk starts at the expansion: extend to its end
+		{12, 1, 2},  // resume mid-expansion: extend to its end
+		{38, 6, 6},  // causal expansion: ending inside is legal
+		{42, 4, 4},  // causal expansion at chunk start: no extension
+		{90, 7, 6},  // trailing expansion starts inside: cut before it
+		{96, 2, 3},  // trailing expansion at chunk start: clip one short of the prompt
+	}
+	for _, c := range cases {
+		if got := m.extendChunk(c.pos, c.n); got != c.want {
+			t.Errorf("extendChunk(%d, %d) = %d, want %d", c.pos, c.n, got, c.want)
+		}
+	}
+
+	var nilMedia *requestMedia
+	if got := nilMedia.extendChunk(0, 12); got != 12 {
+		t.Errorf("nil extendChunk = %d, want 12", got)
+	}
+}
+
+// encodeCountingModel counts EncodeMedia calls and returns a real array so
+// the pin/release lifecycle runs against live handles.
+type encodeCountingModel struct {
+	stubMediaModel
+	calls *int
+}
+
+func (m encodeCountingModel) EncodeMedia(item *base.PreparedItem, data *mlx.Array) *mlx.Array {
+	*m.calls++
+	return mlx.Zeros(mlx.DTypeFloat32, item.Range[1]-item.Range[0], 4)
+}
+
+func TestBatchMediaLifecycle(t *testing.T) {
+	skipIfNoMLX(t)
+
+	calls := 0
+	prepared := &base.PreparedItem{
+		Range:     [2]int{2, 6},
+		MediaData: []float32{1, 2},
+		Dims:      []int{2},
+		Opaque:    7,
+	}
+	r := &Runner{Model: encodeCountingModel{calls: &calls}}
+	request := Request{
+		Tokens:     make([]int32, 8),
+		MediaItems: []mediaItem{{pos: 2, length: 4, item: prepared}},
+	}
+
+	m := r.openMedia(request)
+	if m == nil {
+		t.Fatal("openMedia returned nil for a media request")
+	}
+	if m.manifest[0].Pos != 2 || m.manifest[0].Opaque != 7 {
+		t.Fatalf("manifest = %+v", m.manifest[0])
+	}
+
+	if items := m.batchMedia(0, 2); items[0].Features != nil || calls != 0 {
+		t.Fatal("non-overlapping chunk encoded features")
+	}
+	if items := m.batchMedia(0, 4); items[0].Features == nil || calls != 1 {
+		t.Fatalf("overlap did not encode once (calls=%d)", calls)
+	}
+	if items := m.batchMedia(4, 2); items[0].Features == nil || calls != 1 {
+		t.Fatalf("second overlap re-encoded (calls=%d)", calls)
+	}
+
+	m.release(4)
+	if m.manifest[0].Features == nil {
+		t.Fatal("release dropped features before the expansion was evaluated")
+	}
+	m.release(6)
+	if m.manifest[0].Features != nil {
+		t.Fatal("release kept features past the expansion end")
+	}
+	m.close()
+
+	if r.openMedia(Request{Tokens: make([]int32, 8)}) != nil {
+		t.Fatal("openMedia returned non-nil for a text-only request")
 	}
 }
 

--- a/x/mlxrunner/mlx/ops_extra.go
+++ b/x/mlxrunner/mlx/ops_extra.go
@@ -461,6 +461,12 @@ func Sigmoid(a *Array) *Array {
 	return a.Sigmoid()
 }
 
+func Erf(a *Array) *Array {
+	out := New("ERF")
+	C.mlx_erf(&out.ctx, a.ctx, DefaultStream().ctx)
+	return out
+}
+
 func Exp(a *Array) *Array {
 	out := New("EXP")
 	C.mlx_exp(&out.ctx, a.ctx, DefaultStream().ctx)

--- a/x/mlxrunner/model/base/media.go
+++ b/x/mlxrunner/model/base/media.go
@@ -1,0 +1,77 @@
+package base
+
+import (
+	// Every model's PrepareMedia decodes through image.Decode; the decoder
+	// set is registered once here so all models accept the same formats.
+	_ "image/gif"
+	_ "image/jpeg"
+	_ "image/png"
+
+	_ "golang.org/x/image/webp"
+
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+)
+
+// Segment is one run of the prompt in stream order: either a tokenized text
+// run (Tokens set) or a single media item (Kind and Data set).
+type Segment struct {
+	Tokens []int32
+	Kind   string
+	Data   []byte
+}
+
+// PreparedItem describes one media occurrence in the prepared stream. A
+// model chooses item granularity: one per media segment, or several when
+// parts encode and evaluate independently (e.g. per tile).
+type PreparedItem struct {
+	// Range is the expansion's token range [start, end) in Tokens;
+	// non-empty, since cache identity enters through these positions.
+	Range [2]int
+
+	// Source is the index of the segment this item was prepared from; the
+	// item's prefix-cache identity is keyed on that segment's bytes.
+	Source int
+
+	// MediaData is the preprocessed encoder input with shape Dims. Dims
+	// enters the cache keys too: geometry changes features under
+	// identical bytes.
+	MediaData []float32
+	Dims      []int
+
+	// Opaque carries model-private preprocessing state to EncodeMedia
+	// and Forward.
+	Opaque any
+
+	// Causal marks an expansion whose tokens attend causally, so chunks
+	// may split it. Unset, the first evaluation covers the whole
+	// expansion in one forward, as bidirectional runs require.
+	Causal bool
+}
+
+// PreparedRequest is the expanded input stream, every media segment's
+// expansion spliced in place, with the items in stream order.
+type PreparedRequest struct {
+	Tokens []int32
+	Items  []PreparedItem
+
+	// Layout is an opaque request-scoped value computed in the one pass
+	// that sees every splice position; immutable, carried unread by the
+	// runner to every forward. Delivered only when Items is non-empty.
+	// Nil when the model derives nothing from it.
+	Layout any
+}
+
+// MediaModel is implemented by models that accept media inputs.
+type MediaModel interface {
+	// PrepareMedia runs once per request on the request goroutine, CPU
+	// only, and returns the expanded stream. It must be deterministic for
+	// given segments: prefix-cache restores splice cached state with
+	// recomputed state.
+	PrepareMedia(segments []Segment) (*PreparedRequest, error)
+
+	// EncodeMedia builds one item's lazy feature graph on the MLX thread;
+	// it must not evaluate — the consuming forward's evaluation pulls it.
+	// Read the pixels from data: the runner frees the item's MediaData
+	// once its expansion is evaluated.
+	EncodeMedia(item *PreparedItem, data *mlx.Array) *mlx.Array
+}

--- a/x/mlxrunner/mtp.go
+++ b/x/mlxrunner/mtp.go
@@ -2,6 +2,7 @@ package mlxrunner
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/ollama/ollama/x/mlxrunner/batch"
 	"github.com/ollama/ollama/x/mlxrunner/mlx"
@@ -35,8 +36,8 @@ func (d *mtpDrafter) draftLimit() int { return 0 }
 
 // open returns the drafting session for one request, its pairing frontier
 // synced to the draft caches' restored offset.
-func (d *mtpDrafter) open() draftSession {
-	s := &mtpDraftSession{drafter: d}
+func (d *mtpDrafter) open(layout []any) draftSession {
+	s := &mtpDraftSession{drafter: d, layout: layout}
 	if kv := d.spec.draftKV; len(kv) > 0 {
 		// A restored prefix arrives with the draft caches already written;
 		// pairing resumes from their absolute offset.
@@ -52,6 +53,7 @@ func (d *mtpDrafter) open() draftSession {
 // completes only when the next token arrives.
 type mtpDraftSession struct {
 	drafter *mtpDrafter
+	layout  []any
 
 	// frontier is the slot after the last reported token; frontierHidden is
 	// the pinned target hidden at frontier-1, fused into the next pair.
@@ -72,10 +74,17 @@ type mtpDraftSession struct {
 	// reuses them without a head call.
 	heldHidden    *mlx.Array
 	heldAuxHidden *mlx.Array
+
+	// pendingMedia holds manifest rows the deferred flush may still embed,
+	// pinned since prefill releases them after the target's chunk;
+	// lastDelivered marks each row's newest delivered end.
+	pendingMedia  map[int]batch.MediaItem
+	lastDelivered map[int]int
 }
 
-func (d *mtpDraftSession) committed(tokens, hiddens *mlx.Array, position int) {
+func (d *mtpDraftSession) committed(tokens, hiddens *mlx.Array, position int, media []batch.MediaItem) {
 	n := tokens.Dim(1)
+	d.captureMedia(media, position+n)
 	if len(d.drafter.spec.draftKV) > 0 {
 		// The pair at slot S fuses token[S+1] with hidden[S], so a run pairs its
 		// tokens with its own hiddens shifted one slot back: the first writable
@@ -104,6 +113,59 @@ func (d *mtpDraftSession) committed(tokens, hiddens *mlx.Array, position int) {
 	d.setFrontierHidden(lastHiddenRow(hiddens))
 }
 
+// captureMedia pins the run's feature-bearing rows for the deferred
+// flush, which embeds them after prefill has released the features. A row
+// spanning chunks arrives once per chunk.
+func (d *mtpDraftSession) captureMedia(media []batch.MediaItem, end int) {
+	if len(d.drafter.spec.draftKV) == 0 {
+		return
+	}
+	for _, item := range media {
+		if item.Features == nil {
+			continue
+		}
+		if _, ok := d.pendingMedia[item.Pos]; !ok {
+			if d.pendingMedia == nil {
+				d.pendingMedia = make(map[int]batch.MediaItem)
+				d.lastDelivered = make(map[int]int)
+			}
+			mlx.Pin(item.Features)
+			d.pendingMedia[item.Pos] = item
+		}
+		d.lastDelivered[item.Pos] = end
+	}
+}
+
+// flushMedia returns the held rows for a flush batch and drops rows the
+// flush finishes: fully delivered below embedEnd means never embedded
+// again.
+func (d *mtpDraftSession) flushMedia(embedEnd int) []batch.MediaItem {
+	if len(d.pendingMedia) == 0 {
+		return nil
+	}
+	manifest := make([]batch.MediaItem, 0, len(d.pendingMedia))
+	for _, item := range d.pendingMedia {
+		manifest = append(manifest, item)
+	}
+	slices.SortFunc(manifest, func(a, b batch.MediaItem) int { return a.Pos - b.Pos })
+	for pos, last := range d.lastDelivered {
+		if last <= embedEnd {
+			mlx.Unpin(d.pendingMedia[pos].Features)
+			delete(d.pendingMedia, pos)
+			delete(d.lastDelivered, pos)
+		}
+	}
+	return manifest
+}
+
+func (d *mtpDraftSession) closeMedia() {
+	for pos, item := range d.pendingMedia {
+		mlx.Unpin(item.Features)
+		delete(d.pendingMedia, pos)
+		delete(d.lastDelivered, pos)
+	}
+}
+
 // settle completes any open frontier pair with next — the token after the
 // last committed slot — and flushes, leveling the draft caches with the
 // target.
@@ -119,6 +181,7 @@ func (d *mtpDraftSession) settle(next *mlx.Array) {
 
 func (d *mtpDraftSession) close() {
 	d.flush()
+	d.closeMedia()
 	d.setFrontierHidden(nil)
 	d.setHeld(nil, nil)
 }
@@ -155,11 +218,15 @@ func (d *mtpDraftSession) flush() {
 
 	ids := mlx.Concatenate(d.pendingTokens, 1)
 	hiddens := mlx.Concatenate(d.pendingHiddens, 1)
+	// The pair at slot S embeds the look-ahead token S+1, so this flush
+	// embeds prompt tokens up to committedDraftOffset+len+1.
 	hidden, auxHidden := spec.draft.Forward(&batch.Batch{
 		InputIDs:     ids,
 		SeqOffsets:   []int32{int32(d.committedDraftOffset)},
 		SeqQueryLens: []int32{int32(ids.Dim(1))},
 		Hidden:       hiddens,
+		Media:        d.flushMedia(d.committedDraftOffset + ids.Dim(1) + 1),
+		Layout:       d.layout,
 	}, spec.targets, spec.draftKV)
 	d.setHeld(lastHiddenRow(hidden), lastHiddenRow(auxHidden))
 	d.committedDraftOffset += ids.Dim(1)
@@ -235,6 +302,7 @@ func (d *mtpDraftSession) propose(current *mlx.Array, maxTokens int) *draftCandi
 				SeqOffsets:   []int32{int32(pos)},
 				SeqQueryLens: []int32{1},
 				Hidden:       lastHidden,
+				Layout:       d.layout,
 			}, spec.targets, spec.draftKV)
 		}
 		// Unembed only the row being sampled, never the batch.

--- a/x/mlxrunner/mtp_test.go
+++ b/x/mlxrunner/mtp_test.go
@@ -50,6 +50,9 @@ type fakeMTPModel struct {
 	tok     *tokenizer.Tokenizer
 	// forwards records each Forward call so tests can assert contiguous writes.
 	forwards []forwardCall
+	// layouts records each Forward's Batch.Layout so tests can assert the
+	// request's layout state reaches every target forward.
+	layouts [][]any
 }
 
 type forwardCall struct {
@@ -61,6 +64,7 @@ func (m *fakeMTPModel) Forward(b *batch.Batch, caches []cache.Cache) (hidden, au
 	mlx.Eval(b.InputIDs)
 	ids := b.InputIDs.Ints()
 	m.forwards = append(m.forwards, forwardCall{offset: b.SeqOffsets[0], n: int32(len(ids))})
+	m.layouts = append(m.layouts, b.Layout)
 	for i, c := range caches {
 		if i >= m.NumLayers() {
 			break
@@ -96,6 +100,9 @@ var _ base.Model = (*fakeMTPModel)(nil)
 // fakeMTPDraft is a cacheless draft that extends b.InputIDs through predict;
 // a map (not a step counter) keeps drafting consistent regardless of batching.
 type fakeMTPDraft struct {
+	// layouts records each Forward's Batch.Layout, like fakeMTPModel's.
+	layouts [][]any
+
 	predict map[int32]int32
 	// calls records each Draft call so tests can assert the position convention.
 	calls []draftCall
@@ -111,6 +118,7 @@ func (d *fakeMTPDraft) LoadWeights(map[string]*mlx.Array) error { return nil }
 func (d *fakeMTPDraft) NewCaches() []cache.Cache { return nil }
 
 func (d *fakeMTPDraft) Forward(b *batch.Batch, _, _ []cache.Cache) (hidden, auxHidden *mlx.Array) {
+	d.layouts = append(d.layouts, b.Layout)
 	mlx.Eval(b.InputIDs)
 	prev := int32(b.InputIDs.Ints()[0])
 	d.calls = append(d.calls, draftCall{position: b.SeqOffsets[0], from: prev})
@@ -135,12 +143,14 @@ type fakeKVDraft struct {
 }
 
 // extendCall is one recorded Forward call: the absolute slot of the first
-// entry written, the look-ahead token ids, and the hot index of each fused
-// hidden row (-1 for the head's own aux hidden).
+// entry written, the look-ahead token ids, the hot index of each fused
+// hidden row (-1 for the head's own aux hidden), and the Pos of each media
+// row the batch carried.
 type extendCall struct {
 	offset  int32
 	ids     []int32
 	hiddens []int32
+	media   []int
 }
 
 func (d *fakeKVDraft) LoadWeights(map[string]*mlx.Array) error { return nil }
@@ -166,7 +176,11 @@ func (d *fakeKVDraft) Forward(b *batch.Batch, _, draftCaches []cache.Cache) (hid
 			}
 		}
 	}
-	d.extends = append(d.extends, extendCall{offset: b.SeqOffsets[0], ids: ids, hiddens: hot})
+	var media []int
+	for _, item := range b.Media {
+		media = append(media, item.Pos)
+	}
+	d.extends = append(d.extends, extendCall{offset: b.SeqOffsets[0], ids: ids, hiddens: hot, media: media})
 
 	if rc, ok := draftCaches[0].(*fakeRewindableCache); ok {
 		rc.feed(ids)
@@ -452,7 +466,7 @@ func TestRunMTPDecodeSampled(t *testing.T) {
 		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
 		SamplerOpts:       sampler.Options{Temperature: 1, Seed: 42, UseSeed: true},
 	}
-	spec := r.spec.open(req)
+	spec := r.spec.open(req, nil)
 	if spec == nil || !spec.enabled {
 		t.Fatalf("open rejected a sampled request")
 	}
@@ -496,11 +510,11 @@ func TestRunMTPDecodeWarmDrafter(t *testing.T) {
 		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
 		SamplerOpts:       sampler.Options{},
 	}
-	spec := r.spec.open(req)
+	spec := r.spec.open(req, nil)
 	pinDraftLimit(spec, 4)
 	// The prefill chunk's committed report: token 0 at slot 0 with its
 	// hidden row, leaving the drafter ready to propose from slot 1.
-	spec.committed(mlx.FromValues([]int32{0}, 1, 1), oneHotLogits([]int32{1}), 0)
+	spec.committed(mlx.FromValues([]int32{0}, 1, 1), oneHotLogits([]int32{1}), 0, nil)
 
 	d := spec.decoder(mlx.FromValues([]int32{1}, 1), position)
 	if err := r.decode(context.Background(), req, session, d, 0); err != nil {
@@ -557,14 +571,14 @@ func TestRunMTPDecodeEOSCutLeavesPositionsUnjudged(t *testing.T) {
 		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
 		SamplerOpts:       sampler.Options{},
 	}
-	spec := r.spec.open(req)
+	spec := r.spec.open(req, nil)
 	if spec == nil || !spec.enabled {
 		t.Fatalf("want an enabled speculationSession with a depth controller, got %+v", spec)
 	}
 	// Force a four-token first round so the EOS (third draft) is interior;
 	// the controller still records the round's outcomes.
 	spec.limit = 4
-	spec.committed(mlx.FromValues([]int32{0}, 1, 1), oneHotLogits([]int32{1}), 0)
+	spec.committed(mlx.FromValues([]int32{0}, 1, 1), oneHotLogits([]int32{1}), 0, nil)
 
 	d := spec.decoder(mlx.FromValues([]int32{1}, 1), position)
 	if err := r.decode(context.Background(), req, session, d, 0); err != nil {
@@ -695,6 +709,54 @@ func TestDecodeCancelledMidStream(t *testing.T) {
 	}
 }
 
+func TestLayoutRidesEveryForward(t *testing.T) {
+	skipIfNoMLX(t)
+	// The request's opaque layout state must reach every forward: parked
+	// pipelined dispatches, the fused verification forward, and the draft
+	// model's own forwards alike.
+	const eos int32 = 7
+	predict := map[int32]int32{1: 2, 2: 3, 3: 4, 4: eos, eos: 0}
+	r := mtpTestRunner(t, predict, []int32{eos}, sampler.Options{})
+	caches, _ := newMTPTestCaches(1)
+	r.cache.caches = caches
+	r.spec = newSpeculation(r, &fakeMTPDraft{predict: predict}, caches, nil)
+	session, ch := newMTPTestSession(caches)
+
+	req := Request{
+		Responses:         ch,
+		Tokens:            []int32{0},
+		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
+		SamplerOpts:       sampler.Options{},
+	}
+	spec := r.spec.open(req, []any{"layout"})
+	pinDraftLimit(spec, 4)
+	d := spec.decoder(mlx.FromValues([]int32{1}, 1), 1)
+	if err := r.decode(context.Background(), req, session, d, 0); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	d.close()
+
+	model := r.Model.(*fakeMTPModel)
+	if len(model.layouts) < 3 {
+		t.Fatalf("forwards recorded = %d, want parked dispatches and a fused round", len(model.layouts))
+	}
+	for i, l := range model.layouts {
+		if len(l) != 1 || l[0] != "layout" {
+			t.Fatalf("forward %d layout = %v", i, l)
+		}
+	}
+
+	draft := r.spec.draft.(*fakeMTPDraft)
+	if len(draft.layouts) == 0 {
+		t.Fatal("no draft forwards recorded")
+	}
+	for i, l := range draft.layouts {
+		if len(l) != 1 || l[0] != "layout" {
+			t.Fatalf("draft forward %d layout = %v", i, l)
+		}
+	}
+}
+
 // pinDraftLimit fixes an engine's draft length for the whole run: decode
 // tests assert engine mechanics at known widths, so they disable adaptive
 // depth rather than steer what it learns.
@@ -707,13 +769,13 @@ func pinDraftLimit(spec *speculationSession, limit int) {
 // this request, with the draft length pinned to a fixed width; tests close it
 // explicitly so close-time effects are visible to assertions.
 func testDecoder(r *Runner, req Request, caches []cache.Cache, seed []int32, position int) decoder {
-	if spec := r.spec.open(req); spec != nil {
+	if spec := r.spec.open(req, nil); spec != nil {
 		if spec.enabled {
 			pinDraftLimit(spec, 4)
 		}
 		return spec.decoder(mlx.FromValues(seed, len(seed)), position)
 	}
-	return r.pipelinedDecoder(nil, caches, mlx.FromValues(seed, 1, len(seed)), position)
+	return r.pipelinedDecoder(nil, caches, mlx.FromValues(seed, 1, len(seed)), position, nil)
 }
 
 func TestDecodeKVDraft(t *testing.T) {
@@ -742,7 +804,7 @@ func TestDecodeKVDraft(t *testing.T) {
 		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
 		SamplerOpts:       sampler.Options{},
 	}
-	spec := r.spec.open(req)
+	spec := r.spec.open(req, nil)
 	if spec == nil || !spec.enabled || len(spec.spec.targets) != 1 {
 		t.Fatalf("speculation engine not built around the draft caches")
 	}
@@ -827,7 +889,7 @@ func TestDecodeKVDraftRejectionRebuildsFromTarget(t *testing.T) {
 		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
 		SamplerOpts:       sampler.Options{},
 	}
-	spec := r.spec.open(req)
+	spec := r.spec.open(req, nil)
 	pinDraftLimit(spec, 4)
 	defer spec.close()
 	d := spec.decoder(mlx.FromValues([]int32{1}, 1), position)
@@ -897,7 +959,7 @@ func TestDecodeMaintainsDraftCacheWithoutDrafting(t *testing.T) {
 		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
 		SamplerOpts:       opts,
 	}
-	spec := r.spec.open(req)
+	spec := r.spec.open(req, nil)
 	if spec == nil || spec.enabled {
 		t.Fatalf("want a permanent-park speculationSession, got %+v", spec)
 	}
@@ -955,12 +1017,12 @@ func TestSettleLevelsDraftCacheWithPrefill(t *testing.T) {
 		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
 		SamplerOpts:       sampler.Options{},
 	}
-	spec := r.spec.open(req)
+	spec := r.spec.open(req, nil)
 	defer spec.close()
 
 	// The prompt's only chunk: tokens 1..4 at slots 0..3 with their hiddens;
 	// token 5 is the seed.
-	spec.committed(mlx.FromValues([]int32{1, 2, 3, 4}, 1, 4), oneHotLogits([]int32{1, 2, 3, 4}), 0)
+	spec.committed(mlx.FromValues([]int32{1, 2, 3, 4}, 1, 4), oneHotLogits([]int32{1, 2, 3, 4}), 0, nil)
 	spec.settle(mlx.FromValues([]int32{5}, 1))
 
 	if got := caches[1].Offset(); got != 4 {
@@ -971,6 +1033,46 @@ func TestSettleLevelsDraftCacheWithPrefill(t *testing.T) {
 	}
 	if !reflect.DeepEqual(draft.extends, wantExtends) {
 		t.Fatalf("draft extends = %+v, want %+v", draft.extends, wantExtends)
+	}
+}
+
+func TestFlushMediaHeldUntilEmbedded(t *testing.T) {
+	skipIfNoMLX(t)
+	// The deferred flush embeds prompt tokens after prefill has released the
+	// media features, so the session holds delivered feature rows itself:
+	// each flush carries the held rows, a row is dropped once the flush's
+	// embed frontier passes its delivered end, and a row a later chunk
+	// redelivers is held again.
+	predict := map[int32]int32{}
+	r := mtpTestRunner(t, predict, []int32{7}, sampler.Options{})
+	draft := &fakeKVDraft{predict: predict}
+	caches, _ := newMTPTestCaches(2)
+	draft.draftCaches = caches[1:]
+	r.cache.caches = caches
+	r.spec = newSpeculation(r, draft, caches[:1], caches[1:])
+
+	d := r.spec.drafter.open(nil).(*mtpDraftSession)
+	item := batch.MediaItem{Pos: 1, Features: mlx.Zeros(mlx.DTypeFloat32, 4, 4)}
+
+	// Chunk [0, 4) delivers the item; the flush embeds through the delivered
+	// end, so the row rides that flush and is dropped.
+	d.committed(mlx.FromValues([]int32{1, 2, 3, 4}, 1, 4), oneHotLogits([]int32{1, 2, 3, 4}), 0, []batch.MediaItem{item})
+	d.flush()
+	// A chunk with no delivery flushes without media.
+	d.committed(mlx.FromValues([]int32{5, 6}, 1, 2), oneHotLogits([]int32{5, 6}), 4, nil)
+	d.flush()
+	// A redelivered row (one arrives per chunk it spans) is held and
+	// flushed again.
+	d.committed(mlx.FromValues([]int32{2, 3}, 1, 2), oneHotLogits([]int32{2, 3}), 6, []batch.MediaItem{item})
+	d.flush()
+	d.close()
+
+	got := make([][]int, len(draft.extends))
+	for i, e := range draft.extends {
+		got[i] = e.media
+	}
+	if want := [][]int{{1}, nil, {1}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("flush media = %v, want %v", got, want)
 	}
 }
 
@@ -997,12 +1099,12 @@ func TestCommittedRunBatchesPastFlushCap(t *testing.T) {
 		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
 		SamplerOpts:       sampler.Options{},
 	}
-	spec := r.spec.open(req)
+	spec := r.spec.open(req, nil)
 	defer spec.close()
 
 	// One prefill-sized chunk: n tokens at slots 0..n-1 with their hiddens.
 	// The run crosses the flush cap, so the write happens inside committed.
-	spec.committed(mlx.FromValues(tokens, 1, n), oneHotLogits(tokens), 0)
+	spec.committed(mlx.FromValues(tokens, 1, n), oneHotLogits(tokens), 0, nil)
 
 	if got := len(draft.extends); got != 1 {
 		t.Fatalf("draft extends = %d calls, want 1 batched extend", got)
@@ -1039,7 +1141,7 @@ func TestRestoredPrefixRewritesBoundaryPair(t *testing.T) {
 		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
 		SamplerOpts:       sampler.Options{},
 	}
-	spec := r.spec.open(req)
+	spec := r.spec.open(req, nil)
 	pinDraftLimit(spec, 4)
 	d := spec.decoder(mlx.FromValues([]int32{1}, 1), 0)
 	if err := r.decode(context.Background(), req, session, d, 0); err != nil {
@@ -1061,8 +1163,8 @@ func TestRestoredPrefixRewritesBoundaryPair(t *testing.T) {
 			t.Fatal("restore to 5 failed")
 		}
 	}
-	spec = r.spec.open(req)
-	spec.committed(mlx.FromValues([]int32{6, 1}, 1, 2), oneHotLogits([]int32{eos, 2}), 5)
+	spec = r.spec.open(req, nil)
+	spec.committed(mlx.FromValues([]int32{6, 1}, 1, 2), oneHotLogits([]int32{eos, 2}), 5, nil)
 	spec.close()
 
 	last := draft.extends[len(draft.extends)-1]
@@ -1093,7 +1195,7 @@ func TestDecodeParkedDraftResume(t *testing.T) {
 		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
 		SamplerOpts:       sampler.Options{},
 	}
-	spec := r.spec.open(req)
+	spec := r.spec.open(req, nil)
 	if spec == nil || !spec.enabled {
 		t.Fatalf("want a drafting speculationSession, got %+v", spec)
 	}
@@ -1186,7 +1288,7 @@ func newMTPTestSession(caches []cache.Cache) (*cacheSession, chan CompletionResp
 // no-op drafter, since the engine requires one.
 func testSpeculationSession(r *Runner, caches []cache.Cache) *speculationSession {
 	if r.spec != nil {
-		return &speculationSession{spec: r.spec, drafter: r.spec.drafter.open()}
+		return &speculationSession{spec: r.spec, drafter: r.spec.drafter.open(nil)}
 	}
 	s := &speculation{r: r, targets: caches}
 	return &speculationSession{spec: s, drafter: nopDrafter{}}
@@ -1196,10 +1298,10 @@ func testSpeculationSession(r *Runner, caches []cache.Cache) *speculationSession
 // directly and never propose.
 type nopDrafter struct{}
 
-func (nopDrafter) propose(*mlx.Array, int) *draftCandidates { return nil }
-func (nopDrafter) committed(_, _ *mlx.Array, _ int)         {}
-func (nopDrafter) settle(*mlx.Array)                        {}
-func (nopDrafter) close()                                   {}
+func (nopDrafter) propose(*mlx.Array, int) *draftCandidates              { return nil }
+func (nopDrafter) committed(_, _ *mlx.Array, _ int, _ []batch.MediaItem) {}
+func (nopDrafter) settle(*mlx.Array)                                     {}
+func (nopDrafter) close()                                                {}
 
 // scriptedCandidates builds draft candidates by running the real drafter
 // against a fake whose prediction chain, starting from seed token 0, yields
@@ -1213,8 +1315,8 @@ func scriptedCandidates(r *Runner, tokens []int32) *draftCandidates {
 		prev = tok
 	}
 	s := &speculation{r: r, draft: &fakeMTPDraft{predict: chain}}
-	d := (&mtpDrafter{spec: s}).open()
-	d.committed(mlx.FromValues([]int32{0}, 1, 1), mlx.Zeros(mlx.DTypeFloat32, 1, 1, mtpTestVocab), 0)
+	d := (&mtpDrafter{spec: s}).open(nil)
+	d.committed(mlx.FromValues([]int32{0}, 1, 1), mlx.Zeros(mlx.DTypeFloat32, 1, 1, mtpTestVocab), 0, nil)
 	return d.propose(mlx.FromValues([]int32{0}, 1), len(tokens))
 }
 

--- a/x/mlxrunner/pipeline.go
+++ b/x/mlxrunner/pipeline.go
@@ -82,7 +82,7 @@ func (r *Runner) TextGenerationPipeline(ctx context.Context, request Request) er
 
 	inputs := request.Tokens
 
-	session := r.cache.begin(inputs)
+	session := r.cache.begin(inputs, nil)
 	defer session.close()
 	caches := session.caches
 

--- a/x/mlxrunner/pipeline.go
+++ b/x/mlxrunner/pipeline.go
@@ -31,17 +31,27 @@ func (r *Runner) Prepare(request *Request) error {
 		return errors.New("model not loaded")
 	}
 
-	if len(request.Media) > 0 {
-		if _, ok := r.Model.(base.MediaModel); !ok {
+	var tokens []int32
+	var items []mediaItem
+	if len(request.Media) == 0 {
+		tokens = r.Tokenizer.Encode(request.Prompt, r.Tokenizer.AddBOS())
+	} else {
+		mm, ok := r.Model.(base.MediaModel)
+		if !ok {
 			kind := string(request.Media[0].Kind)
 			if kind == "" {
 				kind = "media"
 			}
 			return fmt.Errorf("this model does not support %s input", kind)
 		}
+		prepared, bound, err := r.expandMedia(mm, request.Prompt, request.Media)
+		if err != nil {
+			return err
+		}
+		tokens, items = prepared.Tokens, bound
+		request.Layout = prepared.Layout
 	}
 
-	tokens := r.Tokenizer.Encode(request.Prompt, r.Tokenizer.AddBOS())
 	if len(tokens) == 0 {
 		return errors.New("empty prompt")
 	}
@@ -59,6 +69,7 @@ func (r *Runner) Prepare(request *Request) error {
 	}
 
 	request.Tokens = tokens
+	request.MediaItems = items
 	return nil
 }
 
@@ -82,7 +93,7 @@ func (r *Runner) TextGenerationPipeline(ctx context.Context, request Request) er
 
 	inputs := request.Tokens
 
-	session := r.cache.begin(inputs, nil)
+	session := r.cache.begin(inputs, request.MediaItems)
 	defer session.close()
 	caches := session.caches
 

--- a/x/mlxrunner/pipeline.go
+++ b/x/mlxrunner/pipeline.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ollama/ollama/x/mlxrunner/batch"
 	"github.com/ollama/ollama/x/mlxrunner/cache"
 	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/mlxrunner/model/base"
 	sampler "github.com/ollama/ollama/x/mlxrunner/sample"
 	"github.com/ollama/ollama/x/tokenizer"
 )
@@ -28,6 +29,16 @@ func prefillChunkSize() int {
 func (r *Runner) Prepare(request *Request) error {
 	if r.Model == nil {
 		return errors.New("model not loaded")
+	}
+
+	if len(request.Media) > 0 {
+		if _, ok := r.Model.(base.MediaModel); !ok {
+			kind := string(request.Media[0].Kind)
+			if kind == "" {
+				kind = "media"
+			}
+			return fmt.Errorf("this model does not support %s input", kind)
+		}
 	}
 
 	tokens := r.Tokenizer.Encode(request.Prompt, r.Tokenizer.AddBOS())

--- a/x/mlxrunner/pipeline.go
+++ b/x/mlxrunner/pipeline.go
@@ -97,12 +97,15 @@ func (r *Runner) TextGenerationPipeline(ctx context.Context, request Request) er
 	defer session.close()
 	caches := session.caches
 
+	media := r.openMedia(request)
+	defer media.close()
+
 	// Built before prefill so a drafter with draft caches follows the prompt
 	// through prefill alongside the target.
-	spec := r.spec.open(request)
+	spec := r.spec.open(request, media.rowLayout())
 	defer spec.close()
 
-	seed, position, promptEval, err := r.prefill(ctx, session, spec)
+	seed, position, promptEval, err := r.prefill(ctx, session, spec, media)
 	if err != nil {
 		return err
 	}
@@ -114,7 +117,7 @@ func (r *Runner) TextGenerationPipeline(ctx context.Context, request Request) er
 	if spec != nil {
 		d = spec.decoder(seed, position)
 	} else {
-		d = r.pipelinedDecoder(nil, caches, seed.ExpandDims(-1), position)
+		d = r.pipelinedDecoder(nil, caches, seed.ExpandDims(-1), position, media.rowLayout())
 	}
 	defer d.close()
 	return r.decode(ctx, request, session, d, promptEval)
@@ -123,7 +126,7 @@ func (r *Runner) TextGenerationPipeline(ctx context.Context, request Request) er
 // prefill evaluates the prompt in chunks, leaving one token for decode to
 // seed from, and schedules the prompt's periodic snapshots. It returns the
 // seed token, the resume position, and the prompt-evaluation duration.
-func (r *Runner) prefill(ctx context.Context, session *cacheSession, spec *speculationSession) (*mlx.Array, int, time.Duration, error) {
+func (r *Runner) prefill(ctx context.Context, session *cacheSession, spec *speculationSession, media *requestMedia) (*mlx.Array, int, time.Duration, error) {
 	start := time.Now()
 	inputs := session.inputs
 	tokens := session.remaining
@@ -159,20 +162,30 @@ func (r *Runner) prefill(ctx context.Context, session *cacheSession, spec *specu
 
 	total, processed := len(tokens), 0
 	position := len(inputs) - len(tokens)
+	// Free restored items' buffers now: on a full cache hit the loop never runs.
+	media.release(position)
 	for total-processed > 1 {
 		if err := ctx.Err(); err != nil {
 			return nil, 0, 0, err
 		}
 
 		n := min(prefillChunk, total-processed-1)
+		n = media.extendChunk(position, n)
 
 		chunkIDs := mlx.FromValues(tokens[processed:processed+n], 1, n)
+		manifest := media.batchMedia(position, n)
 		_, auxHidden := r.Model.Forward(&batch.Batch{
 			InputIDs:     chunkIDs,
 			SeqOffsets:   []int32{int32(position)},
 			SeqQueryLens: []int32{int32(n)},
+			Media:        manifest,
+			Layout:       media.rowLayout(),
 		}, caches)
-		spec.committed(chunkIDs, auxHidden, position)
+		spec.committed(chunkIDs, auxHidden, position, manifest)
+		// Unpin finished items before the sweep: the consuming forward's
+		// graph retains their data until evaluation, so the buffers die with
+		// this chunk's eval instead of surviving into the next chunk.
+		media.release(position + n)
 		mlx.Sweep()
 		materializeCaches()
 		processed += n
@@ -311,12 +324,13 @@ type pipelinedDecoder struct {
 	// drafter at close, keeping a non-drafting session's draft KV level.
 	spec     *speculationSession
 	caches   []cache.Cache
+	layout   []any // the request's per-row layout state, stamped on every forward
 	position int
 	sample   sampler.Result // in flight: sampled, not yet forwarded
 }
 
-func (r *Runner) pipelinedDecoder(spec *speculationSession, caches []cache.Cache, seed *mlx.Array, position int) *pipelinedDecoder {
-	t := &pipelinedDecoder{r: r, spec: spec, caches: caches, position: position}
+func (r *Runner) pipelinedDecoder(spec *speculationSession, caches []cache.Cache, seed *mlx.Array, position int, layout []any) *pipelinedDecoder {
+	t := &pipelinedDecoder{r: r, spec: spec, caches: caches, layout: layout, position: position}
 	t.sample = t.dispatch(seed)
 	return t
 }
@@ -329,8 +343,9 @@ func (t *pipelinedDecoder) dispatch(token *mlx.Array) sampler.Result {
 		InputIDs:     token,
 		SeqOffsets:   []int32{int32(t.position)},
 		SeqQueryLens: []int32{int32(token.Dim(1))},
+		Layout:       t.layout,
 	}, t.caches)
-	t.spec.committed(token, auxHidden, t.position)
+	t.spec.committed(token, auxHidden, t.position, nil)
 	t.position += token.Dim(1)
 	logits := r.Model.Unembed(hidden)
 	next := r.Sampler.Sample([]int{pipelineSlot}, logits.Slice(mlx.Slice(), mlx.Slice(logits.Dim(1)-1), mlx.Slice()).Squeeze(1))

--- a/x/mlxrunner/pipeline_test.go
+++ b/x/mlxrunner/pipeline_test.go
@@ -1,0 +1,42 @@
+package mlxrunner
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ollama/ollama/llm"
+	"github.com/ollama/ollama/x/mlxrunner/batch"
+	"github.com/ollama/ollama/x/mlxrunner/cache"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/tokenizer"
+)
+
+// textOnlyModel satisfies base.Model but not base.MediaModel.
+type textOnlyModel struct{}
+
+func (textOnlyModel) LoadWeights(map[string]*mlx.Array) error { return nil }
+func (textOnlyModel) NewCaches() []cache.Cache                { return nil }
+func (textOnlyModel) Forward(*batch.Batch, []cache.Cache) (*mlx.Array, *mlx.Array) {
+	return nil, nil
+}
+func (textOnlyModel) Unembed(x *mlx.Array) *mlx.Array { return x }
+func (textOnlyModel) Tokenizer() *tokenizer.Tokenizer { return nil }
+func (textOnlyModel) MaxContextLength() int           { return 0 }
+
+func TestPrepareRejectsMediaWithoutSupport(t *testing.T) {
+	r := &Runner{Model: textOnlyModel{}}
+	req := &Request{
+		CompletionRequest: CompletionRequest{
+			Prompt: "[img-0] what is this?",
+			Media:  []llm.MediaData{{ID: 0, Kind: llm.MediaKindImage, Data: []byte{1}}},
+		},
+	}
+
+	err := r.Prepare(req)
+	if err == nil {
+		t.Fatal("expected error for media on a text-only model")
+	}
+	if !strings.Contains(err.Error(), "does not support image input") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/x/mlxrunner/pipeline_test.go
+++ b/x/mlxrunner/pipeline_test.go
@@ -1,6 +1,8 @@
 package mlxrunner
 
 import (
+	"fmt"
+	"slices"
 	"strings"
 	"testing"
 
@@ -8,6 +10,7 @@ import (
 	"github.com/ollama/ollama/x/mlxrunner/batch"
 	"github.com/ollama/ollama/x/mlxrunner/cache"
 	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/mlxrunner/model/base"
 	"github.com/ollama/ollama/x/tokenizer"
 )
 
@@ -38,5 +41,167 @@ func TestPrepareRejectsMediaWithoutSupport(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "does not support image input") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// stubMediaModel expands every media segment to the same placeholder
+// tokens. Expansion token values are deliberately outside the test
+// tokenizer's vocabulary: they are spliced, never encoded.
+type stubMediaModel struct {
+	textOnlyModel
+	expansion []int32
+	layout    any
+}
+
+func (m stubMediaModel) PrepareMedia(segments []base.Segment) (*base.PreparedRequest, error) {
+	prepared := &base.PreparedRequest{Layout: m.layout}
+	for s, seg := range segments {
+		if seg.Data == nil {
+			prepared.Tokens = append(prepared.Tokens, seg.Tokens...)
+			continue
+		}
+		if seg.Kind != string(llm.MediaKindImage) {
+			return nil, fmt.Errorf("stub does not support %s input", seg.Kind)
+		}
+		if len(m.expansion) == 0 {
+			continue
+		}
+		start := len(prepared.Tokens)
+		prepared.Tokens = append(prepared.Tokens, m.expansion...)
+		prepared.Items = append(prepared.Items, base.PreparedItem{
+			Range:     [2]int{start, len(prepared.Tokens)},
+			Source:    s,
+			MediaData: []float32{float32(len(seg.Data))},
+			Dims:      []int{1},
+			Opaque:    len(seg.Data),
+		})
+	}
+	return prepared, nil
+}
+
+func (stubMediaModel) EncodeMedia(*base.PreparedItem, *mlx.Array) *mlx.Array { return nil }
+
+func mediaTestRunner(t *testing.T) *Runner {
+	t.Helper()
+	return &Runner{
+		Model:         stubMediaModel{expansion: []int32{70, 500, 500, 71}, layout: "L"},
+		Tokenizer:     newTestTokenizer(t, []int32{7}),
+		contextLength: 4096,
+	}
+}
+
+func TestPrepareExpandsMediaTags(t *testing.T) {
+	r := mediaTestRunner(t)
+	req := &Request{
+		CompletionRequest: CompletionRequest{
+			Prompt: "01[img-0]23",
+			Media:  []llm.MediaData{{ID: 0, Kind: llm.MediaKindImage, Data: []byte("img")}},
+		},
+	}
+	if err := r.Prepare(req); err != nil {
+		t.Fatal(err)
+	}
+
+	want := []int32{0, 1, 70, 500, 500, 71, 2, 3}
+	if !slices.Equal(req.Tokens, want) {
+		t.Fatalf("tokens = %v, want %v", req.Tokens, want)
+	}
+	if len(req.MediaItems) != 1 {
+		t.Fatalf("items = %d, want 1", len(req.MediaItems))
+	}
+	item := req.MediaItems[0]
+	if item.pos != 2 || item.length != 4 {
+		t.Fatalf("item at [%d,+%d), want [2,+4)", item.pos, item.length)
+	}
+	if item.fold&(1<<31) == 0 {
+		t.Fatal("item fold missing bit 31")
+	}
+	if item.item == nil || item.item.Opaque != 3 {
+		t.Fatal("prepared item not carried")
+	}
+	if req.Layout != "L" {
+		t.Fatalf("layout = %v, want the model's", req.Layout)
+	}
+}
+
+// rawMediaModel returns a fixed PreparedRequest, letting tests exercise the
+// runner's validation of model-authored items.
+type rawMediaModel struct {
+	textOnlyModel
+	prepared base.PreparedRequest
+}
+
+func (m rawMediaModel) PrepareMedia([]base.Segment) (*base.PreparedRequest, error) {
+	p := m.prepared
+	return &p, nil
+}
+func (rawMediaModel) EncodeMedia(*base.PreparedItem, *mlx.Array) *mlx.Array { return nil }
+
+func TestPrepareValidatesAuthoredItems(t *testing.T) {
+	media := []llm.MediaData{{ID: 0, Kind: llm.MediaKindImage, Data: []byte("img")}}
+	item := func(lo, hi, src int) base.PreparedItem {
+		return base.PreparedItem{Range: [2]int{lo, hi}, Source: src, Dims: []int{1}}
+	}
+	// Prompt "0[img-0]1" produces segments 0=text, 1=media, 2=text.
+	cases := []struct {
+		name  string
+		items []base.PreparedItem
+		want  string // "" means the items must be accepted
+	}{
+		{"per-tile items", []base.PreparedItem{item(1, 3, 1), item(3, 4, 1)}, ""},
+		{"overlap", []base.PreparedItem{item(1, 3, 1), item(2, 4, 1)}, "invalid range"},
+		{"out of bounds", []base.PreparedItem{item(2, 9, 1)}, "invalid range"},
+		{"empty range", []base.PreparedItem{item(2, 2, 1)}, "invalid range"},
+		{"text source", []base.PreparedItem{item(1, 3, 0)}, "non-media segment"},
+	}
+	for _, c := range cases {
+		r := mediaTestRunner(t)
+		r.Model = rawMediaModel{prepared: base.PreparedRequest{Tokens: []int32{0, 5, 5, 5, 1}, Items: c.items}}
+		err := r.Prepare(&Request{CompletionRequest: CompletionRequest{Prompt: "0[img-0]1", Media: media}})
+		if c.want == "" {
+			if err != nil {
+				t.Fatalf("%s: unexpected error %v", c.name, err)
+			}
+			continue
+		}
+		if err == nil || !strings.Contains(err.Error(), c.want) {
+			t.Fatalf("%s: err = %v, want %q", c.name, err, c.want)
+		}
+	}
+}
+
+func TestPrepareMediaErrors(t *testing.T) {
+	media := []llm.MediaData{{ID: 0, Kind: llm.MediaKindImage, Data: []byte("img")}}
+
+	r := mediaTestRunner(t)
+	err := r.Prepare(&Request{CompletionRequest: CompletionRequest{Prompt: "0[img-3]1", Media: media}})
+	if err == nil || !strings.Contains(err.Error(), "invalid image index: 3") {
+		t.Fatalf("missing-ID error = %v", err)
+	}
+
+	// Unreferenced media is ignored with a warning; the prompt still works.
+	req := &Request{CompletionRequest: CompletionRequest{Prompt: "01", Media: media}}
+	if err := r.Prepare(req); err != nil {
+		t.Fatal(err)
+	}
+	if len(req.MediaItems) != 0 {
+		t.Fatalf("items = %d, want 0", len(req.MediaItems))
+	}
+
+	// Duplicate references are allowed; each occurrence is its own item with
+	// the same fold.
+	req = &Request{CompletionRequest: CompletionRequest{Prompt: "[img-0]0[img-0]", Media: media}}
+	if err := r.Prepare(req); err != nil {
+		t.Fatal(err)
+	}
+	if len(req.MediaItems) != 2 || req.MediaItems[0].fold != req.MediaItems[1].fold {
+		t.Fatalf("duplicate items = %+v", req.MediaItems)
+	}
+
+	// A zero-length expansion cannot carry identity into the trie keys.
+	r.Model = stubMediaModel{}
+	err = r.Prepare(&Request{CompletionRequest: CompletionRequest{Prompt: "[img-0]", Media: media}})
+	if err == nil || !strings.Contains(err.Error(), "no tokens") {
+		t.Fatalf("zero-expansion error = %v", err)
 	}
 }

--- a/x/mlxrunner/prefix_cache.go
+++ b/x/mlxrunner/prefix_cache.go
@@ -52,9 +52,10 @@ type pendingSnapshot struct {
 // Callers should append generated tokens to outputs and
 // defer close to save the cache state.
 type cacheSession struct {
-	cache   *prefixCache
-	inputs  []int32
-	outputs []int32
+	cache     *prefixCache
+	inputs    []int32
+	effInputs []uint32 // inputs' key alphabet, media folds applied
+	outputs   []int32
 
 	caches    []cache.Cache
 	remaining []int32
@@ -81,10 +82,11 @@ func (c *prefixCache) ensureRoot() {
 
 // begin prepares caches for a new request. It finds the nearest
 // matching cache or creates new caches if none match.
-func (c *prefixCache) begin(inputs []int32) *cacheSession {
+func (c *prefixCache) begin(inputs []int32, items []mediaItem) *cacheSession {
 	c.ensureRoot()
 
-	keys := c.key(inputs)
+	effInputs := effectiveKeyTokens(inputs, items)
+	keys := c.key(effInputs)
 	matchPath, matched := findBestMatch(c.root, keys)
 	originalMatched := matched
 
@@ -104,6 +106,7 @@ func (c *prefixCache) begin(inputs []int32) *cacheSession {
 	session := &cacheSession{
 		cache:     c,
 		inputs:    inputs,
+		effInputs: effInputs,
 		caches:    c.caches,
 		remaining: remaining,
 	}
@@ -123,12 +126,26 @@ func (c *prefixCache) begin(inputs []int32) *cacheSession {
 	return session
 }
 
-// key converts tokens to trie keys, one per restorable cache offset. A model
-// that drafts through MTP-style draft caches pairs each cache slot with the
-// token after it, so slot i is reusable only if token i+1 also matched. The
-// key for offset i then packs (token i, token i+1): matching k keys verifies
-// k+1 tokens, making every match a valid restore point.
-func (c *prefixCache) key(tokens []int32) []trieKey {
+// effectiveKeyTokens returns the per-position key alphabet: the token ID
+// outside media expansions, the item's fold value across each expansion's
+// whole range.
+func effectiveKeyTokens(tokens []int32, items []mediaItem) []uint32 {
+	eff := make([]uint32, len(tokens))
+	for i, t := range tokens {
+		eff[i] = uint32(t)
+	}
+	for _, item := range items {
+		for i := item.pos; i < item.pos+item.length; i++ {
+			eff[i] = item.fold
+		}
+	}
+	return eff
+}
+
+// key packs (token i, token i+1) per restorable offset: draft caches
+// pair each slot with the next token, so matching k keys verifies k+1
+// tokens and every match is a valid restore point.
+func (c *prefixCache) key(tokens []uint32) []trieKey {
 	keys := make([]trieKey, max(len(tokens)-c.draftLookahead, 0))
 	switch c.draftLookahead {
 	case 0:
@@ -137,12 +154,26 @@ func (c *prefixCache) key(tokens []int32) []trieKey {
 		}
 	case 1:
 		for i := range keys {
-			keys[i] = trieKey(uint32(tokens[i]))<<32 | trieKey(uint32(tokens[i+1]))
+			keys[i] = trieKey(tokens[i])<<32 | trieKey(tokens[i+1])
 		}
 	default:
 		panic(fmt.Sprintf("prefixCache: unsupported draft look-ahead %d", c.draftLookahead))
 	}
 	return keys
+}
+
+// storedKeys keys the session's evaluated stream: the prompt's effective
+// tokens plus generated tokens, which are never media.
+func (s *cacheSession) storedKeys() []trieKey {
+	eff := s.effInputs
+	if len(s.outputs) > 0 {
+		eff = make([]uint32, 0, len(s.effInputs)+len(s.outputs))
+		eff = append(eff, s.effInputs...)
+		for _, t := range s.outputs {
+			eff = append(eff, uint32(t))
+		}
+	}
+	return s.cache.key(eff)
 }
 
 // switchToPath transitions from the current active path to a new path,
@@ -381,7 +412,7 @@ func (s *cacheSession) attachPrefillSnapshots() {
 	// no captured state. Skip it rather than materialize a node whose edge
 	// claims tokens the cache never wrote. Closing its (nil) row is a no-op.
 	reached := c.minCacheOffset()
-	stored := c.key(append(s.inputs, s.outputs...))
+	stored := s.storedKeys()
 	for i, p := range pending {
 		if p.offset > reached {
 			// Never crossed by a write, so the row is nil; close any entry
@@ -511,7 +542,7 @@ func (s *cacheSession) close() {
 	// The caches never advance past the stored keys; anything more
 	// means positions desynced.
 	c := s.cache
-	stored := c.key(append(s.inputs, s.outputs...))
+	stored := s.storedKeys()
 	if offset > len(stored) {
 		panic(fmt.Sprintf("cache: offset %d exceeds %d stored keys", offset, len(stored)))
 	}

--- a/x/mlxrunner/prefix_cache_test.go
+++ b/x/mlxrunner/prefix_cache_test.go
@@ -479,7 +479,7 @@ type requestResult struct {
 func simulateRequest(t *testing.T, pc *prefixCache, inputs, generated []int32, userSnapshotAt ...int) requestResult {
 	t.Helper()
 
-	session := pc.begin(inputs)
+	session := pc.begin(inputs, nil)
 	var snapshotOffsets []int
 	for _, at := range userSnapshotAt {
 		if at > 0 {
@@ -692,7 +692,7 @@ func TestBranchCreationAndReuse(t *testing.T) {
 		// Verify trie was populated by close(): everything in the caches
 		// is findable; the last generated token is not.
 		seqA := []int32{1, 2, 3, 4, 5, 6, 7, 8, 20, 21}
-		_, mA := findBestMatch(pc.root, pc.key(seqA))
+		_, mA := findBestMatch(pc.root, pc.key(effectiveKeyTokens(seqA, nil)))
 		if want := len(seqA) - 1; mA != want {
 			t.Fatalf("A findable: expected %d matched, got %d", want, mA)
 		}
@@ -721,11 +721,11 @@ func TestBranchCreationAndReuse(t *testing.T) {
 		env.assertAllTokens(t, "after B", []int32{1, 2, 3, 4, 5, 10, 11, 12, 30})
 
 		// Both A and B should be findable in the trie.
-		_, mA2 := findBestMatch(pc.root, pc.key(seqA))
+		_, mA2 := findBestMatch(pc.root, pc.key(effectiveKeyTokens(seqA, nil)))
 		if mA2 < 5 {
 			t.Fatalf("A still findable: expected >= 5 matched, got %d", mA2)
 		}
-		_, mB := findBestMatch(pc.root, pc.key([]int32{1, 2, 3, 4, 5, 10, 11, 12, 30, 31}))
+		_, mB := findBestMatch(pc.root, pc.key(effectiveKeyTokens([]int32{1, 2, 3, 4, 5, 10, 11, 12, 30, 31}, nil)))
 		if mB < 5 {
 			t.Fatalf("B findable: expected >= 5 matched, got %d", mB)
 		}
@@ -853,8 +853,8 @@ func TestEvictionPreservesActiveConversations(t *testing.T) {
 
 		// System prompt prefix should still be findable (multi-child
 		// branch points are protected from eviction entirely).
-		_, matched := findBestMatch(pc.root, pc.key(systemPrompt))
-		if want := len(pc.key(systemPrompt)); matched < want {
+		_, matched := findBestMatch(pc.root, pc.key(effectiveKeyTokens(systemPrompt, nil)))
+		if want := len(pc.key(effectiveKeyTokens(systemPrompt, nil))); matched < want {
 			t.Fatalf("system prompt match = %d, want %d", matched, want)
 		}
 
@@ -952,7 +952,7 @@ func TestSnapshotBeyondPrefillSkipped(t *testing.T) {
 		pc := env.pc
 		inputs := []int32{1, 2, 3, 4, 5}
 
-		session := pc.begin(inputs)
+		session := pc.begin(inputs, nil)
 		// Request a snapshot at 3 and one at len(inputs); captures land at
 		// the requested prefix minus the look-ahead.
 		session.schedulePrefillSnapshots([]int{3, len(inputs)})
@@ -987,7 +987,7 @@ func TestPrefillSnapshotsDiscardedOnCancel(t *testing.T) {
 		pc := env.pc
 		inputs := []int32{1, 2, 3, 4, 5}
 
-		session := pc.begin(inputs)
+		session := pc.begin(inputs, nil)
 		session.schedulePrefillSnapshots([]int{3})
 		// Cross offset 3 so the caches capture it, then close the session as a
 		// canceled prefill would, before the captures are attached to the trie.

--- a/x/mlxrunner/runner.go
+++ b/x/mlxrunner/runner.go
@@ -32,6 +32,8 @@ type Request struct {
 
 	Ctx         context.Context //nolint:containedctx // Queued requests carry caller cancellation to the runner.
 	Tokens      []int32
+	MediaItems  []mediaItem
+	Layout      any // opaque PrepareMedia layout state, stamped on every batch
 	SamplerOpts sample.Options
 }
 

--- a/x/mlxrunner/speculate.go
+++ b/x/mlxrunner/speculate.go
@@ -21,8 +21,11 @@ type draftSession interface {
 	// committed reports a run of tokens committed to the target caches:
 	// tokens[i] sits at slot position+i and hiddens row i is the target
 	// hidden state at that slot. Runs arrive in slot order — prefill
-	// chunks, the decode seed, then each round's validated tokens.
-	committed(tokens, hiddens *mlx.Array, position int)
+	// chunks, the decode seed, then each round's validated tokens. media is
+	// the run's manifest (feature-bearing for items the run overlaps), valid
+	// only for the call; a session that defers its forward pins what it
+	// keeps. Nil outside prefill.
+	committed(tokens, hiddens *mlx.Array, position int, media []batch.MediaItem)
 
 	// settle completes any open frontier pair with next — the token after
 	// the last committed slot — and writes buffered reports through,
@@ -59,9 +62,9 @@ type speculation struct {
 }
 
 // drafter is the per-model half of a drafting implementation, opening each
-// request's drafting session.
+// request's drafting session with the request's per-row layout state.
 type drafter interface {
-	open() draftSession
+	open(layout []any) draftSession
 
 	// draftLimit is the deepest draft this drafter can produce, 0 when nothing
 	// bounds it. A depth past it is never measured, so the depth search must
@@ -91,8 +94,9 @@ func newSpeculation(r *Runner, draft base.DraftModel, targets, draftKV []cache.C
 type speculationSession struct {
 	spec    *speculation
 	drafter draftSession
-	enabled bool // whether this request drafts; false parks (maintain-only)
-	limit   int  // current draft length
+	enabled bool  // whether this request drafts; false parks (maintain-only)
+	limit   int   // current draft length
+	layout  []any // the request's per-row layout state, stamped on every target forward
 	stats   specStats
 
 	// Cost sampling: each round's wall time (start to next start, spanning the
@@ -105,18 +109,18 @@ type speculationSession struct {
 
 // open returns the speculation cursor for this request or nil when the model ships
 // no draft head (a nil receiver), which decodes plainly.
-func (s *speculation) open(request Request) *speculationSession {
+func (s *speculation) open(request Request, layout []any) *speculationSession {
 	if s == nil {
 		return nil
 	}
-	d := s.drafter.open()
+	d := s.drafter.open(layout)
 
 	// Logprobs are not yet supported, so a logprobs request keeps a speculationSession
 	// only to maintain a draft cache in lockstep (permanently parked).
 	opts := request.SamplerOpts
 	enabled := !opts.Logprobs && opts.TopLogprobs == 0
 
-	spec := &speculationSession{spec: s, drafter: d, enabled: enabled, prevDrafts: -1, roundDrafts: -1}
+	spec := &speculationSession{spec: s, drafter: d, layout: layout, enabled: enabled, prevDrafts: -1, roundDrafts: -1}
 	if enabled {
 		spec.limit = s.depth.scheduled
 	}
@@ -155,11 +159,11 @@ func (s *speculationSession) endRound(drafted, accepted, observed int) {
 	}
 }
 
-func (s *speculationSession) committed(tokens, hiddens *mlx.Array, position int) {
+func (s *speculationSession) committed(tokens, hiddens *mlx.Array, position int, media []batch.MediaItem) {
 	if s == nil {
 		return
 	}
-	s.drafter.committed(tokens, hiddens, position)
+	s.drafter.committed(tokens, hiddens, position, media)
 }
 
 // settle completes the drafter's open frontier pair with next and writes
@@ -272,7 +276,7 @@ func (st *speculativeDecoder) resume() []sampler.Result {
 func (st *speculativeDecoder) park(remaining int) ([]sampler.Result, error) {
 	s := st.s
 	if st.inner == nil {
-		st.inner = s.spec.r.pipelinedDecoder(s, s.spec.targets, st.current.Token.ExpandDims(-1), st.position)
+		st.inner = s.spec.r.pipelinedDecoder(s, s.spec.targets, st.current.Token.ExpandDims(-1), st.position, s.layout)
 	}
 	return st.inner.next(remaining)
 }
@@ -398,6 +402,7 @@ func (s *speculationSession) accept(position *int, current sampler.Result, candi
 		InputIDs:     current.Token.ExpandDims(-1).Concatenate(1, candidates.tokens),
 		SeqOffsets:   []int32{int32(before)},
 		SeqQueryLens: []int32{int32(draftCount + 1)},
+		Layout:       s.layout,
 	}, s.spec.targets)
 
 	// Row i of the fused hidden is the state after the token at before+i, so
@@ -470,7 +475,7 @@ func (s *speculationSession) accept(position *int, current sampler.Result, candi
 	s.drafter.committed(
 		mlx.FromValues(runIDs, 1, len(runIDs)),
 		auxHiddenSeq.Slice(mlx.Slice(), mlx.Slice(0, len(runIDs)), mlx.Slice()),
-		before)
+		before, nil)
 
 	results = draftResults(draftIDs[:accepted])
 	if done {

--- a/x/models/qwen3_5/process_image.go
+++ b/x/models/qwen3_5/process_image.go
@@ -1,0 +1,183 @@
+package qwen3_5
+
+import (
+	"bytes"
+	"fmt"
+	"image"
+	"math"
+
+	"golang.org/x/image/draw"
+)
+
+// Processor bounds from the family's preprocessor config: total pixels are
+// clamped to [shortest_edge, longest_edge] with both sides rounded to
+// multiples of patch_size * spatial_merge_size.
+const (
+	visionMinPixels = 65536
+	visionMaxPixels = 16777216
+)
+
+// preparedImage is the model-private state for one image: the pre-merge
+// patch grid and the CPU-computed lookups the encoder consumes, all in the
+// block-major merge order the pixel rows use.
+type preparedImage struct {
+	gridH, gridW int32
+	// ropePos is (h, w) per patch for the tower's 2D rotary tables.
+	ropePos []int32
+	// posIdx/posWt are the four bilinear corners per patch into the learned
+	// position table, with their interpolation weights.
+	posIdx []int32
+	posWt  []float32
+}
+
+func (p preparedImage) numPatches() int32 { return p.gridH * p.gridW }
+
+func (p preparedImage) numTokens(merge int32) int32 {
+	return p.gridH * p.gridW / (merge * merge)
+}
+
+// smartResize ports the reference resize rule: round each side to the patch
+// factor, then scale into the pixel budget, preserving aspect ratio.
+func smartResize(height, width, factor int32) (int32, int32, error) {
+	if height <= 0 || width <= 0 {
+		return 0, 0, fmt.Errorf("invalid image size %dx%d", width, height)
+	}
+	longer, shorter := float64(max(height, width)), float64(min(height, width))
+	if longer/shorter > 200 {
+		return 0, 0, fmt.Errorf("image aspect ratio %.0f exceeds 200", longer/shorter)
+	}
+
+	f := float64(factor)
+	// The reference uses Python round (half to even).
+	hBar := math.RoundToEven(float64(height)/f) * f
+	wBar := math.RoundToEven(float64(width)/f) * f
+	if hBar*wBar > visionMaxPixels {
+		beta := math.Sqrt(float64(height) * float64(width) / visionMaxPixels)
+		hBar = math.Max(f, math.Floor(float64(height)/beta/f)*f)
+		wBar = math.Max(f, math.Floor(float64(width)/beta/f)*f)
+	} else if hBar*wBar < visionMinPixels {
+		beta := math.Sqrt(visionMinPixels / (float64(height) * float64(width)))
+		hBar = math.Ceil(float64(height)*beta/f) * f
+		wBar = math.Ceil(float64(width)*beta/f) * f
+	}
+	return int32(hBar), int32(wBar), nil
+}
+
+// preprocessImage decodes and prepares one image: aspect-preserving resize,
+// (x/255-0.5)/0.5 normalization, and patchification into the tower's
+// block-major row layout.
+func (m *Model) preprocessImage(data []byte) (pixels []float32, prep preparedImage, err error) {
+	img, _, err := image.Decode(bytes.NewReader(data))
+	if err != nil {
+		return nil, preparedImage{}, fmt.Errorf("decode image: %w", err)
+	}
+
+	v := m.Vision
+	patch, merge, temporal := v.PatchSize, v.SpatialMergeSize, v.TemporalPatchSize
+	bounds := img.Bounds()
+	img = dropAlpha(img, bounds)
+	targetH, targetW, err := smartResize(int32(bounds.Dy()), int32(bounds.Dx()), patch*merge)
+	if err != nil {
+		return nil, preparedImage{}, err
+	}
+
+	resized := image.NewRGBA(image.Rect(0, 0, int(targetW), int(targetH)))
+	draw.CatmullRom.Scale(resized, resized.Bounds(), img, bounds, draw.Src, nil)
+	gridH, gridW := targetH/patch, targetW/patch
+	prep = preparedImage{gridH: gridH, gridW: gridW}
+	pixels = patchifyImage(resized, gridH, gridW, patch, merge, temporal)
+	prep.ropePos, prep.posIdx, prep.posWt = visionPatchLookups(gridH, gridW, merge, v.NumPositionEmbeddings)
+	return pixels, prep, nil
+}
+
+// patchifyImage converts the resized image to the tower's row layout:
+// block-major over merge blocks, each row [channel][temporal duplicate]
+// [pixel row][pixel column].
+func patchifyImage(resized *image.RGBA, gridH, gridW, patch, merge, temporal int32) []float32 {
+	n := int(gridH * gridW)
+	rowLen := int(3 * temporal * patch * patch)
+	pixels := make([]float32, n*rowLen)
+
+	p, t := int(patch), int(temporal)
+	patchArea := p * p
+	row := 0
+	for bh := range gridH / merge {
+		for bw := range gridW / merge {
+			for mh := range merge {
+				for mw := range merge {
+					gh, gw := bh*merge+mh, bw*merge+mw
+					out := pixels[row*rowLen:]
+					baseX, baseY := int(gw)*p, int(gh)*p
+					for py := range p {
+						px0 := resized.PixOffset(baseX, baseY+py)
+						for px := range p {
+							pix := resized.Pix[px0+px*4:]
+							o := py*p + px
+							for c := range 3 {
+								val := float32(pix[c])/127.5 - 1
+								for ti := range t {
+									out[(c*t+ti)*patchArea+o] = val
+								}
+							}
+						}
+					}
+					row++
+				}
+			}
+		}
+	}
+	return pixels
+}
+
+// visionPatchLookups computes, in the block-major token order, each patch's
+// (h, w) rotary position and its four bilinear corners into the learned
+// side*side position grid with their weights.
+func visionPatchLookups(gridH, gridW, merge, numPosEmbeddings int32) (ropePos, posIdx []int32, posWt []float32) {
+	side := int32(math.Sqrt(float64(numPosEmbeddings)))
+	n := int(gridH * gridW)
+	ropePos = make([]int32, 0, 2*n)
+	posIdx = make([]int32, 0, 4*n)
+	posWt = make([]float32, 0, 4*n)
+
+	// linspace(0, side-1, g) per axis over the pre-merge grid.
+	coord := func(i, g int32) float64 {
+		if g == 1 {
+			return 0
+		}
+		return float64(i) * float64(side-1) / float64(g-1)
+	}
+
+	for bh := range gridH / merge {
+		for bw := range gridW / merge {
+			for mh := range merge {
+				for mw := range merge {
+					gh, gw := bh*merge+mh, bw*merge+mw
+					ropePos = append(ropePos, gh, gw)
+
+					hg, wg := coord(gh, gridH), coord(gw, gridW)
+					hf, wf := int32(hg), int32(wg)
+					hc, wc := min(hf+1, side-1), min(wf+1, side-1)
+					hFrac, wFrac := float32(hg-float64(hf)), float32(wg-float64(wf))
+					posIdx = append(posIdx, hf*side+wf, hf*side+wc, hc*side+wf, hc*side+wc)
+					posWt = append(posWt,
+						(1-hFrac)*(1-wFrac), (1-hFrac)*wFrac, hFrac*(1-wFrac), hFrac*wFrac)
+				}
+			}
+		}
+	}
+	return ropePos, posIdx, posWt
+}
+
+// dropAlpha flattens a non-opaque image to straight RGB: the reference
+// drops alpha via RGB conversion before resizing, not by compositing.
+func dropAlpha(img image.Image, bounds image.Rectangle) image.Image {
+	if o, ok := img.(interface{ Opaque() bool }); ok && o.Opaque() {
+		return img
+	}
+	flat := image.NewNRGBA(bounds)
+	draw.Draw(flat, bounds, img, bounds.Min, draw.Src)
+	for i := 3; i < len(flat.Pix); i += 4 {
+		flat.Pix[i] = 0xff
+	}
+	return flat
+}

--- a/x/models/qwen3_5/qwen3_5.go
+++ b/x/models/qwen3_5/qwen3_5.go
@@ -28,6 +28,7 @@ var (
 	_ base.Model      = (*Model)(nil)
 	_ base.SelfDraft  = (*Model)(nil)
 	_ base.DraftModel = (*mtpDraft)(nil)
+	_ base.MediaModel = (*Model)(nil)
 )
 
 // RopeParameters carries optional rope metadata embedded under rope_parameters.
@@ -36,6 +37,7 @@ type RopeParameters struct {
 	RopeType            string  `json:"rope_type"`
 	RopeTheta           float32 `json:"rope_theta"`
 	PartialRotaryFactor float32 `json:"partial_rotary_factor"`
+	MropeSection        []int32 `json:"mrope_section"`
 }
 
 // Config holds Qwen 3.5 text config (top-level or nested text_config).
@@ -76,6 +78,8 @@ type Config struct {
 	RopeScaling         map[string]any  `json:"rope_scaling"`
 	RopeParameters      *RopeParameters `json:"rope_parameters"`
 
+	MropeSection []int32 `json:"-"`
+
 	// Quantization metadata.
 	QuantGroupSize int                               `json:"-"`
 	QuantBits      int                               `json:"-"`
@@ -95,6 +99,11 @@ type Model struct {
 	LMHead      nn.LinearLayer
 
 	MTP *MTPHead
+
+	// Vision components; nil for text-only checkpoints.
+	Vision      *VisionConfig
+	VisionTower *VisionTower
+	MM          multimodalConfig
 
 	tok *tokenizer.Tokenizer
 	*Config
@@ -276,6 +285,10 @@ func parseConfig(configData []byte) (Config, error) {
 		ropeDim = cfg.HeadDim
 	}
 	cfg.RopeDim = ropeDim
+	cfg.MropeSection = []int32{11, 11, 10}
+	if cfg.RopeParameters != nil && len(cfg.RopeParameters.MropeSection) == 3 {
+		cfg.MropeSection = cfg.RopeParameters.MropeSection
+	}
 
 	if cfg.FullAttentionInterval <= 0 {
 		for i, lt := range cfg.LayerTypes {
@@ -405,9 +418,16 @@ func NewModel(root *model.Root) (base.Model, error) {
 		return nil, fmt.Errorf("parse tokenizer: %w", err)
 	}
 
+	mm, err := parseMultimodalConfig(configData)
+	if err != nil {
+		return nil, err
+	}
+
 	m := &Model{
 		Layers: make([]*Layer, cfg.NumHiddenLayers),
 		Config: &cfg,
+		MM:     mm,
+		Vision: mm.VisionConfig,
 		tok:    tok,
 	}
 
@@ -870,7 +890,7 @@ func (m *Model) LoadWeights(tensors map[string]*mlx.Array) error {
 		}
 	}
 
-	return nil
+	return m.loadVisionWeights(tensors, linears)
 }
 
 // loadLayer builds a decoder layer from tensors at layerPrefix. It serves both
@@ -1021,7 +1041,7 @@ func (m *Model) loadMTPHead(linears model.LinearFactory, tensors map[string]*mlx
 	return nil
 }
 
-func (a *FullAttention) Forward(x *mlx.Array, b *batch.Batch, c cache.Cache, positions *mlx.Array, B, L int32, cfg *Config) *mlx.Array {
+func (a *FullAttention) Forward(x *mlx.Array, b *batch.Batch, c cache.Cache, positions *mlx.Array, B, L int32, cfg *Config, mropeCos, mropeSin *mlx.Array) *mlx.Array {
 	qg := a.QProj.Forward(x)
 	qg = mlx.Reshape(qg, B, L, cfg.NumAttentionHeads, cfg.HeadDim*2)
 	q := mlx.SliceStartStop(qg, []int32{0, 0, 0, 0}, []int32{B, L, cfg.NumAttentionHeads, cfg.HeadDim})
@@ -1040,8 +1060,13 @@ func (a *FullAttention) Forward(x *mlx.Array, b *batch.Batch, c cache.Cache, pos
 	k = mlx.Transpose(k, 0, 2, 1, 3)
 	v = mlx.Transpose(v, 0, 2, 1, 3)
 
-	q = mlx.RoPEWithBase(q, int(cfg.RopeDim), false, cfg.RopeTheta, 1.0, positions)
-	k = mlx.RoPEWithBase(k, int(cfg.RopeDim), false, cfg.RopeTheta, 1.0, positions)
+	if mropeCos != nil {
+		q = applyMRoPE(q, mropeCos, mropeSin, cfg.RopeDim)
+		k = applyMRoPE(k, mropeCos, mropeSin, cfg.RopeDim)
+	} else {
+		q = mlx.RoPEWithBase(q, int(cfg.RopeDim), false, cfg.RopeTheta, 1.0, positions)
+		k = mlx.RoPEWithBase(k, int(cfg.RopeDim), false, cfg.RopeTheta, 1.0, positions)
+	}
 
 	var kv nn.SDPAOption
 	if c != nil {
@@ -1181,13 +1206,13 @@ func (m *SparseMoE) Forward(x *mlx.Array, cfg *Config) *mlx.Array {
 	return mlx.Reshape(y, B, L, cfg.HiddenSize)
 }
 
-func (l *Layer) Forward(x *mlx.Array, b *batch.Batch, c cache.Cache, positions *mlx.Array, B, L int32, cfg *Config) *mlx.Array {
+func (l *Layer) Forward(x *mlx.Array, b *batch.Batch, c cache.Cache, positions *mlx.Array, B, L int32, cfg *Config, mropeCos, mropeSin *mlx.Array) *mlx.Array {
 	var r *mlx.Array
 	normed := l.InputNorm.Forward(x, cfg.RMSNormEps)
 	if l.IsLinear {
 		r = l.Linear.Forward(normed, b, c, B, L, cfg)
 	} else {
-		r = l.FullAttn.Forward(normed, b, c, positions, B, L, cfg)
+		r = l.FullAttn.Forward(normed, b, c, positions, B, L, cfg, mropeCos, mropeSin)
 	}
 	h := mlx.Add(x, r)
 	r = l.MLP.Forward(l.PostAttentionNorm.Forward(h, cfg.RMSNormEps), cfg)
@@ -1200,12 +1225,23 @@ func (m *Model) Forward(b *batch.Batch, caches []cache.Cache) (hidden, auxHidden
 	positions := mlx.FromValues(b.SeqOffsets, len(b.SeqOffsets))
 
 	h := m.EmbedTokens.Forward(b.InputIDs)
+	if len(b.Media) > 0 {
+		h = m.scatterMedia(h, b, 0)
+	}
+
+	// One shared table pair per forward: every full-attention layer applies
+	// the same chunk positions.
+	var mropeCos, mropeSin *mlx.Array
+	if mp := ropePositions(b, L); mp != nil {
+		mropeCos, mropeSin = mropeCosSin(m.Config, mp, L)
+	}
+
 	for i, layer := range m.Layers {
 		var c cache.Cache
 		if caches != nil && i < len(caches) {
 			c = caches[i]
 		}
-		h = layer.Forward(h, b, c, positions, B, L, m.Config)
+		h = layer.Forward(h, b, c, positions, B, L, m.Config, mropeCos, mropeSin)
 	}
 	out := m.Norm.Forward(h, m.RMSNormEps)
 	return out, out
@@ -1248,11 +1284,22 @@ func (m *mtpDraft) Forward(b *batch.Batch, _, draftCaches []cache.Cache) (hidden
 	B, L := int32(dims[0]), int32(dims[1])
 	positions := mlx.FromValues(b.SeqOffsets, len(b.SeqOffsets))
 
-	emb := m.MTP.Enorm.Forward(m.EmbedTokens.Forward(b.InputIDs), m.RMSNormEps)
+	raw := m.EmbedTokens.Forward(b.InputIDs)
+	if len(b.Media) > 0 {
+		// The pair at slot S embeds the look-ahead token S+1, so each row's
+		// column 0 holds the prompt token one past its offset.
+		raw = (*Model)(m).scatterMedia(raw, b, 1)
+	}
+	emb := m.MTP.Enorm.Forward(raw, m.RMSNormEps)
 	h := m.MTP.Hnorm.Forward(b.Hidden, m.RMSNormEps)
 	fused := m.MTP.FC.Forward(emb.Concatenate(-1, h))
 
-	out := m.MTP.Layer.Forward(fused, b, draftCaches[0], positions, B, L, m.Config)
+	var mropeCos, mropeSin *mlx.Array
+	if mp := ropePositions(b, L); mp != nil {
+		mropeCos, mropeSin = mropeCosSin(m.Config, mp, L)
+	}
+
+	out := m.MTP.Layer.Forward(fused, b, draftCaches[0], positions, B, L, m.Config, mropeCos, mropeSin)
 	hidden = m.MTP.Norm.Forward(out, m.RMSNormEps)
 	return hidden, hidden
 }

--- a/x/models/qwen3_5/vision.go
+++ b/x/models/qwen3_5/vision.go
@@ -1,0 +1,512 @@
+package qwen3_5
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+
+	"github.com/ollama/ollama/x/mlxrunner/batch"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/mlxrunner/model"
+	"github.com/ollama/ollama/x/mlxrunner/model/base"
+	"github.com/ollama/ollama/x/models/nn"
+)
+
+// VisionConfig holds the qwen3.5 vision tower configuration.
+type VisionConfig struct {
+	Depth                 int32 `json:"depth"`
+	HiddenSize            int32 `json:"hidden_size"`
+	NumHeads              int32 `json:"num_heads"`
+	InChannels            int32 `json:"in_channels"`
+	PatchSize             int32 `json:"patch_size"`
+	SpatialMergeSize      int32 `json:"spatial_merge_size"`
+	TemporalPatchSize     int32 `json:"temporal_patch_size"`
+	NumPositionEmbeddings int32 `json:"num_position_embeddings"`
+
+	// DeepstackVisualIndexes is rejected at load when non-empty: the
+	// family ships it empty, and serving it would need per-layer feature
+	// injection the tower does not implement.
+	DeepstackVisualIndexes []int32 `json:"deepstack_visual_indexes"`
+}
+
+// multimodalConfig carries the top-level fields the text_config unwrap
+// discards.
+type multimodalConfig struct {
+	VisionConfig       *VisionConfig `json:"vision_config"`
+	ImageTokenID       int32         `json:"image_token_id"`
+	VisionStartTokenID int32         `json:"vision_start_token_id"`
+	VisionEndTokenID   int32         `json:"vision_end_token_id"`
+}
+
+func parseMultimodalConfig(configData []byte) (multimodalConfig, error) {
+	var mm multimodalConfig
+	if err := json.Unmarshal(configData, &mm); err != nil {
+		return multimodalConfig{}, fmt.Errorf("parse multimodal config: %w", err)
+	}
+	if v := mm.VisionConfig; v != nil {
+		if len(v.DeepstackVisualIndexes) > 0 {
+			return multimodalConfig{}, fmt.Errorf("unsupported deepstack_visual_indexes %v", v.DeepstackVisualIndexes)
+		}
+		if v.PatchSize == 0 {
+			v.PatchSize = 16
+		}
+		if v.SpatialMergeSize == 0 {
+			v.SpatialMergeSize = 2
+		}
+		if v.TemporalPatchSize == 0 {
+			v.TemporalPatchSize = 2
+		}
+		if v.NumHeads == 0 {
+			v.NumHeads = 16
+		}
+	}
+	return mm, nil
+}
+
+// VisionTower is the qwen3.5 image encoder: a bidirectional transformer over
+// patch embeddings with interpolated learned positions and 2D rotary
+// attention, merged 2x2 into LM-space tokens.
+type VisionTower struct {
+	PatchEmbed nn.LinearLayer
+	PosEmbed   *mlx.Array // [num_position_embeddings, hidden]
+	Blocks     []*VisionBlock
+	MergerNorm *nn.LayerNorm
+	MergerFC1  nn.LinearLayer
+	MergerFC2  nn.LinearLayer
+}
+
+type VisionBlock struct {
+	Norm1 *nn.LayerNorm
+	Norm2 *nn.LayerNorm
+	QKV   nn.LinearLayer
+	Proj  nn.LinearLayer
+	FC1   nn.LinearLayer
+	FC2   nn.LinearLayer
+}
+
+// visionLayout is the request's Batch.Layout value: the prompt's 3-channel
+// rope positions and the delta that continues them past the prompt.
+type visionLayout struct {
+	positions []int32 // flattened [3][promptLen]
+	promptLen int32
+	delta     int32
+}
+
+// visionWeightRoot locates the tower's tensor prefix: the import pipeline
+// renames the reference's model.visual to vision_tower.
+func visionWeightRoot(tensors map[string]*mlx.Array) string {
+	for _, root := range []string{"vision_tower.", "model.visual.", "visual."} {
+		if tensors[root+"patch_embed.proj.bias"] != nil {
+			return root
+		}
+	}
+	return ""
+}
+
+func (m *Model) loadVisionWeights(tensors map[string]*mlx.Array, linears model.LinearFactory) error {
+	root := visionWeightRoot(tensors)
+	v := m.Vision
+	if root == "" {
+		if v != nil {
+			return fmt.Errorf("config declares a vision tower but vision weights are missing from the manifest")
+		}
+		return nil
+	}
+	if v == nil {
+		return fmt.Errorf("vision tower tensors present but config has no vision_config")
+	}
+
+	required := func(name string) (*mlx.Array, error) {
+		w := tensors[root+name]
+		if w == nil {
+			return nil, fmt.Errorf("missing vision weight: %s%s", root, name)
+		}
+		return w, nil
+	}
+	requiredLinear := func(name string) (nn.LinearLayer, error) {
+		l := linears.Make(root + name)
+		if l == nil {
+			return nil, fmt.Errorf("missing vision weight: %s%s", root, name)
+		}
+		return l, nil
+	}
+	layerNorm := func(name string) (*nn.LayerNorm, error) {
+		w, err := required(name + ".weight")
+		if err != nil {
+			return nil, err
+		}
+		b, err := required(name + ".bias")
+		if err != nil {
+			return nil, err
+		}
+		return &nn.LayerNorm{Weight: w, Bias: b, Eps: 1e-6}, nil
+	}
+
+	tower := &VisionTower{Blocks: make([]*VisionBlock, v.Depth)}
+
+	// The reference patch embed is a Conv3d whose stride equals its kernel:
+	// a linear over the flattened patch row.
+	convW, err := required("patch_embed.proj.weight")
+	if err != nil {
+		return err
+	}
+	convB, err := required("patch_embed.proj.bias")
+	if err != nil {
+		return err
+	}
+	rowLen := v.InChannels * v.TemporalPatchSize * v.PatchSize * v.PatchSize
+	tower.PatchEmbed = nn.NewLinear(mlx.Reshape(convW, v.HiddenSize, rowLen), convB)
+
+	if tower.PosEmbed, err = required("pos_embed.weight"); err != nil {
+		return err
+	}
+
+	for i := range tower.Blocks {
+		bp := fmt.Sprintf("blocks.%d.", i)
+		blk := &VisionBlock{}
+		if blk.Norm1, err = layerNorm(bp + "norm1"); err != nil {
+			return err
+		}
+		if blk.Norm2, err = layerNorm(bp + "norm2"); err != nil {
+			return err
+		}
+		if blk.QKV, err = requiredLinear(bp + "attn.qkv"); err != nil {
+			return err
+		}
+		if blk.Proj, err = requiredLinear(bp + "attn.proj"); err != nil {
+			return err
+		}
+		if blk.FC1, err = requiredLinear(bp + "mlp.linear_fc1"); err != nil {
+			return err
+		}
+		if blk.FC2, err = requiredLinear(bp + "mlp.linear_fc2"); err != nil {
+			return err
+		}
+		tower.Blocks[i] = blk
+	}
+
+	if tower.MergerNorm, err = layerNorm("merger.norm"); err != nil {
+		return err
+	}
+	if tower.MergerFC1, err = requiredLinear("merger.linear_fc1"); err != nil {
+		return err
+	}
+	if tower.MergerFC2, err = requiredLinear("merger.linear_fc2"); err != nil {
+		return err
+	}
+
+	m.VisionTower = tower
+	return nil
+}
+
+func (m *Model) visionLoaded() bool { return m.VisionTower != nil }
+
+// PrepareMedia implements base.MediaModel: preprocess each image segment,
+// splice its vision_start + pads + vision_end expansion, and precompute the
+// request's 3-channel rope positions.
+func (m *Model) PrepareMedia(segments []base.Segment) (*base.PreparedRequest, error) {
+	prepared := &base.PreparedRequest{}
+
+	// pos walks the reference's multimodal position rule: text advances one
+	// per token on all channels; an image spans a merged grid anchored at
+	// the current position and advances it by the grid's longer side.
+	var positions []int32
+	cur := int32(0)
+	maxPos := int32(-1)
+	text := func(n int) {
+		for range n {
+			positions = append(positions, cur, cur, cur)
+			maxPos = max(maxPos, cur)
+			cur++
+		}
+	}
+
+	for s, seg := range segments {
+		if seg.Data == nil {
+			prepared.Tokens = append(prepared.Tokens, seg.Tokens...)
+			text(len(seg.Tokens))
+			continue
+		}
+		if !m.visionLoaded() {
+			return nil, fmt.Errorf("this model does not support %s input", seg.Kind)
+		}
+		if seg.Kind != "image" {
+			return nil, fmt.Errorf("qwen3.5 does not support %s input", seg.Kind)
+		}
+
+		pixels, prep, err := m.preprocessImage(seg.Data)
+		if err != nil {
+			return nil, err
+		}
+
+		start := len(prepared.Tokens)
+		prepared.Tokens = append(prepared.Tokens, m.MM.VisionStartTokenID)
+		text(1)
+		merge := m.Vision.SpatialMergeSize
+		mh, mw := prep.gridH/merge, prep.gridW/merge
+		for bh := range mh {
+			for bw := range mw {
+				prepared.Tokens = append(prepared.Tokens, m.MM.ImageTokenID)
+				positions = append(positions, cur, cur+bh, cur+bw)
+				maxPos = max(maxPos, max(cur+bh, cur+bw))
+			}
+		}
+		cur += max(mh, mw)
+		prepared.Tokens = append(prepared.Tokens, m.MM.VisionEndTokenID)
+		text(1)
+
+		n := int(prep.numPatches())
+		prepared.Items = append(prepared.Items, base.PreparedItem{
+			Range:     [2]int{start, len(prepared.Tokens)},
+			Source:    s,
+			MediaData: pixels,
+			Dims:      []int{n, len(pixels) / n},
+			Opaque:    prep,
+			Causal:    true,
+		})
+	}
+
+	if len(prepared.Items) > 0 {
+		// positions accumulated as (t,h,w) triples per token; the layout
+		// stores three channel rows.
+		L := int32(len(prepared.Tokens))
+		table := make([]int32, 3*L)
+		for i := range L {
+			table[i] = positions[3*i]
+			table[L+i] = positions[3*i+1]
+			table[2*L+i] = positions[3*i+2]
+		}
+		prepared.Layout = &visionLayout{positions: table, promptLen: L, delta: maxPos + 1 - L}
+	}
+	return prepared, nil
+}
+
+// EncodeMedia implements base.MediaModel: run the tower over one whole
+// image, returning the lazy [numTokens, hidden] features.
+func (m *Model) EncodeMedia(item *base.PreparedItem, data *mlx.Array) *mlx.Array {
+	prep := item.Opaque.(preparedImage)
+	v := m.Vision
+	t := m.VisionTower
+	n := prep.numPatches()
+
+	h := t.PatchEmbed.Forward(data.AsType(t.PosEmbed.DType()))
+
+	// Bilinear position interpolation: four corner rows summed with their
+	// weights, in fp32 like the reference.
+	pos := mlx.Zeros(mlx.DTypeFloat32, int(n), int(v.HiddenSize))
+	for c := range 4 {
+		idx := make([]int32, n)
+		wt := make([]float32, n)
+		for i := range int(n) {
+			idx[i] = prep.posIdx[4*i+c]
+			wt[i] = prep.posWt[4*i+c]
+		}
+		rows := mlx.Take(t.PosEmbed, mlx.FromValues(idx, int(n)), 0).AsType(mlx.DTypeFloat32)
+		pos = mlx.Add(pos, mlx.Mul(rows, mlx.FromValues(wt, int(n), 1)))
+	}
+	h = mlx.Add(h, pos.AsType(h.DType()))
+	h = mlx.Reshape(h, 1, n, v.HiddenSize)
+
+	headDim := v.HiddenSize / v.NumHeads
+	cos, sin := visionRopeTables(prep.ropePos, n, headDim)
+	scale := float32(1.0 / math.Sqrt(float64(headDim)))
+
+	for _, blk := range t.Blocks {
+		x := blk.Norm1.Forward(h)
+		qkv := mlx.Reshape(blk.QKV.Forward(x), 1, n, 3, v.NumHeads, headDim)
+		split := func(i int32) *mlx.Array {
+			s := mlx.SliceStartStop(qkv, []int32{0, 0, i, 0, 0}, []int32{1, n, i + 1, v.NumHeads, headDim})
+			return mlx.Transpose(mlx.Squeeze(s, 2), 0, 2, 1, 3)
+		}
+		q, k, val := split(0), split(1), split(2)
+		q = applyVisionRoPE(q, cos, sin)
+		k = applyVisionRoPE(k, cos, sin)
+
+		// Fully bidirectional over the single image.
+		out := mlx.FastScaledDotProductAttention(q, k, val, scale, "", nil)
+		out = mlx.Reshape(mlx.Transpose(out, 0, 2, 1, 3), 1, n, v.HiddenSize)
+		h = mlx.Add(h, blk.Proj.Forward(out))
+
+		x = blk.Norm2.Forward(h)
+		h = mlx.Add(h, blk.FC2.Forward(mlx.GELUApprox(blk.FC1.Forward(x))))
+	}
+
+	// Block-major token order makes the merge reshape a plain grouping of
+	// consecutive rows; the activation is the exact erf GELU in fp32, like
+	// the reference.
+	merged := t.MergerNorm.Forward(mlx.Squeeze(h, 0))
+	unit := v.SpatialMergeSize * v.SpatialMergeSize
+	merged = mlx.Reshape(merged, n/unit, v.HiddenSize*unit)
+	f := t.MergerFC1.Forward(merged).AsType(mlx.DTypeFloat32)
+	f = mlx.Mul(mlx.MulScalar(f, 0.5),
+		mlx.AddScalar(mlx.Erf(mlx.MulScalar(f, float32(1/math.Sqrt2))), 1))
+	out := t.MergerFC2.Forward(f.AsType(merged.DType()))
+	return out
+}
+
+// visionRopeTables builds the tower's rotary tables: 2D positions, half the
+// head dim per axis, in fp32.
+func visionRopeTables(ropePos []int32, n, headDim int32) (cos, sin *mlx.Array) {
+	half := int(headDim) / 2
+	nFreq := half / 2
+	invFreq := make([]float32, nFreq)
+	for i := range invFreq {
+		invFreq[i] = float32(1 / math.Pow(10000, float64(2*i)/float64(half)))
+	}
+
+	// Per token: h-axis freqs then w-axis freqs, duplicated across the two
+	// rotation halves.
+	emb := make([]float32, int(n)*int(headDim))
+	for i := range n {
+		hp, wp := float32(ropePos[2*i]), float32(ropePos[2*i+1])
+		row := emb[int(i)*int(headDim):]
+		for j := range nFreq {
+			row[j] = hp * invFreq[j]
+			row[nFreq+j] = wp * invFreq[j]
+		}
+		copy(row[half:], row[:half])
+	}
+	e := mlx.FromValues(emb, 1, int(n), 1, int(headDim))
+	return mlx.Cos(e), mlx.Sin(e)
+}
+
+// applyVisionRoPE applies full-dim rotate-half rotary in fp32, matching the
+// reference's float application.
+func applyVisionRoPE(t, cos, sin *mlx.Array) *mlx.Array {
+	dt := t.DType()
+	tf := t.AsType(mlx.DTypeFloat32)
+	dims := tf.Dims()
+	headDim := int32(dims[3])
+	half := headDim / 2
+	t1 := tf.Slice(mlx.Slice(), mlx.Slice(), mlx.Slice(), mlx.Slice(0, int(half)))
+	t2 := tf.Slice(mlx.Slice(), mlx.Slice(), mlx.Slice(), mlx.Slice(int(half), int(headDim)))
+	rot := mlx.Concatenate([]*mlx.Array{mlx.Neg(t2), t1}, -1)
+	// cos/sin are [1, n, 1, headDim]; broadcast over heads on axis 1 needs
+	// the transpose-matched layout [1, 1, n, headDim].
+	c := mlx.Transpose(cos, 0, 2, 1, 3)
+	s := mlx.Transpose(sin, 0, 2, 1, 3)
+	return mlx.Add(mlx.Mul(tf, c), mlx.Mul(rot, s)).AsType(dt)
+}
+
+// softRun returns an item's image-token range: the expansion is
+// vision_start + pads + vision_end.
+func softRun(item batch.MediaItem, merge int32) (start, end int) {
+	prep := item.Opaque.(preparedImage)
+	return item.Pos + 1, item.Pos + 1 + int(prep.numTokens(merge))
+}
+
+// scatterMedia overwrites the image-token rows this chunk covers with the
+// item's encoded features. delta shifts each row's offset to the sequence
+// position of batch column 0.
+func (m *Model) scatterMedia(h *mlx.Array, b *batch.Batch, delta int) *mlx.Array {
+	merge := m.Vision.SpatialMergeSize
+	for _, item := range b.Media {
+		if item.Features == nil {
+			continue
+		}
+		start, end := softRun(item, merge)
+		base := int(b.SeqOffsets[item.Seq]) + delta
+		qLo := max(start, base)
+		qHi := min(end, base+int(b.SeqQueryLens[item.Seq]))
+		if qHi <= qLo {
+			continue
+		}
+		feat := item.Features.Slice(mlx.Slice(qLo-start, qHi-start), mlx.Slice())
+		feat = mlx.Reshape(feat.AsType(h.DType()), 1, int32(qHi-qLo), m.HiddenSize)
+		h = h.SliceUpdate(feat, mlx.Slice(item.Seq, item.Seq+1), mlx.Slice(qLo-base, qHi-base), mlx.Slice())
+	}
+	return h
+}
+
+// ropePositions returns each row's 3-channel positions, flattened [B][3][L],
+// from its layout: table rows inside the prompt, the uniform text
+// continuation past it. Rows without a layout advance uniformly on all
+// channels. Nil when no row carries a layout (plain 1D positions).
+func ropePositions(b *batch.Batch, L int32) []int32 {
+	carried := false
+	for _, l := range b.Layout {
+		carried = carried || l != nil
+	}
+	if !carried {
+		return nil
+	}
+	out := make([]int32, 3*L*int32(len(b.SeqOffsets)))
+	for r, base := range b.SeqOffsets {
+		row := out[r*3*int(L):]
+		var layout *visionLayout
+		if b.Layout[r] != nil {
+			layout = b.Layout[r].(*visionLayout)
+		}
+		for i := range L {
+			p := base + i
+			switch {
+			case layout == nil:
+				row[i], row[L+i], row[2*L+i] = p, p, p
+			case p < layout.promptLen:
+				row[i] = layout.positions[p]
+				row[L+i] = layout.positions[layout.promptLen+p]
+				row[2*L+i] = layout.positions[2*layout.promptLen+p]
+			default:
+				row[i], row[L+i], row[2*L+i] = p+layout.delta, p+layout.delta, p+layout.delta
+			}
+		}
+	}
+	return out
+}
+
+// mropeCosSin builds the interleaved 3-channel rotary tables for one chunk:
+// each channel's frequencies laid out round-robin T,H,W across the rotary
+// half-dims, matching the reference's interleaved M-RoPE. positions is
+// ropePositions' per-row [3][L] blocks.
+func mropeCosSin(cfg *Config, positions []int32, L int32) (cos, sin *mlx.Array) {
+	half := int(cfg.RopeDim) / 2
+	invFreq := make([]float32, half)
+	for i := range invFreq {
+		invFreq[i] = float32(1 / math.Pow(float64(cfg.RopeTheta), float64(2*i)/float64(cfg.RopeDim)))
+	}
+
+	// Interleave: start from T, then overwrite H at 1,4,7,... and W at
+	// 2,5,8,..., each bounded by its section's 3x length like the reference.
+	sel := make([]int32, half)
+	for c := int32(1); c <= 2; c++ {
+		limit := min(int(cfg.MropeSection[c])*3, half)
+		for j := int(c); j < limit; j += 3 {
+			sel[j] = c
+		}
+	}
+
+	B := len(positions) / (3 * int(L))
+	emb := make([]float32, B*int(L)*int(cfg.RopeDim))
+	for r := range B {
+		rowPos := positions[r*3*int(L):]
+		for i := range int(L) {
+			row := emb[(r*int(L)+i)*int(cfg.RopeDim):]
+			for j, c := range sel {
+				row[j] = float32(rowPos[int(c)*int(L)+i]) * invFreq[j]
+			}
+			copy(row[half:], row[:half])
+		}
+	}
+	e := mlx.FromValues(emb, B, 1, int(L), int(cfg.RopeDim))
+	return mlx.Cos(e), mlx.Sin(e)
+}
+
+// applyMRoPE rotates the leading RopeDim dims with the chunk's tables,
+// passing the rest through, in the tensor's own dtype like the reference.
+func applyMRoPE(t, cos, sin *mlx.Array, ropeDim int32) *mlx.Array {
+	dims := t.Dims()
+	headDim := int32(dims[3])
+	rot := t.Slice(mlx.Slice(), mlx.Slice(), mlx.Slice(), mlx.Slice(0, int(ropeDim)))
+	half := ropeDim / 2
+	r1 := rot.Slice(mlx.Slice(), mlx.Slice(), mlx.Slice(), mlx.Slice(0, int(half)))
+	r2 := rot.Slice(mlx.Slice(), mlx.Slice(), mlx.Slice(), mlx.Slice(int(half), int(ropeDim)))
+	rotated := mlx.Concatenate([]*mlx.Array{mlx.Neg(r2), r1}, -1)
+	c := cos.AsType(t.DType())
+	s := sin.AsType(t.DType())
+	out := mlx.Add(mlx.Mul(rot, c), mlx.Mul(rotated, s))
+	if ropeDim == headDim {
+		return out
+	}
+	pass := t.Slice(mlx.Slice(), mlx.Slice(), mlx.Slice(), mlx.Slice(int(ropeDim), int(headDim)))
+	return mlx.Concatenate([]*mlx.Array{out, pass}, -1)
+}

--- a/x/models/qwen3_5/vision_test.go
+++ b/x/models/qwen3_5/vision_test.go
@@ -1,0 +1,167 @@
+package qwen3_5
+
+import (
+	"bytes"
+	"image"
+	"image/png"
+	"strings"
+	"testing"
+
+	"github.com/ollama/ollama/x/mlxrunner/model/base"
+)
+
+func TestSmartResize(t *testing.T) {
+	// Goldens from the reference smart_resize at the family's processor
+	// bounds (factor 32, pixels in [65536, 16777216]).
+	cases := []struct{ h, w, wantH, wantW int32 }{
+		{480, 640, 480, 640},
+		{1080, 1920, 1088, 1920},
+		{3024, 4032, 3008, 4032},
+		{100, 100, 256, 256},
+		{37, 5000, 32, 4992},
+	}
+	for _, c := range cases {
+		h, w, err := smartResize(c.h, c.w, 32)
+		if err != nil {
+			t.Fatalf("smartResize(%d, %d): %v", c.h, c.w, err)
+		}
+		if h != c.wantH || w != c.wantW {
+			t.Errorf("smartResize(%d, %d) = (%d, %d), want (%d, %d)", c.h, c.w, h, w, c.wantH, c.wantW)
+		}
+	}
+	if _, _, err := smartResize(10, 5000, 32); err == nil {
+		t.Error("aspect ratio over 200 should error")
+	}
+}
+
+func TestParseMultimodalConfig(t *testing.T) {
+	mm, err := parseMultimodalConfig([]byte(`{
+		"image_token_id": 248056, "vision_start_token_id": 248053, "vision_end_token_id": 248054,
+		"vision_config": {"depth": 27, "hidden_size": 1152, "deepstack_visual_indexes": []}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	v := mm.VisionConfig
+	if v == nil || v.PatchSize != 16 || v.SpatialMergeSize != 2 || v.TemporalPatchSize != 2 || v.NumHeads != 16 {
+		t.Fatalf("defaults not applied: %+v", v)
+	}
+
+	// Deepstack injection is not implemented; a config requesting it must
+	// fail the load rather than silently skip the injections.
+	_, err = parseMultimodalConfig([]byte(`{
+		"vision_config": {"depth": 27, "deepstack_visual_indexes": [8, 16, 24]}}`))
+	if err == nil || !strings.Contains(err.Error(), "deepstack") {
+		t.Fatalf("deepstack config accepted: %v", err)
+	}
+}
+
+// TestMRopePositionRule drives a real image through PrepareMedia and checks
+// the reference position rule: text advances all channels one per token; an
+// image grid anchors T at the current position, offsets H/W by row/column,
+// and advances the position by the grid's longer side.
+func TestMRopePositionRule(t *testing.T) {
+	cfg := &VisionConfig{PatchSize: 16, SpatialMergeSize: 2, TemporalPatchSize: 2, InChannels: 3, NumPositionEmbeddings: 2304}
+	m := &Model{
+		Config:      &Config{},
+		VisionTower: &VisionTower{},
+		Vision:      cfg,
+		MM: multimodalConfig{
+			ImageTokenID:       9,
+			VisionStartTokenID: 7,
+			VisionEndTokenID:   8,
+			VisionConfig:       cfg,
+		},
+	}
+
+	prepared, err := m.PrepareMedia([]base.Segment{{Tokens: []int32{1, 2, 3}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prepared.Layout != nil {
+		t.Fatal("text-only stream must carry no layout")
+	}
+
+	// A 64x64 PNG resizes to the 256x256 minimum-pixel floor: a 16x16 patch
+	// grid, merged 8x8.
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, image.NewRGBA(image.Rect(0, 0, 64, 64))); err != nil {
+		t.Fatal(err)
+	}
+	prepared, err = m.PrepareMedia([]base.Segment{
+		{Tokens: []int32{1, 2, 3}},
+		{Kind: "image", Data: buf.Bytes()},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Three text tokens, vision_start, 64 pads, vision_end.
+	const L = 69
+	if len(prepared.Tokens) != L {
+		t.Fatalf("tokens = %d, want %d", len(prepared.Tokens), L)
+	}
+	if len(prepared.Items) != 1 || prepared.Items[0].Range != [2]int{3, L} || !prepared.Items[0].Causal {
+		t.Fatalf("items = %+v", prepared.Items)
+	}
+
+	layout := prepared.Layout.(*visionLayout)
+	if layout.promptLen != L {
+		t.Fatalf("promptLen = %d, want %d", layout.promptLen, L)
+	}
+	// The image anchors at position 4 and advances the cursor by its longer
+	// side: vision_end lands at 12 and decode continues from maxPos+1.
+	if want := int32(12 + 1 - L); layout.delta != want {
+		t.Fatalf("delta = %d, want %d", layout.delta, want)
+	}
+	pos := func(i int32) [3]int32 {
+		return [3]int32{layout.positions[i], layout.positions[L+i], layout.positions[2*L+i]}
+	}
+	checks := []struct {
+		i    int32
+		want [3]int32
+	}{
+		{0, [3]int32{0, 0, 0}},     // text
+		{2, [3]int32{2, 2, 2}},     // text
+		{3, [3]int32{3, 3, 3}},     // vision_start
+		{4, [3]int32{4, 4, 4}},     // image row 0, col 0
+		{5, [3]int32{4, 4, 5}},     // image row 0, col 1
+		{12, [3]int32{4, 5, 4}},    // image row 1, col 0
+		{67, [3]int32{4, 11, 11}},  // image row 7, col 7
+		{68, [3]int32{12, 12, 12}}, // vision_end
+	}
+	for _, c := range checks {
+		if got := pos(c.i); got != c.want {
+			t.Errorf("positions[%d] = %v, want %v", c.i, got, c.want)
+		}
+	}
+}
+
+func TestVisionPatchLookups(t *testing.T) {
+	// 4x6 pre-merge grid, merge 2: token order is block-major; rope
+	// positions are the pre-merge (h, w) indices.
+	ropePos, posIdx, posWt := visionPatchLookups(4, 6, 2, 2304)
+	if len(ropePos) != 2*24 || len(posIdx) != 4*24 || len(posWt) != 4*24 {
+		t.Fatalf("lengths %d %d %d", len(ropePos), len(posIdx), len(posWt))
+	}
+	// First merge block covers (0,0) (0,1) (1,0) (1,1) in that order.
+	want := []int32{0, 0, 0, 1, 1, 0, 1, 1}
+	for i, w := range want {
+		if ropePos[i] != w {
+			t.Fatalf("ropePos[:8] = %v, want %v", ropePos[:8], want)
+		}
+	}
+	// Second block continues at (0,2).
+	if ropePos[8] != 0 || ropePos[9] != 2 {
+		t.Fatalf("second block starts at (%d, %d), want (0, 2)", ropePos[8], ropePos[9])
+	}
+	// Bilinear weights sum to one per patch.
+	for i := range 24 {
+		var sum float32
+		for c := range 4 {
+			sum += posWt[4*i+c]
+		}
+		if sum < 0.999 || sum > 1.001 {
+			t.Fatalf("patch %d weights sum %f", i, sum)
+		}
+	}
+}


### PR DESCRIPTION
MLX vision checkpoints are already exposed as image-capable, but the client does not send media to the runner and the prompt is processed as ordinary text. Supporting images also needs to preserve prefix caching and speculative decoding without teaching the runner the details of each model's image layout.

This adds a media interface that lets a model expand the full ordered prompt and return its preprocessed image inputs and request-wide positional state. The runner remains responsible for parsing references, validating the result, distinguishing images in prefix-cache keys, and scheduling lazy feature encoding as prefill reaches each image. The same state is passed through target and draft forwards.

Qwen 3.5 and Qwen 3.6 implement this with their vision tower and multimodal RoPE layout. The encoded image features replace the corresponding placeholder embeddings in both the main model and its MTP draft head. Text-only requests continue to use the existing tokenization, cache keys, and RoPE path.