### PR TITLE
fix(llm): mirror GraphSize KV accounting in PredictServerVRAM

### DIFF
--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -2623,19 +2623,42 @@ func PredictServerVRAM(modelPath string, f *ggml.GGML, numCtx int) uint64 {
 		weights = uint64(info.Size())
 	}
 
-	// KV cache: 2 (K+V) * layers * kv_heads * head_dim * context * 2 bytes (f16)
-	layers := f.KV().BlockCount()
-	kvHeads := f.KV().HeadCountKVMin()
-	if kvHeads == 0 {
-		kvHeads = 1
-	}
-	headDim := uint64(0)
-	if f.KV().HeadCountMax() > 0 {
-		headDim = f.KV().EmbeddingLength() / f.KV().HeadCountMax()
-	}
-	kvCache := 2 * layers * kvHeads * headDim * uint64(numCtx) * 2
+	return weights + predictKVCacheSize(f, numCtx)
+}
 
-	return weights + kvCache
+// predictKVCacheSize estimates the attention KV cache for numCtx tokens:
+// (k_head_dim + v_head_dim) * kv_heads * context * 2 bytes (f16) per attention
+// layer. Layers that don't run full attention are skipped — hybrid
+// architectures (qwen35, qwen3next) interleave linear attention layers that
+// keep a small fixed-size state instead of a per-token cache.
+func predictKVCacheSize(f *ggml.GGML, numCtx int) uint64 {
+	headDimK := f.KV().EmbeddingHeadCountK()
+	headDimV := f.KV().EmbeddingHeadCountV()
+	if headDimK == 0 && headDimV == 0 {
+		// Models that don't record explicit key/value lengths use a uniform
+		// head size derived from the embedding length.
+		if heads := f.KV().HeadCountMax(); heads > 0 {
+			headDimK = f.KV().EmbeddingLength() / heads
+			headDimV = headDimK
+		}
+	}
+
+	// Hybrid models record a single (max) head count for every block, so the
+	// full attention layers have to be derived from the interval instead.
+	interval := uint64(f.KV().Uint("full_attention_interval"))
+
+	var kvCache uint64
+	for i, kvHeads := range f.KV().HeadCountKV() {
+		if kvHeads == 0 {
+			continue
+		}
+		if interval > 0 && (uint64(i)+1)%interval != 0 {
+			continue
+		}
+		kvCache += (headDimK + headDimV) * kvHeads * uint64(numCtx) * 2
+	}
+
+	return kvCache
 }
 
 // memoryParsingWriter wraps an io.Writer and parses llama-server log output

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -3642,6 +3642,78 @@ func TestLlamaServerChatMessageConvertsMediaParts(t *testing.T) {
 	}
 }
 
