### PR TITLE
cmd: collapse shell-quoted apostrophes in dragged image paths

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -584,6 +584,10 @@ func NewCreateRequest(name string, opts runOptions) *api.CreateRequest {
 
 func normalizeFilePath(fp string) string {
 	return strings.NewReplacer(
+		// A shell single-quoted path spells a literal apostrophe as '\'':
+		// close the quote, escape one, reopen. Collapse the whole
+		// four-character sequence back to a single apostrophe.
+		"'\\''", "'",
 		"\\ ", " ", // Escaped space
 		"\\(", "(", // Escaped left parenthesis
 		"\\)", ")", // Escaped right parenthesis

--- a/cmd/interactive_test.go
+++ b/cmd/interactive_test.go
@@ -64,6 +64,53 @@ d:\path with\spaces\thirteen.WEBP some ending
 	assert.Contains(t, res[12], "d:")
 }
 
+// Dragging a file whose name contains an apostrophe into a shell prompt yields
+// a single-quoted path in which each apostrophe is spelled
+//
+//	'\''
+//
+// that is: close the quote, escape a literal apostrophe, reopen. The whole
+// four-character sequence collapses back to one apostrophe.
+func TestNormalizeFilePathShellQuotedApostrophe(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "apostrophe",
+			in:   `/home/jdoe/Pictures/jdoe'\''s.png`,
+			want: `/home/jdoe/Pictures/jdoe's.png`,
+		},
+		{
+			name: "apostrophe and spaces",
+			in:   `/home/jdoe/my pictures/jdoe'\''s photo.png`,
+			want: `/home/jdoe/my pictures/jdoe's photo.png`,
+		},
+		{
+			name: "multiple apostrophes",
+			in:   `/home/jdoe/a'\''b'\''c.png`,
+			want: `/home/jdoe/a'b'c.png`,
+		},
+		{
+			name: "backslash escaped apostrophe still works",
+			in:   `/home/jdoe/jdoe\'s.png`,
+			want: `/home/jdoe/jdoe's.png`,
+		},
+		{
+			name: "bare apostrophe untouched",
+			in:   `/home/jdoe/jdoe's.png`,
+			want: `/home/jdoe/jdoe's.png`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, normalizeFilePath(tt.in))
+		})
+	}
+}
+
 // Ensure that file paths wrapped in single quotes are removed with the quotes.
 func TestExtractFileDataRemovesQuotedFilepath(t *testing.T) {
 	dir := t.TempDir()

--- a/cmd/internal/filedata/filedata.go
+++ b/cmd/internal/filedata/filedata.go
@@ -23,6 +23,10 @@ type File struct {
 func NormalizePath(fp string) string {
 	fp = strings.Trim(fp, "\"")
 	fp = strings.NewReplacer(
+		// A shell single-quoted path spells a literal apostrophe as '\'':
+		// close the quote, escape one, reopen. Collapse the whole
+		// four-character sequence back to a single apostrophe.
+		"'\\''", "'",
 		"\\ ", " ",
 		"\\(", "(",
 		"\\)", ")",

--- a/cmd/internal/filedata/filedata_test.go
+++ b/cmd/internal/filedata/filedata_test.go
@@ -115,6 +115,96 @@ func TestNormalizePathFileURL(t *testing.T) {
 	}
 }
 
+// Dragging a file whose name contains an apostrophe into a shell prompt yields
+// a single-quoted path in which each apostrophe is spelled
+//
+//	'\''
+//
+// that is: close the quote, escape a literal apostrophe, reopen. The whole
+// four-character sequence collapses back to one apostrophe.
+func TestNormalizePathShellQuotedApostrophe(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "apostrophe",
+			in:   `/home/jdoe/Pictures/jdoe'\''s.png`,
+			want: `/home/jdoe/Pictures/jdoe's.png`,
+		},
+		{
+			name: "apostrophe and spaces",
+			in:   `/home/jdoe/my pictures/jdoe'\''s photo.png`,
+			want: `/home/jdoe/my pictures/jdoe's photo.png`,
+		},
+		{
+			name: "multiple apostrophes",
+			in:   `/home/jdoe/a'\''b'\''c.png`,
+			want: `/home/jdoe/a'b'c.png`,
+		},
+		{
+			name: "backslash escaped apostrophe still works",
+			in:   `/home/jdoe/jdoe\'s.png`,
+			want: `/home/jdoe/jdoe's.png`,
+		},
+		{
+			name: "bare apostrophe untouched",
+			in:   `/home/jdoe/jdoe's.png`,
+			want: `/home/jdoe/jdoe's.png`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NormalizePath(tt.in); got != tt.want {
+				t.Fatalf("path = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// The extraction regex anchors on the leading separator and stops at the
+// extension, so the wrapping quotes fall away on their own.
+func TestExtractNamesShellQuotedApostrophe(t *testing.T) {
+	input := `look at '/home/jdoe/Pictures/jdoe'\''s.png' please`
+	res := ExtractNames(input)
+	if len(res) != 1 {
+		t.Fatalf("len = %d, want 1", len(res))
+	}
+	if got, want := NormalizePath(res[0]), `/home/jdoe/Pictures/jdoe's.png`; got != want {
+		t.Fatalf("path = %q, want %q", got, want)
+	}
+}
+
+// End-to-end: a real file whose name contains an apostrophe, referenced the way
+// a shell quotes it on drag and drop, must still be found and read.
+func TestExtractShellQuotedApostropheFile(t *testing.T) {
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "jdoe's photo.jpg")
+	data := make([]byte, 600)
+	copy(data, []byte{
+		0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 'J', 'F', 'I', 'F',
+		0x00, 0x01, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0xff, 0xd9,
+	})
+	if err := os.WriteFile(fp, data, 0o600); err != nil {
+		t.Fatalf("failed to write test image: %v", err)
+	}
+
+	quoted := "'" + strings.ReplaceAll(fp, "'", `'\''`) + "'"
+	cleaned, imgs, err := Extract("before " + quoted + " after")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(imgs) != 1 {
+		t.Fatalf("imgs = %d, want 1", len(imgs))
+	}
+	if cleaned != "before  after" {
+		t.Fatalf("cleaned = %q, want %q", cleaned, "before  after")
+	}
+}
+
 func TestExtractRemovesQuotedFilepath(t *testing.T) {
 	dir := t.TempDir()
 	fp := filepath.Join(dir, "img.jpg")


### PR DESCRIPTION
Dragging a file whose name contains an apostrophe into `ollama run` silently drops the image. This is the single-quote case @rick-github reported in #10333 (comment 2817135734), still open after the escaped-tilde half was resolved.

## The bug

A shell single-quoted path spells a literal apostrophe as `'\''` — close the quote, escape one, reopen. The normalizers only knew the two-character `\'` escape, so the four-character sequence expanded to *three* apostrophes:

```
input:   '/home/rick/filename with '\''.jpg'
becomes: /home/rick/filename with '''.jpg
want:    /home/rick/filename with '.jpg
```

That path doesn't exist, so the image is dropped without an error — the reported symptom.

## The fix

One replacer entry, collapsing the whole sequence back to a single apostrophe. `strings.Replacer` matches leftmost-by-position, so this takes precedence over `\'` regardless of where it sits in the argument list.

Applied to **both** normalizers:

- `cmd.normalizeFilePath` — the `ollama run` path, which is what the issue reports
- `filedata.NormalizePath` — the agent UI path, added in 82f905cd (`cmd: agent UI`, #17017) after the earlier reports, carrying the same defect

## Relation to existing PRs

The one-line change is the same one @caetano-dev proposed in #11472 — credit there. This adds the `filedata` normalizer, which postdates that PR, plus regression tests.

#13718 takes a broader `shlex.Split` approach. Worth noting before choosing between them: because `normalizeFilePath` receives the post-regex substring with the leading quote already stripped, the remaining unbalanced quote makes `shlex.Split` error and return the input untouched — so it does not fix this case. It also treats `\` as an escape character, which collapses Windows separators (`C:\Users\jdoe\Pictures\img.png` → `C:UsersjdoePicturesimg.png`). The allowlist in the current code appears to be deliberate for exactly that reason.

## Tests

Table-driven coverage in both packages for the quoted form, quoted-with-spaces, multiple apostrophes, and two controls that must not regress (backslash-escaped `\'`, and a bare unescaped apostrophe). Plus an end-to-end test writing a real `jdoe's photo.jpg` to disk and asserting it loads through `Extract`.

Verified non-vacuous — with the fix reverted, the end-to-end test fails with `imgs = 0, want 1`.

`go test ./cmd/...` passes; `gofmt` and `go vet` clean.

## Not addressed

Other escapes a shell emits are still unhandled: `\!`, `\"`, `` \` ``, `\|`, `\<`, `\>`, `\^`, `\,`. @KhushAhuja raised this on the issue. Fixing it generally means separating Unix escape handling from Windows separator handling, which is a design change rather than a bug fix — happy to follow up if you'd like it in scope.
