### PR TITLE
README: add Tarn and Glance AI to community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ console.log(response.message.content);
 - [Kerlig AI](https://www.kerlig.com/) - AI writing assistant for macOS
 - [Hillnote](https://hillnote.com) - Markdown-first AI workspace
 - [Perfect Memory AI](https://www.perfectmemory.ai/) - Productivity AI personalized by screen and meeting history
+- [Glance AI](https://bromind.dev/glance/) - Screen-aware AI assistant for Windows
 
 #### Mobile
 
@@ -310,6 +311,7 @@ console.log(response.message.content);
 - [Vibe](https://github.com/thewh1teagle/vibe) - Transcribe and analyze meetings
 - [Page Assist](https://github.com/n4ze3m/page-assist) - Chrome extension for AI-powered browsing
 - [NativeMind](https://github.com/NativeMindBrowser/NativeMindExtension) - Private, on-device browser AI assistant
+- [Tarn](https://bromind.dev/tarn/) - Browser sidebar for local models on Chrome, Firefox, and Edge
 - [Ollama Fortress](https://github.com/ParisNeo/ollama_proxy_server) - Security proxy for Ollama
 - [1Panel](https://github.com/1Panel-dev/1Panel/) - Web-based Linux server management
 - [Writeopia](https://github.com/Writeopia/Writeopia) - Text editor with Ollama integration


### PR DESCRIPTION
Adds [Tarn](https://bromind.dev/tarn/) (a privacy-focused browser sidebar for Chrome, Firefox, and Edge) and [Glance AI](https://bromind.dev/glance/) (a screen-aware desktop assistant for Windows) to the community integrations list — both work with locally-run models and use Ollama as their primary backend.