+func TestPredictServerVRAM(t *testing.T) {
+	const numCtx = 4096
+
+	tests := []struct {
+		name string
+		kv   ggml.KV
+		// wantKV is the KV cache portion of the prediction, in bytes.
+		wantKV uint64
+	}{
+		{
+			// Hybrid architecture: only every full_attention_interval-th block
+			// runs full attention, the rest keep a small recurrent state. The
+			// converter records a single (max) head_count_kv for every block.
+			name: "qwen35moe hybrid attention",
+			kv: ggml.KV{
+				"general.architecture":              "qwen35moe",
+				"qwen35moe.block_count":             uint32(48),
+				"qwen35moe.embedding_length":        uint32(2048),
+				"qwen35moe.attention.head_count":    uint32(16),
+				"qwen35moe.attention.head_count_kv": uint32(2),
+				"qwen35moe.attention.key_length":    uint32(256),
+				"qwen35moe.attention.value_length":  uint32(256),
+				"qwen35moe.full_attention_interval": uint32(4),
+			},
+			// 48/4 attention layers * (256+256) * 2 heads * 2 bytes * numCtx
+			wantKV: 12 * (256 + 256) * 2 * 2 * numCtx,
+		},
+		{
+			// head_dim is larger than embedding_length/head_count across the
+			// qwen3 family, so the explicit key/value lengths must be used.
+			name: "qwen3moe explicit head dim",
+			kv: ggml.KV{
+				"general.architecture":             "qwen3moe",
+				"qwen3moe.block_count":             uint32(48),
+				"qwen3moe.embedding_length":        uint32(2048),
+				"qwen3moe.attention.head_count":    uint32(32),
+				"qwen3moe.attention.head_count_kv": uint32(4),
+				"qwen3moe.attention.key_length":    uint32(128),
+				"qwen3moe.attention.value_length":  uint32(128),
+			},
+			wantKV: 48 * (128 + 128) * 4 * 2 * numCtx,
+		},
+		{
+			name: "llama without explicit head dim",
+			kv: ggml.KV{
+				"general.architecture":          "llama",
+				"llama.block_count":             uint32(32),
+				"llama.embedding_length":        uint32(4096),
+				"llama.attention.head_count":    uint32(32),
+				"llama.attention.head_count_kv": uint32(32),
+			},
+			wantKV: 32 * (128 + 128) * 32 * 2 * numCtx,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			modelPath, f := writeTestGGML(t, tt.kv, nil)
+			info, err := os.Stat(modelPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			got := PredictServerVRAM(modelPath, f, numCtx)
+			if want := uint64(info.Size()) + tt.wantKV; got != want {
+				t.Errorf("PredictServerVRAM() = %d, want %d (kv cache %d, want %d)",
+					got, want, got-uint64(info.Size()), tt.wantKV)
+			}
+		})
+	}
+}
+
 func TestFindLlamaServer(t *testing.T) {
 	// This just tests that the function doesn't panic and returns a reasonable error
 	// when the binary doesn't exist in the expected locations


### PR DESCRIPTION
# Issue #17517 — Qwen models loading issue in the new update

## 1. Root cause

`llm.PredictServerVRAM` (`llm/llama_server.go`) is the Go-side memory prediction
that the scheduler uses now that GGML models are served by the upstream
`llama-server` subprocess. Its KV cache term was:

```go
layers  := f.KV().BlockCount()
kvHeads := f.KV().HeadCountKVMin(); if kvHeads == 0 { kvHeads = 1 }
headDim := f.KV().EmbeddingLength() / f.KV().HeadCountMax()
kvCache := 2 * layers * kvHeads * headDim * numCtx * 2
```

Two independent assumptions in that formula are false for the Qwen 3.x family:

**a) `head_dim` is not `embedding_length / head_count`.**
Every Qwen 3 converter writes an explicit head dimension —
`convert/convert_qwen3.go:49-50` and `convert/convert_qwen3next.go:446-447` set
`attention.key_length` / `attention.value_length` from `head_dim`. For
`qwen3moe` that is 128 while `embedding_length/head_count` is `2048/32 = 64`,
so the per-layer term is **half** the real size.

**b) Not every block runs full attention.**
`qwen35` / `qwen35moe` / `qwen3next` are hybrid: only every
`full_attention_interval`-th block does full attention, the rest use gated
linear attention (a small fixed-size state, not a per-token cache).
`convert/convert_qwen3next.go:501-509` records a single *max* `head_count_kv`
scalar for the whole model (the per-layer array is not written), and
`block_count` includes the linear-attention blocks *and* the MTP `nextn` blocks
(`convert_qwen3next.go:433`). `full_attention_interval` is written to the GGUF
but was read nowhere in Go. So the prediction counted all ~48 blocks as
full-attention layers instead of the ~12 that actually are.

For Qwen3.5 (`qwen35moe`, the model behind the report — it is the local
recommendation with a 262 144 context in `server/model_recommendations.go:398`)
the two errors do not cancel: (b) inflates by `full_attention_interval` (4×) and
(a) deflates by 2×, netting a **~2× overestimate**. For a 48-layer hybrid with
interval 4, 2 KV heads and `head_dim` 256 that is 12.9 GB predicted vs 6.4 GB
actual at 262k context — more than a whole 5070 Ti's worth of phantom VRAM.

That inflated number is consumed in four places in `server/sched.go`:

- `load()` pre-flight (`sched.go:536-570`) — evicts / refuses to place.
- `applyAutomaticGenerationBatch` → `generationBatchFits` (`sched.go:807-895`) —
  an over-large prediction collapses `num_batch` from 2048 → 512, which is
  exactly the "loads, but I don't get the tok/s I always used to get" symptom.
- `applyLlamaServerMmapDefaults` / `maybeDisableMmapForHostPressure`
  (`sched.go:1138-1242`).
