### PR TITLE
cli: fix unescaping of dragged image file paths in terminal (Fixes #10333)

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -583,7 +583,7 @@ func NewCreateRequest(name string, opts runOptions) *api.CreateRequest {
 }
 
 func normalizeFilePath(fp string) string {
-	return strings.NewReplacer(
+	fp = strings.NewReplacer(
 		"\\ ", " ", // Escaped space
 		"\\(", "(", // Escaped left parenthesis
 		"\\)", ")", // Escaped right parenthesis
@@ -595,11 +595,28 @@ func normalizeFilePath(fp string) string {
 		"\\&", "&", // Escaped ampersand
 		"\\;", ";", // Escaped semicolon
 		"\\'", "'", // Escaped single quote
+		"\\\"", "\"", // Escaped double quote
 		"\\\\", "\\", // Escaped backslash
 		"\\*", "*", // Escaped asterisk
 		"\\?", "?", // Escaped question mark
 		"\\~", "~", // Escaped tilde
+		"\\@", "@", // Escaped at sign
+		"\\#", "#", // Escaped hash tag
+		"\\!", "!", // Escaped exclamation mark
+		"\\%", "%", // Escaped percent
+		"\\^", "^", // Escaped caret
+		"\\=", "=", // Escaped equal sign
+		"\\+", "+", // Escaped plus sign
+		"\\,", ",", // Escaped comma
 	).Replace(fp)
+
+	if strings.HasPrefix(fp, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			fp = filepath.Join(home, fp[2:])
+		}
+	}
+
+	return fp
 }
 
 func extractFileNames(input string) []string {

--- a/cmd/interactive_test.go
+++ b/cmd/interactive_test.go
@@ -114,3 +114,21 @@ func TestExtractFileDataWAV(t *testing.T) {
 	assert.Len(t, imgs, 1)
 	assert.Equal(t, "before  after", cleaned)
 }
+
+func TestNormalizeFilePath(t *testing.T) {
+	// Test escaped characters from drag and drop in terminal
+	escapedPath := `/Users/ollama/Library/Mobile\ Documents/com\~apple\~CloudDocs/screenshots/CleanShot\ 2025-04-17\ at\ 21.26.40\@2x.png`
+	expected := `/Users/ollama/Library/Mobile Documents/com~apple~CloudDocs/screenshots/CleanShot 2025-04-17 at 21.26.40@2x.png`
+	assert.Equal(t, expected, normalizeFilePath(escapedPath))
+
+	// Test special escaped symbols
+	escapedSymbols := `path/to/file\ \#1\!\ \&\ \$test.png`
+	expectedSymbols := `path/to/file #1! & $test.png`
+	assert.Equal(t, expectedSymbols, normalizeFilePath(escapedSymbols))
+
+	// Test home directory expansion
+	if home, err := os.UserHomeDir(); err == nil {
+		homePath := `~/Pictures/photo.png`
+		assert.Equal(t, filepath.Join(home, "Pictures/photo.png"), normalizeFilePath(homePath))
+	}
+}


### PR DESCRIPTION
### Summary
Fixes #10333 where dragging an image into terminal during CLI interactive prompt mode inserted backslash-escaped characters (e.g. `\@2x.png`, `\~`, `\#`, `\!`) or tilde paths (`~/...`), causing `getImageData` (`os.Open`) to fail with file not found.

### Solution
1. Updated `normalizeFilePath` in `cmd/interactive.go` to unescape shell backslash sequences (`\@`, `\#`, `\!`, `\%`, `\^`, `\=`, `\+`, `\,`, `\"`).
2. Added home directory expansion (`~/` -> `os.UserHomeDir()`) in `normalizeFilePath`.
3. Added comprehensive unit tests in `TestNormalizeFilePath` (`cmd/interactive_test.go`).
