### PR TITLE
manifests: remove OCI rootfs from the model config

### DIFF
--- a/server/create.go
+++ b/server/create.go
@@ -52,9 +52,6 @@ func (s *Server) CreateHandler(c *gin.Context) {
 	config := &model.ConfigV2{
 		OS:           "linux",
 		Architecture: "amd64",
-		RootFS: model.RootFS{
-			Type: "layers",
-		},
 	}
 
 	var r api.CreateRequest
@@ -878,7 +875,7 @@ func createModel(r api.CreateRequest, name model.Name, baseLayers []*layerGGML, 
 		return err
 	}
 
-	configLayer, err := createConfigLayer(layers, *config)
+	configLayer, err := createConfigLayer(*config)
 	if err != nil {
 		return err
 	}
@@ -1424,13 +1421,7 @@ func setMessages(layers []manifest.Layer, m []api.Message) ([]manifest.Layer, er
 	return layers, nil
 }
 
-func createConfigLayer(layers []manifest.Layer, config model.ConfigV2) (*manifest.Layer, error) {
-	digests := make([]string, len(layers))
-	for i, layer := range layers {
-		digests[i] = layer.Digest
-	}
-	config.RootFS.DiffIDs = digests
-
+func createConfigLayer(config model.ConfigV2) (*manifest.Layer, error) {
 	var b bytes.Buffer
 	if err := json.NewEncoder(&b).Encode(config); err != nil {
 		return nil, err

--- a/server/images_test.go
+++ b/server/images_test.go
@@ -280,7 +280,7 @@ func writeTestModelManifest(t *testing.T, name, digest, tmpl string) {
 	}
 
 	layers := []manifest.Layer{modelLayer, templateLayer}
-	configLayer, err := createConfigLayer(layers, model.ConfigV2{
+	configLayer, err := createConfigLayer(model.ConfigV2{
 		ModelFormat:   "gguf",
 		ModelFamily:   "llama",
 		ModelFamilies: []string{"llama"},

--- a/server/routes_create_test.go
+++ b/server/routes_create_test.go
@@ -215,7 +215,6 @@ func TestCreateModelPreservesEmbeddedCompatibilityGGUFWithoutQuantization(t *tes
 	config := &model.ConfigV2{
 		OS:           "linux",
 		Architecture: "amd64",
-		RootFS:       model.RootFS{Type: "layers"},
 	}
 	req := api.CreateRequest{Model: name.String()}
 	if err := createModel(req, name, baseLayers, config, func(api.ProgressResponse) {}); err != nil {
@@ -272,7 +271,6 @@ func TestCreateModelValidatesTextOnlyFileGGUFWithoutQuantization(t *testing.T) {
 	config := &model.ConfigV2{
 		OS:           "linux",
 		Architecture: "amd64",
-		RootFS:       model.RootFS{Type: "layers"},
 	}
 	req := api.CreateRequest{Model: name.String()}
 	if err := createModel(req, name, baseLayers, config, func(api.ProgressResponse) {}); err != nil {
@@ -356,7 +354,6 @@ func TestCreateModelValidatesSplitGGUFWithOriginalShardNames(t *testing.T) {
 	config := &model.ConfigV2{
 		OS:           "linux",
 		Architecture: "amd64",
-		RootFS:       model.RootFS{Type: "layers"},
 	}
 	req := api.CreateRequest{Model: name.String()}
 	if err := createModel(req, name, baseLayers, config, func(api.ProgressResponse) {}); err != nil {
@@ -473,7 +470,6 @@ func TestCreateModelAddsDefaultLlavaProjectorType(t *testing.T) {
 	config := &model.ConfigV2{
 		OS:           "linux",
 		Architecture: "amd64",
-		RootFS:       model.RootFS{Type: "layers"},
 	}
 	req := api.CreateRequest{Model: name.String()}
 	if err := createModel(req, name, baseLayers, config, func(api.ProgressResponse) {}); err != nil {
@@ -606,7 +602,6 @@ func TestCreateModelQuantizeRestoresEmbeddedCompatibilityTensors(t *testing.T) {
 	config := &model.ConfigV2{
 		OS:           "linux",
 		Architecture: "amd64",
-		RootFS:       model.RootFS{Type: "layers"},
 	}
 	req := api.CreateRequest{Model: name.String(), Quantize: "Q4_K_M"}
 	if err := createModel(req, name, baseLayers, config, func(api.ProgressResponse) {}); err != nil {
@@ -694,7 +689,6 @@ func TestCreateModelRejectsFileGGUFWhenValidationFails(t *testing.T) {
 	config := &model.ConfigV2{
 		OS:           "linux",
 		Architecture: "amd64",
-		RootFS:       model.RootFS{Type: "layers"},
 	}
 	req := api.CreateRequest{Model: name.String()}
 	err = createModel(req, name, baseLayers, config, func(api.ProgressResponse) {})
@@ -745,7 +739,7 @@ func TestCreateFromBin(t *testing.T) {
 	})
 
 	checkFileExists(t, filepath.Join(p, "blobs", "*"), []string{
-		filepath.Join(p, "blobs", "sha256-6bcdb8859d417753645538d7bbfbd7ca91a3f0c191aef5379c53c05e86b669dd"),
+		filepath.Join(p, "blobs", "sha256-99759ad5b91e723db0393d698ffbb448b1b7df5ff6377a108c49254583b1bc8c"),
 		filepath.Join(p, "blobs", "sha256-89a2116c3a82d6a97f59f748d86ed4417214353fd178ee54df418fde32495fad"),
 	})
 
@@ -820,7 +814,7 @@ func TestCreateFromModel(t *testing.T) {
 	})
 
 	checkFileExists(t, filepath.Join(p, "blobs", "*"), []string{
-		filepath.Join(p, "blobs", "sha256-6bcdb8859d417753645538d7bbfbd7ca91a3f0c191aef5379c53c05e86b669dd"),
+		filepath.Join(p, "blobs", "sha256-99759ad5b91e723db0393d698ffbb448b1b7df5ff6377a108c49254583b1bc8c"),
 		filepath.Join(p, "blobs", "sha256-89a2116c3a82d6a97f59f748d86ed4417214353fd178ee54df418fde32495fad"),
 	})
 }
@@ -917,7 +911,7 @@ func TestCreateRemovesLayers(t *testing.T) {
 	checkFileExists(t, filepath.Join(p, "blobs", "*"), []string{
 		filepath.Join(p, "blobs", "sha256-89a2116c3a82d6a97f59f748d86ed4417214353fd178ee54df418fde32495fad"),
 		filepath.Join(p, "blobs", "sha256-b507b9c2f6ca642bffcd06665ea7c91f235fd32daeefdf875a0f938db05fb315"),
-		filepath.Join(p, "blobs", "sha256-f6e7e4b28e0b1d0c635f2d465bd248c5387c3e75b61a48c4374192b26d832a56"),
+		filepath.Join(p, "blobs", "sha256-99759ad5b91e723db0393d698ffbb448b1b7df5ff6377a108c49254583b1bc8c"),
 	})
 
 	w = createRequest(t, s.CreateHandler, api.CreateRequest{
@@ -936,7 +930,7 @@ func TestCreateRemovesLayers(t *testing.T) {
 	})
 
 	checkFileExists(t, filepath.Join(p, "blobs", "*"), []string{
-		filepath.Join(p, "blobs", "sha256-136bf7c76bac2ec09d6617885507d37829e04b41acc47687d45e512b544e893a"),
+		filepath.Join(p, "blobs", "sha256-99759ad5b91e723db0393d698ffbb448b1b7df5ff6377a108c49254583b1bc8c"),
 		filepath.Join(p, "blobs", "sha256-89a2116c3a82d6a97f59f748d86ed4417214353fd178ee54df418fde32495fad"),
 		filepath.Join(p, "blobs", "sha256-fe7ac77b725cda2ccad03f88a880ecdfd7a33192d6cae08fce2c0ee1455991ed"),
 	})
@@ -966,7 +960,7 @@ func TestCreateUnsetsSystem(t *testing.T) {
 	})
 
 	checkFileExists(t, filepath.Join(p, "blobs", "*"), []string{
-		filepath.Join(p, "blobs", "sha256-0a666d113e8e0a3d27e9c7bd136a0bdfb6241037db50729d81568451ebfdbde8"),
+		filepath.Join(p, "blobs", "sha256-99759ad5b91e723db0393d698ffbb448b1b7df5ff6377a108c49254583b1bc8c"),
 		filepath.Join(p, "blobs", "sha256-89a2116c3a82d6a97f59f748d86ed4417214353fd178ee54df418fde32495fad"),
 		filepath.Join(p, "blobs", "sha256-f29e82a8284dbdf5910b1555580ff60b04238b8da9d5e51159ada67a4d0d5851"),
 	})
@@ -987,7 +981,7 @@ func TestCreateUnsetsSystem(t *testing.T) {
 	})
 
 	checkFileExists(t, filepath.Join(p, "blobs", "*"), []string{
-		filepath.Join(p, "blobs", "sha256-6bcdb8859d417753645538d7bbfbd7ca91a3f0c191aef5379c53c05e86b669dd"),
+		filepath.Join(p, "blobs", "sha256-99759ad5b91e723db0393d698ffbb448b1b7df5ff6377a108c49254583b1bc8c"),
 		filepath.Join(p, "blobs", "sha256-89a2116c3a82d6a97f59f748d86ed4417214353fd178ee54df418fde32495fad"),
 	})
 }
@@ -1021,7 +1015,7 @@ func TestCreateMergeParameters(t *testing.T) {
 
 	checkFileExists(t, filepath.Join(p, "blobs", "*"), []string{
 		filepath.Join(p, "blobs", "sha256-1d0ad71299d48c2fb7ae2b98e683643e771f8a5b72be34942af90d97a91c1e37"),
-		filepath.Join(p, "blobs", "sha256-6d6e36c1f90fc7deefc33a7300aa21ad4b67c506e33ecdeddfafa98147e60bbf"),
+		filepath.Join(p, "blobs", "sha256-99759ad5b91e723db0393d698ffbb448b1b7df5ff6377a108c49254583b1bc8c"),
 		filepath.Join(p, "blobs", "sha256-89a2116c3a82d6a97f59f748d86ed4417214353fd178ee54df418fde32495fad"),
 	})
 
@@ -1063,9 +1057,8 @@ func TestCreateMergeParameters(t *testing.T) {
 
 	checkFileExists(t, filepath.Join(p, "blobs", "*"), []string{
 		filepath.Join(p, "blobs", "sha256-1d0ad71299d48c2fb7ae2b98e683643e771f8a5b72be34942af90d97a91c1e37"),
-		filepath.Join(p, "blobs", "sha256-6d6e36c1f90fc7deefc33a7300aa21ad4b67c506e33ecdeddfafa98147e60bbf"),
+		filepath.Join(p, "blobs", "sha256-99759ad5b91e723db0393d698ffbb448b1b7df5ff6377a108c49254583b1bc8c"),
 		filepath.Join(p, "blobs", "sha256-89a2116c3a82d6a97f59f748d86ed4417214353fd178ee54df418fde32495fad"),
-		filepath.Join(p, "blobs", "sha256-bbdce269dabe013033632238b4b2d1e02fac2f97787c5e895f4da84e09cccd5d"),
 		filepath.Join(p, "blobs", "sha256-e29a7b3c47287a2489c895d21fe413c20f859a85d20e749492f52a838e36e1ba"),
 	})
 
@@ -1107,9 +1100,8 @@ func TestCreateMergeParameters(t *testing.T) {
 	checkFileExists(t, filepath.Join(p, "blobs", "*"), []string{
 		filepath.Join(p, "blobs", "sha256-12f58bb75cb3042d69a7e013ab87fb3c3c7088f50ddc62f0c77bd332f0d44d35"),
 		filepath.Join(p, "blobs", "sha256-1d0ad71299d48c2fb7ae2b98e683643e771f8a5b72be34942af90d97a91c1e37"),
-		filepath.Join(p, "blobs", "sha256-6d6e36c1f90fc7deefc33a7300aa21ad4b67c506e33ecdeddfafa98147e60bbf"),
+		filepath.Join(p, "blobs", "sha256-99759ad5b91e723db0393d698ffbb448b1b7df5ff6377a108c49254583b1bc8c"),
 		filepath.Join(p, "blobs", "sha256-89a2116c3a82d6a97f59f748d86ed4417214353fd178ee54df418fde32495fad"),
-		filepath.Join(p, "blobs", "sha256-9443591d14be23c1e33d101934d76ad03bdb0715fe0879e8b0d1819e7bb063dd"),
 	})
 
 	actual, err = os.ReadFile(filepath.Join(p, "blobs", "sha256-12f58bb75cb3042d69a7e013ab87fb3c3c7088f50ddc62f0c77bd332f0d44d35"))
@@ -1166,7 +1158,7 @@ func TestCreateReplacesMessages(t *testing.T) {
 	checkFileExists(t, filepath.Join(p, "blobs", "*"), []string{
 		filepath.Join(p, "blobs", "sha256-298baeaf6928a60cf666d88d64a1ba606feb43a2865687c39e40652e407bffc4"),
 		filepath.Join(p, "blobs", "sha256-89a2116c3a82d6a97f59f748d86ed4417214353fd178ee54df418fde32495fad"),
-		filepath.Join(p, "blobs", "sha256-c84aee28f2af350596f674de51d2a802ea782653ef2930a21d48bd43d5cd5317"),
+		filepath.Join(p, "blobs", "sha256-99759ad5b91e723db0393d698ffbb448b1b7df5ff6377a108c49254583b1bc8c"),
 	})
 
 	w = createRequest(t, s.CreateHandler, api.CreateRequest{
@@ -1200,11 +1192,10 @@ func TestCreateReplacesMessages(t *testing.T) {
 
 	// Old layers will not have been pruned
 	checkFileExists(t, filepath.Join(p, "blobs", "*"), []string{
-		filepath.Join(p, "blobs", "sha256-09cfac3e6a637e25cb41aa85c24c110dc17ba89634de7df141b564dd2da4168b"),
+		filepath.Join(p, "blobs", "sha256-99759ad5b91e723db0393d698ffbb448b1b7df5ff6377a108c49254583b1bc8c"),
 		filepath.Join(p, "blobs", "sha256-298baeaf6928a60cf666d88d64a1ba606feb43a2865687c39e40652e407bffc4"),
 		filepath.Join(p, "blobs", "sha256-89a2116c3a82d6a97f59f748d86ed4417214353fd178ee54df418fde32495fad"),
 		filepath.Join(p, "blobs", "sha256-a60ecc9da299ec7ede453f99236e5577fd125e143689b646d9f0ddc9971bf4db"),
-		filepath.Join(p, "blobs", "sha256-c84aee28f2af350596f674de51d2a802ea782653ef2930a21d48bd43d5cd5317"),
 	})
 
 	type message struct {
@@ -1259,7 +1250,7 @@ func TestCreateTemplateSystem(t *testing.T) {
 	})
 
 	checkFileExists(t, filepath.Join(p, "blobs", "*"), []string{
-		filepath.Join(p, "blobs", "sha256-0a04d979734167da3b80811a1874d734697f366a689f3912589b99d2e86e7ad1"),
+		filepath.Join(p, "blobs", "sha256-99759ad5b91e723db0393d698ffbb448b1b7df5ff6377a108c49254583b1bc8c"),
 		filepath.Join(p, "blobs", "sha256-4c5f51faac758fecaff8db42f0b7382891a4d0c0bb885f7b86be88c814a7cc86"),
 		filepath.Join(p, "blobs", "sha256-89a2116c3a82d6a97f59f748d86ed4417214353fd178ee54df418fde32495fad"),
 		filepath.Join(p, "blobs", "sha256-fe7ac77b725cda2ccad03f88a880ecdfd7a33192d6cae08fce2c0ee1455991ed"),
@@ -1488,7 +1479,7 @@ func TestCreateLicenses(t *testing.T) {
 	checkFileExists(t, filepath.Join(p, "blobs", "*"), []string{
 		filepath.Join(p, "blobs", "sha256-2af71558e438db0b73a20beab92dc278a94e1bbe974c00c1a33e3ab62d53a608"),
 		filepath.Join(p, "blobs", "sha256-89a2116c3a82d6a97f59f748d86ed4417214353fd178ee54df418fde32495fad"),
-		filepath.Join(p, "blobs", "sha256-a762f214df0d96c9a7b82f96da98d99ceb2776c88e3ea7ffa09d1e5835516ec6"),
+		filepath.Join(p, "blobs", "sha256-99759ad5b91e723db0393d698ffbb448b1b7df5ff6377a108c49254583b1bc8c"),
 		filepath.Join(p, "blobs", "sha256-e5dcffe836b6ec8a58e492419b550e65fb8cbdc308503979e5dacb33ac7ea3b7"),
 	})
 
@@ -1536,7 +1527,7 @@ func TestCreateDetectTemplate(t *testing.T) {
 			filepath.Join(p, "blobs", "sha256-0d79f567714c62c048378f2107fb332dabee0135d080c302d884317da9433cc5"),
 			filepath.Join(p, "blobs", "sha256-3322a0c650c758b7386ff55629d27d07c07b6c3d3515e259dc3e5598c41e9f4e"),
 			filepath.Join(p, "blobs", "sha256-35360843d0c84fb1506952a131bbef13cd2bb4a541251f22535170c05b56e672"),
-			filepath.Join(p, "blobs", "sha256-a56c12acca8068cb6c335e237da6643e8a802a92959a63ad5bd17828e3b5e9b0"),
+			filepath.Join(p, "blobs", "sha256-99759ad5b91e723db0393d698ffbb448b1b7df5ff6377a108c49254583b1bc8c"),
 		})
 	})
 
@@ -1553,7 +1544,7 @@ func TestCreateDetectTemplate(t *testing.T) {
 		}
 
 		checkFileExists(t, filepath.Join(p, "blobs", "*"), []string{
-			filepath.Join(p, "blobs", "sha256-6bcdb8859d417753645538d7bbfbd7ca91a3f0c191aef5379c53c05e86b669dd"),
+			filepath.Join(p, "blobs", "sha256-99759ad5b91e723db0393d698ffbb448b1b7df5ff6377a108c49254583b1bc8c"),
 			filepath.Join(p, "blobs", "sha256-89a2116c3a82d6a97f59f748d86ed4417214353fd178ee54df418fde32495fad"),
 		})
 	})
@@ -1872,7 +1863,7 @@ func createSafetensorsTestModel(t *testing.T, modelName string, config model.Con
 	}
 	layers = append(layers, extraLayers...)
 
-	configLayer, err := createConfigLayer(layers, config)
+	configLayer, err := createConfigLayer(config)
 	if err != nil {
 		t.Fatalf("failed to create config layer: %v", err)
 	}

--- a/server/routes_delete_test.go
+++ b/server/routes_delete_test.go
@@ -48,8 +48,7 @@ func TestDelete(t *testing.T) {
 	})
 
 	checkFileExists(t, filepath.Join(p, "blobs", "*"), []string{
-		filepath.Join(p, "blobs", "sha256-136bf7c76bac2ec09d6617885507d37829e04b41acc47687d45e512b544e893a"),
-		filepath.Join(p, "blobs", "sha256-6bcdb8859d417753645538d7bbfbd7ca91a3f0c191aef5379c53c05e86b669dd"),
+		filepath.Join(p, "blobs", "sha256-99759ad5b91e723db0393d698ffbb448b1b7df5ff6377a108c49254583b1bc8c"),
 		filepath.Join(p, "blobs", "sha256-89a2116c3a82d6a97f59f748d86ed4417214353fd178ee54df418fde32495fad"),
 		filepath.Join(p, "blobs", "sha256-fe7ac77b725cda2ccad03f88a880ecdfd7a33192d6cae08fce2c0ee1455991ed"),
 	})
@@ -65,7 +64,7 @@ func TestDelete(t *testing.T) {
 	})
 
 	checkFileExists(t, filepath.Join(p, "blobs", "*"), []string{
-		filepath.Join(p, "blobs", "sha256-136bf7c76bac2ec09d6617885507d37829e04b41acc47687d45e512b544e893a"),
+		filepath.Join(p, "blobs", "sha256-99759ad5b91e723db0393d698ffbb448b1b7df5ff6377a108c49254583b1bc8c"),
 		filepath.Join(p, "blobs", "sha256-89a2116c3a82d6a97f59f748d86ed4417214353fd178ee54df418fde32495fad"),
 		filepath.Join(p, "blobs", "sha256-fe7ac77b725cda2ccad03f88a880ecdfd7a33192d6cae08fce2c0ee1455991ed"),
 	})

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -130,9 +130,6 @@ func TestRoutes(t *testing.T) {
 		config := &model.ConfigV2{
 			OS:           "linux",
 			Architecture: "amd64",
-			RootFS: model.RootFS{
-				Type: "layers",
-			},
 		}
 
 		if err := createModel(r, modelName, baseLayers, config, fn); err != nil {
@@ -573,7 +570,7 @@ func TestGetModelInfoRepairsUnknownGGUFFileType(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	configLayer, err := createConfigLayer([]manifest.Layer{modelLayer}, model.ConfigV2{
+	configLayer, err := createConfigLayer(model.ConfigV2{
 		ModelFormat:   "gguf",
 		ModelFamily:   "llama",
 		ModelFamilies: []string{"llama"},

--- a/types/model/config.go
+++ b/types/model/config.go
@@ -24,7 +24,6 @@ type ConfigV2 struct {
 	// required by spec
 	Architecture string `json:"architecture"`
 	OS           string `json:"os"`
-	RootFS       RootFS `json:"rootfs"`
 }
 
 // Draft describes an auxiliary draft model stored in the same manifest.
@@ -33,10 +32,4 @@ type Draft struct {
 	Architecture string `json:"architecture,omitempty"`
 	TensorPrefix string `json:"tensor_prefix,omitempty"`
 	Config       string `json:"config,omitempty"`
-}
-
-// RootFS represents the root filesystem configuration for a model.
-type RootFS struct {
-	Type    string   `json:"type"`
-	DiffIDs []string `json:"diff_ids"`
 }


### PR DESCRIPTION
rootfs.diff_ids duplicated the manifest's layer digest list into the config blob and nothing ever read it. On per-tensor safetensors models the copy grows past 100KB and create excessively large config blobs with unused redundant data. Model identity is unaffected: it is the digest of the manifest itself, which already commits to every layer hash.