### PR TITLE
gemma4: do not answer with a channel name the parser was cut off from

### DIFF
--- a/model/parsers/gemma4.go
+++ b/model/parsers/gemma4.go
@@ -28,6 +28,9 @@ const (
 	gemma4ToolCallCloseTag = "<tool_call|>"
 	gemma4ToolResponseTag  = "<|tool_response>"
 	gemma4StringDelimiter  = `<|"|>`
+	// The channel this parser treats as thinking, as the model names it after
+	// the opening tag.
+	gemma4ThinkingChannelName = "thought"
 )
 
 var gemma4QuotedStringRe = regexp.MustCompile(`(?s)<\|"\|>(.*?)<\|"\|>`)
@@ -40,6 +43,11 @@ type Gemma4Parser struct {
 	hasThinkingSupport    bool
 	thinkingEnabled       bool // true when both model supports and user requested thinking
 	needsChannelNameStrip bool // true when we just entered thinking and need to strip "thought\n"
+	// True immediately after a thinking block closed. A block closed by the
+	// reasoning-budget sampler is closed between the model's <|channel> token
+	// and the "thought\n" header it was about to write, so that header arrives
+	// with the block already over and would otherwise be emitted as the answer.
+	strayChannelName bool
 }
 
 func (p *Gemma4Parser) HasToolSupport() bool {
@@ -177,6 +185,29 @@ func (p *Gemma4Parser) eat(done bool) ([]gemma4Event, bool) {
 
 	switch p.state {
 	case Gemma4CollectingContent:
+		// A channel header orphaned by the block closing under it.
+		//
+		// The reasoning-budget sampler forces its message and the closing tag
+		// the moment the budget is gone, and the moment it can see the budget
+		// is gone is the model's <|channel> token -- before the "thought\n"
+		// header that follows it has been written. The model writes it anyway,
+		// into a block that is already closed, and it reads on screen as the
+		// word "thought" sitting after the budget message. Measured live on
+		// gemma4 with a 16,000-token budget.
+		if p.strayChannelName {
+			if stripped, ok := strings.CutPrefix(bufStr, gemma4ThinkingChannelName); ok {
+				bufStr = strings.TrimLeftFunc(stripped, unicode.IsSpace)
+				p.buffer.Reset()
+				p.buffer.WriteString(bufStr)
+				p.strayChannelName = false
+			} else if !done && strings.HasPrefix(gemma4ThinkingChannelName, bufStr) {
+				// Split across chunks: "thou" now, the rest next.
+				return events, false
+			} else {
+				p.strayChannelName = false
+			}
+		}
+
 		// Check for thinking open tag
 		if idx := strings.Index(bufStr, gemma4ThinkingOpenTag); idx != -1 {
 			contentBefore := bufStr[:idx]
@@ -260,6 +291,7 @@ func (p *Gemma4Parser) eat(done bool) ([]gemma4Event, bool) {
 			p.buffer.Reset()
 			p.buffer.WriteString(remaining)
 			p.state = Gemma4CollectingContent
+			p.strayChannelName = true
 
 			if len(thinking) > 0 {
 				events = append(events, gemma4EventThinkingContent{content: thinking})

--- a/model/parsers/gemma4_test.go
+++ b/model/parsers/gemma4_test.go
@@ -492,6 +492,63 @@ Do not enable "mxfp8" by default.
 	}
 }
 
+// The reasoning-budget sampler closes the block between the model's <|channel>
+// token and the "thought\n" header that follows it, because <|channel> is the
+// first thing that tells the sampler the budget is gone. The model writes the
+// header anyway, into a block that is already closed. Measured live: it reached
+// the chat panel as the word "thought" sitting after the budget message.
+func TestGemma4Parser_StrayChannelNameAfterForcedClose(t *testing.T) {
+	budgetMessage := "\n\nI have used my thinking budget. I must stop analysing now and act on what I have."
+
+	for _, tc := range []struct {
+		name   string
+		chunks []string
+	}{
+		{
+			name: "in one chunk",
+			chunks: []string{
+				"<|channel>thought\nSome reasoning that ran long." + budgetMessage + "<channel|>thought\nThe answer is 42.",
+			},
+		},
+		{
+			name: "split across chunks",
+			chunks: []string{
+				"<|channel>thought\nSome reasoning that ran long.",
+				budgetMessage,
+				"<channel|>",
+				"thou",
+				"ght\n",
+				"The answer is 42.",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			parser := &Gemma4Parser{hasThinkingSupport: true}
+			parser.Init(nil, nil, &api.ThinkValue{Value: true})
+
+			var content, thinking strings.Builder
+			for i, chunk := range tc.chunks {
+				c, th, _, err := parser.Add(chunk, i == len(tc.chunks)-1)
+				if err != nil {
+					t.Fatalf("Add() error on chunk %d: %v", i, err)
+				}
+				content.WriteString(c)
+				thinking.WriteString(th)
+			}
+
+			if got := content.String(); got != "The answer is 42." {
+				t.Errorf("content = %q, want %q", got, "The answer is 42.")
+			}
+			if strings.Contains(content.String(), "thought") {
+				t.Errorf("channel name leaked into content: %q", content.String())
+			}
+			if !strings.Contains(thinking.String(), "I have used my thinking budget") {
+				t.Errorf("budget message missing from thinking: %q", thinking.String())
+			}
+		})
+	}
+}
+
 func TestGemma4Parser_Streaming(t *testing.T) {
 	parser := &Gemma4Parser{hasThinkingSupport: true}
 	parser.Init(nil, nil, &api.ThinkValue{Value: true})


### PR DESCRIPTION
Gemma 4 writes reasoning as `<|channel>thought\n...<channel|>`, and `Gemma4Parser` strips that `thought\n` header on entering the block.

A thinking-token budget closes the block from outside. The sampler forces its message and the closing tag as soon as it sees the budget is spent, and the token that tells it so is the model's own `<|channel>` — emitted *before* the header that follows it. The model writes the header anyway, into a block that is already closed, so it arrives as the first thing in the answer.

On screen it reads as the bare word `thought` sitting after the budget message, which is how it was found: a live gemma4 run with a 16,000-token budget put it in the middle of a chat reply.

```
I have used my thinking budget. I must stop analysing now and act on what I have.
thought
```

An orphaned channel name is now dropped rather than answered with, including when it arrives split across chunks (`"thou"` then `"ght\n"`), which is the ordinary case while streaming. Where nothing closes the block from outside, the flag is cleared on the first content that is not the header and nothing changes.

Tests cover both arrival shapes; reverting the parser change fails them with `content = "thought\nThe answer is 42."`.

Only reachable with a thinking budget in play, which arrives in #17566 — this is the defect that surfaced while running it.