### PR TITLE
cmd: show per-file SHA-256 hashing progress during ollama create

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -315,7 +315,10 @@ func CreateHandler(cmd *cobra.Command, args []string) error {
 	spinner := progress.NewSpinner(status)
 	p.Add(status, spinner)
 
-	req, err := modelfile.CreateRequest(filepath.Dir(filename))
+	hashProgress := func(path string, size int64) io.WriteCloser {
+		return newHashProgressWriter(path, size, p)
+	}
+	req, err := modelfile.CreateRequestWithProgress(filepath.Dir(filename), hashProgress)
 	if err != nil {
 		return err
 	}
@@ -538,6 +541,55 @@ type progressWriter struct {
 func (w *progressWriter) Write(p []byte) (n int, err error) {
 	w.n.Add(int64(len(p)))
 	return len(p), nil
+}
+
+// hashProgressWriter reports per-file SHA-256 hashing progress via a spinner
+// on the supplied progress.Progress. Each write increments a byte counter; a
+// goroutine samples the counter every 60ms and updates the spinner message
+// with the completion percentage. Close stops the goroutine and the spinner.
+type hashProgressWriter struct {
+	progressWriter
+	spinner *progress.Spinner
+	done    chan struct{}
+	stopped atomic.Bool
+	base    string
+}
+
+func newHashProgressWriter(path string, size int64, p *progress.Progress) *hashProgressWriter {
+	base := filepath.Base(path)
+	h := &hashProgressWriter{
+		spinner: progress.NewSpinner(fmt.Sprintf("hashing %s 0%%", base)),
+		done:    make(chan struct{}),
+		base:    base,
+	}
+	p.Add("hashing:"+path, h.spinner)
+
+	go func() {
+		ticker := time.NewTicker(60 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				pct := 0
+				if size > 0 {
+					pct = int(100 * h.n.Load() / size)
+				}
+				h.spinner.SetMessage(fmt.Sprintf("hashing %s %d%%", base, pct))
+			case <-h.done:
+				return
+			}
+		}
+	}()
+	return h
+}
+
+func (h *hashProgressWriter) Close() error {
+	if h.stopped.CompareAndSwap(false, true) {
+		close(h.done)
+		h.spinner.SetMessage(fmt.Sprintf("hashing %s 100%%", h.base))
+		h.spinner.Stop()
+	}
+	return nil
 }
 
 func loadOrUnloadModel(cmd *cobra.Command, opts *runOptions) error {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -52,8 +52,24 @@ var deprecatedParameters = []string{
 	"mirostat_eta",
 }
 
-// CreateRequest creates a new *api.CreateRequest from an existing Modelfile
+// HashProgress reports per-file SHA-256 hashing progress during CreateRequest.
+// It is invoked once per file about to be hashed with the file's path and
+// total size in bytes. Bytes written to the returned io.WriteCloser reflect
+// hashing progress; Close is called when hashing of that file completes.
+// A nil return value from the function or from the writer suppresses
+// progress reporting for that file.
+type HashProgress func(path string, size int64) io.WriteCloser
+
+// CreateRequest creates a new *api.CreateRequest from an existing Modelfile.
+// SHA-256 hashing of local files is silent; use CreateRequestWithProgress to
+// receive per-file progress updates.
 func (f Modelfile) CreateRequest(relativeDir string) (*api.CreateRequest, error) {
+	return f.CreateRequestWithProgress(relativeDir, nil)
+}
+
+// CreateRequestWithProgress is like CreateRequest but invokes hashProgress
+// (if non-nil) as each local file is SHA-256'd.
+func (f Modelfile) CreateRequestWithProgress(relativeDir string, hashProgress HashProgress) (*api.CreateRequest, error) {
 	req := &api.CreateRequest{}
 
 	var messages []api.Message
@@ -70,7 +86,7 @@ func (f Modelfile) CreateRequest(relativeDir string) (*api.CreateRequest, error)
 				return nil, err
 			}
 
-			digestMap, err := fileDigestMap(path)
+			digestMap, err := fileDigestMap(path, hashProgress)
 			if errors.Is(err, os.ErrNotExist) {
 				req.From = c.Args
 				continue
@@ -95,7 +111,7 @@ func (f Modelfile) CreateRequest(relativeDir string) (*api.CreateRequest, error)
 				return nil, err
 			}
 
-			digestMap, err := fileDigestMap(path)
+			digestMap, err := fileDigestMap(path, hashProgress)
 			if err != nil {
 				return nil, err
 			}
@@ -117,7 +133,7 @@ func (f Modelfile) CreateRequest(relativeDir string) (*api.CreateRequest, error)
 				return nil, err
 			}
 
-			digestMap, err := fileDigestMap(path)
+			digestMap, err := fileDigestMap(path, hashProgress)
 			if err != nil {
 				return nil, err
 			}
@@ -215,7 +231,7 @@ func canonicalLocalPath(path string) (string, error) {
 	return filepath.EvalSymlinks(abs)
 }
 
-func fileDigestMap(path string) (map[string]string, error) {
+func fileDigestMap(path string, hashProgress HashProgress) (map[string]string, error) {
 	fl := make(map[string]string)
 
 	fi, err := os.Stat(path)
@@ -259,7 +275,7 @@ func fileDigestMap(path string) (map[string]string, error) {
 	g.SetLimit(max(runtime.GOMAXPROCS(0)-1, 1))
 	for _, f := range files {
 		g.Go(func() error {
-			digest, err := digestForFile(f)
+			digest, err := digestForFile(f, hashProgress)
 			if err != nil {
 				return err
 			}
@@ -278,7 +294,7 @@ func fileDigestMap(path string) (map[string]string, error) {
 	return fl, nil
 }
 
-func digestForFile(filename string) (string, error) {
+func digestForFile(filename string, hashProgress HashProgress) (string, error) {
 	filepath, err := filepath.EvalSymlinks(filename)
 	if err != nil {
 		return "", err
@@ -291,7 +307,18 @@ func digestForFile(filename string) (string, error) {
 	defer bin.Close()
 
 	hash := sha256.New()
-	if _, err := io.Copy(hash, bin); err != nil {
+	var target io.Writer = hash
+	if hashProgress != nil {
+		fi, err := bin.Stat()
+		if err != nil {
+			return "", err
+		}
+		if pw := hashProgress(filename, fi.Size()); pw != nil {
+			defer pw.Close()
+			target = io.MultiWriter(hash, pw)
+		}
+	}
+	if _, err := io.Copy(target, bin); err != nil {
 		return "", err
 	}
 	return fmt.Sprintf("sha256:%x", hash.Sum(nil)), nil

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"unicode/utf16"
 
@@ -918,6 +919,64 @@ func TestCreateRequestFiles(t *testing.T) {
 			t.Errorf("mismatch (-got +want):\n%s", diff)
 		}
 	}
+}
+
+// countingWriteCloser records bytes written and whether Close was called.
+type countingWriteCloser struct {
+	written int64
+	closed  bool
+}
+
+func (c *countingWriteCloser) Write(p []byte) (int, error) { c.written += int64(len(p)); return len(p), nil }
+func (c *countingWriteCloser) Close() error                { c.closed = true; return nil }
+
+func TestCreateRequestWithProgressReportsPerFileHashProgress(t *testing.T) {
+	n1, _ := createBinFile(t, nil, nil)
+	n2, _ := createBinFile(t, map[string]any{"foo": "bar"}, nil)
+
+	modelfile, err := ParseFile(strings.NewReader(fmt.Sprintf("FROM %s\nFROM %s", n1, n2)))
+	require.NoError(t, err)
+
+	type call struct {
+		size int64
+		w    *countingWriteCloser
+	}
+	seen := map[string]*call{}
+	var mu sync.Mutex
+
+	hashProgress := func(path string, size int64) io.WriteCloser {
+		w := &countingWriteCloser{}
+		mu.Lock()
+		defer mu.Unlock()
+		seen[path] = &call{size: size, w: w}
+		return w
+	}
+
+	_, err = modelfile.CreateRequestWithProgress("", hashProgress)
+	require.NoError(t, err)
+
+	require.Len(t, seen, 2)
+	for _, path := range []string{n1, n2} {
+		c, ok := seen[path]
+		require.True(t, ok, "missing hash progress call for %s", path)
+
+		fi, err := os.Stat(path)
+		require.NoError(t, err)
+		assert.Equal(t, fi.Size(), c.size, "size reported to callback should match file size")
+		assert.Equal(t, fi.Size(), c.w.written, "bytes written to progress writer should equal file size")
+		assert.True(t, c.w.closed, "progress writer should be closed after hashing")
+	}
+}
+
+func TestCreateRequestWithProgressNilCallbackIsSilent(t *testing.T) {
+	n1, d1 := createBinFile(t, nil, nil)
+
+	modelfile, err := ParseFile(strings.NewReader(fmt.Sprintf("FROM %s", n1)))
+	require.NoError(t, err)
+
+	req, err := modelfile.CreateRequestWithProgress("", nil)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{n1: d1}, req.Files)
 }
 
 func TestFilesForModel(t *testing.T) {


### PR DESCRIPTION
## Summary

Addresses the silent-phase UX bug most likely responsible for #17491: `ollama create` currently displays a single `gathering model components` spinner while SHA-256'ing every local file referenced from the Modelfile, with no per-file progress. For a Pixtral 12B Q8_0 (~13 GB) plus its F16 mmproj (~830 MB), that's ~30-60 s of visible-but-silent hashing before the "copying file X N%" phase begins - which the #17491 reporter (who killed at 60 s) almost certainly hit.

Verified against the reporter's exact setup: real files from `bartowski/mistral-community_pixtral-12b-GGUF` in a two-`FROM` Modelfile. `isProjectorGGUF` (`server/create.go:1284`) correctly classifies Pixtral's mmproj via both branch 2 (`vision.block_count > 0`) and branch 3 (`clip + has_vision_encoder`), and the end-to-end create completes with the expected two-layer manifest. No functional bug on that scenario in current main; the perceived "hang" is silent hashing.

## Change

- **`parser/parser.go`**: introduce `type HashProgress func(path string, size int64) io.WriteCloser`, and thread it through `Modelfile.CreateRequest` -> `fileDigestMap` -> `digestForFile`. `digestForFile` calls the callback once per file with the file's total size; the returned writer is teed into the SHA-256 pipeline and `Close`d when hashing completes. A nil callback (or nil return from the callback) is a no-op, preserving current behavior.

  `CreateRequest(dir)` is kept as a shim over the new `CreateRequestWithProgress(dir, nil)`, so all existing callers are unchanged.

- **`cmd/cmd.go`**: `CreateHandler` supplies a factory that creates a `hashProgressWriter` per file. It mirrors the existing `createBlob` progress pattern: an atomic byte counter incremented by `Write`, a 60 ms ticker goroutine that refreshes a spinner labeled `hashing <basename> N%`, and `Close` that flips to `100%` and stops the spinner. Files hashed in parallel by the parser's errgroup each get their own independent spinner.

- **`parser/parser_test.go`**: two new tests -
  - `TestCreateRequestWithProgressReportsPerFileHashProgress` - two `FROM` lines pointing at real GGUF fixtures created via `createBinFile`; asserts the callback is invoked once per file with a size matching `os.Stat`, that bytes written to the returned writer equal the file size, and that `Close` was called.
  - `TestCreateRequestWithProgressNilCallbackIsSilent` - nil callback path still produces the expected `Files` map (backward-compat regression guard).

## Test plan

- [x] `go test ./parser/... ./cmd/...` - all pass, including the two new tests.
- [x] End-to-end manual test against a real Pixtral 12B Q8_0 (13 GB) + F16 mmproj (830 MB), captured via `grep -oE "hashing [^ ]+ [0-9]+%"` on the CLI output stream:
  ```
  hashing pixtral-Q8_0.gguf 1%
  hashing pixtral-Q8_0.gguf 3%
  hashing pixtral-Q8_0.gguf 10%
  ...
  hashing pixtral-Q8_0.gguf 59%
  hashing pixtral-Q8_0.gguf 100%
  hashing mmproj-f16.gguf 0%
  hashing mmproj-f16.gguf 19%
  hashing mmproj-f16.gguf 57%
  hashing mmproj-f16.gguf 95%
  hashing mmproj-f16.gguf 100%
  ```
  Both files reported live percentages in parallel; final manifest and inference behavior unchanged.

## Follow-ups (not in this PR)

While investigating I noticed two small related UX gaps worth separate patches if maintainers want them:
1. Server-side `parsing GGUF` (`server/create.go:1236`) is a single opaque status; adding the source filename would let users tell which of multiple files is being decoded.
2. `runLlamaQuantizeCommand` (`server/quantization.go:118`) blocks on `cmd.Wait()` with no timeout; a configurable ceiling would prevent a hypothetical `llama-quantize` hang from hanging the server.
