### PR TITLE
Recover panics in CreateHandler's model conversion goroutine

### DIFF
--- a/server/create.go
+++ b/server/create.go
@@ -204,7 +204,7 @@ func (s *Server) CreateHandler(c *gin.Context) {
 				}
 			}
 		} else if r.Files != nil {
-			baseLayers, err = convertModelFromFiles(r.Files, baseLayers, false, fn)
+			baseLayers, err = convertModelFromFilesFn(r.Files, baseLayers, false, fn)
 			if err != nil {
 				for _, badReq := range []error{errNoFilesProvided, errOnlyGGUFSupported, errUnknownType} {
 					if errors.Is(err, badReq) {
@@ -418,6 +418,12 @@ func remoteURL(raw string) (string, error) {
 func convertModelFromFiles(files map[string]string, baseLayers []*layerGGML, isAdapter bool, fn func(resp api.ProgressResponse)) ([]*layerGGML, error) {
 	return convertModelFromFilesWithMediaType(files, baseLayers, isAdapter, "", true, fn)
 }
+
+// convertModelFromFilesFn is a seam over convertModelFromFiles so tests can
+// simulate a panic from the model conversion pipeline (e.g. a malformed
+// GGUF/safetensors file) without needing a real file that crashes a specific
+// converter.
+var convertModelFromFilesFn = convertModelFromFiles
 
 func convertDraftModelFromFiles(files map[string]string, baseLayers []*layerGGML, fn func(resp api.ProgressResponse)) ([]*layerGGML, error) {
 	return convertModelFromFilesWithMediaType(files, baseLayers, false, manifest.MediaTypeImageDraft, false, fn)

--- a/server/create.go
+++ b/server/create.go
@@ -19,6 +19,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"runtime/debug"
 	"slices"
 	"strconv"
 	"strings"
@@ -118,6 +119,17 @@ func (s *Server) CreateHandler(c *gin.Context) {
 	ch := make(chan any)
 	go func() {
 		defer close(ch)
+		defer func() {
+			// A panic anywhere in the conversion pipeline (e.g. a malformed
+			// GGUF/safetensors file triggering an index-out-of-range or
+			// divide-by-zero in one of the model converters) must not take
+			// down the whole ollama serve process. Recover it here and
+			// report it to the client as a regular error instead.
+			if rec := recover(); rec != nil {
+				slog.Error("panic while creating model", "name", name, "error", rec, "stack", string(debug.Stack()))
+				ch <- gin.H{"error": fmt.Sprintf("failed to create model: %v", rec)}
+			}
+		}()
 		fn := func(resp api.ProgressResponse) {
 			ch <- resp
 		}

--- a/server/routes_create_test.go
+++ b/server/routes_create_test.go
@@ -154,6 +154,43 @@ func TestCreateHandlerRejectsInvalidInfoTypes(t *testing.T) {
 	}
 }
 
+// TestCreateHandlerRecoversConversionPanic ensures that a panic inside the
+// background model conversion goroutine (e.g. triggered by a malformed
+// model file) is recovered and reported to the client as a normal error
+// response instead of crashing the process.
+func TestCreateHandlerRecoversConversionPanic(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	oldConvert := convertModelFromFilesFn
+	t.Cleanup(func() { convertModelFromFilesFn = oldConvert })
+	convertModelFromFilesFn = func(files map[string]string, baseLayers []*layerGGML, isAdapter bool, fn func(resp api.ProgressResponse)) ([]*layerGGML, error) {
+		panic("simulated conversion panic: index out of range")
+	}
+
+	var s Server
+	_, digest := createBinFile(t, nil, nil)
+	w := createRequest(t, s.CreateHandler, api.CreateRequest{
+		Model: "test-create-conversion-panic",
+		Files: map[string]string{
+			"test.gguf": digest,
+		},
+		Stream: &stream,
+	})
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status code 500, got %d", w.Code)
+	}
+
+	var resp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := resp["error"]; !strings.Contains(got, "simulated conversion panic") {
+		t.Fatalf("expected error to mention the recovered panic, got %q", got)
+	}
+}
+
 func readCreatedModelConfig(t *testing.T, name string) model.ConfigV2 {
 	t.Helper()
 


### PR DESCRIPTION
Fixes #17179

## Root cause
`POST /api/create` runs model conversion (any of the 20+ converters) inside a background goroutine. Gin's `Recovery()` middleware only protects the synchronous HTTP handler goroutine, not goroutines spawned inside it. A panic triggered by a malformed model file (index out of range, divide-by-zero, bad slice length, etc.) inside that goroutine was unrecovered and crashed the entire `ollama serve` process, dropping all in-flight requests.

## Fix
Add a deferred `recover()` around the goroutine body that logs the panic and reports it to the client as a normal JSON error response instead of taking down the server.

## Note
Go toolchain wasn't available in my environment to run `go build`/`go vet`, so this was verified via careful manual review (import ordering, defer/brace balance, defer LIFO ordering, response handling) rather than a build. Happy to address any CI feedback.