### PR TITLE
fix(server): filter out namespace tools before sending to llama-server

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -2910,6 +2910,20 @@ func (s *Server) ChatHandler(c *gin.Context) {
 	writeChatResponse(c, req, ch)
 }
 
+// filterNamespaceTools removes namespace-type tools that are not supported by llama-server
+func filterNamespaceTools(tools []api.Tool) []api.Tool {
+	if len(tools) == 0 {
+		return tools
+	}
+	filtered := make([]api.Tool, 0, len(tools))
+	for _, tool := range tools {
+		if tool.Type != "namespace" {
+			filtered = append(filtered, tool)
+		}
+	}
+	return filtered
+}
+
 func prepareNativeChatRequest(ctx context.Context, m *Model, r llm.LlamaServer, opts *api.Options, nativeReq llm.ChatRequest, truncate bool) (llm.ChatRequest, error) {
 	var err error
 	nativeReq.Messages, err = truncateNativeChatMessages(ctx, m, r, optionsForPrompt(opts, r), nativeReq, truncate)
@@ -2918,9 +2932,11 @@ func prepareNativeChatRequest(ctx context.Context, m *Model, r llm.LlamaServer, 
 
 func (s *Server) handleNativeChat(c *gin.Context, req api.ChatRequest, m *Model, r llm.LlamaServer, opts *api.Options, msgs []api.Message, checkpointStart, checkpointLoaded time.Time) {
 	truncate := req.Truncate == nil || *req.Truncate
+	// Filter out namespace tools as they are not supported by llama-server
+	filteredTools := filterNamespaceTools(req.Tools)
 	nativeReq, err := prepareNativeChatRequest(c.Request.Context(), m, r, opts, llm.ChatRequest{
 		Messages:    msgs,
-		Tools:       req.Tools,
+		Tools:       filteredTools,
 		Format:      req.Format,
 		Options:     opts,
 		Think:       req.Think,

--- a/server/routes.go
+++ b/server/routes.go
@@ -2910,7 +2910,9 @@ func (s *Server) ChatHandler(c *gin.Context) {
 	writeChatResponse(c, req, ch)
 }
 
-// filterNamespaceTools removes namespace-type tools that are not supported by llama-server
+// filterNamespaceTools removes namespace-type tools that are not supported by llama-server.
+// Namespace tools are group declarations sent by clients like Codex; the actual callable
+// tools are sent separately as function-type entries, so filtering namespaces is safe.
 func filterNamespaceTools(tools []api.Tool) []api.Tool {
 	if len(tools) == 0 {
 		return tools

--- a/server/routes_generate_test.go
+++ b/server/routes_generate_test.go
@@ -3249,7 +3249,9 @@ func TestChatHandlerNamespaceToolsFiltered(t *testing.T) {
 	s := newServerWithMockRunner(t, &mock)
 	createMinimalGGUFModel(t, s, "chat-template", ggml.KV{
 		"tokenizer.chat_template": "{{ messages[0]['content'] }}",
-	}, "", nil)
+	}, "", map[string]any{
+		"capabilities": []any{"completion", "tools"},
+	})
 
 	stream := false
 	w := createRequest(t, s.ChatHandler, api.ChatRequest{

--- a/server/routes_generate_test.go
+++ b/server/routes_generate_test.go
@@ -3217,3 +3217,63 @@ func TestImageGenerateUnsupported(t *testing.T) {
 		t.Fatalf("expected unsupported error in body, got %q", w.Body.String())
 	}
 }
+
+func TestChatHandlerNamespaceToolsFiltered(t *testing.T) {
+	t.Setenv("OLLAMA_CONTEXT_LENGTH", "4096")
+	t.Setenv("OLLAMA_GO_TEMPLATE", "")
+	gin.SetMode(gin.TestMode)
+
+	mock := mockRunner{
+		ChatFn: func(_ context.Context, req llm.ChatRequest, fn func(llm.ChatResponse)) error {
+			// Verify that namespace tools were filtered out
+			if len(req.Tools) != 2 {
+				t.Errorf("expected 2 tools after filtering, got %d", len(req.Tools))
+			}
+			for _, tool := range req.Tools {
+				if tool.Type == "namespace" {
+					t.Errorf("namespace tool was not filtered out: %v", tool)
+				}
+			}
+			fn(llm.ChatResponse{
+				Message:            api.Message{Role: "assistant", Content: "response"},
+				Done:               true,
+				DoneReason:         llm.DoneReasonStop,
+				PromptEvalCount:    1,
+				PromptEvalDuration: time.Millisecond,
+				EvalCount:          2,
+				EvalDuration:       2 * time.Millisecond,
+			})
+			return nil
+		},
+	}
+	s := newServerWithMockRunner(t, &mock)
+	createMinimalGGUFModel(t, s, "chat-template", ggml.KV{
+		"tokenizer.chat_template": "{{ messages[0]['content'] }}",
+	}, "", nil)
+
+	stream := false
+	w := createRequest(t, s.ChatHandler, api.ChatRequest{
+		Model: "chat-template",
+		Messages: []api.Message{
+			{Role: "user", Content: "hello"},
+		},
+		Tools: []api.Tool{
+			{Type: "function", Function: api.ToolFunction{Name: "fn1"}},
+			{Type: "namespace", Function: api.ToolFunction{Name: "ns1"}},
+			{Type: "function", Function: api.ToolFunction{Name: "fn2"}},
+			{Type: "namespace", Function: api.ToolFunction{Name: "ns2"}},
+		},
+		Stream: &stream,
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var actual api.ChatResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &actual); err != nil {
+		t.Fatal(err)
+	}
+	if actual.Message.Content != "response" {
+		t.Fatalf("expected response, got %q", actual.Message.Content)
+	}
+}

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -1196,3 +1196,65 @@ func TestWaitForStream(t *testing.T) {
 		})
 	}
 }
+
+func TestFilterNamespaceTools(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []api.Tool
+		expected []api.Tool
+	}{
+		{
+			name:     "nil input",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name:     "empty input",
+			input:    []api.Tool{},
+			expected: []api.Tool{},
+		},
+		{
+			name: "namespace only",
+			input: []api.Tool{
+				{Type: "namespace", Function: api.ToolFunction{Name: "ns1"}},
+				{Type: "namespace", Function: api.ToolFunction{Name: "ns2"}},
+			},
+			expected: []api.Tool{},
+		},
+		{
+			name: "function only",
+			input: []api.Tool{
+				{Type: "function", Function: api.ToolFunction{Name: "fn1"}},
+				{Type: "function", Function: api.ToolFunction{Name: "fn2"}},
+			},
+			expected: []api.Tool{
+				{Type: "function", Function: api.ToolFunction{Name: "fn1"}},
+				{Type: "function", Function: api.ToolFunction{Name: "fn2"}},
+			},
+		},
+		{
+			name: "mixed namespace and function",
+			input: []api.Tool{
+				{Type: "function", Function: api.ToolFunction{Name: "fn1"}},
+				{Type: "namespace", Function: api.ToolFunction{Name: "ns1"}},
+				{Type: "function", Function: api.ToolFunction{Name: "fn2"}},
+				{Type: "namespace", Function: api.ToolFunction{Name: "ns2"}},
+				{Type: "function", Function: api.ToolFunction{Name: "fn3"}},
+			},
+			expected: []api.Tool{
+				{Type: "function", Function: api.ToolFunction{Name: "fn1"}},
+				{Type: "function", Function: api.ToolFunction{Name: "fn2"}},
+				{Type: "function", Function: api.ToolFunction{Name: "fn3"}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := filterNamespaceTools(tt.input)
+			if diff := cmp.Diff(tt.expected, result); diff != "" {
+				t.Errorf("filterNamespaceTools() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The llama-server backend does not support namespace-type tools, which was causing errors when clients sent such tools in chat requests. This fix adds a filterNamespaceTools function in server/routes.go that removes any tools with type "namespace" before passing the tools array to the native chat handler. The function preserves all other tool types and returns early if no tools are provided. In handleNativeChat, the request tools are now filtered before being added to the native request, ensuring compatibility with llama-server while maintaining support for all other tool types.

Fixes #17618
