### PR TITLE
cmd: suppress word-wrap ANSI escapes when stdout is not a TTY

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -803,7 +803,6 @@ func RunHandler(cmd *cobra.Command, args []string) error {
 			prompts = append([]string{stdinContent}, prompts...)
 		}
 		opts.ShowConnect = false
-		opts.WordWrap = false
 		interactive = false
 	}
 	opts.Prompt = strings.Join(prompts, " ")
@@ -819,7 +818,7 @@ func RunHandler(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	opts.WordWrap = !nowrap
+	opts.WordWrap = !nowrap && term.IsTerminal(int(os.Stdout.Fd()))
 
 	// Fill out the rest of the options based on information about the
 	// model.

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1054,6 +1054,73 @@ func TestRunHandler_ExplicitCloudStubPullFailure_IsBestEffortTEMP(t *testing.T) 
 	}
 }
 
+func TestRunHandler_NonTTYStdout_NoANSIEscapes(t *testing.T) {
+	// Long enough that word-wrap would fire (default termWidth is 80 when
+	// stdout is not a TTY) and emit \x1b[Nd / \x1b[K sequences if it ran.
+	longResponse := strings.Repeat("the quick brown fox jumps over the lazy dog ", 5)
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/show" && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusOK)
+			if err := json.NewEncoder(w).Encode(api.ShowResponse{
+				Capabilities: []model.Capability{model.CapabilityCompletion},
+			}); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+			return
+		case r.URL.Path == "/api/generate" && r.Method == http.MethodPost:
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			w.WriteHeader(http.StatusOK)
+			if err := json.NewEncoder(w).Encode(api.GenerateResponse{
+				Response: longResponse,
+				Done:     true,
+			}); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+			return
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+
+	t.Setenv("OLLAMA_HOST", mockServer.URL)
+	t.Cleanup(mockServer.Close)
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+	cmd.Flags().String("keepalive", "", "")
+	cmd.Flags().Bool("truncate", false, "")
+	cmd.Flags().Int("dimensions", 0, "")
+	cmd.Flags().Bool("verbose", false, "")
+	cmd.Flags().Bool("insecure", false, "")
+	cmd.Flags().Bool("nowordwrap", false, "")
+	cmd.Flags().String("format", "", "")
+	cmd.Flags().String("think", "", "")
+	cmd.Flags().Bool("hidethinking", false, "")
+
+	// Redirecting os.Stdout to a pipe makes term.IsTerminal return false,
+	// exercising the non-TTY code path (issue #16785).
+	oldStdout := os.Stdout
+	readOut, writeOut, _ := os.Pipe()
+	os.Stdout = writeOut
+	t.Cleanup(func() { os.Stdout = oldStdout })
+
+	err := RunHandler(cmd, []string{"llama3", "tell me a story"})
+
+	_ = writeOut.Close()
+	var out bytes.Buffer
+	_, _ = io.Copy(&out, readOut)
+
+	if err != nil {
+		t.Fatalf("RunHandler returned error: %v", err)
+	}
+
+	if strings.Contains(out.String(), "\x1b[") {
+		t.Fatalf("expected no ANSI escape sequences in redirected output, got %q", out.String())
+	}
+}
+
 func TestGetModelfileName(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
## Summary

Fixes #16785 — `ollama run <model> "prompt" > out.txt` was writing ANSI cursor-control sequences into the redirected file.

## Root cause

In `RunHandler` (`cmd/cmd.go`), the non-TTY detection at line ~806 attempted to disable word-wrap when stdin was redirected, but a few lines later `opts.WordWrap = !nowrap` unconditionally re-enabled it — including when stdout itself was redirected. `displayResponse` then emitted `\x1b[Nd` (cursor left) and `\x1b[K\n` (erase-to-EOL + newline) into the redirected stream.

Colors and thinking-block output were already correctly suppressed via the `plainText = !term.IsTerminal(os.Stdout)` check in `generate()`, so word-wrap was the only leak.

Per @rick-github's guidance on the issue: don't fail, just don't emit ANSI on non-TTY stdout.

## Change

- `cmd/cmd.go`: `opts.WordWrap = !nowrap && term.IsTerminal(int(os.Stdout.Fd()))`
- `cmd/cmd.go`: drop the now-redundant `opts.WordWrap = false` inside the stdin-redirected branch (the new expression subsumes it).
- `cmd/cmd_test.go`: add `TestRunHandler_NonTTYStdout_NoANSIEscapes` — invokes `RunHandler` against a mock server with `os.Stdout` redirected to a pipe (which makes `term.IsTerminal` return false) and asserts the captured output contains no `\x1b[` sequences.

Scope is intentionally narrow: stdout only, matching the issue and the maintainer comment. Progress output continues to go to `os.Stderr`, which is unaffected by stdout redirection.

## Test plan

- [x] `go test ./cmd/...` — all pass, including the new regression test.
- [x] Verified the new test **fails** without the src fix (captures `\x1b[K\n` and `\x1b[2D` leaking into the pipe).
- [x] Manual: `ollama run llama3 "tell me a story" > /tmp/out.txt`; confirm `/tmp/out.txt` contains no `0x1B` bytes (`grep -c $'\x1b' /tmp/out.txt` → 0).
