### PR TITLE
fix: stop retrying rejected cloud auth sessions

### DIFF
--- a/app/ui/app/src/api.ts
+++ b/app/ui/app/src/api.ts
@@ -45,6 +45,19 @@ function uint8ArrayToBase64(uint8Array: Uint8Array): string {
   return btoa(binary);
 }
 
+// UIClientError marks failures talking to the local UI server so callers can
+// distinguish retryable network/server failures from definitive HTTP status
+// responses (e.g. 401/403 auth responses) that must not be retried in a loop.
+export class UIClientError extends Error {
+  status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "UIClientError";
+    this.status = status;
+  }
+}
+
 export async function fetchUser(): Promise<User | null> {
   const response = await fetch(`${API_BASE}/api/me`, {
     method: "POST",
@@ -67,7 +80,10 @@ export async function fetchUser(): Promise<User | null> {
     return null;
   }
 
-  throw new Error(`Failed to fetch user: ${response.status}`);
+  throw new UIClientError(
+    `Failed to fetch user: ${response.status}`,
+    response.status,
+  );
 }
 
 export async function fetchConnectUrl(): Promise<string> {
@@ -85,7 +101,17 @@ export async function fetchConnectUrl(): Promise<string> {
     }
   }
 
-  throw new Error("Failed to fetch connect URL");
+  if (response.status === 403) {
+    // A 403 here means the session is rejected, not that the user can fix it
+    // by retrying. Surface the status so the caller stops polling instead of
+    // re-entering the sign-in flow.
+    throw new UIClientError(
+      `Failed to fetch connect URL: ${response.status}`,
+      response.status,
+    );
+  }
+
+  throw new UIClientError("Failed to fetch connect URL", response.status);
 }
 
 export async function disconnectUser(): Promise<void> {
@@ -97,7 +123,10 @@ export async function disconnectUser(): Promise<void> {
   });
 
   if (!response.ok) {
-    throw new Error("Failed to disconnect user");
+    throw new UIClientError(
+      `Failed to disconnect user: ${response.status}`,
+      response.status,
+    );
   }
 }
 

--- a/app/ui/app/src/hooks/useUser.ts
+++ b/app/ui/app/src/hooks/useUser.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { fetchUser, fetchConnectUrl, disconnectUser } from "@/api";
+import { fetchUser, fetchConnectUrl, disconnectUser, UIClientError } from "@/api";
 
 export function useUser() {
   const queryClient = useQueryClient();
@@ -12,8 +12,14 @@ export function useUser() {
     },
     staleTime: 5 * 60 * 1000, // Consider data stale after 5 minutes
     gcTime: 10 * 60 * 1000, // Keep in cache for 10 minutes
-    retry: 10,
-    retryDelay: (attemptIndex) => Math.min(500 * attemptIndex, 2000),
+    retry: (failureCount, error) => {
+      // Do not retry definitive client errors (401/403). During an ollama.com
+      // auth outage, retrying these recreates the sign-in/verification loop
+      // reported in ollama/ollama#17471.
+      if (error instanceof UIClientError && error.status >= 400 && error.status < 500) return false;
+      return failureCount < 3;
+    },
+    retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 10000),
     refetchOnMount: true, // Always fetch when component mounts
   });
 


### PR DESCRIPTION
Fixes #17471

Treat definitive 4xx responses from the local cloud-auth endpoints as non-retryable UI client errors. This prevents rejected Ollama.com sessions from being retried into an endless sign-in or verification loop, while retaining bounded retries for transient failures.

local verification not run; relying on upstream CI