### PR TITLE
progress: track only rendered terminal lines

### DIFF
--- a/progress/progress.go
+++ b/progress/progress.go
@@ -138,7 +138,7 @@ func (p *Progress) renderLocked() {
 		}
 	}
 
-	p.pos = len(p.states)
+	p.pos = maxHeight
 }
 
 func (p *Progress) start() {

--- a/progress/progress_test.go
+++ b/progress/progress_test.go
@@ -2,10 +2,17 @@ package progress
 
 import (
 	"bytes"
+	"os"
 	"runtime"
 	"testing"
 	"time"
 )
+
+type staticProgressState string
+
+func (s staticProgressState) String() string {
+	return string(s)
+}
 
 // TestStopIsIdempotent pins the contract cmd relies on: a second Stop (e.g. a
 // deferred StopAndClear after an explicit one) reports false so callers don't
@@ -27,6 +34,30 @@ func TestStopIsIdempotent(t *testing.T) {
 				t.Fatal("second stop should report false")
 			}
 		})
+	}
+}
+
+func TestProgressTracksOnlyRenderedLines(t *testing.T) {
+	oldStderr := os.Stderr
+	read, write, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = write
+	t.Cleanup(func() {
+		os.Stderr = oldStderr
+		read.Close()
+		write.Close()
+	})
+
+	p := NewProgress(&bytes.Buffer{})
+	for range defaultTermHeight + 5 {
+		p.Add("", staticProgressState("state"))
+	}
+
+	_, pos := p.stop()
+	if pos != defaultTermHeight {
+		t.Fatalf("rendered line count = %d, want %d", pos, defaultTermHeight)
 	}
 }
 


### PR DESCRIPTION
## Summary

`Progress.renderLocked` limits output to the terminal height, but recorded
`p.pos` as the total number of states. When more states existed than visible
rows, the next frame moved the cursor above the progress region and
`StopAndClear` cleared lines that had never been rendered.

Record the actual height-limited line count instead. Progress output within the
terminal height is unchanged.

This is separate from #16726, which prevents long individual lines from
wrapping across terminal columns; this change fixes the row count when the
number of progress states exceeds terminal height.

## Testing

Before the fix:

```text
go test ./progress -run '^TestProgressTracksOnlyRenderedLines$' -count=1
rendered line count = 29, want 24
```

After the fix:

```text
go test ./progress -count=1
go test -race ./progress -count=1
go test ./cmd -run '^(TestPushHandler|TestPullHandler|TestCreateHandler)$' -count=1
go vet ./progress
git diff --check
```
