### PR TITLE
launch: accept Claude context window suffix

### DIFF
--- a/cmd/launch/claude.go
+++ b/cmd/launch/claude.go
@@ -17,6 +17,13 @@ type Claude struct{}
 
 func (c *Claude) String() string { return "Claude Code" }
 
+func (c *Claude) ModelForReadiness(model string) string {
+	if base, ok := strings.CutSuffix(model, "[1m]"); ok && base != "" {
+		return base
+	}
+	return model
+}
+
 func (c *Claude) args(model string, extra []string) []string {
 	var args []string
 	if model != "" {

--- a/cmd/launch/launch.go
+++ b/cmd/launch/launch.go
@@ -145,6 +145,17 @@ type Runner interface {
 	String() string
 }
 
+type readinessModelResolver interface {
+	ModelForReadiness(model string) string
+}
+
+func modelForReadiness(runner Runner, model string) string {
+	if resolver, ok := runner.(readinessModelResolver); ok {
+		return resolver.ModelForReadiness(model)
+	}
+	return model
+}
+
 // Editor can edit config files for integrations that support model configuration.
 type Editor interface {
 	Paths() []string
@@ -978,7 +989,7 @@ func (c *launcherClient) resolveSingleIntegrationTarget(ctx context.Context, nam
 		usable := skipReadiness && target != ""
 		if !skipReadiness {
 			var err error
-			usable, err = c.savedModelUsable(ctx, target)
+			usable, err = c.savedModelUsable(ctx, modelForReadiness(runner, target))
 			if err != nil {
 				return "", false, err
 			}
@@ -995,7 +1006,8 @@ func (c *launcherClient) resolveSingleIntegrationTarget(ctx context.Context, nam
 		}
 		target = selected
 	} else if !skipReadiness {
-		if err := c.ensureModelsReadyFor(ctx, []string{target}, runner.String(), name); err != nil {
+		readinessModel := modelForReadiness(runner, target)
+		if err := c.ensureModelsReadyFor(ctx, []string{readinessModel}, runner.String(), name); err != nil {
 			if !errors.Is(err, errDeprecatedLaunchModelDeclined) {
 				return "", false, err
 			}

--- a/cmd/launch/launch_test.go
+++ b/cmd/launch/launch_test.go
@@ -3614,6 +3614,66 @@ func TestLaunchIntegration_ClaudeContextSuffixUsesBaseModelForReadiness(t *testi
 	}
 }
 
+func TestLaunchIntegration_ClaudeSavedContextSuffixUsesBaseModelForReadiness(t *testing.T) {
+	tmpDir := t.TempDir()
+	setLaunchTestHome(t, tmpDir)
+	withLauncherHooks(t)
+	withInteractiveSession(t, false)
+
+	const model = "gemma4[1m]"
+	if err := config.SaveIntegration("claude", []string{model}); err != nil {
+		t.Fatalf("failed to seed saved config: %v", err)
+	}
+
+	DefaultConfirmPrompt = func(string, ConfirmOptions) (bool, error) {
+		return false, nil
+	}
+
+	var shownModel string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/tags":
+			fmt.Fprint(w, `{"models":[{"name":"gemma4"}]}`)
+		case "/api/show":
+			var req struct {
+				Model string `json:"model"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("failed to decode show request: %v", err)
+			}
+			shownModel = req.Model
+			if req.Model != "gemma4" {
+				w.WriteHeader(http.StatusBadRequest)
+				fmt.Fprint(w, `{"error":"invalid model name"}`)
+				return
+			}
+			fmt.Fprint(w, `{"model":"gemma4"}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	t.Setenv("OLLAMA_HOST", srv.URL)
+
+	if err := LaunchIntegration(context.Background(), IntegrationLaunchRequest{
+		Name:          "claude",
+		ConfigureOnly: true,
+	}); err != nil {
+		t.Fatalf("LaunchIntegration returned error: %v", err)
+	}
+	if shownModel != "gemma4" {
+		t.Fatalf("readiness model = %q, want gemma4", shownModel)
+	}
+
+	saved, err := config.LoadIntegration("claude")
+	if err != nil {
+		t.Fatalf("failed to reload saved config: %v", err)
+	}
+	if saved.Models[0] != model {
+		t.Fatalf("saved model = %q, want %q", saved.Models[0], model)
+	}
+}
+
 func TestLaunchIntegration_ClaudeModelOverrideDeprecatedDeclineOpensPicker(t *testing.T) {
 	tmpDir := t.TempDir()
 	setLaunchTestHome(t, tmpDir)

--- a/cmd/launch/launch_test.go
+++ b/cmd/launch/launch_test.go
@@ -3555,6 +3555,65 @@ func TestLaunchIntegration_ClaudeModelOverrideSkipsSelector(t *testing.T) {
 	}
 }
 
+func TestLaunchIntegration_ClaudeContextSuffixUsesBaseModelForReadiness(t *testing.T) {
+	tmpDir := t.TempDir()
+	setLaunchTestHome(t, tmpDir)
+	withLauncherHooks(t)
+	withInteractiveSession(t, false)
+
+	binDir := t.TempDir()
+	writeFakeBinary(t, binDir, "claude")
+	t.Setenv("PATH", binDir)
+
+	DefaultConfirmPrompt = func(string, ConfirmOptions) (bool, error) {
+		return false, nil
+	}
+
+	var shownModel string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/show" {
+			http.NotFound(w, r)
+			return
+		}
+
+		var req struct {
+			Model string `json:"model"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("failed to decode show request: %v", err)
+		}
+		shownModel = req.Model
+		if req.Model != "gemma4" {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, `{"error":"invalid model name"}`)
+			return
+		}
+		fmt.Fprint(w, `{"model":"gemma4"}`)
+	}))
+	defer srv.Close()
+	t.Setenv("OLLAMA_HOST", srv.URL)
+
+	const model = "gemma4[1m]"
+	if err := LaunchIntegration(context.Background(), IntegrationLaunchRequest{
+		Name:          "claude",
+		ModelOverride: model,
+		ConfigureOnly: true,
+	}); err != nil {
+		t.Fatalf("LaunchIntegration returned error: %v", err)
+	}
+	if shownModel != "gemma4" {
+		t.Fatalf("readiness model = %q, want gemma4", shownModel)
+	}
+
+	saved, err := config.LoadIntegration("claude")
+	if err != nil {
+		t.Fatalf("failed to reload saved config: %v", err)
+	}
+	if saved.Models[0] != model {
+		t.Fatalf("saved model = %q, want %q", saved.Models[0], model)
+	}
+}
+
 func TestLaunchIntegration_ClaudeModelOverrideDeprecatedDeclineOpensPicker(t *testing.T) {
 	tmpDir := t.TempDir()
 	setLaunchTestHome(t, tmpDir)


### PR DESCRIPTION
## Summary

Fixes #17584.

Claude Code supports a documented `[1m]` model suffix, but Ollama launch
previously sent the suffixed value to `/api/show`. Model validation rejected it
before Claude Code could start.

This change lets integrations provide a model name specifically for Ollama
readiness checks. Claude strips only a non-empty, exact `[1m]` suffix for those
checks while preserving the original value in saved configuration and the
Claude command line.

Other integrations and other bracket suffixes are unchanged.

## Testing

Before the fix:

```text
go test ./cmd/launch -run '^TestLaunchIntegration_ClaudeContextSuffixUsesBaseModelForReadiness$' -count=1
--- FAIL: ... LaunchIntegration returned error: invalid model name
```

After the fix:

```text
go test ./cmd/launch -count=1
ok github.com/ollama/ollama/cmd/launch

go test -race ./cmd/launch -run '^TestLaunchIntegration_ClaudeContextSuffixUsesBaseModelForReadiness$' -count=1
ok github.com/ollama/ollama/cmd/launch

go vet ./cmd/launch
git diff --check
```


## Additional regression coverage

The saved-model path is covered separately from the explicit override path:

```text
go test ./cmd/launch -run ^TestLaunchIntegration_Claude.*ContextSuffixUsesBaseModelForReadiness$ -count=1
```

The saved-config test fails before the production fix with `no selector configured` because `gemma4[1m]` is incorrectly treated as missing from an inventory containing `gemma4`. It passes after the fix while preserving the suffixed model in config.