- `reduceAutoNumCtxForLoadOOM` (`sched.go:757-783`) — shrinks auto context.

Non-hybrid Qwen 3 / Qwen 3 MoE models hit only error (a) and are
**under**-estimated 2×, which pushes the scheduler the other way (thinks it
fits, then llama-server has to spill layers to CPU).

## 2. The fix and why

`PredictServerVRAM` now delegates the cache term to a new `predictKVCacheSize`
that mirrors the accounting already used by `fs/ggml.GraphSize`:

- use the explicit `attention.key_length` / `attention.value_length` via
  `KV.EmbeddingHeadCountK()` / `EmbeddingHeadCountV()`, falling back to
  `embedding_length / head_count` only when the model records neither (preserves
  the old result for llama-style models);
- walk the per-layer `KV.HeadCountKV()` array and skip layers with no KV heads;
- when `full_attention_interval` is set, skip the blocks that are not full
  attention, using the same `(i+1) % interval == 0` rule the converter uses in
  `qwen3NextModel.kvHeadCounts` (`convert/convert_qwen3next.go:388-393`).

This is the smallest change that makes the prediction match what llama-server
will actually allocate. It is confined to the estimator — no scheduler policy,
thresholds, or llama-server flags were touched, so every consumer above gets a
correct input without changing its own behaviour.

## 3. Files changed

- `llm/llama_server.go` — `PredictServerVRAM` rewritten to use
  `predictKVCacheSize`; new `predictKVCacheSize` helper.
- `llm/llama_server_test.go` — new `TestPredictServerVRAM` covering the hybrid
  (`qwen35moe`), explicit-head-dim (`qwen3moe`), and no-explicit-head-dim
  (`llama`) cases.
- `NOTES.md` — this file.

## 4. Risk / uncertainty

- **The issue has no server logs.** The reporter gave hardware, a model, and a
  symptom, and the only follow-up comment asks for logs. The diagnosis above is
  derived from the code and the GGUF metadata the converters emit, not from a
  reproduction on the reporter's machine. It explains the reported symptoms
  (memory "hitting the ceiling" without filling the GPU; degraded tok/s at a
  context that used to work) but I cannot rule out a second, independent cause
  inside llama-server's own `-ngl auto` / `--fit` placement, which this repo
  does not control.
- The exact Qwen3.5-35B config (layer count, `head_dim`,
  `full_attention_interval`) is not in this repo, so the GB figures above are
  illustrative of the hybrid shape rather than measured from that checkpoint.
  The *direction* and *ratio* of the error do not depend on those specifics.
- Making the estimate smaller for hybrids is a deliberate move away from the
  "intentionally conservative" note on the function. It is now accurate rather
  than conservative for hybrids, and larger (also more accurate) for dense Qwen3.
  If a model records `full_attention_interval` but actually uses the
  `layer_types` list with a non-uniform pattern, the converter does not write the
  interval key, so we fall back to counting every layer — the old, conservative
  behaviour.
- Models with no `head_count_kv` metadata still default to 1 head per layer via
  `KV.HeadCountKV()`, identical to the old `kvHeads == 0 → 1` guard.

## 5. How I verified it

Toolchain: `go1.26.5`.

- Wrote `TestPredictServerVRAM` **before** the fix and confirmed it reproduced
  both errors with concrete numbers at 4096 context:
  - `qwen35moe hybrid attention`: got 201 326 592 B, want 100 663 296 B (2×
    overestimate)
  - `qwen3moe explicit head dim`: got 201 326 592 B, want 402 653 184 B (2×
    underestimate)
  - `llama without explicit head dim`: already passing (regression guard)
- After the fix all three subtests pass:
  `go test ./llm/ -run TestPredictServerVRAM -v`
- No regressions in the surrounding packages:
  `go test ./llm/... ./server/... ./fs/...` → all ok.
- Whole tree: `go build ./...` clean; `go test $(go list ./... | grep -v
  /integration)` all ok. `go vet ./...` reports one pre-existing, unrelated
  finding in `tokenizer/bytepairencoding_test.go:542`.
- `gofmt` clean.

Not verified: an end-to-end load of Qwen3.5 35B Q4_K_M on a 12 GB CUDA card —
no GPU or that model is available in this environment.
