### PR TITLE
discover: add opt-in SYCL backend discovery

### DIFF
--- a/discover/native_probe_platform.go
+++ b/discover/native_probe_platform.go
@@ -30,6 +30,8 @@ func ggmlProbeLibraryName(name string) string {
 		return "ROCm"
 	case "vulkan":
 		return "Vulkan"
+	case "sycl":
+		return "SYCL"
 	case "metal":
 		return "Metal"
 	default:

--- a/discover/runner.go
+++ b/discover/runner.go
@@ -107,6 +107,9 @@ func GPUDevices(ctx context.Context, runners []ml.FilteredRunnerDiscovery) []ml.
 					continue
 				} else if !envconfig.EnableVulkan(true) && strings.Contains(filepath.Base(dir), "vulkan") {
 					continue
+				} else if !envconfig.EnableSYCL(false) && strings.Contains(filepath.Base(dir), "sycl") {
+					// SYCL backend discovery is opt-in via OLLAMA_SYCL=1
+					continue
 				}
 				dirs = []string{ml.LibOllamaPath, dir}
 			} else {

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -232,6 +232,8 @@ var (
 	UseAuth = Bool("OLLAMA_AUTH")
 	// EnableVulkan controls Vulkan backend discovery.
 	EnableVulkan = BoolWithDefault("OLLAMA_VULKAN")
+	// EnableSYCL controls opt-in SYCL backend discovery.
+	EnableSYCL = BoolWithDefault("OLLAMA_SYCL")
 	// EnableIntegratedGPU controls whether integrated GPUs may be selected.
 	EnableIntegratedGPU = BoolWithDefault("OLLAMA_IGPU_ENABLE")
 	// NoCloudEnv checks the OLLAMA_NO_CLOUD environment variable.
@@ -358,6 +360,7 @@ func AsMap() map[string]EnvVar {
 		ret["GPU_DEVICE_ORDINAL"] = EnvVar{"GPU_DEVICE_ORDINAL", GpuDeviceOrdinal(), "Set which AMD devices are visible by numeric ID"}
 		ret["HSA_OVERRIDE_GFX_VERSION"] = EnvVar{"HSA_OVERRIDE_GFX_VERSION", HsaOverrideGfxVersion(), "Override the gfx used for all detected AMD GPUs"}
 		ret["OLLAMA_VULKAN"] = EnvVar{"OLLAMA_VULKAN", EnableVulkan(true), "Enable Vulkan support"}
+		ret["OLLAMA_SYCL"] = EnvVar{"OLLAMA_SYCL", EnableSYCL(false), "Enable SYCL support (experimental)"}
 	}
 
 	return ret

--- a/envconfig/config_test.go
+++ b/envconfig/config_test.go
@@ -203,6 +203,28 @@ func TestBool(t *testing.T) {
 	}
 }
 
+func TestEnableSYCL(t *testing.T) {
+	t.Run("default disabled", func(t *testing.T) {
+		if EnableSYCL(false) {
+			t.Error("expected SYCL discovery to default to disabled")
+		}
+	})
+
+	t.Run("opt-in enabled", func(t *testing.T) {
+		t.Setenv("OLLAMA_SYCL", "1")
+		if !EnableSYCL(false) {
+			t.Error("expected OLLAMA_SYCL=1 to enable SYCL discovery")
+		}
+	})
+
+	t.Run("explicit opt-out", func(t *testing.T) {
+		t.Setenv("OLLAMA_SYCL", "0")
+		if EnableSYCL(false) {
+			t.Error("expected OLLAMA_SYCL=0 to leave SYCL discovery disabled")
+		}
+	})
+}
+
 func TestUint(t *testing.T) {
 	cases := map[string]uint{
 		"0":    0,


### PR DESCRIPTION
## Summary

Add opt-in discovery and stable display naming for the existing `ggml-sycl` backend. SYCL remains disabled by default and is enabled only with `OLLAMA_SYCL=1`.

Closes #16930.

## Changes

- recognize `sycl` as `SYCL` in native backend naming
- skip SYCL discovery unless explicitly enabled
- expose `OLLAMA_SYCL` in environment configuration
- add configuration coverage for default, opt-in, and explicit opt-out behavior

## Verification

- `go test ./discover ./envconfig`

The worktree has the repository dependencies needed for these Go packages; the focused tests pass.