### PR TITLE
fix(parser): keep ordinary JSON content out of Laguna tool calls

### DIFF
--- a/model/parsers/laguna.go
+++ b/model/parsers/laguna.go
@@ -337,13 +337,32 @@ func (p *LagunaParser) consumeStandaloneJSONTool(done bool) (progress bool, cont
 		return false, "", api.ToolCall{}, false, nil
 	}
 
-	if !done && !json.Valid([]byte(strings.TrimSpace(raw))) {
+	if !json.Valid([]byte(strings.TrimSpace(raw))) {
+		if done {
+			// Trailing incomplete JSON at end of stream is ordinary content,
+			// not a malformed tool call; don't abort the response with a
+			// parse error over it.
+			return false, "", api.ToolCall{}, false, nil
+		}
 		if before != "" {
 			p.buffer.Reset()
 			p.buffer.WriteString(acc[jsonIdx:])
 			return true, before, api.ToolCall{}, true, nil
 		}
 		return false, "", api.ToolCall{}, true, nil
+	}
+
+	// A standalone JSON object is a tool call only when its name field
+	// resolves to one of the declared tools. Ordinary JSON in content
+	// (config snippets, examples, structured answers that happen to use
+	// "name"/"arguments" keys) must be streamed through untouched instead
+	// of being swallowed into a fabricated call.
+	name, nameOk := lagunaToolCallName(raw)
+	if !nameOk {
+		return false, "", api.ToolCall{}, false, nil
+	}
+	if _, resolved := lagunaResolveToolName(name, p.tools); !resolved {
+		return false, "", api.ToolCall{}, false, nil
 	}
 
 	call, err = parseLagunaToolCall(raw, p.tools)

--- a/model/parsers/laguna_regression_test.go
+++ b/model/parsers/laguna_regression_test.go
@@ -1,0 +1,86 @@
+package parsers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ollama/ollama/api"
+)
+
+// Regression tests for https://github.com/ollama/ollama/issues/17602:
+// ordinary JSON in streamed content must pass through untouched even when
+// tools are declared; it must neither be swallowed into a fabricated tool
+// call nor abort the reply with a parse error.
+
+func lagunaIssue17602Tools() []api.Tool {
+	return []api.Tool{
+		{
+			Type: "function",
+			Function: api.ToolFunction{
+				Name:        "get_weather",
+				Description: "Get the weather for a city",
+			},
+		},
+	}
+}
+
+func lagunaIssue17602Stream(t *testing.T, parser *LagunaParser, chunks []string) (string, []api.ToolCall) {
+	t.Helper()
+	var content strings.Builder
+	var calls []api.ToolCall
+	for i, chunk := range chunks {
+		c, _, cs, err := parser.Add(chunk, i == len(chunks)-1)
+		require.NoError(t, err)
+		content.WriteString(c)
+		calls = append(calls, cs...)
+	}
+	return content.String(), calls
+}
+
+func TestLagunaIssue17602JSONWithNameFieldStaysContent(t *testing.T) {
+	var parser LagunaParser
+	parser.Init(lagunaIssue17602Tools(), nil, nil)
+
+	content, calls := lagunaIssue17602Stream(t, &parser, []string{`Config: {"name": "my-app", "version": 2}`})
+	require.Empty(t, calls)
+	require.Equal(t, `Config: {"name": "my-app", "version": 2}`, content)
+}
+
+func TestLagunaIssue17602StreamedJSONWithNameFieldStaysContent(t *testing.T) {
+	var parser LagunaParser
+	parser.Init(lagunaIssue17602Tools(), nil, nil)
+
+	content, calls := lagunaIssue17602Stream(t, &parser, []string{`{"na`, `me": "Bob", "age": 8}`})
+	require.Empty(t, calls)
+	require.Equal(t, `{"name": "Bob", "age": 8}`, content)
+}
+
+func TestLagunaIssue17602UnknownToolJSONStaysContent(t *testing.T) {
+	var parser LagunaParser
+	parser.Init(lagunaIssue17602Tools(), nil, nil)
+
+	content, calls := lagunaIssue17602Stream(t, &parser, []string{`{"name": "not_a_tool", "arguments": {"x": 1}}`})
+	require.Empty(t, calls)
+	require.Equal(t, `{"name": "not_a_tool", "arguments": {"x": 1}}`, content)
+}
+
+func TestLagunaIssue17602PlainJSONMidStreamDoesNotAbort(t *testing.T) {
+	var parser LagunaParser
+	parser.Init(lagunaIssue17602Tools(), nil, nil)
+
+	content, _, calls, err := parser.Add(`Result: {"value": 42}`, false)
+	require.NoError(t, err)
+	require.Empty(t, calls)
+	require.Equal(t, `Result: {"value": 42}`, content)
+}
+
+func TestLagunaIssue17602RealStandaloneJSONToolCallStillParsed(t *testing.T) {
+	var parser LagunaParser
+	parser.Init(lagunaIssue17602Tools(), nil, nil)
+
+	content, calls := lagunaIssue17602Stream(t, &parser, []string{`{"name": "get_weather", "arguments": {"city": "Paris"}}`})
+	require.Equal(t, "", content)
+	require.Len(t, calls, 1)
+}


### PR DESCRIPTION
## Summary

- only treat standalone JSON as a tool call when its name resolves to a declared tool
- pass ordinary JSON content through without swallowing it or raising a parse error
- preserve trailing incomplete JSON as ordinary content at end of stream
- add regression coverage for named, unknown-tool, streamed, plain, and valid tool-call JSON

## Verification

- `go test ./model/parsers`