### PR TITLE
cmd/config: handle null integration entries

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -238,7 +238,7 @@ func LoadIntegration(appName string) (*integration, error) {
 	}
 
 	integrationConfig, ok := cfg.Integrations[strings.ToLower(appName)]
-	if !ok {
+	if !ok || integrationConfig == nil {
 		return nil, os.ErrNotExist
 	}
 

--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -238,6 +238,29 @@ func TestLoadIntegration_NonexistentIntegration(t *testing.T) {
 	}
 }
 
+func TestLoadIntegration_NullIntegration(t *testing.T) {
+	tmpDir := t.TempDir()
+	setTestHome(t, tmpDir)
+
+	dir := filepath.Join(tmpDir, ".ollama")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte(`{"integrations":{"claude":null}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := IntegrationModel("claude"); got != "" {
+		t.Fatalf("IntegrationModel() = %q, want empty", got)
+	}
+	if got := IntegrationModels("claude"); got != nil {
+		t.Fatalf("IntegrationModels() = %v, want nil", got)
+	}
+	if _, err := LoadIntegration("claude"); !os.IsNotExist(err) {
+		t.Fatalf("LoadIntegration() error = %v, want os.ErrNotExist", err)
+	}
+}
+
 func TestConfigPath(t *testing.T) {
 	tmpDir := t.TempDir()
 	setTestHome(t, tmpDir)


### PR DESCRIPTION
## Summary

Ollama's integration config is user-editable JSON. A valid entry such as:

```json
{"integrations":{"claude":null}}
```

made `LoadIntegration` return `(nil, nil)`. Convenience callers such as
`IntegrationModel` and `IntegrationModels` then dereferenced the nil config and
panicked.

Treat null integration entries the same as absent entries by returning the
existing `os.ErrNotExist` result. Normal saved configurations and serialization
are unchanged.

## Testing

Before the fix:

```text
go test ./cmd/config -run '^TestLoadIntegration_NullIntegration$' -count=1
panic: runtime error: invalid memory address or nil pointer dereference
... cmd/config.IntegrationModel ... config.go:180
```

After the fix:

```text
go test ./cmd/config -run '^TestLoadIntegration_NullIntegration$' -count=1
go test ./cmd/config -count=1
go test -race ./cmd/config -count=1
go test ./cmd/launch -count=1
go vet ./cmd/config
git diff --check
```
