### PR TITLE
cmd/tui/chat: add a status line to interactive chat

### DIFF
--- a/cmd/agent_tui.go
+++ b/cmd/agent_tui.go
@@ -156,6 +156,7 @@ func GenerateAgentTUI(cmd *cobra.Command, client *api.Client, opts agentTUIOptio
 			}
 			return user.Name, true, nil
 		},
+		StatusLineScript: os.Getenv("OLLAMA_STATUSLINE"),
 	})
 	return err
 }

--- a/cmd/tui/chat/approval.go
+++ b/cmd/tui/chat/approval.go
@@ -60,6 +60,13 @@ func (m chatModel) allowAllToolsEnabled() bool {
 	return m.approvalState.AllGranted()
 }
 
+func (m chatModel) accessLevelName() string {
+	if m.allowAllToolsEnabled() {
+		return "full-access"
+	}
+	return "review"
+}
+
 func (m *chatModel) setAllowAllTools(allowAll bool) {
 	if allowAll {
 		m.ensureApprovalState().GrantAll()

--- a/cmd/tui/chat/chat.go
+++ b/cmd/tui/chat/chat.go
@@ -1,19 +1,24 @@
 package chat
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"os/exec"
 	"runtime"
 	"slices"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 
 	coreagent "github.com/ollama/ollama/agent"
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/cmd/internal/filedata"
+	"github.com/ollama/ollama/version"
 )
 
 var chatSpinnerFrames = []string{".", "..", "..."}
@@ -21,11 +26,12 @@ var chatSpinnerFrames = []string{".", "..", "..."}
 var chatRuntimeGOOS = runtime.GOOS
 
 const (
-	maxPickerItems            = 8
-	maxInlineModelPickerItems = 5
-	maxSlashCompletions       = 5
-	maxPromptHistory          = 50
-	idleWorkingDelayTicks     = 4
+	maxPickerItems               = 8
+	maxInlineModelPickerItems    = 5
+	maxSlashCompletions          = 5
+	maxPromptHistory             = 50
+	idleWorkingDelayTicks        = 4
+	statuslineCoarseRefreshTicks = 5
 )
 
 var chatEmptyPrompts = []string{
@@ -83,6 +89,7 @@ type Options struct {
 	PollCloudAuth               func(context.Context) (string, bool, error)
 	CompactionThreshold         float64
 	SystemPrompt                string
+	StatusLineScript            string // Path to the external statusline shell script
 }
 
 type Result struct {
@@ -145,20 +152,26 @@ type chatModel struct {
 
 	systemPromptDisabled bool
 
-	width              int
-	height             int
-	status             string
-	spinner            int
-	tickActive         bool
-	preloadingModel    string
-	complete           int
-	quitting           bool
-	openModelOnInit    bool
-	quitArmed          bool
-	quitArmedKey       string
-	escArmed           bool
-	eventErrorRendered bool
-	err                error
+	width                   int
+	height                  int
+	status                  string
+	customStatusText        string
+	persistedThinkValue     string
+	sessionStartedAt        time.Time
+	statuslineTickActive    bool
+	statuslineTicks         int
+	lastStatuslineSignature statuslineSignature
+	spinner                 int
+	tickActive              bool
+	preloadingModel         string
+	complete                int
+	quitting                bool
+	openModelOnInit         bool
+	quitArmed               bool
+	quitArmedKey            string
+	escArmed                bool
+	eventErrorRendered      bool
+	err                     error
 }
 
 type chatSelectionPoint struct {
@@ -171,6 +184,77 @@ type chatSelection struct {
 	dragging bool
 	anchor   chatSelectionPoint
 	cursor   chatSelectionPoint
+}
+
+func (m chatModel) serializeState() []byte {
+	state := map[string]any{
+		"model":                   strings.TrimSpace(m.opts.Model),
+		"status":                  m.status,
+		"context_tokens":          m.contextTokens,
+		"working_dir":             m.workingDir,
+		"chat_id":                 m.chatID,
+		"access_level":            m.accessLevelName(),
+		"compacting":              m.compacting,
+		"compacting_tokens":       m.compactingTokens,
+		"session_elapsed_seconds": int(time.Since(m.sessionStartedAt).Seconds()),
+		"version":                 version.Version,
+	}
+	if percent, ok := m.contextPercent(); ok {
+		state["context_window_size"] = m.displayContextWindowTokens()
+		state["context_used_percentage"] = percent
+	}
+	if m.thinking {
+		state["thinking"] = map[string]any{
+			"active": true,
+			"tokens": m.thinkingTokens,
+			"value":  m.persistedThinkValue,
+		}
+	}
+	b, _ := json.Marshal(state)
+	return b
+}
+
+// statuslineSignature captures the fields that materially change what the
+// native statusline (or a custom OLLAMA_STATUSLINE script) would render, so the
+// script only needs to re-run when something relevant actually changed.
+type statuslineSignature struct {
+	model            string
+	accessLevel      string
+	running          bool
+	compacting       bool
+	compactingTokens int
+	contextPercent   int
+	thinking         bool
+}
+
+func (m chatModel) statuslineSignature() statuslineSignature {
+	percent, _ := m.contextPercent()
+	return statuslineSignature{
+		model:            strings.TrimSpace(m.opts.Model),
+		accessLevel:      m.accessLevelName(),
+		running:          m.running,
+		compacting:       m.compacting,
+		compactingTokens: m.compactingTokens,
+		contextPercent:   percent,
+		thinking:         m.thinking,
+	}
+}
+
+func updateCustomStatusLineCmd(m chatModel) tea.Cmd {
+	return func() tea.Msg {
+		if m.opts.StatusLineScript == "" {
+			return nil
+		}
+
+		payload := m.serializeState()
+		cmd := exec.Command("sh", "-c", m.opts.StatusLineScript)
+		cmd.Stdin = bytes.NewReader(payload)
+		out, err := cmd.Output()
+		if err != nil {
+			return customStatusLineMsg("") // Fail silently
+		}
+		return customStatusLineMsg(strings.TrimSpace(string(out)))
+	}
 }
 
 func startChatSelection(selection *chatSelection, msg tea.MouseMsg, contains func(tea.MouseMsg) bool, point func(tea.MouseMsg) chatSelectionPoint) {
@@ -216,16 +300,17 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 	approvalState.Set(opts.AllowAllTools, nil)
 
 	m := chatModel{
-		ctx:             ctx,
-		opts:            opts,
-		chatID:          opts.ChatID,
-		messages:        slices.Clone(opts.Messages),
-		workingDir:      opts.WorkingDir,
-		approvalState:   approvalState,
-		defaultAllowAll: opts.AllowAllTools,
-		promptHistory:   initialPromptHistory(ctx, opts),
-		status:          "ready",
-		openModelOnInit: opts.OpenModelPicker || (strings.TrimSpace(opts.Model) == "" && opts.ModelOptions != nil),
+		ctx:              ctx,
+		opts:             opts,
+		chatID:           opts.ChatID,
+		messages:         slices.Clone(opts.Messages),
+		workingDir:       opts.WorkingDir,
+		approvalState:    approvalState,
+		defaultAllowAll:  opts.AllowAllTools,
+		promptHistory:    initialPromptHistory(ctx, opts),
+		status:           "ready",
+		openModelOnInit:  opts.OpenModelPicker || (strings.TrimSpace(opts.Model) == "" && opts.ModelOptions != nil),
+		sessionStartedAt: time.Now(),
 	}
 	m.nextImageID, m.nextAudioID = nextInputAttachmentIDsFromMessages(m.messages)
 	m.nextPastedTextID = nextInputPastedTextIDFromMessages(m.messages)
@@ -269,6 +354,7 @@ func (m chatModel) Init() tea.Cmd {
 	if cmd := cloudModelPreflightCmd(m.ctx, m.opts, m.opts.Model, ""); cmd != nil && !m.openModelOnInit {
 		cmds = append(cmds, cmd)
 	}
+	cmds = append(cmds, chatStatuslineTickCmd())
 	return tea.Batch(cmds...)
 }
 
@@ -298,8 +384,20 @@ func (m chatModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.spinner++
-		cmd := m.scheduleTick()
-		return m, cmd
+		return m, m.scheduleTick()
+
+	case chatStatuslineTickMsg:
+		m.statuslineTickActive = false
+		m.statuslineTicks++
+		cmds := []tea.Cmd{m.scheduleStatuslineTick()}
+		if m.opts.StatusLineScript != "" {
+			signature := m.statuslineSignature()
+			if signature != m.lastStatuslineSignature || m.statuslineTicks%statuslineCoarseRefreshTicks == 0 {
+				m.lastStatuslineSignature = signature
+				cmds = append(cmds, updateCustomStatusLineCmd(m))
+			}
+		}
+		return m, tea.Batch(cmds...)
 
 	case chatModelPreloadDoneMsg:
 		if msg.model != "" && msg.model != m.preloadingModel {
@@ -445,6 +543,10 @@ func (m chatModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.cloudAuthPrompt != nil {
 			return m.updateCloudAuthPrompt(msg)
 		}
+		return m, nil
+
+	case customStatusLineMsg:
+		m.customStatusText = string(msg)
 		return m, nil
 
 	case tea.MouseMsg:

--- a/cmd/tui/chat/events.go
+++ b/cmd/tui/chat/events.go
@@ -68,6 +68,10 @@ type chatEventsClosedMsg struct{}
 
 type chatTickMsg struct{}
 
+type chatStatuslineTickMsg struct{}
+
+type customStatusLineMsg string
+
 func (m *chatModel) applyAgentEvent(event coreagent.Event) {
 	contextChanged := false
 
@@ -338,6 +342,24 @@ func (m *chatModel) scheduleTick() tea.Cmd {
 func chatTickCmd() tea.Cmd {
 	return tea.Tick(350*time.Millisecond, func(time.Time) tea.Msg {
 		return chatTickMsg{}
+	})
+}
+
+// scheduleStatuslineTick reschedules unconditionally, independent of
+// run/idle state, so the statusline clock keeps ticking while the TUI is
+// idle. Each tick also checks whether anything statusline-relevant changed
+// and, if so (or on a coarse fallback interval), re-runs OLLAMA_STATUSLINE.
+func (m *chatModel) scheduleStatuslineTick() tea.Cmd {
+	if m.statuslineTickActive {
+		return nil
+	}
+	m.statuslineTickActive = true
+	return chatStatuslineTickCmd()
+}
+
+func chatStatuslineTickCmd() tea.Cmd {
+	return tea.Tick(time.Second, func(time.Time) tea.Msg {
+		return chatStatuslineTickMsg{}
 	})
 }
 

--- a/cmd/tui/chat/input.go
+++ b/cmd/tui/chat/input.go
@@ -183,6 +183,7 @@ func (m *chatModel) submitInput(input string) (tea.Model, tea.Cmd) {
 		return *m, nil
 	}
 
+	m.persistedThinkValue = thinkValueLabel(m.opts.Think)
 	return m.startRun(input)
 }
 

--- a/cmd/tui/chat/render.go
+++ b/cmd/tui/chat/render.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"slices"
 	"sort"
 	"strconv"
@@ -308,8 +309,10 @@ func (m chatModel) bottomLines(width, maxHeight int) []string {
 		}
 	}
 
-	lines = append(lines, actionStatusLines...)
 	lines = append(lines, approvalLines...)
+	if m.customStatusText == "" {
+		lines = append(lines, actionStatusLines...)
+	}
 	modelLines := m.renderModelStatusLines(width)
 	fixedLines := len(lines) + 2
 	if len(modelLines) > 0 {
@@ -334,25 +337,167 @@ func (m chatModel) renderModelStatusLines(width int) []string {
 	if m.modelPicker != nil {
 		return nil
 	}
-	var parts []string
-	if model := strings.TrimSpace(m.opts.Model); model != "" {
-		parts = append(parts, model)
-	}
-	if contextStatus := m.contextStatus(); contextStatus != "" {
-		parts = append(parts, contextStatus)
-	}
-	if notice := m.permissionModeNotice(); notice != "" {
-		parts = append(parts, notice)
-	}
-	if len(parts) == 0 {
-		return nil
-	}
 	indent := inputBoxTextIndent()
-	lines := wrapChatText(strings.Join(parts, "   "), max(20, width-lipgloss.Width(indent)))
-	for i := range lines {
-		lines[i] = renderFooterPlainLine(indent + lines[i])
+	innerWidth := max(20, width-lipgloss.Width(indent))
+
+	var lines []string
+	statusline := m.renderNativeStatusline(innerWidth)
+	switch {
+	case m.customStatusText != "":
+		for _, wrapped := range wrapChatText(m.customStatusText, innerWidth) {
+			lines = append(lines, renderFooterPlainLine(indent+wrapped))
+		}
+	case statusline != "":
+		// The native statusline already shows access level inline, so the
+		// separate permission-mode notice line would just duplicate it.
+		lines = append(lines, renderFooterPlainLine(indent+statusline))
+	default:
+		if notice := m.permissionModeNotice(); notice != "" {
+			for _, wrapped := range wrapChatText(notice, innerWidth) {
+				lines = append(lines, renderFooterPlainLine(indent+wrapped))
+			}
+		}
 	}
 	return lines
+}
+
+// contextPercent reports the percentage of the model's context window
+// currently in use. ok is false when the context window size isn't known
+// yet, so callers can omit the segment instead of showing a misleading 0%.
+func (m chatModel) contextPercent() (percent int, ok bool) {
+	window := m.displayContextWindowTokens()
+	if window <= 0 {
+		return 0, false
+	}
+	used := max(m.contextTokens, 0)
+	return (used*100 + window/2) / window, true
+}
+
+const statuslineBarCells = 10
+
+// statuslineBarColor maps a context-usage percentage to the progress bar's
+// color: grey 0-50%, yellow 51-65%, orange 66-85%, red 86-100%.
+func statuslineBarColor(percent int) string {
+	switch {
+	case percent > 85:
+		return chatAnsiRed
+	case percent > 65:
+		return chatAnsiOrange
+	case percent > 50:
+		return chatAnsiYellow
+	default:
+		return chatAnsiBrightBlack
+	}
+}
+
+func renderProgressBar(percent int) string {
+	percent = max(0, min(100, percent))
+	filled := (percent*statuslineBarCells + 50) / 100
+	filled = max(0, min(statuslineBarCells, filled))
+
+	bar := strings.Repeat("█", filled) + strings.Repeat("░", statuslineBarCells-filled)
+	return lipgloss.NewStyle().Foreground(lipgloss.Color(statuslineBarColor(percent))).Render(bar)
+}
+
+func renderElapsed(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	total := int(d.Seconds())
+	hours := total / 3600
+	minutes := (total % 3600) / 60
+	seconds := total % 60
+	if hours > 0 {
+		return fmt.Sprintf("%dh%02dm", hours, minutes)
+	}
+	return fmt.Sprintf("%dm%02ds", minutes, seconds)
+}
+
+// justifyThreeColumns lays out left/center/right segments on a single line
+// of the given width. When space is tight, segments are dropped in priority
+// order (center first, then right, then left is truncated) rather than
+// overlapping. Segments may carry ANSI styling (e.g. the colored progress
+// bar), so the line is assembled via string concatenation with widths
+// measured through lipgloss.Width, never by indexing into a rune slice.
+func justifyThreeColumns(left, center, right string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	lw, rw := lipgloss.Width(left), lipgloss.Width(right)
+	cw := lipgloss.Width(center)
+
+	if cw > 0 && lw+rw+cw+2 > width {
+		center, cw = "", 0
+	}
+	if lw+rw+1 > width && rw > 0 {
+		avail := width - lw - 1
+		if avail < 1 {
+			right, rw = "", 0
+		} else {
+			right = runewidth.Truncate(right, avail, "")
+			rw = lipgloss.Width(right)
+		}
+	}
+	if lw > width {
+		left = runewidth.Truncate(left, width, "")
+		lw = lipgloss.Width(left)
+		right, rw = "", 0
+	}
+
+	if cw == 0 {
+		return left + strings.Repeat(" ", max(0, width-lw-rw)) + right
+	}
+
+	centerStart := (width - cw) / 2
+	if centerStart < lw {
+		centerStart = lw
+	}
+	if centerStart+cw > width-rw {
+		centerStart = width - rw - cw
+	}
+	if centerStart < lw {
+		// still doesn't fit alongside both neighbors; drop it
+		return left + strings.Repeat(" ", max(0, width-lw-rw)) + right
+	}
+
+	gap1 := strings.Repeat(" ", centerStart-lw)
+	gap2 := strings.Repeat(" ", max(0, width-rw-centerStart-cw))
+	return left + gap1 + center + gap2 + right
+}
+
+// accessLevelLabel renders the access-level word. Only "full access" gets a
+// distinguishing color; "review" stays plain, matching the working directory.
+func (m chatModel) accessLevelLabel() string {
+	if m.accessLevelName() == "full-access" {
+		return chatFullAccessStyle.Render("full access")
+	}
+	return chatFooterStyle.Render("review")
+}
+
+// renderNativeStatusline assembles the statusline. Every segment other than
+// the progress bar and the "full access" label is wrapped in chatFooterStyle
+// explicitly (rather than relying on the outer renderFooterPlainLine wrap),
+// because the bar/access-level ANSI codes reset mid-line and would otherwise
+// leave everything after them unstyled.
+func (m chatModel) renderNativeStatusline(width int) string {
+	model := strings.TrimSpace(m.opts.Model)
+	if model == "" {
+		return ""
+	}
+
+	dir := filepath.Base(m.workingDir)
+	left := chatFooterStyle.Render(dir+" (") + m.accessLevelLabel() + chatFooterStyle.Render(")")
+
+	var center string
+	if m.compacting {
+		center = chatFooterStyle.Render(m.compactingLabel())
+	} else if percent, ok := m.contextPercent(); ok {
+		center = renderProgressBar(percent) + chatFooterStyle.Render(fmt.Sprintf(" %d%% ctx", percent))
+	}
+
+	right := chatFooterStyle.Render(fmt.Sprintf("%s (%s) • %s", model, thinkValueLabel(m.opts.Think), renderElapsed(time.Since(m.sessionStartedAt))))
+
+	return justifyThreeColumns(left, center, right, width)
 }
 
 func (m chatModel) renderActionStatusLines(width int) []string {
@@ -1546,15 +1691,19 @@ func (m chatModel) activityLine() string {
 	return statusWithSpinner(m.spinnerFrame(), label)
 }
 
+func (m chatModel) compactingLabel() string {
+	if m.compactingTokens > 0 {
+		return "Compacting " + formatTokenCount(m.compactingTokens)
+	}
+	return "Compacting"
+}
+
 func (m chatModel) activityLabel() string {
 	if m.status == "canceling" {
 		return "canceling"
 	}
 	if m.compacting {
-		if m.compactingTokens > 0 {
-			return "Compacting " + formatTokenCount(m.compactingTokens)
-		}
-		return "Compacting"
+		return m.compactingLabel()
 	}
 	if m.thinking {
 		return thinkingActivityLabel(m.thinkingTokens)

--- a/cmd/tui/chat/statusline_test.go
+++ b/cmd/tui/chat/statusline_test.go
@@ -1,0 +1,253 @@
+package chat
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestJustifyThreeColumnsPlacesSegments(t *testing.T) {
+	got := justifyThreeColumns("left", "mid", "right", 20)
+	if !strings.HasPrefix(got, "left") {
+		t.Fatalf("expected left segment at start: %q", got)
+	}
+	if !strings.HasSuffix(got, "right") {
+		t.Fatalf("expected right segment at end: %q", got)
+	}
+	if !strings.Contains(got, "mid") {
+		t.Fatalf("expected center segment present: %q", got)
+	}
+	if got := len([]rune(got)); got != 20 {
+		t.Fatalf("width = %d, want 20", got)
+	}
+}
+
+func TestJustifyThreeColumnsDropsCenterWhenTight(t *testing.T) {
+	got := justifyThreeColumns("left", "this center is far too long to fit", "right", 12)
+	if strings.Contains(got, "center") {
+		t.Fatalf("center should have been dropped: %q", got)
+	}
+	if !strings.HasPrefix(got, "left") || !strings.HasSuffix(got, "right") {
+		t.Fatalf("left/right should remain: %q", got)
+	}
+}
+
+func TestJustifyThreeColumnsTruncatesRightRatherThanDroppingIt(t *testing.T) {
+	// Regression test: the right segment (which now carries the model name)
+	// used to be dropped entirely when it didn't fit alongside left, hiding
+	// the model name on moderately narrow terminals. It should be truncated
+	// instead, so at least part of it stays visible.
+	got := justifyThreeColumns("dir (review)", "", "kimi-k2.7-code:cloud (auto) - 0m00s", 20)
+	if got == "dir (review)"+strings.Repeat(" ", 20-len("dir (review)")) {
+		t.Fatalf("right segment should not be fully dropped when it can be truncated: %q", got)
+	}
+	if len([]rune(got)) != 20 {
+		t.Fatalf("width = %d, want 20: %q", len([]rune(got)), got)
+	}
+}
+
+func TestJustifyThreeColumnsTruncatesLeftAsLastResort(t *testing.T) {
+	got := justifyThreeColumns("a very long left segment indeed", "", "", 10)
+	if len([]rune(got)) != 10 {
+		t.Fatalf("width = %d, want 10: %q", len([]rune(got)), got)
+	}
+}
+
+func TestContextPercentUnknownWindow(t *testing.T) {
+	m := chatModel{}
+	if _, ok := m.contextPercent(); ok {
+		t.Fatal("contextPercent should report unknown when window size is 0")
+	}
+}
+
+func TestContextPercentComputesRoundedValue(t *testing.T) {
+	m := chatModel{
+		contextTokens: 100,
+		opts:          Options{ContextWindowTokens: 200},
+	}
+	percent, ok := m.contextPercent()
+	if !ok {
+		t.Fatal("contextPercent should be known when window size is set")
+	}
+	if percent != 50 {
+		t.Fatalf("percent = %d, want 50", percent)
+	}
+}
+
+func TestStatuslineBarColorThresholds(t *testing.T) {
+	cases := []struct {
+		percent int
+		want    string
+	}{
+		{0, chatAnsiBrightBlack},
+		{50, chatAnsiBrightBlack},
+		{51, chatAnsiYellow},
+		{65, chatAnsiYellow},
+		{66, chatAnsiOrange},
+		{85, chatAnsiOrange},
+		{86, chatAnsiRed},
+		{100, chatAnsiRed},
+	}
+	for _, c := range cases {
+		if got := statuslineBarColor(c.percent); got != c.want {
+			t.Errorf("statuslineBarColor(%d) = %q, want %q", c.percent, got, c.want)
+		}
+	}
+}
+
+func TestRenderElapsedFormatsMinutesAndHours(t *testing.T) {
+	cases := []struct {
+		d    time.Duration
+		want string
+	}{
+		{0, "0m00s"},
+		{9 * time.Second, "0m09s"},
+		{754 * time.Second, "12m34s"},
+		{61*time.Minute + 2*time.Minute, "1h03m"},
+		{-5 * time.Second, "0m00s"},
+	}
+	for _, c := range cases {
+		if got := renderElapsed(c.d); got != c.want {
+			t.Errorf("renderElapsed(%v) = %q, want %q", c.d, got, c.want)
+		}
+	}
+}
+
+func TestCompactingLabelWithAndWithoutTokens(t *testing.T) {
+	m := chatModel{compacting: true}
+	if got := m.compactingLabel(); got != "Compacting" {
+		t.Fatalf("compactingLabel() = %q, want %q", got, "Compacting")
+	}
+
+	m.compactingTokens = 1234
+	if got := m.compactingLabel(); got != "Compacting 1234 tokens" {
+		t.Fatalf("compactingLabel() = %q, want %q", got, "Compacting 1234 tokens")
+	}
+}
+
+func TestAccessLevelNameReflectsApprovalState(t *testing.T) {
+	m := chatModel{approvalState: testApprovalState(true, nil)}
+	if got := m.accessLevelName(); got != "full-access" {
+		t.Fatalf("accessLevelName() = %q, want full-access", got)
+	}
+
+	m.approvalState = testApprovalState(false, nil)
+	if got := m.accessLevelName(); got != "review" {
+		t.Fatalf("accessLevelName() = %q, want review", got)
+	}
+}
+
+func TestRenderNativeStatuslineEmptyWithoutModel(t *testing.T) {
+	m := chatModel{}
+	if got := m.renderNativeStatusline(80); got != "" {
+		t.Fatalf("renderNativeStatusline() = %q, want empty when no model is set", got)
+	}
+}
+
+func TestRenderNativeStatuslineShowsCompactingInsteadOfBar(t *testing.T) {
+	m := chatModel{
+		opts:             Options{Model: "llama3.2", ContextWindowTokens: 8192},
+		contextTokens:    100,
+		compacting:       true,
+		compactingTokens: 42,
+		sessionStartedAt: time.Now(),
+	}
+	got := stripANSI(m.renderNativeStatusline(120))
+	if !strings.Contains(got, "Compacting 42 tokens") {
+		t.Fatalf("expected compacting label in statusline, got %q", got)
+	}
+	if strings.Contains(got, "% ctx") {
+		t.Fatalf("should not show the context bar while compacting: %q", got)
+	}
+}
+
+func TestRenderNativeStatuslineShowsContextBarWhenIdle(t *testing.T) {
+	m := chatModel{
+		opts:             Options{Model: "llama3.2", ContextWindowTokens: 8192},
+		contextTokens:    100,
+		sessionStartedAt: time.Now(),
+	}
+	got := stripANSI(m.renderNativeStatusline(120))
+	if !strings.Contains(got, "% ctx") {
+		t.Fatalf("expected abbreviated ctx label, got %q", got)
+	}
+	if strings.Contains(got, "context used") {
+		t.Fatalf("label should be abbreviated to \"ctx\", not the old \"context used\": %q", got)
+	}
+}
+
+func TestSerializeStateIncludesExpandedFields(t *testing.T) {
+	m := chatModel{
+		opts:             Options{Model: "llama3.2", ContextWindowTokens: 8192},
+		contextTokens:    100,
+		workingDir:       "/tmp/project",
+		chatID:           "chat-1",
+		approvalState:    testApprovalState(true, nil),
+		compacting:       true,
+		compactingTokens: 7,
+		sessionStartedAt: time.Now().Add(-10 * time.Second),
+	}
+
+	var state map[string]any
+	if err := json.Unmarshal(m.serializeState(), &state); err != nil {
+		t.Fatalf("serializeState produced invalid JSON: %v", err)
+	}
+
+	for _, field := range []string{
+		"model", "status", "context_tokens", "working_dir", "chat_id",
+		"access_level", "compacting", "compacting_tokens",
+		"session_elapsed_seconds", "version",
+		"context_window_size", "context_used_percentage",
+	} {
+		if _, ok := state[field]; !ok {
+			t.Errorf("serializeState missing field %q: %v", field, state)
+		}
+	}
+	if state["access_level"] != "full-access" {
+		t.Errorf("access_level = %v, want full-access", state["access_level"])
+	}
+	if state["compacting"] != true {
+		t.Errorf("compacting = %v, want true", state["compacting"])
+	}
+}
+
+func TestSerializeStateOmitsContextWindowFieldsWhenUnknown(t *testing.T) {
+	m := chatModel{opts: Options{Model: "llama3.2"}}
+
+	var state map[string]any
+	if err := json.Unmarshal(m.serializeState(), &state); err != nil {
+		t.Fatalf("serializeState produced invalid JSON: %v", err)
+	}
+	if _, ok := state["context_window_size"]; ok {
+		t.Errorf("context_window_size should be omitted when window size is unknown: %v", state)
+	}
+	if _, ok := state["context_used_percentage"]; ok {
+		t.Errorf("context_used_percentage should be omitted when window size is unknown: %v", state)
+	}
+}
+
+func TestStatuslineSignatureChangesWithAccessLevel(t *testing.T) {
+	m := chatModel{
+		opts:          Options{Model: "llama3.2"},
+		approvalState: testApprovalState(false, nil),
+	}
+	before := m.statuslineSignature()
+
+	m.approvalState = testApprovalState(true, nil)
+	after := m.statuslineSignature()
+
+	if before == after {
+		t.Fatal("signature should differ when access level changes")
+	}
+}
+
+func TestStatuslineSignatureStableWhenNothingChanges(t *testing.T) {
+	m := chatModel{
+		opts:          Options{Model: "llama3.2"},
+		approvalState: testApprovalState(true, nil),
+	}
+	if m.statuslineSignature() != m.statuslineSignature() {
+		t.Fatal("signature should be stable across calls with no state change")
+	}
+}

--- a/cmd/tui/chat/theme.go
+++ b/cmd/tui/chat/theme.go
@@ -9,6 +9,7 @@ const (
 	chatAnsiBlue        = "4"
 	chatAnsiCyan        = "6"
 	chatAnsiBrightBlack = "8"
+	chatAnsiOrange      = "208"
 )
 
 var (

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -110,6 +110,7 @@
             "group": "More information",
             "pages": [
               "/cli",
+              "/statusline",
               "/modelfile",
               "/context-length",
               "/linux",

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -337,6 +337,14 @@ The following server settings may be used to adjust how Ollama handles concurren
 
 Note: Windows with Radeon GPUs currently default to 1 model maximum due to limitations in ROCm v5.7 for available VRAM reporting. Once ROCm v6.2 is available, Windows Radeon will follow the defaults above. You may enable concurrent model loads on Radeon on Windows, but ensure you don't load more models than will fit into your GPU's VRAM.
 
+## How can I customize the interactive chat status line?
+
+`ollama run`'s interactive chat shows a status line with the working directory, access level, context usage, model, and session time by default. You can replace it with your own script by setting `OLLAMA_STATUSLINE`; the script receives session details as JSON on stdin and whatever it prints to stdout becomes the status line.
+
+- `OLLAMA_STATUSLINE` - Path to (or inline shell command for) a script that generates a custom status line for `ollama run`'s interactive chat.
+
+See [Status Line](/statusline) for the full data format and examples.
+
 ## How does Ollama load models on multiple GPUs?
 
 When loading a new model, Ollama evaluates the required VRAM for the model against what is currently available. If the model will entirely fit on any single GPU, Ollama will load the model on that GPU. This typically provides the best performance as it reduces the amount of data transferring across the PCI bus during inference. If the model does not fit entirely on one GPU, then it will be spread across all the available GPUs.

--- a/docs/statusline.mdx
+++ b/docs/statusline.mdx
@@ -1,0 +1,185 @@
+---
+title: Status Line
+---
+
+The status line is the bar shown at the bottom of `ollama run`'s interactive chat. It gives you an at-a-glance view of the working directory, access level, context window usage, model, thinking effort, and how long the session has been running.
+
+Status lines are useful when you:
+
+- Want to know at a glance whether the session has full tool access or requires approval for each action
+- Want to keep an eye on context window usage as a conversation grows
+- Want to know how long you've been in a session
+- Want to customize what's shown — git branch, working directory, or anything else a shell script can compute
+
+No setup is required — a status line is shown by default. You can replace it entirely with your own script if you want different information.
+
+## Default status line
+
+```
+repo (full access)          ██████░░░░ 42% ctx          llama3.2 (high) • 12m34s
+```
+
+It has three segments:
+
+- **Left**: the working directory's folder name, and the session's access level in parentheses — `full access` (colored) when all tools are auto-approved, `review` (plain, same color as the directory) when tool calls require approval.
+- **Center**: a 10-cell progress bar and percentage of the model's context window in use. Only the bar is colored, changing with usage: grey from 0-50%, yellow from 51-65%, orange from 66-85%, and red from 86-100%; the percentage text next to it is plain, matching the rest of the line. This segment is omitted if the context window size isn't known yet. While a compaction is running, this segment instead shows `Compacting N tokens` — there's no meaningful percentage for compaction progress, so a running token count is shown.
+- **Right**: the current model and its thinking effort, followed by elapsed time since the session started, e.g. `llama3.2 (high) • 12m34s`. Plain, same color as the rest of the line.
+
+On narrow terminals, the center segment is dropped first, then the right segment, to avoid overlapping text.
+
+## Customizing with a script
+
+Set the `OLLAMA_STATUSLINE` environment variable to replace the default status line with the output of your own script:
+
+```shell
+export OLLAMA_STATUSLINE="~/.ollama/statusline.sh"
+ollama run llama3.2
+```
+
+The value is run through `sh -c`, so it can be either an inline command or a path to a script file. If you point it at a script file, make sure it's executable:
+
+```shell
+chmod +x ~/.ollama/statusline.sh
+```
+
+## How it works
+
+`ollama` writes a JSON object describing the current session to your script's **stdin**, waits for it to exit, and displays whatever it printed to **stdout** in place of the default status line.
+
+Your script re-runs whenever something statusline-relevant changes — the model, access level, thinking state, context usage, or compaction status — plus at least every 5 seconds as a fallback, so externally-driven changes (like switching git branches in another terminal) still show up promptly. It does not re-run on a fixed interval regardless of activity, so an idle session won't spawn your script every second.
+
+Keep your script fast — there's no timeout, so a slow or hanging script will delay status line updates.
+
+If your script exits with a non-zero status or otherwise fails, the status line goes blank until the next successful run rather than showing an error.
+
+Printing more than one line (e.g. multiple `echo` statements) is supported — each line is shown as its own row.
+
+## Available data
+
+Your script receives this JSON structure on stdin:
+
+```json
+{
+  "model": "llama3.2",
+  "status": "ready",
+  "context_tokens": 1234,
+  "working_dir": "/path/to/project",
+  "chat_id": "01JB3F0X8T5Y6Z9G3K1QW2ERT7",
+  "access_level": "full-access",
+  "compacting": false,
+  "compacting_tokens": 0,
+  "session_elapsed_seconds": 754,
+  "version": "0.x.y",
+  "context_window_size": 8192,
+  "context_used_percentage": 15,
+  "thinking": {
+    "active": true,
+    "tokens": 512,
+    "value": "high"
+  }
+}
+```
+
+- `model` - the current model name
+- `status` - the chat's current status string (e.g. `ready`)
+- `context_tokens` - estimated tokens currently used in the context window
+- `working_dir` - the working directory the session was started in
+- `chat_id` - a unique identifier for the current chat session
+- `access_level` - `full-access` when all tools are auto-approved, otherwise `review`
+- `compacting` - `true` while a context compaction is in progress
+- `compacting_tokens` - tokens processed so far during an in-progress compaction (0 when not compacting)
+- `session_elapsed_seconds` - seconds since the session started
+- `version` - the running `ollama` version
+- `context_window_size` / `context_used_percentage` - the model's context window size and percentage used; both are omitted when the window size isn't known yet
+- `thinking` - only present while a thinking turn is in progress
+  - `thinking.active` - always `true` when present
+  - `thinking.tokens` - thinking tokens generated so far for the current turn
+  - `thinking.value` - the thinking effort in effect (`auto`, `on`, `off`, or an effort level)
+
+## Examples
+
+To use any example below: save it to a file, `chmod +x` it, and point `OLLAMA_STATUSLINE` at its path.
+
+### Recreate the default look
+
+```bash
+#!/bin/bash
+input=$(cat)
+
+DIR=$(echo "$input" | jq -r '.working_dir')
+ACCESS=$(echo "$input" | jq -r '.access_level')
+MODEL=$(echo "$input" | jq -r '.model')
+THINK=$(echo "$input" | jq -r '.thinking.value // "auto"')
+COMPACTING=$(echo "$input" | jq -r '.compacting')
+ELAPSED=$(echo "$input" | jq -r '.session_elapsed_seconds')
+
+MINS=$((ELAPSED / 60))
+SECS=$((ELAPSED % 60))
+
+if [ "$COMPACTING" = "true" ]; then
+  TOKENS=$(echo "$input" | jq -r '.compacting_tokens')
+  CENTER="Compacting ${TOKENS} tokens"
+else
+  PCT=$(echo "$input" | jq -r '.context_used_percentage // empty')
+  if [ -n "$PCT" ]; then
+    FILLED=$((PCT / 10))
+    EMPTY=$((10 - FILLED))
+    BAR=""
+    [ "$FILLED" -gt 0 ] && printf -v FILL "%${FILLED}s" && BAR="${FILL// /█}"
+    [ "$EMPTY" -gt 0 ] && printf -v PAD "%${EMPTY}s" && BAR="${BAR}${PAD// /░}"
+    CENTER="$BAR ${PCT}% ctx"
+  fi
+fi
+
+echo "${DIR##*/} (${ACCESS}) | ${CENTER} | ${MODEL} (${THINK}) • ${MINS}m${SECS}s"
+```
+
+### Model and context percentage
+
+```bash
+#!/bin/bash
+input=$(cat)
+
+MODEL=$(echo "$input" | jq -r '.model')
+TOKENS=$(echo "$input" | jq -r '.context_tokens // 0')
+
+echo "[$MODEL] ctx: ${TOKENS} tokens"
+```
+
+### Colors
+
+Use [ANSI escape codes](https://en.wikipedia.org/wiki/ANSI_escape_code#Colors) to add color; your terminal must support them.
+
+```bash
+#!/bin/bash
+input=$(cat)
+
+MODEL=$(echo "$input" | jq -r '.model')
+ACCESS=$(echo "$input" | jq -r '.access_level')
+
+GREEN='\033[32m'
+YELLOW='\033[33m'
+RESET='\033[0m'
+
+if [ "$ACCESS" = "full-access" ]; then
+  echo -e "${YELLOW}[$MODEL] full access${RESET}"
+else
+  echo -e "${GREEN}[$MODEL] review${RESET}"
+fi
+```
+
+## Troubleshooting
+
+**Status line is blank**
+
+- Verify your script is executable: `chmod +x ~/.ollama/statusline.sh`
+- Confirm it prints to stdout, not stderr
+- Test it manually with mock input:
+
+  ```shell
+  echo '{"model":"llama3.2","status":"ready","context_tokens":100,"working_dir":"/tmp","chat_id":"test","access_level":"full-access","compacting":false,"compacting_tokens":0,"session_elapsed_seconds":10,"version":"0.1.0"}' | ~/.ollama/statusline.sh
+  ```
+
+**Status line feels slow to update**
+
+- Your script runs when something relevant changes, plus at least every 5 seconds. Avoid slow operations (network calls, large file reads) inside it — there's no timeout, so a hanging script delays the next visible update.


### PR DESCRIPTION
Closes #17628

## Summary

Adds a status line to the bottom of `ollama run`'s interactive chat:

- Working directory and access level (full access / review), color-coded
- Context window usage as a progress bar + percentage — or compaction progress (as a token count) while a compaction is running
- Current model, thinking effort, and elapsed session time

Shown by default, no configuration needed.

Also adds an `OLLAMA_STATUSLINE` environment variable to fully replace the status line with a custom script. The script receives session state as JSON on stdin and its stdout becomes the status line. It re-runs when anything statusline-relevant changes (model, access level, context usage, compaction state, thinking), with a coarse ~5s fallback for externally-driven changes (e.g. switching git branches in another terminal) — not an unconditional per-second poll.

Full reference docs in `docs/statusline.mdx`.

## Test plan

- [x] `go build ./cmd/...`, `go vet ./cmd/...`, `gofmt` clean
- [x] `go test ./cmd/tui/...` passing, including new unit tests for the column-layout/truncation logic, context-percentage math, access-level/compacting labels, the change-detection signature, and `serializeState()`'s JSON output
- [ ] Manual verification in a real terminal: progress bar color thresholds, access-level toggling, compaction fallback text, narrow-terminal truncation, `OLLAMA_STATUSLINE` still overriding the default line