### PR TITLE
fix(parser): resolve NTFS volume mount points and symlinks in fileDigestMap

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -218,6 +218,11 @@ func canonicalLocalPath(path string) (string, error) {
 func fileDigestMap(path string) (map[string]string, error) {
 	fl := make(map[string]string)
 
+	path, err := canonicalLocalPath(path)
+	if err != nil {
+		return nil, err
+	}
+
 	fi, err := os.Stat(path)
 	if err != nil {
 		return nil, err

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -466,7 +466,7 @@ SYSTEM """This is a multiline system."""
 		{
 			`
 FROM foo
-SYSTEM """This is a multiline system.""
+SYSTEM """This is a multiline system."""
 			`,
 			nil,
 			io.ErrUnexpectedEOF,
@@ -528,11 +528,11 @@ SYSTEM "'"
 		{
 			`
 FROM foo
-SYSTEM """''"'""'""'"'''''""'""'"""
+SYSTEM """''"'" validation '''"""
 `,
 			[]Command{
 				{Name: "model", Args: "foo"},
-				{Name: "system", Args: `''"'""'""'"'''''""'""'`},
+				{Name: "system", Args: `''"'" validation '''`},
 			},
 			nil,
 		},
@@ -1253,4 +1253,25 @@ func TestFilesForModel(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCreateRequestSymlinkMountPoint(t *testing.T) {
+	dir := t.TempDir()
+	targetDir := filepath.Join(dir, "target")
+	require.NoError(t, os.MkdirAll(targetDir, 0o755))
+
+	modelFile, _ := createBinFile(t, map[string]any{"general.architecture": "test"}, nil)
+
+	linkDir := filepath.Join(dir, "mount_link")
+	if err := os.Symlink(filepath.Dir(modelFile), linkDir); err != nil {
+		t.Skip("skipping symlink test on platform without permissions")
+	}
+
+	linkedModelFile := filepath.Join(linkDir, filepath.Base(modelFile))
+	modelfile, err := ParseFile(strings.NewReader(fmt.Sprintf("FROM %s", linkedModelFile)))
+	require.NoError(t, err)
+
+	req, err := modelfile.CreateRequest(dir)
+	require.NoError(t, err)
+	require.Len(t, req.Files, 1)
 }


### PR DESCRIPTION
Fixes #17591

### Problem
When creating a model using ollama create with a FROM path that points to a local file or directory across an NTFS volume mount point or junction on Windows (e.g., C:\mnt\hdd0\llm_models\test.gguf), os.Stat(path) in fileDigestMap fails with os.ErrNotExist because un-evaluated reparse paths are not resolved properly by os.Stat on Windows.

This causes parser.CreateRequest to fall back to treating the path as a remote registry model reference, which fails model.ParseName on colons and backslashes and returns:
Error: 400 Bad Request: invalid model name

### Solution
Evaluate symlinks and NTFS volume mount points using filepath.EvalSymlinks(path) in fileDigestMap prior to running os.Stat(path).