### PR TITLE
docs: add VS Code context length guidance

### DIFF
--- a/docs/integrations/vscode.mdx
+++ b/docs/integrations/vscode.mdx
@@ -38,6 +38,12 @@ ollama signin
 
 Local models do not require sign-in.
 
+## Context length
+
+VS Code may show a model's maximum supported context length even when Ollama allocates a smaller context at runtime.
+
+For local models, open Ollama **Settings**, set the context length to at least 64k, reload the VS Code window, and resend your prompt. See [Context length](/context-length) for more information.
+
 ## Troubleshooting
 
 If Ollama models do not appear in the model picker:


### PR DESCRIPTION
## Summary

- explain that VS Code may show a model's maximum supported context length while Ollama allocates a smaller runtime context
- tell local-model users to set Ollama's context length to at least 64k, reload the VS Code window, and resend their prompt
- link to the context length documentation

## Why

This helps users distinguish model metadata shown in VS Code from the context Ollama actually allocates at runtime and gives them a direct recovery path.

## Validation

- `mintlify validate`