### PR TITLE
harmony: tolerate malformed tool-call argument JSON

### DIFF
--- a/harmony/harmonyparser.go
+++ b/harmony/harmonyparser.go
@@ -11,6 +11,46 @@ import (
 	"github.com/ollama/ollama/logutil"
 )
 
+// parseToolCallFunctionArguments decodes tool-call arguments from raw model
+// output. It is deliberately tolerant: models sometimes emit a single-element
+// JSON array wrapper or trailing control tokens after the value. We scan for
+// the first top-level JSON value and decode it, so malformed generations do
+// not abort the whole chat request.
+func parseToolCallFunctionArguments(raw string) (api.ToolCallFunctionArguments, error) {
+	var args api.ToolCallFunctionArguments
+
+	// Try the common case first.
+	if err := json.Unmarshal([]byte(raw), &args); err == nil {
+		return args, nil
+	}
+
+	trimmed := strings.TrimSpace(raw)
+
+	// The model may have emitted structural tokens around or after the value
+	// (e.g. `[{"x":1}]<|call|>` or `{"x":1}]`). Scan for the first `{` or `[`
+	// and decode a single value from there; the JSON decoder ignores trailing
+	// text after a complete value.
+	for i := 0; i < len(trimmed); i++ {
+		c := trimmed[i]
+		if c == '{' {
+			decoder := json.NewDecoder(strings.NewReader(trimmed[i:]))
+			decoder.UseNumber()
+			var obj api.ToolCallFunctionArguments
+			if err := decoder.Decode(&obj); err == nil {
+				return obj, nil
+			}
+		} else if c == '[' {
+			decoder := json.NewDecoder(strings.NewReader(trimmed[i:]))
+			var arr []api.ToolCallFunctionArguments
+			if err := decoder.Decode(&arr); err == nil && len(arr) > 0 {
+				return arr[0], nil
+			}
+		}
+	}
+
+	return api.ToolCallFunctionArguments{}, fmt.Errorf("could not parse tool call arguments from %q", raw)
+}
+
 type harmonyParserState int
 
 const (
@@ -440,8 +480,8 @@ func (h *HarmonyMessageHandler) Add(s string, done bool) (content string, thinki
 		if toolName != nil {
 			name := strings.TrimPrefix(*toolName, "functions.")
 			name = h.FunctionNameMap.OriginalFromConverted(name)
-			var args api.ToolCallFunctionArguments
-			if err := json.Unmarshal([]byte(raw), &args); err != nil {
+			args, err := parseToolCallFunctionArguments(raw)
+			if err != nil {
 				return "", "", nil, fmt.Errorf("error parsing tool call: raw='%s', err=%w", raw, err)
 			}
 			calls = append(calls, api.ToolCall{Function: api.ToolCallFunction{Name: name, Arguments: args}})

--- a/harmony/harmonyparser_test.go
+++ b/harmony/harmonyparser_test.go
@@ -3,6 +3,8 @@ package harmony
 import (
 	"fmt"
 	"reflect"
+
+	"github.com/ollama/ollama/api"
 	"testing"
 )
 
@@ -536,3 +538,71 @@ func TestFunctionConvertAndAdd(t *testing.T) {
 		})
 	}
 }
+func TestParseToolCallFunctionArguments(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    map[string]any
+		wantErr bool
+	}{
+		{
+			name: "plain object",
+			raw:  `{"location": "San Francisco, CA"}`,
+			want: map[string]any{"location": "San Francisco, CA"},
+		},
+		{
+			name: "array-wrapped object",
+			raw:  `[{"input": "x"}]`,
+			want: map[string]any{"input": "x"},
+		},
+		{
+			name: "object with trailing bracket",
+			raw:  `{"input": "x"}]`,
+			want: map[string]any{"input": "x"},
+		},
+		{
+			name:    "empty",
+			raw:     "",
+			wantErr: true,
+		},
+		{
+			name:    "invalid json",
+			raw:     `{not json}`,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseToolCallFunctionArguments(tt.raw)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseToolCallFunctionArguments(%q) error = %v, wantErr %v", tt.raw, err, tt.wantErr)
+			}
+			if !tt.wantErr && !reflect.DeepEqual(got.ToMap(), tt.want) {
+				t.Errorf("parseToolCallFunctionArguments(%q) = %v, want %v", tt.raw, got.ToMap(), tt.want)
+			}
+		})
+	}
+}
+
+func TestHarmonyMessageHandlerToolArgumentTolerance(t *testing.T) {
+	handler := NewHarmonyMessageHandler()
+	handler.Init([]api.Tool{{Type: "function", Function: api.ToolFunction{Name: "get_weather"}}}, nil, nil)
+
+	// Model emits a single-element JSON array for the tool arguments.
+	_, _, calls, err := handler.Add(`<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>[{"location":"Zurich"}]<|call|>`, true)
+	if err != nil {
+		t.Fatalf("unexpected error parsing array-wrapped tool arguments: %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(calls))
+	}
+	if calls[0].Function.Name != "get_weather" {
+		t.Errorf("got function name %q, want get_weather", calls[0].Function.Name)
+	}
+
+	wantArgs := map[string]any{"location": "Zurich"}
+	if !reflect.DeepEqual(calls[0].Function.Arguments.ToMap(), wantArgs) {
+		t.Errorf("got arguments %v, want %v", calls[0].Function.Arguments.ToMap(), wantArgs)
+	}
+}
+


### PR DESCRIPTION
Hey Ollama team,

This fixes the issue where gpt-oss/harmony models occasionally emit tool-call arguments that aren't a bare JSON object (e.g. `[{"location":"..."}]` or `{"location":"..."}]`) and the whole chat request dies with an HTTP 500.

What changed:
- Added a small `parseToolCallFunctionArguments` helper in `harmony/harmonyparser.go` that tries the plain object first, then unwraps a single-element array, then scans for the first complete JSON object in the raw output.
- Replaced the bare `json.Unmarshal` in `HarmonyMessageHandler.Add` with the helper.
- Added table-driven tests plus an end-to-end handler test.

This is intentionally surgical — the bug is in parsing model output, not in the model itself, and returning 500 for a malformed generation is the wrong semantic.

Fixes #17638